### PR TITLE
[frontend] move OpcodeShape to gate defs

### DIFF
--- a/crates/frontend/src/compiler/gate/assert_0.rs
+++ b/crates/frontend/src/compiler/gate/assert_0.rs
@@ -13,11 +13,22 @@
 use crate::{
 	compiler::{
 		circuit,
+		gate::opcode::OpcodeShape,
 		gate_graph::{Gate, GateData, GateParam},
 	},
 	constraint_system::{AndConstraint, ConstraintSystem},
 	word::Word,
 };
+
+pub fn shape() -> OpcodeShape {
+	OpcodeShape {
+		const_in: &[Word::ALL_ONE],
+		n_in: 1,
+		n_out: 0,
+		n_internal: 0,
+		n_imm: 0,
+	}
+}
 
 pub fn constrain(
 	_gate: Gate,

--- a/crates/frontend/src/compiler/gate/assert_band_0.rs
+++ b/crates/frontend/src/compiler/gate/assert_band_0.rs
@@ -13,11 +13,22 @@
 use crate::{
 	compiler::{
 		circuit,
+		gate::opcode::OpcodeShape,
 		gate_graph::{Gate, GateData, GateParam},
 	},
 	constraint_system::{AndConstraint, ConstraintSystem},
 	word::Word,
 };
+
+pub fn shape() -> OpcodeShape {
+	OpcodeShape {
+		const_in: &[],
+		n_in: 2,
+		n_out: 0,
+		n_internal: 0,
+		n_imm: 0,
+	}
+}
 
 pub fn constrain(
 	_gate: Gate,

--- a/crates/frontend/src/compiler/gate/assert_eq.rs
+++ b/crates/frontend/src/compiler/gate/assert_eq.rs
@@ -14,10 +14,22 @@
 use crate::{
 	compiler::{
 		circuit,
+		gate::opcode::OpcodeShape,
 		gate_graph::{Gate, GateData, GateParam},
 	},
 	constraint_system::{AndConstraint, ConstraintSystem},
+	word::Word,
 };
+
+pub fn shape() -> OpcodeShape {
+	OpcodeShape {
+		const_in: &[Word::ALL_ONE],
+		n_in: 2,
+		n_out: 0,
+		n_internal: 0,
+		n_imm: 0,
+	}
+}
 
 pub fn constrain(
 	_gate: Gate,

--- a/crates/frontend/src/compiler/gate/assert_eq_cond.rs
+++ b/crates/frontend/src/compiler/gate/assert_eq_cond.rs
@@ -15,11 +15,22 @@
 use crate::{
 	compiler::{
 		circuit,
+		gate::opcode::OpcodeShape,
 		gate_graph::{Gate, GateData, GateParam},
 	},
 	constraint_system::{AndConstraint, ConstraintSystem},
 	word::Word,
 };
+
+pub fn shape() -> OpcodeShape {
+	OpcodeShape {
+		const_in: &[],
+		n_in: 3,
+		n_out: 0,
+		n_internal: 0,
+		n_imm: 0,
+	}
+}
 
 pub fn constrain(
 	_gate: Gate,

--- a/crates/frontend/src/compiler/gate/band.rs
+++ b/crates/frontend/src/compiler/gate/band.rs
@@ -13,10 +13,21 @@
 use crate::{
 	compiler::{
 		circuit,
+		gate::opcode::OpcodeShape,
 		gate_graph::{Gate, GateData, GateParam},
 	},
 	constraint_system::{AndConstraint, ConstraintSystem},
 };
+
+pub fn shape() -> OpcodeShape {
+	OpcodeShape {
+		const_in: &[],
+		n_in: 2,
+		n_out: 1,
+		n_internal: 0,
+		n_imm: 0,
+	}
+}
 
 pub fn constrain(
 	_gate: Gate,

--- a/crates/frontend/src/compiler/gate/bor.rs
+++ b/crates/frontend/src/compiler/gate/bor.rs
@@ -14,10 +14,21 @@
 use crate::{
 	compiler::{
 		circuit,
+		gate::opcode::OpcodeShape,
 		gate_graph::{Gate, GateData, GateParam},
 	},
 	constraint_system::{AndConstraint, ConstraintSystem},
 };
+
+pub fn shape() -> OpcodeShape {
+	OpcodeShape {
+		const_in: &[],
+		n_in: 2,
+		n_out: 1,
+		n_internal: 0,
+		n_imm: 0,
+	}
+}
 
 pub fn constrain(
 	_gate: Gate,

--- a/crates/frontend/src/compiler/gate/bxor.rs
+++ b/crates/frontend/src/compiler/gate/bxor.rs
@@ -14,10 +14,22 @@
 use crate::{
 	compiler::{
 		circuit,
+		gate::opcode::OpcodeShape,
 		gate_graph::{Gate, GateData, GateParam},
 	},
 	constraint_system::{AndConstraint, ConstraintSystem},
+	word::Word,
 };
+
+pub fn shape() -> OpcodeShape {
+	OpcodeShape {
+		const_in: &[Word::ALL_ONE],
+		n_in: 2,
+		n_out: 1,
+		n_internal: 0,
+		n_imm: 0,
+	}
+}
 
 pub fn constrain(
 	_gate: Gate,

--- a/crates/frontend/src/compiler/gate/extract_byte.rs
+++ b/crates/frontend/src/compiler/gate/extract_byte.rs
@@ -18,11 +18,22 @@
 use crate::{
 	compiler::{
 		circuit,
+		gate::opcode::OpcodeShape,
 		gate_graph::{Gate, GateData, GateParam},
 	},
 	constraint_system::{AndConstraint, ConstraintSystem, ShiftedValueIndex},
 	word::Word,
 };
+
+pub fn shape() -> OpcodeShape {
+	OpcodeShape {
+		const_in: &[Word(0xFF), Word(0xFFFFFFFFFFFFFF00u64)],
+		n_in: 1,
+		n_out: 1,
+		n_internal: 0,
+		n_imm: 1,
+	}
+}
 
 pub fn constrain(
 	_gate: Gate,

--- a/crates/frontend/src/compiler/gate/iadd32.rs
+++ b/crates/frontend/src/compiler/gate/iadd32.rs
@@ -16,10 +16,22 @@
 use crate::{
 	compiler::{
 		circuit,
+		gate::opcode::OpcodeShape,
 		gate_graph::{Gate, GateData, GateParam},
 	},
 	constraint_system::{AndConstraint, ConstraintSystem, ShiftedValueIndex},
+	word::Word,
 };
+
+pub fn shape() -> OpcodeShape {
+	OpcodeShape {
+		const_in: &[Word::MASK_32],
+		n_in: 2,
+		n_out: 1,
+		n_internal: 1,
+		n_imm: 0,
+	}
+}
 
 pub fn constrain(
 	_gate: Gate,

--- a/crates/frontend/src/compiler/gate/iadd_cin_cout.rs
+++ b/crates/frontend/src/compiler/gate/iadd_cin_cout.rs
@@ -28,10 +28,22 @@
 use crate::{
 	compiler::{
 		circuit,
+		gate::opcode::OpcodeShape,
 		gate_graph::{Gate, GateData, GateParam},
 	},
 	constraint_system::{AndConstraint, ConstraintSystem, ShiftedValueIndex},
+	word::Word,
 };
+
+pub fn shape() -> OpcodeShape {
+	OpcodeShape {
+		const_in: &[Word::ALL_ONE],
+		n_in: 3,
+		n_out: 2,
+		n_internal: 1,
+		n_imm: 0,
+	}
+}
 
 pub fn constrain(
 	_gate: Gate,

--- a/crates/frontend/src/compiler/gate/icmp_eq.rs
+++ b/crates/frontend/src/compiler/gate/icmp_eq.rs
@@ -24,11 +24,22 @@
 use crate::{
 	compiler::{
 		circuit,
+		gate::opcode::OpcodeShape,
 		gate_graph::{Gate, GateData, GateParam},
 	},
 	constraint_system::{AndConstraint, ConstraintSystem, ShiftedValueIndex},
 	word::Word,
 };
+
+pub fn shape() -> OpcodeShape {
+	OpcodeShape {
+		const_in: &[],
+		n_in: 3,
+		n_out: 1,
+		n_internal: 1,
+		n_imm: 0,
+	}
+}
 
 pub fn constrain(
 	_gate: Gate,

--- a/crates/frontend/src/compiler/gate/icmp_ult.rs
+++ b/crates/frontend/src/compiler/gate/icmp_ult.rs
@@ -22,11 +22,22 @@
 use crate::{
 	compiler::{
 		circuit,
+		gate::opcode::OpcodeShape,
 		gate_graph::{Gate, GateData, GateParam},
 	},
 	constraint_system::{AndConstraint, ConstraintSystem, ShiftedValueIndex},
 	word::Word,
 };
+
+pub fn shape() -> OpcodeShape {
+	OpcodeShape {
+		const_in: &[Word::ALL_ONE],
+		n_in: 2,
+		n_out: 1,
+		n_internal: 1,
+		n_imm: 0,
+	}
+}
 
 pub fn constrain(
 	_gate: Gate,

--- a/crates/frontend/src/compiler/gate/imul.rs
+++ b/crates/frontend/src/compiler/gate/imul.rs
@@ -3,10 +3,21 @@
 use crate::{
 	compiler::{
 		circuit,
+		gate::opcode::OpcodeShape,
 		gate_graph::{Gate, GateData, GateParam},
 	},
 	constraint_system::{ConstraintSystem, MulConstraint, ShiftedValueIndex},
 };
+
+pub fn shape() -> OpcodeShape {
+	OpcodeShape {
+		const_in: &[],
+		n_in: 2,
+		n_out: 2,
+		n_internal: 0,
+		n_imm: 0,
+	}
+}
 
 pub fn constrain(
 	_gate: Gate,

--- a/crates/frontend/src/compiler/gate/opcode.rs
+++ b/crates/frontend/src/compiler/gate/opcode.rs
@@ -1,4 +1,4 @@
-use crate::word::Word;
+use crate::{compiler::gate, word::Word};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Opcode {
@@ -44,135 +44,33 @@ impl Opcode {
 	pub fn shape(&self) -> OpcodeShape {
 		match self {
 			// Bitwise operations
-			Opcode::Band => OpcodeShape {
-				const_in: &[],
-				n_in: 2,
-				n_out: 1,
-				n_internal: 0,
-				n_imm: 0,
-			},
-			Opcode::Bxor => OpcodeShape {
-				const_in: &[Word::ALL_ONE],
-				n_in: 2,
-				n_out: 1,
-				n_internal: 0,
-				n_imm: 0,
-			},
-			Opcode::Bor => OpcodeShape {
-				const_in: &[],
-				n_in: 2,
-				n_out: 1,
-				n_internal: 0,
-				n_imm: 0,
-			},
+			Opcode::Band => gate::band::shape(),
+			Opcode::Bxor => gate::bxor::shape(),
+			Opcode::Bor => gate::bor::shape(),
 
 			// Arithmetic
-			Opcode::IaddCinCout => OpcodeShape {
-				const_in: &[Word::ALL_ONE],
-				n_in: 3,
-				n_out: 2,
-				n_internal: 1,
-				n_imm: 0,
-			},
-			Opcode::Iadd32 => OpcodeShape {
-				const_in: &[Word::MASK_32],
-				n_in: 2,
-				n_out: 1,
-				n_imm: 0,
-				n_internal: 1,
-			},
-			Opcode::Imul => OpcodeShape {
-				const_in: &[],
-				n_in: 2,
-				n_out: 2,
-				n_internal: 0,
-				n_imm: 0,
-			},
+			Opcode::IaddCinCout => gate::iadd_cin_cout::shape(),
+			Opcode::Iadd32 => gate::iadd32::shape(),
+			Opcode::Imul => gate::imul::shape(),
 
 			// Shifts
-			Opcode::Shr => OpcodeShape {
-				const_in: &[Word::ALL_ONE],
-				n_in: 1,
-				n_out: 1,
-				n_internal: 0,
-				n_imm: 1,
-			},
-			Opcode::Shl => OpcodeShape {
-				const_in: &[Word::ALL_ONE],
-				n_in: 1,
-				n_out: 1,
-				n_internal: 0,
-				n_imm: 1,
-			},
-			Opcode::Shr32 => OpcodeShape {
-				const_in: &[Word::MASK_32],
-				n_in: 1,
-				n_out: 1,
-				n_internal: 0,
-				n_imm: 1,
-			},
-			Opcode::Rotr32 => OpcodeShape {
-				const_in: &[Word::MASK_32],
-				n_in: 1,
-				n_out: 1,
-				n_internal: 0,
-				n_imm: 1,
-			},
+			Opcode::Shr => gate::shr::shape(),
+			Opcode::Shl => gate::shl::shape(),
+			Opcode::Shr32 => gate::shr32::shape(),
+			Opcode::Rotr32 => gate::rotr32::shape(),
 
 			// Comparisons
-			Opcode::IcmpUlt => OpcodeShape {
-				const_in: &[Word::ALL_ONE],
-				n_in: 2,
-				n_out: 1,
-				n_internal: 1,
-				n_imm: 0,
-			},
-			Opcode::IcmpEq => OpcodeShape {
-				const_in: &[],
-				n_in: 3,
-				n_out: 1,
-				n_internal: 1,
-				n_imm: 0,
-			},
+			Opcode::IcmpUlt => gate::icmp_ult::shape(),
+			Opcode::IcmpEq => gate::icmp_eq::shape(),
 
 			// Extraction
-			Opcode::ExtractByte => OpcodeShape {
-				const_in: &[Word(0xFF), Word(0xFFFFFFFFFFFFFF00u64)],
-				n_in: 1,
-				n_out: 1,
-				n_internal: 0,
-				n_imm: 1,
-			},
+			Opcode::ExtractByte => gate::extract_byte::shape(),
 
 			// Assertions (no outputs)
-			Opcode::AssertEq => OpcodeShape {
-				const_in: &[Word::ALL_ONE],
-				n_in: 2,
-				n_out: 0,
-				n_internal: 0,
-				n_imm: 0,
-			},
-			Opcode::Assert0 => OpcodeShape {
-				const_in: &[Word::ALL_ONE],
-				n_in: 1,
-				n_out: 0,
-				n_internal: 0,
-				n_imm: 0,
-			},
-			Opcode::AssertBand0 => OpcodeShape {
-				const_in: &[],
-				n_in: 2,
-				n_out: 0,
-				n_internal: 0,
-				n_imm: 0,
-			},
-			Opcode::AssertEqCond => OpcodeShape {
-				const_in: &[],
-				n_in: 3,
-				n_out: 0,
-				n_internal: 0,
-				n_imm: 0,
-			},
+			Opcode::AssertEq => gate::assert_eq::shape(),
+			Opcode::Assert0 => gate::assert_0::shape(),
+			Opcode::AssertBand0 => gate::assert_band_0::shape(),
+			Opcode::AssertEqCond => gate::assert_eq_cond::shape(),
 		}
 	}
 }

--- a/crates/frontend/src/compiler/gate/rotr32.rs
+++ b/crates/frontend/src/compiler/gate/rotr32.rs
@@ -20,10 +20,22 @@
 use crate::{
 	compiler::{
 		circuit,
+		gate::opcode::OpcodeShape,
 		gate_graph::{Gate, GateData, GateParam},
 	},
 	constraint_system::{AndConstraint, ConstraintSystem, ShiftedValueIndex},
+	word::Word,
 };
+
+pub fn shape() -> OpcodeShape {
+	OpcodeShape {
+		const_in: &[Word::MASK_32],
+		n_in: 1,
+		n_out: 1,
+		n_internal: 0,
+		n_imm: 1,
+	}
+}
 
 pub fn constrain(
 	_gate: Gate,

--- a/crates/frontend/src/compiler/gate/shl.rs
+++ b/crates/frontend/src/compiler/gate/shl.rs
@@ -14,10 +14,22 @@
 use crate::{
 	compiler::{
 		circuit,
+		gate::opcode::OpcodeShape,
 		gate_graph::{Gate, GateData, GateParam},
 	},
 	constraint_system::{AndConstraint, ConstraintSystem, ShiftedValueIndex},
+	word::Word,
 };
+
+pub fn shape() -> OpcodeShape {
+	OpcodeShape {
+		const_in: &[Word::ALL_ONE],
+		n_in: 1,
+		n_out: 1,
+		n_internal: 0,
+		n_imm: 1,
+	}
+}
 
 pub fn constrain(
 	_gate: Gate,

--- a/crates/frontend/src/compiler/gate/shr.rs
+++ b/crates/frontend/src/compiler/gate/shr.rs
@@ -14,10 +14,22 @@
 use crate::{
 	compiler::{
 		circuit,
+		gate::opcode::OpcodeShape,
 		gate_graph::{Gate, GateData, GateParam},
 	},
 	constraint_system::{AndConstraint, ConstraintSystem, ShiftedValueIndex},
+	word::Word,
 };
+
+pub fn shape() -> OpcodeShape {
+	OpcodeShape {
+		const_in: &[Word::ALL_ONE],
+		n_in: 1,
+		n_out: 1,
+		n_internal: 0,
+		n_imm: 1,
+	}
+}
 
 pub fn constrain(
 	_gate: Gate,

--- a/crates/frontend/src/compiler/gate/shr32.rs
+++ b/crates/frontend/src/compiler/gate/shr32.rs
@@ -13,10 +13,22 @@
 use crate::{
 	compiler::{
 		circuit,
+		gate::opcode::OpcodeShape,
 		gate_graph::{Gate, GateData, GateParam},
 	},
 	constraint_system::{AndConstraint, ConstraintSystem, ShiftedValueIndex},
+	word::Word,
 };
+
+pub fn shape() -> OpcodeShape {
+	OpcodeShape {
+		const_in: &[Word::MASK_32],
+		n_in: 1,
+		n_out: 1,
+		n_internal: 0,
+		n_imm: 1,
+	}
+}
 
 pub fn constrain(
 	_gate: Gate,


### PR DESCRIPTION
This moves OpcodeShape closer to the actual gate implementation which helps to
not mess up the order and the number of parameters.