### PR TITLE
fix bug when using non-trivial packing

### DIFF
--- a/crates/prover/src/protocols/shift/monster.rs
+++ b/crates/prover/src/protocols/shift/monster.rs
@@ -176,7 +176,7 @@ where
 		.map(|chunk| P::from_scalars(chunk))
 		.collect::<Box<[_]>>();
 
-	let log_len = strict_log_2(monster_multilinear.len())
+	let log_len = strict_log_2(key_collection.key_ranges.len())
 		.expect("same length as constraint system's `key_ranges`");
 	Ok(FieldBuffer::new(log_len, monster_multilinear).expect("checked log_len"))
 }

--- a/crates/prover/tests/shift.rs
+++ b/crates/prover/tests/shift.rs
@@ -238,9 +238,9 @@ pub fn evaluate_witness<F: Field>(words: &[Word], r_jr_y: &[F]) -> F {
 
 #[test]
 fn test_shift_prove_and_verify() {
-	use binius_field::{BinaryField128bGhash, PackedBinaryGhash1x128b, Random};
+	use binius_field::{BinaryField128bGhash, PackedBinaryGhash2x128b, Random};
 	type F = BinaryField128bGhash;
-	type P = PackedBinaryGhash1x128b;
+	type P = PackedBinaryGhash2x128b;
 	let mut rng = StdRng::seed_from_u64(0);
 
 	let mut constraint_systems_to_test = vec![


### PR DESCRIPTION
### TL;DR

Fix the monster multilinear computation and update field type in shift tests.

### What changed?

- Fixed a bug in `monster.rs` where the wrong length was being used to calculate `log_len`. Now using `key_collection.key_ranges.len()` instead of `monster_multilinear.len()`.
- Updated the field type in shift tests from `PackedBinaryGhash1x128b` to `PackedBinaryGhash2x128b` and added the appropriate import.

### How to test?

Run the shift tests to verify they pass with the updated field type:
```
cargo test test_shift_prove_and_verify
```

### Why make this change?

The bug fix in `monster.rs` ensures the correct length is used when calculating the logarithm, which is critical for proper constraint system evaluation. The field type update in the tests likely improves performance or compatibility with the current implementation.