### PR TITLE
[mlecheck] Introduce MleCheckProver trait and MleToSumCheckAdaptor

### DIFF
--- a/crates/prover/src/protocols/sumcheck/common.rs
+++ b/crates/prover/src/protocols/sumcheck/common.rs
@@ -77,3 +77,36 @@ where
 		either::for_both!(self, inner => inner.finish())
 	}
 }
+
+/// A prover for the MLE-check variant of the sumcheck protocol.
+///
+/// An MLE-check protocol is an interactive protocol similar to sumcheck, but with modifications
+/// introduced in [Gruen24], Section 3. The prover in this case wants to argue a claim that for
+/// some $n$-variate polynomial $F(X_0, \ldots, X_{n-1})$ (which is not necessarily multilinear),
+/// for a given point $(z_0, \ldots, z_{n-1})$ and claimed value $s$, that
+///
+/// $$
+/// s = \sum_{v \in B_n} F(v) \cdot eq(v, z)
+/// $$
+///
+/// Unless $F$ is indeed multilinear, $s \ne F(z)$ necessarily. While the prover and verifier could
+/// engage in a standard sumcheck protocol to reduce this claim, it is concretely more efficient to
+/// use the optimized protocol from [Gruen24], which we call an "MLE-check".
+///
+/// This trait inherits from [`SumcheckProver`] since it shares the same type-level interface
+/// and protocol execution pattern. However, `MleCheckProver` instances provide different
+/// guarantees for the values returned by [`SumcheckProver::execute`] compared to regular
+/// sumcheck provers.
+///
+/// Note that while this technically violates the Liskov substitution principle (LSP), the
+/// violation is contained and deemed acceptable for the current design. A future refactor
+/// could introduce a common `SumcheckLikeProver` parent trait if stricter LSP compliance
+/// becomes necessary.
+///
+/// [Gruen24]: <https://eprint.iacr.org/2024/108>
+pub trait MleCheckProver<F: Field>: SumcheckProver<F> {
+	/// Returns the evaluation point for the remaining claim.
+	///
+	/// The length of the evaluation point is equal to `self.n_vars()`.
+	fn eval_point(&self) -> &[F];
+}

--- a/crates/prover/src/protocols/sumcheck/mle_to_sumcheck_adaptor.rs
+++ b/crates/prover/src/protocols/sumcheck/mle_to_sumcheck_adaptor.rs
@@ -1,0 +1,76 @@
+use binius_field::Field;
+use binius_math::multilinear::eq::eq_one_var;
+use binius_verifier::protocols::sumcheck::RoundCoeffs;
+
+use crate::protocols::sumcheck::{
+	Error,
+	common::{MleCheckProver, SumcheckProver},
+	round_evals::round_coeffs_by_eq,
+};
+
+/// Adaptor that exposes a `SumcheckProver` interface for an internal `MleCheckProver`.
+///
+/// This struct implements the technique from [Gruen24] to convert an MLE-check protocol
+/// into a standard sumcheck protocol. The key insight is that the MLE-check claim
+/// $\sum_{v \in \{0,1\}^n} F(v) \cdot \text{eq}(v, z) = s$ can be rewritten as a sumcheck
+/// claim by multiplying in the equality polynomial term-by-term during the protocol execution.
+///
+/// In each round, the adaptor multiplies the round polynomials from the inner MLE-check
+/// prover by a linear polynomial term $(X - \alpha)$ where $\alpha$ is the corresponding
+/// coordinate of the evaluation point. This effectively transforms the MLE-check round
+/// polynomial into a sumcheck round polynomial that includes the equality check.
+///
+/// The `eq_prefix_eval` field accumulates the product of all previously factored equality
+/// terms, ensuring the round polynomials maintain the correct scaling throughout the protocol.
+///
+/// [Gruen24]: <https://eprint.iacr.org/2024/108>
+#[derive(Debug)]
+pub struct MleToSumCheckAdaptor<F: Field, InnerProver> {
+	mlecheck_prover: InnerProver,
+	eq_prefix_eval: F,
+}
+
+impl<F: Field, InnerProver: MleCheckProver<F>> MleToSumCheckAdaptor<F, InnerProver> {
+	pub fn new(mlecheck_prover: InnerProver) -> Self {
+		Self {
+			mlecheck_prover,
+			eq_prefix_eval: F::ONE,
+		}
+	}
+}
+
+impl<F: Field, InnerProver: MleCheckProver<F>> SumcheckProver<F>
+	for MleToSumCheckAdaptor<F, InnerProver>
+{
+	fn n_vars(&self) -> usize {
+		self.mlecheck_prover.n_vars()
+	}
+
+	fn execute(&mut self) -> Result<Vec<RoundCoeffs<F>>, Error> {
+		let round_coeffs_multi = self.mlecheck_prover.execute()?;
+
+		// Multiply the round polynomials from the inner MLE-check prover by (X - α).
+		let alpha = self.mlecheck_prover.eval_point()[self.n_vars() - 1];
+		let wrapped_round_coeffs = round_coeffs_multi
+			.into_iter()
+			.map(|round_coeffs| round_coeffs_by_eq(&round_coeffs, alpha) * self.eq_prefix_eval)
+			.collect();
+
+		Ok(wrapped_round_coeffs)
+	}
+
+	fn fold(&mut self, challenge: F) -> Result<(), Error> {
+		if self.n_vars() == 0 {
+			return Err(Error::ExpectedFinish);
+		}
+
+		let alpha = self.mlecheck_prover.eval_point()[self.n_vars() - 1];
+		self.eq_prefix_eval *= eq_one_var(challenge, alpha);
+
+		self.mlecheck_prover.fold(challenge)
+	}
+
+	fn finish(self) -> Result<Vec<F>, Error> {
+		self.mlecheck_prover.finish()
+	}
+}

--- a/crates/prover/src/protocols/sumcheck/mod.rs
+++ b/crates/prover/src/protocols/sumcheck/mod.rs
@@ -7,8 +7,10 @@ pub mod bivariate_product_multi_mle;
 pub mod common;
 mod error;
 mod gruen34;
+mod mle_to_sumcheck_adaptor;
 mod prove;
 mod round_evals;
 
 pub use error::*;
+pub use mle_to_sumcheck_adaptor::*;
 pub use prove::*;


### PR DESCRIPTION
This is the first in a sequence of PRs that separates the MLE-check protocol from sumcheck. There is a new `MleCheckProver` trait to facilitate this and an decorator that turns and MleCheckProver into a SumcheckProver efficiently.

Why? This is a cleaner separation of concerns and there are also times when we want to invoke the specialized MLE-check verifier.