### PR TITLE
integrate BitAnd, IntMul, Shift, PCS

### DIFF
--- a/crates/prover/src/and_reduction/prover.rs
+++ b/crates/prover/src/and_reduction/prover.rs
@@ -6,6 +6,7 @@ use binius_transcript::{
 };
 use binius_verifier::{
 	and_reduction::{
+		AndCheckOutput,
 		univariate::univariate_poly::{GenericPo2UnivariatePoly, UnivariatePolyIsomorphic},
 		utils::constants::{ROWS_PER_HYPERCUBE_VERTEX, SKIPPED_VARS},
 	},
@@ -35,21 +36,6 @@ where
 	small_field_zerocheck_challenges: Vec<PNTTDomain::Scalar>,
 	univariate_round_message: [FChallenge; ROWS_PER_HYPERCUBE_VERTEX],
 	univariate_round_message_domain: BinarySubspace<FChallenge>,
-}
-
-/// Output from the AND reduction proving protocol.
-///
-/// Contains the results after completing both phases of the AND reduction protocol:
-/// the univariate polynomial verification and the multilinear sumcheck reduction.
-pub struct ProveAndReductionOutput<F: Field> {
-	/// The output from the multilinear sumcheck protocol, containing:
-	/// - The final evaluation claim
-	/// - The challenges used in each round
-	/// - The multilinear evaluations at the query point
-	pub sumcheck_output: ProveSingleOutput<F>,
-	/// The challenge value z sampled for Z after the univariate polynomial phase.
-	/// This challenge is used to fold the oblong multilinears before the sumcheck phase.
-	pub univariate_sumcheck_challenge: F,
 }
 
 impl<FChallenge, PNTTDomain> OblongZerocheckProver<FChallenge, PNTTDomain>
@@ -249,7 +235,7 @@ where
 	pub fn prove_with_transcript<TranscriptChallenger>(
 		self,
 		transcript: &mut ProverTranscript<TranscriptChallenger>,
-	) -> Result<ProveAndReductionOutput<FChallenge>, Error>
+	) -> Result<AndCheckOutput<FChallenge>, Error>
 	where
 		TranscriptChallenger: Challenger,
 	{
@@ -268,12 +254,23 @@ where
 			)
 		});
 
-		let sumcheck_output = tracing::debug_span!("MLE-check remaining rounds")
+		let ProveSingleOutput {
+			multilinear_evals: mle_claims,
+			challenges: mut eval_point,
+		} = tracing::debug_span!("MLE-check remaining rounds")
 			.in_scope(|| prove_single_mlecheck(sumcheck_prover, transcript))?;
 
-		Ok(ProveAndReductionOutput {
-			sumcheck_output,
-			univariate_sumcheck_challenge,
+		eval_point.reverse();
+
+		assert_eq!(mle_claims.len(), 3);
+		transcript.message().write_slice(&mle_claims);
+
+		Ok(AndCheckOutput {
+			a_eval: mle_claims[0],
+			b_eval: mle_claims[1],
+			c_eval: mle_claims[2],
+			z_challenge: univariate_sumcheck_challenge,
+			eval_point,
 		})
 	}
 }
@@ -287,10 +284,12 @@ mod test {
 	use binius_math::{BinarySubspace, multilinear::evaluate::evaluate};
 	use binius_transcript::{ProverTranscript, fiat_shamir::CanSample};
 	use binius_verifier::{
-		and_reduction::{utils::constants::SKIPPED_VARS, verifier::verify_with_transcript},
+		and_reduction::{
+			utils::constants::SKIPPED_VARS,
+			verifier::{AndCheckOutput, verify_with_transcript},
+		},
 		config::{B128, StdChallenger},
 	};
-	use itertools::Itertools;
 	use rand::{Rng, SeedableRng, rngs::StdRng};
 
 	use super::OblongZerocheckProver;
@@ -329,8 +328,8 @@ mod test {
 				.map(|(&a, &b)| a & b)
 				.collect(),
 		};
-		// Agreed-upon proof parameter
 
+		// Agreed-upon proof parameter
 		let prover_message_domain =
 			BinarySubspace::<AESTowerField8b>::with_dim(SKIPPED_VARS + 1).unwrap();
 		let verifier_message_domain = prover_message_domain.isomorphic();
@@ -351,18 +350,7 @@ mod test {
 			.prove_with_transcript(&mut prover_challenger)
 			.unwrap();
 
-		let l2h_query_for_evaluation_point = prove_output
-			.sumcheck_output
-			.challenges
-			.clone()
-			.into_iter()
-			.rev()
-			.collect_vec();
-
-		prover_challenger
-			.message()
-			.write_slice(&prove_output.sumcheck_output.multilinear_evals);
-
+		// Verifier is instantiated
 		let mut verifier_challenger = prover_challenger.into_verifier();
 
 		let big_field_zerocheck_challenges =
@@ -378,17 +366,22 @@ mod test {
 			all_zerocheck_challenges.push(*big_field_challenge);
 		}
 
-		let output = verify_with_transcript(
+		let verify_output = verify_with_transcript(
 			&all_zerocheck_challenges,
 			&mut verifier_challenger,
 			verifier_message_domain.clone(),
 		)
 		.unwrap();
 
-		let verifier_mle_eval_claims = verifier_challenger
-			.message()
-			.read_scalar_slice::<B128>(3)
-			.unwrap();
+		assert_eq!(prove_output, verify_output);
+
+		let AndCheckOutput {
+			a_eval,
+			b_eval,
+			c_eval,
+			z_challenge,
+			eval_point,
+		} = verify_output;
 
 		let verifier_univariate_domain = verifier_message_domain
 			.reduce_dim(SKIPPED_VARS)
@@ -397,28 +390,13 @@ mod test {
 		let one_bit_mlvs = [first_mlv, second_mlv, third_mlv];
 
 		let verifier_transparent_fold_lookup =
-			FoldLookup::new(&verifier_univariate_domain, output.univariate_sumcheck_challenge);
-		for (i, eval) in verifier_mle_eval_claims.iter().enumerate().take(3) {
+			FoldLookup::new(&verifier_univariate_domain, z_challenge);
+		for (i, eval) in [a_eval, b_eval, c_eval].iter().enumerate() {
 			assert_eq!(
-				evaluate(
-					&one_bit_mlvs[i].fold(&verifier_transparent_fold_lookup),
-					&l2h_query_for_evaluation_point
-				)
-				.unwrap(),
+				evaluate(&one_bit_mlvs[i].fold(&verifier_transparent_fold_lookup), &eval_point)
+					.unwrap(),
 				*eval
 			);
 		}
-
-		assert_eq!(
-			output.sumcheck_output.eval,
-			verifier_mle_eval_claims[0] * verifier_mle_eval_claims[1] - verifier_mle_eval_claims[2]
-		);
-
-		// Sanity checks, but not necessary verifier assertions
-		assert_eq!(output.sumcheck_output.challenges, prove_output.sumcheck_output.challenges);
-		assert_eq!(
-			output.univariate_sumcheck_challenge,
-			prove_output.univariate_sumcheck_challenge
-		);
 	}
 }

--- a/crates/prover/src/error.rs
+++ b/crates/prover/src/error.rs
@@ -2,7 +2,10 @@
 
 use binius_math::ntt;
 
-use crate::{fri, protocols::sumcheck};
+use crate::{
+	fri,
+	protocols::{intmul, shift, sumcheck},
+};
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -16,4 +19,8 @@ pub enum Error {
 	Fri(#[from] fri::Error),
 	#[error("transcript error: {0}")]
 	Transcript(#[from] binius_transcript::Error),
+	#[error("integer multiplication error: {0}")]
+	IntMul(#[from] intmul::Error),
+	#[error("shift reduction error: {0}")]
+	ShiftReduction(#[from] shift::Error),
 }

--- a/crates/prover/src/protocols/intmul/error.rs
+++ b/crates/prover/src/protocols/intmul/error.rs
@@ -2,23 +2,6 @@
 
 use crate::protocols::sumcheck::Error as SumcheckError;
 
-#[derive(Debug, Clone, Copy)]
-pub enum SumcheckErrorContext {
-	Execute,
-	Fold,
-	Finish,
-}
-
-impl Error {
-	pub fn from_sumcheck_new(error: SumcheckError) -> Self {
-		Error::Sumcheck(error, SumcheckErrorContext::Execute)
-	}
-
-	pub fn from_sumcheck_batch(error: SumcheckError) -> Self {
-		Error::Sumcheck(error, SumcheckErrorContext::Execute)
-	}
-}
-
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
 	#[error("Exponent length should be a power of two")]
@@ -27,40 +10,8 @@ pub enum Error {
 	ExponentLengthMismatch,
 	#[error("transcript error")]
 	Transcript(#[from] binius_transcript::Error),
-	#[error("length mismatch: {0} != {1}")]
-	LengthMismatch(usize, usize),
-	#[error("twisted eval points count ({0}) does not match claims count ({1})")]
-	TwistedPointsEvalsMismatch(usize, usize),
-	#[error("layer length ({0}) does not match pairs count ({1})")]
-	LayerClaimsMismatch(usize, usize),
-	#[error("composition claim mismatch")]
-	CompositionClaimMismatch,
-	#[error("final claims count ({0}) does not match pairs count * 2 ({1})")]
-	FinalClaimsPairsMismatch(usize, usize),
-	#[error("round coeffs count ({0}) does not match pairs count ({1})")]
-	RoundCoeffsPairsMismatch(usize, usize),
-	#[error("sumcheck error: {0} ({1:?})")]
-	Sumcheck(SumcheckError, SumcheckErrorContext),
-	#[error("buffer log len ({0}) and eval point len ({1}) mismatch")]
-	BufferEvalPointMismatch(usize, usize),
-	#[error("layer pairs count ({0}) does not match claims count ({1})")]
-	LayerPairsCountClaimsMismatch(usize, usize),
-	#[error("eval point and buffer log len mismatch")]
-	EvalPointBufferLengthMismatch,
-	#[error("multilinears do not have equal number of variables")]
-	MultilinearSizeMismatch,
-	#[error("number of eval claims does not match the number of multilinears")]
-	EvalClaimsNumberMismatch,
-	#[error("expected execute() call")]
-	ExpectedExecute,
-	#[error("expected fold() call")]
-	ExpectedFold,
-	#[error("expected finish() call")]
-	ExpectedFinish,
+	#[error("sumcheck error: {0}")]
+	Sumcheck(#[from] SumcheckError),
 	#[error("math error: {0}")]
 	Math(#[from] binius_math::Error),
-	#[error("layers empty")]
-	LayersEmpty,
-	#[error("last layer empty")]
-	LastLayerEmpty,
 }

--- a/crates/prover/src/protocols/intmul/mod.rs
+++ b/crates/prover/src/protocols/intmul/mod.rs
@@ -4,5 +4,7 @@ mod error;
 pub mod prove;
 pub mod witness;
 
+pub use error::Error;
+
 #[cfg(test)]
 mod tests;

--- a/crates/prover/src/protocols/intmul/prove.rs
+++ b/crates/prover/src/protocols/intmul/prove.rs
@@ -3,15 +3,21 @@
 use std::marker::PhantomData;
 
 use binius_field::{BinaryField, PackedField};
-use binius_math::{field_buffer::FieldBuffer, multilinear::evaluate::evaluate};
+use binius_math::{
+	BinarySubspace, field_buffer::FieldBuffer, multilinear::evaluate::evaluate,
+	univariate::lagrange_evals,
+};
 use binius_transcript::{
 	ProverTranscript,
 	fiat_shamir::{CanSample, Challenger},
 };
 use binius_utils::bitwise::Bitwise;
-use binius_verifier::protocols::intmul::common::{
-	IntMulOutput, Phase1Output, Phase2Output, Phase3Output, Phase4Output, Phase5Output,
-	frobenius_twist, make_phase_3_output, normalize_a_c_exponent_evals,
+use binius_verifier::{
+	config::LOG_WORD_SIZE_BITS,
+	protocols::intmul::common::{
+		IntMulOutput, Phase1Output, Phase2Output, Phase3Output, Phase4Output, Phase5Output,
+		frobenius_twist, make_phase_3_output, normalize_a_c_exponent_evals,
+	},
 };
 use either::Either;
 use itertools::{Itertools, izip};
@@ -98,20 +104,21 @@ where
 		let b_eval = evaluate(&b_root, &initial_eval_point)?;
 		let c_eval = evaluate(&c_root, &initial_eval_point)?;
 
-		self.transcript.message().write_scalar(b_eval);
-		self.transcript.message().write_scalar(c_eval);
+		let mut writer = self.transcript.message();
+		writer.write_scalar(b_eval);
+		writer.write_scalar(c_eval);
 
-		// phase 1
+		// Phase 1
 		let Phase1Output {
 			eval_point: phase1_eval_point,
 			b_leaves_evals,
 		} = self.phase1(log_bits, &initial_eval_point, (b_eval, b_layers.into_iter()))?;
 
-		// phase 2
+		// Phase 2
 		let Phase2Output { twisted_claims } =
 			frobenius_twist(log_bits, &phase1_eval_point, &b_leaves_evals);
 
-		// splitting
+		// Splitting
 		let (_, a_root, mut a_layers) = a.split();
 		let (_, c_lo_root, mut c_lo_layers) = c_lo.split();
 		let (_, c_hi_root, mut c_hi_layers) = c_hi.split();
@@ -120,7 +127,7 @@ where
 		let c_lo_last_layer = c_lo_layers.pop().expect("log_bits >= 1");
 		let c_hi_last_layer = c_hi_layers.pop().expect("log_bits >= 1");
 
-		// phase 3
+		// Phase 3
 		let Phase3Output {
 			eval_point: phase3_eval_point,
 			b_exponent_evals,
@@ -137,7 +144,7 @@ where
 			c_eval,
 		)?;
 
-		// phase 4
+		// Phase 4
 		let Phase4Output {
 			eval_point: phase4_eval_point,
 			a_evals,
@@ -151,7 +158,7 @@ where
 			(c_hi_root_eval, c_hi_layers.into_iter()),
 		)?;
 
-		// phase 5
+		// Phase 5
 		let Phase5Output {
 			eval_point: phase5_eval_point,
 			scaled_a_c_exponent_evals,
@@ -167,16 +174,24 @@ where
 			&b_exponent_evals,
 		)?;
 
-		// normalize_a_c_exponent_evals
-		let (a_exponent_evals, c_lo_exponent_evals, c_hi_exponent_evals) =
+		let [a_exponent_evals, c_lo_exponent_evals, c_hi_exponent_evals] =
 			normalize_a_c_exponent_evals(log_bits, scaled_a_c_exponent_evals);
 
+		// Phase 6
+		let z_challenge: F = self.transcript.sample();
+		let subspace = BinarySubspace::<F>::with_dim(LOG_WORD_SIZE_BITS)?;
+		let l_tilde = lagrange_evals(&subspace, z_challenge);
+		assert_eq!(l_tilde.len(), a_exponent_evals.len());
+
+		let make_final_claim = |evals| izip!(evals, &l_tilde).map(|(x, y)| x * y).sum();
+
 		Ok(IntMulOutput {
+			z_challenge,
 			eval_point: phase5_eval_point,
-			a_exponent_evals,
-			b_exponent_evals,
-			c_lo_exponent_evals,
-			c_hi_exponent_evals,
+			a_eval: make_final_claim(a_exponent_evals),
+			b_eval: make_final_claim(b_exponent_evals),
+			c_lo_eval: make_final_claim(c_lo_exponent_evals),
+			c_hi_eval: make_final_claim(c_hi_exponent_evals),
 		})
 	}
 
@@ -195,15 +210,14 @@ where
 			assert_eq!(layer.len(), 2 << depth);
 
 			let a_sumcheck_prover =
-				BivariateProductMultiMlecheckProver::new(make_pairs(layer), &eval_point, &evals)
-					.map_err(Error::from_sumcheck_new)?;
+				BivariateProductMultiMlecheckProver::new(make_pairs(layer), &eval_point, &evals)?;
 
 			let a_prover = MleToSumCheckDecorator::new(a_sumcheck_prover);
 
 			let BatchSumcheckOutput {
 				challenges,
 				mut multilinear_evals,
-			} = batch_prove(vec![a_prover], self.transcript).map_err(Error::from_sumcheck_new)?;
+			} = batch_prove(vec![a_prover], self.transcript)?;
 
 			assert_eq!(multilinear_evals.len(), 1);
 
@@ -249,12 +263,10 @@ where
 			.collect();
 
 		let selector_prover =
-			SelectorMlecheckProver::new(selector, selector_claims, b_exponents, self.switchover)
-				.map_err(Error::from_sumcheck_new)?;
+			SelectorMlecheckProver::new(selector, selector_claims, b_exponents, self.switchover)?;
 
 		let c_root_sumcheck_prover =
-			BivariateProductMlecheckProver::new(c_lo_hi_roots, c_eval_point, c_root_eval)
-				.map_err(Error::from_sumcheck_new)?;
+			BivariateProductMlecheckProver::new(c_lo_hi_roots, c_eval_point, c_root_eval)?;
 
 		let c_root_prover = MleToSumCheckDecorator::new(c_root_sumcheck_prover);
 
@@ -262,7 +274,7 @@ where
 		let BatchSumcheckOutput {
 			challenges,
 			mut multilinear_evals,
-		} = batch_prove(provers, self.transcript).map_err(Error::from_sumcheck_batch)?;
+		} = batch_prove(provers, self.transcript)?;
 
 		assert_eq!(multilinear_evals.len(), 2);
 		let c_root_prover_evals = multilinear_evals
@@ -299,15 +311,14 @@ where
 
 			let layer = [a_l, c_lo_l, c_hi_l].concat();
 			let sumcheck_prover =
-				BivariateProductMultiMlecheckProver::new(make_pairs(layer), &eval_point, &evals)
-					.map_err(Error::from_sumcheck_new)?;
+				BivariateProductMultiMlecheckProver::new(make_pairs(layer), &eval_point, &evals)?;
 
 			let prover = MleToSumCheckDecorator::new(sumcheck_prover);
 
 			let BatchSumcheckOutput {
 				challenges,
 				mut multilinear_evals,
-			} = batch_prove(vec![prover], self.transcript).map_err(Error::from_sumcheck_batch)?;
+			} = batch_prove(vec![prover], self.transcript)?;
 
 			assert_eq!(multilinear_evals.len(), 1);
 			eval_point = challenges;
@@ -353,8 +364,7 @@ where
 		let evals = [a_evals, c_lo_evals, c_hi_evals].concat();
 
 		let a_c_sumcheck_prover =
-			BivariateProductMultiMlecheckProver::new(make_pairs(layer), a_c_eval_point, &evals)
-				.map_err(Error::from_sumcheck_new)?;
+			BivariateProductMultiMlecheckProver::new(make_pairs(layer), a_c_eval_point, &evals)?;
 
 		let a_c_prover = MleToSumCheckDecorator::new(a_c_sumcheck_prover);
 
@@ -366,16 +376,14 @@ where
 			b_exponent_evals,
 			b_exponents,
 			self.switchover,
-		)
-		.map_err(Error::from_sumcheck_new)?;
+		)?;
 
 		let b_prover = MleToSumCheckDecorator::new(b_sumcheck_prover);
 
 		let BatchSumcheckOutput {
 			challenges,
 			mut multilinear_evals,
-		} = batch_prove(vec![Either::Left(a_c_prover), Either::Right(b_prover)], self.transcript)
-			.map_err(Error::from_sumcheck_batch)?;
+		} = batch_prove(vec![Either::Left(a_c_prover), Either::Right(b_prover)], self.transcript)?;
 
 		assert_eq!(multilinear_evals.len(), 2);
 		let b_prover_evals = multilinear_evals

--- a/crates/prover/src/protocols/shift/key_collection.rs
+++ b/crates/prover/src/protocols/shift/key_collection.rs
@@ -180,7 +180,7 @@ pub fn build_key_collection(cs: &ConstraintSystem) -> KeyCollection {
 	let bitand_operand_getters: [fn(&AndConstraint) -> &Operand; BITAND_ARITY] =
 		[|c| &c.a, |c| &c.b, |c| &c.c];
 	let intmul_operand_getters: [fn(&MulConstraint) -> &Operand; INTMUL_ARITY] =
-		[|c| &c.a, |c| &c.b, |c| &c.hi, |c| &c.lo];
+		[|c| &c.a, |c| &c.b, |c| &c.lo, |c| &c.hi];
 
 	bitand_operand_getters
 		.iter()

--- a/crates/prover/src/protocols/shift/mod.rs
+++ b/crates/prover/src/protocols/shift/mod.rs
@@ -1,11 +1,14 @@
 // Copyright 2025 Irreducible Inc.
 
+use binius_verifier::protocols::shift::{BITAND_ARITY, INTMUL_ARITY, SHIFT_VARIANT_COUNT};
+
 mod error;
 mod key_collection;
 mod monster;
-use binius_verifier::protocols::shift::{BITAND_ARITY, INTMUL_ARITY, SHIFT_VARIANT_COUNT};
 mod phase_1;
 mod phase_2;
 mod prove;
+
+pub use error::Error;
 pub use key_collection::{KeyCollection, build_key_collection};
 pub use prove::{OperatorData, prove};

--- a/crates/prover/src/protocols/shift/phase_1.rs
+++ b/crates/prover/src/protocols/shift/phase_1.rs
@@ -3,7 +3,7 @@
 use std::{array, ops::Range};
 
 use binius_core::word::Word;
-use binius_field::{BinaryField, Field, PackedField};
+use binius_field::{AESTowerField8b, BinaryField, Field, PackedField};
 use binius_math::{FieldBuffer, inner_product::inner_product_buffers};
 use binius_transcript::{
 	ProverTranscript,
@@ -47,13 +47,16 @@ const LOG_LEN: usize = LOG_WORD_SIZE_BITS + LOG_WORD_SIZE_BITS;
 /// Proves the first phase of the shift reduction.
 /// Computes the g and h multilinears and performs the sumcheck.
 #[instrument(skip_all, name = "prover_phase_1")]
-pub fn prove_phase_1<F: BinaryField, P: PackedField<Scalar = F>, C: Challenger>(
+pub fn prove_phase_1<F, P: PackedField<Scalar = F>, C: Challenger>(
 	key_collection: &KeyCollection,
 	words: &[Word],
 	bitand_data: &OperatorData<F>,
 	intmul_data: &OperatorData<F>,
 	transcript: &mut ProverTranscript<C>,
-) -> Result<SumcheckOutput<F>, Error> {
+) -> Result<SumcheckOutput<F>, Error>
+where
+	F: BinaryField + From<AESTowerField8b>,
+{
 	let [g_triplet_bitand, g_triplet_intmul]: [MultilinearTriplet<P>; 2] =
 		build_g_triplet(words, key_collection, bitand_data, intmul_data)?;
 

--- a/crates/prover/src/protocols/shift/phase_2.rs
+++ b/crates/prover/src/protocols/shift/phase_2.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 Irreducible Inc.
 
 use binius_core::word::Word;
-use binius_field::{BinaryField, Field, PackedField};
+use binius_field::{AESTowerField8b, BinaryField, Field, PackedField};
 use binius_math::{FieldBuffer, multilinear::eq::eq_ind_partial_eval};
 use binius_transcript::{
 	ProverTranscript,
@@ -53,7 +53,7 @@ use crate::{
 /// Returns `SumcheckOutput` containing the combined challenges `[r_j, r_y]` and witness evaluation,
 /// or an error if the protocol fails.
 #[instrument(skip_all, name = "prove_phase_2")]
-pub fn prove_phase_2<F: BinaryField, P: PackedField<Scalar = F>, C: Challenger>(
+pub fn prove_phase_2<F, P: PackedField<Scalar = F>, C: Challenger>(
 	inout_n_vars: usize,
 	key_collection: &KeyCollection,
 	words: &[Word],
@@ -61,7 +61,10 @@ pub fn prove_phase_2<F: BinaryField, P: PackedField<Scalar = F>, C: Challenger>(
 	intmul_data: &OperatorData<F>,
 	phase_1_output: SumcheckOutput<F>,
 	transcript: &mut ProverTranscript<C>,
-) -> Result<SumcheckOutput<F>, Error> {
+) -> Result<SumcheckOutput<F>, Error>
+where
+	F: BinaryField + From<AESTowerField8b>,
+{
 	let SumcheckOutput {
 		challenges: mut r_jr_s,
 		eval: gamma,

--- a/crates/verifier/src/and_reduction/mod.rs
+++ b/crates/verifier/src/and_reduction/mod.rs
@@ -1,3 +1,5 @@
 pub mod univariate;
 pub mod utils;
 pub mod verifier;
+
+pub use verifier::AndCheckOutput;

--- a/crates/verifier/src/error.rs
+++ b/crates/verifier/src/error.rs
@@ -3,7 +3,10 @@
 use binius_core::ConstraintSystemError;
 use binius_math::ntt;
 
-use crate::{fri, pcs, protocols::sumcheck};
+use crate::{
+	fri, pcs,
+	protocols::{shift, sumcheck},
+};
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -25,6 +28,8 @@ pub enum Error {
 	ConstraintSystem(#[from] ConstraintSystemError),
 	#[error("invalid proof: {0}")]
 	Verification(#[from] VerificationError),
+	#[error("shift reduction error: {0}")]
+	ShiftReduction(#[from] shift::Error),
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/verifier/src/protocols/intmul/common.rs
+++ b/crates/verifier/src/protocols/intmul/common.rs
@@ -5,11 +5,12 @@ use itertools::{iterate, izip};
 
 #[derive(Debug, PartialEq)]
 pub struct IntMulOutput<F> {
+	pub z_challenge: F,
 	pub eval_point: Vec<F>,
-	pub a_exponent_evals: Vec<F>,
-	pub b_exponent_evals: Vec<F>,
-	pub c_lo_exponent_evals: Vec<F>,
-	pub c_hi_exponent_evals: Vec<F>,
+	pub a_eval: F,
+	pub b_eval: F,
+	pub c_lo_eval: F,
+	pub c_hi_eval: F,
 }
 
 pub struct Phase1Output<F> {
@@ -96,10 +97,7 @@ pub fn frobenius_twist<F: BinaryField>(
 	Phase2Output { twisted_claims }
 }
 
-pub fn normalize_a_c_exponent_evals<F: BinaryField>(
-	log_bits: usize,
-	evals: Vec<F>,
-) -> (Vec<F>, Vec<F>, Vec<F>) {
+pub fn normalize_a_c_exponent_evals<F: BinaryField>(log_bits: usize, evals: Vec<F>) -> [Vec<F>; 3] {
 	assert_eq!(evals.len(), 3 << log_bits);
 
 	// for i in 0..1 << log_bits: evals[i] = (1-EvalMLE_i)*1 + EvalMLE_i*g^{2^i} =
@@ -134,5 +132,5 @@ pub fn normalize_a_c_exponent_evals<F: BinaryField>(
 		normalize(c_hi_eval, conjugate);
 	}
 
-	(a_scaled_evals, c_lo_scaled_evals, c_hi_scaled_evals)
+	[a_scaled_evals, c_lo_scaled_evals, c_hi_scaled_evals]
 }

--- a/crates/verifier/src/protocols/intmul/error.rs
+++ b/crates/verifier/src/protocols/intmul/error.rs
@@ -2,37 +2,14 @@
 
 use crate::protocols::sumcheck::Error as SumcheckError;
 
-impl Error {
-	pub fn from_transcript_read(error: binius_transcript::Error) -> Self {
-		Error::TranscriptError(error)
-	}
-	pub fn from_sumcheck_verify(error: SumcheckError) -> Self {
-		Error::SumcheckVerifyError(error)
-	}
-}
-
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
+	#[error("math error: {0}")]
+	Math(#[from] binius_math::Error),
 	#[error("transcript error")]
-	TranscriptError(#[from] binius_transcript::Error),
+	Transcript(#[from] binius_transcript::Error),
 	#[error("sumcheck verify error")]
-	SumcheckVerifyError(#[from] SumcheckError),
-	#[error("length mismatch: {0} != {1}")]
-	LengthMismatch(usize, usize),
-	#[error("twisted eval points count ({0}) does not match claims count ({1})")]
-	TwistedPointsEvalsMismatch(usize, usize),
-	#[error("layer length ({0}) does not match pairs count ({1})")]
-	LayerClaimsMismatch(usize, usize),
+	SumcheckVerify(#[from] SumcheckError),
 	#[error("composition claim mismatch")]
 	CompositionClaimMismatch,
-	#[error("final claims count ({0}) does not match pairs count * 2 ({1})")]
-	FinalClaimsPairsMismatch(usize, usize),
-	#[error("round coeffs count ({0}) does not match pairs count ({1})")]
-	RoundCoeffsPairsMismatch(usize, usize),
-	#[error("buffer log len ({0}) and eval point len ({1}) mismatch")]
-	BufferEvalPointMismatch(usize, usize),
-	#[error("layer pairs count ({0}) does not match claims count ({1})")]
-	LayerPairsCountClaimsMismatch(usize, usize),
-	#[error("eval point and buffer log len mismatch")]
-	EvalPointBufferLengthMismatch,
 }

--- a/crates/verifier/src/protocols/intmul/mod.rs
+++ b/crates/verifier/src/protocols/intmul/mod.rs
@@ -2,6 +2,6 @@
 
 pub mod common;
 mod error;
-pub mod verify;
-
-pub use error::*;
+mod verify;
+pub use common::IntMulOutput;
+pub use verify::verify;

--- a/crates/verifier/src/protocols/intmul/verify.rs
+++ b/crates/verifier/src/protocols/intmul/verify.rs
@@ -1,7 +1,11 @@
 // Copyright 2025 Irreducible Inc.
 
 use binius_field::{BinaryField, Field};
-use binius_math::{multilinear::eq::eq_ind, univariate::evaluate_univariate};
+use binius_math::{
+	BinarySubspace,
+	multilinear::eq::eq_ind,
+	univariate::{evaluate_univariate, lagrange_evals},
+};
 use binius_transcript::{
 	VerifierTranscript,
 	fiat_shamir::{CanSample, Challenger},
@@ -15,25 +19,16 @@ use super::{
 	},
 	error::Error,
 };
-use crate::protocols::sumcheck::{BatchSumcheckOutput, batch_verify};
-
-fn read_scalar<F: Field, C: Challenger>(
-	transcript: &mut VerifierTranscript<C>,
-) -> Result<F, Error> {
-	transcript
-		.message()
-		.read_scalar::<F>()
-		.map_err(Error::from_transcript_read)
-}
+use crate::{
+	config::LOG_WORD_SIZE_BITS,
+	protocols::sumcheck::{BatchSumcheckOutput, batch_verify},
+};
 
 fn read_scalar_slice<F: Field, C: Challenger>(
 	transcript: &mut VerifierTranscript<C>,
 	len: usize,
 ) -> Result<Vec<F>, Error> {
-	transcript
-		.message()
-		.read_scalar_slice::<F>(len)
-		.map_err(Error::from_transcript_read)
+	Ok(transcript.message().read_scalar_slice::<F>(len)?)
 }
 
 struct BivariateProductMleLayerOutput<F: Field> {
@@ -297,10 +292,11 @@ pub fn verify<F: BinaryField, C: Challenger>(
 	assert!(log_bits >= 1);
 	let initial_eval_point: Vec<F> = transcript.sample_vec(n_vars);
 
-	let initial_b_eval: F = read_scalar(transcript)?;
-	let initial_c_eval: F = read_scalar(transcript)?;
+	let mut reader = transcript.message();
+	let initial_b_eval: F = reader.read_scalar::<F>()?;
+	let initial_c_eval: F = reader.read_scalar::<F>()?;
 
-	// phase 1
+	// Phase 1
 	let Phase1Output {
 		eval_point: phase_1_eval_point,
 		b_leaves_evals,
@@ -309,10 +305,10 @@ pub fn verify<F: BinaryField, C: Challenger>(
 	assert_eq!(phase_1_eval_point.len(), n_vars);
 	assert_eq!(b_leaves_evals.len(), 1 << log_bits);
 
-	// phase 2
+	// Phase 2
 	let phase2_output = frobenius_twist(log_bits, &phase_1_eval_point, &b_leaves_evals);
 
-	// phase 3
+	// Phase 3
 	let Phase3Output {
 		eval_point: phase_3_eval_point,
 		b_exponent_evals,
@@ -321,7 +317,7 @@ pub fn verify<F: BinaryField, C: Challenger>(
 		c_hi_root_eval,
 	} = verify_phase_3(log_bits, phase2_output, &initial_eval_point, initial_c_eval, transcript)?;
 
-	// phase 4
+	// Phase 4
 	let Phase4Output {
 		eval_point: phase_4_eval_point,
 		a_evals,
@@ -336,7 +332,7 @@ pub fn verify<F: BinaryField, C: Challenger>(
 		transcript,
 	)?;
 
-	// phase 5
+	// Phase 5
 	let Phase5Output {
 		eval_point: phase_5_eval_point,
 		scaled_a_c_exponent_evals,
@@ -352,14 +348,23 @@ pub fn verify<F: BinaryField, C: Challenger>(
 		transcript,
 	)?;
 
-	let (a_exponent_evals, c_lo_exponent_evals, c_hi_exponent_evals) =
+	let [a_exponent_evals, c_lo_exponent_evals, c_hi_exponent_evals] =
 		normalize_a_c_exponent_evals(log_bits, scaled_a_c_exponent_evals);
 
+	// Phase 6
+	let z_challenge: F = transcript.sample();
+	let subspace = BinarySubspace::<F>::with_dim(LOG_WORD_SIZE_BITS)?;
+	let l_tilde = lagrange_evals(&subspace, z_challenge);
+	assert_eq!(l_tilde.len(), a_exponent_evals.len());
+
+	let make_final_claim = |evals| izip!(evals, &l_tilde).map(|(x, y)| x * y).sum();
+
 	Ok(IntMulOutput {
+		z_challenge,
 		eval_point: phase_5_eval_point,
-		a_exponent_evals,
-		b_exponent_evals,
-		c_lo_exponent_evals,
-		c_hi_exponent_evals,
+		a_eval: make_final_claim(a_exponent_evals),
+		b_eval: make_final_claim(b_exponent_evals),
+		c_lo_eval: make_final_claim(c_lo_exponent_evals),
+		c_hi_eval: make_final_claim(c_hi_exponent_evals),
 	})
 }

--- a/crates/verifier/src/protocols/shift/mod.rs
+++ b/crates/verifier/src/protocols/shift/mod.rs
@@ -10,4 +10,5 @@ pub use monster::*;
 mod error;
 mod verify;
 
+pub use error::Error;
 pub use verify::{OperatorData, verify};

--- a/crates/verifier/src/protocols/shift/monster.rs
+++ b/crates/verifier/src/protocols/shift/monster.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 Irreducible Inc.
 
 use binius_core::constraint_system::{Operand, ShiftedValueIndex};
-use binius_field::{BinaryField, Field};
+use binius_field::{AESTowerField8b, BinaryField, Field};
 use binius_math::{
 	BinarySubspace, multilinear::eq::eq_ind_partial_eval, univariate::lagrange_evals,
 };
@@ -120,18 +120,21 @@ fn evaluate_monster_multilinear_term_for_operand<F: Field>(
 /// where $op$ ranges over the shift variants.
 /// This function computes this expression given corresponding `OperatorData`, as well
 /// as $r_j$, $r_s$, and $r_y$.
-pub fn evaluate_monster_multilinear_for_operation<F: BinaryField, const ARITY: usize>(
+pub fn evaluate_monster_multilinear_for_operation<F, const ARITY: usize>(
 	operand_vecs: Vec<Vec<&Operand>>,
 	operator_data: OperatorData<F, ARITY>,
 	r_j: &[F],
 	r_s: &[F],
 	r_y: &[F],
-) -> Result<F, Error> {
+) -> Result<F, Error>
+where
+	F: BinaryField + From<AESTowerField8b>,
+{
 	let r_x_prime_tensor = eq_ind_partial_eval::<F>(&operator_data.r_x_prime);
 	let r_y_tensor = eq_ind_partial_eval::<F>(r_y);
 	let r_s_tensor = eq_ind_partial_eval::<F>(r_s);
 
-	let subspace = BinarySubspace::<F>::with_dim(LOG_WORD_SIZE_BITS)?;
+	let subspace = BinarySubspace::<AESTowerField8b>::with_dim(LOG_WORD_SIZE_BITS)?.isomorphic();
 	let l_tilde = lagrange_evals(&subspace, operator_data.r_zhat_prime);
 	let h_op_evals = evaluate_h_op(&l_tilde, r_j, r_s);
 

--- a/crates/verifier/src/verify.rs
+++ b/crates/verifier/src/verify.rs
@@ -21,7 +21,7 @@ use itertools::Itertools;
 
 use super::{VerificationError, error::Error, pcs};
 use crate::{
-	and_reduction::verifier::{AndReductionOutput, verify_with_transcript},
+	and_reduction::verifier::{AndCheckOutput, verify_with_transcript},
 	config::{
 		B1, B128, LOG_WORD_SIZE_BITS, LOG_WORDS_PER_ELEM, PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES,
 		WORD_SIZE_BITS,
@@ -29,7 +29,11 @@ use crate::{
 	fri::{FRIParams, estimate_optimal_arity},
 	hash::PseudoCompressionFunction,
 	merkle_tree::BinaryMerkleTreeScheme,
-	protocols::pubcheck,
+	protocols::{
+		intmul::{IntMulOutput, verify as verify_intmul_reduction},
+		pubcheck::VerifyOutput,
+		shift::{OperatorData, verify as verify_shift_reduction},
+	},
 };
 
 pub const SECURITY_BITS: usize = 96;
@@ -147,32 +151,58 @@ where
 		// Receive the trace commitment.
 		let trace_commitment = transcript.message().read::<Output<MerkleHash>>()?;
 
-		// verify the and reduction
-		let _output: AndReductionOutput<B128> =
-			run_and_check(self.log_witness_words(), transcript)?;
+		// BitAnd reduction
+		let log_n_and_constraints = checked_log_2(self.constraint_system.n_and_constraints());
+		let bitand_output: AndCheckOutput<B128> =
+			verify_bitand_reduction(log_n_and_constraints, transcript)?;
 
-		// Sample a challenge point during the shift reduction.
-		let z_challenge = transcript.sample_vec(LOG_WORD_SIZE_BITS);
-		let public_input_challenge = transcript.sample_vec(self.log_public_words());
+		// IntMul reduction
+		let log_n_mul_constraints = checked_log_2(self.constraint_system.n_mul_constraints());
+		let intmul_output: IntMulOutput<B128> =
+			verify_intmul_reduction(LOG_WORD_SIZE_BITS, log_n_mul_constraints, transcript).unwrap();
 
-		let pubcheck::VerifyOutput {
+		// Translate from BitAnd and IntMul reduction outputs to Shift reduction inputs
+		let bitand_claim = {
+			let AndCheckOutput {
+				a_eval,
+				b_eval,
+				c_eval,
+				z_challenge,
+				eval_point,
+			} = bitand_output;
+			OperatorData::new(z_challenge, eval_point, [a_eval, b_eval, c_eval])
+		};
+		let intmul_claim = {
+			let IntMulOutput {
+				a_eval,
+				b_eval,
+				c_lo_eval,
+				c_hi_eval,
+				z_challenge,
+				eval_point,
+			} = intmul_output;
+			OperatorData::new(z_challenge, eval_point, [a_eval, b_eval, c_lo_eval, c_hi_eval])
+		};
+
+		// Shift reduction
+		let VerifyOutput {
 			witness_eval,
 			public_eval,
-			eval_point: y_challenge,
-		} = pubcheck::verify(self.log_witness_words(), &public_input_challenge, transcript)?;
+			eval_point,
+		} = verify_shift_reduction(self.constraint_system(), bitand_claim, intmul_claim, transcript)?;
 
+		let (z_challenge, y_challenge) = eval_point.split_at(LOG_WORD_SIZE_BITS);
 		let expected_public_eval =
-			evaluate_public_mle(public, &z_challenge, &y_challenge[..self.log_public_words()]);
+			evaluate_public_mle(public, z_challenge, &y_challenge[..self.log_public_words()]);
 		if public_eval != expected_public_eval {
 			return Err(VerificationError::PublicInputCheckFailed.into());
 		}
 
 		// PCS opening
-		let evaluation_point = [z_challenge, y_challenge].concat();
 		pcs::verify_transcript(
 			transcript,
 			witness_eval,
-			&evaluation_point,
+			&eval_point,
 			trace_commitment,
 			&self.fri_params,
 			&self.merkle_scheme,
@@ -210,15 +240,15 @@ pub fn evaluate_public_mle<F: BinaryField>(public: &[Word], z_coords: &[F], y_co
 		.expect("z_folded_words constructed with log_len = y_coords.len()")
 }
 
-fn run_and_check<F: BinaryField + From<AESTowerField8b>, Challenger_: Challenger>(
-	log_witness_words: usize,
+fn verify_bitand_reduction<F: BinaryField + From<AESTowerField8b>, Challenger_: Challenger>(
+	log_constraint_count: usize,
 	transcript: &mut VerifierTranscript<Challenger_>,
-) -> Result<AndReductionOutput<F>, Error> {
+) -> Result<AndCheckOutput<F>, Error> {
 	// The structure of the AND reduction requires that it verifies at least 2^3 word-level
 	// constraints, you can zero-pad if necessary to reach this minimum
-	assert!(log_witness_words >= checked_log_2(binius_core::consts::MIN_AND_CONSTRAINTS));
+	assert!(log_constraint_count >= checked_log_2(binius_core::consts::MIN_AND_CONSTRAINTS));
 
-	let big_field_zerocheck_challenges = transcript.sample_vec(log_witness_words - 3);
+	let big_field_zerocheck_challenges = transcript.sample_vec(log_constraint_count - 3);
 
 	let mut all_zerocheck_challenges = vec![];
 
@@ -240,19 +270,5 @@ fn run_and_check<F: BinaryField + From<AESTowerField8b>, Challenger_: Challenger
 		all_zerocheck_challenges.push(*big_field_challenge);
 	}
 
-	let output = verify_with_transcript(
-		&all_zerocheck_challenges,
-		transcript,
-		verifier_message_domain.clone(),
-	)?;
-
-	let verifier_mle_eval_claims = transcript.message().read_scalar_slice::<F>(3)?;
-
-	if output.sumcheck_output.eval
-		== verifier_mle_eval_claims[0] * verifier_mle_eval_claims[1] - verifier_mle_eval_claims[2]
-	{
-		Ok(output)
-	} else {
-		Err(VerificationError::AndReductionMLECheckFailed.into())
-	}
+	verify_with_transcript(&all_zerocheck_challenges, transcript, verifier_message_domain)
 }


### PR DESCRIPTION
### TL;DR

Performed integration of BitAnd, IntMul, Shift, and PCS. 
The conversion from outputs of BitAnd and IntMul to inputs of Shift is a bit verbose and may seem unnecessary, but I think it's still fine to let these protocol each have their own interface language and we translate easily between them.

### What changed?

- Replaced `ProveAndReductionOutput` with `AndCheckOutput` to match the verifier's expected format
- Refactored the IntMul protocol to use a consistent output structure between prover and verifier
- Added proper error handling in the Shift reduction protocol
- Updated the main prover to integrate the BitAnd, IntMul, and Shift reductions properly
- Fixed the order of operands in the IntMul constraints to match the expected order (a, b, lo, hi)
- Simplified the error handling across protocols by removing redundant error types
- Added proper type conversions for binary subspaces to ensure compatibility

### How to test?

Run the existing tests for the BitAnd, IntMul, and Shift reductions:

```bash
cargo test -p binius-prover --test shift
cargo test -p binius-prover -- protocols::intmul::tests
cargo test -p binius-prover -- and_reduction::prover::test
```

### Why make this change?

This change improves the consistency between the prover and verifier components, making the codebase more maintainable and easier to understand. By aligning the output structures, we ensure that data flows correctly between components and reduce the risk of mismatches. The refactoring also simplifies error handling and improves type safety across the protocol implementations.