### PR TITLE
[frontend] Change rs256 to use inputs with little-endian wire packing

### DIFF
--- a/crates/frontend/src/circuits/fixed_byte_vec.rs
+++ b/crates/frontend/src/circuits/fixed_byte_vec.rs
@@ -2,13 +2,14 @@ use binius_core::word::Word;
 
 use crate::{
 	compiler::{CircuitBuilder, Wire, circuit::WitnessFiller},
-	util::pack_bytes_into_wires_be,
+	util::pack_bytes_into_wires_le,
 };
 
 /// A vector of bytes of an arbitrary size up to and including the configured `max_len`.
 ///
 /// The bytes are tightly packed into wires, where each wire packs up to 8 bytes. This constrains
 /// the maximum size of the vector to be a multiple of 8.
+#[derive(Clone)]
 pub struct FixedByteVec {
 	/// Maximum length of the vector in bytes.
 	pub max_len: usize,
@@ -18,6 +19,16 @@ pub struct FixedByteVec {
 }
 
 impl FixedByteVec {
+	/// Creates a new fixed byte vector using the given wires and wire
+	/// containing the length of the data in bytes.
+	pub fn new(data: Vec<Wire>, len: Wire) -> Self {
+		Self {
+			max_len: data.len() * 8,
+			len,
+			data,
+		}
+	}
+
 	/// Creates a new fixed byte vector with the given maximum length as inout wires.
 	///
 	/// # Panics
@@ -44,12 +55,28 @@ impl FixedByteVec {
 
 	/// Populate the FixedByteVec with bytes.
 	///
-	/// This method packs bytes into 64-bit words using big-endian ordering,
+	/// This method packs bytes into 64-bit words using little-endian ordering,
 	///
 	/// # Panics
 	/// * If bytes.len() exceeds self.max_len
-	pub fn populate_bytes_be(&self, w: &mut WitnessFiller, bytes: &[u8]) {
-		pack_bytes_into_wires_be(w, &self.data, bytes);
+	pub fn populate_bytes_le(&self, w: &mut WitnessFiller, bytes: &[u8]) {
+		pack_bytes_into_wires_le(w, &self.data, bytes);
 		w[self.len] = Word(bytes.len() as u64);
+	}
+
+	/// Construct a new FixedByteVec by truncating to `num_bytes`.
+	///
+	/// # Panics
+	/// * If num_bytes exceeds self.max_len
+	/// * If num_bytes is not a multiple of 8
+	pub fn truncate(&self, b: &CircuitBuilder, num_bytes: usize) -> FixedByteVec {
+		assert!(num_bytes <= self.max_len, "num_bytes must be less than self.max_len");
+		assert!(num_bytes.is_multiple_of(8), "num_bytes must be a multiple of 8");
+
+		let num_wires = num_bytes / 8;
+		let trimmed_wires = self.data[0..num_wires].to_vec();
+		let len_wire = b.add_constant_64(num_bytes as u64);
+
+		FixedByteVec::new(trimmed_wires, len_wire)
 	}
 }

--- a/crates/frontend/src/util.rs
+++ b/crates/frontend/src/util.rs
@@ -66,10 +66,7 @@ fn time_witness_population(circuit: &Circuit) {
 	println!("fill_witness took {} microseconds", elapsed.as_micros());
 }
 
-/// Populate the given wires with packed 64-bit words from a byte slice.
-///
-/// The packing strategy is determined by the provided `pack` function, which takes
-/// an up-to-8-byte slice and returns a `u64` value.
+/// Populate the given wires from bytes using little-endian packed 64-bit words.
 ///
 /// If `bytes` is not a multiple of 8, the last word is zero-padded.
 ///
@@ -78,12 +75,7 @@ fn time_witness_population(circuit: &Circuit) {
 ///
 /// # Panics
 /// * If bytes.len() exceeds wires.len() * 8
-fn pack_bytes_into_wires(
-	w: &mut WitnessFiller,
-	wires: &[Wire],
-	bytes: &[u8],
-	pack: fn(&[u8]) -> u64,
-) {
+pub fn pack_bytes_into_wires_le(w: &mut WitnessFiller, wires: &[Wire], bytes: &[u8]) {
 	let max_value_size = wires.len() * 8;
 	assert!(
 		bytes.len() <= max_value_size,
@@ -95,8 +87,11 @@ fn pack_bytes_into_wires(
 	// Pack bytes into words
 	for (i, chunk) in bytes.chunks(8).enumerate() {
 		if i < wires.len() {
-			let word = pack(chunk);
-			w[wires[i]] = Word(word);
+			let mut word = 0u64;
+			for (j, &byte) in chunk.iter().enumerate() {
+				word |= (byte as u64) << (j * 8)
+			}
+			w[wires[i]] = Word(word)
 		}
 	}
 
@@ -104,44 +99,4 @@ fn pack_bytes_into_wires(
 	for i in bytes.len().div_ceil(8)..wires.len() {
 		w[wires[i]] = Word::ZERO;
 	}
-}
-
-/// Populate the given wires from bytes using little-endian packed 64-bit words.
-///
-/// If `bytes` is not a multiple of 8, the last word is zero-padded.
-///
-/// If there are more wires than needed to hold all bytes, the remaining wires
-/// are filled with `Word::ZERO`.
-///
-/// # Panics
-/// * If bytes.len() exceeds wires.len() * 8
-pub(crate) fn pack_bytes_into_wires_le(w: &mut WitnessFiller, wires: &[Wire], bytes: &[u8]) {
-	fn pack_le(chunk: &[u8]) -> u64 {
-		let mut word = 0u64;
-		for (j, &byte) in chunk.iter().enumerate() {
-			word |= (byte as u64) << (j * 8)
-		}
-		word
-	}
-	pack_bytes_into_wires(w, wires, bytes, pack_le);
-}
-
-/// Populate the given wires from bytes using big-endian packed 64-bit words.
-///
-/// If `bytes` is not a multiple of 8, the last word is zero-padded.
-///
-/// If there are more wires than needed to hold all bytes, the remaining wires
-/// are filled with `Word::ZERO`.
-///
-/// # Panics
-/// * If bytes.len() exceeds wires.len() * 8
-pub(crate) fn pack_bytes_into_wires_be(w: &mut WitnessFiller, wires: &[Wire], bytes: &[u8]) {
-	fn pack_be(chunk: &[u8]) -> u64 {
-		let mut word = 0u64;
-		for (j, &byte) in chunk.iter().enumerate() {
-			word |= (byte as u64) << ((7 - j) * 8)
-		}
-		word
-	}
-	pack_bytes_into_wires(w, wires, bytes, pack_be);
 }

--- a/crates/zkl/snapshots/stat_output.snap
+++ b/crates/zkl/snapshots/stat_output.snap
@@ -11,11 +11,11 @@ config: Config {
     max_len_t_max: 48,
 }
 --
-Number of gates: 819651
-Number of AND constraints: 1140281
-Number of MUL constraints: 26945
+Number of gates: 821210
+Number of AND constraints: 1141618
+Number of MUL constraints: 26880
 Length of value vec: 2097152
   Constants: 624
   Inout: 133
   Witness: 190506
-  Internal: 1071181
+  Internal: 1072107


### PR DESCRIPTION
The other circuits that rs256 must work with (e.g base64 and concat) in zklogin use little-endian wire packing. 

To make integration simpler with those
circuits this PR changes rs256 to work with little-endian wire packing
inputs. Internally these wires are converted to big-endian packed wires
for compatibility with BigUint.