### PR TITLE
[shift] Store lambda powers on PreparedOperatorData

### DIFF
--- a/crates/prover/src/protocols/shift/monster.rs
+++ b/crates/prover/src/protocols/shift/monster.rs
@@ -114,10 +114,8 @@ where
 	F: BinaryField + From<AESTowerField8b>,
 {
 	// Compute lambda powers
-	let bitand_lambda_powers: [F; BITAND_ARITY] =
-		array::from_fn(|i| bitand_operator_data.lambda.pow(1 + i as u64));
-	let intmul_lambda_powers: [F; INTMUL_ARITY] =
-		array::from_fn(|i| intmul_operator_data.lambda.pow(1 + i as u64));
+	let bitand_lambda_powers = bitand_operator_data.lambda_powers.clone();
+	let intmul_lambda_powers = intmul_operator_data.lambda_powers.clone();
 
 	// Compute h evaluations
 	let subspace = BinarySubspace::<AESTowerField8b>::with_dim(LOG_WORD_SIZE_BITS)?.isomorphic();

--- a/crates/prover/src/protocols/shift/phase_1.rs
+++ b/crates/prover/src/protocols/shift/phase_1.rs
@@ -313,9 +313,11 @@ fn build_multilinear_triplet_for_operator<F: Field, P: PackedField<Scalar = F>>(
 	operator_data: &PreparedOperatorData<F>,
 	arity: usize,
 ) -> Result<MultilinearTriplet<P>, Error> {
-	let lambda_packed = P::broadcast(operator_data.lambda);
-	let lambda_powers = (0..arity)
-		.map(|i| lambda_packed.pow(1 + i as u64))
+	let lambda_powers = operator_data
+		.lambda_powers
+		.iter()
+		.copied()
+		.map(P::broadcast)
 		.collect::<Vec<_>>();
 
 	let [mut sll_buffers, mut srl_buffers, mut sra_buffers] =


### PR DESCRIPTION
### TL;DR

Optimize lambda powers computation in the SHIFT protocol by precomputing and reusing values.

### What changed?

- Modified `PreparedOperatorData` to store precomputed lambda powers instead of just the lambda value
- Updated the `new` method to precompute lambda powers during initialization
- Replaced runtime lambda power calculations with the precomputed values in:
  - `monster.rs`: Using the precomputed lambda powers directly
  - `phase_1.rs`: Leveraging the precomputed powers instead of recalculating
  - `prove.rs`: Using `inner_product` instead of `evaluate_univariate` for more efficient batched evaluation

### How to test?

- Run the existing test suite for the SHIFT protocol
- Verify that all proofs still generate and verify correctly
- Check that performance is improved or at least unchanged

### Why make this change?

This optimization eliminates redundant computation of lambda powers across different parts of the SHIFT protocol. By precomputing these values once during initialization and reusing them, we avoid the overhead of repeatedly calculating the same powers, which should improve performance, especially for larger proofs.