### PR TITLE
[frontend] Fix last_msg_block_index in sha256 circuit

### DIFF
--- a/crates/zkl/snapshots/stat_output.snap
+++ b/crates/zkl/snapshots/stat_output.snap
@@ -12,10 +12,10 @@ config: Config {
 }
 --
 Number of gates: 818551
-Number of AND constraints: 1138868
+Number of AND constraints: 1138871
 Number of MUL constraints: 26945
 Length of value vec: 2097152
   Constants: 620
   Inout: 133
   Witness: 190227
-  Internal: 1070084
+  Internal: 1070090


### PR DESCRIPTION
## Note

The next PR in the stack contains a simpler version of the ` last_msg_block_index` constraint that we might want to use instead. I'm including this version separately so it's easier to see the bug.

## Description

In the sha256 circuit the last_msg_block_index was being computed
incorrectly. There were two overlapping issues:

1. Negations were being computed using builder.bxor(..., one) instead of
  builder.bxor(..., all_ones)
2. Subtraction by 1 was computed using xor with 1

This meant that the computation for (e.g) 256 byte messages was
incorrect:

- len_div_64 = 256 / 64 = 4
- at_boundary = true (256 % 64 == 0)

Thus last_msg_block_index was computed incorrectly as: 4 XOR 1 = 5,
where it should be 4 - 1 = 3.

The existing constraints work fine for messages up-to 128 bytes. But
messages using in zklogin JWTs are larger than this.

This PR fixes the negations and computes the subtraction using
iadd_cin_cout.

