### PR TITLE
Binary fold support and bitmask access utils for switchover

### DIFF
--- a/crates/math/src/error.rs
+++ b/crates/math/src/error.rs
@@ -16,6 +16,8 @@ pub enum Error {
 	ArgumentRangeError { arg: String, range: Range<usize> },
 	#[error("buffer length must be a power of two")]
 	PowerOfTwoLengthRequired,
+	#[error("tensor and/or multilinear sizes do not match during fold")]
+	FoldLengthMismatch,
 	#[error("cannot split a buffer of length 1")]
 	CannotSplit,
 }

--- a/crates/math/src/field_buffer.rs
+++ b/crates/math/src/field_buffer.rs
@@ -22,12 +22,21 @@ use crate::Error;
 /// This struct maintains a set of invariants:
 ///  1) `values.len()` is a power of two
 ///  2) `values.len() >= 1 << log_len.saturating_sub(P::LOG_WIDTH)`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Eq)]
 pub struct FieldBuffer<P: PackedField, Data: Deref<Target = [P]> = Box<[P]>> {
 	/// log2 the number over elements in the buffer.
 	log_len: usize,
 	/// The packed values.
 	values: Data,
+}
+
+impl<P: PackedField, Data: Deref<Target = [P]>> PartialEq for FieldBuffer<P, Data> {
+	fn eq(&self, other: &Self) -> bool {
+		// Custom equality impl is needed because values beyond length until capacity can be
+		// arbitrary.
+		let prefix = 1 << self.log_len.saturating_sub(P::LOG_WIDTH);
+		self.log_len == other.log_len && self.values[..prefix] == other.values[..prefix]
+	}
 }
 
 impl<P: PackedField> FieldBuffer<P> {

--- a/crates/math/src/multilinear/fold.rs
+++ b/crates/math/src/multilinear/fold.rs
@@ -1,9 +1,9 @@
 // Copyright 2024-2025 Irreducible Inc.
 
-use std::ops::DerefMut;
+use std::ops::{Deref, DerefMut};
 
-use binius_field::PackedField;
-use binius_utils::rayon::prelude::*;
+use binius_field::{Field, PackedField};
+use binius_utils::{random_access_sequence::RandomAccessSequence, rayon::prelude::*};
 
 use crate::{Error, FieldBuffer};
 
@@ -28,15 +28,74 @@ pub fn fold_highest_var_inplace<P: PackedField, Data: DerefMut<Target = [P]>>(
 	Ok(())
 }
 
+/// Computes the fold high of a binary multilinear with a fold tensor.
+///
+/// Binary multilinear is represented transparently by a boolean sequence.
+/// Fold high meaning: for every hypercube vertex of the result, we specialize lower
+/// indexed variables of the binary multilinear to the vertex coordinates and take an
+/// inner product of the remaining multilinear and the tensor.
+///
+/// # Throws
+///
+/// * `PowerOfTwoLengthRequired` if the bool sequence is not of power of two length.
+/// * `FoldLengthMismatch` if the tensor, result and binary multilinear lengths do not add up.
+pub fn binary_fold_high<P, DataOut, DataIn>(
+	values: &mut FieldBuffer<P, DataOut>,
+	tensor: &FieldBuffer<P, DataIn>,
+	bits: impl RandomAccessSequence<bool> + Sync,
+) -> Result<(), Error>
+where
+	P: PackedField,
+	DataOut: DerefMut<Target = [P]>,
+	DataIn: Deref<Target = [P]> + Sync,
+{
+	if !bits.len().is_power_of_two() {
+		return Err(Error::PowerOfTwoLengthRequired);
+	}
+
+	let values_log_len = values.log_len();
+
+	if 1 << (values_log_len + tensor.log_len()) != bits.len() {
+		return Err(Error::FoldLengthMismatch);
+	}
+
+	values
+		.as_mut()
+		.par_iter_mut()
+		.enumerate()
+		.for_each(|(i, packed)| {
+			*packed = P::from_fn(|j| {
+				let scalar_index = i << P::LOG_WIDTH | j;
+				let mut acc = P::Scalar::ZERO;
+
+				for (k, tensor_packed) in tensor.as_ref().iter().enumerate() {
+					for (l, tensor_scalar) in tensor_packed.iter().enumerate() {
+						let tensor_scalar_index = k << P::LOG_WIDTH | l;
+						if bits.get(tensor_scalar_index << values_log_len | scalar_index) {
+							acc += tensor_scalar;
+						}
+					}
+				}
+
+				acc
+			});
+		});
+
+	Ok(())
+}
+
 #[cfg(test)]
 mod tests {
-	use std::iter;
+	use std::iter::repeat_with;
 
 	use binius_field::PackedBinaryField4x32b;
 	use rand::prelude::*;
 
 	use super::*;
-	use crate::{multilinear::eq::eq_ind_partial_eval, test_utils::random_scalars};
+	use crate::{
+		multilinear::{eq::eq_ind_partial_eval, evaluate::evaluate},
+		test_utils::{random_field_buffer, random_scalars},
+	};
 
 	type P = PackedBinaryField4x32b;
 	type F = <P as PackedField>::Scalar;
@@ -48,19 +107,46 @@ mod tests {
 		let n_vars = 10;
 
 		let point = random_scalars::<F>(&mut rng, n_vars);
-		let mut multilinear =
-			FieldBuffer::<P>::from_values(&random_scalars(&mut rng, 1 << n_vars)).unwrap();
+		let mut multilinear = random_field_buffer::<P>(&mut rng, n_vars);
 
-		let eq_ind = eq_ind_partial_eval::<P>(&point);
-		let eval = iter::zip(eq_ind.as_ref(), multilinear.as_ref())
-			.fold(P::zero(), |sum, (&l, &r)| sum + l * r)
-			.iter()
-			.sum();
+		let eval = evaluate(&multilinear, &point).unwrap();
 
 		for &scalar in point.iter().rev() {
 			fold_highest_var_inplace(&mut multilinear, scalar).unwrap();
 		}
 
 		assert_eq!(multilinear.get(0).unwrap(), eval);
+	}
+
+	#[test]
+	fn test_binary_fold_high_conforms_to_regular_fold_high() {
+		let mut rng = StdRng::seed_from_u64(0);
+
+		let n_vars = 10;
+		let tensor_n_vars = 5;
+
+		let point = random_scalars::<F>(&mut rng, tensor_n_vars);
+
+		let tensor = eq_ind_partial_eval::<P>(&point);
+
+		let bits = repeat_with(|| rng.random())
+			.take(1 << n_vars)
+			.collect::<Vec<bool>>();
+
+		let bits_scalars = bits
+			.iter()
+			.map(|&b| if b { F::ONE } else { F::ZERO })
+			.collect::<Vec<F>>();
+
+		let mut bits_buffer = FieldBuffer::<P>::from_values(&bits_scalars).unwrap();
+
+		let mut binary_fold_result = FieldBuffer::<P>::zeros(n_vars - tensor_n_vars);
+		binary_fold_high(&mut binary_fold_result, &tensor, bits.as_slice()).unwrap();
+
+		for &scalar in point.iter().rev() {
+			fold_highest_var_inplace(&mut bits_buffer, scalar).unwrap();
+		}
+
+		assert_eq!(bits_buffer, binary_fold_result);
 	}
 }

--- a/crates/prover/src/protocols/sumcheck/bivariate_product_multi_mle.rs
+++ b/crates/prover/src/protocols/sumcheck/bivariate_product_multi_mle.rs
@@ -79,7 +79,11 @@ where
 
 		assert!(self.n_vars() > 0);
 
-		// Perform chunked summation to only ever read the equality indicator expansion once
+		// Perform chunked summation: for every row, evaluate all compositions and add up
+		// results to an array of round evals accumulators. Alternative would be to sum each
+		// composition on its own pass, but that would require reading the entirety of eq field
+		// buffer on each pass, which will evict the latter from the cache. By doing chunked
+		// compute, we reasonably hope that eq chunk always stays in L1 cache.
 		const MAX_CHUNK_VARS: usize = 12;
 		let chunk_vars = max(MAX_CHUNK_VARS, P::LOG_WIDTH).min(self.n_vars() - 1);
 

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -18,6 +18,7 @@ itertools.workspace = true
 rayon = { optional = true, workspace = true }
 regex = { workspace = true, optional = true }
 thiserror.workspace = true
+trait-set.workspace = true
 
 [dev-dependencies]
 rand = { workspace = true, features = ["std_rng"] }

--- a/crates/utils/src/bitwise.rs
+++ b/crates/utils/src/bitwise.rs
@@ -1,0 +1,83 @@
+// Copyright 2025 Irreducible Inc.
+
+use std::{
+	marker::PhantomData,
+	ops::{BitAnd, Shr},
+};
+
+use trait_set::trait_set;
+
+use super::random_access_sequence::RandomAccessSequence;
+
+// A trait alias for a type that can act as a bitmask.
+//
+// It is intended to be a drop in constraint for a primitive integer type.
+// Take note that `Shr` implementation sign extends signed types.
+trait_set! {
+	pub trait Bitwise =
+		BitAnd<Output=Self> +
+		Shr<usize, Output=Self> +
+		From<u8> +
+		PartialEq<Self> +
+		Sized +
+		Sync +
+		Copy;
+}
+
+/// An adaptor structure that wraps a slice of integers and presents a
+/// random access sequence of bits at a given offset.
+pub struct BitSelector<B: Bitwise, S: AsRef<[B]>> {
+	bit_offset: usize,
+	slice: S,
+	_b_marker: PhantomData<B>,
+}
+
+impl<B: Bitwise, S: AsRef<[B]>> BitSelector<B, S> {
+	pub fn new(bit_offset: usize, slice: S) -> Self {
+		Self {
+			bit_offset,
+			slice,
+			_b_marker: PhantomData,
+		}
+	}
+}
+
+impl<B: Bitwise, S: AsRef<[B]>> RandomAccessSequence<bool> for BitSelector<B, S> {
+	#[inline(always)]
+	fn len(&self) -> usize {
+		self.slice.as_ref().len()
+	}
+
+	#[inline(always)]
+	fn get(&self, index: usize) -> bool {
+		(self.slice.as_ref()[index] >> self.bit_offset) & B::from(1u8) != B::from(0u8)
+	}
+
+	#[inline(always)]
+	unsafe fn get_unchecked(&self, index: usize) -> bool {
+		unsafe {
+			(*self.slice.as_ref().get_unchecked(index) >> self.bit_offset) & B::from(1u8)
+				!= B::from(0u8)
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn test_bit_selector_on_sequential_integer_range() {
+		let log_n = 10;
+
+		let integers = (0u16..1 << log_n).collect::<Vec<_>>();
+
+		for bit_offset in 0..log_n {
+			let selector = BitSelector::new(bit_offset, &integers);
+
+			for i in 0..1 << log_n {
+				assert_eq!(selector.get(i), (i >> bit_offset) & 1 != 0);
+			}
+		}
+	}
+}

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -3,6 +3,7 @@
 //! Utility modules used in Binius.
 
 pub mod array_2d;
+pub mod bitwise;
 pub mod checked_arithmetics;
 pub mod env;
 pub mod error_utils;


### PR DESCRIPTION
Introducing helpers to streamline switchover implementation in rerandomization and selector provers:
 * `BitSelector` adapter to view bitmask slices as boolean sequences that select bits at a given offset
 * `binary_fold_high` routine to fold (implicit) binary columns into field buffers