### PR TITLE
[frontend] Use proptest instead of quickcheck for property tests

### DIFF
--- a/crates/frontend/Cargo.toml
+++ b/crates/frontend/Cargo.toml
@@ -14,6 +14,4 @@ base64 = "0.21"
 hex = "0.4.3"
 num-bigint = "0.4"
 num-integer = "0.1.46"
-quickcheck = "1.0"
-quickcheck_macros = "1.0"
 proptest = { workspace = true }


### PR DESCRIPTION
This PR reimplements frontend property tests to use `proptest` instead of `quickcheck`.

Other tests in the repository are already using `proptest`, we should only use one property testing library in the project.