### PR TITLE
[field_buffer] FieldBuffer::split_half and split_half_mut

### DIFF
--- a/crates/math/src/error.rs
+++ b/crates/math/src/error.rs
@@ -16,4 +16,6 @@ pub enum Error {
 	ArgumentRangeError { arg: String, range: Range<usize> },
 	#[error("buffer length must be a power of two")]
 	PowerOfTwoLengthRequired,
+	#[error("cannot split a buffer of length 1")]
+	CannotSplit,
 }


### PR DESCRIPTION
### TL;DR

Added methods to split `FieldBuffer` in half, enabling divide-and-conquer algorithms.

### What changed?

- Added a new `CannotSplit` error variant to handle cases where a buffer of length 1 cannot be split
- Implemented `split_half()` method to split a `FieldBuffer` into two borrowed slices
- Implemented `split_half_mut()` method to split a mutable `FieldBuffer` and apply a closure to both halves
- Added comprehensive tests for both methods covering various buffer sizes

Both methods handle special cases where:
- The buffer contains multiple packed elements (normal case)
- The buffer contains a single packed element that needs to be split
- The buffer is too small to split (length 1)

### How to test?

The implementation includes extensive tests that verify:
- Splitting buffers larger than `P::WIDTH` (multiple packed elements)
- Splitting buffers equal to `P::WIDTH` (single packed element)
- Splitting buffers smaller than `P::WIDTH` but larger than 1
- Error handling for buffers of size 1
- Proper value preservation and modification through the split halves

Run the tests with:
```
cargo test -p math
```

### Why make this change?

This change enables divide-and-conquer algorithms by providing efficient ways to split field buffers in half. The implementation handles all edge cases, including when a single packed element needs to be split, making it robust for various buffer sizes. This is particularly useful for recursive algorithms that operate on field elements.