### PR TITLE
[verify] Specialize high-level protocol for BinaryMerkleTreeScheme

### DIFF
--- a/crates/prover/tests/prove_verify.rs
+++ b/crates/prover/tests/prove_verify.rs
@@ -15,21 +15,19 @@ use binius_verifier::{
 	Params,
 	config::StdChallenger,
 	hash::{StdCompression, StdDigest},
-	merkle_tree::BinaryMerkleTreeScheme,
 	verify,
 };
 
 fn prove_verify(cs: ConstraintSystem, witness: ValueVec) {
 	const LOG_INV_RATE: usize = 1;
 
-	let merkle_scheme = BinaryMerkleTreeScheme::<_, StdDigest, _>::new(StdCompression::default());
-	let params = Params::new(&cs, LOG_INV_RATE, merkle_scheme).unwrap();
+	let params = Params::new(&cs, LOG_INV_RATE, StdCompression::default()).unwrap();
 
 	let ntt = SingleThreadedNTT::with_subspace(params.fri_params().rs_code().subspace()).unwrap();
 	let merkle_prover = BinaryMerkleTreeProver::<_, StdDigest, _>::new(StdCompression::default());
 
 	let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
-	prove::<OptimalPackedB128, _, _, _, _>(
+	prove::<OptimalPackedB128, _, _, _, _, _>(
 		&params,
 		&cs,
 		witness.clone(),

--- a/crates/verifier/src/merkle_tree/scheme.rs
+++ b/crates/verifier/src/merkle_tree/scheme.rs
@@ -17,7 +17,7 @@ use super::{
 };
 use crate::hash::{PseudoCompressionFunction, hash_serialize};
 
-#[derive(Debug, Getters)]
+#[derive(Debug, Clone, Getters)]
 pub struct BinaryMerkleTreeScheme<T, H, C> {
 	#[getset(get = "pub")]
 	compression: C,
@@ -39,6 +39,7 @@ impl<F, H, C> MerkleTreeScheme<F> for BinaryMerkleTreeScheme<F, H, C>
 where
 	F: Field,
 	H: Digest + BlockSizeUser,
+	// TODO: Remove Sync trait here
 	C: PseudoCompressionFunction<Output<H>, 2> + Sync,
 {
 	type Digest = Output<H>;


### PR DESCRIPTION
There are no other MerkleTreeScheme implementations, and this makes the
high-level interface more intuitive.