### PR TITLE
Add a ModReduce circuit for BigNum

### DIFF
--- a/crates/frontend/Cargo.toml
+++ b/crates/frontend/Cargo.toml
@@ -7,12 +7,15 @@ authors.workspace = true
 [lints]
 workspace = true
 
+[dependencies]
+num-bigint = "0.4"
+num-integer = "0.1"
+
 [dev-dependencies]
 rand = { workspace = true, features = ["std_rng", "thread_rng"] }
 hex-literal = "1.0.0"
 base64 = "0.21"
 hex = "0.4.3"
-num-bigint = "0.4"
 quickcheck = "1.0"
 quickcheck_macros = "1.0"
 proptest = { workspace = true }

--- a/crates/frontend/src/circuits/bignum/tests.rs
+++ b/crates/frontend/src/circuits/bignum/tests.rs
@@ -9,22 +9,6 @@ use crate::{
 	word::Word,
 };
 
-/// Convert a slice of u64 limbs (little-endian ordering) to a BigUint.
-///
-/// # Arguments
-/// * `slice` - Limbs in little-endian order (slice\[0\] is least significant)
-///
-/// # Returns
-/// The value as a `BigUint` for arbitrary precision arithmetic
-pub fn biguint_from_u64_slice(slice: &[u64]) -> BigUint {
-	BigUint::from_bytes_le(
-		&slice
-			.iter()
-			.flat_map(|&v| v.to_le_bytes())
-			.collect::<Vec<u8>>(),
-	)
-}
-
 /// Convert witness BigNum to BigUint for computation.
 ///
 /// This function is used during witness generation to extract the actual
@@ -38,7 +22,7 @@ pub fn biguint_from_u64_slice(slice: &[u64]) -> BigUint {
 /// The bignum value as a `BigUint`
 pub fn bignum_to_biguint(bignum: &BigNum, w: &WitnessFiller) -> BigUint {
 	let limb_vals: Vec<_> = bignum.limbs.iter().map(|&l| w[l].as_u64()).collect();
-	biguint_from_u64_slice(&limb_vals)
+	from_u64_limbs(limb_vals)
 }
 
 #[quickcheck]
@@ -193,8 +177,8 @@ fn test_mul_with_values(a_limbs: Vec<u64>, b_limbs: Vec<u64>) -> TestResult {
 		w[b.limbs[i]] = Word(val);
 	}
 
-	let a_big = biguint_from_u64_slice(&a_limbs);
-	let b_big = biguint_from_u64_slice(&b_limbs);
+	let a_big = from_u64_limbs(a_limbs);
+	let b_big = from_u64_limbs(b_limbs);
 	let expected = &a_big * &b_big;
 
 	cs.populate_wire_witness(&mut w).unwrap();
@@ -228,7 +212,7 @@ fn test_square_with_values(a_limbs: Vec<u64>) -> TestResult {
 		w[a.limbs[i]] = Word(val);
 	}
 
-	let a_big = biguint_from_u64_slice(&a_limbs);
+	let a_big = from_u64_limbs(a_limbs);
 	let expected = &a_big * &a_big;
 
 	cs.populate_wire_witness(&mut w).unwrap();
@@ -354,6 +338,101 @@ fn prop_compare_different(a_vals: Vec<u64>, b_vals: Vec<u64>) -> TestResult {
 	// Should be not equal (all 0s)
 	if w[result] != Word(0) {
 		return TestResult::error("Different values detected as equal".to_string());
+	}
+
+	if let Err(e) = verify_constraints(&cs.constraint_system(), &w.into_value_vec()) {
+		return TestResult::error(format!("Constraint verification failed: {e:?}"));
+	}
+
+	TestResult::passed()
+}
+
+#[test]
+fn test_mod_reduce() {
+	let builder = CircuitBuilder::new();
+
+	let a = BigNum {
+		limbs: vec![
+			builder.add_witness(),
+			builder.add_witness(),
+			builder.add_witness(),
+		],
+	};
+	let modulus = BigNum {
+		limbs: vec![builder.add_witness(), builder.add_witness()],
+	};
+
+	let (quotient, remainder) = mod_reduce(&builder, &a, &modulus);
+
+	let cs = builder.build();
+	let mut w = cs.new_witness_filler();
+
+	w[a.limbs[0]] = Word(0x0F1E2D3C4B5A6978);
+	w[a.limbs[1]] = Word(0xFEDCBA9876543210);
+	w[a.limbs[2]] = Word(0x123456789ABCDEF0);
+
+	w[modulus.limbs[0]] = Word(0x2222222222222222);
+	w[modulus.limbs[1]] = Word(0x1111111111111111);
+
+	cs.populate_wire_witness(&mut w).unwrap();
+
+	assert_eq!(w[quotient.limbs[0]].as_u64(), 0x111111111111101d, "Quotient limb 0 mismatch");
+	assert_eq!(w[quotient.limbs[1]].as_u64(), 0x0000000000000001, "Quotient limb 1 mismatch");
+	assert_eq!(w[quotient.limbs[2]].as_u64(), 0x0000000000000000, "Quotient limb 2 mismatch");
+	assert_eq!(w[remainder.limbs[0]].as_u64(), 0x77cb1e71c5186b9e, "Remainder limb 0 mismatch");
+	assert_eq!(w[remainder.limbs[1]].as_u64(), 0x0eca8641fdb97541, "Remainder limb 1 mismatch");
+
+	let a_big = bignum_to_biguint(&a, &w);
+	let modulus_big = bignum_to_biguint(&modulus, &w);
+	let actual_quotient = bignum_to_biguint(&quotient, &w);
+	let actual_remainder = bignum_to_biguint(&remainder, &w);
+
+	let reconstructed = &actual_quotient * &modulus_big + &actual_remainder;
+	assert_eq!(reconstructed, a_big, "Reconstruction mismatch");
+
+	verify_constraints(&cs.constraint_system(), &w.into_value_vec()).unwrap();
+}
+
+#[quickcheck]
+fn prop_mod_reduce(a_vals: Vec<u64>, mod_vals: Vec<u64>) -> TestResult {
+	if mod_vals.len() > a_vals.len() {
+		return TestResult::discard();
+	}
+
+	if mod_vals.iter().all(|&v| v == 0) {
+		return TestResult::discard();
+	}
+
+	let builder = CircuitBuilder::new();
+	let a = BigNum::new_witness(&builder, a_vals.len());
+	let modulus = BigNum::new_witness(&builder, mod_vals.len());
+
+	let (quotient, remainder) = mod_reduce(&builder, &a, &modulus);
+
+	let cs = builder.build();
+	let mut w = cs.new_witness_filler();
+
+	for (i, &val) in a_vals.iter().enumerate() {
+		w[a.limbs[i]] = Word(val);
+	}
+	for (i, &val) in mod_vals.iter().enumerate() {
+		w[modulus.limbs[i]] = Word(val);
+	}
+
+	if let Err(e) = cs.populate_wire_witness(&mut w) {
+		return TestResult::error(format!("Circuit execution failed: {e:?}"));
+	}
+
+	let a_big = bignum_to_biguint(&a, &w);
+	let modulus_big = bignum_to_biguint(&modulus, &w);
+	let quotient_big = bignum_to_biguint(&quotient, &w);
+	let remainder_big = bignum_to_biguint(&remainder, &w);
+
+	let reconstructed = &quotient_big * &modulus_big + &remainder_big;
+	if reconstructed != a_big {
+		return TestResult::error(format!(
+			"ModReduce failed: {a_big} != {quotient_big} * {modulus_big} + {remainder_big}"
+		));
 	}
 
 	if let Err(e) = verify_constraints(&cs.constraint_system(), &w.into_value_vec()) {

--- a/crates/frontend/src/compiler/mod.rs
+++ b/crates/frontend/src/compiler/mod.rs
@@ -5,8 +5,9 @@ use std::{
 	rc::Rc,
 };
 
+pub use gate::Gate;
 use gate::{
-	Assert0, AssertBand0, AssertEq, AssertEqCond, Band, Bor, Bxor, ExtractByte, Gate, Iadd32,
+	Assert0, AssertBand0, AssertEq, AssertEqCond, Band, Bor, Bxor, ExtractByte, Iadd32,
 	IaddCinCout, IcmpEq, IcmpUlt, Imul, Rotr32, Shl, Shr, Shr32,
 };
 
@@ -154,7 +155,7 @@ impl CircuitBuilder {
 		RefMut::map(self.shared.borrow_mut(), |shared| shared.as_mut().unwrap())
 	}
 
-	fn emit(&self, gate: impl Gate + 'static) {
+	pub fn emit(&self, gate: impl Gate + 'static) {
 		self.shared_mut().gates.push(Box::new(gate))
 	}
 


### PR DESCRIPTION
This abuses circuit Gates to populate the quotient and remainder
witnesses to avoid the user of the circuit to have to provide wires for
these. This simplifies the case in RSA where there are several
intermediate ModReduce circuits where only `a` and `modulus` wires are available.