### PR TITLE
fix soundness bug. split wires' top halves were unconstrained

### DIFF
--- a/crates/examples/snapshots/sha256.snap
+++ b/crates/examples/snapshots/sha256.snap
@@ -1,11 +1,11 @@
 sha256 circuit
 --
-Number of gates: 75113
-Number of evaluation instructions: 76342
-Number of AND constraints: 95516
+Number of gates: 74990
+Number of evaluation instructions: 76219
+Number of AND constraints: 95393
 Number of MUL constraints: 0
 Length of value vec: 131072
   Constants: 341
   Inout: 260
   Witness: 570
-  Internal: 94844
+  Internal: 94267

--- a/crates/examples/snapshots/sha512.snap
+++ b/crates/examples/snapshots/sha512.snap
@@ -1,11 +1,11 @@
 sha512 circuit
 --
-Number of gates: 48852
-Number of evaluation instructions: 50065
-Number of AND constraints: 62375
+Number of gates: 48818
+Number of evaluation instructions: 50031
+Number of AND constraints: 62341
 Number of MUL constraints: 0
 Length of value vec: 131072
   Constants: 365
   Inout: 264
   Witness: 298
-  Internal: 74676
+  Internal: 74659

--- a/crates/examples/snapshots/zklogin.snap
+++ b/crates/examples/snapshots/zklogin.snap
@@ -1,11 +1,11 @@
 zklogin circuit
 --
-Number of gates: 627709
-Number of evaluation instructions: 955310
-Number of AND constraints: 847211
+Number of gates: 627577
+Number of evaluation instructions: 955178
+Number of AND constraints: 847079
 Number of MUL constraints: 26880
 Length of value vec: 1048576
   Constants: 624
   Inout: 302
   Witness: 95783
-  Internal: 880143
+  Internal: 879680

--- a/crates/frontend/src/circuits/sha512/compress.rs
+++ b/crates/frontend/src/circuits/sha512/compress.rs
@@ -132,16 +132,16 @@ pub struct Compress {
 impl Compress {
 	pub fn new(builder: &CircuitBuilder, state_in: State, m: [Wire; 16]) -> Self {
 		// ---- message-schedule ----
-		// W[0..15] = block_words & M32
-		// for t = 16 .. 63:
+		// W[0..15] = block_words
+		// for t = 16 .. 79:
 		//     s0   = σ0(W[t-15])
 		//     s1   = σ1(W[t-2])
 		//     (p, _)  = Add(W[t-16], s0)
 		//     (q, _)  = Add(p, W[t-7])
 		//     (W[t],_) = Add(q, s1)
-		let mut w: Vec<Wire> = Vec::with_capacity(80);
+		let mut w = Vec::with_capacity(80);
 
-		// W[0..15] = block_words & M32
+		// W[0..15] = block_words
 		w.extend_from_slice(&m);
 
 		let zero = builder.add_constant(Word::ZERO);

--- a/crates/frontend/src/circuits/sha512/mod.rs
+++ b/crates/frontend/src/circuits/sha512/mod.rs
@@ -312,16 +312,10 @@ impl Sha512 {
 				// Otherwise, if it's a padding word (not message, not length), it must be zero.
 				if column_index == 15 {
 					builder.assert_eq_cond(
-						"3c.zero_pad",
-						padded_message_word,
-						zero,
-						builder.band(is_past_message, builder.bnot(is_length_block)),
-					);
-					builder.assert_eq_cond(
 						"3d.w15_len",
 						padded_message_word,
-						bitlen,
-						is_length_block,
+						builder.select(zero, bitlen, is_length_block),
+						is_past_message,
 					);
 				} else {
 					builder.assert_eq_cond(


### PR DESCRIPTION
this PR finds and fixes what I believe was a soundness bug in SHA-256. the bug was present in all previous versions. SHA-512 was not affected. here is the issue: fix some message wire `i`. `message[i]` is a 64-bit wire; let's write it as

```
message[i] == message_{i, 1} || message_{i, 0}
```

where both halves are 32 bits.

recall that we are allowing the prover to "split" each message word into two wires—call them `w_lo32` and `w_hi32`—that we then feed into the compression gadget.

let’s fix the case of message words (strictly before `w_bd`​). a similar issue affects padding words (strictly after `w_bd`​). note that we ARE constraining

```
message[i] == w_hi32 << 32 ⊕ w_lo32. (*)
```

but we aren't constraining that the top halves of `w_hi32` and `w_lo32` are empty. if the prover is honest, then he will set

```
w_lo32 == 0 || message_{i, 0} and w_hi32 == 0 || message_{i, 1}.
```

but that's not the only way he can make `(*)` hold. instead, he can set

```
w_lo32 == x || message_{i, 0} and w_hi32 == y || message_{i, 1} ⊕ x,
```

where `x`​ and `y`​ are both arbitrary 32-bit strings. in this case, `(*)` will still hold.

let's turn to the compression gadget. this gadget masks each of its inputs by `00000000 || FFFFFFFF` before proceeding. but it doesn't check whether that mask had any effect or not. if the prover does the above attack, then the resulting _masked_ words will be

```
w_lo32 & MASK == message_{i, 0} and w_hi32 & MASK == message_{i, 1} ⊕ x.
```

thus, the high 32-bit word fed into the compression gadget will equal `message_{i, 1} ⊕ x`, while it should equal `message_{i, 1}`. this is a soundness break.

the current proposed change totally gets rid of `padded_message_word`​ in the SHA-256 case; this thing was previously `builder.bxor(w_lo32, builder.shl(w_hi32, 32))`​. instead, we do all checks directly against `w_lo32`​ and `w_hi32`​. that is, we directly check `message[i] & MASK == w_lo32`​ and `message[i] >> 32 == w_hi32`​. the case of padding words is also handled similarly.

a side effect of the current approach is that we guarantee that most words fed into `compress`​ have empty high halves. actually, this is true except in the boundary case `w_bd`​. there, we are directly checking the validity of the low halves of `w_lo32`​ and `w_hi32`​, and the top halves are ignored. but that case was still sound, even before this fix.

but actually, if we just bite the bullet and check _those_ things’ high halves too, then we’ve completed all cases, and have thus certified that all things ever fed into `compress`​—whether even or odd—have empty high halves. this lets us get rid of the mask inside compress. thus we still reduce gate count at the end of the day :)