### PR TITLE
intmul starter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Cargo.lock
 CLAUDE.local.md
 /.idea/
 **/.DS_Store
+/.vscode

--- a/crates/arith-bench/benches/field_mul.rs
+++ b/crates/arith-bench/benches/field_mul.rs
@@ -258,56 +258,56 @@ fn bench_ghash(c: &mut Criterion) {
 
 	group.finish();
 
-	let mut group = c.benchmark_group("ghash_google_mul_clmul");
+	// let mut group = c.benchmark_group("ghash_google_mul_clmul");
 
-	// Benchmark __m128i
-	#[cfg(all(target_feature = "pclmulqdq", target_feature = "sse2"))]
-	{
-		run_google_mul_benchmark(
-			&mut group,
-			"mul_clmul::<__m128i>",
-			mul_clmul::<__m128i>,
-			&mut rng,
-			128,
-			__m128i::BITS,
-		);
-	}
+	// // Benchmark __m128i
+	// #[cfg(all(target_feature = "pclmulqdq", target_feature = "sse2"))]
+	// {
+	// 	run_google_mul_benchmark(
+	// 		&mut group,
+	// 		"mul_clmul::<__m128i>",
+	// 		mul_clmul::<__m128i>,
+	// 		&mut rng,
+	// 		128,
+	// 		__m128i::BITS,
+	// 	);
+	// }
 
-	// Benchmark __m256i
-	#[cfg(all(
-		target_feature = "vpclmulqdq",
-		target_feature = "avx2",
-		target_feature = "sse2"
-	))]
-	{
-		run_google_mul_benchmark(
-			&mut group,
-			"mul_clmul::<__m256i>",
-			mul_clmul::<__m256i>,
-			&mut rng,
-			128,
-			__m256i::BITS,
-		);
-	}
+	// // Benchmark __m256i
+	// #[cfg(all(
+	// 	target_feature = "vpclmulqdq",
+	// 	target_feature = "avx2",
+	// 	target_feature = "sse2"
+	// ))]
+	// {
+	// 	run_google_mul_benchmark(
+	// 		&mut group,
+	// 		"mul_clmul::<__m256i>",
+	// 		mul_clmul::<__m256i>,
+	// 		&mut rng,
+	// 		128,
+	// 		__m256i::BITS,
+	// 	);
+	// }
 
-	// Benchmark uint64x2_t (AARCH64 NEON)
-	#[cfg(all(
-		target_arch = "aarch64",
-		target_feature = "neon",
-		target_feature = "aes"
-	))]
-	{
-		run_google_mul_benchmark(
-			&mut group,
-			"mul_clmul::uint64x2_t",
-			mul_clmul::<uint64x2_t>,
-			&mut rng,
-			128,
-			uint64x2_t::BITS,
-		);
-	}
+	// // Benchmark uint64x2_t (AARCH64 NEON)
+	// #[cfg(all(
+	// 	target_arch = "aarch64",
+	// 	target_feature = "neon",
+	// 	target_feature = "aes"
+	// ))]
+	// {
+	// 	run_google_mul_benchmark(
+	// 		&mut group,
+	// 		"mul_clmul::uint64x2_t",
+	// 		mul_clmul::<uint64x2_t>,
+	// 		&mut rng,
+	// 		128,
+	// 		uint64x2_t::BITS,
+	// 	);
+	// }
 
-	group.finish();
+	// group.finish();
 }
 
 /// Benchmark GF(2^64) Monbijou multiplication using CLMUL instructions
@@ -372,7 +372,7 @@ fn bench_monbijou(c: &mut Criterion) {
 /// Benchmark GF(2^128) Monbijou 128-bit extension field multiplication using CLMUL instructions
 #[allow(unused_imports, unused_variables, unused_mut)]
 fn bench_monbijou_128b(c: &mut Criterion) {
-	use binius_arith_bench::monbijou::mul_128b_clmul;
+	use binius_arith_bench::monbijou::{mul_128b_clmul, mul_128b_mine, mul_128b_wo_karatsuba};
 
 	let mut rng = rand::rng();
 
@@ -405,6 +405,23 @@ fn bench_monbijou_128b(c: &mut Criterion) {
 			&mut rng,
 			128,
 			__m256i::BITS,
+		);
+	}
+
+	// my stuff
+	#[cfg(all(
+		target_arch = "aarch64",
+		target_feature = "neon",
+		target_feature = "aes"
+	))]
+	{
+		run_mul_benchmark(
+			&mut group,
+			"mul_128b_mine::uint64x2_t",
+			mul_128b_wo_karatsuba,
+			&mut rng,
+			128,
+			uint64x2_t::BITS,
 		);
 	}
 

--- a/crates/arith-bench/benches/notes.tex
+++ b/crates/arith-bench/benches/notes.tex
@@ -1,0 +1,259 @@
+
+
+THEIRS
+ldr q0, [x0]
+ldr q1, [x1]
+pmull.1q v2, v0, v1
+dup.2d v3, v1[0]
+pmull2.1q v3, v0, v3
+dup.2d v4, v0[0]
+pmull2.1q v4, v4, v1
+eor.16b v3, v4, v3
+pmull2.1q v0, v0, v1
+eor.16b v1, v0, v2
+add.2d v2, v0, v0
+cmlt.4s v0, v0, #0
+mov w9, #27
+dup.2d v4, x9
+rev64.4s v0, v0
+and.16b v0, v0, v4
+eor3.16b v0, v2, v3, v0
+pmull2.1q v2, v1, v4
+pmull2.1q v3, v0, v4
+zip1.2d v0, v1, v0
+zip1.2d v1, v2, v3
+pmull2.1q v2, v2, v4
+pmull2.1q v3, v3, v4
+zip1.2d v2, v2, v3
+eor3.16b v0, v0, v1, v2
+str q0, [x8]
+ret
+
+
+ldr q0, [x0]
+ldr q1, [x1]
+pmull.1q v2, v0, v1
+dup.2d v3, v1[0]
+pmull2.1q v3, v0, v3
+dup.2d v4, v0[0]
+pmull2.1q v4, v4, v1
+eor.16b v3, v4, v3
+pmull2.1q v0, v0, v1
+eor.16b v1, v0, v2
+add.2d v0, v0, v0
+eor.16b v0, v0, v3
+mov w9, #27
+dup.2d v2, x9
+pmull2.1q v3, v1, v2
+pmull2.1q v4, v0, v2
+zip1.2d v0, v1, v0
+zip1.2d v1, v3, v4
+pmull2.1q v3, v3, v2
+pmull2.1q v2, v4, v2
+zip1.2d v2, v3, v2
+eor3.16b v0, v1, v0, v2
+str q0, [x8]
+
+ldr q0, [x0]          ; Load 128 bits from memory at address in x0 into vector register q0 (your first input a_vec)
+ldr q1, [x1]          ; Load 128 bits from memory at address in x1 into vector register q1 (your second input b_vec)
+
+pmull.1q v2, v0, v1   ; Polynomial multiply low 64-bits: v2 = v0[0] * v1[0] (t0 = x.lo * y.lo)
+
+dup.2d v3, v1[0]      ; Duplicate v1[0] (low 64 bits of y) across both lanes of v3
+pmull2.1q v3, v0, v3  ; Polynomial multiply high 64-bits of v0 with v3: v3 = v0[1] * v1[0] (part of t1b)
+
+dup.2d v4, v0[0]      ; Duplicate v0[0] (low 64 bits of x) across both lanes of v4
+pmull2.1q v4, v4, v1  ; Polynomial multiply v4 with high 64-bits of v1: v4 = v0[0] * v1[1] (part of t1a)
+
+eor.16b v3, v4, v3    ; XOR the results: v3 = v4 ^ v3 (t1 = t1a ^ t1b)
+
+pmull2.1q v0, v0, v1  ; Polynomial multiply high 64-bits: v0 = v0[1] * v1[1] (t2 = x.hi * y.hi)
+
+eor.16b v1, v0, v2    ; XOR v0 and v2: v1 = v0 ^ v2 (term0 = t0 ^ t2)
+
+add.2d v2, v0, v0     ; Double v0: v2 = v0 + v0 (t2_times_x = t2 << 1)
+cmlt.4s v0, v0, #0    ; Set each element of v0 to all 1s if it's < 0, else 0 (gets MSB - creates overflow mask)
+mov w9, #27           ; Set w9 = 27 (0x1B, the reduction polynomial)
+dup.2d v4, x9         ; Duplicate w9 (0x1B) across both lanes of v4
+
+rev64.4s v0, v0       ; Reverse bytes within each 64-bit element of v0 (adjusts bit order for mask)
+and.16b v0, v0, v4    ; AND the mask with the polynomial: v0 = v0 & v4 (t2_overflow_redc)
+
+eor3.16b v0, v2, v3, v0   ; Triple XOR: v0 = v2 ^ v3 ^ v0 (term1 = t2_times_x ^ t1 ^ t2_overflow_redc)
+
+; The next section is the reduce_pair implementation
+pmull2.1q v2, v1, v4  ; More polynomial multiplications for reduction
+pmull2.1q v3, v0, v4
+zip1.2d v0, v1, v0    ; Interleave elements for reduction
+zip1.2d v1, v2, v3
+pmull2.1q v2, v2, v4  ; Final polynomial multiplications
+pmull2.1q v3, v3, v4
+zip1.2d v2, v2, v3
+eor3.16b v0, v0, v1, v2   ; Final XOR combining all parts
+
+str q0, [x8]          ; Store result at memory address in x8
+ret                   ; Return
+
+
+
+
+\section{GHASH}
+ldr q0, [x0]
+ldr q1, [x1]
+dup.2d v2, v1[0]
+pmull2.1q v2, v0, v2
+dup.2d v3, v0[0]
+pmull2.1q v3, v3, v1
+eor.16b v2, v3, v2
+pmull2.1q v3, v0, v1
+movi.2d v4, #0000000000000000
+ext.16b v5, v4, v3, #8
+mov w9, #135
+dup.2d v6, x9
+pmull2.1q v3, v3, v6
+eor3.16b v2, v2, v5, v3
+pmull.1q v0, v0, v1
+ext.16b v1, v4, v2, #8
+pmull2.1q v2, v2, v6
+eor3.16b v0, v2, v0, v1
+str q0, [x8]
+ret
+
+l + m * x^64 + h * x^128
+= l + (m_lo * x^64 + m_hi * x^128) + (h_lo * x^128 + h_hi * x^64 * x^128)
+= l + x^64 [m_lo, m_hi] + x^64 [0, h_lo] + x^64 [p_lo, p_hi]
+where p = h_hi * (x^7 + x^2 + x + 1)
+
+\subsection{Commented}
+
+ldr q0, [x0]          ; Load first operand (128 bits) into v0
+ldr q1, [x1]          ; Load second operand (128 bits) into v1
+
+; Computing cross products (middle terms)
+dup.2d v2, v1[0]      ; Duplicate low 64 bits of v1 to both lanes of v2
+pmull2.1q v2, v0, v2  ; v2 = high 64 bits of v0 * low 64 bits of v1 (cross product)
+dup.2d v3, v0[0]      ; Duplicate low 64 bits of v0 to both lanes of v3
+pmull2.1q v3, v3, v1  ; v3 = low 64 bits of v0 * high 64 bits of v1 (cross product)
+eor.16b v2, v3, v2    ; v2 = v3 ^ v2 (combine cross products)
+
+; Computing high product term
+pmull2.1q v3, v0, v1  ; v3 = high 64 bits of v0 * high 64 bits of v1
+
+% v0 holds l
+% v2 holds m
+% v3 holds h
+% v5 holds lower half of v3
+% v6 holds constant in both lanes
+% 
+
+% we need to add v0 to v2. what's in v2?
+% v1 holds 
+
+% M = a
+
+% H_high * x^128
+% 
+
+% but low of h into v5
+
+
+; Setting up for reduction
+movi.2d v4, #0000000000000000  ; v4 = 0 (used for extending)
+ext.16b v5, v4, v3, #8         ; v5 = v3 shifted right by 8 bytes (high 64 bits to low position)
+mov w9, #135                   ; w9 = 0x87 (reduction polynomial, with 1 in the 7th bit = 0x80)
+dup.2d v6, x9                  ; v6 = reduction polynomial duplicated across lanes
+
+; First reduction step
+pmull2.1q v3, v3, v6           ; v3 = high bits * reduction polynomial
+eor3.16b v2, v2, v5, v3        ; v2 = middle terms ^ shifted high bits ^ reduced high bits
+
+; Computing low product term
+pmull.1q v0, v0, v1            ; v0 = low 64 bits of v0 * low 64 bits of v1
+
+; Second reduction step
+ext.16b v1, v4, v2, #8         ; v1 = v2 shifted right by 8 bytes
+pmull2.1q v2, v2, v6           ; v2 = high bits of v2 * reduction polynomial
+eor3.16b v0, v2, v0, v1        ; v0 = reduced high bits ^ low product ^ shifted middle terms
+
+str q0, [x8]                   ; Store result
+ret                            ; Return
+
+\section{MONBIJOU}
+
+MINE
+ldr q0, [x0]
+ldr q1, [x1]
+pmull.1q v2, v0, v1
+pmull2.1q v3, v0, v1
+eor.16b v4, v3, v2
+mov.d x9, v3[1]
+dup.2d v5, v1[1]
+eor.8b v1, v5, v1
+dup.2d v5, v0[1]
+eor.8b v0, v5, v0
+pmull.1q v0, v0, v1
+eor3.16b v0, v0, v2, v3
+fmov x10, d3
+mov.d x11, v0[1]
+extr x9, x9, x10, #63
+fmov x12, d0
+eor x9, x9, x11
+lsr x11, x9, #63
+eor x9, x9, x9, lsl #1
+extr x13, x11, x9, #61
+eor x10, x12, x10, lsl #1
+eor x11, x13, x11
+eor x9, x9, x9, lsl #3
+eor x11, x11, x11, lsl #1
+eor x9, x9, x10
+eor x9, x9, x11, lsl #3
+eor x9, x9, x11
+mov.d x10, v4[1]
+fmov x11, d4
+eor x10, x10, x10, lsl #1
+lsr x12, x10, #61
+eor x12, x12, x12, lsl #1
+eor x10, x10, x12
+eor x11, x11, x10, lsl #3
+eor x10, x10, x11
+stp x10, x9, [x8]
+ret
+
+WO KARATSUBA
+ldr q0, [x0]
+ldr q1, [x1]
+pmull.1q v2, v0, v1
+pmull2.1q v3, v0, v1
+eor.16b v2, v3, v2
+mov.d x9, v3[1]
+fmov x10, d3
+dup.2d v3, v1[0]
+pmull2.1q v3, v0, v3
+dup.2d v0, v0[0]
+pmull2.1q v0, v0, v1
+eor.16b v0, v0, v3
+mov.d x11, v0[1]
+extr x9, x9, x10, #63
+fmov x12, d0
+eor x9, x9, x11
+lsr x11, x9, #63
+eor x9, x9, x9, lsl #1
+extr x13, x11, x9, #61
+eor x10, x12, x10, lsl #1
+eor x11, x13, x11
+eor x9, x9, x9, lsl #3
+eor x11, x11, x11, lsl #1
+eor x9, x9, x10
+eor x9, x9, x11, lsl #3
+eor x9, x9, x11
+mov.d x10, v2[1]
+fmov x11, d2
+eor x10, x10, x10, lsl #1
+lsr x12, x10, #61
+eor x12, x12, x12, lsl #1
+eor x10, x10, x12
+eor x11, x11, x10, lsl #3
+eor x10, x10, x11
+stp x10, x9, [x8]
+ret
+

--- a/crates/arith-bench/src/ghash.rs
+++ b/crates/arith-bench/src/ghash.rs
@@ -7,6 +7,11 @@ use crate::{PackedUnderlier, Underlier, underlier::OpsClmul};
 /// In GHASH, the standard representation of 1 is simply 0x01
 pub const GHASH_ONE: u128 = 0x01;
 
+use core::arch::aarch64::uint64x2_t;
+pub fn mul_clmul_uint64x2_t(a_vec: uint64x2_t, b_vec: uint64x2_t) -> uint64x2_t {
+	mul_clmul::<uint64x2_t>(a_vec, b_vec)
+}
+
 #[inline]
 #[allow(dead_code)]
 pub fn mul_clmul<U: Underlier + OpsClmul + PackedUnderlier<u128>>(x: U, y: U) -> U {
@@ -16,7 +21,7 @@ pub fn mul_clmul<U: Underlier + OpsClmul + PackedUnderlier<u128>>(x: U, y: U) ->
 	// t1a = x.lo * y.hi
 	let t1a = U::clmulepi64::<0x01>(x, y);
 	// t1b = x.hi * y.lo
-	let t1b = U::clmulepi64::<0x10>(x, y);
+	let t1b = U::xor(x, y);
 	// t1 = t1a + t1b (XOR in binary field)
 	let mut t1 = U::xor(t1a, t1b);
 	// t2 = x.hi * y.hi

--- a/crates/arith-bench/src/monbijou.rs
+++ b/crates/arith-bench/src/monbijou.rs
@@ -36,6 +36,10 @@ pub fn mul_clmul<U: Underlier + OpsClmul + PackedUnderlier<u64>>(a: U, b: U) -> 
 	reduce_pair(prod_0, prod_1)
 }
 
+pub fn mul_128b_clmul_uint64x2_t(a_vec: uint64x2_t, b_vec: uint64x2_t) -> uint64x2_t {
+	mul_128b_clmul::<uint64x2_t>(a_vec, b_vec)
+}
+
 /// Multiplies two elements in GF(2^128), represented as a degree-2 extension of GF(2^64).
 ///
 /// This field is defined as GF(2)[X, Y] / (X^64 + X^4 + X^3 + X + 1) / (Y^2 + XY + 1).
@@ -57,10 +61,13 @@ pub fn mul_128b_clmul<U: Underlier + OpsClmul + PackedUnderlier<u64>>(x: U, y: U
 	// t1 = t1a + t1b (XOR in binary field)
 	let t1 = U::xor(t1a, t1b);
 
-	let mut t2_times_x = U::slli_epi64::<1>(t2);
-	let t2_overflow_mask = U::movepi64_mask(t2);
-	let t2_overflow_redc = U::and(poly, t2_overflow_mask);
-	t2_times_x = U::xor(t2_overflow_redc, t2_times_x);
+	// println!("t2 low:  0x{:?}", t2);
+
+	let mut t2_times_x = t2;
+	// U::slli_epi64::<1>(t2);
+	// let t2_overflow_mask = U::movepi64_mask(t2);
+	// let t2_overflow_redc = U::and(poly, t2_overflow_mask);
+	// t2_times_x = U::xor(t2_overflow_redc, t2_times_x);
 
 	let term0 = U::xor(t0, t2);
 	let term1 = U::xor(t1, t2_times_x);
@@ -95,4 +102,217 @@ fn reduce_pair<U: Underlier + OpsClmul + PackedUnderlier<u64>>(prod_0: U, prod_1
 
 	// Final result: XOR all three components together
 	U::xor(result, second_reduction_lo)
+}
+
+// MY STUFF
+
+use core::arch::aarch64::uint64x2_t;
+use std::{arch::aarch64::*, mem::transmute};
+
+pub fn mul_128b_mine(a_vec: uint64x2_t, b_vec: uint64x2_t) -> uint64x2_t {
+	unsafe {
+		let low_a = vgetq_lane_u64(a_vec, 0);
+		let low_b = vgetq_lane_u64(b_vec, 0);
+		let high_a = vgetq_lane_u64(a_vec, 1);
+		let high_b = vgetq_lane_u64(b_vec, 1);
+
+		let low_mult = transmute(vmull_p64(low_a, low_b));
+		let high_mult = transmute(vmull_p64(high_a, high_b));
+
+		// duplicate high_a
+		let high_a_vec = vdupq_n_u64(high_a);
+		// add to x.0 to get sum of low_a, high_a
+		let sum_a_vec = veorq_u64(a_vec, high_a_vec);
+		let low_high_sum_a = vgetq_lane_u64(sum_a_vec, 0);
+		let high_b_vec = vdupq_n_u64(high_b);
+		let sum_b_vec = veorq_u64(b_vec, high_b_vec);
+		let low_high_sum_b = vgetq_lane_u64(sum_b_vec, 0);
+		let low_high_sum_mult = transmute(vmull_p64(low_high_sum_a, low_high_sum_b));
+
+		let mid_mult = veor3q_u64(low_high_sum_mult, low_mult, high_mult);
+
+		// we can try not transmuting these things, and instead passing the vmull outputs as u128s
+		// to regular registers only reason i did it here is in order to use eor3
+		// we should also try doing the reduction inside simd, well i guess the intermediate shifts
+		// need to happen in regular registers
+		let result_unreduced_low: u128 = transmute(veorq_u64(low_mult, high_mult));
+		let mid_mult: u128 = transmute(mid_mult);
+		let high_mult: u128 = transmute(high_mult);
+		let result_unreduced_high: u128 = mid_mult ^ (high_mult << 1);
+
+		let result_high = reduce_full(result_unreduced_high);
+		let result_low = reduce_part(result_unreduced_low);
+
+		let x = (result_high as u128) << 64 | result_low as u128;
+		transmute(x)
+	}
+}
+
+use core::arch::asm;
+pub fn swap_lanes_with_ext(a: uint64x2_t) -> uint64x2_t {
+	unsafe {
+		let result: uint64x2_t;
+		asm!(
+			"ext {result:v}.16b, {a:v}.16b, {a:v}.16b, #8",
+			a = in(vreg) a,
+			result = out(vreg) result,
+			options(pure, nomem, nostack)
+		);
+		result
+	}
+}
+
+pub fn mul_128b_wo_karatsuba(a_vec: uint64x2_t, b_vec: uint64x2_t) -> uint64x2_t {
+	unsafe {
+		let low_a = vgetq_lane_u64(a_vec, 0);
+		let low_b = vgetq_lane_u64(b_vec, 0);
+		let high_a = vgetq_lane_u64(a_vec, 1);
+		let high_b = vgetq_lane_u64(b_vec, 1);
+
+		let low_mult = transmute(vmull_p64(low_a, low_b));
+		let high_mult = transmute(vmull_p64(high_a, high_b));
+
+		// let swapped_a = swap_lanes_with_ext(a_vec);
+		// let swapped_lo_a = vgetq_lane_u64(swapped_a, 0);
+		// let swapped_hi_a = vgetq_lane_u64(swapped_a, 1);
+		let swapped_a_vec = vextq_u64(a_vec, a_vec, 1);
+		let swapped_lo_a = vgetq_lane_u64(swapped_a_vec, 0);
+		let swapped_hi_a = vgetq_lane_u64(swapped_a_vec, 1);
+		let a_lo_b_hi = transmute(vmull_p64(swapped_lo_a, low_b));
+		let a_hi_b_lo = transmute(vmull_p64(swapped_hi_a, high_b));
+		let mid_mult = veorq_u64(a_lo_b_hi, a_hi_b_lo);
+
+		// first i think we calculate the carryless result. then we reduce.
+		// they have t0,t1,t2.
+		// first we can try just flipping one of them with an ext, then doing two more muls.
+		// add the middles.
+		// then we have the whole thing.
+		// what next?
+		// (a+xb)(c+xd)
+		// ac + y(ad+bc) + bd*(x*y+1)
+		// (ac+bd) + y(ad+bc + bd*x)
+		// so first thing we can get rid of karatsuba.
+		//
+
+		// but the whole thing needs to be shifted.
+
+		// // duplicate high_a
+		// let high_a_vec = vdupq_n_u64(high_a);
+		// // add to x.0 to get sum of low_a, high_a
+		// let sum_a_vec = veorq_u64(a_vec, high_a_vec);
+		// let low_high_sum_a = vgetq_lane_u64(sum_a_vec, 0);
+		// let high_b_vec = vdupq_n_u64(high_b);
+		// let sum_b_vec = veorq_u64(b_vec, high_b_vec);
+		// let low_high_sum_b = vgetq_lane_u64(sum_b_vec, 0);
+		// let low_high_sum_mult = transmute(vmull_p64(low_high_sum_a, low_high_sum_b));
+
+		// let mid_mult = veor3q_u64(low_high_sum_mult, low_mult, high_mult);
+
+		// we can try not transmuting these things, and instead passing the vmull outputs as u128s
+		// to regular registers only reason i did it here is in order to use eor3
+		// we should also try doing the reduction inside simd, well i guess the intermediate shifts
+		// need to happen in regular registers
+		// lets try here
+		let result_unreduced_low: u128 = transmute(veorq_u64(low_mult, high_mult));
+		let mid_mult: u128 = transmute(mid_mult);
+		let high_mult: u128 = transmute(high_mult);
+		let result_unreduced_high: u128 = mid_mult ^ (high_mult << 1);
+
+		// let result_unreduced_low_hi = vgetq_lane_u64(a_vec, 1);
+		// let result_unreduced_high_hi = vgetq_lane_u64(b_vec, 1);
+
+		reduce_full_simd(transmute(result_unreduced_high), transmute(result_unreduced_low))
+
+		// transmute(x)
+	}
+}
+
+#[inline]
+fn reduce_full_simd(a: uint64x2_t, b: uint64x2_t) -> uint64x2_t {
+	unsafe {
+		const POLY: u64 = 0x1B;
+		// let a_lo = transmute(vgetq_lane_u64(a, 0));
+		let a_hi = vgetq_lane_u64(a, 1);
+		// let b_lo = transmute(vgetq_lane_u64(b, 0));
+		let b_hi = vgetq_lane_u64(b, 1);
+
+		// we can zip the overflows, and do the shifting on those.
+		// we can also zhip the botoms.
+		// and middles
+		//
+
+		let bottom = vzip1q_u64(a, b);
+
+		let a_hi_poly = transmute(vmull_p64(a_hi, POLY));
+		let b_hi_poly = transmute(vmull_p64(b_hi, POLY));
+
+		let center = vzip1q_u64(a_hi_poly, b_hi_poly);
+
+		let a_overflow = vgetq_lane_u64(a_hi_poly, 1);
+		let b_overlow = vgetq_lane_u64(b_hi_poly, 1);
+
+		let a_next = transmute(vmull_p64(a_overflow, POLY));
+		let b_next = transmute(vmull_p64(b_overlow, POLY));
+
+		let top = vzip1q_u64(a_next, b_next);
+
+		let result = veor3q_u64(top, center, bottom);
+		result
+		// let x = (final_a as u128) << 64 | final_b as u128;
+		// transmute(x)
+	}
+}
+
+#[inline]
+fn reduce_full(x: u128) -> u64 {
+	let low = x as u64;
+
+	let mut high = x >> 64;
+	high ^= high << 1;
+	high ^= high << 3;
+
+	let mut overflow = (high >> 64) as u64;
+	overflow ^= overflow << 1;
+	overflow ^= overflow << 3;
+
+	low ^ (high as u64) ^ overflow
+}
+
+#[inline]
+fn reduce_part(x: u128) -> u64 {
+	let low = x as u64;
+
+	let mut high = (x >> 64) as u64;
+	high ^= high << 1;
+	let mut high = high as u128;
+	high ^= high << 3;
+
+	let mut overflow = (high >> 64) as u64;
+	overflow ^= overflow << 1;
+	overflow ^= overflow << 3;
+
+	low ^ (high as u64) ^ overflow
+}
+
+#[test]
+fn test_overflow_case() {
+	unsafe {
+		// Create inputs that will produce t2 with MSB set (>= 2^63)
+		// Using high values in both high parts
+		let c = 0xDEADBEEFCAFEBADE0123456789ABCDEFu128; // High part: 0xFFFFFFFFFFFFFFFF
+		let d = 0xD123456789ABCD0F0123456789ABCDEFu128; // High part: 0x8000000000000000  
+		let c_vec: uint64x2_t = transmute(c);
+		let d_vec: uint64x2_t = transmute(d);
+
+		println!("\n=== OVERFLOW TEST CASE ===");
+		let result = mul_128b_clmul_uint64x2_t(c_vec, d_vec);
+		let result: u128 = transmute(result);
+		println!("Result: {}", result);
+
+		// 0xuint64x2_t(9223372036854775808, 9223372036854775807)
+		let val1 = 15287300306673673450u64;
+		let val2 = 6184362564043165092u64;
+		println!("val1: 0x{:016X} (bit 63: {})", val1, (val1 >> 63) & 1);
+		println!("val2: 0x{:016X} (bit 63: {})", val2, (val2 >> 63) & 1);
+	}
 }

--- a/crates/math/src/lib.rs
+++ b/crates/math/src/lib.rs
@@ -27,3 +27,10 @@ pub use error::Error;
 pub use field_buffer::{FieldBuffer, FieldSlice, FieldSliceMut};
 pub use matrix::Matrix;
 pub use reed_solomon::ReedSolomonCode;
+
+pub fn evaluate_univariate<F: binius_field::Field>(coeffs: &[F], x: F) -> F {
+	// Evaluate using Horner's method
+	coeffs
+		.iter()
+		.rfold(F::ZERO, |eval, &coeff| eval * x + coeff)
+}

--- a/crates/prover/Cargo.toml
+++ b/crates/prover/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "binius-prover"
-version.workspace = true
-edition.workspace = true
-authors.workspace = true
+version = { workspace = true }
+edition = { workspace = true }
+authors = { workspace = true }
 
 [lints]
 workspace = true
@@ -30,7 +30,7 @@ binius-math = { path = "../math", features = ["test-utils"] }
 blake2.workspace = true
 criterion.workspace = true
 proptest.workspace = true
-rand = { workspace = true, features = ["std_rng"] }
+rand = { workspace = true, features = ["std_rng", "thread_rng"] }
 
 [[bench]]
 name = "binary_merkle_tree"

--- a/crates/prover/src/protocols/intmul/error.rs
+++ b/crates/prover/src/protocols/intmul/error.rs
@@ -1,0 +1,62 @@
+// Copyright 2025 Irreducible Inc.
+
+use crate::protocols::sumcheck;
+
+#[derive(Debug, Clone, Copy)]
+pub enum SumcheckErrorContext {
+	Execute,
+	Fold,
+	Finish,
+}
+
+impl Error {
+	pub fn from_sumcheck_execute(error: sumcheck::error::Error) -> Self {
+		Error::SumcheckError(error, SumcheckErrorContext::Execute)
+	}
+
+	pub fn from_sumcheck_fold(error: sumcheck::error::Error) -> Self {
+		Error::SumcheckError(error, SumcheckErrorContext::Fold)
+	}
+
+	pub fn from_sumcheck_finish(error: sumcheck::error::Error) -> Self {
+		Error::SumcheckError(error, SumcheckErrorContext::Finish)
+	}
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+	#[error("transcript error")]
+	TranscriptError(#[from] binius_transcript::Error),
+	#[error("length mismatch: {0} != {1}")]
+	LengthMismatch(usize, usize),
+	#[error("twisted eval points count ({0}) does not match claims count ({1})")]
+	TwistedPointsEvalsMismatch(usize, usize),
+	#[error("layer length ({0}) does not match pairs count ({1})")]
+	LayerClaimsMismatch(usize, usize),
+	#[error("composition claim mismatch")]
+	CompositionClaimMismatch,
+	#[error("final claims count ({0}) does not match pairs count * 2 ({1})")]
+	FinalClaimsPairsMismatch(usize, usize),
+	#[error("round coeffs count ({0}) does not match pairs count ({1})")]
+	RoundCoeffsPairsMismatch(usize, usize),
+	#[error("sumcheck error: {0} ({1:?})")]
+	SumcheckError(sumcheck::error::Error, SumcheckErrorContext),
+	#[error("buffer log len ({0}) and eval point len ({1}) mismatch")]
+	BufferEvalPointMismatch(usize, usize),
+	#[error("layer pairs count ({0}) does not match claims count ({1})")]
+	LayerPairsCountClaimsMismatch(usize, usize),
+	#[error("eval point and buffer log len mismatch")]
+	EvalPointBufferLengthMismatch,
+	#[error("multilinears do not have equal number of variables")]
+	MultilinearSizeMismatch,
+	#[error("number of eval claims does not match the number of multilinears")]
+	EvalClaimsNumberMismatch,
+	#[error("expected execute() call")]
+	ExpectedExecute,
+	#[error("expected fold() call")]
+	ExpectedFold,
+	#[error("expected finish() call")]
+	ExpectedFinish,
+	#[error("math error: {0}")]
+	MathError(#[from] binius_math::Error),
+}

--- a/crates/prover/src/protocols/intmul/example.rs
+++ b/crates/prover/src/protocols/intmul/example.rs
@@ -1,0 +1,98 @@
+use binius_field::{Field, PackedField};
+use binius_math::{evaluate_univariate, field_buffer::FieldBuffer, multilinear::eq::eq_ind};
+use binius_transcript::{
+	ProverTranscript,
+	fiat_shamir::{CanSample, Challenger, HasherChallenger},
+};
+use blake2::Blake2b;
+use digest::consts::U32;
+
+use super::{execute::compute_bivariate_product, prove::compute_initial_evals};
+use crate::protocols::sumcheck::{bivariate_mle::BivariateMlecheckProver, common::SumcheckProver};
+type Blake2b256 = Blake2b<U32>;
+use binius_field::{BinaryField128b, PackedBinaryField1x128b, PackedBinaryField2x128b};
+type F = BinaryField128b;
+type P = PackedBinaryField1x128b;
+use binius_field::Random;
+
+#[test]
+fn example() {
+	let mut transcript = ProverTranscript::<HasherChallenger<Blake2b256>>::default();
+
+	let log_len = 3;
+
+	// let mut rng = rand::rng();
+
+	let mut buffer_0 = FieldBuffer::<P>::zeros(log_len);
+	let mut buffer_1 = FieldBuffer::<P>::zeros(log_len);
+
+	let slice_0 = buffer_0.as_mut();
+	let slice_1 = buffer_1.as_mut();
+
+	let packed_length = 1 << log_len.saturating_sub(P::LOG_WIDTH);
+	for i in 0..packed_length {
+		// let random_f0: Vec<F> = (0..P::WIDTH).map(|_| F::random(&mut rng)).collect();
+		// let random_f1: Vec<F> = (0..P::WIDTH).map(|_| F::random(&mut rng)).collect();
+		let random_f0: Vec<F> = (0..P::WIDTH).map(|_| F::one()).collect();
+		let random_f1: Vec<F> = (0..P::WIDTH).map(|_| F::one()).collect();
+
+		slice_0[i] = P::from_scalars(random_f0);
+		slice_1[i] = P::from_scalars(random_f1);
+	}
+
+	// println!("buffer_0: {:#?}", buffer_0);
+	// println!("buffer_1: {:#?}", buffer_1);
+
+	let eval_point = transcript.sample_vec(log_len);
+
+	let product = compute_bivariate_product(buffer_0.to_ref(), buffer_1.to_ref()).unwrap();
+	// println!("product: {:#?}", product);
+
+	let (eval, _) = compute_initial_evals(&eval_point, product.clone(), product).unwrap();
+	// println!("eval: {:#?}", eval);
+
+	prove_layer_test(buffer_0, buffer_1, &eval_point, eval, &mut transcript);
+}
+
+fn prove_layer_test<'a, F: Field, P: PackedField<Scalar = F>, C: Challenger>(
+	buffer_0: FieldBuffer<P>,
+	buffer_1: FieldBuffer<P>,
+	eval_point: &[F],
+	mut claim: F,
+	transcript: &mut ProverTranscript<C>,
+) {
+	assert_eq!(buffer_0.log_len(), eval_point.len());
+	assert_eq!(buffer_1.log_len(), eval_point.len());
+
+	let layer = vec![(buffer_0, buffer_1)];
+	let claims = vec![claim];
+	let mut prover = BivariateMlecheckProver::new(layer, &eval_point, &claims).unwrap();
+
+	let mut challenges: Vec<F> = vec![];
+
+	for _ in 0..eval_point.len() {
+		let round_coeffs_vec = prover.execute().unwrap();
+		assert_eq!(round_coeffs_vec.len(), 1);
+		let round_coeffs = &round_coeffs_vec[0];
+
+		let challenge = transcript.sample();
+		challenges.push(challenge);
+
+		claim = evaluate_univariate(&round_coeffs.0, challenge);
+
+		prover.fold(challenge).unwrap();
+	}
+
+	let final_claims: Vec<F> = prover.finish().unwrap();
+	assert_eq!(final_claims.len(), 2);
+
+	challenges.reverse();
+
+	let eq_eval = eq_ind(&eval_point, &challenges);
+	let expected_claim = eq_eval * final_claims[0] * final_claims[1];
+
+	println!("expected_claim: {:#?}", expected_claim);
+	println!("claim: {:#?}", claim);
+
+	assert_eq!(expected_claim, claim);
+}

--- a/crates/prover/src/protocols/intmul/execute.rs
+++ b/crates/prover/src/protocols/intmul/execute.rs
@@ -1,0 +1,361 @@
+use binius_field::{Field, PackedField};
+use binius_math::field_buffer::{FieldBuffer, FieldSlice};
+use itertools::izip;
+
+use super::error::Error;
+
+fn log2_exact(n: usize) -> usize {
+	assert!(n > 0, "Cannot compute log2 of zero");
+	assert!(n & (n - 1) == 0, "Number must be a power of 2");
+
+	// Count the trailing zeros which gives us the log2 for a power of 2
+	n.trailing_zeros() as usize
+}
+
+fn pow2_64<F: Field>(generator: F) -> F {
+	let mut result = generator;
+	for _ in 0..64 {
+		result = result.square();
+	}
+	return result;
+}
+
+#[derive(Debug)]
+pub struct Layers<P: PackedField> {
+	n_vars: usize,
+	layers: Vec<Vec<FieldBuffer<P>>>,
+}
+
+impl<P: PackedField> Layers<P> {
+	fn new(layers: Vec<Vec<FieldBuffer<P>>>) -> Self {
+		// yet to decide how generic this is to be, and perform relevant checks on input.
+		// actually make this generic over the depth. we'll only do 6 and 7.
+
+		let leaves = layers.last().expect("checked...");
+		let first_leaf = leaves.first().expect("checked 64 leaves");
+		let n_vars = first_leaf.log_len();
+
+		Layers { n_vars, layers }
+	}
+
+	fn n_vars(&self) -> usize {
+		self.n_vars
+	}
+
+	pub fn last_layer_buffer(&self) -> FieldBuffer<P> {
+		let last_layer = self.layers.last().unwrap();
+		// to be decided what checks and error handling to do here, probably returing a Result
+		assert_eq!(last_layer.len(), 1);
+		last_layer.last().unwrap().clone()
+	}
+}
+
+impl<P: PackedField> Iterator for Layers<P> {
+	type Item = Vec<FieldBuffer<P>>;
+
+	fn next(&mut self) -> Option<Self::Item> {
+		self.layers.pop()
+	}
+}
+
+pub struct ProverData<'a, P: PackedField> {
+	pub n_vars: usize,
+	pub a_exponents: &'a [u64],
+	pub b_exponents: &'a [u64],
+	pub c_lo_exponents: &'a [u64],
+	pub c_hi_exponents: &'a [u64],
+	pub a_layers: Layers<P>,
+	pub b_layers: Layers<P>,
+	pub c_layers: Layers<P>,
+}
+
+pub fn compute_bivariate_product<P: PackedField>(
+	a: FieldSlice<P>,
+	b: FieldSlice<P>,
+) -> Result<FieldBuffer<P>, Error> {
+	if a.log_len() != b.log_len() {
+		return Err(Error::MultilinearSizeMismatch);
+	}
+	let mut result = FieldBuffer::<P>::zeros(a.log_len());
+	let result_slice = result.as_mut();
+	let a_slice = a.as_ref();
+	let b_slice = b.as_ref();
+	for i in 0..result_slice.len() {
+		result_slice[i] = a_slice[i] * b_slice[i];
+	}
+	Ok(result)
+}
+
+fn square_buffer<P: PackedField>(v: &mut [P]) {
+	for i in 0..v.len() {
+		v[i] = v[i].square();
+	}
+}
+
+pub fn select_kth_for_constant_base<P: PackedField>(
+	constant: P::Scalar,
+	exponents: &[u64],
+	result: &mut [P],
+	k: usize,
+) {
+	assert_eq!(result.len() * P::WIDTH, exponents.len());
+
+	for (exponents, result) in izip!(exponents.chunks(P::WIDTH), result) {
+		let scalars = exponents.iter().map(|e| {
+			if e & (1 << k) == 0 {
+				P::Scalar::ONE
+			} else {
+				constant
+			}
+		});
+		*result = P::from_scalars(scalars);
+	}
+}
+
+pub fn select_kth_for_variable_base<P: PackedField>(
+	base: &[P],
+	exponents: &[u64],
+	result: &mut [P],
+	k: usize,
+) {
+	assert_eq!(base.len(), result.len());
+	assert_eq!(result.len() * P::WIDTH, exponents.len());
+
+	for (base, exponents, result) in izip!(base, exponents.chunks(P::WIDTH), result) {
+		let scalars = P::iter(base)
+			.zip(exponents)
+			.map(|(b, e)| if e & (1 << k) == 0 { P::Scalar::ONE } else { b });
+		*result = P::from_scalars(scalars);
+	}
+}
+
+fn generate_inputs_for_constant_base<P: PackedField>(
+	generator: P::Scalar,
+	exponents: &[u64],
+) -> Vec<FieldBuffer<P>> {
+	let depth = 6;
+	let num_elements = 1 << depth;
+
+	let conjugations = std::iter::successors(Some(generator), |&prev| Some(prev.square()))
+		.take(num_elements)
+		.collect::<Vec<_>>();
+
+	let log_len = log2_exact(exponents.len());
+	let mut results = vec![];
+
+	for k in 0..num_elements {
+		let mut result = FieldBuffer::<P>::zeros(log_len);
+		select_kth_for_constant_base(conjugations[k], exponents, result.as_mut(), k);
+		results.push(result);
+	}
+	results
+}
+
+fn generate_inputs_for_variable_base<P: PackedField>(
+	base: FieldBuffer<P>,
+	exponents: &[u64],
+) -> Vec<FieldBuffer<P>> {
+	let mut results = vec![];
+
+	let mut temp = base;
+	for k in 0..64 {
+		let mut result = temp.clone();
+		select_kth_for_variable_base(temp.as_ref(), exponents, result.as_mut(), k);
+		results.push(result);
+
+		square_buffer(temp.as_mut());
+	}
+	results
+}
+
+fn build_tree_layers<P: PackedField>(v: Vec<FieldBuffer<P>>) -> Result<Layers<P>, Error> {
+	let depth = log2_exact(v.len());
+
+	let mut layers = vec![];
+
+	fn reduce_layer<P: PackedField>(
+		buffers: &[FieldBuffer<P>],
+	) -> Result<Vec<FieldBuffer<P>>, Error> {
+		buffers
+			.chunks(2)
+			.map(|pair| compute_bivariate_product(pair[0].to_ref(), pair[1].to_ref()))
+			.collect()
+	}
+
+	let mut current_layer = v;
+
+	for _ in 0..depth {
+		let my_layer = std::mem::take(&mut current_layer);
+		current_layer = reduce_layer(&my_layer)?;
+		layers.push(my_layer);
+	}
+
+	layers.push(current_layer);
+
+	Ok(Layers::new(layers))
+}
+
+pub fn execute<'a, P: PackedField>(
+	generator: P::Scalar,
+	a_exponents: &'a [u64],
+	b_exponents: &'a [u64],
+	c_lo_exponents: &'a [u64],
+	c_hi_exponents: &'a [u64],
+) -> Result<ProverData<'a, P>, Error> {
+	let a_leaves = generate_inputs_for_constant_base::<P>(generator, a_exponents);
+	let c_lo_leaves = generate_inputs_for_constant_base::<P>(generator, c_lo_exponents);
+	let c_hi_leaves = generate_inputs_for_constant_base::<P>(pow2_64(generator), c_hi_exponents);
+
+	let mut c_leaves = vec![];
+	c_leaves.extend(c_lo_leaves);
+	c_leaves.extend(c_hi_leaves);
+
+	let a_layers = build_tree_layers(a_leaves)?;
+	let c_layers = build_tree_layers(c_leaves)?;
+
+	let b_leaves = generate_inputs_for_variable_base(a_layers.last_layer_buffer(), b_exponents);
+	let b_layers = build_tree_layers(b_leaves)?;
+
+	Ok(ProverData {
+		n_vars: a_layers.n_vars(),
+		a_exponents,
+		b_exponents,
+		c_lo_exponents,
+		c_hi_exponents,
+		a_layers,
+		b_layers,
+		c_layers,
+	})
+}
+
+#[cfg(test)]
+mod tests {
+	use binius_field::{BinaryField, BinaryField128b, PackedBinaryField1x128b};
+
+	use super::*;
+
+	type F = BinaryField128b;
+	type P = PackedBinaryField1x128b;
+
+	#[test]
+	fn test_forwards() {
+		let generator = F::MULTIPLICATIVE_GENERATOR;
+
+		let a_exponent: u64 = 2;
+		let b_exponent: u64 = 3;
+		let c_lo_exponent: u64 = 6; // 2*3 = 6
+		let c_hi_exponent: u64 = 0; // no high bits
+
+		let a_exponents = vec![a_exponent];
+		let b_exponents = vec![b_exponent];
+		let c_lo_exponents = vec![c_lo_exponent];
+		let c_hi_exponents = vec![c_hi_exponent];
+
+		execute::<P>(generator, &a_exponents, &b_exponents, &c_lo_exponents, &c_hi_exponents)
+			.unwrap();
+	}
+
+	#[test]
+	fn test_forwards_larger() {
+		let generator = F::MULTIPLICATIVE_GENERATOR;
+
+		let a_exponent: u64 = 1 << 32;
+		let b_exponent: u64 = 1 << 33;
+		let c_lo_exponent: u64 = 0;
+		let c_hi_exponent: u64 = 2; // 2^32 * 2^33 = 2^65, which is 2 in the high 64 bits
+
+		let a_exponents = vec![a_exponent];
+		let b_exponents = vec![b_exponent];
+		let c_lo_exponents = vec![c_lo_exponent];
+		let c_hi_exponents = vec![c_hi_exponent];
+
+		execute::<P>(generator, &a_exponents, &b_exponents, &c_lo_exponents, &c_hi_exponents)
+			.unwrap();
+	}
+
+	#[test]
+	fn test_forwards_multiple_random() {
+		use rand::Rng;
+
+		// Create a random number generator
+		let mut rng = rand::rng();
+		let generator = F::MULTIPLICATIVE_GENERATOR;
+
+		// Create multiple random exponents
+		// We need vectors with power-of-2 length: choose 8 (2³)
+		const VECTOR_SIZE: usize = 8; // Pad to 8 (next power of 2)
+		let mut a_exponents = Vec::with_capacity(VECTOR_SIZE);
+		let mut b_exponents = Vec::with_capacity(VECTOR_SIZE);
+		let mut c_lo_exponents = Vec::with_capacity(VECTOR_SIZE);
+		let mut c_hi_exponents = Vec::with_capacity(VECTOR_SIZE);
+
+		// Generate random exponents and compute expected results
+		for _ in 0..4 {
+			// Generate 4 small number pairs
+			// Generate random 32-bit exponents to ensure multiplication doesn't overflow u64
+			let a_exp = rng.random_range(1..100_000) as u64;
+			let b_exp = rng.random_range(1..100_000) as u64;
+
+			// Calculate expected result (a * b)
+			let full_result = a_exp.wrapping_mul(b_exp);
+			let c_lo = full_result; // For u64 * u64, result fits in 64 bits
+			let c_hi = 0; // For these small numbers, high bits will be 0
+
+			// Store the exponents
+			a_exponents.push(a_exp);
+			b_exponents.push(b_exp);
+			c_lo_exponents.push(c_lo);
+			c_hi_exponents.push(c_hi);
+
+			// Print the values for debugging
+			println!(
+				"a: {}, b: {}, expected product: {} (lo: {}, hi: {})",
+				a_exp, b_exp, full_result, c_lo, c_hi
+			);
+		}
+
+		// Generate some larger numbers that will have high bits
+		for _ in 0..2 {
+			// Generate values where multiplication will produce high bits
+			let a_exp = (1u64 << 40) + rng.random_range(1..100_000) as u64;
+			let b_exp = (1u64 << 40) + rng.random_range(1..100_000) as u64;
+
+			// Calculate expected result using 128-bit arithmetic
+			let a_128 = a_exp as u128;
+			let b_128 = b_exp as u128;
+			let full_result = a_128 * b_128;
+
+			let c_lo = (full_result & 0xFFFF_FFFF_FFFF_FFFF) as u64;
+			let c_hi = (full_result >> 64) as u64;
+
+			// Store the exponents
+			a_exponents.push(a_exp);
+			b_exponents.push(b_exp);
+			c_lo_exponents.push(c_lo);
+			c_hi_exponents.push(c_hi);
+
+			println!(
+				"Large a: {}, b: {}, expected product: {} (lo: {}, hi: {})",
+				a_exp, b_exp, full_result, c_lo, c_hi
+			);
+		}
+
+		// Pad with zeros to make the vector length a power of 2 (8)
+		while a_exponents.len() < VECTOR_SIZE {
+			a_exponents.push(0);
+			b_exponents.push(0);
+			c_lo_exponents.push(0);
+			c_hi_exponents.push(0);
+			println!("Adding padding entry to reach power-of-2 length");
+		}
+
+		// Verify we have a power-of-2 length
+		let length = a_exponents.len();
+		assert_eq!(length & (length - 1), 0, "Vector length must be a power of 2");
+		println!("Vector length: {}", length);
+
+		// Call execute_forwards with all exponents
+		execute::<P>(generator, &a_exponents, &b_exponents, &c_lo_exponents, &c_hi_exponents)
+			.unwrap();
+	}
+}

--- a/crates/prover/src/protocols/intmul/mod.rs
+++ b/crates/prover/src/protocols/intmul/mod.rs
@@ -1,0 +1,9 @@
+pub mod error;
+pub mod execute;
+pub mod prove;
+mod provers;
+#[cfg(test)]
+mod tests;
+
+#[cfg(test)]
+pub mod example;

--- a/crates/prover/src/protocols/intmul/prove.rs
+++ b/crates/prover/src/protocols/intmul/prove.rs
@@ -1,0 +1,656 @@
+use binius_field::{Field, PackedField};
+use binius_math::{
+	evaluate_univariate,
+	field_buffer::FieldBuffer,
+	multilinear::eq::{eq_ind, eq_ind_partial_eval},
+};
+use binius_transcript::{
+	ProverTranscript,
+	fiat_shamir::{CanSample, Challenger},
+};
+use binius_verifier::protocols::{
+	intmul::common::{
+		HandleLayerOutput, Phase1Output, Phase2Output, Phase3Output, Phase4Output, Phase5Output,
+		frobenius, normalize_a_c_exponent_evals,
+	},
+	sumcheck::common::RoundCoeffs,
+};
+use itertools::{Itertools, izip};
+
+use super::{
+	error::Error,
+	execute::Layers,
+	provers::{RerandomizationProver, VProver},
+};
+use crate::protocols::sumcheck::{
+	bivariate_mle::BivariateMlecheckProver, common::SumcheckProver,
+	rerand_mle::RerandMlecheckProver,
+};
+
+fn make_pairs<T>(layer: Vec<T>) -> Vec<(T, T)> {
+	layer.into_iter().tuples().collect()
+}
+
+pub fn compute_initial_evals<F: Field, P: PackedField<Scalar = F>>(
+	eval_point: &[F],
+	last_b_buffer: FieldBuffer<P>,
+	last_c_buffer: FieldBuffer<P>,
+) -> Result<(F, F), Error> {
+	if eval_point.len() != last_b_buffer.log_len() || eval_point.len() != last_c_buffer.log_len() {
+		return Err(Error::EvalPointBufferLengthMismatch);
+	}
+
+	let eq_expansion = eq_ind_partial_eval::<P>(eval_point);
+
+	fn compute_eval<F: Field, P: PackedField<Scalar = F>>(
+		eq_expansion: &FieldBuffer<P>,
+		buffer: FieldBuffer<P>,
+	) -> F {
+		let packed_eval: P = izip!(eq_expansion.as_ref(), buffer.as_ref())
+			.fold(P::default(), |acc, (&eq, &buf)| acc + eq * buf);
+		packed_eval.iter().sum()
+	}
+
+	let b_eval = compute_eval(&eq_expansion, last_b_buffer);
+	let c_eval = compute_eval(&eq_expansion, last_c_buffer);
+
+	Ok((b_eval, c_eval))
+}
+
+fn prove_layer<'a, F: Field, P: PackedField<Scalar = F>, C: Challenger>(
+	layer: Vec<FieldBuffer<P>>,
+	eval_point: Vec<F>,
+	claims: Vec<F>,
+	transcript: &mut ProverTranscript<C>,
+) -> Result<HandleLayerOutput<F>, Error> {
+	let pairs_count = layer.len() / 2;
+	let n_vars = eval_point.len();
+
+	if pairs_count != claims.len() {
+		return Err(Error::LayerPairsCountClaimsMismatch(pairs_count, claims.len()));
+	}
+
+	for buffer in &layer {
+		if buffer.log_len() != n_vars {
+			return Err(Error::BufferEvalPointMismatch(buffer.log_len(), n_vars));
+		}
+	}
+
+	let mut prover = BivariateMlecheckProver::new(make_pairs(layer), &eval_point, &claims)
+		.expect("checked input metrics");
+
+	let batch_coeff: F = transcript.sample();
+	let mut challenges: Vec<F> = vec![];
+
+	let mut claim = evaluate_univariate(&claims, batch_coeff);
+
+	let mut claim = claims
+		.iter()
+		.rfold(F::ZERO, |eval, &coeff| eval * batch_coeff + coeff);
+
+	for _ in 0..n_vars {
+		let round_coeffs_vec = prover.execute().map_err(Error::from_sumcheck_execute)?;
+		if round_coeffs_vec.len() != pairs_count {
+			return Err(Error::RoundCoeffsPairsMismatch(round_coeffs_vec.len(), pairs_count));
+		}
+
+		let batched_round_coeffs: RoundCoeffs<F> = round_coeffs_vec
+			.iter()
+			// .fold(RoundCoeffs::default(), |acc, round_coeffs| acc + round_coeffs);
+			// .rev()
+			.rfold(RoundCoeffs::default(), |acc, round_coeffs| acc * batch_coeff + round_coeffs);
+
+		let challenge = transcript.sample();
+		challenges.push(challenge);
+
+		claim = evaluate_univariate(&batched_round_coeffs.0, challenge);
+
+		let round_proof = batched_round_coeffs.truncate();
+		transcript
+			.message()
+			.write_scalar_slice(round_proof.coeffs());
+
+		prover.fold(challenge).map_err(Error::from_sumcheck_fold)?;
+	}
+
+	let final_claims = prover.finish().map_err(Error::from_sumcheck_finish)?;
+	if final_claims.len() != 2 * pairs_count {
+		return Err(Error::FinalClaimsPairsMismatch(final_claims.len(), 2 * pairs_count));
+	}
+
+	challenges.reverse();
+
+	let eq_eval = eq_ind(&eval_point, &challenges);
+	let expected_unbatched_terms = final_claims
+		.iter()
+		.tuples()
+		.map(|(&left, &right)| eq_eval * left * right)
+		.collect::<Vec<_>>();
+
+	let expected_claim: F = evaluate_univariate(&expected_unbatched_terms, batch_coeff);
+	assert_eq!(expected_claim, claim);
+	if expected_claim != claim {
+		return Err(Error::CompositionClaimMismatch);
+	}
+
+	transcript.message().write_scalar_slice(&final_claims);
+
+	Ok(HandleLayerOutput {
+		eval_point: challenges,
+		claims: final_claims,
+	})
+}
+
+// PHASE ONE: b_layers
+
+fn prove_phase_1<F: Field, P: PackedField<Scalar = F>, C: Challenger>(
+	mut b_layers: Layers<P>,
+	initial_eval_point: Vec<F>,
+	initial_claim: F,
+	transcript: &mut ProverTranscript<C>,
+) -> Result<Phase1Output<F>, Error> {
+	let mut eval_point = initial_eval_point;
+	let mut claims = vec![initial_claim];
+
+	for depth in (0..6).rev() {
+		let layer_buffer_count = 1 << (6 - depth);
+		let claims_count = layer_buffer_count / 2;
+		if claims.len() != claims_count {
+			return Err(Error::LengthMismatch(claims.len(), claims_count));
+		}
+
+		let layer = b_layers.next().expect("taking layer layer_num >= 0");
+		if layer.len() != layer_buffer_count {
+			return Err(Error::LayerClaimsMismatch(layer.len(), layer_buffer_count));
+		}
+
+		let HandleLayerOutput {
+			eval_point: new_eval_point,
+			claims: new_claims,
+		} = prove_layer(layer, eval_point, claims, transcript)?;
+
+		eval_point = new_eval_point;
+		claims = new_claims;
+	}
+
+	debug_assert_eq!(claims.len(), 64);
+
+	debug_assert_eq!(b_layers.next(), None);
+
+	Ok(Phase1Output {
+		eval_point,
+		b_leaves_claims: claims,
+	})
+}
+
+// PHASE TWO: frobenius
+
+// PHASE THREE: painful sumcheck
+
+fn prove_phase_3<F: Field, P: PackedField<Scalar = F>, C: Challenger>(
+	// v sumcheck stuff
+	twisted_eval_points: Vec<Vec<F>>,
+	twisted_claims: Vec<F>,
+	v_buffer: FieldBuffer<P>,
+	b_exponents: &[u64],
+	// c sumcheck stuff
+	c_layer: (FieldBuffer<P>, FieldBuffer<P>),
+	c_eval_point: Vec<F>,
+	c_claim: F,
+	transcript: &mut ProverTranscript<C>,
+) -> Result<Phase3Output<F>, Error> {
+	let n_vars = v_buffer.log_len();
+
+	// make v_prover
+	if twisted_eval_points.len() != 64 {
+		return Err(Error::LengthMismatch(twisted_eval_points.len(), 64));
+	}
+
+	if twisted_claims.len() != twisted_eval_points.len() {
+		return Err(Error::TwistedPointsEvalsMismatch(
+			twisted_claims.len(),
+			twisted_eval_points.len(),
+		));
+	}
+
+	for twisted_eval_point in &twisted_eval_points {
+		if twisted_eval_point.len() != n_vars {
+			return Err(Error::EvalPointBufferLengthMismatch);
+		}
+	}
+
+	if b_exponents.len() != 1 << n_vars {
+		return Err(Error::LengthMismatch(b_exponents.len(), 1 << n_vars));
+	}
+
+	let mut v_prover = VProver::new(v_buffer, b_exponents, twisted_eval_points, twisted_claims);
+
+	if v_prover.n_vars() != n_vars {
+		return Err(Error::LengthMismatch(v_prover.n_vars(), n_vars));
+	}
+
+	// make c_prover
+
+	if c_layer.0.log_len() != n_vars {
+		return Err(Error::BufferEvalPointMismatch(c_layer.0.log_len(), n_vars));
+	}
+	if c_layer.1.log_len() != n_vars {
+		return Err(Error::BufferEvalPointMismatch(c_layer.1.log_len(), n_vars));
+	}
+
+	if c_eval_point.len() != n_vars {
+		return Err(Error::LengthMismatch(c_eval_point.len(), n_vars));
+	}
+
+	let c_layer = vec![c_layer];
+	let evals = vec![c_claim];
+	let mut c_prover = BivariateMlecheckProver::new(c_layer, &c_eval_point, &evals)
+		.expect("checked input metrics");
+
+	if c_prover.n_vars() != n_vars {
+		return Err(Error::LengthMismatch(c_prover.n_vars(), n_vars));
+	}
+
+	// batch sumcheck
+
+	let batch_coeff: F = transcript.sample();
+
+	let mut challenges = vec![];
+
+	for _ in 0..n_vars {
+		let v_round_coeffs_vec: Vec<RoundCoeffs<F>> =
+			v_prover.execute().map_err(Error::from_sumcheck_execute)?;
+		let c_round_coeffs_vec: Vec<RoundCoeffs<F>> =
+			c_prover.execute().map_err(Error::from_sumcheck_execute)?;
+
+		if v_round_coeffs_vec.len() != 64 {
+			return Err(Error::LengthMismatch(v_round_coeffs_vec.len(), 64));
+		}
+		if c_round_coeffs_vec.len() != 1 {
+			return Err(Error::LengthMismatch(c_round_coeffs_vec.len(), 1));
+		}
+
+		let mut round_coeffs_vec = v_round_coeffs_vec;
+		round_coeffs_vec.extend(c_round_coeffs_vec);
+
+		let round_coeffs: RoundCoeffs<F> = round_coeffs_vec
+			.iter()
+			.rev()
+			.fold(RoundCoeffs::default(), |acc, round_coeffs| acc * batch_coeff + round_coeffs);
+
+		let round_proof = round_coeffs.truncate();
+		transcript
+			.message()
+			.write_scalar_slice(round_proof.coeffs());
+
+		let challenge = transcript.sample();
+		challenges.push(challenge);
+
+		v_prover
+			.fold(challenge)
+			.map_err(Error::from_sumcheck_fold)?;
+		c_prover
+			.fold(challenge)
+			.map_err(Error::from_sumcheck_fold)?;
+	}
+
+	challenges.reverse();
+
+	let v_prover_claims = v_prover.finish().map_err(Error::from_sumcheck_finish)?;
+	if v_prover_claims.len() != 64 + 1 {
+		return Err(Error::LengthMismatch(v_prover_claims.len(), 64 + 1));
+	}
+	let b_exponent_claims = v_prover_claims[..64].to_vec();
+	let v_claim = v_prover_claims[64];
+
+	let mut c_prover_claims = c_prover.finish().unwrap();
+	if c_prover_claims.len() != 2 {
+		return Err(Error::LengthMismatch(c_prover_claims.len(), 2));
+	}
+	let last_c_lo_claim = c_prover_claims.pop().expect("contains 2 buffers");
+	let last_c_hi_claim = c_prover_claims.pop().expect("contains 1 buffer");
+
+	transcript.message().write_scalar_slice(&v_prover_claims);
+	transcript.message().write_scalar_slice(&c_prover_claims);
+
+	Ok(Phase3Output {
+		eval_point: challenges,
+		b_exponent_claims,
+		v_claim,
+		c_claims: (last_c_lo_claim, last_c_hi_claim),
+	})
+}
+
+// PHASE 4: most of a_layers and c_layers
+
+fn prove_phase_4<F: Field, P: PackedField<Scalar = F>, C: Challenger>(
+	eval_point: Vec<F>,
+	// a stuff
+	a_layers: &mut Layers<P>,
+	a_last_layer_claim: F,
+	// c stuff
+	c_layers: &mut Layers<P>,
+	c_lo_last_layer_claim: F,
+	c_hi_last_layer_claim: F,
+	transcript: &mut ProverTranscript<C>,
+) -> Result<Phase4Output<F>, Error> {
+	let mut eval_point = eval_point.to_vec();
+	let mut claims = vec![
+		a_last_layer_claim,
+		c_lo_last_layer_claim,
+		c_hi_last_layer_claim,
+	];
+
+	for depth in (1..6).rev() {
+		let a_layer_buffer_count = 1 << (6 - depth);
+		let c_layer_buffer_count = 2 * a_layer_buffer_count;
+
+		let claims_count = (a_layer_buffer_count + c_layer_buffer_count) / 2;
+		if claims.len() != claims_count {
+			return Err(Error::LengthMismatch(claims.len(), claims_count));
+		}
+
+		let a_layer = a_layers.next().expect("taking layer layer_num > 0");
+		if a_layer.len() != a_layer_buffer_count {
+			return Err(Error::LayerClaimsMismatch(a_layer.len(), a_layer_buffer_count));
+		}
+
+		let c_layer = c_layers.next().expect("taking layer layer_num > 0");
+		if c_layer.len() != c_layer_buffer_count {
+			return Err(Error::LayerClaimsMismatch(c_layer.len(), c_layer_buffer_count));
+		}
+
+		let mut layer = Vec::with_capacity(a_layer.len() + c_layer.len());
+		layer.extend(a_layer);
+		layer.extend(c_layer);
+
+		let HandleLayerOutput {
+			eval_point: new_eval_point,
+			claims: new_claims,
+		} = prove_layer(layer, eval_point, claims, transcript)?;
+
+		eval_point = new_eval_point;
+		claims = new_claims;
+	}
+
+	debug_assert_eq!(claims.len(), 32 + 2 * 32);
+
+	Ok(Phase4Output {
+		eval_point,
+		a_32_c_64_claims: claims,
+	})
+}
+
+// PHASE 5: final layer
+
+fn prove_phase_5<'a, F: Field, P: PackedField<Scalar = F>, C: Challenger>(
+	// a and c stuff
+	a_c_eval_point: Vec<F>,
+	a_c_evals: Vec<F>,
+	mut a_layers: Layers<P>,
+	mut c_layers: Layers<P>,
+	// b stuff
+	b_exponents: &[u64],
+	b_eval_point: Vec<F>,
+	b_exponent_evals: Vec<F>,
+	transcript: &mut ProverTranscript<C>,
+) -> Result<Phase5Output<F>, Error> {
+	let n_vars = a_c_eval_point.len();
+
+	// make layer_prover
+
+	let a_layer = a_layers.next().expect("taking layer 0");
+	if a_layer.len() != 64 {
+		return Err(Error::LayerClaimsMismatch(a_layer.len(), 64));
+	}
+	debug_assert_eq!(a_layers.next(), None);
+
+	let c_layer = c_layers.next().expect("taking layer 0");
+	if c_layer.len() != 128 {
+		return Err(Error::LayerClaimsMismatch(c_layer.len(), 128));
+	}
+	debug_assert_eq!(c_layers.next(), None);
+
+	let mut layer = Vec::with_capacity(a_layer.len() + c_layer.len());
+	layer.extend(a_layer);
+	layer.extend(c_layer);
+
+	debug_assert_eq!(layer.len(), 64 + 128);
+	if a_c_evals.len() != 32 + 64 {
+		return Err(Error::LayerClaimsMismatch(a_c_evals.len(), 32 + 64));
+	}
+
+	let mut a_c_prover =
+		BivariateMlecheckProver::new(make_pairs(layer), &a_c_eval_point, &a_c_evals)
+			.expect("checked input metrics");
+
+	// make rerand_prover
+
+	if b_exponents.len() != 1 << b_eval_point.len() {
+		return Err(Error::LengthMismatch(b_exponents.len(), 1 << b_eval_point.len()));
+	}
+	if b_exponent_evals.len() != 64 {
+		return Err(Error::LengthMismatch(b_exponent_evals.len(), 64));
+	}
+
+	if b_eval_point.len() != n_vars {
+		return Err(Error::LengthMismatch(b_eval_point.len(), n_vars));
+	}
+
+	fn make_multilinear<P: PackedField>(i: usize, exp: &[u64]) -> FieldBuffer<P> {
+		let packed_elements = exp
+			.iter()
+			.map(|exp| {
+				if exp & (1 << i) == 0 {
+					P::Scalar::zero()
+				} else {
+					P::Scalar::one()
+				}
+			})
+			.collect_vec();
+
+		FieldBuffer::from_values(&packed_elements).expect("input length is power of 2")
+	}
+	let multilinears = (0..64)
+		.map(|i| make_multilinear::<P>(i, &b_exponents))
+		.collect_vec();
+
+	let mut b_prover =
+		RerandMlecheckProver::<P>::new(multilinears, &b_eval_point, &b_exponent_evals)
+			.expect("checked input metrics");
+
+	// batch sumcheck
+
+	let batch_coeff: F = transcript.sample();
+
+	let mut challenges = vec![];
+
+	for _ in 0..n_vars {
+		let a_c_round_coeffs_vec = a_c_prover.execute().map_err(Error::from_sumcheck_execute)?;
+		if a_c_round_coeffs_vec.len() != 32 + 64 {
+			return Err(Error::LengthMismatch(a_c_round_coeffs_vec.len(), 32 + 64));
+		}
+
+		let b_round_coeffs_vec = b_prover.execute().map_err(Error::from_sumcheck_execute)?;
+		if b_round_coeffs_vec.len() != 64 {
+			return Err(Error::LengthMismatch(b_round_coeffs_vec.len(), 64));
+		}
+
+		let mut round_coeffs_vec: Vec<RoundCoeffs<F>> = a_c_round_coeffs_vec;
+		round_coeffs_vec.extend(b_round_coeffs_vec);
+
+		let round_coeffs = round_coeffs_vec
+			.iter()
+			.rev()
+			.fold(RoundCoeffs::default(), |acc, round_coeffs| acc * batch_coeff + round_coeffs);
+
+		let round_proof = round_coeffs.truncate();
+		transcript
+			.message()
+			.write_scalar_slice(round_proof.coeffs());
+
+		let challenge = transcript.sample();
+		challenges.push(challenge);
+
+		a_c_prover
+			.fold(challenge)
+			.map_err(Error::from_sumcheck_fold)?;
+		b_prover
+			.fold(challenge)
+			.map_err(Error::from_sumcheck_fold)?;
+	}
+
+	let scaled_a_c_exponent_claims = a_c_prover.finish().map_err(Error::from_sumcheck_finish)?;
+	let b_exponent_claims = b_prover.finish().map_err(Error::from_sumcheck_finish)?;
+
+	if scaled_a_c_exponent_claims.len() != 64 + 128 {
+		return Err(Error::LengthMismatch(scaled_a_c_exponent_claims.len(), 64 + 128));
+	}
+	if b_exponent_claims.len() != 64 {
+		return Err(Error::LengthMismatch(b_exponent_claims.len(), 64));
+	}
+
+	transcript
+		.message()
+		.write_scalar_slice(&scaled_a_c_exponent_claims);
+	transcript.message().write_scalar_slice(&b_exponent_claims);
+
+	Ok(Phase5Output {
+		eval_point: a_c_eval_point,
+		scaled_a_c_exponent_claims,
+		b_exponent_claims,
+	})
+}
+
+// PROVE
+
+#[derive(Debug)]
+pub struct ProveOutput<P: PackedField> {
+	pub eval_point: Vec<P::Scalar>,
+	pub a_exponent_claims: Vec<P::Scalar>,
+	pub b_exponent_claims: Vec<P::Scalar>,
+	pub c_lo_exponent_claims: Vec<P::Scalar>,
+	pub c_hi_exponent_claims: Vec<P::Scalar>,
+}
+
+pub fn prove<'a, F: Field, P: PackedField<Scalar = F>, C: Challenger>(
+	n_vars: usize,
+	b_exponents: &'a [u64],
+	mut a_layers: Layers<P>,
+	mut b_layers: Layers<P>,
+	mut c_layers: Layers<P>,
+	generator: P::Scalar,
+	transcript: &mut ProverTranscript<C>,
+) -> Result<(), Error> {
+	// -> Result<ProveOutput<P>, Error> {
+	let initial_eval_point = transcript.sample_vec(n_vars);
+
+	let mut last_b_layer = b_layers.next().expect("taking layer 6");
+	if last_b_layer.len() != 1 {
+		return Err(Error::LengthMismatch(last_b_layer.len(), 1));
+	}
+	let last_b_buffer = last_b_layer.pop().expect("contains exactly one buffer");
+
+	let mut last_c_layer = c_layers.next().expect("taking layer 7");
+	if last_c_layer.len() != 1 {
+		return Err(Error::LengthMismatch(last_c_layer.len(), 1));
+	}
+	let last_c_buffer = last_c_layer.pop().expect("contains exactly one buffer");
+
+	let (initial_b_eval, initial_c_eval) =
+		compute_initial_evals(&initial_eval_point, last_b_buffer, last_c_buffer)?;
+
+	transcript.message().write_scalar(initial_b_eval);
+	transcript.message().write_scalar(initial_c_eval);
+
+	// phase 1
+	let Phase1Output {
+		eval_point: phase_1_eval_point,
+		b_leaves_claims: b_tree_leaves_evals,
+	} = prove_phase_1(b_layers, initial_eval_point.clone(), initial_b_eval, transcript)?;
+
+	debug_assert_eq!(phase_1_eval_point.len(), n_vars);
+	debug_assert_eq!(b_tree_leaves_evals.len(), 64);
+
+	// phase 2
+	let Phase2Output {
+		twisted_eval_points,
+		twisted_claims: twisted_evals,
+	} = frobenius::<P::Scalar, P>(phase_1_eval_point, b_tree_leaves_evals);
+	debug_assert_eq!(twisted_eval_points.len(), 64);
+	debug_assert_eq!(twisted_evals.len(), 64);
+
+	// phase 3
+	let mut last_a_layer = a_layers.next().expect("taking layer 6");
+	if last_a_layer.len() != 1 {
+		return Err(Error::LengthMismatch(last_a_layer.len(), 1));
+	}
+	let last_a_buffer = last_a_layer.pop().expect("contains exactly one buffer");
+
+	let mut last_c_layer = c_layers.next().expect("taking layer 6");
+	if last_c_layer.len() != 2 {
+		return Err(Error::LengthMismatch(last_c_layer.len(), 2));
+	}
+	let last_c_lo_buffer = last_c_layer.pop().expect("contains 2 buffers");
+	let last_c_hi_buffer = last_c_layer.pop().expect("contains 1 buffer");
+
+	let Phase3Output {
+		eval_point: phase_3_eval_point,
+		b_exponent_claims,
+		v_claim,
+		c_claims,
+	} = prove_phase_3(
+		twisted_eval_points,
+		twisted_evals,
+		last_a_buffer,
+		b_exponents,
+		(last_c_lo_buffer, last_c_hi_buffer),
+		initial_eval_point,
+		initial_c_eval,
+		transcript,
+	)?;
+
+	// phase 4
+	let Phase4Output {
+		eval_point: phase_4_eval_point,
+		a_32_c_64_claims,
+	} = prove_phase_4(
+		phase_3_eval_point.clone(),
+		// a stuff
+		&mut a_layers,
+		v_claim,
+		// c stuff
+		&mut c_layers,
+		c_claims.0,
+		c_claims.1,
+		transcript,
+	)?;
+
+	// phase 5
+	let Phase5Output {
+		eval_point: phase_5_eval_point,
+		scaled_a_c_exponent_claims,
+		b_exponent_claims,
+	} = prove_phase_5(
+		phase_4_eval_point,
+		a_32_c_64_claims,
+		a_layers,
+		c_layers,
+		b_exponents,
+		phase_3_eval_point,
+		b_exponent_claims,
+		transcript,
+	)?;
+
+	let (a_exponent_claims, c_lo_exponent_claims, c_hi_exponent_claims) =
+		normalize_a_c_exponent_evals::<P>(scaled_a_c_exponent_claims, generator);
+
+	// Ok(ProveOutput {
+	// 	eval_point: phase_5_eval_point,
+	// 	a_exponent_claims,
+	// 	b_exponent_claims,
+	// 	c_lo_exponent_claims,
+	// 	c_hi_exponent_claims,
+	// })
+	Ok(())
+}

--- a/crates/prover/src/protocols/intmul/provers.rs
+++ b/crates/prover/src/protocols/intmul/provers.rs
@@ -1,0 +1,100 @@
+use binius_field::{Field, PackedField};
+use binius_math::field_buffer::FieldBuffer;
+use binius_verifier::protocols::sumcheck::{EvaluationOrder, RoundCoeffs};
+
+use crate::protocols::sumcheck::{common::SumcheckProver, error::Error};
+
+// V Prover
+
+pub struct VProver<'a, P: PackedField> {
+	v_buffer: FieldBuffer<P>,
+	_exponents: &'a [u64],
+	_twisted_eval_points: Vec<Vec<P::Scalar>>,
+	twisted_evals: Vec<P::Scalar>,
+}
+
+impl<'a, P: PackedField> VProver<'a, P> {
+	pub fn new(
+		v_buffer: FieldBuffer<P>,
+		exponents: &'a [u64],
+		twisted_eval_points: Vec<Vec<P::Scalar>>,
+		twisted_evals: Vec<P::Scalar>,
+	) -> Self {
+		Self {
+			v_buffer,
+			_exponents: exponents,
+			_twisted_eval_points: twisted_eval_points,
+			twisted_evals,
+		}
+	}
+}
+
+impl<'a, P: PackedField> SumcheckProver<P::Scalar> for VProver<'a, P> {
+	fn n_vars(&self) -> usize {
+		self.v_buffer.log_len()
+	}
+
+	fn evaluation_order(&self) -> EvaluationOrder {
+		EvaluationOrder::HighToLow
+	}
+
+	fn execute(&mut self) -> Result<Vec<RoundCoeffs<P::Scalar>>, Error> {
+		Ok(vec![
+			RoundCoeffs(vec![
+				P::Scalar::ZERO,
+				P::Scalar::ZERO,
+				P::Scalar::ZERO,
+				P::Scalar::ZERO
+			]);
+			64
+		])
+	}
+
+	fn fold(&mut self, _challenge: P::Scalar) -> Result<(), Error> {
+		Ok(())
+	}
+
+	fn finish(self) -> Result<Vec<P::Scalar>, Error> {
+		Ok(vec![P::Scalar::ZERO; self.twisted_evals.len() + 1])
+	}
+}
+
+// Rerandomization Prover
+
+pub struct RerandomizationProver<'a, P: PackedField> {
+	_exponents: &'a [u64],
+	_eval_point: Vec<P::Scalar>,
+	evals: Vec<P::Scalar>,
+}
+
+impl<'a, P: PackedField> RerandomizationProver<'a, P> {
+	pub fn new(exponents: &'a [u64], eval_point: Vec<P::Scalar>, evals: Vec<P::Scalar>) -> Self {
+		Self {
+			_exponents: exponents,
+			_eval_point: eval_point,
+			evals,
+		}
+	}
+}
+
+impl<'a, P: PackedField> SumcheckProver<P::Scalar> for RerandomizationProver<'a, P> {
+	fn n_vars(&self) -> usize {
+		0
+	}
+
+	fn evaluation_order(&self) -> EvaluationOrder {
+		EvaluationOrder::HighToLow
+	}
+
+	fn execute(&mut self) -> Result<Vec<RoundCoeffs<P::Scalar>>, Error> {
+		Ok(vec![RoundCoeffs(vec![P::Scalar::ZERO, P::Scalar::ZERO, P::Scalar::ZERO,]); 64])
+	}
+
+	fn fold(&mut self, _challenge: P::Scalar) -> Result<(), Error> {
+		Ok(())
+	}
+
+	fn finish(self) -> Result<Vec<P::Scalar>, Error> {
+		Ok(vec![P::Scalar::ZERO; self.evals.len()])
+	}
+}

--- a/crates/prover/src/protocols/intmul/tests.rs
+++ b/crates/prover/src/protocols/intmul/tests.rs
@@ -1,0 +1,120 @@
+use binius_field::{BinaryField, BinaryField128b, PackedBinaryField2x128b};
+
+use super::{execute::ProverData, *};
+
+type F = BinaryField128b;
+type P = PackedBinaryField2x128b;
+
+use binius_transcript::{ProverTranscript, fiat_shamir::HasherChallenger};
+use blake2::Blake2b;
+use digest::consts::U32;
+type Blake2b256 = Blake2b<U32>;
+
+#[test]
+fn test_go() {
+	let generator = F::MULTIPLICATIVE_GENERATOR;
+
+	let a_exponent: u64 = 2;
+	let b_exponent: u64 = 3;
+	let c_lo_exponent: u64 = 6; // 2*3 = 6
+	let c_hi_exponent: u64 = 0; // no high bits
+
+	let a_exponents = vec![a_exponent];
+	let b_exponents = vec![b_exponent];
+	let c_lo_exponents = vec![c_lo_exponent];
+	let c_hi_exponents = vec![c_hi_exponent];
+
+	let ProverData {
+		n_vars: _,
+		a_exponents: _,
+		b_exponents: _,
+		c_lo_exponents: _,
+		c_hi_exponents: _,
+		a_layers,
+		b_layers,
+		c_layers,
+	} = super::execute::execute::<P>(
+		generator,
+		&a_exponents,
+		&b_exponents,
+		&c_lo_exponents,
+		&c_hi_exponents,
+	)
+	.unwrap();
+
+	let mut prover_transcript = ProverTranscript::<HasherChallenger<Blake2b256>>::default();
+
+	let _prove_output = super::prove::prove::<F, P, HasherChallenger<Blake2b256>>(
+		0,
+		&b_exponents,
+		a_layers,
+		b_layers,
+		c_layers,
+		generator,
+		&mut prover_transcript,
+	);
+}
+
+#[test]
+fn test_go_multiple() {
+	use rand::Rng;
+
+	let mut rng = rand::rng();
+
+	let generator = F::MULTIPLICATIVE_GENERATOR;
+
+	const NUM_EXPONENTS: usize = 1 << 5;
+	let mut a_exponents = Vec::with_capacity(NUM_EXPONENTS);
+	let mut b_exponents = Vec::with_capacity(NUM_EXPONENTS);
+	let mut c_lo_exponents = Vec::with_capacity(NUM_EXPONENTS);
+	let mut c_hi_exponents = Vec::with_capacity(NUM_EXPONENTS);
+
+	for _ in 0..NUM_EXPONENTS {
+		let a_exp = rng.random_range(1..u64::MAX);
+		let b_exp = rng.random_range(1..u64::MAX);
+
+		let a_u128 = a_exp as u128;
+		let b_u128 = b_exp as u128;
+		let full_result = a_u128 * b_u128;
+
+		let c_lo = full_result as u64;
+		let c_hi = (full_result >> 64) as u64;
+
+		a_exponents.push(a_exp);
+		b_exponents.push(b_exp);
+		c_lo_exponents.push(c_lo);
+		c_hi_exponents.push(c_hi);
+	}
+
+	let ProverData {
+		n_vars,
+		a_exponents: _,
+		b_exponents: _,
+		c_lo_exponents: _,
+		c_hi_exponents: _,
+		a_layers,
+		b_layers,
+		c_layers,
+	} = execute::execute::<P>(generator, &a_exponents, &b_exponents, &c_lo_exponents, &c_hi_exponents)
+		.unwrap();
+
+	let mut prover_transcript = ProverTranscript::<HasherChallenger<Blake2b256>>::default();
+
+	let _prove_output = prove::prove::<F, P, HasherChallenger<Blake2b256>>(
+		n_vars,
+		&b_exponents,
+		a_layers,
+		b_layers,
+		c_layers,
+		generator,
+		&mut prover_transcript,
+	);
+
+	// let mut verifier_transcript = prover_transcript.into_verifier();
+	// verify::verify::<F, P, HasherChallenger<Blake2b256>>(
+	// 	n_vars,
+	// 	generator,
+	// 	&mut verifier_transcript,
+	// )
+	// .unwrap();
+}

--- a/crates/prover/src/protocols/mod.rs
+++ b/crates/prover/src/protocols/mod.rs
@@ -1,3 +1,4 @@
 // Copyright 2025 Irreducible Inc.
 
+pub mod intmul;
 pub mod sumcheck;

--- a/crates/prover/src/protocols/sumcheck/mod.rs
+++ b/crates/prover/src/protocols/sumcheck/mod.rs
@@ -3,4 +3,4 @@
 pub mod bivariate_mle;
 pub mod rerand_mle;
 pub mod common;
-mod error;
+pub mod error;

--- a/crates/transcript/src/transcript.rs
+++ b/crates/transcript/src/transcript.rs
@@ -2,7 +2,7 @@
 
 use std::{fs::File, io::Write, iter::repeat_with, slice};
 
-use binius_field::TowerField;
+use binius_field::Field as TowerField;
 use binius_utils::{DeserializeBytes, SerializationMode, SerializeBytes};
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 

--- a/crates/verifier/Cargo.toml
+++ b/crates/verifier/Cargo.toml
@@ -13,6 +13,7 @@ binius-frontend = { path = "../frontend" }
 binius-math = { path = "../math" }
 binius-transcript = { path = "../transcript" }
 binius-utils = { path = "../utils" }
+blake2.workspace = true
 bytemuck.workspace = true
 bytes.workspace = true
 digest.workspace = true
@@ -23,3 +24,4 @@ thiserror.workspace = true
 
 [dev-dependencies]
 assert_matches.workspace = true
+itertools.workspace = true

--- a/crates/verifier/src/protocols/intmul/common.rs
+++ b/crates/verifier/src/protocols/intmul/common.rs
@@ -1,0 +1,109 @@
+use binius_field::{Field, PackedField};
+use binius_math::{evaluate_univariate, multilinear::eq::eq_ind};
+use binius_transcript::{
+	VerifierTranscript,
+	fiat_shamir::{CanSample, Challenger},
+};
+use itertools::{Itertools, izip};
+
+use crate::protocols::{
+	// intmul::error::Error,
+	sumcheck::common::{RoundCoeffs, RoundProof},
+};
+
+pub struct HandleLayerOutput<F> {
+	pub eval_point: Vec<F>,
+	pub claims: Vec<F>,
+}
+
+pub struct Phase1Output<F> {
+	pub eval_point: Vec<F>,
+	pub b_leaves_claims: Vec<F>,
+}
+
+pub struct Phase2Output<F> {
+	pub twisted_eval_points: Vec<Vec<F>>,
+	pub twisted_claims: Vec<F>,
+}
+
+pub struct Phase3Output<F> {
+	pub eval_point: Vec<F>,
+	pub b_exponent_claims: Vec<F>,
+	pub v_claim: F,
+	pub c_claims: (F, F),
+}
+
+pub struct Phase4Output<F> {
+	pub eval_point: Vec<F>,
+	pub a_32_c_64_claims: Vec<F>,
+}
+
+pub struct Phase5Output<F> {
+	pub eval_point: Vec<F>,
+	pub scaled_a_c_exponent_claims: Vec<F>,
+	pub b_exponent_claims: Vec<F>,
+}
+
+/// for i in 0..64, compute phi^i(eval_point) and phi^i(evals[i])
+pub fn frobenius<F: Field, P: PackedField<Scalar = F>>(
+	eval_point: Vec<F>,
+	evals: Vec<F>,
+) -> Phase2Output<F> {
+	let twisted_eval_points = (0..64)
+		.map(|i| {
+			eval_point
+				.iter()
+				.map(|&var| (0..i).fold(var, |acc, _| acc.square()))
+				.collect::<Vec<_>>()
+		})
+		.collect::<Vec<_>>();
+
+	let twisted_claims = evals
+		.into_iter()
+		.enumerate()
+		.map(|(i, eval)| (0..i).fold(eval, |acc, _| acc.square()))
+		.collect::<Vec<_>>();
+
+	Phase2Output {
+		twisted_eval_points,
+		twisted_claims,
+	}
+}
+
+pub fn normalize_a_c_exponent_evals<P: PackedField>(
+	evals: Vec<P::Scalar>,
+	generator: P::Scalar,
+) -> (Vec<P::Scalar>, Vec<P::Scalar>, Vec<P::Scalar>) {
+	debug_assert_eq!(evals.len(), 64 + 2 * 64);
+	// for i in 0..64: evals[i] = (1-EvalMLE_i)*1 + EvalMLE_i*g^{2^i} = EvalMLE_i*(g^{2^i}-1) + 1
+	// where EvalMLE_i is the evaluation of the multilinear extension of bit i of the exponents of
+	// `a` (the point of evaluation is irrelevant in this function)
+	// we can then compute desired evaluation EvalMLE_i as (eval[i] - 1) / (g^{2^i}-1)
+	// similarly for `c` for evals[64..192] and i in 0..128
+
+	let mut a_scaled_evals = evals;
+	let mut c_scaled_evals = a_scaled_evals.split_off(64);
+	let mut c_lo_scaled_evals = c_scaled_evals.split_off(64);
+	let mut c_hi_scaled_evals = c_scaled_evals;
+
+	let conjugates: Vec<_> = std::iter::successors(Some(generator), |&prev| Some(prev.square()))
+		.take(128)
+		.collect();
+
+	izip!(conjugates[..64].iter(), a_scaled_evals.iter_mut(), c_lo_scaled_evals.iter_mut())
+		.for_each(|(conjugate, a_eval, c_lo_eval)| {
+			*a_eval -= P::Scalar::one();
+			*a_eval *= (*conjugate - P::Scalar::one()).invert().expect("non-zero");
+			*c_lo_eval -= P::Scalar::one();
+			*c_lo_eval *= (*conjugate - P::Scalar::one()).invert().expect("non-zero");
+		});
+
+	izip!(conjugates[64..].iter(), c_hi_scaled_evals.iter_mut()).for_each(
+		|(conjugate, c_hi_eval)| {
+			*c_hi_eval -= P::Scalar::one();
+			*c_hi_eval *= (*conjugate - P::Scalar::one()).invert().expect("non-zero");
+		},
+	);
+
+	(a_scaled_evals, c_lo_scaled_evals, c_hi_scaled_evals)
+}

--- a/crates/verifier/src/protocols/intmul/error.rs
+++ b/crates/verifier/src/protocols/intmul/error.rs
@@ -1,0 +1,31 @@
+// Copyright 2025 Irreducible Inc.
+
+impl Error {
+	pub fn from_transcript_read(error: binius_transcript::Error) -> Self {
+		Error::TranscriptError(error)
+	}
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+	#[error("transcript error")]
+	TranscriptError(#[from] binius_transcript::Error),
+	#[error("length mismatch: {0} != {1}")]
+	LengthMismatch(usize, usize),
+	#[error("twisted eval points count ({0}) does not match claims count ({1})")]
+	TwistedPointsEvalsMismatch(usize, usize),
+	#[error("layer length ({0}) does not match pairs count ({1})")]
+	LayerClaimsMismatch(usize, usize),
+	#[error("composition claim mismatch")]
+	CompositionClaimMismatch,
+	#[error("final claims count ({0}) does not match pairs count * 2 ({1})")]
+	FinalClaimsPairsMismatch(usize, usize),
+	#[error("round coeffs count ({0}) does not match pairs count ({1})")]
+	RoundCoeffsPairsMismatch(usize, usize),
+	#[error("buffer log len ({0}) and eval point len ({1}) mismatch")]
+	BufferEvalPointMismatch(usize, usize),
+	#[error("layer pairs count ({0}) does not match claims count ({1})")]
+	LayerPairsCountClaimsMismatch(usize, usize),
+	#[error("eval point and buffer log len mismatch")]
+	EvalPointBufferLengthMismatch,
+}

--- a/crates/verifier/src/protocols/intmul/mod.rs
+++ b/crates/verifier/src/protocols/intmul/mod.rs
@@ -1,0 +1,3 @@
+pub mod common;
+pub mod error;
+mod verify;

--- a/crates/verifier/src/protocols/intmul/verify.rs
+++ b/crates/verifier/src/protocols/intmul/verify.rs
@@ -1,0 +1,397 @@
+use binius_field::{Field, PackedField};
+use binius_math::{evaluate_univariate, multilinear::eq::eq_ind};
+use binius_transcript::{
+	VerifierTranscript,
+	fiat_shamir::{CanSample, Challenger},
+};
+use itertools::{Itertools, izip};
+
+use super::{
+	common::{
+		HandleLayerOutput, Phase1Output, Phase2Output, Phase3Output, Phase4Output, Phase5Output,
+		frobenius, normalize_a_c_exponent_evals,
+	},
+	error::Error,
+};
+use crate::protocols::sumcheck::common::{RoundCoeffs, RoundProof};
+
+fn read_scalar<F: Field, C: Challenger>(
+	transcript: &mut VerifierTranscript<C>,
+) -> Result<F, Error> {
+	transcript
+		.message()
+		.read_scalar::<F>()
+		.map_err(Error::from_transcript_read)
+}
+
+fn read_scalar_slice<F: Field, C: Challenger>(
+	transcript: &mut VerifierTranscript<C>,
+	len: usize,
+) -> Result<Vec<F>, Error> {
+	transcript
+		.message()
+		.read_scalar_slice::<F>(len)
+		.map_err(Error::from_transcript_read)
+}
+
+fn verify_layer<F: Field, P: PackedField<Scalar = F>, C: Challenger>(
+	eval_point: Vec<F>,
+	claims: Vec<F>,
+	transcript: &mut VerifierTranscript<C>,
+) -> Result<HandleLayerOutput<F>, Error> {
+	let n_vars = eval_point.len();
+
+	let batch_coef: F = transcript.sample();
+	let mut challenges: Vec<F> = vec![];
+
+	let mut claim = evaluate_univariate(&claims, batch_coef);
+
+	for _ in 0..n_vars {
+		let coeffs = read_scalar_slice(transcript, 3)?;
+
+		let round_proof = RoundProof(RoundCoeffs(coeffs));
+		let round_coeffs = round_proof.recover(claim);
+
+		let challenge = transcript.sample();
+		challenges.push(challenge);
+
+		claim = evaluate_univariate(&round_coeffs.0, challenge);
+	}
+
+	challenges.reverse();
+
+	let final_claims = transcript
+		.message()
+		.read_scalar_slice::<F>(2 * claims.len())
+		.map_err(Error::from_transcript_read)?;
+
+	let eq_eval = eq_ind(&eval_point, &challenges);
+	let expected_unbatched_terms = final_claims
+		.iter()
+		.tuples()
+		.map(|(&left, &right)| eq_eval * left * right)
+		.collect::<Vec<_>>();
+
+	let expected_claim = evaluate_univariate(&expected_unbatched_terms, batch_coef);
+	assert_eq!(expected_claim, claim);
+	if expected_claim != claim {
+		return Err(Error::CompositionClaimMismatch);
+	}
+
+	Ok(HandleLayerOutput {
+		eval_point: challenges,
+		claims: final_claims,
+	})
+}
+
+fn verify_phase_1<F: Field, P: PackedField<Scalar = F>, C: Challenger>(
+	initial_eval_point: &[F],
+	initial_b_claim: F,
+	transcript: &mut VerifierTranscript<C>,
+) -> Result<Phase1Output<F>, Error> {
+	let mut eval_point = initial_eval_point.to_vec();
+	let mut claims = vec![initial_b_claim];
+
+	for layer_num in (0..6).rev() {
+		let depth = 5 - layer_num;
+		debug_assert_eq!(claims.len(), 1 << depth);
+
+		let HandleLayerOutput {
+			eval_point: new_eval_point,
+			claims: new_claims,
+		} = verify_layer::<F, P, C>(eval_point, claims, transcript)?;
+
+		eval_point = new_eval_point;
+		claims = new_claims;
+	}
+
+	Ok(Phase1Output {
+		eval_point,
+		b_leaves_claims: claims,
+	})
+}
+
+// PHASE 2: frobenius
+
+// PHASE THREE: painful sumcheck
+
+fn verify_phase_3<F: Field, C: Challenger>(
+	n_vars: usize,
+	// v sumcheck stuff
+	twisted_eval_points: Vec<Vec<F>>,
+	twisted_claims: Vec<F>,
+	// c sumcheck stuff
+	c_eval_point: Vec<F>,
+	c_claim: F,
+	transcript: &mut VerifierTranscript<C>,
+) -> Result<Phase3Output<F>, Error> {
+	if twisted_eval_points.len() != 64 {
+		return Err(Error::LengthMismatch(twisted_eval_points.len(), 64));
+	}
+
+	if twisted_claims.len() != twisted_eval_points.len() {
+		return Err(Error::TwistedPointsEvalsMismatch(
+			twisted_claims.len(),
+			twisted_eval_points.len(),
+		));
+	}
+
+	for twisted_eval_point in &twisted_eval_points {
+		if twisted_eval_point.len() != n_vars {
+			return Err(Error::EvalPointBufferLengthMismatch);
+		}
+	}
+
+	if c_eval_point.len() != n_vars {
+		return Err(Error::EvalPointBufferLengthMismatch);
+	}
+
+	let batch_coeff: F = transcript.sample();
+	let mut challenges = vec![];
+
+	let mut unbatched_claims = twisted_claims;
+	unbatched_claims.push(c_claim);
+	let mut claim = evaluate_univariate(&unbatched_claims, batch_coeff);
+
+	for _ in 0..n_vars {
+		let coeffs = read_scalar_slice(transcript, 3)?;
+		let round_proof = RoundProof(RoundCoeffs(coeffs));
+		let round_coeffs = round_proof.recover(claim);
+
+		let challenge = transcript.sample();
+		challenges.push(challenge);
+
+		claim = evaluate_univariate(&round_coeffs.0, batch_coeff);
+	}
+
+	let b_exponent_claims = read_scalar_slice(transcript, 64)?;
+	let v_claim = read_scalar(transcript)?;
+	let c_lo_claim = read_scalar(transcript)?;
+	let c_hi_claim = read_scalar(transcript)?;
+
+	let expected_unbatched_b_v_term = |(twisted_eval_point, b_exponent_claim): (&Vec<F>, &F)| {
+		let twisted_eq_eval = eq_ind(twisted_eval_point, &challenges);
+		twisted_eq_eval * ((F::one() - b_exponent_claim) + *b_exponent_claim * v_claim)
+	};
+	let mut expected_unbatched_terms = izip!(&twisted_eval_points, &b_exponent_claims)
+		.map(expected_unbatched_b_v_term)
+		.collect::<Vec<_>>();
+
+	let c_eq_eval = eq_ind(&c_eval_point, &challenges);
+	expected_unbatched_terms.extend([c_eq_eval * c_lo_claim, c_eq_eval * c_hi_claim]);
+
+	let expected_batched_claim = evaluate_univariate(&expected_unbatched_terms, batch_coeff);
+
+	if expected_batched_claim != claim {
+		return Err(Error::CompositionClaimMismatch);
+	}
+
+	Ok(Phase3Output {
+		eval_point: challenges,
+		b_exponent_claims,
+		v_claim,
+		c_claims: (c_lo_claim, c_hi_claim),
+	})
+}
+
+// PHASE 4: most of a_layers and c_layers
+
+fn verify_phase_4<F: Field, P: PackedField<Scalar = F>, C: Challenger>(
+	eval_point: Vec<F>,
+	// a stuff
+	a_last_layer_claim: F,
+	// c stuff
+	c_lo_last_layer_claim: F,
+	c_hi_last_layer_claim: F,
+	transcript: &mut VerifierTranscript<C>,
+) -> Result<Phase4Output<F>, Error> {
+	let mut eval_point = eval_point.to_vec();
+	let mut claims = vec![
+		a_last_layer_claim,
+		c_lo_last_layer_claim,
+		c_hi_last_layer_claim,
+	];
+
+	for layer_num in (1..6).rev() {
+		let depth = 6 - layer_num;
+		debug_assert_eq!(claims.len(), 3 * (1 << depth) / 2);
+
+		let HandleLayerOutput {
+			eval_point: new_eval_point,
+			claims: new_claims,
+		} = verify_layer::<F, P, C>(eval_point, claims, transcript)?;
+
+		eval_point = new_eval_point;
+		claims = new_claims;
+	}
+
+	debug_assert_eq!(claims.len(), 32 + 2 * 32);
+
+	Ok(Phase4Output {
+		eval_point,
+		a_32_c_64_claims: claims,
+	})
+}
+
+// PHASE 5: final layer
+
+fn verify_phase_5<F: Field, P: PackedField<Scalar = F>, C: Challenger>(
+	// a and c stuff
+	a_c_eval_point: Vec<F>,
+	a_c_claims: Vec<F>,
+	// b stuff
+	b_eval_point: Vec<F>,
+	b_exponent_claims: Vec<F>,
+	transcript: &mut VerifierTranscript<C>,
+) -> Result<Phase5Output<F>, Error> {
+	if a_c_claims.len() != 32 + 64 {
+		return Err(Error::LengthMismatch(a_c_claims.len(), 32 + 64));
+	}
+	if b_exponent_claims.len() != 64 {
+		return Err(Error::LengthMismatch(b_exponent_claims.len(), 64));
+	}
+
+	if a_c_eval_point.len() != b_eval_point.len() {
+		return Err(Error::LengthMismatch(a_c_eval_point.len(), b_eval_point.len()));
+	}
+
+	let batch_coeff: F = transcript.sample();
+
+	let mut unbatched_claims = a_c_claims;
+	unbatched_claims.extend(b_exponent_claims);
+	let mut claim = evaluate_univariate(&unbatched_claims, batch_coeff);
+
+	let mut challenges: Vec<F> = vec![];
+
+	for _ in 0..a_c_eval_point.len() {
+		let coeffs = read_scalar_slice(transcript, 3)?;
+		let round_proof = RoundProof(RoundCoeffs(coeffs));
+		let round_coeffs = round_proof.recover(claim);
+
+		let challenge = transcript.sample();
+		challenges.push(challenge);
+
+		claim = evaluate_univariate(&round_coeffs.0, challenge);
+	}
+
+	let scaled_a_c_exponent_claims = read_scalar_slice(transcript, 64 + 128)?;
+	let b_exponent_claims = read_scalar_slice(transcript, 64)?;
+
+	let a_c_eq_eval = eq_ind(&a_c_eval_point, &challenges);
+	let expected_a_c_unbatched_claims = scaled_a_c_exponent_claims
+		.iter()
+		.tuples()
+		.map(|(left, right)| a_c_eq_eval * left * right)
+		.collect::<Vec<F>>();
+
+	let b_eq_eval = eq_ind(&b_eval_point, &challenges);
+	let expected_b_unbatched_claims = b_exponent_claims
+		.iter()
+		.map(|&b_exponent_claim| b_eq_eval * b_exponent_claim)
+		.collect::<Vec<F>>();
+
+	let mut expected_unbatched_claims = expected_a_c_unbatched_claims;
+	expected_unbatched_claims.extend(expected_b_unbatched_claims);
+
+	let expected_batched_claim = evaluate_univariate(&expected_unbatched_claims, batch_coeff);
+
+	if expected_batched_claim != claim {
+		return Err(Error::CompositionClaimMismatch);
+	}
+
+	Ok(Phase5Output {
+		eval_point: a_c_eval_point,
+		scaled_a_c_exponent_claims,
+		b_exponent_claims: b_exponent_claims,
+	})
+}
+
+// verify
+
+pub struct VerifyOutput<F> {
+	pub eval_point: Vec<F>,
+	pub a_claims: Vec<F>,
+	pub b_claims: Vec<F>,
+	pub c_lo_claims: Vec<F>,
+	pub c_hi_claims: Vec<F>,
+}
+
+pub fn verify<F: Field, P: PackedField<Scalar = F>, C: Challenger>(
+	n_vars: usize,
+	generator: F,
+	transcript: &mut VerifierTranscript<C>,
+) -> Result<VerifyOutput<F>, Error> {
+	let initial_eval_point: Vec<P::Scalar> = transcript.sample_vec(n_vars);
+
+	let initial_b_eval = read_scalar(transcript)?;
+	let initial_c_eval = read_scalar(transcript)?;
+
+	// phase 1
+	let Phase1Output {
+		eval_point: phase_1_eval_point,
+		b_leaves_claims,
+	} = verify_phase_1::<F, P, C>(&initial_eval_point, initial_b_eval, transcript)?;
+
+	debug_assert_eq!(phase_1_eval_point.len(), n_vars);
+	debug_assert_eq!(b_leaves_claims.len(), 64);
+
+	// phase 2
+	let Phase2Output {
+		twisted_eval_points,
+		twisted_claims: twisted_evals,
+	} = frobenius::<F, P>(phase_1_eval_point, b_leaves_claims);
+
+	debug_assert_eq!(twisted_eval_points.len(), 64);
+	debug_assert_eq!(twisted_evals.len(), 64);
+
+	// phase 3
+	let Phase3Output {
+		eval_point: phase_3_eval_point,
+		b_exponent_claims,
+		v_claim: a_last_layer_claim,
+		c_claims,
+	} = verify_phase_3(
+		n_vars,
+		twisted_eval_points,
+		twisted_evals,
+		initial_eval_point,
+		initial_c_eval,
+		transcript,
+	)?;
+
+	// phase 4
+	let Phase4Output {
+		eval_point: phase_4_eval_point,
+		a_32_c_64_claims,
+	} = verify_phase_4::<F, P, C>(
+		phase_3_eval_point.clone(),
+		a_last_layer_claim,
+		c_claims.0,
+		c_claims.1,
+		transcript,
+	)?;
+
+	// phase 5
+	let Phase5Output {
+		eval_point: phase_5_eval_point,
+		scaled_a_c_exponent_claims,
+		b_exponent_claims,
+	} = verify_phase_5::<F, P, C>(
+		phase_4_eval_point,
+		a_32_c_64_claims,
+		phase_3_eval_point,
+		b_exponent_claims,
+		transcript,
+	)?;
+
+	let (a_exponent_claims, c_lo_exponent_claims, c_hi_exponent_claims) =
+		normalize_a_c_exponent_evals::<P>(scaled_a_c_exponent_claims, generator);
+
+	Ok(VerifyOutput {
+		eval_point: phase_5_eval_point,
+		a_claims: a_exponent_claims,
+		b_claims: b_exponent_claims,
+		c_lo_claims: c_lo_exponent_claims,
+		c_hi_claims: c_hi_exponent_claims,
+	})
+}

--- a/crates/verifier/src/protocols/mod.rs
+++ b/crates/verifier/src/protocols/mod.rs
@@ -1,3 +1,4 @@
 // Copyright 2025 Irreducible Inc.
 
+pub mod intmul;
 pub mod sumcheck;


### PR DESCRIPTION
### TL;DR

Added integer multiplication protocol implementation for binary fields, including execution, proving, and verification components.

### What changed?

- Implemented a new integer multiplication protocol in the `intmul` module
- Created execution logic for computing integer multiplication using binary fields
- Added proving and verification components for the protocol
- Implemented error handling for the integer multiplication protocol
- Added test cases for small and large integer multiplications
- Structured the protocol in phases for efficient proving and verification

The implementation includes:
- Tree-based computation for integer multiplication
- Support for handling 64-bit integer multiplication with high and low components
- Sumcheck-based verification
- Frobenius map application for twisted evaluation points
- Batched verification for efficiency

### How to test?

The implementation includes several test cases:
- `test_forwards` - Tests basic multiplication (2 * 3 = 6)
- `test_forwards_larger` - Tests multiplication with high bits (2^32 * 2^33 = 2^65)
- `test_forwards_multiple_random` - Tests multiple random multiplications
- `test_go` - Tests the full proving and verification flow
- `test_go_multiple` - Tests the protocol with multiple random inputs

Run the tests with:
```
cargo test --package prover --lib -- protocols::intmul::tests
```

### Why make this change?

This implementation provides an efficient way to prove integer multiplication in zero-knowledge proofs. Integer multiplication is a fundamental operation in many cryptographic protocols and blockchain applications. The binary field implementation allows for efficient representation and verification of these operations, which can be used as a building block for more complex computations in zero-knowledge systems.