### PR TITLE
massive one-shot PR for MSB-bool fix

### DIFF
--- a/crates/core/src/word.rs
+++ b/crates/core/src/word.rs
@@ -11,6 +11,7 @@ impl Word {
 	pub const ONE: Word = Word(1);
 	pub const ALL_ONE: Word = Word(u64::MAX);
 	pub const MASK_32: Word = Word(0x00000000_FFFFFFFF);
+	pub const MSB_ONE: Word = Word(0x80000000_00000000);
 }
 
 impl fmt::Debug for Word {

--- a/crates/examples/examples/ethsign.rs
+++ b/crates/examples/examples/ethsign.rs
@@ -49,7 +49,7 @@ impl ExampleCircuit for EthSignExample {
 		let max_msg_len_bytes = params.max_msg_len_bytes as usize;
 		let signatures = (0..params.n_signatures)
 			.map(|_| {
-				let msg_len = builder.add_inout();
+				let len_bytes = builder.add_inout();
 				let message = (0..params.max_msg_len_bytes.div_ceil(8))
 					.map(|_| builder.add_inout())
 					.collect::<Vec<_>>();
@@ -59,13 +59,7 @@ impl ExampleCircuit for EthSignExample {
 				let address = array::from_fn(|_| builder.add_inout());
 
 				let msg_final_state = array::from_fn(|_| builder.add_witness());
-				let msg_keccak = Keccak::new(
-					builder,
-					max_msg_len_bytes,
-					msg_len,
-					msg_final_state,
-					message.clone(),
-				);
+				let msg_keccak = Keccak::new(builder, len_bytes, msg_final_state, message.clone());
 
 				// The Keccak digest is little endian encoded into 4 words, while Ethereum expects
 				// big endian
@@ -87,7 +81,7 @@ impl ExampleCircuit for EthSignExample {
 				);
 
 				// Check that public key is not a point-at-infinity
-				builder.assert_0("recovered_pk_not_pai", public_key.is_point_at_infinity);
+				builder.assert_false("recovered_pk_not_pai", public_key.is_point_at_infinity);
 
 				// Concatenate x & y in _big_ endian, hash the result to obtain the address
 				let mut public_key_limbs = Vec::with_capacity(8);
@@ -103,7 +97,6 @@ impl ExampleCircuit for EthSignExample {
 				let address_final_state = array::from_fn(|_| builder.add_witness());
 				let address_keccak = Keccak::new(
 					builder,
-					64,
 					builder.add_constant_64(64),
 					address_final_state,
 					public_key_message,
@@ -148,8 +141,8 @@ impl ExampleCircuit for EthSignExample {
 			let secret_key = SecretKey::from_raw(&sk_bytes)?;
 
 			// Random message
-			let msg_len = rng.random_range(1..=self.max_msg_len_bytes);
-			let msg_bytes = (0..msg_len).map(|_| rng.random()).collect::<Vec<u8>>();
+			let len_bytes = rng.random_range(1..=self.max_msg_len_bytes);
+			let msg_bytes = (0..len_bytes).map(|_| rng.random()).collect::<Vec<u8>>();
 			let msg_hash = keccak256(&msg_bytes);
 
 			// Sign the message with ECDSA
@@ -157,7 +150,7 @@ impl ExampleCircuit for EthSignExample {
 			let public = secret_key.public();
 
 			// Hash the message with Keccak
-			msg_keccak.populate_len(w, msg_len);
+			msg_keccak.populate_len_bytes(w, len_bytes);
 			msg_keccak.populate_message(w, &msg_bytes);
 			msg_keccak.populate_digest(w, msg_hash);
 
@@ -179,7 +172,7 @@ impl ExampleCircuit for EthSignExample {
 			let pk_bytes = public.bytes();
 			let pk_hash = keccak256(pk_bytes);
 
-			address_keccak.populate_len(w, 64);
+			address_keccak.populate_len_bytes(w, 64);
 			address_keccak.populate_message(w, pk_bytes);
 			address_keccak.populate_digest(w, pk_hash);
 
@@ -191,7 +184,7 @@ impl ExampleCircuit for EthSignExample {
 }
 
 fn assert_address_eq(b: &CircuitBuilder, digest: &[Wire], address: &[Wire]) {
-	assert_eq!(digest.len(), 25);
+	assert_eq!(digest.len(), 4);
 	assert_eq!(address.len(), 3);
 
 	let bytes_12_20 = b.bxor(b.shr(digest[1], 32), b.shl(digest[2], 32));

--- a/crates/examples/examples/sha256.rs
+++ b/crates/examples/examples/sha256.rs
@@ -70,7 +70,8 @@ impl ExampleCircuit for Sha256Example {
 		let digest = sha2::Sha256::digest(&message_bytes);
 
 		// Populate the input message for the hash function.
-		self.sha256_gadget.populate_len(w, message_bytes.len());
+		self.sha256_gadget
+			.populate_len_bytes(w, message_bytes.len());
 		self.sha256_gadget.populate_message(w, &message_bytes);
 		self.sha256_gadget.populate_digest(w, digest.into());
 

--- a/crates/examples/examples/sha512.rs
+++ b/crates/examples/examples/sha512.rs
@@ -70,7 +70,8 @@ impl ExampleCircuit for Sha512Example {
 		let digest = sha2::Sha512::digest(&message_bytes);
 
 		// Populate the input message for the hash function.
-		self.sha512_gadget.populate_len(w, message_bytes.len());
+		self.sha512_gadget
+			.populate_len_bytes(w, message_bytes.len());
 		self.sha512_gadget.populate_message(w, &message_bytes);
 		self.sha512_gadget.populate_digest(w, digest.into());
 

--- a/crates/examples/examples/zklogin.rs
+++ b/crates/examples/examples/zklogin.rs
@@ -186,15 +186,15 @@ impl ExampleCircuit for ZkLoginExample {
 
 		// Populate JWS signature verification data
 		let message_str = format!("{header_base64}.{payload_base64}");
-		let message = message_str.as_bytes();
-		let hash = Sha256::digest(message);
+		let message_bytes = message_str.as_bytes();
+		let hash = Sha256::digest(message_bytes);
 		self.zklogin.populate_rsa_modulus(w, &modulus_bytes);
 		self.zklogin
 			.jwt_signature_verify
-			.populate_message_len(w, message.len());
+			.populate_len_bytes(w, message_bytes.len());
 		self.zklogin
 			.jwt_signature_verify
-			.populate_message(w, message);
+			.populate_message(w, message_bytes);
 		self.zklogin
 			.jwt_signature_verify
 			.sha256

--- a/crates/examples/snapshots/ethsign.snap
+++ b/crates/examples/snapshots/ethsign.snap
@@ -1,11 +1,11 @@
 ethsign circuit
 --
-Number of gates: 477869
-Number of evaluation instructions: 618078
-Number of AND constraints: 667664
+Number of gates: 473496
+Number of evaluation instructions: 561779
+Number of AND constraints: 607911
 Number of MUL constraints: 48852
 Length of value vec: 1048576
   Constants: 74
   Inout: 29
-  Witness: 29437
-  Internal: 888563
+  Witness: 42
+  Internal: 887330

--- a/crates/examples/snapshots/sha256.snap
+++ b/crates/examples/snapshots/sha256.snap
@@ -1,11 +1,11 @@
 sha256 circuit
 --
-Number of gates: 74994
-Number of evaluation instructions: 76223
-Number of AND constraints: 95397
+Number of gates: 74992
+Number of evaluation instructions: 76699
+Number of AND constraints: 94809
 Number of MUL constraints: 0
 Length of value vec: 131072
-  Constants: 341
+  Constants: 342
   Inout: 260
-  Witness: 570
-  Internal: 94269
+  Witness: 529
+  Internal: 93763

--- a/crates/examples/snapshots/sha512.snap
+++ b/crates/examples/snapshots/sha512.snap
@@ -1,11 +1,11 @@
 sha512 circuit
 --
-Number of gates: 48818
-Number of evaluation instructions: 50031
-Number of AND constraints: 62341
+Number of gates: 48816
+Number of evaluation instructions: 49995
+Number of AND constraints: 61753
 Number of MUL constraints: 0
 Length of value vec: 131072
   Constants: 365
   Inout: 264
-  Witness: 298
-  Internal: 74659
+  Witness: 273
+  Internal: 74122

--- a/crates/examples/snapshots/zklogin.snap
+++ b/crates/examples/snapshots/zklogin.snap
@@ -1,11 +1,11 @@
 zklogin circuit
 --
-Number of gates: 627589
-Number of evaluation instructions: 955190
-Number of AND constraints: 847091
+Number of gates: 467261
+Number of evaluation instructions: 554981
+Number of AND constraints: 581928
 Number of MUL constraints: 26880
 Length of value vec: 1048576
-  Constants: 624
+  Constants: 696
   Inout: 302
-  Witness: 95783
-  Internal: 879686
+  Witness: 1790
+  Internal: 733563

--- a/crates/frontend/src/circuits/base64.rs
+++ b/crates/frontend/src/circuits/base64.rs
@@ -38,9 +38,7 @@ pub struct Base64UrlSafe {
 	/// Encoded base64 array (packed 8 chars per word).
 	pub encoded: Vec<Wire>,
 	/// Actual length of decoded data in bytes.
-	pub len_decoded: Wire,
-	/// Maximum supported decoded data length in bytes (must be a multiple of 24).
-	pub max_len_decoded: usize,
+	pub len_bytes: Wire,
 }
 
 impl Base64UrlSafe {
@@ -49,67 +47,53 @@ impl Base64UrlSafe {
 	/// # Arguments
 	///
 	/// * `builder` - Circuit builder for constructing constraints
-	/// * `max_len_decoded` - Maximum supported decoded data length in bytes (must be a multiple of
-	///   24)
-	/// * `decoded` - Decoded byte array wires (must have length = max_len_decoded/8)
-	/// * `encoded` - Base64 encoded array wires (must have length = max_len_decoded/6)
-	/// * `len_decoded` - Wire containing actual length of decoded data in bytes
+	/// * `decoded` - raw byte array wires
+	/// * `encoded` - Base64 encoded array wires
+	/// * `len_bytes` - Wire containing actual length of raw data in bytes
 	///
 	/// # Panics
 	///
-	/// * If `max_len_decoded` is not a multiple of 24
-	/// * If `decoded.len()` != max_len_decoded/8
-	/// * If `encoded.len()` != max_len_decoded/6
+	/// * If `decoded.len()` is not a multiple of 3
 	///
 	/// # Implementation Notes
 	///
-	/// The requirement that `max_len_decoded` be a multiple of 24 ensures:
+	/// The requirement that `decoded.len()` be a multiple of 3 ensures:
 	/// - Word alignment: divisible by 8 for packing bytes into 64-bit words
 	/// - Base64 group alignment: divisible by 3 for processing complete groups
 	/// - Exact array sizing with no rounding needed
 	pub fn new(
 		builder: &CircuitBuilder,
-		max_len_decoded: usize,
 		decoded: Vec<Wire>,
 		encoded: Vec<Wire>,
-		len_decoded: Wire,
+		len_bytes: Wire,
 	) -> Self {
-		// Ensure max_len_decoded is a multiple of 24 (LCM of 8 and 3)
 		assert!(
-			max_len_decoded.is_multiple_of(24),
-			"max_len_decoded must be a multiple of 24, got {max_len_decoded}"
+			decoded.len().is_multiple_of(3),
+			"decoded.len() must be a multiple of 3, got {}",
+			decoded.len()
 		);
 
-		let expected_decoded_words = max_len_decoded / 8;
-		let expected_encoded_words = max_len_decoded / 6;
-
-		assert_eq!(
-			decoded.len(),
-			expected_decoded_words,
-			"decoded.len() must equal max_len_decoded/8"
-		);
 		assert_eq!(
 			encoded.len(),
-			expected_encoded_words,
-			"encoded.len() must equal max_len_decoded/6"
+			decoded.len() / 3 * 4,
+			"encoded.len() must equal decoded.len() / 3 * 4"
 		);
 
-		// Verify length bounds (use original max_len_decoded for user-specified limit)
-		verify_length_bounds(builder, len_decoded, max_len_decoded);
+		// Verify length bounds
+		verify_length_bounds(builder, len_bytes, decoded.len() << 3);
 
 		// Process groups of 3 bytes -> 4 base64 chars
-		let groups = max_len_decoded / 3;
+		let groups = (decoded.len() << 3) / 3; // how many 3-byte chunks are there?
 
 		for group_idx in 0..groups {
 			let b = builder.subcircuit(format!("group[{group_idx}]"));
-			verify_base64_group(&b, &decoded, &encoded, len_decoded, group_idx);
+			verify_base64_group(&b, &decoded, &encoded, len_bytes, group_idx);
 		}
 
 		Self {
 			decoded,
 			encoded,
-			len_decoded,
-			max_len_decoded,
+			len_bytes,
 		}
 	}
 
@@ -119,8 +103,8 @@ impl Base64UrlSafe {
 	///
 	/// * `w` - Witness filler to populate
 	/// * `length` - Actual length of decoded data in bytes
-	pub fn populate_len_decoded(&self, w: &mut WitnessFiller, length: usize) {
-		w[self.len_decoded] = Word(length as u64);
+	pub fn populate_len_bytes(&self, w: &mut WitnessFiller, len_bytes: usize) {
+		w[self.len_bytes] = Word(len_bytes as u64);
 	}
 
 	/// Populates the decoded data array from a byte slice.
@@ -153,15 +137,11 @@ impl Base64UrlSafe {
 }
 
 /// Verifies that the length is within bounds (0 < len_decoded <= max_len_decoded).
-fn verify_length_bounds(builder: &CircuitBuilder, len_decoded: Wire, max_len_decoded: usize) {
-	let max_len_const = builder.add_constant_64(max_len_decoded as u64);
-
+fn verify_length_bounds(builder: &CircuitBuilder, len_bytes: Wire, max_len_bytes: usize) {
 	// Check if len_decoded > max_len_decoded (which should be false)
 	// len_decoded > max_len_decoded is equivalent to max_len_decoded < len_decoded
-	let too_large = builder.icmp_ult(max_len_const, len_decoded);
-
-	// Assert too_large == 0
-	builder.assert_0("length_check", too_large);
+	let too_long = builder.icmp_ult(builder.add_constant_64(max_len_bytes as u64), len_bytes);
+	builder.assert_false("length_check", too_long);
 }
 
 /// Verifies a single base64 group (3 decoded bytes -> 4 base64 chars).
@@ -178,29 +158,27 @@ fn verify_base64_group(
 	builder: &CircuitBuilder,
 	decoded: &[Wire],
 	encoded: &[Wire],
-	len_decoded: Wire,
+	len_bytes: Wire,
 	group_idx: usize,
 ) {
 	let char_lookup_table = build_base64_char_lookup_table(builder);
 	let base_byte_idx = group_idx * 3;
-
-	// Check if this group is within actual length
-	let group_start = builder.add_constant_64(base_byte_idx as u64);
-	let is_active = builder.icmp_ult(group_start, len_decoded);
+	let base_char_idx = group_idx * 4;
 
 	// Extract 3 decoded bytes
 	let byte0 = extract_byte(builder, decoded, base_byte_idx);
 	let byte1 = extract_byte(builder, decoded, base_byte_idx + 1);
 	let byte2 = extract_byte(builder, decoded, base_byte_idx + 2);
 
-	// Extract 4 base64 characters
-	let char0 = extract_byte(builder, encoded, group_idx * 4);
-	let char1 = extract_byte(builder, encoded, group_idx * 4 + 1);
-	let char2 = extract_byte(builder, encoded, group_idx * 4 + 2);
-	let char3 = extract_byte(builder, encoded, group_idx * 4 + 3);
-
-	// Compute bytes in this group for padding handling
-	let bytes_in_group = compute_bytes_in_group(builder, len_decoded, base_byte_idx);
+	let has_1_byte = builder.icmp_ult(builder.add_constant_64(base_byte_idx as u64), len_bytes);
+	let has_2_bytes =
+		builder.icmp_ult(builder.add_constant_64((base_byte_idx + 1) as u64), len_bytes);
+	let has_3_bytes =
+		builder.icmp_ult(builder.add_constant_64((base_byte_idx + 2) as u64), len_bytes);
+	let zero = builder.add_constant(Word::ZERO);
+	builder.assert_eq_cond("past boundary should be empty", byte0, zero, builder.bnot(has_1_byte));
+	builder.assert_eq_cond("past boundary should be empty", byte1, zero, builder.bnot(has_2_bytes));
+	builder.assert_eq_cond("past boundary should be empty", byte2, zero, builder.bnot(has_3_bytes));
 
 	// Convert 3 bytes to 4 6-bit values
 	let val0 = extract_6bit_value_0(builder, byte0);
@@ -209,32 +187,21 @@ fn verify_base64_group(
 	let val3 = extract_6bit_value_3(builder, byte2);
 
 	// Convert 6-bit values to base64 encoded chars
-	let encoded_char0 = compute_expected_base64_char(builder, val0, &char_lookup_table);
-	let encoded_char1 = compute_expected_base64_char(builder, val1, &char_lookup_table);
-	let encoded_char2 = compute_expected_base64_char(builder, val2, &char_lookup_table);
-	let encoded_char3 = compute_expected_base64_char(builder, val3, &char_lookup_table);
+	let expected_char0 = compute_expected_base64_char(builder, val0, &char_lookup_table);
+	let expected_char1 = compute_expected_base64_char(builder, val1, &char_lookup_table);
+	let expected_char2 = compute_expected_base64_char(builder, val2, &char_lookup_table);
+	let expected_char3 = compute_expected_base64_char(builder, val3, &char_lookup_table);
 
-	// Verify character mappings
-	verify_base64_char(builder, encoded_char0, char0, is_active);
+	// Extract 4 base64 characters
+	let actual_char0 = extract_byte(builder, encoded, base_char_idx);
+	let actual_char1 = extract_byte(builder, encoded, base_char_idx + 1);
+	let actual_char2 = extract_byte(builder, encoded, base_char_idx + 2);
+	let actual_char3 = extract_byte(builder, encoded, base_char_idx + 3);
 
-	// has_byte1 = bytes_in_group > 0 is equivalent to 0 < bytes_in_group
-	let has_byte1 = builder.icmp_ult(builder.add_constant_64(0), bytes_in_group);
-	let check_char1 = builder.band(is_active, has_byte1);
-	verify_base64_char(builder, encoded_char1, char1, check_char1);
-
-	// has_byte2 = bytes_in_group > 1 is equivalent to 1 < bytes_in_group
-	let has_byte2 = builder.icmp_ult(builder.add_constant_64(1), bytes_in_group);
-
-	// has_byte3 = bytes_in_group > 2 is equivalent to 2 < bytes_in_group
-	let has_byte3 = builder.icmp_ult(builder.add_constant_64(2), bytes_in_group);
-
-	// For char2: encode if we have more than 1 byte (i.e., at least 2 bytes)
-	let should_encode_char2 = has_byte2;
-	verify_base64_char_or_zero(builder, encoded_char2, char2, is_active, should_encode_char2);
-
-	// For char3: encode if we have more than 2 bytes (i.e., all 3 bytes)
-	let should_encode_char3 = has_byte3;
-	verify_base64_char_or_zero(builder, encoded_char3, char3, is_active, should_encode_char3);
+	verify_base64_char(builder, expected_char0, actual_char0, has_1_byte);
+	verify_base64_char(builder, expected_char1, actual_char1, has_1_byte);
+	verify_base64_char(builder, expected_char2, actual_char2, has_2_bytes);
+	verify_base64_char(builder, expected_char3, actual_char3, has_3_bytes);
 }
 
 /// Extracts a byte from a word array at the given byte index.
@@ -252,93 +219,25 @@ fn extract_byte(builder: &CircuitBuilder, words: &[Wire], byte_idx: usize) -> Wi
 	let word_idx = byte_idx / 8;
 	let byte_offset = byte_idx % 8;
 
-	if word_idx >= words.len() {
-		// Return zero for out of bounds
-		return builder.add_constant_64(0);
-	}
-
 	let word = words[word_idx];
 	builder.extract_byte(word, byte_offset as u32)
 }
 
-/// Computes the number of valid bytes in a base64 group.
-///
-/// # Returns
-///
-/// Wire containing min(3, len_decoded - base_byte_idx)
-fn compute_bytes_in_group(
-	builder: &CircuitBuilder,
-	len_decoded: Wire,
-	base_byte_idx: usize,
-) -> Wire {
-	// For simplicity, we'll handle the common cases directly
-	// Since we process groups of 3, we need to check:
-	// - If base_byte_idx >= length: return 0
-	// - If base_byte_idx + 1 >= length: return 1
-	// - If base_byte_idx + 2 >= length: return 2
-	// - Otherwise: return 3
-
-	let base_idx = builder.add_constant_64(base_byte_idx as u64);
-	let base_idx_plus_1 = builder.add_constant_64((base_byte_idx + 1) as u64);
-	let base_idx_plus_2 = builder.add_constant_64((base_byte_idx + 2) as u64);
-
-	let zero = builder.add_constant_64(0);
-	let one = builder.add_constant_64(1);
-	let two = builder.add_constant_64(2);
-	let three = builder.add_constant_64(3);
-
-	// Check if base_idx < len_decoded (group has at least 1 byte)
-	let has_byte0 = builder.icmp_ult(base_idx, len_decoded);
-
-	// Check if base_idx + 1 < len_decoded (group has at least 2 bytes)
-	let has_byte1 = builder.icmp_ult(base_idx_plus_1, len_decoded);
-
-	// Check if base_idx + 2 < len_decoded (group has all 3 bytes)
-	let has_byte2 = builder.icmp_ult(base_idx_plus_2, len_decoded);
-
-	// Build result based on which bytes we have
-	// If has_byte2: return 3
-	// Else if has_byte1: return 2
-	// Else if has_byte0: return 1
-	// Else: return 0
-
-	// Select between 2 and 3 based on has_byte2
-	let two_or_three =
-		builder.bor(builder.band(has_byte2, three), builder.band(builder.bnot(has_byte2), two));
-
-	// Select between 0 and 1 based on has_byte0
-	let zero_or_one =
-		builder.bor(builder.band(has_byte0, one), builder.band(builder.bnot(has_byte0), zero));
-
-	// Select between (0 or 1) and (2 or 3) based on has_byte1
-	builder.bor(
-		builder.band(has_byte1, two_or_three),
-		builder.band(builder.bnot(has_byte1), zero_or_one),
-	)
-}
-
 /// Extracts the first 6-bit value (top 6 bits of byte0).
 fn extract_6bit_value_0(builder: &CircuitBuilder, byte0: Wire) -> Wire {
-	let val0 = builder.shr(byte0, 2);
-	builder.band(val0, builder.add_constant_64(0x3F))
+	builder.shr(byte0, 2)
 }
 
 /// Extracts the second 6-bit value (bottom 2 bits of byte0 + top 4 bits of byte1).
 fn extract_6bit_value_1(builder: &CircuitBuilder, byte0: Wire, byte1: Wire) -> Wire {
 	let byte0_low = builder.band(byte0, builder.add_constant_64(0x03));
-	let byte0_low_shifted = builder.shl(byte0_low, 4);
-	let byte1_high = builder.shr(byte1, 4);
-	let byte1_high = builder.band(byte1_high, builder.add_constant_64(0x0F));
-	builder.bor(byte0_low_shifted, byte1_high)
+	builder.bxor(builder.shl(byte0_low, 4), builder.shr(byte1, 4))
 }
 
 /// Extracts the third 6-bit value (bottom 4 bits of byte1 + top 2 bits of byte2).
 fn extract_6bit_value_2(builder: &CircuitBuilder, byte1: Wire, byte2: Wire) -> Wire {
 	let byte1_low = builder.band(byte1, builder.add_constant_64(0x0F));
-	let byte1_low_shifted = builder.shl(byte1_low, 2);
-	let byte2_high = builder.shr(byte2, 6);
-	let byte2_high = builder.band(byte2_high, builder.add_constant_64(0x03));
-	builder.bor(byte1_low_shifted, byte2_high)
+	builder.bxor(builder.shl(byte1_low, 2), builder.shr(byte2, 6))
 }
 
 /// Extracts the fourth 6-bit value (bottom 6 bits of byte2).
@@ -357,57 +256,14 @@ fn extract_6bit_value_3(builder: &CircuitBuilder, byte2: Wire) -> Wire {
 fn verify_base64_char(
 	builder: &CircuitBuilder,
 	expected_encoded_char: Wire,
-	char_val: Wire,
+	actual_encoded_char: Wire,
 	is_active: Wire,
 ) {
-	// Check if char_val == expected_char
-	let eq = builder.icmp_eq(char_val, expected_encoded_char);
-
-	// Only enforce if active: valid = !is_active | eq
-	let not_active = builder.bnot(is_active);
-	let valid = builder.bor(not_active, eq);
-
-	// Assert valid == all ones
-	let all_ones = builder.add_constant_64(u64::MAX);
-	builder.assert_eq("base64_char", valid, all_ones);
-}
-
-/// Verifies that a base64 character is either valid encoding or zero padding.
-///
-/// # Arguments
-///
-/// * `builder` - Circuit builder
-/// * `expected_encoded_char` - The expected encoding of the character
-/// * `char_val` - The actual character value found
-/// * `is_active` - Whether this group is active
-/// * `should_encode` - Whether this position should contain encoded data (vs zero padding)
-fn verify_base64_char_or_zero(
-	builder: &CircuitBuilder,
-	expected_encoded_char: Wire,
-	char_val: Wire,
-	is_active: Wire,
-	should_encode: Wire,
-) {
-	let zero = builder.add_constant(Word::ZERO);
-	let is_zero_padding = builder.icmp_eq(char_val, zero);
-
-	// If should_encode, verify normal base64 char
-	let is_valid_char = builder.icmp_eq(char_val, expected_encoded_char);
-
-	// valid = (should_encode & is_valid_char) | (!should_encode & is_padding)
-	let not_should_encode = builder.bnot(should_encode);
-
-	let case1 = builder.band(should_encode, is_valid_char);
-	let case2 = builder.band(not_should_encode, is_zero_padding);
-	let valid_encoding = builder.bor(case1, case2);
-
-	// Only enforce if active: valid = !is_active | valid_encoding
-	let not_active = builder.bnot(is_active);
-	let valid = builder.bor(not_active, valid_encoding);
-
-	// Assert valid == all ones
-	let all_ones = builder.add_constant_64(u64::MAX);
-	builder.assert_eq("base64_zero_padding", valid, all_ones);
+	builder.assert_eq(
+		"base64_char",
+		actual_encoded_char,
+		builder.select(is_active, expected_encoded_char, builder.add_constant(Word::ZERO)),
+	);
 }
 
 /// Builds a character lookup table for base64 URL-safe encoding.
@@ -488,22 +344,22 @@ mod tests {
 	/// Helper to create base64 circuit with given max size.
 	fn create_base64_circuit(builder: &CircuitBuilder, max_len_decoded: usize) -> Base64UrlSafe {
 		// Create input wires
-		let decoded: Vec<Wire> = (0..max_len_decoded / 8)
-			.map(|_| builder.add_inout())
-			.collect();
+		assert!(
+			max_len_decoded.is_multiple_of(3),
+			"max_len_decoded must be a multiple of 3, got {max_len_decoded}"
+		);
+		let decoded: Vec<Wire> = (0..max_len_decoded).map(|_| builder.add_inout()).collect();
+		let max_len_encoded = (max_len_decoded / 3) * 4;
+		let encoded: Vec<Wire> = (0..max_len_encoded).map(|_| builder.add_inout()).collect();
 
-		let encoded: Vec<Wire> = (0..max_len_decoded / 6)
-			.map(|_| builder.add_inout())
-			.collect();
+		let len_bytes = builder.add_inout();
 
-		let len_decoded = builder.add_inout();
-
-		Base64UrlSafe::new(builder, max_len_decoded, decoded, encoded, len_decoded)
+		Base64UrlSafe::new(builder, decoded, encoded, len_bytes)
 	}
 
 	/// Core helper that tests base64 encoding verification and returns a Result.
 	fn check_base64_encoding(
-		input: &[u8],
+		input_bytes: &[u8],
 		encoded: &[u8],
 		max_len_decoded: usize,
 	) -> Result<(), Box<dyn std::error::Error>> {
@@ -514,8 +370,8 @@ mod tests {
 		// Create witness
 		let mut witness = compiled.new_witness_filler();
 
-		circuit.populate_len_decoded(&mut witness, input.len());
-		circuit.populate_decoded(&mut witness, input);
+		circuit.populate_len_bytes(&mut witness, input_bytes.len());
+		circuit.populate_decoded(&mut witness, input_bytes);
 		circuit.populate_encoded(&mut witness, encoded);
 
 		// Verify circuit
@@ -531,36 +387,36 @@ mod tests {
 	/// Helper to test base64 encoding verification with specified padding mode.
 	fn test_base64_encoding(input: &[u8], max_len_decoded: usize) {
 		let expected_base64 = encode_base64(input);
-		assert!(check_base64_encoding(input, &expected_base64, max_len_decoded).is_ok());
+		check_base64_encoding(input, &expected_base64, max_len_decoded).unwrap();
 	}
 
 	/// Assert that the base64 circuit fails to verify the specified inputs
 	fn assert_base64_failure(input: &[u8], encoded: &[u8], max_len_decoded: usize) {
-		assert!(check_base64_encoding(input, encoded, max_len_decoded).is_err());
+		check_base64_encoding(input, encoded, max_len_decoded).unwrap_err();
 	}
 
 	#[test]
 	fn test_base64_hello_world() {
-		test_base64_encoding(b"Hello World!", 1512);
+		test_base64_encoding(b"Hello World!", 189);
 	}
 
 	#[test]
 	fn test_base64_empty() {
-		test_base64_encoding(b"", 1512);
+		test_base64_encoding(b"", 189);
 	}
 
 	#[test]
 	fn test_base64_long_input() {
 		let input =
 			b"The quick brown fox jumps over the lazy dog. The quick brown fox jumps over the lazy dog.";
-		test_base64_encoding(input, 1512);
+		test_base64_encoding(input, 189);
 	}
 
 	#[test]
 	fn test_invalid_base64() {
 		let input = b"ABC";
 		let invalid_base64 = b"XXXX"; // Invalid base64 for "ABC"
-		assert_base64_failure(input, invalid_base64, 120);
+		assert_base64_failure(input, invalid_base64, 15);
 	}
 
 	#[test]
@@ -579,16 +435,16 @@ mod tests {
 		assert_eq!(expected2[0], b'_', "Index 63 should map to '_' not '/'");
 
 		// Now test with the circuit
-		test_base64_encoding(input1, 120);
-		test_base64_encoding(input2, 120);
+		test_base64_encoding(input1, 15);
+		test_base64_encoding(input2, 15);
 	}
 
 	#[test]
-	#[should_panic(expected = "max_len_decoded must be a multiple of 24")]
-	fn test_panic_when_max_len_not_multiple_of_24() {
-		// This test verifies that max_len_decoded must be a multiple of 24
-		// Testing with max_len_decoded = 100 which is not a multiple of 24
-		test_base64_encoding(b"test", 100);
+	#[should_panic(expected = "max_len_decoded must be a multiple of 3")]
+	fn test_panic_when_max_len_not_multiple_of_3() {
+		// This test verifies that max_len_decoded must be a multiple of 3
+		// Testing with max_len_decoded = 13 which is not a multiple of 3
+		test_base64_encoding(b"test", 13);
 	}
 
 	#[test]
@@ -596,6 +452,6 @@ mod tests {
 		let input = b"A";
 		let encoding_with_padding = b"QQ==";
 		// encoding with padding should be rejected
-		assert_base64_failure(input, encoding_with_padding, 120);
+		assert_base64_failure(input, encoding_with_padding, 15);
 	}
 }

--- a/crates/frontend/src/circuits/bignum/biguint.rs
+++ b/crates/frontend/src/circuits/bignum/biguint.rs
@@ -52,11 +52,11 @@ impl BigUint {
 		// TODO: it's more efficient to add all-1 BigUint and check carry out (jimpo)
 		//       do this once BigUint addition returning a Wire carry out exists
 		let zero = b.add_constant(Word::ZERO);
-		let all_one = b.add_constant(Word::ALL_ONE);
+		let msb_one = b.add_constant(Word::MSB_ONE);
 		self.limbs
 			.iter()
 			.map(|&limb| b.icmp_eq(limb, zero))
-			.fold(all_one, |lhs, rhs| b.band(lhs, rhs))
+			.fold(msb_one, |lhs, rhs| b.band(lhs, rhs))
 	}
 
 	/// Pads to given limb length with zeros.
@@ -133,7 +133,7 @@ pub fn assert_eq(builder: &CircuitBuilder, name: impl Into<String>, a: &BigUint,
 /// * `builder` - Circuit builder for constraint generation
 /// * `a` - First operand `BigUint`
 /// * `b` - Second operand `BigUint` (must have same number of limbs as `a`)
-/// * `mask` - a must equal b if mask is all-1, constraint is ignored if mask is all-0
+/// * `cond` - a must equal b if cond is msb-true; constraint is ignored if cond is msb-false
 ///
 /// # Panics
 /// Panics if `a` and `b` have different number of limbs.
@@ -142,7 +142,7 @@ pub fn assert_eq_cond(
 	name: impl Into<String>,
 	a: &BigUint,
 	b: &BigUint,
-	mask: Wire,
+	cond: Wire,
 ) {
 	assert_eq!(
 		a.limbs.len(),
@@ -151,7 +151,7 @@ pub fn assert_eq_cond(
 	);
 	let base_name = name.into();
 	for (i, (&a_l, &b_l)) in iter::zip(&a.limbs, &b.limbs).enumerate() {
-		builder.assert_eq_cond(format!("{base_name}[{i}]"), a_l, b_l, mask);
+		builder.assert_eq_cond(format!("{base_name}[{i}]"), a_l, b_l, cond);
 	}
 }
 

--- a/crates/frontend/src/circuits/bignum/prime_field.rs
+++ b/crates/frontend/src/circuits/bignum/prime_field.rs
@@ -110,8 +110,7 @@ impl PseudoMersennePrimeField {
 		let quotient = BigUint { limbs: quotient };
 		let remainder = BigUint { limbs: remainder }.pad_limbs_to(self.limbs_len(), zero);
 
-		// TODO: replace with assert_true once available
-		b.assert_0("remainder < modulus", b.bnot(biguint_lt(b, &remainder, &self.modulus)));
+		b.assert_true("remainder < modulus", biguint_lt(b, &remainder, &self.modulus));
 
 		// constraint: product == remainder + quotient * modulus
 		PseudoMersenneModReduce::new(
@@ -146,8 +145,7 @@ impl PseudoMersennePrimeField {
 
 		let product = mul(b, &inverse, fe);
 
-		// TODO: replace with assert_true once available
-		b.assert_0("inverse < modulus", b.bnot(biguint_lt(b, &inverse, &self.modulus)));
+		b.assert_true("inverse < modulus", biguint_lt(b, &inverse, &self.modulus));
 
 		// constraint: base * inverse = 1 + quotient * modulus
 		PseudoMersenneModReduce::new(

--- a/crates/frontend/src/circuits/bignum/reduce.rs
+++ b/crates/frontend/src/circuits/bignum/reduce.rs
@@ -156,7 +156,7 @@ impl PseudoMersenneModReduce {
 	}
 
 	/// Apply the reduction constraint conditionally based on the value of boolean `mask` wire.
-	pub fn constrain_cond(self, builder: &CircuitBuilder, mask: Wire) {
-		assert_eq_cond(builder, "modreduce_pseudo_mersenne", &self.lhs, &self.rhs, mask)
+	pub fn constrain_cond(self, builder: &CircuitBuilder, cond: Wire) {
+		assert_eq_cond(builder, "modred_pseudo_mersenne", &self.lhs, &self.rhs, cond)
 	}
 }

--- a/crates/frontend/src/circuits/bignum/tests.rs
+++ b/crates/frontend/src/circuits/bignum/tests.rs
@@ -314,11 +314,11 @@ proptest! {
 
 		let lt_flag_wire = w[lt_flag];
 		let lt_flag_big = from_u64_limbs(&a_vals) < from_u64_limbs(&b_vals);
-		assert!(lt_flag_big && lt_flag_wire == Word::ALL_ONE || !lt_flag_big && lt_flag_wire == Word::ZERO);
+		assert!(lt_flag_big == (lt_flag_wire >> 63 == Word::ONE));
 
 		let eq_flag_wire = w[eq_flag];
 		let eq_flag_big = from_u64_limbs(&a_vals) == from_u64_limbs(&b_vals);
-		assert!(eq_flag_big && eq_flag_wire == Word::ALL_ONE || !eq_flag_big && eq_flag_wire == Word::ZERO);
+		assert!(eq_flag_big == (eq_flag_wire >> 63 == Word::ONE));
 
 		verify_constraints(cs.constraint_system(), &w.into_value_vec()).unwrap();
 	}

--- a/crates/frontend/src/circuits/ecdsa/tests.rs
+++ b/crates/frontend/src/circuits/ecdsa/tests.rs
@@ -37,9 +37,9 @@ pub fn test_bitcoin_ecdsa_test_vector() {
 
 	let cs = builder.build();
 	let mut w = cs.new_witness_filler();
-	assert!(cs.populate_wire_witness(&mut w).is_ok());
+	cs.populate_wire_witness(&mut w).unwrap();
 
-	assert_eq!(w[signature_valid], Word::ALL_ONE);
+	assert_eq!(w[signature_valid] >> 63, Word::ONE);
 }
 
 #[test]

--- a/crates/frontend/src/circuits/fixed_byte_vec.rs
+++ b/crates/frontend/src/circuits/fixed_byte_vec.rs
@@ -11,46 +11,30 @@ use crate::{
 /// the maximum size of the vector to be a multiple of 8.
 #[derive(Clone)]
 pub struct FixedByteVec {
-	/// Maximum length of the vector in bytes.
-	pub max_len: usize,
 	/// Length of the vector in bytes.
-	pub len: Wire,
+	pub len_bytes: Wire,
 	pub data: Vec<Wire>,
 }
 
 impl FixedByteVec {
 	/// Creates a new fixed byte vector using the given wires and wire
 	/// containing the length of the data in bytes.
-	pub fn new(data: Vec<Wire>, len: Wire) -> Self {
-		Self {
-			max_len: data.len() * 8,
-			len,
-			data,
-		}
+	pub fn new(data: Vec<Wire>, len_bytes: Wire) -> Self {
+		Self { len_bytes, data }
 	}
 
 	/// Creates a new fixed byte vector with the given maximum length as inout wires.
-	///
-	/// # Panics
-	///
-	/// Panics if `max_len` is not a multiple of 8.
 	pub fn new_inout(b: &CircuitBuilder, max_len: usize) -> Self {
-		assert!(max_len.is_multiple_of(8), "max_len must be a multiple of 8");
-		let len = b.add_inout();
-		let data = (0..(max_len / 8)).map(|_| b.add_inout()).collect();
-		Self { max_len, len, data }
+		let len_bytes = b.add_inout();
+		let data = (0..max_len).map(|_| b.add_inout()).collect();
+		Self { len_bytes, data }
 	}
 
 	/// Creates a new fixed byte vector with the given maximum length as witness wires.
-	///
-	/// # Panics
-	///
-	/// Panics if `max_len` is not a multiple of 8.
 	pub fn new_witness(b: &CircuitBuilder, max_len: usize) -> Self {
-		assert!(max_len.is_multiple_of(8), "max_len must be a multiple of 8");
-		let len = b.add_inout();
-		let data = (0..(max_len / 8)).map(|_| b.add_witness()).collect();
-		Self { max_len, len, data }
+		let len_bytes = b.add_inout();
+		let data = (0..max_len).map(|_| b.add_witness()).collect();
+		Self { len_bytes, data }
 	}
 
 	/// Populate the FixedByteVec with bytes.
@@ -61,22 +45,19 @@ impl FixedByteVec {
 	/// * If bytes.len() exceeds self.max_len
 	pub fn populate_bytes_le(&self, w: &mut WitnessFiller, bytes: &[u8]) {
 		pack_bytes_into_wires_le(w, &self.data, bytes);
-		w[self.len] = Word(bytes.len() as u64);
+		w[self.len_bytes] = Word(bytes.len() as u64);
 	}
 
-	/// Construct a new FixedByteVec by truncating to `num_bytes`.
+	/// Construct a new FixedByteVec by truncating to `num_wires`.
 	///
 	/// # Panics
-	/// * If num_bytes exceeds self.max_len
-	/// * If num_bytes is not a multiple of 8
-	pub fn truncate(&self, b: &CircuitBuilder, num_bytes: usize) -> FixedByteVec {
-		assert!(num_bytes <= self.max_len, "num_bytes must be less than self.max_len");
-		assert!(num_bytes.is_multiple_of(8), "num_bytes must be a multiple of 8");
+	/// * If num_wires exceeds self.data.len()
+	pub fn truncate(&self, b: &CircuitBuilder, num_wires: usize) -> FixedByteVec {
+		assert!(num_wires <= self.data.len(), "num_wires must be less than self.data.len()");
 
-		let num_wires = num_bytes / 8;
 		let trimmed_wires = self.data[0..num_wires].to_vec();
-		let len_wire = b.add_constant_64(num_bytes as u64);
+		let len_bytes = b.add_constant_64((num_wires << 3) as u64);
 
-		FixedByteVec::new(trimmed_wires, len_wire)
+		FixedByteVec::new(trimmed_wires, len_bytes)
 	}
 }

--- a/crates/frontend/src/circuits/jwt_claims.rs
+++ b/crates/frontend/src/circuits/jwt_claims.rs
@@ -10,14 +10,14 @@ use crate::{
 pub struct Attribute {
 	pub name: &'static str,
 	/// The actual length of the expected value in bytes.
-	pub len_value: Wire,
+	pub len_bytes: Wire,
 	pub value: Vec<Wire>,
 }
 
 impl Attribute {
 	/// Populate the actual value length
-	pub fn populate_len_value(&self, w: &mut WitnessFiller, len_value: usize) {
-		w[self.len_value] = Word(len_value as u64);
+	pub fn populate_len_bytes(&self, w: &mut WitnessFiller, len_bytes: usize) {
+		w[self.len_bytes] = Word(len_bytes as u64);
 	}
 
 	/// Populate the expected value from bytes
@@ -47,7 +47,7 @@ impl Attribute {
 /// other. A prover can get away with providing the attribute "sub" but the end quote of the nonce.
 pub struct JwtClaims {
 	/// The actual length of the JSON string in bytes.
-	pub len_json: Wire,
+	pub len_bytes: Wire,
 	pub json: Vec<Wire>,
 	pub attributes: Vec<Attribute>,
 }
@@ -57,29 +57,22 @@ impl JwtClaims {
 	///
 	/// # Arguments
 	/// * `b` - Circuit builder
-	/// * `max_len_json` - Maximum JSON size in bytes (must be multiple of 8)
-	/// * `len_json` - Wire for actual JSON size in bytes
+	/// * `len_bytes` - Wire for actual JSON size in bytes
 	/// * `json` - JSON input array packed as words (8 bytes per word)
 	/// * `attributes` - List of attributes to verify with their value wires
-	///
-	/// # Panics
-	/// * If max_len_json is not a multiple of 8
-	/// * If json.len() != max_len_json / 8
-	/// * If any attribute value array has wrong length for its max size
 	pub fn new(
 		b: &CircuitBuilder,
-		max_len_json: usize,
-		len_json: Wire,
+		len_bytes: Wire,
 		json: Vec<Wire>,
 		attributes: Vec<Attribute>,
 	) -> Self {
-		assert_eq!(max_len_json % 8, 0, "max_len_json must be multiple of 8");
-		assert_eq!(json.len(), max_len_json / 8, "json.len() must equal max_len_json / 8");
-
 		// For each attribute, we need to:
 		// 1. Find the pattern "name":" in the JSON
 		// 2. Extract the string value between the quotes
 		// 3. Verify it matches the expected value
+		let max_len_bytes = json.len() << 3;
+		let too_long = b.icmp_ult(b.add_constant_64(max_len_bytes as u64), len_bytes);
+		b.assert_false("length check", too_long);
 
 		for (attr_idx, attr) in attributes.iter().enumerate() {
 			let b = b.subcircuit(format!("attr[ix={}, name={}]", attr_idx, attr.name));
@@ -97,23 +90,21 @@ impl JwtClaims {
 			//
 			// Variables:
 			// - found_position: the position where we found the pattern (0 if not found yet)
-			// - any_found: becomes all-1s when we find the pattern anywhere
+			// - any_found: becomes msb-true when we find the pattern anywhere
 			let zero = b.add_constant(Word::ZERO);
-			let one = b.add_constant(Word::ONE);
-			let all_ones = b.add_constant(Word::ALL_ONE);
-			let mut found_position = zero;
-			let mut any_found = zero;
+			let mut value_start = zero;
+			let mut found_start = zero;
 
 			// Check each possible starting position
-			for start_pos in 0..max_len_json.saturating_sub(pattern_len) {
+			for start_pos in 0..max_len_bytes.saturating_sub(pattern_len) {
 				let b = b.subcircuit(format!("start_pos[{start_pos}]"));
 
 				// Check if this position could contain the full pattern
-				let start_wire = b.add_constant(Word(start_pos as u64));
 				let end_wire = b.add_constant(Word((start_pos + pattern_len) as u64));
 
 				// Verify position is within JSON bounds
-				let within_bounds = b.icmp_ult(end_wire, len_json);
+				let within_bounds = b.icmp_ult(end_wire, len_bytes);
+				// strict inequality is safe, because there will also be a closing "
 				let mut matches_here = within_bounds;
 
 				// Check each byte of the pattern
@@ -122,32 +113,19 @@ impl JwtClaims {
 					let word_idx = byte_pos / 8;
 					let byte_offset = byte_pos % 8;
 
-					if word_idx < json.len() {
-						let actual_byte = b.extract_byte(json[word_idx], byte_offset as u32);
-						let expected = b.add_constant(Word(expected_byte as u64));
-						let byte_matches = b.icmp_eq(actual_byte, expected);
-						matches_here = b.band(matches_here, byte_matches);
-					} else {
-						matches_here = zero;
-					}
+					let actual_byte = b.extract_byte(json[word_idx], byte_offset as u32);
+					let expected = b.add_constant(Word(expected_byte as u64));
+					let byte_matches = b.icmp_eq(actual_byte, expected);
+					matches_here = b.band(matches_here, byte_matches);
 				}
 
 				// If we found a match here, remember this position
-				// When matches_here is all-1s, include start_wire in found_position
-				// When matches_here is all-0s, masked_position is 0 and OR leaves found_position
-				// unchanged
-				let masked_position = b.band(start_wire, matches_here);
-				found_position = b.bor(found_position, masked_position);
-
-				// Update any_found flag (using OR to accumulate any matches)
-				any_found = b.bor(any_found, matches_here);
+				value_start = b.select(matches_here, end_wire, value_start);
+				found_start = b.bor(found_start, matches_here);
 			}
 
-			// Assert that we found the pattern (any_found should be all-1s)
-			b.assert_eq("attr_found".to_string(), any_found, all_ones);
-
-			// Now find the value start position (after the pattern)
-			let value_start = b.iadd_32(found_position, b.add_constant(Word(pattern_len as u64)));
+			// Assert that we found the pattern (found_start should be msb-true)
+			b.assert_true("attr_found".to_string(), found_start);
 
 			// ---- Find value terminator
 			//
@@ -160,75 +138,58 @@ impl JwtClaims {
 			let quote = b.add_constant_zx_8(b'"');
 			let comma = b.add_constant_zx_8(b',');
 			let close_brace = b.add_constant_zx_8(b'}');
+			// i actually don't grok why these latter two are valid terminators.
 
-			for pos in 0..max_len_json {
+			for pos in 0..max_len_bytes {
 				let b = b.subcircuit(format!("find_terminator[{pos}]"));
 
 				let pos_wire = b.add_constant(Word(pos as u64));
+				let within_bounds = b.icmp_ult(pos_wire, len_bytes);
 
-				// Check if this position is at or after value_start
+				// Check if this position is after value_start
 				// For empty strings, the closing quote is at value_start
-				let at_start = b.icmp_eq(value_start, pos_wire);
-				let after_start = b.icmp_ult(value_start, pos_wire);
-				let at_or_after = b.bor(at_start, after_start);
-				// Check if within bounds
-				let within_bounds = b.icmp_ult(pos_wire, len_json);
-				// Check if we haven't found the end yet (using NOT found_end)
-				// found_end is all-0s initially, becomes all-1s when found
-				let not_found_yet = b.bxor(found_end, all_ones);
-
-				let mut should_check = b.band(at_or_after, within_bounds);
-				should_check = b.band(should_check, not_found_yet);
+				let at_or_after_start = b.bnot(b.icmp_ult(pos_wire, value_start));
+				let not_found_yet = b.bnot(found_end);
+				let should_check = b.band(b.band(at_or_after_start, within_bounds), not_found_yet);
 
 				// Extract byte at this position
 				let word_idx = pos / 8;
 				let byte_offset = pos % 8;
 
-				if word_idx < json.len() {
-					let byte_at_pos = b.extract_byte(json[word_idx], byte_offset as u32);
+				let byte_at_pos = b.extract_byte(json[word_idx], byte_offset as u32);
 
-					// Check if this byte is any of the valid terminators
-					let is_quote = b.icmp_eq(byte_at_pos, quote);
-					let is_comma = b.icmp_eq(byte_at_pos, comma);
-					let is_close_brace = b.icmp_eq(byte_at_pos, close_brace);
+				// Check if this byte is any of the valid terminators
+				let is_quote = b.icmp_eq(byte_at_pos, quote);
+				let is_comma = b.icmp_eq(byte_at_pos, comma);
+				let is_close_brace = b.icmp_eq(byte_at_pos, close_brace);
 
-					// It's a terminator if it's any of the three
-					let is_terminator = b.bor(is_quote, is_comma);
-					let is_terminator = b.bor(is_terminator, is_close_brace);
+				// It's a terminator if it's any of the three
+				let is_terminator = b.bor(b.bor(is_quote, is_comma), is_close_brace);
 
-					let found_here = b.band(should_check, is_terminator);
+				let found_here = b.band(should_check, is_terminator);
 
-					// If we found a terminator here, remember this position
-					// When found_here is all-1s, include pos_wire in value_end
-					// When found_here is all-0s, masked_pos is 0 and OR leaves value_end unchanged
-					let masked_pos = b.band(pos_wire, found_here);
-					value_end = b.bor(value_end, masked_pos);
-
-					// Update found flag
-					found_end = b.bor(found_end, found_here);
-				}
+				// If we found a terminator here, remember this position
+				// When found_here is all-1s, include pos_wire in value_end
+				// When found_here is all-0s, masked_pos is 0 and OR leaves value_end unchanged
+				value_end = b.select(found_here, pos_wire, value_end);
+				found_end = b.bor(found_end, found_here);
 			}
 
 			// Assert that we found a terminator (found_end should be all-1s)
-			b.assert_eq("attr_terminator_found".to_string(), found_end, all_ones);
+			b.assert_true("attr_terminator_found", found_end);
 
 			// Calculate value length: value_end - value_start
 			// Since circuits don't have a subtraction operation, we use two's complement:
 			// a - b = a + (~b + 1), where ~b is bitwise NOT of b
-			let neg_start = b.bnot(value_start);
-			let neg_start_plus_one = b.iadd_32(neg_start, one);
-			let value_length = b.iadd_32(value_end, neg_start_plus_one);
+			let (value_length, _borrow) = b.isub_bin_bout(value_end, value_start, zero);
 
 			// Verify the length matches expected
-			b.assert_eq("attr_length".to_string(), value_length, attr.len_value);
+			b.assert_eq("attr_length", value_length, attr.len_bytes);
 
 			// Use Slice to verify the value content
-			let max_value_size = attr.value.len() * 8;
 			let _slice = Slice::new(
 				&b,
-				max_len_json,
-				max_value_size,
-				len_json,
+				len_bytes,
 				value_length,
 				json.clone(),
 				attr.value.clone(),
@@ -237,15 +198,15 @@ impl JwtClaims {
 		}
 
 		JwtClaims {
-			len_json,
+			len_bytes,
 			json,
 			attributes,
 		}
 	}
 
-	/// Populate the len_json wire with the actual JSON size in bytes
-	pub fn populate_len_json(&self, w: &mut WitnessFiller, len_json: usize) {
-		w[self.len_json] = Word(len_json as u64);
+	/// Populate the len_bytes wire with the actual JSON size in bytes
+	pub fn populate_len_bytes(&self, w: &mut WitnessFiller, len_bytes: usize) {
+		w[self.len_bytes] = Word(len_bytes as u64);
 	}
 
 	/// Populate the JSON array from a byte slice
@@ -266,17 +227,16 @@ mod tests {
 	fn test_single_attribute() {
 		let b = CircuitBuilder::new();
 
-		let max_len_json = 256;
 		let len_json = b.add_witness();
-		let json: Vec<Wire> = (0..max_len_json / 8).map(|_| b.add_witness()).collect();
+		let json: Vec<Wire> = (0..32).map(|_| b.add_witness()).collect();
 
 		let attributes = vec![Attribute {
 			name: "sub",
-			len_value: b.add_inout(),
-			value: (0..16 / 8).map(|_| b.add_inout()).collect(),
+			len_bytes: b.add_inout(),
+			value: (0..2).map(|_| b.add_inout()).collect(),
 		}];
 
-		let jwt_claims = JwtClaims::new(&b, max_len_json, len_json, json, attributes);
+		let jwt_claims = JwtClaims::new(&b, len_json, json, attributes);
 
 		let circuit = b.build();
 		let mut filler = circuit.new_witness_filler();
@@ -284,11 +244,11 @@ mod tests {
 		let json_str = r#"{"sub":"1234567890","iss":"google.com"}"#;
 
 		// Populate inputs
-		jwt_claims.populate_len_json(&mut filler, json_str.len());
+		jwt_claims.populate_len_bytes(&mut filler, json_str.len());
 		jwt_claims.populate_json(&mut filler, json_str.as_bytes());
 
 		// Populate expected value
-		jwt_claims.attributes[0].populate_len_value(&mut filler, 10);
+		jwt_claims.attributes[0].populate_len_bytes(&mut filler, 10);
 		jwt_claims.attributes[0].populate_value(&mut filler, b"1234567890");
 
 		circuit.populate_wire_witness(&mut filler).unwrap();
@@ -302,29 +262,28 @@ mod tests {
 	fn test_multiple_attributes() {
 		let b = CircuitBuilder::new();
 
-		let max_len_json = 256;
-		let len_json = b.add_witness();
-		let json: Vec<Wire> = (0..max_len_json / 8).map(|_| b.add_witness()).collect();
+		let len_bytes = b.add_witness();
+		let json: Vec<Wire> = (0..32).map(|_| b.add_witness()).collect();
 
 		let attributes = vec![
 			Attribute {
 				name: "sub",
-				len_value: b.add_inout(),
-				value: (0..16 / 8).map(|_| b.add_inout()).collect(),
+				len_bytes: b.add_inout(),
+				value: (0..2).map(|_| b.add_inout()).collect(),
 			},
 			Attribute {
 				name: "iss",
-				len_value: b.add_inout(),
-				value: (0..32 / 8).map(|_| b.add_inout()).collect(),
+				len_bytes: b.add_inout(),
+				value: (0..4).map(|_| b.add_inout()).collect(),
 			},
 			Attribute {
 				name: "aud",
-				len_value: b.add_inout(),
-				value: (0..16 / 8).map(|_| b.add_inout()).collect(),
+				len_bytes: b.add_inout(),
+				value: (0..2).map(|_| b.add_inout()).collect(),
 			},
 		];
 
-		let jwt_claims = JwtClaims::new(&b, max_len_json, len_json, json, attributes);
+		let jwt_claims = JwtClaims::new(&b, len_bytes, json, attributes);
 
 		let circuit = b.build();
 		let mut filler = circuit.new_witness_filler();
@@ -334,17 +293,17 @@ mod tests {
 			r#"{"sub":"1234567890","iss":"google.com","aud":"4074087","iat":1676415809}"#;
 
 		// Populate inputs
-		jwt_claims.populate_len_json(&mut filler, json_str.len());
+		jwt_claims.populate_len_bytes(&mut filler, json_str.len());
 		jwt_claims.populate_json(&mut filler, json_str.as_bytes());
 
 		// Populate expected values
-		jwt_claims.attributes[0].populate_len_value(&mut filler, 10);
+		jwt_claims.attributes[0].populate_len_bytes(&mut filler, 10);
 		jwt_claims.attributes[0].populate_value(&mut filler, b"1234567890");
 
-		jwt_claims.attributes[1].populate_len_value(&mut filler, 10);
+		jwt_claims.attributes[1].populate_len_bytes(&mut filler, 10);
 		jwt_claims.attributes[1].populate_value(&mut filler, b"google.com");
 
-		jwt_claims.attributes[2].populate_len_value(&mut filler, 7);
+		jwt_claims.attributes[2].populate_len_bytes(&mut filler, 7);
 		jwt_claims.attributes[2].populate_value(&mut filler, b"4074087");
 
 		circuit.populate_wire_witness(&mut filler).unwrap();
@@ -358,17 +317,16 @@ mod tests {
 	fn test_attribute_not_found() {
 		let b = CircuitBuilder::new();
 
-		let max_len_json = 128;
-		let len_json = b.add_witness();
-		let json: Vec<Wire> = (0..max_len_json / 8).map(|_| b.add_witness()).collect();
+		let len_bytes = b.add_witness();
+		let json: Vec<Wire> = (0..16).map(|_| b.add_witness()).collect();
 
 		let attributes = vec![Attribute {
 			name: "missing",
-			len_value: b.add_inout(),
-			value: (0..16 / 8).map(|_| b.add_inout()).collect(),
+			len_bytes: b.add_inout(),
+			value: (0..2).map(|_| b.add_inout()).collect(),
 		}];
 
-		let jwt_claims = JwtClaims::new(&b, max_len_json, len_json, json, attributes);
+		let jwt_claims = JwtClaims::new(&b, len_bytes, json, attributes);
 
 		let circuit = b.build();
 		let mut filler = circuit.new_witness_filler();
@@ -377,11 +335,11 @@ mod tests {
 		let json_str = r#"{"sub":"1234567890","iss":"google.com"}"#;
 
 		// Populate inputs
-		jwt_claims.populate_len_json(&mut filler, json_str.len());
+		jwt_claims.populate_len_bytes(&mut filler, json_str.len());
 		jwt_claims.populate_json(&mut filler, json_str.as_bytes());
 
 		// Populate expected value (won't be found)
-		jwt_claims.attributes[0].populate_len_value(&mut filler, 5);
+		jwt_claims.attributes[0].populate_len_bytes(&mut filler, 5);
 		jwt_claims.attributes[0].populate_value(&mut filler, b"value");
 
 		// This should fail because "missing" attribute is not in the JSON
@@ -393,17 +351,16 @@ mod tests {
 	fn test_wrong_value() {
 		let b = CircuitBuilder::new();
 
-		let max_len_json = 128;
-		let len_json = b.add_witness();
-		let json: Vec<Wire> = (0..max_len_json / 8).map(|_| b.add_witness()).collect();
+		let len_bytes = b.add_witness();
+		let json: Vec<Wire> = (0..16).map(|_| b.add_witness()).collect();
 
 		let attributes = vec![Attribute {
 			name: "sub",
-			len_value: b.add_inout(),
-			value: (0..16 / 8).map(|_| b.add_inout()).collect(),
+			len_bytes: b.add_inout(),
+			value: (0..2).map(|_| b.add_inout()).collect(),
 		}];
 
-		let jwt_claims = JwtClaims::new(&b, max_len_json, len_json, json, attributes);
+		let jwt_claims = JwtClaims::new(&b, len_bytes, json, attributes);
 
 		let circuit = b.build();
 		let mut filler = circuit.new_witness_filler();
@@ -412,11 +369,11 @@ mod tests {
 		let json_str = r#"{"sub":"1234567890","iss":"google.com"}"#;
 
 		// Populate inputs
-		jwt_claims.populate_len_json(&mut filler, json_str.len());
+		jwt_claims.populate_len_bytes(&mut filler, json_str.len());
 		jwt_claims.populate_json(&mut filler, json_str.as_bytes());
 
 		// Populate wrong expected value
-		jwt_claims.attributes[0].populate_len_value(&mut filler, 10);
+		jwt_claims.attributes[0].populate_len_bytes(&mut filler, 10);
 		jwt_claims.attributes[0].populate_value(&mut filler, b"9876543210");
 
 		// This should fail because the value doesn't match
@@ -428,24 +385,23 @@ mod tests {
 	fn test_attributes_in_different_order() {
 		let b = CircuitBuilder::new();
 
-		let max_len_json = 256;
-		let len_json = b.add_witness();
-		let json: Vec<Wire> = (0..max_len_json / 8).map(|_| b.add_witness()).collect();
+		let len_bytes = b.add_witness();
+		let json: Vec<Wire> = (0..32).map(|_| b.add_witness()).collect();
 
 		let attributes = vec![
 			Attribute {
 				name: "aud",
-				len_value: b.add_inout(),
+				len_bytes: b.add_inout(),
 				value: (0..16 / 8).map(|_| b.add_inout()).collect(),
 			},
 			Attribute {
 				name: "sub",
-				len_value: b.add_inout(),
+				len_bytes: b.add_inout(),
 				value: (0..16 / 8).map(|_| b.add_inout()).collect(),
 			},
 		];
 
-		let jwt_claims = JwtClaims::new(&b, max_len_json, len_json, json, attributes);
+		let jwt_claims = JwtClaims::new(&b, len_bytes, json, attributes);
 
 		let circuit = b.build();
 		let mut filler = circuit.new_witness_filler();
@@ -455,14 +411,14 @@ mod tests {
 			r#"{"iss":"google.com","sub":"1234567890","email":"test@example.com","aud":"4074087"}"#;
 
 		// Populate inputs
-		jwt_claims.populate_len_json(&mut filler, json_str.len());
+		jwt_claims.populate_len_bytes(&mut filler, json_str.len());
 		jwt_claims.populate_json(&mut filler, json_str.as_bytes());
 
 		// Populate expected values
-		jwt_claims.attributes[0].populate_len_value(&mut filler, 7);
+		jwt_claims.attributes[0].populate_len_bytes(&mut filler, 7);
 		jwt_claims.attributes[0].populate_value(&mut filler, b"4074087");
 
-		jwt_claims.attributes[1].populate_len_value(&mut filler, 10);
+		jwt_claims.attributes[1].populate_len_bytes(&mut filler, 10);
 		jwt_claims.attributes[1].populate_value(&mut filler, b"1234567890");
 
 		circuit.populate_wire_witness(&mut filler).unwrap();
@@ -476,17 +432,16 @@ mod tests {
 	fn test_empty_string_value() {
 		let b = CircuitBuilder::new();
 
-		let max_len_json = 128;
-		let len_json = b.add_witness();
-		let json: Vec<Wire> = (0..max_len_json / 8).map(|_| b.add_witness()).collect();
+		let len_bytes = b.add_witness();
+		let json: Vec<Wire> = (0..16).map(|_| b.add_witness()).collect();
 
 		let attributes = vec![Attribute {
 			name: "empty",
-			len_value: b.add_inout(),
-			value: (0..8 / 8).map(|_| b.add_inout()).collect(),
+			len_bytes: b.add_inout(),
+			value: (0..1).map(|_| b.add_inout()).collect(),
 		}];
 
-		let jwt_claims = JwtClaims::new(&b, max_len_json, len_json, json, attributes);
+		let jwt_claims = JwtClaims::new(&b, len_bytes, json, attributes);
 
 		let circuit = b.build();
 		let mut filler = circuit.new_witness_filler();
@@ -495,11 +450,11 @@ mod tests {
 		let json_str = r#"{"empty":"","sub":"123"}"#;
 
 		// Populate inputs
-		jwt_claims.populate_len_json(&mut filler, json_str.len());
+		jwt_claims.populate_len_bytes(&mut filler, json_str.len());
 		jwt_claims.populate_json(&mut filler, json_str.as_bytes());
 
 		// Populate expected empty value
-		jwt_claims.attributes[0].populate_len_value(&mut filler, 0);
+		jwt_claims.attributes[0].populate_len_bytes(&mut filler, 0);
 		jwt_claims.attributes[0].populate_value(&mut filler, b"");
 
 		circuit.populate_wire_witness(&mut filler).unwrap();
@@ -513,24 +468,23 @@ mod tests {
 	fn test_special_characters() {
 		let b = CircuitBuilder::new();
 
-		let max_len_json = 256;
-		let len_json = b.add_witness();
-		let json: Vec<Wire> = (0..max_len_json / 8).map(|_| b.add_witness()).collect();
+		let len_bytes = b.add_witness();
+		let json: Vec<Wire> = (0..32).map(|_| b.add_witness()).collect();
 
 		let attributes = vec![
 			Attribute {
 				name: "email",
-				len_value: b.add_inout(),
-				value: (0..32 / 8).map(|_| b.add_inout()).collect(),
+				len_bytes: b.add_inout(),
+				value: (0..4).map(|_| b.add_inout()).collect(),
 			},
 			Attribute {
 				name: "nonce",
-				len_value: b.add_inout(),
-				value: (0..32 / 8).map(|_| b.add_inout()).collect(),
+				len_bytes: b.add_inout(),
+				value: (0..4).map(|_| b.add_inout()).collect(),
 			},
 		];
 
-		let jwt_claims = JwtClaims::new(&b, max_len_json, len_json, json, attributes);
+		let jwt_claims = JwtClaims::new(&b, len_bytes, json, attributes);
 
 		let circuit = b.build();
 		let mut filler = circuit.new_witness_filler();
@@ -539,14 +493,14 @@ mod tests {
 		let json_str = r#"{"email":"john.doe@gmail.com","nonce":"7-VU9fuWeWtgDLHmVJ2UtRrine8"}"#;
 
 		// Populate inputs
-		jwt_claims.populate_len_json(&mut filler, json_str.len());
+		jwt_claims.populate_len_bytes(&mut filler, json_str.len());
 		jwt_claims.populate_json(&mut filler, json_str.as_bytes());
 
 		// Populate expected values
-		jwt_claims.attributes[0].populate_len_value(&mut filler, 18);
+		jwt_claims.attributes[0].populate_len_bytes(&mut filler, 18);
 		jwt_claims.attributes[0].populate_value(&mut filler, b"john.doe@gmail.com");
 
-		jwt_claims.attributes[1].populate_len_value(&mut filler, 27);
+		jwt_claims.attributes[1].populate_len_bytes(&mut filler, 27);
 		jwt_claims.attributes[1].populate_value(&mut filler, b"7-VU9fuWeWtgDLHmVJ2UtRrine8");
 
 		circuit.populate_wire_witness(&mut filler).unwrap();
@@ -560,24 +514,23 @@ mod tests {
 	fn test_last_attribute_no_comma() {
 		let b = CircuitBuilder::new();
 
-		let max_len_json = 128;
-		let len_json = b.add_witness();
-		let json: Vec<Wire> = (0..max_len_json / 8).map(|_| b.add_witness()).collect();
+		let len_bytes = b.add_witness();
+		let json: Vec<Wire> = (0..16).map(|_| b.add_witness()).collect();
 
 		let attributes = vec![
 			Attribute {
 				name: "iss",
-				len_value: b.add_inout(),
+				len_bytes: b.add_inout(),
 				value: (0..16 / 8).map(|_| b.add_inout()).collect(),
 			},
 			Attribute {
 				name: "last",
-				len_value: b.add_inout(),
+				len_bytes: b.add_inout(),
 				value: (0..16 / 8).map(|_| b.add_inout()).collect(),
 			},
 		];
 
-		let jwt_claims = JwtClaims::new(&b, max_len_json, len_json, json, attributes);
+		let jwt_claims = JwtClaims::new(&b, len_bytes, json, attributes);
 
 		let circuit = b.build();
 		let mut filler = circuit.new_witness_filler();
@@ -586,14 +539,14 @@ mod tests {
 		let json_str = r#"{"iss":"example.com","last":"value123"}"#;
 
 		// Populate inputs
-		jwt_claims.populate_len_json(&mut filler, json_str.len());
+		jwt_claims.populate_len_bytes(&mut filler, json_str.len());
 		jwt_claims.populate_json(&mut filler, json_str.as_bytes());
 
 		// Populate expected values
-		jwt_claims.attributes[0].populate_len_value(&mut filler, 11);
+		jwt_claims.attributes[0].populate_len_bytes(&mut filler, 11);
 		jwt_claims.attributes[0].populate_value(&mut filler, b"example.com");
 
-		jwt_claims.attributes[1].populate_len_value(&mut filler, 8);
+		jwt_claims.attributes[1].populate_len_bytes(&mut filler, 8);
 		jwt_claims.attributes[1].populate_value(&mut filler, b"value123");
 
 		circuit.populate_wire_witness(&mut filler).unwrap();

--- a/crates/frontend/src/circuits/keccak/mod.rs
+++ b/crates/frontend/src/circuits/keccak/mod.rs
@@ -4,8 +4,12 @@ pub mod reference;
 use binius_core::word::Word;
 use permutation::Permutation;
 
-use crate::compiler::{CircuitBuilder, Wire, circuit::WitnessFiller};
+use crate::{
+	circuits::multiplexer::{multi_wire_multiplex, single_wire_multiplex},
+	compiler::{CircuitBuilder, Wire, circuit::WitnessFiller},
+};
 
+pub const N_WORDS_PER_DIGEST: usize = 4;
 pub const N_WORDS_PER_STATE: usize = 25;
 pub const RATE_BYTES: usize = 136;
 pub const N_WORDS_PER_BLOCK: usize = RATE_BYTES / 8;
@@ -14,16 +18,14 @@ pub const N_WORDS_PER_BLOCK: usize = RATE_BYTES / 8;
 ///
 /// # Arguments
 ///
-/// * `max_len` - max message length in bytes
-/// * `len` - A wire representing the input message length in bytes
+/// * `len_bytes` - A wire representing the input message length in bytes
 /// * `digest` - Array of 4 wires representing the 256-bit output digest
 /// * `message` - Vector of wires representing the input message
 pub struct Keccak {
-	pub max_len: usize,
-	pub len: Wire,
-	pub digest: [Wire; N_WORDS_PER_STATE],
+	pub len_bytes: Wire,
+	pub digest: [Wire; N_WORDS_PER_DIGEST],
 	pub message: Vec<Wire>,
-	padded_message: Vec<[Wire; N_WORDS_PER_BLOCK]>,
+	padded_message: Vec<Wire>,
 	n_blocks: usize,
 }
 
@@ -42,56 +44,20 @@ impl Keccak {
 	/// * max_len > 0
 	pub fn new(
 		b: &CircuitBuilder,
-		max_len: usize,
-		len: Wire,
-		digest: [Wire; N_WORDS_PER_STATE],
+		len_bytes: Wire,
+		digest: [Wire; N_WORDS_PER_DIGEST],
 		message: Vec<Wire>,
 	) -> Self {
-		assert!(max_len > 0, "max_len must be positive");
-
+		let max_len_bytes = message.len() << 3;
 		// number of blocks needed for the maximum sized message
-		let n_blocks = (max_len + 1).div_ceil(RATE_BYTES);
+		let n_blocks = (max_len_bytes + 1).div_ceil(RATE_BYTES);
 
 		// constrain the message length claim to be explicitly within bounds
-		let len_check = b.icmp_ult(b.add_constant_64(max_len as u64), len); // len <= max_len
-		b.assert_0("len_check", len_check);
+		let len_check = b.icmp_ult(b.add_constant_64(max_len_bytes as u64), len_bytes); // max_len_bytes < len_bytes
+		b.assert_false("len_check", len_check);
 
-		// run keccak function, producing the intermediate states between permutations
-		let (permutation_states, padded_message) = Self::compute_digest(b, n_blocks);
-
-		// ensure digest was correctly computed by keccak
-		let is_final_block_flags =
-			Self::constrain_claimed_digest(b, permutation_states, digest, len, n_blocks);
-
-		// ensure message padding matches keccak expectations
-		Self::constrain_message_padding(
-			b,
-			len,
-			message.clone(),
-			n_blocks,
-			padded_message.clone(),
-			is_final_block_flags,
-		);
-
-		Self {
-			max_len,
-			len,
-			digest,
-			message,
-			padded_message,
-			n_blocks,
-		}
-	}
-
-	/// Computes keccak-256 digest of a padded message.
-	///
-	/// Repeatedly absorb blocks into the state, this forms the digest computation.
-	fn compute_digest(
-		b: &CircuitBuilder,
-		n_blocks: usize,
-	) -> (Vec<[Wire; N_WORDS_PER_STATE]>, Vec<[Wire; N_WORDS_PER_BLOCK]>) {
-		let padded_message: Vec<[Wire; N_WORDS_PER_BLOCK]> = (0..n_blocks)
-			.map(|_| std::array::from_fn(|_| b.add_witness()))
+		let padded_message: Vec<Wire> = (0..n_blocks * N_WORDS_PER_BLOCK)
+			.map(|_| b.add_witness())
 			.collect();
 
 		// zero initialized keccak state
@@ -104,7 +70,8 @@ impl Keccak {
 			let state_in = states[block_no];
 			let mut xored_state = state_in;
 			for i in 0..N_WORDS_PER_BLOCK {
-				xored_state[i] = b.bxor(state_in[i], padded_message[block_no][i]);
+				xored_state[i] =
+					b.bxor(state_in[i], padded_message[block_no * N_WORDS_PER_BLOCK + i]);
 			}
 
 			Permutation::keccak_f1600(b, &mut xored_state);
@@ -112,210 +79,104 @@ impl Keccak {
 			states.push(xored_state);
 		}
 
-		(states, padded_message)
-	}
-
-	/// Checks if the supposed digest is truly a valid keccak digest of the message.
-	///
-	/// This is done by ensuring that the supposed digest is correctly found at the end of the
-	/// states collected during the absorption of the message. By doing this, we ensure that
-	/// digests not only are correctly computed using the keccak permutation but that they
-	/// emerge after the expected number of permutations.
-	fn constrain_claimed_digest(
-		b: &CircuitBuilder,
-		computed_states: Vec<[Wire; N_WORDS_PER_STATE]>,
-		digest: [Wire; N_WORDS_PER_STATE],
-		length: Wire,
-		n_blocks: usize,
-	) -> Vec<Wire> {
-		let zero = b.add_constant(Word::ZERO);
-
-		let mut computed_digest = [zero; N_WORDS_PER_STATE];
-
-		// flags to determine if a block at a given index is the final block
-		let mut is_final_block_flags = Vec::with_capacity(n_blocks);
-
-		// A supposed final block can be validated by checking whether its supposed length
-		// lies within the expected block range. This expectation is further constrained
-		// later on in the circuit by ensuring that the padding expectations for a message
-		// also match up to these checks.
+		// begin "constrain claimed digest".
+		// want to do: `let block_index = (len_bytes + 1).divceil(136)`.
+		// royal pain in the ass that 136 is not a power of 2, so we can't compute this in circuit
+		// still though, i believe that there might be tricks better than what we're doing below.
+		let mut end_block_index = b.add_constant(Word::ZERO);
+		let mut is_not_last_column = b.add_constant(Word::ZERO);
+		// `is_not_last_column` will be true if and only if `len_bytes >> 3` != 16 (mod 17).
+		// true iff the WORD w/ the very first post-message byte is NOT the last word in its block.
 		for block_no in 0..n_blocks {
 			// start of this block
 			let block_start = b.add_constant_64((block_no * RATE_BYTES) as u64);
 			let block_end = b.add_constant_64(((block_no + 1) * RATE_BYTES) as u64);
+			let last_word_start = b.add_constant_64(((block_no + 1) * RATE_BYTES - 8) as u64);
 
-			// supposed length >= block_start
-			let ge_start = if block_no == 0 {
-				b.add_constant(Word::ALL_ONE) // block 0 always len >= 0
-			} else {
-				b.bnot(b.icmp_ult(length, block_start))
-			};
-
-			// supposed length < block_end
-			let lt_end = b.icmp_ult(length, block_end);
-
-			// the final block will fall within the range: len < block_end and len >= block_start
-			let is_final_block = b.band(ge_start, lt_end);
+			let lt_start = b.icmp_ult(len_bytes, block_start);
+			let lt_end = b.icmp_ult(len_bytes, block_end);
+			let lt_last_word = b.icmp_ult(len_bytes, last_word_start);
+			let is_final_block = b.band(b.bnot(lt_start), lt_end);
 
 			// flag that this block is the final block per the claimed length
-			is_final_block_flags.push(is_final_block);
-
-			// ensure that if this block is final, that the digest matches the claimed digest
-			for i in 0..4 {
-				let masked = b.band(is_final_block, computed_states[block_no + 1][i]);
-				computed_digest[i] = b.bxor(computed_digest[i], masked);
-			}
+			end_block_index =
+				b.select(is_final_block, b.add_constant_64(block_no as u64), end_block_index);
+			is_not_last_column = b.select(is_final_block, lt_last_word, is_not_last_column);
 		}
 
-		b.assert_eq_v("claimed digest is correct", computed_digest, digest);
+		let inputs: Vec<&[Wire]> = states[1..].iter().map(|arr| &arr[..]).collect();
+		let computed_digest_vec = multi_wire_multiplex(b, &inputs, end_block_index);
+		let computed_digest = computed_digest_vec[..N_WORDS_PER_DIGEST]
+			.try_into()
+			.unwrap();
+		b.assert_eq_v("claimed digest is correct", digest, computed_digest);
 
-		is_final_block_flags
-	}
+		// begin treatment of boundary word.
+		let word_boundary = b.shr(len_bytes, 3);
+		let boundary_word = single_wire_multiplex(b, &message, word_boundary);
+		let boundary_padded_word = single_wire_multiplex(b, &padded_message, word_boundary);
+		// When the last word of the message is not full, we expect a padding byte to be
+		// somewhere within the word. Since the top bit will also be in this word.
+		let candidates: Vec<Wire> = (0..8)
+			.map(|i| {
+				let mask = b.add_constant_64(0x00FFFFFFFFFFFFFF >> ((7 - i) << 3));
+				let padding_byte = b.add_constant_64(1 << (i << 3));
+				let message_low = b.band(boundary_word, mask);
+				b.bxor(message_low, padding_byte)
+			})
+			.collect();
 
-	/// Constrains message padding to match keccak expectations
-	///
-	/// Keccak splits a message of words into 'rate blocks', which are fixed size word arrays of
-	/// size N_WORDS_PER_BLOCK. This partitions a message into chunks of words small enough to be
-	/// fed into the permutation function during absorption. As a result, a message may not neatly
-	/// fit into a whole number of rate blocks. To account for this, Keccak uses a padding scheme
-	/// where following the end of a message, a padding byte 0x01 is inserted. The end of each rate
-	/// block is also delimited by a top bit 0x80.
-	///
-	/// As a result, three important cases must be handled to ensure padding is correct.
-	///
-	/// 1. The final word of a message comes before the final word of the block.
-	///
-	/// 2. The final word of a message is in the final word of that block but the final byte of that
-	///    word is not the final byte of the block. This means the padding byte and the top bit are
-	///    in the same word but within different bytes.
-	///
-	/// 3. The final word of a message is in the final word and the final byte of the block. Meaning
-	///    that the padding byte and the top bit are within the same byte.
-	fn constrain_message_padding(
-		b: &CircuitBuilder,
-		len: Wire,
-		message: Vec<Wire>,
-		n_blocks: usize,
-		padded_message: Vec<[Wire; N_WORDS_PER_BLOCK]>,
-		is_final_block_flags: Vec<Wire>,
-	) {
-		let total_rate_words = n_blocks * N_WORDS_PER_BLOCK;
+		let zero = b.add_constant(Word::ZERO);
+		let msb_1 = b.add_constant(Word::MSB_ONE);
+		let len_bytes_mod_8 = b.band(len_bytes, b.add_constant_64(7));
+		let expected_partial = single_wire_multiplex(b, &candidates, len_bytes_mod_8);
+		let with_possible_end = b.bxor(expected_partial, b.select(is_not_last_column, zero, msb_1));
 
-		// bit masks for extracting up to the possible locations for the pad byte within a word
-		const LOW_MASK: [u64; 8] = [
-			0,
-			0x0000_00FF,
-			0x0000_FFFF,
-			0x00FF_FFFF,
-			0xFFFF_FFFF,
-			0xFF_FFFF_FFFF,
-			0xFFFF_FFFF_FFFF,
-			0xFF_FFFF_FFFF_FFFF,
-		];
-
-		// possible pad byte placements within a word
-		const PAD_BYTE: [u64; 8] = [
-			0x01,
-			0x01_00,
-			0x01_00_00,
-			0x01_00_00_00,
-			0x01_00_00_00_00,
-			0x01_00_00_00_00_00,
-			0x01_00_00_00_00_00_00,
-			0x01_00_00_00_00_00_00_00,
-		];
-
-		let word_boundary = b.shr(len, 3);
-
-		let zero = b.add_constant_64(0);
-
-		// byte offset for where the pad byte is within a partial word given the claimed length
-		let r = b.band(len, b.add_constant_64(7));
+		b.assert_eq("expected partial", with_possible_end, boundary_padded_word);
 
 		// Within the final rate block, ensure that the pad byte and top bit are where they are
 		// supposed to be
-		for word_index in 0..total_rate_words {
-			// Retrieve the word of the supposed padded message corresponding to the final padded
-			// word
-			let block_idx = word_index / N_WORDS_PER_BLOCK;
-			let word_in_block = word_index % N_WORDS_PER_BLOCK;
-			let padded_word = padded_message[block_idx][word_in_block];
+		for block_index in 0..n_blocks {
+			let is_end_block = b.icmp_eq(end_block_index, b.add_constant_64(block_index as u64));
+			for column_index in 0..N_WORDS_PER_BLOCK {
+				let word_index = block_index * N_WORDS_PER_BLOCK + column_index;
 
-			// a potentially padded word is at this index
-			let word_idx_wire = b.add_constant_64(word_index as u64);
-			let message_word = *message.get(word_index).unwrap_or(&zero);
+				let padded_word = padded_message[word_index];
 
-			//  true if message ends exactly at the block boundary
-			let msg_last_full = b.icmp_ult(word_idx_wire, word_boundary);
+				// a potentially padded word is at this index
+				let word_idx_wire = b.add_constant_64(word_index as u64);
+				if word_index < message.len() {
+					let message_word = message[word_index];
+					let is_before_end = b.icmp_ult(word_idx_wire, word_boundary);
+					b.assert_eq_cond("full", padded_word, message_word, is_before_end);
+				}
 
-			// true if last block word is the last word of msg, so it will be the same as the word
-			// boundary
-			let block_last_is_msg_last = b.icmp_eq(word_idx_wire, word_boundary);
+				let is_past_message = b.icmp_ult(word_boundary, word_idx_wire);
 
-			// In the case where the word is full and is also the last word in the block, it should
-			// match the original msg word.
-			b.assert_eq_cond("full", message_word, padded_word, msg_last_full);
-
-			// When the last word of the message is not full, we expect a padding byte to be
-			// somewhere within the word. Since the top bit will also be in this word.
-			let mut expected_partial = zero;
-			for k in 0..8 {
-				let r_is_k = b.icmp_eq(r, b.add_constant_64(k as u64));
-				let msk = b.add_constant_64(LOW_MASK[k]);
-				let pbyte = b.add_constant_64(PAD_BYTE[k]);
-				let msg_lo = b.band(message_word, msk);
-				let cand = b.bxor(msg_lo, pbyte);
-
-				expected_partial = b.bxor(expected_partial, b.band(r_is_k, cand));
+				if column_index == 16 {
+					// last word in the block
+					let must_check_delimiter = b.band(is_end_block, is_not_last_column);
+					b.assert_eq_cond("delim", padded_word, msb_1, must_check_delimiter);
+					// if the word in which 0x01 must reside is NOT the last word in the block,
+					// then the presence of the 0x80 delimiter is NOT treated with the boundary word
+					// thus we must separately check that the ACTUAL last word in the block has it
+				} else {
+					b.assert_eq_cond("after-message padding", padded_word, zero, is_past_message);
+				}
 			}
-
-			// this will be true if the current word is the last word of the block
-			let is_last_block_word = b.icmp_eq(
-				b.add_constant_64(word_in_block as u64),
-				b.add_constant_64(N_WORDS_PER_BLOCK as u64 - 1),
-			);
-
-			// this will be true if the current word is the last word of the block and the last word
-			// of the message is the last word of the block
-			let partial_and_last = b.band(block_last_is_msg_last, is_last_block_word);
-
-			// Set the top bit into the expected partial word after it has had its padding byte set
-			// If this is not the last word of the block, the expected partial word will not change
-			let top_bit_const = b.add_constant_64(0x80_00_00_00_00_00_00_00u64);
-			let extra_0x80 = b.band(partial_and_last, top_bit_const);
-			let expected_for_partial = b.bxor(expected_partial, extra_0x80);
-
-			// If the last block word is the last word of the message, then assert that the partial
-			// word matches
-			b.assert_eq_cond(
-				"partial matches expected",
-				expected_for_partial,
-				padded_word,
-				block_last_is_msg_last,
-			);
-
-			let is_final_block = is_final_block_flags[block_idx];
-
-			// Only assert 0x80 alone when it's the last word but NOT partial
-			let last_not_partial = b.band(is_last_block_word, b.bnot(block_last_is_msg_last));
-			let last_in_final_block = b.band(is_final_block, last_not_partial);
-			b.assert_eq_cond(
-				"0x80 in final block",
-				padded_word,
-				top_bit_const,
-				last_in_final_block,
-			);
-
-			// Words after the partial word (but before last word) should be zero
-			let is_after_partial = b.icmp_ult(word_boundary, word_idx_wire);
-			let not_last = b.bnot(is_last_block_word);
-			let must_be_zero = b.band(is_final_block, b.band(is_after_partial, not_last));
-			b.assert_eq_cond("zero after partial", padded_word, zero, must_be_zero);
-
-			// All words after final block must be zero
-			let after_final = b.icmp_ult(len, b.add_constant_64((block_idx * RATE_BYTES) as u64));
-			b.assert_eq_cond("zero after final", padded_word, zero, after_final);
 		}
+
+		Self {
+			len_bytes,
+			digest,
+			message,
+			padded_message,
+			n_blocks,
+		}
+	}
+
+	pub fn max_len_bytes(&self) -> usize {
+		self.message.len() << 3
 	}
 
 	/// Populates the witness with the actual message length
@@ -324,14 +185,14 @@ impl Keccak {
 	///
 	/// * w - The witness filler to populate
 	/// * len_bytes - The actual byte length of the message
-	pub fn populate_len(&self, w: &mut WitnessFiller<'_>, len_bytes: usize) {
+	pub fn populate_len_bytes(&self, w: &mut WitnessFiller<'_>, len_bytes: usize) {
 		assert!(
-			len_bytes <= self.max_len,
+			len_bytes <= self.max_len_bytes(),
 			"Message length {} exceeds maximum {}",
 			len_bytes,
-			self.max_len
+			self.max_len_bytes()
 		);
-		w[self.len] = Word(len_bytes as u64);
+		w[self.len_bytes] = Word(len_bytes as u64);
 	}
 
 	/// Populates the witness with the expected digest value packed into 4 64-bit words
@@ -355,14 +216,14 @@ impl Keccak {
 	/// * message_bytes - The input message as a byte slice
 	pub fn populate_message(&self, w: &mut WitnessFiller<'_>, message_bytes: &[u8]) {
 		assert!(
-			message_bytes.len() <= self.max_len,
+			message_bytes.len() <= self.max_len_bytes(),
 			"Message length {} exceeds maximum {}",
 			message_bytes.len(),
-			self.max_len
+			self.max_len_bytes()
 		);
 
 		// populate message words from input bytes
-		let words = self.pack_bytes_into_words(message_bytes, self.max_len.div_ceil(8));
+		let words = self.pack_bytes_into_words(message_bytes, self.max_len_bytes().div_ceil(8));
 		for (i, word) in words.iter().enumerate() {
 			if i < self.message.len() {
 				w[self.message[i]] = Word(*word);
@@ -388,7 +249,7 @@ impl Keccak {
 				.enumerate()
 			{
 				let word = u64::from_le_bytes(chunk.try_into().unwrap());
-				w[self.padded_message[block_idx][i]] = Word(word);
+				w[self.padded_message[block_idx * N_WORDS_PER_BLOCK + i]] = Word(word);
 			}
 		}
 	}
@@ -419,36 +280,40 @@ mod tests {
 	use rand::{Rng, SeedableRng, rngs::StdRng};
 	use sha3::{Digest, Keccak256};
 
-	use super::{Keccak, N_WORDS_PER_STATE};
+	use super::{Keccak, N_WORDS_PER_DIGEST};
 	use crate::{
 		circuits::keccak::RATE_BYTES,
 		compiler::{CircuitBuilder, Wire},
 		constraint_verifier::verify_constraints,
 	};
 
-	fn keccak_crate(message: &[u8]) -> [u8; 32] {
+	fn keccak_crate(message_bytes: &[u8]) -> [u8; 32] {
 		let mut hasher = Keccak256::new();
-		hasher.update(message);
+		hasher.update(message_bytes);
 		hasher.finalize().into()
 	}
 
 	// runs keccak circuit on a message and returns the expected digest
-	fn validate_keccak_circuit(message: &[u8], expected_digest: [u8; 32], max_len: usize) {
+	fn validate_keccak_circuit(
+		message_bytes: &[u8],
+		expected_digest: [u8; 32],
+		max_len_bytes: usize,
+	) {
 		let b = CircuitBuilder::new();
 
 		let len = b.add_witness();
-		let digest: [Wire; N_WORDS_PER_STATE] = std::array::from_fn(|_| b.add_inout());
+		let digest: [Wire; N_WORDS_PER_DIGEST] = std::array::from_fn(|_| b.add_inout());
 
-		let n_words = max_len.div_ceil(8);
-		let message_wires = (0..n_words).map(|_| b.add_inout()).collect();
+		let n_words = max_len_bytes.div_ceil(8);
+		let message = (0..n_words).map(|_| b.add_inout()).collect();
 
-		let keccak = Keccak::new(&b, max_len, len, digest, message_wires);
+		let keccak = Keccak::new(&b, len, digest, message);
 		let circuit = b.build();
 
 		// populate witness
 		let mut w = circuit.new_witness_filler();
-		keccak.populate_len(&mut w, message.len());
-		keccak.populate_message(&mut w, message);
+		keccak.populate_len_bytes(&mut w, message_bytes.len());
+		keccak.populate_message(&mut w, message_bytes);
 		keccak.populate_digest(&mut w, expected_digest);
 
 		// ensure correct final digest
@@ -464,11 +329,11 @@ mod tests {
 	fn test_valid_message() {
 		let mut rng = StdRng::seed_from_u64(0);
 
-		let message = repeat_n(rng.gen_range(0..=255), 1000).collect::<Vec<_>>();
-		let max_message_len = 2048;
+		let message_bytes: Vec<u8> = repeat_n(rng.gen_range(0..=255), 1000).collect::<Vec<_>>();
+		let max_len_bytes = 2048;
 
-		let expected_digest = keccak_crate(&message);
-		validate_keccak_circuit(&message, expected_digest, max_message_len);
+		let expected_digest = keccak_crate(&message_bytes);
+		validate_keccak_circuit(&message_bytes, expected_digest, max_len_bytes);
 	}
 
 	#[test]
@@ -478,10 +343,10 @@ mod tests {
 		let mut rng = StdRng::seed_from_u64(0);
 
 		let message = repeat_n(rng.gen_range(0..=255), 3000).collect::<Vec<_>>();
-		let max_message_len = 2048;
+		let max_len_bytes = 2048;
 
 		let expected_digest = keccak_crate(&message);
-		validate_keccak_circuit(&message, expected_digest, max_message_len);
+		validate_keccak_circuit(&message, expected_digest, max_len_bytes);
 	}
 
 	/// This one byte message ends well before the final word of the block. To pad this message,

--- a/crates/frontend/src/circuits/multiplexer.rs
+++ b/crates/frontend/src/circuits/multiplexer.rs
@@ -1,4 +1,4 @@
-use binius_core::consts::WORD_SIZE_BITS;
+use binius_core::{consts::WORD_SIZE_BITS, word::Word};
 
 use crate::{
 	compiler::{CircuitBuilder, Wire},
@@ -81,7 +81,9 @@ pub fn multi_wire_multiplex(b: &CircuitBuilder, inputs: &[&[Wire]], sel: Wire) -
 /// * If inputs.len() is 0
 pub fn single_wire_multiplex(b: &CircuitBuilder, inputs: &[Wire], sel: Wire) -> Wire {
 	let n = inputs.len();
-	assert!(n > 0, "Input vector must not be empty");
+	if n == 0 {
+		return b.add_constant(Word::ZERO);
+	}
 
 	// Calculate number of selector bits needed
 	let num_sel_bits = log2_ceil_usize(n);

--- a/crates/frontend/src/circuits/secp256k1/curve.rs
+++ b/crates/frontend/src/circuits/secp256k1/curve.rs
@@ -7,7 +7,6 @@ use super::{
 use crate::{
 	circuits::bignum::{BigUint, PseudoMersennePrimeField, assert_eq, biguint_eq, select},
 	compiler::{CircuitBuilder, Wire},
-	util::bool_to_mask,
 };
 
 /// Secp256k1 - a short Weierstrass elliptic curve of the form `y^2 = x^3 + 7` over
@@ -50,7 +49,7 @@ impl Secp256k1 {
 		let y_pow2 = f_p.square(b, &p.y);
 		assert_eq(b, "secp256k1_on_curve", &y_pow2, &f_p.add(b, &x_pow3, &self.b));
 
-		b.assert_0("not_point_at_infinity", p.is_point_at_infinity);
+		b.assert_false("not_point_at_infinity", p.is_point_at_infinity);
 	}
 
 	/// Recover the full affine point `(r, y)` by its x coordinate and y parity.
@@ -143,7 +142,7 @@ impl Secp256k1 {
 		let pai_sum = b.band(x_diff_zero, b.bnot(y_diff_zero)); // adding negation
 		let is_point_at_infinity = b.select(pai_1, pai_2, b.select(pai_2, pai_1, pai_sum));
 
-		b.assert_0("not_doubling", bool_to_mask(b, b.band(x_diff_zero, y_diff_zero)));
+		b.assert_false("not_doubling", b.band(x_diff_zero, y_diff_zero));
 
 		Secp256k1Affine {
 			x,

--- a/crates/frontend/src/circuits/secp256k1/tests.rs
+++ b/crates/frontend/src/circuits/secp256k1/tests.rs
@@ -29,9 +29,9 @@ fn test_secp256k1_group_order() {
 
 	let cs = builder.build();
 	let mut w = cs.new_witness_filler();
-	assert!(cs.populate_wire_witness(&mut w).is_ok());
+	cs.populate_wire_witness(&mut w).unwrap();
 
-	assert_eq!(w[acc.is_point_at_infinity], Word::ALL_ONE);
+	assert_eq!(w[acc.is_point_at_infinity] >> 63, Word::ONE);
 }
 
 #[test]
@@ -51,7 +51,7 @@ fn test_secp256k1_pow2pow137() {
 
 	let cs = builder.build();
 	let mut w = cs.new_witness_filler();
-	assert!(cs.populate_wire_witness(&mut w).is_ok());
+	cs.populate_wire_witness(&mut w).unwrap();
 
 	// 0xede2ae24a4f24f0e70e764555e24170cebf045931e5bff973caff9355246e643
 	assert_eq!(w[acc.x.limbs[0]], Word(0x3caff9355246e643));
@@ -78,7 +78,7 @@ fn test_secp256k1_generator_double_and_add() {
 
 	let cs = builder.build();
 	let mut w = cs.new_witness_filler();
-	assert!(cs.populate_wire_witness(&mut w).is_ok());
+	cs.populate_wire_witness(&mut w).unwrap();
 
 	// 0x79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798
 	assert_eq!(w[generator.x.limbs[0]], Word(0x59f2815b16f81798));

--- a/crates/frontend/src/circuits/slice.rs
+++ b/crates/frontend/src/circuits/slice.rs
@@ -1,6 +1,9 @@
 use binius_core::word::Word;
 
-use crate::compiler::{CircuitBuilder, Wire, circuit::WitnessFiller};
+use crate::{
+	circuits::multiplexer::single_wire_multiplex,
+	compiler::{CircuitBuilder, Wire, circuit::WitnessFiller},
+};
 
 /// Verifies that a slice is correctly extracted from an input byte array.
 ///
@@ -28,8 +31,6 @@ impl Slice {
 	///
 	/// # Arguments
 	/// * `b` - Circuit builder
-	/// * `max_n_input` - Maximum input size in bytes (must be multiple of 8)
-	/// * `max_n_slice` - Maximum slice size in bytes (must be multiple of 8)
 	/// * `len_input` - Actual input size in bytes
 	/// * `len_slice` - Actual slice size in bytes
 	/// * `input` - Input array packed as words (8 bytes per word)
@@ -37,50 +38,36 @@ impl Slice {
 	/// * `offset` - Byte offset where slice starts
 	///
 	/// # Panics
-	/// * If max_n_input is not a multiple of 8
-	/// * If max_n_slice is not a multiple of 8
 	/// * If max_n_input >= 2^32
 	/// * If max_n_slice >= 2^32
-	/// * If input.len() != max_n_input / 8
-	/// * If slice.len() != max_n_slice / 8
 	#[allow(clippy::too_many_arguments)]
 	pub fn new(
 		b: &CircuitBuilder,
-		max_n_input: usize,
-		max_n_slice: usize,
 		len_input: Wire,
 		len_slice: Wire,
 		input: Vec<Wire>,
 		slice: Vec<Wire>,
 		offset: Wire,
 	) -> Self {
-		assert_eq!(max_n_input % 8, 0, "max_n_input must be multiple of 8");
-		assert_eq!(max_n_slice % 8, 0, "max_n_slice must be multiple of 8");
-		assert_eq!(input.len(), max_n_input / 8, "input.len() must equal max_n_input / 8");
-		assert_eq!(slice.len(), max_n_slice / 8, "slice.len() must equal max_n_slice / 8");
-
 		// Static assertions to ensure maximum sizes fit within 32 bits
-		assert!(max_n_input < (1u64 << 32) as usize, "max_n_input must be < 2^32");
-		assert!(max_n_slice < (1u64 << 32) as usize, "max_n_slice must be < 2^32");
+		let max_len_input = input.len() << 3;
+		let max_len_slice = slice.len() << 3;
+		assert!(max_len_input < (1u64 << 32) as usize, "max_n_input must be < 2^32");
+		assert!(max_len_slice < (1u64 << 32) as usize, "max_n_slice must be < 2^32");
 
 		// Ensure all values fit in 32 bits to prevent overflow in iadd_32
-		// Check upper 32 bits are zero by ANDing with 0xffffffff00000000
-		let upper_32_mask = Word(0xffffffff00000000);
-		b.assert_band_0("offset_32bit", offset, upper_32_mask);
-		b.assert_band_0("len_slice_32bit", len_slice, upper_32_mask);
-		b.assert_band_0("len_input_32bit", len_input, upper_32_mask);
+		b.assert_0("offset_32bit", b.shr(offset, 32));
+		b.assert_0("len_slice_32bit", b.shr(len_slice, 32));
+		b.assert_0("len_input_32bit", b.shr(len_input, 32));
 
 		// Verify bounds: offset + len_slice <= len_input
 		let offset_plus_len_slice = b.iadd_32(offset, len_slice);
 		let overflow = b.icmp_ult(len_input, offset_plus_len_slice);
-		b.assert_0("bounds_check", overflow);
+		b.assert_false("bounds_check", overflow);
 
 		// Decompose offset = word_offset * 8 + byte_offset
 		let word_offset = b.shr(offset, 3); // offset / 8
 		let byte_offset = b.band(offset, b.add_constant(Word(7))); // offset % 8
-
-		// Check if aligned (byte_offset == 0)
-		let is_aligned_mask = b.icmp_eq(byte_offset, b.add_constant(Word::ZERO));
 
 		// Go over every word in the slice and check that it was copied from the input byte string
 		// correctly.
@@ -88,18 +75,17 @@ impl Slice {
 			let b = b.subcircuit(format!("slice_word[{slice_idx}]"));
 
 			// Check if this word is within the actual slice
-			let word_start = b.add_constant(Word((slice_idx * 8) as u64));
-			let word_partially_valid_mask = b.icmp_ult(word_start, len_slice);
+			let word_start_bytes = slice_idx << 3;
+			let word_partially_valid =
+				b.icmp_ult(b.add_constant(Word(word_start_bytes as u64)), len_slice);
+			// are ANY of the bytes in this present word actually part of the slice proper?
 
 			// Calculate which input word(s) we need
 			let input_word_idx = b.iadd_32(word_offset, b.add_constant(Word(slice_idx as u64)));
 
-			let extracted_word =
-				extract_word(&b, &input, input_word_idx, byte_offset, is_aligned_mask);
+			let extracted_word = extract_word(&b, &input, input_word_idx, byte_offset);
 
 			// For every word, calculate how many bytes are valid and apply appropriate mask
-			let word_start_bytes = slice_idx * 8;
-
 			// Calculate valid bytes in this word: min(len_slice - word_start, 8)
 			// First calculate len_slice - word_start
 			let neg_start = b.add_constant(Word((-(word_start_bytes as i64)) as u64));
@@ -111,30 +97,26 @@ impl Slice {
 			// For partial words, we need to ensure:
 			// 1. The valid bytes match the extracted word
 			// 2. The invalid bytes are zero
-
-			// First, check that invalid bytes in slice are zero
-			// We do this by asserting that slice_word & ~mask == 0
-			// Which is equivalent to asserting slice_word & ~mask == 0 & ~mask
-			let invalid_mask = b.bnot(mask);
-			let invalid_bytes = b.band(slice_word, invalid_mask);
+			// Assert they are equal (only if word is at least partially valid)
 			let zero = b.add_constant(Word::ZERO);
 			b.assert_eq_cond(
+				format!("slice_word_{slice_idx}"),
+				b.band(slice_word, mask),
+				b.band(extracted_word, mask),
+				word_partially_valid,
+			);
+			b.assert_eq_cond(
 				format!("slice_word_{slice_idx}_padding"),
-				invalid_bytes,
+				b.band(slice_word, b.bnot(mask)),
 				zero,
-				word_partially_valid_mask,
+				word_partially_valid,
 			);
 
-			// Then check that valid bytes match
-			let masked_slice = b.band(slice_word, mask);
-			let masked_extracted = b.band(extracted_word, mask);
-
-			// Assert they are equal (only if word is at least partially valid)
 			b.assert_eq_cond(
-				format!("slice_word_{slice_idx}"),
-				masked_slice,
-				masked_extracted,
-				word_partially_valid_mask,
+				format!("slice_word_{slice_idx} non-slice"),
+				slice_word,
+				zero,
+				b.bnot(word_partially_valid),
 			);
 		}
 
@@ -234,64 +216,28 @@ impl Slice {
 /// * `input` - Array of input words to extract from
 /// * `word_idx` - Index of the word to extract
 /// * `byte_offset` - Byte offset within the word (0-7)
-/// * `is_aligned_mask` - Wire that's all-1 if byte_offset is 0, 0 otherwise
 ///
 /// # Returns
 /// A wire containing the extracted 8-byte word
-fn extract_word(
-	b: &CircuitBuilder,
-	input: &[Wire],
-	word_idx: Wire,
-	byte_offset: Wire,
-	is_aligned_mask: Wire,
-) -> Wire {
-	// Aligned case: directly select the word
-	let mut aligned_word = b.add_constant(Word::ZERO);
-	for (i, &word) in input.iter().enumerate() {
-		let i_wire = b.add_constant(Word(i as u64));
-		let is_this_word = b.icmp_eq(word_idx, i_wire);
-		let masked = b.band(word, is_this_word);
-		aligned_word = b.bor(aligned_word, masked);
-	}
-
-	// Unaligned case: need to combine two adjacent words.
-	//
-	// First we extract both words: lo_word and hi_word. lo_word contains some bytes of the
-	// slice we are looking for and the hi_word contains the rest.
-	//
-	// Once we found that we shift those s.t. when we bitwise-or them together we get a full
-	// word. That's going to be our `unaligned_word`.
+pub fn extract_word(b: &CircuitBuilder, input: &[Wire], word_idx: Wire, byte_offset: Wire) -> Wire {
 	let next_word_idx = b.iadd_32(word_idx, b.add_constant(Word(1)));
-	let mut lo_word = b.add_constant(Word::ZERO);
-	let mut hi_word = b.add_constant(Word::ZERO);
-	for (i, &word) in input.iter().enumerate() {
-		let i_wire = b.add_constant(Word(i as u64));
-		let is_lo = b.icmp_eq(word_idx, i_wire);
-		let is_hi = b.icmp_eq(next_word_idx, i_wire);
+	// Aligned case: directly select the word
+	let aligned_word = single_wire_multiplex(b, input, word_idx);
+	let next_word = single_wire_multiplex(b, input, next_word_idx);
+	let zero = b.add_constant(Word::ZERO);
 
-		let masked_low = b.band(word, is_lo);
-		let masked_high = b.band(word, is_hi);
-
-		lo_word = b.bor(lo_word, masked_low);
-		hi_word = b.bor(hi_word, masked_high);
-	}
-	let mut unaligned_word = b.add_constant(Word::ZERO);
-	for offset in 1..8 {
-		let offset_wire = b.add_constant(Word(offset as u64));
-		let is_this_offset = b.icmp_eq(byte_offset, offset_wire);
-
-		let lo_shifted = b.shr(lo_word, (offset * 8) as u32);
-		let hi_shifted = b.shl(hi_word, ((8 - offset) * 8) as u32);
-		let combined = b.bor(lo_shifted, hi_shifted);
-
-		let masked = b.band(combined, is_this_offset);
-		unaligned_word = b.bor(unaligned_word, masked);
-	}
-
-	// Finally select the aligned or unaligned word.
-	let aligned_masked = b.band(aligned_word, is_aligned_mask);
-	let unaligned_masked = b.band(unaligned_word, b.bnot(is_aligned_mask));
-	b.bor(aligned_masked, unaligned_masked)
+	let candidates: Vec<Wire> = (0..8)
+		.map(|i| {
+			let shifted_aligned = b.shr(aligned_word, i << 3);
+			let shifted_next = if i == 0 {
+				zero
+			} else {
+				b.shl(next_word, (8 - i) << 3)
+			};
+			b.bor(shifted_aligned, shifted_next)
+		})
+		.collect();
+	single_wire_multiplex(b, &candidates, byte_offset)
 }
 
 /// Creates a byte mask with the first `n_bytes` bytes set to 0xFF and remaining bytes to 0x00.
@@ -301,8 +247,8 @@ fn extract_word(
 /// - n_bytes = 1: 0x00000000000000FF
 /// - n_bytes = 2: 0x000000000000FFFF
 /// - ...
-/// - n_bytes = 8: 0xFFFFFFFFFFFFFFFF
-/// - n_bytes > 8: 0xFFFFFFFFFFFFFFFF (clamped to full mask)
+/// - n_bytes = 7: 0x00FFFFFFFFFFFFFF
+/// - n_bytes ≥ 8: 0xFFFFFFFFFFFFFFFF
 ///
 /// # Arguments
 /// * `b` - Circuit builder
@@ -310,35 +256,17 @@ fn extract_word(
 ///
 /// # Returns
 /// A wire containing the byte mask
-fn create_byte_mask(b: &CircuitBuilder, n_bytes: Wire) -> Wire {
-	let mut byte_mask = b.add_constant(Word::ZERO);
-
-	// Handle values > 8 by treating them as 8
+pub fn create_byte_mask(b: &CircuitBuilder, n_bytes: Wire) -> Wire {
+	// Handle values ≥ 8 by treating them as 8
 	let eight = b.add_constant(Word(8));
-	let is_gt_eight = b.icmp_ult(eight, n_bytes);
-	let all_ones = b.add_constant(Word(u64::MAX));
+	let is_lt_eight = b.icmp_ult(n_bytes, eight);
+	let all_ones = b.add_constant(Word::ALL_ONE);
 
-	for i in 0..=8 {
-		let i_wire = b.add_constant(Word(i as u64));
-		let is_this_count_mask = b.icmp_eq(n_bytes, i_wire);
-
-		let mask_value = b.add_constant_64(if i == 0 {
-			0
-		} else if i == 8 {
-			u64::MAX
-		} else {
-			(1 << (i * 8)) - 1
-		});
-
-		let this_mask = b.band(mask_value, is_this_count_mask);
-		byte_mask = b.bor(byte_mask, this_mask);
-	}
-
-	// If n_bytes > 8, use all ones
-	let gt_eight_mask = b.band(all_ones, is_gt_eight);
-	byte_mask = b.bor(byte_mask, gt_eight_mask);
-
-	byte_mask
+	let masks: Vec<Wire> = (0..8)
+		.map(|i| b.add_constant_64(0x00FFFFFFFFFFFFFF >> ((7 - i) << 3)))
+		.collect();
+	let in_range_mask = single_wire_multiplex(b, &masks, n_bytes);
+	b.select(is_lt_eight, in_range_mask, all_ones)
 }
 
 #[cfg(test)]
@@ -351,18 +279,14 @@ mod tests {
 		let b = CircuitBuilder::new();
 
 		// Test case: 16-byte input, 8-byte slice at offset 0
-		let max_n_input = 16;
-		let max_n_slice = 8;
-
 		let len_input = b.add_inout();
 		let len_slice = b.add_inout();
 		let offset = b.add_inout();
 
-		let input: Vec<Wire> = (0..max_n_input / 8).map(|_| b.add_inout()).collect();
-		let slice: Vec<Wire> = (0..max_n_slice / 8).map(|_| b.add_inout()).collect();
+		let input: Vec<Wire> = (0..2).map(|_| b.add_inout()).collect();
+		let slice: Vec<Wire> = (0..1).map(|_| b.add_inout()).collect();
 
-		let verifier =
-			Slice::new(&b, max_n_input, max_n_slice, len_input, len_slice, input, slice, offset);
+		let verifier = Slice::new(&b, len_input, len_slice, input, slice, offset);
 
 		let circuit = b.build();
 
@@ -397,18 +321,15 @@ mod tests {
 		let b = CircuitBuilder::new();
 
 		// Test case: 16-byte input, 8-byte slice at offset 3
-		let max_n_input = 16;
-		let max_n_slice = 8;
 
 		let len_input = b.add_inout();
 		let len_slice = b.add_inout();
 		let offset = b.add_inout();
 
-		let input: Vec<Wire> = (0..max_n_input / 8).map(|_| b.add_inout()).collect();
-		let slice: Vec<Wire> = (0..max_n_slice / 8).map(|_| b.add_inout()).collect();
+		let input: Vec<Wire> = (0..2).map(|_| b.add_inout()).collect();
+		let slice: Vec<Wire> = (0..1).map(|_| b.add_inout()).collect();
 
-		let verifier =
-			Slice::new(&b, max_n_input, max_n_slice, len_input, len_slice, input, slice, offset);
+		let verifier = Slice::new(&b, len_input, len_slice, input, slice, offset);
 
 		let circuit = b.build();
 
@@ -444,18 +365,14 @@ mod tests {
 	fn test_bounds_check() {
 		let b = CircuitBuilder::new();
 
-		let max_n_input = 16;
-		let max_n_slice = 8;
-
 		let len_input = b.add_inout();
 		let len_slice = b.add_inout();
 		let offset = b.add_inout();
 
-		let input: Vec<Wire> = (0..max_n_input / 8).map(|_| b.add_inout()).collect();
-		let slice: Vec<Wire> = (0..max_n_slice / 8).map(|_| b.add_inout()).collect();
+		let input: Vec<Wire> = (0..2).map(|_| b.add_inout()).collect();
+		let slice: Vec<Wire> = (0..1).map(|_| b.add_inout()).collect();
 
-		let verifier =
-			Slice::new(&b, max_n_input, max_n_slice, len_input, len_slice, input, slice, offset);
+		let verifier = Slice::new(&b, len_input, len_slice, input, slice, offset);
 
 		let circuit = b.build();
 
@@ -482,18 +399,14 @@ mod tests {
 	fn test_bounds_check_edge_case() {
 		let b = CircuitBuilder::new();
 
-		let max_n_input = 16;
-		let max_n_slice = 8;
-
 		let len_input = b.add_inout();
 		let len_slice = b.add_inout();
 		let offset = b.add_inout();
 
-		let input: Vec<Wire> = (0..max_n_input / 8).map(|_| b.add_inout()).collect();
-		let slice: Vec<Wire> = (0..max_n_slice / 8).map(|_| b.add_inout()).collect();
+		let input: Vec<Wire> = (0..2).map(|_| b.add_inout()).collect();
+		let slice: Vec<Wire> = (0..1).map(|_| b.add_inout()).collect();
 
-		let verifier =
-			Slice::new(&b, max_n_input, max_n_slice, len_input, len_slice, input, slice, offset);
+		let verifier = Slice::new(&b, len_input, len_slice, input, slice, offset);
 		let circuit = b.build();
 
 		// Test exact boundary: offset + len_slice == len_input (should be valid)
@@ -522,18 +435,14 @@ mod tests {
 	fn test_empty_slice() {
 		let b = CircuitBuilder::new();
 
-		let max_n_input = 16;
-		let max_n_slice = 8;
-
 		let len_input = b.add_inout();
 		let len_slice = b.add_inout();
 		let offset = b.add_inout();
 
-		let input: Vec<Wire> = (0..max_n_input / 8).map(|_| b.add_inout()).collect();
-		let slice: Vec<Wire> = (0..max_n_slice / 8).map(|_| b.add_inout()).collect();
+		let input: Vec<Wire> = (0..2).map(|_| b.add_inout()).collect();
+		let slice: Vec<Wire> = (0..1).map(|_| b.add_inout()).collect();
 
-		let verifier =
-			Slice::new(&b, max_n_input, max_n_slice, len_input, len_slice, input, slice, offset);
+		let verifier = Slice::new(&b, len_input, len_slice, input, slice, offset);
 		let circuit = b.build();
 
 		// Test with len_slice = 0
@@ -559,18 +468,14 @@ mod tests {
 	fn test_mismatched_slice_content() {
 		let b = CircuitBuilder::new();
 
-		let max_n_input = 16;
-		let max_n_slice = 8;
-
 		let len_input = b.add_inout();
 		let len_slice = b.add_inout();
 		let offset = b.add_inout();
 
-		let input: Vec<Wire> = (0..max_n_input / 8).map(|_| b.add_inout()).collect();
-		let slice: Vec<Wire> = (0..max_n_slice / 8).map(|_| b.add_inout()).collect();
+		let input: Vec<Wire> = (0..2).map(|_| b.add_inout()).collect();
+		let slice: Vec<Wire> = (0..1).map(|_| b.add_inout()).collect();
 
-		let verifier =
-			Slice::new(&b, max_n_input, max_n_slice, len_input, len_slice, input, slice, offset);
+		let verifier = Slice::new(&b, len_input, len_slice, input, slice, offset);
 		let circuit = b.build();
 
 		// Test with wrong slice content
@@ -595,18 +500,14 @@ mod tests {
 	fn test_offset_at_end() {
 		let b = CircuitBuilder::new();
 
-		let max_n_input = 16;
-		let max_n_slice = 8;
-
 		let len_input = b.add_inout();
 		let len_slice = b.add_inout();
 		let offset = b.add_inout();
 
-		let input: Vec<Wire> = (0..max_n_input / 8).map(|_| b.add_inout()).collect();
-		let slice: Vec<Wire> = (0..max_n_slice / 8).map(|_| b.add_inout()).collect();
+		let input: Vec<Wire> = (0..2).map(|_| b.add_inout()).collect();
+		let slice: Vec<Wire> = (0..1).map(|_| b.add_inout()).collect();
 
-		let verifier =
-			Slice::new(&b, max_n_input, max_n_slice, len_input, len_slice, input, slice, offset);
+		let verifier = Slice::new(&b, len_input, len_slice, input, slice, offset);
 		let circuit = b.build();
 
 		// Test offset at end with empty slice
@@ -633,18 +534,14 @@ mod tests {
 		// This test verifies that byte extraction works correctly for all paths
 		let b = CircuitBuilder::new();
 
-		let max_n_input = 24; // 3 words
-		let max_n_slice = 8; // 1 word
-
 		let len_input = b.add_inout();
 		let len_slice = b.add_inout();
 		let offset = b.add_inout();
 
-		let input: Vec<Wire> = (0..max_n_input / 8).map(|_| b.add_inout()).collect();
-		let slice: Vec<Wire> = (0..max_n_slice / 8).map(|_| b.add_inout()).collect();
+		let input: Vec<Wire> = (0..3).map(|_| b.add_inout()).collect();
+		let slice: Vec<Wire> = (0..1).map(|_| b.add_inout()).collect();
 
-		let verifier =
-			Slice::new(&b, max_n_input, max_n_slice, len_input, len_slice, input, slice, offset);
+		let verifier = Slice::new(&b, len_input, len_slice, input, slice, offset);
 		let circuit = b.build();
 
 		// Test extraction from each word with different offsets
@@ -686,26 +583,14 @@ mod tests {
 
 		// Set up circuit with specific sizes
 		// max_n_slice = 16 (2 words) but we'll use len_slice = 12 (1.5 words)
-		let max_n_input = 24; // 3 words
-		let max_n_slice = 16; // 2 words
-
 		let len_input = b.add_inout();
 		let len_slice = b.add_inout();
 		let offset = b.add_inout();
 
-		let input: Vec<Wire> = (0..max_n_input / 8).map(|_| b.add_inout()).collect();
-		let slice: Vec<Wire> = (0..max_n_slice / 8).map(|_| b.add_inout()).collect();
+		let input: Vec<Wire> = (0..3).map(|_| b.add_inout()).collect();
+		let slice: Vec<Wire> = (0..2).map(|_| b.add_inout()).collect();
 
-		let verifier = Slice::new(
-			&b,
-			max_n_input,
-			max_n_slice,
-			len_input,
-			len_slice,
-			input.clone(),
-			slice.clone(),
-			offset,
-		);
+		let verifier = Slice::new(&b, len_input, len_slice, input.clone(), slice.clone(), offset);
 		let circuit = b.build();
 
 		// Test case: len_slice = 12 bytes (1.5 words)
@@ -763,9 +648,6 @@ mod tests {
 		// Simplest test case: 1 word slice with only 4 valid bytes
 		let b = CircuitBuilder::new();
 
-		let max_n_input = 8;
-		let max_n_slice = 8;
-
 		let len_input = b.add_inout();
 		let len_slice = b.add_inout();
 		let offset = b.add_inout();
@@ -773,16 +655,7 @@ mod tests {
 		let input: Vec<Wire> = (0..1).map(|_| b.add_inout()).collect();
 		let slice: Vec<Wire> = (0..1).map(|_| b.add_inout()).collect();
 
-		let verifier = Slice::new(
-			&b,
-			max_n_input,
-			max_n_slice,
-			len_input,
-			len_slice,
-			input.clone(),
-			slice.clone(),
-			offset,
-		);
+		let verifier = Slice::new(&b, len_input, len_slice, input.clone(), slice.clone(), offset);
 		let circuit = b.build();
 
 		// Test with 4 bytes
@@ -872,18 +745,14 @@ mod tests {
 	fn test_large_offset_overflow() {
 		let b = CircuitBuilder::new();
 
-		let max_n_input = 16;
-		let max_n_slice = 8;
-
 		let len_input = b.add_inout();
 		let len_slice = b.add_inout();
 		let offset = b.add_inout();
 
-		let input: Vec<Wire> = (0..max_n_input / 8).map(|_| b.add_inout()).collect();
-		let slice: Vec<Wire> = (0..max_n_slice / 8).map(|_| b.add_inout()).collect();
+		let input: Vec<Wire> = (0..2).map(|_| b.add_inout()).collect();
+		let slice: Vec<Wire> = (0..1).map(|_| b.add_inout()).collect();
 
-		let verifier =
-			Slice::new(&b, max_n_input, max_n_slice, len_input, len_slice, input, slice, offset);
+		let verifier = Slice::new(&b, len_input, len_slice, input.clone(), slice.clone(), offset);
 		let circuit = b.build();
 
 		// Test with very large offset that should fail 32-bit check
@@ -909,18 +778,14 @@ mod tests {
 	fn test_32bit_validation() {
 		let b = CircuitBuilder::new();
 
-		let max_n_input = 16;
-		let max_n_slice = 8;
-
 		let len_input = b.add_inout();
 		let len_slice = b.add_inout();
 		let offset = b.add_inout();
 
-		let input: Vec<Wire> = (0..max_n_input / 8).map(|_| b.add_inout()).collect();
-		let slice: Vec<Wire> = (0..max_n_slice / 8).map(|_| b.add_inout()).collect();
+		let input: Vec<Wire> = (0..2).map(|_| b.add_inout()).collect();
+		let slice: Vec<Wire> = (0..1).map(|_| b.add_inout()).collect();
 
-		let verifier =
-			Slice::new(&b, max_n_input, max_n_slice, len_input, len_slice, input, slice, offset);
+		let verifier = Slice::new(&b, len_input, len_slice, input.clone(), slice.clone(), offset);
 		let circuit = b.build();
 
 		// Test multiple 32-bit constraint violations
@@ -965,18 +830,14 @@ mod tests {
 	fn test_edge_case_len_input_zero() {
 		let b = CircuitBuilder::new();
 
-		let max_n_input = 16;
-		let max_n_slice = 8;
-
 		let len_input = b.add_inout();
 		let len_slice = b.add_inout();
 		let offset = b.add_inout();
 
-		let input: Vec<Wire> = (0..max_n_input / 8).map(|_| b.add_inout()).collect();
-		let slice: Vec<Wire> = (0..max_n_slice / 8).map(|_| b.add_inout()).collect();
+		let input: Vec<Wire> = (0..2).map(|_| b.add_inout()).collect();
+		let slice: Vec<Wire> = (0..1).map(|_| b.add_inout()).collect();
 
-		let verifier =
-			Slice::new(&b, max_n_input, max_n_slice, len_input, len_slice, input, slice, offset);
+		let verifier = Slice::new(&b, len_input, len_slice, input.clone(), slice.clone(), offset);
 		let circuit = b.build();
 
 		// Test empty input with empty slice at offset 0
@@ -1002,18 +863,14 @@ mod tests {
 	fn test_edge_case_len_input_zero_with_nonzero_slice() {
 		let b = CircuitBuilder::new();
 
-		let max_n_input = 16;
-		let max_n_slice = 8;
-
 		let len_input = b.add_inout();
 		let len_slice = b.add_inout();
 		let offset = b.add_inout();
 
-		let input: Vec<Wire> = (0..max_n_input / 8).map(|_| b.add_inout()).collect();
-		let slice: Vec<Wire> = (0..max_n_slice / 8).map(|_| b.add_inout()).collect();
+		let input: Vec<Wire> = (0..2).map(|_| b.add_inout()).collect();
+		let slice: Vec<Wire> = (0..1).map(|_| b.add_inout()).collect();
 
-		let verifier =
-			Slice::new(&b, max_n_input, max_n_slice, len_input, len_slice, input, slice, offset);
+		let verifier = Slice::new(&b, len_input, len_slice, input.clone(), slice.clone(), offset);
 		let circuit = b.build();
 
 		// Test empty input with non-empty slice
@@ -1034,22 +891,18 @@ mod tests {
 	fn test_padding_beyond_actual_data() {
 		let b = CircuitBuilder::new();
 
-		let max_n_input = 24; // 3 words
-		let max_n_slice = 16; // 2 words
-
 		let len_input = b.add_inout();
 		let len_slice = b.add_inout();
 		let offset = b.add_inout();
 
-		let input: Vec<Wire> = (0..max_n_input / 8).map(|_| b.add_inout()).collect();
-		let slice: Vec<Wire> = (0..max_n_slice / 8).map(|_| b.add_inout()).collect();
+		let input: Vec<Wire> = (0..3).map(|_| b.add_inout()).collect();
+		let slice: Vec<Wire> = (0..2).map(|_| b.add_inout()).collect();
 
 		// Save wire references before moving vectors
 		let input_wire_2 = input[2];
 		let slice_wire_1 = slice[1];
 
-		let verifier =
-			Slice::new(&b, max_n_input, max_n_slice, len_input, len_slice, input, slice, offset);
+		let verifier = Slice::new(&b, len_input, len_slice, input, slice, offset);
 		let circuit = b.build();
 
 		// Test with actual data smaller than allocated space

--- a/crates/frontend/src/circuits/subset_sum.rs
+++ b/crates/frontend/src/circuits/subset_sum.rs
@@ -59,7 +59,7 @@ impl SubsetSum {
 		for i in 0..len {
 			(sum, carry) = builder.iadd_cin_cout(sum, values_masked[i], carry);
 			// check that no overflow occurred
-			builder.assert_0("no overflow", builder.shr(carry, 63));
+			builder.assert_false("no overflow", carry);
 		}
 
 		// check that the sum matches the target

--- a/crates/frontend/src/compiler/eval_form/builder.rs
+++ b/crates/frontend/src/compiler/eval_form/builder.rs
@@ -238,6 +238,20 @@ impl BytecodeBuilder {
 		self.emit_u32(error_id);
 	}
 
+	pub fn emit_assert_false(&mut self, src: u32, error_id: u32) {
+		self.n_eval_insn += 1;
+		self.emit_u8(0x63);
+		self.emit_reg(src);
+		self.emit_u32(error_id);
+	}
+
+	pub fn emit_assert_true(&mut self, src: u32, error_id: u32) {
+		self.n_eval_insn += 1;
+		self.emit_u8(0x64);
+		self.emit_reg(src);
+		self.emit_u32(error_id);
+	}
+
 	// Hint calls
 	pub fn emit_hint(
 		&mut self,

--- a/crates/frontend/src/compiler/eval_form/interpreter.rs
+++ b/crates/frontend/src/compiler/eval_form/interpreter.rs
@@ -130,6 +130,8 @@ impl<'a> Interpreter<'a> {
 				0x60 => self.exec_assert_eq(ctx),
 				0x61 => self.exec_assert_zero(ctx),
 				0x62 => self.exec_assert_cond(ctx),
+				0x63 => self.exec_assert_false(ctx),
+				0x64 => self.exec_assert_true(ctx),
 
 				// Hint calls
 				0x80 => self.exec_hint(ctx),
@@ -402,6 +404,28 @@ impl<'a> Interpreter<'a> {
 					format!("conditional assert: {val1:?} != {val2:?}"),
 				);
 			}
+		}
+	}
+
+	fn exec_assert_false(&mut self, ctx: &mut ExecutionContext<'_>) {
+		let src = self.read_reg();
+		let error_id = self.read_u32();
+
+		let val = self.load(ctx, src);
+
+		if val & Word::MSB_ONE != Word::ZERO {
+			ctx.note_assertion_failure(error_id, format!("{val:?} & MSB_ONE != 0"));
+		}
+	}
+
+	fn exec_assert_true(&mut self, ctx: &mut ExecutionContext<'_>) {
+		let src = self.read_reg();
+		let error_id = self.read_u32();
+
+		let val = self.load(ctx, src);
+
+		if val & Word::MSB_ONE != Word::MSB_ONE {
+			ctx.note_assertion_failure(error_id, format!("{val:?} & MSB_ONE != MSB_ONE"));
 		}
 	}
 

--- a/crates/frontend/src/compiler/gate/assert_eq_cond.rs
+++ b/crates/frontend/src/compiler/gate/assert_eq_cond.rs
@@ -1,20 +1,20 @@
 //! Conditional equality assertion.
 //!
-//! Enforces `x = y` when `mask = all-1`, no constraint when `mask = 0`.
+//! Enforces `x = y` when the MSB-bool value of `cond` is true, and no constraint otherwise.
 //!
 //! # Algorithm
 //!
-//! Uses a mask to conditionally enforce equality: `(x ^ y) & mask = 0`.
-//! When mask is all-1, this enforces `x = y`. When mask is 0, the constraint is satisfied
+//! Uses a mask to conditionally enforce equality: `(x ^ y) & (cond ~>> 63) = 0`.
+//! When `cond` is MSB-bool-true, this enforces `x = y`. otherwise, the constraint is satisfied
 //! trivially.
 //!
 //! # Constraints
 //!
 //! The gate generates 1 AND constraint:
-//! - `(x ⊕ y) ∧ mask = 0`
+//! - `(x ⊕ y) ∧ (cond ~>> 63) = 0`
 
 use crate::compiler::{
-	constraint_builder::{ConstraintBuilder, empty, xor2},
+	constraint_builder::{ConstraintBuilder, empty, sar, xor2},
 	gate::opcode::OpcodeShape,
 	gate_graph::{Gate, GateData, GateParam, Wire},
 	pathspec::PathSpec,
@@ -26,17 +26,18 @@ pub fn shape() -> OpcodeShape {
 		n_in: 3,
 		n_out: 0,
 		n_aux: 0,
-		n_scratch: 0,
+		n_scratch: 1,
 		n_imm: 0,
 	}
 }
 
 pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) {
 	let GateParam { inputs, .. } = data.gate_param();
-	let [x, y, mask] = inputs else { unreachable!() };
+	let [x, y, cond] = inputs else { unreachable!() };
 
-	// Constraint: (x ⊕ y) ∧ mask = 0
-	builder.and().a(xor2(*x, *y)).b(*mask).c(empty()).build();
+	// Constraint: (x ⊕ y) ∧ (cond ~>> 63) = 0
+	let mask = sar(*cond, 63);
+	builder.and().a(xor2(*x, *y)).b(mask).c(empty()).build();
 }
 
 pub fn emit_eval_bytecode(
@@ -46,8 +47,15 @@ pub fn emit_eval_bytecode(
 	builder: &mut crate::compiler::eval_form::BytecodeBuilder,
 	wire_to_reg: impl Fn(Wire) -> u32,
 ) {
-	let GateParam { inputs, .. } = data.gate_param();
-	let [x, y, mask] = inputs else { unreachable!() };
+	let GateParam {
+		inputs, scratch, ..
+	} = data.gate_param();
+	let [x, y, cond] = inputs else { unreachable!() };
+	let [mask] = scratch else { unreachable!() };
+
+	// Broadcast MSB: mask = cond >> 63 (arithmetic)
+	builder.emit_sar(wire_to_reg(*mask), wire_to_reg(*cond), 63);
+
 	builder.emit_assert_cond(
 		wire_to_reg(*mask),
 		wire_to_reg(*x),

--- a/crates/frontend/src/compiler/gate/assert_false.rs
+++ b/crates/frontend/src/compiler/gate/assert_false.rs
@@ -1,0 +1,56 @@
+//! Assert that a wire, interpreted as a MSB-bool, is false.
+//! i.e., we are checking whether its most-significant bit is 0. all lower bits get ignored.
+//!
+//! Enforces `x & 0x8000000000000000 = 0` using an AND constraint.
+//!
+//! # Algorithm
+//!
+//! Uses the constraint `x ∧ 0x8000000000000000 = 0`.
+//!
+//! # Constraints
+//!
+//! The gate generates 1 AND constraint:
+//! - `x ∧ 0x8000000000000000 = 0`
+
+use binius_core::word::Word;
+
+use crate::compiler::{
+	constraint_builder::{ConstraintBuilder, empty},
+	gate::opcode::OpcodeShape,
+	gate_graph::{Gate, GateData, GateParam, Wire},
+	pathspec::PathSpec,
+};
+
+pub fn shape() -> OpcodeShape {
+	OpcodeShape {
+		const_in: &[Word::MSB_ONE],
+		n_in: 1,
+		n_out: 0,
+		n_aux: 0,
+		n_scratch: 0,
+		n_imm: 0,
+	}
+}
+
+pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) {
+	let GateParam {
+		constants, inputs, ..
+	} = data.gate_param();
+	let [msb_1] = constants else { unreachable!() };
+	let [x] = inputs else { unreachable!() };
+
+	// Constraint: x ∧ msb_1 = msb_1
+	builder.and().a(*x).b(*msb_1).c(empty()).build();
+}
+
+pub fn emit_eval_bytecode(
+	_gate: Gate,
+	data: &GateData,
+	assertion_path: PathSpec,
+	builder: &mut crate::compiler::eval_form::BytecodeBuilder,
+	wire_to_reg: impl Fn(Wire) -> u32,
+) {
+	let GateParam { inputs, .. } = data.gate_param();
+	let [x] = inputs else { unreachable!() };
+	builder.emit_assert_false(wire_to_reg(*x), assertion_path.as_u32());
+}

--- a/crates/frontend/src/compiler/gate/assert_true.rs
+++ b/crates/frontend/src/compiler/gate/assert_true.rs
@@ -1,0 +1,56 @@
+//! Assert that a wire, interpreted as a MSB-bool, is true.
+//! i.e., we are checking whether its most-significant bit is 1. all lower bits get ignored.
+//!
+//! Enforces `x & 0x8000000000000000 = 0x8000000000000000` using an AND constraint.
+//!
+//! # Algorithm
+//!
+//! Uses the constraint `x ∧ 0x8000000000000000 = 0x8000000000000000`.
+//!
+//! # Constraints
+//!
+//! The gate generates 1 AND constraint:
+//! - `x ∧ 0x8000000000000000 = 0`
+
+use binius_core::word::Word;
+
+use crate::compiler::{
+	constraint_builder::ConstraintBuilder,
+	gate::opcode::OpcodeShape,
+	gate_graph::{Gate, GateData, GateParam, Wire},
+	pathspec::PathSpec,
+};
+
+pub fn shape() -> OpcodeShape {
+	OpcodeShape {
+		const_in: &[Word::MSB_ONE],
+		n_in: 1,
+		n_out: 0,
+		n_aux: 0,
+		n_scratch: 0,
+		n_imm: 0,
+	}
+}
+
+pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) {
+	let GateParam {
+		constants, inputs, ..
+	} = data.gate_param();
+	let [msb_1] = constants else { unreachable!() };
+	let [x] = inputs else { unreachable!() };
+
+	// Constraint: x ∧ msb_1 = msb_1
+	builder.and().a(*x).b(*msb_1).c(*msb_1).build();
+}
+
+pub fn emit_eval_bytecode(
+	_gate: Gate,
+	data: &GateData,
+	assertion_path: PathSpec,
+	builder: &mut crate::compiler::eval_form::BytecodeBuilder,
+	wire_to_reg: impl Fn(Wire) -> u32,
+) {
+	let GateParam { inputs, .. } = data.gate_param();
+	let [x] = inputs else { unreachable!() };
+	builder.emit_assert_true(wire_to_reg(*x), assertion_path.as_u32());
+}

--- a/crates/frontend/src/compiler/gate/mod.rs
+++ b/crates/frontend/src/compiler/gate/mod.rs
@@ -13,6 +13,8 @@ pub mod assert_0;
 pub mod assert_band_0;
 pub mod assert_eq;
 pub mod assert_eq_cond;
+pub mod assert_false;
+pub mod assert_true;
 pub mod band;
 pub mod biguint_divide_hint;
 pub mod biguint_mod_pow_hint;
@@ -53,9 +55,11 @@ pub fn constrain(gate: Gate, graph: &GateGraph, builder: &mut ConstraintBuilder)
 		Opcode::AssertEq => assert_eq::constrain(gate, data, builder),
 		Opcode::Assert0 => assert_0::constrain(gate, data, builder),
 		Opcode::AssertBand0 => assert_band_0::constrain(gate, data, builder),
+		Opcode::AssertFalse => assert_false::constrain(gate, data, builder),
+		Opcode::AssertTrue => assert_true::constrain(gate, data, builder),
+		Opcode::AssertEqCond => assert_eq_cond::constrain(gate, data, builder),
 		Opcode::Imul => imul::constrain(gate, data, builder),
 		Opcode::Smul => smul::constrain(gate, data, builder),
-		Opcode::AssertEqCond => assert_eq_cond::constrain(gate, data, builder),
 		Opcode::IcmpUlt => icmp_ult::constrain(gate, data, builder),
 		Opcode::IcmpEq => icmp_eq::constrain(gate, data, builder),
 		Opcode::ExtractByte => extract_byte::constrain(gate, data, builder),
@@ -105,6 +109,14 @@ pub fn emit_gate_bytecode(
 		Opcode::AssertEqCond => {
 			let assertion_path = graph.assertion_names[gate];
 			assert_eq_cond::emit_eval_bytecode(gate, data, assertion_path, builder, wire_to_reg)
+		}
+		Opcode::AssertFalse => {
+			let assertion_path = graph.assertion_names[gate];
+			assert_false::emit_eval_bytecode(gate, data, assertion_path, builder, wire_to_reg)
+		}
+		Opcode::AssertTrue => {
+			let assertion_path = graph.assertion_names[gate];
+			assert_true::emit_eval_bytecode(gate, data, assertion_path, builder, wire_to_reg)
 		}
 		Opcode::Imul => imul::emit_eval_bytecode(gate, data, builder, wire_to_reg),
 		Opcode::Smul => smul::emit_eval_bytecode(gate, data, builder, wire_to_reg),

--- a/crates/frontend/src/compiler/gate/opcode.rs
+++ b/crates/frontend/src/compiler/gate/opcode.rs
@@ -39,6 +39,8 @@ pub enum Opcode {
 	AssertEq,
 	Assert0,
 	AssertBand0,
+	AssertFalse,
+	AssertTrue,
 	AssertEqCond,
 
 	// Hints
@@ -123,6 +125,8 @@ impl Opcode {
 			Opcode::AssertEq => gate::assert_eq::shape(),
 			Opcode::Assert0 => gate::assert_0::shape(),
 			Opcode::AssertBand0 => gate::assert_band_0::shape(),
+			Opcode::AssertFalse => gate::assert_false::shape(),
+			Opcode::AssertTrue => gate::assert_true::shape(),
 			Opcode::AssertEqCond => gate::assert_eq_cond::shape(),
 
 			// Hints (no constraints)

--- a/crates/frontend/src/compiler/gate/select.rs
+++ b/crates/frontend/src/compiler/gate/select.rs
@@ -6,7 +6,7 @@
 //!
 //! The gate inspects the MSB (Most Significant Bit) of the condition value to select between
 //! two inputs. This is computed using a single AND constraint with the formula:
-//! `out = f ⊕ ((cond >> 63) ∧ (t ⊕ f))`
+//! `out = f ⊕ ((cond ~>> 63) ∧ (t ⊕ f))`
 //!
 //! The arithmetic shift right by 63 broadcasts the MSB to all bit positions, creating
 //! an all-ones mask if MSB=1 or all-zeros if MSB=0.

--- a/crates/frontend/src/compiler/tests.rs
+++ b/crates/frontend/src/compiler/tests.rs
@@ -84,7 +84,7 @@ fn test_icmp_ult() {
 	let b = builder.add_inout();
 	let actual = builder.icmp_ult(a, b);
 	let expected = builder.add_inout();
-	builder.assert_eq("lt", actual, expected);
+	builder.assert_false("lt", builder.bxor(actual, expected));
 	let circuit = builder.build();
 
 	// check that it actually works.
@@ -106,7 +106,7 @@ fn test_icmp_eq() {
 	let b = builder.add_inout();
 	let actual = builder.icmp_eq(a, b);
 	let expected = builder.add_inout();
-	builder.assert_eq("eq", actual, expected);
+	builder.assert_false("eq", builder.bxor(actual, expected));
 	let circuit = builder.build();
 
 	// check that it actually works.
@@ -297,7 +297,7 @@ fn prop_check_icmp_ult(a: u64, b: u64, expected_result: Word) {
 	let mut w = circuit.new_witness_filler();
 	circuit.populate_wire_witness(&mut w).unwrap();
 
-	assert_eq!(w[result_wire], expected_result);
+	assert_eq!(w[result_wire] >> 63, expected_result >> 63);
 
 	let cs = circuit.constraint_system();
 	verify_constraints(cs, &w.value_vec).unwrap();
@@ -313,7 +313,7 @@ fn prop_check_icmp_eq(a: u64, b: u64, expected_result: Word) {
 	let mut w = circuit.new_witness_filler();
 	circuit.populate_wire_witness(&mut w).unwrap();
 
-	assert_eq!(w[result_wire], expected_result);
+	assert_eq!(w[result_wire] >> 63, expected_result >> 63);
 
 	let cs = circuit.constraint_system();
 	verify_constraints(cs, &w.value_vec).unwrap();

--- a/crates/prover/benches/shift_reduction.rs
+++ b/crates/prover/benches/shift_reduction.rs
@@ -40,7 +40,7 @@ pub fn create_sha256_cs_with_witness(
 	// Generate random message bytes of specified length
 	let mut message_bytes = vec![0u8; message_len_bytes];
 	rng.fill_bytes(&mut message_bytes);
-	sha256.populate_len(&mut witness_filler, message_bytes.len());
+	sha256.populate_len_bytes(&mut witness_filler, message_bytes.len());
 	sha256.populate_message(&mut witness_filler, &message_bytes);
 
 	// Calculate SHA256 digest of the message dynamically

--- a/crates/prover/tests/shift.rs
+++ b/crates/prover/tests/shift.rs
@@ -55,7 +55,7 @@ pub fn create_sha256_cs_with_witness() -> (ConstraintSystem, ValueVec) {
 
 	// Populate with concrete message: "abc"
 	let message_bytes = b"abc";
-	sha256.populate_len(&mut witness_filler, message_bytes.len());
+	sha256.populate_len_bytes(&mut witness_filler, message_bytes.len());
 	sha256.populate_message(&mut witness_filler, message_bytes);
 
 	// Calculate SHA256 digest of the message dynamically
@@ -83,24 +83,21 @@ pub fn create_concat_cs_with_witness() -> (ConstraintSystem, ValueVec) {
 	// Create terms: "Hello" + " " + "World!"
 	let terms = vec![
 		Term {
-			len: builder.add_witness(),
+			len_bytes: builder.add_witness(),
 			data: (0..1).map(|_| builder.add_witness()).collect(),
-			max_len: 8,
 		},
 		Term {
-			len: builder.add_witness(),
+			len_bytes: builder.add_witness(),
 			data: (0..1).map(|_| builder.add_witness()).collect(),
-			max_len: 8,
 		},
 		Term {
-			len: builder.add_witness(),
+			len_bytes: builder.add_witness(),
 			data: (0..1).map(|_| builder.add_witness()).collect(),
-			max_len: 8,
 		},
 	];
 
 	// Create the Concat circuit
-	let concat = Concat::new(&builder, max_n_joined, len_joined, joined, terms);
+	let concat = Concat::new(&builder, len_joined, joined, terms);
 
 	let circuit = builder.build();
 	let mut witness_filler = circuit.new_witness_filler();
@@ -112,17 +109,17 @@ pub fn create_concat_cs_with_witness() -> (ConstraintSystem, ValueVec) {
 	let joined_data = b"Hello World!";
 
 	// Populate terms
-	concat.terms[0].populate_len(&mut witness_filler, term1_data.len());
+	concat.terms[0].populate_len_bytes(&mut witness_filler, term1_data.len());
 	concat.terms[0].populate_data(&mut witness_filler, term1_data);
 
-	concat.terms[1].populate_len(&mut witness_filler, term2_data.len());
+	concat.terms[1].populate_len_bytes(&mut witness_filler, term2_data.len());
 	concat.terms[1].populate_data(&mut witness_filler, term2_data);
 
-	concat.terms[2].populate_len(&mut witness_filler, term3_data.len());
+	concat.terms[2].populate_len_bytes(&mut witness_filler, term3_data.len());
 	concat.terms[2].populate_data(&mut witness_filler, term3_data);
 
 	// Populate joined result
-	concat.populate_len_joined(&mut witness_filler, joined_data.len());
+	concat.populate_len_joined_bytes(&mut witness_filler, joined_data.len());
 	concat.populate_joined(&mut witness_filler, joined_data);
 
 	// Get the witness vector
@@ -135,23 +132,18 @@ pub fn create_slice_cs_with_witness() -> (ConstraintSystem, ValueVec) {
 	use binius_frontend::circuits::slice::Slice;
 
 	let builder = CircuitBuilder::new();
-	let max_n_input: usize = 32; // Maximum input size
-	let max_n_slice: usize = 16; // Maximum slice size
 
 	// Create wires for slice circuit
 	let len_input = builder.add_witness();
 	let len_slice = builder.add_witness();
-	let input: Vec<binius_frontend::compiler::Wire> = (0..max_n_input / 8)
-		.map(|_| builder.add_witness())
-		.collect();
-	let slice: Vec<binius_frontend::compiler::Wire> = (0..max_n_slice / 8)
-		.map(|_| builder.add_witness())
-		.collect();
+	let input: Vec<binius_frontend::compiler::Wire> =
+		(0..4).map(|_| builder.add_witness()).collect();
+	let slice: Vec<binius_frontend::compiler::Wire> =
+		(0..2).map(|_| builder.add_witness()).collect();
 	let offset = builder.add_witness();
 
 	// Create the Slice circuit
-	let slice_circuit =
-		Slice::new(&builder, max_n_input, max_n_slice, len_input, len_slice, input, slice, offset);
+	let slice_circuit = Slice::new(&builder, len_input, len_slice, input, slice, offset);
 
 	let circuit = builder.build();
 	let mut witness_filler = circuit.new_witness_filler();


### PR DESCRIPTION
this PR fixes https://linear.app/irreducible/issue/ENG2-154/migrate-to-msb-only-bool.

now:

- `icmp_eq` and `icmp_ult` return MSB-bools. the resulting wire's MSB is 1 or 0 depending on if the thing is true or false. _the non-most-significant bits of these wires are undefined_ (they can be anything). this brings both down from 2 constraints --> 1.
- `assert_eq_cond` now works with any MSB-bool as its `cond`; previously it required a `mask` that was all-1 or all-0.
- also added new builder assertions: `assert_true`​ and `assert_false`​. they assert something about the MSB of the wire given to them and ignore the lower bits.

making the above simple changes broke an enormous amount of things throughout the codebase.

i fixed all of them (@GraDKh handled `float64`). In the process, I streamlined and improved a lot of logic. This included major rewrites of keccak, slice, concat, base64, JWT, and so on.