### PR TITLE
[chore] Update the snapshots for ethsign, hashsign and zklogin

### DIFF
--- a/prover/examples/snapshots/ethsign.snap
+++ b/prover/examples/snapshots/ethsign.snap
@@ -4,7 +4,7 @@ Number of gates: 264568
 Number of evaluation instructions: 310572
 Number of AND constraints: 218231
 Number of MUL constraints: 25458
-Number of distinct shifted value indices: 547767
+Number of distinct shifted value indices: 505311
 Length of value vec: 262144
   Constants: 88
   Inout: 29

--- a/prover/examples/snapshots/hashsign.snap
+++ b/prover/examples/snapshots/hashsign.snap
@@ -4,7 +4,7 @@ Number of gates: 2385261
 Number of evaluation instructions: 2886906
 Number of AND constraints: 1557465
 Number of MUL constraints: 0
-Number of distinct shifted value indices: 14239376
+Number of distinct shifted value indices: 6611606
 Length of value vec: 2097152
   Constants: 376
   Inout: 20

--- a/prover/examples/snapshots/zklogin.snap
+++ b/prover/examples/snapshots/zklogin.snap
@@ -4,7 +4,7 @@ Number of gates: 486462
 Number of evaluation instructions: 550412
 Number of AND constraints: 429272
 Number of MUL constraints: 26880
-Number of distinct shifted value indices: 840245
+Number of distinct shifted value indices: 830896
 Length of value vec: 524288
   Constants: 716
   Inout: 302


### PR DESCRIPTION
These tests have been failing since the Number of distinct shifted value
indices line was introduced to stat. But CI merge queue does not reject PRs with
these failures.

https://github.com/IrreducibleOSS/binius64/pull/994

See failure:
https://github.com/IrreducibleOSS/binius64/actions/runs/17550993525/job/49843189042