### PR TITLE
[spartan] Lift precommit oracle commit/receive out of prove/verify

### DIFF
--- a/crates/spartan-prover/src/lib.rs
+++ b/crates/spartan-prover/src/lib.rs
@@ -133,6 +133,35 @@ impl<F: Field> IOPProver<F> {
 		&self.constraint_system
 	}
 
+	/// Packs and commits the precommit segment of a witness on the channel.
+	///
+	/// This must be called before [`Self::prove`], and the returned oracle handle and packed
+	/// buffer must be passed into `prove`. Callers that wrap the IOP (e.g. the ZK wrapper) can
+	/// invoke this separately so the precommit oracle handle is available before the rest of
+	/// the protocol runs.
+	pub fn commit_precommit<P, Channel>(
+		&self,
+		witness: &Witness<F>,
+		rng: &mut impl CryptoRng,
+		channel: &mut Channel,
+	) -> (Channel::Oracle, FieldBuffer<P>)
+	where
+		F: BinaryField,
+		P: PackedField<Scalar = F> + PackedExtension<F>,
+		Channel: IOPProverChannel<P>,
+	{
+		let cs = &self.constraint_system;
+		let precommit_packed = pack_and_blind_witness::<_, P>(
+			cs.log_precommit() as usize,
+			witness.precommit(),
+			cs.n_precommit() as usize,
+			cs.blinding_info(),
+			rng,
+		);
+		let precommit_oracle = channel.send_oracle(precommit_packed.to_ref());
+		(precommit_oracle, precommit_packed)
+	}
+
 	/// Proves using an IOP channel interface.
 	///
 	/// This is the core proving logic, independent of the specific IOP compilation strategy.
@@ -141,12 +170,17 @@ impl<F: Field> IOPProver<F> {
 	/// # Arguments
 	///
 	/// * `witness` - The witness values for the constraint system
+	/// * `precommit_oracle` - Oracle handle obtained from [`Self::commit_precommit`]
+	/// * `precommit_packed` - Packed precommit buffer obtained from [`Self::commit_precommit`]
 	/// * `rng` - Random number generator for blinding
 	/// * `channel` - The IOP prover channel (public input must be observed on transcript before
-	///   creating the channel)
+	///   creating the channel; the precommit oracle must already have been committed on it via
+	///   [`Self::commit_precommit`])
 	pub fn prove<P, Channel>(
 		&self,
 		witness: Witness<F>,
+		precommit_oracle: Channel::Oracle,
+		precommit_packed: FieldBuffer<P>,
 		mut rng: impl CryptoRng,
 		mut channel: Channel,
 	) -> Result<(), Error>
@@ -223,17 +257,8 @@ impl<F: Field> IOPProver<F> {
 			&mut rng,
 		);
 
-		// Pack precommit witness into field elements and add blinding
-		let precommit_packed = pack_and_blind_witness::<_, P>(
-			cs.log_precommit() as usize,
-			witness.precommit(),
-			cs.n_precommit() as usize,
-			blinding_info,
-			&mut rng,
-		);
-
-		// Send the precommit, private, and mask oracles to the channel
-		let precommit_oracle = channel.send_oracle(precommit_packed.to_ref());
+		// Send the private and mask oracles to the channel. The precommit oracle was committed
+		// by the caller via `commit_precommit` and passed in as `precommit_oracle`.
 		let private_oracle = channel.send_oracle(private_packed.to_ref());
 		let mask_oracle = channel.send_oracle(masks_buffer.to_ref());
 
@@ -375,9 +400,14 @@ where
 		let public = witness.public();
 		transcript.observe().write_slice(public);
 
-		// Create ZK channel (owns the RNG for mask generation) and delegate to IOP prover
-		let channel = self.basefold_compiler.create_channel(transcript, &mut rng);
-		self.iop_prover.prove::<P, _>(witness, rng, channel)
+		// Create ZK channel (owns the RNG for mask generation), commit the precommit oracle,
+		// and delegate to the IOP prover.
+		let mut channel = self.basefold_compiler.create_channel(transcript, &mut rng);
+		let (precommit_oracle, precommit_packed) =
+			self.iop_prover
+				.commit_precommit::<P, _>(&witness, &mut rng, &mut channel);
+		self.iop_prover
+			.prove::<P, _>(witness, precommit_oracle, precommit_packed, rng, channel)
 	}
 }
 

--- a/crates/spartan-prover/src/wrapper/zk_wrapped_prover_channel.rs
+++ b/crates/spartan-prover/src/wrapper/zk_wrapped_prover_channel.rs
@@ -112,12 +112,12 @@ where
 	/// 1. Creates a [`ReplayChannel`] from the recorded interaction
 	/// 2. Calls the `replay_fn` closure to replay the inner verification and fill the outer witness
 	/// 3. Validates and generates the outer IOP proof
-	pub fn finish(self, rng: impl CryptoRng) -> Result<(), crate::Error>
+	pub fn finish(self, mut rng: impl CryptoRng) -> Result<(), crate::Error>
 	where
 		ReplayFn: FnOnce(&mut ReplayChannel<'_, F>),
 	{
 		let Self {
-			inner_channel,
+			mut inner_channel,
 			outer_prover,
 			outer_layout,
 			replay_fn,
@@ -135,7 +135,18 @@ where
 		// Validate and generate the outer proof.
 		let outer_cs = outer_prover.constraint_system();
 		outer_cs.validate(&witness);
-		outer_prover.prove::<P, _>(witness, rng, inner_channel)?;
+
+		// TODO(BINIUS-33 follow-up): Lift precommit oracle commitment up to
+		// ZKWrappedProverChannel::new so the handle is obtained at construction time.
+		let (precommit_oracle, precommit_packed) =
+			outer_prover.commit_precommit::<P, _>(&witness, &mut rng, &mut inner_channel);
+		outer_prover.prove::<P, _>(
+			witness,
+			precommit_oracle,
+			precommit_packed,
+			rng,
+			inner_channel,
+		)?;
 		Ok(())
 	}
 }

--- a/crates/spartan-prover/tests/wrapper_integration_test.rs
+++ b/crates/spartan-prover/tests/wrapper_integration_test.rs
@@ -151,9 +151,20 @@ fn test_zk_wrapped_prove_verify() {
 	// Observe public input through the wrapped channel.
 	(&mut wrapped_prover_channel).observe_many(&public);
 
-	// Run the inner proof through the wrapped channel.
+	// Commit the inner precommit oracle on the wrapped channel, then run the inner proof.
+	// Bind a &mut to the wrapped channel so that `Channel` in commit_precommit/prove is
+	// inferred as `&mut ZKWrappedProverChannel` — the type that implements IOPProverChannel.
+	let mut channel_ref = &mut wrapped_prover_channel;
+	let (inner_precommit_oracle, inner_precommit_packed) = inner_iop_prover
+		.commit_precommit::<OptimalPackedB128, _>(&inner_witness, &mut rng, &mut channel_ref);
 	inner_iop_prover
-		.prove::<OptimalPackedB128, _>(inner_witness, &mut rng, &mut wrapped_prover_channel)
+		.prove::<OptimalPackedB128, _>(
+			inner_witness,
+			inner_precommit_oracle,
+			inner_precommit_packed,
+			&mut rng,
+			channel_ref,
+		)
 		.expect("inner prove failed");
 
 	// Finish runs the outer proof.

--- a/crates/spartan-prover/tests/wrapper_integration_test.rs
+++ b/crates/spartan-prover/tests/wrapper_integration_test.rs
@@ -4,13 +4,13 @@ use binius_field::{BinaryField128bGhash as B128, Field, Random, arch::OptimalPac
 use binius_hash::{ParallelCompressionAdaptor, StdCompression, StdDigest};
 use binius_iop::{
 	basefold_compiler::BaseFoldZKVerifierCompiler,
+	channel::IOPVerifierChannel,
 	fri::{self, MinProofSizeStrategy},
 	merkle_tree::BinaryMerkleTreeScheme,
 };
 use binius_iop_prover::{
 	basefold_compiler::BaseFoldZKProverCompiler, merkle_tree::prover::BinaryMerkleTreeProver,
 };
-use binius_iop::channel::IOPVerifierChannel;
 use binius_ip::channel::IPVerifierChannel;
 use binius_ip_prover::channel::IPProverChannel;
 use binius_math::ntt::{NeighborsLastSingleThread, domain_context::GenericOnTheFly};
@@ -188,11 +188,7 @@ fn test_zk_wrapped_prove_verify() {
 	// Run the inner IOP verify through the wrapped channel.
 	let inner_precommit_oracle = wrapped_verifier_channel.recv_oracle().unwrap();
 	inner_iop_verifier
-		.verify(
-			inner_precommit_oracle,
-			inner_public_elems,
-			&mut wrapped_verifier_channel,
-		)
+		.verify(inner_precommit_oracle, inner_public_elems, &mut wrapped_verifier_channel)
 		.expect("inner IOP verify failed");
 
 	// Finish verifies the outer proof.

--- a/crates/spartan-prover/tests/wrapper_integration_test.rs
+++ b/crates/spartan-prover/tests/wrapper_integration_test.rs
@@ -10,6 +10,7 @@ use binius_iop::{
 use binius_iop_prover::{
 	basefold_compiler::BaseFoldZKProverCompiler, merkle_tree::prover::BinaryMerkleTreeProver,
 };
+use binius_iop::channel::IOPVerifierChannel;
 use binius_ip::channel::IPVerifierChannel;
 use binius_ip_prover::channel::IPProverChannel;
 use binius_math::ntt::{NeighborsLastSingleThread, domain_context::GenericOnTheFly};
@@ -68,8 +69,9 @@ fn test_zk_wrapped_prove_verify() {
 	let mut builder_channel = IronSpartanBuilderChannel::new(ConstraintBuilder::new());
 	let dummy_public = vec![B128::ZERO; inner_public_size];
 	let dummy_public_elems = builder_channel.observe_many(&dummy_public);
+	// IronSpartanBuilderChannel::Oracle = () and recv_oracle is a no-op, so pass () directly.
 	inner_iop_verifier
-		.verify(dummy_public_elems, &mut builder_channel)
+		.verify((), dummy_public_elems, &mut builder_channel)
 		.expect("symbolic verify failed");
 	let outer_builder = builder_channel.finish();
 	let (outer_cs, outer_layout) = compile(outer_builder);
@@ -139,8 +141,9 @@ fn test_zk_wrapped_prove_verify() {
 			let public = &public;
 			move |replay_channel: &mut ReplayChannel<'_, B128>| {
 				let inner_public_elems = replay_channel.observe_many(public);
+				// ReplayChannel::Oracle = () and recv_oracle is a no-op, so pass ().
 				inner_iop_verifier
-					.verify(inner_public_elems, replay_channel)
+					.verify((), inner_public_elems, replay_channel)
 					.expect("replay verification should not fail");
 			}
 		});
@@ -172,8 +175,13 @@ fn test_zk_wrapped_prove_verify() {
 	let inner_public_elems = wrapped_verifier_channel.observe_many(&public);
 
 	// Run the inner IOP verify through the wrapped channel.
+	let inner_precommit_oracle = wrapped_verifier_channel.recv_oracle().unwrap();
 	inner_iop_verifier
-		.verify(inner_public_elems, &mut wrapped_verifier_channel)
+		.verify(
+			inner_precommit_oracle,
+			inner_public_elems,
+			&mut wrapped_verifier_channel,
+		)
 		.expect("inner IOP verify failed");
 
 	// Finish verifies the outer proof.

--- a/crates/spartan-verifier/src/lib.rs
+++ b/crates/spartan-verifier/src/lib.rs
@@ -136,6 +136,8 @@ impl<F: Field> IOPVerifier<F> {
 	///
 	/// # Arguments
 	///
+	/// * `precommit_oracle` - Handle to the precommit oracle, received from the channel by the
+	///   caller before invoking `verify`.
 	/// * `public` - The public inputs to the constraint system
 	/// * `channel` - The IOP verifier channel
 	///
@@ -144,6 +146,7 @@ impl<F: Field> IOPVerifier<F> {
 	/// `Ok(())` if the proof is valid, `Err(_)` otherwise.
 	pub fn verify<Channel>(
 		&self,
+		precommit_oracle: Channel::Oracle,
 		public: Vec<Channel::Elem>,
 		channel: &mut Channel,
 	) -> Result<(), Error>
@@ -165,8 +168,7 @@ impl<F: Field> IOPVerifier<F> {
 			});
 		}
 
-		// Receive the precommit, private, and mask oracle commitments.
-		let precommit_oracle = channel.recv_oracle()?;
+		// Receive the private and mask oracle commitments.
 		let private_oracle = channel.recv_oracle()?;
 		let mask_oracle = channel.recv_oracle()?;
 
@@ -303,9 +305,11 @@ where
 		// Verifier observes the public input (includes it in Fiat-Shamir).
 		transcript.observe().write_slice(public);
 
-		// Create channel and delegate to IOPVerifier::verify
+		// Create channel, receive the precommit oracle, and delegate to IOPVerifier::verify.
 		let mut channel = self.basefold_compiler.create_channel(transcript);
-		self.iop_verifier.verify(public.to_vec(), &mut channel)
+		let precommit_oracle = channel.recv_oracle()?;
+		self.iop_verifier
+			.verify(precommit_oracle, public.to_vec(), &mut channel)
 	}
 }
 

--- a/crates/spartan-verifier/src/wrapper/mod.rs
+++ b/crates/spartan-verifier/src/wrapper/mod.rs
@@ -189,8 +189,9 @@ mod tests {
 		// Use zero-filled public inputs of the correct length.
 		let public = vec![B128::ZERO; public_size];
 		let public_elems = channel.observe_many(&public);
+		// IronSpartanBuilderChannel::Oracle = () and recv_oracle is a no-op, so pass () directly.
 		iop_verifier
-			.verify(public_elems, &mut channel)
+			.verify((), public_elems, &mut channel)
 			.expect("symbolic verify failed");
 
 		let builder = channel.finish();

--- a/crates/spartan-verifier/src/wrapper/zk_wrapped_channel.rs
+++ b/crates/spartan-verifier/src/wrapper/zk_wrapped_channel.rs
@@ -93,9 +93,13 @@ where
 		public.append(&mut self.public_values);
 		public.resize(public_size, F::ZERO);
 
+		// TODO(BINIUS-33 follow-up): Lift precommit oracle reception up to
+		// ZKWrappedVerifierChannel::new so the handle is captured at construction time.
+		let precommit_oracle = self.inner_channel.recv_oracle()?;
+
 		// IOPVerifier::verify takes Vec<Channel::Elem>, not &[F].
 		self.outer_verifier
-			.verify(public.clone(), &mut self.inner_channel)?;
+			.verify(precommit_oracle, public.clone(), &mut self.inner_channel)?;
 		Ok(public)
 	}
 }

--- a/crates/spartan-verifier/tests/proof_size_test.rs
+++ b/crates/spartan-verifier/tests/proof_size_test.rs
@@ -1,6 +1,7 @@
 // Copyright 2026 The Binius Developers
 
 use binius_field::BinaryField128bGhash as B128;
+use binius_iop::channel::IOPVerifierChannel;
 use binius_ip::channel::IPVerifierChannel;
 use binius_spartan_frontend::{
 	circuit_builder::{CircuitBuilder, ConstraintBuilder},
@@ -46,9 +47,14 @@ fn test_ip_proof_size() {
 	let mut channel = verifier.iop_compiler().create_size_tracking_channel();
 	let public = vec![B128::default(); 1 << cs.log_public()];
 	let public_elems = channel.observe_many(&public);
+	// SizeTrackingChannel::Oracle = (), but we still bind to exercise the real call pattern.
+	#[allow(clippy::let_unit_value)]
+	let precommit_oracle = channel
+		.recv_oracle()
+		.expect("recv_oracle on size-tracking channel should succeed");
 	verifier
 		.iop_verifier()
-		.verify(public_elems, &mut channel)
+		.verify(precommit_oracle, public_elems, &mut channel)
 		.expect("verify with size tracking channel should succeed");
 	let proof_size = channel.proof_size();
 


### PR DESCRIPTION
## Summary

- `IOPVerifier::verify` now takes the `precommit_oracle` handle as a parameter instead of receiving it internally. Callers (`Verifier::verify`, `ZKWrappedVerifierChannel::finish`) receive the oracle on the channel first and pass the handle in.
- On the prover side, `IOPProver::prove` no longer packs and commits the precommit segment. A new `IOPProver::commit_precommit` helper returns `(Oracle, FieldBuffer)`, and callers forward both into `prove`. `Prover::prove` and `ZKWrappedProverChannel::finish` are updated accordingly.
- Transcript layout is unchanged — the precommit oracle is still the first on the wire. This is a preparatory refactor for [BINIUS-33](https://linear.app/jimpo/issue/BINIUS-33); the follow-up will lift precommit handling into `ZKWrappedVerifier/ProverChannel::new` (TODOs left in both `finish` methods).

## Test plan

- [x] `cargo clippy --all --all-features --tests --benches --examples -- -D warnings`
- [x] `cargo test -p binius-spartan-verifier -p binius-spartan-prover`
- [x] `wrapper_integration_test` end-to-end ZK-wrapped prove+verify passes
- [x] `proof_size_test` unchanged (transcript layout preserved)
