### PR TITLE
[and_reduction] Specialize zerocheck protocol to working on words

### DIFF
--- a/crates/prover/src/and_reduction/univariate/ntt_lookup.rs
+++ b/crates/prover/src/and_reduction/univariate/ntt_lookup.rs
@@ -193,11 +193,12 @@ where
 	#[inline]
 	pub fn ntt(
 		&self,
-		coeffs_in_byte_chunks: impl Iterator<Item = u8>,
+		coeffs_in_byte_chunks: impl IntoIterator<Item = u8>,
 	) -> [PNTTDomain; ROWS_PER_HYPERCUBE_VERTEX / 16] {
 		let mut result = [PNTTDomain::zero(); ROWS_PER_HYPERCUBE_VERTEX / 16];
 
-		for (eight_bit_chunk_idx, eight_bit_chunk) in coeffs_in_byte_chunks.enumerate() {
+		for (eight_bit_chunk_idx, eight_bit_chunk) in coeffs_in_byte_chunks.into_iter().enumerate()
+		{
 			for j in 0..ROWS_PER_HYPERCUBE_VERTEX / 16 {
 				result[j] += self.0[eight_bit_chunk_idx][eight_bit_chunk as usize][j];
 			}
@@ -246,7 +247,7 @@ mod test {
 
 		let mut slice_to_ntt: [u8; _] = [0; ROWS_PER_HYPERCUBE_VERTEX / 8];
 		slice_to_ntt[0] = 1;
-		let results: [PackedAESBinaryField16x8b; _] = lookup.ntt(slice_to_ntt.into_iter());
+		let results: [PackedAESBinaryField16x8b; _] = lookup.ntt(slice_to_ntt);
 
 		for (i, input) in output_domain.iter().enumerate() {
 			let expected_result = (1..ROWS_PER_HYPERCUBE_VERTEX)

--- a/crates/verifier/src/and_reduction/utils/constants.rs
+++ b/crates/verifier/src/and_reduction/utils/constants.rs
@@ -1,5 +1,7 @@
-// 4,5,6 supported but 6 is optimal
-pub const SKIPPED_VARS: usize = 6;
+use crate::{LOG_WORD_SIZE_BITS, WORD_SIZE_BITS};
 
-// This is the amount of hypercubes in the "oblong hypercube"
-pub const ROWS_PER_HYPERCUBE_VERTEX: usize = 1 << SKIPPED_VARS;
+/// log2 size of the univariate domain
+pub const SKIPPED_VARS: usize = LOG_WORD_SIZE_BITS;
+
+// Size of the univariate domain
+pub const ROWS_PER_HYPERCUBE_VERTEX: usize = WORD_SIZE_BITS;


### PR DESCRIPTION
This simplifies the implementation and exposed interface. The calling code will construct the witness as a sequence of words, not as packed 1-bit elements.

This is more compatible with the calling interface I want to use, which computes and provides a vector of computed words.