### PR TITLE
[frontend] Fix constraints in AssertEq gate

### DIFF
--- a/crates/frontend/src/compiler/gate.rs
+++ b/crates/frontend/src/compiler/gate.rs
@@ -338,11 +338,13 @@ pub struct AssertEq {
 	pub name: String,
 	pub x: Wire,
 	pub y: Wire,
+	all_1: Wire,
 }
 
 impl AssertEq {
-	pub fn new(name: String, x: Wire, y: Wire) -> Self {
-		Self { name, x, y }
+	pub fn new(builder: &CircuitBuilder, name: String, x: Wire, y: Wire) -> Self {
+		let all_1 = builder.add_constant(Word::ALL_ONE);
+		Self { name, x, y, all_1 }
 	}
 }
 
@@ -359,8 +361,8 @@ impl Gate for AssertEq {
 	fn constrain(&self, circuit: &Circuit, cs: &mut ConstraintSystem) {
 		let x = circuit.witness_index(self.x);
 		let y = circuit.witness_index(self.y);
-
-		cs.add_and_constraint(AndConstraint::plain_abc([x], [], [y]));
+		let all_1 = circuit.witness_index(self.all_1);
+		cs.add_and_constraint(AndConstraint::plain_abc([x, y], [all_1], []));
 	}
 }
 

--- a/crates/frontend/src/compiler/mod.rs
+++ b/crates/frontend/src/compiler/mod.rs
@@ -348,7 +348,7 @@ impl CircuitBuilder {
 	/// 1 AND constraint.
 	pub fn assert_eq(&self, name: impl Into<String>, x: Wire, y: Wire) {
 		let name = self.namespaced(name.into());
-		self.emit(AssertEq::new(name, x, y))
+		self.emit(AssertEq::new(self, name, x, y))
 	}
 
 	/// Vector equality assertion.


### PR DESCRIPTION
The existing AssertEq constraint failed when tested with the verification checker.

The new constraints are suggested by the circuit_design docs:

https://github.com/IrreducibleOSS/monbijou/blob/e5eb6494ea5d0fb0382cae627f6cc44418047b64/docs/frontend/circuit_design.md?plain=1#L112

`x == y` is encoded as `(x^y) & (all‑1) = 0`