### PR TITLE
[chore] hunt down EN DASH

### DIFF
--- a/crates/math/src/reed_solomon.rs
+++ b/crates/math/src/reed_solomon.rs
@@ -121,7 +121,7 @@ impl<F: BinaryField> ReedSolomonCode<F> {
 		let mut code = FieldSliceMut::from_slice(self.log_len() + log_batch_size, code)?;
 
 		let _scope = tracing::trace_span!(
-			"Reed–Solomon encode",
+			"Reed-Solomon encode",
 			log_len = self.log_len(),
 			log_batch_size = log_batch_size,
 			symbol_bits = F::N_BITS,

--- a/crates/prover/src/fri/commit.rs
+++ b/crates/prover/src/fri/commit.rs
@@ -87,7 +87,7 @@ where
 	let len = 1 << (log_elems - P::LOG_WIDTH + rs_code.log_inv_rate());
 	let mut encoded = Vec::with_capacity(len);
 
-	tracing::debug_span!("Reed–Solomon Encode").in_scope(|| {
+	tracing::debug_span!("Reed-Solomon Encode").in_scope(|| {
 		rs_code.encode_ext_batch(ntt, message, encoded.spare_capacity_mut(), log_batch_size)
 	})?;
 

--- a/crates/prover/src/fri/fold.rs
+++ b/crates/prover/src/fri/fold.rs
@@ -66,7 +66,7 @@ where
 	) -> Result<Self, Error> {
 		if len_packed_slice(committed_codeword) < 1 << params.log_len() {
 			bail!(Error::InvalidArgs(
-				"Reed–Solomon code length must match interleaved codeword length".to_string(),
+				"Reed-Solomon code length must match interleaved codeword length".to_string(),
 			));
 		}
 


### PR DESCRIPTION
In monospace fonts typographic endash — looks almost exactly like a normal
minus/hyphen -.

In JSON for perfetto it shows like \u2013, so `"Reed\u2013Solomon".

I did not remove EN DASH from the rustdoc since they are legit in there.