### PR TITLE
[chore] Fix formatting

### DIFF
--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -63,8 +63,7 @@ where
 
 	transcript.message().write(&evaluation);
 
-	let pcs_prover =
-		OneBitPCSProver::new(witness_packed, evaluation, evaluation_point)?;
+	let pcs_prover = OneBitPCSProver::new(witness_packed, evaluation, evaluation_point)?;
 
 	pcs_prover.prove_with_transcript(
 		transcript,


### PR DESCRIPTION
The rustfmt error was being masked by the wasm32-wasip1 compile error (which is fixed in the child PR in this stack).