### PR TITLE
Integer multiplication benchmarks

### DIFF
--- a/crates/prover/Cargo.toml
+++ b/crates/prover/Cargo.toml
@@ -50,7 +50,10 @@ harness = false
 name = "and_reduction"
 harness = false
 
+[[bench]]
+name = "intmul"
+harness = false
+
 [features]
 default = ["rayon"]
 rayon = ["binius-utils/rayon"]
-

--- a/crates/prover/benches/intmul.rs
+++ b/crates/prover/benches/intmul.rs
@@ -1,0 +1,98 @@
+use binius_field::PackedBinaryGhash1x128b;
+use binius_prover::protocols::intmul::{prove::IntMulProver, witness::Witness};
+use binius_transcript::ProverTranscript;
+use binius_utils::rayon::ThreadPoolBuilder;
+use binius_verifier::config::StdChallenger;
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use rand::{Rng, SeedableRng, rngs::StdRng};
+
+type P = PackedBinaryGhash1x128b;
+
+const LOG_BITS: usize = 6;
+
+fn generate_test_data(log_num: usize) -> (Vec<u64>, Vec<u64>, Vec<u64>, Vec<u64>) {
+	let num_exponents = 1 << log_num;
+	let mut rng = StdRng::seed_from_u64(0);
+
+	let mut a = Vec::with_capacity(num_exponents);
+	let mut b = Vec::with_capacity(num_exponents);
+	let mut c_lo = Vec::with_capacity(num_exponents);
+	let mut c_hi = Vec::with_capacity(num_exponents);
+
+	for _ in 0..num_exponents {
+		let a_i = rng.random_range(1..u64::MAX);
+		let b_i = rng.random_range(1..u64::MAX);
+
+		let full_result = (a_i as u128) * (b_i as u128);
+
+		let c_lo_i = full_result as u64;
+		let c_hi_i = (full_result >> 64) as u64;
+
+		a.push(a_i);
+		b.push(b_i);
+		c_lo.push(c_lo_i);
+		c_hi.push(c_hi_i);
+	}
+
+	(a, b, c_lo, c_hi)
+}
+
+fn bench_intmul_prove(c: &mut Criterion) {
+	ThreadPoolBuilder::new().num_threads(1).build_global().ok();
+
+	let mut group = c.benchmark_group("intmul_phases");
+	group.sample_size(10);
+	group.throughput(Throughput::Elements(1));
+
+	let log_num = 14;
+	let num_exponents = 1 << log_num;
+	let (a, b, c_lo, c_hi) = generate_test_data(log_num);
+
+	group.bench_with_input(
+		BenchmarkId::new("witness", num_exponents),
+		&num_exponents,
+		|bencher, _| {
+			bencher.iter(|| Witness::<P, _, _>::new(LOG_BITS, &a, &b, &c_lo, &c_hi).unwrap())
+		},
+	);
+
+	// prove
+	let witness = Witness::<P, _, _>::new(LOG_BITS, &a, &b, &c_lo, &c_hi).unwrap();
+
+	group.bench_with_input(
+		BenchmarkId::new("prove", num_exponents),
+		&witness,
+		|bencher, witness| {
+			bencher.iter_with_setup(
+				|| {
+					let prover_transcript = ProverTranscript::<StdChallenger>::default();
+					(witness.clone(), prover_transcript)
+				},
+				|(witness, mut prover_transcript)| {
+					let mut intmul_prover = IntMulProver::new(0, &mut prover_transcript);
+					intmul_prover.prove(witness).unwrap();
+				},
+			)
+		},
+	);
+
+	// execute + prove
+	group.bench_with_input(
+		BenchmarkId::new("combined", num_exponents),
+		&num_exponents,
+		|bencher, _| {
+			bencher.iter(|| {
+				let witness = Witness::<P, _, _>::new(LOG_BITS, &a, &b, &c_lo, &c_hi).unwrap();
+
+				let mut prover_transcript = ProverTranscript::<StdChallenger>::default();
+				let mut intmul_prover = IntMulProver::new(0, &mut prover_transcript);
+				intmul_prover.prove(witness).unwrap();
+			})
+		},
+	);
+
+	group.finish();
+}
+
+criterion_group!(intmul_benches, bench_intmul_prove);
+criterion_main!(intmul_benches);

--- a/crates/prover/src/protocols/intmul/witness.rs
+++ b/crates/prover/src/protocols/intmul/witness.rs
@@ -31,7 +31,7 @@ use super::error::Error;
 /// Protocol proves that ${(G^a)}^b = G^{c\\_lo} \times (G^{2^{2^m}})^{c\\_hi}$, which is equivalent
 /// to $a \times b = c$ modulo $2^{2^{m+1}} - 1$. The special case of `0 * 0 = 1` is handled
 /// separately.
-#[derive(Getters)]
+#[derive(Clone, Getters)]
 #[getset(get = "pub")]
 pub struct Witness<P: PackedField, B: Bitwise, S: AsRef<[B]>> {
 	pub a: BinaryTree<P, B, S>,
@@ -104,7 +104,7 @@ where
 /// base raised to the power of the corresponding exponent.
 ///
 /// Tree is laid out from root to the leaves. `IntoIterator` follows this convention.
-#[derive(Debug, IntoIterator)]
+#[derive(Clone, Debug, IntoIterator)]
 pub struct BinaryTree<P: PackedField, B: Bitwise, S: AsRef<[B]>> {
 	exponents: S,
 	#[into_iterator(owned)]


### PR DESCRIPTION
# Add Integer Multiplication Benchmarks

### TL;DR

Added benchmarks for integer multiplication protocol and made related improvements to the codebase.

### What changed?

- Added a new benchmark for integer multiplication (`intmul.rs`)
- Added `rayon` as a dependency in the prover crate
- Made `ProverData` and `Layers` structs cloneable for benchmarking
- Updated imports to use `binius_utils::rayon` instead of `binius_maybe_rayon`
- Improved the `SelectorMlecheckProver` implementation with more efficient code paths
- Fixed the order of multilinear evaluations in `SelectorMlecheckProver`

### How to test?

Run the new benchmark with:
```
cargo bench --bench intmul
```

The benchmark currently focuses on the execution phase of the integer multiplication protocol with a sample size of 16,384 (2^14) multiplications.

### Why make this change?

This change enables performance testing of the integer multiplication protocol, which is important for optimizing the prover implementation. The benchmark helps identify bottlenecks in the execution phase and will be extended to measure the proving phase as well (currently commented out in the code).