### PR TITLE
[ci] snapshot testing for all circuits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,8 +133,8 @@ jobs:
       - name: Build documentation
         run: cargo doc --document-private-items --no-deps
 
-  zklogin-snapshot:
-    name: zklogin-snapshot
+  circuits-snapshot:
+    name: circuits-snapshot
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -143,3 +143,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Check zklogin circuit statistics snapshot
         run: cargo run --example zklogin --release -- check-snapshot
+      - name: Check sha256 circuit statistics snapshot
+        run: cargo run --example sha256 --release -- check-snapshot
+      - name: Check keccak circuit statistics snapshot
+        run: cargo run --example keccak --release -- check-snapshot

--- a/crates/examples/snapshots/sha256.snap
+++ b/crates/examples/snapshots/sha256.snap
@@ -1,11 +1,11 @@
 sha256 circuit
 --
-Number of gates: 98959
-Number of evaluation instructions: 120716
-Number of AND constraints: 130414
+Number of gates: 92534
+Number of evaluation instructions: 99555
+Number of AND constraints: 117673
 Number of MUL constraints: 0
 Length of value vec: 131072
   Constants: 341
   Inout: 268
-  Witness: 3204
-  Internal: 116548
+  Witness: 1098
+  Internal: 105945


### PR DESCRIPTION
I noticed that @benediamond ‘s PRs did not trigger the SHA-256 snapshot failures and turned out that we didn’t really ran a check for those.

This PR adds the check for sha-256 and keccak as well. All further example circuits should be added here as well.