### PR TITLE
Efficient square implementation using caryless multiplication

### DIFF
--- a/crates/field/src/arch/aarch64/packed_ghash_128.rs
+++ b/crates/field/src/arch/aarch64/packed_ghash_128.rs
@@ -12,8 +12,8 @@ use std::ops::Mul;
 use super::{super::portable::packed::PackedPrimitiveType, m128::M128};
 use crate::{
 	BinaryField128bGhash,
-	arch::{PairwiseStrategy, ReuseMultiplyStrategy, shared::ghash::ClMulUnderlier},
-	arithmetic_traits::{InvertOrZero, impl_square_with, impl_transformation_with_strategy},
+	arch::{PairwiseStrategy, shared::ghash::ClMulUnderlier},
+	arithmetic_traits::{InvertOrZero, Square, impl_transformation_with_strategy},
 	packed::PackedField,
 };
 
@@ -63,7 +63,12 @@ impl Mul for PackedBinaryGhash1x128b {
 }
 
 // Define square
-impl_square_with!(PackedBinaryGhash1x128b @ ReuseMultiplyStrategy);
+impl Square for PackedBinaryGhash1x128b {
+	#[inline]
+	fn square(self) -> Self {
+		Self::from_underlier(crate::arch::shared::ghash::square_clmul(self.to_underlier()))
+	}
+}
 
 // Define invert
 impl InvertOrZero for PackedBinaryGhash1x128b {


### PR DESCRIPTION
### TL;DR

Optimize GHASH squaring operations with a dedicated implementation instead of reusing multiplication for the case when caryless multiplication instruction is available. Specialized square implementation gives x2 throughput comparing with re-using multiplication

### What changed?

- Added a specialized `square_clmul` function in `ghash.rs` that optimizes squaring operations for binary fields
- Implemented a helper function `gf2_128_shift_reduce` for the reduction step in squaring
- Updated the `Square` trait implementation for `PackedBinaryGhash1x128b` to use the new optimized squaring function
- Added conditional implementations of the `Square` trait for `PackedBinaryGhash2x128b` and `PackedBinaryGhash4x128b` that use the optimized squaring when hardware support is available
- Removed the generic `ReuseMultiplyStrategy` for squaring in favor of specialized implementations

### How to test?

- Run the existing test suite to ensure correctness
- Benchmark the squaring operations on hardware with PCLMULQDQ, VPCLMULQDQ, AVX2, and AVX512F support to verify performance improvements

### Why make this change?

Squaring in binary fields has special properties that allow for optimization beyond simply multiplying a value by itself. This change implements a specialized squaring algorithm that takes advantage of these properties to improve performance, particularly on hardware with CLMUL support.