### PR TITLE
[frontend] fixed byte vec

### DIFF
--- a/crates/frontend/src/circuits/fixed_byte_vec.rs
+++ b/crates/frontend/src/circuits/fixed_byte_vec.rs
@@ -1,0 +1,39 @@
+use crate::compiler::{CircuitBuilder, Wire};
+
+/// A vector of bytes of an arbitrary size up to and including the configured `max_len`.
+///
+/// The bytes are tightly packed into wires, where each wire packs up to 8 bytes. This constrains
+/// the maximum size of the vector to be a multiple of 8.
+pub struct FixedByteVec {
+	/// Maximum length of the vector in bytes.
+	pub max_len: usize,
+	/// Length of the vector in bytes.
+	pub len: Wire,
+	pub data: Vec<Wire>,
+}
+
+impl FixedByteVec {
+	/// Creates a new fixed byte vector with the given maximum length as inout wires.
+	///
+	/// # Panics
+	///
+	/// Panics if `max_len` is not a multiple of 8.
+	pub fn new_inout(b: &CircuitBuilder, max_len: usize) -> Self {
+		assert!(max_len.is_multiple_of(8), "max_len must be a multiple of 8");
+		let len = b.add_inout();
+		let data = (0..(max_len / 8)).map(|_| b.add_inout()).collect();
+		Self { max_len, len, data }
+	}
+
+	/// Creates a new fixed byte vector with the given maximum length as witness wires.
+	///
+	/// # Panics
+	///
+	/// Panics if `max_len` is not a multiple of 8.
+	pub fn new_witness(b: &CircuitBuilder, max_len: usize) -> Self {
+		assert!(max_len.is_multiple_of(8), "max_len must be a multiple of 8");
+		let len = b.add_inout();
+		let data = (0..(max_len / 8)).map(|_| b.add_witness()).collect();
+		Self { max_len, len, data }
+	}
+}

--- a/crates/frontend/src/circuits/mod.rs
+++ b/crates/frontend/src/circuits/mod.rs
@@ -2,6 +2,7 @@ pub mod base64;
 pub mod basic;
 pub mod concat;
 pub mod eqbool;
+pub mod fixed_byte_vec;
 pub mod hex;
 pub mod jwt_claims;
 pub mod sha256;


### PR DESCRIPTION
This is a convenience struct for dealing with packed byte vectors of a variable
length capped with some circuit-compile-time value.