### PR TITLE
[verifier] Hoist redundant work out of shift check_eval

### DIFF
--- a/crates/prover/benches/shift_reduction.rs
+++ b/crates/prover/benches/shift_reduction.rs
@@ -83,9 +83,8 @@ fn bench_prove_and_verify(c: &mut Criterion) {
 				.collect::<Vec<_>>()
 		};
 
-		// Sample univaraite eval point
-		let r_zhat_prime_bitand = F::random(&mut rng);
-		let r_zhat_prime_intmul = F::random(&mut rng);
+		// Sample univariate eval point — shared across bitand and intmul operators.
+		let r_zhat_prime = F::random(&mut rng);
 
 		let bitand_evals = [F::random(&mut rng); 3];
 		let intmul_evals = [F::random(&mut rng); 4];
@@ -100,12 +99,12 @@ fn bench_prove_and_verify(c: &mut Criterion) {
 			b.iter(|| {
 				let prover_bitand_data = OperatorData {
 					evals: bitand_evals.to_vec(),
-					r_zhat_prime: r_zhat_prime_bitand,
+					r_zhat_prime,
 					r_x_prime: r_x_prime_bitand.clone(),
 				};
 				let prover_intmul_data = OperatorData {
 					evals: intmul_evals.to_vec(),
-					r_zhat_prime: r_zhat_prime_intmul,
+					r_zhat_prime,
 					r_x_prime: r_x_prime_intmul.clone(),
 				};
 
@@ -125,12 +124,12 @@ fn bench_prove_and_verify(c: &mut Criterion) {
 		// Pre-run the prover to get the transcript for verifier benchmarking
 		let prover_bitand_data = OperatorData {
 			evals: bitand_evals.to_vec(),
-			r_zhat_prime: r_zhat_prime_bitand,
+			r_zhat_prime,
 			r_x_prime: r_x_prime_bitand.clone(),
 		};
 		let prover_intmul_data = OperatorData {
 			evals: intmul_evals.to_vec(),
-			r_zhat_prime: r_zhat_prime_intmul,
+			r_zhat_prime,
 			r_x_prime: r_x_prime_intmul.clone(),
 		};
 
@@ -151,16 +150,10 @@ fn bench_prove_and_verify(c: &mut Criterion) {
 			b.iter(|| {
 				let mut verifier_transcript = setup_verifier_transcript.clone();
 
-				let verifier_bitand_data = VerifierOperatorData::new(
-					r_zhat_prime_bitand,
-					r_x_prime_bitand.clone(),
-					bitand_evals,
-				);
-				let verifier_intmul_data = VerifierOperatorData::new(
-					r_zhat_prime_intmul,
-					r_x_prime_intmul.clone(),
-					intmul_evals,
-				);
+				let verifier_bitand_data =
+					VerifierOperatorData::new(r_x_prime_bitand.clone(), bitand_evals);
+				let verifier_intmul_data =
+					VerifierOperatorData::new(r_x_prime_intmul.clone(), intmul_evals);
 
 				verify(&cs, &verifier_bitand_data, &verifier_intmul_data, &mut verifier_transcript)
 					.unwrap();

--- a/crates/prover/tests/shift.rs
+++ b/crates/prover/tests/shift.rs
@@ -255,9 +255,9 @@ fn test_shift_prove_and_verify() {
 				.collect::<Vec<_>>()
 		};
 
-		// Sample univaraite eval point
-		let r_zhat_prime_bitand = F::random(&mut rng);
-		let r_zhat_prime_intmul = F::random(&mut rng);
+		// Sample univariate eval point — the bitand and intmul operators share
+		// `r_zhat_prime` so the verifier can compute `h_op_evals` once for both.
+		let r_zhat_prime = F::random(&mut rng);
 
 		let subspace = BinarySubspace::<AESTowerField8b>::with_dim(LOG_WORD_SIZE_BITS).isomorphic();
 
@@ -265,7 +265,7 @@ fn test_shift_prove_and_verify() {
 			evaluate_image(
 				&subspace,
 				&image,
-				r_zhat_prime_bitand,
+				r_zhat_prime,
 				eq_ind_partial_eval(&r_x_prime_bitand).as_ref(),
 			)
 		});
@@ -274,7 +274,7 @@ fn test_shift_prove_and_verify() {
 			evaluate_image(
 				&subspace,
 				&image,
-				r_zhat_prime_intmul,
+				r_zhat_prime,
 				eq_ind_partial_eval(&r_x_prime_intmul).as_ref(),
 			)
 		});
@@ -287,12 +287,12 @@ fn test_shift_prove_and_verify() {
 
 		let prover_bitand_data = OperatorData {
 			evals: bitand_evals.to_vec(),
-			r_zhat_prime: r_zhat_prime_bitand,
+			r_zhat_prime,
 			r_x_prime: r_x_prime_bitand.clone(),
 		};
 		let prover_intmul_data = OperatorData {
 			evals: intmul_evals.to_vec(),
-			r_zhat_prime: r_zhat_prime_intmul,
+			r_zhat_prime,
 			r_x_prime: r_x_prime_intmul.clone(),
 		};
 
@@ -308,10 +308,8 @@ fn test_shift_prove_and_verify() {
 		// Create verifier transcript and call the verifier
 		let mut verifier_transcript = prover_transcript.into_verifier();
 
-		let verifier_bitand_data =
-			VerifierOperatorData::new(r_zhat_prime_bitand, r_x_prime_bitand, bitand_evals);
-		let verifier_intmul_data =
-			VerifierOperatorData::new(r_zhat_prime_intmul, r_x_prime_intmul, intmul_evals);
+		let verifier_bitand_data = VerifierOperatorData::new(r_x_prime_bitand, bitand_evals);
+		let verifier_intmul_data = VerifierOperatorData::new(r_x_prime_intmul, intmul_evals);
 
 		let verifier_output =
 			verify(&cs, &verifier_bitand_data, &verifier_intmul_data, &mut verifier_transcript)
@@ -323,6 +321,7 @@ fn test_shift_prove_and_verify() {
 			&verifier_bitand_data,
 			&verifier_intmul_data,
 			&subspace,
+			r_zhat_prime,
 			&verifier_output,
 			&mut verifier_transcript,
 		)

--- a/crates/verifier/src/protocols/shift/monster.rs
+++ b/crates/verifier/src/protocols/shift/monster.rs
@@ -8,10 +8,8 @@ use binius_core::{
 };
 use binius_field::{BinaryField, FieldOps, util::powers};
 use binius_math::{
-	BinarySubspace,
 	inner_product::inner_product_scalars,
 	multilinear::{eq::eq_ind_partial_eval_scalars, evaluate::evaluate_inplace_scalars},
-	univariate::lagrange_evals_scalars,
 };
 
 use super::{
@@ -112,47 +110,38 @@ pub fn evaluate_h_op<E: FieldOps>(l_tilde: &[E], r_j: &[E], r_s: &[E]) -> [E; SH
 /// # Arguments
 ///
 /// * `operand_vecs` - Vector of operand vectors, one per operand position in the constraint
-/// * `operator_data` - Contains the multilinear challenge `r_x'`, univariate challenge `r_zhat'`,
-///   and evaluation claims for each operand
+/// * `operator_data` - Contains the multilinear challenge `r_x'` and evaluation claims for each
+///   operand
 /// * `lambda` - Random coefficient for batching operand evaluations
-/// * `r_j` - Challenge point for bit index variables (length `LOG_WORD_SIZE_BITS`)
 /// * `r_s` - Challenge point for shift variables (length `LOG_WORD_SIZE_BITS`)
 /// * `r_y_tensor` - Equality indicator tensor expansion of the word index challenge `r_y`
+/// * `h_op_evals` - Precomputed shift selector evaluations from `evaluate_h_op`, shared across
+///   operations
 ///
 /// # Returns
 ///
 /// The evaluation of the monster multilinear at the given challenge points, or an error
 /// if the computation fails.
-///
-/// # Errors
-///
-/// Returns an error if the binary subspace construction fails.
 pub fn evaluate_monster_multilinear_for_operation<F, E, const ARITY: usize>(
 	operand_vecs: &[Vec<&Operand>],
 	operator_data: &OperatorData<E, ARITY>,
-	subspace: &BinarySubspace<F>,
 	lambda: E,
-	r_j: &[E],
 	r_s: &[E],
 	r_y_tensor: &[E],
+	h_op_evals: &[E; SHIFT_VARIANT_COUNT],
 ) -> Result<E, Error>
 where
 	F: BinaryField,
 	E: FieldOps<Scalar = F> + From<F>,
 {
-	assert_eq!(subspace.dim(), LOG_WORD_SIZE_BITS); // precondition
-
 	let r_x_prime_tensor = eq_ind_partial_eval_scalars(&operator_data.r_x_prime);
-
-	let l_tilde = lagrange_evals_scalars(subspace, operator_data.r_zhat_prime.clone());
-	let h_op_evals = evaluate_h_op(&l_tilde, r_j, r_s);
 
 	let lambda_powers = powers(lambda).skip(1).take(ARITY).collect::<Vec<_>>();
 	let evals = evaluate_matrices(operand_vecs, &lambda_powers, &r_x_prime_tensor, r_y_tensor);
 
 	let eval = inner_product_scalars(
 		evals.map(|mut evals_op| evaluate_inplace_scalars(&mut evals_op[..], r_s)),
-		h_op_evals,
+		h_op_evals.iter().cloned(),
 	);
 
 	Ok(eval)

--- a/crates/verifier/src/protocols/shift/monster.rs
+++ b/crates/verifier/src/protocols/shift/monster.rs
@@ -117,7 +117,7 @@ pub fn evaluate_h_op<E: FieldOps>(l_tilde: &[E], r_j: &[E], r_s: &[E]) -> [E; SH
 /// * `lambda` - Random coefficient for batching operand evaluations
 /// * `r_j` - Challenge point for bit index variables (length `LOG_WORD_SIZE_BITS`)
 /// * `r_s` - Challenge point for shift variables (length `LOG_WORD_SIZE_BITS`)
-/// * `r_y` - Challenge point for word index variables
+/// * `r_y_tensor` - Equality indicator tensor expansion of the word index challenge `r_y`
 ///
 /// # Returns
 ///
@@ -134,7 +134,7 @@ pub fn evaluate_monster_multilinear_for_operation<F, E, const ARITY: usize>(
 	lambda: E,
 	r_j: &[E],
 	r_s: &[E],
-	r_y: &[E],
+	r_y_tensor: &[E],
 ) -> Result<E, Error>
 where
 	F: BinaryField,
@@ -143,13 +143,12 @@ where
 	assert_eq!(subspace.dim(), LOG_WORD_SIZE_BITS); // precondition
 
 	let r_x_prime_tensor = eq_ind_partial_eval_scalars(&operator_data.r_x_prime);
-	let r_y_tensor = eq_ind_partial_eval_scalars(r_y);
 
 	let l_tilde = lagrange_evals_scalars(subspace, operator_data.r_zhat_prime.clone());
 	let h_op_evals = evaluate_h_op(&l_tilde, r_j, r_s);
 
 	let lambda_powers = powers(lambda).skip(1).take(ARITY).collect::<Vec<_>>();
-	let evals = evaluate_matrices(operand_vecs, &lambda_powers, &r_x_prime_tensor, &r_y_tensor);
+	let evals = evaluate_matrices(operand_vecs, &lambda_powers, &r_x_prime_tensor, r_y_tensor);
 
 	let eval = inner_product_scalars(
 		evals.map(|mut evals_op| evaluate_inplace_scalars(&mut evals_op[..], r_s)),

--- a/crates/verifier/src/protocols/shift/verify.rs
+++ b/crates/verifier/src/protocols/shift/verify.rs
@@ -4,13 +4,18 @@ use binius_core::constraint_system::{AndConstraint, ConstraintSystem, MulConstra
 use binius_field::{BinaryField, field::FieldOps};
 use binius_ip::channel::IPVerifierChannel;
 use binius_math::{
-	BinarySubspace, multilinear::eq::eq_ind_partial_eval_scalars, univariate::evaluate_univariate,
+	BinarySubspace,
+	multilinear::eq::eq_ind_partial_eval_scalars,
+	univariate::{evaluate_univariate, lagrange_evals_scalars},
 };
 use binius_utils::checked_arithmetics::strict_log_2;
 use getset::Getters;
 use itertools::Itertools;
 
-use super::{BITAND_ARITY, INTMUL_ARITY, error::Error, evaluate_monster_multilinear_for_operation};
+use super::{
+	BITAND_ARITY, INTMUL_ARITY, error::Error, evaluate_h_op,
+	evaluate_monster_multilinear_for_operation,
+};
 use crate::{
 	config::LOG_WORD_SIZE_BITS,
 	protocols::sumcheck::{SumcheckOutput, verify as verify_sumcheck},
@@ -25,27 +30,19 @@ use crate::{
 /// # Fields
 ///
 /// - `r_x_prime`: multilinear challenge point from the protocol
-/// - `r_zhat_prime`: univariate challenge point
-/// - `lambda`: random linear combination coefficient for operand weighting
 /// - `evals`: array of evaluation claims, one per operand position
 #[derive(Debug, Clone)]
 pub struct OperatorData<F, const ARITY: usize> {
 	pub r_x_prime: Vec<F>,
-	pub r_zhat_prime: F,
 	pub evals: [F; ARITY],
 }
 
 impl<F: FieldOps, const ARITY: usize> OperatorData<F, ARITY> {
 	// Constructs a new operator data instance encoding
-	// evaluation claim with univariate challenge `r_zhat_prime`
-	// multilinear challenge `r_x_prime`, and evaluations `evals`
-	// with one eval for each operand of the operation.
-	pub fn new(r_zhat_prime: F, r_x_prime: Vec<F>, evals: [F; ARITY]) -> Self {
-		Self {
-			r_x_prime,
-			r_zhat_prime,
-			evals,
-		}
+	// evaluation claim with multilinear challenge `r_x_prime` and evaluations `evals`
+	// (one eval for each operand of the operation).
+	pub fn new(r_x_prime: Vec<F>, evals: [F; ARITY]) -> Self {
+		Self { r_x_prime, evals }
 	}
 
 	// Batching is scaled by random lambda and therefore this batched
@@ -210,6 +207,7 @@ pub fn check_eval<F, C>(
 	bitand_data: &OperatorData<C::Elem, BITAND_ARITY>,
 	intmul_data: &OperatorData<C::Elem, INTMUL_ARITY>,
 	subspace: &BinarySubspace<F>,
+	r_zhat_prime: C::Elem,
 	output: &VerifyOutput<C::Elem>,
 	channel: &mut C,
 ) -> Result<(), Error>
@@ -228,8 +226,12 @@ where
 		witness_eval,
 	} = output;
 
-	// Compute monster multilinear evaluation
+	// Compute monster multilinear evaluation. The shift selector evaluations `h_op_evals`
+	// depend only on the shared `r_zhat_prime`, `r_j`, and `r_s`, so they're computed
+	// once and reused across both bitand and intmul.
 	let r_y_tensor = eq_ind_partial_eval_scalars(r_y);
+	let l_tilde = lagrange_evals_scalars(subspace, r_zhat_prime);
+	let h_op_evals = evaluate_h_op(&l_tilde, r_j, r_s);
 	let monster_eval_for_bitand = {
 		let (a, b, c) = constraint_system
 			.and_constraints
@@ -239,11 +241,10 @@ where
 		evaluate_monster_multilinear_for_operation(
 			&[a, b, c],
 			bitand_data,
-			subspace,
 			bitand_lambda.clone(),
-			r_j,
 			r_s,
 			&r_y_tensor,
+			&h_op_evals,
 		)
 	}?;
 	let monster_eval_for_intmul = {
@@ -255,11 +256,10 @@ where
 		evaluate_monster_multilinear_for_operation(
 			&[a, b, lo, hi],
 			intmul_data,
-			subspace,
 			intmul_lambda.clone(),
-			r_j,
 			r_s,
 			&r_y_tensor,
+			&h_op_evals,
 		)
 	}?;
 	let monster_eval = monster_eval_for_bitand + monster_eval_for_intmul;

--- a/crates/verifier/src/protocols/shift/verify.rs
+++ b/crates/verifier/src/protocols/shift/verify.rs
@@ -3,7 +3,9 @@
 use binius_core::constraint_system::{AndConstraint, ConstraintSystem, MulConstraint};
 use binius_field::{BinaryField, field::FieldOps};
 use binius_ip::channel::IPVerifierChannel;
-use binius_math::{BinarySubspace, univariate::evaluate_univariate};
+use binius_math::{
+	BinarySubspace, multilinear::eq::eq_ind_partial_eval_scalars, univariate::evaluate_univariate,
+};
 use binius_utils::checked_arithmetics::strict_log_2;
 use getset::Getters;
 use itertools::Itertools;
@@ -227,6 +229,7 @@ where
 	} = output;
 
 	// Compute monster multilinear evaluation
+	let r_y_tensor = eq_ind_partial_eval_scalars(r_y);
 	let monster_eval_for_bitand = {
 		let (a, b, c) = constraint_system
 			.and_constraints
@@ -240,7 +243,7 @@ where
 			bitand_lambda.clone(),
 			r_j,
 			r_s,
-			r_y,
+			&r_y_tensor,
 		)
 	}?;
 	let monster_eval_for_intmul = {
@@ -256,7 +259,7 @@ where
 			intmul_lambda.clone(),
 			r_j,
 			r_s,
-			r_y,
+			&r_y_tensor,
 		)
 	}?;
 	let monster_eval = monster_eval_for_bitand + monster_eval_for_intmul;

--- a/crates/verifier/src/verify.rs
+++ b/crates/verifier/src/verify.rs
@@ -150,7 +150,7 @@ impl IOPVerifier {
 			n_constraints = self.constraint_system.n_and_constraints()
 		)
 		.entered();
-		let bitand_claim = {
+		let (r_zhat_prime, bitand_claim) = {
 			let log_n_constraints = checked_log_2(self.constraint_system.n_and_constraints());
 			let AndCheckOutput {
 				a_eval,
@@ -159,13 +159,14 @@ impl IOPVerifier {
 				z_challenge,
 				eval_point,
 			} = verify_bitand_reduction(log_n_constraints, &extended_subspace, channel)?;
-			OperatorData::new(z_challenge, eval_point, [a_eval, b_eval, c_eval])
+			(z_challenge, OperatorData::new(eval_point, [a_eval, b_eval, c_eval]))
 		};
 		drop(bitand_guard);
 
-		// Build `OperatorData` for IntMul using the same `r_zhat_prime`
-		// challenge as in BitAnd. Sharing this univariate challenge
-		// improves prover ShiftReduction perf.
+		// Build `OperatorData` for IntMul. The univariate challenge `r_zhat_prime` is
+		// shared with BitAnd (computed above) — sharing it improves prover
+		// ShiftReduction perf and lets the verifier compute `h_op_evals` once for both
+		// operations in `shift::check_eval`.
 		let intmul_claim = {
 			let IntMulOutput {
 				a_evals,
@@ -175,11 +176,9 @@ impl IOPVerifier {
 				eval_point,
 			} = intmul_output;
 
-			let r_zhat_prime = bitand_claim.r_zhat_prime.clone();
 			let l_tilde = lagrange_evals_scalars(&domain_subspace, r_zhat_prime.clone());
 			let make_final_claim = |evals| inner_product_scalars(evals, l_tilde.iter().cloned());
 			OperatorData::new(
-				r_zhat_prime,
 				eval_point,
 				[
 					make_final_claim(a_evals),
@@ -213,6 +212,7 @@ impl IOPVerifier {
 			&bitand_claim,
 			&intmul_claim,
 			&domain_subspace,
+			r_zhat_prime,
 			&shift_output,
 			channel,
 		)?;


### PR DESCRIPTION
Two related hoists of redundant work in `shift::check_eval`. `check_eval` makes two `evaluate_monster_multilinear_for_operation` calls (one for AND, one for MUL constraints) that share several inputs.

## Summary
- **Hoist `r_y` tensor expansion (commit 1).** Both calls expanded the same `r_y` challenge into an eq-indicator tensor via `eq_ind_partial_eval_scalars`. Compute it once in `check_eval` and pass `r_y_tensor: &[E]` into `evaluate_monster_multilinear_for_operation` instead of `r_y: &[E]`.
- **Hoist `h_op_evals` computation (commit 2).** Both calls also recomputed `l_tilde = lagrange_evals_scalars(subspace, r_zhat_prime)` and `h_op_evals = evaluate_h_op(l_tilde, r_j, r_s)`. None of these inputs differ between the two calls — `subspace`, `r_j`, `r_s` are caller-shared, and `r_zhat_prime` is a single shared challenge in production (the verifier explicitly reuses `bitand_claim.r_zhat_prime` when constructing `intmul_claim`).
- Pull `r_zhat_prime` off `OperatorData` and thread it through `check_eval` as an explicit parameter — it's structurally per-protocol, not per-operator. With both hoists, `subspace`, `r_j`, and `r_zhat_prime` no longer appear in `evaluate_monster_multilinear_for_operation`'s signature.
- Update `crates/prover/tests/shift.rs` and `crates/prover/benches/shift_reduction.rs` to sample a single shared `r_zhat_prime` (matching production usage) instead of two unrelated values.

## Test plan
- [x] `cargo test -p binius-verifier shift`
- [x] `cargo test -p binius-prover --test shift` (covers SHA256/Slice/Concat circuits)
- [x] `cargo clippy --workspace --tests --benches --examples -- -D warnings`
