### PR TITLE
Integer multiplication prove/verify

### DIFF
--- a/crates/prover/src/protocols/intmul/error.rs
+++ b/crates/prover/src/protocols/intmul/error.rs
@@ -1,9 +1,66 @@
 // Copyright 2025 Irreducible Inc.
 
+use crate::protocols::sumcheck::Error as SumcheckError;
+
+#[derive(Debug, Clone, Copy)]
+pub enum SumcheckErrorContext {
+	Execute,
+	Fold,
+	Finish,
+}
+
+impl Error {
+	pub fn from_sumcheck_new(error: SumcheckError) -> Self {
+		Error::Sumcheck(error, SumcheckErrorContext::Execute)
+	}
+
+	pub fn from_sumcheck_batch(error: SumcheckError) -> Self {
+		Error::Sumcheck(error, SumcheckErrorContext::Execute)
+	}
+}
+
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
 	#[error("Exponent length should be a power of two")]
 	ExponentsPowerOfTwoLengthRequired,
 	#[error("All exponent slices must have the same length")]
 	ExponentLengthMismatch,
+	#[error("transcript error")]
+	Transcript(#[from] binius_transcript::Error),
+	#[error("length mismatch: {0} != {1}")]
+	LengthMismatch(usize, usize),
+	#[error("twisted eval points count ({0}) does not match claims count ({1})")]
+	TwistedPointsEvalsMismatch(usize, usize),
+	#[error("layer length ({0}) does not match pairs count ({1})")]
+	LayerClaimsMismatch(usize, usize),
+	#[error("composition claim mismatch")]
+	CompositionClaimMismatch,
+	#[error("final claims count ({0}) does not match pairs count * 2 ({1})")]
+	FinalClaimsPairsMismatch(usize, usize),
+	#[error("round coeffs count ({0}) does not match pairs count ({1})")]
+	RoundCoeffsPairsMismatch(usize, usize),
+	#[error("sumcheck error: {0} ({1:?})")]
+	Sumcheck(SumcheckError, SumcheckErrorContext),
+	#[error("buffer log len ({0}) and eval point len ({1}) mismatch")]
+	BufferEvalPointMismatch(usize, usize),
+	#[error("layer pairs count ({0}) does not match claims count ({1})")]
+	LayerPairsCountClaimsMismatch(usize, usize),
+	#[error("eval point and buffer log len mismatch")]
+	EvalPointBufferLengthMismatch,
+	#[error("multilinears do not have equal number of variables")]
+	MultilinearSizeMismatch,
+	#[error("number of eval claims does not match the number of multilinears")]
+	EvalClaimsNumberMismatch,
+	#[error("expected execute() call")]
+	ExpectedExecute,
+	#[error("expected fold() call")]
+	ExpectedFold,
+	#[error("expected finish() call")]
+	ExpectedFinish,
+	#[error("math error: {0}")]
+	Math(#[from] binius_math::Error),
+	#[error("layers empty")]
+	LayersEmpty,
+	#[error("last layer empty")]
+	LastLayerEmpty,
 }

--- a/crates/prover/src/protocols/intmul/mod.rs
+++ b/crates/prover/src/protocols/intmul/mod.rs
@@ -1,4 +1,8 @@
 // Copyright 2025 Irreducible Inc.
 
 mod error;
+pub mod prove;
 pub mod witness;
+
+#[cfg(test)]
+mod tests;

--- a/crates/prover/src/protocols/intmul/prove.rs
+++ b/crates/prover/src/protocols/intmul/prove.rs
@@ -1,0 +1,409 @@
+// Copyright 2025 Irreducible Inc.
+
+use std::marker::PhantomData;
+
+use binius_field::{BinaryField, PackedField};
+use binius_math::{field_buffer::FieldBuffer, multilinear::evaluate::evaluate};
+use binius_transcript::{
+	ProverTranscript,
+	fiat_shamir::{CanSample, Challenger},
+};
+use binius_utils::bitwise::Bitwise;
+use binius_verifier::protocols::{
+	intmul::common::{
+		IntMulOutput, Phase1Output, Phase2Output, Phase3Output, Phase4Output, Phase5Output,
+		frobenius_twist, make_phase_3_output, normalize_a_c_exponent_evals,
+	},
+	sumcheck::common::BatchSumcheckOutput,
+};
+use either::Either;
+use itertools::{Itertools, izip};
+
+use super::{error::Error, witness::Witness};
+use crate::protocols::sumcheck::{
+	MleToSumCheckDecorator,
+	batch::batch_prove,
+	bivariate_product_mle::BivariateProductMlecheckProver,
+	bivariate_product_multi_mle::BivariateProductMultiMlecheckProver,
+	rerand_mle::RerandMlecheckProver,
+	selector_mle::{Claim, SelectorMlecheckProver},
+};
+
+/// A helper structure that encapsulates switchover settings and the prover transcript for
+/// the integer multiplication protocol.
+pub struct IntMulProver<'a, P, B, S, C: Challenger> {
+	_p_marker: PhantomData<P>,
+	_b_marker: PhantomData<B>,
+	_s_marker: PhantomData<S>,
+
+	switchover: usize,
+	transcript: &'a mut ProverTranscript<C>,
+}
+
+impl<'a, P, B, S, C: Challenger> IntMulProver<'a, P, B, S, C> {
+	pub fn new(switchover: usize, transcript: &'a mut ProverTranscript<C>) -> Self {
+		Self {
+			_p_marker: PhantomData,
+			_b_marker: PhantomData,
+			_s_marker: PhantomData,
+			switchover,
+			transcript,
+		}
+	}
+}
+
+impl<'a, F, P, B, S, C> IntMulProver<'a, P, B, S, C>
+where
+	F: BinaryField,
+	P: PackedField<Scalar = F>,
+	B: Bitwise,
+	S: AsRef<[B]>,
+	C: Challenger,
+{
+	/// Prove an integer multiplication statement.
+	///
+	/// This method consumes a `Witness` in order to reduce integer multiplication statement to
+	/// evaluation claims on 1-bit multilinears. More formally:
+	///  * `witness` contains po2-sized integer arrays  `a`, `b`, `c_lo` and `c_hi` that satisfy `a
+	///    * b = c_lo | c_hi << (1 << log_bits)`, as well as the layers of the constant- and
+	///      variable-base GKR product check circuits
+	///  * The proving consists of five phases:
+	///    - Phase 1: GKR tree roots for B & C are evaluated at a sampled point, after which
+	///      reductions are performed to obtain evaluation claims on $(b * (G^{a_i} - 1) + 1)^{2^i}$
+	///    - Phase 2: Frobenius twist is applied to obtain claims on $b * (G^{a_i} - 1) + 1$
+	///    - Phase 3: Two batched sumchecks:
+	///      - Selector mlecheck to reduce claims on $b * (G^{a_i} - 1) + 1$ to claims on $G^{a_i}$
+	///        and $b$
+	///      - First layer of GPA reduction for the `c_lo || c_hi` combined `c` tree
+	///    - Phase 4: Batching all but last layers and `a`, `c_lo` and `c_hi`
+	///    - Phase 5: Proving the last (widest) layers of `a`, `c_lo` and `c_hi` batched with
+	///      rerandomization degree-1 mlecheck on `b` evaluations from phase 3
+	///
+	/// The output of this protocol is a set of evaluation claims on the `b` selectors representing
+	/// all of `a`, `b`, `c_lo` and `c_hi` as column-major bit matrices, at a common evaluation
+	/// point.
+	pub fn prove(&mut self, witness: Witness<P, B, S>) -> Result<IntMulOutput<F>, Error> {
+		let Witness {
+			a,
+			b,
+			c_lo,
+			c_hi,
+			c_root,
+		} = witness;
+
+		let (n_vars, log_bits) = (c_root.log_len(), a.log_bits());
+		assert!(log_bits >= 1);
+
+		let initial_eval_point = self.transcript.sample_vec(n_vars);
+
+		let (b_exponents, b_root, b_layers) = b.split();
+
+		let b_eval = evaluate(&b_root, &initial_eval_point)?;
+		let c_eval = evaluate(&c_root, &initial_eval_point)?;
+
+		self.transcript.message().write_scalar(b_eval);
+		self.transcript.message().write_scalar(c_eval);
+
+		// phase 1
+		let Phase1Output {
+			eval_point: phase1_eval_point,
+			b_leaves_evals,
+		} = self.phase1(log_bits, &initial_eval_point, (b_eval, b_layers.into_iter()))?;
+
+		// phase 2
+		let Phase2Output { twisted_claims } =
+			frobenius_twist(log_bits, &phase1_eval_point, &b_leaves_evals);
+
+		// splitting
+		let (_, a_root, mut a_layers) = a.split();
+		let (_, c_lo_root, mut c_lo_layers) = c_lo.split();
+		let (_, c_hi_root, mut c_hi_layers) = c_hi.split();
+
+		let a_last_layer = a_layers.pop().expect("log_bits >= 1");
+		let c_lo_last_layer = c_lo_layers.pop().expect("log_bits >= 1");
+		let c_hi_last_layer = c_hi_layers.pop().expect("log_bits >= 1");
+
+		// phase 3
+		let Phase3Output {
+			eval_point: phase3_eval_point,
+			b_exponent_evals,
+			selector_eval,
+			c_lo_root_eval,
+			c_hi_root_eval,
+		} = self.phase3(
+			log_bits,
+			&twisted_claims,
+			a_root,
+			b_exponents.as_ref(),
+			[c_lo_root, c_hi_root],
+			&initial_eval_point,
+			c_eval,
+		)?;
+
+		// phase 4
+		let Phase4Output {
+			eval_point: phase4_eval_point,
+			a_evals,
+			c_lo_evals,
+			c_hi_evals,
+		} = self.phase4(
+			log_bits,
+			&phase3_eval_point,
+			(selector_eval, a_layers.into_iter()),
+			(c_lo_root_eval, c_lo_layers.into_iter()),
+			(c_hi_root_eval, c_hi_layers.into_iter()),
+		)?;
+
+		// phase 5
+		let Phase5Output {
+			eval_point: phase5_eval_point,
+			scaled_a_c_exponent_evals,
+			b_exponent_evals,
+		} = self.phase5(
+			log_bits,
+			&phase4_eval_point,
+			(&a_evals, a_last_layer),
+			(&c_lo_evals, c_lo_last_layer),
+			(&c_hi_evals, c_hi_last_layer),
+			b_exponents.as_ref(),
+			&phase3_eval_point,
+			&b_exponent_evals,
+		)?;
+
+		// normalize_a_c_exponent_evals
+		let (a_exponent_evals, c_lo_exponent_evals, c_hi_exponent_evals) =
+			normalize_a_c_exponent_evals(log_bits, scaled_a_c_exponent_evals);
+
+		Ok(IntMulOutput {
+			eval_point: phase5_eval_point,
+			a_exponent_evals,
+			b_exponent_evals,
+			c_lo_exponent_evals,
+			c_hi_exponent_evals,
+		})
+	}
+
+	fn phase1(
+		&mut self,
+		log_bits: usize,
+		eval_point: &[F],
+		(b_root_eval, b_layers): (F, impl ExactSizeIterator<Item = Vec<FieldBuffer<P>>>),
+	) -> Result<Phase1Output<F>, Error> {
+		assert_eq!(b_layers.len(), log_bits);
+		let mut eval_point = eval_point.to_vec();
+		let mut evals = vec![b_root_eval];
+
+		for (depth, layer) in b_layers.enumerate() {
+			assert_eq!(evals.len(), 1 << depth);
+			assert_eq!(layer.len(), 2 << depth);
+
+			let a_sumcheck_prover =
+				BivariateProductMultiMlecheckProver::new(make_pairs(layer), &eval_point, &evals)
+					.map_err(Error::from_sumcheck_new)?;
+
+			let a_prover = MleToSumCheckDecorator::new(a_sumcheck_prover);
+
+			let BatchSumcheckOutput {
+				challenges,
+				mut multilinear_evals,
+			} = batch_prove(vec![a_prover], self.transcript).map_err(Error::from_sumcheck_new)?;
+
+			assert_eq!(multilinear_evals.len(), 1);
+
+			eval_point = challenges;
+			evals = multilinear_evals
+				.pop()
+				.expect("multilinear_evals.len() == 1");
+		}
+
+		assert_eq!(evals.len(), 1 << log_bits);
+
+		Ok(Phase1Output {
+			eval_point,
+			b_leaves_evals: evals,
+		})
+	}
+
+	#[allow(clippy::too_many_arguments)]
+	fn phase3(
+		&mut self,
+		log_bits: usize,
+		twisted_claims: &[(Vec<F>, F)],
+		selector: FieldBuffer<P>,
+		b_exponents: &[B],
+		c_lo_hi_roots: [FieldBuffer<P>; 2],
+		c_eval_point: &[F],
+		c_root_eval: F,
+	) -> Result<Phase3Output<F>, Error> {
+		let n_vars = selector.log_len();
+		assert!(
+			twisted_claims
+				.iter()
+				.all(|(point, _)| point.len() == n_vars)
+		);
+		assert_eq!(b_exponents.len(), 1 << n_vars);
+
+		let selector_claims = twisted_claims
+			.iter()
+			.map(|&(ref point, value)| Claim {
+				point: point.clone(),
+				value,
+			})
+			.collect();
+
+		let selector_prover =
+			SelectorMlecheckProver::new(selector, selector_claims, b_exponents, self.switchover)
+				.map_err(Error::from_sumcheck_new)?;
+
+		let c_root_sumcheck_prover =
+			BivariateProductMlecheckProver::new(c_lo_hi_roots, c_eval_point, c_root_eval)
+				.map_err(Error::from_sumcheck_new)?;
+
+		let c_root_prover = MleToSumCheckDecorator::new(c_root_sumcheck_prover);
+
+		let provers = vec![Either::Left(selector_prover), Either::Right(c_root_prover)];
+		let BatchSumcheckOutput {
+			challenges,
+			mut multilinear_evals,
+		} = batch_prove(provers, self.transcript).map_err(Error::from_sumcheck_batch)?;
+
+		assert_eq!(multilinear_evals.len(), 2);
+		let c_root_prover_evals = multilinear_evals
+			.pop()
+			.expect("multilinear_evals.len() == 2");
+		let selector_prover_evals = multilinear_evals
+			.pop()
+			.expect("multilinear_evals.len() == 2");
+
+		Ok(make_phase_3_output(log_bits, &challenges, &selector_prover_evals, &c_root_prover_evals))
+	}
+
+	fn phase4(
+		&mut self,
+		log_bits: usize,
+		eval_point: &[F],
+		(a_root_eval, a_layers): (F, impl ExactSizeIterator<Item = Vec<FieldBuffer<P>>>),
+		(c_lo_root_eval, c_lo_layers): (F, impl ExactSizeIterator<Item = Vec<FieldBuffer<P>>>),
+		(c_hi_root_eval, c_hi_layers): (F, impl ExactSizeIterator<Item = Vec<FieldBuffer<P>>>),
+	) -> Result<Phase4Output<F>, Error> {
+		assert_eq!(a_layers.len(), log_bits - 1);
+		assert_eq!(c_lo_layers.len(), log_bits - 1);
+		assert_eq!(c_hi_layers.len(), log_bits - 1);
+
+		let mut eval_point = eval_point.to_vec();
+		let mut evals = vec![a_root_eval, c_lo_root_eval, c_hi_root_eval];
+
+		for (depth, (a_l, c_lo_l, c_hi_l)) in izip!(a_layers, c_lo_layers, c_hi_layers).enumerate()
+		{
+			assert_eq!(a_l.len(), 2 << depth);
+			assert_eq!(c_lo_l.len(), 2 << depth);
+			assert_eq!(c_hi_l.len(), 2 << depth);
+			assert_eq!(evals.len(), 3 << depth);
+
+			let layer = [a_l, c_lo_l, c_hi_l].concat();
+			let sumcheck_prover =
+				BivariateProductMultiMlecheckProver::new(make_pairs(layer), &eval_point, &evals)
+					.map_err(Error::from_sumcheck_new)?;
+
+			let prover = MleToSumCheckDecorator::new(sumcheck_prover);
+
+			let BatchSumcheckOutput {
+				challenges,
+				mut multilinear_evals,
+			} = batch_prove(vec![prover], self.transcript).map_err(Error::from_sumcheck_batch)?;
+
+			assert_eq!(multilinear_evals.len(), 1);
+			eval_point = challenges;
+			evals = multilinear_evals
+				.pop()
+				.expect("multilinear_evals.len() == 1");
+		}
+
+		debug_assert_eq!(evals.len(), 3 << (log_bits - 1));
+		let c_hi_evals = evals.split_off(2 << (log_bits - 1));
+		let c_lo_evals = evals.split_off(1 << (log_bits - 1));
+		let a_evals = evals;
+
+		Ok(Phase4Output {
+			eval_point,
+			a_evals,
+			c_lo_evals,
+			c_hi_evals,
+		})
+	}
+
+	#[allow(clippy::too_many_arguments)]
+	fn phase5(
+		&mut self,
+		log_bits: usize,
+		a_c_eval_point: &[F],
+		(a_evals, a_layer): (&[F], Vec<FieldBuffer<P>>),
+		(c_lo_evals, c_lo_layer): (&[F], Vec<FieldBuffer<P>>),
+		(c_hi_evals, c_hi_layer): (&[F], Vec<FieldBuffer<P>>),
+		b_exponents: &[B],
+		b_eval_point: &[F],
+		b_exponent_evals: &[F],
+	) -> Result<Phase5Output<F>, Error> {
+		assert!(log_bits >= 1);
+		assert_eq!(1 << log_bits, a_layer.len());
+		assert_eq!(2 * a_evals.len(), a_layer.len());
+		assert_eq!(2 * c_lo_evals.len(), c_lo_layer.len());
+		assert_eq!(2 * c_hi_evals.len(), c_hi_layer.len());
+		assert_eq!(b_eval_point.len(), a_layer.first().expect("log_bits >= 1").log_len());
+		assert_eq!(a_c_eval_point.len(), b_eval_point.len());
+
+		let layer = [a_layer, c_lo_layer, c_hi_layer].concat();
+		let evals = [a_evals, c_lo_evals, c_hi_evals].concat();
+
+		let a_c_sumcheck_prover =
+			BivariateProductMultiMlecheckProver::new(make_pairs(layer), a_c_eval_point, &evals)
+				.map_err(Error::from_sumcheck_new)?;
+
+		let a_c_prover = MleToSumCheckDecorator::new(a_c_sumcheck_prover);
+
+		assert_eq!(b_exponents.len(), 1 << b_eval_point.len());
+		assert_eq!(b_exponent_evals.len(), 1 << log_bits);
+
+		let b_sumcheck_prover = RerandMlecheckProver::<P, _>::new(
+			b_eval_point,
+			b_exponent_evals,
+			b_exponents,
+			self.switchover,
+		)
+		.map_err(Error::from_sumcheck_new)?;
+
+		let b_prover = MleToSumCheckDecorator::new(b_sumcheck_prover);
+
+		let BatchSumcheckOutput {
+			challenges,
+			mut multilinear_evals,
+		} = batch_prove(vec![Either::Left(a_c_prover), Either::Right(b_prover)], self.transcript)
+			.map_err(Error::from_sumcheck_batch)?;
+
+		assert_eq!(multilinear_evals.len(), 2);
+		let b_prover_evals = multilinear_evals
+			.pop()
+			.expect("multilinear_evals.len() == 2");
+		let a_c_prover_evals = multilinear_evals
+			.pop()
+			.expect("multilinear_evals.len() == 2");
+
+		assert_eq!(a_c_prover_evals.len(), 3 << log_bits);
+		assert_eq!(b_prover_evals.len(), 1 << log_bits);
+
+		Ok(Phase5Output {
+			eval_point: challenges,
+			scaled_a_c_exponent_evals: a_c_prover_evals,
+			b_exponent_evals: b_prover_evals,
+		})
+	}
+}
+
+fn make_pairs<T>(layer: Vec<T>) -> Vec<[T; 2]> {
+	layer
+		.into_iter()
+		.chunks(2)
+		.into_iter()
+		.map(|chunk| chunk.collect_array().expect("chunk.len() == 2"))
+		.collect()
+}

--- a/crates/prover/src/protocols/intmul/tests.rs
+++ b/crates/prover/src/protocols/intmul/tests.rs
@@ -1,0 +1,82 @@
+// Copyright 2025 Irreducible Inc.
+
+use binius_field::{BinaryField128b, PackedBinaryField2x128b, PackedField};
+
+use super::{prove::IntMulProver, witness::Witness};
+
+type F = BinaryField128b;
+type P = PackedBinaryField2x128b;
+
+use binius_math::{FieldBuffer, multilinear::evaluate::evaluate};
+use binius_transcript::ProverTranscript;
+use binius_verifier::{config::StdChallenger, protocols::intmul::verify};
+
+pub fn make_bit_multilinear<P: PackedField>(i: usize, exp: &[u64]) -> FieldBuffer<P> {
+	let packed_elements = exp
+		.iter()
+		.map(|exp| {
+			if exp & (1 << i) == 0 {
+				P::Scalar::zero()
+			} else {
+				P::Scalar::one()
+			}
+		})
+		.collect::<Vec<_>>();
+	FieldBuffer::from_values(&packed_elements).expect("input length is power of 2")
+}
+
+#[test]
+fn prove_and_verify() {
+	use rand::{Rng, SeedableRng, rngs::StdRng};
+
+	let mut rng = StdRng::seed_from_u64(0);
+
+	const LOG_BITS: usize = 6;
+	const LOG_EXPONENTS: usize = 5;
+	const NUM_EXPONENTS: usize = 1 << LOG_EXPONENTS;
+	let mut a = Vec::with_capacity(NUM_EXPONENTS);
+	let mut b = Vec::with_capacity(NUM_EXPONENTS);
+	let mut c_lo = Vec::with_capacity(NUM_EXPONENTS);
+	let mut c_hi = Vec::with_capacity(NUM_EXPONENTS);
+
+	for _ in 0..NUM_EXPONENTS {
+		let a_i = rng.random_range(1..u64::MAX);
+		let b_i = rng.random_range(1..u64::MAX);
+
+		let full_result = (a_i as u128) * (b_i as u128);
+
+		let c_lo_i = full_result as u64;
+		let c_hi_i = (full_result >> 64) as u64;
+
+		a.push(a_i);
+		b.push(b_i);
+		c_lo.push(c_lo_i);
+		c_hi.push(c_hi_i);
+	}
+
+	let witness = Witness::<P, _, _>::new(LOG_BITS, &a, &b, &c_lo, &c_hi).unwrap();
+	// run prover
+	let mut prover_transcript = ProverTranscript::<StdChallenger>::default();
+	let mut prover = IntMulProver::new(0, &mut prover_transcript);
+	let prove_output = prover.prove(witness).unwrap();
+
+	// check prover output is consistent with input
+	let check_evals = |exponents: &[u64], given_evals: &[F]| {
+		for i in 0..64 {
+			let field_buffer = make_bit_multilinear::<P>(i, exponents);
+			let expected_eval = evaluate(&field_buffer, &prove_output.eval_point).unwrap();
+			assert_eq!(expected_eval, given_evals[i]);
+		}
+	};
+	check_evals(&a, &prove_output.a_exponent_evals);
+	check_evals(&b, &prove_output.b_exponent_evals);
+	check_evals(&c_lo, &prove_output.c_lo_exponent_evals);
+	check_evals(&c_hi, &prove_output.c_hi_exponent_evals);
+
+	// run verifier
+	let mut verifier_transcript = prover_transcript.into_verifier();
+	let verify_output = verify::verify(LOG_BITS, LOG_EXPONENTS, &mut verifier_transcript).unwrap();
+
+	// check verifier output is consistent with prover output
+	assert_eq!(prove_output, verify_output);
+}

--- a/crates/prover/src/protocols/intmul/witness.rs
+++ b/crates/prover/src/protocols/intmul/witness.rs
@@ -34,11 +34,11 @@ use super::error::Error;
 #[derive(Getters)]
 #[getset(get = "pub")]
 pub struct Witness<P: PackedField, B: Bitwise, S: AsRef<[B]>> {
-	a: BinaryTree<P, B, S>,
-	b: BinaryTree<P, B, S>,
-	c_lo: BinaryTree<P, B, S>,
-	c_hi: BinaryTree<P, B, S>,
-	c_root: FieldBuffer<P>,
+	pub a: BinaryTree<P, B, S>,
+	pub b: BinaryTree<P, B, S>,
+	pub c_lo: BinaryTree<P, B, S>,
+	pub c_hi: BinaryTree<P, B, S>,
+	pub c_root: FieldBuffer<P>,
 }
 
 impl<F, P, B, S> Witness<P, B, S>
@@ -106,7 +106,6 @@ where
 /// Tree is laid out from root to the leaves. `IntoIterator` follows this convention.
 #[derive(Debug, IntoIterator)]
 pub struct BinaryTree<P: PackedField, B: Bitwise, S: AsRef<[B]>> {
-	#[allow(dead_code)]
 	exponents: S,
 	#[into_iterator(owned)]
 	tree: Vec<Vec<FieldBuffer<P>>>,
@@ -202,7 +201,11 @@ where
 		}
 	}
 
-	fn root(&self) -> &FieldBuffer<P> {
+	pub fn log_bits(&self) -> usize {
+		self.tree.len() - 1
+	}
+
+	pub fn root(&self) -> &FieldBuffer<P> {
 		let first_layer = self
 			.tree
 			.first()
@@ -210,6 +213,13 @@ where
 		assert_eq!(first_layer.len(), 1);
 
 		first_layer.first().expect("first_layer.len() == 1")
+	}
+
+	pub fn split(mut self) -> (S, FieldBuffer<P>, Vec<Vec<FieldBuffer<P>>>) {
+		let rest = self.tree.split_off(1);
+		let mut root_layer = self.tree.pop().expect("exactly one element");
+		let root = root_layer.pop().expect("exactly one element");
+		(self.exponents, root, rest)
 	}
 }
 

--- a/crates/prover/src/protocols/sumcheck/selector_mle.rs
+++ b/crates/prover/src/protocols/sumcheck/selector_mle.rs
@@ -220,14 +220,14 @@ where
 
 		let mut multilinear_evals = Vec::with_capacity(self.gruen34s.len() + 1);
 
-		debug_assert_eq!(self.selected.log_len(), 0);
-		multilinear_evals.push(self.selected.get(0).expect("multilinear.len() == 1"));
-
 		for selector in self.switchover.finalize()? {
 			debug_assert_eq!(selector.log_len(), 0);
 			let eval = selector.get(0).expect("selector.len() == 1");
 			multilinear_evals.push(eval);
 		}
+
+		debug_assert_eq!(self.selected.log_len(), 0);
+		multilinear_evals.push(self.selected.get(0).expect("multilinear.len() == 1"));
 
 		Ok(multilinear_evals)
 	}

--- a/crates/verifier/Cargo.toml
+++ b/crates/verifier/Cargo.toml
@@ -13,6 +13,7 @@ binius-frontend = { path = "../frontend" }
 binius-math = { path = "../math" }
 binius-transcript = { path = "../transcript" }
 binius-utils = { path = "../utils" }
+blake2.workspace = true
 bytemuck.workspace = true
 bytes.workspace = true
 digest.workspace = true
@@ -25,3 +26,4 @@ thiserror.workspace = true
 assert_matches.workspace = true
 binius-math = { path = "../math", features = ["test-utils"] }
 rand = { workspace = true, features = ["std_rng"] }
+itertools.workspace = true

--- a/crates/verifier/src/protocols/intmul/common.rs
+++ b/crates/verifier/src/protocols/intmul/common.rs
@@ -1,0 +1,138 @@
+// Copyright 2025 Irreducible Inc.
+
+use binius_field::{BinaryField, Field};
+use itertools::{iterate, izip};
+
+#[derive(Debug, PartialEq)]
+pub struct IntMulOutput<F> {
+	pub eval_point: Vec<F>,
+	pub a_exponent_evals: Vec<F>,
+	pub b_exponent_evals: Vec<F>,
+	pub c_lo_exponent_evals: Vec<F>,
+	pub c_hi_exponent_evals: Vec<F>,
+}
+
+pub struct Phase1Output<F> {
+	pub eval_point: Vec<F>,
+	pub b_leaves_evals: Vec<F>,
+}
+
+pub struct Phase2Output<F> {
+	pub twisted_claims: Vec<(Vec<F>, F)>,
+}
+
+#[derive(Debug, Clone)]
+pub struct Phase3Output<F> {
+	pub eval_point: Vec<F>,
+	pub b_exponent_evals: Vec<F>,
+	pub selector_eval: F,
+	pub c_lo_root_eval: F,
+	pub c_hi_root_eval: F,
+}
+
+pub fn make_phase_3_output<F: Field>(
+	log_bits: usize,
+	eval_point: &[F],
+	selector_prover_evals: &[F],
+	c_root_prover_evals: &[F],
+) -> Phase3Output<F> {
+	assert_eq!(selector_prover_evals.len(), 1 + (1 << log_bits));
+	let (&selector_eval, b_exponent_evals) = selector_prover_evals
+		.split_last()
+		.expect("non-empty selector sumcheck output");
+
+	let eval_point = eval_point.to_vec();
+	let b_exponent_evals = b_exponent_evals.to_vec();
+
+	let &[c_lo_root_eval, c_hi_root_eval] = c_root_prover_evals else {
+		panic!("expect two multilinears in the c_root prover in phase 3");
+	};
+
+	Phase3Output {
+		eval_point,
+		b_exponent_evals,
+		selector_eval,
+		c_lo_root_eval,
+		c_hi_root_eval,
+	}
+}
+
+pub struct Phase4Output<F> {
+	pub eval_point: Vec<F>,
+	pub a_evals: Vec<F>,
+	pub c_lo_evals: Vec<F>,
+	pub c_hi_evals: Vec<F>,
+}
+
+pub struct Phase5Output<F> {
+	pub eval_point: Vec<F>,
+	pub scaled_a_c_exponent_evals: Vec<F>,
+	pub b_exponent_evals: Vec<F>,
+}
+
+/// Applying the inverse of $\phi^$ to the selector columns.
+pub fn frobenius_twist<F: BinaryField>(
+	log_bits: usize,
+	eval_point: &[F],
+	evals: &[F],
+) -> Phase2Output<F> {
+	let inv_phi = |arg: F, i: usize| {
+		iterate(arg, |g| g.square())
+			.nth(F::DEGREE - i)
+			.expect("infinite iterator")
+	};
+
+	assert_eq!(evals.len(), 1 << log_bits);
+	let twisted_claims = evals
+		.iter()
+		.enumerate()
+		.map(|(i, &eval)| {
+			let twisted_eval = inv_phi(eval, i);
+			let twisted_eval_point = eval_point.iter().map(|&coord| inv_phi(coord, i)).collect();
+			(twisted_eval_point, twisted_eval)
+		})
+		.collect();
+
+	Phase2Output { twisted_claims }
+}
+
+pub fn normalize_a_c_exponent_evals<F: BinaryField>(
+	log_bits: usize,
+	evals: Vec<F>,
+) -> (Vec<F>, Vec<F>, Vec<F>) {
+	assert_eq!(evals.len(), 3 << log_bits);
+
+	// for i in 0..1 << log_bits: evals[i] = (1-EvalMLE_i)*1 + EvalMLE_i*g^{2^i} =
+	// EvalMLE_i*(g^{2^i}-1) + 1 where EvalMLE_i is the evaluation of the multilinear extension of
+	// bit i of the exponents of `a` (the point of evaluation is irrelevant in this function)
+	// we can then compute desired evaluation EvalMLE_i as (evals[i] - 1) / (g^{2^i}-1)
+	// similarly for `c` for evals[1 << log_bits..3 << log_bits] and i in 0..2 << log_bits
+
+	let mut a_scaled_evals = evals;
+	let mut c_lo_scaled_evals = a_scaled_evals.split_off(1 << log_bits);
+	let mut c_hi_scaled_evals = c_lo_scaled_evals.split_off(1 << log_bits);
+
+	let conjugates = iterate(F::MULTIPLICATIVE_GENERATOR, |g| g.square())
+		.take(2 << log_bits)
+		.collect::<Vec<_>>();
+
+	let (lo_conjugates, hi_conjugates) = conjugates.split_at(1 << log_bits);
+
+	fn normalize<F: Field>(eval: &mut F, conjugate: F) {
+		*eval -= F::ONE;
+		*eval *= (conjugate - F::ONE).invert().expect("non-zero");
+	}
+
+	for (&conjugate, a_eval, c_lo_eval) in
+		izip!(lo_conjugates, &mut a_scaled_evals, &mut c_lo_scaled_evals)
+	{
+		normalize(a_eval, conjugate);
+		normalize(c_lo_eval, conjugate);
+	}
+
+	for (&conjugate, c_hi_eval) in izip!(hi_conjugates, &mut c_hi_scaled_evals) {
+		normalize(c_hi_eval, conjugate);
+	}
+
+	(a_scaled_evals, c_lo_scaled_evals, c_hi_scaled_evals)
+}

--- a/crates/verifier/src/protocols/intmul/error.rs
+++ b/crates/verifier/src/protocols/intmul/error.rs
@@ -1,0 +1,38 @@
+// Copyright 2025 Irreducible Inc.
+
+use crate::protocols::sumcheck::Error as SumcheckError;
+
+impl Error {
+	pub fn from_transcript_read(error: binius_transcript::Error) -> Self {
+		Error::TranscriptError(error)
+	}
+	pub fn from_sumcheck_verify(error: SumcheckError) -> Self {
+		Error::SumcheckVerifyError(error)
+	}
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+	#[error("transcript error")]
+	TranscriptError(#[from] binius_transcript::Error),
+	#[error("sumcheck verify error")]
+	SumcheckVerifyError(#[from] SumcheckError),
+	#[error("length mismatch: {0} != {1}")]
+	LengthMismatch(usize, usize),
+	#[error("twisted eval points count ({0}) does not match claims count ({1})")]
+	TwistedPointsEvalsMismatch(usize, usize),
+	#[error("layer length ({0}) does not match pairs count ({1})")]
+	LayerClaimsMismatch(usize, usize),
+	#[error("composition claim mismatch")]
+	CompositionClaimMismatch,
+	#[error("final claims count ({0}) does not match pairs count * 2 ({1})")]
+	FinalClaimsPairsMismatch(usize, usize),
+	#[error("round coeffs count ({0}) does not match pairs count ({1})")]
+	RoundCoeffsPairsMismatch(usize, usize),
+	#[error("buffer log len ({0}) and eval point len ({1}) mismatch")]
+	BufferEvalPointMismatch(usize, usize),
+	#[error("layer pairs count ({0}) does not match claims count ({1})")]
+	LayerPairsCountClaimsMismatch(usize, usize),
+	#[error("eval point and buffer log len mismatch")]
+	EvalPointBufferLengthMismatch,
+}

--- a/crates/verifier/src/protocols/intmul/mod.rs
+++ b/crates/verifier/src/protocols/intmul/mod.rs
@@ -1,0 +1,7 @@
+// Copyright 2025 Irreducible Inc.
+
+pub mod common;
+mod error;
+pub mod verify;
+
+pub use error::*;

--- a/crates/verifier/src/protocols/intmul/verify.rs
+++ b/crates/verifier/src/protocols/intmul/verify.rs
@@ -1,0 +1,389 @@
+// Copyright 2025 Irreducible Inc.
+
+use binius_field::{BinaryField, Field};
+use binius_math::{multilinear::eq::eq_ind, univariate::evaluate_univariate};
+use binius_transcript::{
+	VerifierTranscript,
+	fiat_shamir::{CanSample, Challenger},
+};
+use itertools::{Itertools, izip};
+
+use super::{
+	common::{
+		IntMulOutput, Phase1Output, Phase2Output, Phase3Output, Phase4Output, Phase5Output,
+		frobenius_twist, make_phase_3_output, normalize_a_c_exponent_evals,
+	},
+	error::Error,
+};
+use crate::protocols::sumcheck::{
+	SumcheckOutput, common::BatchSumcheckOutput, verify as verify_sumcheck,
+};
+
+fn read_scalar<F: Field, C: Challenger>(
+	transcript: &mut VerifierTranscript<C>,
+) -> Result<F, Error> {
+	transcript
+		.message()
+		.read_scalar::<F>()
+		.map_err(Error::from_transcript_read)
+}
+
+fn read_scalar_slice<F: Field, C: Challenger>(
+	transcript: &mut VerifierTranscript<C>,
+	len: usize,
+) -> Result<Vec<F>, Error> {
+	transcript
+		.message()
+		.read_scalar_slice::<F>(len)
+		.map_err(Error::from_transcript_read)
+}
+
+struct BatchVerifyOutput<F: Field> {
+	batch_coeff: F,
+	challenges: Vec<F>,
+	eval: F,
+}
+
+fn batch_verify<F: Field, C: Challenger>(
+	n_vars: usize,
+	degree: usize,
+	evals: &[F],
+	transcript: &mut VerifierTranscript<C>,
+) -> Result<BatchVerifyOutput<F>, Error> {
+	let batch_coeff: F = transcript.sample();
+	let eval = evaluate_univariate(evals, batch_coeff);
+
+	let SumcheckOutput {
+		eval,
+		mut challenges,
+	} = verify_sumcheck(n_vars, degree, eval, transcript).map_err(Error::from_sumcheck_verify)?;
+
+	challenges.reverse();
+
+	Ok(BatchVerifyOutput {
+		batch_coeff,
+		challenges,
+		eval,
+	})
+}
+
+fn verify_multi_bivariate_product_mle_layer<F: Field, C: Challenger>(
+	eval_point: &[F],
+	evals: &[F],
+	transcript: &mut VerifierTranscript<C>,
+) -> Result<BatchSumcheckOutput<F>, Error> {
+	let n_vars = eval_point.len();
+
+	let BatchVerifyOutput {
+		batch_coeff,
+		challenges,
+		eval,
+	} = batch_verify(n_vars, 3, evals, transcript)?;
+
+	let final_evals = read_scalar_slice(transcript, 2 * evals.len())?;
+
+	let eq_ind_eval = eq_ind(eval_point, &challenges);
+	let expected_unbatched_terms = final_evals
+		.iter()
+		.tuples()
+		.map(|(&left, &right)| eq_ind_eval * left * right)
+		.collect::<Vec<_>>();
+
+	let expected_eval = evaluate_univariate(&expected_unbatched_terms, batch_coeff);
+	if expected_eval != eval {
+		return Err(Error::CompositionClaimMismatch);
+	}
+
+	Ok(BatchSumcheckOutput {
+		challenges,
+		multilinear_evals: vec![final_evals],
+	})
+}
+
+fn verify_phase_1<F: Field, C: Challenger>(
+	log_bits: usize,
+	initial_eval_point: &[F],
+	initial_b_eval: F,
+	transcript: &mut VerifierTranscript<C>,
+) -> Result<Phase1Output<F>, Error> {
+	let mut eval_point = initial_eval_point.to_vec();
+	let mut evals = vec![initial_b_eval];
+
+	for depth in 0..log_bits {
+		assert_eq!(evals.len(), 1 << depth);
+
+		let BatchSumcheckOutput {
+			challenges,
+			mut multilinear_evals,
+		} = verify_multi_bivariate_product_mle_layer::<F, C>(&eval_point, &evals, transcript)?;
+
+		assert_eq!(multilinear_evals.len(), 1);
+		eval_point = challenges;
+		evals = multilinear_evals.pop().expect("exactly one prover");
+	}
+
+	assert_eq!(evals.len(), 1 << log_bits);
+
+	Ok(Phase1Output {
+		eval_point,
+		b_leaves_evals: evals,
+	})
+}
+
+// PHASE 2: frobenius
+
+// PHASE THREE: selector sumcheck
+
+fn verify_phase_3<F: Field, C: Challenger>(
+	log_bits: usize,
+	// selector sumcheck stuff
+	phase_2_output: Phase2Output<F>,
+	// c sumcheck stuff
+	c_eval_point: &[F],
+	c_eval: F,
+	transcript: &mut VerifierTranscript<C>,
+) -> Result<Phase3Output<F>, Error> {
+	let n_vars = c_eval_point.len();
+
+	let Phase2Output { twisted_claims } = phase_2_output;
+	assert_eq!(twisted_claims.len(), 1 << log_bits);
+
+	let (twisted_eval_points, twisted_evals) =
+		twisted_claims.into_iter().unzip::<_, _, Vec<_>, Vec<_>>();
+
+	for twisted_eval_point in &twisted_eval_points {
+		assert_eq!(twisted_eval_point.len(), c_eval_point.len());
+	}
+
+	let mut evals = Vec::with_capacity(twisted_evals.len());
+	evals.extend(twisted_evals);
+	evals.push(c_eval);
+
+	let BatchVerifyOutput {
+		batch_coeff,
+		challenges,
+		eval,
+	} = batch_verify::<F, C>(n_vars, 3, &evals, transcript)?;
+
+	let selector_prover_evals = read_scalar_slice::<F, _>(transcript, (1 << log_bits) + 1)?;
+	let c_root_prover_evals = read_scalar_slice::<F, _>(transcript, 2)?;
+
+	let output =
+		make_phase_3_output(log_bits, &challenges, &selector_prover_evals, &c_root_prover_evals);
+	let Phase3Output {
+		eval_point,
+		b_exponent_evals,
+		selector_eval,
+		c_lo_root_eval,
+		c_hi_root_eval,
+	} = &output;
+
+	let mut expected_unbatched_terms = Vec::with_capacity((1 << log_bits) + 1);
+
+	for (twisted_eval_point, b_exponent_eval) in izip!(twisted_eval_points, b_exponent_evals) {
+		let twisted_eq_eval = eq_ind(&twisted_eval_point, eval_point);
+		let expected = twisted_eq_eval * (*b_exponent_eval * (*selector_eval - F::ONE) + F::ONE);
+		expected_unbatched_terms.push(expected);
+	}
+
+	let c_eq_eval = eq_ind(c_eval_point, eval_point);
+	expected_unbatched_terms.extend([c_eq_eval * c_lo_root_eval * c_hi_root_eval]);
+
+	let expected_batched_eval = evaluate_univariate(&expected_unbatched_terms, batch_coeff);
+
+	if expected_batched_eval != eval {
+		return Err(Error::CompositionClaimMismatch);
+	}
+
+	Ok(output)
+}
+
+// PHASE 4: all but last layer of a_layers and c_layers
+
+fn verify_phase_4<F: Field, C: Challenger>(
+	log_bits: usize,
+	eval_point: &[F],
+	a_root_eval: F,
+	c_lo_root_eval: F,
+	c_hi_root_eval: F,
+	transcript: &mut VerifierTranscript<C>,
+) -> Result<Phase4Output<F>, Error> {
+	assert!(log_bits >= 1);
+
+	let mut eval_point = eval_point.to_vec();
+	let mut evals = vec![a_root_eval, c_lo_root_eval, c_hi_root_eval];
+
+	for depth in 0..log_bits - 1 {
+		assert_eq!(evals.len(), 3 << depth);
+
+		let BatchSumcheckOutput {
+			challenges,
+			mut multilinear_evals,
+		} = verify_multi_bivariate_product_mle_layer(&eval_point, &evals, transcript)?;
+
+		assert_eq!(multilinear_evals.len(), 1);
+		eval_point = challenges;
+		evals = multilinear_evals.pop().expect("there is one prover");
+	}
+
+	assert_eq!(evals.len(), 3 << (log_bits - 1));
+	let c_hi_evals = evals.split_off(2 << (log_bits - 1));
+	let c_lo_evals = evals.split_off(1 << (log_bits - 1));
+	let a_evals = evals;
+
+	Ok(Phase4Output {
+		eval_point,
+		a_evals,
+		c_lo_evals,
+		c_hi_evals,
+	})
+}
+
+// PHASE 5: final layer
+
+#[allow(clippy::too_many_arguments)]
+fn verify_phase_5<F: Field, C: Challenger>(
+	log_bits: usize,
+	// a and c stuff
+	a_c_eval_point: &[F],
+	a_evals: &[F],
+	c_lo_evals: &[F],
+	c_hi_evals: &[F],
+	// b stuff
+	b_eval_point: &[F],
+	b_exponent_evals: &[F],
+	transcript: &mut VerifierTranscript<C>,
+) -> Result<Phase5Output<F>, Error> {
+	assert!(log_bits >= 1);
+	assert_eq!(2 * a_evals.len(), 1 << log_bits);
+	assert_eq!(2 * c_lo_evals.len(), 1 << log_bits);
+	assert_eq!(2 * c_hi_evals.len(), 1 << log_bits);
+
+	let n_vars = a_c_eval_point.len();
+	assert_eq!(b_eval_point.len(), n_vars);
+
+	let evals = [a_evals, c_lo_evals, c_hi_evals, b_exponent_evals].concat();
+
+	let BatchVerifyOutput {
+		batch_coeff,
+		challenges,
+		eval,
+	} = batch_verify::<F, C>(n_vars, 3, &evals, transcript)?;
+
+	let scaled_a_c_exponent_evals = read_scalar_slice(transcript, 64 + 128)?;
+	let b_exponent_evals = read_scalar_slice(transcript, 64)?;
+
+	let a_c_eq_eval = eq_ind(a_c_eval_point, &challenges);
+	let expected_a_c_unbatched_evals = scaled_a_c_exponent_evals
+		.iter()
+		.tuples()
+		.map(|(left, right)| a_c_eq_eval * left * right)
+		.collect::<Vec<F>>();
+
+	let b_eq_eval = eq_ind(b_eval_point, &challenges);
+	let expected_b_unbatched_evals = b_exponent_evals
+		.iter()
+		.map(|&b_exponent_eval| b_eq_eval * b_exponent_eval)
+		.collect::<Vec<F>>();
+
+	let expected_unbatched_evals =
+		[expected_a_c_unbatched_evals, expected_b_unbatched_evals].concat();
+	let expected_batched_eval = evaluate_univariate(&expected_unbatched_evals, batch_coeff);
+
+	if expected_batched_eval != eval {
+		return Err(Error::CompositionClaimMismatch);
+	}
+
+	Ok(Phase5Output {
+		eval_point: challenges,
+		scaled_a_c_exponent_evals,
+		b_exponent_evals,
+	})
+}
+
+/// This method verifies an integer multiplication reduction to obtain evaluation claims on 1-bit
+/// multilinears. Verification consists of five phases:
+///  - Phase 1: GKR tree roots for B & C are evaluated at a sampled point, after which reductions
+///    are performed to obtain evaluation claims on $(b * (G^{a_i} - 1) + 1)^{2^i}$
+///  - Phase 2: Frobenius twist is applied to obtain claims on $b * (G^{a_i} - 1) + 1$
+///  - Phase 3: Two batched sumchecks:
+///    - Selector mlecheck to reduce claims on $b * (G^{a_i} - 1) + 1$ to claims on $G^{a_i}$ and
+///      $b$
+///    - First layer of GPA reduction for the `c_lo || c_hi` combined `c` tree
+///  - Phase 4: Batching all but last layers and `a`, `c_lo` and `c_hi`
+///  - Phase 5: Verifying the last (widest) layers of `a`, `c_lo` and `c_hi` batched with
+///    rerandomization degree-1 mlecheck on `b` evaluations from phase 3
+pub fn verify<F: BinaryField, C: Challenger>(
+	log_bits: usize,
+	n_vars: usize,
+	transcript: &mut VerifierTranscript<C>,
+) -> Result<IntMulOutput<F>, Error> {
+	assert!(log_bits >= 1);
+	let initial_eval_point: Vec<F> = transcript.sample_vec(n_vars);
+
+	let initial_b_eval: F = read_scalar(transcript)?;
+	let initial_c_eval: F = read_scalar(transcript)?;
+
+	// phase 1
+	let Phase1Output {
+		eval_point: phase_1_eval_point,
+		b_leaves_evals,
+	} = verify_phase_1(log_bits, &initial_eval_point, initial_b_eval, transcript)?;
+
+	assert_eq!(phase_1_eval_point.len(), n_vars);
+	assert_eq!(b_leaves_evals.len(), 1 << log_bits);
+
+	// phase 2
+	let phase2_output = frobenius_twist(log_bits, &phase_1_eval_point, &b_leaves_evals);
+
+	// phase 3
+	let Phase3Output {
+		eval_point: phase_3_eval_point,
+		b_exponent_evals,
+		selector_eval,
+		c_lo_root_eval,
+		c_hi_root_eval,
+	} = verify_phase_3(log_bits, phase2_output, &initial_eval_point, initial_c_eval, transcript)?;
+
+	// phase 4
+	let Phase4Output {
+		eval_point: phase_4_eval_point,
+		a_evals,
+		c_lo_evals,
+		c_hi_evals,
+	} = verify_phase_4(
+		log_bits,
+		&phase_3_eval_point,
+		selector_eval,
+		c_lo_root_eval,
+		c_hi_root_eval,
+		transcript,
+	)?;
+
+	// phase 5
+	let Phase5Output {
+		eval_point: phase_5_eval_point,
+		scaled_a_c_exponent_evals,
+		b_exponent_evals,
+	} = verify_phase_5(
+		log_bits,
+		&phase_4_eval_point,
+		&a_evals,
+		&c_lo_evals,
+		&c_hi_evals,
+		&phase_3_eval_point,
+		&b_exponent_evals,
+		transcript,
+	)?;
+
+	let (a_exponent_evals, c_lo_exponent_evals, c_hi_exponent_evals) =
+		normalize_a_c_exponent_evals(log_bits, scaled_a_c_exponent_evals);
+
+	Ok(IntMulOutput {
+		eval_point: phase_5_eval_point,
+		a_exponent_evals,
+		b_exponent_evals,
+		c_lo_exponent_evals,
+		c_hi_exponent_evals,
+	})
+}

--- a/crates/verifier/src/protocols/mod.rs
+++ b/crates/verifier/src/protocols/mod.rs
@@ -1,5 +1,6 @@
 // Copyright 2025 Irreducible Inc.
 
 pub mod basefold;
+pub mod intmul;
 pub mod mlecheck;
 pub mod sumcheck;


### PR DESCRIPTION
This PR implements the integer multiplication protocol proper, for `log_bits` sized multiplicands.

### Changes

- Prover:
  - `IntMulProver` in `prove.rs` - a struct that was introduced primarily to scope type variables and reduce clutter, also stores switchover setting and the transcript
  - Five phases of the protocol implemented
  - Made `Witness` fields public to support destructuring (TODO: find a better solution)
- Verifier:
  - Common utilities shared between prover and verifier (Frobenius twist, renormalization)
  - Verifier counterparts for all five phases
- Tests:
  - End to end integration test

### Follow ups

* Factoring out batch sumcheck verification logic
* More thorough documentation of prover & verifier
* Memory optimizations for tensor expansions in selector mlecheck
* 1-bit zerocheck for the special case where `log_bits * 2 == F::LOG_DEGREE`

### How to test?

Run the test case in `crates/prover/src/protocols/intmul/tests.rs`:
```
cargo test --package binius-prover --lib -- protocols::intmul::tests::prove_and_verify --exact
```

The test generates random 64-bit integers, proves their multiplication is correct, and verifies the proof.
