### PR TITLE
Use Karatsuba multiplication in rs256

### DIFF
--- a/prover/examples/snapshots/zklogin.snap
+++ b/prover/examples/snapshots/zklogin.snap
@@ -1,28 +1,28 @@
 zklogin circuit
 --
 Gates & Instructions
-├─ Number of gates: 484,343
-└─ Number of evaluation instructions: 548,293
+├─ Number of gates: 533,759
+└─ Number of evaluation instructions: 597,709
 
 Constraints
-├─ AND constraints: 429,272 used (81.9% of 2^19)
-│  [▓▓▓▓▓▓▓▓░░] spare: 95,016
-├─ MUL constraints: 26,880 used (82.0% of 2^15)
-│  [▓▓▓▓▓▓▓▓░░] spare: 5,888
-└─ Distinct value indices: 828,771
-   ├─ Distinct shifted value indices: 349,834
-   └─ Distinct unshifted value indices: 478,937
+├─ AND constraints: 483,536 used (92.2% of 2^19)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 40,752
+├─ MUL constraints: 8,262 used (50.4% of 2^14)
+│  [▓▓▓▓▓░░░░░] spare: 8,122
+└─ Distinct value indices: 862,867
+   ├─ Distinct shifted value indices: 377,136
+   └─ Distinct unshifted value indices: 485,731
 
 Value Vector
 ├─ Public Section: 1,018 used (99.4% of 2^10)
 │  [▓▓▓▓▓▓▓▓▓░] spare: 6
 │  ├─ Constants: 716
 │  └─ Inout: 302
-├─ Private Section: 477,920 used (91.3%)
-│  [▓▓▓▓▓▓▓▓▓░] spare: 45,344
+├─ Private Section: 484,714 used (92.6%)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 38,550
 │  ├─ Witness: 1,788
-│  └─ Internal: 476,132
-├─ Total Committed: 478,938 used (91.4% of 2^19)
-│  [▓▓▓▓▓▓▓▓▓░] spare: 45,350
-└─ Scratch (uncommitted): 348,039
+│  └─ Internal: 482,926
+├─ Total Committed: 485,732 used (92.6% of 2^19)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 38,556
+└─ Scratch (uncommitted): 391,117
 

--- a/verifier/circuits/src/bignum/mod.rs
+++ b/verifier/circuits/src/bignum/mod.rs
@@ -18,6 +18,6 @@ mod tests;
 pub use addsub::{add, sub};
 pub use biguint::{BigUint, assert_eq, select};
 pub use cmp::{biguint_eq, biguint_lt};
-pub use mul::{karatsuba_mul, mul, square};
+pub use mul::{karatsuba_mul, optimal_mul, optimal_sqr, textbook_mul, textbook_square};
 pub use prime_field::PseudoMersennePrimeField;
 pub use reduce::{ModReduce, PseudoMersenneModReduce};

--- a/verifier/circuits/src/bignum/prime_field.rs
+++ b/verifier/circuits/src/bignum/prime_field.rs
@@ -2,7 +2,9 @@
 use binius_core::{consts::WORD_SIZE_BITS, word::Word};
 use binius_frontend::{CircuitBuilder, Wire, util::num_biguint_from_u64_limbs};
 
-use super::{BigUint, PseudoMersenneModReduce, add, biguint_lt, mul, square, sub};
+use super::{
+	BigUint, PseudoMersenneModReduce, add, biguint_lt, sub, textbook_mul, textbook_square,
+};
 
 /// A struct that implements prime field arithmetic over pseudo-Mersenne modulus.
 ///
@@ -88,7 +90,7 @@ impl PseudoMersennePrimeField {
 	/// Equivalent formula: `(fe ** 2) % modulus`
 	pub fn square(&self, b: &CircuitBuilder, fe: &BigUint) -> BigUint {
 		assert!(fe.limbs.len() == self.limbs_len());
-		self.reduce_product(b, square(b, fe))
+		self.reduce_product(b, textbook_square(b, fe))
 	}
 
 	/// Field multiplication.
@@ -97,7 +99,7 @@ impl PseudoMersennePrimeField {
 	/// Note: Both fe1 and fe2 may be greater or equal to modulus.
 	pub fn mul(&self, b: &CircuitBuilder, fe1: &BigUint, fe2: &BigUint) -> BigUint {
 		assert!(fe1.limbs.len() == self.limbs_len() && fe2.limbs.len() == self.limbs_len());
-		self.reduce_product(b, mul(b, fe1, fe2))
+		self.reduce_product(b, textbook_mul(b, fe1, fe2))
 	}
 
 	fn reduce_product(&self, b: &CircuitBuilder, product: BigUint) -> BigUint {
@@ -141,7 +143,7 @@ impl PseudoMersennePrimeField {
 		let one = BigUint::new_constant(b, &num_bigint::BigUint::from(1usize))
 			.pad_limbs_to(self.limbs_len(), zero);
 
-		let product = mul(b, &inverse, fe);
+		let product = textbook_mul(b, &inverse, fe);
 
 		b.assert_true("inverse < modulus", biguint_lt(b, &inverse, &self.modulus));
 

--- a/verifier/circuits/src/bignum/reduce.rs
+++ b/verifier/circuits/src/bignum/reduce.rs
@@ -5,7 +5,7 @@ use binius_frontend::{CircuitBuilder, Wire};
 use super::{
 	addsub::{add, sub},
 	biguint::{BigUint, assert_eq, assert_eq_cond},
-	mul::mul,
+	mul::{optimal_mul, textbook_mul},
 };
 
 /// Modular reduction verification for BigUint.
@@ -41,7 +41,7 @@ impl ModReduce {
 	) -> Self {
 		let zero = builder.add_constant(Word::ZERO);
 
-		let product = mul(builder, &quotient, &modulus);
+		let product = optimal_mul(builder, &quotient, &modulus);
 
 		let remainder_padded = remainder.pad_limbs_to(product.limbs.len(), zero);
 		let reconstructed = add(builder, &product, &remainder_padded);
@@ -130,7 +130,7 @@ impl PseudoMersenneModReduce {
 			.pad_limbs_to(n_lo_limbs, zero)
 			.concat_limbs(&rhs_hi);
 
-		let quotient_modulus_subtrahend = mul(builder, quotient, modulus_subtrahend);
+		let quotient_modulus_subtrahend = textbook_mul(builder, quotient, modulus_subtrahend);
 		let lhs_rhs_len = [
 			rhs.limbs.len(),
 			quotient_modulus_subtrahend.limbs.len() + 1,

--- a/verifier/circuits/src/bignum/tests.rs
+++ b/verifier/circuits/src/bignum/tests.rs
@@ -55,14 +55,14 @@ fn test_add_overflow_detection_via_final_carry() {
 }
 
 #[test]
-fn test_mul_single_case() {
+fn test_textbook_mul_single_case() {
 	let builder = CircuitBuilder::new();
 
 	// Create 2048-bit numbers for inputs (32 limbs)
 	let a = BigUint::new_witness(&builder, 32);
 	let b = BigUint::new_witness(&builder, 32);
 
-	let mul = mul(&builder, &a, &b);
+	let mul = textbook_mul(&builder, &a, &b);
 
 	let cs = builder.build();
 	let mut w = cs.new_witness_filler();
@@ -251,7 +251,7 @@ proptest! {
 	}
 
 	#[test]
-	fn test_mul_with_values(
+	fn test_textbook_mul_with_values(
 		a_limbs in prop::collection::vec(any::<u64>(), 1..10),
 		b_limbs in prop::collection::vec(any::<u64>(), 1..10)
 	) {
@@ -260,7 +260,7 @@ proptest! {
 		let a = BigUint::new_inout(&builder, a_limbs.len());
 		let b = BigUint::new_inout(&builder, b_limbs.len());
 
-		let result = mul(&builder, &a, &b);
+		let result = textbook_mul(&builder, &a, &b);
 
 		let cs = builder.build();
 		let mut w = cs.new_witness_filler();
@@ -289,11 +289,11 @@ proptest! {
 	}
 
 	#[test]
-	fn test_square_with_values(a_limbs in prop::collection::vec(any::<u64>(), 1..10)) {
+	fn test_textbook_square_with_values(a_limbs in prop::collection::vec(any::<u64>(), 1..10)) {
 		let builder = CircuitBuilder::new();
 
 		let a = BigUint::new_witness(&builder, a_limbs.len());
-		let result = square(&builder, &a);
+		let result = textbook_square(&builder, &a);
 
 		let cs = builder.build();
 
@@ -355,13 +355,13 @@ proptest! {
 	}
 
 	#[test]
-	fn prop_square_vs_mul_equivalence(vals in prop::collection::vec(any::<u64>(), 1..=8)) {
+	fn prop_textbook_square_vs_mul_equivalence(vals in prop::collection::vec(any::<u64>(), 1..=8)) {
 		let builder = CircuitBuilder::new();
 
 		let a = BigUint::new_witness(&builder, vals.len());
 
-		let square_result = square(&builder, &a);
-		let mul_result = mul(&builder, &a, &a);
+		let square_result = textbook_square(&builder, &a);
+		let mul_result = textbook_mul(&builder, &a, &a);
 
 		let cs = builder.build();
 		let mut w = cs.new_witness_filler();
@@ -444,11 +444,11 @@ proptest! {
 		let a = BigUint::new_witness(&builder, a_vals.len());
 		let b = BigUint::new_witness(&builder, b_vals.len());
 
-		let textbook_product = mul(&builder, &a, &b);
+		let textbook_product = textbook_mul(&builder, &a, &b);
 		let karatsuba_product = karatsuba_mul(&builder, &a, &b);
 		let equal = biguint_eq(&builder, &textbook_product, &karatsuba_product);
 
-		builder.assert_true("karatsuba_mul() conforms to mul()", equal);
+		builder.assert_true("karatsuba_mul() conforms to textbook_mul()", equal);
 
 		let cs = builder.build();
 		let mut w = cs.new_witness_filler();

--- a/verifier/circuits/src/rs256.rs
+++ b/verifier/circuits/src/rs256.rs
@@ -4,7 +4,7 @@ use num_integer::Integer;
 
 use super::fixed_byte_vec::FixedByteVec;
 use crate::{
-	bignum::{BigUint, ModReduce, assert_eq, mul, square},
+	bignum::{BigUint, ModReduce, assert_eq, optimal_mul, optimal_sqr},
 	sha256::Sha256,
 };
 
@@ -275,7 +275,7 @@ fn modexp_65537_verify(
 
 	for i in 0..16 {
 		let builder = builder.subcircuit(format!("square[{i}]"));
-		let squared = square(&builder, &result);
+		let squared = optimal_sqr(&builder, &result);
 		let circuit = ModReduce::new(
 			&builder,
 			squared,
@@ -287,7 +287,7 @@ fn modexp_65537_verify(
 	}
 
 	let builder = builder.subcircuit("final_multiply");
-	let multiplied = mul(&builder, &result, base);
+	let multiplied = optimal_mul(&builder, &result, base);
 	let _mod_reduce_multiplied = ModReduce::new(
 		&builder,
 		multiplied,


### PR DESCRIPTION
This PR is by @onesk  
  
It updates the rs256 circuit to use Karatsuba multiplication. This reduces the number of Mul constraints used in the zklogin example.