### PR TITLE
renaming stuff inside vision

### DIFF
--- a/prover/prover/benches/vision.rs
+++ b/prover/prover/benches/vision.rs
@@ -6,12 +6,12 @@ use binius_field::{BinaryField128bGhash as Ghash, Field, Random};
 use binius_prover::hash::{
 	parallel_digest::{MultiDigest, ParallelDigest, ParallelMultidigestImpl},
 	vision_4::{
-		parallel::parallel_permutation as parallel_permutation_4,
-		single::VisionHasherMultiDigest as VisionHasherMultiDigest_4,
+		digest::VisionHasherMultiDigest as VisionHasherMultiDigest_4,
+		permutation::batch_permutation as batch_permutation_4,
 	},
 	vision_6::{
-		parallel::parallel_permutation as parallel_permutation_6,
-		single::VisionHasherMultiDigest as VisionHasherMultiDigest_6,
+		digest::VisionHasherMultiDigest as VisionHasherMultiDigest_6,
+		permutation::batch_permutation as batch_permutation_6,
 	},
 };
 use binius_utils::rayon::prelude::*;
@@ -73,7 +73,7 @@ fn bench_parallel_permutation_4(c: &mut Criterion) {
 	bench_parallel_permutation_sizes_4!(
 		&mut group,
 		&mut rng,
-		parallel_permutation_4,
+		batch_permutation_4,
 		scratchpad,
 		M,
 		2,
@@ -98,7 +98,7 @@ fn bench_parallel_permutation_6(c: &mut Criterion) {
 	bench_parallel_permutation_sizes_6!(
 		&mut group,
 		&mut rng,
-		parallel_permutation_6,
+		batch_permutation_6,
 		scratchpad,
 		M,
 		2,

--- a/prover/prover/src/hash/vision_4/compression.rs
+++ b/prover/prover/src/hash/vision_4/compression.rs
@@ -16,7 +16,7 @@ use binius_verifier::hash::vision_4::{
 use digest::Output;
 
 use super::{
-	super::parallel_compression::ParallelPseudoCompression, parallel::parallel_permutation,
+	super::parallel_compression::ParallelPseudoCompression, permutation::batch_permutation,
 };
 
 // The number of parallel compressions N must be a power of 2.
@@ -131,7 +131,7 @@ impl VisionParallelCompression {
 		let originals: [_; N] = array::from_fn(|i| (states[i * M], states[i * M + 1]));
 
 		// Step 3: Apply parallel permutation to all states
-		parallel_permutation::<N, MN>(&mut states, scratchpad);
+		batch_permutation::<N, MN>(&mut states, scratchpad);
 
 		// Step 4: Add original elements back and serialize outputs
 		for i in 0..N {

--- a/prover/prover/src/hash/vision_4/digest.rs
+++ b/prover/prover/src/hash/vision_4/digest.rs
@@ -4,15 +4,15 @@ use std::{array, mem::MaybeUninit};
 
 use binius_field::{BinaryField128bGhash as Ghash, Field};
 use binius_utils::{DeserializeBytes, SerializeBytes};
-use binius_verifier::hash::vision_6::{
+use binius_verifier::hash::vision_4::{
 	M,
 	digest::{PADDING_BLOCK, RATE_AS_U8, RATE_AS_U128, VisionHasherDigest, fill_padding},
 };
 use digest::Output;
 
-use super::{super::parallel_digest::MultiDigest, parallel::parallel_permutation};
+use super::{super::parallel_digest::MultiDigest, permutation::batch_permutation};
 
-/// A Vision hasher with state size M=6 suited for parallelization.
+/// A Vision hasher with state size M=4 suited for parallelization.
 ///
 /// Without using packed fields, there is only one advantage of an explicit parallelized
 /// Vision hasher over invoking the Vision hasher multiple times in parallel:
@@ -21,16 +21,14 @@ use super::{super::parallel_digest::MultiDigest, parallel::parallel_permutation}
 /// We slightly modify Montogery's trick to use a binary tree structure,
 /// maximizing independence of multiplications for better instruction pipelining.
 #[derive(Clone)]
-pub struct VisionHasherMultiDigest<const N: usize, const MN: usize, const MN_DIV_3: usize> {
+pub struct VisionHasherMultiDigest<const N: usize, const MN: usize> {
 	states: [Ghash; MN],
 	scratchpad: Vec<Ghash>,
 	buffers: [[u8; RATE_AS_U8]; N],
 	filled_bytes: usize,
 }
 
-impl<const N: usize, const MN: usize, const MN_DIV_3: usize> Default
-	for VisionHasherMultiDigest<N, MN, MN_DIV_3>
-{
+impl<const N: usize, const MN: usize> Default for VisionHasherMultiDigest<N, MN> {
 	fn default() -> Self {
 		assert!(N.is_power_of_two() && N >= 2, "N must be a power of 2 and >= 2");
 		assert_eq!(MN, M * N);
@@ -43,9 +41,7 @@ impl<const N: usize, const MN: usize, const MN_DIV_3: usize> Default
 	}
 }
 
-impl<const N: usize, const MN: usize, const MN_DIV_3: usize>
-	VisionHasherMultiDigest<N, MN, MN_DIV_3>
-{
+impl<const N: usize, const MN: usize> VisionHasherMultiDigest<N, MN> {
 	#[inline]
 	fn advance_data(data: &mut [&[u8]; N], bytes: usize) {
 		for i in 0..N {
@@ -66,7 +62,7 @@ impl<const N: usize, const MN: usize, const MN_DIV_3: usize>
 			}
 		}
 
-		parallel_permutation::<N, MN, MN_DIV_3>(states, scratchpad);
+		batch_permutation::<N, MN>(states, scratchpad);
 	}
 	fn finalize(&mut self, out: &mut [MaybeUninit<digest::Output<VisionHasherDigest>>; N]) {
 		if self.filled_bytes != 0 {
@@ -101,9 +97,7 @@ impl<const N: usize, const MN: usize, const MN_DIV_3: usize>
 	}
 }
 
-impl<const N: usize, const MN: usize, const MN_DIV_3: usize> MultiDigest<N>
-	for VisionHasherMultiDigest<N, MN, MN_DIV_3>
-{
+impl<const N: usize, const MN: usize> MultiDigest<N> for VisionHasherMultiDigest<N, MN> {
 	type Digest = VisionHasherDigest;
 
 	fn new() -> Self {
@@ -194,13 +188,13 @@ mod tests {
 	}
 
 	// Generic test function that compares parallel vs sequential execution
-	fn test_parallel_vs_sequential<const N: usize, const MN: usize, const MN_DIV_3: usize>(
+	fn test_parallel_vs_sequential<const N: usize, const MN: usize>(
 		data: [&[u8]; N],
 		description: &str,
 	) {
 		// Parallel computation
 		let mut parallel_outputs = [MaybeUninit::uninit(); N];
-		VisionHasherMultiDigest::<N, MN, MN_DIV_3>::digest(data, &mut parallel_outputs);
+		VisionHasherMultiDigest::<N, MN>::digest(data, &mut parallel_outputs);
 		let parallel_results: [Output<VisionHasherDigest>; N] =
 			array::from_fn(|i| unsafe { parallel_outputs[i].assume_init() });
 
@@ -224,14 +218,14 @@ mod tests {
 	fn test_empty_inputs() {
 		const N: usize = 4;
 		let data: [&[u8]; N] = [&[], &[], &[], &[]];
-		test_parallel_vs_sequential::<N, { N * M }, { N * M / 3 }>(data, "empty inputs");
+		test_parallel_vs_sequential::<N, { N * M }>(data, "empty inputs");
 	}
 
 	#[test]
 	fn test_small_inputs() {
 		const N: usize = 2;
 		let data: [&[u8]; N] = [b"Hello... World!", b"Rust is awesome"];
-		test_parallel_vs_sequential::<N, { N * M }, { N * M / 3 }>(data, "small inputs");
+		test_parallel_vs_sequential::<N, { N * M }>(data, "small inputs");
 	}
 
 	#[test]
@@ -242,7 +236,7 @@ mod tests {
 		let data_vecs = generate_random_data::<N>(target_len, 42);
 		let data: [&[u8]; N] = array::from_fn(|i| data_vecs[i].as_slice());
 
-		test_parallel_vs_sequential::<N, { N * M }, { N * M / 3 }>(data, "multi-block inputs");
+		test_parallel_vs_sequential::<N, { N * M }>(data, "multi-block inputs");
 	}
 
 	#[test]
@@ -260,10 +254,7 @@ mod tests {
 			const N: usize = 2;
 			let data_vecs = generate_random_data::<N>(size, 123);
 			let data: [&[u8]; N] = array::from_fn(|i| data_vecs[i].as_slice());
-			test_parallel_vs_sequential::<N, { N * M }, { N * M / 3 }>(
-				data,
-				&format!("size {size}"),
-			);
+			test_parallel_vs_sequential::<N, { N * M }>(data, &format!("size {size}"));
 		}
 	}
 }

--- a/prover/prover/src/hash/vision_4/mod.rs
+++ b/prover/prover/src/hash/vision_4/mod.rs
@@ -1,5 +1,5 @@
 // Copyright 2025 Irreducible Inc.
 
 pub mod compression;
-pub mod parallel;
-pub mod single;
+pub mod digest;
+pub mod permutation;

--- a/prover/prover/src/hash/vision_6/mod.rs
+++ b/prover/prover/src/hash/vision_6/mod.rs
@@ -1,4 +1,4 @@
 // Copyright 2025 Irreducible Inc.
 
-pub mod parallel;
-pub mod single;
+pub mod digest;
+pub mod permutation;


### PR DESCRIPTION
### TL;DR

Reorganize Vision hash implementation files to better reflect their functionality.

### What changed?

- Renamed `parallel.rs` to `permutation.rs` to better reflect its purpose
- Renamed `single.rs` to `digest.rs` to better reflect its purpose
- Renamed functions from `parallel_*` to `batch_*` for clarity
- Updated import paths in all affected files
- Moved implementation files to match the new structure

### How to test?

Run the existing test suite to ensure all functionality continues to work as expected:

```bash
cargo test --package binius-prover --lib hash::vision_4
cargo test --package binius-prover --lib hash::vision_6
cargo bench --package binius-prover vision
```

### Why make this change?

This refactoring improves code organization by:

1. Using more accurate naming that better reflects the purpose of each module
2. Replacing the ambiguous term "parallel" with the more precise "batch" to describe operations that process multiple inputs simultaneously
3. Creating a more consistent structure between Vision-4 and Vision-6 implementations
4. Making the codebase easier to navigate by organizing files according to their functionality rather than their execution model