### PR TITLE
Add ARM underliers implementation

### DIFF
--- a/crates/arith-bench/src/arch/aarch64.rs
+++ b/crates/arith-bench/src/arch/aarch64.rs
@@ -1,0 +1,508 @@
+use std::arch::aarch64::*;
+
+use seq_macro::seq;
+
+use crate::underlier::{PackedUnderlier, Underlier};
+
+impl Underlier for uint64x2_t {
+	const BITS: usize = 128;
+
+	#[inline]
+	fn and(a: Self, b: Self) -> Self {
+		unsafe { vandq_u64(a, b) }
+	}
+
+	#[inline]
+	fn xor(a: Self, b: Self) -> Self {
+		unsafe { veorq_u64(a, b) }
+	}
+
+	#[inline]
+	fn zero() -> Self {
+		unsafe { vdupq_n_u64(0) }
+	}
+
+	#[inline]
+	fn is_equal(a: Self, b: Self) -> bool {
+		unsafe {
+			let cmp = vceqq_u64(a, b);
+			vgetq_lane_u64(cmp, 0) == u64::MAX && vgetq_lane_u64(cmp, 1) == u64::MAX
+		}
+	}
+}
+
+impl PackedUnderlier<u64> for uint64x2_t {
+	const LOG_WIDTH: usize = 1; // 2^1 = 2 elements
+
+	#[inline]
+	fn get(self, index: usize) -> u64 {
+		assert!(index < 2, "index out of bounds");
+		unsafe {
+			seq!(N in 0..2 {
+				match index {
+					#(N => vgetq_lane_u64(self, N),)*
+					_ => unreachable!(),
+				}
+			})
+		}
+	}
+
+	#[inline]
+	fn set(self, index: usize, val: u64) -> Self {
+		assert!(index < 2, "index out of bounds");
+		unsafe {
+			seq!(N in 0..2 {
+				match index {
+					#(N => vsetq_lane_u64(val, self, N),)*
+					_ => unreachable!(),
+				}
+			})
+		}
+	}
+
+	#[inline]
+	fn broadcast(val: u64) -> Self {
+		unsafe { vdupq_n_u64(val) }
+	}
+}
+
+impl PackedUnderlier<u8> for uint64x2_t {
+	const LOG_WIDTH: usize = 4; // 2^4 = 16 elements
+
+	#[inline]
+	fn get(self, index: usize) -> u8 {
+		assert!(index < 16, "index out of bounds");
+		unsafe {
+			let bytes = vreinterpretq_u8_u64(self);
+			seq!(N in 0..16 {
+				match index {
+					#(N => vgetq_lane_u8(bytes, N),)*
+					_ => unreachable!(),
+				}
+			})
+		}
+	}
+
+	#[inline]
+	fn set(self, index: usize, val: u8) -> Self {
+		assert!(index < 16, "index out of bounds");
+		unsafe {
+			let mut bytes = vreinterpretq_u8_u64(self);
+			seq!(N in 0..16 {
+				match index {
+					#(N => { bytes = vsetq_lane_u8(val, bytes, N); },)*
+					_ => unreachable!(),
+				}
+			});
+			vreinterpretq_u64_u8(bytes)
+		}
+	}
+
+	#[inline]
+	fn broadcast(val: u8) -> Self {
+		unsafe {
+			let bytes = vdupq_n_u8(val);
+			vreinterpretq_u64_u8(bytes)
+		}
+	}
+}
+
+impl PackedUnderlier<u128> for uint64x2_t {
+	const LOG_WIDTH: usize = 0; // 2^0 = 1 element
+
+	#[inline]
+	fn get(self, index: usize) -> u128 {
+		assert!(index == 0, "index out of bounds");
+		unsafe { std::mem::transmute(self) }
+	}
+
+	#[inline]
+	fn set(self, index: usize, val: u128) -> Self {
+		assert!(index == 0, "index out of bounds");
+		unsafe { std::mem::transmute(val) }
+	}
+
+	#[inline]
+	fn broadcast(val: u128) -> Self {
+		unsafe { std::mem::transmute(val) }
+	}
+}
+
+impl crate::underlier::OpsClmul for uint64x2_t {
+	#[inline]
+	fn clmulepi64<const IMM8: i32>(a: Self, b: Self) -> Self {
+		let result = match IMM8 {
+            0x00 => {
+                unsafe { vmull_p64(vgetq_lane_u64(a, 0), vgetq_lane_u64(b, 0)) }
+            }
+            0x11 => {
+                unsafe { vmull_p64(vgetq_lane_u64(a, 1), vgetq_lane_u64(b, 1)) }
+            }
+            0x10 => {
+                unsafe { vmull_p64(vgetq_lane_u64(a, 0), vgetq_lane_u64(b, 1)) }
+            }
+            0x01 => {
+                unsafe { vmull_p64(vgetq_lane_u64(a, 1), vgetq_lane_u64(b, 0)) }
+            }
+            _ => panic!("Unsupported IMM8 value for clmulepi64"),
+        };
+
+        unsafe { std::mem::transmute(result) }
+	}
+
+	#[inline]
+	fn duplicate_hi_64(a: Self) -> Self {
+        unsafe {
+            vdupq_n_u64(vgetq_lane_u64(a, 1))
+        }
+    }
+
+    #[inline]
+    fn swap_hi_lo_64(a: Self) -> Self {
+        unsafe {
+            vextq_u64(a, a, 1)
+        }
+    }
+
+    #[inline]
+    fn extract_hi_lo_64(a: Self, b: Self) -> Self {
+        unsafe {
+            vcombine_u64(
+                vcreate_u64(vgetq_lane_u64(a, 1)),
+                vcreate_u64(vgetq_lane_u64(b, 0)),
+            )
+        }
+    }
+
+	#[inline]
+	fn unpacklo_epi64(a: Self, b: Self) -> Self {
+		unsafe {
+			vzip1q_u64(a, b)
+		}
+	}
+
+	#[inline]
+	fn unpackhi_epi64(a: Self, b: Self) -> Self {
+		unsafe {
+			vzip2q_u64(a, b)
+		}
+	}
+
+	#[inline]
+	fn slli_si128<const IMM8: i32>(a: Self) -> Self {
+		// Shift left by IMM8 bytes
+		unsafe {
+			match IMM8 {
+				0 => a,
+				1..16 => {
+                    let a_bytes: uint8x16_t = std::mem::transmute(a);
+                    let zero: uint8x16_t = vdupq_n_u8(0);
+                    let shifted: uint8x16_t = vextq_u8::<IMM8>(zero, a_bytes);
+                    std::mem::transmute(shifted)
+                }
+				16.. => vdupq_n_u64(0),
+				_ => {
+					// For other byte shifts, use a more complex approach
+					// This is a simplified implementation
+					a
+				}
+			}
+		}
+	}
+
+	#[inline]
+	fn slli_epi64<const IMM8: i32>(a: Self) -> Self {
+		unsafe { vshlq_n_u64::<IMM8>(a) }
+	}
+
+	#[inline]
+	fn movepi64_mask(a: Self) -> Self {
+		unsafe {
+            let a = std::mem::transmute(a);
+            // Get the odd lanes (upper 32 bits of each 64-bit element)
+            let odd_lanes = vtrn2q_u32(a, a);
+            // Arithmetic shift right to broadcast the sign bit
+            std::mem::transmute(vshrq_n_s32(std::mem::transmute(odd_lanes), 31))
+        }
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use proptest::prelude::*;
+
+	use super::*;
+	use crate::ghash::{GHASH_ONE, mul_clmul as ghash_mul};
+	use crate::monbijou::{
+		MONBIJOU_128B_ONE, MONBIJOU_ONE, mul_128b_clmul as monbijou_128b_mul,
+		mul_clmul as monbijou_mul,
+	};
+	use crate::polyval::{MONTGOMERY_ONE, mul_clmul as polyval_mul};
+	use crate::test_utils::multiplication_tests::{
+		test_mul_associative, test_mul_commutative, test_mul_distributive, test_mul_identity,
+	};
+	use crate::test_utils::{arb_get_set_op, test_packed_underlier_get_set_behaves_like_vec};
+
+	// Strategy for generating uint64x2_t values
+	fn arb_uint64x2_t() -> impl Strategy<Value = uint64x2_t> {
+		any::<u128>().prop_map(|val| unsafe { std::mem::transmute::<u128, uint64x2_t>(val) })
+	}
+
+	proptest! {
+		#[test]
+		fn test_uint64x2_t_as_packed_u8_proptest(
+			ops in prop::collection::vec(arb_get_set_op::<u8>(16), 0..100)
+		) {
+			test_packed_underlier_get_set_behaves_like_vec::<uint64x2_t, u8>(ops);
+		}
+
+		#[test]
+		fn test_uint64x2_t_as_packed_u64_proptest(
+			ops in prop::collection::vec(arb_get_set_op::<u64>(2), 0..100)
+		) {
+			test_packed_underlier_get_set_behaves_like_vec::<uint64x2_t, u64>(ops);
+		}
+
+		#[test]
+		fn test_uint64x2_t_as_packed_u128_proptest(
+			ops in prop::collection::vec(arb_get_set_op::<u128>(1), 0..100)
+		) {
+			test_packed_underlier_get_set_behaves_like_vec::<uint64x2_t, u128>(ops);
+		}
+
+		// Polynomial Montgomery multiplication property tests for uint64x2_t
+		#[test]
+		fn test_uint64x2_t_polyval_mul_commutative_proptest(
+			a in arb_uint64x2_t(),
+			b in arb_uint64x2_t()
+		) {
+			test_mul_commutative(a, b, polyval_mul, "POLYVAL");
+		}
+
+		#[test]
+		fn test_uint64x2_t_polyval_mul_associative_proptest(
+			a in arb_uint64x2_t(),
+			b in arb_uint64x2_t(),
+			c in arb_uint64x2_t()
+		) {
+			test_mul_associative(a, b, c, polyval_mul, "POLYVAL");
+		}
+
+		#[test]
+		fn test_uint64x2_t_polyval_mul_identity_proptest(
+			a in arb_uint64x2_t()
+		) {
+			test_mul_identity(a, MONTGOMERY_ONE, polyval_mul, "POLYVAL");
+		}
+
+		#[test]
+		fn test_uint64x2_t_polyval_mul_distributive_proptest(
+			a in arb_uint64x2_t(),
+			b in arb_uint64x2_t(),
+			c in arb_uint64x2_t()
+		) {
+			test_mul_distributive(a, b, c, polyval_mul, "POLYVAL");
+		}
+
+		// GHASH multiplication property tests for uint64x2_t
+		#[test]
+		fn test_uint64x2_t_ghash_mul_commutative_proptest(
+			a in arb_uint64x2_t(),
+			b in arb_uint64x2_t()
+		) {
+			test_mul_commutative(a, b, ghash_mul, "GHASH");
+		}
+
+		#[test]
+		fn test_uint64x2_t_ghash_mul_associative_proptest(
+			a in arb_uint64x2_t(),
+			b in arb_uint64x2_t(),
+			c in arb_uint64x2_t()
+		) {
+			test_mul_associative(a, b, c, ghash_mul, "GHASH");
+		}
+
+		#[test]
+		fn test_uint64x2_t_ghash_mul_identity_proptest(
+			a in arb_uint64x2_t()
+		) {
+			test_mul_identity(a, GHASH_ONE, ghash_mul, "GHASH");
+		}
+
+		#[test]
+		fn test_uint64x2_t_ghash_mul_distributive_proptest(
+			a in arb_uint64x2_t(),
+			b in arb_uint64x2_t(),
+			c in arb_uint64x2_t()
+		) {
+			test_mul_distributive(a, b, c, ghash_mul, "GHASH");
+		}
+
+		// Monbijou multiplication property tests for uint64x2_t
+		#[test]
+		fn test_uint64x2_t_monbijou_mul_commutative_proptest(
+			a in arb_uint64x2_t(),
+			b in arb_uint64x2_t()
+		) {
+			test_mul_commutative(a, b, monbijou_mul, "Monbijou");
+		}
+
+		#[test]
+		fn test_uint64x2_t_monbijou_mul_associative_proptest(
+			a in arb_uint64x2_t(),
+			b in arb_uint64x2_t(),
+			c in arb_uint64x2_t()
+		) {
+			test_mul_associative(a, b, c, monbijou_mul, "Monbijou");
+		}
+
+		#[test]
+		fn test_uint64x2_t_monbijou_mul_identity_proptest(
+			a in arb_uint64x2_t()
+		) {
+			test_mul_identity(a, MONBIJOU_ONE, monbijou_mul, "Monbijou");
+		}
+
+		#[test]
+		fn test_uint64x2_t_monbijou_mul_distributive_proptest(
+			a in arb_uint64x2_t(),
+			b in arb_uint64x2_t(),
+			c in arb_uint64x2_t()
+		) {
+			test_mul_distributive(a, b, c, monbijou_mul, "Monbijou");
+		}
+
+		// Monbijou 128-bit multiplication property tests for uint64x2_t
+		#[test]
+		fn test_uint64x2_t_monbijou_128b_mul_commutative_proptest(
+			a in arb_uint64x2_t(),
+			b in arb_uint64x2_t()
+		) {
+			test_mul_commutative(a, b, monbijou_128b_mul, "Monbijou 128b");
+		}
+
+		#[test]
+		fn test_uint64x2_t_monbijou_128b_mul_associative_proptest(
+			a in arb_uint64x2_t(),
+			b in arb_uint64x2_t(),
+			c in arb_uint64x2_t()
+		) {
+			test_mul_associative(a, b, c, monbijou_128b_mul, "Monbijou 128b");
+		}
+
+		#[test]
+		fn test_uint64x2_t_monbijou_128b_mul_identity_proptest(
+			a in arb_uint64x2_t()
+		) {
+			test_mul_identity(a, MONBIJOU_128B_ONE, monbijou_128b_mul, "Monbijou 128b");
+		}
+
+		#[test]
+		fn test_uint64x2_t_monbijou_128b_mul_distributive_proptest(
+			a in arb_uint64x2_t(),
+			b in arb_uint64x2_t(),
+			c in arb_uint64x2_t()
+		) {
+			test_mul_distributive(a, b, c, monbijou_128b_mul, "Monbijou 128b");
+		}
+	}
+
+	#[test]
+	fn test_uint64x2_t_movepi64_mask() {
+		use crate::underlier::{OpsClmul, Underlier};
+
+		unsafe {
+			// Test all zeros - expect all zeros in the mask
+			let zeros = vdupq_n_u64(0);
+			let mask_zeros = <uint64x2_t as OpsClmul>::movepi64_mask(zeros);
+			assert!(<uint64x2_t as Underlier>::is_equal(mask_zeros, vdupq_n_u64(0)));
+
+			// Test with negative values (sign bit set) - expect all 1s in all positions
+			let neg_ones = vdupq_n_u64(u64::MAX);
+			let mask_neg = <uint64x2_t as OpsClmul>::movepi64_mask(neg_ones);
+			let expected_neg = vdupq_n_u64(u64::MAX);
+			assert!(<uint64x2_t as Underlier>::is_equal(mask_neg, expected_neg));
+
+			// Test mixed values - lane 0 positive, lane 1 negative
+			let mixed = vsetq_lane_u64(u64::MAX, vsetq_lane_u64(1, vdupq_n_u64(0), 0), 1);
+			let mask_mixed = <uint64x2_t as OpsClmul>::movepi64_mask(mixed);
+			let expected_mixed = vsetq_lane_u64(u64::MAX, vsetq_lane_u64(0, vdupq_n_u64(0), 0), 1);
+			assert!(<uint64x2_t as Underlier>::is_equal(mask_mixed, expected_mixed));
+
+			// Test another mixed pattern - lane 0 negative, lane 1 positive
+			let mixed2 = vsetq_lane_u64(1, vsetq_lane_u64(u64::MAX, vdupq_n_u64(0), 0), 1);
+			let mask_mixed2 = <uint64x2_t as OpsClmul>::movepi64_mask(mixed2);
+			let expected_mixed2 = vsetq_lane_u64(0, vsetq_lane_u64(u64::MAX, vdupq_n_u64(0), 0), 1);
+			assert!(<uint64x2_t as Underlier>::is_equal(mask_mixed2, expected_mixed2));
+		}
+	}
+
+	#[test]
+	fn test_uint64x2_t_basic_ops() {
+		use crate::underlier::Underlier;
+
+		unsafe {
+			// Test basic operations
+			let a = vsetq_lane_u64(0xDEADBEEF, vsetq_lane_u64(0x12345678, vdupq_n_u64(0), 0), 1);
+			let b = vsetq_lane_u64(0xCAFEBABE, vsetq_lane_u64(0x87654321, vdupq_n_u64(0), 0), 1);
+
+			// Test AND
+			let and_result = <uint64x2_t as Underlier>::and(a, b);
+			let expected_and_low = 0x12345678 & 0x87654321;
+			let expected_and_high = 0xDEADBEEF & 0xCAFEBABE;
+			assert_eq!(vgetq_lane_u64(and_result, 0), expected_and_low);
+			assert_eq!(vgetq_lane_u64(and_result, 1), expected_and_high);
+
+			// Test XOR
+			let xor_result = <uint64x2_t as Underlier>::xor(a, b);
+			let expected_xor_low = 0x12345678 ^ 0x87654321;
+			let expected_xor_high = 0xDEADBEEF ^ 0xCAFEBABE;
+			assert_eq!(vgetq_lane_u64(xor_result, 0), expected_xor_low);
+			assert_eq!(vgetq_lane_u64(xor_result, 1), expected_xor_high);
+
+			// Test zero
+			let zero_result = <uint64x2_t as Underlier>::zero();
+			assert_eq!(vgetq_lane_u64(zero_result, 0), 0);
+			assert_eq!(vgetq_lane_u64(zero_result, 1), 0);
+
+			// Test equality
+			let a_copy = vsetq_lane_u64(0xDEADBEEF, vsetq_lane_u64(0x12345678, vdupq_n_u64(0), 0), 1);
+			assert!(<uint64x2_t as Underlier>::is_equal(a, a_copy));
+			assert!(!<uint64x2_t as Underlier>::is_equal(a, b));
+		}
+	}
+
+	#[test]
+	fn test_uint64x2_t_ops_clmul() {
+		use crate::underlier::OpsClmul;
+
+		unsafe {
+			let a = vsetq_lane_u64(0xDEADBEEF, vsetq_lane_u64(0x12345678, vdupq_n_u64(0), 0), 1);
+			let b = vsetq_lane_u64(0xCAFEBABE, vsetq_lane_u64(0x87654321, vdupq_n_u64(0), 0), 1);
+
+			// Test unpack operations
+			let unpack_lo = <uint64x2_t as OpsClmul>::unpacklo_epi64(a, b);
+			assert_eq!(vgetq_lane_u64(unpack_lo, 0), 0x12345678);
+			assert_eq!(vgetq_lane_u64(unpack_lo, 1), 0x87654321);
+
+			let unpack_hi = <uint64x2_t as OpsClmul>::unpackhi_epi64(a, b);
+			assert_eq!(vgetq_lane_u64(unpack_hi, 0), 0xDEADBEEF);
+			assert_eq!(vgetq_lane_u64(unpack_hi, 1), 0xCAFEBABE);
+
+			// Test shift operations
+			let shift_1 = <uint64x2_t as OpsClmul>::slli_epi64::<1>(a);
+			assert_eq!(vgetq_lane_u64(shift_1, 0), 0x12345678 << 1);
+			assert_eq!(vgetq_lane_u64(shift_1, 1), 0xDEADBEEF << 1);
+
+			let shift_8 = <uint64x2_t as OpsClmul>::slli_epi64::<8>(a);
+			assert_eq!(vgetq_lane_u64(shift_8, 0), 0x12345678 << 8);
+			assert_eq!(vgetq_lane_u64(shift_8, 1), 0xDEADBEEF << 8);
+
+			// Test byte shift (slli_si128)
+			let byte_shift_8 = <uint64x2_t as OpsClmul>::slli_si128::<8>(a);
+			assert_eq!(vgetq_lane_u64(byte_shift_8, 0), 0);
+			assert_eq!(vgetq_lane_u64(byte_shift_8, 1), 0x12345678);
+		}
+	}
+}
+

--- a/crates/arith-bench/src/arch/mod.rs
+++ b/crates/arith-bench/src/arch/mod.rs
@@ -1,2 +1,5 @@
 #[cfg(target_arch = "x86_64")]
 mod x86_64;
+
+#[cfg(all(target_arch = "aarch64", target_feature = "neon", target_feature = "aes"))]
+mod aarch64;

--- a/crates/arith-bench/src/arch/x86_64.rs
+++ b/crates/arith-bench/src/arch/x86_64.rs
@@ -152,14 +152,22 @@ impl crate::underlier::OpsClmul for __m128i {
 	}
 
 	#[inline]
-	fn shuffle_epi32<const IMM8: i32>(a: Self) -> Self {
-		unsafe { _mm_shuffle_epi32::<IMM8>(a) }
+	fn duplicate_hi_64(a: Self) -> Self {
+		unsafe { _mm_shuffle_epi32::<0xEE>(a) }
 	}
 
 	#[inline]
-	fn shuffle_ps<const IMM8: i32>(a: Self, b: Self) -> Self {
+	fn swap_hi_lo_64(a: Self) -> Self {
+		unsafe { _mm_shuffle_epi32::<0x4E>(a) }
+	}
+
+	#[inline]
+	fn extract_hi_lo_64(a: Self, b: Self) -> Self {
 		unsafe {
-			_mm_castps_si128(_mm_shuffle_ps::<IMM8>(_mm_castsi128_ps(a), _mm_castsi128_ps(b)))
+			_mm_castps_si128(_mm_shuffle_ps::<0x4E>(
+				_mm_castsi128_ps(a),
+				_mm_castsi128_ps(b),
+			))
 		}
 	}
 
@@ -399,14 +407,19 @@ impl crate::underlier::OpsClmul for __m256i {
 	}
 
 	#[inline]
-	fn shuffle_epi32<const IMM8: i32>(a: Self) -> Self {
-		unsafe { _mm256_shuffle_epi32::<IMM8>(a) }
+	fn duplicate_hi_64(a: Self) -> Self {
+		unsafe { _mm256_shuffle_epi32::<0xEE>(a) }
 	}
 
 	#[inline]
-	fn shuffle_ps<const IMM8: i32>(a: Self, b: Self) -> Self {
+	fn swap_hi_lo_64(a: Self) -> Self {
+		unsafe { _mm256_shuffle_epi32::<0x4E>(a) }
+	}
+
+	#[inline]
+	fn extract_hi_lo_64(a: Self, b: Self) -> Self {
 		unsafe {
-			_mm256_castps_si256(_mm256_shuffle_ps::<IMM8>(
+			_mm256_castps_si256(_mm256_shuffle_ps::<0x4E>(
 				_mm256_castsi256_ps(a),
 				_mm256_castsi256_ps(b),
 			))

--- a/crates/arith-bench/src/underlier.rs
+++ b/crates/arith-bench/src/underlier.rs
@@ -102,9 +102,10 @@ pub trait OpsGfni {
 pub trait OpsClmul {
 	fn clmulepi64<const IMM8: i32>(a: Self, b: Self) -> Self;
 
-	fn shuffle_epi32<const IMM8: i32>(a: Self) -> Self;
+	fn duplicate_hi_64(a: Self) -> Self;
+	fn swap_hi_lo_64(a: Self) -> Self;
 
-	fn shuffle_ps<const IMM8: i32>(a: Self, b: Self) -> Self;
+	fn extract_hi_lo_64(a: Self, b: Self) -> Self;
 
 	fn unpacklo_epi64(a: Self, b: Self) -> Self;
 


### PR DESCRIPTION
# Add `Underlier` implementation for AArch64 NEON 

While implementing I realized that is more efficient to have several less generic methods in `Underlier` trait as there are no direct analogues for some shuffles in ARM and implementing them in a generic way would be inefficient.  