### PR TITLE
[frontend] fix rustdoc for hex module

### DIFF
--- a/crates/frontend/src/circuits/hex.rs
+++ b/crates/frontend/src/circuits/hex.rs
@@ -27,10 +27,11 @@ fn ascii_to_nibble(b: &CircuitBuilder, ch: Wire) -> Wire {
 }
 
 /// Verify that `encoded` is the uppercase hex representation of `decode`.
-///     decoded: Vec<Wire> each wire contains one data byte to encode.
-///     encoded: Vec<Wire> each wire contains one ASCII character code.
 ///
-///     The number of encoded writes must equal twice the number of decoded wires.
+/// decoded: Vec<Wire> each wire contains one data byte to encode.
+/// encoded: Vec<Wire> each wire contains one ASCII character code.
+///
+/// The number of encoded writes must equal twice the number of decoded wires.
 pub struct HexDecode {
 	pub decoded: Vec<Wire>,
 	pub encoded: Vec<Wire>,


### PR DESCRIPTION
The problem here was that rustdoc treats indented comments the same as code in triple backticks. This lead to breaking the rustdoc tests.
