### PR TITLE
[frontend] extract gate graph in its own module

### DIFF
--- a/crates/frontend/src/compiler/gate/assert_0.rs
+++ b/crates/frontend/src/compiler/gate/assert_0.rs
@@ -10,9 +10,11 @@
 ///
 /// The gate generates 1 AND constraint:
 /// - `x ∧ all-1 = 0`
-use super::{Gate, GateData};
 use crate::{
-	compiler::circuit,
+	compiler::{
+		circuit,
+		gate_graph::{Gate, GateData},
+	},
 	constraint_system::{AndConstraint, ConstraintSystem},
 	word::Word,
 };

--- a/crates/frontend/src/compiler/gate/assert_band_0.rs
+++ b/crates/frontend/src/compiler/gate/assert_band_0.rs
@@ -10,9 +10,11 @@
 ///
 /// The gate generates 1 AND constraint:
 /// - `x ∧ constant = 0`
-use super::{Gate, GateData};
 use crate::{
-	compiler::circuit,
+	compiler::{
+		circuit,
+		gate_graph::{Gate, GateData},
+	},
 	constraint_system::{AndConstraint, ConstraintSystem},
 	word::Word,
 };

--- a/crates/frontend/src/compiler/gate/assert_eq.rs
+++ b/crates/frontend/src/compiler/gate/assert_eq.rs
@@ -11,9 +11,11 @@
 ///
 /// The gate generates 1 AND constraint:
 /// - `(x ⊕ y) ∧ all-1 = 0`
-use super::{Gate, GateData};
 use crate::{
-	compiler::circuit,
+	compiler::{
+		circuit,
+		gate_graph::{Gate, GateData},
+	},
 	constraint_system::{AndConstraint, ConstraintSystem},
 };
 

--- a/crates/frontend/src/compiler/gate/assert_eq_cond.rs
+++ b/crates/frontend/src/compiler/gate/assert_eq_cond.rs
@@ -12,9 +12,11 @@
 ///
 /// The gate generates 1 AND constraint:
 /// - `(x ⊕ y) ∧ mask = 0`
-use super::{Gate, GateData};
 use crate::{
-	compiler::circuit,
+	compiler::{
+		circuit,
+		gate_graph::{Gate, GateData},
+	},
 	constraint_system::{AndConstraint, ConstraintSystem},
 	word::Word,
 };

--- a/crates/frontend/src/compiler/gate/band.rs
+++ b/crates/frontend/src/compiler/gate/band.rs
@@ -10,9 +10,11 @@
 ///
 /// The gate generates 1 AND constraint:
 /// - `x ∧ y = z`
-use super::{Gate, GateData};
 use crate::{
-	compiler::circuit,
+	compiler::{
+		circuit,
+		gate_graph::{Gate, GateData},
+	},
 	constraint_system::{AndConstraint, ConstraintSystem},
 };
 

--- a/crates/frontend/src/compiler/gate/bor.rs
+++ b/crates/frontend/src/compiler/gate/bor.rs
@@ -11,9 +11,11 @@
 ///
 /// The gate generates 1 AND constraint:
 /// - `x ∧ y = x ⊕ y ⊕ z`
-use super::{Gate, GateData};
 use crate::{
-	compiler::circuit,
+	compiler::{
+		circuit,
+		gate_graph::{Gate, GateData},
+	},
 	constraint_system::{AndConstraint, ConstraintSystem},
 };
 

--- a/crates/frontend/src/compiler/gate/bxor.rs
+++ b/crates/frontend/src/compiler/gate/bxor.rs
@@ -11,9 +11,11 @@
 ///
 /// The gate generates 1 AND constraint:
 /// - `(x ⊕ y) ∧ all-1 = z`
-use super::{Gate, GateData};
 use crate::{
-	compiler::circuit,
+	compiler::{
+		circuit,
+		gate_graph::{Gate, GateData},
+	},
 	constraint_system::{AndConstraint, ConstraintSystem},
 };
 

--- a/crates/frontend/src/compiler/gate/extract_byte.rs
+++ b/crates/frontend/src/compiler/gate/extract_byte.rs
@@ -15,9 +15,11 @@
 /// The gate generates 2 AND constraints:
 /// 1. Low byte extraction: `((word >> (8*j)) ⊕ z) ∧ 0xFF = 0`
 /// 2. High bits zeroing: `z ∧ 0xFFFFFFFFFFFFFF00 = 0`
-use super::{Gate, GateData};
 use crate::{
-	compiler::circuit,
+	compiler::{
+		circuit,
+		gate_graph::{Gate, GateData},
+	},
 	constraint_system::{AndConstraint, ConstraintSystem, ShiftedValueIndex},
 	word::Word,
 };

--- a/crates/frontend/src/compiler/gate/iadd32.rs
+++ b/crates/frontend/src/compiler/gate/iadd32.rs
@@ -13,9 +13,11 @@
 /// The gate generates 2 AND constraints:
 /// 1. Carry propagation: `(x ⊕ (cout << 1)) ∧ (y ⊕ (cout << 1)) = cout ⊕ (cout << 1)`
 /// 2. Result masking: `(x ⊕ y ⊕ (cout << 1)) ∧ MASK_32 = z`
-use super::{Gate, GateData};
 use crate::{
-	compiler::circuit,
+	compiler::{
+		circuit,
+		gate_graph::{Gate, GateData},
+	},
 	constraint_system::{AndConstraint, ConstraintSystem, ShiftedValueIndex},
 };
 

--- a/crates/frontend/src/compiler/gate/iadd_cin_cout.rs
+++ b/crates/frontend/src/compiler/gate/iadd_cin_cout.rs
@@ -25,9 +25,11 @@
 ///
 /// 1. **Carry generation constraint**: Ensures correct carry propagation
 /// 2. **Sum constraint**: Ensures the sum equals `a ^ b ^ (cout << 1) ^ cin_msb`
-use super::{Gate, GateData};
 use crate::{
-	compiler::circuit,
+	compiler::{
+		circuit,
+		gate_graph::{Gate, GateData},
+	},
 	constraint_system::{AndConstraint, ConstraintSystem, ShiftedValueIndex},
 };
 

--- a/crates/frontend/src/compiler/gate/icmp_eq.rs
+++ b/crates/frontend/src/compiler/gate/icmp_eq.rs
@@ -21,9 +21,11 @@
 /// The gate generates two AND constraints:
 /// 1. Carry propagation: `(x ⊕ y ⊕ cin) ∧ (all-1 ⊕ cin) = cin ⊕ cout`
 /// 2. Mask generation: `out_mask = (cout SRA 63) ⊕ all-1`
-use super::{Gate, GateData};
 use crate::{
-	compiler::circuit,
+	compiler::{
+		circuit,
+		gate_graph::{Gate, GateData},
+	},
 	constraint_system::{AndConstraint, ConstraintSystem, ShiftedValueIndex},
 	word::Word,
 };

--- a/crates/frontend/src/compiler/gate/icmp_ult.rs
+++ b/crates/frontend/src/compiler/gate/icmp_ult.rs
@@ -19,9 +19,11 @@
 /// The gate generates 2 AND constraints:
 /// 1. Borrow propagation: `(¬x ⊕ bin) ∧ (y ⊕ bin) = bin ⊕ bout`
 /// 2. Mask generation: `out_mask = bout SRA 63`
-use super::{Gate, GateData};
 use crate::{
-	compiler::circuit,
+	compiler::{
+		circuit,
+		gate_graph::{Gate, GateData},
+	},
 	constraint_system::{AndConstraint, ConstraintSystem, ShiftedValueIndex},
 	word::Word,
 };

--- a/crates/frontend/src/compiler/gate/imul.rs
+++ b/crates/frontend/src/compiler/gate/imul.rs
@@ -1,8 +1,10 @@
 /// Imul gate implements 64-bit × 64-bit → 128-bit unsigned multiplication.
 /// Uses the MulConstraint: X * Y = (HI << 64) | LO
-use super::{Gate, GateData};
 use crate::{
-	compiler::circuit,
+	compiler::{
+		circuit,
+		gate_graph::{Gate, GateData},
+	},
 	constraint_system::{ConstraintSystem, MulConstraint, ShiftedValueIndex},
 };
 

--- a/crates/frontend/src/compiler/gate/rotr32.rs
+++ b/crates/frontend/src/compiler/gate/rotr32.rs
@@ -17,9 +17,11 @@
 ///
 /// The gate generates 1 AND constraint:
 /// - `((x >> n) ⊕ (x << (32-n))) ∧ MASK_32 = z`
-use super::{Gate, GateData};
 use crate::{
-	compiler::circuit,
+	compiler::{
+		circuit,
+		gate_graph::{Gate, GateData},
+	},
 	constraint_system::{AndConstraint, ConstraintSystem, ShiftedValueIndex},
 };
 

--- a/crates/frontend/src/compiler/gate/shl.rs
+++ b/crates/frontend/src/compiler/gate/shl.rs
@@ -11,9 +11,11 @@
 ///
 /// The gate generates 1 AND constraint:
 /// - `(x << n) ∧ all-1 = z`
-use super::{Gate, GateData};
 use crate::{
-	compiler::circuit,
+	compiler::{
+		circuit,
+		gate_graph::{Gate, GateData},
+	},
 	constraint_system::{AndConstraint, ConstraintSystem, ShiftedValueIndex},
 };
 

--- a/crates/frontend/src/compiler/gate/shr.rs
+++ b/crates/frontend/src/compiler/gate/shr.rs
@@ -11,9 +11,11 @@
 ///
 /// The gate generates 1 AND constraint:
 /// - `(x >> n) ∧ all-1 = z`
-use super::{Gate, GateData};
 use crate::{
-	compiler::circuit,
+	compiler::{
+		circuit,
+		gate_graph::{Gate, GateData},
+	},
 	constraint_system::{AndConstraint, ConstraintSystem, ShiftedValueIndex},
 };
 

--- a/crates/frontend/src/compiler/gate/shr32.rs
+++ b/crates/frontend/src/compiler/gate/shr32.rs
@@ -10,9 +10,11 @@
 ///
 /// The gate generates 1 AND constraint:
 /// - `(x >> n) ∧ MASK_32 = z`
-use super::{Gate, GateData};
 use crate::{
-	compiler::circuit,
+	compiler::{
+		circuit,
+		gate_graph::{Gate, GateData},
+	},
 	constraint_system::{AndConstraint, ConstraintSystem, ShiftedValueIndex},
 };
 

--- a/crates/frontend/src/compiler/gate_graph.rs
+++ b/crates/frontend/src/compiler/gate_graph.rs
@@ -1,0 +1,124 @@
+use std::collections::HashMap;
+
+use cranelift_entity::{PrimaryMap, SecondaryMap, entity_impl};
+
+use crate::{compiler::gate::opcode::Opcode, word::Word};
+
+#[derive(Default)]
+pub struct ConstPool {
+	pub pool: HashMap<Word, Wire>,
+}
+
+impl ConstPool {
+	pub fn new() -> Self {
+		ConstPool::default()
+	}
+
+	pub fn get(&self, value: Word) -> Option<Wire> {
+		self.pool.get(&value).cloned()
+	}
+
+	pub fn insert(&mut self, word: Word, wire: Wire) {
+		let prev = self.pool.insert(word, wire);
+		assert!(prev.is_none());
+	}
+}
+
+/// A wire through which a value flows in and out of gates.
+///
+/// The difference from `ValueIndex` is that a wire is abstract. Some wires could be moved during
+/// compilation and some wires might be pruned altogether.
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+pub struct Wire(u32);
+entity_impl!(Wire);
+
+#[derive(Copy, Clone)]
+pub enum WireKind {
+	Constant(Word),
+	Inout,
+	Witness,
+}
+
+#[derive(Copy, Clone)]
+pub struct WireData {
+	pub kind: WireKind,
+}
+
+/// Gate ID - identifies a gate in the graph
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct Gate(u32);
+
+entity_impl!(Gate);
+
+/// Describes a particular gate in the gate graph, it's type, input and output wires and
+/// immediate parameters.
+pub struct GateData {
+	/// The code of operation of this gate.
+	pub opcode: Opcode,
+
+	/// The input and output wires of this gate.
+	///
+	/// They are laid out in the following order:
+	/// - Inputs
+	/// - Outputs
+	///
+	/// The number of input and output wires is specified by the opcode's shape.
+	pub wires: Vec<Wire>,
+
+	/// The immediate parameters of this gate.
+	///
+	/// The immediates contain compile-time parameters of the circuits, such as shift amounts,
+	/// byte indices, etc.
+	///
+	/// The length of the immediates is specified by the opcode's shape.
+	pub immediates: Vec<u32>,
+}
+
+impl GateData {
+	pub fn inputs(&self) -> &[Wire] {
+		let shape = self.opcode.shape();
+		&self.wires[..shape.n_in]
+	}
+
+	pub fn outputs(&self) -> &[Wire] {
+		let shape = self.opcode.shape();
+		&self.wires[shape.n_in..]
+	}
+
+	/// Ensures the gate has the right shape.
+	pub fn validate_shape(&self) {
+		assert_eq!(self.inputs().len(), self.opcode.shape().n_in);
+		assert_eq!(self.outputs().len(), self.opcode.shape().n_out);
+		assert_eq!(self.immediates.len(), self.opcode.shape().n_imm);
+	}
+}
+
+/// Gate graph replaces the current Shared struct
+pub struct GateGraph {
+	// Primary maps
+	pub gates: PrimaryMap<Gate, GateData>,
+	pub wires: PrimaryMap<Wire, WireData>,
+
+	// Secondary maps for optional data
+	pub assertion_names: SecondaryMap<Gate, String>,
+
+	// Other circuit data
+	pub const_pool: ConstPool,
+	pub n_witness: usize,
+	pub n_inout: usize,
+}
+
+impl GateGraph {
+	/// Runs a validation pass ensuring all the invariants hold.
+	pub fn validate(&self) {
+		// Every gate holds shape.
+		for gate in self.gates.values() {
+			gate.validate_shape();
+		}
+	}
+
+	/// Return the number of constants this graph defines.
+	pub fn n_const(&self) -> usize {
+		self.const_pool.pool.len()
+	}
+}

--- a/crates/frontend/src/constraint_system.rs
+++ b/crates/frontend/src/constraint_system.rs
@@ -5,6 +5,18 @@ use crate::word::Word;
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub struct ValueIndex(pub u32);
 
+impl ValueIndex {
+	/// The value index that is not considered to be valid.
+	pub const INVALID: ValueIndex = ValueIndex(u32::MAX);
+}
+
+// The most sensible default for a value index is to make it invalid.
+impl Default for ValueIndex {
+	fn default() -> Self {
+		Self::INVALID
+	}
+}
+
 /// A different variants of shifting a value.
 ///
 /// Note that there is no shift left arithmetic because it is redundant.


### PR DESCRIPTION
Also shuffle things around to their natural places.

One thing that we had to do due to the privacy issues is to use SecondaryMap
instead of Vec<ValueIndex> for tracking the correspondence between Wire and
ValueIndex.