### PR TITLE
[intmul] Ensure equality of exponentiations

### DIFF
--- a/crates/prover/src/protocols/intmul/prove.rs
+++ b/crates/prover/src/protocols/intmul/prove.rs
@@ -102,20 +102,18 @@ where
 
 		let initial_eval_point = self.transcript.sample_vec(n_vars);
 
-		let (b_exponents, b_root, b_layers) = b.split();
+		let (b_exponents, _b_root, b_layers) = b.split();
 
-		let b_eval = evaluate(&b_root, &initial_eval_point)?;
-		let c_eval = evaluate(&c_root, &initial_eval_point)?;
+		let exp_eval = evaluate(&c_root, &initial_eval_point)?;
 
 		let mut writer = self.transcript.message();
-		writer.write_scalar(b_eval);
-		writer.write_scalar(c_eval);
+		writer.write_scalar(exp_eval);
 
 		// Phase 1
 		let Phase1Output {
 			eval_point: phase1_eval_point,
 			b_leaves_evals,
-		} = self.phase1(log_bits, &initial_eval_point, (b_eval, b_layers.into_iter()))?;
+		} = self.phase1(log_bits, &initial_eval_point, (exp_eval, b_layers.into_iter()))?;
 
 		// Phase 2
 		let Phase2Output { twisted_claims } =
@@ -144,7 +142,7 @@ where
 			b_exponents.as_ref(),
 			[c_lo_root, c_hi_root],
 			&initial_eval_point,
-			c_eval,
+			exp_eval,
 		)?;
 
 		// Phase 4

--- a/crates/verifier/src/protocols/intmul/verify.rs
+++ b/crates/verifier/src/protocols/intmul/verify.rs
@@ -337,15 +337,15 @@ pub fn verify<F: BinaryField, C: Challenger>(
 	assert!(log_bits >= 1);
 	let initial_eval_point: Vec<F> = transcript.sample_vec(n_vars);
 
+	// Read the evaluation of the multilinear extension of the powers of the generator.
 	let mut reader = transcript.message();
-	let initial_b_eval: F = reader.read_scalar::<F>()?;
-	let initial_c_eval: F = reader.read_scalar::<F>()?;
+	let exp_eval: F = reader.read_scalar::<F>()?;
 
 	// Phase 1
 	let Phase1Output {
 		eval_point: phase_1_eval_point,
 		b_leaves_evals,
-	} = verify_phase_1(log_bits, &initial_eval_point, initial_b_eval, transcript)?;
+	} = verify_phase_1(log_bits, &initial_eval_point, exp_eval, transcript)?;
 
 	assert_eq!(phase_1_eval_point.len(), n_vars);
 	assert_eq!(b_leaves_evals.len(), 1 << log_bits);
@@ -360,7 +360,7 @@ pub fn verify<F: BinaryField, C: Challenger>(
 		selector_eval,
 		c_lo_root_eval,
 		c_hi_root_eval,
-	} = verify_phase_3(log_bits, phase2_output, &initial_eval_point, initial_c_eval, transcript)?;
+	} = verify_phase_3(log_bits, phase2_output, &initial_eval_point, exp_eval, transcript)?;
 
 	// Phase 4
 	let Phase4Output {


### PR DESCRIPTION
This fixes a soundness bug. The code previously computed the exponentiation of the base generator using the left hand side and right hand side, but didn't ensure equality.