### PR TITLE
[verifier] Use compute_public_value for monster_eval in shift::check_eval

### DIFF
--- a/crates/iop/src/basefold_channel.rs
+++ b/crates/iop/src/basefold_channel.rs
@@ -153,6 +153,10 @@ where
 			Err(binius_ip::channel::Error::InvalidAssert)
 		}
 	}
+
+	fn compute_public_value(&mut self, inputs: &[F], f: impl FnOnce(&[F]) -> F) -> F {
+		f(inputs)
+	}
 }
 
 impl<F, MerkleScheme_, Challenger_> IOPVerifierChannel<F>

--- a/crates/iop/src/basefold_zk_channel.rs
+++ b/crates/iop/src/basefold_zk_channel.rs
@@ -141,6 +141,10 @@ where
 			Err(binius_ip::channel::Error::InvalidAssert)
 		}
 	}
+
+	fn compute_public_value(&mut self, inputs: &[F], f: impl FnOnce(&[F]) -> F) -> F {
+		f(inputs)
+	}
 }
 
 impl<F, MerkleScheme_, Challenger_> IOPVerifierChannel<F>

--- a/crates/iop/src/naive_channel.rs
+++ b/crates/iop/src/naive_channel.rs
@@ -133,6 +133,10 @@ where
 			Err(binius_ip::channel::Error::InvalidAssert)
 		}
 	}
+
+	fn compute_public_value(&mut self, inputs: &[F], f: impl FnOnce(&[F]) -> F) -> F {
+		f(inputs)
+	}
 }
 
 impl<F, Challenger_> IOPVerifierChannel<F> for NaiveVerifierChannel<'_, F, Challenger_>

--- a/crates/iop/src/size_tracking_channel.rs
+++ b/crates/iop/src/size_tracking_channel.rs
@@ -115,6 +115,10 @@ impl<F: BinaryField, MerkleScheme_: MerkleTreeScheme<F>> IPVerifierChannel<F>
 	fn assert_zero(&mut self, _val: F) -> Result<(), binius_ip::channel::Error> {
 		Ok(())
 	}
+
+	fn compute_public_value(&mut self, inputs: &[F], f: impl FnOnce(&[F]) -> F) -> F {
+		f(inputs)
+	}
 }
 
 impl<F: BinaryField, MerkleScheme_: MerkleTreeScheme<F>> IOPVerifierChannel<F>

--- a/crates/ip/src/channel.rs
+++ b/crates/ip/src/channel.rs
@@ -83,6 +83,32 @@ pub trait IPVerifierChannel<F: Field> {
 	///
 	/// Returns [`Error::InvalidAssert`] if the value is not zero.
 	fn assert_zero(&mut self, val: Self::Elem) -> Result<(), Error>;
+
+	/// Computes a value that is a function of public-channel-derived elements and returns it
+	/// as a freshly allocated `Elem`.
+	///
+	/// In wrapper channels that build constraints (e.g. `IronSpartanBuilderChannel`), the result
+	/// is materialized as a single inout wire holding the closure's return value, replacing what
+	/// would otherwise be a sub-circuit's worth of constraints. In non-wrapper channels where
+	/// `Elem = F`, the impl is just `f(inputs)`.
+	///
+	/// The caller MUST ensure each entry in `inputs` is either a `Constant` or a `Wire` whose
+	/// public-tag is true — i.e. produced by `sample_*` / `observe_*` / `compute_public_value`
+	/// on this channel, or derived purely from such values via the channel's `Elem` arithmetic.
+	/// Inputs from `recv_*` (or anything that mixed in a non-public value) MUST NOT be passed.
+	/// The contract is documented; wrapper impls debug-assert it but it is not statically enforced.
+	///
+	/// The closure may or may not be invoked: the symbolic-builder channel skips it, and other
+	/// impls run it on either real or dummy values. Callers must therefore supply a pure function
+	/// with no observable side effects.
+	///
+	/// HACK: This is a temporary hack to fix a performance regression. This feature should be
+	/// killed and handled more elegantly with better witness generation code.
+	fn compute_public_value(
+		&mut self,
+		inputs: &[Self::Elem],
+		f: impl FnOnce(&[F]) -> F,
+	) -> Self::Elem;
 }
 
 impl<F, Challenger_> IPVerifierChannel<F> for VerifierTranscript<Challenger_>
@@ -126,6 +152,10 @@ where
 		} else {
 			Err(Error::InvalidAssert)
 		}
+	}
+
+	fn compute_public_value(&mut self, inputs: &[F], f: impl FnOnce(&[F]) -> F) -> F {
+		f(inputs)
 	}
 }
 

--- a/crates/spartan-prover/src/wrapper/replay_channel.rs
+++ b/crates/spartan-prover/src/wrapper/replay_channel.rs
@@ -225,6 +225,27 @@ impl<'a, F: Field> IPVerifierChannel<F> for ReplayChannel<'a, F> {
 			}
 		}
 	}
+
+	fn compute_public_value(
+		&mut self,
+		inputs: &[Self::Elem],
+		f: impl FnOnce(&[F]) -> F,
+	) -> Self::Elem {
+		let input_refs = inputs.iter().collect::<Vec<_>>();
+		let outs = CircuitElem::combine_varlen(
+			&input_refs,
+			1,
+			move |inputs| vec![f(inputs)],
+			|_, _| {
+				// Self::Elem::combine_varlen will only call the builder_op closure if any inputs
+				// are non-public.
+				panic!("compute_public_value: input is not public")
+			},
+		);
+		outs.into_iter()
+			.next()
+			.expect("combine_varlen returns Vec with len = n_out; n_out = 1")
+	}
 }
 
 impl<'a, F: Field> IOPVerifierChannel<F> for ReplayChannel<'a, F> {

--- a/crates/spartan-verifier/src/lib.rs
+++ b/crates/spartan-verifier/src/lib.rs
@@ -33,6 +33,8 @@ pub mod constraint_system;
 pub mod wiring;
 pub mod wrapper;
 
+use std::slice;
+
 use binius_field::{BinaryField, Field, field::FieldOps};
 use binius_hash::PseudoCompressionFunction;
 use binius_iop::{
@@ -185,8 +187,33 @@ impl<F: Field> IOPVerifier<F> {
 
 		// Compute rₓ^⊤ (M_A + λ M_B + λ² M_C) x
 		let r_x_tensor = eq_ind_partial_eval_scalars(&r_x);
-		let public_eval =
-			evaluate_wiring_mle_public(cs.mul_constraints(), &public, lambda.clone(), &r_x_tensor);
+
+		// The public-segment contribution to the operand evaluations is purely a function of
+		// public-channel inputs (the public scalars, λ, and rₓ). Trade in those Elems for plain
+		// field values, run the MLE evaluation in plaintext, and materialize the result as a
+		// single inout wire instead of building the entire sub-circuit.
+		let public_eval = {
+			let public_len = public.len();
+			let inputs = [
+				public.as_slice(),
+				slice::from_ref(&lambda),
+				r_x_tensor.as_ref(),
+			]
+			.concat();
+
+			let mul_constraints = cs.mul_constraints();
+			channel.compute_public_value(&inputs, move |vals| {
+				let public_vals = &vals[..public_len];
+				let lambda_val = vals[public_len];
+				let r_x_tensor_vals = &vals[public_len + 1..];
+				evaluate_wiring_mle_public(
+					mul_constraints,
+					public_vals,
+					lambda_val,
+					r_x_tensor_vals,
+				)
+			})
+		};
 
 		// Prover sends the precommit segment's contribution to the operand evaluations.
 		let precommit_claim = channel.recv_one()?;

--- a/crates/spartan-verifier/src/wrapper/builder_channel.rs
+++ b/crates/spartan-verifier/src/wrapper/builder_channel.rs
@@ -220,6 +220,27 @@ impl<F: Field> IPVerifierChannel<F> for IronSpartanBuilderChannel<F> {
 			}
 		}
 	}
+
+	fn compute_public_value(
+		&mut self,
+		inputs: &[Self::Elem],
+		f: impl FnOnce(&[F]) -> F,
+	) -> Self::Elem {
+		let input_refs = inputs.iter().collect::<Vec<_>>();
+		let outs = CircuitElem::combine_varlen(
+			&input_refs,
+			1,
+			move |inputs| vec![f(inputs)],
+			|_, _| {
+				// Self::Elem::combine_varlen will only call the builder_op closure if any inputs
+				// are non-public.
+				panic!("compute_public_value: input is not public")
+			},
+		);
+		outs.into_iter()
+			.next()
+			.expect("combine_varlen returns Vec with len = n_out; n_out = 1")
+	}
 }
 
 impl<F: Field> IOPVerifierChannel<F> for IronSpartanBuilderChannel<F> {

--- a/crates/spartan-verifier/src/wrapper/circuit_elem.rs
+++ b/crates/spartan-verifier/src/wrapper/circuit_elem.rs
@@ -124,7 +124,7 @@ where
 		}
 	}
 
-	fn combine<const IN: usize, const OUT: usize>(
+	pub fn combine<const IN: usize, const OUT: usize>(
 		elems: [&Self; IN],
 		f_op: impl Fn([F; IN]) -> [F; OUT],
 		builder_op: impl Fn(
@@ -178,7 +178,7 @@ where
 	/// `f_op` and `builder_op` must return a `Vec` of length `n_out`; checked via
 	/// `debug_assert_eq!` inside [`CircuitWire::combine_varlen`] (and here, for the
 	/// all-constants branch).
-	fn combine_varlen(
+	pub fn combine_varlen(
 		elems: &[&Self],
 		n_out: usize,
 		f_op: impl FnOnce(&[F]) -> Vec<F>,

--- a/crates/spartan-verifier/src/wrapper/zk_wrapped_channel.rs
+++ b/crates/spartan-verifier/src/wrapper/zk_wrapped_channel.rs
@@ -373,6 +373,27 @@ where
 			}
 		}
 	}
+
+	fn compute_public_value(
+		&mut self,
+		inputs: &[Self::Elem],
+		f: impl FnOnce(&[F]) -> F,
+	) -> Self::Elem {
+		let input_refs = inputs.iter().collect::<Vec<_>>();
+		let outs = CircuitElem::combine_varlen(
+			&input_refs,
+			1,
+			move |inputs| vec![f(inputs)],
+			|_, _| {
+				// Self::Elem::combine_varlen will only call the builder_op closure if any inputs
+				// are non-public.
+				panic!("compute_public_value: input is not public")
+			},
+		);
+		outs.into_iter()
+			.next()
+			.expect("combine_varlen returns Vec with len = n_out; n_out = 1")
+	}
 }
 
 impl<F, MTScheme, Challenger_> IOPVerifierChannel<F>

--- a/crates/verifier/src/protocols/shift/monster.rs
+++ b/crates/verifier/src/protocols/shift/monster.rs
@@ -16,7 +16,6 @@ use super::{
 	SHIFT_VARIANT_COUNT,
 	error::Error,
 	shift_ind::{partial_eval_phi, partial_eval_sigmas, partial_eval_sigmas_transpose},
-	verify::OperatorData,
 };
 use crate::config::{LOG_WORD_SIZE_BITS, WORD_SIZE_BITS};
 
@@ -102,7 +101,7 @@ pub fn evaluate_h_op<E: FieldOps>(l_tilde: &[E], r_j: &[E], r_s: &[E]) -> [E; SH
 /// $$
 ///
 /// where:
-/// - `m_idx` indexes the operand position (0 to ARITY-1)
+/// - `m_idx` indexes the operand position (0 to `operand_vecs.len() - 1`)
 /// - `op` ranges over the shift variants (logical/arithmetic shifts)
 /// - `h_op` is the shift selector polynomial
 /// - `M_m,op` is the multilinear extension of the operand values
@@ -110,8 +109,7 @@ pub fn evaluate_h_op<E: FieldOps>(l_tilde: &[E], r_j: &[E], r_s: &[E]) -> [E; SH
 /// # Arguments
 ///
 /// * `operand_vecs` - Vector of operand vectors, one per operand position in the constraint
-/// * `operator_data` - Contains the multilinear challenge `r_x'` and evaluation claims for each
-///   operand
+/// * `r_x_prime` - Multilinear challenge `r_x'` for the constraint variables
 /// * `lambda` - Random coefficient for batching operand evaluations
 /// * `r_s` - Challenge point for shift variables (length `LOG_WORD_SIZE_BITS`)
 /// * `r_y_tensor` - Equality indicator tensor expansion of the word index challenge `r_y`
@@ -122,9 +120,9 @@ pub fn evaluate_h_op<E: FieldOps>(l_tilde: &[E], r_j: &[E], r_s: &[E]) -> [E; SH
 ///
 /// The evaluation of the monster multilinear at the given challenge points, or an error
 /// if the computation fails.
-pub fn evaluate_monster_multilinear_for_operation<F, E, const ARITY: usize>(
+pub fn evaluate_monster_multilinear_for_operation<F, E>(
 	operand_vecs: &[Vec<&Operand>],
-	operator_data: &OperatorData<E, ARITY>,
+	r_x_prime: &[E],
 	lambda: E,
 	r_s: &[E],
 	r_y_tensor: &[E],
@@ -134,9 +132,12 @@ where
 	F: BinaryField,
 	E: FieldOps<Scalar = F> + From<F>,
 {
-	let r_x_prime_tensor = eq_ind_partial_eval_scalars(&operator_data.r_x_prime);
+	let r_x_prime_tensor = eq_ind_partial_eval_scalars(r_x_prime);
 
-	let lambda_powers = powers(lambda).skip(1).take(ARITY).collect::<Vec<_>>();
+	let lambda_powers = powers(lambda)
+		.skip(1)
+		.take(operand_vecs.len())
+		.collect::<Vec<_>>();
 	let evals = evaluate_matrices(operand_vecs, &lambda_powers, &r_x_prime_tensor, r_y_tensor);
 
 	let eval = inner_product_scalars(

--- a/crates/verifier/src/protocols/shift/verify.rs
+++ b/crates/verifier/src/protocols/shift/verify.rs
@@ -1,5 +1,7 @@
 // Copyright 2025 Irreducible Inc.
 
+use std::iter;
+
 use binius_core::constraint_system::{AndConstraint, ConstraintSystem, MulConstraint};
 use binius_field::{BinaryField, field::FieldOps};
 use binius_ip::channel::IPVerifierChannel;
@@ -226,43 +228,84 @@ where
 		witness_eval,
 	} = output;
 
-	// Compute monster multilinear evaluation. The shift selector evaluations `h_op_evals`
-	// depend only on the shared `r_zhat_prime`, `r_j`, and `r_s`, so they're computed
-	// once and reused across both bitand and intmul.
-	let r_y_tensor = eq_ind_partial_eval_scalars(r_y);
-	let l_tilde = lagrange_evals_scalars(subspace, r_zhat_prime);
-	let h_op_evals = evaluate_h_op(&l_tilde, r_j, r_s);
-	let monster_eval_for_bitand = {
-		let (a, b, c) = constraint_system
-			.and_constraints
-			.iter()
-			.map(|AndConstraint { a, b, c }| (a, b, c))
-			.multiunzip();
-		evaluate_monster_multilinear_for_operation(
-			&[a, b, c],
-			bitand_data,
-			bitand_lambda.clone(),
-			r_s,
-			&r_y_tensor,
-			&h_op_evals,
-		)
-	}?;
-	let monster_eval_for_intmul = {
-		let (a, b, lo, hi) = constraint_system
-			.mul_constraints
-			.iter()
-			.map(|MulConstraint { a, b, hi, lo }| (a, b, lo, hi))
-			.multiunzip();
-		evaluate_monster_multilinear_for_operation(
-			&[a, b, lo, hi],
-			intmul_data,
-			intmul_lambda.clone(),
-			r_s,
-			&r_y_tensor,
-			&h_op_evals,
-		)
-	}?;
-	let monster_eval = monster_eval_for_bitand + monster_eval_for_intmul;
+	// `monster_eval` is a function of purely public-channel-derived elements
+	// (`r_zhat_prime`, `bitand_lambda`, `intmul_lambda`, the operator data's `r_x_prime`
+	// vectors, `r_j`, `r_s`, `r_y`) plus the constant `subspace` and `constraint_system`.
+	// Trade those Elems for plain field values, run the MLE evaluation in plaintext, and
+	// materialize the result as a single inout wire instead of building the entire
+	// sub-circuit in wrapper channels.
+	let monster_eval = {
+		let bitand_r_x_prime_len = bitand_data.r_x_prime.len();
+		let intmul_r_x_prime_len = intmul_data.r_x_prime.len();
+		let r_j_len = r_j.len();
+		let r_s_len = r_s.len();
+		let r_y_len = r_y.len();
+
+		let inputs: Vec<C::Elem> = iter::once(r_zhat_prime.clone())
+			.chain(iter::once(bitand_lambda.clone()))
+			.chain(iter::once(intmul_lambda.clone()))
+			.chain(bitand_data.r_x_prime.iter().cloned())
+			.chain(intmul_data.r_x_prime.iter().cloned())
+			.chain(r_j.iter().cloned())
+			.chain(r_s.iter().cloned())
+			.chain(r_y.iter().cloned())
+			.collect();
+
+		channel.compute_public_value(&inputs, move |vals| {
+			let r_zhat_prime_v = vals[0];
+			let bitand_lambda_v = vals[1];
+			let intmul_lambda_v = vals[2];
+			let mut off = 3;
+			let bitand_r_x_prime_v = &vals[off..off + bitand_r_x_prime_len];
+			off += bitand_r_x_prime_len;
+			let intmul_r_x_prime_v = &vals[off..off + intmul_r_x_prime_len];
+			off += intmul_r_x_prime_len;
+			let r_j_v = &vals[off..off + r_j_len];
+			off += r_j_len;
+			let r_s_v = &vals[off..off + r_s_len];
+			off += r_s_len;
+			let r_y_v = &vals[off..off + r_y_len];
+
+			let r_y_tensor = eq_ind_partial_eval_scalars(r_y_v);
+			let l_tilde = lagrange_evals_scalars(subspace, r_zhat_prime_v);
+			let h_op_evals = evaluate_h_op(&l_tilde, r_j_v, r_s_v);
+
+			let bitand_part = {
+				let (a, b, c) = constraint_system
+					.and_constraints
+					.iter()
+					.map(|AndConstraint { a, b, c }| (a, b, c))
+					.multiunzip();
+				evaluate_monster_multilinear_for_operation::<F, F>(
+					&[a, b, c],
+					bitand_r_x_prime_v,
+					bitand_lambda_v,
+					r_s_v,
+					&r_y_tensor,
+					&h_op_evals,
+				)
+				.expect("evaluate_monster_multilinear_for_operation has no fallible path")
+			};
+			let intmul_part = {
+				let (a, b, lo, hi) = constraint_system
+					.mul_constraints
+					.iter()
+					.map(|MulConstraint { a, b, hi, lo }| (a, b, lo, hi))
+					.multiunzip();
+				evaluate_monster_multilinear_for_operation::<F, F>(
+					&[a, b, lo, hi],
+					intmul_r_x_prime_v,
+					intmul_lambda_v,
+					r_s_v,
+					&r_y_tensor,
+					&h_op_evals,
+				)
+				.expect("evaluate_monster_multilinear_for_operation has no fallible path")
+			};
+
+			bitand_part + intmul_part
+		})
+	};
 
 	// Check if the prover-provided witness value is satisfying.
 	//


### PR DESCRIPTION
## Summary
- Apply the same optimization as #1465 to the outer Binius64 verifier's
  `shift::check_eval`. The `monster_eval` computation is purely a function
  of public-channel-derived elements (`r_zhat_prime`, the lambdas, the
  operator data's `r_x_prime` vectors, `r_j`/`r_s`/`r_y`) plus compile-time
  constants (`subspace`, `constraint_system`). Wrap it in a single
  `channel.compute_public_value` call so wrapper channels materialize the
  result as one inout wire instead of laying down a sub-circuit's worth of
  constraints; in non-wrapper channels (`Elem = F`) it collapses to
  `f(inputs)`.
- Tighten `evaluate_monster_multilinear_for_operation`'s signature: drop
  the `OperatorData<E, ARITY>` parameter (only its `r_x_prime` field was
  used) and the `ARITY` const generic, replacing them with a plain
  `r_x_prime: &[E]` slice.

> [!NOTE]
> This is a temporary performance hack along the same lines as
> `compute_public_value` itself. An upcoming change will handle this
> computation more elegantly via better witness-generation code, after
> which this site (and the trait method) should be revisited and removed.

## Test plan
- [x] `cargo build -p binius-verifier`
- [x] `cargo test -p binius-verifier`
- [x] `cargo test -p binius-prover` (incl. `prove_verify` and `shift`
      integration tests)
- [x] `cargo test -p binius-spartan-prover --test wrapper_integration_test`
      (`test_zk_wrapped_prove_verify`)
- [x] `cargo clippy -p binius-verifier --tests --all-features`
