### PR TITLE
Add cin-less Iadd and Iadd32 gates and migrate call sites

### DIFF
--- a/crates/circuits/src/blake2b/circuit.rs
+++ b/crates/circuits/src/blake2b/circuit.rs
@@ -276,11 +276,9 @@ pub fn g_mixing(
 	x: Wire,
 	y: Wire,
 ) {
-	let zero = builder.add_constant(Word::ZERO);
-
 	// a = a + b + x
-	let (temp1, _) = builder.iadd_cin_cout(v[a], v[b], zero);
-	let (v_a_new1, _) = builder.iadd_cin_cout(temp1, x, zero);
+	let (temp1, _) = builder.iadd(v[a], v[b]);
+	let (v_a_new1, _) = builder.iadd(temp1, x);
 	v[a] = v_a_new1;
 
 	// d = rotr64(d ^ a, 32)
@@ -288,7 +286,7 @@ pub fn g_mixing(
 	v[d] = builder.rotr(xor1, 32);
 
 	// c = c + d
-	let (v_c_new1, _) = builder.iadd_cin_cout(v[c], v[d], zero);
+	let (v_c_new1, _) = builder.iadd(v[c], v[d]);
 	v[c] = v_c_new1;
 
 	// b = rotr64(b ^ c, 24)
@@ -296,8 +294,8 @@ pub fn g_mixing(
 	v[b] = builder.rotr(xor2, 24);
 
 	// a = a + b + y
-	let (temp2, _) = builder.iadd_cin_cout(v[a], v[b], zero);
-	let (v_a_new2, _) = builder.iadd_cin_cout(temp2, y, zero);
+	let (temp2, _) = builder.iadd(v[a], v[b]);
+	let (v_a_new2, _) = builder.iadd(temp2, y);
 	v[a] = v_a_new2;
 
 	// d = rotr64(d ^ a, 16)
@@ -305,7 +303,7 @@ pub fn g_mixing(
 	v[d] = builder.rotr(xor3, 16);
 
 	// c = c + d
-	let (v_c_new2, _) = builder.iadd_cin_cout(v[c], v[d], zero);
+	let (v_c_new2, _) = builder.iadd(v[c], v[d]);
 	v[c] = v_c_new2;
 
 	// b = rotr64(b ^ c, 63)

--- a/crates/circuits/src/float64/add.rs
+++ b/crates/circuits/src/float64/add.rs
@@ -174,7 +174,7 @@ fn fp64_align_with_sticky(b: &CircuitBuilder, sig_b: Wire, d: Wire) -> Wire {
 /// - `(sum_norm, exp_add)` If carry occurs, result is shifted right by 1; new sticky = (old R) |
 ///   (old S).
 fn fp64_add_path(b: &CircuitBuilder, sig_a: Wire, s_b: Wire, exp_a: Wire) -> (Wire, Wire) {
-	let (sum_raw, carry_mask) = b.iadd_cin_cout(sig_a, s_b, zero(b));
+	let (sum_raw, carry_mask) = b.iadd(sig_a, s_b);
 
 	// Detect final carry-out (bit63 of carry mask) as 0/1 and as a select mask
 	let carry_bit01 = bit_lsb(b, carry_mask, 63); // 0/1
@@ -195,7 +195,7 @@ fn fp64_add_path(b: &CircuitBuilder, sig_a: Wire, s_b: Wire, exp_a: Wire) -> (Wi
 	let sum_norm = b.select(carry_sel_mask, b.bor(sum_shift1clr, new_s), sum_raw);
 
 	// Increment exponent by carry (0/1)
-	let exp_add = iadd(b, exp_a, carry_bit01);
+	let exp_add = b.iadd(exp_a, carry_bit01).0;
 	(sum_norm, exp_add)
 }
 
@@ -606,7 +606,7 @@ mod tests {
 		let builder = CircuitBuilder::new();
 		let a = builder.add_inout();
 		let b = builder.add_inout();
-		let result = iadd(&builder, a, b);
+		let (result, _) = builder.iadd(a, b);
 		let expected = builder.add_inout();
 		builder.assert_eq("iadd_result", result, expected);
 

--- a/crates/circuits/src/float64/mul.rs
+++ b/crates/circuits/src/float64/mul.rs
@@ -29,7 +29,7 @@ pub fn fp64_mul_prepare(
 	let (m_b, exp_eff_b) = fp64_sig53_and_exp(b, pb);
 
 	// exp_pre = exp_eff_a + exp_eff_b - bias
-	let exp_sum = iadd(b, exp_eff_a, exp_eff_b);
+	let exp_sum = b.iadd(exp_eff_a, exp_eff_b).0;
 	let exp_pre = isub(b, exp_sum, bias);
 
 	// sign = sign_a XOR sign_b
@@ -152,7 +152,7 @@ pub fn float64_mul(builder: &CircuitBuilder, a: Wire, b: Wire) -> Wire {
 	let (sig_round_base_uncut, norm_shift1_bit01) = fp64_mul_make_round_base(builder, m_a, m_b);
 
 	// Exponent bump for normalization: exp_round_base = exp_pre + (norm_shift1?1:0)
-	let exp_round_base = iadd(builder, exp_pre, norm_shift1_bit01);
+	let exp_round_base = builder.iadd(exp_pre, norm_shift1_bit01).0;
 
 	// Pre-round underflow to subnormal domain if needed (same as addition block)
 	let (sig_round_base, exp_for_round, exp_lt_1) =

--- a/crates/circuits/src/float64/utils.rs
+++ b/crates/circuits/src/float64/utils.rs
@@ -41,15 +41,6 @@ pub fn msb_to_lsb01(b: &CircuitBuilder, b_msb: Wire) -> Wire {
 	b.shr(b_msb, 63)
 }
 
-/// Performs integer addition: `a + b`.
-///
-/// This is a wrapper around the circuit builder's integer addition that handles
-/// carry-in/carry-out automatically with zero carry-in.
-pub fn iadd(builder: &CircuitBuilder, a: Wire, b: Wire) -> Wire {
-	let (s, _c) = builder.iadd_cin_cout(a, b, zero(builder));
-	s
-}
-
 /// Performs integer subtraction: `a - b`.
 ///
 /// This is a wrapper around the circuit builder's integer subtraction that handles
@@ -227,7 +218,7 @@ pub fn clz64(b: &CircuitBuilder, x: Wire) -> Wire {
 		let t = b.shr(y, 32);
 		let z = b.icmp_eq(t, zero(b));
 		let add32 = b.add_constant_64(32);
-		n = iadd(b, n, b.select(z, add32, zero(b)));
+		n = b.iadd(n, b.select(z, add32, zero(b))).0;
 		y = b.select(z, b.shl(y, 32), y);
 	}
 	// step(16)
@@ -235,7 +226,7 @@ pub fn clz64(b: &CircuitBuilder, x: Wire) -> Wire {
 		let t = b.shr(y, 48);
 		let z = b.icmp_eq(t, zero(b));
 		let add16 = b.add_constant_64(16);
-		n = iadd(b, n, b.select(z, add16, zero(b)));
+		n = b.iadd(n, b.select(z, add16, zero(b))).0;
 		y = b.select(z, b.shl(y, 16), y);
 	}
 	// step(8)
@@ -243,7 +234,7 @@ pub fn clz64(b: &CircuitBuilder, x: Wire) -> Wire {
 		let t = b.shr(y, 56);
 		let z = b.icmp_eq(t, zero(b));
 		let add8 = b.add_constant_64(8);
-		n = iadd(b, n, b.select(z, add8, zero(b)));
+		n = b.iadd(n, b.select(z, add8, zero(b))).0;
 		y = b.select(z, b.shl(y, 8), y);
 	}
 	// step(4)
@@ -251,7 +242,7 @@ pub fn clz64(b: &CircuitBuilder, x: Wire) -> Wire {
 		let t = b.shr(y, 60);
 		let z = b.icmp_eq(t, zero(b));
 		let add4 = b.add_constant_64(4);
-		n = iadd(b, n, b.select(z, add4, zero(b)));
+		n = b.iadd(n, b.select(z, add4, zero(b))).0;
 		y = b.select(z, b.shl(y, 4), y);
 	}
 	// step(2)
@@ -259,14 +250,14 @@ pub fn clz64(b: &CircuitBuilder, x: Wire) -> Wire {
 		let t = b.shr(y, 62);
 		let z = b.icmp_eq(t, zero(b));
 		let add2 = b.add_constant_64(2);
-		n = iadd(b, n, b.select(z, add2, zero(b)));
+		n = b.iadd(n, b.select(z, add2, zero(b))).0;
 		y = b.select(z, b.shl(y, 2), y);
 	}
 	// step(1)
 	{
 		let t = b.shr(y, 63);
 		let z = b.icmp_eq(t, zero(b));
-		n = iadd(b, n, b.select(z, one(b), zero(b)));
+		n = b.iadd(n, b.select(z, one(b), zero(b))).0;
 	}
 	n
 }
@@ -428,12 +419,12 @@ pub fn fp64_round_rne(b: &CircuitBuilder, sig_base: Wire, exp_base: Wire) -> (Wi
 	let round_up01 = b.band(g, tie_or_gt); // 0/1
 
 	let mant_trunc = b.shr(sig_base, 11);
-	let mant_rounded = iadd(b, mant_trunc, round_up01);
+	let mant_rounded = b.iadd(mant_trunc, round_up01).0;
 
 	let overflow01 = bit_lsb(b, mant_rounded, 53); // 0/1
 	let overflow_msb = bit_msb01(b, mant_rounded, 53);
 	let mant_final_53 = b.select(overflow_msb, b.shr(mant_rounded, 1), mant_rounded);
-	let exp_after = iadd(b, exp_base, overflow01);
+	let exp_after = b.iadd(exp_base, overflow01).0;
 
 	(mant_final_53, exp_after, overflow_msb)
 }

--- a/crates/circuits/src/hash_based_sig/chain_verification.rs
+++ b/crates/circuits/src/hash_based_sig/chain_verification.rs
@@ -70,14 +70,13 @@ pub fn circuit_chain(
 	let mut current_hash = signature_hash;
 
 	let one = builder.add_constant(Word::ONE);
-	let zero = builder.add_constant(Word::ZERO);
 	let max_chain_len_wire = builder.add_constant_64(max_chain_len);
 
 	// Build the hash chain
 	for step in 0..max_chain_len {
 		let step_wire = builder.add_constant_64(step);
-		let (position, _) = builder.iadd_cin_cout(step_wire, starting_position, zero);
-		let (position_plus_one, _) = builder.iadd_cin_cout(position, one, zero);
+		let (position, _) = builder.iadd(step_wire, starting_position);
+		let (position_plus_one, _) = builder.iadd(position, one);
 
 		let next_hash = std::array::from_fn(|_| builder.add_witness());
 		let keccak = circuit_chain_hash(

--- a/crates/circuits/src/hash_based_sig/codeword.rs
+++ b/crates/circuits/src/hash_based_sig/codeword.rs
@@ -93,7 +93,7 @@ pub fn codeword(
 
 	let mut codeword_sum = zero;
 	for &coord in coordinates.iter() {
-		let (sum, _carry) = builder.iadd_cin_cout(codeword_sum, coord, zero);
+		let (sum, _carry) = builder.iadd(codeword_sum, coord);
 		codeword_sum = sum;
 	}
 	builder.assert_eq("codeword_sum_check", codeword_sum, target);

--- a/crates/circuits/src/popcount.rs
+++ b/crates/circuits/src/popcount.rs
@@ -71,7 +71,7 @@ pub fn popcount(builder: &mut CircuitBuilder, input: Wire) -> Wire {
 	let n_masked_3333 = builder.band(n_step1, mask_3333);
 	let n_shr_2 = builder.shr(n_step1, 2);
 	let n_shr_2_masked = builder.band(n_shr_2, mask_3333);
-	let (n_step2, _carry) = builder.iadd_cin_cout(n_masked_3333, n_shr_2_masked, zero);
+	let (n_step2, _carry) = builder.iadd(n_masked_3333, n_shr_2_masked);
 
 	// Step 3: Sum adjacent 4-bit groups into 8-bit groups
 	// n = (n + (n >> 4)) & 0x0F0F0F0F0F0F0F0F
@@ -79,25 +79,25 @@ pub fn popcount(builder: &mut CircuitBuilder, input: Wire) -> Wire {
 	// After Step 2, max value per 4-bit group is 4 (0100 binary)
 	// Adding 0100 + 0100 = 1000 (8) still fits in 4 bits, no overflow!
 	let n_shr_4 = builder.shr(n_step2, 4);
-	let (n_sum3, _carry) = builder.iadd_cin_cout(n_step2, n_shr_4, zero);
+	let (n_sum3, _carry) = builder.iadd(n_step2, n_shr_4);
 	let n_step3 = builder.band(n_sum3, mask_0f0f);
 
 	// Step 4: Sum adjacent 8-bit groups into 16-bit groups
 	// n = (n + (n >> 8)) & 0x00FF00FF00FF00FF
 	let n_shr_8 = builder.shr(n_step3, 8);
-	let (n_sum4, _carry) = builder.iadd_cin_cout(n_step3, n_shr_8, zero);
+	let (n_sum4, _carry) = builder.iadd(n_step3, n_shr_8);
 	let n_step4 = builder.band(n_sum4, mask_00ff);
 
 	// Step 5: Sum adjacent 16-bit groups into 32-bit groups
 	// n = (n + (n >> 16)) & 0x0000FFFF0000FFFF
 	let n_shr_16 = builder.shr(n_step4, 16);
-	let (n_sum5, _carry) = builder.iadd_cin_cout(n_step4, n_shr_16, zero);
+	let (n_sum5, _carry) = builder.iadd(n_step4, n_shr_16);
 	let n_step5 = builder.band(n_sum5, mask_0000ffff);
 
 	// Step 6: Sum adjacent 32-bit groups to get final 64-bit result
 	// n = (n + (n >> 32)) & 0x00000000FFFFFFFF
 	let n_shr_32 = builder.shr(n_step5, 32);
-	let (n_sum6, _carry) = builder.iadd_cin_cout(n_step5, n_shr_32, zero);
+	let (n_sum6, _carry) = builder.iadd(n_step5, n_shr_32);
 
 	// The final result is in the lower bits and represents the popcount (0-64)
 	builder.band(n_sum6, mask_00000000ffffffff)

--- a/crates/circuits/src/sha512/compress.rs
+++ b/crates/circuits/src/sha512/compress.rs
@@ -144,14 +144,13 @@ impl Compress {
 		// W[0..15] = block_words
 		w.extend_from_slice(&m);
 
-		let zero = builder.add_constant(Word::ZERO);
 		// W[16..79] computed from previous W values
 		for t in 16..80 {
 			let s0 = small_sigma_0(builder, w[t - 15]);
 			let s1 = small_sigma_1(builder, w[t - 2]);
-			let (p, _carry) = builder.iadd_cin_cout(w[t - 16], s0, zero);
-			let (q, _carry) = builder.iadd_cin_cout(p, w[t - 7], zero);
-			let (w_t, _carry) = builder.iadd_cin_cout(q, s1, zero);
+			let (p, _carry) = builder.iadd(w[t - 16], s0);
+			let (q, _carry) = builder.iadd(p, w[t - 7]);
+			let (w_t, _carry) = builder.iadd(q, s1);
 			w.push(w_t);
 		}
 
@@ -162,14 +161,14 @@ impl Compress {
 		}
 
 		// Add the compressed chunk to the current hash value
-		let (a_out, _carry) = builder.iadd_cin_cout(state_in.0[0], state.0[0], zero);
-		let (b_out, _carry) = builder.iadd_cin_cout(state_in.0[1], state.0[1], zero);
-		let (c_out, _carry) = builder.iadd_cin_cout(state_in.0[2], state.0[2], zero);
-		let (d_out, _carry) = builder.iadd_cin_cout(state_in.0[3], state.0[3], zero);
-		let (e_out, _carry) = builder.iadd_cin_cout(state_in.0[4], state.0[4], zero);
-		let (f_out, _carry) = builder.iadd_cin_cout(state_in.0[5], state.0[5], zero);
-		let (g_out, _carry) = builder.iadd_cin_cout(state_in.0[6], state.0[6], zero);
-		let (h_out, _carry) = builder.iadd_cin_cout(state_in.0[7], state.0[7], zero);
+		let (a_out, _carry) = builder.iadd(state_in.0[0], state.0[0]);
+		let (b_out, _carry) = builder.iadd(state_in.0[1], state.0[1]);
+		let (c_out, _carry) = builder.iadd(state_in.0[2], state.0[2]);
+		let (d_out, _carry) = builder.iadd(state_in.0[3], state.0[3]);
+		let (e_out, _carry) = builder.iadd(state_in.0[4], state.0[4]);
+		let (f_out, _carry) = builder.iadd(state_in.0[5], state.0[5]);
+		let (g_out, _carry) = builder.iadd(state_in.0[6], state.0[6]);
+		let (h_out, _carry) = builder.iadd(state_in.0[7], state.0[7]);
 
 		let state_out = State([a_out, b_out, c_out, d_out, e_out, f_out, g_out, h_out]);
 
@@ -206,25 +205,24 @@ fn round(builder: &CircuitBuilder, round: usize, state: State, w: &[Wire; 80]) -
 
 	let big_sigma_e = big_sigma_1(builder, e);
 	let ch_efg = ch(builder, e, f, g);
-	let zero = builder.add_constant(Word::ZERO);
-	let (t1a, _carry) = builder.iadd_cin_cout(h, big_sigma_e, zero);
-	let (t1b, _carry) = builder.iadd_cin_cout(t1a, ch_efg, zero);
+	let (t1a, _carry) = builder.iadd(h, big_sigma_e);
+	let (t1b, _carry) = builder.iadd(t1a, ch_efg);
 	let rc = builder.add_constant(Word(K[round]));
-	let (t1c, _carry) = builder.iadd_cin_cout(t1b, rc, zero);
-	let (t1, _carry) = builder.iadd_cin_cout(t1c, w[round], zero);
+	let (t1c, _carry) = builder.iadd(t1b, rc);
+	let (t1, _carry) = builder.iadd(t1c, w[round]);
 
 	let big_sigma_a = big_sigma_0(builder, a);
 	let maj_abc = maj(builder, a, b, c);
-	let (t2, _carry) = builder.iadd_cin_cout(big_sigma_a, maj_abc, zero);
+	let (t2, _carry) = builder.iadd(big_sigma_a, maj_abc);
 
 	let h = g;
 	let g = f;
 	let f = e;
-	let (e, _carry) = builder.iadd_cin_cout(d, t1, zero);
+	let (e, _carry) = builder.iadd(d, t1);
 	let d = c;
 	let c = b;
 	let b = a;
-	let (a, _carry) = builder.iadd_cin_cout(t1, t2, zero);
+	let (a, _carry) = builder.iadd(t1, t2);
 
 	State([a, b, c, d, e, f, g, h])
 }

--- a/crates/circuits/src/sha512/mod.rs
+++ b/crates/circuits/src/sha512/mod.rs
@@ -177,7 +177,7 @@ impl Sha512 {
 		// so the high 64 bits are zero. We keep `bitlen` as the low 64-bit portion.
 
 		// end_block_index = floor((len + 16) / 128) using 64-bit add
-		let (sum, _carry) = builder.iadd_cin_cout(len_bytes, builder.add_constant_64(16), zero);
+		let (sum, _carry) = builder.iadd(len_bytes, builder.add_constant_64(16));
 		let end_block_index = builder.shr(sum, 7);
 		// ---- 2b. Final digest selection
 		//

--- a/crates/circuits/src/skein512/mod.rs
+++ b/crates/circuits/src/skein512/mod.rs
@@ -245,8 +245,7 @@ impl Skein512 {
 /// while maintaining the avalanche property essential for cryptographic security.
 fn mix(circuit: &CircuitBuilder, a: Wire, b: Wire, r: u32) -> (Wire, Wire) {
 	// a' = a + b (64-bit addition, ignoring carry)
-	let zero = circuit.add_constant_64(0);
-	let (a_out, _) = circuit.iadd_cin_cout(a, b, zero);
+	let (a_out, _) = circuit.iadd(a, b);
 
 	// b' = ROTL(b, r) ^ a'
 	let b_rotated = circuit.rotl(b, r);
@@ -327,17 +326,16 @@ fn threefish_subkey(circuit: &CircuitBuilder, s: usize, k: [Wire; 9], t: [Wire; 
 
 	// Add tweak components to specific positions
 	// sk[5] += t[s % 3] (64-bit addition, ignoring carry)
-	let zero = circuit.add_constant_64(0);
-	let (sum5, _) = circuit.iadd_cin_cout(subkey[5], t[s % 3], zero);
+	let (sum5, _) = circuit.iadd(subkey[5], t[s % 3]);
 	subkey[5] = sum5;
 
 	// sk[6] += t[(s + 1) % 3] (64-bit addition, ignoring carry)
-	let (sum6, _) = circuit.iadd_cin_cout(subkey[6], t[(s + 1) % 3], zero);
+	let (sum6, _) = circuit.iadd(subkey[6], t[(s + 1) % 3]);
 	subkey[6] = sum6;
 
 	// sk[7] += s (add round number as constant)
 	let round_constant = circuit.add_constant_64(s as u64);
-	let (sum7, _) = circuit.iadd_cin_cout(subkey[7], round_constant, zero);
+	let (sum7, _) = circuit.iadd(subkey[7], round_constant);
 	subkey[7] = sum7;
 
 	subkey
@@ -433,9 +431,8 @@ impl Threefish4RoundsWithInjection {
 	) -> Self {
 		// Inject subkey before the 4 rounds
 		let subkey = threefish_subkey(circuit, group_idx, k, t);
-		let zero = circuit.add_constant_64(0);
 		let mut v_out = std::array::from_fn(|i| {
-			let (sum, _) = circuit.iadd_cin_cout(v_in[i], subkey[i], zero);
+			let (sum, _) = circuit.iadd(v_in[i], subkey[i]);
 			sum
 		});
 
@@ -495,9 +492,8 @@ impl Threefish512Block {
 
 		// Final subkey injection (18th injection after the 72 rounds)
 		let subkey = threefish_subkey(circuit, 18, k, t);
-		let zero = circuit.add_constant_64(0);
 		let v_out = std::array::from_fn(|i| {
-			let (sum, _) = circuit.iadd_cin_cout(v[i], subkey[i], zero);
+			let (sum, _) = circuit.iadd(v[i], subkey[i]);
 			sum
 		});
 

--- a/crates/examples/examples/tutorials/basics_nondeterministic.rs
+++ b/crates/examples/examples/tutorials/basics_nondeterministic.rs
@@ -23,8 +23,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 	// Verify: dividend = divisor × quotient + remainder
 	let (_hi, lo) = builder.imul(divisor[0], quotient[0]);
-	let zero_wire = builder.add_constant_64(0);
-	let sum = builder.iadd_cin_cout(lo, remainder[0], zero_wire).0;
+	let sum = builder.iadd(lo, remainder[0]).0;
 	builder.assert_eq("modulo_check", sum, dividend[0]);
 
 	// Also verify remainder < divisor (for completeness)

--- a/crates/examples/examples/tutorials/basics_word_semantics.rs
+++ b/crates/examples/examples/tutorials/basics_word_semantics.rs
@@ -25,8 +25,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 	// Same 64-bit words, different operations
 	let xor_result = builder.bxor(a, b);
-	let zero = builder.add_constant_64(0);
-	let (int_sum, _) = builder.iadd_cin_cout(x, y, zero);
+	let (int_sum, _) = builder.iadd(x, y);
 	let cmp_result = builder.icmp_ult(p, q);
 	let bit_pattern = builder.band(v, mask);
 

--- a/crates/examples/examples/tutorials/circuits_control_flow.rs
+++ b/crates/examples/examples/tutorials/circuits_control_flow.rs
@@ -187,7 +187,7 @@ fn demo_early_exit() -> Result<()> {
 
 		// Mask value based on found_zero flag
 		let to_add = builder.select(found_zero, zero, value);
-		let (new_sum, _) = builder.iadd_cin_cout(sum, to_add, zero);
+		let (new_sum, _) = builder.iadd(sum, to_add);
 		sum = new_sum;
 
 		// Sticky flag - once set, stays set
@@ -234,7 +234,7 @@ fn demo_variable_length() -> Result<()> {
 
 		let value = builder.select(in_bounds, data_wire, zero);
 
-		let (new_sum, _) = builder.iadd_cin_cout(sum, value, zero);
+		let (new_sum, _) = builder.iadd(sum, value);
 		sum = new_sum;
 	}
 

--- a/crates/examples/snapshots/bitcoin_headers.snap
+++ b/crates/examples/snapshots/bitcoin_headers.snap
@@ -9,8 +9,8 @@ Constraints
 │  [▓▓▓▓▓▓▓▓▓░] spare: 888
 ├─ MUL constraints: 0 used (0.0% of 2^0)
 │  [░░░░░░░░░░] spare: 1
-└─ Distinct value indices: 73,029
-   ├─ Distinct shifted value indices: 41,324
+└─ Distinct value indices: 73,028
+   ├─ Distinct shifted value indices: 41,323
    └─ Distinct unshifted value indices: 31,705
 
 Value Vector

--- a/crates/examples/snapshots/bitcoin_p2pkh.snap
+++ b/crates/examples/snapshots/bitcoin_p2pkh.snap
@@ -9,8 +9,8 @@ Constraints
 │  [▓▓▓▓▓▓▓░░░] spare: 140,284
 ├─ MUL constraints: 48,536 used (74.1% of 2^16)
 │  [▓▓▓▓▓▓▓░░░] spare: 17,000
-└─ Distinct value indices: 860,790
-   ├─ Distinct shifted value indices: 408,724
+└─ Distinct value indices: 860,789
+   ├─ Distinct shifted value indices: 408,723
    └─ Distinct unshifted value indices: 452,066
 
 Value Vector

--- a/crates/examples/snapshots/blake2b.snap
+++ b/crates/examples/snapshots/blake2b.snap
@@ -9,8 +9,8 @@ Constraints
 │  [▓▓▓▓▓▓▓▓▓░] spare: 29
 ├─ MUL constraints: 0 used (0.0% of 2^0)
 │  [░░░░░░░░░░] spare: 1
-└─ Distinct value indices: 21,680
-   ├─ Distinct shifted value indices: 13,375
+└─ Distinct value indices: 21,679
+   ├─ Distinct shifted value indices: 13,374
    └─ Distinct unshifted value indices: 8,305
 
 Value Vector
@@ -24,5 +24,5 @@ Value Vector
 │  └─ Internal: 8,155
 ├─ Total Committed: 8,310 used (50.7% of 2^14)
 │  [▓▓▓▓▓░░░░░] spare: 8,074
-└─ Scratch (uncommitted): 11,901
+└─ Scratch (uncommitted): 7,293
 

--- a/crates/examples/snapshots/blake2s.snap
+++ b/crates/examples/snapshots/blake2s.snap
@@ -9,8 +9,8 @@ Constraints
 │  [▓▓▓▓▓▓▓▓░░] spare: 2,728
 ├─ MUL constraints: 0 used (0.0% of 2^0)
 │  [░░░░░░░░░░] spare: 1
-└─ Distinct value indices: 35,724
-   ├─ Distinct shifted value indices: 21,921
+└─ Distinct value indices: 35,723
+   ├─ Distinct shifted value indices: 21,920
    └─ Distinct unshifted value indices: 13,803
 
 Value Vector

--- a/crates/examples/snapshots/sha256.snap
+++ b/crates/examples/snapshots/sha256.snap
@@ -9,8 +9,8 @@ Constraints
 │  [▓▓▓▓▓░░░░░] spare: 15,822
 ├─ MUL constraints: 0 used (0.0% of 2^0)
 │  [░░░░░░░░░░] spare: 1
-└─ Distinct value indices: 39,500
-   ├─ Distinct shifted value indices: 22,459
+└─ Distinct value indices: 39,499
+   ├─ Distinct shifted value indices: 22,458
    └─ Distinct unshifted value indices: 17,041
 
 Value Vector

--- a/crates/examples/snapshots/sha512.snap
+++ b/crates/examples/snapshots/sha512.snap
@@ -9,8 +9,8 @@ Constraints
 │  [▓▓▓▓▓▓░░░░] spare: 5,070
 ├─ MUL constraints: 0 used (0.0% of 2^0)
 │  [░░░░░░░░░░] spare: 1
-└─ Distinct value indices: 26,827
-   ├─ Distinct shifted value indices: 15,265
+└─ Distinct value indices: 26,826
+   ├─ Distinct shifted value indices: 15,264
    └─ Distinct unshifted value indices: 11,562
 
 Value Vector

--- a/crates/examples/snapshots/zklogin.snap
+++ b/crates/examples/snapshots/zklogin.snap
@@ -9,8 +9,8 @@ Constraints
 │  [▓▓▓▓▓▓▓▓░░] spare: 68,047
 ├─ MUL constraints: 8,262 used (50.4% of 2^14)
 │  [▓▓▓▓▓░░░░░] spare: 8,122
-└─ Distinct value indices: 821,177
-   ├─ Distinct shifted value indices: 362,741
+└─ Distinct value indices: 821,176
+   ├─ Distinct shifted value indices: 362,740
    └─ Distinct unshifted value indices: 458,436
 
 Value Vector

--- a/crates/frontend/src/compiler/eval_form/builder.rs
+++ b/crates/frontend/src/compiler/eval_form/builder.rs
@@ -175,6 +175,15 @@ impl BytecodeBuilder {
 		self.emit_reg(cin);
 	}
 
+	pub fn emit_iadd32_cout(&mut self, dst_sum: u32, dst_cout: u32, src1: u32, src2: u32) {
+		self.n_eval_insn += 1;
+		self.emit_u8(0x46);
+		self.emit_reg(dst_sum);
+		self.emit_reg(dst_cout);
+		self.emit_reg(src1);
+		self.emit_reg(src2);
+	}
+
 	pub fn emit_rotr32(&mut self, dst: u32, src: u32, rotate: u8) {
 		self.n_eval_insn += 1;
 		self.emit_u8(0x41);

--- a/crates/frontend/src/compiler/eval_form/interpreter.rs
+++ b/crates/frontend/src/compiler/eval_form/interpreter.rs
@@ -146,6 +146,7 @@ impl<'a> Interpreter<'a> {
 				0x43 => self.exec_rotr(ctx),
 				0x44 => self.exec_sll32(ctx),
 				0x45 => self.exec_sra32(ctx),
+				0x46 => self.exec_iadd32_cout(ctx),
 
 				// Masks
 				0x50 => self.exec_mask_low(ctx),
@@ -324,6 +325,16 @@ impl<'a> Interpreter<'a> {
 		let (sum, cout) = self
 			.load(ctx, src1)
 			.iadd32_cin_cout(self.load(ctx, src2), self.load(ctx, cin));
+		self.store(ctx, dst_sum, sum);
+		self.store(ctx, dst_cout, cout);
+	}
+
+	fn exec_iadd32_cout(&mut self, ctx: &mut ExecutionContext<'_>) {
+		let dst_sum = self.read_reg();
+		let dst_cout = self.read_reg();
+		let src1 = self.read_reg();
+		let src2 = self.read_reg();
+		let (sum, cout) = self.load(ctx, src1).iadd_cout_32(self.load(ctx, src2));
 		self.store(ctx, dst_sum, sum);
 		self.store(ctx, dst_cout, cout);
 	}

--- a/crates/frontend/src/compiler/gate/iadd.rs
+++ b/crates/frontend/src/compiler/gate/iadd.rs
@@ -74,10 +74,5 @@ pub fn emit_eval_bytecode(
 	} = data.gate_param();
 	let [a, b] = inputs else { unreachable!() };
 	let [sum, cout] = outputs else { unreachable!() };
-	builder.emit_iadd_cout(
-		wire_to_reg(*sum),
-		wire_to_reg(*cout),
-		wire_to_reg(*a),
-		wire_to_reg(*b),
-	);
+	builder.emit_iadd_cout(wire_to_reg(*sum), wire_to_reg(*cout), wire_to_reg(*a), wire_to_reg(*b));
 }

--- a/crates/frontend/src/compiler/gate/iadd.rs
+++ b/crates/frontend/src/compiler/gate/iadd.rs
@@ -1,0 +1,83 @@
+// Copyright 2025 Irreducible Inc.
+//! 64-bit unsigned integer addition without carry-in.
+//!
+//! # Wires
+//!
+//! - `a`, `b`: Input wires for the summands
+//! - `sum`: Output wire containing the resulting sum = a + b
+//! - `cout` (carry-out): Output wire containing a carry word where each bit position indicates
+//!   whether a carry occurred at that position during the addition.
+//!
+//! The carry-out is computed as: `cout = (a & b) | ((a ^ b) & ¬sum)`.
+//!
+//! # Constraints
+//!
+//! The gate generates 1 AND constraint and 1 linear constraint:
+//!
+//! 1. Carry propagation: `(a ⊕ (cout << 1)) ∧ (b ⊕ (cout << 1)) = cout ⊕ (cout << 1)`
+//! 2. Sum: `sum = a ⊕ b ⊕ (cout << 1)`
+
+use crate::compiler::{
+	constraint_builder::{ConstraintBuilder, sll, xor2, xor3},
+	gate::opcode::OpcodeShape,
+	gate_graph::{Gate, GateData, GateParam, Wire},
+};
+
+pub fn shape() -> OpcodeShape {
+	OpcodeShape {
+		const_in: &[],
+		n_in: 2,
+		n_out: 2,
+		n_aux: 0,
+		n_scratch: 0,
+		n_imm: 0,
+	}
+}
+
+pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) {
+	let GateParam {
+		inputs, outputs, ..
+	} = data.gate_param();
+	let [a, b] = inputs else { unreachable!() };
+	let [sum, cout] = outputs else { unreachable!() };
+
+	let cout_sll_1 = sll(*cout, 1);
+
+	// Constraint 1: Carry propagation
+	//
+	// (a ⊕ (cout << 1)) ∧ (b ⊕ (cout << 1)) = cout ⊕ (cout << 1)
+	builder
+		.and()
+		.a(xor2(*a, cout_sll_1))
+		.b(xor2(*b, cout_sll_1))
+		.c(xor2(*cout, cout_sll_1))
+		.build();
+
+	// Constraint 2: Sum equality (linear)
+	//
+	// (a ⊕ b ⊕ (cout << 1)) = sum
+	builder
+		.linear()
+		.rhs(xor3(*a, *b, cout_sll_1))
+		.dst(*sum)
+		.build();
+}
+
+pub fn emit_eval_bytecode(
+	_gate: Gate,
+	data: &GateData,
+	builder: &mut crate::compiler::eval_form::BytecodeBuilder,
+	wire_to_reg: impl Fn(Wire) -> u32,
+) {
+	let GateParam {
+		inputs, outputs, ..
+	} = data.gate_param();
+	let [a, b] = inputs else { unreachable!() };
+	let [sum, cout] = outputs else { unreachable!() };
+	builder.emit_iadd_cout(
+		wire_to_reg(*sum),
+		wire_to_reg(*cout),
+		wire_to_reg(*a),
+		wire_to_reg(*b),
+	);
+}

--- a/crates/frontend/src/compiler/gate/iadd32.rs
+++ b/crates/frontend/src/compiler/gate/iadd32.rs
@@ -9,8 +9,8 @@
 //! - `x`, `y`: Input wires for the summands
 //! - `z`: Output wire containing the resulting sum
 //! - `cout` (carry-out): Output wire containing a carry word where each bit position indicates
-//!   whether a carry occurred at that position during the addition. In particular, bit 31 and
-//!   bit 63 indicate the carry-out of the lower and upper 32-bit halves respectively.
+//!   whether a carry occurred at that position during the addition. In particular, bit 31 and bit
+//!   63 indicate the carry-out of the lower and upper 32-bit halves respectively.
 //!
 //! # Constraints
 //!

--- a/crates/frontend/src/compiler/gate/iadd32_cin_cout.rs
+++ b/crates/frontend/src/compiler/gate/iadd32_cin_cout.rs
@@ -1,5 +1,5 @@
 // Copyright 2025 Irreducible Inc.
-//! Parallel 32-bit unsigned integer addition without carry-in.
+//! Parallel 32-bit unsigned integer addition with carry-in and carry-out.
 //!
 //! Performs simultaneous independent 32-bit additions on the upper and lower 32-bit halves of
 //! the 64-bit word (like [`sll32`](super::sll32) operates on independent halves).
@@ -7,21 +7,24 @@
 //! # Wires
 //!
 //! - `x`, `y`: Input wires for the summands
+//! - `cin` (carry-in): Input wire for the previous carry word. The MSB of each 32-bit half is used
+//!   as the carry-in bit for that half (bit 31 for the lower half, bit 63 for the upper).
 //! - `z`: Output wire containing the resulting sum
 //! - `cout` (carry-out): Output wire containing a carry word where each bit position indicates
-//!   whether a carry occurred at that position during the addition. In particular, bit 31 and
-//!   bit 63 indicate the carry-out of the lower and upper 32-bit halves respectively.
+//!   whether a carry occurred at that position during the addition. In particular, bit 31 and bit
+//!   63 indicate the carry-out of the lower and upper 32-bit halves respectively.
 //!
 //! # Constraints
 //!
 //! The gate generates 1 AND constraint and 1 linear constraint:
-//! 1. Carry propagation: `(x ⊕ (cout <<₃₂ 1)) ∧ (y ⊕ (cout <<₃₂ 1)) = cout ⊕ (cout <<₃₂ 1)`
-//! 2. Result: `z = x ⊕ y ⊕ (cout <<₃₂ 1)`
+//! 1. Carry propagation: `(x ⊕ ci) ∧ (y ⊕ ci) = cout ⊕ ci` where `ci = (cout <<₃₂ 1) ⊕ (cin >>₃₂
+//!    31)`
+//! 2. Result: `z = x ⊕ y ⊕ ci`
 //!
-//! `<<₃₂` denotes a shift that operates independently on each 32-bit half.
+//! `<<₃₂` and `>>₃₂` denote shifts that operate independently on each 32-bit half.
 
 use crate::compiler::{
-	constraint_builder::{ConstraintBuilder, sll32, xor2, xor3},
+	constraint_builder::{ConstraintBuilder, sll32, srl32, xor3, xor4},
 	gate::opcode::OpcodeShape,
 	gate_graph::{Gate, GateData, GateParam, Wire},
 };
@@ -29,7 +32,7 @@ use crate::compiler::{
 pub fn shape() -> OpcodeShape {
 	OpcodeShape {
 		const_in: &[],
-		n_in: 2,
+		n_in: 3,
 		n_out: 2,
 		n_aux: 0,
 		n_scratch: 0,
@@ -41,28 +44,30 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 	let GateParam {
 		inputs, outputs, ..
 	} = data.gate_param();
-	let [x, y] = inputs else { unreachable!() };
+	let [x, y, cin] = inputs else { unreachable!() };
 	let [z, cout] = outputs else { unreachable!() };
 
 	let cout_shifted = sll32(*cout, 1);
+	let cin_bit = srl32(*cin, 31);
 
 	// Constraint 1: Carry propagation
 	//
-	// (x ⊕ (cout <<₃₂ 1)) ∧ (y ⊕ (cout <<₃₂ 1)) = cout ⊕ (cout <<₃₂ 1)
+	// (x ⊕ ci) ∧ (y ⊕ ci) = cout ⊕ ci
+	// where ci = (cout <<₃₂ 1) ⊕ (cin >>₃₂ 31)
 	builder
 		.and()
-		.a(xor2(*x, cout_shifted))
-		.b(xor2(*y, cout_shifted))
-		.c(xor2(*cout, cout_shifted))
+		.a(xor3(*x, cout_shifted, cin_bit))
+		.b(xor3(*y, cout_shifted, cin_bit))
+		.c(xor3(*cout, cout_shifted, cin_bit))
 		.build();
 
 	// Constraint 2: Result
 	//
-	// z = x ⊕ y ⊕ (cout <<₃₂ 1)
+	// z = x ⊕ y ⊕ ci
 	builder
 		.linear()
 		.dst(*z)
-		.rhs(xor3(*x, *y, cout_shifted))
+		.rhs(xor4(*x, *y, cout_shifted, cin_bit))
 		.build();
 }
 
@@ -75,12 +80,13 @@ pub fn emit_eval_bytecode(
 	let GateParam {
 		inputs, outputs, ..
 	} = data.gate_param();
-	let [a, b] = inputs else { unreachable!() };
+	let [a, b, cin] = inputs else { unreachable!() };
 	let [sum, cout] = outputs else { unreachable!() };
-	builder.emit_iadd32_cout(
+	builder.emit_iadd32_cin_cout(
 		wire_to_reg(*sum),
 		wire_to_reg(*cout),
 		wire_to_reg(*a),
 		wire_to_reg(*b),
+		wire_to_reg(*cin),
 	);
 }

--- a/crates/frontend/src/compiler/gate/mod.rs
+++ b/crates/frontend/src/compiler/gate/mod.rs
@@ -21,7 +21,9 @@ pub mod bor;
 pub mod bxor;
 pub mod bxor_multi;
 pub mod fax;
+pub mod iadd;
 pub mod iadd32;
+pub mod iadd32_cin_cout;
 pub mod iadd_cin_cout;
 pub mod icmp_eq;
 pub mod icmp_ult;
@@ -47,8 +49,10 @@ pub fn constrain(gate: Gate, graph: &GateGraph, builder: &mut ConstraintBuilder)
 		Opcode::Bor => bor::constrain(gate, data, builder),
 		Opcode::Fax => fax::constrain(gate, data, builder),
 		Opcode::Select => select::constrain(gate, data, builder),
+		Opcode::Iadd => iadd::constrain(gate, data, builder),
 		Opcode::IaddCinCout => iadd_cin_cout::constrain(gate, data, builder),
 		Opcode::Iadd32 => iadd32::constrain(gate, data, builder),
+		Opcode::Iadd32CinCout => iadd32_cin_cout::constrain(gate, data, builder),
 		Opcode::IsubBinBout => isub_bin_bout::constrain(gate, data, builder),
 		Opcode::Sll32 => sll32::constrain(gate, data, builder),
 		Opcode::Srl32 => srl32::constrain(gate, data, builder),
@@ -89,8 +93,12 @@ pub fn emit_gate_bytecode(
 		Opcode::Bor => bor::emit_eval_bytecode(gate, data, builder, wire_to_reg),
 		Opcode::Fax => fax::emit_eval_bytecode(gate, data, builder, wire_to_reg),
 		Opcode::Select => select::emit_eval_bytecode(gate, data, builder, wire_to_reg),
+		Opcode::Iadd => iadd::emit_eval_bytecode(gate, data, builder, wire_to_reg),
 		Opcode::IaddCinCout => iadd_cin_cout::emit_eval_bytecode(gate, data, builder, wire_to_reg),
 		Opcode::Iadd32 => iadd32::emit_eval_bytecode(gate, data, builder, wire_to_reg),
+		Opcode::Iadd32CinCout => {
+			iadd32_cin_cout::emit_eval_bytecode(gate, data, builder, wire_to_reg)
+		}
 		Opcode::IsubBinBout => isub_bin_bout::emit_eval_bytecode(gate, data, builder, wire_to_reg),
 		Opcode::Sll32 => sll32::emit_eval_bytecode(gate, data, builder, wire_to_reg),
 		Opcode::Srl32 => srl32::emit_eval_bytecode(gate, data, builder, wire_to_reg),

--- a/crates/frontend/src/compiler/gate/opcode.rs
+++ b/crates/frontend/src/compiler/gate/opcode.rs
@@ -16,8 +16,10 @@ pub enum Opcode {
 	Select,
 
 	// Arithmetic
+	Iadd,
 	IaddCinCout,
 	Iadd32,
+	Iadd32CinCout,
 	IsubBinBout,
 	Imul,
 	Smul,
@@ -104,8 +106,10 @@ impl Opcode {
 			Opcode::Select => gate::select::shape(),
 
 			// Arithmetic
+			Opcode::Iadd => gate::iadd::shape(),
 			Opcode::IaddCinCout => gate::iadd_cin_cout::shape(),
 			Opcode::Iadd32 => gate::iadd32::shape(),
+			Opcode::Iadd32CinCout => gate::iadd32_cin_cout::shape(),
 			Opcode::IsubBinBout => gate::isub_bin_bout::shape(),
 			Opcode::Imul => gate::imul::shape(),
 			Opcode::Smul => gate::smul::shape(),

--- a/crates/frontend/src/compiler/mod.rs
+++ b/crates/frontend/src/compiler/mod.rs
@@ -501,16 +501,17 @@ impl CircuitBuilder {
 
 	/// Parallel 32-bit integer addition.
 	///
-	/// Performs simultaneous independent 32-bit additions on the upper and lower halves.
-	/// Equivalent to [`iadd32_cin_cout`](Self::iadd32_cin_cout) with zero carry-in,
+	/// Performs simultaneous independent 32-bit additions on the upper and lower halves,
 	/// discarding the carry-out.
 	///
 	/// # Cost
 	///
 	/// 1 AND constraint, 1 linear constraint.
 	pub fn iadd_32(&self, a: Wire, b: Wire) -> Wire {
-		let cin = self.add_constant(Word::ZERO);
-		let (sum, _cout) = self.iadd32_cin_cout(a, b, cin);
+		let sum = self.add_internal();
+		let cout = self.add_internal();
+		let mut graph = self.graph_mut();
+		graph.emit_gate(self.current_path, Opcode::Iadd32, [a, b], [sum, cout]);
 		sum
 	}
 
@@ -531,21 +532,22 @@ impl CircuitBuilder {
 		let sum = self.add_internal();
 		let cout = self.add_internal();
 		let mut graph = self.graph_mut();
-		graph.emit_gate(self.current_path, Opcode::Iadd32, [a, b, cin], [sum, cout]);
+		graph.emit_gate(self.current_path, Opcode::Iadd32CinCout, [a, b, cin], [sum, cout]);
 		(sum, cout)
 	}
 
 	/// 64-bit integer addition returning the sum and carry-out.
-	///
-	/// Equivalent to [`iadd_cin_cout`](Self::iadd_cin_cout) with zero carry-in.
 	///
 	/// # Cost
 	///
 	/// - 1 AND constraint,
 	/// - 1 linear constraint.
 	pub fn iadd(&self, a: Wire, b: Wire) -> (Wire, Wire) {
-		let zero = self.add_constant(Word::ZERO);
-		self.iadd_cin_cout(a, b, zero)
+		let sum = self.add_internal();
+		let cout = self.add_internal();
+		let mut graph = self.graph_mut();
+		graph.emit_gate(self.current_path, Opcode::Iadd, [a, b], [sum, cout]);
+		(sum, cout)
 	}
 
 	/// 64-bit integer addition with carry input and output.


### PR DESCRIPTION
## Summary
- Introduce dedicated `Opcode::Iadd` (64-bit) and `Opcode::Iadd32` (parallel halves) gates that take no carry-in wire. Both still emit sum and cout (free to compute). Rename the old `Opcode::Iadd32` → `Opcode::Iadd32CinCout` for symmetry with `IaddCinCout`. New constraints drop the `cin_msb` XOR term.
- Wire `CircuitBuilder::iadd` / `iadd_32` to emit the new gates directly. No method signature changes; existing `iadd_32` call sites untouched.
- Sweep 41 `iadd_cin_cout(a, b, zero)` sites across binius-circuits and binius-examples to use the new `iadd` helper; delete the redundant `float64::utils::iadd` wrapper.

## Test plan
- [x] `cargo test -p binius-frontend`
- [x] `cargo test -p binius-circuits`
- [x] `cargo test -p binius-core`
- [x] `cargo run --example basics_word_semantics -p binius-examples`
- [x] `cargo run --example basics_nondeterministic -p binius-examples`
- [x] `cargo run --example circuits_control_flow -p binius-examples`
- [x] `cargo clippy --all --all-features --tests --benches -- -D warnings`
