### PR TITLE
[keccak] integrate padding gadget into full keccak circuit

### DIFF
--- a/crates/frontend/src/circuits/keccak/mod.rs
+++ b/crates/frontend/src/circuits/keccak/mod.rs
@@ -1,10 +1,10 @@
+pub mod padding;
 pub mod permutation;
 pub mod reference;
-pub mod padding;
 
 use binius_core::word::Word;
-use permutation::Permutation;
 use padding::KeccakPadding;
+use permutation::Permutation;
 
 use crate::compiler::{CircuitBuilder, Wire, circuit::WitnessFiller};
 
@@ -58,9 +58,9 @@ impl Keccak {
 		// number of blocks needed for the maximum sized message
 		let n_blocks = (max_len + 1).div_ceil(RATE_BYTES);
 		assert_eq!(
-			expected_padded_message.len(), 
-			n_blocks, 
-			"expected_padded_message must have {} blocks", 
+			expected_padded_message.len(),
+			n_blocks,
+			"expected_padded_message must have {} blocks",
 			n_blocks
 		);
 
@@ -69,13 +69,8 @@ impl Keccak {
 		b.assert_0("len_check", len_check);
 
 		// Use standalone padding circuit to constrain message padding
-		let padding = KeccakPadding::new(
-			b, 
-			message.clone(), 
-			len, 
-			max_len, 
-			expected_padded_message.clone()
-		);
+		let padding =
+			KeccakPadding::new(b, message.clone(), len, max_len, expected_padded_message.clone());
 
 		// Compute digest using the expected padded message
 		let permutation_states = Self::compute_digest(b, &expected_padded_message);
@@ -101,7 +96,7 @@ impl Keccak {
 		padded_message: &[[Wire; N_WORDS_PER_BLOCK]],
 	) -> Vec<[Wire; N_WORDS_PER_STATE]> {
 		let n_blocks = padded_message.len();
-		
+
 		// zero initialized keccak state
 		let mut states: Vec<[Wire; N_WORDS_PER_STATE]> = Vec::with_capacity(n_blocks + 1);
 		let zero = b.add_constant(Word::ZERO);


### PR DESCRIPTION
# integrate padding gadget into full keccak circuit

This PR refactors the Keccak circuit to use the standalone KeccakPadding gadget for message padding, improving modularity and code organization. The changes include:

- Integrate the KeccakPadding gadget into the main Keccak circuit
- Fix the digest type to use 4 wires instead of the full state size
- Simplify the compute_digest function to take padded message blocks directly
- Remove redundant padding constraint logic that's now handled by the padding gadget
- Update the witness population to use the padding gadget's methods