### PR TITLE
[verify] Integrate the public input check

### DIFF
--- a/crates/prover/src/error.rs
+++ b/crates/prover/src/error.rs
@@ -1,11 +1,13 @@
 // Copyright 2025 Irreducible Inc.
 
-use crate::fri;
+use crate::{fri, protocols::sumcheck};
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
 	#[error("invalid argument {arg}: {msg}")]
 	ArgumentError { arg: String, msg: String },
+	#[error("sumcheck error: {0}")]
+	Sumcheck(#[from] sumcheck::Error),
 	#[error("FRI error: {0}")]
 	Fri(#[from] fri::Error),
 	#[error("transcript error: {0}")]

--- a/crates/prover/src/pcs/prover.rs
+++ b/crates/prover/src/pcs/prover.rs
@@ -223,7 +223,7 @@ mod test {
 		fields::{B1, B128},
 		fri::FRIParams,
 		hash::{StdCompression, StdDigest},
-		pcs::verifier::verify_transcript,
+		pcs,
 	};
 	use itertools::Itertools;
 	use rand::{SeedableRng, rngs::StdRng};
@@ -300,7 +300,7 @@ mod test {
 
 		let retrieved_codeword_commitment = verifier_challenger.message().read()?;
 
-		verify_transcript(
+		pcs::verify_transcript(
 			&mut verifier_challenger,
 			evaluation_claim,
 			&evaluation_point,

--- a/crates/verifier/src/error.rs
+++ b/crates/verifier/src/error.rs
@@ -23,6 +23,8 @@ pub enum Error {
 	IncorrectPublicInputLength { expected: usize, actual: usize },
 	#[error("constraint system error: {0}")]
 	ConstraintSystem(#[from] ConstraintSystemError),
+	#[error("invalid proof: {0}")]
+	Verification(#[from] VerificationError),
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -31,4 +33,10 @@ pub enum ConstraintSystemError {
 	PublicInputPowerOfTwo,
 	#[error("the public input segment must at least 2^{LOG_WORDS_PER_ELEM} words")]
 	PublicInputTooShort,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum VerificationError {
+	#[error("public input check failed")]
+	PublicInputCheckFailed,
 }

--- a/crates/verifier/src/pcs/mod.rs
+++ b/crates/verifier/src/pcs/mod.rs
@@ -1,6 +1,7 @@
 // Copyright 2025 Irreducible Inc.
 
 pub mod error;
-pub mod verifier;
+mod verifier;
 
 pub use error::{Error, VerificationError};
+pub use verifier::verify_transcript;


### PR DESCRIPTION
### TL;DR

Implement public input verification in the prover and verifier.

### What changed?

- Added a sumcheck protocol to verify public inputs during proof generation and verification
- Implemented a folding mechanism to handle word-level operations efficiently
- Added error types for sumcheck and verification failures
- Refactored the prove/verify flow to include public input verification
- Added a function to evaluate the multilinear extension of public inputs
- Simplified PCS module exports by making the verifier module private and exposing only the necessary function

### How to test?

The existing integration tests for the `binius-prover` crate pass.