### PR TITLE
[fri] Copies FRI verifier code

### DIFF
--- a/crates/transcript/src/transcript.rs
+++ b/crates/transcript/src/transcript.rs
@@ -113,6 +113,15 @@ where
 	}
 }
 
+impl<Challenger_> CanSampleBits<u32> for VerifierTranscript<Challenger_>
+where
+	Challenger_: Challenger,
+{
+	fn sample_bits(&mut self, bits: usize) -> u32 {
+		sample_bits_reader(self.combined.challenger.sampler(), bits)
+	}
+}
+
 pub struct TranscriptReader<'a, B: Buf> {
 	buffer: &'a mut B,
 	debug_assertions: bool,

--- a/crates/verifier/Cargo.toml
+++ b/crates/verifier/Cargo.toml
@@ -10,12 +10,16 @@ workspace = true
 [dependencies]
 binius-field = { path = "../field" }
 binius-frontend = { path = "../frontend" }
+binius-math = { path = "../math" }
 binius-transcript = { path = "../transcript" }
 binius-utils = { path = "../utils" }
-blake2.workspace = true
 bytemuck.workspace = true
 bytes.workspace = true
 digest.workspace = true
 getset.workspace = true
+itertools.workspace = true
 sha2 = { workspace = true, features = ["compress"] }
 thiserror.workspace = true
+
+[dev-dependencies]
+assert_matches.workspace = true

--- a/crates/verifier/src/fri/common.rs
+++ b/crates/verifier/src/fri/common.rs
@@ -1,0 +1,298 @@
+// Copyright 2024-2025 Irreducible Inc.
+
+use std::marker::PhantomData;
+
+use binius_field::{BinaryField, ExtensionField};
+use binius_math::{ntt::AdditiveNTT, reed_solomon::ReedSolomonCode};
+use binius_utils::{bail, checked_arithmetics::log2_ceil_usize};
+use getset::{CopyGetters, Getters};
+
+use super::error::Error;
+use crate::merkle_tree::MerkleTreeScheme;
+
+/// Parameters for an FRI interleaved code proximity protocol.
+#[derive(Debug, Getters, CopyGetters)]
+pub struct FRIParams<F, FA>
+where
+	F: BinaryField,
+	FA: BinaryField,
+{
+	/// The Reed-Solomon code the verifier is testing proximity to.
+	#[getset(get = "pub")]
+	rs_code: ReedSolomonCode<FA>,
+	/// Vector commitment scheme for the codeword oracle.
+	#[getset(get_copy = "pub")]
+	log_batch_size: usize,
+	/// The reduction arities between each oracle sent to the verifier.
+	fold_arities: Vec<usize>,
+	/// The number oracle consistency queries required during the query phase.
+	#[getset(get_copy = "pub")]
+	n_test_queries: usize,
+	_marker: PhantomData<F>,
+}
+
+impl<F, FA> FRIParams<F, FA>
+where
+	F: BinaryField + ExtensionField<FA>,
+	FA: BinaryField,
+{
+	pub fn new(
+		rs_code: ReedSolomonCode<FA>,
+		log_batch_size: usize,
+		fold_arities: Vec<usize>,
+		n_test_queries: usize,
+	) -> Result<Self, Error> {
+		if fold_arities.iter().sum::<usize>() >= rs_code.log_dim() + log_batch_size {
+			bail!(Error::InvalidFoldAritySequence)
+		}
+
+		Ok(Self {
+			rs_code,
+			log_batch_size,
+			fold_arities,
+			n_test_queries,
+			_marker: PhantomData,
+		})
+	}
+
+	/// Choose commit parameters based on protocol parameters, using a constant fold arity.
+	///
+	/// ## Arguments
+	///
+	/// * `log_msg_len` - the binary logarithm of the length of the message to commit.
+	/// * `security_bits` - the target security level in bits.
+	/// * `log_inv_rate` - the binary logarithm of the inverse Reed–Solomon code rate.
+	/// * `arity` - the folding arity.
+	pub fn choose_with_constant_fold_arity(
+		ntt: &impl AdditiveNTT<FA>,
+		log_msg_len: usize,
+		security_bits: usize,
+		log_inv_rate: usize,
+		arity: usize,
+	) -> Result<Self, Error> {
+		assert!(arity > 0);
+
+		let log_dim = log_msg_len.saturating_sub(arity);
+		let log_batch_size = log_msg_len.min(arity);
+		let rs_code = ReedSolomonCode::with_ntt_subspace(ntt, log_dim, log_inv_rate)?;
+		let n_test_queries = calculate_n_test_queries::<F, _>(security_bits, &rs_code)?;
+
+		let cap_height = log2_ceil_usize(n_test_queries);
+		let fold_arities = std::iter::repeat_n(
+			arity,
+			log_msg_len.saturating_sub(cap_height.saturating_sub(log_inv_rate)) / arity,
+		)
+		.collect::<Vec<_>>();
+		// here is the down-to-earth explanation of what we're doing: we want the terminal
+		// codeword's log-length to be at least as large as the Merkle cap height. note that
+		// `total_vars + log_inv_rate - sum(fold_arities)` is exactly the log-length of the
+		// terminal codeword; we want this number to be ≥ cap height. so fold_arities will repeat
+		// `arity` the maximal number of times possible, while maintaining that `total_vars +
+		// log_inv_rate - sum(fold_arities) ≥ cap_height` stays true. this arity-selection
+		// strategy can be characterized as: "terminate as late as you can, while maintaining that
+		// no Merkle cap is strictly smaller than `cap_height`." this strategy does attain that
+		// property: the Merkle path height of the last non-terminal codeword will equal the
+		// log-length of the terminal codeword, which is ≥ cap height by fiat. moreover, if we
+		// terminated later than we are above, then this would stop being true. imagine what would
+		// happen if we took the above terminal codeword and continued folding. in that case, we
+		// would Merklize this word, again with the coset-bundling trick; the post-bundling path
+		// height would thus be `total_vars + log_inv_rate - sum(fold_arities) - arity`. but we
+		// already agreed (by the maximality of the number of times we subtracted `arity`) that
+		// the above number will be < cap_height. in other words, its Merkle cap will be
+		// short. equivalently: this is the latest termination for which the `min` in
+		// `optimal_verify_layer` will never trigger; i.e., we will have log2_ceil_usize(n_queries)
+		// ≤ tree_depth there. it can be shown that this strategy beats any strategy which
+		// terminates later than it does (in other words, by doing this, we are NOT terminating
+		// TOO early!). this doesn't mean that we should't terminate EVEN earlier (maybe we
+		// should). but this approach is conservative and simple; and it's easy to show that you
+		// won't lose by doing this.
+
+		// see https://github.com/IrreducibleOSS/binius/pull/300 for proof of this fact
+
+		// how should we handle the case `fold_arities = []`, i.e. total_vars + log_inv_rate -
+		// cap_height < arity? in that case, we would lose nothing by making the entire thing
+		// interleaved, i.e., setting `log_batch_size := total_vars`, so `terminal_codeword` lives
+		// in the interleaving of the repetition code (and so is itself a repetition codeword!).
+		// encoding is trivial. but there's a circularity: whether `total_vars + log_inv_rate -
+		// cap_height < arity` or not depends on `cap_height`, which depends on `n_test_queries`,
+		// which depends on `log_dim`--- soundness depends on block length!---which finally itself
+		// depends on whether we're using the repetition code or not. of course this circular
+		// dependency is artificial, since in the case `log_batch_size = total_vars` and `log_dim
+		// = 0`, we're sending the entire message anyway, so the FRI portion is essentially
+		// trivial / superfluous, and the security is perfect. and in any case we could evade it
+		// simply by calculating `n_test_queries` and `cap_height` using the provisional `log_dim
+		// := total_vars.saturating_sub(arity)`, proceeding as above, and only then, if we find
+		// out post facto that `fold_arities = []`, overwriting `log_batch_size := total_vars` and
+		// `log_dim = 0`---and even recalculating `n_test_queries` if we wanted (though of course
+		// it doesn't matter---we could do 0 queries in that case, and we would still get
+		// security---and in fact during the actual querying part we will skip querying
+		// anyway). in any case, from a purely code-simplicity point of view, the simplest approach
+		// is to bite the bullet and let `log_batch_size := min(total_vars, arity)` for good---and
+		// keep it there, even if we post-facto find out that `fold_arities = []`. the cost of
+		// this is that the prover has to do a nontrivial (though small!) interleaved encoding, as
+		// opposed to a trivial one.
+		Self::new(rs_code, log_batch_size, fold_arities, n_test_queries)
+	}
+
+	pub const fn n_fold_rounds(&self) -> usize {
+		self.rs_code.log_dim() + self.log_batch_size
+	}
+
+	/// Number of oracles sent during the fold rounds.
+	pub fn n_oracles(&self) -> usize {
+		self.fold_arities.len()
+	}
+
+	/// Number of bits in the query indices sampled during the query phase.
+	pub fn index_bits(&self) -> usize {
+		self.fold_arities
+			.first()
+			.map(|arity| self.log_len() - arity)
+			// If there is no folding, there are no random queries either
+			.unwrap_or(0)
+	}
+
+	/// Number of folding challenges the verifier sends after receiving the last oracle.
+	pub fn n_final_challenges(&self) -> usize {
+		self.n_fold_rounds() - self.fold_arities.iter().sum::<usize>()
+	}
+
+	/// The reduction arities between each oracle sent to the verifier.
+	pub fn fold_arities(&self) -> &[usize] {
+		&self.fold_arities
+	}
+
+	/// The binary logarithm of the length of the initial oracle.
+	pub fn log_len(&self) -> usize {
+		self.rs_code().log_len() + self.log_batch_size()
+	}
+}
+
+/// This layer allows minimizing the proof size.
+pub fn vcs_optimal_layers_depths_iter<'a, F, FA, VCS>(
+	fri_params: &'a FRIParams<F, FA>,
+	vcs: &'a VCS,
+) -> impl Iterator<Item = usize> + 'a
+where
+	VCS: MerkleTreeScheme<F>,
+	F: BinaryField + ExtensionField<FA>,
+	FA: BinaryField,
+{
+	fri_params
+		.fold_arities()
+		.iter()
+		.scan(fri_params.log_len(), |log_n_cosets, arity| {
+			*log_n_cosets -= arity;
+			Some(vcs.optimal_verify_layer(fri_params.n_test_queries(), *log_n_cosets))
+		})
+}
+
+/// The type of the termination round codeword in the FRI protocol.
+pub type TerminateCodeword<F> = Vec<F>;
+
+/// Calculates the number of test queries required to achieve a target security level.
+///
+/// Throws [`Error::ParameterError`] if the security level is unattainable given the code
+/// parameters.
+pub fn calculate_n_test_queries<F, FEncode>(
+	security_bits: usize,
+	code: &ReedSolomonCode<FEncode>,
+) -> Result<usize, Error>
+where
+	F: BinaryField + ExtensionField<FEncode>,
+	FEncode: BinaryField,
+{
+	let field_size = 2.0_f64.powi(F::N_BITS as i32);
+	let sumcheck_err = (2 * code.log_dim()) as f64 / field_size;
+	// 2 ⋅ ℓ' / |T_{τ}|
+	let folding_err = code.len() as f64 / field_size;
+	// 2^{ℓ' + R} / |T_{τ}|
+	let per_query_err = 0.5 * (1f64 + 2.0f64.powi(-(code.log_inv_rate() as i32)));
+	let allowed_query_err = 2.0_f64.powi(-(security_bits as i32)) - sumcheck_err - folding_err;
+	if allowed_query_err <= 0.0 {
+		return Err(Error::ParameterError);
+	}
+	let n_queries = allowed_query_err.log(per_query_err).ceil() as usize;
+	Ok(n_queries)
+}
+
+/// Heuristic for estimating the optimal FRI folding arity that minimizes proof size.
+///
+/// `log_block_length` is the binary logarithm of the  block length of the Reed–Solomon code.
+pub fn estimate_optimal_arity(
+	log_block_length: usize,
+	digest_size: usize,
+	field_size: usize,
+) -> usize {
+	(1..=log_block_length)
+		.map(|arity| {
+			(
+				// for given arity, return a tuple (arity, estimate of query_proof_size).
+				// this estimate is basd on the following approximation of a single
+				// query_proof_size, where $\vartheta$ is the arity: $\big((n-\vartheta) +
+				// (n-2\vartheta) + \ldots\big)\text{digest_size} +
+				// \frac{n-\vartheta}{\vartheta}2^{\vartheta}\text{field_size}.$
+				arity,
+				((log_block_length) / 2 * digest_size + (1 << arity) * field_size)
+					* (log_block_length - arity)
+					/ arity,
+			)
+		})
+		// now scan and terminate the iterator when query_proof_size increases.
+		.scan(None, |old: &mut Option<(usize, usize)>, new| {
+			let should_continue = !matches!(*old, Some(ref old) if new.1 > old.1);
+			*old = Some(new);
+			should_continue.then_some(new)
+		})
+		.last()
+		.map(|(arity, _)| arity)
+		.unwrap_or(1)
+}
+
+#[cfg(test)]
+mod tests {
+	use assert_matches::assert_matches;
+	use binius_field::{BinaryField32b, BinaryField128b};
+
+	use super::*;
+
+	#[test]
+	fn test_calculate_n_test_queries() {
+		let security_bits = 96;
+		let rs_code = ReedSolomonCode::new(28, 1).unwrap();
+		let n_test_queries =
+			calculate_n_test_queries::<BinaryField128b, BinaryField32b>(security_bits, &rs_code)
+				.unwrap();
+		assert_eq!(n_test_queries, 232);
+
+		let rs_code = ReedSolomonCode::new(28, 2).unwrap();
+		let n_test_queries =
+			calculate_n_test_queries::<BinaryField128b, BinaryField32b>(security_bits, &rs_code)
+				.unwrap();
+		assert_eq!(n_test_queries, 143);
+	}
+
+	#[test]
+	fn test_calculate_n_test_queries_unsatisfiable() {
+		let security_bits = 128;
+		let rs_code = ReedSolomonCode::<BinaryField32b>::new(28, 1).unwrap();
+		assert_matches!(
+			calculate_n_test_queries::<BinaryField128b, _>(security_bits, &rs_code),
+			Err(Error::ParameterError)
+		);
+	}
+
+	#[test]
+	fn test_estimate_optimal_arity() {
+		let field_size = 128;
+		for log_block_length in 22..35 {
+			let digest_size = 256;
+			assert_eq!(estimate_optimal_arity(log_block_length, digest_size, field_size), 4);
+		}
+
+		for log_block_length in 22..28 {
+			let digest_size = 1024;
+			assert_eq!(estimate_optimal_arity(log_block_length, digest_size, field_size), 6);
+		}
+	}
+}

--- a/crates/verifier/src/fri/error.rs
+++ b/crates/verifier/src/fri/error.rs
@@ -1,0 +1,50 @@
+// Copyright 2024-2025 Irreducible Inc.
+
+use binius_math::{ntt, reed_solomon};
+
+use crate::merkle_tree;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+	#[error("fold arities total exceeds the number of fold rounds")]
+	InvalidFoldAritySequence,
+	#[error("conflicting or incorrect constructor argument: {0}")]
+	InvalidArgs(String),
+	#[error("cannot calculate parameters satisfying the security target")]
+	ParameterError,
+	#[error("Merkle tree error: {0}")]
+	MerkleError(merkle_tree::Error),
+	#[error("Reed-Solomon encoding error: {0}")]
+	CodeError(#[from] reed_solomon::Error),
+	#[error("Reed-Solomon encoding error: {0}")]
+	EncodeError(#[from] ntt::Error),
+	#[error("verification error: {0}")]
+	Verification(#[from] VerificationError),
+	#[error("transcript error: {0}")]
+	TranscriptError(#[from] binius_transcript::Error),
+}
+
+impl From<merkle_tree::Error> for Error {
+	fn from(err: merkle_tree::Error) -> Self {
+		match err {
+			merkle_tree::Error::Verification(err) => Self::Verification(err.into()),
+			_ => Self::MerkleError(err),
+		}
+	}
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum VerificationError {
+	#[error("incorrect codeword folding in query round {query_round} at index {index}")]
+	IncorrectFold { query_round: usize, index: usize },
+	#[error("the size of the query proof is incorrect, expected {expected}")]
+	IncorrectQueryProofLength { expected: usize },
+	#[error(
+		"the number of values in round {round} of the query proof is incorrect, expected {coset_size}"
+	)]
+	IncorrectQueryProofValuesLength { round: usize, coset_size: usize },
+	#[error("The dimension-1 codeword must contain the same values")]
+	IncorrectDegree,
+	#[error("Merkle tree error: {0}")]
+	MerkleError(#[from] merkle_tree::VerificationError),
+}

--- a/crates/verifier/src/fri/fold.rs
+++ b/crates/verifier/src/fri/fold.rs
@@ -1,0 +1,163 @@
+// Copyright 2024-2025 Irreducible Inc.
+
+use std::iter;
+
+use binius_field::{BinaryField, ExtensionField, PackedField};
+use binius_math::{line::extrapolate_line_packed, ntt::AdditiveNTT};
+
+/// Calculate fold of `values` at `index` with `r` random coefficient.
+///
+/// See [DP24], Def. 3.6.
+///
+/// [DP24]: <https://eprint.iacr.org/2024/504>
+#[inline]
+fn fold_pair<F, FS, NTT>(ntt: &NTT, round: usize, index: usize, values: (F, F), r: F) -> F
+where
+	F: BinaryField + ExtensionField<FS>,
+	FS: BinaryField,
+	NTT: AdditiveNTT<FS>,
+{
+	// Perform inverse additive NTT butterfly
+	let t = ntt.get_subspace_eval(round, index);
+	let (mut u, mut v) = values;
+	v += u;
+	u += v * t;
+	extrapolate_line_packed(u, v, r)
+}
+
+/// Calculate FRI fold of `values` at a `chunk_index` with random folding challenges.
+///
+/// Folds a coset of a Reed–Solomon codeword into a single value using the FRI folding algorithm.
+/// The coset has size $2^n$, where $n$ is the number of challenges.
+///
+/// See [DP24], Def. 3.6 and Lemma 3.9 for more details.
+///
+/// NB: This method is on a hot path and does not perform any allocations or
+/// precondition checks.
+///
+/// ## Arguments
+///
+/// * `math` - the NTT instance, used to look up the twiddle values.
+/// * `log_len` - the binary logarithm of the code length.
+/// * `chunk_index` - the index of the chunk, of size $2^n$, in the full codeword.
+/// * `values` - mutable slice of values to fold, modified in place.
+/// * `challenges` - the sequence of folding challenges, with length $n$.
+///
+/// ## Pre-conditions
+///
+/// - `challenges.len() <= log_len`.
+/// - `log_len <= math.log_domain_size()`, so that the NTT domain is large enough.
+/// - `values.len() == 1 << challenges.len()`.
+///
+/// [DP24]: <https://eprint.iacr.org/2024/504>
+#[inline]
+pub fn fold_chunk<F, FS, NTT>(
+	ntt: &NTT,
+	mut log_len: usize,
+	chunk_index: usize,
+	values: &mut [F],
+	challenges: &[F],
+) -> F
+where
+	F: BinaryField + ExtensionField<FS>,
+	FS: BinaryField,
+	NTT: AdditiveNTT<FS>,
+{
+	let mut log_size = challenges.len();
+
+	// Preconditions
+	debug_assert!(log_size <= log_len);
+	debug_assert!(log_len <= ntt.log_domain_size());
+	debug_assert_eq!(values.len(), 1 << log_size);
+
+	// FRI-fold the values in place.
+	for &challenge in challenges {
+		// Fold the (2i) and (2i+1)th cells of the scratch buffer in-place into the i-th cell
+		for index_offset in 0..1 << (log_size - 1) {
+			let pair = (values[index_offset << 1], values[(index_offset << 1) | 1]);
+			values[index_offset] = fold_pair(
+				ntt,
+				log_len,
+				(chunk_index << (log_size - 1)) | index_offset,
+				pair,
+				challenge,
+			)
+		}
+
+		log_len -= 1;
+		log_size -= 1;
+	}
+
+	values[0]
+}
+
+/// Calculate the fold of an interleaved chunk of values with random folding challenges.
+///
+/// The elements in the `values` vector are the interleaved cosets of a batch of codewords at the
+/// index `coset_index`. That is, the layout of elements in the values slice is
+///
+/// ```text
+/// [a0, b0, c0, d0, a1, b1, c1, d1, ...]
+/// ```
+///
+/// where `a0, a1, ...` form a coset of a codeword `a`, `b0, b1, ...` form a coset of a codeword
+/// `b`, and similarly for `c` and `d`.
+///
+/// The fold operation first folds the adjacent symbols in the slice using regular multilinear
+/// tensor folding for the symbols from different cosets and FRI folding for the cosets themselves
+/// using the remaining challenges.
+//
+/// NB: This method is on a hot path and does not perform any allocations or
+/// precondition checks.
+///
+/// See [DP24], Def. 3.6 and Lemma 3.9 for more details.
+///
+/// [DP24]: <https://eprint.iacr.org/2024/504>
+#[inline]
+#[allow(clippy::too_many_arguments)]
+pub fn fold_interleaved_chunk<F, FS, P, NTT>(
+	ntt: &NTT,
+	log_len: usize,
+	log_batch_size: usize,
+	chunk_index: usize,
+	values: &[P],
+	tensor: &[P],
+	fold_challenges: &[F],
+	scratch_buffer: &mut [F],
+) -> F
+where
+	F: BinaryField + ExtensionField<FS>,
+	FS: BinaryField,
+	NTT: AdditiveNTT<FS>,
+	P: PackedField<Scalar = F>,
+{
+	// Preconditions
+	debug_assert!(fold_challenges.len() <= log_len);
+	debug_assert!(log_len <= ntt.log_domain_size());
+	debug_assert_eq!(
+		values.len(),
+		1 << (fold_challenges.len() + log_batch_size).saturating_sub(P::LOG_WIDTH)
+	);
+	debug_assert_eq!(tensor.len(), 1 << log_batch_size.saturating_sub(P::LOG_WIDTH));
+	debug_assert!(scratch_buffer.len() >= 1 << fold_challenges.len());
+
+	let scratch_buffer = &mut scratch_buffer[..1 << fold_challenges.len()];
+
+	if log_batch_size == 0 {
+		iter::zip(&mut *scratch_buffer, P::iter_slice(values)).for_each(|(dst, val)| *dst = val);
+	} else {
+		let folded_values = values
+			.chunks(1 << (log_batch_size - P::LOG_WIDTH))
+			.map(|chunk| {
+				iter::zip(chunk, tensor)
+					.map(|(&a_i, &b_i)| a_i * b_i)
+					.sum::<P>()
+					.into_iter()
+					.take(1 << log_batch_size)
+					.sum()
+			});
+		iter::zip(&mut *scratch_buffer, folded_values).for_each(|(dst, val)| *dst = val);
+	};
+
+	fold_chunk(ntt, log_len, chunk_index, scratch_buffer, fold_challenges)
+}

--- a/crates/verifier/src/fri/mod.rs
+++ b/crates/verifier/src/fri/mod.rs
@@ -1,0 +1,31 @@
+// Copyright 2024-2025 Irreducible Inc.
+
+//! Implementation of the Fast Reed–Solomon IOPP (FRI) over binary fields.
+//!
+//! FRI is an IOP of Proximity for Reed–Solomon codes. The original protocol was introduced in
+//! [BBHR17], and this implementation uses a special instantiation described in [DP24] Section 3.
+//!
+//! This protocol implement FRI for an interleaved Reed–Solomon code, rather than a regular
+//! Reed–Solomon code. Codewords in an interleaved code have the form of being a batch of
+//! Reed–Solomon codewords, interleaved element-wise. For example, an interleaved codeword with a
+//! batch size of 4 would have the form `a0, b0, c0, d0, a1, b1, c1, d1, ...`, where `a0, a1, ...`
+//! is a Reed–Solomon codeword, `b0, b1, ...` is another Reed–Solomon codeword, and so on. The
+//! batch size of the interleaved code is required to be a power of 2.
+//!
+//! The folding phase begins with the verifier having oracle access to an initial, purported
+//! interleaved codeword. In each round the prover receives a challenge and folds the interleaved
+//! codeword in half until it reaches a single codeword, mixing adjacent codewords as a linear
+//! interpolation. Then in each subsequent round, the prover receives a challenge and folds the
+//! codeword in half using the FRI folding procedure and may or may not send a new oracle to the
+//! verifier. The last oracle the prover sends, they send entirely in the clear to the verifier,
+//! rather than sending with oracle access.
+//!
+//! [BBHR17]: <https://eccc.weizmann.ac.il/report/2017/134/>
+//! [DP24]: <https://eprint.iacr.org/2024/504>
+
+pub mod common;
+mod error;
+mod fold;
+pub mod verify;
+
+pub use error::*;

--- a/crates/verifier/src/fri/verify.rs
+++ b/crates/verifier/src/fri/verify.rs
@@ -1,0 +1,385 @@
+// Copyright 2024-2025 Irreducible Inc.
+
+use std::iter;
+
+use binius_field::{BinaryField, ExtensionField, TowerField};
+use binius_math::{FieldBuffer, multilinear::eq::eq_ind_partial_eval, ntt::SingleThreadedNTT};
+use binius_transcript::{
+	TranscriptReader, VerifierTranscript,
+	fiat_shamir::{CanSampleBits, Challenger},
+};
+use binius_utils::{DeserializeBytes, bail};
+use bytes::Buf;
+use itertools::izip;
+
+use super::{
+	common::{FRIParams, vcs_optimal_layers_depths_iter},
+	error::{Error, VerificationError},
+};
+use crate::{
+	fri::fold::{fold_chunk, fold_interleaved_chunk},
+	merkle_tree::MerkleTreeScheme,
+};
+
+/// A verifier for the FRI query phase.
+///
+/// The verifier is instantiated after the folding rounds and is used to test consistency of the
+/// round messages and the original purported codeword.
+#[derive(Debug)]
+pub struct FRIVerifier<'a, F, FA, VCS>
+where
+	F: BinaryField + ExtensionField<FA>,
+	FA: BinaryField,
+	VCS: MerkleTreeScheme<F>,
+{
+	vcs: &'a VCS,
+	params: &'a FRIParams<F, FA>,
+	/// Received commitment to the codeword.
+	codeword_commitment: &'a VCS::Digest,
+	/// Received commitments to the round messages.
+	round_commitments: &'a [VCS::Digest],
+	/// The challenges for each round.
+	interleave_tensor: FieldBuffer<F>,
+	/// The challenges for each round.
+	fold_challenges: &'a [F],
+}
+
+impl<'a, F, FA, VCS> FRIVerifier<'a, F, FA, VCS>
+where
+	F: TowerField + ExtensionField<FA>,
+	FA: BinaryField,
+	VCS: MerkleTreeScheme<F, Digest: DeserializeBytes>,
+{
+	#[allow(clippy::too_many_arguments)]
+	pub fn new(
+		params: &'a FRIParams<F, FA>,
+		vcs: &'a VCS,
+		codeword_commitment: &'a VCS::Digest,
+		round_commitments: &'a [VCS::Digest],
+		challenges: &'a [F],
+	) -> Result<Self, Error> {
+		if round_commitments.len() != params.n_oracles() {
+			bail!(Error::InvalidArgs(format!(
+				"got {} round commitments, expected {}",
+				round_commitments.len(),
+				params.n_oracles(),
+			)));
+		}
+
+		if challenges.len() != params.n_fold_rounds() {
+			bail!(Error::InvalidArgs(format!(
+				"got {} folding challenges, expected {}",
+				challenges.len(),
+				params.n_fold_rounds(),
+			)));
+		}
+
+		let (interleave_challenges, fold_challenges) = challenges.split_at(params.log_batch_size());
+
+		let interleave_tensor = eq_ind_partial_eval(interleave_challenges);
+		Ok(Self {
+			params,
+			vcs,
+			codeword_commitment,
+			round_commitments,
+			interleave_tensor,
+			fold_challenges,
+		})
+	}
+
+	/// Number of oracles sent during the fold rounds.
+	pub fn n_oracles(&self) -> usize {
+		self.params.n_oracles()
+	}
+
+	pub fn verify<Challenger_>(
+		&self,
+		transcript: &mut VerifierTranscript<Challenger_>,
+	) -> Result<F, Error>
+	where
+		Challenger_: Challenger,
+	{
+		let ntt = SingleThreadedNTT::with_subspace(self.params.rs_code().subspace())?;
+
+		// Verify that the last oracle sent is a codeword.
+		let terminate_codeword_len =
+			1 << (self.params.n_final_challenges() + self.params.rs_code().log_inv_rate());
+		let mut advice = transcript.decommitment();
+		let terminate_codeword = advice
+			.read_scalar_slice(terminate_codeword_len)
+			.map_err(Error::TranscriptError)?;
+		let final_value = self.verify_last_oracle(&ntt, &terminate_codeword)?;
+
+		// Verify that the provided layers match the commitments.
+		let layers = vcs_optimal_layers_depths_iter(self.params, self.vcs)
+			.map(|layer_depth| advice.read_vec(1 << layer_depth))
+			.collect::<Result<Vec<_>, _>>()?;
+		for (commitment, layer_depth, layer) in izip!(
+			iter::once(self.codeword_commitment).chain(self.round_commitments),
+			vcs_optimal_layers_depths_iter(self.params, self.vcs),
+			&layers
+		) {
+			self.vcs.verify_layer(commitment, layer_depth, layer)?;
+		}
+
+		// Verify the random openings against the decommitted layers.
+
+		let mut scratch_buffer = self.create_scratch_buffer();
+		for _ in 0..self.params.n_test_queries() {
+			let index = transcript.sample_bits(self.params.index_bits()) as usize;
+			self.verify_query_internal(
+				index,
+				&ntt,
+				&terminate_codeword,
+				&layers,
+				&mut transcript.decommitment(),
+				&mut scratch_buffer,
+			)?
+		}
+
+		Ok(final_value)
+	}
+
+	/// Verifies that the last oracle sent is a codeword.
+	///
+	/// Returns the fully-folded message value.
+	pub fn verify_last_oracle(
+		&self,
+		ntt: &SingleThreadedNTT<FA>,
+		terminate_codeword: &[F],
+	) -> Result<F, Error> {
+		let n_final_challenges = self.params.n_final_challenges();
+
+		self.vcs.verify_vector(
+			self.round_commitments
+				.last()
+				.unwrap_or(self.codeword_commitment),
+			terminate_codeword,
+			1 << n_final_challenges,
+		)?;
+
+		let repetition_codeword = if self.n_oracles() != 0 {
+			let n_prior_challenges = self.fold_challenges.len() - n_final_challenges;
+			let final_challenges = &self.fold_challenges[n_prior_challenges..];
+			let mut scratch_buffer = vec![F::default(); 1 << n_final_challenges];
+
+			terminate_codeword
+				.chunks(1 << n_final_challenges)
+				.enumerate()
+				.map(|(i, coset_values)| {
+					scratch_buffer.copy_from_slice(coset_values);
+					fold_chunk(
+						ntt,
+						n_final_challenges + self.params.rs_code().log_inv_rate(),
+						i,
+						&mut scratch_buffer,
+						final_challenges,
+					)
+				})
+				.collect::<Vec<_>>()
+		} else {
+			// When the prover did not send any round oracles, fold the original interleaved
+			// codeword.
+
+			let fold_arity = self.params.rs_code().log_dim() + self.params.log_batch_size();
+			let mut scratch_buffer = vec![F::default(); 1 << self.params.rs_code().log_dim()];
+			terminate_codeword
+				.chunks(1 << fold_arity)
+				.enumerate()
+				.map(|(i, chunk)| {
+					fold_interleaved_chunk(
+						ntt,
+						self.params.rs_code().log_len(),
+						self.params.log_batch_size(),
+						i,
+						chunk,
+						self.interleave_tensor.as_ref(),
+						self.fold_challenges,
+						&mut scratch_buffer,
+					)
+				})
+				.collect::<Vec<_>>()
+		};
+
+		let final_value = repetition_codeword[0];
+
+		// Check that the fully-folded purported codeword is a repetition codeword.
+		if repetition_codeword[1..]
+			.iter()
+			.any(|&entry| entry != final_value)
+		{
+			return Err(VerificationError::IncorrectDegree.into());
+		}
+
+		Ok(final_value)
+	}
+
+	/// Verifies a FRI challenge query.
+	///
+	/// A FRI challenge query tests for consistency between all consecutive oracles sent by the
+	/// prover. The verifier has full access to the last oracle sent, and this is probabilistically
+	/// verified to be a codeword by `Self::verify_last_oracle`.
+	///
+	/// ## Arguments
+	///
+	/// * `index` - an index into the original codeword domain
+	/// * `proof` - a query proof
+	pub fn verify_query<B: Buf>(
+		&self,
+		index: usize,
+		ntt: &SingleThreadedNTT<FA>,
+		terminate_codeword: &[F],
+		layers: &[Vec<VCS::Digest>],
+		advice: &mut TranscriptReader<B>,
+	) -> Result<(), Error> {
+		self.verify_query_internal(
+			index,
+			ntt,
+			terminate_codeword,
+			layers,
+			advice,
+			&mut self.create_scratch_buffer(),
+		)
+	}
+
+	fn verify_query_internal<B: Buf>(
+		&self,
+		mut index: usize,
+		ntt: &SingleThreadedNTT<FA>,
+		terminate_codeword: &[F],
+		layers: &[Vec<VCS::Digest>],
+		advice: &mut TranscriptReader<B>,
+		scratch_buffer: &mut [F],
+	) -> Result<(), Error> {
+		let mut arities_iter = self.params.fold_arities().iter().copied();
+
+		let mut layer_digest_and_optimal_layer_depth =
+			iter::zip(layers, vcs_optimal_layers_depths_iter(self.params, self.vcs));
+
+		let Some(first_fold_arity) = arities_iter.next() else {
+			// If there are no query proofs, that means that no oracles were sent during the FRI
+			// fold rounds. In that case, the original interleaved codeword is decommitted and
+			// the only checks that need to be performed are in `verify_last_oracle`.
+			return Ok(());
+		};
+
+		let (first_layer, first_optimal_layer_depth) = layer_digest_and_optimal_layer_depth
+			.next()
+			.expect("The length should be the same as the amount of proofs.");
+
+		// This is the round of the folding phase that the codeword to be folded is committed to.
+		let mut fold_round = 0;
+		let mut log_n_cosets = self.params.index_bits();
+
+		// Check the first fold round before the main loop. It is special because in the first
+		// round we need to fold as an interleaved chunk instead of a regular coset.
+		let log_coset_size = first_fold_arity - self.params.log_batch_size();
+		let values = verify_coset_opening(
+			self.vcs,
+			index,
+			first_fold_arity,
+			first_optimal_layer_depth,
+			log_n_cosets,
+			first_layer,
+			advice,
+		)?;
+		let mut next_value = fold_interleaved_chunk(
+			ntt,
+			self.params.rs_code().log_len(),
+			self.params.log_batch_size(),
+			index,
+			&values,
+			self.interleave_tensor.as_ref(),
+			&self.fold_challenges[fold_round..fold_round + log_coset_size],
+			scratch_buffer,
+		);
+		fold_round += log_coset_size;
+
+		for (i, (arity, (layer, optimal_layer_depth))) in
+			izip!(arities_iter, layer_digest_and_optimal_layer_depth).enumerate()
+		{
+			let coset_index = index >> arity;
+
+			log_n_cosets -= arity;
+
+			let mut values = verify_coset_opening(
+				self.vcs,
+				coset_index,
+				arity,
+				optimal_layer_depth,
+				log_n_cosets,
+				layer,
+				advice,
+			)?;
+
+			if next_value != values[index % (1 << arity)] {
+				return Err(VerificationError::IncorrectFold {
+					query_round: i,
+					index,
+				}
+				.into());
+			}
+
+			next_value = fold_chunk(
+				ntt,
+				self.params.rs_code().log_len() - fold_round,
+				coset_index,
+				&mut values,
+				&self.fold_challenges[fold_round..fold_round + arity],
+			);
+			index = coset_index;
+			fold_round += arity;
+		}
+
+		if next_value != terminate_codeword[index] {
+			return Err(VerificationError::IncorrectFold {
+				query_round: self.n_oracles() - 1,
+				index,
+			}
+			.into());
+		}
+
+		Ok(())
+	}
+
+	// scratch buffer used in `fold_chunk`.
+	fn create_scratch_buffer(&self) -> Vec<F> {
+		let max_arity = self
+			.params
+			.fold_arities()
+			.iter()
+			.copied()
+			.max()
+			.unwrap_or_default();
+		let max_buffer_size = 2 * (1 << max_arity);
+		vec![F::default(); max_buffer_size]
+	}
+}
+
+/// Verifies that the coset opening provided in the proof is consistent with the VCS commitment.
+#[allow(clippy::too_many_arguments)]
+fn verify_coset_opening<F, MTScheme, B>(
+	vcs: &MTScheme,
+	coset_index: usize,
+	log_coset_size: usize,
+	optimal_layer_depth: usize,
+	tree_depth: usize,
+	layer_digests: &[MTScheme::Digest],
+	advice: &mut TranscriptReader<B>,
+) -> Result<Vec<F>, Error>
+where
+	F: TowerField,
+	MTScheme: MerkleTreeScheme<F>,
+	B: Buf,
+{
+	let values = advice.read_scalar_slice::<F>(1 << log_coset_size)?;
+	vcs.verify_opening(
+		coset_index,
+		&values,
+		optimal_layer_depth,
+		tree_depth,
+		layer_digests,
+		advice,
+	)?;
+	Ok(values)
+}

--- a/crates/verifier/src/lib.rs
+++ b/crates/verifier/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod config;
 mod error;
 pub mod fields;
+pub mod fri;
 pub mod hash;
 pub mod merkle_tree;
 mod verify;


### PR DESCRIPTION
### TL;DR

Add FRI (Fast Reed-Solomon Interactive Oracle Proof of Proximity) implementation to the verifier crate.

### What changed?

This PR adds a complete implementation of the FRI protocol for the verifier, which is an Interactive Oracle Proof of Proximity for Reed-Solomon codes. The implementation follows the approach described in [DP24] Section 3, using interleaved Reed-Solomon codes.

Key components added:
- `FRIParams` struct to configure the protocol parameters
- `FRIVerifier` for the query phase verification
- Folding functions for both regular and interleaved chunks
- Error handling for verification failures
- Utility functions for parameter selection and optimization

The implementation also adds a `CanSampleBits<u32>` trait implementation for `VerifierTranscript` to enable sampling random bits during verification.

### How to test?

The PR includes unit tests for:
- Calculating the number of test queries required for a target security level
- Handling unsatisfiable security parameters
- Estimating optimal folding arity for different configurations

Run the tests with:
```
cargo test -p binius-verifier
```

### Why make this change?

FRI is a critical component for efficient zero-knowledge proof systems, particularly for those based on Reed-Solomon codes. This implementation enables the verifier to efficiently check proximity to Reed-Solomon codes, which is essential for the overall proof system's security and performance.

The implementation is optimized for binary fields and includes heuristics for parameter selection to minimize proof size while maintaining the desired security level.