### PR TITLE
[shift] Don't send redundant prover data

### DIFF
--- a/prover/prover/src/protocols/intmul/prove.rs
+++ b/prover/prover/src/protocols/intmul/prove.rs
@@ -28,7 +28,7 @@ use super::{
 };
 use crate::protocols::sumcheck::{
 	MleToSumCheckDecorator,
-	batch::{BatchSumcheckOutput, batch_prove},
+	batch::{BatchSumcheckOutput, batch_prove_and_write_evals},
 	bivariate_product_mle::BivariateProductMlecheckProver,
 	bivariate_product_multi_mle::BivariateProductMultiMlecheckProver,
 	rerand_mle::RerandMlecheckProver,
@@ -219,7 +219,7 @@ where
 			let BatchSumcheckOutput {
 				challenges,
 				mut multilinear_evals,
-			} = batch_prove(vec![a_prover], self.transcript)?;
+			} = batch_prove_and_write_evals(vec![a_prover], self.transcript)?;
 
 			assert_eq!(multilinear_evals.len(), 1);
 
@@ -276,7 +276,7 @@ where
 		let BatchSumcheckOutput {
 			challenges,
 			mut multilinear_evals,
-		} = batch_prove(provers, self.transcript)?;
+		} = batch_prove_and_write_evals(provers, self.transcript)?;
 
 		assert_eq!(multilinear_evals.len(), 2);
 		let c_root_prover_evals = multilinear_evals
@@ -323,7 +323,7 @@ where
 			let BatchSumcheckOutput {
 				challenges,
 				mut multilinear_evals,
-			} = batch_prove(vec![prover], self.transcript)?;
+			} = batch_prove_and_write_evals(vec![prover], self.transcript)?;
 
 			assert_eq!(multilinear_evals.len(), 1);
 			eval_point = challenges;
@@ -455,7 +455,7 @@ where
 		let BatchSumcheckOutput {
 			challenges,
 			mut multilinear_evals,
-		} = batch_prove(
+		} = batch_prove_and_write_evals(
 			vec![
 				Either::Left(bivariate_sumcheck_prover),
 				Either::Right(c_lo_0_sumcheck_prover),

--- a/prover/prover/src/protocols/sumcheck/batch.rs
+++ b/prover/prover/src/protocols/sumcheck/batch.rs
@@ -89,15 +89,26 @@ where
 		.map(|prover| prover.finish())
 		.collect::<Result<Vec<_>, _>>()?;
 
-	let mut writer = transcript.message();
-	for multilinear_evals in &multilinear_evals {
-		writer.write_scalar_slice(multilinear_evals);
-	}
-
-	let output = BatchSumcheckOutput {
+	Ok(BatchSumcheckOutput {
 		challenges,
 		multilinear_evals,
-	};
+	})
+}
 
+pub fn batch_prove_and_write_evals<F, Prover, Challenger_>(
+	provers: Vec<Prover>,
+	transcript: &mut ProverTranscript<Challenger_>,
+) -> Result<BatchSumcheckOutput<F>, Error>
+where
+	F: Field,
+	Prover: SumcheckProver<F>,
+	Challenger_: Challenger,
+{
+	let output = batch_prove(provers, transcript)?;
+
+	let mut writer = transcript.message();
+	for evals in &output.multilinear_evals {
+		writer.write_scalar_slice(evals);
+	}
 	Ok(output)
 }

--- a/verifier/verifier/src/protocols/shift/verify.rs
+++ b/verifier/verifier/src/protocols/shift/verify.rs
@@ -137,13 +137,9 @@ where
 	// Check that sumcheck eval equals expected compositional value
 	let mut reader = transcript.message();
 	let witness_eval = reader.read_scalar::<F>()?;
-	let monster_eval = reader.read_scalar::<F>()?;
-	// This inout witness evaluation is redundant and not needed.
-	// The `witness_eval` above suffices.
-	let _inout_witness_eval = reader.read_scalar::<F>()?;
 
-	// Compute expected monster eval for bitand
-	let expected_monster_eval_for_bitand = {
+	// Compute monster multilinear evaluation
+	let monster_eval_for_bitand = {
 		let (a, b, c) = constraint_system
 			.and_constraints
 			.iter()
@@ -151,9 +147,7 @@ where
 			.multiunzip();
 		evaluate_monster_multilinear_for_operation(vec![a, b, c], bitand_data, &r_j, &r_s, &r_y)
 	}?;
-
-	// Compute expected monster eval for intmul
-	let expected_monster_eval_for_intmul = {
+	let monster_eval_for_intmul = {
 		let (a, b, lo, hi) = constraint_system
 			.mul_constraints
 			.iter()
@@ -167,10 +161,7 @@ where
 			&r_y,
 		)
 	}?;
-
-	if monster_eval != expected_monster_eval_for_bitand + expected_monster_eval_for_intmul {
-		return Err(Error::VerificationFailure);
-	}
+	let monster_eval = monster_eval_for_bitand + monster_eval_for_intmul;
 
 	// Rather than checking the eval claims read from the transcript are correct,
 	// we will derive from them the expected evaluation of the public input


### PR DESCRIPTION
The shift reduction verifier computes the monster multilinear evaluation themself.
