### PR TITLE
Implement fast portable GHASH square

### DIFF
--- a/crates/field/src/arch/x86_64/packed_ghash_512.rs
+++ b/crates/field/src/arch/x86_64/packed_ghash_512.rs
@@ -116,6 +116,8 @@ cfg_if! {
 			}
 		}
 	} else {
+		// Potentially we could  use an optimized square implementation here with a scaled underlier.
+		// But this case (an architecture with AVX512 but without VPCLMULQDQ) is pretty rare, doesn't worth spending time on it.
 		crate::arithmetic_traits::impl_square_with!(PackedBinaryGhash4x128b @ crate::arch::ReuseMultiplyStrategy);
 	}
 }


### PR DESCRIPTION
### TL;DR

Optimize GHASH squaring operations with a specialized implementation instead of reusing multiplication for the portable case. Here we take advantage the multiplication for the polynomial basis step is just interleaving bits with zeroes. The reduction step is the same. This shows around x7 throughput comparing with re-using multiplicaiton.

### What changed?

- Added a specialized `ghash_square` function that directly computes squares in the GHASH field by interleaving bits with zeros
- Added a `spread_bits_64` and `spread_bits_128` utility functions to efficiently interleave bits with zeros
- Implemented a dedicated `reduce_64` function to handle the polynomial reduction step
- Updated the `Square` trait implementation for `PackedBinaryGhash1x128b` to use the new optimized squaring function
- Added tests for the new bit spreading functions

### How to test?

- Run the existing test suite to verify correctness
- Run the new tests for `spread_bits_64` and `spread_bits_128` functions
- Benchmark GHASH operations to verify performance improvements

### Why make this change?

Squaring in binary fields can be implemented more efficiently than general multiplication. By using a specialized implementation that interleaves bits with zeros (which is equivalent to squaring in the polynomial basis), we can achieve better performance than reusing the multiplication operation. This optimization is particularly important for cryptographic applications where GHASH is used, such as in AES-GCM.