### PR TITLE
Implement optimized SIMD version of build_g_triplet

### DIFF
--- a/prover/prover/src/protocols/shift/prove.rs
+++ b/prover/prover/src/protocols/shift/prove.rs
@@ -101,7 +101,7 @@ impl<F: Field> PreparedOperatorData<F> {
 ///
 /// # Requirements
 /// - `words` must have power-of-2 length for efficient multilinear operations
-pub fn prove<F, P: PackedField<Scalar = F>, C: Challenger>(
+pub fn prove<F, P, C: Challenger>(
 	log_public_words: usize,
 	key_collection: &KeyCollection,
 	words: &[Word],
@@ -111,6 +111,7 @@ pub fn prove<F, P: PackedField<Scalar = F>, C: Challenger>(
 ) -> Result<SumcheckOutput<F>, Error>
 where
 	F: BinaryField + From<AESTowerField8b> + WithUnderlier<Underlier: UnderlierWithBitOps>,
+	P: PackedField<Scalar = F> + WithUnderlier<Underlier: UnderlierWithBitOps>,
 {
 	// Sample lambdas, one for each operator.
 	let bitand_lambda = transcript.sample();

--- a/prover/prover/src/prove.rs
+++ b/prover/prover/src/prove.rs
@@ -9,6 +9,7 @@ use binius_core::{
 };
 use binius_field::{
 	AESTowerField8b as B8, BinaryField, PackedAESBinaryField16x8b, PackedExtension, PackedField,
+	UnderlierWithBitOps, WithUnderlier,
 };
 use binius_math::{
 	BinarySubspace, FieldBuffer,
@@ -66,7 +67,10 @@ where
 impl<P, MerkleHash, ParallelMerkleCompress, ParallelMerkleHasher>
 	Prover<P, ParallelMerkleCompress, ParallelMerkleHasher>
 where
-	P: PackedField<Scalar = B128> + PackedExtension<B128> + PackedExtension<B1>,
+	P: PackedField<Scalar = B128>
+		+ PackedExtension<B128>
+		+ PackedExtension<B1>
+		+ WithUnderlier<Underlier: UnderlierWithBitOps>,
 	MerkleHash: Digest + BlockSizeUser + FixedOutputReset,
 	ParallelMerkleHasher: ParallelDigest<Digest = MerkleHash>,
 	ParallelMerkleCompress: ParallelPseudoCompression<Output<MerkleHash>, 2>,


### PR DESCRIPTION
### TL;DR

Optimize the shift protocol's phase 1 prover by leveraging packed field operations for better performance. On my laptop with AVX2 support this reduces the `build_g_triplets` time by 40% and for the `hashsign` the overall proving time is reduced by 10%.

This comes at the cost of restricting `P::WIDTH` to not exceed 8, but in real life our packed 128b fields never have bigger width than 4

### What changed?

- Modified `prove_phase_1` and `prove` function signatures to separate the `PackedField` trait bound from the function declaration and move it to the `where` clause
- Added `WithUnderlier<Underlier: UnderlierWithBitOps>` constraint to the packed field type
- Removed the static `BITS_MAP` lookup table and replaced it with a more efficient approach using packed field operations
- Optimized the `build_g_triplet` function to process multiple bits at once using packed fields
- Changed the accumulator size to be dependent on the packed field width
- Created a packed masks map to efficiently handle bit operations
- Updated the `build_multilinear_triplet` function to work with packed fields directly

### How to test?

- Run the existing test suite to ensure correctness is maintained
- Benchmark the shift protocol performance before and after the changes
- Verify that the optimized implementation produces the same results as the original one

### Why make this change?

This optimization significantly improves the performance of the shift protocol's phase 1 by:
1. Reducing memory usage by processing multiple bits at once using packed fields
2. Eliminating the need for the static lookup table which improves cache efficiency
3. Taking advantage of SIMD-like operations through the packed field implementation
4. Reducing the number of operations needed by processing bits in batches

The changes maintain the same functionality while making better use of the underlying hardware capabilities.