### PR TITLE
[frontend] cleanup iadd_cout_32.

### DIFF
--- a/crates/frontend/src/compiler/gate.rs
+++ b/crates/frontend/src/compiler/gate.rs
@@ -146,8 +146,8 @@ impl Gate for IaddCinCout {
 		let b = w[self.b];
 
 		// Extract carry-in bit from MSB of previous carry word
-		let Word(cin) = w[self.cin];
-		let carry_bit = cin >> 63;
+
+		let carry_bit = w[self.cin] >> 63;
 		let (sum, carry_out) = a.iadd_cin_cout(b, carry_bit);
 
 		w[self.sum] = sum;
@@ -217,7 +217,7 @@ impl Iadd32 {
 
 impl Gate for Iadd32 {
 	fn populate_wire_witness(&self, w: &mut WitnessFiller) {
-		let (sum, carry) = w[self.a].iadd_32(w[self.b]);
+		let (sum, carry) = w[self.a].iadd_cout_32(w[self.b]);
 
 		w[self.c] = sum;
 		w[self.cout] = carry;
@@ -574,7 +574,7 @@ impl Gate for IcmpUlt {
 		// The MSB of bout indicates whether x < y:
 		// - If ¬x + y ≥ 2^64 (carries out), then x < y
 		// - If ¬x + y < 2^64 (no carry), then x ≥ y
-		let (_, bout) = nx.iadd_cin_cout(y, 0);
+		let (_, bout) = nx.iadd_cin_cout(y, Word::ZERO);
 		let bin = bout << 1;
 		w[self.diff] = x ^ y ^ bin;
 		w[self.bout] = bout;

--- a/crates/frontend/src/word.rs
+++ b/crates/frontend/src/word.rs
@@ -68,7 +68,11 @@ impl Not for Word {
 }
 
 impl Word {
-	pub fn iadd_32(self, rhs: Word) -> (Word, Word) {
+	/// Performs 32-bit addition.
+	///
+	/// Returns (sum, carry_out) where ith carry_out bit is set to one if there is a carry out at
+	/// that bit position.
+	pub fn iadd_cout_32(self, rhs: Word) -> (Word, Word) {
 		let Word(lhs) = self;
 		let Word(rhs) = rhs;
 		let sum = lhs.wrapping_add(rhs) & 0x00000000_FFFFFFFF;
@@ -77,10 +81,13 @@ impl Word {
 	}
 
 	/// Performs 64-bit addition with carry input bit.
-	/// Returns (sum, carry_word) where carry_word encodes all carry positions.
-	pub fn iadd_cin_cout(self, rhs: Word, cin: u64) -> (Word, Word) {
+	///
+	/// Returns (sum, carry_out) where ith carry_out bit is set to one if there is a carry out at
+	/// that bit position.
+	pub fn iadd_cin_cout(self, rhs: Word, cin: Word) -> (Word, Word) {
 		let Word(lhs) = self;
 		let Word(rhs) = rhs;
+		let Word(cin) = cin;
 		let sum = lhs.wrapping_add(rhs).wrapping_add(cin);
 		let cout = (lhs & rhs) | ((lhs ^ rhs) & !sum);
 		(Word(sum), Word(cout))


### PR DESCRIPTION
Rename it and improve the documentation to highlight the fact that it's a carry
out.