### PR TITLE
[examples] keccak: assert something

### DIFF
--- a/crates/examples/snapshots/keccak.snap
+++ b/crates/examples/snapshots/keccak.snap
@@ -1,11 +1,11 @@
 keccak circuit
 --
-Number of gates: 33600
-Number of evaluation instructions: 33600
-Number of AND constraints: 33600
+Number of gates: 33625
+Number of evaluation instructions: 33625
+Number of AND constraints: 33625
 Number of MUL constraints: 0
 Length of value vec: 65536
   Constants: 23
-  Inout: 25
+  Inout: 50
   Witness: 0
   Internal: 33600


### PR DESCRIPTION
keccak prior to this changeset did not assert anything, it just computed hash
digest, that's all. Because the gates do not have any side effects, they only
produce some values, the whole thing is a subject for dead code elimination.

This changeset fixes this and constrains the final computed value to the
expected one.