### PR TITLE
[frontend] Add hash-based signature aggregation example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        example: [ethsign, zklogin, sha256, sha512, keccak]
+        example: [ethsign, zklogin, sha256, sha512, keccak, hash_based_sig]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/crates/examples/examples/hash_based_sig.rs
+++ b/crates/examples/examples/hash_based_sig.rs
@@ -1,0 +1,204 @@
+use std::array;
+
+use anyhow::Result;
+use binius_core::Word;
+use binius_examples::{Cli, ExampleCircuit};
+use binius_frontend::{
+	circuits::hash_based_sig::{
+		winternitz_ots::WinternitzSpec,
+		witness_utils::{ValidatorSignatureData, XmssHasherData, populate_xmss_hashers},
+		xmss::XmssSignature,
+		xmss_aggregate::{XmssMultisigHashers, circuit_xmss_multisig},
+	},
+	compiler::{CircuitBuilder, Wire, circuit::WitnessFiller},
+	util::pack_bytes_into_wires_le,
+};
+use clap::Args;
+use rand::{RngCore, SeedableRng, rngs::StdRng};
+
+/// Hash-based multi-signature verification example circuit
+struct HashBasedSigExample {
+	spec: WinternitzSpec,
+	tree_height: usize,
+	num_validators: usize,
+	param: Vec<Wire>,
+	message: Vec<Wire>,
+	epoch: Wire,
+	validator_roots: Vec<[Wire; 4]>,
+	validator_signatures: Vec<XmssSignature>,
+	hashers: XmssMultisigHashers,
+}
+
+#[derive(Args, Debug)]
+struct Params {
+	/// Number of validators in the multi-signature
+	#[arg(short = 'n', long, default_value_t = 3)]
+	num_validators: usize,
+
+	/// Height of the Merkle tree (2^height slots)
+	#[arg(short = 't', long, default_value_t = 3)]
+	tree_height: usize,
+
+	/// Winternitz spec: 1 or 2
+	#[arg(short = 's', long, default_value_t = 1)]
+	spec: u8,
+}
+
+#[derive(Args, Debug)]
+struct Instance {}
+
+impl ExampleCircuit for HashBasedSigExample {
+	type Params = Params;
+	type Instance = Instance;
+
+	fn build(params: Params, builder: &mut CircuitBuilder) -> Result<Self> {
+		let spec = match params.spec {
+			1 => WinternitzSpec::spec_1(),
+			2 => WinternitzSpec::spec_2(),
+			_ => anyhow::bail!("Invalid spec: must be 1 or 2"),
+		};
+
+		let tree_height = params.tree_height;
+		if tree_height >= 10 {
+			anyhow::bail!("tree_height {} exceeds the maximum supported height of 10", tree_height);
+		}
+		let num_validators = params.num_validators;
+
+		let param_wire_count = spec.domain_param_len.div_ceil(8);
+		let param: Vec<Wire> = (0..param_wire_count).map(|_| builder.add_inout()).collect();
+		let message: Vec<Wire> = (0..4).map(|_| builder.add_inout()).collect();
+		let epoch = builder.add_inout();
+
+		let validator_roots: Vec<[Wire; 4]> = (0..num_validators)
+			.map(|_| array::from_fn(|_| builder.add_inout()))
+			.collect();
+
+		let validator_signatures: Vec<XmssSignature> = (0..num_validators)
+			.map(|_| XmssSignature {
+				nonce: (0..3).map(|_| builder.add_witness()).collect(),
+				epoch, // All validators use the same epoch wire
+				signature_hashes: (0..spec.dimension())
+					.map(|_| array::from_fn(|_| builder.add_witness()))
+					.collect(),
+				public_key_hashes: (0..spec.dimension())
+					.map(|_| array::from_fn(|_| builder.add_witness()))
+					.collect(),
+				auth_path: (0..tree_height)
+					.map(|_| array::from_fn(|_| builder.add_witness()))
+					.collect(),
+			})
+			.collect();
+
+		let hashers = circuit_xmss_multisig(
+			builder,
+			&spec,
+			&param,
+			&message,
+			epoch,
+			&validator_roots,
+			&validator_signatures,
+		);
+
+		Ok(Self {
+			spec,
+			tree_height,
+			num_validators,
+			param,
+			message,
+			epoch,
+			validator_roots,
+			validator_signatures,
+			hashers,
+		})
+	}
+
+	fn populate_witness(&self, _instance: Instance, w: &mut WitnessFiller) -> Result<()> {
+		let mut rng = StdRng::seed_from_u64(0);
+
+		let mut param_bytes = vec![0u8; self.spec.domain_param_len];
+		rng.fill_bytes(&mut param_bytes);
+
+		let mut message_bytes = [0u8; 32];
+		rng.fill_bytes(&mut message_bytes);
+
+		// Safe because tree_height is validated to be < 10 in build()
+		let epoch = rng.next_u32() % (1u32 << self.tree_height);
+
+		// Pack param_bytes (pad to match wire count)
+		let mut padded_param = vec![0u8; self.param.len() * 8];
+		padded_param[..param_bytes.len()].copy_from_slice(&param_bytes);
+		pack_bytes_into_wires_le(w, &self.param, &padded_param);
+		pack_bytes_into_wires_le(w, &self.message, &message_bytes);
+		w[self.epoch] = Word::from_u64(epoch as u64);
+
+		// Generate a signature for each validator
+		for val_idx in 0..self.num_validators {
+			let validator_data = ValidatorSignatureData::generate(
+				&mut rng,
+				&param_bytes,
+				&message_bytes,
+				epoch,
+				&self.spec,
+				self.tree_height,
+			);
+
+			pack_bytes_into_wires_le(w, &self.validator_roots[val_idx], &validator_data.root);
+
+			let mut nonce_padded = [0u8; 24];
+			nonce_padded[..23].copy_from_slice(&validator_data.nonce);
+			pack_bytes_into_wires_le(w, &self.validator_signatures[val_idx].nonce, &nonce_padded);
+
+			for (i, sig_hash) in validator_data.signature_hashes.iter().enumerate() {
+				pack_bytes_into_wires_le(
+					w,
+					&self.validator_signatures[val_idx].signature_hashes[i],
+					sig_hash,
+				);
+			}
+
+			for (i, pk_hash) in validator_data.public_key_hashes.iter().enumerate() {
+				pack_bytes_into_wires_le(
+					w,
+					&self.validator_signatures[val_idx].public_key_hashes[i],
+					pk_hash,
+				);
+			}
+
+			for (i, auth_node) in validator_data.auth_path.iter().enumerate() {
+				pack_bytes_into_wires_le(
+					w,
+					&self.validator_signatures[val_idx].auth_path[i],
+					auth_node,
+				);
+			}
+
+			let hasher_data = XmssHasherData {
+				param_bytes: param_bytes.clone(),
+				message_bytes,
+				nonce_bytes: validator_data.nonce.to_vec(),
+				epoch: epoch as u64,
+				coords: validator_data.coords,
+				sig_hashes: validator_data.signature_hashes,
+				pk_hashes: validator_data.public_key_hashes,
+				auth_path: validator_data.auth_path,
+			};
+
+			populate_xmss_hashers(
+				w,
+				&self.hashers.validator_hashers[val_idx],
+				&self.spec,
+				&hasher_data,
+			);
+		}
+
+		Ok(())
+	}
+}
+
+fn main() -> Result<()> {
+	let _tracing_guard = tracing_profile::init_tracing()?;
+
+	Cli::<HashBasedSigExample>::new("hash_based_sig")
+		.about("Hash-based multi-signature (XMSS) verification example")
+		.run()
+}

--- a/crates/examples/snapshots/hash_based_sig.snap
+++ b/crates/examples/snapshots/hash_based_sig.snap
@@ -1,0 +1,11 @@
+hash_based_sig circuit
+--
+Number of gates: 4544883
+Number of evaluation instructions: 4634982
+Number of AND constraints: 4580460
+Number of MUL constraints: 0
+Length of value vec: 8388608
+  Constants: 376
+  Inout: 20
+  Witness: 29886
+  Internal: 4536540

--- a/crates/frontend/src/circuits/hash_based_sig/mod.rs
+++ b/crates/frontend/src/circuits/hash_based_sig/mod.rs
@@ -3,8 +3,6 @@ pub mod codeword;
 pub mod hashing;
 pub mod merkle_tree;
 pub mod winternitz_ots;
+pub mod witness_utils;
 pub mod xmss;
 pub mod xmss_aggregate;
-
-#[cfg(test)]
-mod test_utils;

--- a/crates/frontend/src/circuits/hash_based_sig/witness_utils.rs
+++ b/crates/frontend/src/circuits/hash_based_sig/witness_utils.rs
@@ -1,26 +1,33 @@
-//! Test utilities for hash-based signature verification tests.
-#[cfg(test)]
+//! Witness population utilities for hash-based signature verification.
+//!
+//! This module provides helper functions for populating witness data
+//! in hash-based signature circuits, including XMSS and Winternitz OTS.
+
+use rand::{RngCore, rngs::StdRng};
+
 use super::{
 	hashing::{
 		build_chain_hash, build_message_hash, build_public_key_hash, build_tree_hash,
 		hash_chain_keccak, hash_message, hash_public_key_keccak, hash_tree_node_keccak,
 	},
-	winternitz_ots::WinternitzSpec,
+	winternitz_ots::{WinternitzSpec, grind_nonce},
 	xmss::XmssHashers,
 };
+use crate::compiler::circuit::WitnessFiller;
 
 /// Builds a complete Merkle tree from leaf nodes.
 ///
-/// This function assumes the number of leaves is a power of 2, which is the case
-/// for all hash-based signature tests.
+/// This function assumes the number of leaves is a power of 2.
 ///
 /// # Returns
 /// A tuple containing:
 /// - Vector of tree levels (index 0 = leaves, last index = root)
 /// - The root hash
-#[cfg(test)]
+///
+/// # Panics
+/// Panics if leaves.len() is not a power of 2
 pub fn build_merkle_tree(param: &[u8], leaves: &[[u8; 32]]) -> (Vec<Vec<[u8; 32]>>, [u8; 32]) {
-	debug_assert!(leaves.len().is_power_of_two(), "Number of leaves must be a power of 2");
+	assert!(leaves.len().is_power_of_two(), "Number of leaves must be a power of 2");
 
 	let tree_depth = leaves.len().trailing_zeros() as usize;
 	let mut tree_levels = vec![leaves.to_vec()];
@@ -49,8 +56,7 @@ pub fn build_merkle_tree(param: &[u8], leaves: &[[u8; 32]]) -> (Vec<Vec<[u8; 32]
 
 /// Extracts the authentication path for a given leaf index in a Merkle tree.
 ///
-/// This function assumes the tree has power-of-2 leaves, which is the case
-/// for all our hash-based signature tests.
+/// This function assumes the tree has power-of-2 leaves.
 ///
 /// # Arguments
 /// * `tree_levels` - All levels of the tree (from build_merkle_tree)
@@ -58,7 +64,6 @@ pub fn build_merkle_tree(param: &[u8], leaves: &[[u8; 32]]) -> (Vec<Vec<[u8; 32]
 ///
 /// # Returns
 /// Vector of sibling hashes from leaf to root
-#[cfg(test)]
 pub fn extract_auth_path(tree_levels: &[Vec<[u8; 32]>], leaf_index: usize) -> Vec<[u8; 32]> {
 	let mut auth_path = Vec::new();
 	let mut idx = leaf_index;
@@ -73,8 +78,118 @@ pub fn extract_auth_path(tree_levels: &[Vec<[u8; 32]>], leaf_index: usize) -> Ve
 	auth_path
 }
 
+/// Helper structure containing signature data for a validator.
+///
+/// This is useful for generating test data or populating witness values
+/// in multi-signature scenarios.
+pub struct ValidatorSignatureData {
+	/// Root hash of the validator's Merkle tree
+	pub root: [u8; 32],
+	/// Nonce (23 bytes)
+	pub nonce: [u8; 23],
+	/// Signature hashes for each Winternitz chain
+	pub signature_hashes: Vec<[u8; 32]>,
+	/// Public key hashes for each Winternitz chain
+	pub public_key_hashes: Vec<[u8; 32]>,
+	/// Authentication path in the Merkle tree
+	pub auth_path: Vec<[u8; 32]>,
+	/// Codeword coordinates
+	pub coords: Vec<u8>,
+}
+
+impl ValidatorSignatureData {
+	/// Generate a valid signature for a validator at a given epoch.
+	///
+	/// This function generates all the cryptographic data needed for a validator's
+	/// signature including the Winternitz OTS signature, public key, and Merkle tree
+	/// authentication path.
+	///
+	/// # Panics
+	/// Panics if:
+	/// - The epoch is greater than the number of leaves in the tree.
+	/// - A `grind_nonce` fails to find a valid nonce
+	/// - A coordinate returned by `grind_nonce` is invalid.
+	pub fn generate(
+		rng: &mut StdRng,
+		param_bytes: &[u8],
+		message_bytes: &[u8; 32],
+		epoch: u32,
+		spec: &WinternitzSpec,
+		tree_height: usize,
+	) -> Self {
+		assert!(
+			tree_height <= 10,
+			"Tree height {} exceeds maximum supported height of 10",
+			tree_height,
+		);
+
+		// Validate epoch is within valid range for the tree
+		let num_leaves = 1usize << tree_height;
+		assert!(
+			(epoch as usize) < num_leaves,
+			"Epoch {} exceeds maximum leaf index {} for tree height {}",
+			epoch,
+			num_leaves - 1,
+			tree_height
+		);
+
+		let grind_result =
+			grind_nonce(spec, rng, param_bytes, message_bytes).expect("Failed to find valid nonce");
+
+		let mut nonce = [0u8; 23];
+		nonce.copy_from_slice(&grind_result.nonce);
+		let coords = grind_result.coords;
+
+		// Generate Winternitz signature and public key
+		let mut signature_hashes = Vec::new();
+		let mut public_key_hashes = Vec::new();
+
+		for (chain_idx, &coord) in coords.iter().enumerate() {
+			assert!(
+				(coord as usize) < spec.chain_len(),
+				"Coordinate {} exceeds chain length {}",
+				coord,
+				spec.chain_len()
+			);
+
+			let mut sig_hash = [0u8; 32];
+			rng.fill_bytes(&mut sig_hash);
+			signature_hashes.push(sig_hash);
+
+			let pk_hash = hash_chain_keccak(
+				param_bytes,
+				chain_idx,
+				&sig_hash,
+				coord as usize,
+				spec.chain_len() - 1 - coord as usize,
+			);
+			public_key_hashes.push(pk_hash);
+		}
+
+		// Build a Merkle tree with 2^tree_height leaves
+		let mut leaves = vec![[0u8; 32]; num_leaves];
+		leaves[epoch as usize] = hash_public_key_keccak(param_bytes, &public_key_hashes);
+		for (i, leaf) in leaves.iter_mut().enumerate() {
+			if i != epoch as usize {
+				rng.fill_bytes(leaf);
+			}
+		}
+
+		let (tree_levels, root) = build_merkle_tree(param_bytes, &leaves);
+		let auth_path = extract_auth_path(&tree_levels, epoch as usize);
+
+		ValidatorSignatureData {
+			root,
+			nonce,
+			signature_hashes,
+			public_key_hashes,
+			auth_path,
+			coords,
+		}
+	}
+}
+
 /// Data structure containing all the information needed to populate XMSS hashers.
-#[cfg(test)]
 pub struct XmssHasherData {
 	/// Parameter bytes (variable length based on spec)
 	pub param_bytes: Vec<u8>,
@@ -105,13 +220,40 @@ pub struct XmssHasherData {
 /// * `hashers` - The XMSS hashers to populate
 /// * `spec` - The Winternitz specification
 /// * `data` - The data to use for population
-#[cfg(test)]
+///
+/// # Panics
+/// Panics if:
+/// - `data.coord.len()` is not equal to `spec.dimension()`
+/// - `data.sig_hashes.len()` is not equal to `spec.dimension()`
+/// - `data.pk_hashes.len()` is not equal to `spec.dimension()`
 pub fn populate_xmss_hashers(
-	w: &mut crate::compiler::circuit::WitnessFiller,
+	w: &mut WitnessFiller,
 	hashers: &XmssHashers,
 	spec: &WinternitzSpec,
 	data: &XmssHasherData,
 ) {
+	assert_eq!(
+		data.coords.len(),
+		spec.dimension(),
+		"Coordinates length {} doesn't match spec dimension {}",
+		data.coords.len(),
+		spec.dimension()
+	);
+	assert_eq!(
+		data.sig_hashes.len(),
+		spec.dimension(),
+		"Signature hashes length {} doesn't match spec dimension {}",
+		data.sig_hashes.len(),
+		spec.dimension()
+	);
+	assert_eq!(
+		data.pk_hashes.len(),
+		spec.dimension(),
+		"Public key hashes length {} doesn't match spec dimension {}",
+		data.pk_hashes.len(),
+		spec.dimension()
+	);
+
 	// Populate message hasher
 	let message_hash = hash_message(&data.param_bytes, &data.nonce_bytes, &data.message_bytes);
 	let tweaked_message =

--- a/crates/frontend/src/circuits/hash_based_sig/xmss.rs
+++ b/crates/frontend/src/circuits/hash_based_sig/xmss.rs
@@ -35,7 +35,7 @@ pub struct XmssHashers {
 	/// Keccak hasher for computing the OTS public key hash from individual Winternitz public keys.
 	/// Computes: `hash(param || TWEAK_PUBLIC_KEY || pk_hash[0] || pk_hash[1] || ... ||
 	/// pk_hash[D-1])` Must be populated with:
-	/// - Message: The concatenated public key data (use `tweak::build_public_key_tweak`)
+	/// - Message: The concatenated public key data (use `hashing::build_public_key_hash`)
 	/// - Digest: The resulting public key hash (which becomes a leaf in the Merkle tree)
 	pub public_key_hasher: Keccak,
 
@@ -43,7 +43,7 @@ pub struct XmssHashers {
 	/// Contains one hasher per level of the tree that needs to be computed.
 	/// Each hasher computes: `hash(param || TWEAK_TREE || level || index || left_child ||
 	/// right_child)` Must be populated with:
-	/// - Message: The tree node tweak message (use `tweak::build_tree_tweak`)
+	/// - Message: The tree node hash message (use `hashing::build_tree_hash`)
 	/// - Digest: The parent node hash at that level
 	///
 	/// The hashers are ordered from leaf level upward to the root.
@@ -128,10 +128,10 @@ mod tests {
 	use crate::{
 		circuits::hash_based_sig::{
 			hashing::{hash_chain_keccak, hash_public_key_keccak},
-			test_utils::{
+			winternitz_ots::grind_nonce,
+			witness_utils::{
 				XmssHasherData, build_merkle_tree, extract_auth_path, populate_xmss_hashers,
 			},
-			winternitz_ots::grind_nonce,
 		},
 		constraint_verifier::verify_constraints,
 		util::pack_bytes_into_wires_le,


### PR DESCRIPTION
This PR adds an example circuit to demonstrate / test hash-based signature aggregation.

The example is parametrized by:  
1\. The number of validators signing (i.e the number of signatures being aggregated)  
2\. The size of the merkle tree that each validator is using to store public keys  
3\. Which Winternitz spec is being used