### PR TITLE
[merkle_tree] Add binary merkle tree benchmark

### DIFF
--- a/crates/prover/Cargo.toml
+++ b/crates/prover/Cargo.toml
@@ -22,5 +22,10 @@ tracing.workspace = true
 
 [dev-dependencies]
 blake2.workspace = true
+criterion.workspace = true
 itertools.workspace = true
 rand = { workspace = true, features = ["std_rng"] }
+
+[[bench]]
+name = "binary_merkle_tree"
+harness = false

--- a/crates/prover/benches/binary_merkle_tree.rs
+++ b/crates/prover/benches/binary_merkle_tree.rs
@@ -1,0 +1,48 @@
+// Copyright 2025 Irreducible Inc.
+
+use std::iter::repeat_with;
+
+use binius_field::Field;
+use binius_prover::merkle_tree::{MerkleTreeProver, prover::BinaryMerkleTreeProver};
+use binius_verifier::{
+	fields::B64,
+	hash::{StdCompression, StdDigest},
+};
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use digest::{FixedOutputReset, Output, core_api::BlockSizeUser};
+
+const LOG_ELEMS: usize = 17;
+const LOG_ELEMS_IN_LEAF: usize = 5;
+
+type F = B64;
+
+fn bench_binary_merkle_tree<H, C>(c: &mut Criterion, compression: C, hash_name: &str)
+where
+	H: binius_prover::hash::ParallelDigest<Digest: BlockSizeUser + FixedOutputReset>,
+	C: binius_verifier::hash::PseudoCompressionFunction<Output<H::Digest>, 2> + Sync,
+{
+	let merkle_prover = BinaryMerkleTreeProver::<_, H, C>::new(compression);
+	let mut rng = rand::rng();
+	let data: Vec<F> = repeat_with(|| Field::random(&mut rng))
+		.take(1 << (LOG_ELEMS + LOG_ELEMS_IN_LEAF))
+		.collect();
+	let mut group = c.benchmark_group(format!("slow/merkle_tree/{hash_name}"));
+	group.throughput(Throughput::Bytes(
+		((1 << (LOG_ELEMS + LOG_ELEMS_IN_LEAF)) * std::mem::size_of::<F>()) as u64,
+	));
+	group.sample_size(10);
+	group.bench_function(
+		format!("{} log elems size {}xB64 leaf", LOG_ELEMS, 1 << LOG_ELEMS_IN_LEAF),
+		|b| {
+			b.iter(|| merkle_prover.commit(&data, 1 << LOG_ELEMS_IN_LEAF));
+		},
+	);
+	group.finish()
+}
+
+fn bench_sha256_merkle_tree(c: &mut Criterion) {
+	bench_binary_merkle_tree::<StdDigest, _>(c, StdCompression::default(), "SHA-256");
+}
+
+criterion_group!(binary_merkle_tree, bench_sha256_merkle_tree);
+criterion_main!(binary_merkle_tree);


### PR DESCRIPTION
This PR adds a benchmark (copied from binius binary_merkle_tree.rs and adapted to use SHA-256) for binary merkle tree operations. 

```
cargo bench --bench binary_merkle_tree
    Finished `bench` profile [optimized + debuginfo] target(s) in 0.19s
     Running benches/binary_merkle_tree.rs (target/release/deps/binary_merkle_tree-1b29417923ee65c7)
Gnuplot not found, using plotters backend
Benchmarking slow/merkle_tree/SHA-256/17 log elems size 16xBinaryField128b leaf: Collecting 10 samples in estimated 
slow/merkle_tree/SHA-256/17 log elems size 16xBinaryField128b leaf
                        time:   [18.007 ms 18.498 ms 18.906 ms]
                        thrpt:  [1.6529 GiB/s 1.6893 GiB/s 1.7355 GiB/s]
                 change:
                        time:   [−25.883% −19.820% −13.047%] (p = 0.00 < 0.05)
                        thrpt:  [+15.005% +24.719% +34.922%]
                        Performance has improved.
```

```
echo "Model: $(sysctl -n hw.model), CPU: $(sysctl -n machdep.cpu.brand_string), RAM: $(($(sysctl -n hw.memsize)/1024/1024/1024)) GB, macOS: $(sw_vers -productVersion) ($(sw_vers -buildVersion))" 

Model: Mac14,9, CPU: Apple M2 Pro, RAM: 32 GB, macOS: 15.5 (24F74)
```