### PR TITLE
[field_buffer] Index and IndexMut on FieldBuffer for convenience

### DIFF
--- a/prover/prover/src/protocols/basefold/sumcheck.rs
+++ b/prover/prover/src/protocols/basefold/sumcheck.rs
@@ -61,8 +61,12 @@ where
 	let out = (0..(1 << new_log_len))
 		.into_par_iter()
 		.map(|i| {
-			let even = multilinear_extension.get(2 * i).expect("out of bounds");
-			let odd = multilinear_extension.get(2 * i + 1).expect("out of bounds");
+			let even = multilinear_extension
+				.get_checked(2 * i)
+				.expect("out of bounds");
+			let odd = multilinear_extension
+				.get_checked(2 * i + 1)
+				.expect("out of bounds");
 			extrapolate_line_packed(even, odd, challenge)
 		})
 		.collect::<Vec<_>>();
@@ -92,11 +96,11 @@ where
 		let (g_of_zero, g_of_one, g_leading) = (0..n_half)
 			.into_par_iter()
 			.map(|i| {
-				let a_even = a.get(2 * i).expect("a even index out of bounds");
-				let a_odd = a.get(2 * i + 1).expect("a odd index out of bounds");
+				let a_even = a.get_checked(2 * i).expect("a even index out of bounds");
+				let a_odd = a.get_checked(2 * i + 1).expect("a odd index out of bounds");
 
-				let b_even = b.get(2 * i).expect("b even index out of bounds");
-				let b_odd = b.get(2 * i + 1).expect("b odd index out of bounds");
+				let b_even = b.get_checked(2 * i).expect("b even index out of bounds");
+				let b_odd = b.get_checked(2 * i + 1).expect("b odd index out of bounds");
 
 				let even = a_even * b_even;
 				let odd = a_odd * b_odd;
@@ -130,7 +134,10 @@ where
 	}
 
 	fn finish(self) -> Result<Vec<F>, Error> {
-		Ok(vec![self.multilinears[0].get(0)?, self.multilinears[1].get(0)?])
+		Ok(vec![
+			self.multilinears[0].get_checked(0)?,
+			self.multilinears[1].get_checked(0)?,
+		])
 	}
 }
 
@@ -151,7 +158,7 @@ pub mod test {
 		P: PackedField<Scalar = F>,
 	{
 		Ok((0..a.len())
-			.map(|i| Ok(a.get(i)? * b.get(i)?))
+			.map(|i| Ok(a.get_checked(i)? * b.get_checked(i)?))
 			.collect::<Result<Vec<_>, Error>>()?
 			.into_iter()
 			.sum())
@@ -271,7 +278,7 @@ pub mod test {
 		let mut g_of_zero = F::ZERO;
 		let mut g_of_one = F::ZERO;
 		for i in 0..n {
-			let prod = multilinear.get(i)? * eq_r.get(i)?;
+			let prod = multilinear.get_checked(i)? * eq_r.get_checked(i)?;
 			if i.is_multiple_of(2) {
 				g_of_zero += prod;
 			} else {

--- a/prover/prover/src/protocols/inout_check.rs
+++ b/prover/prover/src/protocols/inout_check.rs
@@ -250,7 +250,7 @@ where
 		}
 
 		// Return only the witness evaluation
-		let witness_eval = self.witness.get(0).expect("witness.len() == 1");
+		let witness_eval = self.witness.get_checked(0).expect("witness.len() == 1");
 		Ok(vec![witness_eval])
 	}
 }

--- a/prover/prover/src/protocols/sumcheck/bivariate_product.rs
+++ b/prover/prover/src/protocols/sumcheck/bivariate_product.rs
@@ -106,7 +106,7 @@ impl<F: Field, P: PackedField<Scalar = F>> SumcheckProver<F> for BivariateProduc
 			.multilinears
 			.into_iter()
 			.map(|multilinear| {
-				multilinear.get(0).expect(
+				multilinear.get_checked(0).expect(
 					"multilinear.log_len() == n_vars; \
 				 	n_vars == 0; \
 				 	multilinear.len() == 1",

--- a/prover/prover/src/protocols/sumcheck/bivariate_product_mle.rs
+++ b/prover/prover/src/protocols/sumcheck/bivariate_product_mle.rs
@@ -181,7 +181,7 @@ where
 		let multilinear_evals = self
 			.multilinears
 			.into_iter()
-			.map(|multilinear| multilinear.get(0).expect("multilinear.len() == 1"))
+			.map(|multilinear| multilinear.get_checked(0).expect("multilinear.len() == 1"))
 			.collect();
 
 		Ok(multilinear_evals)

--- a/prover/prover/src/protocols/sumcheck/bivariate_product_multi_mle.rs
+++ b/prover/prover/src/protocols/sumcheck/bivariate_product_multi_mle.rs
@@ -165,7 +165,7 @@ where
 		let multilinear_evals = self
 			.multilinears
 			.into_iter()
-			.map(|multilinear| multilinear.get(0).expect("multilinear.len() == 1"))
+			.map(|multilinear| multilinear.get_checked(0).expect("multilinear.len() == 1"))
 			.collect();
 
 		Ok(multilinear_evals)

--- a/prover/prover/src/protocols/sumcheck/quadratic_mle.rs
+++ b/prover/prover/src/protocols/sumcheck/quadratic_mle.rs
@@ -208,7 +208,7 @@ where
 		let multilinear_evals = self
 			.multilinears
 			.into_iter()
-			.map(|multilinear| multilinear.get(0).expect("multilinear.len() == 1"))
+			.map(|multilinear| multilinear.get_checked(0).expect("multilinear.len() == 1"))
 			.collect();
 
 		Ok(multilinear_evals)

--- a/prover/prover/src/protocols/sumcheck/rerand_mle.rs
+++ b/prover/prover/src/protocols/sumcheck/rerand_mle.rs
@@ -177,7 +177,7 @@ where
 			.into_iter()
 			.map(|multilinear| {
 				debug_assert_eq!(multilinear.log_len(), 0);
-				multilinear.get(0).expect("multilinear.len()==1")
+				multilinear.get_checked(0).expect("multilinear.len()==1")
 			})
 			.collect();
 

--- a/prover/prover/src/protocols/sumcheck/selector_mle.rs
+++ b/prover/prover/src/protocols/sumcheck/selector_mle.rs
@@ -131,7 +131,8 @@ where
 						izip!(&mut packed_prime_evals, &self.gruen32s).enumerate()
 					{
 						let eq_chunk = gruen32.chunk_eq_expansion();
-						let eq_suffix_eval = gruen32.suffix_eq_expansion().get(chunk_index)?;
+						let eq_suffix_eval =
+							gruen32.suffix_eq_expansion().get_checked(chunk_index)?;
 
 						let selector_0_chunk = self.switchover.get_chunk(
 							&mut binary_chunk_0,
@@ -228,12 +229,16 @@ where
 
 		for selector in self.switchover.finalize()? {
 			debug_assert_eq!(selector.log_len(), 0);
-			let eval = selector.get(0).expect("selector.len() == 1");
+			let eval = selector.get_checked(0).expect("selector.len() == 1");
 			multilinear_evals.push(eval);
 		}
 
 		debug_assert_eq!(self.selected.log_len(), 0);
-		multilinear_evals.push(self.selected.get(0).expect("multilinear.len() == 1"));
+		multilinear_evals.push(
+			self.selected
+				.get_checked(0)
+				.expect("multilinear.len() == 1"),
+		);
 
 		Ok(multilinear_evals)
 	}

--- a/prover/prover/src/protocols/sumcheck/switchover.rs
+++ b/prover/prover/src/protocols/sumcheck/switchover.rs
@@ -61,7 +61,7 @@ where
 		let switchover = switchover.min(n_vars).max(1);
 		let mut tensor =
 			FieldBuffer::zeros_truncated(0, switchover).expect("log_cap() can't be negative");
-		tensor.set(0, F::ONE).expect("len() >= 1");
+		tensor.set_checked(0, F::ONE).expect("len() >= 1");
 
 		Self {
 			n_multilinears,

--- a/prover/prover/src/ring_switch.rs
+++ b/prover/prover/src/ring_switch.rs
@@ -403,7 +403,7 @@ mod test {
 				row_batching_expanded_query.as_ref(),
 			);
 
-			assert_eq!(rs_eq.get(hypercube_point).unwrap(), evaluated_at_pt);
+			assert_eq!(rs_eq.get_checked(hypercube_point).unwrap(), evaluated_at_pt);
 		}
 	}
 

--- a/verifier/math/src/field_buffer.rs
+++ b/verifier/math/src/field_buffer.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 Irreducible Inc.
 
 use std::{
-	ops::{Deref, DerefMut},
+	ops::{Deref, DerefMut, Index, IndexMut},
 	slice,
 };
 
@@ -628,6 +628,20 @@ impl<P: PackedField, Data: DerefMut<Target = [P]>> AsMut<[P]> for FieldBuffer<P,
 	#[inline]
 	fn as_mut(&mut self) -> &mut [P] {
 		&mut self.values[..1 << self.log_len.saturating_sub(P::LOG_WIDTH)]
+	}
+}
+
+impl<F: Field, Data: Deref<Target = [F]>> Index<usize> for FieldBuffer<F, Data> {
+	type Output = F;
+
+	fn index(&self, index: usize) -> &Self::Output {
+		&self.values[index]
+	}
+}
+
+impl<F: Field, Data: DerefMut<Target = [F]>> IndexMut<usize> for FieldBuffer<F, Data> {
+	fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+		&mut self.values[index]
 	}
 }
 

--- a/verifier/math/src/fold.rs
+++ b/verifier/math/src/fold.rs
@@ -268,10 +268,10 @@ mod tests {
 
 		// Extract values from both results for comparison
 		let fold_cols_values: Vec<B128> = (0..fold_cols_result.len())
-			.map(|i| fold_cols_result.to_ref().get(i).unwrap())
+			.map(|i| fold_cols_result.to_ref().get_checked(i).unwrap())
 			.collect();
 		let fold_rows_values: Vec<B128> = (0..fold_rows_result.len())
-			.map(|i| fold_rows_result.to_ref().get(i).unwrap())
+			.map(|i| fold_rows_result.to_ref().get_checked(i).unwrap())
 			.collect();
 
 		// Compare results

--- a/verifier/math/src/inner_product.rs
+++ b/verifier/math/src/inner_product.rs
@@ -115,7 +115,7 @@ mod tests {
 		let result_packed = inner_product_buffers(&buffer_a, &buffer_b);
 
 		// Compute expected result manually - only first element should be used
-		let expected = buffer_a.get(0).unwrap() * buffer_b.get(0).unwrap();
+		let expected = buffer_a.get_checked(0).unwrap() * buffer_b.get_checked(0).unwrap();
 
 		assert_eq!(result_par, expected, "inner_product_par failed for log_len=0");
 		assert_eq!(result_packed, expected, "inner_product_packed failed for log_len=0");

--- a/verifier/math/src/multilinear/eq.rs
+++ b/verifier/math/src/multilinear/eq.rs
@@ -125,9 +125,7 @@ pub fn eq_ind_partial_eval<P: PackedField>(point: &[P::Scalar]) -> FieldBuffer<P
 	// but since tensor_prod_eq_ind starts with log_n_values=0, we need the final size
 	let log_size = point.len();
 	let mut buffer = FieldBuffer::zeros_truncated(0, log_size).expect("log_size >= 0");
-	buffer
-		.set(0, P::Scalar::ONE)
-		.expect("buffer has length exactly 1");
+	buffer.set(0, P::Scalar::ONE);
 	tensor_prod_eq_ind(&mut buffer, point).expect("buffer is allocated with the correct length");
 	buffer
 }
@@ -222,7 +220,7 @@ mod tests {
 		let query = vec![v0, v1];
 		// log_len = 0, query.len() = 2, so total log_cap = 2
 		let mut result = FieldBuffer::zeros_truncated(0, query.len()).unwrap();
-		result.set(0, F::ONE).unwrap();
+		result.set_checked(0, F::ONE).unwrap();
 		tensor_prod_eq_ind(&mut result, &query).unwrap();
 		let result_vec: Vec<F> = P::iter_slice(result.as_ref()).collect();
 		assert_eq!(
@@ -244,7 +242,7 @@ mod tests {
 		let max_n_vars = exps * (exps + 1) / 2;
 		let mut coords = Vec::with_capacity(max_n_vars);
 		let mut eq_expansion = FieldBuffer::zeros_truncated(0, max_n_vars).unwrap();
-		eq_expansion.set(0, F::ONE).unwrap();
+		eq_expansion.set_checked(0, F::ONE).unwrap();
 
 		for extra_count in 1..=exps {
 			let extra = random_scalars(&mut rng, extra_count);
@@ -254,7 +252,7 @@ mod tests {
 
 			assert_eq!(eq_expansion.log_len(), coords.len());
 			for i in 0..eq_expansion.len() {
-				let v = eq_expansion.get(i).unwrap();
+				let v = eq_expansion.get_checked(i).unwrap();
 				let hypercube_point = index_to_hypercube_point(coords.len(), i);
 				assert_eq!(v, eq_ind(&hypercube_point, &coords));
 			}
@@ -268,7 +266,7 @@ mod tests {
 		assert_eq!(result.log_len(), 0);
 		assert_eq!(result.len(), 1);
 		let result_mut = result;
-		assert_eq!(result_mut.get(0).unwrap(), F::ONE);
+		assert_eq!(result_mut.get_checked(0).unwrap(), F::ONE);
 	}
 
 	#[test]
@@ -279,8 +277,8 @@ mod tests {
 		assert_eq!(result.log_len(), 1);
 		assert_eq!(result.len(), 2);
 		let result_mut = result;
-		assert_eq!(result_mut.get(0).unwrap(), F::ONE - r0);
-		assert_eq!(result_mut.get(1).unwrap(), r0);
+		assert_eq!(result_mut.get_checked(0).unwrap(), F::ONE - r0);
+		assert_eq!(result_mut.get_checked(1).unwrap(), r0);
 	}
 
 	#[test]
@@ -338,7 +336,7 @@ mod tests {
 
 		// Query the value at that index
 		let result_mut = result;
-		let partial_eval_value = result_mut.get(index).unwrap();
+		let partial_eval_value = result_mut.get_checked(index).unwrap();
 
 		let index_bits = index_to_hypercube_point(n_vars, index);
 		let eq_ind_value = eq_ind(&point, &index_bits);
@@ -364,7 +362,7 @@ mod tests {
 			let eq_ind_ref = eq_ind_partial_eval::<P>(&point[..truncated_log_n_values]);
 			assert_eq!(eq_ind_ref.len(), eq_ind.len());
 			for i in 0..eq_ind.len() {
-				assert_eq!(eq_ind.get(i).unwrap(), eq_ind_ref.get(i).unwrap());
+				assert_eq!(eq_ind.get_checked(i).unwrap(), eq_ind_ref.get_checked(i).unwrap());
 			}
 
 			log_n_values = truncated_log_n_values;
@@ -386,7 +384,7 @@ mod tests {
 
 		let mut prepend = FieldBuffer::<P>::zeros_truncated(0, n_vars).unwrap();
 		let (prefix, suffix) = point.split_at(n_vars - base_vars);
-		prepend.set(0, F::ONE).unwrap();
+		prepend.set_checked(0, F::ONE).unwrap();
 		tensor_prod_eq_ind(&mut prepend, suffix).unwrap();
 		tensor_prod_eq_ind_prepend(&mut prepend, prefix).unwrap();
 

--- a/verifier/math/src/multilinear/evaluate.rs
+++ b/verifier/math/src/multilinear/evaluate.rs
@@ -102,7 +102,7 @@ where
 	}
 
 	assert_eq!(evals.len(), 1);
-	Ok(evals.get(0).expect("evals.len() == 1"))
+	Ok(evals.get(0))
 }
 
 #[cfg(test)]
@@ -180,7 +180,7 @@ mod tests {
 			let eval_result = evaluate(&buffer, &point).unwrap();
 
 			// Get the value directly from the buffer
-			let direct_value = buffer.get(index).unwrap();
+			let direct_value = buffer.get_checked(index).unwrap();
 
 			// They should be equal
 			assert_eq!(eval_result, direct_value);

--- a/verifier/math/src/multilinear/fold.rs
+++ b/verifier/math/src/multilinear/fold.rs
@@ -117,7 +117,7 @@ mod tests {
 			fold_highest_var_inplace(&mut multilinear, scalar).unwrap();
 		}
 
-		assert_eq!(multilinear.get(0).unwrap(), eval);
+		assert_eq!(multilinear.get_checked(0).unwrap(), eval);
 	}
 
 	fn test_binary_fold_high_conforms_to_regular_fold_high_helper(

--- a/verifier/math/src/ntt/neighbors_last.rs
+++ b/verifier/math/src/ntt/neighbors_last.rs
@@ -44,12 +44,12 @@ impl<DC: DomainContext> AdditiveNTT for NeighborsLastReference<DC> {
 				for idx0 in block_start..(block_start + block_size_half) {
 					let idx1 = block_size_half | idx0;
 					// perform butterfly
-					let mut u = data.get(idx0).unwrap();
-					let mut v = data.get(idx1).unwrap();
+					let mut u = data.get_checked(idx0).unwrap();
+					let mut v = data.get_checked(idx1).unwrap();
 					u += v * twiddle;
 					v += u;
-					data.set(idx0, u).unwrap();
-					data.set(idx1, v).unwrap();
+					data.set_checked(idx0, u).unwrap();
+					data.set_checked(idx1, v).unwrap();
 				}
 			}
 		}
@@ -72,12 +72,12 @@ impl<DC: DomainContext> AdditiveNTT for NeighborsLastReference<DC> {
 				for idx0 in block_start..(block_start + block_size_half) {
 					let idx1 = block_size_half | idx0;
 					// perform butterfly
-					let mut u = data.get(idx0).unwrap();
-					let mut v = data.get(idx1).unwrap();
+					let mut u = data.get_checked(idx0).unwrap();
+					let mut v = data.get_checked(idx1).unwrap();
 					v += u;
 					u += v * twiddle;
-					data.set(idx0, u).unwrap();
-					data.set(idx1, v).unwrap();
+					data.set_checked(idx0, u).unwrap();
+					data.set_checked(idx1, v).unwrap();
 				}
 			}
 		}

--- a/verifier/verifier/src/protocols/shift/monster.rs
+++ b/verifier/verifier/src/protocols/shift/monster.rs
@@ -208,7 +208,7 @@ fn evaluate_matrices<F: BinaryField>(
 					};
 					evals[shift_id][*amount] += constraint_eval
 						* r_y_tensor
-							.get(value_index.0 as usize)
+							.get_checked(value_index.0 as usize)
 							.expect("constraint system value indices are in range");
 				}
 			}


### PR DESCRIPTION
Stacked PRs:
 * #1270
 * #1269
 * __->__#1268
 * #1267
 * #1266
 * #1265


--- --- ---

### [field_buffer] Index and IndexMut on FieldBuffer for convenience


They are only implemented for singleton packed fields
