### PR TITLE
End-to-end Ethereum-style signing example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        example: [zklogin, sha256, keccak]
+        example: [ethsign, zklogin, sha256, keccak]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -16,6 +16,8 @@ binius-prover = { path = "../prover", default-features = false }
 clap.workspace = true
 tracing.workspace = true
 tracing-profile.workspace = true
+ethsign = "0.9.0"
+tiny-keccak = "2.0.2"
 
 [dev-dependencies]
 base64.workspace = true

--- a/crates/examples/examples/ethsign.rs
+++ b/crates/examples/examples/ethsign.rs
@@ -1,0 +1,222 @@
+use std::array;
+
+use anyhow::Result;
+use binius_core::word::Word;
+use binius_examples::{Cli, ExampleCircuit};
+use binius_frontend::{
+	circuits::{bignum::BigUint, ecdsa::ecrecover, keccak::Keccak},
+	compiler::{CircuitBuilder, Wire, circuit::WitnessFiller},
+	util::{byteswap, pack_bytes_into_wires_le},
+};
+use clap::Args;
+use ethsign::SecretKey;
+use rand::{Rng, SeedableRng, rngs::StdRng};
+use tiny_keccak::{Hasher, Keccak as KeccakHasher};
+
+struct Signature {
+	r: [Wire; 4],
+	s: [Wire; 4],
+	recid_odd: Wire,
+	address: [Wire; 3],
+	msg_keccak: Keccak,
+	address_keccak: Keccak,
+}
+
+/// Example circuit that proves validity of Ethereum-style ECDSA signatures.
+struct EthSignExample {
+	max_msg_len_bytes: usize,
+	signatures: Vec<Signature>,
+}
+
+#[derive(Args, Debug)]
+struct Params {
+	/// Number of Ethereum-style signatures to validate
+	#[arg(short = 'n', long, default_value_t = 1)]
+	n_signatures: usize,
+	/// Maximum message length
+	#[arg(short = 'm', long, default_value_t = 128, value_parser = clap::value_parser!(u16).range(1..))]
+	max_msg_len_bytes: u16,
+}
+
+#[derive(Args, Debug)]
+struct Instance {}
+
+impl ExampleCircuit for EthSignExample {
+	type Params = Params;
+	type Instance = Instance;
+
+	fn build(params: Params, builder: &mut CircuitBuilder) -> Result<Self> {
+		let max_msg_len_bytes = params.max_msg_len_bytes as usize;
+		let signatures = (0..params.n_signatures)
+			.map(|_| {
+				let msg_len = builder.add_inout();
+				let message = (0..params.max_msg_len_bytes.div_ceil(8))
+					.map(|_| builder.add_inout())
+					.collect::<Vec<_>>();
+				let r = array::from_fn(|_| builder.add_inout());
+				let s = array::from_fn(|_| builder.add_inout());
+				let recid_odd = builder.add_inout();
+				let address = array::from_fn(|_| builder.add_inout());
+
+				let msg_final_state = array::from_fn(|_| builder.add_witness());
+				let msg_keccak = Keccak::new(
+					builder,
+					max_msg_len_bytes,
+					msg_len,
+					msg_final_state,
+					message.clone(),
+				);
+
+				// The Keccak digest is little endian encoded into 4 words, while Ethereum expects
+				// big endian
+				let z = BigUint {
+					limbs: msg_final_state[..4]
+						.iter()
+						.rev()
+						.map(|&word| byteswap(builder, word))
+						.collect(),
+				};
+
+				// Encoding r & s in little endian
+				let public_key = ecrecover(
+					builder,
+					&z,
+					&BigUint { limbs: r.to_vec() },
+					&BigUint { limbs: s.to_vec() },
+					recid_odd,
+				);
+
+				// Check that public key is not a point-at-infinity
+				builder.assert_0("recovered_pk_not_pai", public_key.is_point_at_infinity);
+
+				// Concatenate x & y in _big_ endian, hash the result to obtain the address
+				let mut public_key_limbs = Vec::with_capacity(8);
+				public_key_limbs.extend(&public_key.y.limbs);
+				public_key_limbs.extend(&public_key.x.limbs);
+				public_key_limbs.reverse();
+
+				let public_key_message = public_key_limbs
+					.into_iter()
+					.map(|word| byteswap(builder, word))
+					.collect::<Vec<_>>();
+
+				let address_final_state = array::from_fn(|_| builder.add_witness());
+				let address_keccak = Keccak::new(
+					builder,
+					64,
+					builder.add_constant_64(64),
+					address_final_state,
+					public_key_message,
+				);
+
+				// Assert that the provided address equals digest bytes 12..32
+				assert_address_eq(builder, &address_keccak.digest, &address);
+
+				Signature {
+					r,
+					s,
+					recid_odd,
+					address,
+
+					msg_keccak,
+					address_keccak,
+				}
+			})
+			.collect();
+
+		Ok(Self {
+			signatures,
+			max_msg_len_bytes,
+		})
+	}
+
+	fn populate_witness(&self, _instance: Instance, w: &mut WitnessFiller) -> Result<()> {
+		// Generate random initial state with fixed seed for reproducibility
+		let mut rng = StdRng::seed_from_u64(0);
+
+		for Signature {
+			r,
+			s,
+			recid_odd,
+			address,
+			msg_keccak,
+			address_keccak,
+		} in &self.signatures
+		{
+			// Random private key
+			let sk_bytes: [u8; 32] = rng.random();
+			let secret_key = SecretKey::from_raw(&sk_bytes)?;
+
+			// Random message
+			let msg_len = rng.random_range(1..=self.max_msg_len_bytes);
+			let msg_bytes = (0..msg_len).map(|_| rng.random()).collect::<Vec<u8>>();
+			let msg_hash = keccak256(&msg_bytes);
+
+			// Sign the message with ECDSA
+			let mut signature = secret_key.sign(&msg_hash)?;
+			let public = secret_key.public();
+
+			// Hash the message with Keccak
+			msg_keccak.populate_len(w, msg_len);
+			msg_keccak.populate_message(w, &msg_bytes);
+			msg_keccak.populate_digest(w, msg_hash);
+
+			// ethsign crate returns 0/1 recid, convert to `recid_odd` boolean
+			w[*recid_odd] = if signature.v != 0 {
+				Word::ALL_ONE
+			} else {
+				Word::ZERO
+			};
+
+			// ethsign crate returns r & s big endian, byteswap
+			signature.r.reverse();
+			pack_bytes_into_wires_le(w, r, &signature.r);
+
+			signature.s.reverse();
+			pack_bytes_into_wires_le(w, s, &signature.s);
+
+			// Hash the (big endian) public key
+			let pk_bytes = public.bytes();
+			let pk_hash = keccak256(pk_bytes);
+
+			address_keccak.populate_len(w, 64);
+			address_keccak.populate_message(w, pk_bytes);
+			address_keccak.populate_digest(w, pk_hash);
+
+			pack_bytes_into_wires_le(w, address, public.address());
+		}
+
+		Ok(())
+	}
+}
+
+fn assert_address_eq(b: &CircuitBuilder, digest: &[Wire], address: &[Wire]) {
+	assert_eq!(digest.len(), 25);
+	assert_eq!(address.len(), 3);
+
+	let bytes_12_20 = b.bxor(b.shr(digest[1], 32), b.shl(digest[2], 32));
+	let bytes_20_28 = b.bxor(b.shr(digest[2], 32), b.shl(digest[3], 32));
+	let bytes_28_32 = b.shr(digest[3], 32);
+
+	b.assert_eq("address_0_8", bytes_12_20, address[0]);
+	b.assert_eq("address_8_16", bytes_20_28, address[1]);
+	b.assert_eq("address_16_20", bytes_28_32, address[2]);
+}
+
+fn keccak256(bytes: &[u8]) -> [u8; 32] {
+	let mut hasher = KeccakHasher::v256();
+	hasher.update(bytes);
+
+	let mut digest = [0u8; 32];
+	hasher.finalize(&mut digest);
+
+	digest
+}
+
+fn main() -> Result<()> {
+	let _tracing_guard = tracing_profile::init_tracing()?;
+
+	Cli::<EthSignExample>::new("ethsign")
+		.about("Ethereum-style signing example")
+		.run()
+}

--- a/crates/examples/snapshots/ethsign.snap
+++ b/crates/examples/snapshots/ethsign.snap
@@ -1,0 +1,11 @@
+ethsign circuit
+--
+Number of gates: 477869
+Number of evaluation instructions: 618078
+Number of AND constraints: 667664
+Number of MUL constraints: 48852
+Length of value vec: 1048576
+  Constants: 74
+  Inout: 29
+  Witness: 29437
+  Internal: 888563

--- a/crates/frontend/src/circuits/ecdsa/ecrecover.rs
+++ b/crates/frontend/src/circuits/ecdsa/ecrecover.rs
@@ -5,6 +5,7 @@ use crate::{
 		secp256k1::{Secp256k1, Secp256k1Affine, coord_zero},
 	},
 	compiler::{CircuitBuilder, Wire},
+	util::all_true,
 };
 
 /// EcRecover - an "Ethereum-style" verification of ECDSA signatures over secp256k1.
@@ -39,5 +40,6 @@ pub fn ecrecover(
 	let u1 = f_scalar.sub(b, &coord_zero(b), &f_scalar.mul(b, z, &r_inverse));
 	let u2 = f_scalar.mul(b, s, &r_inverse);
 
-	shamirs_trick(b, &curve, 256, &u1, &u2, nonce).pai_unless(b, b.band(valid_r, valid_s))
+	let conditions = [valid_r, valid_s, b.bnot(nonce.is_point_at_infinity)];
+	shamirs_trick(b, &curve, 256, &u1, &u2, nonce).pai_unless(b, all_true(b, conditions))
 }

--- a/crates/frontend/src/util.rs
+++ b/crates/frontend/src/util.rs
@@ -74,6 +74,19 @@ pub fn bool_to_mask(b: &CircuitBuilder, boolean: Wire) -> Wire {
 	b.sar(boolean, (WORD_SIZE_BITS - 1) as u32)
 }
 
+/// Swap the byte order of the word.
+///
+/// Breaks the word down to bytes and reassembles in reversed order.
+pub fn byteswap(b: &CircuitBuilder, word: Wire) -> Wire {
+	let bytes = (0..8).map(|j| {
+		let byte = b.extract_byte(word, j as u32);
+		b.shl(byte, (56 - 8 * j) as u32)
+	});
+	bytes
+		.reduce(|lhs, rhs| b.bxor(lhs, rhs))
+		.expect("WORD_SIZE_BITS > 0")
+}
+
 /// Computes the binary logarithm of $n$ rounded up to the nearest integer.
 ///
 /// When $n$ is 0, this function returns 0. Otherwise, it returns $\lceil \log_2 n \rceil$.


### PR DESCRIPTION
An example that generates random messages, hashes them with Keccak, signs with ECDSA and ecrecovers into an Ethereum address (which requires another Keccak).

There are some non-tidy bits around endianness conversions to be dealt with in follow ups.