### PR TITLE
[field] Make `underliers` module private

### DIFF
--- a/crates/field/src/lib.rs
+++ b/crates/field/src/lib.rs
@@ -36,7 +36,7 @@ mod tests;
 pub mod tower_levels;
 mod tracing;
 pub mod transpose;
-pub mod underlier;
+mod underlier;
 pub mod util;
 
 pub use aes_field::*;

--- a/crates/field/src/underlier/divisible.rs
+++ b/crates/field/src/underlier/divisible.rs
@@ -13,6 +13,7 @@ use std::{
 /// # Safety
 /// Implementors must ensure that `&Self` can be safely bit-cast to `&[U; Self::WIDTH]` and
 /// `&mut Self` can be safely bit-cast to `&mut [U; Self::WIDTH]`.
+#[allow(dead_code)]
 pub unsafe trait Divisible<U: UnderlierType>: UnderlierType {
 	const WIDTH: usize = {
 		assert!(size_of::<Self>().is_multiple_of(size_of::<U>()));


### PR DESCRIPTION
# Remove `underlier` module from public API

### TL;DR

Removes the `underlier` module from the public API. We can't make the `UnderlierType` trait private itself as it is used in some public generic trait implementations, so Rust won't allow it. But we can hide the whole `underliers` module, so it can't be used directly from other crates.

### What changed?

- Made the `underlier` module private in `crates/field/src/lib.rs`
- Updated code to use `BinaryField::N_BITS` instead of `WithUnderlier::Underlier::BITS`
- Removed unnecessary imports of `underlier` types across multiple files
- Updated benchmarks and tests to use the new trait methods
- Simplified type constraints in generic functions

### How to test?

Run the existing test suite and benchmarks to ensure everything still works correctly:

```bash
cargo test
cargo bench
```

### Why make this change?

This change simplifies the API by removing implementation details from the public interface. Using the `BinaryField` trait methods directly instead of going through the `underlier` module makes the code more maintainable and easier to understand. It also reduces the surface area of the public API, making it cleaner and more focused.