### PR TITLE
pendantic: naming consistency

### DIFF
--- a/crates/frontend/src/circuits/blake2b/circuit.rs
+++ b/crates/frontend/src/circuits/blake2b/circuit.rs
@@ -223,9 +223,7 @@ pub fn compress(
 	v[13] = builder.bxor(v[13], t_high);
 
 	// Conditionally invert v[14] for last block
-	let all_ones = builder.add_constant(Word::ALL_ONE);
-	let inverted = builder.bxor(v[14], all_ones);
-	v[14] = builder.select(last_block_flag, inverted, v[14]);
+	v[14] = builder.select(last_block_flag, builder.bnot(v[14]), v[14]);
 
 	// 12 rounds of mixing
 	for round in 0..ROUNDS {

--- a/crates/frontend/src/circuits/blake2b/tests.rs
+++ b/crates/frontend/src/circuits/blake2b/tests.rs
@@ -44,8 +44,8 @@ mod blake2b_tests {
 		vectors.push((vec![0xAAu8; 2 * BLOCK_BYTES + 1], "just_over_two_blocks".to_string()));
 
 		// Pattern tests
-		vectors.push((vec![0x00u8; 64], "all_zeros_64".to_string()));
-		vectors.push((vec![0xFFu8; 64], "all_ones_64".to_string()));
+		vectors.push((vec![0x00u8; 64], "all_zero_64".to_string()));
+		vectors.push((vec![0xFFu8; 64], "all_one_64".to_string()));
 		vectors.push(((0..64u8).collect(), "sequential_64".to_string()));
 
 		// Various sizes

--- a/crates/frontend/src/circuits/keccak/mod.rs
+++ b/crates/frontend/src/circuits/keccak/mod.rs
@@ -127,10 +127,11 @@ impl Keccak {
 			.collect();
 
 		let zero = b.add_constant(Word::ZERO);
-		let msb_1 = b.add_constant(Word::MSB_ONE);
+		let msb_one = b.add_constant(Word::MSB_ONE);
 		let len_bytes_mod_8 = b.band(len_bytes, b.add_constant_64(7));
 		let expected_partial = single_wire_multiplex(b, &candidates, len_bytes_mod_8);
-		let with_possible_end = b.bxor(expected_partial, b.select(is_not_last_column, zero, msb_1));
+		let with_possible_end =
+			b.bxor(expected_partial, b.select(is_not_last_column, zero, msb_one));
 
 		b.assert_eq("expected partial", with_possible_end, boundary_padded_word);
 
@@ -156,7 +157,7 @@ impl Keccak {
 				if column_index == 16 {
 					// last word in the block
 					let must_check_delimiter = b.band(is_end_block, is_not_last_column);
-					b.assert_eq_cond("delim", padded_word, msb_1, must_check_delimiter);
+					b.assert_eq_cond("delim", padded_word, msb_one, must_check_delimiter);
 					// if the word in which 0x01 must reside is NOT the last word in the block,
 					// then the presence of the 0x80 delimiter is NOT treated with the boundary word
 					// thus we must separately check that the ACTUAL last word in the block has it

--- a/crates/frontend/src/circuits/slice.rs
+++ b/crates/frontend/src/circuits/slice.rs
@@ -260,13 +260,13 @@ pub fn create_byte_mask(b: &CircuitBuilder, n_bytes: Wire) -> Wire {
 	// Handle values ≥ 8 by treating them as 8
 	let eight = b.add_constant(Word(8));
 	let is_lt_eight = b.icmp_ult(n_bytes, eight);
-	let all_ones = b.add_constant(Word::ALL_ONE);
+	let all_one = b.add_constant(Word::ALL_ONE);
 
 	let masks: Vec<Wire> = (0..8)
 		.map(|i| b.add_constant_64(0x00FFFFFFFFFFFFFF >> ((7 - i) << 3)))
 		.collect();
 	let in_range_mask = single_wire_multiplex(b, &masks, n_bytes);
-	b.select(is_lt_eight, in_range_mask, all_ones)
+	b.select(is_lt_eight, in_range_mask, all_one)
 }
 
 #[cfg(test)]

--- a/crates/frontend/src/compiler/gate/assert_eq.rs
+++ b/crates/frontend/src/compiler/gate/assert_eq.rs
@@ -35,11 +35,11 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 	let GateParam {
 		constants, inputs, ..
 	} = data.gate_param();
-	let [all_1] = constants else { unreachable!() };
+	let [all_one] = constants else { unreachable!() };
 	let [x, y] = inputs else { unreachable!() };
 
 	// Constraint: (x ⊕ y) ∧ all-1 = 0
-	builder.and().a(xor2(*x, *y)).b(*all_1).c(empty()).build();
+	builder.and().a(xor2(*x, *y)).b(*all_one).c(empty()).build();
 }
 
 pub fn emit_eval_bytecode(

--- a/crates/frontend/src/compiler/gate/assert_false.rs
+++ b/crates/frontend/src/compiler/gate/assert_false.rs
@@ -36,11 +36,11 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 	let GateParam {
 		constants, inputs, ..
 	} = data.gate_param();
-	let [msb_1] = constants else { unreachable!() };
+	let [msb_one] = constants else { unreachable!() };
 	let [x] = inputs else { unreachable!() };
 
-	// Constraint: x ∧ msb_1 = msb_1
-	builder.and().a(*x).b(*msb_1).c(empty()).build();
+	// Constraint: x ∧ msb_one = msb_one
+	builder.and().a(*x).b(*msb_one).c(empty()).build();
 }
 
 pub fn emit_eval_bytecode(

--- a/crates/frontend/src/compiler/gate/assert_non_zero.rs
+++ b/crates/frontend/src/compiler/gate/assert_non_zero.rs
@@ -51,7 +51,7 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 		outputs,
 		..
 	} = data.gate_param();
-	let [all_1] = constants else { unreachable!() };
+	let [all_one] = constants else { unreachable!() };
 	let [x] = inputs else { unreachable!() };
 	let [cout] = outputs else { unreachable!() };
 
@@ -62,7 +62,7 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 	builder
 		.and()
 		.a(xor2(*x, cin))
-		.b(xor2(*all_1, cin))
+		.b(xor2(*all_one, cin))
 		.c(xor2(cin, *cout))
 		.build();
 }
@@ -81,7 +81,7 @@ pub fn emit_eval_bytecode(
 		scratch,
 		..
 	} = data.gate_param();
-	let [all_1, zero] = constants else {
+	let [all_one, zero] = constants else {
 		unreachable!()
 	};
 	let [x] = inputs else { unreachable!() };
@@ -90,11 +90,11 @@ pub fn emit_eval_bytecode(
 		unreachable!()
 	};
 
-	// Compute carry bits from all_1 + diff
+	// Compute carry bits from all_one + diff
 	builder.emit_iadd_cin_cout(
 		wire_to_reg(*scratch_sum_unused), // sum (unused)
 		wire_to_reg(*cout),               // cout
-		wire_to_reg(*all_1),              // all_1
+		wire_to_reg(*all_one),            // all_one
 		wire_to_reg(*x),                  // x
 		wire_to_reg(*zero),               // cin = 0
 	);

--- a/crates/frontend/src/compiler/gate/assert_true.rs
+++ b/crates/frontend/src/compiler/gate/assert_true.rs
@@ -36,11 +36,11 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 	let GateParam {
 		constants, inputs, ..
 	} = data.gate_param();
-	let [msb_1] = constants else { unreachable!() };
+	let [msb_one] = constants else { unreachable!() };
 	let [x] = inputs else { unreachable!() };
 
-	// Constraint: x ∧ msb_1 = msb_1
-	builder.and().a(*x).b(*msb_1).c(*msb_1).build();
+	// Constraint: x ∧ msb_one = msb_one
+	builder.and().a(*x).b(*msb_one).c(*msb_one).build();
 }
 
 pub fn emit_eval_bytecode(

--- a/crates/frontend/src/compiler/gate/assert_zero.rs
+++ b/crates/frontend/src/compiler/gate/assert_zero.rs
@@ -35,11 +35,11 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 	let GateParam {
 		constants, inputs, ..
 	} = data.gate_param();
-	let [all_1] = constants else { unreachable!() };
+	let [all_one] = constants else { unreachable!() };
 	let [x] = inputs else { unreachable!() };
 
 	// Constraint: x ∧ all-1 = 0
-	builder.and().a(*x).b(*all_1).c(empty()).build();
+	builder.and().a(*x).b(*all_one).c(empty()).build();
 }
 
 pub fn emit_eval_bytecode(

--- a/crates/frontend/src/compiler/gate/bxor.rs
+++ b/crates/frontend/src/compiler/gate/bxor.rs
@@ -38,14 +38,14 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 		outputs,
 		..
 	} = data.gate_param();
-	let [all_1] = constants else { unreachable!() };
+	let [all_one] = constants else { unreachable!() };
 	let [x, y] = inputs else { unreachable!() };
 	let [z] = outputs else { unreachable!() };
 
 	// Constraint: Bitwise XOR
 	//
 	// (x ⊕ y) ∧ all-1 = z
-	builder.and().a(xor2(*x, *y)).b(*all_1).c(*z).build();
+	builder.and().a(xor2(*x, *y)).b(*all_one).c(*z).build();
 }
 
 pub fn emit_eval_bytecode(

--- a/crates/frontend/src/compiler/gate/bxor_multi.rs
+++ b/crates/frontend/src/compiler/gate/bxor_multi.rs
@@ -36,14 +36,14 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 		outputs,
 		..
 	} = data.gate_param();
-	let [all_1] = constants else { unreachable!() };
+	let [all_one] = constants else { unreachable!() };
 	let [z] = outputs else { unreachable!() };
 
 	// Constraint: N-way Bitwise XOR
 	//
 	// (x0 ⊕ x1 ⊕ ... ⊕ xn) ∧ all-1 = z
 	let terms: Vec<WireExprTerm> = inputs.iter().map(|&w| w.into()).collect();
-	builder.and().a(xor_multi(terms)).b(*all_1).c(*z).build();
+	builder.and().a(xor_multi(terms)).b(*all_one).c(*z).build();
 }
 
 pub fn emit_eval_bytecode(

--- a/crates/frontend/src/compiler/gate/iadd_cin_cout.rs
+++ b/crates/frontend/src/compiler/gate/iadd_cin_cout.rs
@@ -52,7 +52,7 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 		outputs,
 		..
 	} = data.gate_param();
-	let [all_1] = constants else { unreachable!() };
+	let [all_one] = constants else { unreachable!() };
 	let [a, b, cin] = inputs else { unreachable!() };
 	let [sum, cout] = outputs else { unreachable!() };
 
@@ -75,7 +75,7 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 	builder
 		.and()
 		.a(xor4(*a, *b, cout_sll_1, cin_msb))
-		.b(*all_1)
+		.b(*all_one)
 		.c(*sum)
 		.build();
 }

--- a/crates/frontend/src/compiler/gate/icmp_eq.rs
+++ b/crates/frontend/src/compiler/gate/icmp_eq.rs
@@ -58,7 +58,7 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 		outputs,
 		..
 	} = data.gate_param();
-	let [all_1, msb_1, _zero] = constants else {
+	let [all_one, msb_one, _zero] = constants else {
 		unreachable!()
 	};
 	let [x, y] = inputs else { unreachable!() };
@@ -71,8 +71,8 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 	builder
 		.and()
 		.a(xor3(*x, *y, cin))
-		.b(xor2(*all_1, cin))
-		.c(xor3(cin, *out_wire, *msb_1))
+		.b(xor2(*all_one, cin))
+		.c(xor3(cin, *out_wire, *msb_one))
 		.build();
 }
 
@@ -90,7 +90,7 @@ pub fn emit_eval_bytecode(
 		scratch,
 		..
 	} = data.gate_param();
-	let [all_1, msb_1, zero] = constants else {
+	let [all_one, msb_one, zero] = constants else {
 		unreachable!()
 	};
 	let [x, y] = inputs else { unreachable!() };
@@ -103,15 +103,15 @@ pub fn emit_eval_bytecode(
 	// Compute diff = x ^ y
 	builder.emit_bxor(wire_to_reg(*scratch_diff), wire_to_reg(*x), wire_to_reg(*y));
 
-	// Compute carry bits from all_1 + diff
+	// Compute carry bits from all_one + diff
 	builder.emit_iadd_cin_cout(
 		wire_to_reg(*scratch_sum_unused), // sum (unused)
 		wire_to_reg(*cout),               // cout
-		wire_to_reg(*all_1),              // all_1
+		wire_to_reg(*all_one),            // all_one
 		wire_to_reg(*scratch_diff),       // diff
 		wire_to_reg(*zero),               // cin = 0
 	);
 
-	// Invert: out_wire = out_wire ^ msb_1
-	builder.emit_bxor(wire_to_reg(*out_wire), wire_to_reg(*cout), wire_to_reg(*msb_1));
+	// Invert: out_wire = out_wire ^ msb_one
+	builder.emit_bxor(wire_to_reg(*out_wire), wire_to_reg(*cout), wire_to_reg(*msb_one));
 }

--- a/crates/frontend/src/compiler/gate/icmp_ult.rs
+++ b/crates/frontend/src/compiler/gate/icmp_ult.rs
@@ -29,7 +29,7 @@ use crate::compiler::{
 
 pub fn shape() -> OpcodeShape {
 	OpcodeShape {
-		const_in: &[Word::ALL_ONE, Word::ZERO], // Need all_1 and zero constants
+		const_in: &[Word::ALL_ONE, Word::ZERO], // Need all_one and zero constants
 		n_in: 2,
 		n_out: 1,
 		n_aux: 0,
@@ -45,7 +45,7 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 		constants,
 		..
 	} = data.gate_param();
-	let [all_1, _zero] = constants else {
+	let [all_one, _zero] = constants else {
 		unreachable!()
 	};
 	let [x, y] = inputs else { unreachable!() };
@@ -55,7 +55,7 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 	// ((x ⊕ all-1) ⊕ (bout << 1)) ∧ (y ⊕ (bout << 1)) = bout ⊕ (bout << 1)
 	builder
 		.and()
-		.a(xor3(*x, *all_1, sll(*bout, 1)))
+		.a(xor3(*x, *all_one, sll(*bout, 1)))
 		.b(xor2(*y, sll(*bout, 1)))
 		.c(xor2(*bout, sll(*bout, 1)))
 		.build();
@@ -74,7 +74,7 @@ pub fn emit_eval_bytecode(
 		scratch,
 		..
 	} = data.gate_param();
-	let [all_1, zero] = constants else {
+	let [all_one, zero] = constants else {
 		unreachable!()
 	};
 	let [x, y] = inputs else { unreachable!() };
@@ -83,8 +83,8 @@ pub fn emit_eval_bytecode(
 		unreachable!()
 	};
 
-	// Compute ¬x (x XOR all_1)
-	builder.emit_bxor(wire_to_reg(*scratch_nx), wire_to_reg(*x), wire_to_reg(*all_1));
+	// Compute ¬x (x XOR all_one)
+	builder.emit_bxor(wire_to_reg(*scratch_nx), wire_to_reg(*x), wire_to_reg(*all_one));
 
 	// Compute carry bits from ¬x + y
 	builder.emit_iadd_cin_cout(

--- a/crates/frontend/src/compiler/gate/isub_bin_bout.rs
+++ b/crates/frontend/src/compiler/gate/isub_bin_bout.rs
@@ -24,7 +24,7 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 		outputs,
 		..
 	} = data.gate_param();
-	let [all_1] = constants else { unreachable!() };
+	let [all_one] = constants else { unreachable!() };
 	let [a, b, bin] = inputs else { unreachable!() };
 	let [diff, bout] = outputs else {
 		unreachable!()
@@ -38,7 +38,7 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 	// (¬a ⊕ (bout << 1) ⊕ bin_msb) ∧ (b ⊕ (bout << 1) ⊕ bin_msb) = bout ⊕ (bout << 1) ⊕ bin_msb
 	builder
 		.and()
-		.a(xor4(*all_1, *a, bout_sll_1, bin_msb))
+		.a(xor4(*all_one, *a, bout_sll_1, bin_msb))
 		.b(xor3(*b, bout_sll_1, bin_msb))
 		.c(xor3(*bout, bout_sll_1, bin_msb))
 		.build();
@@ -49,7 +49,7 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 	builder
 		.and()
 		.a(xor4(*a, *b, bout_sll_1, bin_msb))
-		.b(*all_1)
+		.b(*all_one)
 		.c(*diff)
 		.build();
 }

--- a/crates/frontend/src/compiler/gate/sar.rs
+++ b/crates/frontend/src/compiler/gate/sar.rs
@@ -39,14 +39,14 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 		imm,
 		..
 	} = data.gate_param();
-	let [all_1] = constants else { unreachable!() };
+	let [all_one] = constants else { unreachable!() };
 	let [x] = inputs else { unreachable!() };
 	let [z] = outputs else { unreachable!() };
 	let [n] = imm else { unreachable!() };
 
 	// Constraint: Arithmetic right shift
 	// (x SAR n) ∧ all-1 = z
-	builder.and().a(sar(*x, *n)).b(*all_1).c(*z).build();
+	builder.and().a(sar(*x, *n)).b(*all_one).c(*z).build();
 }
 
 pub fn emit_eval_bytecode(

--- a/crates/frontend/src/compiler/gate/shl.rs
+++ b/crates/frontend/src/compiler/gate/shl.rs
@@ -39,14 +39,14 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 		imm,
 		..
 	} = data.gate_param();
-	let [all_1] = constants else { unreachable!() };
+	let [all_one] = constants else { unreachable!() };
 	let [x] = inputs else { unreachable!() };
 	let [z] = outputs else { unreachable!() };
 	let [n] = imm else { unreachable!() };
 
 	// Constraint: Logical left shift
 	// (x << n) ∧ all-1 = z
-	builder.and().a(sll(*x, *n)).b(*all_1).c(*z).build();
+	builder.and().a(sll(*x, *n)).b(*all_one).c(*z).build();
 }
 
 pub fn emit_eval_bytecode(

--- a/crates/frontend/src/compiler/gate/shr.rs
+++ b/crates/frontend/src/compiler/gate/shr.rs
@@ -39,14 +39,14 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 		imm,
 		..
 	} = data.gate_param();
-	let [all_1] = constants else { unreachable!() };
+	let [all_one] = constants else { unreachable!() };
 	let [x] = inputs else { unreachable!() };
 	let [z] = outputs else { unreachable!() };
 	let [n] = imm else { unreachable!() };
 
 	// Constraint: Logical right shift
 	// (x >> n) ∧ all-1 = z
-	builder.and().a(srl(*x, *n)).b(*all_1).c(*z).build();
+	builder.and().a(srl(*x, *n)).b(*all_one).c(*z).build();
 }
 
 pub fn emit_eval_bytecode(

--- a/crates/frontend/src/compiler/gate_fusion/mod.rs
+++ b/crates/frontend/src/compiler/gate_fusion/mod.rs
@@ -218,8 +218,8 @@ fn try_create_linear_def(
 	constraint: &AndConstraint,
 	all_ones: ValueIndex,
 ) -> Option<LinearDefSite> {
-	// Pattern: a & all_1 = dst
-	// Which means: b = [all_1], c = [dst], and dst ∉ a
+	// Pattern: a & all_one = dst
+	// Which means: b = [all_one], c = [dst], and dst ∉ a
 
 	// Check if `b` is exactly `[all_ones]`
 	if constraint.b.len() != 1 {
@@ -371,7 +371,7 @@ mod tests {
 	fn test_try_create_linear_def() {
 		let all_ones = ValueIndex(0);
 
-		// Valid pure XOR: a & all_1 = dst
+		// Valid pure XOR: a & all_one = dst
 		let constraint = AndConstraint {
 			a: make_operand(vec![(1, ShiftVariant::Sll, 0), (2, ShiftVariant::Sll, 0)]),
 			b: make_operand(vec![(0, ShiftVariant::Sll, 0)]), // all_ones


### PR DESCRIPTION
just some renaming, changes 0 functionality.

- `msb_1` --> `msb_one`
- `all_1` --> `all_one`