### PR TITLE
FieldBuffer support for capacity, truncation and zero extension.

### DIFF
--- a/crates/maybe-rayon/src/iter/indexed_parallel_iterator.rs
+++ b/crates/maybe-rayon/src/iter/indexed_parallel_iterator.rs
@@ -58,7 +58,7 @@ pub(crate) trait IndexedParallelIteratorInner: ParallelIteratorInner {
 		Z: IntoParallelIterator,
 		Z::Iter: IndexedParallelIteratorInner,
 	{
-		Itertools::zip_eq(self, zip_op)
+		itertools::Itertools::zip_eq(self, zip_op)
 	}
 
 	#[inline]


### PR DESCRIPTION
# Truncated Field Buffers

### TL;DR

Enhance `FieldBuffer` to support truncated buffers with capacity larger than logical length, improving memory efficiency and enabling in-place operations.

### What changed?

- Added new constructors `from_values_truncated`, `zeros_truncated`, and `new_truncated` that allow creating buffers with capacity larger than logical length
- Added `truncate` and `zero_extend` methods to modify buffer length without reallocating
- Added `log_cap()` and `cap()` methods to query buffer capacity
- Introduced a new invariant that guarantees zeros in the unused portion of the buffer
- Added `NonZeroRemainder` error for when truncation would discard non-zero values
- Refactored `tensor_prod_eq_ind` and `eq_ind_truncate_low_inplace` to use the new truncation capabilities
- Simplified `fold_highest_var_inplace` to use truncation
- Updated `as_ref()` and `as_mut()` implementations to only expose the active portion of the buffer

### How to test?

- Run the existing test suite, which has been updated to test the new functionality
- Create a field buffer with capacity larger than length:
  ```rust
  let buffer = FieldBuffer::<P>::zeros_truncated(3, 5).unwrap();
  assert_eq!(buffer.log_len(), 3);
  assert_eq!(buffer.log_cap(), 5);
  ```
- Test truncation and extension:
  ```rust
  let mut buffer = FieldBuffer::<P>::zeros_truncated(3, 5).unwrap();
  buffer.truncate(2).unwrap();
  assert_eq!(buffer.log_len(), 2);
  buffer.zero_extend(4).unwrap();
  assert_eq!(buffer.log_len(), 4);
  ```

### Why make this change?

This change improves memory efficiency and performance by:

1. Allowing buffers to grow and shrink without reallocating memory
2. Enabling in-place operations that would otherwise require temporary buffers
3. Maintaining a clear distinction between logical length and physical capacity
4. Ensuring that unused portions of the buffer are zeroed, which is important for correctness in mathematical operations

The implementation is particularly useful for operations like `tensor_prod_eq_ind` that need to grow a buffer incrementally, and for operations like `fold_highest_var_inplace` that need to shrink a buffer.