### PR TITLE
[pcs] Store the multilinear with its packed evaluations

### DIFF
--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -166,12 +166,8 @@ where
 		// PCS opening
 		let evaluation_point = [z_challenge, y_challenge].concat();
 
-		// Convert witness_packed to PackedSubfield view for OneBitPCSProver
-		let witness_packed_subfield_buffer = cast_bases_to_buffer(&witness_packed);
-
 		let _scope = tracing::debug_span!("PCS open").entered();
-		let pcs_prover =
-			OneBitPCSProver::new(witness_packed_subfield_buffer, witness_eval, evaluation_point)?;
+		let pcs_prover = OneBitPCSProver::new(witness_packed, evaluation_point);
 
 		pcs_prover.prove_with_transcript(
 			transcript,
@@ -184,18 +180,6 @@ where
 
 		Ok(())
 	}
-}
-
-/// Helper function to convert cast_bases result to FieldBuffer
-fn cast_bases_to_buffer<P>(
-	packed: &FieldBuffer<P>,
-) -> FieldBuffer<<P as PackedExtension<B1>>::PackedSubfield>
-where
-	P: PackedExtension<B1>,
-{
-	let subfield = <P as PackedExtension<B1>>::cast_bases(packed.as_ref());
-	let values: Vec<_> = subfield.iter().flat_map(|p| p.iter()).collect();
-	FieldBuffer::from_values(&values).expect("cast_bases should produce power-of-2 length")
 }
 
 fn pack_witness<P: PackedField<Scalar = B128>>(

--- a/crates/prover/src/ring_switch.rs
+++ b/crates/prover/src/ring_switch.rs
@@ -1,5 +1,7 @@
 // Copyright 2025 Irreducible Inc.
 
+use std::ops::Deref;
+
 use binius_field::{
 	BinaryField, ExtensionField, Field, PackedExtension, PackedField, PackedSubfield,
 };
@@ -73,13 +75,14 @@ where
 ///
 /// * the length of the matrix, in `B1` elements, must equal vector length, in `F` elements, times
 ///   the field extension degree
-pub fn fold_1b_rows<F, P>(
-	mat: &FieldBuffer<PackedSubfield<P, B1>>,
+pub fn fold_1b_rows<F, P, Data>(
+	mat: &FieldBuffer<PackedSubfield<P, B1>, Data>,
 	vec: &FieldBuffer<P>,
 ) -> FieldBuffer<F>
 where
 	F: BinaryField,
 	P: PackedExtension<B1> + PackedField<Scalar = F>,
+	Data: Deref<Target = [PackedSubfield<P, B1>]>,
 {
 	let log_scalar_bit_width = <F as ExtensionField<B1>>::LOG_DEGREE;
 	assert_eq!(mat.log_len(), log_scalar_bit_width + vec.log_len()); // precondition
@@ -237,7 +240,7 @@ mod test {
 
 		// Method 3: Tensor expand suffix, call fold_1b_rows, then evaluate_inplace on prefix
 		let suffix_tensor = eq_ind_partial_eval::<P>(suffix);
-		let folded_method3 = fold_1b_rows::<F, P>(&bit_matrix, &suffix_tensor);
+		let folded_method3 = fold_1b_rows(&bit_matrix, &suffix_tensor);
 		let method3_result = evaluate_inplace(folded_method3, prefix).unwrap();
 
 		// Compare all three results


### PR DESCRIPTION
This removes conversions and simplifies lots of trait bounds.