### PR TITLE
Optimize fold_1b_rows to speed up ring switch partial evaluations

### DIFF
--- a/crates/field/src/byte_iteration.rs
+++ b/crates/field/src/byte_iteration.rs
@@ -8,7 +8,8 @@ use bytemuck::{Pod, zeroed_vec};
 use crate::{
 	AESTowerField8b, AESTowerField16b, AESTowerField32b, AESTowerField64b, AESTowerField128b,
 	BinaryField8b, BinaryField16b, BinaryField32b, BinaryField64b, BinaryField128b,
-	BinaryField128bPolyval, PackedField,
+	BinaryField128bGhash, BinaryField128bPolyval, PackedBinaryGhash1x128b, PackedBinaryGhash2x128b,
+	PackedBinaryGhash4x128b, PackedField,
 	arch::{
 		byte_sliced::*, packed_8::*, packed_16::*, packed_32::*, packed_64::*, packed_128::*,
 		packed_256::*, packed_512::*, packed_aes_8::*, packed_aes_16::*, packed_aes_32::*,
@@ -127,6 +128,12 @@ unsafe impl SequentialBytes for BinaryField128bPolyval {}
 unsafe impl SequentialBytes for PackedBinaryPolyval1x128b {}
 unsafe impl SequentialBytes for PackedBinaryPolyval2x128b {}
 unsafe impl SequentialBytes for PackedBinaryPolyval4x128b {}
+
+unsafe impl SequentialBytes for BinaryField128bGhash {}
+
+unsafe impl SequentialBytes for PackedBinaryGhash1x128b {}
+unsafe impl SequentialBytes for PackedBinaryGhash2x128b {}
+unsafe impl SequentialBytes for PackedBinaryGhash4x128b {}
 
 /// Returns true if T implements `SequentialBytes` trait.
 /// Use a hack that exploits that array copying is optimized for the `Copy` types.

--- a/crates/field/src/underlier/underlier_with_bit_ops.rs
+++ b/crates/field/src/underlier/underlier_with_bit_ops.rs
@@ -27,6 +27,23 @@ pub trait UnderlierWithBitOps:
 	const ONE: Self;
 	const ONES: Self;
 
+	// A map from a byte to 8 values, where `i`-th value is filled with a `i`-th bit from the byte.
+	const BYTE_MASK_MAP: [[Self; 8]; 256] = const {
+		let mut map = [[Self::ZERO; 8]; 256];
+		let mut byte = 0;
+		while byte < 256 {
+			let mut bit = 0;
+			while bit < 8 {
+				if (byte & (1 << bit)) != 0 {
+					map[byte][bit] = Self::ONES;
+				}
+				bit += 1;
+			}
+			byte += 1;
+		}
+		map
+	};
+
 	/// Fill value with the given bit
 	/// `val` must be 0 or 1.
 	fn fill_with_bit(val: u8) -> Self;

--- a/crates/prover/src/pcs.rs
+++ b/crates/prover/src/pcs.rs
@@ -1,6 +1,8 @@
 // Copyright 2025 Irreducible Inc.
 
-use binius_field::{BinaryField, ExtensionField, PackedExtension, PackedField};
+use binius_field::{
+	BinaryField, ExtensionField, PackedExtension, PackedField, UnderlierWithBitOps, WithUnderlier,
+};
 use binius_math::{
 	FieldBuffer, inner_product::inner_product, multilinear::eq::eq_ind_partial_eval,
 	ntt::AdditiveNTT, tensor_algebra::TensorAlgebra,
@@ -30,7 +32,7 @@ pub struct OneBitPCSProver<P: PackedField> {
 
 impl<F, P> OneBitPCSProver<P>
 where
-	F: BinaryField,
+	F: BinaryField + WithUnderlier<Underlier: UnderlierWithBitOps>,
 	P: PackedExtension<B1> + PackedField<Scalar = F>,
 {
 	/// Create a new ring switched PCS prover.


### PR DESCRIPTION
### TL;DR

Optimize binary field operations in `fold_1b_rows` by adding a precomputed byte mask map and implementing byte iteration for GHASH fields.
This reduces the "Compute ring-switching partial evaluations" from ~800 ms to ~400 ms

### What changed?

- Added a precomputed `BYTE_MASK_MAP` constant to `UnderlierWithBitOps` trait that maps bytes to bit masks
- Implemented `SequentialBytes` for `BinaryField128bGhash` and related packed types
- Replaced runtime-generated masks map in `build_g_triplet` with the precomputed constant
- Optimized `fold_1b_rows` function in `ring_switch.rs` to use byte iteration when available
- Added type constraints to ensure fields have the required bit operations capabilities

### How to test?

Run the existing test suite to verify that all functionality continues to work correctly. The optimizations should be transparent to users and not change any behavior, only improve performance.

### Why make this change?

This change improves performance by:
1. Replacing runtime mask generation with compile-time constants
2. Enabling byte iteration optimization for GHASH field types
3. Optimizing the `fold_1b_rows` function to process bytes in chunks rather than individual bits when possible

These optimizations reduce computational overhead in critical field operations, particularly for binary field operations used in cryptographic protocols.