### PR TITLE
[frontend] eval form

### DIFF
--- a/crates/frontend/src/compiler/eval_form/builder.rs
+++ b/crates/frontend/src/compiler/eval_form/builder.rs
@@ -1,0 +1,240 @@
+//! Bytecode builder for generating evaluation instructions
+
+/// Builder for constructing bytecode during circuit compilation
+pub struct BytecodeBuilder {
+	bytecode: Vec<u8>,
+}
+
+impl BytecodeBuilder {
+	pub fn new() -> Self {
+		Self {
+			bytecode: Vec::new(),
+		}
+	}
+
+	// Bitwise operations
+	pub fn emit_band(&mut self, dst: u32, src1: u32, src2: u32) {
+		self.emit_u8(0x01);
+		self.emit_reg(dst);
+		self.emit_reg(src1);
+		self.emit_reg(src2);
+	}
+
+	pub fn emit_bor(&mut self, dst: u32, src1: u32, src2: u32) {
+		self.emit_u8(0x02);
+		self.emit_reg(dst);
+		self.emit_reg(src1);
+		self.emit_reg(src2);
+	}
+
+	pub fn emit_bxor(&mut self, dst: u32, src1: u32, src2: u32) {
+		self.emit_u8(0x03);
+		self.emit_reg(dst);
+		self.emit_reg(src1);
+		self.emit_reg(src2);
+	}
+
+	pub fn emit_bnot(&mut self, dst: u32, src: u32) {
+		self.emit_u8(0x04);
+		self.emit_reg(dst);
+		self.emit_reg(src);
+	}
+
+	// Shifts
+	pub fn emit_sll(&mut self, dst: u32, src: u32, shift: u8) {
+		self.emit_u8(0x10);
+		self.emit_reg(dst);
+		self.emit_reg(src);
+		self.emit_u8(shift);
+	}
+
+	pub fn emit_slr(&mut self, dst: u32, src: u32, shift: u8) {
+		self.emit_u8(0x11);
+		self.emit_reg(dst);
+		self.emit_reg(src);
+		self.emit_u8(shift);
+	}
+
+	pub fn emit_sar(&mut self, dst: u32, src: u32, shift: u8) {
+		self.emit_u8(0x12);
+		self.emit_reg(dst);
+		self.emit_reg(src);
+		self.emit_u8(shift);
+	}
+
+	// Arithmetic with carry
+	pub fn emit_iadd_cout(&mut self, dst_sum: u32, dst_cout: u32, src1: u32, src2: u32) {
+		self.emit_u8(0x20);
+		self.emit_reg(dst_sum);
+		self.emit_reg(dst_cout);
+		self.emit_reg(src1);
+		self.emit_reg(src2);
+	}
+
+	pub fn emit_iadd_cin_cout(
+		&mut self,
+		dst_sum: u32,
+		dst_cout: u32,
+		src1: u32,
+		src2: u32,
+		cin: u32,
+	) {
+		self.emit_u8(0x21);
+		self.emit_reg(dst_sum);
+		self.emit_reg(dst_cout);
+		self.emit_reg(src1);
+		self.emit_reg(src2);
+		self.emit_reg(cin);
+	}
+
+	pub fn emit_isub_bout(&mut self, dst_diff: u32, dst_bout: u32, src1: u32, src2: u32) {
+		self.emit_u8(0x22);
+		self.emit_reg(dst_diff);
+		self.emit_reg(dst_bout);
+		self.emit_reg(src1);
+		self.emit_reg(src2);
+	}
+
+	pub fn emit_isub_bin_bout(
+		&mut self,
+		dst_diff: u32,
+		dst_bout: u32,
+		src1: u32,
+		src2: u32,
+		bin: u32,
+	) {
+		self.emit_u8(0x23);
+		self.emit_reg(dst_diff);
+		self.emit_reg(dst_bout);
+		self.emit_reg(src1);
+		self.emit_reg(src2);
+		self.emit_reg(bin);
+	}
+
+	// Multiply
+	pub fn emit_imul(&mut self, dst_hi: u32, dst_lo: u32, src1: u32, src2: u32) {
+		self.emit_u8(0x30);
+		self.emit_reg(dst_hi);
+		self.emit_reg(dst_lo);
+		self.emit_reg(src1);
+		self.emit_reg(src2);
+	}
+
+	// 32-bit operations
+	pub fn emit_iadd_cout32(&mut self, dst_sum: u32, dst_cout: u32, src1: u32, src2: u32) {
+		self.emit_u8(0x40);
+		self.emit_reg(dst_sum);
+		self.emit_reg(dst_cout);
+		self.emit_reg(src1);
+		self.emit_reg(src2);
+	}
+
+	pub fn emit_rotr32(&mut self, dst: u32, src: u32, rotate: u8) {
+		self.emit_u8(0x41);
+		self.emit_reg(dst);
+		self.emit_reg(src);
+		self.emit_u8(rotate);
+	}
+
+	pub fn emit_shr32(&mut self, dst: u32, src: u32, shift: u8) {
+		self.emit_u8(0x42);
+		self.emit_reg(dst);
+		self.emit_reg(src);
+		self.emit_u8(shift);
+	}
+
+	pub fn emit_rotl(&mut self, dst: u32, src: u32, rotate: u8) {
+		self.emit_u8(0x43);
+		self.emit_reg(dst);
+		self.emit_reg(src);
+		self.emit_u8(rotate);
+	}
+
+	// Mask operations
+	pub fn emit_mask_low(&mut self, dst: u32, src: u32, n_bits: u8) {
+		self.emit_u8(0x50);
+		self.emit_reg(dst);
+		self.emit_reg(src);
+		self.emit_u8(n_bits);
+	}
+
+	pub fn emit_mask_high(&mut self, dst: u32, src: u32, n_bits: u8) {
+		self.emit_u8(0x51);
+		self.emit_reg(dst);
+		self.emit_reg(src);
+		self.emit_u8(n_bits);
+	}
+
+	// Assertions
+	pub fn emit_assert_eq(&mut self, src1: u32, src2: u32, error_id: u32) {
+		self.emit_u8(0x60);
+		self.emit_reg(src1);
+		self.emit_reg(src2);
+		self.emit_u32(error_id);
+	}
+
+	pub fn emit_assert_zero(&mut self, src: u32, error_id: u32) {
+		self.emit_u8(0x61);
+		self.emit_reg(src);
+		self.emit_u32(error_id);
+	}
+
+	pub fn emit_assert_cond(&mut self, cond: u32, src1: u32, src2: u32, error_id: u32) {
+		self.emit_u8(0x62);
+		self.emit_reg(cond);
+		self.emit_reg(src1);
+		self.emit_reg(src2);
+		self.emit_u32(error_id);
+	}
+
+	// Hint calls
+	pub fn emit_hint(
+		&mut self,
+		hint_id: u32,
+		dimensions: &[usize],
+		inputs: &[u32],
+		outputs: &[u32],
+	) {
+		self.emit_u8(0x80);
+		self.emit_u32(hint_id);
+		self.emit_u16(dimensions.len() as u16);
+		for &dim in dimensions {
+			self.emit_u32(dim as u32);
+		}
+		self.emit_u16(inputs.len() as u16);
+		self.emit_u16(outputs.len() as u16);
+		for &input in inputs {
+			self.emit_reg(input);
+		}
+		for &output in outputs {
+			self.emit_reg(output);
+		}
+	}
+
+	// Low-level emitters
+	fn emit_u8(&mut self, val: u8) {
+		self.bytecode.push(val);
+	}
+
+	fn emit_u16(&mut self, val: u16) {
+		self.bytecode.extend_from_slice(&val.to_le_bytes());
+	}
+
+	fn emit_u32(&mut self, val: u32) {
+		self.bytecode.extend_from_slice(&val.to_le_bytes());
+	}
+
+	fn emit_reg(&mut self, reg: u32) {
+		self.emit_u32(reg);
+	}
+
+	pub fn finalize(self) -> Vec<u8> {
+		self.bytecode
+	}
+}
+
+impl Default for BytecodeBuilder {
+	fn default() -> Self {
+		Self::new()
+	}
+}

--- a/crates/frontend/src/compiler/eval_form/interpreter.rs
+++ b/crates/frontend/src/compiler/eval_form/interpreter.rs
@@ -1,0 +1,454 @@
+//! Bytecode interpreter for circuit evaluation
+
+use binius_core::{ValueIndex, ValueVec, Word};
+
+use crate::compiler::{circuit::PopulateError, hints::HintRegistry};
+
+const MAX_ASSERTION_FAILURES: usize = 100;
+
+/// Assertion failure information
+pub struct AssertionFailure {
+	pub error_id: u32,
+	pub message: String,
+}
+
+/// Execution context holds a reference to ValueVec during execution
+pub struct ExecutionContext<'a> {
+	value_vec: &'a mut ValueVec,
+	/// The scratch space.
+	scratch: Vec<Word>,
+	/// Assertion failures recorded during the evaluation of the circuit.
+	///
+	/// This list is capped by [`MAX_ASSERTION_FAILURES`].
+	assertion_failures: Vec<AssertionFailure>,
+	/// The total number of assert violations recorded.
+	assertion_count: usize,
+}
+
+impl<'a> ExecutionContext<'a> {
+	pub fn new(value_vec: &'a mut ValueVec, scratch: Vec<Word>) -> Self {
+		Self {
+			value_vec,
+			scratch,
+			assertion_failures: Vec::new(),
+			assertion_count: 0,
+		}
+	}
+
+	/// Record an assertion failure with the given error ID and message.
+	///
+	/// Note that this assertion might be discarded in case there is already too many recorded
+	/// assertions.
+	#[cold]
+	fn note_assertion_failure(&mut self, error_id: u32, message: String) {
+		self.assertion_count += 1;
+		if self.assertion_failures.len() < MAX_ASSERTION_FAILURES {
+			self.assertion_failures
+				.push(AssertionFailure { error_id, message });
+		}
+	}
+
+	/// Check assertions and return error if any failed
+	pub fn check_assertions(self) -> Result<(), PopulateError> {
+		if !self.assertion_failures.is_empty() {
+			Err(PopulateError {
+				messages: self
+					.assertion_failures
+					.into_iter()
+					.map(|f| f.message)
+					.collect(),
+				total_count: self.assertion_count,
+			})
+		} else {
+			Ok(())
+		}
+	}
+}
+
+pub struct Interpreter<'a> {
+	bytecode: &'a [u8],
+	hints: &'a HintRegistry,
+	pc: usize,
+}
+
+impl<'a> Interpreter<'a> {
+	pub fn new(bytecode: &'a [u8], hints: &'a HintRegistry) -> Self {
+		Self {
+			bytecode,
+			hints,
+			pc: 0,
+		}
+	}
+
+	pub fn run_with_value_vec(
+		&mut self,
+		value_vec: &mut ValueVec,
+		scratch: Vec<Word>,
+	) -> Result<(), PopulateError> {
+		let mut ctx = ExecutionContext::new(value_vec, scratch);
+		self.run(&mut ctx)?;
+		ctx.check_assertions()
+	}
+
+	pub fn run(&mut self, ctx: &mut ExecutionContext<'_>) -> Result<(), PopulateError> {
+		while self.pc < self.bytecode.len() {
+			let opcode = self.read_u8();
+
+			match opcode {
+				// Bitwise operations
+				0x01 => self.exec_band(ctx),
+				0x02 => self.exec_bor(ctx),
+				0x03 => self.exec_bxor(ctx),
+				0x04 => self.exec_bnot(ctx),
+
+				// Shifts
+				0x10 => self.exec_sll(ctx),
+				0x11 => self.exec_slr(ctx),
+				0x12 => self.exec_sar(ctx),
+
+				// Arithmetic
+				0x20 => self.exec_iadd_cout(ctx),
+				0x21 => self.exec_iadd_cin_cout(ctx),
+				0x22 => self.exec_isub_bout(ctx),
+				0x23 => self.exec_isub_bin_bout(ctx),
+				0x30 => self.exec_imul(ctx),
+
+				// 32-bit operations
+				0x40 => self.exec_iadd_cout32(ctx),
+				0x41 => self.exec_rotr32(ctx),
+				0x42 => self.exec_shr32(ctx),
+				0x43 => self.exec_rotl(ctx),
+
+				// Masks
+				0x50 => self.exec_mask_low(ctx),
+				0x51 => self.exec_mask_high(ctx),
+
+				// Assertions
+				0x60 => self.exec_assert_eq(ctx),
+				0x61 => self.exec_assert_zero(ctx),
+				0x62 => self.exec_assert_cond(ctx),
+
+				// Hint calls
+				0x80 => self.exec_hint(ctx),
+
+				_ => panic!("Unknown opcode: {:#x} at pc={}", opcode, self.pc - 1),
+			}
+		}
+		Ok(())
+	}
+
+	// Bitwise operations
+	fn exec_band(&mut self, ctx: &mut ExecutionContext<'_>) {
+		let dst = self.read_reg();
+		let src1 = self.read_reg();
+		let src2 = self.read_reg();
+		let val = self.load(ctx, src1) & self.load(ctx, src2);
+		self.store(ctx, dst, val);
+	}
+
+	fn exec_bor(&mut self, ctx: &mut ExecutionContext<'_>) {
+		let dst = self.read_reg();
+		let src1 = self.read_reg();
+		let src2 = self.read_reg();
+		let val = self.load(ctx, src1) | self.load(ctx, src2);
+		self.store(ctx, dst, val);
+	}
+
+	fn exec_bxor(&mut self, ctx: &mut ExecutionContext<'_>) {
+		let dst = self.read_reg();
+		let src1 = self.read_reg();
+		let src2 = self.read_reg();
+		let val = self.load(ctx, src1) ^ self.load(ctx, src2);
+		self.store(ctx, dst, val);
+	}
+
+	fn exec_bnot(&mut self, ctx: &mut ExecutionContext<'_>) {
+		let dst = self.read_reg();
+		let src = self.read_reg();
+		let val = !self.load(ctx, src);
+		self.store(ctx, dst, val);
+	}
+
+	// Shifts
+	fn exec_sll(&mut self, ctx: &mut ExecutionContext<'_>) {
+		let dst = self.read_reg();
+		let src = self.read_reg();
+		let shift = self.read_u8() as u32;
+		let val = self.load(ctx, src) << shift;
+		self.store(ctx, dst, val);
+	}
+
+	fn exec_slr(&mut self, ctx: &mut ExecutionContext<'_>) {
+		let dst = self.read_reg();
+		let src = self.read_reg();
+		let shift = self.read_u8() as u32;
+		let val = self.load(ctx, src) >> shift;
+		self.store(ctx, dst, val);
+	}
+
+	fn exec_sar(&mut self, ctx: &mut ExecutionContext<'_>) {
+		let dst = self.read_reg();
+		let src = self.read_reg();
+		let shift = self.read_u8() as u32;
+		let val = self.load(ctx, src).sar(shift);
+		self.store(ctx, dst, val);
+	}
+
+	// Arithmetic operations
+	fn exec_iadd_cout(&mut self, ctx: &mut ExecutionContext<'_>) {
+		let dst_sum = self.read_reg();
+		let dst_cout = self.read_reg();
+		let src1 = self.read_reg();
+		let src2 = self.read_reg();
+		let (sum, cout) = self
+			.load(ctx, src1)
+			.iadd_cin_cout(self.load(ctx, src2), Word::ZERO);
+		self.store(ctx, dst_sum, sum);
+		self.store(ctx, dst_cout, cout);
+	}
+
+	fn exec_iadd_cin_cout(&mut self, ctx: &mut ExecutionContext<'_>) {
+		let dst_sum = self.read_reg();
+		let dst_cout = self.read_reg();
+		let src1 = self.read_reg();
+		let src2 = self.read_reg();
+		let cin = self.read_reg();
+		let cin_bit = self.load(ctx, cin) >> 63; // Use MSB as carry bit
+		let (sum, cout) = self
+			.load(ctx, src1)
+			.iadd_cin_cout(self.load(ctx, src2), cin_bit);
+		self.store(ctx, dst_sum, sum);
+		self.store(ctx, dst_cout, cout);
+	}
+
+	fn exec_isub_bout(&mut self, ctx: &mut ExecutionContext<'_>) {
+		let dst_diff = self.read_reg();
+		let dst_bout = self.read_reg();
+		let src1 = self.read_reg();
+		let src2 = self.read_reg();
+		let (diff, bout) = self
+			.load(ctx, src1)
+			.isub_bin_bout(self.load(ctx, src2), Word::ZERO);
+		self.store(ctx, dst_diff, diff);
+		self.store(ctx, dst_bout, bout);
+	}
+
+	fn exec_isub_bin_bout(&mut self, ctx: &mut ExecutionContext<'_>) {
+		let dst_diff = self.read_reg();
+		let dst_bout = self.read_reg();
+		let src1 = self.read_reg();
+		let src2 = self.read_reg();
+		let bin = self.read_reg();
+		let bin_bit = self.load(ctx, bin) >> 63; // Use MSB as borrow bit
+		let (diff, bout) = self
+			.load(ctx, src1)
+			.isub_bin_bout(self.load(ctx, src2), bin_bit);
+		self.store(ctx, dst_diff, diff);
+		self.store(ctx, dst_bout, bout);
+	}
+
+	fn exec_imul(&mut self, ctx: &mut ExecutionContext<'_>) {
+		let dst_hi = self.read_reg();
+		let dst_lo = self.read_reg();
+		let src1 = self.read_reg();
+		let src2 = self.read_reg();
+		let (hi, lo) = self.load(ctx, src1).imul(self.load(ctx, src2));
+		self.store(ctx, dst_hi, hi);
+		self.store(ctx, dst_lo, lo);
+	}
+
+	// 32-bit operations
+	fn exec_iadd_cout32(&mut self, ctx: &mut ExecutionContext<'_>) {
+		let dst_sum = self.read_reg();
+		let dst_cout = self.read_reg();
+		let src1 = self.read_reg();
+		let src2 = self.read_reg();
+		let (sum, cout) = self.load(ctx, src1).iadd_cout_32(self.load(ctx, src2));
+		self.store(ctx, dst_sum, sum);
+		self.store(ctx, dst_cout, cout);
+	}
+
+	fn exec_rotr32(&mut self, ctx: &mut ExecutionContext<'_>) {
+		let dst = self.read_reg();
+		let src = self.read_reg();
+		let rotate = self.read_u8() as u32;
+		let val = self.load(ctx, src).rotr_32(rotate);
+		self.store(ctx, dst, val);
+	}
+
+	fn exec_shr32(&mut self, ctx: &mut ExecutionContext<'_>) {
+		let dst = self.read_reg();
+		let src = self.read_reg();
+		let shift = self.read_u8() as u32;
+		let val = self.load(ctx, src).shr_32(shift);
+		self.store(ctx, dst, val);
+	}
+
+	fn exec_rotl(&mut self, ctx: &mut ExecutionContext<'_>) {
+		let dst = self.read_reg();
+		let src = self.read_reg();
+		let rotate = self.read_u8() as u32;
+		let val = self.load(ctx, src).rotl_64(rotate);
+		self.store(ctx, dst, val);
+	}
+
+	// Mask operations
+	fn exec_mask_low(&mut self, ctx: &mut ExecutionContext<'_>) {
+		let dst = self.read_reg();
+		let src = self.read_reg();
+		let n_bits = self.read_u8();
+		let mask = if n_bits >= 64 {
+			Word::ALL_ONE
+		} else {
+			Word::from_u64((1u64 << n_bits) - 1)
+		};
+		let val = self.load(ctx, src) & mask;
+		self.store(ctx, dst, val);
+	}
+
+	fn exec_mask_high(&mut self, ctx: &mut ExecutionContext<'_>) {
+		let dst = self.read_reg();
+		let src = self.read_reg();
+		let n_bits = self.read_u8();
+		let mask = if n_bits >= 64 {
+			Word::ALL_ONE
+		} else {
+			Word::from_u64(!((1u64 << (64 - n_bits)) - 1))
+		};
+		let val = self.load(ctx, src) & mask;
+		self.store(ctx, dst, val);
+	}
+
+	// Assertions
+	fn exec_assert_eq(&mut self, ctx: &mut ExecutionContext<'_>) {
+		let src1 = self.read_reg();
+		let src2 = self.read_reg();
+		let error_id = self.read_u32();
+
+		let val1 = self.load(ctx, src1);
+		let val2 = self.load(ctx, src2);
+
+		if val1 != val2 {
+			ctx.note_assertion_failure(error_id, format!("{val1:?} != {val2:?}"));
+		}
+	}
+
+	fn exec_assert_zero(&mut self, ctx: &mut ExecutionContext<'_>) {
+		let src = self.read_reg();
+		let error_id = self.read_u32();
+
+		let val = self.load(ctx, src);
+
+		if val != Word::ZERO {
+			ctx.note_assertion_failure(error_id, format!("{val:?} != 0"));
+		}
+	}
+
+	fn exec_assert_cond(&mut self, ctx: &mut ExecutionContext<'_>) {
+		let cond = self.read_reg();
+		let src1 = self.read_reg();
+		let src2 = self.read_reg();
+		let error_id = self.read_u32();
+
+		let cond_val = self.load(ctx, cond);
+
+		// Only assert if condition is non-zero
+		if cond_val != Word::ZERO {
+			let val1 = self.load(ctx, src1);
+			let val2 = self.load(ctx, src2);
+
+			if val1 != val2 {
+				ctx.note_assertion_failure(
+					error_id,
+					format!("conditional assert: {val1:?} != {val2:?}"),
+				);
+			}
+		}
+	}
+
+	// Hint execution
+	fn exec_hint(&mut self, ctx: &mut ExecutionContext<'_>) {
+		let hint_id = self.read_u32() as usize;
+
+		// Read dimensions
+		let n_dimensions = self.read_u16() as usize;
+		let mut dimensions = Vec::with_capacity(n_dimensions);
+		for _ in 0..n_dimensions {
+			dimensions.push(self.read_u32() as usize);
+		}
+
+		let n_inputs = self.read_u16() as usize;
+		let n_outputs = self.read_u16() as usize;
+
+		// Collect input values
+		let mut inputs = Vec::with_capacity(n_inputs);
+		for _ in 0..n_inputs {
+			let reg = self.read_reg();
+			inputs.push(self.load(ctx, reg));
+		}
+
+		// Prepare output buffer
+		let mut outputs = vec![Word::ZERO; n_outputs];
+
+		self.hints
+			.execute(hint_id, &dimensions, &inputs, &mut outputs);
+
+		// Store outputs
+		for output_val in outputs {
+			let dst = self.read_reg();
+			self.store(ctx, dst, output_val);
+		}
+	}
+
+	fn load(&self, ctx: &ExecutionContext<'_>, reg: u32) -> Word {
+		if let Some(scratch_reg) = as_scratch_reg(reg) {
+			ctx.scratch[scratch_reg as usize]
+		} else {
+			ctx.value_vec[ValueIndex(reg)]
+		}
+	}
+
+	fn store(&self, ctx: &mut ExecutionContext<'_>, reg: u32, value: Word) {
+		if let Some(scratch_reg) = as_scratch_reg(reg) {
+			ctx.scratch[scratch_reg as usize] = value;
+		} else {
+			ctx.value_vec.set(reg as usize, value);
+		}
+	}
+
+	// Bytecode reading helpers
+	fn read_u8(&mut self) -> u8 {
+		let val = self.bytecode[self.pc];
+		self.pc += 1;
+		val
+	}
+
+	fn read_u16(&mut self) -> u16 {
+		let val = u16::from_le_bytes([self.bytecode[self.pc], self.bytecode[self.pc + 1]]);
+		self.pc += 2;
+		val
+	}
+
+	fn read_u32(&mut self) -> u32 {
+		let val = u32::from_le_bytes([
+			self.bytecode[self.pc],
+			self.bytecode[self.pc + 1],
+			self.bytecode[self.pc + 2],
+			self.bytecode[self.pc + 3],
+		]);
+		self.pc += 4;
+		val
+	}
+
+	fn read_reg(&mut self) -> u32 {
+		self.read_u32()
+	}
+}
+
+fn as_scratch_reg(reg: u32) -> Option<u32> {
+	if reg & 0x8000_0000 != 0 {
+		Some(reg & 0x7FFF_FFFF)
+	} else {
+		None
+	}
+}

--- a/crates/frontend/src/compiler/eval_form/mod.rs
+++ b/crates/frontend/src/compiler/eval_form/mod.rs
@@ -1,0 +1,88 @@
+//! Circuit representation in the evaluation form.
+//!
+//! The main purpose of the evaluation form is to evaluate and assign the intermediate witness
+//! values. Those are also referred as internal wires.
+
+mod builder;
+mod interpreter;
+
+use binius_core::{ValueIndex, ValueVec, Word};
+pub use builder::BytecodeBuilder;
+use cranelift_entity::SecondaryMap;
+pub use interpreter::{AssertionFailure, ExecutionContext};
+
+use crate::compiler::{
+	circuit::PopulateError,
+	gate,
+	gate_graph::{GateGraph, Wire},
+	hints::HintRegistry,
+};
+
+/// Compiled evaluation form for circuit witness computation
+pub struct EvalForm {
+	/// Compiled bytecode instructions
+	bytecode: Vec<u8>,
+	/// Number of scratch registers needed
+	n_scratch: usize,
+	/// Registered hint handlers
+	hint_registry: HintRegistry,
+}
+
+impl EvalForm {
+	/// Build the evaluation form from the gate graph
+	pub(crate) fn build(
+		gate_graph: &GateGraph,
+		wire_mapping: &SecondaryMap<Wire, ValueIndex>,
+		scratch_mapping: &SecondaryMap<Wire, u32>,
+		n_scratch: usize,
+	) -> Self {
+		let mut builder = BytecodeBuilder::new();
+		let mut hint_registry = HintRegistry::new();
+
+		// Combined wire to register mapping
+		let wire_to_reg = |wire: Wire| -> u32 {
+			// IMPORTANT: SecondaryMap returns default value (0) for non-existent keys!
+			// We need to check if the value has the high bit set to know if it's a real scratch
+			// register
+			let scratch_reg = scratch_mapping[wire];
+			if scratch_reg & 0x8000_0000 != 0 {
+				// This is a real scratch register (high bit is set)
+				scratch_reg // Already has high bit set
+			} else if let Some(&ValueIndex(idx)) = wire_mapping.get(wire) {
+				idx // ValueVec index
+			} else {
+				panic!("Wire {wire:?} not mapped");
+			}
+		};
+
+		// Build bytecode for each gate
+		for (gate_id, data) in gate_graph.gates.iter() {
+			gate::emit_gate_bytecode(
+				gate_id,
+				data,
+				gate_graph,
+				&mut builder,
+				wire_to_reg,
+				&mut hint_registry,
+			);
+		}
+
+		let bytecode = builder.finalize();
+
+		EvalForm {
+			bytecode,
+			n_scratch,
+			hint_registry,
+		}
+	}
+
+	/// Execute the evaluation form to populate witness values
+	pub fn evaluate(&self, value_vec: &mut ValueVec) -> Result<(), PopulateError> {
+		let scratch = vec![Word::ZERO; self.n_scratch];
+
+		let mut interpreter = interpreter::Interpreter::new(&self.bytecode, &self.hint_registry);
+		interpreter.run_with_value_vec(value_vec, scratch)?;
+
+		Ok(())
+	}
+}

--- a/crates/frontend/src/compiler/gate/assert_eq.rs
+++ b/crates/frontend/src/compiler/gate/assert_eq.rs
@@ -14,10 +14,9 @@
 use binius_core::word::Word;
 
 use crate::compiler::{
-	circuit,
 	constraint_builder::{ConstraintBuilder, empty, xor2},
 	gate::opcode::OpcodeShape,
-	gate_graph::{Gate, GateData, GateParam},
+	gate_graph::{Gate, GateData, GateParam, Wire},
 	pathspec::PathSpec,
 };
 
@@ -27,6 +26,7 @@ pub fn shape() -> OpcodeShape {
 		n_in: 2,
 		n_out: 0,
 		n_internal: 0,
+		n_scratch: 0,
 		n_imm: 0,
 	}
 }
@@ -42,16 +42,14 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 	builder.and().a(xor2(*x, *y)).b(*all_1).c(empty()).build();
 }
 
-pub fn evaluate(
+pub fn emit_eval_bytecode(
 	_gate: Gate,
 	data: &GateData,
 	assertion_path: PathSpec,
-	w: &mut circuit::WitnessFiller,
+	builder: &mut crate::compiler::eval_form::BytecodeBuilder,
+	wire_to_reg: impl Fn(Wire) -> u32,
 ) {
 	let GateParam { inputs, .. } = data.gate_param();
 	let [x, y] = inputs else { unreachable!() };
-
-	if w[*x] != w[*y] {
-		w.flag_assertion_failed(assertion_path, |w| format!("{:?} != {:?}", w[*x], w[*y]));
-	}
+	builder.emit_assert_eq(wire_to_reg(*x), wire_to_reg(*y), assertion_path.as_u32());
 }

--- a/crates/frontend/src/compiler/gate/assert_eq_cond.rs
+++ b/crates/frontend/src/compiler/gate/assert_eq_cond.rs
@@ -13,13 +13,10 @@
 //! The gate generates 1 AND constraint:
 //! - `(x ⊕ y) ∧ mask = 0`
 
-use binius_core::word::Word;
-
 use crate::compiler::{
-	circuit,
 	constraint_builder::{ConstraintBuilder, empty, xor2},
 	gate::opcode::OpcodeShape,
-	gate_graph::{Gate, GateData, GateParam},
+	gate_graph::{Gate, GateData, GateParam, Wire},
 	pathspec::PathSpec,
 };
 
@@ -29,6 +26,7 @@ pub fn shape() -> OpcodeShape {
 		n_in: 3,
 		n_out: 0,
 		n_internal: 0,
+		n_scratch: 0,
 		n_imm: 0,
 	}
 }
@@ -41,19 +39,19 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 	builder.and().a(xor2(*x, *y)).b(*mask).c(empty()).build();
 }
 
-pub fn evaluate(
+pub fn emit_eval_bytecode(
 	_gate: Gate,
 	data: &GateData,
 	assertion_path: PathSpec,
-	w: &mut circuit::WitnessFiller,
+	builder: &mut crate::compiler::eval_form::BytecodeBuilder,
+	wire_to_reg: impl Fn(Wire) -> u32,
 ) {
 	let GateParam { inputs, .. } = data.gate_param();
 	let [x, y, mask] = inputs else { unreachable!() };
-
-	let diff = w[*x] ^ w[*y];
-	if (diff & w[*mask]) != Word::ZERO {
-		w.flag_assertion_failed(assertion_path, |w| {
-			format!("({:?} ^ {:?}) & {:?} != 0", w[*x], w[*y], w[*mask])
-		});
-	}
+	builder.emit_assert_cond(
+		wire_to_reg(*mask),
+		wire_to_reg(*x),
+		wire_to_reg(*y),
+		assertion_path.as_u32(),
+	);
 }

--- a/crates/frontend/src/compiler/gate/band.rs
+++ b/crates/frontend/src/compiler/gate/band.rs
@@ -12,10 +12,9 @@
 //! - `x ∧ y = z`
 
 use crate::compiler::{
-	circuit,
 	constraint_builder::ConstraintBuilder,
 	gate::opcode::OpcodeShape,
-	gate_graph::{Gate, GateData, GateParam},
+	gate_graph::{Gate, GateData, GateParam, Wire},
 };
 
 pub fn shape() -> OpcodeShape {
@@ -24,6 +23,7 @@ pub fn shape() -> OpcodeShape {
 		n_in: 2,
 		n_out: 1,
 		n_internal: 0,
+		n_scratch: 0,
 		n_imm: 0,
 	}
 }
@@ -41,12 +41,17 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 	builder.and().a(*x).b(*y).c(*z).build();
 }
 
-pub fn evaluate(_gate: Gate, data: &GateData, w: &mut circuit::WitnessFiller) {
+pub fn emit_eval_bytecode(
+	_gate: Gate,
+	data: &GateData,
+	builder: &mut crate::compiler::eval_form::BytecodeBuilder,
+	wire_to_reg: impl Fn(Wire) -> u32,
+) {
 	let GateParam {
 		inputs, outputs, ..
 	} = data.gate_param();
 	let [x, y] = inputs else { unreachable!() };
 	let [z] = outputs else { unreachable!() };
 
-	w[*z] = w[*x] & w[*y];
+	builder.emit_band(wire_to_reg(*z), wire_to_reg(*x), wire_to_reg(*y));
 }

--- a/crates/frontend/src/compiler/gate/bxor.rs
+++ b/crates/frontend/src/compiler/gate/bxor.rs
@@ -15,10 +15,9 @@
 use binius_core::word::Word;
 
 use crate::compiler::{
-	circuit,
 	constraint_builder::{ConstraintBuilder, xor2},
 	gate::opcode::OpcodeShape,
-	gate_graph::{Gate, GateData, GateParam},
+	gate_graph::{Gate, GateData, GateParam, Wire},
 };
 
 pub fn shape() -> OpcodeShape {
@@ -27,6 +26,7 @@ pub fn shape() -> OpcodeShape {
 		n_in: 2,
 		n_out: 1,
 		n_internal: 0,
+		n_scratch: 0,
 		n_imm: 0,
 	}
 }
@@ -48,12 +48,17 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 	builder.and().a(xor2(*x, *y)).b(*all_1).c(*z).build();
 }
 
-pub fn evaluate(_gate: Gate, data: &GateData, w: &mut circuit::WitnessFiller) {
+pub fn emit_eval_bytecode(
+	_gate: Gate,
+	data: &GateData,
+	builder: &mut crate::compiler::eval_form::BytecodeBuilder,
+	wire_to_reg: impl Fn(Wire) -> u32,
+) {
 	let GateParam {
 		inputs, outputs, ..
 	} = data.gate_param();
 	let [x, y] = inputs else { unreachable!() };
 	let [z] = outputs else { unreachable!() };
 
-	w[*z] = w[*x] ^ w[*y];
+	builder.emit_bxor(wire_to_reg(*z), wire_to_reg(*x), wire_to_reg(*y));
 }

--- a/crates/frontend/src/compiler/gate/opcode.rs
+++ b/crates/frontend/src/compiler/gate/opcode.rs
@@ -45,6 +45,7 @@ pub struct OpcodeShape {
 	pub n_in: usize,
 	pub n_out: usize,
 	pub n_internal: usize,
+	pub n_scratch: usize,
 	pub n_imm: usize,
 }
 

--- a/crates/frontend/src/compiler/gate/rotl64.rs
+++ b/crates/frontend/src/compiler/gate/rotl64.rs
@@ -21,10 +21,9 @@
 use binius_core::word::Word;
 
 use crate::compiler::{
-	circuit,
 	constraint_builder::{ConstraintBuilder, sll, srl, xor2},
 	gate::opcode::OpcodeShape,
-	gate_graph::{Gate, GateData, GateParam},
+	gate_graph::{Gate, GateData, GateParam, Wire},
 };
 
 pub fn shape() -> OpcodeShape {
@@ -33,6 +32,7 @@ pub fn shape() -> OpcodeShape {
 		n_in: 1,
 		n_out: 1,
 		n_internal: 0,
+		n_scratch: 0,
 		n_imm: 1,
 	}
 }
@@ -60,7 +60,12 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 		.build();
 }
 
-pub fn evaluate(_gate: Gate, data: &GateData, w: &mut circuit::WitnessFiller) {
+pub fn emit_eval_bytecode(
+	_gate: Gate,
+	data: &GateData,
+	builder: &mut crate::compiler::eval_form::BytecodeBuilder,
+	wire_to_reg: impl Fn(Wire) -> u32,
+) {
 	let GateParam {
 		inputs,
 		outputs,
@@ -70,7 +75,5 @@ pub fn evaluate(_gate: Gate, data: &GateData, w: &mut circuit::WitnessFiller) {
 	let [x] = inputs else { unreachable!() };
 	let [z] = outputs else { unreachable!() };
 	let [n] = imm else { unreachable!() };
-
-	let result = w[*x].rotl_64(*n);
-	w[*z] = result;
+	builder.emit_rotl(wire_to_reg(*z), wire_to_reg(*x), *n as u8);
 }

--- a/crates/frontend/src/compiler/gate/rotr32.rs
+++ b/crates/frontend/src/compiler/gate/rotr32.rs
@@ -21,10 +21,9 @@
 use binius_core::word::Word;
 
 use crate::compiler::{
-	circuit,
 	constraint_builder::{ConstraintBuilder, sll, srl, xor2},
 	gate::opcode::OpcodeShape,
-	gate_graph::{Gate, GateData, GateParam},
+	gate_graph::{Gate, GateData, GateParam, Wire},
 };
 
 pub fn shape() -> OpcodeShape {
@@ -33,6 +32,7 @@ pub fn shape() -> OpcodeShape {
 		n_in: 1,
 		n_out: 1,
 		n_internal: 0,
+		n_scratch: 0,
 		n_imm: 1,
 	}
 }
@@ -60,7 +60,12 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 		.build();
 }
 
-pub fn evaluate(_gate: Gate, data: &GateData, w: &mut circuit::WitnessFiller) {
+pub fn emit_eval_bytecode(
+	_gate: Gate,
+	data: &GateData,
+	builder: &mut crate::compiler::eval_form::BytecodeBuilder,
+	wire_to_reg: impl Fn(Wire) -> u32,
+) {
 	let GateParam {
 		inputs,
 		outputs,
@@ -70,7 +75,5 @@ pub fn evaluate(_gate: Gate, data: &GateData, w: &mut circuit::WitnessFiller) {
 	let [x] = inputs else { unreachable!() };
 	let [z] = outputs else { unreachable!() };
 	let [n] = imm else { unreachable!() };
-
-	let result = w[*x].rotr_32(*n);
-	w[*z] = result;
+	builder.emit_rotr32(wire_to_reg(*z), wire_to_reg(*x), *n as u8);
 }

--- a/crates/frontend/src/compiler/gate/shl.rs
+++ b/crates/frontend/src/compiler/gate/shl.rs
@@ -15,10 +15,9 @@
 use binius_core::word::Word;
 
 use crate::compiler::{
-	circuit,
 	constraint_builder::{ConstraintBuilder, sll},
 	gate::opcode::OpcodeShape,
-	gate_graph::{Gate, GateData, GateParam},
+	gate_graph::{Gate, GateData, GateParam, Wire},
 };
 
 pub fn shape() -> OpcodeShape {
@@ -27,6 +26,7 @@ pub fn shape() -> OpcodeShape {
 		n_in: 1,
 		n_out: 1,
 		n_internal: 0,
+		n_scratch: 0,
 		n_imm: 1,
 	}
 }
@@ -49,7 +49,12 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 	builder.and().a(sll(*x, *n)).b(*all_1).c(*z).build();
 }
 
-pub fn evaluate(_gate: Gate, data: &GateData, w: &mut circuit::WitnessFiller) {
+pub fn emit_eval_bytecode(
+	_gate: Gate,
+	data: &GateData,
+	builder: &mut crate::compiler::eval_form::BytecodeBuilder,
+	wire_to_reg: impl Fn(Wire) -> u32,
+) {
 	let GateParam {
 		inputs,
 		outputs,
@@ -59,7 +64,5 @@ pub fn evaluate(_gate: Gate, data: &GateData, w: &mut circuit::WitnessFiller) {
 	let [x] = inputs else { unreachable!() };
 	let [z] = outputs else { unreachable!() };
 	let [n] = imm else { unreachable!() };
-
-	let result = w[*x] << *n;
-	w[*z] = result;
+	builder.emit_sll(wire_to_reg(*z), wire_to_reg(*x), *n as u8);
 }

--- a/crates/frontend/src/compiler/gate/shr.rs
+++ b/crates/frontend/src/compiler/gate/shr.rs
@@ -15,10 +15,9 @@
 use binius_core::word::Word;
 
 use crate::compiler::{
-	circuit,
 	constraint_builder::{ConstraintBuilder, srl},
 	gate::opcode::OpcodeShape,
-	gate_graph::{Gate, GateData, GateParam},
+	gate_graph::{Gate, GateData, GateParam, Wire},
 };
 
 pub fn shape() -> OpcodeShape {
@@ -27,6 +26,7 @@ pub fn shape() -> OpcodeShape {
 		n_in: 1,
 		n_out: 1,
 		n_internal: 0,
+		n_scratch: 0,
 		n_imm: 1,
 	}
 }
@@ -49,7 +49,12 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 	builder.and().a(srl(*x, *n)).b(*all_1).c(*z).build();
 }
 
-pub fn evaluate(_gate: Gate, data: &GateData, w: &mut circuit::WitnessFiller) {
+pub fn emit_eval_bytecode(
+	_gate: Gate,
+	data: &GateData,
+	builder: &mut crate::compiler::eval_form::BytecodeBuilder,
+	wire_to_reg: impl Fn(Wire) -> u32,
+) {
 	let GateParam {
 		inputs,
 		outputs,
@@ -59,7 +64,5 @@ pub fn evaluate(_gate: Gate, data: &GateData, w: &mut circuit::WitnessFiller) {
 	let [x] = inputs else { unreachable!() };
 	let [z] = outputs else { unreachable!() };
 	let [n] = imm else { unreachable!() };
-
-	let result = w[*x] >> *n;
-	w[*z] = result;
+	builder.emit_slr(wire_to_reg(*z), wire_to_reg(*x), *n as u8);
 }

--- a/crates/frontend/src/compiler/hints/big_uint_divide.rs
+++ b/crates/frontend/src/compiler/hints/big_uint_divide.rs
@@ -1,0 +1,72 @@
+//! BigUint division hint implementation
+
+use binius_core::Word;
+
+use super::Hint;
+use crate::util::num_biguint_from_u64_limbs;
+
+pub struct BigUintDivideHint;
+
+impl BigUintDivideHint {
+	pub fn new() -> Self {
+		Self
+	}
+}
+
+impl Default for BigUintDivideHint {
+	fn default() -> Self {
+		Self::new()
+	}
+}
+
+impl Hint for BigUintDivideHint {
+	fn shape(&self, dimensions: &[usize]) -> (usize, usize) {
+		let [dividend_limbs, divisor_limbs] = dimensions else {
+			panic!("BigUintDivide requires 2 dimensions");
+		};
+		(*dividend_limbs + *divisor_limbs, *dividend_limbs + *divisor_limbs)
+	}
+
+	fn execute(&self, dimensions: &[usize], inputs: &[Word], outputs: &mut [Word]) {
+		let [n_dividend, n_divisor] = dimensions else {
+			panic!("BigUintDivide requires 2 dimensions");
+		};
+		let n_quotient = *n_dividend;
+		let n_remainder = *n_divisor;
+
+		let dividend_limbs = &inputs[0..*n_dividend];
+		let divisor_limbs = &inputs[*n_dividend..];
+
+		let dividend = num_biguint_from_u64_limbs(dividend_limbs.iter().map(|w| w.as_u64()));
+		let divisor = num_biguint_from_u64_limbs(divisor_limbs.iter().map(|w| w.as_u64()));
+
+		let zero = num_bigint::BigUint::ZERO;
+		let (quotient, remainder) = if divisor != zero {
+			(dividend.clone() / divisor.clone(), dividend % divisor)
+		} else {
+			(zero.clone(), zero.clone())
+		};
+
+		// Fill quotient limbs (first part of output)
+		for (i, limb) in quotient.iter_u64_digits().enumerate() {
+			if i < n_quotient {
+				outputs[i] = Word::from_u64(limb);
+			}
+		}
+		// Zero remaining quotient outputs
+		for i in quotient.iter_u64_digits().len()..n_quotient {
+			outputs[i] = Word::ZERO;
+		}
+
+		// Fill remainder limbs (second part of output)
+		for (i, limb) in remainder.iter_u64_digits().enumerate() {
+			if i < n_remainder {
+				outputs[n_quotient + i] = Word::from_u64(limb);
+			}
+		}
+		// Zero remaining remainder outputs
+		for i in remainder.iter_u64_digits().len()..n_remainder {
+			outputs[n_quotient + i] = Word::ZERO;
+		}
+	}
+}

--- a/crates/frontend/src/compiler/hints/mod.rs
+++ b/crates/frontend/src/compiler/hints/mod.rs
@@ -1,0 +1,70 @@
+//! Hint system.
+//!
+//! Hints are deterministic computations that happen on the prover side.
+//!
+//! They can be used for operations that require many constraints to compute but few constraints
+//! to verify.
+
+use binius_core::Word;
+
+mod big_uint_divide;
+mod mod_inverse;
+
+pub use big_uint_divide::BigUintDivideHint;
+pub use mod_inverse::ModInverseHint;
+
+pub type HintId = u32;
+
+/// Hint handler trait for extensible operations
+pub trait Hint: Send + Sync {
+	/// Execute the hint with given inputs, writing outputs
+	fn execute(&self, dimensions: &[usize], inputs: &[Word], outputs: &mut [Word]);
+
+	/// Get the shape of this hint (n_inputs, n_outputs)
+	fn shape(&self, dimensions: &[usize]) -> (usize, usize);
+}
+
+/// Registry for hint handlers
+pub struct HintRegistry {
+	handlers: Vec<Box<dyn Hint>>,
+}
+
+impl HintRegistry {
+	pub fn new() -> Self {
+		Self {
+			handlers: Vec::new(),
+		}
+	}
+
+	pub fn register(&mut self, handler: Box<dyn Hint>) -> HintId {
+		let id = self.handlers.len() as HintId;
+		self.handlers.push(handler);
+		id
+	}
+
+	pub fn execute(
+		&self,
+		hint_id: usize,
+		dimensions: &[usize],
+		inputs: &[Word],
+		outputs: &mut [Word],
+	) {
+		self.handlers[hint_id].execute(dimensions, inputs, outputs);
+	}
+
+	/// Get the number of registered hints
+	pub fn len(&self) -> usize {
+		self.handlers.len()
+	}
+
+	/// Check if the registry is empty
+	pub fn is_empty(&self) -> bool {
+		self.handlers.is_empty()
+	}
+}
+
+impl Default for HintRegistry {
+	fn default() -> Self {
+		Self::new()
+	}
+}

--- a/crates/frontend/src/compiler/hints/mod_inverse.rs
+++ b/crates/frontend/src/compiler/hints/mod_inverse.rs
@@ -1,0 +1,72 @@
+//! Modular inverse hint implementation
+
+use binius_core::Word;
+
+use super::Hint;
+use crate::util::num_biguint_from_u64_limbs;
+
+/// ModInverse hint implementation
+pub struct ModInverseHint;
+
+impl ModInverseHint {
+	pub fn new() -> Self {
+		Self
+	}
+}
+
+impl Default for ModInverseHint {
+	fn default() -> Self {
+		Self::new()
+	}
+}
+
+impl Hint for ModInverseHint {
+	fn shape(&self, dimensions: &[usize]) -> (usize, usize) {
+		let [base_limbs, mod_limbs] = dimensions else {
+			panic!("ModInverse requires 2 dimensions");
+		};
+		(*base_limbs + *mod_limbs, 2 * *mod_limbs)
+	}
+
+	fn execute(&self, dimensions: &[usize], inputs: &[Word], outputs: &mut [Word]) {
+		let [n_base, n_mod] = dimensions else {
+			panic!("ModInverse requires 2 dimensions");
+		};
+
+		let base_limbs = &inputs[0..*n_base];
+		let mod_limbs = &inputs[*n_base..];
+
+		let base = num_biguint_from_u64_limbs(base_limbs.iter().map(|w| w.as_u64()));
+		let modulus = num_biguint_from_u64_limbs(mod_limbs.iter().map(|w| w.as_u64()));
+
+		let zero = num_bigint::BigUint::ZERO;
+		let (quotient, inverse) = if let Some(inverse) = base.modinv(&modulus) {
+			let quotient = (base * &inverse - num_bigint::BigUint::from(1usize)) / &modulus;
+			(quotient, inverse)
+		} else {
+			(zero.clone(), zero)
+		};
+
+		assert_eq!(outputs.len(), 2 * *n_mod);
+		let (quotient_words, inverse_words) = outputs.split_at_mut(*n_mod);
+
+		// Fill output quotient limbs
+		for (i, limb) in quotient.iter_u64_digits().enumerate() {
+			quotient_words[i] = Word::from_u64(limb);
+		}
+
+		// Zero remaining outputs if quotient has fewer limbs
+		for i in quotient.iter_u64_digits().len()..*n_mod {
+			quotient_words[i] = Word::ZERO;
+		}
+
+		// Fill output inverse limbs
+		for (i, limb) in inverse.iter_u64_digits().enumerate() {
+			inverse_words[i] = Word::from_u64(limb);
+		}
+		// Zero remaining outputs if inverse has fewer limbs
+		for i in inverse.iter_u64_digits().len()..*n_mod {
+			inverse_words[i] = Word::ZERO;
+		}
+	}
+}


### PR DESCRIPTION
Ok so this is the first sketch of the evaluation form of the circuit. It's really bare bones and really raw. But I am submitting it anyway so that we integrate it faster and avoid conflicts.

Right now, it does work and seems to be correct. But.

**It does not have the shape we want**. Right now the gates just emit bytecodes directly. This is not what we want for the purposes of constant propagation. Nor we can deduplicate committed internal witnesses based on this structure.

**The hint mechanism is unbaked**. It kind of gets into the shape envisioned but it's still not what we want. Specifically, right now it's still a gate and we don't want that. Moreover, we register the hint each time we emit such a gate. And finally, the serialization aspect is basically ignored. This is all left for the follow-up work.

**Non-optimal**. Right now this regressses witness filling performance from 30%-200% on smaller circuits (like sha256 2 KiB and zklogin). Curiously, it actually works 2x faster on bigger circuits like sha256 1 MiB. There are several reasons for that, like conditional branching on every load and store, and similiar stuff. Work on this is deferred for the follow-up PRs.

It's also concievable that this is not even getting back on par with the previous mechanism. That seems to be alright becuase it allows us to optimize the constraint system.
