### PR TITLE
Optimize hot loop in build_g_triplet

### DIFF
--- a/crates/field/src/lib.rs
+++ b/crates/field/src/lib.rs
@@ -56,3 +56,4 @@ pub use packed_polyval::*;
 pub use polyval::*;
 pub use random::Random;
 pub use transpose::{Error as TransposeError, square_transpose};
+pub use underlier::{UnderlierWithBitOps, WithUnderlier};

--- a/crates/prover/src/protocols/shift/prove.rs
+++ b/crates/prover/src/protocols/shift/prove.rs
@@ -1,7 +1,9 @@
 // Copyright 2025 Irreducible Inc.
 
 use binius_core::word::Word;
-use binius_field::{AESTowerField8b, BinaryField, Field, PackedField};
+use binius_field::{
+	AESTowerField8b, BinaryField, Field, PackedField, UnderlierWithBitOps, WithUnderlier,
+};
 use binius_math::{
 	FieldBuffer, multilinear::eq::eq_ind_partial_eval, univariate::evaluate_univariate,
 };
@@ -101,7 +103,7 @@ pub fn prove<F, P: PackedField<Scalar = F>, C: Challenger>(
 	transcript: &mut ProverTranscript<C>,
 ) -> Result<SumcheckOutput<F>, Error>
 where
-	F: BinaryField + From<AESTowerField8b>,
+	F: BinaryField + From<AESTowerField8b> + WithUnderlier<Underlier: UnderlierWithBitOps>,
 {
 	// Sample lambdas, one for each operator.
 	let bitand_lambda = transcript.sample();

--- a/crates/verifier/src/config.rs
+++ b/crates/verifier/src/config.rs
@@ -2,7 +2,7 @@
 
 use binius_field::{AESTowerField8b, BinaryField, BinaryField1b, BinaryField128bGhash};
 use binius_transcript::fiat_shamir::HasherChallenger;
-use binius_utils::checked_arithmetics::checked_log_2;
+use binius_utils::checked_arithmetics::{checked_int_div, checked_log_2};
 
 use super::hash::StdDigest;
 
@@ -15,6 +15,7 @@ pub type StdChallenger = HasherChallenger<StdDigest>;
 
 /// The protocol proves constraint systems over 64-bit words.
 pub const WORD_SIZE_BITS: usize = 64;
+pub const WORD_SIZE_BYTES: usize = checked_int_div(WORD_SIZE_BITS, 8);
 
 /// log2 of [`WORD_SIZE_BITS`].
 pub const LOG_WORD_SIZE_BITS: usize = checked_log_2(WORD_SIZE_BITS);


### PR DESCRIPTION
### TL;DR

Optimize the shift protocol's phase 1 implementation by using lookup mask lookup table and operations with underliers. Yes, I had to make underliers public again but the performance improvement 2.2s -> 1.37s worth it. 

### What changed?

- Added `UnderlierWithBitOps` and `WithUnderlier` traits to the public API in the field crate
- Optimized the `build_g_triplet` function in the shift protocol's phase 1 implementation:
  - Created a lookup table (`masks_map`) to efficiently map bytes to bit masks
  - Replaced the bit-by-bit iteration with a byte-wise approach that processes 8 bits at once
  - Used direct bit operations on field underliers instead of field arithmetic
- Added `WORD_SIZE_BYTES` constant to the verifier config
- Updated function signatures to require the new trait bounds

### How to test?

Run the existing test suite for the shift protocol to ensure the optimized implementation produces the same results as before:

```bash
cargo test -p binius-prover --features="test-utils" -- protocols::shift
```

### Why make this change?

This optimization significantly improves the performance of the shift protocol's phase 1 by:
1. Reducing the number of iterations by processing bytes instead of individual bits
2. Using more efficient bit operations directly on the underlying representation
3. Leveraging a precomputed lookup table to avoid repeated bit calculations
4. Eliminating unnecessary field arithmetic operations when simple bit operations suffice