### PR TITLE
[secp256k1] check_endomorphism_split performs an assertion

### DIFF
--- a/crates/examples/snapshots/ethsign.snap
+++ b/crates/examples/snapshots/ethsign.snap
@@ -1,11 +1,11 @@
 ethsign circuit
 --
-Number of gates: 265682
-Number of evaluation instructions: 311798
-Number of AND constraints: 335718
+Number of gates: 265672
+Number of evaluation instructions: 311772
+Number of AND constraints: 335708
 Number of MUL constraints: 25458
 Length of value vec: 524288
   Constants: 82
   Inout: 29
   Witness: 42
-  Internal: 481221
+  Internal: 481197


### PR DESCRIPTION
Since this is used to check a prover hint, and the prover hint is known to always be computable, we can assert rather than returning a boolean.