### PR TITLE
Optimize RS buffer copy in fri_commit_interleaved

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ tracing = "0.1.38"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "fmt"] }
 tracing-profile = "0.10.9"
 trait-set = "0.3.0"
+uninit = "0.6.2"
 z3 = "0.13.3"
 
 

--- a/crates/math/Cargo.toml
+++ b/crates/math/Cargo.toml
@@ -17,6 +17,7 @@ rand.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 transpose.workspace = true
+uninit.workspace = true
 
 [dev-dependencies]
 assert_matches.workspace = true


### PR DESCRIPTION
### TL;DR

Add a more efficient implementation of Reed-Solomon encoding that uses uninitialized memory and parallel chunks copy. In the old version we first initialized a vector with zeroes, then copied the first chunk and then copied it to the spare space in the vector and all of that happened in the main thread. In the new version we allocate uninitialized memory and copy all chunks (actually two IRL) in parallel.

### What changed?

- Added the `uninit` crate dependency to both the root and math crates
- Implemented a new `encode_batch` method for `ReedSolomonCode` that writes directly to uninitialized memory
- Implemented a new `encode_ext_batch` method for extension fields that also works with uninitialized memory
- Added comprehensive tests for the new encoding methods
- Updated the FRI commit function to use the new encoding methods
- Added parallel processing with Rayon to improve performance

### How to test?

- Run the existing test suite, which now includes new tests for the added functionality
- The new tests verify that:
    - The new encoding methods produce the same results as the existing methods
    - Dimension validation works correctly
    - Extension field encoding works as expected

### Why make this change?

This change improves performance of Reed-Solomon encoding by:

1. Avoiding unnecessary memory initialization when encoding data
2. Leveraging parallel processing for better performance on multi-core systems
3. Reducing memory copies by writing directly to the output buffer
4. Providing a more ergonomic API for encoding extension fields

The implementation maintains the same correctness guarantees while being more efficient, which is particularly important for the FRI commit process.