### PR TITLE
first commit for mask ---> MSB-bool

### DIFF
--- a/crates/core/src/word.rs
+++ b/crates/core/src/word.rs
@@ -11,6 +11,7 @@ impl Word {
 	pub const ONE: Word = Word(1);
 	pub const ALL_ONE: Word = Word(u64::MAX);
 	pub const MASK_32: Word = Word(0x00000000_FFFFFFFF);
+	pub const MSB_ONE: Word = Word(0x80000000_00000000);
 }
 
 impl fmt::Debug for Word {

--- a/crates/examples/snapshots/sha256.snap
+++ b/crates/examples/snapshots/sha256.snap
@@ -1,11 +1,11 @@
 sha256 circuit
 --
 Number of gates: 74994
-Number of evaluation instructions: 76223
-Number of AND constraints: 95397
+Number of evaluation instructions: 76701
+Number of AND constraints: 94811
 Number of MUL constraints: 0
 Length of value vec: 131072
-  Constants: 341
+  Constants: 342
   Inout: 260
-  Witness: 570
-  Internal: 94269
+  Witness: 529
+  Internal: 93765

--- a/crates/examples/snapshots/sha512.snap
+++ b/crates/examples/snapshots/sha512.snap
@@ -1,11 +1,11 @@
 sha512 circuit
 --
 Number of gates: 48818
-Number of evaluation instructions: 50031
-Number of AND constraints: 62341
+Number of evaluation instructions: 49997
+Number of AND constraints: 61755
 Number of MUL constraints: 0
 Length of value vec: 131072
-  Constants: 365
+  Constants: 366
   Inout: 264
-  Witness: 298
-  Internal: 74659
+  Witness: 273
+  Internal: 74123

--- a/crates/examples/snapshots/zklogin.snap
+++ b/crates/examples/snapshots/zklogin.snap
@@ -1,11 +1,11 @@
 zklogin circuit
 --
 Number of gates: 627589
-Number of evaluation instructions: 955190
-Number of AND constraints: 847091
+Number of evaluation instructions: 851281
+Number of AND constraints: 742097
 Number of MUL constraints: 26880
 Length of value vec: 1048576
-  Constants: 624
+  Constants: 625
   Inout: 302
-  Witness: 95783
-  Internal: 879686
+  Witness: 1790
+  Internal: 962678

--- a/crates/frontend/src/circuits/sha256/mod.rs
+++ b/crates/frontend/src/circuits/sha256/mod.rs
@@ -122,7 +122,7 @@ impl Sha256 {
 
 		// Assert that len_bytes <= max_len_bytes by checking that !(max_len_bytes < len_bytes)
 		let too_long = builder.icmp_ult(builder.add_constant_64(max_len_bytes as u64), len_bytes);
-		builder.assert_0("1.len_check", too_long);
+		builder.assert_msb_false("1.len_check", too_long);
 
 		// ---- 2. Message padding and compression setup
 		//

--- a/crates/frontend/src/circuits/sha512/mod.rs
+++ b/crates/frontend/src/circuits/sha512/mod.rs
@@ -123,7 +123,7 @@ impl Sha512 {
 
 		// Assert that len_bytes <= max_len_bytes by checking that !(max_len_bytes < len_bytes)
 		let too_long = builder.icmp_ult(builder.add_constant_64(max_len_bytes as u64), len_bytes);
-		builder.assert_0("1.len_check", too_long);
+		builder.assert_msb_false("1.len_check", too_long);
 
 		// ---- 2. Message padding and compression setup
 		//

--- a/crates/frontend/src/compiler/eval_form/builder.rs
+++ b/crates/frontend/src/compiler/eval_form/builder.rs
@@ -238,6 +238,13 @@ impl BytecodeBuilder {
 		self.emit_u32(error_id);
 	}
 
+	pub fn emit_assert_msb_false(&mut self, src: u32, error_id: u32) {
+		self.n_eval_insn += 1;
+		self.emit_u8(0x63);
+		self.emit_reg(src);
+		self.emit_u32(error_id);
+	}
+
 	// Hint calls
 	pub fn emit_hint(
 		&mut self,

--- a/crates/frontend/src/compiler/eval_form/interpreter.rs
+++ b/crates/frontend/src/compiler/eval_form/interpreter.rs
@@ -130,6 +130,7 @@ impl<'a> Interpreter<'a> {
 				0x60 => self.exec_assert_eq(ctx),
 				0x61 => self.exec_assert_zero(ctx),
 				0x62 => self.exec_assert_cond(ctx),
+				0x63 => self.exec_assert_msb_false(ctx),
 
 				// Hint calls
 				0x80 => self.exec_hint(ctx),
@@ -402,6 +403,17 @@ impl<'a> Interpreter<'a> {
 					format!("conditional assert: {val1:?} != {val2:?}"),
 				);
 			}
+		}
+	}
+
+	fn exec_assert_msb_false(&mut self, ctx: &mut ExecutionContext<'_>) {
+		let src = self.read_reg();
+		let error_id = self.read_u32();
+
+		let val = self.load(ctx, src);
+
+		if val & Word::MSB_ONE != Word::ZERO {
+			ctx.note_assertion_failure(error_id, format!("{val:?} & MSB_ONE != 0"));
 		}
 	}
 

--- a/crates/frontend/src/compiler/gate/assert_eq_cond.rs
+++ b/crates/frontend/src/compiler/gate/assert_eq_cond.rs
@@ -1,20 +1,20 @@
 //! Conditional equality assertion.
 //!
-//! Enforces `x = y` when `mask = all-1`, no constraint when `mask = 0`.
+//! Enforces `x = y` when the MSB-bool value of `cond` is true, and no constraint otherwise.
 //!
 //! # Algorithm
 //!
-//! Uses a mask to conditionally enforce equality: `(x ^ y) & mask = 0`.
-//! When mask is all-1, this enforces `x = y`. When mask is 0, the constraint is satisfied
+//! Uses a mask to conditionally enforce equality: `(x ^ y) & (cond ~>> 63) = 0`.
+//! When `cond` is MSB-bool-true, this enforces `x = y`. otherwise, the constraint is satisfied
 //! trivially.
 //!
 //! # Constraints
 //!
 //! The gate generates 1 AND constraint:
-//! - `(x ⊕ y) ∧ mask = 0`
+//! - `(x ⊕ y) ∧ (cond ~>> 63) = 0`
 
 use crate::compiler::{
-	constraint_builder::{ConstraintBuilder, empty, xor2},
+	constraint_builder::{ConstraintBuilder, empty, sar, xor2},
 	gate::opcode::OpcodeShape,
 	gate_graph::{Gate, GateData, GateParam, Wire},
 	pathspec::PathSpec,
@@ -26,17 +26,18 @@ pub fn shape() -> OpcodeShape {
 		n_in: 3,
 		n_out: 0,
 		n_aux: 0,
-		n_scratch: 0,
+		n_scratch: 1,
 		n_imm: 0,
 	}
 }
 
 pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) {
 	let GateParam { inputs, .. } = data.gate_param();
-	let [x, y, mask] = inputs else { unreachable!() };
+	let [x, y, cond] = inputs else { unreachable!() };
 
-	// Constraint: (x ⊕ y) ∧ mask = 0
-	builder.and().a(xor2(*x, *y)).b(*mask).c(empty()).build();
+	// Constraint: (x ⊕ y) ∧ (cond ~>> 63) = 0
+	let mask = sar(*cond, 63);
+	builder.and().a(xor2(*x, *y)).b(mask).c(empty()).build();
 }
 
 pub fn emit_eval_bytecode(
@@ -46,8 +47,15 @@ pub fn emit_eval_bytecode(
 	builder: &mut crate::compiler::eval_form::BytecodeBuilder,
 	wire_to_reg: impl Fn(Wire) -> u32,
 ) {
-	let GateParam { inputs, .. } = data.gate_param();
-	let [x, y, mask] = inputs else { unreachable!() };
+	let GateParam {
+		inputs, scratch, ..
+	} = data.gate_param();
+	let [x, y, cond] = inputs else { unreachable!() };
+	let [mask] = scratch else { unreachable!() };
+
+	// Broadcast MSB: mask = cond >> 63 (arithmetic)
+	builder.emit_sar(wire_to_reg(*mask), wire_to_reg(*cond), 63);
+
 	builder.emit_assert_cond(
 		wire_to_reg(*mask),
 		wire_to_reg(*x),

--- a/crates/frontend/src/compiler/gate/assert_msb_false.rs
+++ b/crates/frontend/src/compiler/gate/assert_msb_false.rs
@@ -1,0 +1,56 @@
+//! Assert that a wire, interpreted as a MSB-bool, is true.
+//! i.e., we are checking whether its most-significant bit is 1. all lower bits get ignored.
+//!
+//! Enforces `x & 0x8000000000000000 = 0` using an AND constraint.
+//!
+//! # Algorithm
+//!
+//! Uses the constraint `x ∧ 0x8000000000000000 = 0`.
+//!
+//! # Constraints
+//!
+//! The gate generates 1 AND constraint:
+//! - `x ∧ 0x8000000000000000 = 0`
+
+use binius_core::word::Word;
+
+use crate::compiler::{
+	constraint_builder::{ConstraintBuilder, empty},
+	gate::opcode::OpcodeShape,
+	gate_graph::{Gate, GateData, GateParam, Wire},
+	pathspec::PathSpec,
+};
+
+pub fn shape() -> OpcodeShape {
+	OpcodeShape {
+		const_in: &[Word::MSB_ONE],
+		n_in: 1,
+		n_out: 0,
+		n_aux: 0,
+		n_scratch: 0,
+		n_imm: 0,
+	}
+}
+
+pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) {
+	let GateParam {
+		constants, inputs, ..
+	} = data.gate_param();
+	let [msb_1] = constants else { unreachable!() };
+	let [x] = inputs else { unreachable!() };
+
+	// Constraint: x ∧ msb_1 = msb_1
+	builder.and().a(*x).b(*msb_1).c(empty()).build();
+}
+
+pub fn emit_eval_bytecode(
+	_gate: Gate,
+	data: &GateData,
+	assertion_path: PathSpec,
+	builder: &mut crate::compiler::eval_form::BytecodeBuilder,
+	wire_to_reg: impl Fn(Wire) -> u32,
+) {
+	let GateParam { inputs, .. } = data.gate_param();
+	let [x] = inputs else { unreachable!() };
+	builder.emit_assert_msb_false(wire_to_reg(*x), assertion_path.as_u32());
+}

--- a/crates/frontend/src/compiler/gate/mod.rs
+++ b/crates/frontend/src/compiler/gate/mod.rs
@@ -13,6 +13,7 @@ pub mod assert_0;
 pub mod assert_band_0;
 pub mod assert_eq;
 pub mod assert_eq_cond;
+pub mod assert_msb_false;
 pub mod band;
 pub mod biguint_divide_hint;
 pub mod biguint_mod_pow_hint;
@@ -53,9 +54,10 @@ pub fn constrain(gate: Gate, graph: &GateGraph, builder: &mut ConstraintBuilder)
 		Opcode::AssertEq => assert_eq::constrain(gate, data, builder),
 		Opcode::Assert0 => assert_0::constrain(gate, data, builder),
 		Opcode::AssertBand0 => assert_band_0::constrain(gate, data, builder),
+		Opcode::AssertMSBFalse => assert_msb_false::constrain(gate, data, builder),
+		Opcode::AssertEqCond => assert_eq_cond::constrain(gate, data, builder),
 		Opcode::Imul => imul::constrain(gate, data, builder),
 		Opcode::Smul => smul::constrain(gate, data, builder),
-		Opcode::AssertEqCond => assert_eq_cond::constrain(gate, data, builder),
 		Opcode::IcmpUlt => icmp_ult::constrain(gate, data, builder),
 		Opcode::IcmpEq => icmp_eq::constrain(gate, data, builder),
 		Opcode::ExtractByte => extract_byte::constrain(gate, data, builder),
@@ -105,6 +107,10 @@ pub fn emit_gate_bytecode(
 		Opcode::AssertEqCond => {
 			let assertion_path = graph.assertion_names[gate];
 			assert_eq_cond::emit_eval_bytecode(gate, data, assertion_path, builder, wire_to_reg)
+		}
+		Opcode::AssertMSBFalse => {
+			let assertion_path = graph.assertion_names[gate];
+			assert_msb_false::emit_eval_bytecode(gate, data, assertion_path, builder, wire_to_reg)
 		}
 		Opcode::Imul => imul::emit_eval_bytecode(gate, data, builder, wire_to_reg),
 		Opcode::Smul => smul::emit_eval_bytecode(gate, data, builder, wire_to_reg),

--- a/crates/frontend/src/compiler/gate/opcode.rs
+++ b/crates/frontend/src/compiler/gate/opcode.rs
@@ -39,6 +39,7 @@ pub enum Opcode {
 	AssertEq,
 	Assert0,
 	AssertBand0,
+	AssertMSBFalse,
 	AssertEqCond,
 
 	// Hints
@@ -123,6 +124,7 @@ impl Opcode {
 			Opcode::AssertEq => gate::assert_eq::shape(),
 			Opcode::Assert0 => gate::assert_0::shape(),
 			Opcode::AssertBand0 => gate::assert_band_0::shape(),
+			Opcode::AssertMSBFalse => gate::assert_msb_false::shape(),
 			Opcode::AssertEqCond => gate::assert_eq_cond::shape(),
 
 			// Hints (no constraints)

--- a/crates/frontend/src/compiler/gate/select.rs
+++ b/crates/frontend/src/compiler/gate/select.rs
@@ -6,7 +6,7 @@
 //!
 //! The gate inspects the MSB (Most Significant Bit) of the condition value to select between
 //! two inputs. This is computed using a single AND constraint with the formula:
-//! `out = f ⊕ ((cond >> 63) ∧ (t ⊕ f))`
+//! `out = f ⊕ ((cond ~>> 63) ∧ (t ⊕ f))`
 //!
 //! The arithmetic shift right by 63 broadcasts the MSB to all bit positions, creating
 //! an all-ones mask if MSB=1 or all-zeros if MSB=0.

--- a/crates/frontend/src/compiler/mod.rs
+++ b/crates/frontend/src/compiler/mod.rs
@@ -553,6 +553,19 @@ impl CircuitBuilder {
 		graph.assertion_names[gate] = path_spec;
 	}
 
+	/// asserts that the given wire, interpreted as a MSB-bool, is true.
+	/// this is equivalent to asserting that x & 0x8000000000000000 == 0x8000000000000000.
+	///
+	/// # Cost
+	///
+	/// 1 AND constraint.
+	pub fn assert_msb_false(&self, name: impl Into<String>, x: Wire) {
+		let mut graph = self.graph_mut();
+		let gate = graph.emit_gate(self.current_path, Opcode::AssertMSBFalse, [x], []);
+		let path_spec = graph.path_spec_tree.extend(self.current_path, name);
+		graph.assertion_names[gate] = path_spec;
+	}
+
 	/// 64-bit × 64-bit → 128-bit unsigned multiplication.
 	/// Returns (hi, lo) where result = (hi << 64) | lo
 	pub fn imul(&self, a: Wire, b: Wire) -> (Wire, Wire) {
@@ -575,21 +588,22 @@ impl CircuitBuilder {
 
 	/// Conditional equality assertion.
 	///
-	/// Asserts that two 64-bit wires are equal, but only when the mask is all-1.
-	/// When mask is all-0, the assertion is a no-op.
+	/// Asserts that two 64-bit wires are equal, but only when the MSB-bool value of `cond` is true.
+	/// When `cond` is MSB-bool-false, the assertion is a no-op.
+	/// the non-most-significant bits of `cond` are ignored / have no impact.
 	///
-	/// Takes wires a, b, and mask and enforces:
-	/// - If mask is all-1: a must equal b
-	/// - If mask is all-0: no constraint (assertion is ignored)
+	/// Takes wires a, b, and cond and enforces:
+	/// - If cond is MSB-bool-true: a must equal b
+	/// - If cond is MSB-bool-false: no constraint (assertion is ignored)
 	///
-	/// Pattern: AND((a ^ b), mask, 0)
+	/// Pattern: AND((a ^ b), (cond ~>> 63), 0)
 	///
 	/// # Cost
 	///
 	/// 1 AND constraint.
-	pub fn assert_eq_cond(&self, name: impl Into<String>, x: Wire, y: Wire, mask: Wire) {
+	pub fn assert_eq_cond(&self, name: impl Into<String>, x: Wire, y: Wire, cond: Wire) {
 		let mut graph = self.graph_mut();
-		let gate = graph.emit_gate(self.current_path, Opcode::AssertEqCond, [x, y, mask], []);
+		let gate = graph.emit_gate(self.current_path, Opcode::AssertEqCond, [x, y, cond], []);
 		let path_spec = graph.path_spec_tree.extend(self.current_path, name);
 		graph.assertion_names[gate] = path_spec;
 	}
@@ -599,17 +613,19 @@ impl CircuitBuilder {
 	/// Compares two 64-bit wires as unsigned integers.
 	///
 	/// Returns:
-	/// - all-1 if a < b
-	/// - all-0 if a >= b
+	/// - a wire whose MSB-bool value is true if a < b
+	/// - a wire whose MSB-bool value is false if a ≥ b
+	///
+	/// the non-most-significant bits of the output wire are undefined.
 	///
 	/// # Cost
 	///
 	/// 2 AND constraints.
 	pub fn icmp_ult(&self, x: Wire, y: Wire) -> Wire {
-		let out_mask = self.add_internal();
+		let out_wire = self.add_internal();
 		let mut graph = self.graph_mut();
-		graph.emit_gate(self.current_path, Opcode::IcmpUlt, [x, y], [out_mask]);
-		out_mask
+		graph.emit_gate(self.current_path, Opcode::IcmpUlt, [x, y], [out_wire]);
+		out_wire
 	}
 
 	/// Equality comparison.
@@ -617,18 +633,19 @@ impl CircuitBuilder {
 	/// Compares two 64-bit wires for equality.
 	///
 	/// Returns:
-	/// - all-1 if a == b
-	/// - all-0 if a != b
+	/// - a wire whose MSB-bool value is true if a == b
+	/// - a wire whose MSB-bool value is false if a != b
+	///
+	/// the non-most-significant bits of the output wire are undefined.
 	///
 	/// # Cost
 	///
-	/// 2 AND constraints.
+	/// 1 AND constraint.
 	pub fn icmp_eq(&self, x: Wire, y: Wire) -> Wire {
-		let out_mask = self.add_witness();
-		let all_1 = self.add_constant(Word::ALL_ONE);
+		let out_wire = self.add_internal();
 		let mut graph = self.graph_mut();
-		graph.emit_gate(self.current_path, Opcode::IcmpEq, [x, y, all_1], [out_mask]);
-		out_mask
+		graph.emit_gate(self.current_path, Opcode::IcmpEq, [x, y], [out_wire]);
+		out_wire
 	}
 
 	/// Byte extraction.

--- a/crates/frontend/src/compiler/tests.rs
+++ b/crates/frontend/src/compiler/tests.rs
@@ -84,7 +84,7 @@ fn test_icmp_ult() {
 	let b = builder.add_inout();
 	let actual = builder.icmp_ult(a, b);
 	let expected = builder.add_inout();
-	builder.assert_eq("lt", actual, expected);
+	builder.assert_msb_false("lt", builder.bxor(actual, expected));
 	let circuit = builder.build();
 
 	// check that it actually works.
@@ -106,7 +106,7 @@ fn test_icmp_eq() {
 	let b = builder.add_inout();
 	let actual = builder.icmp_eq(a, b);
 	let expected = builder.add_inout();
-	builder.assert_eq("eq", actual, expected);
+	builder.assert_msb_false("eq", builder.bxor(actual, expected));
 	let circuit = builder.build();
 
 	// check that it actually works.
@@ -297,7 +297,7 @@ fn prop_check_icmp_ult(a: u64, b: u64, expected_result: Word) {
 	let mut w = circuit.new_witness_filler();
 	circuit.populate_wire_witness(&mut w).unwrap();
 
-	assert_eq!(w[result_wire], expected_result);
+	assert_eq!(w[result_wire] >> 63, expected_result >> 63);
 
 	let cs = circuit.constraint_system();
 	verify_constraints(cs, &w.value_vec).unwrap();
@@ -313,7 +313,7 @@ fn prop_check_icmp_eq(a: u64, b: u64, expected_result: Word) {
 	let mut w = circuit.new_witness_filler();
 	circuit.populate_wire_witness(&mut w).unwrap();
 
-	assert_eq!(w[result_wire], expected_result);
+	assert_eq!(w[result_wire] >> 63, expected_result >> 63);
 
 	let cs = circuit.constraint_system();
 	verify_constraints(cs, &w.value_vec).unwrap();


### PR DESCRIPTION
changes:

- `icmp_eq` and `icmp_ult` now no longer bother broadcasting / `sar`\-ing the MSB of their output. now, _only_ the MSB is guaranteed to reflect the truth value. the lower bits are undefined. this reduces each from 2 constraints to 1.
- `assert_eq_cond` now _does_ `sar` the input it gets—i.e., it no longer assumes that its input is all-1 or all-0; instead, it only uses the MSB of the input as the truth value.
- added a new assertion type: `assert_msb_false`. internally, this does `x & 0x80...00 == 0`.

all SHA-256 and SHA-512 tests pass.

_on the other hand_ there are now a number of failures in the rest of the codebase. i have not gotten to these yet. so draft for now.

migration guide: the main thing that needs to change is that `assert_0(x)`s might need to be replaced with `assert_msb_false(x)`s etc. because if `x` was the output of an `icmp_eq` gate or `icmp_ult` gate, then asserting 0 is no longer a good proxy for asserting false.

i suspect that the other tests will pass quickly with minor changes.

@pepyakin and @onesk i could really use your help—whichever parts of the codebase you're familiar with, can you try to address failing tests? the diffs you need should be quite small, i do think (see the diffs of `sha256.rs` and `sha512.rs` in this PR). cc. @jimpo.