### PR TITLE
[toolchain] Change toolchain to Rust stable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,7 +198,6 @@ This approach provides:
 ## Development Conventions
 
 ### Toolchain Requirements
-- Uses Rust nightly (see rust-toolchain.toml for specific version)
 - All operations are 64-bit word-based (fundamental to Binius64 design)
 - Heavy performance optimization with SIMD support
 - Pre-commit hooks run rustfmt and clippy automatically

--- a/crates/field/Cargo.toml
+++ b/crates/field/Cargo.toml
@@ -30,9 +30,9 @@ proptest.workspace = true
 rand = { workspace = true, features = ["std_rng", "thread_rng"] }
 
 [features]
+default = []
 benchmark_alternative_strategies = []
 trace_multiplications = []
-default = ["nightly_features"]
 nightly_features = []
 
 [lib]

--- a/crates/math/Cargo.toml
+++ b/crates/math/Cargo.toml
@@ -27,7 +27,7 @@ proptest.workspace = true
 rand = { workspace = true, features = ["std_rng", "thread_rng"] }
 
 [features]
-default = ["nightly-features"]
+default = []
 test-utils = []
 nightly-features = ["binius-field/nightly_features"]
 rayon = ["binius-utils/rayon"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2025-07-01"
+channel = "1.89.0"


### PR DESCRIPTION
Version 1.89.0 stabilized AVX-512 & GFNI features!