### PR TITLE
Fix x64 tests with GFNI enabled, remove Canonical type

### DIFF
--- a/crates/field/src/aes_field.rs
+++ b/crates/field/src/aes_field.rs
@@ -44,8 +44,6 @@ mul_by_binary_field_1b!(AESTowerField8b);
 impl_arithmetic_using_packed!(AESTowerField8b);
 
 impl TowerField for AESTowerField8b {
-	type Canonical = AESTowerField8b;
-
 	fn min_tower_level(self) -> usize {
 		match self {
 			Self::ZERO | Self::ONE => 0,

--- a/crates/field/src/binary_field.rs
+++ b/crates/field/src/binary_field.rs
@@ -1,7 +1,6 @@
 // Copyright 2023-2025 Irreducible Inc.
 
 use std::{
-	any::TypeId,
 	fmt::{Debug, Display, Formatter},
 	iter::{Product, Sum},
 	ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
@@ -31,17 +30,9 @@ pub trait BinaryField: ExtensionField<BinaryField1b> {
 /// trait can be implemented on any binary field *isomorphic* to the canonical tower field.
 ///
 /// [DP23]: https://eprint.iacr.org/2023/1784
-pub trait TowerField: BinaryField + From<Self::Canonical>
-where
-	Self::Canonical: From<Self>,
-{
+pub trait TowerField: BinaryField {
 	/// The level $\iota$ in the tower, where this field is isomorphic to $T_{\iota}$.
 	const TOWER_LEVEL: usize = Self::N_BITS.ilog2() as usize;
-
-	/// The canonical field isomorphic to this tower field.
-	/// Currently for every tower field, the canonical field is Fan-Paar's binary field of the same
-	/// degree.
-	type Canonical: TowerField + SerializeBytes + DeserializeBytes;
 
 	/// Returns the smallest valid `TOWER_LEVEL` in the tower that can fit the same value.
 	///
@@ -533,11 +524,6 @@ macro_rules! impl_field_extension {
 pub(crate) use impl_field_extension;
 
 binary_field!(pub BinaryField1b(U1), U1::new(0x1));
-
-#[inline(always)]
-pub fn is_canonical_tower<F: TowerField>() -> bool {
-	TypeId::of::<F::Canonical>() == TypeId::of::<F>()
-}
 
 macro_rules! serialize_deserialize {
 	($bin_type:ty) => {

--- a/crates/field/src/binary_field_arithmetic.rs
+++ b/crates/field/src/binary_field_arithmetic.rs
@@ -59,8 +59,6 @@ pub(crate) use impl_arithmetic_using_packed;
 
 // TODO: try to get rid of `TowerFieldArithmetic` and use `impl_arithmetic_using_packed` here
 impl TowerField for BinaryField1b {
-	type Canonical = Self;
-
 	fn min_tower_level(self) -> usize {
 		0
 	}

--- a/crates/field/src/ghash.rs
+++ b/crates/field/src/ghash.rs
@@ -504,8 +504,6 @@ impl BinaryField for BinaryField128bGhash {
 }
 
 impl TowerField for BinaryField128bGhash {
-	type Canonical = Self;
-
 	fn min_tower_level(self) -> usize {
 		match self {
 			Self::ZERO | Self::ONE => 0,

--- a/crates/field/src/polyval.rs
+++ b/crates/field/src/polyval.rs
@@ -483,8 +483,6 @@ impl BinaryField for BinaryField128bPolyval {
 }
 
 impl TowerField for BinaryField128bPolyval {
-	type Canonical = BinaryField128bPolyval;
-
 	fn min_tower_level(self) -> usize {
 		match self {
 			Self::ZERO | Self::ONE => 0,


### PR DESCRIPTION
### TL;DR

Remove the `Canonical` associated type from the `TowerField` trait and related code. This fixes the unit tests that were not passing with GFNI enabled because `is_canonical` was returning a wrong value

### What changed?

- Removed the `Canonical` associated type from the `TowerField` trait
- Removed implementations of this associated type from all implementors of `TowerField`
- Removed the `is_canonical_tower` function and its usages
- Removed the tower-to-AES and AES-to-tower mapping constants that were used for conversions
- Removed the `linear_transform` function that was no longer needed
- Simplified the `invert_or_zero` implementation to only handle AES tower fields without conversion

### How to test?

- Run the existing test suite to ensure all functionality still works correctly
- Verify that code using binary fields still compiles and functions as expected
- Check that GFNI-based field operations still work correctly

### Why make this change?

This change simplifies the binary field implementation by removing the concept of "canonical" tower fields. The code previously supported conversions between different representations of tower fields, but this added complexity wasn't necessary. By removing this abstraction, the code becomes more straightforward and easier to maintain while preserving all required functionality.