### PR TITLE
[fri] split FRI commit() from FRI new()

### DIFF
--- a/prover/prover/src/pcs.rs
+++ b/prover/prover/src/pcs.rs
@@ -70,12 +70,10 @@ where
 		P: PackedField<Scalar = B128>,
 		Data: Deref<Target = [P]>,
 	{
-		FRIProver::write_initial_commitment(
-			self.fri_params,
-			packed_multilin.as_ref(),
-			self.ntt,
-			transcript,
-		)
+		let mut fri_prover = FRIProver::new(self.fri_params, self.ntt);
+		fri_prover.write_initial_commitment(packed_multilin.as_ref(), transcript);
+
+		fri_prover
 	}
 
 	/// Prove the committed polynomial's evaluation at a given point.
@@ -242,11 +240,8 @@ mod test {
 
 		let mut verifier_transcript = prover_transcript.into_verifier();
 
-		let fri_verifier = FRIVerifier::read_initial_commitment(
-			&fri_params,
-			&domain_context,
-			&mut verifier_transcript.message(),
-		);
+		let mut fri_verifier = FRIVerifier::new(&fri_params, &domain_context);
+		fri_verifier.read_initial_commitment(&mut verifier_transcript.message());
 
 		verify(&mut verifier_transcript, evaluation_claim, &evaluation_point, fri_verifier)?;
 

--- a/prover/prover/src/protocols/basefold/prover.rs
+++ b/prover/prover/src/protocols/basefold/prover.rs
@@ -195,10 +195,9 @@ mod test {
 
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 
-		let fri_prover = FRIProver::write_initial_commitment(
-			&fri_params,
+		let mut fri_prover = FRIProver::new(&fri_params, &ntt);
+		fri_prover.write_initial_commitment(
 			multilinear.to_ref().as_ref(),
-			&ntt,
 			&mut prover_transcript.message(),
 		);
 
@@ -208,11 +207,8 @@ mod test {
 
 		let mut verifier_transcript = prover_transcript.into_verifier();
 
-		let fri_verifier = FRIVerifier::read_initial_commitment(
-			&fri_params,
-			&domain_context,
-			&mut verifier_transcript.message(),
-		);
+		let mut fri_verifier = FRIVerifier::new(&fri_params, &domain_context);
+		fri_verifier.read_initial_commitment(&mut verifier_transcript.message());
 
 		let basefold::ReducedOutput {
 			final_fri_value,

--- a/verifier/verifier/src/verify.rs
+++ b/verifier/verifier/src/verify.rs
@@ -137,11 +137,8 @@ where
 		// Receive the trace commitment.
 		let subspace = self.fri_params.rs_code().subspace();
 		let domain_context = GenericOnTheFly::generate_from_subspace(subspace);
-		let fri_verifier = FRIVerifier::read_initial_commitment(
-			&self.fri_params,
-			domain_context,
-			&mut transcript.message(),
-		);
+		let mut fri_verifier = FRIVerifier::new(&self.fri_params, domain_context);
+		fri_verifier.read_initial_commitment(&mut transcript.message());
 
 		// [phase] Verify IntMul Reduction - multiplication constraint verification
 		let intmul_guard = tracing::info_span!(


### PR DESCRIPTION
Splits `write_initial_commitment() -> Self` into `new() -> Self` and `write_initial_commitment()`. Same on the verifier side.