### PR TITLE
BigUint modular exponentiation hint.

### DIFF
--- a/crates/frontend/src/compiler/gate/biguint_mod_pow_hint.rs
+++ b/crates/frontend/src/compiler/gate/biguint_mod_pow_hint.rs
@@ -1,0 +1,54 @@
+//! BigUint modular exponentiation.
+//!
+//! Given `base`, `exp` and `modulus` represented by little-endian arrays of
+//! 64-bit limbs returns `(base^exp) % modulus`.
+//!
+//! Shape is determined by number of limbs in `base`, `exp` and `modulus`.
+//! There are `base.len() + exp.len() + modulus.len()` inputs and
+//! `modulus.len()` outputs.
+//!
+//! # Algorithm
+//!
+//! Performs the modular exponentiation.
+//!
+//! # Constraints
+//!
+//! No constraints are generated! This is a hint - a deterministic computation that happens
+//! only on the prover side. The result should be additionally constrained with bignum circuits.
+
+use crate::compiler::{
+	gate::opcode::OpcodeShape,
+	gate_graph::{Gate, GateData, GateParam, Wire},
+};
+
+pub fn shape(dimensions: &[usize]) -> OpcodeShape {
+	let [n_base_limbs, n_exp_limbs, n_modulus_limbs] = dimensions else {
+		unreachable!()
+	};
+	OpcodeShape {
+		const_in: &[],
+		n_in: *n_base_limbs + *n_exp_limbs + *n_modulus_limbs,
+		n_out: *n_modulus_limbs,
+		n_aux: 0,
+		n_scratch: 0,
+		n_imm: 0,
+	}
+}
+
+pub fn emit_eval_bytecode(
+	_gate: Gate,
+	data: &GateData,
+	builder: &mut crate::compiler::eval_form::BytecodeBuilder,
+	wire_to_reg: impl Fn(Wire) -> u32,
+	hint_id: u32,
+) {
+	let GateParam {
+		inputs, outputs, ..
+	} = data.gate_param();
+
+	let input_regs: Vec<u32> = inputs.iter().map(|&wire| wire_to_reg(wire)).collect();
+
+	let output_regs: Vec<u32> = outputs.iter().map(|&wire| wire_to_reg(wire)).collect();
+
+	builder.emit_hint(hint_id, &data.dimensions, &input_regs, &output_regs);
+}

--- a/crates/frontend/src/compiler/gate/mod.rs
+++ b/crates/frontend/src/compiler/gate/mod.rs
@@ -2,7 +2,7 @@ use crate::compiler::{
 	constraint_builder::ConstraintBuilder,
 	eval_form::BytecodeBuilder,
 	gate_graph::{Gate, GateData, GateGraph},
-	hints::{BigUintDivideHint, HintRegistry, ModInverseHint},
+	hints::{BigUintDivideHint, BigUintModPowHint, HintRegistry, ModInverseHint},
 };
 
 pub mod opcode;
@@ -15,6 +15,7 @@ pub mod assert_eq;
 pub mod assert_eq_cond;
 pub mod band;
 pub mod biguint_divide_hint;
+pub mod biguint_mod_pow_hint;
 pub mod bor;
 pub mod bxor;
 pub mod bxor_multi;
@@ -61,6 +62,7 @@ pub fn constrain(gate: Gate, graph: &GateGraph, builder: &mut ConstraintBuilder)
 		Opcode::Sar => sar::constrain(gate, data, builder),
 		// Hints do not introduce constraints
 		Opcode::BigUintDivideHint => (),
+		Opcode::BigUintModPowHint => (),
 		Opcode::ModInverseHint => (),
 	}
 }
@@ -114,6 +116,10 @@ pub fn emit_gate_bytecode(
 		Opcode::ModInverseHint => {
 			let hint_id = hint_registry.register(Box::new(ModInverseHint::new()));
 			mod_inverse_hint::emit_eval_bytecode(gate, data, builder, wire_to_reg, hint_id)
+		}
+		Opcode::BigUintModPowHint => {
+			let hint_id = hint_registry.register(Box::new(BigUintModPowHint::new()));
+			biguint_mod_pow_hint::emit_eval_bytecode(gate, data, builder, wire_to_reg, hint_id)
 		}
 		Opcode::BigUintDivideHint => {
 			let hint_id = hint_registry.register(Box::new(BigUintDivideHint::new()));

--- a/crates/frontend/src/compiler/gate/opcode.rs
+++ b/crates/frontend/src/compiler/gate/opcode.rs
@@ -42,6 +42,7 @@ pub enum Opcode {
 
 	// Hints
 	BigUintDivideHint,
+	BigUintModPowHint,
 	ModInverseHint,
 }
 
@@ -124,6 +125,7 @@ impl Opcode {
 
 			// Hints (no constraints)
 			Opcode::BigUintDivideHint => gate::biguint_divide_hint::shape(dimensions),
+			Opcode::BigUintModPowHint => gate::biguint_mod_pow_hint::shape(dimensions),
 			Opcode::ModInverseHint => gate::mod_inverse_hint::shape(dimensions),
 		}
 	}
@@ -132,6 +134,7 @@ impl Opcode {
 		#[allow(clippy::match_like_matches_macro)]
 		match self {
 			Opcode::BigUintDivideHint => false,
+			Opcode::BigUintModPowHint => false,
 			Opcode::ModInverseHint => false,
 			Opcode::BxorMulti => false,
 			_ => true,

--- a/crates/frontend/src/compiler/hints/big_uint_mod_pow.rs
+++ b/crates/frontend/src/compiler/hints/big_uint_mod_pow.rs
@@ -1,0 +1,56 @@
+//! BigUint mod pow hint implementation
+
+use binius_core::Word;
+
+use super::Hint;
+use crate::util::num_biguint_from_u64_limbs;
+
+pub struct BigUintModPowHint;
+
+impl BigUintModPowHint {
+	pub fn new() -> Self {
+		Self
+	}
+}
+
+impl Default for BigUintModPowHint {
+	fn default() -> Self {
+		Self::new()
+	}
+}
+
+impl Hint for BigUintModPowHint {
+	fn shape(&self, dimensions: &[usize]) -> (usize, usize) {
+		let [n_base_limbs, n_exp_limbs, n_modulus_limbs] = dimensions else {
+			panic!("BigUintModPowHint requires 3 dimensions");
+		};
+		(*n_base_limbs + *n_exp_limbs + *n_modulus_limbs, *n_modulus_limbs)
+	}
+
+	fn execute(&self, dimensions: &[usize], inputs: &[Word], outputs: &mut [Word]) {
+		let [n_base_limbs, n_exp_limbs, n_modulus_limbs] = dimensions else {
+			panic!("BigUintModPowHint requires 3 dimensions");
+		};
+
+		assert_eq!(inputs.len(), *n_base_limbs + *n_exp_limbs + *n_modulus_limbs);
+		assert_eq!(outputs.len(), *n_modulus_limbs);
+
+		let (base_limbs, inputs) = inputs.split_at(*n_base_limbs);
+		let (exp_limbs, modulus_limbs) = inputs.split_at(*n_exp_limbs);
+
+		let base = num_biguint_from_u64_limbs(base_limbs.iter().map(|w| w.as_u64()));
+		let exp = num_biguint_from_u64_limbs(exp_limbs.iter().map(|w| w.as_u64()));
+		let modulus = num_biguint_from_u64_limbs(modulus_limbs.iter().map(|w| w.as_u64()));
+
+		let modpow = base.modpow(&exp, &modulus);
+
+		// Fill modpow limbs (first part of the output)
+		for (i, limb) in modpow.iter_u64_digits().enumerate() {
+			outputs[i] = Word::from_u64(limb);
+		}
+
+		for i in modpow.iter_u64_digits().len()..*n_modulus_limbs {
+			outputs[i] = Word::ZERO;
+		}
+	}
+}

--- a/crates/frontend/src/compiler/hints/mod.rs
+++ b/crates/frontend/src/compiler/hints/mod.rs
@@ -8,9 +8,11 @@
 use binius_core::Word;
 
 mod big_uint_divide;
+mod big_uint_mod_pow;
 mod mod_inverse;
 
 pub use big_uint_divide::BigUintDivideHint;
+pub use big_uint_mod_pow::BigUintModPowHint;
 pub use mod_inverse::ModInverseHint;
 
 pub type HintId = u32;

--- a/crates/frontend/src/compiler/mod.rs
+++ b/crates/frontend/src/compiler/mod.rs
@@ -645,6 +645,29 @@ impl CircuitBuilder {
 		(quotient, remainder)
 	}
 
+	/// Modular exponentiation.
+	///
+	/// Computes `(base^exp) % modulus`.
+	/// This is a hint - a deterministic computation that happens only on the prover side.
+	/// The result should be additionally constrained using bignum circuits.
+	pub fn biguint_mod_pow_hint(&self, base: &[Wire], exp: &[Wire], modulus: &[Wire]) -> Vec<Wire> {
+		let modpow = (0..modulus.len())
+			.map(|_| self.add_internal())
+			.collect::<Vec<_>>();
+
+		let mut graph = self.graph_mut();
+		graph.emit_gate_generic(
+			self.current_path,
+			Opcode::BigUintModPowHint,
+			base.iter().chain(exp).chain(modulus).copied(),
+			modpow.iter().copied(),
+			&[base.len(), exp.len(), modulus.len()],
+			&[],
+		);
+
+		modpow
+	}
+
 	/// Modular inverse.
 	///
 	/// Computes the modular inverse of `base` modulo `modulus`.

--- a/crates/frontend/src/compiler/tests.rs
+++ b/crates/frontend/src/compiler/tests.rs
@@ -221,6 +221,23 @@ fn test_biguint_divide_hint_div_by_zero() {
 }
 
 #[test]
+fn test_mod_pow_hint() {
+	let builder = CircuitBuilder::new();
+
+	let c = builder.add_constant_64(0x123456789abcdef0);
+	let modpow = builder.biguint_mod_pow_hint(&[c], &[c, c], &[c, c, c]);
+
+	let circuit = builder.build();
+	let mut w = circuit.new_witness_filler();
+	circuit.populate_wire_witness(&mut w).unwrap();
+
+	assert_eq!(modpow.len(), 3);
+	assert_eq!(w[modpow[0]], Word(0x6f151e00d2c39f30));
+	assert_eq!(w[modpow[1]], Word(0xfef75acc27ead52f));
+	assert_eq!(w[modpow[2]], Word(0x00443adf222ea27));
+}
+
+#[test]
 fn test_mod_inverse_hint() {
 	let builder = CircuitBuilder::new();
 


### PR DESCRIPTION
A hint to compute `(base^exp) % modulus` on `BigUint`s. Still implemented as a gate without constraints, will get refactored into a "pure" eval form along with other hints afterwards.