### PR TITLE
[ntt] Use FieldBuffer to clean up code

### DIFF
--- a/crates/math/benches/ntt.rs
+++ b/crates/math/benches/ntt.rs
@@ -1,11 +1,11 @@
 use binius_field::{BinaryField, PackedField};
-use binius_math::test_utils::random_field_buffer;
 use binius_math::{
 	BinarySubspace, FieldBuffer,
 	ntt::{
 		AdditiveNTT, NeighborsLastMultiThread, NeighborsLastSingleThread,
 		domain_context::GenericPreExpanded,
 	},
+	test_utils::random_field_buffer,
 };
 use binius_utils::{
 	env::boolean_env_flag_set,

--- a/crates/math/src/ntt/mod.rs
+++ b/crates/math/src/ntt/mod.rs
@@ -19,9 +19,8 @@ pub use neighbors_last::{
 	NeighborsLastMultiThread, NeighborsLastReference, NeighborsLastSingleThread,
 };
 
-use crate::FieldSliceMut;
-
 use super::BinarySubspace;
+use crate::FieldSliceMut;
 
 /// The binary field additive NTT.
 ///

--- a/crates/math/src/ntt/neighbors_last.rs
+++ b/crates/math/src/ntt/neighbors_last.rs
@@ -11,9 +11,8 @@ use binius_utils::rayon::{
 	slice::ParallelSliceMut,
 };
 
-use crate::{FieldSlice, FieldSliceMut};
-
 use super::{AdditiveNTT, DomainContext};
+use crate::{FieldSlice, FieldSliceMut};
 
 const DEFAULT_LOG_BASE_LEN: usize = 4;
 

--- a/crates/math/src/ntt/tests_evaluation.rs
+++ b/crates/math/src/ntt/tests_evaluation.rs
@@ -1,17 +1,18 @@
 //! This module tests that running the NTT is equivalent to evaluating the respective polynomial at
 //! the respective points of $S^{(0)}$.
 
-use binius_field::{BinaryField, Field};
-use rand::prelude::*;
 use std::ops::{Add, AddAssign, Mul, MulAssign};
 
-use crate::test_utils::random_field_buffer;
+use binius_field::{BinaryField, Field};
+use rand::prelude::*;
+
 use crate::{
 	BinarySubspace,
 	ntt::{
 		AdditiveNTT, DomainContext, NeighborsLastSingleThread,
 		domain_context::{self},
 	},
+	test_utils::random_field_buffer,
 };
 
 /// Represents a univariate polynomial with coefficients in a field.

--- a/crates/math/src/ntt/tests_reference.rs
+++ b/crates/math/src/ntt/tests_reference.rs
@@ -8,13 +8,13 @@ use binius_field::{
 use rand::prelude::*;
 
 use super::{AdditiveNTT, DomainContext};
-use crate::test_utils::random_field_buffer;
 use crate::{
 	BinarySubspace,
 	ntt::{
 		NeighborsLastMultiThread, NeighborsLastReference, NeighborsLastSingleThread,
 		domain_context::{GaoMateerPreExpanded, GenericPreExpanded, TraceOneElement},
 	},
+	test_utils::random_field_buffer,
 };
 
 fn test_equivalence<P: PackedField>(

--- a/crates/math/src/reed_solomon.rs
+++ b/crates/math/src/reed_solomon.rs
@@ -4,13 +4,12 @@
 //!
 //! See [`ReedSolomonCode`] for details.
 
-use crate::FieldSliceMut;
 use binius_field::{BinaryField, ExtensionField, PackedExtension, PackedField};
 use binius_utils::bail;
 use getset::{CopyGetters, Getters};
 
 use super::{binary_subspace::BinarySubspace, error::Error as MathError, ntt::AdditiveNTT};
-use crate::FieldBuffer;
+use crate::FieldSliceMut;
 
 /// [Reed–Solomon] codes over binary fields.
 ///
@@ -123,23 +122,30 @@ impl<F: BinaryField> ReedSolomonCode<F> {
 
 		// Repeat the message to fill the entire buffer.
 
-		// First, if the message is less than the packing width, we need to repeat it to fill one
+		// If the message is less than the packing width, we need to repeat it to fill one
 		// packed element.
-		if self.log_dim() + log_batch_size < P::LOG_WIDTH {
+		let chunk_size = self.log_dim() + log_batch_size;
+		let chunk_size = if chunk_size < P::LOG_WIDTH {
 			let elem_0 = &mut code.as_mut()[0];
 			let repeated_values = elem_0
 				.into_iter()
 				.take(1 << (self.log_dim() + log_batch_size))
 				.cycle();
 			*elem_0 = P::from_scalars(repeated_values);
-		}
+			P::LOG_WIDTH
+		} else {
+			chunk_size
+		};
 
-		// Repeat the packed message to fill the entire buffer.
-		let mut chunks =
-			code.chunks_mut(1 << (self.log_dim() + log_batch_size).saturating_sub(P::LOG_WIDTH));
-		let first_chunk = chunks.next().expect("code is not empty; checked above");
-		for chunk in chunks {
-			chunk.copy_from_slice(first_chunk);
+		if chunk_size < code.log_len() {
+			let mut chunks = code.chunks_mut(chunk_size).expect(
+				"chunk_size >= P::LOG_WIDTH from assignment above; \
+				chunk_size < code.log_len() in conditional",
+			);
+			let first_chunk = chunks.next().expect("chunks_mut cannot be empty");
+			for mut chunk in chunks {
+				chunk.as_mut().copy_from_slice(first_chunk.as_ref());
+			}
 		}
 
 		let skip_early = self.log_inv_rate;

--- a/crates/prover/src/and_reduction/ntt_lookup.rs
+++ b/crates/prover/src/and_reduction/ntt_lookup.rs
@@ -216,7 +216,6 @@ where
 mod test {
 	use std::iter::repeat_with;
 
-	use super::{NTTLookup, ROWS_PER_HYPERCUBE_VERTEX};
 	use binius_field::{
 		AESTowerField8b, Field, PackedAESBinaryField16x8b, PackedBinaryField8x1b, PackedField,
 		Random,
@@ -229,6 +228,8 @@ mod test {
 	use binius_verifier::{and_reduction::utils::constants::SKIPPED_VARS, config::B1};
 	use itertools::Itertools;
 	use rand::{SeedableRng, rngs::StdRng};
+
+	use super::{NTTLookup, ROWS_PER_HYPERCUBE_VERTEX};
 
 	/// Tests NTT accuracy on a well-known polynomial with a single coefficient set.
 	///

--- a/crates/prover/src/fri/fold.rs
+++ b/crates/prover/src/fri/fold.rs
@@ -329,17 +329,17 @@ where
 
 #[cfg(test)]
 mod tests {
-	use super::*;
-	use binius_math::test_utils::random_field_buffer;
 	use binius_math::{
 		BinarySubspace,
 		fold::fold_cols,
 		ntt::{NeighborsLastSingleThread, domain_context::GenericOnTheFly},
-		test_utils::random_scalars,
+		test_utils::{random_field_buffer, random_scalars},
 	};
 	use binius_verifier::config::B128;
 	use proptest::prelude::*;
 	use rand::prelude::*;
+
+	use super::*;
 
 	proptest! {
 		#[test]


### PR DESCRIPTION
The attempt to use FieldBuffer in NTT code was incomplete. This does the change more thoroughly.

https://app.graphite.dev/github/pr/IrreducibleOSS/monbijou/492/Make-AdditiveNTT-interface-use-%60FieldBuffer%3CP%2C-Data%3E%60-instead-of-%60%26mut-%5BP%5D%60