### PR TITLE
Remote constant-time trait implementations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,6 @@ seq-macro = "0.3.5"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 sha2 = "0.10.8"
-subtle = "2.5.0"
 thiserror = "2.0.3"
 transpose = "0.2.2"
 tracing = "0.1.38"

--- a/crates/field/Cargo.toml
+++ b/crates/field/Cargo.toml
@@ -14,7 +14,6 @@ cfg-if.workspace = true
 derive_more.workspace = true
 rand.workspace = true
 seq-macro.workspace = true
-subtle.workspace = true
 thiserror.workspace = true
 transpose.workspace = true
 tracing.workspace = true

--- a/crates/field/src/aes_field.rs
+++ b/crates/field/src/aes_field.rs
@@ -13,7 +13,6 @@ use binius_utils::{
 	bytes::{Buf, BufMut},
 };
 use bytemuck::{Pod, Zeroable};
-use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 
 use super::{
 	BinaryField8b, Error, PackedExtension, PackedSubfield,

--- a/crates/field/src/arch/aarch64/m128.rs
+++ b/crates/field/src/arch/aarch64/m128.rs
@@ -16,7 +16,6 @@ use rand::{
 	distr::{Distribution, StandardUniform},
 };
 use seq_macro::seq;
-use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 
 use super::super::portable::{
 	packed::{PackedPrimitiveType, impl_pack_scalar},
@@ -291,18 +290,6 @@ impl Shl<usize> for M128 {
 	#[inline]
 	fn shl(self, rhs: usize) -> Self::Output {
 		Self::from(u128::from(self) << rhs)
-	}
-}
-
-impl ConstantTimeEq for M128 {
-	fn ct_eq(&self, other: &Self) -> subtle::Choice {
-		u128::from(*self).ct_eq(&u128::from(*other))
-	}
-}
-
-impl ConditionallySelectable for M128 {
-	fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
-		ConditionallySelectable::conditional_select(&u128::from(*a), &u128::from(*b), choice).into()
 	}
 }
 

--- a/crates/field/src/arch/portable/byte_sliced/underlier.rs
+++ b/crates/field/src/arch/portable/byte_sliced/underlier.rs
@@ -6,7 +6,6 @@ use rand::{
 	Rng,
 	distr::{Distribution, StandardUniform},
 };
-use subtle::{Choice, ConstantTimeEq};
 
 use crate::{
 	Random,
@@ -23,12 +22,6 @@ pub struct ByteSlicedUnderlier<U, const N: usize>(ScaledUnderlier<U, N>);
 impl<U: Random, const N: usize> Distribution<ByteSlicedUnderlier<U, N>> for StandardUniform {
 	fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> ByteSlicedUnderlier<U, N> {
 		ByteSlicedUnderlier(rng.random())
-	}
-}
-
-impl<U: ConstantTimeEq, const N: usize> ConstantTimeEq for ByteSlicedUnderlier<U, N> {
-	fn ct_eq(&self, other: &Self) -> Choice {
-		self.0.ct_eq(&other.0)
 	}
 }
 

--- a/crates/field/src/arch/portable/packed.rs
+++ b/crates/field/src/arch/portable/packed.rs
@@ -19,7 +19,6 @@ use rand::{
 	Rng,
 	distr::{Distribution, StandardUniform},
 };
-use subtle::{Choice, ConstantTimeEq};
 
 use super::packed_arithmetic::UnderlierWithBitConstants;
 use crate::{
@@ -141,12 +140,6 @@ impl<U: UnderlierType, Scalar: BinaryField> From<U> for PackedPrimitiveType<U, S
 	#[inline]
 	fn from(val: U) -> Self {
 		Self(val, PhantomData)
-	}
-}
-
-impl<U: UnderlierType, Scalar: BinaryField> ConstantTimeEq for PackedPrimitiveType<U, Scalar> {
-	fn ct_eq(&self, other: &Self) -> Choice {
-		self.0.ct_eq(&other.0)
 	}
 }
 

--- a/crates/field/src/arch/portable/packed_scaled.rs
+++ b/crates/field/src/arch/portable/packed_scaled.rs
@@ -16,7 +16,6 @@ use rand::{
 	Rng,
 	distr::{Distribution, StandardUniform},
 };
-use subtle::ConstantTimeEq;
 
 use crate::{
 	Field, PackedField,
@@ -145,12 +144,6 @@ where
 unsafe impl<PT: Zeroable, const N: usize> Zeroable for ScaledPackedField<PT, N> {}
 
 unsafe impl<PT: Pod, const N: usize> Pod for ScaledPackedField<PT, N> {}
-
-impl<PT: ConstantTimeEq, const N: usize> ConstantTimeEq for ScaledPackedField<PT, N> {
-	fn ct_eq(&self, other: &Self) -> subtle::Choice {
-		self.0.ct_eq(&other.0)
-	}
-}
 
 impl<PT: Copy + Add<Output = PT>, const N: usize> Add for ScaledPackedField<PT, N>
 where

--- a/crates/field/src/arch/x86_64/m128.rs
+++ b/crates/field/src/arch/x86_64/m128.rs
@@ -17,7 +17,6 @@ use rand::{
 	distr::{Distribution, StandardUniform},
 };
 use seq_macro::seq;
-use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 
 use crate::{
 	BinaryField,
@@ -296,21 +295,6 @@ impl PartialOrd for M128 {
 impl Ord for M128 {
 	fn cmp(&self, other: &Self) -> std::cmp::Ordering {
 		u128::from(*self).cmp(&u128::from(*other))
-	}
-}
-
-impl ConstantTimeEq for M128 {
-	fn ct_eq(&self, other: &Self) -> Choice {
-		unsafe {
-			let neq = _mm_xor_si128(self.0, other.0);
-			Choice::from(_mm_test_all_zeros(neq, neq) as u8)
-		}
-	}
-}
-
-impl ConditionallySelectable for M128 {
-	fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
-		ConditionallySelectable::conditional_select(&u128::from(*a), &u128::from(*b), choice).into()
 	}
 }
 

--- a/crates/field/src/arch/x86_64/m256.rs
+++ b/crates/field/src/arch/x86_64/m256.rs
@@ -18,7 +18,6 @@ use rand::{
 	distr::{Distribution, StandardUniform},
 };
 use seq_macro::seq;
-use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 
 use crate::{
 	BinaryField,
@@ -297,29 +296,6 @@ impl PartialOrd for M256 {
 impl Ord for M256 {
 	fn cmp(&self, other: &Self) -> std::cmp::Ordering {
 		<[u128; 2]>::from(*self).cmp(&<[u128; 2]>::from(*other))
-	}
-}
-
-impl ConstantTimeEq for M256 {
-	#[inline(always)]
-	fn ct_eq(&self, other: &Self) -> Choice {
-		unsafe {
-			let pcmp = _mm256_cmpeq_epi32(self.0, other.0);
-			let bitmask = _mm256_movemask_epi8(pcmp) as u32;
-			bitmask.ct_eq(&0xffffffff)
-		}
-	}
-}
-
-impl ConditionallySelectable for M256 {
-	fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
-		let a = <[u128; 2]>::from(*a);
-		let b = <[u128; 2]>::from(*b);
-		let result: [u128; 2] = std::array::from_fn(|i| {
-			ConditionallySelectable::conditional_select(&a[i], &b[i], choice)
-		});
-
-		result.into()
 	}
 }
 

--- a/crates/field/src/arch/x86_64/m512.rs
+++ b/crates/field/src/arch/x86_64/m512.rs
@@ -17,7 +17,6 @@ use rand::{
 	distr::{Distribution, StandardUniform},
 };
 use seq_macro::seq;
-use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 
 use crate::{
 	BinaryField,
@@ -349,28 +348,6 @@ impl PartialOrd for M512 {
 impl Ord for M512 {
 	fn cmp(&self, other: &Self) -> std::cmp::Ordering {
 		<[u128; 4]>::from(*self).cmp(&<[u128; 4]>::from(*other))
-	}
-}
-
-impl ConstantTimeEq for M512 {
-	#[inline(always)]
-	fn ct_eq(&self, other: &Self) -> Choice {
-		unsafe {
-			let pcmp = _mm512_cmpeq_epi32_mask(self.0, other.0);
-			pcmp.ct_eq(&0xFFFF)
-		}
-	}
-}
-
-impl ConditionallySelectable for M512 {
-	fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
-		let a = <[u128; 4]>::from(*a);
-		let b = <[u128; 4]>::from(*b);
-		let result: [u128; 4] = std::array::from_fn(|i| {
-			ConditionallySelectable::conditional_select(&a[i], &b[i], choice)
-		});
-
-		result.into()
 	}
 }
 

--- a/crates/field/src/binary_field.rs
+++ b/crates/field/src/binary_field.rs
@@ -12,7 +12,6 @@ use binius_utils::{
 	bytes::{Buf, BufMut},
 };
 use bytemuck::{Pod, Zeroable};
-use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 
 use super::{
 	binary_field_arithmetic::TowerFieldArithmetic, error::Error, extension::ExtensionField,
@@ -293,17 +292,6 @@ macro_rules! binary_field {
 			}
 		}
 
-		impl ConstantTimeEq for $name {
-			fn ct_eq(&self, other: &Self) -> Choice {
-				self.0.ct_eq(&other.0)
-			}
-		}
-
-		impl ConditionallySelectable for $name {
-			fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
-				Self(ConditionallySelectable::conditional_select(&a.0, &b.0, choice))
-			}
-		}
 
 		impl crate::arithmetic_traits::Square for $name {
 			fn square(self) -> Self {
@@ -794,12 +782,6 @@ serialize_deserialize!(BinaryField32b);
 serialize_deserialize!(BinaryField64b);
 serialize_deserialize!(BinaryField128b);
 
-impl From<BinaryField1b> for Choice {
-	fn from(val: BinaryField1b) -> Self {
-		Self::from(val.val().val())
-	}
-}
-
 impl BinaryField1b {
 	/// Creates value without checking that it is within valid range (0 or 1)
 	///
@@ -1248,13 +1230,6 @@ pub(crate) mod tests {
 		#[test]
 		fn test_mul_primitive_128b(val in 0u128.., iota in 0usize..8) {
 			test_mul_primitive::<BinaryField128b>(val.into(), iota)
-		}
-	}
-
-	#[test]
-	fn test_1b_to_choice() {
-		for i in 0..2 {
-			assert_eq!(Choice::from(BinaryField1b::from(i)).unwrap_u8(), i);
 		}
 	}
 

--- a/crates/field/src/polyval.rs
+++ b/crates/field/src/polyval.rs
@@ -19,7 +19,6 @@ use rand::{
 	Rng,
 	distr::{Distribution, StandardUniform},
 };
-use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
 use super::{
 	aes_field::AESTowerField128b,
@@ -239,20 +238,6 @@ impl<'a> Product<&'a Self> for BinaryField128bPolyval {
 	}
 }
 
-impl ConstantTimeEq for BinaryField128bPolyval {
-	#[inline]
-	fn ct_eq(&self, other: &Self) -> Choice {
-		self.0.ct_eq(&other.0)
-	}
-}
-
-impl ConditionallySelectable for BinaryField128bPolyval {
-	#[inline]
-	fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
-		Self(ConditionallySelectable::conditional_select(&a.0, &b.0, choice))
-	}
-}
-
 impl Square for BinaryField128bPolyval {
 	#[inline]
 	fn square(self) -> Self {
@@ -330,9 +315,13 @@ impl TryInto<BinaryField1b> for BinaryField128bPolyval {
 
 	#[inline]
 	fn try_into(self) -> Result<BinaryField1b, Self::Error> {
-		let result = CtOption::new(BinaryField1b::ZERO, self.ct_eq(&Self::ZERO))
-			.or_else(|| CtOption::new(BinaryField1b::ONE, self.ct_eq(&Self::ONE)));
-		Option::from(result).ok_or(())
+		if self == Self::ZERO {
+			Ok(BinaryField1b::ZERO)
+		} else if self == Self::ONE {
+			Ok(BinaryField1b::ONE)
+		} else {
+			Err(())
+		}
 	}
 }
 

--- a/crates/field/src/underlier/scaled.rs
+++ b/crates/field/src/underlier/scaled.rs
@@ -11,7 +11,6 @@ use rand::{
 	Rng,
 	distr::{Distribution, StandardUniform},
 };
-use subtle::{Choice, ConstantTimeEq};
 
 use super::{Divisible, NumCast, UnderlierType, UnderlierWithBitOps};
 use crate::{Random, tower_levels::TowerLevel};
@@ -49,12 +48,6 @@ impl<T, U: From<T>, const N: usize> From<[T; N]> for ScaledUnderlier<U, N> {
 impl<T: Copy, U: From<[T; 2]>> From<[T; 4]> for ScaledUnderlier<U, 2> {
 	fn from(value: [T; 4]) -> Self {
 		Self([[value[0], value[1]], [value[2], value[3]]].map(Into::into))
-	}
-}
-
-impl<U: ConstantTimeEq, const N: usize> ConstantTimeEq for ScaledUnderlier<U, N> {
-	fn ct_eq(&self, other: &Self) -> Choice {
-		self.0.ct_eq(&other.0)
 	}
 }
 

--- a/crates/field/src/underlier/small_uint.rs
+++ b/crates/field/src/underlier/small_uint.rs
@@ -18,7 +18,6 @@ use rand::{
 	Rng,
 	distr::{Distribution, StandardUniform},
 };
-use subtle::{ConditionallySelectable, ConstantTimeEq};
 
 use super::{UnderlierType, underlier_with_bit_ops::UnderlierWithBitOps};
 
@@ -96,18 +95,6 @@ impl<const N: usize> Hash for SmallU<N> {
 	#[inline]
 	fn hash<H: Hasher>(&self, state: &mut H) {
 		self.val().hash(state);
-	}
-}
-
-impl<const N: usize> ConstantTimeEq for SmallU<N> {
-	fn ct_eq(&self, other: &Self) -> subtle::Choice {
-		self.val().ct_eq(&other.val())
-	}
-}
-
-impl<const N: usize> ConditionallySelectable for SmallU<N> {
-	fn conditional_select(a: &Self, b: &Self, choice: subtle::Choice) -> Self {
-		Self(u8::conditional_select(&a.0, &b.0, choice))
 	}
 }
 

--- a/crates/field/src/underlier/underlier_type.rs
+++ b/crates/field/src/underlier/underlier_type.rs
@@ -3,7 +3,6 @@
 use std::fmt::Debug;
 
 use bytemuck::{NoUninit, Zeroable};
-use subtle::ConstantTimeEq;
 
 use crate::Random;
 
@@ -16,7 +15,6 @@ pub trait UnderlierType:
 	+ Eq
 	+ PartialOrd
 	+ Ord
-	+ ConstantTimeEq
 	+ Copy
 	+ Random
 	+ NoUninit


### PR DESCRIPTION
### TL;DR

Remove the `subtle` crate dependency and all constant-time equality implementations.

### What changed?

- Removed the `subtle` crate dependency from the workspace and field crate
- Removed all implementations of `ConstantTimeEq` and `ConditionallySelectable` traits across various field types
- Replaced constant-time equality checks with regular equality checks in the `try_into` implementations for `BinaryField128bGhash` and `BinaryField128bPolyval`
- Removed the `From<BinaryField1b> for Choice` implementation
- Removed the test for `1b_to_choice` conversion

### How to test?

- Verify that the codebase builds successfully without the `subtle` dependency
- Run the test suite to ensure all tests pass with the regular equality checks
- Specifically test the `try_into` implementations for `BinaryField128bGhash` and `BinaryField128bPolyval` to ensure they work correctly with regular equality checks

### Why make this change?

The `subtle` crate provides constant-time equality operations to prevent timing attacks. This change suggests that constant-time equality is no longer needed for these field operations, possibly because:

1. The code is not being used in cryptographic contexts where timing attacks are a concern
2. The operations are being protected against timing attacks through other means
3. The project is simplifying dependencies and removing unnecessary complexity