### PR TITLE
[chore] squash warnings

### DIFF
--- a/crates/frontend/src/compiler/mod.rs
+++ b/crates/frontend/src/compiler/mod.rs
@@ -112,7 +112,7 @@ impl CircuitBuilder {
 		}
 	}
 
-	fn shared_mut(&self) -> RefMut<Shared> {
+	fn shared_mut(&self) -> RefMut<'_, Shared> {
 		RefMut::map(self.shared.borrow_mut(), |shared| shared.as_mut().unwrap())
 	}
 
@@ -253,7 +253,7 @@ impl Circuit {
 		self.wire_mapping[wire.0 as usize]
 	}
 
-	pub fn new_witness_filler(&self) -> WitnessFiller {
+	pub fn new_witness_filler(&self) -> WitnessFiller<'_> {
 		WitnessFiller {
 			circuit: self,
 			value_vec: ValueVec::new(value_vec_len(

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -1,9 +1,8 @@
+use super::error::Error;
 use binius_field::{BinaryField, ExtensionField};
 use binius_frontend::constraint_system::{ConstraintSystem, ValueVec};
 use binius_transcript::{ProverTranscript, fiat_shamir::Challenger};
 use binius_verifier::{Params, fields::B64};
-
-use super::error::Error;
 
 pub fn prove<F, Challenger_>(
 	params: &Params,
@@ -15,5 +14,6 @@ where
 	F: BinaryField + ExtensionField<B64>,
 	Challenger_: Challenger,
 {
+	let _ = (params, cs, witness, transcript);
 	Ok(())
 }

--- a/crates/transcript/src/transcript.rs
+++ b/crates/transcript/src/transcript.rs
@@ -68,7 +68,7 @@ impl<Challenger_: Challenger> VerifierTranscript<Challenger_> {
 	///
 	/// This method should only be used to read advice that was previously written to the transcript
 	/// as an observed message.
-	pub fn decommitment(&mut self) -> TranscriptReader<impl Buf + '_> {
+	pub fn decommitment(&mut self) -> TranscriptReader<'_, impl Buf + '_> {
 		TranscriptReader {
 			buffer: &mut self.combined.buffer,
 			debug_assertions: self.debug_assertions,
@@ -275,7 +275,7 @@ impl<Challenger_: Challenger> ProverTranscript<Challenger_> {
 	/// a Merkle tree root as a commitment, and later sends leaf openings. The leaf openings should
 	/// be written using [`Self::decommitment`] because they are verified with respect to the
 	/// previously sent Merkle root.
-	pub fn decommitment(&mut self) -> TranscriptWriter<impl BufMut> {
+	pub fn decommitment(&mut self) -> TranscriptWriter<'_, impl BufMut> {
 		TranscriptWriter {
 			buffer: &mut self.combined.buffer,
 			debug_assertions: self.debug_assertions,

--- a/crates/utils/src/sparse_index.rs
+++ b/crates/utils/src/sparse_index.rs
@@ -17,7 +17,7 @@ impl<T> SparseIndex<T> {
 		Self { entries }
 	}
 
-	pub fn entry(&mut self, id: usize) -> Entry<T> {
+	pub fn entry(&mut self, id: usize) -> Entry<'_, T> {
 		if self.entries.len() <= id {
 			self.entries.resize_with(id + 1, || None);
 		}

--- a/crates/verifier/src/verify.rs
+++ b/crates/verifier/src/verify.rs
@@ -17,5 +17,6 @@ where
 	F: BinaryField + ExtensionField<B64>,
 	Challenger_: Challenger,
 {
+	let _ = (params, cs, inout, transcript);
 	Ok(())
 }


### PR DESCRIPTION
- discard the parameters values explicitly
- remove unused imports
- specify the elided lifetimes explicitly