### PR TITLE
[ci] relax wasm check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,9 +83,7 @@ jobs:
             rustflags: "-C debug-assertions"
           - name: "wasm-build"
             command: |
-              ALL_FEATURES_WO_BAIL_PANIC=$(.github/scripts/get-features-without-bail-panic.sh | tail -1)
-              echo "ALL_FEATURES_WO_BAIL_PANIC: $ALL_FEATURES_WO_BAIL_PANIC"
-              cargo build --all --features "$ALL_FEATURES_WO_BAIL_PANIC" --tests --benches --examples --target wasm32-wasip1
+              cargo build -p binius-math -p binius-field -p binius-prover -p binius-verifier --benches --tests --all-features --examples --target wasm32-wasip1
             rust-target: "wasm32-wasip1"
     steps:
       - name: Checkout Repository

--- a/crates/prover/Cargo.toml
+++ b/crates/prover/Cargo.toml
@@ -33,7 +33,7 @@ binius-math = { path = "../math", features = ["test-utils"] }
 blake2.workspace = true
 criterion.workspace = true
 proptest.workspace = true
-rand = { workspace = true, features = ["std_rng"] }
+rand = { workspace = true, features = ["std_rng", "thread_rng"] }
 
 [lib]
 bench = false


### PR DESCRIPTION
Now we are building absolutely everything under wasm32-wasi which is a bit too
aggressive because not every crate is supposed to be run under wasm.

Specifically,

1. circuits are meant to be compiled offline, ie. on a developer
machine, before being deployed. While for now binius-frontend is a part of the
compilation tree for binius-prover and binius-verifier it's not always going to
be.

2. there is already one developer tool, `zkl`, which is not meant to be used
   under wasm and probably will never be, and a second tool is upcoming.

It seems to me that what we actually care about is making sure that
binius-prover and binius-verifier (and obviously all the upstream crates) are
compiling and this is what this changeset aims to do.