### PR TITLE
Run tests again native CPU in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,13 +96,13 @@ jobs:
             command: |
               cargo nextest run --workspace --release --no-fail-fast
               cargo test --doc --workspace
-            rustflags: "-C debug-assertions"
+            rustflags: "-C debug-assertions -C target-cpu=native"
           - name: "test-all-features"
             command: |
               ALL_FEATURES_WO_BAIL_PANIC=$(.github/scripts/get-features-without-bail-panic.sh | tail -1)
               echo "ALL_FEATURES_WO_BAIL_PANIC: $ALL_FEATURES_WO_BAIL_PANIC"
               cargo nextest run --workspace --release --features "$ALL_FEATURES_WO_BAIL_PANIC" --no-fail-fast
-            rustflags: "-C debug-assertions"
+            rustflags: "-C debug-assertions -C target-cpu=native"
           - name: "wasm-build"
             command: |
               cargo build -p binius-math -p binius-field -p binius-prover -p binius-verifier --target wasm32-wasip1 --tests --benches


### PR DESCRIPTION
### TL;DR

Enable CPU-specific optimizations for test runs in CI by adding the `-C target-cpu=native` flag.
Ideally we also need nightly jobs on `main` without those flags to ensure that portable version is not broken as well.

### What changed?

Added the `-C target-cpu=native` rustflag to both the standard test and all-features test configurations in the CI workflow. This flag instructs the Rust compiler to generate code optimized for the specific CPU architecture of the machine running the tests.

### How to test?

Run the CI pipeline and verify that tests complete successfully with the new flags. You can also compare performance metrics between runs with and without the flag to observe potential improvements.

### Why make this change?

Using `-C target-cpu=native` allows the compiler to take advantage of all available CPU features on the CI machines, potentially improving test performance by generating more optimized code. This can lead to faster test execution without changing the actual test behavior or validity.