### PR TITLE
reformat rather than check formatting in precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
     name: Run `rustfmt`
     language: rust
     types: [rust]
-    entry: cargo +nightly-2025-08-11 fmt --check
+    entry: cargo +nightly-2025-08-11 fmt
     pass_filenames: false
     stages: [pre-commit]
   - id: clippy


### PR DESCRIPTION
### TL;DR

Remove the `--check` flag from the pre-commit rustfmt hook.

### What changed?

Modified the `.pre-commit-config.yaml` file to remove the `--check` flag from the rustfmt pre-commit hook. Now the command will be `cargo +nightly-2025-08-11 fmt` instead of `cargo +nightly-2025-08-11 fmt --check`.

### How to test?

1. Make a change to a Rust file that violates rustfmt rules
2. Run `git commit`
3. Verify that the pre-commit hook automatically formats the file instead of just checking and failing

### Why make this change?

The `--check` flag causes rustfmt to only check for formatting issues without actually fixing them. By removing this flag, the pre-commit hook will now automatically format Rust files before committing, which improves developer experience by fixing formatting issues instead of just reporting them.