### PR TITLE
Make underliers private again

### DIFF
--- a/crates/field/src/extension.rs
+++ b/crates/field/src/extension.rs
@@ -86,6 +86,10 @@ pub trait ExtensionField<F: Field>:
 
 	/// Transpose square block of subfield elements within `values` in place.
 	fn square_transpose(values: &mut [Self]) -> Result<(), Error>;
+
+	/// Multiplies two extension field elements as if they were represented in their base field
+	/// elements.
+	fn mul_as_bases(self, other: Self) -> Self;
 }
 
 impl<F: Field> ExtensionField<F> for F {
@@ -138,5 +142,10 @@ impl<F: Field> ExtensionField<F> for F {
 		}
 
 		Ok(())
+	}
+
+	#[inline]
+	fn mul_as_bases(self, other: Self) -> Self {
+		self * other
 	}
 }

--- a/crates/field/src/ghash.rs
+++ b/crates/field/src/ghash.rs
@@ -447,6 +447,11 @@ impl ExtensionField<BinaryField1b> for BinaryField128bGhash {
 		square_transforms_extension_field::<BinaryField1b, Self>(values)
 			.map_err(|_| Error::ExtensionDegreeMismatch)
 	}
+
+	#[inline]
+	fn mul_as_bases(self, other: Self) -> Self {
+		Self(self.0 & other.0)
+	}
 }
 
 impl SerializeBytes for BinaryField128bGhash {
@@ -466,6 +471,7 @@ impl DeserializeBytes for BinaryField128bGhash {
 
 impl BinaryField for BinaryField128bGhash {
 	const MULTIPLICATIVE_GENERATOR: Self = Self(0x494ef99794d5244f9152df59d87a9186);
+	const ALL_ONES: Self = Self(u128::MAX);
 }
 
 impl TowerField for BinaryField128bGhash {

--- a/crates/field/src/lib.rs
+++ b/crates/field/src/lib.rs
@@ -56,4 +56,3 @@ pub use packed_polyval::*;
 pub use polyval::*;
 pub use random::Random;
 pub use transpose::{Error as TransposeError, square_transpose};
-pub use underlier::{UnderlierWithBitOps, WithUnderlier};

--- a/crates/field/src/polyval.rs
+++ b/crates/field/src/polyval.rs
@@ -462,6 +462,11 @@ impl ExtensionField<BinaryField1b> for BinaryField128bPolyval {
 		square_transforms_extension_field::<BinaryField1b, Self>(values)
 			.map_err(|_| Error::ExtensionDegreeMismatch)
 	}
+
+	#[inline]
+	fn mul_as_bases(self, other: Self) -> Self {
+		Self(self.0 & other.0)
+	}
 }
 
 impl SerializeBytes for BinaryField128bPolyval {
@@ -481,6 +486,7 @@ impl DeserializeBytes for BinaryField128bPolyval {
 
 impl BinaryField for BinaryField128bPolyval {
 	const MULTIPLICATIVE_GENERATOR: Self = Self(0x72bdf2504ce49c03105433c1c25a4a7);
+	const ALL_ONES: Self = Self(u128::MAX);
 }
 
 impl TowerField for BinaryField128bPolyval {

--- a/crates/field/src/underlier/underlier_with_bit_ops.rs
+++ b/crates/field/src/underlier/underlier_with_bit_ops.rs
@@ -27,23 +27,6 @@ pub trait UnderlierWithBitOps:
 	const ONE: Self;
 	const ONES: Self;
 
-	// A map from a byte to 8 values, where `i`-th value is filled with a `i`-th bit from the byte.
-	const BYTE_MASK_MAP: [[Self; 8]; 256] = const {
-		let mut map = [[Self::ZERO; 8]; 256];
-		let mut byte = 0;
-		while byte < 256 {
-			let mut bit = 0;
-			while bit < 8 {
-				if (byte & (1 << bit)) != 0 {
-					map[byte][bit] = Self::ONES;
-				}
-				bit += 1;
-			}
-			byte += 1;
-		}
-		map
-	};
-
 	/// Fill value with the given bit
 	/// `val` must be 0 or 1.
 	fn fill_with_bit(val: u8) -> Self;

--- a/crates/prover/src/pcs.rs
+++ b/crates/prover/src/pcs.rs
@@ -1,8 +1,6 @@
 // Copyright 2025 Irreducible Inc.
 
-use binius_field::{
-	BinaryField, ExtensionField, PackedExtension, PackedField, UnderlierWithBitOps, WithUnderlier,
-};
+use binius_field::{BinaryField, ExtensionField, PackedExtension, PackedField};
 use binius_math::{
 	FieldBuffer, inner_product::inner_product, multilinear::eq::eq_ind_partial_eval,
 	ntt::AdditiveNTT, tensor_algebra::TensorAlgebra,
@@ -32,7 +30,7 @@ pub struct OneBitPCSProver<P: PackedField> {
 
 impl<F, P> OneBitPCSProver<P>
 where
-	F: BinaryField + WithUnderlier<Underlier: UnderlierWithBitOps>,
+	F: BinaryField,
 	P: PackedExtension<B1> + PackedField<Scalar = F>,
 {
 	/// Create a new ring switched PCS prover.

--- a/crates/prover/src/protocols/shift/prove.rs
+++ b/crates/prover/src/protocols/shift/prove.rs
@@ -1,9 +1,7 @@
 // Copyright 2025 Irreducible Inc.
 
 use binius_core::word::Word;
-use binius_field::{
-	AESTowerField8b, BinaryField, Field, PackedField, UnderlierWithBitOps, WithUnderlier,
-};
+use binius_field::{AESTowerField8b, BinaryField, Field, PackedField};
 use binius_math::{
 	FieldBuffer, multilinear::eq::eq_ind_partial_eval, univariate::evaluate_univariate,
 };
@@ -103,7 +101,7 @@ pub fn prove<F, P: PackedField<Scalar = F>, C: Challenger>(
 	transcript: &mut ProverTranscript<C>,
 ) -> Result<SumcheckOutput<F>, Error>
 where
-	F: BinaryField + From<AESTowerField8b> + WithUnderlier<Underlier: UnderlierWithBitOps>,
+	F: BinaryField + From<AESTowerField8b>,
 {
 	// Sample lambdas, one for each operator.
 	let bitand_lambda = transcript.sample();


### PR DESCRIPTION
### TL;DR

Make underliers private and move BYTE_MASK_MAP to `BinaryField`. I've introduced a new method `mul_as_bases` to the ExtensionField which seems to make sense and to my opinion is less ugly then adding extra bounds. 

### What changed?

- Added `ALL_ONES` constant to the `BinaryField` trait
- Moved `BYTE_MASK_MAP` from `UnderlierWithBitOps` to `BinaryField` trait
- Added `mul_as_bases` method to `ExtensionField` trait for multiplying extension field elements as if they were represented in their base field
- Implemented `mul_as_bases` for various field types
- Updated code in `prover` crate to use the new methods instead of accessing underlier directly
- Removed unnecessary imports of `UnderlierWithBitOps` and `WithUnderlier` from various files

### How to test?

- Run the existing test suite to ensure all functionality works as expected
- Verify that the prover still works correctly with the updated field operations
- Check that performance is maintained or improved with the new implementation

### Why make this change?

This change improves the abstraction of binary field operations by moving bit-related functionality directly into the `BinaryField` trait rather than relying on the underlier implementation. The new `mul_as_bases` method provides a more efficient way to perform certain operations on extension fields without needing to access the underlying representation directly. This makes the code more maintainable and potentially more performant by providing specialized implementations for different field types.