### PR TITLE
[field] Implement portable GHASH multiplication

### DIFF
--- a/crates/field/src/arch/portable/packed_ghash_128.rs
+++ b/crates/field/src/arch/portable/packed_ghash_128.rs
@@ -11,17 +11,47 @@ use crate::{
 	arithmetic_traits::{InvertOrZero, impl_square_with, impl_transformation_with_strategy},
 };
 
+/// GHASH field multiplication using the standard bit-by-bit algorithm.
+/// This implements multiplication in GF(2^128) with the irreducible polynomial
+/// x^128 + x^7 + x^2 + x + 1, represented as 0xe1000000000000000000000000000000.
+/// This is a straightforward implementation portable version of russian peasant multiplication.
+/// We most probably won't use this field for the platforms that don't have caryless
+/// multiplication instruction, so no need to optimize this for now.
+pub fn ghash_mul(mut x: u128, mut y: u128) -> u128 {
+	let mut z: u128 = 0;
+
+	for _ in 0..128 {
+		// If the top bit of y is set, XOR current x into accumulator z
+		if (y & (1 << 127)) != 0 {
+			z ^= x;
+		}
+		// Save the bit that will be shifted out (rightmost/LSB of x)
+		let lsb = x & 1;
+		// Shift x right by 1 (polynomial division by x)
+		x >>= 1;
+		// If the bit we shifted out was 1, reduce modulo the GCM polynomial
+		if lsb != 0 {
+			x ^= 0xe1000000000000000000000000000000u128;
+		}
+		// Shift y left by 1, bringing the next bit into the top position
+		y <<= 1;
+	}
+	z
+}
+
 pub type PackedBinaryGhash1x128b = PackedPrimitiveType<u128, BinaryField128bGhash>;
 
 // Define broadcast
 impl_broadcast!(u128, BinaryField128bGhash);
 
-// Define multiply - placeholder implementation
+// Define multiply
 impl Mul for PackedBinaryGhash1x128b {
 	type Output = Self;
 
-	fn mul(self, _rhs: Self) -> Self::Output {
-		todo!("Implement packed GHASH multiplication")
+	fn mul(self, rhs: Self) -> Self::Output {
+		crate::tracing::trace_multiplication!(PackedBinaryGhash1x128b);
+
+		ghash_mul(self.0, rhs.0).into()
 	}
 }
 

--- a/crates/field/src/arch/x86_64/m256.rs
+++ b/crates/field/src/arch/x86_64/m256.rs
@@ -21,7 +21,7 @@ use seq_macro::seq;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 
 use crate::{
-	BinaryField, Random,
+	BinaryField,
 	arch::{
 		binary_utils::{as_array_mut, as_array_ref, make_func_to_i8},
 		portable::{


### PR DESCRIPTION
### TL;DR

Implemented a portable version of GHASH field multiplication. This may not be the fastest possible implementation but we are not going to use it actually, so no reason to spent time optimizing it.

### What changed?

- Added a `ghash_mul` function that implements multiplication in GF(2^128) using the standard bit-by-bit algorithm (Russian peasant multiplication)
- Implemented the `Mul` trait for `PackedBinaryGhash1x128b` using the new `ghash_mul` function
- Added detailed documentation explaining the algorithm and the irreducible polynomial used (x^128 + x^7 + x^2 + x + 1)
- Removed an unused import (`Random`) from the x86_64/m256.rs file

### How to test?

- Run the existing test suite to ensure the implementation works correctly
- Add specific tests for GHASH multiplication with known input/output pairs to verify correctness

### Why make this change?

This change provides a functional implementation of GHASH field multiplication for the portable architecture, replacing the previous placeholder implementation. While this implementation may not be optimized for performance (as noted in the comments), it provides a correct reference implementation that can be used on platforms without carryless multiplication instructions.