### PR TITLE
[fold_word] Low-level perf optimization

### DIFF
--- a/crates/prover/src/fold_word.rs
+++ b/crates/prover/src/fold_word.rs
@@ -47,9 +47,9 @@ where
 				// Split the word into bytes and perform one lookup per byte
 				let word_bytes = word.as_u64().to_le_bytes();
 				word_bytes
-					.into_iter()
+					.iter()
 					.enumerate()
-					.map(|(i_byte, byte)| lookup_table[i_byte][byte as usize])
+					.map(|(i_byte, &byte)| lookup_table[i_byte][byte as usize])
 					.sum()
 			}))
 		})


### PR DESCRIPTION
```
% taskset -c 0-11 cargo bench --package binius-prover --bench fold_words --no-default-features                        *[git:main][INS][12:43:35]
   Compiling binius-prover v0.1.0 (/home/jimpo/Code/github.com/IrreducibleOSS/monbijou/crates/prover)
    Finished `bench` profile [optimized + debuginfo] target(s) in 5.90s
     Running benches/fold_words.rs (target/release/deps/fold_words-6d76d1f53ffb1724)
fold_words/4096         time:   [34.278 µs 34.304 µs 34.332 µs]
                        thrpt:  [119.31 Melem/s 119.40 Melem/s 119.50 Melem/s]
                 change:
                        time:   [−56.399% −56.256% −56.119%] (p = 0.00 < 0.05)
                        thrpt:  [+127.89% +128.60% +129.35%]
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) low mild
  2 (2.00%) high mild
  1 (1.00%) high severe
fold_words/65536        time:   [327.85 µs 327.91 µs 327.98 µs]
                        thrpt:  [199.82 Melem/s 199.86 Melem/s 199.90 Melem/s]
                 change:
                        time:   [−68.156% −68.061% −67.987%] (p = 0.00 < 0.05)
                        thrpt:  [+212.37% +213.09% +214.03%]
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe
fold_words/1048576      time:   [5.0495 ms 5.0542 ms 5.0620 ms]
                        thrpt:  [207.15 Melem/s 207.47 Melem/s 207.66 Melem/s]
                 change:
                        time:   [−68.930% −68.875% −68.819%] (p = 0.00 < 0.05)
                        thrpt:  [+220.71% +221.29% +221.85%]
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe
```