### PR TITLE
[chore] Update sha2/sha3 to 0.11 and digest to 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,18 +43,18 @@ clap = { version = "4.5", features = ["derive"] }
 cranelift-entity = "0.121.1"
 criterion = { version = "0.7.0", default-features = false }
 derive_more = "0.99.17"
-digest = "0.10.7"
-# Pin to generic-array version before traits were marked deprecated. This is not
-# ideal, but necessary until the digest crate releases a new version with the
-# upgraded dependency.
-generic-array = "=0.14.7"
+digest = "0.11.2"
+either = "1.11.0"
 getrandom = "0.3.3"
 getset = "0.1.6"
 hex = "0.4"
 hex-literal = "1.0.0"
-either = "1.11.0"
+hmac = "0.13.0"
+hybrid-array = "0.4.7"
 itertools = "0.14.0"
-jwt-simple = { version = "0.12.12", default-features = false, features = ["pure-rust"] }
+jwt-simple = { version = "0.12.14", default-features = false, features = [
+    "pure-rust",
+] }
 k256 = "0.13.4"
 lazy_static = "1.5.0"
 num-bigint = "0.4.6"
@@ -76,9 +76,8 @@ rstest = "0.26.1"
 seq-macro = "0.3.5"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
-sha2 = "0.10.8"
-sha3 = "0.10.8"
-hmac = "0.12.1"
+sha2 = "0.11.0"
+sha3 = "0.11.0"
 insta = "1.43.1"
 petgraph = "0.8.2"
 rustc-hash = "2.1.1"
@@ -100,5 +99,5 @@ needless_range_loop = "allow"
 default.extend-words = { "typ" = "typ", "Toom" = "Toom", "inouts" = "inouts", "ceck" = "ceck" }
 default.extend-ignore-re = [
     "(?Rm)^.*(#|//)\\s*spellchecker:disable-line$",
-    "ands\\.mdx"
+    "ands\\.mdx",
 ]

--- a/crates/circuits/src/hmac.rs
+++ b/crates/circuits/src/hmac.rs
@@ -95,7 +95,7 @@ mod tests {
 	use std::{array, iter::repeat_with};
 
 	use binius_core::{verify::verify_constraints, word::Word};
-	use hmac::{Hmac, Mac};
+	use hmac::{Hmac, KeyInit, Mac};
 	use rand::{Rng, SeedableRng, rngs::StdRng};
 	use sha2::Sha512;
 

--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -30,6 +30,9 @@ peakmem-alloc = "0.2.0"
 rand.workspace = true
 sha2.workspace = true
 sha3.workspace = true
+# Pin this dependency of jwt-simple because the latest version depends on an RC for ml-dsa and is
+# causing issues.
+superboring = "=0.1.8"
 tiny-keccak = "2.0.2"
 tracing-profile.workspace = true
 tracing.workspace = true

--- a/crates/examples/src/lib.rs
+++ b/crates/examples/src/lib.rs
@@ -24,7 +24,7 @@ use binius_verifier::{
 };
 use clap::ValueEnum;
 pub use cli::Cli;
-use digest::{Digest, FixedOutputReset, Output, core_api::BlockSizeUser};
+use digest::{Digest, FixedOutputReset, Output, block_api::BlockSizeUser};
 
 #[derive(Debug, Clone, ValueEnum)]
 pub enum CompressionType {

--- a/crates/hash/Cargo.toml
+++ b/crates/hash/Cargo.toml
@@ -18,7 +18,7 @@ bytemuck.workspace = true
 bytes.workspace = true
 digest.workspace = true
 itertools.workspace = true
-sha2 = { workspace = true, features = ["compress"] }
+sha2.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 

--- a/crates/hash/src/compress.rs
+++ b/crates/hash/src/compress.rs
@@ -23,8 +23,8 @@ pub trait CompressionFunction<T, const N: usize>: PseudoCompressionFunction<T, N
 
 pub mod sha256 {
 	use bytemuck::{bytes_of_mut, must_cast};
-	use digest::{Digest, core_api::Block};
-	use sha2::{Sha256, compress256, digest::Output};
+	use digest::Digest;
+	use sha2::{Sha256, block_api::compress256, digest::Output};
 
 	use super::*;
 
@@ -46,9 +46,9 @@ pub mod sha256 {
 	impl PseudoCompressionFunction<Output<Sha256>, 2> for Sha256Compression {
 		fn compress(&self, input: [Output<Sha256>; 2]) -> Output<Sha256> {
 			let mut ret = self.initial_state;
-			let mut block = <Block<Sha256>>::default();
-			block.as_mut_slice()[..32].copy_from_slice(input[0].as_slice());
-			block.as_mut_slice()[32..].copy_from_slice(input[1].as_slice());
+			let mut block = [0u8; 64];
+			block[..32].copy_from_slice(input[0].as_slice());
+			block[32..].copy_from_slice(input[1].as_slice());
 			compress256(&mut ret, &[block]);
 			must_cast::<[u32; 8], [u8; 32]>(ret).into()
 		}

--- a/crates/hash/src/parallel_digest.rs
+++ b/crates/hash/src/parallel_digest.rs
@@ -11,7 +11,7 @@ use binius_utils::{
 	},
 };
 use bytes::BytesMut;
-use digest::{Digest, Output, core_api::BlockSizeUser};
+use digest::{Digest, Output, block_api::BlockSizeUser};
 
 use crate::HashBuffer;
 

--- a/crates/hash/src/serialization.rs
+++ b/crates/hash/src/serialization.rs
@@ -7,7 +7,7 @@ use binius_utils::{SerializationError, SerializeBytes};
 use bytes::buf::UninitSlice;
 use digest::{
 	Digest, Output,
-	core_api::{Block, BlockSizeUser},
+	block_api::{Block, BlockSizeUser},
 };
 
 /// Adapter that wraps [`Digest`] references and exposes the [`BufMut`] interface.

--- a/crates/hash/src/vision_4/digest.rs
+++ b/crates/hash/src/vision_4/digest.rs
@@ -3,8 +3,8 @@
 use binius_field::{BinaryField128bGhash as Ghash, Field};
 use binius_utils::{DeserializeBytes, SerializeBytes};
 use digest::{
-	FixedOutput, FixedOutputReset, HashMarker, OutputSizeUser, Reset, Update, consts::U32,
-	core_api::BlockSizeUser,
+	FixedOutput, FixedOutputReset, HashMarker, OutputSizeUser, Reset, Update,
+	block_api::BlockSizeUser, consts::U32,
 };
 
 use super::{constants::M, permutation::permutation};

--- a/crates/hash/src/vision_6/digest.rs
+++ b/crates/hash/src/vision_6/digest.rs
@@ -3,8 +3,8 @@
 use binius_field::{BinaryField128bGhash as Ghash, Field};
 use binius_utils::{DeserializeBytes, SerializeBytes};
 use digest::{
-	FixedOutput, FixedOutputReset, HashMarker, OutputSizeUser, Reset, Update, consts::U32,
-	core_api::BlockSizeUser,
+	FixedOutput, FixedOutputReset, HashMarker, OutputSizeUser, Reset, Update,
+	block_api::BlockSizeUser, consts::U32,
 };
 
 use super::{constants::M, permutation::permutation};

--- a/crates/iop-prover/src/merkle_tree/binary_merkle_tree.rs
+++ b/crates/iop-prover/src/merkle_tree/binary_merkle_tree.rs
@@ -11,7 +11,7 @@ use binius_utils::{
 	rand::par_rand,
 	rayon::{prelude::*, slice::ParallelSlice},
 };
-use digest::{FixedOutputReset, Output, crypto_common::BlockSizeUser};
+use digest::{FixedOutputReset, Output, block_api::BlockSizeUser};
 use rand::{CryptoRng, Rng, rngs::StdRng};
 
 /// A binary Merkle tree that commits batches of vectors.

--- a/crates/iop-prover/src/merkle_tree/prover.rs
+++ b/crates/iop-prover/src/merkle_tree/prover.rs
@@ -7,7 +7,7 @@ use binius_hash::{ParallelDigest, ParallelPseudoCompression};
 use binius_iop::merkle_tree::{BinaryMerkleTreeScheme, Commitment, Error, MerkleTreeScheme};
 use binius_transcript::{BufMut, TranscriptWriter};
 use binius_utils::rayon::iter::IndexedParallelIterator;
-use digest::{FixedOutputReset, Output, core_api::BlockSizeUser};
+use digest::{FixedOutputReset, Output, block_api::BlockSizeUser};
 use getset::Getters;
 use rand::{CryptoRng, SeedableRng, rngs::StdRng};
 

--- a/crates/iop/src/merkle_tree/scheme.rs
+++ b/crates/iop/src/merkle_tree/scheme.rs
@@ -8,7 +8,7 @@ use binius_utils::{
 	DeserializeBytes, SerializeBytes,
 	checked_arithmetics::{log2_ceil_usize, log2_strict_usize},
 };
-use digest::{Digest, Output, core_api::BlockSizeUser};
+use digest::{Digest, Output, block_api::BlockSizeUser};
 use getset::{CopyGetters, Getters};
 
 use super::{

--- a/crates/prover/benches/binary_merkle_tree.rs
+++ b/crates/prover/benches/binary_merkle_tree.rs
@@ -13,7 +13,7 @@ use binius_hash::{
 use binius_prover::merkle_tree::{MerkleTreeProver, prover::BinaryMerkleTreeProver};
 use binius_verifier::config::B128;
 use criterion::{Criterion, Throughput, criterion_group, criterion_main};
-use digest::{FixedOutputReset, Output, core_api::BlockSizeUser};
+use digest::{FixedOutputReset, Output, block_api::BlockSizeUser};
 
 const LOG_ELEMS: usize = 17;
 const LOG_ELEMS_IN_LEAF: usize = 4;

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -29,7 +29,7 @@ use binius_verifier::{
 	},
 	protocols::{bitand::AndCheckOutput, intmul::IntMulOutput, sumcheck::SumcheckOutput},
 };
-use digest::{Digest, FixedOutputReset, Output, core_api::BlockSizeUser};
+use digest::{Digest, FixedOutputReset, Output, block_api::BlockSizeUser};
 
 use super::error::Error;
 use crate::{

--- a/crates/prover/src/zk_config.rs
+++ b/crates/prover/src/zk_config.rs
@@ -20,7 +20,7 @@ use binius_spartan_verifier::{constraint_system::ConstraintSystemPadded, wrapper
 use binius_transcript::{ProverTranscript, fiat_shamir::Challenger};
 use binius_utils::SerializeBytes;
 use binius_verifier::{IOPVerifier, zk_config::ZKVerifier};
-use digest::{Digest, FixedOutputReset, Output, core_api::BlockSizeUser};
+use digest::{Digest, FixedOutputReset, Output, block_api::BlockSizeUser};
 use rand::CryptoRng;
 
 use crate::{

--- a/crates/spartan-prover/src/lib.rs
+++ b/crates/spartan-prover/src/lib.rs
@@ -66,7 +66,7 @@ use binius_utils::{
 	checked_arithmetics::checked_log_2,
 	rayon::{self, prelude::*},
 };
-use digest::{Digest, FixedOutputReset, Output, core_api::BlockSizeUser};
+use digest::{Digest, FixedOutputReset, Output, block_api::BlockSizeUser};
 pub use error::*;
 use itertools::chain;
 use rand::CryptoRng;

--- a/crates/spartan-verifier/src/lib.rs
+++ b/crates/spartan-verifier/src/lib.rs
@@ -47,7 +47,7 @@ use binius_math::{multilinear::eq::eq_ind_partial_eval_scalars, univariate::eval
 use binius_spartan_frontend::constraint_system::{ConstraintSystem, WitnessSegment};
 use binius_transcript::{VerifierTranscript, fiat_shamir::Challenger};
 use binius_utils::{DeserializeBytes, checked_arithmetics::checked_log_2};
-use digest::{Digest, Output, core_api::BlockSizeUser};
+use digest::{Digest, Output, block_api::BlockSizeUser};
 
 use crate::{
 	constraint_system::{BlindingInfo, ConstraintSystemPadded},

--- a/crates/transcript/src/fiat_shamir/hasher_challenger.rs
+++ b/crates/transcript/src/fiat_shamir/hasher_challenger.rs
@@ -5,7 +5,7 @@ use std::{cmp::min, mem};
 use bytes::{Buf, BufMut, buf::UninitSlice};
 use digest::{
 	Digest, FixedOutputReset, Output,
-	core_api::{Block, BlockSizeUser},
+	block_api::{Block, BlockSizeUser},
 };
 
 use super::Challenger;

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -13,7 +13,7 @@ array-util.workspace = true
 bytemuck = { workspace = true, features = ["extern_crate_alloc"] }
 bytes.workspace = true
 cfg-if.workspace = true
-generic-array.workspace = true
+hybrid-array.workspace = true
 itertools.workspace = true
 rand.workspace = true
 rayon = { optional = true, workspace = true}

--- a/crates/utils/src/serialization.rs
+++ b/crates/utils/src/serialization.rs
@@ -1,7 +1,7 @@
 // Copyright 2024-2025 Irreducible Inc.
 
 use bytes::{Buf, BufMut};
-use generic_array::{ArrayLength, GenericArray};
+use hybrid_array::{Array, ArraySize};
 use thiserror::Error;
 
 /// Serialize data according to Mode param
@@ -297,17 +297,17 @@ impl<T: DeserializeBytes, const N: usize> DeserializeBytes for [T; N] {
 	}
 }
 
-impl<N: ArrayLength<u8>> SerializeBytes for GenericArray<u8, N> {
+impl<U: ArraySize> SerializeBytes for Array<u8, U> {
 	fn serialize(&self, mut write_buf: impl BufMut) -> Result<(), SerializationError> {
-		assert_enough_space_for(&write_buf, N::USIZE)?;
+		assert_enough_space_for(&write_buf, U::USIZE)?;
 		write_buf.put_slice(self);
 		Ok(())
 	}
 }
 
-impl<N: ArrayLength<u8>> DeserializeBytes for GenericArray<u8, N> {
+impl<U: ArraySize> DeserializeBytes for Array<u8, U> {
 	fn deserialize(mut read_buf: impl Buf) -> Result<Self, SerializationError> {
-		assert_enough_data_for(&read_buf, N::USIZE)?;
+		assert_enough_data_for(&read_buf, U::USIZE)?;
 		let mut ret = Self::default();
 		read_buf.copy_to_slice(&mut ret);
 		Ok(ret)
@@ -335,7 +335,7 @@ pub fn assert_enough_data_for(read_buf: &impl Buf, size: usize) -> Result<(), Se
 
 #[cfg(test)]
 mod tests {
-	use generic_array::typenum::U32;
+	use hybrid_array::sizes::U32;
 	use rand::{RngCore, SeedableRng, rngs::StdRng};
 
 	use super::*;
@@ -344,13 +344,13 @@ mod tests {
 	fn test_generic_array_serialize_deserialize() {
 		let mut rng = StdRng::seed_from_u64(0);
 
-		let mut data = GenericArray::<u8, U32>::default();
+		let mut data = Array::<u8, U32>::default();
 		rng.fill_bytes(&mut data);
 
 		let mut buf = Vec::new();
 		data.serialize(&mut buf).unwrap();
 
-		let data_deserialized = GenericArray::<u8, U32>::deserialize(&mut buf.as_slice()).unwrap();
+		let data_deserialized = Array::<u8, U32>::deserialize(&mut buf.as_slice()).unwrap();
 		assert_eq!(data_deserialized, data);
 	}
 }

--- a/crates/verifier/src/verify.rs
+++ b/crates/verifier/src/verify.rs
@@ -18,7 +18,7 @@ use binius_utils::{
 	DeserializeBytes,
 	checked_arithmetics::{checked_log_2, log2_ceil_usize},
 };
-use digest::{Digest, Output, core_api::BlockSizeUser};
+use digest::{Digest, Output, block_api::BlockSizeUser};
 use itertools::chain;
 
 use super::error::Error;

--- a/crates/verifier/src/zk_config.rs
+++ b/crates/verifier/src/zk_config.rs
@@ -31,7 +31,7 @@ use binius_spartan_verifier::{
 };
 use binius_transcript::{VerifierTranscript, fiat_shamir::Challenger};
 use binius_utils::{DeserializeBytes, checked_arithmetics::log2_ceil_usize};
-use digest::{Digest, Output, core_api::BlockSizeUser};
+use digest::{Digest, Output, block_api::BlockSizeUser};
 
 use crate::{
 	config::LOG_WORDS_PER_ELEM,


### PR DESCRIPTION
## Summary
- Bumps the RustCrypto stack: digest 0.10.7 → 0.11.2 (drops the workaround `generic-array =0.14.7` pin), sha2/sha3 to 0.11, hmac to 0.13. Also adds `hybrid-array 0.4.7` and bumps jwt-simple to 0.12.14.
- Updates the few API rename sites: `digest::core_api`/`crypto_common` → `digest::block_api`, `sha2::compress256` → `sha2::block_api::compress256`, `KeyInit` import for `Hmac::new_from_slice`. Drops the `compress` feature on sha2 (no longer feature-gated). Replaces `<Block<Sha256>>::default()` with a plain `[0u8; 64]` since digest 0.11 makes the typed Block awkward to default-construct here.
- Pins `superboring = "=0.1.8"` in `binius-examples` so jwt-simple doesn't transitively pull `ml-dsa 0.1.0-rc.8`, which fails to build against the released `pkcs8 0.11.0` (it was authored against `pkcs8 0.11.0-rc.11`).

## Test plan
- `cargo build --tests` (clean, no warnings)
- `cargo test`
- `cargo clippy --all --all-features --tests --benches --examples -- -D warnings`
