### PR TITLE
[field] Use SIMD type for AARCH64 underlier

### DIFF
--- a/crates/field/src/arch/aarch64/packed_128.rs
+++ b/crates/field/src/arch/aarch64/packed_128.rs
@@ -103,7 +103,7 @@ define_packed_binary_fields!(
 // PackedBinaryField16x8b is constructed separately
 pub type PackedBinaryField16x8b = PackedPrimitiveType<M128, BinaryField8b>;
 impl_serialize_deserialize_for_packed_binary_field!(PackedBinaryField16x8b);
-impl_tower_constants!(BinaryField8b, M128, { M128(alphas!(u128, 3)) });
+impl_tower_constants!(BinaryField8b, M128, { M128::from_u128(alphas!(u128, 3)) });
 
 impl Mul for PackedBinaryField16x8b {
 	type Output = Self;

--- a/crates/field/src/arch/aarch64/packed_aes_128.rs
+++ b/crates/field/src/arch/aarch64/packed_aes_128.rs
@@ -72,7 +72,9 @@ define_packed_binary_fields!(
 );
 
 pub type PackedAESBinaryField16x8b = PackedPrimitiveType<M128, AESTowerField8b>;
-impl_tower_constants!(AESTowerField8b, M128, { M128(0x00d300d300d300d300d300d300d300d3) });
+impl_tower_constants!(AESTowerField8b, M128, {
+	M128::from_u128(0x00d300d300d300d300d300d300d300d3)
+});
 impl Mul for PackedAESBinaryField16x8b {
 	type Output = Self;
 

--- a/crates/field/src/arch/aarch64/packed_ghash_128.rs
+++ b/crates/field/src/arch/aarch64/packed_ghash_128.rs
@@ -36,13 +36,11 @@ impl ClMulUnderlier for M128 {
 
 	#[inline]
 	fn move_64_to_hi(a: Self) -> Self {
-		let a_u64x2: uint64x2_t = a.into();
+		let a_bytes: uint8x16_t = a.into();
 		// Shift left by 8 bytes
 		unsafe {
-			let a_bytes: uint8x16_t = std::mem::transmute(a_u64x2);
-			let zero: uint8x16_t = vdupq_n_u8(0);
-			let shifted: uint8x16_t = vextq_u8::<8>(zero, a_bytes);
-			std::mem::transmute::<uint8x16_t, uint64x2_t>(shifted).into()
+			let zero = vdupq_n_u8(0);
+			vextq_u8::<8>(zero, a_bytes).into()
 		}
 	}
 }

--- a/crates/field/src/arch/aarch64/packed_macros.rs
+++ b/crates/field/src/arch/aarch64/packed_macros.rs
@@ -7,7 +7,7 @@ macro_rules! maybe_impl_broadcast {
 macro_rules! maybe_impl_tower_constants {
 	($scalar:path, $underlier:ty, _) => {};
 	($scalar:path, M128, $alpha_idx:tt) => {
-		impl_tower_constants!($scalar, M128, { M128(alphas!(u128, $alpha_idx)) });
+		impl_tower_constants!($scalar, M128, { M128::from_u128(alphas!(u128, $alpha_idx)) });
 	};
 }
 


### PR DESCRIPTION
### TL;DR

Refactored the `M128` type for AArch64 to use NEON SIMD type instead of `u128`. To my measurements apart from  having cleaner code it also significantly improves the POLYVAL performance in benchmarks (but not GHASH for some reason)

### What changed?

- Changed the internal representation of `M128` from `u128` to `uint64x2_t` to better leverage NEON SIMD instructions
- Implemented trait methods directly using NEON intrinsics instead of going through `u128` operations
- Removed dependency on `derive_more::Not` and implemented `Not` trait manually
- Manually implemented `Default`, `PartialEq`, `Eq`, `PartialOrd`, and `Ord` traits
- Updated all type conversions to work with the new representation
- Added a new `from_u128` constructor method
- Fixed all bitwise operations to use NEON intrinsics directly
- Updated constants to use the new representation

### How to test?

- Run the existing test suite to ensure all functionality works correctly
- Benchmark the code on AArch64 platforms to verify performance improvements
- Verify that all binary field operations produce the same results as before

### Why make this change?

This change improves performance on AArch64 platforms by using NEON SIMD instructions directly instead of relying on `u128` operations that might not be optimally implemented. The new implementation better aligns with the hardware capabilities of AArch64, potentially reducing instruction count and improving throughput for cryptographic operations.