### PR TITLE
Use wasm32::M128 in GHash multiplication

### DIFF
--- a/crates/field/src/arch/portable/mod.rs
+++ b/crates/field/src/arch/portable/mod.rs
@@ -31,7 +31,7 @@ pub mod packed_ghash_256;
 pub mod packed_ghash_512;
 
 mod nibble_invert_128b;
-mod univariate_mul_utils_128;
+pub(crate) mod univariate_mul_utils_128;
 
 pub mod byte_sliced;
 

--- a/crates/field/src/arch/portable/packed_polyval_128.rs
+++ b/crates/field/src/arch/portable/packed_polyval_128.rs
@@ -14,7 +14,7 @@ use super::{
 	nibble_invert_128b::nibble_invert_128b,
 	packed::PackedPrimitiveType,
 	packed_macros::impl_broadcast,
-	univariate_mul_utils_128::{bmul64, join_u64s, split_u128},
+	univariate_mul_utils_128::{Underlier128bLanes, bmul64},
 };
 use crate::{
 	BinaryField128bPolyval,
@@ -66,13 +66,13 @@ impl_transformation_with_strategy!(PackedBinaryPolyval1x128b, PairwiseStrategy);
 ///
 /// [1]: <https://datatracker.ietf.org/doc/html/rfc8452>
 fn montgomery_multiply(a: u128, b: u128) -> u128 {
-	let (h1, h0) = split_u128(a);
+	let (h1, h0) = a.split_hi_lo_64();
 	let h0r = h0.reverse_bits();
 	let h1r = h1.reverse_bits();
 	let h2 = h0 ^ h1;
 	let h2r = h0r ^ h1r;
 
-	let (y1, y0) = split_u128(b);
+	let (y1, y0) = b.split_hi_lo_64();
 	let y0r = y0.reverse_bits();
 	let y1r = y1.reverse_bits();
 	let y2 = y0 ^ y1;
@@ -101,7 +101,7 @@ fn montgomery_multiply(a: u128, b: u128) -> u128 {
 	v3 ^= v1 ^ (v1 >> 1) ^ (v1 >> 2) ^ (v1 >> 7);
 	v2 ^= (v1 << 63) ^ (v1 << 62) ^ (v1 << 57);
 
-	join_u64s(v3, v2)
+	u128::join_u64s(v3, v2)
 }
 
 /// Table where `value[i][k][j] = BinaryField128bPolyval(j << 4 * k) ^ (2^(i+1))`

--- a/crates/field/src/arch/wasm32/m128.rs
+++ b/crates/field/src/arch/wasm32/m128.rs
@@ -36,6 +36,16 @@ impl M128 {
 	pub(super) const fn from_u128(value: u128) -> Self {
 		Self(u64x2(value as u64, (value >> 64) as u64))
 	}
+
+	#[inline]
+	pub fn from_lanes_u64(lo: u64, hi: u64) -> Self {
+		Self(u64x2(lo, hi))
+	}
+
+	#[inline]
+	pub fn split_lanes_u64(self) -> (u64, u64) {
+		(u64x2_extract_lane::<0>(self.0), u64x2_extract_lane::<1>(self.0))
+	}
 }
 
 impl Default for M128 {
@@ -281,19 +291,75 @@ impl UnderlierWithBitOps for M128 {
 	const ONE: Self = { Self(u64x2(1, 0)) };
 	const ONES: Self = { Self(u64x2(u64::MAX, u64::MAX)) };
 
-	#[inline]
+	#[inline(always)]
 	fn fill_with_bit(val: u8) -> Self {
 		Self(u64x2_splat(u64::fill_with_bit(val)))
 	}
 
-	#[inline]
+	#[inline(always)]
 	fn shl_128b_lanes(self, shift: usize) -> Self {
 		self << shift
 	}
 
-	#[inline]
+	#[inline(always)]
 	fn shr_128b_lanes(self, shift: usize) -> Self {
 		self >> shift
+	}
+
+	#[inline]
+	unsafe fn get_subvalue<T>(&self, i: usize) -> T
+	where
+		T: UnderlierType + NumCast<Self>,
+	{
+		match T::LOG_BITS {
+			0..4 => {
+				let byte = match i >> (3 - T::LOG_BITS) {
+					0 => u8x16_extract_lane::<0>(self.0),
+					1 => u8x16_extract_lane::<1>(self.0),
+					2 => u8x16_extract_lane::<2>(self.0),
+					3 => u8x16_extract_lane::<3>(self.0),
+					4 => u8x16_extract_lane::<4>(self.0),
+					5 => u8x16_extract_lane::<5>(self.0),
+					6 => u8x16_extract_lane::<6>(self.0),
+					7 => u8x16_extract_lane::<7>(self.0),
+					8 => u8x16_extract_lane::<8>(self.0),
+					9 => u8x16_extract_lane::<9>(self.0),
+					10 => u8x16_extract_lane::<10>(self.0),
+					11 => u8x16_extract_lane::<11>(self.0),
+					12 => u8x16_extract_lane::<12>(self.0),
+					13 => u8x16_extract_lane::<13>(self.0),
+					14 => u8x16_extract_lane::<14>(self.0),
+					15 => u8x16_extract_lane::<15>(self.0),
+					_ => unreachable!(),
+				};
+
+				T::num_cast_from(Self::from(byte))
+			}
+			4 => match i {
+				0 => T::num_cast_from(Self::from(u16x8_extract_lane::<0>(self.0))),
+				1 => T::num_cast_from(Self::from(u16x8_extract_lane::<1>(self.0))),
+				2 => T::num_cast_from(Self::from(u16x8_extract_lane::<2>(self.0))),
+				3 => T::num_cast_from(Self::from(u16x8_extract_lane::<3>(self.0))),
+				4 => T::num_cast_from(Self::from(u16x8_extract_lane::<4>(self.0))),
+				5 => T::num_cast_from(Self::from(u16x8_extract_lane::<5>(self.0))),
+				6 => T::num_cast_from(Self::from(u16x8_extract_lane::<6>(self.0))),
+				7 => T::num_cast_from(Self::from(u16x8_extract_lane::<7>(self.0))),
+				_ => unreachable!(),
+			},
+			5 => match i {
+				0 => T::num_cast_from(Self::from(u32x4_extract_lane::<0>(self.0))),
+				1 => T::num_cast_from(Self::from(u32x4_extract_lane::<1>(self.0))),
+				2 => T::num_cast_from(Self::from(u32x4_extract_lane::<2>(self.0))),
+				3 => T::num_cast_from(Self::from(u32x4_extract_lane::<3>(self.0))),
+				_ => unreachable!(),
+			},
+			6 => match i {
+				0 => T::num_cast_from(Self::from(u64x2_extract_lane::<0>(self.0))),
+				1 => T::num_cast_from(Self::from(u64x2_extract_lane::<1>(self.0))),
+				_ => unreachable!(),
+			},
+			_ => unreachable!(),
+		}
 	}
 }
 
@@ -358,7 +424,7 @@ impl UnderlierWithBitConstants for M128 {
 		Self::from_u128(interleave_mask_odd!(u128, 6)),
 	];
 
-	#[inline]
+	#[inline(always)]
 	fn interleave(self, other: Self, log_block_len: usize) -> (Self, Self) {
 		match log_block_len {
 			// Bitwise/masked interleave

--- a/crates/field/src/arch/wasm32/mod.rs
+++ b/crates/field/src/arch/wasm32/mod.rs
@@ -5,8 +5,9 @@ use cfg_if::cfg_if;
 cfg_if! {
 	if #[cfg(target_feature = "simd128")] {
 		mod m128;
+		pub mod packed_ghash_128;
 
-		pub use super::portable::{packed_ghash_128, packed_ghash_256};
+		pub use super::portable::{packed_ghash_256};
 	} else {
 		pub use super::portable::{packed_ghash_128, packed_ghash_256};
 	}

--- a/crates/field/src/arch/wasm32/packed_ghash_128.rs
+++ b/crates/field/src/arch/wasm32/packed_ghash_128.rs
@@ -1,0 +1,68 @@
+// Copyright 2023-2025 Irreducible Inc.
+// Copyright (c) 2019-2023 RustCrypto Developers
+
+//! ARMv8 `PMULL`-accelerated implementation of GHASH.
+//!
+//! Based on the optimized GHASH implementation using carryless multiplication
+//! instructions available on ARMv8 processors with NEON support.
+
+use std::{arch::wasm32::*, ops::Mul};
+
+use super::{super::portable::packed::PackedPrimitiveType, m128::M128};
+use crate::{
+	BinaryField128bGhash,
+	arch::{
+		PairwiseStrategy, ReuseMultiplyStrategy,
+		portable::{packed_ghash_128::ghash_mul, univariate_mul_utils_128::Underlier128bLanes},
+	},
+	arithmetic_traits::{InvertOrZero, impl_square_with, impl_transformation_with_strategy},
+	packed::PackedField,
+};
+
+pub type PackedBinaryGhash1x128b = PackedPrimitiveType<M128, BinaryField128bGhash>;
+
+// Define multiply
+impl Mul for PackedBinaryGhash1x128b {
+	type Output = Self;
+
+	#[inline]
+	fn mul(self, rhs: Self) -> Self::Output {
+		Self::from_underlier(ghash_mul(self.0, rhs.0))
+	}
+}
+
+impl Underlier128bLanes for M128 {
+	type U64 = u64;
+
+	#[inline(always)]
+	fn split_hi_lo_64(self) -> (Self::U64, Self::U64) {
+		(u64x2_extract_lane::<0>(self.0), u64x2_extract_lane::<1>(self.0))
+	}
+
+	#[inline(always)]
+	fn join_u64s(high: Self::U64, low: Self::U64) -> Self {
+		M128::from(u64x2(low, high))
+	}
+
+	#[inline(always)]
+	fn broadcast_64(val: u64) -> Self {
+		M128::from(u64x2_splat(val))
+	}
+}
+
+// Define square
+impl_square_with!(PackedBinaryGhash1x128b @ ReuseMultiplyStrategy);
+
+// Define invert
+impl InvertOrZero for PackedBinaryGhash1x128b {
+	fn invert_or_zero(self) -> Self {
+		let portable = super::super::portable::packed_ghash_128::PackedBinaryGhash1x128b::from(
+			u128::from(self.to_underlier()),
+		);
+
+		Self::from_underlier(PackedField::invert_or_zero(portable).to_underlier().into())
+	}
+}
+
+// Define linear transformations
+impl_transformation_with_strategy!(PackedBinaryGhash1x128b, PairwiseStrategy);


### PR DESCRIPTION
### TL;DR

Use `M128` type for the packed GHASH field implementation. I've made several attempts to use the vectorized vectorized version of the algorithm with WASM SIMDs, both for 128-bit and 256-bit  packed types. But the problem is that although there is a `u64x2_mul` intrinsics it doesn't have a single intsruction both on x86 and aarch64 so all my attempts resulted in a slower code. So I just left the one which uses M128 type for a single packed value to take advandage of faster additions at least

### What changed?

- Created new traits `Underlier64bLanes` and `Underlier128bLanes` to abstract bit operations for different types
- Made `univariate_mul_utils_128` module public within the crate
- Refactored `ghash_mul` to be generic over any type implementing `Underlier128bLanes`
- Replaced direct bit manipulation operations with trait methods
- Added WASM32 SIMD implementation for GHASH using the new trait system
- Implemented the required traits for both `u128` and WASM32's `M128` type

### How to test?

- Run the existing test suite to ensure the refactored code maintains correctness
- Test specifically on WASM32 targets with SIMD128 support to verify the new implementation works correctly
- Verify that the portable implementation still works as expected

### Why make this change?

This change improves code reuse between different architectures by abstracting bit operations through traits. It enables the GHASH implementation to work efficiently with SIMD types on WASM32 platforms, while maintaining the same algorithm structure. The abstraction allows the same core algorithm to be used with different underlying types, reducing code duplication and making it easier to optimize for specific architectures.