### PR TITLE
[field] Refactor to make Field and PackedField inherit Random trait

### DIFF
--- a/crates/field/benches/byte_sliced.rs
+++ b/crates/field/benches/byte_sliced.rs
@@ -2,13 +2,13 @@
 
 use std::hint::black_box;
 
-use binius_field::{PackedField, arch::byte_sliced::*};
+use binius_field::{PackedField, Random, arch::byte_sliced::*};
 use criterion::{Criterion, Throughput, criterion_group, criterion_main};
 
 macro_rules! bench_transform_to_byte_sliced {
 	($byte_sliced:ty, $group:ident) => {{
 		let mut rng = rand::rng();
-		let original = std::array::from_fn(|_| PackedField::random(&mut rng));
+		let original = std::array::from_fn(|_| Random::random(&mut rng));
 
 		$group.throughput(Throughput::Elements(<$byte_sliced>::WIDTH as _));
 		$group.bench_function(stringify!($byte_sliced), |b| {

--- a/crates/field/benches/packed_extension_mul.rs
+++ b/crates/field/benches/packed_extension_mul.rs
@@ -4,7 +4,7 @@ use std::hint::black_box;
 
 use binius_field::{
 	BinaryField1b, BinaryField8b, BinaryField16b, BinaryField128b, ExtensionField, Field,
-	PackedBinaryField2x128b, PackedExtension, PackedField, ext_base_mul,
+	PackedBinaryField2x128b, PackedExtension, PackedField, Random, ext_base_mul,
 	packed::set_packed_slice_unchecked,
 };
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};

--- a/crates/field/benches/packed_field_element_access.rs
+++ b/crates/field/benches/packed_field_element_access.rs
@@ -3,7 +3,7 @@
 use std::array;
 
 use binius_field::{
-	PackedField,
+	PackedField, Random,
 	arch::{byte_sliced::*, packed_128::*, packed_256::*, packed_512::*},
 };
 use criterion::{

--- a/crates/field/benches/packed_field_init.rs
+++ b/crates/field/benches/packed_field_init.rs
@@ -3,7 +3,7 @@
 use std::array;
 
 use binius_field::{
-	PackedField,
+	PackedField, Random,
 	arch::{byte_sliced::*, packed_128::*, packed_256::*, packed_512::*},
 };
 use criterion::{

--- a/crates/field/benches/packed_field_linear_transform.rs
+++ b/crates/field/benches/packed_field_linear_transform.rs
@@ -1,7 +1,7 @@
 // Copyright 2024-2025 Irreducible Inc.
 
 use binius_field::{
-	ExtensionField, PackedField,
+	ExtensionField, Random,
 	arch::{
 		byte_sliced::*, packed_8::*, packed_16::*, packed_32::*, packed_64::*, packed_128::*,
 		packed_256::*, packed_512::*, packed_aes_8::*, packed_aes_16::*, packed_aes_32::*,

--- a/crates/field/benches/packed_field_utils.rs
+++ b/crates/field/benches/packed_field_utils.rs
@@ -168,14 +168,16 @@ macro_rules! benchmark_packed_operation {
             #[allow(non_snake_case)]
 			#[inline(never)]
             fn $packed_field(c: &mut criterion::Criterion) {
+				use binius_field::Random;
+
                 let mut group = c.benchmark_group(format!("{}/{}", stringify!($op_name), stringify!($packed_field)));
                 group.warm_up_time(core::time::Duration::from_secs(1));
                 group.measurement_time(core::time::Duration::from_secs(3));
                 group.throughput(criterion::Throughput::Elements((<$packed_field as binius_field::PackedField>::WIDTH *  $crate::packed_field_utils::BATCH_SIZE) as _));
 
                 let mut rng = rand::rng();
-                let a: $crate::packed_field_utils::Batch<$packed_field> = std::array::from_fn(|_| <$packed_field as binius_field::PackedField>::random(&mut rng));
-                let b: $crate::packed_field_utils::Batch<$packed_field> = std::array::from_fn(|_| <$packed_field as binius_field::PackedField>::random(&mut rng));
+                let a: $crate::packed_field_utils::Batch<$packed_field> = std::array::from_fn(|_| <$packed_field>::random(&mut rng));
+                let b: $crate::packed_field_utils::Batch<$packed_field> = std::array::from_fn(|_| <$packed_field>::random(&mut rng));
 
                 benchmark_packed_operation!(@run_func group, $packed_field, a, b, op_name @ $op_name, strategies @ $strategies);
 

--- a/crates/field/src/aes_field.rs
+++ b/crates/field/src/aes_field.rs
@@ -13,7 +13,6 @@ use binius_utils::{
 	bytes::{Buf, BufMut},
 };
 use bytemuck::{Pod, Zeroable};
-use rand::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 
 use super::{
@@ -357,7 +356,7 @@ mod tests {
 	use super::*;
 	use crate::{
 		PackedAESBinaryField4x32b, PackedAESBinaryField8x32b, PackedAESBinaryField16x32b,
-		PackedBinaryField4x32b, PackedBinaryField8x32b, PackedBinaryField16x32b,
+		PackedBinaryField4x32b, PackedBinaryField8x32b, PackedBinaryField16x32b, Random,
 		binary_field::tests::is_binary_field_valid_generator, underlier::WithUnderlier,
 	};
 
@@ -651,11 +650,11 @@ mod tests {
 	fn test_canonical_serialization() {
 		let mut buffer = BytesMut::new();
 		let mut rng = StdRng::seed_from_u64(0);
-		let aes8 = <AESTowerField8b as Field>::random(&mut rng);
-		let aes16 = <AESTowerField16b as Field>::random(&mut rng);
-		let aes32 = <AESTowerField32b as Field>::random(&mut rng);
-		let aes64 = <AESTowerField64b as Field>::random(&mut rng);
-		let aes128 = <AESTowerField128b as Field>::random(&mut rng);
+		let aes8 = AESTowerField8b::random(&mut rng);
+		let aes16 = AESTowerField16b::random(&mut rng);
+		let aes32 = AESTowerField32b::random(&mut rng);
+		let aes64 = AESTowerField64b::random(&mut rng);
+		let aes128 = AESTowerField128b::random(&mut rng);
 
 		let mode = SerializationMode::CanonicalTower;
 

--- a/crates/field/src/arch/aarch64/m128.rs
+++ b/crates/field/src/arch/aarch64/m128.rs
@@ -12,7 +12,10 @@ use binius_utils::{
 };
 use bytemuck::{Pod, Zeroable};
 use derive_more::Not;
-use rand::RngCore;
+use rand::{
+	Rng,
+	distr::{Distribution, StandardUniform},
+};
 use seq_macro::seq;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 
@@ -21,12 +24,12 @@ use super::super::portable::{
 	packed_arithmetic::{UnderlierWithBitConstants, interleave_mask_even, interleave_mask_odd},
 };
 use crate::{
-	BinaryField,
+	BinaryField, Random,
 	arch::binary_utils::{as_array_mut, as_array_ref},
 	arithmetic_traits::Broadcast,
 	tower_levels::TowerLevel,
 	underlier::{
-		NumCast, Random, SmallU, U1, U2, U4, UnderlierType, UnderlierWithBitOps, WithUnderlier,
+		NumCast, SmallU, U1, U2, U4, UnderlierType, UnderlierWithBitOps, WithUnderlier,
 		impl_divisible, impl_iteration, transpose_128b_values, unpack_lo_128b_fallback,
 	},
 };
@@ -266,9 +269,9 @@ impl ConditionallySelectable for M128 {
 	}
 }
 
-impl Random for M128 {
-	fn random(rng: impl RngCore) -> Self {
-		Self(u128::random(rng))
+impl Distribution<M128> for StandardUniform {
+	fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> M128 {
+		M128(rng.random())
 	}
 }
 

--- a/crates/field/src/arch/portable/byte_sliced/packed_byte_sliced.rs
+++ b/crates/field/src/arch/portable/byte_sliced/packed_byte_sliced.rs
@@ -156,11 +156,6 @@ macro_rules! define_byte_sliced_3d {
 				}
 			}
 
-			fn random(mut rng: impl rand::RngCore) -> Self {
-				let data = array::from_fn(|_| array::from_fn(|_| <$packed_storage>::random(&mut rng)));
-				Self { data }
-			}
-
 			#[allow(unreachable_patterns)]
 			#[inline]
 			fn broadcast(scalar: Self::Scalar) -> Self {
@@ -283,6 +278,14 @@ macro_rules! define_byte_sliced_3d {
 			}
 
 			impl_spread!($name, $scalar_type, $packed_storage, $storage_tower_level);
+		}
+
+		impl ::rand::distr::Distribution<$name> for ::rand::distr::StandardUniform {
+			fn sample<R: ::rand::Rng + ?Sized>(&self, mut rng: &mut R) -> $name {
+				use $crate::Random;
+				let data = array::from_fn(|_| array::from_fn(|_| <$packed_storage>::random(&mut rng)));
+				$name { data }
+			}
 		}
 
 		impl Mul for $name {
@@ -733,11 +736,6 @@ macro_rules! define_byte_sliced_3d_1b {
 				}
 			}
 
-			fn random(mut rng: impl rand::RngCore) -> Self {
-				let data = array::from_fn(|_| <$packed_storage>::random(&mut rng));
-				Self { data }
-			}
-
 			impl_init_with_transpose!($packed_storage, BinaryField1b, $storage_tower_level);
 
 			// Benchmarks show that transposing before the iteration makes it slower for 1b case,
@@ -840,6 +838,14 @@ macro_rules! define_byte_sliced_3d_1b {
 			}
 
 			impl_spread!($name, BinaryField1b, $packed_storage, $storage_tower_level);
+		}
+
+		impl ::rand::distr::Distribution<$name> for ::rand::distr::StandardUniform {
+			fn sample<R: ::rand::Rng + ?Sized>(&self, mut rng: &mut R) -> $name {
+				use $crate::Random;
+				let data = array::from_fn(|_| <$packed_storage>::random(&mut rng));
+				$name { data }
+			}
 		}
 
 		impl Mul for $name {

--- a/crates/field/src/arch/portable/byte_sliced/underlier.rs
+++ b/crates/field/src/arch/portable/byte_sliced/underlier.rs
@@ -2,10 +2,16 @@
 
 use binius_utils::checked_arithmetics::checked_log_2;
 use bytemuck::{Pod, Zeroable};
-use rand::RngCore;
+use rand::{
+	Rng,
+	distr::{Distribution, StandardUniform},
+};
 use subtle::{Choice, ConstantTimeEq};
 
-use crate::underlier::{Random, ScaledUnderlier, UnderlierType};
+use crate::{
+	Random,
+	underlier::{ScaledUnderlier, UnderlierType},
+};
 
 /// Unerlier for byte-sliced fields. Even though it may seem to be equivalent to
 /// `ScaledUnderlier<U, N>`, it is not. The difference is in order of bytes,
@@ -14,9 +20,9 @@ use crate::underlier::{Random, ScaledUnderlier, UnderlierType};
 #[repr(transparent)]
 pub struct ByteSlicedUnderlier<U, const N: usize>(ScaledUnderlier<U, N>);
 
-impl<U: Random, const N: usize> Random for ByteSlicedUnderlier<U, N> {
-	fn random(mut rng: impl RngCore) -> Self {
-		Self(Random::random(&mut rng))
+impl<U: Random, const N: usize> Distribution<ByteSlicedUnderlier<U, N>> for StandardUniform {
+	fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> ByteSlicedUnderlier<U, N> {
+		ByteSlicedUnderlier(rng.random())
 	}
 }
 

--- a/crates/field/src/arch/portable/packed.rs
+++ b/crates/field/src/arch/portable/packed.rs
@@ -15,7 +15,10 @@ use std::{
 
 use binius_utils::{checked_arithmetics::checked_int_div, iter::IterExtensions};
 use bytemuck::{Pod, TransparentWrapper, Zeroable};
-use rand::RngCore;
+use rand::{
+	Rng,
+	distr::{Distribution, StandardUniform},
+};
 use subtle::{Choice, ConstantTimeEq};
 
 use super::packed_arithmetic::UnderlierWithBitConstants;
@@ -308,10 +311,6 @@ where
 		Self::from_underlier(U::ZERO)
 	}
 
-	fn random(rng: impl RngCore) -> Self {
-		U::random(rng).into()
-	}
-
 	#[inline]
 	fn iter(&self) -> impl Iterator<Item = Self::Scalar> + Send + Clone + '_ {
 		IterationMethods::<Scalar::Underlier, U>::ref_iter(&self.0)
@@ -381,6 +380,14 @@ where
 	#[inline]
 	fn invert_or_zero(self) -> Self {
 		<Self as InvertOrZero>::invert_or_zero(self)
+	}
+}
+
+impl<U: UnderlierType, Scalar: BinaryField> Distribution<PackedPrimitiveType<U, Scalar>>
+	for StandardUniform
+{
+	fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> PackedPrimitiveType<U, Scalar> {
+		PackedPrimitiveType::from_underlier(U::random(rng))
 	}
 }
 

--- a/crates/field/src/arch/portable/packed_scaled.rs
+++ b/crates/field/src/arch/portable/packed_scaled.rs
@@ -12,7 +12,10 @@ use binius_utils::{
 	checked_arithmetics::checked_log_2,
 };
 use bytemuck::{Pod, TransparentWrapper, Zeroable};
-use rand::RngCore;
+use rand::{
+	Rng,
+	distr::{Distribution, StandardUniform},
+};
 use subtle::ConstantTimeEq;
 
 use crate::{
@@ -295,10 +298,6 @@ where
 		Self(array::from_fn(|_| PT::zero()))
 	}
 
-	fn random(mut rng: impl RngCore) -> Self {
-		Self(array::from_fn(|_| PT::random(&mut rng)))
-	}
-
 	#[inline]
 	fn broadcast(scalar: Self::Scalar) -> Self {
 		Self(array::from_fn(|_| PT::broadcast(scalar)))
@@ -389,6 +388,15 @@ where
 			unsafe { std::slice::from_raw_parts(slice.as_ptr() as *const [PT; N], slice.len()) };
 
 		PT::iter_slice(cast_slice.as_flattened())
+	}
+}
+
+impl<PT: PackedField, const N: usize> Distribution<ScaledPackedField<PT, N>> for StandardUniform
+where
+	[PT; N]: Default,
+{
+	fn sample<R: Rng + ?Sized>(&self, mut rng: &mut R) -> ScaledPackedField<PT, N> {
+		ScaledPackedField(array::from_fn(|_| PT::random(&mut rng)))
 	}
 }
 

--- a/crates/field/src/arch/x86_64/m128.rs
+++ b/crates/field/src/arch/x86_64/m128.rs
@@ -12,7 +12,10 @@ use binius_utils::{
 	serialization::{assert_enough_data_for, assert_enough_space_for},
 };
 use bytemuck::{Pod, Zeroable};
-use rand::{Rng, RngCore};
+use rand::{
+	Rng,
+	distr::{Distribution, StandardUniform},
+};
 use seq_macro::seq;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 
@@ -30,7 +33,7 @@ use crate::{
 	arithmetic_traits::Broadcast,
 	tower_levels::TowerLevel,
 	underlier::{
-		NumCast, Random, SmallU, SpreadToByte, U1, U2, U4, UnderlierType, UnderlierWithBitOps,
+		NumCast, SmallU, SpreadToByte, U1, U2, U4, UnderlierType, UnderlierWithBitOps,
 		WithUnderlier, impl_divisible, impl_iteration, spread_fallback, transpose_128b_values,
 		unpack_hi_128b_fallback, unpack_lo_128b_fallback,
 	},
@@ -318,10 +321,9 @@ impl ConditionallySelectable for M128 {
 	}
 }
 
-impl Random for M128 {
-	fn random(mut rng: impl RngCore) -> Self {
-		let val: u128 = rng.random();
-		val.into()
+impl Distribution<M128> for StandardUniform {
+	fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> M128 {
+		M128(rng.random())
 	}
 }
 

--- a/crates/field/src/arch/x86_64/m256.rs
+++ b/crates/field/src/arch/x86_64/m256.rs
@@ -13,12 +13,15 @@ use binius_utils::{
 };
 use bytemuck::{Pod, Zeroable, must_cast};
 use cfg_if::cfg_if;
-use rand::{Rng, RngCore};
+use rand::{
+	Rng,
+	distr::{Distribution, StandardUniform},
+};
 use seq_macro::seq;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 
 use crate::{
-	BinaryField,
+	BinaryField, Random,
 	arch::{
 		binary_utils::{as_array_mut, as_array_ref, make_func_to_i8},
 		portable::{
@@ -32,7 +35,7 @@ use crate::{
 	arithmetic_traits::Broadcast,
 	tower_levels::TowerLevel,
 	underlier::{
-		NumCast, Random, SmallU, U1, U2, U4, UnderlierType, UnderlierWithBitOps, WithUnderlier,
+		NumCast, SmallU, U1, U2, U4, UnderlierType, UnderlierWithBitOps, WithUnderlier,
 		get_block_values, get_spread_bytes, impl_divisible, impl_iteration,
 		pair_unpack_lo_hi_128b_lanes, spread_fallback, transpose_128b_blocks_low_to_high,
 		unpack_hi_128b_fallback, unpack_lo_128b_fallback,
@@ -327,8 +330,8 @@ impl ConditionallySelectable for M256 {
 	}
 }
 
-impl Random for M256 {
-	fn random(mut rng: impl RngCore) -> Self {
+impl Distribution<M256> for StandardUniform {
+	fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> M256 {
 		let val: [u128; 2] = rng.random();
 		val.into()
 	}

--- a/crates/field/src/arch/x86_64/m512.rs
+++ b/crates/field/src/arch/x86_64/m512.rs
@@ -12,12 +12,15 @@ use binius_utils::{
 	serialization::{assert_enough_data_for, assert_enough_space_for},
 };
 use bytemuck::{Pod, Zeroable, must_cast};
-use rand::{Rng, RngCore};
+use rand::{
+	Rng,
+	distr::{Distribution, StandardUniform},
+};
 use seq_macro::seq;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 
 use crate::{
-	BinaryField,
+	BinaryField, Random,
 	arch::{
 		binary_utils::{as_array_mut, as_array_ref, make_func_to_i8},
 		portable::{
@@ -34,7 +37,7 @@ use crate::{
 	arithmetic_traits::Broadcast,
 	tower_levels::TowerLevel,
 	underlier::{
-		NumCast, Random, SmallU, U1, U2, U4, UnderlierType, UnderlierWithBitOps, WithUnderlier,
+		NumCast, SmallU, U1, U2, U4, UnderlierType, UnderlierWithBitOps, WithUnderlier,
 		get_block_values, get_spread_bytes, impl_divisible, impl_iteration,
 		pair_unpack_lo_hi_128b_lanes, spread_fallback, transpose_128b_blocks_low_to_high,
 		unpack_hi_128b_fallback, unpack_lo_128b_fallback,
@@ -378,8 +381,8 @@ impl ConditionallySelectable for M512 {
 	}
 }
 
-impl Random for M512 {
-	fn random(mut rng: impl RngCore) -> Self {
+impl Distribution<M512> for StandardUniform {
+	fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> M512 {
 		let val: [u128; 4] = rng.random();
 		val.into()
 	}

--- a/crates/field/src/binary_field.rs
+++ b/crates/field/src/binary_field.rs
@@ -12,7 +12,6 @@ use binius_utils::{
 	bytes::{Buf, BufMut},
 };
 use bytemuck::{Pod, Zeroable};
-use rand::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 
 use super::{
@@ -317,12 +316,14 @@ macro_rules! binary_field {
 			const ONE: Self = $name::new(<$typ as $crate::underlier::UnderlierWithBitOps>::ONE);
 			const CHARACTERISTIC: usize = 2;
 
-			fn random(mut rng: impl RngCore) -> Self {
-				Self(<$typ as $crate::underlier::Random>::random(&mut rng))
-			}
-
 			fn double(&self) -> Self {
 				Self::ZERO
+			}
+		}
+
+		impl ::rand::distr::Distribution<$name> for ::rand::distr::StandardUniform {
+			fn sample<R: ::rand::Rng + ?Sized>(&self, rng: &mut R) -> $name {
+				$name(rng.random())
 			}
 		}
 

--- a/crates/field/src/field.rs
+++ b/crates/field/src/field.rs
@@ -8,9 +8,9 @@ use std::{
 };
 
 use binius_utils::{DeserializeBytes, SerializeBytes};
-use rand::RngCore;
 
 use crate::{
+	Random,
 	arithmetic_traits::{InvertOrZero, Square},
 	as_packed_field::PackScalar,
 	underlier::WithUnderlier,
@@ -48,6 +48,7 @@ pub trait Field:
 	+ for<'a> MulAssign<&'a Self>
 	+ Square
 	+ InvertOrZero
+	+ Random
 	// `Underlier: PackScalar<Self>` is an obvious property but it can't be deduced by the compiler so we are id here.
 	+ WithUnderlier<Underlier: PackScalar<Self>>
 	+ SerializeBytes
@@ -61,9 +62,6 @@ pub trait Field:
 
 	/// The characteristic of the field.
 	const CHARACTERISTIC: usize;
-
-	/// Returns an element chosen uniformly at random using a user-provided RNG.
-	fn random(rng: impl RngCore) -> Self;
 
 	/// Returns true iff this element is zero.
 	fn is_zero(&self) -> bool {

--- a/crates/field/src/lib.rs
+++ b/crates/field/src/lib.rs
@@ -28,6 +28,7 @@ pub mod packed_extension;
 pub mod packed_extension_ops;
 mod packed_polyval;
 pub mod polyval;
+mod random;
 #[cfg(test)]
 mod tests;
 pub mod tower;
@@ -50,4 +51,5 @@ pub use packed_extension::*;
 pub use packed_extension_ops::*;
 pub use packed_polyval::*;
 pub use polyval::*;
+pub use random::Random;
 pub use transpose::{Error as TransposeError, square_transpose};

--- a/crates/field/src/packed_binary_field.rs
+++ b/crates/field/src/packed_binary_field.rs
@@ -886,7 +886,7 @@ mod tests {
 		*,
 	};
 	use crate::{
-		Field, PackedField, PackedFieldIndexable,
+		PackedField, PackedFieldIndexable, Random,
 		arch::{
 			packed_aes_16::*, packed_aes_32::*, packed_aes_64::*, packed_aes_128::*,
 			packed_aes_256::*, packed_aes_512::*,
@@ -922,9 +922,9 @@ mod tests {
 		let mut rng = StdRng::seed_from_u64(0);
 		let mut elem = P::random(&mut rng);
 
-		let scalars = repeat_with(|| Field::random(&mut rng))
+		let scalars = repeat_with(|| P::Scalar::random(&mut rng))
 			.take(P::WIDTH)
-			.collect::<Vec<P::Scalar>>();
+			.collect::<Vec<_>>();
 
 		for (i, val) in scalars.iter().enumerate() {
 			elem.set(i, *val);

--- a/crates/field/src/random.rs
+++ b/crates/field/src/random.rs
@@ -1,0 +1,18 @@
+// Copyright 2024-2025 Irreducible Inc.
+
+use rand::distr::{Distribution, StandardUniform};
+
+/// A value that can be randomly generated
+pub trait Random {
+	/// Generate random value
+	fn random(rng: impl rand::Rng) -> Self;
+}
+
+impl<T> Random for T
+where
+	StandardUniform: Distribution<T>,
+{
+	fn random(mut rng: impl rand::Rng) -> Self {
+		rng.random()
+	}
+}

--- a/crates/field/src/underlier/scaled.rs
+++ b/crates/field/src/underlier/scaled.rs
@@ -7,11 +7,14 @@ use std::{
 
 use binius_utils::checked_arithmetics::checked_log_2;
 use bytemuck::{NoUninit, Pod, Zeroable, must_cast_mut, must_cast_ref};
-use rand::RngCore;
+use rand::{
+	Rng,
+	distr::{Distribution, StandardUniform},
+};
 use subtle::{Choice, ConstantTimeEq};
 
-use super::{Divisible, NumCast, Random, UnderlierType, UnderlierWithBitOps};
-use crate::tower_levels::TowerLevel;
+use super::{Divisible, NumCast, UnderlierType, UnderlierWithBitOps};
+use crate::{Random, tower_levels::TowerLevel};
 
 /// A type that represents a pair of elements of the same underlier type.
 /// We use it as an underlier for the `ScaledPackedField` type.
@@ -25,9 +28,9 @@ impl<U: Default, const N: usize> Default for ScaledUnderlier<U, N> {
 	}
 }
 
-impl<U: Random, const N: usize> Random for ScaledUnderlier<U, N> {
-	fn random(mut rng: impl RngCore) -> Self {
-		Self(array::from_fn(|_| U::random(&mut rng)))
+impl<U: Random, const N: usize> Distribution<ScaledUnderlier<U, N>> for StandardUniform {
+	fn sample<R: Rng + ?Sized>(&self, mut rng: &mut R) -> ScaledUnderlier<U, N> {
+		ScaledUnderlier(array::from_fn(|_| U::random(&mut rng)))
 	}
 }
 

--- a/crates/field/src/underlier/small_uint.rs
+++ b/crates/field/src/underlier/small_uint.rs
@@ -14,10 +14,13 @@ use binius_utils::{
 };
 use bytemuck::{NoUninit, Zeroable};
 use derive_more::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign};
-use rand::Rng;
+use rand::{
+	Rng,
+	distr::{Distribution, StandardUniform},
+};
 use subtle::{ConditionallySelectable, ConstantTimeEq};
 
-use super::{Random, UnderlierType, underlier_with_bit_ops::UnderlierWithBitOps};
+use super::{UnderlierType, underlier_with_bit_ops::UnderlierWithBitOps};
 
 /// Unsigned type with a size strictly less than 8 bits.
 #[derive(
@@ -108,9 +111,9 @@ impl<const N: usize> ConditionallySelectable for SmallU<N> {
 	}
 }
 
-impl<const N: usize> Random for SmallU<N> {
-	fn random(mut rng: impl Rng) -> Self {
-		Self(rng.random_range(0..1u8 << N))
+impl<const N: usize> Distribution<SmallU<N>> for StandardUniform {
+	fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> SmallU<N> {
+		SmallU(rng.random_range(0..1u8 << N))
 	}
 }
 

--- a/crates/field/src/underlier/underlier_type.rs
+++ b/crates/field/src/underlier/underlier_type.rs
@@ -3,8 +3,9 @@
 use std::fmt::Debug;
 
 use bytemuck::{NoUninit, Zeroable};
-use rand::distr::{Distribution, StandardUniform};
 use subtle::ConstantTimeEq;
+
+use crate::Random;
 
 /// Primitive integer underlying a binary field or packed binary field implementation.
 /// Note that this type is not guaranteed to be POD, U1, U2 and U4 have some unused bits.
@@ -158,21 +159,6 @@ unsafe impl<U: UnderlierType> WithUnderlier for U {
 	#[inline]
 	fn from_underliers_ref_mut(val: &mut [Self::Underlier]) -> &mut [Self] {
 		val
-	}
-}
-
-/// A value that can be randomly generated
-pub trait Random {
-	/// Generate random value
-	fn random(rng: impl rand::Rng) -> Self;
-}
-
-impl<T> Random for T
-where
-	StandardUniform: Distribution<T>,
-{
-	fn random(mut rng: impl rand::Rng) -> Self {
-		rng.random()
 	}
 }
 

--- a/crates/math/src/ntt/odd_interpolate.rs
+++ b/crates/math/src/ntt/odd_interpolate.rs
@@ -154,7 +154,7 @@ where
 mod tests {
 	use std::iter::repeat_with;
 
-	use binius_field::{BinaryField32b, Field};
+	use binius_field::{BinaryField32b, Field, Random};
 	use binius_utils::checked_arithmetics::log2_ceil_usize;
 	use rand::{SeedableRng, rngs::StdRng};
 

--- a/crates/math/src/ntt/single_threaded.rs
+++ b/crates/math/src/ntt/single_threaded.rs
@@ -464,7 +464,7 @@ mod tests {
 
 	use assert_matches::assert_matches;
 	use binius_field::{
-		BinaryField8b, BinaryField16b, Field, PackedBinaryField8x16b, PackedFieldIndexable,
+		BinaryField8b, BinaryField16b, Field, PackedBinaryField8x16b, PackedFieldIndexable, Random,
 	};
 	use rand::{SeedableRng, rngs::StdRng};
 
@@ -504,7 +504,7 @@ mod tests {
 		let ntt = SingleThreadedNTT::<BinaryField16b>::new(log_len + 2).unwrap();
 
 		let mut rng = StdRng::seed_from_u64(0);
-		let msg = repeat_with(|| <BinaryField16b as Field>::random(&mut rng))
+		let msg = repeat_with(|| BinaryField16b::random(&mut rng))
 			.take(1 << log_len)
 			.collect::<Vec<_>>();
 

--- a/crates/math/src/ntt/tests/ntt_tests.rs
+++ b/crates/math/src/ntt/tests/ntt_tests.rs
@@ -5,7 +5,7 @@ use std::ops::Range;
 use binius_field::{
 	AESTowerField8b, BinaryField, BinaryField8b, ByteSlicedAES8x16x16b, ByteSlicedAES16x32x8b,
 	PackedBinaryField8x32b, PackedBinaryField16x32b, PackedBinaryField32x16b, PackedExtension,
-	PackedField, RepackedExtension,
+	PackedField, Random, RepackedExtension,
 	arch::{
 		packed_8::PackedBinaryField1x8b,
 		packed_16::{PackedBinaryField1x16b, PackedBinaryField2x8b},

--- a/crates/prover/benches/binary_merkle_tree.rs
+++ b/crates/prover/benches/binary_merkle_tree.rs
@@ -2,7 +2,7 @@
 
 use std::iter::repeat_with;
 
-use binius_field::Field;
+use binius_field::Random;
 use binius_prover::merkle_tree::{MerkleTreeProver, prover::BinaryMerkleTreeProver};
 use binius_verifier::{
 	fields::B64,
@@ -23,9 +23,9 @@ where
 {
 	let merkle_prover = BinaryMerkleTreeProver::<_, H, C>::new(compression);
 	let mut rng = rand::rng();
-	let data: Vec<F> = repeat_with(|| Field::random(&mut rng))
+	let data = repeat_with(|| F::random(&mut rng))
 		.take(1 << (LOG_ELEMS + LOG_ELEMS_IN_LEAF))
-		.collect();
+		.collect::<Vec<_>>();
 	let mut group = c.benchmark_group(format!("slow/merkle_tree/{hash_name}"));
 	group.throughput(Throughput::Bytes(
 		((1 << (LOG_ELEMS + LOG_ELEMS_IN_LEAF)) * std::mem::size_of::<F>()) as u64,

--- a/crates/prover/src/merkle_tree/tests.rs
+++ b/crates/prover/src/merkle_tree/tests.rs
@@ -3,7 +3,7 @@
 use core::slice;
 use std::iter::repeat_with;
 
-use binius_field::{BinaryField16b, Field};
+use binius_field::{BinaryField16b, Random};
 use binius_transcript::ProverTranscript;
 use binius_verifier::{
 	config::StdChallenger,
@@ -20,9 +20,9 @@ fn test_binary_merkle_vcs_commit_prove_open_correctly() {
 
 	let mr_prover = BinaryMerkleTreeProver::<_, StdDigest, _>::new(StdCompression::default());
 
-	let data = repeat_with(|| Field::random(&mut rng))
+	let data = repeat_with(|| BinaryField16b::random(&mut rng))
 		.take(16)
-		.collect::<Vec<BinaryField16b>>();
+		.collect::<Vec<_>>();
 	let (commitment, tree) = mr_prover.commit(&data, 1).unwrap();
 
 	assert_eq!(commitment.root, tree.root());
@@ -54,9 +54,9 @@ fn test_binary_merkle_vcs_commit_layer_prove_open_correctly() {
 
 	let mr_prover = BinaryMerkleTreeProver::<_, StdDigest, _>::new(StdCompression::default());
 
-	let data = repeat_with(|| Field::random(&mut rng))
+	let data = repeat_with(|| BinaryField16b::random(&mut rng))
 		.take(32)
-		.collect::<Vec<BinaryField16b>>();
+		.collect::<Vec<_>>();
 	let (commitment, tree) = mr_prover.commit(&data, 1).unwrap();
 
 	assert_eq!(commitment.root, tree.root());
@@ -94,9 +94,9 @@ fn test_binary_merkle_vcs_verify_vector() {
 
 	let mr_prover = BinaryMerkleTreeProver::<_, StdDigest, _>::new(StdCompression::default());
 
-	let data = repeat_with(|| Field::random(&mut rng))
+	let data = repeat_with(|| BinaryField16b::random(&mut rng))
 		.take(4)
-		.collect::<Vec<BinaryField16b>>();
+		.collect::<Vec<_>>();
 	let (commitment, _) = mr_prover.commit(&data, 1).unwrap();
 
 	mr_prover


### PR DESCRIPTION
This refactor moves the `random` methods on Field and PackedField into a common supertrait, `Random`. This is shared with `Underlier` as well.

This resolves a long-standing annoyance that all `Field` implementations have an ambiguous definition of `random`. This is because there is a blanket impl of `PackedField` for `F: Field`. Now the ambiguity is resolved because the method is defined by the `Random` trait.