### PR TITLE
fix: suppress unused variable warning in verifier

### DIFF
--- a/prover/examples/src/bin/verifier.rs
+++ b/prover/examples/src/bin/verifier.rs
@@ -77,7 +77,7 @@ fn main() -> Result<()> {
 			.context("Failed to setup verifier")?;
 
 	// Create a verifier transcript from the serialized proof data
-	let (data, _) = proof.into_owned();
+	let (data, _challenger_type) = proof.into_owned();
 	let mut verifier_transcript = VerifierTranscript::new(StdChallenger::default(), data);
 
 	// Verify


### PR DESCRIPTION
Fixed unused variable warning by properly destructuring proof.into_owned() return value. The challenger_type is intentionally unused since it was already validated earlier in the code. Added underscore prefix to indicate intentional non-usage.