### PR TITLE
[spartan] OTP-encrypt inner transcript in the ZK wrapper

### DIFF
--- a/crates/ip/Cargo.toml
+++ b/crates/ip/Cargo.toml
@@ -8,6 +8,7 @@ authors.workspace = true
 workspace = true
 
 [dependencies]
+array-util.workspace = true
 binius-field = { path = "../field" }
 binius-math = { path = "../math" }
 binius-transcript = { path = "../transcript" }

--- a/crates/ip/src/channel.rs
+++ b/crates/ip/src/channel.rs
@@ -34,7 +34,7 @@ use binius_transcript::{
 ///
 /// When used with a Fiat-Shamir transcript, the challenges are derived deterministically from
 /// the transcript state, making the protocol non-interactive.
-pub trait IPVerifierChannel<F> {
+pub trait IPVerifierChannel<F: Field> {
 	/// The element type returned by receive and sample methods.
 	type Elem: FieldOps;
 
@@ -47,7 +47,9 @@ pub trait IPVerifierChannel<F> {
 	}
 
 	/// Receives a fixed-size array of field elements from the prover.
-	fn recv_array<const N: usize>(&mut self) -> Result<[Self::Elem; N], Error>;
+	fn recv_array<const N: usize>(&mut self) -> Result<[Self::Elem; N], Error> {
+		array_util::try_from_fn(|_| self.recv_one())
+	}
 
 	/// Samples a random challenge.
 	///
@@ -73,7 +75,9 @@ pub trait IPVerifierChannel<F> {
 	/// Observes multiple field elements, feeding them into the Fiat-Shamir state.
 	///
 	/// Returns the elements converted to `Vec<Self::Elem>`.
-	fn observe_many(&mut self, vals: &[F]) -> Vec<Self::Elem>;
+	fn observe_many(&mut self, vals: &[F]) -> Vec<Self::Elem> {
+		vals.iter().map(|&val| self.observe_one(val)).collect()
+	}
 
 	/// Asserts that a value is zero.
 	///

--- a/crates/prover/src/zk_config.rs
+++ b/crates/prover/src/zk_config.rs
@@ -151,6 +151,7 @@ where
 			basefold_channel,
 			&self.outer_iop_prover,
 			&self.outer_layout,
+			&mut rng,
 			{
 				let inner_iop_verifier = &self.inner_iop_verifier;
 				move |replay_channel: &mut ReplayChannel<'_, B128>| {

--- a/crates/spartan-frontend/src/constraint_system.rs
+++ b/crates/spartan-frontend/src/constraint_system.rs
@@ -378,12 +378,16 @@ impl<F: Field> WitnessLayout<F> {
 	}
 
 	pub fn with_blinding(self, info: BlindingInfo) -> Self {
-		let blinding_size = info.n_dummy_wires + 3 * info.n_dummy_constraints;
+		// Precommit is a ZK-hidden oracle that only needs dummy wires; no dummy mul constraints
+		// are added to it. Private gets both. Keep this in sync with
+		// `ConstraintSystemPadded::new` in the verifier crate.
+		let precommit_blinding_size = info.n_dummy_wires;
+		let private_blinding_size = info.n_dummy_wires + 3 * info.n_dummy_constraints;
 
-		let total_precommit = self.n_precommit as usize + blinding_size;
+		let total_precommit = self.n_precommit as usize + precommit_blinding_size;
 		let log_precommit = log2_ceil_usize(total_precommit) as u32;
 
-		let total_private = self.n_private as usize + blinding_size;
+		let total_private = self.n_private as usize + private_blinding_size;
 		let log_private = log2_ceil_usize(total_private) as u32;
 
 		Self {

--- a/crates/spartan-prover/src/lib.rs
+++ b/crates/spartan-prover/src/lib.rs
@@ -151,11 +151,16 @@ impl<F: Field> IOPProver<F> {
 		Channel: IOPProverChannel<P>,
 	{
 		let cs = &self.constraint_system;
+		// Precommit segment has no dummy mul-constraint blinding (see ConstraintSystemPadded).
+		let precommit_blinding = BlindingInfo {
+			n_dummy_wires: cs.blinding_info().n_dummy_wires,
+			n_dummy_constraints: 0,
+		};
 		let precommit_packed = pack_and_blind_witness::<_, P>(
 			cs.log_precommit() as usize,
 			witness.precommit(),
 			cs.n_precommit() as usize,
-			cs.blinding_info(),
+			&precommit_blinding,
 			rng,
 		);
 		let precommit_oracle = channel.send_oracle(precommit_packed.to_ref());

--- a/crates/spartan-prover/src/wrapper/zk_wrapped_prover_channel.rs
+++ b/crates/spartan-prover/src/wrapper/zk_wrapped_prover_channel.rs
@@ -273,6 +273,16 @@ where
 			Item = (Self::Oracle, FieldBuffer<P>, FieldBuffer<P>, P::Scalar),
 		>,
 	) {
+		let oracle_relations = oracle_relations.into_iter().collect::<Vec<_>>();
+
+		// For each oracle opening, the prover sends the decrypted evaluation. The outer verifier
+		// checks in the circuit equality of this value with the expected expression over encrypted
+		// values.
+		for (_, _, _, claim) in &oracle_relations {
+			self.inner_channel.send_one(*claim);
+			self.interaction.push(*claim);
+		}
+
 		self.inner_channel.prove_oracle_relations(oracle_relations)
 	}
 }

--- a/crates/spartan-prover/src/wrapper/zk_wrapped_prover_channel.rs
+++ b/crates/spartan-prover/src/wrapper/zk_wrapped_prover_channel.rs
@@ -28,7 +28,7 @@ use binius_transcript::fiat_shamir::Challenger;
 use binius_utils::SerializeBytes;
 use rand::CryptoRng;
 
-use crate::IOPProver;
+use crate::{Error, IOPProver, pack_and_blind_witness};
 
 /// A prover channel that wraps a [`BaseFoldZKProverChannel`] and an outer Spartan IOP prover.
 ///
@@ -52,6 +52,8 @@ where
 	outer_prover: &'a IOPProver<P::Scalar>,
 	outer_layout: &'a WitnessLayout<P::Scalar>,
 	replay_fn: ReplayFn,
+	keys: Vec<P::Scalar>,
+	next_key_idx: usize,
 	interaction: Vec<P::Scalar>,
 	/// Handle to the outer precommit oracle committed at construction time. The buffer
 	/// (`precommit_packed`) is purely random — it is the one-time-pad encryption key for the
@@ -120,14 +122,26 @@ where
 			"outer private/mask oracle specs must be the final suffix of channel specs",
 		);
 
-		// Commit a random buffer as the outer precommit oracle. This is the one-time-pad
-		// encryption key for the outer encrypted transcript (to be wired up in a follow-up).
-		let log_precommit = outer_prover.constraint_system().log_precommit() as usize;
-		let precommit_packed = FieldBuffer::<P>::new(
-			log_precommit,
-			repeat_with(|| P::random(&mut rng))
-				.take(1 << log_precommit.saturating_sub(P::LOG_WIDTH))
-				.collect(),
+		// Commit random OTP keys as the outer precommit oracle. Each key encrypts one
+		// element sent by the inner prover through this wrapped channel; the outer CS
+		// (built symbolically from the inner verifier) contains a matching precommit wire per
+		// key that the outer proof uses to decrypt.
+		let cs = outer_prover.constraint_system();
+		let keys = repeat_with(|| F::random(&mut rng))
+			.take(cs.n_precommit() as usize)
+			.collect::<Vec<F>>();
+		// The precommit segment has no dummy mul-constraint blinding (see
+		// ConstraintSystemPadded::new) — mirror that when packing.
+		let precommit_blinding = binius_spartan_frontend::constraint_system::BlindingInfo {
+			n_dummy_wires: cs.blinding_info().n_dummy_wires,
+			n_dummy_constraints: 0,
+		};
+		let precommit_packed = pack_and_blind_witness::<_, P>(
+			cs.log_precommit() as usize,
+			&keys,
+			cs.n_precommit() as usize,
+			&precommit_blinding,
+			&mut rng,
 		);
 		let precommit_oracle = inner_channel.send_oracle(precommit_packed.to_ref());
 
@@ -136,11 +150,19 @@ where
 			outer_prover,
 			outer_layout,
 			replay_fn,
+			keys,
+			next_key_idx: 0,
 			interaction: Vec::new(),
 			precommit_oracle,
 			precommit_packed,
 			n_outer_suffix_oracles: suffix_len,
 		}
+	}
+
+	fn next_key(&mut self) -> F {
+		let key = self.keys[self.next_key_idx];
+		self.next_key_idx += 1;
+		key
 	}
 
 	/// Consumes the channel and runs the outer proof.
@@ -150,7 +172,7 @@ where
 	/// 1. Creates a [`ReplayChannel`] from the recorded interaction
 	/// 2. Calls the `replay_fn` closure to replay the inner verification and fill the outer witness
 	/// 3. Validates and generates the outer IOP proof
-	pub fn finish(self, rng: impl CryptoRng) -> Result<(), crate::Error>
+	pub fn finish(self, rng: impl CryptoRng) -> Result<(), Error>
 	where
 		ReplayFn: FnOnce(&mut ReplayChannel<'_, F>),
 	{
@@ -159,6 +181,7 @@ where
 			outer_prover,
 			outer_layout,
 			replay_fn,
+			keys,
 			interaction,
 			precommit_oracle,
 			precommit_packed,
@@ -166,7 +189,7 @@ where
 		} = self;
 
 		// Replay the inner verification through the outer witness generator.
-		let mut replay_channel = ReplayChannel::new(outer_layout, interaction);
+		let mut replay_channel = ReplayChannel::new(outer_layout, keys, interaction);
 		replay_fn(&mut replay_channel);
 		let witness = replay_channel
 			.finish()
@@ -197,23 +220,18 @@ where
 	Challenger_: Challenger,
 {
 	fn send_one(&mut self, elem: F) {
-		self.inner_channel.send_one(elem);
-		self.interaction.push(elem);
-	}
-
-	fn send_many(&mut self, elems: &[F]) {
-		self.inner_channel.send_many(elems);
-		self.interaction.extend_from_slice(elems);
+		let key = self.next_key();
+		// Encrypt the element with the OTP key before sending. Record the encrypted value in
+		// `interaction` — that's what the outer witness's inout wires hold (and what the replay
+		// side adds the key back to in order to recover the plaintext for the inner verifier).
+		let encrypted = elem + key;
+		self.inner_channel.send_one(encrypted);
+		self.interaction.push(encrypted);
 	}
 
 	fn observe_one(&mut self, val: F) {
 		self.inner_channel.observe_one(val);
 		self.interaction.push(val);
-	}
-
-	fn observe_many(&mut self, vals: &[F]) {
-		self.inner_channel.observe_many(vals);
-		self.interaction.extend_from_slice(vals);
 	}
 
 	fn sample(&mut self) -> F {

--- a/crates/spartan-prover/src/wrapper/zk_wrapped_prover_channel.rs
+++ b/crates/spartan-prover/src/wrapper/zk_wrapped_prover_channel.rs
@@ -11,6 +11,8 @@
 //! [`BaseFoldZKProverChannel`]: binius_iop_prover::basefold_zk_channel::BaseFoldZKProverChannel
 //! [`finish`]: ZKWrappedProverChannel::finish
 
+use std::iter::repeat_with;
+
 use binius_field::{BinaryField, PackedExtension, PackedField};
 use binius_iop::{channel::OracleSpec, merkle_tree::MerkleTreeScheme};
 use binius_iop_prover::{
@@ -51,7 +53,15 @@ where
 	outer_layout: &'a WitnessLayout<P::Scalar>,
 	replay_fn: ReplayFn,
 	interaction: Vec<P::Scalar>,
-	n_outer_oracles: usize,
+	/// Handle to the outer precommit oracle committed at construction time. The buffer
+	/// (`precommit_packed`) is purely random — it is the one-time-pad encryption key for the
+	/// outer encrypted transcript (to be wired up in a follow-up; for now the outer circuit has
+	/// no precommit wires that reference it).
+	precommit_oracle: BaseFoldZKOracle,
+	precommit_packed: FieldBuffer<P>,
+	/// Number of outer oracles still to be committed on `inner_channel` during `finish` (the
+	/// outer prover's non-precommit oracles — private and mask).
+	n_outer_suffix_oracles: usize,
 }
 
 impl<'a, F, P, NTT, MTScheme, MTProver, Challenger_, ReplayFn>
@@ -66,18 +76,28 @@ where
 {
 	/// Creates a new ZK-wrapped prover channel.
 	///
+	/// Commits the outer prover's precommit oracle on the inner channel as part of construction:
+	/// a random [`FieldBuffer<P>`] the size of the outer precommit oracle segment is sent to
+	/// the channel and kept for use in [`Self::finish`]. This random buffer is the one-time-pad
+	/// encryption key for the (future) outer encrypted transcript.
+	///
+	/// The inner channel's oracle specs are expected to be laid out as
+	/// `[outer_precommit, inner..., outer_private, outer_mask]`.
+	///
 	/// # Arguments
 	///
 	/// * `inner_channel` - The BaseFold ZK channel with oracle specs for both inner and outer
 	///   proofs
 	/// * `outer_prover` - The IOP prover for the outer (wrapper) constraint system
 	/// * `outer_layout` - The witness layout for the outer constraint system
+	/// * `rng` - RNG used to generate the random precommit buffer (the future OTP key)
 	/// * `replay_fn` - Closure called during [`finish`](Self::finish) with a [`ReplayChannel`] to
 	///   replay the inner verification and fill the outer witness
 	pub fn new(
-		inner_channel: BaseFoldZKProverChannel<'a, F, P, NTT, MTProver, Challenger_>,
+		mut inner_channel: BaseFoldZKProverChannel<'a, F, P, NTT, MTProver, Challenger_>,
 		outer_prover: &'a IOPProver<F>,
 		outer_layout: &'a WitnessLayout<F>,
+		mut rng: impl CryptoRng,
 		replay_fn: ReplayFn,
 	) -> Self {
 		let outer_oracle_specs =
@@ -85,15 +105,31 @@ where
 		let all_specs = inner_channel.remaining_oracle_specs();
 		let n_outer = outer_oracle_specs.len();
 		assert!(
-			all_specs.len() >= n_outer,
-			"outer oracle specs ({n_outer}) exceed channel oracle specs ({})",
+			n_outer >= 1 && all_specs.len() >= n_outer,
+			"outer oracle specs ({n_outer}) exceed channel oracle specs ({}) or are empty",
 			all_specs.len(),
 		);
 		assert_eq!(
-			&all_specs[all_specs.len() - n_outer..],
-			&outer_oracle_specs,
-			"outer oracle specs must be a suffix of channel oracle specs",
+			all_specs[0], outer_oracle_specs[0],
+			"outer precommit oracle spec must be the first spec on the channel",
 		);
+		let suffix_len = n_outer - 1;
+		assert_eq!(
+			&all_specs[all_specs.len() - suffix_len..],
+			&outer_oracle_specs[1..],
+			"outer private/mask oracle specs must be the final suffix of channel specs",
+		);
+
+		// Commit a random buffer as the outer precommit oracle. This is the one-time-pad
+		// encryption key for the outer encrypted transcript (to be wired up in a follow-up).
+		let log_precommit = outer_prover.constraint_system().log_precommit() as usize;
+		let precommit_packed = FieldBuffer::<P>::new(
+			log_precommit,
+			repeat_with(|| P::random(&mut rng))
+				.take(1 << log_precommit.saturating_sub(P::LOG_WIDTH))
+				.collect(),
+		);
+		let precommit_oracle = inner_channel.send_oracle(precommit_packed.to_ref());
 
 		Self {
 			inner_channel,
@@ -101,7 +137,9 @@ where
 			outer_layout,
 			replay_fn,
 			interaction: Vec::new(),
-			n_outer_oracles: n_outer,
+			precommit_oracle,
+			precommit_packed,
+			n_outer_suffix_oracles: suffix_len,
 		}
 	}
 
@@ -112,16 +150,18 @@ where
 	/// 1. Creates a [`ReplayChannel`] from the recorded interaction
 	/// 2. Calls the `replay_fn` closure to replay the inner verification and fill the outer witness
 	/// 3. Validates and generates the outer IOP proof
-	pub fn finish(self, mut rng: impl CryptoRng) -> Result<(), crate::Error>
+	pub fn finish(self, rng: impl CryptoRng) -> Result<(), crate::Error>
 	where
 		ReplayFn: FnOnce(&mut ReplayChannel<'_, F>),
 	{
 		let Self {
-			mut inner_channel,
+			inner_channel,
 			outer_prover,
 			outer_layout,
 			replay_fn,
 			interaction,
+			precommit_oracle,
+			precommit_packed,
 			..
 		} = self;
 
@@ -135,11 +175,6 @@ where
 		// Validate and generate the outer proof.
 		let outer_cs = outer_prover.constraint_system();
 		outer_cs.validate(&witness);
-
-		// TODO(BINIUS-33 follow-up): Lift precommit oracle commitment up to
-		// ZKWrappedProverChannel::new so the handle is obtained at construction time.
-		let (precommit_oracle, precommit_packed) =
-			outer_prover.commit_precommit::<P, _>(&witness, &mut rng, &mut inner_channel);
 		outer_prover.prove::<P, _>(
 			witness,
 			precommit_oracle,
@@ -202,7 +237,7 @@ where
 
 	fn remaining_oracle_specs(&self) -> &[OracleSpec] {
 		let remaining = self.inner_channel.remaining_oracle_specs();
-		let n_inner_remaining = remaining.len() - self.n_outer_oracles;
+		let n_inner_remaining = remaining.len() - self.n_outer_suffix_oracles;
 		&remaining[..n_inner_remaining]
 	}
 

--- a/crates/spartan-prover/tests/wrapper_integration_test.rs
+++ b/crates/spartan-prover/tests/wrapper_integration_test.rs
@@ -92,13 +92,20 @@ fn test_zk_wrapped_prove_verify() {
 
 	let compression = StdCompression::default();
 	let merkle_scheme = BinaryMerkleTreeScheme::<B128, StdDigest, _>::new(compression.clone());
+
+	// Transcript layout: outer precommit oracle first (committed at wrapper construction),
+	// then all inner oracles, then the remaining outer oracles (private, mask).
+	let outer_oracle_specs = outer_iop_verifier.oracle_specs();
+	let combined_oracle_specs = [
+		vec![outer_oracle_specs[0]],
+		inner_iop_verifier.oracle_specs(),
+		outer_oracle_specs[1..].to_vec(),
+	]
+	.concat();
+
 	let zk_basefold_compiler = BaseFoldZKVerifierCompiler::new(
 		merkle_scheme,
-		[
-			inner_iop_verifier.oracle_specs(),
-			outer_iop_verifier.oracle_specs(),
-		]
-		.concat(),
+		combined_oracle_specs,
 		log_inv_rate,
 		n_test_queries,
 		&MinProofSizeStrategy,
@@ -135,8 +142,12 @@ fn test_zk_wrapped_prove_verify() {
 	prover_transcript.observe().write_slice(&public);
 
 	let basefold_channel = zk_basefold_prover.create_channel(&mut prover_transcript, &mut rng);
-	let mut wrapped_prover_channel =
-		ZKWrappedProverChannel::new(basefold_channel, &outer_iop_prover, &outer_layout, {
+	let mut wrapped_prover_channel = ZKWrappedProverChannel::new(
+		basefold_channel,
+		&outer_iop_prover,
+		&outer_layout,
+		&mut rng,
+		{
 			let inner_iop_verifier = &inner_iop_verifier;
 			let public = &public;
 			move |replay_channel: &mut ReplayChannel<'_, B128>| {
@@ -146,7 +157,8 @@ fn test_zk_wrapped_prove_verify() {
 					.verify((), inner_public_elems, replay_channel)
 					.expect("replay verification should not fail");
 			}
-		});
+		},
+	);
 
 	// Observe public input through the wrapped channel.
 	(&mut wrapped_prover_channel).observe_many(&public);
@@ -180,7 +192,8 @@ fn test_zk_wrapped_prove_verify() {
 
 	let verifier_channel = zk_basefold_compiler.create_channel(&mut verifier_transcript);
 	let mut wrapped_verifier_channel =
-		ZKWrappedVerifierChannel::new(verifier_channel, &outer_iop_verifier);
+		ZKWrappedVerifierChannel::new(verifier_channel, &outer_iop_verifier)
+			.expect("ZKWrappedVerifierChannel::new should succeed");
 
 	// Observe public input through the wrapped channel.
 	let inner_public_elems = wrapped_verifier_channel.observe_many(&public);

--- a/crates/spartan-verifier/Cargo.toml
+++ b/crates/spartan-verifier/Cargo.toml
@@ -8,6 +8,7 @@ authors.workspace = true
 workspace = true
 
 [dependencies]
+array-util.workspace = true
 binius-field = { path = "../field" }
 binius-hash = { path = "../hash", default-features = false }
 binius-iop = { path = "../iop" }

--- a/crates/spartan-verifier/src/constraint_system.rs
+++ b/crates/spartan-verifier/src/constraint_system.rs
@@ -35,18 +35,17 @@ impl<F: Field> ConstraintSystemPadded<F> {
 	/// 4. Computes mask buffer dimensions for the ZK mulcheck mask polynomial
 	pub fn new(cs: ConstraintSystem<F>, blinding_info: BlindingInfo) -> Self {
 		let mut mul_constraints = cs.mul_constraints().to_vec();
-		let blinding_size = blinding_info.n_dummy_wires + 3 * blinding_info.n_dummy_constraints;
 
 		/// Adds dummy blinding constraints for a segment and returns its padded log-size.
 		fn add_blinding_constraints(
 			mul_constraints: &mut Vec<MulConstraint<WitnessIndex>>,
 			make_index: fn(u32) -> WitnessIndex,
 			n_circuit_wires: usize,
-			blinding_info: &BlindingInfo,
-			blinding_size: usize,
+			n_dummy_wires: usize,
+			n_dummy_constraints: usize,
 		) -> u32 {
-			let dummy_base = n_circuit_wires + blinding_info.n_dummy_wires;
-			for i in 0..blinding_info.n_dummy_constraints {
+			let dummy_base = n_circuit_wires + n_dummy_wires;
+			for i in 0..n_dummy_constraints {
 				let a = make_index((dummy_base + 3 * i) as u32);
 				let b = make_index((dummy_base + 3 * i + 1) as u32);
 				let c = make_index((dummy_base + 3 * i + 2) as u32);
@@ -56,6 +55,8 @@ impl<F: Field> ConstraintSystemPadded<F> {
 					c: Operand::from(c),
 				});
 			}
+
+			let blinding_size = n_dummy_wires + 3 * n_dummy_constraints;
 			log2_ceil_usize(n_circuit_wires + blinding_size) as u32
 		}
 
@@ -63,15 +64,16 @@ impl<F: Field> ConstraintSystemPadded<F> {
 			&mut mul_constraints,
 			WitnessIndex::precommit,
 			cs.n_precommit() as usize,
-			&blinding_info,
-			blinding_size,
+			blinding_info.n_dummy_wires,
+			// Precommit segment doesn't need dummy constraints, only the private segment does.
+			0,
 		);
 		let log_private = add_blinding_constraints(
 			&mut mul_constraints,
 			WitnessIndex::private,
 			cs.n_private() as usize,
-			&blinding_info,
-			blinding_size,
+			blinding_info.n_dummy_wires,
+			blinding_info.n_dummy_constraints,
 		);
 
 		// Pad to next power of two with `one * one = one` constraints

--- a/crates/spartan-verifier/src/wrapper/channel.rs
+++ b/crates/spartan-verifier/src/wrapper/channel.rs
@@ -2,14 +2,14 @@
 
 //! Channels that symbolically execute a verifier to build constraint systems or fill witnesses.
 
-use std::{cell::RefCell, rc::Rc};
+use std::{cell::RefCell, rc::Rc, vec::IntoIter as VecIntoIter};
 
 use binius_field::Field;
 use binius_iop::channel::{IOPVerifierChannel, OracleLinearRelation, OracleSpec};
 use binius_ip::channel::IPVerifierChannel;
 use binius_spartan_frontend::{
-	circuit_builder::{CircuitBuilder, ConstraintBuilder, WitnessGenerator},
-	constraint_system::{ConstraintWire, WitnessLayout},
+	circuit_builder::{CircuitBuilder, ConstraintBuilder, WitnessError, WitnessGenerator},
+	constraint_system::{ConstraintWire, Witness, WitnessLayout},
 };
 
 use super::circuit_elem::{CircuitElem, CircuitWire};
@@ -40,6 +40,11 @@ impl<F: Field> IronSpartanBuilderChannel<F> {
 		CircuitElem::Wire(CircuitWire::new(&self.builder, wire))
 	}
 
+	fn alloc_precommit_elem(&self) -> CircuitElem<ConstraintBuilder<F>> {
+		let wire = self.builder.borrow_mut().alloc_precommit();
+		CircuitElem::Wire(CircuitWire::new(&self.builder, wire))
+	}
+
 	/// Consumes the channel and returns the underlying [`ConstraintBuilder`].
 	///
 	/// This must be called after all `CircuitElem` values derived from this channel have been
@@ -55,15 +60,12 @@ impl<F: Field> IPVerifierChannel<F> for IronSpartanBuilderChannel<F> {
 	type Elem = CircuitElem<ConstraintBuilder<F>>;
 
 	fn recv_one(&mut self) -> Result<Self::Elem, binius_ip::channel::Error> {
-		Ok(self.alloc_inout_elem())
-	}
-
-	fn recv_many(&mut self, n: usize) -> Result<Vec<Self::Elem>, binius_ip::channel::Error> {
-		Ok((0..n).map(|_| self.alloc_inout_elem()).collect())
-	}
-
-	fn recv_array<const N: usize>(&mut self) -> Result<[Self::Elem; N], binius_ip::channel::Error> {
-		Ok(std::array::from_fn(|_| self.alloc_inout_elem()))
+		// For each element that the inner prover sends, the wrapped prover allocates a one-time-pad
+		// encryption key in the precommit segment and encrypts the underlying value before sending.
+		// Here the verifier gets the encryption key from the precommit segment and decrypts.
+		let inout = self.alloc_inout_elem();
+		let key = self.alloc_precommit_elem();
+		Ok(inout - key)
 	}
 
 	fn sample(&mut self) -> Self::Elem {
@@ -72,10 +74,6 @@ impl<F: Field> IPVerifierChannel<F> for IronSpartanBuilderChannel<F> {
 
 	fn observe_one(&mut self, _val: F) -> Self::Elem {
 		self.alloc_inout_elem()
-	}
-
-	fn observe_many(&mut self, vals: &[F]) -> Vec<Self::Elem> {
-		(0..vals.len()).map(|_| self.alloc_inout_elem()).collect()
 	}
 
 	fn assert_zero(&mut self, val: Self::Elem) -> Result<(), binius_ip::channel::Error> {
@@ -118,40 +116,52 @@ impl<F: Field> IOPVerifierChannel<F> for IronSpartanBuilderChannel<F> {
 /// [`CircuitElem`] values, the [`WitnessGenerator`] fills private wires.
 pub struct ReplayChannel<'a, F: Field> {
 	witness_gen: Rc<RefCell<WitnessGenerator<'a, F>>>,
-	events: std::vec::IntoIter<F>,
+	keys: VecIntoIter<F>,
+	events: VecIntoIter<F>,
 	next_inout_id: u32,
+	next_precommit_id: u32,
 }
 
 impl<'a, F: Field> ReplayChannel<'a, F> {
 	/// Creates a new replay channel.
-	pub fn new(layout: &'a WitnessLayout<F>, events: Vec<F>) -> Self {
+	///
+	/// TODO: Document args. Keys are the symmetric OTP keys for the received values.
+	pub fn new(layout: &'a WitnessLayout<F>, keys: Vec<F>, events: Vec<F>) -> Self {
 		Self {
 			witness_gen: Rc::new(RefCell::new(WitnessGenerator::new(layout))),
+			keys: keys.into_iter(),
 			events: events.into_iter(),
 			next_inout_id: 0,
+			next_precommit_id: 0,
 		}
 	}
 
-	fn next_inout_elem(&mut self, value: F) -> CircuitElem<WitnessGenerator<'a, F>> {
+	fn next_inout_elem(&mut self) -> CircuitElem<WitnessGenerator<'a, F>> {
+		let value = self
+			.events
+			.next()
+			.unwrap_or_else(|| panic!("replay exhausted: no more events"));
+
 		let wire = ConstraintWire::inout(self.next_inout_id);
 		self.next_inout_id += 1;
 		let witness_wire = self.witness_gen.borrow_mut().write_inout(wire, value);
 		CircuitElem::Wire(CircuitWire::new(&self.witness_gen, witness_wire))
 	}
 
-	fn next_event(&mut self) -> F {
-		self.events
+	fn next_precommit_elem(&mut self) -> CircuitElem<WitnessGenerator<'a, F>> {
+		let value = self
+			.keys
 			.next()
-			.unwrap_or_else(|| panic!("replay exhausted: no more events"))
+			.expect("precommit segment is sized incorrectly");
+
+		let wire = ConstraintWire::precommit(self.next_precommit_id);
+		self.next_precommit_id += 1;
+		let witness_wire = self.witness_gen.borrow_mut().write_precommit(wire, value);
+		CircuitElem::Wire(CircuitWire::new(&self.witness_gen, witness_wire))
 	}
 
 	/// Consumes the channel and builds the outer witness.
-	pub fn finish(
-		self,
-	) -> Result<
-		binius_spartan_frontend::constraint_system::Witness<F>,
-		binius_spartan_frontend::circuit_builder::WitnessError,
-	> {
+	pub fn finish(self) -> Result<Witness<F>, WitnessError> {
 		Rc::try_unwrap(self.witness_gen)
 			.expect("CircuitElem values should only hold Weak references")
 			.into_inner()
@@ -163,34 +173,17 @@ impl<'a, F: Field> IPVerifierChannel<F> for ReplayChannel<'a, F> {
 	type Elem = CircuitElem<WitnessGenerator<'a, F>>;
 
 	fn recv_one(&mut self) -> Result<Self::Elem, binius_ip::channel::Error> {
-		let val = self.next_event();
-		Ok(self.next_inout_elem(val))
-	}
-
-	fn recv_many(&mut self, n: usize) -> Result<Vec<Self::Elem>, binius_ip::channel::Error> {
-		(0..n).map(|_| self.recv_one()).collect()
-	}
-
-	fn recv_array<const N: usize>(&mut self) -> Result<[Self::Elem; N], binius_ip::channel::Error> {
-		let mut result = [(); N].map(|_| CircuitElem::Constant(F::ZERO));
-		for elem in &mut result {
-			*elem = self.recv_one()?;
-		}
-		Ok(result)
+		let encrypted_elem = self.next_inout_elem();
+		let key = self.next_precommit_elem();
+		Ok(encrypted_elem + key)
 	}
 
 	fn sample(&mut self) -> Self::Elem {
-		let val = self.next_event();
-		self.next_inout_elem(val)
+		self.next_inout_elem()
 	}
 
 	fn observe_one(&mut self, _val: F) -> Self::Elem {
-		let val = self.next_event();
-		self.next_inout_elem(val)
-	}
-
-	fn observe_many(&mut self, vals: &[F]) -> Vec<Self::Elem> {
-		vals.iter().map(|&val| self.observe_one(val)).collect()
+		self.next_inout_elem()
 	}
 
 	fn assert_zero(&mut self, val: Self::Elem) -> Result<(), binius_ip::channel::Error> {

--- a/crates/spartan-verifier/src/wrapper/channel.rs
+++ b/crates/spartan-verifier/src/wrapper/channel.rs
@@ -101,8 +101,15 @@ impl<F: Field> IOPVerifierChannel<F> for IronSpartanBuilderChannel<F> {
 
 	fn verify_oracle_relations<'a>(
 		&mut self,
-		_oracle_relations: impl IntoIterator<Item = OracleLinearRelation<'a, Self::Oracle, Self::Elem>>,
+		oracle_relations: impl IntoIterator<Item = OracleLinearRelation<'a, Self::Oracle, Self::Elem>>,
 	) -> Result<(), binius_iop::channel::Error> {
+		// For each oracle opening, the prover sends the decrypted evaluation. The outer verifier
+		// checks in the circuit equality of this value with the expected expression over encrypted
+		// values.
+		for relation in oracle_relations {
+			let decrypted_claim = self.alloc_inout_elem();
+			self.assert_zero(relation.claim - decrypted_claim)?;
+		}
 		Ok(())
 	}
 }
@@ -211,8 +218,15 @@ impl<'a, F: Field> IOPVerifierChannel<F> for ReplayChannel<'a, F> {
 
 	fn verify_oracle_relations<'b>(
 		&mut self,
-		_oracle_relations: impl IntoIterator<Item = OracleLinearRelation<'b, Self::Oracle, Self::Elem>>,
+		oracle_relations: impl IntoIterator<Item = OracleLinearRelation<'b, Self::Oracle, Self::Elem>>,
 	) -> Result<(), binius_iop::channel::Error> {
+		// For each oracle opening, the prover sends the decrypted evaluation. The outer verifier
+		// checks in the circuit equality of this value with the expected expression over encrypted
+		// values.
+		for relation in oracle_relations {
+			let decrypted_claim = self.next_inout_elem();
+			self.assert_zero(relation.claim - decrypted_claim)?;
+		}
 		Ok(())
 	}
 }

--- a/crates/spartan-verifier/src/wrapper/zk_wrapped_channel.rs
+++ b/crates/spartan-verifier/src/wrapper/zk_wrapped_channel.rs
@@ -98,9 +98,7 @@ where
 	///
 	/// Prepends the outer constraint system's constants to the recorded public values, pads to
 	/// the required public size, and runs [`IOPVerifier::verify`] against the inner channel.
-	///
-	/// Returns the full public input vector on success.
-	pub fn finish(mut self) -> Result<Vec<F>, Error> {
+	pub fn finish(mut self) -> Result<(), Error> {
 		let outer_cs = self.outer_verifier.constraint_system();
 		let public_size = 1 << outer_cs.log_public();
 
@@ -110,8 +108,8 @@ where
 
 		// IOPVerifier::verify takes Vec<Channel::Elem>, not &[F].
 		self.outer_verifier
-			.verify(self.precommit_oracle, public.clone(), &mut self.inner_channel)?;
-		Ok(public)
+			.verify(self.precommit_oracle, public, &mut self.inner_channel)?;
+		Ok(())
 	}
 }
 
@@ -130,18 +128,6 @@ where
 		Ok(val)
 	}
 
-	fn recv_many(&mut self, n: usize) -> Result<Vec<F>, binius_ip::channel::Error> {
-		let vals = self.inner_channel.recv_many(n)?;
-		self.public_values.extend_from_slice(&vals);
-		Ok(vals)
-	}
-
-	fn recv_array<const N: usize>(&mut self) -> Result<[F; N], binius_ip::channel::Error> {
-		let vals = self.inner_channel.recv_array::<N>()?;
-		self.public_values.extend_from_slice(&vals);
-		Ok(vals)
-	}
-
 	fn sample(&mut self) -> F {
 		let val = self.inner_channel.sample();
 		self.public_values.push(val);
@@ -152,12 +138,6 @@ where
 		let elem = self.inner_channel.observe_one(val);
 		self.public_values.push(elem);
 		elem
-	}
-
-	fn observe_many(&mut self, vals: &[F]) -> Vec<F> {
-		let elems = self.inner_channel.observe_many(vals);
-		self.public_values.extend_from_slice(&elems);
-		elems
 	}
 
 	fn assert_zero(&mut self, _val: F) -> Result<(), binius_ip::channel::Error> {

--- a/crates/spartan-verifier/src/wrapper/zk_wrapped_channel.rs
+++ b/crates/spartan-verifier/src/wrapper/zk_wrapped_channel.rs
@@ -173,6 +173,16 @@ where
 		&mut self,
 		oracle_relations: impl IntoIterator<Item = OracleLinearRelation<'b, Self::Oracle, Self::Elem>>,
 	) -> Result<(), binius_iop::channel::Error> {
+		let oracle_relations = oracle_relations
+			.into_iter()
+			.map(|relation| {
+				let decrypted_claim = self.recv_one()?;
+				Ok(OracleLinearRelation {
+					claim: decrypted_claim,
+					..relation
+				})
+			})
+			.collect::<Result<Vec<_>, binius_iop::channel::Error>>()?;
 		self.inner_channel.verify_oracle_relations(oracle_relations)
 	}
 }

--- a/crates/spartan-verifier/src/wrapper/zk_wrapped_channel.rs
+++ b/crates/spartan-verifier/src/wrapper/zk_wrapped_channel.rs
@@ -33,8 +33,11 @@ where
 {
 	inner_channel: BaseFoldZKVerifierChannel<'a, F, MTScheme, Challenger_>,
 	outer_verifier: &'a IOPVerifier<F>,
+	precommit_oracle: BaseFoldZKOracle,
 	public_values: Vec<F>,
-	n_outer_oracles: usize,
+	/// Number of outer oracles still to be received on `inner_channel` after inner verification
+	/// completes (i.e. the outer verifier's non-precommit oracles — private and mask).
+	n_outer_suffix_oracles: usize,
 }
 
 impl<'a, F, MTScheme, Challenger_> ZKWrappedVerifierChannel<'a, F, MTScheme, Challenger_>
@@ -45,38 +48,50 @@ where
 {
 	/// Creates a new ZK-wrapped verifier channel.
 	///
-	/// The outer verifier's oracle specs must be a suffix of the inner channel's oracle specs.
+	/// The outer verifier's oracle specs are expected to straddle the inner channel specs:
+	/// the outer precommit spec is at position 0 (committed before any inner interaction), and
+	/// the remaining outer specs (private, mask) form a suffix that will be received after the
+	/// inner verification completes. `new` receives the outer precommit oracle from the inner
+	/// channel and stores the handle for use in [`Self::finish`].
 	///
 	/// # Panics
 	///
-	/// Panics if the outer oracle specs are not a suffix of the channel's oracle specs.
+	/// Panics if the channel's oracle specs do not match the expected layout
+	/// `[outer_precommit, inner..., outer_private, outer_mask]`.
 	pub fn new(
-		inner_channel: BaseFoldZKVerifierChannel<'a, F, MTScheme, Challenger_>,
+		mut inner_channel: BaseFoldZKVerifierChannel<'a, F, MTScheme, Challenger_>,
 		outer_verifier: &'a IOPVerifier<F>,
-	) -> Self {
+	) -> Result<Self, Error> {
 		let outer_oracle_specs = outer_verifier.oracle_specs();
 		let channel_oracle_specs = inner_channel.remaining_oracle_specs();
 
 		let n_outer = outer_oracle_specs.len();
 		let n_total = channel_oracle_specs.len();
 		assert!(
-			n_outer <= n_total,
-			"outer oracle specs ({n_outer}) exceed channel oracle specs ({n_total})"
+			n_outer >= 1 && n_outer <= n_total,
+			"outer oracle specs ({n_outer}) exceed channel oracle specs ({n_total}) or are empty"
+		);
+		assert_eq!(
+			channel_oracle_specs[0], outer_oracle_specs[0],
+			"outer precommit oracle spec must be the first spec on the channel"
+		);
+		let suffix_len = n_outer - 1;
+		assert_eq!(
+			&channel_oracle_specs[n_total - suffix_len..],
+			&outer_oracle_specs[1..],
+			"outer private/mask oracle specs must be the final suffix of channel specs"
 		);
 
-		let suffix = &channel_oracle_specs[n_total - n_outer..];
-		assert_eq!(
-			suffix, &outer_oracle_specs,
-			"outer oracle specs must be a suffix of channel oracle specs"
-		);
+		let precommit_oracle = inner_channel.recv_oracle()?;
 
 		let outer_public_size = 1 << outer_verifier.constraint_system().log_public();
-		Self {
+		Ok(Self {
 			inner_channel,
 			outer_verifier,
+			precommit_oracle,
 			public_values: Vec::with_capacity(outer_public_size),
-			n_outer_oracles: n_outer,
-		}
+			n_outer_suffix_oracles: suffix_len,
+		})
 	}
 
 	/// Consumes the channel and runs the outer verifier.
@@ -93,13 +108,9 @@ where
 		public.append(&mut self.public_values);
 		public.resize(public_size, F::ZERO);
 
-		// TODO(BINIUS-33 follow-up): Lift precommit oracle reception up to
-		// ZKWrappedVerifierChannel::new so the handle is captured at construction time.
-		let precommit_oracle = self.inner_channel.recv_oracle()?;
-
 		// IOPVerifier::verify takes Vec<Channel::Elem>, not &[F].
 		self.outer_verifier
-			.verify(precommit_oracle, public.clone(), &mut self.inner_channel)?;
+			.verify(self.precommit_oracle, public.clone(), &mut self.inner_channel)?;
 		Ok(public)
 	}
 }
@@ -166,7 +177,7 @@ where
 
 	fn remaining_oracle_specs(&self) -> &[OracleSpec] {
 		let all = self.inner_channel.remaining_oracle_specs();
-		let n_remaining_inner = all.len() - self.n_outer_oracles;
+		let n_remaining_inner = all.len() - self.n_outer_suffix_oracles;
 		&all[..n_remaining_inner]
 	}
 

--- a/crates/verifier/src/zk_config.rs
+++ b/crates/verifier/src/zk_config.rs
@@ -95,10 +95,13 @@ where
 		let outer_cs = ConstraintSystemPadded::new(outer_cs, blinding_info);
 		let outer_iop_verifier = IronSpartanIOPVerifier::new(outer_cs);
 
-		// Combine inner and outer oracle specs.
+		// Transcript layout: outer precommit oracle first (committed at wrapper construction),
+		// then all inner oracles, then the remaining outer oracles (private, mask).
+		let outer_oracle_specs = outer_iop_verifier.oracle_specs();
 		let oracle_specs: Vec<OracleSpec> = [
+			vec![outer_oracle_specs[0]],
 			inner_iop_verifier.oracle_specs(),
-			outer_iop_verifier.oracle_specs(),
+			outer_oracle_specs[1..].to_vec(),
 		]
 		.concat();
 
@@ -154,7 +157,7 @@ where
 	) -> Result<(), Error> {
 		// Create BaseFoldZK channel and wrap with outer verifier.
 		let channel = self.basefold_compiler.create_channel(transcript);
-		let mut wrapped_channel = ZKWrappedVerifierChannel::new(channel, &self.outer_iop_verifier);
+		let mut wrapped_channel = ZKWrappedVerifierChannel::new(channel, &self.outer_iop_verifier)?;
 
 		// Run the inner IOP verification through the wrapped channel.
 		self.inner_iop_verifier


### PR DESCRIPTION
## Summary

- Structural prep for the OTP encryption: the outer precommit segment drops dummy mul-constraint blinding (`n_dummy_constraints = 0` for precommit) so a fully-random precommit buffer satisfies the mulcheck, and the ZK-wrapped verifier/prover constructors receive/commit the outer precommit oracle up front (completing [BINIUS-34](https://linear.app/jimpo/issue/BINIUS-34)).
- Introduces one-time-pad encryption of the inner transcript: `ZKWrappedProverChannel::new` commits random OTP keys as the outer precommit oracle, and `send_one` encrypts each outgoing scalar with the next key. The symbolic builder (`IronSpartanBuilderChannel`) and replay channel now allocate a precommit (key) wire alongside each received inout wire so the outer CS operates on the decrypted stream.
- Inner oracle opening claims bypass the OTP: the wrapped prover sends each plaintext claim directly on the inner channel before `prove_oracle_relations`, and both the symbolic builder and replay channel consume that plaintext claim as a fresh inout wire, asserting it equals the claim expression the inner verifier computed over encrypted values — the constraint that glues the two views together. Wrapped verifier substitutes the plaintext claim before delegating to the real BaseFold opening.

## Test plan

- [x] `cargo clippy --all --all-features --tests --benches --examples -- -D warnings`
- [x] `cargo test -p binius-spartan-verifier -p binius-spartan-prover -p binius-spartan-frontend`
- [x] `wrapper_integration_test::test_zk_wrapped_prove_verify` — full prover↔verifier round-trip with OTP encryption on
- [x] `proof_size_test` unchanged
