### PR TITLE
[chore] batch sumcheck verification moved from intmul to generic sumcheck

### DIFF
--- a/crates/prover/src/protocols/intmul/prove.rs
+++ b/crates/prover/src/protocols/intmul/prove.rs
@@ -9,12 +9,9 @@ use binius_transcript::{
 	fiat_shamir::{CanSample, Challenger},
 };
 use binius_utils::bitwise::Bitwise;
-use binius_verifier::protocols::{
-	intmul::common::{
-		IntMulOutput, Phase1Output, Phase2Output, Phase3Output, Phase4Output, Phase5Output,
-		frobenius_twist, make_phase_3_output, normalize_a_c_exponent_evals,
-	},
-	sumcheck::common::BatchSumcheckOutput,
+use binius_verifier::protocols::intmul::common::{
+	IntMulOutput, Phase1Output, Phase2Output, Phase3Output, Phase4Output, Phase5Output,
+	frobenius_twist, make_phase_3_output, normalize_a_c_exponent_evals,
 };
 use either::Either;
 use itertools::{Itertools, izip};
@@ -22,7 +19,7 @@ use itertools::{Itertools, izip};
 use super::{error::Error, witness::Witness};
 use crate::protocols::sumcheck::{
 	MleToSumCheckDecorator,
-	batch::batch_prove,
+	batch::{BatchSumcheckOutput, batch_prove},
 	bivariate_product_mle::BivariateProductMlecheckProver,
 	bivariate_product_multi_mle::BivariateProductMultiMlecheckProver,
 	rerand_mle::RerandMlecheckProver,

--- a/crates/prover/src/protocols/sumcheck/batch.rs
+++ b/crates/prover/src/protocols/sumcheck/batch.rs
@@ -5,11 +5,33 @@ use binius_transcript::{
 	ProverTranscript,
 	fiat_shamir::{CanSample, Challenger},
 };
-use binius_verifier::protocols::sumcheck::common::{BatchSumcheckOutput, RoundCoeffs};
+use binius_verifier::protocols::sumcheck::common::RoundCoeffs;
 
 use crate::protocols::sumcheck::{common::SumcheckProver, error::Error};
 
+/// Prover view of the execution result of a batched sumcheck.
+#[derive(Debug, PartialEq, Eq)]
+pub struct BatchSumcheckOutput<F: Field> {
+	/// Verifier challenges for each round of the sumcheck protocol.
+	///
+	/// One challenge is generated per variable in the multivariate polynomial,
+	/// with challenges\[i\] corresponding to the i-th round of the protocol.
+	///
+	/// Note: reverse when folding high-to-low to obtain evaluation claim.
+	pub challenges: Vec<F>,
+	/// Evaluation claims on non-transparent multilinears, per prover.
+	/// These values are concatenated and written to the transcript.
+	pub multilinear_evals: Vec<Vec<F>>,
+}
+
 /// Prove a batched sumcheck protocol execution, where all provers have the same number of rounds.
+///
+/// The batched sumcheck reduces a set of claims about the sums of a multivariate polynomials over
+/// the boolean hypercube to their evaluation at a (shared) challenge point. This is achieved by
+/// constructing an `n_vars + 1`-variate polynomial whose coefficients in the "new variable" are the
+/// individual sum claims and evaluating it at a random point. Due to linearity of sums each claim
+/// can be proven separately with an individual [`SumcheckProver`] followed by weighted summation of
+/// the round polynomials.
 pub fn batch_prove<F, Prover, Challenger_>(
 	mut provers: Vec<Prover>,
 	transcript: &mut ProverTranscript<Challenger_>,

--- a/crates/prover/src/protocols/sumcheck/prove.rs
+++ b/crates/prover/src/protocols/sumcheck/prove.rs
@@ -133,5 +133,6 @@ pub struct ProveSingleOutput<F: Field> {
 	///
 	/// One challenge is generated per variable in the multivariate polynomial,
 	/// with challenges\[i\] corresponding to the i-th round of the protocol.
+	/// NB: reverse when folding high-to-low to obtain evaluation claim.
 	pub challenges: Vec<F>,
 }

--- a/crates/verifier/src/protocols/sumcheck/batch.rs
+++ b/crates/verifier/src/protocols/sumcheck/batch.rs
@@ -1,0 +1,53 @@
+// Copyright 2025 Irreducible Inc.
+
+use binius_field::Field;
+use binius_math::univariate::evaluate_univariate;
+use binius_transcript::{
+	VerifierTranscript,
+	fiat_shamir::{CanSample, Challenger},
+};
+
+use crate::protocols::sumcheck::{self, Error, SumcheckOutput};
+
+/// The reduced output of a sumcheck verification.
+///
+/// The [`batch_verify`] function reduces a set of claims on multivariate polynomials over the
+/// boolean hypercube to their evaluation at a challenge point. See the function docstring for
+/// details.
+pub struct BatchSumcheckOutput<F: Field> {
+	/// The challenge value of the batching variable.
+	pub batch_coeff: F,
+	/// The evaluation of the sumcheck multivariate at the challenge point.
+	pub eval: F,
+	/// Verifier challenges for each round of the sumcheck protocol.
+	///
+	/// One challenge is generated per variable in the multivariate polynomial,
+	/// with challenges\[i\] corresponding to the i-th round of the protocol.
+	///
+	/// Note: reverse when folding high-to-low to obtain evaluation claim.
+	pub challenges: Vec<F>,
+}
+
+/// Verify a batched sumcheck protocol interaction.
+///
+/// The batched sumcheck verifier reduces a set of claims about the sums of multivariate polynomials
+/// over the boolean hypercube to their evaluation at a (shared) challenge point. This is achieved
+/// by constructing an `n_vars + 1`-variate polynomial whose coefficients in the "new variable" are
+/// the individual sum claims and evaluating it at a random point.
+pub fn batch_verify<F: Field, Challenger_: Challenger>(
+	n_vars: usize,
+	degree: usize,
+	sums: &[F],
+	transcript: &mut VerifierTranscript<Challenger_>,
+) -> Result<BatchSumcheckOutput<F>, Error> {
+	let batch_coeff = transcript.sample();
+	let sum = evaluate_univariate(sums, batch_coeff);
+
+	let SumcheckOutput { eval, challenges } = sumcheck::verify(n_vars, degree, sum, transcript)?;
+
+	Ok(BatchSumcheckOutput {
+		batch_coeff,
+		challenges,
+		eval,
+	})
+}

--- a/crates/verifier/src/protocols/sumcheck/common.rs
+++ b/crates/verifier/src/protocols/sumcheck/common.rs
@@ -113,9 +113,3 @@ impl<F: Field> RoundProof<F> {
 		&self.0.0
 	}
 }
-
-#[derive(Debug, PartialEq, Eq)]
-pub struct BatchSumcheckOutput<F: Field> {
-	pub challenges: Vec<F>,
-	pub multilinear_evals: Vec<Vec<F>>,
-}

--- a/crates/verifier/src/protocols/sumcheck/mod.rs
+++ b/crates/verifier/src/protocols/sumcheck/mod.rs
@@ -1,9 +1,11 @@
 // Copyright 2023-2025 Irreducible Inc.
 
+mod batch;
 pub mod common;
 mod error;
 mod verify;
 
+pub use batch::*;
 pub use common::{RoundCoeffs, RoundProof};
 pub use error::*;
 pub use verify::*;


### PR DESCRIPTION
It just doesn't belong here.
Also moved the version with `multilinear_evals` to prover crate as we already handle claims on multilinears somewhat manually in the verifier.