### PR TITLE
[field_buffer] FieldSlice and FieldSliceMut to own single elements

### DIFF
--- a/crates/math/Cargo.toml
+++ b/crates/math/Cargo.toml
@@ -16,6 +16,7 @@ getset.workspace = true
 rand.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
+log = "0.4.27"
 
 [dev-dependencies]
 assert_matches.workspace = true


### PR DESCRIPTION
This modifies the definition of FieldSlice and FieldSliceMut so that they may own single packed elements or a reference. This will allow us to create `split_half` and `split_half_mut` methods in a follow-up.