### PR TITLE
Refactor gate constructors to allocate wires internally

### DIFF
--- a/src/circuit/gate.rs
+++ b/src/circuit/gate.rs
@@ -1,4 +1,4 @@
-use super::Wire;
+use super::{CircuitBuilder, Wire};
 use crate::constraint_system::AndConstraint;
 use crate::constraint_system::ConstraintSystem;
 use crate::constraint_system::ValueIndex;
@@ -18,7 +18,8 @@ pub struct Band {
 }
 
 impl Band {
-    pub fn new(a: Wire, b: Wire, c: Wire) -> Self {
+    pub fn new(builder: &CircuitBuilder, a: Wire, b: Wire) -> Self {
+        let c = builder.add_private();
         Self { a, b, c }
     }
 }
@@ -46,7 +47,8 @@ pub struct Bxor {
 }
 
 impl Bxor {
-    pub fn new(a: Wire, b: Wire, c: Wire) -> Self {
+    pub fn new(builder: &CircuitBuilder, a: Wire, b: Wire) -> Self {
+        let c = builder.add_private();
         Self { a, b, c }
     }
 }
@@ -74,7 +76,8 @@ pub struct Bor {
 }
 
 impl Bor {
-    pub fn new(a: Wire, b: Wire, c: Wire) -> Self {
+    pub fn new(builder: &CircuitBuilder, a: Wire, b: Wire) -> Self {
+        let c = builder.add_private();
         Self { a, b, c }
     }
 }
@@ -104,7 +107,10 @@ pub struct Iadd32 {
 }
 
 impl Iadd32 {
-    pub fn new(a: Wire, b: Wire, c: Wire, cout: Wire, mask32: Wire) -> Self {
+    pub fn new(builder: &CircuitBuilder, a: Wire, b: Wire) -> Self {
+        let c = builder.add_private();
+        let cout = builder.add_private();
+        let mask32 = builder.add_constant(crate::word::Word::MASK_32);
         Self {
             a,
             b,
@@ -163,7 +169,9 @@ pub struct Shr32 {
 }
 
 impl Shr32 {
-    pub fn new(a: Wire, c: Wire, mask32: Wire, n: u32) -> Self {
+    pub fn new(builder: &CircuitBuilder, a: Wire, n: u32) -> Self {
+        let c = builder.add_private();
+        let mask32 = builder.add_constant(crate::word::Word::MASK_32);
         Self { a, c, mask32, n }
     }
 }
@@ -199,7 +207,9 @@ pub struct Rotr32 {
 }
 
 impl Rotr32 {
-    pub fn new(a: Wire, c: Wire, mask32: Wire, n: u32) -> Self {
+    pub fn new(builder: &CircuitBuilder, a: Wire, n: u32) -> Self {
+        let c = builder.add_private();
+        let mask32 = builder.add_constant(crate::word::Word::MASK_32);
         Self { a, c, mask32, n }
     }
 }

--- a/src/circuit/mod.rs
+++ b/src/circuit/mod.rs
@@ -141,15 +141,17 @@ impl CircuitBuilder {
     }
 
     pub fn band(&self, a: Wire, b: Wire) -> Wire {
-        let c = self.add_private();
-        self.emit(Band::new(a, b, c));
-        c
+        let gate = Band::new(self, a, b);
+        let out = gate.c;
+        self.emit(gate);
+        out
     }
 
     pub fn bxor(&self, a: Wire, b: Wire) -> Wire {
-        let c = self.add_private();
-        self.emit(Bxor::new(a, b, c));
-        c
+        let gate = Bxor::new(self, a, b);
+        let out = gate.c;
+        self.emit(gate);
+        out
     }
 
     /// Bitwise Not
@@ -159,31 +161,31 @@ impl CircuitBuilder {
     }
 
     pub fn bor(&self, a: Wire, b: Wire) -> Wire {
-        let c = self.add_private();
-        self.emit(Bor::new(a, b, c));
-        c
+        let gate = Bor::new(self, a, b);
+        let out = gate.c;
+        self.emit(gate);
+        out
     }
 
     pub fn iadd_32(&self, a: Wire, b: Wire) -> Wire {
-        let c = self.add_private();
-        let cout = self.add_private();
-        let mask32 = self.add_constant(Word::MASK_32);
-        self.emit(Iadd32::new(a, b, c, cout, mask32));
-        c
+        let gate = Iadd32::new(self, a, b);
+        let out = gate.c;
+        self.emit(gate);
+        out
     }
 
     pub fn rotr_32(&self, a: Wire, n: u32) -> Wire {
-        let c = self.add_private();
-        let mask32 = self.add_constant(Word::MASK_32);
-        self.emit(Rotr32::new(a, c, mask32, n));
-        c
+        let gate = Rotr32::new(self, a, n);
+        let out = gate.c;
+        self.emit(gate);
+        out
     }
 
     pub fn shr_32(&self, a: Wire, n: u32) -> Wire {
-        let c = self.add_private();
-        let mask32 = self.add_constant(Word::MASK_32);
-        self.emit(Shr32::new(a, c, mask32, n));
-        c
+        let gate = Shr32::new(self, a, n);
+        let out = gate.c;
+        self.emit(gate);
+        out
     }
 
     pub fn assert_eq(&self, x: Wire, y: Wire) {


### PR DESCRIPTION
## Summary
- update gates to allocate their own wires via `CircuitBuilder`
- adjust `CircuitBuilder` to obtain outputs from gates

## Testing
- `cargo check`
- `cargo build`
- `cargo run --release`

------
https://chatgpt.com/codex/tasks/task_b_685ebba20f30832399cb21bb1e955b50