### PR TITLE
Optimize the multithreaded performance of the prover

### DIFF
--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -13,6 +13,7 @@ binius-core = { path = "../core" }
 binius-frontend = { path = "../frontend" }
 binius-verifier = { path = "../verifier" }
 binius-prover = { path = "../prover", default-features = false }
+binius-utils = { path = "../utils" }
 clap.workspace = true
 tracing.workspace = true
 tracing-profile.workspace = true

--- a/crates/examples/examples/ethsign.rs
+++ b/crates/examples/examples/ethsign.rs
@@ -8,6 +8,7 @@ use binius_frontend::{
 	compiler::{CircuitBuilder, Wire, circuit::WitnessFiller},
 	util::{byteswap, pack_bytes_into_wires_le},
 };
+use binius_utils::rayon::config::adjust_thread_pool;
 use clap::Args;
 use ethsign::SecretKey;
 use rand::{Rng, SeedableRng, rngs::StdRng};
@@ -215,6 +216,7 @@ fn keccak256(bytes: &[u8]) -> [u8; 32] {
 
 fn main() -> Result<()> {
 	let _tracing_guard = tracing_profile::init_tracing()?;
+	adjust_thread_pool();
 
 	Cli::<EthSignExample>::new("ethsign")
 		.about("Ethereum-style signing example")

--- a/crates/examples/examples/keccak.rs
+++ b/crates/examples/examples/keccak.rs
@@ -5,6 +5,7 @@ use binius_frontend::{
 	circuits::keccak::permutation::Permutation,
 	compiler::{CircuitBuilder, Wire, circuit::WitnessFiller},
 };
+use binius_utils::rayon::config::adjust_thread_pool;
 use clap::Args;
 use rand::{Rng, SeedableRng, rngs::StdRng};
 
@@ -85,6 +86,7 @@ impl ExampleCircuit for KeccakExample {
 
 fn main() -> Result<()> {
 	let _tracing_guard = tracing_profile::init_tracing()?;
+	adjust_thread_pool();
 
 	Cli::<KeccakExample>::new("keccak")
 		.about("Keccak-f[1600] permutation example - chains multiple permutations together")

--- a/crates/examples/examples/sha256.rs
+++ b/crates/examples/examples/sha256.rs
@@ -6,6 +6,7 @@ use binius_frontend::{
 	circuits::sha256::Sha256,
 	compiler::{CircuitBuilder, Wire, circuit::WitnessFiller},
 };
+use binius_utils::rayon::config::adjust_thread_pool;
 use clap::Args;
 use rand::prelude::*;
 use sha2::Digest;
@@ -86,6 +87,7 @@ fn mk_circuit(b: &mut CircuitBuilder, max_len: usize, len_bytes: Wire) -> Sha256
 
 fn main() -> Result<()> {
 	let _tracing_guard = tracing_profile::init_tracing()?;
+	adjust_thread_pool();
 
 	Cli::<Sha256Example>::new("sha256")
 		.about("SHA256 compression function example")

--- a/crates/examples/examples/sha512.rs
+++ b/crates/examples/examples/sha512.rs
@@ -6,6 +6,7 @@ use binius_frontend::{
 	circuits::sha512::Sha512,
 	compiler::{CircuitBuilder, Wire, circuit::WitnessFiller},
 };
+use binius_utils::rayon::config::adjust_thread_pool;
 use clap::Args;
 use rand::prelude::*;
 use sha2::Digest;
@@ -86,6 +87,7 @@ fn mk_circuit(b: &mut CircuitBuilder, max_len: usize, len_bytes: Wire) -> Sha512
 
 fn main() -> Result<()> {
 	let _tracing_guard = tracing_profile::init_tracing()?;
+	adjust_thread_pool();
 
 	Cli::<Sha512Example>::new("sha512")
 		.about("SHA512 compression function example")

--- a/crates/examples/examples/zklogin.rs
+++ b/crates/examples/examples/zklogin.rs
@@ -5,6 +5,7 @@ use binius_frontend::{
 	circuits::zklogin::{Config, ZkLogin},
 	compiler::{CircuitBuilder, circuit::WitnessFiller},
 };
+use binius_utils::rayon::config::adjust_thread_pool;
 use clap::Args;
 use jwt_simple::prelude::*;
 use rand::prelude::*;
@@ -211,6 +212,7 @@ impl ExampleCircuit for ZkLoginExample {
 
 fn main() -> Result<()> {
 	let _tracing_guard = tracing_profile::init_tracing()?;
+	adjust_thread_pool();
 
 	Cli::<ZkLoginExample>::new("zklogin")
 		.about("Circuit verifying knowledge of a valid OpenID Connect login")

--- a/crates/prover/src/protocols/sumcheck/bivariate_product_multi_mle.rs
+++ b/crates/prover/src/protocols/sumcheck/bivariate_product_multi_mle.rs
@@ -25,7 +25,7 @@ impl<F: Field, P: PackedField<Scalar = F>> BivariateProductMultiMlecheckProver<P
 	pub fn new(
 		multilinears: Vec<[FieldBuffer<P>; 2]>,
 		eval_point: &[F],
-		eval_claims: &[F],
+		eval_claims: Vec<F>,
 	) -> Result<Self, Error> {
 		let n_vars = eval_point.len();
 
@@ -42,7 +42,7 @@ impl<F: Field, P: PackedField<Scalar = F>> BivariateProductMultiMlecheckProver<P
 		}
 
 		let multilinears = multilinears.into_iter().flatten().collect_vec();
-		let last_coeffs_or_sums = RoundCoeffsOrSums::Sums(eval_claims.to_vec());
+		let last_coeffs_or_sums = RoundCoeffsOrSums::Sums(eval_claims);
 
 		let gruen34 = Gruen34::new(eval_point);
 
@@ -234,7 +234,7 @@ mod tests {
 		let mut multi_prover = BivariateProductMultiMlecheckProver::new(
 			[multilinears].to_vec(),
 			&eval_point,
-			&[eval_claim],
+			vec![eval_claim],
 		)
 		.unwrap();
 
@@ -295,7 +295,7 @@ mod tests {
 			.collect_vec();
 
 		let mlecheck_prover =
-			BivariateProductMultiMlecheckProver::new(multilinears, &eval_point, &eval_claims)
+			BivariateProductMultiMlecheckProver::new(multilinears, &eval_point, eval_claims)
 				.unwrap();
 		let mut prover = MleToSumCheckDecorator::new(mlecheck_prover);
 

--- a/crates/prover/src/protocols/sumcheck/rerand_mle.rs
+++ b/crates/prover/src/protocols/sumcheck/rerand_mle.rs
@@ -261,7 +261,7 @@ mod tests {
 				.map(|selector| [selector, ones.clone()])
 				.collect_vec(),
 			&eval_point,
-			&eval_claims,
+			eval_claims.clone(),
 		)
 		.unwrap();
 

--- a/crates/utils/src/rayon/iter/from_parallel_iterator.rs
+++ b/crates/utils/src/rayon/iter/from_parallel_iterator.rs
@@ -22,6 +22,20 @@ where
 	}
 }
 
+impl<T, U> FromParallelIterator<(T, U)> for (Vec<T>, Vec<U>)
+where
+	T: Send,
+	U: Send,
+{
+	#[inline(always)]
+	fn from_par_iter<I>(par_iter: I) -> Self
+	where
+		I: IntoParallelIterator<Item = (T, U)>,
+	{
+		par_iter.into_par_iter().into_inner().unzip()
+	}
+}
+
 impl<T, E> FromParallelIterator<Result<T, E>> for Result<Vec<T>, E>
 where
 	T: Send,


### PR DESCRIPTION
### TL;DR

This PR contains several minor optimizations mostly to improv the multithreaded performance:

1. Use `adjust_thread_pool` method in our examples to force rayon to use the current thread when only one thread is available
2. Several minor optimizations for the places where a single thread is mostly used
This change improves the performance on my laptop in the following way:

- no rayon:            334 ms -> 314 ms
- rayon,  1 thread: 377 ms -> 351 ms
- rayon 4 threads: 199 ms -> 151 ms

### What changed?

- Added `binius-utils` dependency to examples and called `adjust_thread_pool()` in all example entry points
- Modified several prover functions to take ownership of vectors instead of references, avoiding unnecessary cloning
- Improved parallel processing in the integer multiplication witness construction
- Optimized memory usage in various prover components by using iterators instead of intermediate vectors
- Added a new implementation of `FromParallelIterator` for tuple vectors
- Fixed parameter passing in various sumcheck prover implementations

### How to test?

1. Run the examples to verify they work with the thread pool configuration:
2. Run the prover benchmarks to ensure performance is maintained or improved:

### Why make this change?

This change improves performance and resource utilization by:

1. Configuring thread pools appropriately in examples
2. Reducing unnecessary memory allocations and copies in the prover code
3. Leveraging parallel processing more effectively, especially in compute-intensive operations
4. Optimizing memory usage patterns for better cache locality and reduced allocation overhead

The changes maintain the same functionality while making the code more efficient.