### PR TITLE
[frontend] fuse shifts

### DIFF
--- a/crates/core/src/constraint_system.rs
+++ b/crates/core/src/constraint_system.rs
@@ -23,7 +23,7 @@ impl Default for ValueIndex {
 /// A different variants of shifting a value.
 ///
 /// Note that there is no shift left arithmetic because it is redundant.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum ShiftVariant {
 	/// Shift logical left.
 	Sll,


### PR DESCRIPTION
Prior to this commit gate fusion would not inline into any expressions that are
shifted, conservatively. This changeset fixes that.

This gives a tremendous improvement on the keccak lowering down the AND
constraint count to 25 per round.