### PR TITLE
restor format checking in precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
     name: Run `rustfmt`
     language: rust
     types: [rust]
-    entry: cargo +nightly-2025-08-11 fmt
+    entry: cargo +nightly-2025-08-11 fmt --check
     pass_filenames: false
     stages: [pre-commit]
   - id: clippy


### PR DESCRIPTION
### TL;DR

Update pre-commit hook to check formatting without modifying files.

### What changed?

Modified the `.pre-commit-config.yaml` file to change the `rustfmt` hook from `cargo +nightly-2025-08-11 fmt` to `cargo +nightly-2025-08-11 fmt --check`. This changes the behavior from automatically formatting Rust files to only checking if they are properly formatted.

### How to test?

1. Install pre-commit hooks: `pre-commit install`
2. Make a change to a Rust file that violates formatting rules
3. Try to commit the change
4. Verify that the pre-commit hook fails without modifying your files
5. Run `cargo +nightly-2025-08-11 fmt` manually to fix the formatting
6. Commit the properly formatted code

### Why make this change?

The `--check` flag makes the pre-commit hook report formatting issues without automatically fixing them. This is more consistent with typical CI behavior and gives developers more control over when formatting changes are applied to their code. It also makes the formatting step more explicit, requiring developers to intentionally run the formatter rather than having it happen automatically during commit.