### PR TITLE
[shift] Refactor to avoid reading monster and public evals

### DIFF
--- a/prover/prover/benches/shift_reduction.rs
+++ b/prover/prover/benches/shift_reduction.rs
@@ -166,7 +166,7 @@ fn bench_prove_and_verify(c: &mut Criterion) {
 					intmul_evals,
 				);
 
-				verify(&cs, verifier_bitand_data, verifier_intmul_data, &mut verifier_transcript)
+				verify(&cs, &verifier_bitand_data, &verifier_intmul_data, &mut verifier_transcript)
 					.unwrap();
 			})
 		});

--- a/prover/prover/src/protocols/inout_check.rs
+++ b/prover/prover/src/protocols/inout_check.rs
@@ -327,14 +327,13 @@ mod tests {
 		let mut verifier_transcript = prover_transcript.into_verifier();
 
 		let pubcheck::VerifyOutput {
-			witness_eval,
-			public_eval,
+			eval,
 			eval_point: reduced_eval_point,
 		} = pubcheck::verify(n_witness_vars, &eval_point, &mut verifier_transcript).unwrap();
 
-		// Verifier computes the input/output evaluation and checks the reduced evaluation.
+		// Verifier computes the input/output evaluation and computes the witness evaluation.
 		let inout_eval = evaluate(&inout, &reduced_eval_point[..n_inout_vars]).unwrap();
-		assert_eq!(public_eval, inout_eval);
+		let witness_eval = pubcheck::compute_witness_eval(inout_eval, eval);
 
 		// Check that the original multilinears evaluate to the claimed values at the challenge.
 		let expected_witness_eval = evaluate(&witness, &reduced_eval_point).unwrap();

--- a/verifier/verifier/src/protocols/pubcheck.rs
+++ b/verifier/verifier/src/protocols/pubcheck.rs
@@ -12,10 +12,8 @@ use crate::{
 /// Output of [`verify`].
 #[derive(Debug)]
 pub struct VerifyOutput<F: Field> {
-	/// Reduced evaluation claim on the witness multilinear at the challenge point.
-	pub witness_eval: F,
-	/// Reduced evaluation claim on the public multilinear at a prefix of the challenge point.
-	pub public_eval: F,
+	/// Evaluation of the (w - p) polynomial at `eval_point`.
+	pub eval: F,
 	/// Evaluation point from the MLE-check.
 	pub eval_point: Vec<F>,
 }
@@ -69,15 +67,13 @@ pub fn verify<F: Field, Challenger_: Challenger>(
 	// MLE-check expects prover to bind variables high-to-low, so reverse challenge order.
 	challenges.reverse();
 
-	// Read the witness evaluation w(r_z, r_y').
-	let witness_eval = transcript.message().read::<F>()?;
-
-	// Derive the expected public evaluation
-	let public_eval = witness_eval - eval;
-
 	Ok(VerifyOutput {
-		witness_eval,
-		public_eval,
+		eval,
 		eval_point: challenges,
 	})
+}
+
+/// Derive the expected witness evaluation
+pub fn compute_witness_eval<F: Field>(public_eval: F, reduced_eval: F) -> F {
+	reduced_eval + public_eval
 }

--- a/verifier/verifier/src/protocols/pubcheck.rs
+++ b/verifier/verifier/src/protocols/pubcheck.rs
@@ -73,7 +73,27 @@ pub fn verify<F: Field, Challenger_: Challenger>(
 	})
 }
 
-/// Derive the expected witness evaluation
+/// Derive the expected witness evaluation.
+///
+/// Given the public input evaluation and the reduced evaluation from the pubcheck
+/// protocol, computes the witness evaluation.
+///
+/// The pubcheck protocol reduces the claim `(w - p)(r) = reduced_eval`, where
+/// `w` is the witness multilinear, `p` is the public multilinear, and `r` is
+/// the evaluation point. This function recovers `w(r)` from the equation:
+///
+/// ```text
+/// w(r) = reduced_eval + p(r)
+/// ```
+///
+/// # Arguments
+///
+/// * `public_eval` - The evaluation of the public multilinear `p` at point `r`
+/// * `reduced_eval` - The evaluation of `(w - p)` at point `r`
+///
+/// # Returns
+///
+/// The evaluation of the witness multilinear `w` at point `r`
 pub fn compute_witness_eval<F: Field>(public_eval: F, reduced_eval: F) -> F {
 	reduced_eval + public_eval
 }

--- a/verifier/verifier/src/protocols/shift/mod.rs
+++ b/verifier/verifier/src/protocols/shift/mod.rs
@@ -11,4 +11,4 @@ mod error;
 mod verify;
 
 pub use error::Error;
-pub use verify::{OperatorData, verify};
+pub use verify::{OperatorData, VerifyOutput, check_eval, verify};

--- a/verifier/verifier/src/protocols/shift/monster.rs
+++ b/verifier/verifier/src/protocols/shift/monster.rs
@@ -116,15 +116,41 @@ fn evaluate_monster_multilinear_term_for_operand<F: Field>(
 		.sum()
 }
 
-/// The monster multilinear for an operation is written
+/// Evaluates the monster multilinear polynomial for a constraint operation.
+///
+/// The monster multilinear encodes all constraints of a given type (AND or MUL) into
+/// a single polynomial. For an operation with multiple operands, it computes:
+///
 /// $$
 /// \sum_{\text{m_idx} \in \text{enumerate(operands)}}
 ///     \lambda^{\text{m_idx}+1}
 ///     \sum_{\text{op}} h_{\text{op}}(r_j, r_s) \cdot M_{\text{m}, \text{op}}(r_x', r_y, r_s)
 /// $$
-/// where $op$ ranges over the shift variants.
-/// This function computes this expression given corresponding `OperatorData`, as well
-/// as $r_j$, $r_s$, and $r_y$.
+///
+/// where:
+/// - `m_idx` indexes the operand position (0 to ARITY-1)
+/// - `op` ranges over the shift variants (logical/arithmetic shifts)
+/// - `h_op` is the shift selector polynomial
+/// - `M_m,op` is the multilinear extension of the operand values
+///
+/// # Arguments
+///
+/// * `operand_vecs` - Vector of operand vectors, one per operand position in the constraint
+/// * `operator_data` - Contains the multilinear challenge `r_x'`, univariate challenge `r_zhat'`,
+///   and evaluation claims for each operand
+/// * `lambda` - Random coefficient for batching operand evaluations
+/// * `r_j` - Challenge point for bit index variables (length `LOG_WORD_SIZE_BITS`)
+/// * `r_s` - Challenge point for shift variables (length `LOG_WORD_SIZE_BITS`)
+/// * `r_y` - Challenge point for word index variables
+///
+/// # Returns
+///
+/// The evaluation of the monster multilinear at the given challenge points, or an error
+/// if the computation fails.
+///
+/// # Errors
+///
+/// Returns an error if the binary subspace construction fails.
 pub fn evaluate_monster_multilinear_for_operation<F, const ARITY: usize>(
 	operand_vecs: Vec<Vec<&Operand>>,
 	operator_data: &OperatorData<F, ARITY>,

--- a/verifier/verifier/src/protocols/shift/monster.rs
+++ b/verifier/verifier/src/protocols/shift/monster.rs
@@ -127,7 +127,8 @@ fn evaluate_monster_multilinear_term_for_operand<F: Field>(
 /// as $r_j$, $r_s$, and $r_y$.
 pub fn evaluate_monster_multilinear_for_operation<F, const ARITY: usize>(
 	operand_vecs: Vec<Vec<&Operand>>,
-	operator_data: OperatorData<F, ARITY>,
+	operator_data: &OperatorData<F, ARITY>,
+	lambda: F,
 	r_j: &[F],
 	r_s: &[F],
 	r_y: &[F],
@@ -158,7 +159,7 @@ where
 		.into_par_iter()
 		.enumerate()
 		.map(|(i, operand_vec)| {
-			operator_data.lambda.pow([i as u64 + 1])
+			lambda.pow([i as u64 + 1])
 				* evaluate_monster_multilinear_term_for_operand(
 					operand_vec,
 					&h_op_r_s_product,

--- a/verifier/verifier/src/protocols/shift/verify.rs
+++ b/verifier/verifier/src/protocols/shift/verify.rs
@@ -8,15 +8,13 @@ use binius_transcript::{
 	fiat_shamir::{CanSample, Challenger},
 };
 use binius_utils::checked_arithmetics::strict_log_2;
+use getset::CopyGetters;
 use itertools::Itertools;
 
 use super::{BITAND_ARITY, INTMUL_ARITY, error::Error, evaluate_monster_multilinear_for_operation};
 use crate::{
 	config::LOG_WORD_SIZE_BITS,
-	protocols::{
-		pubcheck::VerifyOutput,
-		sumcheck::{SumcheckOutput, verify as verify_sumcheck},
-	},
+	protocols::sumcheck::{SumcheckOutput, verify as verify_sumcheck},
 };
 
 /// Verifier data for an operation with the specified arity.
@@ -35,7 +33,6 @@ use crate::{
 pub struct OperatorData<F, const ARITY: usize> {
 	pub r_x_prime: Vec<F>,
 	pub r_zhat_prime: F,
-	pub lambda: F,
 	pub evals: [F; ARITY],
 }
 
@@ -48,7 +45,6 @@ impl<F: Field, const ARITY: usize> OperatorData<F, ARITY> {
 		Self {
 			r_x_prime,
 			r_zhat_prime,
-			lambda: F::ZERO,
 			evals,
 		}
 	}
@@ -56,8 +52,41 @@ impl<F: Field, const ARITY: usize> OperatorData<F, ARITY> {
 	// Batching is scaled by random lambda and therefore this batched
 	// evaluation claim can be added to other batched evaluation claims
 	// without further random scaling.
-	fn batched_eval(&self) -> F {
-		self.lambda * evaluate_univariate(&self.evals, self.lambda)
+	fn batched_eval(&self, lambda: F) -> F {
+		lambda * evaluate_univariate(&self.evals, lambda)
+	}
+}
+
+/// Output of [`verify`].
+#[derive(Debug, CopyGetters)]
+pub struct VerifyOutput<F: Field> {
+	bitand_lambda: F,
+	intmul_lambda: F,
+	batch_coeff: F,
+	pub r_j: Vec<F>,
+	pub r_s: Vec<F>,
+	pub r_y: Vec<F>,
+	eval: F,
+	#[getset(get_copy = "pub")]
+	pub witness_eval: F,
+	pub inout_eval_point: Vec<F>,
+}
+
+impl<F: Field> VerifyOutput<F> {
+	pub fn r_j(&self) -> &[F] {
+		&self.r_j
+	}
+
+	pub fn r_s(&self) -> &[F] {
+		&self.r_s
+	}
+
+	pub fn r_y(&self) -> &[F] {
+		&self.r_y
+	}
+
+	pub fn inout_eval_point(&self) -> &[F] {
+		&self.inout_eval_point
 	}
 }
 
@@ -81,26 +110,23 @@ impl<F: Field, const ARITY: usize> OperatorData<F, ARITY> {
 /// - `transcript`: Interactive transcript for challenge sampling and message reading
 ///
 /// # Returns
-/// Returns `SumcheckOutput` containing the final challenges and witness evaluation,
+/// Returns [`VerifyOutput`] containing the final challenges and witness evaluation,
 /// or an error if verification fails.
 ///
 /// # Errors
 /// - Returns `Error::VerificationFailure` if monster multilinear evaluations don't match expected
 ///   values
 /// - Propagates sumcheck verification errors
-pub fn verify<F, C: Challenger>(
+pub fn verify<F: BinaryField, C: Challenger>(
 	constraint_system: &ConstraintSystem,
-	mut bitand_data: OperatorData<F, BITAND_ARITY>,
-	mut intmul_data: OperatorData<F, INTMUL_ARITY>,
+	bitand_data: &OperatorData<F, BITAND_ARITY>,
+	intmul_data: &OperatorData<F, INTMUL_ARITY>,
 	transcript: &mut VerifierTranscript<C>,
-) -> Result<VerifyOutput<F>, Error>
-where
-	F: BinaryField + From<AESTowerField8b>,
-{
-	bitand_data.lambda = transcript.sample();
-	intmul_data.lambda = transcript.sample();
+) -> Result<VerifyOutput<F>, Error> {
+	let bitand_lambda = transcript.sample();
+	let intmul_lambda = transcript.sample();
 
-	let eval = bitand_data.batched_eval() + intmul_data.batched_eval();
+	let eval = bitand_data.batched_eval(bitand_lambda) + intmul_data.batched_eval(intmul_lambda);
 
 	let SumcheckOutput {
 		eval: gamma,
@@ -119,8 +145,7 @@ where
 	let inout_n_vars = strict_log_2(constraint_system.value_vec_layout.offset_witness)
 		.expect("constraints preprocessed");
 
-	let mut inout_eval_point: Vec<F> = transcript.sample_vec(inout_n_vars);
-	inout_eval_point.extend(vec![F::ZERO; log_word_count - inout_n_vars]);
+	let inout_eval_point: Vec<F> = transcript.sample_vec(inout_n_vars);
 
 	// Batch the `gamma` as the eval claim for the shift prover
 	// together with zero as the eval claim for the inout prover.
@@ -134,9 +159,42 @@ where
 
 	r_y.reverse();
 
-	// Check that sumcheck eval equals expected compositional value
-	let mut reader = transcript.message();
-	let witness_eval = reader.read_scalar::<F>()?;
+	let witness_eval = transcript.message().read::<F>()?;
+
+	Ok(VerifyOutput {
+		bitand_lambda,
+		intmul_lambda,
+		batch_coeff,
+		r_j,
+		r_y,
+		r_s,
+		eval,
+		witness_eval,
+		inout_eval_point,
+	})
+}
+
+pub fn check_eval<F>(
+	constraint_system: &ConstraintSystem,
+	bitand_data: &OperatorData<F, BITAND_ARITY>,
+	intmul_data: &OperatorData<F, INTMUL_ARITY>,
+	output: &VerifyOutput<F>,
+	public_eval: F,
+) -> Result<(), Error>
+where
+	F: BinaryField + From<AESTowerField8b>,
+{
+	let VerifyOutput {
+		bitand_lambda,
+		intmul_lambda,
+		batch_coeff,
+		eval,
+		r_j,
+		r_s,
+		r_y,
+		witness_eval,
+		inout_eval_point,
+	} = output;
 
 	// Compute monster multilinear evaluation
 	let monster_eval_for_bitand = {
@@ -145,7 +203,14 @@ where
 			.iter()
 			.map(|AndConstraint { a, b, c }| (a, b, c))
 			.multiunzip();
-		evaluate_monster_multilinear_for_operation(vec![a, b, c], bitand_data, &r_j, &r_s, &r_y)
+		evaluate_monster_multilinear_for_operation(
+			vec![a, b, c],
+			bitand_data,
+			*bitand_lambda,
+			r_j,
+			r_s,
+			r_y,
+		)
 	}?;
 	let monster_eval_for_intmul = {
 		let (a, b, lo, hi) = constraint_system
@@ -156,34 +221,30 @@ where
 		evaluate_monster_multilinear_for_operation(
 			vec![a, b, lo, hi],
 			intmul_data,
-			&r_j,
-			&r_s,
-			&r_y,
+			*intmul_lambda,
+			r_j,
+			r_s,
+			r_y,
 		)
 	}?;
 	let monster_eval = monster_eval_for_bitand + monster_eval_for_intmul;
 
-	// Rather than checking the eval claims read from the transcript are correct,
-	// we will derive from them the expected evaluation of the public input
-	// and return that in the `VerifyOutput`.
-	// The composition should equal
-	// `witness_eval * monster_eval + batch_coeff * eq_eval * (witness_eval - public_eval)`
-	// where
-	let eq_eval = eq_ind(&inout_eval_point, &r_y);
-	// and the prover claims this equals `eval`, output from the sumcheck.
-	// We must rearrange this equation to isolate `public_eval` on one side.
-	// Step 1: `(witness_eval * monster_eval - eval) == batch_coeff * eq_eval * (public_eval -
-	// witness_eval)`
-	// Step 2: `(witness_eval * monster_eval - eval) / (batch_coeff *
-	// eq_eval).invert() + witness_eval == public_eval`
-	// Therefore we derive `public_eval` as
-	let public_eval = (witness_eval * monster_eval - eval)
-		* (batch_coeff * eq_eval).invert_or_zero()
-		+ witness_eval;
+	// Compute the evaluation of the eq indicator with r_y and the zero-padded inout point.
+	let (r_y_head, r_y_tail) = r_y.split_at(inout_eval_point.len());
+	let eq_eval_head = eq_ind(inout_eval_point, r_y_head);
+	let eq_eval_tail = eq_ind(&vec![F::ZERO; r_y_tail.len()], r_y_tail);
+	let eq_eval = eq_eval_head * eq_eval_tail;
 
-	Ok(VerifyOutput {
-		witness_eval,
-		public_eval,
-		eval_point: [r_j, r_y].concat(),
-	})
+	// Check if the prover-provided witness value is satisfying.
+	//
+	// The protocol could compute this witness value instead of reading it from the prover. This
+	// would require inverting a random element, however, making the protocol incomplete with
+	// negligible probability. As a matter of taste, we read the witness value from the prover.
+	let expected_eval =
+		*witness_eval * monster_eval + *batch_coeff * eq_eval * (*witness_eval - public_eval);
+	if *eval != expected_eval {
+		return Err(Error::VerificationFailure);
+	}
+
+	Ok(())
 }


### PR DESCRIPTION
[shift] Refactor to avoid reading monster and public evals

This refactors the shift reduction prover, so that the only value read
by the verifier is the witness evaluation---the monster multilinear eval
and public eval are computed by the verifier. This is correct because
the verifier *can* compute them, whereas the witness eval is the claim
for the next reduction.

Fix documentation