### PR TITLE
[backend] handle intmul overflow check without AND constraints

### DIFF
--- a/crates/examples/snapshots/ethsign.snap
+++ b/crates/examples/snapshots/ethsign.snap
@@ -2,11 +2,11 @@ ethsign circuit
 --
 Number of gates: 264568
 Number of evaluation instructions: 310572
-Number of AND constraints: 246345
+Number of AND constraints: 218231
 Number of MUL constraints: 25458
 Length of value vec: 262144
   Constants: 88
   Inout: 29
   Witness: 42
-  Internal: 256480
-  Scratch: 283175
+  Internal: 253824
+  Scratch: 285831

--- a/crates/examples/snapshots/zklogin.snap
+++ b/crates/examples/snapshots/zklogin.snap
@@ -2,7 +2,7 @@ zklogin circuit
 --
 Number of gates: 486462
 Number of evaluation instructions: 550412
-Number of AND constraints: 456152
+Number of AND constraints: 429272
 Number of MUL constraints: 26880
 Length of value vec: 524288
   Constants: 716

--- a/crates/frontend/src/compiler/gate/imul.rs
+++ b/crates/frontend/src/compiler/gate/imul.rs
@@ -3,7 +3,7 @@
 //! Uses the MulConstraint: X * Y = (HI << 64) | LO
 
 use crate::compiler::{
-	constraint_builder::{ConstraintBuilder, sll},
+	constraint_builder::ConstraintBuilder,
 	gate::opcode::OpcodeShape,
 	gate_graph::{Gate, GateData, GateParam, Wire},
 };
@@ -28,23 +28,6 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 
 	// Create MulConstraint: X * Y = (HI << 64) | LO
 	builder.mul().a(*x).b(*y).hi(*hi).lo(*lo).build();
-
-	// Security fix: IntMul reduction proves x*y ≡ lo + 2^64*hi (mod 2^128-1), but we need (mod
-	// 2^128). Attack: If x=0 or y=0, malicious prover sets lo=hi=2^64-1, giving lo + 2^64*hi =
-	// 2^128-1 ≡ 0 (mod 2^128-1). This passes the IntMul check but violates the intended x*y = lo +
-	// 2^64*hi over integers.
-	//
-	// Fix: Check LSB multiplication x[0] * y[0] = lo[0].
-	// If x=0 or y=0, then x[0]*y[0] = 0, so lo[0] must be 0. But the attack has lo[0] = 1, failing
-	// this check.
-	//
-	// Implementation: Shift LSBs to MSB position for AND constraint.
-	builder
-		.and()
-		.a(sll(*x, 63))
-		.b(sll(*y, 63))
-		.c(sll(*lo, 63))
-		.build();
 }
 
 pub fn emit_eval_bytecode(

--- a/crates/frontend/src/compiler/gate_fusion/tests/awhole.rs
+++ b/crates/frontend/src/compiler/gate_fusion/tests/awhole.rs
@@ -122,10 +122,7 @@ fn test_mul_inlining_duplicate_linear_in_mul() {
 
 	let cs = compile(b);
 
-	insta::assert_snapshot!(stringify_constraint_system(&cs), @r"
-	AND[0]: (v[2]≪63 ⊕ v[3]≪63) ∧ (v[2]≪63 ⊕ v[3]≪63) = (v[5]≪63)
-	MUL[0]: (v[2] ⊕ v[3]) * (v[2] ⊕ v[3]) = (HI: v[4], LO: v[5])
-	");
+	insta::assert_snapshot!(stringify_constraint_system(&cs), @"MUL[0]: (v[2] ⊕ v[3]) * (v[2] ⊕ v[3]) = (HI: v[4], LO: v[5])");
 }
 
 #[test]
@@ -149,7 +146,6 @@ fn test_mul_and_and_shared_linear_uses() {
 	let cs = compile(b);
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @r"
 	AND[0]: (v[2] ⊕ v[3]) ∧ (v[4]) = (v[6])
-	AND[1]: (v[2]≪63 ⊕ v[3]≪63) ∧ (v[5]≪63) = (v[8]≪63)
 	MUL[0]: (v[2] ⊕ v[3]) * (v[5]) = (HI: v[7], LO: v[8])
 	");
 }
@@ -178,11 +174,10 @@ fn test_mul_inlining_into_hi_lo() {
 
 	let cs = compile(b);
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @r"
-AND[0]: (v[6]≪63) ∧ (v[7]≪63) = (v[11]≪63)
-AND[1]: (v[2] ⊕ v[3]) ∧ (all-1) = (v[8])
-AND[2]: (v[4] ⊕ v[5]) ∧ (all-1) = (v[9])
-MUL[0]: (v[6]) * (v[7]) = (HI: v[10], LO: v[11])
-");
+	AND[0]: (v[2] ⊕ v[3]) ∧ (all-1) = (v[8])
+	AND[1]: (v[4] ⊕ v[5]) ∧ (all-1) = (v[9])
+	MUL[0]: (v[6]) * (v[7]) = (HI: v[10], LO: v[11])
+	");
 }
 
 #[test]
@@ -205,11 +200,7 @@ fn test_mul_inlining_distinct_linears() {
 	let (_hi, _lo) = b.imul(y1, y2);
 
 	let cs = compile(b);
-	insta::assert_snapshot!(stringify_constraint_system(&cs), @r"
-	AND[0]: (v[2]≪63 ⊕ v[3]≪63) ∧ (v[6]≪63 ⊕ v[5]≪63) = (v[8]≪63)
-	AND[1]: (v[4]≪3) ∧ (all-1) = (v[6])
-	MUL[0]: (v[2] ⊕ v[3]) * (v[6] ⊕ v[5]) = (HI: v[7], LO: v[8])
-	");
+	insta::assert_snapshot!(stringify_constraint_system(&cs), @"MUL[0]: (v[2] ⊕ v[3]) * (v[4]≪3 ⊕ v[5]) = (HI: v[6], LO: v[7])");
 }
 
 #[test]

--- a/crates/prover/src/protocols/intmul/prove.rs
+++ b/crates/prover/src/protocols/intmul/prove.rs
@@ -3,12 +3,18 @@
 use std::marker::PhantomData;
 
 use binius_field::{BinaryField, PackedField};
-use binius_math::{field_buffer::FieldBuffer, multilinear::evaluate::evaluate};
+use binius_math::{
+	field_buffer::FieldBuffer,
+	multilinear::{eq::eq_ind_partial_eval, evaluate::evaluate},
+};
 use binius_transcript::{
 	ProverTranscript,
 	fiat_shamir::{CanSample, Challenger},
 };
-use binius_utils::bitwise::Bitwise;
+use binius_utils::{
+	bitwise::{BitSelector, Bitwise},
+	random_access_sequence::RandomAccessSequence,
+};
 use binius_verifier::protocols::intmul::common::{
 	IntMulOutput, Phase1Output, Phase2Output, Phase3Output, Phase4Output, Phase5Output,
 	frobenius_twist, make_phase_3_output, normalize_a_c_exponent_evals,
@@ -16,7 +22,10 @@ use binius_verifier::protocols::intmul::common::{
 use either::Either;
 use itertools::{Itertools, izip};
 
-use super::{error::Error, witness::Witness};
+use super::{
+	error::Error,
+	witness::{Witness, two_valued_field_buffer},
+};
 use crate::protocols::sumcheck::{
 	MleToSumCheckDecorator,
 	batch::{BatchSumcheckOutput, batch_prove},
@@ -113,8 +122,8 @@ where
 			frobenius_twist(log_bits, &phase1_eval_point, &b_leaves_evals);
 
 		// Splitting
-		let (_, a_root, mut a_layers) = a.split();
-		let (_, c_lo_root, mut c_lo_layers) = c_lo.split();
+		let (a_exponents, a_root, mut a_layers) = a.split();
+		let (c_lo_exponents, c_lo_root, mut c_lo_layers) = c_lo.split();
 		let (_, c_hi_root, mut c_hi_layers) = c_hi.split();
 
 		let a_last_layer = a_layers.pop().expect("log_bits >= 1");
@@ -157,6 +166,9 @@ where
 			eval_point: phase5_eval_point,
 			scaled_a_c_exponent_evals,
 			b_exponent_evals,
+			a_0_eval: _,
+			b_0_eval: _,
+			c_lo_0_eval: _,
 		} = self.phase5(
 			log_bits,
 			&phase4_eval_point,
@@ -166,6 +178,8 @@ where
 			b_exponents.as_ref(),
 			&phase3_eval_point,
 			&b_exponent_evals,
+			a_exponents.as_ref(),
+			c_lo_exponents.as_ref(),
 		)?;
 
 		let [a_exponent_evals, c_lo_exponent_evals, c_hi_exponent_evals] =
@@ -342,6 +356,9 @@ where
 		b_exponents: &[B],
 		b_eval_point: &[F],
 		b_exponent_evals: &[F],
+		// Needed for the zerocheck on `a_0 * b_0 = c_lo_0`.
+		a_exponents: &[B],
+		c_lo_exponents: &[B],
 	) -> Result<Phase5Output<F>, Error> {
 		assert!(log_bits >= 1);
 		assert_eq!(1 << log_bits, a_layer.len());
@@ -351,46 +368,134 @@ where
 		assert_eq!(b_eval_point.len(), a_layer.first().expect("log_bits >= 1").log_len());
 		assert_eq!(a_c_eval_point.len(), b_eval_point.len());
 
-		let layer = a_layer.into_iter().chain(c_lo_layer).chain(c_hi_layer);
-		let evals = [a_evals, c_lo_evals, c_hi_evals].concat();
+		// We must check that `a_0 * b_0 = c_lo_0` across all rows, where these represent the least
+		// significant bits of `a_exponents`, `b_exponents`, and `c_lo_exponents` respectively.
+		// This check is performed in GF(2) (interpreting bits as field elements 0 and 1).
+		//
+		// Purpose: This prevents an attack when `a*b = 0` (due to `a=0` or `b=0`). A malicious
+		// prover could set `c = 2^128 - 1`, which satisfies `a*b ≡ c (mod 2^128-1)` since
+		// `0 ≡ 2^128-1 (mod 2^128-1)`. However, we need `a*b = c (mod 2^128)` where `0 ≠ 2^128-1`.
+		// This check catches the attack: if `c = 2^128-1` then `c_lo_0 = 1` (since 2^128-1 is odd),
+		// but `a_0 * b_0 = 0` when `a=0` or `b=0`, so the check `a_0 * b_0 = c_lo_0` fails.
+		//
+		// Implementation: We must perform a zerocheck on `a_0 * b_0 = c_lo_0`. We can reuse
+		// `a_c_eval_point` as our zerocheck challenge. We don't have a sumcheck prover generic
+		// over the composition. Therefore we'll use a bivariate product mle prover on `a_0*b_0`
+		// and the `RerandMlecheckProver` on `c_lo_0`. To do so we must feed each prover an eval
+		// claim, and we compute the corresponding eval by evaluating `c_lo_0` at
+		// `a_c_eval_point`.
 
-		let a_c_sumcheck_prover =
-			BivariateProductMultiMlecheckProver::new(make_pairs(layer), a_c_eval_point, evals)?;
+		// Embed `a_0` and `b_0` bits into field buffers for `BivariateProductMultiMlecheckProver`.
+		let binary_elements = [F::zero(), F::one()];
+		let a_0: FieldBuffer<P> = two_valued_field_buffer(0, &a_exponents, binary_elements);
+		let b_0: FieldBuffer<P> = two_valued_field_buffer(0, &b_exponents, binary_elements);
 
-		let a_c_prover = MleToSumCheckDecorator::new(a_c_sumcheck_prover);
+		// Compute the evaluation of `c_lo_0` at `a_c_eval_point`.
+		let c_lo_0_eval = {
+			let c_lo_bits = BitSelector::new(0, c_lo_exponents);
+			let p_width = P::WIDTH.min(1 << log_bits);
 
+			eq_ind_partial_eval::<P>(a_c_eval_point)
+				.as_ref()
+				.iter()
+				.enumerate()
+				.fold(F::zero(), |acc, (i, packed)| {
+					(0..p_width).fold(acc, |inner_acc, j| unsafe {
+						if c_lo_bits.get_unchecked(i << P::LOG_WIDTH | j) {
+							inner_acc + packed.get_unchecked(j)
+						} else {
+							inner_acc
+						}
+					})
+				})
+		};
+
+		// Write `c_lo_0_eval` to the transcript so the verifier has the claimed
+		// eval for both the `a_0 * b_0` bivariate product and `c_lo_0` rerand sumcheck.
+		self.transcript.message().write_scalar(c_lo_0_eval);
+
+		// Make the `BivariateProductMultiMlecheckProver` prover.
+		// The prover proves an MLE eval claim on each pair of adjacent multilinears
+		// in the `multilinears` iterator below.
+		let multilinears = a_layer
+			.into_iter()
+			.chain(c_lo_layer)
+			.chain(c_hi_layer)
+			.chain([a_0, b_0]);
+		let evals = [a_evals, c_lo_evals, c_hi_evals, &[c_lo_0_eval]].concat();
+
+		let bivariate_mle_prover = BivariateProductMultiMlecheckProver::new(
+			make_pairs(multilinears),
+			a_c_eval_point,
+			evals,
+		)?;
+		let bivariate_sumcheck_prover = MleToSumCheckDecorator::new(bivariate_mle_prover);
+
+		// Make the `RerandMlecheckProver` prover for `c_lo_0`.
+		let c_lo_0_rerand_prover = RerandMlecheckProver::<P, _>::new(
+			a_c_eval_point,
+			&[c_lo_0_eval],
+			c_lo_exponents,
+			self.switchover,
+		)?;
+		let c_lo_0_sumcheck_prover = MleToSumCheckDecorator::new(c_lo_0_rerand_prover);
+
+		// Make the `RerandMlecheckProver` for `b_exponents`.
 		assert_eq!(b_exponents.len(), 1 << b_eval_point.len());
 		assert_eq!(b_exponent_evals.len(), 1 << log_bits);
 
-		let b_sumcheck_prover = RerandMlecheckProver::<P, _>::new(
+		let b_rerand_prover = RerandMlecheckProver::<P, _>::new(
 			b_eval_point,
 			b_exponent_evals,
 			b_exponents,
 			self.switchover,
 		)?;
+		let b_sumcheck_prover = MleToSumCheckDecorator::new(b_rerand_prover);
 
-		let b_prover = MleToSumCheckDecorator::new(b_sumcheck_prover);
-
+		// Batch prove all three provers.
 		let BatchSumcheckOutput {
 			challenges,
 			mut multilinear_evals,
-		} = batch_prove(vec![Either::Left(a_c_prover), Either::Right(b_prover)], self.transcript)?;
+		} = batch_prove(
+			vec![
+				Either::Left(bivariate_sumcheck_prover),
+				Either::Right(c_lo_0_sumcheck_prover),
+				Either::Right(b_sumcheck_prover),
+			],
+			self.transcript,
+		)?;
 
-		assert_eq!(multilinear_evals.len(), 2);
+		// Pull out the evals of all three provers.
+		assert_eq!(multilinear_evals.len(), 3);
 		let b_prover_evals = multilinear_evals
 			.pop()
-			.expect("multilinear_evals.len() == 2");
-		let a_c_prover_evals = multilinear_evals
+			.expect("multilinear_evals.len() == 3");
+		let c_lo_0_prover_evals = multilinear_evals
 			.pop()
 			.expect("multilinear_evals.len() == 2");
+		let mut a_c_prover_evals = multilinear_evals
+			.pop()
+			.expect("multilinear_evals.len() == 1");
 
-		assert_eq!(a_c_prover_evals.len(), 3 << log_bits);
+		assert_eq!(a_c_prover_evals.len(), (3 << log_bits) + 2);
+		assert_eq!(c_lo_0_prover_evals.len(), 1);
 		assert_eq!(b_prover_evals.len(), 1 << log_bits);
+
+		let b_0_eval = a_c_prover_evals
+			.pop()
+			.expect("a_c_prover_evals.len() == (3 << log_bits) + 2");
+		let a_0_eval = a_c_prover_evals
+			.pop()
+			.expect("a_c_prover_evals.len() == (3 << log_bits) + 2");
+		let c_lo_0_eval = c_lo_0_prover_evals[0];
 
 		Ok(Phase5Output {
 			eval_point: challenges,
 			scaled_a_c_exponent_evals: a_c_prover_evals,
 			b_exponent_evals: b_prover_evals,
+			a_0_eval,
+			b_0_eval,
+			c_lo_0_eval,
 		})
 	}
 }

--- a/crates/verifier/src/protocols/intmul/common.rs
+++ b/crates/verifier/src/protocols/intmul/common.rs
@@ -68,6 +68,9 @@ pub struct Phase5Output<F> {
 	pub eval_point: Vec<F>,
 	pub scaled_a_c_exponent_evals: Vec<F>,
 	pub b_exponent_evals: Vec<F>,
+	pub a_0_eval: F,
+	pub b_0_eval: F,
+	pub c_lo_0_eval: F,
 }
 
 /// Applying the inverse of $\phi^$ to the selector columns.


### PR DESCRIPTION
### TL;DR

Added a security check to the integer multiplication protocol to prevent an overflow attack when `a*b = 0`.

### What changed?

This PR adds a critical security check to the integer multiplication protocol that verifies `a_0 * b_0 = c_lo_0` across all rows, where these represent the least significant bits of the respective values. This prevents a potential attack when `a*b = 0` (due to either `a=0` or `b=0`).

The implementation:
- Extracts the least significant bits of `a`, `b`, and `c_lo` into field buffers
- Adds a zerocheck on `a_0 * b_0 = c_lo_0` using a bivariate product MLE prover for `a_0 * b_0` and a rerand MLE prover for `c_lo_0`
- Refactors the batch proving to include this additional check
- Adds a helper function `two_valued_field_buffer` to create field buffers from bit values
- Updates the verification logic to validate this additional constraint

### How to test?

Run the existing test suite to ensure the protocol still works correctly. Additionally, create specific test cases where `a=0` or `b=0` and verify that the protocol correctly rejects attempts to set `c = 2^128-1`.

### Why make this change?

This change addresses a security vulnerability in the integer multiplication protocol. Without this check, when `a*b = 0`, a malicious prover could set `c = 2^128-1`, which satisfies `a*b ≡ c (mod 2^128-1)` since `0 ≡ 2^128-1 (mod 2^128-1)`. However, we need `a*b = c (mod 2^128)` where `0 ≠ 2^128-1`.

The added check catches this attack because if `c = 2^128-1` then `c_lo_0 = 1` (since 2^128-1 is odd), but `a_0 * b_0 = 0` when `a=0` or `b=0`, causing the check to fail.