### PR TITLE
[frontend] stat prints distinct shift value indices (#994)

### DIFF
--- a/prover/examples/examples/blake2b.rs
+++ b/prover/examples/examples/blake2b.rs
@@ -1,0 +1,130 @@
+// Copyright 2025 Irreducible Inc.
+
+use anyhow::{Result, ensure};
+use binius_examples::{Cli, ExampleCircuit};
+use binius_frontend::{
+	circuits::blake2b::{Blake2bCircuit, blake2b},
+	compiler::{CircuitBuilder, circuit::WitnessFiller},
+};
+use clap::Args;
+use rand::prelude::*;
+
+/// Blake2b circuit example demonstrating the Blake2b hash function implementation
+struct Blake2bExample {
+	blake2b_circuit: Blake2bCircuit,
+	max_msg_len_bytes: usize,
+}
+
+/// Circuit parameters that affect structure (compile-time configuration)
+#[derive(Args, Debug)]
+struct Params {
+	/// Maximum message length in bytes that the circuit can handle.
+	#[arg(long, default_value_t = 128)]
+	max_msg_len_bytes: usize,
+}
+
+/// Instance data for witness population (runtime values)
+#[derive(Args, Debug)]
+#[group(multiple = false)]
+struct Instance {
+	/// Length of the randomly generated message, in bytes (defaults to max_msg_len_bytes).
+	#[arg(long)]
+	message_len: Option<usize>,
+
+	/// UTF-8 string to hash (if not provided, random bytes are generated)
+	#[arg(long)]
+	message_string: Option<String>,
+}
+
+impl ExampleCircuit for Blake2bExample {
+	type Params = Params;
+	type Instance = Instance;
+
+	fn build(params: Params, builder: &mut CircuitBuilder) -> Result<Self> {
+		// Blake2b processes messages in 128-byte blocks
+		ensure!(params.max_msg_len_bytes > 0, "Message length must be positive");
+
+		let blake2b_circuit = Blake2bCircuit::new_with_length(builder, params.max_msg_len_bytes);
+
+		Ok(Self {
+			blake2b_circuit,
+			max_msg_len_bytes: params.max_msg_len_bytes,
+		})
+	}
+
+	fn populate_witness(&self, instance: Instance, w: &mut WitnessFiller) -> Result<()> {
+		// Determine the message bytes to hash and actual length
+		let (message_bytes, actual_len) = if let Some(message_string) = instance.message_string {
+			// Use provided UTF-8 string
+			let bytes = message_string.as_bytes().to_vec();
+			let actual_len = bytes.len();
+			ensure!(
+				actual_len <= self.max_msg_len_bytes,
+				"Message string length ({}) exceeds maximum ({})",
+				actual_len,
+				self.max_msg_len_bytes
+			);
+			// Pad to max length
+			let mut padded = bytes;
+			padded.resize(self.max_msg_len_bytes, 0);
+			(padded, actual_len)
+		} else {
+			// Generate random bytes
+			let mut rng = StdRng::seed_from_u64(42);
+			let len = instance.message_len.unwrap_or(self.max_msg_len_bytes);
+			ensure!(
+				len <= self.max_msg_len_bytes,
+				"Message length ({}) exceeds maximum ({})",
+				len,
+				self.max_msg_len_bytes
+			);
+
+			let mut message_bytes = vec![0u8; self.max_msg_len_bytes];
+			rng.fill_bytes(&mut message_bytes[..len]);
+			(message_bytes, len)
+		};
+
+		let expected_digest_vec = blake2b(&message_bytes[..actual_len], 64);
+		let mut expected_digest = [0u8; 64];
+		expected_digest.copy_from_slice(&expected_digest_vec);
+
+		// Populate the message and digest in the witness
+		self.blake2b_circuit
+			.populate_message(w, &message_bytes[..actual_len]);
+		self.blake2b_circuit.populate_digest(w, &expected_digest);
+
+		Ok(())
+	}
+}
+
+fn main() -> Result<()> {
+	let _tracing_guard = tracing_profile::init_tracing()?;
+
+	// Create and run the CLI
+	Cli::<Blake2bExample>::new("blake2b")
+		.about("Blake2b hash function circuit example")
+		.long_about(
+			"Blake2b cryptographic hash function circuit implementation.\n\
+			\n\
+			This example demonstrates the Blake2b hash function which produces \
+			64-byte digests. Blake2b is optimized for 64-bit platforms and is \
+			faster than Blake2s on such architectures.\n\
+			\n\
+			The circuit supports variable-length messages up to the specified \
+			maximum length. It implements the full Blake2b algorithm as \
+			specified in RFC 7693, including 12 rounds of the compression \
+			function.\n\
+			\n\
+			Examples:\n\
+			\n\
+			Hash a string:\n\
+			cargo run --release --example blake2b -- prove --message-string \"Hello, World!\"\n\
+			\n\
+			Generate and hash random data (64 bytes):\n\
+			cargo run --release --example blake2b -- prove --message-len 64\n\
+			\n\
+			Test with maximum message length:\n\
+			cargo run --release --example blake2b -- prove --max-msg-len-bytes 256 --message-len 256",
+		)
+		.run()
+}

--- a/prover/examples/snapshots/blake2b.snap
+++ b/prover/examples/snapshots/blake2b.snap
@@ -1,0 +1,13 @@
+blake2b circuit
+--
+Number of gates: 1363
+Number of evaluation instructions: 1363
+Number of AND constraints: 1064
+Number of MUL constraints: 0
+Number of distinct shifted value indices: 4121
+Length of value vec: 2048
+  Constants: 12
+  Inout: 0
+  Witness: 24
+  Internal: 1056
+  Scratch: 1451

--- a/verifier/frontend/src/circuits/blake2b/tests.rs
+++ b/verifier/frontend/src/circuits/blake2b/tests.rs
@@ -125,23 +125,29 @@ mod blake2b_tests {
 	/// Helper function to test circuit with any message
 	fn test_circuit_with_message(input: &[u8]) -> [u8; 64] {
 		let builder = CircuitBuilder::new();
-		let circuit_impl = Blake2bCircuit::new(&builder);
+		// Create circuit with exact size for the input
+		let circuit_impl = Blake2bCircuit::new_with_length(&builder, input.len());
 		let circuit = builder.build();
 		let cs = circuit.constraint_system();
 		let mut w = circuit.new_witness_filler();
 
+		// Compute expected digest using reference implementation
+		let expected_digest_vec = reference::blake2b(input, 64);
+		let mut expected_digest = [0u8; 64];
+		expected_digest.copy_from_slice(&expected_digest_vec);
+
 		// Use the new populate methods
 		circuit_impl.populate_message(&mut w, input);
-		circuit_impl.populate_length(&mut w, input);
+		circuit_impl.populate_digest(&mut w, &expected_digest);
 
 		// Populate wire witness
 		circuit.populate_wire_witness(&mut w).unwrap();
 
-		// Extract circuit output
+		// Extract circuit output (which should match the expected digest)
 		let circuit_hash: [u8; 64] = core::array::from_fn(|i| {
 			let word_idx = i / 8;
 			let byte_idx = i % 8;
-			let word_val = w[circuit_impl.output[word_idx]].0;
+			let word_val = w[circuit_impl.digest[word_idx]].0;
 			((word_val >> (byte_idx * 8)) & 0xFF) as u8
 		});
 


### PR DESCRIPTION
[frontend] stat prints distinct shift value indices (#994)

As we’ve discovered shift reduction is not cheap. It’s cost depends on the unique number of different tuples: `value index, shift variant, shift amount`​ in the constraints. This is what `ShiftValueIndex`​ is.

[chore] Separate prover and verifier crates directories (#1035)

[chore] Update the snapshots for ethsign, hashsign and zklogin (#1039)

These tests have been failing since the Number of distinct shifted value
indices line was introduced to stat. But CI merge queue does not reject PRs with
these failures.

https://github.com/IrreducibleOSS/binius64/pull/994

See failure:
https://github.com/IrreducibleOSS/binius64/actions/runs/17550993525/job/49843189042

blake2b benchmarks
rebase main after changing to proof + verifier

blake2b benchmarks; update info about the size

more rebase

restore changes after rebase