### PR TITLE
implement digest trait for size-4 vision

### DIFF
--- a/crates/verifier/Cargo.toml
+++ b/crates/verifier/Cargo.toml
@@ -30,3 +30,4 @@ binius-math = { path = "../math", features = ["test-utils"] }
 proptest.workspace = true
 rand = { workspace = true, features = ["std_rng"] }
 itertools.workspace = true
+hex-literal.workspace = true

--- a/crates/verifier/src/hash/mod.rs
+++ b/crates/verifier/src/hash/mod.rs
@@ -1,7 +1,9 @@
+// Copyright 2025 Irreducible Inc.
+
 pub mod compress;
 mod serialization;
-#[allow(dead_code)]
-mod vision;
+
+pub mod vision;
 
 pub use compress::{CompressionFunction, PseudoCompressionFunction};
 pub use serialization::*;

--- a/crates/verifier/src/hash/vision/constants.rs
+++ b/crates/verifier/src/hash/vision/constants.rs
@@ -3,6 +3,7 @@
 use binius_field::BinaryField128bGhash as Ghash;
 
 pub const M: usize = 4;
+
 pub const BYTES_PER_GHASH: usize = 16;
 
 pub const NUM_ROUNDS: usize = 8;
@@ -146,39 +147,6 @@ pub static B_INV_COEFFS: [Ghash; 1 + 128] = [
 	Ghash::new(0xd9bc6edaf1b4a689ba169b5554228af8),
 ];
 
-pub static INITIAL_CONSTANT: [Ghash; 4] = [
-	Ghash::new(0xd0e015190f5e0795f4a1d28234ffdf87),
-	Ghash::new(0x6111731acd9a89f6b93ec3a23ec7681b),
-	Ghash::new(0x15da8de707ee3f3918a34a96728b8d29),
-	Ghash::new(0x2ea920e89fbb13a1ed2a216b1d232bfb),
-];
-
-pub static CONSTANTS_MATRIX: [Ghash; 16] = [
-	Ghash::new(0x1cac9af051191d2c8ef96344bc8cbd0f),
-	Ghash::new(0x3ceb350e8c2d2f4d4750ab0a854c3a4d),
-	Ghash::new(0x09cc78f7eafef94d8e092e899156946b),
-	Ghash::new(0x1d1ad17c8c7ee715a3d58f7eedb30dbb),
-	Ghash::new(0x06bee572113950b3dd0cdae9dff5dfc5),
-	Ghash::new(0x4799c3743a3560428b4bfa1a5cd3d295),
-	Ghash::new(0x516883bf97b07fcf4cb89ac6bf636d0b),
-	Ghash::new(0x0b681d1621d6aa1fdf1a9113b04d755b),
-	Ghash::new(0xe9ba2f01051f6b4b3ddfe74c125e99e5),
-	Ghash::new(0x1f58efc5ecf2e1b933e31cfb26b916d1),
-	Ghash::new(0x36da671249b5444cf67efc573241fe19),
-	Ghash::new(0x056cae18b867d486615a130556e5eb99),
-	Ghash::new(0x1d8645dd4b1e46b78dd9df84956bcf11),
-	Ghash::new(0x3efa34e48e3b218395efe6255339375b),
-	Ghash::new(0x79bf44bae0d2379397d0812db56c5eff),
-	Ghash::new(0x7fb3b7fce84776e39e538151daddae85),
-];
-
-pub static CONSTANTS_CONSTANT: [Ghash; 4] = [
-	Ghash::new(0x0d42981a71a7c2e493ca17e6bb10203f),
-	Ghash::new(0x9ceed672ccb7030fca17ed48e18717b9),
-	Ghash::new(0x0cec5c463024f2ba95c6ecdb4a349d15),
-	Ghash::new(0xa46023576301b995990418f3a23e3c99),
-];
-
 pub static ROUND_CONSTANTS: [[Ghash; 4]; 1 + 2 * 8] = [
 	[
 		Ghash::new(0xd0e015190f5e0795f4a1d28234ffdf87),
@@ -284,19 +252,8 @@ pub static ROUND_CONSTANTS: [[Ghash; 4]; 1 + 2 * 8] = [
 	],
 ];
 
-pub fn matrix_mul(matrix: &[Ghash; M * M], vector: &[Ghash; M]) -> [Ghash; M] {
-	std::array::from_fn(|i| {
-		// Row i: slice from i*N to (i+1)*N, dot product with vector
-		matrix[i * M..(i + 1) * M]
-			.iter()
-			.zip(vector.iter())
-			.map(|(&m_ij, &v_j)| m_ij * v_j)
-			.sum()
-	})
-}
-
 #[cfg(test)]
-mod tests {
+pub mod tests {
 	use binius_field::{Field, Random, arithmetic_traits::Square};
 	use rand::{SeedableRng, rngs::StdRng};
 
@@ -310,6 +267,50 @@ mod tests {
 		},
 		*,
 	};
+
+	pub fn matrix_mul(matrix: &[Ghash; M * M], vector: &[Ghash; M]) -> [Ghash; M] {
+		std::array::from_fn(|i| {
+			// Row i: slice from i*N to (i+1)*N, dot product with vector
+			matrix[i * M..(i + 1) * M]
+				.iter()
+				.zip(vector.iter())
+				.map(|(&m_ij, &v_j)| m_ij * v_j)
+				.sum()
+		})
+	}
+
+	pub static INITIAL_CONSTANT: [Ghash; 4] = [
+		Ghash::new(0xd0e015190f5e0795f4a1d28234ffdf87),
+		Ghash::new(0x6111731acd9a89f6b93ec3a23ec7681b),
+		Ghash::new(0x15da8de707ee3f3918a34a96728b8d29),
+		Ghash::new(0x2ea920e89fbb13a1ed2a216b1d232bfb),
+	];
+
+	pub static CONSTANTS_MATRIX: [Ghash; 16] = [
+		Ghash::new(0x1cac9af051191d2c8ef96344bc8cbd0f),
+		Ghash::new(0x3ceb350e8c2d2f4d4750ab0a854c3a4d),
+		Ghash::new(0x09cc78f7eafef94d8e092e899156946b),
+		Ghash::new(0x1d1ad17c8c7ee715a3d58f7eedb30dbb),
+		Ghash::new(0x06bee572113950b3dd0cdae9dff5dfc5),
+		Ghash::new(0x4799c3743a3560428b4bfa1a5cd3d295),
+		Ghash::new(0x516883bf97b07fcf4cb89ac6bf636d0b),
+		Ghash::new(0x0b681d1621d6aa1fdf1a9113b04d755b),
+		Ghash::new(0xe9ba2f01051f6b4b3ddfe74c125e99e5),
+		Ghash::new(0x1f58efc5ecf2e1b933e31cfb26b916d1),
+		Ghash::new(0x36da671249b5444cf67efc573241fe19),
+		Ghash::new(0x056cae18b867d486615a130556e5eb99),
+		Ghash::new(0x1d8645dd4b1e46b78dd9df84956bcf11),
+		Ghash::new(0x3efa34e48e3b218395efe6255339375b),
+		Ghash::new(0x79bf44bae0d2379397d0812db56c5eff),
+		Ghash::new(0x7fb3b7fce84776e39e538151daddae85),
+	];
+
+	pub static CONSTANTS_CONSTANT: [Ghash; 4] = [
+		Ghash::new(0x0d42981a71a7c2e493ca17e6bb10203f),
+		Ghash::new(0x9ceed672ccb7030fca17ed48e18717b9),
+		Ghash::new(0x0cec5c463024f2ba95c6ecdb4a349d15),
+		Ghash::new(0xa46023576301b995990418f3a23e3c99),
+	];
 
 	fn compute_round_constants() -> [[Ghash; M]; 1 + 2 * NUM_ROUNDS] {
 		let mut round_keys = [[Ghash::ZERO; M]; 1 + 2 * NUM_ROUNDS];

--- a/crates/verifier/src/hash/vision/digest.rs
+++ b/crates/verifier/src/hash/vision/digest.rs
@@ -1,0 +1,174 @@
+// Copyright 2025 Irreducible Inc.
+
+use binius_field::{BinaryField128bGhash as Ghash, Field};
+use binius_utils::{DeserializeBytes, SerializeBytes};
+use digest::{
+	FixedOutput, FixedOutputReset, HashMarker, OutputSizeUser, Reset, Update, consts::U32,
+};
+
+use super::{constants::M, permutation::permutation};
+
+const RATE_AS_U128: usize = 2;
+pub const RATE_AS_U8: usize = RATE_AS_U128 * std::mem::size_of::<u128>();
+
+const PADDING_START: u8 = 0x80;
+const PADDING_END: u8 = 0x01;
+
+pub const PADDING_BLOCK: [u8; RATE_AS_U8] = {
+	let mut block = [0; RATE_AS_U8];
+	block[0] = PADDING_START;
+	block[RATE_AS_U8 - 1] |= PADDING_END;
+	block
+};
+
+/// Fill the data using Keccak padding scheme.
+#[inline(always)]
+pub fn fill_padding(data: &mut [u8]) {
+	debug_assert!(!data.is_empty() && data.len() <= RATE_AS_U8);
+
+	data.fill(0);
+	data[0] |= PADDING_START;
+	data[data.len() - 1] |= PADDING_END;
+}
+
+/// An implementation of the Vision permutation with 4 Ghash elements for state.
+#[derive(Clone)]
+pub struct VisionHasherDigest {
+	state: [Ghash; M],
+	buffer: [u8; RATE_AS_U8],
+	filled_bytes: usize,
+}
+
+impl Default for VisionHasherDigest {
+	fn default() -> Self {
+		Self {
+			state: [Ghash::ZERO; M],
+			buffer: [0; RATE_AS_U8],
+			filled_bytes: 0,
+		}
+	}
+}
+
+impl VisionHasherDigest {
+	pub fn permute(state: &mut [Ghash; M], data: &[u8]) {
+		debug_assert_eq!(data.len(), RATE_AS_U8);
+
+		// Overwrite first RATE_AS_U128 elements of state with data
+		for i in 0..RATE_AS_U128 {
+			state[i] = Ghash::deserialize(&data[i * 16..]).expect("data len checked");
+		}
+
+		permutation(state);
+	}
+
+	fn finalize(&mut self, out: &mut digest::Output<Self>) {
+		if self.filled_bytes != 0 {
+			fill_padding(&mut self.buffer[self.filled_bytes..]);
+			Self::permute(&mut self.state, &self.buffer);
+		} else {
+			Self::permute(&mut self.state, &PADDING_BLOCK);
+		}
+
+		// Serialize first two state elements to output (32 bytes total)
+		let (state0, state1) = out.as_mut_slice().split_at_mut(16);
+		self.state[0].serialize(state0).expect("fits in 16 bytes");
+		self.state[1].serialize(state1).expect("fits in 16 bytes");
+	}
+}
+
+impl HashMarker for VisionHasherDigest {}
+
+impl Update for VisionHasherDigest {
+	fn update(&mut self, mut data: &[u8]) {
+		if self.filled_bytes != 0 {
+			let to_copy = std::cmp::min(data.len(), RATE_AS_U8 - self.filled_bytes);
+			self.buffer[self.filled_bytes..self.filled_bytes + to_copy]
+				.copy_from_slice(&data[..to_copy]);
+			data = &data[to_copy..];
+			self.filled_bytes += to_copy;
+
+			if self.filled_bytes == RATE_AS_U8 {
+				Self::permute(&mut self.state, &self.buffer);
+				self.filled_bytes = 0;
+			}
+		}
+
+		let mut chunks = data.chunks_exact(RATE_AS_U8);
+		for chunk in &mut chunks {
+			Self::permute(&mut self.state, chunk);
+		}
+
+		let remaining = chunks.remainder();
+		if !remaining.is_empty() {
+			self.buffer[..remaining.len()].copy_from_slice(remaining);
+			self.filled_bytes = remaining.len();
+		}
+	}
+}
+
+impl OutputSizeUser for VisionHasherDigest {
+	type OutputSize = U32;
+}
+
+impl FixedOutput for VisionHasherDigest {
+	fn finalize_into(mut self, out: &mut digest::Output<Self>) {
+		Self::finalize(&mut self, out);
+	}
+}
+
+impl FixedOutputReset for VisionHasherDigest {
+	fn finalize_into_reset(&mut self, out: &mut digest::Output<Self>) {
+		Self::finalize(self, out);
+		Reset::reset(self);
+	}
+}
+
+impl Reset for VisionHasherDigest {
+	fn reset(&mut self) {
+		self.state = [Ghash::ZERO; M];
+		self.buffer = [0; RATE_AS_U8];
+		self.filled_bytes = 0;
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use digest::Digest;
+
+	use super::VisionHasherDigest;
+
+	const INPUT: &[u8] = "One part of the mysterious existence of Captain Nemo had been unveiled and, if his identity had not been recognised, at least, the nations united against him were no longer hunting a chimerical creature, but a man who had vowed a deadly hatred against them".as_bytes();
+
+	#[test]
+	fn test_multi_block_aligned() {
+		let mut hasher = VisionHasherDigest::default();
+
+		hasher.update(INPUT);
+		let out = hasher.finalize();
+
+		let mut hasher = VisionHasherDigest::default();
+		let input_as_b = INPUT;
+		hasher.update(&input_as_b[0..63]);
+		hasher.update(&input_as_b[63..128]);
+		hasher.update(&input_as_b[128..163]);
+		hasher.update(&input_as_b[163..]);
+
+		assert_eq!(out, hasher.finalize());
+	}
+
+	#[test]
+	fn test_multi_block_unaligned() {
+		let mut hasher = VisionHasherDigest::default();
+		hasher.update(INPUT);
+		let out = hasher.finalize();
+
+		let mut hasher = VisionHasherDigest::default();
+		let input_as_b = INPUT;
+		hasher.update(&input_as_b[0..1]);
+		hasher.update(&input_as_b[1..120]);
+		hasher.update(&input_as_b[120..120]);
+		hasher.update(&input_as_b[120..]);
+
+		assert_eq!(out, hasher.finalize());
+	}
+}

--- a/crates/verifier/src/hash/vision/mod.rs
+++ b/crates/verifier/src/hash/vision/mod.rs
@@ -1,5 +1,8 @@
 // Copyright 2025 Irreducible Inc.
 
 mod constants;
+pub mod digest;
 mod linear_tables;
 pub mod permutation;
+
+pub use constants::M;


### PR DESCRIPTION
# Add Vision Hash Digest Implementation

### TL;DR

Implements a cryptographic hash digest for the Vision hash function using the digest trait.

### What changed?

- Added a new `digest.rs` module to the Vision hash implementation
- Implemented the Vision hash digest with proper padding and state management
- Added test cases to verify multi-block hashing with both aligned and unaligned inputs
- Added `hex-literal` dependency to the verifier crate

### How to test?

Run the included tests to verify that the Vision hash digest correctly processes inputs:

```
cargo test -p binius-verifier --lib hash::vision::digest
```

### Why make this change?

This implementation provides a standard digest interface for the Vision hash function, making it compatible with the Rust crypto ecosystem. The digest trait implementation allows for incremental hashing of data, which is essential for processing large inputs efficiently.