### PR TITLE
[frontend] Add base64 check for zklogin nonce

### DIFF
--- a/crates/zkl/snapshots/stat_output.snap
+++ b/crates/zkl/snapshots/stat_output.snap
@@ -11,11 +11,11 @@ config: Config {
     max_len_t_max: 48,
 }
 --
-Number of gates: 802733
-Number of AND constraints: 1117833
+Number of gates: 818551
+Number of AND constraints: 1138868
 Number of MUL constraints: 26945
-Length of value vec: 1240471
-  Constants: 619
+Length of value vec: 1261335
+  Constants: 620
   Inout: 133
-  Witness: 185241
-  Internal: 1054206
+  Witness: 190227
+  Internal: 1070084


### PR DESCRIPTION
The zklogin nonce is contained in the JWT paylaod as a base64 encoded
string. We must base64-decode this string to the bytes of a SHA256 hash
before asserting it is equal to SHA256(concat(vk_u, T_max, r)).

This is expected to increase the total number of constraints so the
snapshot is regenerated.