### PR TITLE
fix packed field bug in intmul

### DIFF
--- a/prover/prover/src/protocols/intmul/prove.rs
+++ b/prover/prover/src/protocols/intmul/prove.rs
@@ -393,8 +393,7 @@ where
 		// Compute the evaluation of `c_lo_0` at `a_c_eval_point`.
 		let c_lo_0_eval = {
 			let c_lo_bits = BitSelector::new(0, c_lo_exponents);
-			let p_width = P::WIDTH.min(1 << log_bits);
-
+			let p_width = P::WIDTH.min(c_lo_bits.len());
 			eq_ind_partial_eval::<P>(a_c_eval_point)
 				.as_ref()
 				.iter()


### PR DESCRIPTION
### TL;DR

Fix the calculation of `p_width` in the `intmul` protocol to use the correct length.

### What changed?

Changed the calculation of `p_width` in the `intmul` protocol's `prove.rs` file. Instead of using `1 << log_bits`, it now uses `c_lo_bits.len()` to determine the proper width for partial evaluation.

### How to test?

Run the existing test suite for the integer multiplication protocol to ensure that the proof generation still works correctly with this change.

### Why make this change?

The previous implementation was using a potentially incorrect value for `p_width` by calculating it based on `log_bits`. Using `c_lo_bits.len()` directly provides the actual length of the bit selector, which is more accurate for determining the appropriate width for the partial evaluation.