### PR TITLE
[frontend] populate wire witness returns an error

### DIFF
--- a/crates/frontend/src/circuits/base64.rs
+++ b/crates/frontend/src/circuits/base64.rs
@@ -176,7 +176,7 @@ mod tests {
 			}
 			w[len_wire] = Word(len as u64);
 
-			circuit.populate_wire_witness(&mut w);
+			circuit.populate_wire_witness(&mut w).unwrap();
 		}
 	}
 }

--- a/crates/frontend/src/circuits/eqbool.rs
+++ b/crates/frontend/src/circuits/eqbool.rs
@@ -46,7 +46,7 @@ mod tests {
 		w[y] = Word(0x1234);
 		w[out] = Word(1);
 
-		circuit.populate_wire_witness(&mut w);
+		circuit.populate_wire_witness(&mut w).unwrap();
 	}
 
 	#[test]
@@ -60,11 +60,10 @@ mod tests {
 		w[y] = Word(0x1235);
 		w[out] = Word(0);
 
-		circuit.populate_wire_witness(&mut w);
+		circuit.populate_wire_witness(&mut w).unwrap();
 	}
 
 	#[test]
-	#[should_panic]
 	fn fail_if_out_wrong() {
 		let mut b = CircuitBuilder::new();
 		let EqBool { x, y, out } = EqBool::new(&mut b);
@@ -75,6 +74,7 @@ mod tests {
 		w[y] = Word(0x1234);
 		w[out] = Word(0);
 
-		circuit.populate_wire_witness(&mut w);
+		let result = circuit.populate_wire_witness(&mut w);
+		assert!(result.is_err());
 	}
 }

--- a/crates/frontend/src/circuits/hex.rs
+++ b/crates/frontend/src/circuits/hex.rs
@@ -117,6 +117,6 @@ mod tests {
 		hex_decode.populate_decoded(&mut w, &decoded_bytes);
 		hex_decode.populate_encoded(&mut w, encoded_bytes.as_bytes());
 
-		circuit.populate_wire_witness(&mut w);
+		circuit.populate_wire_witness(&mut w).unwrap();
 	}
 }

--- a/crates/frontend/src/circuits/sha256/compress.rs
+++ b/crates/frontend/src/circuits/sha256/compress.rs
@@ -249,7 +249,7 @@ mod tests {
 		for (i, &output) in output.iter().enumerate() {
 			w[output] = Word(expected_state[i] as u64);
 		}
-		circuit.populate_wire_witness(&mut w);
+		circuit.populate_wire_witness(&mut w).unwrap();
 
 		println!("Number of AND constraints: {}", cs.n_and_constraints());
 		println!("Number of gates: {}", circuit.n_gates());
@@ -296,7 +296,7 @@ mod tests {
 		for compress in &compress_vec {
 			compress.populate_m(&mut w, [0; 64]);
 		}
-		circuit.populate_wire_witness(&mut w);
+		circuit.populate_wire_witness(&mut w).unwrap();
 
 		println!("Number of AND constraints: {}", cs.n_and_constraints());
 		println!("Number of gates: {}", circuit.n_gates());
@@ -332,7 +332,7 @@ mod tests {
 		for compress in &compress_vec {
 			compress.populate_m(&mut w, [0; 64]);
 		}
-		circuit.populate_wire_witness(&mut w);
+		circuit.populate_wire_witness(&mut w).unwrap();
 
 		println!("Number of AND constraints: {}", cs.n_and_constraints());
 		println!("Number of gates: {}", circuit.n_gates());

--- a/crates/prover/tests/prove_verify.rs
+++ b/crates/prover/tests/prove_verify.rs
@@ -46,7 +46,7 @@ fn test_prove_verify_sha256_preimage() {
 	for (i, &output) in output.iter().enumerate() {
 		w[output] = Word(expected_state[i] as u64);
 	}
-	circuit.populate_wire_witness(&mut w);
+	circuit.populate_wire_witness(&mut w).unwrap();
 
 	let cs = circuit.constraint_system();
 	println!("Number of AND constraints: {}", cs.n_and_constraints());


### PR DESCRIPTION
It's more convenient to write tests and the user might handle the error more
gracefully in a production environment.