### PR TITLE
[field_buffer] Replace split_half_mut with the no-closure version

### DIFF
--- a/verifier/math/src/field_buffer.rs
+++ b/verifier/math/src/field_buffer.rs
@@ -583,7 +583,7 @@ impl<P: PackedField, Data: DerefMut<Target = [P]>> FieldBuffer<P, Data> {
 	/// # Throws
 	///
 	/// * [`Error::CannotSplit`] if `self.log_len() == 0`
-	pub fn split_half_mut_no_closure(&mut self) -> Result<FieldBufferSplitMut<'_, P>, Error> {
+	pub fn split_half_mut(&mut self) -> Result<FieldBufferSplitMut<'_, P>, Error> {
 		if self.log_len == 0 {
 			return Err(Error::CannotSplit);
 		}
@@ -733,7 +733,7 @@ impl<'a, P> DerefMut for FieldSliceDataMut<'a, P> {
 	}
 }
 
-/// Return type of [`FieldBuffer::split_half_mut_no_closure`].
+/// Return type of [`FieldBuffer::split_half_mut`].
 #[derive(Debug)]
 pub struct FieldBufferSplitMut<'a, P: PackedField>(FieldBufferSplitMutInner<'a, P>);
 
@@ -1439,7 +1439,7 @@ mod tests {
 		}
 
 		{
-			let mut split = buffer.split_half_mut_no_closure().unwrap();
+			let mut split = buffer.split_half_mut().unwrap();
 			let (mut first, mut second) = split.halves();
 
 			assert_eq!(first.len(), 8);
@@ -1469,7 +1469,7 @@ mod tests {
 		}
 
 		{
-			let mut split = buffer.split_half_mut_no_closure().unwrap();
+			let mut split = buffer.split_half_mut().unwrap();
 			let (mut first, mut second) = split.halves();
 
 			assert_eq!(first.len(), 2);
@@ -1496,7 +1496,7 @@ mod tests {
 		buffer.set_checked(1, F::new(20)).unwrap();
 
 		{
-			let mut split = buffer.split_half_mut_no_closure().unwrap();
+			let mut split = buffer.split_half_mut().unwrap();
 			let (mut first, mut second) = split.halves();
 
 			assert_eq!(first.len(), 1);
@@ -1515,7 +1515,7 @@ mod tests {
 		// Test error case: buffer of size 1
 		let mut buffer = FieldBuffer::<P>::zeros(0); // 1 element
 
-		let result = buffer.split_half_mut_no_closure();
+		let result = buffer.split_half_mut();
 		assert!(matches!(result, Err(Error::CannotSplit)));
 	}
 }

--- a/verifier/math/src/multilinear/eq.rs
+++ b/verifier/math/src/multilinear/eq.rs
@@ -53,9 +53,7 @@ fn tensor_prod_eq_ind<P: PackedField, Data: DerefMut<Target = [P]>>(
 		let packed_r_i = P::broadcast(r_i);
 
 		values.resize(values.log_len() + 1)?;
-		let mut split = values
-			.split_half_mut_no_closure()
-			.expect("doubled by zero_extend()");
+		let mut split = values.split_half_mut().expect("doubled by zero_extend()");
 		let (mut lo, mut hi) = split.halves();
 
 		(lo.as_mut(), hi.as_mut())
@@ -149,7 +147,7 @@ pub fn eq_ind_truncate_low_inplace<P: PackedField, Data: DerefMut<Target = [P]>>
 
 	for log_len in (truncated_log_len..values.log_len()).rev() {
 		{
-			let mut split = values.split_half_mut_no_closure()?;
+			let mut split = values.split_half_mut()?;
 			let (mut lo, hi) = split.halves();
 			(lo.as_mut(), hi.as_ref())
 				.into_par_iter()

--- a/verifier/math/src/multilinear/fold.rs
+++ b/verifier/math/src/multilinear/fold.rs
@@ -17,7 +17,7 @@ pub fn fold_highest_var_inplace<P: PackedField, Data: DerefMut<Target = [P]>>(
 ) -> Result<(), Error> {
 	let broadcast_scalar = P::broadcast(scalar);
 	{
-		let mut split = values.split_half_mut_no_closure()?;
+		let mut split = values.split_half_mut()?;
 		let (mut lo, mut hi) = split.halves();
 		(lo.as_mut(), hi.as_mut())
 			.into_par_iter()


### PR DESCRIPTION
Previously we had two method interfaces for the same logic, one with a closure interface and one with a `drop`-based interface. Fully switch over to the non-closure interface.