### PR TITLE
Use fast portable ghash multiplication

### DIFF
--- a/crates/field/src/arch/portable/mod.rs
+++ b/crates/field/src/arch/portable/mod.rs
@@ -31,6 +31,7 @@ pub mod packed_ghash_256;
 pub mod packed_ghash_512;
 
 mod nibble_invert_128b;
+mod univariate_mul_utils_128;
 
 pub mod byte_sliced;
 

--- a/crates/field/src/arch/portable/packed_polyval_128.rs
+++ b/crates/field/src/arch/portable/packed_polyval_128.rs
@@ -8,11 +8,13 @@
 //!
 //! <https://bearssl.org/gitweb/?p=BearSSL;a=blob;f=src/hash/ghash_ctmul64.c;hb=4b6046412>
 
-use std::{num::Wrapping, ops::Mul};
+use std::ops::Mul;
 
 use super::{
-	nibble_invert_128b::nibble_invert_128b, packed::PackedPrimitiveType,
+	nibble_invert_128b::nibble_invert_128b,
+	packed::PackedPrimitiveType,
 	packed_macros::impl_broadcast,
+	univariate_mul_utils_128::{bmul64, join_u64s, split_u128},
 };
 use crate::{
 	BinaryField128bPolyval,
@@ -64,17 +66,15 @@ impl_transformation_with_strategy!(PackedBinaryPolyval1x128b, PairwiseStrategy);
 ///
 /// [1]: <https://datatracker.ietf.org/doc/html/rfc8452>
 fn montgomery_multiply(a: u128, b: u128) -> u128 {
-	let h0 = a as u64;
-	let h1 = (a >> 64) as u64;
-	let h0r = rev64(h0);
-	let h1r = rev64(h1);
+	let (h1, h0) = split_u128(a);
+	let h0r = h0.reverse_bits();
+	let h1r = h1.reverse_bits();
 	let h2 = h0 ^ h1;
 	let h2r = h0r ^ h1r;
 
-	let y0 = b as u64;
-	let y1 = (b >> 64) as u64;
-	let y0r = rev64(y0);
-	let y1r = rev64(y1);
+	let (y1, y0) = split_u128(b);
+	let y0r = y0.reverse_bits();
+	let y1r = y1.reverse_bits();
 	let y2 = y0 ^ y1;
 	let y2r = y0r ^ y1r;
 	let z0 = bmul64(y0, h0);
@@ -87,9 +87,9 @@ fn montgomery_multiply(a: u128, b: u128) -> u128 {
 
 	z2 ^= z0 ^ z1;
 	z2h ^= z0h ^ z1h;
-	z0h = rev64(z0h) >> 1;
-	z1h = rev64(z1h) >> 1;
-	z2h = rev64(z2h) >> 1;
+	z0h = z0h.reverse_bits() >> 1;
+	z1h = z1h.reverse_bits() >> 1;
+	z2h = z2h.reverse_bits() >> 1;
 
 	let v0 = z0;
 	let mut v1 = z0h ^ z2;
@@ -101,45 +101,7 @@ fn montgomery_multiply(a: u128, b: u128) -> u128 {
 	v3 ^= v1 ^ (v1 >> 1) ^ (v1 >> 2) ^ (v1 >> 7);
 	v2 ^= (v1 << 63) ^ (v1 << 62) ^ (v1 << 57);
 
-	v2 as u128 | (v3 as u128) << 64
-}
-
-/// Multiplication in `GF(2)[X]`, truncated to the low 64-bits, with “holes”
-/// (sequences of zeroes) to avoid carry spilling.
-///
-/// When carries do occur, they wind up in a "hole" and are subsequently masked
-/// out of the result.
-fn bmul64(x: u64, y: u64) -> u64 {
-	let x0 = Wrapping(x & 0x1111_1111_1111_1111);
-	let x1 = Wrapping(x & 0x2222_2222_2222_2222);
-	let x2 = Wrapping(x & 0x4444_4444_4444_4444);
-	let x3 = Wrapping(x & 0x8888_8888_8888_8888);
-	let y0 = Wrapping(y & 0x1111_1111_1111_1111);
-	let y1 = Wrapping(y & 0x2222_2222_2222_2222);
-	let y2 = Wrapping(y & 0x4444_4444_4444_4444);
-	let y3 = Wrapping(y & 0x8888_8888_8888_8888);
-
-	let mut z0 = ((x0 * y0) ^ (x1 * y3) ^ (x2 * y2) ^ (x3 * y1)).0;
-	let mut z1 = ((x0 * y1) ^ (x1 * y0) ^ (x2 * y3) ^ (x3 * y2)).0;
-	let mut z2 = ((x0 * y2) ^ (x1 * y1) ^ (x2 * y0) ^ (x3 * y3)).0;
-	let mut z3 = ((x0 * y3) ^ (x1 * y2) ^ (x2 * y1) ^ (x3 * y0)).0;
-
-	z0 &= 0x1111_1111_1111_1111;
-	z1 &= 0x2222_2222_2222_2222;
-	z2 &= 0x4444_4444_4444_4444;
-	z3 &= 0x8888_8888_8888_8888;
-
-	z0 | z1 | z2 | z3
-}
-
-/// Bit-reverse a `u64` in constant time
-const fn rev64(mut x: u64) -> u64 {
-	x = ((x & 0x5555_5555_5555_5555) << 1) | ((x >> 1) & 0x5555_5555_5555_5555);
-	x = ((x & 0x3333_3333_3333_3333) << 2) | ((x >> 2) & 0x3333_3333_3333_3333);
-	x = ((x & 0x0f0f_0f0f_0f0f_0f0f) << 4) | ((x >> 4) & 0x0f0f_0f0f_0f0f_0f0f);
-	x = ((x & 0x00ff_00ff_00ff_00ff) << 8) | ((x >> 8) & 0x00ff_00ff_00ff_00ff);
-	x = ((x & 0xffff_0000_ffff) << 16) | ((x >> 16) & 0xffff_0000_ffff);
-	x.rotate_right(32)
+	join_u64s(v3, v2)
 }
 
 /// Table where `value[i][k][j] = BinaryField128bPolyval(j << 4 * k) ^ (2^(i+1))`

--- a/crates/field/src/arch/portable/univariate_mul_utils_128.rs
+++ b/crates/field/src/arch/portable/univariate_mul_utils_128.rs
@@ -1,0 +1,108 @@
+// Copyright (c) 2019-2025 The RustCrypto Project Developers
+// Copyright (c) 2016 Thomas Pornin <pornin@bolet.org>
+//
+// Permission is hereby granted, free of charge, to any
+// person obtaining a copy of this software and associated
+// documentation files (the "Software"), to deal in the
+// Software without restriction, including without
+// limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software
+// is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice
+// shall be included in all copies or substantial portions
+// of the Software.
+
+//! Constant-time software implementation of carryless multiplication for 64-bit architectures.
+//!
+//! This implementation is adapted from the RustCrypto/universal-hashes repository:
+//! <https://github.com/RustCrypto/universal-hashes>
+//!
+//! Which in turn was adapted from BearSSL's `ghash_ctmul64.c`:
+//! <https://bearssl.org/gitweb/?p=BearSSL;a=blob;f=src/hash/ghash_ctmul64.c;hb=4b6046412>
+
+use std::num::Wrapping;
+
+pub fn split_u128(x: u128) -> (u64, u64) {
+	((x >> 64) as u64, x as u64)
+}
+
+pub fn join_u64s(high: u64, low: u64) -> u128 {
+	((high as u128) << 64) | (low as u128)
+}
+
+/// Multiplication in GF(2)\[X\], truncated to the low 64-bits, with "holes"
+/// (sequences of zeroes) to avoid carry spilling.
+///
+/// When carries do occur, they wind up in a "hole" and are subsequently masked
+/// out of the result.
+pub fn bmul64(x: u64, y: u64) -> u64 {
+	let x0 = Wrapping(x & 0x1111_1111_1111_1111);
+	let x1 = Wrapping(x & 0x2222_2222_2222_2222);
+	let x2 = Wrapping(x & 0x4444_4444_4444_4444);
+	let x3 = Wrapping(x & 0x8888_8888_8888_8888);
+	let y0 = Wrapping(y & 0x1111_1111_1111_1111);
+	let y1 = Wrapping(y & 0x2222_2222_2222_2222);
+	let y2 = Wrapping(y & 0x4444_4444_4444_4444);
+	let y3 = Wrapping(y & 0x8888_8888_8888_8888);
+
+	let mut z0 = ((x0 * y0) ^ (x1 * y3) ^ (x2 * y2) ^ (x3 * y1)).0;
+	let mut z1 = ((x0 * y1) ^ (x1 * y0) ^ (x2 * y3) ^ (x3 * y2)).0;
+	let mut z2 = ((x0 * y2) ^ (x1 * y1) ^ (x2 * y0) ^ (x3 * y3)).0;
+	let mut z3 = ((x0 * y3) ^ (x1 * y2) ^ (x2 * y1) ^ (x3 * y0)).0;
+
+	z0 &= 0x1111_1111_1111_1111;
+	z1 &= 0x2222_2222_2222_2222;
+	z2 &= 0x4444_4444_4444_4444;
+	z3 &= 0x8888_8888_8888_8888;
+
+	z0 | z1 | z2 | z3
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn test_u64x2_conversion() {
+		// Test round-trip conversion
+		let test_values = [
+			0u128,
+			1u128,
+			u128::MAX,
+			0x0123456789abcdef_fedcba9876543210u128,
+		];
+
+		for &val in &test_values {
+			let u64x2 = split_u128(val);
+			let back: u128 = join_u64s(u64x2.0, u64x2.1);
+			assert_eq!(val, back, "Round-trip conversion failed for 0x{val:032x}");
+		}
+	}
+
+	#[test]
+	fn test_bmul64_basic() {
+		// Test basic cases
+		assert_eq!(bmul64(0, 0), 0);
+		assert_eq!(bmul64(1, 1), 1);
+		assert_eq!(bmul64(2, 2), 4);
+		assert_eq!(bmul64(3, 3), 5); // 11b * 11b = 101b in GF(2)[X]
+
+		// Test that bmul64 is commutative
+		let test_pairs = [
+			(0x1234567890abcdef, 0xfedcba0987654321),
+			(0x1111111111111111, 0x2222222222222222),
+			(0xaaaaaaaaaaaaaaaa, 0x5555555555555555),
+		];
+
+		for (a, b) in test_pairs {
+			assert_eq!(
+				bmul64(a, b),
+				bmul64(b, a),
+				"bmul64 not commutative for 0x{a:016x} and 0x{b:016x}",
+			);
+		}
+	}
+}


### PR DESCRIPTION
### TL;DR

Use a more efficient GHASH field multiplication algorithm using the BearSSL approach from `arith-bench` crate.

### What changed?

- Replaced the naive bit-by-bit GHASH multiplication algorithm with a more efficient implementation based on BearSSL's approach
- Created a new `univariate_mul_utils_128.rs` module with shared utility functions for both GHASH and POLYVAL implementations
- Extracted common code for carryless multiplication operations (`bmul64`, `split_u128`, `join_u64s`)
- Refactored the POLYVAL implementation to use these shared utilities
- Added tests for the utility functions

### How to test?

Run the existing test suite to verify that the GHASH and POLYVAL implementations still work correctly:

```
cargo test --package field --features=portable
```

### Why make this change?

The previous GHASH implementation used a naive bit-by-bit algorithm that was inefficient. This change implements a more optimized approach based on BearSSL's constant-time implementation, which is both more efficient and maintains constant-time properties. By sharing utility functions between GHASH and POLYVAL, the code is also more maintainable and consistent.