### PR TITLE
[field] Implement optimized ghash implementation for aarch64

### DIFF
--- a/crates/arith-bench/src/arch/aarch64.rs
+++ b/crates/arith-bench/src/arch/aarch64.rs
@@ -186,7 +186,7 @@ impl crate::underlier::OpsClmul for uint64x2_t {
 					let a_bytes: uint8x16_t = std::mem::transmute(a);
 					let zero: uint8x16_t = vdupq_n_u8(0);
 					let shifted: uint8x16_t = vextq_u8::<IMM8>(zero, a_bytes);
-					std::mem::transmute(shifted)
+					std::mem::transmute::<uint8x16_t, uint64x2_t>(shifted)
 				}
 				16.. => vdupq_n_u64(0),
 				_ => {
@@ -206,11 +206,14 @@ impl crate::underlier::OpsClmul for uint64x2_t {
 	#[inline]
 	fn movepi64_mask(a: Self) -> Self {
 		unsafe {
-			let a = std::mem::transmute(a);
+			let a = std::mem::transmute::<uint64x2_t, uint32x4_t>(a);
 			// Get the odd lanes (upper 32 bits of each 64-bit element)
 			let odd_lanes = vtrn2q_u32(a, a);
 			// Arithmetic shift right to broadcast the sign bit
-			std::mem::transmute(vshrq_n_s32(std::mem::transmute(odd_lanes), 31))
+			std::mem::transmute(vshrq_n_s32(
+				std::mem::transmute::<uint32x4_t, int32x4_t>(odd_lanes),
+				31,
+			))
 		}
 	}
 }

--- a/crates/field/src/arch/aarch64/m128.rs
+++ b/crates/field/src/arch/aarch64/m128.rs
@@ -24,7 +24,7 @@ use super::super::portable::{
 	packed_arithmetic::{UnderlierWithBitConstants, interleave_mask_even, interleave_mask_odd},
 };
 use crate::{
-	BinaryField, Random,
+	BinaryField,
 	arch::binary_utils::{as_array_mut, as_array_ref},
 	arithmetic_traits::Broadcast,
 	tower_levels::TowerLevel,

--- a/crates/field/src/arch/aarch64/mod.rs
+++ b/crates/field/src/arch/aarch64/mod.rs
@@ -10,10 +10,13 @@ cfg_if! {
 		pub mod packed_128;
 		pub mod packed_aes_128;
 		pub mod packed_polyval_128;
+		pub mod packed_ghash_128;
+
 		mod packed_macros;
 	} else {
 		pub use super::portable::packed_128;
 		pub use super::portable::packed_aes_128;
 		pub use super::portable::packed_polyval_128;
+		pub use super::portable::packed_ghash_128;
 	}
 }

--- a/crates/field/src/arch/aarch64/packed_ghash_128.rs
+++ b/crates/field/src/arch/aarch64/packed_ghash_128.rs
@@ -1,0 +1,91 @@
+// Copyright 2023-2025 Irreducible Inc.
+// Copyright (c) 2019-2023 RustCrypto Developers
+
+//! ARMv8 `PMULL`-accelerated implementation of GHASH.
+//!
+//! Based on the optimized GHASH implementation using carryless multiplication
+//! instructions available on ARMv8 processors with NEON support.
+
+use core::arch::aarch64::*;
+use std::ops::Mul;
+
+use super::{super::portable::packed::PackedPrimitiveType, m128::M128};
+use crate::{
+	BinaryField128bGhash,
+	arch::{PairwiseStrategy, ReuseMultiplyStrategy, shared::ghash::ClMulUnderlier},
+	arithmetic_traits::{InvertOrZero, impl_square_with, impl_transformation_with_strategy},
+	packed::PackedField,
+};
+
+impl ClMulUnderlier for M128 {
+	#[inline]
+	fn clmulepi64<const IMM8: i32>(a: Self, b: Self) -> Self {
+		let a_u64x2: uint64x2_t = a.into();
+		let b_u64x2: uint64x2_t = b.into();
+
+		let result = match IMM8 {
+			0x00 => unsafe { vmull_p64(vgetq_lane_u64(a_u64x2, 0), vgetq_lane_u64(b_u64x2, 0)) },
+			0x11 => unsafe { vmull_p64(vgetq_lane_u64(a_u64x2, 1), vgetq_lane_u64(b_u64x2, 1)) },
+			0x10 => unsafe { vmull_p64(vgetq_lane_u64(a_u64x2, 0), vgetq_lane_u64(b_u64x2, 1)) },
+			0x01 => unsafe { vmull_p64(vgetq_lane_u64(a_u64x2, 1), vgetq_lane_u64(b_u64x2, 0)) },
+			_ => panic!("Unsupported IMM8 value for clmulepi64"),
+		};
+
+		unsafe { std::mem::transmute::<u128, uint64x2_t>(result) }.into()
+	}
+
+	#[inline]
+	fn slli_si128<const IMM8: i32>(a: Self) -> Self {
+		let a_u64x2: uint64x2_t = a.into();
+		// Shift left by IMM8 bytes
+		unsafe {
+			match IMM8 {
+				0 => a,
+				1..=15 => {
+					let a_bytes: uint8x16_t = std::mem::transmute(a_u64x2);
+					let zero: uint8x16_t = vdupq_n_u8(0);
+					let shifted: uint8x16_t = vextq_u8::<IMM8>(zero, a_bytes);
+					std::mem::transmute::<uint8x16_t, uint64x2_t>(shifted).into()
+				}
+				16.. => M128::from(0u128),
+				_ => {
+					// For negative shifts, return zero
+					M128::from(0u128)
+				}
+			}
+		}
+	}
+}
+
+pub type PackedBinaryGhash1x128b = PackedPrimitiveType<M128, BinaryField128bGhash>;
+
+// Define multiply
+impl Mul for PackedBinaryGhash1x128b {
+	type Output = Self;
+
+	fn mul(self, rhs: Self) -> Self::Output {
+		crate::tracing::trace_multiplication!(PackedBinaryGhash1x128b);
+
+		Self::from_underlier(crate::arch::shared::ghash::mul_clmul(
+			self.to_underlier(),
+			rhs.to_underlier(),
+		))
+	}
+}
+
+// Define square
+impl_square_with!(PackedBinaryGhash1x128b @ ReuseMultiplyStrategy);
+
+// Define invert
+impl InvertOrZero for PackedBinaryGhash1x128b {
+	fn invert_or_zero(self) -> Self {
+		let portable = super::super::portable::packed_ghash_128::PackedBinaryGhash1x128b::from(
+			u128::from(self.to_underlier()),
+		);
+
+		Self::from_underlier(PackedField::invert_or_zero(portable).to_underlier().into())
+	}
+}
+
+// Define linear transformations
+impl_transformation_with_strategy!(PackedBinaryGhash1x128b, PairwiseStrategy);

--- a/crates/field/src/arch/mod.rs
+++ b/crates/field/src/arch/mod.rs
@@ -4,6 +4,7 @@ use cfg_if::cfg_if;
 
 mod arch_optimal;
 mod binary_utils;
+mod shared;
 mod strategies;
 
 cfg_if! {
@@ -19,8 +20,8 @@ cfg_if! {
 		mod portable;
 
 		mod aarch64;
-		pub use aarch64::{packed_128, packed_polyval_128, packed_aes_128};
-		pub use portable::{packed_256, packed_512, packed_aes_256, packed_aes_512, packed_polyval_256, packed_polyval_512, packed_ghash_128, packed_ghash_256, packed_ghash_512};
+		pub use aarch64::{packed_128, packed_polyval_128, packed_aes_128, packed_ghash_128};
+		pub use portable::{packed_256, packed_512, packed_aes_256, packed_aes_512, packed_polyval_256, packed_polyval_512, packed_ghash_256, packed_ghash_512};
 	} else {
 		mod portable;
 		pub use portable::{packed_128, packed_256, packed_512, packed_aes_128, packed_aes_256, packed_aes_512, packed_polyval_128, packed_polyval_256, packed_polyval_512, packed_ghash_128, packed_ghash_256, packed_ghash_512};

--- a/crates/field/src/arch/shared/ghash.rs
+++ b/crates/field/src/arch/shared/ghash.rs
@@ -1,0 +1,62 @@
+// Copyright 2025 Irreducible Inc.
+
+use crate::underlier::UnderlierWithBitOps;
+
+/// Trait for underliers that support CLMUL operations which are needed for the
+/// GHASH multiplication algorithm.
+pub trait ClMulUnderlier: UnderlierWithBitOps + From<u64> + From<u128> {
+	fn clmulepi64<const IMM8: i32>(a: Self, b: Self) -> Self;
+
+	/// Shifts 128-bit value left by IMM8 bytes while shifting in zeros.
+	///
+	/// For 256-bit values, this operates on each 128-bit lane independently.
+	fn slli_si128<const IMM8: i32>(a: Self) -> Self;
+}
+
+#[inline]
+#[allow(dead_code)]
+pub fn mul_clmul<U: ClMulUnderlier>(x: U, y: U) -> U {
+	// Based on the C++ reference implementation
+	// The algorithm performs polynomial multiplication followed by reduction
+
+	// t1a = x.lo * y.hi
+	let t1a = U::clmulepi64::<0x01>(x, y);
+
+	// t1b = x.hi * y.lo
+	let t1b = U::clmulepi64::<0x10>(x, y);
+
+	// t1 = t1a + t1b (XOR in binary field)
+	let mut t1 = t1a ^ t1b;
+
+	// t2 = x.hi * y.hi
+	let t2 = U::clmulepi64::<0x11>(x, y);
+
+	// Reduce t1 and t2
+	t1 = gf2_128_reduce(t1, t2);
+
+	// t0 = x.lo * y.lo
+	let mut t0 = U::clmulepi64::<0x00>(x, y);
+
+	// Final reduction
+	t0 = gf2_128_reduce(t0, t1);
+
+	t0
+}
+
+/// Performs reduction step: returns t0 + x^64 * t1
+#[inline]
+fn gf2_128_reduce<U: ClMulUnderlier>(mut t0: U, t1: U) -> U {
+	// The reduction polynomial x^128 + x^7 + x^2 + x + 1 is represented as 0x87
+	const POLY: u128 = 0x87;
+	let poly = <U as UnderlierWithBitOps>::broadcast_subvalue(POLY);
+
+	// t0 = t0 XOR (t1 << 64)
+	// In SIMD, left shift by 64 bits is shifting by 8 bytes
+	t0 ^= U::slli_si128::<8>(t1);
+
+	// t0 = t0 XOR clmul(t1, poly, 0x01)
+	// This multiplies the high 64 bits of t1 with the low 64 bits of poly
+	t0 ^= U::clmulepi64::<0x01>(t1, poly);
+
+	t0
+}

--- a/crates/field/src/arch/shared/mod.rs
+++ b/crates/field/src/arch/shared/mod.rs
@@ -1,0 +1,3 @@
+// Copyright 2025 Irreducible Inc.
+
+pub mod ghash;


### PR DESCRIPTION
### TL;DR

Added AARCH64 PMULL-accelerated implementation of GHASH with proper type annotations.

### What changed?

- Added a new `packed_ghash_128.rs` module for ARMv8 with NEON support
- Implemented GHASH using carryless multiplication instructions available on AARCH64 processors
- Created a shared GHASH implementation in `arch/shared/ghash.rs` that can be used across architectures
- Fixed type annotations in `aarch64.rs` to be more explicit with `std::mem::transmute` calls
- Updated module exports to include the new GHASH implementation

### How to test?

- Run the test suite on AARCH64 hardware with NEON support
- Benchmark the GHASH implementation against the portable version to verify performance improvements
- Verify that all existing functionality continues to work correctly

### Why make this change?

This change provides an optimized GHASH implementation for ARMv8 processors using hardware-accelerated carryless multiplication instructions. By leveraging the PMULL instruction, this implementation should significantly improve performance for GHASH operations on ARM platforms compared to the portable implementation.