### PR TITLE
[circuits] Move bitcoin/block_contains_transaction circuit to examples

### DIFF
--- a/prover/examples/src/circuits/bitcoin_block_contains_transaction.rs
+++ b/prover/examples/src/circuits/bitcoin_block_contains_transaction.rs
@@ -1,12 +1,11 @@
 // Copyright 2025 Irreducible Inc.
 //! Proof that a Bitcoin block contains a certain transaction.
 
-use binius_frontend::compiler::{CircuitBuilder, Wire, circuit::WitnessFiller};
-
-use super::{
+use binius_circuits::bitcoin::{
 	double_sha256::DoubleSha256,
 	merkle_path::{MerklePath, SiblingSide},
 };
+use binius_frontend::compiler::{CircuitBuilder, Wire, circuit::WitnessFiller};
 
 /// Stores some intermediate wires of the circuit, so that they can later be populated with
 /// [`Self::populate_inner`].

--- a/prover/examples/src/circuits/mod.rs
+++ b/prover/examples/src/circuits/mod.rs
@@ -1,4 +1,5 @@
 // Copyright 2025 Irreducible Inc.
+pub mod bitcoin_block_contains_transaction;
 pub mod bitcoin_header_chain;
 pub mod blake2b;
 pub mod blake2s;

--- a/verifier/circuits/src/bitcoin/mod.rs
+++ b/verifier/circuits/src/bitcoin/mod.rs
@@ -1,7 +1,6 @@
 // Copyright 2025 Irreducible Inc.
 //! Circuits related to Bitcoin.
 
-pub mod block_contains_transaction;
 pub mod double_sha256;
 pub mod header_chain;
 pub mod merkle_path;


### PR DESCRIPTION
After discussion with @jimpo we decided to move the bitcoin/block_contains_transaction circuit to the examples crate and leave the other bitcoin related circuits in the binius-circuits crate.