### PR TITLE
improve prover implementation performance

### DIFF
--- a/crates/prover/Cargo.toml
+++ b/crates/prover/Cargo.toml
@@ -67,6 +67,10 @@ harness = false
 name = "ring_switch"
 harness = false
 
+[[bench]]
+name = "vision"
+harness = false
+
 [features]
 default = ["rayon"]
 rayon = ["binius-utils/rayon"]

--- a/crates/prover/benches/vision.rs
+++ b/crates/prover/benches/vision.rs
@@ -1,0 +1,229 @@
+// Copyright 2025 Irreducible Inc.
+
+use std::{array, mem::MaybeUninit};
+
+use binius_field::{BinaryField128bGhash as Ghash, Field, Random};
+use binius_prover::hash::{
+	parallel_digest::{MultiDigest, ParallelDigest, ParallelMultidigestImpl},
+	vision_4::{
+		parallel::parallel_permutation as parallel_permutation_4,
+		single::VisionHasherMultiDigest as VisionHasherMultiDigest_4,
+	},
+	vision_6::{
+		parallel::parallel_permutation as parallel_permutation_6,
+		single::VisionHasherMultiDigest as VisionHasherMultiDigest_6,
+	},
+};
+use binius_utils::rayon::prelude::*;
+use binius_verifier::hash::vision_4::digest::VisionHasherDigest;
+use criterion::{
+	BenchmarkGroup, Criterion, Throughput, criterion_group, criterion_main, measurement::WallTime,
+};
+use digest::Digest;
+use rand::{RngCore, rngs::ThreadRng};
+
+fn bench_parallel_permutation_for_size<const N: usize, const MN: usize>(
+	group: &mut BenchmarkGroup<WallTime>,
+	rng: &mut ThreadRng,
+	permutation: fn(&mut [Ghash; MN], &mut [Ghash]),
+	scratchpad: &mut [Ghash],
+) {
+	const BYTES_PER_ELEMENT: u64 = 16;
+	group.throughput(Throughput::Bytes(MN as u64 * BYTES_PER_ELEMENT));
+	let mut parallel_states: [Ghash; MN] = array::from_fn(|_| Ghash::random(&mut *rng));
+	group.bench_function(format!("N={N}"), |b| {
+		b.iter(|| {
+			permutation(&mut parallel_states, scratchpad);
+		})
+	});
+}
+
+macro_rules! bench_parallel_permutation_sizes_4 {
+	($group:expr, $rng:expr, $permutation:ident, $scratchpad:expr, $m:expr, $($n:expr),*) => {
+		$(
+			bench_parallel_permutation_for_size::<$n, { $n * $m }>(
+				$group,
+				$rng,
+				$permutation::<$n, { $n * $m }>,
+				$scratchpad,
+			);
+		)*
+	};
+}
+
+macro_rules! bench_parallel_permutation_sizes_6 {
+	($group:expr, $rng:expr, $permutation:ident, $scratchpad:expr, $m:expr, $($n:expr),*) => {
+		$(
+			bench_parallel_permutation_for_size::<$n, { $n * $m }>(
+				$group,
+				$rng,
+				$permutation::<$n, { $n * $m }, { $n * $m / 3 }>,
+				$scratchpad,
+			);
+		)*
+	};
+}
+
+fn bench_parallel_permutation_4(c: &mut Criterion) {
+	const M: usize = 4;
+	let mut group = c.benchmark_group("Parallel Permutation 4");
+	let mut rng = rand::rng();
+
+	let scratchpad = &mut [Ghash::ZERO; 256 * M * 2];
+	bench_parallel_permutation_sizes_4!(
+		&mut group,
+		&mut rng,
+		parallel_permutation_4,
+		scratchpad,
+		M,
+		2,
+		4,
+		8,
+		16,
+		32,
+		64,
+		128,
+		256
+	);
+
+	group.finish();
+}
+
+fn bench_parallel_permutation_6(c: &mut Criterion) {
+	const M: usize = 6;
+	let mut group = c.benchmark_group("Parallel Permutation 6");
+	let mut rng = rand::rng();
+
+	let scratchpad = &mut [Ghash::ZERO; 256 * M * 2];
+	bench_parallel_permutation_sizes_6!(
+		&mut group,
+		&mut rng,
+		parallel_permutation_6,
+		scratchpad,
+		M,
+		2,
+		4,
+		8,
+		16,
+		32,
+		64,
+		128,
+		256
+	);
+
+	group.finish();
+}
+
+fn bench_hash_vision_4(c: &mut Criterion) {
+	const M: usize = 4;
+	let mut group = c.benchmark_group("Hash 4");
+	let mut rng = rand::rng();
+
+	const BYTE_COUNT: usize = 1 << 20;
+	let mut data = vec![0u8; BYTE_COUNT];
+	rng.fill_bytes(&mut data);
+
+	group.throughput(Throughput::Bytes(BYTE_COUNT as u64));
+
+	group.bench_function("SingleDigest", |bench| {
+		bench.iter(|| <VisionHasherDigest as Digest>::digest(data.clone()))
+	});
+
+	// Number of parallel hashing instances
+	// Larger powers of 2 perform better.
+	const N: usize = 32;
+
+	group.bench_function("MultiDigest", |bench| {
+		bench.iter(|| {
+			let mut out = [MaybeUninit::<digest::Output<VisionHasherDigest>>::uninit(); N];
+
+			VisionHasherMultiDigest_4::<N, { N * M }>::digest(
+				array::from_fn(|i| &data[i * BYTE_COUNT / N..(i + 1) * BYTE_COUNT / N]),
+				&mut out,
+			);
+			out
+		})
+	});
+
+	group.bench_function("ParallelMultiDigest", |bench| {
+		bench.iter(|| {
+			let mut out = [MaybeUninit::<digest::Output<VisionHasherDigest>>::uninit(); N];
+			let hasher =
+				ParallelMultidigestImpl::<VisionHasherMultiDigest_4<N, { N * M }>, N>::new();
+
+			hasher.digest(
+				(0..N).into_par_iter().map(|i| {
+					let start = i * BYTE_COUNT / N;
+					let end = (i + 1) * BYTE_COUNT / N;
+					std::iter::once(&data[start..end])
+				}),
+				&mut out,
+			);
+			out
+		})
+	});
+
+	group.finish()
+}
+
+fn bench_hash_vision_6(c: &mut Criterion) {
+	const M: usize = 6;
+	let mut group = c.benchmark_group("Hash 6");
+	let mut rng = rand::rng();
+
+	const BYTE_COUNT: usize = 1 << 20;
+	let mut data = vec![0u8; BYTE_COUNT];
+	rng.fill_bytes(&mut data);
+
+	group.throughput(Throughput::Bytes(BYTE_COUNT as u64));
+
+	group.bench_function("SingleDigest", |bench| {
+		bench.iter(|| <VisionHasherDigest as Digest>::digest(data.clone()))
+	});
+
+	// Number of parallel hashing instances
+	// Larger powers of 2 perform better.
+	const N: usize = 32;
+
+	group.bench_function("MultiDigest", |bench| {
+		bench.iter(|| {
+			let mut out = [MaybeUninit::<digest::Output<VisionHasherDigest>>::uninit(); N];
+
+			VisionHasherMultiDigest_6::<N, { N * M }, { N * M / 3 }>::digest(
+				array::from_fn(|i| &data[i * BYTE_COUNT / N..(i + 1) * BYTE_COUNT / N]),
+				&mut out,
+			);
+			out
+		})
+	});
+
+	group.bench_function("ParallelMultiDigest", |bench| {
+		bench.iter(|| {
+			let mut out = [MaybeUninit::<digest::Output<VisionHasherDigest>>::uninit(); N];
+			let hasher = ParallelMultidigestImpl::<
+				VisionHasherMultiDigest_6<N, { N * M }, { N * M / 3 }>,
+				N,
+			>::new();
+
+			hasher.digest(
+				(0..N).into_par_iter().map(|i| {
+					let start = i * BYTE_COUNT / N;
+					let end = (i + 1) * BYTE_COUNT / N;
+					std::iter::once(&data[start..end])
+				}),
+				&mut out,
+			);
+			out
+		})
+	});
+
+	group.finish()
+}
+
+criterion_group!(
+	parallel_permutation_bench,
+	bench_parallel_permutation_4,
+	bench_parallel_permutation_6
+);
+criterion_group!(hash_vision_bench, bench_hash_vision_4, bench_hash_vision_6);
+criterion_main!(parallel_permutation_bench, hash_vision_bench);

--- a/crates/prover/src/hash/mod.rs
+++ b/crates/prover/src/hash/mod.rs
@@ -1,5 +1,6 @@
 pub mod parallel_digest;
-#[allow(dead_code)]
-pub mod vision;
+
+pub mod vision_4;
+pub mod vision_6;
 
 pub use parallel_digest::ParallelDigest;

--- a/crates/prover/src/hash/vision_4/mod.rs
+++ b/crates/prover/src/hash/vision_4/mod.rs
@@ -1,0 +1,4 @@
+// Copyright 2025 Irreducible Inc.
+
+pub mod parallel;
+pub mod single;

--- a/crates/prover/src/hash/vision_4/parallel.rs
+++ b/crates/prover/src/hash/vision_4/parallel.rs
@@ -1,0 +1,151 @@
+// Copyright 2025 Irreducible Inc.
+
+//! Parallel Vision-4 hash permutation using flattened state arrays.
+//!
+//! Processes N Vision-4 states simultaneously by flattening them into a single N×4 array.
+//! The key optimization is **batch inversion** - replacing N expensive field inversions
+//! with a single inversion across all states using Montgomery's algorithm.
+//!
+//! # Layout
+//! States: `[s0[0], s0[1], s0[2], s0[3], s1[0], s1[1], ...]` where `N` = number of states, `M = 4`.
+//!
+//! # Round Structure  
+//! Each round: inversion → transform → MDS → constants → inversion → transform → MDS → constants
+
+use binius_field::{BinaryField128bGhash as Ghash, arithmetic_traits::Square};
+use binius_math::batch_invert::batch_invert;
+use binius_verifier::hash::vision_4::{
+	constants::{B_FWD_COEFFS, M, NUM_ROUNDS, ROUND_CONSTANTS},
+	permutation::{constants_add, linearized_b_inv_transform_scalar, mds_mul},
+};
+
+/// Applies forward B-polynomial transformation: B(x) = c₀ + c₁x + c₂x² + c₃x⁴.
+#[inline]
+fn parallel_forward_transform<const N: usize, const MN: usize>(states: &mut [Ghash; MN]) {
+	for i in 0..MN {
+		let scalar = states[i];
+		let square = scalar.square();
+		let quartic = square.square();
+
+		states[i] = B_FWD_COEFFS[0]
+			+ B_FWD_COEFFS[1] * scalar
+			+ B_FWD_COEFFS[2] * square
+			+ B_FWD_COEFFS[3] * quartic;
+	}
+}
+
+/// Applies inverse B-polynomial transformation using lookups.
+#[inline]
+fn parallel_inverse_transform<const N: usize, const MN: usize>(states: &mut [Ghash; MN]) {
+	for i in 0..MN {
+		linearized_b_inv_transform_scalar(&mut states[i]);
+	}
+}
+
+/// Applies MDS matrix multiplication to each of the N parallel states.
+#[inline]
+fn parallel_mds_mul<const N: usize, const MN: usize>(states: &mut [Ghash; MN]) {
+	for i in 0..N {
+		let state = &mut states[i * M..];
+		mds_mul(state);
+	}
+}
+
+/// Adds round constants to each of the N parallel states.
+#[inline]
+fn parallel_constants_add<const N: usize, const MN: usize>(
+	states: &mut [Ghash; MN],
+	constants: &[Ghash; M],
+) {
+	for i in 0..N {
+		let state = &mut states[i * M..];
+		constants_add(state, constants);
+	}
+}
+
+/// Executes a complete Vision-4 round on all parallel states.
+#[inline]
+fn parallel_round<const N: usize, const MN: usize>(
+	states: &mut [Ghash; MN],
+	scratchpad: &mut [Ghash],
+	round_constants_idx: usize,
+) {
+	// First half-round: inversion → inverse transform → MDS → constants
+	batch_invert::<MN>(states, scratchpad);
+	parallel_inverse_transform::<N, MN>(states);
+	parallel_mds_mul::<N, MN>(states);
+	parallel_constants_add::<N, MN>(states, &ROUND_CONSTANTS[round_constants_idx]);
+
+	// Second half-round: inversion → forward transform → MDS → constants
+	batch_invert::<MN>(states, scratchpad);
+	parallel_forward_transform::<N, MN>(states);
+	parallel_mds_mul::<N, MN>(states);
+	parallel_constants_add::<N, MN>(states, &ROUND_CONSTANTS[round_constants_idx + 1]);
+}
+
+/// Executes the complete Vision-4 permutation on N parallel states.
+///
+/// Main entry point for parallel Vision-4 hashing. Requires scratchpad ≥ 2×MN-1 elements.
+#[inline]
+pub fn parallel_permutation<const N: usize, const MN: usize>(
+	states: &mut [Ghash; MN],
+	scratchpad: &mut [Ghash],
+) {
+	// Initial round constant addition
+	parallel_constants_add::<N, MN>(states, &ROUND_CONSTANTS[0]);
+
+	// Execute all rounds of the permutation
+	for round_num in 0..NUM_ROUNDS {
+		parallel_round::<N, MN>(states, scratchpad, 1 + 2 * round_num);
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use std::array;
+
+	use binius_field::{Field, Random};
+	use binius_verifier::hash::vision_4::permutation::permutation;
+	use rand::{SeedableRng, rngs::StdRng};
+
+	use super::*;
+
+	macro_rules! test_parallel_permutation {
+		($name:ident, $n:expr) => {
+			#[test]
+			fn $name() {
+				const N: usize = $n;
+				const MN: usize = M * N;
+				let mut rng = StdRng::seed_from_u64(0);
+
+				for _ in 0..4 {
+					let mut parallel_states: [Ghash; MN] =
+						array::from_fn(|_| Ghash::random(&mut rng));
+
+					let mut single_states: [[Ghash; M]; N] =
+						array::from_fn(|i| array::from_fn(|j| parallel_states[i * M + j]));
+
+					let scratchpad = &mut [Ghash::ZERO; { 2 * MN }];
+					parallel_permutation::<N, MN>(&mut parallel_states, scratchpad);
+
+					for state in single_states.iter_mut() {
+						permutation(state);
+					}
+
+					let expected_parallel: [Ghash; MN] =
+						array::from_fn(|i| single_states[i / M][i % M]);
+
+					assert_eq!(parallel_states, expected_parallel);
+				}
+			}
+		};
+	}
+
+	test_parallel_permutation!(test_parallel_permutation_1, 1);
+	test_parallel_permutation!(test_parallel_permutation_2, 2);
+	test_parallel_permutation!(test_parallel_permutation_4, 4);
+	test_parallel_permutation!(test_parallel_permutation_8, 8);
+	test_parallel_permutation!(test_parallel_permutation_16, 16);
+	test_parallel_permutation!(test_parallel_permutation_32, 32);
+	test_parallel_permutation!(test_parallel_permutation_64, 64);
+}

--- a/crates/prover/src/hash/vision_4/single.rs
+++ b/crates/prover/src/hash/vision_4/single.rs
@@ -1,0 +1,260 @@
+// Copyright 2025 Irreducible Inc.
+
+use std::{array, mem::MaybeUninit};
+
+use binius_field::{BinaryField128bGhash as Ghash, Field};
+use binius_utils::{DeserializeBytes, SerializeBytes};
+use binius_verifier::hash::vision_4::{
+	M,
+	digest::{PADDING_BLOCK, RATE_AS_U8, RATE_AS_U128, VisionHasherDigest, fill_padding},
+};
+use digest::Output;
+
+use super::{super::parallel_digest::MultiDigest, parallel::parallel_permutation};
+
+/// A Vision hasher with state size M=4 suited for parallelization.
+///
+/// Without using packed fields, there is only one advantage of an explicit parallelized
+/// Vision hasher over invoking the Vision hasher multiple times in parallel:
+/// we can amortize the cost of inversion in the sbox using
+/// [Montogery's trick](https://medium.com/eryxcoop/montgomerys-trick-for-batch-galois-field-inversion-9b6d0f399da2).
+/// We slightly modify Montogery's trick to use a binary tree structure,
+/// maximizing independence of multiplications for better instruction pipelining.
+#[derive(Clone)]
+pub struct VisionHasherMultiDigest<const N: usize, const MN: usize> {
+	states: [Ghash; MN],
+	scratchpad: Vec<Ghash>,
+	buffers: [[u8; RATE_AS_U8]; N],
+	filled_bytes: usize,
+}
+
+impl<const N: usize, const MN: usize> Default for VisionHasherMultiDigest<N, MN> {
+	fn default() -> Self {
+		assert!(N.is_power_of_two() && N >= 2, "N must be a power of 2 and >= 2");
+		assert_eq!(MN, M * N);
+		Self {
+			states: array::from_fn(|_| Ghash::ZERO),
+			scratchpad: vec![Ghash::ZERO; 2 * MN],
+			buffers: array::from_fn(|_| [0; RATE_AS_U8]),
+			filled_bytes: 0,
+		}
+	}
+}
+
+impl<const N: usize, const MN: usize> VisionHasherMultiDigest<N, MN> {
+	#[inline]
+	fn advance_data(data: &mut [&[u8]; N], bytes: usize) {
+		for i in 0..N {
+			data[i] = &data[i][bytes..];
+		}
+	}
+
+	fn permute(states: &mut [Ghash; MN], scratchpad: &mut [Ghash], data: [&[u8]; N]) {
+		for (i, data) in data.iter().enumerate() {
+			debug_assert_eq!(data.len(), RATE_AS_U8);
+
+			// Overwrite first RATE_AS_U128 elements of state i with data
+			let state_start = i * M;
+			for j in 0..RATE_AS_U128 {
+				let element_bytes = &data[j * (128 / 8)..];
+				states[state_start + j] =
+					Ghash::deserialize(element_bytes).expect("data len checked");
+			}
+		}
+
+		parallel_permutation::<N, MN>(states, scratchpad);
+	}
+	fn finalize(&mut self, out: &mut [MaybeUninit<digest::Output<VisionHasherDigest>>; N]) {
+		if self.filled_bytes != 0 {
+			for i in 0..N {
+				fill_padding(&mut self.buffers[i][self.filled_bytes..]);
+			}
+			Self::permute(
+				&mut self.states,
+				&mut self.scratchpad,
+				array::from_fn(|i| &self.buffers[i][..]),
+			);
+		} else {
+			Self::permute(
+				&mut self.states,
+				&mut self.scratchpad,
+				array::from_fn(|_| &PADDING_BLOCK[..]),
+			);
+		}
+
+		// Serialize first two state elements for each digest (32 bytes total per digest)
+		for i in 0..N {
+			let output_slice = out[i].as_mut_ptr() as *mut u8;
+			let output_bytes = unsafe { std::slice::from_raw_parts_mut(output_slice, 32) };
+			let (state0, state1) = output_bytes.split_at_mut(16);
+			self.states[i * M]
+				.serialize(state0)
+				.expect("fits in 16 bytes");
+			self.states[i * M + 1]
+				.serialize(state1)
+				.expect("fits in 16 bytes");
+		}
+	}
+}
+
+impl<const N: usize, const MN: usize> MultiDigest<N> for VisionHasherMultiDigest<N, MN> {
+	type Digest = VisionHasherDigest;
+
+	fn new() -> Self {
+		Self::default()
+	}
+
+	fn update(&mut self, mut data: [&[u8]; N]) {
+		data[1..].iter().for_each(|row| {
+			assert_eq!(row.len(), data[0].len());
+		});
+
+		if self.filled_bytes != 0 {
+			let to_copy = std::cmp::min(data[0].len(), RATE_AS_U8 - self.filled_bytes);
+			data.iter().enumerate().for_each(|(row_i, row)| {
+				self.buffers[row_i][self.filled_bytes..self.filled_bytes + to_copy]
+					.copy_from_slice(&row[..to_copy]);
+			});
+			Self::advance_data(&mut data, to_copy);
+			self.filled_bytes += to_copy;
+
+			if self.filled_bytes == RATE_AS_U8 {
+				Self::permute(
+					&mut self.states,
+					&mut self.scratchpad,
+					array::from_fn(|i| &self.buffers[i][..]),
+				);
+				self.filled_bytes = 0;
+			}
+		}
+
+		while data[0].len() >= RATE_AS_U8 {
+			let chunks = array::from_fn(|i| &data[i][..RATE_AS_U8]);
+			Self::permute(&mut self.states, &mut self.scratchpad, chunks);
+			Self::advance_data(&mut data, RATE_AS_U8);
+		}
+
+		if !data[0].is_empty() {
+			data.iter().enumerate().for_each(|(row_i, row)| {
+				self.buffers[row_i][..row.len()].copy_from_slice(row);
+			});
+			self.filled_bytes = data[0].len();
+		}
+	}
+
+	fn finalize_into(mut self, out: &mut [MaybeUninit<Output<Self::Digest>>; N]) {
+		self.finalize(out);
+	}
+
+	fn finalize_into_reset(&mut self, out: &mut [MaybeUninit<Output<Self::Digest>>; N]) {
+		self.finalize(out);
+		self.reset();
+	}
+
+	fn reset(&mut self) {
+		self.states = array::from_fn(|_| Ghash::ZERO);
+		self.buffers = array::from_fn(|_| [0; RATE_AS_U8]);
+		self.filled_bytes = 0;
+	}
+
+	fn digest(data: [&[u8]; N], out: &mut [MaybeUninit<Output<Self::Digest>>; N]) {
+		let mut digest = Self::default();
+		digest.update(data);
+		digest.finalize_into(out);
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use std::mem::MaybeUninit;
+
+	use digest::Digest;
+	use rand::{Rng, SeedableRng, rngs::StdRng};
+
+	use super::*;
+
+	// Helper function to generate random data vectors
+	fn generate_random_data<const N: usize>(length: usize, seed: u64) -> Vec<Vec<u8>> {
+		let mut rng = StdRng::seed_from_u64(seed);
+		let mut data_vecs = Vec::new();
+		for _ in 0..N {
+			let mut vec = Vec::with_capacity(length);
+			for _ in 0..length {
+				vec.push(rng.random());
+			}
+			data_vecs.push(vec);
+		}
+		data_vecs
+	}
+
+	// Generic test function that compares parallel vs sequential execution
+	fn test_parallel_vs_sequential<const N: usize, const MN: usize>(
+		data: [&[u8]; N],
+		description: &str,
+	) {
+		// Parallel computation
+		let mut parallel_outputs = [MaybeUninit::uninit(); N];
+		VisionHasherMultiDigest::<N, MN>::digest(data, &mut parallel_outputs);
+		let parallel_results: [Output<VisionHasherDigest>; N] =
+			array::from_fn(|i| unsafe { parallel_outputs[i].assume_init() });
+
+		// Sequential computation
+		let sequential_results: [_; N] = array::from_fn(|i| {
+			let mut hasher = VisionHasherDigest::new();
+			hasher.update(data[i]);
+			hasher.finalize()
+		});
+
+		// Compare results
+		for i in 0..N {
+			assert_eq!(
+				parallel_results[i], sequential_results[i],
+				"Mismatch at index {i} for {description}"
+			);
+		}
+	}
+
+	#[test]
+	fn test_empty_inputs() {
+		const N: usize = 4;
+		let data: [&[u8]; N] = [&[], &[], &[], &[]];
+		test_parallel_vs_sequential::<N, { N * M }>(data, "empty inputs");
+	}
+
+	#[test]
+	fn test_small_inputs() {
+		const N: usize = 2;
+		let data: [&[u8]; N] = [b"Hello... World!", b"Rust is awesome"];
+		test_parallel_vs_sequential::<N, { N * M }>(data, "small inputs");
+	}
+
+	#[test]
+	fn test_multi_block() {
+		const N: usize = 4;
+		// Multiple blocks with different random patterns
+		let target_len = RATE_AS_U8 * 2 + 10;
+		let data_vecs = generate_random_data::<N>(target_len, 42);
+		let data: [&[u8]; N] = array::from_fn(|i| data_vecs[i].as_slice());
+
+		test_parallel_vs_sequential::<N, { N * M }>(data, "multi-block inputs");
+	}
+
+	#[test]
+	fn test_various_sizes() {
+		// Test different sizes separately since parallel requires same length per batch
+		let sizes = [
+			1,
+			RATE_AS_U8 - 7,
+			RATE_AS_U8,
+			RATE_AS_U8 + 5,
+			RATE_AS_U8 * 2 - 3,
+		];
+
+		for &size in &sizes {
+			const N: usize = 2;
+			let data_vecs = generate_random_data::<N>(size, 123);
+			let data: [&[u8]; N] = array::from_fn(|i| data_vecs[i].as_slice());
+			test_parallel_vs_sequential::<N, { N * M }>(data, &format!("size {size}"));
+		}
+	}
+}

--- a/crates/prover/src/hash/vision_6/mod.rs
+++ b/crates/prover/src/hash/vision_6/mod.rs
@@ -1,0 +1,4 @@
+// Copyright 2025 Irreducible Inc.
+
+pub mod parallel;
+pub mod single;

--- a/crates/prover/src/hash/vision_6/parallel.rs
+++ b/crates/prover/src/hash/vision_6/parallel.rs
@@ -1,0 +1,171 @@
+// Copyright 2025 Irreducible Inc.
+
+//! Parallel Vision-6 hash permutation using flattened state arrays.
+//!
+//! Processes N Vision-6 states simultaneously by flattening them into a single N×6 array.
+//! The key optimization is **batch inversion** - replacing N expensive field inversions
+//! with a single inversion across all states using Montgomery's algorithm.
+//!
+//! # Layout
+//! States: `[s0[0], s0[1], ..., s0[5], s1[0], s1[1], ...]` where `N` = number of states, `M = 6`.
+//!
+//! # Round Structure  
+//! Each round: inversion → transform → MDS → constants → inversion → transform → MDS → constants
+
+use binius_field::{BinaryField128bGhash as Ghash, arithmetic_traits::Square};
+use binius_math::batch_invert::batch_invert;
+use binius_verifier::hash::vision_6::{
+	constants::{B_FWD_COEFFS, M, NUM_ROUNDS, ROUND_CONSTANTS},
+	permutation::{linearized_b_inv_transform_scalar, mds_mul},
+};
+
+/// Applies forward B-polynomial transformation: B(x) = c₀ + c₁x + c₂x² + c₃x⁴.
+#[inline]
+fn parallel_forward_transform<const N: usize, const MN: usize>(states: &mut [Ghash; MN]) {
+	for i in 0..MN {
+		let scalar = states[i];
+		let square = scalar.square();
+		let quartic = square.square();
+
+		states[i] = B_FWD_COEFFS[0]
+			+ B_FWD_COEFFS[1] * scalar
+			+ B_FWD_COEFFS[2] * square
+			+ B_FWD_COEFFS[3] * quartic;
+	}
+}
+
+/// Applies inverse B-polynomial transformation using lookups.
+#[inline]
+fn parallel_inverse_transform<const N: usize, const MN: usize>(states: &mut [Ghash; MN]) {
+	for i in 0..MN {
+		linearized_b_inv_transform_scalar(&mut states[i]);
+	}
+}
+
+/// Applies MDS matrix multiplication to each of the N parallel states.
+#[inline]
+fn parallel_mds_mul<const N: usize, const MN: usize>(states: &mut [Ghash; MN]) {
+	for i in 0..N {
+		let state = &mut states[i * M..];
+		mds_mul(state);
+	}
+}
+
+/// Adds round constants to each of the N parallel states.
+#[inline]
+fn parallel_constants_add<const N: usize, const MN: usize>(
+	states: &mut [Ghash; MN],
+	constants: &[Ghash; M],
+) {
+	for i in 0..N {
+		let state_start = i * M;
+		for j in 0..M {
+			states[state_start + j] += constants[j];
+		}
+	}
+}
+
+/// Applies batch inversion to all parallel states, splitting each 6-element state into 3 pairs.
+#[inline]
+fn parallel_batch_invert<const N: usize, const MN: usize, const MN_DIV_3: usize>(
+	states: &mut [Ghash; MN],
+	scratchpad: &mut [Ghash],
+) {
+	batch_invert::<MN_DIV_3>(&mut states[0..MN_DIV_3], &mut scratchpad[0..2 * MN_DIV_3]);
+	batch_invert::<MN_DIV_3>(
+		&mut states[MN_DIV_3..MN_DIV_3 * 2],
+		&mut scratchpad[2 * MN_DIV_3..4 * MN_DIV_3],
+	);
+	batch_invert::<MN_DIV_3>(
+		&mut states[MN_DIV_3 * 2..MN_DIV_3 * 3],
+		&mut scratchpad[4 * MN_DIV_3..6 * MN_DIV_3],
+	);
+}
+
+/// Executes a complete Vision-6 round on all parallel states.
+#[inline]
+fn parallel_round<const N: usize, const MN: usize, const MN_DIV_3: usize>(
+	states: &mut [Ghash; MN],
+	scratchpad: &mut [Ghash],
+	round_constants_idx: usize,
+) {
+	// First half-round: inversion → inverse transform → MDS → constants
+	parallel_batch_invert::<N, MN, MN_DIV_3>(states, scratchpad);
+	parallel_inverse_transform::<N, MN>(states);
+	parallel_mds_mul::<N, MN>(states);
+	parallel_constants_add::<N, MN>(states, &ROUND_CONSTANTS[round_constants_idx]);
+
+	// Second half-round: inversion → forward transform → MDS → constants
+	parallel_batch_invert::<N, MN, MN_DIV_3>(states, scratchpad);
+	parallel_forward_transform::<N, MN>(states);
+	parallel_mds_mul::<N, MN>(states);
+	parallel_constants_add::<N, MN>(states, &ROUND_CONSTANTS[round_constants_idx + 1]);
+}
+
+/// Executes the complete Vision-6 permutation on N parallel states.
+///
+/// Main entry point for parallel Vision-6 hashing. Requires scratchpad ≥ 2×MN-1 elements.
+#[inline]
+pub fn parallel_permutation<const N: usize, const MN: usize, const MN_DIV_3: usize>(
+	states: &mut [Ghash; MN],
+	scratchpad: &mut [Ghash],
+) {
+	// Initial round constant addition
+	parallel_constants_add::<N, MN>(states, &ROUND_CONSTANTS[0]);
+
+	// Execute all rounds of the permutation
+	for round_num in 0..NUM_ROUNDS {
+		parallel_round::<N, MN, MN_DIV_3>(states, scratchpad, 1 + 2 * round_num);
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use std::array;
+
+	use binius_field::{Field, Random};
+	use binius_verifier::hash::vision_6::permutation::permutation;
+	use rand::{SeedableRng, rngs::StdRng};
+
+	use super::*;
+
+	macro_rules! test_parallel_permutation {
+		($name:ident, $n:expr) => {
+			#[test]
+			fn $name() {
+				const N: usize = $n;
+				const MN: usize = M * N;
+				const MN_DIV_3: usize = MN / 3;
+				let mut rng = StdRng::seed_from_u64(0);
+
+				for _ in 0..4 {
+					let mut parallel_states: [Ghash; MN] =
+						array::from_fn(|_| Ghash::random(&mut rng));
+
+					let mut single_states: [[Ghash; M]; N] =
+						array::from_fn(|i| array::from_fn(|j| parallel_states[i * M + j]));
+
+					let scratchpad = &mut [Ghash::ZERO; { 2 * MN }];
+					parallel_permutation::<N, MN, MN_DIV_3>(&mut parallel_states, scratchpad);
+
+					for state in single_states.iter_mut() {
+						permutation(state);
+					}
+
+					let expected_parallel: [Ghash; MN] =
+						array::from_fn(|i| single_states[i / M][i % M]);
+
+					assert_eq!(parallel_states, expected_parallel);
+				}
+			}
+		};
+	}
+
+	test_parallel_permutation!(test_parallel_permutation_1, 1);
+	test_parallel_permutation!(test_parallel_permutation_2, 2);
+	test_parallel_permutation!(test_parallel_permutation_4, 4);
+	test_parallel_permutation!(test_parallel_permutation_8, 8);
+	test_parallel_permutation!(test_parallel_permutation_16, 16);
+	test_parallel_permutation!(test_parallel_permutation_32, 32);
+	test_parallel_permutation!(test_parallel_permutation_64, 64);
+}

--- a/crates/prover/src/hash/vision_6/single.rs
+++ b/crates/prover/src/hash/vision_6/single.rs
@@ -1,0 +1,269 @@
+// Copyright 2025 Irreducible Inc.
+
+use std::{array, mem::MaybeUninit};
+
+use binius_field::{BinaryField128bGhash as Ghash, Field};
+use binius_utils::{DeserializeBytes, SerializeBytes};
+use binius_verifier::hash::vision_6::{
+	M,
+	digest::{PADDING_BLOCK, RATE_AS_U8, RATE_AS_U128, VisionHasherDigest, fill_padding},
+};
+use digest::Output;
+
+use super::{super::parallel_digest::MultiDigest, parallel::parallel_permutation};
+
+/// A Vision hasher with state size M=6 suited for parallelization.
+///
+/// Without using packed fields, there is only one advantage of an explicit parallelized
+/// Vision hasher over invoking the Vision hasher multiple times in parallel:
+/// we can amortize the cost of inversion in the sbox using
+/// [Montogery's trick](https://medium.com/eryxcoop/montgomerys-trick-for-batch-galois-field-inversion-9b6d0f399da2).
+/// We slightly modify Montogery's trick to use a binary tree structure,
+/// maximizing independence of multiplications for better instruction pipelining.
+#[derive(Clone)]
+pub struct VisionHasherMultiDigest<const N: usize, const MN: usize, const MN_DIV_3: usize> {
+	states: [Ghash; MN],
+	scratchpad: Vec<Ghash>,
+	buffers: [[u8; RATE_AS_U8]; N],
+	filled_bytes: usize,
+}
+
+impl<const N: usize, const MN: usize, const MN_DIV_3: usize> Default
+	for VisionHasherMultiDigest<N, MN, MN_DIV_3>
+{
+	fn default() -> Self {
+		assert!(N.is_power_of_two() && N >= 2, "N must be a power of 2 and >= 2");
+		assert_eq!(MN, M * N);
+		Self {
+			states: array::from_fn(|_| Ghash::ZERO),
+			scratchpad: vec![Ghash::ZERO; 2 * MN],
+			buffers: array::from_fn(|_| [0; RATE_AS_U8]),
+			filled_bytes: 0,
+		}
+	}
+}
+
+impl<const N: usize, const MN: usize, const MN_DIV_3: usize>
+	VisionHasherMultiDigest<N, MN, MN_DIV_3>
+{
+	#[inline]
+	fn advance_data(data: &mut [&[u8]; N], bytes: usize) {
+		for i in 0..N {
+			data[i] = &data[i][bytes..];
+		}
+	}
+
+	fn permute(states: &mut [Ghash; MN], scratchpad: &mut [Ghash], data: [&[u8]; N]) {
+		for (i, data) in data.iter().enumerate() {
+			debug_assert_eq!(data.len(), RATE_AS_U8);
+
+			// Overwrite first RATE_AS_U128 elements of state i with data
+			let state_start = i * M;
+			for j in 0..RATE_AS_U128 {
+				let element_bytes = &data[j * (128 / 8)..];
+				states[state_start + j] =
+					Ghash::deserialize(element_bytes).expect("data len checked");
+			}
+		}
+
+		parallel_permutation::<N, MN, MN_DIV_3>(states, scratchpad);
+	}
+	fn finalize(&mut self, out: &mut [MaybeUninit<digest::Output<VisionHasherDigest>>; N]) {
+		if self.filled_bytes != 0 {
+			for i in 0..N {
+				fill_padding(&mut self.buffers[i][self.filled_bytes..]);
+			}
+			Self::permute(
+				&mut self.states,
+				&mut self.scratchpad,
+				array::from_fn(|i| &self.buffers[i][..]),
+			);
+		} else {
+			Self::permute(
+				&mut self.states,
+				&mut self.scratchpad,
+				array::from_fn(|_| &PADDING_BLOCK[..]),
+			);
+		}
+
+		// Serialize first two state elements for each digest (32 bytes total per digest)
+		for i in 0..N {
+			let output_slice = out[i].as_mut_ptr() as *mut u8;
+			let output_bytes = unsafe { std::slice::from_raw_parts_mut(output_slice, 32) };
+			let (state0, state1) = output_bytes.split_at_mut(16);
+			self.states[i * M]
+				.serialize(state0)
+				.expect("fits in 16 bytes");
+			self.states[i * M + 1]
+				.serialize(state1)
+				.expect("fits in 16 bytes");
+		}
+	}
+}
+
+impl<const N: usize, const MN: usize, const MN_DIV_3: usize> MultiDigest<N>
+	for VisionHasherMultiDigest<N, MN, MN_DIV_3>
+{
+	type Digest = VisionHasherDigest;
+
+	fn new() -> Self {
+		Self::default()
+	}
+
+	fn update(&mut self, mut data: [&[u8]; N]) {
+		data[1..].iter().for_each(|row| {
+			assert_eq!(row.len(), data[0].len());
+		});
+
+		if self.filled_bytes != 0 {
+			let to_copy = std::cmp::min(data[0].len(), RATE_AS_U8 - self.filled_bytes);
+			data.iter().enumerate().for_each(|(row_i, row)| {
+				self.buffers[row_i][self.filled_bytes..self.filled_bytes + to_copy]
+					.copy_from_slice(&row[..to_copy]);
+			});
+			Self::advance_data(&mut data, to_copy);
+			self.filled_bytes += to_copy;
+
+			if self.filled_bytes == RATE_AS_U8 {
+				Self::permute(
+					&mut self.states,
+					&mut self.scratchpad,
+					array::from_fn(|i| &self.buffers[i][..]),
+				);
+				self.filled_bytes = 0;
+			}
+		}
+
+		while data[0].len() >= RATE_AS_U8 {
+			let chunks = array::from_fn(|i| &data[i][..RATE_AS_U8]);
+			Self::permute(&mut self.states, &mut self.scratchpad, chunks);
+			Self::advance_data(&mut data, RATE_AS_U8);
+		}
+
+		if !data[0].is_empty() {
+			data.iter().enumerate().for_each(|(row_i, row)| {
+				self.buffers[row_i][..row.len()].copy_from_slice(row);
+			});
+			self.filled_bytes = data[0].len();
+		}
+	}
+
+	fn finalize_into(mut self, out: &mut [MaybeUninit<Output<Self::Digest>>; N]) {
+		self.finalize(out);
+	}
+
+	fn finalize_into_reset(&mut self, out: &mut [MaybeUninit<Output<Self::Digest>>; N]) {
+		self.finalize(out);
+		self.reset();
+	}
+
+	fn reset(&mut self) {
+		self.states = array::from_fn(|_| Ghash::ZERO);
+		self.buffers = array::from_fn(|_| [0; RATE_AS_U8]);
+		self.filled_bytes = 0;
+	}
+
+	fn digest(data: [&[u8]; N], out: &mut [MaybeUninit<Output<Self::Digest>>; N]) {
+		let mut digest = Self::default();
+		digest.update(data);
+		digest.finalize_into(out);
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use std::mem::MaybeUninit;
+
+	use digest::Digest;
+	use rand::{Rng, SeedableRng, rngs::StdRng};
+
+	use super::*;
+
+	// Helper function to generate random data vectors
+	fn generate_random_data<const N: usize>(length: usize, seed: u64) -> Vec<Vec<u8>> {
+		let mut rng = StdRng::seed_from_u64(seed);
+		let mut data_vecs = Vec::new();
+		for _ in 0..N {
+			let mut vec = Vec::with_capacity(length);
+			for _ in 0..length {
+				vec.push(rng.random());
+			}
+			data_vecs.push(vec);
+		}
+		data_vecs
+	}
+
+	// Generic test function that compares parallel vs sequential execution
+	fn test_parallel_vs_sequential<const N: usize, const MN: usize, const MN_DIV_3: usize>(
+		data: [&[u8]; N],
+		description: &str,
+	) {
+		// Parallel computation
+		let mut parallel_outputs = [MaybeUninit::uninit(); N];
+		VisionHasherMultiDigest::<N, MN, MN_DIV_3>::digest(data, &mut parallel_outputs);
+		let parallel_results: [Output<VisionHasherDigest>; N] =
+			array::from_fn(|i| unsafe { parallel_outputs[i].assume_init() });
+
+		// Sequential computation
+		let sequential_results: [_; N] = array::from_fn(|i| {
+			let mut hasher = VisionHasherDigest::new();
+			hasher.update(data[i]);
+			hasher.finalize()
+		});
+
+		// Compare results
+		for i in 0..N {
+			assert_eq!(
+				parallel_results[i], sequential_results[i],
+				"Mismatch at index {i} for {description}"
+			);
+		}
+	}
+
+	#[test]
+	fn test_empty_inputs() {
+		const N: usize = 4;
+		let data: [&[u8]; N] = [&[], &[], &[], &[]];
+		test_parallel_vs_sequential::<N, { N * M }, { N * M / 3 }>(data, "empty inputs");
+	}
+
+	#[test]
+	fn test_small_inputs() {
+		const N: usize = 2;
+		let data: [&[u8]; N] = [b"Hello... World!", b"Rust is awesome"];
+		test_parallel_vs_sequential::<N, { N * M }, { N * M / 3 }>(data, "small inputs");
+	}
+
+	#[test]
+	fn test_multi_block() {
+		const N: usize = 4;
+		// Multiple blocks with different random patterns
+		let target_len = RATE_AS_U8 * 2 + 10;
+		let data_vecs = generate_random_data::<N>(target_len, 42);
+		let data: [&[u8]; N] = array::from_fn(|i| data_vecs[i].as_slice());
+
+		test_parallel_vs_sequential::<N, { N * M }, { N * M / 3 }>(data, "multi-block inputs");
+	}
+
+	#[test]
+	fn test_various_sizes() {
+		// Test different sizes separately since parallel requires same length per batch
+		let sizes = [
+			1,
+			RATE_AS_U8 - 7,
+			RATE_AS_U8,
+			RATE_AS_U8 + 5,
+			RATE_AS_U8 * 2 - 3,
+		];
+
+		for &size in &sizes {
+			const N: usize = 2;
+			let data_vecs = generate_random_data::<N>(size, 123);
+			let data: [&[u8]; N] = array::from_fn(|i| data_vecs[i].as_slice());
+			test_parallel_vs_sequential::<N, { N * M }, { N * M / 3 }>(
+				data,
+				&format!("size {size}"),
+			);
+		}
+	}
+}


### PR DESCRIPTION
Adds prover implementation of Vision with state size 6. Jim says he doesn’t mind code duplication here.  
Performance is not far behind what I projected, but still disappointing. Can achieve almost 100MB/s of throughput on the permutation, but when using the permutation for a hash that throughput gets cut in half since the sponge rate is half the state size.  
Best performance comes from very large N (in `MultiDigest<N>`​), but we don’t currently have Merkle tree functionality to take advantage of this. The main benefit of large N is more amortization in batch inversion. But even if one omits the actual inversion in batch inversion, large N still perform better than small N, not really sure why, maybe better scheduling/pipelining.

Parallel Permutation 4/N=2
time:   [3.6298 µs 3.6804 µs 3.7397 µs]
thrpt:  [32.641 MiB/s 33.168 MiB/s 33.630 MiB/s]
change:
time:   [+2.3884% +3.7663% +5.3490%] (p = 0.00 < 0.05)
thrpt:  [−5.0774% −3.6296% −2.3327%]
Performance has regressed.
Found 6 outliers among 100 measurements (6.00%)
5 (5.00%) high mild
1 (1.00%) high severe
Parallel Permutation 4/N=4
time:   [4.6550 µs 4.7429 µs 4.9089 µs]
thrpt:  [49.734 MiB/s 51.475 MiB/s 52.447 MiB/s]
change:
time:   [−0.0004% +0.9655% +2.5581%] (p = 0.16 > 0.05)
thrpt:  [−2.4943% −0.9562% +0.0004%]
No change in performance detected.
Found 4 outliers among 100 measurements (4.00%)
3 (3.00%) high mild
1 (1.00%) high severe
Parallel Permutation 4/N=8
time:   [7.7937 µs 7.8926 µs 8.0414 µs]
thrpt:  [60.721 MiB/s 61.866 MiB/s 62.651 MiB/s]
change:
time:   [+0.8726% +1.7268% +2.7749%] (p = 0.00 < 0.05)
thrpt:  [−2.6999% −1.6975% −0.8650%]
Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
4 (4.00%) high mild
2 (2.00%) high severe
Parallel Permutation 4/N=16
time:   [11.623 µs 11.699 µs 11.853 µs]
thrpt:  [82.388 MiB/s 83.475 MiB/s 84.018 MiB/s]
change:
time:   [−0.2909% +1.1834% +2.9253%] (p = 0.18 > 0.05)
thrpt:  [−2.8422% −1.1696% +0.2918%]
No change in performance detected.
Found 16 outliers among 100 measurements (16.00%)
6 (6.00%) high mild
10 (10.00%) high severe
Parallel Permutation 4/N=32
time:   [22.147 µs 22.290 µs 22.483 µs]
thrpt:  [86.872 MiB/s 87.622 MiB/s 88.190 MiB/s]
change:
time:   [+0.2918% +1.0759% +2.1523%] (p = 0.01 < 0.05)
thrpt:  [−2.1070% −1.0645% −0.2909%]
Change within noise threshold.
Found 8 outliers among 100 measurements (8.00%)
6 (6.00%) high mild
2 (2.00%) high severe
Parallel Permutation 4/N=64
time:   [43.330 µs 45.342 µs 48.827 µs]
thrpt:  [80.002 MiB/s 86.152 MiB/s 90.150 MiB/s]
change:
time:   [−12.996% −5.3653% +1.5599%] (p = 0.21 > 0.05)
thrpt:  [−1.5359% +5.6695% +14.938%]
No change in performance detected.
Found 5 outliers among 100 measurements (5.00%)
4 (4.00%) high mild
1 (1.00%) high severe
Parallel Permutation 4/N=128
time:   [81.801 µs 82.376 µs 83.244 µs]
thrpt:  [93.851 MiB/s 94.840 MiB/s 95.507 MiB/s]
change:
time:   [+2.4380% +3.8121% +5.8269%] (p = 0.00 < 0.05)
thrpt:  [−5.5061% −3.6721% −2.3799%]
Performance has regressed.
Found 1 outliers among 100 measurements (1.00%)
1 (1.00%) high severe
Parallel Permutation 4/N=256
time:   [174.03 µs 175.40 µs 177.72 µs]
thrpt:  [87.918 MiB/s 89.084 MiB/s 89.786 MiB/s]
change:
time:   [+6.8970% +7.5235% +8.3288%] (p = 0.00 < 0.05)
thrpt:  [−7.6885% −6.9971% −6.4520%]
Performance has regressed.
Found 1 outliers among 100 measurements (1.00%)
1 (1.00%) high severe

Parallel Permutation 6/N=2
time:   [8.3730 µs 8.3930 µs 8.4160 µs]
thrpt:  [21.757 MiB/s 21.817 MiB/s 21.868 MiB/s]
change:
time:   [−1.8771% −1.3376% −0.8506%] (p = 0.00 < 0.05)
thrpt:  [+0.8579% +1.3557% +1.9130%]
Change within noise threshold.
Found 14 outliers among 100 measurements (14.00%)
3 (3.00%) high mild
11 (11.00%) high severe
Parallel Permutation 6/N=4
time:   [10.584 µs 10.648 µs 10.767 µs]
thrpt:  [34.012 MiB/s 34.393 MiB/s 34.601 MiB/s]
change:
time:   [−6.4469% −5.6859% −4.3582%] (p = 0.00 < 0.05)
thrpt:  [+4.5568% +6.0287% +6.8912%]
Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
3 (3.00%) high mild
9 (9.00%) high severe
Parallel Permutation 6/N=8
time:   [14.327 µs 14.459 µs 14.679 µs]
thrpt:  [49.897 MiB/s 50.654 MiB/s 51.121 MiB/s]
change:
time:   [−18.099% −8.6572% −0.6537%] (p = 0.06 > 0.05)
thrpt:  [+0.6580% +9.4777% +22.098%]
No change in performance detected.
Found 10 outliers among 100 measurements (10.00%)
2 (2.00%) high mild
8 (8.00%) high severe
Parallel Permutation 6/N=16
time:   [22.281 µs 22.462 µs 22.839 µs]
thrpt:  [64.139 MiB/s 65.213 MiB/s 65.745 MiB/s]
change:
time:   [−0.0500% +0.5183% +1.1710%] (p = 0.14 > 0.05)
thrpt:  [−1.1574% −0.5156% +0.0500%]
No change in performance detected.
Found 2 outliers among 100 measurements (2.00%)
2 (2.00%) high severe
Parallel Permutation 6/N=32
time:   [46.704 µs 47.196 µs 47.868 µs]
thrpt:  [61.204 MiB/s 62.075 MiB/s 62.729 MiB/s]
change:
time:   [−3.5693% +7.6817% +18.480%] (p = 0.16 > 0.05)
thrpt:  [−15.597% −7.1337% +3.7014%]
No change in performance detected.
Found 10 outliers among 100 measurements (10.00%)
7 (7.00%) high mild
3 (3.00%) high severe
Parallel Permutation 6/N=64
time:   [77.127 µs 77.558 µs 78.497 µs]
thrpt:  [74.644 MiB/s 75.548 MiB/s 75.971 MiB/s]
change:
time:   [+8.5941% +9.1896% +10.178%] (p = 0.00 < 0.05)
thrpt:  [−9.2381% −8.4161% −7.9140%]
Performance has regressed.
Found 11 outliers among 100 measurements (11.00%)
1 (1.00%) low severe
6 (6.00%) low mild
2 (2.00%) high mild
2 (2.00%) high severe
Parallel Permutation 6/N=128
time:   [151.56 µs 153.32 µs 156.36 µs]
thrpt:  [74.947 MiB/s 76.434 MiB/s 77.321 MiB/s]
change:
time:   [−15.153% −4.3106% +6.7489%] (p = 0.50 > 0.05)
thrpt:  [−6.3222% +4.5047% +17.859%]
No change in performance detected.
Found 2 outliers among 100 measurements (2.00%)
1 (1.00%) high mild
1 (1.00%) high severe
Parallel Permutation 6/N=256
time:   [302.66 µs 307.18 µs 314.55 µs]
thrpt:  [74.510 MiB/s 76.300 MiB/s 77.437 MiB/s]
change:
time:   [+9.7996% +17.086% +23.467%] (p = 0.00 < 0.05)
thrpt:  [−19.006% −14.592% −8.9250%]
Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
2 (2.00%) high mild

Benchmarking Hash 4/SingleDigest: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 10.6s, or reduce sample count to 40.
Hash 4/SingleDigest     time:   [104.92 ms 105.67 ms 106.89 ms]
thrpt:  [9.3553 MiB/s 9.4632 MiB/s 9.5312 MiB/s]
change:
time:   [−0.6217% +0.8143% +2.2627%] (p = 0.30 > 0.05)
thrpt:  [−2.2127% −0.8077% +0.6255%]
No change in performance detected.
Found 9 outliers among 100 measurements (9.00%)
4 (4.00%) high mild
5 (5.00%) high severe
Hash 4/MultiDigest      time:   [24.366 ms 24.682 ms 25.086 ms]
thrpt:  [39.862 MiB/s 40.516 MiB/s 41.042 MiB/s]
change:
time:   [+4.5156% +7.0489% +9.4734%] (p = 0.00 < 0.05)
thrpt:  [−8.6536% −6.5847% −4.3205%]
Performance has regressed.
Found 6 outliers among 100 measurements (6.00%)
3 (3.00%) high mild
3 (3.00%) high severe
Hash 4/ParallelMultiDigest
time:   [29.631 ms 31.631 ms 33.889 ms]
thrpt:  [29.508 MiB/s 31.615 MiB/s 33.748 MiB/s]
change:
time:   [+24.346% +33.460% +43.320%] (p = 0.00 < 0.05)
thrpt:  [−30.226% −25.071% −19.580%]
Performance has regressed.
Found 5 outliers among 100 measurements (5.00%)
3 (3.00%) high mild
2 (2.00%) high severe

Benchmarking Hash 6/SingleDigest: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 15.0s, or reduce sample count to 30.
Hash 6/SingleDigest     time:   [132.38 ms 133.46 ms 134.77 ms]
thrpt:  [7.4201 MiB/s 7.4926 MiB/s 7.5543 MiB/s]
change:
time:   [+21.756% +24.234% +26.421%] (p = 0.00 < 0.05)
thrpt:  [−20.899% −19.506% −17.869%]
Performance has regressed.
Found 6 outliers among 100 measurements (6.00%)
4 (4.00%) high mild
2 (2.00%) high severe
Benchmarking Hash 6/MultiDigest: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 7.2s, or reduce sample count to 60.
Hash 6/MultiDigest      time:   [54.197 ms 54.670 ms 55.245 ms]
thrpt:  [18.101 MiB/s 18.292 MiB/s 18.451 MiB/s]
change:
time:   [+30.561% +34.703% +37.621%] (p = 0.00 < 0.05)
thrpt:  [−27.337% −25.763% −23.407%]
Performance has regressed.
Found 3 outliers among 100 measurements (3.00%)
2 (2.00%) high mild
1 (1.00%) high severe
Benchmarking Hash 6/ParallelMultiDigest: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.7s, or reduce sample count to 80.
Hash 6/ParallelMultiDigest
time:   [54.822 ms 55.508 ms 56.582 ms]
thrpt:  [17.673 MiB/s 18.015 MiB/s 18.241 MiB/s]
change:
time:   [+2.8487% +10.090% +17.763%] (p = 0.00 < 0.05)
thrpt:  [−15.083% −9.1652% −2.7698%]
Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
2 (2.00%) high severe