### PR TITLE
Bitcoin Header Chain Verification Circuit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ digest = "0.10.7"
 generic-array = "0.14.7"
 getrandom = "0.3.3"
 getset = "0.1.6"
+hex = "0.4"
 hex-literal = "1.0.0"
 either = "1.11.0"
 itertools = "0.14.0"
@@ -83,6 +84,7 @@ tracing-profile = "0.10.9"
 trait-set = "0.3.0"
 uninit = "0.6.2"
 z3 = "0.13.3"
+ureq = "3.1"
 
 
 [workspace.lints.clippy]

--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -24,6 +24,8 @@ base64.workspace = true
 blake2.workspace = true
 jwt-simple.workspace = true
 sha2.workspace = true
+ureq.workspace = true
+hex.workspace = true
 
 [dev-dependencies]
 criterion.workspace = true

--- a/crates/examples/examples/bitcoin_header_chain.rs
+++ b/crates/examples/examples/bitcoin_header_chain.rs
@@ -1,0 +1,17 @@
+// Copyright 2025 Irreducible Inc.
+
+use anyhow::Result;
+use binius_examples::{Cli, circuits::bitcoin_header_chain::BitcoinHeaderChainExample};
+
+fn main() -> Result<()> {
+	// disable `ureq` logging
+	// unfortunately this also changes the binius logging/tracing slightly
+	unsafe {
+		std::env::set_var("RUST_LOG", "binius=trace,ureq=off");
+	}
+	let _tracing_guard = tracing_profile::init_tracing()?;
+
+	Cli::<BitcoinHeaderChainExample>::new("bitcoin_headers")
+		.about("Bitcoin Header Chain Example")
+		.run()
+}

--- a/crates/examples/src/circuits/bitcoin_header_chain.rs
+++ b/crates/examples/src/circuits/bitcoin_header_chain.rs
@@ -1,0 +1,126 @@
+// Copyright 2025 Irreducible Inc.
+
+use anyhow::bail;
+use binius_frontend::{
+	circuits::bitcoin::header_chain::HeaderChain,
+	compiler::{CircuitBuilder, Wire, circuit::WitnessFiller},
+	util::pack_bytes_into_wires_le,
+};
+use clap::Args;
+
+use crate::ExampleCircuit;
+
+/// Check some basic things about a Bitcoin header chain.
+///
+/// **IMPORTANT**: This does **NOT** prove full validity of the header chain.
+/// In particular it's not checked _at all_ that the target difficulty is calculated correctly.
+/// One could easily satisfy this circuit by quickly self-mining many blocks with low difficulty.
+pub struct BitcoinHeaderChainExample {
+	latest_digest: [Wire; 4],
+	headers: Vec<[Wire; 10]>,
+	header_chain_gadget: HeaderChain,
+}
+
+#[derive(Args)]
+pub struct Params {
+	/// Number of block headers to prove.
+	#[arg(long, default_value_t = 10)]
+	pub num_blocks: usize,
+}
+
+#[derive(Args)]
+pub struct Instance {
+	/// Height of the newest block in the proved header chain.
+	/// Defaults to the currently latest block in the network.
+	#[arg(long)]
+	pub to_block: Option<usize>,
+}
+
+impl ExampleCircuit for BitcoinHeaderChainExample {
+	type Params = Params;
+	type Instance = Instance;
+
+	fn build(params: Self::Params, builder: &mut CircuitBuilder) -> anyhow::Result<Self> {
+		if params.num_blocks == 0 {
+			bail!("need to prove at least one block")
+		}
+
+		let latest_digest: [Wire; 4] = std::array::from_fn(|_| builder.add_witness());
+		let headers: Vec<[Wire; 10]> =
+			std::iter::repeat_with(|| std::array::from_fn(|_| builder.add_witness()))
+				.take(params.num_blocks)
+				.collect();
+		let header_chain_gadget = HeaderChain::construct_circuit(builder, &headers, latest_digest);
+
+		Ok(Self {
+			latest_digest,
+			headers,
+			header_chain_gadget,
+		})
+	}
+
+	fn populate_witness(
+		&self,
+		instance: Self::Instance,
+		filler: &mut WitnessFiller,
+	) -> anyhow::Result<()> {
+		let (headers_value, latest_digest_value) =
+			pull_headers(self.headers.len(), instance.to_block)?;
+		for (header, header_value) in self.headers.iter().zip(&headers_value) {
+			pack_bytes_into_wires_le(filler, header, header_value);
+		}
+		pack_bytes_into_wires_le(filler, &self.latest_digest, &latest_digest_value);
+		let headers_value_ref: Vec<&[u8]> = headers_value.iter().map(AsRef::as_ref).collect();
+		self.header_chain_gadget
+			.populate_inner(filler, &headers_value_ref);
+
+		Ok(())
+	}
+}
+
+fn pull_headers(
+	num_blocks: usize,
+	to_block: Option<usize>,
+) -> anyhow::Result<(Vec<Vec<u8>>, Vec<u8>)> {
+	let last_height: usize = match to_block {
+		Some(to_block) => to_block,
+		None => ureq::get("https://mempool.space/api/blocks/tip/height")
+			.call()?
+			.body_mut()
+			.read_to_string()?
+			.trim()
+			.parse()?,
+	};
+
+	let latest_digest = ureq::get(format!("https://mempool.space/api/block-height/{last_height}"))
+		.call()?
+		.body_mut()
+		.read_to_string()?;
+	let mut latest_digest = hex::decode(latest_digest)?;
+	latest_digest.reverse();
+
+	let first_height = (last_height + 1).checked_sub(num_blocks).unwrap();
+	println!(
+		"Fetching {num_blocks} block headers. First height is {first_height} and last height is {last_height} .."
+	);
+	let mut headers = Vec::new();
+	for height in (first_height..=last_height).rev() {
+		let hash = ureq::get(format!("https://mempool.space/api/block-height/{height}"))
+			.call()?
+			.body_mut()
+			.read_to_string()?;
+		println!("Fetching header with height {height} and hash {hash} ..");
+		let header = ureq::get(format!("https://mempool.space/api/block/{hash}/header"))
+			.call()?
+			.body_mut()
+			.read_to_string()?;
+		let mut hash = hex::decode(hash)?;
+		hash.reverse();
+		let header = hex::decode(header)?;
+		headers.push(header);
+	}
+
+	println!("Done.");
+
+	Ok((headers, latest_digest))
+}

--- a/crates/examples/src/circuits/mod.rs
+++ b/crates/examples/src/circuits/mod.rs
@@ -1,4 +1,5 @@
 // Copyright 2025 Irreducible Inc.
+pub mod bitcoin_header_chain;
 pub mod blake2s;
 pub mod ethsign;
 pub mod hashsign;

--- a/crates/frontend/src/circuits/bitcoin/header_chain.rs
+++ b/crates/frontend/src/circuits/bitcoin/header_chain.rs
@@ -1,0 +1,241 @@
+// Copyright 2025 Irreducible Inc.
+
+//! Verifying a Bitcoin header chain.
+
+use binius_core::Word;
+
+use crate::{
+	circuits::{
+		bignum::{self, BigUint},
+		bitcoin::double_sha256::DoubleSha256,
+	},
+	compiler::{CircuitBuilder, Wire, circuit::WitnessFiller},
+};
+
+/// Stores some intermediate wires of the circuit, so that they can later be populated with
+/// [`Self::populate_inner`].
+pub struct HeaderChain {
+	header_digests: Vec<DoubleSha256>,
+}
+
+impl HeaderChain {
+	/// Constructs a circuit that asserts the following things:
+	///
+	/// - `latest_digest == hash(headers[0])` (head)
+	/// - `previous_block_hash(headers[i]) = hash(headers[i+1])` (hash chain)
+	/// - `hash(headers[i]) < target(headers[i])` (proof of work)
+	///
+	/// **IMPORTANT**: This does currently NOT assert that `target(headers[i])` is in any way
+	/// related to `target(headers[i+1])`, like it must be in the Bitcoin protocol. In particular,
+	/// this means that one can easily satisfy this circuit with a self-mined sequence of blocks
+	/// which have low difficulty.
+	///
+	/// **Note**: It also doesn't check many other things about the block header, like that the
+	/// constraints on the timestamps.
+	pub fn construct_circuit(
+		builder: &CircuitBuilder,
+		// latest block comes first
+		headers: &[[Wire; 10]],
+		latest_digest: [Wire; 4],
+	) -> Self {
+		let mut header_digests = Vec::new();
+
+		// latest header
+		{
+			// hash equals `latest_digest`
+			header_digests.push(DoubleSha256::construct_circuit(
+				builder,
+				headers[0].to_vec(),
+				latest_digest,
+			));
+
+			// hash is smaller than target (proof of work)
+			let target = target(builder, headers[0][9]);
+			let digest_as_uint = BigUint {
+				limbs: latest_digest.to_vec(),
+			};
+			let fulfills_target = bignum::biguint_lt(builder, &digest_as_uint, &target);
+			builder.assert_true("PoW fulfills target", fulfills_target);
+		}
+
+		// header chain
+		for i in 1..headers.len() {
+			// hash equals the "previous block hash" in the newer block
+			let digest = previous_block_hash(builder, &headers[i - 1]);
+			header_digests.push(DoubleSha256::construct_circuit(
+				builder,
+				headers[i].to_vec(),
+				digest,
+			));
+
+			// hash is smaller than target (proof of work)
+			// NOTE: One could save constraints by noting that the target only changes every 2016
+			// blocks.
+			let target = target(builder, headers[i][9]);
+			let digest_as_uint = BigUint {
+				limbs: digest.to_vec(),
+			};
+			let fulfills_target = bignum::biguint_lt(builder, &digest_as_uint, &target);
+			builder.assert_true("PoW fulfills target", fulfills_target);
+
+			// bits of newer block is correctly computed from bits of older block
+			// FIXME TODO
+		}
+
+		Self { header_digests }
+	}
+
+	pub fn populate_inner(&self, filler: &mut WitnessFiller, headers: &[&[u8]]) {
+		for (header_digest, header) in self.header_digests.iter().zip(headers) {
+			header_digest.populate_inner(filler, header);
+		}
+	}
+}
+
+/// Extracts the previous block hash from a block header.
+fn previous_block_hash(builder: &CircuitBuilder, header: &[Wire; 10]) -> [Wire; 4] {
+	[
+		join(builder, header[1], header[0]),
+		join(builder, header[2], header[1]),
+		join(builder, header[3], header[2]),
+		join(builder, header[4], header[3]),
+	]
+}
+
+fn join(builder: &CircuitBuilder, b0: Wire, b1: Wire) -> Wire {
+	let c0 = builder.shl(b0, 32);
+	let c1 = builder.shr(b1, 32);
+	builder.bxor(c0, c1)
+}
+
+/// Computes the 32-byte target from the 4-byte compact bits field.
+fn target(builder: &CircuitBuilder, bits: Wire) -> BigUint {
+	let mantissa = builder.band(builder.add_constant_64(0x0000000000ffffff), bits);
+	let exponent = builder.band(builder.add_constant_64(0x00000000000000ff), builder.shr(bits, 24));
+
+	// compute how many bytes we need to shift the mantissa to the left
+	// NOTE: Check underflow? And check that exponent is not too big?
+	let (shift_val, _) = builder.isub_bin_bout(
+		exponent,
+		builder.add_constant_64(3),
+		builder.add_constant(Word::ZERO),
+	);
+
+	// optionally shift by 1 byte
+	let cond_1 = builder.shl(shift_val, 63);
+	let v0_1 = builder.select(cond_1, builder.shl(mantissa, 8), mantissa);
+
+	// optionally shift by 2 bytes
+	let cond_2 = builder.shl(shift_val, 62);
+	let v0_2 = builder.select(cond_2, builder.shl(v0_1, 2 * 8), v0_1);
+
+	// optionally shift by 4 bytes
+	let cond_4 = builder.shl(shift_val, 61);
+	let v0_4 = builder.select(cond_4, builder.shl(v0_2, 4 * 8), v0_2);
+	let v1_4 = builder.select(cond_4, builder.shr(v0_2, 4 * 8), builder.add_constant(Word::ZERO));
+
+	// optionally shift by 8 bytes
+	let cond_8 = builder.shl(shift_val, 60);
+	let v0_8 = builder.select(cond_8, builder.add_constant(Word::ZERO), v0_4);
+	let v1_8 = builder.select(cond_8, v0_4, v1_4);
+	let v2_8 = builder.select(cond_8, v1_4, builder.add_constant(Word::ZERO));
+
+	// optionally shift by 16 bytes
+	let cond_16 = builder.shl(shift_val, 59);
+	let v0_16 = builder.select(cond_16, builder.add_constant(Word::ZERO), v0_8);
+	let v1_16 = builder.select(cond_16, builder.add_constant(Word::ZERO), v1_8);
+	let v2_16 = builder.select(cond_16, v0_8, v2_8);
+	let v3_16 = builder.select(cond_16, v1_8, builder.add_constant(Word::ZERO));
+
+	BigUint {
+		limbs: vec![v0_16, v1_16, v2_16, v3_16],
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use binius_core::verify::verify_constraints;
+	use hex_literal::hex;
+
+	use super::*;
+	use crate::{circuits::bignum, util::pack_bytes_into_wires_le};
+
+	/// Tests that the `target` circuit is correct.
+	fn test_target_fixed_exponent(exponent: usize) {
+		// build circuit
+		let builder = CircuitBuilder::new();
+		let bits = builder.add_witness();
+		let asserted_target = BigUint::new_witness(&builder, 4);
+		let target = target(&builder, bits);
+		bignum::assert_eq(&builder, "target matches asserted target", &target, &asserted_target);
+		let circuit = builder.build();
+
+		// populate witness
+		let mut filler = circuit.new_witness_filler();
+		let bits_value: u64 = 0x4444444400aabbcc | ((exponent as u64) << 24);
+		filler[bits] = Word(bits_value);
+		let shift_val = exponent - 3;
+		let asserted_target_value = num_bigint::BigUint::from_bytes_be(&hex!(
+			"0000000000000000000000000000000000000000000000000000000000aabbcc"
+		)) << (shift_val * 8);
+		let mut asserted_target_digits = asserted_target_value.to_u64_digits();
+		asserted_target_digits.truncate(4);
+		while asserted_target_digits.len() < 4 {
+			asserted_target_digits.push(0);
+		}
+		asserted_target.populate_limbs(&mut filler, &asserted_target_digits);
+		circuit.populate_wire_witness(&mut filler).unwrap();
+
+		// check
+		let constraint_system = circuit.constraint_system();
+		verify_constraints(constraint_system, &filler.into_value_vec()).unwrap();
+	}
+
+	#[test]
+	fn test_target() {
+		// `exponent - 3` runs in 0..32
+		for exponent in 3..35 {
+			test_target_fixed_exponent(exponent);
+		}
+	}
+
+	#[test]
+	fn test_valid() {
+		// build circuit
+		let builder = CircuitBuilder::new();
+		let headers: Vec<[Wire; 10]> =
+			std::iter::repeat_with(|| std::array::from_fn(|_| builder.add_witness()))
+				.take(3)
+				.collect();
+		let latest_digest: [Wire; 4] = std::array::from_fn(|_| builder.add_witness());
+		let header_chain = HeaderChain::construct_circuit(&builder, &headers, latest_digest);
+		let circuit = builder.build();
+
+		// populate witness
+		let mut filler = circuit.new_witness_filler();
+		let headers_value = vec![
+			hex!(
+				"000000264a14e21adad047d981c06a26446e345eda3d8beb807401000000000000000000fc01df2139954b36cebc3fa6fbf6a7160a67d34b67e5c4aa2a7ce46f5bb42a83642ea468b32c0217d14ba4d1"
+			),
+			hex!(
+				"00606a3190af271dec0197c6b87f218070c5611cf0c506f6671c0200000000000000000021f21732014796558e6736b15de9b132ca65318b42fe5759b153c63dd4306e38842da468b32c021737421730"
+			),
+			hex!(
+				"00800020e77cf8eb3114116cc2e6d4aca9b27d35bb5402a5054a010000000000000000005b41d83c40c8226c48807401b0b08aa8e4e2eb053bf91d580f62cd49f5c2a99f802ba468b32c0217cea24c34"
+			),
+		];
+		let latest_digest_value =
+			hex!("228561b085b7524957e515605725901238299ff2793300000000000000000000");
+		for (header, header_value) in headers.iter().zip(&headers_value) {
+			pack_bytes_into_wires_le(&mut filler, header, header_value);
+		}
+		pack_bytes_into_wires_le(&mut filler, &latest_digest, &latest_digest_value);
+		let headers_value_ref: Vec<&[u8]> = headers_value.iter().map(AsRef::as_ref).collect();
+		header_chain.populate_inner(&mut filler, &headers_value_ref);
+		circuit.populate_wire_witness(&mut filler).unwrap();
+
+		// check
+		let constraint_system = circuit.constraint_system();
+		verify_constraints(constraint_system, &filler.into_value_vec()).unwrap();
+	}
+}

--- a/crates/frontend/src/circuits/bitcoin/mod.rs
+++ b/crates/frontend/src/circuits/bitcoin/mod.rs
@@ -3,4 +3,5 @@
 
 pub mod block_contains_transaction;
 pub mod double_sha256;
+pub mod header_chain;
 pub mod merkle_path;


### PR DESCRIPTION
Introduces a circuit and example to check the following things on a Bitcoin header chain:
- `previous_block_hash(headers[i]) = hash(headers[i+1])` (hash chain)
- `hash(headers[i]) < target(headers[i])` (proof of work)

**Important:** So far, this does NOT check that `target(headers[i])` is in any way related to `target(headers[i+1])`, like it must be in the Bitcoin protocol. In particular, this means that one can easily satisfy this circuit with a self-mined sequence of blocks which have low difficulty. (I.e. this could circuit could be seen as **unsound**.)

The reason is that this check on the difficulty is highly non-trivial:
- In the worst case one needs 4032 blocks just to check the difficulty _locally_.
- One needs the _block number_ to compute the difficulty. Originally a Bitcoin block doesn't even contain the block number. Instead, one needs the whole blockchain to count the blocks from the start. Nowadays the block number is contained in the coinbase transaction, so one could extract it with an additional parsing of the coinbase transaction and using the Bitcoin merkle path circuit, but I didn't have time for that now.