### PR TITLE
Add nightly Rust toolchain

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly-2025-07-01"


### PR DESCRIPTION
We use nightly for
* rustfmt lint rules
* some SIMD instruction implementations

We can undo this later if needed