### PR TITLE
[fri] Put initial commitments into separate Vec

### DIFF
--- a/prover/prover/src/fri/mod.rs
+++ b/prover/prover/src/fri/mod.rs
@@ -40,10 +40,11 @@ use crate::merkle_tree::MerkleTreeProver;
 pub struct FRIProver<'a, F, H: OutputSizeUser, C, NTT> {
 	params: &'a FRIParams<F, H, C>,
 	ntt: &'a NTT,
+	initial_provers: Vec<MerkleTreeProver<F, H, C>>,
 	unprocessed_fold_challenges: Vec<F>,
-	merkle_tree_provers: Vec<MerkleTreeProver<F, H, C>>,
+	fold_provers: Vec<MerkleTreeProver<F, H, C>>,
 	terminal_codeword: Option<Vec<F>>,
-	rounds_done: usize,
+	fold_rounds_done: usize,
 }
 
 impl<'a, F, H, C, NTT> FRIProver<'a, F, H, C, NTT>
@@ -62,10 +63,11 @@ where
 		Self {
 			params,
 			ntt,
+			initial_provers: Vec::new(),
 			unprocessed_fold_challenges: Vec::new(),
-			merkle_tree_provers: Vec::new(),
+			fold_provers: Vec::new(),
 			terminal_codeword: None,
-			rounds_done: 0,
+			fold_rounds_done: 0,
 		}
 	}
 
@@ -81,7 +83,7 @@ where
 		poly: &[P],
 		transcript: &mut TranscriptWriter<impl BufMut>,
 	) {
-		assert_eq!(self.rounds_done, 0);
+		assert_eq!(self.fold_rounds_done, 0);
 
 		let (log_len, log_batch_size) = match *self.params.round_type(0) {
 			RoundType::InitialCommitment {
@@ -138,8 +140,7 @@ where
 			transcript,
 		);
 
-		self.merkle_tree_provers.push(initial_prover);
-		self.rounds_done += 1;
+		self.initial_provers.push(initial_prover);
 	}
 
 	/// The number of times [`Self::prove_fold_round`] must be called.
@@ -168,7 +169,7 @@ where
 	) {
 		self.unprocessed_fold_challenges.push(fold_challenge);
 
-		match *self.params.round_type(self.rounds_done) {
+		match *self.params.round_type(self.fold_rounds_done + 1) {
 			RoundType::Vacant => {}
 			RoundType::Commitment {
 				log_len,
@@ -184,7 +185,7 @@ where
 					self.params.commit_layer(),
 					transcript,
 				);
-				self.merkle_tree_provers.push(prover);
+				self.fold_provers.push(prover);
 			}
 			RoundType::TerminalCodeword { log_len } => {
 				let codeword = self.fold_previous_codeword();
@@ -196,41 +197,51 @@ where
 			_ => panic!("round type mismatch"),
 		}
 
-		self.rounds_done += 1;
+		self.fold_rounds_done += 1;
 	}
 
 	/// Internal function used for folding a codeword.
 	fn fold_previous_codeword(&mut self) -> Vec<F> {
-		let prover = self.merkle_tree_provers.last().unwrap();
-		let log_len = prover.log_leaves();
-		let log_chunk_len = prover.log_batch_size();
-
-		let create_scratch_buffer = || vec![F::default(); 1 << (log_chunk_len - 1)];
 		let mut folded: Vec<F> = Vec::new();
-
-		match self.merkle_tree_provers.len() {
+		match self.fold_provers.len() {
 			// in the first round we fold without applying the NTT
-			1 => prover
-				.par_leaf_batches()
-				.map_init(create_scratch_buffer, |scratch_buffer, chunk| {
-					fold_chunk_without_ntt(chunk, &self.unprocessed_fold_challenges, scratch_buffer)
-				})
-				.collect_into_vec(&mut folded),
+			0 => {
+				assert_eq!(self.initial_provers.len(), 1);
+				let prover = self.initial_provers.last().unwrap();
+				let log_chunk_len = prover.log_batch_size();
+				let create_scratch_buffer = || vec![F::default(); 1 << (log_chunk_len - 1)];
+				prover
+					.par_leaf_batches()
+					.map_init(create_scratch_buffer, |scratch_buffer, chunk| {
+						fold_chunk_without_ntt(
+							chunk,
+							&self.unprocessed_fold_challenges,
+							scratch_buffer,
+						)
+					})
+					.collect_into_vec(&mut folded);
+			}
 			// in all other rounds we fold normally
-			_ => prover
-				.par_leaf_batches()
-				.enumerate()
-				.map_init(create_scratch_buffer, |scratch_buffer, (chunk_index, chunk)| {
-					fold_chunk(
-						chunk,
-						&self.unprocessed_fold_challenges,
-						self.ntt.domain_context(),
-						log_len,
-						chunk_index,
-						scratch_buffer,
-					)
-				})
-				.collect_into_vec(&mut folded),
+			_ => {
+				let prover = self.fold_provers.last().unwrap();
+				let log_len = prover.log_leaves();
+				let log_chunk_len = prover.log_batch_size();
+				let create_scratch_buffer = || vec![F::default(); 1 << (log_chunk_len - 1)];
+				prover
+					.par_leaf_batches()
+					.enumerate()
+					.map_init(create_scratch_buffer, |scratch_buffer, (chunk_index, chunk)| {
+						fold_chunk(
+							chunk,
+							&self.unprocessed_fold_challenges,
+							self.ntt.domain_context(),
+							log_len,
+							chunk_index,
+							scratch_buffer,
+						)
+					})
+					.collect_into_vec(&mut folded);
+			}
 		};
 		self.unprocessed_fold_challenges.clear();
 
@@ -249,27 +260,27 @@ where
 	/// - `transcript`: The [`ProverTranscript`] used for sampling the query challenges and opening
 	///   the commitments on the decommitment tape.
 	pub fn prove_queries(&self, transcript: &mut ProverTranscript<impl Challenger>) {
-		assert_eq!(self.rounds_done, self.params.num_rounds());
+		assert_eq!(self.fold_rounds_done, self.num_fold_rounds());
+
+		assert_eq!(self.initial_provers.len(), 1);
+		let log_chunks =
+			self.initial_provers[0].log_leaves() - self.initial_provers[0].log_batch_size();
 
 		// prove the queries
 		for _ in 0..self.params.num_queries() {
 			// sample a random index
-			let log_chunks = self.merkle_tree_provers[0].log_leaves()
-				- self.merkle_tree_provers[0].log_batch_size();
 			let mut index = transcript.sample_bits(log_chunks) as usize;
 
 			// open the merkle leaves at each layer
-			let mut merkle_tree_provers = self.merkle_tree_provers.iter();
-			merkle_tree_provers
-				.next()
-				.unwrap()
-				.prove_opening(index, &mut transcript.decommitment());
-			for i in 1..self.params.num_rounds() {
-				match self.params.round_type(i) {
+			assert_eq!(self.initial_provers.len(), 1);
+			self.initial_provers[0].prove_opening(index, &mut transcript.decommitment());
+			let mut fold_provers = self.fold_provers.iter();
+			for i in 0..self.num_fold_rounds() {
+				match self.params.round_type(i + 1) {
 					RoundType::Vacant | RoundType::TerminalCodeword { .. } => {}
 					RoundType::Commitment { log_batch_size, .. } => {
 						index >>= log_batch_size;
-						merkle_tree_provers
+						fold_provers
 							.next()
 							.unwrap()
 							.prove_opening(index, &mut transcript.decommitment());
@@ -277,7 +288,7 @@ where
 					_ => panic!("round type mismatch"),
 				}
 			}
-			assert!(merkle_tree_provers.next().is_none());
+			assert!(fold_provers.next().is_none());
 		}
 	}
 }


### PR DESCRIPTION
Previously `FRIProver` had a single `merkle_tree_provers: Vec<...>`, which is now split into `initial_provers` and `fold_provers`. Same for `FRIVerifier`.

This is preparation for batched FRI.