### PR TITLE
Pseudo Mersenne modular reduction constraint.

### DIFF
--- a/crates/frontend/src/circuits/bignum/biguint.rs
+++ b/crates/frontend/src/circuits/bignum/biguint.rs
@@ -25,6 +25,34 @@ impl BigUint {
 		BigUint { limbs }
 	}
 
+	/// Pads to given limb length with a wire value.
+	///
+	/// No-op if `new_limbs_len` is shorter then the current one.
+	pub fn pad_limbs_to(&self, new_limbs_len: usize, padding_value: Wire) -> Self {
+		let mut padded_limbs = self.limbs.clone();
+		if new_limbs_len > padded_limbs.len() {
+			padded_limbs.resize(new_limbs_len, padding_value);
+		}
+		Self {
+			limbs: padded_limbs,
+		}
+	}
+
+	/// Splits the `BigUint` at a given limb position into `(lo, hi)`. The result
+	/// satisfies `lo + 2^(WORD_SIZE_BITS * lo.limbs.len()) * hi`.
+	pub fn split_at_limbs(mut self, at_limbs: usize) -> (Self, Self) {
+		let hi_limbs = self.limbs.split_off(at_limbs);
+		(self, Self { limbs: hi_limbs })
+	}
+
+	/// Concatenate the limbs of another `BigUint` on top. The resulting value
+	/// equals `self + 2^(WORD_SIZE_BITS * self.limbs.len()) * hi`.
+	pub fn concat_limbs(&self, hi: &Self) -> Self {
+		let mut limbs = self.limbs.clone();
+		limbs.extend(&hi.limbs);
+		Self { limbs }
+	}
+
 	/// Populate the BigUint with the expected limb_values
 	///
 	/// Panics if limb_values.len() != self.limbs.len()

--- a/crates/frontend/src/circuits/bignum/mod.rs
+++ b/crates/frontend/src/circuits/bignum/mod.rs
@@ -4,7 +4,7 @@
 //! where each `Wire` represents a 64-bit limb. The representation uses little-endian ordering,
 //! meaning the least significant limb is at index 0.
 
-mod add;
+mod addsub;
 mod biguint;
 mod mul;
 mod reduce;
@@ -12,7 +12,7 @@ mod reduce;
 #[cfg(test)]
 mod tests;
 
-pub use add::add;
+pub use addsub::{add, sub};
 pub use biguint::{BigUint, assert_eq};
 pub use mul::{mul, square};
-pub use reduce::ModReduce;
+pub use reduce::{ModReduce, PseudoMersenneModReduce};

--- a/crates/frontend/src/circuits/bignum/mul.rs
+++ b/crates/frontend/src/circuits/bignum/mul.rs
@@ -1,4 +1,4 @@
-use super::{add::compute_stack_adds, biguint::BigUint};
+use super::{addsub::compute_stack_adds, biguint::BigUint};
 use crate::compiler::CircuitBuilder;
 
 /// Multiply two arbitrary-sized `BigUint`s.

--- a/crates/frontend/src/circuits/bignum/reduce.rs
+++ b/crates/frontend/src/circuits/bignum/reduce.rs
@@ -1,11 +1,14 @@
 use binius_core::word::Word;
 
 use super::{
-	add::add,
+	addsub::{add, sub},
 	biguint::{BigUint, assert_eq},
 	mul::mul,
 };
 use crate::compiler::CircuitBuilder;
+
+/// TODO: this should be moved from binius-verifier to binius-core
+const WORD_SIZE_BITS: usize = 64;
 
 /// Modular reduction verification for BigUint.
 ///
@@ -42,23 +45,107 @@ impl ModReduce {
 
 		let product = mul(builder, &quotient, &modulus);
 
-		let mut remainder_padded = remainder.limbs.clone();
-		remainder_padded.resize(product.limbs.len(), zero);
-		let remainder_padded = BigUint {
-			limbs: remainder_padded,
-		};
-
+		let remainder_padded = remainder.pad_limbs_to(product.limbs.len(), zero);
 		let reconstructed = add(builder, &product, &remainder_padded);
 
-		let mut a_padded = a.limbs.clone();
-		a_padded.resize(reconstructed.limbs.len(), zero);
-		let a_padded = BigUint { limbs: a_padded };
-
-		assert_eq(builder, "modreduce_a_eq_reconstructed", &reconstructed, &a_padded);
+		let n_limbs = reconstructed.limbs.len().max(a.limbs.len());
+		assert_eq(
+			builder,
+			"modreduce_a_eq_reconstructed",
+			&reconstructed.pad_limbs_to(n_limbs, zero),
+			&a.pad_limbs_to(n_limbs, zero),
+		);
 
 		ModReduce {
 			a,
 			modulus,
+			quotient,
+			remainder,
+		}
+	}
+}
+
+/// Modular reduction verification for BigUint for pseudo Mersenne moduli.
+///
+/// This circuit verifies that:
+///
+/// a = quotient * (2^modulus_po2 - modulus_subtrahend) + remainder
+///
+/// where modulus_po2 is additionally restricted to be a multiple of limb size to only
+/// split BigUint at limb boundaries.
+///
+/// This algorithm is more efficient than `ModReduce` when `modulus_subtrahend` is a short
+/// compared to `modulus_po2`. This is the case for many practically interesting prime field.
+pub struct PseudoMersenneModReduce {
+	pub a: BigUint,
+	pub modulus_subtrahend: BigUint,
+	pub quotient: BigUint,
+	pub remainder: BigUint,
+}
+
+impl PseudoMersenneModReduce {
+	/// Creates a new pseudo Mersenne modular reduction verifier circuit.
+	///
+	/// # Arguments
+	/// * `builder` - Circuit builder for constraint generation
+	/// * `a` - The dividend
+	/// * `modulus_po2` - the power of two modulus minuend (has to be a multiple of
+	///   `WORD_SIZE_BITS`)
+	/// * `modulus_subtrahend` - the value subtracted form `2^modulus_po2` to obtain modulus
+	/// * `quotient` - The quotient
+	/// * `remainder` - The remainder
+	///
+	/// # Constraints
+	/// The circuit enforces that `a = quotient * (2^modulus_po2 - modulus_subtrahend) + remainder`
+	pub fn new(
+		builder: &CircuitBuilder,
+		a: BigUint,
+		modulus_po2: usize,
+		modulus_subtrahend: BigUint,
+		quotient: BigUint,
+		remainder: BigUint,
+	) -> Self {
+		// a = quotient * (2^modulus_po2 - modulus_subtrahend) + remainder
+		// hi * 2^modulus_po2 + lo = quotient * (2^modulus_po2 - modulus_subtrahend) + remainder
+		// lo + quotient * modulus_subtrahend = remainder + 2^modulus_po2 * (quotient - hi)
+		// max(lo, remainder) < 2^modulus_po2
+		// quotient < |a/(2^modulus_po2 - modulus_subtrahend)|
+		// quotient >= hi
+		assert!(modulus_po2.is_multiple_of(WORD_SIZE_BITS));
+		assert!(modulus_subtrahend.limbs.len() * WORD_SIZE_BITS <= modulus_po2);
+		assert!(remainder.limbs.len() * WORD_SIZE_BITS <= modulus_po2);
+
+		let zero = builder.add_constant(Word::ZERO);
+
+		let n_lo_limbs = modulus_po2 / WORD_SIZE_BITS;
+
+		let (a_lo, a_hi) = a.pad_limbs_to(n_lo_limbs, zero).split_at_limbs(n_lo_limbs);
+
+		let rhs_hi = sub(builder, &quotient, &a_hi.pad_limbs_to(quotient.limbs.len(), zero));
+		let rhs = remainder
+			.pad_limbs_to(n_lo_limbs, zero)
+			.concat_limbs(&rhs_hi);
+
+		let quotient_modulus_subtrahend = mul(builder, &quotient, &modulus_subtrahend);
+		let lhs_rhs_len = [
+			rhs.limbs.len(),
+			quotient_modulus_subtrahend.limbs.len() + 1,
+			a_lo.limbs.len() + 1,
+		]
+		.into_iter()
+		.max()
+		.expect("exactly 3 elements");
+
+		let lhs = add(
+			builder,
+			&a_lo.pad_limbs_to(lhs_rhs_len, zero),
+			&quotient_modulus_subtrahend.pad_limbs_to(lhs_rhs_len, zero),
+		);
+
+		assert_eq(builder, "modreduce_pseudo_mersenne", &lhs, &rhs.pad_limbs_to(lhs_rhs_len, zero));
+		Self {
+			a,
+			modulus_subtrahend,
 			quotient,
 			remainder,
 		}

--- a/crates/zkl/snapshots/stat_output.snap
+++ b/crates/zkl/snapshots/stat_output.snap
@@ -11,8 +11,8 @@ config: Config {
     max_len_t_max: 48,
 }
 --
-Number of gates: 819666
-Number of AND constraints: 1140296
+Number of gates: 819669
+Number of AND constraints: 1140299
 Number of MUL constraints: 26945
 Length of value vec: 2097152
   Constants: 624


### PR DESCRIPTION
Add a more efficient modular reduction to cater for the needs of both secp256k1 `Fp` (which is a pseudo Mersenne with a 1 limb subtrahend) and scalar field (two limbs).