### PR TITLE
[frontend] circuit builder shared ref

### DIFF
--- a/crates/frontend/src/circuits/rs256.rs
+++ b/crates/frontend/src/circuits/rs256.rs
@@ -101,10 +101,10 @@ impl Rs256Verify {
 		let modulus_bignum = fixedbytevec_be_to_bignum(&modulus);
 		builder.assert_eq("modulus_bytes_len", modulus.len, builder.add_constant_64(256));
 
-		let mut sha256_builder = builder.subcircuit("sha256");
+		let sha256_builder = builder.subcircuit("sha256");
 		let expected_hash_wires: [Wire; 4] = std::array::from_fn(|_| sha256_builder.add_witness());
 		let sha256 = Sha256::new(
-			&mut sha256_builder,
+			&sha256_builder,
 			message.max_len,
 			message.len,
 			expected_hash_wires,

--- a/crates/frontend/src/circuits/sha256/mod.rs
+++ b/crates/frontend/src/circuits/sha256/mod.rs
@@ -76,7 +76,7 @@ impl Sha256 {
 	/// 3. Computes the hash through chained compression functions
 	/// 4. Verifies the computed digest matches the expected digest
 	pub fn new(
-		builder: &mut CircuitBuilder,
+		builder: &CircuitBuilder,
 		max_len: usize,
 		len: Wire,
 		digest: [Wire; 4],
@@ -142,7 +142,7 @@ impl Sha256 {
 		states.push(State::iv(builder));
 		for block_no in 0..n_blocks {
 			let c = Compress::new(
-				&mut builder.subcircuit(format!("compress[{block_no}]")),
+				&builder.subcircuit(format!("compress[{block_no}]")),
 				states[block_no].clone(),
 				padded_message[block_no],
 			);

--- a/crates/frontend/src/circuits/zklogin.rs
+++ b/crates/frontend/src/circuits/zklogin.rs
@@ -168,7 +168,7 @@ impl ZkLogin {
 		);
 
 		let _zkaddr_sha256 = Sha256::new(
-			&mut b.subcircuit("zkaddr_sha256"),
+			&b.subcircuit("zkaddr_sha256"),
 			zkaddr_preimage.max_len,
 			zkaddr_preimage.len,
 			zkaddr,
@@ -207,7 +207,7 @@ impl ZkLogin {
 			],
 		);
 		let _nonce_sha256 = Sha256::new(
-			&mut b.subcircuit("nonce_sha256"),
+			&b.subcircuit("nonce_sha256"),
 			nonce_preimage.max_len,
 			nonce_preimage.len,
 			nonce,

--- a/crates/prover/tests/prove_verify.rs
+++ b/crates/prover/tests/prove_verify.rs
@@ -32,11 +32,11 @@ fn test_prove_verify_sha256_preimage() {
 		0xb00361a3, 0x96177a9c, 0xb410ff61, 0xf20015ad,
 	];
 
-	let mut circuit = compiler::CircuitBuilder::new();
-	let state = State::iv(&mut circuit);
+	let circuit = compiler::CircuitBuilder::new();
+	let state = State::iv(&circuit);
 	let input: [Wire; 16] = std::array::from_fn(|_| circuit.add_witness());
 	let output: [Wire; 8] = std::array::from_fn(|_| circuit.add_inout());
-	let compress = Compress::new(&mut circuit, state, input);
+	let compress = Compress::new(&circuit, state, input);
 
 	// Mask to only low 32-bit.
 	let mask32 = circuit.add_constant(Word::MASK_32);


### PR DESCRIPTION
Initially, the builder was supposed to be passed as a mut, or exclusive,
reference. This is actually more annoying that it has to be, so the
whole thing was changed to have interior mutability which allowed us to
switch to shared reference which greatly reduced friction of using the
circuit builder.

This changeset removes the last remnants of the prior approach.