### PR TITLE
Fix serialization roundtrip for the case when n_scratch is non-zero

### DIFF
--- a/verifier/core/src/error.rs
+++ b/verifier/core/src/error.rs
@@ -15,7 +15,7 @@ pub enum ConstraintSystemError {
 		"the public input segment must be at least {MIN_WORDS_PER_SEGMENT} words, got: {pub_input_size}"
 	)]
 	PublicInputTooShort { pub_input_size: usize },
-	#[error("the data length doesn't match layout")]
+	#[error("the data length doesn't match layout. Expected: {expected}, Actual: {actual}")]
 	ValueVecLenMismatch { expected: usize, actual: usize },
 	#[error(
 		"{constraint_type} #{constraint_index} uses non canonical shift in its {operand_name} operand"


### PR DESCRIPTION
### TL;DR

Fix ValueVec initialization to properly handle scratch space and improve error reporting.

### What changed?

- Fixed `ValueVec::new_from_data` to correctly validate committed length before merging public and private data
- Added proper scratch space initialization by reserving the full length and zero-filling the scratch area
- Fixed `ValueVec::non_public()` to only return committed values, excluding scratch space
- Added a comprehensive test case to verify ValueVec reconstruction with scratch space
- Improved the error message for ValueVecLenMismatch to include expected and actual values

### How to test?

Run the new test case `test_roundtrip_cs_and_witnesses_reconstruct_valuevec_with_scratch` which verifies:
- Correct serialization and deserialization of constraint systems with scratch space
- Proper reconstruction of ValueVec from public and non-public parts
- Zero-initialization of scratch space in reconstructed ValueVec

### Why make this change?

The previous implementation had issues with scratch space handling during ValueVec initialization and reconstruction. This could lead to incorrect behavior when serializing and deserializing constraint systems with scratch space. The fix ensures that scratch space is properly initialized and that the non-public accessor correctly excludes scratch space, improving the robustness of the constraint system implementation.