### PR TITLE
[field] Optimized GHASH implementation for x64

### DIFF
--- a/crates/field/src/arch/aarch64/packed_ghash_128.rs
+++ b/crates/field/src/arch/aarch64/packed_ghash_128.rs
@@ -35,24 +35,14 @@ impl ClMulUnderlier for M128 {
 	}
 
 	#[inline]
-	fn slli_si128<const IMM8: i32>(a: Self) -> Self {
+	fn move_64_to_hi(a: Self) -> Self {
 		let a_u64x2: uint64x2_t = a.into();
-		// Shift left by IMM8 bytes
+		// Shift left by 8 bytes
 		unsafe {
-			match IMM8 {
-				0 => a,
-				1..=15 => {
-					let a_bytes: uint8x16_t = std::mem::transmute(a_u64x2);
-					let zero: uint8x16_t = vdupq_n_u8(0);
-					let shifted: uint8x16_t = vextq_u8::<IMM8>(zero, a_bytes);
-					std::mem::transmute::<uint8x16_t, uint64x2_t>(shifted).into()
-				}
-				16.. => M128::from(0u128),
-				_ => {
-					// For negative shifts, return zero
-					M128::from(0u128)
-				}
-			}
+			let a_bytes: uint8x16_t = std::mem::transmute(a_u64x2);
+			let zero: uint8x16_t = vdupq_n_u8(0);
+			let shifted: uint8x16_t = vextq_u8::<8>(zero, a_bytes);
+			std::mem::transmute::<uint8x16_t, uint64x2_t>(shifted).into()
 		}
 	}
 }

--- a/crates/field/src/arch/mod.rs
+++ b/crates/field/src/arch/mod.rs
@@ -13,8 +13,7 @@ cfg_if! {
 		mod portable;
 
 		mod x86_64;
-		pub use x86_64::{packed_128, packed_256, packed_512, packed_aes_128, packed_aes_256, packed_aes_512, packed_polyval_128, packed_polyval_256, packed_polyval_512};
-		pub use portable::{packed_ghash_128, packed_ghash_256, packed_ghash_512};
+		pub use x86_64::{packed_128, packed_256, packed_512, packed_aes_128, packed_aes_256, packed_aes_512, packed_polyval_128, packed_polyval_256, packed_polyval_512, packed_ghash_128, packed_ghash_256, packed_ghash_512};
 	} else if #[cfg(target_arch = "aarch64")] {
 		#[allow(dead_code)]
 		mod portable;

--- a/crates/field/src/arch/x86_64/m512.rs
+++ b/crates/field/src/arch/x86_64/m512.rs
@@ -20,7 +20,7 @@ use seq_macro::seq;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 
 use crate::{
-	BinaryField, Random,
+	BinaryField,
 	arch::{
 		binary_utils::{as_array_mut, as_array_ref, make_func_to_i8},
 		portable::{

--- a/crates/field/src/arch/x86_64/mod.rs
+++ b/crates/field/src/arch/x86_64/mod.rs
@@ -13,12 +13,14 @@ cfg_if! {
 	if #[cfg(target_feature = "sse2")] {
 		pub(super) mod m128;
 		pub mod packed_128;
-		pub mod packed_polyval_128;
 		pub mod packed_aes_128;
+		pub mod packed_ghash_128;
+		pub mod packed_polyval_128;
 		mod packed_macros;
 	} else {
 		pub use super::portable::packed_128;
 		pub use super::portable::packed_aes_128;
+		pub use super::portable::packed_ghash_128;
 		pub use super::portable::packed_polyval_128;
 	}
 }
@@ -26,12 +28,14 @@ cfg_if! {
 cfg_if! {
 	if #[cfg(target_feature = "avx2")] {
 		pub(super) mod m256;
-		pub mod  packed_256;
-		pub mod packed_polyval_256;
+		pub mod packed_256;
 		pub mod packed_aes_256;
+		pub mod packed_ghash_256;
+		pub mod packed_polyval_256;
 	} else {
 		pub use super::portable::packed_256;
 		pub use super::portable::packed_aes_256;
+		pub use super::portable::packed_ghash_256;
 		pub use super::portable::packed_polyval_256;
 	}
 }
@@ -40,11 +44,14 @@ cfg_if! {
 	if #[cfg(target_feature = "avx512f")] {
 		pub(super) mod m512;
 		pub mod packed_512;
-		pub mod packed_polyval_512;
 		pub mod packed_aes_512;
+		pub mod packed_ghash_512;
+		pub mod packed_polyval_512;
+
 	} else {
 		pub use super::portable::packed_512;
 		pub use super::portable::packed_aes_512;
+		pub use super::portable::packed_ghash_512;
 		pub use super::portable::packed_polyval_512;
 	}
 }

--- a/crates/field/src/arch/x86_64/packed_ghash_128.rs
+++ b/crates/field/src/arch/x86_64/packed_ghash_128.rs
@@ -1,0 +1,93 @@
+// Copyright 2024-2025 Irreducible Inc.
+
+//! PCLMULQDQ-accelerated implementation of GHASH for x86_64.
+//!
+//! This module provides optimized GHASH multiplication using the PCLMULQDQ instruction
+//! available on modern x86_64 processors. The implementation follows the algorithm
+//! described in the GHASH specification with polynomial x^128 + x^7 + x^2 + x + 1.
+
+use std::ops::Mul;
+
+use cfg_if::cfg_if;
+
+use super::{super::portable::packed::PackedPrimitiveType, m128::M128};
+use crate::{
+	BinaryField128bGhash,
+	arch::ReuseMultiplyStrategy,
+	arithmetic_traits::{InvertOrZero, impl_square_with},
+	packed::PackedField,
+};
+
+#[cfg(target_feature = "pclmulqdq")]
+impl crate::arch::shared::ghash::ClMulUnderlier for M128 {
+	#[inline]
+	fn clmulepi64<const IMM8: i32>(a: Self, b: Self) -> Self {
+		unsafe { std::arch::x86_64::_mm_clmulepi64_si128::<IMM8>(a.into(), b.into()) }.into()
+	}
+
+	#[inline]
+	fn move_64_to_hi(a: Self) -> Self {
+		unsafe { std::arch::x86_64::_mm_slli_si128::<8>(a.into()) }.into()
+	}
+}
+
+pub type PackedBinaryGhash1x128b = PackedPrimitiveType<M128, BinaryField128bGhash>;
+
+// Define multiply
+cfg_if! {
+	if #[cfg(target_feature = "pclmulqdq")] {
+		impl Mul for PackedBinaryGhash1x128b {
+			type Output = Self;
+
+			fn mul(self, rhs: Self) -> Self::Output {
+				crate::tracing::trace_multiplication!(PackedBinaryGhash1x128b);
+
+				Self::from_underlier(crate::arch::shared::ghash::mul_clmul(
+					self.to_underlier(),
+					rhs.to_underlier(),
+				))
+			}
+		}
+	} else {
+		impl Mul for PackedBinaryGhash1x128b {
+			type Output = Self;
+
+			fn mul(self, rhs: Self) -> Self::Output {
+				use super::super::portable::packed_ghash_128::PackedBinaryGhash1x128b as PortablePackedBinaryGhash1x128b;
+
+				crate::tracing::trace_multiplication!(PackedBinaryGhash1x128b);
+
+				let portable_lhs = PortablePackedBinaryGhash1x128b::from(u128::from(self.to_underlier()));
+				let portable_rhs = PortablePackedBinaryGhash1x128b::from(u128::from(rhs.to_underlier()));
+
+				Self::from_underlier(Mul::mul(portable_lhs, portable_rhs).to_underlier().into())
+			}
+		}
+	}
+}
+
+// Define square
+impl_square_with!(PackedBinaryGhash1x128b @ ReuseMultiplyStrategy);
+
+// Define invert
+impl InvertOrZero for PackedBinaryGhash1x128b {
+	fn invert_or_zero(self) -> Self {
+		let portable = super::super::portable::packed_ghash_128::PackedBinaryGhash1x128b::from(
+			u128::from(self.to_underlier()),
+		);
+
+		Self::from_underlier(PackedField::invert_or_zero(portable).to_underlier().into())
+	}
+}
+
+cfg_if! {
+	if #[cfg(target_feature = "gfni")] {
+		use crate::arch::x86_64::gfni::gfni_arithmetics::impl_transformation_with_gfni_nxn;
+		impl_transformation_with_gfni_nxn!(PackedBinaryGhash1x128b, 16);
+	} else {
+		crate::arithmetic_traits::impl_transformation_with_strategy!(
+			PackedBinaryGhash1x128b,
+			crate::arch::SimdStrategy
+		);
+	}
+}

--- a/crates/field/src/arch/x86_64/packed_ghash_256.rs
+++ b/crates/field/src/arch/x86_64/packed_ghash_256.rs
@@ -1,0 +1,126 @@
+// Copyright 2024-2025 Irreducible Inc.
+
+//! VPCLMULQDQ-accelerated implementation of GHASH for x86_64 AVX2.
+//!
+//! This module provides optimized GHASH multiplication using the VPCLMULQDQ instruction
+//! available on modern x86_64 processors with AVX2 support. The implementation follows
+//! the algorithm described in the GHASH specification with polynomial x^128 + x^7 + x^2 + x + 1.
+
+use std::ops::Mul;
+
+use cfg_if::cfg_if;
+
+use super::{super::portable::packed::PackedPrimitiveType, m256::M256};
+use crate::{
+	BinaryField128bGhash,
+	arch::ReuseMultiplyStrategy,
+	arithmetic_traits::{InvertOrZero, impl_square_with},
+	packed::PackedField,
+	underlier::UnderlierWithBitOps,
+};
+
+#[cfg(all(target_feature = "vpclmulqdq", target_feature = "avx2"))]
+impl crate::arch::shared::ghash::ClMulUnderlier for M256 {
+	#[inline]
+	fn clmulepi64<const IMM8: i32>(a: Self, b: Self) -> Self {
+		unsafe { std::arch::x86_64::_mm256_clmulepi64_epi128::<IMM8>(a.into(), b.into()) }.into()
+	}
+
+	#[inline]
+	fn move_64_to_hi(a: Self) -> Self {
+		unsafe { std::arch::x86_64::_mm256_slli_si256::<8>(a.into()) }.into()
+	}
+}
+
+pub type PackedBinaryGhash2x128b = PackedPrimitiveType<M256, BinaryField128bGhash>;
+
+// Define multiply using if_cfg!
+cfg_if! {
+	if #[cfg(all(target_feature = "vpclmulqdq", target_feature = "avx2"))] {
+		impl Mul for PackedBinaryGhash2x128b {
+			type Output = Self;
+
+			fn mul(self, rhs: Self) -> Self::Output {
+				crate::tracing::trace_multiplication!(PackedBinaryGhash2x128b);
+
+				Self::from_underlier(crate::arch::shared::ghash::mul_clmul(
+					self.to_underlier(),
+					rhs.to_underlier(),
+				))
+			}
+		}
+	} else {
+		impl Mul for PackedBinaryGhash2x128b {
+			type Output = Self;
+
+			fn mul(self, rhs: Self) -> Self::Output {
+				crate::tracing::trace_multiplication!(PackedBinaryGhash2x128b);
+
+				// Fallback: perform scalar multiplication on each 128-bit element
+				let mut result_underlier = self.to_underlier();
+				unsafe {
+					let self_0 = self.to_underlier().get_subvalue::<u128>(0);
+					let self_1 = self.to_underlier().get_subvalue::<u128>(1);
+					let rhs_0 = rhs.to_underlier().get_subvalue::<u128>(0);
+					let rhs_1 = rhs.to_underlier().get_subvalue::<u128>(1);
+
+					// Use the portable scalar multiplication for each element
+					use super::super::portable::packed_ghash_128::PackedBinaryGhash1x128b as PortablePackedBinaryGhash1x128b;
+					let result_0 = Mul::mul(
+						PortablePackedBinaryGhash1x128b::from(self_0),
+						PortablePackedBinaryGhash1x128b::from(rhs_0),
+					);
+					let result_1 = Mul::mul(
+						PortablePackedBinaryGhash1x128b::from(self_1),
+						PortablePackedBinaryGhash1x128b::from(rhs_1),
+					);
+
+					result_underlier.set_subvalue(0, result_0.to_underlier());
+					result_underlier.set_subvalue(1, result_1.to_underlier());
+				}
+
+				Self::from_underlier(result_underlier)
+			}
+		}
+	}
+}
+
+// Define square
+impl_square_with!(PackedBinaryGhash2x128b @ ReuseMultiplyStrategy);
+
+// Define invert
+impl InvertOrZero for PackedBinaryGhash2x128b {
+	fn invert_or_zero(self) -> Self {
+		// Fallback: perform scalar invert on each 128-bit element
+		let mut result_underlier = self.to_underlier();
+		unsafe {
+			let self_0 = self.to_underlier().get_subvalue::<u128>(0);
+			let self_1 = self.to_underlier().get_subvalue::<u128>(1);
+
+			// Use the portable scalar invert for each element
+			use super::super::portable::packed_ghash_128::PackedBinaryGhash1x128b as PortablePackedBinaryGhash1x128b;
+			let result_0 =
+				PackedField::invert_or_zero(PortablePackedBinaryGhash1x128b::from(self_0));
+			let result_1 =
+				PackedField::invert_or_zero(PortablePackedBinaryGhash1x128b::from(self_1));
+
+			result_underlier.set_subvalue(0, result_0.to_underlier());
+			result_underlier.set_subvalue(1, result_1.to_underlier());
+		}
+
+		Self::from_underlier(result_underlier)
+	}
+}
+
+// Define linear transformations
+cfg_if! {
+	if #[cfg(all(target_feature = "gfni", target_feature = "avx2"))] {
+		use crate::arch::x86_64::gfni::gfni_arithmetics::impl_transformation_with_gfni_nxn;
+		impl_transformation_with_gfni_nxn!(PackedBinaryGhash2x128b, 16);
+	} else {
+		crate::arithmetic_traits::impl_transformation_with_strategy!(
+			PackedBinaryGhash2x128b,
+			crate::arch::SimdStrategy
+		);
+	}
+}

--- a/crates/field/src/arch/x86_64/packed_ghash_512.rs
+++ b/crates/field/src/arch/x86_64/packed_ghash_512.rs
@@ -1,0 +1,154 @@
+// Copyright 2024-2025 Irreducible Inc.
+
+//! VPCLMULQDQ-accelerated implementation of GHASH for x86_64 AVX-512.
+//!
+//! This module provides optimized GHASH multiplication using the VPCLMULQDQ instruction
+//! available on modern x86_64 processors with AVX-512 support. The implementation follows
+//! the algorithm described in the GHASH specification with polynomial x^128 + x^7 + x^2 + x + 1.
+
+use std::ops::Mul;
+
+use cfg_if::cfg_if;
+
+use super::{super::portable::packed::PackedPrimitiveType, m512::M512};
+use crate::{
+	BinaryField128bGhash,
+	arch::ReuseMultiplyStrategy,
+	arithmetic_traits::{InvertOrZero, impl_square_with},
+	packed::PackedField,
+	underlier::UnderlierWithBitOps,
+};
+
+#[cfg(all(target_feature = "vpclmulqdq", target_feature = "avx512f"))]
+impl crate::arch::shared::ghash::ClMulUnderlier for M512 {
+	#[inline]
+	fn clmulepi64<const IMM8: i32>(a: Self, b: Self) -> Self {
+		unsafe { std::arch::x86_64::_mm512_clmulepi64_epi128::<IMM8>(a.into(), b.into()) }.into()
+	}
+
+	#[inline]
+	fn move_64_to_hi(a: Self) -> Self {
+		unsafe {
+			std::arch::x86_64::_mm512_unpacklo_epi64(
+				std::arch::x86_64::_mm512_setzero_si512(),
+				a.into(),
+			)
+		}
+		.into()
+	}
+}
+
+pub type PackedBinaryGhash4x128b = PackedPrimitiveType<M512, BinaryField128bGhash>;
+
+// Define multiply
+cfg_if! {
+	if #[cfg(all(target_feature = "vpclmulqdq", target_feature = "avx512f"))] {
+		impl Mul for PackedBinaryGhash4x128b {
+			type Output = Self;
+
+			fn mul(self, rhs: Self) -> Self::Output {
+				crate::tracing::trace_multiplication!(PackedBinaryGhash4x128b);
+
+				Self::from_underlier(crate::arch::shared::ghash::mul_clmul(
+					self.to_underlier(),
+					rhs.to_underlier(),
+				))
+			}
+		}
+	} else {
+		impl Mul for PackedBinaryGhash4x128b {
+			type Output = Self;
+
+			fn mul(self, rhs: Self) -> Self::Output {
+				crate::tracing::trace_multiplication!(PackedBinaryGhash4x128b);
+
+				// Fallback: perform scalar multiplication on each 128-bit element
+				let mut result_underlier = self.to_underlier();
+				unsafe {
+					let self_0 = self.to_underlier().get_subvalue::<u128>(0);
+					let self_1 = self.to_underlier().get_subvalue::<u128>(1);
+					let self_2 = self.to_underlier().get_subvalue::<u128>(2);
+					let self_3 = self.to_underlier().get_subvalue::<u128>(3);
+					let rhs_0 = rhs.to_underlier().get_subvalue::<u128>(0);
+					let rhs_1 = rhs.to_underlier().get_subvalue::<u128>(1);
+					let rhs_2 = rhs.to_underlier().get_subvalue::<u128>(2);
+					let rhs_3 = rhs.to_underlier().get_subvalue::<u128>(3);
+
+					// Use the portable scalar multiplication for each element
+					use super::super::portable::packed_ghash_128::PackedBinaryGhash1x128b as PortablePackedBinaryGhash1x128b;
+					let result_0 = Mul::mul(
+						PortablePackedBinaryGhash1x128b::from(self_0),
+						PortablePackedBinaryGhash1x128b::from(rhs_0),
+					);
+					let result_1 = Mul::mul(
+						PortablePackedBinaryGhash1x128b::from(self_1),
+						PortablePackedBinaryGhash1x128b::from(rhs_1),
+					);
+					let result_2 = Mul::mul(
+						PortablePackedBinaryGhash1x128b::from(self_2),
+						PortablePackedBinaryGhash1x128b::from(rhs_2),
+					);
+					let result_3 = Mul::mul(
+						PortablePackedBinaryGhash1x128b::from(self_3),
+						PortablePackedBinaryGhash1x128b::from(rhs_3),
+					);
+
+					result_underlier.set_subvalue(0, result_0.to_underlier());
+					result_underlier.set_subvalue(1, result_1.to_underlier());
+					result_underlier.set_subvalue(2, result_2.to_underlier());
+					result_underlier.set_subvalue(3, result_3.to_underlier());
+				}
+
+				Self::from_underlier(result_underlier)
+			}
+		}
+	}
+}
+
+// Define square
+impl_square_with!(PackedBinaryGhash4x128b @ ReuseMultiplyStrategy);
+
+// Define invert
+impl InvertOrZero for PackedBinaryGhash4x128b {
+	fn invert_or_zero(self) -> Self {
+		// Fallback: perform scalar invert on each 128-bit element
+		let mut result_underlier = self.to_underlier();
+		unsafe {
+			let self_0 = self.to_underlier().get_subvalue::<u128>(0);
+			let self_1 = self.to_underlier().get_subvalue::<u128>(1);
+			let self_2 = self.to_underlier().get_subvalue::<u128>(2);
+			let self_3 = self.to_underlier().get_subvalue::<u128>(3);
+
+			// Use the portable scalar invert for each element
+			use super::super::portable::packed_ghash_128::PackedBinaryGhash1x128b as PortablePackedBinaryGhash1x128b;
+			let result_0 =
+				PackedField::invert_or_zero(PortablePackedBinaryGhash1x128b::from(self_0));
+			let result_1 =
+				PackedField::invert_or_zero(PortablePackedBinaryGhash1x128b::from(self_1));
+			let result_2 =
+				PackedField::invert_or_zero(PortablePackedBinaryGhash1x128b::from(self_2));
+			let result_3 =
+				PackedField::invert_or_zero(PortablePackedBinaryGhash1x128b::from(self_3));
+
+			result_underlier.set_subvalue(0, result_0.to_underlier());
+			result_underlier.set_subvalue(1, result_1.to_underlier());
+			result_underlier.set_subvalue(2, result_2.to_underlier());
+			result_underlier.set_subvalue(3, result_3.to_underlier());
+		}
+
+		Self::from_underlier(result_underlier)
+	}
+}
+
+// Define linear transformations
+cfg_if! {
+	if #[cfg(target_feature = "gfni")] {
+		use crate::arch::x86_64::gfni::gfni_arithmetics::impl_transformation_with_gfni_nxn;
+		impl_transformation_with_gfni_nxn!(PackedBinaryGhash4x128b, 16);
+	} else {
+		crate::arithmetic_traits::impl_transformation_with_strategy!(
+			PackedBinaryGhash4x128b,
+			crate::arch::SimdStrategy
+		);
+	}
+}


### PR DESCRIPTION
### TL;DR

Add optimized GHASH implementation with hardware acceleration for x86_64 architectures.

### What changed?

- Replaced the generic `slli_si128` function with a more specific `move_64_to_hi` function that only handles the 8-byte shift case needed for GHASH. This is because there is no corresponding AVX512 instruction to shift 128 lanes by a given number of bytes.
- Added x86_64-specific GHASH implementations using PCLMULQDQ/VPCLMULQDQ instructions:
  - `packed_ghash_128.rs` for SSE2
  - `packed_ghash_256.rs` for AVX2
  - `packed_ghash_512.rs` for AVX-512
- Updated module exports to use the x86_64 GHASH implementations when available instead of the portable ones
- Fixed the AArch64 implementation to use the simplified function

### How to test?

- Run tests on x86_64 systems with different instruction set support:
  - Basic x86_64 systems
  - Systems with PCLMULQDQ support
  - Systems with AVX2 and VPCLMULQDQ
  - Systems with AVX-512
- Verify that GHASH operations work correctly on all platforms
- Compare performance between the optimized and portable implementations

### Why make this change?

This change improves GHASH performance on x86_64 platforms by leveraging hardware-specific instructions for carryless multiplication (PCLMULQDQ/VPCLMULQDQ). By providing specialized implementations for different SIMD widths (128-bit, 256-bit, and 512-bit), we can achieve better performance on modern processors while maintaining compatibility with older hardware through fallback implementations.