### PR TITLE
significantly simplify `compute_stack_adds`.

### DIFF
--- a/crates/examples/snapshots/zklogin.snap
+++ b/crates/examples/snapshots/zklogin.snap
@@ -1,11 +1,11 @@
 zklogin circuit
 --
-Number of gates: 640185
-Number of evaluation instructions: 972063
-Number of AND constraints: 863248
+Number of gates: 640151
+Number of evaluation instructions: 972029
+Number of AND constraints: 863180
 Number of MUL constraints: 26880
 Length of value vec: 1048576
   Constants: 624
   Inout: 302
   Witness: 96158
-  Internal: 887940
+  Internal: 887838


### PR DESCRIPTION
notes:

- the block `if limb_stack.is_empty() { limb_stack.push(zero); }` was redundant—if removed, the next step will have exactly the same effect (push one `zero` onto `limb_stack`, followed by more if `carries.len() > 0`​).
- in the case `limb_stack.len() == 1`, an add was wasted. indeed, in light of the block immediately above, the only way this case happens is if `carries.len() == 0`. but then, `carries.pop().unwrap_or(zero);` must be `zero`, and adding `builder.iadd_cin_cout(single_wire, zero, carry_in);` has no effect. moreover, the `cout` thus produced is necessarily `zero`; so adding it to the stack of carries _could_ waste a further add in the next stack, depending on the shape of the stack pushed.
- actually, the entire `limb_stack.len() == 1` case can be eliminated, and subsumed into the general case. it's enough to keep adding until the stack length becomes exactly 1, and then write that result into the sum.