### PR TITLE
[field] Remove canonical serialization mode (do not perform isomorphism on serialization/deserialization)

### DIFF
--- a/crates/field/src/arch/aarch64/m128.rs
+++ b/crates/field/src/arch/aarch64/m128.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use binius_utils::{
-	DeserializeBytes, SerializationError, SerializationMode, SerializeBytes,
+	DeserializeBytes, SerializationError, SerializeBytes,
 	bytes::{Buf, BufMut},
 	serialization::{assert_enough_data_for, assert_enough_space_for},
 };
@@ -199,11 +199,7 @@ impl From<poly64x2_t> for M128 {
 }
 
 impl SerializeBytes for M128 {
-	fn serialize(
-		&self,
-		mut write_buf: impl BufMut,
-		_mode: SerializationMode,
-	) -> Result<(), SerializationError> {
+	fn serialize(&self, mut write_buf: impl BufMut) -> Result<(), SerializationError> {
 		assert_enough_space_for(&write_buf, std::mem::size_of::<Self>())?;
 
 		write_buf.put_u128_le(u128::from(*self));
@@ -213,10 +209,7 @@ impl SerializeBytes for M128 {
 }
 
 impl DeserializeBytes for M128 {
-	fn deserialize(
-		mut read_buf: impl Buf,
-		_mode: SerializationMode,
-	) -> Result<Self, SerializationError>
+	fn deserialize(mut read_buf: impl Buf) -> Result<Self, SerializationError>
 	where
 		Self: Sized,
 	{
@@ -652,16 +645,14 @@ mod tests {
 
 	#[test]
 	fn test_serialize_and_deserialize_m128() {
-		let mode = SerializationMode::Native;
-
 		let mut rng = StdRng::from_seed([0; 32]);
 
 		let original_value = M128::from(rng.random::<u128>());
 
 		let mut buf = BytesMut::new();
-		original_value.serialize(&mut buf, mode).unwrap();
+		original_value.serialize(&mut buf).unwrap();
 
-		let deserialized_value = M128::deserialize(buf.freeze(), mode).unwrap();
+		let deserialized_value = M128::deserialize(buf.freeze()).unwrap();
 
 		assert_eq!(original_value, deserialized_value);
 	}

--- a/crates/field/src/arch/portable/packed_macros.rs
+++ b/crates/field/src/arch/portable/packed_macros.rs
@@ -164,21 +164,19 @@ macro_rules! impl_serialize_deserialize_for_packed_binary_field {
 			fn serialize(
 				&self,
 				write_buf: impl binius_utils::bytes::BufMut,
-				mode: binius_utils::SerializationMode,
 			) -> Result<(), binius_utils::SerializationError> {
 				assert_scalar_matches_canonical!($bin_type);
-				self.0.serialize(write_buf, mode)
+				self.0.serialize(write_buf)
 			}
 		}
 
 		impl binius_utils::DeserializeBytes for $bin_type {
 			fn deserialize(
 				read_buf: impl binius_utils::bytes::Buf,
-				mode: binius_utils::SerializationMode,
 			) -> Result<Self, binius_utils::SerializationError> {
 				assert_scalar_matches_canonical!($bin_type);
 				Ok(Self(
-					binius_utils::DeserializeBytes::deserialize(read_buf, mode)?,
+					binius_utils::DeserializeBytes::deserialize(read_buf)?,
 					std::marker::PhantomData,
 				))
 			}

--- a/crates/field/src/arch/portable/packed_scaled.rs
+++ b/crates/field/src/arch/portable/packed_scaled.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use binius_utils::{
-	DeserializeBytes, SerializationError, SerializationMode, SerializeBytes,
+	DeserializeBytes, SerializationError, SerializeBytes,
 	bytes::{Buf, BufMut},
 	checked_arithmetics::checked_log_2,
 };
@@ -88,13 +88,9 @@ impl<PT, const N: usize> SerializeBytes for ScaledPackedField<PT, N>
 where
 	PT: SerializeBytes,
 {
-	fn serialize(
-		&self,
-		mut write_buf: impl BufMut,
-		mode: SerializationMode,
-	) -> Result<(), SerializationError> {
+	fn serialize(&self, mut write_buf: impl BufMut) -> Result<(), SerializationError> {
 		for elem in &self.0 {
-			elem.serialize(&mut write_buf, mode)?;
+			elem.serialize(&mut write_buf)?;
 		}
 		Ok(())
 	}
@@ -104,13 +100,10 @@ impl<PT, const N: usize> DeserializeBytes for ScaledPackedField<PT, N>
 where
 	PT: DeserializeBytes,
 {
-	fn deserialize(
-		mut read_buf: impl Buf,
-		mode: SerializationMode,
-	) -> Result<Self, SerializationError> {
+	fn deserialize(mut read_buf: impl Buf) -> Result<Self, SerializationError> {
 		let mut result = Vec::with_capacity(N);
 		for _ in 0..N {
-			result.push(PT::deserialize(&mut read_buf, mode)?);
+			result.push(PT::deserialize(&mut read_buf)?);
 		}
 
 		match result.try_into() {
@@ -601,7 +594,7 @@ where
 
 #[cfg(test)]
 mod tests {
-	use binius_utils::{SerializationMode, SerializeBytes, bytes::BytesMut};
+	use binius_utils::{SerializeBytes, bytes::BytesMut};
 	use rand::{Rng, SeedableRng, rngs::StdRng};
 
 	use super::ScaledPackedField;
@@ -609,8 +602,6 @@ mod tests {
 
 	#[test]
 	fn test_equivalent_serialization_between_packed_representations() {
-		let mode = SerializationMode::Native;
-
 		let mut rng = StdRng::seed_from_u64(0);
 
 		let byte_low: u8 = rng.random();
@@ -625,10 +616,8 @@ mod tests {
 		let mut buffer_packed = BytesMut::new();
 		let mut buffer_equivalent = BytesMut::new();
 
-		packed.serialize(&mut buffer_packed, mode).unwrap();
-		packed_equivalent
-			.serialize(&mut buffer_equivalent, mode)
-			.unwrap();
+		packed.serialize(&mut buffer_packed).unwrap();
+		packed_equivalent.serialize(&mut buffer_equivalent).unwrap();
 
 		assert_eq!(buffer_packed, buffer_equivalent);
 	}

--- a/crates/field/src/arch/x86_64/m128.rs
+++ b/crates/field/src/arch/x86_64/m128.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use binius_utils::{
-	DeserializeBytes, SerializationError, SerializationMode, SerializeBytes,
+	DeserializeBytes, SerializationError, SerializeBytes,
 	bytes::{Buf, BufMut},
 	serialization::{assert_enough_data_for, assert_enough_space_for},
 };
@@ -116,11 +116,7 @@ impl From<M128> for __m128i {
 }
 
 impl SerializeBytes for M128 {
-	fn serialize(
-		&self,
-		mut write_buf: impl BufMut,
-		_mode: SerializationMode,
-	) -> Result<(), SerializationError> {
+	fn serialize(&self, mut write_buf: impl BufMut) -> Result<(), SerializationError> {
 		assert_enough_space_for(&write_buf, std::mem::size_of::<Self>())?;
 
 		let raw_value: u128 = (*self).into();
@@ -131,10 +127,7 @@ impl SerializeBytes for M128 {
 }
 
 impl DeserializeBytes for M128 {
-	fn deserialize(
-		mut read_buf: impl Buf,
-		_mode: SerializationMode,
-	) -> Result<Self, SerializationError>
+	fn deserialize(mut read_buf: impl Buf) -> Result<Self, SerializationError>
 	where
 		Self: Sized,
 	{
@@ -1137,16 +1130,14 @@ mod tests {
 
 	#[test]
 	fn test_serialize_and_deserialize_m128() {
-		let mode = SerializationMode::Native;
-
 		let mut rng = StdRng::from_seed([0; 32]);
 
 		let original_value = M128::from(rng.random::<u128>());
 
 		let mut buf = BytesMut::new();
-		original_value.serialize(&mut buf, mode).unwrap();
+		original_value.serialize(&mut buf).unwrap();
 
-		let deserialized_value = M128::deserialize(buf.freeze(), mode).unwrap();
+		let deserialized_value = M128::deserialize(buf.freeze()).unwrap();
 
 		assert_eq!(original_value, deserialized_value);
 	}

--- a/crates/field/src/arch/x86_64/m256.rs
+++ b/crates/field/src/arch/x86_64/m256.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use binius_utils::{
-	DeserializeBytes, SerializationError, SerializationMode, SerializeBytes,
+	DeserializeBytes, SerializationError, SerializeBytes,
 	bytes::{Buf, BufMut},
 	serialization::{assert_enough_data_for, assert_enough_space_for},
 };
@@ -125,11 +125,7 @@ impl From<M256> for __m256i {
 }
 
 impl SerializeBytes for M256 {
-	fn serialize(
-		&self,
-		mut write_buf: impl BufMut,
-		_mode: SerializationMode,
-	) -> Result<(), SerializationError> {
+	fn serialize(&self, mut write_buf: impl BufMut) -> Result<(), SerializationError> {
 		assert_enough_space_for(&write_buf, std::mem::size_of::<Self>())?;
 
 		let raw_values: [u128; 2] = (*self).into();
@@ -143,10 +139,7 @@ impl SerializeBytes for M256 {
 }
 
 impl DeserializeBytes for M256 {
-	fn deserialize(
-		mut read_buf: impl Buf,
-		_mode: SerializationMode,
-	) -> Result<Self, SerializationError>
+	fn deserialize(mut read_buf: impl Buf) -> Result<Self, SerializationError>
 	where
 		Self: Sized,
 	{
@@ -1546,16 +1539,14 @@ mod tests {
 
 	#[test]
 	fn test_serialize_and_deserialize_m256() {
-		let mode = SerializationMode::Native;
-
 		let mut rng = StdRng::from_seed([0; 32]);
 
 		let original_value = M256::from([rng.random::<u128>(), rng.random::<u128>()]);
 
 		let mut buf = BytesMut::new();
-		original_value.serialize(&mut buf, mode).unwrap();
+		original_value.serialize(&mut buf).unwrap();
 
-		let deserialized_value = M256::deserialize(buf.freeze(), mode).unwrap();
+		let deserialized_value = M256::deserialize(buf.freeze()).unwrap();
 
 		assert_eq!(original_value, deserialized_value);
 	}

--- a/crates/field/src/arch/x86_64/m512.rs
+++ b/crates/field/src/arch/x86_64/m512.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use binius_utils::{
-	DeserializeBytes, SerializationError, SerializationMode, SerializeBytes,
+	DeserializeBytes, SerializationError, SerializeBytes,
 	bytes::{Buf, BufMut},
 	serialization::{assert_enough_data_for, assert_enough_space_for},
 };
@@ -137,11 +137,7 @@ impl<U: NumCast<u128>> NumCast<M512> for U {
 }
 
 impl SerializeBytes for M512 {
-	fn serialize(
-		&self,
-		mut write_buf: impl BufMut,
-		_mode: SerializationMode,
-	) -> Result<(), SerializationError> {
+	fn serialize(&self, mut write_buf: impl BufMut) -> Result<(), SerializationError> {
 		assert_enough_space_for(&write_buf, std::mem::size_of::<Self>())?;
 
 		let raw_values: [u128; 4] = (*self).into();
@@ -155,10 +151,7 @@ impl SerializeBytes for M512 {
 }
 
 impl DeserializeBytes for M512 {
-	fn deserialize(
-		mut read_buf: impl Buf,
-		_mode: SerializationMode,
-	) -> Result<Self, SerializationError>
+	fn deserialize(mut read_buf: impl Buf) -> Result<Self, SerializationError>
 	where
 		Self: Sized,
 	{
@@ -1747,16 +1740,14 @@ mod tests {
 
 	#[test]
 	fn test_serialize_and_deserialize_m512() {
-		let mode = SerializationMode::Native;
-
 		let mut rng = StdRng::from_seed([0; 32]);
 
 		let original_value = M512::from(core::array::from_fn(|_| rng.random::<u128>()));
 
 		let mut buf = BytesMut::new();
-		original_value.serialize(&mut buf, mode).unwrap();
+		original_value.serialize(&mut buf).unwrap();
 
-		let deserialized_value = M512::deserialize(buf.freeze(), mode).unwrap();
+		let deserialized_value = M512::deserialize(buf.freeze()).unwrap();
 
 		assert_eq!(original_value, deserialized_value);
 	}

--- a/crates/field/src/binary_field.rs
+++ b/crates/field/src/binary_field.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use binius_utils::{
-	DeserializeBytes, SerializationError, SerializationMode, SerializeBytes,
+	DeserializeBytes, SerializationError, SerializeBytes,
 	bytes::{Buf, BufMut},
 };
 use bytemuck::{Pod, Zeroable};
@@ -772,21 +772,14 @@ pub fn is_canonical_tower<F: TowerField>() -> bool {
 macro_rules! serialize_deserialize {
 	($bin_type:ty) => {
 		impl SerializeBytes for $bin_type {
-			fn serialize(
-				&self,
-				write_buf: impl BufMut,
-				mode: SerializationMode,
-			) -> Result<(), SerializationError> {
-				self.0.serialize(write_buf, mode)
+			fn serialize(&self, write_buf: impl BufMut) -> Result<(), SerializationError> {
+				self.0.serialize(write_buf)
 			}
 		}
 
 		impl DeserializeBytes for $bin_type {
-			fn deserialize(
-				read_buf: impl Buf,
-				mode: SerializationMode,
-			) -> Result<Self, SerializationError> {
-				Ok(Self(DeserializeBytes::deserialize(read_buf, mode)?))
+			fn deserialize(read_buf: impl Buf) -> Result<Self, SerializationError> {
+				Ok(Self(DeserializeBytes::deserialize(read_buf)?))
 			}
 		}
 	};
@@ -897,7 +890,7 @@ impl From<BinaryField4b> for u8 {
 
 #[cfg(test)]
 pub(crate) mod tests {
-	use binius_utils::{SerializationMode, bytes::BytesMut};
+	use binius_utils::bytes::BytesMut;
 	use proptest::prelude::*;
 
 	use super::{
@@ -1267,7 +1260,6 @@ pub(crate) mod tests {
 
 	#[test]
 	fn test_serialization() {
-		let mode = SerializationMode::CanonicalTower;
 		let mut buffer = BytesMut::new();
 		let b1 = BinaryField1b::from(0x1);
 		let b8 = BinaryField8b::new(0x12);
@@ -1278,25 +1270,25 @@ pub(crate) mod tests {
 		let b64 = BinaryField64b::new(0x13579BDF02468ACE);
 		let b128 = BinaryField128b::new(0x147AD0369CF258BE8899AABBCCDDEEFF);
 
-		b1.serialize(&mut buffer, mode).unwrap();
-		b8.serialize(&mut buffer, mode).unwrap();
-		b2.serialize(&mut buffer, mode).unwrap();
-		b16.serialize(&mut buffer, mode).unwrap();
-		b32.serialize(&mut buffer, mode).unwrap();
-		b4.serialize(&mut buffer, mode).unwrap();
-		b64.serialize(&mut buffer, mode).unwrap();
-		b128.serialize(&mut buffer, mode).unwrap();
+		b1.serialize(&mut buffer).unwrap();
+		b8.serialize(&mut buffer).unwrap();
+		b2.serialize(&mut buffer).unwrap();
+		b16.serialize(&mut buffer).unwrap();
+		b32.serialize(&mut buffer).unwrap();
+		b4.serialize(&mut buffer).unwrap();
+		b64.serialize(&mut buffer).unwrap();
+		b128.serialize(&mut buffer).unwrap();
 
 		let mut read_buffer = buffer.freeze();
 
-		assert_eq!(BinaryField1b::deserialize(&mut read_buffer, mode).unwrap(), b1);
-		assert_eq!(BinaryField8b::deserialize(&mut read_buffer, mode).unwrap(), b8);
-		assert_eq!(BinaryField2b::deserialize(&mut read_buffer, mode).unwrap(), b2);
-		assert_eq!(BinaryField16b::deserialize(&mut read_buffer, mode).unwrap(), b16);
-		assert_eq!(BinaryField32b::deserialize(&mut read_buffer, mode).unwrap(), b32);
-		assert_eq!(BinaryField4b::deserialize(&mut read_buffer, mode).unwrap(), b4);
-		assert_eq!(BinaryField64b::deserialize(&mut read_buffer, mode).unwrap(), b64);
-		assert_eq!(BinaryField128b::deserialize(&mut read_buffer, mode).unwrap(), b128);
+		assert_eq!(BinaryField1b::deserialize(&mut read_buffer).unwrap(), b1);
+		assert_eq!(BinaryField8b::deserialize(&mut read_buffer).unwrap(), b8);
+		assert_eq!(BinaryField2b::deserialize(&mut read_buffer).unwrap(), b2);
+		assert_eq!(BinaryField16b::deserialize(&mut read_buffer).unwrap(), b16);
+		assert_eq!(BinaryField32b::deserialize(&mut read_buffer).unwrap(), b32);
+		assert_eq!(BinaryField4b::deserialize(&mut read_buffer).unwrap(), b4);
+		assert_eq!(BinaryField64b::deserialize(&mut read_buffer).unwrap(), b64);
+		assert_eq!(BinaryField128b::deserialize(&mut read_buffer).unwrap(), b128);
 	}
 
 	#[test]

--- a/crates/field/src/ghash.rs
+++ b/crates/field/src/ghash.rs
@@ -11,7 +11,7 @@ use std::{
 };
 
 use binius_utils::{
-	DeserializeBytes, SerializationError, SerializationMode, SerializeBytes,
+	DeserializeBytes, SerializationError, SerializeBytes,
 	bytes::{Buf, BufMut},
 	iter::IterExtensions,
 };
@@ -454,31 +454,17 @@ impl ExtensionField<BinaryField1b> for BinaryField128bGhash {
 }
 
 impl SerializeBytes for BinaryField128bGhash {
-	fn serialize(
-		&self,
-		write_buf: impl BufMut,
-		mode: SerializationMode,
-	) -> Result<(), SerializationError> {
-		match mode {
-			SerializationMode::Native => self.0.serialize(write_buf, mode),
-			SerializationMode::CanonicalTower => {
-				todo!("Implement canonical tower serialization for GHASH")
-			}
-		}
+	fn serialize(&self, write_buf: impl BufMut) -> Result<(), SerializationError> {
+		self.0.serialize(write_buf)
 	}
 }
 
 impl DeserializeBytes for BinaryField128bGhash {
-	fn deserialize(read_buf: impl Buf, mode: SerializationMode) -> Result<Self, SerializationError>
+	fn deserialize(read_buf: impl Buf) -> Result<Self, SerializationError>
 	where
 		Self: Sized,
 	{
-		match mode {
-			SerializationMode::Native => Ok(Self(DeserializeBytes::deserialize(read_buf, mode)?)),
-			SerializationMode::CanonicalTower => {
-				todo!("Implement canonical tower deserialization for GHASH")
-			}
-		}
+		Ok(Self(DeserializeBytes::deserialize(read_buf)?))
 	}
 }
 

--- a/crates/field/src/packed_binary_field.rs
+++ b/crates/field/src/packed_binary_field.rs
@@ -873,7 +873,7 @@ pub mod test_utils {
 mod tests {
 	use std::{iter::repeat_with, ops::Mul};
 
-	use binius_utils::{DeserializeBytes, SerializationMode, SerializeBytes, bytes::BytesMut};
+	use binius_utils::{DeserializeBytes, SerializeBytes, bytes::BytesMut};
 	use proptest::prelude::*;
 	use rand::prelude::*;
 	use test_utils::{check_interleave_all_heights, implements_transformation_factory};
@@ -935,15 +935,14 @@ mod tests {
 	}
 
 	fn test_serialize_then_deserialize<P: PackedField + DeserializeBytes + SerializeBytes>() {
-		let mode = SerializationMode::Native;
 		let mut buffer = BytesMut::new();
 		let mut rng = StdRng::seed_from_u64(0);
 		let packed = P::random(&mut rng);
-		packed.serialize(&mut buffer, mode).unwrap();
+		packed.serialize(&mut buffer).unwrap();
 
 		let mut read_buffer = buffer.freeze();
 
-		assert_eq!(P::deserialize(&mut read_buffer, mode).unwrap(), packed);
+		assert_eq!(P::deserialize(&mut read_buffer).unwrap(), packed);
 	}
 
 	#[test]
@@ -1005,18 +1004,17 @@ mod tests {
 
 	#[test]
 	fn test_serialize_deserialize_different_packing_width() {
-		let mode = SerializationMode::Native;
 		let mut rng = StdRng::seed_from_u64(0);
 
 		let packed0 = PackedBinaryField1x128b::random(&mut rng);
 		let packed1 = PackedBinaryField1x128b::random(&mut rng);
 
 		let mut buffer = BytesMut::new();
-		packed0.serialize(&mut buffer, mode).unwrap();
-		packed1.serialize(&mut buffer, mode).unwrap();
+		packed0.serialize(&mut buffer).unwrap();
+		packed1.serialize(&mut buffer).unwrap();
 
 		let mut read_buffer = buffer.freeze();
-		let packed01 = PackedBinaryField2x128b::deserialize(&mut read_buffer, mode).unwrap();
+		let packed01 = PackedBinaryField2x128b::deserialize(&mut read_buffer).unwrap();
 
 		assert!(
 			packed01

--- a/crates/field/src/underlier/small_uint.rs
+++ b/crates/field/src/underlier/small_uint.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use binius_utils::{
-	SerializationError, SerializationMode, SerializeBytes,
+	SerializationError, SerializeBytes,
 	bytes::{Buf, BufMut},
 	checked_arithmetics::checked_log_2,
 	serialization::DeserializeBytes,
@@ -247,21 +247,17 @@ impl From<U1> for bool {
 }
 
 impl<const N: usize> SerializeBytes for SmallU<N> {
-	fn serialize(
-		&self,
-		write_buf: impl BufMut,
-		mode: SerializationMode,
-	) -> Result<(), SerializationError> {
-		self.val().serialize(write_buf, mode)
+	fn serialize(&self, write_buf: impl BufMut) -> Result<(), SerializationError> {
+		self.val().serialize(write_buf)
 	}
 }
 
 impl<const N: usize> DeserializeBytes for SmallU<N> {
-	fn deserialize(read_buf: impl Buf, mode: SerializationMode) -> Result<Self, SerializationError>
+	fn deserialize(read_buf: impl Buf) -> Result<Self, SerializationError>
 	where
 		Self: Sized,
 	{
-		Ok(Self::new(DeserializeBytes::deserialize(read_buf, mode)?))
+		Ok(Self::new(DeserializeBytes::deserialize(read_buf)?))
 	}
 }
 

--- a/crates/prover/src/hash/parallel_digest.rs
+++ b/crates/prover/src/hash/parallel_digest.rs
@@ -7,7 +7,7 @@ use binius_maybe_rayon::{
 	slice::ParallelSliceMut,
 };
 use binius_transcript::BufMut;
-use binius_utils::{SerializationMode, SerializeBytes};
+use binius_utils::SerializeBytes;
 use binius_verifier::hash::HashBuffer;
 use bytes::BytesMut;
 use digest::{Digest, Output, core_api::BlockSizeUser};
@@ -123,7 +123,7 @@ impl<D: MultiDigest<N, Digest: Send> + Send + Sync, const N: usize> ParallelDige
 				for (mut buf, chunk) in buffers.iter_mut().zip(data.into_iter()) {
 					buf.clear();
 					for item in chunk {
-						item.serialize(&mut buf, SerializationMode::Native)
+						item.serialize(&mut buf)
 							.expect("pre-condition: items must serialize without error")
 					}
 				}
@@ -166,7 +166,7 @@ impl<D: Digest + BlockSizeUser + Send + Sync + Clone> ParallelDigest for D {
 			{
 				let mut buffer = HashBuffer::new(&mut hasher);
 				for item in items {
-					item.serialize(&mut buffer, SerializationMode::Native)
+					item.serialize(&mut buffer)
 						.expect("pre-condition: items must serialize without error")
 				}
 			}

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -16,4 +16,4 @@ pub mod sparse_index;
 pub mod strided_array;
 
 pub use bytes;
-pub use serialization::{DeserializeBytes, SerializationError, SerializationMode, SerializeBytes};
+pub use serialization::{DeserializeBytes, SerializationError, SerializeBytes};

--- a/crates/utils/src/serialization.rs
+++ b/crates/utils/src/serialization.rs
@@ -7,27 +7,14 @@ use thiserror::Error;
 /// Serialize data according to Mode param
 #[auto_impl(Box, &)]
 pub trait SerializeBytes {
-	fn serialize(
-		&self,
-		write_buf: impl BufMut,
-		mode: SerializationMode,
-	) -> Result<(), SerializationError>;
+	fn serialize(&self, write_buf: impl BufMut) -> Result<(), SerializationError>;
 }
 
 /// Deserialize data according to Mode param
 pub trait DeserializeBytes {
-	fn deserialize(read_buf: impl Buf, mode: SerializationMode) -> Result<Self, SerializationError>
+	fn deserialize(read_buf: impl Buf) -> Result<Self, SerializationError>
 	where
 		Self: Sized;
-}
-
-/// Specifies serialization/deserialization behavior
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SerializationMode {
-	/// This mode is faster, and serializes to the underlying bytes
-	Native,
-	/// Will first convert any tower fields into the Fan-Paar field equivalent
-	CanonicalTower,
 }
 
 #[derive(Error, Debug, Clone)]
@@ -57,46 +44,35 @@ pub enum SerializationError {
 use generic_array::{ArrayLength, GenericArray};
 
 impl<T: DeserializeBytes> DeserializeBytes for Box<T> {
-	fn deserialize(read_buf: impl Buf, mode: SerializationMode) -> Result<Self, SerializationError>
+	fn deserialize(read_buf: impl Buf) -> Result<Self, SerializationError>
 	where
 		Self: Sized,
 	{
-		Ok(Self::new(T::deserialize(read_buf, mode)?))
+		Ok(Self::new(T::deserialize(read_buf)?))
 	}
 }
 
 impl SerializeBytes for usize {
-	fn serialize(
-		&self,
-		mut write_buf: impl BufMut,
-		mode: SerializationMode,
-	) -> Result<(), SerializationError> {
+	fn serialize(&self, mut write_buf: impl BufMut) -> Result<(), SerializationError> {
 		let value: u32 = (*self)
 			.try_into()
 			.map_err(|_| SerializationError::UsizeTooLarge { size: *self })?;
-		SerializeBytes::serialize(&value, &mut write_buf, mode)
+		SerializeBytes::serialize(&value, &mut write_buf)
 	}
 }
 
 impl DeserializeBytes for usize {
-	fn deserialize(
-		mut read_buf: impl Buf,
-		mode: SerializationMode,
-	) -> Result<Self, SerializationError>
+	fn deserialize(mut read_buf: impl Buf) -> Result<Self, SerializationError>
 	where
 		Self: Sized,
 	{
-		let value: u32 = DeserializeBytes::deserialize(&mut read_buf, mode)?;
+		let value: u32 = DeserializeBytes::deserialize(&mut read_buf)?;
 		Ok(value as Self)
 	}
 }
 
 impl SerializeBytes for u128 {
-	fn serialize(
-		&self,
-		mut write_buf: impl BufMut,
-		_mode: SerializationMode,
-	) -> Result<(), SerializationError> {
+	fn serialize(&self, mut write_buf: impl BufMut) -> Result<(), SerializationError> {
 		assert_enough_space_for(&write_buf, std::mem::size_of::<Self>())?;
 		write_buf.put_u128_le(*self);
 		Ok(())
@@ -104,10 +80,7 @@ impl SerializeBytes for u128 {
 }
 
 impl DeserializeBytes for u128 {
-	fn deserialize(
-		mut read_buf: impl Buf,
-		_mode: SerializationMode,
-	) -> Result<Self, SerializationError>
+	fn deserialize(mut read_buf: impl Buf) -> Result<Self, SerializationError>
 	where
 		Self: Sized,
 	{
@@ -117,11 +90,7 @@ impl DeserializeBytes for u128 {
 }
 
 impl SerializeBytes for u64 {
-	fn serialize(
-		&self,
-		mut write_buf: impl BufMut,
-		_mode: SerializationMode,
-	) -> Result<(), SerializationError> {
+	fn serialize(&self, mut write_buf: impl BufMut) -> Result<(), SerializationError> {
 		assert_enough_space_for(&write_buf, std::mem::size_of::<Self>())?;
 		write_buf.put_u64_le(*self);
 		Ok(())
@@ -129,10 +98,7 @@ impl SerializeBytes for u64 {
 }
 
 impl DeserializeBytes for u64 {
-	fn deserialize(
-		mut read_buf: impl Buf,
-		_mode: SerializationMode,
-	) -> Result<Self, SerializationError>
+	fn deserialize(mut read_buf: impl Buf) -> Result<Self, SerializationError>
 	where
 		Self: Sized,
 	{
@@ -142,11 +108,7 @@ impl DeserializeBytes for u64 {
 }
 
 impl SerializeBytes for u32 {
-	fn serialize(
-		&self,
-		mut write_buf: impl BufMut,
-		_mode: SerializationMode,
-	) -> Result<(), SerializationError> {
+	fn serialize(&self, mut write_buf: impl BufMut) -> Result<(), SerializationError> {
 		assert_enough_space_for(&write_buf, std::mem::size_of::<Self>())?;
 		write_buf.put_u32_le(*self);
 		Ok(())
@@ -154,10 +116,7 @@ impl SerializeBytes for u32 {
 }
 
 impl DeserializeBytes for u32 {
-	fn deserialize(
-		mut read_buf: impl Buf,
-		_mode: SerializationMode,
-	) -> Result<Self, SerializationError>
+	fn deserialize(mut read_buf: impl Buf) -> Result<Self, SerializationError>
 	where
 		Self: Sized,
 	{
@@ -167,11 +126,7 @@ impl DeserializeBytes for u32 {
 }
 
 impl SerializeBytes for u16 {
-	fn serialize(
-		&self,
-		mut write_buf: impl BufMut,
-		_mode: SerializationMode,
-	) -> Result<(), SerializationError> {
+	fn serialize(&self, mut write_buf: impl BufMut) -> Result<(), SerializationError> {
 		assert_enough_space_for(&write_buf, std::mem::size_of::<Self>())?;
 		write_buf.put_u16_le(*self);
 		Ok(())
@@ -179,10 +134,7 @@ impl SerializeBytes for u16 {
 }
 
 impl DeserializeBytes for u16 {
-	fn deserialize(
-		mut read_buf: impl Buf,
-		_mode: SerializationMode,
-	) -> Result<Self, SerializationError>
+	fn deserialize(mut read_buf: impl Buf) -> Result<Self, SerializationError>
 	where
 		Self: Sized,
 	{
@@ -192,11 +144,7 @@ impl DeserializeBytes for u16 {
 }
 
 impl SerializeBytes for u8 {
-	fn serialize(
-		&self,
-		mut write_buf: impl BufMut,
-		_mode: SerializationMode,
-	) -> Result<(), SerializationError> {
+	fn serialize(&self, mut write_buf: impl BufMut) -> Result<(), SerializationError> {
 		assert_enough_space_for(&write_buf, std::mem::size_of::<Self>())?;
 		write_buf.put_u8(*self);
 		Ok(())
@@ -204,10 +152,7 @@ impl SerializeBytes for u8 {
 }
 
 impl DeserializeBytes for u8 {
-	fn deserialize(
-		mut read_buf: impl Buf,
-		_mode: SerializationMode,
-	) -> Result<Self, SerializationError>
+	fn deserialize(mut read_buf: impl Buf) -> Result<Self, SerializationError>
 	where
 		Self: Sized,
 	{
@@ -217,39 +162,28 @@ impl DeserializeBytes for u8 {
 }
 
 impl SerializeBytes for bool {
-	fn serialize(
-		&self,
-		write_buf: impl BufMut,
-		mode: SerializationMode,
-	) -> Result<(), SerializationError> {
-		u8::serialize(&(*self as u8), write_buf, mode)
+	fn serialize(&self, write_buf: impl BufMut) -> Result<(), SerializationError> {
+		u8::serialize(&(*self as u8), write_buf)
 	}
 }
 
 impl DeserializeBytes for bool {
-	fn deserialize(read_buf: impl Buf, mode: SerializationMode) -> Result<Self, SerializationError>
+	fn deserialize(read_buf: impl Buf) -> Result<Self, SerializationError>
 	where
 		Self: Sized,
 	{
-		Ok(u8::deserialize(read_buf, mode)? != 0)
+		Ok(u8::deserialize(read_buf)? != 0)
 	}
 }
 
 impl<T> SerializeBytes for std::marker::PhantomData<T> {
-	fn serialize(
-		&self,
-		_write_buf: impl BufMut,
-		_mode: SerializationMode,
-	) -> Result<(), SerializationError> {
+	fn serialize(&self, _write_buf: impl BufMut) -> Result<(), SerializationError> {
 		Ok(())
 	}
 }
 
 impl<T> DeserializeBytes for std::marker::PhantomData<T> {
-	fn deserialize(
-		_read_buf: impl Buf,
-		_mode: SerializationMode,
-	) -> Result<Self, SerializationError>
+	fn deserialize(_read_buf: impl Buf) -> Result<Self, SerializationError>
 	where
 		Self: Sized,
 	{
@@ -258,13 +192,9 @@ impl<T> DeserializeBytes for std::marker::PhantomData<T> {
 }
 
 impl SerializeBytes for &str {
-	fn serialize(
-		&self,
-		mut write_buf: impl BufMut,
-		mode: SerializationMode,
-	) -> Result<(), SerializationError> {
+	fn serialize(&self, mut write_buf: impl BufMut) -> Result<(), SerializationError> {
 		let bytes = self.as_bytes();
-		SerializeBytes::serialize(&bytes.len(), &mut write_buf, mode)?;
+		SerializeBytes::serialize(&bytes.len(), &mut write_buf)?;
 		assert_enough_space_for(&write_buf, bytes.len())?;
 		write_buf.put_slice(bytes);
 		Ok(())
@@ -272,79 +202,57 @@ impl SerializeBytes for &str {
 }
 
 impl SerializeBytes for String {
-	fn serialize(
-		&self,
-		mut write_buf: impl BufMut,
-		mode: SerializationMode,
-	) -> Result<(), SerializationError> {
-		SerializeBytes::serialize(&self.as_str(), &mut write_buf, mode)
+	fn serialize(&self, mut write_buf: impl BufMut) -> Result<(), SerializationError> {
+		SerializeBytes::serialize(&self.as_str(), &mut write_buf)
 	}
 }
 
 impl DeserializeBytes for String {
-	fn deserialize(
-		mut read_buf: impl Buf,
-		mode: SerializationMode,
-	) -> Result<Self, SerializationError>
+	fn deserialize(mut read_buf: impl Buf) -> Result<Self, SerializationError>
 	where
 		Self: Sized,
 	{
-		let len = DeserializeBytes::deserialize(&mut read_buf, mode)?;
+		let len = DeserializeBytes::deserialize(&mut read_buf)?;
 		assert_enough_data_for(&read_buf, len)?;
 		Ok(Self::from_utf8(read_buf.copy_to_bytes(len).to_vec())?)
 	}
 }
 
 impl<T: SerializeBytes> SerializeBytes for [T] {
-	fn serialize(
-		&self,
-		mut write_buf: impl BufMut,
-		mode: SerializationMode,
-	) -> Result<(), SerializationError> {
-		SerializeBytes::serialize(&self.len(), &mut write_buf, mode)?;
+	fn serialize(&self, mut write_buf: impl BufMut) -> Result<(), SerializationError> {
+		SerializeBytes::serialize(&self.len(), &mut write_buf)?;
 		self.iter()
-			.try_for_each(|item| SerializeBytes::serialize(item, &mut write_buf, mode))
+			.try_for_each(|item| SerializeBytes::serialize(item, &mut write_buf))
 	}
 }
 
 impl<T: SerializeBytes> SerializeBytes for Vec<T> {
-	fn serialize(
-		&self,
-		mut write_buf: impl BufMut,
-		mode: SerializationMode,
-	) -> Result<(), SerializationError> {
-		SerializeBytes::serialize(self.as_slice(), &mut write_buf, mode)
+	fn serialize(&self, mut write_buf: impl BufMut) -> Result<(), SerializationError> {
+		SerializeBytes::serialize(self.as_slice(), &mut write_buf)
 	}
 }
 
 impl<T: DeserializeBytes> DeserializeBytes for Vec<T> {
-	fn deserialize(
-		mut read_buf: impl Buf,
-		mode: SerializationMode,
-	) -> Result<Self, SerializationError>
+	fn deserialize(mut read_buf: impl Buf) -> Result<Self, SerializationError>
 	where
 		Self: Sized,
 	{
-		let len: usize = DeserializeBytes::deserialize(&mut read_buf, mode)?;
+		let len: usize = DeserializeBytes::deserialize(&mut read_buf)?;
 		(0..len)
-			.map(|_| DeserializeBytes::deserialize(&mut read_buf, mode))
+			.map(|_| DeserializeBytes::deserialize(&mut read_buf))
 			.collect()
 	}
 }
 
 impl<T: SerializeBytes> SerializeBytes for Option<T> {
-	fn serialize(
-		&self,
-		mut write_buf: impl BufMut,
-		mode: SerializationMode,
-	) -> Result<(), SerializationError> {
+	fn serialize(&self, mut write_buf: impl BufMut) -> Result<(), SerializationError> {
 		match self {
 			Some(value) => {
-				SerializeBytes::serialize(&true, &mut write_buf, mode)?;
-				SerializeBytes::serialize(value, &mut write_buf, mode)?;
+				SerializeBytes::serialize(&true, &mut write_buf)?;
+				SerializeBytes::serialize(value, &mut write_buf)?;
 			}
 			None => {
-				SerializeBytes::serialize(&false, write_buf, mode)?;
+				SerializeBytes::serialize(&false, write_buf)?;
 			}
 		}
 		Ok(())
@@ -352,49 +260,35 @@ impl<T: SerializeBytes> SerializeBytes for Option<T> {
 }
 
 impl<T: DeserializeBytes> DeserializeBytes for Option<T> {
-	fn deserialize(
-		mut read_buf: impl Buf,
-		mode: SerializationMode,
-	) -> Result<Self, SerializationError>
+	fn deserialize(mut read_buf: impl Buf) -> Result<Self, SerializationError>
 	where
 		Self: Sized,
 	{
-		Ok(match bool::deserialize(&mut read_buf, mode)? {
-			true => Some(T::deserialize(&mut read_buf, mode)?),
+		Ok(match bool::deserialize(&mut read_buf)? {
+			true => Some(T::deserialize(&mut read_buf)?),
 			false => None,
 		})
 	}
 }
 
 impl<U: SerializeBytes, V: SerializeBytes> SerializeBytes for (U, V) {
-	fn serialize(
-		&self,
-		mut write_buf: impl BufMut,
-		mode: SerializationMode,
-	) -> Result<(), SerializationError> {
-		U::serialize(&self.0, &mut write_buf, mode)?;
-		V::serialize(&self.1, write_buf, mode)
+	fn serialize(&self, mut write_buf: impl BufMut) -> Result<(), SerializationError> {
+		U::serialize(&self.0, &mut write_buf)?;
+		V::serialize(&self.1, write_buf)
 	}
 }
 
 impl<U: DeserializeBytes, V: DeserializeBytes> DeserializeBytes for (U, V) {
-	fn deserialize(
-		mut read_buf: impl Buf,
-		mode: SerializationMode,
-	) -> Result<Self, SerializationError>
+	fn deserialize(mut read_buf: impl Buf) -> Result<Self, SerializationError>
 	where
 		Self: Sized,
 	{
-		Ok((U::deserialize(&mut read_buf, mode)?, V::deserialize(read_buf, mode)?))
+		Ok((U::deserialize(&mut read_buf)?, V::deserialize(read_buf)?))
 	}
 }
 
 impl<N: ArrayLength<u8>> SerializeBytes for GenericArray<u8, N> {
-	fn serialize(
-		&self,
-		mut write_buf: impl BufMut,
-		_mode: SerializationMode,
-	) -> Result<(), SerializationError> {
+	fn serialize(&self, mut write_buf: impl BufMut) -> Result<(), SerializationError> {
 		assert_enough_space_for(&write_buf, N::USIZE)?;
 		write_buf.put_slice(self);
 		Ok(())
@@ -402,10 +296,7 @@ impl<N: ArrayLength<u8>> SerializeBytes for GenericArray<u8, N> {
 }
 
 impl<N: ArrayLength<u8>> DeserializeBytes for GenericArray<u8, N> {
-	fn deserialize(
-		mut read_buf: impl Buf,
-		_mode: SerializationMode,
-	) -> Result<Self, SerializationError> {
+	fn deserialize(mut read_buf: impl Buf) -> Result<Self, SerializationError> {
 		assert_enough_data_for(&read_buf, N::USIZE)?;
 		let mut ret = Self::default();
 		read_buf.copy_to_slice(&mut ret);
@@ -447,11 +338,9 @@ mod tests {
 		rng.fill_bytes(&mut data);
 
 		let mut buf = Vec::new();
-		data.serialize(&mut buf, SerializationMode::Native).unwrap();
+		data.serialize(&mut buf).unwrap();
 
-		let data_deserialized =
-			GenericArray::<u8, U32>::deserialize(&mut buf.as_slice(), SerializationMode::Native)
-				.unwrap();
+		let data_deserialized = GenericArray::<u8, U32>::deserialize(&mut buf.as_slice()).unwrap();
 		assert_eq!(data_deserialized, data);
 	}
 }

--- a/crates/verifier/src/hash/serialization.rs
+++ b/crates/verifier/src/hash/serialization.rs
@@ -3,7 +3,7 @@
 use std::{borrow::Borrow, cmp::min};
 
 use binius_transcript::BufMut;
-use binius_utils::{SerializationError, SerializationMode, SerializeBytes};
+use binius_utils::{SerializationError, SerializeBytes};
 use bytes::buf::UninitSlice;
 use digest::{
 	Digest, Output,
@@ -77,8 +77,7 @@ where
 	{
 		let mut buffer = HashBuffer::new(&mut hasher);
 		for item in items {
-			item.borrow()
-				.serialize(&mut buffer, SerializationMode::Native)?;
+			item.borrow().serialize(&mut buffer)?;
 		}
 	}
 	Ok(hasher.finalize())


### PR DESCRIPTION
# Remove SerializationMode from serialization traits

### TL;DR

Simplify the code by removing the option to serialize using canonical tower representation. We actually won't be able to use it anyway unless having an isomorphic 1b basis for the GHASH which could slow down the performance.

### What changed?

- Removed the `SerializationMode` enum and its usage throughout the codebase
- Updated the `SerializeBytes` trait to no longer require a mode parameter
- Updated the `DeserializeBytes` trait to no longer require a mode parameter
- Removed conditional serialization logic that was based on the mode
- Updated all implementations and call sites to use the simplified API
- Renamed a test from `test_canonical_serialization` to `test_serialization` to reflect the change

### How to test?

- Run the existing test suite to ensure serialization and deserialization still work correctly
- Verify that all serialization-related tests pass with the simplified API

### Why make this change?

This change simplifies the serialization API by removing the unnecessary complexity of different serialization modes. The codebase was primarily using a single mode, and the dual-mode approach added complexity without providing significant benefits. This change makes the API more straightforward and easier to use while reducing the potential for errors related to mode selection.