### PR TITLE
introduce Record to represent transposed constraints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ profile.json
 Cargo.lock
 CLAUDE.local.md
 /.idea/
+/.vscode/
 **/.DS_Store

--- a/crates/frontend/src/constraint_system.rs
+++ b/crates/frontend/src/constraint_system.rs
@@ -20,7 +20,7 @@ impl Default for ValueIndex {
 /// A different variants of shifting a value.
 ///
 /// Note that there is no shift left arithmetic because it is redundant.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub enum ShiftVariant {
 	/// Shift logical left.
 	Sll,
@@ -30,7 +30,7 @@ pub enum ShiftVariant {
 	Sar,
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub struct ShiftedValueIndex {
 	/// The index of this value in the input values vector `z`.
 	pub value_index: ValueIndex,
@@ -83,6 +83,7 @@ impl ShiftedValueIndex {
 
 pub type Operand = Vec<ShiftedValueIndex>;
 
+#[derive(Clone, Debug, PartialEq)]
 pub struct AndConstraint {
 	pub a: Operand,
 	pub b: Operand,
@@ -115,6 +116,7 @@ impl AndConstraint {
 	}
 }
 
+#[derive(Clone, Debug, PartialEq)]
 pub struct MulConstraint {
 	pub a: Operand,
 	pub b: Operand,

--- a/crates/prover/Cargo.toml
+++ b/crates/prover/Cargo.toml
@@ -24,7 +24,6 @@ serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
-rand.workspace = true
 
 [dev-dependencies]
 binius-math = { path = "../math", features = ["test-utils"] }
@@ -32,6 +31,7 @@ blake2.workspace = true
 criterion.workspace = true
 proptest.workspace = true
 rand = { workspace = true, features = ["std_rng"] }
+rsa = { workspace = true, features = ["sha2"] }
 
 [[bench]]
 name = "binary_merkle_tree"

--- a/crates/prover/src/protocols/mod.rs
+++ b/crates/prover/src/protocols/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod basefold;
 mod inout_check;
+mod shift;
 pub mod sumcheck;
 
 pub use inout_check::InOutCheckProver;

--- a/crates/prover/src/protocols/shift/mod.rs
+++ b/crates/prover/src/protocols/shift/mod.rs
@@ -1,0 +1,6 @@
+// Copyright 2025 Irreducible Inc.
+
+mod record;
+
+#[cfg(test)]
+mod tests;

--- a/crates/prover/src/protocols/shift/record.rs
+++ b/crates/prover/src/protocols/shift/record.rs
@@ -1,0 +1,338 @@
+// Copyright 2025 Irreducible Inc.
+
+use binius_field::Field;
+use binius_frontend::constraint_system::{
+	AndConstraint, ConstraintSystem, MulConstraint, Operand, ShiftVariant, ShiftedValueIndex,
+};
+
+/// `ShiftedValueDatum` identifies a shift variant and a shift amount
+/// and a subset of the constraint indices
+#[derive(Debug, Clone)]
+pub struct ShiftedValueKey {
+	// The shift variant together with the amount form an identifier.
+	// With 3 variants, and amounts up to 64, this can fit in 8 bits.
+	// Using a u8 identifier could save space and increase speed in
+	// in the hot accumuulation loops due to less indirection.
+	pub shift_variant: ShiftVariant,
+	pub amount: usize,
+	pub constraint_indices: Vec<u32>,
+}
+
+impl ShiftedValueKey {
+	// The
+	#[inline]
+	pub fn accumulate<F: Field>(&self, tensor: &[F]) -> F {
+		self.constraint_indices
+			.iter()
+			.map(|&i| tensor[i as usize])
+			.sum()
+	}
+}
+
+/// WordData is a vector of vectors of `WordItem`.
+/// so the outer vector goes across all the witness words.
+/// it should have length equal to the number of witness words.
+/// the inside vector goes across all `duplicates`
+pub type Record = Vec<Vec<ShiftedValueKey>>;
+
+/// Generic function to build word index from any iterator of constraints
+///
+/// we want this to take a list of operands, one for each word, and make a word index.
+fn build_record(word_count: usize, operands: impl Iterator<Item = impl AsRef<Operand>>) -> Record {
+	let mut word_index: Vec<Vec<ShiftedValueKey>> = (0..word_count).map(|_| Vec::new()).collect();
+
+	for (i, operand) in operands.enumerate() {
+		for ShiftedValueIndex {
+			value_index,
+			shift_variant,
+			amount,
+		} in operand.as_ref()
+		{
+			let keys = &mut word_index[value_index.0 as usize];
+
+			if let Some(info) = keys.iter_mut().find(|info| {
+				info.shift_variant as u8 == *shift_variant as u8 && info.amount == *amount
+			}) {
+				info.constraint_indices.push(i as u32);
+			} else {
+				keys.push(ShiftedValueKey {
+					shift_variant: *shift_variant,
+					amount: *amount,
+					constraint_indices: vec![i as u32],
+				});
+			}
+		}
+	}
+
+	word_index
+}
+
+/// Build word index for AND constraints (bit multiplication)
+/// Returns [a_index, b_index, c_index] for the three operands of AND constraints
+pub fn build_record_for_bitmul_constraints(cs: &ConstraintSystem) -> [Record; 3] {
+	let word_count = cs.value_vec_layout.total_len;
+	let constraints = &cs.and_constraints;
+	[
+		build_record(word_count, constraints.iter().map(|c| &c.a)),
+		build_record(word_count, constraints.iter().map(|c| &c.b)),
+		build_record(word_count, constraints.iter().map(|c| &c.c)),
+	]
+}
+
+/// Build word index for MUL constraints (integer multiplication)
+pub fn build_record_for_intmul_constraints(cs: &ConstraintSystem) -> [Record; 4] {
+	let word_count = cs.value_vec_layout.total_len;
+	let constraints = &cs.mul_constraints;
+	[
+		build_record(word_count, constraints.iter().map(|c| &c.a)),
+		build_record(word_count, constraints.iter().map(|c| &c.b)),
+		build_record(word_count, constraints.iter().map(|c| &c.hi)),
+		build_record(word_count, constraints.iter().map(|c| &c.lo)),
+	]
+}
+
+#[cfg(test)]
+mod tests {
+	use std::ops::IndexMut;
+
+	use binius_frontend::{compiler::CircuitBuilder, constraint_system::ValueIndex};
+
+	use super::*;
+	use crate::protocols::shift::tests::*;
+
+	#[test]
+	fn test_invert_cs_simple_circuit() {
+		let builder = CircuitBuilder::new();
+		let a = builder.add_inout();
+		let b = builder.add_inout();
+
+		let result = builder.icmp_ult(a, b);
+		let expected = builder.add_inout();
+		builder.assert_eq("test", result, expected);
+
+		let circuit = builder.build();
+		let cs = circuit.constraint_system();
+
+		invert_constraints(cs);
+	}
+
+	#[test]
+	fn test_invert_cs_jwt_claims() {
+		let (cs, _) = create_jwt_claims_cs_with_witness();
+		invert_constraints(cs);
+	}
+
+	#[test]
+	fn test_invert_cs_sha256() {
+		let (cs, _) = create_sha256_cs_with_witness();
+		invert_constraints(cs);
+	}
+
+	#[test]
+	fn test_invert_cs_base64() {
+		let (cs, _) = create_base64_cs_with_witness();
+		invert_constraints(cs);
+	}
+
+	#[test]
+	fn test_invert_cs_concat() {
+		let (cs, _) = create_concat_cs_with_witness();
+		invert_constraints(cs);
+	}
+
+	#[test]
+	fn test_invert_cs_slice() {
+		let (cs, _) = create_slice_cs_with_witness();
+		invert_constraints(cs);
+	}
+
+	#[test]
+	fn test_invert_cs_rs256() {
+		let (cs, _) = create_rs256_cs_with_witness();
+		invert_constraints(cs);
+	}
+
+	// Tools for testing
+
+	fn find_max_constraint_index(record: &Record) -> u32 {
+		record
+			.iter()
+			.flat_map(|keys| keys.iter())
+			.flat_map(|key| key.constraint_indices.iter())
+			.max()
+			.copied()
+			.unwrap_or(0)
+	}
+
+	/// Generic function to fill operands from record data
+	fn fill_operand_list_from_record<Operands>(
+		record: &[Vec<ShiftedValueKey>],
+		operand_list: &mut Operands,
+	) where
+		Operands: IndexMut<usize, Output = Operand>,
+	{
+		for (word_index, keys) in record.iter().enumerate() {
+			for key in keys {
+				let shifted_value_index = ShiftedValueIndex {
+					value_index: ValueIndex(word_index as u32),
+					shift_variant: key.shift_variant,
+					amount: key.amount,
+				};
+
+				for &constraint_index in &key.constraint_indices {
+					operand_list[constraint_index as usize].push(shifted_value_index);
+				}
+			}
+		}
+	}
+
+	fn revert_bitmul_constraints(
+		a_record: Record,
+		b_record: Record,
+		c_record: Record,
+	) -> Vec<AndConstraint> {
+		let max_index = [
+			find_max_constraint_index(&a_record),
+			find_max_constraint_index(&b_record),
+			find_max_constraint_index(&c_record),
+		]
+		.into_iter()
+		.max()
+		.unwrap_or(0);
+
+		if max_index == 0 {
+			return Vec::new();
+		}
+
+		let mut constraints: Vec<AndConstraint> = (0..=max_index)
+			.map(|_| AndConstraint {
+				a: Vec::new(),
+				b: Vec::new(),
+				c: Vec::new(),
+			})
+			.collect();
+
+		// Create separate operand collections for each constraint operand
+		let mut a_operands: Vec<Operand> = (0..=max_index).map(|_| Vec::new()).collect();
+		let mut b_operands: Vec<Operand> = (0..=max_index).map(|_| Vec::new()).collect();
+		let mut c_operands: Vec<Operand> = (0..=max_index).map(|_| Vec::new()).collect();
+
+		// Fill each operand collection separately
+		fill_operand_list_from_record(&a_record, &mut a_operands);
+		fill_operand_list_from_record(&b_record, &mut b_operands);
+		fill_operand_list_from_record(&c_record, &mut c_operands);
+
+		// Copy operands back to constraints
+		for (i, constraint) in constraints.iter_mut().enumerate() {
+			constraint.a = a_operands[i].clone();
+			constraint.b = b_operands[i].clone();
+			constraint.c = c_operands[i].clone();
+		}
+
+		constraints
+	}
+
+	fn revert_intmul_constraints(
+		a_record: Record,
+		b_record: Record,
+		hi_record: Record,
+		lo_record: Record,
+	) -> Vec<MulConstraint> {
+		let max_index = [
+			find_max_constraint_index(&a_record),
+			find_max_constraint_index(&b_record),
+			find_max_constraint_index(&hi_record),
+			find_max_constraint_index(&lo_record),
+		]
+		.into_iter()
+		.max()
+		.unwrap_or(0);
+
+		if max_index == 0 {
+			return Vec::new();
+		}
+
+		let mut constraints: Vec<MulConstraint> = (0..=max_index)
+			.map(|_| MulConstraint {
+				a: Vec::new(),
+				b: Vec::new(),
+				hi: Vec::new(),
+				lo: Vec::new(),
+			})
+			.collect();
+
+		// Create separate operand collections for each constraint operand
+		let mut a_operands: Vec<Operand> = (0..=max_index).map(|_| Vec::new()).collect();
+		let mut b_operands: Vec<Operand> = (0..=max_index).map(|_| Vec::new()).collect();
+		let mut hi_operands: Vec<Operand> = (0..=max_index).map(|_| Vec::new()).collect();
+		let mut lo_operands: Vec<Operand> = (0..=max_index).map(|_| Vec::new()).collect();
+
+		// Fill each operand collection separately
+		fill_operand_list_from_record(&a_record, &mut a_operands);
+		fill_operand_list_from_record(&b_record, &mut b_operands);
+		fill_operand_list_from_record(&hi_record, &mut hi_operands);
+		fill_operand_list_from_record(&lo_record, &mut lo_operands);
+
+		// Copy operands back to constraints
+		for (i, constraint) in constraints.iter_mut().enumerate() {
+			constraint.a = a_operands[i].clone();
+			constraint.b = b_operands[i].clone();
+			constraint.hi = hi_operands[i].clone();
+			constraint.lo = lo_operands[i].clone();
+		}
+
+		constraints
+	}
+
+	/// Sort operand for canonical ordering by value_index, shift_variant, and amount
+	fn sort_operand(operand: &mut Vec<ShiftedValueIndex>) {
+		operand.sort_by_key(|idx| (idx.value_index.0, idx.shift_variant as u8, idx.amount));
+	}
+
+	fn sort_bitmul_constraint_operands(bitmul: &mut AndConstraint) {
+		sort_operand(&mut bitmul.a);
+		sort_operand(&mut bitmul.b);
+		sort_operand(&mut bitmul.c);
+	}
+
+	fn sort_intmul_constraint_operands(intmul: &mut MulConstraint) {
+		sort_operand(&mut intmul.a);
+		sort_operand(&mut intmul.b);
+		sort_operand(&mut intmul.hi);
+		sort_operand(&mut intmul.lo);
+	}
+
+	// The reversion function
+	fn invert_constraints(cs: ConstraintSystem) {
+		let mut original_bitmul = cs.and_constraints.clone();
+		let mut original_intmul = cs.mul_constraints.clone();
+
+		// Sort original constraints for canonical ordering
+
+		original_bitmul
+			.iter_mut()
+			.for_each(sort_bitmul_constraint_operands);
+		original_intmul
+			.iter_mut()
+			.for_each(sort_intmul_constraint_operands);
+
+		let [bitmul_a, bitmul_b, bitmul_c] = build_record_for_bitmul_constraints(&cs);
+		let [intmul_a, intmul_b, intmul_hi, intmul_lo] = build_record_for_intmul_constraints(&cs);
+
+		let mut reverted_bitmul = revert_bitmul_constraints(bitmul_a, bitmul_b, bitmul_c);
+		let mut reverted_intmul =
+			revert_intmul_constraints(intmul_a, intmul_b, intmul_hi, intmul_lo);
+
+		// Sort reverted constraints for canonical ordering
+		reverted_bitmul
+			.iter_mut()
+			.for_each(sort_bitmul_constraint_operands);
+		reverted_intmul
+			.iter_mut()
+			.for_each(sort_intmul_constraint_operands);
+
+		// Assert that original and reverted constraints are identical
+		assert_eq!(original_bitmul, reverted_bitmul);
+		assert_eq!(original_intmul, reverted_intmul);
+	}
+}

--- a/crates/prover/src/protocols/shift/tests.rs
+++ b/crates/prover/src/protocols/shift/tests.rs
@@ -1,0 +1,287 @@
+// Copyright 2025 Irreducible Inc.
+
+use binius_frontend::{
+	circuits::jwt_claims::{Attribute, JwtClaims},
+	compiler::CircuitBuilder,
+	constraint_system::{ConstraintSystem, ValueVec},
+};
+
+pub fn create_jwt_claims_cs_with_witness() -> (ConstraintSystem, ValueVec) {
+	let builder = CircuitBuilder::new();
+	let max_len_json = 128;
+	let len_json = builder.add_witness();
+	let json: Vec<binius_frontend::compiler::Wire> = (0..max_len_json / 8)
+		.map(|_| builder.add_witness())
+		.collect();
+
+	let attributes = vec![
+		Attribute {
+			name: "iss",
+			len_value: builder.add_inout(),
+			value: (0..32 / 8).map(|_| builder.add_inout()).collect(),
+		},
+		Attribute {
+			name: "sub",
+			len_value: builder.add_inout(),
+			value: (0..32 / 8).map(|_| builder.add_inout()).collect(),
+		},
+	];
+
+	let jwt_claims = JwtClaims::new(&builder, max_len_json, len_json, json, attributes);
+
+	let circuit = builder.build();
+	let mut witness_filler = circuit.new_witness_filler();
+
+	// Populate with concrete JSON
+	let json_str = r#"{"iss":"example.com","sub":"user123"}"#;
+	jwt_claims.populate_len_json(&mut witness_filler, json_str.len());
+	jwt_claims.populate_json(&mut witness_filler, json_str.as_bytes());
+
+	// Populate expected attribute values
+	jwt_claims.attributes[0].populate_len_value(&mut witness_filler, 11); // "example.com"
+	jwt_claims.attributes[0].populate_value(&mut witness_filler, b"example.com");
+
+	jwt_claims.attributes[1].populate_len_value(&mut witness_filler, 7); // "user123"
+	jwt_claims.attributes[1].populate_value(&mut witness_filler, b"user123");
+
+	// Get the witness vector
+	circuit.populate_wire_witness(&mut witness_filler).unwrap();
+
+	(circuit.constraint_system(), witness_filler.into_value_vec())
+}
+
+pub fn create_sha256_cs_with_witness() -> (ConstraintSystem, ValueVec) {
+	use binius_frontend::circuits::sha256::Sha256;
+
+	let mut builder = CircuitBuilder::new();
+	let max_len: usize = 64; // Maximum message length in bytes
+
+	// Create wires for the SHA256 circuit
+	let len = builder.add_witness(); // Actual message length
+	let digest = [
+		builder.add_inout(), // Expected digest as 4x64-bit words
+		builder.add_inout(),
+		builder.add_inout(),
+		builder.add_inout(),
+	];
+	let message: Vec<binius_frontend::compiler::Wire> = (0..max_len.div_ceil(8))
+		.map(|_| builder.add_witness())
+		.collect();
+
+	// Create the SHA256 circuit
+	let sha256 = Sha256::new(&mut builder, max_len, len, digest, message);
+
+	let circuit = builder.build();
+	let mut witness_filler = circuit.new_witness_filler();
+
+	// Populate with concrete message: "abc"
+	let message_bytes = b"abc";
+	sha256.populate_len(&mut witness_filler, message_bytes.len());
+	sha256.populate_message(&mut witness_filler, message_bytes);
+
+	// SHA256 digest of "abc"
+	let expected_digest = [
+		0xba, 0x78, 0x16, 0xbf, 0x8f, 0x01, 0xcf, 0xea, 0x41, 0x41, 0x40, 0xde, 0x5d, 0xae, 0x22,
+		0x23, 0xb0, 0x03, 0x61, 0xa3, 0x96, 0x17, 0x7a, 0x9c, 0xb4, 0x10, 0xff, 0x61, 0xf2, 0x00,
+		0x15, 0xad,
+	];
+	sha256.populate_digest(&mut witness_filler, expected_digest);
+
+	// Get the witness vector
+	circuit.populate_wire_witness(&mut witness_filler).unwrap();
+
+	(circuit.constraint_system(), witness_filler.into_value_vec())
+}
+
+pub fn create_base64_cs_with_witness() -> (ConstraintSystem, ValueVec) {
+	use binius_frontend::circuits::base64::Base64UrlSafe;
+
+	let builder = CircuitBuilder::new();
+	let max_len_decoded: usize = 24; // Must be multiple of 24
+
+	// Create wires for Base64 circuit
+	let decoded: Vec<binius_frontend::compiler::Wire> = (0..max_len_decoded / 8)
+		.map(|_| builder.add_inout())
+		.collect();
+	let encoded: Vec<binius_frontend::compiler::Wire> = (0..max_len_decoded / 6)
+		.map(|_| builder.add_inout())
+		.collect();
+	let len_decoded = builder.add_inout();
+
+	// Create the Base64 circuit
+	let base64 = Base64UrlSafe::new(&builder, max_len_decoded, decoded, encoded, len_decoded);
+
+	let circuit = builder.build();
+	let mut witness_filler = circuit.new_witness_filler();
+
+	// Test with "Hello!" -> "SGVsbG8h" in base64
+	let decoded_data = b"Hello!";
+	let encoded_data = b"SGVsbG8h";
+
+	base64.populate_len_decoded(&mut witness_filler, decoded_data.len());
+	base64.populate_decoded(&mut witness_filler, decoded_data);
+	base64.populate_encoded(&mut witness_filler, encoded_data);
+
+	// Get the witness vector
+	circuit.populate_wire_witness(&mut witness_filler).unwrap();
+
+	(circuit.constraint_system(), witness_filler.into_value_vec())
+}
+
+pub fn create_concat_cs_with_witness() -> (ConstraintSystem, ValueVec) {
+	use binius_frontend::circuits::concat::{Concat, Term};
+
+	let builder = CircuitBuilder::new();
+	let max_n_joined: usize = 32; // Maximum joined size
+
+	// Create wires for concat circuit
+	let len_joined = builder.add_inout();
+	let joined: Vec<binius_frontend::compiler::Wire> =
+		(0..max_n_joined / 8).map(|_| builder.add_inout()).collect();
+
+	// Create terms: "Hello" + " " + "World!"
+	let terms = vec![
+		Term {
+			len: builder.add_witness(),
+			data: (0..8 / 8).map(|_| builder.add_witness()).collect(),
+			max_len: 8,
+		},
+		Term {
+			len: builder.add_witness(),
+			data: (0..8 / 8).map(|_| builder.add_witness()).collect(),
+			max_len: 8,
+		},
+		Term {
+			len: builder.add_witness(),
+			data: (0..8 / 8).map(|_| builder.add_witness()).collect(),
+			max_len: 8,
+		},
+	];
+
+	// Create the Concat circuit
+	let concat = Concat::new(&builder, max_n_joined, len_joined, joined, terms);
+
+	let circuit = builder.build();
+	let mut witness_filler = circuit.new_witness_filler();
+
+	// Test data
+	let term1_data = b"Hello";
+	let term2_data = b" ";
+	let term3_data = b"World!";
+	let joined_data = b"Hello World!";
+
+	// Populate terms
+	concat.terms[0].populate_len(&mut witness_filler, term1_data.len());
+	concat.terms[0].populate_data(&mut witness_filler, term1_data);
+
+	concat.terms[1].populate_len(&mut witness_filler, term2_data.len());
+	concat.terms[1].populate_data(&mut witness_filler, term2_data);
+
+	concat.terms[2].populate_len(&mut witness_filler, term3_data.len());
+	concat.terms[2].populate_data(&mut witness_filler, term3_data);
+
+	// Populate joined result
+	concat.populate_len_joined(&mut witness_filler, joined_data.len());
+	concat.populate_joined(&mut witness_filler, joined_data);
+
+	// Get the witness vector
+	circuit.populate_wire_witness(&mut witness_filler).unwrap();
+
+	(circuit.constraint_system(), witness_filler.into_value_vec())
+}
+
+pub fn create_slice_cs_with_witness() -> (ConstraintSystem, ValueVec) {
+	use binius_frontend::circuits::slice::Slice;
+
+	let builder = CircuitBuilder::new();
+	let max_n_input: usize = 32; // Maximum input size
+	let max_n_slice: usize = 16; // Maximum slice size
+
+	// Create wires for slice circuit
+	let len_input = builder.add_witness();
+	let len_slice = builder.add_witness();
+	let input: Vec<binius_frontend::compiler::Wire> = (0..max_n_input / 8)
+		.map(|_| builder.add_witness())
+		.collect();
+	let slice: Vec<binius_frontend::compiler::Wire> = (0..max_n_slice / 8)
+		.map(|_| builder.add_witness())
+		.collect();
+	let offset = builder.add_witness();
+
+	// Create the Slice circuit
+	let slice_circuit =
+		Slice::new(&builder, max_n_input, max_n_slice, len_input, len_slice, input, slice, offset);
+
+	let circuit = builder.build();
+	let mut witness_filler = circuit.new_witness_filler();
+
+	// Test slicing "Hello World!" from offset 6 with length 5 to get "World"
+	let input_data = b"Hello World!";
+	let slice_data = b"World";
+	let offset_val = 6;
+
+	slice_circuit.populate_len_input(&mut witness_filler, input_data.len());
+	slice_circuit.populate_len_slice(&mut witness_filler, slice_data.len());
+	slice_circuit.populate_input(&mut witness_filler, input_data);
+	slice_circuit.populate_slice(&mut witness_filler, slice_data);
+	slice_circuit.populate_offset(&mut witness_filler, offset_val);
+
+	// Get the witness vector
+	circuit.populate_wire_witness(&mut witness_filler).unwrap();
+
+	(circuit.constraint_system(), witness_filler.into_value_vec())
+}
+
+pub fn create_rs256_cs_with_witness() -> (ConstraintSystem, ValueVec) {
+	use binius_frontend::circuits::{fixed_byte_vec::FixedByteVec, rs256::Rs256Verify};
+	use rand::{SeedableRng, rngs::StdRng};
+	use rsa::{
+		RsaPrivateKey, RsaPublicKey,
+		pkcs1v15::SigningKey,
+		sha2::{Digest, Sha256},
+		signature::{SignatureEncoding, Signer},
+		traits::PublicKeyParts,
+	};
+
+	let mut builder = CircuitBuilder::new();
+	let max_message_len: usize = 256; // Maximum message length
+
+	// Setup circuit using the new Rs256Verify API
+	let signature_bytes = FixedByteVec::new_inout(&mut builder, 256);
+	let modulus_bytes = FixedByteVec::new_inout(&mut builder, 256);
+	let message = FixedByteVec::new_witness(&mut builder, max_message_len);
+
+	// Create the RS256 circuit with new API (only 4 arguments)
+	let rs256 = Rs256Verify::new(&mut builder, message, signature_bytes, modulus_bytes);
+
+	let circuit = builder.build();
+	let mut witness_filler = circuit.new_witness_filler();
+
+	// Generate real RSA signature and witness data (following the existing test pattern)
+	let mut rng = StdRng::seed_from_u64(42);
+	let bits = 2048;
+	let private_key = RsaPrivateKey::new(&mut rng, bits).expect("failed to generate key");
+	let public_key = RsaPublicKey::from(&private_key);
+
+	let message_bytes = b"Test message for RS256 verification";
+	let signing_key = SigningKey::<Sha256>::new(private_key);
+	let signature_obj = signing_key.sign(message_bytes);
+
+	// Get signature and modulus as byte arrays (not limbs)
+	let signature_bytes = signature_obj.to_bytes();
+	let modulus_bytes = public_key.n().to_be_bytes();
+
+	// Use the new populate_rsa method and other public methods
+	let hash = Sha256::digest(message_bytes);
+	rs256.populate_rsa(&mut witness_filler, &signature_bytes, &modulus_bytes);
+	rs256.populate_message_len(&mut witness_filler, message_bytes.len());
+	rs256.populate_message(&mut witness_filler, message_bytes);
+	rs256
+		.sha256
+		.populate_digest(&mut witness_filler, hash.into());
+
+	// Get the witness vector
+	circuit.populate_wire_witness(&mut witness_filler).unwrap();
+
+	(circuit.constraint_system(), witness_filler.into_value_vec())
+}


### PR DESCRIPTION
### Experiment with Record Type

*NOT A PULL REQUEST*

Makes a new prover shift module with a data structure that "transposes" a list of constraints.

### What changed?

- Added `.vscode/` to `.gitignore`
- Added `PartialEq` trait to `ShiftVariant` and `ShiftedValueIndex` structs
- Added `PartialEq`, `Clone`, and `Debug` traits to `AndConstraint` and `MulConstraint` structs
- Created a new `shift` module in the prover crate with:
  - A `ShiftedValueKey` data structure to efficiently identify and accumulate shifted values
  - Functions to build records from constraint systems for both bit multiplication and integer multiplication
  - Comprehensive test suite with various circuit types (JWT claims, SHA256, Base64, etc.)

### How to test?

```
cargo test --package binius-prover --lib -- protocols::shift::record::tests --show-output 
```