### PR TITLE
[AND reudction] Utilities for verifier to use on Univariate Polynomials in the first round of interaction

### DIFF
--- a/crates/verifier/src/and_reduction/mod.rs
+++ b/crates/verifier/src/and_reduction/mod.rs
@@ -1,0 +1,2 @@
+pub mod univariate;
+pub mod utils;

--- a/crates/verifier/src/and_reduction/univariate/mod.rs
+++ b/crates/verifier/src/and_reduction/univariate/mod.rs
@@ -1,0 +1,2 @@
+pub mod univariate_lagrange;
+pub mod univariate_poly;

--- a/crates/verifier/src/and_reduction/univariate/univariate_lagrange.rs
+++ b/crates/verifier/src/and_reduction/univariate/univariate_lagrange.rs
@@ -1,0 +1,115 @@
+use binius_field::{BinaryField, Field};
+use binius_math::BinarySubspace;
+
+fn products_excluding_one_element<F: Field>(input: &[F]) -> Vec<F> {
+	let mut results = vec![F::ONE; input.len()];
+	for i in (0..(input.len() - 1)).rev() {
+		results[i] = results[i + 1] * input[i + 1];
+	}
+
+	let mut forward_product = F::ONE;
+
+	for i in 1..input.len() {
+		forward_product *= input[i - 1];
+		results[i] *= forward_product;
+	}
+
+	results
+}
+
+/// Computes the common denominator for Lagrange interpolation polynomials
+/// in the univariate case over a binary subspace.
+///
+/// For a binary subspace, this computes the product of all nonzero elements
+/// in the subspace.
+///
+/// # Arguments
+/// * `binary_subspace` - The binary subspace defining the domain
+///
+/// # Returns
+/// The product of all nonzero elements in the binary subspace
+pub fn lexicographic_lagrange_denominator<
+	FDomain: Field + BinaryField,
+	FOutput: Field + From<FDomain>,
+>(
+	binary_subspace: &BinarySubspace<FDomain>,
+) -> FOutput {
+	FOutput::from(
+		binary_subspace
+			.iter()
+			.filter(|x| *x != FDomain::ZERO)
+			.product::<FDomain>(),
+	)
+}
+
+/// Computes the numerators for Lagrange interpolation polynomials evaluated at a given point.
+///
+/// For a binary subspace and evaluation point z, this computes the numerators for each
+/// Lagrange basis polynomial L_i(z). Specifically, for each basis point i in the subspace,
+/// it computes the product of (z - j) for all j ≠ i.
+///
+/// This function supports field extension where the domain field can be embedded into
+/// the output field.
+///
+/// # Arguments
+/// * `eval_point` - The point at which to evaluate the Lagrange numerators
+/// * `binary_subspace` - The binary subspace defining the domain
+///
+/// # Returns
+/// A vector of numerators, one for each basis polynomial
+pub fn lexicographic_lagrange_numerators<
+	FDomain: Field + BinaryField,
+	FOutput: Field + From<FDomain>,
+>(
+	eval_point: FOutput,
+	binary_subspace: &BinarySubspace<FDomain>,
+) -> Vec<FOutput> {
+	let basis_point_differences: Vec<_> = binary_subspace
+		.iter()
+		.map(|i| eval_point - FOutput::from(i))
+		.collect();
+
+	products_excluding_one_element(&basis_point_differences)
+}
+
+/// Computes the Lagrange basis polynomial evaluations at a given point for a binary subspace.
+///
+/// This function computes the values of all Lagrange basis polynomials L_i(z) evaluated at
+/// the given point z, where each L_i is the unique polynomial of degree < n that satisfies:
+/// - L_i(x_i) = 1
+/// - L_i(x_j) = 0 for all j ≠ i
+///
+/// For a binary subspace with basis points {x_0, x_1, ..., x_{n-1}}, the Lagrange basis
+/// polynomial L_i(z) is given by:
+///
+/// L_i(z) = ∏_{j≠i} (z - x_j) / ∏_{j≠i} (x_i - x_j)
+///
+/// This function efficiently computes all L_i(z) values by:
+/// 1. Computing the numerators ∏_{j≠i} (z - x_j) for each i
+/// 2. Computing the common denominator (which is the same for all basis polynomials in a binary
+///    subspace)
+/// 3. Dividing each numerator by the common denominator
+///
+/// # Arguments
+/// * `eval_point` - The point z at which to evaluate all Lagrange basis polynomials
+/// * `binary_subspace` - The binary subspace defining the interpolation domain
+///
+/// # Returns
+/// A vector containing L_i(z) for each basis point x_i in lexicographic order
+pub fn lexicographic_lagrange_basis_vectors<
+	FDomain: Field + BinaryField,
+	FOutput: Field + From<FDomain>,
+>(
+	eval_point: FOutput,
+	binary_subspace: &BinarySubspace<FDomain>,
+) -> Vec<FOutput> {
+	let mut result = lexicographic_lagrange_numerators(eval_point, binary_subspace);
+	let inverse_denominator: FOutput =
+		lexicographic_lagrange_denominator::<FDomain, FOutput>(binary_subspace).invert_or_zero();
+
+	result
+		.iter_mut()
+		.for_each(|res| *res *= inverse_denominator);
+
+	result
+}

--- a/crates/verifier/src/and_reduction/univariate/univariate_poly.rs
+++ b/crates/verifier/src/and_reduction/univariate/univariate_poly.rs
@@ -1,0 +1,181 @@
+use binius_field::{BinaryField, Field};
+use binius_math::BinarySubspace;
+
+use super::univariate_lagrange::lexicographic_lagrange_numerators;
+use crate::and_reduction::univariate::univariate_lagrange::lexicographic_lagrange_denominator;
+
+/// Trait for univariate polynomials that can be evaluated at challenge points.
+///
+/// This trait abstracts over different representations of univariate polynomials,
+/// enabling polymorphic evaluation at points from potentially larger extension fields.
+///
+/// # Type Parameters
+/// * `FChallenge` - The field type of evaluation points
+pub trait UnivariatePolyIsomorphic<FChallenge: Field> {
+	/// Evaluates the polynomial at a given challenge point.
+	///
+	/// # Arguments
+	/// * `challenge` - The point at which to evaluate the polynomial
+	///
+	/// # Returns
+	/// The polynomial evaluation p(challenge) as a field element
+	fn evaluate_at_challenge(&self, challenge: FChallenge) -> FChallenge;
+}
+
+/// A univariate polynomial represented in Lagrange basis over a binary subspace.
+///
+/// # Representation
+/// The polynomial is stored as coefficients in the Lagrange basis corresponding to
+/// evaluation points from the binary subspace.
+///
+/// # Mathematical Background
+/// For a polynomial p(x) and basis points B = {b₀, b₁, ..., b_{n-1}} from the binary subspace,
+/// the Lagrange representation stores coefficients [c₀, c₁, ..., c_{n-1}] such that:
+///
+/// p(x) = Σᵢ cᵢ · Lᵢ(x)
+///
+/// where Lᵢ(x) is the i-th Lagrange basis polynomial that equals 1 at bᵢ and 0 at all other basis
+/// points.
+///
+/// # Field Isomorphism Support
+/// The struct supports evaluation in fields isomorphic to extension fields through the type system:
+/// - Coefficients are stored in field F
+/// - Evaluation can occur in any field that F can be embedded into
+///
+/// # Type Parameters
+/// * `F` - The coefficient field (must be a binary field)
+pub struct GenericPo2UnivariatePoly<F: Field + BinaryField> {
+	univariate_lagrange_coeffs: Vec<F>,
+	log_degree_lt: usize,
+	domain: BinarySubspace<F>,
+}
+
+impl<F: Field + BinaryField> GenericPo2UnivariatePoly<F> {
+	/// Creates a new univariate polynomial from Lagrange basis coefficients.
+	///
+	/// # Arguments
+	/// * `univariate_lagrange_coeffs` - Coefficients in Lagrange basis ordered by the binary
+	///   subspace iteration order
+	/// * `domain` - The binary subspace defining the domain
+	///
+	/// # Panics
+	/// Panics if the number of coefficients is not a power of 2.
+	pub fn new(univariate_lagrange_coeffs: Vec<F>, domain: BinarySubspace<F>) -> Self {
+		let degree_lt = univariate_lagrange_coeffs.len();
+		let log_degree_lt = degree_lt.trailing_zeros() as usize;
+
+		// panic if length is not a po2
+		assert_eq!(degree_lt, 1 << log_degree_lt);
+
+		Self {
+			univariate_lagrange_coeffs,
+			log_degree_lt,
+			domain,
+		}
+	}
+
+	/// Returns the degree bound of the polynomial.
+	///
+	/// For a polynomial in Lagrange basis over n points, the degree is at most n-1.
+	/// This method returns n, which is the smallest degree bound.
+	///
+	/// # Returns
+	/// The number of basis points (2^log_degree_lt)
+	pub fn degree_lt(&self) -> usize {
+		1 << self.log_degree_lt
+	}
+
+	/// Returns an iterator over the Lagrange basis coefficients.
+	///
+	/// The coefficients are ordered by the binary subspace iteration order.
+	///
+	/// # Returns
+	/// An iterator yielding references to the Lagrange coefficients
+	pub fn iter(&self) -> impl Iterator<Item = &F> {
+		self.univariate_lagrange_coeffs.iter()
+	}
+
+	fn evaluate_lagrange_common<FChallenge: Field>(
+		&self,
+		numerators: impl Iterator<Item = FChallenge>,
+		coeffs_in_eval_field: impl Iterator<Item = FChallenge>,
+		denominator_inv_in_eval_field: FChallenge,
+	) -> FChallenge {
+		numerators
+			.zip(coeffs_in_eval_field)
+			.map(|(basis_vec_eval, coeff)| basis_vec_eval * coeff)
+			.sum::<FChallenge>()
+			* denominator_inv_in_eval_field
+	}
+}
+
+impl<FCoeffs, FChallenge> UnivariatePolyIsomorphic<FChallenge> for GenericPo2UnivariatePoly<FCoeffs>
+where
+	FCoeffs: Field + BinaryField,
+	FChallenge: Field + From<FCoeffs>,
+{
+	fn evaluate_at_challenge(&self, challenge: FChallenge) -> FChallenge {
+		let evals_of_lagrange_basis_vectors_not_yet_divide_by_denominator =
+			lexicographic_lagrange_numerators::<FCoeffs, FChallenge>(challenge, &self.domain);
+
+		let denominator_inv =
+			lexicographic_lagrange_denominator::<FCoeffs, FChallenge>(&self.domain)
+				.invert_or_zero();
+
+		self.evaluate_lagrange_common(
+			evals_of_lagrange_basis_vectors_not_yet_divide_by_denominator.into_iter(),
+			self.iter().map(|coeff| FChallenge::from(*coeff)),
+			denominator_inv,
+		)
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use binius_field::{AESTowerField8b, Random};
+	use binius_math::BinarySubspace;
+	use itertools::Itertools;
+	use rand::{SeedableRng, rngs::StdRng};
+
+	use super::GenericPo2UnivariatePoly;
+	use crate::{
+		and_reduction::{
+			univariate::univariate_poly::UnivariatePolyIsomorphic,
+			utils::constants::{ROWS_PER_HYPERCUBE_VERTEX, SKIPPED_VARS},
+		},
+		fields::B128,
+		protocols::sumcheck::RoundCoeffs,
+	};
+
+	#[test]
+	fn univariate_po2_sanity_check() {
+		let mut rng = StdRng::from_seed([0; 32]);
+
+		let monomial_basis_coeffs = (0..ROWS_PER_HYPERCUBE_VERTEX)
+			.map(|_| AESTowerField8b::random(&mut rng))
+			.collect_vec();
+		let monomial_basis_poly = RoundCoeffs(monomial_basis_coeffs.clone());
+
+		let monomial_basis_coeffs_isomorphic = monomial_basis_coeffs
+			.into_iter()
+			.map(B128::from)
+			.collect_vec();
+
+		let monomial_basis_isomorphic = RoundCoeffs(monomial_basis_coeffs_isomorphic);
+
+		let domain = BinarySubspace::<AESTowerField8b>::with_dim(SKIPPED_VARS).unwrap();
+		let v = domain
+			.iter()
+			.map(|x| monomial_basis_poly.evaluate(x))
+			.collect();
+
+		let poly = GenericPo2UnivariatePoly::<AESTowerField8b>::new(v, domain);
+
+		let random_point = B128::random(&mut rng);
+
+		assert_eq!(
+			poly.evaluate_at_challenge(random_point),
+			monomial_basis_isomorphic.evaluate(random_point)
+		);
+	}
+}

--- a/crates/verifier/src/and_reduction/utils/constants.rs
+++ b/crates/verifier/src/and_reduction/utils/constants.rs
@@ -1,0 +1,5 @@
+// 4,5,6 supported but 6 is optimal
+pub const SKIPPED_VARS: usize = 6;
+
+// This is the amount of hypercubes in the "oblong hypercube"
+pub const ROWS_PER_HYPERCUBE_VERTEX: usize = 1 << SKIPPED_VARS;

--- a/crates/verifier/src/and_reduction/utils/mod.rs
+++ b/crates/verifier/src/and_reduction/utils/mod.rs
@@ -1,0 +1,1 @@
+pub mod constants;

--- a/crates/verifier/src/lib.rs
+++ b/crates/verifier/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod and_reduction;
 pub mod config;
 mod error;
 pub mod fields;


### PR DESCRIPTION
# Add univariate polynomial implementation for AND reduction

This PR adds the foundation for univariate polynomial implementation needed for the AND reduction optimization. The implementation includes:

- A new `and_reduction` module with univariate polynomial functionality
- Implementation of delta polynomials that satisfy the Lagrange basis properties
- Utilities for working with subfield isomorphisms
- Constants for the AND reduction optimization parameters
- Comprehensive test coverage to verify correctness

The univariate polynomial implementation provides efficient evaluation at challenge points and supports operations in both the main field and subfield.