### PR TITLE
[pcs] Rename type parameters for codebase consistency

### DIFF
--- a/crates/verifier/src/pcs.rs
+++ b/crates/verifier/src/pcs.rs
@@ -32,19 +32,18 @@ use crate::{
 /// * `codeword_commitment` - VCS commitment to the codeword
 /// * `fri_params` - the FRI parameters
 /// * `vcs` - the vector commitment scheme
-pub fn verify_transcript<F, FA, TranscriptChallenger, VCS>(
-	transcript: &mut VerifierTranscript<TranscriptChallenger>,
+pub fn verify_transcript<F, MTScheme, Challenger_>(
+	transcript: &mut VerifierTranscript<Challenger_>,
 	evaluation_claim: F,
 	eval_point: &[F],
-	codeword_commitment: VCS::Digest,
-	fri_params: &FRIParams<F, FA>,
-	vcs: &VCS,
+	codeword_commitment: MTScheme::Digest,
+	fri_params: &FRIParams<F, F>,
+	vcs: &MTScheme,
 ) -> Result<(), Error>
 where
-	F: Field + BinaryField + PackedField<Scalar = F> + ExtensionField<FA>,
-	FA: BinaryField,
-	TranscriptChallenger: Challenger,
-	VCS: MerkleTreeScheme<F, Digest: DeserializeBytes>,
+	F: Field + BinaryField + PackedField<Scalar = F>,
+	Challenger_: Challenger,
+	MTScheme: MerkleTreeScheme<F, Digest: DeserializeBytes>,
 {
 	let packing_degree = <F as ExtensionField<B1>>::LOG_DEGREE;
 

--- a/crates/verifier/src/protocols/basefold/verifier.rs
+++ b/crates/verifier/src/protocols/basefold/verifier.rs
@@ -1,6 +1,6 @@
 // Copyright 2025 Irreducible Inc.
 
-use binius_field::{BinaryField, ExtensionField, Field};
+use binius_field::{BinaryField, Field};
 use binius_math::multilinear::eq::eq_ind;
 use binius_transcript::{
 	VerifierTranscript,
@@ -65,19 +65,18 @@ fn is_fri_commit_round(
 /// * `fri_params` - The FRI parameters
 /// * `vcs` - The Merkle tree scheme
 /// * `n_vars` - The number of variables in the multilinear polynomial
-pub fn verify_transcript<F, FA, VCS, TranscriptChallenger>(
-	codeword_commitment: VCS::Digest,
-	transcript: &mut VerifierTranscript<TranscriptChallenger>,
+pub fn verify_transcript<F, MTScheme, Challenger_>(
+	codeword_commitment: MTScheme::Digest,
+	transcript: &mut VerifierTranscript<Challenger_>,
 	evaluation_claim: F,
-	fri_params: &FRIParams<F, FA>,
-	vcs: &VCS,
+	fri_params: &FRIParams<F, F>,
+	vcs: &MTScheme,
 	n_vars: usize,
 ) -> Result<(F, SumcheckOutput<F>), Error>
 where
-	F: Field + BinaryField + ExtensionField<FA>,
-	FA: BinaryField,
-	TranscriptChallenger: Challenger,
-	VCS: MerkleTreeScheme<F, Digest: DeserializeBytes>,
+	F: BinaryField,
+	Challenger_: Challenger,
+	MTScheme: MerkleTreeScheme<F, Digest: DeserializeBytes>,
 {
 	let mut challenges = Vec::with_capacity(n_vars);
 	let fri_commit_rounds = is_fri_commit_round(fri_params.fold_arities(), n_vars)?;


### PR DESCRIPTION
These are the type names we've moved to in monbijou.