### PR TITLE
Add precommit witness segment for Spartan proofs

### DIFF
--- a/crates/iop-prover/src/basefold_zk_channel.rs
+++ b/crates/iop-prover/src/basefold_zk_channel.rs
@@ -7,6 +7,8 @@
 //! this channel always applies zero-knowledge blinding to all oracles by generating masks
 //! internally.
 
+use std::iter;
+
 use binius_field::{BinaryField, PackedField};
 use binius_iop::{channel::OracleSpec, fri::FRIParams, merkle_tree::MerkleTreeScheme};
 use binius_ip_prover::channel::IPProverChannel;
@@ -182,23 +184,35 @@ where
 			buffer.log_len()
 		);
 
-		// Copy the message for later use in prove_zk (commit_masked consumes buffer).
-		let log_len = buffer.log_len();
-		let message_values: Box<[P]> = buffer.as_ref().into();
-
 		// Generate mask, interleave, and commit via commit_masked.
 		let CommitMaskedOutput {
 			commitment,
 			committed,
 			codeword,
 			mask,
-		} = fri::commit_masked(fri_params, self.ntt, self.merkle_prover, buffer, &mut self.rng)
-			.expect("FRI commit_masked should succeed with valid params");
+		} = fri::commit_masked(
+			fri_params,
+			self.ntt,
+			self.merkle_prover,
+			buffer.to_ref(),
+			&mut self.rng,
+		)
+		.expect("FRI commit_masked should succeed with valid params");
 
 		// Build the combined (witness || mask) buffer for later use in prove_zk.
-		let mut combined_values = Vec::with_capacity(message_values.len() * 2);
-		combined_values.extend_from_slice(&message_values);
-		combined_values.extend_from_slice(mask.as_ref());
+		let log_len = buffer.log_len();
+		let combined_values = if log_len < P::LOG_WIDTH {
+			let combined_value =
+				P::from_scalars(iter::chain(buffer.iter_scalars(), mask.iter_scalars()));
+			vec![combined_value]
+		} else {
+			// TODO: The concatenation here is sequential and a performance issue. Ideally, commit
+			// should not allocate and copy the memory into a temp buffer.
+			// TODO: At the very least, make this a parallel copy
+			iter::chain(buffer.as_ref(), mask.as_ref())
+				.copied()
+				.collect::<Vec<_>>()
+		};
 		let combined = FieldBuffer::new(log_len + 1, combined_values.into_boxed_slice());
 
 		// Send commitment via transcript.

--- a/crates/iop-prover/src/fri/commit.rs
+++ b/crates/iop-prover/src/fri/commit.rs
@@ -1,6 +1,8 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
+use std::iter;
+
 use binius_field::{BinaryField, PackedField};
 use binius_iop::{fri::FRIParams, merkle_tree::MerkleTreeScheme};
 use binius_math::{FieldBuffer, FieldSlice, ntt::AdditiveNTT};
@@ -133,12 +135,18 @@ where
 		par_rand::<StdRng, _, _>(packed_len, &mut rng, P::random).collect(),
 	);
 
-	// TODO: The concatenation here is sequential and a performance issue. Ideally, commit should
-	// not allocate and copy the memory into a temp buffer.
-	let combined_packed_len = packed_len * 2;
-	let mut combined_values = Vec::with_capacity(combined_packed_len);
-	combined_values.extend_from_slice(message.as_ref());
-	combined_values.extend_from_slice(mask.as_ref());
+	let combined_values = if log_len < P::LOG_WIDTH {
+		let combined_value =
+			P::from_scalars(iter::chain(message.iter_scalars(), mask.iter_scalars()));
+		vec![combined_value]
+	} else {
+		// TODO: The concatenation here is sequential and a performance issue. Ideally, commit
+		// should not allocate and copy the memory into a temp buffer.
+		// TODO: At the very least, make this a parallel copy
+		iter::chain(message.as_ref(), mask.as_ref())
+			.copied()
+			.collect::<Vec<_>>()
+	};
 	let combined = FieldBuffer::new(log_len + 1, combined_values.into_boxed_slice());
 
 	let CommitOutput {

--- a/crates/spartan-frontend/src/circuit_builder.rs
+++ b/crates/spartan-frontend/src/circuit_builder.rs
@@ -91,6 +91,7 @@ pub enum WireStatus {
 pub struct ConstraintSystemIR<F: Field> {
 	pub(crate) constant_alloc: WireAllocator,
 	pub(crate) public_alloc: WireAllocator,
+	pub(crate) precommit_alloc: WireAllocator,
 	pub(crate) private_alloc: WireAllocator,
 	pub(crate) constants: HashMap<F, u32>,
 	pub(crate) zero_constraints: Vec<Operand<ConstraintWire>>,
@@ -145,8 +146,12 @@ impl<F: Field> ConstraintSystemIR<F> {
 			.collect();
 
 		// Create WitnessLayout
-		let layout =
-			WitnessLayout::sparse(constants.clone(), self.public_alloc.n_wires, &private_alive);
+		let layout = WitnessLayout::sparse(
+			constants.clone(),
+			self.public_alloc.n_wires,
+			self.precommit_alloc.n_wires,
+			&private_alive,
+		);
 
 		// Map all ConstraintWire to WitnessIndex
 		let map_operand = |operand: &Operand<ConstraintWire>| -> Operand<WitnessIndex> {
@@ -177,6 +182,7 @@ impl<F: Field> ConstraintSystemIR<F> {
 		let cs = ConstraintSystem::new(
 			constants,
 			layout.n_inout() as u32,
+			layout.n_precommit() as u32,
 			layout.n_private() as u32,
 			layout.log_public(),
 			mul_constraints,
@@ -203,6 +209,7 @@ impl<F: Field> ConstraintBuilder<F> {
 			ir: ConstraintSystemIR {
 				constant_alloc: WireAllocator::new(WireKind::Constant),
 				public_alloc: WireAllocator::new(WireKind::InOut),
+				precommit_alloc: WireAllocator::new(WireKind::Precommit),
 				private_alloc: WireAllocator::new(WireKind::Private),
 				constants: HashMap::new(),
 				zero_constraints: Vec::new(),
@@ -214,6 +221,10 @@ impl<F: Field> ConstraintBuilder<F> {
 
 	pub fn alloc_inout(&mut self) -> ConstraintWire {
 		self.ir.public_alloc.alloc()
+	}
+
+	pub fn alloc_precommit(&mut self) -> ConstraintWire {
+		self.ir.precommit_alloc.alloc()
 	}
 
 	pub fn build(self) -> ConstraintSystemIR<F> {
@@ -304,6 +315,7 @@ impl<F: Field> WitnessWire<F> {
 pub struct WitnessGenerator<'a, F: Field> {
 	alloc: WireAllocator,
 	public: Vec<F>,
+	precommit: Vec<F>,
 	private: Vec<F>,
 	layout: &'a WitnessLayout<F>,
 	first_error: Option<Backtrace>,
@@ -314,11 +326,13 @@ impl<'a, F: Field> WitnessGenerator<'a, F> {
 		let mut public = zeroed_vec(layout.public_size());
 		public[..layout.constants.len()].copy_from_slice(&layout.constants);
 
+		let precommit = zeroed_vec(layout.precommit_size());
 		let private = zeroed_vec(layout.private_size());
 
 		Self {
 			alloc: WireAllocator::new(WireKind::Private),
 			public,
+			precommit,
 			private,
 			layout,
 			first_error: None,
@@ -334,6 +348,7 @@ impl<'a, F: Field> WitnessGenerator<'a, F> {
 		if let Some(index) = self.layout.get(&wire) {
 			match index.segment {
 				WitnessSegment::Public => self.public[index.index as usize] = value,
+				WitnessSegment::Precommit => self.precommit[index.index as usize] = value,
 				WitnessSegment::Private => self.private[index.index as usize] = value,
 			}
 		}
@@ -345,11 +360,16 @@ impl<'a, F: Field> WitnessGenerator<'a, F> {
 		self.write_value(wire, value)
 	}
 
+	pub fn write_precommit(&mut self, wire: ConstraintWire, value: F) -> WitnessWire<F> {
+		assert_eq!(wire.kind, WireKind::Precommit);
+		self.write_value(wire, value)
+	}
+
 	pub fn build(self) -> Result<Witness<F>, WitnessError> {
 		if let Some(backtrace) = self.first_error {
 			Err(WitnessError { backtrace })
 		} else {
-			Ok(Witness::new(self.public, self.private))
+			Ok(Witness::new(self.public, self.precommit, self.private))
 		}
 	}
 

--- a/crates/spartan-frontend/src/circuit_builder.rs
+++ b/crates/spartan-frontend/src/circuit_builder.rs
@@ -472,6 +472,28 @@ mod tests {
 	}
 
 	#[test]
+	fn test_fibonacci_with_precommit() {
+		let mut constraint_builder = ConstraintBuilder::new();
+		let x0 = constraint_builder.alloc_inout();
+		let x1 = constraint_builder.alloc_inout();
+		let xn = constraint_builder.alloc_precommit();
+		let out = fibonacci(&mut constraint_builder, x0, x1, 20);
+		constraint_builder.assert_eq(out, xn);
+		let ir = constraint_builder.build();
+		let (constraint_system, layout) = ir.finalize();
+
+		let mut witness_generator = WitnessGenerator::new(&layout);
+		let x0 = witness_generator.write_inout(x0, B128::ONE);
+		let x1 = witness_generator.write_inout(x1, B128::MULTIPLICATIVE_GENERATOR);
+		let xn = witness_generator.write_precommit(xn, B128::MULTIPLICATIVE_GENERATOR.pow(6765));
+		let out = fibonacci(&mut witness_generator, x0, x1, 20);
+		witness_generator.assert_eq(out, xn);
+		let witness = witness_generator.build().unwrap();
+
+		constraint_system.validate(&witness);
+	}
+
+	#[test]
 	fn test_assertion_failure_captured() {
 		let mut constraint_builder = ConstraintBuilder::new();
 		let x = constraint_builder.alloc_inout();

--- a/crates/spartan-frontend/src/constraint_system.rs
+++ b/crates/spartan-frontend/src/constraint_system.rs
@@ -378,11 +378,16 @@ impl<F: Field> WitnessLayout<F> {
 	}
 
 	pub fn with_blinding(self, info: BlindingInfo) -> Self {
-		let n_private = self.n_private as usize;
-		let total_private = n_private + info.n_dummy_wires + 3 * info.n_dummy_constraints;
+		let blinding_size = info.n_dummy_wires + 3 * info.n_dummy_constraints;
+
+		let total_precommit = self.n_precommit as usize + blinding_size;
+		let log_precommit = log2_ceil_usize(total_precommit) as u32;
+
+		let total_private = self.n_private as usize + blinding_size;
 		let log_private = log2_ceil_usize(total_private) as u32;
 
 		Self {
+			log_precommit,
 			log_private,
 			..self
 		}

--- a/crates/spartan-frontend/src/constraint_system.rs
+++ b/crates/spartan-frontend/src/constraint_system.rs
@@ -15,6 +15,7 @@ use smallvec::{SmallVec, smallvec};
 pub enum WireKind {
 	Constant,
 	InOut,
+	Precommit,
 	Private,
 }
 
@@ -31,6 +32,14 @@ impl ConstraintWire {
 	pub fn inout(id: u32) -> Self {
 		Self {
 			kind: WireKind::InOut,
+			id,
+		}
+	}
+
+	/// Creates a constraint wire referencing a precommit wire by ID.
+	pub fn precommit(id: u32) -> Self {
+		Self {
+			kind: WireKind::Precommit,
 			id,
 		}
 	}
@@ -139,6 +148,9 @@ pub struct MulConstraint<W> {
 pub enum WitnessSegment {
 	/// The public segment contains constant and input/output witness values.
 	Public,
+	/// The precommit segment contains values committed in a separate oracle before the private
+	/// segment. These are zero-knowledge hidden but not prunable or rearrangeable.
+	Precommit,
 	/// The private segment contains the remaining witness values, which are hidden from the
 	/// verifier.
 	Private,
@@ -158,6 +170,13 @@ impl WitnessIndex {
 		}
 	}
 
+	pub fn precommit(index: u32) -> Self {
+		Self {
+			segment: WitnessSegment::Precommit,
+			index,
+		}
+	}
+
 	pub fn private(index: u32) -> Self {
 		Self {
 			segment: WitnessSegment::Private,
@@ -168,16 +187,25 @@ impl WitnessIndex {
 
 pub struct Witness<F> {
 	public: Vec<F>,
+	precommit: Vec<F>,
 	private: Vec<F>,
 }
 
 impl<F> Witness<F> {
-	pub fn new(public: Vec<F>, private: Vec<F>) -> Self {
-		Self { public, private }
+	pub fn new(public: Vec<F>, precommit: Vec<F>, private: Vec<F>) -> Self {
+		Self {
+			public,
+			precommit,
+			private,
+		}
 	}
 
 	pub fn public(&self) -> &[F] {
 		&self.public
+	}
+
+	pub fn precommit(&self) -> &[F] {
+		&self.precommit
 	}
 
 	pub fn private(&self) -> &[F] {
@@ -191,6 +219,7 @@ impl<F> Index<WitnessIndex> for Witness<F> {
 	fn index(&self, index: WitnessIndex) -> &Self::Output {
 		match index.segment {
 			WitnessSegment::Public => &self.public[index.index as usize],
+			WitnessSegment::Precommit => &self.precommit[index.index as usize],
 			WitnessSegment::Private => &self.private[index.index as usize],
 		}
 	}
@@ -200,6 +229,7 @@ impl<F> IndexMut<WitnessIndex> for Witness<F> {
 	fn index_mut(&mut self, index: WitnessIndex) -> &mut Self::Output {
 		match index.segment {
 			WitnessSegment::Public => &mut self.public[index.index as usize],
+			WitnessSegment::Precommit => &mut self.precommit[index.index as usize],
 			WitnessSegment::Private => &mut self.private[index.index as usize],
 		}
 	}
@@ -216,6 +246,7 @@ impl<F> IndexMut<WitnessIndex> for Witness<F> {
 pub struct ConstraintSystem<F: Field> {
 	constants: Vec<F>,
 	n_inout: u32,
+	n_precommit: u32,
 	n_private: u32,
 	log_public: u32,
 	mul_constraints: Vec<MulConstraint<WitnessIndex>>,
@@ -227,6 +258,7 @@ impl<F: Field> ConstraintSystem<F> {
 	pub fn new(
 		constants: Vec<F>,
 		n_inout: u32,
+		n_precommit: u32,
 		n_private: u32,
 		log_public: u32,
 		mul_constraints: Vec<MulConstraint<WitnessIndex>>,
@@ -235,6 +267,7 @@ impl<F: Field> ConstraintSystem<F> {
 		Self {
 			constants,
 			n_inout,
+			n_precommit,
 			n_private,
 			log_public,
 			mul_constraints,
@@ -248,6 +281,10 @@ impl<F: Field> ConstraintSystem<F> {
 
 	pub fn n_inout(&self) -> u32 {
 		self.n_inout
+	}
+
+	pub fn n_precommit(&self) -> u32 {
+		self.n_precommit
 	}
 
 	pub fn n_private(&self) -> u32 {
@@ -297,17 +334,25 @@ pub struct BlindingInfo {
 pub struct WitnessLayout<F: Field> {
 	pub(crate) constants: Vec<F>,
 	n_inout: u32,
+	n_precommit: u32,
 	n_private: u32,
 	log_public: u32,
+	log_precommit: u32,
 	log_private: u32,
 	private_index_map: HashMap<u32, u32>,
 }
 
 impl<F: Field> WitnessLayout<F> {
-	pub fn sparse(constants: Vec<F>, n_inout: u32, private_alive: &[bool]) -> Self {
+	pub fn sparse(
+		constants: Vec<F>,
+		n_inout: u32,
+		n_precommit: u32,
+		private_alive: &[bool],
+	) -> Self {
 		let n_constants = constants.len() as u32;
 		let n_public = n_constants + n_inout;
 		let log_public = log2_ceil_usize(n_public as usize) as u32;
+		let log_precommit = log2_ceil_usize(n_precommit as usize) as u32;
 
 		let private_index_map = private_alive
 			.iter()
@@ -323,8 +368,10 @@ impl<F: Field> WitnessLayout<F> {
 		Self {
 			constants,
 			n_inout,
+			n_precommit,
 			n_private,
 			log_public,
+			log_precommit,
 			log_private,
 			private_index_map,
 		}
@@ -345,6 +392,10 @@ impl<F: Field> WitnessLayout<F> {
 		1 << self.log_public as usize
 	}
 
+	pub fn precommit_size(&self) -> usize {
+		1 << self.log_precommit as usize
+	}
+
 	pub fn private_size(&self) -> usize {
 		1 << self.log_private as usize
 	}
@@ -357,12 +408,20 @@ impl<F: Field> WitnessLayout<F> {
 		self.n_inout as usize
 	}
 
+	pub fn n_precommit(&self) -> usize {
+		self.n_precommit as usize
+	}
+
 	pub fn n_private(&self) -> usize {
 		self.n_private as usize
 	}
 
 	pub fn log_public(&self) -> u32 {
 		self.log_public
+	}
+
+	pub fn log_precommit(&self) -> u32 {
+		self.log_precommit
 	}
 
 	pub fn log_private(&self) -> u32 {
@@ -383,6 +442,10 @@ impl<F: Field> WitnessLayout<F> {
 			WireKind::InOut => {
 				assert!(wire.id < self.n_inout);
 				Some(WitnessIndex::public(self.constants.len() as u32 + wire.id))
+			}
+			WireKind::Precommit => {
+				assert!(wire.id < self.n_precommit);
+				Some(WitnessIndex::precommit(wire.id))
 			}
 			WireKind::Private => self
 				.private_index_map

--- a/crates/spartan-prover/src/lib.rs
+++ b/crates/spartan-prover/src/lib.rs
@@ -51,7 +51,9 @@ use binius_math::{
 	ntt::{NeighborsLastMultiThread, domain_context::GenericPreExpanded},
 	univariate::evaluate_univariate,
 };
-use binius_spartan_frontend::constraint_system::{MulConstraint, Witness, WitnessIndex};
+use binius_spartan_frontend::constraint_system::{
+	MulConstraint, Witness, WitnessIndex, WitnessSegment,
+};
 use binius_spartan_verifier::{
 	Verifier,
 	constraint_system::{BlindingInfo, ConstraintSystemPadded},
@@ -82,7 +84,8 @@ type ProverMerkleProver<F, ParallelMerkleHasher, ParallelMerkleCompress> =
 #[derive(Debug)]
 pub struct IOPProver<F: Field> {
 	constraint_system: ConstraintSystemPadded<F>,
-	wiring_transpose: WiringTranspose,
+	precommit_wiring_transpose: WiringTranspose,
+	private_wiring_transpose: WiringTranspose,
 }
 
 /// Struct for proving instances of a particular constraint system.
@@ -108,13 +111,20 @@ where
 impl<F: Field> IOPProver<F> {
 	/// Constructs an IOP prover for a constraint system.
 	pub fn new(constraint_system: ConstraintSystemPadded<F>) -> Self {
-		let wiring_transpose = WiringTranspose::transpose(
+		let precommit_wiring_transpose = WiringTranspose::transpose(
+			WitnessSegment::Precommit,
+			constraint_system.precommit_size(),
+			constraint_system.mul_constraints(),
+		);
+		let private_wiring_transpose = WiringTranspose::transpose(
+			WitnessSegment::Private,
 			constraint_system.private_size(),
 			constraint_system.mul_constraints(),
 		);
 		Self {
 			constraint_system,
-			wiring_transpose,
+			precommit_wiring_transpose,
+			private_wiring_transpose,
 		}
 	}
 
@@ -201,14 +211,22 @@ impl<F: Field> IOPProver<F> {
 			&mut rng,
 		);
 
-		// Send the private witness and masks oracles to the channel
-		let trace_oracle = channel.send_oracle(private_packed.to_ref());
+		// Pack precommit witness into field elements
+		let precommit_packed = pack_witness::<_, P>(
+			cs.log_precommit() as usize,
+			witness.precommit(),
+		);
+
+		// Send the precommit, private, and mask oracles to the channel
+		let precommit_oracle = channel.send_oracle(precommit_packed.to_ref());
+		let private_oracle = channel.send_oracle(private_packed.to_ref());
 		let mask_oracle = channel.send_oracle(masks_buffer.to_ref());
 
 		// Prove the multiplication constraints
 		let (mulcheck_evals, mask_eval, r_x) = prove_mulcheck::<F, P, _>(
 			cs.mul_constraints(),
 			witness.public(),
+			precommit_packed.to_ref(),
 			private_packed.to_ref(),
 			mulcheck_mask,
 			&mut channel,
@@ -229,19 +247,31 @@ impl<F: Field> IOPProver<F> {
 			&r_x,
 		);
 
-		let trace_claim = batched_sum - public_eval;
+		// Compute the precommit segment's contribution to the wiring check.
+		// The prover sends this as a scalar; the oracle relation then verifies it.
+		let precommit_wiring_poly =
+			fold_constraints(&self.precommit_wiring_transpose, lambda, &r_x);
+		let precommit_claim = binius_math::inner_product::inner_product_buffers(
+			&precommit_packed.to_ref(),
+			&precommit_wiring_poly,
+		);
+		channel.send_one(precommit_claim);
 
-		// Fold constraints with batching and compute the folded polynomial
-		let wiring_poly = fold_constraints(&self.wiring_transpose, lambda, &r_x);
+		let private_claim = batched_sum - public_eval - precommit_claim;
+
+		// Fold private wiring constraints
+		let private_wiring_poly =
+			fold_constraints(&self.private_wiring_transpose, lambda, &r_x);
 
 		// Compute the mask folding polynomial (libra_eval tensor)
 		let n_vars = r_x.len();
 		let libra_eval_tensor =
 			zk_mlecheck::expand_libra_eval::<P>(&r_x, n_vars, mask_degree, m_n, m_d);
 
-		// Prove both oracle relations
+		// Prove all oracle relations
 		channel.prove_oracle_relations([
-			(trace_oracle, wiring_poly, trace_claim),
+			(precommit_oracle, precommit_wiring_poly, precommit_claim),
+			(private_oracle, private_wiring_poly, private_claim),
 			(mask_oracle, libra_eval_tensor, mask_eval),
 		]);
 
@@ -337,6 +367,7 @@ where
 fn prove_mulcheck<F, P, Channel>(
 	mul_constraints: &[MulConstraint<WitnessIndex>],
 	public: &[F],
+	precommit_packed: FieldSlice<P>,
 	private_packed: FieldSlice<P>,
 	mask: zk_mlecheck::Mask<P, impl Deref<Target = [P]>>,
 	channel: &mut Channel,
@@ -346,7 +377,8 @@ where
 	P: PackedField<Scalar = F> + PackedExtension<F>,
 	Channel: IPProverChannel<F>,
 {
-	let mulcheck_witness = wiring::build_mulcheck_witness(mul_constraints, public, private_packed);
+	let mulcheck_witness =
+		wiring::build_mulcheck_witness(mul_constraints, public, precommit_packed, private_packed);
 
 	// Sample random evaluation point for mulcheck
 	let r_mulcheck = channel.sample_many(mask.n_vars());
@@ -379,6 +411,26 @@ where
 	let mask_eval = mlecheck_output.mask_eval;
 
 	Ok((mulcheck_evals, mask_eval, r_x))
+}
+
+/// Packs witness values into a [`FieldBuffer`] without blinding.
+fn pack_witness<F: Field, P: PackedField<Scalar = F>>(
+	log_size: usize,
+	values: &[F],
+) -> FieldBuffer<P> {
+	let packed = if log_size < P::LOG_WIDTH {
+		let elems_iter = values.iter().copied();
+		let zeros_iter = repeat_n(F::ZERO, (1 << log_size) - values.len());
+		vec![P::from_scalars(chain!(elems_iter, zeros_iter))]
+	} else {
+		let packed_len = 1 << (log_size - P::LOG_WIDTH);
+		let elems_iter = values
+			.par_chunks(P::WIDTH)
+			.map(|chunk| P::from_scalars(chunk.iter().copied()));
+		let zeros_iter = rayon::iter::repeat_n(P::zero(), packed_len - elems_iter.len());
+		elems_iter.chain(zeros_iter).collect::<Vec<_>>()
+	};
+	FieldBuffer::new(log_size, packed.into_boxed_slice())
 }
 
 /// Packs private witness values into a [`FieldBuffer`] and adds blinding values for dummy wires.

--- a/crates/spartan-prover/src/lib.rs
+++ b/crates/spartan-prover/src/lib.rs
@@ -47,9 +47,7 @@ use binius_ip_prover::{
 	sumcheck::{quadratic_mle::QuadraticMleCheckProver, zk_mlecheck},
 };
 use binius_math::{
-	FieldBuffer, FieldSlice,
-	ntt::{NeighborsLastMultiThread, domain_context::GenericPreExpanded},
-	univariate::evaluate_univariate,
+	FieldBuffer, FieldSlice, multilinear::eq::eq_ind_partial_eval, ntt::{NeighborsLastMultiThread, domain_context::GenericPreExpanded}, univariate::evaluate_univariate
 };
 use binius_spartan_frontend::constraint_system::{
 	MulConstraint, Witness, WitnessIndex, WitnessSegment,
@@ -252,19 +250,21 @@ impl<F: Field> IOPProver<F> {
 		// Batch together the constraint operand evaluation claims.
 		let batched_sum = evaluate_univariate(&mulcheck_evals, lambda);
 
+		// Compute eq indicator tensor for r_x (shared across all segment evaluations)
+		let r_x_tensor = eq_ind_partial_eval::<F>(&r_x);
+
 		// Compute rₓ^⊤ (M_A + λ M_B + λ² M_C) x
 		let public_eval = evaluate_wiring_mle_public(
 			cs.mul_constraints(),
-			cs.log_public() as usize,
 			witness.public(),
 			lambda,
-			&r_x,
+			r_x_tensor.as_ref(),
 		);
 
 		// Compute the precommit segment's contribution to the wiring check.
 		// The prover sends this as a scalar; the oracle relation then verifies it.
 		let precommit_wiring_poly =
-			fold_constraints(&self.precommit_wiring_transpose, lambda, &r_x);
+			fold_constraints(&self.precommit_wiring_transpose, lambda, r_x_tensor.as_ref());
 		let precommit_claim = binius_math::inner_product::inner_product_buffers(
 			&precommit_packed.to_ref(),
 			&precommit_wiring_poly,
@@ -275,7 +275,7 @@ impl<F: Field> IOPProver<F> {
 
 		// Fold private wiring constraints
 		let private_wiring_poly =
-			fold_constraints(&self.private_wiring_transpose, lambda, &r_x);
+			fold_constraints(&self.private_wiring_transpose, lambda, r_x_tensor.as_ref());
 
 		// Compute the mask folding polynomial (libra_eval tensor)
 		let n_vars = r_x.len();

--- a/crates/spartan-prover/src/lib.rs
+++ b/crates/spartan-prover/src/lib.rs
@@ -162,6 +162,7 @@ impl<F: Field> IOPProver<F> {
 
 		// Check that the witness segments have the expected sizes
 		let expected_public_size = 1 << cs.log_public() as usize;
+		let expected_precommit_size = cs.precommit_size();
 		let expected_private_size = cs.private_size();
 		if witness.public().len() != expected_public_size {
 			return Err(Error::ArgumentError {
@@ -170,6 +171,16 @@ impl<F: Field> IOPProver<F> {
 					"public segment has {} elements, expected {}",
 					witness.public().len(),
 					expected_public_size
+				),
+			});
+		}
+		if witness.precommit().len() != expected_precommit_size {
+			return Err(Error::ArgumentError {
+				arg: "witness".to_string(),
+				msg: format!(
+					"precommit segment has {} elements, expected {}",
+					witness.precommit().len(),
+					expected_precommit_size
 				),
 			});
 		}
@@ -211,10 +222,13 @@ impl<F: Field> IOPProver<F> {
 			&mut rng,
 		);
 
-		// Pack precommit witness into field elements
-		let precommit_packed = pack_witness::<_, P>(
+		// Pack precommit witness into field elements and add blinding
+		let precommit_packed = pack_and_blind_witness::<_, P>(
 			cs.log_precommit() as usize,
 			witness.precommit(),
+			cs.n_precommit() as usize,
+			blinding_info,
+			&mut rng,
 		);
 
 		// Send the precommit, private, and mask oracles to the channel
@@ -413,27 +427,7 @@ where
 	Ok((mulcheck_evals, mask_eval, r_x))
 }
 
-/// Packs witness values into a [`FieldBuffer`] without blinding.
-fn pack_witness<F: Field, P: PackedField<Scalar = F>>(
-	log_size: usize,
-	values: &[F],
-) -> FieldBuffer<P> {
-	let packed = if log_size < P::LOG_WIDTH {
-		let elems_iter = values.iter().copied();
-		let zeros_iter = repeat_n(F::ZERO, (1 << log_size) - values.len());
-		vec![P::from_scalars(chain!(elems_iter, zeros_iter))]
-	} else {
-		let packed_len = 1 << (log_size - P::LOG_WIDTH);
-		let elems_iter = values
-			.par_chunks(P::WIDTH)
-			.map(|chunk| P::from_scalars(chunk.iter().copied()));
-		let zeros_iter = rayon::iter::repeat_n(P::zero(), packed_len - elems_iter.len());
-		elems_iter.chain(zeros_iter).collect::<Vec<_>>()
-	};
-	FieldBuffer::new(log_size, packed.into_boxed_slice())
-}
-
-/// Packs private witness values into a [`FieldBuffer`] and adds blinding values for dummy wires.
+/// Packs witness values into a [`FieldBuffer`] and adds blinding values for dummy wires.
 fn pack_and_blind_witness<F: Field, P: PackedField<Scalar = F>>(
 	log_private: usize,
 	private: &[F],

--- a/crates/spartan-prover/src/lib.rs
+++ b/crates/spartan-prover/src/lib.rs
@@ -47,7 +47,10 @@ use binius_ip_prover::{
 	sumcheck::{quadratic_mle::QuadraticMleCheckProver, zk_mlecheck},
 };
 use binius_math::{
-	FieldBuffer, FieldSlice, multilinear::eq::eq_ind_partial_eval, ntt::{NeighborsLastMultiThread, domain_context::GenericPreExpanded}, univariate::evaluate_univariate
+	FieldBuffer, FieldSlice,
+	multilinear::eq::eq_ind_partial_eval,
+	ntt::{NeighborsLastMultiThread, domain_context::GenericPreExpanded},
+	univariate::evaluate_univariate,
 };
 use binius_spartan_frontend::constraint_system::{
 	MulConstraint, Witness, WitnessIndex, WitnessSegment,

--- a/crates/spartan-prover/src/wiring.rs
+++ b/crates/spartan-prover/src/wiring.rs
@@ -7,15 +7,15 @@ use binius_spartan_frontend::constraint_system::{
 };
 use binius_utils::{checked_arithmetics::checked_log_2, rayon::prelude::*};
 
-/// Transpose of the private wiring sparse matrix.
+/// Transpose of a wiring sparse matrix for a specific witness segment.
 ///
-/// Only indexes private witness wires. The private segment's size determines
+/// Indexes witness wires of a given segment. The segment's padded size determines
 /// the buffer dimensions.
 #[derive(Debug)]
 pub struct WiringTranspose {
 	flat_keys: Vec<Key>,
-	keys_start_by_private_index: Vec<u32>,
-	log_private_size: usize,
+	keys_start: Vec<u32>,
+	log_size: usize,
 }
 
 #[derive(Debug, Clone)]
@@ -25,15 +25,20 @@ pub struct Key {
 }
 
 impl WiringTranspose {
-	pub fn transpose(private_size: usize, mul_constraints: &[MulConstraint<WitnessIndex>]) -> Self {
-		let mut keys_by_private_idx = vec![Vec::new(); private_size];
+	/// Build a transposed wiring matrix for a specific witness segment.
+	pub fn transpose(
+		segment: WitnessSegment,
+		segment_size: usize,
+		mul_constraints: &[MulConstraint<WitnessIndex>],
+	) -> Self {
+		let mut keys_by_idx = vec![Vec::new(); segment_size];
 
 		let mut n_total_keys = 0;
 		for (i, MulConstraint { a, b, c }) in mul_constraints.iter().enumerate() {
 			for (operand_idx, operand) in [a, b, c].into_iter().enumerate() {
 				for &witness_idx in operand.wires() {
-					if witness_idx.segment == WitnessSegment::Private {
-						keys_by_private_idx[witness_idx.index as usize].push(Key {
+					if witness_idx.segment == segment {
+						keys_by_idx[witness_idx.index as usize].push(Key {
 							operand_idx: operand_idx as u8,
 							constraint_idx: i as u32,
 						});
@@ -45,48 +50,46 @@ impl WiringTranspose {
 
 		// Flatten the sparse matrix representation.
 		let mut flat_keys = Vec::with_capacity(n_total_keys);
-		let mut keys_start = Vec::with_capacity(private_size);
-		for keys in keys_by_private_idx {
+		let mut keys_start = Vec::with_capacity(segment_size);
+		for keys in keys_by_idx {
 			let start = flat_keys.len() as u32;
 			flat_keys.extend(keys);
 			keys_start.push(start);
 		}
 
-		let log_private_size = checked_log_2(private_size);
+		let log_size = checked_log_2(segment_size);
 
 		Self {
 			flat_keys,
-			keys_start_by_private_index: keys_start,
-			log_private_size,
+			keys_start,
+			log_size,
 		}
 	}
 
-	/// Returns the log2 of the private segment size.
-	pub fn log_private_size(&self) -> usize {
-		self.log_private_size
+	pub fn log_size(&self) -> usize {
+		self.log_size
 	}
 
-	/// Returns the private segment size.
-	pub fn private_size(&self) -> usize {
-		1 << self.log_private_size
+	pub fn size(&self) -> usize {
+		1 << self.log_size
 	}
 
-	/// Returns the keys for a specific private witness index.
-	pub fn keys_for_private(&self, private_idx: usize) -> &[Key] {
-		let start = self.keys_start_by_private_index[private_idx] as usize;
+	/// Returns the keys for a specific witness index within the segment.
+	pub fn keys_for(&self, idx: usize) -> &[Key] {
+		let start = self.keys_start[idx] as usize;
 		let end = self
-			.keys_start_by_private_index
-			.get(private_idx + 1)
+			.keys_start
+			.get(idx + 1)
 			.map(|&x| x as usize)
 			.unwrap_or(self.flat_keys.len());
 		&self.flat_keys[start..end]
 	}
 }
 
-/// Folds the private wiring matrix along the constraint axis by partially evaluating at r_x.
+/// Folds the wiring matrix along the constraint axis by partially evaluating at r_x.
 ///
 /// Also batches the three operands (a, b, c) using powers of lambda.
-/// Returns a multilinear polynomial over private witness indices where each coefficient is the
+/// Returns a multilinear polynomial over witness indices where each coefficient is the
 /// weighted sum of constraint contributions.
 pub fn fold_constraints<F: Field, P: PackedField<Scalar = F>>(
 	transposed: &WiringTranspose,
@@ -99,24 +102,24 @@ pub fn fold_constraints<F: Field, P: PackedField<Scalar = F>>(
 	// Batching powers for the three operands
 	let lambda_powers = [F::ONE, lambda, lambda.square()];
 
-	let private_size = transposed.private_size();
-	let log_private_size = transposed.log_private_size();
-	let len = 1 << log_private_size.saturating_sub(P::LOG_WIDTH);
+	let segment_size = transposed.size();
+	let log_size = transposed.log_size();
+	let len = 1 << log_size.saturating_sub(P::LOG_WIDTH);
 
-	// Process in parallel over chunks of P::WIDTH private indices
+	// Process in parallel over chunks of P::WIDTH indices
 	let result = (0..len)
 		.into_par_iter()
 		.map(|packed_idx| {
 			let base_idx = packed_idx << P::LOG_WIDTH;
 
 			P::from_fn(|scalar_idx| {
-				let private_idx = base_idx + scalar_idx;
-				if private_idx >= private_size {
+				let idx = base_idx + scalar_idx;
+				if idx >= segment_size {
 					return F::ZERO;
 				}
 
 				let mut acc = F::ZERO;
-				for key in transposed.keys_for_private(private_idx) {
+				for key in transposed.keys_for(idx) {
 					let r_x_weight = r_x_tensor[key.constraint_idx as usize];
 					let lambda_weight = lambda_powers[key.operand_idx as usize];
 					acc += r_x_weight * lambda_weight;
@@ -126,7 +129,7 @@ pub fn fold_constraints<F: Field, P: PackedField<Scalar = F>>(
 		})
 		.collect::<Vec<_>>();
 
-	FieldBuffer::new(log_private_size, result.into_boxed_slice())
+	FieldBuffer::new(log_size, result.into_boxed_slice())
 }
 
 /// Witness data for multiplication constraint checking.
@@ -142,6 +145,7 @@ pub struct MulCheckWitness<P: PackedField> {
 /// Evaluates an operand by XORing witness values at the specified indices.
 fn eval_operand<F: Field, P: PackedField<Scalar = F>>(
 	public: &[F],
+	precommit_packed: &FieldSlice<P>,
 	private_packed: &FieldSlice<P>,
 	operand: &Operand<WitnessIndex>,
 ) -> F {
@@ -150,7 +154,7 @@ fn eval_operand<F: Field, P: PackedField<Scalar = F>>(
 		.iter()
 		.map(|idx| match idx.segment {
 			WitnessSegment::Public => public[idx.index as usize],
-			WitnessSegment::Precommit => todo!("precommit segment in eval_operand"),
+			WitnessSegment::Precommit => precommit_packed.get(idx.index as usize),
 			WitnessSegment::Private => private_packed.get(idx.index as usize),
 		})
 		.sum()
@@ -165,6 +169,7 @@ fn eval_operand<F: Field, P: PackedField<Scalar = F>>(
 pub fn build_mulcheck_witness<F: Field, P: PackedField<Scalar = F>>(
 	mul_constraints: &[MulConstraint<WitnessIndex>],
 	public: &[F],
+	precommit_packed: FieldSlice<P>,
 	private_packed: FieldSlice<P>,
 ) -> MulCheckWitness<P> {
 	fn get_a(c: &MulConstraint<WitnessIndex>) -> &Operand<WitnessIndex> {
@@ -203,6 +208,7 @@ pub fn build_mulcheck_witness<F: Field, P: PackedField<Scalar = F>>(
 					if constraint_idx < n_constraints {
 						eval_operand(
 							public,
+							&precommit_packed,
 							&private_packed,
 							get_operand(&mul_constraints[constraint_idx]),
 						)
@@ -237,7 +243,8 @@ mod tests {
 		univariate::evaluate_univariate,
 	};
 	use binius_spartan_frontend::constraint_system::{MulConstraint, Operand, WitnessIndex};
-	use binius_spartan_verifier::wiring::evaluate_private_wiring_mle;
+	use binius_spartan_frontend::constraint_system::WitnessSegment;
+	use binius_spartan_verifier::wiring::evaluate_segment_wiring_mle;
 	use rand::{Rng, SeedableRng, rngs::StdRng};
 	use smallvec::SmallVec;
 
@@ -281,8 +288,8 @@ mod tests {
 		Operand::new(wires)
 	}
 
-	/// Evaluate the private wiring MLE using the transposed representation.
-	fn evaluate_private_wiring_mle_transposed<F: Field>(
+	/// Evaluate the wiring MLE using the transposed representation.
+	fn evaluate_wiring_mle_transposed<F: Field>(
 		transposed: &WiringTranspose,
 		lambda: F,
 		r_x_tensor: &[F],
@@ -290,9 +297,9 @@ mod tests {
 	) -> F {
 		let mut acc = [F::ZERO; 3];
 
-		for private_idx in 0..transposed.private_size() {
-			let r_y_weight = r_y_tensor[private_idx];
-			for key in transposed.keys_for_private(private_idx) {
+		for idx in 0..transposed.size() {
+			let r_y_weight = r_y_tensor[idx];
+			for key in transposed.keys_for(idx) {
 				let r_x_weight = r_x_tensor[key.constraint_idx as usize];
 				acc[key.operand_idx as usize] += r_x_weight * r_y_weight;
 			}
@@ -322,13 +329,20 @@ mod tests {
 		let lambda = B128::random(&mut rng);
 
 		// Compute expected result using the verifier's reference implementation
-		let expected = evaluate_private_wiring_mle(&constraints, lambda, &r_x, &r_y);
+		let expected = evaluate_segment_wiring_mle(
+			&constraints,
+			WitnessSegment::Private,
+			lambda,
+			&r_x,
+			&r_y,
+		);
 
 		// Compute result using the transposed representation
-		let transposed = WiringTranspose::transpose(private_size, &constraints);
+		let transposed =
+			WiringTranspose::transpose(WitnessSegment::Private, private_size, &constraints);
 		let r_x_tensor = eq_ind_partial_eval::<B128>(&r_x);
 		let r_y_tensor = eq_ind_partial_eval::<B128>(&r_y);
-		let actual = evaluate_private_wiring_mle_transposed(
+		let actual = evaluate_wiring_mle_transposed(
 			&transposed,
 			lambda,
 			r_x_tensor.as_ref(),
@@ -358,17 +372,24 @@ mod tests {
 		let r_y = random_scalars::<B128>(&mut rng, log_private);
 		let lambda = B128::random(&mut rng);
 
-		// Method 1: Compute expected result using evaluate_private_wiring_mle
-		let expected = evaluate_private_wiring_mle(&constraints, lambda, &r_x, &r_y);
+		// Method 1: Compute expected result using evaluate_segment_wiring_mle
+		let expected = evaluate_segment_wiring_mle(
+			&constraints,
+			WitnessSegment::Private,
+			lambda,
+			&r_x,
+			&r_y,
+		);
 
 		// Method 2: Use fold_constraints then evaluate at r_y
-		let transposed = WiringTranspose::transpose(private_size, &constraints);
+		let transposed =
+			WiringTranspose::transpose(WitnessSegment::Private, private_size, &constraints);
 		let folded = fold_constraints::<_, Packed128b>(&transposed, lambda, &r_x);
 		let actual = evaluate(&folded, &r_y);
 
 		assert_eq!(
 			actual, expected,
-			"fold_constraints + evaluate does not match evaluate_private_wiring_mle"
+			"fold_constraints + evaluate does not match evaluate_segment_wiring_mle"
 		);
 	}
 
@@ -403,12 +424,18 @@ mod tests {
 		let constraints =
 			generate_random_constraints(&mut rng, n_constraints, public_size, private_size);
 
-		// Create random public and private witness buffers
+		// Create random public, precommit, and private witness buffers
 		let public = random_scalars::<B128>(&mut rng, public_size);
+		let precommit_buf = random_field_buffer::<Packed128b>(&mut rng, 0); // empty precommit
 		let private_buf = random_field_buffer::<Packed128b>(&mut rng, log_private);
 
 		// Compute mulcheck witness
-		let mulcheck_witness = build_mulcheck_witness(&constraints, &public, private_buf.to_ref());
+		let mulcheck_witness = build_mulcheck_witness(
+			&constraints,
+			&public,
+			precommit_buf.to_ref(),
+			private_buf.to_ref(),
+		);
 
 		// Sample r_x (sumcheck evaluation point for constraint axis)
 		let r_x = random_scalars::<B128>(&mut rng, log_n_constraints);
@@ -422,7 +449,8 @@ mod tests {
 		];
 
 		// Create transposed wiring
-		let wiring_transpose = WiringTranspose::transpose(private_size, &constraints);
+		let wiring_transpose =
+			WiringTranspose::transpose(WitnessSegment::Private, private_size, &constraints);
 
 		let oracle_specs = vec![OracleSpec {
 			log_msg_len: log_private,

--- a/crates/spartan-prover/src/wiring.rs
+++ b/crates/spartan-prover/src/wiring.rs
@@ -242,8 +242,9 @@ mod tests {
 		test_utils::{Packed128b, random_scalars},
 		univariate::evaluate_univariate,
 	};
-	use binius_spartan_frontend::constraint_system::{MulConstraint, Operand, WitnessIndex};
-	use binius_spartan_frontend::constraint_system::WitnessSegment;
+	use binius_spartan_frontend::constraint_system::{
+		MulConstraint, Operand, WitnessIndex, WitnessSegment,
+	};
 	use binius_spartan_verifier::wiring::evaluate_segment_wiring_mle;
 	use rand::{Rng, SeedableRng, rngs::StdRng};
 	use smallvec::SmallVec;

--- a/crates/spartan-prover/src/wiring.rs
+++ b/crates/spartan-prover/src/wiring.rs
@@ -150,6 +150,7 @@ fn eval_operand<F: Field, P: PackedField<Scalar = F>>(
 		.iter()
 		.map(|idx| match idx.segment {
 			WitnessSegment::Public => public[idx.index as usize],
+			WitnessSegment::Precommit => todo!("precommit segment in eval_operand"),
 			WitnessSegment::Private => private_packed.get(idx.index as usize),
 		})
 		.sum()

--- a/crates/spartan-prover/src/wiring.rs
+++ b/crates/spartan-prover/src/wiring.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 Irreducible Inc.
 
 use binius_field::{Field, PackedField};
-use binius_math::{FieldBuffer, FieldSlice, multilinear::eq::eq_ind_partial_eval};
+use binius_math::{FieldBuffer, FieldSlice};
 use binius_spartan_frontend::constraint_system::{
 	MulConstraint, Operand, WitnessIndex, WitnessSegment,
 };
@@ -91,14 +91,14 @@ impl WiringTranspose {
 /// Also batches the three operands (a, b, c) using powers of lambda.
 /// Returns a multilinear polynomial over witness indices where each coefficient is the
 /// weighted sum of constraint contributions.
+/// `r_x_tensor` is the eq-indicator partial evaluation at r_x, i.e.
+/// `eq_ind_partial_eval(r_x)`. Accepting it as a parameter avoids redundant
+/// computation when folding multiple segments with the same r_x.
 pub fn fold_constraints<F: Field, P: PackedField<Scalar = F>>(
 	transposed: &WiringTranspose,
 	lambda: F,
-	r_x: &[F],
+	r_x_tensor: &[F],
 ) -> FieldBuffer<P> {
-	// Compute eq indicator tensor for constraint evaluation points
-	let r_x_tensor = eq_ind_partial_eval::<F>(r_x);
-
 	// Batching powers for the three operands
 	let lambda_powers = [F::ONE, lambda, lambda.square()];
 
@@ -328,20 +328,22 @@ mod tests {
 		let r_y = random_scalars::<B128>(&mut rng, log_private);
 		let lambda = B128::random(&mut rng);
 
+		// Compute the eq indicator tensors
+		let r_x_tensor = eq_ind_partial_eval::<B128>(&r_x);
+		let r_y_tensor = eq_ind_partial_eval::<B128>(&r_y);
+
 		// Compute expected result using the verifier's reference implementation
 		let expected = evaluate_segment_wiring_mle(
 			&constraints,
 			WitnessSegment::Private,
 			lambda,
-			&r_x,
+			r_x_tensor.as_ref(),
 			&r_y,
 		);
 
 		// Compute result using the transposed representation
 		let transposed =
 			WiringTranspose::transpose(WitnessSegment::Private, private_size, &constraints);
-		let r_x_tensor = eq_ind_partial_eval::<B128>(&r_x);
-		let r_y_tensor = eq_ind_partial_eval::<B128>(&r_y);
 		let actual = evaluate_wiring_mle_transposed(
 			&transposed,
 			lambda,
@@ -372,19 +374,21 @@ mod tests {
 		let r_y = random_scalars::<B128>(&mut rng, log_private);
 		let lambda = B128::random(&mut rng);
 
+		let r_x_tensor = eq_ind_partial_eval::<B128>(&r_x);
+
 		// Method 1: Compute expected result using evaluate_segment_wiring_mle
 		let expected = evaluate_segment_wiring_mle(
 			&constraints,
 			WitnessSegment::Private,
 			lambda,
-			&r_x,
+			r_x_tensor.as_ref(),
 			&r_y,
 		);
 
 		// Method 2: Use fold_constraints then evaluate at r_y
 		let transposed =
 			WiringTranspose::transpose(WitnessSegment::Private, private_size, &constraints);
-		let folded = fold_constraints::<_, Packed128b>(&transposed, lambda, &r_x);
+		let folded = fold_constraints::<_, Packed128b>(&transposed, lambda, r_x_tensor.as_ref());
 		let actual = evaluate(&folded, &r_y);
 
 		assert_eq!(
@@ -469,14 +473,18 @@ mod tests {
 		// Sample lambda
 		let lambda: B128 = prover_channel.sample();
 
+		// Compute r_x_tensor once
+		let r_x_tensor = eq_ind_partial_eval::<B128>(&r_x);
+
 		// Compute the batched sum and public contribution
 		let batched_sum = evaluate_univariate(&mulcheck_evals, lambda);
 		let public_eval =
-			evaluate_wiring_mle_public(&constraints, log_public, &public, lambda, &r_x);
+			evaluate_wiring_mle_public(&constraints, &public, lambda, r_x_tensor.as_ref());
 		let trace_claim = batched_sum - public_eval;
 
 		// Fold constraints to get the private wiring polynomial
-		let wiring_poly = fold_constraints::<_, Packed128b>(&wiring_transpose, lambda, &r_x);
+		let wiring_poly =
+			fold_constraints::<_, Packed128b>(&wiring_transpose, lambda, r_x_tensor.as_ref());
 
 		// Finish the IOP with the oracle relation
 		prover_channel.prove_oracle_relations([(witness_oracle, wiring_poly.clone(), trace_claim)]);
@@ -496,8 +504,13 @@ mod tests {
 
 		// Compute the same claim on the verifier side
 		let verifier_batched_sum = evaluate_univariate(&mulcheck_evals, verifier_lambda);
-		let verifier_public_eval =
-			evaluate_wiring_mle_public(&constraints, log_public, &public, verifier_lambda, &r_x);
+		let verifier_r_x_tensor = eq_ind_partial_eval::<B128>(&r_x);
+		let verifier_public_eval = evaluate_wiring_mle_public(
+			&constraints,
+			&public,
+			verifier_lambda,
+			verifier_r_x_tensor.as_ref(),
+		);
 		let verifier_trace_claim = verifier_batched_sum - verifier_public_eval;
 
 		// Verify that prover and verifier computed the same trace_claim

--- a/crates/spartan-verifier/src/constraint_system.rs
+++ b/crates/spartan-verifier/src/constraint_system.rs
@@ -17,6 +17,7 @@ use binius_utils::checked_arithmetics::{checked_log_2, log2_ceil_usize};
 #[derive(Debug, Clone)]
 pub struct ConstraintSystemPadded<F: Field> {
 	inner: ConstraintSystem<F>,
+	log_precommit: u32,
 	log_private: u32,
 	blinding_info: BlindingInfo,
 	mul_constraints: Vec<MulConstraint<WitnessIndex>>,
@@ -34,27 +35,44 @@ impl<F: Field> ConstraintSystemPadded<F> {
 	/// 4. Computes mask buffer dimensions for the ZK mulcheck mask polynomial
 	pub fn new(cs: ConstraintSystem<F>, blinding_info: BlindingInfo) -> Self {
 		let mut mul_constraints = cs.mul_constraints().to_vec();
+		let blinding_size = blinding_info.n_dummy_wires + 3 * blinding_info.n_dummy_constraints;
 
-		// Calculate padded private segment size
-		let n_circuit_private = cs.n_private() as usize;
-		let n_private =
-			n_circuit_private + blinding_info.n_dummy_wires + 3 * blinding_info.n_dummy_constraints;
-		let log_private = log2_ceil_usize(n_private) as u32;
-
-		// Add dummy constraints for blinding
-		// Each dummy constraint uses 3 consecutive private wires starting after n_dummy_wires
-		let dummy_private_base = n_circuit_private + blinding_info.n_dummy_wires;
-		for i in 0..blinding_info.n_dummy_constraints {
-			let a = WitnessIndex::private((dummy_private_base + 3 * i) as u32);
-			let b = WitnessIndex::private((dummy_private_base + 3 * i + 1) as u32);
-			let c = WitnessIndex::private((dummy_private_base + 3 * i + 2) as u32);
-
-			mul_constraints.push(MulConstraint {
-				a: Operand::from(a),
-				b: Operand::from(b),
-				c: Operand::from(c),
-			});
+		/// Adds dummy blinding constraints for a segment and returns its padded log-size.
+		fn add_blinding_constraints<F: Field>(
+			mul_constraints: &mut Vec<MulConstraint<WitnessIndex>>,
+			make_index: fn(u32) -> WitnessIndex,
+			n_circuit_wires: usize,
+			blinding_info: &BlindingInfo,
+			blinding_size: usize,
+		) -> u32 {
+			let dummy_base = n_circuit_wires + blinding_info.n_dummy_wires;
+			for i in 0..blinding_info.n_dummy_constraints {
+				let a = make_index((dummy_base + 3 * i) as u32);
+				let b = make_index((dummy_base + 3 * i + 1) as u32);
+				let c = make_index((dummy_base + 3 * i + 2) as u32);
+				mul_constraints.push(MulConstraint {
+					a: Operand::from(a),
+					b: Operand::from(b),
+					c: Operand::from(c),
+				});
+			}
+			log2_ceil_usize(n_circuit_wires + blinding_size) as u32
 		}
+
+		let log_precommit = add_blinding_constraints::<F>(
+			&mut mul_constraints,
+			WitnessIndex::precommit,
+			cs.n_precommit() as usize,
+			&blinding_info,
+			blinding_size,
+		);
+		let log_private = add_blinding_constraints::<F>(
+			&mut mul_constraints,
+			WitnessIndex::private,
+			cs.n_private() as usize,
+			&blinding_info,
+			blinding_size,
+		);
 
 		// Pad to next power of two with `one * one = one` constraints
 		let one_operand = Operand::from(cs.one_wire());
@@ -76,6 +94,7 @@ impl<F: Field> ConstraintSystemPadded<F> {
 
 		Self {
 			inner: cs,
+			log_precommit,
 			log_private,
 			blinding_info,
 			mul_constraints,
@@ -112,11 +131,11 @@ impl<F: Field> ConstraintSystemPadded<F> {
 	}
 
 	pub fn log_precommit(&self) -> u32 {
-		log2_ceil_usize(self.inner.n_precommit() as usize) as u32
+		self.log_precommit
 	}
 
 	pub fn precommit_size(&self) -> usize {
-		1 << self.log_precommit() as usize
+		1 << self.log_precommit as usize
 	}
 
 	pub fn log_private(&self) -> u32 {

--- a/crates/spartan-verifier/src/constraint_system.rs
+++ b/crates/spartan-verifier/src/constraint_system.rs
@@ -38,7 +38,7 @@ impl<F: Field> ConstraintSystemPadded<F> {
 		let blinding_size = blinding_info.n_dummy_wires + 3 * blinding_info.n_dummy_constraints;
 
 		/// Adds dummy blinding constraints for a segment and returns its padded log-size.
-		fn add_blinding_constraints<F: Field>(
+		fn add_blinding_constraints(
 			mul_constraints: &mut Vec<MulConstraint<WitnessIndex>>,
 			make_index: fn(u32) -> WitnessIndex,
 			n_circuit_wires: usize,
@@ -59,14 +59,14 @@ impl<F: Field> ConstraintSystemPadded<F> {
 			log2_ceil_usize(n_circuit_wires + blinding_size) as u32
 		}
 
-		let log_precommit = add_blinding_constraints::<F>(
+		let log_precommit = add_blinding_constraints(
 			&mut mul_constraints,
 			WitnessIndex::precommit,
 			cs.n_precommit() as usize,
 			&blinding_info,
 			blinding_size,
 		);
-		let log_private = add_blinding_constraints::<F>(
+		let log_private = add_blinding_constraints(
 			&mut mul_constraints,
 			WitnessIndex::private,
 			cs.n_private() as usize,

--- a/crates/spartan-verifier/src/constraint_system.rs
+++ b/crates/spartan-verifier/src/constraint_system.rs
@@ -91,6 +91,10 @@ impl<F: Field> ConstraintSystemPadded<F> {
 		self.inner.n_inout()
 	}
 
+	pub fn n_precommit(&self) -> u32 {
+		self.inner.n_precommit()
+	}
+
 	pub fn n_private(&self) -> u32 {
 		self.inner.n_private()
 	}
@@ -105,6 +109,14 @@ impl<F: Field> ConstraintSystemPadded<F> {
 
 	pub fn one_wire(&self) -> WitnessIndex {
 		self.inner.one_wire()
+	}
+
+	pub fn log_precommit(&self) -> u32 {
+		log2_ceil_usize(self.inner.n_precommit() as usize) as u32
+	}
+
+	pub fn precommit_size(&self) -> usize {
+		1 << self.log_precommit() as usize
 	}
 
 	pub fn log_private(&self) -> u32 {

--- a/crates/spartan-verifier/src/lib.rs
+++ b/crates/spartan-verifier/src/lib.rs
@@ -44,7 +44,7 @@ use binius_iop::{
 };
 use binius_ip::{channel::IPVerifierChannel, mlecheck, sumcheck};
 use binius_math::univariate::evaluate_univariate;
-use binius_spartan_frontend::constraint_system::ConstraintSystem;
+use binius_spartan_frontend::constraint_system::{ConstraintSystem, WitnessSegment};
 use binius_transcript::{VerifierTranscript, fiat_shamir::Challenger};
 use binius_utils::{DeserializeBytes, checked_arithmetics::checked_log_2};
 use digest::{Digest, Output, core_api::BlockSizeUser};
@@ -113,13 +113,15 @@ impl<F: Field> IOPVerifier<F> {
 	/// These describe the oracles (witness and mask) that the prover commits to.
 	pub fn oracle_specs(&self) -> Vec<OracleSpec> {
 		let cs = &self.constraint_system;
-		let log_witness_size = cs.log_private() as usize;
 		let (m_n, m_d) = cs.mask_dims();
 		let log_mask_dim = m_n + m_d;
 
 		vec![
 			OracleSpec {
-				log_msg_len: log_witness_size,
+				log_msg_len: cs.log_precommit() as usize,
+			},
+			OracleSpec {
+				log_msg_len: cs.log_private() as usize,
 			},
 			OracleSpec {
 				log_msg_len: log_mask_dim,
@@ -163,10 +165,9 @@ impl<F: Field> IOPVerifier<F> {
 			});
 		}
 
-		// Receive the trace oracle commitment.
-		let trace_oracle = channel.recv_oracle()?;
-
-		// Receive the mask oracle commitment.
+		// Receive the precommit, private, and mask oracle commitments.
+		let precommit_oracle = channel.recv_oracle()?;
+		let private_oracle = channel.recv_oracle()?;
 		let mask_oracle = channel.recv_oracle()?;
 
 		// Verify the multiplication constraints.
@@ -193,20 +194,29 @@ impl<F: Field> IOPVerifier<F> {
 			&r_x,
 		);
 
-		let trace_claim = batched_sum - public_eval;
+		// Prover sends the precommit segment's contribution to the operand evaluations.
+		let precommit_claim = channel.recv_one()?;
 
-		// Build the transparent closure for the wiring oracle relation
-		let trace_transparent = wiring::eval_transparent(cs, &r_x, lambda);
+		let private_claim = batched_sum - public_eval - precommit_claim.clone();
 
-		// Build the transparent closure for the mask oracle relation
+		// Build transparent closures for each oracle relation
+		let precommit_transparent =
+			wiring::eval_transparent(cs, WitnessSegment::Precommit, &r_x, lambda.clone());
+		let private_transparent =
+			wiring::eval_transparent(cs, WitnessSegment::Private, &r_x, lambda);
 		let mask_transparent = mask_transparent(cs, &r_x);
 
-		// Verify both oracle relations (checks are done inside verify_oracle_relations)
+		// Verify all oracle relations
 		channel.verify_oracle_relations([
 			OracleLinearRelation {
-				oracle: trace_oracle,
-				transparent: trace_transparent,
-				claim: trace_claim,
+				oracle: precommit_oracle,
+				transparent: precommit_transparent,
+				claim: precommit_claim,
+			},
+			OracleLinearRelation {
+				oracle: private_oracle,
+				transparent: private_transparent,
+				claim: private_claim,
 			},
 			OracleLinearRelation {
 				oracle: mask_oracle,

--- a/crates/spartan-verifier/src/lib.rs
+++ b/crates/spartan-verifier/src/lib.rs
@@ -43,7 +43,7 @@ use binius_iop::{
 	merkle_tree::BinaryMerkleTreeScheme,
 };
 use binius_ip::{channel::IPVerifierChannel, mlecheck, sumcheck};
-use binius_math::univariate::evaluate_univariate;
+use binius_math::{multilinear::eq::eq_ind_partial_eval_scalars, univariate::evaluate_univariate};
 use binius_spartan_frontend::constraint_system::{ConstraintSystem, WitnessSegment};
 use binius_transcript::{VerifierTranscript, fiat_shamir::Challenger};
 use binius_utils::{DeserializeBytes, checked_arithmetics::checked_log_2};
@@ -186,13 +186,9 @@ impl<F: Field> IOPVerifier<F> {
 		let batched_sum = evaluate_univariate(&[a_eval, b_eval, c_eval], lambda.clone());
 
 		// Compute rₓ^⊤ (M_A + λ M_B + λ² M_C) x
-		let public_eval = evaluate_wiring_mle_public(
-			cs.mul_constraints(),
-			cs.log_public() as usize,
-			&public,
-			lambda.clone(),
-			&r_x,
-		);
+		let r_x_tensor = eq_ind_partial_eval_scalars(&r_x);
+		let public_eval =
+			evaluate_wiring_mle_public(cs.mul_constraints(), &public, lambda.clone(), &r_x_tensor);
 
 		// Prover sends the precommit segment's contribution to the operand evaluations.
 		let precommit_claim = channel.recv_one()?;
@@ -201,9 +197,9 @@ impl<F: Field> IOPVerifier<F> {
 
 		// Build transparent closures for each oracle relation
 		let precommit_transparent =
-			wiring::eval_transparent(cs, WitnessSegment::Precommit, &r_x, lambda.clone());
+			wiring::eval_transparent(cs, WitnessSegment::Precommit, &r_x_tensor, lambda.clone());
 		let private_transparent =
-			wiring::eval_transparent(cs, WitnessSegment::Private, &r_x, lambda);
+			wiring::eval_transparent(cs, WitnessSegment::Private, &r_x_tensor, lambda);
 		let mask_transparent = mask_transparent(cs, &r_x);
 
 		// Verify all oracle relations

--- a/crates/spartan-verifier/src/wiring.rs
+++ b/crates/spartan-verifier/src/wiring.rs
@@ -8,12 +8,13 @@ use binius_spartan_frontend::constraint_system::{MulConstraint, WitnessIndex, Wi
 
 use crate::constraint_system::ConstraintSystemPadded;
 
-/// Returns a closure that evaluates the wiring transparent polynomial at a given point.
+/// Returns a closure that evaluates the wiring transparent polynomial for a specific segment.
 ///
-/// The returned closure computes the expected evaluation of the wiring MLE batched with the
-/// public input equality check, given a challenge point from the BaseFold opening.
+/// The returned closure computes the expected evaluation of the wiring MLE for the given
+/// segment, batched with lambda, given a challenge point from the BaseFold opening.
 pub fn eval_transparent<'a, G: Field, F: FieldOps + 'a>(
 	constraint_system: &ConstraintSystemPadded<G>,
+	segment: WitnessSegment,
 	r_x: &[F],
 	lambda: F,
 ) -> binius_iop::channel::TransparentEvalFn<'a, F> {
@@ -21,16 +22,17 @@ pub fn eval_transparent<'a, G: Field, F: FieldOps + 'a>(
 	let mul_constraints = constraint_system.mul_constraints().to_vec();
 
 	Box::new(move |r_y: &[F]| {
-		evaluate_private_wiring_mle(&mul_constraints, lambda.clone(), &r_x, r_y)
+		evaluate_segment_wiring_mle(&mul_constraints, segment, lambda.clone(), &r_x, r_y)
 	})
 }
 
-/// Evaluates the private wiring MLE at a point (r_x, r_y).
+/// Evaluates the wiring MLE for a specific segment at a point (r_x, r_y).
 ///
-/// The r_y dimension corresponds to the private witness segment only (log_private variables).
-/// Private wire indices are used directly as indices into r_y_tensor.
-pub fn evaluate_private_wiring_mle<F: FieldOps>(
+/// The r_y dimension corresponds to the given segment's oracle (log_segment variables).
+/// Wire indices within the segment are used directly as indices into r_y_tensor.
+pub fn evaluate_segment_wiring_mle<F: FieldOps>(
 	mul_constraints: &[MulConstraint<WitnessIndex>],
+	segment: WitnessSegment,
 	lambda: F,
 	r_x: &[F],
 	r_y: &[F],
@@ -45,7 +47,7 @@ pub fn evaluate_private_wiring_mle<F: FieldOps>(
 				.wires()
 				.iter()
 				.flat_map(|index| {
-					if let WitnessSegment::Private = index.segment {
+					if index.segment == segment {
 						Some(r_y_tensor[index.index as usize].clone())
 					} else {
 						None

--- a/crates/spartan-verifier/src/wiring.rs
+++ b/crates/spartan-verifier/src/wiring.rs
@@ -12,36 +12,40 @@ use crate::constraint_system::ConstraintSystemPadded;
 ///
 /// The returned closure computes the expected evaluation of the wiring MLE for the given
 /// segment, batched with lambda, given a challenge point from the BaseFold opening.
+/// `r_x_tensor` is the eq-indicator partial evaluation at r_x.
 pub fn eval_transparent<'a, G: Field, F: FieldOps + 'a>(
-	constraint_system: &ConstraintSystemPadded<G>,
+	constraint_system: &'a ConstraintSystemPadded<G>,
 	segment: WitnessSegment,
-	r_x: &[F],
+	r_x_tensor: &'a [F],
 	lambda: F,
 ) -> binius_iop::channel::TransparentEvalFn<'a, F> {
-	let r_x = r_x.to_vec();
-	let mul_constraints = constraint_system.mul_constraints().to_vec();
-
 	Box::new(move |r_y: &[F]| {
-		evaluate_segment_wiring_mle(&mul_constraints, segment, lambda.clone(), &r_x, r_y)
+		evaluate_segment_wiring_mle(
+			constraint_system.mul_constraints(),
+			segment,
+			lambda.clone(),
+			r_x_tensor,
+			r_y,
+		)
 	})
 }
 
 /// Evaluates the wiring MLE for a specific segment at a point (r_x, r_y).
 ///
-/// The r_y dimension corresponds to the given segment's oracle (log_segment variables).
-/// Wire indices within the segment are used directly as indices into r_y_tensor.
+/// `r_x_tensor` is the eq-indicator partial evaluation at r_x, i.e.
+/// `eq_ind_partial_eval_scalars(r_x)`. Accepting it as a parameter avoids redundant
+/// computation when evaluating multiple segments with the same r_x.
 pub fn evaluate_segment_wiring_mle<F: FieldOps>(
 	mul_constraints: &[MulConstraint<WitnessIndex>],
 	segment: WitnessSegment,
 	lambda: F,
-	r_x: &[F],
+	r_x_tensor: &[F],
 	r_y: &[F],
 ) -> F {
 	let mut acc = [F::zero(), F::zero(), F::zero()];
 
-	let r_x_tensor = eq_ind_partial_eval_scalars(r_x);
 	let r_y_tensor = eq_ind_partial_eval_scalars(r_y);
-	for (r_x_tensor_i, MulConstraint { a, b, c }) in iter::zip(&r_x_tensor, mul_constraints) {
+	for (r_x_tensor_i, MulConstraint { a, b, c }) in iter::zip(r_x_tensor, mul_constraints) {
 		for (dst, operand) in iter::zip(&mut acc, [a, b, c]) {
 			let r_y_tensor_sum = operand
 				.wires()
@@ -61,18 +65,17 @@ pub fn evaluate_segment_wiring_mle<F: FieldOps>(
 	evaluate_univariate(&acc, lambda)
 }
 
+/// Evaluates the public segment's contribution to the wiring MLE.
+///
+/// `r_x_tensor` is the eq-indicator partial evaluation at r_x.
 pub fn evaluate_wiring_mle_public<F: FieldOps>(
 	mul_constraints: &[MulConstraint<WitnessIndex>],
-	log_public: usize,
 	public: &[F],
 	lambda: F,
-	r_x: &[F],
+	r_x_tensor: &[F],
 ) -> F {
-	assert_eq!(public.len(), 1 << log_public);
-
 	let mut acc = [F::zero(), F::zero(), F::zero()];
-	let r_x_tensor = eq_ind_partial_eval_scalars(r_x);
-	for (r_x_tensor_i, MulConstraint { a, b, c }) in iter::zip(&r_x_tensor, mul_constraints) {
+	for (r_x_tensor_i, MulConstraint { a, b, c }) in iter::zip(r_x_tensor, mul_constraints) {
 		for (dst, operand) in iter::zip(&mut acc, [a, b, c]) {
 			let public_sum = operand
 				.wires()

--- a/crates/spartan-verifier/tests/proof_size_test.rs
+++ b/crates/spartan-verifier/tests/proof_size_test.rs
@@ -57,5 +57,5 @@ fn test_ip_proof_size() {
 	// FRI proof sizes. It is a slight underestimate because it does not account for some
 	// smaller BaseFold components (e.g. sumcheck coefficients within BaseFold, blinding
 	// elements for ZK).
-	assert_eq!(proof_size, 71056, "proof size regression");
+	assert_eq!(proof_size, 106496, "proof size regression");
 }


### PR DESCRIPTION
## Summary

- Introduce `WitnessSegment::Precommit` — values committed in a separate oracle before the private segment, zero-knowledge hidden but not prunable or rearrangeable (BINIUS-26)
- Handle the precommit segment end-to-end in prover and verifier: three oracles (precommit, private, mask), precommit contribution sent as a scalar claim, and three oracle relations verified (BINIUS-27)
- Blind the precommit segment with the same dummy-wire/dummy-constraint scheme as private, and DRY up the generation via `add_blinding_constraints`
- Minor: pass `r_x_tensor` into `eval_transparent` instead of recomputing it

## Test plan

- `cargo test -p binius-spartan-frontend`
- `cargo test -p binius-spartan-prover`
- `cargo test -p binius-spartan-verifier`
