### PR TITLE
add backend support for linear constraints

### DIFF
--- a/crates/core/src/constraint_system.rs
+++ b/crates/core/src/constraint_system.rs
@@ -251,12 +251,38 @@ impl DeserializeBytes for MulConstraint {
 	}
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct ZeroConstraint(pub Operand);
+
+impl ZeroConstraint {
+	pub fn plain(operand: impl IntoIterator<Item = ValueIndex>) -> ZeroConstraint {
+		ZeroConstraint(operand.into_iter().map(ShiftedValueIndex::plain).collect())
+	}
+}
+
+impl SerializeBytes for ZeroConstraint {
+	fn serialize(&self, mut write_buf: impl BufMut) -> Result<(), SerializationError> {
+		self.0.serialize(&mut write_buf)
+	}
+}
+
+impl DeserializeBytes for ZeroConstraint {
+	fn deserialize(mut read_buf: impl Buf) -> Result<Self, SerializationError>
+	where
+		Self: Sized,
+	{
+		let operand = Vec::<ShiftedValueIndex>::deserialize(&mut read_buf)?;
+		Ok(ZeroConstraint(operand))
+	}
+}
+
 #[derive(Debug, Clone)]
 pub struct ConstraintSystem {
 	pub value_vec_layout: ValueVecLayout,
 	pub constants: Vec<Word>,
 	pub and_constraints: Vec<AndConstraint>,
 	pub mul_constraints: Vec<MulConstraint>,
+	pub zero_constraints: Vec<ZeroConstraint>,
 }
 
 impl ConstraintSystem {
@@ -270,6 +296,7 @@ impl ConstraintSystem {
 		value_vec_layout: ValueVecLayout,
 		and_constraints: Vec<AndConstraint>,
 		mul_constraints: Vec<MulConstraint>,
+		zero_constraints: Vec<ZeroConstraint>,
 	) -> Self {
 		assert_eq!(constants.len(), value_vec_layout.n_const);
 		ConstraintSystem {
@@ -277,6 +304,7 @@ impl ConstraintSystem {
 			value_vec_layout,
 			and_constraints,
 			mul_constraints,
+			zero_constraints,
 		}
 	}
 
@@ -364,11 +392,15 @@ impl ConstraintSystem {
 			cmp::max(consts::MIN_AND_CONSTRAINTS, self.and_constraints.len()).next_power_of_two();
 		let mul_target_size =
 			cmp::max(consts::MIN_MUL_CONSTRAINTS, self.mul_constraints.len()).next_power_of_two();
+		let zeros_target_size =
+			cmp::max(consts::MIN_ZERO_CONSTRAINTS, self.zero_constraints.len()).next_power_of_two();
 
 		self.and_constraints
 			.resize_with(and_target_size, AndConstraint::default);
 		self.mul_constraints
 			.resize_with(mul_target_size, MulConstraint::default);
+		self.zero_constraints
+			.resize_with(zeros_target_size, ZeroConstraint::default);
 
 		Ok(())
 	}
@@ -381,12 +413,20 @@ impl ConstraintSystem {
 		self.mul_constraints.push(mul_constraint);
 	}
 
+	pub fn add_zero_constraint(&mut self, zero_constraint: ZeroConstraint) {
+		self.zero_constraints.push(zero_constraint);
+	}
+
 	pub fn n_and_constraints(&self) -> usize {
 		self.and_constraints.len()
 	}
 
 	pub fn n_mul_constraints(&self) -> usize {
 		self.mul_constraints.len()
+	}
+
+	pub fn n_zero_constraints(&self) -> usize {
+		self.zero_constraints.len()
 	}
 
 	/// The total length of the [`ValueVec`] expected by this constraint system.
@@ -426,7 +466,8 @@ impl DeserializeBytes for ConstraintSystem {
 		let value_vec_layout = ValueVecLayout::deserialize(&mut read_buf)?;
 		let constants = Vec::<Word>::deserialize(&mut read_buf)?;
 		let and_constraints = Vec::<AndConstraint>::deserialize(&mut read_buf)?;
-		let mul_constraints = Vec::<MulConstraint>::deserialize(read_buf)?;
+		let mul_constraints = Vec::<MulConstraint>::deserialize(&mut read_buf)?;
+		let zero_constraints = Vec::<ZeroConstraint>::deserialize(read_buf)?;
 
 		if constants.len() != value_vec_layout.n_const {
 			return Err(SerializationError::InvalidConstruction {
@@ -439,6 +480,7 @@ impl DeserializeBytes for ConstraintSystem {
 			constants,
 			and_constraints,
 			mul_constraints,
+			zero_constraints,
 		})
 	}
 }
@@ -933,7 +975,15 @@ mod serialization_tests {
 			lo: vec![ShiftedValueIndex::plain(ValueIndex(3))],
 		}];
 
-		ConstraintSystem::new(constants, value_vec_layout, and_constraints, mul_constraints)
+		let zero_constraints = vec![];
+
+		ConstraintSystem::new(
+			constants,
+			value_vec_layout,
+			and_constraints,
+			mul_constraints,
+			zero_constraints,
+		)
 	}
 
 	#[test]
@@ -1744,6 +1794,7 @@ mod serialization_tests {
 			},
 			vec![],
 			vec![],
+			vec![],
 		);
 
 		// Add constraint that references padding (index 2 is padding between const and inout)
@@ -1779,6 +1830,7 @@ mod serialization_tests {
 				offset_witness: 4,
 				total_len: 16,
 			},
+			vec![],
 			vec![],
 			vec![],
 		);
@@ -1942,6 +1994,7 @@ mod serialization_tests {
 			},
 			vec![],
 			vec![],
+			vec![],
 		);
 
 		// Add AND constraint that references an out-of-range index
@@ -1984,6 +2037,7 @@ mod serialization_tests {
 				offset_witness: 4,
 				total_len: 16,
 			},
+			vec![],
 			vec![],
 			vec![],
 		);
@@ -2032,6 +2086,7 @@ mod serialization_tests {
 				offset_witness: 8,
 				total_len: 16,
 			},
+			vec![],
 			vec![],
 			vec![],
 		);

--- a/crates/core/src/consts.rs
+++ b/crates/core/src/consts.rs
@@ -28,6 +28,10 @@ pub const MIN_AND_CONSTRAINTS: usize = 8;
 /// This is a protocol requirement for the constraint system.
 pub const MIN_MUL_CONSTRAINTS: usize = 1;
 
+/// Minimum number of zero constraints (must be a power of 2).
+/// This is a protocol requirement for the constraint system.
+pub const MIN_ZERO_CONSTRAINTS: usize = 1;
+
 /// The number of bits in a byte.
 pub const BYTE_BITS: usize = 8;
 

--- a/crates/examples/snapshots/blake2s.snap
+++ b/crates/examples/snapshots/blake2s.snap
@@ -2,8 +2,9 @@ blake2s circuit
 --
 Number of gates: 2937
 Number of evaluation instructions: 3068
-Number of AND constraints: 3897
+Number of AND constraints: 2841
 Number of MUL constraints: 0
+Number of ZERO constraints: 1056
 Length of value vec: 8192
   Constants: 140
   Inout: 0

--- a/crates/examples/snapshots/ethsign.snap
+++ b/crates/examples/snapshots/ethsign.snap
@@ -2,8 +2,9 @@ ethsign circuit
 --
 Number of gates: 264472
 Number of evaluation instructions: 310572
-Number of AND constraints: 359966
+Number of AND constraints: 211251
 Number of MUL constraints: 25458
+Number of ZERO constraints: 148715
 Length of value vec: 524288
   Constants: 82
   Inout: 29

--- a/crates/examples/snapshots/hash_based_sig.snap
+++ b/crates/examples/snapshots/hash_based_sig.snap
@@ -2,8 +2,9 @@ hash_based_sig circuit
 --
 Number of gates: 3986883
 Number of evaluation instructions: 4076982
-Number of AND constraints: 4022460
+Number of AND constraints: 1636239
 Number of MUL constraints: 0
+Number of ZERO constraints: 2386221
 Length of value vec: 4194304
   Constants: 376
   Inout: 20

--- a/crates/examples/snapshots/keccak.snap
+++ b/crates/examples/snapshots/keccak.snap
@@ -2,8 +2,9 @@ keccak circuit
 --
 Number of gates: 27625
 Number of evaluation instructions: 27625
-Number of AND constraints: 27625
+Number of AND constraints: 6000
 Number of MUL constraints: 0
+Number of ZERO constraints: 21625
 Length of value vec: 32768
   Constants: 23
   Inout: 50

--- a/crates/examples/snapshots/sha256.snap
+++ b/crates/examples/snapshots/sha256.snap
@@ -2,8 +2,9 @@ sha256 circuit
 --
 Number of gates: 74954
 Number of evaluation instructions: 76589
-Number of AND constraints: 94755
+Number of AND constraints: 67780
 Number of MUL constraints: 0
+Number of ZERO constraints: 26975
 Length of value vec: 131072
   Constants: 353
   Inout: 260

--- a/crates/examples/snapshots/sha512.snap
+++ b/crates/examples/snapshots/sha512.snap
@@ -2,8 +2,9 @@ sha512 circuit
 --
 Number of gates: 48779
 Number of evaluation instructions: 49886
-Number of AND constraints: 61700
+Number of AND constraints: 16891
 Number of MUL constraints: 0
+Number of ZERO constraints: 44809
 Length of value vec: 131072
   Constants: 377
   Inout: 264

--- a/crates/examples/snapshots/zklogin.snap
+++ b/crates/examples/snapshots/zklogin.snap
@@ -2,8 +2,9 @@ zklogin circuit
 --
 Number of gates: 462908
 Number of evaluation instructions: 550412
-Number of AND constraints: 604407
+Number of AND constraints: 446336
 Number of MUL constraints: 26880
+Number of ZERO constraints: 158071
 Length of value vec: 1048576
   Constants: 710
   Inout: 302

--- a/crates/frontend/ceck/src/ast.rs
+++ b/crates/frontend/ceck/src/ast.rs
@@ -53,6 +53,9 @@ pub enum Constraint {
 		hi: OperandExpr,
 		lo: OperandExpr,
 	},
+	Zero {
+		zero: OperandExpr,
+	},
 }
 
 #[derive(Debug, Clone)]

--- a/crates/frontend/ceck/src/grammar.pest
+++ b/crates/frontend/ceck/src/grammar.pest
@@ -27,7 +27,8 @@ operand  = { xor_expr | term }
 // Constraints
 and_constraint = { "(" ~ "and" ~ operand ~ operand ~ operand ~ ")" }
 mul_constraint = { "(" ~ "mul" ~ operand ~ operand ~ operand ~ operand ~ ")" }
-constraint     = { and_constraint | mul_constraint }
+zero_constraint = { "(" ~ "zero" ~ operand ~ ")" }
+constraint     = { and_constraint | mul_constraint | zero_constraint }
 
 // Top level constraint set
 constraint_set = { "(" ~ "constraint_set" ~ constraint* ~ ")" }

--- a/crates/frontend/ceck/src/parser.rs
+++ b/crates/frontend/ceck/src/parser.rs
@@ -100,6 +100,7 @@ fn parse_constraint(pair: pest::iterators::Pair<Rule>) -> Result<Constraint> {
 	match inner.as_rule() {
 		Rule::and_constraint => parse_and_constraint(inner),
 		Rule::mul_constraint => parse_mul_constraint(inner),
+		Rule::zero_constraint => parse_zero_constraint(inner),
 		_ => Err(anyhow!("Unexpected constraint type: {:?}", inner.as_rule())),
 	}
 }
@@ -151,6 +152,18 @@ fn parse_mul_constraint(pair: pest::iterators::Pair<Rule>) -> Result<Constraint>
 	)?;
 
 	Ok(Constraint::Mul { a, b, hi, lo })
+}
+
+fn parse_zero_constraint(pair: pest::iterators::Pair<Rule>) -> Result<Constraint> {
+	let mut operands = pair.into_inner();
+
+	let zero = parse_operand(
+		operands
+			.next()
+			.ok_or_else(|| anyhow!("Missing operand in ZERO constraint"))?,
+	)?;
+
+	Ok(Constraint::Zero { zero })
 }
 
 fn parse_operand(pair: pest::iterators::Pair<Rule>) -> Result<OperandExpr> {

--- a/crates/frontend/ceck/src/randblast.rs
+++ b/crates/frontend/ceck/src/randblast.rs
@@ -111,7 +111,9 @@ impl RandBlast {
 
 #[cfg(test)]
 mod tests {
-	use binius_core::constraint_system::{AndConstraint, ValueIndex, ValueVecLayout};
+	use binius_core::constraint_system::{
+		AndConstraint, ValueIndex, ValueVecLayout, ZeroConstraint,
+	};
 
 	use super::*;
 
@@ -129,24 +131,24 @@ mod tests {
 			offset_witness: 4, // next power of 2 after constants
 			total_len: 8,      // next power of 2 after all values
 		};
-		// Both implement: v0 & v1 ^ v2 = 0
-		let constraint = AndConstraint::plain_abc(
-			vec![ValueIndex(2)], // v0
-			vec![ValueIndex(3)], // v1
-			vec![ValueIndex(4)], // v2
+		// Both implement: v0 & v1 = v2
+		let constraint = ZeroConstraint::plain(
+			[ValueIndex(2), ValueIndex(3), ValueIndex(4)], // v0, v1, v2
 		);
 
 		let lhs = ConstraintSystem::new(
 			vec![Word(0), Word(u64::MAX)],
 			value_vec_layout.clone(),
-			vec![constraint.clone()],
 			vec![],
+			vec![],
+			vec![constraint.clone()],
 		);
 		let rhs = ConstraintSystem::new(
 			vec![Word(0), Word(u64::MAX)],
 			value_vec_layout,
-			vec![constraint],
 			vec![],
+			vec![],
+			vec![constraint],
 		);
 
 		let mut blaster = RandBlast::new(0);
@@ -190,11 +192,13 @@ mod tests {
 			value_vec_layout.clone(),
 			vec![lhs_constraint],
 			vec![],
+			vec![],
 		);
 		let rhs = ConstraintSystem::new(
 			vec![Word(0), Word(u64::MAX)],
 			value_vec_layout,
 			vec![rhs_constraint],
+			vec![],
 			vec![],
 		);
 

--- a/crates/frontend/ceck/src/translate.rs
+++ b/crates/frontend/ceck/src/translate.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use binius_core::{
 	constraint_system::{
 		AndConstraint, ConstraintSystem, MulConstraint, Operand, ShiftedValueIndex, ValueIndex,
-		ValueVecLayout,
+		ValueVecLayout, ZeroConstraint,
 	},
 	word::Word,
 };
@@ -48,6 +48,9 @@ impl Context {
 					self.preprocess_operand(b);
 					self.preprocess_operand(hi);
 					self.preprocess_operand(lo);
+				}
+				Constraint::Zero { zero } => {
+					self.preprocess_operand(zero);
 				}
 			}
 		}
@@ -118,6 +121,7 @@ impl Context {
 	pub fn build(&self, cs: &ConstraintSet) -> ConstraintSystem {
 		let mut and_constraints = Vec::new();
 		let mut mul_constraints = Vec::new();
+		let mut zero_constraints = Vec::new();
 
 		for constraint in &cs.constraints {
 			match constraint {
@@ -138,6 +142,10 @@ impl Context {
 					};
 					mul_constraints.push(mul_constraint);
 				}
+				Constraint::Zero { zero } => {
+					let zero_constraint = ZeroConstraint(self.convert_operand(zero));
+					zero_constraints.push(zero_constraint);
+				}
 			}
 		}
 
@@ -148,6 +156,7 @@ impl Context {
 			self.value_vec_layout.clone().unwrap(),
 			and_constraints,
 			mul_constraints,
+			zero_constraints,
 		)
 	}
 

--- a/crates/frontend/src/compiler/gate/assert_eq.rs
+++ b/crates/frontend/src/compiler/gate/assert_eq.rs
@@ -1,20 +1,19 @@
 //! Equality assertion.
 //!
-//! Enforces `x = y` using an AND constraint.
+//! Enforces `x = y` using a ZERO constraint.
 //!
 //! # Algorithm
 //!
 //! Uses the property that `x = y` iff `x ^ y = 0`.
-//! This is enforced as `(x ⊕ y) ∧ all-1 = 0`.
+//! This is enforced as `x ⊕ y = 0`.
 //!
 //! # Constraints
 //!
-//! The gate generates 1 AND constraint:
-//! - `(x ⊕ y) ∧ all-1 = 0`
-use binius_core::word::Word;
+//! The gate generates 1 ZERO constraint:
+//! - `x ⊕ y = 0`
 
 use crate::compiler::{
-	constraint_builder::{ConstraintBuilder, empty, xor2},
+	constraint_builder::{ConstraintBuilder, xor2},
 	gate::opcode::OpcodeShape,
 	gate_graph::{Gate, GateData, GateParam, Wire},
 	pathspec::PathSpec,
@@ -22,7 +21,7 @@ use crate::compiler::{
 
 pub fn shape() -> OpcodeShape {
 	OpcodeShape {
-		const_in: &[Word::ALL_ONE],
+		const_in: &[],
 		n_in: 2,
 		n_out: 0,
 		n_aux: 0,
@@ -32,14 +31,11 @@ pub fn shape() -> OpcodeShape {
 }
 
 pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) {
-	let GateParam {
-		constants, inputs, ..
-	} = data.gate_param();
-	let [all_one] = constants else { unreachable!() };
+	let GateParam { inputs, .. } = data.gate_param();
 	let [x, y] = inputs else { unreachable!() };
 
-	// Constraint: (x ⊕ y) ∧ all-1 = 0
-	builder.and().a(xor2(*x, *y)).b(*all_one).c(empty()).build();
+	// Constraint: x ⊕ y = 0
+	builder.zero().xor(xor2(*x, *y)).build();
 }
 
 pub fn emit_eval_bytecode(

--- a/crates/frontend/src/compiler/gate/assert_eq_cond.rs
+++ b/crates/frontend/src/compiler/gate/assert_eq_cond.rs
@@ -10,11 +10,11 @@
 //!
 //! # Constraints
 //!
-//! The gate generates 1 AND constraint:
+//! The gate generates 1 ZERO constraint:
 //! - `(x ⊕ y) ∧ (cond ~>> 63) = 0`
 
 use crate::compiler::{
-	constraint_builder::{ConstraintBuilder, empty, sar, xor2},
+	constraint_builder::{ConstraintBuilder, sar, xor2},
 	gate::opcode::OpcodeShape,
 	gate_graph::{Gate, GateData, GateParam, Wire},
 	pathspec::PathSpec,
@@ -37,7 +37,7 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 
 	// Constraint: (x ⊕ y) ∧ (cond ~>> 63) = 0
 	let mask = sar(*cond, 63);
-	builder.and().a(xor2(*x, *y)).b(mask).c(empty()).build();
+	builder.zero().xor(xor2(*x, *y)).xor(mask).build();
 }
 
 pub fn emit_eval_bytecode(

--- a/crates/frontend/src/compiler/gate/assert_zero.rs
+++ b/crates/frontend/src/compiler/gate/assert_zero.rs
@@ -4,17 +4,15 @@
 //!
 //! # Algorithm
 //!
-//! Uses the constraint `x ∧ all-1 = 0`, which forces `x = 0`.
+//! Uses the constraint `x = 0`.
 //!
 //! # Constraints
 //!
-//! The gate generates 1 AND constraint:
-//! - `x ∧ all-1 = 0`
-
-use binius_core::word::Word;
+//! The gate generates 1 ZERO constraint:
+//! - `x = 0`
 
 use crate::compiler::{
-	constraint_builder::{ConstraintBuilder, empty},
+	constraint_builder::ConstraintBuilder,
 	gate::opcode::OpcodeShape,
 	gate_graph::{Gate, GateData, GateParam, Wire},
 	pathspec::PathSpec,
@@ -22,7 +20,7 @@ use crate::compiler::{
 
 pub fn shape() -> OpcodeShape {
 	OpcodeShape {
-		const_in: &[Word::ALL_ONE],
+		const_in: &[],
 		n_in: 1,
 		n_out: 0,
 		n_aux: 0,
@@ -32,14 +30,11 @@ pub fn shape() -> OpcodeShape {
 }
 
 pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) {
-	let GateParam {
-		constants, inputs, ..
-	} = data.gate_param();
-	let [all_one] = constants else { unreachable!() };
+	let GateParam { inputs, .. } = data.gate_param();
 	let [x] = inputs else { unreachable!() };
 
-	// Constraint: x ∧ all-1 = 0
-	builder.and().a(*x).b(*all_one).c(empty()).build();
+	// Constraint: x = 0
+	builder.zero().xor(*x).build();
 }
 
 pub fn emit_eval_bytecode(

--- a/crates/frontend/src/compiler/gate/bxor.rs
+++ b/crates/frontend/src/compiler/gate/bxor.rs
@@ -4,11 +4,11 @@
 //!
 //! # Algorithm
 //!
-//! Computes the bitwise XOR using a linear constraint.
+//! Computes the bitwise XOR using a ZERO constraint.
 //!
 //! # Constraints
 //!
-//! The gate generates 1 linear constraint:
+//! The gate generates 1 ZERO constraint:
 //! - `x ⊕ y = z`
 
 use binius_core::word::Word;
@@ -40,7 +40,7 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 	// Constraint: Bitwise XOR (linear)
 	//
 	// (x ⊕ y) = z
-	builder.linear().rhs(xor2(*x, *y)).dst(*z).build();
+	builder.zero().xor(xor2(*x, *y)).xor(*z).build();
 }
 
 pub fn emit_eval_bytecode(

--- a/crates/frontend/src/compiler/gate/bxor_multi.rs
+++ b/crates/frontend/src/compiler/gate/bxor_multi.rs
@@ -4,7 +4,7 @@
 //!
 //! # Constraints
 //!
-//! The gate generates 1 linear constraint:
+//! The gate generates 1 ZERO constraint:
 //! - `x0 ⊕ x1 ⊕ ... ⊕ xn = z`
 
 use binius_core::word::Word;
@@ -35,11 +35,10 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 	} = data.gate_param();
 	let [z] = outputs else { unreachable!() };
 
-	// Constraint: N-way Bitwise XOR (linear)
-	//
+	// Constraint: N-way Bitwise XOR
 	// (x0 ⊕ x1 ⊕ ... ⊕ xn) = z
 	let terms: Vec<WireExprTerm> = inputs.iter().map(|&w| w.into()).collect();
-	builder.linear().rhs(xor_multi(terms)).dst(*z).build();
+	builder.zero().xor(xor_multi(terms)).xor(*z).build();
 }
 
 pub fn emit_eval_bytecode(

--- a/crates/frontend/src/compiler/gate/iadd_cin_cout.rs
+++ b/crates/frontend/src/compiler/gate/iadd_cin_cout.rs
@@ -65,13 +65,13 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 		.c(xor3(*cout, cout_sll_1, cin_msb))
 		.build();
 
-	// Constraint 2: Sum equality (linear)
+	// Constraint 2: Sum equality
 	//
 	// (a ⊕ b ⊕ (cout << 1) ⊕ cin_msb) = sum
 	builder
-		.linear()
-		.rhs(xor4(*a, *b, cout_sll_1, cin_msb))
-		.dst(*sum)
+		.zero()
+		.xor(xor4(*a, *b, cout_sll_1, cin_msb))
+		.xor(*sum)
 		.build();
 }
 

--- a/crates/frontend/src/compiler/gate/isub_bin_bout.rs
+++ b/crates/frontend/src/compiler/gate/isub_bin_bout.rs
@@ -47,9 +47,9 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 	//
 	// (a ⊕ b ⊕ (bout << 1) ⊕ bin_msb) = diff
 	builder
-		.linear()
-		.rhs(xor4(*a, *b, bout_sll_1, bin_msb))
-		.dst(*diff)
+		.zero()
+		.xor(xor4(*a, *b, bout_sll_1, bin_msb))
+		.xor(*diff)
 		.build();
 }
 

--- a/crates/frontend/src/compiler/gate/rotr.rs
+++ b/crates/frontend/src/compiler/gate/rotr.rs
@@ -48,9 +48,9 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 	let [z] = outputs else { unreachable!() };
 	let [n] = imm else { unreachable!() };
 
-	// Constraint: Rotate right (linear)
+	// Constraint: Rotate right
 	// rotr(x, n) = z
-	builder.linear().rhs(rotr(*x, *n)).dst(*z).build();
+	builder.zero().xor(rotr(*x, *n)).xor(*z).build();
 }
 
 pub fn emit_eval_bytecode(

--- a/crates/frontend/src/compiler/gate/sar.rs
+++ b/crates/frontend/src/compiler/gate/sar.rs
@@ -42,9 +42,9 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 	let [z] = outputs else { unreachable!() };
 	let [n] = imm else { unreachable!() };
 
-	// Constraint: Arithmetic right shift (linear)
+	// Constraint: Arithmetic right shift
 	// (x SAR n) = z
-	builder.linear().rhs(sar(*x, *n)).dst(*z).build();
+	builder.zero().xor(sar(*x, *n)).xor(*z).build();
 }
 
 pub fn emit_eval_bytecode(

--- a/crates/frontend/src/compiler/gate/shl.rs
+++ b/crates/frontend/src/compiler/gate/shl.rs
@@ -42,9 +42,9 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 	let [z] = outputs else { unreachable!() };
 	let [n] = imm else { unreachable!() };
 
-	// Constraint: Logical left shift (linear)
+	// Constraint: Logical left shift
 	// (x << n) = z
-	builder.linear().rhs(sll(*x, *n)).dst(*z).build();
+	builder.zero().xor(sll(*x, *n)).xor(*z).build();
 }
 
 pub fn emit_eval_bytecode(

--- a/crates/frontend/src/compiler/gate/shr.rs
+++ b/crates/frontend/src/compiler/gate/shr.rs
@@ -42,9 +42,9 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 	let [z] = outputs else { unreachable!() };
 	let [n] = imm else { unreachable!() };
 
-	// Constraint: Logical right shift (linear)
+	// Constraint: Logical right shift
 	// (x >> n) = z
-	builder.linear().rhs(srl(*x, *n)).dst(*z).build();
+	builder.zero().xor(srl(*x, *n)).xor(*z).build();
 }
 
 pub fn emit_eval_bytecode(

--- a/crates/frontend/src/stat.rs
+++ b/crates/frontend/src/stat.rs
@@ -8,6 +8,7 @@ pub struct CircuitStat {
 	pub n_eval_insn: usize,
 	pub n_and_constraints: usize,
 	pub n_mul_constraints: usize,
+	pub n_zero_constraints: usize,
 	pub value_vec_len: usize,
 	pub n_const: usize,
 	pub n_inout: usize,
@@ -23,6 +24,7 @@ impl CircuitStat {
 			n_eval_insn: circuit.n_eval_insn(),
 			n_and_constraints: cs.n_and_constraints(),
 			n_mul_constraints: cs.n_mul_constraints(),
+			n_zero_constraints: cs.n_zero_constraints(),
 			value_vec_len: cs.value_vec_layout.total_len,
 			n_const: cs.value_vec_layout.n_const,
 			n_inout: cs.value_vec_layout.n_inout,
@@ -38,6 +40,7 @@ impl fmt::Display for CircuitStat {
 		writeln!(f, "Number of evaluation instructions: {}", self.n_eval_insn)?;
 		writeln!(f, "Number of AND constraints: {}", self.n_and_constraints)?;
 		writeln!(f, "Number of MUL constraints: {}", self.n_mul_constraints)?;
+		writeln!(f, "Number of ZERO constraints: {}", self.n_zero_constraints)?;
 		writeln!(f, "Length of value vec: {}", self.value_vec_len)?;
 		writeln!(f, "  Constants: {}", self.n_const)?;
 		writeln!(f, "  Inout: {}", self.n_inout)?;

--- a/crates/prover/src/protocols/shift/mod.rs
+++ b/crates/prover/src/protocols/shift/mod.rs
@@ -1,6 +1,8 @@
 // Copyright 2025 Irreducible Inc.
 
-use binius_verifier::protocols::shift::{BITAND_ARITY, INTMUL_ARITY, SHIFT_VARIANT_COUNT};
+use binius_verifier::protocols::shift::{
+	BITAND_ARITY, INTMUL_ARITY, SHIFT_VARIANT_COUNT, ZERO_ARITY,
+};
 
 mod error;
 mod key_collection;

--- a/crates/prover/src/protocols/shift/phase_2.rs
+++ b/crates/prover/src/protocols/shift/phase_2.rs
@@ -52,6 +52,7 @@ use crate::{
 /// # Returns
 /// Returns `SumcheckOutput` containing the combined challenges `[r_j, r_y]` and witness evaluation,
 /// or an error if the protocol fails.
+#[allow(clippy::too_many_arguments)]
 #[instrument(skip_all, name = "prove_phase_2")]
 pub fn prove_phase_2<F, P: PackedField<Scalar = F>, C: Challenger>(
 	inout_n_vars: usize,
@@ -59,6 +60,7 @@ pub fn prove_phase_2<F, P: PackedField<Scalar = F>, C: Challenger>(
 	words: &[Word],
 	bitand_data: &PreparedOperatorData<F>,
 	intmul_data: &PreparedOperatorData<F>,
+	zeros_data: &PreparedOperatorData<F>,
 	phase_1_output: SumcheckOutput<F>,
 	transcript: &mut ProverTranscript<C>,
 ) -> Result<SumcheckOutput<F>, Error>
@@ -78,8 +80,14 @@ where
 	let r_j_tensor = eq_ind_partial_eval::<F>(&r_j);
 	let r_j_witness = fold_words::<_, P>(words, r_j_tensor.as_ref());
 
-	let monster_multilinear =
-		build_monster_multilinear(key_collection, bitand_data, intmul_data, &r_j, &r_s)?;
+	let monster_multilinear = build_monster_multilinear(
+		key_collection,
+		bitand_data,
+		intmul_data,
+		zeros_data,
+		&r_j,
+		&r_s,
+	)?;
 
 	run_sumcheck(inout_n_vars, r_j_witness, monster_multilinear, r_j, gamma, transcript)
 }

--- a/crates/prover/src/protocols/shift/prove.rs
+++ b/crates/prover/src/protocols/shift/prove.rs
@@ -107,6 +107,7 @@ pub fn prove<F, P: PackedField<Scalar = F>, C: Challenger>(
 	words: &[Word],
 	bitand_data: OperatorData<F>,
 	intmul_data: OperatorData<F>,
+	zeros_data: OperatorData<F>,
 	transcript: &mut ProverTranscript<C>,
 ) -> Result<SumcheckOutput<F>, Error>
 where
@@ -115,11 +116,13 @@ where
 	// Sample lambdas, one for each operator.
 	let bitand_lambda = transcript.sample();
 	let intmul_lambda = transcript.sample();
+	let zeros_lambda = transcript.sample();
 
 	// Create prepared operator data with sampled lambdas
 	let expand_scope = tracing::debug_span!("Expand tensor queries").entered();
 	let prepared_bitand_data = PreparedOperatorData::new(bitand_data, bitand_lambda);
 	let prepared_intmul_data = PreparedOperatorData::new(intmul_data, intmul_lambda);
+	let prepared_zeros_data = PreparedOperatorData::new(zeros_data, zeros_lambda);
 	drop(expand_scope);
 
 	// Prove the first phase, receiving a `SumcheckOutput`
@@ -130,6 +133,7 @@ where
 		words,
 		&prepared_bitand_data,
 		&prepared_intmul_data,
+		&prepared_zeros_data,
 		transcript,
 	)?;
 
@@ -143,6 +147,7 @@ where
 		words,
 		&prepared_bitand_data,
 		&prepared_intmul_data,
+		&prepared_zeros_data,
 		phase_1_output,
 		transcript,
 	)?;

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -219,6 +219,17 @@ where
 		};
 		drop(intmul_guard);
 
+		// [phase] Zero Reduction - zero constraint reduction
+		let zeros_claim = {
+			let r_zhat_prime = transcript.sample();
+			let r_x_prime = transcript.sample_vec(checked_log_2(cs.n_zero_constraints()));
+			OperatorData {
+				evals: vec![B128::zero()],
+				r_zhat_prime,
+				r_x_prime,
+			}
+		};
+
 		// [phase] Shift Reduction - shift operations
 		let shift_guard = tracing::info_span!(
 			"[phase] Shift Reduction",
@@ -235,6 +246,7 @@ where
 			witness.combined_witness(),
 			bitand_claim,
 			intmul_claim,
+			zeros_claim,
 			transcript,
 		)?;
 		drop(shift_guard);

--- a/crates/verifier/src/protocols/shift/mod.rs
+++ b/crates/verifier/src/protocols/shift/mod.rs
@@ -3,6 +3,7 @@
 pub const SHIFT_VARIANT_COUNT: usize = 3;
 pub const BITAND_ARITY: usize = 3;
 pub const INTMUL_ARITY: usize = 4;
+pub const ZERO_ARITY: usize = 1;
 
 mod monster;
 


### PR DESCRIPTION
### TL;DR

_WIP: restack this on top of Pep’s Fusion PR. Since this optimization achieves lower AND constraint count than the Fusion PR for every example, hopefully some improvement will be left once stacked._

Adds explicit support for linear constraints, meaning checks for `Operand=0`​. Until now we’ve been checking linear constraints using non-linear constraints (AND-checks). Many AND constraints are now replaced with ZERO constraints.

While the “backend” cost of ZERO constraints is zero, it still takes it’s toll on the shift reduction. The shift reduction has a cost for each operand of each backend accelerator, for example 3 operands for BITAND and 4 for INTMUL. There is only 1 operand for ZERO, but we can’t keep adding operands without cache trouble, due to the way shift reduction was built (handling all operands of all backends at once).

I should probably stack this PR on top of @pepyakin‘s Fusion PR, but I’ll wait for initial feedback on this.

**AND Constraint Difference:**

- _EthSign:_ 359966 -> 211251, **1\.7x**
- _ZKLogin_: 604407 -> 446336, **1\.35x**
- _Hash Based Sig:_ 4022460 -> 1636239, **2\.46x**
- _Blake2s:_ 3897 -> 2841, **1\.37x**
- _Keccak:_ 27625 -> 6000, **4\.60x**
- _Sha512:_ 61700 -> 16891, **3\.65x**
- _Sha256:_ 94755 -> 67780, **1\.40x**

**Benchmarks Difference:**

- _Keccak:_
    - Witness gen: 44.284 ms -> 68.647 ms (!)
    - Prove: 2.6907 s -> 1.3990 s
    - Verify: 267.64 ms -> 382.29 ms (!)
- _EthSign:_
    - Witness gen: 27.235 ms -> 11.505 ms
    - Prove: 556.81 ms -> 424.99 ms
    - Verify: 32.844 ms ->
- _Blake2s_:
    - Witness gen: 157.46 ms -> 80.236 ms
    - Prove: 4.9014 s -> 
    - Verify: ~484.15 s -> 



### What changed?

- Added a new `ZeroConstraint` type to the constraint system that enforces `x = 0` for an operand `x`
- Updated the constraint system to store and process zero constraints
- Modified gates that previously used AND constraints with all-ones to use the more efficient ZERO constraints:
    - `assert_eq`, `assert_eq_cond`, `assert_zero`
    - `bxor`, `bxor_multi`, `rotr`, `shl`, `shr`, `sar`
- Replaced linear constraints with ZERO constraints in the constraint builder
- Updated the prover and verifier to handle ZERO constraints in the shift reduction protocol

### How to test?

- Run the existing test suite to verify that all functionality works with the new constraint type
- Compile and run circuits that use equality assertions and XOR operations to verify they work correctly with the new implementation

### Why make this change?

This change improves efficiency by replacing the pattern `(x ⊕ y) ∧ all-1 = 0` (used to enforce `x = y`) with the simpler `x ⊕ y = 0`. The new ZERO constraint directly enforces that an operand equals zero, which is more efficient and clearer than using AND constraints with all-ones. This reduces the number of constraints needed for common operations like equality checks and XOR operations, and eliminates the need for the all-ones constant in many gates.