### PR TITLE
Restore building tests and examples against WASM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
             rustflags: "-C debug-assertions"
           - name: "wasm-build"
             command: |
-              cargo build -p binius-math -p binius-field -p binius-prover -p binius-verifier --target wasm32-wasip1
+              cargo build -p binius-math -p binius-field -p binius-prover -p binius-verifier --target wasm32-wasip1 --tests --benches
             rust-target: "wasm32-wasip1"
     steps:
       - name: Checkout Repository

--- a/crates/prover/Cargo.toml
+++ b/crates/prover/Cargo.toml
@@ -35,7 +35,6 @@ proptest.workspace = true
 rand = { workspace = true, features = ["std_rng", "thread_rng"] }
 rsa.workspace = true
 tracing-subscriber.workspace = true
-tracing-profile.workspace = true
 sha2.workspace = true
 
 [lib]


### PR DESCRIPTION
### TL;DR

Build tests and benchmarks for WASM target in CI and remove unused dependency which prevented those from compiling.

### What changed?

- Updated the CI workflow to build tests and benchmarks for the WASM target by adding `--tests --benches` flags to the wasm-build command
- Removed the unused `tracing-profile` dependency from the prover crate's Cargo.toml

### How to test?

- Run the CI workflow to verify that tests and benchmarks build successfully for the WASM target
- Verify that the prover crate still builds and functions correctly without the `tracing-profile` dependency

### Why make this change?

Building tests and benchmarks for the WASM target ensures that our test suite is compatible with WebAssembly, which is important for cross-platform compatibility. Removing the unused dependency helps reduce build times and keeps the dependency tree clean.