### PR TITLE
[frontend] Add public key hash tweak

### DIFF
--- a/crates/frontend/src/circuits/hash_based_sig/hashing/chain.rs
+++ b/crates/frontend/src/circuits/hash_based_sig/hashing/chain.rs
@@ -109,6 +109,33 @@ pub fn build_chain_hash(
 	message
 }
 
+/// Computes a hash chain for Winternitz OTS signature verification.
+///
+/// # Arguments
+/// * `param` - Cryptographic parameter
+/// * `chain_index` - Index of the chain being computed
+/// * `start_hash` - Starting hash value
+/// * `start_pos` - Starting position in the chain
+/// * `num_hashes` - Number of hash iterations to perform
+pub fn hash_chain_keccak(
+	param: &[u8],
+	chain_index: usize,
+	start_hash: &[u8; 32],
+	start_pos: usize,
+	num_hashes: usize,
+) -> [u8; 32] {
+	use sha3::{Digest, Keccak256};
+
+	let mut current = *start_hash;
+	for i in 0..num_hashes {
+		let position = start_pos + i + 1;
+		let tweaked_message =
+			build_chain_hash(param, &current, chain_index as u64, position as u64);
+		current = Keccak256::digest(tweaked_message).into();
+	}
+	current
+}
+
 #[cfg(test)]
 mod tests {
 	use binius_core::Word;

--- a/crates/frontend/src/circuits/hash_based_sig/hashing/mod.rs
+++ b/crates/frontend/src/circuits/hash_based_sig/hashing/mod.rs
@@ -2,8 +2,16 @@
 mod base;
 mod chain;
 mod message;
+mod public_key;
 mod tree;
 
-pub use chain::{CHAIN_TWEAK, FIXED_MESSAGE_OVERHEAD, build_chain_hash, circuit_chain_hash};
+pub use chain::{
+	CHAIN_TWEAK, FIXED_MESSAGE_OVERHEAD, build_chain_hash, circuit_chain_hash, hash_chain_keccak,
+};
 pub use message::{MESSAGE_TWEAK, build_message_hash, circuit_message_hash, hash_message};
-pub use tree::{TREE_MESSAGE_OVERHEAD, TREE_TWEAK, build_tree_hash, circuit_tree_hash};
+pub use public_key::{
+	PUBLIC_KEY_TWEAK, build_public_key_hash, circuit_public_key_hash, hash_public_key_keccak,
+};
+pub use tree::{
+	TREE_MESSAGE_OVERHEAD, TREE_TWEAK, build_tree_hash, circuit_tree_hash, hash_tree_node_keccak,
+};

--- a/crates/frontend/src/circuits/hash_based_sig/hashing/public_key.rs
+++ b/crates/frontend/src/circuits/hash_based_sig/hashing/public_key.rs
@@ -1,0 +1,366 @@
+use super::base::circuit_tweaked_keccak;
+// Note: PublicKeyTweak reuses TREE_TWEAK (0x01) for consistency with XMSS spec
+pub use super::tree::TREE_TWEAK as PUBLIC_KEY_TWEAK;
+use crate::{
+	circuits::{concat::Term, keccak::Keccak},
+	compiler::{CircuitBuilder, Wire},
+};
+
+/// A circuit that verifies a public key hash for XMSS.
+///
+/// This circuit verifies Keccak-256 of a message that's been tweaked with
+/// multiple public key hashes: `Keccak256(domain_param || 0x01 || pk_hash_0 || pk_hash_1 || ... ||
+/// pk_hash_n)`
+///
+/// # Arguments
+///
+/// * `builder` - Circuit builder for constructing constraints
+/// * `domain_param_wires` - The cryptographic domain parameter wires, where each wire holds 8 bytes
+///   as a 64-bit LE-packed value
+/// * `domain_param_len` - The actual domain parameter length in bytes
+/// * `pk_hashes` - The public key end hashes (32 bytes each as 4x64-bit LE-packed wires)
+/// * `digest` - Output: The computed Keccak-256 digest (32 bytes as 4x64-bit LE-packed wires)
+///
+/// # Returns
+///
+/// A `Keccak` circuit that needs to be populated with the tweaked message and digest
+pub fn circuit_public_key_hash(
+	builder: &CircuitBuilder,
+	domain_param_wires: Vec<Wire>,
+	domain_param_len: usize,
+	pk_hashes: &[[Wire; 4]],
+	digest: [Wire; 4],
+) -> Keccak {
+	let num_hashes = pk_hashes.len();
+	let message_len = domain_param_len + 1 + (num_hashes * 32); // +1 for tweak byte
+	assert_eq!(domain_param_wires.len(), domain_param_len.div_ceil(8));
+
+	// Build additional terms for all public key hashes
+	let mut additional_terms = Vec::new();
+
+	// Add all public key hashes
+	for pk_hash in pk_hashes {
+		let hash_term = Term {
+			len_bytes: builder.add_constant_64(32),
+			data: pk_hash.to_vec(),
+		};
+		additional_terms.push(hash_term);
+	}
+
+	circuit_tweaked_keccak(
+		builder,
+		domain_param_wires,
+		domain_param_len,
+		PUBLIC_KEY_TWEAK,
+		additional_terms,
+		message_len,
+		digest,
+	)
+}
+
+/// Build the tweaked message for public key hashing.
+///
+/// Constructs the complete message for Keccak-256 hashing by concatenating:
+/// `domain_param || 0x01 || pk_hash_0 || pk_hash_1 || ... || pk_hash_n`
+///
+/// This function is typically used when populating witness data for the
+/// `circuit_public_key_hash` circuit.
+///
+/// # Arguments
+///
+/// * `domain_param_bytes` - The cryptographic domain parameter bytes
+/// * `pk_hashes` - Array of 32-byte public key hashes
+///
+/// # Returns
+///
+/// A vector containing the complete tweaked message ready for hashing
+pub fn build_public_key_hash(domain_param_bytes: &[u8], pk_hashes: &[[u8; 32]]) -> Vec<u8> {
+	let mut message = Vec::new();
+	message.extend_from_slice(domain_param_bytes);
+	message.push(PUBLIC_KEY_TWEAK);
+	for pk_hash in pk_hashes {
+		message.extend_from_slice(pk_hash);
+	}
+	message
+}
+
+/// Computes the public key hash from Winternitz public keys.
+///
+/// # Arguments
+/// * `domain_param` - Cryptographic domain parameter
+/// * `pk_hashes` - Array of 32-byte public key hashes
+pub fn hash_public_key_keccak(domain_param: &[u8], pk_hashes: &[[u8; 32]]) -> [u8; 32] {
+	use sha3::{Digest, Keccak256};
+	let tweaked_public_key = build_public_key_hash(domain_param, pk_hashes);
+	Keccak256::digest(tweaked_public_key).into()
+}
+
+#[cfg(test)]
+mod tests {
+	use proptest::prelude::*;
+	use sha3::{Digest, Keccak256};
+
+	use super::*;
+	use crate::{
+		compiler::{CircuitBuilder, circuit::Circuit},
+		constraint_verifier::verify_constraints,
+		util::pack_bytes_into_wires_le,
+	};
+
+	/// Helper struct for PublicKeyHash testing
+	struct PublicKeyTestCircuit {
+		circuit: Circuit,
+		keccak: Keccak,
+		domain_param_wires: Vec<Wire>,
+		domain_param_len: usize,
+		pk_hashes: Vec<[Wire; 4]>,
+	}
+
+	impl PublicKeyTestCircuit {
+		fn new(domain_param_len: usize, num_hashes: usize) -> Self {
+			let builder = CircuitBuilder::new();
+
+			let digest: [Wire; 4] = std::array::from_fn(|_| builder.add_inout());
+
+			let num_domain_param_wires = domain_param_len.div_ceil(8);
+			let domain_param_wires: Vec<Wire> = (0..num_domain_param_wires)
+				.map(|_| builder.add_inout())
+				.collect();
+
+			let pk_hashes: Vec<[Wire; 4]> = (0..num_hashes)
+				.map(|_| std::array::from_fn(|_| builder.add_inout()))
+				.collect();
+
+			let keccak = circuit_public_key_hash(
+				&builder,
+				domain_param_wires.clone(),
+				domain_param_len,
+				&pk_hashes,
+				digest,
+			);
+
+			let circuit = builder.build();
+
+			Self {
+				circuit,
+				keccak,
+				domain_param_wires,
+				domain_param_len,
+				pk_hashes,
+			}
+		}
+
+		/// Populate witness and verify constraints with given test data
+		fn populate_and_verify(
+			&self,
+			domain_param_bytes: &[u8],
+			pk_hashes_bytes: &[[u8; 32]],
+			message: &[u8],
+			digest: [u8; 32],
+		) -> Result<(), Box<dyn std::error::Error>> {
+			let mut w = self.circuit.new_witness_filler();
+
+			// Populate domain param
+			assert_eq!(domain_param_bytes.len(), self.domain_param_len);
+			pack_bytes_into_wires_le(&mut w, &self.domain_param_wires, domain_param_bytes);
+
+			// Populate public key hashes
+			assert_eq!(pk_hashes_bytes.len(), self.pk_hashes.len());
+			for (wires, bytes) in self.pk_hashes.iter().zip(pk_hashes_bytes.iter()) {
+				pack_bytes_into_wires_le(&mut w, wires, bytes);
+			}
+
+			// Populate message for Keccak
+			let expected_len = self.domain_param_len + 1 + (self.pk_hashes.len() * 32);
+			assert_eq!(
+				message.len(),
+				expected_len,
+				"Message length {} doesn't match expected length {}",
+				message.len(),
+				expected_len
+			);
+			self.keccak.populate_message(&mut w, message);
+
+			// Populate digest
+			self.keccak.populate_digest(&mut w, digest);
+
+			self.circuit.populate_wire_witness(&mut w)?;
+			let cs = self.circuit.constraint_system();
+			verify_constraints(cs, &w.into_value_vec())?;
+			Ok(())
+		}
+	}
+
+	#[test]
+	fn test_public_key_hash_basic() {
+		let test_circuit = PublicKeyTestCircuit::new(32, 3);
+
+		let domain_param_bytes = b"test_parameter_32_bytes_long!!!!";
+		let pk_hashes = [
+			*b"first_public_key_hash_32_bytes!!",
+			*b"second_public_key_hash_32_bytes!",
+			*b"third_public_key_hash_32_bytes!!",
+		];
+
+		let message = build_public_key_hash(domain_param_bytes, &pk_hashes);
+
+		let expected_digest = Keccak256::digest(&message);
+
+		test_circuit
+			.populate_and_verify(domain_param_bytes, &pk_hashes, &message, expected_digest.into())
+			.unwrap();
+	}
+
+	#[test]
+	fn test_public_key_hash_with_18_byte_domain_param() {
+		// Test with 18-byte domain param as per XMSS specifications
+		let test_circuit = PublicKeyTestCircuit::new(18, 2);
+
+		let domain_param_bytes: &[u8; 18] = b"test_param_18bytes";
+		let pk_hashes = [
+			*b"first_public_key_hash_32_bytes!!",
+			*b"second_public_key_hash_32_bytes!",
+		];
+
+		let message = build_public_key_hash(domain_param_bytes, &pk_hashes);
+
+		let expected_digest = Keccak256::digest(&message);
+
+		test_circuit
+			.populate_and_verify(domain_param_bytes, &pk_hashes, &message, expected_digest.into())
+			.unwrap();
+	}
+
+	#[test]
+	fn test_public_key_hash_single_hash() {
+		let test_circuit = PublicKeyTestCircuit::new(32, 1);
+
+		let domain_param_bytes = b"test_parameter_32_bytes_long!!!!";
+		let pk_hashes = [*b"single_public_key_hash_32_bytes!"];
+
+		let message = build_public_key_hash(domain_param_bytes, &pk_hashes);
+
+		let expected_digest = Keccak256::digest(&message);
+
+		test_circuit
+			.populate_and_verify(domain_param_bytes, &pk_hashes, &message, expected_digest.into())
+			.unwrap();
+	}
+
+	#[test]
+	fn test_public_key_hash_many_hashes() {
+		// Test with many hashes (e.g., Winternitz with 72 chains)
+		let num_hashes = 72;
+		let test_circuit = PublicKeyTestCircuit::new(18, num_hashes);
+
+		let domain_param_bytes: &[u8; 18] = b"test_param_18bytes";
+
+		// Generate deterministic hashes for testing
+		let mut pk_hashes = Vec::new();
+		for i in 0..num_hashes {
+			let mut hash = [0u8; 32];
+			hash[0] = i as u8;
+			hash[1] = (i >> 8) as u8;
+			for j in 2..32 {
+				hash[j] = ((i * j) % 256) as u8;
+			}
+			pk_hashes.push(hash);
+		}
+
+		let message = build_public_key_hash(domain_param_bytes, &pk_hashes);
+
+		let expected_digest = Keccak256::digest(&message);
+
+		test_circuit
+			.populate_and_verify(domain_param_bytes, &pk_hashes, &message, expected_digest.into())
+			.unwrap();
+	}
+
+	#[test]
+	fn test_public_key_hash_wrong_digest() {
+		let test_circuit = PublicKeyTestCircuit::new(32, 2);
+
+		let domain_param_bytes = b"test_parameter_32_bytes_long!!!!";
+		let pk_hashes = [
+			*b"first_public_key_hash_32_bytes!!",
+			*b"second_public_key_hash_32_bytes!",
+		];
+
+		let message = build_public_key_hash(domain_param_bytes, &pk_hashes);
+
+		// Populate with WRONG digest - this should cause verification to fail
+		let wrong_digest = [0u8; 32];
+
+		let result = test_circuit.populate_and_verify(
+			domain_param_bytes,
+			&pk_hashes,
+			&message,
+			wrong_digest,
+		);
+
+		assert!(result.is_err(), "Expected error for wrong digest");
+	}
+
+	#[test]
+	fn test_public_key_hash_ensures_tweak_byte() {
+		// This test verifies that the PUBLIC_KEY_TWEAK byte (0x01) is correctly inserted
+		let test_circuit = PublicKeyTestCircuit::new(16, 1);
+
+		let domain_param_bytes = b"param_16_bytes!!";
+		let pk_hashes = [*b"single_public_key_hash_32_bytes!"];
+
+		let message = build_public_key_hash(domain_param_bytes, &pk_hashes);
+
+		// Verify the tweak byte is at the correct position
+		assert_eq!(message[16], PUBLIC_KEY_TWEAK);
+		assert_eq!(message.len(), 16 + 1 + 32); // domain_param + tweak + one hash
+
+		let expected_digest = Keccak256::digest(&message);
+
+		test_circuit
+			.populate_and_verify(domain_param_bytes, &pk_hashes, &message, expected_digest.into())
+			.unwrap();
+	}
+
+	proptest! {
+		#[test]
+		fn test_public_key_hash_property_based(
+			domain_param_len in 1usize..=100,
+			num_hashes in 1usize..=10,
+		) {
+			use rand::SeedableRng;
+			use rand::prelude::StdRng;
+
+			let mut rng = StdRng::seed_from_u64(0);
+
+			// Generate random domain param bytes
+			let mut domain_param_bytes = vec![0u8; domain_param_len];
+			rng.fill_bytes(&mut domain_param_bytes);
+
+			// Generate random public key hashes
+			let mut pk_hashes = Vec::new();
+			for _ in 0..num_hashes {
+				let mut hash = [0u8; 32];
+				rng.fill_bytes(&mut hash);
+				pk_hashes.push(hash);
+			}
+
+			// Create circuit
+			let test_circuit = PublicKeyTestCircuit::new(domain_param_len, num_hashes);
+
+			// Build message and compute digest
+			let message = build_public_key_hash(&domain_param_bytes, &pk_hashes);
+
+			// Verify message structure
+			prop_assert_eq!(message.len(), domain_param_len + 1 + (num_hashes * 32));
+			prop_assert_eq!(message[domain_param_len], PUBLIC_KEY_TWEAK);
+
+			let expected_digest: [u8; 32] = Keccak256::digest(&message).into();
+
+			// Verify circuit
+			test_circuit
+				.populate_and_verify(&domain_param_bytes, &pk_hashes, &message, expected_digest)
+				.unwrap();
+		}
+	}
+}

--- a/crates/frontend/src/circuits/hash_based_sig/hashing/tree.rs
+++ b/crates/frontend/src/circuits/hash_based_sig/hashing/tree.rs
@@ -125,6 +125,26 @@ pub fn build_tree_hash(
 	message
 }
 
+/// Computes a Merkle tree node hash.
+///
+/// # Arguments
+/// * `param` - Cryptographic parameter
+/// * `left` - Left child hash
+/// * `right` - Right child hash
+/// * `level` - Tree level (0 = leaf level)
+/// * `index` - Node index at this level
+pub fn hash_tree_node_keccak(
+	param: &[u8],
+	left: &[u8; 32],
+	right: &[u8; 32],
+	level: u32,
+	index: u32,
+) -> [u8; 32] {
+	use sha3::{Digest, Keccak256};
+	let tweaked_tree_node = build_tree_hash(param, left, right, level, index);
+	Keccak256::digest(tweaked_tree_node).into()
+}
+
 #[cfg(test)]
 mod tests {
 	use binius_core::Word;

--- a/crates/frontend/src/circuits/hash_based_sig/merkle_tree.rs
+++ b/crates/frontend/src/circuits/hash_based_sig/merkle_tree.rs
@@ -100,32 +100,13 @@ pub fn circuit_merkle_path(
 #[cfg(test)]
 mod tests {
 	use binius_core::Word;
-	use sha3::{Digest, Keccak256};
 
 	use super::*;
 	use crate::{
-		circuits::hash_based_sig::hashing::{TREE_TWEAK, build_tree_hash},
+		circuits::hash_based_sig::hashing::{build_tree_hash, hash_tree_node_keccak},
 		constraint_verifier::verify_constraints,
 		util::pack_bytes_into_wires_le,
 	};
-
-	/// Helper to compute tree node hash using Keccak
-	fn hash_tree_node_keccak(
-		param: &[u8],
-		left: &[u8; 32],
-		right: &[u8; 32],
-		level: u32,
-		index: u32,
-	) -> [u8; 32] {
-		let mut hasher = Keccak256::new();
-		hasher.update(param);
-		hasher.update([TREE_TWEAK]);
-		hasher.update(level.to_le_bytes());
-		hasher.update(index.to_le_bytes());
-		hasher.update(left);
-		hasher.update(right);
-		hasher.finalize().into()
-	}
 
 	#[test]
 	fn test_circuit_merkle_path_verification() {

--- a/crates/frontend/src/circuits/hash_based_sig/winternitz_ots.rs
+++ b/crates/frontend/src/circuits/hash_based_sig/winternitz_ots.rs
@@ -257,27 +257,12 @@ pub fn grind_nonce(
 #[cfg(test)]
 mod tests {
 	use rand::{RngCore, SeedableRng, rngs::StdRng};
-	use sha3::{Digest, Keccak256};
 
-	use super::{super::hashing::build_chain_hash, *};
+	use super::{
+		super::hashing::{build_chain_hash, hash_chain_keccak},
+		*,
+	};
 	use crate::{constraint_verifier::verify_constraints, util::pack_bytes_into_wires_le};
-
-	fn hash_chain_keccak(
-		domain_param: &[u8],
-		chain_index: usize,
-		start_hash: &[u8; 32],
-		start_pos: usize,
-		num_hashes: usize,
-	) -> [u8; 32] {
-		let mut current = *start_hash;
-		for i in 0..num_hashes {
-			let position = start_pos + i + 1;
-			let tweaked_message =
-				build_chain_hash(domain_param, &current, chain_index as u64, position as u64);
-			current = Keccak256::digest(tweaked_message).into();
-		}
-		current
-	}
 
 	#[test]
 	fn test_circuit_winternitz_ots() {


### PR DESCRIPTION
This PR adds a Keccak256 tweak circuit that will be used to hash the public keys in the hash-based signature circuit.

Helper functions to compute the hash for tree and chain tweaks are also added.