### PR TITLE
Add benchmarks for AARCH64 target

### DIFF
--- a/crates/arith-bench/src/arch/mod.rs
+++ b/crates/arith-bench/src/arch/mod.rs
@@ -1,5 +1,9 @@
 #[cfg(target_arch = "x86_64")]
 mod x86_64;
 
-#[cfg(all(target_arch = "aarch64", target_feature = "neon", target_feature = "aes"))]
+#[cfg(all(
+	target_arch = "aarch64",
+	target_feature = "neon",
+	target_feature = "aes"
+))]
 mod aarch64;

--- a/crates/arith-bench/src/underlier.rs
+++ b/crates/arith-bench/src/underlier.rs
@@ -1,5 +1,7 @@
 use std::fmt::Debug;
 
+use rand::RngCore;
+
 /// A type that supports bitwise operations and has a known bit width.
 ///
 /// Underliers are the basic building blocks for field arithmetic operations,
@@ -23,6 +25,9 @@ pub trait Underlier: Sized + Clone + Copy + Debug {
 
 	/// Checks if two underlier values are equal.
 	fn is_equal(a: Self, b: Self) -> bool;
+
+	/// Generates a random value of this underlier type using the provided rng.
+	fn random(rng: impl RngCore) -> Self;
 }
 
 /// An [`Underlier`] that can represent a packed vector of smaller underlier values.
@@ -152,6 +157,13 @@ macro_rules! impl_underlier_for_native_uint {
 			#[inline]
 			fn is_equal(a: Self, b: Self) -> bool {
 				a == b
+			}
+
+			#[inline]
+			fn random(mut rng: impl RngCore) -> Self {
+				use rand::Rng;
+
+				rng.random()
 			}
 		}
 	};


### PR DESCRIPTION
### TL;DR

Add support for ARM64 (AArch64) architecture in field multiplication benchmarks.

### What changed?

- Added conditional compilation for AArch64 architecture alongside x86_64
- Implemented the `random()` method for all `Underlier` types to generate random values
- Modified benchmark functions to use the new `random()` method instead of relying on `StandardUniform` distribution
- Added AArch64-specific benchmark configurations for POLYVAL, GHASH, and Monbijou field operations
- Improved code formatting and cleaned up implementation of AArch64 vector operations
- Renamed the Monbijou benchmark group to clarify it's for 64-bit operations

### How to test?

Run the benchmarks on both x86_64 and AArch64 platforms:

```bash
# On x86_64
cargo bench --bench field_mul

# On AArch64 with NEON and AES features
cargo bench --bench field_mul
```

### Why make this change?

This change enables benchmarking field multiplication operations on ARM64 processors, which are increasingly common in modern devices and servers. By supporting both x86_64 and AArch64 architectures, we can compare performance characteristics across different platforms and optimize our cryptographic implementations accordingly.