### PR TITLE
[evaluate] Methods for multilinear evaluation

### DIFF
--- a/crates/math/src/inner_product.rs
+++ b/crates/math/src/inner_product.rs
@@ -1,0 +1,49 @@
+// Copyright 2024-2025 Irreducible Inc.
+
+use std::ops::Deref;
+
+use binius_field::{ExtensionField, Field, PackedField};
+use binius_maybe_rayon::prelude::*;
+
+use crate::FieldBuffer;
+
+#[inline]
+pub fn inner_product<F: Field>(
+	a: impl IntoIterator<Item = F>,
+	b: impl IntoIterator<Item = F>,
+) -> F {
+	inner_product_subfield(a, b)
+}
+
+#[inline]
+pub fn inner_product_subfield<F, FSub>(
+	a: impl IntoIterator<Item = FSub>,
+	b: impl IntoIterator<Item = F>,
+) -> F
+where
+	F: Field + ExtensionField<FSub>,
+	FSub: Field,
+{
+	itertools::zip_eq(a, b).map(|(a_i, b_i)| b_i * a_i).sum()
+}
+
+pub fn inner_product_par<F, P, DataA, DataB>(
+	a: &FieldBuffer<P, DataA>,
+	b: &FieldBuffer<P, DataB>,
+) -> F
+where
+	F: Field,
+	P: PackedField<Scalar = F>,
+	DataA: Deref<Target = [P]>,
+	DataB: Deref<Target = [P]>,
+{
+	assert_eq!(a.len(), b.len()); // pre-condition
+
+	a.as_ref()
+		.par_iter()
+		.zip(b.as_ref().par_iter())
+		.map(|(&a_i, &b_i)| a_i * b_i)
+		.sum::<P>()
+		.into_iter()
+		.sum()
+}

--- a/crates/math/src/lib.rs
+++ b/crates/math/src/lib.rs
@@ -14,6 +14,7 @@ pub mod binary_subspace;
 mod error;
 pub mod field_buffer;
 pub mod fold;
+pub mod inner_product;
 pub mod line;
 pub mod matrix;
 pub mod multilinear;

--- a/crates/math/src/multilinear/evaluate.rs
+++ b/crates/math/src/multilinear/evaluate.rs
@@ -1,0 +1,187 @@
+// Copyright 2025 Irreducible Inc.
+
+use std::{
+	iter,
+	ops::{Deref, DerefMut},
+};
+
+use binius_field::{Field, PackedField};
+
+use crate::{
+	Error, FieldBuffer, inner_product::inner_product_par, multilinear::eq::eq_ind_partial_eval,
+};
+
+/// Evaluates a multilinear polynomial at a given point using inner product with eq indicator.
+///
+/// This method computes the evaluation by:
+/// 1. Computing the tensor expansion of the equality indicator at the given coordinates
+/// 2. Taking the inner product of the evaluations and the eq tensor
+///
+/// # Arguments
+/// * `evals` - A FieldBuffer containing the 2^n evaluations over the boolean hypercube
+/// * `coords` - The n coordinates at which to evaluate the polynomial
+///
+/// # Returns
+/// The evaluation of the multilinear polynomial at the given point
+pub fn evaluate_with_inner_product<F, P, Data>(
+	evals: &FieldBuffer<P, Data>,
+	point: &[F],
+) -> Result<F, Error>
+where
+	F: Field,
+	P: PackedField<Scalar = F>,
+	Data: Deref<Target = [P]>,
+{
+	if point.len() != evals.log_len() {
+		return Err(Error::IncorrectArgumentLength {
+			arg: "coords".to_string(),
+			expected: evals.log_len(),
+		});
+	}
+
+	// Compute the equality indicator tensor expansion
+	let eq_tensor = eq_ind_partial_eval::<P>(point);
+	let result = inner_product_par(evals, &eq_tensor);
+	Ok(result)
+}
+
+/// Evaluates a multilinear polynomial at a given point, modifying the buffer in-place.
+///
+/// This method computes the evaluation of a multilinear polynomial specified by it's evaluations
+/// on the boolean hypercube. For an $n$-variate multilinear, this implementation performs
+/// $2^n - 1$ field multiplications and allocates no additional memory. The `evals` buffer is
+/// modified in-place.
+///
+/// # Arguments
+/// * `evals` - A [`FieldBuffer`] containing the $2^n$ evaluations over the boolean hypercube
+/// * `coords` - The $n$ coordinates at which to evaluate the polynomial
+///
+/// # Returns
+/// The evaluation of the multilinear polynomial at the given point
+pub fn evaluate_inplace<F, P, Data>(
+	mut evals: FieldBuffer<P, Data>,
+	coords: &[F],
+) -> Result<F, Error>
+where
+	F: Field,
+	P: PackedField<Scalar = F>,
+	Data: DerefMut<Target = [P]>,
+{
+	if coords.len() != evals.log_len() {
+		return Err(Error::IncorrectArgumentLength {
+			arg: "coords".to_string(),
+			expected: evals.log_len(),
+		});
+	}
+
+	// Perform folding for each coordinate in reverse order
+	if let Some((&last_coord, remaining_coords)) = coords.split_last() {
+		evals.split_half_mut(move |evals_lo, evals_hi| {
+			// Compute the folded values: lo + (hi - lo) * coord
+			// This is equivalent to lo * (1 - coord) + hi * coord
+			let packed_coord = P::broadcast(last_coord);
+			for (lo_i, hi_i) in iter::zip(evals_lo.as_mut(), evals_hi.as_ref()) {
+				*lo_i += (*hi_i - *lo_i) * packed_coord;
+			}
+
+			evaluate_inplace(evals_lo.to_mut(), remaining_coords)
+		})?
+	} else {
+		// Base case: no coordinates means we just return the single evaluation
+		let val = evals
+			.get(0)
+			.expect("coords.len() == 0; coords.len() == evals.log_len(); evals has one element");
+		Ok(val)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use binius_field::BinaryField128bGhash;
+	use rand::{RngCore, SeedableRng, rngs::StdRng};
+
+	use super::*;
+	use crate::test_utils::{index_to_hypercube_point, random_field_buffer, random_scalars};
+
+	#[test]
+	fn test_evaluate_consistency() {
+		let mut rng = StdRng::seed_from_u64(0);
+
+		// Generate random buffer and evaluation point
+		let log_n = 10;
+		let buffer = random_field_buffer::<BinaryField128bGhash>(&mut rng, log_n);
+		let point = random_scalars::<BinaryField128bGhash>(&mut rng, log_n);
+
+		// Evaluate using both methods
+		let result_inner_product = evaluate_with_inner_product(&buffer, &point).unwrap();
+		let result_inplace = evaluate_inplace(buffer.clone(), &point).unwrap();
+
+		// Results should be equal
+		assert_eq!(result_inner_product, result_inplace);
+	}
+
+	#[test]
+	fn test_evaluate_at_hypercube_indices() {
+		let mut rng = StdRng::seed_from_u64(0);
+
+		// Generate random multilinear with 8 variables
+		let log_n = 8;
+		let buffer = random_field_buffer::<BinaryField128bGhash>(&mut rng, log_n);
+
+		// Test 16 random hypercube indices
+		for _ in 0..16 {
+			let index = (rng.next_u32() as usize) % (1 << log_n);
+			let point = index_to_hypercube_point::<BinaryField128bGhash>(log_n, index);
+
+			// Evaluate at the hypercube point
+			let eval_result = evaluate_with_inner_product(&buffer, &point).unwrap();
+
+			// Get the value directly from the buffer
+			let direct_value = buffer.get(index).unwrap();
+
+			// They should be equal
+			assert_eq!(eval_result, direct_value);
+		}
+	}
+
+	#[test]
+	fn test_linearity() {
+		let mut rng = StdRng::seed_from_u64(0);
+
+		// Generate random 8-variable multilinear and evaluation point
+		let log_n = 8;
+		let buffer = random_field_buffer::<BinaryField128bGhash>(&mut rng, log_n);
+		let mut point = random_scalars::<BinaryField128bGhash>(&mut rng, log_n);
+
+		// Test linearity for each coordinate
+		for coord_idx in 0..log_n {
+			// Choose three coordinate values
+			let coord_vals = random_scalars::<BinaryField128bGhash>(&mut rng, 3);
+
+			// Evaluate at three points differing only in coordinate coord_idx
+			let evals: Vec<_> = coord_vals
+				.iter()
+				.map(|&coord_val| {
+					point[coord_idx] = coord_val;
+					evaluate_with_inner_product(&buffer, &point).unwrap()
+				})
+				.collect();
+
+			// Check that the three evaluations form a line
+			// For a line through points (x0, y0), (x1, y1), (x2, y2):
+			// y2 - y0 = (y1 - y0) * (x2 - x0) / (x1 - x0)
+			// Rearranging: (y2 - y0) * (x1 - x0) = (y1 - y0) * (x2 - x0)
+			let x0 = coord_vals[0];
+			let x1 = coord_vals[1];
+			let x2 = coord_vals[2];
+			let y0 = evals[0];
+			let y1 = evals[1];
+			let y2 = evals[2];
+
+			let lhs = (y2 - y0) * (x1 - x0);
+			let rhs = (y1 - y0) * (x2 - x0);
+
+			assert_eq!(lhs, rhs);
+		}
+	}
+}

--- a/crates/math/src/multilinear/mod.rs
+++ b/crates/math/src/multilinear/mod.rs
@@ -1,4 +1,5 @@
 // Copyright 2025 Irreducible Inc.
 
 pub mod eq;
+pub mod evaluate;
 pub mod fold;


### PR DESCRIPTION
# Add multilinear polynomial evaluation functions

### TL;DR

Adds functions for evaluating multilinear polynomials at arbitrary points using two different methods.

### What changed?

- Added a new `inner_product.rs` module with functions for computing inner products between vectors. We had inner product functions in `binius_field::utils` before, but I don't think those interfaces are great and this code belongs in `binius_math`.
- Added a new `evaluate.rs` module in the multilinear package with two evaluation methods:
  - `evaluate_with_inner_product`: Evaluates using inner product with equality indicators
  - `evaluate_inplace`: Performs evaluation by folding the buffer in-place
- Added comprehensive tests for the evaluation functions, including consistency checks, hypercube point evaluation, and linearity verification

### How to test?

Run the test suite for the new evaluation functions:
```
cargo test -p binius-math --lib multilinear::evaluate
```

### Why make this change?

Multilinear polynomial evaluation is a fundamental operation needed for various cryptographic protocols. This implementation provides two different approaches:
1. The inner product method is conceptually simpler and can leverage parallelism
2. The in-place method is more memory-efficient as it requires no additional allocations

Having both methods allows for flexibility depending on the use case requirements.es FRI