### PR TITLE
[ntt] Broadcast Twiddle

### DIFF
--- a/crates/math/src/ntt/single_threaded.rs
+++ b/crates/math/src/ntt/single_threaded.rs
@@ -207,6 +207,7 @@ pub fn forward_transform<F: BinaryField, P: PackedField<Scalar = F>>(
 			// the same twiddle factor.
 			for k in 0..1 << (log_y - 1 - i) {
 				let twiddle = s_evals_i.get(coset_offset | k);
+				let twiddle = P::broadcast(twiddle);
 				for l in 0..1 << (i + log_x - log_w) {
 					let idx0 = j << (log_x + log_y - log_w) | k << (log_x + i + 1 - log_w) | l;
 					let idx1 = idx0 | 1 << (log_x + i - log_w);
@@ -349,6 +350,7 @@ pub fn inverse_transform<F: BinaryField, P: PackedField<Scalar = F>>(
 			// the same twiddle factor.
 			for k in 0..1 << (log_y - 1 - i) {
 				let twiddle = s_evals_i.get(coset_offset | k);
+				let twiddle = P::broadcast(twiddle);
 				for l in 0..1 << (i + log_x - log_w) {
 					let idx0 = j << (log_x + log_y - log_w) | k << (log_x + i + 1 - log_w) | l;
 					let idx1 = idx0 | 1 << (log_x + i - log_w);


### PR DESCRIPTION
### TL;DR

Optimize NTT performance by broadcasting twiddle factors in single-threaded implementation.

### What changed?

Added `P::broadcast(twiddle)` calls in both the forward and inverse transform functions to convert scalar twiddle factors into packed field elements. This allows the compiler to optimize operations by reusing the broadcasted value rather than repeatedly converting the scalar.

### How to test?

Run the existing NTT tests to verify correctness:
```
cargo test --package math --lib ntt
```

Additionally, benchmark the NTT implementation to confirm performance improvements:
```
cargo bench --package math ntt
```

### Why make this change?

This optimization improves performance by avoiding redundant scalar-to-packed conversions inside the inner loops. By broadcasting the twiddle factor once before entering the inner loop, we eliminate repeated conversions that would otherwise happen implicitly during field operations.