### PR TITLE
pad constraints and witness to power of 2

### DIFF
--- a/crates/frontend/src/compiler/circuit.rs
+++ b/crates/frontend/src/compiler/circuit.rs
@@ -8,7 +8,10 @@ use crate::{
 		gate_graph::{Wire, WireKind},
 		pathspec::PathSpec,
 	},
-	constraint_system::{ConstraintSystem, ValueIndex, ValueVec, ValueVecLayout},
+	constraint_system::{
+		AndConstraint, ConstraintSystem, MulConstraint, ShiftVariant, ShiftedValueIndex,
+		ValueIndex, ValueVec, ValueVecLayout,
+	},
 	word::Word,
 };
 
@@ -188,6 +191,40 @@ impl Circuit {
 		for (gate_id, _) in self.shared.graph.gates.iter() {
 			gate::constrain(gate_id, &self.shared.graph, self, &mut cs);
 		}
+
+		let zero_wire = self
+			.shared
+			.graph
+			.const_pool
+			.get(Word::ZERO)
+			.expect("every circuit has the zero constant... but seems an unsafe assumption");
+		let zero_value_index = self.wire_mapping[zero_wire];
+
+		let zero_operand = vec![ShiftedValueIndex {
+			value_index: zero_value_index,
+			shift_variant: ShiftVariant::Sll,
+			amount: 0,
+		}];
+
+		// Pad AND constraints: 0 & 0 = 0
+		let and_target_len = cs.and_constraints.len().next_power_of_two();
+		cs.and_constraints
+			.resize_with(and_target_len, || AndConstraint {
+				a: zero_operand.clone(),
+				b: zero_operand.clone(),
+				c: zero_operand.clone(),
+			});
+
+		// Pad MUL constraints: 0 * 0 = 0 with hi=0, lo=0
+		let mul_target_len = cs.mul_constraints.len().next_power_of_two();
+		cs.mul_constraints
+			.resize_with(mul_target_len, || MulConstraint {
+				a: zero_operand.clone(),
+				b: zero_operand.clone(),
+				hi: zero_operand.clone(),
+				lo: zero_operand.clone(),
+			});
+
 		cs
 	}
 

--- a/crates/frontend/src/compiler/mod.rs
+++ b/crates/frontend/src/compiler/mod.rs
@@ -129,6 +129,7 @@ impl CircuitBuilder {
 			wire_mapping[wire] = ValueIndex(cur_index);
 			cur_index += 1;
 		}
+		cur_index = cur_index.next_power_of_two();
 		let total_len = cur_index as usize;
 		let value_vec_layout = ValueVecLayout {
 			n_const,

--- a/crates/frontend/src/constraint_system.rs
+++ b/crates/frontend/src/constraint_system.rs
@@ -83,6 +83,7 @@ impl ShiftedValueIndex {
 
 pub type Operand = Vec<ShiftedValueIndex>;
 
+#[derive(Clone, Debug)]
 pub struct AndConstraint {
 	pub a: Operand,
 	pub b: Operand,
@@ -115,6 +116,7 @@ impl AndConstraint {
 	}
 }
 
+#[derive(Clone, Debug)]
 pub struct MulConstraint {
 	pub a: Operand,
 	pub b: Operand,
@@ -122,6 +124,7 @@ pub struct MulConstraint {
 	pub lo: Operand,
 }
 
+#[derive(Clone, Debug)]
 pub struct ConstraintSystem {
 	pub value_vec_layout: ValueVecLayout,
 	pub constants: Vec<Word>,


### PR DESCRIPTION
Pads the AND and MUL constraints, and the witness, to the next power of 2.
This is needed for the shift reduction.
See the dubious `expect`, how to do this right?

By using `next_power_of_two` I think when there are zero MUL constraints, there will now be 1 trivial MUL constraint. Would could keep it at zero, but that's trickier for the shift reduction.