### PR TITLE
[frontend] Simplify sha256 last_msg_block_index

### DIFF
--- a/crates/zkl/snapshots/stat_output.snap
+++ b/crates/zkl/snapshots/stat_output.snap
@@ -11,11 +11,11 @@ config: Config {
     max_len_t_max: 48,
 }
 --
-Number of gates: 819669
-Number of AND constraints: 1140299
+Number of gates: 819651
+Number of AND constraints: 1140281
 Number of MUL constraints: 26945
 Length of value vec: 2097152
   Constants: 624
   Inout: 133
   Witness: 190506
-  Internal: 1071199
+  Internal: 1071181


### PR DESCRIPTION
For empty messages the last_msg_block_index is 0.

For non-empty messages we can compute last_msg_block_index by
computing (len - 1) / 64.

This is simpler to understand than the exsting constraints.