### PR TITLE
[frontend] Fix constraints in IcmpUlt

### DIFF
--- a/crates/frontend/src/compiler/mod.rs
+++ b/crates/frontend/src/compiler/mod.rs
@@ -430,7 +430,7 @@ impl CircuitBuilder {
 	///
 	/// # Cost
 	///
-	/// 3 AND constraints.
+	/// 4 AND constraints.
 	pub fn icmp_ult(&self, a: Wire, b: Wire) -> Wire {
 		let gate = IcmpUlt::new(self, a, b);
 		let out = gate.result;


### PR DESCRIPTION
I added constraint_verification tests for IcmpUlt and these failed. So this PR is an attempt to fix the issue.

The test failed with inputs a=0 and a=1 in the full-adder borrow relation. I am not 100% sure what the issue is with this check but I think it has something to do with hardcoding the carry_in wire to 1 in the constraint.

With this change I do the computation of the `a - b = a + (~b) + 1` using the same approach as the `IaddCinCout` gate which has the correct borrow (or equivalently carry propagation check). This makes the constraint verification tests pass.

Unfortunately, this adds an extra AND constraint to this gate as we need  not_b as a wire to and so the relation `not_b = b ^ all_1` needs to be checked. Perhaps we can have a variation of the `IaddCinCout` circuit constraints where this can be improved.
