### PR TITLE
[pcs] Benchmark PCS verification

### DIFF
--- a/verifier/transcript/src/transcript.rs
+++ b/verifier/transcript/src/transcript.rs
@@ -201,7 +201,7 @@ impl<B: Buf> TranscriptReader<'_, B> {
 ///
 /// A Transcript is an abstraction over Fiat-Shamir so the prover and verifier can send and receive
 /// data.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ProverTranscript<Challenger> {
 	combined: FiatShamirBuf<BytesMut, Challenger>,
 	options: Options,


### PR DESCRIPTION
### TL;DR

Added PCS verification benchmarking and improved transcript functionality.

### What changed?

- Added benchmarking for PCS verification alongside the existing commit and prove benchmarks
- Increased security bits from 32 to 96 in the benchmark parameters
- Added `Clone` derive for `ProverTranscript` to support benchmark iterations
- Added imports for verification-related modules and functions
- Implemented evaluation point generation and evaluation in the benchmark to properly test the full verification flow
- Added proof size reporting to provide insights on proof sizes

### How to test?

Run the PCS benchmarks with:
```
cargo bench --bench pcs
```

The output will now include both proving and verification benchmarks for different log lengths, as well as reporting the proof size in bytes.

### Why make this change?

This change provides a more complete performance picture by benchmarking both the proving and verification sides of the PCS (Polynomial Commitment Scheme). Having verification benchmarks is crucial for understanding the full system performance, as verification is a critical part of the cryptographic workflow. The increased security bits also make the benchmarks more representative of real-world security requirements.