### PR TITLE
[bench] Fix compile error for wasm32-wasip1 target

### DIFF
--- a/crates/utils/src/rayon/iter/from_parallel_iterator.rs
+++ b/crates/utils/src/rayon/iter/from_parallel_iterator.rs
@@ -34,3 +34,16 @@ where
 		par_iter.into_par_iter().into_inner().collect()
 	}
 }
+
+impl<T> FromParallelIterator<T> for Box<[T]>
+where
+	T: Send,
+{
+	#[inline(always)]
+	fn from_par_iter<I>(par_iter: I) -> Self
+	where
+		I: IntoParallelIterator<Item = T>,
+	{
+		Vec::from_par_iter(par_iter).into_boxed_slice()
+	}
+}


### PR DESCRIPTION
The bench compilation is failing for the wasm32-wasip1 target:

cargo build --all --all-features --tests --benches --examples --target wasm32-wasip1

```
error[E0277]: the trait bound `Box<[BinaryField128bGhash]>: FromParallelIterator<BinaryField128bGhash>` is not satisfied
    --> crates/prover/benches/sumcheck.rs:160:7
     |
160  |                     .collect(),
     |                      ^^^^^^^ the trait `FromParallelIterator<BinaryField128bGhash>` is not implemented for `Box<[BinaryField128bGhash]
```

for the wasm32-wasip1 we use a fallback rayon implementation that does
not define an instance of FromParallelIterator<T> for Box<[T]>.

This PR adds this fallback instance to fix the compile error.