### PR TITLE
[frontend] Downgrade rsa test dependency to latest stable release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,8 +61,7 @@ rand = { version = "0.9.1", default-features = false, features = [
 ] }
 rayon = "1.10.0"
 regex = "1.10"
-# Uses RC because latest stable rsa-0.9.8 API requires RNG from rand=0.6
-rsa = { version = "0.10.0-rc.3", features = ["sha2"] }
+rsa = { version = "0.9.8", features = ["sha2"] }
 seq-macro = "0.3.5"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"


### PR DESCRIPTION
We use the rsa crate to create test data for the Rs256Verify circuit.

We used rsa-0.10.0-rc.* because these are the first versions with an API
that's compatible with rand-0.9 RNGs (and this is the version we use in
the monbijou project). The stable version 0.9.8 APIs are only compatible
with rand-0.6 RNGs.

The rsa-0.10.0-rc.* are currently broken because it depends on
crypto-bigint-0.7.0-rc.* and this crate introduced a breaking change. So
I think we should consider these rc releases to be unstable.

This PR solves this problem by downgrading to the latest stable rsa
release, 0.9.8. The dependency on rand-0.6 RNGs is avoided by including
a precomputed RSA private key for use in tests.