### PR TITLE
[sumcheck] Adapt the MleCheckProvers to support the MleCheckProver interface

### DIFF
--- a/crates/prover/src/protocols/sumcheck/common.rs
+++ b/crates/prover/src/protocols/sumcheck/common.rs
@@ -80,18 +80,7 @@ where
 
 /// A prover for the MLE-check variant of the sumcheck protocol.
 ///
-/// An MLE-check protocol is an interactive protocol similar to sumcheck, but with modifications
-/// introduced in [Gruen24], Section 3. The prover in this case wants to argue a claim that for
-/// some $n$-variate polynomial $F(X_0, \ldots, X_{n-1})$ (which is not necessarily multilinear),
-/// for a given point $(z_0, \ldots, z_{n-1})$ and claimed value $s$, that
-///
-/// $$
-/// s = \sum_{v \in B_n} F(v) \cdot eq(v, z)
-/// $$
-///
-/// Unless $F$ is indeed multilinear, $s \ne F(z)$ necessarily. While the prover and verifier could
-/// engage in a standard sumcheck protocol to reduce this claim, it is concretely more efficient to
-/// use the optimized protocol from [Gruen24], which we call an "MLE-check".
+/// See [`binius_verifier::protocols::mlecheck::verify`] for context on the protocol.
 ///
 /// This trait inherits from [`SumcheckProver`] since it shares the same type-level interface
 /// and protocol execution pattern. However, `MleCheckProver` instances provide different


### PR DESCRIPTION
# Implement MLE-check protocol verification

This PR implements the MLE-check protocol verification functionality:

1. Moves the MLE-check protocol documentation from the prover to the verifier crate
2. Implements the `verify` function in the `mlecheck` module that:
   - Takes a point, degree, evaluation, and transcript
   - Processes each round of the protocol by reading coefficients and sampling challenges
   - Returns the final evaluation and challenge point

The MLE-check protocol is an optimized variant of sumcheck for verifying polynomial evaluations, as described in [Gruen24].