### PR TITLE
Revert [spartan] compute_public_value challenges/field eval (#1465)

### DIFF
--- a/crates/iop/src/basefold_channel.rs
+++ b/crates/iop/src/basefold_channel.rs
@@ -153,10 +153,6 @@ where
 			Err(binius_ip::channel::Error::InvalidAssert)
 		}
 	}
-
-	fn compute_public_value(&mut self, inputs: &[F], f: impl FnOnce(&[F]) -> F) -> F {
-		f(inputs)
-	}
 }
 
 impl<F, MerkleScheme_, Challenger_> IOPVerifierChannel<F>

--- a/crates/iop/src/basefold_zk_channel.rs
+++ b/crates/iop/src/basefold_zk_channel.rs
@@ -141,10 +141,6 @@ where
 			Err(binius_ip::channel::Error::InvalidAssert)
 		}
 	}
-
-	fn compute_public_value(&mut self, inputs: &[F], f: impl FnOnce(&[F]) -> F) -> F {
-		f(inputs)
-	}
 }
 
 impl<F, MerkleScheme_, Challenger_> IOPVerifierChannel<F>

--- a/crates/iop/src/naive_channel.rs
+++ b/crates/iop/src/naive_channel.rs
@@ -133,10 +133,6 @@ where
 			Err(binius_ip::channel::Error::InvalidAssert)
 		}
 	}
-
-	fn compute_public_value(&mut self, inputs: &[F], f: impl FnOnce(&[F]) -> F) -> F {
-		f(inputs)
-	}
 }
 
 impl<F, Challenger_> IOPVerifierChannel<F> for NaiveVerifierChannel<'_, F, Challenger_>

--- a/crates/iop/src/size_tracking_channel.rs
+++ b/crates/iop/src/size_tracking_channel.rs
@@ -115,10 +115,6 @@ impl<F: BinaryField, MerkleScheme_: MerkleTreeScheme<F>> IPVerifierChannel<F>
 	fn assert_zero(&mut self, _val: F) -> Result<(), binius_ip::channel::Error> {
 		Ok(())
 	}
-
-	fn compute_public_value(&mut self, inputs: &[F], f: impl FnOnce(&[F]) -> F) -> F {
-		f(inputs)
-	}
 }
 
 impl<F: BinaryField, MerkleScheme_: MerkleTreeScheme<F>> IOPVerifierChannel<F>

--- a/crates/ip/src/channel.rs
+++ b/crates/ip/src/channel.rs
@@ -83,29 +83,6 @@ pub trait IPVerifierChannel<F: Field> {
 	///
 	/// Returns [`Error::InvalidAssert`] if the value is not zero.
 	fn assert_zero(&mut self, val: Self::Elem) -> Result<(), Error>;
-
-	/// Computes a value that is a function of public-channel-derived elements and returns it
-	/// as a freshly allocated `Elem`.
-	///
-	/// In wrapper channels that build constraints (e.g. `IronSpartanBuilderChannel`), the result
-	/// is materialized as a single inout wire holding the closure's return value, replacing what
-	/// would otherwise be a sub-circuit's worth of constraints. In non-wrapper channels where
-	/// `Elem = F`, the impl is just `f(inputs)`.
-	///
-	/// The caller MUST ensure each entry in `inputs` is either a `Constant` or a `Wire` whose
-	/// public-tag is true — i.e. produced by `sample_*` / `observe_*` / `compute_public_value`
-	/// on this channel, or derived purely from such values via the channel's `Elem` arithmetic.
-	/// Inputs from `recv_*` (or anything that mixed in a non-public value) MUST NOT be passed.
-	/// The contract is documented; wrapper impls debug-assert it but it is not statically enforced.
-	///
-	/// The closure may or may not be invoked: the symbolic-builder channel skips it, and other
-	/// impls run it on either real or dummy values. Callers must therefore supply a pure function
-	/// with no observable side effects.
-	fn compute_public_value(
-		&mut self,
-		inputs: &[Self::Elem],
-		f: impl FnOnce(&[F]) -> F,
-	) -> Self::Elem;
 }
 
 impl<F, Challenger_> IPVerifierChannel<F> for VerifierTranscript<Challenger_>
@@ -149,10 +126,6 @@ where
 		} else {
 			Err(Error::InvalidAssert)
 		}
-	}
-
-	fn compute_public_value(&mut self, inputs: &[F], f: impl FnOnce(&[F]) -> F) -> F {
-		f(inputs)
 	}
 }
 

--- a/crates/spartan-verifier/src/lib.rs
+++ b/crates/spartan-verifier/src/lib.rs
@@ -33,8 +33,6 @@ pub mod constraint_system;
 pub mod wiring;
 pub mod wrapper;
 
-use std::slice;
-
 use binius_field::{BinaryField, Field, field::FieldOps};
 use binius_hash::PseudoCompressionFunction;
 use binius_iop::{
@@ -191,33 +189,8 @@ impl<F: Field> IOPVerifier<F> {
 
 		// Compute rₓ^⊤ (M_A + λ M_B + λ² M_C) x
 		let r_x_tensor = eq_ind_partial_eval_scalars(&r_x);
-
-		// The public-segment contribution to the operand evaluations is purely a function of
-		// public-channel inputs (the public scalars, λ, and rₓ). Trade in those Elems for plain
-		// field values, run the MLE evaluation in plaintext, and materialize the result as a
-		// single inout wire instead of building the entire sub-circuit.
-		let public_eval = {
-			let public_len = public.len();
-			let inputs = [
-				public.as_slice(),
-				slice::from_ref(&lambda),
-				r_x_tensor.as_ref(),
-			]
-			.concat();
-
-			let mul_constraints = cs.mul_constraints();
-			channel.compute_public_value(&inputs, move |vals| {
-				let public_vals = &vals[..public_len];
-				let lambda_val = vals[public_len];
-				let r_x_tensor_vals = &vals[public_len + 1..];
-				evaluate_wiring_mle_public(
-					mul_constraints,
-					public_vals,
-					lambda_val,
-					r_x_tensor_vals,
-				)
-			})
-		};
+		let public_eval =
+			evaluate_wiring_mle_public(cs.mul_constraints(), &public, lambda.clone(), &r_x_tensor);
 
 		// Prover sends the precommit segment's contribution to the operand evaluations.
 		let precommit_claim = channel.recv_one()?;

--- a/crates/spartan-verifier/src/wrapper/channel.rs
+++ b/crates/spartan-verifier/src/wrapper/channel.rs
@@ -35,26 +35,14 @@ impl<F: Field> IronSpartanBuilderChannel<F> {
 		}
 	}
 
-	/// Allocates a fresh inout wire, tagged public.
-	///
-	/// Inout wires from `recv_one` start out public-tagged here too, but the result of `recv_one`
-	/// is `inout - key` where `key` is precommit (public: false), so the AND-propagation in `Sub`
-	/// makes the recv'd value non-public — exactly as it should be. Treating every alloc_inout
-	/// as public-tagged simplifies the API and is sound under that propagation.
 	fn alloc_inout_elem(&self) -> CircuitElem<ConstraintBuilder<F>> {
 		let wire = self.builder.borrow_mut().alloc_inout();
-		CircuitElem::Wire {
-			wire: CircuitWire::new(&self.builder, wire),
-			public: true,
-		}
+		CircuitElem::Wire(CircuitWire::new(&self.builder, wire))
 	}
 
 	fn alloc_precommit_elem(&self) -> CircuitElem<ConstraintBuilder<F>> {
 		let wire = self.builder.borrow_mut().alloc_precommit();
-		CircuitElem::Wire {
-			wire: CircuitWire::new(&self.builder, wire),
-			public: false,
-		}
+		CircuitElem::Wire(CircuitWire::new(&self.builder, wire))
 	}
 
 	/// Consumes the channel and returns the underlying [`ConstraintBuilder`].
@@ -75,8 +63,6 @@ impl<F: Field> IPVerifierChannel<F> for IronSpartanBuilderChannel<F> {
 		// For each element that the inner prover sends, the wrapped prover allocates a one-time-pad
 		// encryption key in the precommit segment and encrypts the underlying value before sending.
 		// Here the verifier gets the encryption key from the precommit segment and decrypts.
-		// `inout` is tagged public; subtracting the (non-public) `key` AND-propagates the result to
-		// non-public, which is the correct tag for a recv'd value.
 		let inout = self.alloc_inout_elem();
 		let key = self.alloc_precommit_elem();
 		Ok(inout - key)
@@ -94,26 +80,11 @@ impl<F: Field> IPVerifierChannel<F> for IronSpartanBuilderChannel<F> {
 		match val {
 			CircuitElem::Constant(c) if c == F::ZERO => Ok(()),
 			CircuitElem::Constant(_) => Err(binius_ip::channel::Error::InvalidAssert),
-			CircuitElem::Wire { wire, .. } => {
-				self.builder.borrow_mut().assert_zero(wire.wire());
+			CircuitElem::Wire(w) => {
+				self.builder.borrow_mut().assert_zero(w.wire());
 				Ok(())
 			}
 		}
-	}
-
-	fn compute_public_value(
-		&mut self,
-		inputs: &[Self::Elem],
-		_f: impl FnOnce(&[F]) -> F,
-	) -> Self::Elem {
-		// In builder mode there is nothing to compute — the closure result would be a function of
-		// dummy zeros. We skip running it entirely and only validate the input contract. The
-		// trait documents that the closure may or may not be invoked and must therefore be a
-		// pure function with no observable side effects.
-		for input in inputs {
-			debug_assert!(input.is_public(), "compute_public_value: input is not public");
-		}
-		self.alloc_inout_elem()
 	}
 }
 
@@ -172,11 +143,6 @@ impl<'a, F: Field> ReplayChannel<'a, F> {
 		}
 	}
 
-	/// Allocates the next inout slot, writes its value, and returns it tagged public.
-	///
-	/// See [`IronSpartanBuilderChannel::alloc_inout_elem`] for why every alloc_inout result is
-	/// tagged public regardless of whether the caller is `recv_one` (which subtracts a non-public
-	/// key) or `sample` / `observe_one` / `verify_oracle_relations`.
 	fn next_inout_elem(&mut self) -> CircuitElem<WitnessGenerator<'a, F>> {
 		let value = self
 			.events
@@ -186,10 +152,7 @@ impl<'a, F: Field> ReplayChannel<'a, F> {
 		let wire = ConstraintWire::inout(self.next_inout_id);
 		self.next_inout_id += 1;
 		let witness_wire = self.witness_gen.borrow_mut().write_inout(wire, value);
-		CircuitElem::Wire {
-			wire: CircuitWire::new(&self.witness_gen, witness_wire),
-			public: true,
-		}
+		CircuitElem::Wire(CircuitWire::new(&self.witness_gen, witness_wire))
 	}
 
 	fn next_precommit_elem(&mut self) -> CircuitElem<WitnessGenerator<'a, F>> {
@@ -201,10 +164,7 @@ impl<'a, F: Field> ReplayChannel<'a, F> {
 		let wire = ConstraintWire::precommit(self.next_precommit_id);
 		self.next_precommit_id += 1;
 		let witness_wire = self.witness_gen.borrow_mut().write_precommit(wire, value);
-		CircuitElem::Wire {
-			wire: CircuitWire::new(&self.witness_gen, witness_wire),
-			public: false,
-		}
+		CircuitElem::Wire(CircuitWire::new(&self.witness_gen, witness_wire))
 	}
 
 	/// Consumes the channel and builds the outer witness.
@@ -237,35 +197,10 @@ impl<'a, F: Field> IPVerifierChannel<F> for ReplayChannel<'a, F> {
 		match val {
 			CircuitElem::Constant(c) if c == F::ZERO => Ok(()),
 			CircuitElem::Constant(_) => Err(binius_ip::channel::Error::InvalidAssert),
-			CircuitElem::Wire { wire, .. } => {
-				self.witness_gen.borrow_mut().assert_zero(wire.wire());
+			CircuitElem::Wire(w) => {
+				self.witness_gen.borrow_mut().assert_zero(w.wire());
 				Ok(())
 			}
-		}
-	}
-
-	fn compute_public_value(
-		&mut self,
-		inputs: &[Self::Elem],
-		f: impl FnOnce(&[F]) -> F,
-	) -> Self::Elem {
-		let values: Vec<F> = inputs
-			.iter()
-			.map(|e| match e {
-				CircuitElem::Constant(c) => *c,
-				CircuitElem::Wire { wire, public } => {
-					debug_assert!(*public, "compute_public_value: input is not public");
-					wire.wire().val()
-				}
-			})
-			.collect();
-		let result = f(&values);
-		let cwire = ConstraintWire::inout(self.next_inout_id);
-		self.next_inout_id += 1;
-		let witness_wire = self.witness_gen.borrow_mut().write_inout(cwire, result);
-		CircuitElem::Wire {
-			wire: CircuitWire::new(&self.witness_gen, witness_wire),
-			public: true,
 		}
 	}
 }

--- a/crates/spartan-verifier/src/wrapper/circuit_elem.rs
+++ b/crates/spartan-verifier/src/wrapper/circuit_elem.rs
@@ -74,26 +74,14 @@ impl<B: CircuitBuilder> CircuitWire<B> {
 /// [`WitnessGenerator`]: binius_spartan_frontend::circuit_builder::WitnessGenerator
 pub enum CircuitElem<B: CircuitBuilder> {
 	Constant(B::Field),
-	/// A wire with a tag indicating whether its value is purely a function of public-channel
-	/// inputs (sampled challenges, observed values, constants, and other public wires).
-	///
-	/// The tag is used by [`binius_ip::channel::IPVerifierChannel::compute_public_value`] to
-	/// validate that trade-in inputs are public-derived. It is propagated conservatively through
-	/// arithmetic (AND of operand tags, with `Constant` treated as public).
-	Wire {
-		wire: CircuitWire<B>,
-		public: bool,
-	},
+	Wire(CircuitWire<B>),
 }
 
 impl<B: CircuitBuilder> Clone for CircuitElem<B> {
 	fn clone(&self) -> Self {
 		match self {
 			CircuitElem::Constant(c) => CircuitElem::Constant(*c),
-			CircuitElem::Wire { wire, public } => CircuitElem::Wire {
-				wire: wire.clone(),
-				public: *public,
-			},
+			CircuitElem::Wire(w) => CircuitElem::Wire(w.clone()),
 		}
 	}
 }
@@ -103,16 +91,7 @@ impl<B: CircuitBuilder> CircuitElem<B> {
 	fn builder_rc(&self) -> Option<Rc<RefCell<B>>> {
 		match self {
 			CircuitElem::Constant(_) => None,
-			CircuitElem::Wire { wire, .. } => Some(wire.upgrade()),
-		}
-	}
-
-	/// Returns whether this element is purely a function of public-channel inputs.
-	/// `Constant` is treated as public.
-	pub(crate) fn is_public(&self) -> bool {
-		match self {
-			CircuitElem::Constant(_) => true,
-			CircuitElem::Wire { public, .. } => *public,
+			CircuitElem::Wire(w) => Some(w.upgrade()),
 		}
 	}
 
@@ -132,18 +111,15 @@ impl<B: CircuitBuilder> CircuitElem<B> {
 	fn to_wire(&self, builder: &mut B) -> B::Wire {
 		match self {
 			CircuitElem::Constant(val) => builder.constant(*val),
-			CircuitElem::Wire { wire, .. } => wire.wire,
+			CircuitElem::Wire(w) => w.wire,
 		}
 	}
 
-	fn make_wire(rc: &Rc<RefCell<B>>, wire: B::Wire, public: bool) -> Self {
-		CircuitElem::Wire {
-			wire: CircuitWire {
-				builder: Rc::downgrade(rc),
-				wire,
-			},
-			public,
-		}
+	fn make_wire(rc: &Rc<RefCell<B>>, wire: B::Wire) -> Self {
+		CircuitElem::Wire(CircuitWire {
+			builder: Rc::downgrade(rc),
+			wire,
+		})
 	}
 }
 
@@ -169,13 +145,12 @@ impl<B: CircuitBuilder> Add for CircuitElem<B> {
 				if matches!(&rhs, CircuitElem::Constant(c) if *c == B::Field::ZERO) {
 					return self;
 				}
-				let public = self.is_public() && rhs.is_public();
 				let rc = Self::resolve_builder(&self, &rhs);
 				let mut builder = rc.borrow_mut();
 				let a_wire = self.to_wire(&mut builder);
 				let b_wire = rhs.to_wire(&mut builder);
 				let out = builder.add(a_wire, b_wire);
-				Self::make_wire(&rc, out, public)
+				Self::make_wire(&rc, out)
 			}
 		}
 	}
@@ -194,13 +169,12 @@ impl<B: CircuitBuilder> Sub for CircuitElem<B> {
 				if matches!(&rhs, CircuitElem::Constant(c) if *c == B::Field::ZERO) {
 					return self;
 				}
-				let public = self.is_public() && rhs.is_public();
 				let rc = Self::resolve_builder(&self, &rhs);
 				let mut builder = rc.borrow_mut();
 				let a_wire = self.to_wire(&mut builder);
 				let b_wire = rhs.to_wire(&mut builder);
 				let out = builder.sub(a_wire, b_wire);
-				Self::make_wire(&rc, out, public)
+				Self::make_wire(&rc, out)
 			}
 		}
 	}
@@ -225,13 +199,12 @@ impl<B: CircuitBuilder> Mul for CircuitElem<B> {
 				if matches!(&rhs, CircuitElem::Constant(c) if *c == B::Field::ONE) {
 					return self;
 				}
-				let public = self.is_public() && rhs.is_public();
 				let rc = Self::resolve_builder(&self, &rhs);
 				let mut builder = rc.borrow_mut();
 				let a_wire = self.to_wire(&mut builder);
 				let b_wire = rhs.to_wire(&mut builder);
 				let out = builder.mul(a_wire, b_wire);
-				Self::make_wire(&rc, out, public)
+				Self::make_wire(&rc, out)
 			}
 		}
 	}
@@ -349,7 +322,7 @@ impl<B: CircuitBuilder> InvertOrZero for CircuitElem<B> {
 	fn invert_or_zero(self) -> Self {
 		match &self {
 			CircuitElem::Constant(c) => CircuitElem::Constant(c.invert_or_zero()),
-			CircuitElem::Wire { wire: w, public } => {
+			CircuitElem::Wire(w) => {
 				let rc = w.upgrade();
 				let mut builder = rc.borrow_mut();
 				let wire = w.wire;
@@ -362,7 +335,7 @@ impl<B: CircuitBuilder> InvertOrZero for CircuitElem<B> {
 				let one = builder.constant(B::Field::ONE);
 				builder.assert_eq(product, one);
 
-				Self::make_wire(&rc, inv_wire, *public)
+				Self::make_wire(&rc, inv_wire)
 			}
 		}
 	}
@@ -396,7 +369,7 @@ impl<B: CircuitBuilder> FieldOps for CircuitElem<B> {
 				.iter()
 				.map(|e| match e {
 					CircuitElem::Constant(c) => *c,
-					CircuitElem::Wire { .. } => unreachable!(),
+					CircuitElem::Wire(_) => unreachable!(),
 				})
 				.collect::<Vec<_>>();
 			<B::Field as ExtensionField<FSub>>::square_transpose(&mut vals);
@@ -411,7 +384,6 @@ impl<B: CircuitBuilder> FieldOps for CircuitElem<B> {
 			.iter()
 			.find_map(|e| e.builder_rc())
 			.expect("at least one wire exists (not all-constants)");
-		let public = elems.iter().all(|e| e.is_public());
 		let mut builder = rc.borrow_mut();
 
 		let input_wires = elems
@@ -424,7 +396,7 @@ impl<B: CircuitBuilder> FieldOps for CircuitElem<B> {
 		drop(builder);
 
 		for (e, out_wire) in elems.iter_mut().zip(outputs) {
-			*e = Self::make_wire(&rc, out_wire, public);
+			*e = Self::make_wire(&rc, out_wire);
 		}
 	}
 }

--- a/crates/spartan-verifier/src/wrapper/mod.rs
+++ b/crates/spartan-verifier/src/wrapper/mod.rs
@@ -38,10 +38,7 @@ mod tests {
 	/// Helper to create a BuildWire from a ConstraintBuilder Rc for tests.
 	fn alloc_inout_wire(rc: &Rc<std::cell::RefCell<ConstraintBuilder<B128>>>) -> BuildElem {
 		let wire = rc.borrow_mut().alloc_inout();
-		BuildElem::Wire {
-			wire: BuildWire::new(rc, wire),
-			public: false,
-		}
+		BuildElem::Wire(BuildWire::new(rc, wire))
 	}
 
 	#[test]
@@ -69,11 +66,11 @@ mod tests {
 
 		// Adding zero returns the wire unchanged.
 		let result = elem.clone() + BuildElem::Constant(B128::ZERO);
-		assert!(matches!(result, BuildElem::Wire { .. }));
+		assert!(matches!(result, BuildElem::Wire(_)));
 
 		// Multiplying by one returns the wire unchanged.
 		let result = elem.clone() * BuildElem::Constant(B128::ONE);
-		assert!(matches!(result, BuildElem::Wire { .. }));
+		assert!(matches!(result, BuildElem::Wire(_)));
 
 		// Multiplying by zero returns constant zero.
 		let result = elem * BuildElem::Constant(B128::ZERO);
@@ -126,10 +123,10 @@ mod tests {
 		let c = channel.recv_array::<3>().unwrap();
 
 		// All should be Wire variants.
-		assert!(matches!(a, BuildElem::Wire { .. }));
-		assert!(matches!(b, BuildElem::Wire { .. }));
+		assert!(matches!(a, BuildElem::Wire(_)));
+		assert!(matches!(b, BuildElem::Wire(_)));
 		for elem in &c {
-			assert!(matches!(elem, BuildElem::Wire { .. }));
+			assert!(matches!(elem, BuildElem::Wire(_)));
 		}
 	}
 
@@ -205,14 +202,6 @@ mod tests {
 		// The symbolic execution should have produced a nontrivial constraint system.
 		assert!(wrapper_cs.n_inout() > 0);
 		assert!(!wrapper_cs.mul_constraints().is_empty());
-
-		// Diagnostic — visible with `cargo test -- --nocapture`. Useful when measuring the impact
-		// of optimizations like `compute_public_value`.
-		eprintln!(
-			"wrapper CS: n_inout={}, mul_constraints={}",
-			wrapper_cs.n_inout(),
-			wrapper_cs.mul_constraints().len(),
-		);
 	}
 
 	#[test]
@@ -238,9 +227,7 @@ mod tests {
 		for (i, (elem, &exp)) in elems.iter().zip(&expected).enumerate() {
 			match elem {
 				CircuitElem::Constant(c) => assert_eq!(*c, exp, "mismatch at index {i}"),
-				CircuitElem::Wire { .. } => {
-					panic!("expected constant after all-constants transpose")
-				}
+				CircuitElem::Wire(_) => panic!("expected constant after all-constants transpose"),
 			}
 		}
 	}
@@ -262,10 +249,7 @@ mod tests {
 		let rc = Rc::new(std::cell::RefCell::new(constraint_builder));
 		let mut elems: Vec<BuildElem> = inout_wires
 			.iter()
-			.map(|&w| BuildElem::Wire {
-				wire: BuildWire::new(&rc, w),
-				public: false,
-			})
+			.map(|&w| BuildElem::Wire(BuildWire::new(&rc, w)))
 			.collect();
 
 		<BuildElem as FieldOps>::square_transpose::<FSub>(&mut elems);
@@ -295,9 +279,8 @@ mod tests {
 		let witness_rc = Rc::new(std::cell::RefCell::new(witness_gen));
 		let mut witness_elems: Vec<WitnessElem> = witness_wires
 			.iter()
-			.map(|&w| WitnessElem::Wire {
-				wire: crate::wrapper::circuit_elem::CircuitWire::new(&witness_rc, w),
-				public: false,
+			.map(|&w| {
+				WitnessElem::Wire(crate::wrapper::circuit_elem::CircuitWire::new(&witness_rc, w))
 			})
 			.collect();
 

--- a/crates/spartan-verifier/src/wrapper/zk_wrapped_channel.rs
+++ b/crates/spartan-verifier/src/wrapper/zk_wrapped_channel.rs
@@ -144,16 +144,6 @@ where
 		// No-op: inner assertions are checked by the outer verifier.
 		Ok(())
 	}
-
-	fn compute_public_value(&mut self, inputs: &[F], f: impl FnOnce(&[F]) -> F) -> F {
-		// The wrapped verifier records every channel-derived value as an outer public input.
-		// `compute_public_value` materializes one inout wire on the wrapper-side constraint system,
-		// so the corresponding F value must be pushed to `public_values` exactly as if it had come
-		// from `sample` / `observe_one`.
-		let result = f(inputs);
-		self.public_values.push(result);
-		result
-	}
 }
 
 impl<F, MTScheme, Challenger_> IOPVerifierChannel<F>


### PR DESCRIPTION
## Summary
- Reverts commit 115108d5 (PR #1465, [spartan] compute_public_value: trade in challenges for plain field eval).

## Test plan
- [ ] cargo test --workspace
- [ ] cargo clippy --all --all-features --tests --benches --examples -- -D warnings
