### PR TITLE
Documenting the BivariateProductMlecheckProver and auxiliary structs

### DIFF
--- a/crates/prover/src/protocols/sumcheck/round_evals.rs
+++ b/crates/prover/src/protocols/sumcheck/round_evals.rs
@@ -5,6 +5,10 @@ use std::ops::Add;
 use binius_field::{Field, PackedField};
 use binius_verifier::protocols::sumcheck::RoundCoeffs;
 
+// Sumcheck round evaluations for degree-2 polynomials, on points 1 and ∞. The latter
+// is defined as limit of P(X)/X^n as X approaches infinity, which equals the leading coefficient.
+// This is the Karatsuba trick. Take note that it may require removing lower-degree terms from the
+// composition polynomial.
 #[derive(Clone, Debug, Default)]
 pub struct RoundEvals2<P: PackedField> {
 	pub y_1: P,
@@ -21,12 +25,17 @@ impl<P: PackedField> RoundEvals2<P> {
 }
 
 impl<F: Field> RoundEvals2<F> {
+	// Regular degree-2 interpolation routine.
 	pub fn interpolate(self, sum: F) -> RoundCoeffs<F> {
+		// Computing evaluation at 0 from sum claim and evaluation on 1.
 		let y_0 = sum - self.y_1;
 		calculate_round_coeffs_from_evals_2(y_0, self.y_1, self.y_inf)
 	}
 
+	// Interpolation routine for evaluations on P'(x) in Mlechecks.
 	pub fn interpolate_eq(self, sum: F, alpha: F) -> RoundCoeffs<F> {
+		// We are given a sum claim on prime polynomial from the previous round, we also know that
+		//  sum = (1 - alpha) * P'(0) + alpha * P'(1)
 		let y_0 = (sum - self.y_1 * alpha) * (F::ONE - alpha).invert_or_zero();
 		calculate_round_coeffs_from_evals_2(y_0, self.y_1, self.y_inf)
 	}
@@ -42,10 +51,8 @@ impl<P: PackedField> Add<&Self> for RoundEvals2<P> {
 	}
 }
 
-/// Computes the coefficients of a degree 2 polynomial interpolating three points: (0, y_0),
-/// (1, y_1), and (infinity, y_inf). The evaluation of a polynomial at infinity is defined as the
-/// limit of P(X)/X^n as X approaches infinity, which equals the leading coefficient. This is the
-/// Karatsuba trick.
+// Computes the coefficients of a degree 2 polynomial interpolating three points: (0, y_0),
+// (1, y_1), and (infinity, y_inf).
 fn calculate_round_coeffs_from_evals_2<F: Field>(y_0: F, y_1: F, y_inf: F) -> RoundCoeffs<F> {
 	// For a polynomial P(X) = c_2 x² + c_1 x + c_0:
 	//
@@ -59,6 +66,7 @@ fn calculate_round_coeffs_from_evals_2<F: Field>(y_0: F, y_1: F, y_inf: F) -> Ro
 	RoundCoeffs(vec![c_0, c_1, c_2])
 }
 
+// Multiplication of a polynomial in monomial form by eq(x, alpha).
 pub fn round_coeffs_by_eq<F: Field>(prime: &RoundCoeffs<F>, alpha: F) -> RoundCoeffs<F> {
 	// eq(X, α) = (1 − α) + (2 α − 1) X
 	// NB: In characteristic 2, this expression can be simplified to 1 + α + challenge.


### PR DESCRIPTION
### TL;DR

Added comprehensive documentation to the Mlecheck implementation, explaining the mathematical foundations and optimization techniques used in the sumcheck protocol.

### What changed?

- Added detailed documentation to `BivariateProductMlecheckProver` explaining the mathematical definition, partitioning of equality indicators, and optimization techniques
- Added documentation to the `Gruen34` helper struct explaining its purpose in implementing degree lowering logic from the Gruen24 paper
- Added explanatory comments throughout the code to clarify the implementation of interpolation routines and polynomial operations
- Added documentation to `RoundEvals2` explaining the Karatsuba trick for evaluating polynomials at infinity
- Clarified the mathematical operations in various methods with inline comments

### How to test?

The changes are documentation-only, so existing tests should continue to pass without modification. Code reviewers should verify that the documentation accurately reflects the implementation.

### Why make this change?

This documentation improves code readability and maintainability by explaining the complex mathematical concepts behind the Mlecheck implementation. It references the Gruen24 paper (https://eprint.iacr.org/2024/108) and explains how the implementation follows the techniques described in Section 3.4 of that paper. This will help developers understand the purpose and functionality of the code, making future modifications easier and less error-prone.