### PR TITLE
[field] Remove stdarch_x86_avx512 feature

### DIFF
--- a/crates/field/src/lib.rs
+++ b/crates/field/src/lib.rs
@@ -9,11 +9,6 @@
 //!
 //! [DP23]: https://eprint.iacr.org/2023/1784
 
-#![cfg_attr(
-	all(feature = "nightly_features", target_arch = "x86_64"),
-	feature(stdarch_x86_avx512)
-)]
-
 pub mod aes_field;
 pub mod arch;
 pub mod arithmetic_traits;


### PR DESCRIPTION
It is no longer needed after Rust 1.89.0. See tracking issue: https://github.com/rust-lang/rust/issues/111137