### PR TITLE
[fri] Remove separate alphabet field in FRI

### DIFF
--- a/prover/prover/src/fri/query.rs
+++ b/prover/prover/src/fri/query.rs
@@ -2,9 +2,7 @@
 
 use std::iter;
 
-use binius_field::{
-	BinaryField, ExtensionField, PackedField, packed::iter_packed_slice_with_offset,
-};
+use binius_field::{BinaryField, PackedField, packed::iter_packed_slice_with_offset};
 use binius_transcript::TranscriptWriter;
 use binius_verifier::{
 	fri::{FRIParams, vcs_optimal_layers_depths_iter},
@@ -18,25 +16,23 @@ use crate::{fri::Error, merkle_tree::MerkleTreeProver};
 
 /// A prover for the FRI query phase.
 #[derive(Debug)]
-pub struct FRIQueryProver<'a, F, FA, P, MerkleProver, VCS>
+pub struct FRIQueryProver<'a, F, P, MerkleProver, VCS>
 where
 	F: BinaryField,
-	FA: BinaryField,
 	P: PackedField<Scalar = F>,
 	MerkleProver: MerkleTreeProver<F, Scheme = VCS>,
 	VCS: MerkleTreeScheme<F>,
 {
-	pub(super) params: &'a FRIParams<F, FA>,
+	pub(super) params: &'a FRIParams<F>,
 	pub(super) codeword: &'a [P],
 	pub(super) codeword_committed: &'a MerkleProver::Committed,
 	pub(super) round_committed: Vec<(Vec<F>, MerkleProver::Committed)>,
 	pub(super) merkle_prover: &'a MerkleProver,
 }
 
-impl<F, FA, P, MerkleProver, VCS> FRIQueryProver<'_, F, FA, P, MerkleProver, VCS>
+impl<F, P, MerkleProver, VCS> FRIQueryProver<'_, F, P, MerkleProver, VCS>
 where
-	F: BinaryField + ExtensionField<FA>,
-	FA: BinaryField,
+	F: BinaryField,
 	P: PackedField<Scalar = F>,
 	MerkleProver: MerkleTreeProver<F, Scheme = VCS>,
 	VCS: MerkleTreeScheme<F>,

--- a/prover/prover/src/pcs.rs
+++ b/prover/prover/src/pcs.rs
@@ -40,7 +40,7 @@ where
 {
 	ntt: &'a NTT,
 	merkle_prover: &'a MerkleProver,
-	fri_params: &'a FRIParams<B128, B128>,
+	fri_params: &'a FRIParams<B128>,
 }
 
 impl<'a, NTT, MerkleProver, VCS> OneBitPCSProver<'a, NTT, MerkleProver, VCS>
@@ -59,7 +59,7 @@ where
 	pub fn new(
 		ntt: &'a NTT,
 		merkle_prover: &'a MerkleProver,
-		fri_params: &'a FRIParams<B128, B128>,
+		fri_params: &'a FRIParams<B128>,
 	) -> Self {
 		let rs_code = fri_params.rs_code();
 		assert_eq!(&ntt.subspace(rs_code.log_len()), rs_code.subspace()); // precondition

--- a/prover/prover/src/protocols/basefold/prover.rs
+++ b/prover/prover/src/protocols/basefold/prover.rs
@@ -37,7 +37,7 @@ where
 	VCS: MerkleTreeScheme<F, Digest: SerializeBytes>,
 {
 	sumcheck_prover: MultilinearSumcheckProver<F, P>,
-	fri_folder: FRIFoldProver<'a, F, F, P, NTT, MerkleProver, VCS>,
+	fri_folder: FRIFoldProver<'a, F, P, NTT, MerkleProver, VCS>,
 }
 
 impl<'a, F, P, NTT, MerkleProver, VCS> BaseFoldProver<'a, F, P, NTT, MerkleProver, VCS>
@@ -73,7 +73,7 @@ where
 		committed: &'a MerkleProver::Committed,
 		merkle_prover: &'a MerkleProver,
 		ntt: &'a NTT,
-		fri_params: &'a FRIParams<F, F>,
+		fri_params: &'a FRIParams<F>,
 	) -> Result<Self, Error> {
 		assert_eq!(multilinear.log_len(), transparent_multilinear.log_len());
 

--- a/verifier/verifier/src/fri/fold.rs
+++ b/verifier/verifier/src/fri/fold.rs
@@ -133,10 +133,9 @@ where
 ///
 /// This verifier encapsulates the logic of determining which FRI rounds require
 /// commitments and handles reading them from the transcript at the appropriate times.
-pub struct FRIFoldVerifier<'a, F, FA, Digest>
+pub struct FRIFoldVerifier<'a, F, Digest>
 where
-	F: BinaryField + ExtensionField<FA>,
-	FA: BinaryField,
+	F: BinaryField,
 {
 	/// Indicates which rounds require reading a commitment
 	commit_rounds: Vec<bool>,
@@ -144,13 +143,12 @@ where
 	round_commitments: Vec<Digest>,
 	/// Current round number
 	curr_round: usize,
-	_phantom: std::marker::PhantomData<&'a (F, FA)>,
+	_phantom: std::marker::PhantomData<&'a F>,
 }
 
-impl<'a, F, FA, Digest> FRIFoldVerifier<'a, F, FA, Digest>
+impl<'a, F, Digest> FRIFoldVerifier<'a, F, Digest>
 where
-	F: BinaryField + ExtensionField<FA>,
-	FA: BinaryField,
+	F: BinaryField,
 	Digest: DeserializeBytes + Clone,
 {
 	/// Creates a new FRI fold verifier.
@@ -159,7 +157,7 @@ where
 	///
 	/// * `params` - The FRI parameters
 	/// * `n_rounds` - The total number of folding rounds (typically equals n_vars for sumcheck)
-	pub fn new(params: &'a FRIParams<F, FA>) -> Self {
+	pub fn new(params: &'a FRIParams<F>) -> Self {
 		let commit_rounds = calculate_fri_commit_rounds(
 			params.log_batch_size(),
 			params.fold_arities(),

--- a/verifier/verifier/src/fri/verify.rs
+++ b/verifier/verifier/src/fri/verify.rs
@@ -2,7 +2,7 @@
 
 use std::iter;
 
-use binius_field::{BinaryField, ExtensionField};
+use binius_field::BinaryField;
 use binius_math::{
 	FieldBuffer,
 	multilinear::eq::eq_ind_partial_eval,
@@ -30,14 +30,13 @@ use crate::{
 /// The verifier is instantiated after the folding rounds and is used to test consistency of the
 /// round messages and the original purported codeword.
 #[derive(Debug)]
-pub struct FRIQueryVerifier<'a, F, FA, VCS>
+pub struct FRIQueryVerifier<'a, F, VCS>
 where
-	F: BinaryField + ExtensionField<FA>,
-	FA: BinaryField,
+	F: BinaryField,
 	VCS: MerkleTreeScheme<F>,
 {
 	vcs: &'a VCS,
-	params: &'a FRIParams<F, FA>,
+	params: &'a FRIParams<F>,
 	/// Received commitment to the codeword.
 	codeword_commitment: &'a VCS::Digest,
 	/// Received commitments to the round messages.
@@ -48,15 +47,14 @@ where
 	fold_challenges: &'a [F],
 }
 
-impl<'a, F, FA, VCS> FRIQueryVerifier<'a, F, FA, VCS>
+impl<'a, F, VCS> FRIQueryVerifier<'a, F, VCS>
 where
-	F: BinaryField + ExtensionField<FA>,
-	FA: BinaryField,
+	F: BinaryField,
 	VCS: MerkleTreeScheme<F, Digest: DeserializeBytes>,
 {
 	#[allow(clippy::too_many_arguments)]
 	pub fn new(
-		params: &'a FRIParams<F, FA>,
+		params: &'a FRIParams<F>,
 		vcs: &'a VCS,
 		codeword_commitment: &'a VCS::Digest,
 		round_commitments: &'a [VCS::Digest],
@@ -148,7 +146,7 @@ where
 	/// Returns the fully-folded message value.
 	pub fn verify_last_oracle(
 		&self,
-		ntt: &NeighborsLastSingleThread<GenericOnTheFly<FA>>,
+		ntt: &NeighborsLastSingleThread<GenericOnTheFly<F>>,
 		terminate_codeword: &[F],
 	) -> Result<F, Error> {
 		let n_final_challenges = self.params.n_final_challenges();
@@ -205,7 +203,7 @@ where
 	pub fn verify_query<B: Buf>(
 		&self,
 		mut index: usize,
-		ntt: &impl AdditiveNTT<Field = FA>,
+		ntt: &impl AdditiveNTT<Field = F>,
 		terminate_codeword: &[F],
 		layers: &[Vec<VCS::Digest>],
 		advice: &mut TranscriptReader<B>,

--- a/verifier/verifier/src/pcs.rs
+++ b/verifier/verifier/src/pcs.rs
@@ -43,7 +43,7 @@ pub fn verify<F, MTScheme, Challenger_>(
 	evaluation_claim: F,
 	eval_point: &[F],
 	codeword_commitment: MTScheme::Digest,
-	fri_params: &FRIParams<F, F>,
+	fri_params: &FRIParams<F>,
 	merkle_scheme: &MTScheme,
 ) -> Result<(), Error>
 where

--- a/verifier/verifier/src/protocols/basefold.rs
+++ b/verifier/verifier/src/protocols/basefold.rs
@@ -53,7 +53,7 @@ use crate::{
 /// The [`ReducedOutput`] holding the final FRI value, the final sumcheck value, and the challenges
 /// used in the sumcheck rounds.
 pub fn verify<F, MTScheme, Challenger_>(
-	fri_params: &FRIParams<F, F>,
+	fri_params: &FRIParams<F>,
 	merkle_scheme: &MTScheme,
 	n_vars: usize,
 	codeword_commitment: MTScheme::Digest,

--- a/verifier/verifier/src/verify.rs
+++ b/verifier/verifier/src/verify.rs
@@ -46,7 +46,7 @@ pub const SECURITY_BITS: usize = 96;
 #[derive(Debug, Clone)]
 pub struct Verifier<MerkleHash, MerkleCompress> {
 	constraint_system: ConstraintSystem,
-	fri_params: FRIParams<B128, B128>,
+	fri_params: FRIParams<B128>,
 	merkle_scheme: BinaryMerkleTreeScheme<B128, MerkleHash, MerkleCompress>,
 	log_public_words: usize,
 }
@@ -124,7 +124,7 @@ where
 	}
 
 	/// Returns the chosen FRI parameters.
-	pub fn fri_params(&self) -> &FRIParams<B128, B128> {
+	pub fn fri_params(&self) -> &FRIParams<B128> {
 		&self.fri_params
 	}
 


### PR DESCRIPTION
This generalization is no longer needed in Binius64.