### PR TITLE
[frontend] named assert failures

### DIFF
--- a/crates/frontend/src/circuits/base64.rs
+++ b/crates/frontend/src/circuits/base64.rs
@@ -58,7 +58,7 @@ impl<const N: usize, const EN: usize> Base64<N, EN> {
 		// Ensure len <= N
 		let over = gt_const(b, len, N as u32);
 		let zero = b.add_constant(Word::ZERO);
-		b.assert_eq(over, zero);
+		b.assert_eq("overflow", over, zero);
 
 		let eq_char = b.add_constant(Word('=' as u64));
 		let mask_0f = b.add_constant(Word(0x0F));
@@ -81,9 +81,21 @@ impl<const N: usize, const EN: usize> Base64<N, EN> {
 
 			// Padding checks
 			let need_pad2 = b.band(cond_block, bool_not(b, cond_b1));
-			assert_eq_cond(b, encoded[i_enc + 2], eq_char, need_pad2);
+			assert_eq_cond(
+				b,
+				format!("encoded+2[{i_enc}]"),
+				encoded[i_enc + 2],
+				eq_char,
+				need_pad2,
+			);
 			let need_pad3 = b.band(cond_block, bool_not(b, cond_b2));
-			assert_eq_cond(b, encoded[i_enc + 3], eq_char, need_pad3);
+			assert_eq_cond(
+				b,
+				format!("encoded+3[{i_enc}]"),
+				encoded[i_enc + 3],
+				eq_char,
+				need_pad3,
+			);
 
 			// byte0 = (c0 << 2) | (c1 >> 4)
 			let c0_shl = shl_const(b, c0, 2);
@@ -103,13 +115,25 @@ impl<const N: usize, const EN: usize> Base64<N, EN> {
 
 			// Assert decoded bytes
 			if i_dec < N {
-				assert_eq_cond(b, decoded[i_dec], byte0, cond_block);
+				assert_eq_cond(b, format!("decoded+0[{i_dec}]"), decoded[i_dec], byte0, cond_block);
 			}
 			if i_dec + 1 < N {
-				assert_eq_cond(b, decoded[i_dec + 1], byte1, cond_b1);
+				assert_eq_cond(
+					b,
+					format!("decoded+1[{}]", i_dec + 1),
+					decoded[i_dec + 1],
+					byte1,
+					cond_b1,
+				);
 			}
 			if i_dec + 2 < N {
-				assert_eq_cond(b, decoded[i_dec + 2], byte2, cond_b2);
+				assert_eq_cond(
+					b,
+					format!("decoded+2[{}]", i_dec + 2),
+					decoded[i_dec + 2],
+					byte2,
+					cond_b2,
+				);
 			}
 		}
 

--- a/crates/frontend/src/circuits/basic.rs
+++ b/crates/frontend/src/circuits/basic.rs
@@ -22,12 +22,12 @@ pub fn bool_not(b: &CircuitBuilder, x: Wire) -> Wire {
 ///
 /// When `cond` is one, asserts that `x == y`.  When `cond` is zero, no
 /// constraint is emitted on `x` and `y`.
-pub fn assert_eq_cond(b: &CircuitBuilder, x: Wire, y: Wire, cond: Wire) {
+pub fn assert_eq_cond(b: &CircuitBuilder, name: impl Into<String>, x: Wire, y: Wire, cond: Wire) {
 	let diff = b.bxor(x, y);
 	let mask = bool_to_mask(b, cond);
 	let masked = b.band(diff, mask);
 	let zero = b.add_constant(Word::ZERO);
-	b.assert_eq(masked, zero);
+	b.assert_eq(name, masked, zero);
 }
 
 /// Select between two wires depending on a boolean condition.

--- a/crates/frontend/src/circuits/eqbool.rs
+++ b/crates/frontend/src/circuits/eqbool.rs
@@ -25,7 +25,7 @@ impl EqBool {
 		// !neq = 1 if diff == 0 else 0
 		let eq_val = bool_not(builder, neq);
 
-		builder.assert_eq(eq_val, out);
+		builder.assert_eq("eq", eq_val, out);
 		EqBool { x, y, out }
 	}
 }

--- a/crates/frontend/src/circuits/hex.rs
+++ b/crates/frontend/src/circuits/hex.rs
@@ -57,7 +57,7 @@ impl HexDecode {
 			let hi_shl = shl_const(b, hi, 4);
 			let expected_decoded_byte = b.bor(hi_shl, lo);
 			let actual_decoded_byte = decoded[i];
-			b.assert_eq(actual_decoded_byte, expected_decoded_byte);
+			b.assert_eq(format!("{i}"), actual_decoded_byte, expected_decoded_byte);
 		}
 
 		HexDecode { decoded, encoded }

--- a/crates/frontend/src/circuits/sha256.rs
+++ b/crates/frontend/src/circuits/sha256.rs
@@ -231,8 +231,12 @@ mod tests {
 
 		// Mask to only low 32-bit.
 		let mask32 = circuit.add_constant(Word::MASK_32);
-		for (actual_x, expected_x) in compress.state_out.0.iter().zip(output) {
-			circuit.assert_eq(circuit.band(*actual_x, mask32), expected_x);
+		for (i, (actual_x, expected_x)) in compress.state_out.0.iter().zip(output).enumerate() {
+			circuit.assert_eq(
+				format!("preimage_eq[{i}]"),
+				circuit.band(*actual_x, mask32),
+				expected_x,
+			);
 		}
 
 		let circuit = circuit.build();

--- a/crates/frontend/src/compiler/gate.rs
+++ b/crates/frontend/src/compiler/gate.rs
@@ -230,20 +230,24 @@ impl Gate for Rotr32 {
 }
 
 pub struct AssertEq {
+	pub name: String,
 	pub x: Wire,
 	pub y: Wire,
 }
 
 impl AssertEq {
-	pub fn new(x: Wire, y: Wire) -> Self {
-		Self { x, y }
+	pub fn new(name: String, x: Wire, y: Wire) -> Self {
+		Self { name, x, y }
 	}
 }
 
 impl Gate for AssertEq {
 	fn populate_wire_witness(&self, w: &mut WitnessFiller) {
 		if w[self.x] != w[self.y] {
-			w.flag_assertion_failed();
+			w.flag_assertion_failed(format!(
+				"{} failed: {:?} != {:?}",
+				self.name, w[self.x], w[self.y]
+			));
 		}
 	}
 
@@ -260,12 +264,13 @@ impl Gate for AssertEq {
 pub struct Assert0 {
 	pub a: Wire,
 	pub all_1: Wire,
+	pub name: String,
 }
 
 impl Assert0 {
-	pub fn new(builder: &CircuitBuilder, a: Wire) -> Self {
+	pub fn new(builder: &CircuitBuilder, name: String, a: Wire) -> Self {
 		let all_1 = builder.add_constant(Word::ALL_ONE);
-		Self { a, all_1 }
+		Self { name, a, all_1 }
 	}
 }
 
@@ -273,7 +278,7 @@ impl Gate for Assert0 {
 	fn populate_wire_witness(&self, w: &mut WitnessFiller) {
 		// The constraint is: a & ALL_1 = 0, which means a must be 0
 		if w[self.a] != Word::ZERO {
-			w.flag_assertion_failed();
+			w.flag_assertion_failed(format!("{} failed: {:?} != ZERO", self.name, self.a));
 		}
 	}
 

--- a/crates/prover/tests/prove_verify.rs
+++ b/crates/prover/tests/prove_verify.rs
@@ -34,7 +34,7 @@ fn test_prove_verify_sha256_preimage() {
 	// Mask to only low 32-bit.
 	let mask32 = circuit.add_constant(Word::MASK_32);
 	for (actual_x, expected_x) in compress.state_out.0.iter().zip(output) {
-		circuit.assert_eq(circuit.band(*actual_x, mask32), expected_x);
+		circuit.assert_eq("eq", circuit.band(*actual_x, mask32), expected_x);
 	}
 
 	let circuit = circuit.build();


### PR DESCRIPTION
This requires naming each and every assert. It might be boring but it's imensely
helpful when debugging.

Example below.

    .word[7].w15_zero failed: Word(0x0000000000000018) != Word(0x0000000000000000)
    .word[15].w15_len failed: Word(0x0000000000000000) != Word(0x0000000000000018)