### PR TITLE
Add float64 addition circuit

### DIFF
--- a/crates/frontend/src/circuits/float64/add.rs
+++ b/crates/frontend/src/circuits/float64/add.rs
@@ -1,0 +1,1478 @@
+use super::utils::*;
+use crate::compiler::{CircuitBuilder, Wire};
+
+/// IEEE-754 double (binary64) addition built from small testable blocks.
+/// Returns a 64-bit IEEE-754 encoding.
+///
+/// Behavior summary:
+/// - Fully handles normals, subnormals, zeros (signed), infinities, NaNs
+/// - Rounding mode: round-to-nearest, ties-to-even
+/// - Sticky tracking across alignment and underflow right-shifts
+/// - Exact cancellation (+x) + (-x) → +0
+/// - Overflow → ±Inf with computed sign
+pub fn float64_add(cb: &CircuitBuilder, a: Wire, b: Wire) -> Wire {
+	// unpack & classify
+	let pa = fp64_unpack(cb, a);
+	let pb = fp64_unpack(cb, b);
+
+	// extended sig & effective exp
+	let (sig_a, exp_a) = fp64_ext_sig_and_exp(cb, &pa);
+	let (sig_b, exp_b) = fp64_ext_sig_and_exp(cb, &pb);
+
+	// order by exponent
+	let (
+		sig_a_ordered,
+		exp_a_ordered,
+		sign_a_ordered,
+		sig_b_ordered,
+		exp_b_ordered,
+		sign_b_ordered,
+		_swapped,
+	) = fp64_order_by_exp(cb, sig_a, exp_a, pa.sign, sig_b, exp_b, pb.sign);
+
+	// alignment with sticky→bit0
+	let d = isub(cb, exp_a_ordered, exp_b_ordered);
+	let s_b = fp64_align_with_sticky(cb, sig_b_ordered, d);
+
+	// same/different sign split
+	let same_sign = cb.icmp_eq(sign_a_ordered, sign_b_ordered);
+
+	// add path
+	let (sum_norm, exp_add) = fp64_add_path(cb, sig_a_ordered, s_b, exp_a_ordered);
+
+	// sub path
+	let (diff_norm, exp_sub, sign_sub, mags_equal) =
+		fp64_sub_path(cb, sig_a_ordered, s_b, exp_a_ordered, sign_a_ordered, sign_b_ordered);
+
+	// merge + cancellation -> +0
+	let (res_sig, res_exp, res_sign) = fp64_merge_and_cancel(
+		cb,
+		same_sign,
+		sum_norm,
+		exp_add,
+		sign_a_ordered,
+		diff_norm,
+		exp_sub,
+		sign_sub,
+		mags_equal,
+	);
+
+	// underflow pre-round right-shift if exp<=0
+	let (sig_round_base, exp_round_base, exp_lt_1) = fp64_underflow_shift(cb, res_sig, res_exp);
+
+	// round to nearest even
+	let (mant_final_53, exp_after_round, mant_overflow_mask) =
+		fp64_round_rne(cb, sig_round_base, exp_round_base);
+
+	// Pack finite or overflow to inf.
+	// Subnormal regime if:
+	//   - we were below 1 (exp_lt_1), OR
+	//   - base exponent == 1 and the integer bit (bit 63) is 0 (no hidden 1)
+	let msb01 = bit_lsb(cb, sig_round_base, 63); // 0/1
+	let msb_is_zero_mask = cb.bnot(to_mask01(cb, msb01));
+	let base_is_one_mask = cb.icmp_eq(exp_round_base, one(cb));
+	let in_sub_regime = cb.bor(exp_lt_1, cb.band(base_is_one_mask, msb_is_zero_mask));
+	let stayed_sub_mask = cb.band(in_sub_regime, cb.bnot(mant_overflow_mask));
+	let finite_or_inf =
+		fp64_pack_finite_or_inf(cb, res_sign, mant_final_53, exp_after_round, stayed_sub_mask);
+
+	// operand-driven specials (NaN, operand infinities)
+	fp64_finish_specials(cb, &pa, &pb, finite_or_inf)
+}
+
+/// Simple view of a decoded binary64 payload.
+#[derive(Clone, Copy)]
+struct Fp64Parts {
+	sign: Wire, // 0 or 1, placed in LSB
+	exp: Wire,  // unbiased field bits (0..=0x7FF)
+	frac: Wire, // 52-bit payload
+
+	// Common classifiers (all-1/all-0 masks):
+	is_nan: Wire,  // exp==0x7FF && frac!=0
+	is_inf: Wire,  // exp==0x7FF && frac==0
+	is_norm: Wire, // normal: exp!=0 && exp!=0x7FF
+}
+
+/// Unpack and classify a binary64 word.
+///
+/// Input:
+/// - `x`: 64-bit IEEE-754 encoding
+///
+/// Output:
+/// - `Fp64Parts` with fields:
+///   - `sign = (x >> 63) & 1`
+///   - `exp = (x >> 52) & 0x7FF`
+///   - `frac = x & ((1<<52)-1)`
+///   - `is_nan`: exp==0x7FF && frac!=0
+///   - `is_inf`: exp==0x7FF && frac==0
+///   - `is_zero`: exp==0 && frac==0
+///   - `is_sub`: exp==0 && frac!=0
+///   - `is_norm`: exp!=0 && exp!=0x7FF
+///
+/// All booleans are 64-bit masks (all-1/all-0), suitable for `select`.
+fn fp64_unpack(cb: &CircuitBuilder, x: Wire) -> Fp64Parts {
+	let exp_m = cb.add_constant_64(0x7FF);
+	let frac_m = cb.add_constant_64((1u64 << 52) - 1);
+
+	let sign = cb.shr(x, 63);
+	let exp = cb.band(cb.shr(x, 52), exp_m);
+	let frac = cb.band(x, frac_m);
+
+	let exp_is_max = cb.icmp_eq(exp, exp_m);
+	let exp_is_zero = cb.icmp_eq(exp, zero(cb));
+	let frac_nz = is_nonzero_mask(cb, frac);
+
+	let is_nan = cb.band(exp_is_max, frac_nz);
+	let is_inf = cb.band(exp_is_max, cb.bnot(frac_nz));
+	let is_norm = cb.bnot(cb.bor(exp_is_max, exp_is_zero));
+
+	Fp64Parts {
+		sign,
+		exp,
+		frac,
+		is_nan,
+		is_inf,
+		is_norm,
+	}
+}
+
+/// Build an **extended significand** and **effective exponent**.
+///
+/// Convention:
+/// - We keep the integer bit at position 63 and leave **11 low bits** for G/R/S and headroom. i.e.,
+///   `sig_ext = significand << 11`.
+///
+/// For normals:  sig = ((1<<52) | frac) << 11,  exp_eff = exp
+/// For subnorms:  sig = (frac           ) << 11, exp_eff = 1
+///
+/// Input:
+/// - `p`: parts from `fp64_unpack`
+///
+/// Output:
+/// - `(sig_ext, exp_eff)` using the above convention.
+fn fp64_ext_sig_and_exp(cb: &CircuitBuilder, p: &Fp64Parts) -> (Wire, Wire) {
+	let one52 = cb.add_constant_64(1u64 << 52);
+
+	let sig_norm = cb.shl(cb.bor(one52, p.frac), 11);
+	let sig_sub = cb.shl(p.frac, 11);
+	let sig = cb.select(p.is_norm, sig_norm, sig_sub);
+
+	let exp_eff = cb.select(p.is_norm, p.exp, one(cb)); // subnormals use exp=1
+	(sig, exp_eff)
+}
+
+/// Order two operands by **effective exponent** (A has >= exponent).
+///
+/// Input:
+/// - `(sig_a, exp_a, sign_a)`, `(sig_b, exp_b, sign_b)`
+///
+/// Output:
+/// - `(sig_a, exp_a, sign_a, sig_b, exp_b, sign_b, swapped_mask)` where `swapped_mask` is all-1 if
+///   we swapped A/B (i.e., A.exp < B.exp).
+fn fp64_order_by_exp(
+	cb: &CircuitBuilder,
+	sig_a: Wire,
+	exp_a: Wire,
+	sign_a: Wire,
+	sig_b: Wire,
+	exp_b: Wire,
+	sign_b: Wire,
+) -> (Wire, Wire, Wire, Wire, Wire, Wire, Wire) {
+	let a_lt_b = cb.icmp_ult(exp_a, exp_b);
+
+	let exp_a_ordered = cb.select(a_lt_b, exp_b, exp_a);
+	let exp_b_ordered = cb.select(a_lt_b, exp_a, exp_b);
+	let sig_a_ordered = cb.select(a_lt_b, sig_b, sig_a);
+	let sig_b_ordered = cb.select(a_lt_b, sig_a, sig_b);
+	let sign_a_ordered = cb.select(a_lt_b, sign_b, sign_a);
+	let sign_b_ordered = cb.select(a_lt_b, sign_a, sign_b);
+
+	(
+		sig_a_ordered,
+		exp_a_ordered,
+		sign_a_ordered,
+		sig_b_ordered,
+		exp_b_ordered,
+		sign_b_ordered,
+		a_lt_b,
+	)
+}
+
+/// Align `sig_b` to `exp_a` by right shifting with **sticky** folded to bit 0.
+///
+/// Input:
+/// - `sig_b`: extended significand per our convention
+/// - `d   = exp_a - exp_b`
+/// - Saturates large shifts to 63; accumulates sticky over all discarded bits.
+///
+/// Output:
+/// - `aligned` where bit0 = old_bit0 | sticky (i.e., precise sticky folding).
+fn fp64_align_with_sticky(cb: &CircuitBuilder, sig_b: Wire, d: Wire) -> Wire {
+	let (mut v, sticky) = var_shr_with_sticky(cb, sig_b, d, true);
+
+	let one_const = one(cb);
+	let keep = cb.bnot(one_const); // ~1 = clear bit0
+	let bit0 = cb.bor(cb.band(v, one_const), cb.band(sticky, one_const));
+	v = cb.bor(cb.band(v, keep), bit0);
+	v
+}
+
+/// Magnitude add path (same signs), with one-bit renormalize if carry=1.
+///
+/// Input:
+/// - `sig_a`, `s_b`, `exp_a`
+///
+/// Output:
+/// - `(sum_norm, exp_add)` If carry occurs, result is shifted right by 1; new sticky = (old R) |
+///   (old S).
+fn fp64_add_path(cb: &CircuitBuilder, sig_a: Wire, s_b: Wire, exp_a: Wire) -> (Wire, Wire) {
+	let (sum_raw, carry_mask) = cb.iadd_cin_cout(sig_a, s_b, zero(cb));
+
+	// Detect final carry-out (bit63 of carry mask) as 0/1 and as a select mask
+	let carry_bit01 = bit_lsb(cb, carry_mask, 63); // 0/1
+	let carry_sel_mask = to_mask01(cb, carry_bit01); // all-ones or zero
+
+	// if carry: shift 1 and update sticky := old R | old S
+	let sum_shift1 = cb.shr(sum_raw, 1);
+	let old_r = bit_lsb(cb, sum_raw, 9);
+	let old_s = cb.band(sum_raw, one(cb));
+	let new_s = cb.bor(old_r, old_s);
+
+	// Inject carry into bit63 when renormalizing: (carry_bit01 << 63)
+	let carry_hi = cb.shl(carry_bit01, 63);
+	let sum_shift1_with_carry = cb.bor(sum_shift1, carry_hi);
+
+	let keep = cb.bnot(one(cb));
+	let sum_shift1clr = cb.band(sum_shift1_with_carry, keep);
+	let sum_norm = cb.select(carry_sel_mask, cb.bor(sum_shift1clr, new_s), sum_raw);
+
+	// Increment exponent by carry (0/1)
+	let exp_add = iadd(cb, exp_a, carry_bit01);
+	(sum_norm, exp_add)
+}
+
+/// Magnitude subtraction path (different signs), normalized by CLZ.
+///
+/// Chooses `big-small` by comparing magnitudes; sign takes the sign of the larger magnitude.
+/// Normalizes by shifting left up to `min(clz(diff), exp_a-1)`.
+///
+/// Input:
+/// - `sig_a`, `s_b`, `exp_a`, `sign_a`, `sign_b`
+///
+/// Output:
+/// - `(diff_norm, exp_sub, sign_sub, mags_equal_mask)`
+///   - If `sig_a == s_b`, `diff_norm` may be 0; caller can force +0 behavior using
+///     `mags_equal_mask`.
+fn fp64_sub_path(
+	cb: &CircuitBuilder,
+	sig_a: Wire,
+	s_b: Wire,
+	exp_a: Wire,
+	sign_a: Wire,
+	sign_b: Wire,
+) -> (Wire, Wire, Wire, Wire) {
+	let a_lt_b = cb.icmp_ult(sig_a, s_b);
+	let big = cb.select(a_lt_b, s_b, sig_a);
+	let small = cb.select(a_lt_b, sig_a, s_b);
+	let diff_raw = isub(cb, big, small);
+	let sign_sub = cb.select(a_lt_b, sign_b, sign_a);
+	let mags_eq = cb.icmp_eq(sig_a, s_b);
+
+	let lz = clz64(cb, diff_raw);
+	let c64 = cb.add_constant_64(64);
+	let c63 = cb.add_constant_64(63);
+	let lt64 = cb.icmp_ult(lz, c64);
+	let lz_clamped = cb.select(lt64, lz, c63);
+
+	let exp_a_m1 = isub(cb, exp_a, one(cb));
+	let lz_lt_expm1 = cb.icmp_ult(lz_clamped, exp_a_m1);
+	let sh = cb.select(lz_lt_expm1, lz_clamped, exp_a_m1);
+
+	let diff_norm = var_shl(cb, diff_raw, sh);
+	let exp_sub = isub(cb, exp_a, sh);
+
+	(diff_norm, exp_sub, sign_sub, mags_eq)
+}
+
+/// Merge add/sub paths and handle **exact cancellation → +0**.
+///
+/// Input:
+/// - `same_sign_mask`
+/// - add: `(sum_norm, exp_add, sign_a)`
+/// - sub: `(diff_norm, exp_sub, sign_sub, mags_equal_mask)`
+///
+/// Output:
+/// - `(res_sig, res_exp, res_sign)` with cancellation mapped to +0.
+#[allow(clippy::too_many_arguments)]
+fn fp64_merge_and_cancel(
+	cb: &CircuitBuilder,
+	same_sign: Wire,
+	sum_norm: Wire,
+	exp_add: Wire,
+	sign_a: Wire,
+	diff_norm: Wire,
+	exp_sub: Wire,
+	sign_sub: Wire,
+	mags_equal: Wire,
+) -> (Wire, Wire, Wire) {
+	let res_sig_pre = cb.select(same_sign, sum_norm, diff_norm);
+	let res_exp_pre = cb.select(same_sign, exp_add, exp_sub);
+	let res_sign_pre = cb.select(same_sign, sign_a, sign_sub);
+
+	// different signs and equal magnitudes => +0
+	let cancel = cb.band(cb.bnot(same_sign), mags_equal);
+
+	let res_sig = cb.select(cancel, zero(cb), res_sig_pre);
+	let res_exp = cb.select(cancel, zero(cb), res_exp_pre); // exp ignored for zero
+	let res_sign = cb.select(cancel, zero(cb), res_sign_pre); // +0
+	(res_sig, res_exp, res_sign)
+}
+
+/// Pre-round **underflow** handling: if `exp<=0`, right shift by `k=1-exp`
+/// and fold sticky into bit0. Also prepare the exponent for rounding geometry (Exp=1).
+///
+/// Input: `(res_sig, res_exp)`
+///
+/// Output:
+/// - `(sig_round_base, exp_round_base, exp_lt_1_mask)` where `exp_round_base = (exp<=0 ? 1 : exp)`.
+fn fp64_underflow_shift(cb: &CircuitBuilder, res_sig: Wire, res_exp: Wire) -> (Wire, Wire, Wire) {
+	let c1 = one(cb);
+	let keep = cb.bnot(c1);
+
+	let exp_lt_1 = cb.icmp_ult(res_exp, c1);
+	let k = isub(cb, c1, res_exp); // 1 - exp
+	let k_use = cb.select(exp_lt_1, k, zero(cb));
+
+	let (mut sig_u, st) = var_shr_with_sticky(cb, res_sig, k_use, true);
+	let bit0 = cb.bor(cb.band(sig_u, c1), cb.band(st, c1));
+	sig_u = cb.bor(cb.band(sig_u, keep), bit0);
+
+	let sig_round_base = cb.select(exp_lt_1, sig_u, res_sig);
+	let exp_round_base = cb.select(exp_lt_1, c1, res_exp);
+	(sig_round_base, exp_round_base, exp_lt_1)
+}
+
+/// Round-to-nearest, ties-to-even (RN-even).
+///
+/// Geometry:
+/// - Integer bit at 63; we interpret bits:
+///   - LSB of target mantissa at bit 11
+///   - Guard=10, Round=9, Sticky=bit 0 (already folded)
+///
+/// Input: `(sig_base, exp_base)`
+///
+/// Output:
+/// - `(mant_final_53, exp_after_round, mant_overflow_mask)`
+///   - `mant_final_53` is a 53-bit value (includes hidden 1 for normals)
+///   - If mant overflowed to 54 bits, we shift right 1 and increment exponent.
+fn fp64_round_rne(cb: &CircuitBuilder, sig_base: Wire, exp_base: Wire) -> (Wire, Wire, Wire) {
+	let lsb = bit_lsb(cb, sig_base, 11);
+	let g = bit_lsb(cb, sig_base, 10);
+	let r = bit_lsb(cb, sig_base, 9);
+	let s = cb.band(sig_base, one(cb));
+	let r_or_s = cb.bor(r, s);
+	let tie_or_gt = cb.bor(r_or_s, lsb);
+	let round_up01 = cb.band(g, tie_or_gt); // 0/1
+
+	let mant_trunc = cb.shr(sig_base, 11);
+	let mant_rounded = iadd(cb, mant_trunc, round_up01);
+
+	let overflow01 = bit_lsb(cb, mant_rounded, 53); // 0/1
+	let overflow_mask = to_mask01(cb, overflow01);
+	let mant_final_53 = cb.select(overflow_mask, cb.shr(mant_rounded, 1), mant_rounded);
+	let exp_after = iadd(cb, exp_base, overflow01);
+
+	(mant_final_53, exp_after, overflow_mask)
+}
+
+/// Pack finite (normal / subnormal) and apply overflow-to-Inf if needed.
+///
+/// Input:
+/// - `sign` (0/1), `mant_final_53`, `exp_after_round`
+/// - `stayed_sub_mask`: all-1 iff we are in subnormal regime **and** there was no mantissa overflow
+///
+/// Output:
+/// - `finite_or_inf`: packed 64-bit result (finite or +/−Inf on overflow)
+fn fp64_pack_finite_or_inf(
+	cb: &CircuitBuilder,
+	sign: Wire,
+	mant_final_53: Wire,
+	exp_after_round: Wire,
+	stayed_sub_mask: Wire,
+) -> Wire {
+	let frac_m = cb.add_constant_64((1u64 << 52) - 1);
+	let exp_2047 = cb.add_constant_64(0x7FF);
+	let sign_hi = cb.shl(sign, 63);
+
+	let frac = cb.band(mant_final_53, frac_m);
+	let packed_sub = cb.bor(sign_hi, frac);
+
+	let exp_sh = cb.shl(exp_after_round, 52);
+	let packed_norm = cb.bor(cb.bor(sign_hi, exp_sh), frac);
+
+	let finite_packed = cb.select(stayed_sub_mask, packed_sub, packed_norm);
+
+	// If mantissa is zero, the result is a signed zero regardless of exp_after_round.
+	let mant_is_zero = is_zero_mask(cb, mant_final_53);
+	let packed_zero = sign_hi; // exp=0, frac=0
+	let finite_or_zero = cb.select(mant_is_zero, packed_zero, finite_packed);
+
+	let overflow_to_inf = cb.bnot(cb.icmp_ult(exp_after_round, exp_2047));
+	let inf_payload = cb.shl(exp_2047, 52);
+	let packed_inf = cb.bor(sign_hi, inf_payload);
+
+	cb.select(overflow_to_inf, packed_inf, finite_or_zero)
+}
+
+/// Final special-case selection: NaN and operand Infinities.
+///
+/// Precedence: **NaN > operand-Inf > (finite/overflow result)**.
+///
+/// - If any NaN, or (+Inf)+(-Inf), return canonical quiet NaN: 0x7FF8_0000_0000_0000
+/// - Else if any operand is Inf, return that infinity with its operand sign
+/// - Else return `finite_or_inf`
+///
+/// Inputs:
+/// - `pa`, `pb`: parts from `fp64_unpack` for a and b
+/// - `finite_or_inf`: result from `fp64_pack_finite_or_inf` (includes overflow to Inf)
+///
+/// Output:
+/// - final packed double
+fn fp64_finish_specials(
+	cb: &CircuitBuilder,
+	pa: &Fp64Parts,
+	pb: &Fp64Parts,
+	finite_or_inf: Wire,
+) -> Wire {
+	let qnan = cb.add_constant_64(0x7FF8_0000_0000_0000);
+	let exp_2047 = cb.add_constant_64(0x7FF);
+	let inf_payload = cb.shl(exp_2047, 52);
+
+	let same_sign = cb.icmp_eq(pa.sign, pb.sign);
+	let opp_inf_nan = cb.band(cb.band(pa.is_inf, pb.is_inf), cb.bnot(same_sign));
+	let any_nan = cb.bor(pa.is_nan, pb.is_nan);
+	let nan_mask = cb.bor(any_nan, opp_inf_nan);
+
+	// If any operand is infinity (with either same signs or only one inf), pick its sign.
+	let any_inf = cb.bor(pa.is_inf, pb.is_inf);
+	let inf_sign = cb.select(pb.is_inf, pb.sign, pa.sign);
+	let inf_hi = cb.shl(inf_sign, 63);
+	let packed_inf = cb.bor(inf_hi, inf_payload);
+
+	let with_inf = cb.select(any_inf, packed_inf, finite_or_inf);
+	cb.select(nan_mask, qnan, with_inf)
+}
+
+#[cfg(test)]
+mod tests {
+	use binius_core::word::Word;
+
+	use super::*;
+	use crate::constraint_verifier::verify_constraints;
+
+	#[derive(Debug, Clone, PartialEq)]
+	struct Fp64UnpackResult {
+		sign: u64,
+		exp: u64,
+		frac: u64,
+		is_nan: u64,
+		is_inf: u64,
+		is_norm: u64,
+	}
+
+	fn ref_fp64_unpack(x: u64) -> Fp64UnpackResult {
+		let sign = (x >> 63) & 1;
+		let exp = (x >> 52) & 0x7FF;
+		let frac = x & ((1u64 << 52) - 1);
+
+		let exp_is_max = if exp == 0x7FF { u64::MAX } else { 0 };
+		let exp_is_zero = if exp == 0 { u64::MAX } else { 0 };
+		let frac_nz = if frac != 0 { u64::MAX } else { 0 };
+
+		let is_nan = exp_is_max & frac_nz;
+		let is_inf = exp_is_max & (!frac_nz);
+		let is_norm = (!exp_is_max) & (!exp_is_zero);
+
+		Fp64UnpackResult {
+			sign,
+			exp,
+			frac,
+			is_nan,
+			is_inf,
+			is_norm,
+		}
+	}
+
+	fn ref_fp64_ext_sig_and_exp(_sign: u64, exp: u64, frac: u64, is_norm: u64) -> (u64, u64) {
+		let sig = if is_norm == u64::MAX {
+			((1u64 << 52) | frac) << 11
+		} else {
+			frac << 11
+		};
+
+		let exp_eff = if is_norm == u64::MAX { exp } else { 1 };
+
+		(sig, exp_eff)
+	}
+
+	fn ref_fp64_order_by_exp(
+		sig_a: u64,
+		exp_a: u64,
+		sign_a: u64,
+		sig_b: u64,
+		exp_b: u64,
+		sign_b: u64,
+	) -> (u64, u64, u64, u64, u64, u64, u64) {
+		if exp_a < exp_b {
+			(sig_b, exp_b, sign_b, sig_a, exp_a, sign_a, u64::MAX)
+		} else {
+			(sig_a, exp_a, sign_a, sig_b, exp_b, sign_b, 0)
+		}
+	}
+
+	fn ref_fp64_align_with_sticky(sig_b: u64, d: u64) -> u64 {
+		let d_eff = std::cmp::min(d, 63);
+		if d_eff == 0 {
+			return sig_b;
+		}
+
+		let shifted = sig_b >> d_eff;
+		let lost_bits = sig_b & ((1u64 << d_eff) - 1);
+		let sticky = if lost_bits != 0 { 1 } else { 0 };
+
+		// Set bit 0 to be old bit 0 OR sticky
+		let old_bit0 = shifted & 1;
+		let new_bit0 = old_bit0 | sticky;
+		(shifted & !1) | new_bit0
+	}
+
+	fn ref_fp64_add_path(sig_a: u64, s_b: u64, exp_a: u64) -> (u64, u64) {
+		// Reference implementation following the provided pseudocode exactly
+		// function fp64_add_path(sig_a, s_b, exp_a) -> (sum_norm, exp_add):
+
+		// 1) Add magnitudes
+		let sum_raw = sig_a.wrapping_add(s_b);
+
+		// 2) Detect 1-bit carry out of the 64-bit lane
+		// (classic unsigned carry detection)
+		let carry01 = if sum_raw < sig_a { 1 } else { 0 };
+
+		// 3) If carry: renormalize by shifting right one, and update sticky := old_R | old_S
+		if carry01 == 1 {
+			// Old rounding geometry before the shift
+			let old_r = (sum_raw >> 9) & 1; // bit 9
+			let old_s = sum_raw & 1; // bit 0 (already a sticky-OR)
+
+			// Shift right and preserve the carry into bit 63
+			let shifted = (sum_raw >> 1) | (1u64 << 63);
+			let new_s = old_r | old_s; // new sticky for bit 0 after shift
+			let sum_norm = (shifted & !1) | new_s; // clear bit0, then OR in newS
+
+			let exp_add = exp_a + 1;
+
+			(sum_norm, exp_add)
+		} else {
+			// No carry: already normalized
+			let sum_norm = sum_raw;
+			let exp_add = exp_a;
+
+			(sum_norm, exp_add)
+		}
+	}
+
+	fn ref_fp64_sub_path(
+		sig_a: u64,
+		s_b: u64,
+		exp_a: u64,
+		sign_a: u64,
+		sign_b: u64,
+	) -> (u64, u64, u64, u64) {
+		// Match the circuit logic exactly
+		let a_lt_b = if sig_a < s_b { u64::MAX } else { 0 };
+		let big = if a_lt_b == u64::MAX { s_b } else { sig_a };
+		let small = if a_lt_b == u64::MAX { sig_a } else { s_b };
+		let diff_raw = big.wrapping_sub(small);
+		let sign_sub = if a_lt_b == u64::MAX { sign_b } else { sign_a };
+		let mags_eq = if sig_a == s_b { u64::MAX } else { 0 };
+
+		// Use clz64 reference implementation
+		let lz = if diff_raw == 0 {
+			64
+		} else {
+			diff_raw.leading_zeros() as u64
+		};
+		let c64 = 64;
+		let c63 = 63;
+		let lt64 = if lz < c64 { u64::MAX } else { 0 };
+		let lz_clamped = if lt64 == u64::MAX { lz } else { c63 };
+
+		let exp_a_m1 = exp_a.wrapping_sub(1);
+		let lz_lt_expm1 = if lz_clamped < exp_a_m1 { u64::MAX } else { 0 };
+		let sh = if lz_lt_expm1 == u64::MAX {
+			lz_clamped
+		} else {
+			exp_a_m1
+		};
+
+		// Use variable left shift
+		let shift_amt = std::cmp::min(sh, 63); // Simulate var_shl behavior
+		let diff_norm = diff_raw << shift_amt;
+		let exp_sub = exp_a.wrapping_sub(sh);
+
+		(diff_norm, exp_sub, sign_sub, mags_eq)
+	}
+
+	#[allow(clippy::too_many_arguments)]
+	fn ref_fp64_merge_and_cancel(
+		same_sign: u64,
+		sum_norm: u64,
+		exp_add: u64,
+		sign_a: u64,
+		diff_norm: u64,
+		exp_sub: u64,
+		sign_sub: u64,
+		mags_equal: u64,
+	) -> (u64, u64, u64) {
+		let (res_sig_pre, res_exp_pre, res_sign_pre) = if same_sign == u64::MAX {
+			(sum_norm, exp_add, sign_a)
+		} else {
+			(diff_norm, exp_sub, sign_sub)
+		};
+
+		// Handle exact cancellation -> +0
+		let cancel = if same_sign == 0 && mags_equal == u64::MAX {
+			u64::MAX
+		} else {
+			0
+		};
+
+		let res_sig = if cancel == u64::MAX { 0 } else { res_sig_pre };
+		let res_exp = if cancel == u64::MAX { 0 } else { res_exp_pre };
+		let res_sign = if cancel == u64::MAX { 0 } else { res_sign_pre };
+
+		(res_sig, res_exp, res_sign)
+	}
+
+	fn ref_fp64_underflow_shift(res_sig: u64, res_exp: u64) -> (u64, u64, u64) {
+		let exp_lt_1 = if res_exp < 1 { u64::MAX } else { 0 };
+
+		if exp_lt_1 == u64::MAX {
+			let k = 1u64.wrapping_sub(res_exp);
+			let k_use = std::cmp::min(k, 63);
+
+			let sig_shifted = res_sig >> k_use;
+			let lost_bits = res_sig & ((1u64 << k_use) - 1);
+			let sticky = if lost_bits != 0 { 1 } else { 0 };
+			let bit0 = (sig_shifted & 1) | sticky;
+			let sig_u = (sig_shifted & !1) | bit0;
+
+			(sig_u, 1, exp_lt_1)
+		} else {
+			(res_sig, res_exp, exp_lt_1)
+		}
+	}
+
+	fn ref_fp64_round_rne(sig_base: u64, exp_base: u64) -> (u64, u64, u64) {
+		let lsb = (sig_base >> 11) & 1;
+		let g = (sig_base >> 10) & 1;
+		let r = (sig_base >> 9) & 1;
+		let s = sig_base & 1;
+
+		let r_or_s = r | s;
+		let tie_or_gt = r_or_s | lsb;
+		let round_up = g & tie_or_gt;
+
+		let mant_trunc = sig_base >> 11;
+		let mant_rounded = mant_trunc.wrapping_add(round_up);
+
+		let overflow = (mant_rounded >> 53) & 1;
+		let overflow_mask = if overflow != 0 { u64::MAX } else { 0 };
+		let mant_final_53 = if overflow_mask == u64::MAX {
+			mant_rounded >> 1
+		} else {
+			mant_rounded
+		};
+		let exp_after = exp_base.wrapping_add(overflow);
+
+		(mant_final_53, exp_after, overflow_mask)
+	}
+
+	fn ref_fp64_pack_finite_or_inf(
+		sign: u64,
+		mant_final_53: u64,
+		exp_after_round: u64,
+		stayed_sub_mask: u64,
+	) -> u64 {
+		let sign_hi = sign << 63;
+		let frac = mant_final_53 & ((1u64 << 52) - 1);
+
+		let packed_sub = sign_hi | frac;
+		let exp_sh = exp_after_round << 52;
+		let packed_norm = sign_hi | exp_sh | frac;
+
+		let finite_packed = if stayed_sub_mask == u64::MAX {
+			packed_sub
+		} else {
+			packed_norm
+		};
+
+		// If mantissa is zero, this is a signed zero regardless of exponent
+		let finite_or_zero = if mant_final_53 == 0 {
+			sign_hi
+		} else {
+			finite_packed
+		};
+
+		let overflow_to_inf = exp_after_round >= 0x7FF;
+		if overflow_to_inf {
+			let inf_payload = 0x7FFu64 << 52;
+			sign_hi | inf_payload
+		} else {
+			finite_or_zero
+		}
+	}
+
+	fn ref_fp64_finish_specials(
+		pa_is_nan: u64,
+		pa_is_inf: u64,
+		pa_sign: u64,
+		pb_is_nan: u64,
+		pb_is_inf: u64,
+		pb_sign: u64,
+		finite_or_inf: u64,
+	) -> u64 {
+		let qnan = 0x7FF8_0000_0000_0000u64;
+
+		let any_nan = (pa_is_nan | pb_is_nan) != 0;
+		let same_sign = pa_sign == pb_sign;
+		let opp_inf_nan = (pa_is_inf != 0) && (pb_is_inf != 0) && !same_sign;
+		let nan_case = any_nan || opp_inf_nan;
+
+		if nan_case {
+			return qnan;
+		}
+
+		let any_inf = (pa_is_inf | pb_is_inf) != 0;
+		if any_inf {
+			let inf_sign = if pb_is_inf != 0 { pb_sign } else { pa_sign };
+			let inf_hi = inf_sign << 63;
+			let inf_payload = 0x7FFu64 << 52;
+			return inf_hi | inf_payload;
+		}
+
+		finite_or_inf
+	}
+
+	fn ref_float64_add(a_bits: u64, b_bits: u64) -> u64 {
+		// Unpack & classify operands
+		let pa = ref_fp64_unpack(a_bits);
+		let pb = ref_fp64_unpack(b_bits);
+
+		// Extended significands and effective exponents
+		let (sig_a0, exp_a0) = ref_fp64_ext_sig_and_exp(pa.sign, pa.exp, pa.frac, pa.is_norm);
+		let (sig_b0, exp_b0) = ref_fp64_ext_sig_and_exp(pb.sign, pb.exp, pb.frac, pb.is_norm);
+
+		// Order by exponent
+		let (sig_a, exp_a, sign_a, sig_b, exp_b, sign_b, _swapped) =
+			ref_fp64_order_by_exp(sig_a0, exp_a0, pa.sign, sig_b0, exp_b0, pb.sign);
+
+		// Align B to A with sticky folded into bit0
+		let d = exp_a.wrapping_sub(exp_b);
+		let s_b_align = ref_fp64_align_with_sticky(sig_b, d);
+
+		// Choose path by sign
+		let same_sign = if sign_a == sign_b { u64::MAX } else { 0 };
+		let (sum_norm, exp_add) = ref_fp64_add_path(sig_a, s_b_align, exp_a);
+		let (diff_norm, exp_sub, sign_sub, mags_equal) =
+			ref_fp64_sub_path(sig_a, s_b_align, exp_a, sign_a, sign_b);
+
+		// Merge + exact cancellation to +0
+		let (res_sig, res_exp, res_sign) = ref_fp64_merge_and_cancel(
+			same_sign, sum_norm, exp_add, sign_a, diff_norm, exp_sub, sign_sub, mags_equal,
+		);
+
+		// Pre-round underflow handling
+		let (sig_round_base, exp_round_base, exp_lt_1) = ref_fp64_underflow_shift(res_sig, res_exp);
+
+		// Round to nearest ties-to-even
+		let (mant_final_53, exp_after_round, mant_overflow_mask) =
+			ref_fp64_round_rne(sig_round_base, exp_round_base);
+
+		// Pack finite or overflow to Inf
+		// Subnormal regime if:
+		//   - we were below 1 (exp_lt_1), OR
+		//   - base exponent == 1 and the integer bit (bit 63) is 0 (no hidden 1)
+		let msb = (sig_round_base >> 63) & 1;
+		let base_is_one = exp_round_base == 1;
+		let in_sub_regime = (exp_lt_1 != 0) || (base_is_one && msb == 0);
+		let stayed_sub_mask = if in_sub_regime && mant_overflow_mask == 0 {
+			u64::MAX
+		} else {
+			0
+		};
+		let finite_or_inf =
+			ref_fp64_pack_finite_or_inf(res_sign, mant_final_53, exp_after_round, stayed_sub_mask);
+
+		// Final specials overlay
+		ref_fp64_finish_specials(
+			pa.is_nan,
+			pa.is_inf,
+			pa.sign,
+			pb.is_nan,
+			pb.is_inf,
+			pb.sign,
+			finite_or_inf,
+		)
+	}
+
+	// Helper: semantic equality for f64 bit patterns, treating any-NaN as equal
+	fn f64_bits_semantic_eq(a_bits: u64, b_bits: u64) -> bool {
+		let a = f64::from_bits(a_bits);
+		let b = f64::from_bits(b_bits);
+		if a.is_nan() && b.is_nan() {
+			true
+		} else {
+			a_bits == b_bits
+		}
+	}
+
+	#[test]
+	fn test_fp64_align_with_sticky() {
+		let test_cases = [
+			// (sig_b, d, expected_result)
+			(0x8000000000000000u64, 1), // Simple shift right by 1
+			(0x8000000000000001u64, 1), // Shift right by 1 with sticky
+			(0xFFFFFFFFFFFFFFFFu64, 4), // Shift right by 4 with sticky
+			(0x1000000000000000u64, 0), // No shift
+			(0x123456789ABCDEFFu64, 8), // Shift by 8, lost bits set sticky
+		];
+
+		for (sig_b, d) in test_cases {
+			let builder = CircuitBuilder::new();
+			let sig_b_wire = builder.add_inout();
+			let d_wire = builder.add_inout();
+			let result = fp64_align_with_sticky(&builder, sig_b_wire, d_wire);
+			let expected_wire = builder.add_inout();
+			builder.assert_eq("align_result", result, expected_wire);
+
+			let circuit = builder.build();
+			let mut w = circuit.new_witness_filler();
+			w[sig_b_wire] = Word(sig_b);
+			w[d_wire] = Word(d);
+			w[expected_wire] = Word(ref_fp64_align_with_sticky(sig_b, d));
+
+			circuit.populate_wire_witness(&mut w).unwrap();
+			let cs = circuit.constraint_system();
+			verify_constraints(cs, &w.into_value_vec()).unwrap();
+		}
+	}
+
+	#[test]
+	fn test_iadd_simple() {
+		let builder = CircuitBuilder::new();
+		let a = builder.add_inout();
+		let b = builder.add_inout();
+		let result = iadd(&builder, a, b);
+		let expected = builder.add_inout();
+		builder.assert_eq("iadd_result", result, expected);
+
+		let circuit = builder.build();
+		let mut w = circuit.new_witness_filler();
+		w[a] = Word(1000);
+		w[b] = Word(1);
+		w[expected] = Word(1001);
+
+		circuit.populate_wire_witness(&mut w).unwrap();
+		let cs = circuit.constraint_system();
+		verify_constraints(cs, &w.into_value_vec()).unwrap();
+	}
+
+	#[test]
+	fn test_fp64_add_path() {
+		let test_cases = [
+			// (sig_a, s_b, exp_a)
+			(0x8000000000000000u64, 0x4000000000000000u64, 1023), // Normal addition
+			(0xFFFFFFFFFFFFFFFFu64, 0x0000000000000001u64, 1000), // Addition with carry
+			(0x1000000000000000u64, 0x1000000000000000u64, 500),  // Equal values
+			// 1.5 + 1.5 geometry in extended sig space: each is 0xC000.., expect renorm carry
+			(0xC000000000000000u64, 0xC000000000000000u64, 1023),
+		];
+
+		for (sig_a, s_b, exp_a) in test_cases.iter() {
+			let builder = CircuitBuilder::new();
+			let sig_a_wire = builder.add_inout();
+			let s_b_wire = builder.add_inout();
+			let exp_a_wire = builder.add_inout();
+			let (sum_norm, exp_add) = fp64_add_path(&builder, sig_a_wire, s_b_wire, exp_a_wire);
+			let expected_sum = builder.add_inout();
+			let expected_exp = builder.add_inout();
+			builder.assert_eq("sum_norm", sum_norm, expected_sum);
+			builder.assert_eq("exp_add", exp_add, expected_exp);
+
+			let circuit = builder.build();
+			let mut w = circuit.new_witness_filler();
+			w[sig_a_wire] = Word(*sig_a);
+			w[s_b_wire] = Word(*s_b);
+			w[exp_a_wire] = Word(*exp_a);
+
+			let (ref_sum, ref_exp) = ref_fp64_add_path(*sig_a, *s_b, *exp_a);
+			w[expected_sum] = Word(ref_sum);
+			w[expected_exp] = Word(ref_exp);
+
+			circuit.populate_wire_witness(&mut w).unwrap();
+			let cs = circuit.constraint_system();
+			verify_constraints(cs, &w.into_value_vec()).unwrap();
+		}
+	}
+
+	#[test]
+	fn test_fp64_sub_path() {
+		let test_cases = [
+			// (sig_a, s_b, exp_a, sign_a, sign_b)
+			(0x8000000000000000u64, 0x4000000000000000u64, 1023, 0, 1), // Normal subtraction
+			(0x4000000000000000u64, 0x8000000000000000u64, 1020, 0, 1), // B > A
+			(0x8000000000000000u64, 0x8000000000000000u64, 1023, 0, 1), // Equal magnitudes
+			(0x1000000000000000u64, 0x0800000000000000u64, 1000, 1, 0), // Small difference
+		];
+
+		for (sig_a, s_b, exp_a, sign_a, sign_b) in test_cases {
+			let builder = CircuitBuilder::new();
+			let sig_a_wire = builder.add_inout();
+			let s_b_wire = builder.add_inout();
+			let exp_a_wire = builder.add_inout();
+			let sign_a_wire = builder.add_inout();
+			let sign_b_wire = builder.add_inout();
+
+			let (diff_norm, exp_sub, sign_sub, mags_equal) =
+				fp64_sub_path(&builder, sig_a_wire, s_b_wire, exp_a_wire, sign_a_wire, sign_b_wire);
+
+			let expected_diff = builder.add_inout();
+			let expected_exp = builder.add_inout();
+			let expected_sign = builder.add_inout();
+			let expected_mags = builder.add_inout();
+
+			builder.assert_eq("diff_norm", diff_norm, expected_diff);
+			builder.assert_eq("exp_sub", exp_sub, expected_exp);
+			builder.assert_eq("sign_sub", sign_sub, expected_sign);
+			builder.assert_eq("mags_equal", mags_equal, expected_mags);
+
+			let circuit = builder.build();
+			let mut w = circuit.new_witness_filler();
+			w[sig_a_wire] = Word(sig_a);
+			w[s_b_wire] = Word(s_b);
+			w[exp_a_wire] = Word(exp_a);
+			w[sign_a_wire] = Word(sign_a);
+			w[sign_b_wire] = Word(sign_b);
+
+			let (ref_diff, ref_exp, ref_sign, ref_mags) =
+				ref_fp64_sub_path(sig_a, s_b, exp_a, sign_a, sign_b);
+			w[expected_diff] = Word(ref_diff);
+			w[expected_exp] = Word(ref_exp);
+			w[expected_sign] = Word(ref_sign);
+			w[expected_mags] = Word(ref_mags);
+
+			circuit.populate_wire_witness(&mut w).unwrap();
+			let cs = circuit.constraint_system();
+			verify_constraints(cs, &w.into_value_vec()).unwrap();
+		}
+	}
+
+	#[test]
+	fn test_fp64_merge_and_cancel() {
+		let test_cases = [
+			// (same_sign, sum_norm, exp_add, sign_a, diff_norm, exp_sub, sign_sub, mags_equal)
+			(u64::MAX, 0x8000000000000000u64, 1024, 0, 0x4000000000000000u64, 1020, 1, 0), /* Same sign - use add path */
+			(0, 0x8000000000000000u64, 1024, 0, 0x4000000000000000u64, 1020, 1, 0),        /* Different
+			                                                                                * sign - use
+			                                                                                * sub path */
+			(0, 0x8000000000000000u64, 1024, 0, 0x4000000000000000u64, 1020, 1, u64::MAX), /* Exact cancellation */
+		];
+
+		for (same_sign, sum_norm, exp_add, sign_a, diff_norm, exp_sub, sign_sub, mags_equal) in
+			test_cases
+		{
+			let builder = CircuitBuilder::new();
+			let same_sign_wire = builder.add_inout();
+			let sum_norm_wire = builder.add_inout();
+			let exp_add_wire = builder.add_inout();
+			let sign_a_wire = builder.add_inout();
+			let diff_norm_wire = builder.add_inout();
+			let exp_sub_wire = builder.add_inout();
+			let sign_sub_wire = builder.add_inout();
+			let mags_equal_wire = builder.add_inout();
+
+			let (res_sig, res_exp, res_sign) = fp64_merge_and_cancel(
+				&builder,
+				same_sign_wire,
+				sum_norm_wire,
+				exp_add_wire,
+				sign_a_wire,
+				diff_norm_wire,
+				exp_sub_wire,
+				sign_sub_wire,
+				mags_equal_wire,
+			);
+
+			let expected_sig = builder.add_inout();
+			let expected_exp = builder.add_inout();
+			let expected_sign = builder.add_inout();
+
+			builder.assert_eq("res_sig", res_sig, expected_sig);
+			builder.assert_eq("res_exp", res_exp, expected_exp);
+			builder.assert_eq("res_sign", res_sign, expected_sign);
+
+			let circuit = builder.build();
+			let mut w = circuit.new_witness_filler();
+			w[same_sign_wire] = Word(same_sign);
+			w[sum_norm_wire] = Word(sum_norm);
+			w[exp_add_wire] = Word(exp_add);
+			w[sign_a_wire] = Word(sign_a);
+			w[diff_norm_wire] = Word(diff_norm);
+			w[exp_sub_wire] = Word(exp_sub);
+			w[sign_sub_wire] = Word(sign_sub);
+			w[mags_equal_wire] = Word(mags_equal);
+
+			let (ref_sig, ref_exp, ref_sign) = ref_fp64_merge_and_cancel(
+				same_sign, sum_norm, exp_add, sign_a, diff_norm, exp_sub, sign_sub, mags_equal,
+			);
+			w[expected_sig] = Word(ref_sig);
+			w[expected_exp] = Word(ref_exp);
+			w[expected_sign] = Word(ref_sign);
+
+			circuit.populate_wire_witness(&mut w).unwrap();
+			let cs = circuit.constraint_system();
+			verify_constraints(cs, &w.into_value_vec()).unwrap();
+		}
+	}
+
+	#[test]
+	fn test_fp64_underflow_shift() {
+		let test_cases = [
+			// (res_sig, res_exp)
+			(0x8000000000000000u64, 5),            // Normal case, no underflow
+			(0x8000000000000000u64, 0),            // Underflow case, exp = 0
+			(0x4000000000000000u64, -5i64 as u64), // Significant underflow
+		];
+
+		for (res_sig, res_exp) in test_cases {
+			let builder = CircuitBuilder::new();
+			let res_sig_wire = builder.add_inout();
+			let res_exp_wire = builder.add_inout();
+
+			let (sig_round_base, exp_round_base, exp_lt_1) =
+				fp64_underflow_shift(&builder, res_sig_wire, res_exp_wire);
+
+			let expected_sig = builder.add_inout();
+			let expected_exp = builder.add_inout();
+			let expected_lt1 = builder.add_inout();
+
+			builder.assert_eq("sig_round_base", sig_round_base, expected_sig);
+			builder.assert_eq("exp_round_base", exp_round_base, expected_exp);
+			builder.assert_eq("exp_lt_1", exp_lt_1, expected_lt1);
+
+			let circuit = builder.build();
+			let mut w = circuit.new_witness_filler();
+			w[res_sig_wire] = Word(res_sig);
+			w[res_exp_wire] = Word(res_exp);
+
+			let (ref_sig, ref_exp, ref_lt1) = ref_fp64_underflow_shift(res_sig, res_exp);
+			w[expected_sig] = Word(ref_sig);
+			w[expected_exp] = Word(ref_exp);
+			w[expected_lt1] = Word(ref_lt1);
+
+			circuit.populate_wire_witness(&mut w).unwrap();
+			let cs = circuit.constraint_system();
+			verify_constraints(cs, &w.into_value_vec()).unwrap();
+		}
+	}
+
+	#[test]
+	fn test_fp64_round_rne() {
+		let test_cases = [
+			// (sig_base, exp_base) - test round-to-nearest-even
+			(0x8000000000000000u64, 1023), // No rounding needed
+			(0x8000000000000800u64, 1023), /* Round up (G=1, R=0, S=0, LSB=0 -> ties to even =
+			                                * no round) */
+			(0x8000000000001800u64, 1023), // Round up (G=1, R=1, S=0 -> round up)
+			(0x8000000000000C00u64, 1023), // Round up (G=1, R=0, S=1 -> round up)
+		];
+
+		for (sig_base, exp_base) in test_cases {
+			let builder = CircuitBuilder::new();
+			let sig_base_wire = builder.add_inout();
+			let exp_base_wire = builder.add_inout();
+
+			let (mant_final_53, exp_after_round, mant_overflow_mask) =
+				fp64_round_rne(&builder, sig_base_wire, exp_base_wire);
+
+			let expected_mant = builder.add_inout();
+			let expected_exp = builder.add_inout();
+			let expected_overflow = builder.add_inout();
+
+			builder.assert_eq("mant_final_53", mant_final_53, expected_mant);
+			builder.assert_eq("exp_after_round", exp_after_round, expected_exp);
+			builder.assert_eq("mant_overflow_mask", mant_overflow_mask, expected_overflow);
+
+			let circuit = builder.build();
+			let mut w = circuit.new_witness_filler();
+			w[sig_base_wire] = Word(sig_base);
+			w[exp_base_wire] = Word(exp_base);
+
+			let (ref_mant, ref_exp, ref_overflow) = ref_fp64_round_rne(sig_base, exp_base);
+			w[expected_mant] = Word(ref_mant);
+			w[expected_exp] = Word(ref_exp);
+			w[expected_overflow] = Word(ref_overflow);
+
+			circuit.populate_wire_witness(&mut w).unwrap();
+			let cs = circuit.constraint_system();
+			verify_constraints(cs, &w.into_value_vec()).unwrap();
+		}
+	}
+
+	#[test]
+	fn test_fp64_pack_finite_or_inf() {
+		let test_cases = [
+			// (sign, mant_final_53, exp_after_round, stayed_sub_mask)
+			(0, 0x1000000000000000u64, 1023, 0), // Normal positive number
+			(1, 0x1800000000000000u64, 1000, 0), // Normal negative number
+			(0, 0x0000000000001000u64, 1, u64::MAX), // Subnormal positive
+			(0, 0x1000000000000000u64, 0x7FF, 0), // Overflow to infinity
+		];
+
+		for (sign, mant_final_53, exp_after_round, stayed_sub_mask) in test_cases {
+			let builder = CircuitBuilder::new();
+			let sign_wire = builder.add_inout();
+			let mant_wire = builder.add_inout();
+			let exp_wire = builder.add_inout();
+			let stayed_sub_wire = builder.add_inout();
+
+			let result =
+				fp64_pack_finite_or_inf(&builder, sign_wire, mant_wire, exp_wire, stayed_sub_wire);
+
+			let expected_result = builder.add_inout();
+			builder.assert_eq("pack_result", result, expected_result);
+
+			let circuit = builder.build();
+			let mut w = circuit.new_witness_filler();
+			w[sign_wire] = Word(sign);
+			w[mant_wire] = Word(mant_final_53);
+			w[exp_wire] = Word(exp_after_round);
+			w[stayed_sub_wire] = Word(stayed_sub_mask);
+
+			let ref_result =
+				ref_fp64_pack_finite_or_inf(sign, mant_final_53, exp_after_round, stayed_sub_mask);
+			w[expected_result] = Word(ref_result);
+
+			circuit.populate_wire_witness(&mut w).unwrap();
+			let cs = circuit.constraint_system();
+			verify_constraints(cs, &w.into_value_vec()).unwrap();
+		}
+	}
+
+	#[test]
+	fn test_fp64_finish_specials() {
+		let test_cases = [
+			// (pa_is_nan, pa_is_inf, pa_sign, pb_is_nan, pb_is_inf, pb_sign, finite_or_inf)
+			(0, 0, 0, 0, 0, 0, 0x3FF0000000000000u64), // Normal case
+			(u64::MAX, 0, 0, 0, 0, 0, 0x4000000000000000u64), // A is NaN
+			(0, 0, 0, u64::MAX, 0, 1, 0x4000000000000000u64), // B is NaN
+			(0, u64::MAX, 0, 0, 0, 1, 0x4000000000000000u64), // A is +inf
+			(0, 0, 1, 0, u64::MAX, 1, 0x4000000000000000u64), // B is -inf
+			(0, u64::MAX, 0, 0, u64::MAX, 1, 0x4000000000000000u64), // +inf + (-inf) = NaN
+		];
+
+		for (pa_is_nan, pa_is_inf, pa_sign, pb_is_nan, pb_is_inf, pb_sign, finite_or_inf) in
+			test_cases
+		{
+			let builder = CircuitBuilder::new();
+			let pa = Fp64Parts {
+				sign: builder.add_inout(),
+				exp: builder.add_inout(),
+				frac: builder.add_inout(),
+				is_nan: builder.add_inout(),
+				is_inf: builder.add_inout(),
+				is_norm: builder.add_inout(),
+			};
+			let pb = Fp64Parts {
+				sign: builder.add_inout(),
+				exp: builder.add_inout(),
+				frac: builder.add_inout(),
+				is_nan: builder.add_inout(),
+				is_inf: builder.add_inout(),
+				is_norm: builder.add_inout(),
+			};
+			let finite_or_inf_wire = builder.add_inout();
+
+			let result = fp64_finish_specials(&builder, &pa, &pb, finite_or_inf_wire);
+			let expected_result = builder.add_inout();
+			builder.assert_eq("finish_result", result, expected_result);
+
+			let circuit = builder.build();
+			let mut w = circuit.new_witness_filler();
+
+			// Fill in all the pa/pb fields (most are unused for this test)
+			w[pa.sign] = Word(pa_sign);
+			w[pa.exp] = Word(0);
+			w[pa.frac] = Word(0);
+			w[pa.is_nan] = Word(pa_is_nan);
+			w[pa.is_inf] = Word(pa_is_inf);
+			w[pa.is_norm] = Word(0);
+
+			w[pb.sign] = Word(pb_sign);
+			w[pb.exp] = Word(0);
+			w[pb.frac] = Word(0);
+			w[pb.is_nan] = Word(pb_is_nan);
+			w[pb.is_inf] = Word(pb_is_inf);
+			w[pb.is_norm] = Word(0);
+
+			w[finite_or_inf_wire] = Word(finite_or_inf);
+
+			let ref_result = ref_fp64_finish_specials(
+				pa_is_nan,
+				pa_is_inf,
+				pa_sign,
+				pb_is_nan,
+				pb_is_inf,
+				pb_sign,
+				finite_or_inf,
+			);
+			w[expected_result] = Word(ref_result);
+
+			circuit.populate_wire_witness(&mut w).unwrap();
+			let cs = circuit.constraint_system();
+			verify_constraints(cs, &w.into_value_vec()).unwrap();
+		}
+	}
+
+	#[test]
+	fn test_fp64_unpack() {
+		let test_values = vec![
+			0.0f64,
+			-0.0f64,
+			1.0f64,
+			-1.0f64,
+			f64::INFINITY,
+			f64::NEG_INFINITY,
+			f64::NAN,
+			f64::MIN_POSITIVE,
+		];
+
+		for val in test_values {
+			let builder = CircuitBuilder::new();
+			let input = builder.add_inout();
+			let result = fp64_unpack(&builder, input);
+
+			// Create expected outputs
+			let expected_sign = builder.add_inout();
+			let expected_exp = builder.add_inout();
+			let expected_frac = builder.add_inout();
+			let expected_is_nan = builder.add_inout();
+			let expected_is_inf = builder.add_inout();
+			let expected_is_norm = builder.add_inout();
+
+			builder.assert_eq("sign", result.sign, expected_sign);
+			builder.assert_eq("exp", result.exp, expected_exp);
+			builder.assert_eq("frac", result.frac, expected_frac);
+			builder.assert_eq("is_nan", result.is_nan, expected_is_nan);
+			builder.assert_eq("is_inf", result.is_inf, expected_is_inf);
+			builder.assert_eq("is_norm", result.is_norm, expected_is_norm);
+
+			let circuit = builder.build();
+			let mut w = circuit.new_witness_filler();
+			w[input] = Word(val.to_bits());
+
+			// Get expected values from reference implementation
+			let result = ref_fp64_unpack(val.to_bits());
+
+			w[expected_sign] = Word(result.sign);
+			w[expected_exp] = Word(result.exp);
+			w[expected_frac] = Word(result.frac);
+			w[expected_is_nan] = Word(result.is_nan);
+			w[expected_is_inf] = Word(result.is_inf);
+			w[expected_is_norm] = Word(result.is_norm);
+
+			circuit.populate_wire_witness(&mut w).unwrap();
+			let cs = circuit.constraint_system();
+			verify_constraints(cs, &w.into_value_vec()).unwrap();
+		}
+	}
+
+	#[test]
+	fn test_fp64_ext_sig_and_exp() {
+		let test_values = vec![1.0f64, -1.0f64, 2.0f64, f64::MIN_POSITIVE, 0.0f64];
+
+		for val in test_values {
+			let builder = CircuitBuilder::new();
+			let input = builder.add_inout();
+			let parts = fp64_unpack(&builder, input);
+			let (sig, exp_eff) = fp64_ext_sig_and_exp(&builder, &parts);
+			let expected_sig = builder.add_inout();
+			let expected_exp = builder.add_inout();
+
+			builder.assert_eq("sig", sig, expected_sig);
+			builder.assert_eq("exp_eff", exp_eff, expected_exp);
+
+			let circuit = builder.build();
+			let mut w = circuit.new_witness_filler();
+			w[input] = Word(val.to_bits());
+
+			// Get reference values
+			let unpack_result = ref_fp64_unpack(val.to_bits());
+			let (exp_sig, exp_exp) = ref_fp64_ext_sig_and_exp(
+				unpack_result.sign,
+				unpack_result.exp,
+				unpack_result.frac,
+				unpack_result.is_norm,
+			);
+
+			w[expected_sig] = Word(exp_sig);
+			w[expected_exp] = Word(exp_exp);
+
+			circuit.populate_wire_witness(&mut w).unwrap();
+			let cs = circuit.constraint_system();
+			verify_constraints(cs, &w.into_value_vec()).unwrap();
+		}
+	}
+
+	#[test]
+	fn test_fp64_order_by_exp() {
+		let test_cases = [
+			// (sig_a, exp_a, sign_a, sig_b, exp_b, sign_b)
+			(100, 5, 1, 200, 10, 0),  // a < b, should swap
+			(100, 10, 1, 200, 5, 0),  // a >= b, no swap
+			(300, 15, 0, 400, 15, 1), // equal exp, no swap
+		];
+
+		for (sig_a_val, exp_a_val, sign_a_val, sig_b_val, exp_b_val, sign_b_val) in test_cases {
+			let builder = CircuitBuilder::new();
+			let sig_a = builder.add_inout();
+			let exp_a = builder.add_inout();
+			let sign_a = builder.add_inout();
+			let sig_b = builder.add_inout();
+			let exp_b = builder.add_inout();
+			let sign_b = builder.add_inout();
+
+			let (sig_a_out, exp_a_out, sign_a_out, sig_b_out, exp_b_out, sign_b_out, swapped) =
+				fp64_order_by_exp(&builder, sig_a, exp_a, sign_a, sig_b, exp_b, sign_b);
+
+			let expected_sig_a = builder.add_inout();
+			let expected_exp_a = builder.add_inout();
+			let expected_sign_a = builder.add_inout();
+			let expected_sig_b = builder.add_inout();
+			let expected_exp_b = builder.add_inout();
+			let expected_sign_b = builder.add_inout();
+			let expected_swapped = builder.add_inout();
+
+			builder.assert_eq("sig_a", sig_a_out, expected_sig_a);
+			builder.assert_eq("exp_a", exp_a_out, expected_exp_a);
+			builder.assert_eq("sign_a", sign_a_out, expected_sign_a);
+			builder.assert_eq("sig_b", sig_b_out, expected_sig_b);
+			builder.assert_eq("exp_b", exp_b_out, expected_exp_b);
+			builder.assert_eq("sign_b", sign_b_out, expected_sign_b);
+			builder.assert_eq("swapped", swapped, expected_swapped);
+
+			let circuit = builder.build();
+			let mut w = circuit.new_witness_filler();
+
+			w[sig_a] = Word(sig_a_val);
+			w[exp_a] = Word(exp_a_val);
+			w[sign_a] = Word(sign_a_val);
+			w[sig_b] = Word(sig_b_val);
+			w[exp_b] = Word(exp_b_val);
+			w[sign_b] = Word(sign_b_val);
+
+			// Get expected values from reference implementation
+			let (exp_sig_a, exp_exp_a, exp_sign_a, exp_sig_b, exp_exp_b, exp_sign_b, exp_swapped) =
+				ref_fp64_order_by_exp(
+					sig_a_val, exp_a_val, sign_a_val, sig_b_val, exp_b_val, sign_b_val,
+				);
+
+			w[expected_sig_a] = Word(exp_sig_a);
+			w[expected_exp_a] = Word(exp_exp_a);
+			w[expected_sign_a] = Word(exp_sign_a);
+			w[expected_sig_b] = Word(exp_sig_b);
+			w[expected_exp_b] = Word(exp_exp_b);
+			w[expected_sign_b] = Word(exp_sign_b);
+			w[expected_swapped] = Word(exp_swapped);
+
+			circuit.populate_wire_witness(&mut w).unwrap();
+			let cs = circuit.constraint_system();
+			verify_constraints(cs, &w.into_value_vec()).unwrap();
+		}
+	}
+
+	#[test]
+	fn test_float64_add_basic() {
+		let tiny_sub = f64::from_bits(1); // smallest subnormal 2^-1074
+		let half_ulp_at_1 = 2f64.powi(-53);
+		let one_ulp_at_1 = 2f64.powi(-52);
+		let big = 1e300f64;
+		let small = 1e-300f64;
+		let min_norm = f64::MIN_POSITIVE; // 2^-1022
+		let half_min_norm = min_norm / 2.0; // subnormal
+
+		let test_cases: &[(f64, f64)] = &[
+			(0.0, 0.0),
+			(0.0, -0.0),
+			(-0.0, -0.0),
+			(1.0, -1.0),
+			(-1.0, 1.0),
+			(1.0, 2.0),
+			(1.5, 1.5),
+			(2.0, -0.5),
+			// Rounding behavior near 1.0
+			(1.0, half_ulp_at_1), // tie, LSB even -> stays 1.0
+			(1.0, one_ulp_at_1),  // round up -> nextafter(1, +inf)
+			// Subnormals and underflow path
+			(tiny_sub, tiny_sub),           // sticky folding
+			(half_min_norm, half_min_norm), // rises to min normal
+			(min_norm, tiny_sub),           // tiny add that should not lose sticky
+			// Large exponent differences (alignment saturates + sticky accumulates)
+			(1.0, 2f64.powi(-1000)),
+			(2f64.powi(100), 2f64.powi(-1000)),
+			// Big/small normals
+			(big, big),   // overflow to +inf
+			(-big, -big), // overflow to -inf
+			(small, small),
+			// Infinities
+			(f64::INFINITY, 1.0),
+			(-f64::INFINITY, -1.0),
+			(f64::INFINITY, -f64::INFINITY), // -> qNaN
+			// NaNs (canonical qNaN regardless of payload)
+			(f64::NAN, 1.0),
+			(1.0, f64::NAN),
+			(f64::NAN, f64::NAN),
+		];
+
+		for (i, (a_val, b_val)) in test_cases.iter().copied().enumerate() {
+			let ref_result = ref_float64_add(a_val.to_bits(), b_val.to_bits());
+			let native = (a_val + b_val).to_bits();
+			assert!(
+				f64_bits_semantic_eq(ref_result, native),
+				"Test case {}: pseudo {} != native {}",
+				i,
+				ref_result,
+				native
+			);
+
+			let builder = CircuitBuilder::new();
+			let a = builder.add_inout();
+			let b = builder.add_inout();
+			let result = float64_add(&builder, a, b);
+			let expected = builder.add_inout();
+			builder.assert_eq(format!("float64_add_case_{}", i), result, expected);
+
+			let circuit = builder.build();
+			let mut w = circuit.new_witness_filler();
+			w[a] = Word(a_val.to_bits());
+			w[b] = Word(b_val.to_bits());
+
+			let expected_val = ref_result;
+			w[expected] = Word(expected_val);
+
+			circuit.populate_wire_witness(&mut w).unwrap();
+			let cs = circuit.constraint_system();
+			verify_constraints(cs, &w.into_value_vec()).unwrap();
+		}
+	}
+}

--- a/crates/frontend/src/circuits/float64/mod.rs
+++ b/crates/frontend/src/circuits/float64/mod.rs
@@ -1,0 +1,2 @@
+pub mod add;
+pub mod utils;

--- a/crates/frontend/src/circuits/float64/utils.rs
+++ b/crates/frontend/src/circuits/float64/utils.rs
@@ -1,0 +1,452 @@
+use binius_core::word::Word;
+
+use crate::compiler::{CircuitBuilder, Wire};
+
+/// Creates a wire containing the constant value 0.
+pub fn zero(builder: &CircuitBuilder) -> Wire {
+	builder.add_constant_64(0)
+}
+
+/// Creates a wire containing the constant value 1.
+pub fn one(builder: &CircuitBuilder) -> Wire {
+	builder.add_constant_64(1)
+}
+
+/// Creates a wire containing all-ones (0xFFFFFFFFFFFFFFFF).
+pub fn all_ones(builder: &CircuitBuilder) -> Wire {
+	builder.add_constant(Word::ALL_ONE)
+}
+
+/// Performs integer addition: `a + b`.
+///
+/// This is a wrapper around the circuit builder's integer addition that handles
+/// carry-in/carry-out automatically with zero carry-in.
+pub fn iadd(builder: &CircuitBuilder, a: Wire, b: Wire) -> Wire {
+	let (s, _c) = builder.iadd_cin_cout(a, b, zero(builder));
+	s
+}
+
+/// Performs integer subtraction: `a - b`.
+///
+/// This is a wrapper around the circuit builder's integer subtraction that handles
+/// borrow-in/borrow-out automatically with zero borrow-in.
+pub fn isub(builder: &CircuitBuilder, a: Wire, b: Wire) -> Wire {
+	let (d, _b) = builder.isub_bin_bout(a, b, zero(builder));
+	d
+}
+
+/// Returns an all-ones mask if `x` is zero, all-zeros mask otherwise.
+///
+/// This is equivalent to `x == 0 ? 0xFFFFFFFFFFFFFFFF : 0x0000000000000000`.
+pub fn is_zero_mask(builder: &CircuitBuilder, x: Wire) -> Wire {
+	builder.icmp_eq(x, zero(builder))
+}
+
+/// Returns an all-ones mask if `x` is non-zero, all-zeros mask otherwise.
+///
+/// This is equivalent to `x != 0 ? 0xFFFFFFFFFFFFFFFF : 0x0000000000000000`.
+pub fn is_nonzero_mask(builder: &CircuitBuilder, x: Wire) -> Wire {
+	builder.bnot(is_zero_mask(builder, x))
+}
+
+/// Converts a 0/1 value to an all-0/all-1 mask.
+///
+/// Input: `b01` should be 0 or 1
+/// Output: 0x0000000000000000 if `b01` is 0, 0xFFFFFFFFFFFFFFFF if `b01` is 1
+pub fn to_mask01(builder: &CircuitBuilder, b01: Wire) -> Wire {
+	isub(builder, zero(builder), builder.band(b01, one(builder)))
+}
+
+/// Extracts bit `i` from `x` as a 0/1 value.
+///
+/// Returns `(x >> i) & 1`.
+pub fn bit_lsb(builder: &CircuitBuilder, x: Wire, i: u32) -> Wire {
+	builder.band(builder.shr(x, i), one(builder))
+}
+
+/// Extracts bit `i` from `x` as an all-0/all-1 mask.
+///
+/// Returns 0xFFFFFFFFFFFFFFFF if bit `i` is set, 0x0000000000000000 otherwise.
+pub fn bit_mask(builder: &CircuitBuilder, x: Wire, i: u32) -> Wire {
+	to_mask01(builder, bit_lsb(builder, x, i))
+}
+
+/// Performs variable right shift with sticky bit tracking.
+///
+/// This implements a barrel shifter that can shift by any amount 0-63,
+/// with optional saturation. All bits shifted out are OR'd together to
+/// create a "sticky" bit that tracks whether any precision was lost.
+///
+/// # Parameters
+/// - `x`: Value to shift
+/// - `d`: Shift amount (0-63, or optionally saturated at 63)
+/// - `saturate_at_63`: If true, shifts >= 64 are treated as 63; if false, they wrap
+///
+/// # Returns
+/// - First wire: The shifted value
+/// - Second wire: Sticky bit (all-1 mask if any bits were lost, all-0 otherwise)
+pub fn var_shr_with_sticky(
+	builder: &CircuitBuilder,
+	x: Wire,
+	d: Wire,
+	saturate_at_63: bool,
+) -> (Wire, Wire) {
+	let c63 = builder.add_constant_64(63);
+	let c64 = builder.add_constant_64(64);
+	let d_eff = if saturate_at_63 {
+		let lt64 = builder.icmp_ult(d, c64);
+		builder.select(lt64, d, c63)
+	} else {
+		builder.band(d, c63)
+	};
+
+	let mut v = x;
+	let mut sticky = zero(builder);
+
+	// Stage 32 (bit 5)
+	{
+		let cond = bit_mask(builder, d_eff, 5);
+		let lost = builder.band(v, builder.add_constant_64((1u64 << 32) - 1));
+		let lost_nz = is_nonzero_mask(builder, lost);
+		sticky = builder.bor(sticky, builder.band(lost_nz, cond));
+		let shifted = builder.shr(v, 32);
+		v = builder.select(cond, shifted, v);
+	}
+	// Stage 16 (bit 4)
+	{
+		let cond = bit_mask(builder, d_eff, 4);
+		let lost = builder.band(v, builder.add_constant_64((1u64 << 16) - 1));
+		let lost_nz = is_nonzero_mask(builder, lost);
+		sticky = builder.bor(sticky, builder.band(lost_nz, cond));
+		let shifted = builder.shr(v, 16);
+		v = builder.select(cond, shifted, v);
+	}
+	// Stage 8 (bit 3)
+	{
+		let cond = bit_mask(builder, d_eff, 3);
+		let lost = builder.band(v, builder.add_constant_64((1u64 << 8) - 1));
+		let lost_nz = is_nonzero_mask(builder, lost);
+		sticky = builder.bor(sticky, builder.band(lost_nz, cond));
+		let shifted = builder.shr(v, 8);
+		v = builder.select(cond, shifted, v);
+	}
+	// Stage 4 (bit 2)
+	{
+		let cond = bit_mask(builder, d_eff, 2);
+		let lost = builder.band(v, builder.add_constant_64((1u64 << 4) - 1));
+		let lost_nz = is_nonzero_mask(builder, lost);
+		sticky = builder.bor(sticky, builder.band(lost_nz, cond));
+		let shifted = builder.shr(v, 4);
+		v = builder.select(cond, shifted, v);
+	}
+	// Stage 2 (bit 1)
+	{
+		let cond = bit_mask(builder, d_eff, 1);
+		let lost = builder.band(v, builder.add_constant_64((1u64 << 2) - 1));
+		let lost_nz = is_nonzero_mask(builder, lost);
+		sticky = builder.bor(sticky, builder.band(lost_nz, cond));
+		let shifted = builder.shr(v, 2);
+		v = builder.select(cond, shifted, v);
+	}
+	// Stage 1 (bit 0)
+	{
+		let cond = bit_mask(builder, d_eff, 0);
+		let lost = builder.band(v, builder.add_constant_64(1));
+		let lost_nz = is_nonzero_mask(builder, lost);
+		sticky = builder.bor(sticky, builder.band(lost_nz, cond));
+		let shifted = builder.shr(v, 1);
+		v = builder.select(cond, shifted, v);
+	}
+
+	(v, sticky)
+}
+
+/// Performs variable left shift.
+///
+/// This implements a barrel shifter that can shift left by any amount 0-63.
+/// Shift amounts >= 64 are masked to 0-63 range (i.e., `d & 63`).
+///
+/// # Parameters
+/// - `x`: Value to shift
+/// - `d`: Shift amount (effectively `d & 63`)
+///
+/// # Returns
+/// The left-shifted value `x << (d & 63)`
+pub fn var_shl(builder: &CircuitBuilder, x: Wire, d: Wire) -> Wire {
+	let d_eff = builder.band(d, builder.add_constant_64(63));
+	let mut v = x;
+
+	{
+		let cond = bit_mask(builder, d_eff, 5); // 32
+		let shifted = builder.shl(v, 32);
+		v = builder.select(cond, shifted, v);
+	}
+	{
+		let cond = bit_mask(builder, d_eff, 4); // 16
+		let shifted = builder.shl(v, 16);
+		v = builder.select(cond, shifted, v);
+	}
+	{
+		let cond = bit_mask(builder, d_eff, 3); // 8
+		let shifted = builder.shl(v, 8);
+		v = builder.select(cond, shifted, v);
+	}
+	{
+		let cond = bit_mask(builder, d_eff, 2); // 4
+		let shifted = builder.shl(v, 4);
+		v = builder.select(cond, shifted, v);
+	}
+	{
+		let cond = bit_mask(builder, d_eff, 1); // 2
+		let shifted = builder.shl(v, 2);
+		v = builder.select(cond, shifted, v);
+	}
+	{
+		let cond = bit_mask(builder, d_eff, 0); // 1
+		let shifted = builder.shl(v, 1);
+		v = builder.select(cond, shifted, v);
+	}
+
+	v
+}
+
+/// Count leading zeroes in `x`
+pub fn clz64(builder: &CircuitBuilder, x: Wire) -> Wire {
+	let mut n = zero(builder);
+	let mut y = x;
+
+	// step(32)
+	{
+		let t = builder.shr(y, 32);
+		let z = is_zero_mask(builder, t);
+		n = iadd(builder, n, builder.band(z, builder.add_constant_64(32)));
+		y = builder.select(z, builder.shl(y, 32), y);
+	}
+	// step(16)
+	{
+		let t = builder.shr(y, 48);
+		let z = is_zero_mask(builder, t);
+		n = iadd(builder, n, builder.band(z, builder.add_constant_64(16)));
+		y = builder.select(z, builder.shl(y, 16), y);
+	}
+	// step(8)
+	{
+		let t = builder.shr(y, 56);
+		let z = is_zero_mask(builder, t);
+		n = iadd(builder, n, builder.band(z, builder.add_constant_64(8)));
+		y = builder.select(z, builder.shl(y, 8), y);
+	}
+	// step(4)
+	{
+		let t = builder.shr(y, 60);
+		let z = is_zero_mask(builder, t);
+		n = iadd(builder, n, builder.band(z, builder.add_constant_64(4)));
+		y = builder.select(z, builder.shl(y, 4), y);
+	}
+	// step(2)
+	{
+		let t = builder.shr(y, 62);
+		let z = is_zero_mask(builder, t);
+		n = iadd(builder, n, builder.band(z, builder.add_constant_64(2)));
+		y = builder.select(z, builder.shl(y, 2), y);
+	}
+	// step(1)
+	{
+		let t = builder.shr(y, 63);
+		let z = is_zero_mask(builder, t);
+		n = iadd(builder, n, builder.band(z, builder.add_constant_64(1)));
+	}
+	n
+}
+
+#[cfg(test)]
+mod tests {
+	use binius_core::word::Word;
+
+	use super::*;
+	use crate::constraint_verifier::verify_constraints;
+
+	#[test]
+	fn test_is_zero_mask() {
+		let builder = CircuitBuilder::new();
+		let input = builder.add_inout();
+		let output = is_zero_mask(&builder, input);
+		let expected = builder.add_inout();
+		builder.assert_eq("test_output", output, expected);
+
+		let circuit = builder.build();
+
+		let test_cases = [
+			(0, u64::MAX),
+			(1, 0),
+			(0xFFFFFFFFFFFFFFFF, 0),
+			(0x8000000000000000, 0),
+		];
+
+		for (val, expected_val) in test_cases {
+			let mut w = circuit.new_witness_filler();
+			w[input] = Word(val);
+			w[expected] = Word(expected_val);
+
+			circuit.populate_wire_witness(&mut w).unwrap();
+			let cs = circuit.constraint_system();
+			verify_constraints(cs, &w.into_value_vec()).unwrap();
+		}
+	}
+
+	#[test]
+	fn test_is_nonzero_mask() {
+		let builder = CircuitBuilder::new();
+		let input = builder.add_inout();
+		let output = is_nonzero_mask(&builder, input);
+		let expected = builder.add_inout();
+		builder.assert_eq("test_output", output, expected);
+
+		let circuit = builder.build();
+
+		let test_cases = [
+			(0, 0),
+			(1, u64::MAX),
+			(0xFFFFFFFFFFFFFFFF, u64::MAX),
+			(0x8000000000000000, u64::MAX),
+		];
+
+		for (val, expected_val) in test_cases {
+			let mut w = circuit.new_witness_filler();
+			w[input] = Word(val);
+			w[expected] = Word(expected_val);
+
+			circuit.populate_wire_witness(&mut w).unwrap();
+			let cs = circuit.constraint_system();
+			verify_constraints(cs, &w.into_value_vec()).unwrap();
+		}
+	}
+
+	#[test]
+	fn test_bit_lsb() {
+		let builder = CircuitBuilder::new();
+		let input = builder.add_inout();
+		let output0 = bit_lsb(&builder, input, 0);
+		let output1 = bit_lsb(&builder, input, 1);
+		let output63 = bit_lsb(&builder, input, 63);
+		let expected0 = builder.add_inout();
+		let expected1 = builder.add_inout();
+		let expected63 = builder.add_inout();
+		builder.assert_eq("test_output0", output0, expected0);
+		builder.assert_eq("test_output1", output1, expected1);
+		builder.assert_eq("test_output63", output63, expected63);
+
+		let circuit = builder.build();
+
+		let test_cases = [
+			(0b101, 1, 0, 0),              // bit 0=1, bit 1=0, bit 63=0
+			(0b110, 0, 1, 0),              // bit 0=0, bit 1=1, bit 63=0
+			(0x8000000000000001, 1, 0, 1), // bit 0=1, bit 1=0, bit 63=1
+		];
+
+		for (val, exp0, exp1, exp63) in test_cases {
+			let mut w = circuit.new_witness_filler();
+			w[input] = Word(val);
+			w[expected0] = Word(exp0);
+			w[expected1] = Word(exp1);
+			w[expected63] = Word(exp63);
+
+			circuit.populate_wire_witness(&mut w).unwrap();
+			let cs = circuit.constraint_system();
+			verify_constraints(cs, &w.into_value_vec()).unwrap();
+		}
+	}
+
+	#[test]
+	fn test_clz64() {
+		let builder = CircuitBuilder::new();
+		let input = builder.add_inout();
+		let output = clz64(&builder, input);
+		let expected = builder.add_inout();
+		builder.assert_eq("test_output", output, expected);
+
+		let circuit = builder.build();
+
+		let test_cases = [
+			(0x8000000000000000u64, 0),  // Top bit set
+			(0x4000000000000000u64, 1),  // Second bit set
+			(0x0000000000000001u64, 63), // Only bottom bit set
+			(0xFFFFFFFFFFFFFFFFu64, 0),  // All bits set
+			(0x0000000000008000u64, 48), // Bit 15 set
+		];
+
+		for (val, expected_clz) in test_cases {
+			let mut w = circuit.new_witness_filler();
+			w[input] = Word(val);
+			w[expected] = Word(expected_clz);
+
+			circuit.populate_wire_witness(&mut w).unwrap();
+			let cs = circuit.constraint_system();
+			verify_constraints(cs, &w.into_value_vec()).unwrap();
+		}
+	}
+
+	#[test]
+	fn test_var_shl() {
+		let builder = CircuitBuilder::new();
+		let input = builder.add_inout();
+		let shift = builder.add_inout();
+		let output = var_shl(&builder, input, shift);
+		let expected = builder.add_inout();
+		builder.assert_eq("test_output", output, expected);
+
+		let circuit = builder.build();
+
+		let test_cases = [
+			(1, 0, 1),        // No shift
+			(1, 1, 2),        // Shift left by 1
+			(1, 8, 256),      // Shift left by 8
+			(0xFF, 4, 0xFF0), // Shift 0xFF left by 4
+			(1, 64, 1),       // Shift amount wraps (64 & 63 = 0)
+		];
+
+		for (val, shift_amt, expected_result) in test_cases {
+			let mut w = circuit.new_witness_filler();
+			w[input] = Word(val);
+			w[shift] = Word(shift_amt);
+			w[expected] = Word(expected_result);
+
+			circuit.populate_wire_witness(&mut w).unwrap();
+			let cs = circuit.constraint_system();
+			verify_constraints(cs, &w.into_value_vec()).unwrap();
+		}
+	}
+
+	#[test]
+	fn test_var_shr_with_sticky() {
+		let builder = CircuitBuilder::new();
+		let input = builder.add_inout();
+		let shift = builder.add_inout();
+		let (output, sticky) = var_shr_with_sticky(&builder, input, shift, false);
+		let expected_out = builder.add_inout();
+		let expected_sticky = builder.add_inout();
+		builder.assert_eq("test_output", output, expected_out);
+		builder.assert_eq("test_sticky", sticky, expected_sticky);
+
+		let circuit = builder.build();
+
+		let test_cases = [
+			(8, 1, 4, 0),                           // 8 >> 1 = 4, no bits lost
+			(7, 1, 3, Word::ALL_ONE.as_u64()),      // 7 >> 1 = 3, bit lost (sticky)
+			(0xFF, 4, 0xF, Word::ALL_ONE.as_u64()), // 0xFF >> 4 = 0xF, bits lost
+			(0xF0, 4, 0xF, 0),                      // 0xF0 >> 4 = 0xF, no bits lost
+		];
+
+		for (val, shift_amt, expected_result, expected_sticky_val) in test_cases {
+			let mut w = circuit.new_witness_filler();
+			w[input] = Word(val);
+			w[shift] = Word(shift_amt);
+			w[expected_out] = Word(expected_result);
+			w[expected_sticky] = Word(expected_sticky_val);
+
+			circuit.populate_wire_witness(&mut w).unwrap();
+			let cs = circuit.constraint_system();
+			verify_constraints(cs, &w.into_value_vec()).unwrap();
+		}
+	}
+}

--- a/crates/frontend/src/circuits/mod.rs
+++ b/crates/frontend/src/circuits/mod.rs
@@ -4,6 +4,7 @@ pub mod blake2b;
 pub mod concat;
 pub mod ecdsa;
 pub mod fixed_byte_vec;
+pub mod float64;
 pub mod hash_based_sig;
 pub mod jwt_claims;
 pub mod keccak;


### PR DESCRIPTION
### TL;DR

Added IEEE-754 double-precision floating point addition implementation to the circuit frontend.

### What changed?

This PR implements a complete IEEE-754 binary64 (double-precision) addition circuit in the frontend. The implementation:

- Handles all special cases: normals, subnormals, zeros (signed), infinities, and NaNs
- Uses round-to-nearest, ties-to-even rounding mode
- Tracks sticky bits across alignment and underflow right-shifts
- Handles exact cancellation (+x) + (-x) → +0
- Properly handles overflow → ±Inf with computed sign

The implementation is broken down into modular blocks (A-K) that are individually testable:

- Unpacking and classifying binary64 values
- Building extended significands and effective exponents
- Ordering operands by exponent
- Aligning significands with sticky bit tracking
- Separate add/subtract paths based on operand signs
- Merging results and handling cancellation
- Underflow handling and rounding
- Special case handling for NaNs and infinities

### How to test?

The implementation includes comprehensive unit tests for each component block and the full addition operation. Tests cover:

- Basic arithmetic operations
- Special cases (NaN, infinity)
- Rounding behavior
- Subnormal handling
- Overflow and underflow conditions

Run the tests with:

```
cargo test -p frontend -- circuits::float64
```

### Why make this change?

This implementation provides a foundation for floating-point operations in the circuit frontend, enabling more complex financial and scientific computations. The modular design makes it easier to test, maintain, and extend to other floating-point operations in the future.