### PR TITLE
prove first phase of shift reduction

### DIFF
--- a/crates/prover/src/protocols/shift/mod.rs
+++ b/crates/prover/src/protocols/shift/mod.rs
@@ -8,3 +8,4 @@ mod phase_1;
 mod prove;
 pub use key_collection::*;
 pub use monster::*;
+pub use phase_1::*;

--- a/crates/prover/src/protocols/shift/monster.rs
+++ b/crates/prover/src/protocols/shift/monster.rs
@@ -161,7 +161,7 @@ pub fn build_monster_multilinear<F: BinaryField, P: PackedField<Scalar = F>>(
 							(&intmul_operator_data.r_x_prime_tensor, &intmul_scalars)
 						}
 					};
-					key.accumulate(&key_collection.constraint_indices, tensor)
+					key.accumulate(&key_collection.constraint_indices, tensor.as_ref())
 						* scalars[key.id as usize]
 				})
 				.sum()

--- a/crates/prover/src/protocols/shift/prove.rs
+++ b/crates/prover/src/protocols/shift/prove.rs
@@ -1,5 +1,10 @@
 // Copyright 2025 Irreducible Inc.
 
+use binius_field::Field;
+use binius_math::{
+	FieldBuffer, multilinear::eq::eq_ind_partial_eval, univariate::evaluate_univariate,
+};
+
 /// Holds the prover data for an operator.
 ///
 /// Contains evaluation claims and challenge points for an operation.
@@ -12,11 +17,38 @@
 /// During proving, the prover samples `lambda` for operand weighting and computes the
 /// tensor expansion of `r_x_prime` for efficient proving in both phases.
 #[derive(Debug, Clone)]
-pub struct OperatorData<F> {
+pub struct OperatorData<F: Field> {
 	pub evals: Vec<F>,
 	pub r_zhat_prime: F,
 	pub r_x_prime: Vec<F>,
 	// These fields filled at runtime
-	pub r_x_prime_tensor: Vec<F>,
+	pub r_x_prime_tensor: FieldBuffer<F>,
 	pub lambda: F,
+}
+
+impl<F: Field> OperatorData<F> {
+	// Constructs a new operator data instance encoding
+	// evaluation claim with univariate challenge `r_zhat_prime`
+	// multilinear challenge `r_x_prime`, and evaluations `evals`
+	// with one eval for each operand of the operation.
+	pub fn new(r_zhat_prime: F, r_x_prime: Vec<F>, evals: Vec<F>) -> Self {
+		let r_x_prime_tensor = eq_ind_partial_eval::<F>(&r_x_prime);
+
+		Self {
+			evals,
+			lambda: F::ZERO,
+			r_zhat_prime,
+			r_x_prime,
+			r_x_prime_tensor,
+		}
+	}
+
+	/// Returns the batched evaluation of the oblong evaluation claims.
+	/// Since the univariate evaluation of the evals at lambda is
+	/// further multiplied by lambda, the batched evaluation claims
+	/// for different operators can soundly be added without further
+	/// random scaling.
+	pub fn batched_eval(&self) -> F {
+		self.lambda * evaluate_univariate(&self.evals, self.lambda)
+	}
 }


### PR DESCRIPTION
### TL;DR

Implement phase 1 of the shift reduction protocol, including sumcheck proving functionality.

### What changed?

- Exported the `phase_1` module in the shift protocol
- Implemented `prove_phase_1` function to handle the first phase of the shift reduction protocol
- Added `run_phase_1_sumcheck` to execute the sumcheck protocol over bivariate products
- Enhanced `OperatorData` with a constructor and a `batched_eval` method
- Added `tensor_expand_scalar` utility function to expand vectors into multilinear tensors
- Integrated the sumcheck protocol with the transcript system for challenge generation

### How to test?

The implementation can be tested by:
1. Running the shift protocol test suite
2. Verifying that the sumcheck protocol correctly proves the claimed evaluations
3. Checking that the phase 1 proof generates valid challenges and evaluation points

### Why make this change?

This change completes a critical part of the shift protocol implementation, enabling the prover to generate valid proofs for shift operations. The phase 1 implementation handles the reduction of shift constraints to multilinear evaluation claims through sumcheck, which is essential for the overall zero-knowledge proof system.