### PR TITLE
Remove the only method which used the `UnderlierWithBitOps::BYTE_MASK_MAP` which appeared to be unused.

### DIFF
--- a/prover/prover/benches/ring_switch.rs
+++ b/prover/prover/benches/ring_switch.rs
@@ -5,33 +5,11 @@ use std::mem::size_of;
 use binius_field::{BinaryField, ExtensionField, arch::OptimalPackedB128};
 use binius_math::test_utils::random_field_buffer;
 use binius_prover::ring_switch::{
-	fold_1b_rows, fold_1b_rows_for_b128, fold_b128_elems_inplace, fold_elems_inplace,
+	fold_1b_rows_for_b128, fold_b128_elems_inplace, fold_elems_inplace,
 };
 use binius_utils::checked_arithmetics::log2_strict_usize;
 use binius_verifier::config::{B1, B128};
 use criterion::{Criterion, Throughput, criterion_group, criterion_main};
-
-fn bench_fold_1b_rows(c: &mut Criterion) {
-	let mut group = c.benchmark_group("pcs/fold_1b_rows");
-
-	type P = OptimalPackedB128;
-
-	let log_bits = log2_strict_usize(B128::N_BITS);
-	for log_len in [12, 16] {
-		const LOG_BITS_PER_BYTE: usize = 3;
-		group.throughput(Throughput::Bytes((1 << (log_len + log_bits - LOG_BITS_PER_BYTE)) as u64));
-		group.bench_function(format!("log_len={log_len}"), |b| {
-			let mut rng = rand::rng();
-
-			let mat = random_field_buffer::<P>(&mut rng, log_len);
-			let vec = random_field_buffer::<P>(&mut rng, log_len);
-
-			b.iter(|| fold_1b_rows(&mat, &vec));
-		});
-	}
-
-	group.finish();
-}
 
 fn bench_fold_1b_rows_for_b128(c: &mut Criterion) {
 	let mut group = c.benchmark_group("pcs/fold_1b_rows_for_b128");
@@ -101,7 +79,6 @@ fn bench_fold_b128_elems_inplace(c: &mut Criterion) {
 
 criterion_group!(
 	pcs,
-	bench_fold_1b_rows,
 	bench_fold_1b_rows_for_b128,
 	bench_fold_elems_inplace,
 	bench_fold_b128_elems_inplace

--- a/verifier/field/src/underlier/underlier_with_bit_ops.rs
+++ b/verifier/field/src/underlier/underlier_with_bit_ops.rs
@@ -26,23 +26,6 @@ pub trait UnderlierWithBitOps:
 	const ONE: Self;
 	const ONES: Self;
 
-	// A map from a byte to 8 values, where `i`-th value is filled with a `i`-th bit from the byte.
-	const BYTE_MASK_MAP: [[Self; 8]; 256] = const {
-		let mut map = [[Self::ZERO; 8]; 256];
-		let mut byte = 0;
-		while byte < 256 {
-			let mut bit = 0;
-			while bit < 8 {
-				if (byte & (1 << bit)) != 0 {
-					map[byte][bit] = Self::ONES;
-				}
-				bit += 1;
-			}
-			byte += 1;
-		}
-		map
-	};
-
 	/// Fill value with the given bit
 	/// `val` must be 0 or 1.
 	fn fill_with_bit(val: u8) -> Self;


### PR DESCRIPTION
### TL;DR

Remove the unused `fold_1b_rows` function and related code from the ring switch implementation.

### What changed?

- Removed the `fold_1b_rows` function from `ring_switch.rs` which was a more generic implementation
- Removed the corresponding benchmark in `ring_switch.rs`
- Removed the `BYTE_MASK_MAP` constant from `UnderlierWithBitOps` trait
- Removed the test that verified consistency between `fold_1b_rows` and `fold_1b_rows_for_b128`
- Updated documentation to reflect that `fold_1b_rows_for_b128` is now the primary implementation
- Removed unused imports

### How to test?

- Run the existing test suite to ensure all functionality still works correctly
- Run the benchmarks to verify that performance is maintained:
  ```
  cargo bench -p binius-prover --bench ring_switch
  ```

### Why make this change?

The specialized `fold_1b_rows_for_b128` function is more efficient than the generic `fold_1b_rows` implementation. Since we're only using the B128 field implementation in practice, we can remove the unused generic version to simplify the codebase and reduce maintenance overhead. This change also removes the now-unused `BYTE_MASK_MAP` constant which was only used by the removed function.