### PR TITLE
Sumcheck prover batching

### DIFF
--- a/crates/prover/src/protocols/sumcheck/batch.rs
+++ b/crates/prover/src/protocols/sumcheck/batch.rs
@@ -1,0 +1,81 @@
+// Copyright 2024-2025 Irreducible Inc.
+
+use binius_field::Field;
+use binius_transcript::{
+	ProverTranscript,
+	fiat_shamir::{CanSample, Challenger},
+};
+use binius_verifier::protocols::sumcheck::common::{BatchSumcheckOutput, RoundCoeffs};
+
+use crate::protocols::sumcheck::{common::SumcheckProver, error::Error};
+
+/// Prove a batched sumcheck protocol execution, where all provers have the same number of rounds.
+pub fn batch_prove<F, Prover, Challenger_>(
+	mut provers: Vec<Prover>,
+	transcript: &mut ProverTranscript<Challenger_>,
+) -> Result<BatchSumcheckOutput<F>, Error>
+where
+	F: Field,
+	Prover: SumcheckProver<F>,
+	Challenger_: Challenger,
+{
+	let Some(first_prover) = provers.first() else {
+		return Ok(BatchSumcheckOutput {
+			challenges: Vec::new(),
+			multilinear_evals: Vec::new(),
+		});
+	};
+
+	let n_vars = first_prover.n_vars();
+
+	if provers.iter().any(|prover| prover.n_vars() != n_vars) {
+		return Err(Error::ProverRoundCountMismatch);
+	}
+
+	let batch_coeff = transcript.sample();
+
+	let mut challenges = Vec::with_capacity(n_vars);
+	for _ in 0..n_vars {
+		let mut all_round_coeffs = Vec::new();
+
+		for prover in &mut provers {
+			all_round_coeffs.extend(prover.execute()?);
+		}
+
+		let batched_round_coeffs = all_round_coeffs
+			.into_iter()
+			.rfold(RoundCoeffs::default(), |acc, coeffs| acc * batch_coeff + &coeffs);
+
+		let round_proof = batched_round_coeffs.truncate();
+
+		transcript
+			.message()
+			.write_scalar_slice(round_proof.coeffs());
+
+		let challenge = transcript.sample();
+		challenges.push(challenge);
+
+		for prover in &mut provers {
+			prover.fold(challenge)?;
+		}
+	}
+
+	challenges.reverse();
+
+	let multilinear_evals = provers
+		.into_iter()
+		.map(|prover| prover.finish())
+		.collect::<Result<Vec<_>, _>>()?;
+
+	let mut writer = transcript.message();
+	for multilinear_evals in &multilinear_evals {
+		writer.write_scalar_slice(multilinear_evals);
+	}
+
+	let output = BatchSumcheckOutput {
+		challenges,
+		multilinear_evals,
+	};
+
+	Ok(output)
+}

--- a/crates/prover/src/protocols/sumcheck/error.rs
+++ b/crates/prover/src/protocols/sumcheck/error.rs
@@ -8,6 +8,8 @@ pub enum Error {
 	MultilinearSizeMismatch,
 	#[error("number of eval claims does not match the number of multilinears")]
 	EvalClaimsNumberMismatch,
+	#[error("batched provers should have the same number of rounds")]
+	ProverRoundCountMismatch,
 	#[error("expected execute() call")]
 	ExpectedExecute,
 	#[error("expected fold() call")]

--- a/crates/prover/src/protocols/sumcheck/mod.rs
+++ b/crates/prover/src/protocols/sumcheck/mod.rs
@@ -1,4 +1,5 @@
 // Copyright 2023-2025 Irreducible Inc.
 
+pub mod batch;
 pub mod common;
 mod error;

--- a/crates/verifier/src/protocols/sumcheck/common.rs
+++ b/crates/verifier/src/protocols/sumcheck/common.rs
@@ -110,3 +110,9 @@ impl<F: Field> RoundProof<F> {
 		&self.0.0
 	}
 }
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct BatchSumcheckOutput<F: Field> {
+	pub challenges: Vec<F>,
+	pub multilinear_evals: Vec<Vec<F>>,
+}


### PR DESCRIPTION
Support for batching same-sized provers. Round coeffs are weighted with consecutive powers of a single batching coefficient.