### PR TITLE
Fixing parallelism regression in IntMul

### DIFF
--- a/crates/math/src/multilinear/fold.rs
+++ b/crates/math/src/multilinear/fold.rs
@@ -35,6 +35,8 @@ pub fn fold_highest_var_inplace<P: PackedField, Data: DerefMut<Target = [P]>>(
 /// indexed variables of the binary multilinear to the vertex coordinates and take an
 /// inner product of the remaining multilinear and the tensor.
 ///
+/// This method is single threaded.
+///
 /// # Throws
 ///
 /// * `PowerOfTwoLengthRequired` if the bool sequence is not of power of two length.
@@ -62,7 +64,7 @@ where
 
 	values
 		.as_mut()
-		.par_iter_mut()
+		.iter_mut()
 		.enumerate()
 		.for_each(|(i, packed)| {
 			*packed = P::from_scalars((0..width).map(|j| {

--- a/crates/prover/src/protocols/sumcheck/bivariate_product_mle.rs
+++ b/crates/prover/src/protocols/sumcheck/bivariate_product_mle.rs
@@ -159,9 +159,9 @@ where
 
 		let sum = prime_coeffs.evaluate(challenge);
 
-		for multilinear in &mut self.multilinears {
-			fold_highest_var_inplace(multilinear, challenge)?;
-		}
+		self.multilinears
+			.par_iter_mut()
+			.try_for_each(|multilinear| fold_highest_var_inplace(multilinear, challenge))?;
 
 		self.gruen34.fold(challenge)?;
 		self.last_coeffs_or_eval = RoundCoeffsOrEval::Eval(sum);

--- a/crates/prover/src/protocols/sumcheck/rerand_mle.rs
+++ b/crates/prover/src/protocols/sumcheck/rerand_mle.rs
@@ -90,7 +90,7 @@ where
 		//
 		// We also do switchover there, which by definition requires small scratchpads to hold
 		// large field partial evaluations of the transparent multilinears.
-		const MAX_CHUNK_VARS: usize = 12;
+		const MAX_CHUNK_VARS: usize = 8;
 		let chunk_vars = max(MAX_CHUNK_VARS, P::LOG_WIDTH).min(self.n_vars() - 1);
 		let chunk_count = 1 << (self.n_vars() - 1 - chunk_vars);
 

--- a/crates/prover/src/protocols/sumcheck/selector_mle.rs
+++ b/crates/prover/src/protocols/sumcheck/selector_mle.rs
@@ -105,7 +105,7 @@ where
 		//
 		// We also do switchover there, which by definition requires small scratchpads to hold
 		// large field partial evaluations of the transparent multilinears.
-		const MAX_CHUNK_VARS: usize = 12;
+		const MAX_CHUNK_VARS: usize = 8;
 		let chunk_vars = max(MAX_CHUNK_VARS, P::LOG_WIDTH).min(self.n_vars() - 1);
 		let chunk_count = 1 << (self.n_vars() - 1 - chunk_vars);
 
@@ -197,9 +197,9 @@ where
 			.map(|coeffs| coeffs.evaluate(challenge))
 			.collect();
 
-		for gruen34 in &mut self.gruen34s {
-			gruen34.fold(challenge)?;
-		}
+		self.gruen34s
+			.par_iter_mut()
+			.try_for_each(|gruen34| gruen34.fold(challenge))?;
 
 		self.switchover.fold(challenge)?;
 		fold_highest_var_inplace(&mut self.selected, challenge)?;


### PR DESCRIPTION
1. Benchmarking shows it mostly makes sense to parallelize across multilinears when folding in IntMul-specific sumchecks
2. Chunk size of 2^12 rows is arguably too high for the witness size of ECDSA
3. "Nested" parallelism is a regression in binary sumchecks with switchover, so `get_binary_chunk` becomes single threaded (it's not used anywhere else). Methods like `eq_ind_partial_eval` and the likes are unfortunately cannot follow suit.

These changes at least bring rayon on par with single threaded version for small ECDSA verification batches (`-n 1` specifically). For `-n 10` and above the winnings are more significant but I feel like scaling could be so much better. We need to investigate more. 