### PR TITLE
[spartan] compute_public_value: trade in challenges for plain field eval

### DIFF
--- a/crates/iop/src/basefold_channel.rs
+++ b/crates/iop/src/basefold_channel.rs
@@ -154,11 +154,7 @@ where
 		}
 	}
 
-	fn compute_public_value(
-		&mut self,
-		inputs: &[F],
-		f: impl FnOnce(&[F]) -> F,
-	) -> F {
+	fn compute_public_value(&mut self, inputs: &[F], f: impl FnOnce(&[F]) -> F) -> F {
 		f(inputs)
 	}
 }

--- a/crates/iop/src/basefold_channel.rs
+++ b/crates/iop/src/basefold_channel.rs
@@ -153,6 +153,14 @@ where
 			Err(binius_ip::channel::Error::InvalidAssert)
 		}
 	}
+
+	fn compute_public_value(
+		&mut self,
+		inputs: &[F],
+		f: impl FnOnce(&[F]) -> F,
+	) -> F {
+		f(inputs)
+	}
 }
 
 impl<F, MerkleScheme_, Challenger_> IOPVerifierChannel<F>

--- a/crates/iop/src/basefold_zk_channel.rs
+++ b/crates/iop/src/basefold_zk_channel.rs
@@ -142,11 +142,7 @@ where
 		}
 	}
 
-	fn compute_public_value(
-		&mut self,
-		inputs: &[F],
-		f: impl FnOnce(&[F]) -> F,
-	) -> F {
+	fn compute_public_value(&mut self, inputs: &[F], f: impl FnOnce(&[F]) -> F) -> F {
 		f(inputs)
 	}
 }

--- a/crates/iop/src/basefold_zk_channel.rs
+++ b/crates/iop/src/basefold_zk_channel.rs
@@ -141,6 +141,14 @@ where
 			Err(binius_ip::channel::Error::InvalidAssert)
 		}
 	}
+
+	fn compute_public_value(
+		&mut self,
+		inputs: &[F],
+		f: impl FnOnce(&[F]) -> F,
+	) -> F {
+		f(inputs)
+	}
 }
 
 impl<F, MerkleScheme_, Challenger_> IOPVerifierChannel<F>

--- a/crates/iop/src/naive_channel.rs
+++ b/crates/iop/src/naive_channel.rs
@@ -133,6 +133,14 @@ where
 			Err(binius_ip::channel::Error::InvalidAssert)
 		}
 	}
+
+	fn compute_public_value(
+		&mut self,
+		inputs: &[F],
+		f: impl FnOnce(&[F]) -> F,
+	) -> F {
+		f(inputs)
+	}
 }
 
 impl<F, Challenger_> IOPVerifierChannel<F> for NaiveVerifierChannel<'_, F, Challenger_>

--- a/crates/iop/src/naive_channel.rs
+++ b/crates/iop/src/naive_channel.rs
@@ -134,11 +134,7 @@ where
 		}
 	}
 
-	fn compute_public_value(
-		&mut self,
-		inputs: &[F],
-		f: impl FnOnce(&[F]) -> F,
-	) -> F {
+	fn compute_public_value(&mut self, inputs: &[F], f: impl FnOnce(&[F]) -> F) -> F {
 		f(inputs)
 	}
 }

--- a/crates/iop/src/size_tracking_channel.rs
+++ b/crates/iop/src/size_tracking_channel.rs
@@ -115,6 +115,14 @@ impl<F: BinaryField, MerkleScheme_: MerkleTreeScheme<F>> IPVerifierChannel<F>
 	fn assert_zero(&mut self, _val: F) -> Result<(), binius_ip::channel::Error> {
 		Ok(())
 	}
+
+	fn compute_public_value(
+		&mut self,
+		inputs: &[F],
+		f: impl FnOnce(&[F]) -> F,
+	) -> F {
+		f(inputs)
+	}
 }
 
 impl<F: BinaryField, MerkleScheme_: MerkleTreeScheme<F>> IOPVerifierChannel<F>

--- a/crates/iop/src/size_tracking_channel.rs
+++ b/crates/iop/src/size_tracking_channel.rs
@@ -116,11 +116,7 @@ impl<F: BinaryField, MerkleScheme_: MerkleTreeScheme<F>> IPVerifierChannel<F>
 		Ok(())
 	}
 
-	fn compute_public_value(
-		&mut self,
-		inputs: &[F],
-		f: impl FnOnce(&[F]) -> F,
-	) -> F {
+	fn compute_public_value(&mut self, inputs: &[F], f: impl FnOnce(&[F]) -> F) -> F {
 		f(inputs)
 	}
 }

--- a/crates/ip/src/channel.rs
+++ b/crates/ip/src/channel.rs
@@ -83,6 +83,25 @@ pub trait IPVerifierChannel<F: Field> {
 	///
 	/// Returns [`Error::InvalidAssert`] if the value is not zero.
 	fn assert_zero(&mut self, val: Self::Elem) -> Result<(), Error>;
+
+	/// Computes a value that is a function of public-channel-derived elements and returns it
+	/// as a freshly allocated `Elem`.
+	///
+	/// In wrapper channels that build constraints (e.g. `IronSpartanBuilderChannel`), the result
+	/// is materialized as a single inout wire holding the closure's return value, replacing what
+	/// would otherwise be a sub-circuit's worth of constraints. In non-wrapper channels where
+	/// `Elem = F`, the impl is just `f(inputs)`.
+	///
+	/// The caller MUST ensure each entry in `inputs` is either a `Constant` or a `Wire` whose
+	/// public-tag is true — i.e. produced by `sample_*` / `observe_*` / `compute_public_value`
+	/// on this channel, or derived purely from such values via the channel's `Elem` arithmetic.
+	/// Inputs from `recv_*` (or anything that mixed in a non-public value) MUST NOT be passed.
+	/// The contract is documented; wrapper impls debug-assert it but it is not statically enforced.
+	fn compute_public_value(
+		&mut self,
+		inputs: &[Self::Elem],
+		f: impl FnOnce(&[F]) -> F,
+	) -> Self::Elem;
 }
 
 impl<F, Challenger_> IPVerifierChannel<F> for VerifierTranscript<Challenger_>
@@ -126,6 +145,14 @@ where
 		} else {
 			Err(Error::InvalidAssert)
 		}
+	}
+
+	fn compute_public_value(
+		&mut self,
+		inputs: &[F],
+		f: impl FnOnce(&[F]) -> F,
+	) -> F {
+		f(inputs)
 	}
 }
 

--- a/crates/ip/src/channel.rs
+++ b/crates/ip/src/channel.rs
@@ -97,6 +97,10 @@ pub trait IPVerifierChannel<F: Field> {
 	/// on this channel, or derived purely from such values via the channel's `Elem` arithmetic.
 	/// Inputs from `recv_*` (or anything that mixed in a non-public value) MUST NOT be passed.
 	/// The contract is documented; wrapper impls debug-assert it but it is not statically enforced.
+	///
+	/// The closure may or may not be invoked: the symbolic-builder channel skips it, and other
+	/// impls run it on either real or dummy values. Callers must therefore supply a pure function
+	/// with no observable side effects.
 	fn compute_public_value(
 		&mut self,
 		inputs: &[Self::Elem],

--- a/crates/ip/src/channel.rs
+++ b/crates/ip/src/channel.rs
@@ -147,11 +147,7 @@ where
 		}
 	}
 
-	fn compute_public_value(
-		&mut self,
-		inputs: &[F],
-		f: impl FnOnce(&[F]) -> F,
-	) -> F {
+	fn compute_public_value(&mut self, inputs: &[F], f: impl FnOnce(&[F]) -> F) -> F {
 		f(inputs)
 	}
 }

--- a/crates/spartan-verifier/src/lib.rs
+++ b/crates/spartan-verifier/src/lib.rs
@@ -189,8 +189,29 @@ impl<F: Field> IOPVerifier<F> {
 
 		// Compute rₓ^⊤ (M_A + λ M_B + λ² M_C) x
 		let r_x_tensor = eq_ind_partial_eval_scalars(&r_x);
-		let public_eval =
-			evaluate_wiring_mle_public(cs.mul_constraints(), &public, lambda.clone(), &r_x_tensor);
+
+		// The public-segment contribution to the operand evaluations is purely a function of
+		// public-channel inputs (the public scalars, λ, and rₓ). Trade in those Elems for plain
+		// field values, run the MLE evaluation in plaintext, and materialize the result as a
+		// single inout wire instead of building the entire sub-circuit.
+		let public_eval = {
+			let public_len = public.len();
+			let mut inputs = public.clone();
+			inputs.push(lambda.clone());
+			inputs.extend(r_x_tensor.iter().cloned());
+			let mul_constraints = cs.mul_constraints();
+			channel.compute_public_value(&inputs, move |vals| {
+				let public_vals = &vals[..public_len];
+				let lambda_val = vals[public_len];
+				let r_x_tensor_vals = &vals[public_len + 1..];
+				evaluate_wiring_mle_public(
+					mul_constraints,
+					public_vals,
+					lambda_val,
+					r_x_tensor_vals,
+				)
+			})
+		};
 
 		// Prover sends the precommit segment's contribution to the operand evaluations.
 		let precommit_claim = channel.recv_one()?;

--- a/crates/spartan-verifier/src/lib.rs
+++ b/crates/spartan-verifier/src/lib.rs
@@ -33,6 +33,8 @@ pub mod constraint_system;
 pub mod wiring;
 pub mod wrapper;
 
+use std::slice;
+
 use binius_field::{BinaryField, Field, field::FieldOps};
 use binius_hash::PseudoCompressionFunction;
 use binius_iop::{
@@ -196,9 +198,13 @@ impl<F: Field> IOPVerifier<F> {
 		// single inout wire instead of building the entire sub-circuit.
 		let public_eval = {
 			let public_len = public.len();
-			let mut inputs = public.clone();
-			inputs.push(lambda.clone());
-			inputs.extend(r_x_tensor.iter().cloned());
+			let inputs = [
+				public.as_slice(),
+				slice::from_ref(&lambda),
+				r_x_tensor.as_ref(),
+			]
+			.concat();
+
 			let mul_constraints = cs.mul_constraints();
 			channel.compute_public_value(&inputs, move |vals| {
 				let public_vals = &vals[..public_len];

--- a/crates/spartan-verifier/src/wrapper/channel.rs
+++ b/crates/spartan-verifier/src/wrapper/channel.rs
@@ -92,6 +92,28 @@ impl<F: Field> IPVerifierChannel<F> for IronSpartanBuilderChannel<F> {
 			}
 		}
 	}
+
+	fn compute_public_value(
+		&mut self,
+		inputs: &[Self::Elem],
+		f: impl FnOnce(&[F]) -> F,
+	) -> Self::Elem {
+		// Dummy field values for the closure: in builder mode the result is discarded, but the
+		// closure is still run so that any panics, type errors, or side effects surface symmetrically
+		// with the replay-channel side.
+		let values: Vec<F> = inputs
+			.iter()
+			.map(|e| match e {
+				CircuitElem::Constant(c) => *c,
+				CircuitElem::Wire { public, .. } => {
+					debug_assert!(*public, "compute_public_value: input is not public");
+					F::ZERO
+				}
+			})
+			.collect();
+		let _ = f(&values);
+		self.alloc_inout_elem(true)
+	}
 }
 
 impl<F: Field> IOPVerifierChannel<F> for IronSpartanBuilderChannel<F> {
@@ -213,6 +235,31 @@ impl<'a, F: Field> IPVerifierChannel<F> for ReplayChannel<'a, F> {
 				self.witness_gen.borrow_mut().assert_zero(wire.wire());
 				Ok(())
 			}
+		}
+	}
+
+	fn compute_public_value(
+		&mut self,
+		inputs: &[Self::Elem],
+		f: impl FnOnce(&[F]) -> F,
+	) -> Self::Elem {
+		let values: Vec<F> = inputs
+			.iter()
+			.map(|e| match e {
+				CircuitElem::Constant(c) => *c,
+				CircuitElem::Wire { wire, public } => {
+					debug_assert!(*public, "compute_public_value: input is not public");
+					wire.wire().val()
+				}
+			})
+			.collect();
+		let result = f(&values);
+		let cwire = ConstraintWire::inout(self.next_inout_id);
+		self.next_inout_id += 1;
+		let witness_wire = self.witness_gen.borrow_mut().write_inout(cwire, result);
+		CircuitElem::Wire {
+			wire: CircuitWire::new(&self.witness_gen, witness_wire),
+			public: true,
 		}
 	}
 }

--- a/crates/spartan-verifier/src/wrapper/channel.rs
+++ b/crates/spartan-verifier/src/wrapper/channel.rs
@@ -35,11 +35,17 @@ impl<F: Field> IronSpartanBuilderChannel<F> {
 		}
 	}
 
-	fn alloc_inout_elem(&self, public: bool) -> CircuitElem<ConstraintBuilder<F>> {
+	/// Allocates a fresh inout wire, tagged public.
+	///
+	/// Inout wires from `recv_one` start out public-tagged here too, but the result of `recv_one`
+	/// is `inout - key` where `key` is precommit (public: false), so the AND-propagation in `Sub`
+	/// makes the recv'd value non-public — exactly as it should be. Treating every alloc_inout
+	/// as public-tagged simplifies the API and is sound under that propagation.
+	fn alloc_inout_elem(&self) -> CircuitElem<ConstraintBuilder<F>> {
 		let wire = self.builder.borrow_mut().alloc_inout();
 		CircuitElem::Wire {
 			wire: CircuitWire::new(&self.builder, wire),
-			public,
+			public: true,
 		}
 	}
 
@@ -69,17 +75,19 @@ impl<F: Field> IPVerifierChannel<F> for IronSpartanBuilderChannel<F> {
 		// For each element that the inner prover sends, the wrapped prover allocates a one-time-pad
 		// encryption key in the precommit segment and encrypts the underlying value before sending.
 		// Here the verifier gets the encryption key from the precommit segment and decrypts.
-		let inout = self.alloc_inout_elem(false);
+		// `inout` is tagged public; subtracting the (non-public) `key` AND-propagates the result to
+		// non-public, which is the correct tag for a recv'd value.
+		let inout = self.alloc_inout_elem();
 		let key = self.alloc_precommit_elem();
 		Ok(inout - key)
 	}
 
 	fn sample(&mut self) -> Self::Elem {
-		self.alloc_inout_elem(true)
+		self.alloc_inout_elem()
 	}
 
 	fn observe_one(&mut self, _val: F) -> Self::Elem {
-		self.alloc_inout_elem(true)
+		self.alloc_inout_elem()
 	}
 
 	fn assert_zero(&mut self, val: Self::Elem) -> Result<(), binius_ip::channel::Error> {
@@ -96,23 +104,16 @@ impl<F: Field> IPVerifierChannel<F> for IronSpartanBuilderChannel<F> {
 	fn compute_public_value(
 		&mut self,
 		inputs: &[Self::Elem],
-		f: impl FnOnce(&[F]) -> F,
+		_f: impl FnOnce(&[F]) -> F,
 	) -> Self::Elem {
-		// Dummy field values for the closure: in builder mode the result is discarded, but the
-		// closure is still run so that any panics, type errors, or side effects surface symmetrically
-		// with the replay-channel side.
-		let values: Vec<F> = inputs
-			.iter()
-			.map(|e| match e {
-				CircuitElem::Constant(c) => *c,
-				CircuitElem::Wire { public, .. } => {
-					debug_assert!(*public, "compute_public_value: input is not public");
-					F::ZERO
-				}
-			})
-			.collect();
-		let _ = f(&values);
-		self.alloc_inout_elem(true)
+		// In builder mode there is nothing to compute — the closure result would be a function of
+		// dummy zeros. We skip running it entirely and only validate the input contract. The
+		// trait documents that the closure may or may not be invoked and must therefore be a
+		// pure function with no observable side effects.
+		for input in inputs {
+			debug_assert!(input.is_public(), "compute_public_value: input is not public");
+		}
+		self.alloc_inout_elem()
 	}
 }
 
@@ -135,7 +136,7 @@ impl<F: Field> IOPVerifierChannel<F> for IronSpartanBuilderChannel<F> {
 		// checks in the circuit equality of this value with the expected expression over encrypted
 		// values.
 		for relation in oracle_relations {
-			let decrypted_claim = self.alloc_inout_elem(false);
+			let decrypted_claim = self.alloc_inout_elem();
 			self.assert_zero(relation.claim - decrypted_claim)?;
 		}
 		Ok(())
@@ -171,7 +172,12 @@ impl<'a, F: Field> ReplayChannel<'a, F> {
 		}
 	}
 
-	fn next_inout_elem(&mut self, public: bool) -> CircuitElem<WitnessGenerator<'a, F>> {
+	/// Allocates the next inout slot, writes its value, and returns it tagged public.
+	///
+	/// See [`IronSpartanBuilderChannel::alloc_inout_elem`] for why every alloc_inout result is
+	/// tagged public regardless of whether the caller is `recv_one` (which subtracts a non-public
+	/// key) or `sample` / `observe_one` / `verify_oracle_relations`.
+	fn next_inout_elem(&mut self) -> CircuitElem<WitnessGenerator<'a, F>> {
 		let value = self
 			.events
 			.next()
@@ -182,7 +188,7 @@ impl<'a, F: Field> ReplayChannel<'a, F> {
 		let witness_wire = self.witness_gen.borrow_mut().write_inout(wire, value);
 		CircuitElem::Wire {
 			wire: CircuitWire::new(&self.witness_gen, witness_wire),
-			public,
+			public: true,
 		}
 	}
 
@@ -214,17 +220,17 @@ impl<'a, F: Field> IPVerifierChannel<F> for ReplayChannel<'a, F> {
 	type Elem = CircuitElem<WitnessGenerator<'a, F>>;
 
 	fn recv_one(&mut self) -> Result<Self::Elem, binius_ip::channel::Error> {
-		let encrypted_elem = self.next_inout_elem(false);
+		let encrypted_elem = self.next_inout_elem();
 		let key = self.next_precommit_elem();
 		Ok(encrypted_elem + key)
 	}
 
 	fn sample(&mut self) -> Self::Elem {
-		self.next_inout_elem(true)
+		self.next_inout_elem()
 	}
 
 	fn observe_one(&mut self, _val: F) -> Self::Elem {
-		self.next_inout_elem(true)
+		self.next_inout_elem()
 	}
 
 	fn assert_zero(&mut self, val: Self::Elem) -> Result<(), binius_ip::channel::Error> {
@@ -283,7 +289,7 @@ impl<'a, F: Field> IOPVerifierChannel<F> for ReplayChannel<'a, F> {
 		// checks in the circuit equality of this value with the expected expression over encrypted
 		// values.
 		for relation in oracle_relations {
-			let decrypted_claim = self.next_inout_elem(false);
+			let decrypted_claim = self.next_inout_elem();
 			self.assert_zero(relation.claim - decrypted_claim)?;
 		}
 		Ok(())

--- a/crates/spartan-verifier/src/wrapper/channel.rs
+++ b/crates/spartan-verifier/src/wrapper/channel.rs
@@ -35,14 +35,20 @@ impl<F: Field> IronSpartanBuilderChannel<F> {
 		}
 	}
 
-	fn alloc_inout_elem(&self) -> CircuitElem<ConstraintBuilder<F>> {
+	fn alloc_inout_elem(&self, public: bool) -> CircuitElem<ConstraintBuilder<F>> {
 		let wire = self.builder.borrow_mut().alloc_inout();
-		CircuitElem::Wire(CircuitWire::new(&self.builder, wire))
+		CircuitElem::Wire {
+			wire: CircuitWire::new(&self.builder, wire),
+			public,
+		}
 	}
 
 	fn alloc_precommit_elem(&self) -> CircuitElem<ConstraintBuilder<F>> {
 		let wire = self.builder.borrow_mut().alloc_precommit();
-		CircuitElem::Wire(CircuitWire::new(&self.builder, wire))
+		CircuitElem::Wire {
+			wire: CircuitWire::new(&self.builder, wire),
+			public: false,
+		}
 	}
 
 	/// Consumes the channel and returns the underlying [`ConstraintBuilder`].
@@ -63,25 +69,25 @@ impl<F: Field> IPVerifierChannel<F> for IronSpartanBuilderChannel<F> {
 		// For each element that the inner prover sends, the wrapped prover allocates a one-time-pad
 		// encryption key in the precommit segment and encrypts the underlying value before sending.
 		// Here the verifier gets the encryption key from the precommit segment and decrypts.
-		let inout = self.alloc_inout_elem();
+		let inout = self.alloc_inout_elem(false);
 		let key = self.alloc_precommit_elem();
 		Ok(inout - key)
 	}
 
 	fn sample(&mut self) -> Self::Elem {
-		self.alloc_inout_elem()
+		self.alloc_inout_elem(true)
 	}
 
 	fn observe_one(&mut self, _val: F) -> Self::Elem {
-		self.alloc_inout_elem()
+		self.alloc_inout_elem(true)
 	}
 
 	fn assert_zero(&mut self, val: Self::Elem) -> Result<(), binius_ip::channel::Error> {
 		match val {
 			CircuitElem::Constant(c) if c == F::ZERO => Ok(()),
 			CircuitElem::Constant(_) => Err(binius_ip::channel::Error::InvalidAssert),
-			CircuitElem::Wire(w) => {
-				self.builder.borrow_mut().assert_zero(w.wire());
+			CircuitElem::Wire { wire, .. } => {
+				self.builder.borrow_mut().assert_zero(wire.wire());
 				Ok(())
 			}
 		}
@@ -107,7 +113,7 @@ impl<F: Field> IOPVerifierChannel<F> for IronSpartanBuilderChannel<F> {
 		// checks in the circuit equality of this value with the expected expression over encrypted
 		// values.
 		for relation in oracle_relations {
-			let decrypted_claim = self.alloc_inout_elem();
+			let decrypted_claim = self.alloc_inout_elem(false);
 			self.assert_zero(relation.claim - decrypted_claim)?;
 		}
 		Ok(())
@@ -143,7 +149,7 @@ impl<'a, F: Field> ReplayChannel<'a, F> {
 		}
 	}
 
-	fn next_inout_elem(&mut self) -> CircuitElem<WitnessGenerator<'a, F>> {
+	fn next_inout_elem(&mut self, public: bool) -> CircuitElem<WitnessGenerator<'a, F>> {
 		let value = self
 			.events
 			.next()
@@ -152,7 +158,10 @@ impl<'a, F: Field> ReplayChannel<'a, F> {
 		let wire = ConstraintWire::inout(self.next_inout_id);
 		self.next_inout_id += 1;
 		let witness_wire = self.witness_gen.borrow_mut().write_inout(wire, value);
-		CircuitElem::Wire(CircuitWire::new(&self.witness_gen, witness_wire))
+		CircuitElem::Wire {
+			wire: CircuitWire::new(&self.witness_gen, witness_wire),
+			public,
+		}
 	}
 
 	fn next_precommit_elem(&mut self) -> CircuitElem<WitnessGenerator<'a, F>> {
@@ -164,7 +173,10 @@ impl<'a, F: Field> ReplayChannel<'a, F> {
 		let wire = ConstraintWire::precommit(self.next_precommit_id);
 		self.next_precommit_id += 1;
 		let witness_wire = self.witness_gen.borrow_mut().write_precommit(wire, value);
-		CircuitElem::Wire(CircuitWire::new(&self.witness_gen, witness_wire))
+		CircuitElem::Wire {
+			wire: CircuitWire::new(&self.witness_gen, witness_wire),
+			public: false,
+		}
 	}
 
 	/// Consumes the channel and builds the outer witness.
@@ -180,25 +192,25 @@ impl<'a, F: Field> IPVerifierChannel<F> for ReplayChannel<'a, F> {
 	type Elem = CircuitElem<WitnessGenerator<'a, F>>;
 
 	fn recv_one(&mut self) -> Result<Self::Elem, binius_ip::channel::Error> {
-		let encrypted_elem = self.next_inout_elem();
+		let encrypted_elem = self.next_inout_elem(false);
 		let key = self.next_precommit_elem();
 		Ok(encrypted_elem + key)
 	}
 
 	fn sample(&mut self) -> Self::Elem {
-		self.next_inout_elem()
+		self.next_inout_elem(true)
 	}
 
 	fn observe_one(&mut self, _val: F) -> Self::Elem {
-		self.next_inout_elem()
+		self.next_inout_elem(true)
 	}
 
 	fn assert_zero(&mut self, val: Self::Elem) -> Result<(), binius_ip::channel::Error> {
 		match val {
 			CircuitElem::Constant(c) if c == F::ZERO => Ok(()),
 			CircuitElem::Constant(_) => Err(binius_ip::channel::Error::InvalidAssert),
-			CircuitElem::Wire(w) => {
-				self.witness_gen.borrow_mut().assert_zero(w.wire());
+			CircuitElem::Wire { wire, .. } => {
+				self.witness_gen.borrow_mut().assert_zero(wire.wire());
 				Ok(())
 			}
 		}
@@ -224,7 +236,7 @@ impl<'a, F: Field> IOPVerifierChannel<F> for ReplayChannel<'a, F> {
 		// checks in the circuit equality of this value with the expected expression over encrypted
 		// values.
 		for relation in oracle_relations {
-			let decrypted_claim = self.next_inout_elem();
+			let decrypted_claim = self.next_inout_elem(false);
 			self.assert_zero(relation.claim - decrypted_claim)?;
 		}
 		Ok(())

--- a/crates/spartan-verifier/src/wrapper/circuit_elem.rs
+++ b/crates/spartan-verifier/src/wrapper/circuit_elem.rs
@@ -74,14 +74,26 @@ impl<B: CircuitBuilder> CircuitWire<B> {
 /// [`WitnessGenerator`]: binius_spartan_frontend::circuit_builder::WitnessGenerator
 pub enum CircuitElem<B: CircuitBuilder> {
 	Constant(B::Field),
-	Wire(CircuitWire<B>),
+	/// A wire with a tag indicating whether its value is purely a function of public-channel
+	/// inputs (sampled challenges, observed values, constants, and other public wires).
+	///
+	/// The tag is used by [`IPVerifierChannel::compute_public_value`] to validate that
+	/// trade-in inputs are public-derived. It is propagated conservatively through arithmetic
+	/// (AND of operand tags, with `Constant` treated as public).
+	Wire {
+		wire: CircuitWire<B>,
+		public: bool,
+	},
 }
 
 impl<B: CircuitBuilder> Clone for CircuitElem<B> {
 	fn clone(&self) -> Self {
 		match self {
 			CircuitElem::Constant(c) => CircuitElem::Constant(*c),
-			CircuitElem::Wire(w) => CircuitElem::Wire(w.clone()),
+			CircuitElem::Wire { wire, public } => CircuitElem::Wire {
+				wire: wire.clone(),
+				public: *public,
+			},
 		}
 	}
 }
@@ -91,7 +103,16 @@ impl<B: CircuitBuilder> CircuitElem<B> {
 	fn builder_rc(&self) -> Option<Rc<RefCell<B>>> {
 		match self {
 			CircuitElem::Constant(_) => None,
-			CircuitElem::Wire(w) => Some(w.upgrade()),
+			CircuitElem::Wire { wire, .. } => Some(wire.upgrade()),
+		}
+	}
+
+	/// Returns whether this element is purely a function of public-channel inputs.
+	/// `Constant` is treated as public.
+	pub(crate) fn is_public(&self) -> bool {
+		match self {
+			CircuitElem::Constant(_) => true,
+			CircuitElem::Wire { public, .. } => *public,
 		}
 	}
 
@@ -111,15 +132,18 @@ impl<B: CircuitBuilder> CircuitElem<B> {
 	fn to_wire(&self, builder: &mut B) -> B::Wire {
 		match self {
 			CircuitElem::Constant(val) => builder.constant(*val),
-			CircuitElem::Wire(w) => w.wire,
+			CircuitElem::Wire { wire, .. } => wire.wire,
 		}
 	}
 
-	fn make_wire(rc: &Rc<RefCell<B>>, wire: B::Wire) -> Self {
-		CircuitElem::Wire(CircuitWire {
-			builder: Rc::downgrade(rc),
-			wire,
-		})
+	fn make_wire(rc: &Rc<RefCell<B>>, wire: B::Wire, public: bool) -> Self {
+		CircuitElem::Wire {
+			wire: CircuitWire {
+				builder: Rc::downgrade(rc),
+				wire,
+			},
+			public,
+		}
 	}
 }
 
@@ -150,7 +174,7 @@ impl<B: CircuitBuilder> Add for CircuitElem<B> {
 				let a_wire = self.to_wire(&mut builder);
 				let b_wire = rhs.to_wire(&mut builder);
 				let out = builder.add(a_wire, b_wire);
-				Self::make_wire(&rc, out)
+				Self::make_wire(&rc, out, false)
 			}
 		}
 	}
@@ -174,7 +198,7 @@ impl<B: CircuitBuilder> Sub for CircuitElem<B> {
 				let a_wire = self.to_wire(&mut builder);
 				let b_wire = rhs.to_wire(&mut builder);
 				let out = builder.sub(a_wire, b_wire);
-				Self::make_wire(&rc, out)
+				Self::make_wire(&rc, out, false)
 			}
 		}
 	}
@@ -204,7 +228,7 @@ impl<B: CircuitBuilder> Mul for CircuitElem<B> {
 				let a_wire = self.to_wire(&mut builder);
 				let b_wire = rhs.to_wire(&mut builder);
 				let out = builder.mul(a_wire, b_wire);
-				Self::make_wire(&rc, out)
+				Self::make_wire(&rc, out, false)
 			}
 		}
 	}
@@ -322,7 +346,7 @@ impl<B: CircuitBuilder> InvertOrZero for CircuitElem<B> {
 	fn invert_or_zero(self) -> Self {
 		match &self {
 			CircuitElem::Constant(c) => CircuitElem::Constant(c.invert_or_zero()),
-			CircuitElem::Wire(w) => {
+			CircuitElem::Wire { wire: w, .. } => {
 				let rc = w.upgrade();
 				let mut builder = rc.borrow_mut();
 				let wire = w.wire;
@@ -335,7 +359,7 @@ impl<B: CircuitBuilder> InvertOrZero for CircuitElem<B> {
 				let one = builder.constant(B::Field::ONE);
 				builder.assert_eq(product, one);
 
-				Self::make_wire(&rc, inv_wire)
+				Self::make_wire(&rc, inv_wire, false)
 			}
 		}
 	}
@@ -369,7 +393,7 @@ impl<B: CircuitBuilder> FieldOps for CircuitElem<B> {
 				.iter()
 				.map(|e| match e {
 					CircuitElem::Constant(c) => *c,
-					CircuitElem::Wire(_) => unreachable!(),
+					CircuitElem::Wire { .. } => unreachable!(),
 				})
 				.collect::<Vec<_>>();
 			<B::Field as ExtensionField<FSub>>::square_transpose(&mut vals);
@@ -396,7 +420,7 @@ impl<B: CircuitBuilder> FieldOps for CircuitElem<B> {
 		drop(builder);
 
 		for (e, out_wire) in elems.iter_mut().zip(outputs) {
-			*e = Self::make_wire(&rc, out_wire);
+			*e = Self::make_wire(&rc, out_wire, false);
 		}
 	}
 }

--- a/crates/spartan-verifier/src/wrapper/circuit_elem.rs
+++ b/crates/spartan-verifier/src/wrapper/circuit_elem.rs
@@ -77,9 +77,9 @@ pub enum CircuitElem<B: CircuitBuilder> {
 	/// A wire with a tag indicating whether its value is purely a function of public-channel
 	/// inputs (sampled challenges, observed values, constants, and other public wires).
 	///
-	/// The tag is used by [`IPVerifierChannel::compute_public_value`] to validate that
-	/// trade-in inputs are public-derived. It is propagated conservatively through arithmetic
-	/// (AND of operand tags, with `Constant` treated as public).
+	/// The tag is used by [`binius_ip::channel::IPVerifierChannel::compute_public_value`] to
+	/// validate that trade-in inputs are public-derived. It is propagated conservatively through
+	/// arithmetic (AND of operand tags, with `Constant` treated as public).
 	Wire {
 		wire: CircuitWire<B>,
 		public: bool,

--- a/crates/spartan-verifier/src/wrapper/circuit_elem.rs
+++ b/crates/spartan-verifier/src/wrapper/circuit_elem.rs
@@ -169,12 +169,13 @@ impl<B: CircuitBuilder> Add for CircuitElem<B> {
 				if matches!(&rhs, CircuitElem::Constant(c) if *c == B::Field::ZERO) {
 					return self;
 				}
+				let public = self.is_public() && rhs.is_public();
 				let rc = Self::resolve_builder(&self, &rhs);
 				let mut builder = rc.borrow_mut();
 				let a_wire = self.to_wire(&mut builder);
 				let b_wire = rhs.to_wire(&mut builder);
 				let out = builder.add(a_wire, b_wire);
-				Self::make_wire(&rc, out, false)
+				Self::make_wire(&rc, out, public)
 			}
 		}
 	}
@@ -193,12 +194,13 @@ impl<B: CircuitBuilder> Sub for CircuitElem<B> {
 				if matches!(&rhs, CircuitElem::Constant(c) if *c == B::Field::ZERO) {
 					return self;
 				}
+				let public = self.is_public() && rhs.is_public();
 				let rc = Self::resolve_builder(&self, &rhs);
 				let mut builder = rc.borrow_mut();
 				let a_wire = self.to_wire(&mut builder);
 				let b_wire = rhs.to_wire(&mut builder);
 				let out = builder.sub(a_wire, b_wire);
-				Self::make_wire(&rc, out, false)
+				Self::make_wire(&rc, out, public)
 			}
 		}
 	}
@@ -223,12 +225,13 @@ impl<B: CircuitBuilder> Mul for CircuitElem<B> {
 				if matches!(&rhs, CircuitElem::Constant(c) if *c == B::Field::ONE) {
 					return self;
 				}
+				let public = self.is_public() && rhs.is_public();
 				let rc = Self::resolve_builder(&self, &rhs);
 				let mut builder = rc.borrow_mut();
 				let a_wire = self.to_wire(&mut builder);
 				let b_wire = rhs.to_wire(&mut builder);
 				let out = builder.mul(a_wire, b_wire);
-				Self::make_wire(&rc, out, false)
+				Self::make_wire(&rc, out, public)
 			}
 		}
 	}
@@ -346,7 +349,7 @@ impl<B: CircuitBuilder> InvertOrZero for CircuitElem<B> {
 	fn invert_or_zero(self) -> Self {
 		match &self {
 			CircuitElem::Constant(c) => CircuitElem::Constant(c.invert_or_zero()),
-			CircuitElem::Wire { wire: w, .. } => {
+			CircuitElem::Wire { wire: w, public } => {
 				let rc = w.upgrade();
 				let mut builder = rc.borrow_mut();
 				let wire = w.wire;
@@ -359,7 +362,7 @@ impl<B: CircuitBuilder> InvertOrZero for CircuitElem<B> {
 				let one = builder.constant(B::Field::ONE);
 				builder.assert_eq(product, one);
 
-				Self::make_wire(&rc, inv_wire, false)
+				Self::make_wire(&rc, inv_wire, *public)
 			}
 		}
 	}
@@ -408,6 +411,7 @@ impl<B: CircuitBuilder> FieldOps for CircuitElem<B> {
 			.iter()
 			.find_map(|e| e.builder_rc())
 			.expect("at least one wire exists (not all-constants)");
+		let public = elems.iter().all(|e| e.is_public());
 		let mut builder = rc.borrow_mut();
 
 		let input_wires = elems
@@ -420,7 +424,7 @@ impl<B: CircuitBuilder> FieldOps for CircuitElem<B> {
 		drop(builder);
 
 		for (e, out_wire) in elems.iter_mut().zip(outputs) {
-			*e = Self::make_wire(&rc, out_wire, false);
+			*e = Self::make_wire(&rc, out_wire, public);
 		}
 	}
 }

--- a/crates/spartan-verifier/src/wrapper/mod.rs
+++ b/crates/spartan-verifier/src/wrapper/mod.rs
@@ -205,6 +205,14 @@ mod tests {
 		// The symbolic execution should have produced a nontrivial constraint system.
 		assert!(wrapper_cs.n_inout() > 0);
 		assert!(!wrapper_cs.mul_constraints().is_empty());
+
+		// Diagnostic — visible with `cargo test -- --nocapture`. Useful when measuring the impact
+		// of optimizations like `compute_public_value`.
+		eprintln!(
+			"wrapper CS: n_inout={}, mul_constraints={}",
+			wrapper_cs.n_inout(),
+			wrapper_cs.mul_constraints().len(),
+		);
 	}
 
 	#[test]
@@ -230,7 +238,9 @@ mod tests {
 		for (i, (elem, &exp)) in elems.iter().zip(&expected).enumerate() {
 			match elem {
 				CircuitElem::Constant(c) => assert_eq!(*c, exp, "mismatch at index {i}"),
-				CircuitElem::Wire { .. } => panic!("expected constant after all-constants transpose"),
+				CircuitElem::Wire { .. } => {
+					panic!("expected constant after all-constants transpose")
+				}
 			}
 		}
 	}

--- a/crates/spartan-verifier/src/wrapper/mod.rs
+++ b/crates/spartan-verifier/src/wrapper/mod.rs
@@ -38,7 +38,10 @@ mod tests {
 	/// Helper to create a BuildWire from a ConstraintBuilder Rc for tests.
 	fn alloc_inout_wire(rc: &Rc<std::cell::RefCell<ConstraintBuilder<B128>>>) -> BuildElem {
 		let wire = rc.borrow_mut().alloc_inout();
-		BuildElem::Wire(BuildWire::new(rc, wire))
+		BuildElem::Wire {
+			wire: BuildWire::new(rc, wire),
+			public: false,
+		}
 	}
 
 	#[test]
@@ -66,11 +69,11 @@ mod tests {
 
 		// Adding zero returns the wire unchanged.
 		let result = elem.clone() + BuildElem::Constant(B128::ZERO);
-		assert!(matches!(result, BuildElem::Wire(_)));
+		assert!(matches!(result, BuildElem::Wire { .. }));
 
 		// Multiplying by one returns the wire unchanged.
 		let result = elem.clone() * BuildElem::Constant(B128::ONE);
-		assert!(matches!(result, BuildElem::Wire(_)));
+		assert!(matches!(result, BuildElem::Wire { .. }));
 
 		// Multiplying by zero returns constant zero.
 		let result = elem * BuildElem::Constant(B128::ZERO);
@@ -123,10 +126,10 @@ mod tests {
 		let c = channel.recv_array::<3>().unwrap();
 
 		// All should be Wire variants.
-		assert!(matches!(a, BuildElem::Wire(_)));
-		assert!(matches!(b, BuildElem::Wire(_)));
+		assert!(matches!(a, BuildElem::Wire { .. }));
+		assert!(matches!(b, BuildElem::Wire { .. }));
 		for elem in &c {
-			assert!(matches!(elem, BuildElem::Wire(_)));
+			assert!(matches!(elem, BuildElem::Wire { .. }));
 		}
 	}
 
@@ -227,7 +230,7 @@ mod tests {
 		for (i, (elem, &exp)) in elems.iter().zip(&expected).enumerate() {
 			match elem {
 				CircuitElem::Constant(c) => assert_eq!(*c, exp, "mismatch at index {i}"),
-				CircuitElem::Wire(_) => panic!("expected constant after all-constants transpose"),
+				CircuitElem::Wire { .. } => panic!("expected constant after all-constants transpose"),
 			}
 		}
 	}
@@ -249,7 +252,10 @@ mod tests {
 		let rc = Rc::new(std::cell::RefCell::new(constraint_builder));
 		let mut elems: Vec<BuildElem> = inout_wires
 			.iter()
-			.map(|&w| BuildElem::Wire(BuildWire::new(&rc, w)))
+			.map(|&w| BuildElem::Wire {
+				wire: BuildWire::new(&rc, w),
+				public: false,
+			})
 			.collect();
 
 		<BuildElem as FieldOps>::square_transpose::<FSub>(&mut elems);
@@ -279,8 +285,9 @@ mod tests {
 		let witness_rc = Rc::new(std::cell::RefCell::new(witness_gen));
 		let mut witness_elems: Vec<WitnessElem> = witness_wires
 			.iter()
-			.map(|&w| {
-				WitnessElem::Wire(crate::wrapper::circuit_elem::CircuitWire::new(&witness_rc, w))
+			.map(|&w| WitnessElem::Wire {
+				wire: crate::wrapper::circuit_elem::CircuitWire::new(&witness_rc, w),
+				public: false,
 			})
 			.collect();
 

--- a/crates/spartan-verifier/src/wrapper/zk_wrapped_channel.rs
+++ b/crates/spartan-verifier/src/wrapper/zk_wrapped_channel.rs
@@ -150,7 +150,13 @@ where
 		inputs: &[F],
 		f: impl FnOnce(&[F]) -> F,
 	) -> F {
-		f(inputs)
+		// The wrapped verifier records every channel-derived value as an outer public input.
+		// `compute_public_value` materializes one inout wire on the wrapper-side constraint system,
+		// so the corresponding F value must be pushed to `public_values` exactly as if it had come
+		// from `sample` / `observe_one`.
+		let result = f(inputs);
+		self.public_values.push(result);
+		result
 	}
 }
 

--- a/crates/spartan-verifier/src/wrapper/zk_wrapped_channel.rs
+++ b/crates/spartan-verifier/src/wrapper/zk_wrapped_channel.rs
@@ -144,6 +144,14 @@ where
 		// No-op: inner assertions are checked by the outer verifier.
 		Ok(())
 	}
+
+	fn compute_public_value(
+		&mut self,
+		inputs: &[F],
+		f: impl FnOnce(&[F]) -> F,
+	) -> F {
+		f(inputs)
+	}
 }
 
 impl<F, MTScheme, Challenger_> IOPVerifierChannel<F>

--- a/crates/spartan-verifier/src/wrapper/zk_wrapped_channel.rs
+++ b/crates/spartan-verifier/src/wrapper/zk_wrapped_channel.rs
@@ -145,11 +145,7 @@ where
 		Ok(())
 	}
 
-	fn compute_public_value(
-		&mut self,
-		inputs: &[F],
-		f: impl FnOnce(&[F]) -> F,
-	) -> F {
+	fn compute_public_value(&mut self, inputs: &[F], f: impl FnOnce(&[F]) -> F) -> F {
 		// The wrapped verifier records every channel-derived value as an outer public input.
 		// `compute_public_value` materializes one inout wire on the wrapper-side constraint system,
 		// so the corresponding F value must be pushed to `public_values` exactly as if it had come


### PR DESCRIPTION
## Summary
- Adds `compute_public_value(&[Self::Elem], impl FnOnce(&[F]) -> F) -> Self::Elem` to `IPVerifierChannel`. The caller hands in elements that originated from `sample_*` / `observe_*` (or are `Constant`-derived) plus a closure that does the F-level computation; the channel returns one freshly allocated `Elem` holding the closure's result.
- Tags `CircuitElem::Wire` with a `public: bool` flag, AND-propagated through arithmetic (`Constant` treated as public). Wrapper-channel impls (`IronSpartanBuilderChannel`, `ReplayChannel`) materialize one inout wire per call; non-wrapper impls (`Elem = F`) are one-line `f(inputs)`.
- Rewrites the wiring-MLE site in `IOPVerifier::verify` to compute the batched MLE evaluation in plaintext field arithmetic via `compute_public_value`, replacing what was a forest of `CircuitElem` constraints over public-derived challenges.
- On the existing `power7` wrapper round-trip test: `mul_constraints` drop from **153 → 90** (~41%), at the cost of +1 inout wire (the materialized result). `n_inout`: 31 → 32.

## Test plan
- [x] `cargo test --workspace` (1100+ tests, including the ZK-wrapped end-to-end integration `test_zk_wrapped_prove_verify`)
- [x] `cargo clippy --all --all-features --tests --benches --examples -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test -- --nocapture test_verify_iop_builds_constraint_system` confirms the constraint-count drop
