### PR TITLE
Implement `build_p2pkh_circuit` function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ assert_matches = "1.5.0"
 auto_impl = "1.2.0"
 base64 = "0.22.1"
 blake2 = "0.10.6"
+bitcoin = "0.32.7"
 bytemuck = { version = "1.18.0", features = [
     "derive",
     "min_const_generics",

--- a/verifier/circuits/Cargo.toml
+++ b/verifier/circuits/Cargo.toml
@@ -25,6 +25,7 @@ rustc-hash.workspace = true
 
 [dev-dependencies]
 base64 = { workspace = true }
+bitcoin = { workspace = true }
 blake2 = { workspace = true }
 hmac = { workspace = true }
 jwt-simple = { workspace = true }


### PR DESCRIPTION
### TL;DR

Implemented a complete Bitcoin P2PKH address derivation circuit that proves knowledge of a private key corresponding to a P2PKH address. This implementation works with compressed keys only

### What changed?

Added the `build_p2pkh_circuit` function that implements the full Bitcoin P2PKH address derivation flow:
1. Performs scalar multiplication of the private key with the secp256k1 generator point
2. Compresses the resulting public key to 33-byte format
3. Computes SHA256 hash of the compressed public key
4. Converts SHA256 output from big-endian to little-endian format
5. Computes RIPEMD160 hash of the SHA256 digest
6. Verifies the computed address matches the expected address

Added two test cases:
- `test_p2pkh_circuit_known_vector`: Tests with private key = 1 (secp256k1 generator point)
- `test_p2pkh_circuit_vector_2`: Tests with private key = 2 (2*G)

### How to test?

Run the unit tests:
```
cargo test --package binius-frontend --lib circuits::bitcoin::p2pkh_signature
```

The tests verify that the circuit correctly derives P2PKH addresses from private keys and validates them against expected values.

### Why make this change?

This implementation enables zero-knowledge proofs of Bitcoin private key ownership without revealing the key itself. It's a fundamental building block for Bitcoin-related ZK applications, allowing users to prove they control a specific Bitcoin address without exposing their private key.