### PR TITLE
[frontend] show po2 stats

### DIFF
--- a/prover/examples/snapshots/blake2b.snap
+++ b/prover/examples/snapshots/blake2b.snap
@@ -1,13 +1,26 @@
 blake2b circuit
 --
-Number of gates: 1363
-Number of evaluation instructions: 1363
-Number of AND constraints: 1064
-Number of MUL constraints: 0
-Number of distinct shifted value indices: 4121
-Length of value vec: 2048
-  Constants: 12
-  Inout: 0
-  Witness: 24
-  Internal: 1056
-  Scratch: 1451
+Gates & Instructions
+├─ Number of gates: 1,363
+├─ Number of evaluation instructions: 1,363
+└─ Distinct shifted value indices: 4,121
+
+Constraints
+├─ AND constraints: 1,064 used (52.0% of 2^11)
+│  [▓▓▓▓▓░░░░░] spare: 984
+└─ MUL constraints: 0 used (0.0% of 2^0)
+   [░░░░░░░░░░] spare: 1
+
+Value Vector
+├─ Public Section: 12 used (75.0% of 2^4)
+│  [▓▓▓▓▓▓▓░░░] spare: 4
+│  ├─ Constants: 12
+│  └─ Inout: 0
+├─ Private Section: 1,080 used (53.1%)
+│  [▓▓▓▓▓░░░░░] spare: 952
+│  ├─ Witness: 24
+│  └─ Internal: 1,056
+├─ Total Committed: 1,092 used (53.3% of 2^11)
+│  [▓▓▓▓▓░░░░░] spare: 956
+└─ Scratch (uncommitted): 1,451
+

--- a/prover/examples/snapshots/blake2s.snap
+++ b/prover/examples/snapshots/blake2s.snap
@@ -1,13 +1,26 @@
 blake2s circuit
 --
-Number of gates: 2318
-Number of evaluation instructions: 2318
-Number of AND constraints: 2584
-Number of MUL constraints: 0
-Number of distinct shifted value indices: 6155
-Length of value vec: 4096
-  Constants: 14
-  Inout: 0
-  Witness: 24
-  Internal: 2576
-  Scratch: 694
+Gates & Instructions
+├─ Number of gates: 2,318
+├─ Number of evaluation instructions: 2,318
+└─ Distinct shifted value indices: 6,155
+
+Constraints
+├─ AND constraints: 2,584 used (63.1% of 2^12)
+│  [▓▓▓▓▓▓░░░░] spare: 1,512
+└─ MUL constraints: 0 used (0.0% of 2^0)
+   [░░░░░░░░░░] spare: 1
+
+Value Vector
+├─ Public Section: 14 used (87.5% of 2^4)
+│  [▓▓▓▓▓▓▓▓░░] spare: 2
+│  ├─ Constants: 14
+│  └─ Inout: 0
+├─ Private Section: 2,600 used (63.7%)
+│  [▓▓▓▓▓▓░░░░] spare: 1,480
+│  ├─ Witness: 24
+│  └─ Internal: 2,576
+├─ Total Committed: 2,614 used (63.8% of 2^12)
+│  [▓▓▓▓▓▓░░░░] spare: 1,482
+└─ Scratch (uncommitted): 694
+

--- a/prover/examples/snapshots/ethsign.snap
+++ b/prover/examples/snapshots/ethsign.snap
@@ -1,13 +1,26 @@
 ethsign circuit
 --
-Number of gates: 253204
-Number of evaluation instructions: 299208
-Number of AND constraints: 218471
-Number of MUL constraints: 25458
-Number of distinct shifted value indices: 475243
-Length of value vec: 262144
-  Constants: 88
-  Inout: 29
-  Witness: 42
-  Internal: 254064
-  Scratch: 274227
+Gates & Instructions
+├─ Number of gates: 253,204
+├─ Number of evaluation instructions: 299,208
+└─ Distinct shifted value indices: 475,243
+
+Constraints
+├─ AND constraints: 218,471 used (83.3% of 2^18)
+│  [▓▓▓▓▓▓▓▓░░] spare: 43,673
+└─ MUL constraints: 25,458 used (77.7% of 2^15)
+   [▓▓▓▓▓▓▓░░░] spare: 7,310
+
+Value Vector
+├─ Public Section: 117 used (91.4% of 2^7)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 11
+│  ├─ Constants: 88
+│  └─ Inout: 29
+├─ Private Section: 254,106 used (97.0%)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 7,910
+│  ├─ Witness: 42
+│  └─ Internal: 254,064
+├─ Total Committed: 254,223 used (97.0% of 2^18)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 7,921
+└─ Scratch (uncommitted): 274,227
+

--- a/prover/examples/snapshots/hashsign.snap
+++ b/prover/examples/snapshots/hashsign.snap
@@ -1,13 +1,26 @@
 hashsign circuit
 --
-Number of gates: 2385261
-Number of evaluation instructions: 2886906
-Number of AND constraints: 1600305
-Number of MUL constraints: 0
-Number of distinct shifted value indices: 3322922
-Length of value vec: 2097152
-  Constants: 376
-  Inout: 20
-  Witness: 14733
-  Internal: 1580865
-  Scratch: 1597599
+Gates & Instructions
+├─ Number of gates: 2,385,261
+├─ Number of evaluation instructions: 2,886,906
+└─ Distinct shifted value indices: 3,322,922
+
+Constraints
+├─ AND constraints: 1,600,305 used (76.3% of 2^21)
+│  [▓▓▓▓▓▓▓░░░] spare: 496,847
+└─ MUL constraints: 0 used (0.0% of 2^0)
+   [░░░░░░░░░░] spare: 1
+
+Value Vector
+├─ Public Section: 396 used (77.3% of 2^9)
+│  [▓▓▓▓▓▓▓░░░] spare: 116
+│  ├─ Constants: 376
+│  └─ Inout: 20
+├─ Private Section: 1,595,598 used (76.1%)
+│  [▓▓▓▓▓▓▓░░░] spare: 501,042
+│  ├─ Witness: 14,733
+│  └─ Internal: 1,580,865
+├─ Total Committed: 1,595,994 used (76.1% of 2^21)
+│  [▓▓▓▓▓▓▓░░░] spare: 501,158
+└─ Scratch (uncommitted): 1,597,599
+

--- a/prover/examples/snapshots/keccak.snap
+++ b/prover/examples/snapshots/keccak.snap
@@ -1,13 +1,26 @@
 keccak circuit
 --
-Number of gates: 27625
-Number of evaluation instructions: 27625
-Number of AND constraints: 7225
-Number of MUL constraints: 0
-Number of distinct shifted value indices: 41877
-Length of value vec: 8192
-  Constants: 23
-  Inout: 50
-  Witness: 0
-  Internal: 7200
-  Scratch: 20400
+Gates & Instructions
+├─ Number of gates: 27,625
+├─ Number of evaluation instructions: 27,625
+└─ Distinct shifted value indices: 41,877
+
+Constraints
+├─ AND constraints: 7,225 used (88.2% of 2^13)
+│  [▓▓▓▓▓▓▓▓░░] spare: 967
+└─ MUL constraints: 0 used (0.0% of 2^0)
+   [░░░░░░░░░░] spare: 1
+
+Value Vector
+├─ Public Section: 73 used (57.0% of 2^7)
+│  [▓▓▓▓▓░░░░░] spare: 55
+│  ├─ Constants: 23
+│  └─ Inout: 50
+├─ Private Section: 7,200 used (89.3%)
+│  [▓▓▓▓▓▓▓▓░░] spare: 864
+│  ├─ Witness: 0
+│  └─ Internal: 7,200
+├─ Total Committed: 7,273 used (88.8% of 2^13)
+│  [▓▓▓▓▓▓▓▓░░] spare: 919
+└─ Scratch (uncommitted): 20,400
+

--- a/prover/examples/snapshots/sha256.snap
+++ b/prover/examples/snapshots/sha256.snap
@@ -1,13 +1,26 @@
 sha256 circuit
 --
-Number of gates: 74954
-Number of evaluation instructions: 76589
-Number of AND constraints: 68881
-Number of MUL constraints: 0
-Number of distinct shifted value indices: 131539
-Length of value vec: 131072
-  Constants: 353
-  Inout: 260
-  Witness: 529
-  Internal: 67834
-  Scratch: 28071
+Gates & Instructions
+├─ Number of gates: 74,954
+├─ Number of evaluation instructions: 76,589
+└─ Distinct shifted value indices: 131,539
+
+Constraints
+├─ AND constraints: 68,881 used (52.6% of 2^17)
+│  [▓▓▓▓▓░░░░░] spare: 62,191
+└─ MUL constraints: 0 used (0.0% of 2^0)
+   [░░░░░░░░░░] spare: 1
+
+Value Vector
+├─ Public Section: 613 used (59.9% of 2^10)
+│  [▓▓▓▓▓░░░░░] spare: 411
+│  ├─ Constants: 353
+│  └─ Inout: 260
+├─ Private Section: 68,363 used (52.6%)
+│  [▓▓▓▓▓░░░░░] spare: 61,685
+│  ├─ Witness: 529
+│  └─ Internal: 67,834
+├─ Total Committed: 68,976 used (52.6% of 2^17)
+│  [▓▓▓▓▓░░░░░] spare: 62,096
+└─ Scratch (uncommitted): 28,071
+

--- a/prover/examples/snapshots/sha512.snap
+++ b/prover/examples/snapshots/sha512.snap
@@ -1,13 +1,26 @@
 sha512 circuit
 --
-Number of gates: 48779
-Number of evaluation instructions: 49886
-Number of AND constraints: 21349
-Number of MUL constraints: 0
-Number of distinct shifted value indices: 63034
-Length of value vec: 32768
-  Constants: 377
-  Inout: 264
-  Witness: 273
-  Internal: 20811
-  Scratch: 54941
+Gates & Instructions
+├─ Number of gates: 48,779
+├─ Number of evaluation instructions: 49,886
+└─ Distinct shifted value indices: 63,034
+
+Constraints
+├─ AND constraints: 21,349 used (65.2% of 2^15)
+│  [▓▓▓▓▓▓░░░░] spare: 11,419
+└─ MUL constraints: 0 used (0.0% of 2^0)
+   [░░░░░░░░░░] spare: 1
+
+Value Vector
+├─ Public Section: 641 used (62.6% of 2^10)
+│  [▓▓▓▓▓▓░░░░] spare: 383
+│  ├─ Constants: 377
+│  └─ Inout: 264
+├─ Private Section: 21,084 used (66.4%)
+│  [▓▓▓▓▓▓░░░░] spare: 10,660
+│  ├─ Witness: 273
+│  └─ Internal: 20,811
+├─ Total Committed: 21,725 used (66.3% of 2^15)
+│  [▓▓▓▓▓▓░░░░] spare: 11,043
+└─ Scratch (uncommitted): 54,941
+

--- a/verifier/frontend/src/stat.rs
+++ b/verifier/frontend/src/stat.rs
@@ -46,45 +46,220 @@ pub struct CircuitStat {
 	///
 	/// Those values are not committed, those only exist during witness generation.
 	pub n_scratch: usize,
+	/// Allocated size for AND constraints (power of 2)
+	pub and_allocated: usize,
+	/// Allocated size for MUL constraints (power of 2)
+	pub mul_allocated: usize,
+	/// Allocated size for public section (power of 2)
+	pub public_allocated: usize,
+	/// Allocated size for private section.
+	///
+	/// This is the space available for witness and internal values. Note that unlike
+	/// `public_allocated` and the total committed length, this is NOT necessarily a
+	/// power of two. It's simply the difference between the total committed length
+	/// (power of 2) and the public section size (power of 2). For example, if total
+	/// is 8192 and public is 128, private is 8064.
+	pub private_allocated: usize,
 }
 
 impl CircuitStat {
 	/// Creates a new `CircuitStat` instance by collecting statistics from the given circuit.
 	pub fn collect(circuit: &Circuit) -> Self {
-		let cs = circuit.constraint_system();
+		// Clone the constraint system so we can prepare it
+		let mut cs = circuit.constraint_system().clone();
+
+		// Store original counts before padding
+		let n_and_constraints = cs.n_and_constraints();
+		let n_mul_constraints = cs.n_mul_constraints();
+		let distinct_indices = distinct_shifted_value_indices(&cs);
+
+		// validate_and_prepare will pad constraints to power of 2
+		cs.validate_and_prepare()
+			.expect("constraint system should be valid");
+
+		// Now we have the actual allocated sizes after padding
+		let and_allocated = cs.n_and_constraints();
+		let mul_allocated = cs.n_mul_constraints();
+
+		// The public section size is already determined by the layout
+		let n_const = cs.value_vec_layout.n_const;
+		let n_inout = cs.value_vec_layout.n_inout;
+		let public_allocated = cs.value_vec_layout.offset_witness;
+		let total_allocated = cs.value_vec_layout.committed_total_len;
+		let private_allocated = total_allocated - public_allocated;
+
 		Self {
 			n_gates: circuit.n_gates(),
 			n_eval_insn: circuit.n_eval_insn(),
-			n_and_constraints: cs.n_and_constraints(),
-			n_mul_constraints: cs.n_mul_constraints(),
-			value_vec_len: cs.value_vec_layout.committed_total_len,
-			distinct_shifted_value_indices: distinct_shifted_value_indices(cs),
-			n_const: cs.value_vec_layout.n_const,
-			n_inout: cs.value_vec_layout.n_inout,
+			n_and_constraints,
+			n_mul_constraints,
+			value_vec_len: total_allocated,
+			distinct_shifted_value_indices: distinct_indices,
+			n_const,
+			n_inout,
 			n_witness: cs.value_vec_layout.n_witness,
 			n_internal: cs.value_vec_layout.n_internal,
 			n_scratch: cs.value_vec_layout.n_scratch,
+			and_allocated,
+			mul_allocated,
+			public_allocated,
+			private_allocated,
 		}
 	}
 }
 
 impl fmt::Display for CircuitStat {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		writeln!(f, "Number of gates: {}", self.n_gates)?;
-		writeln!(f, "Number of evaluation instructions: {}", self.n_eval_insn)?;
-		writeln!(f, "Number of AND constraints: {}", self.n_and_constraints)?;
-		writeln!(f, "Number of MUL constraints: {}", self.n_mul_constraints)?;
+		// Helper to format numbers with commas
+		fn fmt_num(n: usize) -> String {
+			let s = n.to_string();
+			let mut result = String::new();
+			for (i, c) in s.chars().rev().enumerate() {
+				if i > 0 && i % 3 == 0 {
+					result.push(',');
+				}
+				result.push(c);
+			}
+			result.chars().rev().collect()
+		}
+
+		// Helper to create a simple progress bar
+		fn progress_bar(used: usize, total: usize) -> String {
+			let percent = (used as f64 / total as f64 * 100.0) as usize;
+			let filled = percent / 10;
+			let mut bar = String::from("[");
+			for i in 0..10 {
+				if i < filled {
+					bar.push('▓');
+				} else {
+					bar.push('░');
+				}
+			}
+			bar.push(']');
+			bar
+		}
+
+		// Helper to get log2 of a power of 2
+		fn log2(n: usize) -> u32 {
+			n.trailing_zeros()
+		}
+
+		// Use pre-calculated values
+		let public_used = self.n_const + self.n_inout;
+		let private_used = self.n_witness + self.n_internal;
+		let total_used = public_used + private_used;
+
+		// Gates & Instructions
+		writeln!(f, "Gates & Instructions")?;
+		writeln!(f, "├─ Number of gates: {}", fmt_num(self.n_gates))?;
+		writeln!(f, "├─ Number of evaluation instructions: {}", fmt_num(self.n_eval_insn))?;
 		writeln!(
 			f,
-			"Number of distinct shifted value indices: {}",
-			self.distinct_shifted_value_indices
+			"└─ Distinct shifted value indices: {}",
+			fmt_num(self.distinct_shifted_value_indices)
 		)?;
-		writeln!(f, "Length of value vec: {}", self.value_vec_len)?;
-		writeln!(f, "  Constants: {}", self.n_const)?;
-		writeln!(f, "  Inout: {}", self.n_inout)?;
-		writeln!(f, "  Witness: {}", self.n_witness)?;
-		writeln!(f, "  Internal: {}", self.n_internal)?;
-		writeln!(f, "  Scratch: {}", self.n_scratch)?;
+		writeln!(f)?;
+
+		// Constraints
+		writeln!(f, "Constraints")?;
+		let and_percent = self.n_and_constraints as f64 / self.and_allocated as f64 * 100.0;
+		let and_spare = self.and_allocated - self.n_and_constraints;
+		writeln!(
+			f,
+			"├─ AND constraints: {} used ({:.1}% of 2^{})",
+			fmt_num(self.n_and_constraints),
+			and_percent,
+			log2(self.and_allocated)
+		)?;
+		writeln!(
+			f,
+			"│  {} spare: {}",
+			progress_bar(self.n_and_constraints, self.and_allocated),
+			fmt_num(and_spare)
+		)?;
+
+		let mul_percent = if self.mul_allocated > 0 {
+			self.n_mul_constraints as f64 / self.mul_allocated as f64 * 100.0
+		} else {
+			0.0
+		};
+		let mul_spare = self.mul_allocated - self.n_mul_constraints;
+		writeln!(
+			f,
+			"└─ MUL constraints: {} used ({:.1}% of 2^{})",
+			fmt_num(self.n_mul_constraints),
+			mul_percent,
+			log2(self.mul_allocated)
+		)?;
+		writeln!(
+			f,
+			"   {} spare: {}",
+			progress_bar(self.n_mul_constraints, self.mul_allocated),
+			fmt_num(mul_spare)
+		)?;
+		writeln!(f)?;
+
+		// Value Vector
+		writeln!(f, "Value Vector")?;
+
+		// Public Section
+		let public_percent = public_used as f64 / self.public_allocated as f64 * 100.0;
+		let public_spare = self.public_allocated - public_used;
+		writeln!(
+			f,
+			"├─ Public Section: {} used ({:.1}% of 2^{})",
+			fmt_num(public_used),
+			public_percent,
+			log2(self.public_allocated)
+		)?;
+		writeln!(
+			f,
+			"│  {} spare: {}",
+			progress_bar(public_used, self.public_allocated),
+			fmt_num(public_spare)
+		)?;
+		writeln!(f, "│  ├─ Constants: {}", fmt_num(self.n_const))?;
+		writeln!(f, "│  └─ Inout: {}", fmt_num(self.n_inout))?;
+
+		// Private Section (no allocated size shown since it's not a power of 2)
+		let private_percent = private_used as f64 / self.private_allocated as f64 * 100.0;
+		let private_spare = self.private_allocated - private_used;
+		writeln!(
+			f,
+			"├─ Private Section: {} used ({:.1}%)",
+			fmt_num(private_used),
+			private_percent
+		)?;
+		writeln!(
+			f,
+			"│  {} spare: {}",
+			progress_bar(private_used, self.private_allocated),
+			fmt_num(private_spare)
+		)?;
+		writeln!(f, "│  ├─ Witness: {}", fmt_num(self.n_witness))?;
+		writeln!(f, "│  └─ Internal: {}", fmt_num(self.n_internal))?;
+
+		// Total Committed
+		let total_percent = total_used as f64 / self.value_vec_len as f64 * 100.0;
+		let total_spare = self.value_vec_len - total_used;
+		writeln!(
+			f,
+			"├─ Total Committed: {} used ({:.1}% of 2^{})",
+			fmt_num(total_used),
+			total_percent,
+			log2(self.value_vec_len)
+		)?;
+		writeln!(
+			f,
+			"│  {} spare: {}",
+			progress_bar(total_used, self.value_vec_len),
+			fmt_num(total_spare)
+		)?;
+
+		// Scratch
+		writeln!(f, "└─ Scratch (uncommitted): {}", fmt_num(self.n_scratch))?;
+		writeln!(f)?;
+
 		Ok(())
 	}
 }


### PR DESCRIPTION
This also changes the presentation format to something like this:

```
Gates & Instructions
├─ Number of gates: 2,385,261
├─ Number of evaluation instructions: 2,886,906
└─ Distinct shifted value indices: 3,322,922
Constraints
├─ AND constraints: 1,600,305 used (76.3% of 2^21)
│  [▓▓▓▓▓▓▓░░░] spare: 496,847
└─ MUL constraints: 0 used (0.0% of 2^0)
   [░░░░░░░░░░] spare: 1
Value Vector
├─ Public Section: 396 used (77.3% of 2^9)
│  [▓▓▓▓▓▓▓░░░] spare: 116
│  ├─ Constants: 376
│  └─ Inout: 20
├─ Private Section: 1,595,598 used (76.1%)
│  [▓▓▓▓▓▓▓░░░] spare: 501,042
│  ├─ Witness: 14,733
│  └─ Internal: 1,580,865
├─ Total Committed: 1,595,994 used (76.1% of 2^21)
│  [▓▓▓▓▓▓▓░░░] spare: 501,158
└─ Scratch (uncommitted): 1,597,599
```

There were other designs such as one below, but I did not really like the idea of complexity of adding the TTY detection and similiar stuff to frontend, but is possible to go that direction if there is any desire.

```
  ╔════════════════════════════════════════════════════════════════════════════╗
  ║                         CONSTRAINT SYSTEM STATISTICS                        ║
  ╚════════════════════════════════════════════════════════════════════════════╝

  Gates & Instructions
  ├─ Number of gates:                2,385,261
  └─ Number of evaluation instructions: 2,886,906

  ╔═══════════════════╤════════════╤═══════════╤══════════════════════╤════════╗
  ║ Constraint Type   │ Used       │ Allocated │ Utilization          │ Spare  ║
  ╠═══════════════════╪════════════╪═══════════╪══════════════════════╪════════╣
  ║ AND constraints   │ 1,600,305  │ 2,097,152 │ [▓▓▓▓▓▓▓▓░░] 76.3%   │496,847 ║
  ║ MUL constraints   │         0  │         8 │ [░░░░░░░░░░]  0.0%   │      8 ║
  ╚═══════════════════╧════════════╧═══════════╧══════════════════════╧════════╝
  Note: Next power-of-2 levels: AND @ 4,194,304 | MUL @ 16

  ╔═══════════════════╤════════════╤═══════════╤══════════════════════╤════════╗
  ║ Value Vec Section │ Used       │ Allocated │ Utilization          │ Spare  ║
  ╠═══════════════════╪════════════╪═══════════╪══════════════════════╪════════╣
  ║ Public Section    │       396  │       512 │ [▓▓▓▓▓▓▓▓░░] 77.3%   │    116 ║
  ║ ├─ Constants      │       376  │           │                      │        ║
  ║ └─ Inout          │        20  │           │                      │        ║
  ║                   │            │           │                      │        ║
  ║ Private Section   │ 1,595,598  │ 2,096,640 │ [▓▓▓▓▓▓▓▓░░] 76.1%   │501,042 ║
  ║ ├─ Witness        │    14,733  │           │                      │        ║
  ║ └─ Internal       │ 1,580,865  │           │                      │        ║
  ╠═══════════════════╪════════════╪═══════════╪══════════════════════╪════════╣
  ║ Total Committed   │ 1,595,994  │ 2,097,152 │ [▓▓▓▓▓▓▓▓░░] 76.1%   │501,158 ║
  ║ Scratch (uncommit)│ 1,597,599  │       n/a │                      │        ║
  ╚═══════════════════╧════════════╧═══════════╧══════════════════════╧════════╝

  Performance Metrics
  ├─ Distinct shifted value indices: 3,322,922
  └─ Estimated proving cost: ~2,516,692 units
     (AND: 2,097,152 × 1.0 + MUL: 8 × 3.5 + Commit: 2,097,152 × 0.2)
```

