### PR TITLE
[ci] Add CI job to run tests on wasm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,10 +103,26 @@ jobs:
               echo "ALL_FEATURES_WO_BAIL_PANIC: $ALL_FEATURES_WO_BAIL_PANIC"
               cargo nextest run --workspace --release --features "$ALL_FEATURES_WO_BAIL_PANIC" --no-fail-fast
             rustflags: "-C debug-assertions -C target-cpu=native"
-          - name: "wasm-build"
+          # Build against wasm32-unknown-unknown target to that our libraries compile to wasm.
+          - name: "vanilla-wasm32"
+            command: |
+              cargo build -p binius-prover -p binius-verifier
+            rust-target: "wasm32-unknown-unknown"
+          - name: "wasm32-wasip1"
             command: |
               cargo build -p binius-math -p binius-field -p binius-prover -p binius-verifier --target wasm32-wasip1 --tests --benches
+              cargo test -p binius-math -p binius-field -p binius-prover -p binius-verifier --target wasm32-wasip1 --config "target.'cfg(all())'.runner=['wasmer']"
             rust-target: "wasm32-wasip1"
+        # Exclude wasm targets on ARM64 as the host architecture doesn't affect the results
+        exclude:
+          - machine:
+              name: "arm64"
+            test:
+              name: "vanilla-wasm32"
+          - machine:
+              name: "arm64"
+            test:
+              name: "wasm32-wasip1"
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -131,6 +147,10 @@ jobs:
         run: cargo test -p binius-utils --features platform-diagnostics test_platform_diagnostics -- --nocapture
         env:
           RUSTFLAGS: "-C target-cpu=native"
+      - name: Set up Wasmer
+        uses: wasmerio/setup-wasmer@v2
+        with:
+          version: 'v6.0.1'
       - name: Run command
         run: ${{ matrix.test.command }}
         env:

--- a/verifier/circuits/src/slice.rs
+++ b/verifier/circuits/src/slice.rs
@@ -51,8 +51,9 @@ impl Slice {
 		// Static assertions to ensure maximum sizes fit within 32 bits
 		let max_len_input = input.len() << 3;
 		let max_len_slice = slice.len() << 3;
-		assert!(max_len_input < (1u64 << 32) as usize, "max_n_input must be < 2^32");
-		assert!(max_len_slice < (1u64 << 32) as usize, "max_n_slice must be < 2^32");
+
+		assert!(max_len_input <= u32::MAX as usize, "max_n_input must be < 2^32");
+		assert!(max_len_slice <= u32::MAX as usize, "max_n_slice must be < 2^32");
 
 		// Ensure all values fit in 32 bits to prevent overflow in iadd_32
 		b.assert_zero("offset_32bit", b.shr(offset, 32));


### PR DESCRIPTION
### TL;DR

Added WASM tests to CI workflow and set up Wasmer for test execution.

### What changed?

- Added a new command to run tests for `binius-math`, `binius-field`, `binius-prover`, and `binius-verifier` packages using the `wasm32-wasip1` target with `wasmtime` as the runner
- Added a step to set up Wasmer in the CI workflow using the `wasmerio/setup-wasmer@v2` action

### How to test?

1. Run the CI workflow to verify that WASM tests execute correctly
2. Locally, you can test with:
   ```bash
   cargo test -p binius-math -p binius-field -p binius-prover -p binius-verifier --target wasm32-wasip1 --config "target.'cfg(all())'.runner=['wasmtime']"
   ```

### Why make this change?

This change ensures that our code works correctly when compiled to WebAssembly by actually running the tests in a WASM environment. Previously, we were only building for WASM but not executing the tests, which could miss runtime issues specific to the WASM target.