### PR TITLE
[frontend] canonicalize shifts

### DIFF
--- a/crates/core/src/constraint_system.rs
+++ b/crates/core/src/constraint_system.rs
@@ -311,6 +311,14 @@ impl ConstraintSystem {
 			operand_name: &'static str,
 		) -> Result<(), ConstraintSystemError> {
 			for term in operand {
+				// check canonicity. SLL is the canonical form of the operand.
+				if term.amount == 0 && term.shift_variant != ShiftVariant::Sll {
+					return Err(ConstraintSystemError::NonCanonicalShift {
+						constraint_type,
+						constraint_index,
+						operand_name,
+					});
+				}
 				if term.amount >= 64 {
 					return Err(ConstraintSystemError::ShiftAmountTooLarge {
 						constraint_type,

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -13,6 +13,14 @@ pub enum ConstraintSystemError {
 	#[error("the data length doesn't match layout")]
 	ValueVecLenMismatch { expected: usize, actual: usize },
 	#[error(
+		"{constraint_type} #{constraint_index} uses non canonical shift in its {operand_name} operand"
+	)]
+	NonCanonicalShift {
+		constraint_type: &'static str,
+		constraint_index: usize,
+		operand_name: &'static str,
+	},
+	#[error(
 		"{constraint_type} #{constraint_index} refers to padding in its {operand_name} operand"
 	)]
 	PaddingValueIndex {

--- a/crates/frontend/src/compiler/constraint_builder.rs
+++ b/crates/frontend/src/compiler/constraint_builder.rs
@@ -189,9 +189,27 @@ impl ShiftedWire {
 		let idx = wire_mapping[self.wire];
 		match self.shift {
 			Shift::None => ShiftedValueIndex::plain(idx),
-			Shift::Sll(n) => ShiftedValueIndex::sll(idx, n as usize),
-			Shift::Srl(n) => ShiftedValueIndex::srl(idx, n as usize),
-			Shift::Sar(n) => ShiftedValueIndex::sar(idx, n as usize),
+			Shift::Sll(n) => {
+				if n == 0 {
+					ShiftedValueIndex::plain(idx)
+				} else {
+					ShiftedValueIndex::sll(idx, n as usize)
+				}
+			}
+			Shift::Srl(n) => {
+				if n == 0 {
+					ShiftedValueIndex::plain(idx)
+				} else {
+					ShiftedValueIndex::srl(idx, n as usize)
+				}
+			}
+			Shift::Sar(n) => {
+				if n == 0 {
+					ShiftedValueIndex::plain(idx)
+				} else {
+					ShiftedValueIndex::sar(idx, n as usize)
+				}
+			}
 			Shift::Rotr(_) => {
 				unreachable!("Rotr should be expanded in expand_and_convert_operand()")
 			}


### PR DESCRIPTION
If no shift is used we should turn it into SLL.