### PR TITLE
allow multiplexer to handle empty input

### DIFF
--- a/crates/examples/snapshots/sha256.snap
+++ b/crates/examples/snapshots/sha256.snap
@@ -1,11 +1,11 @@
 sha256 circuit
 --
-Number of gates: 74994
-Number of evaluation instructions: 76701
-Number of AND constraints: 94811
+Number of gates: 74992
+Number of evaluation instructions: 76699
+Number of AND constraints: 94809
 Number of MUL constraints: 0
 Length of value vec: 131072
   Constants: 342
   Inout: 260
   Witness: 529
-  Internal: 93765
+  Internal: 93763

--- a/crates/examples/snapshots/sha512.snap
+++ b/crates/examples/snapshots/sha512.snap
@@ -1,11 +1,11 @@
 sha512 circuit
 --
-Number of gates: 48818
-Number of evaluation instructions: 49997
-Number of AND constraints: 61755
+Number of gates: 48816
+Number of evaluation instructions: 49995
+Number of AND constraints: 61753
 Number of MUL constraints: 0
 Length of value vec: 131072
   Constants: 366
   Inout: 264
   Witness: 273
-  Internal: 74123
+  Internal: 74121

--- a/crates/examples/snapshots/zklogin.snap
+++ b/crates/examples/snapshots/zklogin.snap
@@ -1,11 +1,11 @@
 zklogin circuit
 --
-Number of gates: 611921
-Number of evaluation instructions: 821628
-Number of AND constraints: 726429
+Number of gates: 486383
+Number of evaluation instructions: 583869
+Number of AND constraints: 601062
 Number of MUL constraints: 26880
 Length of value vec: 1048576
-  Constants: 624
+  Constants: 696
   Inout: 302
   Witness: 1790
-  Internal: 939974
+  Internal: 758477

--- a/crates/frontend/src/circuits/multiplexer.rs
+++ b/crates/frontend/src/circuits/multiplexer.rs
@@ -1,4 +1,4 @@
-use binius_core::consts::WORD_SIZE_BITS;
+use binius_core::{consts::WORD_SIZE_BITS, word::Word};
 
 use crate::{
 	compiler::{CircuitBuilder, Wire},
@@ -81,7 +81,9 @@ pub fn multi_wire_multiplex(b: &CircuitBuilder, inputs: &[&[Wire]], sel: Wire) -
 /// * If inputs.len() is 0
 pub fn single_wire_multiplex(b: &CircuitBuilder, inputs: &[Wire], sel: Wire) -> Wire {
 	let n = inputs.len();
-	assert!(n > 0, "Input vector must not be empty");
+	if n == 0 {
+		return b.add_constant(Word::ZERO);
+	}
 
 	// Calculate number of selector bits needed
 	let num_sel_bits = log2_ceil_usize(n);

--- a/crates/frontend/src/circuits/sha256/mod.rs
+++ b/crates/frontend/src/circuits/sha256/mod.rs
@@ -246,14 +246,12 @@ impl Sha256 {
 		// for the other words, we guarantee this indirectly, via the other checks we are running.
 		// this condition in turn is necessary for the Compress gadget to be sound.
 
-		let boundary_message_word =
-			single_wire_multiplex(builder, &([message.as_slice(), &[zero]].concat()), w_bd);
+		let boundary_message_word = single_wire_multiplex(builder, &message, w_bd);
 		// for the multiplexer above to be sound, we need `sel < inputs.len()` to be true.
 		// since we constrained `len_bytes ≤ max_len_bytes ≔ message.len() << 3`, above,
 		// we necessarily have `w_bd ≔ len_bytes >> 3 ≤ max_len_bytes >> 3 == message.len()`.
-		// thus we have w_bd ≤ message.len() < message.concat(zero).len(), so it's strict.
-		// in the exceptional case w_bd ≔ len_bytes >> 3 == max_len_bytes >> 3 == message.len(),
-		// `boundary_message_word` will be `zero`, but that's fine, as I now explain. indeed:
+		// in the exceptional case w_bd ≔ len_bytes >> 3 == max_len_bytes >> 3 == message.len().
+		// this case can indeed happen. but i claim that we will still get soundness in this case.
 		// the only way w_bd = message.len() and len_bytes ≤ max_len_bytes can both be true is if
 		// len_bytes = max_len_bytes. in this case, len_bytes is a multiple of 8, so len_mod_8 = 0.
 		// in this case, `data_b` will thus be false for each j ∈ {0, … , 7}, ergo, "3b.1" will be

--- a/crates/frontend/src/circuits/sha512/mod.rs
+++ b/crates/frontend/src/circuits/sha512/mod.rs
@@ -221,14 +221,12 @@ impl Sha512 {
 		// 3. zero byte. Placed after the delimiter byte.
 
 		let boundary_padded_word = single_wire_multiplex(builder, &padded_message, w_bd);
-		let boundary_message_word =
-			single_wire_multiplex(builder, &([message.as_slice(), &[zero]].concat()), w_bd);
+		let boundary_message_word = single_wire_multiplex(builder, &message, w_bd);
 		// for the multiplexer above to be sound, we need `sel < inputs.len()` to be true.
 		// since we constrained `len_bytes ≤ max_len_bytes ≔ message.len() << 3`, above,
 		// we necessarily have `w_bd ≔ len_bytes >> 3 ≤ max_len_bytes >> 3 == message.len()`.
-		// thus we have w_bd ≤ message.len() < message.concat(zero).len(), so it's strict.
-		// in the exceptional case w_bd ≔ len_bytes >> 3 == max_len_bytes >> 3 == message.len(),
-		// `boundary_message_word` will be `zero`, but that's fine, as I now explain. indeed:
+		// in the exceptional case w_bd ≔ len_bytes >> 3 == max_len_bytes >> 3 == message.len().
+		// this case can indeed happen. but i claim that we will still get soundness in this case.
 		// the only way w_bd = message.len() and len_bytes ≤ max_len_bytes can both be true is if
 		// len_bytes = max_len_bytes. in this case, len_bytes is a multiple of 8, so len_mod_8 = 0.
 		// in this case, `data_b` will thus be false for each j ∈ {0, … , 7}, ergo, "3b.1" will be


### PR DESCRIPTION
this causes the remaining tests in slice to pass

moreover back-adapt SHA-256 / SHA-512 to account for this