### PR TITLE
[prover] Fix prover crate when rayon is disabled

### DIFF
--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -24,7 +24,7 @@ trait-set.workspace = true
 rand = { workspace = true, features = ["std_rng"] }
 
 [features]
-default = ["rayon"]
+default = []
 bail_panic = []
 rayon = ["dep:rayon"]
 platform-diagnostics = ["dep:regex"]

--- a/crates/utils/src/rayon/iter/mod.rs
+++ b/crates/utils/src/rayon/iter/mod.rs
@@ -8,6 +8,8 @@ mod par_bridge;
 mod parallel_iterator;
 mod parallel_wrapper;
 
+pub use core::iter::{empty, once, repeat, repeat_n as repeatn};
+
 pub use from_parallel_iterator::FromParallelIterator;
 pub use indexed_parallel_iterator::IndexedParallelIterator;
 pub(super) use indexed_parallel_iterator::IndexedParallelIteratorInner;


### PR DESCRIPTION
The logic in prover had to be adjusted because a ParallelIterator
created using .chain, with inner IndexedParallelIterators, does
implement IndexedParallelIterator itself, but with the serial stub
implementation, this does not hold.