### PR TITLE
[AND reduction] Benchmarks

### DIFF
--- a/crates/prover/Cargo.toml
+++ b/crates/prover/Cargo.toml
@@ -35,6 +35,9 @@ criterion.workspace = true
 proptest.workspace = true
 rand = { workspace = true, features = ["std_rng"] }
 
+[lib]
+bench = false
+
 [[bench]]
 name = "binary_merkle_tree"
 harness = false
@@ -43,6 +46,11 @@ harness = false
 name = "sumcheck"
 harness = false
 
+[[bench]]
+name = "and_reduction"
+harness = false
+
 [features]
 default = ["rayon"]
 rayon = ["binius-utils/rayon"]
+

--- a/crates/prover/src/and_reduction/univariate/ntt_lookup.rs
+++ b/crates/prover/src/and_reduction/univariate/ntt_lookup.rs
@@ -67,6 +67,7 @@ use binius_verifier::and_reduction::{
 ///
 /// - `P`: The packed field type used for storing precomputed values. Must implement `PackedField`
 ///   with a scalar type that is a binary field.
+#[derive(Clone)]
 pub struct NTTLookup<P>(Vec<Vec<Vec<P>>>);
 
 impl<PNTTDomain> NTTLookup<PNTTDomain>


### PR DESCRIPTION
# Add benchmarks for AND reduction

This PR adds benchmarks for the AND reduction protocol, including:

1. A new benchmark file `and_reduction.rs` with two benchmarks:
   - `univariate_round 2^24`: Measures performance of a single univariate round with 2^24 elements
   - `full zerocheck 2^24`: Benchmarks the complete zerocheck process

2. Updates to `Cargo.toml` to:
   - Disable library benchmarking with `bench = false`
   - Register the new `and_reduction` benchmark

The benchmarks test the performance of univariate round message generation and the full zerocheck process with various field operations and polynomial evaluations.