### PR TITLE
Rerandomization prover

### DIFF
--- a/crates/math/src/field_buffer.rs
+++ b/crates/math/src/field_buffer.rs
@@ -34,8 +34,24 @@ impl<P: PackedField, Data: Deref<Target = [P]>> PartialEq for FieldBuffer<P, Dat
 	fn eq(&self, other: &Self) -> bool {
 		// Custom equality impl is needed because values beyond length until capacity can be
 		// arbitrary.
-		let prefix = 1 << self.log_len.saturating_sub(P::LOG_WIDTH);
-		self.log_len == other.log_len && self.values[..prefix] == other.values[..prefix]
+		if self.log_len < P::LOG_WIDTH {
+			let iter_1 = self
+				.values
+				.first()
+				.expect("len >= 1")
+				.iter()
+				.take(1 << self.log_len);
+			let iter_2 = other
+				.values
+				.first()
+				.expect("len >= 1")
+				.iter()
+				.take(1 << self.log_len);
+			iter_1.eq(iter_2)
+		} else {
+			let prefix = 1 << (self.log_len - P::LOG_WIDTH);
+			self.log_len == other.log_len && self.values[..prefix] == other.values[..prefix]
+		}
 	}
 }
 

--- a/crates/prover/src/protocols/sumcheck/error.rs
+++ b/crates/prover/src/protocols/sumcheck/error.rs
@@ -9,6 +9,8 @@ pub enum Error {
 	ArgumentError(String),
 	#[error("multilinears do not have equal number of variables")]
 	MultilinearSizeMismatch,
+	#[error("bitmasks slice length does not match the evaluation point length")]
+	BitmasksSizeMismatch,
 	#[error("number of eval claims does not match the number of multilinears")]
 	EvalClaimsNumberMismatch,
 	#[error("the length of evaluation point does not match the size of the multilinears")]

--- a/crates/prover/src/protocols/sumcheck/mod.rs
+++ b/crates/prover/src/protocols/sumcheck/mod.rs
@@ -11,7 +11,9 @@ pub mod gruen34;
 mod mle_to_sumcheck;
 mod prove;
 pub mod quadratic_mle;
+pub mod rerand_mle;
 mod round_evals;
+mod switchover;
 
 pub use error::*;
 pub use mle_to_sumcheck::*;

--- a/crates/prover/src/protocols/sumcheck/rerand_mle.rs
+++ b/crates/prover/src/protocols/sumcheck/rerand_mle.rs
@@ -1,0 +1,302 @@
+// Copyright 2025 Irreducible Inc.
+
+use std::cmp::max;
+
+use binius_field::{Field, PackedField};
+use binius_math::FieldBuffer;
+use binius_utils::{bitwise::Bitwise, rayon::prelude::*};
+use binius_verifier::protocols::sumcheck::RoundCoeffs;
+use itertools::izip;
+
+use super::{
+	common::{MleCheckProver, SumcheckProver},
+	error::Error,
+	gruen34::Gruen34,
+	round_evals::RoundEvals1,
+	switchover::BinarySwitchover,
+};
+
+/// A [`SumcheckProver`] implementation that can "rerandomize" evaluation claims on a set of 1-bit
+/// multilinears, with those claims sharing the evaluation point. This is essentially a degree-1
+/// mlecheck.
+///
+/// The set of 1-bit multilinears is represented by a power-of-two long slice of bitmasks, and the
+/// multilinear set is constructed by arranging the bitmasks as a 2D matrix in row-major order and
+/// taking vertical slices. This representation is very compact and has no embedding overhead.
+///
+/// To combat memory blowup issues arising from folding 1-bit multilinears, this prover introduces
+/// switchover. See `BinarySwitchover` for more in-depth explanation of the mechanism.
+pub struct RerandMlecheckProver<'b, P: PackedField, B: Bitwise> {
+	last_coeffs_or_sums: RoundCoeffsOrSums<P::Scalar>,
+	gruen34: Gruen34<P>,
+	switchover: BinarySwitchover<'b, P, B>,
+}
+
+impl<'b, F, P, B> RerandMlecheckProver<'b, P, B>
+where
+	F: Field,
+	P: PackedField<Scalar = F>,
+	B: Bitwise,
+{
+	/// Constructs a prover, given `bitmasks` as representation of 1-bit columns, evaluation claims
+	/// `eval_claims` on the shared `eval_point`, and `switchover` being the round at which 1-bit
+	/// columns should be folded.
+	pub fn new(
+		eval_point: &[F],
+		eval_claims: &[F],
+		bitmasks: &'b [B],
+		switchover: usize,
+	) -> Result<Self, Error> {
+		let n_vars = eval_point.len();
+
+		if bitmasks.len() != 1 << n_vars {
+			return Err(Error::BitmasksSizeMismatch);
+		}
+
+		let gruen34 = Gruen34::new(eval_point);
+		let switchover = BinarySwitchover::new(eval_claims.len(), switchover.min(n_vars), bitmasks);
+		let last_coeffs_or_sums = RoundCoeffsOrSums::Sums(eval_claims.to_vec());
+
+		Ok(Self {
+			last_coeffs_or_sums,
+			gruen34,
+			switchover,
+		})
+	}
+}
+
+impl<'b, F, P, B> SumcheckProver<F> for RerandMlecheckProver<'b, P, B>
+where
+	F: Field,
+	P: PackedField<Scalar = F>,
+	B: Bitwise,
+{
+	fn n_vars(&self) -> usize {
+		self.gruen34.n_vars_remaining()
+	}
+
+	fn execute(&mut self) -> Result<Vec<RoundCoeffs<F>>, Error> {
+		let RoundCoeffsOrSums::Sums(sums) = &self.last_coeffs_or_sums else {
+			return Err(Error::ExpectedFold);
+		};
+
+		assert!(self.n_vars() > 0);
+
+		// Perform chunked summation: for every row, evaluate all compositions and add up
+		// results to an array of round evals accumulators. Alternative would be to sum each
+		// composition on its own pass, but that would require reading the entirety of eq field
+		// buffer on each pass, which will evict the latter from the cache. By doing chunked
+		// compute, we reasonably hope that eq chunk always stays in L1 cache.
+		//
+		// We also do switchover there, which by definition requires small scratchpads to hold
+		// large field partial evaluations of the transparent multilinears.
+		const MAX_CHUNK_VARS: usize = 12;
+		let chunk_vars = max(MAX_CHUNK_VARS, P::LOG_WIDTH).min(self.n_vars() - 1);
+		let chunk_count = 1 << (self.n_vars() - 1 - chunk_vars);
+
+		let packed_prime_evals = (0..chunk_count)
+			.into_par_iter()
+			.try_fold(
+				// A chunk-sized scratchpad is needed for switchover.
+				|| (vec![RoundEvals1::default(); sums.len()], FieldBuffer::<P>::zeros(chunk_vars)),
+				|(mut packed_prime_evals, mut binary_chunk): (
+					Vec<RoundEvals1<P>>,
+					FieldBuffer<P>,
+				),
+				 chunk_index|
+				 -> Result<_, Error> {
+					let eq_chunk = self.gruen34.eq_expansion().chunk(chunk_vars, chunk_index)?;
+
+					for (bit_offset, round_evals) in packed_prime_evals.iter_mut().enumerate() {
+						// Degree-1 composition - evaluate at 1 only
+						let evals_1_chunk = self.switchover.get_chunk(
+							&mut binary_chunk,
+							bit_offset,
+							chunk_vars,
+							chunk_index | chunk_count,
+						)?;
+						for (&eq_i, &evals_1_i) in izip!(eq_chunk.as_ref(), evals_1_chunk.as_ref())
+						{
+							round_evals.y_1 += eq_i * evals_1_i;
+						}
+					}
+
+					Ok((packed_prime_evals, binary_chunk))
+				},
+			)
+			.map(|evals_with_scratchpad| evals_with_scratchpad.map(|(evals, _)| evals))
+			.try_reduce(
+				|| vec![RoundEvals1::default(); sums.len()],
+				|lhs, rhs| Ok(izip!(lhs, rhs).map(|(l, r)| l + &r).collect()),
+			)?;
+
+		let alpha = self.gruen34.next_coordinate();
+		let round_coeffs = izip!(sums, packed_prime_evals)
+			.map(|(&sum, packed_evals)| {
+				let round_evals = packed_evals.sum_scalars(self.n_vars());
+				round_evals.interpolate_eq(sum, alpha)
+			})
+			.collect::<Vec<_>>();
+
+		self.last_coeffs_or_sums = RoundCoeffsOrSums::Coeffs(round_coeffs.clone());
+		Ok(round_coeffs)
+	}
+
+	fn fold(&mut self, challenge: F) -> Result<(), Error> {
+		let RoundCoeffsOrSums::Coeffs(round_coeffs) = &self.last_coeffs_or_sums else {
+			return Err(Error::ExpectedExecute);
+		};
+
+		assert!(self.n_vars() > 0);
+
+		let sums = round_coeffs
+			.iter()
+			.map(|coeffs| coeffs.evaluate(challenge))
+			.collect::<Vec<F>>();
+
+		self.switchover.fold(challenge)?;
+		self.gruen34.fold(challenge)?;
+
+		self.last_coeffs_or_sums = RoundCoeffsOrSums::Sums(sums);
+		Ok(())
+	}
+
+	fn finish(self) -> Result<Vec<F>, Error> {
+		if self.n_vars() > 0 {
+			let error = match self.last_coeffs_or_sums {
+				RoundCoeffsOrSums::Coeffs(_) => Error::ExpectedFold,
+				RoundCoeffsOrSums::Sums(_) => Error::ExpectedExecute,
+			};
+
+			return Err(error);
+		}
+
+		let multilinear_evals = self
+			.switchover
+			.finalize()?
+			.into_iter()
+			.map(|multilinear| {
+				debug_assert_eq!(multilinear.log_len(), 0);
+				multilinear.get(0).expect("multilinear.len()==1")
+			})
+			.collect();
+
+		Ok(multilinear_evals)
+	}
+}
+
+impl<'b, F, P, B> MleCheckProver<F> for RerandMlecheckProver<'b, P, B>
+where
+	F: Field,
+	P: PackedField<Scalar = F>,
+	B: Bitwise,
+{
+	fn eval_point(&self) -> &[F] {
+		self.gruen34.eval_point()
+	}
+}
+
+enum RoundCoeffsOrSums<F: Field> {
+	Coeffs(Vec<RoundCoeffs<F>>),
+	Sums(Vec<F>),
+}
+
+#[cfg(test)]
+mod tests {
+	use std::iter::repeat_with;
+
+	use binius_field::{Field, PackedBinaryField8x16b, PackedField, Random};
+	use binius_math::{multilinear::evaluate::evaluate, test_utils::random_scalars};
+	use binius_utils::{bitwise::BitSelector, random_access_sequence::RandomAccessSequence};
+	use itertools::Itertools;
+	use rand::{Rng, SeedableRng, rngs::StdRng};
+
+	use super::*;
+	use crate::protocols::sumcheck::bivariate_product_multi_mle::BivariateProductMultiMlecheckProver;
+
+	type P = PackedBinaryField8x16b;
+	type F = <P as PackedField>::Scalar;
+
+	fn test_bivariate_mlecheck_conformance_helper(n_vars: usize, switchover: usize) {
+		let mut rng = StdRng::seed_from_u64(0);
+
+		let selector_count = 3;
+		let eval_point = random_scalars::<F>(&mut rng, n_vars);
+
+		let selector_mask = (1u16 << selector_count) - 1;
+		let bitmasks = repeat_with(|| rng.random::<u16>() & selector_mask)
+			.take(1 << n_vars)
+			.collect_vec();
+
+		// Compare the round polynomials and final multilinear evals of bivariate product mlecheck
+		// and the rerandomization prover. Bivariate product prover is invoked by embedding bits
+		// into large field elements and doing a product with a constant multilinear of ones.
+
+		let ones_scalars = repeat_with(|| F::ONE).take(1 << n_vars).collect_vec();
+		let ones = FieldBuffer::<P>::from_values(&ones_scalars).unwrap();
+
+		let selectors_with_claims = (0..selector_count)
+			.map(|bit_offset| {
+				let bit_selector = BitSelector::new(bit_offset, &bitmasks);
+
+				let selector_scalars = (0..bit_selector.len())
+					.map(|i| if bit_selector.get(i) { F::ONE } else { F::ZERO })
+					.collect_vec();
+				let selector = FieldBuffer::<P>::from_values(&selector_scalars).unwrap();
+
+				let eval_claim = evaluate(&selector, &eval_point).unwrap();
+				(selector, eval_claim)
+			})
+			.collect_vec();
+
+		let (selectors, eval_claims) = selectors_with_claims
+			.into_iter()
+			.unzip::<_, _, Vec<_>, Vec<_>>();
+		let mut multi_bivariate_prover = BivariateProductMultiMlecheckProver::new(
+			selectors
+				.into_iter()
+				.map(|selector| [selector, ones.clone()])
+				.collect_vec(),
+			&eval_point,
+			&eval_claims,
+		)
+		.unwrap();
+
+		let mut rerand_prover =
+			RerandMlecheckProver::<P, _>::new(&eval_point, &eval_claims, &bitmasks, switchover)
+				.unwrap();
+
+		for _round in 0..n_vars {
+			let rerand_round_coeffs = rerand_prover.execute().unwrap();
+			let multi_bivariate_round_coeffs = multi_bivariate_prover.execute().unwrap();
+
+			for (rerand, mut multi) in izip!(rerand_round_coeffs, multi_bivariate_round_coeffs) {
+				// Bivariate product prover sizes round polynomials for degree-3 but they are
+				// actually degree-2 and the highest coefficient is zero.
+				assert_eq!(multi.0.pop(), Some(F::ZERO));
+				assert_eq!(rerand, multi);
+			}
+
+			let challenge = F::random(&mut rng);
+			rerand_prover.fold(challenge).unwrap();
+			multi_bivariate_prover.fold(challenge).unwrap();
+		}
+
+		let rerand_multilinear_evals = rerand_prover.finish().unwrap();
+		let multi_bivariate_multilinear_evals = multi_bivariate_prover.finish().unwrap();
+
+		for (rerand, multi) in
+			izip!(rerand_multilinear_evals, multi_bivariate_multilinear_evals.chunks(2))
+		{
+			assert_eq!(rerand, multi[0]);
+			assert_eq!(F::ONE, multi[1]);
+		}
+	}
+
+	#[test]
+	fn test_bivariate_mlecheck_conformance() {
+		for (n_vars, switchover) in [(8, 1), (8, 3), (8, 9)] {
+			test_bivariate_mlecheck_conformance_helper(n_vars, switchover);
+		}
+	}
+}

--- a/crates/prover/src/protocols/sumcheck/switchover.rs
+++ b/crates/prover/src/protocols/sumcheck/switchover.rs
@@ -1,0 +1,194 @@
+// Copyright 2025 Irreducible Inc.
+
+use std::ops::{Deref, DerefMut};
+
+use binius_field::{Field, PackedField};
+use binius_math::{
+	FieldBuffer, FieldSlice,
+	multilinear::{
+		eq::tensor_prod_eq_ind_prepend,
+		fold::{binary_fold_high, fold_highest_var_inplace},
+	},
+};
+use binius_utils::{
+	bitwise::{BitSelector, Bitwise},
+	checked_arithmetics::checked_log_2,
+	random_access_sequence::{MatrixVertSliceSubrange, RandomAccessSequence},
+};
+
+use super::error::Error;
+
+/// A helper struct to maintain switchover-related invariants related to a set of 1-bit
+/// multilinears represented by a slice of bitmasks.
+///
+/// # Invariants
+/// 1. `i`-th transparent multilinear is equal to a slice of `i`-th bits of all bitmasks
+/// 2. For the first `switchover` rounds, the said multilinears are transparent, and their partial
+///    evaluations are obtained in linear time by doing binary folds
+/// 3. Partial evaluations are stored after `switchover` rounds and folded as usual afterwards.
+/// 4. Switchover is never performed before the first round.
+///
+/// Choosing switchover round value is a balancing act between peak memory consumption and
+/// performance.
+pub struct BinarySwitchover<'b, P: PackedField, B: Bitwise> {
+	n_multilinears: usize,
+	bitmasks: &'b [B],
+	tensor: FieldBuffer<P>,
+	folded: Option<Vec<FieldBuffer<P>>>,
+	switchover: usize,
+}
+
+impl<'b, F, P, B> BinarySwitchover<'b, P, B>
+where
+	F: Field,
+	P: PackedField<Scalar = F>,
+	B: Bitwise,
+{
+	/// Construct a new switchover helper.
+	///
+	/// # Params
+	/// * `bitmasks`       - bitmask representation of 1-bit multilinears
+	/// * `n_multilinears` - number of  lower bitmask bits that become multilinears
+	/// * `switchover`     - number of rounds after which to do the folding
+	pub fn new(n_multilinears: usize, switchover: usize, bitmasks: &'b [B]) -> Self {
+		assert!(
+			bitmasks.len().is_power_of_two(),
+			"Bitmasks represent a collection of multilinears and thus should be of power of two length"
+		);
+
+		let n_vars = checked_log_2(bitmasks.len());
+		let switchover = switchover.min(n_vars).max(1);
+		let mut tensor =
+			FieldBuffer::zeros_truncated(0, switchover).expect("log_cap() can't be negative");
+		tensor.set(0, F::ONE).expect("len() >= 1");
+
+		Self {
+			n_multilinears,
+			bitmasks,
+			tensor,
+			folded: None,
+			// Store this separately as `log_cap` is rounded up to the packing width
+			switchover,
+		}
+	}
+
+	// Number of variables in all 1-bit multilinears at start of sumcheck.
+	fn n_vars_transparent(&self) -> usize {
+		checked_log_2(self.bitmasks.len())
+	}
+
+	/// Get a power-of-two sized aligned chunk of the multilinear at `bit_offset` in the current
+	/// round. This method abstracts transparent/folded state handling. Pre-switchover logic
+	/// requires a chunk sized scratchpad to hold the result.
+	pub fn get_chunk<'switchover, 'scratchpad, Data: DerefMut<Target = [P]>>(
+		&'switchover self,
+		scratchpad: &'scratchpad mut FieldBuffer<P, Data>,
+		bit_offset: usize,
+		chunk_vars: usize,
+		chunk_index: usize,
+	) -> Result<FieldSlice<'scratchpad, P>, Error>
+	where
+		'switchover: 'scratchpad,
+	{
+		assert!(bit_offset < self.n_multilinears);
+		assert_eq!(scratchpad.len(), 1 << chunk_vars);
+
+		if let Some(folded) = &self.folded {
+			Ok(folded[bit_offset].chunk(chunk_vars, chunk_index)?)
+		} else {
+			get_binary_chunk(
+				scratchpad,
+				&self.tensor,
+				&BitSelector::new(bit_offset, self.bitmasks),
+				chunk_vars,
+				chunk_index,
+			)?;
+			Ok(scratchpad.to_ref())
+		}
+	}
+
+	pub fn fold(&mut self, challenge: F) -> Result<(), Error> {
+		if let Some(folded) = &mut self.folded {
+			// Post-switchover: fold high as usual
+			for multilinear in folded {
+				fold_highest_var_inplace(multilinear, challenge)?;
+			}
+		} else {
+			// Pre-switchover: update the folding tensor
+			assert!(self.tensor.log_len() < self.switchover);
+			tensor_prod_eq_ind_prepend(&mut self.tensor, &[challenge])?;
+
+			if self.tensor.log_len() == self.switchover {
+				self.perform()?;
+			}
+		}
+
+		Ok(())
+	}
+
+	// Perform the switchover process. This operation is idempotent.
+	fn perform(&mut self) -> Result<(), Error> {
+		if self.folded.is_some() {
+			return Ok(());
+		}
+
+		let folded_n_vars = self.n_vars_transparent() - self.tensor.log_len();
+
+		let mut all_folded = Vec::with_capacity(self.n_multilinears);
+		for bit_offset in 0..self.n_multilinears {
+			let mut folded = FieldBuffer::<P>::zeros(folded_n_vars);
+			get_binary_chunk(
+				&mut folded,
+				&self.tensor,
+				&BitSelector::new(bit_offset, self.bitmasks),
+				folded_n_vars,
+				0,
+			)?;
+
+			all_folded.push(folded);
+		}
+
+		self.folded = Some(all_folded);
+		Ok(())
+	}
+
+	pub fn finalize(mut self) -> Result<Vec<FieldBuffer<P>>, Error> {
+		self.perform()?;
+		Ok(self.folded.expect("explicit call to perform()"))
+	}
+}
+
+// Compute a power-of-two sized aligned chunk of the partial evaluation of a binary sequence
+// with a tensor using fold high. Conceptually, this method:
+//  * takes in a boolean sequence `binary_sequence`, splits it into tensor-sized chunks, then does a
+//    tensor product with each of them
+//  * the `2^chunk_vars` aligned chunk with index `chunk_index` is put into `dest`
+// The folded column is not fully materialized though.
+fn get_binary_chunk<P, DataOut, DataIn>(
+	dest: &mut FieldBuffer<P, DataOut>,
+	tensor: &FieldBuffer<P, DataIn>,
+	binary_sequence: &(impl RandomAccessSequence<bool> + Sync),
+	chunk_vars: usize,
+	chunk_index: usize,
+) -> Result<(), Error>
+where
+	P: PackedField,
+	DataOut: DerefMut<Target = [P]>,
+	DataIn: Deref<Target = [P]> + Sync,
+{
+	assert!(binary_sequence.len().is_power_of_two());
+	let sequence_log_len = checked_log_2(binary_sequence.len());
+
+	// We can view fold high as a following matrix operation:
+	//  1) Rearrange the sequence into a row-major matrix with `tensor.len()` rows
+	//  2) Obtain a view into a chunk-sized vertical slice of said matrix
+	//  3) Fold this matrix along columns to get chunk-sized partial evaluations
+	let matrix_vert_slice = MatrixVertSliceSubrange::new(
+		binary_sequence,
+		tensor.log_len(),
+		sequence_log_len - tensor.log_len(),
+		chunk_vars,
+		chunk_index,
+	);
+	Ok(binary_fold_high(dest, tensor, matrix_vert_slice)?)
+}


### PR DESCRIPTION
A prover which reduces a claim on the MLE to another claim on the same MLE. This essentially performs a 1-bit zerocheck.

1-bit multilinears are represented as vertical slices of an array of bitmasks. Due to memory blowup issues this is the first prover that does switchover, and introduces all the required machinery.