### PR TITLE
[frontend] gate golfing: icmp_ult is now down to 2

### DIFF
--- a/crates/frontend/src/compiler/mod.rs
+++ b/crates/frontend/src/compiler/mod.rs
@@ -434,7 +434,7 @@ impl CircuitBuilder {
 	///
 	/// # Cost
 	///
-	/// 3 AND constraints.
+	/// 2 AND constraints.
 	pub fn icmp_ult(&self, a: Wire, b: Wire) -> Wire {
 		let gate = IcmpUlt::new(self, a, b);
 		let out = gate.out_mask;


### PR DESCRIPTION
We don't need a full sum as in full addition/substraction, it's literally not
used and thus we don't need to constrain it.

```
Number of AND constraints: 1766696
Number of gates: 1274560
Length of value vec: 2097152
fill_witness took 69748 microseconds
```