### PR TITLE
[circuits] Tier 1 of BINIUS-36: convert struct gadgets to functions

### DIFF
--- a/crates/circuits/src/base64.rs
+++ b/crates/circuits/src/base64.rs
@@ -38,8 +38,8 @@ use crate::multiplexer::single_wire_multiplex;
 ///
 /// # Panics
 ///
-/// * If `decoded.len()` is not a multiple of 3 — this guarantees word and base64-group alignment
-///   so no fractional groups appear at the end.
+/// * If `decoded.len()` is not a multiple of 3 — this guarantees word and base64-group alignment so
+///   no fractional groups appear at the end.
 pub fn base64_url_safe(b: &CircuitBuilder, decoded: &[Wire], encoded: &[Wire], len_bytes: Wire) {
 	// Verify length bounds
 	verify_length_bounds(b, len_bytes, decoded.len() << 3);

--- a/crates/circuits/src/base64.rs
+++ b/crates/circuits/src/base64.rs
@@ -1,13 +1,11 @@
 // Copyright 2025 Irreducible Inc.
 use binius_core::word::Word;
-use binius_frontend::{CircuitBuilder, Wire, WitnessFiller, util::pack_bytes_into_wires_le};
+use binius_frontend::{CircuitBuilder, Wire};
 
 use crate::multiplexer::single_wire_multiplex;
 
-/// Base64 encoding (URL-safe, without trailing padding characters) encoding verification.
-///
-/// Verifies that encoded data is a valid base64 URL-safe encoding (without
-/// trailing padding characters) of decoded data.
+/// Asserts that `encoded` is a valid base64 URL-safe encoding (without trailing padding
+/// characters) of `decoded`.
 ///
 /// This encoding is defined in the JSON Web Signature (JWS) spec:
 /// <https://datatracker.ietf.org/doc/html/rfc7515#section-2> (Base64url Encoding)
@@ -21,104 +19,37 @@ use crate::multiplexer::single_wire_multiplex;
 /// # Circuit Behavior
 ///
 /// The circuit performs the following validations:
-/// - encoded is valid base64 URL-safe encoding of decoded
-/// - len_decoded is the actual length of data in decoded (in bytes)
-/// - len_decoded ≤ max_len_decoded (compile-time maximum)
+/// - `encoded` is valid base64 URL-safe encoding of `decoded`
+/// - `len_bytes` is the actual length of data in `decoded` (in bytes)
+/// - `len_bytes` ≤ `decoded.len() * 8` (compile-time maximum)
 ///
 /// # Input Packing
 ///
-/// - decoded: Pack 8 bytes per 64-bit word in little-endian format
-/// - encoded: Pack 8 base64 characters per 64-bit word in little-endian format
-/// - len_decoded: Single 64-bit word containing byte count
-pub struct Base64UrlSafe {
-	/// Decoded data array (packed 8 bytes per word).
-	pub decoded: Vec<Wire>,
-	/// Encoded base64 array (packed 8 chars per word).
-	pub encoded: Vec<Wire>,
-	/// Actual length of decoded data in bytes.
-	pub len_bytes: Wire,
-}
+/// - `decoded`: Pack 8 bytes per 64-bit word in little-endian format
+/// - `encoded`: Pack 8 base64 characters per 64-bit word in little-endian format
+/// - `len_bytes`: Single 64-bit word containing byte count
+///
+/// # Arguments
+///
+/// * `b` - Circuit builder for constructing constraints
+/// * `decoded` - raw byte array wires
+/// * `encoded` - base64 encoded array wires
+/// * `len_bytes` - wire containing the actual length of raw data in bytes
+///
+/// # Panics
+///
+/// * If `decoded.len()` is not a multiple of 3 — this guarantees word and base64-group alignment
+///   so no fractional groups appear at the end.
+pub fn base64_url_safe(b: &CircuitBuilder, decoded: &[Wire], encoded: &[Wire], len_bytes: Wire) {
+	// Verify length bounds
+	verify_length_bounds(b, len_bytes, decoded.len() << 3);
 
-impl Base64UrlSafe {
-	/// Creates a new Base64UrlSafe verifier.
-	///
-	/// # Arguments
-	///
-	/// * `builder` - Circuit builder for constructing constraints
-	/// * `decoded` - raw byte array wires
-	/// * `encoded` - Base64 encoded array wires
-	/// * `len_bytes` - Wire containing actual length of raw data in bytes
-	///
-	/// # Panics
-	///
-	/// * If `decoded.len()` is not a multiple of 3
-	///
-	/// # Implementation Notes
-	///
-	/// The requirement that `decoded.len()` be a multiple of 3 ensures:
-	/// - Word alignment: divisible by 8 for packing bytes into 64-bit words
-	/// - Base64 group alignment: divisible by 3 for processing complete groups
-	/// - Exact array sizing with no rounding needed
-	pub fn new(
-		builder: &CircuitBuilder,
-		decoded: Vec<Wire>,
-		encoded: Vec<Wire>,
-		len_bytes: Wire,
-	) -> Self {
-		// Verify length bounds
-		verify_length_bounds(builder, len_bytes, decoded.len() << 3);
+	// Process groups of 3 bytes -> 4 base64 chars
+	let groups = (decoded.len() << 3).div_ceil(3); // how many 3-byte chunks are there?
 
-		// Process groups of 3 bytes -> 4 base64 chars
-		let groups = (decoded.len() << 3).div_ceil(3); // how many 3-byte chunks are there?
-
-		for group_idx in 0..groups {
-			let b = builder.subcircuit(format!("group[{group_idx}]"));
-			verify_base64_group(&b, &decoded, &encoded, len_bytes, group_idx);
-		}
-
-		Self {
-			decoded,
-			encoded,
-			len_bytes,
-		}
-	}
-
-	/// Populates the length wire with the actual decoded data length.
-	///
-	/// # Arguments
-	///
-	/// * `w` - Witness filler to populate
-	/// * `length` - Actual length of decoded data in bytes
-	pub fn populate_len_bytes(&self, w: &mut WitnessFiller, len_bytes: usize) {
-		w[self.len_bytes] = Word(len_bytes as u64);
-	}
-
-	/// Populates the decoded data array from a byte slice.
-	///
-	/// # Arguments
-	///
-	/// * `w` - Witness filler to populate
-	/// * `data` - Decoded bytes
-	///
-	/// # Panics
-	///
-	/// Panics if `data.len()` exceeds the maximum size specified during construction.
-	pub fn populate_decoded(&self, w: &mut WitnessFiller, data: &[u8]) {
-		pack_bytes_into_wires_le(w, &self.decoded, data);
-	}
-
-	/// Populates the encoded base64 array from a byte slice.
-	///
-	/// # Arguments
-	///
-	/// * `w` - Witness filler to populate
-	/// * `data` - Base64-encoded bytes
-	///
-	/// # Panics
-	///
-	/// Panics if `data.len()` exceeds the maximum size specified during construction.
-	pub fn populate_encoded(&self, w: &mut WitnessFiller, data: &[u8]) {
-		pack_bytes_into_wires_le(w, &self.encoded, data);
+	for group_idx in 0..groups {
+		let b = b.subcircuit(format!("group[{group_idx}]"));
+		verify_base64_group(&b, decoded, encoded, len_bytes, group_idx);
 	}
 }
 
@@ -294,9 +225,9 @@ fn compute_expected_base64_char(
 #[cfg(test)]
 mod tests {
 	use binius_core::verify::verify_constraints;
-	use binius_frontend::CircuitBuilder;
+	use binius_frontend::{CircuitBuilder, util::pack_bytes_into_wires_le};
 
-	use super::{Base64UrlSafe, Wire};
+	use super::{Wire, Word, base64_url_safe};
 
 	/// Encodes bytes to base64 using URL-safe alphabet without trailing padding
 	/// '=" chars.
@@ -328,8 +259,14 @@ mod tests {
 		output
 	}
 
-	/// Helper to create base64 circuit with given max size.
-	fn create_base64_circuit(builder: &CircuitBuilder, max_len_decoded: usize) -> Base64UrlSafe {
+	struct Base64TestSetup {
+		decoded: Vec<Wire>,
+		encoded: Vec<Wire>,
+		len_bytes: Wire,
+	}
+
+	/// Helper to create base64 wires + constraints with given max size.
+	fn create_base64_circuit(builder: &CircuitBuilder, max_len_decoded: usize) -> Base64TestSetup {
 		// Create input wires
 		assert!(
 			max_len_decoded.is_multiple_of(3),
@@ -341,7 +278,13 @@ mod tests {
 
 		let len_bytes = builder.add_inout();
 
-		Base64UrlSafe::new(builder, decoded, encoded, len_bytes)
+		base64_url_safe(builder, &decoded, &encoded, len_bytes);
+
+		Base64TestSetup {
+			decoded,
+			encoded,
+			len_bytes,
+		}
 	}
 
 	/// Core helper that tests base64 encoding verification and returns a Result.
@@ -351,15 +294,15 @@ mod tests {
 		max_len_decoded: usize,
 	) -> Result<(), Box<dyn std::error::Error>> {
 		let builder = CircuitBuilder::new();
-		let circuit = create_base64_circuit(&builder, max_len_decoded);
+		let setup = create_base64_circuit(&builder, max_len_decoded);
 		let compiled = builder.build();
 
 		// Create witness
 		let mut witness = compiled.new_witness_filler();
 
-		circuit.populate_len_bytes(&mut witness, input_bytes.len());
-		circuit.populate_decoded(&mut witness, input_bytes);
-		circuit.populate_encoded(&mut witness, encoded);
+		witness[setup.len_bytes] = Word(input_bytes.len() as u64);
+		pack_bytes_into_wires_le(&mut witness, &setup.decoded, input_bytes);
+		pack_bytes_into_wires_le(&mut witness, &setup.encoded, encoded);
 
 		// Verify circuit
 		compiled.populate_wire_witness(&mut witness)?;

--- a/crates/circuits/src/concat.rs
+++ b/crates/circuits/src/concat.rs
@@ -38,8 +38,7 @@ pub fn concat(b: &CircuitBuilder, terms: &[ByteVec], max_words: Option<usize>) -
 		let b = b.subcircuit(format!("term[{i}]"));
 
 		// Verify the term's runtime length fits in its capacity.
-		let too_long =
-			b.icmp_ugt(term.len_bytes, b.add_constant_64((term.data.len() << 3) as u64));
+		let too_long = b.icmp_ugt(term.len_bytes, b.add_constant_64((term.data.len() << 3) as u64));
 		b.assert_false("term_length_check", too_long);
 
 		let word_offset = b.shr(offset, 3); // offset / 8
@@ -67,15 +66,20 @@ pub fn concat(b: &CircuitBuilder, terms: &[ByteVec], max_words: Option<usize>) -
 			let shifted_low_candidates: Vec<Wire> =
 				(0..8u32).map(|i| b.shl(masked, i * 8)).collect();
 			let shifted_high_candidates: Vec<Wire> = (0..8u32)
-				.map(|i| if i == 0 { zero } else { b.shr(masked, (8 - i) * 8) })
+				.map(|i| {
+					if i == 0 {
+						zero
+					} else {
+						b.shr(masked, (8 - i) * 8)
+					}
+				})
 				.collect();
 			let shifted_low = single_wire_multiplex(&b, &shifted_low_candidates, byte_offset);
 			let shifted_high = single_wire_multiplex(&b, &shifted_high_candidates, byte_offset);
 
 			// dest_low = word_offset + word_idx is the output position receiving the low bytes.
 			// The high bytes (if any) land at dest_low + 1.
-			let (dest_low, _) =
-				b.iadd(word_offset, b.add_constant(Word(word_idx as u64)));
+			let (dest_low, _) = b.iadd(word_offset, b.add_constant(Word(word_idx as u64)));
 
 			// Conditionally add contributions to each output position.
 			for (p, output_p) in output.iter_mut().enumerate() {

--- a/crates/circuits/src/concat.rs
+++ b/crates/circuits/src/concat.rs
@@ -1,207 +1,133 @@
 // Copyright 2025 Irreducible Inc.
 use binius_core::word::Word;
-use binius_frontend::{CircuitBuilder, Wire, WitnessFiller};
+use binius_frontend::{CircuitBuilder, Wire};
 
-use crate::{
-	fixed_byte_vec::ByteVec,
-	slice::{create_byte_mask, extract_word},
-};
+use crate::{fixed_byte_vec::ByteVec, multiplexer::single_wire_multiplex, slice::create_byte_mask};
 
-/// Verifies that a joined string is the concatenation of a list of terms.
+/// Concatenates the given `terms` into a single [`ByteVec`].
 ///
-/// This circuit validates that `joined` contains exactly the concatenation
-/// of all provided terms in order.
-pub struct Concat {
-	/// The actual length of the concatenated result in bytes.
-	///
-	/// This wire will be constrained to equal the sum of all term lengths.
-	pub len_joined_bytes: Wire,
-	/// The concatenated data packed as 64-bit words.
-	///
-	/// Each wire contains 8 bytes in little-endian order.
-	/// The circuit will check / enforce whether the total length of the concatenated data
-	/// fits in `joined.len()` wires, i.e. `joined.len() << 3` bytes.
-	pub joined: Vec<Wire>,
-	/// The list of terms to be concatenated.
-	///
-	/// Terms are concatenated in order: terms\[0\] || terms\[1\] || ... || terms\[n-1\]
-	pub terms: Vec<ByteVec>,
-}
+/// Returns a `ByteVec` whose `data` holds the byte-level concatenation of each term's bytes
+/// (packed in little-endian 8-bytes-per-word) and whose `len_bytes` equals the sum of the
+/// terms' runtime lengths. Bytes past the runtime length, and any trailing words past
+/// `ceil(len_bytes / 8)`, are zero.
+///
+/// # Arguments
+/// * `b` - Circuit builder
+/// * `terms` - Slice of terms to concatenate, in order
+/// * `max_words` - Number of output wires; if `None`, defaults to the sum of `term.data.len()`
+///   across all terms (the smallest size that always fits the concatenation).
+///
+/// # Constraints
+/// * Each term's runtime length must fit in its capacity (`term.len_bytes <= term.data.len() * 8`).
+/// * The sum of term lengths must fit in `max_words * 8` bytes.
+pub fn concat(b: &CircuitBuilder, terms: &[ByteVec], max_words: Option<usize>) -> ByteVec {
+	let max_words = max_words.unwrap_or_else(|| terms.iter().map(|t| t.data.len()).sum());
+	let max_bytes = max_words << 3;
 
-impl Concat {
-	/// Creates a new concatenation verifier circuit.
-	///
-	/// # Arguments
-	/// * `b` - Circuit builder for constructing constraints
-	/// * `len_joined` - Wire containing the actual joined size in bytes
-	/// * `joined` - Joined array packed as 64-bit words (8 bytes per word)
-	/// * `terms` - Vector of terms that should concatenate to form `joined`
-	pub fn new(
-		b: &CircuitBuilder,
-		len_joined_bytes: Wire,
-		joined: Vec<Wire>,
-		terms: Vec<ByteVec>,
-	) -> Self {
-		// Input validation
-		//
-		// Ensure all inputs meet the word-alignment requirements necessary for
-		// efficient word-level processing.
+	let zero = b.add_constant(Word::ZERO);
 
-		// Algorithm overview
-		//
-		// Process terms sequentially, maintaining a running offset to track position
-		// in the joined array. For each term, verify its data appears at the correct
-		// location.
-		//
-		// The algorithm:
-		// 1. Start with offset = 0
-		// 2. For each term: a. Verify its data matches joined[offset : offset + term.len] b. Update
-		//    offset += term.len
-		// 3. Verify final offset equals total length
-		//
-		// Circuit constraints:
-		// - No dynamic array indexing (use multiplexers instead)
-		// - All operations must be on fixed-size data (hence word-level processing)
-		// - Conditional operations use masking (condition & value)
+	// For each term word we produce two contributions:
+	//   - a "low" word that lands at output[word_offset + word_idx]
+	//   - a "high" word that lands at output[word_offset + word_idx + 1] (only non-zero when
+	//     byte_offset != 0)
+	// We accumulate contributions into `output` by XOR; contributions at the same byte position
+	// from different term words can never overlap.
+	let mut output = vec![zero; max_words];
+	let mut offset = zero;
+	for (i, term) in terms.iter().enumerate() {
+		let b = b.subcircuit(format!("term[{i}]"));
 
-		let mut offset = b.add_constant(Word::ZERO);
-
-		// 1. Sequential term processing
-		//
-		// Process each term in order, verifying its data appears at the correct
-		// position in the joined array.
-		for (i, term) in terms.iter().enumerate() {
-			let b = b.subcircuit(format!("term[{i}]"));
-
-			let too_long =
-				b.icmp_ugt(term.len_bytes, b.add_constant(Word((term.data.len() << 3) as u64)));
-			b.assert_false("term_length_check", too_long);
-
-			// 2. Word-level verification for current term
-			//
-			// Process the term's data word by word (8 bytes at a time) for efficiency.
-			let word_offset = b.shr(offset, 3);
-			for (word_idx, &term_word) in term.data.iter().enumerate() {
-				let b = b.subcircuit(format!("word[{word_idx}]"));
-
-				// Calculate this word's byte position within the term
-				let word_byte_offset = word_idx << 3;
-				let word_byte_offset_wire = b.add_constant(Word(word_byte_offset as u64));
-
-				// 2a. Validity checks
-				//
-				// Determine if this word contains valid data based on the term's actual length.
-				// A word is:
-				// - Partially valid if it at least one "meaningful" byte of the term.
-				// - not partially valid if it lives entirely after the point where the term ends.
-				let word_partially_valid = b.icmp_ult(word_byte_offset_wire, term.len_bytes);
-
-				// 2b. Global position calculation
-				//
-				// Calculate where this word should appear in the joined array.
-				// This is the current offset plus the word's position within the term.
-				let (input_word_idx, _) =
-					b.iadd(word_offset, b.add_constant(Word(word_idx as u64)));
-				let byte_offset = b.band(offset, b.add_constant(Word(7)));
-
-				// 2c. Extract corresponding data from joined array
-				//
-				// Extract the word from the joined array at the calculated position.
-				// This handles both aligned (byte position % 8 == 0) and unaligned cases.
-				let joined_data = extract_word(&b, &joined, input_word_idx, byte_offset);
-
-				let neg_start = b.add_constant(Word((-(word_byte_offset as i64)) as u64));
-				let (bytes_remaining, _) = b.iadd(term.len_bytes, neg_start);
-
-				// The mask will handle clamping to 8 bytes internally
-				let mask = create_byte_mask(&b, bytes_remaining);
-
-				b.assert_eq_cond(
-					format!("term[{word_idx}]"),
-					b.band(joined_data, mask),
-					b.band(term_word, mask),
-					word_partially_valid,
-				);
-			}
-
-			// 4. Update offset for next term
-			//
-			// After processing all words of the current term, advance the offset
-			// by the term's actual length to position for the next term.
-			(offset, _) = b.iadd(offset, term.len_bytes);
-		}
-
-		// 5. Final length verification
-		//
-		// The sum of all term lengths must equal the total joined length.
-		b.assert_eq("concat_length", offset, len_joined_bytes);
+		// Verify the term's runtime length fits in its capacity.
 		let too_long =
-			b.icmp_ugt(len_joined_bytes, b.add_constant(Word((joined.len() << 3) as u64)));
-		b.assert_false("concat_length_lt_joined_len", too_long);
+			b.icmp_ugt(term.len_bytes, b.add_constant_64((term.data.len() << 3) as u64));
+		b.assert_false("term_length_check", too_long);
 
-		Concat {
-			len_joined_bytes,
-			joined,
-			terms,
-		}
-	}
+		let word_offset = b.shr(offset, 3); // offset / 8
+		let byte_offset = b.band(offset, b.add_constant(Word(7))); // offset % 8
 
-	/// Populate the len_joined wire with the actual joined size in bytes.
-	pub fn populate_len_joined_bytes(&self, w: &mut WitnessFiller, len_joined_bytes: usize) {
-		w[self.len_joined_bytes] = Word(len_joined_bytes as u64);
-	}
+		for (word_idx, &term_word) in term.data.iter().enumerate() {
+			let b = b.subcircuit(format!("word[{word_idx}]"));
+			let word_byte_offset = word_idx << 3;
 
-	/// Populate the joined array from a byte slice.
-	///
-	/// Packs the bytes into 64-bit words in little-endian order and ensures
-	/// any unused words are zeroed out.
-	///
-	/// # Panics
-	/// Panics if `joined_bytes.len()` > `max_joined_bytes()` (the maximum size possible)
-	pub fn populate_joined(&self, w: &mut WitnessFiller, joined_bytes: &[u8]) {
-		assert!(
-			joined_bytes.len() <= self.max_joined_bytes(),
-			"joined length {} exceeds maximum {}",
-			joined_bytes.len(),
-			self.max_joined_bytes()
-		);
+			// word_partially_valid = (word_byte_offset < term.len_bytes)
+			let word_partially_valid =
+				b.icmp_ult(b.add_constant(Word(word_byte_offset as u64)), term.len_bytes);
 
-		for (i, chunk) in joined_bytes.chunks(8).enumerate() {
-			let mut word = 0u64;
-			for (j, &byte) in chunk.iter().enumerate() {
-				word |= (byte as u64) << (j << 3);
+			// bytes_remaining = term.len_bytes - word_byte_offset (mask clamps to 8).
+			let neg_start = b.add_constant(Word((-(word_byte_offset as i64)) as u64));
+			let (bytes_remaining, _) = b.iadd(term.len_bytes, neg_start);
+			let mask = create_byte_mask(&b, bytes_remaining);
+
+			// Mask invalid bytes within the term word, and zero out completely if past term
+			// boundary (so this word contributes nothing).
+			let masked = b.band(term_word, mask);
+			let masked = b.select(word_partially_valid, masked, zero);
+
+			// Compute shifted versions for each possible byte_offset (0..7).
+			let shifted_low_candidates: Vec<Wire> =
+				(0..8u32).map(|i| b.shl(masked, i * 8)).collect();
+			let shifted_high_candidates: Vec<Wire> = (0..8u32)
+				.map(|i| if i == 0 { zero } else { b.shr(masked, (8 - i) * 8) })
+				.collect();
+			let shifted_low = single_wire_multiplex(&b, &shifted_low_candidates, byte_offset);
+			let shifted_high = single_wire_multiplex(&b, &shifted_high_candidates, byte_offset);
+
+			// dest_low = word_offset + word_idx is the output position receiving the low bytes.
+			// The high bytes (if any) land at dest_low + 1.
+			let (dest_low, _) =
+				b.iadd(word_offset, b.add_constant(Word(word_idx as u64)));
+
+			// Conditionally add contributions to each output position.
+			for (p, output_p) in output.iter_mut().enumerate() {
+				let p_wire = b.add_constant(Word(p as u64));
+				let is_low_dest = b.icmp_eq(p_wire, dest_low);
+				let low_contrib = b.select(is_low_dest, shifted_low, zero);
+				*output_p = b.bxor(*output_p, low_contrib);
+
+				if p > 0 {
+					let p_minus_1 = b.add_constant(Word((p - 1) as u64));
+					let is_high_dest = b.icmp_eq(p_minus_1, dest_low);
+					let high_contrib = b.select(is_high_dest, shifted_high, zero);
+					*output_p = b.bxor(*output_p, high_contrib);
+				}
 			}
-			w[self.joined[i]] = Word(word);
 		}
 
-		for i in joined_bytes.len().div_ceil(8)..self.joined.len() {
-			w[self.joined[i]] = Word::ZERO;
-		}
+		(offset, _) = b.iadd(offset, term.len_bytes);
 	}
 
-	pub fn max_joined_bytes(&self) -> usize {
-		self.joined.len() << 3
-	}
+	// `offset` now equals the total length. Verify it fits in max_words.
+	let total_len = offset;
+	let too_long = b.icmp_ugt(total_len, b.add_constant_64(max_bytes as u64));
+	b.assert_false("concat_length_check", too_long);
+
+	ByteVec::new(output, total_len)
 }
 
 #[cfg(test)]
 mod tests {
 	use anyhow::{Result, anyhow};
 	use binius_core::verify::verify_constraints;
+	use binius_frontend::util::pack_bytes_into_wires_le;
 	use rand::prelude::*;
 
 	use super::*;
 
 	// Test utilities
 
+	struct ConcatTestSetup {
+		builder: CircuitBuilder,
+		len_joined: Wire,
+		joined: Vec<Wire>,
+		terms: Vec<ByteVec>,
+	}
+
 	/// Helper to create a concat circuit with given parameters.
 	///
-	/// Creates a circuit with the specified maximum sizes for joined data and terms.
-	/// All wires are created as input/output wires for testing.
-	fn create_concat_circuit(
-		max_n_joined: usize,
-		term_max_lens: Vec<usize>,
-	) -> (CircuitBuilder, Concat) {
+	/// Allocates inout wires for the expected joined buffer and each term, builds the concat
+	/// gadget, and asserts the returned `ByteVec` equals the expected wires. Returns a
+	/// `ConcatTestSetup` so the test can populate the term and expected-joined values.
+	fn create_concat_circuit(max_n_joined: usize, term_max_lens: Vec<usize>) -> ConcatTestSetup {
 		let b = CircuitBuilder::new();
 
 		let len_joined = b.add_inout();
@@ -215,38 +141,48 @@ mod tests {
 			})
 			.collect();
 
-		let concat = Concat::new(&b, len_joined, joined, terms);
+		// Compute concat and assert its outputs equal the (caller-supplied) expected wires.
+		let computed = concat(&b, &terms, Some(max_n_joined));
+		b.assert_eq("concat_len", computed.len_bytes, len_joined);
+		for (i, (&a, &e)) in computed.data.iter().zip(&joined).enumerate() {
+			b.assert_eq(format!("concat_data[{i}]"), a, e);
+		}
 
-		(b, concat)
+		ConcatTestSetup {
+			builder: b,
+			len_joined,
+			joined,
+			terms,
+		}
 	}
 
 	/// Helper to test a concatenation scenario.
 	///
-	/// Sets up a circuit with the given parameters and verifies that the
-	/// concatenation of `term_data` equals `expected_joined`.
+	/// Sets up a circuit with the given parameters and verifies that the concatenation of
+	/// `term_data` equals `expected_joined`.
 	fn test_concat(
 		max_n_joined: usize,
 		term_max_lens: Vec<usize>,
 		expected_joined: &[u8],
 		term_data: &[&[u8]],
 	) -> Result<()> {
-		let (b, concat) = create_concat_circuit(max_n_joined, term_max_lens);
-		let circuit = b.build();
+		let setup = create_concat_circuit(max_n_joined, term_max_lens);
+		let circuit = setup.builder.build();
 		let mut filler = circuit.new_witness_filler();
 
-		// Set the expected joined length
-		concat.populate_len_joined_bytes(&mut filler, expected_joined.len());
-		concat.populate_joined(&mut filler, expected_joined);
+		// Set the expected joined length and bytes.
+		filler[setup.len_joined] = Word(expected_joined.len() as u64);
+		pack_bytes_into_wires_le(&mut filler, &setup.joined, expected_joined);
 
-		// Set up each term
+		// Set up each term.
 		for (i, data_bytes) in term_data.iter().enumerate() {
-			concat.terms[i].populate_len_bytes(&mut filler, data_bytes.len());
-			concat.terms[i].populate_data(&mut filler, data_bytes);
+			setup.terms[i].populate_len_bytes(&mut filler, data_bytes.len());
+			setup.terms[i].populate_data(&mut filler, data_bytes);
 		}
 
 		circuit.populate_wire_witness(&mut filler)?;
 
-		// Verify constraints
+		// Verify constraints.
 		let cs = circuit.constraint_system();
 		verify_constraints(cs, &filler.into_value_vec())
 			.map_err(|msg| anyhow!("verify_constraints: {}", msg))?;
@@ -323,18 +259,18 @@ mod tests {
 	fn test_length_mismatch() {
 		// Verify the circuit rejects incorrect length claims
 		// Test where claimed length doesn't match actual concatenation
-		let (b, concat) = create_concat_circuit(2, vec![1, 1]);
-		let circuit = b.build();
+		let setup = create_concat_circuit(2, vec![1, 1]);
+		let circuit = setup.builder.build();
 		let mut filler = circuit.new_witness_filler();
 
 		// Claim joined is 8 bytes but terms sum to 10
-		concat.populate_len_joined_bytes(&mut filler, 8);
-		concat.populate_joined(&mut filler, b"helloworld");
+		filler[setup.len_joined] = Word(8);
+		pack_bytes_into_wires_le(&mut filler, &setup.joined, b"helloworld");
 
-		concat.terms[0].populate_len_bytes(&mut filler, 5);
-		concat.terms[0].populate_data(&mut filler, b"hello");
-		concat.terms[1].populate_len_bytes(&mut filler, 5);
-		concat.terms[1].populate_data(&mut filler, b"world");
+		setup.terms[0].populate_len_bytes(&mut filler, 5);
+		setup.terms[0].populate_data(&mut filler, b"hello");
+		setup.terms[1].populate_len_bytes(&mut filler, 5);
+		setup.terms[1].populate_data(&mut filler, b"world");
 
 		let result = circuit.populate_wire_witness(&mut filler);
 		assert!(result.is_err());
@@ -350,17 +286,17 @@ mod tests {
 		assert_eq!(correct_data.len(), 16);
 		assert_eq!(wrong_data.len(), 16);
 
-		let (b, concat) = create_concat_circuit(2, vec![2]);
-		let circuit = b.build();
+		let setup = create_concat_circuit(2, vec![2]);
+		let circuit = setup.builder.build();
 		let mut filler = circuit.new_witness_filler();
 
 		// Populate with WRONG data in joined array
-		concat.populate_len_joined_bytes(&mut filler, 16);
-		concat.populate_joined(&mut filler, wrong_data);
+		filler[setup.len_joined] = Word(16);
+		pack_bytes_into_wires_le(&mut filler, &setup.joined, wrong_data);
 
 		// But claim it matches the CORRECT data in the term
-		concat.terms[0].populate_len_bytes(&mut filler, 16);
-		concat.terms[0].populate_data(&mut filler, correct_data);
+		setup.terms[0].populate_len_bytes(&mut filler, 16);
+		setup.terms[0].populate_data(&mut filler, correct_data);
 
 		// This should fail since the data doesn't match
 		let result = circuit.populate_wire_witness(&mut filler);
@@ -373,14 +309,14 @@ mod tests {
 		let correct_data = b"0123456789ABCDEF0123456789ABCDEF";
 		let wrong_data = b"0123456789ABCDEF0123456789ABCDXX"; // Last word wrong
 
-		let (b, concat) = create_concat_circuit(4, vec![4]);
-		let circuit = b.build();
+		let setup = create_concat_circuit(4, vec![4]);
+		let circuit = setup.builder.build();
 		let mut filler = circuit.new_witness_filler();
 
-		concat.populate_len_joined_bytes(&mut filler, 32);
-		concat.populate_joined(&mut filler, wrong_data);
-		concat.terms[0].populate_len_bytes(&mut filler, 32);
-		concat.terms[0].populate_data(&mut filler, correct_data);
+		filler[setup.len_joined] = Word(32);
+		pack_bytes_into_wires_le(&mut filler, &setup.joined, wrong_data);
+		setup.terms[0].populate_len_bytes(&mut filler, 32);
+		setup.terms[0].populate_data(&mut filler, correct_data);
 
 		let result = circuit.populate_wire_witness(&mut filler);
 
@@ -432,16 +368,16 @@ mod tests {
 		let max_n_joined = expected_joined_bytes.len().div_ceil(8);
 		let term_max_lens: Vec<usize> = term_specs.iter().map(|(_, max_len)| *max_len).collect();
 
-		let (b, concat) = create_concat_circuit(max_n_joined, term_max_lens);
-		let circuit = b.build();
+		let setup = create_concat_circuit(max_n_joined, term_max_lens);
+		let circuit = setup.builder.build();
 		let mut filler = circuit.new_witness_filler();
 
-		concat.populate_len_joined_bytes(&mut filler, expected_joined_bytes.len());
-		concat.populate_joined(&mut filler, &expected_joined_bytes);
+		filler[setup.len_joined] = Word(expected_joined_bytes.len() as u64);
+		pack_bytes_into_wires_le(&mut filler, &setup.joined, &expected_joined_bytes);
 
 		for (i, (data_bytes, _)) in term_specs.iter().enumerate() {
-			concat.terms[i].populate_len_bytes(&mut filler, data_bytes.len());
-			concat.terms[i].populate_data(&mut filler, data_bytes);
+			setup.terms[i].populate_len_bytes(&mut filler, data_bytes.len());
+			setup.terms[i].populate_data(&mut filler, data_bytes);
 		}
 
 		let result = circuit.populate_wire_witness(&mut filler);

--- a/crates/circuits/src/hash_based_sig/hashing/base.rs
+++ b/crates/circuits/src/hash_based_sig/hashing/base.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 Irreducible Inc.
 use binius_frontend::{CircuitBuilder, Wire};
 
-use crate::{concat::Concat, fixed_byte_vec::ByteVec, keccak::Keccak256};
+use crate::{concat::concat, fixed_byte_vec::ByteVec, keccak::Keccak256};
 
 /// Verify a tweaked Keccak-256 circuit with custom terms.
 ///
@@ -53,6 +53,10 @@ pub fn circuit_tweaked_keccak(
 	terms.push(tweak_term);
 	terms.extend(additional_terms);
 
-	let _message_structure_verifier = Concat::new(builder, len, message_le, terms);
+	let computed = concat(builder, &terms, Some(message_le.len()));
+	builder.assert_eq("tweaked_keccak_concat_len", computed.len_bytes, len);
+	for (i, (&a, &e)) in computed.data.iter().zip(&message_le).enumerate() {
+		builder.assert_eq(format!("tweaked_keccak_concat_data[{i}]"), a, e);
+	}
 	keccak
 }

--- a/crates/circuits/src/jwt_claims.rs
+++ b/crates/circuits/src/jwt_claims.rs
@@ -1,36 +1,13 @@
 // Copyright 2025 Irreducible Inc.
 use binius_core::word::Word;
-use binius_frontend::{CircuitBuilder, Wire, WitnessFiller, util::pack_bytes_into_wires_le};
+use binius_frontend::{CircuitBuilder, Wire};
 
-use crate::slice;
+use crate::{fixed_byte_vec::ByteVec, slice};
 
-/// Represents a single JWT attribute to verify
-pub struct Attribute {
-	pub name: &'static str,
-	/// The actual length of the expected value in bytes.
-	pub len_bytes: Wire,
-	pub value: Vec<Wire>,
-}
-
-impl Attribute {
-	/// Populate the actual value length
-	pub fn populate_len_bytes(&self, w: &mut WitnessFiller, len_bytes: usize) {
-		w[self.len_bytes] = Word(len_bytes as u64);
-	}
-
-	/// Populate the expected value from bytes
-	///
-	/// # Panics
-	/// Panics if value.len() > max_value_size (determined by self.value.len() * 8)
-	pub fn populate_value(&self, w: &mut WitnessFiller, value: &[u8]) {
-		pack_bytes_into_wires_le(w, &self.value, value);
-	}
-}
-
-/// Verifies that a JSON string contains specific attribute values.
+/// Asserts that a JSON string contains specific attribute values.
 ///
-/// This circuit validates that the JSON contains each specified attribute
-/// with exactly the expected string value.
+/// Validates that `json` (with actual length `len_bytes`) contains each `(name, value)` pair as
+/// `"<name>":"<value>"` where the value matches the bytes of the supplied [`ByteVec`].
 ///
 /// This circuit makes some strong assumptions, in particular:
 ///
@@ -43,182 +20,161 @@ impl Attribute {
 /// ❗️ At this point, the circuit does not check that it did not get multiple attributes. For
 /// example, imagine there are two attributes "sub" and "nonce" where one is right next to the
 /// other. A prover can get away with providing the attribute "sub" but the end quote of the nonce.
-pub struct JwtClaims {
-	/// The actual length of the JSON string in bytes.
-	pub len_bytes: Wire,
-	pub json: Vec<Wire>,
-	pub attributes: Vec<Attribute>,
-}
+///
+/// # Arguments
+/// * `b` - Circuit builder
+/// * `len_bytes` - Wire for actual JSON size in bytes
+/// * `json` - JSON input array packed as words (8 bytes per word)
+/// * `attributes` - Slice of `(name, value)` pairs to verify, where `value` is a `ByteVec`
+///   carrying the expected bytes and runtime length.
+pub fn jwt_claims(
+	b: &CircuitBuilder,
+	len_bytes: Wire,
+	json: &[Wire],
+	attributes: &[(&str, &ByteVec)],
+) {
+	// For each attribute, we need to:
+	// 1. Find the pattern "name":" in the JSON
+	// 2. Extract the string value between the quotes
+	// 3. Verify it matches the expected value
+	let max_len_bytes = json.len() << 3;
+	let too_long = b.icmp_ult(b.add_constant_64(max_len_bytes as u64), len_bytes);
+	b.assert_false("length check", too_long);
 
-impl JwtClaims {
-	/// Creates a new JWT claims verifier circuit. See the struct documentation for more details.
-	///
-	/// # Arguments
-	/// * `b` - Circuit builder
-	/// * `len_bytes` - Wire for actual JSON size in bytes
-	/// * `json` - JSON input array packed as words (8 bytes per word)
-	/// * `attributes` - List of attributes to verify with their value wires
-	pub fn new(
-		b: &CircuitBuilder,
-		len_bytes: Wire,
-		json: Vec<Wire>,
-		attributes: Vec<Attribute>,
-	) -> Self {
-		// For each attribute, we need to:
-		// 1. Find the pattern "name":" in the JSON
-		// 2. Extract the string value between the quotes
-		// 3. Verify it matches the expected value
-		let max_len_bytes = json.len() << 3;
-		let too_long = b.icmp_ult(b.add_constant_64(max_len_bytes as u64), len_bytes);
-		b.assert_false("length check", too_long);
+	for (attr_idx, &(name, value)) in attributes.iter().enumerate() {
+		let b = b.subcircuit(format!("attr[ix={attr_idx}, name={name}]"));
 
-		for (attr_idx, attr) in attributes.iter().enumerate() {
-			let b = b.subcircuit(format!("attr[ix={}, name={}]", attr_idx, attr.name));
+		// Build the search pattern: "name":"
+		let pattern = format!("\"{name}\":\"");
+		let pattern_bytes = pattern.as_bytes();
+		let pattern_len = pattern_bytes.len();
 
-			// Build the search pattern: "name":"
-			let pattern = format!("\"{}\":\"", attr.name);
-			let pattern_bytes = pattern.as_bytes();
-			let pattern_len = pattern_bytes.len();
+		// ---- Pattern matching algorithm
+		//
+		// We search for the pattern "name":" in the JSON by checking every possible
+		// starting position. Since we can't break out of loops in circuits, we check
+		// all positions and use masking to track where we found matches.
+		//
+		// Variables:
+		// - found_position: the position where we found the pattern (0 if not found yet)
+		// - any_found: becomes msb-true when we find the pattern anywhere
+		let zero = b.add_constant(Word::ZERO);
+		let mut value_start = zero;
+		let mut found_start = zero;
 
-			// ---- Pattern matching algorithm
-			//
-			// We search for the pattern "name":" in the JSON by checking every possible
-			// starting position. Since we can't break out of loops in circuits, we check
-			// all positions and use masking to track where we found matches.
-			//
-			// Variables:
-			// - found_position: the position where we found the pattern (0 if not found yet)
-			// - any_found: becomes msb-true when we find the pattern anywhere
-			let zero = b.add_constant(Word::ZERO);
-			let mut value_start = zero;
-			let mut found_start = zero;
+		// Check each possible starting position
+		for start_pos in 0..max_len_bytes.saturating_sub(pattern_len) {
+			let b = b.subcircuit(format!("start_pos[{start_pos}]"));
 
-			// Check each possible starting position
-			for start_pos in 0..max_len_bytes.saturating_sub(pattern_len) {
-				let b = b.subcircuit(format!("start_pos[{start_pos}]"));
+			// Check if this position could contain the full pattern
+			let end_wire = b.add_constant(Word((start_pos + pattern_len) as u64));
 
-				// Check if this position could contain the full pattern
-				let end_wire = b.add_constant(Word((start_pos + pattern_len) as u64));
+			// Verify position is within JSON bounds
+			let within_bounds = b.icmp_ult(end_wire, len_bytes);
+			// strict inequality is safe, because there will also be a closing "
+			let mut matches_here = within_bounds;
 
-				// Verify position is within JSON bounds
-				let within_bounds = b.icmp_ult(end_wire, len_bytes);
-				// strict inequality is safe, because there will also be a closing "
-				let mut matches_here = within_bounds;
+			// Check each byte of the pattern
+			for (i, &expected_byte) in pattern_bytes.iter().enumerate() {
+				let byte_pos = start_pos + i;
+				let word_idx = byte_pos / 8;
+				let byte_offset = byte_pos % 8;
 
-				// Check each byte of the pattern
-				for (i, &expected_byte) in pattern_bytes.iter().enumerate() {
-					let byte_pos = start_pos + i;
-					let word_idx = byte_pos / 8;
-					let byte_offset = byte_pos % 8;
-
-					let actual_byte = b.extract_byte(json[word_idx], byte_offset as u32);
-					let expected = b.add_constant(Word(expected_byte as u64));
-					let byte_matches = b.icmp_eq(actual_byte, expected);
-					matches_here = b.band(matches_here, byte_matches);
-				}
-
-				// If we found a match here, remember this position
-				value_start = b.select(matches_here, end_wire, value_start);
-				found_start = b.bor(found_start, matches_here);
+				let actual_byte = b.extract_byte(json[word_idx], byte_offset as u32);
+				let expected = b.add_constant(Word(expected_byte as u64));
+				let byte_matches = b.icmp_eq(actual_byte, expected);
+				matches_here = b.band(matches_here, byte_matches);
 			}
 
-			// Assert that we found the pattern (found_start should be msb-true)
-			b.assert_true("attr_found".to_string(), found_start);
-
-			// ---- Find value terminator
-			//
-			// Search for the terminator that marks the end of the attribute value.
-			// Valid terminators are: " (closing quote), , (comma), or } (closing brace)
-			// We scan all positions starting from value_start and use masking to
-			// remember where we found a terminator.
-			let mut value_end = zero;
-			let mut found_end = zero;
-			let quote = b.add_constant_zx_8(b'"');
-			let comma = b.add_constant_zx_8(b',');
-			let close_brace = b.add_constant_zx_8(b'}');
-			// i actually don't grok why these latter two are valid terminators.
-
-			for pos in 0..max_len_bytes {
-				let b = b.subcircuit(format!("find_terminator[{pos}]"));
-
-				let pos_wire = b.add_constant(Word(pos as u64));
-				let within_bounds = b.icmp_ult(pos_wire, len_bytes);
-
-				// Check if this position is after value_start
-				// For empty strings, the closing quote is at value_start
-				let at_or_after_start = b.bnot(b.icmp_ult(pos_wire, value_start));
-				let not_found_yet = b.bnot(found_end);
-				let should_check = b.band(b.band(at_or_after_start, within_bounds), not_found_yet);
-
-				// Extract byte at this position
-				let word_idx = pos / 8;
-				let byte_offset = pos % 8;
-
-				let byte_at_pos = b.extract_byte(json[word_idx], byte_offset as u32);
-
-				// Check if this byte is any of the valid terminators
-				let is_quote = b.icmp_eq(byte_at_pos, quote);
-				let is_comma = b.icmp_eq(byte_at_pos, comma);
-				let is_close_brace = b.icmp_eq(byte_at_pos, close_brace);
-
-				// It's a terminator if it's any of the three
-				let is_terminator = b.bor(b.bor(is_quote, is_comma), is_close_brace);
-
-				let found_here = b.band(should_check, is_terminator);
-
-				// If we found a terminator here, remember this position
-				// When found_here is all-1s, include pos_wire in value_end
-				// When found_here is all-0s, masked_pos is 0 and OR leaves value_end unchanged
-				value_end = b.select(found_here, pos_wire, value_end);
-				found_end = b.bor(found_end, found_here);
-			}
-
-			// Assert that we found a terminator (found_end should be all-1s)
-			b.assert_true("attr_terminator_found", found_end);
-
-			// Calculate value length: value_end - value_start
-			// Since circuits don't have a subtraction operation, we use two's complement:
-			// a - b = a + (~b + 1), where ~b is bitwise NOT of b
-			let (value_length, _borrow) = b.isub_bin_bout(value_end, value_start, zero);
-
-			// Verify the length matches expected
-			b.assert_eq("attr_length", value_length, attr.len_bytes);
-
-			// Extract the value from the JSON and assert it matches the caller-supplied value.
-			let extracted =
-				slice::slice(&b, len_bytes, value_length, &json, value_start, attr.value.len());
-			for (i, (&a, &e)) in extracted.iter().zip(&attr.value).enumerate() {
-				b.assert_eq(format!("attr_value[{i}]"), a, e);
-			}
+			// If we found a match here, remember this position
+			value_start = b.select(matches_here, end_wire, value_start);
+			found_start = b.bor(found_start, matches_here);
 		}
 
-		JwtClaims {
-			len_bytes,
-			json,
-			attributes,
+		// Assert that we found the pattern (found_start should be msb-true)
+		b.assert_true("attr_found".to_string(), found_start);
+
+		// ---- Find value terminator
+		//
+		// Search for the terminator that marks the end of the attribute value.
+		// Valid terminators are: " (closing quote), , (comma), or } (closing brace)
+		// We scan all positions starting from value_start and use masking to
+		// remember where we found a terminator.
+		let mut value_end = zero;
+		let mut found_end = zero;
+		let quote = b.add_constant_zx_8(b'"');
+		let comma = b.add_constant_zx_8(b',');
+		let close_brace = b.add_constant_zx_8(b'}');
+		// i actually don't grok why these latter two are valid terminators.
+
+		for pos in 0..max_len_bytes {
+			let b = b.subcircuit(format!("find_terminator[{pos}]"));
+
+			let pos_wire = b.add_constant(Word(pos as u64));
+			let within_bounds = b.icmp_ult(pos_wire, len_bytes);
+
+			// Check if this position is after value_start
+			// For empty strings, the closing quote is at value_start
+			let at_or_after_start = b.bnot(b.icmp_ult(pos_wire, value_start));
+			let not_found_yet = b.bnot(found_end);
+			let should_check = b.band(b.band(at_or_after_start, within_bounds), not_found_yet);
+
+			// Extract byte at this position
+			let word_idx = pos / 8;
+			let byte_offset = pos % 8;
+
+			let byte_at_pos = b.extract_byte(json[word_idx], byte_offset as u32);
+
+			// Check if this byte is any of the valid terminators
+			let is_quote = b.icmp_eq(byte_at_pos, quote);
+			let is_comma = b.icmp_eq(byte_at_pos, comma);
+			let is_close_brace = b.icmp_eq(byte_at_pos, close_brace);
+
+			// It's a terminator if it's any of the three
+			let is_terminator = b.bor(b.bor(is_quote, is_comma), is_close_brace);
+
+			let found_here = b.band(should_check, is_terminator);
+
+			// If we found a terminator here, remember this position
+			// When found_here is all-1s, include pos_wire in value_end
+			// When found_here is all-0s, masked_pos is 0 and OR leaves value_end unchanged
+			value_end = b.select(found_here, pos_wire, value_end);
+			found_end = b.bor(found_end, found_here);
 		}
-	}
 
-	/// Populate the len_bytes wire with the actual JSON size in bytes
-	pub fn populate_len_bytes(&self, w: &mut WitnessFiller, len_bytes: usize) {
-		w[self.len_bytes] = Word(len_bytes as u64);
-	}
+		// Assert that we found a terminator (found_end should be all-1s)
+		b.assert_true("attr_terminator_found", found_end);
 
-	/// Populate the JSON array from a byte slice
-	///
-	/// # Panics
-	/// Panics if json.len() > max_len_json (the maximum size specified during construction)
-	pub fn populate_json(&self, w: &mut WitnessFiller, json: &[u8]) {
-		pack_bytes_into_wires_le(w, &self.json, json);
+		// Calculate value length: value_end - value_start
+		// Since circuits don't have a subtraction operation, we use two's complement:
+		// a - b = a + (~b + 1), where ~b is bitwise NOT of b
+		let (value_length, _borrow) = b.isub_bin_bout(value_end, value_start, zero);
+
+		// Verify the length matches expected
+		b.assert_eq("attr_length", value_length, value.len_bytes);
+
+		// Extract the value bytes from the JSON and assert they match the caller-supplied value.
+		let extracted = slice::slice(&b, len_bytes, value_length, json, value_start, value.data.len());
+		for (i, (&a, &e)) in extracted.iter().zip(&value.data).enumerate() {
+			b.assert_eq(format!("attr_value[{i}]"), a, e);
+		}
 	}
 }
 
 #[cfg(test)]
 mod tests {
 	use binius_core::verify::verify_constraints;
-	use binius_frontend::CircuitBuilder;
+	use binius_frontend::{CircuitBuilder, util::pack_bytes_into_wires_le};
 
-	use super::{Attribute, JwtClaims, Wire};
+	use super::{ByteVec, Wire, Word, jwt_claims};
+
+	/// Helper that allocates a `ByteVec` of `n_words` inout wires.
+	fn alloc_byte_vec(b: &CircuitBuilder, n_words: usize) -> ByteVec {
+		ByteVec {
+			len_bytes: b.add_inout(),
+			data: (0..n_words).map(|_| b.add_inout()).collect(),
+		}
+	}
 
 	#[test]
 	fn test_single_attribute() {
@@ -227,13 +183,9 @@ mod tests {
 		let len_json = b.add_witness();
 		let json: Vec<Wire> = (0..32).map(|_| b.add_witness()).collect();
 
-		let attributes = vec![Attribute {
-			name: "sub",
-			len_bytes: b.add_inout(),
-			value: (0..2).map(|_| b.add_inout()).collect(),
-		}];
+		let sub = alloc_byte_vec(&b, 2);
 
-		let jwt_claims = JwtClaims::new(&b, len_json, json, attributes);
+		jwt_claims(&b, len_json, &json, &[("sub", &sub)]);
 
 		let circuit = b.build();
 		let mut filler = circuit.new_witness_filler();
@@ -241,12 +193,12 @@ mod tests {
 		let json_str = r#"{"sub":"1234567890","iss":"google.com"}"#;
 
 		// Populate inputs
-		jwt_claims.populate_len_bytes(&mut filler, json_str.len());
-		jwt_claims.populate_json(&mut filler, json_str.as_bytes());
+		filler[len_json] = Word(json_str.len() as u64);
+		pack_bytes_into_wires_le(&mut filler, &json, json_str.as_bytes());
 
 		// Populate expected value
-		jwt_claims.attributes[0].populate_len_bytes(&mut filler, 10);
-		jwt_claims.attributes[0].populate_value(&mut filler, b"1234567890");
+		sub.populate_len_bytes(&mut filler, 10);
+		sub.populate_data(&mut filler, b"1234567890");
 
 		circuit.populate_wire_witness(&mut filler).unwrap();
 
@@ -262,25 +214,16 @@ mod tests {
 		let len_bytes = b.add_witness();
 		let json: Vec<Wire> = (0..32).map(|_| b.add_witness()).collect();
 
-		let attributes = vec![
-			Attribute {
-				name: "sub",
-				len_bytes: b.add_inout(),
-				value: (0..2).map(|_| b.add_inout()).collect(),
-			},
-			Attribute {
-				name: "iss",
-				len_bytes: b.add_inout(),
-				value: (0..4).map(|_| b.add_inout()).collect(),
-			},
-			Attribute {
-				name: "aud",
-				len_bytes: b.add_inout(),
-				value: (0..2).map(|_| b.add_inout()).collect(),
-			},
-		];
+		let sub = alloc_byte_vec(&b, 2);
+		let iss = alloc_byte_vec(&b, 4);
+		let aud = alloc_byte_vec(&b, 2);
 
-		let jwt_claims = JwtClaims::new(&b, len_bytes, json, attributes);
+		jwt_claims(
+			&b,
+			len_bytes,
+			&json,
+			&[("sub", &sub), ("iss", &iss), ("aud", &aud)],
+		);
 
 		let circuit = b.build();
 		let mut filler = circuit.new_witness_filler();
@@ -290,18 +233,18 @@ mod tests {
 			r#"{"sub":"1234567890","iss":"google.com","aud":"4074087","iat":1676415809}"#;
 
 		// Populate inputs
-		jwt_claims.populate_len_bytes(&mut filler, json_str.len());
-		jwt_claims.populate_json(&mut filler, json_str.as_bytes());
+		filler[len_bytes] = Word(json_str.len() as u64);
+		pack_bytes_into_wires_le(&mut filler, &json, json_str.as_bytes());
 
 		// Populate expected values
-		jwt_claims.attributes[0].populate_len_bytes(&mut filler, 10);
-		jwt_claims.attributes[0].populate_value(&mut filler, b"1234567890");
+		sub.populate_len_bytes(&mut filler, 10);
+		sub.populate_data(&mut filler, b"1234567890");
 
-		jwt_claims.attributes[1].populate_len_bytes(&mut filler, 10);
-		jwt_claims.attributes[1].populate_value(&mut filler, b"google.com");
+		iss.populate_len_bytes(&mut filler, 10);
+		iss.populate_data(&mut filler, b"google.com");
 
-		jwt_claims.attributes[2].populate_len_bytes(&mut filler, 7);
-		jwt_claims.attributes[2].populate_value(&mut filler, b"4074087");
+		aud.populate_len_bytes(&mut filler, 7);
+		aud.populate_data(&mut filler, b"4074087");
 
 		circuit.populate_wire_witness(&mut filler).unwrap();
 
@@ -317,13 +260,9 @@ mod tests {
 		let len_bytes = b.add_witness();
 		let json: Vec<Wire> = (0..16).map(|_| b.add_witness()).collect();
 
-		let attributes = vec![Attribute {
-			name: "missing",
-			len_bytes: b.add_inout(),
-			value: (0..2).map(|_| b.add_inout()).collect(),
-		}];
+		let missing = alloc_byte_vec(&b, 2);
 
-		let jwt_claims = JwtClaims::new(&b, len_bytes, json, attributes);
+		jwt_claims(&b, len_bytes, &json, &[("missing", &missing)]);
 
 		let circuit = b.build();
 		let mut filler = circuit.new_witness_filler();
@@ -332,12 +271,12 @@ mod tests {
 		let json_str = r#"{"sub":"1234567890","iss":"google.com"}"#;
 
 		// Populate inputs
-		jwt_claims.populate_len_bytes(&mut filler, json_str.len());
-		jwt_claims.populate_json(&mut filler, json_str.as_bytes());
+		filler[len_bytes] = Word(json_str.len() as u64);
+		pack_bytes_into_wires_le(&mut filler, &json, json_str.as_bytes());
 
 		// Populate expected value (won't be found)
-		jwt_claims.attributes[0].populate_len_bytes(&mut filler, 5);
-		jwt_claims.attributes[0].populate_value(&mut filler, b"value");
+		missing.populate_len_bytes(&mut filler, 5);
+		missing.populate_data(&mut filler, b"value");
 
 		// This should fail because "missing" attribute is not in the JSON
 		let result = circuit.populate_wire_witness(&mut filler);
@@ -351,13 +290,9 @@ mod tests {
 		let len_bytes = b.add_witness();
 		let json: Vec<Wire> = (0..16).map(|_| b.add_witness()).collect();
 
-		let attributes = vec![Attribute {
-			name: "sub",
-			len_bytes: b.add_inout(),
-			value: (0..2).map(|_| b.add_inout()).collect(),
-		}];
+		let sub = alloc_byte_vec(&b, 2);
 
-		let jwt_claims = JwtClaims::new(&b, len_bytes, json, attributes);
+		jwt_claims(&b, len_bytes, &json, &[("sub", &sub)]);
 
 		let circuit = b.build();
 		let mut filler = circuit.new_witness_filler();
@@ -366,12 +301,12 @@ mod tests {
 		let json_str = r#"{"sub":"1234567890","iss":"google.com"}"#;
 
 		// Populate inputs
-		jwt_claims.populate_len_bytes(&mut filler, json_str.len());
-		jwt_claims.populate_json(&mut filler, json_str.as_bytes());
+		filler[len_bytes] = Word(json_str.len() as u64);
+		pack_bytes_into_wires_le(&mut filler, &json, json_str.as_bytes());
 
 		// Populate wrong expected value
-		jwt_claims.attributes[0].populate_len_bytes(&mut filler, 10);
-		jwt_claims.attributes[0].populate_value(&mut filler, b"9876543210");
+		sub.populate_len_bytes(&mut filler, 10);
+		sub.populate_data(&mut filler, b"9876543210");
 
 		// This should fail because the value doesn't match
 		let result = circuit.populate_wire_witness(&mut filler);
@@ -385,20 +320,10 @@ mod tests {
 		let len_bytes = b.add_witness();
 		let json: Vec<Wire> = (0..32).map(|_| b.add_witness()).collect();
 
-		let attributes = vec![
-			Attribute {
-				name: "aud",
-				len_bytes: b.add_inout(),
-				value: (0..16 / 8).map(|_| b.add_inout()).collect(),
-			},
-			Attribute {
-				name: "sub",
-				len_bytes: b.add_inout(),
-				value: (0..16 / 8).map(|_| b.add_inout()).collect(),
-			},
-		];
+		let aud = alloc_byte_vec(&b, 16 / 8);
+		let sub = alloc_byte_vec(&b, 16 / 8);
 
-		let jwt_claims = JwtClaims::new(&b, len_bytes, json, attributes);
+		jwt_claims(&b, len_bytes, &json, &[("aud", &aud), ("sub", &sub)]);
 
 		let circuit = b.build();
 		let mut filler = circuit.new_witness_filler();
@@ -408,15 +333,15 @@ mod tests {
 			r#"{"iss":"google.com","sub":"1234567890","email":"test@example.com","aud":"4074087"}"#;
 
 		// Populate inputs
-		jwt_claims.populate_len_bytes(&mut filler, json_str.len());
-		jwt_claims.populate_json(&mut filler, json_str.as_bytes());
+		filler[len_bytes] = Word(json_str.len() as u64);
+		pack_bytes_into_wires_le(&mut filler, &json, json_str.as_bytes());
 
 		// Populate expected values
-		jwt_claims.attributes[0].populate_len_bytes(&mut filler, 7);
-		jwt_claims.attributes[0].populate_value(&mut filler, b"4074087");
+		aud.populate_len_bytes(&mut filler, 7);
+		aud.populate_data(&mut filler, b"4074087");
 
-		jwt_claims.attributes[1].populate_len_bytes(&mut filler, 10);
-		jwt_claims.attributes[1].populate_value(&mut filler, b"1234567890");
+		sub.populate_len_bytes(&mut filler, 10);
+		sub.populate_data(&mut filler, b"1234567890");
 
 		circuit.populate_wire_witness(&mut filler).unwrap();
 
@@ -432,13 +357,9 @@ mod tests {
 		let len_bytes = b.add_witness();
 		let json: Vec<Wire> = (0..16).map(|_| b.add_witness()).collect();
 
-		let attributes = vec![Attribute {
-			name: "empty",
-			len_bytes: b.add_inout(),
-			value: (0..1).map(|_| b.add_inout()).collect(),
-		}];
+		let empty = alloc_byte_vec(&b, 1);
 
-		let jwt_claims = JwtClaims::new(&b, len_bytes, json, attributes);
+		jwt_claims(&b, len_bytes, &json, &[("empty", &empty)]);
 
 		let circuit = b.build();
 		let mut filler = circuit.new_witness_filler();
@@ -447,12 +368,12 @@ mod tests {
 		let json_str = r#"{"empty":"","sub":"123"}"#;
 
 		// Populate inputs
-		jwt_claims.populate_len_bytes(&mut filler, json_str.len());
-		jwt_claims.populate_json(&mut filler, json_str.as_bytes());
+		filler[len_bytes] = Word(json_str.len() as u64);
+		pack_bytes_into_wires_le(&mut filler, &json, json_str.as_bytes());
 
 		// Populate expected empty value
-		jwt_claims.attributes[0].populate_len_bytes(&mut filler, 0);
-		jwt_claims.attributes[0].populate_value(&mut filler, b"");
+		empty.populate_len_bytes(&mut filler, 0);
+		empty.populate_data(&mut filler, b"");
 
 		circuit.populate_wire_witness(&mut filler).unwrap();
 
@@ -468,20 +389,10 @@ mod tests {
 		let len_bytes = b.add_witness();
 		let json: Vec<Wire> = (0..32).map(|_| b.add_witness()).collect();
 
-		let attributes = vec![
-			Attribute {
-				name: "email",
-				len_bytes: b.add_inout(),
-				value: (0..4).map(|_| b.add_inout()).collect(),
-			},
-			Attribute {
-				name: "nonce",
-				len_bytes: b.add_inout(),
-				value: (0..4).map(|_| b.add_inout()).collect(),
-			},
-		];
+		let email = alloc_byte_vec(&b, 4);
+		let nonce = alloc_byte_vec(&b, 4);
 
-		let jwt_claims = JwtClaims::new(&b, len_bytes, json, attributes);
+		jwt_claims(&b, len_bytes, &json, &[("email", &email), ("nonce", &nonce)]);
 
 		let circuit = b.build();
 		let mut filler = circuit.new_witness_filler();
@@ -490,15 +401,15 @@ mod tests {
 		let json_str = r#"{"email":"john.doe@gmail.com","nonce":"7-VU9fuWeWtgDLHmVJ2UtRrine8"}"#;
 
 		// Populate inputs
-		jwt_claims.populate_len_bytes(&mut filler, json_str.len());
-		jwt_claims.populate_json(&mut filler, json_str.as_bytes());
+		filler[len_bytes] = Word(json_str.len() as u64);
+		pack_bytes_into_wires_le(&mut filler, &json, json_str.as_bytes());
 
 		// Populate expected values
-		jwt_claims.attributes[0].populate_len_bytes(&mut filler, 18);
-		jwt_claims.attributes[0].populate_value(&mut filler, b"john.doe@gmail.com");
+		email.populate_len_bytes(&mut filler, 18);
+		email.populate_data(&mut filler, b"john.doe@gmail.com");
 
-		jwt_claims.attributes[1].populate_len_bytes(&mut filler, 27);
-		jwt_claims.attributes[1].populate_value(&mut filler, b"7-VU9fuWeWtgDLHmVJ2UtRrine8");
+		nonce.populate_len_bytes(&mut filler, 27);
+		nonce.populate_data(&mut filler, b"7-VU9fuWeWtgDLHmVJ2UtRrine8");
 
 		circuit.populate_wire_witness(&mut filler).unwrap();
 
@@ -514,20 +425,10 @@ mod tests {
 		let len_bytes = b.add_witness();
 		let json: Vec<Wire> = (0..16).map(|_| b.add_witness()).collect();
 
-		let attributes = vec![
-			Attribute {
-				name: "iss",
-				len_bytes: b.add_inout(),
-				value: (0..16 / 8).map(|_| b.add_inout()).collect(),
-			},
-			Attribute {
-				name: "last",
-				len_bytes: b.add_inout(),
-				value: (0..16 / 8).map(|_| b.add_inout()).collect(),
-			},
-		];
+		let iss = alloc_byte_vec(&b, 16 / 8);
+		let last = alloc_byte_vec(&b, 16 / 8);
 
-		let jwt_claims = JwtClaims::new(&b, len_bytes, json, attributes);
+		jwt_claims(&b, len_bytes, &json, &[("iss", &iss), ("last", &last)]);
 
 		let circuit = b.build();
 		let mut filler = circuit.new_witness_filler();
@@ -536,15 +437,15 @@ mod tests {
 		let json_str = r#"{"iss":"example.com","last":"value123"}"#;
 
 		// Populate inputs
-		jwt_claims.populate_len_bytes(&mut filler, json_str.len());
-		jwt_claims.populate_json(&mut filler, json_str.as_bytes());
+		filler[len_bytes] = Word(json_str.len() as u64);
+		pack_bytes_into_wires_le(&mut filler, &json, json_str.as_bytes());
 
 		// Populate expected values
-		jwt_claims.attributes[0].populate_len_bytes(&mut filler, 11);
-		jwt_claims.attributes[0].populate_value(&mut filler, b"example.com");
+		iss.populate_len_bytes(&mut filler, 11);
+		iss.populate_data(&mut filler, b"example.com");
 
-		jwt_claims.attributes[1].populate_len_bytes(&mut filler, 8);
-		jwt_claims.attributes[1].populate_value(&mut filler, b"value123");
+		last.populate_len_bytes(&mut filler, 8);
+		last.populate_data(&mut filler, b"value123");
 
 		circuit.populate_wire_witness(&mut filler).unwrap();
 

--- a/crates/circuits/src/jwt_claims.rs
+++ b/crates/circuits/src/jwt_claims.rs
@@ -2,7 +2,7 @@
 use binius_core::word::Word;
 use binius_frontend::{CircuitBuilder, Wire, WitnessFiller, util::pack_bytes_into_wires_le};
 
-use crate::slice::Slice;
+use crate::slice;
 
 /// Represents a single JWT attribute to verify
 pub struct Attribute {
@@ -184,15 +184,12 @@ impl JwtClaims {
 			// Verify the length matches expected
 			b.assert_eq("attr_length", value_length, attr.len_bytes);
 
-			// Use Slice to verify the value content
-			let _slice = Slice::new(
-				&b,
-				len_bytes,
-				value_length,
-				json.clone(),
-				attr.value.clone(),
-				value_start,
-			);
+			// Extract the value from the JSON and assert it matches the caller-supplied value.
+			let extracted =
+				slice::slice(&b, len_bytes, value_length, &json, value_start, attr.value.len());
+			for (i, (&a, &e)) in extracted.iter().zip(&attr.value).enumerate() {
+				b.assert_eq(format!("attr_value[{i}]"), a, e);
+			}
 		}
 
 		JwtClaims {

--- a/crates/circuits/src/jwt_claims.rs
+++ b/crates/circuits/src/jwt_claims.rs
@@ -25,8 +25,8 @@ use crate::{fixed_byte_vec::ByteVec, slice};
 /// * `b` - Circuit builder
 /// * `len_bytes` - Wire for actual JSON size in bytes
 /// * `json` - JSON input array packed as words (8 bytes per word)
-/// * `attributes` - Slice of `(name, value)` pairs to verify, where `value` is a `ByteVec`
-///   carrying the expected bytes and runtime length.
+/// * `attributes` - Slice of `(name, value)` pairs to verify, where `value` is a `ByteVec` carrying
+///   the expected bytes and runtime length.
 pub fn jwt_claims(
 	b: &CircuitBuilder,
 	len_bytes: Wire,
@@ -154,7 +154,8 @@ pub fn jwt_claims(
 		b.assert_eq("attr_length", value_length, value.len_bytes);
 
 		// Extract the value bytes from the JSON and assert they match the caller-supplied value.
-		let extracted = slice::slice(&b, len_bytes, value_length, json, value_start, value.data.len());
+		let extracted =
+			slice::slice(&b, len_bytes, value_length, json, value_start, value.data.len());
 		for (i, (&a, &e)) in extracted.iter().zip(&value.data).enumerate() {
 			b.assert_eq(format!("attr_value[{i}]"), a, e);
 		}
@@ -218,12 +219,7 @@ mod tests {
 		let iss = alloc_byte_vec(&b, 4);
 		let aud = alloc_byte_vec(&b, 2);
 
-		jwt_claims(
-			&b,
-			len_bytes,
-			&json,
-			&[("sub", &sub), ("iss", &iss), ("aud", &aud)],
-		);
+		jwt_claims(&b, len_bytes, &json, &[("sub", &sub), ("iss", &iss), ("aud", &aud)]);
 
 		let circuit = b.build();
 		let mut filler = circuit.new_witness_filler();

--- a/crates/circuits/src/keccak/fixed_length.rs
+++ b/crates/circuits/src/keccak/fixed_length.rs
@@ -4,8 +4,7 @@ use binius_core::word::Word;
 use binius_frontend::{CircuitBuilder, Wire};
 
 use super::{
-	N_WORDS_PER_BLOCK, N_WORDS_PER_DIGEST, N_WORDS_PER_STATE, RATE_BYTES,
-	permutation::keccak_f1600,
+	N_WORDS_PER_BLOCK, N_WORDS_PER_DIGEST, N_WORDS_PER_STATE, RATE_BYTES, permutation::keccak_f1600,
 };
 
 /// Computes the Keccak-256 hash of a fixed-length message.

--- a/crates/circuits/src/keccak/fixed_length.rs
+++ b/crates/circuits/src/keccak/fixed_length.rs
@@ -4,7 +4,8 @@ use binius_core::word::Word;
 use binius_frontend::{CircuitBuilder, Wire};
 
 use super::{
-	N_WORDS_PER_BLOCK, N_WORDS_PER_DIGEST, N_WORDS_PER_STATE, RATE_BYTES, permutation::Permutation,
+	N_WORDS_PER_BLOCK, N_WORDS_PER_DIGEST, N_WORDS_PER_STATE, RATE_BYTES,
+	permutation::keccak_f1600,
 };
 
 /// Computes the Keccak-256 hash of a fixed-length message.
@@ -107,7 +108,7 @@ pub fn keccak256(
 		}
 
 		// Apply Keccak-f[1600] permutation
-		Permutation::keccak_f1600(builder, &mut state);
+		keccak_f1600(builder, &mut state);
 	}
 
 	// Return the first 4 words (256 bits) of the state as the digest

--- a/crates/circuits/src/keccak/mod.rs
+++ b/crates/circuits/src/keccak/mod.rs
@@ -5,7 +5,7 @@ pub mod permutation;
 
 use binius_core::word::Word;
 use binius_frontend::{CircuitBuilder, Wire, WitnessFiller};
-use permutation::Permutation;
+use permutation::keccak_f1600;
 
 use crate::multiplexer::{multi_wire_multiplex, single_wire_multiplex};
 
@@ -74,7 +74,7 @@ impl Keccak256 {
 					b.bxor(state_in[i], padded_message[block_no * N_WORDS_PER_BLOCK + i]);
 			}
 
-			Permutation::keccak_f1600(b, &mut xored_state);
+			keccak_f1600(b, &mut xored_state);
 
 			states.push(xored_state);
 		}

--- a/crates/circuits/src/keccak/permutation.rs
+++ b/crates/circuits/src/keccak/permutation.rs
@@ -2,7 +2,7 @@
 use std::array;
 
 use binius_core::word::Word;
-use binius_frontend::{CircuitBuilder, Wire, WitnessFiller};
+use binius_frontend::{CircuitBuilder, Wire};
 
 // ι round constants
 pub const RC: [u64; 24] = [
@@ -47,131 +47,93 @@ pub const fn idx(x: usize, y: usize) -> usize {
 	x + 5 * y
 }
 
+/// Keccak-f\[1600\] state: 25 lanes of 64 bits.
 #[derive(Clone, Copy)]
 pub struct State {
 	pub words: [Wire; 25],
 }
 
-/// Keccak f\[1600\] permutation circuit.
-pub struct Permutation {
-	pub input_state: State,
-	pub output_state: State,
+/// Apply the Keccak-f\[1600\] permutation to the state in place.
+pub fn keccak_f1600(b: &CircuitBuilder, state: &mut [Wire; 25]) {
+	for round in 0..24 {
+		keccak_permutation_round(b, state, round);
+	}
 }
 
-impl Permutation {
-	/// Create a new permutation circuit.
-	///
-	/// ## Arguments
-	///
-	/// * `b` - The circuit builder to use.
-	pub fn new(b: &CircuitBuilder, input_state: State) -> Self {
-		let mut output_state = input_state;
-		Self::keccak_f1600(b, &mut output_state.words);
+/// Apply a single Keccak-f\[1600\] round to the state in place.
+pub fn keccak_permutation_round(b: &CircuitBuilder, state: &mut [Wire; 25], round: usize) {
+	theta(b, state);
+	rho_pi(b, state);
+	chi(b, state);
+	iota(b, state, round);
+}
 
-		Self {
-			input_state,
-			output_state,
-		}
+fn theta(b: &CircuitBuilder, state: &mut [Wire; 25]) {
+	let c0 = b.bxor_multi(&array::from_fn::<_, 5, _>(|y| state[idx(0, y)]));
+	let c1 = b.bxor_multi(&array::from_fn::<_, 5, _>(|y| state[idx(1, y)]));
+	let c2 = b.bxor_multi(&array::from_fn::<_, 5, _>(|y| state[idx(2, y)]));
+	let c3 = b.bxor_multi(&array::from_fn::<_, 5, _>(|y| state[idx(3, y)]));
+	let c4 = b.bxor_multi(&array::from_fn::<_, 5, _>(|y| state[idx(4, y)]));
+
+	// D[x] = C[x-1] ^ rotl1(C[x+1])
+	let d0 = b.bxor(c4, b.rotl(c1, 1));
+	let d1 = b.bxor(c0, b.rotl(c2, 1));
+	let d2 = b.bxor(c1, b.rotl(c3, 1));
+	let d3 = b.bxor(c2, b.rotl(c4, 1));
+	let d4 = b.bxor(c3, b.rotl(c0, 1));
+
+	// Fusing every linear expression into its AND leads to too many distinct shifted value
+	// indices and that slows down the shift reduction phase. Empirically we found out that
+	// preventing committing those here leads to better performance.
+	b.force_commit(d0);
+	b.force_commit(d1);
+	b.force_commit(d2);
+	b.force_commit(d3);
+	b.force_commit(d4);
+
+	// A'[x,y] = A[x,y] ^ D[x]
+	for y in 0..5 {
+		state[idx(0, y)] = b.bxor(state[idx(0, y)], d0);
+		state[idx(1, y)] = b.bxor(state[idx(1, y)], d1);
+		state[idx(2, y)] = b.bxor(state[idx(2, y)], d2);
+		state[idx(3, y)] = b.bxor(state[idx(3, y)], d3);
+		state[idx(4, y)] = b.bxor(state[idx(4, y)], d4);
 	}
+}
 
-	/// Populate the state with the given witness.
-	///
-	/// ## Arguments
-	///
-	/// * `w` - The witness to populate the state with.
-	/// * `state` - The state to populate the witness with.
-	pub fn populate_state(&self, w: &mut WitnessFiller, state: [u64; 25]) {
-		for i in 0..25 {
-			w[self.input_state.words[i]] = Word(state[i]);
-		}
+fn chi(b: &CircuitBuilder, state: &mut [Wire; 25]) {
+	for y in 0..5 {
+		let a0 = state[idx(0, y)];
+		let a1 = state[idx(1, y)];
+		let a2 = state[idx(2, y)];
+		let a3 = state[idx(3, y)];
+		let a4 = state[idx(4, y)];
+
+		state[idx(0, y)] = b.fax(b.bnot(a1), a2, a0);
+		state[idx(1, y)] = b.fax(b.bnot(a2), a3, a1);
+		state[idx(2, y)] = b.fax(b.bnot(a3), a4, a2);
+		state[idx(3, y)] = b.fax(b.bnot(a4), a0, a3);
+		state[idx(4, y)] = b.fax(b.bnot(a0), a1, a4);
 	}
+}
 
-	/// Perform the Keccak f\[1600\] permutation.
-	///
-	/// ## Arguments
-	///
-	/// * `b` - The circuit builder to use.
-	/// * `state` - The state to perform the permutation on.
-	pub fn keccak_f1600(b: &CircuitBuilder, state: &mut [Wire; 25]) {
-		for round in 0..24 {
-			Self::keccak_permutation_round(b, state, round);
-		}
-	}
-
-	pub fn keccak_permutation_round(b: &CircuitBuilder, state: &mut [Wire; 25], round: usize) {
-		Self::theta(b, state);
-		Self::rho_pi(b, state);
-		Self::chi(b, state);
-		Self::iota(b, state, round);
-	}
-
-	fn theta(b: &CircuitBuilder, state: &mut [Wire; 25]) {
-		let c0 = b.bxor_multi(&array::from_fn::<_, 5, _>(|y| state[idx(0, y)]));
-		let c1 = b.bxor_multi(&array::from_fn::<_, 5, _>(|y| state[idx(1, y)]));
-		let c2 = b.bxor_multi(&array::from_fn::<_, 5, _>(|y| state[idx(2, y)]));
-		let c3 = b.bxor_multi(&array::from_fn::<_, 5, _>(|y| state[idx(3, y)]));
-		let c4 = b.bxor_multi(&array::from_fn::<_, 5, _>(|y| state[idx(4, y)]));
-
-		// D[x] = C[x-1] ^ rotl1(C[x+1])
-		let d0 = b.bxor(c4, b.rotl(c1, 1));
-		let d1 = b.bxor(c0, b.rotl(c2, 1));
-		let d2 = b.bxor(c1, b.rotl(c3, 1));
-		let d3 = b.bxor(c2, b.rotl(c4, 1));
-		let d4 = b.bxor(c3, b.rotl(c0, 1));
-
-		// Fusing every linear expression into its AND leads to too many distinct shifted value
-		// indices and that slows down the shift reduction phase. Empirically we found out that
-		// preventing committing those here leads to better performance.
-		b.force_commit(d0);
-		b.force_commit(d1);
-		b.force_commit(d2);
-		b.force_commit(d3);
-		b.force_commit(d4);
-
-		// A'[x,y] = A[x,y] ^ D[x]
-		for y in 0..5 {
-			state[idx(0, y)] = b.bxor(state[idx(0, y)], d0);
-			state[idx(1, y)] = b.bxor(state[idx(1, y)], d1);
-			state[idx(2, y)] = b.bxor(state[idx(2, y)], d2);
-			state[idx(3, y)] = b.bxor(state[idx(3, y)], d3);
-			state[idx(4, y)] = b.bxor(state[idx(4, y)], d4);
-		}
-	}
-
-	fn chi(b: &CircuitBuilder, state: &mut [Wire; 25]) {
-		for y in 0..5 {
-			let a0 = state[idx(0, y)];
-			let a1 = state[idx(1, y)];
-			let a2 = state[idx(2, y)];
-			let a3 = state[idx(3, y)];
-			let a4 = state[idx(4, y)];
-
-			state[idx(0, y)] = b.fax(b.bnot(a1), a2, a0);
-			state[idx(1, y)] = b.fax(b.bnot(a2), a3, a1);
-			state[idx(2, y)] = b.fax(b.bnot(a3), a4, a2);
-			state[idx(3, y)] = b.fax(b.bnot(a4), a0, a3);
-			state[idx(4, y)] = b.fax(b.bnot(a0), a1, a4);
-		}
-	}
-
-	fn rho_pi(b: &CircuitBuilder, state: &mut [Wire; 25]) {
-		let mut temp = [state[0]; 25];
-		for y in 0..5 {
-			for x in 0..5 {
-				// no need to rotate if rotating by 0
-				if R[idx(x, y)] == 0 {
-					continue;
-				}
-				temp[idx(y, (2 * x + 3 * y) % 5)] = b.rotl(state[idx(x, y)], R[idx(x, y)]);
+fn rho_pi(b: &CircuitBuilder, state: &mut [Wire; 25]) {
+	let mut temp = [state[0]; 25];
+	for y in 0..5 {
+		for x in 0..5 {
+			// no need to rotate if rotating by 0
+			if R[idx(x, y)] == 0 {
+				continue;
 			}
+			temp[idx(y, (2 * x + 3 * y) % 5)] = b.rotl(state[idx(x, y)], R[idx(x, y)]);
 		}
-		*state = temp;
 	}
+	*state = temp;
+}
 
-	fn iota(b: &CircuitBuilder, state: &mut [Wire; 25], round: usize) {
-		let rc_wire = b.add_constant(Word(RC[round]));
-		state[0] = b.bxor(state[0], rc_wire);
-	}
+fn iota(b: &CircuitBuilder, state: &mut [Wire; 25], round: usize) {
+	let rc_wire = b.add_constant(Word(RC[round]));
+	state[0] = b.bxor(state[0], rc_wire);
 }
 
 #[cfg(test)]
@@ -259,18 +221,19 @@ mod tests {
 
 		let builder = CircuitBuilder::new();
 
-		let input_words = State {
-			words: array::from_fn(|_| builder.add_inout()),
-		};
-
-		let permutation = Permutation::new(&builder, input_words);
+		let input_words: [Wire; 25] = array::from_fn(|_| builder.add_inout());
+		let mut state = input_words;
+		keccak_f1600(&builder, &mut state);
+		let output_words = state;
 
 		let circuit = builder.build();
 
 		let mut w = circuit.new_witness_filler();
 
 		let initial_state = rng.random::<[u64; 25]>();
-		permutation.populate_state(&mut w, initial_state);
+		for i in 0..25 {
+			w[input_words[i]] = Word(initial_state[i]);
+		}
 
 		circuit.populate_wire_witness(&mut w).unwrap();
 
@@ -278,7 +241,7 @@ mod tests {
 		reference::keccak_f1600(&mut expected_output);
 
 		for i in 0..25 {
-			assert_eq!(w[permutation.output_state.words[i]], Word(expected_output[i]));
+			assert_eq!(w[output_words[i]], Word(expected_output[i]));
 		}
 
 		let cs = circuit.constraint_system();
@@ -327,7 +290,7 @@ mod tests {
 		let mut rng = StdRng::seed_from_u64(0);
 		let input_state = rng.random::<[u64; 25]>();
 
-		validate_circuit_component(Permutation::keccak_f1600, reference::keccak_f1600, input_state);
+		validate_circuit_component(keccak_f1600, reference::keccak_f1600, input_state);
 	}
 
 	#[test]
@@ -336,7 +299,7 @@ mod tests {
 		let input_state = rng.random::<[u64; 25]>();
 
 		validate_circuit_component(
-			|b, state| Permutation::keccak_permutation_round(b, state, 0),
+			|b, state| keccak_permutation_round(b, state, 0),
 			|state| reference::keccak_permutation_round(state, 0),
 			input_state,
 		);
@@ -347,7 +310,7 @@ mod tests {
 		let mut rng = StdRng::seed_from_u64(0);
 		let input_state = rng.random::<[u64; 25]>();
 
-		validate_circuit_component(Permutation::theta, reference::theta, input_state);
+		validate_circuit_component(theta, reference::theta, input_state);
 	}
 
 	#[test]
@@ -355,7 +318,7 @@ mod tests {
 		let mut rng = StdRng::seed_from_u64(0);
 		let input_state = rng.random::<[u64; 25]>();
 
-		validate_circuit_component(Permutation::rho_pi, reference::rho_pi, input_state);
+		validate_circuit_component(rho_pi, reference::rho_pi, input_state);
 	}
 
 	#[test]
@@ -363,7 +326,7 @@ mod tests {
 		let mut rng = StdRng::seed_from_u64(0);
 		let input_state = rng.random::<[u64; 25]>();
 
-		validate_circuit_component(Permutation::chi, reference::chi, input_state);
+		validate_circuit_component(chi, reference::chi, input_state);
 	}
 
 	#[test]
@@ -372,7 +335,7 @@ mod tests {
 		let input_state = rng.random::<[u64; 25]>();
 
 		validate_circuit_component(
-			|b, state| Permutation::iota(b, state, 0),
+			|b, state| iota(b, state, 0),
 			|state| reference::iota(state, 0),
 			input_state,
 		);

--- a/crates/circuits/src/sha256/compress.rs
+++ b/crates/circuits/src/sha256/compress.rs
@@ -1,6 +1,6 @@
 // Copyright 2025 Irreducible Inc.
 use binius_core::word::Word;
-use binius_frontend::{CircuitBuilder, Wire};
+use binius_frontend::{CircuitBuilder, Wire, WitnessFiller};
 
 const IV: [u32; 8] = [
 	0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19,
@@ -58,81 +58,71 @@ impl State {
 	}
 }
 
-/// SHA-256 compress function.
-pub struct Compress {
-	pub state_in: State,
-	pub state_out: State,
-	pub m: [Wire; 16],
-}
+/// SHA-256 compression function.
+///
+/// Builds a circuit that updates the chaining state with one 512-bit message block. Returns the
+/// next chaining state.
+///
+/// # Preconditions
+///
+/// The high halves of the message wires must be empty: `m[i] & 0xffffffff == m[i]` must hold for
+/// each `i`. The caller is responsible for enforcing this; otherwise the gadget is insecure.
+pub fn compress(builder: &CircuitBuilder, state_in: State, m: [Wire; 16]) -> State {
+	// ---- message-schedule ----
+	// W[0..15] = block_words
+	// for t = 16 .. 63:
+	//     s0   = σ0(W[t-15])
+	//     s1   = σ1(W[t-2])
+	//     (p, _)  = Add32(W[t-16], s0)
+	//     (q, _)  = Add32(p, W[t-7])
+	//     (W[t],_) = Add32(q, s1)
 
-impl Compress {
-	pub fn new(builder: &CircuitBuilder, state_in: State, m: [Wire; 16]) -> Self {
-		// it is a PRECONDITION of this gadget that the high halves of the wires fed in be empty.
-		// that is, `m[i] & 0xffffffff == m[i]` must hold for each wire `i` passed in.
-		// it is the caller's responsibility to ensure that this is the case for all wires.
-		// if this isn't true, then the behavior becomes undefined / the gadget becomes insecure.
+	let mut w: Vec<Wire> = Vec::with_capacity(64);
+	// W[0..15] = block_words
+	w.extend_from_slice(&m);
 
-		// ---- message-schedule ----
-		// W[0..15] = block_words
-		// for t = 16 .. 63:
-		//     s0   = σ0(W[t-15])
-		//     s1   = σ1(W[t-2])
-		//     (p, _)  = Add32(W[t-16], s0)
-		//     (q, _)  = Add32(p, W[t-7])
-		//     (W[t],_) = Add32(q, s1)
-
-		let mut w: Vec<Wire> = Vec::with_capacity(64);
-		// W[0..15] = block_words
-		w.extend_from_slice(&m);
-
-		// W[16..63] computed from previous W values
-		for t in 16..64 {
-			let s0 = small_sigma_0(builder, w[t - 15]);
-			let s1 = small_sigma_1(builder, w[t - 2]);
-			let p = builder.iadd_32(w[t - 16], s0);
-			let q = builder.iadd_32(p, w[t - 7]);
-			w.push(builder.iadd_32(q, s1));
-		}
-
-		let w: &[Wire; 64] = (&*w).try_into().unwrap();
-		let mut state = state_in.clone();
-		for t in 0..64 {
-			state = round(builder, t, state, w);
-		}
-
-		// Add the compressed chunk to the current hash value
-		let state_out = State([
-			builder.iadd_32(state_in.0[0], state.0[0]),
-			builder.iadd_32(state_in.0[1], state.0[1]),
-			builder.iadd_32(state_in.0[2], state.0[2]),
-			builder.iadd_32(state_in.0[3], state.0[3]),
-			builder.iadd_32(state_in.0[4], state.0[4]),
-			builder.iadd_32(state_in.0[5], state.0[5]),
-			builder.iadd_32(state_in.0[6], state.0[6]),
-			builder.iadd_32(state_in.0[7], state.0[7]),
-		]);
-
-		Compress {
-			state_in,
-			state_out,
-			m,
-		}
+	// W[16..63] computed from previous W values
+	for t in 16..64 {
+		let s0 = small_sigma_0(builder, w[t - 15]);
+		let s1 = small_sigma_1(builder, w[t - 2]);
+		let p = builder.iadd_32(w[t - 16], s0);
+		let q = builder.iadd_32(p, w[t - 7]);
+		w.push(builder.iadd_32(q, s1));
 	}
 
-	pub fn populate_m(&self, w: &mut binius_frontend::WitnessFiller, m: [u8; 64]) {
-		debug_assert_eq!(self.m.len(), 16);
+	let w: &[Wire; 64] = (&*w).try_into().unwrap();
+	let mut state = state_in.clone();
+	for t in 0..64 {
+		state = round(builder, t, state, w);
+	}
 
-		for i in 0..16 {
-			let j = i * 4;
-			// Assemble a 32-bit big-endian word and widen to 64 bits.
-			let limb = ((m[j] as u64) << 24)
-				| ((m[j + 1] as u64) << 16)
-				| ((m[j + 2] as u64) << 8)
-				| (m[j + 3] as u64);
+	// Add the compressed chunk to the current hash value
+	State([
+		builder.iadd_32(state_in.0[0], state.0[0]),
+		builder.iadd_32(state_in.0[1], state.0[1]),
+		builder.iadd_32(state_in.0[2], state.0[2]),
+		builder.iadd_32(state_in.0[3], state.0[3]),
+		builder.iadd_32(state_in.0[4], state.0[4]),
+		builder.iadd_32(state_in.0[5], state.0[5]),
+		builder.iadd_32(state_in.0[6], state.0[6]),
+		builder.iadd_32(state_in.0[7], state.0[7]),
+	])
+}
 
-			// Write it to the witness.  Word is a thin wrapper around u64.
-			w[self.m[i]] = Word(limb);
-		}
+/// Packs a 64-byte SHA-256 message block into the 16 message wires of [`compress`].
+///
+/// Each output wire receives the 32-bit big-endian word formed from the corresponding 4 input
+/// bytes, zero-extended to 64 bits.
+pub fn pack_message_block(w: &mut WitnessFiller<'_>, m_wires: &[Wire; 16], block: [u8; 64]) {
+	for i in 0..16 {
+		let j = i * 4;
+		// Assemble a 32-bit big-endian word and widen to 64 bits.
+		let limb = ((block[j] as u64) << 24)
+			| ((block[j + 1] as u64) << 16)
+			| ((block[j + 2] as u64) << 8)
+			| (block[j + 3] as u64);
+
+		w[m_wires[i]] = Word(limb);
 	}
 }
 
@@ -216,7 +206,7 @@ mod tests {
 	use binius_core::{verify::verify_constraints, word::Word};
 	use binius_frontend::{CircuitBuilder, Wire};
 
-	use super::{Compress, State};
+	use super::{State, compress, pack_message_block};
 
 	/// A test circuit that proves a knowledge of preimage for a given state vector S in
 	///
@@ -241,11 +231,11 @@ mod tests {
 		let state = State::iv(&circuit);
 		let input: [Wire; 16] = std::array::from_fn(|_| circuit.add_witness());
 		let output: [Wire; 8] = std::array::from_fn(|_| circuit.add_inout());
-		let compress = Compress::new(&circuit, state, input);
+		let state_out = compress(&circuit, state, input);
 
 		// Mask to only low 32-bit.
 		let mask32 = circuit.add_constant(Word::MASK_32);
-		for (i, (actual_x, expected_x)) in compress.state_out.0.iter().zip(output).enumerate() {
+		for (i, (actual_x, expected_x)) in state_out.0.iter().zip(output).enumerate() {
 			circuit.assert_eq(
 				format!("preimage_eq[{i}]"),
 				circuit.band(*actual_x, mask32),
@@ -258,7 +248,7 @@ mod tests {
 		let mut w = circuit.new_witness_filler();
 
 		// Populate the input message for the compression function.
-		compress.populate_m(&mut w, preimage);
+		pack_message_block(&mut w, &input, preimage);
 
 		for (i, &output) in output.iter().enumerate() {
 			w[output] = Word(expected_state[i] as u64);
@@ -275,7 +265,7 @@ mod tests {
 		const N: usize = 3;
 		let circuit = CircuitBuilder::new();
 
-		let mut compress_vec = Vec::with_capacity(N);
+		let mut m_wires: Vec<[Wire; 16]> = Vec::with_capacity(N);
 
 		// First, declare the initial state.
 		let mut state = State::iv(&circuit);
@@ -291,18 +281,16 @@ mod tests {
 			} else {
 				std::array::from_fn(|_| sha256_builder.add_witness())
 			};
-			let compress = Compress::new(&sha256_builder, state, m);
-			state = compress.state_out.clone();
-
-			compress_vec.push(compress);
+			state = compress(&sha256_builder, state, m);
+			m_wires.push(m);
 		}
 
 		let circuit = circuit.build();
 		let cs = circuit.constraint_system();
 		let mut w = circuit.new_witness_filler();
 
-		for compress in &compress_vec {
-			compress.populate_m(&mut w, [0; 64]);
+		for m in &m_wires {
+			pack_message_block(&mut w, m, [0; 64]);
 		}
 		circuit.populate_wire_witness(&mut w).unwrap();
 
@@ -315,7 +303,7 @@ mod tests {
 		const N: usize = 3;
 		let circuit = CircuitBuilder::new();
 
-		let mut compress_vec = Vec::with_capacity(N);
+		let mut m_wires: Vec<[Wire; 16]> = Vec::with_capacity(N);
 
 		for i in 0..N {
 			// Create a new subcircuit builder
@@ -324,17 +312,16 @@ mod tests {
 			// Each SHA-256 instance gets its own IV and input (all committed)
 			let state = State::iv(&sha256_builder);
 			let m: [Wire; 16] = std::array::from_fn(|_| sha256_builder.add_inout());
-			let compress = Compress::new(&sha256_builder, state, m);
-
-			compress_vec.push(compress);
+			let _state_out = compress(&sha256_builder, state, m);
+			m_wires.push(m);
 		}
 
 		let circuit = circuit.build();
 		let cs = circuit.constraint_system();
 		let mut w = circuit.new_witness_filler();
 
-		for compress in &compress_vec {
-			compress.populate_m(&mut w, [0; 64]);
+		for m in &m_wires {
+			pack_message_block(&mut w, m, [0; 64]);
 		}
 		circuit.populate_wire_witness(&mut w).unwrap();
 

--- a/crates/circuits/src/sha256/mod.rs
+++ b/crates/circuits/src/sha256/mod.rs
@@ -47,7 +47,7 @@ pub struct Sha256 {
 	/// This circuit will run enough hash blocks to process the entire message.
 	pub message: Vec<Wire>,
 
-	/// Per-block message wires fed into [`compress`], one `[Wire; 16]` array per 512-bit block.
+	/// Per-block message wires fed into [`compress()`], one `[Wire; 16]` array per 512-bit block.
 	///
 	/// The compression functions are chained together, with each taking the output state from the
 	/// previous compression as input. The first compression starts from the SHA-256 IV. The

--- a/crates/circuits/src/sha256/mod.rs
+++ b/crates/circuits/src/sha256/mod.rs
@@ -6,7 +6,7 @@ use binius_core::{
 	word::Word,
 };
 use binius_frontend::{CircuitBuilder, Wire, WitnessFiller};
-pub use compress::{Compress, State};
+pub use compress::{State, compress, pack_message_block};
 
 use crate::{
 	bytes::{swap_bytes, swap_bytes_32},
@@ -47,15 +47,13 @@ pub struct Sha256 {
 	/// This circuit will run enough hash blocks to process the entire message.
 	pub message: Vec<Wire>,
 
-	/// Compression gadgets for each 512-bit block.
+	/// Per-block message wires fed into [`compress`], one `[Wire; 16]` array per 512-bit block.
 	///
-	/// Each compression gadget processes one 512-bit (64-byte) block of the padded message.
-	/// The gadgets are chained together, with each taking the output state from the previous
-	/// compression as input. The first compression starts from the SHA-256 initialization vector.
-	///
-	/// The number of compression gadgets is `ceil((max_len_bytes + 9) / 64)`, accounting for
-	/// the minimum 9 bytes of padding (1 byte for 0x80 delimiter + 8 bytes for length).
-	compress: Vec<Compress>,
+	/// The compression functions are chained together, with each taking the output state from the
+	/// previous compression as input. The first compression starts from the SHA-256 IV. The
+	/// number of blocks is `ceil((max_len_bytes + 9) / 64)`, accounting for the minimum 9 bytes
+	/// of padding (1 byte for 0x80 delimiter + 8 bytes for length).
+	compress_m_wires: Vec<[Wire; 16]>,
 }
 
 impl Sha256 {
@@ -149,24 +147,25 @@ impl Sha256 {
 		let padded_evens: Vec<Wire> = (0..n_words).map(|_| builder.add_witness()).collect();
 		let padded_odds: Vec<Wire> = (0..n_words).map(|_| builder.add_witness()).collect();
 
-		let mut compress = Vec::with_capacity(n_blocks);
+		let mut compress_m_wires: Vec<[Wire; 16]> = Vec::with_capacity(n_blocks);
 		let mut states = Vec::with_capacity(n_blocks + 1);
 		states.push(State::iv(builder));
 		for block_no in 0..n_blocks {
-			let c = Compress::new(
+			// grab appropriate interleaved wires, in order to feed into compression gadget.
+			let m: [Wire; 16] = std::array::from_fn(|i| {
+				if i & 1 == 0 {
+					padded_evens[block_no << 3 | i >> 1]
+				} else {
+					padded_odds[block_no << 3 | i >> 1]
+				}
+			});
+			let state_out = compress(
 				&builder.subcircuit(format!("compress[{block_no}]")),
 				states[block_no].clone(),
-				// grab appropriate interleaved wires, in order to feed into compression gadget.
-				std::array::from_fn(|i| {
-					if i & 1 == 0 {
-						padded_evens[block_no << 3 | i >> 1]
-					} else {
-						padded_odds[block_no << 3 | i >> 1]
-					}
-				}),
+				m,
 			);
-			states.push(c.state_out.clone());
-			compress.push(c);
+			states.push(state_out);
+			compress_m_wires.push(m);
 		}
 
 		// ---- 2a. SHA-256 padding position calculation
@@ -354,7 +353,7 @@ impl Sha256 {
 			len_bytes,
 			digest,
 			message,
-			compress,
+			compress_m_wires,
 		}
 	}
 
@@ -426,7 +425,7 @@ impl Sha256 {
 			self.max_len_bytes()
 		);
 
-		let n_blocks = self.compress.len();
+		let n_blocks = self.compress_m_wires.len();
 		let mut padded_message_bytes = vec![0u8; n_blocks * 64];
 
 		// Apply SHA-256 padding
@@ -476,10 +475,10 @@ impl Sha256 {
 			w[*wire] = Word(word);
 		}
 
-		for (i, compress) in self.compress.iter().enumerate() {
+		for (i, m_wires) in self.compress_m_wires.iter().enumerate() {
 			let block_start = i * 64;
 			let block = &padded_message_bytes[block_start..block_start + 64];
-			compress.populate_m(w, block.try_into().unwrap());
+			pack_message_block(w, m_wires, block.try_into().unwrap());
 		}
 	}
 }
@@ -588,14 +587,11 @@ pub fn sha256_fixed(builder: &CircuitBuilder, message: &[Wire], len_bytes: usize
 		State::iv(builder),
 		|state, (block_idx, block)| {
 			let block_message: [Wire; 16] = block.try_into().unwrap();
-
-			let compress = Compress::new(
+			compress(
 				&builder.subcircuit(format!("sha256_fixed_compress[{}]", block_idx)),
 				state.clone(),
 				block_message,
-			);
-
-			compress.state_out
+			)
 		},
 	);
 

--- a/crates/circuits/src/sha512/compress.rs
+++ b/crates/circuits/src/sha512/compress.rs
@@ -1,6 +1,6 @@
 // Copyright 2025 Irreducible Inc.
 use binius_core::word::Word;
-use binius_frontend::{CircuitBuilder, Wire};
+use binius_frontend::{CircuitBuilder, Wire, WitnessFiller};
 
 const IV: [u64; 8] = [
 	0x6a09e667f3bcc908,
@@ -122,81 +122,71 @@ impl State {
 	}
 }
 
-/// SHA-512 compress function.
-pub struct Compress {
-	pub state_in: State,
-	pub state_out: State,
-	pub m: [Wire; 16],
-}
+/// SHA-512 compression function.
+///
+/// Builds a circuit that updates the chaining state with one 1024-bit message block. Returns the
+/// next chaining state.
+pub fn compress(builder: &CircuitBuilder, state_in: State, m: [Wire; 16]) -> State {
+	// ---- message-schedule ----
+	// W[0..15] = block_words
+	// for t = 16 .. 79:
+	//     s0   = σ0(W[t-15])
+	//     s1   = σ1(W[t-2])
+	//     (p, _)  = Add(W[t-16], s0)
+	//     (q, _)  = Add(p, W[t-7])
+	//     (W[t],_) = Add(q, s1)
+	let mut w = Vec::with_capacity(80);
 
-impl Compress {
-	pub fn new(builder: &CircuitBuilder, state_in: State, m: [Wire; 16]) -> Self {
-		// ---- message-schedule ----
-		// W[0..15] = block_words
-		// for t = 16 .. 79:
-		//     s0   = σ0(W[t-15])
-		//     s1   = σ1(W[t-2])
-		//     (p, _)  = Add(W[t-16], s0)
-		//     (q, _)  = Add(p, W[t-7])
-		//     (W[t],_) = Add(q, s1)
-		let mut w = Vec::with_capacity(80);
+	// W[0..15] = block_words
+	w.extend_from_slice(&m);
 
-		// W[0..15] = block_words
-		w.extend_from_slice(&m);
-
-		// W[16..79] computed from previous W values
-		for t in 16..80 {
-			let s0 = small_sigma_0(builder, w[t - 15]);
-			let s1 = small_sigma_1(builder, w[t - 2]);
-			let (p, _carry) = builder.iadd(w[t - 16], s0);
-			let (q, _carry) = builder.iadd(p, w[t - 7]);
-			let (w_t, _carry) = builder.iadd(q, s1);
-			w.push(w_t);
-		}
-
-		let w: &[Wire; 80] = (&*w).try_into().unwrap();
-		let mut state = state_in.clone();
-		for t in 0..80 {
-			state = round(builder, t, state, w);
-		}
-
-		// Add the compressed chunk to the current hash value
-		let (a_out, _carry) = builder.iadd(state_in.0[0], state.0[0]);
-		let (b_out, _carry) = builder.iadd(state_in.0[1], state.0[1]);
-		let (c_out, _carry) = builder.iadd(state_in.0[2], state.0[2]);
-		let (d_out, _carry) = builder.iadd(state_in.0[3], state.0[3]);
-		let (e_out, _carry) = builder.iadd(state_in.0[4], state.0[4]);
-		let (f_out, _carry) = builder.iadd(state_in.0[5], state.0[5]);
-		let (g_out, _carry) = builder.iadd(state_in.0[6], state.0[6]);
-		let (h_out, _carry) = builder.iadd(state_in.0[7], state.0[7]);
-
-		let state_out = State([a_out, b_out, c_out, d_out, e_out, f_out, g_out, h_out]);
-
-		Compress {
-			state_in,
-			state_out,
-			m,
-		}
+	// W[16..79] computed from previous W values
+	for t in 16..80 {
+		let s0 = small_sigma_0(builder, w[t - 15]);
+		let s1 = small_sigma_1(builder, w[t - 2]);
+		let (p, _carry) = builder.iadd(w[t - 16], s0);
+		let (q, _carry) = builder.iadd(p, w[t - 7]);
+		let (w_t, _carry) = builder.iadd(q, s1);
+		w.push(w_t);
 	}
 
-	pub fn populate_m(&self, w: &mut binius_frontend::WitnessFiller, m: [u8; 128]) {
-		debug_assert_eq!(self.m.len(), 16);
+	let w: &[Wire; 80] = (&*w).try_into().unwrap();
+	let mut state = state_in.clone();
+	for t in 0..80 {
+		state = round(builder, t, state, w);
+	}
 
-		for i in 0..16 {
-			let j = i * 8;
-			// Assemble a 64-bit big-endian word.
-			let limb = ((m[j] as u64) << 56)
-				| ((m[j + 1] as u64) << 48)
-				| ((m[j + 2] as u64) << 40)
-				| ((m[j + 3] as u64) << 32)
-				| ((m[j + 4] as u64) << 24)
-				| ((m[j + 5] as u64) << 16)
-				| ((m[j + 6] as u64) << 8)
-				| (m[j + 7] as u64);
+	// Add the compressed chunk to the current hash value
+	let (a_out, _carry) = builder.iadd(state_in.0[0], state.0[0]);
+	let (b_out, _carry) = builder.iadd(state_in.0[1], state.0[1]);
+	let (c_out, _carry) = builder.iadd(state_in.0[2], state.0[2]);
+	let (d_out, _carry) = builder.iadd(state_in.0[3], state.0[3]);
+	let (e_out, _carry) = builder.iadd(state_in.0[4], state.0[4]);
+	let (f_out, _carry) = builder.iadd(state_in.0[5], state.0[5]);
+	let (g_out, _carry) = builder.iadd(state_in.0[6], state.0[6]);
+	let (h_out, _carry) = builder.iadd(state_in.0[7], state.0[7]);
 
-			// Write it to the witness.  Word is a thin wrapper around u64.
-			w[self.m[i]] = Word(limb);
-		}
+	State([a_out, b_out, c_out, d_out, e_out, f_out, g_out, h_out])
+}
+
+/// Packs a 128-byte SHA-512 message block into the 16 message wires of [`compress`].
+///
+/// Each output wire receives the 64-bit big-endian word formed from the corresponding 8 input
+/// bytes.
+pub fn pack_message_block(w: &mut WitnessFiller<'_>, m_wires: &[Wire; 16], block: [u8; 128]) {
+	for i in 0..16 {
+		let j = i * 8;
+		// Assemble a 64-bit big-endian word.
+		let limb = ((block[j] as u64) << 56)
+			| ((block[j + 1] as u64) << 48)
+			| ((block[j + 2] as u64) << 40)
+			| ((block[j + 3] as u64) << 32)
+			| ((block[j + 4] as u64) << 24)
+			| ((block[j + 5] as u64) << 16)
+			| ((block[j + 6] as u64) << 8)
+			| (block[j + 7] as u64);
+
+		w[m_wires[i]] = Word(limb);
 	}
 }
 
@@ -280,7 +270,7 @@ mod tests {
 	use binius_core::{verify::verify_constraints, word::Word};
 	use binius_frontend::{CircuitBuilder, Wire};
 
-	use super::{Compress, State};
+	use super::{State, compress, pack_message_block};
 
 	/// A test circuit that proves a knowledge of preimage for a given state vector S in
 	///
@@ -305,9 +295,9 @@ mod tests {
 		let state = State::iv(&circuit);
 		let input: [Wire; 16] = std::array::from_fn(|_| circuit.add_witness());
 		let output: [Wire; 8] = std::array::from_fn(|_| circuit.add_inout());
-		let compress = Compress::new(&circuit, state, input);
+		let state_out = compress(&circuit, state, input);
 
-		for (i, (actual_x, expected_x)) in compress.state_out.0.iter().zip(output).enumerate() {
+		for (i, (actual_x, expected_x)) in state_out.0.iter().zip(output).enumerate() {
 			circuit.assert_eq(format!("preimage_eq[{i}]"), *actual_x, expected_x);
 		}
 
@@ -316,7 +306,7 @@ mod tests {
 		let mut w = circuit.new_witness_filler();
 
 		// Populate the input message for the compression function.
-		compress.populate_m(&mut w, preimage);
+		pack_message_block(&mut w, &input, preimage);
 
 		for (i, &output) in output.iter().enumerate() {
 			w[output] = Word(expected_state[i]);
@@ -333,7 +323,7 @@ mod tests {
 		const N: usize = 3;
 		let circuit = CircuitBuilder::new();
 
-		let mut compress_vec = Vec::with_capacity(N);
+		let mut m_wires: Vec<[Wire; 16]> = Vec::with_capacity(N);
 
 		// First, declare the initial state.
 		let mut state = State::iv(&circuit);
@@ -349,18 +339,16 @@ mod tests {
 			} else {
 				std::array::from_fn(|_| sha512_builder.add_witness())
 			};
-			let compress = Compress::new(&sha512_builder, state, m);
-			state = compress.state_out.clone();
-
-			compress_vec.push(compress);
+			state = compress(&sha512_builder, state, m);
+			m_wires.push(m);
 		}
 
 		let circuit = circuit.build();
 		let cs = circuit.constraint_system();
 		let mut w = circuit.new_witness_filler();
 
-		for compress in &compress_vec {
-			compress.populate_m(&mut w, [0; 128]);
+		for m in &m_wires {
+			pack_message_block(&mut w, m, [0; 128]);
 		}
 		circuit.populate_wire_witness(&mut w).unwrap();
 
@@ -373,7 +361,7 @@ mod tests {
 		const N: usize = 3;
 		let circuit = CircuitBuilder::new();
 
-		let mut compress_vec = Vec::with_capacity(N);
+		let mut m_wires: Vec<[Wire; 16]> = Vec::with_capacity(N);
 
 		for i in 0..N {
 			// Create a new subcircuit builder
@@ -382,17 +370,16 @@ mod tests {
 			// Each SHA-512 instance gets its own IV and input (all committed)
 			let state = State::iv(&sha512_builder);
 			let m: [Wire; 16] = std::array::from_fn(|_| sha512_builder.add_inout());
-			let compress = Compress::new(&sha512_builder, state, m);
-
-			compress_vec.push(compress);
+			let _state_out = compress(&sha512_builder, state, m);
+			m_wires.push(m);
 		}
 
 		let circuit = circuit.build();
 		let cs = circuit.constraint_system();
 		let mut w = circuit.new_witness_filler();
 
-		for compress in &compress_vec {
-			compress.populate_m(&mut w, [0; 128]);
+		for m in &m_wires {
+			pack_message_block(&mut w, m, [0; 128]);
 		}
 		circuit.populate_wire_witness(&mut w).unwrap();
 		verify_constraints(cs, &w.into_value_vec()).unwrap();

--- a/crates/circuits/src/sha512/mod.rs
+++ b/crates/circuits/src/sha512/mod.rs
@@ -6,7 +6,7 @@ use binius_core::{
 	word::Word,
 };
 use binius_frontend::{CircuitBuilder, Wire, WitnessFiller};
-pub use compress::{Compress, State};
+pub use compress::{State, compress, pack_message_block};
 
 use crate::{
 	bytes::swap_bytes,
@@ -46,15 +46,13 @@ pub struct Sha512 {
 	/// This circuit will run enough hash blocks to process the entire message.
 	pub message: Vec<Wire>,
 
-	/// Compression gadgets for each 1024-bit block.
+	/// Per-block message wires fed into [`compress`], one `[Wire; 16]` array per 1024-bit block.
 	///
-	/// Each compression gadget processes one 1024-bit (128-byte) block of the padded message.
-	/// The gadgets are chained together, with each taking the output state from the previous
-	/// compression as input. The first compression starts from the SHA-512 initialization vector.
-	///
-	/// The number of compression gadgets is `ceil((max_len_bytes + 17) / 128)`, accounting for
-	/// the minimum 17 bytes of padding (1 byte for 0x80 delimiter + 16 bytes for length).
-	compress: Vec<Compress>,
+	/// The compression functions are chained together, with each taking the output state from the
+	/// previous compression as input. The first compression starts from the SHA-512 IV. The
+	/// number of blocks is `ceil((max_len_bytes + 17) / 128)`, accounting for the minimum 17
+	/// bytes of padding (1 byte for 0x80 delimiter + 16 bytes for length).
+	compress_m_wires: Vec<[Wire; 16]>,
 }
 
 impl Sha512 {
@@ -139,19 +137,20 @@ impl Sha512 {
 
 		let padded_message: Vec<Wire> = (0..n_words).map(|_| builder.add_witness()).collect();
 
-		let mut compress = Vec::with_capacity(n_blocks);
+		let mut compress_m_wires: Vec<[Wire; 16]> = Vec::with_capacity(n_blocks);
 		let mut states = Vec::with_capacity(n_blocks + 1);
 		states.push(State::iv(builder));
 		for block_no in 0..n_blocks {
-			let c = Compress::new(
+			let m: [Wire; 16] = padded_message[block_no << 4..(block_no + 1) << 4]
+				.try_into()
+				.unwrap();
+			let state_out = compress(
 				&builder.subcircuit(format!("compress[{block_no}]")),
 				states[block_no].clone(),
-				padded_message[block_no << 4..(block_no + 1) << 4]
-					.try_into()
-					.unwrap(),
+				m,
 			);
-			states.push(c.state_out.clone());
-			compress.push(c);
+			states.push(state_out);
+			compress_m_wires.push(m);
 		}
 
 		// ---- 2a. SHA-512 padding position calculation
@@ -324,7 +323,7 @@ impl Sha512 {
 			len_bytes,
 			digest,
 			message,
-			compress,
+			compress_m_wires,
 		}
 	}
 
@@ -394,7 +393,7 @@ impl Sha512 {
 			self.max_len_bytes()
 		);
 
-		let n_blocks = self.compress.len();
+		let n_blocks = self.compress_m_wires.len();
 		let mut padded_message_bytes = vec![0u8; n_blocks * 128];
 
 		// Apply SHA-512 padding
@@ -437,11 +436,11 @@ impl Sha512 {
 			w[*wire] = Word(word);
 		}
 
-		for (i, compress) in self.compress.iter().enumerate() {
+		for (i, m_wires) in self.compress_m_wires.iter().enumerate() {
 			let block_start = i * 128;
 			let mut block_arr = [0u8; 128];
 			block_arr.copy_from_slice(&padded_message_bytes[block_start..block_start + 128]);
-			compress.populate_m(w, block_arr);
+			pack_message_block(w, m_wires, block_arr);
 		}
 	}
 }
@@ -548,14 +547,11 @@ pub fn sha512_fixed(builder: &CircuitBuilder, message: &[Wire], len_bytes: usize
 			let block_message: [Wire; 16] = block
 				.try_into()
 				.expect("padded_message.len() must be divisible by 16");
-
-			let compress = Compress::new(
+			compress(
 				&builder.subcircuit(format!("sha512_fixed_compress[{}]", block_idx)),
 				state.clone(),
 				block_message,
-			);
-
-			compress.state_out
+			)
 		},
 	);
 

--- a/crates/circuits/src/sha512/mod.rs
+++ b/crates/circuits/src/sha512/mod.rs
@@ -46,7 +46,7 @@ pub struct Sha512 {
 	/// This circuit will run enough hash blocks to process the entire message.
 	pub message: Vec<Wire>,
 
-	/// Per-block message wires fed into [`compress`], one `[Wire; 16]` array per 1024-bit block.
+	/// Per-block message wires fed into [`compress()`], one `[Wire; 16]` array per 1024-bit block.
 	///
 	/// The compression functions are chained together, with each taking the output state from the
 	/// previous compression as input. The first compression starts from the SHA-512 IV. The

--- a/crates/circuits/src/slice.rs
+++ b/crates/circuits/src/slice.rs
@@ -76,8 +76,7 @@ pub fn slice(
 				b.icmp_ult(b.add_constant(Word(word_start_bytes as u64)), len_slice);
 
 			// Calculate which input word(s) we need
-			let (input_word_idx, _) =
-				b.iadd(word_offset, b.add_constant(Word(slice_idx as u64)));
+			let (input_word_idx, _) = b.iadd(word_offset, b.add_constant(Word(slice_idx as u64)));
 
 			let extracted_word = extract_word(&b, input, input_word_idx, byte_offset);
 

--- a/crates/circuits/src/slice.rs
+++ b/crates/circuits/src/slice.rs
@@ -1,13 +1,14 @@
 // Copyright 2025 Irreducible Inc.
 use binius_core::word::Word;
-use binius_frontend::{CircuitBuilder, Wire, WitnessFiller};
+use binius_frontend::{CircuitBuilder, Wire};
 
 use crate::multiplexer::single_wire_multiplex;
 
-/// Verifies that a slice is correctly extracted from an input byte array.
+/// Extracts a slice from an input byte array and returns it as a vector of packed 64-bit words.
 ///
-/// This circuit validates that `slice` contains exactly the bytes from
-/// `input` starting at `offset` for `len_slice` bytes.
+/// Returns the bytes from `input` starting at `offset` for `len_slice` bytes, packed into
+/// `max_n_words` little-endian 64-bit words. Bytes past `len_slice` in the active words and any
+/// trailing words past `ceil(len_slice / 8)` are zero.
 ///
 /// # Limitations
 /// All size and offset values must fit within 32 bits. Specifically:
@@ -17,192 +18,79 @@ use crate::multiplexer::single_wire_multiplex;
 /// - `offset + len_slice` must be < 2^32
 ///
 /// These limitations are enforced by the circuit constraints.
-pub struct Slice {
-	pub len_input: Wire,
-	pub len_slice: Wire,
-	pub input: Vec<Wire>,
-	pub slice: Vec<Wire>,
-	pub offset: Wire,
-}
+///
+/// # Arguments
+/// * `b` - Circuit builder
+/// * `len_input` - Actual input size in bytes
+/// * `len_slice` - Actual slice size in bytes
+/// * `input` - Input array packed as words (8 bytes per word)
+/// * `offset` - Byte offset where slice starts
+/// * `max_n_words` - Number of output wires; the maximum slice length in bytes is `max_n_words * 8`
+///
+/// # Returns
+/// A `Vec<Wire>` of length `max_n_words` containing the extracted slice bytes packed in
+/// little-endian order. Bytes past `len_slice` are zero.
+///
+/// # Panics
+/// * If `input.len() * 8 > u32::MAX`
+/// * If `max_n_words * 8 > u32::MAX`
+pub fn slice(
+	b: &CircuitBuilder,
+	len_input: Wire,
+	len_slice: Wire,
+	input: &[Wire],
+	offset: Wire,
+	max_n_words: usize,
+) -> Vec<Wire> {
+	// Static assertions to ensure maximum sizes fit within 32 bits
+	let max_len_input = input.len() << 3;
+	let max_len_slice = max_n_words << 3;
 
-impl Slice {
-	/// Creates a new slice verifier circuit.
-	///
-	/// # Arguments
-	/// * `b` - Circuit builder
-	/// * `len_input` - Actual input size in bytes
-	/// * `len_slice` - Actual slice size in bytes
-	/// * `input` - Input array packed as words (8 bytes per word)
-	/// * `slice` - Slice array packed as words (8 bytes per word)
-	/// * `offset` - Byte offset where slice starts
-	///
-	/// # Panics
-	/// * If max_n_input >= 2^32
-	/// * If max_n_slice >= 2^32
-	#[allow(clippy::too_many_arguments)]
-	pub fn new(
-		b: &CircuitBuilder,
-		len_input: Wire,
-		len_slice: Wire,
-		input: Vec<Wire>,
-		slice: Vec<Wire>,
-		offset: Wire,
-	) -> Self {
-		// Static assertions to ensure maximum sizes fit within 32 bits
-		let max_len_input = input.len() << 3;
-		let max_len_slice = slice.len() << 3;
+	assert!(max_len_input <= u32::MAX as usize, "max_n_input must be < 2^32");
+	assert!(max_len_slice <= u32::MAX as usize, "max_n_slice must be < 2^32");
 
-		assert!(max_len_input <= u32::MAX as usize, "max_n_input must be < 2^32");
-		assert!(max_len_slice <= u32::MAX as usize, "max_n_slice must be < 2^32");
+	// Ensure all values fit in 32 bits to prevent overflow in iadd_32
+	b.assert_zero("offset_32bit", b.shr(offset, 32));
+	b.assert_zero("len_slice_32bit", b.shr(len_slice, 32));
+	b.assert_zero("len_input_32bit", b.shr(len_input, 32));
 
-		// Ensure all values fit in 32 bits to prevent overflow in iadd_32
-		b.assert_zero("offset_32bit", b.shr(offset, 32));
-		b.assert_zero("len_slice_32bit", b.shr(len_slice, 32));
-		b.assert_zero("len_input_32bit", b.shr(len_input, 32));
+	// Verify bounds: offset + len_slice <= len_input
+	let (offset_plus_len_slice, _) = b.iadd(offset, len_slice);
+	let in_bounds = b.icmp_ule(offset_plus_len_slice, len_input);
+	b.assert_true("bounds_check", in_bounds);
 
-		// Verify bounds: offset + len_slice <= len_input
-		let (offset_plus_len_slice, _) = b.iadd(offset, len_slice);
-		let in_bounds = b.icmp_ule(offset_plus_len_slice, len_input);
-		b.assert_true("bounds_check", in_bounds);
+	// Decompose offset = word_offset * 8 + byte_offset
+	let word_offset = b.shr(offset, 3); // offset / 8
+	let byte_offset = b.band(offset, b.add_constant(Word(7))); // offset % 8
 
-		// Decompose offset = word_offset * 8 + byte_offset
-		let word_offset = b.shr(offset, 3); // offset / 8
-		let byte_offset = b.band(offset, b.add_constant(Word(7))); // offset % 8
-
-		// Go over every word in the slice and check that it was copied from the input byte string
-		// correctly.
-		for (slice_idx, &slice_word) in slice.iter().enumerate() {
+	// For each output word, compute the corresponding bytes of the slice. Trailing positions past
+	// `len_slice` are zeroed via the byte mask and the `word_partially_valid` guard.
+	let zero = b.add_constant(Word::ZERO);
+	(0..max_n_words)
+		.map(|slice_idx| {
 			let b = b.subcircuit(format!("slice_word[{slice_idx}]"));
 
 			// Check if this word is within the actual slice
 			let word_start_bytes = slice_idx << 3;
 			let word_partially_valid =
 				b.icmp_ult(b.add_constant(Word(word_start_bytes as u64)), len_slice);
-			// are ANY of the bytes in this present word actually part of the slice proper?
 
 			// Calculate which input word(s) we need
-			let (input_word_idx, _) = b.iadd(word_offset, b.add_constant(Word(slice_idx as u64)));
+			let (input_word_idx, _) =
+				b.iadd(word_offset, b.add_constant(Word(slice_idx as u64)));
 
-			let extracted_word = extract_word(&b, &input, input_word_idx, byte_offset);
+			let extracted_word = extract_word(&b, input, input_word_idx, byte_offset);
 
-			// For every word, calculate how many bytes are valid and apply appropriate mask
-			// Calculate valid bytes in this word: min(len_slice - word_start, 8)
-			// First calculate len_slice - word_start
+			// For every word, calculate how many bytes are valid and apply appropriate mask:
+			//     bytes_remaining = len_slice - word_start_bytes (mask clamps internally to 8).
 			let neg_start = b.add_constant(Word((-(word_start_bytes as i64)) as u64));
 			let (bytes_remaining, _) = b.iadd(len_slice, neg_start);
-
-			// The mask will handle clamping to 8 bytes internally
 			let mask = create_byte_mask(&b, bytes_remaining);
 
-			// For partial words, we need to ensure:
-			// 1. The valid bytes match the extracted word
-			// 2. The invalid bytes are zero
-			// Assert they are equal (only if word is at least partially valid)
-			let zero = b.add_constant(Word::ZERO);
-			b.assert_eq_cond(
-				format!("slice_word_{slice_idx}"),
-				b.band(slice_word, mask),
-				b.band(extracted_word, mask),
-				word_partially_valid,
-			);
-			b.assert_eq_cond(
-				format!("slice_word_{slice_idx}_padding"),
-				b.band(slice_word, b.bnot(mask)),
-				zero,
-				word_partially_valid,
-			);
-
-			b.assert_eq_cond(
-				format!("slice_word_{slice_idx} non-slice"),
-				slice_word,
-				zero,
-				b.bnot(word_partially_valid),
-			);
-		}
-
-		Slice {
-			len_input,
-			len_slice,
-			input,
-			slice,
-			offset,
-		}
-	}
-
-	/// Populate the len_input wire with the actual input size in bytes
-	pub fn populate_len_input(&self, w: &mut WitnessFiller, len_input: usize) {
-		w[self.len_input] = Word(len_input as u64);
-	}
-
-	/// Populate the len_slice wire with the actual slice size in bytes
-	pub fn populate_len_slice(&self, w: &mut WitnessFiller, len_slice: usize) {
-		w[self.len_slice] = Word(len_slice as u64);
-	}
-
-	/// Populate the input array from a byte slice
-	///
-	/// # Panics
-	/// Panics if input.len() > max_n_input (the maximum size specified during construction)
-	pub fn populate_input(&self, w: &mut WitnessFiller, input: &[u8]) {
-		let max_n_input = self.input.len() * 8;
-		assert!(
-			input.len() <= max_n_input,
-			"input length {} exceeds maximum {}",
-			input.len(),
-			max_n_input
-		);
-
-		// Pack bytes into words
-		for (i, chunk) in input.chunks(8).enumerate() {
-			if i < self.input.len() {
-				let mut word = 0u64;
-				for (j, &byte) in chunk.iter().enumerate() {
-					word |= (byte as u64) << (j * 8);
-				}
-				w[self.input[i]] = Word(word);
-			}
-		}
-
-		// Zero out remaining words
-		for i in input.len().div_ceil(8)..self.input.len() {
-			w[self.input[i]] = Word::ZERO;
-		}
-	}
-
-	/// Populate the slice array from a byte slice
-	///
-	/// # Panics
-	/// Panics if slice.len() > max_n_slice (the maximum size specified during construction)
-	pub fn populate_slice(&self, w: &mut WitnessFiller, slice: &[u8]) {
-		let max_n_slice = self.slice.len() * 8;
-		assert!(
-			slice.len() <= max_n_slice,
-			"slice length {} exceeds maximum {}",
-			slice.len(),
-			max_n_slice
-		);
-
-		// Pack bytes into words
-		for (i, chunk) in slice.chunks(8).enumerate() {
-			if i < self.slice.len() {
-				let mut word = 0u64;
-				for (j, &byte) in chunk.iter().enumerate() {
-					word |= (byte as u64) << (j * 8);
-				}
-				w[self.slice[i]] = Word(word);
-			}
-		}
-
-		// Zero out remaining words
-		for i in slice.len().div_ceil(8)..self.slice.len() {
-			w[self.slice[i]] = Word::ZERO;
-		}
-	}
-
-	/// Populate the offset wire
-	pub fn populate_offset(&self, w: &mut WitnessFiller, offset: usize) {
-		w[self.offset] = Word(offset as u64);
-	}
+			let masked_extracted = b.band(extracted_word, mask);
+			b.select(word_partially_valid, masked_extracted, zero)
+		})
+		.collect()
 }
 
 /// Extracts a word from the input array at the specified word index and byte offset.
@@ -272,665 +160,296 @@ pub fn create_byte_mask(b: &CircuitBuilder, n_bytes: Wire) -> Wire {
 #[cfg(test)]
 mod tests {
 	use binius_core::verify::verify_constraints;
+	use binius_frontend::util::pack_bytes_into_wires_le;
 
-	use super::{CircuitBuilder, Slice, Wire, Word};
+	use super::{CircuitBuilder, Wire, Word, slice};
+
+	/// Build a test circuit that takes input + offset wires, calls `slice`, and asserts the
+	/// returned bytes equal a separately allocated `expected` byte vector. Returns the wires the
+	/// caller needs to populate.
+	struct SliceTestSetup {
+		builder: CircuitBuilder,
+		len_input: Wire,
+		len_slice: Wire,
+		offset: Wire,
+		input: Vec<Wire>,
+		expected: Vec<Wire>,
+	}
+
+	fn build_slice_check(n_input_words: usize, n_slice_words: usize) -> SliceTestSetup {
+		let builder = CircuitBuilder::new();
+		let len_input = builder.add_inout();
+		let len_slice = builder.add_inout();
+		let offset = builder.add_inout();
+		let input: Vec<Wire> = (0..n_input_words).map(|_| builder.add_inout()).collect();
+		let expected: Vec<Wire> = (0..n_slice_words).map(|_| builder.add_inout()).collect();
+		let actual = slice(&builder, len_input, len_slice, &input, offset, n_slice_words);
+		for (i, (&a, &e)) in actual.iter().zip(&expected).enumerate() {
+			builder.assert_eq(format!("slice_eq[{i}]"), a, e);
+		}
+		SliceTestSetup {
+			builder,
+			len_input,
+			len_slice,
+			offset,
+			input,
+			expected,
+		}
+	}
+
+	/// Run a success-case test: pack `input_data` and `expected_slice_data` into the test setup,
+	/// run the circuit, and verify constraints.
+	fn run_slice_success(
+		setup: SliceTestSetup,
+		len_input_val: u64,
+		len_slice_val: u64,
+		offset_val: u64,
+		input_data: &[u8],
+		expected_slice_data: &[u8],
+	) {
+		let circuit = setup.builder.build();
+		let mut filler = circuit.new_witness_filler();
+		filler[setup.len_input] = Word(len_input_val);
+		filler[setup.len_slice] = Word(len_slice_val);
+		filler[setup.offset] = Word(offset_val);
+		pack_bytes_into_wires_le(&mut filler, &setup.input, input_data);
+		pack_bytes_into_wires_le(&mut filler, &setup.expected, expected_slice_data);
+
+		circuit.populate_wire_witness(&mut filler).unwrap();
+		let cs = circuit.constraint_system();
+		verify_constraints(cs, &filler.into_value_vec()).unwrap();
+	}
+
+	/// Run a failure-case test: expect `populate_wire_witness` to error.
+	fn run_slice_failure(
+		setup: SliceTestSetup,
+		len_input_val: u64,
+		len_slice_val: u64,
+		offset_val: u64,
+		input_data: &[u8],
+		expected_slice_data: &[u8],
+	) {
+		let circuit = setup.builder.build();
+		let mut filler = circuit.new_witness_filler();
+		filler[setup.len_input] = Word(len_input_val);
+		filler[setup.len_slice] = Word(len_slice_val);
+		filler[setup.offset] = Word(offset_val);
+		pack_bytes_into_wires_le(&mut filler, &setup.input, input_data);
+		pack_bytes_into_wires_le(&mut filler, &setup.expected, expected_slice_data);
+		assert!(circuit.populate_wire_witness(&mut filler).is_err());
+	}
 
 	#[test]
 	fn test_aligned_slice() {
-		let b = CircuitBuilder::new();
-
-		// Test case: 16-byte input, 8-byte slice at offset 0
-		let len_input = b.add_inout();
-		let len_slice = b.add_inout();
-		let offset = b.add_inout();
-
-		let input: Vec<Wire> = (0..2).map(|_| b.add_inout()).collect();
-		let slice: Vec<Wire> = (0..1).map(|_| b.add_inout()).collect();
-
-		let verifier = Slice::new(&b, len_input, len_slice, input, slice, offset);
-
-		let circuit = b.build();
-
-		// Test with actual values
-		let mut filler = circuit.new_witness_filler();
-
-		verifier.populate_len_input(&mut filler, 16);
-		verifier.populate_len_slice(&mut filler, 8);
-		verifier.populate_offset(&mut filler, 0);
-
-		// Input: 16 bytes
+		// 16-byte input, 8-byte slice at offset 0
+		let setup = build_slice_check(2, 1);
 		let input_data = [
 			0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d,
 			0x0e, 0x0f,
 		];
-		verifier.populate_input(&mut filler, &input_data);
-
-		// Slice: first 8 bytes of input
 		let slice_data = [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07];
-		verifier.populate_slice(&mut filler, &slice_data);
-
-		// Fill the circuit - this should succeed
-		circuit.populate_wire_witness(&mut filler).unwrap();
-
-		// Verify constraints
-		let cs = circuit.constraint_system();
-		verify_constraints(cs, &filler.into_value_vec()).unwrap();
+		run_slice_success(setup, 16, 8, 0, &input_data, &slice_data);
 	}
 
 	#[test]
 	fn test_unaligned_slice() {
-		let b = CircuitBuilder::new();
-
-		// Test case: 16-byte input, 8-byte slice at offset 3
-
-		let len_input = b.add_inout();
-		let len_slice = b.add_inout();
-		let offset = b.add_inout();
-
-		let input: Vec<Wire> = (0..2).map(|_| b.add_inout()).collect();
-		let slice: Vec<Wire> = (0..1).map(|_| b.add_inout()).collect();
-
-		let verifier = Slice::new(&b, len_input, len_slice, input, slice, offset);
-
-		let circuit = b.build();
-
-		// Test with actual values
-		let mut filler = circuit.new_witness_filler();
-
-		// Set up test data using populate methods
-		verifier.populate_len_input(&mut filler, 16);
-		verifier.populate_len_slice(&mut filler, 8);
-		verifier.populate_offset(&mut filler, 3);
-
-		// Input: 16 bytes
+		// 16-byte input, 8-byte slice at offset 3
+		let setup = build_slice_check(2, 1);
 		let input_data = [
 			0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d,
 			0x0e, 0x0f,
 		];
-		verifier.populate_input(&mut filler, &input_data);
-
-		// Slice at offset 3: bytes 3-10
-		// This should be: 03 04 05 06 07 08 09 0a
 		let slice_data = [0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a];
-		verifier.populate_slice(&mut filler, &slice_data);
-
-		// Fill the circuit - this should succeed
-		circuit.populate_wire_witness(&mut filler).unwrap();
-
-		// Verify constraints
-		let cs = circuit.constraint_system();
-		verify_constraints(cs, &filler.into_value_vec()).unwrap();
+		run_slice_success(setup, 16, 8, 3, &input_data, &slice_data);
 	}
 
 	#[test]
 	fn test_bounds_check() {
-		let b = CircuitBuilder::new();
-
-		let len_input = b.add_inout();
-		let len_slice = b.add_inout();
-		let offset = b.add_inout();
-
-		let input: Vec<Wire> = (0..2).map(|_| b.add_inout()).collect();
-		let slice: Vec<Wire> = (0..1).map(|_| b.add_inout()).collect();
-
-		let verifier = Slice::new(&b, len_input, len_slice, input, slice, offset);
-
-		let circuit = b.build();
-
-		// Test with values that should fail bounds check
-		let mut filler = circuit.new_witness_filler();
-
-		// Set up test data that violates bounds using populate methods
-		verifier.populate_len_input(&mut filler, 10);
-		verifier.populate_len_slice(&mut filler, 8);
-		verifier.populate_offset(&mut filler, 5);
-
-		// Fill dummy data
+		// offset(5) + len_slice(8) > len_input(10) → bounds check fails.
+		let setup = build_slice_check(2, 1);
 		let dummy_input = vec![0u8; 10];
 		let dummy_slice = vec![0u8; 8];
-		verifier.populate_input(&mut filler, &dummy_input);
-		verifier.populate_slice(&mut filler, &dummy_slice);
-
-		// This should fail the bounds check
-		let result = circuit.populate_wire_witness(&mut filler);
-		assert!(result.is_err());
+		run_slice_failure(setup, 10, 8, 5, &dummy_input, &dummy_slice);
 	}
 
 	#[test]
 	fn test_bounds_check_edge_case() {
-		let b = CircuitBuilder::new();
-
-		let len_input = b.add_inout();
-		let len_slice = b.add_inout();
-		let offset = b.add_inout();
-
-		let input: Vec<Wire> = (0..2).map(|_| b.add_inout()).collect();
-		let slice: Vec<Wire> = (0..1).map(|_| b.add_inout()).collect();
-
-		let verifier = Slice::new(&b, len_input, len_slice, input, slice, offset);
-		let circuit = b.build();
-
-		// Test exact boundary: offset + len_slice == len_input (should be valid)
-		let mut filler = circuit.new_witness_filler();
-		verifier.populate_len_input(&mut filler, 10);
-		verifier.populate_len_slice(&mut filler, 5);
-		verifier.populate_offset(&mut filler, 5);
-
-		// Create matching data
+		// Exact boundary: offset(5) + len_slice(5) == len_input(10).
+		let setup = build_slice_check(2, 1);
 		let input_data = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
 		let slice_data = vec![5, 6, 7, 8, 9];
-
-		verifier.populate_input(&mut filler, &input_data);
-		verifier.populate_slice(&mut filler, &slice_data);
-
-		// This should succeed since offset(5) + len_slice(5) == len_input(10)
-		let result = circuit.populate_wire_witness(&mut filler);
-		assert!(result.is_ok(), "Valid boundary case should succeed");
-
-		// Verify constraints
-		let cs = circuit.constraint_system();
-		verify_constraints(cs, &filler.into_value_vec()).unwrap();
+		run_slice_success(setup, 10, 5, 5, &input_data, &slice_data);
 	}
 
 	#[test]
 	fn test_empty_slice() {
-		let b = CircuitBuilder::new();
-
-		let len_input = b.add_inout();
-		let len_slice = b.add_inout();
-		let offset = b.add_inout();
-
-		let input: Vec<Wire> = (0..2).map(|_| b.add_inout()).collect();
-		let slice: Vec<Wire> = (0..1).map(|_| b.add_inout()).collect();
-
-		let verifier = Slice::new(&b, len_input, len_slice, input, slice, offset);
-		let circuit = b.build();
-
-		// Test with len_slice = 0
-		let mut filler = circuit.new_witness_filler();
-		verifier.populate_len_input(&mut filler, 10);
-		verifier.populate_len_slice(&mut filler, 0);
-		verifier.populate_offset(&mut filler, 5);
-
+		// len_slice = 0 — output is all zeros.
+		let setup = build_slice_check(2, 1);
 		let input_data = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
-		verifier.populate_input(&mut filler, &input_data);
-		verifier.populate_slice(&mut filler, &[]);
-
-		// Empty slice should be valid
-		let result = circuit.populate_wire_witness(&mut filler);
-		assert!(result.is_ok(), "Empty slice should be valid");
-
-		// Verify constraints
-		let cs = circuit.constraint_system();
-		verify_constraints(cs, &filler.into_value_vec()).unwrap();
+		run_slice_success(setup, 10, 0, 5, &input_data, &[]);
 	}
 
 	#[test]
 	fn test_mismatched_slice_content() {
-		let b = CircuitBuilder::new();
-
-		let len_input = b.add_inout();
-		let len_slice = b.add_inout();
-		let offset = b.add_inout();
-
-		let input: Vec<Wire> = (0..2).map(|_| b.add_inout()).collect();
-		let slice: Vec<Wire> = (0..1).map(|_| b.add_inout()).collect();
-
-		let verifier = Slice::new(&b, len_input, len_slice, input, slice, offset);
-		let circuit = b.build();
-
-		// Test with wrong slice content
-		let mut filler = circuit.new_witness_filler();
-		verifier.populate_len_input(&mut filler, 10);
-		verifier.populate_len_slice(&mut filler, 5);
-		verifier.populate_offset(&mut filler, 2);
-
+		// Caller's expected slice differs from the actual extracted bytes — the external
+		// `assert_eq` in `build_slice_check` should fail.
+		let setup = build_slice_check(2, 1);
 		let input_data = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
-		// Wrong slice data - should be [2, 3, 4, 5, 6] but we provide [0, 1, 2, 3, 4]
+		// Actual extracted slice at offset 2 with len 5 is [2,3,4,5,6]; we claim [0,1,2,3,4].
 		let wrong_slice_data = vec![0, 1, 2, 3, 4];
-
-		verifier.populate_input(&mut filler, &input_data);
-		verifier.populate_slice(&mut filler, &wrong_slice_data);
-
-		// This should fail
-		let result = circuit.populate_wire_witness(&mut filler);
-		assert!(result.is_err(), "Mismatched slice content should fail");
+		run_slice_failure(setup, 10, 5, 2, &input_data, &wrong_slice_data);
 	}
 
 	#[test]
 	fn test_offset_at_end() {
-		let b = CircuitBuilder::new();
-
-		let len_input = b.add_inout();
-		let len_slice = b.add_inout();
-		let offset = b.add_inout();
-
-		let input: Vec<Wire> = (0..2).map(|_| b.add_inout()).collect();
-		let slice: Vec<Wire> = (0..1).map(|_| b.add_inout()).collect();
-
-		let verifier = Slice::new(&b, len_input, len_slice, input, slice, offset);
-		let circuit = b.build();
-
-		// Test offset at end with empty slice
-		let mut filler = circuit.new_witness_filler();
-		verifier.populate_len_input(&mut filler, 10);
-		verifier.populate_len_slice(&mut filler, 0);
-		verifier.populate_offset(&mut filler, 10);
-
+		// Empty slice at offset 10, where len_input = 10.
+		let setup = build_slice_check(2, 1);
 		let input_data = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
-		verifier.populate_input(&mut filler, &input_data);
-		verifier.populate_slice(&mut filler, &[]);
-
-		// This should succeed - empty slice at end
-		let result = circuit.populate_wire_witness(&mut filler);
-		assert!(result.is_ok(), "Empty slice at end should be valid");
-
-		// Verify constraints
-		let cs = circuit.constraint_system();
-		verify_constraints(cs, &filler.into_value_vec()).unwrap();
+		run_slice_success(setup, 10, 0, 10, &input_data, &[]);
 	}
 
 	#[test]
 	fn test_multiple_byte_extraction_paths() {
-		// This test verifies that byte extraction works correctly for all paths
-		let b = CircuitBuilder::new();
-
-		let len_input = b.add_inout();
-		let len_slice = b.add_inout();
-		let offset = b.add_inout();
-
-		let input: Vec<Wire> = (0..3).map(|_| b.add_inout()).collect();
-		let slice: Vec<Wire> = (0..1).map(|_| b.add_inout()).collect();
-
-		let verifier = Slice::new(&b, len_input, len_slice, input, slice, offset);
-		let circuit = b.build();
-
-		// Test extraction from each word with different offsets
+		// Verify byte extraction works for a range of offsets in a fresh circuit each time.
+		// (The expected slice differs per case so we can't reuse one circuit.)
 		for word_idx in 0..3 {
 			for byte_offset in 0..8 {
 				let offset_val = word_idx * 8 + byte_offset;
 				if offset_val + 8 > 24 {
 					continue;
 				}
-
-				let mut filler = circuit.new_witness_filler();
-				verifier.populate_len_input(&mut filler, 24);
-				verifier.populate_len_slice(&mut filler, 8);
-				verifier.populate_offset(&mut filler, offset_val);
-
-				// Create distinct pattern for each byte
+				let setup = build_slice_check(3, 1);
 				let input_data: Vec<u8> = (0..24).map(|i| i as u8).collect();
 				let slice_data: Vec<u8> = input_data[offset_val..offset_val + 8].to_vec();
-
-				verifier.populate_input(&mut filler, &input_data);
-				verifier.populate_slice(&mut filler, &slice_data);
-
-				let result = circuit.populate_wire_witness(&mut filler);
-				assert!(
-					result.is_ok(),
-					"Extraction from word {word_idx} byte {byte_offset} failed"
-				);
-
-				// Verify constraints
-				let cs = circuit.constraint_system();
-				verify_constraints(cs, &filler.into_value_vec()).unwrap();
+				run_slice_success(setup, 24, 8, offset_val as u64, &input_data, &slice_data);
 			}
 		}
 	}
 
 	#[test]
-	fn test_full_word_assert_vulnerability_fixed() {
-		let b = CircuitBuilder::new();
-
-		// Set up circuit with specific sizes
-		// max_n_slice = 16 (2 words) but we'll use len_slice = 12 (1.5 words)
-		let len_input = b.add_inout();
-		let len_slice = b.add_inout();
-		let offset = b.add_inout();
-
-		let input: Vec<Wire> = (0..3).map(|_| b.add_inout()).collect();
-		let slice: Vec<Wire> = (0..2).map(|_| b.add_inout()).collect();
-
-		let verifier = Slice::new(&b, len_input, len_slice, input.clone(), slice.clone(), offset);
-		let circuit = b.build();
-
-		// Test case: len_slice = 12 bytes (1.5 words)
-		// This test verifies that the fix correctly validates partial words
-		let mut filler = circuit.new_witness_filler();
-
-		verifier.populate_len_input(&mut filler, 20);
-		verifier.populate_len_slice(&mut filler, 12); // 1.5 words
-		verifier.populate_offset(&mut filler, 0);
-
-		// Input data
+	fn test_partial_word_zero_padding() {
+		// `slice` returns words zero-padded past `len_slice`. For len_slice=12 (1.5 words), the
+		// upper 4 bytes of word 1 must be zero — and the assert_eq will catch any drift.
+		let setup = build_slice_check(3, 2);
 		let input_data = vec![
 			0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, // word 0
 			0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, // word 1
 			0x10, 0x11, 0x12, 0x13, // partial word 2
 		];
-		verifier.populate_input(&mut filler, &input_data);
-
-		// Try to provide malicious slice data:
-		// First word: correct
-		// Second word: only first 4 bytes need to be correct, last 4 are garbage
-		// Directly set the slice words to bypass populate_slice
-		filler[slice[0]] = Word(0x0706050403020100); // Correct first word
-		filler[slice[1]] = Word(0xffffffff0b0a0908); // Wrong last 4 bytes!
-
-		// This should now fail with the fix
-		let result = circuit.populate_wire_witness(&mut filler);
-		assert!(result.is_err(), "Fixed circuit should reject invalid slice data");
-
-		// Now test with correct data to ensure the fix doesn't break valid cases
-		let mut filler2 = circuit.new_witness_filler();
-		verifier.populate_len_input(&mut filler2, 20);
-		verifier.populate_len_slice(&mut filler2, 12);
-		verifier.populate_offset(&mut filler2, 0);
-		verifier.populate_input(&mut filler2, &input_data);
-
-		// Correct slice data
+		// Expected slice: 12 valid bytes, word-1 high half zero-padded.
 		let correct_slice = [
 			0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, // word 0
-			0x08, 0x09, 0x0a, 0x0b, 0x00, 0x00, 0x00, 0x00, // word 1 (padded correctly)
+			0x08, 0x09, 0x0a, 0x0b, 0x00, 0x00, 0x00, 0x00, // word 1 padded to 16 bytes
 		];
-		verifier.populate_slice(&mut filler2, &correct_slice[..12]); // Only 12 bytes
-
-		// This should succeed
-		let result2 = circuit.populate_wire_witness(&mut filler2);
-		assert!(result2.is_ok(), "Fixed circuit should accept valid slice data");
-
-		// Verify constraints
-		let cs = circuit.constraint_system();
-		verify_constraints(cs, &filler2.into_value_vec()).unwrap();
+		run_slice_success(setup, 20, 12, 0, &input_data, &correct_slice);
 	}
 
 	#[test]
-	fn test_simple_partial_word() {
-		// Simplest test case: 1 word slice with only 4 valid bytes
-		let b = CircuitBuilder::new();
-
-		let len_input = b.add_inout();
-		let len_slice = b.add_inout();
-		let offset = b.add_inout();
-
-		let input: Vec<Wire> = (0..1).map(|_| b.add_inout()).collect();
-		let slice: Vec<Wire> = (0..1).map(|_| b.add_inout()).collect();
-
-		let verifier = Slice::new(&b, len_input, len_slice, input.clone(), slice.clone(), offset);
-		let circuit = b.build();
-
-		// Test with 4 bytes
+	fn test_partial_word_rejects_garbage_padding() {
+		// If the caller's expected slice has nonzero bytes past len_slice, the assert_eq
+		// against the (zero-padded) returned wires must fail.
+		let setup = build_slice_check(3, 2);
+		let input_data = vec![
+			0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d,
+			0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13,
+		];
+		let circuit = setup.builder.build();
 		let mut filler = circuit.new_witness_filler();
-		verifier.populate_len_input(&mut filler, 8);
-		verifier.populate_len_slice(&mut filler, 4); // Only 4 bytes
-		verifier.populate_offset(&mut filler, 0);
-
-		// Input: full 8 bytes
-		filler[input[0]] = Word(0x0706050403020100);
-
-		// Slice with wrong data in upper 4 bytes
-		// The slice should contain bytes 0x00, 0x01, 0x02, 0x03 from input
-		filler[slice[0]] = Word(0xffffffff03020100); // Correct lower 4 bytes, wrong upper 4
-
-		let result = circuit.populate_wire_witness(&mut filler);
-		assert!(result.is_err(), "Should reject slice with wrong upper bytes");
-
-		// Now test with correct data
-		let mut filler2 = circuit.new_witness_filler();
-		verifier.populate_len_input(&mut filler2, 8);
-		verifier.populate_len_slice(&mut filler2, 4);
-		verifier.populate_offset(&mut filler2, 0);
-
-		filler2[input[0]] = Word(0x0706050403020100);
-		filler2[slice[0]] = Word(0x0000000003020100); // Correct: upper 4 bytes are 0
-
-		let result2 = circuit.populate_wire_witness(&mut filler2);
-		assert!(result2.is_ok(), "Should accept correct partial word: {result2:?}");
-
-		// Additional test: verify constraints
-		let cs = circuit.constraint_system();
-		verify_constraints(cs, &filler2.into_value_vec()).unwrap();
-
-		// Test 3: Verify populate_slice handles this correctly
-		let mut filler3 = circuit.new_witness_filler();
-		verifier.populate_len_input(&mut filler3, 8);
-		verifier.populate_len_slice(&mut filler3, 4);
-		verifier.populate_offset(&mut filler3, 0);
-
-		let input_bytes = vec![0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07];
-		let slice_bytes = vec![0x00, 0x01, 0x02, 0x03]; // Only 4 bytes
-
-		verifier.populate_input(&mut filler3, &input_bytes);
-		verifier.populate_slice(&mut filler3, &slice_bytes);
-
-		let result3 = circuit.populate_wire_witness(&mut filler3);
-		assert!(result3.is_ok(), "populate_slice should handle partial words correctly");
-
-		// Test 4: Now manually set wrong upper bytes and it should fail
-		let mut filler4 = circuit.new_witness_filler();
-		verifier.populate_len_input(&mut filler4, 8);
-		verifier.populate_len_slice(&mut filler4, 4);
-		verifier.populate_offset(&mut filler4, 0);
-		verifier.populate_input(&mut filler4, &input_bytes);
-		verifier.populate_slice(&mut filler4, &slice_bytes);
-
-		// Corrupt the upper bytes
-		filler4[slice[0]] = Word(filler4[slice[0]].0 | 0xffffffff00000000);
-
-		let result4 = circuit.populate_wire_witness(&mut filler4);
-		assert!(result4.is_err(), "Should reject corrupted upper bytes");
-	}
-
-	#[test]
-	fn test_direct_masking_logic() {
-		// Test the masking logic directly
-		let slice_word = Word(0xffffffff_0b0a0908); // Wrong upper 4 bytes
-		let extracted_word = Word(0x00000000_0b0a0908); // Correct upper 4 bytes
-		let mask = Word(0x00000000_ffffffff); // Mask for 4 valid bytes
-
-		let masked_slice = slice_word & mask;
-		let masked_extracted = extracted_word & mask;
-
-		assert_eq!(
-			masked_slice, masked_extracted,
-			"Masked values should be equal: slice=0x{:016x}, extracted=0x{:016x}",
-			masked_slice.0, masked_extracted.0
-		);
-
-		// This is what the constraint checks
-		let xor_result = masked_slice ^ masked_extracted;
-		assert_eq!(xor_result, Word::ZERO, "XOR of masked values should be zero");
+		filler[setup.len_input] = Word(20);
+		filler[setup.len_slice] = Word(12);
+		filler[setup.offset] = Word(0);
+		pack_bytes_into_wires_le(&mut filler, &setup.input, &input_data);
+		// Word 0 correct, word 1 has garbage 0xffffffff in the upper half (past len_slice).
+		filler[setup.expected[0]] = Word(0x0706050403020100);
+		filler[setup.expected[1]] = Word(0xffffffff0b0a0908);
+		assert!(circuit.populate_wire_witness(&mut filler).is_err());
 	}
 
 	#[test]
 	fn test_large_offset_overflow() {
-		let b = CircuitBuilder::new();
-
-		let len_input = b.add_inout();
-		let len_slice = b.add_inout();
-		let offset = b.add_inout();
-
-		let input: Vec<Wire> = (0..2).map(|_| b.add_inout()).collect();
-		let slice: Vec<Wire> = (0..1).map(|_| b.add_inout()).collect();
-
-		let verifier = Slice::new(&b, len_input, len_slice, input.clone(), slice.clone(), offset);
-		let circuit = b.build();
-
-		// Test with very large offset that should fail 32-bit check
+		// offset has bit 32 set → 32-bit assertion fails.
+		let setup = build_slice_check(2, 1);
+		let circuit = setup.builder.build();
 		let mut filler = circuit.new_witness_filler();
-		verifier.populate_len_input(&mut filler, 10);
-		verifier.populate_len_slice(&mut filler, 5);
-
-		// Try to set offset with upper 32 bits set
-		// This tests that the circuit properly validates 32-bit constraints
-		filler[offset] = Word(1u64 << 32); // Direct assignment to test constraint
-
-		let input_data = vec![0u8; 10];
-		let slice_data = vec![0u8; 5];
-		verifier.populate_input(&mut filler, &input_data);
-		verifier.populate_slice(&mut filler, &slice_data);
-
-		// This should fail the 32-bit check
-		let result = circuit.populate_wire_witness(&mut filler);
-		assert!(result.is_err(), "Large offset should fail 32-bit check");
+		filler[setup.len_input] = Word(10);
+		filler[setup.len_slice] = Word(5);
+		filler[setup.offset] = Word(1u64 << 32);
+		pack_bytes_into_wires_le(&mut filler, &setup.input, &[0u8; 10]);
+		pack_bytes_into_wires_le(&mut filler, &setup.expected, &[0u8; 5]);
+		assert!(circuit.populate_wire_witness(&mut filler).is_err());
 	}
 
 	#[test]
 	fn test_32bit_validation() {
-		let b = CircuitBuilder::new();
-
-		let len_input = b.add_inout();
-		let len_slice = b.add_inout();
-		let offset = b.add_inout();
-
-		let input: Vec<Wire> = (0..2).map(|_| b.add_inout()).collect();
-		let slice: Vec<Wire> = (0..1).map(|_| b.add_inout()).collect();
-
-		let verifier = Slice::new(&b, len_input, len_slice, input.clone(), slice.clone(), offset);
-		let circuit = b.build();
-
-		// Test multiple 32-bit constraint violations
-		// Test 1: offset with bit 33 set
+		// offset with bit 33 set
+		let setup = build_slice_check(2, 1);
+		let circuit = setup.builder.build();
 		let mut filler = circuit.new_witness_filler();
-		verifier.populate_len_input(&mut filler, 10);
-		verifier.populate_len_slice(&mut filler, 5);
-		filler[offset] = Word(1u64 << 33);
+		filler[setup.len_input] = Word(10);
+		filler[setup.len_slice] = Word(5);
+		filler[setup.offset] = Word(1u64 << 33);
+		pack_bytes_into_wires_le(&mut filler, &setup.input, &[0u8; 10]);
+		pack_bytes_into_wires_le(&mut filler, &setup.expected, &[0u8; 5]);
+		assert!(circuit.populate_wire_witness(&mut filler).is_err());
 
-		let input_data = vec![0u8; 10];
-		let slice_data = vec![0u8; 5];
-		verifier.populate_input(&mut filler, &input_data);
-		verifier.populate_slice(&mut filler, &slice_data);
-
-		let result = circuit.populate_wire_witness(&mut filler);
-		assert!(result.is_err(), "Offset with bit 33 set should fail");
-
-		// Test 2: len_input with upper bits set
+		// len_input with upper 32 bits set
+		let setup = build_slice_check(2, 1);
+		let circuit = setup.builder.build();
 		let mut filler = circuit.new_witness_filler();
-		filler[len_input] = Word(0xffffffff00000010); // Upper 32 bits set
-		verifier.populate_len_slice(&mut filler, 5);
-		verifier.populate_offset(&mut filler, 0);
-		verifier.populate_input(&mut filler, &input_data);
-		verifier.populate_slice(&mut filler, &slice_data);
+		filler[setup.len_input] = Word(0xffffffff00000010);
+		filler[setup.len_slice] = Word(5);
+		filler[setup.offset] = Word(0);
+		pack_bytes_into_wires_le(&mut filler, &setup.input, &[0u8; 10]);
+		pack_bytes_into_wires_le(&mut filler, &setup.expected, &[0u8; 5]);
+		assert!(circuit.populate_wire_witness(&mut filler).is_err());
 
-		let result = circuit.populate_wire_witness(&mut filler);
-		assert!(result.is_err(), "len_input with upper 32 bits set should fail");
-
-		// Test 3: len_slice with upper bits set
+		// len_slice with bit 32 set
+		let setup = build_slice_check(2, 1);
+		let circuit = setup.builder.build();
 		let mut filler = circuit.new_witness_filler();
-		verifier.populate_len_input(&mut filler, 10);
-		filler[len_slice] = Word(0x100000005); // Bit 32 set
-		verifier.populate_offset(&mut filler, 0);
-		verifier.populate_input(&mut filler, &input_data);
-		verifier.populate_slice(&mut filler, &slice_data);
-
-		let result = circuit.populate_wire_witness(&mut filler);
-		assert!(result.is_err(), "len_slice with upper bits set should fail");
+		filler[setup.len_input] = Word(10);
+		filler[setup.len_slice] = Word(0x100000005);
+		filler[setup.offset] = Word(0);
+		pack_bytes_into_wires_le(&mut filler, &setup.input, &[0u8; 10]);
+		pack_bytes_into_wires_le(&mut filler, &setup.expected, &[0u8; 5]);
+		assert!(circuit.populate_wire_witness(&mut filler).is_err());
 	}
 
 	#[test]
 	fn test_edge_case_len_input_zero() {
-		let b = CircuitBuilder::new();
-
-		let len_input = b.add_inout();
-		let len_slice = b.add_inout();
-		let offset = b.add_inout();
-
-		let input: Vec<Wire> = (0..2).map(|_| b.add_inout()).collect();
-		let slice: Vec<Wire> = (0..1).map(|_| b.add_inout()).collect();
-
-		let verifier = Slice::new(&b, len_input, len_slice, input.clone(), slice.clone(), offset);
-		let circuit = b.build();
-
-		// Test empty input with empty slice at offset 0
-		let mut filler = circuit.new_witness_filler();
-		verifier.populate_len_input(&mut filler, 0);
-		verifier.populate_len_slice(&mut filler, 0);
-		verifier.populate_offset(&mut filler, 0);
-
-		// Empty arrays
-		verifier.populate_input(&mut filler, &[]);
-		verifier.populate_slice(&mut filler, &[]);
-
-		// This should succeed - empty input with empty slice at offset 0
-		let result = circuit.populate_wire_witness(&mut filler);
-		assert!(result.is_ok(), "Empty input with empty slice should succeed");
-
-		// Verify constraints
-		let cs = circuit.constraint_system();
-		verify_constraints(cs, &filler.into_value_vec()).unwrap();
+		// Empty input + empty slice at offset 0.
+		let setup = build_slice_check(2, 1);
+		run_slice_success(setup, 0, 0, 0, &[], &[]);
 	}
 
 	#[test]
 	fn test_edge_case_len_input_zero_with_nonzero_slice() {
-		let b = CircuitBuilder::new();
-
-		let len_input = b.add_inout();
-		let len_slice = b.add_inout();
-		let offset = b.add_inout();
-
-		let input: Vec<Wire> = (0..2).map(|_| b.add_inout()).collect();
-		let slice: Vec<Wire> = (0..1).map(|_| b.add_inout()).collect();
-
-		let verifier = Slice::new(&b, len_input, len_slice, input.clone(), slice.clone(), offset);
-		let circuit = b.build();
-
-		// Test empty input with non-empty slice
-		let mut filler = circuit.new_witness_filler();
-		verifier.populate_len_input(&mut filler, 0);
-		verifier.populate_len_slice(&mut filler, 5);
-		verifier.populate_offset(&mut filler, 0);
-
-		verifier.populate_input(&mut filler, &[]);
-		verifier.populate_slice(&mut filler, &[1, 2, 3, 4, 5]);
-
-		// This should fail - can't extract non-empty slice from empty input
-		let result = circuit.populate_wire_witness(&mut filler);
-		assert!(result.is_err(), "Non-empty slice from empty input should fail");
+		// Empty input + non-empty slice → bounds check fails.
+		let setup = build_slice_check(2, 1);
+		run_slice_failure(setup, 0, 5, 0, &[], &[1, 2, 3, 4, 5]);
 	}
 
 	#[test]
 	fn test_padding_beyond_actual_data() {
-		let b = CircuitBuilder::new();
-
-		let len_input = b.add_inout();
-		let len_slice = b.add_inout();
-		let offset = b.add_inout();
-
-		let input: Vec<Wire> = (0..3).map(|_| b.add_inout()).collect();
-		let slice: Vec<Wire> = (0..2).map(|_| b.add_inout()).collect();
-
-		// Save wire references before moving vectors
-		let input_wire_2 = input[2];
-		let slice_wire_1 = slice[1];
-
-		let verifier = Slice::new(&b, len_input, len_slice, input, slice, offset);
-		let circuit = b.build();
-
-		// Test with actual data smaller than allocated space
-		let mut filler = circuit.new_witness_filler();
-		verifier.populate_len_input(&mut filler, 12); // 1.5 words
-		verifier.populate_len_slice(&mut filler, 8); // 1 word
-		verifier.populate_offset(&mut filler, 2);
-
-		// Input: 12 bytes (will be padded to 3 words)
+		// 12 bytes of input data padded into 3 input words; 8-byte slice at offset 2.
+		let setup = build_slice_check(3, 2);
 		let input_data = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
-		verifier.populate_input(&mut filler, &input_data);
-
-		// Slice at offset 2: bytes 2-9
+		// Slice is 8 bytes, so word 1 is fully zero-padded.
 		let slice_data = vec![2, 3, 4, 5, 6, 7, 8, 9];
-		verifier.populate_slice(&mut filler, &slice_data);
+		run_slice_success(setup, 12, 8, 2, &input_data, &slice_data);
+	}
 
-		// Verify the circuit handles padding correctly
-		let result = circuit.populate_wire_witness(&mut filler);
-		assert!(result.is_ok(), "Should handle data with padding correctly");
+	#[test]
+	fn test_direct_masking_logic() {
+		// Test the masking logic directly (Rust-side, no circuit).
+		let slice_word = Word(0xffffffff_0b0a0908);
+		let extracted_word = Word(0x00000000_0b0a0908);
+		let mask = Word(0x00000000_ffffffff);
 
-		// Also verify that padded words in input are zeroed
-		assert_eq!(filler[input_wire_2], Word::ZERO, "Third input word should be zero");
-		// Second slice word should also be zero since slice is only 1 word
-		assert_eq!(filler[slice_wire_1], Word::ZERO, "Second slice word should be zero");
+		let masked_slice = slice_word & mask;
+		let masked_extracted = extracted_word & mask;
 
-		// Verify constraints
-		let cs = circuit.constraint_system();
-		verify_constraints(cs, &filler.into_value_vec()).unwrap();
+		assert_eq!(masked_slice, masked_extracted);
+		assert_eq!(masked_slice ^ masked_extracted, Word::ZERO);
 	}
 }

--- a/crates/circuits/tests/gate_fusion_keccak.rs
+++ b/crates/circuits/tests/gate_fusion_keccak.rs
@@ -1,5 +1,5 @@
 // Copyright 2025 Irreducible Inc.
-use binius_circuits::keccak::permutation::Permutation;
+use binius_circuits::keccak::permutation::{keccak_f1600, keccak_permutation_round};
 use binius_frontend::{CircuitBuilder, Wire};
 
 #[test]
@@ -8,7 +8,7 @@ fn keccak() {
 	let initial_state: [Wire; 25] = std::array::from_fn(|_| builder.add_inout());
 	let expected_final_state: [Wire; 25] = std::array::from_fn(|_| builder.add_inout());
 	let mut computed_state = initial_state;
-	Permutation::keccak_f1600(&builder, &mut computed_state);
+	keccak_f1600(&builder, &mut computed_state);
 	builder.assert_eq_v("final_state", computed_state, expected_final_state);
 	let _ = builder.build();
 }
@@ -22,7 +22,7 @@ fn keccak_single_round() {
 	let mut computed_state = initial_state;
 
 	// Run just one round of Keccak
-	Permutation::keccak_permutation_round(&builder, &mut computed_state, 0);
+	keccak_permutation_round(&builder, &mut computed_state, 0);
 
 	builder.assert_eq_v("final_state", computed_state, expected_final_state);
 	let _ = builder.build();
@@ -37,14 +37,14 @@ fn keccak_two_rounds() {
 	let mut computed_state = initial_state;
 
 	// Run exactly 2 rounds of Keccak
-	Permutation::keccak_permutation_round(&builder, &mut computed_state, 0);
+	keccak_permutation_round(&builder, &mut computed_state, 0);
 	eprintln!("\n=== Round 1 output state (these become inputs to round 2) ===");
 	for (i, &wire) in computed_state.iter().enumerate() {
 		if i < 5 {
 			eprintln!("  computed_state[{}] = {:?}", i, wire);
 		}
 	}
-	Permutation::keccak_permutation_round(&builder, &mut computed_state, 1);
+	keccak_permutation_round(&builder, &mut computed_state, 1);
 
 	builder.assert_eq_v("final_state", computed_state, expected_final_state);
 	let _ = builder.build();

--- a/crates/examples/src/circuits/zklogin.rs
+++ b/crates/examples/src/circuits/zklogin.rs
@@ -3,11 +3,12 @@ use anyhow::{Result, ensure};
 use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD as BASE64_URL_SAFE_NO_PAD};
 use binius_circuits::{
 	base64::Base64UrlSafe,
-	concat::Concat,
+	concat::concat,
 	fixed_byte_vec::ByteVec,
 	jwt_claims::{Attribute, JwtClaims},
 	rs256::Rs256Verify,
 	sha256::Sha256 as Sha256Circuit,
+	slice::create_byte_mask,
 };
 use binius_core::Word;
 use binius_frontend::{CircuitBuilder, Wire, WitnessFiller, util::pack_bytes_into_wires_le};
@@ -192,12 +193,11 @@ impl ZkLogin {
 		let zkaddr_joined_words = max_len_zkaddr_preimage;
 		let zkaddr_joined_le = zkaddr_preimage_le_wires[..zkaddr_joined_words].to_vec();
 
-		// Create the concatenation that outputs to the LE wires
-		let _zkaddr_preimage_concat = Concat::new(
-			&b.subcircuit("zkaddr_preimage_concat"),
-			zkaddr_preimage_len_bytes,
-			zkaddr_joined_le,
-			vec![
+		// Compute the concatenation and assert it equals the SHA-256 message LE wires.
+		let zkaddr_concat_b = b.subcircuit("zkaddr_preimage_concat");
+		let zkaddr_concat = concat(
+			&zkaddr_concat_b,
+			&[
 				ByteVec {
 					data: sub.data.clone(),
 					len_bytes: sub.len_bytes,
@@ -215,7 +215,10 @@ impl ZkLogin {
 					len_bytes: salt.len_bytes,
 				},
 			],
+			Some(zkaddr_joined_le.len()),
 		);
+		zkaddr_concat_b.assert_eq("len", zkaddr_concat.len_bytes, zkaddr_preimage_len_bytes);
+		assert_sha256_message_eq_concat(&zkaddr_concat_b, &zkaddr_concat, &zkaddr_joined_le);
 
 		// We need to check:
 		//
@@ -239,14 +242,13 @@ impl ZkLogin {
 		let nonce_preimage_le_wires = nonce_sha256.message_to_le_wires(b);
 		let nonce_joined_words = max_len_nonce_preimage;
 		let nonce_joined_le = nonce_preimage_le_wires[..nonce_joined_words].to_vec();
-		let _nonce_preimage_concat = Concat::new(
-			&b.subcircuit("nonce_preimage_concat"),
-			nonce_preimage_len_bytes,
-			nonce_joined_le,
-			vec![
+		let nonce_concat_b = b.subcircuit("nonce_preimage_concat");
+		let nonce_concat = concat(
+			&nonce_concat_b,
+			&[
 				ByteVec {
 					data: vk_u.to_vec(),
-					len_bytes: b.add_constant_64(32),
+					len_bytes: nonce_concat_b.add_constant_64(32),
 				},
 				ByteVec {
 					data: t_max.data.clone(),
@@ -257,7 +259,10 @@ impl ZkLogin {
 					len_bytes: nonce_r.len_bytes,
 				},
 			],
+			Some(nonce_joined_le.len()),
 		);
+		nonce_concat_b.assert_eq("len", nonce_concat.len_bytes, nonce_preimage_len_bytes);
+		assert_sha256_message_eq_concat(&nonce_concat_b, &nonce_concat, &nonce_joined_le);
 
 		let nonce_le = nonce_sha256.digest_to_le_wires(b);
 
@@ -304,24 +309,30 @@ impl ZkLogin {
 		let jwt_signing_payload_le_wires = jwt_signature_verify.sha256.message_to_le_wires(b);
 		let signing_joined_words = max_len_jwt_signing_payload;
 		let signing_joined_le = jwt_signing_payload_le_wires[..signing_joined_words].to_vec();
-		let _jwt_signing_payload_concat = Concat::new(
-			&b.subcircuit("jwt_signing_payload_concat"),
-			jwt_signing_payload_sha256_len,
-			signing_joined_le,
-			vec![
+		let signing_concat_b = b.subcircuit("jwt_signing_payload_concat");
+		let signing_concat = concat(
+			&signing_concat_b,
+			&[
 				ByteVec {
 					data: base64_jwt_header.data.clone(),
 					len_bytes: base64_jwt_header.len_bytes,
 				},
 				ByteVec {
-					data: vec![b.add_constant_zx_8(b'.')],
-					len_bytes: b.add_constant_64(1),
+					data: vec![signing_concat_b.add_constant_zx_8(b'.')],
+					len_bytes: signing_concat_b.add_constant_64(1),
 				},
 				ByteVec {
 					data: base64_jwt_payload.data.clone(),
 					len_bytes: base64_jwt_payload.len_bytes,
 				},
 			],
+			Some(signing_joined_le.len()),
+		);
+		signing_concat_b.assert_eq("len", signing_concat.len_bytes, jwt_signing_payload_sha256_len);
+		assert_sha256_message_eq_concat(
+			&signing_concat_b,
+			&signing_concat,
+			&signing_joined_le,
 		);
 
 		let jwt_claims_header = jwt_header_check(b, &jwt_header);
@@ -443,6 +454,37 @@ impl ZkLogin {
 		let mut padded = vec![0u8; 48];
 		padded[..base64_nonce.len()].copy_from_slice(&base64_nonce[..base64_nonce.len()]);
 		pack_bytes_into_wires_le(w, &self.base64_jwt_payload_nonce, &padded);
+	}
+}
+
+/// Asserts that `expected.data[i] == joined_le[i]` for the bytes within `expected.len_bytes`
+/// (ignoring trailing bytes past the length).
+///
+/// This is needed because the SHA-256 message wires past `len_bytes` carry padding bytes
+/// (`0x80` delimiter plus the bit-length field), which differ from the zero-padded trailing
+/// bytes of the [`concat`] gadget's output. We mask both sides to the valid byte range and
+/// only assert there.
+fn assert_sha256_message_eq_concat(
+	b: &CircuitBuilder,
+	concat_result: &ByteVec,
+	joined_le: &[Wire],
+) {
+	assert_eq!(concat_result.data.len(), joined_le.len());
+	for (i, (&a, &e)) in concat_result.data.iter().zip(joined_le).enumerate() {
+		let word_byte_offset = i << 3;
+		let is_valid_word = b.icmp_ult(
+			b.add_constant(Word(word_byte_offset as u64)),
+			concat_result.len_bytes,
+		);
+		let neg_start = b.add_constant(Word((-(word_byte_offset as i64)) as u64));
+		let (bytes_remaining, _) = b.iadd(concat_result.len_bytes, neg_start);
+		let mask = create_byte_mask(b, bytes_remaining);
+		b.assert_eq_cond(
+			format!("data[{i}]"),
+			b.band(a, mask),
+			b.band(e, mask),
+			is_valid_word,
+		);
 	}
 }
 

--- a/crates/examples/src/circuits/zklogin.rs
+++ b/crates/examples/src/circuits/zklogin.rs
@@ -5,7 +5,7 @@ use binius_circuits::{
 	base64::Base64UrlSafe,
 	concat::concat,
 	fixed_byte_vec::ByteVec,
-	jwt_claims::{Attribute, JwtClaims},
+	jwt_claims::jwt_claims,
 	rs256::Rs256Verify,
 	sha256::Sha256 as Sha256Circuit,
 	slice::create_byte_mask,
@@ -83,10 +83,9 @@ pub struct ZkLogin {
 	pub zkaddr: [Wire; 4],
 	/// The SHA256 circuit for zkaddr verification
 	pub zkaddr_sha256: Sha256Circuit,
-	/// The subcircuit that verifies the JWT header.
-	pub jwt_claims_header: JwtClaims,
-	/// The subcircuit that verifies the JWT in the payload.
-	pub jwt_claims_payload: JwtClaims,
+	/// Inout-allocated `(alg, typ)` ByteVecs whose `len_bytes` wires are filled by
+	/// [`Self::populate_jwt_header_attributes`].
+	pub jwt_header_attrs: [ByteVec; 2],
 	/// The subcircuit that verifies the RS256 signature in the JWT.
 	pub jwt_signature_verify: Rs256Verify,
 	/// The JWT header
@@ -335,9 +334,8 @@ impl ZkLogin {
 			&signing_joined_le,
 		);
 
-		let jwt_claims_header = jwt_header_check(b, &jwt_header);
-		let jwt_claims_payload =
-			jwt_payload_check(b, &jwt_payload, &sub, &aud, &iss, &base64_jwt_payload_nonce);
+		let jwt_header_attrs = jwt_header_check(b, &jwt_header);
+		jwt_payload_check(b, &jwt_payload, &sub, &aud, &iss, &base64_jwt_payload_nonce);
 
 		Self {
 			sub,
@@ -346,8 +344,7 @@ impl ZkLogin {
 			salt,
 			zkaddr,
 			zkaddr_sha256,
-			jwt_claims_header,
-			jwt_claims_payload,
+			jwt_header_attrs,
 			jwt_signature_verify,
 			base64_jwt_header,
 			base64_jwt_payload,
@@ -423,8 +420,8 @@ impl ZkLogin {
 
 	pub fn populate_jwt_header_attributes(&self, w: &mut WitnessFiller) {
 		// Populate the expected lengths for "alg" and "typ" attributes
-		self.jwt_claims_header.attributes[0].populate_len_bytes(w, 5); // "RS256" is 5 bytes
-		self.jwt_claims_header.attributes[1].populate_len_bytes(w, 3); // "JWT" is 3 bytes
+		self.jwt_header_attrs[0].populate_len_bytes(w, 5); // "RS256" is 5 bytes
+		self.jwt_header_attrs[1].populate_len_bytes(w, 3); // "JWT" is 3 bytes
 	}
 
 	pub fn populate_nonce(&self, w: &mut WitnessFiller, nonce_hash: &[u8; 32]) {
@@ -490,24 +487,25 @@ fn assert_sha256_message_eq_concat(
 
 /// A check that verifies that JWT header has the expected constant values in the `alg` and `typ`
 /// fields.
-fn jwt_header_check(b: &CircuitBuilder, jwt_header: &ByteVec) -> JwtClaims {
-	JwtClaims::new(
-		&b.subcircuit("jwt_claims_header"),
+///
+/// Returns the `(alg, typ)` ByteVecs so callers can populate the runtime length wires.
+fn jwt_header_check(b: &CircuitBuilder, jwt_header: &ByteVec) -> [ByteVec; 2] {
+	let b = b.subcircuit("jwt_claims_header");
+	let alg = ByteVec {
+		len_bytes: b.add_inout(),
+		data: vec![b.add_constant_64(u64::from_le_bytes(*b"RS256\0\0\0"))],
+	};
+	let typ = ByteVec {
+		len_bytes: b.add_inout(),
+		data: vec![b.add_constant_64(u64::from_le_bytes(*b"JWT\0\0\0\0\0"))],
+	};
+	jwt_claims(
+		&b,
 		jwt_header.len_bytes,
-		jwt_header.data.clone(),
-		vec![
-			Attribute {
-				name: "alg",
-				len_bytes: b.add_inout(),
-				value: vec![b.add_constant_64(u64::from_le_bytes(*b"RS256\0\0\0"))],
-			},
-			Attribute {
-				name: "typ",
-				len_bytes: b.add_inout(),
-				value: vec![b.add_constant_64(u64::from_le_bytes(*b"JWT\0\0\0\0\0"))],
-			},
-		],
-	)
+		&jwt_header.data,
+		&[("alg", &alg), ("typ", &typ)],
+	);
+	[alg, typ]
 }
 
 /// A check that verifies that the payload has all the claimed values of `sub`, `aud`, `iss`
@@ -519,35 +517,24 @@ fn jwt_payload_check(
 	aud_byte_vec: &ByteVec,
 	iss_byte_vec: &ByteVec,
 	base64_nonce: &[Wire; 6],
-) -> JwtClaims {
-	JwtClaims::new(
-		&b.subcircuit("jwt_claims_payload"),
+) {
+	let b = b.subcircuit("jwt_claims_payload");
+	// Base64-encoded 32 bytes without padding = 43 chars.
+	let nonce_byte_vec = ByteVec {
+		len_bytes: b.add_constant_64(43),
+		data: base64_nonce.to_vec(),
+	};
+	jwt_claims(
+		&b,
 		jwt_payload.len_bytes,
-		jwt_payload.data.clone(),
-		vec![
-			Attribute {
-				name: "sub",
-				len_bytes: sub_byte_vec.len_bytes,
-				value: sub_byte_vec.data.clone(),
-			},
-			Attribute {
-				name: "aud",
-				len_bytes: aud_byte_vec.len_bytes,
-				value: aud_byte_vec.data.clone(),
-			},
-			Attribute {
-				name: "iss",
-				len_bytes: iss_byte_vec.len_bytes,
-				value: iss_byte_vec.data.clone(),
-			},
-			Attribute {
-				name: "nonce",
-				len_bytes: b.add_constant_64(43), /* Base64 encoded 32 bytes without padding = 43
-				                                   * chars */
-				value: base64_nonce.to_vec(),
-			},
+		&jwt_payload.data,
+		&[
+			("sub", sub_byte_vec),
+			("aud", aud_byte_vec),
+			("iss", iss_byte_vec),
+			("nonce", &nonce_byte_vec),
 		],
-	)
+	);
 }
 
 pub struct ZkLoginExample {

--- a/crates/examples/src/circuits/zklogin.rs
+++ b/crates/examples/src/circuits/zklogin.rs
@@ -2,13 +2,8 @@
 use anyhow::{Result, ensure};
 use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD as BASE64_URL_SAFE_NO_PAD};
 use binius_circuits::{
-	base64::base64_url_safe,
-	concat::concat,
-	fixed_byte_vec::ByteVec,
-	jwt_claims::jwt_claims,
-	rs256::Rs256Verify,
-	sha256::Sha256 as Sha256Circuit,
-	slice::create_byte_mask,
+	base64::base64_url_safe, concat::concat, fixed_byte_vec::ByteVec, jwt_claims::jwt_claims,
+	rs256::Rs256Verify, sha256::Sha256 as Sha256Circuit, slice::create_byte_mask,
 };
 use binius_core::Word;
 use binius_frontend::{CircuitBuilder, Wire, WitnessFiller, util::pack_bytes_into_wires_le};
@@ -328,11 +323,7 @@ impl ZkLogin {
 			Some(signing_joined_le.len()),
 		);
 		signing_concat_b.assert_eq("len", signing_concat.len_bytes, jwt_signing_payload_sha256_len);
-		assert_sha256_message_eq_concat(
-			&signing_concat_b,
-			&signing_concat,
-			&signing_joined_le,
-		);
+		assert_sha256_message_eq_concat(&signing_concat_b, &signing_concat, &signing_joined_le);
 
 		let jwt_header_attrs = jwt_header_check(b, &jwt_header);
 		jwt_payload_check(b, &jwt_payload, &sub, &aud, &iss, &base64_jwt_payload_nonce);
@@ -459,7 +450,7 @@ impl ZkLogin {
 ///
 /// This is needed because the SHA-256 message wires past `len_bytes` carry padding bytes
 /// (`0x80` delimiter plus the bit-length field), which differ from the zero-padded trailing
-/// bytes of the [`concat`] gadget's output. We mask both sides to the valid byte range and
+/// bytes of the [`concat()`] gadget's output. We mask both sides to the valid byte range and
 /// only assert there.
 fn assert_sha256_message_eq_concat(
 	b: &CircuitBuilder,
@@ -469,19 +460,12 @@ fn assert_sha256_message_eq_concat(
 	assert_eq!(concat_result.data.len(), joined_le.len());
 	for (i, (&a, &e)) in concat_result.data.iter().zip(joined_le).enumerate() {
 		let word_byte_offset = i << 3;
-		let is_valid_word = b.icmp_ult(
-			b.add_constant(Word(word_byte_offset as u64)),
-			concat_result.len_bytes,
-		);
+		let is_valid_word =
+			b.icmp_ult(b.add_constant(Word(word_byte_offset as u64)), concat_result.len_bytes);
 		let neg_start = b.add_constant(Word((-(word_byte_offset as i64)) as u64));
 		let (bytes_remaining, _) = b.iadd(concat_result.len_bytes, neg_start);
 		let mask = create_byte_mask(b, bytes_remaining);
-		b.assert_eq_cond(
-			format!("data[{i}]"),
-			b.band(a, mask),
-			b.band(e, mask),
-			is_valid_word,
-		);
+		b.assert_eq_cond(format!("data[{i}]"), b.band(a, mask), b.band(e, mask), is_valid_word);
 	}
 }
 
@@ -499,12 +483,7 @@ fn jwt_header_check(b: &CircuitBuilder, jwt_header: &ByteVec) -> [ByteVec; 2] {
 		len_bytes: b.add_inout(),
 		data: vec![b.add_constant_64(u64::from_le_bytes(*b"JWT\0\0\0\0\0"))],
 	};
-	jwt_claims(
-		&b,
-		jwt_header.len_bytes,
-		&jwt_header.data,
-		&[("alg", &alg), ("typ", &typ)],
-	);
+	jwt_claims(&b, jwt_header.len_bytes, &jwt_header.data, &[("alg", &alg), ("typ", &typ)]);
 	[alg, typ]
 }
 

--- a/crates/examples/src/circuits/zklogin.rs
+++ b/crates/examples/src/circuits/zklogin.rs
@@ -2,7 +2,7 @@
 use anyhow::{Result, ensure};
 use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD as BASE64_URL_SAFE_NO_PAD};
 use binius_circuits::{
-	base64::Base64UrlSafe,
+	base64::base64_url_safe,
 	concat::concat,
 	fixed_byte_vec::ByteVec,
 	jwt_claims::jwt_claims,
@@ -148,22 +148,22 @@ impl ZkLogin {
 		// 2. payload
 		// 3. signature
 
-		let _base64decode_check_header = Base64UrlSafe::new(
+		base64_url_safe(
 			&b.subcircuit("base64_check_header"),
-			jwt_header.data.clone(),
-			base64_jwt_header.data.clone(),
+			&jwt_header.data,
+			&base64_jwt_header.data,
 			jwt_header.len_bytes,
 		);
-		let _base64decode_check_payload = Base64UrlSafe::new(
+		base64_url_safe(
 			&b.subcircuit("base64_check_payload"),
-			jwt_payload.data.clone(),
-			base64_jwt_payload.data.clone(),
+			&jwt_payload.data,
+			&base64_jwt_payload.data,
 			jwt_payload.len_bytes,
 		);
-		let _base64decode_check_signature = Base64UrlSafe::new(
+		base64_url_safe(
 			&b.subcircuit("base64_check_signature"),
-			jwt_signature.data.clone(),
-			base64_jwt_signature.data.clone(),
+			&jwt_signature.data,
+			&base64_jwt_signature.data,
 			jwt_signature.len_bytes,
 		);
 
@@ -276,10 +276,10 @@ impl ZkLogin {
 		// The nonce is 32 bytes which encodes to 43 base64 characters.
 		// minimal wires those will fit into: 6 wires.
 		let base64_check_nonce_builder = b.subcircuit("base64_check_nonce");
-		let _base64decode_check_nonce = Base64UrlSafe::new(
+		base64_url_safe(
 			&base64_check_nonce_builder,
-			nonce_le_for_base64.clone(),
-			base64_jwt_payload_nonce.to_vec(),
+			&nonce_le_for_base64,
+			&base64_jwt_payload_nonce,
 			base64_check_nonce_builder.add_constant_64(32),
 		);
 

--- a/crates/prover/tests/prove_verify.rs
+++ b/crates/prover/tests/prove_verify.rs
@@ -1,6 +1,6 @@
 // Copyright 2025 Irreducible Inc.
 
-use binius_circuits::sha256::{Compress, State};
+use binius_circuits::sha256::{State, compress, pack_message_block};
 use binius_core::{
 	constraint_system::{ConstraintSystem, ValueVec},
 	word::Word,
@@ -85,11 +85,11 @@ fn sha256_preimage_circuit() -> (ConstraintSystem, ValueVec) {
 	let state = State::iv(&circuit);
 	let input: [Wire; 16] = std::array::from_fn(|_| circuit.add_witness());
 	let output: [Wire; 8] = std::array::from_fn(|_| circuit.add_inout());
-	let compress = Compress::new(&circuit, state, input);
+	let state_out = compress(&circuit, state, input);
 
 	// Mask to only low 32-bit.
 	let mask32 = circuit.add_constant(Word::MASK_32);
-	for (actual_x, expected_x) in compress.state_out.0.iter().zip(output) {
+	for (actual_x, expected_x) in state_out.0.iter().zip(output) {
 		circuit.assert_eq("eq", circuit.band(*actual_x, mask32), expected_x);
 	}
 
@@ -97,7 +97,7 @@ fn sha256_preimage_circuit() -> (ConstraintSystem, ValueVec) {
 	let mut w = circuit.new_witness_filler();
 
 	// Populate the input message for the compression function.
-	compress.populate_m(&mut w, preimage);
+	pack_message_block(&mut w, &input, preimage);
 
 	for (i, &output) in output.iter().enumerate() {
 		w[output] = Word(expected_state[i] as u64);

--- a/crates/prover/tests/shift.rs
+++ b/crates/prover/tests/shift.rs
@@ -67,7 +67,8 @@ pub fn create_sha256_cs_with_witness() -> (ConstraintSystem, ValueVec) {
 }
 
 pub fn create_concat_cs_with_witness() -> (ConstraintSystem, ValueVec) {
-	use binius_circuits::{concat::Concat, fixed_byte_vec::ByteVec};
+	use binius_circuits::{concat::concat, fixed_byte_vec::ByteVec};
+	use binius_frontend::util::pack_bytes_into_wires_le;
 
 	let builder = CircuitBuilder::new();
 	let max_n_joined: usize = 32; // Maximum joined size
@@ -92,8 +93,12 @@ pub fn create_concat_cs_with_witness() -> (ConstraintSystem, ValueVec) {
 		},
 	];
 
-	// Create the Concat circuit
-	let concat = Concat::new(&builder, len_joined, joined, terms);
+	// Compute the concat and assert it matches the expected joined wires.
+	let computed = concat(&builder, &terms, Some(joined.len()));
+	builder.assert_eq("concat_len", computed.len_bytes, len_joined);
+	for (i, (&a, &e)) in computed.data.iter().zip(&joined).enumerate() {
+		builder.assert_eq(format!("concat_data[{i}]"), a, e);
+	}
 
 	let circuit = builder.build();
 	let mut witness_filler = circuit.new_witness_filler();
@@ -105,18 +110,18 @@ pub fn create_concat_cs_with_witness() -> (ConstraintSystem, ValueVec) {
 	let joined_data = b"Hello World!";
 
 	// Populate terms
-	concat.terms[0].populate_len_bytes(&mut witness_filler, term1_data.len());
-	concat.terms[0].populate_data(&mut witness_filler, term1_data);
+	terms[0].populate_len_bytes(&mut witness_filler, term1_data.len());
+	terms[0].populate_data(&mut witness_filler, term1_data);
 
-	concat.terms[1].populate_len_bytes(&mut witness_filler, term2_data.len());
-	concat.terms[1].populate_data(&mut witness_filler, term2_data);
+	terms[1].populate_len_bytes(&mut witness_filler, term2_data.len());
+	terms[1].populate_data(&mut witness_filler, term2_data);
 
-	concat.terms[2].populate_len_bytes(&mut witness_filler, term3_data.len());
-	concat.terms[2].populate_data(&mut witness_filler, term3_data);
+	terms[2].populate_len_bytes(&mut witness_filler, term3_data.len());
+	terms[2].populate_data(&mut witness_filler, term3_data);
 
-	// Populate joined result
-	concat.populate_len_joined_bytes(&mut witness_filler, joined_data.len());
-	concat.populate_joined(&mut witness_filler, joined_data);
+	// Populate expected joined result
+	witness_filler[len_joined] = Word(joined_data.len() as u64);
+	pack_bytes_into_wires_le(&mut witness_filler, &joined, joined_data);
 
 	// Get the witness vector
 	circuit.populate_wire_witness(&mut witness_filler).unwrap();

--- a/crates/prover/tests/shift.rs
+++ b/crates/prover/tests/shift.rs
@@ -125,7 +125,8 @@ pub fn create_concat_cs_with_witness() -> (ConstraintSystem, ValueVec) {
 }
 
 pub fn create_slice_cs_with_witness() -> (ConstraintSystem, ValueVec) {
-	use binius_circuits::slice::Slice;
+	use binius_circuits::slice::slice;
+	use binius_frontend::util::pack_bytes_into_wires_le;
 
 	let builder = CircuitBuilder::new();
 
@@ -133,11 +134,14 @@ pub fn create_slice_cs_with_witness() -> (ConstraintSystem, ValueVec) {
 	let len_input = builder.add_witness();
 	let len_slice = builder.add_witness();
 	let input: Vec<Wire> = (0..4).map(|_| builder.add_witness()).collect();
-	let slice: Vec<Wire> = (0..2).map(|_| builder.add_witness()).collect();
+	let expected: Vec<Wire> = (0..2).map(|_| builder.add_witness()).collect();
 	let offset = builder.add_witness();
 
-	// Create the Slice circuit
-	let slice_circuit = Slice::new(&builder, len_input, len_slice, input, slice, offset);
+	// Extract the slice and assert it matches `expected`.
+	let actual = slice(&builder, len_input, len_slice, &input, offset, expected.len());
+	for (i, (&a, &e)) in actual.iter().zip(&expected).enumerate() {
+		builder.assert_eq(format!("slice_eq[{i}]"), a, e);
+	}
 
 	let circuit = builder.build();
 	let mut witness_filler = circuit.new_witness_filler();
@@ -145,13 +149,13 @@ pub fn create_slice_cs_with_witness() -> (ConstraintSystem, ValueVec) {
 	// Test slicing "Hello World!" from offset 6 with length 5 to get "World"
 	let input_data = b"Hello World!";
 	let slice_data = b"World";
-	let offset_val = 6;
+	let offset_val = 6u64;
 
-	slice_circuit.populate_len_input(&mut witness_filler, input_data.len());
-	slice_circuit.populate_len_slice(&mut witness_filler, slice_data.len());
-	slice_circuit.populate_input(&mut witness_filler, input_data);
-	slice_circuit.populate_slice(&mut witness_filler, slice_data);
-	slice_circuit.populate_offset(&mut witness_filler, offset_val);
+	witness_filler[len_input] = Word(input_data.len() as u64);
+	witness_filler[len_slice] = Word(slice_data.len() as u64);
+	pack_bytes_into_wires_le(&mut witness_filler, &input, input_data);
+	pack_bytes_into_wires_le(&mut witness_filler, &expected, slice_data);
+	witness_filler[offset] = Word(offset_val);
 
 	// Get the witness vector
 	circuit.populate_wire_witness(&mut witness_filler).unwrap();


### PR DESCRIPTION
## Summary

- Tier 1 of [BINIUS-36](https://linear.app/jimpo/issue/BINIUS-36): replaces struct-with-`populate_*` gadgets in `binius_circuits` with free `pub fn` gadgets following the `multiplexer` style. Each gadget is its own commit.
- Two converted gadgets (`slice` and `concat`) now *return* their result wires instead of taking them as inputs and asserting equality:
  - `slice(b, len_input, len_slice, input, offset, max_n_words) -> Vec<Wire>` — extracts the slice as zero-padded LE words. Saves ~3 AND constraints per output word vs the old asserting form, even with caller-side equality checks added back.
  - `concat(b, terms, max_words: Option<usize>) -> ByteVec` — concatenates terms into a returned `ByteVec`. ~6-7% AND constraints heavier than the old verifier when the caller asserts equality with a target buffer; the API matches `slice` and removes the need to thread a length wire and target buffer through callers.
- Remaining five conversions are mechanical:
  - `jwt_claims::JwtClaims` → `jwt_claims` (`Attribute` dropped; attributes pass as `&[(&str, &ByteVec)]`)
  - `base64::Base64UrlSafe` → `base64_url_safe`
  - `sha256/sha512::compress::Compress` → `compress` + `pack_message_block`
  - `keccak::permutation::Permutation` → free `keccak_f1600`, `keccak_permutation_round`
- Callers updated: `examples/zklogin.rs`, `hash_based_sig::hashing::base`, `prover/tests/{shift,prove_verify}.rs`, `tests/gate_fusion_keccak`.
- Tier 2/3 (variable-length hashes needing [BINIUS-30](https://linear.app/jimpo/issue/BINIUS-30), plus `bitcoin::*` and `rs256::*` cascades) are deferred.

## Test plan

- [x] `cargo build -p binius-circuits -p binius-examples -p binius-prover --tests`
- [x] `cargo test -p binius-circuits --lib` (352 passed)
- [x] `cargo test -p binius-circuits --tests` (gate_fusion_keccak)
- [x] `cargo test -p binius-prover --tests` (prove_verify + shift)
- [x] `cargo test -p binius-examples --lib` (zklogin + others, 7 passed)
- [x] Each commit individually builds and passes its own crate's tests
