### PR TITLE
add back constraints for high halves of boundary words

### DIFF
--- a/crates/examples/snapshots/sha256.snap
+++ b/crates/examples/snapshots/sha256.snap
@@ -1,11 +1,11 @@
 sha256 circuit
 --
-Number of gates: 74990
-Number of evaluation instructions: 76219
-Number of AND constraints: 95393
+Number of gates: 74994
+Number of evaluation instructions: 76223
+Number of AND constraints: 95397
 Number of MUL constraints: 0
 Length of value vec: 131072
   Constants: 341
   Inout: 260
   Witness: 570
-  Internal: 94267
+  Internal: 94269

--- a/crates/examples/snapshots/zklogin.snap
+++ b/crates/examples/snapshots/zklogin.snap
@@ -1,11 +1,11 @@
 zklogin circuit
 --
-Number of gates: 627577
-Number of evaluation instructions: 955178
-Number of AND constraints: 847079
+Number of gates: 627589
+Number of evaluation instructions: 955190
+Number of AND constraints: 847091
 Number of MUL constraints: 26880
 Length of value vec: 1048576
   Constants: 624
   Inout: 302
   Witness: 95783
-  Internal: 879680
+  Internal: 879686

--- a/crates/frontend/src/circuits/sha256/compress.rs
+++ b/crates/frontend/src/circuits/sha256/compress.rs
@@ -67,9 +67,10 @@ pub struct Compress {
 
 impl Compress {
 	pub fn new(builder: &CircuitBuilder, state_in: State, m: [Wire; 16]) -> Self {
-		// it is "expected" that the wires `m` will have empty high (most-significant) halves.
-		// otoh, if schedule wires `m` with nonempty high halves are fed into this gadget,
-		// said high halves will have no effect, and will eventually be masked off.
+		// it is a PRECONDITION of this gadget that the high halves of the wires fed in be empty.
+		// that is, `m[i] & 0xffffffff == m[i]` must hold for each wire `i` passed in.
+		// it is the caller's responsibility to ensure that this is the case for all wires.
+		// if this isn't true, then the behavior becomes undefined / the gadget becomes insecure.
 
 		// ---- message-schedule ----
 		// W[0..15] = block_words


### PR DESCRIPTION
i earlier misunderstood the compress gadget: i failed to realize that `rotr_32`s have a "high halves empty" precondition. the compress gadget is thus only sound if all wires fed in have empty high halves. this was true even before this PR, _except perhaps_ for the boundary word, i.e. for `padded_evens[w_bd]` and `padded_odds[w_bd]`. earlier, i had a check to enforce it in this case too, which i removed. this PR adds those checks back. thanks @jimpo for catching.