### PR TITLE
Add BLAKE3 compression gadget, 2x SIMD variant, and benchmark

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ assert_matches = "1.5.0"
 auto_impl = "1.3.0"
 base64 = "0.22.1"
 blake2 = "0.10.6"
+blake3 = "1"
 bitcoin = "0.32.7"
 bitcoin_hashes = "0.14.0"
 bytemuck = { version = "1.18.0", features = [

--- a/crates/circuits/Cargo.toml
+++ b/crates/circuits/Cargo.toml
@@ -22,6 +22,7 @@ anyhow.workspace = true
 bitcoin = { workspace = true }
 bitcoin_hashes = { workspace = true }
 blake2 = { workspace = true }
+blake3 = { workspace = true }
 hmac = { workspace = true }
 k256 = { workspace = true, features = ["arithmetic"] }
 rand = { workspace = true, features = ["thread_rng"] }

--- a/crates/circuits/src/blake3/compress.rs
+++ b/crates/circuits/src/blake3/compress.rs
@@ -460,13 +460,8 @@ mod tests {
 				super::super::CHUNK_END,
 			],
 		);
-		let exp0 = ref_compress(
-			&cv,
-			&block,
-			counter0,
-			64,
-			super::super::CHUNK_START | super::super::ROOT,
-		);
+		let exp0 =
+			ref_compress(&cv, &block, counter0, 64, super::super::CHUNK_START | super::super::ROOT);
 		let exp1 = ref_compress(&cv, &block, counter1, 64, super::super::CHUNK_END);
 		assert_eq!(actual[0], exp0);
 		assert_eq!(actual[1], exp1);

--- a/crates/circuits/src/blake3/compress.rs
+++ b/crates/circuits/src/blake3/compress.rs
@@ -1,0 +1,269 @@
+// Copyright 2025 Irreducible Inc.
+//! BLAKE3 compression primitive.
+//!
+//! A BLAKE3 block is 64 bytes (16 × 32-bit words). The compression function mixes an
+//! 8-word chaining value with a 16-word message block, a 64-bit block counter, a byte
+//! count, and a flags word, producing an updated 8-word chaining value.
+//!
+//! The structure mirrors the [reference implementation] from the BLAKE3 crate.
+//!
+//! [reference implementation]: https://github.com/BLAKE3-team/BLAKE3/blob/master/src/portable.rs
+
+use std::array;
+
+use binius_core::word::Word;
+use binius_frontend::{CircuitBuilder, Wire};
+
+use super::{IV, MSG_SCHEDULE};
+
+/// BLAKE3 compression function.
+///
+/// # Arguments
+///
+/// - `cv`: 8 chaining-value words (32-bit each, stored in the low 32 bits of each wire).
+/// - `block`: 16 message words (32-bit each, low 32 bits of each wire, little-endian).
+/// - `counter`: the 64-bit block counter. Low 32 bits are `t_low`, high 32 are `t_high`. The wire
+///   may carry either a genuinely-64-bit counter (multi-chunk) or a 32-bit value with zero high
+///   half (single-chunk).
+/// - `block_len`: byte count for this block, 0..=64. 32-bit value in low 32 bits.
+/// - `flags`: domain-separation flags. 32-bit value in low 32 bits.
+///
+/// # Returns
+///
+/// The updated 8-word chaining value.
+pub fn blake3_compress(
+	builder: &CircuitBuilder,
+	cv: [Wire; 8],
+	block: [Wire; 16],
+	counter: Wire,
+	block_len: Wire,
+	flags: Wire,
+) -> [Wire; 8] {
+	// Split the counter into 32-bit halves.
+	let mask_lo32 = builder.add_constant(Word(0xFFFF_FFFF));
+	let t_low = builder.band(counter, mask_lo32);
+	let t_high = builder.shr(counter, 32);
+
+	// Initialize the 16-word working state.
+	let mut v: [Wire; 16] = [
+		cv[0],
+		cv[1],
+		cv[2],
+		cv[3],
+		cv[4],
+		cv[5],
+		cv[6],
+		cv[7],
+		builder.add_constant(Word(IV[0] as u64)),
+		builder.add_constant(Word(IV[1] as u64)),
+		builder.add_constant(Word(IV[2] as u64)),
+		builder.add_constant(Word(IV[3] as u64)),
+		t_low,
+		t_high,
+		block_len,
+		flags,
+	];
+
+	// Seven rounds of mixing.
+	for i in 0..7 {
+		round(builder, &mut v, &block, i);
+	}
+
+	// Feed-forward: new_cv[i] = v[i] ^ v[i+8].
+	array::from_fn(|i| builder.bxor(v[i], v[i + 8]))
+}
+
+/// BLAKE3 G mixing function.
+#[allow(clippy::too_many_arguments)]
+fn g(
+	builder: &CircuitBuilder,
+	v: &mut [Wire; 16],
+	a: usize,
+	b: usize,
+	c: usize,
+	d: usize,
+	x: Wire,
+	y: Wire,
+) {
+	v[a] = builder.iadd_32(builder.iadd_32(v[a], v[b]), x);
+	v[d] = builder.rotr32(builder.bxor(v[d], v[a]), 16);
+	v[c] = builder.iadd_32(v[c], v[d]);
+	v[b] = builder.rotr32(builder.bxor(v[b], v[c]), 12);
+	v[a] = builder.iadd_32(builder.iadd_32(v[a], v[b]), y);
+	v[d] = builder.rotr32(builder.bxor(v[d], v[a]), 8);
+	v[c] = builder.iadd_32(v[c], v[d]);
+	v[b] = builder.rotr32(builder.bxor(v[b], v[c]), 7);
+}
+
+/// One BLAKE3 round: four column G's followed by four diagonal G's.
+fn round(builder: &CircuitBuilder, state: &mut [Wire; 16], msg: &[Wire; 16], round: usize) {
+	let schedule = MSG_SCHEDULE[round];
+
+	// Mix the columns.
+	g(builder, state, 0, 4, 8, 12, msg[schedule[0]], msg[schedule[1]]);
+	g(builder, state, 1, 5, 9, 13, msg[schedule[2]], msg[schedule[3]]);
+	g(builder, state, 2, 6, 10, 14, msg[schedule[4]], msg[schedule[5]]);
+	g(builder, state, 3, 7, 11, 15, msg[schedule[6]], msg[schedule[7]]);
+
+	// Mix the diagonals.
+	g(builder, state, 0, 5, 10, 15, msg[schedule[8]], msg[schedule[9]]);
+	g(builder, state, 1, 6, 11, 12, msg[schedule[10]], msg[schedule[11]]);
+	g(builder, state, 2, 7, 8, 13, msg[schedule[12]], msg[schedule[13]]);
+	g(builder, state, 3, 4, 9, 14, msg[schedule[14]], msg[schedule[15]]);
+}
+
+#[cfg(test)]
+mod tests {
+	use binius_frontend::CircuitBuilder;
+
+	use super::*;
+
+	// --- Pure-Rust reference implementation of BLAKE3 compression ---------------------
+
+	fn ref_g(v: &mut [u32; 16], a: usize, b: usize, c: usize, d: usize, mx: u32, my: u32) {
+		v[a] = v[a].wrapping_add(v[b]).wrapping_add(mx);
+		v[d] = (v[d] ^ v[a]).rotate_right(16);
+		v[c] = v[c].wrapping_add(v[d]);
+		v[b] = (v[b] ^ v[c]).rotate_right(12);
+		v[a] = v[a].wrapping_add(v[b]).wrapping_add(my);
+		v[d] = (v[d] ^ v[a]).rotate_right(8);
+		v[c] = v[c].wrapping_add(v[d]);
+		v[b] = (v[b] ^ v[c]).rotate_right(7);
+	}
+
+	fn ref_round(state: &mut [u32; 16], msg: &[u32; 16], round: usize) {
+		let schedule = MSG_SCHEDULE[round];
+
+		ref_g(state, 0, 4, 8, 12, msg[schedule[0]], msg[schedule[1]]);
+		ref_g(state, 1, 5, 9, 13, msg[schedule[2]], msg[schedule[3]]);
+		ref_g(state, 2, 6, 10, 14, msg[schedule[4]], msg[schedule[5]]);
+		ref_g(state, 3, 7, 11, 15, msg[schedule[6]], msg[schedule[7]]);
+
+		ref_g(state, 0, 5, 10, 15, msg[schedule[8]], msg[schedule[9]]);
+		ref_g(state, 1, 6, 11, 12, msg[schedule[10]], msg[schedule[11]]);
+		ref_g(state, 2, 7, 8, 13, msg[schedule[12]], msg[schedule[13]]);
+		ref_g(state, 3, 4, 9, 14, msg[schedule[14]], msg[schedule[15]]);
+	}
+
+	fn ref_compress(
+		cv: &[u32; 8],
+		block: &[u32; 16],
+		counter: u64,
+		block_len: u32,
+		flags: u32,
+	) -> [u32; 8] {
+		let mut v = [
+			cv[0],
+			cv[1],
+			cv[2],
+			cv[3],
+			cv[4],
+			cv[5],
+			cv[6],
+			cv[7],
+			IV[0],
+			IV[1],
+			IV[2],
+			IV[3],
+			counter as u32,
+			(counter >> 32) as u32,
+			block_len,
+			flags,
+		];
+		for i in 0..7 {
+			ref_round(&mut v, block, i);
+		}
+		std::array::from_fn(|i| v[i] ^ v[i + 8])
+	}
+
+	// --- Circuit-level tests --------------------------------------------------------
+
+	/// Build a circuit that computes `blake3_compress` on witness inputs, populate the
+	/// witness with the given values, and return the evaluated 8-word output.
+	fn run_compress(
+		cv: [u32; 8],
+		block: [u32; 16],
+		counter: u64,
+		block_len: u32,
+		flags: u32,
+	) -> [u32; 8] {
+		let builder = CircuitBuilder::new();
+		let cv_wires: [Wire; 8] = std::array::from_fn(|_| builder.add_witness());
+		let block_wires: [Wire; 16] = std::array::from_fn(|_| builder.add_witness());
+		let counter_w = builder.add_witness();
+		let block_len_w = builder.add_witness();
+		let flags_w = builder.add_witness();
+
+		let out = blake3_compress(&builder, cv_wires, block_wires, counter_w, block_len_w, flags_w);
+		let out_inout: [Wire; 8] = std::array::from_fn(|_| builder.add_inout());
+		for i in 0..8 {
+			builder.assert_eq("out_match", out[i], out_inout[i]);
+		}
+
+		let circuit = builder.build();
+		let mut w = circuit.new_witness_filler();
+		for i in 0..8 {
+			w[cv_wires[i]] = Word(cv[i] as u64);
+		}
+		for i in 0..16 {
+			w[block_wires[i]] = Word(block[i] as u64);
+		}
+		w[counter_w] = Word(counter);
+		w[block_len_w] = Word(block_len as u64);
+		w[flags_w] = Word(flags as u64);
+
+		let expected = ref_compress(&cv, &block, counter, block_len, flags);
+		for i in 0..8 {
+			w[out_inout[i]] = Word(expected[i] as u64);
+		}
+		circuit.populate_wire_witness(&mut w).unwrap();
+		std::array::from_fn(|i| w[out_inout[i]].0 as u32)
+	}
+
+	#[test]
+	fn zero_block_chunk_start_end_root() {
+		let cv = IV;
+		let block = [0u32; 16];
+		let flags = super::super::CHUNK_START | super::super::CHUNK_END | super::super::ROOT;
+		let actual = run_compress(cv, block, 0, 0, flags);
+		let expected = ref_compress(&cv, &block, 0, 0, flags);
+		assert_eq!(actual, expected);
+	}
+
+	#[test]
+	fn all_ones_block() {
+		let cv = IV;
+		let block = [0xFFFF_FFFFu32; 16];
+		let actual = run_compress(cv, block, 0, 64, 0);
+		let expected = ref_compress(&cv, &block, 0, 64, 0);
+		assert_eq!(actual, expected);
+	}
+
+	#[test]
+	fn nonzero_counter_splits_correctly() {
+		let cv = IV;
+		let block = std::array::from_fn(|i| i as u32 * 0x0101_0101);
+		let counter: u64 = 0x0123_4567_89AB_CDEF;
+		let actual = run_compress(cv, block, counter, 64, super::super::CHUNK_END);
+		let expected = ref_compress(&cv, &block, counter, 64, super::super::CHUNK_END);
+		assert_eq!(actual, expected);
+	}
+
+	#[test]
+	fn nontrivial_cv() {
+		let cv = [
+			0xDEAD_BEEF,
+			0xCAFE_BABE,
+			0x1234_5678,
+			0x9ABC_DEF0,
+			0x0BAD_F00D,
+			0xFEED_FACE,
+			0x0123_4567,
+			0x89AB_CDEF,
+		];
+		let block = std::array::from_fn(|i| (i as u32).wrapping_mul(0xDEAD_BEEFu32));
+		let actual = run_compress(cv, block, 42, 32, super::super::CHUNK_START);
+		let expected = ref_compress(&cv, &block, 42, 32, super::super::CHUNK_START);
+		assert_eq!(actual, expected);
+	}
+}

--- a/crates/circuits/src/blake3/compress.rs
+++ b/crates/circuits/src/blake3/compress.rs
@@ -44,8 +44,7 @@ pub fn blake3_compress(
 	let t_low = builder.band(counter, mask_lo32);
 	let t_high = builder.shr(counter, 32);
 
-	// Initialize the 16-word working state.
-	let mut v: [Wire; 16] = [
+	let v: [Wire; 16] = [
 		cv[0],
 		cv[1],
 		cv[2],
@@ -64,12 +63,80 @@ pub fn blake3_compress(
 		flags,
 	];
 
-	// Seven rounds of mixing.
+	compress_core(builder, v, block)
+}
+
+/// BLAKE3 compression function running two independent compressions in parallel.
+///
+/// Each 64-bit input wire packs two 32-bit lanes: bits `[0:32]` hold the lane-0 word,
+/// bits `[32:64]` hold the lane-1 word. This matches the lane layout expected by the
+/// parallel-halves [`iadd_32`](CircuitBuilder::iadd_32) and
+/// [`rotr32`](CircuitBuilder::rotr32) gates, so the 7-round core runs both
+/// compressions at the gate cost of a single one.
+///
+/// The 64-bit block counter is split by the caller into low and high 32-bit halves:
+/// `counter_lo` packs each lane's `t_low`, `counter_hi` packs each lane's `t_high`.
+///
+/// # Arguments
+///
+/// All wires follow the packing convention above.
+///
+/// - `cv`: 8 chaining-value words (per lane).
+/// - `block`: 16 message words (per lane).
+/// - `counter_lo`: low 32 bits of each lane's block counter.
+/// - `counter_hi`: high 32 bits of each lane's block counter.
+/// - `block_len`: byte count (0..=64) per lane.
+/// - `flags`: domain-separation flags per lane.
+///
+/// # Returns
+///
+/// The updated 8-word chaining value, with each word packing both lanes.
+pub fn blake3_compress_2x(
+	builder: &CircuitBuilder,
+	cv: [Wire; 8],
+	block: [Wire; 16],
+	counter_lo: Wire,
+	counter_hi: Wire,
+	block_len: Wire,
+	flags: Wire,
+) -> [Wire; 8] {
+	// IV constants replicated into both 32-bit halves.
+	let iv_2x = |i: usize| {
+		let w = IV[i] as u64;
+		builder.add_constant(Word(w | (w << 32)))
+	};
+
+	let v: [Wire; 16] = [
+		cv[0],
+		cv[1],
+		cv[2],
+		cv[3],
+		cv[4],
+		cv[5],
+		cv[6],
+		cv[7],
+		iv_2x(0),
+		iv_2x(1),
+		iv_2x(2),
+		iv_2x(3),
+		counter_lo,
+		counter_hi,
+		block_len,
+		flags,
+	];
+
+	compress_core(builder, v, block)
+}
+
+/// Shared body: 7 rounds of mixing followed by feed-forward.
+///
+/// Lane-agnostic: `g()` uses parallel-halves `iadd_32` / `rotr32` and bit-parallel
+/// `bxor`, so the same core advances one or two independent compressions depending
+/// on how the caller packed `v` and `block`.
+fn compress_core(builder: &CircuitBuilder, mut v: [Wire; 16], block: [Wire; 16]) -> [Wire; 8] {
 	for i in 0..7 {
 		round(builder, &mut v, &block, i);
 	}
-
-	// Feed-forward: new_cv[i] = v[i] ^ v[i+8].
 	array::from_fn(|i| builder.bxor(v[i], v[i + 8]))
 }
 
@@ -265,5 +332,143 @@ mod tests {
 		let actual = run_compress(cv, block, 42, 32, super::super::CHUNK_START);
 		let expected = ref_compress(&cv, &block, 42, 32, super::super::CHUNK_START);
 		assert_eq!(actual, expected);
+	}
+
+	// --- 2× SIMD tests -------------------------------------------------------------
+
+	fn pack2x(lo: u32, hi: u32) -> u64 {
+		(lo as u64) | ((hi as u64) << 32)
+	}
+
+	fn unpack2x(w: u64) -> (u32, u32) {
+		(w as u32, (w >> 32) as u32)
+	}
+
+	/// Run `blake3_compress_2x` with two independent per-lane inputs and return the
+	/// two per-lane 8-word outputs.
+	fn run_compress_2x(
+		cv: [[u32; 8]; 2],
+		block: [[u32; 16]; 2],
+		counter: [u64; 2],
+		block_len: [u32; 2],
+		flags: [u32; 2],
+	) -> [[u32; 8]; 2] {
+		let builder = CircuitBuilder::new();
+		let cv_wires: [Wire; 8] = std::array::from_fn(|_| builder.add_witness());
+		let block_wires: [Wire; 16] = std::array::from_fn(|_| builder.add_witness());
+		let counter_lo_w = builder.add_witness();
+		let counter_hi_w = builder.add_witness();
+		let block_len_w = builder.add_witness();
+		let flags_w = builder.add_witness();
+
+		let out = blake3_compress_2x(
+			&builder,
+			cv_wires,
+			block_wires,
+			counter_lo_w,
+			counter_hi_w,
+			block_len_w,
+			flags_w,
+		);
+		let out_inout: [Wire; 8] = std::array::from_fn(|_| builder.add_inout());
+		for i in 0..8 {
+			builder.assert_eq("out_match_2x", out[i], out_inout[i]);
+		}
+
+		let circuit = builder.build();
+		let mut w = circuit.new_witness_filler();
+		for i in 0..8 {
+			w[cv_wires[i]] = Word(pack2x(cv[0][i], cv[1][i]));
+		}
+		for i in 0..16 {
+			w[block_wires[i]] = Word(pack2x(block[0][i], block[1][i]));
+		}
+		w[counter_lo_w] = Word(pack2x(counter[0] as u32, counter[1] as u32));
+		w[counter_hi_w] = Word(pack2x((counter[0] >> 32) as u32, (counter[1] >> 32) as u32));
+		w[block_len_w] = Word(pack2x(block_len[0], block_len[1]));
+		w[flags_w] = Word(pack2x(flags[0], flags[1]));
+
+		let exp0 = ref_compress(&cv[0], &block[0], counter[0], block_len[0], flags[0]);
+		let exp1 = ref_compress(&cv[1], &block[1], counter[1], block_len[1], flags[1]);
+		for i in 0..8 {
+			w[out_inout[i]] = Word(pack2x(exp0[i], exp1[i]));
+		}
+		circuit.populate_wire_witness(&mut w).unwrap();
+
+		let mut actual = [[0u32; 8]; 2];
+		for i in 0..8 {
+			let (lo, hi) = unpack2x(w[out_inout[i]].0);
+			actual[0][i] = lo;
+			actual[1][i] = hi;
+		}
+		actual
+	}
+
+	#[test]
+	fn compress_2x_identical_lanes() {
+		let cv = IV;
+		let block = [0u32; 16];
+		let flags = super::super::CHUNK_START | super::super::CHUNK_END | super::super::ROOT;
+		let actual = run_compress_2x([cv, cv], [block, block], [0, 0], [0, 0], [flags, flags]);
+		let expected = ref_compress(&cv, &block, 0, 0, flags);
+		assert_eq!(actual[0], expected);
+		assert_eq!(actual[1], expected);
+	}
+
+	#[test]
+	fn compress_2x_distinct_lanes() {
+		let cv0 = IV;
+		let cv1 = [
+			0xDEAD_BEEF,
+			0xCAFE_BABE,
+			0x1234_5678,
+			0x9ABC_DEF0,
+			0x0BAD_F00D,
+			0xFEED_FACE,
+			0x0123_4567,
+			0x89AB_CDEF,
+		];
+		let block0: [u32; 16] = std::array::from_fn(|i| i as u32 * 0x0101_0101);
+		let block1: [u32; 16] = std::array::from_fn(|i| (i as u32).wrapping_mul(0xDEAD_BEEFu32));
+
+		let actual = run_compress_2x(
+			[cv0, cv1],
+			[block0, block1],
+			[0, 42],
+			[64, 32],
+			[super::super::CHUNK_END, super::super::CHUNK_START],
+		);
+		let exp0 = ref_compress(&cv0, &block0, 0, 64, super::super::CHUNK_END);
+		let exp1 = ref_compress(&cv1, &block1, 42, 32, super::super::CHUNK_START);
+		assert_eq!(actual[0], exp0);
+		assert_eq!(actual[1], exp1);
+	}
+
+	#[test]
+	fn compress_2x_counter_across_32bit_boundary() {
+		let cv = IV;
+		let block: [u32; 16] = std::array::from_fn(|i| i as u32);
+		let counter0: u64 = 0x0123_4567_89AB_CDEF;
+		let counter1: u64 = 0;
+		let actual = run_compress_2x(
+			[cv, cv],
+			[block, block],
+			[counter0, counter1],
+			[64, 64],
+			[
+				super::super::CHUNK_START | super::super::ROOT,
+				super::super::CHUNK_END,
+			],
+		);
+		let exp0 = ref_compress(
+			&cv,
+			&block,
+			counter0,
+			64,
+			super::super::CHUNK_START | super::super::ROOT,
+		);
+		let exp1 = ref_compress(&cv, &block, counter1, 64, super::super::CHUNK_END);
+		assert_eq!(actual[0], exp0);
+		assert_eq!(actual[1], exp1);
 	}
 }

--- a/crates/circuits/src/blake3/mod.rs
+++ b/crates/circuits/src/blake3/mod.rs
@@ -8,8 +8,8 @@
 //!
 //! The entry points are:
 //! - [`blake3_compress`] — single-block compression primitive.
-//! - [`blake3_fixed`] — single-chunk hash gadget for messages of compile-time-known
-//!   length up to 1024 bytes.
+//! - [`blake3_fixed`] — single-chunk hash gadget for messages of compile-time-known length up to
+//!   1024 bytes.
 
 use binius_core::word::Word;
 use binius_frontend::{CircuitBuilder, Wire};
@@ -69,11 +69,10 @@ pub const CHUNK_BYTES: usize = 1024;
 /// # Arguments
 ///
 /// - `builder`: Circuit builder.
-/// - `message`: Input message as 32-bit little-endian words (4 bytes per wire). The
-///   high 32 bits of each wire must be zero. Length must equal
-///   `len_bytes.div_ceil(4)`.
-/// - `len_bytes`: The compile-time-known length of the message in bytes. Must be at
-///   most [`CHUNK_BYTES`] (1024).
+/// - `message`: Input message as 32-bit little-endian words (4 bytes per wire). The high 32 bits of
+///   each wire must be zero. Length must equal `len_bytes.div_ceil(4)`.
+/// - `len_bytes`: The compile-time-known length of the message in bytes. Must be at most
+///   [`CHUNK_BYTES`] (1024).
 ///
 /// # Returns
 ///

--- a/crates/circuits/src/blake3/mod.rs
+++ b/crates/circuits/src/blake3/mod.rs
@@ -1,0 +1,45 @@
+// Copyright 2025 Irreducible Inc.
+
+//! BLAKE3 circuit gadgets.
+//!
+//! This module provides circuit primitives for the BLAKE3 hash function. The primitives
+//! are exposed as free functions that take input wires and return output wires — no
+//! wrapping structs.
+//!
+//! The entry points are:
+//! - [`blake3_compress`] — single-block compression primitive.
+//! - [`blake3_fixed`](fn@blake3_fixed) — single-chunk hash gadget for messages of
+//!   compile-time-known length up to 1024 bytes (to be added).
+
+pub mod compress;
+
+pub use compress::blake3_compress;
+
+/// BLAKE3 initial chaining value. Same as the SHA-256 IV.
+pub const IV: [u32; 8] = [
+	0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19,
+];
+
+/// Message schedule for each of the 7 rounds of the BLAKE3 compression function.
+///
+/// Matches the `MSG_SCHEDULE` constant in the [reference implementation].
+///
+/// [reference implementation]: https://github.com/BLAKE3-team/BLAKE3/blob/master/src/portable.rs
+pub const MSG_SCHEDULE: [[usize; 16]; 7] = [
+	[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+	[2, 6, 3, 10, 7, 0, 4, 13, 1, 11, 12, 5, 9, 14, 15, 8],
+	[3, 4, 10, 12, 13, 2, 7, 14, 6, 5, 9, 0, 11, 15, 8, 1],
+	[10, 7, 12, 9, 14, 3, 13, 15, 4, 0, 11, 2, 5, 8, 1, 6],
+	[12, 13, 9, 11, 15, 10, 14, 8, 7, 2, 5, 3, 0, 1, 6, 4],
+	[9, 14, 11, 5, 8, 12, 15, 1, 13, 3, 0, 10, 2, 6, 4, 7],
+	[11, 15, 5, 0, 1, 9, 8, 6, 14, 10, 2, 12, 3, 4, 7, 13],
+];
+
+// Domain separation flags.
+pub const CHUNK_START: u32 = 1 << 0;
+pub const CHUNK_END: u32 = 1 << 1;
+pub const PARENT: u32 = 1 << 2;
+pub const ROOT: u32 = 1 << 3;
+pub const KEYED_HASH: u32 = 1 << 4;
+pub const DERIVE_KEY_CONTEXT: u32 = 1 << 5;
+pub const DERIVE_KEY_MATERIAL: u32 = 1 << 6;

--- a/crates/circuits/src/blake3/mod.rs
+++ b/crates/circuits/src/blake3/mod.rs
@@ -8,8 +8,11 @@
 //!
 //! The entry points are:
 //! - [`blake3_compress`] — single-block compression primitive.
-//! - [`blake3_fixed`](fn@blake3_fixed) — single-chunk hash gadget for messages of
-//!   compile-time-known length up to 1024 bytes (to be added).
+//! - [`blake3_fixed`] — single-chunk hash gadget for messages of compile-time-known
+//!   length up to 1024 bytes.
+
+use binius_core::word::Word;
+use binius_frontend::{CircuitBuilder, Wire};
 
 pub mod compress;
 
@@ -43,3 +46,192 @@ pub const ROOT: u32 = 1 << 3;
 pub const KEYED_HASH: u32 = 1 << 4;
 pub const DERIVE_KEY_CONTEXT: u32 = 1 << 5;
 pub const DERIVE_KEY_MATERIAL: u32 = 1 << 6;
+
+/// Byte length of a BLAKE3 block.
+pub const BLOCK_BYTES: usize = 64;
+
+/// Byte length of a BLAKE3 chunk.
+pub const CHUNK_BYTES: usize = 1024;
+
+/// Computes the BLAKE3 hash of a compile-time fixed-length message.
+///
+/// This is the BLAKE3 analog of
+/// [`sha256_fixed`](crate::sha256::sha256_fixed) — the message length is known at
+/// circuit construction time, which eliminates runtime padding logic.
+///
+/// # Scope
+///
+/// Currently restricted to single-chunk inputs (`len_bytes <= 1024`). Multi-chunk
+/// hashing requires BLAKE3's tree construction with parent nodes and chunk counters,
+/// which is out of scope for this gadget. The underlying [`blake3_compress`] is
+/// fully general and can be wrapped to support multi-chunk in a follow-up.
+///
+/// # Arguments
+///
+/// - `builder`: Circuit builder.
+/// - `message`: Input message as 32-bit little-endian words (4 bytes per wire). The
+///   high 32 bits of each wire must be zero. Length must equal
+///   `len_bytes.div_ceil(4)`.
+/// - `len_bytes`: The compile-time-known length of the message in bytes. Must be at
+///   most [`CHUNK_BYTES`] (1024).
+///
+/// # Returns
+///
+/// The BLAKE3 digest as 8 wires, each holding a 32-bit little-endian word in its
+/// low 32 bits.
+pub fn blake3_fixed(builder: &CircuitBuilder, message: &[Wire], len_bytes: usize) -> [Wire; 8] {
+	assert!(
+		len_bytes <= CHUNK_BYTES,
+		"blake3_fixed: len_bytes ({len_bytes}) exceeds single-chunk limit of {CHUNK_BYTES}",
+	);
+	assert_eq!(
+		message.len(),
+		len_bytes.div_ceil(4),
+		"blake3_fixed: message.len() ({}) must equal len_bytes.div_ceil(4) ({})",
+		message.len(),
+		len_bytes.div_ceil(4),
+	);
+
+	let zero = builder.add_constant(Word::ZERO);
+
+	// Build the padded message as a flat list of 32-bit LE words. BLAKE3 does not
+	// append a length field; the trailing partial block is simply zero-filled and
+	// its `block_len` parameter records the actual byte count.
+	let n_blocks = len_bytes.div_ceil(BLOCK_BYTES).max(1);
+	let n_padded_words = n_blocks * 16;
+
+	let n_message_words = len_bytes / 4;
+	let boundary_bytes = len_bytes % 4;
+
+	let mut padded: Vec<Wire> = Vec::with_capacity(n_padded_words);
+	padded.extend_from_slice(&message[..n_message_words]);
+	if boundary_bytes > 0 {
+		// Partial trailing word: mask the high bytes to zero (BLAKE3 words are
+		// little-endian, so the valid message bytes occupy the low bytes).
+		let mask_value = (1u64 << (boundary_bytes * 8)) - 1;
+		let mask = builder.add_constant(Word(mask_value));
+		padded.push(builder.band(message[n_message_words], mask));
+	}
+	padded.resize(n_padded_words, zero);
+
+	// Constants used each block.
+	let counter = zero;
+	let flag_start = builder.add_constant(Word(CHUNK_START as u64));
+	let flag_end_root = builder.add_constant(Word((CHUNK_END | ROOT) as u64));
+	let flag_start_end_root = builder.add_constant(Word((CHUNK_START | CHUNK_END | ROOT) as u64));
+	let flag_zero = zero;
+
+	// Initial chaining value = IV.
+	let mut cv: [Wire; 8] = std::array::from_fn(|i| builder.add_constant(Word(IV[i] as u64)));
+
+	for block_idx in 0..n_blocks {
+		let block: [Wire; 16] = std::array::from_fn(|i| padded[block_idx * 16 + i]);
+
+		let block_byte_count = if block_idx + 1 == n_blocks {
+			len_bytes - block_idx * BLOCK_BYTES
+		} else {
+			BLOCK_BYTES
+		};
+		let block_len = builder.add_constant(Word(block_byte_count as u64));
+
+		let flags = match (block_idx == 0, block_idx + 1 == n_blocks) {
+			(true, true) => flag_start_end_root,
+			(true, false) => flag_start,
+			(false, true) => flag_end_root,
+			(false, false) => flag_zero,
+		};
+
+		cv = blake3_compress(
+			&builder.subcircuit(format!("blake3_fixed_compress[{block_idx}]")),
+			cv,
+			block,
+			counter,
+			block_len,
+			flags,
+		);
+	}
+
+	cv
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	/// Convert a byte slice into the 32-bit LE word encoding expected by [`blake3_fixed`].
+	/// The last word is zero-padded in its high bytes if the length is not a multiple of 4.
+	fn bytes_to_le_words(bytes: &[u8]) -> Vec<u64> {
+		let n_words = bytes.len().div_ceil(4);
+		(0..n_words)
+			.map(|i| {
+				let mut buf = [0u8; 4];
+				let start = i * 4;
+				let end = (start + 4).min(bytes.len());
+				buf[..end - start].copy_from_slice(&bytes[start..end]);
+				u32::from_le_bytes(buf) as u64
+			})
+			.collect()
+	}
+
+	/// Run `blake3_fixed` over `input` and assert it matches `blake3::hash(input)`.
+	fn check(input: &[u8]) {
+		let builder = CircuitBuilder::new();
+		let message: Vec<Wire> = (0..input.len().div_ceil(4))
+			.map(|_| builder.add_witness())
+			.collect();
+		let digest = blake3_fixed(&builder, &message, input.len());
+		let digest_out: [Wire; 8] = std::array::from_fn(|_| builder.add_inout());
+		for i in 0..8 {
+			builder.assert_eq("digest_match", digest[i], digest_out[i]);
+		}
+
+		let circuit = builder.build();
+		let mut w = circuit.new_witness_filler();
+		let words = bytes_to_le_words(input);
+		for (wire, word) in message.iter().zip(words.iter()) {
+			w[*wire] = Word(*word);
+		}
+
+		let expected = blake3::hash(input);
+		let expected_words: [u32; 8] = std::array::from_fn(|i| {
+			u32::from_le_bytes(expected.as_bytes()[i * 4..i * 4 + 4].try_into().unwrap())
+		});
+		for i in 0..8 {
+			w[digest_out[i]] = Word(expected_words[i] as u64);
+		}
+		circuit
+			.populate_wire_witness(&mut w)
+			.unwrap_or_else(|e| panic!("blake3_fixed failed for len_bytes={}: {e:?}", input.len()));
+	}
+
+	#[test]
+	fn empty() {
+		check(b"");
+	}
+
+	#[test]
+	fn one_byte() {
+		check(&[0x5a]);
+	}
+
+	#[test]
+	fn abc() {
+		check(b"abc");
+	}
+
+	#[test]
+	fn block_boundaries() {
+		for &len in &[1usize, 63, 64, 65, 127, 128, 511, 512, 1023, 1024] {
+			let input: Vec<u8> = (0..len).map(|i| (i * 37 + 1) as u8).collect();
+			check(&input);
+		}
+	}
+
+	#[test]
+	#[should_panic(expected = "exceeds single-chunk limit")]
+	fn rejects_oversize() {
+		let builder = CircuitBuilder::new();
+		let message: Vec<Wire> = (0..257).map(|_| builder.add_witness()).collect();
+		blake3_fixed(&builder, &message, CHUNK_BYTES + 1);
+	}
+}

--- a/crates/circuits/src/blake3/mod.rs
+++ b/crates/circuits/src/blake3/mod.rs
@@ -16,7 +16,7 @@ use binius_frontend::{CircuitBuilder, Wire};
 
 pub mod compress;
 
-pub use compress::blake3_compress;
+pub use compress::{blake3_compress, blake3_compress_2x};
 
 /// BLAKE3 initial chaining value. Same as the SHA-256 IV.
 pub const IV: [u32; 8] = [

--- a/crates/circuits/src/lib.rs
+++ b/crates/circuits/src/lib.rs
@@ -23,6 +23,7 @@ pub mod bignum;
 pub mod bitcoin;
 pub mod blake2b;
 pub mod blake2s;
+pub mod blake3;
 pub mod bytes;
 pub mod concat;
 pub mod ecdsa;

--- a/crates/examples/examples/blake3_compress.rs
+++ b/crates/examples/examples/blake3_compress.rs
@@ -1,0 +1,10 @@
+// Copyright 2025-2026 The Binius Developers
+
+use anyhow::Result;
+use binius_examples::{Cli, circuits::blake3_compress::Blake3CompressExample};
+
+fn main() -> Result<()> {
+	Cli::<Blake3CompressExample>::new("blake3_compress")
+		.about("BLAKE3 compression benchmark (uses blake3_compress_2x under the hood)")
+		.run()
+}

--- a/crates/examples/src/circuits/blake3_compress.rs
+++ b/crates/examples/src/circuits/blake3_compress.rs
@@ -98,9 +98,6 @@ impl ExampleCircuit for Blake3CompressExample {
 	}
 
 	fn param_summary(params: &Self::Params) -> Option<String> {
-		Some(format!(
-			"{}c",
-			params.num_compressions.unwrap_or(DEFAULT_NUM_COMPRESSIONS)
-		))
+		Some(format!("{}c", params.num_compressions.unwrap_or(DEFAULT_NUM_COMPRESSIONS)))
 	}
 }

--- a/crates/examples/src/circuits/blake3_compress.rs
+++ b/crates/examples/src/circuits/blake3_compress.rs
@@ -1,0 +1,106 @@
+// Copyright 2025-2026 The Binius Developers
+
+use anyhow::Result;
+use binius_circuits::blake3::blake3_compress_2x;
+use binius_core::word::Word;
+use binius_frontend::{CircuitBuilder, Wire, WitnessFiller};
+use clap::Args;
+use rand::{RngCore, SeedableRng, rngs::StdRng};
+
+use super::utils::DEFAULT_RANDOM_SEED;
+use crate::ExampleCircuit;
+
+/// Default number of logical BLAKE3 compressions if none is specified.
+const DEFAULT_NUM_COMPRESSIONS: usize = 16;
+
+/// Benchmark for `blake3_compress_2x`: runs ceil(num_compressions / 2) parallel 2-lane
+/// compressions chained through their chaining-value output.
+pub struct Blake3CompressExample {
+	initial_cv: [Wire; 8],
+	pairs: Vec<PairInputs>,
+}
+
+struct PairInputs {
+	block: [Wire; 16],
+	counter_lo: Wire,
+	counter_hi: Wire,
+	block_len: Wire,
+	flags: Wire,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct Params {
+	/// Total number of logical BLAKE3 compressions. The circuit issues
+	/// `ceil(num_compressions / 2)` calls to `blake3_compress_2x`, running two
+	/// compressions per call in the upper/lower 32-bit lanes.
+	#[arg(long)]
+	pub num_compressions: Option<usize>,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct Instance {
+	/// RNG seed for witness values.
+	#[arg(long)]
+	pub seed: Option<u64>,
+}
+
+impl ExampleCircuit for Blake3CompressExample {
+	type Params = Params;
+	type Instance = Instance;
+
+	fn build(params: Params, builder: &mut CircuitBuilder) -> Result<Self> {
+		let num_compressions = params.num_compressions.unwrap_or(DEFAULT_NUM_COMPRESSIONS);
+		let n_pairs = num_compressions.div_ceil(2);
+
+		let initial_cv: [Wire; 8] = std::array::from_fn(|_| builder.add_witness());
+		let mut cv = initial_cv;
+		let mut pairs = Vec::with_capacity(n_pairs);
+
+		for _ in 0..n_pairs {
+			let block: [Wire; 16] = std::array::from_fn(|_| builder.add_witness());
+			let counter_lo = builder.add_witness();
+			let counter_hi = builder.add_witness();
+			let block_len = builder.add_witness();
+			let flags = builder.add_witness();
+
+			cv = blake3_compress_2x(builder, cv, block, counter_lo, counter_hi, block_len, flags);
+
+			pairs.push(PairInputs {
+				block,
+				counter_lo,
+				counter_hi,
+				block_len,
+				flags,
+			});
+		}
+
+		Ok(Self { initial_cv, pairs })
+	}
+
+	fn populate_witness(&self, instance: Instance, w: &mut WitnessFiller) -> Result<()> {
+		let mut rng = StdRng::seed_from_u64(instance.seed.unwrap_or(DEFAULT_RANDOM_SEED));
+		let mut next = || Word(rng.next_u64());
+
+		for wire in self.initial_cv {
+			w[wire] = next();
+		}
+		for pair in &self.pairs {
+			for b in pair.block {
+				w[b] = next();
+			}
+			w[pair.counter_lo] = next();
+			w[pair.counter_hi] = next();
+			w[pair.block_len] = next();
+			w[pair.flags] = next();
+		}
+
+		Ok(())
+	}
+
+	fn param_summary(params: &Self::Params) -> Option<String> {
+		Some(format!(
+			"{}c",
+			params.num_compressions.unwrap_or(DEFAULT_NUM_COMPRESSIONS)
+		))
+	}
+}

--- a/crates/examples/src/circuits/mod.rs
+++ b/crates/examples/src/circuits/mod.rs
@@ -4,6 +4,7 @@ pub mod bitcoin_header_chain;
 pub mod bitcoin_p2pkh;
 pub mod blake2b;
 pub mod blake2s;
+pub mod blake3_compress;
 pub mod ethsign;
 pub mod hashsign;
 pub mod keccak;

--- a/crates/frontend/src/compiler/gate/rotr32.rs
+++ b/crates/frontend/src/compiler/gate/rotr32.rs
@@ -14,8 +14,6 @@
 //! The gate generates 1 AND constraint:
 //! - `(x ROTR32 n) ∧ all-1 = z`
 
-use binius_core::word::Word;
-
 use crate::compiler::{
 	constraint_builder::{ConstraintBuilder, rotr32},
 	gate::opcode::OpcodeShape,
@@ -24,7 +22,7 @@ use crate::compiler::{
 
 pub fn shape() -> OpcodeShape {
 	OpcodeShape {
-		const_in: &[Word::ALL_ONE],
+		const_in: &[],
 		n_in: 1,
 		n_out: 1,
 		n_aux: 0,


### PR DESCRIPTION
## Summary
- Add `blake3_compress` gadget (`crates/circuits/src/blake3/compress.rs`) and `blake3_fixed` wrapper for compile-time-known-length single-chunk hashes, matching the BLAKE3 reference portable.rs.
- Add `blake3_compress_2x` — a 2x32b SIMD variant that packs two independent BLAKE3 compressions into the upper/lower 32-bit lanes of each 64-bit wire. Reuses the shared `compress_core` helper with a distinct state init (IV constants replicated into both halves, counter split into pre-packed lo/hi wires).
- Clean up rotr32 gate: drop unused `const_in`.
- Add `blake3_compress` benchmark example (`crates/examples`) that takes `--num-compressions N` and issues `ceil(N/2)` calls to `blake3_compress_2x` chained through their CV output.

## Test plan
- [x] `cargo test -p binius-circuits -- blake3`
- [x] `cargo test -p binius-circuits`
- [x] `cargo test -p binius-frontend`
- [x] `cargo run --release --example blake3_compress -p binius-examples -- stat --num-compressions 64`
- [x] `cargo run --release --example blake3_compress -p binius-examples -- prove --num-compressions 16`
- [x] `cargo clippy -p binius-circuits --tests --lib`
- [x] `cargo clippy -p binius-examples --example blake3_compress --lib`
