### PR TITLE
improve handling of lengths in zklogin.

### DIFF
--- a/crates/examples/snapshots/zklogin.snap
+++ b/crates/examples/snapshots/zklogin.snap
@@ -7,5 +7,5 @@ Number of MUL constraints: 26880
 Length of value vec: 1048576
   Constants: 696
   Inout: 302
-  Witness: 1790
+  Witness: 1788
   Internal: 733563


### PR DESCRIPTION
fix handling of byte-lengths in zk login that were not multiples of 8 / 3 / 24.

number of rounding / division issues.

relaxed an unnecessary wire length restriction in the base64 sub-circuit.

added test case that tests "weird" lengths. you can check that these lengths cause the earlier version to fail, but work here.