### PR TITLE
[frontend] breakdown shifted value indices

### DIFF
--- a/prover/examples/snapshots/blake2b.snap
+++ b/prover/examples/snapshots/blake2b.snap
@@ -3,7 +3,9 @@ blake2b circuit
 Gates & Instructions
 ├─ Number of gates: 1,363
 ├─ Number of evaluation instructions: 1,363
-└─ Distinct shifted value indices: 4,121
+├─ Distinct value indices: 4,121
+│  ├─ Distinct shifted value indices: 3,031
+│  └─ Distinct unshifted value indices: 1,090
 
 Constraints
 ├─ AND constraints: 1,064 used (52.0% of 2^11)

--- a/prover/examples/snapshots/blake2s.snap
+++ b/prover/examples/snapshots/blake2s.snap
@@ -3,7 +3,9 @@ blake2s circuit
 Gates & Instructions
 ├─ Number of gates: 2,318
 ├─ Number of evaluation instructions: 2,318
-└─ Distinct shifted value indices: 6,155
+├─ Distinct value indices: 6,155
+│  ├─ Distinct shifted value indices: 3,544
+│  └─ Distinct unshifted value indices: 2,611
 
 Constraints
 ├─ AND constraints: 2,584 used (63.1% of 2^12)

--- a/prover/examples/snapshots/ethsign.snap
+++ b/prover/examples/snapshots/ethsign.snap
@@ -3,7 +3,9 @@ ethsign circuit
 Gates & Instructions
 ├─ Number of gates: 253,204
 ├─ Number of evaluation instructions: 299,208
-└─ Distinct shifted value indices: 475,243
+├─ Distinct value indices: 475,243
+│  ├─ Distinct shifted value indices: 221,027
+│  └─ Distinct unshifted value indices: 254,216
 
 Constraints
 ├─ AND constraints: 218,471 used (83.3% of 2^18)

--- a/prover/examples/snapshots/hashsign.snap
+++ b/prover/examples/snapshots/hashsign.snap
@@ -3,7 +3,9 @@ hashsign circuit
 Gates & Instructions
 ├─ Number of gates: 2,385,261
 ├─ Number of evaluation instructions: 2,886,906
-└─ Distinct shifted value indices: 3,322,922
+├─ Distinct value indices: 3,322,922
+│  ├─ Distinct shifted value indices: 1,726,928
+│  └─ Distinct unshifted value indices: 1,595,994
 
 Constraints
 ├─ AND constraints: 1,600,305 used (76.3% of 2^21)

--- a/prover/examples/snapshots/keccak.snap
+++ b/prover/examples/snapshots/keccak.snap
@@ -3,7 +3,9 @@ keccak circuit
 Gates & Instructions
 ├─ Number of gates: 27,625
 ├─ Number of evaluation instructions: 27,625
-└─ Distinct shifted value indices: 41,877
+├─ Distinct value indices: 41,877
+│  ├─ Distinct shifted value indices: 34,604
+│  └─ Distinct unshifted value indices: 7,273
 
 Constraints
 ├─ AND constraints: 7,225 used (88.2% of 2^13)

--- a/prover/examples/snapshots/sha256.snap
+++ b/prover/examples/snapshots/sha256.snap
@@ -3,7 +3,9 @@ sha256 circuit
 Gates & Instructions
 ├─ Number of gates: 74,954
 ├─ Number of evaluation instructions: 76,589
-└─ Distinct shifted value indices: 131,539
+├─ Distinct value indices: 131,539
+│  ├─ Distinct shifted value indices: 62,563
+│  └─ Distinct unshifted value indices: 68,976
 
 Constraints
 ├─ AND constraints: 68,881 used (52.6% of 2^17)

--- a/prover/examples/snapshots/sha512.snap
+++ b/prover/examples/snapshots/sha512.snap
@@ -3,7 +3,9 @@ sha512 circuit
 Gates & Instructions
 ├─ Number of gates: 48,779
 ├─ Number of evaluation instructions: 49,886
-└─ Distinct shifted value indices: 63,034
+├─ Distinct value indices: 63,034
+│  ├─ Distinct shifted value indices: 41,309
+│  └─ Distinct unshifted value indices: 21,725
 
 Constraints
 ├─ AND constraints: 21,349 used (65.2% of 2^15)


### PR DESCRIPTION
Now the circuit stats breaks down the number of distinct shifted value indices
and unshifted value indices.

```
Gates & Instructions
├─ Number of gates: 27,625
├─ Number of evaluation instructions: 27,625
├─ Distinct value indices: 41,877
│  ├─ Distinct shifted value indices: 34,604
│  └─ Distinct unshifted value indices: 7,273
```