### PR TITLE
[fri] Batched FRI with same codeword size

### DIFF
--- a/prover/prover/src/pcs.rs
+++ b/prover/prover/src/pcs.rs
@@ -72,6 +72,7 @@ where
 	{
 		let mut fri_prover = FRIProver::new(self.fri_params, self.ntt);
 		fri_prover.write_initial_commitment(packed_multilin.as_ref(), transcript);
+		fri_prover.add_batch_challenges(Vec::new());
 
 		fri_prover
 	}
@@ -242,6 +243,7 @@ mod test {
 
 		let mut fri_verifier = FRIVerifier::new(&fri_params, &domain_context);
 		fri_verifier.read_initial_commitment(&mut verifier_transcript.message());
+		fri_verifier.add_batch_challenges(Vec::new());
 
 		verify(&mut verifier_transcript, evaluation_claim, &evaluation_point, fri_verifier)?;
 

--- a/prover/prover/src/protocols/basefold/prover.rs
+++ b/prover/prover/src/protocols/basefold/prover.rs
@@ -200,6 +200,7 @@ mod test {
 			multilinear.to_ref().as_ref(),
 			&mut prover_transcript.message(),
 		);
+		fri_prover.add_batch_challenges(Vec::new());
 
 		let prover = BaseFoldProver::new(multilinear, eval_point_eq, evaluation_claim, fri_prover)?;
 
@@ -209,6 +210,7 @@ mod test {
 
 		let mut fri_verifier = FRIVerifier::new(&fri_params, &domain_context);
 		fri_verifier.read_initial_commitment(&mut verifier_transcript.message());
+		fri_verifier.add_batch_challenges(Vec::new());
 
 		let basefold::ReducedOutput {
 			final_fri_value,

--- a/verifier/verifier/src/fri/params.rs
+++ b/verifier/verifier/src/fri/params.rs
@@ -56,7 +56,7 @@ where
 	/// Arguments:
 	/// - `compression`: The compression function used in the merkle trees.
 	/// - `commit_layer`: The layer of commitment in the merkle trees.
-	/// - `poly_log_len`: Base-2 logarithm of the length of the multilinear polynomial that will be
+	/// - `poly_log_len`: Base-2 logarithm of the length of the multilinear polynomials that will be
 	///   committed.
 	/// - `rs_code`: The code for used for encoding the message at the beginning of FRI. \ Must
 	///   satisfy `rs_code.log_dim() + fold_arities[0] >= poly_log_len`.
@@ -132,6 +132,7 @@ where
 	/// - `poly_log_len`: Base-2 logarithm of the length of the multilinear polynomial that will be
 	///   committed.
 	/// - `log_inv_rate`: Base-2 logarithm of the inverse of the rate that will be used.
+	// FIXME NOTE This might need adaptation for batched FRI.
 	pub fn estimate_optimal_arity(poly_log_len: usize, log_inv_rate: usize) -> usize {
 		// NOTE: This is copied over from the old FRI implementation.
 		let log_block_length = poly_log_len + log_inv_rate;
@@ -182,6 +183,7 @@ where
 	/// - `fold_arity <= poly_log_len`
 	/// - (in particular this implies `0 < poly_log_len`)
 	/// - `subspace.dim() == poly_log_len + log_inv_rate - fold_arity`
+	// FIXME NOTE The computation of the number of queries might needs adaptation for batched FRI.
 	pub fn new_with_constant_arity(
 		compression: C,
 		poly_log_len: usize,
@@ -234,7 +236,7 @@ where
 		&self.rs_code
 	}
 
-	/// counts the initial commitment as an additional round
+	/// counts the initial commitments as an additional round
 	pub fn num_rounds(&self) -> usize {
 		self.round_types.len()
 	}

--- a/verifier/verifier/src/merkle_tree/mod.rs
+++ b/verifier/verifier/src/merkle_tree/mod.rs
@@ -1,6 +1,7 @@
 // Copyright 2025 Irreducible Inc.
 use std::{cmp::min, marker::PhantomData};
 
+use binius_field::BinaryField;
 use binius_transcript::TranscriptReader;
 use binius_utils::{DeserializeBytes, SerializeBytes};
 use bytes::Buf;
@@ -97,7 +98,7 @@ where
 		}
 	}
 
-	/// Verifies opening of a leaf batch.
+	/// Verifies opening of a leaf batch and returns its value.
 	///
 	/// Arguments:
 	/// - `leaf_batch_index`: The index of the leaf batch whose opening proof should be verified.
@@ -137,5 +138,81 @@ where
 	/// Number of leaf batches.
 	pub fn log_leaf_batches(&self) -> usize {
 		self.log_leaf_batches
+	}
+
+	/// Number of leaves. (Not leaf batches!)
+	pub fn log_leaves(&self) -> usize {
+		self.log_leaf_batches + self.log_batch_size
+	}
+
+	/// Base-2 logarithm of leaf batch size.
+	pub fn log_batch_size(&self) -> usize {
+		self.log_batch_size
+	}
+}
+
+/// Provides the ability to batch [`MerkleTreeVerifier`]s together.
+pub struct BatchedMerkleTreeVerifier<F, H: OutputSizeUser, C> {
+	verifiers: Vec<MerkleTreeVerifier<F, H, C>>,
+	batch_challenges: Vec<F>,
+}
+
+impl<F, H, C> BatchedMerkleTreeVerifier<F, H, C>
+where
+	F: BinaryField,
+	H: Digest + BlockSizeUser,
+	C: PseudoCompressionFunction<Output<H>, 2>,
+{
+	pub fn new(verifiers: Vec<MerkleTreeVerifier<F, H, C>>, batch_challenges: Vec<F>) -> Self {
+		assert_eq!(batch_challenges.len() + 1, verifiers.len());
+		let log_leaves = verifiers[0].log_leaves();
+		let log_batch_size = verifiers[0].log_batch_size();
+		for verifier in &verifiers[1..] {
+			assert_eq!(verifier.log_leaves(), log_leaves);
+			assert_eq!(verifier.log_batch_size(), log_batch_size);
+		}
+
+		Self {
+			verifiers,
+			batch_challenges,
+		}
+	}
+
+	/// Verifies opening of a batched leaf batch and returns its value.
+	///
+	/// This first calls [`MerkleTreeVerifier::verify_opening`] on all the `verifiers` and then
+	/// batches them together using the `batch_challenges`.
+	pub fn verify_opening(
+		&self,
+		leaf_batch_index: usize,
+		transcript: &mut TranscriptReader<impl Buf>,
+	) -> Result<Vec<F>, VerificationError> {
+		let mut batched_leaf_batch =
+			self.verifiers[0].verify_opening(leaf_batch_index, transcript)?;
+
+		for (verifier, &batch_challenge) in
+			self.verifiers[1..].iter().zip(self.batch_challenges.iter())
+		{
+			let leaf_batch = verifier.verify_opening(leaf_batch_index, transcript)?;
+			// fold leaf_batch into batched_leaf_batch using the batch_challenge
+			assert_eq!(leaf_batch.len(), batched_leaf_batch.len());
+			for i in 0..batched_leaf_batch.len() {
+				batched_leaf_batch[i] += batch_challenge * leaf_batch[i];
+			}
+		}
+
+		Ok(batched_leaf_batch)
+	}
+
+	pub fn log_leaf_batches(&self) -> usize {
+		self.verifiers[0].log_leaf_batches
+	}
+
+	pub fn log_leaves(&self) -> usize {
+		self.verifiers[0].log_leaf_batches + self.verifiers[0].log_batch_size
+	}
+
+	pub fn log_batch_size(&self) -> usize {
+		self.verifiers[0].log_batch_size
 	}
 }

--- a/verifier/verifier/src/verify.rs
+++ b/verifier/verifier/src/verify.rs
@@ -139,6 +139,7 @@ where
 		let domain_context = GenericOnTheFly::generate_from_subspace(subspace);
 		let mut fri_verifier = FRIVerifier::new(&self.fri_params, domain_context);
 		fri_verifier.read_initial_commitment(&mut transcript.message());
+		fri_verifier.add_batch_challenges(Vec::new());
 
 		// [phase] Verify IntMul Reduction - multiplication constraint verification
 		let intmul_guard = tracing::info_span!(


### PR DESCRIPTION
Modifies `FRIProver` and `FRIVerifier` so that they do batched FRI, with the assumptions that all the multilinears that are committed have the same size.

It does so by replacing the `MerkleTreeProver` for the initial codeword by a `BatchedMerkleTreeProver`, which itself captures the batching of multiple `MerkleTreeProver`s. Same for the verifier.

There is one **inefficiency**, which is how the leaf access is provided in `BatchedMerkleTreeProver`. Currently it computes the vector of batches leaves, stores it, and then provides an Iterator over that. This wastes memory. Instead it could just provide an iterator which batches the leaves ad-hoc.  It also doesn't use SIMD.