### PR TITLE
[iop-prover] Thread oracle message through prove_oracle_relations

### DIFF
--- a/crates/iop-prover/src/basefold.rs
+++ b/crates/iop-prover/src/basefold.rs
@@ -8,14 +8,13 @@ use binius_ip_prover::sumcheck::{
 	bivariate_product::BivariateProductSumcheckProver, common::SumcheckProver,
 };
 use binius_math::{
-	FieldBuffer, inner_product::inner_product_par, line::extrapolate_line_packed,
-	multilinear::fold::fold_highest_var_inplace, ntt::AdditiveNTT,
+	FieldBuffer, inner_product::inner_product_par, line::extrapolate_line_packed, ntt::AdditiveNTT,
 };
 use binius_transcript::{
 	ProverTranscript,
 	fiat_shamir::{CanSample, Challenger},
 };
-use binius_utils::SerializeBytes;
+use binius_utils::{SerializeBytes, rayon::prelude::*};
 
 use crate::{
 	fri::{self, FRIFoldProver, FoldRoundOutput},
@@ -186,6 +185,7 @@ where
 /// `.prove(transcript)`.
 pub fn prove_zk<'a, F, P, NTT, MerkleScheme, MerkleProver, Challenger_>(
 	mut multilinear: FieldBuffer<P>,
+	mask: FieldBuffer<P>,
 	transparent_multilinear: FieldBuffer<P>,
 	sum_claim: F,
 	mut fri_folder: FRIFoldProver<'a, F, P, NTT, MerkleProver>,
@@ -201,12 +201,15 @@ where
 {
 	let _scope = tracing::debug_span!("Basefold ZK setup").entered();
 
-	assert_eq!(multilinear.log_len(), transparent_multilinear.log_len() + 1);
-	assert_eq!(multilinear.log_len(), fri_folder.n_rounds());
+	// The FRI folder operates on the codeword of the combined (witness || mask) polynomial,
+	// so `n_rounds == multilinear.log_len() + 1`.
+	let n_rounds = fri_folder.n_rounds();
+	assert_eq!(multilinear.log_len() + 1, n_rounds);
+	assert_eq!(mask.log_len(), multilinear.log_len());
+	assert_eq!(transparent_multilinear.log_len(), multilinear.log_len());
 
 	// Compute blinding_eval = sum_x[mask * l_poly]
 	// The verifier will compute sum = (1-r)*claim + r*blinding_eval using linear interpolation.
-	let (_witness, mask) = multilinear.split_half_ref();
 	let mask_claim = inner_product_par(&mask, &transparent_multilinear);
 
 	// Write blinding_eval to transcript
@@ -219,7 +222,13 @@ where
 	fri_folder.receive_challenge(batch_challenge);
 
 	// Fold multilinear at its last variable.
-	fold_highest_var_inplace(&mut multilinear, batch_challenge);
+	let batch_challenge_broadcast = P::broadcast(batch_challenge);
+	(multilinear.as_mut(), mask.as_ref())
+		.into_par_iter()
+		.for_each(|(multilinear_i, mask_i)| {
+			*multilinear_i =
+				extrapolate_line_packed(*multilinear_i, *mask_i, batch_challenge_broadcast);
+		});
 
 	// Compute the batched sum using linear interpolation.
 	let batched_sum = extrapolate_line_packed(sum_claim, mask_claim, batch_challenge);
@@ -358,7 +367,8 @@ mod test {
 	}
 
 	fn run_basefold_zk_prove_and_verify<F, P>(
-		witness_plus_mask: FieldBuffer<P>,
+		witness: FieldBuffer<P>,
+		mask: FieldBuffer<P>,
 		evaluation_point: Vec<F>,
 		evaluation_claim: F,
 	) -> Result<()>
@@ -367,7 +377,8 @@ mod test {
 		P: PackedField<Scalar = F> + PackedExtension<F>,
 	{
 		let n_vars = evaluation_point.len();
-		assert_eq!(witness_plus_mask.log_len(), n_vars + 1);
+		assert_eq!(witness.log_len(), n_vars);
+		assert_eq!(mask.log_len(), n_vars);
 
 		let eval_point_eq = eq_ind_partial_eval::<P>(&evaluation_point);
 
@@ -384,12 +395,21 @@ mod test {
 		let fri_params = binius_iop::fri::FRIParams::with_strategy(
 			ntt.domain_context(),
 			merkle_prover.scheme(),
-			witness_plus_mask.log_len(),
+			n_vars + 1,
 			Some(1),
 			LOG_INV_RATE,
 			32,
 			&ConstantArityStrategy::new(2),
 		)?;
+
+		// Build the combined (witness || mask) buffer for commitment.
+		let combined_values: Vec<P> = witness
+			.as_ref()
+			.iter()
+			.chain(mask.as_ref())
+			.copied()
+			.collect();
+		let witness_plus_mask = FieldBuffer::new(n_vars + 1, combined_values.into_boxed_slice());
 
 		// Commit batched multilinear
 		let CommitOutput {
@@ -406,7 +426,8 @@ mod test {
 
 		// Run prove_zk then continue with basefold prover
 		let prover = prove_zk(
-			witness_plus_mask,
+			witness,
+			mask,
 			eval_point_eq,
 			evaluation_claim,
 			fri_folder,
@@ -451,19 +472,15 @@ mod test {
 		let n_vars = 8;
 		let mut rng = StdRng::seed_from_u64(0);
 
-		let witness_plus_mask = random_field_buffer::<P>(&mut rng, n_vars + 1);
+		let witness = random_field_buffer::<P>(&mut rng, n_vars);
+		let mask = random_field_buffer::<P>(&mut rng, n_vars);
 		let evaluation_point = random_scalars(&mut rng, n_vars);
 
-		let (witness, _mask) = witness_plus_mask.split_half_ref();
 		let eval_point_eq = eq_ind_partial_eval::<P>(&evaluation_point);
 		let evaluation_claim = inner_product_buffers(&witness, &eval_point_eq);
 
-		run_basefold_zk_prove_and_verify::<_, P>(
-			witness_plus_mask,
-			evaluation_point,
-			evaluation_claim,
-		)
-		.unwrap();
+		run_basefold_zk_prove_and_verify::<_, P>(witness, mask, evaluation_point, evaluation_claim)
+			.unwrap();
 	}
 
 	#[test]

--- a/crates/iop-prover/src/basefold_channel.rs
+++ b/crates/iop-prover/src/basefold_channel.rs
@@ -31,8 +31,6 @@ pub struct BaseFoldOracle {
 
 /// Committed oracle data stored internally.
 struct CommittedOracleData<P: PackedField, Committed> {
-	/// The original message buffer.
-	message: FieldBuffer<P>,
 	/// RS-encoded codeword.
 	codeword: FieldBuffer<P>,
 	/// Merkle commitment data for query proofs.
@@ -235,10 +233,6 @@ where
 			buffer.log_len()
 		);
 
-		// Copy the message buffer before RS encoding (FieldSlice doesn't implement ToOwned)
-		let message_values: Vec<F> = buffer.iter_scalars().collect();
-		let message = FieldBuffer::from_values(&message_values);
-
 		// RS encode and commit
 		let CommitOutput {
 			commitment,
@@ -252,7 +246,6 @@ where
 
 		// Store committed oracle data
 		self.committed_oracles.push(CommittedOracleData {
-			message,
 			codeword,
 			committed,
 		});
@@ -264,10 +257,12 @@ where
 
 	fn prove_oracle_relations(
 		&mut self,
-		oracle_relations: impl IntoIterator<Item = (Self::Oracle, FieldBuffer<P>, P::Scalar)>,
+		oracle_relations: impl IntoIterator<
+			Item = (Self::Oracle, FieldBuffer<P>, FieldBuffer<P>, P::Scalar),
+		>,
 	) {
 		// Process each oracle relation with its own BaseFold proof
-		for (oracle, transparent_poly, eval_claim) in oracle_relations {
+		for (oracle, message, transparent_poly, eval_claim) in oracle_relations {
 			let index = oracle.index;
 			assert!(
 				index < self.committed_oracles.len(),
@@ -277,6 +272,11 @@ where
 
 			let fri_params = &self.fri_params[index];
 			let committed_data = &self.committed_oracles[index];
+			assert_eq!(
+				message.log_len(),
+				self.oracle_specs[index].log_msg_len,
+				"oracle message log_len mismatch for oracle {index}"
+			);
 
 			// Create FRI folder from committed codeword
 			let fri_folder = FRIFoldProver::new(
@@ -289,12 +289,7 @@ where
 			.expect("FRI folder creation should succeed");
 
 			// Run BaseFold proof (non-ZK variant).
-			let prover = BaseFoldProver::new(
-				committed_data.message.clone(),
-				transparent_poly,
-				eval_claim,
-				fri_folder,
-			);
+			let prover = BaseFoldProver::new(message, transparent_poly, eval_claim, fri_folder);
 			prover
 				.prove(self.transcript)
 				.expect("BaseFold proof should succeed");
@@ -410,8 +405,8 @@ mod tests {
 		assert_eq!(oracle_2.index, 1);
 
 		prover_channel.prove_oracle_relations([
-			(oracle_1, transparent_poly_1, eval_claim_1),
-			(oracle_2, transparent_poly_2, eval_claim_2),
+			(oracle_1, buffer_1, transparent_poly_1, eval_claim_1),
+			(oracle_2, buffer_2, transparent_poly_2, eval_claim_2),
 		]);
 	}
 

--- a/crates/iop-prover/src/basefold_zk_channel.rs
+++ b/crates/iop-prover/src/basefold_zk_channel.rs
@@ -7,8 +7,6 @@
 //! this channel always applies zero-knowledge blinding to all oracles by generating masks
 //! internally.
 
-use std::iter;
-
 use binius_field::{BinaryField, PackedField};
 use binius_iop::{channel::OracleSpec, fri::FRIParams, merkle_tree::MerkleTreeScheme};
 use binius_ip_prover::channel::IPProverChannel;
@@ -36,8 +34,9 @@ pub struct BaseFoldZKOracle {
 
 /// Committed oracle data stored internally.
 struct CommittedOracleData<P: PackedField, Committed> {
-	/// The combined (witness || mask) buffer.
-	combined: FieldBuffer<P>,
+	/// The mask buffer generated during [`fri::commit_masked`]. Held by the channel because it is
+	/// the only party that knows it.
+	mask: FieldBuffer<P>,
 	/// RS-encoded codeword.
 	codeword: FieldBuffer<P>,
 	/// Merkle commitment data for query proofs.
@@ -199,27 +198,11 @@ where
 		)
 		.expect("FRI commit_masked should succeed with valid params");
 
-		// Build the combined (witness || mask) buffer for later use in prove_zk.
-		let log_len = buffer.log_len();
-		let combined_values = if log_len < P::LOG_WIDTH {
-			let combined_value =
-				P::from_scalars(iter::chain(buffer.iter_scalars(), mask.iter_scalars()));
-			vec![combined_value]
-		} else {
-			// TODO: The concatenation here is sequential and a performance issue. Ideally, commit
-			// should not allocate and copy the memory into a temp buffer.
-			// TODO: At the very least, make this a parallel copy
-			iter::chain(buffer.as_ref(), mask.as_ref())
-				.copied()
-				.collect::<Vec<_>>()
-		};
-		let combined = FieldBuffer::new(log_len + 1, combined_values.into_boxed_slice());
-
 		// Send commitment via transcript.
 		self.transcript.message().write(&commitment);
 
 		self.committed_oracles.push(CommittedOracleData {
-			combined,
+			mask,
 			codeword,
 			committed,
 		});
@@ -231,9 +214,11 @@ where
 
 	fn prove_oracle_relations(
 		&mut self,
-		oracle_relations: impl IntoIterator<Item = (Self::Oracle, FieldBuffer<P>, P::Scalar)>,
+		oracle_relations: impl IntoIterator<
+			Item = (Self::Oracle, FieldBuffer<P>, FieldBuffer<P>, P::Scalar),
+		>,
 	) {
-		for (oracle, transparent_poly, eval_claim) in oracle_relations {
+		for (oracle, message, transparent_poly, eval_claim) in oracle_relations {
 			let index = oracle.index;
 			assert!(
 				index < self.committed_oracles.len(),
@@ -243,6 +228,11 @@ where
 
 			let fri_params = &self.fri_params[index];
 			let committed_data = &self.committed_oracles[index];
+			assert_eq!(
+				message.log_len(),
+				self.oracle_specs[index].log_msg_len,
+				"oracle message log_len mismatch for oracle {index}"
+			);
 
 			let fri_folder = FRIFoldProver::new(
 				fri_params,
@@ -255,7 +245,8 @@ where
 
 			// Always use ZK variant.
 			let prover = basefold::prove_zk(
-				committed_data.combined.clone(),
+				message,
+				committed_data.mask.clone(),
 				transparent_poly,
 				eval_claim,
 				fri_folder,
@@ -372,7 +363,12 @@ mod tests {
 		let oracle = prover_channel.send_oracle(buffer.to_ref());
 		assert_eq!(oracle.index, 0);
 
-		prover_channel.prove_oracle_relations([(oracle, transparent_poly.clone(), eval_claim)]);
+		prover_channel.prove_oracle_relations([(
+			oracle,
+			buffer,
+			transparent_poly.clone(),
+			eval_claim,
+		)]);
 
 		// === VERIFIER SIDE ===
 		let mut verifier_transcript = prover_transcript.into_verifier();
@@ -442,8 +438,8 @@ mod tests {
 		let oracle_2 = prover_channel.send_oracle(buffer_2.to_ref());
 
 		prover_channel.prove_oracle_relations([
-			(oracle_1, transparent_poly_1.clone(), eval_claim_1),
-			(oracle_2, transparent_poly_2.clone(), eval_claim_2),
+			(oracle_1, buffer_1, transparent_poly_1.clone(), eval_claim_1),
+			(oracle_2, buffer_2, transparent_poly_2.clone(), eval_claim_2),
 		]);
 
 		// === VERIFIER SIDE ===

--- a/crates/iop-prover/src/channel.rs
+++ b/crates/iop-prover/src/channel.rs
@@ -50,13 +50,20 @@ pub trait IOPProverChannel<P: PackedField>: IPProverChannel<P::Scalar> {
 
 	/// Generates opening proofs for all oracle linear relations.
 	///
+	/// Each item is `(oracle, message, transparent_poly, eval_claim)` where `message` is
+	/// the same buffer that was passed to `send_oracle()` for this oracle. Callers provide
+	/// the message here so the channel does not need to store it internally.
+	///
 	/// # Preconditions
 	///
 	/// * `remaining_oracle_specs()` must be empty (all oracles committed).
 	/// * All oracle handles in `oracle_relations` must be valid handles returned by
 	///   `send_oracle()`.
+	/// * Each `message` must match the buffer previously committed via `send_oracle()`.
 	fn prove_oracle_relations(
 		&mut self,
-		oracle_relations: impl IntoIterator<Item = (Self::Oracle, FieldBuffer<P>, P::Scalar)>,
+		oracle_relations: impl IntoIterator<
+			Item = (Self::Oracle, FieldBuffer<P>, FieldBuffer<P>, P::Scalar),
+		>,
 	);
 }

--- a/crates/iop-prover/src/naive_channel.rs
+++ b/crates/iop-prover/src/naive_channel.rs
@@ -23,12 +23,6 @@ pub struct NaiveOracle {
 	index: usize,
 }
 
-/// Stored data for a committed oracle.
-struct StoredOracleData<P: PackedField> {
-	/// The polynomial buffer (size 2^n_vars).
-	buffer: FieldBuffer<P>,
-}
-
 /// A naive prover channel that writes full polynomial data to the transcript.
 ///
 /// This channel wraps a [`ProverTranscript`] and provides oracle operations by writing
@@ -38,28 +32,26 @@ struct StoredOracleData<P: PackedField> {
 /// # Type Parameters
 ///
 /// - `F`: The field type
-/// - `P`: The packed field type with `Scalar = F`
 /// - `Challenger_`: The Fiat-Shamir challenger
-pub struct NaiveProverChannel<'a, F, P, Challenger_>
+pub struct NaiveProverChannel<'a, F, Challenger_>
 where
 	F: Field,
-	P: PackedField<Scalar = F>,
 	Challenger_: Challenger,
 {
 	/// Prover transcript for Fiat-Shamir (borrowed).
 	transcript: &'a mut ProverTranscript<Challenger_>,
 	/// Oracle specifications.
 	oracle_specs: Vec<OracleSpec>,
-	/// Stored oracle data for each committed oracle.
-	stored_oracles: Vec<StoredOracleData<P>>,
+	/// Number of oracles committed so far.
+	n_committed: usize,
 	/// Next oracle index.
 	next_oracle_index: usize,
+	_f: std::marker::PhantomData<F>,
 }
 
-impl<'a, F, P, Challenger_> NaiveProverChannel<'a, F, P, Challenger_>
+impl<'a, F, Challenger_> NaiveProverChannel<'a, F, Challenger_>
 where
 	F: Field,
-	P: PackedField<Scalar = F>,
 	Challenger_: Challenger,
 {
 	/// Creates a new naive prover channel.
@@ -75,8 +67,9 @@ where
 		Self {
 			transcript,
 			oracle_specs,
-			stored_oracles: Vec::new(),
+			n_committed: 0,
 			next_oracle_index: 0,
+			_f: std::marker::PhantomData,
 		}
 	}
 
@@ -92,10 +85,9 @@ where
 	}
 }
 
-impl<F, P, Challenger_> IPProverChannel<F> for NaiveProverChannel<'_, F, P, Challenger_>
+impl<F, Challenger_> IPProverChannel<F> for NaiveProverChannel<'_, F, Challenger_>
 where
 	F: Field,
-	P: PackedField<Scalar = F>,
 	Challenger_: Challenger,
 {
 	fn send_one(&mut self, elem: F) {
@@ -119,7 +111,7 @@ where
 	}
 }
 
-impl<F, P, Challenger_> IOPProverChannel<P> for NaiveProverChannel<'_, F, P, Challenger_>
+impl<F, P, Challenger_> IOPProverChannel<P> for NaiveProverChannel<'_, F, Challenger_>
 where
 	F: Field,
 	P: PackedField<Scalar = F>,
@@ -132,12 +124,11 @@ where
 	}
 
 	fn send_oracle(&mut self, buffer: FieldSlice<P>) -> Self::Oracle {
+		let index = self.next_oracle_index;
 		assert!(
-			!self.remaining_oracle_specs().is_empty(),
+			index < self.oracle_specs.len(),
 			"send_oracle called but no remaining oracle specs"
 		);
-
-		let index = self.next_oracle_index;
 
 		// Validate buffer length matches spec
 		let spec_log_msg_len = self.oracle_specs[index].log_msg_len;
@@ -154,13 +145,7 @@ where
 			.message()
 			.write_scalar_iter(buffer.iter_scalars());
 
-		// Store the buffer for use in prove_oracle_relations()
-		let stored_buffer =
-			FieldBuffer::new(buffer.log_len(), buffer.as_ref().to_vec().into_boxed_slice());
-		self.stored_oracles.push(StoredOracleData {
-			buffer: stored_buffer,
-		});
-
+		self.n_committed += 1;
 		self.next_oracle_index += 1;
 
 		NaiveOracle { index }
@@ -168,15 +153,23 @@ where
 
 	fn prove_oracle_relations(
 		&mut self,
-		oracle_relations: impl IntoIterator<Item = (Self::Oracle, FieldBuffer<P>, P::Scalar)>,
+		oracle_relations: impl IntoIterator<
+			Item = (Self::Oracle, FieldBuffer<P>, FieldBuffer<P>, P::Scalar),
+		>,
 	) {
 		// For the naive channel, we write the transparent polynomial to the transcript
 		// so the verifier can read it and verify the inner product directly.
-		for (oracle, transparent_poly, eval_claim) in oracle_relations {
+		for (oracle, message, transparent_poly, eval_claim) in oracle_relations {
 			let index = oracle.index;
-			assert!(index < self.stored_oracles.len(), "oracle index {index} out of bounds");
+			assert!(index < self.n_committed, "oracle index {index} out of bounds");
 
 			let log_msg_len = self.oracle_specs[index].log_msg_len;
+			assert_eq!(
+				message.log_len(),
+				log_msg_len,
+				"oracle message log_len mismatch: expected {log_msg_len}, got {}",
+				message.log_len()
+			);
 
 			// Write the transparent polynomial to the transcript
 			self.transcript
@@ -187,9 +180,7 @@ where
 			let _point: Vec<F> = CanSample::sample_vec(&mut self.transcript, log_msg_len);
 
 			// Debug assertion: prover should provide consistent eval claims
-			let stored = &self.stored_oracles[index];
-			let witness_poly = stored.buffer.to_ref();
-			let actual_eval: F = inner_product_buffers(&witness_poly, &transparent_poly);
+			let actual_eval: F = inner_product_buffers(&message, &transparent_poly);
 			debug_assert_eq!(
 				actual_eval, eval_claim,
 				"NaiveProverChannel: eval_claim mismatch for oracle {index}"

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -260,7 +260,12 @@ impl IOPProver {
 			compute_batched_transparent(rs_eq_ind, pubcheck_point, batch_coeff);
 
 		// Prove oracle relations via channel (runs BaseFold internally)
-		channel.prove_oracle_relations([(trace_oracle, batched_transparent, batched_claim)]);
+		channel.prove_oracle_relations([(
+			trace_oracle,
+			witness_packed,
+			batched_transparent,
+			batched_claim,
+		)]);
 
 		drop(pcs_guard);
 

--- a/crates/spartan-prover/src/lib.rs
+++ b/crates/spartan-prover/src/lib.rs
@@ -287,9 +287,9 @@ impl<F: Field> IOPProver<F> {
 
 		// Prove all oracle relations
 		channel.prove_oracle_relations([
-			(precommit_oracle, precommit_wiring_poly, precommit_claim),
-			(private_oracle, private_wiring_poly, private_claim),
-			(mask_oracle, libra_eval_tensor, mask_eval),
+			(precommit_oracle, precommit_packed, precommit_wiring_poly, precommit_claim),
+			(private_oracle, private_packed, private_wiring_poly, private_claim),
+			(mask_oracle, masks_buffer, libra_eval_tensor, mask_eval),
 		]);
 
 		Ok(())

--- a/crates/spartan-prover/src/wiring.rs
+++ b/crates/spartan-prover/src/wiring.rs
@@ -463,10 +463,8 @@ mod tests {
 
 		// === PROVER SIDE ===
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
-		let mut prover_channel = NaiveProverChannel::<B128, Packed128b, _>::new(
-			&mut prover_transcript,
-			oracle_specs.clone(),
-		);
+		let mut prover_channel =
+			NaiveProverChannel::<B128, _>::new(&mut prover_transcript, oracle_specs.clone());
 
 		// Send private witness oracle
 		let witness_oracle = prover_channel.send_oracle(private_buf.to_ref());
@@ -488,7 +486,12 @@ mod tests {
 			fold_constraints::<_, Packed128b>(&wiring_transpose, lambda, r_x_tensor.as_ref());
 
 		// Finish the IOP with the oracle relation
-		prover_channel.prove_oracle_relations([(witness_oracle, wiring_poly.clone(), trace_claim)]);
+		prover_channel.prove_oracle_relations([(
+			witness_oracle,
+			private_buf,
+			wiring_poly.clone(),
+			trace_claim,
+		)]);
 
 		// === VERIFIER SIDE ===
 		let mut verifier_transcript = prover_transcript.into_verifier();

--- a/crates/spartan-prover/src/wrapper/zk_wrapped_prover_channel.rs
+++ b/crates/spartan-prover/src/wrapper/zk_wrapped_prover_channel.rs
@@ -205,7 +205,9 @@ where
 
 	fn prove_oracle_relations(
 		&mut self,
-		oracle_relations: impl IntoIterator<Item = (Self::Oracle, FieldBuffer<P>, P::Scalar)>,
+		oracle_relations: impl IntoIterator<
+			Item = (Self::Oracle, FieldBuffer<P>, FieldBuffer<P>, P::Scalar),
+		>,
 	) {
 		self.inner_channel.prove_oracle_relations(oracle_relations)
 	}


### PR DESCRIPTION
## Summary

- Eliminate the `(witness || mask)` buffer copy that `BaseFoldZKProverChannel::send_oracle` built on every oracle commitment by pushing message ownership back to the caller: `IOPProverChannel::prove_oracle_relations` now takes a 4-tuple `(oracle, message, transparent_poly, eval_claim)`.
- `basefold::prove_zk` takes `(multilinear, mask)` separately and does the witness/mask linear combination in-place via `extrapolate_line`, rather than folding a concatenated buffer. FRI folder still runs over the doubled codeword, so `n_rounds == log_len + 1`.
- All three channel impls drop their internal message storage; `NaiveProverChannel` additionally drops its `P` type parameter so one channel instance can handle oracles at multiple packings.

## Test plan

- `cargo test --no-default-features -p binius-iop-prover`
- `cargo test --no-default-features -p binius-spartan-prover`
- `cargo test -p binius-prover --test prove_verify`
