### PR TITLE
[frontend] rename internal to aux

### DIFF
--- a/crates/frontend/src/compiler/gate/assert_0.rs
+++ b/crates/frontend/src/compiler/gate/assert_0.rs
@@ -25,7 +25,7 @@ pub fn shape() -> OpcodeShape {
 		const_in: &[Word::ALL_ONE],
 		n_in: 1,
 		n_out: 0,
-		n_internal: 0,
+		n_aux: 0,
 		n_scratch: 0,
 		n_imm: 0,
 	}

--- a/crates/frontend/src/compiler/gate/assert_band_0.rs
+++ b/crates/frontend/src/compiler/gate/assert_band_0.rs
@@ -23,7 +23,7 @@ pub fn shape() -> OpcodeShape {
 		const_in: &[],
 		n_in: 2,
 		n_out: 0,
-		n_internal: 0,
+		n_aux: 0,
 		// 1 scratch for the intermediate computation of the AND.
 		n_scratch: 1,
 		n_imm: 0,

--- a/crates/frontend/src/compiler/gate/assert_eq.rs
+++ b/crates/frontend/src/compiler/gate/assert_eq.rs
@@ -25,7 +25,7 @@ pub fn shape() -> OpcodeShape {
 		const_in: &[Word::ALL_ONE],
 		n_in: 2,
 		n_out: 0,
-		n_internal: 0,
+		n_aux: 0,
 		n_scratch: 0,
 		n_imm: 0,
 	}

--- a/crates/frontend/src/compiler/gate/assert_eq_cond.rs
+++ b/crates/frontend/src/compiler/gate/assert_eq_cond.rs
@@ -25,7 +25,7 @@ pub fn shape() -> OpcodeShape {
 		const_in: &[],
 		n_in: 3,
 		n_out: 0,
-		n_internal: 0,
+		n_aux: 0,
 		n_scratch: 0,
 		n_imm: 0,
 	}

--- a/crates/frontend/src/compiler/gate/band.rs
+++ b/crates/frontend/src/compiler/gate/band.rs
@@ -22,7 +22,7 @@ pub fn shape() -> OpcodeShape {
 		const_in: &[],
 		n_in: 2,
 		n_out: 1,
-		n_internal: 0,
+		n_aux: 0,
 		n_scratch: 0,
 		n_imm: 0,
 	}

--- a/crates/frontend/src/compiler/gate/biguint_divide_hint.rs
+++ b/crates/frontend/src/compiler/gate/biguint_divide_hint.rs
@@ -30,7 +30,7 @@ pub fn shape(dimensions: &[usize]) -> OpcodeShape {
 		const_in: &[],
 		n_in: *dividend_limbs_len + *divisor_limbs_len,
 		n_out: *dividend_limbs_len + *divisor_limbs_len,
-		n_internal: 0,
+		n_aux: 0,
 		n_scratch: 0,
 		n_imm: 0,
 	}

--- a/crates/frontend/src/compiler/gate/bor.rs
+++ b/crates/frontend/src/compiler/gate/bor.rs
@@ -23,7 +23,7 @@ pub fn shape() -> OpcodeShape {
 		const_in: &[],
 		n_in: 2,
 		n_out: 1,
-		n_internal: 0,
+		n_aux: 0,
 		n_scratch: 0,
 		n_imm: 0,
 	}

--- a/crates/frontend/src/compiler/gate/bxor.rs
+++ b/crates/frontend/src/compiler/gate/bxor.rs
@@ -25,7 +25,7 @@ pub fn shape() -> OpcodeShape {
 		const_in: &[Word::ALL_ONE],
 		n_in: 2,
 		n_out: 1,
-		n_internal: 0,
+		n_aux: 0,
 		n_scratch: 0,
 		n_imm: 0,
 	}

--- a/crates/frontend/src/compiler/gate/bxor_multi.rs
+++ b/crates/frontend/src/compiler/gate/bxor_multi.rs
@@ -23,7 +23,7 @@ pub fn shape(dimensions: &[usize]) -> OpcodeShape {
 		const_in: &[Word::ALL_ONE],
 		n_in: *n_inputs,
 		n_out: 1,
-		n_internal: 0,
+		n_aux: 0,
 		n_scratch: 0,
 		n_imm: 0,
 	}

--- a/crates/frontend/src/compiler/gate/extract_byte.rs
+++ b/crates/frontend/src/compiler/gate/extract_byte.rs
@@ -29,7 +29,7 @@ pub fn shape() -> OpcodeShape {
 		const_in: &[Word(0xFF), Word(0xFFFFFFFFFFFFFF00u64)],
 		n_in: 1,
 		n_out: 1,
-		n_internal: 0,
+		n_aux: 0,
 		n_scratch: 0,
 		n_imm: 1,
 	}

--- a/crates/frontend/src/compiler/gate/iadd32.rs
+++ b/crates/frontend/src/compiler/gate/iadd32.rs
@@ -27,7 +27,7 @@ pub fn shape() -> OpcodeShape {
 		const_in: &[Word::MASK_32],
 		n_in: 2,
 		n_out: 1,
-		n_internal: 1,
+		n_aux: 1,
 		n_scratch: 0,
 		n_imm: 0,
 	}

--- a/crates/frontend/src/compiler/gate/iadd_cin_cout.rs
+++ b/crates/frontend/src/compiler/gate/iadd_cin_cout.rs
@@ -39,7 +39,7 @@ pub fn shape() -> OpcodeShape {
 		const_in: &[Word::ALL_ONE],
 		n_in: 3,
 		n_out: 2,
-		n_internal: 1,
+		n_aux: 1,
 		n_scratch: 0,
 		n_imm: 0,
 	}

--- a/crates/frontend/src/compiler/gate/icmp_eq.rs
+++ b/crates/frontend/src/compiler/gate/icmp_eq.rs
@@ -35,7 +35,7 @@ pub fn shape() -> OpcodeShape {
 		const_in: &[Word::ZERO], // Need zero constant for cin
 		n_in: 3,
 		n_out: 1,
-		n_internal: 1,
+		n_aux: 1,
 		n_scratch: 3, // Need 3 scratch registers for intermediate computations
 		n_imm: 0,
 	}

--- a/crates/frontend/src/compiler/gate/icmp_ult.rs
+++ b/crates/frontend/src/compiler/gate/icmp_ult.rs
@@ -33,7 +33,7 @@ pub fn shape() -> OpcodeShape {
 		const_in: &[Word::ALL_ONE, Word::ZERO], // Need all_1 and zero constants
 		n_in: 2,
 		n_out: 1,
-		n_internal: 1,
+		n_aux: 1,
 		n_scratch: 2, // Need 2 scratch registers for intermediate computations
 		n_imm: 0,
 	}

--- a/crates/frontend/src/compiler/gate/imul.rs
+++ b/crates/frontend/src/compiler/gate/imul.rs
@@ -12,7 +12,7 @@ pub fn shape() -> OpcodeShape {
 		const_in: &[],
 		n_in: 2,
 		n_out: 2,
-		n_internal: 0,
+		n_aux: 0,
 		n_scratch: 0,
 		n_imm: 0,
 	}

--- a/crates/frontend/src/compiler/gate/isub_bin_bout.rs
+++ b/crates/frontend/src/compiler/gate/isub_bin_bout.rs
@@ -11,7 +11,7 @@ pub fn shape() -> OpcodeShape {
 		const_in: &[Word::ALL_ONE],
 		n_in: 3,
 		n_out: 2,
-		n_internal: 1,
+		n_aux: 1,
 		n_scratch: 0,
 		n_imm: 0,
 	}

--- a/crates/frontend/src/compiler/gate/mod_inverse_hint.rs
+++ b/crates/frontend/src/compiler/gate/mod_inverse_hint.rs
@@ -30,7 +30,7 @@ pub fn shape(dimensions: &[usize]) -> OpcodeShape {
 		const_in: &[],
 		n_in: *base_limbs_len + *modulus_limbs_len,
 		n_out: 2 * *modulus_limbs_len,
-		n_internal: 0,
+		n_aux: 0,
 		n_scratch: 0,
 		n_imm: 0,
 	}

--- a/crates/frontend/src/compiler/gate/opcode.rs
+++ b/crates/frontend/src/compiler/gate/opcode.rs
@@ -44,12 +44,39 @@ pub enum Opcode {
 	ModInverseHint,
 }
 
+/// The shape of an opcode is a description of it's inputs and outputs. It allows treating a gate as
+/// a black box, correctly identifying its inputs or outputs.
 pub struct OpcodeShape {
+	/// The constants the gate with this opcode expects.
 	pub const_in: &'static [Word],
+	/// The number of inputs this opcode expects.
+	///
+	/// In case this opcode has a dynamic shape, it specifies the fixed number of inputs.
 	pub n_in: usize,
+	/// The number of outputs this opcode provides.
+	///
+	/// In case this opcode has a dynamic shape, it specifies the fixed number of outputs.
 	pub n_out: usize,
-	pub n_internal: usize,
+	/// The number of wires of aux wires.
+	///
+	/// Aux wires are neither inputs nor outputs, but are still being used within constraint
+	/// system.
+	///
+	/// In case this opcode has a dynamic shape, it specifies the fixed number of aux wires.
+	pub n_aux: usize,
+	/// The number of scratch wires.
+	///
+	/// Scratch wires are the wires that are neither inputs nor outputs. They also do not
+	/// get referenced in the constraint system. Those are only needed for the witness evaluation.
+	///
+	/// In case this opcode has a dynamic shape, it specifies the fixed number of scratch wires.
 	pub n_scratch: usize,
+	/// The number of immediate operands.
+	///
+	/// Those are the fixed constant parameters for the opcode. Those include the constant shift
+	/// amounts and things like that.
+	///
+	/// In case this opcode has a dynamic shape, it specifies the fixed number of immediates.
 	pub n_imm: usize,
 }
 

--- a/crates/frontend/src/compiler/gate/rotl64.rs
+++ b/crates/frontend/src/compiler/gate/rotl64.rs
@@ -31,7 +31,7 @@ pub fn shape() -> OpcodeShape {
 		const_in: &[Word::ALL_ONE],
 		n_in: 1,
 		n_out: 1,
-		n_internal: 0,
+		n_aux: 0,
 		n_scratch: 0,
 		n_imm: 1,
 	}

--- a/crates/frontend/src/compiler/gate/rotr32.rs
+++ b/crates/frontend/src/compiler/gate/rotr32.rs
@@ -31,7 +31,7 @@ pub fn shape() -> OpcodeShape {
 		const_in: &[Word::MASK_32],
 		n_in: 1,
 		n_out: 1,
-		n_internal: 0,
+		n_aux: 0,
 		n_scratch: 0,
 		n_imm: 1,
 	}

--- a/crates/frontend/src/compiler/gate/select.rs
+++ b/crates/frontend/src/compiler/gate/select.rs
@@ -27,7 +27,7 @@ pub fn shape() -> OpcodeShape {
 		const_in: &[],
 		n_in: 3,
 		n_out: 1,
-		n_internal: 0,
+		n_aux: 0,
 		n_scratch: 0,
 		n_imm: 0,
 	}

--- a/crates/frontend/src/compiler/gate/shl.rs
+++ b/crates/frontend/src/compiler/gate/shl.rs
@@ -25,7 +25,7 @@ pub fn shape() -> OpcodeShape {
 		const_in: &[Word::ALL_ONE],
 		n_in: 1,
 		n_out: 1,
-		n_internal: 0,
+		n_aux: 0,
 		n_scratch: 0,
 		n_imm: 1,
 	}

--- a/crates/frontend/src/compiler/gate/shr.rs
+++ b/crates/frontend/src/compiler/gate/shr.rs
@@ -25,7 +25,7 @@ pub fn shape() -> OpcodeShape {
 		const_in: &[Word::ALL_ONE],
 		n_in: 1,
 		n_out: 1,
-		n_internal: 0,
+		n_aux: 0,
 		n_scratch: 0,
 		n_imm: 1,
 	}

--- a/crates/frontend/src/compiler/gate/shr32.rs
+++ b/crates/frontend/src/compiler/gate/shr32.rs
@@ -24,7 +24,7 @@ pub fn shape() -> OpcodeShape {
 		const_in: &[Word::MASK_32],
 		n_in: 1,
 		n_out: 1,
-		n_internal: 0,
+		n_aux: 0,
 		n_scratch: 0,
 		n_imm: 1,
 	}

--- a/crates/frontend/src/compiler/gate_graph.rs
+++ b/crates/frontend/src/compiler/gate_graph.rs
@@ -113,7 +113,7 @@ impl GateData {
 		let start_output = end_input;
 		let end_output = start_output + shape.n_out;
 		let start_internal = end_output;
-		let end_internal = start_internal + shape.n_internal;
+		let end_internal = start_internal + shape.n_aux;
 		let start_scratch = end_internal;
 		let end_scratch = start_scratch + shape.n_scratch;
 		GateParam {
@@ -137,7 +137,7 @@ impl GateData {
 		let gate_param = self.gate_param();
 		assert_eq!(gate_param.inputs.len(), shape.n_in);
 		assert_eq!(gate_param.outputs.len(), shape.n_out);
-		assert_eq!(gate_param.internal.len(), shape.n_internal);
+		assert_eq!(gate_param.internal.len(), shape.n_aux);
 		assert_eq!(self.immediates.len(), shape.n_imm);
 	}
 }
@@ -244,14 +244,15 @@ impl GateGraph {
 	) -> Gate {
 		let shape = opcode.shape(dimensions);
 		let mut wires: Vec<Wire> = Vec::with_capacity(
-			shape.const_in.len() + shape.n_in + shape.n_out + shape.n_internal + shape.n_scratch,
+			shape.const_in.len() + shape.n_in + shape.n_out + shape.n_aux + shape.n_scratch,
 		);
 		for c in shape.const_in {
 			wires.push(self.add_constant(*c));
 		}
 		wires.extend(inputs);
 		wires.extend(outputs);
-		for _ in 0..shape.n_internal {
+		for _ in 0..shape.n_aux {
+			// We create internal wires as auxiliary.
 			wires.push(self.add_internal());
 		}
 		for _ in 0..shape.n_scratch {


### PR DESCRIPTION
Because this is a slightly different concept. To make it clear consider that the
outputs of the gates are represented by the internal wires. So in a sense those
wires that are created inside a gate they use internal wires but they are used
for a completely different thing.

Also add documentation.