### PR TITLE
introduct parallel compression traits

### DIFF
--- a/crates/examples/src/lib.rs
+++ b/crates/examples/src/lib.rs
@@ -5,7 +5,9 @@ pub mod snapshot;
 use anyhow::Result;
 use binius_core::constraint_system::{ConstraintSystem, ValueVec};
 use binius_frontend::compiler::{CircuitBuilder, circuit::WitnessFiller};
-use binius_prover::{OptimalPackedB128, Prover};
+use binius_prover::{
+	OptimalPackedB128, Prover, hash::parallel_compression::ParallelCompressionAdaptor,
+};
 use binius_verifier::{
 	Verifier,
 	config::StdChallenger,
@@ -15,12 +17,16 @@ use binius_verifier::{
 pub use cli::Cli;
 
 pub type StdVerifier = Verifier<StdDigest, StdCompression>;
-pub type StdProver = Prover<OptimalPackedB128, StdCompression, StdDigest>;
+pub type StdProver =
+	Prover<OptimalPackedB128, ParallelCompressionAdaptor<StdCompression>, StdDigest>;
 
 pub fn setup(cs: ConstraintSystem, log_inv_rate: usize) -> Result<(StdVerifier, StdProver)> {
 	let _setup_guard = tracing::info_span!("Setup", log_inv_rate).entered();
 	let verifier = Verifier::<StdDigest, _>::setup(cs, log_inv_rate, StdCompression::default())?;
-	let prover = Prover::<OptimalPackedB128, _, StdDigest>::setup(verifier.clone())?;
+	let prover = Prover::<OptimalPackedB128, _, StdDigest>::setup(
+		verifier.clone(),
+		ParallelCompressionAdaptor::new(StdCompression::default()),
+	)?;
 	Ok((verifier, prover))
 }
 

--- a/crates/prover/benches/binary_merkle_tree.rs
+++ b/crates/prover/benches/binary_merkle_tree.rs
@@ -3,7 +3,10 @@
 use std::iter::repeat_with;
 
 use binius_field::Random;
-use binius_prover::merkle_tree::{MerkleTreeProver, prover::BinaryMerkleTreeProver};
+use binius_prover::{
+	hash::parallel_compression::ParallelCompressionAdaptor,
+	merkle_tree::{MerkleTreeProver, prover::BinaryMerkleTreeProver},
+};
 use binius_verifier::{
 	config::B128,
 	hash::{StdCompression, StdDigest},
@@ -21,7 +24,8 @@ where
 	H: binius_prover::hash::ParallelDigest<Digest: BlockSizeUser + FixedOutputReset>,
 	C: binius_verifier::hash::PseudoCompressionFunction<Output<H::Digest>, 2> + Sync,
 {
-	let merkle_prover = BinaryMerkleTreeProver::<_, H, C>::new(compression);
+	let parallel_compression = ParallelCompressionAdaptor::new(compression);
+	let merkle_prover = BinaryMerkleTreeProver::<_, H, _>::new(parallel_compression);
 	let mut rng = rand::rng();
 	let data = repeat_with(|| F::random(&mut rng))
 		.take(1 << (LOG_ELEMS + LOG_ELEMS_IN_LEAF))

--- a/crates/prover/benches/pcs.rs
+++ b/crates/prover/benches/pcs.rs
@@ -7,7 +7,8 @@ use binius_math::{
 	test_utils::{random_field_buffer, random_scalars},
 };
 use binius_prover::{
-	fri, fri::CommitOutput, merkle_tree::prover::BinaryMerkleTreeProver, pcs::OneBitPCSProver,
+	fri, fri::CommitOutput, hash::parallel_compression::ParallelCompressionAdaptor,
+	merkle_tree::prover::BinaryMerkleTreeProver, pcs::OneBitPCSProver,
 };
 use binius_transcript::ProverTranscript;
 use binius_verifier::{
@@ -34,8 +35,8 @@ fn bench_pcs(c: &mut Criterion) {
 		let mut rng = rand::rng();
 		let packed_multilin = random_field_buffer::<P>(&mut rng, log_len);
 
-		let merkle_prover =
-			BinaryMerkleTreeProver::<B128, StdDigest, _>::new(StdCompression::default());
+		let compression = ParallelCompressionAdaptor::new(StdCompression::default());
+		let merkle_prover = BinaryMerkleTreeProver::<B128, StdDigest, _>::new(compression);
 
 		let subspace =
 			BinarySubspace::<B128>::with_dim(log_len).expect("Failed to create subspace");

--- a/crates/prover/src/fri/tests.rs
+++ b/crates/prover/src/fri/tests.rs
@@ -22,7 +22,10 @@ use binius_verifier::{
 use rand::prelude::*;
 
 use super::{CommitOutput, FRIFolder, FoldRoundOutput, commit_interleaved};
-use crate::merkle_tree::{MerkleTreeProver, prover::BinaryMerkleTreeProver};
+use crate::{
+	hash::parallel_compression::ParallelCompressionAdaptor,
+	merkle_tree::{MerkleTreeProver, prover::BinaryMerkleTreeProver},
+};
 
 fn test_commit_prove_verify_success<F, FA, P>(
 	log_dimension: usize,
@@ -36,7 +39,8 @@ fn test_commit_prove_verify_success<F, FA, P>(
 {
 	let mut rng = StdRng::seed_from_u64(0);
 
-	let merkle_prover = BinaryMerkleTreeProver::<_, StdDigest, _>::new(StdCompression::default());
+	let parallel_compression = ParallelCompressionAdaptor::new(StdCompression::default());
+	let merkle_prover = BinaryMerkleTreeProver::<_, StdDigest, _>::new(parallel_compression);
 
 	let committed_rs_code = ReedSolomonCode::<FA>::new(log_dimension, log_inv_rate).unwrap();
 

--- a/crates/prover/src/hash/mod.rs
+++ b/crates/prover/src/hash/mod.rs
@@ -1,3 +1,4 @@
+pub mod parallel_compression;
 pub mod parallel_digest;
 
 pub mod vision_4;

--- a/crates/prover/src/hash/parallel_compression.rs
+++ b/crates/prover/src/hash/parallel_compression.rs
@@ -1,0 +1,154 @@
+// Copyright 2025 Irreducible Inc.
+
+use std::{array, fmt::Debug, mem::MaybeUninit};
+
+use binius_utils::rayon::prelude::*;
+use binius_verifier::hash::PseudoCompressionFunction;
+
+/// A trait for parallel application of N-to-1 compression functions.
+///
+/// This trait enables efficient batch compression operations where multiple N-element
+/// chunks are compressed in parallel. It's particularly useful for constructing hash trees
+/// and Merkle trees where many compression operations need to be performed simultaneously.
+///
+/// The trait is parameterized by:
+/// - `T`: The type of values being compressed (typically hash digests)
+/// - `N`: The arity of the compression function (number of inputs per compression)
+pub trait ParallelPseudoCompression<T, const N: usize> {
+	/// The underlying compression function that performs N-to-1 compression.
+	type Compression: PseudoCompressionFunction<T, N>;
+
+	/// Returns a reference to the underlying compression function.
+	fn compression(&self) -> &Self::Compression;
+
+	/// Compresses multiple N-element chunks in parallel.
+	///
+	/// # Arguments
+	/// * `inputs` - A slice containing the values to compress. Must have length `N * out.len()`.
+	/// * `out` - Output buffer where compressed values will be written.
+	///
+	/// # Behavior
+	/// For each index `i` in `0..out.len()`, this method computes:
+	/// ```text
+	/// out[i] = Compression::compress([inputs[i*N], inputs[i*N+1], ..., inputs[i*N+N-1]])
+	/// ```
+	///
+	/// All compressions are performed in parallel for efficiency.
+	///
+	/// # Post-conditions
+	/// After this method returns, all elements in `out` will be initialized with the
+	/// compressed values from their corresponding N-element chunks in `inputs`.
+	///
+	/// # Panics
+	/// Panics if `inputs.len() != N * out.len()`.
+	fn parallel_compress(&self, inputs: &[T], out: &mut [MaybeUninit<T>]);
+}
+
+/// A simple adapter that wraps any `PseudoCompressionFunction` to implement `ParallelCompression`.
+///
+/// This adapter provides a straightforward way to use existing compression functions
+/// in parallel contexts by applying them sequentially to each N-element chunk.
+#[derive(Debug, Clone)]
+pub struct ParallelCompressionAdaptor<C> {
+	compression: C,
+}
+
+impl<C> ParallelCompressionAdaptor<C> {
+	/// Creates a new adapter wrapping the given compression function.
+	pub fn new(compression: C) -> Self {
+		Self { compression }
+	}
+
+	/// Returns a reference to the underlying compression function.
+	pub fn compression(&self) -> &C {
+		&self.compression
+	}
+}
+
+impl<T, C, const ARITY: usize> ParallelPseudoCompression<T, ARITY> for ParallelCompressionAdaptor<C>
+where
+	T: Clone + Send + Sync,
+	C: PseudoCompressionFunction<T, ARITY> + Sync,
+{
+	type Compression = C;
+
+	fn compression(&self) -> &Self::Compression {
+		&self.compression
+	}
+
+	fn parallel_compress(&self, inputs: &[T], out: &mut [MaybeUninit<T>]) {
+		assert_eq!(inputs.len(), ARITY * out.len(), "Input length must be N * output length");
+
+		inputs
+			.par_chunks_exact(ARITY)
+			.zip(out.par_iter_mut())
+			.for_each(|(chunk, output)| {
+				// Convert slice to array for compression function
+				let chunk_array: [T; ARITY] = array::from_fn(|j| chunk[j].clone());
+				let compressed = self.compression.compress(chunk_array);
+				output.write(compressed);
+			});
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use std::mem::MaybeUninit;
+
+	use rand::{Rng, SeedableRng, rngs::StdRng};
+
+	use super::*;
+
+	// Simple test compression function that XORs all inputs
+	#[derive(Clone, Debug)]
+	struct XorCompression;
+
+	impl PseudoCompressionFunction<u64, 3> for XorCompression {
+		fn compress(&self, input: [u64; 3]) -> u64 {
+			input[0] ^ input[1] ^ input[2]
+		}
+	}
+
+	#[test]
+	fn test_parallel_compression_adaptor() {
+		let mut rng = StdRng::seed_from_u64(0);
+		let compression = XorCompression;
+		let adaptor = ParallelCompressionAdaptor::new(compression.clone());
+
+		// Test with 4 chunks of 3 elements each
+		const N: usize = 3;
+		const NUM_CHUNKS: usize = 4;
+		let inputs: Vec<u64> = (0..N * NUM_CHUNKS).map(|_| rng.random()).collect();
+
+		// Use the adaptor
+		let mut adaptor_output = [MaybeUninit::<u64>::uninit(); NUM_CHUNKS];
+		adaptor.parallel_compress(&inputs, &mut adaptor_output);
+		let adaptor_results: Vec<u64> = adaptor_output
+			.into_iter()
+			.map(|x| unsafe { x.assume_init() })
+			.collect();
+
+		// Manually compress each chunk
+		let mut manual_results = Vec::new();
+		for chunk_idx in 0..NUM_CHUNKS {
+			let start = chunk_idx * N;
+			let chunk = [inputs[start], inputs[start + 1], inputs[start + 2]];
+			manual_results.push(compression.compress(chunk));
+		}
+
+		// Results should be identical
+		assert_eq!(adaptor_results, manual_results);
+	}
+
+	#[test]
+	#[should_panic(expected = "Input length must be N * output length")]
+	fn test_mismatched_input_length() {
+		let compression = XorCompression;
+		let adaptor = ParallelCompressionAdaptor::new(compression);
+
+		let inputs = vec![1u64, 2, 3, 4]; // 4 elements
+		let mut output = [MaybeUninit::<u64>::uninit(); 2]; // Expecting 6 elements (2 * 3)
+
+		adaptor.parallel_compress(&inputs, &mut output);
+	}
+}

--- a/crates/prover/src/merkle_tree/mod.rs
+++ b/crates/prover/src/merkle_tree/mod.rs
@@ -11,7 +11,7 @@ mod tests;
 ///
 /// This is separate from [`MerkleTreeScheme`] so that it may be implemented using a
 /// hardware-accelerated backend.
-pub trait MerkleTreeProver<T>: Sync {
+pub trait MerkleTreeProver<T> {
 	type Scheme: MerkleTreeScheme<T>;
 	/// Data generated during commitment required to generate opening proofs.
 	type Committed;

--- a/crates/prover/src/merkle_tree/tests.rs
+++ b/crates/prover/src/merkle_tree/tests.rs
@@ -11,13 +11,17 @@ use binius_verifier::{
 };
 use rand::prelude::*;
 
-use crate::merkle_tree::{MerkleTreeProver, prover::BinaryMerkleTreeProver};
+use crate::{
+	hash::parallel_compression::ParallelCompressionAdaptor,
+	merkle_tree::{MerkleTreeProver, prover::BinaryMerkleTreeProver},
+};
 
 #[test]
 fn test_binary_merkle_vcs_commit_prove_open_correctly() {
 	let mut rng = StdRng::seed_from_u64(0);
 
-	let mr_prover = BinaryMerkleTreeProver::<_, StdDigest, _>::new(StdCompression::default());
+	let parallel_compression = ParallelCompressionAdaptor::new(StdCompression::default());
+	let mr_prover = BinaryMerkleTreeProver::<_, StdDigest, _>::new(parallel_compression);
 
 	let data = random_scalars::<B128>(&mut rng, 16);
 	let (commitment, tree) = mr_prover.commit(&data, 1).unwrap();
@@ -49,7 +53,8 @@ fn test_binary_merkle_vcs_commit_prove_open_correctly() {
 fn test_binary_merkle_vcs_commit_layer_prove_open_correctly() {
 	let mut rng = StdRng::seed_from_u64(0);
 
-	let mr_prover = BinaryMerkleTreeProver::<_, StdDigest, _>::new(StdCompression::default());
+	let parallel_compression = ParallelCompressionAdaptor::new(StdCompression::default());
+	let mr_prover = BinaryMerkleTreeProver::<_, StdDigest, _>::new(parallel_compression);
 
 	let data = random_scalars::<B128>(&mut rng, 32);
 	let (commitment, tree) = mr_prover.commit(&data, 1).unwrap();
@@ -87,7 +92,8 @@ fn test_binary_merkle_vcs_commit_layer_prove_open_correctly() {
 fn test_binary_merkle_vcs_verify_vector() {
 	let mut rng = StdRng::seed_from_u64(0);
 
-	let mr_prover = BinaryMerkleTreeProver::<_, StdDigest, _>::new(StdCompression::default());
+	let parallel_compression = ParallelCompressionAdaptor::new(StdCompression::default());
+	let mr_prover = BinaryMerkleTreeProver::<_, StdDigest, _>::new(parallel_compression);
 
 	let data = random_scalars::<B128>(&mut rng, 4);
 	let (commitment, _) = mr_prover.commit(&data, 1).unwrap();

--- a/crates/prover/src/pcs.rs
+++ b/crates/prover/src/pcs.rs
@@ -207,6 +207,7 @@ mod test {
 	use super::OneBitPCSProver;
 	use crate::{
 		fri::{self, CommitOutput},
+		hash::parallel_compression::ParallelCompressionAdaptor,
 		merkle_tree::prover::BinaryMerkleTreeProver,
 	};
 
@@ -240,8 +241,9 @@ mod test {
 		const LOG_INV_RATE: usize = 1;
 		const NUM_TEST_QUERIES: usize = 3;
 
-		let merkle_prover =
-			BinaryMerkleTreeProver::<B128, StdDigest, _>::new(StdCompression::default());
+		let merkle_prover = BinaryMerkleTreeProver::<B128, StdDigest, _>::new(
+			ParallelCompressionAdaptor::new(StdCompression::default()),
+		);
 
 		let committed_rs_code = ReedSolomonCode::<B128>::new(packed_mle.log_len(), LOG_INV_RATE)?;
 
@@ -496,8 +498,9 @@ mod test {
 		let scalars = random_scalars::<B128>(&mut rng, n_scalars);
 		let packed_buffer: FieldBuffer<P> = FieldBuffer::from_values(&scalars).unwrap();
 
-		let merkle_prover =
-			BinaryMerkleTreeProver::<B128, StdDigest, _>::new(StdCompression::default());
+		let merkle_prover = BinaryMerkleTreeProver::<B128, StdDigest, _>::new(
+			ParallelCompressionAdaptor::new(StdCompression::default()),
+		);
 		let committed_rs_code = ReedSolomonCode::<B128>::new(log_dimension, LOG_INV_RATE).unwrap();
 
 		let fri_log_batch_size = 0;

--- a/crates/prover/src/protocols/basefold/prover.rs
+++ b/crates/prover/src/protocols/basefold/prover.rs
@@ -207,6 +207,7 @@ mod test {
 	use super::BaseFoldProver;
 	use crate::{
 		fri::{self, CommitOutput},
+		hash::parallel_compression::ParallelCompressionAdaptor,
 		merkle_tree::prover::BinaryMerkleTreeProver,
 	};
 
@@ -226,8 +227,9 @@ mod test {
 
 		let eval_point_eq = eq_ind_partial_eval::<P>(&evaluation_point);
 
-		let merkle_prover =
-			BinaryMerkleTreeProver::<F, StdDigest, _>::new(StdCompression::default());
+		let merkle_prover = BinaryMerkleTreeProver::<F, StdDigest, _>::new(
+			ParallelCompressionAdaptor::new(StdCompression::default()),
+		);
 
 		let rs_code = ReedSolomonCode::<F>::new(multilinear.log_len(), LOG_INV_RATE)?;
 

--- a/crates/prover/tests/prove_verify.rs
+++ b/crates/prover/tests/prove_verify.rs
@@ -10,7 +10,7 @@ use binius_frontend::{
 	compiler,
 	compiler::Wire,
 };
-use binius_prover::Prover;
+use binius_prover::{Prover, hash::parallel_compression::ParallelCompressionAdaptor};
 use binius_transcript::ProverTranscript;
 use binius_verifier::{
 	Verifier,
@@ -24,7 +24,11 @@ fn prove_verify(cs: ConstraintSystem, witness: ValueVec) {
 	let verifier =
 		Verifier::<StdDigest, _>::setup(cs, LOG_INV_RATE, StdCompression::default()).unwrap();
 
-	let prover = Prover::<OptimalPackedB128, _, StdDigest>::setup(verifier.clone()).unwrap();
+	let prover = Prover::<OptimalPackedB128, _, StdDigest>::setup(
+		verifier.clone(),
+		ParallelCompressionAdaptor::new(StdCompression::default()),
+	)
+	.unwrap();
 
 	let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 	prover

--- a/crates/verifier/src/merkle_tree/scheme.rs
+++ b/crates/verifier/src/merkle_tree/scheme.rs
@@ -40,7 +40,7 @@ where
 	F: Field,
 	H: Digest + BlockSizeUser,
 	// TODO: Remove Sync trait here
-	C: PseudoCompressionFunction<Output<H>, 2> + Sync,
+	C: PseudoCompressionFunction<Output<H>, 2>,
 {
 	type Digest = Output<H>;
 
@@ -148,7 +148,7 @@ where
 // Merkle-tree-like folding
 fn fold_digests_vector_inplace<C, D>(compression: &C, digests: &mut [D]) -> Result<(), Error>
 where
-	C: PseudoCompressionFunction<D, 2> + Sync,
+	C: PseudoCompressionFunction<D, 2>,
 	D: Clone + Default + Send + Sync + Debug,
 {
 	if !digests.len().is_power_of_two() {

--- a/crates/verifier/src/verify.rs
+++ b/crates/verifier/src/verify.rs
@@ -54,7 +54,7 @@ pub struct Verifier<MerkleHash, MerkleCompress> {
 impl<MerkleHash, MerkleCompress> Verifier<MerkleHash, MerkleCompress>
 where
 	MerkleHash: Digest + BlockSizeUser,
-	MerkleCompress: PseudoCompressionFunction<Output<MerkleHash>, 2> + Sync,
+	MerkleCompress: PseudoCompressionFunction<Output<MerkleHash>, 2>,
 	Output<MerkleHash>: DeserializeBytes,
 {
 	/// Constructs a verifier for a constraint system.


### PR DESCRIPTION
# Parallel Compression for Merkle Tree Construction

### TL;DR

Introduces a `ParallelCompressionAdaptor` to optimize Merkle tree construction by enabling parallel compression operations.

### What changed?

- Added a new `ParallelPseudoCompression` trait that enables efficient batch compression operations
- Implemented `ParallelCompressionAdaptor` to wrap existing compression functions for parallel execution
- Modified the Merkle tree prover to use parallel compression
- Updated the `Prover` setup to accept a parallel compression adaptor
- Refactored binary Merkle tree construction to leverage parallel compression

The implementation allows multiple N-element chunks to be compressed simultaneously using Rayon's parallel iterators, which is particularly beneficial for Merkle tree construction where many compression operations need to be performed at once.

### How to test?

- Run existing tests which now use the parallel compression adaptor
- The PR includes new unit tests for the `ParallelCompressionAdaptor` class
- Benchmark the binary Merkle tree construction with and without parallel compression

### Why make this change?

This change improves performance by parallelizing compression operations during Merkle tree construction. By leveraging Rayon's parallel iterators, the implementation can utilize multiple CPU cores efficiently when compressing large batches of data, which is a common bottleneck in zero-knowledge proof systems.