### PR TITLE
[frontend] fix po2 value vec promise

### DIFF
--- a/crates/frontend/src/compiler/circuit.rs
+++ b/crates/frontend/src/compiler/circuit.rs
@@ -96,6 +96,7 @@ impl Circuit {
 		value_vec_layout: ValueVecLayout,
 		wire_mapping: SecondaryMap<Wire, ValueIndex>,
 	) -> Self {
+		value_vec_layout.validate();
 		Self {
 			shared,
 			value_vec_layout,

--- a/crates/frontend/src/compiler/mod.rs
+++ b/crates/frontend/src/compiler/mod.rs
@@ -129,7 +129,7 @@ impl CircuitBuilder {
 			wire_mapping[wire] = ValueIndex(cur_index);
 			cur_index += 1;
 		}
-		let total_len = cur_index as usize;
+		let total_len = (cur_index as usize).next_power_of_two();
 		let value_vec_layout = ValueVecLayout {
 			n_const,
 			n_inout,

--- a/crates/frontend/src/constraint_system.rs
+++ b/crates/frontend/src/constraint_system.rs
@@ -194,6 +194,17 @@ pub struct ValueVecLayout {
 	pub total_len: usize,
 }
 
+impl ValueVecLayout {
+	/// Asserts that the value vec layout has a correct shape.
+	pub fn validate(&self) {
+		assert!(self.total_len.is_power_of_two(), "total length must be a power-of-two");
+		assert!(
+			self.offset_witness.is_power_of_two(),
+			"witness parameters must start at a power-of-two offset",
+		);
+	}
+}
+
 /// The vector of values.
 ///
 /// This is a prover-only structure.

--- a/crates/zkl/snapshots/stat_output.snap
+++ b/crates/zkl/snapshots/stat_output.snap
@@ -14,7 +14,7 @@ config: Config {
 Number of gates: 818551
 Number of AND constraints: 1138868
 Number of MUL constraints: 26945
-Length of value vec: 1261335
+Length of value vec: 2097152
   Constants: 620
   Inout: 133
   Witness: 190227


### PR DESCRIPTION
The total length of the value vec is promised to be a power-of-two size, but
this promise was broken by recent change. This changeset fixes that and adds
some additional assertions to prevent that in the future.