### PR TITLE
[chore] Fix README example command

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The `prover/examples/` directory contains example circuits, which you can run us
 For example, to run an example proving a SHA-512 preimage:
 
 ```bash
-$ RUSTFLAGS="-Ctarget-cpu=native" cargo run --release --example sha512 prove --max-len-bytes 65536 --exact-len-bytes
+$ RUSTFLAGS="-Ctarget-cpu=native" cargo run --release --example sha512 prove --max-len-bytes 65536 --exact-len
    Finished `release` profile [optimized + debuginfo] target(s) in 0.09s
      Running `target/release/examples/sha512 prove --max-len-bytes 65536 --exact-len`
 Building circuit [ 2.99s | 100.00% ]


### PR DESCRIPTION
The `--exact-len-bytes` flag was changned to `--exact-len` in https://github.com/IrreducibleOSS/binius64/commit/655c0d6f337b417e6e19927377d6d42a53d60136