### PR TITLE
[math] Copy NTT crate from binius

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ inherits = "release"
 debug = true
 
 [workspace.dependencies]
+assert_matches = "1.5.0"
 auto_impl = "1.2.0"
 blake2 = "0.10.6"
 bytemuck = { version = "1.18.0", features = [
@@ -36,6 +37,7 @@ generic-array = "0.14.7"
 getrandom = "0.3.3"
 getset = "0.1.6"
 itertools = "0.14.0"
+lazy_static = "1.5.0"
 paste = "1.0.15"
 proptest = "1.2.0"
 rand = { version = "0.9.1", default-features = false, features = ["std"] }

--- a/crates/math/Cargo.toml
+++ b/crates/math/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "binius-math"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+binius-field = { path = "../field", default-features = false }
+binius-maybe-rayon = { path = "../maybe-rayon", default-features = false }
+binius-utils = { path = "../utils", default-features = false }
+bytemuck.workspace = true
+getset.workspace = true
+rand.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+
+[dev-dependencies]
+assert_matches.workspace = true
+criterion.workspace = true
+lazy_static.workspace = true
+proptest.workspace = true
+rand = { workspace = true, features = ["std_rng", "thread_rng"] }
+
+[lib]
+bench = false
+
+[[bench]]
+name = "additive_ntt"
+harness = false
+
+[[bench]]
+name = "large_transform"
+harness = false

--- a/crates/math/benches/additive_ntt.rs
+++ b/crates/math/benches/additive_ntt.rs
@@ -1,0 +1,177 @@
+// Copyright 2024-2025 Irreducible Inc.
+
+use std::{iter::repeat_with, mem};
+
+use binius_field::{
+	BinaryField, PackedBinaryField4x32b, PackedBinaryField8x16b, PackedBinaryField8x32b,
+	PackedBinaryField16x16b, PackedField,
+	arch::byte_sliced::{ByteSlicedAES32x16b, ByteSlicedAES32x32b},
+};
+use binius_math::ntt::{AdditiveNTT, NTTShape, SingleThreadedNTT};
+use criterion::{
+	BenchmarkGroup, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main,
+	measurement::WallTime,
+};
+
+trait BenchTransformationFunc {
+	fn run_bench<F, P>(
+		group: &mut BenchmarkGroup<WallTime>,
+		ntt: &impl AdditiveNTT<F>,
+		data: &mut [P],
+		name: &str,
+		param: &str,
+		log_batch_size: usize,
+	) where
+		F: BinaryField,
+		P: PackedField<Scalar = F>;
+}
+
+fn bench_helper<P, BT: BenchTransformationFunc>(
+	group: &mut BenchmarkGroup<WallTime>,
+	id: &str,
+	log_n: usize,
+	log_stride_batch: usize,
+) where
+	P: PackedField<Scalar: BinaryField>,
+{
+	let data_len = 1 << (log_n + log_stride_batch - P::LOG_WIDTH);
+	let mut rng = rand::rng();
+	let mut data = repeat_with(|| P::random(&mut rng))
+		.take(data_len)
+		.collect::<Vec<_>>();
+
+	let params = format!("field={id}/log_n={log_n}/log_s={log_stride_batch}");
+	group.throughput(Throughput::Bytes((data_len * mem::size_of::<P>()) as u64));
+
+	let ntt = SingleThreadedNTT::<P::Scalar>::new(log_n).unwrap();
+	BT::run_bench(group, &ntt, &mut data, "single-thread/on-the-fly", &params, log_stride_batch);
+
+	let ntt = SingleThreadedNTT::<P::Scalar>::new(log_n)
+		.unwrap()
+		.precompute_twiddles();
+	BT::run_bench(group, &ntt, &mut data, "single-thread/precompute", &params, log_stride_batch);
+
+	let ntt = SingleThreadedNTT::<P::Scalar>::new(log_n)
+		.unwrap()
+		.multithreaded();
+	BT::run_bench(group, &ntt, &mut data, "multithread/on-the-fly", &params, log_stride_batch);
+
+	let ntt = SingleThreadedNTT::<P::Scalar>::new(log_n)
+		.unwrap()
+		.precompute_twiddles()
+		.multithreaded();
+	BT::run_bench(group, &ntt, &mut data, "multithread/precompute", &params, log_stride_batch);
+}
+
+fn run_benchmarks_on_packed_fields<BT: BenchTransformationFunc>(c: &mut Criterion, name: &str) {
+	let mut group = c.benchmark_group(name);
+	for &log_n in std::iter::once(&16) {
+		for &log_stride_batch in &[0, 4] {
+			// 128 bit registers
+			bench_helper::<PackedBinaryField8x16b, BT>(
+				&mut group,
+				"8x16b",
+				log_n,
+				log_stride_batch,
+			);
+			bench_helper::<PackedBinaryField4x32b, BT>(
+				&mut group,
+				"4x32b",
+				log_n,
+				log_stride_batch,
+			);
+
+			// 256 bit registers
+			bench_helper::<PackedBinaryField16x16b, BT>(
+				&mut group,
+				"16x16b",
+				log_n,
+				log_stride_batch,
+			);
+			bench_helper::<PackedBinaryField8x32b, BT>(
+				&mut group,
+				"8x32b",
+				log_n,
+				log_stride_batch,
+			);
+
+			// 256-bit registers with byte-slicing
+			bench_helper::<ByteSlicedAES32x16b, BT>(
+				&mut group,
+				"byte_sliced32x16",
+				log_n,
+				log_stride_batch,
+			);
+			bench_helper::<ByteSlicedAES32x32b, BT>(
+				&mut group,
+				"byte_sliced32x32",
+				log_n,
+				log_stride_batch,
+			);
+		}
+	}
+	group.finish();
+}
+
+fn bench_forward_transform(c: &mut Criterion) {
+	struct ForwardBench;
+
+	impl BenchTransformationFunc for ForwardBench {
+		fn run_bench<F, P>(
+			group: &mut BenchmarkGroup<WallTime>,
+			ntt: &impl AdditiveNTT<F>,
+			data: &mut [P],
+			name: &str,
+			param: &str,
+			log_stride_batch: usize,
+		) where
+			F: BinaryField,
+			P: PackedField<Scalar = F>,
+		{
+			let log_n = data.len().ilog2() as usize + P::LOG_WIDTH - log_stride_batch;
+			let shape = NTTShape {
+				log_x: log_stride_batch,
+				log_y: log_n,
+				..Default::default()
+			};
+			group.bench_function(BenchmarkId::new(name, param), |b| {
+				b.iter(|| ntt.forward_transform(data, shape, 0, 0, 0));
+			});
+		}
+	}
+
+	run_benchmarks_on_packed_fields::<ForwardBench>(c, "forward_transform");
+}
+
+fn bench_inverse_transform(c: &mut Criterion) {
+	struct InverseBench;
+
+	impl BenchTransformationFunc for InverseBench {
+		fn run_bench<F, P>(
+			group: &mut BenchmarkGroup<WallTime>,
+			ntt: &impl AdditiveNTT<F>,
+			data: &mut [P],
+			name: &str,
+			param: &str,
+			log_stride_batch: usize,
+		) where
+			F: BinaryField,
+			P: PackedField<Scalar = F>,
+		{
+			let log_n = data.len().ilog2() as usize + P::LOG_WIDTH - log_stride_batch;
+			let shape = NTTShape {
+				log_x: log_stride_batch,
+				log_y: log_n,
+				..Default::default()
+			};
+			group.bench_function(BenchmarkId::new(name, param), |b| {
+				b.iter(|| ntt.inverse_transform(data, shape, 0, 0, 0));
+			});
+		}
+	}
+
+	run_benchmarks_on_packed_fields::<InverseBench>(c, "inverse_transform");
+}
+
+criterion_group!(ntt, bench_forward_transform, bench_inverse_transform);
+criterion_main!(ntt);

--- a/crates/math/benches/large_transform.rs
+++ b/crates/math/benches/large_transform.rs
@@ -1,0 +1,81 @@
+// Copyright 2024-2025 Irreducible Inc.
+
+use std::iter::repeat_with;
+
+use binius_field::{
+	AESTowerField32b, AESTowerField128b, BinaryField32b, BinaryField128b, BinaryField128bPolyval,
+	PackedExtension, TowerField,
+	arch::{OptimalUnderlier, OptimalUnderlierByteSliced},
+	as_packed_field::PackedType,
+};
+use binius_math::ntt::{AdditiveNTT, NTTShape, SingleThreadedNTT};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+
+fn bench_large_transform<F: TowerField, PE: PackedExtension<F>>(c: &mut Criterion, field: &str) {
+	let mut group = c.benchmark_group("NTT");
+	for log_dim in [16, 20] {
+		for log_stride_batch in [1, 4] {
+			let data_len = 1 << (log_dim + log_stride_batch - PE::LOG_WIDTH);
+			let mut rng = rand::rng();
+			let mut data = repeat_with(|| PE::random(&mut rng))
+				.take(data_len)
+				.collect::<Vec<_>>();
+
+			let params = format!("{field}/log_dim={log_dim}/log_s={log_stride_batch}");
+			group.throughput(Throughput::Bytes((data_len * size_of::<PE>()) as u64));
+
+			let shape = NTTShape {
+				log_x: log_stride_batch,
+				log_y: log_dim,
+				..Default::default()
+			};
+
+			let ntt = SingleThreadedNTT::<F>::new(log_dim)
+				.unwrap()
+				.precompute_twiddles();
+			group.bench_function(BenchmarkId::new("single-thread/precompute", &params), |b| {
+				b.iter(|| ntt.forward_transform_ext(&mut data, shape, 0, 0, 0));
+			});
+
+			let ntt = SingleThreadedNTT::<F>::new(log_dim)
+				.unwrap()
+				.precompute_twiddles()
+				.multithreaded();
+			group.bench_function(BenchmarkId::new("multithread/precompute", &params), |b| {
+				b.iter(|| ntt.forward_transform_ext(&mut data, shape, 0, 0, 0));
+			});
+		}
+	}
+}
+
+// We are ignoring the transposition associated with byte slicing
+fn bench_byte_sliced(c: &mut Criterion) {
+	bench_large_transform::<
+		AESTowerField32b,
+		PackedType<OptimalUnderlierByteSliced, AESTowerField128b>,
+	>(c, "bytesliced=AESTowerField128b");
+}
+
+fn bench_packed128b(c: &mut Criterion) {
+	bench_large_transform::<BinaryField32b, PackedType<OptimalUnderlier, BinaryField128b>>(
+		c,
+		"field=BinaryField128b",
+	);
+
+	bench_large_transform::<AESTowerField32b, PackedType<OptimalUnderlier, AESTowerField128b>>(
+		c,
+		"field=AESTowerField128b",
+	);
+
+	bench_large_transform::<
+		BinaryField128bPolyval,
+		PackedType<OptimalUnderlier, BinaryField128bPolyval>,
+	>(c, "field=BinaryField128bPolyval");
+}
+
+criterion_group! {
+	name = large_transform;
+	config = Criterion::default().sample_size(10);
+	targets = bench_packed128b, bench_byte_sliced
+}
+criterion_main!(large_transform);

--- a/crates/math/src/binary_subspace.rs
+++ b/crates/math/src/binary_subspace.rs
@@ -1,0 +1,278 @@
+// Copyright 2024-2025 Irreducible Inc.
+
+use binius_field::BinaryField;
+use binius_utils::{bail, iter::IterExtensions};
+
+use super::error::Error;
+
+/// An $F_2$-linear subspace of a binary field.
+///
+/// The subspace is defined by a basis of elements from a binary field. The basis elements are
+/// ordered, which implies an ordering on the subspace elements.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BinarySubspace<F: BinaryField> {
+	basis: Vec<F>,
+}
+
+impl<F: BinaryField> BinarySubspace<F> {
+	/// Creates a new subspace from a vector of ordered basis elements.
+	///
+	/// This constructor does not check that the basis elements are linearly independent.
+	pub const fn new_unchecked(basis: Vec<F>) -> Self {
+		Self { basis }
+	}
+
+	/// Creates a new subspace of this binary subspace with the given dimension.
+	///
+	/// This creates a new sub-subspace using a prefix of the default $\mathbb{F}_2$ basis elements
+	/// of the field.
+	///
+	/// ## Throws
+	///
+	/// * `Error::DomainSizeTooLarge` if `dim` is greater than this subspace's dimension.
+	pub fn with_dim(dim: usize) -> Result<Self, Error> {
+		let basis = (0..dim)
+			.map(|i| F::basis_checked(i).map_err(|_| Error::DomainSizeTooLarge))
+			.collect::<Result<_, _>>()?;
+		Ok(Self { basis })
+	}
+
+	/// Creates a new subspace of this binary subspace with reduced dimension.
+	///
+	/// This creates a new sub-subspace using a prefix of the ordered basis elements.
+	///
+	/// ## Throws
+	///
+	/// * `Error::DomainSizeTooLarge` if `dim` is greater than this subspace's dimension.
+	pub fn reduce_dim(&self, dim: usize) -> Result<Self, Error> {
+		if dim > self.dim() {
+			bail!(Error::DomainSizeTooLarge);
+		}
+		Ok(Self {
+			basis: self.basis[..dim].to_vec(),
+		})
+	}
+
+	/// Creates a new subspace isomorphic to the given one.
+	pub fn isomorphic<FIso>(&self) -> BinarySubspace<FIso>
+	where
+		FIso: BinaryField + From<F>,
+	{
+		BinarySubspace {
+			basis: self.basis.iter().copied().map(Into::into).collect(),
+		}
+	}
+
+	/// Returns the dimension of the subspace.
+	pub fn dim(&self) -> usize {
+		self.basis.len()
+	}
+
+	/// Returns the slice of ordered basis elements.
+	pub fn basis(&self) -> &[F] {
+		&self.basis
+	}
+
+	pub fn get(&self, index: usize) -> F {
+		self.basis
+			.iter()
+			.take(usize::BITS as usize)
+			.enumerate()
+			.fold(F::ZERO, |acc, (i, basis_i)| {
+				if (index >> i) & 1 != 0 {
+					acc + basis_i
+				} else {
+					acc
+				}
+			})
+	}
+
+	pub fn get_checked(&self, index: usize) -> Result<F, Error> {
+		if index >= 1 << self.basis.len() {
+			bail!(Error::ArgumentRangeError {
+				arg: "index".to_string(),
+				range: 0..1 << self.basis.len(),
+			});
+		}
+		Ok(self.get(index))
+	}
+
+	/// Returns an iterator over all elements of the subspace in order.
+	///
+	/// This has a limitation that the iterator only yields the first `2^usize::BITS` elements.
+	pub fn iter(&self) -> impl Iterator<Item = F> + '_ {
+		let last = if self.basis.len() < usize::BITS as usize {
+			(1 << self.basis.len()) - 1
+		} else {
+			usize::MAX
+		};
+		(0..=last).map_skippable(|i| self.get(i))
+	}
+}
+
+impl<F: BinaryField> Default for BinarySubspace<F> {
+	fn default() -> Self {
+		let basis = (0..F::DEGREE).map(|i| F::basis(i)).collect();
+		Self { basis }
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use assert_matches::assert_matches;
+	use binius_field::{BinaryField8b, BinaryField128b};
+
+	use super::*;
+
+	#[test]
+	fn test_default_binary_subspace_iterates_elements() {
+		let subspace = BinarySubspace::<BinaryField8b>::default();
+		for i in 0..=255 {
+			assert_eq!(subspace.get(i), BinaryField8b::new(i as u8));
+		}
+	}
+
+	#[test]
+	fn test_binary_subspace_range_error() {
+		let subspace = BinarySubspace::<BinaryField8b>::default();
+		assert_matches!(subspace.get_checked(256), Err(Error::ArgumentRangeError { .. }));
+	}
+
+	#[test]
+	fn test_default_large_binary_subspace_iterates_elements() {
+		let subspace = BinarySubspace::<BinaryField128b>::default();
+		for i in 0..=255 {
+			assert_eq!(subspace.get(i), BinaryField128b::new(i as u128));
+		}
+	}
+
+	#[test]
+	fn test_default_binary_subspace() {
+		let subspace = BinarySubspace::<BinaryField8b>::default();
+		assert_eq!(subspace.dim(), 8);
+		assert_eq!(subspace.basis().len(), 8);
+
+		assert_eq!(
+			subspace.basis(),
+			[
+				BinaryField8b::new(0b00000001),
+				BinaryField8b::new(0b00000010),
+				BinaryField8b::new(0b00000100),
+				BinaryField8b::new(0b00001000),
+				BinaryField8b::new(0b00010000),
+				BinaryField8b::new(0b00100000),
+				BinaryField8b::new(0b01000000),
+				BinaryField8b::new(0b10000000)
+			]
+		);
+
+		let expected_elements: [u8; 256] = (0..=255).collect::<Vec<_>>().try_into().unwrap();
+
+		for (i, &expected) in expected_elements.iter().enumerate() {
+			assert_eq!(subspace.get(i), BinaryField8b::new(expected));
+		}
+	}
+
+	#[test]
+	fn test_with_dim_valid() {
+		let subspace = BinarySubspace::<BinaryField8b>::with_dim(3).unwrap();
+		assert_eq!(subspace.dim(), 3);
+		assert_eq!(subspace.basis().len(), 3);
+
+		assert_eq!(
+			subspace.basis(),
+			[
+				BinaryField8b::new(0b001),
+				BinaryField8b::new(0b010),
+				BinaryField8b::new(0b100)
+			]
+		);
+
+		let expected_elements: [u8; 8] = [0b000, 0b001, 0b010, 0b011, 0b100, 0b101, 0b110, 0b111];
+
+		for (i, &expected) in expected_elements.iter().enumerate() {
+			assert_eq!(subspace.get(i), BinaryField8b::new(expected));
+		}
+	}
+
+	#[test]
+	fn test_with_dim_invalid() {
+		let result = BinarySubspace::<BinaryField8b>::with_dim(10);
+		assert_matches!(result, Err(Error::DomainSizeTooLarge));
+	}
+
+	#[test]
+	fn test_reduce_dim_valid() {
+		let subspace = BinarySubspace::<BinaryField8b>::with_dim(6).unwrap();
+		let reduced = subspace.reduce_dim(4).unwrap();
+		assert_eq!(reduced.dim(), 4);
+		assert_eq!(reduced.basis().len(), 4);
+
+		assert_eq!(
+			reduced.basis(),
+			[
+				BinaryField8b::new(0b0001),
+				BinaryField8b::new(0b0010),
+				BinaryField8b::new(0b0100),
+				BinaryField8b::new(0b1000)
+			]
+		);
+
+		let expected_elements: [u8; 16] = (0..16).collect::<Vec<_>>().try_into().unwrap();
+
+		for (i, &expected) in expected_elements.iter().enumerate() {
+			assert_eq!(reduced.get(i), BinaryField8b::new(expected));
+		}
+	}
+
+	#[test]
+	fn test_reduce_dim_invalid() {
+		let subspace = BinarySubspace::<BinaryField8b>::with_dim(4).unwrap();
+		let result = subspace.reduce_dim(6);
+		assert_matches!(result, Err(Error::DomainSizeTooLarge));
+	}
+
+	#[test]
+	fn test_isomorphic_conversion() {
+		let subspace = BinarySubspace::<BinaryField8b>::with_dim(3).unwrap();
+		let iso_subspace: BinarySubspace<BinaryField128b> = subspace.isomorphic();
+		assert_eq!(iso_subspace.dim(), 3);
+		assert_eq!(iso_subspace.basis().len(), 3);
+
+		assert_eq!(
+			iso_subspace.basis(),
+			[
+				BinaryField128b::from(BinaryField8b::new(0b001)),
+				BinaryField128b::from(BinaryField8b::new(0b010)),
+				BinaryField128b::from(BinaryField8b::new(0b100))
+			]
+		);
+	}
+
+	#[test]
+	fn test_get_checked_valid() {
+		let subspace = BinarySubspace::<BinaryField8b>::default();
+		for i in 0..256 {
+			assert!(subspace.get_checked(i).is_ok());
+		}
+	}
+
+	#[test]
+	fn test_get_checked_invalid() {
+		let subspace = BinarySubspace::<BinaryField8b>::default();
+		assert_matches!(subspace.get_checked(256), Err(Error::ArgumentRangeError { .. }));
+	}
+
+	#[test]
+	fn test_iterate_subspace() {
+		let subspace = BinarySubspace::<BinaryField8b>::with_dim(3).unwrap();
+		let elements: Vec<_> = subspace.iter().collect();
+		assert_eq!(elements.len(), 8);
+
+		let expected_elements: [u8; 8] = [0b000, 0b001, 0b010, 0b011, 0b100, 0b101, 0b110, 0b111];
+
+		for (i, &expected) in expected_elements.iter().enumerate() {
+			assert_eq!(elements[i], BinaryField8b::new(expected));
+		}
+	}
+}

--- a/crates/math/src/error.rs
+++ b/crates/math/src/error.rs
@@ -1,0 +1,17 @@
+// Copyright 2024-2025 Irreducible Inc.
+
+use std::ops::Range;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+	#[error("argument {arg} does not have expected length {expected}")]
+	IncorrectArgumentLength { arg: String, expected: usize },
+	#[error("the matrix is not square")]
+	MatrixNotSquare,
+	#[error("the matrix is singular")]
+	MatrixIsSingular,
+	#[error("domain size is larger than the field")]
+	DomainSizeTooLarge,
+	#[error("argument {arg} must be in the range {range:?}")]
+	ArgumentRangeError { arg: String, range: Range<usize> },
+}

--- a/crates/math/src/lib.rs
+++ b/crates/math/src/lib.rs
@@ -1,0 +1,8 @@
+mod binary_subspace;
+mod error;
+mod matrix;
+pub mod ntt;
+
+pub use binary_subspace::*;
+pub use error::*;
+pub use matrix::*;

--- a/crates/math/src/matrix.rs
+++ b/crates/math/src/matrix.rs
@@ -1,0 +1,344 @@
+// Copyright 2024-2025 Irreducible Inc.
+
+use std::{
+	iter::repeat_with,
+	ops::{Add, AddAssign, Index, IndexMut, Sub, SubAssign},
+};
+
+use binius_field::{ExtensionField, Field};
+use binius_utils::bail;
+use bytemuck::zeroed_slice_box;
+use getset::CopyGetters;
+use rand::RngCore;
+
+use super::error::Error;
+
+/// A matrix over a field.
+#[derive(Debug, Clone, PartialEq, Eq, CopyGetters)]
+pub struct Matrix<F: Field> {
+	/// The number of rows.
+	#[getset(get_copy = "pub")]
+	m: usize,
+	/// The number of columns.
+	#[getset(get_copy = "pub")]
+	n: usize,
+	elements: Box<[F]>,
+}
+
+impl<F: Field> Matrix<F> {
+	pub fn new(m: usize, n: usize, elements: &[F]) -> Result<Self, Error> {
+		if elements.len() != m * n {
+			bail!(Error::IncorrectArgumentLength {
+				arg: "elements".into(),
+				expected: m * n,
+			});
+		}
+		Ok(Self {
+			m,
+			n,
+			elements: elements.into(),
+		})
+	}
+
+	pub fn zeros(m: usize, n: usize) -> Self {
+		Self {
+			m,
+			n,
+			elements: zeroed_slice_box(m * n),
+		}
+	}
+
+	pub fn identity(n: usize) -> Self {
+		let mut out = Self::zeros(n, n);
+		for i in 0..n {
+			out[(i, i)] = F::ONE;
+		}
+		out
+	}
+
+	fn fill_identity(&mut self) {
+		assert_eq!(self.m, self.n);
+		self.elements.fill(F::ZERO);
+		for i in 0..self.n {
+			self[(i, i)] = F::ONE;
+		}
+	}
+
+	pub const fn elements(&self) -> &[F] {
+		&self.elements
+	}
+
+	pub fn random(m: usize, n: usize, mut rng: impl RngCore) -> Self {
+		Self {
+			m,
+			n,
+			elements: repeat_with(|| F::random(&mut rng)).take(m * n).collect(),
+		}
+	}
+
+	pub const fn dim(&self) -> (usize, usize) {
+		(self.m, self.n)
+	}
+
+	pub fn copy_from(&mut self, other: &Self) {
+		assert_eq!(self.dim(), other.dim());
+		self.elements.copy_from_slice(&other.elements);
+	}
+
+	pub fn mul_into(a: &Self, b: &Self, c: &mut Self) {
+		assert_eq!(a.n(), b.m());
+		assert_eq!(a.m(), c.m());
+		assert_eq!(b.n(), c.n());
+
+		for i in 0..c.m() {
+			for j in 0..c.n() {
+				c[(i, j)] = (0..a.n()).map(|k| a[(i, k)] * b[(k, j)]).sum();
+			}
+		}
+	}
+
+	pub fn mul_vec_into<FE: ExtensionField<F>>(&self, x: &[FE], y: &mut [FE]) {
+		assert_eq!(self.n(), x.len());
+		assert_eq!(self.m(), y.len());
+
+		for i in 0..y.len() {
+			y[i] = (0..self.n()).map(|j| x[j] * self[(i, j)]).sum();
+		}
+	}
+
+	/// Invert a square matrix
+	///
+	/// ## Throws
+	///
+	/// * [`Error::MatrixNotSquare`]
+	/// * [`Error::MatrixIsSingular`]
+	///
+	/// ## Preconditions
+	///
+	/// * `out` - must have the same dimensions as `self`
+	pub fn inverse_into(&self, out: &mut Self) -> Result<(), Error> {
+		assert_eq!(self.dim(), out.dim());
+
+		if self.m != self.n {
+			bail!(Error::MatrixNotSquare);
+		}
+
+		let n = self.n;
+
+		let mut tmp = self.clone();
+		out.fill_identity();
+
+		let mut row_buffer = vec![F::ZERO; n];
+
+		for i in 0..n {
+			// Find the pivot row
+			let pivot = (i..n)
+				.find(|&pivot| tmp[(pivot, i)] != F::ZERO)
+				.ok_or(Error::MatrixIsSingular)?;
+			if pivot != i {
+				tmp.swap_rows(i, pivot, &mut row_buffer);
+				out.swap_rows(i, pivot, &mut row_buffer);
+			}
+
+			// Normalize the pivot
+			let scalar = tmp[(i, i)]
+				.invert()
+				.expect("pivot is checked to be non-zero above");
+			tmp.scale_row(i, scalar);
+			out.scale_row(i, scalar);
+
+			// Clear the pivot column
+			for j in (0..i).chain(i + 1..n) {
+				let scalar = tmp[(j, i)];
+				tmp.sub_pivot_row(j, i, scalar);
+				out.sub_pivot_row(j, i, scalar);
+			}
+		}
+
+		debug_assert_eq!(tmp, Self::identity(n));
+
+		Ok(())
+	}
+
+	fn row_ref(&self, i: usize) -> &[F] {
+		assert!(i < self.m);
+		&self.elements[i * self.n..(i + 1) * self.n]
+	}
+
+	fn row_mut(&mut self, i: usize) -> &mut [F] {
+		assert!(i < self.m);
+		&mut self.elements[i * self.n..(i + 1) * self.n]
+	}
+
+	fn swap_rows(&mut self, i0: usize, i1: usize, buffer: &mut [F]) {
+		assert!(i0 < self.m);
+		assert!(i1 < self.m);
+		assert_eq!(buffer.len(), self.n);
+
+		if i0 == i1 {
+			return;
+		}
+
+		buffer.copy_from_slice(self.row_ref(i1));
+		self.elements
+			.copy_within(i0 * self.n..(i0 + 1) * self.n, i1 * self.n);
+		self.row_mut(i0).copy_from_slice(buffer);
+	}
+
+	fn scale_row(&mut self, i: usize, scalar: F) {
+		for x in self.row_mut(i) {
+			*x *= scalar;
+		}
+	}
+
+	fn sub_pivot_row(&mut self, i0: usize, i1: usize, scalar: F) {
+		assert!(i0 < self.m);
+		assert!(i1 < self.m);
+
+		for j in 0..self.n {
+			let x = self[(i1, j)];
+			self[(i0, j)] -= x * scalar;
+		}
+	}
+}
+
+impl<F: Field> Index<(usize, usize)> for Matrix<F> {
+	type Output = F;
+
+	fn index(&self, (i, j): (usize, usize)) -> &Self::Output {
+		assert!(i < self.m);
+		assert!(j < self.n);
+		&self.elements[i * self.n + j]
+	}
+}
+
+impl<F: Field> IndexMut<(usize, usize)> for Matrix<F> {
+	fn index_mut(&mut self, (i, j): (usize, usize)) -> &mut Self::Output {
+		assert!(i < self.m);
+		assert!(j < self.n);
+		&mut self.elements[i * self.n + j]
+	}
+}
+
+impl<F: Field> Add<Self> for &Matrix<F> {
+	type Output = Matrix<F>;
+
+	fn add(self, rhs: Self) -> Matrix<F> {
+		let mut out = self.clone();
+		out += rhs;
+		out
+	}
+}
+
+impl<F: Field> Sub<Self> for &Matrix<F> {
+	type Output = Matrix<F>;
+
+	fn sub(self, rhs: Self) -> Matrix<F> {
+		let mut out = self.clone();
+		out -= rhs;
+		out
+	}
+}
+
+impl<F: Field> AddAssign<&Self> for Matrix<F> {
+	fn add_assign(&mut self, rhs: &Self) {
+		assert_eq!(self.dim(), rhs.dim());
+		for (a_ij, &b_ij) in self.elements.iter_mut().zip(rhs.elements.iter()) {
+			*a_ij += b_ij;
+		}
+	}
+}
+
+impl<F: Field> SubAssign<&Self> for Matrix<F> {
+	fn sub_assign(&mut self, rhs: &Self) {
+		assert_eq!(self.dim(), rhs.dim());
+		for (a_ij, &b_ij) in self.elements.iter_mut().zip(rhs.elements.iter()) {
+			*a_ij -= b_ij;
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use binius_field::BinaryField32b;
+	use proptest::prelude::*;
+	use rand::{SeedableRng, rngs::StdRng};
+
+	use super::*;
+
+	proptest! {
+		#[test]
+		fn test_left_linearity(c_m in 0..8usize, c_n in 0..8usize, a_n in 0..8usize) {
+			type F = BinaryField32b;
+
+			let mut rng = StdRng::seed_from_u64(0);
+			let a0 = Matrix::<F>::random(c_m, a_n, &mut rng);
+			let a1 = Matrix::<F>::random(c_m, a_n, &mut rng);
+			let b = Matrix::<F>::random(a_n, c_n, &mut rng);
+			let mut c0 = Matrix::<F>::zeros(c_m, c_n);
+			let mut c1 = Matrix::<F>::zeros(c_m, c_n);
+
+			let a0p1 = &a0 + &a1;
+			let mut c0p1 = Matrix::<F>::zeros(c_m, c_n);
+
+			Matrix::mul_into(&a0, &b, &mut c0);
+			Matrix::mul_into(&a1, &b, &mut c1);
+			Matrix::mul_into(&a0p1, &b, &mut c0p1);
+
+			assert_eq!(c0p1, &c0 + &c1);
+		}
+
+		#[test]
+		fn test_right_linearity(c_m in 0..8usize, c_n in 0..8usize, a_n in 0..8usize) {
+			type F = BinaryField32b;
+
+			let mut rng = StdRng::seed_from_u64(0);
+			let a = Matrix::<F>::random(c_m, a_n, &mut rng);
+			let b0 = Matrix::<F>::random(a_n, c_n, &mut rng);
+			let b1 = Matrix::<F>::random(a_n, c_n, &mut rng);
+			let mut c0 = Matrix::<F>::zeros(c_m, c_n);
+			let mut c1 = Matrix::<F>::zeros(c_m, c_n);
+
+			let b0p1 = &b0 + &b1;
+			let mut c0p1 = Matrix::<F>::zeros(c_m, c_n);
+
+			Matrix::mul_into(&a, &b0, &mut c0);
+			Matrix::mul_into(&a, &b1, &mut c1);
+			Matrix::mul_into(&a, &b0p1, &mut c0p1);
+
+			assert_eq!(c0p1, &c0 + &c1);
+		}
+
+		#[test]
+		fn test_double_inverse(n in 0..8usize) {
+			type F = BinaryField32b;
+
+			let mut rng = StdRng::seed_from_u64(0);
+			let a = Matrix::<F>::random(n, n, &mut rng);
+			let mut a_inv = Matrix::<F>::zeros(n, n);
+			let mut a_inv_inv = Matrix::<F>::zeros(n, n);
+
+			a.inverse_into(&mut a_inv).unwrap();
+			a_inv.inverse_into(&mut a_inv_inv).unwrap();
+			assert_eq!(a_inv_inv, a);
+		}
+
+		#[test]
+		fn test_inverse(n in 0..8usize) {
+			type F = BinaryField32b;
+
+			let mut rng = StdRng::seed_from_u64(0);
+			let a = Matrix::<F>::random(n, n, &mut rng);
+			let mut a_inv = Matrix::<F>::zeros(n, n);
+			let mut prod = Matrix::<F>::zeros(n, n);
+
+			a.inverse_into(&mut a_inv).unwrap();
+
+			Matrix::mul_into(&a, &a_inv, &mut prod);
+			assert_eq!(prod, Matrix::<F>::identity(n));
+
+			Matrix::mul_into(&a_inv, &a, &mut prod);
+			assert_eq!(prod, Matrix::<F>::identity(n));
+		}
+	}
+}

--- a/crates/math/src/ntt/additive_ntt.rs
+++ b/crates/math/src/ntt/additive_ntt.rs
@@ -1,0 +1,166 @@
+// Copyright 2024-2025 Irreducible Inc.
+
+use binius_field::{BinaryField, ExtensionField, PackedExtension, PackedField};
+
+use super::error::Error;
+use crate::BinarySubspace;
+
+/// Shape of a batched NTT operation on a 3-dimensional tensor.
+///
+/// The tensor has three dimensions. Elements are indexed first along axis X (width),
+/// then axis Y (height), then axis Z (depth). In other words, the range of elements sharing Y and
+/// Z coordinates are contiguous in memory, elements sharing X and Z coordinates are strided by the
+/// tensor width, and elements sharing X and Y coordinates are strided by the width times height.
+///
+/// The tensor has power-of-two length in each dimension.
+///
+/// The NTT operation performs a parallel NTT along the _Y axis_, meaning each the operation
+/// transforms each column independently.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NTTShape {
+	/// Log length along the X axis (width). This is the interleaved batch size.
+	pub log_x: usize,
+	/// Log length along the Y axis (height). This is the size of the NTT transform.
+	pub log_y: usize,
+	/// Log length along the Z axis (depth). This is the consecutive batch size.
+	pub log_z: usize,
+}
+
+/// The binary field additive NTT.
+///
+/// A number-theoretic transform (NTT) is a linear transformation on a finite field analogous to
+/// the discrete fourier transform. The version of the additive NTT we use is originally described
+/// in [LCH14]. In [DP24] Section 3.1, the authors present the LCH additive NTT algorithm in a way
+/// that makes apparent its compatibility with the FRI proximity test. Throughout the
+/// documentation, we will refer to the notation used in [DP24].
+///
+/// The additive NTT is parameterized by a binary field $K$ and $\mathbb{F}\_2$-linear subspace. We
+/// write $\beta_0, \ldots, \beta_{\ell-1}$ for the ordered basis elements of the subspace and
+/// require $\beta_0 = 1$. The basis determines a novel polynomial basis and an evaluation domain.
+/// In the forward direction, the additive NTT transforms a vector of polynomial coefficients, with
+/// respect to the novel polynomial basis, into a vector of their evaluations over the evaluation
+/// domain. The inverse transformation interpolates polynomial values over the domain into novel
+/// polynomial basis coefficients.
+///
+/// An [`AdditiveNTT`] implementation with a maximum domain dimension of $\ell$ can be applied on
+/// a sequence of $\ell + 1$ evaluation domains of sizes $2^0, \ldots, 2^\ell$. These are the
+/// domains $S^{(\ell)}, S^{(\ell - 1)}, \ldots, S^{(0)}$ defined in [DP24] Section 4. The methods
+/// [`Self::forward_transform`] and [`Self::inverse_transform`] require a parameter
+/// `log_domain_size` that indicates which of the $S^(i)$ domains to use for the transformation's
+/// evaluation domain and novel polynomial basis. (Remember, the novel polynomial basis is itself
+/// parameterized by basis). **Counterintuitively, the field subspace $S^(i+1)$ is not necessarily
+/// a subset of $S^i$**. We choose this behavior for the [`AdditiveNTT`] trait because it
+/// facilitates compatibility with FRI when batching proximity tests for codewords of different
+/// dimensions.
+///
+/// [LCH14]: <https://arxiv.org/abs/1404.3458>
+/// [DP24]: <https://eprint.iacr.org/2024/504>
+pub trait AdditiveNTT<F: BinaryField> {
+	/// Base-2 logarithm of the maximum size of the NTT domain, $\ell$.
+	fn log_domain_size(&self) -> usize;
+
+	/// Returns the binary subspace with dimension $i$.
+	///
+	/// In [DP24], this subspace is referred to as $S^{(\ell - i)}$, where $\ell$ is the maximum
+	/// domain size of the NTT. We choose to reverse the indexing order with respect to the paper
+	/// because it is more natural in code that $i$th subspace have dimension $i$.
+	///
+	/// ## Preconditions
+	///
+	/// * `i` must be less than `self.log_domain_size()`
+	///
+	/// [DP24]: <https://eprint.iacr.org/2024/504>
+	fn subspace(&self, i: usize) -> BinarySubspace<F>;
+
+	/// Get the $j$'th basis element of the $i$'th subspace.
+	///
+	/// ## Preconditions
+	///
+	/// * `i` must be less than `self.log_domain_size()`
+	/// * `j` must be less than `i`
+	fn get_subspace_eval(&self, i: usize, j: usize) -> F {
+		self.subspace(i).basis()[j]
+	}
+
+	/// Batched forward transformation defined in [DP24], Section 2.3.
+	///
+	/// The scalars of `data`, viewed in natural order, represent a tensor of `shape` dimensions.
+	/// See [`NTTShape`] for layout details. The transform is inplace, output adheres to `shape`.
+	///
+	/// The `coset` specifies the evaluation domain as an indexed coset of the subspace. The coset
+	/// index must representable in `coset_bits` bits. The evaluation domain of the NTT is chosen
+	/// to be the subspace $S^{(i)}$ with dimension `shape.log_y + coset_bits`. Choosing the NTT
+	/// domain in this way ensures consistency of the domains when using FRI with different
+	/// codeword lengths.
+	///
+	/// The transformation accepts a `skip_rounds` parameter, which is a number of NTT layers to
+	/// skip at the beginning of the forward transform. This corresponds to parallel NTTs on
+	/// multiple adjacent subspace cosets, but beginning with messages interpreted as coefficients
+	/// in a modified novel polynomial basis. See [DP24] Remark 4.15.
+	///
+	/// [DP24]: <https://eprint.iacr.org/2024/504>
+	fn forward_transform<P: PackedField<Scalar = F>>(
+		&self,
+		data: &mut [P],
+		shape: NTTShape,
+		coset: usize,
+		coset_bits: usize,
+		skip_rounds: usize,
+	) -> Result<(), Error>;
+
+	/// Batched inverse transformation defined in [DP24], Section 2.3.
+	///
+	/// The scalars of `data`, viewed in natural order, represent a tensor of `shape` dimensions.
+	/// See [`NTTShape`] for layout details. The transform is inplace, output adheres to `shape`.
+	///
+	/// The `coset` specifies the evaluation domain as an indexed coset of the subspace. The coset
+	/// index must representable in `coset_bits` bits. The evaluation domain of the NTT is chosen
+	/// to be the subspace $S^{(i)}$ with dimension `shape.log_y + coset_bits`. Choosing the NTT
+	/// domain in this way ensures consistency of the domains when using FRI with different
+	/// codeword lengths.
+	///
+	/// The transformation accepts a `skip_rounds` parameter, which is a number of NTT layers to
+	/// skip at the end of the inverse transform. This corresponds to parallel NTTs on multiple
+	/// adjacent subspace cosets, but returning with messages interpreted as coefficients in a
+	/// modified novel polynomial basis. See [DP24] Remark 4.15.
+	///
+	/// [DP24]: <https://eprint.iacr.org/2024/504>
+	fn inverse_transform<P: PackedField<Scalar = F>>(
+		&self,
+		data: &mut [P],
+		shape: NTTShape,
+		coset: usize,
+		coset_bits: usize,
+		skip_rounds: usize,
+	) -> Result<(), Error>;
+
+	fn forward_transform_ext<PE: PackedExtension<F>>(
+		&self,
+		data: &mut [PE],
+		shape: NTTShape,
+		coset: usize,
+		coset_bits: usize,
+		skip_rounds: usize,
+	) -> Result<(), Error> {
+		let shape_ext = NTTShape {
+			log_x: shape.log_x + PE::Scalar::LOG_DEGREE,
+			..shape
+		};
+		self.forward_transform(PE::cast_bases_mut(data), shape_ext, coset, coset_bits, skip_rounds)
+	}
+
+	fn inverse_transform_ext<PE: PackedExtension<F>>(
+		&self,
+		data: &mut [PE],
+		shape: NTTShape,
+		coset: usize,
+		coset_bits: usize,
+		skip_rounds: usize,
+	) -> Result<(), Error> {
+		let shape_ext = NTTShape {
+			log_x: shape.log_x + PE::Scalar::LOG_DEGREE,
+			..shape
+		};
+		self.inverse_transform(PE::cast_bases_mut(data), shape_ext, coset, coset_bits, skip_rounds)
+	}
+}

--- a/crates/math/src/ntt/dynamic_dispatch.rs
+++ b/crates/math/src/ntt/dynamic_dispatch.rs
@@ -1,0 +1,227 @@
+// Copyright 2024-2025 Irreducible Inc.
+
+use binius_field::{BinaryField, PackedField};
+use binius_utils::rayon::get_log_max_threads;
+
+use super::{
+	additive_ntt::{AdditiveNTT, NTTShape},
+	error::Error,
+	multithreaded::MultithreadedNTT,
+	single_threaded::SingleThreadedNTT,
+	twiddle::PrecomputedTwiddleAccess,
+};
+use crate::BinarySubspace;
+
+/// How many threads to use (threads number is a power of 2).
+#[derive(Default, Debug, Clone, Copy)]
+pub enum ThreadingSettings {
+	/// Use a single thread for calculations.
+	#[default]
+	SingleThreaded,
+	/// Use the default number of threads based on the number of cores.
+	MultithreadedDefault,
+	/// Explicitly set the logarithm of number of threads.
+	ExplicitThreadsCount { log_threads: usize },
+}
+
+impl ThreadingSettings {
+	/// Get the log2 of the number of threads to use.
+	pub fn log_threads_count(&self) -> usize {
+		match self {
+			Self::SingleThreaded => 0,
+			Self::MultithreadedDefault => get_log_max_threads(),
+			Self::ExplicitThreadsCount { log_threads } => *log_threads,
+		}
+	}
+
+	/// Check if settings imply multithreading.
+	pub const fn is_multithreaded(&self) -> bool {
+		match self {
+			Self::SingleThreaded => false,
+			Self::MultithreadedDefault => true,
+			Self::ExplicitThreadsCount { log_threads } => *log_threads > 0,
+		}
+	}
+}
+
+#[derive(Default)]
+pub struct NTTOptions {
+	pub precompute_twiddles: bool,
+	pub thread_settings: ThreadingSettings,
+}
+
+/// An enum that can be used to switch between different NTT implementations without passing
+/// AdditiveNTT as a type parameter.
+#[derive(Debug)]
+pub enum DynamicDispatchNTT<F: BinaryField> {
+	SingleThreaded(SingleThreadedNTT<F>),
+	SingleThreadedPrecompute(SingleThreadedNTT<F, PrecomputedTwiddleAccess<F>>),
+	MultiThreaded(MultithreadedNTT<F>),
+	MultiThreadedPrecompute(MultithreadedNTT<F, PrecomputedTwiddleAccess<F>>),
+}
+
+impl<F: BinaryField> DynamicDispatchNTT<F> {
+	/// Create a new AdditiveNTT based on the given settings.
+	pub fn new(log_domain_size: usize, options: &NTTOptions) -> Result<Self, Error> {
+		let log_threads = options.thread_settings.log_threads_count();
+		let result = match (options.precompute_twiddles, log_threads) {
+			(false, 0) => Self::SingleThreaded(SingleThreadedNTT::new(log_domain_size)?),
+			(true, 0) => Self::SingleThreadedPrecompute(
+				SingleThreadedNTT::new(log_domain_size)?.precompute_twiddles(),
+			),
+			(false, _) => Self::MultiThreaded(
+				SingleThreadedNTT::new(log_domain_size)?
+					.multithreaded_with_max_threads(log_threads),
+			),
+			(true, _) => Self::MultiThreadedPrecompute(
+				SingleThreadedNTT::new(log_domain_size)?
+					.precompute_twiddles()
+					.multithreaded_with_max_threads(log_threads),
+			),
+		};
+
+		Ok(result)
+	}
+}
+
+impl<F: BinaryField> AdditiveNTT<F> for DynamicDispatchNTT<F> {
+	fn log_domain_size(&self) -> usize {
+		match self {
+			Self::SingleThreaded(ntt) => ntt.log_domain_size(),
+			Self::SingleThreadedPrecompute(ntt) => ntt.log_domain_size(),
+			Self::MultiThreaded(ntt) => ntt.log_domain_size(),
+			Self::MultiThreadedPrecompute(ntt) => ntt.log_domain_size(),
+		}
+	}
+
+	fn subspace(&self, i: usize) -> BinarySubspace<F> {
+		match self {
+			Self::SingleThreaded(ntt) => ntt.subspace(i),
+			Self::SingleThreadedPrecompute(ntt) => ntt.subspace(i),
+			Self::MultiThreaded(ntt) => ntt.subspace(i),
+			Self::MultiThreadedPrecompute(ntt) => ntt.subspace(i),
+		}
+	}
+
+	fn get_subspace_eval(&self, i: usize, j: usize) -> F {
+		match self {
+			Self::SingleThreaded(ntt) => ntt.get_subspace_eval(i, j),
+			Self::SingleThreadedPrecompute(ntt) => ntt.get_subspace_eval(i, j),
+			Self::MultiThreaded(ntt) => ntt.get_subspace_eval(i, j),
+			Self::MultiThreadedPrecompute(ntt) => ntt.get_subspace_eval(i, j),
+		}
+	}
+
+	fn forward_transform<P: PackedField<Scalar = F>>(
+		&self,
+		data: &mut [P],
+		shape: NTTShape,
+		coset: usize,
+		coset_bits: usize,
+		skip_rounds: usize,
+	) -> Result<(), Error> {
+		match self {
+			Self::SingleThreaded(ntt) => {
+				ntt.forward_transform(data, shape, coset, coset_bits, skip_rounds)
+			}
+			Self::SingleThreadedPrecompute(ntt) => {
+				ntt.forward_transform(data, shape, coset, coset_bits, skip_rounds)
+			}
+			Self::MultiThreaded(ntt) => {
+				ntt.forward_transform(data, shape, coset, coset_bits, skip_rounds)
+			}
+			Self::MultiThreadedPrecompute(ntt) => {
+				ntt.forward_transform(data, shape, coset, coset_bits, skip_rounds)
+			}
+		}
+	}
+
+	fn inverse_transform<P: PackedField<Scalar = F>>(
+		&self,
+		data: &mut [P],
+		shape: NTTShape,
+		coset: usize,
+		coset_bits: usize,
+		skip_rounds: usize,
+	) -> Result<(), Error> {
+		match self {
+			Self::SingleThreaded(ntt) => {
+				ntt.inverse_transform(data, shape, coset, coset_bits, skip_rounds)
+			}
+			Self::SingleThreadedPrecompute(ntt) => {
+				ntt.inverse_transform(data, shape, coset, coset_bits, skip_rounds)
+			}
+			Self::MultiThreaded(ntt) => {
+				ntt.inverse_transform(data, shape, coset, coset_bits, skip_rounds)
+			}
+			Self::MultiThreadedPrecompute(ntt) => {
+				ntt.inverse_transform(data, shape, coset, coset_bits, skip_rounds)
+			}
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use binius_field::BinaryField8b;
+
+	use super::*;
+
+	#[test]
+	fn test_creation() {
+		fn make_ntt(options: &NTTOptions) -> DynamicDispatchNTT<BinaryField8b> {
+			DynamicDispatchNTT::<BinaryField8b>::new(6, options).unwrap()
+		}
+
+		let ntt = make_ntt(&NTTOptions {
+			precompute_twiddles: false,
+			thread_settings: ThreadingSettings::SingleThreaded,
+		});
+		assert!(matches!(ntt, DynamicDispatchNTT::SingleThreaded(_)));
+
+		let ntt = make_ntt(&NTTOptions {
+			precompute_twiddles: true,
+			thread_settings: ThreadingSettings::SingleThreaded,
+		});
+		assert!(matches!(ntt, DynamicDispatchNTT::SingleThreadedPrecompute(_)));
+
+		let multithreaded = get_log_max_threads() > 0;
+		let ntt = make_ntt(&NTTOptions {
+			precompute_twiddles: false,
+			thread_settings: ThreadingSettings::MultithreadedDefault,
+		});
+		if multithreaded {
+			assert!(matches!(ntt, DynamicDispatchNTT::MultiThreaded(_)));
+		} else {
+			assert!(matches!(ntt, DynamicDispatchNTT::SingleThreaded(_)));
+		}
+
+		let ntt = make_ntt(&NTTOptions {
+			precompute_twiddles: true,
+			thread_settings: ThreadingSettings::MultithreadedDefault,
+		});
+		if multithreaded {
+			assert!(matches!(ntt, DynamicDispatchNTT::MultiThreadedPrecompute(_)));
+		} else {
+			assert!(matches!(ntt, DynamicDispatchNTT::SingleThreadedPrecompute(_)));
+		}
+
+		let ntt = make_ntt(&NTTOptions {
+			precompute_twiddles: false,
+			thread_settings: ThreadingSettings::ExplicitThreadsCount { log_threads: 2 },
+		});
+		assert!(matches!(ntt, DynamicDispatchNTT::MultiThreaded(_)));
+
+		let ntt = make_ntt(&NTTOptions {
+			precompute_twiddles: true,
+			thread_settings: ThreadingSettings::ExplicitThreadsCount { log_threads: 0 },
+		});
+		assert!(matches!(ntt, DynamicDispatchNTT::SingleThreadedPrecompute(_)));
+
+		let ntt = make_ntt(&NTTOptions {
+			precompute_twiddles: false,
+			thread_settings: ThreadingSettings::ExplicitThreadsCount { log_threads: 0 },
+		});
+		assert!(matches!(ntt, DynamicDispatchNTT::SingleThreaded(_)));
+	}
+}

--- a/crates/math/src/ntt/error.rs
+++ b/crates/math/src/ntt/error.rs
@@ -1,0 +1,29 @@
+// Copyright 2024-2025 Irreducible Inc.
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+	#[error("codeword buffer must be at least 2**{log_code_len} elements")]
+	BufferTooSmall { log_code_len: usize },
+	#[error("field order must be at least 2**{log_domain_size}")]
+	FieldTooSmall { log_domain_size: usize },
+	#[error("domain size is less than 2**{log_required_domain_size}")]
+	DomainTooSmall { log_required_domain_size: usize },
+	#[error("evaluation subspace must include the 1 element")]
+	DomainMustIncludeOne,
+	#[error("the input length must be a power of two")]
+	PowerOfTwoLengthRequired,
+	#[error("the field extension degree must be a power of two")]
+	PowerOfTwoExtensionDegreeRequired,
+	#[error("the stride cannot be greater than the packed width")]
+	StrideGreaterThanPackedWidth,
+	#[error("the batch size is greater than the number of elements")]
+	BatchTooLarge,
+	#[error("the skip_rounds parameter exceeds the total number of NTT rounds")]
+	SkipRoundsTooLarge,
+	#[error("coset index must be less than 2**{coset_bits}, got {coset}")]
+	CosetIndexOutOfBounds { coset: usize, coset_bits: usize },
+	#[error("odd interpolation length mismatch, expected to be exactly {expected_len}")]
+	OddInterpolateIncorrectLength { expected_len: usize },
+	#[error("math error: {0}")]
+	MathError(#[from] crate::Error),
+}

--- a/crates/math/src/ntt/fri.rs
+++ b/crates/math/src/ntt/fri.rs
@@ -1,0 +1,245 @@
+// Copyright 2024-2025 Irreducible Inc.
+
+use std::iter;
+
+use binius_field::{BinaryField, ExtensionField, PackedField};
+use crate::{MultilinearQuery, extrapolate_line_scalar};
+use binius_maybe_rayon::prelude::*;
+use bytemuck::zeroed_vec;
+use tracing::instrument;
+
+use crate::AdditiveNTT;
+
+/// FRI-fold the interleaved codeword using the given challenges.
+///
+/// ## Arguments
+///
+/// * `math` - the NTT instance, used to look up the twiddle values.
+/// * `codeword` - an interleaved codeword.
+/// * `challenges` - the folding challenges. The length must be at least `log_batch_size`.
+/// * `log_len` - the binary logarithm of the code length.
+/// * `log_batch_size` - the binary logarithm of the interleaved code batch size.
+///
+/// See [DP24], Def. 3.6 and Lemma 3.9 for more details.
+///
+/// [DP24]: <https://eprint.iacr.org/2024/504>
+#[instrument(skip_all, level = "debug")]
+pub fn fold_interleaved_allocated<F, FS, NTT, P>(
+	ntt: &NTT,
+	codeword: &[P],
+	challenges: &[F],
+	log_len: usize,
+	log_batch_size: usize,
+	out: &mut [F],
+) where
+	F: BinaryField + ExtensionField<FS>,
+	FS: BinaryField,
+	NTT: AdditiveNTT<FS> + Sync,
+	P: PackedField<Scalar = F>,
+{
+	assert_eq!(codeword.len(), 1 << (log_len + log_batch_size).saturating_sub(P::LOG_WIDTH));
+	assert!(challenges.len() >= log_batch_size);
+	assert_eq!(out.len(), 1 << (log_len - (challenges.len() - log_batch_size)));
+
+	let (interleave_challenges, fold_challenges) = challenges.split_at(log_batch_size);
+	let tensor = MultilinearQuery::expand(interleave_challenges);
+
+	// For each chunk of size `2^chunk_size` in the codeword, fold it with the folding challenges
+	let fold_chunk_size = 1 << fold_challenges.len();
+	let chunk_size = 1 << challenges.len().saturating_sub(P::LOG_WIDTH);
+	codeword
+		.par_chunks(chunk_size)
+		.enumerate()
+		.zip(out)
+		.for_each_init(
+			|| vec![F::default(); fold_chunk_size],
+			|scratch_buffer, ((i, chunk), out)| {
+				*out = fold_interleaved_chunk(
+					ntt,
+					log_len,
+					log_batch_size,
+					i,
+					chunk,
+					tensor.expansion(),
+					fold_challenges,
+					scratch_buffer,
+				)
+			},
+		)
+}
+
+pub fn fold_interleaved<F, FS, NTT, P>(
+	ntt: &NTT,
+	codeword: &[P],
+	challenges: &[F],
+	log_len: usize,
+	log_batch_size: usize,
+) -> Vec<F>
+where
+	F: BinaryField + ExtensionField<FS>,
+	FS: BinaryField,
+	NTT: AdditiveNTT<FS> + Sync,
+	P: PackedField<Scalar = F>,
+{
+	let mut result =
+		zeroed_vec(1 << log_len.saturating_sub(challenges.len().saturating_sub(log_batch_size)));
+	fold_interleaved_allocated(ntt, codeword, challenges, log_len, log_batch_size, &mut result);
+	result
+}
+
+/// Calculate fold of `values` at `index` with `r` random coefficient.
+///
+/// See [DP24], Def. 3.6.
+///
+/// [DP24]: <https://eprint.iacr.org/2024/504>
+#[inline]
+fn fold_pair<F, FS, NTT>(ntt: &NTT, round: usize, index: usize, values: (F, F), r: F) -> F
+where
+	F: BinaryField + ExtensionField<FS>,
+	FS: BinaryField,
+	NTT: AdditiveNTT<FS>,
+{
+	// Perform inverse additive NTT butterfly
+	let t = ntt.get_subspace_eval(round, index);
+	let (mut u, mut v) = values;
+	v += u;
+	u += v * t;
+	extrapolate_line_scalar(u, v, r)
+}
+
+/// Calculate FRI fold of `values` at a `chunk_index` with random folding challenges.
+///
+/// Folds a coset of a Reed–Solomon codeword into a single value using the FRI folding algorithm.
+/// The coset has size $2^n$, where $n$ is the number of challenges.
+///
+/// See [DP24], Def. 3.6 and Lemma 3.9 for more details.
+///
+/// NB: This method is on a hot path and does not perform any allocations or
+/// precondition checks.
+///
+/// ## Arguments
+///
+/// * `math` - the NTT instance, used to look up the twiddle values.
+/// * `log_len` - the binary logarithm of the code length.
+/// * `chunk_index` - the index of the chunk, of size $2^n$, in the full codeword.
+/// * `values` - mutable slice of values to fold, modified in place.
+/// * `challenges` - the sequence of folding challenges, with length $n$.
+///
+/// ## Pre-conditions
+///
+/// - `challenges.len() <= log_len`.
+/// - `log_len <= math.log_domain_size()`, so that the NTT domain is large enough.
+/// - `values.len() == 1 << challenges.len()`.
+///
+/// [DP24]: <https://eprint.iacr.org/2024/504>
+#[inline]
+pub fn fold_chunk<F, FS, NTT>(
+	ntt: &NTT,
+	mut log_len: usize,
+	chunk_index: usize,
+	values: &mut [F],
+	challenges: &[F],
+) -> F
+where
+	F: BinaryField + ExtensionField<FS>,
+	FS: BinaryField,
+	NTT: AdditiveNTT<FS>,
+{
+	let mut log_size = challenges.len();
+
+	// Preconditions
+	debug_assert!(log_size <= log_len);
+	debug_assert!(log_len <= ntt.log_domain_size());
+	debug_assert_eq!(values.len(), 1 << log_size);
+
+	// FRI-fold the values in place.
+	for &challenge in challenges {
+		// Fold the (2i) and (2i+1)th cells of the scratch buffer in-place into the i-th cell
+		for index_offset in 0..1 << (log_size - 1) {
+			let pair = (values[index_offset << 1], values[(index_offset << 1) | 1]);
+			values[index_offset] = fold_pair(
+				ntt,
+				log_len,
+				(chunk_index << (log_size - 1)) | index_offset,
+				pair,
+				challenge,
+			)
+		}
+
+		log_len -= 1;
+		log_size -= 1;
+	}
+
+	values[0]
+}
+
+/// Calculate the fold of an interleaved chunk of values with random folding challenges.
+///
+/// The elements in the `values` vector are the interleaved cosets of a batch of codewords at the
+/// index `coset_index`. That is, the layout of elements in the values slice is
+///
+/// ```text
+/// [a0, b0, c0, d0, a1, b1, c1, d1, ...]
+/// ```
+///
+/// where `a0, a1, ...` form a coset of a codeword `a`, `b0, b1, ...` form a coset of a codeword
+/// `b`, and similarly for `c` and `d`.
+///
+/// The fold operation first folds the adjacent symbols in the slice using regular multilinear
+/// tensor folding for the symbols from different cosets and FRI folding for the cosets themselves
+/// using the remaining challenges.
+//
+/// NB: This method is on a hot path and does not perform any allocations or
+/// precondition checks.
+///
+/// See [DP24], Def. 3.6 and Lemma 3.9 for more details.
+///
+/// [DP24]: <https://eprint.iacr.org/2024/504>
+#[inline]
+#[allow(clippy::too_many_arguments)]
+pub fn fold_interleaved_chunk<F, FS, P, NTT>(
+	ntt: &NTT,
+	log_len: usize,
+	log_batch_size: usize,
+	chunk_index: usize,
+	values: &[P],
+	tensor: &[P],
+	fold_challenges: &[F],
+	scratch_buffer: &mut [F],
+) -> F
+where
+	F: BinaryField + ExtensionField<FS>,
+	FS: BinaryField,
+	NTT: AdditiveNTT<FS>,
+	P: PackedField<Scalar = F>,
+{
+	// Preconditions
+	debug_assert!(fold_challenges.len() <= log_len);
+	debug_assert!(log_len <= ntt.log_domain_size());
+	debug_assert_eq!(
+		values.len(),
+		1 << (fold_challenges.len() + log_batch_size).saturating_sub(P::LOG_WIDTH)
+	);
+	debug_assert_eq!(tensor.len(), 1 << log_batch_size.saturating_sub(P::LOG_WIDTH));
+	debug_assert!(scratch_buffer.len() >= 1 << fold_challenges.len());
+
+	let scratch_buffer = &mut scratch_buffer[..1 << fold_challenges.len()];
+
+	if log_batch_size == 0 {
+		iter::zip(&mut *scratch_buffer, P::iter_slice(values)).for_each(|(dst, val)| *dst = val);
+	} else {
+		let folded_values = values
+			.chunks(1 << (log_batch_size - P::LOG_WIDTH))
+			.map(|chunk| {
+				iter::zip(chunk, tensor)
+					.map(|(&a_i, &b_i)| a_i * b_i)
+					.sum::<P>()
+					.into_iter()
+					.take(1 << log_batch_size)
+					.sum()
+			});
+		iter::zip(&mut *scratch_buffer, folded_values).for_each(|(dst, val)| *dst = val);
+	};
+
+	fold_chunk(ntt, log_len, chunk_index, scratch_buffer, fold_challenges)
+}

--- a/crates/math/src/ntt/mod.rs
+++ b/crates/math/src/ntt/mod.rs
@@ -1,0 +1,26 @@
+// Copyright 2024-2025 Irreducible Inc.
+
+//! Efficient implementations of the binary field additive NTT.
+//!
+//! See [LCH14] and [DP24] Section 2.3 for mathematical background.
+//!
+//! [LCH14]: <https://arxiv.org/abs/1404.3458>
+//! [DP24]: <https://eprint.iacr.org/2024/504>
+
+mod additive_ntt;
+mod dynamic_dispatch;
+mod error;
+//pub mod fri;
+mod multithreaded;
+mod odd_interpolate;
+mod single_threaded;
+#[cfg(test)]
+mod tests;
+pub mod twiddle;
+
+pub use additive_ntt::{AdditiveNTT, NTTShape};
+pub use dynamic_dispatch::{DynamicDispatchNTT, NTTOptions, ThreadingSettings};
+pub use error::Error;
+pub use multithreaded::MultithreadedNTT;
+pub use odd_interpolate::OddInterpolate;
+pub use single_threaded::SingleThreadedNTT;

--- a/crates/math/src/ntt/multithreaded.rs
+++ b/crates/math/src/ntt/multithreaded.rs
@@ -1,0 +1,355 @@
+// Copyright 2024-2025 Irreducible Inc.
+
+use binius_field::{BinaryField, PackedField};
+use binius_maybe_rayon::prelude::*;
+use binius_utils::{rayon::get_log_max_threads, strided_array::StridedArray2DViewMut};
+
+use super::{
+	additive_ntt::{AdditiveNTT, NTTShape},
+	error::Error,
+	single_threaded::{SingleThreadedNTT, check_batch_transform_inputs_and_params},
+	twiddle::{OnTheFlyTwiddleAccess, TwiddleAccess},
+};
+use crate::BinarySubspace;
+
+/// Implementation of `AdditiveNTT` that performs the computation multithreaded.
+#[derive(Debug)]
+pub struct MultithreadedNTT<F: BinaryField, TA: TwiddleAccess<F> = OnTheFlyTwiddleAccess<F, Vec<F>>>
+{
+	single_threaded: SingleThreadedNTT<F, TA>,
+	log_max_threads: usize,
+}
+
+impl<F: BinaryField, TA: TwiddleAccess<F> + Sync> SingleThreadedNTT<F, TA> {
+	/// Returns multithreaded NTT implementation which uses default number of threads.
+	pub fn multithreaded(self) -> MultithreadedNTT<F, TA> {
+		let log_max_threads = get_log_max_threads();
+		self.multithreaded_with_max_threads(log_max_threads as _)
+	}
+
+	/// Returns multithreaded NTT implementation which uses `1 << log_max_threads` threads.
+	pub const fn multithreaded_with_max_threads(
+		self,
+		log_max_threads: usize,
+	) -> MultithreadedNTT<F, TA> {
+		MultithreadedNTT {
+			single_threaded: self,
+			log_max_threads,
+		}
+	}
+}
+
+impl<F, TA> AdditiveNTT<F> for MultithreadedNTT<F, TA>
+where
+	F: BinaryField,
+	TA: TwiddleAccess<F> + Sync,
+{
+	fn log_domain_size(&self) -> usize {
+		self.single_threaded.log_domain_size()
+	}
+
+	fn subspace(&self, i: usize) -> BinarySubspace<F> {
+		self.single_threaded.subspace(i)
+	}
+
+	fn get_subspace_eval(&self, i: usize, j: usize) -> F {
+		self.single_threaded.get_subspace_eval(i, j)
+	}
+
+	fn forward_transform<P: PackedField<Scalar = F>>(
+		&self,
+		data: &mut [P],
+		shape: NTTShape,
+		coset: usize,
+		coset_bits: usize,
+		skip_rounds: usize,
+	) -> Result<(), Error> {
+		forward_transform(
+			&self.single_threaded,
+			data,
+			shape,
+			coset,
+			coset_bits,
+			skip_rounds,
+			self.log_max_threads,
+		)
+	}
+
+	fn inverse_transform<P: PackedField<Scalar = F>>(
+		&self,
+		data: &mut [P],
+		shape: NTTShape,
+		coset: usize,
+		coset_bits: usize,
+		skip_rounds: usize,
+	) -> Result<(), Error> {
+		inverse_transform(
+			&self.single_threaded,
+			data,
+			shape,
+			coset,
+			coset_bits,
+			skip_rounds,
+			self.log_max_threads,
+		)
+	}
+}
+
+#[allow(clippy::too_many_arguments)]
+fn forward_transform<F, P, TA>(
+	subntt: &SingleThreadedNTT<F, TA>,
+	data: &mut [P],
+	shape: NTTShape,
+	coset: usize,
+	coset_bits: usize,
+	skip_rounds: usize,
+	log_max_threads: usize,
+) -> Result<(), Error>
+where
+	F: BinaryField,
+	P: PackedField<Scalar = F>,
+	TA: TwiddleAccess<F> + Sync,
+{
+	check_batch_transform_inputs_and_params(
+		subntt.log_domain_size(),
+		data,
+		shape,
+		coset,
+		coset_bits,
+		skip_rounds,
+	)?;
+
+	match data.len() {
+		0 => return Ok(()),
+		1 => {
+			return match P::WIDTH {
+				1 => Ok(()),
+				_ => subntt.forward_transform(data, shape, coset, coset_bits, skip_rounds),
+			};
+		}
+		_ => {}
+	};
+
+	let NTTShape {
+		log_x,
+		log_y,
+		log_z,
+	} = shape;
+
+	let log_w = P::LOG_WIDTH;
+
+	// Determine the optimal log_height and log_width, measured in packed field elements. log_width
+	// must be at least 1, so that the row-wise NTTs have pairs of butterfly blocks to work with.
+	// Furthermore, we want the number of scalars in the width to be at least log_x, so that each
+	// row-wise NTT operates on full batches. Subject to the minimum width requirement, we want to
+	// set the height to the lowest value that takes advantage of all available threads.
+	let min_log_width_scalars = (log_w + 1).max(log_x);
+
+	// The subtraction must not underflow because data is checked to have at least 2 packed
+	// elements at the top of the function.
+	let log_height = (log_x + log_y + log_z - min_log_width_scalars).min(log_max_threads);
+	let log_width = log_x + log_y + log_z - (log_w + log_height);
+
+	// The NTT algorithm shapes the tensor into a 2D matrix and runs two phases:
+	//
+	// 1. The first phase performs strided column-wise NTTs.
+	// 2. The second phase performs the row-wise NTTs.
+
+	// par_rounds is the number of phase 1 strided rounds.
+	let par_rounds = log_height.saturating_sub(log_z);
+
+	// Perform the column-wise NTTs in parallel over vertical strides of the matrix.
+	{
+		let matrix = StridedArray2DViewMut::without_stride(data, 1 << log_height, 1 << log_width)
+			.expect("dimensions are correct");
+
+		let log_strides = log_max_threads.min(log_width);
+		let log_stride_len = log_width - log_strides;
+
+		let log_domain_size = subntt.log_domain_size();
+		let s_evals = &subntt.twiddles()[log_domain_size - (par_rounds + coset_bits)..];
+
+		matrix
+			.into_par_strides(1 << log_stride_len)
+			.for_each(|mut stride| {
+				// i indexes the layer of the NTT network, also the binary subspace.
+				for i in (0..par_rounds.saturating_sub(skip_rounds)).rev() {
+					let s_evals_par_i = &s_evals[i];
+					let coset_offset = coset << (par_rounds - 1 - i);
+
+					// j indexes the outer Z tensor axis.
+					for j in 0..1 << log_z {
+						// k indexes the block within the layer. Each block performs butterfly
+						// operations with the same twiddle factor.
+						for k in 0..1 << (par_rounds - 1 - i) {
+							let twiddle = P::broadcast(s_evals_par_i.get(coset_offset | k));
+							// l indexes parallel stride columns
+							for l in 0..1 << i {
+								for m in 0..1 << log_stride_len {
+									let idx0 = j << par_rounds | k << (i + 1) | l;
+									let idx1 = idx0 | 1 << i;
+
+									let mut u = stride[(idx0, m)];
+									let mut v = stride[(idx1, m)];
+									u += v * twiddle;
+									v += u;
+									stride[(idx0, m)] = u;
+									stride[(idx1, m)] = v;
+								}
+							}
+						}
+					}
+				}
+			});
+	}
+
+	let log_row_z = log_z.saturating_sub(log_height);
+	let single_thread_log_y = log_width + log_w - log_x - log_row_z;
+
+	data.par_chunks_mut(1 << (log_width + par_rounds))
+		.flat_map(|large_chunk| large_chunk.par_chunks_mut(1 << log_width).enumerate())
+		.try_for_each(|(inner_coset, chunk)| {
+			subntt.forward_transform(
+				chunk,
+				NTTShape {
+					log_x,
+					log_y: single_thread_log_y,
+					log_z: log_row_z,
+				},
+				coset << par_rounds | inner_coset,
+				coset_bits + par_rounds,
+				skip_rounds.saturating_sub(par_rounds),
+			)
+		})?;
+
+	Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn inverse_transform<F, P, TA>(
+	subntt: &SingleThreadedNTT<F, TA>,
+	data: &mut [P],
+	shape: NTTShape,
+	coset: usize,
+	coset_bits: usize,
+	skip_rounds: usize,
+	log_max_threads: usize,
+) -> Result<(), Error>
+where
+	F: BinaryField,
+	P: PackedField<Scalar = F>,
+	TA: TwiddleAccess<F> + Sync,
+{
+	check_batch_transform_inputs_and_params(
+		subntt.log_domain_size(),
+		data,
+		shape,
+		coset,
+		coset_bits,
+		skip_rounds,
+	)?;
+
+	match data.len() {
+		0 => return Ok(()),
+		1 => {
+			return match P::WIDTH {
+				1 => Ok(()),
+				_ => subntt.inverse_transform(data, shape, coset, coset_bits, skip_rounds),
+			};
+		}
+		_ => {}
+	};
+
+	let NTTShape {
+		log_x,
+		log_y,
+		log_z,
+	} = shape;
+
+	let log_w = P::LOG_WIDTH;
+
+	// Determine the optimal log_height and log_width, measured in packed field elements. log_width
+	// must be at least 1, so that the row-wise NTTs have pairs of butterfly blocks to work with.
+	// Furthermore, we want the number of scalars in the width to be at least log_x, so that each
+	// row-wise NTT operates on full batches. Subject to the minimum width requirement, we want to
+	// set the height to the lowest value that takes advantage of all available threads.
+	let min_log_width_scalars = (log_w + 1).max(log_x);
+
+	// The subtraction must not underflow because data is checked to have at least 2 packed
+	// elements at the top of the function.
+	let log_height = (log_x + log_y + log_z - min_log_width_scalars).min(log_max_threads);
+	let log_width = log_x + log_y + log_z - (log_w + log_height);
+
+	// The iNTT algorithm shapes the tensor into a 2D matrix and runs two phases:
+	//
+	// 1. The first phase performs the row-wise iNTTs.
+	// 2. The second phase performs strided column-wise iNTTs.
+
+	// par_rounds is the number of phase 2 strided rounds.
+	let par_rounds = log_height.saturating_sub(log_z);
+
+	let log_row_z = log_z.saturating_sub(log_height);
+	let single_thread_log_y = log_width + log_w - log_x - log_row_z;
+
+	data.par_chunks_mut(1 << (log_width + par_rounds))
+		.flat_map(|large_chunk| large_chunk.par_chunks_mut(1 << log_width).enumerate())
+		.try_for_each(|(inner_coset, chunk)| {
+			subntt.inverse_transform(
+				chunk,
+				NTTShape {
+					log_x,
+					log_y: single_thread_log_y,
+					log_z: log_row_z,
+				},
+				coset << par_rounds | inner_coset,
+				coset_bits + par_rounds,
+				skip_rounds.saturating_sub(par_rounds),
+			)
+		})?;
+
+	// Perform the column-wise NTTs in parallel over vertical strides of the matrix.
+	let matrix = StridedArray2DViewMut::without_stride(data, 1 << log_height, 1 << log_width)
+		.expect("dimensions are correct");
+
+	let log_strides = log_max_threads.min(log_width);
+	let log_stride_len = log_width - log_strides;
+
+	let log_domain_size = subntt.log_domain_size();
+	let s_evals = &subntt.twiddles()[log_domain_size - (par_rounds + coset_bits)..];
+
+	matrix
+		.into_par_strides(1 << log_stride_len)
+		.for_each(|mut stride| {
+			// i indexes the layer of the NTT network, also the binary subspace.
+			#[allow(clippy::needless_range_loop)]
+			for i in 0..par_rounds.saturating_sub(skip_rounds) {
+				let s_evals_par_i = &s_evals[i];
+				let coset_offset = coset << (par_rounds - 1 - i);
+
+				// j indexes the outer Z tensor axis.
+				for j in 0..1 << log_z {
+					// k indexes the block within the layer. Each block performs butterfly
+					// operations with the same twiddle factor.
+					for k in 0..1 << (par_rounds - 1 - i) {
+						let twiddle = P::broadcast(s_evals_par_i.get(coset_offset | k));
+						// l indexes parallel stride columns
+						for l in 0..1 << i {
+							for m in 0..1 << log_stride_len {
+								let idx0 = j << par_rounds | k << (i + 1) | l;
+								let idx1 = idx0 | 1 << i;
+
+								let mut u = stride[(idx0, m)];
+								let mut v = stride[(idx1, m)];
+								v += u;
+								u += v * twiddle;
+								stride[(idx0, m)] = u;
+								stride[(idx1, m)] = v;
+							}
+						}
+					}
+				}
+			}
+		});
+
+	Ok(())
+}

--- a/crates/math/src/ntt/odd_interpolate.rs
+++ b/crates/math/src/ntt/odd_interpolate.rs
@@ -1,0 +1,201 @@
+// Copyright 2024-2025 Irreducible Inc.
+
+use binius_field::BinaryField;
+use binius_utils::{bail, checked_arithmetics::log2_ceil_usize};
+
+use super::{
+	additive_ntt::{AdditiveNTT, NTTShape},
+	error::Error,
+};
+use crate::Matrix;
+
+/// A struct that can interpolate polynomials over odd NTT domains.
+///
+/// An _odd NTT domain_ is an interpolation domain that is the union of multiple cosets of an
+/// additive subspace. The set of the domain is $d 2^{\ell}$. We generally care about the case when
+/// $d$ is an odd integer, otherwise $\ell$ could be incremented, though the struct handles even
+/// $d$ values as well (even though it's suboptimal).
+///
+/// The complexity of the interpolation algorithm is $O(d^2 2^{\ell} + \ell 2^{\ell})$.
+#[derive(Debug)]
+pub struct OddInterpolate<'a, F: BinaryField, NTT: AdditiveNTT<F>> {
+	vandermonde_inverse: Matrix<F>,
+	ell: usize,
+	coset_bits: usize,
+	ntt: &'a NTT,
+}
+
+impl<'a, F: BinaryField, NTT: AdditiveNTT<F>> OddInterpolate<'a, F, NTT> {
+	/// Create a new odd interpolator into novel polynomial basis for domains of size $d \times
+	/// 2^{\ell}$. Takes a reference to NTT twiddle factors to seed the "Vandermonde" matrix and
+	/// compute its inverse. Time complexity is $\mathcal{O}(d^3).$
+	pub fn new(ntt: &'a NTT, d: usize, ell: usize, coset_bits: usize) -> Result<Self, Error> {
+		if d > (1 << coset_bits) {
+			bail!(Error::CosetIndexOutOfBounds {
+				coset: d - 1,
+				coset_bits
+			});
+		}
+
+		let log_required_domain_size = coset_bits + ell;
+		if ntt.log_domain_size() < log_required_domain_size {
+			bail!(Error::DomainTooSmall {
+				log_required_domain_size
+			});
+		}
+
+		let vandermonde = novel_vandermonde(ntt, d, coset_bits)?;
+
+		let mut vandermonde_inverse = Matrix::zeros(d, d);
+		vandermonde.inverse_into(&mut vandermonde_inverse)?;
+
+		Ok(Self {
+			ntt,
+			vandermonde_inverse,
+			ell,
+			coset_bits,
+		})
+	}
+
+	/// Let $L/\mathbb F_2$ be a binary field, and fix an $\mathbb F_2$-basis $1=:\beta_0,\ldots,
+	/// \beta_{r-1}$ as usual. Let $d\geq 1$ be an odd integer and let $\ell\geq 0$ be an integer.
+	/// Let $[a_0,\ldots, a_{d\times 2^{\ell} - 1}]$ be a list of elements of $L$. There is a
+	/// unique univariate polynomial $P(X)\in L\[X\]$ of degree less than $d\times 2^{\ell}$ such
+	/// that the *evaluations* of $P$ on the "first" $d\times 2^{\ell}$ elements of $L$ (in
+	/// little-Endian binary counting order with respect to the basis $\beta_0,\ldots, \beta_{r}$)
+	/// are precisely $a_0,\ldots, a_{d\times 2^{\ell} - 1}$.
+	///
+	/// We efficiently compute the coefficients of $P(X)$ with respect to the Novel Polynomial Basis
+	/// (itself taken with respect to the given ordered list $\beta_0,\ldots, \beta_{r-1}$).
+	///
+	/// Time complexity is $\mathcal{O}(d^2\times 2^{\ell} + \ell 2^{\ell})$, thus this routine is
+	/// intended to be used for small values of $d$.
+	pub fn inverse_transform(&self, data: &mut [F]) -> Result<(), Error> {
+		// TODO: Generalize `data` to packed fields
+		let d = self.vandermonde_inverse.m();
+		let ell = self.ell;
+
+		if data.len() != d << ell {
+			bail!(Error::OddInterpolateIncorrectLength {
+				expected_len: d << ell
+			});
+		}
+
+		let shape = NTTShape {
+			log_y: ell,
+			..Default::default()
+		};
+		for (i, chunk) in data.chunks_exact_mut(1 << ell).enumerate() {
+			self.ntt
+				.inverse_transform(chunk, shape, i, self.coset_bits, 0)?;
+		}
+
+		// Given M and a vector v, do the "strided product" M v. In more detail: we assume matrix is
+		// $d\times d$, and vector is $d\times 2^{\ell}$. For each $i$ in $0,\ldots, 2^{\ell-1}$,
+		// let $v_i$ be the subvect given by those entries whose index is congruent to $i$ mod
+		// $2^{\ell}$. Then this computes $M v_i$, and finally "interleaves" the result (which
+		// means that we treat $M v_i = w_i$ for each $i$ and then conjure up the associated
+		// vector $w$.)
+		let mut bases = vec![F::ZERO; d];
+		let mut novel = vec![F::ZERO; d];
+		// TODO: use `Matrix::mul_into`, implement when data is a slice of type `P:
+		// PackedField<Scalar=F>`.
+		for stride in 0..1 << ell {
+			(0..d).for_each(|i| bases[i] = data[i << ell | stride]);
+			self.vandermonde_inverse.mul_vec_into(&bases, &mut novel);
+			(0..d).for_each(|i| data[i << ell | stride] = novel[i]);
+		}
+
+		Ok(())
+	}
+}
+
+/// Compute the Vandermonde matrix: $X^{(\ell)}_i(w^{\ell}_j)$, where $w^{\ell}_j$ is the
+/// $j^{\text{th}}$ element of the field with respect to the $\beta^{(\ell)}_i$ in little Endian
+/// order. The matrix has dimensions $d\times d$. The key trick is that
+/// $\widehat{W}^{(\ell)}_i(\beta^{\ell}_j) = $\widehat{W}_{i+\ell}(\beta_{j+\ell})$.
+fn novel_vandermonde<F, NTT>(ntt: &NTT, d: usize, coset_bits: usize) -> Result<Matrix<F>, Error>
+where
+	F: BinaryField,
+	NTT: AdditiveNTT<F>,
+{
+	// This will contain the evaluations of $X^{(\ell)}_{j}(w^{(\ell)}_i)$. As usual, indexing goes
+	// from 0..d-1.
+	let mut x_ell = Matrix::zeros(d, d);
+
+	// $X_0$ is the function "1".
+	(0..d).for_each(|j| x_ell[(j, 0)] = F::ONE);
+
+	if d == 0 {
+		return Ok(x_ell);
+	}
+
+	let log_d = log2_ceil_usize(d);
+	for j in 0..log_d {
+		let subspace_dim = coset_bits - j;
+		for i in 0..d {
+			x_ell[(i, 1 << j)] = ntt.get_subspace_eval(subspace_dim, i >> (j + 1))
+				+ if (i >> j) & 1 == 1 { F::ONE } else { F::ZERO };
+		}
+
+		// Note that the jth column of x_ell is the ordered list of values $X_j(w_i)$ for i = 0,
+		// ..., d-1.
+		for k in 1..(1 << j).min(d - (1 << j)) {
+			for t in 0..d {
+				x_ell[(t, k + (1 << j))] = x_ell[(t, k)] * x_ell[(t, 1 << j)];
+			}
+		}
+	}
+
+	Ok(x_ell)
+}
+
+#[cfg(test)]
+mod tests {
+	use std::iter::repeat_with;
+
+	use binius_field::{BinaryField32b, Field};
+	use binius_utils::checked_arithmetics::log2_ceil_usize;
+	use rand::{SeedableRng, rngs::StdRng};
+
+	use super::*;
+	use crate::ntt::single_threaded::SingleThreadedNTT;
+
+	#[test]
+	fn test_interpolate_odd() {
+		type F = BinaryField32b;
+		let max_ell = 8;
+		let max_d = 10;
+
+		let mut rng = StdRng::seed_from_u64(0);
+		let ntt = SingleThreadedNTT::<F>::new(max_ell + log2_ceil_usize(max_d)).unwrap();
+
+		for ell in 0..max_ell {
+			for d in 0..max_d {
+				let expected_novel = repeat_with(|| F::random(&mut rng))
+					.take(d << ell)
+					.collect::<Vec<_>>();
+
+				let mut ntt_evals = expected_novel.clone();
+				// zero-pad to the next power of two to apply the forward transform.
+				let next_log_n = log2_ceil_usize(expected_novel.len());
+				ntt_evals.resize(1 << next_log_n, F::ZERO);
+				// apply forward transform and then run our odd interpolation routine.
+				let shape = NTTShape {
+					log_y: next_log_n,
+					..Default::default()
+				};
+				ntt.forward_transform(&mut ntt_evals, shape, 0, 0, 0)
+					.unwrap();
+
+				let coset_bits = next_log_n.saturating_sub(ell);
+				let odd_interpolate = OddInterpolate::new(&ntt, d, ell, coset_bits).unwrap();
+				odd_interpolate
+					.inverse_transform(&mut ntt_evals[..d << ell])
+					.unwrap();
+
+				assert_eq!(expected_novel, &ntt_evals[..d << ell]);
+			}
+		}
+	}
+}

--- a/crates/math/src/ntt/single_threaded.rs
+++ b/crates/math/src/ntt/single_threaded.rs
@@ -1,0 +1,633 @@
+// Copyright 2024-2025 Irreducible Inc.
+
+use std::{cmp, marker::PhantomData};
+
+use binius_field::{BinaryField, PackedField, TowerField};
+use binius_utils::bail;
+
+use super::{
+	additive_ntt::{AdditiveNTT, NTTShape},
+	error::Error,
+	twiddle::{
+		OnTheFlyTwiddleAccess, PrecomputedTwiddleAccess, TwiddleAccess, expand_subspace_evals,
+	},
+};
+use crate::BinarySubspace;
+
+/// Implementation of `AdditiveNTT` that performs the computation single-threaded.
+#[derive(Debug)]
+pub struct SingleThreadedNTT<F: BinaryField, TA: TwiddleAccess<F> = OnTheFlyTwiddleAccess<F>> {
+	// TODO: Figure out how to make this private, it should not be `pub(super)`.
+	pub(super) s_evals: Vec<TA>,
+	_marker: PhantomData<F>,
+}
+
+impl<F: BinaryField> SingleThreadedNTT<F> {
+	/// Default constructor constructs an NTT over the canonical subspace for the field using
+	/// on-the-fly computed twiddle factors.
+	pub fn new(log_domain_size: usize) -> Result<Self, Error> {
+		let subspace = BinarySubspace::with_dim(log_domain_size)?;
+		Self::with_subspace(&subspace)
+	}
+
+	/// Constructs an NTT over an isomorphic subspace for the given domain field using on-the-fly
+	/// computed twiddle factors.
+	pub fn with_domain_field<FDomain>(log_domain_size: usize) -> Result<Self, Error>
+	where
+		FDomain: BinaryField,
+		F: From<FDomain>,
+	{
+		let subspace = BinarySubspace::<FDomain>::with_dim(log_domain_size)?.isomorphic();
+		Self::with_subspace(&subspace)
+	}
+
+	pub fn with_subspace(subspace: &BinarySubspace<F>) -> Result<Self, Error> {
+		let twiddle_access = OnTheFlyTwiddleAccess::generate(subspace)?;
+		Ok(Self::with_twiddle_access(twiddle_access))
+	}
+
+	pub fn precompute_twiddles(&self) -> SingleThreadedNTT<F, PrecomputedTwiddleAccess<F>> {
+		SingleThreadedNTT::with_twiddle_access(expand_subspace_evals(&self.s_evals))
+	}
+}
+
+impl<F: TowerField> SingleThreadedNTT<F> {
+	/// A specialization of [`with_domain_field`](Self::with_domain_field) to the canonical tower
+	/// field.
+	pub fn with_canonical_field(log_domain_size: usize) -> Result<Self, Error> {
+		Self::with_domain_field::<F::Canonical>(log_domain_size)
+	}
+}
+
+impl<F: BinaryField, TA: TwiddleAccess<F>> SingleThreadedNTT<F, TA> {
+	const fn with_twiddle_access(twiddle_access: Vec<TA>) -> Self {
+		Self {
+			s_evals: twiddle_access,
+			_marker: PhantomData,
+		}
+	}
+}
+
+impl<F: BinaryField, TA: TwiddleAccess<F>> SingleThreadedNTT<F, TA> {
+	pub fn twiddles(&self) -> &[TA] {
+		&self.s_evals
+	}
+}
+
+impl<F, TA> AdditiveNTT<F> for SingleThreadedNTT<F, TA>
+where
+	F: BinaryField,
+	TA: TwiddleAccess<F>,
+{
+	fn log_domain_size(&self) -> usize {
+		self.s_evals.len()
+	}
+
+	fn subspace(&self, i: usize) -> BinarySubspace<F> {
+		let (subspace, shift) = self.s_evals[self.log_domain_size() - i].affine_subspace();
+		debug_assert_eq!(shift, F::ZERO, "s_evals subspaces must be linear by construction");
+		subspace
+	}
+
+	fn get_subspace_eval(&self, i: usize, j: usize) -> F {
+		self.s_evals[self.log_domain_size() - i].get(j)
+	}
+
+	fn forward_transform<P: PackedField<Scalar = F>>(
+		&self,
+		data: &mut [P],
+		shape: NTTShape,
+		coset: usize,
+		coset_bits: usize,
+		skip_rounds: usize,
+	) -> Result<(), Error> {
+		forward_transform(
+			self.log_domain_size(),
+			&self.s_evals,
+			data,
+			shape,
+			coset,
+			coset_bits,
+			skip_rounds,
+		)
+	}
+
+	fn inverse_transform<P: PackedField<Scalar = F>>(
+		&self,
+		data: &mut [P],
+		shape: NTTShape,
+		coset: usize,
+		coset_bits: usize,
+		skip_rounds: usize,
+	) -> Result<(), Error> {
+		inverse_transform(
+			self.log_domain_size(),
+			&self.s_evals,
+			data,
+			shape,
+			coset,
+			coset_bits,
+			skip_rounds,
+		)
+	}
+}
+
+pub fn forward_transform<F: BinaryField, P: PackedField<Scalar = F>>(
+	log_domain_size: usize,
+	s_evals: &[impl TwiddleAccess<F>],
+	data: &mut [P],
+	shape: NTTShape,
+	coset: usize,
+	coset_bits: usize,
+	skip_rounds: usize,
+) -> Result<(), Error> {
+	check_batch_transform_inputs_and_params(
+		log_domain_size,
+		data,
+		shape,
+		coset,
+		coset_bits,
+		skip_rounds,
+	)?;
+
+	match data.len() {
+		0 => return Ok(()),
+		1 => {
+			return match P::LOG_WIDTH {
+				0 => Ok(()),
+				_ => {
+					// Special case when there is only one packed element: since we cannot
+					// interleave with another packed element, the code below will panic when there
+					// is only one.
+					//
+					// Handle the case of one packed element by batch transforming the original
+					// data with dummy data and extracting the transformed result.
+					let mut buffer = [data[0], P::zero()];
+					forward_transform(
+						log_domain_size,
+						s_evals,
+						&mut buffer,
+						shape,
+						coset,
+						coset_bits,
+						skip_rounds,
+					)?;
+					data[0] = buffer[0];
+					Ok(())
+				}
+			};
+		}
+		_ => {}
+	};
+
+	let NTTShape {
+		log_x,
+		log_y,
+		log_z,
+	} = shape;
+
+	let log_w = P::LOG_WIDTH;
+
+	// Cutoff is the stage of the NTT where each the butterfly units are contained within
+	// packed base field elements.
+	let cutoff = log_w.saturating_sub(log_x);
+
+	// Choose the twiddle factors so that NTTs on differently sized domains, with the same
+	// coset_bits, share the beginning layer twiddles.
+	let s_evals = &s_evals[log_domain_size - (log_y + coset_bits)..];
+
+	// i indexes the layer of the NTT network, also the binary subspace.
+	for i in (cutoff..(log_y - skip_rounds)).rev() {
+		let s_evals_i = &s_evals[i];
+		let coset_offset = coset << (log_y - 1 - i);
+
+		// j indexes the outer Z tensor axis.
+		for j in 0..1 << log_z {
+			// k indexes the block within the layer. Each block performs butterfly operations with
+			// the same twiddle factor.
+			for k in 0..1 << (log_y - 1 - i) {
+				let twiddle = s_evals_i.get(coset_offset | k);
+				for l in 0..1 << (i + log_x - log_w) {
+					let idx0 = j << (log_x + log_y - log_w) | k << (log_x + i + 1 - log_w) | l;
+					let idx1 = idx0 | 1 << (log_x + i - log_w);
+					data[idx0] += data[idx1] * twiddle;
+					data[idx1] += data[idx0];
+				}
+			}
+		}
+	}
+
+	for i in (0..cmp::min(cutoff, log_y - skip_rounds)).rev() {
+		let s_evals_i = &s_evals[i];
+		let coset_offset = coset << (log_y - 1 - i);
+
+		// A block is a block of butterfly units that all have the same twiddle factor. Since we
+		// are below the cutoff round, the block length is less than the packing width, and
+		// therefore each packed multiplication is with a non-uniform twiddle. Since the subspace
+		// polynomials are linear, we can calculate an additive factor that can be added to the
+		// packed twiddles for all packed butterfly units.
+		let block_twiddle = calculate_packed_additive_twiddle::<P>(s_evals_i, shape, i);
+
+		let log_block_len = i + log_x;
+		let log_packed_count = (log_y - 1).saturating_sub(cutoff);
+		for j in 0..1 << (log_x + log_y + log_z).saturating_sub(log_w + log_packed_count + 1) {
+			for k in 0..1 << log_packed_count {
+				let twiddle =
+					P::broadcast(s_evals_i.get(coset_offset | k << (cutoff - i))) + block_twiddle;
+				let index = k << 1 | j << (log_packed_count + 1);
+				let (mut u, mut v) = data[index].interleave(data[index | 1], log_block_len);
+				u += v * twiddle;
+				v += u;
+				(data[index], data[index | 1]) = u.interleave(v, log_block_len);
+			}
+		}
+	}
+
+	Ok(())
+}
+
+pub fn inverse_transform<F: BinaryField, P: PackedField<Scalar = F>>(
+	log_domain_size: usize,
+	s_evals: &[impl TwiddleAccess<F>],
+	data: &mut [P],
+	shape: NTTShape,
+	coset: usize,
+	coset_bits: usize,
+	skip_rounds: usize,
+) -> Result<(), Error> {
+	check_batch_transform_inputs_and_params(
+		log_domain_size,
+		data,
+		shape,
+		coset,
+		coset_bits,
+		skip_rounds,
+	)?;
+
+	match data.len() {
+		0 => return Ok(()),
+		1 => {
+			return match P::LOG_WIDTH {
+				0 => Ok(()),
+				_ => {
+					// Special case when there is only one packed element: since we cannot
+					// interleave with another packed element, the code below will panic when there
+					// is only one.
+					//
+					// Handle the case of one packed element by batch transforming the original
+					// data with dummy data and extracting the transformed result.
+					let mut buffer = [data[0], P::zero()];
+					inverse_transform(
+						log_domain_size,
+						s_evals,
+						&mut buffer,
+						shape,
+						coset,
+						coset_bits,
+						skip_rounds,
+					)?;
+					data[0] = buffer[0];
+					Ok(())
+				}
+			};
+		}
+		_ => {}
+	};
+
+	let NTTShape {
+		log_x,
+		log_y,
+		log_z,
+	} = shape;
+
+	let log_w = P::LOG_WIDTH;
+
+	// Cutoff is the stage of the NTT where each the butterfly units are contained within
+	// packed base field elements.
+	let cutoff = log_w.saturating_sub(log_x);
+
+	// Choose the twiddle factors so that NTTs on differently sized domains, with the same
+	// coset_bits, share the final layer twiddles.
+	let s_evals = &s_evals[log_domain_size - (log_y + coset_bits)..];
+
+	#[allow(clippy::needless_range_loop)]
+	for i in 0..cutoff.min(log_y - skip_rounds) {
+		let s_evals_i = &s_evals[i];
+		let coset_offset = coset << (log_y - 1 - i);
+
+		// A block is a block of butterfly units that all have the same twiddle factor. Since we
+		// are below the cutoff round, the block length is less than the packing width, and
+		// therefore each packed multiplication is with a non-uniform twiddle. Since the subspace
+		// polynomials are linear, we can calculate an additive factor that can be added to the
+		// packed twiddles for all packed butterfly units.
+		let block_twiddle = calculate_packed_additive_twiddle::<P>(s_evals_i, shape, i);
+
+		let log_block_len = i + log_x;
+		let log_packed_count = (log_y - 1).saturating_sub(cutoff);
+		for j in 0..1 << (log_x + log_y + log_z).saturating_sub(log_w + log_packed_count + 1) {
+			for k in 0..1 << log_packed_count {
+				let twiddle =
+					P::broadcast(s_evals_i.get(coset_offset | k << (cutoff - i))) + block_twiddle;
+				let index = k << 1 | j << (log_packed_count + 1);
+				let (mut u, mut v) = data[index].interleave(data[index | 1], log_block_len);
+				v += u;
+				u += v * twiddle;
+				(data[index], data[index | 1]) = u.interleave(v, log_block_len);
+			}
+		}
+	}
+
+	// i indexes the layer of the NTT network, also the binary subspace.
+	#[allow(clippy::needless_range_loop)]
+	for i in cutoff..(log_y - skip_rounds) {
+		let s_evals_i = &s_evals[i];
+		let coset_offset = coset << (log_y - 1 - i);
+
+		// j indexes the outer Z tensor axis.
+		for j in 0..1 << log_z {
+			// k indexes the block within the layer. Each block performs butterfly operations with
+			// the same twiddle factor.
+			for k in 0..1 << (log_y - 1 - i) {
+				let twiddle = s_evals_i.get(coset_offset | k);
+				for l in 0..1 << (i + log_x - log_w) {
+					let idx0 = j << (log_x + log_y - log_w) | k << (log_x + i + 1 - log_w) | l;
+					let idx1 = idx0 | 1 << (log_x + i - log_w);
+					data[idx1] += data[idx0];
+					data[idx0] += data[idx1] * twiddle;
+				}
+			}
+		}
+	}
+
+	Ok(())
+}
+
+pub fn check_batch_transform_inputs_and_params<PB: PackedField>(
+	log_domain_size: usize,
+	data: &[PB],
+	shape: NTTShape,
+	coset: usize,
+	coset_bits: usize,
+	skip_rounds: usize,
+) -> Result<(), Error> {
+	let NTTShape {
+		log_x,
+		log_y,
+		log_z,
+	} = shape;
+
+	if !data.len().is_power_of_two() {
+		bail!(Error::PowerOfTwoLengthRequired);
+	}
+	if skip_rounds > log_y {
+		bail!(Error::SkipRoundsTooLarge);
+	}
+
+	let full_sized_y = (data.len() * PB::WIDTH) >> (log_x + log_z);
+
+	// Verify that our log_y exactly matches the data length, except when we are NTT-ing one packed
+	// field
+	if (1 << log_y != full_sized_y && data.len() > 2) || (1 << log_y > full_sized_y) {
+		bail!(Error::BatchTooLarge);
+	}
+
+	if coset >= (1 << coset_bits) {
+		bail!(Error::CosetIndexOutOfBounds { coset, coset_bits });
+	}
+
+	// The domain size should be at least large enough to represent the given coset.
+	let log_required_domain_size = log_y + coset_bits;
+	if log_required_domain_size > log_domain_size {
+		bail!(Error::DomainTooSmall {
+			log_required_domain_size
+		});
+	}
+
+	Ok(())
+}
+
+#[inline]
+fn calculate_packed_additive_twiddle<P>(
+	s_evals: &impl TwiddleAccess<P::Scalar>,
+	shape: NTTShape,
+	ntt_round: usize,
+) -> P
+where
+	P: PackedField<Scalar: BinaryField>,
+{
+	let NTTShape {
+		log_x,
+		log_y,
+		log_z,
+	} = shape;
+	debug_assert!(log_y > 0);
+
+	let log_block_len = ntt_round + log_x;
+	debug_assert!(log_block_len < P::LOG_WIDTH);
+
+	let packed_log_len = (log_x + log_y + log_z).min(P::LOG_WIDTH);
+	let log_blocks_count = packed_log_len.saturating_sub(log_block_len + 1);
+
+	let packed_log_z = packed_log_len.saturating_sub(log_x + log_y);
+	let packed_log_y = packed_log_len - packed_log_z - log_x;
+
+	let twiddle_stride = P::LOG_WIDTH
+		.saturating_sub(log_x)
+		.min(log_blocks_count - packed_log_z);
+
+	let mut twiddle = P::default();
+	for i in 0..1 << (log_blocks_count - twiddle_stride) {
+		for j in 0..1 << twiddle_stride {
+			let (subblock_twiddle_0, subblock_twiddle_1) = if packed_log_y == log_y {
+				let same_twiddle = s_evals.get(j);
+				(same_twiddle, same_twiddle)
+			} else {
+				s_evals.get_pair(twiddle_stride, j)
+			};
+			let idx0 = j << (log_block_len + 1) | i << (log_block_len + twiddle_stride + 1);
+			let idx1 = idx0 | 1 << log_block_len;
+
+			for k in 0..1 << log_block_len {
+				twiddle.set(idx0 | k, subblock_twiddle_0);
+				twiddle.set(idx1 | k, subblock_twiddle_1);
+			}
+		}
+	}
+	twiddle
+}
+
+#[cfg(test)]
+mod tests {
+	use std::iter::repeat_with;
+
+	use assert_matches::assert_matches;
+	use binius_field::{
+		BinaryField8b, BinaryField16b, Field, PackedBinaryField8x16b, PackedFieldIndexable,
+	};
+	use rand::{SeedableRng, rngs::StdRng};
+
+	use super::*;
+	use crate::Error as MathError;
+
+	#[test]
+	fn test_additive_ntt_fails_with_field_too_small() {
+		assert_matches!(
+			SingleThreadedNTT::<BinaryField8b>::new(10),
+			Err(Error::MathError(MathError::DomainSizeTooLarge))
+		);
+	}
+
+	#[test]
+	fn test_subspace_size_agrees_with_domain_size() {
+		let ntt = SingleThreadedNTT::<BinaryField16b>::new(10).expect("msg");
+		assert_eq!(ntt.subspace(10).dim(), 10);
+		assert_eq!(ntt.subspace(1).dim(), 1);
+	}
+
+	/// The additive NTT has a useful property that the NTT output of an internally zero-padded
+	/// input has the structure of repeating codeword symbols.
+	///
+	/// More precisely, let $m \in K^{2^\ell}$ be a message and $c = \text{NTT}_{\ell}(m)$ be its
+	/// NTT evaluation on the domain $S^{(\ell)}$. Define $m' \in K^{2^{\ell+\nu}}$ to be a
+	/// sequence with $m'_{i * 2^\nu} = m_i$ and $m'_j = 0$ when $j \ne 0 \mod 2^\nu$. The
+	/// property is that $c' = \text{NTT}_{\ell+\nu}(m')$ will have the structure
+	/// $c'_j = c_{\lfloor j / 2^\nu \rfloor}$.
+	///
+	/// So for $\nu = 2$, then $m' = (m_0, 0, 0, 0, m_1, 0, 0, 0, \ldots, m_{\ell-1}, 0, 0, 0)$ and
+	/// $c' = (c_0, c_0, c_0, c_0, c_1, c_1, c_1, c_1, \ldots, c_{\ell-1}, c_{\ell-1}, c_{\ell-1},
+	/// c_{\ell-1})$.
+	#[test]
+	fn test_repetition_property() {
+		let log_len = 8;
+		let ntt = SingleThreadedNTT::<BinaryField16b>::new(log_len + 2).unwrap();
+
+		let mut rng = StdRng::seed_from_u64(0);
+		let msg = repeat_with(|| <BinaryField16b as Field>::random(&mut rng))
+			.take(1 << log_len)
+			.collect::<Vec<_>>();
+
+		let mut msg_padded = vec![BinaryField16b::ZERO; 1 << (log_len + 2)];
+		for i in 0..1 << log_len {
+			msg_padded[i << 2] = msg[i];
+		}
+
+		let mut out = msg;
+		ntt.forward_transform(
+			&mut out,
+			NTTShape {
+				log_y: log_len,
+				..Default::default()
+			},
+			0,
+			0,
+			0,
+		)
+		.unwrap();
+		let mut out_rep = msg_padded;
+		ntt.forward_transform(
+			&mut out_rep,
+			NTTShape {
+				log_y: log_len + 2,
+				..Default::default()
+			},
+			0,
+			0,
+			0,
+		)
+		.unwrap();
+		for i in 0..1 << (log_len + 2) {
+			assert_eq!(out_rep[i], out[i >> 2]);
+		}
+	}
+
+	#[test]
+	fn one_packed_field_forward() {
+		let s = SingleThreadedNTT::<BinaryField16b>::new(10).expect("msg");
+		let mut packed = [PackedBinaryField8x16b::random(StdRng::from_os_rng())];
+
+		let mut packed_copy = packed;
+
+		let unpacked = PackedBinaryField8x16b::unpack_scalars_mut(&mut packed_copy);
+
+		let shape = NTTShape {
+			log_x: 0,
+			log_y: 3,
+			log_z: 0,
+		};
+		let _ = s.forward_transform(&mut packed, shape, 3, 2, 0);
+		let _ = s.forward_transform(unpacked, shape, 3, 2, 0);
+
+		for (i, unpacked_item) in unpacked.iter().enumerate().take(8) {
+			assert_eq!(packed[0].get(i), *unpacked_item);
+		}
+	}
+
+	#[test]
+	fn one_packed_field_inverse() {
+		let s = SingleThreadedNTT::<BinaryField16b>::new(10).expect("msg");
+		let mut packed = [PackedBinaryField8x16b::random(StdRng::from_os_rng())];
+
+		let mut packed_copy = packed;
+
+		let unpacked = PackedBinaryField8x16b::unpack_scalars_mut(&mut packed_copy);
+
+		let shape = NTTShape {
+			log_x: 0,
+			log_y: 3,
+			log_z: 0,
+		};
+		let _ = s.inverse_transform(&mut packed, shape, 3, 2, 0);
+		let _ = s.inverse_transform(unpacked, shape, 3, 2, 0);
+
+		for (i, unpacked_item) in unpacked.iter().enumerate().take(8) {
+			assert_eq!(packed[0].get(i), *unpacked_item);
+		}
+	}
+
+	#[test]
+	fn smaller_embedded_batch_forward() {
+		let s = SingleThreadedNTT::<BinaryField16b>::new(10).expect("msg");
+		let mut packed = [PackedBinaryField8x16b::random(StdRng::from_os_rng())];
+
+		let mut packed_copy = packed;
+
+		let unpacked = &mut PackedBinaryField8x16b::unpack_scalars_mut(&mut packed_copy)[0..4];
+
+		let shape = NTTShape {
+			log_x: 0,
+			log_y: 2,
+			log_z: 0,
+		};
+		let _ = forward_transform(s.log_domain_size(), &s.s_evals, &mut packed, shape, 3, 2, 0);
+		let _ = s.forward_transform(unpacked, shape, 3, 2, 0);
+
+		for (i, unpacked_item) in unpacked.iter().enumerate().take(4) {
+			assert_eq!(packed[0].get(i), *unpacked_item);
+		}
+	}
+
+	#[test]
+	fn smaller_embedded_batch_inverse() {
+		let s = SingleThreadedNTT::<BinaryField16b>::new(10).expect("msg");
+		let mut packed = [PackedBinaryField8x16b::random(StdRng::from_os_rng())];
+
+		let mut packed_copy = packed;
+
+		let unpacked = &mut PackedBinaryField8x16b::unpack_scalars_mut(&mut packed_copy)[0..4];
+
+		let shape = NTTShape {
+			log_x: 0,
+			log_y: 2,
+			log_z: 0,
+		};
+		let _ = inverse_transform(s.log_domain_size(), &s.s_evals, &mut packed, shape, 3, 2, 0);
+		let _ = s.inverse_transform(unpacked, shape, 3, 2, 0);
+
+		for (i, unpacked_item) in unpacked.iter().enumerate().take(4) {
+			assert_eq!(packed[0].get(i), *unpacked_item);
+		}
+	}
+
+	// TODO: Write test that compares polynomial evaluation via additive NTT with naive Lagrange
+	// polynomial interpolation. A randomized test should suffice for larger NTT sizes.
+}

--- a/crates/math/src/ntt/tests/mod.rs
+++ b/crates/math/src/ntt/tests/mod.rs
@@ -1,0 +1,4 @@
+// Copyright 2024-2025 Irreducible Inc.
+
+mod ntt_tests;
+mod reference;

--- a/crates/math/src/ntt/tests/ntt_tests.rs
+++ b/crates/math/src/ntt/tests/ntt_tests.rs
@@ -1,0 +1,491 @@
+// Copyright 2024-2025 Irreducible Inc.
+
+use std::ops::Range;
+
+use binius_field::{
+	AESTowerField8b, BinaryField, BinaryField8b, ByteSlicedAES8x16x16b, ByteSlicedAES16x32x8b,
+	PackedBinaryField8x32b, PackedBinaryField16x32b, PackedBinaryField32x16b, PackedExtension,
+	PackedField, RepackedExtension,
+	arch::{
+		packed_8::PackedBinaryField1x8b,
+		packed_16::{PackedBinaryField1x16b, PackedBinaryField2x8b},
+		packed_32::PackedBinaryField2x16b,
+		packed_64::{PackedBinaryField2x32b, PackedBinaryField4x16b},
+	},
+	underlier::{NumCast, WithUnderlier},
+};
+use rand::prelude::*;
+
+use crate::ntt::{AdditiveNTT, NTTShape, SingleThreadedNTT, dynamic_dispatch::DynamicDispatchNTT};
+
+/// Check that forward and inverse transformation of `math` on `data` is the same as forward and
+/// inverse transformation of `reference_ntt` on `data` and that the result of the roundtrip is the
+/// same as the original data.
+fn check_roundtrip_with_reference<F, P>(
+	reference_ntt: &impl AdditiveNTT<F>,
+	ntt: &impl AdditiveNTT<F>,
+	data: &[P],
+	shape: NTTShape,
+	cosets: Range<usize>,
+	coset_bits: usize,
+	skip_rounds: usize,
+) where
+	F: BinaryField,
+	P: PackedField<Scalar = F>,
+{
+	let NTTShape {
+		log_x,
+		log_y,
+		log_z,
+	} = shape;
+
+	let log_len = log_x + log_y + log_z;
+	let mut orig_data = data.to_vec();
+
+	if log_len < P::LOG_WIDTH {
+		for i in 1 << log_len..P::WIDTH {
+			orig_data[0].set(i, F::ZERO);
+		}
+	}
+
+	let mut data_copy_impl = orig_data.clone();
+	let mut data_copy_ref = orig_data.clone();
+
+	for coset in cosets {
+		ntt.forward_transform(&mut data_copy_impl, shape, coset, coset_bits, skip_rounds)
+			.unwrap();
+		reference_ntt
+			.forward_transform(&mut data_copy_ref, shape, coset, coset_bits, skip_rounds)
+			.unwrap();
+
+		assert_eq!(&data_copy_impl, &data_copy_ref);
+
+		ntt.inverse_transform(&mut data_copy_impl, shape, coset, coset_bits, skip_rounds)
+			.unwrap();
+		reference_ntt
+			.inverse_transform(&mut data_copy_ref, shape, coset, coset_bits, skip_rounds)
+			.unwrap();
+
+		assert_eq!(&orig_data, &data_copy_impl);
+		assert_eq!(&orig_data, &data_copy_ref);
+	}
+}
+
+/// Check the all NTTs have the same behavior.
+fn check_roundtrip_all_ntts<P>(
+	log_domain_size: usize,
+	log_data_size: usize,
+	max_log_stride_batch: usize,
+	max_log_coset: usize,
+) where
+	P: PackedField<Scalar: BinaryField>,
+{
+	let simple_ntt = SingleThreadedNTT::<P::Scalar>::new(log_domain_size)
+		.unwrap()
+		.into_simple_ntt();
+	let single_threaded_ntt = SingleThreadedNTT::<P::Scalar>::new(log_domain_size).unwrap();
+	let single_threaded_precompute_ntt = SingleThreadedNTT::<P::Scalar>::new(log_domain_size)
+		.unwrap()
+		.precompute_twiddles();
+	let multithreaded_ntt_2 = SingleThreadedNTT::<P::Scalar>::new(log_domain_size)
+		.unwrap()
+		.multithreaded_with_max_threads(1);
+	let multithreaded_ntt_4 = SingleThreadedNTT::<P::Scalar>::new(log_domain_size)
+		.unwrap()
+		.multithreaded_with_max_threads(2);
+	let multithreaded_precompute_ntt_2 = SingleThreadedNTT::<P::Scalar>::new(log_domain_size)
+		.unwrap()
+		.precompute_twiddles()
+		.multithreaded_with_max_threads(1);
+	let dynamic_dispatch_ntt = DynamicDispatchNTT::SingleThreaded(
+		SingleThreadedNTT::<P::Scalar>::new(log_domain_size).unwrap(),
+	);
+
+	let mut rng = StdRng::seed_from_u64(0);
+	let data = (0..1u128 << log_data_size)
+		.map(|_| P::random(&mut rng))
+		.collect::<Vec<_>>();
+
+	let cosets = 0..1 << max_log_coset;
+	for log_stride_batch in 0..=max_log_stride_batch {
+		let log_n_b_range = if data.len() > 1 {
+			let single_log_n = data.len().ilog2() as usize + P::LOG_WIDTH - log_stride_batch;
+			single_log_n..single_log_n + 1
+		} else {
+			0..P::LOG_WIDTH - log_stride_batch
+		};
+
+		for log_n_b in log_n_b_range {
+			for log_n in 0..=log_n_b {
+				let log_batch = log_n_b - log_n;
+				let shape = NTTShape {
+					log_x: log_stride_batch,
+					log_y: log_n,
+					log_z: log_batch,
+				};
+
+				for skip_rounds in [0, log_n / 3, log_n / 2] {
+					check_roundtrip_with_reference(
+						&simple_ntt,
+						&single_threaded_ntt,
+						&data,
+						shape,
+						cosets.clone(),
+						max_log_coset,
+						skip_rounds,
+					);
+					check_roundtrip_with_reference(
+						&simple_ntt,
+						&single_threaded_precompute_ntt,
+						&data,
+						shape,
+						cosets.clone(),
+						max_log_coset,
+						skip_rounds,
+					);
+					check_roundtrip_with_reference(
+						&simple_ntt,
+						&multithreaded_ntt_2,
+						&data,
+						shape,
+						cosets.clone(),
+						max_log_coset,
+						skip_rounds,
+					);
+					check_roundtrip_with_reference(
+						&simple_ntt,
+						&multithreaded_ntt_4,
+						&data,
+						shape,
+						cosets.clone(),
+						max_log_coset,
+						skip_rounds,
+					);
+					check_roundtrip_with_reference(
+						&simple_ntt,
+						&multithreaded_precompute_ntt_2,
+						&data,
+						shape,
+						cosets.clone(),
+						max_log_coset,
+						skip_rounds,
+					);
+					check_roundtrip_with_reference(
+						&simple_ntt,
+						&dynamic_dispatch_ntt,
+						&data,
+						shape,
+						cosets.clone(),
+						max_log_coset,
+						skip_rounds,
+					);
+				}
+			}
+		}
+	}
+}
+
+#[test]
+fn tests_roundtrip_packed_1() {
+	check_roundtrip_all_ntts::<BinaryField8b>(8, 6, 4, 2);
+}
+
+#[test]
+fn tests_roundtrip_packed_2() {
+	check_roundtrip_all_ntts::<PackedBinaryField2x8b>(8, 6, 4, 1);
+}
+
+#[test]
+fn tests_roundtrip_packed_4() {
+	check_roundtrip_all_ntts::<PackedBinaryField2x8b>(8, 6, 4, 0);
+}
+
+#[test]
+fn tests_field_256_bits() {
+	check_roundtrip_all_ntts::<PackedBinaryField8x32b>(12, 8, 4, 1);
+}
+
+#[test]
+fn tests_field_512_bits() {
+	check_roundtrip_all_ntts::<PackedBinaryField16x32b>(13, 6, 4, 1);
+}
+
+#[test]
+fn tests_3d_bytesliced_field_128_bits() {
+	check_roundtrip_all_ntts::<ByteSlicedAES8x16x16b>(14, 6, 4, 1);
+}
+
+#[test]
+fn test_sub_packing_width() {
+	check_roundtrip_all_ntts::<PackedBinaryField32x16b>(12, 0, 2, 1);
+}
+
+#[test]
+fn test_3d_bytesliced_sub_packing_width() {
+	check_roundtrip_all_ntts::<ByteSlicedAES8x16x16b>(12, 0, 2, 1);
+}
+
+#[test]
+fn test_3d_bytesliced_larger_than_domain() {
+	check_roundtrip_all_ntts::<ByteSlicedAES16x32x8b>(8, 0, 0, 0);
+}
+
+fn check_packed_extension_roundtrip_with_reference<F, PE>(
+	reference_ntt: &impl AdditiveNTT<F>,
+	ntt: &impl AdditiveNTT<F>,
+	data: &mut [PE],
+	cosets: Range<usize>,
+	coset_bits: usize,
+) where
+	F: BinaryField,
+	PE: PackedExtension<F>,
+{
+	let data_copy = data.to_vec();
+	let mut data_copy_2 = data.to_vec();
+
+	for coset in cosets {
+		let log_n = data.len().ilog2() as usize + PE::LOG_WIDTH;
+
+		let shape = NTTShape {
+			log_y: log_n,
+			..Default::default()
+		};
+
+		ntt.forward_transform_ext(data, shape, coset, coset_bits, 0)
+			.unwrap();
+		reference_ntt
+			.forward_transform_ext(&mut data_copy_2, shape, coset, coset_bits, 0)
+			.unwrap();
+
+		assert_eq!(data, &data_copy_2);
+
+		ntt.inverse_transform_ext(data, shape, coset, coset_bits, 0)
+			.unwrap();
+		reference_ntt
+			.inverse_transform_ext(&mut data_copy_2, shape, coset, coset_bits, 0)
+			.unwrap();
+
+		assert_eq!(data, &data_copy);
+		assert_eq!(data, &data_copy_2);
+	}
+}
+
+fn check_packed_extension_roundtrip_all_ntts<P, PE>(
+	log_domain_size: usize,
+	log_data_size: usize,
+	max_log_coset: usize,
+) where
+	P: PackedField<Scalar: BinaryField>,
+	PE: RepackedExtension<P> + WithUnderlier<Underlier: NumCast<u128>>,
+{
+	let simple_ntt = SingleThreadedNTT::<P::Scalar>::new(log_domain_size)
+		.unwrap()
+		.into_simple_ntt();
+	let single_threaded_ntt = SingleThreadedNTT::<P::Scalar>::new(log_domain_size).unwrap();
+	let single_threaded_precompute_ntt = SingleThreadedNTT::<P::Scalar>::new(log_domain_size)
+		.unwrap()
+		.precompute_twiddles();
+	let multithreaded_ntt = SingleThreadedNTT::<P::Scalar>::new(log_domain_size)
+		.unwrap()
+		.multithreaded();
+	let multithreaded_precompute_ntt = SingleThreadedNTT::<P::Scalar>::new(log_domain_size)
+		.unwrap()
+		.precompute_twiddles()
+		.multithreaded();
+	let dynamic_dispatch_ntt = DynamicDispatchNTT::SingleThreaded(
+		SingleThreadedNTT::<P::Scalar>::new(log_domain_size).unwrap(),
+	);
+
+	let mut data = (0..1u128 << log_data_size)
+		.map(|i| PE::from_underlier(NumCast::num_cast_from(i)))
+		.collect::<Vec<_>>();
+
+	let cosets = 0..1 << max_log_coset;
+
+	check_packed_extension_roundtrip_with_reference(
+		&simple_ntt,
+		&single_threaded_ntt,
+		&mut data,
+		cosets.clone(),
+		max_log_coset,
+	);
+	check_packed_extension_roundtrip_with_reference(
+		&simple_ntt,
+		&single_threaded_precompute_ntt,
+		&mut data,
+		cosets.clone(),
+		max_log_coset,
+	);
+	check_packed_extension_roundtrip_with_reference(
+		&simple_ntt,
+		&multithreaded_ntt,
+		&mut data,
+		cosets.clone(),
+		max_log_coset,
+	);
+	check_packed_extension_roundtrip_with_reference(
+		&simple_ntt,
+		&multithreaded_precompute_ntt,
+		&mut data,
+		cosets.clone(),
+		max_log_coset,
+	);
+	check_packed_extension_roundtrip_with_reference(
+		&simple_ntt,
+		&dynamic_dispatch_ntt,
+		&mut data,
+		cosets,
+		max_log_coset,
+	);
+}
+
+#[test]
+fn tests_packed_extension_roundtrip_packed_single_value() {
+	check_packed_extension_roundtrip_all_ntts::<PackedBinaryField1x8b, PackedBinaryField1x8b>(
+		8, 6, 2,
+	);
+	check_packed_extension_roundtrip_all_ntts::<PackedBinaryField1x16b, PackedBinaryField1x16b>(
+		9, 6, 2,
+	);
+}
+
+#[test]
+fn tests_packed_extension_roundtrip_packed_2_packed() {
+	check_packed_extension_roundtrip_all_ntts::<PackedBinaryField2x8b, PackedBinaryField2x8b>(
+		8, 6, 1,
+	);
+	check_packed_extension_roundtrip_all_ntts::<PackedBinaryField2x16b, PackedBinaryField2x16b>(
+		9, 6, 2,
+	);
+}
+
+#[test]
+fn tests_packed_extension_roundtrip_packed_extension() {
+	check_packed_extension_roundtrip_all_ntts::<PackedBinaryField4x16b, PackedBinaryField2x32b>(
+		8, 6, 1,
+	);
+}
+
+#[test]
+fn tests_packed_extension_roundtrip_message_size_1() {
+	check_packed_extension_roundtrip_all_ntts::<PackedBinaryField2x32b, PackedBinaryField2x32b>(
+		8, 0, 1,
+	);
+	check_packed_extension_roundtrip_all_ntts::<PackedBinaryField4x16b, PackedBinaryField4x16b>(
+		8, 0, 1,
+	);
+}
+
+/// Check that NTT transformations give isomorphic results for isomorphic fields.
+fn check_ntt_with_transform<P1, P2>(
+	ntt_binary: &impl AdditiveNTT<P1::Scalar>,
+	ntt_aes_1: &impl AdditiveNTT<P2::Scalar>,
+	ntt_aes_2: &impl AdditiveNTT<P2::Scalar>,
+	data_size: usize,
+) where
+	P1: PackedField<Scalar: BinaryField>,
+	P2: PackedField<Scalar: BinaryField + From<P1::Scalar>> + From<P1>,
+{
+	let mut rng = StdRng::seed_from_u64(0);
+
+	let data: Vec<_> = (0..data_size)
+		.map(|_| P1::Scalar::random(&mut rng))
+		.collect();
+	let data_as_aes: Vec<_> = data.iter().map(|x| P2::Scalar::from(*x)).collect();
+
+	let coset_bits = 2;
+	for coset in 0..1 << coset_bits {
+		let mut result_bin = data.clone();
+		let mut result_aes = data_as_aes.clone();
+		let mut result_aes_cob = data_as_aes.clone();
+
+		let log_n = data_size.ilog2() as usize + P1::LOG_WIDTH;
+		let shape = NTTShape {
+			log_y: log_n,
+			..Default::default()
+		};
+
+		ntt_binary
+			.forward_transform(&mut result_bin, shape, coset, coset_bits, 0)
+			.unwrap();
+		ntt_aes_1
+			.forward_transform(&mut result_aes, shape, coset, coset_bits, 0)
+			.unwrap();
+		ntt_aes_2
+			.forward_transform(&mut result_aes_cob, shape, coset, coset_bits, 0)
+			.unwrap();
+
+		let result_bin_to_aes: Vec<_> = result_bin.iter().map(|x| P2::Scalar::from(*x)).collect();
+
+		assert_eq!(result_bin_to_aes, result_aes_cob);
+		assert_ne!(result_bin_to_aes, result_aes);
+
+		ntt_binary
+			.inverse_transform(&mut result_bin, shape, coset, coset_bits, 0)
+			.unwrap();
+		ntt_aes_1
+			.inverse_transform(&mut result_aes, shape, coset, coset_bits, 0)
+			.unwrap();
+		ntt_aes_2
+			.inverse_transform(&mut result_aes_cob, shape, coset, coset_bits, 0)
+			.unwrap();
+
+		let result_bin_to_aes: Vec<_> = result_bin.iter().map(|x| P2::Scalar::from(*x)).collect();
+
+		assert_eq!(result_bin_to_aes, result_aes_cob);
+	}
+}
+
+#[test]
+fn test_transform_single_thread_on_the_fly() {
+	check_ntt_with_transform::<BinaryField8b, AESTowerField8b>(
+		&SingleThreadedNTT::<BinaryField8b>::new(8).unwrap(),
+		&SingleThreadedNTT::<AESTowerField8b>::new(8).unwrap(),
+		&SingleThreadedNTT::<AESTowerField8b, _>::with_domain_field::<BinaryField8b>(8).unwrap(),
+		64,
+	)
+}
+
+#[test]
+fn test_transform_single_thread_precompute() {
+	check_ntt_with_transform::<BinaryField8b, AESTowerField8b>(
+		&SingleThreadedNTT::<BinaryField8b>::new(8).unwrap(),
+		&SingleThreadedNTT::<AESTowerField8b>::new(8)
+			.unwrap()
+			.precompute_twiddles(),
+		&SingleThreadedNTT::<AESTowerField8b, _>::with_domain_field::<BinaryField8b>(8)
+			.unwrap()
+			.precompute_twiddles(),
+		64,
+	)
+}
+
+#[test]
+fn test_transform_multithread_on_the_fly() {
+	check_ntt_with_transform::<BinaryField8b, AESTowerField8b>(
+		&SingleThreadedNTT::<BinaryField8b>::new(8).unwrap(),
+		&SingleThreadedNTT::<AESTowerField8b>::new(8)
+			.unwrap()
+			.multithreaded(),
+		&SingleThreadedNTT::<AESTowerField8b, _>::with_domain_field::<BinaryField8b>(8)
+			.unwrap()
+			.multithreaded(),
+		64,
+	)
+}
+
+#[test]
+fn test_transform_multithread_precompute() {
+	check_ntt_with_transform::<BinaryField8b, AESTowerField8b>(
+		&SingleThreadedNTT::<BinaryField8b>::new(8).unwrap(),
+		&SingleThreadedNTT::<AESTowerField8b>::new(8)
+			.unwrap()
+			.precompute_twiddles()
+			.multithreaded(),
+		&SingleThreadedNTT::<AESTowerField8b, _>::with_domain_field::<BinaryField8b>(8)
+			.unwrap()
+			.precompute_twiddles()
+			.multithreaded(),
+		64,
+	)
+}

--- a/crates/math/src/ntt/tests/reference.rs
+++ b/crates/math/src/ntt/tests/reference.rs
@@ -1,0 +1,270 @@
+// Copyright 2024-2025 Irreducible Inc.
+
+use std::marker::PhantomData;
+
+use binius_field::{
+	BinaryField, ExtensionField, PackedField,
+	packed::{get_packed_slice_unchecked, set_packed_slice_unchecked},
+};
+use binius_utils::random_access_sequence::{RandomAccessSequence, RandomAccessSequenceMut};
+
+use crate::{
+	BinarySubspace,
+	ntt::{AdditiveNTT, Error, NTTShape, SingleThreadedNTT, twiddle::TwiddleAccess},
+};
+
+/// A slice of packed field elements with an access to a batch with the given index:
+/// [batch_0_element_0, batch_1_element_0, ..., batch_0_element_1, batch_0_element_1, ...]
+struct BatchedPackedFieldSlice<'a, P> {
+	data: &'a mut [P],
+	log_n: usize,
+	log_batch_count: usize,
+	batch_index: usize,
+}
+
+impl<'a, P> BatchedPackedFieldSlice<'a, P> {
+	fn new(data: &'a mut [P], log_n: usize, log_batch_count: usize, batch_index: usize) -> Self {
+		Self {
+			data,
+			log_n,
+			log_batch_count,
+			batch_index,
+		}
+	}
+}
+
+impl<P> RandomAccessSequence<P::Scalar> for BatchedPackedFieldSlice<'_, P>
+where
+	P: PackedField,
+{
+	unsafe fn get_unchecked(&self, index: usize) -> P::Scalar {
+		unsafe {
+			get_packed_slice_unchecked(
+				self.data,
+				self.batch_index + (index << self.log_batch_count),
+			)
+		}
+	}
+
+	fn len(&self) -> usize {
+		1 << self.log_n
+	}
+}
+
+impl<P> RandomAccessSequenceMut<P::Scalar> for BatchedPackedFieldSlice<'_, P>
+where
+	P: PackedField,
+{
+	unsafe fn set_unchecked(&mut self, index: usize, value: P::Scalar) {
+		unsafe {
+			set_packed_slice_unchecked(
+				self.data,
+				self.batch_index + (index << self.log_batch_count),
+				value,
+			);
+		}
+	}
+}
+
+/// Reference implementation of the forward NTT to compare against in tests.
+fn forward_transform_simple<F, FF>(
+	log_domain_size: usize,
+	s_evals: &[impl TwiddleAccess<F>],
+	data: &mut impl RandomAccessSequenceMut<FF>,
+	coset: usize,
+	log_n: usize,
+	coset_bits: usize,
+	skip_rounds: usize,
+) -> Result<(), Error>
+where
+	F: BinaryField,
+	FF: ExtensionField<F>,
+{
+	if coset >= (1 << coset_bits) {
+		return Err(Error::CosetIndexOutOfBounds { coset, coset_bits });
+	}
+	if log_n + coset_bits > log_domain_size {
+		return Err(Error::DomainTooSmall {
+			log_required_domain_size: log_n + coset_bits,
+		});
+	}
+
+	let s_evals = &s_evals[log_domain_size - (log_n + coset_bits)..];
+
+	for i in (0..(log_n - skip_rounds)).rev() {
+		let s_evals_i = &s_evals[i];
+		for j in 0..1 << (log_n - 1 - i) {
+			let twiddle = s_evals_i.get(coset << (log_n - 1 - i) | j);
+			for k in 0..1 << i {
+				let idx0 = j << (i + 1) | k;
+				let idx1 = idx0 | 1 << i;
+
+				let (mut u, mut v) = (data.get(idx0), data.get(idx1));
+
+				u += v * twiddle;
+				v += u;
+
+				data.set(idx0, u);
+				data.set(idx1, v);
+			}
+		}
+	}
+
+	Ok(())
+}
+
+/// Reference implementation of the inverse NTT to compare against in tests.
+fn inverse_transform_simple<F, FF>(
+	log_domain_size: usize,
+	s_evals: &[impl TwiddleAccess<F>],
+	data: &mut impl RandomAccessSequenceMut<FF>,
+	coset: usize,
+	log_n: usize,
+	coset_bits: usize,
+	skip_rounds: usize,
+) -> Result<(), Error>
+where
+	F: BinaryField,
+	FF: ExtensionField<F>,
+{
+	if coset >= (1 << coset_bits) {
+		return Err(Error::CosetIndexOutOfBounds { coset, coset_bits });
+	}
+	if log_n + coset_bits > log_domain_size {
+		return Err(Error::DomainTooSmall {
+			log_required_domain_size: log_n + coset_bits,
+		});
+	}
+
+	let s_evals = &s_evals[log_domain_size - (log_n + coset_bits)..];
+
+	#[allow(clippy::needless_range_loop)]
+	for i in 0..(log_n - skip_rounds) {
+		let s_evals_i = &s_evals[i];
+		for j in 0..1 << (log_n - 1 - i) {
+			let twiddle = s_evals_i.get(coset << (log_n - 1 - i) | j);
+			for k in 0..1 << i {
+				let idx0 = j << (i + 1) | k;
+				let idx1 = idx0 | 1 << i;
+
+				let (mut u, mut v) = (data.get(idx0), data.get(idx1));
+
+				v += u;
+				u += v * twiddle;
+
+				data.set(idx0, u);
+				data.set(idx1, v);
+			}
+		}
+	}
+
+	Ok(())
+}
+
+/// Simple NTT implementation that uses the reference implementation for the forward and inverse
+/// NTT.
+pub struct SimpleAdditiveNTT<F: BinaryField, TA: TwiddleAccess<F>> {
+	s_evals: Vec<TA>,
+	_marker: PhantomData<F>,
+}
+
+impl<F: BinaryField, TA: TwiddleAccess<F>> AdditiveNTT<F> for SimpleAdditiveNTT<F, TA> {
+	fn log_domain_size(&self) -> usize {
+		self.s_evals[0].log_n() + 1
+	}
+
+	fn subspace(&self, i: usize) -> BinarySubspace<F> {
+		let (subspace, shift) = self.s_evals[i].affine_subspace();
+		debug_assert_eq!(shift, F::ZERO, "s_evals subspaces must be linear by construction");
+		subspace
+	}
+
+	fn get_subspace_eval(&self, i: usize, j: usize) -> F {
+		self.s_evals[i].get(j)
+	}
+
+	fn forward_transform<P: PackedField<Scalar = F>>(
+		&self,
+		data: &mut [P],
+		shape: NTTShape,
+		coset: usize,
+		coset_bits: usize,
+		skip_rounds: usize,
+	) -> Result<(), Error> {
+		let NTTShape {
+			log_x,
+			log_y,
+			log_z,
+		} = shape;
+		for x_index in 0..1 << log_x {
+			for z_index in 0..1 << log_z {
+				let mut batch = BatchedPackedFieldSlice::new(
+					data,
+					log_y,
+					log_x,
+					x_index | z_index << (log_x + log_y),
+				);
+				forward_transform_simple(
+					self.log_domain_size(),
+					&self.s_evals,
+					&mut batch,
+					coset,
+					log_y,
+					coset_bits,
+					skip_rounds,
+				)?;
+			}
+		}
+
+		Ok(())
+	}
+
+	fn inverse_transform<P: PackedField<Scalar = F>>(
+		&self,
+		data: &mut [P],
+		shape: NTTShape,
+		coset: usize,
+		coset_bits: usize,
+		skip_rounds: usize,
+	) -> Result<(), Error> {
+		let NTTShape {
+			log_x,
+			log_y,
+			log_z,
+		} = shape;
+		for x_index in 0..1 << log_x {
+			for z_index in 0..1 << log_z {
+				let mut batch = BatchedPackedFieldSlice::new(
+					data,
+					log_y,
+					log_x,
+					x_index | z_index << (log_x + log_y),
+				);
+				inverse_transform_simple(
+					self.log_domain_size(),
+					&self.s_evals,
+					&mut batch,
+					coset,
+					log_y,
+					coset_bits,
+					skip_rounds,
+				)?;
+			}
+		}
+
+		Ok(())
+	}
+}
+
+impl<F, TA> SingleThreadedNTT<F, TA>
+where
+	F: BinaryField,
+	TA: TwiddleAccess<F>,
+{
+	pub(super) fn into_simple_ntt(self) -> SimpleAdditiveNTT<F, TA> {
+		SimpleAdditiveNTT {
+			s_evals: self.s_evals,
+			_marker: PhantomData,
+		}
+	}
+}

--- a/crates/math/src/ntt/twiddle.rs
+++ b/crates/math/src/ntt/twiddle.rs
@@ -1,0 +1,534 @@
+// Copyright 2024-2025 Irreducible Inc.
+
+use std::{iter, marker::PhantomData, ops::Deref};
+
+use binius_field::{BinaryField, Field};
+use binius_utils::bail;
+
+use super::error::Error;
+use crate::BinarySubspace;
+
+/// A trait for accessing twiddle factors in a single NTT round.
+///
+/// Twiddle factors in the additive NTT are subspace polynomial evaluations over linear subspaces,
+/// with an implicit NTT round $i$.
+/// Setup: let $K \mathbin{/} \mathbb{F}\_2$ be a finite extension of degree $d$, and let
+/// $\beta_0,\ldots ,\beta_{d-1}$ be an $\mathbb{F}\_2$-basis. Let $U_i$ be the
+/// $\mathbb{F}\_2$-linear span of $\beta_0,\ldots ,\beta_{i-1}$. Let $\hat{W}_i(X)$
+/// be the normalized subspace polynomial of degree $2^i$ that vanishes on $U_i$ and is $1$ on
+/// $\beta_i$. Evaluating $\hat{W}_i(X)$ turns out to yield an $\mathbb{F}\_2$-linear function $K
+/// \rightarrow K$.
+///
+/// This trait accesses the subspace polynomial evaluations for $\hat{W}\_i(X)$.
+/// The evaluations of the vanishing polynomial over all elements in any coset of the subspace
+/// are equal. Equivalently, the evaluations of $\hat{W}\_i(X)$ are well-defined on
+/// the $d-i$-dimensional vector space $K \mathbin{/} U_i$. Note that $K \mathbin{/} U_i$ has a
+/// natural induced basis. Write $\{j\}$ for the $j$th coset of the subspace, where $j$ is in
+/// $[0,2^{d-i})$, with respect to this natural basis. This means: write $j$ in binary: $j = j_0 +
+/// \cdots + j_{d-i-1} \cdot 2^{d-i-1}$ and consider the following element of $K$: $j_0 \cdot
+/// \beta_i + \cdots  + j_{d-i-1} \cdot \beta_{d-1}$. This element determines an element of $K
+/// \mathbin{/} U_i$. The twiddle factor $t_{i,j}$ is then $\hat{W}\_i(\{j\})$, i.e., $\hat{W}\_j$
+/// evaluated at the aforementioned element of the quotient $K \mathbin{/} U_i$.
+///
+/// As explained, the evaluations of these polynomial yield linear functions, which allows for
+/// flexibility in how they are computed. Namely, for an evaluation domain of size $2^{i}$, there is
+/// a strategy for computing polynomial evaluations "on-the-fly" with $O(\ell)$ field additions
+/// using $O(\ell)$ stored elements or precomputing the $2^\ell$ evaluations and looking them up in
+/// constant time (see the [`OnTheFlyTwiddleAccess`] and [`PrecomputedTwiddleAccess`]
+/// implementations, respectively).
+///
+/// See [LCH14] and [DP24] Section 2.3 for more details.
+///
+/// [LCH14]: <https://arxiv.org/abs/1404.3458>
+/// [DP24]: <https://eprint.iacr.org/2024/504>
+pub trait TwiddleAccess<F: BinaryField> {
+	/// Base-2 logarithm of the number of twiddle factors in this round.
+	fn log_n(&self) -> usize;
+
+	/// The twiddle values are the span of this binary subspace, excluding 1 as a basis element,
+	/// and with an affine shift.
+	///
+	/// Returns a tuple with the subspace and shift value.
+	fn affine_subspace(&self) -> (BinarySubspace<F>, F);
+
+	/// Get the twiddle factor at the given index.
+	///
+	/// Evaluate $\hat{W}\_i(X)$ at the element `index`: write `index` in binary
+	/// and evaluate at the element $index_0\beta_{i+1} \ldots + index_{d-i-2}\beta_{d-1}$.
+	///
+	/// Panics if `index` is not in the range 0 to `1 << self.log_n()`.
+	fn get(&self, index: usize) -> F;
+
+	/// Get the pair of twiddle factors at the indices `index` and `(1 << index_bits) | index`.
+	///
+	/// Panics if `index_bits` is not in the range 0 to `self.log_n()` or `index` is not in the
+	/// range 0 to `1 << index_bits`.
+	fn get_pair(&self, index_bits: usize, index: usize) -> (F, F);
+
+	/// Returns a scoped twiddle access for the coset that fixes the upper `coset_bits` of the
+	/// index to `coset`.
+	///
+	/// Recall that a `TwiddleAccess` has an implicit NTT round $i$. Let $j=d-coset_{bits}$.
+	/// Then`coset` returns a `TwiddleAccess` object (of NTT round i) for the following affine
+	/// subspace of $K/U_{i-1}$: the set of all elements of $K/U_{i-1}$
+	/// whose coordinates in the basis $\beta_i,\ldots ,\beta_{d-1}$ is:
+	/// $(*, \cdots, *, coset_{0}, \ldots , coset_{bits-1})$, where the first $j$ coordinates are
+	/// arbitrary. Here $coset = coset_0 + \ldots  + coset_{bits-1}2^{bits-1}$. In sum, this
+	/// amounts to *evaluations* of $\hat{W}\_i$ at all such elements.
+	///
+	/// Therefore, the `self.log_n` of the new `TwiddleAccess` object is computed as `self.log_n() -
+	/// coset_bits`.
+	///
+	/// Panics if `coset_bits` is not in the range 0 to `self.log_n()` or `coset` is not in the
+	/// range 0 to `1 << coset_bits`.
+	fn coset(&self, coset_bits: usize, coset: usize) -> impl TwiddleAccess<F>;
+}
+
+/// Twiddle access method that does on-the-fly computation to reduce its memory footprint.
+///
+/// This implementation uses a small amount of precomputed constants from which the twiddle factors
+/// are derived on the fly (OTF). The number of constants is ~$1/2 d^2$ field elements for a domain
+/// of size $2^d$.
+#[derive(Debug)]
+pub struct OnTheFlyTwiddleAccess<F, SEvals = Vec<F>> {
+	log_n: usize,
+	/// `offset` is a constant that is added to all twiddle factors.
+	offset: F,
+	/// `s_evals` is $<\hat{W}\_i(\beta_{i+1}),\ldots ,\hat{W}\_i(\beta_{d-1})>$ for the implicit
+	/// round $i$.
+	s_evals: SEvals,
+}
+
+impl<F: BinaryField> OnTheFlyTwiddleAccess<F> {
+	/// Generate a vector of OnTheFlyTwiddleAccess objects, one for each NTT round.
+	pub fn generate(subspace: &BinarySubspace<F>) -> Result<Vec<Self>, Error> {
+		let log_domain_size = subspace.dim();
+		let s_evals = precompute_subspace_evals(subspace)?
+			.into_iter()
+			.enumerate()
+			.map(|(i, s_evals_i)| Self {
+				log_n: log_domain_size - 1 - i,
+				offset: F::ZERO,
+				s_evals: s_evals_i,
+			})
+			.collect();
+		// The `s_evals` for the $i$th round contains the evaluations of $\hat{W}\_i$ on
+		// $\beta_{i+1},\ldots ,\beta_{d-1}$.
+		Ok(s_evals)
+	}
+}
+
+impl<F, SEvals> TwiddleAccess<F> for OnTheFlyTwiddleAccess<F, SEvals>
+where
+	F: BinaryField,
+	SEvals: Deref<Target = [F]>,
+{
+	#[inline]
+	fn log_n(&self) -> usize {
+		self.log_n
+	}
+
+	fn affine_subspace(&self) -> (BinarySubspace<F>, F) {
+		let subspace = BinarySubspace::new_unchecked(
+			iter::once(F::ONE)
+				.chain(self.s_evals.iter().copied())
+				.collect(),
+		);
+		(subspace, self.offset)
+	}
+
+	#[inline]
+	fn get(&self, i: usize) -> F {
+		self.offset + subset_sum(&self.s_evals, self.log_n, i)
+	}
+
+	#[inline]
+	fn get_pair(&self, index_bits: usize, i: usize) -> (F, F) {
+		let t0 = self.offset + subset_sum(&self.s_evals, index_bits, i);
+		(t0, t0 + self.s_evals[index_bits])
+	}
+
+	#[inline]
+	fn coset(&self, coset_bits: usize, coset: usize) -> impl TwiddleAccess<F> {
+		let log_n = self.log_n - coset_bits;
+		let offset = subset_sum(&self.s_evals[log_n..], coset_bits, coset);
+		OnTheFlyTwiddleAccess {
+			log_n,
+			offset: self.offset + offset,
+			s_evals: &self.s_evals[..log_n],
+		}
+	}
+}
+
+fn subset_sum<F: Field>(values: &[F], n_bits: usize, index: usize) -> F {
+	(0..n_bits)
+		.filter(|b| (index >> b) & 1 != 0)
+		.map(|b| values[b])
+		.sum()
+}
+
+/// Twiddle access method using a larger table of precomputed constants.
+///
+/// This implementation precomputes all $2^k$ twiddle factors for a domain of size $2^k$.
+#[derive(Debug)]
+pub struct PrecomputedTwiddleAccess<F, SEvals = Vec<F>> {
+	log_n: usize,
+	/// If we are implicitly in NTT round i, then `s_evals` contains the evaluations of
+	/// $\hat{W}\_i$ on the entire space $K/U_{i+1}$, where the order is the usual "binary
+	/// counting order" in the basis vectors $\beta_{i+1},\ldots ,\beta_{d-1}$.
+	///
+	/// While $\hat{W}\_i$ is indeed well-defined on $K/U_i$, we have the
+	/// normalization $\hat{W}\_{i}(\beta_i)=1$, hence to specify the function we need
+	/// only specify it on $K/U_{i+1}$, equivalently, the $\mathbb{F}_2$-span of
+	/// $\beta_{i+1},\ldots ,\beta_{d-1}$.
+	s_evals: SEvals,
+	_marker: PhantomData<F>,
+}
+
+impl<F: BinaryField> PrecomputedTwiddleAccess<F> {
+	pub fn generate(subspace: &BinarySubspace<F>) -> Result<Vec<Self>, Error> {
+		let on_the_fly = OnTheFlyTwiddleAccess::generate(subspace)?;
+		Ok(expand_subspace_evals(&on_the_fly))
+	}
+}
+
+impl<F, SEvals> TwiddleAccess<F> for PrecomputedTwiddleAccess<F, SEvals>
+where
+	F: BinaryField,
+	SEvals: Deref<Target = [F]>,
+{
+	#[inline]
+	fn log_n(&self) -> usize {
+		self.log_n
+	}
+
+	fn affine_subspace(&self) -> (BinarySubspace<F>, F) {
+		let shift = self.s_evals[0];
+		let subspace = BinarySubspace::new_unchecked(
+			iter::once(F::ONE)
+				.chain((0..self.log_n()).map(|i| self.s_evals[1 << i] - shift))
+				.collect(),
+		);
+		(subspace, shift)
+	}
+
+	#[inline]
+	fn get(&self, i: usize) -> F {
+		self.s_evals[i]
+	}
+
+	#[inline]
+	fn get_pair(&self, index_bits: usize, i: usize) -> (F, F) {
+		(self.s_evals[i], self.s_evals[1 << index_bits | i])
+	}
+
+	#[inline]
+	fn coset(&self, coset_bits: usize, coset: usize) -> impl TwiddleAccess<F> {
+		let log_n = self.log_n - coset_bits;
+		PrecomputedTwiddleAccess {
+			log_n,
+			s_evals: &self.s_evals[coset << log_n..(coset + 1) << log_n],
+			_marker: PhantomData,
+		}
+	}
+}
+
+/// Precompute the evaluations of the normalized subspace polynomials $\hat{W}_i$ on a basis.
+///
+/// Let $K/\mathbb{F}_2$ be a finite extension of degree $d$, and let $\beta_0,\ldots ,\beta_{d-1}$
+/// be a linear basis, with $\beta_0$ = 1. Let $U_i$ be the $\mathbb{F}_2$-linear span of
+/// $\beta_0,\ldots ,\beta_{i-1}$, so $U_0$ is the zero subspace. Let $\hat{W}\_i(X)$ be the
+/// normalized subspace polynomial of degree $2^i$ that vanishes on $U_i$ and is $1$ on $\beta_i$.
+/// Return a vector whose $i$th entry is a vector of evaluations of $\hat{W}\_i$ at
+/// $\beta_{i+1},\ldots ,\beta_{d-1}$.
+fn precompute_subspace_evals<F: BinaryField>(
+	subspace: &BinarySubspace<F>,
+) -> Result<Vec<Vec<F>>, Error> {
+	let log_domain_size = subspace.dim();
+	if log_domain_size == 0 {
+		bail!(Error::DomainTooSmall {
+			log_required_domain_size: 1,
+		});
+	}
+	if subspace.basis()[0] != F::ONE {
+		bail!(Error::DomainMustIncludeOne);
+	}
+
+	let mut s_evals = Vec::with_capacity(log_domain_size);
+
+	// `normalization_consts[i]` = $W\_i(2^i):=  W\_i(\beta_i)$
+	let mut normalization_consts = Vec::with_capacity(log_domain_size);
+	// $\beta_0 = 1$ and $W\_0(X) = X$, so $W\_0(\beta_0) = \beta_0 = 1$
+	normalization_consts.push(F::ONE);
+	//`s0_evals` = $(\beta_1,\ldots ,\beta_{d-1}) = (W\_0(\beta_1), \ldots , W\_0(\beta_{d-1}))$
+	let s0_evals = subspace.basis()[1..].to_vec();
+	s_evals.push(s0_evals);
+	// let $W\_i(X)$ be the *unnormalized* subspace polynomial, i.e., $\prod_{u\in U_{i}}(X-u)$.
+	// Then $W\_{i+1}(X) = W\_i(X)(W\_i(X)+W\_i(\beta_i))$. This crucially uses the "linearity" of
+	// $W\_i(X)$. This fundamental relation allows us to iteratively compute `s_evals` layer by
+	// layer.
+	for _ in 1..log_domain_size {
+		let (norm_const_i, s_i_evals) = {
+			let norm_prev = *normalization_consts
+				.last()
+				.expect("normalization_consts is not empty");
+			let s_prev_evals = s_evals.last().expect("s_evals is not empty");
+			// `norm_prev` = $W\_{i-1}(\beta_{i-1})$
+			// s_prev_evals = $W\_{i-1}(\beta_i),\ldots ,W\_{i-1}(\beta_{d-1})$
+			let norm_const_i = subspace_map(s_prev_evals[0], norm_prev);
+			let s_i_evals = s_prev_evals
+				.iter()
+				.skip(1)
+				.map(|&s_ij_prev| subspace_map(s_ij_prev, norm_prev))
+				.collect::<Vec<_>>();
+			// the two calls to the function subspace_map yield the following:
+			// `norm_const_i` = $W\_{i}(\beta_i)$; and
+			// `s_i_evals` = $W\_{i}(\beta_{i+1}),\ldots ,W\_{i}(\beta_{d-1})$.
+			(norm_const_i, s_i_evals)
+		};
+
+		normalization_consts.push(norm_const_i);
+		s_evals.push(s_i_evals);
+	}
+
+	for (norm_const_i, s_evals_i) in normalization_consts.iter().zip(s_evals.iter_mut()) {
+		let inv_norm_const = norm_const_i
+			.invert()
+			.expect("normalization constants are nonzero");
+		// replace all terms $W\_{i}(\beta_j)$ with $W\_{i}(\beta_j)/W\_{i}(\beta_i)$
+		// to obtain the evaluations of the *normalized* subspace polynomials.
+		for s_ij in s_evals_i.iter_mut() {
+			*s_ij *= inv_norm_const;
+		}
+	}
+
+	Ok(s_evals)
+}
+
+/// Computes the function $(e,c)\mapsto e^2+ce$.
+///
+/// This is primarily used to compute $W\_{i+1}(X)$ from $W\_i(X)$ in the binary field setting.
+fn subspace_map<F: Field>(elem: F, constant: F) -> F {
+	elem.square() + constant * elem
+}
+
+/// Given `OnTheFlyTwiddleAccess` instances for each NTT round, returns a vector of
+/// `PrecomputedTwiddleAccess` objects, one for each NTT round.
+///
+/// For each round $i$, the input contains the value of $\hat{W}\_i$ on the basis
+/// $\beta_{i+1},\ldots ,\beta_{d-1}$. The ith element of the output contains the evaluations of
+/// $\hat{W}\_i$ on the entire space $K/U_{i+1}$, where the order is the usual "binary counting
+/// order" in $\beta_{i+1},\ldots ,\beta_{d-1}$. While $\hat{W}\_i$ is well-defined on $K/U_i$, we
+/// have the normalization $\hat{W}\_{i}(\beta_i)=1$, hence to specify the function we need only
+/// specify it on $K/U_{i+1}$.
+pub fn expand_subspace_evals<F, SEvals>(
+	on_the_fly: &[OnTheFlyTwiddleAccess<F, SEvals>],
+) -> Vec<PrecomputedTwiddleAccess<F>>
+where
+	F: BinaryField,
+	SEvals: Deref<Target = [F]>,
+{
+	let log_domain_size = on_the_fly.len();
+	on_the_fly
+		.iter()
+		.enumerate()
+		.map(|(i, on_the_fly_i)| {
+			let s_evals_i = &on_the_fly_i.s_evals;
+
+			let mut expanded = Vec::with_capacity(1 << s_evals_i.len());
+			expanded.push(F::ZERO);
+			for &eval in s_evals_i.iter() {
+				for i in 0..expanded.len() {
+					expanded.push(expanded[i] + eval);
+				}
+			}
+
+			PrecomputedTwiddleAccess {
+				log_n: log_domain_size - 1 - i,
+				s_evals: expanded,
+				_marker: PhantomData,
+			}
+		})
+		.collect()
+}
+
+#[cfg(test)]
+mod tests {
+	use binius_field::{BinaryField, BinaryField8b, BinaryField16b, BinaryField32b};
+	use lazy_static::lazy_static;
+	use proptest::prelude::*;
+
+	use super::*;
+
+	lazy_static! {
+		// Precomputed and OnTheFlytwiddle access objects for various binary field sizes.
+		// We avoided doing the 32B precomputed twiddle access because the tests take too long.
+		static ref PRECOMPUTED_TWIDDLE_ACCESS_8B: Vec<PrecomputedTwiddleAccess<BinaryField8b>> =
+			PrecomputedTwiddleAccess::<BinaryField8b>::generate(&BinarySubspace::default()).unwrap();
+
+		static ref OTF_TWIDDLE_ACCESS_8B: Vec<OnTheFlyTwiddleAccess<BinaryField8b>> =
+			OnTheFlyTwiddleAccess::<BinaryField8b>::generate(&BinarySubspace::default()).unwrap();
+
+		static ref PRECOMPUTED_TWIDDLE_ACCESS_16B: Vec<PrecomputedTwiddleAccess<BinaryField16b>> =
+			PrecomputedTwiddleAccess::<BinaryField16b>::generate(&BinarySubspace::default()).unwrap();
+
+		static ref OTF_TWIDDLE_ACCESS_16B: Vec<OnTheFlyTwiddleAccess<BinaryField16b>> =
+			OnTheFlyTwiddleAccess::<BinaryField16b>::generate(&BinarySubspace::default()).unwrap();
+
+		static ref OTF_TWIDDLE_ACCESS_32B: Vec<OnTheFlyTwiddleAccess<BinaryField32b>> =
+			OnTheFlyTwiddleAccess::<BinaryField32b>::generate(&BinarySubspace::default()).unwrap();
+	}
+
+	// Tests that `PrecomputedTwiddleAccess` and `OnTheFlyTwiddleAccess`is linear.
+	// (This is more or less by design/construction for `PrecomputedTwiddleAccess`.)
+	// More concretely: picks a `layer`, $\ell$, and two valid indices,
+	// checks if the claimed equality holds: $\hat{W}_{\ell}(x) + \hat{W}_{\ell}(y) =
+	// \hat{W}_{\ell}(x + y).$
+	proptest! {
+		#[test]
+		fn test_linearity_precomputed_8b((x, y, layer) in generate_layer_and_indices(8)) {
+			let twiddle_access = &PRECOMPUTED_TWIDDLE_ACCESS_8B[layer];
+			test_linearity::<BinaryField8b, _>(twiddle_access, x, y);
+		}
+
+		#[test]
+		fn test_linearity_precomputed_16b((x, y, layer) in generate_layer_and_indices(16)) {
+			let twiddle_access = &PRECOMPUTED_TWIDDLE_ACCESS_16B[layer];
+			test_linearity::<BinaryField16b, _>(twiddle_access, x, y);
+		}
+
+		#[test]
+		fn test_linearity_otf_8b((x, y, layer) in generate_layer_and_indices(8)) {
+			let twiddle_access = &OTF_TWIDDLE_ACCESS_8B[layer];
+			test_linearity::<BinaryField8b, _>(twiddle_access, x, y);
+		}
+
+		#[test]
+		fn test_linearity_otf_16b((x, y, layer) in generate_layer_and_indices(16)) {
+			let twiddle_access = &OTF_TWIDDLE_ACCESS_16B[layer];
+			test_linearity::<BinaryField16b, _>(twiddle_access, x, y);
+		}
+
+		#[test]
+		fn test_linearity_otf_32b((x, y, layer) in generate_layer_and_indices(32)) {
+			let twiddle_access = &OTF_TWIDDLE_ACCESS_32B[layer];
+			test_linearity::<BinaryField32b, _>(twiddle_access, x, y);
+		}
+
+	}
+
+	// Test compatibility between layers for a `TwiddleAccess` object. More precisely,
+	// this checks that the values of $\hat{W}_{\ell}$ and $\hat{W}_{\ell+1}$ are compatible.
+	proptest! {
+		#[test]
+		fn test_compatibility_otf_8b((x, layer) in generate_layer_and_index(8)){
+			compatibility_between_layers::<BinaryField8b,_>(layer, &OTF_TWIDDLE_ACCESS_8B, x);
+		}
+
+		#[test]
+		fn test_compatibility_otf_16b((x, layer) in generate_layer_and_index(16)){
+			compatibility_between_layers::<BinaryField16b,_>(layer, &OTF_TWIDDLE_ACCESS_16B, x);
+		}
+
+		#[test]
+		fn test_compatibility_otf_32b((x, layer) in generate_layer_and_index(32)){
+			compatibility_between_layers::<BinaryField32b,_>(layer, &OTF_TWIDDLE_ACCESS_32B, x);
+		}
+
+		#[test]
+		fn test_compatibility_precomputed_8b((x, layer) in generate_layer_and_index(8)){
+			compatibility_between_layers::<BinaryField8b,_>(layer, &PRECOMPUTED_TWIDDLE_ACCESS_8B, x);
+		}
+
+		#[test]
+		fn test_compatibility_precomputed_16b((x, layer) in generate_layer_and_index(16)){
+			compatibility_between_layers::<BinaryField16b,_>(layer, &PRECOMPUTED_TWIDDLE_ACCESS_16B, x);
+		}
+
+	}
+
+	prop_compose! {
+		/// Given a `max_layer`, which is implicitly assumed to be the logarithm of the field size,
+		/// generate a layer (between 0 and `max_layer-2`) of the NTT instance,
+		/// such that `layer+1` is a valid layer, and furthermore generate
+		/// a valid index $x$ for `layer+1`.
+		///
+		/// Designed to test for compatibility between layers, hence `layer+1` must also be a valid layer.
+		fn generate_layer_and_index
+			(max_layer: usize)
+			(layer in 0usize..max_layer-1)
+			(x in 0usize..(1 << (max_layer-layer-2)), layer in Just(layer))
+				-> (usize, usize) {
+			(x, layer)
+		}
+	}
+
+	prop_compose! {
+		/// Given a `max_layer`, which is implicitly assumed to be the logarithm of the field size,
+		/// generate a layer (between 0 and `max_layer-1`) of the NTT instance a
+		/// pair of indices $(x, y)$ that are valid for that layer.
+		///
+		/// Designed for testing linearity.
+		fn generate_layer_and_indices
+			(max_layer: usize)
+			(layer in 0usize..max_layer)
+			(x in 0usize..(1 << (max_layer-layer-1)), y in 0usize..1<<(max_layer-layer-1), layer in Just(layer))
+				-> (usize, usize, usize) {
+			(x, y, layer)
+		}
+	}
+
+	/// Given a `TwiddleAccess` object, test linearity, i.e., that:
+	/// $\hat{W}\_{\ell}(x) + \hat{W}\_{\ell}(y) = \hat{W}\_{\ell}(x + y)$.
+	///
+	/// Here, it is important to note that although $x$ and $y$ are `usize`, we consider them
+	/// elements of the $F$ via the binary expansion encoding the coefficients of a basis
+	/// expansion. Then the expression $x+y$ in $F$ corresponds to the bitwise XOR of the
+	/// two `usize` values.
+	fn test_linearity<F: BinaryField + std::fmt::Display, T: TwiddleAccess<F>>(
+		twiddle_access: &T,
+		x: usize,
+		y: usize,
+	) {
+		let first_val = twiddle_access.get(x);
+		let second_val = twiddle_access.get(y);
+		assert_eq!(first_val + second_val, twiddle_access.get(x ^ y));
+	}
+
+	/// Test for compatibility between adjacent layers of a `TwiddleAccess` object.
+	///
+	/// This checks that the values of $\hat{W}\_{\ell}$ and $\hat{W}\_{\ell+1}$ are compatible.
+	/// Set $\tilde{W}\_{\ell+1}(X)=\hat{W}\_{\ell}(X)(\hat{W}\_{\ell}(X)+1)$.
+	/// Then $\hat{W}\_{\ell+1}(X)=\tilde{W}\_{\ell+1}(X)/\tilde{W}\_{\ell+1}(\beta_{\ell+1})$.
+	/// (The above ensures that $\hat{W}\_{\ell+1}$ has the right properties: vanishes in $U_{\ell}$
+	/// and is 1 at $\beta_{\ell+1}$.) This means that knowing $\hat{W}\_{\ell}(x)$ and
+	/// $\hat{W}\_{\ell}(\beta_{\ell+1}$, we can compute $\hat{W}\_{\ell+1}(x)$.
+	fn compatibility_between_layers<F: BinaryField + std::fmt::Display, T: TwiddleAccess<F>>(
+		layer: usize,
+		twiddle_access: &[T],
+		// `index_next_layer` is a valid index for the layer `layer+1`,
+		// i.e., `twiddle_access_next_layer.get(index)` makes sense.
+		index_next_layer: usize,
+	) {
+		let twiddle_access_layer = &twiddle_access[layer];
+		let twiddle_access_next_layer = &twiddle_access[layer + 1];
+		// `index` corresponds to an element of $F/U_{i+1}$. This corresponds to elements
+		// of the space $F/U_i$ whose $\beta_i$ and $\beta_{i+1}$ coordinates are both 0.
+		let index = index_next_layer << 1;
+		// If index corresponds to an element $x$ in $F$.
+		// Claimed value of $\hat{W}_{\ell}(x)$.
+		let w_hat_layer_x = twiddle_access_layer.get(index);
+		// Claimed value of $\hat{W}_{\ell+1}(x)$.
+		let w_hat_next_layer_x = twiddle_access_next_layer.get(index_next_layer);
+		// In the below, `beta` refers to $\beta_{\ell+1}$.
+		// $\hat{W}_{\ell}(\beta_{\ell+1})$.
+		let w_hat_layer_beta = twiddle_access_layer.get(1);
+		// `normalizing_factor` is $\hat{W}_{\ell}(\beta) * (\hat{W}_{\ell}(\beta) + 1)$,
+		// i.e. $\tilde{W}_{\ell+1}(\beta)$.
+		let normalizing_factor = w_hat_layer_beta * w_hat_layer_beta + w_hat_layer_beta;
+		assert_eq!(
+			w_hat_next_layer_x * normalizing_factor,
+			w_hat_layer_x * w_hat_layer_x + w_hat_layer_x
+		);
+	}
+}


### PR DESCRIPTION
I have moved the NTT to a submodule of the `binius-math` crate. This pulls in a couple other math modules that the NTT depends on, like matrix inversion and binary subspaces.