### PR TITLE
[frontend] linear constraints

### DIFF
--- a/crates/frontend/src/compiler/gate/bxor.rs
+++ b/crates/frontend/src/compiler/gate/bxor.rs
@@ -33,19 +33,15 @@ pub fn shape() -> OpcodeShape {
 
 pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) {
 	let GateParam {
-		constants,
-		inputs,
-		outputs,
-		..
+		inputs, outputs, ..
 	} = data.gate_param();
-	let [all_one] = constants else { unreachable!() };
 	let [x, y] = inputs else { unreachable!() };
 	let [z] = outputs else { unreachable!() };
 
-	// Constraint: Bitwise XOR
+	// Constraint: Bitwise XOR (linear)
 	//
-	// (x ⊕ y) ∧ all-1 = z
-	builder.and().a(xor2(*x, *y)).b(*all_one).c(*z).build();
+	// (x ⊕ y) = z
+	builder.linear().rhs(xor2(*x, *y)).dst(*z).build();
 }
 
 pub fn emit_eval_bytecode(

--- a/crates/frontend/src/compiler/gate/bxor_multi.rs
+++ b/crates/frontend/src/compiler/gate/bxor_multi.rs
@@ -31,19 +31,15 @@ pub fn shape(dimensions: &[usize]) -> OpcodeShape {
 
 pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) {
 	let GateParam {
-		constants,
-		inputs,
-		outputs,
-		..
+		inputs, outputs, ..
 	} = data.gate_param();
-	let [all_one] = constants else { unreachable!() };
 	let [z] = outputs else { unreachable!() };
 
-	// Constraint: N-way Bitwise XOR
+	// Constraint: N-way Bitwise XOR (linear)
 	//
-	// (x0 ⊕ x1 ⊕ ... ⊕ xn) ∧ all-1 = z
+	// (x0 ⊕ x1 ⊕ ... ⊕ xn) = z
 	let terms: Vec<WireExprTerm> = inputs.iter().map(|&w| w.into()).collect();
-	builder.and().a(xor_multi(terms)).b(*all_one).c(*z).build();
+	builder.linear().rhs(xor_multi(terms)).dst(*z).build();
 }
 
 pub fn emit_eval_bytecode(

--- a/crates/frontend/src/compiler/gate/iadd_cin_cout.rs
+++ b/crates/frontend/src/compiler/gate/iadd_cin_cout.rs
@@ -47,12 +47,8 @@ pub fn shape() -> OpcodeShape {
 
 pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) {
 	let GateParam {
-		constants,
-		inputs,
-		outputs,
-		..
+		inputs, outputs, ..
 	} = data.gate_param();
-	let [all_one] = constants else { unreachable!() };
 	let [a, b, cin] = inputs else { unreachable!() };
 	let [sum, cout] = outputs else { unreachable!() };
 
@@ -69,14 +65,13 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 		.c(xor3(*cout, cout_sll_1, cin_msb))
 		.build();
 
-	// Constraint 2: Sum equality
+	// Constraint 2: Sum equality (linear)
 	//
-	// (a ⊕ b ⊕ (cout << 1) ⊕ cin_msb) ∧ all-1 = sum
+	// (a ⊕ b ⊕ (cout << 1) ⊕ cin_msb) = sum
 	builder
-		.and()
-		.a(xor4(*a, *b, cout_sll_1, cin_msb))
-		.b(*all_one)
-		.c(*sum)
+		.linear()
+		.rhs(xor4(*a, *b, cout_sll_1, cin_msb))
+		.dst(*sum)
 		.build();
 }
 

--- a/crates/frontend/src/compiler/gate/isub_bin_bout.rs
+++ b/crates/frontend/src/compiler/gate/isub_bin_bout.rs
@@ -43,14 +43,13 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 		.c(xor3(*bout, bout_sll_1, bin_msb))
 		.build();
 
-	// Constraint 2: Diff equality
+	// Constraint 2: Diff equality (linear)
 	//
-	// (a ⊕ b ⊕ (bout << 1) ⊕ bin_msb) ∧ all-1 = diff
+	// (a ⊕ b ⊕ (bout << 1) ⊕ bin_msb) = diff
 	builder
-		.and()
-		.a(xor4(*a, *b, bout_sll_1, bin_msb))
-		.b(*all_one)
-		.c(*diff)
+		.linear()
+		.rhs(xor4(*a, *b, bout_sll_1, bin_msb))
+		.dst(*diff)
 		.build();
 }
 

--- a/crates/frontend/src/compiler/gate/sar.rs
+++ b/crates/frontend/src/compiler/gate/sar.rs
@@ -33,20 +33,18 @@ pub fn shape() -> OpcodeShape {
 
 pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) {
 	let GateParam {
-		constants,
 		inputs,
 		outputs,
 		imm,
 		..
 	} = data.gate_param();
-	let [all_one] = constants else { unreachable!() };
 	let [x] = inputs else { unreachable!() };
 	let [z] = outputs else { unreachable!() };
 	let [n] = imm else { unreachable!() };
 
-	// Constraint: Arithmetic right shift
-	// (x SAR n) ∧ all-1 = z
-	builder.and().a(sar(*x, *n)).b(*all_one).c(*z).build();
+	// Constraint: Arithmetic right shift (linear)
+	// (x SAR n) = z
+	builder.linear().rhs(sar(*x, *n)).dst(*z).build();
 }
 
 pub fn emit_eval_bytecode(

--- a/crates/frontend/src/compiler/gate/shl.rs
+++ b/crates/frontend/src/compiler/gate/shl.rs
@@ -33,20 +33,18 @@ pub fn shape() -> OpcodeShape {
 
 pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) {
 	let GateParam {
-		constants,
 		inputs,
 		outputs,
 		imm,
 		..
 	} = data.gate_param();
-	let [all_one] = constants else { unreachable!() };
 	let [x] = inputs else { unreachable!() };
 	let [z] = outputs else { unreachable!() };
 	let [n] = imm else { unreachable!() };
 
-	// Constraint: Logical left shift
-	// (x << n) ∧ all-1 = z
-	builder.and().a(sll(*x, *n)).b(*all_one).c(*z).build();
+	// Constraint: Logical left shift (linear)
+	// (x << n) = z
+	builder.linear().rhs(sll(*x, *n)).dst(*z).build();
 }
 
 pub fn emit_eval_bytecode(

--- a/crates/frontend/src/compiler/gate/shr.rs
+++ b/crates/frontend/src/compiler/gate/shr.rs
@@ -33,20 +33,18 @@ pub fn shape() -> OpcodeShape {
 
 pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) {
 	let GateParam {
-		constants,
 		inputs,
 		outputs,
 		imm,
 		..
 	} = data.gate_param();
-	let [all_one] = constants else { unreachable!() };
 	let [x] = inputs else { unreachable!() };
 	let [z] = outputs else { unreachable!() };
 	let [n] = imm else { unreachable!() };
 
-	// Constraint: Logical right shift
-	// (x >> n) ∧ all-1 = z
-	builder.and().a(srl(*x, *n)).b(*all_one).c(*z).build();
+	// Constraint: Logical right shift (linear)
+	// (x >> n) = z
+	builder.linear().rhs(srl(*x, *n)).dst(*z).build();
 }
 
 pub fn emit_eval_bytecode(

--- a/crates/frontend/src/compiler/mod.rs
+++ b/crates/frontend/src/compiler/mod.rs
@@ -109,7 +109,9 @@ impl CircuitBuilder {
 	///
 	/// Must be called only once.
 	pub fn build(&self) -> Circuit {
+		let all_one = self.add_constant(Word::ALL_ONE);
 		let shared = self.shared.borrow_mut().take();
+
 		let Some(shared) = shared else {
 			panic!("CircuitBuilder::build called twice");
 		};
@@ -211,7 +213,7 @@ impl CircuitBuilder {
 		for (gate_id, _) in graph.gates.iter() {
 			gate::constrain(gate_id, &graph, &mut builder);
 		}
-		let (mut and_constraints, mut mul_constraints) = builder.build(&wire_mapping);
+		let (mut and_constraints, mut mul_constraints) = builder.build(&wire_mapping, all_one);
 
 		// Perform fusion if the corresponding feature flag is turned on.
 		if shared.opts.enable_gate_fusion {


### PR DESCRIPTION
Introduce the concept of linear constraints into the constraint builder.

This is something we've discussed already and decided that it's a good idea. Our
constraint system does not support the linear constraints natively instead these
need to be transformed into AND constraints. That being said, there is still
value in having a higher-level representation because this would aid
optimizations like gate fusion.

Another change that is proposed here is modelling rotations. Those are not
supported by our constraint system either and there is also value in deferring
lowering them. Specifically this is useful to hold on for longer because we can
distribute them. In the lowered form (rotr(a, n) = (a >> n) | (a << (64-n)))
we cannot really do much about them.

As you could've guessed those changes are preparations for the new version of
gate fusion. So it also makes some much of fields public.