### PR TITLE
parallel vision hasher

### DIFF
--- a/crates/prover/Cargo.toml
+++ b/crates/prover/Cargo.toml
@@ -67,6 +67,10 @@ harness = false
 name = "ring_switch"
 harness = false
 
+[[bench]]
+name = "vision"
+harness = false
+
 [features]
 default = ["rayon"]
 rayon = ["binius-utils/rayon"]

--- a/crates/prover/benches/vision.rs
+++ b/crates/prover/benches/vision.rs
@@ -1,0 +1,310 @@
+use std::{array, hint::black_box, mem::MaybeUninit};
+
+use binius_field::{BinaryField128bGhash as Ghash, Field, Random};
+use binius_prover::hash::{
+	VisionHasherMultiDigest,
+	batch_invert::batch_invert_scratchpad_generic,
+	parallel_digest::{MultiDigest, ParallelDigest, ParallelMultidigestImpl},
+	vision_parallel::flattened_parallel_permutation,
+};
+use binius_utils::rayon::prelude::*;
+use binius_verifier::hash::vision::{constants::M, digest::VisionHasherDigest};
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use digest::Digest;
+use rand::{RngCore, SeedableRng, rngs::StdRng};
+
+fn bench_batch_invert(c: &mut Criterion) {
+	let mut group = c.benchmark_group("Batch Invert Throughput");
+	let mut rng = StdRng::seed_from_u64(0);
+
+	const ITERATIONS: usize = 1000;
+
+	// 1 state of 4 elements
+	let mut state_4: [Ghash; 4] = std::array::from_fn(|_| <Ghash as Random>::random(&mut rng));
+	group.throughput(Throughput::Elements(ITERATIONS as u64 * 4));
+	group.bench_function("batch_invert_4_scratchpad", |b| {
+		b.iter(|| {
+			let scratchpad = &mut [Ghash::ZERO; 7];
+			for _ in 0..ITERATIONS {
+				batch_invert_scratchpad_generic::<4>(black_box(&mut state_4), scratchpad);
+				state_4[0] = Ghash::random(&mut rng);
+			}
+		})
+	});
+
+	// 2 states of 4 elements each
+	let mut state_8: [Ghash; 8] = std::array::from_fn(|_| Ghash::random(&mut rng));
+	group.throughput(Throughput::Elements(ITERATIONS as u64 * 8));
+	group.bench_function("batch_invert_8_scratchpad", |b| {
+		b.iter(|| {
+			let scratchpad = &mut [Ghash::ZERO; 15];
+			for _ in 0..ITERATIONS {
+				batch_invert_scratchpad_generic::<8>(black_box(&mut state_8), scratchpad);
+				state_8[0] = Ghash::random(&mut rng);
+			}
+		})
+	});
+
+	// 4 states of 4 elements each
+	let mut state_16: [Ghash; 16] = std::array::from_fn(|_| Ghash::random(&mut rng));
+	group.throughput(Throughput::Elements(ITERATIONS as u64 * 16));
+	group.bench_function("batch_invert_16_scratchpad", |b| {
+		b.iter(|| {
+			let scratchpad = &mut [Ghash::ZERO; 31];
+			for _ in 0..ITERATIONS {
+				batch_invert_scratchpad_generic::<16>(black_box(&mut state_16), scratchpad);
+				state_16[0] = Ghash::random(&mut rng);
+			}
+		})
+	});
+
+	// 8 states of 4 elements each
+	let mut state_32: [Ghash; 32] = std::array::from_fn(|_| Ghash::random(&mut rng));
+	group.throughput(Throughput::Elements(ITERATIONS as u64 * 32));
+	group.bench_function("batch_invert_32_scratchpad", |b| {
+		b.iter(|| {
+			let scratchpad = &mut [Ghash::ZERO; 63];
+			for _ in 0..ITERATIONS {
+				batch_invert_scratchpad_generic::<32>(black_box(&mut state_32), scratchpad);
+				state_32[0] = Ghash::random(&mut rng);
+			}
+		})
+	});
+
+	// 16 states of 4 elements each
+	let mut state_64: [Ghash; 64] = std::array::from_fn(|_| Ghash::random(&mut rng));
+	group.throughput(Throughput::Elements(ITERATIONS as u64 * 64));
+	group.bench_function("batch_invert_64_scratchpad", |b| {
+		b.iter(|| {
+			let scratchpad = &mut [Ghash::ZERO; 127];
+			for _ in 0..ITERATIONS {
+				batch_invert_scratchpad_generic::<64>(black_box(&mut state_64), scratchpad);
+				state_64[0] = Ghash::random(&mut rng);
+			}
+		})
+	});
+
+	// 32 states of 4 elements each
+	let mut state_128: [Ghash; 128] = std::array::from_fn(|_| Ghash::random(&mut rng));
+	group.throughput(Throughput::Elements(ITERATIONS as u64 * 128));
+	group.bench_function("batch_invert_128_scratchpad", |b| {
+		b.iter(|| {
+			let scratchpad = &mut [Ghash::ZERO; 255];
+			for _ in 0..ITERATIONS {
+				batch_invert_scratchpad_generic::<128>(black_box(&mut state_128), scratchpad);
+				state_128[0] = Ghash::random(&mut rng);
+			}
+		})
+	});
+
+	// 64 states of 4 elements each
+	let mut state_256: [Ghash; 256] = std::array::from_fn(|_| Ghash::random(&mut rng));
+	group.throughput(Throughput::Elements(ITERATIONS as u64 * 256));
+	group.bench_function("batch_invert_256_scratchpad", |b| {
+		b.iter(|| {
+			let scratchpad = &mut [Ghash::ZERO; 511];
+			for _ in 0..ITERATIONS {
+				batch_invert_scratchpad_generic::<256>(black_box(&mut state_256), scratchpad);
+				state_256[0] = Ghash::random(&mut rng);
+			}
+		})
+	});
+
+	group.finish();
+}
+
+fn bench_parallel_permutation(c: &mut Criterion) {
+	let mut group = c.benchmark_group("Parallel Permutation Throughput");
+	let mut rng = StdRng::seed_from_u64(0);
+
+	const ITERATIONS: usize = 100;
+
+	// Benchmark parallel permutation N=1
+	let elements_hashed = ITERATIONS as u64 * M as u64;
+	group.throughput(Throughput::Elements(elements_hashed * 16));
+	let mut parallel_states_1: [Ghash; M] = array::from_fn(|_| Ghash::random(&mut rng));
+	let scratchpad = &mut [Ghash::ZERO; { 2 * M }];
+	group.bench_function("parallel_permutation_N1", |b| {
+		b.iter(|| {
+			for _ in 0..ITERATIONS {
+				flattened_parallel_permutation::<1, { M }>(&mut parallel_states_1, scratchpad);
+			}
+		})
+	});
+
+	// Benchmark parallel permutation N=2
+	let elements_hashed = ITERATIONS as u64 * 2 * M as u64;
+	group.throughput(Throughput::Bytes(elements_hashed * 16));
+	let mut parallel_states_2: [Ghash; 2 * M] = array::from_fn(|_| Ghash::random(&mut rng));
+	let scratchpad = &mut [Ghash::ZERO; { 2 * 2 * M }];
+	group.bench_function("parallel_permutation_N2", |b| {
+		b.iter(|| {
+			for _ in 0..ITERATIONS {
+				flattened_parallel_permutation::<2, { 2 * M }>(&mut parallel_states_2, scratchpad);
+			}
+		})
+	});
+
+	// Benchmark parallel permutation N=4
+	let elements_hashed = ITERATIONS as u64 * 4 * M as u64;
+	group.throughput(Throughput::Bytes(elements_hashed * 16));
+	let mut parallel_states_4: [Ghash; 4 * M] = array::from_fn(|_| Ghash::random(&mut rng));
+	let scratchpad = &mut [Ghash::ZERO; { 2 * 4 * M }];
+	group.bench_function("parallel_permutation_N4", |b| {
+		b.iter(|| {
+			for _ in 0..ITERATIONS {
+				flattened_parallel_permutation::<4, { 4 * M }>(&mut parallel_states_4, scratchpad);
+			}
+		})
+	});
+
+	// Benchmark parallel permutation N=8
+	let elements_hashed = ITERATIONS as u64 * 8 * M as u64;
+	group.throughput(Throughput::Bytes(elements_hashed * 16));
+	let mut parallel_states_8: [Ghash; 8 * M] = array::from_fn(|_| Ghash::random(&mut rng));
+	let scratchpad = &mut [Ghash::ZERO; { 2 * 8 * M }];
+	group.bench_function("parallel_permutation_N8", |b| {
+		b.iter(|| {
+			for _ in 0..ITERATIONS {
+				flattened_parallel_permutation::<8, { 8 * M }>(&mut parallel_states_8, scratchpad);
+			}
+		})
+	});
+
+	// Benchmark parallel permutation N=16
+	let elements_hashed = ITERATIONS as u64 * 16 * M as u64;
+	group.throughput(Throughput::Bytes(elements_hashed * 16));
+	let mut parallel_states_16: [Ghash; 16 * M] = array::from_fn(|_| Ghash::random(&mut rng));
+	let scratchpad = &mut [Ghash::ZERO; { 2 * 16 * M }];
+	group.bench_function("parallel_permutation_N16", |b| {
+		b.iter(|| {
+			for _ in 0..ITERATIONS {
+				flattened_parallel_permutation::<16, { 16 * M }>(
+					&mut parallel_states_16,
+					scratchpad,
+				);
+			}
+		})
+	});
+
+	// Benchmark parallel permutation N=32
+	let elements_hashed = ITERATIONS as u64 * 32 * M as u64;
+	group.throughput(Throughput::Bytes(elements_hashed * 16));
+	let mut parallel_states_32: [Ghash; 32 * M] = array::from_fn(|_| Ghash::random(&mut rng));
+	let scratchpad = &mut [Ghash::ZERO; { 2 * 32 * M }];
+	group.bench_function("parallel_permutation_N32", |b| {
+		b.iter(|| {
+			for _ in 0..ITERATIONS {
+				flattened_parallel_permutation::<32, { 32 * M }>(
+					&mut parallel_states_32,
+					scratchpad,
+				);
+			}
+		})
+	});
+
+	// Benchmark parallel permutation N=64
+	let elements_hashed = ITERATIONS as u64 * 64 * M as u64;
+	group.throughput(Throughput::Bytes(elements_hashed * 16));
+	let mut parallel_states_64: [Ghash; 64 * M] = array::from_fn(|_| Ghash::random(&mut rng));
+	let scratchpad = &mut [Ghash::ZERO; { 2 * 64 * M }];
+	group.bench_function("parallel_permutation_N64", |b| {
+		b.iter(|| {
+			for _ in 0..ITERATIONS {
+				flattened_parallel_permutation::<64, { 64 * M }>(
+					&mut parallel_states_64,
+					scratchpad,
+				);
+			}
+		})
+	});
+
+	// Benchmark parallel permutation N=128
+	let elements_hashed = ITERATIONS as u64 * 128 * M as u64;
+	group.throughput(Throughput::Bytes(elements_hashed * 16));
+	let mut parallel_states_128: [Ghash; 128 * M] = array::from_fn(|_| Ghash::random(&mut rng));
+	let scratchpad = &mut [Ghash::ZERO; { 2 * 128 * M }];
+	group.bench_function("parallel_permutation_N128", |b| {
+		b.iter(|| {
+			for _ in 0..ITERATIONS {
+				flattened_parallel_permutation::<128, { 128 * M }>(
+					&mut parallel_states_128,
+					scratchpad,
+				);
+			}
+		})
+	});
+
+	// Benchmark parallel permutation N=256
+	let elements_hashed = ITERATIONS as u64 * 256 * M as u64;
+	group.throughput(Throughput::Bytes(elements_hashed * 16));
+	let mut parallel_states_256: [Ghash; 256 * M] = array::from_fn(|_| Ghash::random(&mut rng));
+	let scratchpad = &mut [Ghash::ZERO; { 2 * 256 * M }];
+	group.bench_function("parallel_permutation_N256", |b| {
+		b.iter(|| {
+			for _ in 0..ITERATIONS {
+				flattened_parallel_permutation::<256, { 256 * M }>(
+					&mut parallel_states_256,
+					scratchpad,
+				);
+			}
+		})
+	});
+
+	group.finish();
+}
+
+fn bench_vision(c: &mut Criterion) {
+	let mut group = c.benchmark_group("Vision");
+
+	let mut rng = rand::rng();
+
+	const BYTE_COUNT: usize = 1 << 22;
+	let mut data = vec![0u8; BYTE_COUNT];
+	rng.fill_bytes(&mut data);
+
+	group.throughput(Throughput::Bytes(BYTE_COUNT as u64));
+
+	group.bench_function("Vision-Single", |bench| {
+		bench.iter(|| <VisionHasherDigest as Digest>::digest(data.clone()))
+	});
+
+	// Number of parallel hashing instances
+	const N: usize = 128;
+
+	group.bench_function("Vision-Multi", |bench| {
+		bench.iter(|| {
+			let mut out = [MaybeUninit::<digest::Output<VisionHasherDigest>>::uninit(); N];
+
+			VisionHasherMultiDigest::<N, { N * M }>::digest(
+				array::from_fn(|i| &data[i * BYTE_COUNT / N..(i + 1) * BYTE_COUNT / N]),
+				&mut out,
+			);
+			out
+		})
+	});
+
+	group.bench_function("Vision-Parallel", |bench| {
+		bench.iter(|| {
+			let mut out = [MaybeUninit::<digest::Output<VisionHasherDigest>>::uninit(); N];
+			let hasher = ParallelMultidigestImpl::<VisionHasherMultiDigest<N, { N * M }>, N>::new();
+
+			hasher.digest(
+				(0..N).into_par_iter().map(|i| {
+					let start = i * BYTE_COUNT / N;
+					let end = (i + 1) * BYTE_COUNT / N;
+					std::iter::once(&data[start..end])
+				}),
+				&mut out,
+			);
+			out
+		})
+	});
+
+	group.finish()
+}
+
+criterion_group!(batch_invert, bench_batch_invert);
+criterion_group!(parallel_permutation, bench_parallel_permutation,);
+criterion_group!(hash, bench_vision);
+criterion_main!(batch_invert, parallel_permutation, hash);

--- a/crates/prover/src/hash/batch_invert.rs
+++ b/crates/prover/src/hash/batch_invert.rs
@@ -1,0 +1,250 @@
+// Copyright 2025 Irreducible Inc.
+
+use binius_field::{BinaryField128bGhash as Ghash, Field};
+
+/// Efficiently inverts multiple field elements simultaneously using Montgomery's batch inversion
+/// trick.
+///
+/// This function implements a binary tree approach to batch field inversion, which is significantly
+/// more efficient than inverting each element individually when dealing with many elements.
+///
+/// # Algorithm Overview
+/// 1. **Product Tree Construction**: Build a binary tree where each leaf is an input element and
+///    each internal node is the product of its children
+/// 2. **Root Inversion**: Invert only the root (product of all elements)
+/// 3. **Inverse Propagation**: Propagate the inverse down the tree to compute individual inverses
+///
+/// # Performance Benefits
+/// - Single field inversion instead of N inversions (inversion is expensive)
+/// - Tree structure maximizes instruction-level parallelism in multiplications
+/// - Zero elements are handled gracefully without division-by-zero
+///
+/// # Parameters
+/// - `elements`: Array of field elements to invert (modified in-place)
+/// - `scratchpad`: Working memory buffer, must be at least `2*N-1` elements
+///
+/// # Requirements
+/// - `N` must be a power of 2 and ≥ 2
+/// - `scratchpad.len() >= 2*N-1` for intermediate computations
+///
+/// # Scratchpad Layout
+/// ```
+/// [0..N): Input elements (zeros replaced with ones)
+/// [N..2N-1): Product tree levels (bottom-up)
+/// ```
+pub fn batch_invert_scratchpad_generic<const N: usize>(
+	elements: &mut [Ghash; N],
+	scratchpad: &mut [Ghash],
+) {
+	assert!(N.is_power_of_two() && N >= 2, "N must be a power of 2 and >= 2");
+	assert!(scratchpad.len() >= 2 * N - 1, "scratchpad too small");
+
+	let zero = Ghash::ZERO;
+	let one = Ghash::ONE;
+	let levels = N.ilog2() as usize;
+
+	// Phase 1: Setup - Copy input elements, replacing zeros with ones
+	// This prevents division-by-zero while preserving zero semantics in final output
+	for i in 0..N {
+		scratchpad[i] = if elements[i] == zero {
+			one // Temporary replacement - restored to zero in final phase
+		} else {
+			elements[i]
+		};
+	}
+
+	// Phase 2: Build product tree bottom-up
+	// Each level computes products of pairs from the previous level
+	let mut dest_offset = N; // Points to current level's storage in scratchpad
+
+	// Level 1: Pair up adjacent elements (N/2 products)
+	// Each element at position i becomes product of elements at 2i and 2i+1
+	if levels >= 2 {
+		let level_size = N >> 1; // Number of products at this level
+		let src_offset = dest_offset ^ (level_size << 1); // XOR for efficient offset calculation
+
+		for i in 0..level_size {
+			// Multiply adjacent pairs: scratchpad[2i] * scratchpad[2i+1]
+			scratchpad[dest_offset ^ i] =
+				scratchpad[src_offset ^ (i << 1)] * scratchpad[src_offset ^ (i << 1) ^ 1];
+		}
+		dest_offset += level_size;
+	}
+
+	// Level 2: Pair up level 1 products (N/4 products)
+	if levels >= 3 {
+		let level_size = N >> 2;
+		let src_offset = dest_offset ^ (level_size << 1);
+
+		for i in 0..level_size {
+			scratchpad[dest_offset ^ i] =
+				scratchpad[src_offset ^ (i << 1)] * scratchpad[src_offset ^ (i << 1) ^ 1];
+		}
+		dest_offset += level_size;
+	}
+
+	// Level 3: Continue building tree (N/8 products)
+	if levels >= 4 {
+		let level_size = N >> 3;
+		let src_offset = dest_offset ^ (level_size << 1);
+
+		for i in 0..level_size {
+			scratchpad[dest_offset ^ i] =
+				scratchpad[src_offset ^ (i << 1)] * scratchpad[src_offset ^ (i << 1) ^ 1];
+		}
+		dest_offset += level_size;
+	}
+
+	// Manually unroll level 4 (level_size = N/16)
+	if levels >= 5 {
+		let level_size = N >> 4;
+		let src_offset = dest_offset ^ (N >> 3);
+
+		for i in 0..level_size {
+			scratchpad[dest_offset ^ i] =
+				scratchpad[src_offset ^ (i << 1)] * scratchpad[src_offset ^ (i << 1) ^ 1];
+		}
+		dest_offset += level_size;
+	}
+
+	// Handle remaining larger levels with loop
+	for level in 5..levels {
+		let level_size = N >> level;
+		let src_offset = dest_offset ^ (level_size << 1);
+
+		for i in 0..level_size {
+			scratchpad[dest_offset ^ i] =
+				scratchpad[src_offset ^ (i << 1)] * scratchpad[src_offset ^ (i << 1) ^ 1];
+		}
+		dest_offset += level_size;
+	}
+
+	let src_offset = dest_offset ^ (1 << 1);
+	scratchpad[dest_offset] = scratchpad[src_offset] * scratchpad[src_offset ^ 1];
+
+	// Invert root product (Montgomery's key insight: single inversion)
+	scratchpad[dest_offset] = scratchpad[dest_offset]
+		.invert()
+		.expect("factors are non-zero, so product is non-zero");
+
+	// Phase 3: Propagate inverses down tree (unrolled for performance)
+	// Level 1: size=2
+	if levels >= 2 {
+		let src_offset = dest_offset;
+		dest_offset -= 2;
+
+		let save = scratchpad[dest_offset];
+		scratchpad[dest_offset] = scratchpad[dest_offset ^ 1] * scratchpad[src_offset];
+		scratchpad[dest_offset ^ 1] = save * scratchpad[src_offset];
+	}
+
+	// Level 2: size=4
+	if levels >= 3 {
+		let src_offset = dest_offset;
+		dest_offset -= 4;
+
+		for i in 0..2 {
+			let save = scratchpad[dest_offset ^ (i << 1)];
+			scratchpad[dest_offset ^ (i << 1)] =
+				scratchpad[dest_offset ^ (i << 1) ^ 1] * scratchpad[src_offset ^ i];
+			scratchpad[dest_offset ^ (i << 1) ^ 1] = save * scratchpad[src_offset ^ i];
+		}
+	}
+
+	// Level 3: size=8
+	if levels >= 4 {
+		let src_offset = dest_offset;
+		dest_offset -= 8;
+
+		for i in 0..4 {
+			let save = scratchpad[dest_offset ^ (i << 1)];
+			scratchpad[dest_offset ^ (i << 1)] =
+				scratchpad[dest_offset ^ (i << 1) ^ 1] * scratchpad[src_offset ^ i];
+			scratchpad[dest_offset ^ (i << 1) ^ 1] = save * scratchpad[src_offset ^ i];
+		}
+	}
+
+	// Level 4: size=16
+	if levels >= 5 {
+		let src_offset = dest_offset;
+		dest_offset -= 16;
+
+		for i in 0..8 {
+			let save = scratchpad[dest_offset ^ (i << 1)];
+			scratchpad[dest_offset ^ (i << 1)] =
+				scratchpad[dest_offset ^ (i << 1) ^ 1] * scratchpad[src_offset ^ i];
+			scratchpad[dest_offset ^ (i << 1) ^ 1] = save * scratchpad[src_offset ^ i];
+		}
+	}
+
+	// Dynamic levels: size=32,64,128,...
+	for level in 5..levels {
+		let level_size = 1 << level;
+		let src_offset = dest_offset;
+		dest_offset -= level_size;
+
+		for i in 0..level_size >> 1 {
+			let save = scratchpad[dest_offset ^ (i << 1)];
+			scratchpad[dest_offset ^ (i << 1)] =
+				scratchpad[dest_offset ^ (i << 1) ^ 1] * scratchpad[src_offset ^ i];
+			scratchpad[dest_offset ^ (i << 1) ^ 1] = save * scratchpad[src_offset ^ i];
+		}
+	}
+
+	// Final: compute inverses and restore zeros
+	for i in 0..N >> 1 {
+		let j = i << 1;
+		elements[j] = if elements[j] == zero {
+			zero
+		} else {
+			scratchpad[j ^ 1] * scratchpad[dest_offset ^ i]
+		};
+		elements[j ^ 1] = if elements[j ^ 1] == zero {
+			zero
+		} else {
+			scratchpad[j] * scratchpad[dest_offset ^ i]
+		};
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use binius_field::{Field, Random, arithmetic_traits::InvertOrZero};
+	use rand::{Rng, SeedableRng, rngs::StdRng};
+
+	use super::*;
+
+	fn test_batch_invert_size<const N: usize>(rng: &mut StdRng) {
+		let mut state = [Ghash::ZERO; N];
+		for i in 0..N {
+			state[i] = if rng.random::<bool>() {
+				Ghash::ZERO
+			} else {
+				Ghash::random(&mut *rng)
+			};
+		}
+
+		let expected: [Ghash; N] = state.map(|x| x.invert_or_zero());
+
+		let mut scratchpad = vec![Ghash::ZERO; 2 * N - 1];
+		batch_invert_scratchpad_generic::<N>(&mut state, &mut scratchpad);
+
+		assert_eq!(state, expected);
+	}
+
+	#[test]
+	fn test_batch_invert_scratchpad_generic() {
+		let mut rng = StdRng::seed_from_u64(0);
+
+		for _ in 0..4 {
+			test_batch_invert_size::<2>(&mut rng);
+			test_batch_invert_size::<4>(&mut rng);
+			test_batch_invert_size::<8>(&mut rng);
+			test_batch_invert_size::<16>(&mut rng);
+			test_batch_invert_size::<32>(&mut rng);
+			test_batch_invert_size::<64>(&mut rng);
+			test_batch_invert_size::<128>(&mut rng);
+			test_batch_invert_size::<256>(&mut rng);
+		}
+	}
+}

--- a/crates/prover/src/hash/mod.rs
+++ b/crates/prover/src/hash/mod.rs
@@ -1,5 +1,9 @@
+// Copyright 2025 Irreducible Inc.
+
+pub mod batch_invert;
 pub mod parallel_digest;
-#[allow(dead_code)]
 pub mod vision;
+pub mod vision_parallel;
 
 pub use parallel_digest::ParallelDigest;
+pub use vision::VisionHasherMultiDigest;

--- a/crates/prover/src/hash/vision_parallel.rs
+++ b/crates/prover/src/hash/vision_parallel.rs
@@ -1,0 +1,180 @@
+// Copyright 2025 Irreducible Inc.
+
+use binius_field::{BinaryField128bGhash as Ghash, arithmetic_traits::Square};
+use binius_verifier::hash::vision::{
+	constants::{B_FWD_COEFFS, M, NUM_ROUNDS, ROUND_CONSTANTS},
+	permutation::linearized_b_inv_transform_scalar,
+};
+
+use super::batch_invert::batch_invert_scratchpad_generic;
+
+fn flattened_forward_transform<const N: usize, const MN: usize>(states: &mut [Ghash; MN]) {
+	for i in 0..MN {
+		let scalar = states[i];
+		let square = scalar.square();
+		let quartic = square.square();
+
+		states[i] = B_FWD_COEFFS[0]
+			+ B_FWD_COEFFS[1] * scalar
+			+ B_FWD_COEFFS[2] * square
+			+ B_FWD_COEFFS[3] * quartic;
+	}
+}
+
+fn flattened_inverse_transform<const N: usize, const MN: usize>(states: &mut [Ghash; MN]) {
+	for i in 0..MN {
+		linearized_b_inv_transform_scalar(&mut states[i]);
+	}
+}
+
+fn flattened_round<const N: usize, const MN: usize>(
+	states: &mut [Ghash; MN],
+	scratchpad: &mut [Ghash],
+	round_constants_idx: usize,
+) {
+	// First half
+	batch_invert_scratchpad_generic(states, scratchpad);
+	flattened_inverse_transform::<N, MN>(states);
+	flattened_parallel_mds_mul::<N, MN>(states);
+	flattened_constants_add::<N, MN>(states, &ROUND_CONSTANTS[round_constants_idx]);
+	// Second half
+	batch_invert_scratchpad_generic(states, scratchpad);
+	flattened_forward_transform::<N, MN>(states);
+	flattened_parallel_mds_mul::<N, MN>(states);
+	flattened_constants_add::<N, MN>(states, &ROUND_CONSTANTS[round_constants_idx + 1]);
+}
+
+fn flattened_constants_add<const N: usize, const MN: usize>(
+	states: &mut [Ghash; MN],
+	constants: &[Ghash; M],
+) {
+	for i in 0..N {
+		let state_start = i * M;
+		for j in 0..M {
+			states[state_start + j] += constants[j];
+		}
+	}
+}
+
+pub fn flattened_mds_mul(a: &mut [Ghash]) {
+	// a = [a0, a1, a2, a3]
+	let sum = a[0] + a[1] + a[2] + a[3];
+	let a0 = a[0];
+
+	// 2*a0 + 3*a1 + a2 + a3
+	a[0] += sum + (a[0] + a[1]).mul_x();
+
+	// a0 + 2*a1 + 3*a2 + a3
+	a[1] += sum + (a[1] + a[2]).mul_x();
+
+	// a0 + a1 + 2*a2 + 3*a3
+	a[2] += sum + (a[2] + a[3]).mul_x();
+
+	// 3*a0 + a1 + a2 + 2*a3
+	a[3] += sum + (a[3] + a0).mul_x();
+}
+
+fn flattened_parallel_mds_mul<const N: usize, const MN: usize>(states: &mut [Ghash; MN]) {
+	for i in 0..N {
+		let state = &mut states[i * M..];
+		flattened_mds_mul(state);
+	}
+}
+
+pub fn flattened_parallel_permutation<const N: usize, const MN: usize>(
+	states: &mut [Ghash; MN],
+	scratchpad: &mut [Ghash],
+) {
+	flattened_constants_add::<N, MN>(states, &ROUND_CONSTANTS[0]);
+	for round_num in 0..NUM_ROUNDS {
+		flattened_round::<N, MN>(states, scratchpad, 1 + 2 * round_num);
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use std::array;
+
+	use binius_field::{Field, Random};
+	use binius_verifier::hash::vision::permutation::permutation;
+	use rand::{SeedableRng, rngs::StdRng};
+
+	use super::*;
+
+	macro_rules! test_parallel_permutation {
+		($name:ident, $n:expr) => {
+			#[test]
+			fn $name() {
+				const N: usize = $n;
+				const MN: usize = M * N;
+				let mut rng = StdRng::seed_from_u64(0);
+
+				// Test multiple trials with random states
+				for _ in 0..10 {
+					// Create flat array for parallel processing
+					let mut parallel_states: [Ghash; MN] =
+						array::from_fn(|_| Ghash::random(&mut rng));
+
+					// Create individual states for single processing
+					let mut single_states: [[Ghash; M]; N] =
+						array::from_fn(|i| array::from_fn(|j| parallel_states[i * M + j]));
+
+					// Apply parallel permutation
+					let scratchpad = &mut [Ghash::ZERO; { 2 * MN }];
+					flattened_parallel_permutation::<N, MN>(&mut parallel_states, scratchpad);
+					// nested_parallel_permutation::<N>(&mut parallel_states);
+
+					// Apply single permutation to each state
+					for state in single_states.iter_mut() {
+						permutation(state);
+					}
+
+					// Convert single states back to flat array for comparison
+					let expected_flat: [Ghash; MN] =
+						array::from_fn(|i| single_states[i / M][i % M]);
+
+					assert_eq!(parallel_states, expected_flat);
+				}
+
+				// Test edge cases
+				// All zeros
+				let mut parallel_states: [Ghash; MN] = [Ghash::ZERO; MN];
+				let mut single_states: [[Ghash; M]; N] = [[Ghash::ZERO; M]; N];
+
+				let scratchpad = &mut [Ghash::ZERO; { 2 * MN }];
+				flattened_parallel_permutation::<N, MN>(&mut parallel_states, scratchpad);
+				// nested_parallel_permutation::<N>(&mut parallel_states);
+
+				for state in single_states.iter_mut() {
+					permutation(state);
+				}
+
+				let expected_flat: [Ghash; MN] = array::from_fn(|i| single_states[i / M][i % M]);
+				assert_eq!(parallel_states, expected_flat);
+
+				// All ones
+				let mut parallel_states: [Ghash; MN] = [Ghash::ONE; MN];
+				let mut single_states: [[Ghash; M]; N] = [[Ghash::ONE; M]; N];
+
+				let scratchpad = &mut [Ghash::ZERO; { 2 * MN }];
+				flattened_parallel_permutation::<N, MN>(&mut parallel_states, scratchpad);
+				// nested_parallel_permutation::<N>(&mut parallel_states);
+
+				for state in single_states.iter_mut() {
+					permutation(state);
+				}
+
+				let expected_flat: [Ghash; MN] = array::from_fn(|i| single_states[i / M][i % M]);
+				assert_eq!(parallel_states, expected_flat);
+			}
+		};
+	}
+
+	test_parallel_permutation!(test_parallel_permutation_1, 1);
+	test_parallel_permutation!(test_parallel_permutation_2, 2);
+	test_parallel_permutation!(test_parallel_permutation_4, 4);
+	test_parallel_permutation!(test_parallel_permutation_8, 8);
+	test_parallel_permutation!(test_parallel_permutation_16, 16);
+	test_parallel_permutation!(test_parallel_permutation_32, 32);
+	test_parallel_permutation!(test_parallel_permutation_64, 64);
+}

--- a/crates/verifier/src/hash/vision/digest.rs
+++ b/crates/verifier/src/hash/vision/digest.rs
@@ -8,7 +8,7 @@ use digest::{
 
 use super::{constants::M, permutation::permutation};
 
-const RATE_AS_U128: usize = 2;
+pub const RATE_AS_U128: usize = 2;
 pub const RATE_AS_U8: usize = RATE_AS_U128 * std::mem::size_of::<u128>();
 
 const PADDING_START: u8 = 0x80;

--- a/crates/verifier/src/hash/vision/mod.rs
+++ b/crates/verifier/src/hash/vision/mod.rs
@@ -1,6 +1,6 @@
 // Copyright 2025 Irreducible Inc.
 
-mod constants;
+pub mod constants;
 pub mod digest;
 mod linear_tables;
 pub mod permutation;

--- a/crates/verifier/src/hash/vision/permutation.rs
+++ b/crates/verifier/src/hash/vision/permutation.rs
@@ -43,6 +43,11 @@ fn batch_invert(state: &mut [Ghash; M]) {
 	state[3] = if x3 == zero { zero } else { x2_nz * right_inv };
 }
 
+pub fn linearized_b_inv_transform_scalar(x: &mut Ghash) {
+	linearized_transform_scalar(x, &LINEAR_B_INV_TABLE);
+	*x += B_INV_COEFFS[0];
+}
+
 pub fn linearized_transform_scalar(x: &mut Ghash, table: &'static [[Ghash; 256]; BYTES_PER_GHASH]) {
 	struct TableCallback {
 		table: &'static [[Ghash; 256]; BYTES_PER_GHASH],


### PR DESCRIPTION
# Parallel Vision Draft

A draft before I do re-organization, cleanup and better docs, now looking for any major feedback.
I'm hashing almost 100MB/s (single threaded) measuring simply by how many bytes go through the permutation. (Previously I said the best upper bound we could imagine is 128MB/s single threaded). But when I use `ParallelMultidigestImpl` and perform a multithreaded sponge construction, it drops to below 50MB/s. That's mostly expected because the sponge rate is half the state size, but we'd hope for better given the multithreading. I guess this is an indication I should switch to state size 6 rather than 4.

See `batch_invert` in the prover hash directory. Where should this be relocated, somewhere in the field crate? It took many iterations to get a generic implementation like this almost as fast as hand-written. It's still 10% slower than handwritten in some cases (but not consistently). The manual loop unrolling and the XORs and shifts replacing additions and multiplications both seemed to make a difference for me, but I need to check this again (it’s a many-variate optimization problem).