### PR TITLE
Blake2s with fixed message length and 64-bit input wires

### DIFF
--- a/crates/examples/examples/blake2s.rs
+++ b/crates/examples/examples/blake2s.rs
@@ -53,9 +53,7 @@ impl ExampleCircuit for Blake2sExample {
 		} else {
 			// Generate random bytes
 			let mut rng = StdRng::seed_from_u64(0);
-			let len = instance
-				.message_len
-				.unwrap_or(self.blake2s_gadget.max_bytes / 2);
+			let len = instance.message_len.unwrap_or(self.blake2s_gadget.length);
 
 			let mut message_bytes = vec![0u8; len];
 			rng.fill_bytes(&mut message_bytes);
@@ -64,10 +62,10 @@ impl ExampleCircuit for Blake2sExample {
 
 		// Validate message length
 		ensure!(
-			message_bytes.len() <= self.blake2s_gadget.max_bytes,
-			"Message length ({}) exceeds maximum ({})",
+			message_bytes.len() == self.blake2s_gadget.length,
+			"Message length ({}) does not equal ({})",
 			message_bytes.len(),
-			self.blake2s_gadget.max_bytes
+			self.blake2s_gadget.length
 		);
 
 		// Compute the expected Blake2s digest using the reference implementation

--- a/crates/examples/snapshots/blake2s.snap
+++ b/crates/examples/snapshots/blake2s.snap
@@ -1,11 +1,11 @@
 blake2s circuit
 --
-Number of gates: 2937
-Number of evaluation instructions: 3068
-Number of AND constraints: 3897
+Number of gates: 2318
+Number of evaluation instructions: 2318
+Number of AND constraints: 3278
 Number of MUL constraints: 0
-Length of value vec: 8192
-  Constants: 140
+Length of value vec: 4096
+  Constants: 14
   Inout: 0
-  Witness: 137
-  Internal: 3761
+  Witness: 24
+  Internal: 3270


### PR DESCRIPTION
Boosting up Blake2s:
 * packing message witness into 64-bit words (little endian)
 * supporting only fixed-length messages, which saves a lot of multiplexers