### PR TITLE
Optimize pack_witness for multiple threads

### DIFF
--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -275,27 +275,33 @@ fn pack_witness<P: PackedField<Scalar = B128>>(
 		});
 	}
 
-	let mut padded_witness_elems = FieldBuffer::zeros(log_witness_elems);
-	let witness_elems = witness
-		.combined_witness()
-		.par_chunks(2 * P::WIDTH)
-		.map(|chunk| {
-			// Pack B128 elements into packed elements
-			P::from_scalars(
-				// Pack words into B128 elements
-				chunk.chunks(2).map(|word_pair| {
-					let word_0 = word_pair.first().copied().expect("chunk cannot be empty");
-					let word_1 = word_pair.get(1).copied().unwrap_or(Word::ZERO);
-					B128::new(((word_1.0 as u128) << 64) | (word_0.0 as u128))
-				}),
-			)
-		});
-	padded_witness_elems
-		.as_mut()
-		.par_iter_mut()
-		.zip(witness_elems)
-		.for_each(|(dst, elem)| *dst = elem);
+	let len = 1 << log_witness_elems.saturating_sub(P::LOG_WIDTH);
+	let mut padded_witness_elems = Vec::<P>::with_capacity(len);
 
+	let combined_witness = witness.combined_witness();
+	padded_witness_elems
+		.spare_capacity_mut()
+		.into_par_iter()
+		.enumerate()
+		.for_each(|(i, dst)| {
+			// Pack B128 elements into packed elements
+			let offset = i << (P::LOG_WIDTH + 1);
+			let value = P::from_fn(|j| {
+				let word_0 = combined_witness[offset + 2 * j];
+				let word_1 = combined_witness[offset + 2 * j + 1];
+				B128::new(((word_1.0 as u128) << 64) | (word_0.0 as u128))
+			});
+
+			dst.write(value);
+		});
+
+	// SAFETY: We just initialized all elements
+	unsafe {
+		padded_witness_elems.set_len(len);
+	};
+
+	let padded_witness_elems =
+		FieldBuffer::new(log_witness_elems, padded_witness_elems.into_boxed_slice())?;
 	Ok(padded_witness_elems)
 }
 


### PR DESCRIPTION
### TL;DR

Optimize witness packing in the prover by pre-allocating uninitialized memory and using parallel initialization instead of initializing the field buffer with zeroes first.

### What changed?

Refactored the `pack_witness` function to improve performance:

- Replaced the approach of creating a zero-filled buffer and then updating it
- Now pre-allocates a vector with exact capacity needed
- Uses parallel initialization directly into the spare capacity
- Avoids intermediate collections and unnecessary memory operations
- Uses unsafe code in a controlled manner to set the final length after initialization

### How to test?

Run the prover with a large witness and verify:

1. Correctness of the packed witness
2. Performance improvement compared to the previous implementation
3. No memory leaks or unexpected behavior

### Why make this change?

This optimization reduces memory usage and improves performance during witness packing, which is a critical part of the proving process. The previous implementation created unnecessary intermediate collections and performed redundant memory operations. The new approach is more efficient by directly initializing the memory in parallel without extra allocations or copies.