### PR TITLE
[secp256k1] Naive scalar multiplication circuit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ hex-literal = "1.0.0"
 either = "1.11.0"
 itertools = "0.14.0"
 jwt-simple = { version = "0.12.12", default-features = false, features = ["pure-rust"] }
+k256 = "0.13.4"
 lazy_static = "1.5.0"
 num-bigint = "0.4.6"
 num-integer = "0.1.46"

--- a/crates/frontend/Cargo.toml
+++ b/crates/frontend/Cargo.toml
@@ -22,6 +22,7 @@ smallvec.workspace = true
 base64 = { workspace = true }
 blake2 = { workspace = true }
 jwt-simple = { workspace = true }
+k256 = { workspace = true, features = ["arithmetic"] }
 rand = { workspace = true, features = ["std_rng", "thread_rng"] }
 rsa = { workspace = true, features = ["sha2"] }
 hex-literal = { workspace = true }

--- a/crates/frontend/src/circuits/ecdsa/mod.rs
+++ b/crates/frontend/src/circuits/ecdsa/mod.rs
@@ -2,7 +2,7 @@
 
 mod bitcoin;
 mod ecrecover;
-mod scalar_mul;
+pub mod scalar_mul;
 
 pub use bitcoin::verify as bitcoin_verify;
 pub use ecrecover::ecrecover;

--- a/crates/frontend/src/circuits/ecdsa/tests.rs
+++ b/crates/frontend/src/circuits/ecdsa/tests.rs
@@ -1,12 +1,11 @@
 use binius_core::word::Word;
 use hex_literal::hex;
 
-use super::scalar_mul::scalar_mul_naive;
 use crate::{
 	circuits::{
 		bignum::{BigUint, assert_eq},
 		ecdsa::{bitcoin_verify, ecrecover},
-		secp256k1::{Secp256k1, Secp256k1Affine},
+		secp256k1::Secp256k1Affine,
 	},
 	compiler::CircuitBuilder,
 };
@@ -68,46 +67,4 @@ pub fn test_ecdsa_recover_test_vector() {
 	let cs = builder.build();
 	let mut w = cs.new_witness_filler();
 	assert!(cs.populate_wire_witness(&mut w).is_ok());
-}
-
-#[test]
-pub fn test_scalar_mul_naive() {
-	let builder = CircuitBuilder::new();
-	let curve = Secp256k1::new(&builder);
-
-	// Test vector: scalar * G = known point
-	// Using a small scalar for initial testing: 3
-	// 3 * G should give us a known point on the curve
-	let scalar_bytes = hex!("0000000000000000000000000000000000000000000000000000000000000003");
-	let scalar =
-		BigUint::new_constant(&builder, &num_bigint::BigUint::from_bytes_be(&scalar_bytes))
-			.zero_extend(&builder, 4); // Extend to 4 limbs for 256 bits
-
-	// Expected result coordinates for 3*G
-	// These are the x and y coordinates of 3 times the generator point
-	let expected_x_bytes = hex!("F9308A019258C31049344F85F89D5229B531C845836F99B08601F113BCE036F9");
-	let expected_y_bytes = hex!("388F7B0F632DE8140FE337E62A37F3566500A99934C2231B6CB9FD7584B8E672");
-
-	let expected_x =
-		BigUint::new_constant(&builder, &num_bigint::BigUint::from_bytes_be(&expected_x_bytes));
-	let expected_y =
-		BigUint::new_constant(&builder, &num_bigint::BigUint::from_bytes_be(&expected_y_bytes));
-
-	// Get the generator point
-	let generator = Secp256k1Affine::generator(&builder);
-
-	// Perform scalar multiplication
-	let result = scalar_mul_naive(&builder, &curve, 256, &scalar, generator);
-
-	// Check that the result matches the expected point
-	assert_eq(&builder, "result_x", &result.x, &expected_x);
-	assert_eq(&builder, "result_y", &result.y, &expected_y);
-
-	// Build and verify the circuit
-	let cs = builder.build();
-	let mut w = cs.new_witness_filler();
-	assert!(cs.populate_wire_witness(&mut w).is_ok());
-
-	// Also verify the point is not at infinity
-	assert_eq!(w[result.is_point_at_infinity], Word::ZERO);
 }


### PR DESCRIPTION
This is a primitive circuit for secp256k1 scalar multiplication.

I want to use this (or rather the optimized one in the next stack PR) for BIP32 derivation example.