### PR TITLE
implement vision parallel compression

### DIFF
--- a/prover/prover/src/hash/vision_4/compression.rs
+++ b/prover/prover/src/hash/vision_4/compression.rs
@@ -1,0 +1,241 @@
+// Copyright 2025 Irreducible Inc.
+
+use std::{array, fmt::Debug, mem::MaybeUninit};
+
+use binius_field::{BinaryField128bGhash as Ghash, Field};
+use binius_utils::{
+	DeserializeBytes, SerializeBytes,
+	rayon::{
+		iter::{IndexedParallelIterator, ParallelIterator},
+		slice::{ParallelSlice, ParallelSliceMut},
+	},
+};
+use binius_verifier::hash::vision_4::{
+	compression::VisionCompression, constants::M, digest::VisionHasherDigest,
+};
+use digest::Output;
+
+use super::{
+	super::parallel_compression::ParallelPseudoCompression, parallel::parallel_permutation,
+};
+
+// The number of parallel compressions N must be a power of 2.
+// The amortization of batch inversion grows with the batch size
+// and thus with N. Heuristically 128 is the largest N before
+// performance degrades.
+const N: usize = 128;
+const MN: usize = N * M;
+
+/// Parallel Vision compression with N parallel compressions using rayon.
+///
+/// Processes N compression pairs simultaneously using parallel Vision permutation
+/// and multithreading for optimal performance.
+#[derive(Clone, Debug, Default)]
+pub struct VisionParallelCompression {
+	compression: VisionCompression,
+}
+
+impl VisionParallelCompression {
+	pub fn new() -> Self {
+		Self::default()
+	}
+}
+
+impl ParallelPseudoCompression<Output<VisionHasherDigest>, 2> for VisionParallelCompression {
+	type Compression = VisionCompression;
+
+	fn compression(&self) -> &Self::Compression {
+		&self.compression
+	}
+
+	// If we add another implementation of `ParallelPseudoCompression`, it makes sense to add the
+	// compression-equivalent of `MultiDigest` and `ParallelMultidigestImpl` to avoid
+	// duplicating the logic below of breaking into chunks of N and handling remainders.
+	#[tracing::instrument(
+		"VisionParallelCompression::parallel_compress",
+		skip_all,
+		level = "debug"
+	)]
+	fn parallel_compress(
+		&self,
+		inputs: &[Output<VisionHasherDigest>],
+		out: &mut [MaybeUninit<Output<VisionHasherDigest>>],
+	) {
+		assert_eq!(inputs.len(), 2 * out.len(), "Input length must be 2 * output length");
+
+		inputs
+			.par_chunks_exact(N * 2)
+			.zip(out.par_chunks_exact_mut(N))
+			.for_each_with([Ghash::ZERO; 2 * MN], |scratchpad, (input_chunk, output_chunk)| {
+				self.compress_batch_parallel(input_chunk, output_chunk, scratchpad);
+			});
+
+		// Handle remaining pairs using batched processing
+		let remainder_inputs = inputs.chunks_exact(N * 2).remainder();
+		let remainder_outputs = out.chunks_exact_mut(N).into_remainder();
+
+		if !remainder_outputs.is_empty() {
+			// Use stack-allocated arrays for remainder handling
+			let mut padded_inputs = [Output::<VisionHasherDigest>::default(); N * 2];
+			let mut padded_outputs = [MaybeUninit::uninit(); N];
+
+			// Copy remainder inputs
+			padded_inputs[..remainder_inputs.len()].copy_from_slice(remainder_inputs);
+
+			// Process full batch (including padding)
+			let mut scratchpad = [Ghash::ZERO; 2 * MN];
+			self.compress_batch_parallel(&padded_inputs, &mut padded_outputs, &mut scratchpad);
+
+			// Copy only the actual results back
+			for (output, padded) in remainder_outputs.iter_mut().zip(padded_outputs) {
+				// Safety: `compress_batch_parallel` guarantees to initialize `padded_outputs`
+				output.write(unsafe { padded.assume_init() });
+			}
+		}
+	}
+}
+
+impl VisionParallelCompression {
+	/// Compress exactly N pairs using parallel permutation.
+	#[tracing::instrument(
+		"VisionParallelCompression::compress_batch_parallel",
+		skip_all,
+		level = "debug"
+	)]
+	#[inline]
+	fn compress_batch_parallel(
+		&self,
+		inputs: &[Output<VisionHasherDigest>],
+		out: &mut [MaybeUninit<Output<VisionHasherDigest>>],
+		scratchpad: &mut [Ghash],
+	) {
+		assert_eq!(out.len(), N, "Must process exactly {N} pairs");
+		assert_eq!(inputs.len(), 2 * N, "Must have 2*N inputs");
+
+		// Step 1: Deserialize inputs into flattened state array
+		let mut states = [Ghash::ZERO; MN];
+		for i in 0..N {
+			let input0 = &inputs[i * 2];
+			let input1 = &inputs[i * 2 + 1];
+
+			// Deserialize each 32-byte input into 2 Ghash elements
+			states[i * M] = Ghash::deserialize(&input0[0..16]).expect("16 bytes fits in Ghash");
+			states[i * M + 1] =
+				Ghash::deserialize(&input0[16..32]).expect("16 bytes fits in Ghash");
+			states[i * M + 2] = Ghash::deserialize(&input1[0..16]).expect("16 bytes fits in Ghash");
+			states[i * M + 3] =
+				Ghash::deserialize(&input1[16..32]).expect("16 bytes fits in Ghash");
+		}
+
+		// Step 2: Copy original first 2 elements for each state
+		let originals: [_; N] = array::from_fn(|i| (states[i * M], states[i * M + 1]));
+
+		// Step 3: Apply parallel permutation to all states
+		parallel_permutation::<N, MN>(&mut states, scratchpad);
+
+		// Step 4: Add original elements back and serialize outputs
+		for i in 0..N {
+			states[i * M] += originals[i].0;
+			states[i * M + 1] += originals[i].1;
+
+			let mut output = Output::<VisionHasherDigest>::default();
+			let (left, right) = output.as_mut_slice().split_at_mut(16);
+			states[i * M].serialize(left).expect("fits in 16 bytes");
+			states[i * M + 1]
+				.serialize(right)
+				.expect("fits in 16 bytes");
+			out[i].write(output);
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use std::array;
+
+	use binius_verifier::hash::PseudoCompressionFunction;
+	use digest::Digest;
+
+	use super::*;
+
+	#[test]
+	fn test_parallel_vs_sequential_simple() {
+		let parallel = VisionParallelCompression::default();
+		let sequential = &parallel.compression;
+
+		// Create test inputs (4 inputs = 2 pairs)
+		let inputs = [
+			VisionHasherDigest::new().finalize(), // input 0 (pair 0, element 0)
+			{
+				let mut hasher = VisionHasherDigest::new();
+				hasher.update(b"first");
+				hasher.finalize()
+			}, // input 1 (pair 0, element 1)
+			{
+				let mut hasher = VisionHasherDigest::new();
+				hasher.update(b"second");
+				hasher.finalize()
+			}, // input 2 (pair 1, element 0)
+			{
+				let mut hasher = VisionHasherDigest::new();
+				hasher.update(b"third");
+				hasher.finalize()
+			}, // input 3 (pair 1, element 1)
+		];
+
+		// Compute expected results sequentially
+		let sequential_results = [
+			sequential.compress([inputs[0], inputs[1]]),
+			sequential.compress([inputs[2], inputs[3]]),
+		];
+
+		// Compute parallel results
+		let mut parallel_outputs = [MaybeUninit::uninit(); 2];
+		parallel.parallel_compress(&inputs, &mut parallel_outputs);
+		let parallel_results: [_; 2] =
+			array::from_fn(|i| unsafe { parallel_outputs[i].assume_init() });
+
+		// Compare
+		assert_eq!(sequential_results, parallel_results);
+	}
+
+	#[test]
+	fn test_parallel_compress_large_batch() {
+		use rand::{Rng, SeedableRng, rngs::StdRng};
+
+		let parallel = VisionParallelCompression::default();
+		let mut rng = StdRng::seed_from_u64(0);
+
+		// Test 300 pairs (600 inputs) to exercise batch processing (N=128) + remainder handling
+		const NUM_PAIRS: usize = 300;
+
+		// Generate test inputs
+		let inputs: Vec<_> = (0..NUM_PAIRS * 2)
+			.map(|i| {
+				let mut hasher = VisionHasherDigest::new();
+				hasher.update(i.to_le_bytes());
+				hasher.update(rng.random::<[u8; 32]>());
+				hasher.finalize()
+			})
+			.collect();
+
+		// Compute expected results sequentially
+		let sequential_results: Vec<_> = (0..NUM_PAIRS)
+			.map(|i| {
+				parallel
+					.compression
+					.compress([inputs[i * 2], inputs[i * 2 + 1]])
+			})
+			.collect();
+
+		// Compute parallel results
+		let mut parallel_outputs = vec![MaybeUninit::uninit(); NUM_PAIRS];
+		parallel.parallel_compress(&inputs, &mut parallel_outputs);
+		let parallel_results: Vec<_> = parallel_outputs
+			.into_iter()
+			.map(|out| unsafe { out.assume_init() })
+			.collect();
+
+		assert_eq!(sequential_results, parallel_results);
+	}
+}

--- a/prover/prover/src/hash/vision_4/mod.rs
+++ b/prover/prover/src/hash/vision_4/mod.rs
@@ -1,4 +1,5 @@
 // Copyright 2025 Irreducible Inc.
 
+pub mod compression;
 pub mod parallel;
 pub mod single;

--- a/verifier/verifier/src/hash/vision_4/compression.rs
+++ b/verifier/verifier/src/hash/vision_4/compression.rs
@@ -1,0 +1,55 @@
+// Copyright 2025 Irreducible Inc.
+
+use binius_field::BinaryField128bGhash as Ghash;
+use binius_utils::{DeserializeBytes, SerializeBytes};
+use digest::Output;
+
+use super::{constants::M, permutation::permutation};
+use crate::hash::{
+	CompressionFunction, PseudoCompressionFunction, vision_4::digest::VisionHasherDigest,
+};
+
+/// Vision pseudo-compression function for 2-to-1 compression.
+///
+/// Uses the standard collision-resistant construction: `h(x) = Trunc(p(x) ⊕ x)`
+/// where `p` is the Vision permutation. The inputs are combined, passed through
+/// the permutation, then the original input state is added back before truncating
+/// to the output size. This is the
+/// [Matyas–Meyer–Oseas](en.wikipedia.org/wiki/One-way_compression_function#Matyas–Meyer–Oseas) (or
+/// MMO) compression function construction.
+#[derive(Clone, Debug, Default)]
+pub struct VisionCompression;
+
+impl PseudoCompressionFunction<Output<VisionHasherDigest>, 2> for VisionCompression {
+	fn compress(&self, input: [Output<VisionHasherDigest>; 2]) -> Output<VisionHasherDigest> {
+		// Step 1: Deserialize each 32-byte input into 2 Ghash elements
+		let mut state: [Ghash; M] = [
+			Ghash::deserialize(&input[0][0..16]).expect("16 bytes fits in Ghash"),
+			Ghash::deserialize(&input[0][16..32]).expect("16 bytes fits in Ghash"),
+			Ghash::deserialize(&input[1][0..16]).expect("16 bytes fits in Ghash"),
+			Ghash::deserialize(&input[1][16..32]).expect("16 bytes fits in Ghash"),
+		];
+
+		// Step 2: Copy original first 2 state elements
+		let original_first = state[0];
+		let original_second = state[1];
+
+		// Step 3: Apply Vision permutation
+		permutation(&mut state);
+
+		// Step 4: Add original first 2 elements to permuted result
+		state[0] += original_first;
+		state[1] += original_second;
+
+		// Step 5: Serialize first 2 elements (left half) back to 32 bytes
+		let mut output = Output::<VisionHasherDigest>::default();
+		let (left, right) = output.as_mut_slice().split_at_mut(16);
+		state[0].serialize(left).expect("fits in 16 bytes");
+		state[1].serialize(right).expect("fits in 16 bytes");
+		// Note: state[2] and state[3] are discarded (right half truncated)
+
+		output
+	}
+}
+
+impl CompressionFunction<Output<VisionHasherDigest>, 2> for VisionCompression {}

--- a/verifier/verifier/src/hash/vision_4/mod.rs
+++ b/verifier/verifier/src/hash/vision_4/mod.rs
@@ -1,5 +1,6 @@
 // Copyright 2025 Irreducible Inc.
 
+pub mod compression;
 pub mod constants;
 pub mod digest;
 mod linear_tables;


### PR DESCRIPTION
# Add Vision-4 Compression Function Implementation

I’m re-writing this in a new stack due to new repo structure, too hard to rebase.

### TL;DR

Implement the Vision-4 compression function for both sequential and parallel execution.

### What changed?

- Added `VisionCompression` in the verifier crate that implements the Matyas–Meyer–Oseas (MMO) compression function construction for Vision-4
- Implemented `VisionParallelCompression` in the prover crate that processes 128 compression pairs simultaneously using parallel permutation and multithreading
- Added unit tests to verify that parallel compression produces the same results as sequential compression
- Updated module exports to expose the new compression functionality

### How to test?

Run the unit tests in the prover crate:

```
cargo test -p prover --lib hash::vision_4::compression::tests::test_parallel_vs_sequential
```

This test verifies that the parallel implementation produces identical results to the sequential implementation.

### Why make this change?

The Vision-4 hash function requires an efficient compression function to combine pairs of hash digests. The parallel implementation significantly improves performance by processing multiple compression operations simultaneously, which is critical for the prover's performance when handling large Merkle trees and other hash-intensive operations.