### PR TITLE
[chore] Update rand to 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ paste = "1.0.15"
 pest = "2.8.1"
 pest_derive = "2.8.1"
 proptest = { version = "1.2.0", default-features = false, features = ["std"] }
-rand = { version = "0.9.1", default-features = false, features = [
+rand = { version = "0.10.1", default-features = false, features = [
     "std",
     "std_rng",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ criterion = { version = "0.7.0", default-features = false }
 derive_more = "0.99.17"
 digest = "0.11.2"
 either = "1.11.0"
-getrandom = "0.3.3"
+getrandom = "0.4.0"
 getset = "0.1.6"
 hex = "0.4"
 hex-literal = "1.0.0"

--- a/crates/arith-bench/src/arch/aarch64.rs
+++ b/crates/arith-bench/src/arch/aarch64.rs
@@ -1,6 +1,7 @@
 // Copyright 2025 Irreducible Inc.
 use std::arch::aarch64::*;
 
+use rand::prelude::*;
 use seq_macro::seq;
 
 use crate::underlier::{PackedUnderlier, Underlier};
@@ -31,9 +32,7 @@ impl Underlier for uint64x2_t {
 		}
 	}
 
-	fn random(mut rng: impl rand::RngCore) -> Self {
-		use rand::Rng;
-
+	fn random(mut rng: impl Rng) -> Self {
 		let value: u128 = rng.random();
 		unsafe { std::mem::transmute::<_, uint64x2_t>(value) }
 	}

--- a/crates/arith-bench/src/arch/x86_64.rs
+++ b/crates/arith-bench/src/arch/x86_64.rs
@@ -1,6 +1,7 @@
 // Copyright 2025 Irreducible Inc.
 use std::arch::x86_64::*;
 
+use rand::prelude::*;
 use seq_macro::seq;
 
 use crate::underlier::{PackedUnderlier, Underlier};
@@ -32,7 +33,7 @@ impl Underlier for __m128i {
 		}
 	}
 
-	fn random(mut rng: impl rand::RngCore) -> Self {
+	fn random(mut rng: impl Rng) -> Self {
 		let mut bytes = [0u8; 16];
 		rng.fill_bytes(&mut bytes);
 		unsafe { _mm_loadu_si128(bytes.as_ptr() as *const __m128i) }
@@ -239,7 +240,7 @@ impl Underlier for __m256i {
 		}
 	}
 
-	fn random(mut rng: impl rand::RngCore) -> Self {
+	fn random(mut rng: impl Rng) -> Self {
 		let mut bytes = [0u8; 32];
 		rng.fill_bytes(&mut bytes);
 		unsafe { _mm256_loadu_si256(bytes.as_ptr() as *const __m256i) }

--- a/crates/arith-bench/src/underlier.rs
+++ b/crates/arith-bench/src/underlier.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 Irreducible Inc.
 use std::fmt::Debug;
 
-use rand::RngCore;
+use rand::prelude::*;
 
 /// A type that supports bitwise operations and has a known bit width.
 ///
@@ -40,7 +40,7 @@ pub trait Underlier: Sized + Clone + Copy + Debug {
 	fn is_equal(a: Self, b: Self) -> bool;
 
 	/// Generates a random value of this underlier type using the provided rng.
-	fn random(rng: impl RngCore) -> Self;
+	fn random(rng: impl Rng) -> Self;
 }
 
 impl<U: Underlier, const N: usize> Underlier for [U; N] {
@@ -74,7 +74,7 @@ impl<U: Underlier, const N: usize> Underlier for [U; N] {
 		a.iter().zip(b.iter()).all(|(x, y)| U::is_equal(*x, *y))
 	}
 
-	fn random(mut rng: impl RngCore) -> Self {
+	fn random(mut rng: impl Rng) -> Self {
 		std::array::from_fn(|_| U::random(&mut rng))
 	}
 }
@@ -215,9 +215,7 @@ macro_rules! impl_underlier_for_native_uint {
 			}
 
 			#[inline]
-			fn random(mut rng: impl RngCore) -> Self {
-				use rand::Rng;
-
+			fn random(mut rng: impl Rng) -> Self {
 				rng.random()
 			}
 		}

--- a/crates/circuits/src/bignum/tests.rs
+++ b/crates/circuits/src/bignum/tests.rs
@@ -7,7 +7,7 @@ use binius_frontend::{
 };
 use num_integer::Integer;
 use proptest::prelude::*;
-use rand::{SeedableRng, rngs::StdRng};
+use rand::prelude::*;
 
 use super::*;
 

--- a/crates/circuits/src/bitcoin/p2pkh_signature.rs
+++ b/crates/circuits/src/bitcoin/p2pkh_signature.rs
@@ -138,8 +138,7 @@ mod tests {
 	use binius_core::{verify::verify_constraints, word::Word};
 	use bitcoin::PublicKey;
 	use bitcoin_hashes::Hash;
-	use proptest::prelude::RngCore;
-	use rand::{SeedableRng, rngs::StdRng};
+	use rand::prelude::*;
 
 	use super::*;
 
@@ -168,7 +167,7 @@ mod tests {
 	}
 
 	/// Convenience to produce a random pair (privkey_be, compressed_pubkey)
-	pub fn gen_priv_pub_pair_from_rng(mut rng: impl RngCore) -> ([u8; 32], [u8; 33]) {
+	pub fn gen_priv_pub_pair_from_rng(mut rng: impl Rng) -> ([u8; 32], [u8; 33]) {
 		let mut sk_be = [0u8; 32];
 		rng.fill_bytes(&mut sk_be);
 		let pk_comp = compressed_pubkey_from_be_sk(sk_be);

--- a/crates/circuits/src/blake2b/tests.rs
+++ b/crates/circuits/src/blake2b/tests.rs
@@ -9,7 +9,7 @@
 mod blake2b_tests {
 	use binius_core::verify::verify_constraints;
 	use binius_frontend::CircuitBuilder;
-	use rand::{Rng, SeedableRng, rngs::StdRng};
+	use rand::prelude::*;
 
 	use crate::blake2b::{
 		BLOCK_BYTES,

--- a/crates/circuits/src/blake2s/tests.rs
+++ b/crates/circuits/src/blake2s/tests.rs
@@ -3,7 +3,7 @@
 use binius_core::verify::verify_constraints;
 use binius_frontend::CircuitBuilder;
 use blake2::{Blake2s256, Digest};
-use rand::{RngCore, SeedableRng, rngs::StdRng};
+use rand::prelude::*;
 use rstest::rstest;
 
 use super::Blake2s;

--- a/crates/circuits/src/hash_based_sig/hashing/chain.rs
+++ b/crates/circuits/src/hash_based_sig/hashing/chain.rs
@@ -380,8 +380,7 @@ mod tests {
 			chain_index in 0u64..=1000,
 			position in 0u64..=1000,
 		) {
-			use rand::SeedableRng;
-			use rand::prelude::StdRng;
+			use rand::prelude::*;
 
 			let mut rng = StdRng::seed_from_u64(0);
 

--- a/crates/circuits/src/hash_based_sig/hashing/message.rs
+++ b/crates/circuits/src/hash_based_sig/hashing/message.rs
@@ -396,8 +396,7 @@ mod tests {
 			nonce_len in 1usize..=50,
 			message_len in 1usize..=200,
 		) {
-			use rand::SeedableRng;
-			use rand::prelude::StdRng;
+			use rand::prelude::*;
 
 			let mut rng = StdRng::seed_from_u64(0);
 

--- a/crates/circuits/src/hash_based_sig/hashing/public_key.rs
+++ b/crates/circuits/src/hash_based_sig/hashing/public_key.rs
@@ -325,8 +325,7 @@ mod tests {
 			domain_param_len in 1usize..=100,
 			num_hashes in 1usize..=10,
 		) {
-			use rand::SeedableRng;
-			use rand::prelude::StdRng;
+			use rand::prelude::*;
 
 			let mut rng = StdRng::seed_from_u64(0);
 

--- a/crates/circuits/src/hash_based_sig/hashing/tree.rs
+++ b/crates/circuits/src/hash_based_sig/hashing/tree.rs
@@ -408,8 +408,7 @@ mod tests {
 			level in 0u32..=20,
 			index in 0u32..=1000,
 		) {
-			use rand::SeedableRng;
-			use rand::prelude::StdRng;
+			use rand::prelude::*;
 
 			let mut rng = StdRng::seed_from_u64(0);
 

--- a/crates/circuits/src/hash_based_sig/winternitz_ots.rs
+++ b/crates/circuits/src/hash_based_sig/winternitz_ots.rs
@@ -441,7 +441,7 @@ pub fn grind_nonce(
 	param: &[u8],
 	message: &[u8],
 ) -> Option<GrindResult> {
-	use rand::RngCore;
+	use rand::prelude::*;
 
 	use super::{codeword::extract_coordinates, hashing::hash_message};
 
@@ -473,7 +473,7 @@ pub fn grind_nonce(
 mod tests {
 	use binius_core::verify::verify_constraints;
 	use binius_frontend::util::pack_bytes_into_wires_le;
-	use rand::{RngCore, SeedableRng, rngs::StdRng};
+	use rand::prelude::*;
 	use sha3::{Digest, Keccak256};
 
 	use super::*;

--- a/crates/circuits/src/hash_based_sig/witness_utils.rs
+++ b/crates/circuits/src/hash_based_sig/witness_utils.rs
@@ -6,7 +6,7 @@
 
 use binius_core::Word;
 use binius_frontend::{WitnessFiller, util::pack_bytes_into_wires_le};
-use rand::{RngCore, rngs::StdRng};
+use rand::prelude::*;
 use sha3::{Digest, Keccak256};
 
 use super::{

--- a/crates/circuits/src/hash_based_sig/xmss.rs
+++ b/crates/circuits/src/hash_based_sig/xmss.rs
@@ -122,7 +122,7 @@ pub fn circuit_xmss(
 mod tests {
 	use binius_core::{Word, verify::verify_constraints};
 	use binius_frontend::util::pack_bytes_into_wires_le;
-	use rand::{RngCore, SeedableRng, rngs::StdRng};
+	use rand::prelude::*;
 	use rstest::rstest;
 
 	use super::*;

--- a/crates/circuits/src/hash_based_sig/xmss_aggregate.rs
+++ b/crates/circuits/src/hash_based_sig/xmss_aggregate.rs
@@ -121,7 +121,7 @@ mod tests {
 
 	use binius_core::{Word, verify::verify_constraints};
 	use binius_frontend::util::pack_bytes_into_wires_le;
-	use rand::{RngCore, SeedableRng, rngs::StdRng};
+	use rand::prelude::*;
 	use rstest::rstest;
 
 	use super::*;

--- a/crates/circuits/src/hmac.rs
+++ b/crates/circuits/src/hmac.rs
@@ -96,7 +96,7 @@ mod tests {
 
 	use binius_core::{verify::verify_constraints, word::Word};
 	use hmac::{Hmac, KeyInit, Mac};
-	use rand::{Rng, SeedableRng, rngs::StdRng};
+	use rand::prelude::*;
 	use sha2::Sha512;
 
 	use super::*;

--- a/crates/circuits/src/keccak/fixed_length.rs
+++ b/crates/circuits/src/keccak/fixed_length.rs
@@ -118,7 +118,7 @@ pub fn keccak256(
 mod tests {
 	use binius_core::verify::verify_constraints;
 	use binius_frontend::CircuitBuilder;
-	use rand::{RngCore, SeedableRng, rngs::StdRng};
+	use rand::prelude::*;
 	use rstest::rstest;
 	use sha3::{Digest, Keccak256};
 

--- a/crates/circuits/src/keccak/mod.rs
+++ b/crates/circuits/src/keccak/mod.rs
@@ -298,7 +298,7 @@ impl Keccak256 {
 mod tests {
 	use binius_core::verify::verify_constraints;
 	use binius_frontend::{CircuitBuilder, Wire};
-	use rand::{RngCore, SeedableRng, rngs::StdRng};
+	use rand::prelude::*;
 	use rstest::rstest;
 	use sha3::Digest;
 

--- a/crates/circuits/src/keccak/permutation.rs
+++ b/crates/circuits/src/keccak/permutation.rs
@@ -178,7 +178,7 @@ impl Permutation {
 mod tests {
 	use binius_core::{verify::verify_constraints, word::Word};
 	use binius_frontend::CircuitBuilder;
-	use rand::{Rng, SeedableRng, rngs::StdRng};
+	use rand::prelude::*;
 
 	use super::*;
 

--- a/crates/circuits/src/rs256.rs
+++ b/crates/circuits/src/rs256.rs
@@ -440,7 +440,7 @@ mod tests {
 	use binius_core::verify::verify_constraints;
 	use hex_literal::hex;
 	use num_bigint::BigUint;
-	use rand::{SeedableRng, TryRngCore, rngs::StdRng};
+	use rand::{TryRng, prelude::*};
 	use rsa::{
 		BigUint as RsaBigUint, RsaPrivateKey, RsaPublicKey,
 		sha2::{Digest, Sha256},

--- a/crates/circuits/src/sha256/mod.rs
+++ b/crates/circuits/src/sha256/mod.rs
@@ -1087,7 +1087,7 @@ mod tests {
 
 	#[test]
 	fn test_sha256_fixed_various_sizes() {
-		use rand::{Rng, SeedableRng, rngs::StdRng};
+		use rand::prelude::*;
 
 		// Test various message sizes to ensure padding works correctly
 		let sizes = vec![

--- a/crates/circuits/src/sha512/mod.rs
+++ b/crates/circuits/src/sha512/mod.rs
@@ -1120,7 +1120,7 @@ mod tests {
 
 	#[test]
 	fn test_sha512_fixed_various_sizes() {
-		use rand::{Rng, SeedableRng, rngs::StdRng};
+		use rand::prelude::*;
 
 		// Test various message sizes to ensure padding works correctly
 		let sizes = vec![

--- a/crates/core/src/constraint_system.rs
+++ b/crates/core/src/constraint_system.rs
@@ -1126,7 +1126,7 @@ impl<'a> std::ops::Deref for Proof<'a> {
 
 #[cfg(test)]
 mod serialization_tests {
-	use rand::{RngCore, SeedableRng, rngs::StdRng};
+	use rand::prelude::*;
 
 	use super::*;
 

--- a/crates/examples/src/circuits/bitcoin_p2pkh.rs
+++ b/crates/examples/src/circuits/bitcoin_p2pkh.rs
@@ -11,7 +11,7 @@ use binius_frontend::{CircuitBuilder, Wire, WitnessFiller};
 use bitcoin::{Network, PrivateKey, secp256k1::Secp256k1};
 use bitcoin_hashes::Hash;
 use clap::Args;
-use rand::{RngCore, SeedableRng, rngs::StdRng};
+use rand::prelude::*;
 
 use crate::ExampleCircuit;
 

--- a/crates/examples/src/circuits/blake3_compress.rs
+++ b/crates/examples/src/circuits/blake3_compress.rs
@@ -5,7 +5,7 @@ use binius_circuits::blake3::blake3_compress_2x;
 use binius_core::word::Word;
 use binius_frontend::{CircuitBuilder, Wire, WitnessFiller};
 use clap::Args;
-use rand::{RngCore, SeedableRng, rngs::StdRng};
+use rand::prelude::*;
 
 use super::utils::DEFAULT_RANDOM_SEED;
 use crate::ExampleCircuit;

--- a/crates/examples/src/circuits/ethsign.rs
+++ b/crates/examples/src/circuits/ethsign.rs
@@ -12,7 +12,7 @@ use binius_frontend::{
 };
 use clap::Args;
 use ethsign::SecretKey;
-use rand::{Rng, SeedableRng, rngs::StdRng};
+use rand::prelude::*;
 use tiny_keccak::{Hasher, Keccak as KeccakHasher};
 
 use crate::ExampleCircuit;

--- a/crates/examples/src/circuits/hashsign.rs
+++ b/crates/examples/src/circuits/hashsign.rs
@@ -10,7 +10,7 @@ use binius_circuits::hash_based_sig::{
 use binius_core::Word;
 use binius_frontend::{CircuitBuilder, Wire, WitnessFiller, util::pack_bytes_into_wires_le};
 use clap::Args;
-use rand::{RngCore, SeedableRng, rngs::StdRng};
+use rand::prelude::*;
 
 use crate::ExampleCircuit;
 

--- a/crates/examples/src/circuits/utils.rs
+++ b/crates/examples/src/circuits/utils.rs
@@ -2,7 +2,7 @@
 //! Utilities for hash circuit examples
 
 use anyhow::{Result, ensure};
-use rand::{RngCore, SeedableRng, rngs::StdRng};
+use rand::prelude::*;
 
 /// Default message size for hash circuit examples (1 KiB)
 ///

--- a/crates/examples/src/circuits/zklogin.rs
+++ b/crates/examples/src/circuits/zklogin.rs
@@ -548,13 +548,7 @@ struct JwtGenerationResult {
 }
 
 impl JwtGenerationResult {
-	fn generate(
-		sub: &str,
-		aud: &str,
-		iss: &str,
-		salt: &str,
-		rng: &mut impl RngCore,
-	) -> Result<Self> {
+	fn generate(sub: &str, aud: &str, iss: &str, salt: &str, rng: &mut impl Rng) -> Result<Self> {
 		// Generate VK_u (verifier public key)
 		let mut vk_u = [0u8; 32];
 		rng.fill_bytes(&mut vk_u);

--- a/crates/field/Cargo.toml
+++ b/crates/field/Cargo.toml
@@ -24,6 +24,7 @@ paste.workspace = true
 proptest.workspace = true
 rand = { workspace = true, features = ["thread_rng"] }
 
+# See https://github.com/rust-random/rand#webassembly-support
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 getrandom = { workspace = true, features = ["wasm_js"] }
 

--- a/crates/field/src/arch/aarch64/m128.rs
+++ b/crates/field/src/arch/aarch64/m128.rs
@@ -11,10 +11,7 @@ use binius_utils::{
 	serialization::{assert_enough_data_for, assert_enough_space_for},
 };
 use bytemuck::{Pod, Zeroable};
-use rand::{
-	Rng,
-	distr::{Distribution, StandardUniform},
-};
+use rand::{distr::StandardUniform, prelude::*};
 use seq_macro::seq;
 
 use super::super::portable::{
@@ -740,7 +737,6 @@ impl<U: NumCast<u128>> NumCast<M128> for U {
 #[cfg(test)]
 mod tests {
 	use binius_utils::bytes::BytesMut;
-	use rand::{Rng, SeedableRng, rngs::StdRng};
 
 	use super::*;
 

--- a/crates/field/src/arch/portable/univariate_mul_utils_128.rs
+++ b/crates/field/src/arch/portable/univariate_mul_utils_128.rs
@@ -154,7 +154,7 @@ pub fn spread_bits_64(val: u64) -> u128 {
 }
 #[cfg(test)]
 mod tests {
-	use rand::{Rng, SeedableRng, rngs::StdRng};
+	use rand::prelude::*;
 
 	use super::*;
 

--- a/crates/field/src/arch/wasm32/m128.rs
+++ b/crates/field/src/arch/wasm32/m128.rs
@@ -12,7 +12,7 @@ use binius_utils::{
 };
 use bytemuck::{Pod, Zeroable};
 use derive_more::{From, Into};
-use rand::{Rng, RngCore};
+use rand::prelude::*;
 
 use crate::{
 	BinaryField, Random,
@@ -250,7 +250,7 @@ impl Shr<usize> for M128 {
 }
 
 impl Random for M128 {
-	fn random(mut rng: impl RngCore) -> Self {
+	fn random(mut rng: impl Rng) -> Self {
 		let val: u128 = rng.random();
 		val.into()
 	}
@@ -378,7 +378,7 @@ impl<Scalar: BinaryField> From<PackedPrimitiveType<M128, Scalar>> for u128 {
 
 #[cfg(test)]
 mod tests {
-	use rand::{SeedableRng, rngs::StdRng};
+	use rand::prelude::*;
 
 	use super::*;
 

--- a/crates/field/src/arch/x86_64/m128.rs
+++ b/crates/field/src/arch/x86_64/m128.rs
@@ -13,8 +13,8 @@ use binius_utils::{
 };
 use bytemuck::{Pod, Zeroable};
 use rand::{
-	Rng,
 	distr::{Distribution, StandardUniform},
+	prelude::*,
 };
 use seq_macro::seq;
 
@@ -998,7 +998,7 @@ impl Divisible<u8> for M128 {
 mod tests {
 	use binius_utils::bytes::BytesMut;
 	use proptest::{arbitrary::any, proptest};
-	use rand::{SeedableRng, rngs::StdRng};
+	use rand::prelude::*;
 
 	use super::*;
 

--- a/crates/field/src/arch/x86_64/m256.rs
+++ b/crates/field/src/arch/x86_64/m256.rs
@@ -13,10 +13,7 @@ use binius_utils::{
 };
 use bytemuck::{Pod, Zeroable};
 use cfg_if::cfg_if;
-use rand::{
-	Rng,
-	distr::{Distribution, StandardUniform},
-};
+use rand::{distr::StandardUniform, prelude::*};
 
 use crate::{
 	BinaryField,

--- a/crates/field/src/arch/x86_64/m512.rs
+++ b/crates/field/src/arch/x86_64/m512.rs
@@ -12,10 +12,7 @@ use binius_utils::{
 	serialization::{assert_enough_data_for, assert_enough_space_for},
 };
 use bytemuck::{Pod, Zeroable};
-use rand::{
-	Rng,
-	distr::{Distribution, StandardUniform},
-};
+use rand::{distr::StandardUniform, prelude::*};
 
 use crate::{
 	BinaryField,

--- a/crates/field/src/binary_field.rs
+++ b/crates/field/src/binary_field.rs
@@ -238,7 +238,7 @@ macro_rules! binary_field {
 
 		impl ::rand::distr::Distribution<$name> for ::rand::distr::StandardUniform {
 			fn sample<R: ::rand::Rng + ?Sized>(&self, rng: &mut R) -> $name {
-				$name(rng.random())
+				$name(::rand::distr::StandardUniform.sample(rng))
 			}
 		}
 

--- a/crates/field/src/linear_transformation.rs
+++ b/crates/field/src/linear_transformation.rs
@@ -2,7 +2,7 @@
 
 use std::{iter, marker::PhantomData, ops::BitXor};
 
-use rand::RngCore;
+use rand::prelude::*;
 
 use crate::{
 	BinaryField, BinaryField1b, ExtensionField, UnderlierWithBitOps, WithUnderlier,
@@ -65,7 +65,7 @@ impl<IF: BinaryField, OF: BinaryField, Data: AsRef<[OF]> + Sync> Transformation<
 }
 
 impl<OF: BinaryField> FieldLinearTransformation<OF, Vec<OF>> {
-	pub fn random(mut rng: impl RngCore) -> Self {
+	pub fn random(mut rng: impl Rng) -> Self {
 		Self {
 			bases: (0..OF::DEGREE).map(|_| OF::random(&mut rng)).collect(),
 			_pd: PhantomData,

--- a/crates/field/src/packed.rs
+++ b/crates/field/src/packed.rs
@@ -482,7 +482,7 @@ impl<PT> PackedBinaryField for PT where PT: PackedField<Scalar: BinaryField> {}
 #[cfg(test)]
 mod tests {
 	use itertools::Itertools;
-	use rand::{Rng, RngCore, SeedableRng, rngs::StdRng};
+	use rand::prelude::*;
 
 	use super::*;
 	use crate::{
@@ -532,7 +532,7 @@ mod tests {
 		test.run::<PackedBinaryGhash4x128b>();
 	}
 
-	fn check_value_iteration<P: PackedField>(mut rng: impl RngCore) {
+	fn check_value_iteration<P: PackedField>(mut rng: impl Rng) {
 		let packed = P::random(&mut rng);
 		let mut iter = packed.iter();
 		for i in 0..P::WIDTH {
@@ -541,7 +541,7 @@ mod tests {
 		assert!(iter.next().is_none());
 	}
 
-	fn check_ref_iteration<P: PackedField>(mut rng: impl RngCore) {
+	fn check_ref_iteration<P: PackedField>(mut rng: impl Rng) {
 		let packed = P::random(&mut rng);
 		let mut iter = packed.into_iter();
 		for i in 0..P::WIDTH {
@@ -550,7 +550,7 @@ mod tests {
 		assert!(iter.next().is_none());
 	}
 
-	fn check_slice_iteration<P: PackedField>(mut rng: impl RngCore) {
+	fn check_slice_iteration<P: PackedField>(mut rng: impl Rng) {
 		for len in [0, 1, 5] {
 			let packed = std::iter::repeat_with(|| P::random(&mut rng))
 				.take(len)

--- a/crates/field/src/random.rs
+++ b/crates/field/src/random.rs
@@ -1,6 +1,9 @@
 // Copyright 2024-2025 Irreducible Inc.
 
-use rand::distr::{Distribution, StandardUniform};
+use rand::{
+	distr::{Distribution, StandardUniform},
+	prelude::*,
+};
 
 /// A value that can be randomly generated
 pub trait Random {

--- a/crates/field/src/underlier/small_uint.rs
+++ b/crates/field/src/underlier/small_uint.rs
@@ -15,8 +15,8 @@ use binius_utils::{
 use bytemuck::{NoUninit, Zeroable};
 use derive_more::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign};
 use rand::{
-	Rng,
 	distr::{Distribution, StandardUniform},
+	prelude::*,
 };
 
 use super::{UnderlierType, underlier_with_bit_ops::UnderlierWithBitOps};

--- a/crates/frontend/ceck/src/randblast.rs
+++ b/crates/frontend/ceck/src/randblast.rs
@@ -5,7 +5,7 @@ use binius_core::{
 	verify::verify_constraints,
 	word::Word,
 };
-use rand::{Rng, SeedableRng, rngs::StdRng};
+use rand::prelude::*;
 
 pub struct RandBlast {
 	rng: StdRng,

--- a/crates/frontend/src/compiler/gate/assert_non_zero.rs
+++ b/crates/frontend/src/compiler/gate/assert_non_zero.rs
@@ -108,7 +108,7 @@ pub fn emit_eval_bytecode(
 #[cfg(test)]
 mod tests {
 	use binius_core::{verify::verify_constraints, word::Word};
-	use rand::{RngCore, SeedableRng, rngs::StdRng};
+	use rand::prelude::*;
 
 	use crate::compiler::CircuitBuilder;
 

--- a/crates/frontend/src/compiler/gate/bxor_multi.rs
+++ b/crates/frontend/src/compiler/gate/bxor_multi.rs
@@ -61,7 +61,7 @@ pub fn emit_eval_bytecode(
 #[cfg(test)]
 mod tests {
 	use binius_core::word::Word;
-	use rand::{Rng, SeedableRng, rngs::StdRng};
+	use rand::prelude::*;
 
 	use crate::compiler::CircuitBuilder;
 

--- a/crates/frontend/src/compiler/gate/select.rs
+++ b/crates/frontend/src/compiler/gate/select.rs
@@ -70,7 +70,7 @@ pub fn emit_eval_bytecode(
 #[cfg(test)]
 mod tests {
 	use binius_core::{verify::verify_constraints, word::Word};
-	use rand::{RngCore, SeedableRng, rngs::StdRng};
+	use rand::prelude::*;
 
 	use crate::compiler::CircuitBuilder;
 

--- a/crates/frontend/src/compiler/tests.rs
+++ b/crates/frontend/src/compiler/tests.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 Irreducible Inc.
 use binius_core::{verify::verify_constraints, word::Word};
 use proptest::prelude::*;
-use rand::{Rng, SeedableRng as _, rngs::StdRng};
+use rand::{RngExt, SeedableRng, rngs::StdRng};
 
 use super::*;
 use crate::util::num_biguint_from_u64_limbs;

--- a/crates/hash/src/parallel_compression.rs
+++ b/crates/hash/src/parallel_compression.rs
@@ -97,7 +97,7 @@ where
 mod tests {
 	use std::mem::MaybeUninit;
 
-	use rand::{Rng, SeedableRng, rngs::StdRng};
+	use rand::prelude::*;
 
 	use super::*;
 

--- a/crates/hash/src/parallel_digest.rs
+++ b/crates/hash/src/parallel_digest.rs
@@ -184,7 +184,7 @@ mod tests {
 		consts::{U1, U32},
 	};
 	use itertools::izip;
-	use rand::{RngCore, SeedableRng, rngs::StdRng};
+	use rand::prelude::*;
 
 	use super::*;
 

--- a/crates/hash/src/vision.rs
+++ b/crates/hash/src/vision.rs
@@ -148,7 +148,7 @@ mod tests {
 	use std::mem::MaybeUninit;
 
 	use digest::Digest;
-	use rand::{Rng, SeedableRng, rngs::StdRng};
+	use rand::prelude::*;
 
 	use super::*;
 

--- a/crates/hash/src/vision_4/parallel_compression.rs
+++ b/crates/hash/src/vision_4/parallel_compression.rs
@@ -199,7 +199,7 @@ mod tests {
 
 	#[test]
 	fn test_parallel_compress_large_batch() {
-		use rand::{Rng, SeedableRng, rngs::StdRng};
+		use rand::prelude::*;
 
 		let parallel = VisionParallelCompression::default();
 		let mut rng = StdRng::seed_from_u64(0);

--- a/crates/hash/src/vision_4/parallel_digest.rs
+++ b/crates/hash/src/vision_4/parallel_digest.rs
@@ -157,7 +157,7 @@ mod tests {
 	use std::mem::MaybeUninit;
 
 	use digest::Digest;
-	use rand::{Rng, SeedableRng, rngs::StdRng};
+	use rand::prelude::*;
 
 	use super::*;
 

--- a/crates/hash/src/vision_6/parallel_digest.rs
+++ b/crates/hash/src/vision_6/parallel_digest.rs
@@ -157,7 +157,7 @@ mod tests {
 	use std::mem::MaybeUninit;
 
 	use digest::Digest;
-	use rand::{Rng, SeedableRng, rngs::StdRng};
+	use rand::prelude::*;
 
 	use super::*;
 

--- a/crates/ip-prover/src/fracaddcheck.rs
+++ b/crates/ip-prover/src/fracaddcheck.rs
@@ -198,7 +198,7 @@ mod tests {
 	use binius_transcript::{ProverTranscript, fiat_shamir::HasherChallenger};
 
 	type StdChallenger = HasherChallenger<sha2::Sha256>;
-	use rand::{SeedableRng, rngs::StdRng};
+	use rand::prelude::*;
 
 	use super::*;
 

--- a/crates/ip-prover/src/prodcheck.rs
+++ b/crates/ip-prover/src/prodcheck.rs
@@ -356,7 +356,7 @@ mod tests {
 	use binius_utils::checked_arithmetics::log2_ceil_usize;
 
 	type StdChallenger = HasherChallenger<sha2::Sha256>;
-	use rand::{SeedableRng, rngs::StdRng};
+	use rand::prelude::*;
 
 	use super::*;
 

--- a/crates/ip-prover/src/sumcheck/batch.rs
+++ b/crates/ip-prover/src/sumcheck/batch.rs
@@ -254,7 +254,7 @@ mod tests {
 	use binius_transcript::{ProverTranscript, fiat_shamir::HasherChallenger};
 
 	type StdChallenger = HasherChallenger<sha2::Sha256>;
-	use rand::{SeedableRng, prelude::StdRng};
+	use rand::prelude::*;
 
 	use super::{Error, batch_prove_mle};
 	use crate::sumcheck::bivariate_product_mle;

--- a/crates/ip-prover/src/sumcheck/bivariate_product.rs
+++ b/crates/ip-prover/src/sumcheck/bivariate_product.rs
@@ -133,7 +133,7 @@ mod tests {
 	use binius_transcript::{ProverTranscript, fiat_shamir::HasherChallenger};
 
 	type StdChallenger = HasherChallenger<sha2::Sha256>;
-	use rand::{SeedableRng, prelude::StdRng};
+	use rand::prelude::*;
 
 	use super::*;
 	use crate::sumcheck::prove::prove_single;

--- a/crates/ip-prover/src/sumcheck/bivariate_product_mle.rs
+++ b/crates/ip-prover/src/sumcheck/bivariate_product_mle.rs
@@ -80,7 +80,7 @@ mod tests {
 
 	type StdChallenger = HasherChallenger<sha2::Sha256>;
 	use itertools::{self, Itertools};
-	use rand::{SeedableRng, prelude::StdRng};
+	use rand::prelude::*;
 
 	use super::*;
 	use crate::sumcheck::{MleToSumCheckDecorator, prove::prove_single, prove_single_mlecheck};

--- a/crates/ip-prover/src/sumcheck/frac_add_mle.rs
+++ b/crates/ip-prover/src/sumcheck/frac_add_mle.rs
@@ -49,7 +49,7 @@ mod tests {
 
 	type StdChallenger = HasherChallenger<sha2::Sha256>;
 	use itertools::{Itertools, izip};
-	use rand::{SeedableRng, prelude::StdRng};
+	use rand::prelude::*;
 
 	use super::*;
 	use crate::sumcheck::{MleToSumCheckDecorator, batch::batch_prove, common::SumcheckProver};

--- a/crates/ip-prover/src/sumcheck/quadratic_mle.rs
+++ b/crates/ip-prover/src/sumcheck/quadratic_mle.rs
@@ -261,7 +261,7 @@ mod tests {
 
 	type StdChallenger = HasherChallenger<sha2::Sha256>;
 	use itertools::{self, Itertools};
-	use rand::{SeedableRng, prelude::StdRng};
+	use rand::prelude::*;
 
 	use super::*;
 	use crate::sumcheck::prove_single_mlecheck;

--- a/crates/ip-prover/src/sumcheck/rerand_mle.rs
+++ b/crates/ip-prover/src/sumcheck/rerand_mle.rs
@@ -218,7 +218,7 @@ mod tests {
 	};
 	use binius_utils::{bitwise::BitSelector, random_access_sequence::RandomAccessSequence};
 	use itertools::Itertools;
-	use rand::{Rng, SeedableRng, rngs::StdRng};
+	use rand::prelude::*;
 
 	use super::*;
 	use crate::sumcheck::bivariate_product_multi_mle::BivariateProductMultiMlecheckProver;

--- a/crates/ip-prover/src/sumcheck/selector_mle.rs
+++ b/crates/ip-prover/src/sumcheck/selector_mle.rs
@@ -259,7 +259,7 @@ mod tests {
 		test_utils::{Packed128b, random_scalars},
 	};
 	use itertools::Itertools;
-	use rand::{Rng, SeedableRng, rngs::StdRng};
+	use rand::prelude::*;
 
 	use super::*;
 	use crate::sumcheck::{

--- a/crates/ip-prover/src/sumcheck/zk_mlecheck.rs
+++ b/crates/ip-prover/src/sumcheck/zk_mlecheck.rs
@@ -450,7 +450,7 @@ mod tests {
 	use binius_transcript::{ProverTranscript, fiat_shamir::HasherChallenger};
 
 	type StdChallenger = HasherChallenger<sha2::Sha256>;
-	use rand::{SeedableRng, prelude::StdRng};
+	use rand::prelude::*;
 
 	use super::*;
 	use crate::sumcheck::prove_single_mlecheck;

--- a/crates/math/src/batch_invert.rs
+++ b/crates/math/src/batch_invert.rs
@@ -250,7 +250,7 @@ mod tests {
 		assert!(n_zeros <= n, "n_zeros must be <= n");
 
 		// Sample indices for zeros without replacement
-		let zero_indices: Vec<usize> = (0..n).choose_multiple(rng, n_zeros);
+		let zero_indices: Vec<usize> = (0..n).sample(rng, n_zeros);
 
 		// Create state vector with zeros at sampled indices
 		let mut state = Vec::with_capacity(n);

--- a/crates/math/src/matrix.rs
+++ b/crates/math/src/matrix.rs
@@ -8,7 +8,7 @@ use std::{
 use binius_field::{ExtensionField, Field};
 use bytemuck::zeroed_slice_box;
 use getset::CopyGetters;
-use rand::RngCore;
+use rand::prelude::*;
 
 /// A matrix over a field.
 #[derive(Debug, Clone, PartialEq, Eq, CopyGetters)]
@@ -60,7 +60,7 @@ impl<F: Field> Matrix<F> {
 		&self.elements
 	}
 
-	pub fn random(m: usize, n: usize, mut rng: impl RngCore) -> Self {
+	pub fn random(m: usize, n: usize, mut rng: impl Rng) -> Self {
 		Self {
 			m,
 			n,
@@ -245,7 +245,7 @@ impl<F: Field> SubAssign<&Self> for Matrix<F> {
 #[cfg(test)]
 mod tests {
 	use proptest::prelude::*;
-	use rand::{SeedableRng, rngs::StdRng};
+	use rand::prelude::*;
 
 	use super::*;
 	use crate::test_utils::B128;

--- a/crates/math/src/multilinear/evaluate.rs
+++ b/crates/math/src/multilinear/evaluate.rs
@@ -141,7 +141,7 @@ pub fn evaluate_inplace_scalars<F: FieldOps>(
 
 #[cfg(test)]
 mod tests {
-	use rand::{RngCore, SeedableRng, rngs::StdRng};
+	use rand::prelude::*;
 
 	use super::*;
 	use crate::{

--- a/crates/math/src/test_utils.rs
+++ b/crates/math/src/test_utils.rs
@@ -3,7 +3,7 @@
 use std::iter::repeat_with;
 
 use binius_field::{BinaryField128bGhash, Field, PackedBinaryGhash4x128b, PackedField};
-use rand::RngCore;
+use rand::prelude::*;
 
 use crate::FieldBuffer;
 
@@ -23,7 +23,7 @@ pub type Packed128b = PackedBinaryGhash4x128b;
 /// # Returns
 ///
 /// Vector containing n random field elements
-pub fn random_scalars<F: Field>(mut rng: impl RngCore, n: usize) -> Vec<F> {
+pub fn random_scalars<F: Field>(mut rng: impl Rng, n: usize) -> Vec<F> {
 	repeat_with(|| F::random(&mut rng)).take(n).collect()
 }
 
@@ -37,7 +37,7 @@ pub fn random_scalars<F: Field>(mut rng: impl RngCore, n: usize) -> Vec<F> {
 /// # Returns
 ///
 /// Vector containing `2^log_n` random field elements
-pub fn random_field_buffer<P: PackedField>(mut rng: impl RngCore, log_n: usize) -> FieldBuffer<P> {
+pub fn random_field_buffer<P: PackedField>(mut rng: impl Rng, log_n: usize) -> FieldBuffer<P> {
 	FieldBuffer::<P>::new(
 		log_n,
 		repeat_with(|| P::random(&mut rng))
@@ -90,7 +90,7 @@ pub fn index_to_hypercube_point<F: Field>(n_vars: usize, index: usize) -> Vec<F>
 mod tests {
 	use binius_field::BinaryField128bGhash as B128;
 	use proptest::prelude::*;
-	use rand::{SeedableRng, rngs::StdRng};
+	use rand::prelude::*;
 
 	use super::*;
 

--- a/crates/prover/benches/and_reduction.rs
+++ b/crates/prover/benches/and_reduction.rs
@@ -27,7 +27,7 @@ use binius_verifier::{
 	protocols::bitand::{ROWS_PER_HYPERCUBE_VERTEX, SKIPPED_VARS},
 };
 use criterion::{Criterion, Throughput, criterion_group, criterion_main};
-use rand::{Rng, SeedableRng, rngs::StdRng};
+use rand::prelude::*;
 
 fn bench(c: &mut Criterion) {
 	let log_num_rows = 27;

--- a/crates/prover/benches/fold_words.rs
+++ b/crates/prover/benches/fold_words.rs
@@ -5,7 +5,7 @@ use binius_math::test_utils::random_scalars;
 use binius_prover::fold_word::fold_words;
 use binius_verifier::config::{B128, WORD_SIZE_BITS};
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
-use rand::Rng;
+use rand::prelude::*;
 
 fn bench_fold_words(c: &mut Criterion) {
 	let mut group = c.benchmark_group("fold_words");

--- a/crates/prover/benches/intmul.rs
+++ b/crates/prover/benches/intmul.rs
@@ -5,7 +5,7 @@ use binius_transcript::ProverTranscript;
 use binius_utils::rayon::ThreadPoolBuilder;
 use binius_verifier::config::StdChallenger;
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
-use rand::{Rng, SeedableRng, rngs::StdRng};
+use rand::prelude::*;
 
 type P = PackedBinaryGhash1x128b;
 

--- a/crates/prover/benches/vision.rs
+++ b/crates/prover/benches/vision.rs
@@ -21,7 +21,7 @@ use criterion::{
 	BenchmarkGroup, Criterion, Throughput, criterion_group, criterion_main, measurement::WallTime,
 };
 use digest::Digest;
-use rand::{RngCore, rngs::ThreadRng};
+use rand::prelude::*;
 
 fn bench_parallel_permutation_for_size<const N: usize, const MN: usize>(
 	group: &mut BenchmarkGroup<WallTime>,

--- a/crates/prover/src/and_reduction/prover.rs
+++ b/crates/prover/src/and_reduction/prover.rs
@@ -291,7 +291,7 @@ mod test {
 		config::{B128, StdChallenger},
 		protocols::bitand::{AndCheckOutput, SKIPPED_VARS, verify_with_channel},
 	};
-	use rand::{Rng, SeedableRng, rngs::StdRng};
+	use rand::prelude::*;
 
 	use super::OblongZerocheckProver;
 	use crate::fold_word::fold_words_with_transform;

--- a/crates/prover/src/and_reduction/sumcheck_round_messages.rs
+++ b/crates/prover/src/and_reduction/sumcheck_round_messages.rs
@@ -177,7 +177,7 @@ mod test {
 		protocols::bitand::{ROWS_PER_HYPERCUBE_VERTEX, SKIPPED_VARS},
 	};
 	use itertools::izip;
-	use rand::{Rng, SeedableRng, rngs::StdRng};
+	use rand::prelude::*;
 
 	use super::univariate_round_message_extension_domain;
 	use crate::{

--- a/crates/prover/src/fold_word.rs
+++ b/crates/prover/src/fold_word.rs
@@ -75,7 +75,7 @@ mod tests {
 	use binius_core::consts::WORD_SIZE_BITS;
 	use binius_math::test_utils::random_scalars;
 	use binius_verifier::config::B128;
-	use rand::{Rng, SeedableRng, rngs::StdRng};
+	use rand::prelude::*;
 
 	use super::*;
 

--- a/crates/prover/src/protocols/intmul/tests.rs
+++ b/crates/prover/src/protocols/intmul/tests.rs
@@ -9,7 +9,7 @@ use binius_verifier::{
 	protocols::intmul::{common::IntMulOutput, verify},
 };
 use itertools::izip;
-use rand::{Rng, SeedableRng, rngs::StdRng};
+use rand::prelude::*;
 
 use super::{prove::IntMulProver, witness::Witness};
 use crate::fold_word::fold_words;

--- a/crates/prover/src/protocols/intmul/witness.rs
+++ b/crates/prover/src/protocols/intmul/witness.rs
@@ -445,7 +445,7 @@ mod tests {
 
 	#[test]
 	fn test_forwards_multiple_random() {
-		use rand::{Rng, SeedableRng, rngs::StdRng};
+		use rand::prelude::*;
 
 		let mut rng = StdRng::seed_from_u64(0);
 

--- a/crates/spartan-prover/src/wiring.rs
+++ b/crates/spartan-prover/src/wiring.rs
@@ -246,7 +246,7 @@ mod tests {
 		MulConstraint, Operand, WitnessIndex, WitnessSegment,
 	};
 	use binius_spartan_verifier::wiring::evaluate_segment_wiring_mle;
-	use rand::{Rng, SeedableRng, rngs::StdRng};
+	use rand::prelude::*;
 	use smallvec::SmallVec;
 
 	use super::*;

--- a/crates/utils/src/random_access_sequence.rs
+++ b/crates/utils/src/random_access_sequence.rs
@@ -235,7 +235,7 @@ impl<T: Copy, Inner: RandomAccessSequence<T>> RandomAccessSequence<T>
 mod tests {
 	use std::fmt::Debug;
 
-	use rand::{Rng, SeedableRng, rngs::StdRng};
+	use rand::prelude::*;
 
 	use super::*;
 

--- a/crates/utils/src/serialization.rs
+++ b/crates/utils/src/serialization.rs
@@ -336,7 +336,7 @@ pub fn assert_enough_data_for(read_buf: &impl Buf, size: usize) -> Result<(), Se
 #[cfg(test)]
 mod tests {
 	use hybrid_array::sizes::U32;
-	use rand::{RngCore, SeedableRng, rngs::StdRng};
+	use rand::prelude::*;
 
 	use super::*;
 

--- a/crates/verifier/src/protocols/shift/monster.rs
+++ b/crates/verifier/src/protocols/shift/monster.rs
@@ -237,7 +237,7 @@ mod tests {
 		test_utils::{index_to_hypercube_point, random_scalars},
 		univariate::lagrange_evals_scalars,
 	};
-	use rand::{Rng, SeedableRng, rngs::StdRng};
+	use rand::prelude::*;
 
 	use super::*;
 


### PR DESCRIPTION
Migrate the workspace from rand 0.9 to 0.10.

The 0.10 release moves RngCore out of the crate root and splits Rng into Rng + RngExt, so call sites that use random(), random_range(), or fill() now require RngExt in scope. Switch internal uses to `rand::prelude::*` and use explicit imports where proptest::prelude (still on rand 0.9) makes Rng ambiguous. In the binary_field! macro, use the fully-qualified ::rand::distr::StandardUniform.sample(rng) so it works regardless of what's imported at each call site.