### PR TITLE
Segment Witness into public and private parts for Spartan proofs

### DIFF
--- a/crates/spartan-frontend/src/circuit_builder.rs
+++ b/crates/spartan-frontend/src/circuit_builder.rs
@@ -7,7 +7,7 @@ use bytemuck::zeroed_vec;
 use smallvec::{SmallVec, smallvec};
 
 use crate::constraint_system::{
-	ConstraintSystem, ConstraintWire, MulConstraint, Operand, Witness, WireKind, WitnessIndex,
+	ConstraintSystem, ConstraintWire, MulConstraint, Operand, WireKind, Witness, WitnessIndex,
 	WitnessLayout, WitnessSegment,
 };
 

--- a/crates/spartan-frontend/src/circuit_builder.rs
+++ b/crates/spartan-frontend/src/circuit_builder.rs
@@ -7,7 +7,8 @@ use bytemuck::zeroed_vec;
 use smallvec::{SmallVec, smallvec};
 
 use crate::constraint_system::{
-	ConstraintSystem, ConstraintWire, MulConstraint, Operand, WireKind, WitnessIndex, WitnessLayout,
+	ConstraintSystem, ConstraintWire, MulConstraint, Operand, Witness, WireKind, WitnessIndex,
+	WitnessLayout,
 };
 
 /// Common interface for circuit construction and witness generation.
@@ -170,7 +171,8 @@ impl<F: Field> ConstraintSystemIR<F> {
 		// Map one_wire to WitnessIndex
 		let one_wire_index = layout
 			.get(&one_wire)
-			.expect("one_wire constant should exist in layout");
+			.expect("one_wire constant should exist in layout")
+			.index;
 
 		let cs = ConstraintSystem::new(
 			constants,
@@ -328,7 +330,7 @@ impl<'a, F: Field> WitnessGenerator<'a, F> {
 
 	fn write_value(&mut self, wire: ConstraintWire, value: F) -> WitnessWire<F> {
 		if let Some(index) = self.layout.get(&wire) {
-			self.witness[index.0 as usize] = value;
+			self.witness[index.flat_index(self.layout.private_offset())] = value;
 		}
 		WitnessWire(value)
 	}
@@ -338,11 +340,11 @@ impl<'a, F: Field> WitnessGenerator<'a, F> {
 		self.write_value(wire, value)
 	}
 
-	pub fn build(self) -> Result<Vec<F>, WitnessError> {
+	pub fn build(self) -> Result<Witness<F>, WitnessError> {
 		if let Some(backtrace) = self.first_error {
 			Err(WitnessError { backtrace })
 		} else {
-			Ok(self.witness)
+			Ok(Witness::new(self.witness, self.layout.private_offset()))
 		}
 	}
 

--- a/crates/spartan-frontend/src/circuit_builder.rs
+++ b/crates/spartan-frontend/src/circuit_builder.rs
@@ -8,7 +8,7 @@ use smallvec::{SmallVec, smallvec};
 
 use crate::constraint_system::{
 	ConstraintSystem, ConstraintWire, MulConstraint, Operand, Witness, WireKind, WitnessIndex,
-	WitnessLayout,
+	WitnessLayout, WitnessSegment,
 };
 
 /// Common interface for circuit construction and witness generation.
@@ -303,21 +303,23 @@ impl<F: Field> WitnessWire<F> {
 #[derive(Debug)]
 pub struct WitnessGenerator<'a, F: Field> {
 	alloc: WireAllocator,
-	witness: Vec<F>,
+	public: Vec<F>,
+	private: Vec<F>,
 	layout: &'a WitnessLayout<F>,
 	first_error: Option<Backtrace>,
 }
 
 impl<'a, F: Field> WitnessGenerator<'a, F> {
 	pub fn new(layout: &'a WitnessLayout<F>) -> Self {
-		let witness_size = layout.size();
+		let mut public = zeroed_vec(layout.public_size());
+		public[..layout.constants.len()].copy_from_slice(&layout.constants);
 
-		let mut witness = zeroed_vec(witness_size);
-		witness[..layout.constants.len()].copy_from_slice(&layout.constants);
+		let private = zeroed_vec(layout.private_size());
 
 		Self {
 			alloc: WireAllocator::new(WireKind::Private),
-			witness,
+			public,
+			private,
 			layout,
 			first_error: None,
 		}
@@ -330,7 +332,10 @@ impl<'a, F: Field> WitnessGenerator<'a, F> {
 
 	fn write_value(&mut self, wire: ConstraintWire, value: F) -> WitnessWire<F> {
 		if let Some(index) = self.layout.get(&wire) {
-			self.witness[index.flat_index(self.layout.private_offset())] = value;
+			match index.segment {
+				WitnessSegment::Public => self.public[index.index as usize] = value,
+				WitnessSegment::Private => self.private[index.index as usize] = value,
+			}
 		}
 		WitnessWire(value)
 	}
@@ -344,7 +349,7 @@ impl<'a, F: Field> WitnessGenerator<'a, F> {
 		if let Some(backtrace) = self.first_error {
 			Err(WitnessError { backtrace })
 		} else {
-			Ok(Witness::new(self.witness, self.layout.private_offset()))
+			Ok(Witness::new(self.public, self.private))
 		}
 	}
 

--- a/crates/spartan-frontend/src/constraint_system.rs
+++ b/crates/spartan-frontend/src/constraint_system.rs
@@ -160,12 +160,6 @@ impl WitnessIndex {
 		}
 	}
 
-	pub fn flat_index(self, private_offset: usize) -> usize {
-		match self.segment {
-			WitnessSegment::Public => self.index as usize,
-			WitnessSegment::Private => private_offset + self.index as usize,
-		}
-	}
 }
 
 pub struct Witness<F> {

--- a/crates/spartan-frontend/src/constraint_system.rs
+++ b/crates/spartan-frontend/src/constraint_system.rs
@@ -1,6 +1,11 @@
 // Copyright 2025 Irreducible Inc.
 
-use std::{cmp::Ordering, collections::HashMap, mem, ops::{Index, IndexMut}};
+use std::{
+	cmp::Ordering,
+	collections::HashMap,
+	mem,
+	ops::{Index, IndexMut},
+};
 
 use binius_field::Field;
 use binius_utils::checked_arithmetics::log2_ceil_usize;
@@ -159,7 +164,6 @@ impl WitnessIndex {
 			index,
 		}
 	}
-
 }
 
 pub struct Witness<F> {
@@ -272,11 +276,7 @@ impl<F: Field> ConstraintSystem<F> {
 	/// Validate that a witness satisfies all multiplication constraints.
 	pub fn validate(&self, witness: &Witness<F>) {
 		let operand_val = |operand: &Operand<WitnessIndex>| {
-			operand
-				.wires()
-				.iter()
-				.map(|&idx| witness[idx])
-				.sum::<F>()
+			operand.wires().iter().map(|&idx| witness[idx]).sum::<F>()
 		};
 
 		for MulConstraint { a, b, c } in &self.mul_constraints {

--- a/crates/spartan-frontend/src/constraint_system.rs
+++ b/crates/spartan-frontend/src/constraint_system.rs
@@ -1,6 +1,6 @@
 // Copyright 2025 Irreducible Inc.
 
-use std::{cmp::Ordering, collections::HashMap, mem};
+use std::{cmp::Ordering, collections::HashMap, mem, ops::{Index, IndexMut}};
 
 use binius_field::Field;
 use binius_utils::checked_arithmetics::log2_ceil_usize;
@@ -131,7 +131,93 @@ pub struct MulConstraint<W> {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub struct WitnessIndex(pub u32);
+pub enum WitnessSegment {
+	/// The public segment contains constant and input/output witness values.
+	Public,
+	/// The private segment contains the remaining witness values, which are hidden from the
+	/// verifier.
+	Private,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct WitnessIndex {
+	pub segment: WitnessSegment,
+	pub index: u32,
+}
+
+impl WitnessIndex {
+	pub fn public(index: u32) -> Self {
+		Self {
+			segment: WitnessSegment::Public,
+			index,
+		}
+	}
+
+	pub fn private(index: u32) -> Self {
+		Self {
+			segment: WitnessSegment::Private,
+			index,
+		}
+	}
+
+	pub fn flat_index(self, private_offset: usize) -> usize {
+		match self.segment {
+			WitnessSegment::Public => self.index as usize,
+			WitnessSegment::Private => private_offset + self.index as usize,
+		}
+	}
+}
+
+pub struct Witness<F> {
+	// TODO: Split the single values vector into multiple segments
+	pub values: Vec<F>,
+	private_offset: usize,
+}
+
+impl<F> Witness<F> {
+	pub fn new(values: Vec<F>, private_offset: usize) -> Self {
+		Self {
+			values,
+			private_offset,
+		}
+	}
+
+	pub fn as_slice(&self) -> &[F] {
+		&self.values
+	}
+
+	pub fn public(&self) -> &[F] {
+		&self.values[..self.private_offset]
+	}
+
+	pub fn private_offset(&self) -> usize {
+		self.private_offset
+	}
+}
+
+impl<F> Index<WitnessIndex> for Witness<F> {
+	type Output = F;
+
+	fn index(&self, index: WitnessIndex) -> &Self::Output {
+		match index.segment {
+			WitnessSegment::Public => &self.values[index.index as usize],
+			WitnessSegment::Private => {
+				&self.values[self.private_offset + index.index as usize]
+			}
+		}
+	}
+}
+
+impl<F> IndexMut<WitnessIndex> for Witness<F> {
+	fn index_mut(&mut self, index: WitnessIndex) -> &mut Self::Output {
+		match index.segment {
+			WitnessSegment::Public => &mut self.values[index.index as usize],
+			WitnessSegment::Private => {
+				&mut self.values[self.private_offset + index.index as usize]
+			}
+		}
+	}
+}
 
 /// A constraint system with multiplication constraints over witness indices.
 ///
@@ -147,7 +233,7 @@ pub struct ConstraintSystem<F: Field> {
 	n_private: u32,
 	log_public: u32,
 	mul_constraints: Vec<MulConstraint<WitnessIndex>>,
-	one_wire: WitnessIndex,
+	one_wire_index: u32,
 }
 
 impl<F: Field> ConstraintSystem<F> {
@@ -158,7 +244,7 @@ impl<F: Field> ConstraintSystem<F> {
 		n_private: u32,
 		log_public: u32,
 		mul_constraints: Vec<MulConstraint<WitnessIndex>>,
-		one_wire: WitnessIndex,
+		one_wire_index: u32,
 	) -> Self {
 		Self {
 			constants,
@@ -166,7 +252,7 @@ impl<F: Field> ConstraintSystem<F> {
 			n_private,
 			log_public,
 			mul_constraints,
-			one_wire,
+			one_wire_index,
 		}
 	}
 
@@ -195,16 +281,19 @@ impl<F: Field> ConstraintSystem<F> {
 	}
 
 	pub fn one_wire(&self) -> WitnessIndex {
-		self.one_wire
+		WitnessIndex {
+			segment: WitnessSegment::Public,
+			index: self.one_wire_index,
+		}
 	}
 
 	/// Validate that a witness satisfies all multiplication constraints.
-	pub fn validate(&self, witness: &[F]) {
+	pub fn validate(&self, witness: &Witness<F>) {
 		let operand_val = |operand: &Operand<WitnessIndex>| {
 			operand
 				.wires()
 				.iter()
-				.map(|idx| witness[idx.0 as usize])
+				.map(|&idx| witness[idx])
 				.sum::<F>()
 		};
 
@@ -233,18 +322,22 @@ pub struct WitnessLayout<F: Field> {
 }
 
 impl<F: Field> WitnessLayout<F> {
+	pub fn private_offset(&self) -> usize {
+		1 << self.log_public as usize
+	}
+
 	pub fn sparse(constants: Vec<F>, n_inout: u32, private_alive: &[bool]) -> Self {
 		let n_constants = constants.len() as u32;
 		let n_public = n_constants + n_inout;
 		let log_public = log2_ceil_usize(n_public as usize) as u32;
 
-		let private_offset = 1 << log_public;
+		let private_offset = 1u32 << log_public;
 		let private_index_map = private_alive
 			.iter()
 			.enumerate()
 			.filter(|(_, alive)| **alive)
 			.enumerate()
-			.map(|(new_idx, (id, _))| (id as u32, private_offset + new_idx as u32))
+			.map(|(new_idx, (id, _))| (id as u32, new_idx as u32))
 			.collect::<HashMap<_, _>>();
 
 		let n_private = private_index_map.len() as u32;
@@ -298,27 +391,23 @@ impl<F: Field> WitnessLayout<F> {
 
 	/// Returns the first index of the inout
 	pub fn inout_offset(&self) -> WitnessIndex {
-		WitnessIndex(self.constants.len() as u32)
-	}
-
-	pub fn private_offset(&self) -> WitnessIndex {
-		WitnessIndex(1 << self.log_public)
+		WitnessIndex::public(self.constants.len() as u32)
 	}
 
 	pub fn get(&self, wire: &ConstraintWire) -> Option<WitnessIndex> {
 		match wire.kind {
 			WireKind::Constant => {
 				assert!((wire.id as usize) < self.constants.len());
-				Some(WitnessIndex(wire.id))
+				Some(WitnessIndex::public(wire.id))
 			}
 			WireKind::InOut => {
 				assert!(wire.id < self.n_inout);
-				Some(WitnessIndex(self.inout_offset().0 + wire.id))
+				Some(WitnessIndex::public(self.constants.len() as u32 + wire.id))
 			}
 			WireKind::Private => self
 				.private_index_map
 				.get(&wire.id)
-				.map(|&id| WitnessIndex(id)),
+				.map(|&id| WitnessIndex::private(id)),
 		}
 	}
 }

--- a/crates/spartan-frontend/src/constraint_system.rs
+++ b/crates/spartan-frontend/src/constraint_system.rs
@@ -169,29 +169,21 @@ impl WitnessIndex {
 }
 
 pub struct Witness<F> {
-	// TODO: Split the single values vector into multiple segments
-	pub values: Vec<F>,
-	private_offset: usize,
+	public: Vec<F>,
+	private: Vec<F>,
 }
 
 impl<F> Witness<F> {
-	pub fn new(values: Vec<F>, private_offset: usize) -> Self {
-		Self {
-			values,
-			private_offset,
-		}
-	}
-
-	pub fn as_slice(&self) -> &[F] {
-		&self.values
+	pub fn new(public: Vec<F>, private: Vec<F>) -> Self {
+		Self { public, private }
 	}
 
 	pub fn public(&self) -> &[F] {
-		&self.values[..self.private_offset]
+		&self.public
 	}
 
-	pub fn private_offset(&self) -> usize {
-		self.private_offset
+	pub fn private(&self) -> &[F] {
+		&self.private
 	}
 }
 
@@ -200,10 +192,8 @@ impl<F> Index<WitnessIndex> for Witness<F> {
 
 	fn index(&self, index: WitnessIndex) -> &Self::Output {
 		match index.segment {
-			WitnessSegment::Public => &self.values[index.index as usize],
-			WitnessSegment::Private => {
-				&self.values[self.private_offset + index.index as usize]
-			}
+			WitnessSegment::Public => &self.public[index.index as usize],
+			WitnessSegment::Private => &self.private[index.index as usize],
 		}
 	}
 }
@@ -211,10 +201,8 @@ impl<F> Index<WitnessIndex> for Witness<F> {
 impl<F> IndexMut<WitnessIndex> for Witness<F> {
 	fn index_mut(&mut self, index: WitnessIndex) -> &mut Self::Output {
 		match index.segment {
-			WitnessSegment::Public => &mut self.values[index.index as usize],
-			WitnessSegment::Private => {
-				&mut self.values[self.private_offset + index.index as usize]
-			}
+			WitnessSegment::Public => &mut self.public[index.index as usize],
+			WitnessSegment::Private => &mut self.private[index.index as usize],
 		}
 	}
 }
@@ -317,21 +305,16 @@ pub struct WitnessLayout<F: Field> {
 	n_inout: u32,
 	n_private: u32,
 	log_public: u32,
-	log_size: u32,
+	log_private: u32,
 	private_index_map: HashMap<u32, u32>,
 }
 
 impl<F: Field> WitnessLayout<F> {
-	pub fn private_offset(&self) -> usize {
-		1 << self.log_public as usize
-	}
-
 	pub fn sparse(constants: Vec<F>, n_inout: u32, private_alive: &[bool]) -> Self {
 		let n_constants = constants.len() as u32;
 		let n_public = n_constants + n_inout;
 		let log_public = log2_ceil_usize(n_public as usize) as u32;
 
-		let private_offset = 1u32 << log_public;
 		let private_index_map = private_alive
 			.iter()
 			.enumerate()
@@ -341,32 +324,35 @@ impl<F: Field> WitnessLayout<F> {
 			.collect::<HashMap<_, _>>();
 
 		let n_private = private_index_map.len() as u32;
-		let log_size = log2_ceil_usize((private_offset + n_private) as usize) as u32;
+		let log_private = log2_ceil_usize(n_private as usize) as u32;
 
 		Self {
 			constants,
 			n_inout,
 			n_private,
 			log_public,
-			log_size,
+			log_private,
 			private_index_map,
 		}
 	}
 
 	pub fn with_blinding(self, info: BlindingInfo) -> Self {
-		let log_public = self.log_public;
 		let n_private = self.n_private as usize;
+		let total_private = n_private + info.n_dummy_wires + 3 * info.n_dummy_constraints;
+		let log_private = log2_ceil_usize(total_private) as u32;
 
-		let private_offset = 1 << log_public as usize;
-		let total_size =
-			private_offset + n_private + info.n_dummy_wires + 3 * info.n_dummy_constraints;
-		let log_size = log2_ceil_usize(total_size) as u32;
-
-		Self { log_size, ..self }
+		Self {
+			log_private,
+			..self
+		}
 	}
 
-	pub fn size(&self) -> usize {
-		1 << self.log_size as usize
+	pub fn public_size(&self) -> usize {
+		1 << self.log_public as usize
+	}
+
+	pub fn private_size(&self) -> usize {
+		1 << self.log_private as usize
 	}
 
 	pub fn n_constants(&self) -> usize {
@@ -385,8 +371,8 @@ impl<F: Field> WitnessLayout<F> {
 		self.log_public
 	}
 
-	pub fn log_size(&self) -> u32 {
-		self.log_size
+	pub fn log_private(&self) -> u32 {
+		self.log_private
 	}
 
 	/// Returns the first index of the inout

--- a/crates/spartan-prover/src/lib.rs
+++ b/crates/spartan-prover/src/lib.rs
@@ -109,8 +109,7 @@ impl<F: Field> IOPProver<F> {
 	/// Constructs an IOP prover for a constraint system.
 	pub fn new(constraint_system: ConstraintSystemPadded<F>) -> Self {
 		let wiring_transpose = WiringTranspose::transpose(
-			constraint_system.size(),
-			constraint_system.n_public() as usize,
+			constraint_system.private_size(),
 			constraint_system.mul_constraints(),
 		);
 		Self {
@@ -151,15 +150,26 @@ impl<F: Field> IOPProver<F> {
 
 		let cs = &self.constraint_system;
 
-		// Check that the witness length matches the constraint system
-		let expected_size = cs.size();
-		if witness.as_slice().len() != expected_size {
+		// Check that the witness segments have the expected sizes
+		let expected_public_size = 1 << cs.log_public() as usize;
+		let expected_private_size = cs.private_size();
+		if witness.public().len() != expected_public_size {
 			return Err(Error::ArgumentError {
 				arg: "witness".to_string(),
 				msg: format!(
-					"witness has {} elements, expected {}",
-					witness.as_slice().len(),
-					expected_size
+					"public segment has {} elements, expected {}",
+					witness.public().len(),
+					expected_public_size
+				),
+			});
+		}
+		if witness.private().len() != expected_private_size {
+			return Err(Error::ArgumentError {
+				arg: "witness".to_string(),
+				msg: format!(
+					"private segment has {} elements, expected {}",
+					witness.private().len(),
+					expected_private_size
 				),
 			});
 		}
@@ -181,27 +191,25 @@ impl<F: Field> IOPProver<F> {
 		let mulcheck_mask =
 			zk_mlecheck::Mask::new(log_mul_constraints, mask_degree, masks_buffer.to_ref());
 
-		// Pack witness into field elements and add blinding
+		// Pack private witness into field elements and add blinding
 		let blinding_info = cs.blinding_info();
-		let witness_packed = pack_and_blind_witness::<_, P>(
-			cs.log_size() as usize,
-			witness.as_slice(),
-			blinding_info,
-			cs.n_public() as usize,
+		let private_packed = pack_and_blind_witness::<_, P>(
+			cs.log_private() as usize,
+			witness.private(),
 			cs.n_private() as usize,
+			blinding_info,
 			&mut rng,
 		);
 
-		// Send the witness and masks oracles to the channel
-		let trace_oracle = channel.send_oracle(witness_packed.to_ref());
+		// Send the private witness and masks oracles to the channel
+		let trace_oracle = channel.send_oracle(private_packed.to_ref());
 		let mask_oracle = channel.send_oracle(masks_buffer.to_ref());
 
 		// Prove the multiplication constraints
-		let private_offset = cs.n_public() as usize;
 		let (mulcheck_evals, mask_eval, r_x) = prove_mulcheck::<F, P, _>(
 			cs.mul_constraints(),
-			witness_packed.to_ref(),
-			private_offset,
+			witness.public(),
+			private_packed.to_ref(),
 			mulcheck_mask,
 			&mut channel,
 		)?;
@@ -328,8 +336,8 @@ where
 
 fn prove_mulcheck<F, P, Channel>(
 	mul_constraints: &[MulConstraint<WitnessIndex>],
-	witness: FieldSlice<P>,
-	private_offset: usize,
+	public: &[F],
+	private_packed: FieldSlice<P>,
 	mask: zk_mlecheck::Mask<P, impl Deref<Target = [P]>>,
 	channel: &mut Channel,
 ) -> Result<([F; 3], F, Vec<F>), Error>
@@ -338,7 +346,7 @@ where
 	P: PackedField<Scalar = F> + PackedExtension<F>,
 	Channel: IPProverChannel<F>,
 {
-	let mulcheck_witness = wiring::build_mulcheck_witness(mul_constraints, witness, private_offset);
+	let mulcheck_witness = wiring::build_mulcheck_witness(mul_constraints, public, private_packed);
 
 	// Sample random evaluation point for mulcheck
 	let r_mulcheck = channel.sample_many(mask.n_vars());
@@ -373,25 +381,24 @@ where
 	Ok((mulcheck_evals, mask_eval, r_x))
 }
 
-/// Packs the witness into a [`FieldBuffer`] and adds blinding values for dummy wires.
+/// Packs private witness values into a [`FieldBuffer`] and adds blinding values for dummy wires.
 fn pack_and_blind_witness<F: Field, P: PackedField<Scalar = F>>(
-	log_witness_elems: usize,
-	witness: &[F],
-	blinding_info: &BlindingInfo,
-	n_public: usize,
+	log_private: usize,
+	private: &[F],
 	n_private: usize,
+	blinding_info: &BlindingInfo,
 	mut rng: impl CryptoRng,
 ) -> FieldBuffer<P> {
-	let packed_witness = if log_witness_elems < P::LOG_WIDTH {
-		let elems_iter = witness.iter().copied();
-		let zeros_iter = repeat_n(F::ZERO, (1 << log_witness_elems) - witness.len());
+	let packed = if log_private < P::LOG_WIDTH {
+		let elems_iter = private.iter().copied();
+		let zeros_iter = repeat_n(F::ZERO, (1 << log_private) - private.len());
 
 		let elems = P::from_scalars(chain!(elems_iter, zeros_iter));
 		vec![elems]
 	} else {
-		let packed_len = 1 << (log_witness_elems - P::LOG_WIDTH);
+		let packed_len = 1 << (log_private - P::LOG_WIDTH);
 
-		let elems_iter = witness
+		let elems_iter = private
 			.par_chunks(P::WIDTH)
 			.map(|chunk| P::from_scalars(chunk.iter().copied()));
 		let zeros_iter = rayon::iter::repeat_n(P::zero(), packed_len - elems_iter.len());
@@ -399,27 +406,25 @@ fn pack_and_blind_witness<F: Field, P: PackedField<Scalar = F>>(
 		elems_iter.chain(zeros_iter).collect::<Vec<_>>()
 	};
 
-	let mut witness_packed = FieldBuffer::new(log_witness_elems, packed_witness.into_boxed_slice());
+	let mut buffer = FieldBuffer::new(log_private, packed.into_boxed_slice());
 
-	// Add blinding values
-	let base = n_public + n_private;
-
+	// Add blinding values after the actual private wires
 	// Set random values for non-constraint dummy wires
 	for i in 0..blinding_info.n_dummy_wires {
-		witness_packed.set(base + i, F::random(&mut rng));
+		buffer.set(n_private + i, F::random(&mut rng));
 	}
 
 	// Set random values for dummy constraint wires (A * B = C)
-	let constraint_wire_base = base + blinding_info.n_dummy_wires;
+	let constraint_wire_base = n_private + blinding_info.n_dummy_wires;
 	for i in 0..blinding_info.n_dummy_constraints {
 		let a = F::random(&mut rng);
 		let b = F::random(&mut rng);
 		let c = a * b;
 
-		witness_packed.set(constraint_wire_base + 3 * i, a);
-		witness_packed.set(constraint_wire_base + 3 * i + 1, b);
-		witness_packed.set(constraint_wire_base + 3 * i + 2, c);
+		buffer.set(constraint_wire_base + 3 * i, a);
+		buffer.set(constraint_wire_base + 3 * i + 1, b);
+		buffer.set(constraint_wire_base + 3 * i + 2, c);
 	}
 
-	witness_packed
+	buffer
 }

--- a/crates/spartan-prover/src/lib.rs
+++ b/crates/spartan-prover/src/lib.rs
@@ -49,11 +49,13 @@ use binius_ip_prover::{
 use binius_math::{
 	FieldBuffer, FieldSlice,
 	ntt::{NeighborsLastMultiThread, domain_context::GenericPreExpanded},
+	univariate::evaluate_univariate,
 };
 use binius_spartan_frontend::constraint_system::{MulConstraint, Witness, WitnessIndex};
 use binius_spartan_verifier::{
 	Verifier,
 	constraint_system::{BlindingInfo, ConstraintSystemPadded},
+	wiring::evaluate_wiring_mle_public,
 };
 use binius_transcript::{ProverTranscript, fiat_shamir::Challenger};
 use binius_utils::{
@@ -66,7 +68,7 @@ pub use error::*;
 use itertools::chain;
 use rand::CryptoRng;
 
-use crate::wiring::WiringTranspose;
+use crate::wiring::{WiringTranspose, fold_constraints};
 
 type ProverNTT<F> = NeighborsLastMultiThread<GenericPreExpanded<F>>;
 type ProverMerkleProver<F, ParallelMerkleHasher, ParallelMerkleCompress> =
@@ -148,14 +150,17 @@ impl<F: Field> IOPProver<F> {
 				.entered();
 
 		let cs = &self.constraint_system;
-		let witness = witness.as_slice();
 
 		// Check that the witness length matches the constraint system
 		let expected_size = cs.size();
-		if witness.len() != expected_size {
+		if witness.as_slice().len() != expected_size {
 			return Err(Error::ArgumentError {
 				arg: "witness".to_string(),
-				msg: format!("witness has {} elements, expected {}", witness.len(), expected_size),
+				msg: format!(
+					"witness has {} elements, expected {}",
+					witness.as_slice().len(),
+					expected_size
+				),
 			});
 		}
 
@@ -180,7 +185,7 @@ impl<F: Field> IOPProver<F> {
 		let blinding_info = cs.blinding_info();
 		let witness_packed = pack_and_blind_witness::<_, P>(
 			cs.log_size() as usize,
-			witness,
+			witness.as_slice(),
 			blinding_info,
 			cs.n_public() as usize,
 			cs.n_private() as usize,
@@ -201,17 +206,25 @@ impl<F: Field> IOPProver<F> {
 			&mut channel,
 		)?;
 
-		// Compute wiring claim components
-		let r_public = channel.sample_many(cs.log_public() as usize);
+		// λ is the batching challenge for the constraint operands
+		let lambda = channel.sample();
 
-		let wiring_relation = wiring::compute_wiring_relation(
-			&self.wiring_transpose,
-			&witness_packed.to_ref(),
-			&r_public,
+		// Batch together the constraint operand evaluation claims.
+		let batched_sum = evaluate_univariate(&mulcheck_evals, lambda);
+
+		// Compute rₓ^⊤ (M_A + λ M_B + λ² M_C) x
+		let public_eval = evaluate_wiring_mle_public(
+			cs.mul_constraints(),
+			cs.log_public() as usize,
+			witness.public(),
+			lambda,
 			&r_x,
-			&mulcheck_evals,
-			&mut channel,
 		);
+
+		let trace_claim = batched_sum - public_eval;
+
+		// Fold constraints with batching and compute the folded polynomial
+		let wiring_poly = fold_constraints(&self.wiring_transpose, lambda, &r_x);
 
 		// Compute the mask folding polynomial (libra_eval tensor)
 		let n_vars = r_x.len();
@@ -220,7 +233,7 @@ impl<F: Field> IOPProver<F> {
 
 		// Prove both oracle relations
 		channel.prove_oracle_relations([
-			(trace_oracle, wiring_relation.l_poly, wiring_relation.batched_sum),
+			(trace_oracle, wiring_poly, trace_claim),
 			(mask_oracle, libra_eval_tensor, mask_eval),
 		]);
 
@@ -325,8 +338,7 @@ where
 	P: PackedField<Scalar = F> + PackedExtension<F>,
 	Channel: IPProverChannel<F>,
 {
-	let mulcheck_witness =
-		wiring::build_mulcheck_witness(mul_constraints, witness, private_offset);
+	let mulcheck_witness = wiring::build_mulcheck_witness(mul_constraints, witness, private_offset);
 
 	// Sample random evaluation point for mulcheck
 	let r_mulcheck = channel.sample_many(mask.n_vars());

--- a/crates/spartan-prover/src/lib.rs
+++ b/crates/spartan-prover/src/lib.rs
@@ -50,7 +50,7 @@ use binius_math::{
 	FieldBuffer, FieldSlice,
 	ntt::{NeighborsLastMultiThread, domain_context::GenericPreExpanded},
 };
-use binius_spartan_frontend::constraint_system::{MulConstraint, WitnessIndex};
+use binius_spartan_frontend::constraint_system::{MulConstraint, Witness, WitnessIndex};
 use binius_spartan_verifier::{
 	Verifier,
 	constraint_system::{BlindingInfo, ConstraintSystemPadded},
@@ -134,7 +134,7 @@ impl<F: Field> IOPProver<F> {
 	///   creating the channel)
 	pub fn prove<P, Channel>(
 		&self,
-		witness: &[F],
+		witness: Witness<F>,
 		mut rng: impl CryptoRng,
 		mut channel: Channel,
 	) -> Result<(), Error>
@@ -148,6 +148,7 @@ impl<F: Field> IOPProver<F> {
 				.entered();
 
 		let cs = &self.constraint_system;
+		let witness = witness.as_slice();
 
 		// Check that the witness length matches the constraint system
 		let expected_size = cs.size();
@@ -298,14 +299,12 @@ where
 	/// * The witness length must match the constraint system size
 	pub fn prove<Challenger_: Challenger>(
 		&self,
-		witness: &[F],
+		witness: Witness<F>,
 		mut rng: impl CryptoRng,
 		transcript: &mut ProverTranscript<Challenger_>,
 	) -> Result<(), Error> {
-		let cs = self.iop_prover.constraint_system();
-
 		// Prover observes the public input (includes it in Fiat-Shamir).
-		let public = &witness[..1 << cs.log_public()];
+		let public = witness.public();
 		transcript.observe().write_slice(public);
 
 		// Create ZK channel (owns the RNG for mask generation) and delegate to IOP prover

--- a/crates/spartan-prover/src/lib.rs
+++ b/crates/spartan-prover/src/lib.rs
@@ -108,6 +108,7 @@ impl<F: Field> IOPProver<F> {
 	pub fn new(constraint_system: ConstraintSystemPadded<F>) -> Self {
 		let wiring_transpose = WiringTranspose::transpose(
 			constraint_system.size(),
+			constraint_system.n_public() as usize,
 			constraint_system.mul_constraints(),
 		);
 		Self {
@@ -190,9 +191,11 @@ impl<F: Field> IOPProver<F> {
 		let mask_oracle = channel.send_oracle(masks_buffer.to_ref());
 
 		// Prove the multiplication constraints
+		let private_offset = cs.n_public() as usize;
 		let (mulcheck_evals, mask_eval, r_x) = prove_mulcheck::<F, P, _>(
 			cs.mul_constraints(),
 			witness_packed.to_ref(),
+			private_offset,
 			mulcheck_mask,
 			&mut channel,
 		)?;
@@ -314,6 +317,7 @@ where
 fn prove_mulcheck<F, P, Channel>(
 	mul_constraints: &[MulConstraint<WitnessIndex>],
 	witness: FieldSlice<P>,
+	private_offset: usize,
 	mask: zk_mlecheck::Mask<P, impl Deref<Target = [P]>>,
 	channel: &mut Channel,
 ) -> Result<([F; 3], F, Vec<F>), Error>
@@ -322,7 +326,8 @@ where
 	P: PackedField<Scalar = F> + PackedExtension<F>,
 	Channel: IPProverChannel<F>,
 {
-	let mulcheck_witness = wiring::build_mulcheck_witness(mul_constraints, witness);
+	let mulcheck_witness =
+		wiring::build_mulcheck_witness(mul_constraints, witness, private_offset);
 
 	// Sample random evaluation point for mulcheck
 	let r_mulcheck = channel.sample_many(mask.n_vars());

--- a/crates/spartan-prover/src/wiring.rs
+++ b/crates/spartan-prover/src/wiring.rs
@@ -26,14 +26,18 @@ pub struct Key {
 }
 
 impl WiringTranspose {
-	pub fn transpose(witness_size: usize, mul_constraints: &[MulConstraint<WitnessIndex>]) -> Self {
+	pub fn transpose(
+		witness_size: usize,
+		private_offset: usize,
+		mul_constraints: &[MulConstraint<WitnessIndex>],
+	) -> Self {
 		let mut operands_keys_by_wit_idx = vec![Vec::new(); witness_size];
 
 		let mut n_total_keys = 0;
 		for (i, MulConstraint { a, b, c }) in mul_constraints.iter().enumerate() {
 			for (operand_idx, operand) in [a, b, c].into_iter().enumerate() {
 				for &witness_idx in operand.wires() {
-					operands_keys_by_wit_idx[witness_idx.0 as usize].push(Key {
+					operands_keys_by_wit_idx[witness_idx.flat_index(private_offset)].push(Key {
 						operand_idx: operand_idx as u8,
 						constraint_idx: i as u32,
 					});
@@ -214,6 +218,7 @@ pub struct MulCheckWitness<P: PackedField> {
 fn eval_operand<P: PackedField>(
 	witness: &FieldSlice<P>,
 	operand: &Operand<WitnessIndex>,
+	private_offset: usize,
 ) -> P::Scalar
 where
 	P::Scalar: Field,
@@ -221,7 +226,7 @@ where
 	operand
 		.wires()
 		.iter()
-		.map(|idx| witness.get(idx.0 as usize))
+		.map(|idx| witness.get(idx.flat_index(private_offset)))
 		.sum()
 }
 
@@ -234,6 +239,7 @@ where
 pub fn build_mulcheck_witness<F: Field, P: PackedField<Scalar = F>>(
 	mul_constraints: &[MulConstraint<WitnessIndex>],
 	witness: FieldSlice<P>,
+	private_offset: usize,
 ) -> MulCheckWitness<P> {
 	fn get_a(c: &MulConstraint<WitnessIndex>) -> &Operand<WitnessIndex> {
 		&c.a
@@ -269,7 +275,11 @@ pub fn build_mulcheck_witness<F: Field, P: PackedField<Scalar = F>>(
 				let val = P::from_fn(|j| {
 					let constraint_idx = offset + j;
 					if constraint_idx < n_constraints {
-						eval_operand(&witness, get_operand(&mul_constraints[constraint_idx]))
+						eval_operand(
+							&witness,
+							get_operand(&mul_constraints[constraint_idx]),
+							private_offset,
+						)
 					} else {
 						F::ZERO
 					}
@@ -313,21 +323,33 @@ mod tests {
 		rng: &mut StdRng,
 		n_constraints: usize,
 		witness_size: usize,
+		private_offset: usize,
 	) -> Vec<MulConstraint<WitnessIndex>> {
 		(0..n_constraints)
 			.map(|_| {
-				let a = generate_random_operand(rng, witness_size);
-				let b = generate_random_operand(rng, witness_size);
-				let c = generate_random_operand(rng, witness_size);
+				let a = generate_random_operand(rng, witness_size, private_offset);
+				let b = generate_random_operand(rng, witness_size, private_offset);
+				let c = generate_random_operand(rng, witness_size, private_offset);
 				MulConstraint { a, b, c }
 			})
 			.collect()
 	}
 
-	fn generate_random_operand(rng: &mut StdRng, witness_size: usize) -> Operand<WitnessIndex> {
+	fn generate_random_operand(
+		rng: &mut StdRng,
+		witness_size: usize,
+		private_offset: usize,
+	) -> Operand<WitnessIndex> {
 		let n_wires = rng.random_range(0..=4);
 		let wires: SmallVec<[WitnessIndex; 4]> = (0..n_wires)
-			.map(|_| WitnessIndex(rng.random_range(0..witness_size as u32)))
+			.map(|_| {
+				let flat = rng.random_range(0..witness_size);
+				if flat < private_offset {
+					WitnessIndex::public(flat as u32)
+				} else {
+					WitnessIndex::private((flat - private_offset) as u32)
+				}
+			})
 			.collect();
 		Operand::new(wires)
 	}
@@ -358,12 +380,15 @@ mod tests {
 
 		// Generate random constraints
 		let log_n_constraints = 4;
+		let log_public = 3;
 		let log_witness_size = 5;
 
 		let n_constraints = 1 << log_n_constraints;
 		let witness_size = 1 << log_witness_size;
+		let private_offset = 1 << log_public;
 
-		let constraints = generate_random_constraints(&mut rng, n_constraints, witness_size);
+		let constraints =
+			generate_random_constraints(&mut rng, n_constraints, witness_size, private_offset);
 
 		// Sample random evaluation points
 		let r_x = random_scalars::<B128>(&mut rng, log_n_constraints);
@@ -371,10 +396,11 @@ mod tests {
 		let lambda = B128::random(&mut rng);
 
 		// Compute expected result using the original representation
-		let expected = evaluate_wiring_mle(&constraints, lambda, &r_x, &r_y);
+		let expected =
+			evaluate_wiring_mle(&constraints, lambda, &r_x, &r_y, private_offset);
 
 		// Compute result using the transposed representation
-		let transposed = WiringTranspose::transpose(witness_size, &constraints);
+		let transposed = WiringTranspose::transpose(witness_size, private_offset, &constraints);
 		let r_x_tensor = eq_ind_partial_eval::<B128>(&r_x);
 		let r_y_tensor = eq_ind_partial_eval::<B128>(&r_y);
 		let actual = evaluate_wiring_mle_transposed(
@@ -392,13 +418,16 @@ mod tests {
 		let mut rng = StdRng::seed_from_u64(0);
 
 		let log_n_constraints = 4;
+		let log_public = 3;
 		let log_witness_size = 5;
 
 		let n_constraints = 1 << log_n_constraints;
 		let witness_size = 1 << log_witness_size;
+		let private_offset = 1 << log_public;
 
 		// Generate random constraints
-		let constraints = generate_random_constraints(&mut rng, n_constraints, witness_size);
+		let constraints =
+			generate_random_constraints(&mut rng, n_constraints, witness_size, private_offset);
 
 		// Sample random evaluation points
 		let r_x = random_scalars::<B128>(&mut rng, log_n_constraints);
@@ -406,10 +435,11 @@ mod tests {
 		let lambda = B128::random(&mut rng);
 
 		// Method 1: Compute expected result using evaluate_wiring_mle
-		let expected = evaluate_wiring_mle(&constraints, lambda, &r_x, &r_y);
+		let expected =
+			evaluate_wiring_mle(&constraints, lambda, &r_x, &r_y, private_offset);
 
 		// Method 2: Use fold_constraints then evaluate at r_y
-		let transposed = WiringTranspose::transpose(witness_size, &constraints);
+		let transposed = WiringTranspose::transpose(witness_size, private_offset, &constraints);
 		let folded = fold_constraints::<_, Packed128b>(&transposed, lambda, &r_x);
 		let actual = evaluate(&folded, &r_y);
 
@@ -444,14 +474,18 @@ mod tests {
 		let n_constraints = 1 << log_n_constraints;
 		let witness_size = 1 << log_witness_size;
 
+		let private_offset = 1 << log_public;
+
 		// Generate random constraints
-		let constraints = generate_random_constraints(&mut rng, n_constraints, witness_size);
+		let constraints =
+			generate_random_constraints(&mut rng, n_constraints, witness_size, private_offset);
 
 		// Create random witness
 		let witness = random_field_buffer::<Packed128b>(&mut rng, log_witness_size);
 
 		// Compute mulcheck witness
-		let mulcheck_witness = build_mulcheck_witness(&constraints, witness.to_ref());
+		let mulcheck_witness =
+			build_mulcheck_witness(&constraints, witness.to_ref(), private_offset);
 
 		// Sample r_x (sumcheck evaluation point for constraint axis)
 		let r_x = random_scalars::<B128>(&mut rng, log_n_constraints);
@@ -472,7 +506,8 @@ mod tests {
 		let public_eval = evaluate(&public, &r_public);
 
 		// Create transposed wiring
-		let wiring_transpose = WiringTranspose::transpose(witness_size, &constraints);
+		let wiring_transpose =
+			WiringTranspose::transpose(witness_size, private_offset, &constraints);
 
 		// Create constraint system for verifier (compute_claim doesn't actually use it,
 		// but we need a valid reference for the type signature)
@@ -482,7 +517,7 @@ mod tests {
 			0,                   // n_private
 			log_public as u32,   // log_public
 			constraints.clone(), // mul_constraints
-			WitnessIndex(0),     // one_wire (dummy for test)
+			0,                   // one_wire_index (dummy for test)
 		);
 		let constraint_system_padded = ConstraintSystemPadded::new(
 			constraint_system,

--- a/crates/spartan-prover/src/wiring.rs
+++ b/crates/spartan-prover/src/wiring.rs
@@ -25,10 +25,7 @@ pub struct Key {
 }
 
 impl WiringTranspose {
-	pub fn transpose(
-		private_size: usize,
-		mul_constraints: &[MulConstraint<WitnessIndex>],
-	) -> Self {
+	pub fn transpose(private_size: usize, mul_constraints: &[MulConstraint<WitnessIndex>]) -> Self {
 		let mut keys_by_private_idx = vec![Vec::new(); private_size];
 
 		let mut n_total_keys = 0;
@@ -381,9 +378,9 @@ mod tests {
 			channel::{IOPVerifierChannel, OracleLinearRelation, OracleSpec},
 			naive_channel::NaiveVerifierChannel,
 		};
+		use binius_iop_prover::{channel::IOPProverChannel, naive_channel::NaiveProverChannel};
 		use binius_ip::channel::IPVerifierChannel;
 		use binius_ip_prover::channel::IPProverChannel;
-		use binius_iop_prover::{channel::IOPProverChannel, naive_channel::NaiveProverChannel};
 		use binius_math::{inner_product::inner_product_buffers, test_utils::random_field_buffer};
 		use binius_spartan_verifier::wiring::evaluate_wiring_mle_public;
 		use binius_transcript::{ProverTranscript, fiat_shamir::HasherChallenger};
@@ -410,8 +407,7 @@ mod tests {
 		let private_buf = random_field_buffer::<Packed128b>(&mut rng, log_private);
 
 		// Compute mulcheck witness
-		let mulcheck_witness =
-			build_mulcheck_witness(&constraints, &public, private_buf.to_ref());
+		let mulcheck_witness = build_mulcheck_witness(&constraints, &public, private_buf.to_ref());
 
 		// Sample r_x (sumcheck evaluation point for constraint axis)
 		let r_x = random_scalars::<B128>(&mut rng, log_n_constraints);
@@ -454,11 +450,7 @@ mod tests {
 		let wiring_poly = fold_constraints::<_, Packed128b>(&wiring_transpose, lambda, &r_x);
 
 		// Finish the IOP with the oracle relation
-		prover_channel.prove_oracle_relations([(
-			witness_oracle,
-			wiring_poly.clone(),
-			trace_claim,
-		)]);
+		prover_channel.prove_oracle_relations([(witness_oracle, wiring_poly.clone(), trace_claim)]);
 
 		// === VERIFIER SIDE ===
 		let mut verifier_transcript = prover_transcript.into_verifier();
@@ -475,20 +467,12 @@ mod tests {
 
 		// Compute the same claim on the verifier side
 		let verifier_batched_sum = evaluate_univariate(&mulcheck_evals, verifier_lambda);
-		let verifier_public_eval = evaluate_wiring_mle_public(
-			&constraints,
-			log_public,
-			&public,
-			verifier_lambda,
-			&r_x,
-		);
+		let verifier_public_eval =
+			evaluate_wiring_mle_public(&constraints, log_public, &public, verifier_lambda, &r_x);
 		let verifier_trace_claim = verifier_batched_sum - verifier_public_eval;
 
 		// Verify that prover and verifier computed the same trace_claim
-		assert_eq!(
-			trace_claim, verifier_trace_claim,
-			"Prover and verifier trace_claim mismatch"
-		);
+		assert_eq!(trace_claim, verifier_trace_claim, "Prover and verifier trace_claim mismatch");
 
 		// Build the transparent closure using the prover's wiring_poly for evaluation.
 		let transparent = Box::new(move |point: &[_]| evaluate(&wiring_poly, point));

--- a/crates/spartan-prover/src/wiring.rs
+++ b/crates/spartan-prover/src/wiring.rs
@@ -1,13 +1,7 @@
 // Copyright 2025 Irreducible Inc.
 
-use std::iter;
-
 use binius_field::{Field, PackedField};
-use binius_ip_prover::channel::IPProverChannel;
-use binius_math::{
-	FieldBuffer, FieldSlice, multilinear, multilinear::eq::eq_ind_partial_eval,
-	univariate::evaluate_univariate,
-};
+use binius_math::{FieldBuffer, FieldSlice, multilinear::eq::eq_ind_partial_eval};
 use binius_spartan_frontend::constraint_system::{MulConstraint, Operand, WitnessIndex};
 use binius_utils::{checked_arithmetics::checked_log_2, rayon::prelude::*};
 
@@ -17,6 +11,7 @@ pub struct WiringTranspose {
 	flat_keys: Vec<Key>,
 	keys_start_by_witness_index: Vec<u32>,
 	log_witness_size: usize,
+	private_offset: usize,
 }
 
 #[derive(Debug, Clone)]
@@ -61,6 +56,7 @@ impl WiringTranspose {
 			flat_keys: operand_keys,
 			keys_start_by_witness_index: operand_key_start_by_word,
 			log_witness_size,
+			private_offset,
 		}
 	}
 
@@ -74,6 +70,11 @@ impl WiringTranspose {
 		1 << self.log_witness_size
 	}
 
+	/// Returns the minimum witness index of the private segment.
+	pub fn private_offset(&self) -> usize {
+		self.private_offset
+	}
+
 	/// Returns an iterator over keys for a specific witness index.
 	pub fn keys_for_witness(&self, witness_idx: usize) -> &[Key] {
 		let start = self.keys_start_by_witness_index[witness_idx] as usize;
@@ -84,33 +85,6 @@ impl WiringTranspose {
 			.unwrap_or(self.flat_keys.len());
 		&self.flat_keys[start..end]
 	}
-}
-
-/// Computes the batched polynomial ℓ = w + χ eq(r_pub || 0), where w is the wiring polynomial
-/// and χ is `batch_coeff`.
-///
-/// Since eq(r_pub || 0) takes the value 0 on all hypercube vertices except the first 2^r_pub.len(),
-/// only that first chunk needs to be updated.
-fn compute_l_poly<F: Field, P: PackedField<Scalar = F>>(
-	wiring_poly: FieldBuffer<P>,
-	r_public: &[F],
-	batch_coeff: F,
-) -> FieldBuffer<P> {
-	let mut l_poly = wiring_poly;
-
-	{
-		let mut l_poly_public_chunk = l_poly.chunk_mut(r_public.len(), 0);
-		let mut l_poly_public_chunk = l_poly_public_chunk.get();
-
-		let eq_public = eq_ind_partial_eval::<P>(r_public);
-
-		let batch_coeff_packed = P::broadcast(batch_coeff);
-		for (dst, src) in iter::zip(l_poly_public_chunk.as_mut(), eq_public.as_ref()) {
-			*dst += *src * batch_coeff_packed;
-		}
-	}
-
-	l_poly
 }
 
 /// Folds the wiring matrix along the constraint axis by partially evaluating at r_x.
@@ -130,6 +104,7 @@ pub fn fold_constraints<F: Field, P: PackedField<Scalar = F>>(
 	let lambda_powers = [F::ONE, lambda, lambda.square()];
 
 	// Create packed field buffer for witness indices
+	let private_offset = transposed.private_offset();
 	let witness_size = transposed.witness_size();
 	let log_witness_size = transposed.log_witness_size();
 	let len = 1 << log_witness_size.saturating_sub(P::LOG_WIDTH);
@@ -142,7 +117,8 @@ pub fn fold_constraints<F: Field, P: PackedField<Scalar = F>>(
 
 			P::from_fn(|scalar_idx| {
 				let witness_idx = base_witness_idx + scalar_idx;
-				if witness_idx >= witness_size {
+				// For now, only accumulate for the private segment.
+				if witness_idx < private_offset || witness_idx >= witness_size {
 					return F::ZERO;
 				}
 
@@ -158,50 +134,6 @@ pub fn fold_constraints<F: Field, P: PackedField<Scalar = F>>(
 		.collect::<Vec<_>>();
 
 	FieldBuffer::new(log_witness_size, result.into_boxed_slice())
-}
-
-/// Result of computing the wiring relation for IOP proving.
-///
-/// Contains the folding polynomial (l_poly) and the claimed batched sum
-/// that will be passed to the IOP channel's `prove_oracle_relations` method.
-pub struct WiringRelation<P: PackedField> {
-	/// The folding polynomial: wiring poly + batch_coeff * eq(r_public, ·)
-	pub l_poly: FieldBuffer<P>,
-	/// The claimed batched sum: λ-batched mulcheck evals + batch_coeff * public_eval
-	pub batched_sum: P::Scalar,
-}
-
-/// Computes the wiring relation for IOP proving.
-///
-/// Samples batching challenges from the channel, computes the folding polynomial,
-/// and returns the relation data needed for the IOP channel's `prove_oracle_relations` method.
-pub fn compute_wiring_relation<F: Field, P: PackedField<Scalar = F>>(
-	wiring_transpose: &WiringTranspose,
-	witness: &FieldSlice<P>,
-	r_public: &[F],
-	r_x: &[F],
-	mulcheck_evals: &[F],
-	channel: &mut impl IPProverChannel<F>,
-) -> WiringRelation<P> {
-	// Sample batching challenges
-	let lambda = channel.sample();
-	let batch_coeff = channel.sample();
-
-	// Fold constraints with batching and compute the folded polynomial
-	let wiring_poly = fold_constraints(wiring_transpose, lambda, r_x);
-	let l_poly = compute_l_poly(wiring_poly, r_public, batch_coeff);
-
-	// Compute the public input evaluation
-	let public = witness.chunk(r_public.len(), 0);
-	let public_eval = multilinear::evaluate::evaluate(&public, r_public);
-
-	// Compute the batched sum
-	let batched_sum = evaluate_univariate(mulcheck_evals, lambda) + batch_coeff * public_eval;
-
-	WiringRelation {
-		l_poly,
-		batched_sum,
-	}
 }
 
 /// Witness data for multiplication constraint checking.
@@ -311,7 +243,7 @@ mod tests {
 		univariate::evaluate_univariate,
 	};
 	use binius_spartan_frontend::constraint_system::{MulConstraint, Operand, WitnessIndex};
-	use binius_spartan_verifier::wiring::evaluate_wiring_mle;
+	use binius_spartan_verifier::wiring::evaluate_private_wiring_mle;
 	use rand::{Rng, SeedableRng, rngs::StdRng};
 	use smallvec::SmallVec;
 
@@ -354,8 +286,8 @@ mod tests {
 		Operand::new(wires)
 	}
 
-	/// Evaluate the wiring MLE using the transposed representation.
-	fn evaluate_wiring_mle_transposed<F: Field>(
+	/// Evaluate the private wiring MLE using the transposed representation.
+	fn evaluate_private_wiring_mle_transposed<F: Field>(
 		transposed: &WiringTranspose,
 		lambda: F,
 		r_x_tensor: &[F],
@@ -363,7 +295,7 @@ mod tests {
 	) -> F {
 		let mut acc = [F::ZERO; 3];
 
-		for witness_idx in 0..transposed.witness_size() {
+		for witness_idx in transposed.private_offset()..transposed.witness_size() {
 			let r_y_weight = r_y_tensor[witness_idx];
 			for key in transposed.keys_for_witness(witness_idx) {
 				let r_x_weight = r_x_tensor[key.constraint_idx as usize];
@@ -395,15 +327,15 @@ mod tests {
 		let r_y = random_scalars::<B128>(&mut rng, log_witness_size);
 		let lambda = B128::random(&mut rng);
 
-		// Compute expected result using the original representation
+		// Compute expected result using the verifier's reference implementation
 		let expected =
-			evaluate_wiring_mle(&constraints, lambda, &r_x, &r_y, private_offset);
+			evaluate_private_wiring_mle(&constraints, lambda, &r_x, &r_y, private_offset);
 
 		// Compute result using the transposed representation
 		let transposed = WiringTranspose::transpose(witness_size, private_offset, &constraints);
 		let r_x_tensor = eq_ind_partial_eval::<B128>(&r_x);
 		let r_y_tensor = eq_ind_partial_eval::<B128>(&r_y);
-		let actual = evaluate_wiring_mle_transposed(
+		let actual = evaluate_private_wiring_mle_transposed(
 			&transposed,
 			lambda,
 			r_x_tensor.as_ref(),
@@ -434,9 +366,9 @@ mod tests {
 		let r_y = random_scalars::<B128>(&mut rng, log_witness_size);
 		let lambda = B128::random(&mut rng);
 
-		// Method 1: Compute expected result using evaluate_wiring_mle
+		// Method 1: Compute expected result using evaluate_private_wiring_mle
 		let expected =
-			evaluate_wiring_mle(&constraints, lambda, &r_x, &r_y, private_offset);
+			evaluate_private_wiring_mle(&constraints, lambda, &r_x, &r_y, private_offset);
 
 		// Method 2: Use fold_constraints then evaluate at r_y
 		let transposed = WiringTranspose::transpose(witness_size, private_offset, &constraints);
@@ -445,7 +377,7 @@ mod tests {
 
 		assert_eq!(
 			actual, expected,
-			"fold_constraints + evaluate does not match evaluate_wiring_mle"
+			"fold_constraints + evaluate does not match evaluate_private_wiring_mle"
 		);
 	}
 
@@ -456,10 +388,11 @@ mod tests {
 			channel::{IOPVerifierChannel, OracleLinearRelation, OracleSpec},
 			naive_channel::NaiveVerifierChannel,
 		};
+		use binius_ip::channel::IPVerifierChannel;
+		use binius_ip_prover::channel::IPProverChannel;
 		use binius_iop_prover::{channel::IOPProverChannel, naive_channel::NaiveProverChannel};
 		use binius_math::{inner_product::inner_product_buffers, test_utils::random_field_buffer};
-		use binius_spartan_frontend::constraint_system::ConstraintSystem;
-		use binius_spartan_verifier::constraint_system::{BlindingInfo, ConstraintSystemPadded};
+		use binius_spartan_verifier::wiring::evaluate_wiring_mle_public;
 		use binius_transcript::{ProverTranscript, fiat_shamir::HasherChallenger};
 
 		type StdChallenger = HasherChallenger<StdDigest>;
@@ -498,34 +431,9 @@ mod tests {
 			inner_product_buffers(&mulcheck_witness.c, &r_x_tensor),
 		];
 
-		// Sample r_public
-		let r_public = random_scalars::<B128>(&mut rng, log_public);
-
-		// Compute public input evaluation
-		let public = witness.chunk(log_public, 0);
-		let public_eval = evaluate(&public, &r_public);
-
 		// Create transposed wiring
 		let wiring_transpose =
 			WiringTranspose::transpose(witness_size, private_offset, &constraints);
-
-		// Create constraint system for verifier (compute_claim doesn't actually use it,
-		// but we need a valid reference for the type signature)
-		let constraint_system = ConstraintSystem::new(
-			vec![],              // constants
-			0,                   // n_inout
-			0,                   // n_private
-			log_public as u32,   // log_public
-			constraints.clone(), // mul_constraints
-			0,                   // one_wire_index (dummy for test)
-		);
-		let constraint_system_padded = ConstraintSystemPadded::new(
-			constraint_system,
-			BlindingInfo {
-				n_dummy_wires: 0,
-				n_dummy_constraints: 0,
-			},
-		);
 
 		let oracle_specs = vec![OracleSpec {
 			log_msg_len: log_witness_size,
@@ -541,21 +449,26 @@ mod tests {
 		// Send witness oracle
 		let witness_oracle = prover_channel.send_oracle(witness.to_ref());
 
-		// Compute wiring relation (this samples lambda and batch_coeff from the channel)
-		let wiring_relation = compute_wiring_relation(
-			&wiring_transpose,
-			&witness.to_ref(),
-			&r_public,
-			&r_x,
-			&mulcheck_evals,
-			&mut prover_channel,
-		);
+		// Sample lambda
+		let lambda: B128 = prover_channel.sample();
+
+		// Compute the batched sum and public contribution
+		let batched_sum = evaluate_univariate(&mulcheck_evals, lambda);
+		let public: Vec<B128> = (0..private_offset)
+			.map(|i| witness.to_ref().get(i))
+			.collect();
+		let public_eval =
+			evaluate_wiring_mle_public(&constraints, log_public, &public, lambda, &r_x);
+		let trace_claim = batched_sum - public_eval;
+
+		// Fold constraints to get the private wiring polynomial
+		let wiring_poly = fold_constraints::<_, Packed128b>(&wiring_transpose, lambda, &r_x);
 
 		// Finish the IOP with the oracle relation
 		prover_channel.prove_oracle_relations([(
 			witness_oracle,
-			wiring_relation.l_poly.clone(),
-			wiring_relation.batched_sum,
+			wiring_poly.clone(),
+			trace_claim,
 		)]);
 
 		// === VERIFIER SIDE ===
@@ -568,24 +481,28 @@ mod tests {
 			.recv_oracle()
 			.expect("recv_oracle should succeed");
 
-		// Compute wiring claim (samples the same lambda and batch_coeff as prover)
-		let wiring_claim = binius_spartan_verifier::wiring::compute_claim(
-			&constraint_system_padded,
-			&r_public,
-			&mulcheck_evals,
-			public_eval,
-			&mut verifier_channel,
-		);
+		// Sample the same lambda as prover
+		let verifier_lambda: B128 = verifier_channel.sample();
 
-		// Verify that prover and verifier computed the same batched_sum
+		// Compute the same claim on the verifier side
+		let verifier_batched_sum = evaluate_univariate(&mulcheck_evals, verifier_lambda);
+		let verifier_public_eval = evaluate_wiring_mle_public(
+			&constraints,
+			log_public,
+			&public,
+			verifier_lambda,
+			&r_x,
+		);
+		let verifier_trace_claim = verifier_batched_sum - verifier_public_eval;
+
+		// Verify that prover and verifier computed the same trace_claim
 		assert_eq!(
-			wiring_relation.batched_sum, wiring_claim.batched_sum,
-			"Prover and verifier batched_sum mismatch"
+			trace_claim, verifier_trace_claim,
+			"Prover and verifier trace_claim mismatch"
 		);
 
-		// Build the transparent closure using the prover's l_poly for evaluation.
-		let l_poly = wiring_relation.l_poly;
-		let transparent = Box::new(move |point: &[_]| evaluate(&l_poly, point));
+		// Build the transparent closure using the prover's wiring_poly for evaluation.
+		let transparent = Box::new(move |point: &[_]| evaluate(&wiring_poly, point));
 
 		// Finish verification. The naive channel verifies the inner product directly inside
 		// verify_oracle_relations(), reads the transparent polynomial from the transcript,
@@ -594,7 +511,7 @@ mod tests {
 			.verify_oracle_relations([OracleLinearRelation {
 				oracle: witness_oracle,
 				transparent,
-				claim: wiring_claim.batched_sum,
+				claim: verifier_trace_claim,
 			}])
 			.expect("verify_oracle_relations should succeed (inner product verified)");
 	}

--- a/crates/spartan-prover/src/wiring.rs
+++ b/crates/spartan-prover/src/wiring.rs
@@ -2,16 +2,20 @@
 
 use binius_field::{Field, PackedField};
 use binius_math::{FieldBuffer, FieldSlice, multilinear::eq::eq_ind_partial_eval};
-use binius_spartan_frontend::constraint_system::{MulConstraint, Operand, WitnessIndex};
+use binius_spartan_frontend::constraint_system::{
+	MulConstraint, Operand, WitnessIndex, WitnessSegment,
+};
 use binius_utils::{checked_arithmetics::checked_log_2, rayon::prelude::*};
 
-/// Transpose of the wiring sparse matrix.
+/// Transpose of the private wiring sparse matrix.
+///
+/// Only indexes private witness wires. The private segment's size determines
+/// the buffer dimensions.
 #[derive(Debug)]
 pub struct WiringTranspose {
 	flat_keys: Vec<Key>,
-	keys_start_by_witness_index: Vec<u32>,
-	log_witness_size: usize,
-	private_offset: usize,
+	keys_start_by_private_index: Vec<u32>,
+	log_private_size: usize,
 }
 
 #[derive(Debug, Clone)]
@@ -22,75 +26,70 @@ pub struct Key {
 
 impl WiringTranspose {
 	pub fn transpose(
-		witness_size: usize,
-		private_offset: usize,
+		private_size: usize,
 		mul_constraints: &[MulConstraint<WitnessIndex>],
 	) -> Self {
-		let mut operands_keys_by_wit_idx = vec![Vec::new(); witness_size];
+		let mut keys_by_private_idx = vec![Vec::new(); private_size];
 
 		let mut n_total_keys = 0;
 		for (i, MulConstraint { a, b, c }) in mul_constraints.iter().enumerate() {
 			for (operand_idx, operand) in [a, b, c].into_iter().enumerate() {
 				for &witness_idx in operand.wires() {
-					operands_keys_by_wit_idx[witness_idx.flat_index(private_offset)].push(Key {
-						operand_idx: operand_idx as u8,
-						constraint_idx: i as u32,
-					});
-					n_total_keys += 1;
+					if witness_idx.segment == WitnessSegment::Private {
+						keys_by_private_idx[witness_idx.index as usize].push(Key {
+							operand_idx: operand_idx as u8,
+							constraint_idx: i as u32,
+						});
+						n_total_keys += 1;
+					}
 				}
 			}
 		}
 
 		// Flatten the sparse matrix representation.
-		let mut operand_keys = Vec::with_capacity(n_total_keys);
-		let mut operand_key_start_by_word = Vec::with_capacity(witness_size);
-		for keys in operands_keys_by_wit_idx {
-			let start = operand_keys.len() as u32;
-			operand_keys.extend(keys);
-			operand_key_start_by_word.push(start);
+		let mut flat_keys = Vec::with_capacity(n_total_keys);
+		let mut keys_start = Vec::with_capacity(private_size);
+		for keys in keys_by_private_idx {
+			let start = flat_keys.len() as u32;
+			flat_keys.extend(keys);
+			keys_start.push(start);
 		}
 
-		let log_witness_size = checked_log_2(witness_size);
+		let log_private_size = checked_log_2(private_size);
 
 		Self {
-			flat_keys: operand_keys,
-			keys_start_by_witness_index: operand_key_start_by_word,
-			log_witness_size,
-			private_offset,
+			flat_keys,
+			keys_start_by_private_index: keys_start,
+			log_private_size,
 		}
 	}
 
-	/// Returns the log2 of the witness size.
-	pub fn log_witness_size(&self) -> usize {
-		self.log_witness_size
+	/// Returns the log2 of the private segment size.
+	pub fn log_private_size(&self) -> usize {
+		self.log_private_size
 	}
 
-	/// Returns the witness size.
-	pub fn witness_size(&self) -> usize {
-		1 << self.log_witness_size
+	/// Returns the private segment size.
+	pub fn private_size(&self) -> usize {
+		1 << self.log_private_size
 	}
 
-	/// Returns the minimum witness index of the private segment.
-	pub fn private_offset(&self) -> usize {
-		self.private_offset
-	}
-
-	/// Returns an iterator over keys for a specific witness index.
-	pub fn keys_for_witness(&self, witness_idx: usize) -> &[Key] {
-		let start = self.keys_start_by_witness_index[witness_idx] as usize;
+	/// Returns the keys for a specific private witness index.
+	pub fn keys_for_private(&self, private_idx: usize) -> &[Key] {
+		let start = self.keys_start_by_private_index[private_idx] as usize;
 		let end = self
-			.keys_start_by_witness_index
-			.get(witness_idx + 1)
+			.keys_start_by_private_index
+			.get(private_idx + 1)
 			.map(|&x| x as usize)
 			.unwrap_or(self.flat_keys.len());
 		&self.flat_keys[start..end]
 	}
 }
 
-/// Folds the wiring matrix along the constraint axis by partially evaluating at r_x.
+/// Folds the private wiring matrix along the constraint axis by partially evaluating at r_x.
 ///
 /// Also batches the three operands (a, b, c) using powers of lambda.
-/// Returns a multilinear polynomial over witness indices where each coefficient is the
+/// Returns a multilinear polynomial over private witness indices where each coefficient is the
 /// weighted sum of constraint contributions.
 pub fn fold_constraints<F: Field, P: PackedField<Scalar = F>>(
 	transposed: &WiringTranspose,
@@ -103,27 +102,24 @@ pub fn fold_constraints<F: Field, P: PackedField<Scalar = F>>(
 	// Batching powers for the three operands
 	let lambda_powers = [F::ONE, lambda, lambda.square()];
 
-	// Create packed field buffer for witness indices
-	let private_offset = transposed.private_offset();
-	let witness_size = transposed.witness_size();
-	let log_witness_size = transposed.log_witness_size();
-	let len = 1 << log_witness_size.saturating_sub(P::LOG_WIDTH);
+	let private_size = transposed.private_size();
+	let log_private_size = transposed.log_private_size();
+	let len = 1 << log_private_size.saturating_sub(P::LOG_WIDTH);
 
-	// Process in parallel over chunks of P::WIDTH witness indices
+	// Process in parallel over chunks of P::WIDTH private indices
 	let result = (0..len)
 		.into_par_iter()
 		.map(|packed_idx| {
-			let base_witness_idx = packed_idx << P::LOG_WIDTH;
+			let base_idx = packed_idx << P::LOG_WIDTH;
 
 			P::from_fn(|scalar_idx| {
-				let witness_idx = base_witness_idx + scalar_idx;
-				// For now, only accumulate for the private segment.
-				if witness_idx < private_offset || witness_idx >= witness_size {
+				let private_idx = base_idx + scalar_idx;
+				if private_idx >= private_size {
 					return F::ZERO;
 				}
 
 				let mut acc = F::ZERO;
-				for key in transposed.keys_for_witness(witness_idx) {
+				for key in transposed.keys_for_private(private_idx) {
 					let r_x_weight = r_x_tensor[key.constraint_idx as usize];
 					let lambda_weight = lambda_powers[key.operand_idx as usize];
 					acc += r_x_weight * lambda_weight;
@@ -133,7 +129,7 @@ pub fn fold_constraints<F: Field, P: PackedField<Scalar = F>>(
 		})
 		.collect::<Vec<_>>();
 
-	FieldBuffer::new(log_witness_size, result.into_boxed_slice())
+	FieldBuffer::new(log_private_size, result.into_boxed_slice())
 }
 
 /// Witness data for multiplication constraint checking.
@@ -147,18 +143,18 @@ pub struct MulCheckWitness<P: PackedField> {
 }
 
 /// Evaluates an operand by XORing witness values at the specified indices.
-fn eval_operand<P: PackedField>(
-	witness: &FieldSlice<P>,
+fn eval_operand<F: Field, P: PackedField<Scalar = F>>(
+	public: &[F],
+	private_packed: &FieldSlice<P>,
 	operand: &Operand<WitnessIndex>,
-	private_offset: usize,
-) -> P::Scalar
-where
-	P::Scalar: Field,
-{
+) -> F {
 	operand
 		.wires()
 		.iter()
-		.map(|idx| witness.get(idx.flat_index(private_offset)))
+		.map(|idx| match idx.segment {
+			WitnessSegment::Public => public[idx.index as usize],
+			WitnessSegment::Private => private_packed.get(idx.index as usize),
+		})
 		.sum()
 }
 
@@ -170,8 +166,8 @@ where
 #[tracing::instrument(skip_all, level = "debug")]
 pub fn build_mulcheck_witness<F: Field, P: PackedField<Scalar = F>>(
 	mul_constraints: &[MulConstraint<WitnessIndex>],
-	witness: FieldSlice<P>,
-	private_offset: usize,
+	public: &[F],
+	private_packed: FieldSlice<P>,
 ) -> MulCheckWitness<P> {
 	fn get_a(c: &MulConstraint<WitnessIndex>) -> &Operand<WitnessIndex> {
 		&c.a
@@ -208,9 +204,9 @@ pub fn build_mulcheck_witness<F: Field, P: PackedField<Scalar = F>>(
 					let constraint_idx = offset + j;
 					if constraint_idx < n_constraints {
 						eval_operand(
-							&witness,
+							public,
+							&private_packed,
 							get_operand(&mul_constraints[constraint_idx]),
-							private_offset,
 						)
 					} else {
 						F::ZERO
@@ -254,14 +250,14 @@ mod tests {
 	fn generate_random_constraints(
 		rng: &mut StdRng,
 		n_constraints: usize,
-		witness_size: usize,
-		private_offset: usize,
+		public_size: usize,
+		private_size: usize,
 	) -> Vec<MulConstraint<WitnessIndex>> {
 		(0..n_constraints)
 			.map(|_| {
-				let a = generate_random_operand(rng, witness_size, private_offset);
-				let b = generate_random_operand(rng, witness_size, private_offset);
-				let c = generate_random_operand(rng, witness_size, private_offset);
+				let a = generate_random_operand(rng, public_size, private_size);
+				let b = generate_random_operand(rng, public_size, private_size);
+				let c = generate_random_operand(rng, public_size, private_size);
 				MulConstraint { a, b, c }
 			})
 			.collect()
@@ -269,17 +265,18 @@ mod tests {
 
 	fn generate_random_operand(
 		rng: &mut StdRng,
-		witness_size: usize,
-		private_offset: usize,
+		public_size: usize,
+		private_size: usize,
 	) -> Operand<WitnessIndex> {
+		let total = public_size + private_size;
 		let n_wires = rng.random_range(0..=4);
 		let wires: SmallVec<[WitnessIndex; 4]> = (0..n_wires)
 			.map(|_| {
-				let flat = rng.random_range(0..witness_size);
-				if flat < private_offset {
+				let flat = rng.random_range(0..total);
+				if flat < public_size {
 					WitnessIndex::public(flat as u32)
 				} else {
-					WitnessIndex::private((flat - private_offset) as u32)
+					WitnessIndex::private((flat - public_size) as u32)
 				}
 			})
 			.collect();
@@ -295,9 +292,9 @@ mod tests {
 	) -> F {
 		let mut acc = [F::ZERO; 3];
 
-		for witness_idx in transposed.private_offset()..transposed.witness_size() {
-			let r_y_weight = r_y_tensor[witness_idx];
-			for key in transposed.keys_for_witness(witness_idx) {
+		for private_idx in 0..transposed.private_size() {
+			let r_y_weight = r_y_tensor[private_idx];
+			for key in transposed.keys_for_private(private_idx) {
 				let r_x_weight = r_x_tensor[key.constraint_idx as usize];
 				acc[key.operand_idx as usize] += r_x_weight * r_y_weight;
 			}
@@ -310,29 +307,27 @@ mod tests {
 	fn test_wiring_transpose_equivalence() {
 		let mut rng = StdRng::seed_from_u64(0);
 
-		// Generate random constraints
 		let log_n_constraints = 4;
 		let log_public = 3;
-		let log_witness_size = 5;
+		let log_private = 5;
 
 		let n_constraints = 1 << log_n_constraints;
-		let witness_size = 1 << log_witness_size;
-		let private_offset = 1 << log_public;
+		let public_size = 1 << log_public;
+		let private_size = 1 << log_private;
 
 		let constraints =
-			generate_random_constraints(&mut rng, n_constraints, witness_size, private_offset);
+			generate_random_constraints(&mut rng, n_constraints, public_size, private_size);
 
 		// Sample random evaluation points
 		let r_x = random_scalars::<B128>(&mut rng, log_n_constraints);
-		let r_y = random_scalars::<B128>(&mut rng, log_witness_size);
+		let r_y = random_scalars::<B128>(&mut rng, log_private);
 		let lambda = B128::random(&mut rng);
 
 		// Compute expected result using the verifier's reference implementation
-		let expected =
-			evaluate_private_wiring_mle(&constraints, lambda, &r_x, &r_y, private_offset);
+		let expected = evaluate_private_wiring_mle(&constraints, lambda, &r_x, &r_y);
 
 		// Compute result using the transposed representation
-		let transposed = WiringTranspose::transpose(witness_size, private_offset, &constraints);
+		let transposed = WiringTranspose::transpose(private_size, &constraints);
 		let r_x_tensor = eq_ind_partial_eval::<B128>(&r_x);
 		let r_y_tensor = eq_ind_partial_eval::<B128>(&r_y);
 		let actual = evaluate_private_wiring_mle_transposed(
@@ -351,27 +346,25 @@ mod tests {
 
 		let log_n_constraints = 4;
 		let log_public = 3;
-		let log_witness_size = 5;
+		let log_private = 5;
 
 		let n_constraints = 1 << log_n_constraints;
-		let witness_size = 1 << log_witness_size;
-		let private_offset = 1 << log_public;
+		let public_size = 1 << log_public;
+		let private_size = 1 << log_private;
 
-		// Generate random constraints
 		let constraints =
-			generate_random_constraints(&mut rng, n_constraints, witness_size, private_offset);
+			generate_random_constraints(&mut rng, n_constraints, public_size, private_size);
 
 		// Sample random evaluation points
 		let r_x = random_scalars::<B128>(&mut rng, log_n_constraints);
-		let r_y = random_scalars::<B128>(&mut rng, log_witness_size);
+		let r_y = random_scalars::<B128>(&mut rng, log_private);
 		let lambda = B128::random(&mut rng);
 
 		// Method 1: Compute expected result using evaluate_private_wiring_mle
-		let expected =
-			evaluate_private_wiring_mle(&constraints, lambda, &r_x, &r_y, private_offset);
+		let expected = evaluate_private_wiring_mle(&constraints, lambda, &r_x, &r_y);
 
 		// Method 2: Use fold_constraints then evaluate at r_y
-		let transposed = WiringTranspose::transpose(witness_size, private_offset, &constraints);
+		let transposed = WiringTranspose::transpose(private_size, &constraints);
 		let folded = fold_constraints::<_, Packed128b>(&transposed, lambda, &r_x);
 		let actual = evaluate(&folded, &r_y);
 
@@ -402,23 +395,23 @@ mod tests {
 		// Parameters
 		let log_n_constraints = 4;
 		let log_public = 3;
-		let log_witness_size = 5;
+		let log_private = 5;
 
 		let n_constraints = 1 << log_n_constraints;
-		let witness_size = 1 << log_witness_size;
-
-		let private_offset = 1 << log_public;
+		let public_size = 1 << log_public;
+		let private_size = 1 << log_private;
 
 		// Generate random constraints
 		let constraints =
-			generate_random_constraints(&mut rng, n_constraints, witness_size, private_offset);
+			generate_random_constraints(&mut rng, n_constraints, public_size, private_size);
 
-		// Create random witness
-		let witness = random_field_buffer::<Packed128b>(&mut rng, log_witness_size);
+		// Create random public and private witness buffers
+		let public = random_scalars::<B128>(&mut rng, public_size);
+		let private_buf = random_field_buffer::<Packed128b>(&mut rng, log_private);
 
 		// Compute mulcheck witness
 		let mulcheck_witness =
-			build_mulcheck_witness(&constraints, witness.to_ref(), private_offset);
+			build_mulcheck_witness(&constraints, &public, private_buf.to_ref());
 
 		// Sample r_x (sumcheck evaluation point for constraint axis)
 		let r_x = random_scalars::<B128>(&mut rng, log_n_constraints);
@@ -432,11 +425,10 @@ mod tests {
 		];
 
 		// Create transposed wiring
-		let wiring_transpose =
-			WiringTranspose::transpose(witness_size, private_offset, &constraints);
+		let wiring_transpose = WiringTranspose::transpose(private_size, &constraints);
 
 		let oracle_specs = vec![OracleSpec {
-			log_msg_len: log_witness_size,
+			log_msg_len: log_private,
 		}];
 
 		// === PROVER SIDE ===
@@ -446,17 +438,14 @@ mod tests {
 			oracle_specs.clone(),
 		);
 
-		// Send witness oracle
-		let witness_oracle = prover_channel.send_oracle(witness.to_ref());
+		// Send private witness oracle
+		let witness_oracle = prover_channel.send_oracle(private_buf.to_ref());
 
 		// Sample lambda
 		let lambda: B128 = prover_channel.sample();
 
 		// Compute the batched sum and public contribution
 		let batched_sum = evaluate_univariate(&mulcheck_evals, lambda);
-		let public: Vec<B128> = (0..private_offset)
-			.map(|i| witness.to_ref().get(i))
-			.collect();
 		let public_eval =
 			evaluate_wiring_mle_public(&constraints, log_public, &public, lambda, &r_x);
 		let trace_claim = batched_sum - public_eval;
@@ -504,9 +493,7 @@ mod tests {
 		// Build the transparent closure using the prover's wiring_poly for evaluation.
 		let transparent = Box::new(move |point: &[_]| evaluate(&wiring_poly, point));
 
-		// Finish verification. The naive channel verifies the inner product directly inside
-		// verify_oracle_relations(), reads the transparent polynomial from the transcript,
-		// and checks that the transparent closure evaluation matches.
+		// Finish verification.
 		verifier_channel
 			.verify_oracle_relations([OracleLinearRelation {
 				oracle: witness_oracle,

--- a/crates/spartan-prover/src/wrapper/zk_wrapped_prover_channel.rs
+++ b/crates/spartan-prover/src/wrapper/zk_wrapped_prover_channel.rs
@@ -135,7 +135,7 @@ where
 		// Validate and generate the outer proof.
 		let outer_cs = outer_prover.constraint_system();
 		outer_cs.validate(&witness);
-		outer_prover.prove::<P, _>(&witness, rng, inner_channel)?;
+		outer_prover.prove::<P, _>(witness.as_slice(), rng, inner_channel)?;
 		Ok(())
 	}
 }

--- a/crates/spartan-prover/src/wrapper/zk_wrapped_prover_channel.rs
+++ b/crates/spartan-prover/src/wrapper/zk_wrapped_prover_channel.rs
@@ -135,7 +135,7 @@ where
 		// Validate and generate the outer proof.
 		let outer_cs = outer_prover.constraint_system();
 		outer_cs.validate(&witness);
-		outer_prover.prove::<P, _>(witness.as_slice(), rng, inner_channel)?;
+		outer_prover.prove::<P, _>(witness, rng, inner_channel)?;
 		Ok(())
 	}
 }

--- a/crates/spartan-prover/tests/integration_test.rs
+++ b/crates/spartan-prover/tests/integration_test.rs
@@ -63,18 +63,18 @@ fn test_power7_circuit_prover_verifier() {
 	cs.validate(&witness);
 
 	// Extract public inputs (constants + inout, padded to 2^log_public)
-	let public = witness.public();
+	let public = witness.public().to_vec();
 
 	// Generate proof
 	let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 	prover
-		.prove(witness.as_slice(), &mut rng, &mut prover_transcript)
+		.prove(witness, &mut rng, &mut prover_transcript)
 		.expect("prove failed");
 
 	// Verify proof
 	let mut verifier_transcript = prover_transcript.into_verifier();
 	verifier
-		.verify(public, &mut verifier_transcript)
+		.verify(&public, &mut verifier_transcript)
 		.expect("verify failed");
 	verifier_transcript.finalize().expect("finalize failed");
 }

--- a/crates/spartan-prover/tests/integration_test.rs
+++ b/crates/spartan-prover/tests/integration_test.rs
@@ -63,12 +63,12 @@ fn test_power7_circuit_prover_verifier() {
 	cs.validate(&witness);
 
 	// Extract public inputs (constants + inout, padded to 2^log_public)
-	let public = &witness[..1 << cs.log_public()];
+	let public = witness.public();
 
 	// Generate proof
 	let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 	prover
-		.prove(&witness, &mut rng, &mut prover_transcript)
+		.prove(witness.as_slice(), &mut rng, &mut prover_transcript)
 		.expect("prove failed");
 
 	// Verify proof

--- a/crates/spartan-prover/tests/wrapper_integration_test.rs
+++ b/crates/spartan-prover/tests/wrapper_integration_test.rs
@@ -124,7 +124,7 @@ fn test_zk_wrapped_prove_verify() {
 
 	inner_cs.validate(&inner_witness);
 
-	let public = &inner_witness[..inner_public_size];
+	let public = inner_witness.public();
 
 	// === Step 7: Prove with ZKWrappedProverChannel ===
 	let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
@@ -149,7 +149,7 @@ fn test_zk_wrapped_prove_verify() {
 
 	// Run the inner proof through the wrapped channel.
 	inner_iop_prover
-		.prove::<OptimalPackedB128, _>(&inner_witness, &mut rng, &mut wrapped_prover_channel)
+		.prove::<OptimalPackedB128, _>(inner_witness.as_slice(), &mut rng, &mut wrapped_prover_channel)
 		.expect("inner prove failed");
 
 	// Finish runs the outer proof.

--- a/crates/spartan-prover/tests/wrapper_integration_test.rs
+++ b/crates/spartan-prover/tests/wrapper_integration_test.rs
@@ -124,19 +124,20 @@ fn test_zk_wrapped_prove_verify() {
 
 	inner_cs.validate(&inner_witness);
 
-	let public = inner_witness.public();
+	let public = inner_witness.public().to_vec();
 
 	// === Step 7: Prove with ZKWrappedProverChannel ===
 	let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 
 	// Observe inner public input on the transcript (Fiat-Shamir).
-	prover_transcript.observe().write_slice(public);
+	prover_transcript.observe().write_slice(&public);
 
 	let basefold_channel = zk_basefold_prover.create_channel(&mut prover_transcript, &mut rng);
 	let mut wrapped_prover_channel =
 		ZKWrappedProverChannel::new(basefold_channel, &outer_iop_prover, &outer_layout, {
 			let inner_iop_verifier = &inner_iop_verifier;
-			|replay_channel: &mut ReplayChannel<'_, B128>| {
+			let public = &public;
+			move |replay_channel: &mut ReplayChannel<'_, B128>| {
 				let inner_public_elems = replay_channel.observe_many(public);
 				inner_iop_verifier
 					.verify(inner_public_elems, replay_channel)
@@ -145,11 +146,11 @@ fn test_zk_wrapped_prove_verify() {
 		});
 
 	// Observe public input through the wrapped channel.
-	(&mut wrapped_prover_channel).observe_many(public);
+	(&mut wrapped_prover_channel).observe_many(&public);
 
 	// Run the inner proof through the wrapped channel.
 	inner_iop_prover
-		.prove::<OptimalPackedB128, _>(inner_witness.as_slice(), &mut rng, &mut wrapped_prover_channel)
+		.prove::<OptimalPackedB128, _>(inner_witness, &mut rng, &mut wrapped_prover_channel)
 		.expect("inner prove failed");
 
 	// Finish runs the outer proof.
@@ -161,14 +162,14 @@ fn test_zk_wrapped_prove_verify() {
 	let mut verifier_transcript = prover_transcript.into_verifier();
 
 	// Verifier observes the public input on the transcript (Fiat-Shamir).
-	verifier_transcript.observe().write_slice(public);
+	verifier_transcript.observe().write_slice(&public);
 
 	let verifier_channel = zk_basefold_compiler.create_channel(&mut verifier_transcript);
 	let mut wrapped_verifier_channel =
 		ZKWrappedVerifierChannel::new(verifier_channel, &outer_iop_verifier);
 
 	// Observe public input through the wrapped channel.
-	let inner_public_elems = wrapped_verifier_channel.observe_many(public);
+	let inner_public_elems = wrapped_verifier_channel.observe_many(&public);
 
 	// Run the inner IOP verify through the wrapped channel.
 	inner_iop_verifier

--- a/crates/spartan-verifier/src/constraint_system.rs
+++ b/crates/spartan-verifier/src/constraint_system.rs
@@ -5,7 +5,7 @@ use binius_field::Field;
 use binius_ip::mlecheck::mask_buffer_dimensions;
 pub use binius_spartan_frontend::constraint_system::BlindingInfo;
 use binius_spartan_frontend::constraint_system::{
-	ConstraintSystem, MulConstraint, Operand, WitnessIndex,
+	ConstraintSystem, MulConstraint, Operand, Witness, WitnessIndex,
 };
 use binius_utils::checked_arithmetics::{checked_log_2, log2_ceil_usize};
 
@@ -45,12 +45,12 @@ impl<F: Field> ConstraintSystemPadded<F> {
 		let log_size = log2_ceil_usize(total_witness_size) as u32;
 
 		// Add dummy constraints for blinding
-		// Each dummy constraint uses 3 consecutive wires starting after n_dummy_wires
-		let dummy_constraint_wire_base = n_public + n_private + blinding_info.n_dummy_wires;
+		// Each dummy constraint uses 3 consecutive private wires starting after n_dummy_wires
+		let dummy_private_base = n_private + blinding_info.n_dummy_wires;
 		for i in 0..blinding_info.n_dummy_constraints {
-			let a = WitnessIndex((dummy_constraint_wire_base + 3 * i) as u32);
-			let b = WitnessIndex((dummy_constraint_wire_base + 3 * i + 1) as u32);
-			let c = WitnessIndex((dummy_constraint_wire_base + 3 * i + 2) as u32);
+			let a = WitnessIndex::private((dummy_private_base + 3 * i) as u32);
+			let b = WitnessIndex::private((dummy_private_base + 3 * i + 1) as u32);
+			let c = WitnessIndex::private((dummy_private_base + 3 * i + 2) as u32);
 
 			mul_constraints.push(MulConstraint {
 				a: Operand::from(a),
@@ -131,14 +131,14 @@ impl<F: Field> ConstraintSystemPadded<F> {
 		self.mask_dims
 	}
 
-	pub fn validate(&self, witness: &[F]) {
-		assert_eq!(witness.len(), self.size());
+	pub fn validate(&self, witness: &Witness<F>) {
+		assert_eq!(witness.as_slice().len(), self.size());
 
 		let operand_val = |operand: &Operand<WitnessIndex>| {
 			operand
 				.wires()
 				.iter()
-				.map(|idx| witness[idx.0 as usize])
+				.map(|&idx| witness[idx])
 				.sum::<F>()
 		};
 

--- a/crates/spartan-verifier/src/constraint_system.rs
+++ b/crates/spartan-verifier/src/constraint_system.rs
@@ -36,14 +36,15 @@ impl<F: Field> ConstraintSystemPadded<F> {
 		let mut mul_constraints = cs.mul_constraints().to_vec();
 
 		// Calculate padded private segment size
-		let n_private = cs.n_private() as usize
+		let n_circuit_private = cs.n_private() as usize;
+		let n_private = n_circuit_private
 			+ blinding_info.n_dummy_wires
 			+ 3 * blinding_info.n_dummy_constraints;
 		let log_private = log2_ceil_usize(n_private) as u32;
 
 		// Add dummy constraints for blinding
 		// Each dummy constraint uses 3 consecutive private wires starting after n_dummy_wires
-		let dummy_private_base = n_private + blinding_info.n_dummy_wires;
+		let dummy_private_base = n_circuit_private + blinding_info.n_dummy_wires;
 		for i in 0..blinding_info.n_dummy_constraints {
 			let a = WitnessIndex::private((dummy_private_base + 3 * i) as u32);
 			let b = WitnessIndex::private((dummy_private_base + 3 * i + 1) as u32);

--- a/crates/spartan-verifier/src/constraint_system.rs
+++ b/crates/spartan-verifier/src/constraint_system.rs
@@ -17,7 +17,7 @@ use binius_utils::checked_arithmetics::{checked_log_2, log2_ceil_usize};
 #[derive(Debug, Clone)]
 pub struct ConstraintSystemPadded<F: Field> {
 	inner: ConstraintSystem<F>,
-	log_size: u32,
+	log_private: u32,
 	blinding_info: BlindingInfo,
 	mul_constraints: Vec<MulConstraint<WitnessIndex>>,
 	/// Mask buffer dimensions (m_n, m_d) for the ZK mulcheck mask polynomial.
@@ -35,14 +35,11 @@ impl<F: Field> ConstraintSystemPadded<F> {
 	pub fn new(cs: ConstraintSystem<F>, blinding_info: BlindingInfo) -> Self {
 		let mut mul_constraints = cs.mul_constraints().to_vec();
 
-		// Calculate witness size and log_size
-		let n_public = cs.n_public() as usize;
-		let n_private = cs.n_private() as usize;
-		let total_witness_size = n_public
-			+ n_private
+		// Calculate padded private segment size
+		let n_private = cs.n_private() as usize
 			+ blinding_info.n_dummy_wires
 			+ 3 * blinding_info.n_dummy_constraints;
-		let log_size = log2_ceil_usize(total_witness_size) as u32;
+		let log_private = log2_ceil_usize(n_private) as u32;
 
 		// Add dummy constraints for blinding
 		// Each dummy constraint uses 3 consecutive private wires starting after n_dummy_wires
@@ -79,7 +76,7 @@ impl<F: Field> ConstraintSystemPadded<F> {
 
 		Self {
 			inner: cs,
-			log_size,
+			log_private,
 			blinding_info,
 			mul_constraints,
 			mask_dims,
@@ -110,12 +107,12 @@ impl<F: Field> ConstraintSystemPadded<F> {
 		self.inner.one_wire()
 	}
 
-	pub fn log_size(&self) -> u32 {
-		self.log_size
+	pub fn log_private(&self) -> u32 {
+		self.log_private
 	}
 
-	pub fn size(&self) -> usize {
-		1 << self.log_size as usize
+	pub fn private_size(&self) -> usize {
+		1 << self.log_private as usize
 	}
 
 	pub fn blinding_info(&self) -> &BlindingInfo {
@@ -132,14 +129,11 @@ impl<F: Field> ConstraintSystemPadded<F> {
 	}
 
 	pub fn validate(&self, witness: &Witness<F>) {
-		assert_eq!(witness.as_slice().len(), self.size());
+		assert_eq!(witness.public().len(), 1 << self.log_public() as usize);
+		assert_eq!(witness.private().len(), self.private_size());
 
 		let operand_val = |operand: &Operand<WitnessIndex>| {
-			operand
-				.wires()
-				.iter()
-				.map(|&idx| witness[idx])
-				.sum::<F>()
+			operand.wires().iter().map(|&idx| witness[idx]).sum::<F>()
 		};
 
 		for MulConstraint { a, b, c } in &self.mul_constraints {

--- a/crates/spartan-verifier/src/constraint_system.rs
+++ b/crates/spartan-verifier/src/constraint_system.rs
@@ -37,9 +37,8 @@ impl<F: Field> ConstraintSystemPadded<F> {
 
 		// Calculate padded private segment size
 		let n_circuit_private = cs.n_private() as usize;
-		let n_private = n_circuit_private
-			+ blinding_info.n_dummy_wires
-			+ 3 * blinding_info.n_dummy_constraints;
+		let n_private =
+			n_circuit_private + blinding_info.n_dummy_wires + 3 * blinding_info.n_dummy_constraints;
 		let log_private = log2_ceil_usize(n_private) as u32;
 
 		// Add dummy constraints for blinding

--- a/crates/spartan-verifier/src/lib.rs
+++ b/crates/spartan-verifier/src/lib.rs
@@ -43,13 +43,16 @@ use binius_iop::{
 	merkle_tree::BinaryMerkleTreeScheme,
 };
 use binius_ip::{channel::IPVerifierChannel, mlecheck, sumcheck};
-use binius_math::multilinear::evaluate::evaluate_inplace_scalars;
+use binius_math::univariate::evaluate_univariate;
 use binius_spartan_frontend::constraint_system::ConstraintSystem;
 use binius_transcript::{VerifierTranscript, fiat_shamir::Challenger};
 use binius_utils::{DeserializeBytes, checked_arithmetics::checked_log_2};
 use digest::{Digest, Output, core_api::BlockSizeUser};
 
-use crate::constraint_system::{BlindingInfo, ConstraintSystemPadded};
+use crate::{
+	constraint_system::{BlindingInfo, ConstraintSystemPadded},
+	wiring::evaluate_wiring_mle_public,
+};
 
 pub const SECURITY_BITS: usize = 96;
 
@@ -175,24 +178,25 @@ impl<F: Field> IOPVerifier<F> {
 			r_x,
 		} = verify_mulcheck(cs, channel)?;
 
-		// Sample the public input check challenge and evaluate the public input at the challenge
-		// point.
-		let r_public = channel.sample_many(cs.log_public() as usize);
+		// λ is the batching challenge for the constraint operands
+		let lambda = channel.sample();
 
-		let public_eval = evaluate_inplace_scalars(public, &r_public);
+		// Batch together the constraint operand evaluation claims.
+		let batched_sum = evaluate_univariate(&[a_eval, b_eval, c_eval], lambda.clone());
 
-		// Compute wiring claim components
-		let wiring_claim =
-			wiring::compute_claim(cs, &r_public, &[a_eval, b_eval, c_eval], public_eval, channel);
+		// Compute rₓ^⊤ (M_A + λ M_B + λ² M_C) x
+		let public_eval = evaluate_wiring_mle_public(
+			cs.mul_constraints(),
+			cs.log_public() as usize,
+			&public,
+			lambda.clone(),
+			&r_x,
+		);
+
+		let trace_claim = batched_sum - public_eval;
 
 		// Build the transparent closure for the wiring oracle relation
-		let trace_transparent = wiring::eval_transparent(
-			cs,
-			&r_public,
-			&r_x,
-			wiring_claim.lambda,
-			wiring_claim.batch_coeff,
-		);
+		let trace_transparent = wiring::eval_transparent(cs, &r_x, lambda);
 
 		// Build the transparent closure for the mask oracle relation
 		let mask_transparent = mask_transparent(cs, &r_x);
@@ -202,7 +206,7 @@ impl<F: Field> IOPVerifier<F> {
 			OracleLinearRelation {
 				oracle: trace_oracle,
 				transparent: trace_transparent,
-				claim: wiring_claim.batched_sum,
+				claim: trace_claim,
 			},
 			OracleLinearRelation {
 				oracle: mask_oracle,
@@ -362,9 +366,7 @@ pub enum Error {
 	Sumcheck(#[from] sumcheck::Error),
 	#[error("BaseFold error: {0}")]
 	BaseFold(#[from] basefold::Error),
-	#[error("wiring error: {0}")]
-	Wiring(#[from] wiring::Error),
-	#[error("Transcript error: {0}")]
+#[error("Transcript error: {0}")]
 	Transcript(#[from] binius_transcript::Error),
 	#[error("IOP channel error: {0}")]
 	IOPChannel(#[from] binius_iop::channel::Error),

--- a/crates/spartan-verifier/src/lib.rs
+++ b/crates/spartan-verifier/src/lib.rs
@@ -113,7 +113,7 @@ impl<F: Field> IOPVerifier<F> {
 	/// These describe the oracles (witness and mask) that the prover commits to.
 	pub fn oracle_specs(&self) -> Vec<OracleSpec> {
 		let cs = &self.constraint_system;
-		let log_witness_size = cs.log_size() as usize;
+		let log_witness_size = cs.log_private() as usize;
 		let (m_n, m_d) = cs.mask_dims();
 		let log_mask_dim = m_n + m_d;
 

--- a/crates/spartan-verifier/src/lib.rs
+++ b/crates/spartan-verifier/src/lib.rs
@@ -366,7 +366,7 @@ pub enum Error {
 	Sumcheck(#[from] sumcheck::Error),
 	#[error("BaseFold error: {0}")]
 	BaseFold(#[from] basefold::Error),
-#[error("Transcript error: {0}")]
+	#[error("Transcript error: {0}")]
 	Transcript(#[from] binius_transcript::Error),
 	#[error("IOP channel error: {0}")]
 	IOPChannel(#[from] binius_iop::channel::Error),

--- a/crates/spartan-verifier/src/wiring.rs
+++ b/crates/spartan-verifier/src/wiring.rs
@@ -3,59 +3,10 @@
 use std::iter;
 
 use binius_field::{Field, field::FieldOps};
-use binius_iop::basefold;
-use binius_ip::{channel::IPVerifierChannel, sumcheck};
-use binius_math::{
-	multilinear::eq::{eq_ind, eq_ind_partial_eval_scalars, eq_one_var},
-	univariate::evaluate_univariate,
-};
-use binius_spartan_frontend::constraint_system::{MulConstraint, WitnessIndex};
+use binius_math::{multilinear::eq::eq_ind_partial_eval_scalars, univariate::evaluate_univariate};
+use binius_spartan_frontend::constraint_system::{MulConstraint, WitnessIndex, WitnessSegment};
 
 use crate::constraint_system::ConstraintSystemPadded;
-
-/// Claim components from the wiring check computation via IOP channel.
-#[derive(Debug, Clone)]
-pub struct WiringClaim<F> {
-	/// Batching challenge for constraint operands.
-	pub lambda: F,
-	/// Coefficient for batching public input check with wiring check.
-	pub batch_coeff: F,
-	/// The batched sum of all claims.
-	pub batched_sum: F,
-}
-
-/// Computes the wiring claim using an IOP channel interface.
-///
-/// Samples the batching challenges and computes the batched claim from the
-/// evaluation claims and public input evaluation.
-pub fn compute_claim<F, C>(
-	_constraint_system: &ConstraintSystemPadded<F>,
-	_r_public: &[C::Elem],
-	eval_claims: &[C::Elem],
-	public_eval: C::Elem,
-	channel: &mut C,
-) -> WiringClaim<C::Elem>
-where
-	F: Field,
-	C: IPVerifierChannel<F>,
-{
-	// \lambda is the batching challenge for the constraint operands
-	let lambda = channel.sample();
-
-	// Coefficient for batching the public input check with the wiring check.
-	let batch_coeff = channel.sample();
-
-	// Batch together the witness public input consistency claim with the
-	// constraint operand evaluation claims.
-	let batched_sum =
-		evaluate_univariate(eval_claims, lambda.clone()) + batch_coeff.clone() * public_eval;
-
-	WiringClaim {
-		lambda,
-		batch_coeff,
-		batched_sum,
-	}
-}
 
 /// Returns a closure that evaluates the wiring transparent polynomial at a given point.
 ///
@@ -63,32 +14,19 @@ where
 /// public input equality check, given a challenge point from the BaseFold opening.
 pub fn eval_transparent<'a, G: Field, F: FieldOps + 'a>(
 	constraint_system: &ConstraintSystemPadded<G>,
-	r_public: &[F],
 	r_x: &[F],
 	lambda: F,
-	batch_coeff: F,
 ) -> binius_iop::channel::TransparentEvalFn<'a, F> {
-	let r_public = r_public.to_vec();
 	let r_x = r_x.to_vec();
 	let mul_constraints = constraint_system.mul_constraints().to_vec();
 	let private_offset = constraint_system.n_public() as usize;
 
 	Box::new(move |r_y: &[F]| {
-		let wiring_eval =
-			evaluate_wiring_mle(&mul_constraints, lambda.clone(), &r_x, r_y, private_offset);
-
-		// Evaluate eq(r_public || ZERO, r_y)
-		let (r_y_head, r_y_tail) = r_y.split_at(r_public.len());
-		let eq_head = eq_ind(&r_public, r_y_head);
-		let eq_public = r_y_tail
-			.iter()
-			.fold(eq_head, |eval, r_y_i| eval * eq_one_var(r_y_i.clone(), F::zero()));
-
-		wiring_eval + batch_coeff.clone() * eq_public
+		evaluate_private_wiring_mle(&mul_constraints, lambda.clone(), &r_x, r_y, private_offset)
 	})
 }
 
-pub fn evaluate_wiring_mle<F: FieldOps>(
+pub fn evaluate_private_wiring_mle<F: FieldOps>(
 	mul_constraints: &[MulConstraint<WitnessIndex>],
 	lambda: F,
 	r_x: &[F],
@@ -104,7 +42,13 @@ pub fn evaluate_wiring_mle<F: FieldOps>(
 			let r_y_tensor_sum = operand
 				.wires()
 				.iter()
-				.map(|j| r_y_tensor[j.flat_index(private_offset)].clone())
+				.flat_map(|index| {
+					if let WitnessSegment::Private = index.segment {
+						Some(r_y_tensor[index.flat_index(private_offset)].clone())
+					} else {
+						None
+					}
+				})
 				.sum::<F>();
 			*dst += r_x_tensor_i.clone() * r_y_tensor_sum;
 		}
@@ -113,12 +57,33 @@ pub fn evaluate_wiring_mle<F: FieldOps>(
 	evaluate_univariate(&acc, lambda)
 }
 
-#[derive(Debug, thiserror::Error)]
-pub enum Error {
-	#[error("transcript error: {0}")]
-	Transcript(#[from] binius_transcript::Error),
-	#[error("BaseFold error: {0}")]
-	BaseFold(#[from] basefold::Error),
-	#[error("sumcheck error: {0}")]
-	Sumcheck(#[from] sumcheck::Error),
+pub fn evaluate_wiring_mle_public<F: FieldOps>(
+	mul_constraints: &[MulConstraint<WitnessIndex>],
+	log_public: usize,
+	public: &[F],
+	lambda: F,
+	r_x: &[F],
+) -> F {
+	assert_eq!(public.len(), 1 << log_public);
+
+	let mut acc = [F::zero(), F::zero(), F::zero()];
+	let r_x_tensor = eq_ind_partial_eval_scalars(r_x);
+	for (r_x_tensor_i, MulConstraint { a, b, c }) in iter::zip(&r_x_tensor, mul_constraints) {
+		for (dst, operand) in iter::zip(&mut acc, [a, b, c]) {
+			let public_sum = operand
+				.wires()
+				.iter()
+				.flat_map(|index| {
+					if let WitnessSegment::Public = index.segment {
+						Some(public[index.index as usize].clone())
+					} else {
+						None
+					}
+				})
+				.sum::<F>();
+			*dst += r_x_tensor_i.clone() * public_sum;
+		}
+	}
+
+	evaluate_univariate(&acc, lambda)
 }

--- a/crates/spartan-verifier/src/wiring.rs
+++ b/crates/spartan-verifier/src/wiring.rs
@@ -19,19 +19,21 @@ pub fn eval_transparent<'a, G: Field, F: FieldOps + 'a>(
 ) -> binius_iop::channel::TransparentEvalFn<'a, F> {
 	let r_x = r_x.to_vec();
 	let mul_constraints = constraint_system.mul_constraints().to_vec();
-	let private_offset = constraint_system.n_public() as usize;
 
 	Box::new(move |r_y: &[F]| {
-		evaluate_private_wiring_mle(&mul_constraints, lambda.clone(), &r_x, r_y, private_offset)
+		evaluate_private_wiring_mle(&mul_constraints, lambda.clone(), &r_x, r_y)
 	})
 }
 
+/// Evaluates the private wiring MLE at a point (r_x, r_y).
+///
+/// The r_y dimension corresponds to the private witness segment only (log_private variables).
+/// Private wire indices are used directly as indices into r_y_tensor.
 pub fn evaluate_private_wiring_mle<F: FieldOps>(
 	mul_constraints: &[MulConstraint<WitnessIndex>],
 	lambda: F,
 	r_x: &[F],
 	r_y: &[F],
-	private_offset: usize,
 ) -> F {
 	let mut acc = [F::zero(), F::zero(), F::zero()];
 
@@ -44,7 +46,7 @@ pub fn evaluate_private_wiring_mle<F: FieldOps>(
 				.iter()
 				.flat_map(|index| {
 					if let WitnessSegment::Private = index.segment {
-						Some(r_y_tensor[index.flat_index(private_offset)].clone())
+						Some(r_y_tensor[index.index as usize].clone())
 					} else {
 						None
 					}

--- a/crates/spartan-verifier/src/wiring.rs
+++ b/crates/spartan-verifier/src/wiring.rs
@@ -71,9 +71,11 @@ pub fn eval_transparent<'a, G: Field, F: FieldOps + 'a>(
 	let r_public = r_public.to_vec();
 	let r_x = r_x.to_vec();
 	let mul_constraints = constraint_system.mul_constraints().to_vec();
+	let private_offset = constraint_system.n_public() as usize;
 
 	Box::new(move |r_y: &[F]| {
-		let wiring_eval = evaluate_wiring_mle(&mul_constraints, lambda.clone(), &r_x, r_y);
+		let wiring_eval =
+			evaluate_wiring_mle(&mul_constraints, lambda.clone(), &r_x, r_y, private_offset);
 
 		// Evaluate eq(r_public || ZERO, r_y)
 		let (r_y_head, r_y_tail) = r_y.split_at(r_public.len());
@@ -91,6 +93,7 @@ pub fn evaluate_wiring_mle<F: FieldOps>(
 	lambda: F,
 	r_x: &[F],
 	r_y: &[F],
+	private_offset: usize,
 ) -> F {
 	let mut acc = [F::zero(), F::zero(), F::zero()];
 
@@ -101,7 +104,7 @@ pub fn evaluate_wiring_mle<F: FieldOps>(
 			let r_y_tensor_sum = operand
 				.wires()
 				.iter()
-				.map(|j| r_y_tensor[j.0 as usize].clone())
+				.map(|j| r_y_tensor[j.flat_index(private_offset)].clone())
 				.sum::<F>();
 			*dst += r_x_tensor_i.clone() * r_y_tensor_sum;
 		}

--- a/crates/spartan-verifier/src/wrapper/channel.rs
+++ b/crates/spartan-verifier/src/wrapper/channel.rs
@@ -146,7 +146,12 @@ impl<'a, F: Field> ReplayChannel<'a, F> {
 	}
 
 	/// Consumes the channel and builds the outer witness.
-	pub fn finish(self) -> Result<Vec<F>, binius_spartan_frontend::circuit_builder::WitnessError> {
+	pub fn finish(
+		self,
+	) -> Result<
+		binius_spartan_frontend::constraint_system::Witness<F>,
+		binius_spartan_frontend::circuit_builder::WitnessError,
+	> {
 		Rc::try_unwrap(self.witness_gen)
 			.expect("CircuitElem values should only hold Weak references")
 			.into_inner()

--- a/crates/spartan-verifier/tests/proof_size_test.rs
+++ b/crates/spartan-verifier/tests/proof_size_test.rs
@@ -57,5 +57,5 @@ fn test_ip_proof_size() {
 	// FRI proof sizes. It is a slight underestimate because it does not account for some
 	// smaller BaseFold components (e.g. sumcheck coefficients within BaseFold, blinding
 	// elements for ZK).
-	assert_eq!(proof_size, 91152, "proof size regression");
+	assert_eq!(proof_size, 71056, "proof size regression");
 }


### PR DESCRIPTION
## Summary

- Introduce `Witness` struct with separate public/private segments and `WitnessIndex` with `WitnessSegment` discriminant, replacing flat `Vec<F>` witness representation
- Change public input handling: treat public values as a partition of wiring matrices rather than a subsection of the witness, so the committed oracle covers only the private segment
- Adapt prover and verifier to segmented witness — oracle size is `1 << log_private`, wiring transpose indexes only private wires, and `ConstraintSystemPadded` tracks `log_private`
- Fix dummy constraint wire index miscalculation in `ConstraintSystemPadded::new()` where `dummy_private_base` double-counted `n_dummy_wires`, silently defeating zero-knowledge (BINIUS-23)

## Test plan

- `cargo test -p binius-spartan-frontend`
- `cargo test -p binius-spartan-prover`
- `cargo test -p binius-spartan-verifier`
- `cargo test -p binius-prover --test prove_verify`
