### PR TITLE
[frontend] constraint system creation

### DIFF
--- a/crates/core/src/constraint_system.rs
+++ b/crates/core/src/constraint_system.rs
@@ -136,13 +136,18 @@ pub struct ConstraintSystem {
 }
 
 impl ConstraintSystem {
-	pub fn new(constants: Vec<Word>, value_vec_layout: ValueVecLayout) -> Self {
+	pub fn new(
+		constants: Vec<Word>,
+		value_vec_layout: ValueVecLayout,
+		and_constraints: Vec<AndConstraint>,
+		mul_constraints: Vec<MulConstraint>,
+	) -> Self {
 		assert_eq!(constants.len(), value_vec_layout.n_const);
 		ConstraintSystem {
 			constants,
 			value_vec_layout,
-			and_constraints: Vec::new(),
-			mul_constraints: Vec::new(),
+			and_constraints,
+			mul_constraints,
 		}
 	}
 

--- a/crates/frontend/ceck/src/randblast.rs
+++ b/crates/frontend/ceck/src/randblast.rs
@@ -129,22 +129,25 @@ mod tests {
 			offset_witness: 4, // next power of 2 after constants
 			total_len: 8,      // next power of 2 after all values
 		};
-		let mut lhs =
-			ConstraintSystem::new(vec![Word(0), Word(u64::MAX)], value_vec_layout.clone());
-		let mut rhs = ConstraintSystem::new(vec![Word(0), Word(u64::MAX)], value_vec_layout);
-
 		// Both implement: v0 & v1 ^ v2 = 0
+		let constraint = AndConstraint::plain_abc(
+			vec![ValueIndex(2)], // v0
+			vec![ValueIndex(3)], // v1
+			vec![ValueIndex(4)], // v2
+		);
 
-		lhs.add_and_constraint(AndConstraint::plain_abc(
-			vec![ValueIndex(2)], // v0
-			vec![ValueIndex(3)], // v1
-			vec![ValueIndex(4)], // v2
-		));
-		rhs.add_and_constraint(AndConstraint::plain_abc(
-			vec![ValueIndex(2)], // v0
-			vec![ValueIndex(3)], // v1
-			vec![ValueIndex(4)], // v2
-		));
+		let lhs = ConstraintSystem::new(
+			vec![Word(0), Word(u64::MAX)],
+			value_vec_layout.clone(),
+			vec![constraint.clone()],
+			vec![],
+		);
+		let rhs = ConstraintSystem::new(
+			vec![Word(0), Word(u64::MAX)],
+			value_vec_layout,
+			vec![constraint],
+			vec![],
+		);
 
 		let mut blaster = RandBlast::new(0);
 		let result = blaster.test_equivalence(&lhs, &rhs, 100);
@@ -165,25 +168,35 @@ mod tests {
 			offset_witness: 4, // next power of 2 after constants
 			total_len: 8,      // next power of 2 after all values
 		};
-		let mut lhs =
-			ConstraintSystem::new(vec![Word(0), Word(u64::MAX)], value_vec_layout.clone());
-		let mut rhs = ConstraintSystem::new(vec![Word(0), Word(u64::MAX)], value_vec_layout);
-
 		// LHS: ZERO & ZERO ^ ZERO = 0 (always satisfied)
-		lhs.add_and_constraint(AndConstraint::plain_abc(
+		let lhs_constraint = AndConstraint::plain_abc(
 			vec![ValueIndex(0)], // ZERO
 			vec![ValueIndex(0)], // ZERO
 			vec![ValueIndex(0)], // ZERO
-		));
+		);
 
 		// RHS: ALL_ONE & ALL_ONE ^ ZERO = 0
-		// This is never satisfied since ALL_ONE & ALL_ONE = ALL_ONE, and ALL_ONE ^ ZERO = ALL_ONE
-		// != 0
-		rhs.add_and_constraint(AndConstraint::plain_abc(
+		// This is never satisfied since:
+		//
+		// ALL_ONE & ALL_ONE = ALL_ONE, and ALL_ONE ^ ZERO = ALL_ONE != 0
+		let rhs_constraint = AndConstraint::plain_abc(
 			vec![ValueIndex(1)], // ALL_ONE
 			vec![ValueIndex(1)], // ALL_ONE
 			vec![ValueIndex(0)], // ZERO
-		));
+		);
+
+		let lhs = ConstraintSystem::new(
+			vec![Word(0), Word(u64::MAX)],
+			value_vec_layout.clone(),
+			vec![lhs_constraint],
+			vec![],
+		);
+		let rhs = ConstraintSystem::new(
+			vec![Word(0), Word(u64::MAX)],
+			value_vec_layout,
+			vec![rhs_constraint],
+			vec![],
+		);
 
 		// LHS is always satisfied, RHS is never satisfied
 		// They are definitely not equivalent

--- a/crates/frontend/ceck/src/translate.rs
+++ b/crates/frontend/ceck/src/translate.rs
@@ -135,14 +135,12 @@ impl Context {
 
 		let constants = self.literals.keys().map(|&lit| Word(lit)).collect();
 
-		let mut cs = ConstraintSystem::new(constants, self.value_vec_layout.clone().unwrap());
-		for constraint in and_constraints {
-			cs.add_and_constraint(constraint);
-		}
-		for constraint in mul_constraints {
-			cs.add_mul_constraint(constraint);
-		}
-		cs
+		ConstraintSystem::new(
+			constants,
+			self.value_vec_layout.clone().unwrap(),
+			and_constraints,
+			mul_constraints,
+		)
 	}
 
 	fn convert_term(&self, term: &Term) -> ShiftedValueIndex {

--- a/crates/frontend/src/circuits/base64.rs
+++ b/crates/frontend/src/circuits/base64.rs
@@ -558,7 +558,7 @@ mod tests {
 
 		// Verify constraints
 		let cs = compiled.constraint_system();
-		verify_constraints(&cs, &witness.into_value_vec())?;
+		verify_constraints(cs, &witness.into_value_vec())?;
 
 		Ok(())
 	}

--- a/crates/frontend/src/circuits/bignum/tests.rs
+++ b/crates/frontend/src/circuits/bignum/tests.rs
@@ -105,7 +105,7 @@ fn test_mul_single_case() {
 	}
 
 	// Verify all constraints are satisfied
-	verify_constraints(&cs.constraint_system(), &w.into_value_vec()).unwrap();
+	verify_constraints(cs.constraint_system(), &w.into_value_vec()).unwrap();
 }
 
 proptest! {
@@ -155,7 +155,7 @@ proptest! {
 			);
 		}
 
-		verify_constraints(&cs.constraint_system(), &w.into_value_vec()).unwrap();
+		verify_constraints(cs.constraint_system(), &w.into_value_vec()).unwrap();
 	}
 
 	#[test]
@@ -193,7 +193,7 @@ proptest! {
 			"Multiplication failed: {a_big} * {b_big} = {result_big} (expected {expected})"
 		);
 
-		verify_constraints(&cs.constraint_system(), &w.into_value_vec()).unwrap();
+		verify_constraints(cs.constraint_system(), &w.into_value_vec()).unwrap();
 	}
 
 	#[test]
@@ -222,7 +222,7 @@ proptest! {
 			"Squaring failed: {a_big}^2 = {result_big} (expected {expected})"
 		);
 
-		verify_constraints(&cs.constraint_system(), &w.into_value_vec()).unwrap();
+		verify_constraints(cs.constraint_system(), &w.into_value_vec()).unwrap();
 	}
 
 	#[test]
@@ -248,7 +248,7 @@ proptest! {
 
 		assert_eq!(square_big, mul_big, "square(a) != mul(a,a): {square_big} != {mul_big}");
 
-		verify_constraints(&cs.constraint_system(), &w.into_value_vec()).unwrap();
+		verify_constraints(cs.constraint_system(), &w.into_value_vec()).unwrap();
 	}
 
 	#[test]
@@ -269,7 +269,7 @@ proptest! {
 		}
 
 		cs.populate_wire_witness(&mut w).unwrap();
-		verify_constraints(&cs.constraint_system(), &w.into_value_vec()).unwrap();
+		verify_constraints(cs.constraint_system(), &w.into_value_vec()).unwrap();
 	}
 
 	#[test]
@@ -347,7 +347,7 @@ proptest! {
 			"ModReduce failed: {a_big} != {quotient_big} * {modulus_big} + {remainder_big}"
 		);
 
-		verify_constraints(&cs.constraint_system(), &w.into_value_vec()).unwrap();
+		verify_constraints(cs.constraint_system(), &w.into_value_vec()).unwrap();
 	}
 
 	#[test]

--- a/crates/frontend/src/circuits/concat.rs
+++ b/crates/frontend/src/circuits/concat.rs
@@ -510,7 +510,7 @@ mod tests {
 
 		// Verify constraints
 		let cs = circuit.constraint_system();
-		verify_constraints(&cs, &filler.into_value_vec())?;
+		verify_constraints(cs, &filler.into_value_vec())?;
 
 		Ok(())
 	}

--- a/crates/frontend/src/circuits/jwt_claims.rs
+++ b/crates/frontend/src/circuits/jwt_claims.rs
@@ -338,7 +338,7 @@ mod tests {
 
 		// Verify constraints
 		let cs = circuit.constraint_system();
-		verify_constraints(&cs, &filler.into_value_vec()).unwrap();
+		verify_constraints(cs, &filler.into_value_vec()).unwrap();
 	}
 
 	#[test]
@@ -394,7 +394,7 @@ mod tests {
 
 		// Verify constraints
 		let cs = circuit.constraint_system();
-		verify_constraints(&cs, &filler.into_value_vec()).unwrap();
+		verify_constraints(cs, &filler.into_value_vec()).unwrap();
 	}
 
 	#[test]
@@ -512,7 +512,7 @@ mod tests {
 
 		// Verify constraints
 		let cs = circuit.constraint_system();
-		verify_constraints(&cs, &filler.into_value_vec()).unwrap();
+		verify_constraints(cs, &filler.into_value_vec()).unwrap();
 	}
 
 	#[test]
@@ -549,7 +549,7 @@ mod tests {
 
 		// Verify constraints
 		let cs = circuit.constraint_system();
-		verify_constraints(&cs, &filler.into_value_vec()).unwrap();
+		verify_constraints(cs, &filler.into_value_vec()).unwrap();
 	}
 
 	#[test]
@@ -596,7 +596,7 @@ mod tests {
 
 		// Verify constraints
 		let cs = circuit.constraint_system();
-		verify_constraints(&cs, &filler.into_value_vec()).unwrap();
+		verify_constraints(cs, &filler.into_value_vec()).unwrap();
 	}
 
 	#[test]
@@ -643,6 +643,6 @@ mod tests {
 
 		// Verify constraints
 		let cs = circuit.constraint_system();
-		verify_constraints(&cs, &filler.into_value_vec()).unwrap();
+		verify_constraints(cs, &filler.into_value_vec()).unwrap();
 	}
 }

--- a/crates/frontend/src/circuits/rs256.rs
+++ b/crates/frontend/src/circuits/rs256.rs
@@ -487,7 +487,7 @@ mod tests {
 		populate_circuit(&circuit, &mut w, &signature_bytes, message, &modulus_bytes);
 
 		cs.populate_wire_witness(&mut w).unwrap();
-		verify_constraints(&cs.constraint_system(), &w.into_value_vec()).unwrap();
+		verify_constraints(cs.constraint_system(), &w.into_value_vec()).unwrap();
 	}
 
 	#[test]

--- a/crates/frontend/src/circuits/sha256/compress.rs
+++ b/crates/frontend/src/circuits/sha256/compress.rs
@@ -271,7 +271,7 @@ mod tests {
 		}
 		circuit.populate_wire_witness(&mut w).unwrap();
 
-		verify_constraints(&cs, &w.into_value_vec()).unwrap();
+		verify_constraints(cs, &w.into_value_vec()).unwrap();
 	}
 
 	#[test]
@@ -317,7 +317,7 @@ mod tests {
 		}
 		circuit.populate_wire_witness(&mut w).unwrap();
 
-		verify_constraints(&cs, &w.into_value_vec()).unwrap();
+		verify_constraints(cs, &w.into_value_vec()).unwrap();
 	}
 
 	#[test]
@@ -351,6 +351,6 @@ mod tests {
 		}
 		circuit.populate_wire_witness(&mut w).unwrap();
 
-		verify_constraints(&cs, &w.into_value_vec()).unwrap();
+		verify_constraints(cs, &w.into_value_vec()).unwrap();
 	}
 }

--- a/crates/frontend/src/circuits/sha256/mod.rs
+++ b/crates/frontend/src/circuits/sha256/mod.rs
@@ -591,7 +591,7 @@ mod tests {
 		c.populate_digest(&mut w, expected_digest);
 
 		circuit.populate_wire_witness(&mut w).unwrap();
-		verify_constraints(&cs, &w.into_value_vec()).unwrap();
+		verify_constraints(cs, &w.into_value_vec()).unwrap();
 	}
 
 	#[test]

--- a/crates/frontend/src/circuits/slice.rs
+++ b/crates/frontend/src/circuits/slice.rs
@@ -363,7 +363,7 @@ mod tests {
 
 		// Verify constraints
 		let cs = circuit.constraint_system();
-		verify_constraints(&cs, &filler.into_value_vec()).unwrap();
+		verify_constraints(cs, &filler.into_value_vec()).unwrap();
 	}
 
 	#[test]
@@ -411,7 +411,7 @@ mod tests {
 
 		// Verify constraints
 		let cs = circuit.constraint_system();
-		verify_constraints(&cs, &filler.into_value_vec()).unwrap();
+		verify_constraints(cs, &filler.into_value_vec()).unwrap();
 	}
 
 	#[test]
@@ -489,7 +489,7 @@ mod tests {
 
 		// Verify constraints
 		let cs = circuit.constraint_system();
-		verify_constraints(&cs, &filler.into_value_vec()).unwrap();
+		verify_constraints(cs, &filler.into_value_vec()).unwrap();
 	}
 
 	#[test]
@@ -526,7 +526,7 @@ mod tests {
 
 		// Verify constraints
 		let cs = circuit.constraint_system();
-		verify_constraints(&cs, &filler.into_value_vec()).unwrap();
+		verify_constraints(cs, &filler.into_value_vec()).unwrap();
 	}
 
 	#[test]
@@ -599,7 +599,7 @@ mod tests {
 
 		// Verify constraints
 		let cs = circuit.constraint_system();
-		verify_constraints(&cs, &filler.into_value_vec()).unwrap();
+		verify_constraints(cs, &filler.into_value_vec()).unwrap();
 	}
 
 	#[test]
@@ -649,7 +649,7 @@ mod tests {
 
 				// Verify constraints
 				let cs = circuit.constraint_system();
-				verify_constraints(&cs, &filler.into_value_vec()).unwrap();
+				verify_constraints(cs, &filler.into_value_vec()).unwrap();
 			}
 		}
 	}
@@ -781,7 +781,7 @@ mod tests {
 
 		// Verify constraints
 		let cs = circuit.constraint_system();
-		verify_constraints(&cs, &filler.into_value_vec()).unwrap();
+		verify_constraints(cs, &filler.into_value_vec()).unwrap();
 	}
 
 	#[test]
@@ -863,6 +863,6 @@ mod tests {
 
 		// Verify constraints
 		let cs = circuit.constraint_system();
-		verify_constraints(&cs, &filler.into_value_vec()).unwrap();
+		verify_constraints(cs, &filler.into_value_vec()).unwrap();
 	}
 }

--- a/crates/frontend/src/compiler/tests.rs
+++ b/crates/frontend/src/compiler/tests.rs
@@ -167,7 +167,7 @@ fn prop_check_icmp_ult(a: u64, b: u64, expected_result: Word) {
 	assert_eq!(w[result_wire], expected_result);
 
 	let cs = circuit.constraint_system();
-	verify_constraints(&cs, &w.value_vec).unwrap();
+	verify_constraints(cs, &w.value_vec).unwrap();
 }
 
 fn prop_check_icmp_eq(a: u64, b: u64, expected_result: Word) {
@@ -183,7 +183,7 @@ fn prop_check_icmp_eq(a: u64, b: u64, expected_result: Word) {
 	assert_eq!(w[result_wire], expected_result);
 
 	let cs = circuit.constraint_system();
-	verify_constraints(&cs, &w.value_vec).unwrap();
+	verify_constraints(cs, &w.value_vec).unwrap();
 }
 
 proptest! {
@@ -221,7 +221,7 @@ proptest! {
 		assert_eq!(w[cout2_wire], Word(expected_cout2));
 
 		let cs = circuit.constraint_system();
-		verify_constraints(&cs, &w.value_vec).unwrap();
+		verify_constraints(cs, &w.value_vec).unwrap();
 	}
 
 	#[test]
@@ -254,7 +254,7 @@ proptest! {
 			assert!(result.is_ok());
 			// And constraints should verify
 			let cs = circuit.constraint_system();
-			verify_constraints(&cs, &w.value_vec).unwrap();
+			verify_constraints(cs, &w.value_vec).unwrap();
 		} else {
 			// When values are not equal, witness population should fail
 			assert!(result.is_err());

--- a/crates/prover/tests/prove_verify.rs
+++ b/crates/prover/tests/prove_verify.rs
@@ -75,5 +75,5 @@ fn test_prove_verify_sha256_preimage() {
 	}
 	circuit.populate_wire_witness(&mut w).unwrap();
 
-	prove_verify(circuit.constraint_system(), w.into_value_vec())
+	prove_verify(circuit.constraint_system().clone(), w.into_value_vec())
 }


### PR DESCRIPTION
Refactors constraint system creation and puts it into the `build` method so
centralizing the conversion between the circuit representation and the
constraint system representation. This sets the stage for further optimization
like constraint selection.