### PR TITLE
[field] Allow compiler inlining multiplications for GHASH

### DIFF
--- a/crates/arith-bench/benches/field_mul.rs
+++ b/crates/arith-bench/benches/field_mul.rs
@@ -21,7 +21,7 @@ use rand::{
 fn run_google_mul_benchmark<U, R>(
 	group: &mut BenchmarkGroup<'_, criterion::measurement::WallTime>,
 	name: &str,
-	mul_fn: fn(U, U) -> U,
+	mul_fn: impl Fn(U, U) -> U,
 	rng: &mut R,
 	element_bits: usize,
 	underlier_bits: usize,
@@ -71,7 +71,7 @@ fn run_google_mul_benchmark<U, R>(
 fn run_mul_benchmark<T, R>(
 	group: &mut BenchmarkGroup<'_, criterion::measurement::WallTime>,
 	name: &str,
-	mul_fn: fn(T, T) -> T,
+	mul_fn: impl Fn(T, T) -> T,
 	mut rng: R,
 	element_bits: usize,
 	underlier_bits: usize,

--- a/crates/field/src/arch/aarch64/packed_ghash_128.rs
+++ b/crates/field/src/arch/aarch64/packed_ghash_128.rs
@@ -51,6 +51,7 @@ pub type PackedBinaryGhash1x128b = PackedPrimitiveType<M128, BinaryField128bGhas
 impl Mul for PackedBinaryGhash1x128b {
 	type Output = Self;
 
+	#[inline]
 	fn mul(self, rhs: Self) -> Self::Output {
 		crate::tracing::trace_multiplication!(PackedBinaryGhash1x128b);
 

--- a/crates/field/src/arch/aarch64/packed_polyval_128.rs
+++ b/crates/field/src/arch/aarch64/packed_polyval_128.rs
@@ -30,6 +30,7 @@ pub type PackedBinaryPolyval1x128b = PackedPrimitiveType<M128, BinaryField128bPo
 impl Mul for PackedBinaryPolyval1x128b {
 	type Output = Self;
 
+	#[inline]
 	fn mul(self, rhs: Self) -> Self::Output {
 		crate::tracing::trace_multiplication!(PackedBinaryPolyval1x128b);
 

--- a/crates/field/src/arch/x86_64/packed_ghash_128.rs
+++ b/crates/field/src/arch/x86_64/packed_ghash_128.rs
@@ -39,6 +39,7 @@ cfg_if! {
 		impl Mul for PackedBinaryGhash1x128b {
 			type Output = Self;
 
+			#[inline]
 			fn mul(self, rhs: Self) -> Self::Output {
 				crate::tracing::trace_multiplication!(PackedBinaryGhash1x128b);
 
@@ -52,6 +53,7 @@ cfg_if! {
 		impl Mul for PackedBinaryGhash1x128b {
 			type Output = Self;
 
+			#[inline]
 			fn mul(self, rhs: Self) -> Self::Output {
 				use super::super::portable::packed_ghash_128::PackedBinaryGhash1x128b as PortablePackedBinaryGhash1x128b;
 

--- a/crates/field/src/arch/x86_64/packed_ghash_256.rs
+++ b/crates/field/src/arch/x86_64/packed_ghash_256.rs
@@ -40,6 +40,7 @@ cfg_if! {
 		impl Mul for PackedBinaryGhash2x128b {
 			type Output = Self;
 
+			#[inline]
 			fn mul(self, rhs: Self) -> Self::Output {
 				crate::tracing::trace_multiplication!(PackedBinaryGhash2x128b);
 
@@ -53,6 +54,7 @@ cfg_if! {
 		impl Mul for PackedBinaryGhash2x128b {
 			type Output = Self;
 
+			#[inline]
 			fn mul(self, rhs: Self) -> Self::Output {
 				crate::tracing::trace_multiplication!(PackedBinaryGhash2x128b);
 

--- a/crates/field/src/arch/x86_64/packed_ghash_512.rs
+++ b/crates/field/src/arch/x86_64/packed_ghash_512.rs
@@ -46,6 +46,7 @@ cfg_if! {
 		impl Mul for PackedBinaryGhash4x128b {
 			type Output = Self;
 
+			#[inline]
 			fn mul(self, rhs: Self) -> Self::Output {
 				crate::tracing::trace_multiplication!(PackedBinaryGhash4x128b);
 
@@ -59,6 +60,7 @@ cfg_if! {
 		impl Mul for PackedBinaryGhash4x128b {
 			type Output = Self;
 
+			#[inline]
 			fn mul(self, rhs: Self) -> Self::Output {
 				crate::tracing::trace_multiplication!(PackedBinaryGhash4x128b);
 


### PR DESCRIPTION
### TL;DR

Several changes to allow the compiler to inline the GHASH multiplications. As the multiplication function is small it is critical to make sure it;s inlined everywhere (without setting LTO to "fat") as it greatly affects the benchmark results. 

### What changed?

- Modified `run_google_mul_benchmark` in `field_mul.rs` to accept `impl Fn(U, U) -> U` instead of a function pointer `fn(U, U) -> U`
- Added `#[inline]` attributes to all `Mul` trait implementations for various packed field types:
  - `PackedBinaryGhash1x128b`
  - `PackedBinaryPolyval1x128b`
  - `PackedBinaryGhash2x128b`
  - `PackedBinaryGhash4x128b`

### How to test?

- Run the benchmarks to ensure they still work with the new function parameter type
- Verify that the code compiles and all tests pass

### Why make this change?

The `#[inline]` attributes help the compiler make better optimization decisions for these critical multiplication operations, potentially improving performance. Changing the benchmark function to accept `impl Fn` instead of a function pointer provides more flexibility, allowing it to work with closures and other callable types beyond just function pointers.