### PR TITLE
[frontend] stat prints distinct shift value indices

### DIFF
--- a/crates/core/src/constraint_system.rs
+++ b/crates/core/src/constraint_system.rs
@@ -45,7 +45,7 @@ impl DeserializeBytes for ValueIndex {
 /// A different variants of shifting a value.
 ///
 /// Note that there is no shift left arithmetic because it is redundant.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ShiftVariant {
 	/// Shift logical left.
 	Sll,
@@ -93,7 +93,7 @@ impl DeserializeBytes for ShiftVariant {
 ///
 /// The canonical formto represent a value without any shifting is [`ShiftVariant::Sll`] with
 /// amount equals 0.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
 pub struct ShiftedValueIndex {
 	/// The index of this value in the input values vector.
 	pub value_index: ValueIndex,

--- a/crates/examples/snapshots/blake2s.snap
+++ b/crates/examples/snapshots/blake2s.snap
@@ -4,6 +4,7 @@ Number of gates: 2318
 Number of evaluation instructions: 2318
 Number of AND constraints: 2584
 Number of MUL constraints: 0
+Number of distinct shifted value indices: 6155
 Length of value vec: 4096
   Constants: 14
   Inout: 0

--- a/crates/examples/snapshots/ethsign.snap
+++ b/crates/examples/snapshots/ethsign.snap
@@ -4,6 +4,7 @@ Number of gates: 264472
 Number of evaluation instructions: 310572
 Number of AND constraints: 246345
 Number of MUL constraints: 25458
+Number of distinct shifted value indices: 547767
 Length of value vec: 262144
   Constants: 82
   Inout: 29

--- a/crates/examples/snapshots/hashsign.snap
+++ b/crates/examples/snapshots/hashsign.snap
@@ -4,6 +4,7 @@ Number of gates: 3986883
 Number of evaluation instructions: 4076982
 Number of AND constraints: 1837176
 Number of MUL constraints: 0
+Number of distinct shifted value indices: 14239376
 Length of value vec: 2097152
   Constants: 376
   Inout: 20

--- a/crates/examples/snapshots/keccak.snap
+++ b/crates/examples/snapshots/keccak.snap
@@ -4,6 +4,7 @@ Number of gates: 27625
 Number of evaluation instructions: 27625
 Number of AND constraints: 6025
 Number of MUL constraints: 0
+Number of distinct shifted value indices: 135134
 Length of value vec: 8192
   Constants: 23
   Inout: 50

--- a/crates/examples/snapshots/sha256.snap
+++ b/crates/examples/snapshots/sha256.snap
@@ -4,6 +4,7 @@ Number of gates: 74954
 Number of evaluation instructions: 76589
 Number of AND constraints: 68881
 Number of MUL constraints: 0
+Number of distinct shifted value indices: 131539
 Length of value vec: 131072
   Constants: 353
   Inout: 260

--- a/crates/examples/snapshots/sha512.snap
+++ b/crates/examples/snapshots/sha512.snap
@@ -4,6 +4,7 @@ Number of gates: 48779
 Number of evaluation instructions: 49886
 Number of AND constraints: 21349
 Number of MUL constraints: 0
+Number of distinct shifted value indices: 63034
 Length of value vec: 32768
   Constants: 377
   Inout: 264

--- a/crates/examples/snapshots/zklogin.snap
+++ b/crates/examples/snapshots/zklogin.snap
@@ -4,6 +4,7 @@ Number of gates: 462908
 Number of evaluation instructions: 550412
 Number of AND constraints: 479710
 Number of MUL constraints: 26880
+Number of distinct shifted value indices: 840245
 Length of value vec: 524288
   Constants: 710
   Inout: 302


### PR DESCRIPTION
As we’ve discovered shift reduction is not cheap. It’s cost depends on the unique number of different tuples: `value index, shift variant, shift amount`​ in the constraints. This is what `ShiftValueIndex`​ is.