### PR TITLE
[ring switch] ring switch verifier components

### DIFF
--- a/crates/verifier/src/lib.rs
+++ b/crates/verifier/src/lib.rs
@@ -5,6 +5,7 @@ pub mod fri;
 pub mod hash;
 pub mod merkle_tree;
 pub mod protocols;
+pub mod ring_switch;
 mod verify;
 
 pub use error::*;

--- a/crates/verifier/src/ring_switch/mod.rs
+++ b/crates/verifier/src/ring_switch/mod.rs
@@ -1,0 +1,1 @@
+pub mod verifier;

--- a/crates/verifier/src/ring_switch/verifier.rs
+++ b/crates/verifier/src/ring_switch/verifier.rs
@@ -1,0 +1,28 @@
+use std::iter;
+
+use binius_field::{ExtensionField, Field, PackedExtension};
+use binius_math::tensor_algebra::TensorAlgebra;
+
+/// Evaluate the ring switching equality indicator for a given query and z_vals
+///
+/// Used by the verifier within the the one bit pcs verifier during the
+/// verification of the large field pcs.
+pub fn eval_rs_eq<F, FE>(z_vals: &[FE], query: &[FE], expanded_row_batch_query: &[FE]) -> FE
+where
+	F: Field,
+	FE: Field + ExtensionField<F> + PackedExtension<F>,
+{
+	let tensor_eval = iter::zip(z_vals, query).fold(
+		<TensorAlgebra<F, FE>>::from_vertical(FE::ONE),
+		|eval, (&vert_i, &hztl_i)| {
+			// This formula is specific to characteristic 2 fields
+			// Here we know that $h v + (1 - h) (1 - v) = 1 + h + v$.
+			let vert_scaled = eval.clone().scale_vertical(vert_i);
+			let hztl_scaled = eval.clone().scale_horizontal(hztl_i);
+
+			eval + &vert_scaled + &hztl_scaled
+		},
+	);
+
+	tensor_eval.fold_vertical(expanded_row_batch_query)
+}


### PR DESCRIPTION
### TL;DR

Added ring switching functionality to the verifier crate.

### What changed?

- Created a new `ring_switch` module in the verifier crate
- Implemented a verifier for ring switching with the `eval_rs_eq` function
- The function evaluates the ring switching equality indicator for a given query and z_vals
- This is used by the verifier within the one bit PCS verifier during verification of the large field PCS

### How to test?

Unit tests can be added to verify that the `eval_rs_eq` function correctly evaluates the ring switching equality indicator for various inputs. Test cases should include different combinations of z_vals, queries, and expanded_row_batch_query values.

### Why make this change?

This implementation adds support for ring switching verification, which is a necessary component for the one bit PCS verifier when verifying large field PCS. The ring switching equality indicator helps ensure the correctness of the verification process in characteristic 2 fields.