### PR TITLE
[AND reduction] Replace AndReductionProver with QuadraticMleCheckProver

### DIFF
--- a/crates/verifier/src/and_reduction/verifier.rs
+++ b/crates/verifier/src/and_reduction/verifier.rs
@@ -11,7 +11,7 @@ use crate::{
 		univariate::univariate_poly::{GenericPo2UnivariatePoly, UnivariatePolyIsomorphic},
 		utils::constants::ROWS_PER_HYPERCUBE_VERTEX,
 	},
-	protocols::sumcheck::{SumcheckOutput, verify},
+	protocols::{mlecheck::verify, sumcheck::SumcheckOutput},
 };
 
 pub struct AndReductionOutput<F: Field> {
@@ -84,7 +84,7 @@ pub struct AndReductionOutput<F: Field> {
 /// - `sumcheck_output`: The reduced claim (evaluation and challenge point) from the sumcheck
 ///   protocol
 pub fn verify_with_transcript<F, TranscriptChallenger>(
-	n_vars: usize,
+	all_zerocheck_challenges: &[F],
 	transcript: &mut VerifierTranscript<TranscriptChallenger>,
 	round_message_univariate_domain: BinarySubspace<F>,
 ) -> Result<AndReductionOutput<F>, Error>
@@ -110,7 +110,7 @@ where
 	let sumcheck_claim = univariate_message.evaluate_at_challenge(univariate_sumcheck_challenge);
 
 	Ok(AndReductionOutput {
-		sumcheck_output: verify(n_vars, 3, sumcheck_claim, transcript)?,
+		sumcheck_output: verify(all_zerocheck_challenges, 2, sumcheck_claim, transcript)?,
 		univariate_sumcheck_challenge,
 	})
 }


### PR DESCRIPTION
### TL;DR

Refactored the AND reduction protocol to use the quadratic MLE check prover instead of the AND reduction prover.

### What changed?

- Replaced `AndReductionProver` with `QuadraticMleCheckProver` in the AND reduction protocol
- Updated imports to use `prove_single_mlecheck` instead of `prove_single`
- Modified the prover's `create_sumcheck_prover` method to return a `QuadraticMleCheckProver` with appropriate function parameters
- Updated the verification process to use the MLE check verifier on the zerocheck challenges
- Simplified the evaluation claim by removing the equality indicator polynomial

### How to test?

Run the existing test suite for the AND reduction protocol. The tests have been updated to match the new implementation, particularly the verification of MLE evaluation claims.

### Why make this change?

This change improves the implementation by using a more general quadratic MLE check prover, which provides better abstraction and reusability. The new approach simplifies the protocol by removing the need for the equality indicator polynomial, making the code more maintainable and potentially more efficient.