### PR TITLE
Improve RS-Code struct

### DIFF
--- a/verifier/math/src/binary_subspace.rs
+++ b/verifier/math/src/binary_subspace.rs
@@ -10,7 +10,7 @@ use super::error::Error;
 /// The subspace is defined by a basis of elements from a binary field. The basis elements are
 /// ordered, which implies an ordering on the subspace elements.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct BinarySubspace<F: BinaryField> {
+pub struct BinarySubspace<F> {
 	basis: Vec<F>,
 }
 


### PR DESCRIPTION
- removes unnecessary trait bounds
- adds a new constructor using `DomainContext`