### PR TITLE
[frontend] fix slice gadget

### DIFF
--- a/crates/zkl/snapshots/stat_output.snap
+++ b/crates/zkl/snapshots/stat_output.snap
@@ -11,11 +11,11 @@ config: Config {
     max_len_t_max: 48,
 }
 --
-Number of gates: 818551
-Number of AND constraints: 1138871
+Number of gates: 819666
+Number of AND constraints: 1140296
 Number of MUL constraints: 26945
 Length of value vec: 2097152
-  Constants: 620
+  Constants: 624
   Inout: 133
-  Witness: 190227
-  Internal: 1070090
+  Witness: 190506
+  Internal: 1071199


### PR DESCRIPTION
This fix ensures that:
1. Any word containing bytes beyond len_slice has its invalid bytes
   checked to be zero
2. Valid bytes are properly masked and compared with the extracted data

This prevents accepting slices with garbage data in positions that
should be zero-padded.