### PR TITLE
Fix zklogin populate_base64_jwt_signature

### DIFF
--- a/crates/frontend/src/circuits/concat.rs
+++ b/crates/frontend/src/circuits/concat.rs
@@ -727,7 +727,7 @@ mod tests {
 			for len in lengths {
 				let data_bytes = vec![0x55u8; len << 3]; // Repeated pattern
 				let mut wrong_data = data_bytes.clone();
-				wrong_data[len << 3 - 1] = 0xAA; // Change last byte
+				wrong_data[(len << 3) - 1] = 0xAA; // Change last byte
 
 				let term_specs = vec![(data_bytes.clone(), len)];
 

--- a/crates/frontend/src/circuits/rs256.rs
+++ b/crates/frontend/src/circuits/rs256.rs
@@ -506,7 +506,7 @@ mod tests {
 		rng.try_fill_bytes(&mut message_bytes).unwrap();
 
 		// Sign with PKCS1v15 padding scheme
-		let digest = Sha256::digest(&message_bytes);
+		let digest = Sha256::digest(message_bytes);
 		let signature_bytes = private_key
 			.sign(rsa::Pkcs1v15Sign::new::<Sha256>(), &digest)
 			.expect("failed to sign");

--- a/crates/frontend/src/circuits/zklogin.rs
+++ b/crates/frontend/src/circuits/zklogin.rs
@@ -401,7 +401,7 @@ impl ZkLogin {
 
 	pub fn populate_base64_jwt_signature(&self, w: &mut WitnessFiller, bytes: &[u8]) {
 		let mut padded = bytes.to_vec();
-		let expected_len = (self.jwt_signature.data.len() / 3) * 4; // 264/3*4 = 352
+		let expected_len = ((self.jwt_signature.data.len() * 8) / 3) * 4; // (264 bytes / 3) * 4 = 352
 		padded.resize(expected_len, 0);
 		self.base64_jwt_signature.populate_bytes_le(w, &padded);
 	}


### PR DESCRIPTION
The base64 encoded jwt_signature must be padded because of alignment
requirements in the base64 circuit.

To compute the total number of bytes in the unpadded jwt_signature_data
we must use `self.jwt_signature.data.len() * 8` instead of
`self.jwt_signature.data.len()` as `self.jwt_signature.data.len()` is
the number of 64bit packed wires.