### PR TITLE
move verify_constraints into core

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -7,6 +7,7 @@
 pub mod constraint_system;
 pub mod consts;
 pub mod error;
+pub mod verify;
 pub mod word;
 
 pub use constraint_system::*;

--- a/crates/core/src/verify.rs
+++ b/crates/core/src/verify.rs
@@ -1,6 +1,8 @@
-//! Simple constraint verifier for testing
+//! Routines for checking whether the
+//! [constraint system][`crate::constraint_system::ConstraintSystem`] is satisfied with the given
+//! [value vector][`ValueVec`].
 
-use binius_core::{
+use crate::{
 	constraint_system::{
 		AndConstraint, ConstraintSystem, MulConstraint, ShiftVariant, ShiftedValueIndex, ValueVec,
 	},

--- a/crates/frontend/ceck/src/randblast.rs
+++ b/crates/frontend/ceck/src/randblast.rs
@@ -1,9 +1,9 @@
 use anyhow::{Result, anyhow};
 use binius_core::{
 	constraint_system::{ConstraintSystem, ValueVec},
+	verify::verify_constraints,
 	word::Word,
 };
-use binius_frontend::constraint_verifier::verify_constraints;
 use rand::{Rng, SeedableRng, rngs::StdRng};
 
 pub struct RandBlast {

--- a/crates/frontend/src/circuits/base64.rs
+++ b/crates/frontend/src/circuits/base64.rs
@@ -296,8 +296,10 @@ fn compute_expected_base64_char(
 
 #[cfg(test)]
 mod tests {
+	use binius_core::verify::verify_constraints;
+
 	use super::{Base64UrlSafe, Wire};
-	use crate::{compiler::CircuitBuilder, constraint_verifier::verify_constraints};
+	use crate::compiler::CircuitBuilder;
 
 	/// Encodes bytes to base64 using URL-safe alphabet without trailing padding
 	/// '=" chars.

--- a/crates/frontend/src/circuits/bignum/tests.rs
+++ b/crates/frontend/src/circuits/bignum/tests.rs
@@ -1,6 +1,6 @@
 use std::iter::repeat_with;
 
-use binius_core::word::Word;
+use binius_core::{verify::verify_constraints, word::Word};
 use num_integer::Integer;
 use proptest::prelude::*;
 use rand::{SeedableRng, rngs::StdRng};
@@ -8,7 +8,6 @@ use rand::{SeedableRng, rngs::StdRng};
 use super::*;
 use crate::{
 	compiler::{CircuitBuilder, circuit::WitnessFiller},
-	constraint_verifier::verify_constraints,
 	util::num_biguint_from_u64_limbs as from_u64_limbs,
 };
 

--- a/crates/frontend/src/circuits/bitcoin/block_contains_transaction.rs
+++ b/crates/frontend/src/circuits/bitcoin/block_contains_transaction.rs
@@ -76,11 +76,11 @@ fn join(builder: &CircuitBuilder, b0: Wire, b1: Wire) -> Wire {
 
 #[cfg(test)]
 mod tests {
-	use binius_core::Word;
+	use binius_core::{Word, verify::verify_constraints};
 	use hex_literal::hex;
 
 	use super::*;
-	use crate::{constraint_verifier::verify_constraints, util::pack_bytes_into_wires_le};
+	use crate::util::pack_bytes_into_wires_le;
 
 	#[test]
 	fn test_valid() {

--- a/crates/frontend/src/circuits/bitcoin/double_sha256.rs
+++ b/crates/frontend/src/circuits/bitcoin/double_sha256.rs
@@ -99,10 +99,11 @@ impl DoubleSha256 {
 mod tests {
 	use std::array;
 
+	use binius_core::verify::verify_constraints;
 	use hex_literal::hex;
 
 	use super::*;
-	use crate::{constraint_verifier::verify_constraints, util::pack_bytes_into_wires_le};
+	use crate::util::pack_bytes_into_wires_le;
 
 	#[test]
 	fn test_valid() {

--- a/crates/frontend/src/circuits/bitcoin/merkle_path.rs
+++ b/crates/frontend/src/circuits/bitcoin/merkle_path.rs
@@ -92,11 +92,10 @@ impl MerklePath {
 mod tests {
 	use std::array;
 
-	use binius_core::Word;
+	use binius_core::{Word, verify::verify_constraints};
 	use hex_literal::hex;
 
 	use super::*;
-	use crate::constraint_verifier::verify_constraints;
 
 	#[test]
 	fn test_valid() {

--- a/crates/frontend/src/circuits/blake2b/circuit.rs
+++ b/crates/frontend/src/circuits/blake2b/circuit.rs
@@ -311,12 +311,11 @@ pub fn g_mixing(
 
 #[cfg(test)]
 mod tests {
-	use binius_core::word::Word;
+	use binius_core::{verify::verify_constraints, word::Word};
 
 	use crate::{
 		circuits::blake2b::{circuit::g_mixing, reference},
 		compiler::CircuitBuilder,
-		constraint_verifier::verify_constraints,
 	};
 
 	/// Test the G mixing function with known values

--- a/crates/frontend/src/circuits/blake2b/tests.rs
+++ b/crates/frontend/src/circuits/blake2b/tests.rs
@@ -6,6 +6,7 @@
 
 #[cfg(test)]
 mod blake2b_tests {
+	use binius_core::verify::verify_constraints;
 	use rand::{Rng, SeedableRng, rngs::StdRng};
 
 	use crate::{
@@ -16,7 +17,6 @@ mod blake2b_tests {
 			test_constants::{ground_truth_blake2b, hex_string},
 		},
 		compiler::CircuitBuilder,
-		constraint_verifier::verify_constraints,
 	};
 
 	/// All test vectors for comprehensive testing

--- a/crates/frontend/src/circuits/bytes.rs
+++ b/crates/frontend/src/circuits/bytes.rs
@@ -123,11 +123,10 @@ pub fn swap_bytes(builder: &CircuitBuilder, input: Wire) -> Wire {
 
 #[cfg(test)]
 mod tests {
-	use binius_core::word::Word;
+	use binius_core::{verify::verify_constraints, word::Word};
 	use proptest::prelude::*;
 
 	use super::*;
-	use crate::constraint_verifier::verify_constraints;
 
 	/// Helper function to test swap_bytes circuit with given input and expected output
 	fn test_swap_bytes_helper(input_val: u64, expected: u64) {

--- a/crates/frontend/src/circuits/concat.rs
+++ b/crates/frontend/src/circuits/concat.rs
@@ -265,8 +265,9 @@ impl Concat {
 }
 #[cfg(test)]
 mod tests {
+	use binius_core::verify::verify_constraints;
+
 	use super::*;
-	use crate::{compiler::CircuitBuilder, constraint_verifier::verify_constraints};
 
 	// Test utilities
 

--- a/crates/frontend/src/circuits/float64/add.rs
+++ b/crates/frontend/src/circuits/float64/add.rs
@@ -315,15 +315,12 @@ fn fp64_finish_specials(
 
 #[cfg(test)]
 mod tests {
-	use binius_core::word::Word;
+	use binius_core::{verify::verify_constraints, word::Word};
 
 	use super::*;
-	use crate::{
-		circuits::float64::utils::tests::{
-			f64_bits_semantic_eq, ref_fp64_pack_finite_or_inf, ref_fp64_round_rne,
-			ref_fp64_underflow_shift, ref_fp64_unpack,
-		},
-		constraint_verifier::verify_constraints,
+	use crate::circuits::float64::utils::tests::{
+		f64_bits_semantic_eq, ref_fp64_pack_finite_or_inf, ref_fp64_round_rne,
+		ref_fp64_underflow_shift, ref_fp64_unpack,
 	};
 
 	fn ref_fp64_ext_sig_and_exp(_sign: u64, exp: u64, frac: u64, is_norm: u64) -> (u64, u64) {

--- a/crates/frontend/src/circuits/float64/mul.rs
+++ b/crates/frontend/src/circuits/float64/mul.rs
@@ -171,15 +171,12 @@ pub fn float64_mul(builder: &CircuitBuilder, a: Wire, b: Wire) -> Wire {
 
 #[cfg(test)]
 mod tests {
-	use binius_core::word::Word;
+	use binius_core::{verify::verify_constraints, word::Word};
 
 	use super::*;
-	use crate::{
-		circuits::float64::utils::tests::{
-			f64_bits_semantic_eq, ref_fp64_pack_finite_or_inf, ref_fp64_round_rne,
-			ref_fp64_underflow_shift, ref_fp64_unpack,
-		},
-		constraint_verifier::verify_constraints,
+	use crate::circuits::float64::utils::tests::{
+		f64_bits_semantic_eq, ref_fp64_pack_finite_or_inf, ref_fp64_round_rne,
+		ref_fp64_underflow_shift, ref_fp64_unpack,
 	};
 
 	fn ref_fp64_sig53_and_exp(exp: u64, frac: u64, is_norm: bool) -> (u64, u64) {

--- a/crates/frontend/src/circuits/float64/utils.rs
+++ b/crates/frontend/src/circuits/float64/utils.rs
@@ -481,11 +481,10 @@ pub fn fp64_pack_finite_or_inf(
 
 #[cfg(test)]
 pub mod tests {
-	use binius_core::word::Word;
+	use binius_core::{verify::verify_constraints, word::Word};
 	use proptest::bool;
 
 	use super::*;
-	use crate::constraint_verifier::verify_constraints;
 
 	// Reference implementations for testing (shared between add.rs and utils.rs tests)
 	pub struct Fp64UnpackResult {

--- a/crates/frontend/src/circuits/hash_based_sig/chain_verification.rs
+++ b/crates/frontend/src/circuits/hash_based_sig/chain_verification.rs
@@ -111,12 +111,12 @@ pub fn circuit_chain(
 
 #[cfg(test)]
 mod tests {
-	use binius_core::Word;
+	use binius_core::{Word, verify::verify_constraints};
 	use proptest::{prelude::*, strategy::Just};
 	use sha3::{Digest, Keccak256};
 
 	use super::{super::hashing::build_chain_hash, *};
-	use crate::{constraint_verifier::verify_constraints, util::pack_bytes_into_wires_le};
+	use crate::util::pack_bytes_into_wires_le;
 
 	proptest! {
 		#[test]

--- a/crates/frontend/src/circuits/hash_based_sig/codeword.rs
+++ b/crates/frontend/src/circuits/hash_based_sig/codeword.rs
@@ -118,13 +118,10 @@ pub fn extract_coordinates(hash: &[u8], dimension: usize, resolution_bits: usize
 
 #[cfg(test)]
 mod tests {
-	use binius_core::Word;
+	use binius_core::{Word, verify::verify_constraints};
 
 	use super::*;
-	use crate::{
-		compiler::{CircuitBuilder, Wire},
-		constraint_verifier::verify_constraints,
-	};
+	use crate::compiler::{CircuitBuilder, Wire};
 
 	#[test]
 	fn test_coordinate_extraction() {

--- a/crates/frontend/src/circuits/hash_based_sig/hashing/chain.rs
+++ b/crates/frontend/src/circuits/hash_based_sig/hashing/chain.rs
@@ -138,14 +138,13 @@ pub fn hash_chain_keccak(
 
 #[cfg(test)]
 mod tests {
-	use binius_core::Word;
+	use binius_core::{Word, verify::verify_constraints};
 	use proptest::prelude::*;
 	use sha3::{Digest, Keccak256};
 
 	use super::*;
 	use crate::{
 		compiler::{CircuitBuilder, circuit::Circuit},
-		constraint_verifier::verify_constraints,
 		util::pack_bytes_into_wires_le,
 	};
 

--- a/crates/frontend/src/circuits/hash_based_sig/hashing/message.rs
+++ b/crates/frontend/src/circuits/hash_based_sig/hashing/message.rs
@@ -119,13 +119,13 @@ pub fn hash_message(param: &[u8], nonce: &[u8], message: &[u8]) -> [u8; 32] {
 
 #[cfg(test)]
 mod tests {
+	use binius_core::verify::verify_constraints;
 	use proptest::prelude::*;
 	use sha3::{Digest, Keccak256};
 
 	use super::*;
 	use crate::{
 		compiler::{CircuitBuilder, circuit::Circuit},
-		constraint_verifier::verify_constraints,
 		util::pack_bytes_into_wires_le,
 	};
 

--- a/crates/frontend/src/circuits/hash_based_sig/hashing/public_key.rs
+++ b/crates/frontend/src/circuits/hash_based_sig/hashing/public_key.rs
@@ -97,13 +97,13 @@ pub fn hash_public_key_keccak(domain_param: &[u8], pk_hashes: &[[u8; 32]]) -> [u
 
 #[cfg(test)]
 mod tests {
+	use binius_core::verify::verify_constraints;
 	use proptest::prelude::*;
 	use sha3::{Digest, Keccak256};
 
 	use super::*;
 	use crate::{
 		compiler::{CircuitBuilder, circuit::Circuit},
-		constraint_verifier::verify_constraints,
 		util::pack_bytes_into_wires_le,
 	};
 

--- a/crates/frontend/src/circuits/hash_based_sig/hashing/tree.rs
+++ b/crates/frontend/src/circuits/hash_based_sig/hashing/tree.rs
@@ -147,14 +147,13 @@ pub fn hash_tree_node_keccak(
 
 #[cfg(test)]
 mod tests {
-	use binius_core::Word;
+	use binius_core::{Word, verify::verify_constraints};
 	use proptest::prelude::*;
 	use sha3::{Digest, Keccak256};
 
 	use super::*;
 	use crate::{
 		compiler::{CircuitBuilder, circuit::Circuit},
-		constraint_verifier::verify_constraints,
 		util::pack_bytes_into_wires_le,
 	};
 

--- a/crates/frontend/src/circuits/hash_based_sig/merkle_tree.rs
+++ b/crates/frontend/src/circuits/hash_based_sig/merkle_tree.rs
@@ -99,12 +99,11 @@ pub fn circuit_merkle_path(
 
 #[cfg(test)]
 mod tests {
-	use binius_core::Word;
+	use binius_core::{Word, verify::verify_constraints};
 
 	use super::*;
 	use crate::{
 		circuits::hash_based_sig::hashing::{build_tree_hash, hash_tree_node_keccak},
-		constraint_verifier::verify_constraints,
 		util::pack_bytes_into_wires_le,
 	};
 

--- a/crates/frontend/src/circuits/hash_based_sig/tweak.rs
+++ b/crates/frontend/src/circuits/hash_based_sig/tweak.rs
@@ -1,4 +1,5 @@
 use binius_core::Word;
+use binius_core::verify::verify_constraints;
 
 use crate::{
 	circuits::{
@@ -194,7 +195,7 @@ mod tests {
 	use super::*;
 	use crate::{
 		compiler::{CircuitBuilder, circuit::Circuit},
-		constraint_verifier::verify_constraints,
+		binius_core::verify::verify_constraints,
 	};
 
 	/// Helper struct to encapsulate test circuit setup

--- a/crates/frontend/src/circuits/hash_based_sig/winternitz_ots.rs
+++ b/crates/frontend/src/circuits/hash_based_sig/winternitz_ots.rs
@@ -256,13 +256,14 @@ pub fn grind_nonce(
 
 #[cfg(test)]
 mod tests {
+	use binius_core::verify::verify_constraints;
 	use rand::{RngCore, SeedableRng, rngs::StdRng};
 
 	use super::{
 		super::hashing::{build_chain_hash, hash_chain_keccak},
 		*,
 	};
-	use crate::{constraint_verifier::verify_constraints, util::pack_bytes_into_wires_le};
+	use crate::util::pack_bytes_into_wires_le;
 
 	#[test]
 	fn test_circuit_winternitz_ots() {

--- a/crates/frontend/src/circuits/hash_based_sig/xmss.rs
+++ b/crates/frontend/src/circuits/hash_based_sig/xmss.rs
@@ -120,7 +120,7 @@ pub fn circuit_xmss(
 
 #[cfg(test)]
 mod tests {
-	use binius_core::Word;
+	use binius_core::{Word, verify::verify_constraints};
 	use rand::{RngCore, SeedableRng, rngs::StdRng};
 	use rstest::rstest;
 
@@ -133,7 +133,6 @@ mod tests {
 				XmssHasherData, build_merkle_tree, extract_auth_path, populate_xmss_hashers,
 			},
 		},
-		constraint_verifier::verify_constraints,
 		util::pack_bytes_into_wires_le,
 	};
 

--- a/crates/frontend/src/circuits/hash_based_sig/xmss_aggregate.rs
+++ b/crates/frontend/src/circuits/hash_based_sig/xmss_aggregate.rs
@@ -117,7 +117,7 @@ impl<'a> MultiSigBuilder<'a> {
 mod tests {
 	use std::error::Error;
 
-	use binius_core::Word;
+	use binius_core::{Word, verify::verify_constraints};
 	use rand::{RngCore, SeedableRng, rngs::StdRng};
 	use rstest::rstest;
 
@@ -126,7 +126,6 @@ mod tests {
 		circuits::hash_based_sig::witness_utils::{
 			ValidatorSignatureData, XmssHasherData, populate_xmss_hashers,
 		},
-		constraint_verifier::verify_constraints,
 		util::pack_bytes_into_wires_le,
 	};
 

--- a/crates/frontend/src/circuits/hmac.rs
+++ b/crates/frontend/src/circuits/hmac.rs
@@ -93,13 +93,12 @@ pub fn hmac_sha512_fixed(
 mod tests {
 	use std::{array, iter::repeat_with};
 
-	use binius_core::word::Word;
+	use binius_core::{verify::verify_constraints, word::Word};
 	use hmac::{Hmac, Mac};
 	use rand::{Rng, SeedableRng, rngs::StdRng};
 	use sha2::Sha512;
 
 	use super::*;
-	use crate::constraint_verifier::verify_constraints;
 
 	type HmacSha512 = Hmac<Sha512>;
 

--- a/crates/frontend/src/circuits/jwt_claims.rs
+++ b/crates/frontend/src/circuits/jwt_claims.rs
@@ -220,8 +220,10 @@ impl JwtClaims {
 
 #[cfg(test)]
 mod tests {
+	use binius_core::verify::verify_constraints;
+
 	use super::{Attribute, JwtClaims, Wire};
-	use crate::{compiler::CircuitBuilder, constraint_verifier::verify_constraints};
+	use crate::compiler::CircuitBuilder;
 
 	#[test]
 	fn test_single_attribute() {

--- a/crates/frontend/src/circuits/keccak/mod.rs
+++ b/crates/frontend/src/circuits/keccak/mod.rs
@@ -298,6 +298,7 @@ impl Keccak {
 mod tests {
 	use std::iter::repeat_n;
 
+	use binius_core::verify::verify_constraints;
 	use rand::{Rng, SeedableRng, rngs::StdRng};
 	use sha3::{Digest, Keccak256};
 
@@ -305,7 +306,6 @@ mod tests {
 	use crate::{
 		circuits::keccak::RATE_BYTES,
 		compiler::{CircuitBuilder, Wire},
-		constraint_verifier::verify_constraints,
 	};
 
 	fn keccak_crate(message_bytes: &[u8]) -> [u8; 32] {

--- a/crates/frontend/src/circuits/keccak/permutation.rs
+++ b/crates/frontend/src/circuits/keccak/permutation.rs
@@ -128,7 +128,7 @@ impl Permutation {
 
 #[cfg(test)]
 mod tests {
-	use binius_core::word::Word;
+	use binius_core::{verify::verify_constraints, word::Word};
 	use rand::{Rng, SeedableRng, rngs::StdRng};
 
 	use super::*;
@@ -138,7 +138,6 @@ mod tests {
 			keccak_permutation_round_reference, rho_pi_reference, theta_reference,
 		},
 		compiler::CircuitBuilder,
-		constraint_verifier::verify_constraints,
 	};
 
 	#[test]

--- a/crates/frontend/src/circuits/multiplexer.rs
+++ b/crates/frontend/src/circuits/multiplexer.rs
@@ -120,10 +120,9 @@ pub fn single_wire_multiplex(b: &CircuitBuilder, inputs: &[Wire], sel: Wire) -> 
 
 #[cfg(test)]
 mod tests {
-	use binius_core::word::Word;
+	use binius_core::{verify::verify_constraints, word::Word};
 
 	use super::*;
-	use crate::constraint_verifier::verify_constraints;
 
 	/// Helper function to verify single-wire multiplexer behavior
 	/// Takes input values and test cases as (selector, expected_output) pairs

--- a/crates/frontend/src/circuits/ripemd.rs
+++ b/crates/frontend/src/circuits/ripemd.rs
@@ -358,11 +358,11 @@ pub fn ripemd160_fixed(builder: &CircuitBuilder, message: &[Wire], len_bytes: us
 mod tests {
 	use std::{array, iter, iter::repeat_with};
 
+	use binius_core::verify::verify_constraints;
 	use rand::prelude::*;
 	use ripemd::Digest;
 
 	use super::*;
-	use crate::{compiler::CircuitBuilder, constraint_verifier::verify_constraints};
 
 	// Helper function for ripemd160_fixed tests
 	fn test_ripemd160_fixed_with_input(message: &[u8], expected_bytes: [u8; 20]) {

--- a/crates/frontend/src/circuits/rs256.rs
+++ b/crates/frontend/src/circuits/rs256.rs
@@ -438,6 +438,7 @@ impl RsaIntermediates {
 
 #[cfg(test)]
 mod tests {
+	use binius_core::verify::verify_constraints;
 	use hex_literal::hex;
 	use num_bigint::BigUint;
 	use rand::{SeedableRng, TryRngCore, rngs::StdRng};
@@ -448,7 +449,6 @@ mod tests {
 	};
 
 	use super::*;
-	use crate::{compiler::CircuitBuilder, constraint_verifier::verify_constraints};
 
 	/// Create a deterministic test RSA key
 	/// This is a 2048-bit RSA key generated with ChaCha8Rng seed 42

--- a/crates/frontend/src/circuits/sha256/compress.rs
+++ b/crates/frontend/src/circuits/sha256/compress.rs
@@ -213,13 +213,10 @@ fn small_sigma_1(b: &CircuitBuilder, x: Wire) -> Wire {
 
 #[cfg(test)]
 mod tests {
-	use binius_core::word::Word;
+	use binius_core::{verify::verify_constraints, word::Word};
 
 	use super::{Compress, State};
-	use crate::{
-		compiler::{self, Wire},
-		constraint_verifier::verify_constraints,
-	};
+	use crate::compiler::{self, Wire};
 
 	/// A test circuit that proves a knowledge of preimage for a given state vector S in
 	///

--- a/crates/frontend/src/circuits/sha256/mod.rs
+++ b/crates/frontend/src/circuits/sha256/mod.rs
@@ -608,15 +608,12 @@ pub fn sha256_fixed(builder: &CircuitBuilder, message: &[Wire], len_bytes: usize
 mod tests {
 	use std::array;
 
-	use binius_core::Word;
+	use binius_core::{Word, verify::verify_constraints};
 	use hex_literal::hex;
 	use sha2::Digest;
 
 	use super::*;
-	use crate::{
-		compiler::{self, Wire},
-		constraint_verifier::verify_constraints,
-	};
+	use crate::compiler::{self, Wire};
 
 	fn mk_circuit(b: &mut compiler::CircuitBuilder, max_len: usize) -> Sha256 {
 		let len = b.add_witness();

--- a/crates/frontend/src/circuits/sha512/compress.rs
+++ b/crates/frontend/src/circuits/sha512/compress.rs
@@ -279,13 +279,10 @@ fn small_sigma_1(b: &CircuitBuilder, x: Wire) -> Wire {
 
 #[cfg(test)]
 mod tests {
-	use binius_core::word::Word;
+	use binius_core::{verify::verify_constraints, word::Word};
 
 	use super::{Compress, State};
-	use crate::{
-		compiler::{self, Wire},
-		constraint_verifier::verify_constraints,
-	};
+	use crate::compiler::{self, Wire};
 
 	/// A test circuit that proves a knowledge of preimage for a given state vector S in
 	///

--- a/crates/frontend/src/circuits/sha512/mod.rs
+++ b/crates/frontend/src/circuits/sha512/mod.rs
@@ -566,15 +566,12 @@ pub fn sha512_fixed(builder: &CircuitBuilder, message: &[Wire], len_bytes: usize
 
 #[cfg(test)]
 mod tests {
-	use binius_core::Word;
+	use binius_core::{Word, verify::verify_constraints};
 	use hex_literal::hex;
 	use sha2::Digest;
 
 	use super::{Sha512, sha512_fixed};
-	use crate::{
-		compiler::{self, CircuitBuilder, Wire},
-		constraint_verifier::verify_constraints,
-	};
+	use crate::compiler::{self, CircuitBuilder, Wire};
 
 	fn mk_circuit(b: &mut CircuitBuilder, max_len: usize) -> Sha512 {
 		let len = b.add_witness();

--- a/crates/frontend/src/circuits/skein512/mod.rs
+++ b/crates/frontend/src/circuits/skein512/mod.rs
@@ -507,11 +507,10 @@ impl Threefish512Block {
 
 #[cfg(test)]
 mod tests {
+	use binius_core::verify::verify_constraints;
+
 	use super::*;
-	use crate::{
-		circuits::skein512::reference, compiler::CircuitBuilder,
-		constraint_verifier::verify_constraints,
-	};
+	use crate::{circuits::skein512::reference, compiler::CircuitBuilder};
 
 	// Tests from skein512.rs
 	fn test_skein512_with_blocks(message_blocks: &[[u8; 64]]) {

--- a/crates/frontend/src/circuits/slice.rs
+++ b/crates/frontend/src/circuits/slice.rs
@@ -271,8 +271,9 @@ pub fn create_byte_mask(b: &CircuitBuilder, n_bytes: Wire) -> Wire {
 
 #[cfg(test)]
 mod tests {
+	use binius_core::verify::verify_constraints;
+
 	use super::{CircuitBuilder, Slice, Wire, Word};
-	use crate::constraint_verifier::verify_constraints;
 
 	#[test]
 	fn test_aligned_slice() {

--- a/crates/frontend/src/circuits/subset_sum.rs
+++ b/crates/frontend/src/circuits/subset_sum.rs
@@ -108,8 +108,9 @@ impl SubsetSum {
 
 #[cfg(test)]
 mod tests {
+	use binius_core::verify::verify_constraints;
+
 	use super::*;
-	use crate::constraint_verifier::verify_constraints;
 
 	/// Checks that it works with a valid solution.
 	#[test]

--- a/crates/frontend/src/circuits/zklogin.rs
+++ b/crates/frontend/src/circuits/zklogin.rs
@@ -508,11 +508,11 @@ fn jwt_payload_check(
 mod tests {
 
 	use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD as BASE64_URL_SAFE_NO_PAD};
+	use binius_core::verify::verify_constraints;
 	use rand::{SeedableRng, TryRngCore, rngs::StdRng};
 	use sha2::{Digest, Sha256};
 
 	use super::*;
-	use crate::constraint_verifier::verify_constraints;
 
 	fn run_zk_login_with_jwt_population(config: Config) {
 		use jwt_simple::prelude::*;

--- a/crates/frontend/src/compiler/gate/select.rs
+++ b/crates/frontend/src/compiler/gate/select.rs
@@ -68,10 +68,10 @@ pub fn emit_eval_bytecode(
 
 #[cfg(test)]
 mod tests {
-	use binius_core::word::Word;
+	use binius_core::{verify::verify_constraints, word::Word};
 	use rand::{RngCore, SeedableRng, rngs::StdRng};
 
-	use crate::{compiler::CircuitBuilder, constraint_verifier::verify_constraints};
+	use crate::compiler::CircuitBuilder;
 
 	#[test]
 	fn test_select_basic() {

--- a/crates/frontend/src/compiler/gate/smul.rs
+++ b/crates/frontend/src/compiler/gate/smul.rs
@@ -306,10 +306,10 @@ pub fn emit_eval_bytecode(
 
 #[cfg(test)]
 mod tests {
-	use binius_core::word::Word;
+	use binius_core::{verify::verify_constraints, word::Word};
 	use proptest::prelude::*;
 
-	use crate::{compiler::CircuitBuilder, constraint_verifier::verify_constraints};
+	use crate::compiler::CircuitBuilder;
 
 	// Property: SMUL gate should correctly compute signed multiplication
 	proptest! {

--- a/crates/frontend/src/compiler/tests.rs
+++ b/crates/frontend/src/compiler/tests.rs
@@ -1,9 +1,9 @@
-use binius_core::word::Word;
+use binius_core::{verify::verify_constraints, word::Word};
 use proptest::prelude::*;
 use rand::{Rng, SeedableRng as _, rngs::StdRng};
 
 use super::*;
-use crate::{constraint_verifier::verify_constraints, util::num_biguint_from_u64_limbs};
+use crate::util::num_biguint_from_u64_limbs;
 
 #[test]
 fn wires_layout() {

--- a/crates/frontend/src/lib.rs
+++ b/crates/frontend/src/lib.rs
@@ -1,5 +1,4 @@
 pub mod circuits;
 pub mod compiler;
-pub mod constraint_verifier;
 pub mod stat;
 pub mod util;

--- a/crates/prover/tests/shift.rs
+++ b/crates/prover/tests/shift.rs
@@ -2,14 +2,11 @@
 
 use binius_core::{
 	constraint_system::{AndConstraint, ConstraintSystem, MulConstraint, ValueVec},
+	verify::{eval_operand, verify_constraints},
 	word::Word,
 };
 use binius_field::{AESTowerField8b, BinaryField, Field};
-use binius_frontend::{
-	circuits::sha256::Sha256,
-	compiler::CircuitBuilder,
-	constraint_verifier::{eval_operand, verify_constraints},
-};
+use binius_frontend::{circuits::sha256::Sha256, compiler::CircuitBuilder};
 use binius_math::{
 	BinarySubspace,
 	inner_product::{inner_product, inner_product_buffers},


### PR DESCRIPTION
`verify_constraints` is not really dependent on anything frontend and can be
used independently from it. Therefore, the core is a better home for it.

This is a non-functional change.