### PR TITLE
Implement transpose method for the `ExtensionField`

### DIFF
--- a/crates/field/src/binary_field.rs
+++ b/crates/field/src/binary_field.rs
@@ -643,6 +643,12 @@ macro_rules! impl_field_extension {
 					$subfield_name::from_underlier(self.to_underlier().get_subvalue(i))
 				}
 			}
+
+			#[inline]
+			fn square_transpose(values: &mut [Self]) -> Result<(), Error> {
+				crate::transpose::square_transforms_extension_field::<$subfield_name, Self>(values)
+					.map_err(|_| Error::ExtensionDegreeMismatch)
+			}
 		}
 	};
 }

--- a/crates/field/src/extension.rs
+++ b/crates/field/src/extension.rs
@@ -83,6 +83,9 @@ pub trait ExtensionField<F: Field>:
 	/// # Safety
 	/// `i` must be less than `DEGREE`.
 	unsafe fn get_base_unchecked(&self, i: usize) -> F;
+
+	/// Transpose square block of subfield elements within `values` in place.
+	fn square_transpose(values: &mut [Self]) -> Result<(), Error>;
 }
 
 impl<F: Field> ExtensionField<F> for F {
@@ -126,5 +129,14 @@ impl<F: Field> ExtensionField<F> for F {
 	unsafe fn get_base_unchecked(&self, i: usize) -> F {
 		debug_assert_eq!(i, 0);
 		*self
+	}
+
+	#[inline]
+	fn square_transpose(values: &mut [Self]) -> Result<(), Error> {
+		if values.len() != 1 {
+			return Err(Error::MismatchedLengths);
+		}
+
+		Ok(())
 	}
 }

--- a/crates/field/src/ghash.rs
+++ b/crates/field/src/ghash.rs
@@ -36,6 +36,7 @@ use crate::{
 		invert_or_zero_using_packed, multiple_using_packed, square_using_packed,
 	},
 	linear_transformation::{FieldLinearTransformation, Transformation},
+	transpose::square_transforms_extension_field,
 	underlier::{IterationMethods, IterationStrategy, NumCast, U1, UnderlierWithBitOps},
 };
 
@@ -439,6 +440,12 @@ impl ExtensionField<BinaryField1b> for BinaryField128bGhash {
 	#[inline]
 	unsafe fn get_base_unchecked(&self, i: usize) -> BinaryField1b {
 		BinaryField1b(U1::num_cast_from(self.0 >> i))
+	}
+
+	#[inline]
+	fn square_transpose(values: &mut [Self]) -> Result<(), Error> {
+		square_transforms_extension_field::<BinaryField1b, Self>(values)
+			.map_err(|_| Error::ExtensionDegreeMismatch)
 	}
 }
 

--- a/crates/field/src/polyval.rs
+++ b/crates/field/src/polyval.rs
@@ -36,6 +36,7 @@ use crate::{
 		invert_or_zero_using_packed, multiple_using_packed, square_using_packed,
 	},
 	linear_transformation::{FieldLinearTransformation, Transformation},
+	transpose::square_transforms_extension_field,
 	underlier::{IterationMethods, IterationStrategy, NumCast, U1, UnderlierWithBitOps},
 };
 
@@ -454,6 +455,12 @@ impl ExtensionField<BinaryField1b> for BinaryField128bPolyval {
 	#[inline]
 	unsafe fn get_base_unchecked(&self, i: usize) -> BinaryField1b {
 		BinaryField1b(U1::num_cast_from(self.0 >> i))
+	}
+
+	#[inline]
+	fn square_transpose(values: &mut [Self]) -> Result<(), Error> {
+		square_transforms_extension_field::<BinaryField1b, Self>(values)
+			.map_err(|_| Error::ExtensionDegreeMismatch)
 	}
 }
 

--- a/crates/field/src/transpose.rs
+++ b/crates/field/src/transpose.rs
@@ -3,6 +3,7 @@
 use binius_utils::checked_arithmetics::log2_strict_usize;
 
 use super::packed::PackedField;
+use crate::{ExtensionField, Field, PackedExtension};
 
 /// Error thrown when a transpose operation fails.
 #[derive(Clone, thiserror::Error, Debug)]
@@ -66,6 +67,12 @@ pub fn square_transpose<P: PackedField>(log_n: usize, elems: &mut [P]) -> Result
 	}
 
 	Ok(())
+}
+
+pub fn square_transforms_extension_field<F: Field, FE: ExtensionField<F> + PackedExtension<F>>(
+	values: &mut [FE],
+) -> Result<(), Error> {
+	square_transpose(FE::LOG_DEGREE, FE::cast_bases_mut(values))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Add `square_transpose` to `ExtensionField` trait

### TL;DR

Add a `square_transpose` method to the `ExtensionField` trait to enable in-place transposition of square blocks of subfield elements so that `F: PackedExtension<FE>` bound is not needed

### What changed?

- Added a new `square_transpose` method to the `ExtensionField` trait
- Implemented the method for base field case (F: Field)
- Added implementations for binary field extensions, GHASH, and POLYVAL
- Created a helper function `square_transforms_extension_field` in the transpose module

### How to test?

The implementation leverages the existing `square_transpose` function which already has tests. No additional tests are needed as this is primarily adding a trait method that uses existing functionality.

### Why make this change?

This change enables efficient in-place transposition of square blocks of subfield elements within extension fields. This operation is useful for various cryptographic applications and field arithmetic optimizations, particularly when working with matrices of field elements that need to be transposed.