### PR TITLE
[ci] Don't compile tests, benchmarks, examples for WASM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
             rustflags: "-C debug-assertions"
           - name: "wasm-build"
             command: |
-              cargo build -p binius-math -p binius-field -p binius-prover -p binius-verifier --benches --tests --all-features --examples --target wasm32-wasip1
+              cargo build -p binius-math -p binius-field -p binius-prover -p binius-verifier --target wasm32-wasip1
             rust-target: "wasm32-wasip1"
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
Dev dependencies may not compile on WASM, and that's OK.