### PR TITLE
Skeleton for prove & verify with FRI proximity test

### DIFF
--- a/crates/frontend/src/constraint_system.rs
+++ b/crates/frontend/src/constraint_system.rs
@@ -211,6 +211,11 @@ impl ValueVec {
 		&self.data[start..end]
 	}
 
+	/// Returns the combined values vector.
+	pub fn combined_witness(&self) -> &[Word] {
+		&self.data
+	}
+
 	pub fn assert_filled(&self) {}
 }
 

--- a/crates/math/src/reed_solomon.rs
+++ b/crates/math/src/reed_solomon.rs
@@ -23,7 +23,7 @@ use super::{
 ///
 /// [Reed–Solomon]: <https://en.wikipedia.org/wiki/Reed%E2%80%93Solomon_error_correction>
 /// [LCH14]: <https://arxiv.org/abs/1404.3458>
-#[derive(Debug, Getters, CopyGetters)]
+#[derive(Debug, Clone, Getters, CopyGetters)]
 pub struct ReedSolomonCode<F: BinaryField> {
 	#[get = "pub"]
 	subspace: BinarySubspace<F>,

--- a/crates/prover/src/error.rs
+++ b/crates/prover/src/error.rs
@@ -1,4 +1,13 @@
 // Copyright 2025 Irreducible Inc.
 
+use crate::fri;
+
 #[derive(Debug, thiserror::Error)]
-pub enum Error {}
+pub enum Error {
+	#[error("invalid argument {arg}: {msg}")]
+	ArgumentError { arg: String, msg: String },
+	#[error("FRI error: {0}")]
+	Fri(#[from] fri::Error),
+	#[error("transcript error: {0}")]
+	Transcript(#[from] binius_transcript::Error),
+}

--- a/crates/prover/src/fri/commit.rs
+++ b/crates/prover/src/fri/commit.rs
@@ -29,6 +29,7 @@ pub struct CommitOutput<P, VCSCommitment, VCSCommitted> {
 /// * `message` - the interleaved message to encode and commit
 #[instrument(skip_all, level = "debug")]
 pub fn commit_interleaved<F, FA, P, PA, NTT, MerkleProver, VCS>(
+	// TODO: Remove rs_code and use rs_code from params
 	rs_code: &ReedSolomonCode<FA>,
 	params: &FRIParams<F, FA>,
 	ntt: &NTT,

--- a/crates/prover/src/fri/fold.rs
+++ b/crates/prover/src/fri/fold.rs
@@ -1,8 +1,6 @@
 // Copyright 2024-2025 Irreducible Inc.
 
-use binius_field::{
-	BinaryField, ExtensionField, PackedField, TowerField, packed::len_packed_slice,
-};
+use binius_field::{BinaryField, ExtensionField, PackedField, packed::len_packed_slice};
 use binius_math::{multilinear::eq::eq_ind_partial_eval, ntt::AdditiveNTT};
 use binius_maybe_rayon::prelude::*;
 use binius_transcript::{
@@ -54,7 +52,7 @@ where
 
 impl<'a, F, FA, P, NTT, MerkleProver, VCS> FRIFolder<'a, F, FA, P, NTT, MerkleProver, VCS>
 where
-	F: TowerField + ExtensionField<FA>,
+	F: BinaryField + ExtensionField<FA>,
 	FA: BinaryField,
 	P: PackedField<Scalar = F>,
 	NTT: AdditiveNTT<FA> + Sync,

--- a/crates/prover/src/fri/query.rs
+++ b/crates/prover/src/fri/query.rs
@@ -1,5 +1,5 @@
 use binius_field::{
-	BinaryField, ExtensionField, PackedField, TowerField, packed::iter_packed_slice_with_offset,
+	BinaryField, ExtensionField, PackedField, packed::iter_packed_slice_with_offset,
 };
 use binius_transcript::TranscriptWriter;
 use binius_verifier::{
@@ -31,7 +31,7 @@ where
 
 impl<F, FA, P, MerkleProver, VCS> FRIQueryProver<'_, F, FA, P, MerkleProver, VCS>
 where
-	F: TowerField + ExtensionField<FA>,
+	F: BinaryField + ExtensionField<FA>,
 	FA: BinaryField,
 	P: PackedField<Scalar = F>,
 	MerkleProver: MerkleTreeProver<F, Scheme = VCS>,
@@ -124,7 +124,7 @@ fn prove_coset_opening<F, P, MTProver, B>(
 	advice: &mut TranscriptWriter<B>,
 ) -> Result<(), Error>
 where
-	F: TowerField,
+	F: BinaryField,
 	P: PackedField<Scalar = F>,
 	MTProver: MerkleTreeProver<F>,
 	B: BufMut,

--- a/crates/prover/src/fri/tests.rs
+++ b/crates/prover/src/fri/tests.rs
@@ -88,11 +88,12 @@ fn test_commit_prove_verify_success<U, F, FA>(
 	codeword_commitment = verifier_challenger.message().read().unwrap();
 	let mut verifier_challenges = Vec::with_capacity(params.n_fold_rounds());
 
-	assert_eq!(round_commitments.len(), n_round_commitments);
-	for (i, commitment) in round_commitments.iter().enumerate() {
-		verifier_challenges.append(&mut verifier_challenger.sample_vec(params.fold_arities()[i]));
-		let mut _commitment = *commitment;
-		_commitment = verifier_challenger.message().read().unwrap();
+	assert_eq!(params.fold_arities().len(), n_round_commitments);
+	let mut round_commitments = Vec::with_capacity(params.n_oracles());
+	for &round_arity in params.fold_arities() {
+		verifier_challenges.append(&mut verifier_challenger.sample_vec(round_arity));
+		let commitment = verifier_challenger.message().read().unwrap();
+		round_commitments.push(commitment);
 	}
 
 	verifier_challenges.append(&mut verifier_challenger.sample_vec(params.n_final_challenges()));

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -1,19 +1,123 @@
-use binius_field::{BinaryField, ExtensionField};
-use binius_frontend::constraint_system::{ConstraintSystem, ValueVec};
-use binius_transcript::{ProverTranscript, fiat_shamir::Challenger};
-use binius_verifier::{Params, fields::B64};
+use binius_field::{Field, PackedExtension, PackedField};
+use binius_frontend::{constraint_system::ValueVec, word::Word};
+use binius_math::{FieldBuffer, ntt::AdditiveNTT};
+use binius_maybe_rayon::{iter::repeatn, prelude::*};
+use binius_transcript::{
+	ProverTranscript,
+	fiat_shamir::{CanSample, Challenger},
+};
+use binius_utils::SerializeBytes;
+use binius_verifier::{
+	LOG_WORDS_PER_ELEM, Params, fields::B128, fri::FRIParams, merkle_tree::MerkleTreeScheme,
+};
 
 use super::error::Error;
+use crate::{
+	fri,
+	fri::{CommitOutput, FRIFolder, FoldRoundOutput},
+	merkle_tree::MerkleTreeProver,
+};
 
-pub fn prove<F, Challenger_>(
-	_params: &Params,
-	_cs: &ConstraintSystem,
-	_witness: ValueVec,
-	_transcript: &mut ProverTranscript<Challenger_>,
+#[allow(clippy::too_many_arguments)]
+pub fn prove<P, Challenger_, NTT, MTScheme, MTProver>(
+	params: &Params<MTScheme>,
+	witness: ValueVec,
+	transcript: &mut ProverTranscript<Challenger_>,
+	ntt: &NTT,
+	merkle_prover: &MTProver,
 ) -> Result<(), Error>
 where
-	F: BinaryField + ExtensionField<B64>,
+	P: PackedField<Scalar = B128> + PackedExtension<B128>,
 	Challenger_: Challenger,
+	NTT: AdditiveNTT<B128> + Sync,
+	MTScheme: MerkleTreeScheme<B128>,
+	MTScheme::Digest: SerializeBytes,
+	MTProver: MerkleTreeProver<B128, Scheme = MTScheme>,
 {
+	let witness_packed = pack_witness::<P>(params.log_witness_elems(), witness)?;
+
+	// Commit the witness.
+	let CommitOutput {
+		commitment: trace_commitment,
+		committed: trace_committed,
+		codeword: trace_codeword,
+	} = fri::commit_interleaved(
+		params.fri_params().rs_code(),
+		params.fri_params(),
+		ntt,
+		merkle_prover,
+		witness_packed.as_ref(),
+	)?;
+	transcript.message().write(&trace_commitment);
+
+	// Run the FRI proximity test protocol on the witness commitment.
+	run_fri(params.fri_params(), ntt, merkle_prover, trace_codeword, trace_committed, transcript)?;
+	Ok(())
+}
+
+fn pack_witness<P: PackedField<Scalar = B128>>(
+	log_witness_elems: usize,
+	witness: ValueVec,
+) -> Result<FieldBuffer<P>, Error> {
+	// The number of field elements that constitute the packed witness.
+	let n_witness_elems = witness.size().div_ceil(1 << LOG_WORDS_PER_ELEM);
+	if n_witness_elems > 1 << log_witness_elems {
+		return Err(Error::ArgumentError {
+			arg: "witness".to_string(),
+			msg: "witness element count is incompatible with the constraint system".to_string(),
+		});
+	}
+
+	let witness_elems = witness.combined_witness().par_chunks(2).map(|chunk| {
+		let word_0 = chunk.first().copied().expect("chunk cannot be empty");
+		let word_1 = chunk.get(1).copied().unwrap_or(Word::ZERO);
+		B128::new(((word_1.0 as u128) << 64) | (word_0.0 as u128))
+	});
+	let padded_witness_elems =
+		witness_elems.chain(repeatn(B128::ZERO, (1 << log_witness_elems) - n_witness_elems));
+
+	let witness_packed = padded_witness_elems
+		.chunks(P::WIDTH)
+		.map(|chunk| P::from_scalars(chunk))
+		.collect::<Vec<_>>();
+	debug_assert_eq!(witness_packed.len(), 1 << log_witness_elems.saturating_sub(P::LOG_WIDTH));
+
+	let ret = FieldBuffer::new(log_witness_elems, witness_packed.into_boxed_slice())
+		.expect("witness_packed length is correct by construction");
+	Ok(ret)
+}
+
+fn run_fri<P, Challenger_, NTT, MTScheme, MTProver>(
+	params: &FRIParams<B128, B128>,
+	ntt: &NTT,
+	merkle_prover: &MTProver,
+	codeword: Vec<P>,
+	committed: MTProver::Committed,
+	transcript: &mut ProverTranscript<Challenger_>,
+) -> Result<(), Error>
+where
+	P: PackedField<Scalar = B128>,
+	Challenger_: Challenger,
+	NTT: AdditiveNTT<B128> + Sync,
+	MTScheme: MerkleTreeScheme<B128>,
+	MTScheme::Digest: SerializeBytes,
+	MTProver: MerkleTreeProver<B128, Scheme = MTScheme>,
+{
+	let mut round_prover = FRIFolder::new(params, ntt, merkle_prover, &codeword, &committed)?;
+
+	let mut round_commitments = Vec::with_capacity(params.n_oracles());
+	for _i in 0..params.n_fold_rounds() {
+		let challenge = transcript.sample();
+		let fold_round_output = round_prover.execute_fold_round(challenge)?;
+		match fold_round_output {
+			FoldRoundOutput::NoCommitment => {}
+			FoldRoundOutput::Commitment(round_commitment) => {
+				transcript.message().write(&round_commitment);
+				round_commitments.push(round_commitment);
+			}
+		}
+	}
+
+	round_prover.finish_proof(transcript)?;
 	Ok(())
 }

--- a/crates/verifier/src/error.rs
+++ b/crates/verifier/src/error.rs
@@ -1,2 +1,15 @@
+// Copyright 2025 Irreducible Inc.
+
+use binius_math::ntt;
+
+use crate::fri;
+
 #[derive(Debug, thiserror::Error)]
-pub enum Error {}
+pub enum Error {
+	#[error("transcript error: {0}")]
+	Transcript(#[from] binius_transcript::Error),
+	#[error("FRI error: {0}")]
+	FRI(#[from] fri::Error),
+	#[error("NTT error: {0}")]
+	NTT(#[from] ntt::Error),
+}

--- a/crates/verifier/src/fri/common.rs
+++ b/crates/verifier/src/fri/common.rs
@@ -11,7 +11,7 @@ use super::error::Error;
 use crate::merkle_tree::MerkleTreeScheme;
 
 /// Parameters for an FRI interleaved code proximity protocol.
-#[derive(Debug, Getters, CopyGetters)]
+#[derive(Debug, Clone, Getters, CopyGetters)]
 pub struct FRIParams<F, FA>
 where
 	F: BinaryField,

--- a/crates/verifier/src/fri/verify.rs
+++ b/crates/verifier/src/fri/verify.rs
@@ -2,7 +2,7 @@
 
 use std::iter;
 
-use binius_field::{BinaryField, ExtensionField, TowerField};
+use binius_field::{BinaryField, ExtensionField};
 use binius_math::{FieldBuffer, multilinear::eq::eq_ind_partial_eval, ntt::SingleThreadedNTT};
 use binius_transcript::{
 	TranscriptReader, VerifierTranscript,
@@ -46,7 +46,7 @@ where
 
 impl<'a, F, FA, VCS> FRIVerifier<'a, F, FA, VCS>
 where
-	F: TowerField + ExtensionField<FA>,
+	F: BinaryField + ExtensionField<FA>,
 	FA: BinaryField,
 	VCS: MerkleTreeScheme<F, Digest: DeserializeBytes>,
 {
@@ -368,7 +368,7 @@ fn verify_coset_opening<F, MTScheme, B>(
 	advice: &mut TranscriptReader<B>,
 ) -> Result<Vec<F>, Error>
 where
-	F: TowerField,
+	F: BinaryField,
 	MTScheme: MerkleTreeScheme<F>,
 	B: Buf,
 {

--- a/crates/verifier/src/merkle_tree/merkle_tree_vcs.rs
+++ b/crates/verifier/src/merkle_tree/merkle_tree_vcs.rs
@@ -17,7 +17,7 @@ pub struct Commitment<Digest> {
 }
 
 /// A Merkle tree scheme.
-pub trait MerkleTreeScheme<T>: Sync {
+pub trait MerkleTreeScheme<T> {
 	type Digest: Clone + PartialEq + Eq;
 
 	/// Returns the optimal layer that the verifier should verify only once.

--- a/crates/verifier/src/verify.rs
+++ b/crates/verifier/src/verify.rs
@@ -1,21 +1,142 @@
+// Copyright 2025 Irreducible Inc.
+
 use binius_field::{BinaryField, ExtensionField};
 use binius_frontend::{constraint_system::ConstraintSystem, word::Word};
-use binius_transcript::{VerifierTranscript, fiat_shamir::Challenger};
+use binius_math::ntt::SingleThreadedNTT;
+use binius_transcript::{
+	VerifierTranscript,
+	fiat_shamir::{CanSample, Challenger},
+};
+use binius_utils::{
+	DeserializeBytes,
+	checked_arithmetics::{checked_log_2, log2_ceil_usize},
+};
 
-use super::{error::Error, fields::B64};
+use super::error::Error;
+use crate::{
+	fields::B128,
+	fri::{FRIParams, estimate_optimal_arity, verify::FRIVerifier},
+	merkle_tree::MerkleTreeScheme,
+};
 
+/// The protocol proves constraint systems over 64-bit words.
+pub const WORD_SIZE_BITS: usize = 64;
+
+/// log2 of [`WORD_SIZE_BITS`].
+pub const LOG_WORD_SIZE_BITS: usize = checked_log_2(WORD_SIZE_BITS);
+pub const LOG_WORDS_PER_ELEM: usize = checked_log_2(B128::N_BITS) - LOG_WORD_SIZE_BITS;
+
+pub const SECURITY_BITS: usize = 96;
+
+/// Public parameters for proving constraint systems of a certain size.
 #[derive(Debug, Clone)]
-pub struct Params {}
+pub struct Params<MTScheme> {
+	fri_params: FRIParams<B128, B128>,
+	merkle_scheme: MTScheme,
+}
 
-pub fn verify<F, Challenger_>(
-	_params: &Params,
+impl<MTScheme: MerkleTreeScheme<B128>> Params<MTScheme> {
+	pub fn new(
+		cs: &ConstraintSystem,
+		log_inv_rate: usize,
+		merkle_scheme: MTScheme,
+	) -> Result<Self, Error> {
+		// The number of field elements that constitute the packed witness.
+		let log_witness_words = log2_ceil_usize(cs.value_vec_len()).max(LOG_WORDS_PER_ELEM);
+		let log_witness_elems = log_witness_words - LOG_WORDS_PER_ELEM;
+
+		let log_code_len = log_witness_words + log_inv_rate;
+		let fri_arity =
+			estimate_optimal_arity(log_code_len, size_of::<MTScheme::Digest>(), size_of::<B128>());
+
+		let ntt = SingleThreadedNTT::new(log_code_len)?;
+		let fri_params = FRIParams::choose_with_constant_fold_arity(
+			&ntt,
+			log_witness_elems,
+			SECURITY_BITS,
+			log_inv_rate,
+			fri_arity,
+		)?;
+
+		Ok(Self {
+			fri_params,
+			merkle_scheme,
+		})
+	}
+
+	/// Returns log2 of the number of words in the witness.
+	pub fn log_witness_words(&self) -> usize {
+		self.log_witness_elems() + LOG_WORDS_PER_ELEM
+	}
+
+	/// Returns log2 of the number of field elements in the packed trace.
+	pub fn log_witness_elems(&self) -> usize {
+		let rs_code = self.fri_params.rs_code();
+		rs_code.log_dim() + self.fri_params.log_batch_size()
+	}
+
+	/// Returns the chosen FRI parameters.
+	pub fn fri_params(&self) -> &FRIParams<B128, B128> {
+		&self.fri_params
+	}
+
+	/// Returns the [`MerkleTreeScheme`] instance used.
+	pub fn merkle_scheme(&self) -> &MTScheme {
+		&self.merkle_scheme
+	}
+}
+
+pub fn verify<Challenger_, MTScheme>(
+	params: &Params<MTScheme>,
 	_cs: &ConstraintSystem,
 	_inout: &[Word],
-	_transcript: &mut VerifierTranscript<Challenger_>,
+	transcript: &mut VerifierTranscript<Challenger_>,
 ) -> Result<(), Error>
 where
-	F: BinaryField + ExtensionField<B64>,
 	Challenger_: Challenger,
+	MTScheme: MerkleTreeScheme<B128>,
+	MTScheme::Digest: DeserializeBytes,
 {
+	// Receive the trace commitment.
+	let trace_commitment = transcript.message().read::<MTScheme::Digest>()?;
+
+	// Run the FRI proximity test protocol on the trace commitment.
+	run_fri(params.fri_params(), params.merkle_scheme(), trace_commitment, transcript)?;
+	Ok(())
+}
+
+fn run_fri<F, Challenger_, MTScheme>(
+	params: &FRIParams<F, B128>,
+	merkle_scheme: &MTScheme,
+	commitment: MTScheme::Digest,
+	transcript: &mut VerifierTranscript<Challenger_>,
+) -> Result<(), Error>
+where
+	F: BinaryField + ExtensionField<B128>,
+	Challenger_: Challenger,
+	MTScheme: MerkleTreeScheme<F>,
+	MTScheme::Digest: DeserializeBytes,
+{
+	// FRI folding phase
+	let mut challenges = Vec::with_capacity(params.n_fold_rounds());
+	let mut round_commitments = Vec::with_capacity(params.n_oracles());
+	for &round_arity in params.fold_arities() {
+		for _ in 0..round_arity {
+			challenges.push(transcript.sample());
+		}
+
+		let commitment = transcript.message().read()?;
+		round_commitments.push(commitment);
+	}
+
+	for _ in 0..params.n_final_challenges() {
+		challenges.push(transcript.sample());
+	}
+
+	// FRI query phase
+	let verifier =
+		FRIVerifier::new(params, merkle_scheme, &commitment, &round_commitments, &challenges)?;
+	verifier.verify(transcript)?;
+
 	Ok(())
 }


### PR DESCRIPTION
# Skeleton for prove & verify with FRI proximity test

This PR implements the skeleton for the prove and verify functions with FRI proximity test:

- Adds error types for both prover and verifier
- Implements `prove()` function that packs witness, commits to it, and runs FRI protocol
- Implements `verify()` function that verifies the FRI proximity test
- Adds `combined_witness()` helper to `ValueVec` for accessing the full witness
- Makes `ReedSolomonCode` and `FRIParams` cloneable
- Relaxes type constraints from `TowerField` to `BinaryField` in several places
- Fixes FRI test to properly handle round commitments
- Adds integration test for prove/verify with SHA-256 circuit

The implementation follows the FRI proximity test protocol, with the prover committing to the witness, running the FRI folding protocol, and the verifier checking the proximity test.
