### PR TITLE
[frontend] time failed witness fill

### DIFF
--- a/crates/frontend/src/compiler/mod.rs
+++ b/crates/frontend/src/compiler/mod.rs
@@ -599,6 +599,9 @@ impl Circuit {
 			gate.populate_wire_witness(w);
 		}
 
+		let elapsed = start.elapsed();
+		println!("fill_witness took {} microseconds", elapsed.as_micros());
+
 		if w.assertion_failed_count > 0 {
 			return Err(PopulateError {
 				messages: w.assertion_failed_message_vec.clone(),
@@ -606,8 +609,6 @@ impl Circuit {
 			});
 		}
 
-		let elapsed = start.elapsed();
-		println!("fill_witness took {} microseconds", elapsed.as_micros());
 		Ok(())
 	}
 


### PR DESCRIPTION
This is useful to measure witness filling performance even when it's not really
populated with any useful values. This works because the computation is more or
less the same. The actual difference is that we might spend some time on
allocating vectors and formatting when filling out the assertion errors.