### PR TITLE
[math] Benchmark multilinear evaluation functions

### DIFF
--- a/crates/math/Cargo.toml
+++ b/crates/math/Cargo.toml
@@ -21,14 +21,17 @@ transpose.workspace = true
 
 [dev-dependencies]
 assert_matches.workspace = true
-binius-math = { path = ".", default-features = false, features = ["test-utils"] }
+binius-math = { path = ".", features = ["test-utils"] }
 criterion.workspace = true
 lazy_static.workspace = true
 proptest.workspace = true
 rand = { workspace = true, features = ["std_rng", "thread_rng"] }
 
 [features]
+default = ["nightly-features", "rayon"]
 test-utils = []
+nightly-features = ["binius-field/nightly_features"]
+rayon = ["binius-maybe-rayon/rayon"]
 
 [lib]
 bench = false
@@ -39,4 +42,8 @@ harness = false
 
 [[bench]]
 name = "large_transform"
+harness = false
+
+[[bench]]
+name = "multilinear_evaluate"
 harness = false

--- a/crates/math/benches/multilinear_evaluate.rs
+++ b/crates/math/benches/multilinear_evaluate.rs
@@ -1,0 +1,62 @@
+// Copyright 2025 Irreducible Inc.
+
+use binius_field::arch::{OptimalB128, OptimalPackedB128};
+use binius_math::{
+	inner_product::inner_product_par,
+	multilinear::{
+		eq::eq_ind_partial_eval,
+		evaluate::{evaluate, evaluate_inplace},
+	},
+	test_utils::{random_field_buffer, random_scalars},
+};
+use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use rand::{SeedableRng, rngs::StdRng};
+
+fn bench_multilinear_evaluate(c: &mut Criterion) {
+	type F = OptimalB128;
+	type P = OptimalPackedB128;
+
+	let mut group = c.benchmark_group("multilinear_evaluate");
+
+	// Benchmark with 20 variables
+	let log_n = 20;
+	let n_vars = log_n;
+
+	// Calculate data size for throughput measurement
+	let data_len = 1 << (log_n - P::LOG_WIDTH);
+	let data_size = data_len * size_of::<P>();
+	group.throughput(Throughput::Bytes(data_size as u64));
+
+	// Generate random multilinear polynomial and evaluation point
+	let mut rng = StdRng::seed_from_u64(0);
+	let buffer = random_field_buffer::<P>(&mut rng, log_n);
+	let point = random_scalars::<F>(&mut rng, n_vars);
+
+	// Benchmark evaluate function (sqrt memory)
+	group.bench_function(BenchmarkId::new("evaluate", format!("n_vars={n_vars}")), |b| {
+		b.iter(|| evaluate(&buffer, &point).unwrap());
+	});
+
+	// Benchmark evaluate_inplace function
+	group.bench_function(BenchmarkId::new("evaluate_inplace", format!("n_vars={n_vars}")), |b| {
+		b.iter_batched(
+			|| buffer.clone(),
+			|buffer| evaluate_inplace(buffer, &point).unwrap(),
+			BatchSize::SmallInput,
+		);
+	});
+
+	// Benchmark evaluation with already-expanded tensor
+	group.bench_function(
+		BenchmarkId::new("evaluate with tensor", format!("n_vars={n_vars}")),
+		|b| {
+			let eq_tensor = eq_ind_partial_eval::<P>(&point);
+			b.iter(|| inner_product_par(&buffer, &eq_tensor));
+		},
+	);
+
+	group.finish();
+}
+
+criterion_group!(benches, bench_multilinear_evaluate);
+criterion_main!(benches);

--- a/crates/math/src/inner_product.rs
+++ b/crates/math/src/inner_product.rs
@@ -27,6 +27,7 @@ where
 	itertools::zip_eq(a, b).map(|(a_i, b_i)| b_i * a_i).sum()
 }
 
+#[inline]
 pub fn inner_product_par<F, P, DataA, DataB>(
 	a: &FieldBuffer<P, DataA>,
 	b: &FieldBuffer<P, DataB>,
@@ -42,6 +43,24 @@ where
 	a.as_ref()
 		.par_iter()
 		.zip(b.as_ref().par_iter())
+		.map(|(&a_i, &b_i)| a_i * b_i)
+		.sum::<P>()
+		.into_iter()
+		.sum()
+}
+
+#[inline]
+pub fn inner_product_packed<F, P, DataA, DataB>(
+	a: &FieldBuffer<P, DataA>,
+	b: &FieldBuffer<P, DataB>,
+) -> F
+where
+	F: Field,
+	P: PackedField<Scalar = F>,
+	DataA: Deref<Target = [P]>,
+	DataB: Deref<Target = [P]>,
+{
+	itertools::zip_eq(a.as_ref(), b.as_ref())
 		.map(|(&a_i, &b_i)| a_i * b_i)
 		.sum::<P>()
 		.into_iter()

--- a/crates/math/src/multilinear/evaluate.rs
+++ b/crates/math/src/multilinear/evaluate.rs
@@ -8,7 +8,7 @@ use std::{
 use binius_field::{Field, PackedField};
 
 use crate::{
-	Error, FieldBuffer, inner_product::inner_product_par, multilinear::eq::eq_ind_partial_eval,
+	Error, FieldBuffer, inner_product::inner_product_packed, multilinear::eq::eq_ind_partial_eval,
 };
 
 /// Evaluates a multilinear polynomial at a given point using sqrt(n) memory.
@@ -52,7 +52,7 @@ where
 	// Collect inner products of chunks into scalar values
 	let scalars = evals
 		.chunks(log_chunk_size)?
-		.map(|chunk| inner_product_par(&chunk, &eq_tensor))
+		.map(|chunk| inner_product_packed(&chunk, &eq_tensor))
 		.collect::<Vec<_>>();
 
 	// Create temporary buffer from collected scalar values
@@ -118,7 +118,10 @@ mod tests {
 	use rand::{RngCore, SeedableRng, rngs::StdRng};
 
 	use super::*;
-	use crate::test_utils::{index_to_hypercube_point, random_field_buffer, random_scalars};
+	use crate::{
+		inner_product::inner_product_par,
+		test_utils::{index_to_hypercube_point, random_field_buffer, random_scalars},
+	};
 
 	#[test]
 	fn test_evaluate_consistency() {


### PR DESCRIPTION
# Add multilinear evaluation benchmarks and optimize inner product operations

### TL;DR

Added benchmarks for multilinear polynomial evaluation and optimized inner product operations with a new specialized function.

### What changed?

- Added a new benchmark for multilinear polynomial evaluation
- Created a specialized `inner_product_packed` function for better performance
- Updated the `evaluate` function to use the new optimized inner product function
- Added default features to the crate: `nightly-features` and `rayon`
- Added explicit feature flags for nightly features and rayon support
- Fixed dev-dependencies to properly include default features

### How to test?

Run the new benchmark to compare different multilinear evaluation approaches:

```bash
cargo bench --bench multilinear_evaluate
```

The benchmark compares three evaluation methods:
1. The `evaluate` function (using sqrt memory)
2. The `evaluate_inplace` function
3. Evaluation with pre-expanded tensor

### Why make this change?

This change improves performance for multilinear polynomial evaluation operations by providing a specialized inner product function optimized for packed fields. The benchmarks help measure and compare the performance of different evaluation strategies, which is crucial for optimizing cryptographic operations that rely on these primitives.