### PR TITLE
[frontend] Fix assumption in concat test_wrong_length_rejected

### DIFF
--- a/crates/frontend/src/circuits/concat.rs
+++ b/crates/frontend/src/circuits/concat.rs
@@ -826,12 +826,10 @@ mod tests {
 					.flat_map(|(data, _)| data.clone())
 					.collect();
 
+				prop_assume!(!correct_joined.is_empty());
+
 				// Create joined data that's too short
-				let short_joined = if correct_joined.len() > 1 {
-					correct_joined[..correct_joined.len() - 1].to_vec()
-				} else {
-					vec![]
-				};
+				let short_joined = correct_joined[..correct_joined.len() - 1].to_vec();
 
 				run_concat_test(term_specs, Some(short_joined), false);
 			}


### PR DESCRIPTION
The test_wrong_length_rejected proptest was failing with the following input:

```
minimal failing input: term_specs = [
    (
        [],
        8,
    ),
    (
        [],
        8,
    ),
]
```

Since all the data of all terms are empty, their concatenation is
empty. The test constructed an empty "short_joined" subject to test
against. And the circuit (comparing two empty concats) succeeded when
it's expected to fail (as this is a negative test).

The test case is fixed by adding the assumption that the expected
concatenation is non-empty.

This test starteds to fail when the proptest dependency is updated to
version 1.7.0. This happens because we don't commit the Cargo.lock
file (by choice) and the Cargo.toml spec specifies "1.2.0", allowing
Cargo to resolve newer versions < 2.0.0.