### PR TITLE
Returning quotient (second Bezout coefficient) from modular inverse hint.

### DIFF
--- a/crates/frontend/src/compiler/tests.rs
+++ b/crates/frontend/src/compiler/tests.rs
@@ -230,15 +230,19 @@ fn test_mod_inverse_hint() {
 	let m0 = builder.add_constant_64(u64::MAX);
 	let m1 = builder.add_constant_64((1u64 << 63) - 1);
 
-	let inv = builder.mod_inverse_hint(&[b], &[m0, m1]);
+	let (quotient, inverse) = builder.mod_inverse_hint(&[b], &[m0, m1]);
 
 	let circuit = builder.build();
 	let mut w = circuit.new_witness_filler();
 	circuit.populate_wire_witness(&mut w).unwrap();
 
-	assert_eq!(inv.len(), 2);
-	assert_eq!(w[inv[0]], Word(0xe5a542e11f99750a));
-	assert_eq!(w[inv[1]], Word(0x1849faf75fbb9752));
+	assert_eq!(inverse.len(), 2);
+	assert_eq!(w[inverse[0]], Word(0xe5a542e11f99750a));
+	assert_eq!(w[inverse[1]], Word(0x1849faf75fbb9752));
+
+	assert_eq!(quotient.len(), 2);
+	assert_eq!(w[quotient[0]], Word(0x37455c1554b9aa1));
+	assert_eq!(w[quotient[1]], Word::ZERO);
 }
 
 #[test]
@@ -251,15 +255,19 @@ fn test_mod_inverse_hint_non_coprime() {
 	let m0 = builder.add_constant_64(0xfffffffffff80001);
 	let m1 = builder.add_constant_64(0x3ffff7ffffffffff);
 
-	let inv = builder.mod_inverse_hint(&[b], &[m0, m1]);
+	let (quotient, inverse) = builder.mod_inverse_hint(&[b], &[m0, m1]);
 
 	let circuit = builder.build();
 	let mut w = circuit.new_witness_filler();
 	circuit.populate_wire_witness(&mut w).unwrap();
 
-	assert_eq!(inv.len(), 2);
-	assert_eq!(w[inv[0]], Word::ZERO);
-	assert_eq!(w[inv[1]], Word::ZERO);
+	assert_eq!(inverse.len(), 2);
+	assert_eq!(w[inverse[0]], Word::ZERO);
+	assert_eq!(w[inverse[1]], Word::ZERO);
+
+	assert_eq!(quotient.len(), 2);
+	assert_eq!(w[quotient[0]], Word::ZERO);
+	assert_eq!(w[quotient[1]], Word::ZERO);
 }
 
 fn prop_check_icmp_ult(a: u64, b: u64, expected_result: Word) {


### PR DESCRIPTION
Returning `quotient`, the second Bézout coefficient of `gcd(base, modulus)`, from the modular inverse hint. That's needed to constraint the field inverse.