### PR TITLE
Simplify iadd32 gate and refactor blake3 to match reference

### DIFF
--- a/crates/circuits/proptest-regressions/concat.txt
+++ b/crates/circuits/proptest-regressions/concat.txt
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc aa6139073fbf3838e94c5edae473d19199ce90bc7607a33d68a3a94387b7787d # shrinks to term_specs = [([97], 8), ([135, 169, 119, 151, 72, 136, 141, 165, 217], 16)]
+cc c3794747371d19a48f6c46e6eeb6f5a5e95754abb0664a8d8b92174ff7055c8f # shrinks to n_terms = 2, base_size = 121

--- a/crates/circuits/proptest-regressions/hash_based_sig/chain_verification.txt
+++ b/crates/circuits/proptest-regressions/hash_based_sig/chain_verification.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 34e58b17f8ddae654ed26644dae446a9665b1c131205fe12c209147395a68624 # shrinks to (starting_position_val, max_chain_len) = (0, 1), chain_index_val = 0, domain_param_bytes = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], signature_hash_bytes = [0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]

--- a/crates/circuits/proptest-regressions/hash_based_sig/hashing/chain.txt
+++ b/crates/circuits/proptest-regressions/hash_based_sig/hashing/chain.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 25bf5aac87e3e81cce96618429eff6503409b8d0c01c0a224c2df5ab3b319477 # shrinks to domain_param_len = 9, chain_index = 0, position = 0

--- a/crates/circuits/proptest-regressions/hash_based_sig/hashing/message.txt
+++ b/crates/circuits/proptest-regressions/hash_based_sig/hashing/message.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 6a4a4b1b66bf85ba8a46e4e4b360cd5945cd4a67d8471b5223a0c37731c59d62 # shrinks to domain_param_len = 1, nonce_len = 7, message_len = 121

--- a/crates/circuits/proptest-regressions/hash_based_sig/hashing/public_key.txt
+++ b/crates/circuits/proptest-regressions/hash_based_sig/hashing/public_key.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc e486398ef8e561f09e65830d550e1f79389a4407307338efeb92eefde4775d1f # shrinks to domain_param_len = 9, num_hashes = 1

--- a/crates/circuits/proptest-regressions/hash_based_sig/hashing/tree.txt
+++ b/crates/circuits/proptest-regressions/hash_based_sig/hashing/tree.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc d9e55e29c308d14d3500ad626be5a90f0b07d2c77baf6136a29b6e9ce00ac49a # shrinks to domain_param_len = 25, level = 0, index = 0

--- a/crates/circuits/src/concat.rs
+++ b/crates/circuits/src/concat.rs
@@ -100,7 +100,8 @@ impl Concat {
 				//
 				// Calculate where this word should appear in the joined array.
 				// This is the current offset plus the word's position within the term.
-				let input_word_idx = b.iadd_32(word_offset, b.add_constant(Word(word_idx as u64)));
+				let (input_word_idx, _) =
+					b.iadd(word_offset, b.add_constant(Word(word_idx as u64)));
 				let byte_offset = b.band(offset, b.add_constant(Word(7)));
 
 				// 2c. Extract corresponding data from joined array
@@ -110,7 +111,7 @@ impl Concat {
 				let joined_data = extract_word(&b, &joined, input_word_idx, byte_offset);
 
 				let neg_start = b.add_constant(Word((-(word_byte_offset as i64)) as u64));
-				let bytes_remaining = b.iadd_32(term.len_bytes, neg_start);
+				let (bytes_remaining, _) = b.iadd(term.len_bytes, neg_start);
 
 				// The mask will handle clamping to 8 bytes internally
 				let mask = create_byte_mask(&b, bytes_remaining);
@@ -127,7 +128,7 @@ impl Concat {
 			//
 			// After processing all words of the current term, advance the offset
 			// by the term's actual length to position for the next term.
-			offset = b.iadd_32(offset, term.len_bytes);
+			(offset, _) = b.iadd(offset, term.len_bytes);
 		}
 
 		// 5. Final length verification

--- a/crates/circuits/src/ripemd.rs
+++ b/crates/circuits/src/ripemd.rs
@@ -153,6 +153,8 @@ fn ripemd160_compress(
 	}
 
 	// Combine results: state[i] = state[i] + cl + dr (and appropriate permutation)
+	// Mask to 32 bits: intermediate round values may have non-zero upper halves
+	// (e.g. from bnot which produces a full 64-bit NOT), so clear them before output.
 	[
 		builder.iadd_32(builder.iadd_32(state[1], cl), dr),
 		builder.iadd_32(builder.iadd_32(state[2], dl), er),
@@ -160,6 +162,7 @@ fn ripemd160_compress(
 		builder.iadd_32(builder.iadd_32(state[4], al), br),
 		builder.iadd_32(builder.iadd_32(state[0], bl), cr),
 	]
+	.map(|w| builder.shr(builder.shl(w, 32), 32))
 }
 
 // Selection function f(x, y, z) = x XOR y XOR z

--- a/crates/circuits/src/slice.rs
+++ b/crates/circuits/src/slice.rs
@@ -81,8 +81,7 @@ impl Slice {
 			// are ANY of the bytes in this present word actually part of the slice proper?
 
 			// Calculate which input word(s) we need
-			let (input_word_idx, _) =
-				b.iadd(word_offset, b.add_constant(Word(slice_idx as u64)));
+			let (input_word_idx, _) = b.iadd(word_offset, b.add_constant(Word(slice_idx as u64)));
 
 			let extracted_word = extract_word(&b, &input, input_word_idx, byte_offset);
 

--- a/crates/circuits/src/slice.rs
+++ b/crates/circuits/src/slice.rs
@@ -61,8 +61,7 @@ impl Slice {
 		b.assert_zero("len_input_32bit", b.shr(len_input, 32));
 
 		// Verify bounds: offset + len_slice <= len_input
-		let zero = b.add_constant_64(0);
-		let (offset_plus_len_slice, _) = b.iadd_cin_cout(offset, len_slice, zero);
+		let (offset_plus_len_slice, _) = b.iadd(offset, len_slice);
 		let in_bounds = b.icmp_ule(offset_plus_len_slice, len_input);
 		b.assert_true("bounds_check", in_bounds);
 
@@ -82,11 +81,8 @@ impl Slice {
 			// are ANY of the bytes in this present word actually part of the slice proper?
 
 			// Calculate which input word(s) we need
-			let (input_word_idx, _) = b.iadd_cin_cout(
-				word_offset,
-				b.add_constant(Word(slice_idx as u64)),
-				zero,
-			);
+			let (input_word_idx, _) =
+				b.iadd(word_offset, b.add_constant(Word(slice_idx as u64)));
 
 			let extracted_word = extract_word(&b, &input, input_word_idx, byte_offset);
 
@@ -94,7 +90,7 @@ impl Slice {
 			// Calculate valid bytes in this word: min(len_slice - word_start, 8)
 			// First calculate len_slice - word_start
 			let neg_start = b.add_constant(Word((-(word_start_bytes as i64)) as u64));
-			let (bytes_remaining, _) = b.iadd_cin_cout(len_slice, neg_start, zero);
+			let (bytes_remaining, _) = b.iadd(len_slice, neg_start);
 
 			// The mask will handle clamping to 8 bytes internally
 			let mask = create_byte_mask(&b, bytes_remaining);
@@ -225,11 +221,11 @@ impl Slice {
 /// # Returns
 /// A wire containing the extracted 8-byte word
 pub fn extract_word(b: &CircuitBuilder, input: &[Wire], word_idx: Wire, byte_offset: Wire) -> Wire {
-	let zero = b.add_constant(Word::ZERO);
-	let (next_word_idx, _) = b.iadd_cin_cout(word_idx, b.add_constant(Word(1)), zero);
+	let (next_word_idx, _) = b.iadd(word_idx, b.add_constant(Word(1)));
 	// Aligned case: directly select the word
 	let aligned_word = single_wire_multiplex(b, input, word_idx);
 	let next_word = single_wire_multiplex(b, input, next_word_idx);
+	let zero = b.add_constant(Word::ZERO);
 
 	let candidates: Vec<Wire> = (0..8)
 		.map(|i| {

--- a/crates/circuits/src/slice.rs
+++ b/crates/circuits/src/slice.rs
@@ -61,7 +61,8 @@ impl Slice {
 		b.assert_zero("len_input_32bit", b.shr(len_input, 32));
 
 		// Verify bounds: offset + len_slice <= len_input
-		let offset_plus_len_slice = b.iadd_32(offset, len_slice);
+		let zero = b.add_constant_64(0);
+		let (offset_plus_len_slice, _) = b.iadd_cin_cout(offset, len_slice, zero);
 		let in_bounds = b.icmp_ule(offset_plus_len_slice, len_input);
 		b.assert_true("bounds_check", in_bounds);
 
@@ -81,7 +82,11 @@ impl Slice {
 			// are ANY of the bytes in this present word actually part of the slice proper?
 
 			// Calculate which input word(s) we need
-			let input_word_idx = b.iadd_32(word_offset, b.add_constant(Word(slice_idx as u64)));
+			let (input_word_idx, _) = b.iadd_cin_cout(
+				word_offset,
+				b.add_constant(Word(slice_idx as u64)),
+				zero,
+			);
 
 			let extracted_word = extract_word(&b, &input, input_word_idx, byte_offset);
 
@@ -89,7 +94,7 @@ impl Slice {
 			// Calculate valid bytes in this word: min(len_slice - word_start, 8)
 			// First calculate len_slice - word_start
 			let neg_start = b.add_constant(Word((-(word_start_bytes as i64)) as u64));
-			let bytes_remaining = b.iadd_32(len_slice, neg_start);
+			let (bytes_remaining, _) = b.iadd_cin_cout(len_slice, neg_start, zero);
 
 			// The mask will handle clamping to 8 bytes internally
 			let mask = create_byte_mask(&b, bytes_remaining);
@@ -220,11 +225,11 @@ impl Slice {
 /// # Returns
 /// A wire containing the extracted 8-byte word
 pub fn extract_word(b: &CircuitBuilder, input: &[Wire], word_idx: Wire, byte_offset: Wire) -> Wire {
-	let next_word_idx = b.iadd_32(word_idx, b.add_constant(Word(1)));
+	let zero = b.add_constant(Word::ZERO);
+	let (next_word_idx, _) = b.iadd_cin_cout(word_idx, b.add_constant(Word(1)), zero);
 	// Aligned case: directly select the word
 	let aligned_word = single_wire_multiplex(b, input, word_idx);
 	let next_word = single_wire_multiplex(b, input, next_word_idx);
-	let zero = b.add_constant(Word::ZERO);
 
 	let candidates: Vec<Wire> = (0..8)
 		.map(|i| {

--- a/crates/core/src/word.rs
+++ b/crates/core/src/word.rs
@@ -89,16 +89,27 @@ impl Word {
 		Word(value)
 	}
 
-	/// Performs 32-bit addition.
+	/// Performs parallel 32-bit additions on the upper and lower halves.
 	///
-	/// Returns (sum, carry_out) where ith carry_out bit is set to one if there is a carry out at
-	/// that bit position.
+	/// Each 32-bit half is added independently, like [`sll32`](Word::sll32) operates on
+	/// independent halves. Returns (sum, carry_out) where the ith carry_out bit is set to one
+	/// if there is a carry out at that bit position.
 	pub fn iadd_cout_32(self, rhs: Word) -> (Word, Word) {
 		let Word(lhs) = self;
 		let Word(rhs) = rhs;
-		let full_sum = lhs.wrapping_add(rhs);
-		let sum = full_sum & 0x00000000_FFFFFFFF;
-		let cout = (lhs & rhs) | ((lhs ^ rhs) & !full_sum);
+
+		// Extract 32-bit halves
+		let lo_l = lhs as u32;
+		let hi_l = (lhs >> 32) as u32;
+		let lo_r = rhs as u32;
+		let hi_r = (rhs >> 32) as u32;
+
+		// Add each half independently
+		let lo_sum = lo_l.wrapping_add(lo_r);
+		let hi_sum = hi_l.wrapping_add(hi_r);
+		let sum = (lo_sum as u64) | ((hi_sum as u64) << 32);
+
+		let cout = (lhs & rhs) | ((lhs ^ rhs) & !sum);
 		(Word(sum), Word(cout))
 	}
 
@@ -152,13 +163,6 @@ impl Word {
 		let value = *value as i64;
 		let result = value >> n;
 		Word(result as u64)
-	}
-
-	/// Rotate Right by a given number of bits followed by masking with a 32-bit mask.
-	pub fn rotr_32(self, n: u32) -> Word {
-		let Word(value) = self;
-		let value_32 = (value as u32).rotate_right(n);
-		Word(value_32 as u64)
 	}
 
 	/// Rotate Right by a given number of bits.
@@ -541,21 +545,24 @@ mod tests {
 		}
 
 		#[test]
-		fn prop_iadd_cout_32(a in any::<u32>(), b in any::<u32>()) {
-			let wa = Word(a as u64);
-			let wb = Word(b as u64);
+		fn prop_iadd_cout_32(a in any::<u64>(), b in any::<u64>()) {
+			let wa = Word(a);
+			let wb = Word(b);
 			let (sum, cout) = wa.iadd_cout_32(wb);
 
-			// Sum should be masked to 32 bits
-			assert_eq!(sum.0, (a as u64 + b as u64) & 0xFFFFFFFF);
+			// Each 32-bit half is added independently
+			let lo_sum = (a as u32).wrapping_add(b as u32);
+			let hi_sum = ((a >> 32) as u32).wrapping_add((b >> 32) as u32);
+			let expected_sum = (lo_sum as u64) | ((hi_sum as u64) << 32);
+			assert_eq!(sum.0, expected_sum);
 
 			// Carry computation: cout = (a & b) | ((a ^ b) & !sum)
-			let expected_cout = (a as u64 & b as u64) | ((a as u64 ^ b as u64) & !sum.0);
+			let expected_cout = (a & b) | ((a ^ b) & !expected_sum);
 			assert_eq!(cout.0, expected_cout);
 
 			// Identity: adding 0 produces no carries
 			let (sum0, cout0) = wa.iadd_cout_32(Word::ZERO);
-			assert_eq!(sum0.0, a as u64);
+			assert_eq!(sum0.0, a);
 			assert_eq!(cout0, Word::ZERO);
 		}
 
@@ -620,27 +627,6 @@ mod tests {
 				assert_eq!(result.0, (val >> shift) & 0xFFFFFFFF);
 			}
 		}
-
-		#[test]
-		fn prop_rotr_32(val in any::<u32>(), rotate in 0u32..64) {
-			let w = Word(val as u64);
-			let result = w.rotr_32(rotate);
-
-			// Only lower 32 bits are rotated
-			let rotate_mod = rotate % 32;
-			let val32 = val as u64;
-			let expected = if rotate_mod == 0 {
-				val32
-			} else {
-				((val32 >> rotate_mod) | (val32 << (32 - rotate_mod))) & 0xFFFFFFFF
-			};
-			assert_eq!(result.0, expected);
-
-			// Rotation by 0 or 32 is identity
-			assert_eq!(w.rotr_32(0).0, val32);
-			assert_eq!(w.rotr_32(32).0, val32);
-		}
-
 		#[test]
 		fn prop_rotr(val in any::<u64>(), rotate in 0u32..128) {
 			let w = Word(val);

--- a/crates/core/src/word.rs
+++ b/crates/core/src/word.rs
@@ -89,14 +89,22 @@ impl Word {
 		Word(value)
 	}
 
-	/// Performs parallel 32-bit additions on the upper and lower halves.
+	/// Performs parallel 32-bit additions on the upper and lower halves with carry-in.
 	///
 	/// Each 32-bit half is added independently, like [`sll32`](Word::sll32) operates on
-	/// independent halves. Returns (sum, carry_out) where the ith carry_out bit is set to one
-	/// if there is a carry out at that bit position.
-	pub fn iadd_cout_32(self, rhs: Word) -> (Word, Word) {
+	/// independent halves. The carry-in for the lower half is taken from bit 31 of `cin`,
+	/// and the carry-in for the upper half is taken from bit 63 of `cin`.
+	///
+	/// Returns (sum, carry_out) where the ith carry_out bit is set to one if there is a
+	/// carry out at that bit position.
+	pub fn iadd32_cin_cout(self, rhs: Word, cin: Word) -> (Word, Word) {
 		let Word(lhs) = self;
 		let Word(rhs) = rhs;
+		let Word(cin) = cin;
+
+		// Extract carry-in bits from MSBs of each 32-bit half
+		let cin_lo = (cin >> 31) & 1;
+		let cin_hi = (cin >> 63) & 1;
 
 		// Extract 32-bit halves
 		let lo_l = lhs as u32;
@@ -104,13 +112,20 @@ impl Word {
 		let lo_r = rhs as u32;
 		let hi_r = (rhs >> 32) as u32;
 
-		// Add each half independently
-		let lo_sum = lo_l.wrapping_add(lo_r);
-		let hi_sum = hi_l.wrapping_add(hi_r);
-		let sum = (lo_sum as u64) | ((hi_sum as u64) << 32);
+		// Add each half independently with carry-in
+		let lo_sum = (lo_l as u64) + (lo_r as u64) + cin_lo;
+		let hi_sum = (hi_l as u64) + (hi_r as u64) + cin_hi;
+		let sum = (lo_sum as u32 as u64) | ((hi_sum as u32 as u64) << 32);
 
 		let cout = (lhs & rhs) | ((lhs ^ rhs) & !sum);
 		(Word(sum), Word(cout))
+	}
+
+	/// Performs parallel 32-bit additions on the upper and lower halves.
+	///
+	/// Equivalent to [`iadd32_cin_cout`](Word::iadd32_cin_cout) with zero carry-in.
+	pub fn iadd_cout_32(self, rhs: Word) -> (Word, Word) {
+		self.iadd32_cin_cout(rhs, Word::ZERO)
 	}
 
 	/// Performs 64-bit addition with carry input bit.
@@ -545,25 +560,32 @@ mod tests {
 		}
 
 		#[test]
-		fn prop_iadd_cout_32(a in any::<u64>(), b in any::<u64>()) {
+		fn prop_iadd32_cin_cout(
+			a in any::<u64>(), b in any::<u64>(),
+			cin_lo in proptest::bool::ANY, cin_hi in proptest::bool::ANY,
+		) {
+			// Build cin with carry bits at MSB of each 32-bit half
+			let cin_word = ((cin_lo as u64) << 31) | ((cin_hi as u64) << 63);
 			let wa = Word(a);
 			let wb = Word(b);
-			let (sum, cout) = wa.iadd_cout_32(wb);
+			let wcin = Word(cin_word);
+			let (sum, cout) = wa.iadd32_cin_cout(wb, wcin);
 
-			// Each 32-bit half is added independently
-			let lo_sum = (a as u32).wrapping_add(b as u32);
-			let hi_sum = ((a >> 32) as u32).wrapping_add((b >> 32) as u32);
-			let expected_sum = (lo_sum as u64) | ((hi_sum as u64) << 32);
+			// Each 32-bit half is added independently with its carry-in
+			let lo_sum = (a as u32 as u64) + (b as u32 as u64) + (cin_lo as u64);
+			let hi_sum = ((a >> 32) as u32 as u64) + ((b >> 32) as u32 as u64) + (cin_hi as u64);
+			let expected_sum = (lo_sum as u32 as u64) | ((hi_sum as u32 as u64) << 32);
 			assert_eq!(sum.0, expected_sum);
 
 			// Carry computation: cout = (a & b) | ((a ^ b) & !sum)
 			let expected_cout = (a & b) | ((a ^ b) & !expected_sum);
 			assert_eq!(cout.0, expected_cout);
 
-			// Identity: adding 0 produces no carries
-			let (sum0, cout0) = wa.iadd_cout_32(Word::ZERO);
-			assert_eq!(sum0.0, a);
-			assert_eq!(cout0, Word::ZERO);
+			// Zero cin should match iadd_cout_32
+			let (sum0, cout0) = wa.iadd_cout_32(wb);
+			let (sum1, cout1) = wa.iadd32_cin_cout(wb, Word::ZERO);
+			assert_eq!(sum0, sum1);
+			assert_eq!(cout0, cout1);
 		}
 
 		#[test]

--- a/crates/examples/snapshots/bitcoin_headers.snap
+++ b/crates/examples/snapshots/bitcoin_headers.snap
@@ -1,0 +1,28 @@
+bitcoin_headers circuit
+--
+Gates & Instructions
+├─ Number of gates: 71,498
+└─ Number of evaluation instructions: 72,938
+
+Constraints
+├─ AND constraints: 31,880 used (97.3% of 2^15)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 888
+├─ MUL constraints: 0 used (0.0% of 2^0)
+│  [░░░░░░░░░░] spare: 1
+└─ Distinct value indices: 73,028
+   ├─ Distinct shifted value indices: 41,323
+   └─ Distinct unshifted value indices: 31,705
+
+Value Vector
+├─ Public Section: 111 used (86.7% of 2^7)
+│  [▓▓▓▓▓▓▓▓░░] spare: 17
+│  ├─ Constants: 111
+│  └─ Inout: 0
+├─ Private Section: 31,594 used (96.8%)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 1,046
+│  ├─ Witness: 804
+│  └─ Internal: 30,790
+├─ Total Committed: 31,705 used (96.8% of 2^15)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 1,063
+└─ Scratch (uncommitted): 59,708
+

--- a/crates/examples/snapshots/bitcoin_headers.snap
+++ b/crates/examples/snapshots/bitcoin_headers.snap
@@ -9,8 +9,8 @@ Constraints
 │  [▓▓▓▓▓▓▓▓▓░] spare: 888
 ├─ MUL constraints: 0 used (0.0% of 2^0)
 │  [░░░░░░░░░░] spare: 1
-└─ Distinct value indices: 73,028
-   ├─ Distinct shifted value indices: 41,323
+└─ Distinct value indices: 73,029
+   ├─ Distinct shifted value indices: 41,324
    └─ Distinct unshifted value indices: 31,705
 
 Value Vector

--- a/crates/examples/snapshots/bitcoin_p2pkh.snap
+++ b/crates/examples/snapshots/bitcoin_p2pkh.snap
@@ -1,28 +1,28 @@
 bitcoin_p2pkh circuit
 --
 Gates & Instructions
-├─ Number of gates: 443,617
-└─ Number of evaluation instructions: 531,244
+├─ Number of gates: 443,627
+└─ Number of evaluation instructions: 531,254
 
 Constraints
-├─ AND constraints: 383,994 used (73.2% of 2^19)
-│  [▓▓▓▓▓▓▓░░░] spare: 140,294
+├─ AND constraints: 384,004 used (73.2% of 2^19)
+│  [▓▓▓▓▓▓▓░░░] spare: 140,284
 ├─ MUL constraints: 48,536 used (74.1% of 2^16)
 │  [▓▓▓▓▓▓▓░░░] spare: 17,000
-└─ Distinct value indices: 860,769
-   ├─ Distinct shifted value indices: 408,713
-   └─ Distinct unshifted value indices: 452,056
+└─ Distinct value indices: 860,790
+   ├─ Distinct shifted value indices: 408,724
+   └─ Distinct unshifted value indices: 452,066
 
 Value Vector
 ├─ Public Section: 115 used (89.8% of 2^7)
 │  [▓▓▓▓▓▓▓▓░░] spare: 13
 │  ├─ Constants: 115
 │  └─ Inout: 0
-├─ Private Section: 451,947 used (86.2%)
-│  [▓▓▓▓▓▓▓▓░░] spare: 72,213
+├─ Private Section: 451,957 used (86.2%)
+│  [▓▓▓▓▓▓▓▓░░] spare: 72,203
 │  ├─ Witness: 9
-│  └─ Internal: 451,938
-├─ Total Committed: 452,062 used (86.2% of 2^19)
-│  [▓▓▓▓▓▓▓▓░░] spare: 72,226
-└─ Scratch (uncommitted): 517,890
+│  └─ Internal: 451,948
+├─ Total Committed: 452,072 used (86.2% of 2^19)
+│  [▓▓▓▓▓▓▓▓░░] spare: 72,216
+└─ Scratch (uncommitted): 376,629
 

--- a/crates/examples/snapshots/bitcoin_p2pkh.snap
+++ b/crates/examples/snapshots/bitcoin_p2pkh.snap
@@ -5,24 +5,24 @@ Gates & Instructions
 └─ Number of evaluation instructions: 531,244
 
 Constraints
-├─ AND constraints: 385,736 used (73.6% of 2^19)
-│  [▓▓▓▓▓▓▓░░░] spare: 138,552
+├─ AND constraints: 383,994 used (73.2% of 2^19)
+│  [▓▓▓▓▓▓▓░░░] spare: 140,294
 ├─ MUL constraints: 48,536 used (74.1% of 2^16)
 │  [▓▓▓▓▓▓▓░░░] spare: 17,000
-└─ Distinct value indices: 863,397
-   ├─ Distinct shifted value indices: 409,599
-   └─ Distinct unshifted value indices: 453,798
+└─ Distinct value indices: 860,769
+   ├─ Distinct shifted value indices: 408,713
+   └─ Distinct unshifted value indices: 452,056
 
 Value Vector
 ├─ Public Section: 115 used (89.8% of 2^7)
 │  [▓▓▓▓▓▓▓▓░░] spare: 13
 │  ├─ Constants: 115
 │  └─ Inout: 0
-├─ Private Section: 453,689 used (86.6%)
-│  [▓▓▓▓▓▓▓▓░░] spare: 70,471
+├─ Private Section: 451,947 used (86.2%)
+│  [▓▓▓▓▓▓▓▓░░] spare: 72,213
 │  ├─ Witness: 9
-│  └─ Internal: 453,680
-├─ Total Committed: 453,804 used (86.6% of 2^19)
-│  [▓▓▓▓▓▓▓▓░░] spare: 70,484
-└─ Scratch (uncommitted): 516,148
+│  └─ Internal: 451,938
+├─ Total Committed: 452,062 used (86.2% of 2^19)
+│  [▓▓▓▓▓▓▓▓░░] spare: 72,226
+└─ Scratch (uncommitted): 517,890
 

--- a/crates/examples/snapshots/blake2s.snap
+++ b/crates/examples/snapshots/blake2s.snap
@@ -5,24 +5,24 @@ Gates & Instructions
 └─ Number of evaluation instructions: 18,488
 
 Constraints
-├─ AND constraints: 16,820 used (51.3% of 2^15)
-│  [▓▓▓▓▓░░░░░] spare: 15,948
+├─ AND constraints: 13,656 used (83.3% of 2^14)
+│  [▓▓▓▓▓▓▓▓░░] spare: 2,728
 ├─ MUL constraints: 0 used (0.0% of 2^0)
 │  [░░░░░░░░░░] spare: 1
-└─ Distinct value indices: 38,496
-   ├─ Distinct shifted value indices: 21,532
-   └─ Distinct unshifted value indices: 16,964
+└─ Distinct value indices: 35,723
+   ├─ Distinct shifted value indices: 21,920
+   └─ Distinct unshifted value indices: 13,803
 
 Value Vector
 ├─ Public Section: 28 used (87.5% of 2^5)
 │  [▓▓▓▓▓▓▓▓░░] spare: 4
 │  ├─ Constants: 28
 │  └─ Inout: 0
-├─ Private Section: 16,948 used (51.8%)
-│  [▓▓▓▓▓░░░░░] spare: 15,788
+├─ Private Section: 13,784 used (84.3%)
+│  [▓▓▓▓▓▓▓▓░░] spare: 2,568
 │  ├─ Witness: 136
-│  └─ Internal: 16,812
-├─ Total Committed: 16,976 used (51.8% of 2^15)
-│  [▓▓▓▓▓░░░░░] spare: 15,792
-└─ Scratch (uncommitted): 9,348
+│  └─ Internal: 13,648
+├─ Total Committed: 13,812 used (84.3% of 2^14)
+│  [▓▓▓▓▓▓▓▓░░] spare: 2,572
+└─ Scratch (uncommitted): 12,512
 

--- a/crates/examples/snapshots/blake2s.snap
+++ b/crates/examples/snapshots/blake2s.snap
@@ -9,8 +9,8 @@ Constraints
 │  [▓▓▓▓▓▓▓▓░░] spare: 2,728
 ├─ MUL constraints: 0 used (0.0% of 2^0)
 │  [░░░░░░░░░░] spare: 1
-└─ Distinct value indices: 35,723
-   ├─ Distinct shifted value indices: 21,920
+└─ Distinct value indices: 35,724
+   ├─ Distinct shifted value indices: 21,921
    └─ Distinct unshifted value indices: 13,803
 
 Value Vector

--- a/crates/examples/snapshots/ethsign.snap
+++ b/crates/examples/snapshots/ethsign.snap
@@ -24,5 +24,5 @@ Value Vector
 │  └─ Internal: 254,066
 ├─ Total Committed: 254,227 used (97.0% of 2^18)
 │  [▓▓▓▓▓▓▓▓▓░] spare: 7,917
-└─ Scratch (uncommitted): 274,230
+└─ Scratch (uncommitted): 200,256
 

--- a/crates/examples/snapshots/hashsign.snap
+++ b/crates/examples/snapshots/hashsign.snap
@@ -24,5 +24,5 @@ Value Vector
 │  └─ Internal: 1,580,559
 ├─ Total Committed: 1,595,688 used (76.1% of 2^21)
 │  [▓▓▓▓▓▓▓░░░] spare: 501,464
-└─ Scratch (uncommitted): 1,597,905
+└─ Scratch (uncommitted): 1,597,689
 

--- a/crates/examples/snapshots/hashsign.snap
+++ b/crates/examples/snapshots/hashsign.snap
@@ -5,24 +5,24 @@ Gates & Instructions
 └─ Number of evaluation instructions: 2,886,906
 
 Constraints
-├─ AND constraints: 1,600,305 used (76.3% of 2^21)
-│  [▓▓▓▓▓▓▓░░░] spare: 496,847
+├─ AND constraints: 1,599,999 used (76.3% of 2^21)
+│  [▓▓▓▓▓▓▓░░░] spare: 497,153
 ├─ MUL constraints: 0 used (0.0% of 2^0)
 │  [░░░░░░░░░░] spare: 1
-└─ Distinct value indices: 2,709,247
+└─ Distinct value indices: 2,708,941
    ├─ Distinct shifted value indices: 1,113,253
-   └─ Distinct unshifted value indices: 1,595,994
+   └─ Distinct unshifted value indices: 1,595,688
 
 Value Vector
 ├─ Public Section: 396 used (77.3% of 2^9)
 │  [▓▓▓▓▓▓▓░░░] spare: 116
 │  ├─ Constants: 376
 │  └─ Inout: 20
-├─ Private Section: 1,595,598 used (76.1%)
-│  [▓▓▓▓▓▓▓░░░] spare: 501,042
+├─ Private Section: 1,595,292 used (76.1%)
+│  [▓▓▓▓▓▓▓░░░] spare: 501,348
 │  ├─ Witness: 14,733
-│  └─ Internal: 1,580,865
-├─ Total Committed: 1,595,994 used (76.1% of 2^21)
-│  [▓▓▓▓▓▓▓░░░] spare: 501,158
-└─ Scratch (uncommitted): 1,597,599
+│  └─ Internal: 1,580,559
+├─ Total Committed: 1,595,688 used (76.1% of 2^21)
+│  [▓▓▓▓▓▓▓░░░] spare: 501,464
+└─ Scratch (uncommitted): 1,597,905
 

--- a/crates/examples/snapshots/sha256.snap
+++ b/crates/examples/snapshots/sha256.snap
@@ -9,8 +9,8 @@ Constraints
 │  [▓▓▓▓▓░░░░░] spare: 15,822
 ├─ MUL constraints: 0 used (0.0% of 2^0)
 │  [░░░░░░░░░░] spare: 1
-└─ Distinct value indices: 39,499
-   ├─ Distinct shifted value indices: 22,458
+└─ Distinct value indices: 39,500
+   ├─ Distinct shifted value indices: 22,459
    └─ Distinct unshifted value indices: 17,041
 
 Value Vector

--- a/crates/examples/snapshots/sha256.snap
+++ b/crates/examples/snapshots/sha256.snap
@@ -5,24 +5,24 @@ Gates & Instructions
 └─ Number of evaluation instructions: 39,462
 
 Constraints
-├─ AND constraints: 24,074 used (73.5% of 2^15)
-│  [▓▓▓▓▓▓▓░░░] spare: 8,694
+├─ AND constraints: 16,946 used (51.7% of 2^15)
+│  [▓▓▓▓▓░░░░░] spare: 15,822
 ├─ MUL constraints: 0 used (0.0% of 2^0)
 │  [░░░░░░░░░░] spare: 1
-└─ Distinct value indices: 46,627
+└─ Distinct value indices: 39,499
    ├─ Distinct shifted value indices: 22,458
-   └─ Distinct unshifted value indices: 24,169
+   └─ Distinct unshifted value indices: 17,041
 
 Value Vector
 ├─ Public Section: 357 used (69.7% of 2^9)
 │  [▓▓▓▓▓▓░░░░] spare: 155
 │  ├─ Constants: 225
 │  └─ Inout: 132
-├─ Private Section: 23,812 used (73.8%)
-│  [▓▓▓▓▓▓▓░░░] spare: 8,444
+├─ Private Section: 16,684 used (51.7%)
+│  [▓▓▓▓▓░░░░░] spare: 15,572
 │  ├─ Witness: 273
-│  └─ Internal: 23,539
-├─ Total Committed: 24,169 used (73.8% of 2^15)
-│  [▓▓▓▓▓▓▓░░░] spare: 8,599
-└─ Scratch (uncommitted): 25,879
+│  └─ Internal: 16,411
+├─ Total Committed: 17,041 used (52.0% of 2^15)
+│  [▓▓▓▓▓░░░░░] spare: 15,727
+└─ Scratch (uncommitted): 33,007
 

--- a/crates/examples/snapshots/sha512.snap
+++ b/crates/examples/snapshots/sha512.snap
@@ -24,5 +24,5 @@ Value Vector
 │  └─ Internal: 11,032
 ├─ Total Committed: 11,562 used (70.6% of 2^14)
 │  [▓▓▓▓▓▓▓░░░] spare: 4,822
-└─ Scratch (uncommitted): 29,086
+└─ Scratch (uncommitted): 22,245
 

--- a/crates/examples/snapshots/zklogin.snap
+++ b/crates/examples/snapshots/zklogin.snap
@@ -5,24 +5,24 @@ Gates & Instructions
 └─ Number of evaluation instructions: 597,709
 
 Constraints
-├─ AND constraints: 466,736 used (89.0% of 2^19)
-│  [▓▓▓▓▓▓▓▓░░] spare: 57,552
+├─ AND constraints: 456,241 used (87.0% of 2^19)
+│  [▓▓▓▓▓▓▓▓░░] spare: 68,047
 ├─ MUL constraints: 8,262 used (50.4% of 2^14)
 │  [▓▓▓▓▓░░░░░] spare: 8,122
-└─ Distinct value indices: 831,671
+└─ Distinct value indices: 821,176
    ├─ Distinct shifted value indices: 362,740
-   └─ Distinct unshifted value indices: 468,931
+   └─ Distinct unshifted value indices: 458,436
 
 Value Vector
 ├─ Public Section: 1,018 used (99.4% of 2^10)
 │  [▓▓▓▓▓▓▓▓▓░] spare: 6
 │  ├─ Constants: 716
 │  └─ Inout: 302
-├─ Private Section: 467,914 used (89.4%)
-│  [▓▓▓▓▓▓▓▓░░] spare: 55,350
+├─ Private Section: 457,419 used (87.4%)
+│  [▓▓▓▓▓▓▓▓░░] spare: 65,845
 │  ├─ Witness: 1,788
-│  └─ Internal: 466,126
-├─ Total Committed: 468,932 used (89.4% of 2^19)
-│  [▓▓▓▓▓▓▓▓░░] spare: 55,356
-└─ Scratch (uncommitted): 407,917
+│  └─ Internal: 455,631
+├─ Total Committed: 458,437 used (87.4% of 2^19)
+│  [▓▓▓▓▓▓▓▓░░] spare: 65,851
+└─ Scratch (uncommitted): 418,412
 

--- a/crates/examples/snapshots/zklogin.snap
+++ b/crates/examples/snapshots/zklogin.snap
@@ -9,8 +9,8 @@ Constraints
 │  [▓▓▓▓▓▓▓▓░░] spare: 68,047
 ├─ MUL constraints: 8,262 used (50.4% of 2^14)
 │  [▓▓▓▓▓░░░░░] spare: 8,122
-└─ Distinct value indices: 821,176
-   ├─ Distinct shifted value indices: 362,740
+└─ Distinct value indices: 821,177
+   ├─ Distinct shifted value indices: 362,741
    └─ Distinct unshifted value indices: 458,436
 
 Value Vector
@@ -24,5 +24,5 @@ Value Vector
 │  └─ Internal: 455,631
 ├─ Total Committed: 458,437 used (87.4% of 2^19)
 │  [▓▓▓▓▓▓▓▓░░] spare: 65,851
-└─ Scratch (uncommitted): 418,412
+└─ Scratch (uncommitted): 352,758
 

--- a/crates/frontend/src/compiler/eval_form/builder.rs
+++ b/crates/frontend/src/compiler/eval_form/builder.rs
@@ -158,13 +158,21 @@ impl BytecodeBuilder {
 	}
 
 	// 32-bit operations
-	pub fn emit_iadd_cout32(&mut self, dst_sum: u32, dst_cout: u32, src1: u32, src2: u32) {
+	pub fn emit_iadd32_cin_cout(
+		&mut self,
+		dst_sum: u32,
+		dst_cout: u32,
+		src1: u32,
+		src2: u32,
+		cin: u32,
+	) {
 		self.n_eval_insn += 1;
 		self.emit_u8(0x40);
 		self.emit_reg(dst_sum);
 		self.emit_reg(dst_cout);
 		self.emit_reg(src1);
 		self.emit_reg(src2);
+		self.emit_reg(cin);
 	}
 
 	pub fn emit_rotr32(&mut self, dst: u32, src: u32, rotate: u8) {

--- a/crates/frontend/src/compiler/eval_form/interpreter.rs
+++ b/crates/frontend/src/compiler/eval_form/interpreter.rs
@@ -140,7 +140,7 @@ impl<'a> Interpreter<'a> {
 				0x31 => self.exec_smul(ctx),
 
 				// 32-bit operations
-				0x40 => self.exec_iadd_cout32(ctx),
+				0x40 => self.exec_iadd32_cin_cout(ctx),
 				0x41 => self.exec_rotr32(ctx),
 				0x42 => self.exec_srl32(ctx),
 				0x43 => self.exec_rotr(ctx),
@@ -315,12 +315,15 @@ impl<'a> Interpreter<'a> {
 	}
 
 	// 32-bit operations
-	fn exec_iadd_cout32(&mut self, ctx: &mut ExecutionContext<'_>) {
+	fn exec_iadd32_cin_cout(&mut self, ctx: &mut ExecutionContext<'_>) {
 		let dst_sum = self.read_reg();
 		let dst_cout = self.read_reg();
 		let src1 = self.read_reg();
 		let src2 = self.read_reg();
-		let (sum, cout) = self.load(ctx, src1).iadd_cout_32(self.load(ctx, src2));
+		let cin = self.read_reg();
+		let (sum, cout) = self
+			.load(ctx, src1)
+			.iadd32_cin_cout(self.load(ctx, src2), self.load(ctx, cin));
 		self.store(ctx, dst_sum, sum);
 		self.store(ctx, dst_cout, cout);
 	}

--- a/crates/frontend/src/compiler/gate/iadd32.rs
+++ b/crates/frontend/src/compiler/gate/iadd32.rs
@@ -7,18 +7,18 @@
 //! # Wires
 //!
 //! - `x`, `y`: Input wires for the summands
-//! - `cin` (carry-in): Input wire for the previous carry word. The MSB of each 32-bit half
-//!   is used as the carry-in bit for that half (bit 31 for the lower half, bit 63 for the upper).
+//! - `cin` (carry-in): Input wire for the previous carry word. The MSB of each 32-bit half is used
+//!   as the carry-in bit for that half (bit 31 for the lower half, bit 63 for the upper).
 //! - `z`: Output wire containing the resulting sum
 //! - `cout` (carry-out): Output wire containing a carry word where each bit position indicates
-//!   whether a carry occurred at that position during the addition. In particular, bit 31 and
-//!   bit 63 indicate the carry-out of the lower and upper 32-bit halves respectively.
+//!   whether a carry occurred at that position during the addition. In particular, bit 31 and bit
+//!   63 indicate the carry-out of the lower and upper 32-bit halves respectively.
 //!
 //! # Constraints
 //!
 //! The gate generates 1 AND constraint and 1 linear constraint:
-//! 1. Carry propagation: `(x ⊕ ci) ∧ (y ⊕ ci) = cout ⊕ ci`
-//!    where `ci = (cout <<₃₂ 1) ⊕ (cin >>₃₂ 31)`
+//! 1. Carry propagation: `(x ⊕ ci) ∧ (y ⊕ ci) = cout ⊕ ci` where `ci = (cout <<₃₂ 1) ⊕ (cin >>₃₂
+//!    31)`
 //! 2. Result: `z = x ⊕ y ⊕ ci`
 //!
 //! `<<₃₂` and `>>₃₂` denote shifts that operate independently on each 32-bit half.

--- a/crates/frontend/src/compiler/gate/iadd32.rs
+++ b/crates/frontend/src/compiler/gate/iadd32.rs
@@ -1,31 +1,28 @@
 // Copyright 2025 Irreducible Inc.
-//! 32-bit unsigned integer addition with carry propagation.
+//! Parallel 32-bit unsigned integer addition with carry propagation.
 //!
-//! Returns `z = (x + y) & MASK_32` and `cout` containing carry bits.
-//!
-//! # Algorithm
-//!
-//! Performs 32-bit addition by computing the full 64-bit result and masking:
-//! 1. Compute carry bits `cout` from `x + y` using carry propagation
-//! 2. Extract the lower 32 bits: `z = (x ⊕ y ⊕ (cout << 1)) ∧ MASK_32`
+//! Performs simultaneous independent 32-bit additions on the upper and lower 32-bit halves of
+//! the 64-bit word (like [`sll32`](super::sll32) operates on independent halves). Returns
+//! `z = x + y` (with carry not crossing the 32-bit boundary) and `cout` containing carry bits.
 //!
 //! # Constraints
 //!
-//! The gate generates 2 AND constraints:
-//! 1. Carry propagation: `(x ⊕ (cout << 1)) ∧ (y ⊕ (cout << 1)) = cout ⊕ (cout << 1)`
-//! 2. Result masking: `(x ⊕ y ⊕ (cout << 1)) ∧ MASK_32 = z`
-
-use binius_core::word::Word;
+//! The gate generates 1 AND constraint and 1 linear constraint:
+//! 1. Carry propagation: `(x ⊕ (cout <<₃₂ 1)) ∧ (y ⊕ (cout <<₃₂ 1)) = cout ⊕ (cout <<₃₂ 1)`
+//! 2. Result: `z = x ⊕ y ⊕ (cout <<₃₂ 1)`
+//!
+//! where `<<₃₂` denotes [`sll32`](super::sll32), a shift that operates independently on each
+//! 32-bit half.
 
 use crate::compiler::{
-	constraint_builder::{ConstraintBuilder, sll, xor2, xor3},
+	constraint_builder::{ConstraintBuilder, sll32, xor2, xor3},
 	gate::opcode::OpcodeShape,
 	gate_graph::{Gate, GateData, GateParam, Wire},
 };
 
 pub fn shape() -> OpcodeShape {
 	OpcodeShape {
-		const_in: &[Word::MASK_32],
+		const_in: &[],
 		n_in: 2,
 		n_out: 1,
 		n_aux: 1,
@@ -36,38 +33,31 @@ pub fn shape() -> OpcodeShape {
 
 pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) {
 	let GateParam {
-		constants,
 		inputs,
 		outputs,
 		aux,
 		..
 	} = data.gate_param();
-	let [mask32] = constants else { unreachable!() };
 	let [x, y] = inputs else { unreachable!() };
 	let [z] = outputs else { unreachable!() };
 	let [cout] = aux else { unreachable!() };
 
-	let cout_sll_1 = sll(*cout, 1);
+	let cin = sll32(*cout, 1);
 
 	// Constraint 1: Carry propagation
 	//
 	// (x ⊕ (cout << 1)) ∧ (y ⊕ (cout << 1)) = cout ⊕ (cout << 1)
 	builder
 		.and()
-		.a(xor2(*x, cout_sll_1))
-		.b(xor2(*y, cout_sll_1))
-		.c(xor2(*cout, cout_sll_1))
+		.a(xor2(*x, cin))
+		.b(xor2(*y, cin))
+		.c(xor2(*cout, cin))
 		.build();
 
-	// Constraint 2: Result masking
+	// Constraint 2: Result
 	//
-	// (x ⊕ y ⊕ (cout << 1)) ∧ MASK_32 = z
-	builder
-		.and()
-		.a(xor3(*x, *y, cout_sll_1))
-		.b(*mask32)
-		.c(*z)
-		.build();
+	// z = x ⊕ y ⊕ (cout <<₃₂ 1)
+	builder.linear().dst(*z).rhs(xor3(*x, *y, cin)).build();
 }
 
 pub fn emit_eval_bytecode(

--- a/crates/frontend/src/compiler/gate/iadd32.rs
+++ b/crates/frontend/src/compiler/gate/iadd32.rs
@@ -1,21 +1,30 @@
 // Copyright 2025 Irreducible Inc.
-//! Parallel 32-bit unsigned integer addition with carry propagation.
+//! Parallel 32-bit unsigned integer addition with carry-in and carry-out.
 //!
 //! Performs simultaneous independent 32-bit additions on the upper and lower 32-bit halves of
-//! the 64-bit word (like [`sll32`](super::sll32) operates on independent halves). Returns
-//! `z = x + y` (with carry not crossing the 32-bit boundary) and `cout` containing carry bits.
+//! the 64-bit word (like [`sll32`](super::sll32) operates on independent halves).
+//!
+//! # Wires
+//!
+//! - `x`, `y`: Input wires for the summands
+//! - `cin` (carry-in): Input wire for the previous carry word. The MSB of each 32-bit half
+//!   is used as the carry-in bit for that half (bit 31 for the lower half, bit 63 for the upper).
+//! - `z`: Output wire containing the resulting sum
+//! - `cout` (carry-out): Output wire containing a carry word where each bit position indicates
+//!   whether a carry occurred at that position during the addition. In particular, bit 31 and
+//!   bit 63 indicate the carry-out of the lower and upper 32-bit halves respectively.
 //!
 //! # Constraints
 //!
 //! The gate generates 1 AND constraint and 1 linear constraint:
-//! 1. Carry propagation: `(x ⊕ (cout <<₃₂ 1)) ∧ (y ⊕ (cout <<₃₂ 1)) = cout ⊕ (cout <<₃₂ 1)`
-//! 2. Result: `z = x ⊕ y ⊕ (cout <<₃₂ 1)`
+//! 1. Carry propagation: `(x ⊕ ci) ∧ (y ⊕ ci) = cout ⊕ ci`
+//!    where `ci = (cout <<₃₂ 1) ⊕ (cin >>₃₂ 31)`
+//! 2. Result: `z = x ⊕ y ⊕ ci`
 //!
-//! where `<<₃₂` denotes [`sll32`](super::sll32), a shift that operates independently on each
-//! 32-bit half.
+//! `<<₃₂` and `>>₃₂` denote shifts that operate independently on each 32-bit half.
 
 use crate::compiler::{
-	constraint_builder::{ConstraintBuilder, sll32, xor2, xor3},
+	constraint_builder::{ConstraintBuilder, sll32, srl32, xor3, xor4},
 	gate::opcode::OpcodeShape,
 	gate_graph::{Gate, GateData, GateParam, Wire},
 };
@@ -23,9 +32,9 @@ use crate::compiler::{
 pub fn shape() -> OpcodeShape {
 	OpcodeShape {
 		const_in: &[],
-		n_in: 2,
-		n_out: 1,
-		n_aux: 1,
+		n_in: 3,
+		n_out: 2,
+		n_aux: 0,
 		n_scratch: 0,
 		n_imm: 0,
 	}
@@ -33,31 +42,33 @@ pub fn shape() -> OpcodeShape {
 
 pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) {
 	let GateParam {
-		inputs,
-		outputs,
-		aux,
-		..
+		inputs, outputs, ..
 	} = data.gate_param();
-	let [x, y] = inputs else { unreachable!() };
-	let [z] = outputs else { unreachable!() };
-	let [cout] = aux else { unreachable!() };
+	let [x, y, cin] = inputs else { unreachable!() };
+	let [z, cout] = outputs else { unreachable!() };
 
-	let cin = sll32(*cout, 1);
+	let cout_shifted = sll32(*cout, 1);
+	let cin_bit = srl32(*cin, 31);
 
 	// Constraint 1: Carry propagation
 	//
-	// (x ⊕ (cout << 1)) ∧ (y ⊕ (cout << 1)) = cout ⊕ (cout << 1)
+	// (x ⊕ ci) ∧ (y ⊕ ci) = cout ⊕ ci
+	// where ci = (cout <<₃₂ 1) ⊕ (cin >>₃₂ 31)
 	builder
 		.and()
-		.a(xor2(*x, cin))
-		.b(xor2(*y, cin))
-		.c(xor2(*cout, cin))
+		.a(xor3(*x, cout_shifted, cin_bit))
+		.b(xor3(*y, cout_shifted, cin_bit))
+		.c(xor3(*cout, cout_shifted, cin_bit))
 		.build();
 
 	// Constraint 2: Result
 	//
-	// z = x ⊕ y ⊕ (cout <<₃₂ 1)
-	builder.linear().dst(*z).rhs(xor3(*x, *y, cin)).build();
+	// z = x ⊕ y ⊕ ci
+	builder
+		.linear()
+		.dst(*z)
+		.rhs(xor4(*x, *y, cout_shifted, cin_bit))
+		.build();
 }
 
 pub fn emit_eval_bytecode(
@@ -67,18 +78,15 @@ pub fn emit_eval_bytecode(
 	wire_to_reg: impl Fn(Wire) -> u32,
 ) {
 	let GateParam {
-		inputs,
-		outputs,
-		aux,
-		..
+		inputs, outputs, ..
 	} = data.gate_param();
-	let [a, b] = inputs else { unreachable!() };
-	let [sum] = outputs else { unreachable!() };
-	let [cout] = aux else { unreachable!() };
-	builder.emit_iadd_cout32(
+	let [a, b, cin] = inputs else { unreachable!() };
+	let [sum, cout] = outputs else { unreachable!() };
+	builder.emit_iadd32_cin_cout(
 		wire_to_reg(*sum),
 		wire_to_reg(*cout),
 		wire_to_reg(*a),
 		wire_to_reg(*b),
+		wire_to_reg(*cin),
 	);
 }

--- a/crates/frontend/src/compiler/gate/iadd_cin_cout.rs
+++ b/crates/frontend/src/compiler/gate/iadd_cin_cout.rs
@@ -40,7 +40,7 @@ pub fn shape() -> OpcodeShape {
 		const_in: &[Word::ALL_ONE],
 		n_in: 3,
 		n_out: 2,
-		n_aux: 1,
+		n_aux: 0,
 		n_scratch: 0,
 		n_imm: 0,
 	}

--- a/crates/frontend/src/compiler/mod.rs
+++ b/crates/frontend/src/compiler/mod.rs
@@ -535,6 +535,19 @@ impl CircuitBuilder {
 		(sum, cout)
 	}
 
+	/// 64-bit integer addition returning the sum and carry-out.
+	///
+	/// Equivalent to [`iadd_cin_cout`](Self::iadd_cin_cout) with zero carry-in.
+	///
+	/// # Cost
+	///
+	/// - 1 AND constraint,
+	/// - 1 linear constraint.
+	pub fn iadd(&self, a: Wire, b: Wire) -> (Wire, Wire) {
+		let zero = self.add_constant(Word::ZERO);
+		self.iadd_cin_cout(a, b, zero)
+	}
+
 	/// 64-bit integer addition with carry input and output.
 	///
 	/// Performs full 64-bit unsigned addition of two wires plus a carry input.

--- a/crates/frontend/src/compiler/mod.rs
+++ b/crates/frontend/src/compiler/mod.rs
@@ -499,18 +499,40 @@ impl CircuitBuilder {
 		z
 	}
 
-	/// 32-bit integer addition.
+	/// Parallel 32-bit integer addition.
 	///
-	/// Performs a 32-bit integer addition of two wires. The high bits of the result are discarded.
+	/// Performs simultaneous independent 32-bit additions on the upper and lower halves.
+	/// Equivalent to [`iadd32_cin_cout`](Self::iadd32_cin_cout) with zero carry-in,
+	/// discarding the carry-out.
 	///
 	/// # Cost
 	///
-	/// 2 AND constraints.
+	/// 1 AND constraint, 1 linear constraint.
 	pub fn iadd_32(&self, a: Wire, b: Wire) -> Wire {
-		let z = self.add_internal();
+		let cin = self.add_constant(Word::ZERO);
+		let (sum, _cout) = self.iadd32_cin_cout(a, b, cin);
+		sum
+	}
+
+	/// Parallel 32-bit integer addition with carry-in and carry-out.
+	///
+	/// Performs simultaneous independent 32-bit additions on the upper and lower halves
+	/// of the 64-bit word, with per-half carry-in and carry-out.
+	///
+	/// The carry-in for each half is taken from the MSB of that half in `cin`:
+	/// bit 31 for the lower half, bit 63 for the upper half. The carry-out
+	/// is a full carry word where bit 31 and bit 63 indicate the carry-out
+	/// of the lower and upper halves respectively.
+	///
+	/// # Cost
+	///
+	/// 1 AND constraint, 1 linear constraint.
+	pub fn iadd32_cin_cout(&self, a: Wire, b: Wire, cin: Wire) -> (Wire, Wire) {
+		let sum = self.add_internal();
+		let cout = self.add_internal();
 		let mut graph = self.graph_mut();
-		graph.emit_gate(self.current_path, Opcode::Iadd32, [a, b], [z]);
-		z
+		graph.emit_gate(self.current_path, Opcode::Iadd32, [a, b, cin], [sum, cout]);
+		(sum, cout)
 	}
 
 	/// 64-bit integer addition with carry input and output.


### PR DESCRIPTION
## Summary

- Replace the iadd32 gate's MASK_32 AND constraint with a linear constraint by performing simultaneous independent 32-bit additions on upper and lower halves (like sll32/srl32). This saves one AND constraint per iadd32 gate.
- Update `Word::iadd_cout_32` to do parallel 32-bit half additions to match. Remove the now-unused `Word::rotr_32`.
- Refactor `blake3_compress` to use a precomputed `MSG_SCHEDULE` table indexed by round, matching the [BLAKE3 reference implementation](https://github.com/BLAKE3-team/BLAKE3/blob/master/src/portable.rs) for easier review.

## Test plan

- `cargo test -p binius-core` — validates `Word::iadd_cout_32` with parallel halves
- `cargo test -p binius-frontend` — validates iadd32 gate constraints
- `cargo test -p binius-circuits` — validates blake3 compress and fixed-length hashing
- `cargo doc --no-deps --document-private-items` — docs build cleanly
