### PR TITLE
check intmul doesn't overflow modulo 2^128-1

### DIFF
--- a/crates/examples/snapshots/ethsign.snap
+++ b/crates/examples/snapshots/ethsign.snap
@@ -2,7 +2,7 @@ ethsign circuit
 --
 Number of gates: 265672
 Number of evaluation instructions: 311772
-Number of AND constraints: 335708
+Number of AND constraints: 361166
 Number of MUL constraints: 25458
 Length of value vec: 524288
   Constants: 82

--- a/crates/examples/snapshots/zklogin.snap
+++ b/crates/examples/snapshots/zklogin.snap
@@ -2,7 +2,7 @@ zklogin circuit
 --
 Number of gates: 462908
 Number of evaluation instructions: 550412
-Number of AND constraints: 577527
+Number of AND constraints: 604407
 Number of MUL constraints: 26880
 Length of value vec: 1048576
   Constants: 710


### PR DESCRIPTION
### TL;DR

Added an overflow check to the integer multiplication gate to prevent potential vulnerabilities.

### What changed?

Added an additional constraint to the `imul.rs` gate implementation that prevents overflow modulo 2^128-1. The implementation now verifies integer multiplication on the least significant bits by:

1. Extracting the least significant bits using shift-left operations
2. Adding an AND constraint to verify that `x[0] * y[0] = lo[0]`

This is accomplished by importing the `sll` function from the constraint builder module and adding the new AND constraint after the existing multiplication constraint.

### How to test?

Run the existing test suite to ensure that the integer multiplication gate still functions correctly with the added overflow protection. Consider adding specific tests that attempt to trigger overflow conditions to verify the new constraint is working as expected.

### Why make this change?

This change addresses a potential security vulnerability where overflow modulo 2^128-1 could occur in integer multiplication operations. The additional constraint ensures that the least significant bits of the multiplication are correctly verified, which is sufficient to guard against overflow attacks that could potentially compromise the system's integrity.