### PR TITLE
Add bitcion address validation example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ auto_impl = "1.2.0"
 base64 = "0.22.1"
 blake2 = "0.10.6"
 bitcoin = "0.32.7"
+bitcoin_hashes = "0.14.0"
 bytemuck = { version = "1.18.0", features = [
     "derive",
     "min_const_generics",

--- a/prover/examples/Cargo.toml
+++ b/prover/examples/Cargo.toml
@@ -9,24 +9,26 @@ workspace = true
 
 [dependencies]
 anyhow.workspace = true
+base64.workspace = true
 binius-circuits = { path = "../../verifier/circuits" }
 binius-core = { path = "../../verifier/core" }
 binius-frontend = { path = "../../verifier/frontend" }
-binius-verifier = { path = "../../verifier/verifier", default-features = false }
 binius-prover = { path = "../prover", default-features = false }
 binius-utils = { path = "../../verifier/utils", features = ["platform-diagnostics"] }
-clap.workspace = true
-tracing.workspace = true
-tracing-profile.workspace = true
+binius-verifier = { path = "../../verifier/verifier", default-features = false }
+bitcoin_hashes.workspace = true
+bitcoin.workspace = true
 blake2.workspace = true
+clap.workspace = true
 ethsign = "0.9.0"
-tiny-keccak = "2.0.2"
-rand.workspace = true
-base64.workspace = true
-jwt-simple.workspace = true
-sha2.workspace = true
-ureq.workspace = true
 hex.workspace = true
+jwt-simple.workspace = true
+rand.workspace = true
+sha2.workspace = true
+tiny-keccak = "2.0.2"
+tracing-profile.workspace = true
+tracing.workspace = true
+ureq.workspace = true
 
 [dev-dependencies]
 criterion.workspace = true

--- a/prover/examples/examples/bitcoin_p2pkh.rs
+++ b/prover/examples/examples/bitcoin_p2pkh.rs
@@ -1,0 +1,12 @@
+// Copyright 2025 Irreducible Inc.
+
+use anyhow::Result;
+use binius_examples::{Cli, circuits::bitcoin_p2pkh::BitcoinP2PKHExample};
+
+fn main() -> Result<()> {
+	let _tracing_guard = tracing_profile::init_tracing()?;
+
+	Cli::<BitcoinP2PKHExample>::new("bitcoin_p2pkh")
+		.about("Bitcoin P2PKH address validation example - proves knowledge of private key without revealing it")
+		.run()
+}

--- a/prover/examples/src/circuits/bitcoin_p2pkh.rs
+++ b/prover/examples/src/circuits/bitcoin_p2pkh.rs
@@ -1,0 +1,202 @@
+// Copyright 2025 Irreducible Inc.
+
+use std::array;
+
+use anyhow::Result;
+use binius_circuits::{
+	bignum::BigUint,
+	bitcoin::p2pkh_signature::{addr_bytes_to_le_words, build_p2pkh_circuit},
+};
+use binius_frontend::compiler::{CircuitBuilder, Wire, circuit::WitnessFiller};
+use bitcoin::{Network, PrivateKey, secp256k1::Secp256k1};
+use bitcoin_hashes::Hash;
+use clap::Args;
+use rand::{RngCore, SeedableRng, rngs::StdRng};
+
+use crate::ExampleCircuit;
+
+/// Example circuit that proves knowledge of a Bitcoin private key corresponding to a P2PKH address.
+///
+/// This demonstrates a post-quantum secure Bitcoin signature scheme that maintains backwards
+/// compatibility with existing Bitcoin addresses. The circuit proves knowledge of a private key
+/// without revealing it, using the complete Bitcoin P2PKH address derivation:
+///
+/// Private Key → scalar_mul → Public Key → compress → Compressed PubKey
+/// → SHA256 → Digest → swap_bytes → LE Format → RIPEMD160 → Address
+pub struct BitcoinP2PKHExample {
+	private_key: BigUint,
+	expected_address: [Wire; 5],
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct Params {
+	// No circuit parameters needed for this example
+	// The circuit is fixed-size for secp256k1 private keys
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct Instance {
+	/// Private key as hex string (32 bytes = 64 hex chars, without 0x prefix).
+	/// If not provided, a random private key will be generated.
+	#[arg(long, value_parser = parse_hex_private_key)]
+	pub private_key: Option<[u8; 32]>,
+
+	/// Expected Bitcoin P2PKH address hash as hex string (20 bytes = 40 hex chars, without 0x
+	/// prefix). If not provided, the address will be computed from the private key.
+	#[arg(long, value_parser = parse_hex_address)]
+	pub expected_address: Option<[u8; 20]>,
+
+	/// Seed for deterministic random generation (for reproducible results)
+	#[arg(long, default_value_t = 42)]
+	pub seed: u64,
+}
+
+impl ExampleCircuit for BitcoinP2PKHExample {
+	type Params = Params;
+	type Instance = Instance;
+
+	fn build(_params: Params, builder: &mut CircuitBuilder) -> Result<Self> {
+		// Create witness for private key (4 limbs = 256 bits)
+		let private_key = BigUint::new_witness(builder, 4);
+
+		// Create witness wires for expected address (5 × 32-bit words = 160 bits = 20 bytes)
+		let expected_address: [Wire; 5] = array::from_fn(|_| builder.add_witness());
+
+		// Build the complete P2PKH circuit that proves knowledge of the private key
+		build_p2pkh_circuit(builder, &private_key, expected_address);
+
+		Ok(Self {
+			private_key,
+			expected_address,
+		})
+	}
+
+	fn populate_witness(&self, instance: Instance, w: &mut WitnessFiller) -> Result<()> {
+		// Generate or use provided private key
+		let private_key_bytes = match instance.private_key {
+			Some(key) => {
+				tracing::info!("Using provided private key");
+				key
+			}
+			None => {
+				let mut rng = StdRng::seed_from_u64(instance.seed);
+				let mut key = [0u8; 32];
+
+				// Generate a valid secp256k1 private key (1 <= key < group_order)
+				loop {
+					rng.fill_bytes(&mut key);
+
+					// Ensure key is not zero and is less than secp256k1 group order
+					// Group order:
+					// 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
+					if !is_zero(&key) && is_valid_secp256k1_key(&key) {
+						break;
+					}
+				}
+
+				tracing::info!(
+					"Generated private key (seed={}): {}",
+					instance.seed,
+					hex::encode(key)
+				);
+				key
+			}
+		};
+
+		// Get expected Bitcoin address (hash160). If not provided, compute from the private key
+		let expected_address_bytes = match instance.expected_address {
+			Some(addr) => {
+				tracing::info!("Using provided expected address: {}", hex::encode(addr));
+				addr
+			}
+			None => {
+				// Use bitcoin crate to compute the P2PKH address hash from private key
+				let secp = Secp256k1::new();
+				let private_key = PrivateKey::from_slice(&private_key_bytes, Network::Bitcoin)
+					.map_err(|e| anyhow::anyhow!("Invalid private key: {}", e))?;
+				let public_key = private_key.public_key(&secp);
+				let addr = public_key.pubkey_hash().to_byte_array();
+				tracing::info!("Computed expected address from private key: {}", hex::encode(addr));
+				addr
+			}
+		};
+
+		// Convert private key bytes to little-endian 64-bit limbs
+		let private_key_limbs = bytes_to_le_limbs(&private_key_bytes);
+
+		// Convert address bytes to little-endian 32-bit words
+		let address_words = addr_bytes_to_le_words(&expected_address_bytes);
+
+		// Populate witness values
+		self.private_key.populate_limbs(w, &private_key_limbs);
+
+		for i in 0..5 {
+			w[self.expected_address[i]] =
+				binius_core::word::Word::from_u64(address_words[i] as u64);
+		}
+
+		tracing::info!("Successfully populated witness for Bitcoin P2PKH proof");
+		Ok(())
+	}
+}
+
+/// Parse hex string to 32-byte private key
+fn parse_hex_private_key(s: &str) -> Result<[u8; 32], String> {
+	let bytes = hex::decode(s).map_err(|e| format!("Invalid hex: {}", e))?;
+	if bytes.len() != 32 {
+		return Err(format!("Private key must be exactly 32 bytes, got {}", bytes.len()));
+	}
+	let mut key = [0u8; 32];
+	key.copy_from_slice(&bytes);
+
+	if is_zero(&key) || !is_valid_secp256k1_key(&key) {
+		return Err("Invalid secp256k1 private key".to_string());
+	}
+
+	Ok(key)
+}
+
+/// Parse hex string to 20-byte address
+fn parse_hex_address(s: &str) -> Result<[u8; 20], String> {
+	let bytes = hex::decode(s).map_err(|e| format!("Invalid hex: {}", e))?;
+	if bytes.len() != 20 {
+		return Err(format!("Address must be exactly 20 bytes, got {}", bytes.len()));
+	}
+	let mut addr = [0u8; 20];
+	addr.copy_from_slice(&bytes);
+	Ok(addr)
+}
+
+/// Check if byte array is all zeros
+fn is_zero(bytes: &[u8; 32]) -> bool {
+	bytes.iter().all(|&b| b == 0)
+}
+
+/// Simplified check for valid secp256k1 private key
+/// Real implementation would check against exact group order, but this is sufficient for examples
+fn is_valid_secp256k1_key(bytes: &[u8; 32]) -> bool {
+	// secp256k1 group order starts with 0xFFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFE
+	// So any key starting with 0xFFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF is definitely too large
+	// Return false if the first 12 bytes are all 0xFF
+	for i in 0..12 {
+		if bytes[i] != 0xFF {
+			return true;
+		}
+	}
+	false
+}
+
+/// Convert a 32-byte big-endian private key into 4 little-endian 64-bit limbs
+fn bytes_to_le_limbs(bytes_be: &[u8; 32]) -> [u64; 4] {
+	// Reverse to little-endian byte order first, then chunk into u64 limbs
+	let mut le = [0u8; 32];
+	for i in 0..32 {
+		le[i] = bytes_be[31 - i];
+	}
+	[
+		u64::from_le_bytes(le[0..8].try_into().unwrap()),
+		u64::from_le_bytes(le[8..16].try_into().unwrap()),
+		u64::from_le_bytes(le[16..24].try_into().unwrap()),
+		u64::from_le_bytes(le[24..32].try_into().unwrap()),
+	]
+}

--- a/prover/examples/src/circuits/mod.rs
+++ b/prover/examples/src/circuits/mod.rs
@@ -1,6 +1,7 @@
 // Copyright 2025 Irreducible Inc.
 pub mod bitcoin_block_contains_transaction;
 pub mod bitcoin_header_chain;
+pub mod bitcoin_p2pkh;
 pub mod blake2b;
 pub mod blake2s;
 pub mod ethsign;

--- a/verifier/circuits/Cargo.toml
+++ b/verifier/circuits/Cargo.toml
@@ -26,6 +26,7 @@ rustc-hash.workspace = true
 [dev-dependencies]
 base64 = { workspace = true }
 bitcoin = { workspace = true }
+bitcoin_hashes = { workspace = true }
 blake2 = { workspace = true }
 hmac = { workspace = true }
 jwt-simple = { workspace = true }

--- a/verifier/frontend/Cargo.toml
+++ b/verifier/frontend/Cargo.toml
@@ -21,15 +21,14 @@ sha2.workspace = true
 sha3.workspace = true
 smallvec.workspace = true
 rustc-hash.workspace = true
+ripemd = { workspace = true }
 
 [dev-dependencies]
 base64 = { workspace = true }
 blake2 = { workspace = true }
 hmac = { workspace = true }
 jwt-simple = { workspace = true }
-k256 = { workspace = true, features = ["arithmetic"] }
 rand = { workspace = true, features = ["std_rng", "thread_rng"] }
-ripemd = { workspace = true }
 rsa = { workspace = true, features = ["sha2"] }
 hex-literal = { workspace = true }
 num-traits = { workspace = true }


### PR DESCRIPTION
# Add Bitcoin P2PKH Address Validation Example

### TL;DR

Adds a new example that proves knowledge of a Bitcoin private key corresponding to a P2PKH address without revealing the private key.

### What changed?

- Added a new `bitcoin_p2pkh.rs` example that demonstrates a post-quantum secure Bitcoin signature scheme
- Implemented `BitcoinP2PKHExample` circuit that proves knowledge of a private key without revealing it
- Added helper functions for Bitcoin address derivation (private key → public key → compressed pubkey → hash160)
- Moved some Bitcoin-related utility functions from test code to public API for reuse
- Added a new executable example entry point in `examples/bitcoin_p2pkh.rs`
- Updated dependencies in Cargo.toml files

### How to test?

Run the new example with:

```bash
cargo run --example bitcoin_p2pkh
```

You can provide your own private key and/or expected address:

```bash
cargo run --example bitcoin_p2pkh -- --private-key <32_BYTES_HEX> --expected-address <20_BYTES_HEX>
```

Or use the default random key generation with a specific seed:

```bash
cargo run --example bitcoin_p2pkh -- --seed 12345
```

### Why make this change?

This example demonstrates how zero-knowledge proofs can be used to create post-quantum secure Bitcoin signatures that maintain backward compatibility with existing Bitcoin addresses. It showcases the complete Bitcoin P2PKH address derivation flow in a circuit, including secp256k1 operations, SHA256, and RIPEMD160 hashing.