### PR TITLE
[shift] Refactor evaluate_h_op to use FieldBuffer

### DIFF
--- a/prover/prover/src/protocols/shift/monster.rs
+++ b/prover/prover/src/protocols/shift/monster.rs
@@ -127,7 +127,7 @@ where
 	]
 	.map(|r_zhat_prime| {
 		let l_tilde = lagrange_evals(&subspace, r_zhat_prime);
-		evaluate_h_op(&l_tilde, r_j, r_s)
+		evaluate_h_op(l_tilde.to_ref(), r_j, r_s)
 	});
 
 	let r_s_tensor = eq_ind_partial_eval::<F>(r_s);
@@ -223,7 +223,7 @@ mod tests {
 				.unwrap()
 				.isomorphic();
 			let l_tilde = lagrange_evals(&subspace, r_zhat_prime);
-			let succinct_evaluations = evaluate_h_op(&l_tilde, &r_j, &r_s);
+			let succinct_evaluations = evaluate_h_op(l_tilde.to_ref(), &r_j, &r_s);
 
 			// Method 2: Direct evaluation via multilinear part
 			let h_parts = build_h_parts(r_zhat_prime).unwrap();

--- a/prover/prover/src/prove.rs
+++ b/prover/prover/src/prove.rs
@@ -12,6 +12,7 @@ use binius_field::{
 };
 use binius_math::{
 	BinarySubspace, FieldBuffer,
+	inner_product::inner_product,
 	ntt::{NeighborsLastMultiThread, domain_context::GenericPreExpanded},
 	univariate::lagrange_evals,
 };
@@ -29,7 +30,6 @@ use binius_verifier::{
 	protocols::{intmul::IntMulOutput, sumcheck::SumcheckOutput},
 };
 use digest::{Digest, FixedOutputReset, Output, core_api::BlockSizeUser};
-use itertools::izip;
 
 use super::error::Error;
 use crate::{
@@ -230,7 +230,7 @@ where
 			let r_zhat_prime = bitand_claim.r_zhat_prime;
 			let subspace = BinarySubspace::<B8>::with_dim(LOG_WORD_SIZE_BITS)?.isomorphic();
 			let l_tilde = lagrange_evals(&subspace, r_zhat_prime);
-			let make_final_claim = |evals| izip!(evals, &l_tilde).map(|(x, y)| x * y).sum();
+			let make_final_claim = |evals| inner_product(evals, l_tilde.iter_scalars());
 			OperatorData {
 				evals: vec![
 					make_final_claim(a_evals),

--- a/verifier/verifier/src/verify.rs
+++ b/verifier/verifier/src/verify.rs
@@ -4,7 +4,7 @@ use binius_core::{constraint_system::ConstraintSystem, word::Word};
 use binius_field::{AESTowerField8b as B8, BinaryField};
 use binius_math::{
 	BinarySubspace, FieldBuffer,
-	inner_product::inner_product_subfield,
+	inner_product::{inner_product, inner_product_subfield},
 	multilinear::{eq::eq_ind_partial_eval, evaluate::evaluate_inplace},
 	ntt::{NeighborsLastSingleThread, domain_context::GenericOnTheFly},
 	univariate::lagrange_evals,
@@ -18,7 +18,7 @@ use binius_utils::{
 	checked_arithmetics::{checked_log_2, log2_ceil_usize},
 };
 use digest::{Digest, Output, core_api::BlockSizeUser};
-use itertools::{Itertools, chain, izip};
+use itertools::{Itertools, chain};
 
 use super::error::Error;
 use crate::{
@@ -207,7 +207,7 @@ where
 			let r_zhat_prime = bitand_claim.r_zhat_prime;
 			let subspace = BinarySubspace::<B8>::with_dim(LOG_WORD_SIZE_BITS)?.isomorphic();
 			let l_tilde = lagrange_evals(&subspace, r_zhat_prime);
-			let make_final_claim = |evals| izip!(evals, &l_tilde).map(|(x, y)| x * y).sum();
+			let make_final_claim = |evals| inner_product(evals, l_tilde.iter_scalars());
 			OperatorData::new(
 				r_zhat_prime,
 				eval_point,


### PR DESCRIPTION
Stacked PRs:
 * __->__#1270
 * #1269
 * #1268
 * #1267
 * #1266
 * #1265


--- --- ---

### [shift] Refactor evaluate_h_op to use FieldBuffer


This will make it easier to extend to more shift variants
