### PR TITLE
[frontend] Add bignum compare function

### DIFF
--- a/crates/frontend/Cargo.toml
+++ b/crates/frontend/Cargo.toml
@@ -7,14 +7,12 @@ authors.workspace = true
 [lints]
 workspace = true
 
-[dependencies]
-num-bigint = "0.4"
-
 [dev-dependencies]
 rand = { workspace = true, features = ["std_rng", "thread_rng"] }
 hex-literal = "1.0.0"
 base64 = "0.21"
 hex = "0.4.3"
+num-bigint = "0.4"
 quickcheck = "1.0"
 quickcheck_macros = "1.0"
 proptest = { workspace = true }


### PR DESCRIPTION
This PR adds a bignum compare circuit.

I tried to use bxor / xor but the constraint verification failed. I couldn't get to the bottom of it:

	if a.is_empty() {
		return builder.add_constant(Word::ALL_ONE);
	}

	// XOR each limb pair, then OR them all together starting from zero
	let combined = a
		.iter()
		.zip(b.iter())
		.map(|(&x, &y)| builder.bxor(x, y))
		.reduce(|acc, x| builder.bor(acc, x))
                .unwrap();

	// If combined==0 then all XORs were zero and the limbs are equal
	builder.icmp_eq(combined, zero)
