### PR TITLE
[pcs] expand tests

### DIFF
--- a/crates/prover/src/protocols/basefold/prover.rs
+++ b/crates/prover/src/protocols/basefold/prover.rs
@@ -211,7 +211,6 @@ mod test {
 		evaluation_point: Vec<F>,
 		evaluation_claim: F,
 	) -> Result<(), Box<dyn std::error::Error>> {
-
 		let n_vars = multilinear.log_len();
 
 		let eval_point_eq = eq_ind_partial_eval(&evaluation_point);


### PR DESCRIPTION
### TL;DR

Added a test for invalid proofs in the Basefold protocol implementation.

### What changed?

- Refactored the existing Basefold test into a reusable test utility function `run_basefold_prove_and_verify`
- Created two separate test cases:
  - `test_basefold_valid_proof`: Tests that valid proofs are accepted
  - `test_basefold_invalid_proof`: Tests that invalid proofs (with a modified claim) are rejected
- Added necessary imports for `Field` and `FieldBuffer`

### How to test?

Run the tests in the Basefold protocol module:

```bash
cargo test -p prover --lib protocols::basefold::prover::test
```

### Why make this change?

This change improves test coverage by explicitly verifying that the Basefold protocol correctly rejects invalid proofs. By testing both the positive and negative cases, we ensure the protocol's security properties are working as expected. The refactoring also makes the test code more maintainable and reusable.