### PR TITLE
muliply ghash by inverse X

### DIFF
--- a/crates/field/src/ghash.rs
+++ b/crates/field/src/ghash.rs
@@ -79,6 +79,22 @@ impl BinaryField128bGhash {
 
 		Self::from_underlier(result)
 	}
+
+	#[inline]
+	pub fn mul_inv_x(self) -> Self {
+		let val = self.to_underlier();
+		let shifted = val >> 1;
+
+		// If low bit was set, we need to add compensation for the remainder
+		// When dividing by x with remainder 1, we add x^(-1) = x^127 to the result
+		// Since x^128 ≡ x^7 + x^2 + x + 1, we have x^127 ≡ x^6 + x + 1
+		// So 0x43 = x^6 + x + 1 (bits 6, 1, 0) and we set bit 127 for the x^127 term
+		// All 1s if the bottom bit is set, all 0s otherwise
+		let mask = (val & 1).wrapping_neg();
+		let result = shifted ^ (((1u128 << 127) | 0x43) & mask);
+
+		Self::from_underlier(result)
+	}
 }
 
 unsafe impl WithUnderlier for BinaryField128bGhash {
@@ -1167,6 +1183,35 @@ mod tests {
 			assert_eq!(
 				mul_x_result, regular_mul_result,
 				"mul_x and regular multiplication by 2 differ for value {:#x}",
+				value
+			);
+		}
+	}
+
+	#[test]
+	fn test_mul_inv_x() {
+		let test_cases = [
+			0x0,                                    // Zero
+			0x1,                                    // One
+			0x2,                                    // Two
+			0x1u128,                                // Low bit set
+			0x3u128,                                // Two lowest bits set
+			0xffffffffffffffffffffffffffffffffu128, // All bits set
+			0x87u128,                               // GHASH reduction polynomial
+			0x21ac73a21d46a21badd6747bcdfc5d4d,     // Random value
+		];
+
+		for &value in &test_cases {
+			let field_val = BinaryField128bGhash::new(value);
+			let mul_inv_x_result = field_val.mul_inv_x();
+			let regular_mul_result = field_val
+				* BinaryField128bGhash::new(2u128)
+					.invert()
+					.expect("2 is invertible");
+
+			assert_eq!(
+				mul_inv_x_result, regular_mul_result,
+				"mul_inv_x and regular multiplication by 2 differ for value {:#x}",
 				value
 			);
 		}

--- a/crates/field/src/packed_ghash.rs
+++ b/crates/field/src/packed_ghash.rs
@@ -12,6 +12,12 @@ pub fn mul_x<P: PackedField<Scalar = BinaryField128bGhash>>(x: P) -> P {
 	P::from_scalars(x.iter().map(|scalar| scalar.mul_x()))
 }
 
+// TODO: move to PackedField for an optimized SIMD version
+#[inline]
+pub fn mul_inv_x<P: PackedField<Scalar = BinaryField128bGhash>>(x: P) -> P {
+	P::from_scalars(x.iter().map(|scalar| scalar.mul_inv_x()))
+}
+
 #[cfg(test)]
 mod test_utils {
 	/// Test if `mult_func` operation is a valid multiply operation on the given values for


### PR DESCRIPTION
### TL;DR

Added a new `mul_inv_x` function to efficiently divide by x in binary field operations.

### What changed?

- Added a new `mul_inv_x` method to `BinaryField128bGhash` that efficiently divides a field element by x (or multiplies by x^-1)
- Implemented a corresponding `mul_inv_x` function in the `packed_ghash` module that operates on packed field elements
- Added comprehensive test cases to verify the correctness of the implementation by comparing with regular field inversion

### How to test?

Run the new test case `test_mul_inv_x` which verifies that the optimized implementation produces the same results as the standard approach of multiplying by the inverse of 2:

```
cargo test --package field --lib -- ghash::tests::test_mul_inv_x
```

### Why make this change?

This optimization provides a more efficient way to divide by x in binary field operations. Instead of performing a full field inversion and multiplication, the implementation uses bit manipulation and the properties of the binary field to compute the result directly. This is particularly useful in cryptographic applications like GHASH where field operations need to be as efficient as possible.