### PR TITLE
[field] Make `PackedDivisible` trait private

### DIFF
--- a/crates/field/src/packed_binary_field.rs
+++ b/crates/field/src/packed_binary_field.rs
@@ -871,7 +871,7 @@ pub mod test_utils {
 
 #[cfg(test)]
 mod tests {
-	use std::{iter::repeat_with, ops::Mul, slice};
+	use std::{iter::repeat_with, ops::Mul};
 
 	use binius_utils::{DeserializeBytes, SerializationMode, SerializeBytes, bytes::BytesMut};
 	use proptest::prelude::*;
@@ -886,7 +886,7 @@ mod tests {
 		*,
 	};
 	use crate::{
-		PackedField, PackedFieldIndexable, Random,
+		PackedField, Random,
 		arch::{
 			packed_aes_16::*, packed_aes_32::*, packed_aes_64::*, packed_aes_128::*,
 			packed_aes_256::*, packed_aes_512::*,
@@ -934,15 +934,6 @@ mod tests {
 		}
 	}
 
-	fn test_elements_order<P: PackedFieldIndexable>() {
-		let mut rng = StdRng::seed_from_u64(0);
-		let packed = P::random(&mut rng);
-		let scalars = P::unpack_scalars(slice::from_ref(&packed));
-		for (i, val) in scalars.iter().enumerate() {
-			assert_eq!(packed.get(i), *val, "index: {i}");
-		}
-	}
-
 	fn test_serialize_then_deserialize<P: PackedField + DeserializeBytes + SerializeBytes>() {
 		let mode = SerializationMode::Native;
 		let mut buffer = BytesMut::new();
@@ -978,13 +969,6 @@ mod tests {
 	}
 
 	#[test]
-	fn test_elements_order_32b() {
-		test_elements_order::<PackedBinaryField4x32b>();
-		test_elements_order::<PackedBinaryField8x32b>();
-		test_elements_order::<PackedBinaryField16x32b>();
-	}
-
-	#[test]
 	fn test_serialize_then_deserialize_32b() {
 		test_serialize_then_deserialize::<PackedBinaryField4x32b>();
 		test_serialize_then_deserialize::<PackedBinaryField8x32b>();
@@ -999,13 +983,6 @@ mod tests {
 	}
 
 	#[test]
-	fn test_elements_order_64b() {
-		test_elements_order::<PackedBinaryField2x64b>();
-		test_elements_order::<PackedBinaryField4x64b>();
-		test_elements_order::<PackedBinaryField8x64b>();
-	}
-
-	#[test]
 	fn test_serialize_then_deserialize_64b() {
 		test_serialize_then_deserialize::<PackedBinaryField2x64b>();
 		test_serialize_then_deserialize::<PackedBinaryField4x64b>();
@@ -1017,13 +994,6 @@ mod tests {
 		test_set_then_get::<PackedBinaryField1x128b>();
 		test_set_then_get::<PackedBinaryField2x128b>();
 		test_set_then_get::<PackedBinaryField4x128b>();
-	}
-
-	#[test]
-	fn test_elements_order_128b() {
-		test_elements_order::<PackedBinaryField1x128b>();
-		test_elements_order::<PackedBinaryField2x128b>();
-		test_elements_order::<PackedBinaryField4x128b>();
 	}
 
 	#[test]

--- a/crates/math/src/ntt/single_threaded.rs
+++ b/crates/math/src/ntt/single_threaded.rs
@@ -463,9 +463,7 @@ mod tests {
 	use std::iter::repeat_with;
 
 	use assert_matches::assert_matches;
-	use binius_field::{
-		BinaryField8b, BinaryField16b, Field, PackedBinaryField8x16b, PackedFieldIndexable, Random,
-	};
+	use binius_field::{BinaryField8b, BinaryField16b, Field, PackedBinaryField8x16b, Random};
 	use rand::{SeedableRng, rngs::StdRng};
 
 	use super::*;
@@ -549,7 +547,7 @@ mod tests {
 
 		let mut packed_copy = packed;
 
-		let unpacked = PackedBinaryField8x16b::unpack_scalars_mut(&mut packed_copy);
+		let unpacked: &mut [BinaryField16b; 8] = bytemuck::must_cast_mut(&mut packed_copy);
 
 		let shape = NTTShape {
 			log_x: 0,
@@ -571,7 +569,7 @@ mod tests {
 
 		let mut packed_copy = packed;
 
-		let unpacked = PackedBinaryField8x16b::unpack_scalars_mut(&mut packed_copy);
+		let unpacked: &mut [BinaryField16b; 8] = bytemuck::must_cast_mut(&mut packed_copy);
 
 		let shape = NTTShape {
 			log_x: 0,
@@ -593,7 +591,8 @@ mod tests {
 
 		let mut packed_copy = packed;
 
-		let unpacked = &mut PackedBinaryField8x16b::unpack_scalars_mut(&mut packed_copy)[0..4];
+		let unpacked =
+			&mut bytemuck::must_cast_mut::<_, [BinaryField16b; 8]>(&mut packed_copy)[0..4];
 
 		let shape = NTTShape {
 			log_x: 0,
@@ -615,7 +614,8 @@ mod tests {
 
 		let mut packed_copy = packed;
 
-		let unpacked = &mut PackedBinaryField8x16b::unpack_scalars_mut(&mut packed_copy)[0..4];
+		let unpacked =
+			&mut bytemuck::must_cast_mut::<_, [BinaryField16b; 8]>(&mut packed_copy)[0..4];
 
 		let shape = NTTShape {
 			log_x: 0,


### PR DESCRIPTION
### TL;DR

Make `PackedFieldIndexable` trait private and remove it's method. We still need this trait as a marker one for keep `unpack_if_possible` working which we may still need in the future.

### What changed?

- Converted `PackedFieldIndexable` from a trait with methods to a marker trait
- Removed the `unpack_scalars` and `unpack_scalars_mut` methods
- Removed the `PackedExtensionIndexable` trait entirely
- Converted `PackedDivisible` to a marker trait by removing its methods
- Updated tests to use `bytemuck::must_cast_mut` instead of the removed methods
- Removed unused imports and test functions that were relying on the removed functionality

### How to test?

- Run the existing test suite to ensure all functionality still works correctly
- Verify that code that previously used the removed methods has been properly updated to use alternative approaches

### Why make this change?

This change simplifies the codebase by removing unnecessary trait methods that were adding complexity without providing significant value. By converting these to marker traits, we maintain type safety while reducing the API surface. The functionality can be achieved through other means like `bytemuck::must_cast_mut`, as demonstrated in the updated tests.