### PR TITLE
Fixes doc comments so that the docs build

### DIFF
--- a/crates/field/src/arch/x86_64/m128.rs
+++ b/crates/field/src/arch/x86_64/m128.rs
@@ -226,7 +226,7 @@ pub(crate) const fn max_i32(left: i32, right: i32) -> i32 {
 /// This solution shows 4X better performance.
 /// We have to use macro because parameter `count` in _mm_slli_epi64/_mm_srli_epi64 should be passed
 /// as constant and Rust currently doesn't allow passing expressions (`count - 64`) where variable
-/// is a generic constant parameter. Source: https://stackoverflow.com/questions/34478328/the-best-way-to-shift-a-m128i/34482688#34482688
+/// is a generic constant parameter. Source: <https://stackoverflow.com/questions/34478328/the-best-way-to-shift-a-m128i/34482688#34482688>
 macro_rules! bitshift_128b {
 	($val:expr, $shift:ident, $byte_shift:ident, $bit_shift_64:ident, $bit_shift_64_opposite:ident, $or:ident) => {
 		unsafe {

--- a/crates/frontend/src/circuits/hex.rs
+++ b/crates/frontend/src/circuits/hex.rs
@@ -28,8 +28,8 @@ fn ascii_to_nibble(b: &CircuitBuilder, ch: Wire) -> Wire {
 
 /// Verify that `encoded` is the uppercase hex representation of `decode`.
 ///
-/// decoded: Vec<Wire> each wire contains one data byte to encode.
-/// encoded: Vec<Wire> each wire contains one ASCII character code.
+/// decoded: `Vec<Wire>` each wire contains one data byte to encode.
+/// encoded: `Vec<Wire>` each wire contains one ASCII character code.
 ///
 /// The number of encoded writes must equal twice the number of decoded wires.
 pub struct HexDecode {

--- a/crates/frontend/src/compiler/mod.rs
+++ b/crates/frontend/src/compiler/mod.rs
@@ -337,7 +337,7 @@ impl CircuitBuilder {
 	///
 	/// Asserts that two arrays of 64-bit wires are equal element-wise.
 	///
-	/// Takes wire arrays x and y and enforces x[i] == y[i] for all i.
+	/// Takes wire arrays x and y and enforces `x[i] == y[i]` for all `i`.
 	/// Each element assertion is named with the base name and index.
 	///
 	/// # Cost

--- a/crates/math/src/reed_solomon.rs
+++ b/crates/math/src/reed_solomon.rs
@@ -19,7 +19,7 @@ use super::{
 /// The Reed–Solomon code admits an efficient encoding algorithm over binary fields due to [LCH14].
 /// The additive NTT encoding algorithm encodes messages interpreted as the coefficients of a
 /// polynomial in a non-standard, novel polynomial basis and the codewords are the polynomial
-/// evaluations over a linear subspace of the field. See the [binius_ntt] crate for more details.
+/// evaluations over a linear subspace of the field. See the [binius-math] crate for more details.
 ///
 /// [Reed–Solomon]: <https://en.wikipedia.org/wiki/Reed%E2%80%93Solomon_error_correction>
 /// [LCH14]: <https://arxiv.org/abs/1404.3458>


### PR DESCRIPTION
Fixes some doc comments so that `cargo doc --no-deps` builds.