### PR TITLE
[shift] Move operand index into ConstraintIndex

### DIFF
--- a/crates/prover/src/protocols/shift/phase_1.rs
+++ b/crates/prover/src/protocols/shift/phase_1.rs
@@ -232,14 +232,7 @@ fn build_g_triplet<
 						Operation::IntegerMul => (intmul_operator_data, &mut intmul_multilinears),
 					};
 
-					let tensor_acc = key.accumulate(
-						&key_collection.constraint_indices,
-						operator_data.r_x_prime_tensor.as_ref(),
-					);
-					let operand_challenge = operator_data.lambda_powers[key.operand_index as usize];
-
-					let acc = tensor_acc * operand_challenge;
-
+					let acc = key.accumulate(&key_collection.constraint_indices, operator_data);
 					let acc_underlier = acc.to_underlier();
 
 					// The following loop is an optimized version of the following


### PR DESCRIPTION
This version now results in a performance gain over the baseline. It reduces the cost of `build_g_triplet`, but increases the cost of `build_monster_multilinear`, but that's much cheaper to begin with.
