### PR TITLE
[frontend] refactor path specification

### DIFF
--- a/crates/frontend/src/compiler/gate/assert_0.rs
+++ b/crates/frontend/src/compiler/gate/assert_0.rs
@@ -15,6 +15,7 @@ use crate::{
 		circuit,
 		gate::opcode::OpcodeShape,
 		gate_graph::{Gate, GateData, GateParam},
+		pathspec::PathSpec,
 	},
 	constraint_system::{AndConstraint, ConstraintSystem},
 	word::Word,
@@ -52,16 +53,13 @@ pub fn constrain(
 pub fn evaluate(
 	_gate: Gate,
 	data: &GateData,
-	assertion_name: Option<&String>,
+	assertion_path: PathSpec,
 	w: &mut circuit::WitnessFiller,
 ) {
 	let GateParam { inputs, .. } = data.gate_param();
 	let [x] = inputs else { unreachable!() };
 
 	if w[*x] != Word::ZERO {
-		let name = assertion_name
-			.map(|s| s.as_str())
-			.unwrap_or("<unnamed assertion>");
-		w.flag_assertion_failed(|w| format!("{} failed: {:?} != 0", name, w[*x]));
+		w.flag_assertion_failed(assertion_path, |w| format!("{:?} != 0", w[*x]));
 	}
 }

--- a/crates/frontend/src/compiler/gate/assert_band_0.rs
+++ b/crates/frontend/src/compiler/gate/assert_band_0.rs
@@ -15,6 +15,7 @@ use crate::{
 		circuit,
 		gate::opcode::OpcodeShape,
 		gate_graph::{Gate, GateData, GateParam},
+		pathspec::PathSpec,
 	},
 	constraint_system::{AndConstraint, ConstraintSystem},
 	word::Word,
@@ -49,16 +50,13 @@ pub fn constrain(
 pub fn evaluate(
 	_gate: Gate,
 	data: &GateData,
-	assertion_name: Option<&String>,
+	assertion_path: PathSpec,
 	w: &mut circuit::WitnessFiller,
 ) {
 	let GateParam { inputs, .. } = data.gate_param();
 	let [x, y] = inputs else { unreachable!() };
 
 	if (w[*x] & w[*y]) != Word::ZERO {
-		let name = assertion_name
-			.map(|s| s.as_str())
-			.unwrap_or("<unnamed assertion>");
-		w.flag_assertion_failed(|w| format!("{} failed: {:?} & {:?} != 0", name, w[*x], w[*y]));
+		w.flag_assertion_failed(assertion_path, |w| format!("{:?} & {:?} != 0", w[*x], w[*y]));
 	}
 }

--- a/crates/frontend/src/compiler/gate/assert_eq.rs
+++ b/crates/frontend/src/compiler/gate/assert_eq.rs
@@ -16,6 +16,7 @@ use crate::{
 		circuit,
 		gate::opcode::OpcodeShape,
 		gate_graph::{Gate, GateData, GateParam},
+		pathspec::PathSpec,
 	},
 	constraint_system::{AndConstraint, ConstraintSystem},
 	word::Word,
@@ -54,16 +55,13 @@ pub fn constrain(
 pub fn evaluate(
 	_gate: Gate,
 	data: &GateData,
-	assertion_name: Option<&String>,
+	assertion_path: PathSpec,
 	w: &mut circuit::WitnessFiller,
 ) {
 	let GateParam { inputs, .. } = data.gate_param();
 	let [x, y] = inputs else { unreachable!() };
 
 	if w[*x] != w[*y] {
-		let name = assertion_name
-			.map(|s| s.as_str())
-			.unwrap_or("<unnamed assertion>");
-		w.flag_assertion_failed(|w| format!("{} failed: {:?} != {:?}", name, w[*x], w[*y]));
+		w.flag_assertion_failed(assertion_path, |w| format!("{:?} != {:?}", w[*x], w[*y]));
 	}
 }

--- a/crates/frontend/src/compiler/gate/assert_eq_cond.rs
+++ b/crates/frontend/src/compiler/gate/assert_eq_cond.rs
@@ -17,6 +17,7 @@ use crate::{
 		circuit,
 		gate::opcode::OpcodeShape,
 		gate_graph::{Gate, GateData, GateParam},
+		pathspec::PathSpec,
 	},
 	constraint_system::{AndConstraint, ConstraintSystem},
 	word::Word,
@@ -52,7 +53,7 @@ pub fn constrain(
 pub fn evaluate(
 	_gate: Gate,
 	data: &GateData,
-	assertion_name: Option<&String>,
+	assertion_path: PathSpec,
 	w: &mut circuit::WitnessFiller,
 ) {
 	let GateParam { inputs, .. } = data.gate_param();
@@ -60,11 +61,8 @@ pub fn evaluate(
 
 	let diff = w[*x] ^ w[*y];
 	if (diff & w[*mask]) != Word::ZERO {
-		let name = assertion_name
-			.map(|s| s.as_str())
-			.unwrap_or("<unnamed assertion>");
-		w.flag_assertion_failed(|w| {
-			format!("{} failed: ({:?} ^ {:?}) & {:?} != 0", name, w[*x], w[*y], w[*mask])
+		w.flag_assertion_failed(assertion_path, |w| {
+			format!("({:?} ^ {:?}) & {:?} != 0", w[*x], w[*y], w[*mask])
 		});
 	}
 }

--- a/crates/frontend/src/compiler/gate/mod.rs
+++ b/crates/frontend/src/compiler/gate/mod.rs
@@ -58,7 +58,7 @@ pub fn constrain(
 
 pub fn evaluate(gate: Gate, graph: &GateGraph, w: &mut circuit::WitnessFiller) {
 	let data = &graph.gates[gate];
-	let assertion_name = graph.assertion_names.get(gate);
+	let assertion_path = graph.assertion_names[gate];
 
 	match data.opcode {
 		Opcode::Band => band::evaluate(gate, data, w),
@@ -68,11 +68,11 @@ pub fn evaluate(gate: Gate, graph: &GateGraph, w: &mut circuit::WitnessFiller) {
 		Opcode::Iadd32 => iadd32::evaluate(gate, data, w),
 		Opcode::Shr32 => shr32::evaluate(gate, data, w),
 		Opcode::Rotr32 => rotr32::evaluate(gate, data, w),
-		Opcode::AssertEq => assert_eq::evaluate(gate, data, assertion_name, w),
-		Opcode::Assert0 => assert_0::evaluate(gate, data, assertion_name, w),
-		Opcode::AssertBand0 => assert_band_0::evaluate(gate, data, assertion_name, w),
+		Opcode::AssertEq => assert_eq::evaluate(gate, data, assertion_path, w),
+		Opcode::Assert0 => assert_0::evaluate(gate, data, assertion_path, w),
+		Opcode::AssertBand0 => assert_band_0::evaluate(gate, data, assertion_path, w),
 		Opcode::Imul => imul::evaluate(gate, data, w),
-		Opcode::AssertEqCond => assert_eq_cond::evaluate(gate, data, assertion_name, w),
+		Opcode::AssertEqCond => assert_eq_cond::evaluate(gate, data, assertion_path, w),
 		Opcode::IcmpUlt => icmp_ult::evaluate(gate, data, w),
 		Opcode::IcmpEq => icmp_eq::evaluate(gate, data, w),
 		Opcode::ExtractByte => extract_byte::evaluate(gate, data, w),

--- a/crates/frontend/src/compiler/pathspec.rs
+++ b/crates/frontend/src/compiler/pathspec.rs
@@ -1,0 +1,66 @@
+use cranelift_entity::PrimaryMap;
+
+/// A designator of a path within a circuit.
+///
+/// Compact, only 32-bit.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub struct PathSpec(u32);
+cranelift_entity::entity_impl!(PathSpec);
+
+struct Node {
+	name: String,
+	parent: PathSpec,
+}
+
+/// A tree that holds paths within a circuit.
+pub struct PathSpecTree {
+	root: PathSpec,
+	nodes: PrimaryMap<PathSpec, Node>,
+}
+
+impl PathSpecTree {
+	/// Creates a new empty tree.
+	pub fn new() -> Self {
+		let mut nodes = PrimaryMap::new();
+		let root = nodes.push(Node {
+			name: String::new(),
+			parent: PathSpec(0),
+		});
+		Self { root, nodes }
+	}
+
+	/// Extend the tree with a new branch that stems from the given `parent` and has a certain
+	/// `name`.
+	pub fn extend(&mut self, parent: PathSpec, name: impl Into<String>) -> PathSpec {
+		self.nodes.push(Node {
+			name: name.into(),
+			parent,
+		})
+	}
+
+	/// Writes a string representation of the given path spec into a given string buffer.
+	///
+	/// Note that the string buffer is not reset, which allows appending to the existing contents
+	/// of the string but poses a string of mangling of the string.
+	pub fn stringify(&self, ls: PathSpec, out: &mut String) {
+		fn stringify_rec(
+			root: PathSpec,
+			nodes: &PrimaryMap<PathSpec, Node>,
+			ls: PathSpec,
+			out: &mut String,
+		) {
+			if ls == root {
+				return;
+			}
+			stringify_rec(root, nodes, nodes[ls].parent, out);
+			out.push('.');
+			out.push_str(&nodes[ls].name);
+		}
+		stringify_rec(self.root, &self.nodes, ls, out);
+	}
+
+	/// Returns the root of the tree.
+	pub fn root(&self) -> PathSpec {
+		self.root
+	}
+}


### PR DESCRIPTION
Instead of stringifying each location now create a tree that allows for fast
allocation of location IDs and efficiently stringifying them.

This brings modest efficiency gains but those are not the goal. The goal is to
be able to sort the gates by their origin.