### PR TITLE
[mlecheck] Rename MleToSumCheckAdaptor to Decorator

### DIFF
--- a/crates/prover/src/protocols/sumcheck/bivariate_product_mle.rs
+++ b/crates/prover/src/protocols/sumcheck/bivariate_product_mle.rs
@@ -170,7 +170,7 @@ mod tests {
 
 	use super::*;
 	use crate::protocols::sumcheck::{
-		MleToSumCheckAdaptor, prove::prove_single, prove_single_mlecheck,
+		MleToSumCheckDecorator, prove::prove_single, prove_single_mlecheck,
 	};
 
 	fn test_mlecheck_prove_verify<F, P>(
@@ -248,7 +248,7 @@ mod tests {
 		P: PackedField<Scalar = F>,
 	{
 		let n_vars = mlecheck_prover.n_vars();
-		let prover = MleToSumCheckAdaptor::new(mlecheck_prover);
+		let prover = MleToSumCheckDecorator::new(mlecheck_prover);
 
 		// Run the proving protocol
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());

--- a/crates/prover/src/protocols/sumcheck/bivariate_product_multi_mle.rs
+++ b/crates/prover/src/protocols/sumcheck/bivariate_product_multi_mle.rs
@@ -194,7 +194,7 @@ mod tests {
 	use rand::{SeedableRng, rngs::StdRng};
 
 	use super::*;
-	use crate::protocols::sumcheck::MleToSumCheckAdaptor;
+	use crate::protocols::sumcheck::MleToSumCheckDecorator;
 
 	fn test_bivariate_product_multi_mlecheck_consistency_helper<
 		F: Field,
@@ -239,7 +239,7 @@ mod tests {
 		let mlecheck_prover =
 			BivariateProductMultiMlecheckProver::new(multilinears, &eval_point, &eval_claims)
 				.unwrap();
-		let mut prover = MleToSumCheckAdaptor::new(mlecheck_prover);
+		let mut prover = MleToSumCheckDecorator::new(mlecheck_prover);
 
 		// Append eq indicator at the end
 		folded_multilinears.push(eq_ind_partial_eval(&eval_point));

--- a/crates/prover/src/protocols/sumcheck/mle_to_sumcheck.rs
+++ b/crates/prover/src/protocols/sumcheck/mle_to_sumcheck.rs
@@ -25,12 +25,12 @@ use crate::protocols::sumcheck::{
 ///
 /// [Gruen24]: <https://eprint.iacr.org/2024/108>
 #[derive(Debug, Clone)]
-pub struct MleToSumCheckAdaptor<F: Field, InnerProver> {
+pub struct MleToSumCheckDecorator<F: Field, InnerProver> {
 	mlecheck_prover: InnerProver,
 	eq_prefix_eval: F,
 }
 
-impl<F: Field, InnerProver: MleCheckProver<F>> MleToSumCheckAdaptor<F, InnerProver> {
+impl<F: Field, InnerProver: MleCheckProver<F>> MleToSumCheckDecorator<F, InnerProver> {
 	pub fn new(mlecheck_prover: InnerProver) -> Self {
 		Self {
 			mlecheck_prover,
@@ -40,7 +40,7 @@ impl<F: Field, InnerProver: MleCheckProver<F>> MleToSumCheckAdaptor<F, InnerProv
 }
 
 impl<F: Field, InnerProver: MleCheckProver<F>> SumcheckProver<F>
-	for MleToSumCheckAdaptor<F, InnerProver>
+	for MleToSumCheckDecorator<F, InnerProver>
 {
 	fn n_vars(&self) -> usize {
 		self.mlecheck_prover.n_vars()

--- a/crates/prover/src/protocols/sumcheck/mod.rs
+++ b/crates/prover/src/protocols/sumcheck/mod.rs
@@ -7,10 +7,10 @@ pub mod bivariate_product_multi_mle;
 pub mod common;
 mod error;
 mod gruen34;
-mod mle_to_sumcheck_adaptor;
+mod mle_to_sumcheck;
 mod prove;
 mod round_evals;
 
 pub use error::*;
-pub use mle_to_sumcheck_adaptor::*;
+pub use mle_to_sumcheck::*;
 pub use prove::*;


### PR DESCRIPTION
This actually matches the Decorator pattern better because it's adding behavior, not just bridging interfaces.