### PR TITLE
[field] Replace OptimalUnderlier with OptimalPacked

### DIFF
--- a/crates/field/benches/byte_iteration.rs
+++ b/crates/field/benches/byte_iteration.rs
@@ -3,8 +3,10 @@
 use std::iter::repeat_with;
 
 use binius_field::{
-	BinaryField1b, BinaryField8b, BinaryField128b, PackedField, arch::ArchOptimal,
-	byte_iteration::create_partial_sums_lookup_tables, packed::PackedSlice,
+	PackedField,
+	arch::{OptimalPackedB1, OptimalPackedB128},
+	byte_iteration::create_partial_sums_lookup_tables,
+	packed::PackedSlice,
 };
 use criterion::{
 	BenchmarkGroup, Criterion, criterion_group, criterion_main, measurement::WallTime,
@@ -37,17 +39,12 @@ fn partial_sums_benchmark(c: &mut Criterion) {
 	let mut group = c.benchmark_group("create_partial_sums_lookup_tables");
 	let counts = [8, 64, 128];
 
-	bench_create_partial_sums::<<BinaryField1b as ArchOptimal>::OptimalThroughputPacked>(
+	bench_create_partial_sums::<OptimalPackedB1>(
 		&mut group,
 		"BinaryField1b",
 		counts.iter().copied(),
 	);
-	bench_create_partial_sums::<<BinaryField8b as ArchOptimal>::OptimalThroughputPacked>(
-		&mut group,
-		"BinaryField8b",
-		counts.iter().copied(),
-	);
-	bench_create_partial_sums::<<BinaryField128b as ArchOptimal>::OptimalThroughputPacked>(
+	bench_create_partial_sums::<OptimalPackedB128>(
 		&mut group,
 		"BinaryField128b",
 		counts.iter().copied(),

--- a/crates/field/benches/main_field_binary_ops.rs
+++ b/crates/field/benches/main_field_binary_ops.rs
@@ -4,37 +4,9 @@ mod packed_field_utils;
 
 use std::ops::Mul;
 
-use binius_field::{
-	AESTowerField8b, AESTowerField16b, AESTowerField32b, AESTowerField64b, AESTowerField128b,
-	BinaryField1b, BinaryField8b, BinaryField16b, BinaryField32b, BinaryField64b, BinaryField128b,
-	BinaryField128bPolyval,
-	arch::{OptimalUnderlier, OptimalUnderlierByteSliced},
-	as_packed_field::PackedType,
-};
+use binius_field::arch::{OptimalPackedB1, OptimalPackedB128};
 use criterion::criterion_main;
 use packed_field_utils::benchmark_packed_operation;
-
-type OptimalPackedFP1b = PackedType<OptimalUnderlier, BinaryField1b>;
-type OptimalPackedFP8b = PackedType<OptimalUnderlier, BinaryField8b>;
-type OptimalPackedFP16b = PackedType<OptimalUnderlier, BinaryField16b>;
-type OptimalPackedFP32b = PackedType<OptimalUnderlier, BinaryField32b>;
-type OptimalPackedFP64b = PackedType<OptimalUnderlier, BinaryField64b>;
-type OptimalPackedFP128b = PackedType<OptimalUnderlier, BinaryField128b>;
-
-type OptimalPackedAES8b = PackedType<OptimalUnderlier, AESTowerField8b>;
-type OptimalPackedAES16b = PackedType<OptimalUnderlier, AESTowerField16b>;
-type OptimalPackedAES32b = PackedType<OptimalUnderlier, AESTowerField32b>;
-type OptimalPackedAES64b = PackedType<OptimalUnderlier, AESTowerField64b>;
-type OptimalPackedAES128b = PackedType<OptimalUnderlier, AESTowerField128b>;
-
-type OptimalPackedPolyval128b = PackedType<OptimalUnderlier, BinaryField128bPolyval>;
-
-type OptimalByteSliced1b = PackedType<OptimalUnderlierByteSliced, BinaryField1b>;
-type OptimalByteSlicedAES8b = PackedType<OptimalUnderlierByteSliced, AESTowerField8b>;
-type OptimalByteSlicedAES16b = PackedType<OptimalUnderlierByteSliced, AESTowerField16b>;
-type OptimalByteSlicedAES32b = PackedType<OptimalUnderlierByteSliced, AESTowerField32b>;
-type OptimalByteSlicedAES64b = PackedType<OptimalUnderlierByteSliced, AESTowerField64b>;
-type OptimalByteSlicedAES128b = PackedType<OptimalUnderlierByteSliced, AESTowerField128b>;
 
 trait SelfMul: Mul<Self, Output = Self> + Sized {}
 
@@ -51,31 +23,8 @@ benchmark_packed_operation!(
 		(mul_main, SelfMul, mul_main),
 	),
 	packed_fields @ [
-		// Fan-Paar Packed Fields
-		OptimalPackedFP1b
-		OptimalPackedFP8b
-		OptimalPackedFP16b
-		OptimalPackedFP32b
-		OptimalPackedFP64b
-		OptimalPackedFP128b
-
-		// AES-Tower Packed Fields
-		OptimalPackedAES8b
-		OptimalPackedAES16b
-		OptimalPackedAES32b
-		OptimalPackedAES64b
-		OptimalPackedAES128b
-
-		// Polyval field
-		OptimalPackedPolyval128b
-
-		// Byte-sliced fields
-		OptimalByteSliced1b
-		OptimalByteSlicedAES8b
-		OptimalByteSlicedAES16b
-		OptimalByteSlicedAES32b
-		OptimalByteSlicedAES64b
-		OptimalByteSlicedAES128b
+		OptimalPackedB1
+		OptimalPackedB128
 	]
 );
 

--- a/crates/field/benches/main_field_unary_ops.rs
+++ b/crates/field/benches/main_field_unary_ops.rs
@@ -3,36 +3,11 @@
 mod packed_field_utils;
 
 use binius_field::{
-	AESTowerField8b, AESTowerField16b, AESTowerField32b, AESTowerField64b, AESTowerField128b,
-	BinaryField1b, BinaryField8b, BinaryField16b, BinaryField32b, BinaryField64b, BinaryField128b,
-	BinaryField128bPolyval, PackedField,
-	arch::{OptimalUnderlier, OptimalUnderlierByteSliced},
-	as_packed_field::PackedType,
+	PackedField,
+	arch::{OptimalPackedB1, OptimalPackedB128},
 };
 use criterion::criterion_main;
 use packed_field_utils::benchmark_packed_operation;
-
-type OptimalPackedFP1b = PackedType<OptimalUnderlier, BinaryField1b>;
-type OptimalPackedFP8b = PackedType<OptimalUnderlier, BinaryField8b>;
-type OptimalPackedFP16b = PackedType<OptimalUnderlier, BinaryField16b>;
-type OptimalPackedFP32b = PackedType<OptimalUnderlier, BinaryField32b>;
-type OptimalPackedFP64b = PackedType<OptimalUnderlier, BinaryField64b>;
-type OptimalPackedFP128b = PackedType<OptimalUnderlier, BinaryField128b>;
-
-type OptimalPackedAES8b = PackedType<OptimalUnderlier, AESTowerField8b>;
-type OptimalPackedAES16b = PackedType<OptimalUnderlier, AESTowerField16b>;
-type OptimalPackedAES32b = PackedType<OptimalUnderlier, AESTowerField32b>;
-type OptimalPackedAES64b = PackedType<OptimalUnderlier, AESTowerField64b>;
-type OptimalPackedAES128b = PackedType<OptimalUnderlier, AESTowerField128b>;
-
-type OptimalPackedPolyval128b = PackedType<OptimalUnderlier, BinaryField128bPolyval>;
-
-type OptimalByteSliced1b = PackedType<OptimalUnderlierByteSliced, BinaryField1b>;
-type OptimalByteSlicedAES8b = PackedType<OptimalUnderlierByteSliced, AESTowerField8b>;
-type OptimalByteSlicedAES16b = PackedType<OptimalUnderlierByteSliced, AESTowerField16b>;
-type OptimalByteSlicedAES32b = PackedType<OptimalUnderlierByteSliced, AESTowerField32b>;
-type OptimalByteSlicedAES64b = PackedType<OptimalUnderlierByteSliced, AESTowerField64b>;
-type OptimalByteSlicedAES128b = PackedType<OptimalUnderlierByteSliced, AESTowerField128b>;
 
 fn invert<T: PackedField>(val: T) -> T {
 	val.invert_or_zero()
@@ -50,31 +25,8 @@ benchmark_packed_operation!(
 		(main_square, PackedField, square),
 	),
 	packed_fields @ [
-		// Fan-Paar Packed Fields
-		OptimalPackedFP1b
-		OptimalPackedFP8b
-		OptimalPackedFP16b
-		OptimalPackedFP32b
-		OptimalPackedFP64b
-		OptimalPackedFP128b
-
-		// AES-Tower Packed Fields
-		OptimalPackedAES8b
-		OptimalPackedAES16b
-		OptimalPackedAES32b
-		OptimalPackedAES64b
-		OptimalPackedAES128b
-
-		// Polyval field
-		OptimalPackedPolyval128b
-
-		// Byte-sliced fields
-		OptimalByteSliced1b
-		OptimalByteSlicedAES8b
-		OptimalByteSlicedAES16b
-		OptimalByteSlicedAES32b
-		OptimalByteSlicedAES64b
-		OptimalByteSlicedAES128b
+		OptimalPackedB1
+		OptimalPackedB128
 	]
 );
 

--- a/crates/field/src/arch/arch_optimal.rs
+++ b/crates/field/src/arch/arch_optimal.rs
@@ -2,87 +2,37 @@
 
 use cfg_if::cfg_if;
 
-use crate::{
-	ByteSlicedUnderlier, Field, PackedField,
-	as_packed_field::{PackScalar, PackedType},
-	underlier::WithUnderlier,
-};
-
-/// A trait to retrieve the optimal throughput `ordinal` packed field for a given architecture.
-pub trait ArchOptimal: Field {
-	type OptimalThroughputPacked: PackedField<Scalar = Self>
-		+ WithUnderlier<Underlier = OptimalUnderlier>;
-}
-
-impl<F> ArchOptimal for F
-where
-	F: Field,
-	OptimalUnderlier: PackScalar<F>,
-{
-	type OptimalThroughputPacked = PackedType<OptimalUnderlier, F>;
-}
-
-/// A trait to retrieve the optimal throughput packed byte-sliced field for a given architecture
-pub trait ArchOptimalByteSliced: Field {
-	type OptimalByteSliced: PackedField<Scalar = Self>
-		+ WithUnderlier<Underlier = OptimalUnderlierByteSliced>;
-}
-
-impl<F> ArchOptimalByteSliced for F
-where
-	F: Field,
-	OptimalUnderlierByteSliced: PackScalar<F>,
-{
-	type OptimalByteSliced = PackedType<OptimalUnderlierByteSliced, F>;
-}
-
 cfg_if! {
 	if #[cfg(all(feature = "nightly_features", target_arch = "x86_64", target_feature = "avx512f"))] {
 		pub const OPTIMAL_ALIGNMENT: usize = 512;
 
-		pub type OptimalUnderlier128b = crate::arch::x86_64::m128::M128;
-		pub type OptimalUnderlier256b = crate::arch::x86_64::m256::M256;
-		pub type OptimalUnderlier512b = crate::arch::x86_64::m512::M512;
-		pub type OptimalUnderlier = OptimalUnderlier512b;
-	} else if #[cfg(all(feature = "nightly_features", target_arch = "x86_64", target_feature = "avx2"))] {
-		use crate::underlier::ScaledUnderlier;
+		pub type OptimalPackedB1 = crate::PackedBinaryField512x1b;
+		pub type OptimalPackedB128 = crate::PackedBinaryGhash4x128b;
+		pub type OptimalB128 = crate::BinaryField128bGhash;
 
+	} else if #[cfg(all(feature = "nightly_features", target_arch = "x86_64", target_feature = "avx2"))] {
 		pub const OPTIMAL_ALIGNMENT: usize = 256;
 
-		pub type OptimalUnderlier128b = crate::arch::x86_64::m128::M128;
-		pub type OptimalUnderlier256b = crate::arch::x86_64::m256::M256;
-		pub type OptimalUnderlier512b = ScaledUnderlier<OptimalUnderlier256b, 2>;
-		pub type OptimalUnderlier = OptimalUnderlier256b;
+		pub type OptimalPackedB1 = crate::PackedBinaryField256x1b;
+		pub type OptimalPackedB128 = crate::PackedBinaryGhash2x128b;
+		pub type OptimalB128 = crate::BinaryField128bGhash;
 	} else if #[cfg(all(feature = "nightly_features", target_arch = "x86_64", target_feature = "sse2"))] {
-		use crate::underlier::ScaledUnderlier;
-
 		pub const OPTIMAL_ALIGNMENT: usize = 128;
 
-		pub type OptimalUnderlier128b = crate::arch::x86_64::m128::M128;
-		pub type OptimalUnderlier256b = ScaledUnderlier<OptimalUnderlier128b, 2>;
-		pub type OptimalUnderlier512b = ScaledUnderlier<OptimalUnderlier256b, 2>;
-		pub type OptimalUnderlier = OptimalUnderlier128b;
+		pub type OptimalPackedB1 = crate::PackedBinaryField128x1b;
+		pub type OptimalPackedB128 = crate::PackedBinaryGhash1x128b;
+		pub type OptimalB128 = crate::BinaryField128bGhash;
 	} else if #[cfg(all(target_arch = "aarch64", target_feature = "neon", target_feature = "aes"))] {
-		use crate::underlier::ScaledUnderlier;
-
 		pub const OPTIMAL_ALIGNMENT: usize = 128;
 
-		pub type OptimalUnderlier128b = crate::arch::aarch64::m128::M128;
-		pub type OptimalUnderlier256b = ScaledUnderlier<OptimalUnderlier128b, 2>;
-		pub type OptimalUnderlier512b = ScaledUnderlier<OptimalUnderlier256b, 2>;
-		pub type OptimalUnderlier = OptimalUnderlier128b;
+		pub type OptimalPackedB1 = crate::PackedBinaryField128x1b;
+		pub type OptimalPackedB128 = crate::PackedBinaryGhash1x128b;
+		pub type OptimalB128 = crate::BinaryField128bGhash;
 	} else {
-		use crate::underlier::ScaledUnderlier;
-
 		pub const OPTIMAL_ALIGNMENT: usize = 128;
 
-		pub type OptimalUnderlier128b = u128;
-		pub type OptimalUnderlier256b = ScaledUnderlier<OptimalUnderlier128b, 2>;
-		pub type OptimalUnderlier512b = ScaledUnderlier<OptimalUnderlier256b, 2>;
-		pub type OptimalUnderlier = OptimalUnderlier128b;
+		pub type OptimalPackedB1 = crate::PackedBinaryField128x1b;
+		pub type OptimalPackedB128 = crate::PackedBinaryGhash1x128b;
+		pub type OptimalB128 = crate::BinaryField128bGhash;
 	}
 }
-
-/// Optimal underlier for byte-sliced packed field for the current architecture.
-/// This underlier can pack up to 128b scalars.
-pub type OptimalUnderlierByteSliced = ByteSlicedUnderlier<OptimalUnderlier, 16>;

--- a/crates/math/benches/large_transform.rs
+++ b/crates/math/benches/large_transform.rs
@@ -3,10 +3,8 @@
 use std::iter::repeat_with;
 
 use binius_field::{
-	AESTowerField32b, AESTowerField128b, BinaryField32b, BinaryField128b, BinaryField128bPolyval,
 	PackedExtension, TowerField,
-	arch::{OptimalUnderlier, OptimalUnderlierByteSliced},
-	as_packed_field::PackedType,
+	arch::{OptimalB128, OptimalPackedB128},
 };
 use binius_math::ntt::{AdditiveNTT, NTTShape, SingleThreadedNTT};
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
@@ -48,34 +46,13 @@ fn bench_large_transform<F: TowerField, PE: PackedExtension<F>>(c: &mut Criterio
 	}
 }
 
-// We are ignoring the transposition associated with byte slicing
-fn bench_byte_sliced(c: &mut Criterion) {
-	bench_large_transform::<
-		AESTowerField32b,
-		PackedType<OptimalUnderlierByteSliced, AESTowerField128b>,
-	>(c, "bytesliced=AESTowerField128b");
-}
-
 fn bench_packed128b(c: &mut Criterion) {
-	bench_large_transform::<BinaryField32b, PackedType<OptimalUnderlier, BinaryField128b>>(
-		c,
-		"field=BinaryField128b",
-	);
-
-	bench_large_transform::<AESTowerField32b, PackedType<OptimalUnderlier, AESTowerField128b>>(
-		c,
-		"field=AESTowerField128b",
-	);
-
-	bench_large_transform::<
-		BinaryField128bPolyval,
-		PackedType<OptimalUnderlier, BinaryField128bPolyval>,
-	>(c, "field=BinaryField128bPolyval");
+	bench_large_transform::<OptimalB128, OptimalPackedB128>(c, "field=OptimalPackedB128");
 }
 
 criterion_group! {
 	name = large_transform;
 	config = Criterion::default().sample_size(10);
-	targets = bench_packed128b, bench_byte_sliced
+	targets = bench_packed128b
 }
 criterion_main!(large_transform);

--- a/crates/prover/src/fri/tests.rs
+++ b/crates/prover/src/fri/tests.rs
@@ -3,8 +3,9 @@
 use std::vec;
 
 use binius_field::{
-	BinaryField, BinaryField16b, BinaryField32b, BinaryField128b, ExtensionField, PackedExtension,
-	PackedField, arch::OptimalUnderlier128b, as_packed_field::PackedType, util::inner_product_par,
+	BinaryField, BinaryField16b, BinaryField32b, BinaryField128b, ExtensionField,
+	PackedBinaryField1x128b, PackedBinaryField4x32b, PackedExtension, PackedField,
+	util::inner_product_par,
 };
 use binius_math::{
 	ReedSolomonCode, multilinear::eq::eq_ind_partial_eval, ntt::SingleThreadedNTT,
@@ -146,11 +147,12 @@ fn test_commit_prove_verify_success_128b_full() {
 	let log_inv_rate = 2;
 	let arities = vec![1; log_dimension - log_final_dimension];
 
-	test_commit_prove_verify_success::<
-		BinaryField128b,
-		BinaryField16b,
-		PackedType<OptimalUnderlier128b, BinaryField128b>,
-	>(log_dimension, log_inv_rate, 0, &arities);
+	test_commit_prove_verify_success::<BinaryField128b, BinaryField16b, PackedBinaryField1x128b>(
+		log_dimension,
+		log_inv_rate,
+		0,
+		&arities,
+	);
 }
 
 #[test]
@@ -159,11 +161,12 @@ fn test_commit_prove_verify_success_128b_higher_arity() {
 	let log_inv_rate = 2;
 	let arities = [3, 2, 1];
 
-	test_commit_prove_verify_success::<
-		BinaryField128b,
-		BinaryField16b,
-		PackedType<OptimalUnderlier128b, BinaryField128b>,
-	>(log_dimension, log_inv_rate, 0, &arities);
+	test_commit_prove_verify_success::<BinaryField128b, BinaryField16b, PackedBinaryField1x128b>(
+		log_dimension,
+		log_inv_rate,
+		0,
+		&arities,
+	);
 }
 
 #[test]
@@ -173,11 +176,12 @@ fn test_commit_prove_verify_success_128b_interleaved() {
 	let log_batch_size = 2;
 	let arities = [3, 2, 1];
 
-	test_commit_prove_verify_success::<
-		BinaryField128b,
-		BinaryField16b,
-		PackedType<OptimalUnderlier128b, BinaryField128b>,
-	>(log_dimension, log_inv_rate, log_batch_size, &arities);
+	test_commit_prove_verify_success::<BinaryField128b, BinaryField16b, PackedBinaryField1x128b>(
+		log_dimension,
+		log_inv_rate,
+		log_batch_size,
+		&arities,
+	);
 }
 
 #[test]
@@ -187,11 +191,12 @@ fn test_commit_prove_verify_success_128b_interleaved_packed() {
 	let log_batch_size = 2;
 	let arities = [3, 2, 1];
 
-	test_commit_prove_verify_success::<
-		BinaryField32b,
-		BinaryField16b,
-		PackedType<OptimalUnderlier128b, BinaryField32b>,
-	>(log_dimension, log_inv_rate, log_batch_size, &arities);
+	test_commit_prove_verify_success::<BinaryField32b, BinaryField16b, PackedBinaryField4x32b>(
+		log_dimension,
+		log_inv_rate,
+		log_batch_size,
+		&arities,
+	);
 }
 
 #[test]
@@ -200,9 +205,10 @@ fn test_commit_prove_verify_success_without_folding() {
 	let log_inv_rate = 2;
 	let log_batch_size = 2;
 
-	test_commit_prove_verify_success::<
-		BinaryField128b,
-		BinaryField16b,
-		PackedType<OptimalUnderlier128b, BinaryField128b>,
-	>(log_dimension, log_inv_rate, log_batch_size, &[]);
+	test_commit_prove_verify_success::<BinaryField128b, BinaryField16b, PackedBinaryField1x128b>(
+		log_dimension,
+		log_inv_rate,
+		log_batch_size,
+		&[],
+	);
 }

--- a/crates/prover/tests/prove_verify.rs
+++ b/crates/prover/tests/prove_verify.rs
@@ -1,4 +1,4 @@
-use binius_field::{arch::OptimalUnderlier256b, as_packed_field::PackedType};
+use binius_field::arch::OptimalPackedB128;
 use binius_frontend::{
 	circuits::sha256::{Compress, State},
 	compiler,
@@ -10,7 +10,6 @@ use binius_prover::{merkle_tree::prover::BinaryMerkleTreeProver, prove};
 use binius_transcript::{ProverTranscript, fiat_shamir::HasherChallenger};
 use binius_verifier::{
 	Params,
-	fields::B128,
 	hash::{StdCompression, StdDigest},
 	merkle_tree::BinaryMerkleTreeScheme,
 	verify,
@@ -66,7 +65,7 @@ fn test_prove_verify_sha256_preimage() {
 	let ntt = SingleThreadedNTT::with_subspace(params.fri_params().rs_code().subspace()).unwrap();
 	let merkle_prover = BinaryMerkleTreeProver::<_, StdDigest, _>::new(StdCompression::default());
 	let mut prover_transcript = ProverTranscript::<HasherChallenger<Blake2b256>>::default();
-	prove::<PackedType<OptimalUnderlier256b, B128>, _, _, _, _>(
+	prove::<OptimalPackedB128, _, _, _, _>(
 		&params,
 		witness.clone(),
 		&mut prover_transcript,


### PR DESCRIPTION
### TL;DR

Replace optimal underliers with optimal packed 128b field. This simplifies the code and is a necessary step for making underliers private.

### What changed?

- Replaced the `ArchOptimal` trait with direct type aliases for optimal packed field implementations
- Introduced architecture-specific type aliases like `OptimalPackedB1` and `OptimalPackedB128` for binary fields
- Removed numerous unused type aliases in benchmark files
- Simplified benchmarks to focus on the most relevant field types
- Updated test code to use the new type aliases

### How to test?

- Run the existing benchmarks to ensure they still work with the new type system
- Verify that all tests pass with the new type aliases
- Check that the performance characteristics remain the same

### Why make this change?

This change simplifies the type system by removing an unnecessary layer of abstraction. Instead of using traits to determine the optimal field implementation for a given architecture, the code now directly uses type aliases that are defined based on the target architecture. This makes the code more straightforward and easier to understand, while maintaining the same functionality and performance characteristics.