### PR TITLE
Add a circuit helper to subtract a constant from a word

### DIFF
--- a/crates/frontend/src/circuits/basic.rs
+++ b/crates/frontend/src/circuits/basic.rs
@@ -45,6 +45,13 @@ pub fn add_const(b: &CircuitBuilder, x: Wire, c: u32) -> Wire {
 	b.iadd_32(x, cst)
 }
 
+/// Subtract a 32-bit constant from a word
+pub fn sub_const(b: &CircuitBuilder, x: Wire, c: u32) -> Wire {
+	// compute -c in twos-complement
+	let neg_c = (!c).wrapping_add(1);
+	add_const(b, x, neg_c)
+}
+
 /// Compute x > const as a boolean wire (0/1).
 pub fn gt_const(b: &CircuitBuilder, x: Wire, c: u32) -> Wire {
 	// Compute x - (c + 1) and extract the sign bit.


### PR DESCRIPTION
Adds a construction for subtracting a 32-bit constant from a word.

I'm adding this because it wasn't immediately clear to me what `(!x).wrapping_add(1)` meant.