### PR TITLE
[circuits] Make sha256 and sha512 faster

### DIFF
--- a/verifier/circuits/src/sha256/compress.rs
+++ b/verifier/circuits/src/sha256/compress.rs
@@ -272,13 +272,8 @@ mod tests {
 	fn sha256_chain() {
 		// Tests multiple SHA-256 compress512 invocations where the outputs are linked to the inputs
 		// of the following compression function.
-		//
-		// This creates ~100 layers with a lot of computations and a very large number of layers
-		// (hundreds of thousands) with a few gates each.
-		const N: usize = 1 << 10;
+		const N: usize = 3;
 		let circuit = CircuitBuilder::new();
-
-		println!("{N} sha256 compress512 invocations");
 
 		let mut compress_vec = Vec::with_capacity(N);
 
@@ -317,10 +312,8 @@ mod tests {
 	#[test]
 	fn sha256_parallel() {
 		// Test multiple SHA-256 compressions in parallel (no chaining)
-		const N: usize = 1 << 10;
+		const N: usize = 3;
 		let circuit = CircuitBuilder::new();
-
-		println!("{N} sha256 compress512 invocations in parallel");
 
 		let mut compress_vec = Vec::with_capacity(N);
 

--- a/verifier/circuits/src/sha512/compress.rs
+++ b/verifier/circuits/src/sha512/compress.rs
@@ -332,13 +332,8 @@ mod tests {
 	fn sha512_chain() {
 		// Tests multiple SHA-512 compress1024 invocations where the outputs are linked to the
 		// inputs of the following compression function.
-		//
-		// This creates ~100 layers with a lot of computations and a very large number of layers
-		// (hundreds of thousands) with a few gates each.
-		const N: usize = 1 << 10;
+		const N: usize = 3;
 		let circuit = CircuitBuilder::new();
-
-		println!("{N} sha512 compress1024 invocations");
 
 		let mut compress_vec = Vec::with_capacity(N);
 
@@ -377,10 +372,8 @@ mod tests {
 	#[test]
 	fn sha512_parallel() {
 		// Test multiple SHA-512 compressions in parallel (no chaining)
-		const N: usize = 1 << 10;
+		const N: usize = 3;
 		let circuit = CircuitBuilder::new();
-
-		println!("{N} sha512 compress1024 invocations in parallel");
 
 		let mut compress_vec = Vec::with_capacity(N);
 
@@ -404,7 +397,6 @@ mod tests {
 			compress.populate_m(&mut w, [0; 128]);
 		}
 		circuit.populate_wire_witness(&mut w).unwrap();
-
 		verify_constraints(cs, &w.into_value_vec()).unwrap();
 	}
 }


### PR DESCRIPTION
Simply reduce the circuit size in tests.