### PR TITLE
[field] Add packed GHASH fields to benchmarks

### DIFF
--- a/crates/field/benches/packed_field_invert.rs
+++ b/crates/field/benches/packed_field_invert.rs
@@ -8,7 +8,8 @@ use binius_field::{
 		byte_sliced::*, packed_8::*, packed_16::*, packed_32::*, packed_64::*, packed_128::*,
 		packed_256::*, packed_512::*, packed_aes_8::*, packed_aes_16::*, packed_aes_32::*,
 		packed_aes_64::*, packed_aes_128::*, packed_aes_256::*, packed_aes_512::*,
-		packed_polyval_128::*, packed_polyval_256::*, packed_polyval_512::*,
+		packed_ghash_128::*, packed_ghash_256::*, packed_ghash_512::*, packed_polyval_128::*,
+		packed_polyval_256::*, packed_polyval_512::*,
 	},
 };
 use cfg_if::cfg_if;

--- a/crates/field/benches/packed_field_linear_transform.rs
+++ b/crates/field/benches/packed_field_linear_transform.rs
@@ -6,7 +6,8 @@ use binius_field::{
 		byte_sliced::*, packed_8::*, packed_16::*, packed_32::*, packed_64::*, packed_128::*,
 		packed_256::*, packed_512::*, packed_aes_8::*, packed_aes_16::*, packed_aes_32::*,
 		packed_aes_64::*, packed_aes_128::*, packed_aes_256::*, packed_aes_512::*,
-		packed_polyval_128::*, packed_polyval_256::*, packed_polyval_512::*,
+		packed_ghash_128::*, packed_ghash_256::*, packed_ghash_512::*, packed_polyval_128::*,
+		packed_polyval_256::*, packed_polyval_512::*,
 	},
 	linear_transformation::{
 		FieldLinearTransformation, PackedTransformationFactory, Transformation,

--- a/crates/field/benches/packed_field_mul_alpha.rs
+++ b/crates/field/benches/packed_field_mul_alpha.rs
@@ -7,7 +7,8 @@ use binius_field::{
 		byte_sliced::*, packed_8::*, packed_16::*, packed_32::*, packed_64::*, packed_128::*,
 		packed_256::*, packed_512::*, packed_aes_8::*, packed_aes_16::*, packed_aes_32::*,
 		packed_aes_64::*, packed_aes_128::*, packed_aes_256::*, packed_aes_512::*,
-		packed_polyval_128::*, packed_polyval_256::*, packed_polyval_512::*,
+		packed_ghash_128::*, packed_ghash_256::*, packed_ghash_512::*, packed_polyval_128::*,
+		packed_polyval_256::*, packed_polyval_512::*,
 	},
 	arithmetic_traits::MulAlpha,
 };

--- a/crates/field/benches/packed_field_multiply.rs
+++ b/crates/field/benches/packed_field_multiply.rs
@@ -7,8 +7,9 @@ use std::ops::Mul;
 use binius_field::arch::{
 	byte_sliced::*, packed_8::*, packed_16::*, packed_32::*, packed_64::*, packed_128::*,
 	packed_256::*, packed_512::*, packed_aes_8::*, packed_aes_16::*, packed_aes_32::*,
-	packed_aes_64::*, packed_aes_128::*, packed_aes_256::*, packed_aes_512::*,
-	packed_polyval_128::*, packed_polyval_256::*, packed_polyval_512::*,
+	packed_aes_64::*, packed_aes_128::*, packed_aes_256::*, packed_aes_512::*, packed_ghash_128::*,
+	packed_ghash_256::*, packed_ghash_512::*, packed_polyval_128::*, packed_polyval_256::*,
+	packed_polyval_512::*,
 };
 use cfg_if::cfg_if;
 use criterion::criterion_main;

--- a/crates/field/benches/packed_field_square.rs
+++ b/crates/field/benches/packed_field_square.rs
@@ -8,7 +8,8 @@ use binius_field::{
 		byte_sliced::*, packed_8::*, packed_16::*, packed_32::*, packed_64::*, packed_128::*,
 		packed_256::*, packed_512::*, packed_aes_8::*, packed_aes_16::*, packed_aes_32::*,
 		packed_aes_64::*, packed_aes_128::*, packed_aes_256::*, packed_aes_512::*,
-		packed_polyval_128::*, packed_polyval_256::*, packed_polyval_512::*,
+		packed_ghash_128::*, packed_ghash_256::*, packed_ghash_512::*, packed_polyval_128::*,
+		packed_polyval_256::*, packed_polyval_512::*,
 	},
 };
 use cfg_if::cfg_if;

--- a/crates/field/benches/packed_field_utils.rs
+++ b/crates/field/benches/packed_field_utils.rs
@@ -277,6 +277,11 @@ macro_rules! benchmark_packed_operation {
 				PackedBinaryPolyval2x128b
 				PackedBinaryPolyval4x128b
 
+				// Packed GHASH fields
+				PackedBinaryGhash1x128b
+				PackedBinaryGhash2x128b
+				PackedBinaryGhash4x128b
+
 				// Byte sliced AES fields
 				ByteSlicedAES16x128b
 				ByteSlicedAES16x64b


### PR DESCRIPTION
### TL;DR

Added GHASH packed field implementations to benchmarks.

### What changed?

Added imports for `packed_ghash_128::*`, `packed_ghash_256::*`, and `packed_ghash_512::*` to various benchmark files. Also added `PackedBinaryGhash1x128b`, `PackedBinaryGhash2x128b`, and `PackedBinaryGhash4x128b` to the benchmark operation macros in `packed_field_utils.rs`.

### How to test?

Run the benchmarks to ensure the GHASH implementations are properly included and measured:

```bash
cargo bench --package binius-field
```

### Why make this change?

To include GHASH field implementations in the benchmarking suite, allowing for performance comparison with other field implementations like AES and POLYVAL. This helps evaluate the efficiency of GHASH operations which are commonly used in cryptographic applications.