### PR TITLE
Optimize build_monster_multilinear

### DIFF
--- a/crates/field/src/packed.rs
+++ b/crates/field/src/packed.rs
@@ -175,6 +175,7 @@ pub trait PackedField:
 	/// If the number of values in the sequence is less than the packing width, the remaining
 	/// elements are set to zero. If greater than the packing width, the excess elements are
 	/// ignored.
+	#[inline]
 	fn from_scalars(values: impl IntoIterator<Item=Self::Scalar>) -> Self {
 		let mut result = Self::default();
 		for (i, val) in values.into_iter().take(Self::WIDTH).enumerate() {


### PR DESCRIPTION
### TL;DR

Optimized the monster multilinear computation in the shift protocol by using parallel chunks and added an inline attribute to `from_scalars`.
The rayon's `chunks` method creates a vector for each chunk (which is 1-4 size in our case) so the previous version was allocating many small vectors.
This change reduces the `build_monster_multilinear`'s time from 316 ms to 220 ms

### What changed?

- Added `#[inline]` attribute to the `from_scalars` method in the `PackedField` trait to improve performance
- Refactored the monster multilinear computation in the shift protocol to use `par_chunks(P::WIDTH)` instead of `par_iter()` followed by `chunks(P::WIDTH)`
- This change allows for more efficient parallel processing by avoiding an intermediate collection step

### How to test?

Run the existing test suite for the prover crate to ensure the functionality remains correct:
```
cargo test -p prover
```

Additionally, benchmark the performance of the shift protocol to verify the optimization:
```
cargo bench --bench shift_protocol
```

### Why make this change?

This optimization improves the performance of the monster multilinear computation by:
1. Reducing memory allocations by processing chunks in parallel directly
2. Eliminating the need to collect intermediate results before chunking
3. Inlining the `from_scalars` method to reduce function call overhead

These changes should result in better performance for the shift protocol, especially for large problem sizes.