### PR TITLE
[ci] Differentiate Rust cache key by CPU feature set

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,13 +69,14 @@ jobs:
       # GitHub-hosted x86_64 runners include both Intel (with AVX-512/GFNI) and
       # AMD (without) SKUs. With `-Ctarget-cpu=native`, build artifacts cached
       # on one SKU produce illegal instructions when restored on another.
-      # Hash the CPU flag set into the cache key so heterogeneous runners do
-      # not share artifacts.
+      # Hash the CPU feature set into the cache key so heterogeneous runners do
+      # not share artifacts. Skipped for portable builds (CPU-agnostic output).
       - name: Compute CPU feature cache key
+        if: matrix.arch.rustflags != ''
         id: cpu
         run: |
           if [ -r /proc/cpuinfo ]; then
-            HASH=$(grep -m1 '^flags' /proc/cpuinfo | sha256sum | cut -c1-16)
+            HASH=$(grep -m1 -E '^(flags|Features)[[:space:]]*:' /proc/cpuinfo | sha256sum | cut -c1-16)
           else
             HASH=portable
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,10 +66,25 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6
+      # GitHub-hosted x86_64 runners include both Intel (with AVX-512/GFNI) and
+      # AMD (without) SKUs. With `-Ctarget-cpu=native`, build artifacts cached
+      # on one SKU produce illegal instructions when restored on another.
+      # Hash the CPU flag set into the cache key so heterogeneous runners do
+      # not share artifacts.
+      - name: Compute CPU feature cache key
+        id: cpu
+        run: |
+          if [ -r /proc/cpuinfo ]; then
+            HASH=$(grep -m1 '^flags' /proc/cpuinfo | sha256sum | cut -c1-16)
+          else
+            HASH=portable
+          fi
+          echo "key=cpu-${HASH}" >> "$GITHUB_OUTPUT"
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: clippy
+          cache-key: ${{ steps.cpu.outputs.key }}
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2
         with:


### PR DESCRIPTION
Fixes #1471.

## Problem

`rust-checks-x86_64` recurringly fails on `main` with `SIGILL` in `binius-circuits::rs256::tests::*`. Root cause is documented in #1471: GitHub's `ubuntu-24.04` runner pool mixes Intel Xeon (with AVX-512/GFNI) and AMD EPYC (without). With `RUSTFLAGS=-Ctarget-cpu=native` and `Swatinem/rust-cache` keyed only by `Cargo.lock` + toolchain, a build cached on an Intel runner is reused on an AMD runner and crashes at runtime.

## Fix

Hash `/proc/cpuinfo` flags into `setup-rust-toolchain`'s `cache-key`. Same-class runners keep sharing cache; cross-class runs get separate caches. Falls back to `cpu-portable` on systems without `/proc/cpuinfo`.

## Why this approach

- Keeps the existing `-Ctarget-cpu=native` strategy: AVX-512, GFNI, VAES, VPCLMULQDQ code paths in `binius-field` are still exercised when CI lands on Intel runners.
- Surgical: 15 added lines in one job, no other CI changes.
- Self-correcting: even if GitHub adds a third CPU SKU later, it just gets its own cache bucket — no further CI work needed.

## Alternatives considered

- **Drop `-Ctarget-cpu=native`, use `-Ctarget-cpu=x86-64-v3`**: bypasses AVX-512/GFNI/VAES `cfg(target_feature=...)` gates in `binius-field`, leaving them untested.
- **Disable cache for the native job**: significantly slower CI for every run, not just the cross-class restores.
- **Pin to one runner SKU**: GitHub does not expose this knob for `ubuntu-24.04`.

## Test plan

- [x] YAML validates (`ruby -ryaml ...`)
- [x] Bash snippet exercised locally (Linux path produces 16-hex digest from `flags`; non-Linux path falls back to `cpu-portable`)
- [ ] CI on this PR runs across Intel and AMD runners, both pass without SIGILL