### PR TITLE
Remove redundant trait bounds from TensorAlgebra an its usages

### DIFF
--- a/crates/field/src/arch/x86_64/packed_ghash_256.rs
+++ b/crates/field/src/arch/x86_64/packed_ghash_256.rs
@@ -96,6 +96,8 @@ cfg_if! {
 			}
 		}
 	} else {
+		// Potentially we could  use an optimized square implementation here with a scaled underlier.
+		// But this case (an architecture with AVX2 but without VPCLMULQDQ) is pretty rare, doesn't worth spending time on it.
 		crate::arithmetic_traits::impl_square_with!(PackedBinaryGhash2x128b @ crate::arch::ReuseMultiplyStrategy);
 	}
 }

--- a/crates/math/src/tensor_algebra.rs
+++ b/crates/math/src/tensor_algebra.rs
@@ -7,9 +7,7 @@ use std::{
 	ops::{Add, AddAssign, Sub, SubAssign},
 };
 
-use binius_field::{
-	ExtensionField, Field, PackedExtension, square_transpose, util::inner_product_unchecked,
-};
+use binius_field::{ExtensionField, Field, util::inner_product_unchecked};
 
 /// An element of the tensor algebra defined as the tensor product of `FE` and `FE` as fields.
 ///
@@ -123,7 +121,7 @@ where
 	}
 }
 
-impl<F: Field, FE: ExtensionField<F> + PackedExtension<F>> TensorAlgebra<F, FE> {
+impl<F: Field, FE: ExtensionField<F>> TensorAlgebra<F, FE> {
 	/// Multiply by an element from the vertical subring.
 	///
 	/// Internally, this performs a transpose, vertical scaling, then transpose sequence. If
@@ -137,7 +135,7 @@ impl<F: Field, FE: ExtensionField<F> + PackedExtension<F>> TensorAlgebra<F, FE> 
 	///
 	/// A transpose flips the vertical and horizontal subring elements.
 	pub fn transpose(mut self) -> Self {
-		square_transpose(Self::kappa(), FE::cast_bases_mut(&mut self.elems))
+		FE::square_transpose(&mut self.elems)
 			.expect("transpose dimensions are square by struct invariant");
 		self
 	}

--- a/crates/prover/src/pcs/prover.rs
+++ b/crates/prover/src/pcs/prover.rs
@@ -24,7 +24,7 @@ use crate::{
 /// soundness.
 pub struct OneBitPCSProver<F>
 where
-	F: BinaryField + PackedExtension<B1> + PackedExtension<F>,
+	F: BinaryField + PackedExtension<B1>,
 {
 	pub small_field_evaluation_claim: F,
 	pub evaluation_claim: F,

--- a/crates/verifier/src/pcs/verifier.rs
+++ b/crates/verifier/src/pcs/verifier.rs
@@ -1,6 +1,6 @@
 // Copyright 2025 Irreducible Inc.
 
-use binius_field::{BinaryField, ExtensionField, Field, PackedExtension, PackedField};
+use binius_field::{BinaryField, ExtensionField, Field, PackedField};
 use binius_math::{
 	field_buffer::FieldBuffer,
 	multilinear::{eq::eq_ind_partial_eval, evaluate::evaluate},
@@ -42,7 +42,7 @@ pub fn verify_transcript<F, FA, TranscriptChallenger, VCS>(
 	vcs: &VCS,
 ) -> Result<(), Error>
 where
-	F: Field + BinaryField + PackedField<Scalar = F> + ExtensionField<FA> + PackedExtension<B1>,
+	F: Field + BinaryField + PackedField<Scalar = F> + ExtensionField<FA>,
 	FA: BinaryField,
 	TranscriptChallenger: Challenger,
 	VCS: MerkleTreeScheme<F, Digest: DeserializeBytes>,
@@ -97,7 +97,7 @@ where
 
 	let (_, eval_point_high) = eval_point.split_at(packing_degree);
 
-	let rs_eq_at_basefold_challenges = eval_rs_eq(
+	let rs_eq_at_basefold_challenges = eval_rs_eq::<B1, F>(
 		eval_point_high,
 		&sumcheck_output.challenges,
 		eq_ind_partial_eval(&batching_scalars).as_ref(),

--- a/crates/verifier/src/ring_switch/verifier.rs
+++ b/crates/verifier/src/ring_switch/verifier.rs
@@ -1,6 +1,6 @@
 use std::iter;
 
-use binius_field::{ExtensionField, Field, PackedExtension};
+use binius_field::{ExtensionField, Field};
 use binius_math::tensor_algebra::TensorAlgebra;
 
 /// Evaluate the ring switching equality indicator at a given point.
@@ -26,7 +26,7 @@ use binius_math::tensor_algebra::TensorAlgebra;
 pub fn eval_rs_eq<F, FE>(z_vals: &[FE], query: &[FE], expanded_row_batch_query: &[FE]) -> FE
 where
 	F: Field,
-	FE: Field + ExtensionField<F> + PackedExtension<F>,
+	FE: Field + ExtensionField<F>,
 {
 	assert_eq!(z_vals.len(), query.len()); // pre-condition
 	assert_eq!(expanded_row_batch_query.len(), FE::DEGREE); // pre-condition


### PR DESCRIPTION
### TL;DR

Removed unnecessary `PackedExtension<F>` trait bounds and updated tensor algebra transpose implementation.

### What changed?

- Removed redundant `PackedExtension<F>` trait bounds from several functions and structs
- Updated the `transpose` method in `TensorAlgebra` to use `FE::square_transpose` instead of the standalone `square_transpose` function
- Added comments in `packed_ghash_256.rs` explaining why an optimized square implementation isn't needed for architectures with AVX2 but without VPCLMULQDQ
- Modified the `eval_rs_eq` function to explicitly specify the type parameters

### How to test?

Compile and run the existing test suite to ensure all functionality continues to work as expected.

### Why make this change?

This change simplifies the code by removing unnecessary trait bounds, making the API more flexible and easier to use. The updated transpose implementation in `TensorAlgebra` now uses the method provided by the extension field type directly, which is more idiomatic. The added comments help explain implementation decisions for future developers.