### PR TITLE
[chore] Rename option from exact-len-bytes to exact-len

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ For example, to run an example proving a SHA-512 preimage:
 ```bash
 $ RUSTFLAGS="-Ctarget-cpu=native" cargo run --release --example prove --max-len-bytes 65536 --exact-len
    Finished `release` profile [optimized + debuginfo] target(s) in 0.09s
-     Running `target/release/examples/sha512 prove --max-len-bytes 65536 --exact-len-bytes`
+     Running `target/release/examples/sha512 prove --max-len-bytes 65536 --exact-len`
 Building circuit [ 2.99s | 100.00% ]
 
 Setup [ 619.81ms | 100.00% ] { log_inv_rate = 1 }

--- a/prover/examples/src/circuits/sha256.rs
+++ b/prover/examples/src/circuits/sha256.rs
@@ -23,7 +23,7 @@ pub struct Params {
 	/// Build circuit for exact message length (makes length a compile-time constant instead of
 	/// runtime witness).
 	#[arg(long, default_value_t = false)]
-	pub exact_len_bytes: bool,
+	pub exact_len: bool,
 }
 
 #[derive(Args, Debug, Clone)]
@@ -44,7 +44,7 @@ impl ExampleCircuit for Sha256Example {
 
 	fn build(params: Params, builder: &mut CircuitBuilder) -> Result<Self> {
 		let max_len = params.max_len_bytes.div_ceil(8);
-		let len_bytes = if params.exact_len_bytes {
+		let len_bytes = if params.exact_len {
 			builder.add_constant_64(params.max_len_bytes as u64)
 		} else {
 			builder.add_witness()

--- a/prover/examples/src/circuits/sha512.rs
+++ b/prover/examples/src/circuits/sha512.rs
@@ -23,7 +23,7 @@ pub struct Params {
 	/// Build circuit for exact message length (makes length a compile-time constant instead of
 	/// runtime witness).
 	#[arg(long, default_value_t = false)]
-	pub exact_len_bytes: bool,
+	pub exact_len: bool,
 }
 
 #[derive(Args, Debug, Clone)]
@@ -44,7 +44,7 @@ impl ExampleCircuit for Sha512Example {
 
 	fn build(params: Params, builder: &mut CircuitBuilder) -> Result<Self> {
 		let max_len = params.max_len_bytes.div_ceil(8);
-		let len_bytes = if params.exact_len_bytes {
+		let len_bytes = if params.exact_len {
 			builder.add_constant_64(params.max_len_bytes as u64)
 		} else {
 			builder.add_witness()


### PR DESCRIPTION
This is a boolean option, not a valued flag.