### PR TITLE
Keccak-f[1600] gate

### DIFF
--- a/crates/examples/benches/keccak.rs
+++ b/crates/examples/benches/keccak.rs
@@ -65,7 +65,10 @@ fn bench_keccak_permutations(c: &mut Criterion) {
 	println!("  Permutations: {}", n_permutations);
 	println!("=======================================\n");
 
-	let params = Params { n_permutations };
+	let params = Params {
+		n_permutations,
+		no_intrinsic: false,
+	};
 	let instance = Instance {};
 
 	// Setup phase - do this once outside the benchmark loop

--- a/crates/examples/snapshots/ethsign.snap
+++ b/crates/examples/snapshots/ethsign.snap
@@ -1,11 +1,11 @@
 ethsign circuit
 --
-Number of gates: 264472
-Number of evaluation instructions: 310572
-Number of AND constraints: 359966
+Number of gates: 258954
+Number of evaluation instructions: 305054
+Number of AND constraints: 355646
 Number of MUL constraints: 25458
 Length of value vec: 524288
   Constants: 82
   Inout: 29
   Witness: 42
-  Internal: 479997
+  Internal: 475677

--- a/crates/examples/snapshots/hash_based_sig.snap
+++ b/crates/examples/snapshots/hash_based_sig.snap
@@ -1,11 +1,11 @@
 hash_based_sig circuit
 --
-Number of gates: 3986883
-Number of evaluation instructions: 4076982
-Number of AND constraints: 4022460
+Number of gates: 1421013
+Number of evaluation instructions: 1511112
+Number of AND constraints: 2013660
 Number of MUL constraints: 0
-Length of value vec: 4194304
+Length of value vec: 2097152
   Constants: 376
   Inout: 20
   Witness: 29886
-  Internal: 3978540
+  Internal: 1969740

--- a/crates/examples/snapshots/keccak.snap
+++ b/crates/examples/snapshots/keccak.snap
@@ -1,11 +1,11 @@
 keccak circuit
 --
-Number of gates: 27625
-Number of evaluation instructions: 27625
-Number of AND constraints: 27625
+Number of gates: 35
+Number of evaluation instructions: 35
+Number of AND constraints: 6025
 Number of MUL constraints: 0
-Length of value vec: 32768
+Length of value vec: 8192
   Constants: 23
   Inout: 50
   Witness: 0
-  Internal: 27600
+  Internal: 6000

--- a/crates/examples/src/circuits/keccak.rs
+++ b/crates/examples/src/circuits/keccak.rs
@@ -21,6 +21,10 @@ pub struct Params {
 	/// Number of Keccak-f\[1600\] permutations to chain together
 	#[arg(short = 'n', long, default_value_t = 10)]
 	pub n_permutations: usize,
+
+	/// Do not use Keccakf1600 intrinsic opcode, build primitive gate circuit instead
+	#[arg(long)]
+	pub no_intrinsic: bool,
 }
 
 #[derive(Args, Debug, Clone)]
@@ -42,7 +46,7 @@ impl ExampleCircuit for KeccakExample {
 		// Chain n permutations starting from initial state
 		let mut computed_state = initial_state;
 		for _ in 0..params.n_permutations {
-			Permutation::keccak_f1600(builder, &mut computed_state);
+			Permutation::keccak_f1600(builder, !params.no_intrinsic, &mut computed_state);
 		}
 
 		// Constrain computed final state to equal expected final state

--- a/crates/frontend/src/circuits/keccak/mod.rs
+++ b/crates/frontend/src/circuits/keccak/mod.rs
@@ -48,6 +48,30 @@ impl Keccak {
 		digest: [Wire; N_WORDS_PER_DIGEST],
 		message: Vec<Wire>,
 	) -> Self {
+		let use_intrinsic = true;
+		Self::new_with_intrinsic(b, use_intrinsic, len_bytes, digest, message)
+	}
+
+	/// Create a new keccak circuit using the circuit builder
+	///
+	/// # Arguments
+	///
+	/// * `builder` - circuit builder object
+	/// * `use_intrinsic` - use `Keccakf1600` opcode instead of a circuit of more primitive gates.
+	/// * `max_len` - max message length in bytes for this circuit instance
+	/// * `len` - wire representing the claimed input message length in bytes
+	/// * `digest` - array of 4 wires representing the claimed 256-bit output digest
+	/// * `message` - vector of wires representing the claimed input message
+	///
+	/// ## Preconditions
+	/// * max_len > 0
+	pub fn new_with_intrinsic(
+		b: &CircuitBuilder,
+		use_intrinsic: bool,
+		len_bytes: Wire,
+		digest: [Wire; N_WORDS_PER_DIGEST],
+		message: Vec<Wire>,
+	) -> Self {
 		let max_len_bytes = message.len() << 3;
 		// number of blocks needed for the maximum sized message
 		let n_blocks = (max_len_bytes + 1).div_ceil(RATE_BYTES);
@@ -74,7 +98,7 @@ impl Keccak {
 					b.bxor(state_in[i], padded_message[block_no * N_WORDS_PER_BLOCK + i]);
 			}
 
-			Permutation::keccak_f1600(b, &mut xored_state);
+			Permutation::keccak_f1600(b, use_intrinsic, &mut xored_state);
 
 			states.push(xored_state);
 		}

--- a/crates/frontend/src/compiler/eval_form/builder.rs
+++ b/crates/frontend/src/compiler/eval_form/builder.rs
@@ -268,6 +268,14 @@ impl BytecodeBuilder {
 		self.emit_u32(error_id);
 	}
 
+	pub fn emit_keccakf1600(&mut self, rounds: [u32; (24 + 1) * 25]) {
+		self.n_eval_insn += 1;
+		self.emit_u8(0x70);
+		for reg in rounds {
+			self.emit_reg(reg);
+		}
+	}
+
 	// Hint calls
 	pub fn emit_hint(
 		&mut self,

--- a/crates/frontend/src/compiler/gate/keccakf1600.rs
+++ b/crates/frontend/src/compiler/gate/keccakf1600.rs
@@ -1,0 +1,201 @@
+//! Keccak-f/[1600/] permutation
+//!
+//! Takes 25 wires representing 5x5x64 state in lane order (column major, `i = x + 5*y`).
+//! Commits to 24 * 25 = 600 words to represent states after each of the 24 rounds, where the
+//! output of the last round is the output of the gate.
+//!
+//! # Constraints
+//! Generates 25 AND constraints for each round χ step, which is allegedly optimal.
+
+use std::{
+	array,
+	iter::{self, once},
+};
+
+use binius_core::word::Word;
+
+use crate::compiler::{
+	constraint_builder::{ConstraintBuilder, WireExpr, sll, srl, xor_multi},
+	gate::opcode::OpcodeShape,
+	gate_graph::{Gate, GateData, GateParam, Wire},
+};
+
+// Gate constants (ι round constants + all ones)
+pub const CONSTS: [Word; 25] = [
+	Word(0x0000_0000_0000_0001),
+	Word(0x0000_0000_0000_8082),
+	Word(0x8000_0000_0000_808A),
+	Word(0x8000_0000_8000_8000),
+	Word(0x0000_0000_0000_808B),
+	Word(0x0000_0000_8000_0001),
+	Word(0x8000_0000_8000_8081),
+	Word(0x8000_0000_0000_8009),
+	Word(0x0000_0000_0000_008A),
+	Word(0x0000_0000_0000_0088),
+	Word(0x0000_0000_8000_8009),
+	Word(0x0000_0000_8000_000A),
+	Word(0x0000_0000_8000_808B),
+	Word(0x8000_0000_0000_008B),
+	Word(0x8000_0000_0000_8089),
+	Word(0x8000_0000_0000_8003),
+	Word(0x8000_0000_0000_8002),
+	Word(0x8000_0000_0000_0080),
+	Word(0x0000_0000_0000_800A),
+	Word(0x8000_0000_8000_000A),
+	Word(0x8000_0000_8000_8081),
+	Word(0x8000_0000_0000_8080),
+	Word(0x0000_0000_8000_0001),
+	Word(0x8000_0000_8000_8008),
+	Word::ALL_ONE,
+];
+
+// ρ rotation offsets r[x,y] in lane order (i = x + 5*y)
+pub const R: [u32; 25] = [
+	0x00, 0x01, 0x3E, 0x1C, 0x1B, 0x24, 0x2C, 0x06, 0x37, 0x14, 0x03, 0x0A, 0x2B, 0x19, 0x27, 0x29,
+	0x2D, 0x0F, 0x15, 0x08, 0x12, 0x02, 0x3D, 0x38, 0x0E,
+];
+
+#[derive(Clone, Copy)]
+struct RotWire {
+	amount: u32,
+	wire: Wire,
+}
+
+fn plain(wire: Wire) -> RotWire {
+	RotWire { wire, amount: 0 }
+}
+
+fn rot(amount: u32, operand: &[RotWire]) -> Vec<RotWire> {
+	operand
+		.iter()
+		.map(|rot_wire| RotWire {
+			amount: (rot_wire.amount + amount) % 64,
+			wire: rot_wire.wire,
+		})
+		.collect()
+}
+
+fn xor(operand1: &[RotWire], operand2: &[RotWire]) -> Vec<RotWire> {
+	[operand1, operand2].concat()
+}
+
+#[inline(always)]
+pub const fn idx(x: usize, y: usize) -> usize {
+	(x % 5) + 5 * (y % 5)
+}
+
+fn to_wire_expr_terms(wires: &[RotWire]) -> WireExpr {
+	let mut terms = Vec::new();
+	for &RotWire { wire, amount } in wires {
+		if amount == 0 {
+			terms.push(wire.into())
+		} else {
+			terms.extend([sll(wire, amount), srl(wire, 64 - amount)])
+		}
+	}
+
+	xor_multi(terms)
+}
+
+fn emit_and(builder: &mut ConstraintBuilder, a: &[RotWire], b: &[RotWire], c: &[RotWire]) {
+	let a = to_wire_expr_terms(a);
+	let b = to_wire_expr_terms(b);
+	let c = to_wire_expr_terms(c);
+	builder.and().a(a).b(b).c(c).build()
+}
+
+pub fn shape() -> OpcodeShape {
+	OpcodeShape {
+		const_in: &CONSTS,
+		n_in: 25,
+		n_out: 25,
+		n_aux: (24 - 1) * 25,
+		n_scratch: 0,
+		n_imm: 0,
+	}
+}
+
+pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) {
+	let GateParam {
+		constants,
+		inputs,
+		outputs,
+		aux,
+		..
+	} = data.gate_param();
+
+	assert_eq!(constants.len(), 24 + 1);
+	assert_eq!(inputs.len(), 25);
+	assert_eq!(outputs.len(), 25);
+	assert_eq!(aux.len(), (24 - 1) * 25);
+
+	let (all_one, round_constants) = constants.split_last().expect("RC[0..24] + ALL_ONE");
+
+	let inputs = once(inputs).chain(aux.chunks(25));
+	let outputs = aux.chunks(25).chain(once(outputs));
+
+	for (round, (pre, post)) in iter::zip(inputs, outputs).enumerate() {
+		// θ
+		let c: [Vec<RotWire>; 5] =
+			array::from_fn(|i| (0..5).map(|j| plain(pre[idx(i, j)])).collect());
+		let d: [Vec<RotWire>; 5] =
+			array::from_fn(|i| xor(&c[(i + 4) % 5], &rot(1, &c[(i + 1) % 5])));
+		let a: [Vec<RotWire>; 25] = array::from_fn(|i| xor(&[plain(pre[i])], &d[i % 5]));
+
+		// ρ & π
+		let mut b: [Vec<RotWire>; 25] = Default::default();
+		for x in 0..5 {
+			for y in 0..5 {
+				let i = idx(x, y);
+				b[idx(y, 2 * x + 3 * y)] = rot(R[i], &a[i]);
+			}
+		}
+
+		// χ & ι
+		for x in 0..5 {
+			for y in 0..5 {
+				let i = idx(x, y);
+
+				let and_a = xor(&[plain(*all_one)], &b[idx(x + 1, y)]);
+				let and_b = &b[idx(x + 2, y)];
+
+				let mut and_c = xor(&[plain(post[i])], &b[i]);
+				if i == 0 {
+					and_c.push(plain(round_constants[round]));
+				}
+
+				emit_and(builder, &and_a, and_b, &and_c);
+			}
+		}
+	}
+}
+
+pub fn emit_eval_bytecode(
+	_gate: Gate,
+	data: &GateData,
+	builder: &mut crate::compiler::eval_form::BytecodeBuilder,
+	wire_to_reg: impl Fn(Wire) -> u32,
+) {
+	let GateParam {
+		inputs,
+		outputs,
+		aux,
+		..
+	} = data.gate_param();
+
+	assert_eq!(inputs.len(), 25);
+	assert_eq!(outputs.len(), 25);
+	assert_eq!(aux.len(), (24 - 1) * 25);
+
+	let regs = inputs
+		.iter()
+		.chain(aux)
+		.chain(outputs)
+		.map(|&wire| wire_to_reg(wire))
+		.collect::<Vec<_>>();
+
+	builder.emit_keccakf1600(
+		TryInto::<[u32; (24 + 1) * 25]>::try_into(regs)
+			.expect("correct number of Keccak intermediates"),
+	);
+}

--- a/crates/frontend/src/compiler/gate/mod.rs
+++ b/crates/frontend/src/compiler/gate/mod.rs
@@ -31,6 +31,7 @@ pub mod icmp_eq;
 pub mod icmp_ult;
 pub mod imul;
 pub mod isub_bin_bout;
+pub mod keccakf1600;
 pub mod mod_inverse_hint;
 pub mod rotr;
 pub mod rotr32;
@@ -68,6 +69,7 @@ pub fn constrain(gate: Gate, graph: &GateGraph, builder: &mut ConstraintBuilder)
 		Opcode::IcmpUlt => icmp_ult::constrain(gate, data, builder),
 		Opcode::IcmpEq => icmp_eq::constrain(gate, data, builder),
 		Opcode::ExtractByte => extract_byte::constrain(gate, data, builder),
+		Opcode::Keccakf1600 => keccakf1600::constrain(gate, data, builder),
 		Opcode::Shr => shr::constrain(gate, data, builder),
 		Opcode::Shl => shl::constrain(gate, data, builder),
 		Opcode::Sar => sar::constrain(gate, data, builder),
@@ -130,6 +132,7 @@ pub fn emit_gate_bytecode(
 		Opcode::IcmpUlt => icmp_ult::emit_eval_bytecode(gate, data, builder, wire_to_reg),
 		Opcode::IcmpEq => icmp_eq::emit_eval_bytecode(gate, data, builder, wire_to_reg),
 		Opcode::ExtractByte => extract_byte::emit_eval_bytecode(gate, data, builder, wire_to_reg),
+		Opcode::Keccakf1600 => keccakf1600::emit_eval_bytecode(gate, data, builder, wire_to_reg),
 		Opcode::Shr => shr::emit_eval_bytecode(gate, data, builder, wire_to_reg),
 		Opcode::Shl => shl::emit_eval_bytecode(gate, data, builder, wire_to_reg),
 		Opcode::Sar => sar::emit_eval_bytecode(gate, data, builder, wire_to_reg),

--- a/crates/frontend/src/compiler/gate/opcode.rs
+++ b/crates/frontend/src/compiler/gate/opcode.rs
@@ -36,6 +36,9 @@ pub enum Opcode {
 	// Extraction
 	ExtractByte,
 
+	// Keccak-f[1600]
+	Keccakf1600,
+
 	// Assertions
 	AssertEq,
 	AssertZero,
@@ -123,6 +126,9 @@ impl Opcode {
 
 			// Extraction
 			Opcode::ExtractByte => gate::extract_byte::shape(),
+
+			// Keccakf-f[1600]
+			Opcode::Keccakf1600 => gate::keccakf1600::shape(),
 
 			// Assertions (no outputs)
 			Opcode::AssertEq => gate::assert_eq::shape(),

--- a/crates/frontend/src/compiler/mod.rs
+++ b/crates/frontend/src/compiler/mod.rs
@@ -716,6 +716,21 @@ impl CircuitBuilder {
 		z
 	}
 
+	/// Keccak-f\[1600\] permutation.
+	///
+	/// Takes 25 wires representing 5x5x64 state in lane order (column major, `i = x + 5*y`).
+	/// Outputs 25 wires representing post-permutation state.
+	///
+	/// # Cost
+	///
+	/// 600 AND constraints (25 per each round χ step for 24 rounds, which is optimal)
+	pub fn keccakf1600(&self, inputs: [Wire; 25]) -> [Wire; 25] {
+		let outputs = array::from_fn(|_| self.add_internal());
+		let mut graph = self.graph_mut();
+		graph.emit_gate(self.current_path, Opcode::Keccakf1600, inputs, outputs);
+		outputs
+	}
+
 	/// Select operation.
 	///
 	/// Returns `t` if MSB(cond) is 1, otherwise returns `f`.


### PR DESCRIPTION
Introducing an intrinsic `Keccakf1600` opcode, which instantiates an optimal 600 AND constraint circuit.

The `keccak` example has a `--no-intrinsic` flag to facilitate comparison with the gate fusion approach.