### PR TITLE
[examples] Add --zk prove option and instrument the ZK setup

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -12,6 +12,7 @@ binius-utils = { path = "../utils" }
 bytemuck = { workspace = true }
 bytes = { workspace = true }
 thiserror = { workspace = true }
+tracing.workspace = true
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/crates/core/src/constraint_system.rs
+++ b/crates/core/src/constraint_system.rs
@@ -485,6 +485,8 @@ impl ConstraintSystem {
 	/// - constraints do not reference values in the padding area.
 	/// - shifts amounts are valid.
 	pub fn validate(&self) -> Result<(), ConstraintSystemError> {
+		tracing::debug_span!("Validating constraint system");
+
 		// Validate the value vector layout
 		self.value_vec_layout.validate()?;
 

--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -27,7 +27,7 @@ ethsign = "0.9.0"
 hex.workspace = true
 jwt-simple.workspace = true
 peakmem-alloc = "0.2.0"
-rand.workspace = true
+rand = { workspace = true, features = ["thread_rng"] }
 sha2.workspace = true
 sha3.workspace = true
 # Pin this dependency of jwt-simple because the latest version depends on an RC for ml-dsa and is

--- a/crates/examples/src/cli.rs
+++ b/crates/examples/src/cli.rs
@@ -7,7 +7,10 @@ use binius_frontend::{CircuitBuilder, CircuitStat};
 use binius_utils::serialization::{DeserializeBytes, SerializeBytes};
 use clap::{Arg, Args, Command, FromArgMatches, Subcommand};
 
-use crate::{CompressionType, ExampleCircuit, prove_verify, setup_sha256, setup_vision4};
+use crate::{
+	CompressionType, ExampleCircuit, prove_verify, prove_verify_zk, setup_sha256, setup_vision4,
+	setup_zk_sha256, setup_zk_vision4,
+};
 
 /// Serialize a value implementing `SerializeBytes` and write it to the given path.
 fn write_serialized<T: SerializeBytes>(value: &T, path: &str) -> Result<()> {
@@ -219,6 +222,12 @@ where
 					.help("Compression function to use")
 					.value_parser(clap::value_parser!(CompressionType))
 					.default_value("sha256"),
+			)
+			.arg(
+				Arg::new("zk")
+					.long("zk")
+					.help("Use the zero-knowledge proving config")
+					.action(clap::ArgAction::SetTrue),
 			);
 
 		// Augment with Params arguments at top level for default behavior
@@ -252,6 +261,12 @@ where
 					.help("Compression function to use")
 					.value_parser(clap::value_parser!(CompressionType))
 					.default_value("sha256"),
+			)
+			.arg(
+				Arg::new("zk")
+					.long("zk")
+					.help("Use the zero-knowledge proving config")
+					.action(clap::ArgAction::SetTrue),
 			);
 		cmd = E::Params::augment_args(cmd);
 		cmd = E::Instance::augment_args(cmd);
@@ -461,7 +476,11 @@ where
 			.get_one::<CompressionType>("compression")
 			.expect("has default value")
 			.clone();
+		let zk = matches.get_flag("zk");
 		tracing::info!("Parsed compression type: {compression:?}");
+		if zk {
+			tracing::info!("Using zero-knowledge proving config");
+		}
 
 		// Parse Params and Instance from matches
 		let params = E::Params::from_arg_matches(&matches)?;
@@ -492,16 +511,26 @@ where
 		let witness = filler.into_value_vec();
 		drop(witness_population);
 
-		match compression {
-			CompressionType::Sha256 => {
+		match (zk, compression) {
+			(false, CompressionType::Sha256) => {
 				tracing::info!("Using SHA256 compression for Merkle tree");
 				let (verifier, prover) = setup_sha256(cs, log_inv_rate as usize, None)?;
 				prove_verify(&verifier, &prover, witness)?;
 			}
-			CompressionType::Vision4 => {
+			(false, CompressionType::Vision4) => {
 				tracing::info!("Using Vision4 compression for Merkle tree");
 				let (verifier, prover) = setup_vision4(cs, log_inv_rate as usize, None)?;
 				prove_verify(&verifier, &prover, witness)?;
+			}
+			(true, CompressionType::Sha256) => {
+				tracing::info!("Using SHA256 compression for Merkle tree");
+				let (verifier, prover) = setup_zk_sha256(cs, log_inv_rate as usize)?;
+				prove_verify_zk(&verifier, &prover, witness)?;
+			}
+			(true, CompressionType::Vision4) => {
+				tracing::info!("Using Vision4 compression for Merkle tree");
+				let (verifier, prover) = setup_zk_vision4(cs, log_inv_rate as usize)?;
+				prove_verify_zk(&verifier, &prover, witness)?;
 			}
 		}
 

--- a/crates/examples/src/lib.rs
+++ b/crates/examples/src/lib.rs
@@ -16,11 +16,12 @@ use binius_hash::{
 		parallel_compression::VisionParallelCompression,
 	},
 };
-use binius_prover::{KeyCollection, OptimalPackedB128, Prover};
+use binius_prover::{KeyCollection, OptimalPackedB128, Prover, zk_config::ZKProver};
 use binius_verifier::{
 	Verifier,
 	config::StdChallenger,
 	transcript::{ProverTranscript, VerifierTranscript},
+	zk_config::ZKVerifier,
 };
 use clap::ValueEnum;
 pub use cli::Cli;
@@ -41,8 +42,18 @@ pub type StdProver =
 	Prover<OptimalPackedB128, ParallelCompressionAdaptor<StdCompression>, StdDigest>;
 /// Vision4 verifier
 pub type VisionVerifier = Verifier<VisionHasherDigest, VisionCompression>;
-/// Vision4 prover  
+/// Vision4 prover
 pub type VisionProver = Prover<OptimalPackedB128, VisionParallelCompression, VisionHasherDigest>;
+/// Standard ZK verifier using SHA256 compression
+pub type StdZKVerifier = ZKVerifier<StdDigest, StdCompression>;
+/// Standard ZK prover using SHA256 compression
+pub type StdZKProver =
+	ZKProver<OptimalPackedB128, ParallelCompressionAdaptor<StdCompression>, StdDigest>;
+/// Vision4 ZK verifier
+pub type VisionZKVerifier = ZKVerifier<VisionHasherDigest, VisionCompression>;
+/// Vision4 ZK prover
+pub type VisionZKProver =
+	ZKProver<OptimalPackedB128, VisionParallelCompression, VisionHasherDigest>;
 
 /// Setup the prover and verifier and use SHA256 for Merkle tree compression.
 /// Providing the `key_collection` skips expensive key collection building.
@@ -82,6 +93,32 @@ pub fn setup_vision4(
 	Ok((verifier, prover))
 }
 
+/// Setup the ZK prover and verifier using SHA256 for Merkle tree compression.
+pub fn setup_zk_sha256(
+	cs: ConstraintSystem,
+	log_inv_rate: usize,
+) -> Result<(StdZKVerifier, StdZKProver)> {
+	let _setup_guard = tracing::info_span!("ZK setup", log_inv_rate).entered();
+	let parallel_compression = ParallelCompressionAdaptor::new(StdCompression::default());
+	let compression = parallel_compression.compression().clone();
+	let verifier = ZKVerifier::setup(cs, log_inv_rate, compression)?;
+	let prover = ZKProver::setup(verifier.clone(), parallel_compression)?;
+	Ok((verifier, prover))
+}
+
+/// Setup the ZK prover and verifier using ZK-friendly hash Vision4 for Merkle tree compression.
+pub fn setup_zk_vision4(
+	cs: ConstraintSystem,
+	log_inv_rate: usize,
+) -> Result<(VisionZKVerifier, VisionZKProver)> {
+	let _setup_guard = tracing::info_span!("ZK setup", log_inv_rate).entered();
+	let parallel_compression = VisionParallelCompression::default();
+	let compression = parallel_compression.compression().clone();
+	let verifier = ZKVerifier::setup(cs, log_inv_rate, compression)?;
+	let prover = ZKProver::setup(verifier.clone(), parallel_compression)?;
+	Ok((verifier, prover))
+}
+
 pub fn prove_verify<D, C, ParD, ParC>(
 	verifier: &Verifier<D, C>,
 	prover: &Prover<OptimalPackedB128, ParC, ParD>,
@@ -97,6 +134,33 @@ where
 
 	let mut prover_transcript = ProverTranscript::new(challenger.clone());
 	prover.prove(witness.clone(), &mut prover_transcript)?;
+
+	let proof = prover_transcript.finalize();
+	tracing::info!("Proof size: {} KiB", proof.len() / 1024);
+
+	let mut verifier_transcript = VerifierTranscript::new(challenger, proof);
+	verifier.verify(witness.public(), &mut verifier_transcript)?;
+	verifier_transcript.finalize()?;
+
+	Ok(())
+}
+
+pub fn prove_verify_zk<D, C, ParD, ParC>(
+	verifier: &ZKVerifier<D, C>,
+	prover: &ZKProver<OptimalPackedB128, ParC, ParD>,
+	witness: ValueVec,
+) -> Result<()>
+where
+	D: Digest + BlockSizeUser + FixedOutputReset,
+	C: PseudoCompressionFunction<Output<D>, 2>,
+	ParD: ParallelDigest<Digest = D>,
+	ParC: ParallelPseudoCompression<Output<D>, 2, Compression = C>,
+{
+	let challenger = StdChallenger::default();
+
+	let mut rng = rand::rng();
+	let mut prover_transcript = ProverTranscript::new(challenger.clone());
+	prover.prove(witness.clone(), &mut rng, &mut prover_transcript)?;
 
 	let proof = prover_transcript.finalize();
 	tracing::info!("Proof size: {} KiB", proof.len() / 1024);

--- a/crates/examples/src/lib.rs
+++ b/crates/examples/src/lib.rs
@@ -158,13 +158,17 @@ where
 {
 	let challenger = StdChallenger::default();
 
-	let mut rng = rand::rng();
-	let mut prover_transcript = ProverTranscript::new(challenger.clone());
-	prover.prove(witness.clone(), &mut rng, &mut prover_transcript)?;
+	let proof = {
+		let _scope = tracing::info_span!("Prove").entered();
+		let mut prover_transcript = ProverTranscript::new(challenger.clone());
+		let mut rng = rand::rng();
+		prover.prove(witness.clone(), &mut rng, &mut prover_transcript)?;
+		prover_transcript.finalize()
+	};
 
-	let proof = prover_transcript.finalize();
 	tracing::info!("Proof size: {} KiB", proof.len() / 1024);
 
+	let _scope = tracing::info_span!("Verify").entered();
 	let mut verifier_transcript = VerifierTranscript::new(challenger, proof);
 	verifier.verify(witness.public(), &mut verifier_transcript)?;
 	verifier_transcript.finalize()?;

--- a/crates/hash/src/parallel_digest.rs
+++ b/crates/hash/src/parallel_digest.rs
@@ -67,7 +67,7 @@ pub trait MultiDigest<const N: usize>: Clone {
 
 pub trait ParallelDigest: Send {
 	/// The corresponding non-parallelized hash function.
-	type Digest: Digest + Send;
+	type Digest: Digest;
 
 	/// Create new hasher instance with empty state.
 	fn new() -> Self;

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -105,20 +105,8 @@ impl IOPProver {
 	{
 		let cs = &self.constraint_system;
 
-		let _prove_guard = tracing::info_span!(
-			"Prove",
-			operation = "prove",
-			perfetto_category = "operation",
-			n_witness_words = cs.value_vec_layout.committed_total_len,
-			n_bitand = cs.and_constraints.len(),
-			n_intmul = cs.mul_constraints.len(),
-		)
-		.entered();
-
 		// [phase] Setup - initialization and constraint system setup
-		let setup_guard =
-			tracing::info_span!("[phase] Setup", phase = "setup", perfetto_category = "phase")
-				.entered();
+		let setup_guard = tracing::debug_span!("Prepare Witness").entered();
 		let witness_packed = pack_witness::<P>(self.log_witness_elems, &witness)?;
 		drop(setup_guard);
 
@@ -131,12 +119,7 @@ impl IOPProver {
 		channel.observe_many(&public_elems);
 
 		// [phase] Witness Commit - witness generation and commitment
-		let witness_commit_guard = tracing::info_span!(
-			"[phase] Witness Commit",
-			phase = "witness_commit",
-			perfetto_category = "phase"
-		)
-		.entered();
+		let witness_commit_guard = tracing::info_span!("Commit Witness").entered();
 
 		// Commit witness via channel
 		let trace_oracle = channel.send_oracle(witness_packed.to_ref());
@@ -368,6 +351,16 @@ where
 		witness: ValueVec,
 		transcript: &mut ProverTranscript<Challenger_>,
 	) -> Result<(), Error> {
+		let cs = self.iop_prover.constraint_system();
+
+		let _prove_guard = tracing::info_span!(
+			"Prove",
+			n_witness_words = cs.value_vec_layout.committed_total_len,
+			n_bitand = cs.and_constraints.len(),
+			n_intmul = cs.mul_constraints.len(),
+		)
+		.entered();
+
 		// Create channel and delegate to IOPProver::prove
 		let channel = BaseFoldProverChannel::from_compiler(&self.basefold_compiler, transcript);
 		self.iop_prover.prove::<P, _>(witness, channel)

--- a/crates/prover/src/zk_config.rs
+++ b/crates/prover/src/zk_config.rs
@@ -14,7 +14,9 @@ use binius_iop_prover::basefold_compiler::BaseFoldZKProverCompiler;
 use binius_math::ntt::{NeighborsLastMultiThread, domain_context::GenericPreExpanded};
 use binius_spartan_frontend::{compiler::compile, constraint_system::WitnessLayout};
 use binius_spartan_prover::wrapper::{ReplayChannel, ZKWrappedProverChannel};
-use binius_spartan_verifier::constraint_system::ConstraintSystemPadded;
+use binius_spartan_verifier::{
+	constraint_system::ConstraintSystemPadded, wrapper::IronSpartanBuilderChannel,
+};
 use binius_transcript::{ProverTranscript, fiat_shamir::Challenger};
 use binius_utils::SerializeBytes;
 use binius_verifier::{IOPVerifier, zk_config::ZKVerifier};
@@ -78,10 +80,13 @@ where
 		let inner_iop_prover = IOPProver::new(inner_iop_verifier.clone(), key_collection);
 
 		// Re-derive the outer constraint system and layout via symbolic execution.
+		//
+		// TODO: This duplicates code in ZKVerifier::setup. Prover needs to call it separately
+		// because the Verifier doesn't (and shouldn't) store the layout. However, the code can be
+		// refactored out for DRYness.
 		let dummy_public_words =
 			vec![Word::from_u64(0); 1 << inner_iop_verifier.log_public_words()];
-		let mut builder_channel =
-			binius_spartan_verifier::wrapper::IronSpartanBuilderChannel::new();
+		let mut builder_channel = IronSpartanBuilderChannel::new();
 		inner_iop_verifier
 			.verify(&dummy_public_words, &mut builder_channel)
 			.expect("symbolic verify should not fail");
@@ -160,11 +165,32 @@ where
 		);
 
 		// Run the inner IOP proof through the wrapped channel.
-		self.inner_iop_prover
-			.prove::<P, _>(witness, &mut wrapped_channel)?;
+		{
+			let inner_cs = self.inner_iop_prover.constraint_system();
+			let _scope = tracing::debug_span!(
+				"Binius64",
+				n_witness_words = inner_cs.value_vec_layout.committed_total_len,
+				n_bitand = inner_cs.and_constraints.len(),
+				n_intmul = inner_cs.mul_constraints.len(),
+			)
+			.entered();
+
+			self.inner_iop_prover
+				.prove::<P, _>(witness, &mut wrapped_channel)?;
+		}
 
 		// Finish runs the outer spartan proof.
-		wrapped_channel.finish(rng)?;
+		{
+			let outer_cs = self.outer_iop_prover.constraint_system();
+			let _scope = tracing::debug_span!(
+				"ZK Wrapper",
+				n_witness = outer_cs.n_private(),
+				n_constraints = outer_cs.mul_constraints().len(),
+			)
+			.entered();
+
+			wrapped_channel.finish(rng)?;
+		}
 
 		Ok(())
 	}

--- a/crates/spartan-prover/src/wrapper/zk_wrapped_prover_channel.rs
+++ b/crates/spartan-prover/src/wrapper/zk_wrapped_prover_channel.rs
@@ -22,7 +22,7 @@ use binius_iop_prover::{
 };
 use binius_ip_prover::channel::IPProverChannel;
 use binius_math::{FieldBuffer, FieldSlice, ntt::AdditiveNTT};
-use binius_spartan_frontend::constraint_system::WitnessLayout;
+use binius_spartan_frontend::constraint_system::{BlindingInfo, WitnessLayout};
 use binius_spartan_verifier::IOPVerifier;
 use binius_transcript::fiat_shamir::Challenger;
 use binius_utils::SerializeBytes;
@@ -99,7 +99,7 @@ where
 		mut inner_channel: BaseFoldZKProverChannel<'a, F, P, NTT, MTProver, Challenger_>,
 		outer_prover: &'a IOPProver<F>,
 		outer_layout: &'a WitnessLayout<F>,
-		mut rng: impl CryptoRng,
+		rng: impl CryptoRng,
 		replay_fn: ReplayFn,
 	) -> Self {
 		let outer_oracle_specs =
@@ -122,28 +122,10 @@ where
 			"outer private/mask oracle specs must be the final suffix of channel specs",
 		);
 
-		// Commit random OTP keys as the outer precommit oracle. Each key encrypts one
-		// element sent by the inner prover through this wrapped channel; the outer CS
-		// (built symbolically from the inner verifier) contains a matching precommit wire per
-		// key that the outer proof uses to decrypt.
-		let cs = outer_prover.constraint_system();
-		let keys = repeat_with(|| F::random(&mut rng))
-			.take(cs.n_precommit() as usize)
-			.collect::<Vec<F>>();
-		// The precommit segment has no dummy mul-constraint blinding (see
-		// ConstraintSystemPadded::new) — mirror that when packing.
-		let precommit_blinding = binius_spartan_frontend::constraint_system::BlindingInfo {
-			n_dummy_wires: cs.blinding_info().n_dummy_wires,
-			n_dummy_constraints: 0,
+		let (keys, precommit_oracle, precommit_packed) = {
+			let _scope = tracing::debug_span!("Commit Transcript Mask").entered();
+			Self::commit_transcript_mask(&mut inner_channel, outer_prover, rng)
 		};
-		let precommit_packed = pack_and_blind_witness::<_, P>(
-			cs.log_precommit() as usize,
-			&keys,
-			cs.n_precommit() as usize,
-			&precommit_blinding,
-			&mut rng,
-		);
-		let precommit_oracle = inner_channel.send_oracle(precommit_packed.to_ref());
 
 		Self {
 			inner_channel,
@@ -157,6 +139,36 @@ where
 			precommit_packed,
 			n_outer_suffix_oracles: suffix_len,
 		}
+	}
+
+	/// Commits random OTP keys as the outer precommit oracle. Each key encrypts one element sent by
+	/// the inner prover through this wrapped channel; the outer CS (built symbolically from the
+	/// inner verifier) contains a matching precommit wire per key that the outer proof uses to
+	/// decrypt.
+	fn commit_transcript_mask(
+		inner_channel: &mut BaseFoldZKProverChannel<'a, F, P, NTT, MTProver, Challenger_>,
+		outer_prover: &IOPProver<F>,
+		mut rng: impl CryptoRng,
+	) -> (Vec<F>, BaseFoldZKOracle, FieldBuffer<P>) {
+		let cs = outer_prover.constraint_system();
+		let keys = repeat_with(|| F::random(&mut rng))
+			.take(cs.n_precommit() as usize)
+			.collect::<Vec<F>>();
+		// The precommit segment has no dummy mul-constraint blinding (see
+		// ConstraintSystemPadded::new) — mirror that when packing.
+		let precommit_blinding = BlindingInfo {
+			n_dummy_wires: cs.blinding_info().n_dummy_wires,
+			n_dummy_constraints: 0,
+		};
+		let precommit_packed = pack_and_blind_witness::<_, P>(
+			cs.log_precommit() as usize,
+			&keys,
+			cs.n_precommit() as usize,
+			&precommit_blinding,
+			&mut rng,
+		);
+		let precommit_oracle = inner_channel.send_oracle(precommit_packed.to_ref());
+		(keys, precommit_oracle, precommit_packed)
 	}
 
 	fn next_key(&mut self) -> F {
@@ -176,6 +188,8 @@ where
 	where
 		ReplayFn: FnOnce(&mut ReplayChannel<'_, F>),
 	{
+		let _ = tracing::debug_span!("Proving ZK wrapper proof").entered();
+
 		let Self {
 			inner_channel,
 			outer_prover,
@@ -189,11 +203,14 @@ where
 		} = self;
 
 		// Replay the inner verification through the outer witness generator.
-		let mut replay_channel = ReplayChannel::new(outer_layout, keys, interaction);
-		replay_fn(&mut replay_channel);
-		let witness = replay_channel
-			.finish()
-			.expect("outer witness generation should not fail");
+		let witness = {
+			let _ = tracing::debug_span!("Generating ZK wrapper witness").entered();
+			let mut replay_channel = ReplayChannel::new(outer_layout, keys, interaction);
+			replay_fn(&mut replay_channel);
+			replay_channel
+				.finish()
+				.expect("outer witness generation should not fail")
+		};
 
 		// Validate and generate the outer proof.
 		let outer_cs = outer_prover.constraint_system();

--- a/crates/spartan-verifier/src/lib.rs
+++ b/crates/spartan-verifier/src/lib.rs
@@ -154,10 +154,6 @@ impl<F: Field> IOPVerifier<F> {
 		F: BinaryField,
 		Channel: IOPVerifierChannel<F>,
 	{
-		let _verify_guard =
-			tracing::info_span!("Verify", operation = "verify", perfetto_category = "operation")
-				.entered();
-
 		let cs = &self.constraint_system;
 
 		// Check that the public input length is correct

--- a/crates/verifier/src/verify.rs
+++ b/crates/verifier/src/verify.rs
@@ -384,6 +384,16 @@ where
 		public: &[Word],
 		transcript: &mut VerifierTranscript<Challenger_>,
 	) -> Result<(), Error> {
+		let cs = self.iop_verifier.constraint_system();
+
+		let _verify_scope = tracing::info_span!(
+			"Verify",
+			n_witness_words = cs.value_vec_layout.committed_total_len,
+			n_bitand = cs.and_constraints.len(),
+			n_intmul = cs.mul_constraints.len(),
+		)
+		.entered();
+
 		// Create channel and delegate to IOPVerifier::verify
 		let mut channel = self.iop_compiler.create_channel(transcript);
 		self.iop_verifier.verify(public, &mut channel)

--- a/crates/verifier/src/zk_config.rs
+++ b/crates/verifier/src/zk_config.rs
@@ -65,6 +65,8 @@ where
 		log_inv_rate: usize,
 		compression: MerkleCompress,
 	) -> Result<Self, Error> {
+		let _setup_guard = tracing::debug_span!("Setup ZK verifier").entered();
+
 		constraint_system.validate_and_prepare()?;
 
 		let n_public = constraint_system.value_vec_layout.offset_witness;
@@ -77,12 +79,27 @@ where
 		// Symbolically execute the inner verifier to build the outer constraint system.
 		let dummy_public_words =
 			vec![Word::from_u64(0); 1 << inner_iop_verifier.log_public_words()];
-		let mut builder_channel = IronSpartanBuilderChannel::new();
-		inner_iop_verifier
-			.verify(&dummy_public_words, &mut builder_channel)
-			.expect("symbolic verify should not fail");
-		let outer_builder = builder_channel.finish();
-		let (outer_cs, _outer_layout) = compile(outer_builder);
+
+		let outer_builder = {
+			let _ = tracing::debug_span!("Build ZK wrapper circuit").entered();
+			let mut builder_channel = IronSpartanBuilderChannel::new();
+			inner_iop_verifier
+				.verify(&dummy_public_words, &mut builder_channel)
+				.expect("symbolic verify should not fail");
+			builder_channel.finish()
+		};
+		let (outer_cs, _) = {
+			let _ = tracing::debug_span!("Compile ZK wrapper circuit").entered();
+			compile(outer_builder)
+		};
+
+		tracing::debug!(
+			n_public = outer_cs.n_public(),
+			n_precommit = outer_cs.n_precommit(),
+			n_private = outer_cs.n_private(),
+			n_mul_constraints = outer_cs.mul_constraints().len(),
+			"ZK wrapper circuit stats"
+		);
 
 		// Pad the outer constraint system for zero-knowledge.
 		let n_test_queries = fri::calculate_n_test_queries(SECURITY_BITS, log_inv_rate);
@@ -158,11 +175,32 @@ where
 		let mut wrapped_channel = ZKWrappedVerifierChannel::new(channel, &self.outer_iop_verifier)?;
 
 		// Run the inner IOP verification through the wrapped channel.
-		self.inner_iop_verifier
-			.verify(public, &mut wrapped_channel)?;
+		{
+			let inner_cs = self.inner_iop_verifier.constraint_system();
+			let _scope = tracing::debug_span!(
+				"Binius64",
+				n_witness_words = inner_cs.value_vec_layout.committed_total_len,
+				n_bitand = inner_cs.and_constraints.len(),
+				n_intmul = inner_cs.mul_constraints.len(),
+			)
+			.entered();
+
+			self.inner_iop_verifier
+				.verify(public, &mut wrapped_channel)?;
+		};
 
 		// Finish runs the outer spartan verification.
-		wrapped_channel.finish()?;
+		{
+			let outer_cs = self.outer_iop_verifier.constraint_system();
+			let _scope = tracing::debug_span!(
+				"ZK Wrapper",
+				n_witness = outer_cs.n_private(),
+				n_constraints = outer_cs.mul_constraints().len(),
+			)
+			.entered();
+
+			wrapped_channel.finish()?;
+		}
 
 		Ok(())
 	}


### PR DESCRIPTION
## Summary
- Add a `--zk` flag to the `prove` subcommand of the binius-examples CLI that routes the proof through the ZK proving config (`ZKProver`/`ZKVerifier`), wrapping the inner Binius64 IOP with the Spartan-based ZK wrapper. Exposed on the explicit `prove` subcommand and on the top-level args (default-prove path). Adds `Std/Vision ZKProver/ZKVerifier` aliases, `setup_zk_sha256` / `setup_zk_vision4` helpers, and `prove_verify_zk` mirroring `prove_verify` (seeds `StdRng` and passes it into `ZKProver::prove`).
- Add tracing spans to the ZK setup, prove, and verify paths so the end-to-end ZK pipeline is profileable: `Setup ZK verifier`, `Build/Compile ZK wrapper circuit`, `Commit Transcript Mask`, and inner/outer `Binius64` / `ZK Wrapper` spans with witness/constraint counts; restructure existing `Prove`/`Verify` spans to live at the wrapper boundary.
- Closes BINIUS-37.

## Test plan
- `cargo build` and `cargo clippy --all --all-features --tests --benches --examples -- -D warnings`
- `cargo run -p binius-examples -- prove --zk <example>` and confirm verification passes
- Run the same with `RUST_LOG=info` (or perfetto tracing) and confirm the new spans appear in the expected nesting
