### PR TITLE
[examples] Create SHA-256 example program

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ sha2 = "0.10.8"
 thiserror = "2.0.3"
 transpose = "0.2.2"
 tracing = "0.1.38"
+tracing-profile = "0.10.9"
 trait-set = "0.3.0"
 z3 = "0.13.3"
 

--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "binius-examples"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+anyhow.workspace = true
+binius-core = { path = "../core" }
+binius-frontend = { path = "../frontend" }
+binius-verifier = { path = "../verifier" }
+binius-prover = { path = "../prover", default-features = false }
+tracing.workspace = true
+tracing-profile.workspace = true
+
+[features]
+default = ["rayon"]
+perfetto = ["tracing-profile/perfetto"]
+rayon = ["binius-prover/rayon"]

--- a/crates/examples/examples/sha256.rs
+++ b/crates/examples/examples/sha256.rs
@@ -1,0 +1,59 @@
+use binius_core::word::Word;
+use binius_examples::{prove_verify, setup};
+use binius_frontend::{
+	circuits::sha256::{Compress, State},
+	compiler,
+	compiler::Wire,
+};
+
+fn main() {
+	let _tracing_guard = tracing_profile::init_tracing().unwrap();
+
+	let build_scope = tracing::info_span!("Building circuit").entered();
+
+	// Use the test-vector for SHA256 single block message: "abc".
+	let mut preimage: [u8; 64] = [0; 64];
+	preimage[0..3].copy_from_slice(b"abc");
+	preimage[3] = 0x80;
+	preimage[63] = 0x18;
+
+	#[rustfmt::skip]
+	let expected_state: [u32; 8] = [
+		0xba7816bf, 0x8f01cfea, 0x414140de, 0x5dae2223,
+		0xb00361a3, 0x96177a9c, 0xb410ff61, 0xf20015ad,
+	];
+
+	let circuit = compiler::CircuitBuilder::new();
+	let state = State::iv(&circuit);
+	let input: [Wire; 16] = std::array::from_fn(|_| circuit.add_witness());
+	let output: [Wire; 8] = std::array::from_fn(|_| circuit.add_inout());
+	let compress = Compress::new(&circuit, state, input);
+
+	// Mask to only low 32-bit.
+	let mask32 = circuit.add_constant(Word::MASK_32);
+	for (actual_x, expected_x) in compress.state_out.0.iter().zip(output) {
+		circuit.assert_eq("eq", circuit.band(*actual_x, mask32), expected_x);
+	}
+
+	let circuit = circuit.build();
+	drop(build_scope);
+
+	const LOG_INV_RATE: usize = 1;
+	let cs = circuit.constraint_system().clone();
+	let (verifier, prover) = setup(cs, LOG_INV_RATE).unwrap();
+
+	let witness = tracing::info_span!("Generating witness").in_scope(|| {
+		let mut w = circuit.new_witness_filler();
+
+		// Populate the input message for the compression function.
+		compress.populate_m(&mut w, preimage);
+
+		for (i, &output) in output.iter().enumerate() {
+			w[output] = Word(expected_state[i] as u64);
+		}
+		circuit.populate_wire_witness(&mut w).unwrap();
+		w.into_value_vec()
+	});
+
+	prove_verify(&verifier, &prover, witness).unwrap();
+}

--- a/crates/examples/src/lib.rs
+++ b/crates/examples/src/lib.rs
@@ -1,0 +1,32 @@
+use anyhow::Result;
+use binius_core::constraint_system::{ConstraintSystem, ValueVec};
+use binius_prover::{OptimalPackedB128, Prover};
+use binius_verifier::{
+	Verifier,
+	config::StdChallenger,
+	hash::{StdCompression, StdDigest},
+	transcript::ProverTranscript,
+};
+
+pub type StdVerifier = Verifier<StdDigest, StdCompression>;
+pub type StdProver = Prover<OptimalPackedB128, StdCompression, StdDigest>;
+
+pub fn setup(cs: ConstraintSystem, log_inv_rate: usize) -> Result<(StdVerifier, StdProver)> {
+	let _scope = tracing::info_span!("Setup", log_inv_rate).entered();
+	let verifier = Verifier::<StdDigest, _>::setup(cs, log_inv_rate, StdCompression::default())?;
+	let prover = Prover::<OptimalPackedB128, _, StdDigest>::setup(verifier.clone())?;
+	Ok((verifier, prover))
+}
+
+pub fn prove_verify(verifier: &StdVerifier, prover: &StdProver, witness: ValueVec) -> Result<()> {
+	let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
+	tracing::info_span!("Proving")
+		.in_scope(|| prover.prove(witness.clone(), &mut prover_transcript))?;
+
+	let mut verifier_transcript = prover_transcript.into_verifier();
+	tracing::info_span!("Verifying")
+		.in_scope(|| verifier.verify(witness.public(), &mut verifier_transcript))?;
+	verifier_transcript.finalize()?;
+
+	Ok(())
+}

--- a/crates/prover/src/lib.rs
+++ b/crates/prover/src/lib.rs
@@ -10,5 +10,6 @@ pub mod protocols;
 mod prove;
 pub mod ring_switch;
 
+pub use binius_field::arch::OptimalPackedB128;
 pub use error::*;
 pub use prove::*;

--- a/crates/verifier/src/lib.rs
+++ b/crates/verifier/src/lib.rs
@@ -9,5 +9,6 @@ pub mod protocols;
 pub mod ring_switch;
 mod verify;
 
+pub use binius_transcript as transcript;
 pub use error::*;
 pub use verify::*;


### PR DESCRIPTION
Create an `examples/` crate. Examples binaries with command line flags for tweaking params are easy to run and pull in the prover crate for end-to-end testing.