### PR TITLE
[frontend] fix stat output categories

### DIFF
--- a/prover/examples/snapshots/blake2b.snap
+++ b/prover/examples/snapshots/blake2b.snap
@@ -2,16 +2,16 @@ blake2b circuit
 --
 Gates & Instructions
 ├─ Number of gates: 1,363
-├─ Number of evaluation instructions: 1,363
-├─ Distinct value indices: 4,121
-│  ├─ Distinct shifted value indices: 3,031
-│  └─ Distinct unshifted value indices: 1,090
+└─ Number of evaluation instructions: 1,363
 
 Constraints
 ├─ AND constraints: 1,064 used (52.0% of 2^11)
 │  [▓▓▓▓▓░░░░░] spare: 984
-└─ MUL constraints: 0 used (0.0% of 2^0)
-   [░░░░░░░░░░] spare: 1
+├─ MUL constraints: 0 used (0.0% of 2^0)
+│  [░░░░░░░░░░] spare: 1
+└─ Distinct value indices: 4,121
+   ├─ Distinct shifted value indices: 3,031
+   └─ Distinct unshifted value indices: 1,090
 
 Value Vector
 ├─ Public Section: 12 used (75.0% of 2^4)

--- a/prover/examples/snapshots/blake2s.snap
+++ b/prover/examples/snapshots/blake2s.snap
@@ -2,16 +2,16 @@ blake2s circuit
 --
 Gates & Instructions
 ├─ Number of gates: 2,318
-├─ Number of evaluation instructions: 2,318
-├─ Distinct value indices: 6,155
-│  ├─ Distinct shifted value indices: 3,544
-│  └─ Distinct unshifted value indices: 2,611
+└─ Number of evaluation instructions: 2,318
 
 Constraints
 ├─ AND constraints: 2,584 used (63.1% of 2^12)
 │  [▓▓▓▓▓▓░░░░] spare: 1,512
-└─ MUL constraints: 0 used (0.0% of 2^0)
-   [░░░░░░░░░░] spare: 1
+├─ MUL constraints: 0 used (0.0% of 2^0)
+│  [░░░░░░░░░░] spare: 1
+└─ Distinct value indices: 6,155
+   ├─ Distinct shifted value indices: 3,544
+   └─ Distinct unshifted value indices: 2,611
 
 Value Vector
 ├─ Public Section: 14 used (87.5% of 2^4)

--- a/prover/examples/snapshots/ethsign.snap
+++ b/prover/examples/snapshots/ethsign.snap
@@ -2,16 +2,16 @@ ethsign circuit
 --
 Gates & Instructions
 ├─ Number of gates: 253,204
-├─ Number of evaluation instructions: 299,208
-├─ Distinct value indices: 475,243
-│  ├─ Distinct shifted value indices: 221,027
-│  └─ Distinct unshifted value indices: 254,216
+└─ Number of evaluation instructions: 299,208
 
 Constraints
 ├─ AND constraints: 218,471 used (83.3% of 2^18)
 │  [▓▓▓▓▓▓▓▓░░] spare: 43,673
-└─ MUL constraints: 25,458 used (77.7% of 2^15)
-   [▓▓▓▓▓▓▓░░░] spare: 7,310
+├─ MUL constraints: 25,458 used (77.7% of 2^15)
+│  [▓▓▓▓▓▓▓░░░] spare: 7,310
+└─ Distinct value indices: 475,243
+   ├─ Distinct shifted value indices: 221,027
+   └─ Distinct unshifted value indices: 254,216
 
 Value Vector
 ├─ Public Section: 117 used (91.4% of 2^7)

--- a/prover/examples/snapshots/hashsign.snap
+++ b/prover/examples/snapshots/hashsign.snap
@@ -2,16 +2,16 @@ hashsign circuit
 --
 Gates & Instructions
 ├─ Number of gates: 2,385,261
-├─ Number of evaluation instructions: 2,886,906
-├─ Distinct value indices: 3,322,922
-│  ├─ Distinct shifted value indices: 1,726,928
-│  └─ Distinct unshifted value indices: 1,595,994
+└─ Number of evaluation instructions: 2,886,906
 
 Constraints
 ├─ AND constraints: 1,600,305 used (76.3% of 2^21)
 │  [▓▓▓▓▓▓▓░░░] spare: 496,847
-└─ MUL constraints: 0 used (0.0% of 2^0)
-   [░░░░░░░░░░] spare: 1
+├─ MUL constraints: 0 used (0.0% of 2^0)
+│  [░░░░░░░░░░] spare: 1
+└─ Distinct value indices: 3,322,922
+   ├─ Distinct shifted value indices: 1,726,928
+   └─ Distinct unshifted value indices: 1,595,994
 
 Value Vector
 ├─ Public Section: 396 used (77.3% of 2^9)

--- a/prover/examples/snapshots/keccak.snap
+++ b/prover/examples/snapshots/keccak.snap
@@ -2,16 +2,16 @@ keccak circuit
 --
 Gates & Instructions
 ├─ Number of gates: 27,625
-├─ Number of evaluation instructions: 27,625
-├─ Distinct value indices: 41,877
-│  ├─ Distinct shifted value indices: 34,604
-│  └─ Distinct unshifted value indices: 7,273
+└─ Number of evaluation instructions: 27,625
 
 Constraints
 ├─ AND constraints: 7,225 used (88.2% of 2^13)
 │  [▓▓▓▓▓▓▓▓░░] spare: 967
-└─ MUL constraints: 0 used (0.0% of 2^0)
-   [░░░░░░░░░░] spare: 1
+├─ MUL constraints: 0 used (0.0% of 2^0)
+│  [░░░░░░░░░░] spare: 1
+└─ Distinct value indices: 41,877
+   ├─ Distinct shifted value indices: 34,604
+   └─ Distinct unshifted value indices: 7,273
 
 Value Vector
 ├─ Public Section: 73 used (57.0% of 2^7)

--- a/prover/examples/snapshots/sha256.snap
+++ b/prover/examples/snapshots/sha256.snap
@@ -2,16 +2,16 @@ sha256 circuit
 --
 Gates & Instructions
 ├─ Number of gates: 74,954
-├─ Number of evaluation instructions: 76,589
-├─ Distinct value indices: 131,539
-│  ├─ Distinct shifted value indices: 62,563
-│  └─ Distinct unshifted value indices: 68,976
+└─ Number of evaluation instructions: 76,589
 
 Constraints
 ├─ AND constraints: 68,881 used (52.6% of 2^17)
 │  [▓▓▓▓▓░░░░░] spare: 62,191
-└─ MUL constraints: 0 used (0.0% of 2^0)
-   [░░░░░░░░░░] spare: 1
+├─ MUL constraints: 0 used (0.0% of 2^0)
+│  [░░░░░░░░░░] spare: 1
+└─ Distinct value indices: 131,539
+   ├─ Distinct shifted value indices: 62,563
+   └─ Distinct unshifted value indices: 68,976
 
 Value Vector
 ├─ Public Section: 613 used (59.9% of 2^10)

--- a/prover/examples/snapshots/sha512.snap
+++ b/prover/examples/snapshots/sha512.snap
@@ -2,16 +2,16 @@ sha512 circuit
 --
 Gates & Instructions
 ├─ Number of gates: 48,779
-├─ Number of evaluation instructions: 49,886
-├─ Distinct value indices: 63,034
-│  ├─ Distinct shifted value indices: 41,309
-│  └─ Distinct unshifted value indices: 21,725
+└─ Number of evaluation instructions: 49,886
 
 Constraints
 ├─ AND constraints: 21,349 used (65.2% of 2^15)
 │  [▓▓▓▓▓▓░░░░] spare: 11,419
-└─ MUL constraints: 0 used (0.0% of 2^0)
-   [░░░░░░░░░░] spare: 1
+├─ MUL constraints: 0 used (0.0% of 2^0)
+│  [░░░░░░░░░░] spare: 1
+└─ Distinct value indices: 63,034
+   ├─ Distinct shifted value indices: 41,309
+   └─ Distinct unshifted value indices: 21,725
 
 Value Vector
 ├─ Public Section: 641 used (62.6% of 2^10)

--- a/verifier/frontend/src/stat.rs
+++ b/verifier/frontend/src/stat.rs
@@ -160,22 +160,7 @@ impl fmt::Display for CircuitStat {
 		// Gates & Instructions
 		writeln!(f, "Gates & Instructions")?;
 		writeln!(f, "├─ Number of gates: {}", fmt_num(self.n_gates))?;
-		writeln!(f, "├─ Number of evaluation instructions: {}", fmt_num(self.n_eval_insn))?;
-		writeln!(
-			f,
-			"├─ Distinct value indices: {}",
-			fmt_num(self.distinct_shifted_value_indices + self.distinct_unshifted_value_indices)
-		)?;
-		writeln!(
-			f,
-			"│  ├─ Distinct shifted value indices: {}",
-			fmt_num(self.distinct_shifted_value_indices)
-		)?;
-		writeln!(
-			f,
-			"│  └─ Distinct unshifted value indices: {}",
-			fmt_num(self.distinct_unshifted_value_indices)
-		)?;
+		writeln!(f, "└─ Number of evaluation instructions: {}", fmt_num(self.n_eval_insn))?;
 		writeln!(f)?;
 
 		// Constraints
@@ -204,16 +189,31 @@ impl fmt::Display for CircuitStat {
 		let mul_spare = self.mul_allocated - self.n_mul_constraints;
 		writeln!(
 			f,
-			"└─ MUL constraints: {} used ({:.1}% of 2^{})",
+			"├─ MUL constraints: {} used ({:.1}% of 2^{})",
 			fmt_num(self.n_mul_constraints),
 			mul_percent,
 			log2(self.mul_allocated)
 		)?;
 		writeln!(
 			f,
-			"   {} spare: {}",
+			"│  {} spare: {}",
 			progress_bar(self.n_mul_constraints, self.mul_allocated),
 			fmt_num(mul_spare)
+		)?;
+		writeln!(
+			f,
+			"└─ Distinct value indices: {}",
+			fmt_num(self.distinct_shifted_value_indices + self.distinct_unshifted_value_indices)
+		)?;
+		writeln!(
+			f,
+			"   ├─ Distinct shifted value indices: {}",
+			fmt_num(self.distinct_shifted_value_indices)
+		)?;
+		writeln!(
+			f,
+			"   └─ Distinct unshifted value indices: {}",
+			fmt_num(self.distinct_unshifted_value_indices)
 		)?;
 		writeln!(f)?;
 


### PR DESCRIPTION
Prior this change the distinct value indices were put into the Gate & Instructions category which is more of the circuit level stats. This change moves it to the Constraints category, which kinda makes sense: it should read as the constraints use this much distinct value indices.

