### PR TITLE
Add WASM build to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,27 @@ jobs:
       - name: Run clippy
         run: cargo clippy --all --all-features --tests --benches --examples -- -D warnings
 
+  rust-wasm-wasi:
+    name: rust-wasm-wasi-${{ matrix.expand.name }}
+    runs-on: ${{ matrix.expand.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        expand:
+          - runner: "ubuntu-arm64-2core-8gb"
+            name: "arm64"
+          - runner: "ubuntu-24.04"
+            name: "x86_64"
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      - name: Setup Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          target: wasm32-wasip1
+      - name: Run WASM build
+        run: cargo build --all --all-features --tests --benches --examples --target wasm32-wasip1
+
   rust-doc:
     name: rust-doc
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ bytemuck = { version = "1.18.0", features = [
 bytes = "1.7.2"
 cfg-if = "1.0.0"
 cranelift-entity = "0.121.1"
-criterion = "0.6.0"
+criterion = { version =  "0.6.0", default-features = false }
 derive_more = "0.99.17"
 digest = "0.10.7"
 generic-array = "0.14.7"
@@ -45,7 +45,7 @@ num-bigint = "0.4.6"
 num-integer = "0.1.46"
 num-traits = "0.2.19"
 paste = "1.0.15"
-proptest = "1.2.0"
+proptest = { version = "1.2.0", default-features = false, features = ["std"] }
 rand = { version = "0.9.1", default-features = false, features = ["std"] }
 rayon = "1.10.0"
 regex = "1.10"

--- a/crates/field/src/arch/portable/nibble_invert_128b.rs
+++ b/crates/field/src/arch/portable/nibble_invert_128b.rs
@@ -105,6 +105,7 @@ where
 ///
 /// # Returns
 /// The precomputed nibble power table that can be used with `nibble_invert_128b`.
+#[allow(unused)]
 pub fn generate_nibble_pow_2_n_table<F>(
 	new_fn: impl Fn(u128) -> F,
 	to_u128: impl Fn(F) -> u128,

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -15,7 +15,7 @@ bytes.workspace = true
 cfg-if.workspace = true
 generic-array.workspace = true
 itertools.workspace = true
-rayon = { optional = true, workspace = true }
+rayon = { optional = true, workspace = true}
 regex = { workspace = true, optional = true }
 thiserror.workspace = true
 trait-set.workspace = true

--- a/crates/utils/src/rayon/iter/indexed_parallel_iterator.rs
+++ b/crates/utils/src/rayon/iter/indexed_parallel_iterator.rs
@@ -61,7 +61,7 @@ pub(crate) trait IndexedParallelIteratorInner: ParallelIteratorInner {
 	}
 
 	#[inline]
-	fn step_by(self, step: usize) -> impl IndexedParallelIteratorInner<Item = Self::Item>
+	fn step_by(self, step: usize) -> std::iter::StepBy<Self>
 	where
 		Self: Sized,
 	{
@@ -123,10 +123,19 @@ impl<L: IndexedParallelIteratorInner, R: IndexedParallelIteratorInner> IndexedPa
 }
 impl<I: IndexedParallelIteratorInner> IndexedParallelIteratorInner for std::iter::Enumerate<I> {}
 impl<I: IndexedParallelIteratorInner> IndexedParallelIteratorInner for std::iter::StepBy<I> {}
-impl<I: Iterator, R, F: Fn(I::Item) -> R> IndexedParallelIteratorInner for std::iter::Map<I, F> {}
+impl<I: IndexedParallelIteratorInner, R, F: Fn(I::Item) -> R> IndexedParallelIteratorInner
+	for std::iter::Map<I, F>
+{
+}
 impl<I: IndexedParallelIteratorInner> IndexedParallelIteratorInner for std::iter::Take<I> {}
 impl<T> IndexedParallelIteratorInner for std::vec::IntoIter<T> {}
 impl<T, const N: usize> IndexedParallelIteratorInner for std::array::IntoIter<T, N> {}
+impl<T: Clone> IndexedParallelIteratorInner for std::iter::Repeat<T> {}
+impl<I1: IndexedParallelIteratorInner, I2: IndexedParallelIteratorInner<Item = I1::Item>>
+	IndexedParallelIteratorInner for std::iter::Chain<I1, I2>
+{
+}
+impl<I: IndexedParallelIteratorInner> IndexedParallelIteratorInner for std::iter::Skip<I> {}
 
 #[allow(private_bounds)]
 pub trait IndexedParallelIterator: ParallelIterator {
@@ -203,7 +212,10 @@ pub trait IndexedParallelIterator: ParallelIterator {
 	}
 
 	#[inline]
-	fn step_by(self, step: usize) -> impl IndexedParallelIterator<Item = Self::Item>
+	fn step_by(
+		self,
+		step: usize,
+	) -> ParallelWrapper<std::iter::StepBy<<Self as IndexedParallelIterator>::Inner>>
 	where
 		Self: Sized,
 	{

--- a/crates/utils/src/rayon/mod.rs
+++ b/crates/utils/src/rayon/mod.rs
@@ -39,6 +39,16 @@ cfg_if::cfg_if! {
 			pub const fn num_threads(self, _num_threads: usize) -> Self {
 				Self()
 			}
+
+			#[inline(always)]
+			pub const fn use_current_thread(self) -> Self {
+				Self()
+			}
+
+			#[inline(always)]
+			pub const fn build_global(self) -> Result<(), ThreadPoolBuildError> {
+				Ok(())
+			}
 		}
 
 		#[derive(Debug)]


### PR DESCRIPTION
# Add WASM/WASI support

### TL;DR

Add WASM/WASI support by configuring dependencies and CI workflow to build for the `wasm32-wasip1` target.

### What changed?

- Added a new CI job `rust-wasm-wasi` that builds the project for the `wasm32-wasip1` target on both ARM64 and x86_64 runners
- Modified dependency configurations in `Cargo.toml`:
  - Disabled default features for `criterion` and `proptest` to improve WASM compatibility
  - Kept necessary features like `std` for `proptest`
- Enhanced the `rayon` compatibility layer:
  - Added missing trait implementations for various iterator types
  - Fixed return type specifications for `step_by` method
  - Added stub implementations for `use_current_thread` and `build_global` methods

### How to test?

1. Run `cargo build --target wasm32-wasip1` to verify the project builds for WASM
2. Verify the CI workflow passes for the new WASM/WASI job

### Why make this change?

This change enables the project to be compiled to WebAssembly, expanding its potential use cases to browser and WASI environments. The modifications ensure compatibility with the WASM target while maintaining functionality across all platforms.