### PR TITLE
Add IaddCinCout gate

### DIFF
--- a/crates/frontend/Cargo.toml
+++ b/crates/frontend/Cargo.toml
@@ -12,3 +12,5 @@ workspace = true
 [dev-dependencies]
 base64 = "0.21"
 hex = "0.4.3"
+quickcheck = "1.0"
+quickcheck_macros = "1.0"

--- a/crates/frontend/src/compiler/mod.rs
+++ b/crates/frontend/src/compiler/mod.rs
@@ -7,7 +7,7 @@ use std::{
 
 use gate::{
 	Assert0, AssertBand0, AssertEq, AssertEqCond, Band, Bor, Bxor, ExtractByte, Gate, Iadd32,
-	IcmpEq, IcmpUlt, Imul, Rotr32, Shl, Shr, Shr32,
+	IaddCinCout, IcmpEq, IcmpUlt, Imul, Rotr32, Shl, Shr, Shr32,
 };
 
 use crate::{
@@ -270,6 +270,24 @@ impl CircuitBuilder {
 		let out = gate.c;
 		self.emit(gate);
 		out
+	}
+
+	/// 64-bit addition with carry input and output.
+	///
+	/// Performs full 64-bit unsigned addition of two wires plus a carry input.
+	///
+	/// Returns (sum, carry_out) where sum is the 64-bit result and carry_out
+	/// indicates overflow.
+	///
+	/// # Cost
+	///
+	/// 2 AND constraints.
+	pub fn iadd_cin_cout(&self, a: Wire, b: Wire, cin: Wire) -> (Wire, Wire) {
+		let gate = IaddCinCout::new(self, a, b, cin);
+		let sum = gate.sum;
+		let cout = gate.cout;
+		self.emit(gate);
+		(sum, cout)
 	}
 
 	pub fn rotr_32(&self, a: Wire, n: u32) -> Wire {

--- a/crates/frontend/src/word.rs
+++ b/crates/frontend/src/word.rs
@@ -68,6 +68,16 @@ impl Word {
 		(Word(sum), Word(cout))
 	}
 
+	/// Performs 64-bit addition with carry input bit.
+	/// Returns (sum, carry_word) where carry_word encodes all carry positions.
+	pub fn iadd_cin_cout(self, rhs: Word, cin: u64) -> (Word, Word) {
+		let Word(lhs) = self;
+		let Word(rhs) = rhs;
+		let sum = lhs.wrapping_add(rhs).wrapping_add(cin);
+		let cout = (lhs & rhs) | ((lhs ^ rhs) & !sum);
+		(Word(sum), Word(cout))
+	}
+
 	pub fn shr_32(self, n: u32) -> Word {
 		let Word(value) = self;
 		// Shift right logically by n bits and mask with 32-bit mask


### PR DESCRIPTION
This PR adds an IaddCinCout gate for performing 64bit unsigned addition with carry propagation.

This is similar to Iadd32 but also supports cin (carry_in) and cout (carry_out)  wires that will be used for performing a chain of additions to compute the sum of two big integers consisting of several unsigned 64bit limbs.