### PR TITLE
[prover] Initial prover and verifier crates

### DIFF
--- a/crates/monbijou/src/compiler/mod.rs
+++ b/crates/monbijou/src/compiler/mod.rs
@@ -221,6 +221,10 @@ impl<'a> WitnessFiller<'a> {
 	pub fn flag_assertion_failed(&mut self) {
 		self.assertion_failed = true;
 	}
+
+	pub fn into_value_vec(self) -> ValueVec {
+		self.value_vec
+	}
 }
 
 impl<'a> std::ops::Index<Wire> for WitnessFiller<'a> {

--- a/crates/monbijou/src/constraint_system.rs
+++ b/crates/monbijou/src/constraint_system.rs
@@ -144,6 +144,7 @@ pub fn value_vec_len(n_const: usize, n_inout: usize, n_witness: usize) -> usize 
 /// This is a prover-only structure.
 ///
 /// The size of the value vec is always a power-of-two.
+#[derive(Clone, Debug)]
 pub struct ValueVec {
 	data: Vec<Word>,
 }

--- a/crates/prover/Cargo.toml
+++ b/crates/prover/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "binius_prover"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+binius_field = { path = "../field" }
+binius_transcript = { path = "../transcript" }
+binius_verifier = { path = "../verifier" }
+monbijou = { path = "../monbijou" }
+thiserror.workspace = true
+
+[dev-dependencies]
+blake2.workspace = true

--- a/crates/prover/src/error.rs
+++ b/crates/prover/src/error.rs
@@ -1,0 +1,3 @@
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+}

--- a/crates/prover/src/lib.rs
+++ b/crates/prover/src/lib.rs
@@ -1,0 +1,5 @@
+mod error;
+mod prove;
+
+pub use error::*;
+pub use prove::*;

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -1,0 +1,19 @@
+use binius_field::{BinaryField, ExtensionField};
+use binius_transcript::{ProverTranscript, fiat_shamir::Challenger};
+use binius_verifier::{Params, fields::B64};
+use monbijou::{constraint_system::ConstraintSystem, word::Word};
+use monbijou::constraint_system::ValueVec;
+use super::error::Error;
+
+pub fn prove<F, Challenger_>(
+	params: &Params,
+	cs: &ConstraintSystem,
+	witness: ValueVec,
+	transcript: &mut ProverTranscript<Challenger_>,
+) -> Result<(), Error>
+where
+	F: BinaryField + ExtensionField<B64>,
+	Challenger_: Challenger,
+{
+	Ok(())
+}

--- a/crates/prover/tests/prove_verify.rs
+++ b/crates/prover/tests/prove_verify.rs
@@ -1,0 +1,67 @@
+use binius_prover::prove;
+use binius_transcript::{ProverTranscript, fiat_shamir::HasherChallenger};
+use binius_verifier::{Params, fields::B128, verify};
+use blake2::{Blake2b, digest::consts::U32};
+use monbijou::{
+	circuits::sha256::{Compress, State},
+	compiler,
+	compiler::Wire,
+	word::Word,
+};
+
+type Blake2b256 = Blake2b<U32>;
+
+#[test]
+fn test_prove_verify_sha256_preimage() {
+	// Use the test-vector for SHA256 single block message: "abc".
+	let mut preimage: [u8; 64] = [0; 64];
+	preimage[0..3].copy_from_slice(b"abc");
+	preimage[3] = 0x80;
+	preimage[63] = 0x18;
+
+	#[rustfmt::skip]
+        let expected_state: [u32; 8] = [
+            0xba7816bf, 0x8f01cfea, 0x414140de, 0x5dae2223,
+            0xb00361a3, 0x96177a9c, 0xb410ff61, 0xf20015ad,
+        ];
+
+	let mut circuit = compiler::CircuitBuilder::new();
+	let state = State::iv(&mut circuit);
+	let input: [Wire; 16] = std::array::from_fn(|_| circuit.add_witness());
+	let output: [Wire; 8] = std::array::from_fn(|_| circuit.add_inout());
+	let compress = Compress::new(&mut circuit, state, input);
+
+	// Mask to only low 32-bit.
+	let mask32 = circuit.add_constant(Word::MASK_32);
+	for (actual_x, expected_x) in compress.state_out.0.iter().zip(output) {
+		circuit.assert_eq(circuit.band(*actual_x, mask32), expected_x);
+	}
+
+	let circuit = circuit.build();
+	let mut w = circuit.new_witness_filler();
+
+	// Populate the input message for the compression function.
+	compress.populate_m(&mut w, preimage);
+
+	for (i, &output) in output.iter().enumerate() {
+		w[output] = Word(expected_state[i] as u64);
+	}
+	circuit.populate_wire_witness(&mut w);
+
+	let cs = circuit.constraint_system();
+	println!("Number of AND constraints: {}", cs.n_and_constraints());
+	println!("Number of gates: {}", circuit.n_gates());
+
+	let witness = w.into_value_vec();
+
+	// TODO: this is wrong, this should be the inout values from the witness.
+	let inout = vec![];
+
+	let params = Params {};
+
+	let mut prover_transcript = ProverTranscript::<HasherChallenger<Blake2b256>>::default();
+	prove::<B128, _>(&params, &cs, witness, &mut prover_transcript).unwrap();
+
+	let mut verifier_transcript = prover_transcript.into_verifier();
+	verify::<B128, _>(&params, &cs, &inout, &mut verifier_transcript).unwrap();
+}

--- a/crates/verifier/Cargo.toml
+++ b/crates/verifier/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "binius_verifier"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+binius_field = { path = "../field" }
+binius_transcript = { path = "../transcript" }
+monbijou = { path = "../monbijou" }
+thiserror.workspace = true

--- a/crates/verifier/src/error.rs
+++ b/crates/verifier/src/error.rs
@@ -1,0 +1,4 @@
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+	
+}

--- a/crates/verifier/src/fields.rs
+++ b/crates/verifier/src/fields.rs
@@ -1,0 +1,7 @@
+//! Exports the binary fields that this system uses
+
+use binius_field::{BinaryField1b, BinaryField64b, BinaryField128b};
+
+pub type B1 = BinaryField1b;
+pub type B64 = BinaryField64b;
+pub type B128 = BinaryField128b;

--- a/crates/verifier/src/lib.rs
+++ b/crates/verifier/src/lib.rs
@@ -1,0 +1,6 @@
+mod error;
+pub mod fields;
+mod verify;
+
+pub use error::*;
+pub use verify::*;

--- a/crates/verifier/src/verify.rs
+++ b/crates/verifier/src/verify.rs
@@ -1,0 +1,21 @@
+use binius_field::{BinaryField, ExtensionField};
+use binius_transcript::{VerifierTranscript, fiat_shamir::Challenger};
+use monbijou::{constraint_system::ConstraintSystem, word::Word};
+
+use super::{error::Error, fields::B64};
+
+#[derive(Debug, Clone)]
+pub struct Params {}
+
+pub fn verify<F, Challenger_>(
+	params: &Params,
+	cs: &ConstraintSystem,
+	inout: &[Word],
+	transcript: &mut VerifierTranscript<Challenger_>,
+) -> Result<(), Error>
+where
+	F: BinaryField + ExtensionField<B64>,
+	Challenger_: Challenger,
+{
+	Ok(())
+}


### PR DESCRIPTION
These basically just contain function signatures for prove and verify, and one high-level integration test.

I couldn't figure out how to get the proper witness and inout inputs to the `prove` and `verify` methods from the frontend crate, so I added a couple methods there. I'd like @pepyakin or @paulcadman 's input on how this interface should work.