### PR TITLE
Refactor index types for constraints

### DIFF
--- a/src/circuit/gate.rs
+++ b/src/circuit/gate.rs
@@ -1,7 +1,7 @@
 use super::Wire;
 use crate::constraint_system::AndConstraint;
 use crate::constraint_system::ConstraintSystem;
-use crate::constraint_system::ShiftedValueIndex;
+use crate::constraint_system::ValueIndex;
 use crate::constraint_system::Witness;
 
 use super::Circuit;
@@ -137,23 +137,20 @@ impl Gate for Iadd32 {
 
         // (x XOR (cout << 1)) AND (y XOR (cout << 1)) = (cout << 1) XOR cout
         cs.add_and_constraint(AndConstraint::abc(
-            [ShiftedValueIndex::plain(a), ShiftedValueIndex::sll(cout, 1)],
-            [ShiftedValueIndex::plain(b), ShiftedValueIndex::sll(cout, 1)],
-            [
-                ShiftedValueIndex::plain(cout),
-                ShiftedValueIndex::sll(cout, 1),
-            ],
+            [ValueIndex::plain(a), ValueIndex::sll(cout, 1)],
+            [ValueIndex::plain(b), ValueIndex::sll(cout, 1)],
+            [ValueIndex::plain(cout), ValueIndex::sll(cout, 1)],
         ));
 
         // (x XOR y XOR (cout « 1)) AND M32 = z
         cs.add_and_constraint(AndConstraint::abc(
             [
-                ShiftedValueIndex::plain(a),
-                ShiftedValueIndex::plain(b),
-                ShiftedValueIndex::sll(cout, 1),
+                ValueIndex::plain(a),
+                ValueIndex::plain(b),
+                ValueIndex::sll(cout, 1),
             ],
-            [ShiftedValueIndex::plain(mask32)],
-            [ShiftedValueIndex::plain(c)],
+            [ValueIndex::plain(mask32)],
+            [ValueIndex::plain(c)],
         ));
     }
 }
@@ -187,9 +184,9 @@ impl Gate for Shr32 {
 
         // SHR = AND(srl(x, n), M32)
         cs.add_and_constraint(AndConstraint::abc(
-            [ShiftedValueIndex::srl(a, self.n as usize)],
-            [ShiftedValueIndex::plain(mask32)],
-            [ShiftedValueIndex::plain(c)],
+            [ValueIndex::srl(a, self.n as usize)],
+            [ValueIndex::plain(mask32)],
+            [ValueIndex::plain(c)],
         ));
     }
 }
@@ -225,11 +222,11 @@ impl Gate for Rotr32 {
         // This translates to: AND(OR(srl(x, n), sll(x, 32-n)), M32) = c
         cs.add_and_constraint(AndConstraint::abc(
             [
-                ShiftedValueIndex::srl(a, self.n as usize),
-                ShiftedValueIndex::sll(a, (32 - self.n) as usize),
+                ValueIndex::srl(a, self.n as usize),
+                ValueIndex::sll(a, (32 - self.n) as usize),
             ],
-            [ShiftedValueIndex::plain(mask32)],
-            [ShiftedValueIndex::plain(c)],
+            [ValueIndex::plain(mask32)],
+            [ValueIndex::plain(c)],
         ));
     }
 }

--- a/src/constraint_system.rs
+++ b/src/constraint_system.rs
@@ -14,13 +14,15 @@ pub enum ShiftVariant {
 }
 
 #[derive(Copy, Clone, Debug)]
-pub struct ShiftedValueIndex {
+pub struct ValueIndex {
     pub value_index: usize,
     pub shift_variant: ShiftVariant,
     pub amount: usize,
 }
 
-impl ShiftedValueIndex {
+pub type Operand = Vec<ValueIndex>;
+
+impl ValueIndex {
     pub fn plain(value_index: usize) -> Self {
         Self {
             value_index,
@@ -47,9 +49,9 @@ impl ShiftedValueIndex {
 }
 
 pub struct AndConstraint {
-    pub a: Vec<ShiftedValueIndex>,
-    pub b: Vec<ShiftedValueIndex>,
-    pub c: Vec<ShiftedValueIndex>,
+    pub a: Operand,
+    pub b: Operand,
+    pub c: Operand,
 }
 
 impl AndConstraint {
@@ -59,16 +61,16 @@ impl AndConstraint {
         c: impl IntoIterator<Item = usize>,
     ) -> AndConstraint {
         AndConstraint {
-            a: a.into_iter().map(|i| ShiftedValueIndex::plain(i)).collect(),
-            b: b.into_iter().map(|i| ShiftedValueIndex::plain(i)).collect(),
-            c: c.into_iter().map(|i| ShiftedValueIndex::plain(i)).collect(),
+            a: a.into_iter().map(|i| ValueIndex::plain(i)).collect(),
+            b: b.into_iter().map(|i| ValueIndex::plain(i)).collect(),
+            c: c.into_iter().map(|i| ValueIndex::plain(i)).collect(),
         }
     }
 
     pub fn abc(
-        a: impl IntoIterator<Item = ShiftedValueIndex>,
-        b: impl IntoIterator<Item = ShiftedValueIndex>,
-        c: impl IntoIterator<Item = ShiftedValueIndex>,
+        a: impl IntoIterator<Item = ValueIndex>,
+        b: impl IntoIterator<Item = ValueIndex>,
+        c: impl IntoIterator<Item = ValueIndex>,
     ) -> AndConstraint {
         AndConstraint {
             a: a.into_iter().collect(),
@@ -79,10 +81,10 @@ impl AndConstraint {
 }
 
 pub struct MulConstraint {
-    pub a: Vec<ShiftedValueIndex>,
-    pub b: Vec<ShiftedValueIndex>,
-    pub hi: Vec<ShiftedValueIndex>,
-    pub lo: Vec<ShiftedValueIndex>,
+    pub a: Operand,
+    pub b: Operand,
+    pub hi: Operand,
+    pub lo: Operand,
 }
 
 pub struct ConstraintSystem {


### PR DESCRIPTION
## Summary
- rename `ShiftedValueIndex` to `ValueIndex`
- add `Operand` type alias
- update gates and constraints to use the new names

## Testing
- `cargo check -q`
- `cargo build -q`
- `cargo run --quiet`
- `cargo test -q`


------
https://chatgpt.com/codex/tasks/task_b_685eb7b2c8448323b764bfc9e8de700b