### PR TITLE
[sumcheck] Rebrand the meaning of SumcheckProver n_vars

### DIFF
--- a/crates/prover/src/basefold/sumcheck.rs
+++ b/crates/prover/src/basefold/sumcheck.rs
@@ -14,16 +14,16 @@ use crate::protocols::sumcheck::{Error, common::SumcheckProver};
 /// some multilinears A and B over all hypercube points X
 pub struct MultilinearSumcheckProver<F: Field> {
 	multilinears: [FieldBuffer<F>; 2],
-	log_n: usize,
 	current_round_claim: F,
 	round_message: Option<Vec<F>>,
 }
 
 impl<F: Field> MultilinearSumcheckProver<F> {
 	pub fn new(multilinears: [FieldBuffer<F>; 2], overall_claim: F, log_n: usize) -> Self {
+		assert_eq!(multilinears[0].log_len(), log_n);
+		assert_eq!(multilinears[1].log_len(), log_n);
 		Self {
 			multilinears,
-			log_n,
 			current_round_claim: overall_claim,
 			round_message: None,
 		}
@@ -61,7 +61,7 @@ fn fold_low_to_high<F: Field>(
 
 impl<F: Field> SumcheckProver<F> for MultilinearSumcheckProver<F> {
 	fn n_vars(&self) -> usize {
-		self.log_n
+		self.multilinears[0].log_len()
 	}
 
 	fn execute(&mut self) -> Result<Vec<RoundCoeffs<F>>, Error> {
@@ -142,7 +142,7 @@ pub mod test {
 	pub fn sumcheck_interactive_protocol(
 		prover: &mut MultilinearSumcheckProver<F>,
 	) -> Result<(F, Vec<F>), Error> {
-		let log_n = prover.log_n;
+		let log_n = prover.n_vars();
 
 		let mut expected_next_round_claim =
 			prover.execute().unwrap()[0].0[0] + prover.execute().unwrap()[0].0[1];

--- a/crates/prover/src/protocols/sumcheck/bivariate_product_mle.rs
+++ b/crates/prover/src/protocols/sumcheck/bivariate_product_mle.rs
@@ -39,10 +39,6 @@ impl<F: Field, P: PackedField<Scalar = F>> BivariateProductMlecheckProver<P> {
 			gruen34,
 		})
 	}
-
-	fn n_vars_remaining(&self) -> usize {
-		self.gruen34.n_vars_remaining()
-	}
 }
 
 impl<F, P> SumcheckProver<F> for BivariateProductMlecheckProver<P>
@@ -51,7 +47,7 @@ where
 	P: PackedField<Scalar = F>,
 {
 	fn n_vars(&self) -> usize {
-		self.gruen34.n_vars()
+		self.gruen34.n_vars_remaining()
 	}
 
 	fn execute(&mut self) -> Result<Vec<RoundCoeffs<F>>, Error> {
@@ -62,7 +58,7 @@ where
 		// Multilinear inputs are the same length by invariant
 		debug_assert_eq!(self.multilinears[0].len(), self.multilinears[1].len());
 
-		let n_vars_remaining = self.n_vars_remaining();
+		let n_vars_remaining = self.n_vars();
 		assert!(n_vars_remaining > 0);
 
 		let eq_expansion = self.gruen34.eq_expansion();
@@ -106,7 +102,7 @@ where
 			return Err(Error::ExpectedExecute);
 		};
 
-		assert!(self.n_vars_remaining() > 0);
+		assert!(self.n_vars() > 0);
 
 		let sum = prime_coeffs.evaluate(challenge);
 
@@ -120,7 +116,7 @@ where
 	}
 
 	fn finish(self) -> Result<Vec<F>, Error> {
-		if self.n_vars_remaining() > 0 {
+		if self.n_vars() > 0 {
 			let error = match self.last_coeffs_or_eval {
 				RoundCoeffsOrEval::Coeffs(_) => Error::ExpectedFold,
 				RoundCoeffsOrEval::Eval(_) => Error::ExpectedExecute,

--- a/crates/prover/src/protocols/sumcheck/common.rs
+++ b/crates/prover/src/protocols/sumcheck/common.rs
@@ -27,7 +27,10 @@ use super::error::Error;
 ///
 /// [Gruen24]: <https://eprint.iacr.org/2024/108>
 pub trait SumcheckProver<F: Field> {
-	/// The number of variables in the multivariate polynomial.
+	/// The number of variables in the remaining multivariate polynomial.
+	///
+	/// The number of variables decrements after each [`Self::fold`] call, as that binds one free
+	/// variable with a concrete challenge.
 	fn n_vars(&self) -> usize;
 
 	/// Computes the prover messages for this round as a univariate polynomial.

--- a/crates/prover/src/protocols/sumcheck/gruen34.rs
+++ b/crates/prover/src/protocols/sumcheck/gruen34.rs
@@ -35,10 +35,6 @@ impl<F: Field, P: PackedField<Scalar = F>> Gruen34<P> {
 		&self.eq_expansion
 	}
 
-	pub fn n_vars(&self) -> usize {
-		self.eval_point.len()
-	}
-
 	pub fn n_vars_remaining(&self) -> usize {
 		self.n_vars_remaining
 	}


### PR DESCRIPTION
Discussed in ENG2-64. The new definition satisfies the caller
requirements in all cases. n_vars was only called before to get the
initial number of variables. Now the method is more useful.