### PR TITLE
Add verifier binary

### DIFF
--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -43,3 +43,7 @@ rayon = ["binius-prover/rayon"]
 [[example]]
 name = "prover"
 path = "examples/prover.rs"
+
+[[example]]
+name = "verifier"
+path = "examples/verifier.rs"

--- a/crates/examples/README.md
+++ b/crates/examples/README.md
@@ -361,6 +361,31 @@ cargo run --release --example prover -- \
     --log-inv-rate 1
 ```
 
+## Verifier binary
+
+The `verifier` example binary reads a constraint system, a public witness, and a proof from disk and verifies the proof. It also checks that the challenger type embedded in the proof matches the verifier’s expected challenger (HasherChallenger<Sha256>), returning an error if it doesn’t.
+
+Arguments:
+- `--cs-path PATH`: path to the constraint system binary
+- `--pub-witness-path PATH`: path to the public values binary (ValuesData)
+- `--proof-path PATH`: path to the proof binary
+- `-l, --log-inv-rate N`: log of the inverse rate (default: 1)
+
+Usage:
+
+```bash
+# Verify the proof generated above
+cargo run --release --example verifier -- \
+    --cs-path out/sha256/cs.bin \
+    --pub-witness-path out/sha256/public.bin \
+    --proof-path out/sha256/proof.bin \
+    --log-inv-rate 1
+```
+
+Notes:
+- The verifier fails if the challenger type in the proof is not `HasherChallenger<Sha256>`.
+- The public witness must match the constraint system and the proof’s statement.
+
 ## Tips
 
 1. **Keep it simple**: The main function should just create the CLI and run it

--- a/crates/examples/examples/verifier.rs
+++ b/crates/examples/examples/verifier.rs
@@ -1,0 +1,92 @@
+use std::{fs, path::PathBuf};
+
+use anyhow::{Context, Result, bail};
+use binius_core::constraint_system::{ConstraintSystem, Proof, ValuesData};
+use binius_examples::StdVerifier;
+use binius_utils::serialization::DeserializeBytes;
+use binius_verifier::{
+	Verifier,
+	config::{ChallengerWithName, StdChallenger},
+	hash::StdCompression,
+	transcript::VerifierTranscript,
+};
+use clap::Parser;
+
+/// Verifier CLI: load CS, public witness and proof, then verify.
+#[derive(Debug, Parser)]
+#[command(
+	name = "verifier",
+	about = "Verify a proof from a constraint system, public witness, and proof binary"
+)]
+struct Args {
+	/// Path to the constraint system binary
+	#[arg(long = "cs-path")]
+	cs_path: PathBuf,
+
+	/// Path to the public values (ValuesData) binary
+	#[arg(long = "pub-witness-path")]
+	pub_witness_path: PathBuf,
+
+	/// Path to the proof binary
+	#[arg(long = "proof-path")]
+	proof_path: PathBuf,
+
+	/// Log of the inverse rate for the proof system (must match what was used for proving)
+	#[arg(short = 'l', long = "log-inv-rate", default_value_t = 1, value_parser = clap::value_parser!(u32).range(1..))]
+	log_inv_rate: u32,
+}
+
+fn main() -> Result<()> {
+	let _tracing_guard = tracing_profile::init_tracing().ok();
+	let args = Args::parse();
+
+	// Read and deserialize constraint system
+	let cs_bytes = fs::read(&args.cs_path).with_context(|| {
+		format!("Failed to read constraint system from {}", args.cs_path.display())
+	})?;
+	let cs = ConstraintSystem::deserialize(&mut cs_bytes.as_slice())
+		.context("Failed to deserialize ConstraintSystem")?;
+
+	// Read and deserialize public values
+	let pub_bytes = fs::read(&args.pub_witness_path).with_context(|| {
+		format!("Failed to read public values from {}", args.pub_witness_path.display())
+	})?;
+	let public = ValuesData::deserialize(&mut pub_bytes.as_slice())
+		.context("Failed to deserialize public ValuesData")?;
+
+	// Read and deserialize proof
+	let proof_bytes = fs::read(&args.proof_path)
+		.with_context(|| format!("Failed to read proof from {}", args.proof_path.display()))?;
+	let proof =
+		Proof::deserialize(&mut proof_bytes.as_slice()).context("Failed to deserialize Proof")?;
+
+	// Validate challenger type matches our verifier configuration
+	let expected_challenger = StdChallenger::NAME;
+	if proof.challenger_type() != expected_challenger {
+		bail!(
+			"Challenger type mismatch: expected '{}', found '{}'",
+			expected_challenger,
+			proof.challenger_type()
+		);
+	}
+
+	// Set up the verifier
+	let verifier: StdVerifier =
+		Verifier::setup(cs, args.log_inv_rate as usize, StdCompression::default())
+			.context("Failed to setup verifier")?;
+
+	// Create a verifier transcript from the serialized proof data
+	let (data, _) = proof.into_owned();
+	let mut verifier_transcript = VerifierTranscript::new(StdChallenger::default(), data);
+
+	// Verify
+	verifier
+		.verify(public.as_slice(), &mut verifier_transcript)
+		.context("Verification failed")?;
+	verifier_transcript
+		.finalize()
+		.context("Transcript not fully consumed after verification")?;
+
+	tracing::info!("Proof verified successfully");
+	Ok(())
+}


### PR DESCRIPTION
### TL;DR

Add a verifier binary to verify the serialized proofs using the serialized constraint system and public witness data.

### What changed?

- Added a new `verifier` example binary that reads a constraint system, public witness, and proof from disk and verifies the proof
- Updated `Cargo.toml` to include the new verifier example
- Added documentation for the verifier binary in the README, including usage instructions and command-line arguments

### How to test?

Run the verifier on a proof generated by the prover example:

```
# First generate a proof with the prover
cargo run --release --example prover -- \
    --cs-path out/sha256/cs.bin \
    --pub-witness-path out/sha256/public.bin \
    --priv-witness-path out/sha256/private.bin \
    --proof-path out/sha256/proof.bin \
    --log-inv-rate 1

# Then verify the proof
cargo run --release --example verifier -- \
    --cs-path out/sha256/cs.bin \
    --pub-witness-path out/sha256/public.bin \
    --proof-path out/sha256/proof.bin \
    --log-inv-rate 1
```

### Why make this change?

This completes the example workflow by providing a way to verify proofs generated by the prover example. The verifier demonstrates how to load and verify proofs, including checking that the challenger type in the proof matches the verifier's expected challenger type (HasherChallenger\<Sha256>).