### PR TITLE
[bench] Benchmark the AndReductionProver

### DIFF
--- a/crates/prover/benches/sumcheck.rs
+++ b/crates/prover/benches/sumcheck.rs
@@ -1,20 +1,26 @@
 // Copyright 2025 Irreducible Inc.
 
-use binius_field::{arch::OptimalPackedB128, packed::PackedField};
+use binius_field::{
+	Field,
+	arch::{OptimalB128, OptimalPackedB128},
+	packed::PackedField,
+};
 use binius_math::{
+	FieldBuffer,
 	inner_product::inner_product_par,
 	test_utils::{random_field_buffer, random_scalars},
 };
 use binius_prover::protocols::sumcheck::{
-	bivariate_product::BivariateProductSumcheckProver, prove_single, prove_single_mlecheck,
-	quadratic_mle::QuadraticMleCheckProver,
+	and_reduction::prover::AndReductionProver, bivariate_product::BivariateProductSumcheckProver,
+	prove_single, prove_single_mlecheck, quadratic_mle::QuadraticMleCheckProver,
 };
 use binius_transcript::ProverTranscript;
 use binius_utils::rayon::prelude::*;
 use binius_verifier::config::StdChallenger;
-use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
 use rand::{SeedableRng, prelude::StdRng};
 
+type F = OptimalB128;
 type P = OptimalPackedB128;
 
 fn bench_sumcheck_prove(c: &mut Criterion) {
@@ -34,15 +40,14 @@ fn bench_sumcheck_prove(c: &mut Criterion) {
 			let mut transcript = ProverTranscript::new(StdChallenger::default());
 
 			// Benchmark only the proving phase
-			b.iter(|| {
-				let prover = BivariateProductSumcheckProver::new(
-					[multilinear_a.clone(), multilinear_b.clone()],
-					sum,
-				)
-				.unwrap();
-
-				prove_single(prover, &mut transcript).unwrap()
-			});
+			b.iter_batched(
+				|| [multilinear_a.clone(), multilinear_b.clone()],
+				|multilinears| {
+					let prover = BivariateProductSumcheckProver::new(multilinears, sum).unwrap();
+					prove_single(prover, &mut transcript).unwrap()
+				},
+				BatchSize::SmallInput,
+			);
 		});
 	}
 
@@ -68,18 +73,22 @@ fn bench_mlecheck_prove(c: &mut Criterion) {
 			let mut transcript = ProverTranscript::new(StdChallenger::default());
 
 			// Benchmark only the proving phase
-			b.iter(|| {
-				let prover = QuadraticMleCheckProver::new(
-					[multilinear_a.clone(), multilinear_b.clone()],
-					|[a, b]| a * b,
-					|[a, b]| a * b,
-					&eval_point,
-					eval_claim,
-				)
-				.unwrap();
+			b.iter_batched(
+				|| [multilinear_a.clone(), multilinear_b.clone()],
+				|multilinears| {
+					let prover = QuadraticMleCheckProver::new(
+						multilinears,
+						|[a, b]| a * b,
+						|[a, b]| a * b,
+						&eval_point,
+						eval_claim,
+					)
+					.unwrap();
 
-				prove_single_mlecheck(prover, &mut transcript).unwrap()
-			});
+					prove_single_mlecheck(prover, &mut transcript).unwrap()
+				},
+				BatchSize::SmallInput,
+			);
 		});
 
 		// Benchmark mul gate composition: a * b - c
@@ -101,27 +110,86 @@ fn bench_mlecheck_prove(c: &mut Criterion) {
 			let mut transcript = ProverTranscript::new(StdChallenger::default());
 
 			// Benchmark only the proving phase
-			b.iter(|| {
-				let prover = QuadraticMleCheckProver::new(
+			b.iter_batched(
+				|| {
 					[
 						multilinear_a.clone(),
 						multilinear_b.clone(),
 						multilinear_c.clone(),
-					],
-					|[a, b, c]| a * b - c,
-					|[a, b, _c]| a * b,
-					&eval_point,
-					eval_claim,
-				)
-				.unwrap();
+					]
+				},
+				|multilinears| {
+					let prover = QuadraticMleCheckProver::new(
+						multilinears,
+						|[a, b, c]| a * b - c,
+						|[a, b, _c]| a * b,
+						&eval_point,
+						eval_claim,
+					)
+					.unwrap();
 
-				prove_single_mlecheck(prover, &mut transcript).unwrap()
-			});
+					prove_single_mlecheck(prover, &mut transcript).unwrap()
+				},
+				BatchSize::SmallInput,
+			);
 		});
 	}
 
 	group.finish();
 }
 
-criterion_group!(sumcheck, bench_sumcheck_prove, bench_mlecheck_prove);
+fn bench_and_reduction_prove(c: &mut Criterion) {
+	let mut group = c.benchmark_group("sumcheck/and_reduction");
+
+	// Test different sizes of multilinear polynomials
+	for n_vars in [12, 16, 20] {
+		// Consider each element to be one hypercube vertex.
+		group.throughput(Throughput::Elements(1 << n_vars));
+		group.bench_function(format!("n_vars={n_vars}"), |b| {
+			// Setup phase
+			let mut rng = StdRng::seed_from_u64(0);
+
+			// Generate random multilinear polynomials A, B and C, such that A * B = C
+			let multilinear_a = random_field_buffer::<F>(&mut rng, n_vars);
+			let multilinear_b = random_field_buffer::<F>(&mut rng, n_vars);
+			let multilinear_c = FieldBuffer::new(
+				n_vars,
+				(multilinear_a.as_ref(), multilinear_b.as_ref())
+					.into_par_iter()
+					.map(|(&a_i, &b_i)| a_i * b_i)
+					.collect(),
+			)
+			.unwrap();
+
+			let zerocheck_challenges = random_scalars(&mut rng, n_vars);
+			let mut transcript = ProverTranscript::new(StdChallenger::default());
+
+			// Benchmark only the proving phase
+			b.iter_batched(
+				|| {
+					vec![
+						multilinear_a.clone(),
+						multilinear_b.clone(),
+						multilinear_c.clone(),
+					]
+				},
+				|multilinears| {
+					let prover = AndReductionProver::new(
+						multilinears,
+						zerocheck_challenges.clone(),
+						F::ZERO,
+						n_vars,
+					);
+
+					prove_single(prover, &mut transcript).unwrap()
+				},
+				BatchSize::SmallInput,
+			);
+		});
+	}
+
+	group.finish();
+}
+
+criterion_group!(sumcheck, bench_sumcheck_prove, bench_mlecheck_prove, bench_and_reduction_prove);
 criterion_main!(sumcheck);


### PR DESCRIPTION
Benchmark the `AndReductionProver` against the `QuadraticMleCheckProver`.

Also, fix the sumcheck benchmark method by using batched_iter.

Results on my laptop are:

```
% RAYON_NUM_THREADS=4 taskset -c 0-11 cargo bench --package binius-prover --bench sumcheck -- n_vars=20                                                                                                                                                         [git:07-24-_bench_benchmark_the_andreductionprover][INS][13:49:52]
warning: binius-utils@0.1.0: Platform Build Configuration:
warning: binius-utils@0.1.0:   Target: x86_64-unknown-linux-gnu
warning: binius-utils@0.1.0:   Host: x86_64-unknown-linux-gnu
warning: binius-utils@0.1.0:   RUSTFLAGS: -Ctarget-cpu=native
warning: binius-utils@0.1.0:   Features detected: 36
    Finished `bench` profile [optimized + debuginfo] target(s) in 0.05s
     Running benches/sumcheck.rs (target/release/deps/sumcheck-1a8bb0d82066cba0)
Gnuplot not found, using plotters backend
sumcheck/bivariate_product/n_vars=20
                        time:   [3.3954 ms 3.4659 ms 3.5504 ms]
                        thrpt:  [295.34 Melem/s 302.54 Melem/s 308.82 Melem/s]
                 change:
                        time:   [−56.338% −54.979% −53.441%] (p = 0.00 < 0.05)
                        thrpt:  [+114.78% +122.12% +129.03%]
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  5 (5.00%) high mild
  3 (3.00%) high severe

mlecheck/A*B/n_vars=20  time:   [5.6939 ms 5.7567 ms 5.8237 ms]
                        thrpt:  [180.05 Melem/s 182.15 Melem/s 184.16 Melem/s]
                 change:
                        time:   [−59.665% −58.315% −56.985%] (p = 0.00 < 0.05)
                        thrpt:  [+132.48% +139.89% +147.93%]
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
mlecheck/A*B-C/n_vars=20
                        time:   [7.2783 ms 7.3779 ms 7.4843 ms]
                        thrpt:  [140.10 Melem/s 142.12 Melem/s 144.07 Melem/s]
                 change:
                        time:   [−62.743% −61.577% −60.409%] (p = 0.00 < 0.05)
                        thrpt:  [+152.58% +160.26% +168.41%]
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe

sumcheck/and_reduction/n_vars=20
                        time:   [10.825 ms 10.967 ms 11.111 ms]
                        thrpt:  [94.376 Melem/s 95.615 Melem/s 96.866 Melem/s]
                 change:
                        time:   [−58.463% −57.390% −56.348%] (p = 0.00 < 0.05)
                        thrpt:  [+129.09% +134.69% +140.75%]
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

```