### PR TITLE
parallelize shift verifier monster eval

### DIFF
--- a/crates/verifier/Cargo.toml
+++ b/crates/verifier/Cargo.toml
@@ -32,3 +32,7 @@ proptest.workspace = true
 rand = { workspace = true, features = ["std_rng"] }
 itertools.workspace = true
 hex-literal.workspace = true
+
+[features]
+default = ["rayon"]
+rayon = ["binius-utils/rayon"]


### PR DESCRIPTION
### TL;DR

Running `cargo bench --bench hashsign -- hashsign_proof_verification`

1. parallelizing within `evaluate_monster_multilinear_term_for_operand`, time drops on my machine from 2.38s to 1.4s. This parallelizes the work across all the operands in a "column" (think of the 3 columns for BitAnd and the 4 for IntMul). The work is proportional to the height of the column, thus the number of AND and MUL constraints.
2. additionally parallelizing in `evaluate_monster_multilinear_for_operation` across columns (even though there's only 3+4 of them), we get another 35% percent and time drops to 1s.

### What changed?

- Added `rayon` as a dependency in `crates/verifier/Cargo.toml`
- Replaced `itertools::izip` with `rayon`'s parallel iterators in the `evaluate_monster_multilinear_term_for_operand` function
- Converted the sequential iteration to parallel processing using `par_iter()` and `zip` to potentially improve performance

### How to test?

Run the existing test suite for the verifier to ensure correctness:

```
cargo test -p verifier
```

Additionally, benchmark the verifier with large inputs to verify performance improvements.

### Why make this change?

The evaluation of monster multilinear terms is computationally intensive. By leveraging parallel processing through Rayon, we can distribute this work across multiple CPU cores, potentially reducing verification time significantly for large proofs.