### PR TITLE
[frontend] refactor imcp_ult to have 3 gates

### DIFF
--- a/crates/frontend/src/compiler/mod.rs
+++ b/crates/frontend/src/compiler/mod.rs
@@ -434,10 +434,10 @@ impl CircuitBuilder {
 	///
 	/// # Cost
 	///
-	/// 4 AND constraints.
+	/// 3 AND constraints.
 	pub fn icmp_ult(&self, a: Wire, b: Wire) -> Wire {
 		let gate = IcmpUlt::new(self, a, b);
-		let out = gate.result;
+		let out = gate.out_mask;
 		self.emit(gate);
 		out
 	}

--- a/crates/frontend/src/word.rs
+++ b/crates/frontend/src/word.rs
@@ -1,6 +1,6 @@
 use std::{
 	fmt,
-	ops::{BitAnd, BitOr, BitXor, Shl, Shr},
+	ops::{BitAnd, BitOr, BitXor, Not, Shl, Shr},
 };
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
@@ -56,6 +56,14 @@ impl Shr<u32> for Word {
 
 	fn shr(self, rhs: u32) -> Self::Output {
 		Word(self.0 >> rhs)
+	}
+}
+
+impl Not for Word {
+	type Output = Self;
+
+	fn not(self) -> Self::Output {
+		Word(!self.0)
 	}
 }
 


### PR DESCRIPTION
Bring it closer to what it's written/implied by the binius64 writeup.

See [ENG2-29: gate golfing: icmp_ult takes 4 constraints](https://linear.app/irreducible/issue/ENG2-29/gate-golfing-icmp-ult-takes-4-constraints)

```
Number of AND constraints: 3704069
Number of gates: 1274560
Length of value vec: 4194304
fill_witness took 101088 microseconds
```