### PR TITLE
[iop-prover] Replace iter::chain.collect() with extend_from_slice in commit_masked

### DIFF
--- a/crates/iop-prover/src/fri/commit.rs
+++ b/crates/iop-prover/src/fri/commit.rs
@@ -140,12 +140,11 @@ where
 			P::from_scalars(iter::chain(message.iter_scalars(), mask.iter_scalars()));
 		vec![combined_value]
 	} else {
-		// TODO: The concatenation here is sequential and a performance issue. Ideally, commit
-		// should not allocate and copy the memory into a temp buffer.
-		// TODO: At the very least, make this a parallel copy
-		iter::chain(message.as_ref(), mask.as_ref())
-			.copied()
-			.collect::<Vec<_>>()
+		// TODO: Ideally, commit should not allocate and copy the memory into a temp buffer.
+		let mut combined_values: Vec<P> = Vec::with_capacity(2 * packed_len);
+		combined_values.extend_from_slice(message.as_ref());
+		combined_values.extend_from_slice(mask.as_ref());
+		combined_values
 	};
 	let combined = FieldBuffer::new(log_len + 1, combined_values.into_boxed_slice());
 


### PR DESCRIPTION
## Summary

The TODO in \`commit_masked\` asked for at least a parallel copy of the message+mask concatenation. Benchmarking showed the actual bottleneck was Iterator machinery, not lack of parallelism — \`memcpy\` is memory-bandwidth-bound, and adding \`rayon::join\` was 2–3x slower for typical buffer sizes (thread overhead) and only 1.05–1.20x faster for very large buffers.

Switching to \`Vec::with_capacity\` + two \`extend_from_slice\` calls compiles down to two direct \`memcpy\`s, with no thread overhead, beating the original \`iter::chain(...).copied().collect()\` consistently across all sizes.

## Benchmark results (Apple Silicon, u128 elements)

| log_len | size      | iter::chain | extend_from_slice | speedup |
|---------|-----------|-------------|-------------------|---------|
| 10      | 31 KB     | 2.92 us     | 1.94 us           | 1.50x   |
| 12      | 125 KB    | 8.63 us     | 7.40 us           | 1.17x   |
| 14      | 0.5 MB    | 29.27 us    | 22.28 us          | 1.31x   |
| 16      | 2 MB      | 119.61 us   | 78.44 us          | 1.52x   |
| 18      | 8 MB      | 288.69 us   | 204.75 us         | 1.41x   |
| 20      | 32 MB     | 1020 us     | 794 us            | 1.28x   |
| 22      | 128 MB    | 3.85 ms     | 2.87 ms           | 1.34x   |
| 24      | 512 MB    | 15.59 ms    | 11.74 ms          | 1.33x   |

For comparison, a \`rayon::join\` parallel version was tested but performed worse than \`extend_from_slice\` for all sizes below 8 MB and only marginally better at very large sizes — the inherent memory-bandwidth ceiling means parallelism does not help much, while thread overhead hurts.

The remaining TODO (\"commit should not allocate and copy into a temp buffer\") is preserved because eliminating the allocation requires a broader refactor of \`commit_interleaved\`'s API to accept multiple slices.

## Test plan

- [x] \`cargo test -p binius-iop-prover --lib\` — 26/26 pass
- [x] \`cargo clippy -p binius-iop-prover --tests\` — clean
- [x] \`cargo +nightly-2026-01-01 fmt -- --check\` — clean
- [x] Benchmarked across 8 buffer sizes (31 KB → 512 MB), every size shows ≥ 1.17x speedup over the original