### PR TITLE
more multiplexer tricks in sha

### DIFF
--- a/crates/examples/snapshots/sha256.snap
+++ b/crates/examples/snapshots/sha256.snap
@@ -1,11 +1,11 @@
 sha256 circuit
 --
-Number of gates: 74992
-Number of evaluation instructions: 76699
-Number of AND constraints: 94809
+Number of gates: 74954
+Number of evaluation instructions: 76589
+Number of AND constraints: 94755
 Number of MUL constraints: 0
 Length of value vec: 131072
-  Constants: 342
+  Constants: 353
   Inout: 260
   Witness: 529
-  Internal: 93763
+  Internal: 93741

--- a/crates/examples/snapshots/sha512.snap
+++ b/crates/examples/snapshots/sha512.snap
@@ -1,11 +1,11 @@
 sha512 circuit
 --
-Number of gates: 48816
-Number of evaluation instructions: 49995
-Number of AND constraints: 61753
+Number of gates: 48779
+Number of evaluation instructions: 49886
+Number of AND constraints: 61700
 Number of MUL constraints: 0
 Length of value vec: 131072
-  Constants: 365
+  Constants: 377
   Inout: 264
   Witness: 273
-  Internal: 74122
+  Internal: 74100

--- a/crates/examples/snapshots/zklogin.snap
+++ b/crates/examples/snapshots/zklogin.snap
@@ -1,11 +1,11 @@
 zklogin circuit
 --
-Number of gates: 467261
-Number of evaluation instructions: 554981
-Number of AND constraints: 581928
+Number of gates: 467147
+Number of evaluation instructions: 554651
+Number of AND constraints: 581766
 Number of MUL constraints: 26880
 Length of value vec: 1048576
-  Constants: 696
+  Constants: 708
   Inout: 302
   Witness: 1788
-  Internal: 733563
+  Internal: 733497


### PR DESCRIPTION
even more multiplexing tricks!

use yet another multiplexer in order to concoct the "expected" padding word, given the real padding word.

i did something similar when i rewrote keccak.

in the sha256 case, we have to be a bit tricky, because of the endianness of the high and low halves.