### PR TITLE
Test conformance of multi and single bivariate product mlechecks

### DIFF
--- a/crates/prover/src/protocols/sumcheck/bivariate_product.rs
+++ b/crates/prover/src/protocols/sumcheck/bivariate_product.rs
@@ -71,7 +71,9 @@ impl<F: Field, P: PackedField<Scalar = F>> SumcheckProver<F> for BivariateProduc
 				})
 				.reduce(RoundEvals2::default, |lhs, rhs| lhs + &rhs);
 
-		let round_coeffs = round_evals.sum_scalars().interpolate(*last_sum);
+		let round_coeffs = round_evals
+			.sum_scalars(n_vars_remaining)
+			.interpolate(*last_sum);
 		self.last_coeffs_or_sum = RoundCoeffsOrSum::Coeffs(round_coeffs.clone());
 		Ok(vec![round_coeffs])
 	}

--- a/crates/prover/src/protocols/sumcheck/bivariate_product_mle.rs
+++ b/crates/prover/src/protocols/sumcheck/bivariate_product_mle.rs
@@ -143,7 +143,7 @@ where
 				}
 			})
 			.reduce(RoundEvals2::default, |lhs, rhs| lhs + &rhs)
-			.sum_scalars();
+			.sum_scalars(n_vars_remaining);
 
 		let alpha = self.gruen34.next_coordinate();
 		let round_coeffs = round_evals.interpolate_eq(*last_eval, alpha);
@@ -322,6 +322,8 @@ mod tests {
 		)
 		.unwrap();
 
+		// The prover binds variables from high to low, but evaluate expects them from low
+		// to high
 		let mut reduced_eval_point = sumcheck_output.challenges.clone();
 		reduced_eval_point.reverse();
 
@@ -339,8 +341,7 @@ mod tests {
 		);
 
 		// Check that the original multilinears evaluate to the claimed values at the challenge
-		// point The prover binds variables from high to low, but evaluate expects them from low
-		// to high
+		// point
 		let eval_a = evaluate(&multilinear_a, &reduced_eval_point).unwrap();
 		let eval_b = evaluate(&multilinear_b, &reduced_eval_point).unwrap();
 

--- a/crates/prover/src/protocols/sumcheck/round_evals.rs
+++ b/crates/prover/src/protocols/sumcheck/round_evals.rs
@@ -16,10 +16,10 @@ pub struct RoundEvals2<P: PackedField> {
 }
 
 impl<P: PackedField> RoundEvals2<P> {
-	pub fn sum_scalars(self) -> RoundEvals2<P::Scalar> {
+	pub fn sum_scalars(self, n_vars: usize) -> RoundEvals2<P::Scalar> {
 		RoundEvals2 {
-			y_1: self.y_1.iter().sum(),
-			y_inf: self.y_inf.iter().sum(),
+			y_1: self.y_1.iter().take(1 << n_vars).sum(),
+			y_inf: self.y_inf.iter().take(1 << n_vars).sum(),
 		}
 	}
 }


### PR DESCRIPTION
Test conformance of single claim and multiple claim bivariate product mlecheck provers. This uncovered a bug in the former (as well as in bivariate product prover) where the cruft from folding results in incorrect round polynomials.