### PR TITLE
[AND reduction] Bench: Replace AndReductionProver with QuadraticMleCheckProver

### DIFF
--- a/crates/prover/benches/and_reduction.rs
+++ b/crates/prover/benches/and_reduction.rs
@@ -10,7 +10,7 @@ use binius_prover::{
 		sumcheck_round_messages::univariate_round_message_extension_domain,
 		utils::multivariate::OneBitOblongMultilinear,
 	},
-	protocols::sumcheck::{and_reduction::prover::AndReductionProver, common::SumcheckProver},
+	protocols::sumcheck::{common::SumcheckProver, quadratic_mle::QuadraticMleCheckProver},
 };
 use binius_verifier::{
 	and_reduction::{
@@ -151,18 +151,20 @@ fn bench(c: &mut Criterion) {
 				.copied()
 				.collect();
 
-			let proving_polys = vec![
+			let proving_polys = [
 				first_mlv.fold(&fold_lookup),
 				second_mlv.fold(&fold_lookup),
 				third_mlv.fold(&fold_lookup),
 			];
 
-			let mut prover = AndReductionProver::new(
+			let mut prover = QuadraticMleCheckProver::new(
 				proving_polys,
-				multilinear_zerocheck_challenges.clone(),
+				|[a, b, c]| a * b - c,
+				|[a, b, _]| a * b,
+				&multilinear_zerocheck_challenges,
 				next_round_claim,
-				log_num_rows - SKIPPED_VARS,
-			);
+			)
+			.expect("multilinears should have consistent dimensions");
 
 			for _ in multilinear_zerocheck_challenges {
 				let _ = prover.execute().unwrap();


### PR DESCRIPTION
### TL;DR

Replace `AndReductionProver` with `QuadraticMleCheckProver` in the benchmarking code.

### What changed?

- Updated the import path to use `quadratic_mle::QuadraticMleCheckProver` instead of `and_reduction::prover::AndReductionProver`
- Modified the prover initialization to use the new `QuadraticMleCheckProver` with appropriate parameters:
  - Added explicit function closures for the quadratic check and the product computation
  - Changed the vector initialization syntax from `vec![]` to array syntax `[]`
  - Added an `expect` call to handle potential errors from the constructor
  - Removed the `log_num_rows - SKIPPED_VARS` parameter which is no longer needed

### How to test?

Run the benchmarks to ensure they still function correctly with the new prover implementation:

```
cargo bench --bench and_reduction
```

### Why make this change?

This change likely aligns the benchmarking code with architectural improvements in the prover implementation, using a more generalized `QuadraticMleCheckProver` that can handle various types of quadratic multilinear extension checks rather than the more specific `AndReductionProver`.