### PR TITLE
[field] Remove the unused packed field types from the benchmarks

### DIFF
--- a/crates/field/benches/packed_field_invert.rs
+++ b/crates/field/benches/packed_field_invert.rs
@@ -5,11 +5,9 @@ mod packed_field_utils;
 use binius_field::{
 	PackedField,
 	arch::{
-		byte_sliced::*, packed_8::*, packed_16::*, packed_32::*, packed_64::*, packed_128::*,
-		packed_256::*, packed_512::*, packed_aes_8::*, packed_aes_16::*, packed_aes_32::*,
-		packed_aes_64::*, packed_aes_128::*, packed_aes_256::*, packed_aes_512::*,
-		packed_ghash_128::*, packed_ghash_256::*, packed_ghash_512::*, packed_polyval_128::*,
-		packed_polyval_256::*, packed_polyval_512::*,
+		byte_sliced::*, packed_128::*, packed_256::*, packed_512::*, packed_aes_128::*,
+		packed_aes_256::*, packed_aes_512::*, packed_ghash_128::*, packed_ghash_256::*,
+		packed_ghash_512::*, packed_polyval_128::*, packed_polyval_256::*, packed_polyval_512::*,
 	},
 };
 use cfg_if::cfg_if;

--- a/crates/field/benches/packed_field_linear_transform.rs
+++ b/crates/field/benches/packed_field_linear_transform.rs
@@ -3,11 +3,9 @@
 use binius_field::{
 	ExtensionField, Random,
 	arch::{
-		byte_sliced::*, packed_8::*, packed_16::*, packed_32::*, packed_64::*, packed_128::*,
-		packed_256::*, packed_512::*, packed_aes_8::*, packed_aes_16::*, packed_aes_32::*,
-		packed_aes_64::*, packed_aes_128::*, packed_aes_256::*, packed_aes_512::*,
-		packed_ghash_128::*, packed_ghash_256::*, packed_ghash_512::*, packed_polyval_128::*,
-		packed_polyval_256::*, packed_polyval_512::*,
+		byte_sliced::*, packed_128::*, packed_256::*, packed_512::*, packed_aes_128::*,
+		packed_aes_256::*, packed_aes_512::*, packed_ghash_128::*, packed_ghash_256::*,
+		packed_ghash_512::*, packed_polyval_128::*, packed_polyval_256::*, packed_polyval_512::*,
 	},
 	linear_transformation::{
 		FieldLinearTransformation, PackedTransformationFactory, Transformation,

--- a/crates/field/benches/packed_field_mul_alpha.rs
+++ b/crates/field/benches/packed_field_mul_alpha.rs
@@ -4,11 +4,9 @@ mod packed_field_utils;
 
 use binius_field::{
 	arch::{
-		byte_sliced::*, packed_8::*, packed_16::*, packed_32::*, packed_64::*, packed_128::*,
-		packed_256::*, packed_512::*, packed_aes_8::*, packed_aes_16::*, packed_aes_32::*,
-		packed_aes_64::*, packed_aes_128::*, packed_aes_256::*, packed_aes_512::*,
-		packed_ghash_128::*, packed_ghash_256::*, packed_ghash_512::*, packed_polyval_128::*,
-		packed_polyval_256::*, packed_polyval_512::*,
+		byte_sliced::*, packed_128::*, packed_256::*, packed_512::*, packed_aes_128::*,
+		packed_aes_256::*, packed_aes_512::*, packed_ghash_128::*, packed_ghash_256::*,
+		packed_ghash_512::*, packed_polyval_128::*, packed_polyval_256::*, packed_polyval_512::*,
 	},
 	arithmetic_traits::MulAlpha,
 };

--- a/crates/field/benches/packed_field_multiply.rs
+++ b/crates/field/benches/packed_field_multiply.rs
@@ -5,11 +5,9 @@ mod packed_field_utils;
 use std::ops::Mul;
 
 use binius_field::arch::{
-	byte_sliced::*, packed_8::*, packed_16::*, packed_32::*, packed_64::*, packed_128::*,
-	packed_256::*, packed_512::*, packed_aes_8::*, packed_aes_16::*, packed_aes_32::*,
-	packed_aes_64::*, packed_aes_128::*, packed_aes_256::*, packed_aes_512::*, packed_ghash_128::*,
-	packed_ghash_256::*, packed_ghash_512::*, packed_polyval_128::*, packed_polyval_256::*,
-	packed_polyval_512::*,
+	byte_sliced::*, packed_128::*, packed_256::*, packed_512::*, packed_aes_128::*,
+	packed_aes_256::*, packed_aes_512::*, packed_ghash_128::*, packed_ghash_256::*,
+	packed_ghash_512::*, packed_polyval_128::*, packed_polyval_256::*, packed_polyval_512::*,
 };
 use cfg_if::cfg_if;
 use criterion::criterion_main;

--- a/crates/field/benches/packed_field_square.rs
+++ b/crates/field/benches/packed_field_square.rs
@@ -5,11 +5,9 @@ mod packed_field_utils;
 use binius_field::{
 	PackedField,
 	arch::{
-		byte_sliced::*, packed_8::*, packed_16::*, packed_32::*, packed_64::*, packed_128::*,
-		packed_256::*, packed_512::*, packed_aes_8::*, packed_aes_16::*, packed_aes_32::*,
-		packed_aes_64::*, packed_aes_128::*, packed_aes_256::*, packed_aes_512::*,
-		packed_ghash_128::*, packed_ghash_256::*, packed_ghash_512::*, packed_polyval_128::*,
-		packed_polyval_256::*, packed_polyval_512::*,
+		byte_sliced::*, packed_128::*, packed_256::*, packed_512::*, packed_aes_128::*,
+		packed_aes_256::*, packed_aes_512::*, packed_ghash_128::*, packed_ghash_256::*,
+		packed_ghash_512::*, packed_polyval_128::*, packed_polyval_256::*, packed_polyval_512::*,
 	},
 };
 use cfg_if::cfg_if;

--- a/crates/field/benches/packed_field_utils.rs
+++ b/crates/field/benches/packed_field_utils.rs
@@ -194,24 +194,6 @@ macro_rules! benchmark_packed_operation {
 			bench_type @ $benchmark_type,
 			strategies @ $strategies,
 			packed_fields @ [
-				// 8-bit binary tower
-				PackedBinaryField1x8b
-
-				// 16-bit binary tower
-				PackedBinaryField2x8b
-				PackedBinaryField1x16b
-
-				// 32-bit binary tower
-				PackedBinaryField4x8b
-				PackedBinaryField2x16b
-				PackedBinaryField1x32b
-
-				// 64-bit binary tower
-				PackedBinaryField8x8b
-				PackedBinaryField4x16b
-				PackedBinaryField2x32b
-				PackedBinaryField1x64b
-
 				// 128-bit binary tower
 				PackedBinaryField16x8b
 				PackedBinaryField8x16b
@@ -232,24 +214,6 @@ macro_rules! benchmark_packed_operation {
 				PackedBinaryField16x32b
 				PackedBinaryField8x64b
 				PackedBinaryField4x128b
-
-				// 8-bit AES tower
-				PackedAESBinaryField1x8b
-
-				// 16-bit AES tower
-				PackedAESBinaryField2x8b
-				PackedAESBinaryField1x16b
-
-				// 32-bit AES tower
-				PackedAESBinaryField4x8b
-				PackedAESBinaryField2x16b
-				PackedAESBinaryField1x32b
-
-				// 64-bit AES tower
-				PackedAESBinaryField8x8b
-				PackedAESBinaryField4x16b
-				PackedAESBinaryField2x32b
-				PackedAESBinaryField1x64b
 
 				// 128-bit AES tower
 				PackedAESBinaryField16x8b


### PR DESCRIPTION
### TL;DR

Removed small-width packed field implementations from benchmarks. We never actually watched over those values, these types just consume compilation and run time.

### What changed?

Removed imports and benchmark configurations for smaller packed field implementations (8-bit, 16-bit, 32-bit, and 64-bit) from all benchmark files. The benchmarks now only include larger field implementations (128-bit, 256-bit, and 512-bit) which are more relevant for performance testing.

Specifically:
- Removed `packed_8::*`, `packed_16::*`, `packed_32::*`, `packed_64::*` imports
- Removed `packed_aes_8::*`, `packed_aes_16::*`, `packed_aes_32::*`, `packed_aes_64::*` imports
- Removed corresponding field types from the benchmark configuration in `packed_field_utils.rs`

### How to test?

Run the benchmarks to verify they still function correctly:
```
cargo bench --package binius-field
```

### Why make this change?

The smaller packed field implementations (8-bit through 64-bit) are less efficient for cryptographic operations compared to the larger implementations. By focusing benchmarks on the larger, more performant implementations (128-bit and above), we can reduce benchmark execution time while still measuring the performance characteristics of the most relevant implementations.