### PR TITLE
Introduce HashSuite trait and migrate workspace to it

### DIFF
--- a/crates/examples/benches/utils/runner.rs
+++ b/crates/examples/benches/utils/runner.rs
@@ -3,8 +3,9 @@
 
 use std::error::Error;
 
-use binius_examples::{ExampleCircuit, setup_sha256};
+use binius_examples::{ExampleCircuit, setup};
 use binius_frontend::CircuitBuilder;
+use binius_hash::StdHashSuite;
 use binius_utils::platform_diagnostics::PlatformDiagnostics;
 use binius_verifier::{
 	config::StdChallenger,
@@ -79,7 +80,7 @@ pub fn run_cs_benchmark<B: ExampleBenchmark>(
 	let example = B::build_example_circuit(params.clone(), &mut builder).unwrap();
 	let circuit = builder.build();
 	let cs = circuit.constraint_system().clone();
-	let (verifier, prover) = setup_sha256(cs, benchmark.log_inv_rate(), None).unwrap();
+	let (verifier, prover) = setup::<StdHashSuite>(cs, benchmark.log_inv_rate(), None).unwrap();
 
 	// Track memory for witness generation
 	peak_alloc.reset_peak_memory();

--- a/crates/examples/examples/tutorials/end_to_end_example.rs
+++ b/crates/examples/examples/tutorials/end_to_end_example.rs
@@ -10,15 +10,10 @@
 use binius_circuits::sha256::Sha256;
 use binius_core::{verify::verify_constraints, word::Word};
 use binius_frontend::CircuitBuilder;
-use binius_prover::{
-	OptimalPackedB128, Prover, hash::parallel_compression::ParallelCompressionAdaptor,
-};
+use binius_hash::StdHashSuite;
+use binius_prover::{OptimalPackedB128, Prover};
 use binius_transcript::{ProverTranscript, VerifierTranscript};
-use binius_verifier::{
-	Verifier,
-	config::StdChallenger,
-	hash::{StdCompression, StdDigest},
-};
+use binius_verifier::{Verifier, config::StdChallenger};
 use sha2::{Digest, Sha256 as StdSha256};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -57,9 +52,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 	println!("✓ the wire values you populated satisfy the circuit's constraints");
 
-	let compression = ParallelCompressionAdaptor::new(StdCompression::default());
-	let verifier = Verifier::<StdDigest, _>::setup(cs.clone(), 1, StdCompression::default())?;
-	let prover = Prover::<OptimalPackedB128, _, StdDigest>::setup(verifier.clone(), compression)?;
+	let verifier = Verifier::<StdHashSuite>::setup(cs.clone(), 1)?;
+	let prover = Prover::<OptimalPackedB128, StdHashSuite>::setup(verifier.clone())?;
 
 	let challenger = StdChallenger::default();
 	let mut prover_transcript = ProverTranscript::new(challenger.clone());

--- a/crates/examples/src/bin/prover.rs
+++ b/crates/examples/src/bin/prover.rs
@@ -3,7 +3,8 @@ use std::{fs, path::PathBuf};
 
 use anyhow::{Context, Result};
 use binius_core::constraint_system::{ConstraintSystem, Proof, ValueVec, ValuesData};
-use binius_examples::setup_sha256;
+use binius_examples::setup;
+use binius_hash::StdHashSuite;
 use binius_utils::serialization::{DeserializeBytes, SerializeBytes};
 use binius_verifier::{
 	config::{ChallengerWithName, StdChallenger},
@@ -72,7 +73,7 @@ fn main() -> Result<()> {
 		.context("Failed to reconstruct ValueVec from provided values")?;
 
 	// Setup prover (verifier is not used here)
-	let (_verifier, prover) = setup_sha256(cs, args.log_inv_rate as usize, None)?;
+	let (_verifier, prover) = setup::<StdHashSuite>(cs, args.log_inv_rate as usize, None)?;
 
 	// Prove
 	let mut prover_transcript = ProverTranscript::new(StdChallenger::default());

--- a/crates/examples/src/bin/verifier.rs
+++ b/crates/examples/src/bin/verifier.rs
@@ -8,7 +8,6 @@ use binius_utils::serialization::DeserializeBytes;
 use binius_verifier::{
 	Verifier,
 	config::{ChallengerWithName, StdChallenger},
-	hash::StdCompression,
 	transcript::VerifierTranscript,
 };
 use clap::Parser;
@@ -73,8 +72,7 @@ fn main() -> Result<()> {
 
 	// Set up the verifier
 	let verifier: StdVerifier =
-		Verifier::setup(cs, args.log_inv_rate as usize, StdCompression::default())
-			.context("Failed to setup verifier")?;
+		Verifier::setup(cs, args.log_inv_rate as usize).context("Failed to setup verifier")?;
 
 	// Create a verifier transcript from the serialized proof data
 	let (data, _) = proof.into_owned();

--- a/crates/examples/src/cli.rs
+++ b/crates/examples/src/cli.rs
@@ -4,13 +4,11 @@ use std::{fs, path::Path};
 use anyhow::Result;
 use binius_core::constraint_system::{ConstraintSystem, ValueVec, ValuesData};
 use binius_frontend::{CircuitBuilder, CircuitStat};
+use binius_hash::{StdHashSuite, vision::VisionHashSuite};
 use binius_utils::serialization::{DeserializeBytes, SerializeBytes};
 use clap::{Arg, Args, Command, FromArgMatches, Subcommand};
 
-use crate::{
-	CompressionType, ExampleCircuit, prove_verify, prove_verify_zk, setup_sha256, setup_vision,
-	setup_zk_sha256, setup_zk_vision,
-};
+use crate::{CompressionType, ExampleCircuit, prove_verify, prove_verify_zk, setup, setup_zk};
 
 /// Serialize a value implementing `SerializeBytes` and write it to the given path.
 fn write_serialized<T: SerializeBytes>(value: &T, path: &str) -> Result<()> {
@@ -514,22 +512,22 @@ where
 		match (zk, compression) {
 			(false, CompressionType::Sha256) => {
 				tracing::info!("Using SHA256 compression for Merkle tree");
-				let (verifier, prover) = setup_sha256(cs, log_inv_rate as usize, None)?;
+				let (verifier, prover) = setup::<StdHashSuite>(cs, log_inv_rate as usize, None)?;
 				prove_verify(&verifier, &prover, witness)?;
 			}
 			(false, CompressionType::Vision) => {
 				tracing::info!("Using Vision suite for Merkle tree");
-				let (verifier, prover) = setup_vision(cs, log_inv_rate as usize, None)?;
+				let (verifier, prover) = setup::<VisionHashSuite>(cs, log_inv_rate as usize, None)?;
 				prove_verify(&verifier, &prover, witness)?;
 			}
 			(true, CompressionType::Sha256) => {
 				tracing::info!("Using SHA256 compression for Merkle tree");
-				let (verifier, prover) = setup_zk_sha256(cs, log_inv_rate as usize)?;
+				let (verifier, prover) = setup_zk::<StdHashSuite>(cs, log_inv_rate as usize)?;
 				prove_verify_zk(&verifier, &prover, witness)?;
 			}
 			(true, CompressionType::Vision) => {
 				tracing::info!("Using Vision suite for Merkle tree");
-				let (verifier, prover) = setup_zk_vision(cs, log_inv_rate as usize)?;
+				let (verifier, prover) = setup_zk::<VisionHashSuite>(cs, log_inv_rate as usize)?;
 				prove_verify_zk(&verifier, &prover, witness)?;
 			}
 		}
@@ -722,13 +720,13 @@ where
 			CompressionType::Sha256 => {
 				tracing::info!("Using SHA256 compression for Merkle tree");
 				let (verifier, prover) =
-					setup_sha256(cs, log_inv_rate as usize, maybe_key_collection)?;
+					setup::<StdHashSuite>(cs, log_inv_rate as usize, maybe_key_collection)?;
 				prove_verify(&verifier, &prover, witness)?;
 			}
 			CompressionType::Vision => {
 				tracing::info!("Using Vision suite for Merkle tree");
 				let (verifier, prover) =
-					setup_vision(cs, log_inv_rate as usize, maybe_key_collection)?;
+					setup::<VisionHashSuite>(cs, log_inv_rate as usize, maybe_key_collection)?;
 				prove_verify(&verifier, &prover, witness)?;
 			}
 		};

--- a/crates/examples/src/cli.rs
+++ b/crates/examples/src/cli.rs
@@ -8,8 +8,8 @@ use binius_utils::serialization::{DeserializeBytes, SerializeBytes};
 use clap::{Arg, Args, Command, FromArgMatches, Subcommand};
 
 use crate::{
-	CompressionType, ExampleCircuit, prove_verify, prove_verify_zk, setup_sha256, setup_vision4,
-	setup_zk_sha256, setup_zk_vision4,
+	CompressionType, ExampleCircuit, prove_verify, prove_verify_zk, setup_sha256, setup_vision,
+	setup_zk_sha256, setup_zk_vision,
 };
 
 /// Serialize a value implementing `SerializeBytes` and write it to the given path.
@@ -517,9 +517,9 @@ where
 				let (verifier, prover) = setup_sha256(cs, log_inv_rate as usize, None)?;
 				prove_verify(&verifier, &prover, witness)?;
 			}
-			(false, CompressionType::Vision4) => {
-				tracing::info!("Using Vision4 compression for Merkle tree");
-				let (verifier, prover) = setup_vision4(cs, log_inv_rate as usize, None)?;
+			(false, CompressionType::Vision) => {
+				tracing::info!("Using Vision suite for Merkle tree");
+				let (verifier, prover) = setup_vision(cs, log_inv_rate as usize, None)?;
 				prove_verify(&verifier, &prover, witness)?;
 			}
 			(true, CompressionType::Sha256) => {
@@ -527,9 +527,9 @@ where
 				let (verifier, prover) = setup_zk_sha256(cs, log_inv_rate as usize)?;
 				prove_verify_zk(&verifier, &prover, witness)?;
 			}
-			(true, CompressionType::Vision4) => {
-				tracing::info!("Using Vision4 compression for Merkle tree");
-				let (verifier, prover) = setup_zk_vision4(cs, log_inv_rate as usize)?;
+			(true, CompressionType::Vision) => {
+				tracing::info!("Using Vision suite for Merkle tree");
+				let (verifier, prover) = setup_zk_vision(cs, log_inv_rate as usize)?;
 				prove_verify_zk(&verifier, &prover, witness)?;
 			}
 		}
@@ -725,10 +725,10 @@ where
 					setup_sha256(cs, log_inv_rate as usize, maybe_key_collection)?;
 				prove_verify(&verifier, &prover, witness)?;
 			}
-			CompressionType::Vision4 => {
-				tracing::info!("Using Vision4 compression for Merkle tree");
+			CompressionType::Vision => {
+				tracing::info!("Using Vision suite for Merkle tree");
 				let (verifier, prover) =
-					setup_vision4(cs, log_inv_rate as usize, maybe_key_collection)?;
+					setup_vision(cs, log_inv_rate as usize, maybe_key_collection)?;
 				prove_verify(&verifier, &prover, witness)?;
 			}
 		};

--- a/crates/examples/src/lib.rs
+++ b/crates/examples/src/lib.rs
@@ -9,14 +9,10 @@ use anyhow::Result;
 use binius_core::constraint_system::{ConstraintSystem, ValueVec};
 use binius_frontend::{CircuitBuilder, WitnessFiller};
 use binius_hash::{
-	ParallelCompressionAdaptor, ParallelDigest, ParallelPseudoCompression,
-	PseudoCompressionFunction, StdCompression, StdDigest,
-	vision_4::{
-		compression::VisionCompression, digest::VisionHasherDigest,
-		parallel_compression::VisionParallelCompression,
-	},
+	binary_merkle_tree::HashSuite, sha256::Sha256HashSuite, vision::VisionHashSuite,
 };
 use binius_prover::{KeyCollection, OptimalPackedB128, Prover, zk_config::ZKProver};
+use binius_utils::SerializeBytes;
 use binius_verifier::{
 	Verifier,
 	config::StdChallenger,
@@ -25,35 +21,32 @@ use binius_verifier::{
 };
 use clap::ValueEnum;
 pub use cli::Cli;
-use digest::{Digest, FixedOutputReset, Output, block_api::BlockSizeUser};
+use digest::Output;
 
 #[derive(Debug, Clone, ValueEnum)]
 pub enum CompressionType {
 	/// SHA-256 compression function
 	Sha256,
-	/// Vision 4-element compression function
-	Vision4,
+	/// Vision compression function (Vision-6 leaves, Vision-4 inner-node compression)
+	Vision,
 }
 
 /// Standard verifier using SHA256 compression
-pub type StdVerifier = Verifier<StdDigest, StdCompression>;
+pub type StdVerifier = Verifier<Sha256HashSuite>;
 /// Standard prover using SHA256 compression
-pub type StdProver =
-	Prover<OptimalPackedB128, ParallelCompressionAdaptor<StdCompression>, StdDigest>;
-/// Vision4 verifier
-pub type VisionVerifier = Verifier<VisionHasherDigest, VisionCompression>;
-/// Vision4 prover
-pub type VisionProver = Prover<OptimalPackedB128, VisionParallelCompression, VisionHasherDigest>;
+pub type StdProver = Prover<OptimalPackedB128, Sha256HashSuite>;
+/// Vision verifier (Vision-6 leaves + Vision-4 compression)
+pub type VisionVerifier = Verifier<VisionHashSuite>;
+/// Vision prover (Vision-6 leaves + Vision-4 compression)
+pub type VisionProver = Prover<OptimalPackedB128, VisionHashSuite>;
 /// Standard ZK verifier using SHA256 compression
-pub type StdZKVerifier = ZKVerifier<StdDigest, StdCompression>;
+pub type StdZKVerifier = ZKVerifier<Sha256HashSuite>;
 /// Standard ZK prover using SHA256 compression
-pub type StdZKProver =
-	ZKProver<OptimalPackedB128, ParallelCompressionAdaptor<StdCompression>, StdDigest>;
-/// Vision4 ZK verifier
-pub type VisionZKVerifier = ZKVerifier<VisionHasherDigest, VisionCompression>;
-/// Vision4 ZK prover
-pub type VisionZKProver =
-	ZKProver<OptimalPackedB128, VisionParallelCompression, VisionHasherDigest>;
+pub type StdZKProver = ZKProver<OptimalPackedB128, Sha256HashSuite>;
+/// Vision ZK verifier (Vision-6 leaves + Vision-4 compression)
+pub type VisionZKVerifier = ZKVerifier<VisionHashSuite>;
+/// Vision ZK prover (Vision-6 leaves + Vision-4 compression)
+pub type VisionZKProver = ZKProver<OptimalPackedB128, VisionHashSuite>;
 
 /// Setup the prover and verifier and use SHA256 for Merkle tree compression.
 /// Providing the `key_collection` skips expensive key collection building.
@@ -63,32 +56,28 @@ pub fn setup_sha256(
 	key_collection: Option<KeyCollection>,
 ) -> Result<(StdVerifier, StdProver)> {
 	let _setup_guard = tracing::info_span!("Setup", log_inv_rate).entered();
-	let parallel_compression = ParallelCompressionAdaptor::new(StdCompression::default());
-	let compression = parallel_compression.compression().clone();
-	let verifier = Verifier::setup(cs, log_inv_rate, compression)?;
+	let verifier = Verifier::setup(cs, log_inv_rate)?;
 	let prover = if let Some(key_collection) = key_collection {
-		Prover::setup_with_key_collection(verifier.clone(), parallel_compression, key_collection)?
+		Prover::setup_with_key_collection(verifier.clone(), key_collection)?
 	} else {
-		Prover::setup(verifier.clone(), parallel_compression)?
+		Prover::setup(verifier.clone())?
 	};
 	Ok((verifier, prover))
 }
 
-/// Setup the prover and verifier and use ZK-friendly hash Vision4 for Merkle tree compression.
+/// Setup the prover and verifier and use the ZK-friendly Vision suite for Merkle tree hashing.
 /// Providing the `key_collection` skips expensive key collection building.
-pub fn setup_vision4(
+pub fn setup_vision(
 	cs: ConstraintSystem,
 	log_inv_rate: usize,
 	key_collection: Option<KeyCollection>,
 ) -> Result<(VisionVerifier, VisionProver)> {
 	let _setup_guard = tracing::info_span!("Setup", log_inv_rate).entered();
-	let parallel_compression = VisionParallelCompression::default();
-	let compression = parallel_compression.compression().clone();
-	let verifier = Verifier::setup(cs, log_inv_rate, compression)?;
+	let verifier = Verifier::setup(cs, log_inv_rate)?;
 	let prover = if let Some(key_collection) = key_collection {
-		Prover::setup_with_key_collection(verifier.clone(), parallel_compression, key_collection)?
+		Prover::setup_with_key_collection(verifier.clone(), key_collection)?
 	} else {
-		Prover::setup(verifier.clone(), parallel_compression)?
+		Prover::setup(verifier.clone())?
 	};
 	Ok((verifier, prover))
 }
@@ -99,36 +88,30 @@ pub fn setup_zk_sha256(
 	log_inv_rate: usize,
 ) -> Result<(StdZKVerifier, StdZKProver)> {
 	let _setup_guard = tracing::info_span!("ZK setup", log_inv_rate).entered();
-	let parallel_compression = ParallelCompressionAdaptor::new(StdCompression::default());
-	let compression = parallel_compression.compression().clone();
-	let verifier = ZKVerifier::setup(cs, log_inv_rate, compression)?;
-	let prover = ZKProver::setup(verifier.clone(), parallel_compression)?;
+	let verifier = ZKVerifier::setup(cs, log_inv_rate)?;
+	let prover = ZKProver::setup(verifier.clone())?;
 	Ok((verifier, prover))
 }
 
-/// Setup the ZK prover and verifier using ZK-friendly hash Vision4 for Merkle tree compression.
-pub fn setup_zk_vision4(
+/// Setup the ZK prover and verifier using the ZK-friendly Vision suite for Merkle tree hashing.
+pub fn setup_zk_vision(
 	cs: ConstraintSystem,
 	log_inv_rate: usize,
 ) -> Result<(VisionZKVerifier, VisionZKProver)> {
 	let _setup_guard = tracing::info_span!("ZK setup", log_inv_rate).entered();
-	let parallel_compression = VisionParallelCompression::default();
-	let compression = parallel_compression.compression().clone();
-	let verifier = ZKVerifier::setup(cs, log_inv_rate, compression)?;
-	let prover = ZKProver::setup(verifier.clone(), parallel_compression)?;
+	let verifier = ZKVerifier::setup(cs, log_inv_rate)?;
+	let prover = ZKProver::setup(verifier.clone())?;
 	Ok((verifier, prover))
 }
 
-pub fn prove_verify<D, C, ParD, ParC>(
-	verifier: &Verifier<D, C>,
-	prover: &Prover<OptimalPackedB128, ParC, ParD>,
+pub fn prove_verify<H>(
+	verifier: &Verifier<H>,
+	prover: &Prover<OptimalPackedB128, H>,
 	witness: ValueVec,
 ) -> Result<()>
 where
-	D: Digest + BlockSizeUser + FixedOutputReset,
-	C: PseudoCompressionFunction<Output<D>, 2>,
-	ParD: ParallelDigest<Digest = D>,
-	ParC: ParallelPseudoCompression<Output<D>, 2, Compression = C>,
+	H: HashSuite,
+	Output<H::LeafHash>: SerializeBytes + binius_utils::DeserializeBytes,
 {
 	let challenger = StdChallenger::default();
 
@@ -145,16 +128,14 @@ where
 	Ok(())
 }
 
-pub fn prove_verify_zk<D, C, ParD, ParC>(
-	verifier: &ZKVerifier<D, C>,
-	prover: &ZKProver<OptimalPackedB128, ParC, ParD>,
+pub fn prove_verify_zk<H>(
+	verifier: &ZKVerifier<H>,
+	prover: &ZKProver<OptimalPackedB128, H>,
 	witness: ValueVec,
 ) -> Result<()>
 where
-	D: Digest + BlockSizeUser + FixedOutputReset,
-	C: PseudoCompressionFunction<Output<D>, 2>,
-	ParD: ParallelDigest<Digest = D>,
-	ParC: ParallelPseudoCompression<Output<D>, 2, Compression = C>,
+	H: HashSuite,
+	Output<H::LeafHash>: SerializeBytes + binius_utils::DeserializeBytes,
 {
 	let challenger = StdChallenger::default();
 

--- a/crates/examples/src/lib.rs
+++ b/crates/examples/src/lib.rs
@@ -12,7 +12,7 @@ use binius_hash::{
 	binary_merkle_tree::HashSuite, sha256::Sha256HashSuite, vision::VisionHashSuite,
 };
 use binius_prover::{KeyCollection, OptimalPackedB128, Prover, zk_config::ZKProver};
-use binius_utils::SerializeBytes;
+use binius_utils::{DeserializeBytes, SerializeBytes};
 use binius_verifier::{
 	Verifier,
 	config::StdChallenger,
@@ -48,15 +48,22 @@ pub type VisionZKVerifier = ZKVerifier<VisionHashSuite>;
 /// Vision ZK prover (Vision-6 leaves + Vision-4 compression)
 pub type VisionZKProver = ZKProver<OptimalPackedB128, VisionHashSuite>;
 
-/// Setup the prover and verifier and use SHA256 for Merkle tree compression.
-/// Providing the `key_collection` skips expensive key collection building.
-pub fn setup_sha256(
+/// Set up a non-ZK prover and verifier for the given constraint system using `H` as the
+/// Merkle hash suite.
+///
+/// Providing `key_collection` skips the expensive key-collection building phase during prover
+/// setup.
+pub fn setup<H>(
 	cs: ConstraintSystem,
 	log_inv_rate: usize,
 	key_collection: Option<KeyCollection>,
-) -> Result<(StdVerifier, StdProver)> {
+) -> Result<(Verifier<H>, Prover<OptimalPackedB128, H>)>
+where
+	H: HashSuite + Clone,
+	Output<H::LeafHash>: SerializeBytes + DeserializeBytes,
+{
 	let _setup_guard = tracing::info_span!("Setup", log_inv_rate).entered();
-	let verifier = Verifier::setup(cs, log_inv_rate)?;
+	let verifier = Verifier::<H>::setup(cs, log_inv_rate)?;
 	let prover = if let Some(key_collection) = key_collection {
 		Prover::setup_with_key_collection(verifier.clone(), key_collection)?
 	} else {
@@ -65,41 +72,18 @@ pub fn setup_sha256(
 	Ok((verifier, prover))
 }
 
-/// Setup the prover and verifier and use the ZK-friendly Vision suite for Merkle tree hashing.
-/// Providing the `key_collection` skips expensive key collection building.
-pub fn setup_vision(
+/// Set up a ZK prover and verifier for the given constraint system using `H` as the Merkle
+/// hash suite.
+pub fn setup_zk<H>(
 	cs: ConstraintSystem,
 	log_inv_rate: usize,
-	key_collection: Option<KeyCollection>,
-) -> Result<(VisionVerifier, VisionProver)> {
-	let _setup_guard = tracing::info_span!("Setup", log_inv_rate).entered();
-	let verifier = Verifier::setup(cs, log_inv_rate)?;
-	let prover = if let Some(key_collection) = key_collection {
-		Prover::setup_with_key_collection(verifier.clone(), key_collection)?
-	} else {
-		Prover::setup(verifier.clone())?
-	};
-	Ok((verifier, prover))
-}
-
-/// Setup the ZK prover and verifier using SHA256 for Merkle tree compression.
-pub fn setup_zk_sha256(
-	cs: ConstraintSystem,
-	log_inv_rate: usize,
-) -> Result<(StdZKVerifier, StdZKProver)> {
+) -> Result<(ZKVerifier<H>, ZKProver<OptimalPackedB128, H>)>
+where
+	H: HashSuite + Clone,
+	Output<H::LeafHash>: SerializeBytes + DeserializeBytes,
+{
 	let _setup_guard = tracing::info_span!("ZK setup", log_inv_rate).entered();
-	let verifier = ZKVerifier::setup(cs, log_inv_rate)?;
-	let prover = ZKProver::setup(verifier.clone())?;
-	Ok((verifier, prover))
-}
-
-/// Setup the ZK prover and verifier using the ZK-friendly Vision suite for Merkle tree hashing.
-pub fn setup_zk_vision(
-	cs: ConstraintSystem,
-	log_inv_rate: usize,
-) -> Result<(VisionZKVerifier, VisionZKProver)> {
-	let _setup_guard = tracing::info_span!("ZK setup", log_inv_rate).entered();
-	let verifier = ZKVerifier::setup(cs, log_inv_rate)?;
+	let verifier = ZKVerifier::<H>::setup(cs, log_inv_rate)?;
 	let prover = ZKProver::setup(verifier.clone())?;
 	Ok((verifier, prover))
 }
@@ -111,7 +95,7 @@ pub fn prove_verify<H>(
 ) -> Result<()>
 where
 	H: HashSuite,
-	Output<H::LeafHash>: SerializeBytes + binius_utils::DeserializeBytes,
+	Output<H::LeafHash>: SerializeBytes + DeserializeBytes,
 {
 	let challenger = StdChallenger::default();
 
@@ -135,7 +119,7 @@ pub fn prove_verify_zk<H>(
 ) -> Result<()>
 where
 	H: HashSuite,
-	Output<H::LeafHash>: SerializeBytes + binius_utils::DeserializeBytes,
+	Output<H::LeafHash>: SerializeBytes + DeserializeBytes,
 {
 	let challenger = StdChallenger::default();
 

--- a/crates/hash/Cargo.toml
+++ b/crates/hash/Cargo.toml
@@ -18,12 +18,10 @@ bytemuck.workspace = true
 bytes.workspace = true
 digest.workspace = true
 itertools.workspace = true
+rand.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
-
-[dev-dependencies]
-rand.workspace = true
 
 [features]
 default = []

--- a/crates/hash/src/binary_merkle_tree.rs
+++ b/crates/hash/src/binary_merkle_tree.rs
@@ -64,17 +64,15 @@ pub struct BinaryMerkleTree<D, F> {
 	pub salts: Vec<F>,
 }
 
-pub fn build<F, H, C, R>(
-	compression: &C,
+pub fn build<F, H, R>(
 	elements: &[F],
 	batch_size: usize,
 	salt_len: usize,
 	rng: R,
-) -> Result<BinaryMerkleTree<Output<H::Digest>, F>, Error>
+) -> Result<BinaryMerkleTree<Output<H::LeafHash>, F>, Error>
 where
 	F: Field,
-	H: ParallelDigest<Digest: BlockSizeUser + FixedOutputReset>,
-	C: ParallelPseudoCompression<Output<H::Digest>, 2>,
+	H: HashSuite,
 	R: Rng + CryptoRng,
 {
 	if !elements.len().is_multiple_of(batch_size) {
@@ -87,8 +85,7 @@ where
 		return Err(Error::PowerOfTwoLengthRequired);
 	}
 
-	build_from_iterator::<_, H, _, _, _>(
-		compression,
+	build_from_iterator::<_, H, _, _>(
 		elements
 			.par_chunks(batch_size)
 			.map(|chunk| chunk.iter().copied()),
@@ -97,16 +94,14 @@ where
 	)
 }
 
-pub fn build_from_iterator<F, H, C, R, ParIter>(
-	compression: &C,
+pub fn build_from_iterator<F, H, R, ParIter>(
 	iterated_chunks: ParIter,
 	salt_len: usize,
 	mut rng: R,
-) -> Result<BinaryMerkleTree<Output<H::Digest>, F>, Error>
+) -> Result<BinaryMerkleTree<Output<H::LeafHash>, F>, Error>
 where
 	F: Field,
-	H: ParallelDigest<Digest: BlockSizeUser + FixedOutputReset>,
-	C: ParallelPseudoCompression<Output<H::Digest>, 2>,
+	H: HashSuite,
 	R: Rng + CryptoRng,
 	ParIter: IndexedParallelIterator<Item: IntoIterator<Item = F, IntoIter: Send>>,
 {
@@ -130,11 +125,12 @@ where
 		// SAFETY: prev-layer was initialized by hash_leaves
 		slice_assume_init_mut(prev_layer)
 	};
+	let parallel_compression = H::ParCompression::default();
 	for i in 1..(log_len + 1) {
 		let (next_layer, next_remaining) = remaining.split_at_mut(1 << (log_len - i));
 		remaining = next_remaining;
 
-		compression.parallel_compress(prev_layer, next_layer);
+		parallel_compression.parallel_compress(prev_layer, next_layer);
 
 		prev_layer = unsafe {
 			// SAFETY: next_layer was just initialized by compress_layer
@@ -211,17 +207,17 @@ impl<D: Clone, F> BinaryMerkleTree<D, F> {
 #[tracing::instrument("hash_leaves", skip_all, level = "debug")]
 fn hash_leaves<F, H, ParIter>(
 	iterated_chunks: ParIter,
-	digests: &mut [MaybeUninit<Output<H::Digest>>],
+	digests: &mut [MaybeUninit<Output<H::LeafHash>>],
 	salts: &[F],
 ) where
 	F: Field,
-	H: ParallelDigest<Digest: BlockSizeUser + FixedOutputReset>,
+	H: HashSuite,
 	ParIter: IndexedParallelIterator<Item: IntoIterator<Item = F, IntoIter: Send>>,
 {
 	if salts.is_empty() {
 		// Need special-case handling when salts is empty, otherwise salt_len is 0 and par_chunks
 		// cannot handle chunk size of 0.
-		let hasher = H::new();
+		let hasher = H::ParLeafHash::default();
 		hasher.digest(iterated_chunks, digests);
 	} else {
 		assert!(salts.len().is_multiple_of(digests.len()));
@@ -233,7 +229,7 @@ fn hash_leaves<F, H, ParIter>(
 			.zip(salts.par_chunks(salt_len))
 			.map(|(chunk, salt)| chunk.into_iter().chain(salt.iter().copied()));
 
-		let hasher = H::new();
+		let hasher = H::ParLeafHash::default();
 		hasher.digest(salted_iter, digests);
 	}
 }

--- a/crates/hash/src/binary_merkle_tree.rs
+++ b/crates/hash/src/binary_merkle_tree.rs
@@ -1,10 +1,9 @@
 // Copyright 2024-2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 use std::{fmt::Debug, mem::MaybeUninit};
 
 use binius_field::Field;
-use binius_hash::{ParallelDigest, ParallelPseudoCompression};
-use binius_iop::merkle_tree::Error;
 use binius_utils::{
 	checked_arithmetics::log2_strict_usize,
 	mem::slice_assume_init_mut,
@@ -13,6 +12,20 @@ use binius_utils::{
 };
 use digest::{FixedOutputReset, Output, block_api::BlockSizeUser};
 use rand::{CryptoRng, Rng, rngs::StdRng};
+
+use crate::{ParallelDigest, ParallelPseudoCompression};
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+	#[error("Index exceeds Merkle tree base size: {max}")]
+	IndexOutOfRange { max: usize },
+	#[error("values length must be a multiple of the batch size")]
+	IncorrectBatchSize,
+	#[error("The argument length must be a power of two.")]
+	PowerOfTwoLengthRequired,
+	#[error("The layer does not exist in the Merkle tree")]
+	IncorrectLayerDepth,
+}
 
 /// A binary Merkle tree that commits batches of vectors.
 ///

--- a/crates/hash/src/binary_merkle_tree.rs
+++ b/crates/hash/src/binary_merkle_tree.rs
@@ -10,10 +10,32 @@ use binius_utils::{
 	rand::par_rand,
 	rayon::{prelude::*, slice::ParallelSlice},
 };
-use digest::{FixedOutputReset, Output, block_api::BlockSizeUser};
+use digest::{Digest, FixedOutputReset, Output, block_api::BlockSizeUser};
 use rand::{CryptoRng, Rng, rngs::StdRng};
 
-use crate::{ParallelDigest, ParallelPseudoCompression};
+use super::{
+	compress::PseudoCompressionFunction, parallel_compression::ParallelPseudoCompression,
+	parallel_digest::ParallelDigest,
+};
+
+/// A bundle of hash and compression types used to build and verify a binary Merkle tree.
+///
+/// Most callers want to vary the underlying hash family (SHA-256, Vision, etc.) as a single unit
+/// rather than independently picking a leaf hash, a compression function, and their parallel
+/// counterparts. `HashSuite` bundles the four related types so that user-facing prover and
+/// verifier APIs can take a single `H: HashSuite` parameter instead of two or three loose hash
+/// trait parameters.
+pub trait HashSuite {
+	/// Sequential hash used to compute leaf digests during verification.
+	type LeafHash: Digest + BlockSizeUser + FixedOutputReset + Send;
+	/// Sequential 2-to-1 compression used to fold inner Merkle nodes during verification.
+	type Compression: PseudoCompressionFunction<Output<Self::LeafHash>, 2> + Default;
+	/// Parallel counterpart of [`Self::LeafHash`] used during proving.
+	type ParLeafHash: ParallelDigest<Digest = Self::LeafHash> + Default;
+	/// Parallel counterpart of [`Self::Compression`] used during proving.
+	type ParCompression: ParallelPseudoCompression<Output<Self::LeafHash>, 2, Compression = Self::Compression>
+		+ Default;
+}
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {

--- a/crates/hash/src/compress.rs
+++ b/crates/hash/src/compress.rs
@@ -20,39 +20,3 @@ pub trait PseudoCompressionFunction<T, const N: usize>: Clone {
 
 /// An `N`-to-1 compression function.
 pub trait CompressionFunction<T, const N: usize>: PseudoCompressionFunction<T, N> {}
-
-pub mod sha256 {
-	use bytemuck::{bytes_of_mut, must_cast};
-	use digest::Digest;
-	use sha2::{Sha256, block_api::compress256, digest::Output};
-
-	use super::*;
-
-	/// A two-to-one compression function for SHA-256 digests.
-	#[derive(Debug, Clone)]
-	pub struct Sha256Compression {
-		initial_state: [u32; 8],
-	}
-
-	impl Default for Sha256Compression {
-		fn default() -> Self {
-			let initial_state_bytes = Sha256::digest(b"BINIUS SHA-256 COMPRESS");
-			let mut initial_state = [0u32; 8];
-			bytes_of_mut(&mut initial_state).copy_from_slice(&initial_state_bytes);
-			Self { initial_state }
-		}
-	}
-
-	impl PseudoCompressionFunction<Output<Sha256>, 2> for Sha256Compression {
-		fn compress(&self, input: [Output<Sha256>; 2]) -> Output<Sha256> {
-			let mut ret = self.initial_state;
-			let mut block = [0u8; 64];
-			block[..32].copy_from_slice(input[0].as_slice());
-			block[32..].copy_from_slice(input[1].as_slice());
-			compress256(&mut ret, &[block]);
-			must_cast::<[u32; 8], [u8; 32]>(ret).into()
-		}
-	}
-
-	impl CompressionFunction<Output<Sha256>, 2> for Sha256Compression {}
-}

--- a/crates/hash/src/lib.rs
+++ b/crates/hash/src/lib.rs
@@ -8,6 +8,7 @@
 //! including both standard hash functions (SHA-256) and specialized binary field hash functions
 //! (Vision).
 
+pub mod binary_merkle_tree;
 pub mod compress;
 pub mod parallel_compression;
 pub mod parallel_digest;

--- a/crates/hash/src/lib.rs
+++ b/crates/hash/src/lib.rs
@@ -13,6 +13,7 @@ pub mod compress;
 pub mod parallel_compression;
 pub mod parallel_digest;
 mod serialization;
+pub mod sha256;
 pub mod vision;
 pub mod vision_4;
 pub mod vision_6;
@@ -24,4 +25,4 @@ pub use serialization::*;
 
 /// The standard digest is SHA-256.
 pub type StdDigest = sha2::Sha256;
-pub type StdCompression = compress::sha256::Sha256Compression;
+pub type StdCompression = sha256::Sha256Compression;

--- a/crates/hash/src/lib.rs
+++ b/crates/hash/src/lib.rs
@@ -26,3 +26,4 @@ pub use serialization::*;
 /// The standard digest is SHA-256.
 pub type StdDigest = sha2::Sha256;
 pub type StdCompression = sha256::Sha256Compression;
+pub type StdHashSuite = sha256::Sha256HashSuite;

--- a/crates/hash/src/parallel_compression.rs
+++ b/crates/hash/src/parallel_compression.rs
@@ -50,7 +50,7 @@ pub trait ParallelPseudoCompression<T, const N: usize> {
 ///
 /// This adapter provides a straightforward way to use existing compression functions
 /// in parallel contexts by applying them sequentially to each N-element chunk.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct ParallelCompressionAdaptor<C> {
 	compression: C,
 }

--- a/crates/hash/src/parallel_digest.rs
+++ b/crates/hash/src/parallel_digest.rs
@@ -96,6 +96,12 @@ pub trait ParallelDigest: Send {
 #[derive(Clone)]
 pub struct ParallelMultidigestImpl<D: MultiDigest<N>, const N: usize>(D);
 
+impl<D: MultiDigest<N> + Default, const N: usize> Default for ParallelMultidigestImpl<D, N> {
+	fn default() -> Self {
+		Self(D::default())
+	}
+}
+
 impl<D: MultiDigest<N, Digest: Send> + Send + Sync, const N: usize> ParallelDigest
 	for ParallelMultidigestImpl<D, N>
 {

--- a/crates/hash/src/sha256.rs
+++ b/crates/hash/src/sha256.rs
@@ -7,7 +7,11 @@ use bytemuck::{bytes_of_mut, must_cast};
 use digest::Digest;
 use sha2::{Sha256, block_api::compress256, digest::Output};
 
-use crate::{CompressionFunction, PseudoCompressionFunction};
+use super::{
+	binary_merkle_tree::HashSuite,
+	compress::{CompressionFunction, PseudoCompressionFunction},
+	parallel_compression::ParallelCompressionAdaptor,
+};
 
 /// A two-to-one compression function for SHA-256 digests.
 #[derive(Debug, Clone)]
@@ -36,3 +40,14 @@ impl PseudoCompressionFunction<Output<Sha256>, 2> for Sha256Compression {
 }
 
 impl CompressionFunction<Output<Sha256>, 2> for Sha256Compression {}
+
+/// SHA-256 [`HashSuite`]: SHA-256 leaves and a SHA-256 compression function for inner nodes.
+#[derive(Debug, Clone, Default)]
+pub struct Sha256HashSuite;
+
+impl HashSuite for Sha256HashSuite {
+	type LeafHash = Sha256;
+	type Compression = Sha256Compression;
+	type ParLeafHash = Sha256;
+	type ParCompression = ParallelCompressionAdaptor<Sha256Compression>;
+}

--- a/crates/hash/src/sha256.rs
+++ b/crates/hash/src/sha256.rs
@@ -1,0 +1,38 @@
+// Copyright 2024-2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
+
+//! SHA-256 compression function for use in Merkle tree constructions.
+
+use bytemuck::{bytes_of_mut, must_cast};
+use digest::Digest;
+use sha2::{Sha256, block_api::compress256, digest::Output};
+
+use crate::{CompressionFunction, PseudoCompressionFunction};
+
+/// A two-to-one compression function for SHA-256 digests.
+#[derive(Debug, Clone)]
+pub struct Sha256Compression {
+	initial_state: [u32; 8],
+}
+
+impl Default for Sha256Compression {
+	fn default() -> Self {
+		let initial_state_bytes = Sha256::digest(b"BINIUS SHA-256 COMPRESS");
+		let mut initial_state = [0u32; 8];
+		bytes_of_mut(&mut initial_state).copy_from_slice(&initial_state_bytes);
+		Self { initial_state }
+	}
+}
+
+impl PseudoCompressionFunction<Output<Sha256>, 2> for Sha256Compression {
+	fn compress(&self, input: [Output<Sha256>; 2]) -> Output<Sha256> {
+		let mut ret = self.initial_state;
+		let mut block = [0u8; 64];
+		block[..32].copy_from_slice(input[0].as_slice());
+		block[32..].copy_from_slice(input[1].as_slice());
+		compress256(&mut ret, &[block]);
+		must_cast::<[u32; 8], [u8; 32]>(ret).into()
+	}
+}
+
+impl CompressionFunction<Output<Sha256>, 2> for Sha256Compression {}

--- a/crates/hash/src/vision.rs
+++ b/crates/hash/src/vision.rs
@@ -9,12 +9,43 @@ use digest::Output;
 use itertools::izip;
 
 use crate::{
-	parallel_digest::MultiDigest,
+	binary_merkle_tree::HashSuite,
+	parallel_digest::{MultiDigest, ParallelMultidigestImpl},
 	vision_4::{
 		M,
+		compression::VisionCompression,
 		digest::{PADDING_BLOCK, RATE_AS_U8, VisionHasherDigest, fill_padding},
+		parallel_compression::VisionParallelCompression,
 	},
 };
+
+/// Parallel batch size for the Vision parallel hash and compression types.
+///
+/// 128 is the largest batch before the Montgomery-trick amortization in the parallel Vision
+/// permutation stops paying off; this matches the constant used in
+/// `vision_4::parallel_compression`.
+const VISION_PAR_N: usize = 128;
+
+/// Vision [`HashSuite`]: Vision-6 leaves paired with a Vision-4 2-to-1 compression.
+///
+/// Vision-6 has a wider internal state and absorbs leaf data faster, while Vision-4 produces a
+/// smaller (and faster) 2-to-1 compression for inner Merkle nodes. The two share a digest output
+/// type (32 bytes), so they can be composed directly.
+#[derive(Debug, Clone, Default)]
+pub struct VisionHashSuite;
+
+impl HashSuite for VisionHashSuite {
+	type LeafHash = crate::vision_6::digest::VisionHasherDigest;
+	type Compression = VisionCompression;
+	type ParLeafHash = ParallelMultidigestImpl<
+		crate::vision_6::parallel_digest::VisionHasherMultiDigest<
+			VISION_PAR_N,
+			{ VISION_PAR_N * crate::vision_6::M },
+		>,
+		VISION_PAR_N,
+	>;
+	type ParCompression = VisionParallelCompression;
+}
 
 /// A Vision hasher suited for parallelization.
 ///

--- a/crates/iop-prover/src/basefold.rs
+++ b/crates/iop-prover/src/basefold.rs
@@ -242,7 +242,7 @@ mod test {
 		BinaryField, PackedBinaryGhash1x128b, PackedBinaryGhash2x128b, PackedBinaryGhash4x128b,
 		PackedExtension, PackedField,
 	};
-	use binius_hash::{ParallelCompressionAdaptor, StdCompression, StdDigest};
+	use binius_hash::{StdDigest, StdHashSuite};
 	use binius_iop::{basefold as verifier_basefold, fri::ConstantArityStrategy};
 	use binius_math::{
 		BinarySubspace, FieldBuffer,
@@ -280,9 +280,7 @@ mod test {
 	{
 		let eval_point_eq = eq_ind_partial_eval::<P>(&evaluation_point);
 
-		let merkle_prover = BinaryMerkleTreeProver::<F, StdDigest, _>::new(
-			ParallelCompressionAdaptor::new(StdCompression::default()),
-		);
+		let merkle_prover = BinaryMerkleTreeProver::<F, StdHashSuite>::new();
 
 		let subspace = BinarySubspace::with_dim(multilinear.log_len() + LOG_INV_RATE);
 		let domain_context = GenericOnTheFly::generate_from_subspace(&subspace);
@@ -382,9 +380,7 @@ mod test {
 
 		let eval_point_eq = eq_ind_partial_eval::<P>(&evaluation_point);
 
-		let merkle_prover = BinaryMerkleTreeProver::<F, StdDigest, _>::new(
-			ParallelCompressionAdaptor::new(StdCompression::default()),
-		);
+		let merkle_prover = BinaryMerkleTreeProver::<F, StdHashSuite>::new();
 
 		// Setup NTT with subspace dimension = witness.log_len + LOG_INV_RATE
 		let subspace = BinarySubspace::with_dim(n_vars + LOG_INV_RATE);

--- a/crates/iop-prover/src/basefold_channel.rs
+++ b/crates/iop-prover/src/basefold_channel.rs
@@ -300,7 +300,7 @@ where
 #[cfg(test)]
 mod tests {
 	use binius_field::{BinaryField, BinaryField128bGhash, PackedBinaryGhash1x128b, PackedField};
-	use binius_hash::{ParallelCompressionAdaptor, StdCompression, StdDigest};
+	use binius_hash::{StdDigest, StdHashSuite};
 	use binius_iop::{channel::OracleSpec, fri::MinProofSizeStrategy};
 	use binius_math::{
 		BinarySubspace, FieldBuffer,
@@ -369,9 +369,7 @@ mod tests {
 			generate_oracle_data::<F, P, _>(&mut rng, n_vars_2);
 
 		let max_codeword_log_len = n_vars_2 + LOG_INV_RATE;
-		let merkle_prover = BinaryMerkleTreeProver::<F, StdDigest, _>::new(
-			ParallelCompressionAdaptor::new(StdCompression::default()),
-		);
+		let merkle_prover = BinaryMerkleTreeProver::<F, StdHashSuite>::new();
 
 		let subspace = BinarySubspace::with_dim(max_codeword_log_len);
 		let domain_context = GenericOnTheFly::generate_from_subspace(&subspace);
@@ -419,9 +417,7 @@ mod tests {
 		let n_vars_1 = 6;
 		let n_vars_2 = 8;
 
-		let merkle_prover = BinaryMerkleTreeProver::<F, StdDigest, _>::new(
-			ParallelCompressionAdaptor::new(StdCompression::default()),
-		);
+		let merkle_prover = BinaryMerkleTreeProver::<F, StdHashSuite>::new();
 		let merkle_scheme = merkle_prover.scheme().clone();
 
 		let n_test_queries = calculate_n_test_queries(SECURITY_BITS, LOG_INV_RATE);

--- a/crates/iop-prover/src/basefold_zk_channel.rs
+++ b/crates/iop-prover/src/basefold_zk_channel.rs
@@ -262,7 +262,7 @@ where
 #[cfg(test)]
 mod tests {
 	use binius_field::{BinaryField, BinaryField128bGhash, PackedBinaryGhash1x128b, PackedField};
-	use binius_hash::{ParallelCompressionAdaptor, StdCompression, StdDigest};
+	use binius_hash::{StdDigest, StdHashSuite};
 	use binius_iop::{
 		basefold_compiler::BaseFoldZKVerifierCompiler,
 		channel::{IOPVerifierChannel, OracleLinearRelation, OracleSpec},
@@ -299,12 +299,8 @@ mod tests {
 		NeighborsLastSingleThread::new(domain_context)
 	}
 
-	fn make_merkle_prover() -> BinaryMerkleTreeProver<
-		BinaryField128bGhash,
-		StdDigest,
-		ParallelCompressionAdaptor<StdCompression>,
-	> {
-		BinaryMerkleTreeProver::new(ParallelCompressionAdaptor::new(StdCompression::default()))
+	fn make_merkle_prover() -> BinaryMerkleTreeProver<BinaryField128bGhash, StdHashSuite> {
+		BinaryMerkleTreeProver::new()
 	}
 
 	fn generate_zk_oracle_data<F, P, R: Rng>(

--- a/crates/iop-prover/src/fri/commit.rs
+++ b/crates/iop-prover/src/fri/commit.rs
@@ -201,7 +201,7 @@ mod tests {
 		BinaryField128bGhash as B128, PackedBinaryGhash1x128b, PackedBinaryGhash2x128b,
 		PackedBinaryGhash4x128b,
 	};
-	use binius_hash::{ParallelCompressionAdaptor, StdCompression, StdDigest};
+	use binius_hash::StdHashSuite;
 	use binius_iop::fri::FRIParams;
 	use binius_math::{
 		BinarySubspace, FieldBuffer,
@@ -225,9 +225,7 @@ mod tests {
 		let log_batch_size = 1;
 		let n_test_queries = 3;
 
-		let merkle_prover = BinaryMerkleTreeProver::<F, StdDigest, _>::new(
-			ParallelCompressionAdaptor::new(StdCompression::default()),
-		);
+		let merkle_prover = BinaryMerkleTreeProver::<F, StdHashSuite>::new();
 
 		let subspace = BinarySubspace::with_dim(log_dim + log_inv_rate);
 		let domain_context = GenericOnTheFly::generate_from_subspace(&subspace);

--- a/crates/iop-prover/src/fri/tests.rs
+++ b/crates/iop-prover/src/fri/tests.rs
@@ -6,7 +6,7 @@ use std::vec;
 use binius_field::{
 	BinaryField, BinaryField128bGhash as B128, PackedBinaryGhash1x128b, PackedField,
 };
-use binius_hash::{ParallelCompressionAdaptor, StdCompression, StdDigest};
+use binius_hash::{StdDigest, StdHashSuite};
 use binius_iop::fri::{self, FRIFoldVerifier, FRIParams, verify::FRIQueryVerifier};
 use binius_math::{
 	BinarySubspace, ReedSolomonCode,
@@ -37,8 +37,7 @@ fn test_commit_prove_verify_success<F, P>(
 {
 	let mut rng = StdRng::seed_from_u64(0);
 
-	let parallel_compression = ParallelCompressionAdaptor::new(StdCompression::default());
-	let merkle_prover = BinaryMerkleTreeProver::<_, StdDigest, _>::new(parallel_compression);
+	let merkle_prover = BinaryMerkleTreeProver::<_, StdHashSuite>::new();
 
 	let committed_rs_code = ReedSolomonCode::<F>::new(log_dimension, log_inv_rate);
 
@@ -240,19 +239,14 @@ fn generate_fri_proof<F, P>(
 	log_inv_rate: usize,
 	log_batch_size: usize,
 	arities: &[usize],
-) -> (
-	Vec<u8>,
-	FRIParams<F>,
-	binius_iop::merkle_tree::BinaryMerkleTreeScheme<F, StdDigest, StdCompression>,
-)
+) -> (Vec<u8>, FRIParams<F>, binius_iop::merkle_tree::BinaryMerkleTreeScheme<F, StdHashSuite>)
 where
 	F: BinaryField,
 	P: PackedField<Scalar = F>,
 {
 	let mut rng = StdRng::seed_from_u64(0);
 
-	let parallel_compression = ParallelCompressionAdaptor::new(StdCompression::default());
-	let merkle_prover = BinaryMerkleTreeProver::<_, StdDigest, _>::new(parallel_compression);
+	let merkle_prover = BinaryMerkleTreeProver::<_, StdHashSuite>::new();
 
 	let committed_rs_code = ReedSolomonCode::<F>::new(log_dimension, log_inv_rate);
 

--- a/crates/iop-prover/src/merkle_tree/mod.rs
+++ b/crates/iop-prover/src/merkle_tree/mod.rs
@@ -4,7 +4,6 @@ use binius_iop::merkle_tree::{Commitment, Error, MerkleTreeScheme};
 use binius_transcript::{BufMut, TranscriptWriter};
 use binius_utils::rayon::prelude::*;
 
-pub mod binary_merkle_tree;
 pub mod prover;
 #[cfg(test)]
 mod tests;

--- a/crates/iop-prover/src/merkle_tree/prover.rs
+++ b/crates/iop-prover/src/merkle_tree/prover.rs
@@ -1,66 +1,56 @@
 // Copyright 2024-2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 use std::sync::Mutex;
 
 use binius_field::Field;
-use binius_hash::{
-	ParallelDigest, ParallelPseudoCompression,
-	binary_merkle_tree::{self, BinaryMerkleTree},
-};
+use binius_hash::binary_merkle_tree::{self, BinaryMerkleTree, HashSuite};
 use binius_iop::merkle_tree::{BinaryMerkleTreeScheme, Commitment, Error, MerkleTreeScheme};
 use binius_transcript::{BufMut, TranscriptWriter};
 use binius_utils::rayon::iter::IndexedParallelIterator;
-use digest::{FixedOutputReset, Output, block_api::BlockSizeUser};
+use digest::Output;
 use getset::Getters;
 use rand::{CryptoRng, SeedableRng, rngs::StdRng};
 
 use super::MerkleTreeProver;
 
-#[derive(Debug, Getters)]
-pub struct BinaryMerkleTreeProver<T, H: ParallelDigest, C>
-where
-	C: ParallelPseudoCompression<Output<H::Digest>, 2>,
-{
+#[derive(Getters)]
+pub struct BinaryMerkleTreeProver<T, H: HashSuite> {
 	#[getset(get = "pub")]
-	scheme: BinaryMerkleTreeScheme<T, H::Digest, C::Compression>,
-	parallel_compression: C,
+	scheme: BinaryMerkleTreeScheme<T, H>,
 	salt_rng: Mutex<StdRng>,
 }
 
-impl<T, C, H: ParallelDigest> BinaryMerkleTreeProver<T, H, C>
-where
-	C: ParallelPseudoCompression<Output<H::Digest>, 2>,
-	C::Compression: Clone,
-{
-	pub fn new(parallel_compression: C) -> Self {
+impl<T, H: HashSuite> BinaryMerkleTreeProver<T, H> {
+	pub fn new() -> Self {
 		Self {
-			scheme: BinaryMerkleTreeScheme::new(parallel_compression.compression().clone()),
-			parallel_compression,
+			scheme: BinaryMerkleTreeScheme::new(),
 			// We can construct a dummy Rng with a deterministic seed because it will be unused.
 			salt_rng: Mutex::new(StdRng::seed_from_u64(0)),
 		}
 	}
 
-	pub fn hiding(parallel_compression: C, mut rng: impl CryptoRng, salt_len: usize) -> Self {
+	pub fn hiding(mut rng: impl CryptoRng, salt_len: usize) -> Self {
 		Self {
-			scheme: BinaryMerkleTreeScheme::hiding(
-				parallel_compression.compression().clone(),
-				salt_len,
-			),
-			parallel_compression,
+			scheme: BinaryMerkleTreeScheme::hiding(salt_len),
 			salt_rng: Mutex::new(StdRng::from_rng(&mut rng)),
 		}
 	}
 }
 
-impl<F, H, C> MerkleTreeProver<F> for BinaryMerkleTreeProver<F, H, C>
+impl<T, H: HashSuite> Default for BinaryMerkleTreeProver<T, H> {
+	fn default() -> Self {
+		Self::new()
+	}
+}
+
+impl<F, H> MerkleTreeProver<F> for BinaryMerkleTreeProver<F, H>
 where
 	F: Field,
-	H: ParallelDigest<Digest: BlockSizeUser + FixedOutputReset>,
-	C: ParallelPseudoCompression<Output<H::Digest>, 2>,
+	H: HashSuite,
 {
-	type Scheme = BinaryMerkleTreeScheme<F, H::Digest, C::Compression>;
-	type Committed = BinaryMerkleTree<Output<H::Digest>, F>;
+	type Scheme = BinaryMerkleTreeScheme<F, H>;
+	type Committed = BinaryMerkleTree<Output<H::LeafHash>, F>;
 
 	fn scheme(&self) -> &Self::Scheme {
 		&self.scheme
@@ -70,7 +60,7 @@ where
 		&self,
 		committed: &'a Self::Committed,
 		depth: usize,
-	) -> Result<&'a [Output<H::Digest>], Error> {
+	) -> Result<&'a [Output<H::LeafHash>], Error> {
 		Ok(committed.layer(depth)?)
 	}
 
@@ -102,8 +92,7 @@ where
 			let mut root_rng = self.salt_rng.lock().unwrap();
 			StdRng::from_rng(&mut *root_rng)
 		};
-		let tree = binary_merkle_tree::build_from_iterator::<F, H, _, _, _>(
-			&self.parallel_compression,
+		let tree = binary_merkle_tree::build_from_iterator::<F, H, _, _>(
 			leaves,
 			self.scheme.salt_len(),
 			salt_rng,

--- a/crates/iop-prover/src/merkle_tree/prover.rs
+++ b/crates/iop-prover/src/merkle_tree/prover.rs
@@ -3,7 +3,10 @@
 use std::sync::Mutex;
 
 use binius_field::Field;
-use binius_hash::{ParallelDigest, ParallelPseudoCompression};
+use binius_hash::{
+	ParallelDigest, ParallelPseudoCompression,
+	binary_merkle_tree::{self, BinaryMerkleTree},
+};
 use binius_iop::merkle_tree::{BinaryMerkleTreeScheme, Commitment, Error, MerkleTreeScheme};
 use binius_transcript::{BufMut, TranscriptWriter};
 use binius_utils::rayon::iter::IndexedParallelIterator;
@@ -12,7 +15,6 @@ use getset::Getters;
 use rand::{CryptoRng, SeedableRng, rngs::StdRng};
 
 use super::MerkleTreeProver;
-use crate::merkle_tree::binary_merkle_tree::{self, BinaryMerkleTree};
 
 #[derive(Debug, Getters)]
 pub struct BinaryMerkleTreeProver<T, H: ParallelDigest, C>
@@ -69,7 +71,7 @@ where
 		committed: &'a Self::Committed,
 		depth: usize,
 	) -> Result<&'a [Output<H::Digest>], Error> {
-		committed.layer(depth)
+		Ok(committed.layer(depth)?)
 	}
 
 	fn prove_opening<B: BufMut>(

--- a/crates/iop-prover/src/merkle_tree/tests.rs
+++ b/crates/iop-prover/src/merkle_tree/tests.rs
@@ -4,7 +4,7 @@
 use core::slice;
 
 use binius_field::BinaryField128bGhash as B128;
-use binius_hash::{ParallelCompressionAdaptor, StdCompression, StdDigest};
+use binius_hash::{StdDigest, StdHashSuite};
 use binius_iop::merkle_tree::MerkleTreeScheme;
 use binius_math::test_utils::random_scalars;
 use binius_transcript::{ProverTranscript, VerifierTranscript, fiat_shamir::HasherChallenger};
@@ -18,8 +18,7 @@ type StdChallenger = HasherChallenger<StdDigest>;
 fn test_binary_merkle_vcs_commit_prove_open_correctly() {
 	let mut rng = StdRng::seed_from_u64(0);
 
-	let parallel_compression = ParallelCompressionAdaptor::new(StdCompression::default());
-	let mr_prover = BinaryMerkleTreeProver::<_, StdDigest, _>::new(parallel_compression);
+	let mr_prover = BinaryMerkleTreeProver::<_, StdHashSuite>::new();
 
 	let data = random_scalars::<B128>(&mut rng, 16);
 	let (commitment, tree) = mr_prover.commit(&data, 1).unwrap();
@@ -51,8 +50,7 @@ fn test_binary_merkle_vcs_commit_prove_open_correctly() {
 fn test_binary_merkle_vcs_commit_layer_prove_open_correctly() {
 	let mut rng = StdRng::seed_from_u64(0);
 
-	let parallel_compression = ParallelCompressionAdaptor::new(StdCompression::default());
-	let mr_prover = BinaryMerkleTreeProver::<_, StdDigest, _>::new(parallel_compression);
+	let mr_prover = BinaryMerkleTreeProver::<_, StdHashSuite>::new();
 
 	let data = random_scalars::<B128>(&mut rng, 32);
 	let (commitment, tree) = mr_prover.commit(&data, 1).unwrap();
@@ -90,8 +88,7 @@ fn test_binary_merkle_vcs_commit_layer_prove_open_correctly() {
 fn test_binary_merkle_vcs_verify_vector() {
 	let mut rng = StdRng::seed_from_u64(0);
 
-	let parallel_compression = ParallelCompressionAdaptor::new(StdCompression::default());
-	let mt_prover = BinaryMerkleTreeProver::<_, StdDigest, _>::new(parallel_compression);
+	let mt_prover = BinaryMerkleTreeProver::<_, StdHashSuite>::new();
 
 	let mut proof_reader = VerifierTranscript::new(StdChallenger::default(), Vec::new());
 	let data = random_scalars::<B128>(&mut rng, 4);
@@ -107,10 +104,8 @@ fn test_binary_merkle_vcs_verify_vector() {
 fn test_binary_merkle_vcs_hiding_commit_prove_open() {
 	let mut rng = StdRng::seed_from_u64(0);
 
-	let parallel_compression = ParallelCompressionAdaptor::new(StdCompression::default());
 	let salt_len = 2;
-	let mt_prover =
-		BinaryMerkleTreeProver::<_, StdDigest, _>::hiding(parallel_compression, &mut rng, salt_len);
+	let mt_prover = BinaryMerkleTreeProver::<_, StdHashSuite>::hiding(&mut rng, salt_len);
 
 	let data = random_scalars::<B128>(&mut rng, 16);
 	let (commitment, tree) = mt_prover.commit(&data, 1).unwrap();
@@ -143,10 +138,8 @@ fn test_binary_merkle_vcs_hiding_commit_prove_open() {
 fn test_binary_merkle_vcs_hiding_verify_vector() {
 	let mut rng = StdRng::seed_from_u64(0);
 
-	let parallel_compression = ParallelCompressionAdaptor::new(StdCompression::default());
 	let salt_len = 3;
-	let mt_prover =
-		BinaryMerkleTreeProver::<_, StdDigest, _>::hiding(parallel_compression, &mut rng, salt_len);
+	let mt_prover = BinaryMerkleTreeProver::<_, StdHashSuite>::hiding(&mut rng, salt_len);
 
 	let data = random_scalars::<B128>(&mut rng, 8);
 	let (commitment, tree) = mt_prover.commit(&data, 1).unwrap();
@@ -170,10 +163,8 @@ fn test_binary_merkle_vcs_hiding_verify_vector() {
 fn test_binary_merkle_vcs_hiding_batch_size() {
 	let mut rng = StdRng::seed_from_u64(0);
 
-	let parallel_compression = ParallelCompressionAdaptor::new(StdCompression::default());
 	let salt_len = 1;
-	let mt_prover =
-		BinaryMerkleTreeProver::<_, StdDigest, _>::hiding(parallel_compression, &mut rng, salt_len);
+	let mt_prover = BinaryMerkleTreeProver::<_, StdHashSuite>::hiding(&mut rng, salt_len);
 
 	let data = random_scalars::<B128>(&mut rng, 32);
 	let batch_size = 4;

--- a/crates/iop/src/fri/common.rs
+++ b/crates/iop/src/fri/common.rs
@@ -432,7 +432,7 @@ impl AritySelectionStrategy for ConstantArityStrategy {
 #[cfg(test)]
 mod tests {
 	use binius_field::BinaryField128bGhash as B128;
-	use binius_hash::StdCompression;
+	use binius_hash::StdHashSuite;
 	use binius_math::ntt::{
 		AdditiveNTT, NeighborsLastReference, domain_context::GaoMateerOnTheFly,
 	};
@@ -440,11 +440,10 @@ mod tests {
 	use super::*;
 	use crate::merkle_tree::BinaryMerkleTreeScheme;
 
-	type StdDigest = sha2::Sha256;
-	type TestMerkleScheme = BinaryMerkleTreeScheme<B128, StdDigest, StdCompression>;
+	type TestMerkleScheme = BinaryMerkleTreeScheme<B128, StdHashSuite>;
 
 	fn test_merkle_scheme() -> TestMerkleScheme {
-		BinaryMerkleTreeScheme::new(StdCompression::default())
+		BinaryMerkleTreeScheme::new()
 	}
 
 	#[test]

--- a/crates/iop/src/merkle_tree/error.rs
+++ b/crates/iop/src/merkle_tree/error.rs
@@ -1,4 +1,5 @@
 // Copyright 2024-2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 use binius_utils::SerializationError;
 
@@ -6,16 +7,10 @@ use binius_utils::SerializationError;
 pub enum Error {
 	#[error("Length of the input vector is incorrect, expected {expected}")]
 	IncorrectVectorLen { expected: usize },
-	#[error("Index exceeds Merkle tree base size: {max}")]
-	IndexOutOfRange { max: usize },
-	#[error("values length must be a multiple of the batch size")]
-	IncorrectBatchSize,
-	#[error("The argument length must be a power of two.")]
-	PowerOfTwoLengthRequired,
+	#[error("binary Merkle tree error: {0}")]
+	BinaryMerkleTree(#[from] binius_hash::binary_merkle_tree::Error),
 	#[error("Failed to serialize leaf element: {0}")]
 	Serialization(SerializationError),
-	#[error("The layer does not exist in the Merkle tree")]
-	IncorrectLayerDepth,
 	#[error("transcript error: {0}")]
 	Transcript(#[from] binius_transcript::Error),
 	#[error("verification failure: {0}")]

--- a/crates/iop/src/merkle_tree/scheme.rs
+++ b/crates/iop/src/merkle_tree/scheme.rs
@@ -1,69 +1,78 @@
 // Copyright 2024-2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 use std::{array, fmt::Debug, marker::PhantomData};
 
-use binius_hash::{PseudoCompressionFunction, binary_merkle_tree, hash_serialize};
+use binius_hash::{
+	PseudoCompressionFunction,
+	binary_merkle_tree::{self, HashSuite},
+	hash_serialize,
+};
 use binius_transcript::{Buf, TranscriptReader};
 use binius_utils::{
 	DeserializeBytes, SerializeBytes,
 	checked_arithmetics::{log2_ceil_usize, log2_strict_usize},
 };
-use digest::{Digest, Output, block_api::BlockSizeUser};
-use getset::{CopyGetters, Getters};
+use digest::{Digest, Output};
+use getset::CopyGetters;
 
 use super::{
 	error::{Error, VerificationError},
 	merkle_tree_vcs::MerkleTreeScheme,
 };
 
-#[derive(Debug, Clone, Getters, CopyGetters)]
-pub struct BinaryMerkleTreeScheme<T, H, C> {
+#[derive(Clone, CopyGetters)]
+pub struct BinaryMerkleTreeScheme<T, H: HashSuite> {
 	#[getset(get = "pub")]
-	compression: C,
+	compression: H::Compression,
 	#[getset(get_copy = "pub")]
 	salt_len: usize,
-	// This makes it so that `BinaryMerkleTreeScheme` remains Send + Sync
+	// This makes it so that `BinaryMerkleTreeScheme` remains Send + Sync regardless of `T`.
 	// See https://doc.rust-lang.org/nomicon/phantom-data.html#table-of-phantomdata-patterns
-	_phantom: PhantomData<fn() -> (T, H)>,
+	_phantom: PhantomData<fn() -> T>,
 }
 
-impl<T, H, C> BinaryMerkleTreeScheme<T, H, C> {
-	pub fn new(compression: C) -> Self {
-		Self::hiding(compression, 0)
+impl<T, H: HashSuite> Default for BinaryMerkleTreeScheme<T, H> {
+	fn default() -> Self {
+		Self::new()
+	}
+}
+
+impl<T, H: HashSuite> BinaryMerkleTreeScheme<T, H> {
+	pub fn new() -> Self {
+		Self::hiding(0)
 	}
 
-	pub fn hiding(compression: C, salt_len: usize) -> Self {
+	pub fn hiding(salt_len: usize) -> Self {
 		Self {
-			compression,
+			compression: H::Compression::default(),
 			salt_len,
 			_phantom: PhantomData,
 		}
 	}
 }
 
-impl<T, H, C> BinaryMerkleTreeScheme<T, H, C>
+impl<T, H> BinaryMerkleTreeScheme<T, H>
 where
 	T: SerializeBytes + DeserializeBytes,
-	H: Digest + BlockSizeUser,
-	C: PseudoCompressionFunction<Output<H>, 2>,
+	H: HashSuite,
 {
 	fn compute_leaf_digest<B: Buf>(
 		&self,
 		values: &[T],
 		proof: &mut TranscriptReader<B>,
-	) -> Result<Output<H>, Error> {
+	) -> Result<Output<H::LeafHash>, Error> {
 		let salt = proof.read_vec::<T>(self.salt_len)?;
-		hash_serialize::<T, H>(values.iter().chain(&salt)).map_err(Error::Serialization)
+		hash_serialize::<T, H::LeafHash>(values.iter().chain(&salt)).map_err(Error::Serialization)
 	}
 }
 
-impl<T, H, C> MerkleTreeScheme<T> for BinaryMerkleTreeScheme<T, H, C>
+impl<T, H> MerkleTreeScheme<T> for BinaryMerkleTreeScheme<T, H>
 where
 	T: SerializeBytes + DeserializeBytes,
-	H: Digest + BlockSizeUser,
-	C: PseudoCompressionFunction<Output<H>, 2>,
+	H: HashSuite,
 {
-	type Digest = Output<H>;
+	type Digest = Output<H::LeafHash>;
 
 	/// This layer allows minimizing the proof size.
 	fn optimal_verify_layer(&self, n_queries: usize, tree_depth: usize) -> usize {
@@ -82,7 +91,7 @@ where
 		}
 
 		Ok(((log_len - layer_depth) * n_queries + (1 << layer_depth))
-			* <H as Digest>::output_size())
+			* <H::LeafHash as Digest>::output_size())
 	}
 
 	fn verify_vector<B: Buf>(

--- a/crates/iop/src/merkle_tree/scheme.rs
+++ b/crates/iop/src/merkle_tree/scheme.rs
@@ -2,7 +2,7 @@
 
 use std::{array, fmt::Debug, marker::PhantomData};
 
-use binius_hash::{PseudoCompressionFunction, hash_serialize};
+use binius_hash::{PseudoCompressionFunction, binary_merkle_tree, hash_serialize};
 use binius_transcript::{Buf, TranscriptReader};
 use binius_utils::{
 	DeserializeBytes, SerializeBytes,
@@ -72,13 +72,13 @@ where
 
 	fn proof_size(&self, len: usize, n_queries: usize, layer_depth: usize) -> Result<usize, Error> {
 		if !len.is_power_of_two() {
-			return Err(Error::PowerOfTwoLengthRequired);
+			return Err(binary_merkle_tree::Error::PowerOfTwoLengthRequired.into());
 		}
 
 		let log_len = log2_strict_usize(len);
 
 		if layer_depth > log_len {
-			return Err(Error::IncorrectLayerDepth);
+			return Err(binary_merkle_tree::Error::IncorrectLayerDepth.into());
 		}
 
 		Ok(((log_len - layer_depth) * n_queries + (1 << layer_depth))
@@ -93,7 +93,7 @@ where
 		proof: &mut TranscriptReader<B>,
 	) -> Result<(), Error> {
 		if !data.len().is_multiple_of(batch_size) {
-			return Err(Error::IncorrectBatchSize);
+			return Err(binary_merkle_tree::Error::IncorrectBatchSize.into());
 		}
 
 		let digests = data
@@ -138,9 +138,10 @@ where
 		}
 
 		if index >= (1 << tree_depth) {
-			return Err(Error::IndexOutOfRange {
+			return Err(binary_merkle_tree::Error::IndexOutOfRange {
 				max: (1 << tree_depth) - 1,
-			});
+			}
+			.into());
 		}
 
 		let mut leaf_digest = self.compute_leaf_digest(values, proof)?;

--- a/crates/prover/benches/binary_merkle_tree.rs
+++ b/crates/prover/benches/binary_merkle_tree.rs
@@ -5,28 +5,19 @@ use std::iter::repeat_with;
 
 use binius_field::Random;
 use binius_hash::{
-	ParallelCompressionAdaptor, ParallelDigest, ParallelMultidigestImpl, PseudoCompressionFunction,
-	StdCompression, StdDigest,
-	vision_4::parallel_compression::VisionParallelCompression as VisionParallelCompression_4,
-	vision_6::parallel_digest::VisionHasherMultiDigest as VisionHasherMultiDigest_6,
+	binary_merkle_tree::HashSuite, sha256::Sha256HashSuite, vision::VisionHashSuite,
 };
 use binius_prover::merkle_tree::{MerkleTreeProver, prover::BinaryMerkleTreeProver};
 use binius_verifier::config::B128;
 use criterion::{Criterion, Throughput, criterion_group, criterion_main};
-use digest::{FixedOutputReset, Output, block_api::BlockSizeUser};
 
 const LOG_ELEMS: usize = 17;
 const LOG_ELEMS_IN_LEAF: usize = 4;
 
 type F = B128;
 
-fn bench_binary_merkle_tree<H, C>(c: &mut Criterion, compression: C, hash_name: &str)
-where
-	H: ParallelDigest<Digest: BlockSizeUser + FixedOutputReset>,
-	C: PseudoCompressionFunction<Output<H::Digest>, 2> + Sync,
-{
-	let parallel_compression = ParallelCompressionAdaptor::new(compression);
-	let merkle_prover = BinaryMerkleTreeProver::<_, H, _>::new(parallel_compression);
+fn bench_binary_merkle_tree<H: HashSuite>(c: &mut Criterion, hash_name: &str) {
+	let merkle_prover = BinaryMerkleTreeProver::<F, H>::new();
 	let mut rng = rand::rng();
 	let data = repeat_with(|| F::random(&mut rng))
 		.take(1 << (LOG_ELEMS + LOG_ELEMS_IN_LEAF))
@@ -46,33 +37,11 @@ where
 }
 
 fn bench_sha256_merkle_tree(c: &mut Criterion) {
-	bench_binary_merkle_tree::<StdDigest, _>(c, StdCompression::default(), "SHA-256");
+	bench_binary_merkle_tree::<Sha256HashSuite>(c, "SHA-256");
 }
 
-const N: usize = 128;
-type LeafHasher = ParallelMultidigestImpl<VisionHasherMultiDigest_6<N, { N * 6 }>, N>;
-
-// Use Vision6 for leaves and Vision4 for compression
 fn bench_vision_merkle_tree(c: &mut Criterion) {
-	let vision_compression = VisionParallelCompression_4::new();
-	let merkle_prover = BinaryMerkleTreeProver::<_, LeafHasher, _>::new(vision_compression);
-	let mut rng = rand::rng();
-	let data = repeat_with(|| F::random(&mut rng))
-		.take(1 << (LOG_ELEMS + LOG_ELEMS_IN_LEAF))
-		.collect::<Vec<_>>();
-
-	let mut group = c.benchmark_group("slow/merkle_tree/Vision");
-	group.throughput(Throughput::Bytes(
-		((1 << (LOG_ELEMS + LOG_ELEMS_IN_LEAF)) * std::mem::size_of::<F>()) as u64,
-	));
-	group.sample_size(10);
-	group.bench_function(
-		format!("{LOG_ELEMS} log elems size {}xB64 leaf", 1 << LOG_ELEMS_IN_LEAF),
-		|b| {
-			b.iter(|| merkle_prover.commit(&data, 1 << LOG_ELEMS_IN_LEAF));
-		},
-	);
-	group.finish()
+	bench_binary_merkle_tree::<VisionHashSuite>(c, "Vision");
 }
 
 criterion_group!(binary_merkle_tree, bench_sha256_merkle_tree, bench_vision_merkle_tree);

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -9,6 +9,7 @@ use binius_field::{
 	AESTowerField8b as B8, BinaryField, ExtensionField, PackedAESBinaryField16x8b, PackedExtension,
 	PackedField, UnderlierWithBitOps, WithUnderlier,
 };
+use binius_hash::binary_merkle_tree::HashSuite;
 use binius_iop_prover::{
 	basefold_channel::BaseFoldProverChannel, basefold_compiler::BaseFoldProverCompiler,
 	channel::IOPProverChannel,
@@ -29,12 +30,11 @@ use binius_verifier::{
 	},
 	protocols::{bitand::AndCheckOutput, intmul::IntMulOutput, sumcheck::SumcheckOutput},
 };
-use digest::{Digest, FixedOutputReset, Output, block_api::BlockSizeUser};
+use digest::Output;
 
 use super::error::Error;
 use crate::{
 	and_reduction::prover::OblongZerocheckProver,
-	hash::{ParallelDigest, parallel_compression::ParallelPseudoCompression},
 	merkle_tree::prover::BinaryMerkleTreeProver,
 	protocols::{
 		intmul::{prove::IntMulProver, witness::Witness as IntMulWitness},
@@ -49,8 +49,7 @@ use crate::{
 type ProverNTT<F> = NeighborsLastMultiThread<GenericPreExpanded<F>>;
 
 /// Type alias for the prover Merkle tree prover parameterized by field.
-type ProverMerkleProver<F, ParallelMerkleHasher, ParallelMerkleCompress> =
-	BinaryMerkleTreeProver<F, ParallelMerkleHasher, ParallelMerkleCompress>;
+type ProverMerkleProver<F, H> = BinaryMerkleTreeProver<F, H>;
 
 /// IOP prover for a particular constraint system.
 ///
@@ -260,43 +259,30 @@ impl IOPProver {
 /// The [`Self::setup`] constructor pre-processes reusable structures for proving instances of the
 /// given constraint system. Then [`Self::prove`] is called one or more times with individual
 /// instances.
-pub struct Prover<P, ParallelMerkleCompress, ParallelMerkleHasher>
+pub struct Prover<P, H>
 where
 	P: PackedField<Scalar = B128>,
-	ParallelMerkleHasher: ParallelDigest,
-	ParallelMerkleHasher::Digest: Digest + BlockSizeUser + FixedOutputReset,
-	ParallelMerkleCompress: ParallelPseudoCompression<Output<ParallelMerkleHasher::Digest>, 2>,
+	H: HashSuite,
 {
 	iop_prover: IOPProver,
-	#[allow(clippy::type_complexity)]
-	basefold_compiler: BaseFoldProverCompiler<
-		P,
-		ProverNTT<B128>,
-		ProverMerkleProver<B128, ParallelMerkleHasher, ParallelMerkleCompress>,
-	>,
+	basefold_compiler: BaseFoldProverCompiler<P, ProverNTT<B128>, ProverMerkleProver<B128, H>>,
 }
 
-impl<P, MerkleHash, ParallelMerkleCompress, ParallelMerkleHasher>
-	Prover<P, ParallelMerkleCompress, ParallelMerkleHasher>
+impl<P, H> Prover<P, H>
 where
 	P: PackedField<Scalar = B128>
 		+ PackedExtension<B128>
 		+ PackedExtension<B1>
 		+ WithUnderlier<Underlier: UnderlierWithBitOps>,
-	MerkleHash: Digest + BlockSizeUser + FixedOutputReset,
-	ParallelMerkleHasher: ParallelDigest<Digest = MerkleHash>,
-	ParallelMerkleCompress: ParallelPseudoCompression<Output<MerkleHash>, 2>,
-	Output<MerkleHash>: SerializeBytes,
+	H: HashSuite,
+	Output<H::LeafHash>: SerializeBytes,
 {
 	/// Constructs a prover corresponding to a constraint system verifier.
 	///
 	/// See [`Prover`] struct documentation for details.
-	pub fn setup(
-		verifier: Verifier<MerkleHash, ParallelMerkleCompress::Compression>,
-		compression: ParallelMerkleCompress,
-	) -> Result<Self, Error> {
+	pub fn setup(verifier: Verifier<H>) -> Result<Self, Error> {
 		let key_collection = build_key_collection(verifier.constraint_system());
-		Self::setup_with_key_collection(verifier, compression, key_collection)
+		Self::setup_with_key_collection(verifier, key_collection)
 	}
 
 	/// Constructs a prover with a pre-built KeyCollection.
@@ -304,8 +290,7 @@ where
 	/// This allows loading a previously serialized KeyCollection to avoid
 	/// the expensive key building phase during setup.
 	pub fn setup_with_key_collection(
-		verifier: Verifier<MerkleHash, ParallelMerkleCompress::Compression>,
-		compression: ParallelMerkleCompress,
+		verifier: Verifier<H>,
 		key_collection: KeyCollection,
 	) -> Result<Self, Error> {
 		// Get max subspace from verifier's IOP compiler (reuses FRI params)
@@ -317,7 +302,7 @@ where
 		let log_num_shares = binius_utils::rayon::current_num_threads().ilog2() as usize;
 		let ntt = NeighborsLastMultiThread::new(domain_context, log_num_shares);
 
-		let merkle_prover = BinaryMerkleTreeProver::<_, ParallelMerkleHasher, _>::new(compression);
+		let merkle_prover = BinaryMerkleTreeProver::<_, H>::new();
 
 		// Create prover compiler from verifier compiler (reuses FRI params and oracle specs)
 		let basefold_compiler = BaseFoldProverCompiler::from_verifier_compiler(

--- a/crates/prover/src/zk_config.rs
+++ b/crates/prover/src/zk_config.rs
@@ -10,6 +10,7 @@ use binius_core::{constraint_system::ValueVec, word::Word};
 use binius_field::{
 	BinaryField128bGhash as B128, PackedExtension, PackedField, UnderlierWithBitOps, WithUnderlier,
 };
+use binius_hash::binary_merkle_tree::HashSuite;
 use binius_iop_prover::basefold_compiler::BaseFoldZKProverCompiler;
 use binius_math::ntt::{NeighborsLastMultiThread, domain_context::GenericPreExpanded};
 use binius_spartan_frontend::{compiler::compile, constraint_system::WitnessLayout};
@@ -20,60 +21,43 @@ use binius_spartan_verifier::{
 use binius_transcript::{ProverTranscript, fiat_shamir::Challenger};
 use binius_utils::SerializeBytes;
 use binius_verifier::{IOPVerifier, zk_config::ZKVerifier};
-use digest::{Digest, FixedOutputReset, Output, block_api::BlockSizeUser};
+use digest::Output;
 use rand::CryptoRng;
 
 use crate::{
-	IOPProver,
-	hash::{ParallelDigest, parallel_compression::ParallelPseudoCompression},
-	merkle_tree::prover::BinaryMerkleTreeProver,
-	protocols::shift::build_key_collection,
+	IOPProver, merkle_tree::prover::BinaryMerkleTreeProver, protocols::shift::build_key_collection,
 };
 
 type ProverNTT<F> = NeighborsLastMultiThread<GenericPreExpanded<F>>;
-type ProverMerkleProver<F, ParallelMerkleHasher, ParallelMerkleCompress> =
-	BinaryMerkleTreeProver<F, ParallelMerkleHasher, ParallelMerkleCompress>;
+type ProverMerkleProver<F, H> = BinaryMerkleTreeProver<F, H>;
 
 /// Zero-knowledge prover for Binius64 constraint systems.
 ///
 /// Wraps the Binius64 IOP prover with a Spartan-based ZK wrapper. Call [`Self::setup`] with
 /// a [`ZKVerifier`], then [`Self::prove`] with witness data and a proof transcript.
-pub struct ZKProver<P, ParallelMerkleCompress, ParallelMerkleHasher>
+pub struct ZKProver<P, H>
 where
 	P: PackedField<Scalar = B128>,
-	ParallelMerkleHasher: ParallelDigest,
-	ParallelMerkleHasher::Digest: Digest + BlockSizeUser + FixedOutputReset,
-	ParallelMerkleCompress: ParallelPseudoCompression<Output<ParallelMerkleHasher::Digest>, 2>,
+	H: HashSuite,
 {
 	inner_iop_prover: IOPProver,
 	inner_iop_verifier: IOPVerifier,
 	outer_iop_prover: binius_spartan_prover::IOPProver<B128>,
 	outer_layout: WitnessLayout<B128>,
-	#[allow(clippy::type_complexity)]
-	basefold_compiler: BaseFoldZKProverCompiler<
-		P,
-		ProverNTT<B128>,
-		ProverMerkleProver<B128, ParallelMerkleHasher, ParallelMerkleCompress>,
-	>,
+	basefold_compiler: BaseFoldZKProverCompiler<P, ProverNTT<B128>, ProverMerkleProver<B128, H>>,
 }
 
-impl<P, MerkleHash, ParallelMerkleCompress, ParallelMerkleHasher>
-	ZKProver<P, ParallelMerkleCompress, ParallelMerkleHasher>
+impl<P, H> ZKProver<P, H>
 where
 	P: PackedField<Scalar = B128>
 		+ PackedExtension<B128>
 		+ PackedExtension<binius_verifier::config::B1>
 		+ WithUnderlier<Underlier: UnderlierWithBitOps>,
-	MerkleHash: Digest + BlockSizeUser + FixedOutputReset,
-	ParallelMerkleHasher: ParallelDigest<Digest = MerkleHash>,
-	ParallelMerkleCompress: ParallelPseudoCompression<Output<MerkleHash>, 2>,
-	Output<MerkleHash>: SerializeBytes,
+	H: HashSuite,
+	Output<H::LeafHash>: SerializeBytes,
 {
 	/// Constructs a ZK prover from a [`ZKVerifier`].
-	pub fn setup(
-		zk_verifier: ZKVerifier<MerkleHash, ParallelMerkleCompress::Compression>,
-		compression: ParallelMerkleCompress,
-	) -> Result<Self, Error> {
+	pub fn setup(zk_verifier: ZKVerifier<H>) -> Result<Self, Error> {
 		// Build the inner IOPProver.
 		let inner_iop_verifier = zk_verifier.inner_iop_verifier().clone();
 		let key_collection = build_key_collection(inner_iop_verifier.constraint_system());
@@ -111,7 +95,7 @@ where
 		let domain_context = GenericPreExpanded::generate_from_subspace(subspace);
 		let log_num_shares = binius_utils::rayon::current_num_threads().ilog2() as usize;
 		let ntt = NeighborsLastMultiThread::new(domain_context, log_num_shares);
-		let merkle_prover = BinaryMerkleTreeProver::<_, ParallelMerkleHasher, _>::new(compression);
+		let merkle_prover = BinaryMerkleTreeProver::<_, H>::new();
 		let basefold_compiler = BaseFoldZKProverCompiler::from_verifier_compiler(
 			zk_verifier.basefold_compiler(),
 			ntt,

--- a/crates/prover/tests/prove_verify.rs
+++ b/crates/prover/tests/prove_verify.rs
@@ -7,29 +7,18 @@ use binius_core::{
 };
 use binius_field::arch::OptimalPackedB128;
 use binius_frontend::{CircuitBuilder, Wire};
-use binius_prover::{
-	Prover, hash::parallel_compression::ParallelCompressionAdaptor, zk_config::ZKProver,
-};
+use binius_hash::StdHashSuite;
+use binius_prover::{Prover, zk_config::ZKProver};
 use binius_transcript::ProverTranscript;
-use binius_verifier::{
-	Verifier,
-	config::StdChallenger,
-	hash::{StdCompression, StdDigest},
-	zk_config::ZKVerifier,
-};
+use binius_verifier::{Verifier, config::StdChallenger, zk_config::ZKVerifier};
 use rand::{SeedableRng, rngs::StdRng};
 
 fn prove_verify(cs: ConstraintSystem, witness: ValueVec) {
 	const LOG_INV_RATE: usize = 1;
 
-	let verifier =
-		Verifier::<StdDigest, _>::setup(cs, LOG_INV_RATE, StdCompression::default()).unwrap();
+	let verifier = Verifier::<StdHashSuite>::setup(cs, LOG_INV_RATE).unwrap();
 
-	let prover = Prover::<OptimalPackedB128, _, StdDigest>::setup(
-		verifier.clone(),
-		ParallelCompressionAdaptor::new(StdCompression::default()),
-	)
-	.unwrap();
+	let prover = Prover::<OptimalPackedB128, StdHashSuite>::setup(verifier.clone()).unwrap();
 
 	let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 	prover
@@ -46,14 +35,10 @@ fn prove_verify(cs: ConstraintSystem, witness: ValueVec) {
 fn prove_verify_zk(cs: ConstraintSystem, witness: ValueVec) {
 	const LOG_INV_RATE: usize = 1;
 
-	let zk_verifier =
-		ZKVerifier::<StdDigest, _>::setup(cs, LOG_INV_RATE, StdCompression::default()).unwrap();
+	let zk_verifier = ZKVerifier::<StdHashSuite>::setup(cs, LOG_INV_RATE).unwrap();
 
-	let zk_prover = ZKProver::<OptimalPackedB128, _, StdDigest>::setup(
-		zk_verifier.clone(),
-		ParallelCompressionAdaptor::new(StdCompression::default()),
-	)
-	.unwrap();
+	let zk_prover =
+		ZKProver::<OptimalPackedB128, StdHashSuite>::setup(zk_verifier.clone()).unwrap();
 
 	let mut rng = StdRng::seed_from_u64(0);
 	let mut prover_transcript = ProverTranscript::new(StdChallenger::default());

--- a/crates/spartan-prover/src/lib.rs
+++ b/crates/spartan-prover/src/lib.rs
@@ -37,7 +37,7 @@ use std::{
 };
 
 use binius_field::{BinaryField, Field, PackedExtension, PackedField};
-use binius_hash::{ParallelDigest, parallel_compression::ParallelPseudoCompression};
+use binius_hash::binary_merkle_tree::HashSuite;
 use binius_iop_prover::{
 	basefold_compiler::BaseFoldZKProverCompiler, channel::IOPProverChannel,
 	merkle_tree::prover::BinaryMerkleTreeProver,
@@ -66,7 +66,7 @@ use binius_utils::{
 	checked_arithmetics::checked_log_2,
 	rayon::{self, prelude::*},
 };
-use digest::{Digest, FixedOutputReset, Output, block_api::BlockSizeUser};
+use digest::Output;
 pub use error::*;
 use itertools::chain;
 use rand::CryptoRng;
@@ -74,8 +74,7 @@ use rand::CryptoRng;
 use crate::wiring::{WiringTranspose, fold_constraints};
 
 type ProverNTT<F> = NeighborsLastMultiThread<GenericPreExpanded<F>>;
-type ProverMerkleProver<F, ParallelMerkleHasher, ParallelMerkleCompress> =
-	BinaryMerkleTreeProver<F, ParallelMerkleHasher, ParallelMerkleCompress>;
+type ProverMerkleProver<F, H> = BinaryMerkleTreeProver<F, H>;
 
 /// IOP prover for a particular constraint system.
 ///
@@ -94,19 +93,14 @@ pub struct IOPProver<F: Field> {
 /// The [`Self::setup`] constructor pre-processes reusable structures for proving instances of the
 /// given constraint system. Then [`Self::prove`] is called one or more times with individual
 /// instances.
-pub struct Prover<P, ParallelMerkleCompress, ParallelMerkleHasher>
+pub struct Prover<P, H>
 where
 	P: PackedField<Scalar: BinaryField>,
-	ParallelMerkleHasher: ParallelDigest<Digest: Digest + BlockSizeUser + FixedOutputReset>,
-	ParallelMerkleCompress: ParallelPseudoCompression<Output<ParallelMerkleHasher::Digest>, 2>,
+	H: HashSuite,
 {
 	iop_prover: IOPProver<P::Scalar>,
-	#[allow(clippy::type_complexity)]
-	basefold_compiler: BaseFoldZKProverCompiler<
-		P,
-		ProverNTT<P::Scalar>,
-		ProverMerkleProver<P::Scalar, ParallelMerkleHasher, ParallelMerkleCompress>,
-	>,
+	basefold_compiler:
+		BaseFoldZKProverCompiler<P, ProverNTT<P::Scalar>, ProverMerkleProver<P::Scalar, H>>,
 }
 
 impl<F: Field> IOPProver<F> {
@@ -326,23 +320,17 @@ impl<F: Field> IOPProver<F> {
 	}
 }
 
-impl<F, P, MerkleHash, ParallelMerkleCompress, ParallelMerkleHasher>
-	Prover<P, ParallelMerkleCompress, ParallelMerkleHasher>
+impl<F, P, H> Prover<P, H>
 where
 	F: BinaryField,
 	P: PackedField<Scalar = F> + PackedExtension<F>,
-	MerkleHash: Digest + BlockSizeUser + FixedOutputReset,
-	ParallelMerkleHasher: ParallelDigest<Digest = MerkleHash>,
-	ParallelMerkleCompress: ParallelPseudoCompression<Output<MerkleHash>, 2>,
-	Output<MerkleHash>: SerializeBytes,
+	H: HashSuite,
+	Output<H::LeafHash>: SerializeBytes,
 {
 	/// Constructs a prover corresponding to a constraint system verifier.
 	///
 	/// See [`Prover`] struct documentation for details.
-	pub fn setup(
-		verifier: Verifier<F, MerkleHash, ParallelMerkleCompress::Compression>,
-		compression: ParallelMerkleCompress,
-	) -> Result<Self, Error> {
+	pub fn setup(verifier: Verifier<F, H>) -> Result<Self, Error> {
 		let log_num_shares = binius_utils::rayon::current_num_threads().ilog2() as usize;
 
 		// Get the largest subspace from the verifier compiler for NTT creation
@@ -350,7 +338,7 @@ where
 		let domain_context = GenericPreExpanded::generate_from_subspace(subspace);
 		let ntt = NeighborsLastMultiThread::new(domain_context, log_num_shares);
 
-		let merkle_prover = BinaryMerkleTreeProver::<_, ParallelMerkleHasher, _>::new(compression);
+		let merkle_prover = BinaryMerkleTreeProver::<_, H>::new();
 
 		// Create the BaseFold ZK compiler from verifier compiler (reuses oracle_specs and
 		// fri_params)
@@ -376,11 +364,7 @@ where
 	/// Returns a reference to the BaseFold ZK prover compiler.
 	pub fn iop_compiler(
 		&self,
-	) -> &BaseFoldZKProverCompiler<
-		P,
-		ProverNTT<F>,
-		ProverMerkleProver<F, ParallelMerkleHasher, ParallelMerkleCompress>,
-	> {
+	) -> &BaseFoldZKProverCompiler<P, ProverNTT<F>, ProverMerkleProver<F, H>> {
 		&self.basefold_compiler
 	}
 

--- a/crates/spartan-prover/tests/integration_test.rs
+++ b/crates/spartan-prover/tests/integration_test.rs
@@ -2,7 +2,7 @@
 // Copyright 2026 The Binius Developers
 
 use binius_field::{BinaryField128bGhash as B128, Random, arch::OptimalPackedB128};
-use binius_hash::{ParallelCompressionAdaptor, StdCompression, StdDigest};
+use binius_hash::StdHashSuite;
 use binius_spartan_frontend::{
 	circuit_builder::{CircuitBuilder, ConstraintBuilder, WitnessGenerator},
 	circuits::powers,
@@ -35,14 +35,10 @@ fn test_power7_circuit_prover_verifier() {
 
 	// Setup prover and verifier
 	let log_inv_rate = 1;
-	let compression = StdCompression::default();
-	let verifier = Verifier::<_, StdDigest, _>::setup(cs, log_inv_rate, compression.clone())
-		.expect("verifier setup failed");
-	let prover = Prover::<OptimalPackedB128, _, StdDigest>::setup(
-		verifier.clone(),
-		ParallelCompressionAdaptor::new(compression),
-	)
-	.expect("prover setup failed");
+	let verifier =
+		Verifier::<_, StdHashSuite>::setup(cs, log_inv_rate).expect("verifier setup failed");
+	let prover = Prover::<OptimalPackedB128, StdHashSuite>::setup(verifier.clone())
+		.expect("prover setup failed");
 
 	let cs = verifier.constraint_system();
 	let layout = layout.with_blinding(cs.blinding_info().clone());

--- a/crates/spartan-prover/tests/wrapper_integration_test.rs
+++ b/crates/spartan-prover/tests/wrapper_integration_test.rs
@@ -1,7 +1,7 @@
 // Copyright 2026 The Binius Developers
 
 use binius_field::{BinaryField128bGhash as B128, Field, Random, arch::OptimalPackedB128};
-use binius_hash::{ParallelCompressionAdaptor, StdCompression, StdDigest};
+use binius_hash::StdHashSuite;
 use binius_iop::{
 	basefold_compiler::BaseFoldZKVerifierCompiler,
 	channel::IOPVerifierChannel,
@@ -93,8 +93,7 @@ fn test_zk_wrapped_prove_verify() {
 	let outer_iop_verifier = IOPVerifier::new(outer_cs.clone());
 	let outer_iop_prover = IOPProver::new(outer_cs);
 
-	let compression = StdCompression::default();
-	let merkle_scheme = BinaryMerkleTreeScheme::<B128, StdDigest, _>::new(compression.clone());
+	let merkle_scheme = BinaryMerkleTreeScheme::<B128, StdHashSuite>::new();
 
 	// Transcript layout: outer precommit oracle first (committed at wrapper construction),
 	// then all inner oracles, then the remaining outer oracles (private, mask).
@@ -117,9 +116,7 @@ fn test_zk_wrapped_prove_verify() {
 	let subspace = zk_basefold_compiler.max_subspace();
 	let domain_context = GenericOnTheFly::generate_from_subspace(subspace);
 	let ntt = NeighborsLastSingleThread::new(domain_context);
-	let merkle_prover = BinaryMerkleTreeProver::<_, StdDigest, _>::new(
-		ParallelCompressionAdaptor::new(compression.clone()),
-	);
+	let merkle_prover = BinaryMerkleTreeProver::<_, StdHashSuite>::new();
 	let zk_basefold_prover: BaseFoldZKProverCompiler<OptimalPackedB128, _, _> =
 		BaseFoldZKProverCompiler::from_verifier_compiler(&zk_basefold_compiler, ntt, merkle_prover);
 

--- a/crates/spartan-verifier/src/lib.rs
+++ b/crates/spartan-verifier/src/lib.rs
@@ -36,7 +36,7 @@ pub mod wrapper;
 use std::slice;
 
 use binius_field::{BinaryField, Field, field::FieldOps};
-use binius_hash::PseudoCompressionFunction;
+use binius_hash::binary_merkle_tree::HashSuite;
 use binius_iop::{
 	basefold,
 	basefold_compiler::BaseFoldZKVerifierCompiler,
@@ -49,7 +49,7 @@ use binius_math::{multilinear::eq::eq_ind_partial_eval_scalars, univariate::eval
 use binius_spartan_frontend::constraint_system::{ConstraintSystem, WitnessSegment};
 use binius_transcript::{VerifierTranscript, fiat_shamir::Challenger};
 use binius_utils::{DeserializeBytes, checked_arithmetics::checked_log_2};
-use digest::{Digest, Output, block_api::BlockSizeUser};
+use digest::Output;
 
 use crate::{
 	constraint_system::{BlindingInfo, ConstraintSystemPadded},
@@ -87,17 +87,15 @@ pub struct IOPVerifier<F: Field> {
 ///
 /// The [`Self::setup`] constructor determines public parameters for proving instances of the given
 /// constraint system. Then [`Self::verify`] is called one or more times with individual instances.
-#[derive(Debug, Clone)]
-pub struct Verifier<F, MerkleHash, MerkleCompress>
+#[derive(Clone)]
+pub struct Verifier<F, H>
 where
 	F: BinaryField,
-	MerkleHash: Digest + BlockSizeUser,
-	MerkleCompress: PseudoCompressionFunction<Output<MerkleHash>, 2>,
+	H: HashSuite,
 {
 	iop_verifier: IOPVerifier<F>,
 	/// BaseFold ZK compiler for creating verifier channels.
-	basefold_compiler:
-		BaseFoldZKVerifierCompiler<F, BinaryMerkleTreeScheme<F, MerkleHash, MerkleCompress>>,
+	basefold_compiler: BaseFoldZKVerifierCompiler<F, BinaryMerkleTreeScheme<F, H>>,
 }
 
 impl<F: Field> IOPVerifier<F> {
@@ -250,12 +248,11 @@ impl<F: Field> IOPVerifier<F> {
 	}
 }
 
-impl<F, MerkleHash, MerkleCompress> Verifier<F, MerkleHash, MerkleCompress>
+impl<F, H> Verifier<F, H>
 where
 	F: BinaryField,
-	MerkleHash: Digest + BlockSizeUser,
-	MerkleCompress: PseudoCompressionFunction<Output<MerkleHash>, 2>,
-	Output<MerkleHash>: DeserializeBytes,
+	H: HashSuite,
+	Output<H::LeafHash>: DeserializeBytes,
 {
 	/// Constructs a verifier for a constraint system.
 	///
@@ -263,7 +260,6 @@ where
 	pub fn setup(
 		constraint_system: ConstraintSystem<F>,
 		log_inv_rate: usize,
-		compression: MerkleCompress,
 	) -> Result<Self, Error> {
 		// Modify the constraint system for zero-knowledge.
 		let n_test_queries = fri::calculate_n_test_queries(SECURITY_BITS, log_inv_rate);
@@ -277,7 +273,7 @@ where
 		let iop_verifier = IOPVerifier::new(constraint_system);
 		let oracle_specs = iop_verifier.oracle_specs();
 
-		let merkle_scheme = BinaryMerkleTreeScheme::new(compression);
+		let merkle_scheme = BinaryMerkleTreeScheme::<F, H>::new();
 
 		// Create the BaseFold ZK compiler for IOP verification
 		let basefold_compiler = BaseFoldZKVerifierCompiler::new(
@@ -304,9 +300,7 @@ where
 	}
 
 	/// Returns a reference to the BaseFold ZK verifier compiler.
-	pub fn iop_compiler(
-		&self,
-	) -> &BaseFoldZKVerifierCompiler<F, BinaryMerkleTreeScheme<F, MerkleHash, MerkleCompress>> {
+	pub fn iop_compiler(&self) -> &BaseFoldZKVerifierCompiler<F, BinaryMerkleTreeScheme<F, H>> {
 		&self.basefold_compiler
 	}
 

--- a/crates/spartan-verifier/tests/proof_size_test.rs
+++ b/crates/spartan-verifier/tests/proof_size_test.rs
@@ -1,6 +1,7 @@
 // Copyright 2026 The Binius Developers
 
 use binius_field::BinaryField128bGhash as B128;
+use binius_hash::StdHashSuite;
 use binius_iop::channel::IOPVerifierChannel;
 use binius_ip::channel::IPVerifierChannel;
 use binius_spartan_frontend::{
@@ -8,10 +9,7 @@ use binius_spartan_frontend::{
 	circuits::powers,
 	compiler::compile,
 };
-use binius_spartan_verifier::{
-	Verifier,
-	config::{StdCompression, StdDigest},
-};
+use binius_spartan_verifier::Verifier;
 
 // Build a power circuit: assert that x^n = y
 fn power_circuit<Builder: CircuitBuilder>(
@@ -36,9 +34,8 @@ fn test_ip_proof_size() {
 
 	// Setup verifier
 	let log_inv_rate = 3;
-	let compression = StdCompression::default();
-	let verifier = Verifier::<_, StdDigest, _>::setup(cs, log_inv_rate, compression)
-		.expect("verifier setup failed");
+	let verifier =
+		Verifier::<_, StdHashSuite>::setup(cs, log_inv_rate).expect("verifier setup failed");
 
 	let cs = verifier.constraint_system();
 

--- a/crates/verifier/src/verify.rs
+++ b/crates/verifier/src/verify.rs
@@ -2,6 +2,7 @@
 
 use binius_core::{constraint_system::ConstraintSystem, word::Word};
 use binius_field::{AESTowerField8b as B8, BinaryField, ExtensionField, FieldOps};
+use binius_hash::binary_merkle_tree::HashSuite;
 use binius_iop::{
 	basefold_compiler::BaseFoldVerifierCompiler,
 	channel::{IOPVerifierChannel, OracleLinearRelation, OracleSpec},
@@ -18,7 +19,7 @@ use binius_utils::{
 	DeserializeBytes,
 	checked_arithmetics::{checked_log_2, log2_ceil_usize},
 };
-use digest::{Digest, Output, block_api::BlockSizeUser};
+use digest::Output;
 use itertools::chain;
 
 use super::error::Error;
@@ -27,7 +28,6 @@ use crate::{
 		B1, B128, LOG_WORD_SIZE_BITS, LOG_WORDS_PER_ELEM, PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES,
 	},
 	fri::{ConstantArityStrategy, FRIParams, calculate_n_test_queries},
-	hash::PseudoCompressionFunction,
 	merkle_tree::BinaryMerkleTreeScheme,
 	protocols::{
 		bitand::{AndCheckOutput, verify_with_channel},
@@ -269,22 +269,16 @@ impl IOPVerifier {
 ///
 /// The [`Self::setup`] constructor determines public parameters for proving instances of the given
 /// constraint system. Then [`Self::verify`] is called one or more times with individual instances.
-#[derive(Debug, Clone)]
-pub struct Verifier<MerkleHash, MerkleCompress>
-where
-	MerkleHash: Digest + BlockSizeUser,
-	MerkleCompress: PseudoCompressionFunction<Output<MerkleHash>, 2>,
-{
+#[derive(Clone)]
+pub struct Verifier<H: HashSuite> {
 	iop_verifier: IOPVerifier,
-	iop_compiler:
-		BaseFoldVerifierCompiler<B128, BinaryMerkleTreeScheme<B128, MerkleHash, MerkleCompress>>,
+	iop_compiler: BaseFoldVerifierCompiler<B128, BinaryMerkleTreeScheme<B128, H>>,
 }
 
-impl<MerkleHash, MerkleCompress> Verifier<MerkleHash, MerkleCompress>
+impl<H> Verifier<H>
 where
-	MerkleHash: Digest + BlockSizeUser,
-	MerkleCompress: PseudoCompressionFunction<Output<MerkleHash>, 2>,
-	Output<MerkleHash>: DeserializeBytes,
+	H: HashSuite,
+	Output<H::LeafHash>: DeserializeBytes,
 {
 	/// Constructs a verifier for a constraint system.
 	///
@@ -292,7 +286,6 @@ where
 	pub fn setup(
 		mut constraint_system: ConstraintSystem,
 		log_inv_rate: usize,
-		compression: MerkleCompress,
 	) -> Result<Self, Error> {
 		constraint_system.validate_and_prepare()?;
 
@@ -309,7 +302,7 @@ where
 		let oracle_specs = iop_verifier.oracle_specs();
 
 		let log_code_len = log_witness_elems + log_inv_rate;
-		let merkle_scheme = BinaryMerkleTreeScheme::new(compression);
+		let merkle_scheme = BinaryMerkleTreeScheme::<B128, H>::new();
 		let fri_arity =
 			ConstantArityStrategy::with_optimal_arity::<B128, _>(&merkle_scheme, log_code_len)
 				.arity;
@@ -362,7 +355,7 @@ where
 	}
 
 	/// Returns the [`crate::merkle_tree::MerkleTreeScheme`] instance used.
-	pub fn merkle_scheme(&self) -> &BinaryMerkleTreeScheme<B128, MerkleHash, MerkleCompress> {
+	pub fn merkle_scheme(&self) -> &BinaryMerkleTreeScheme<B128, H> {
 		self.iop_compiler.merkle_scheme()
 	}
 
@@ -372,10 +365,7 @@ where
 	}
 
 	/// Returns the IOP compiler for creating verifier channels.
-	pub fn iop_compiler(
-		&self,
-	) -> &BaseFoldVerifierCompiler<B128, BinaryMerkleTreeScheme<B128, MerkleHash, MerkleCompress>>
-	{
+	pub fn iop_compiler(&self) -> &BaseFoldVerifierCompiler<B128, BinaryMerkleTreeScheme<B128, H>> {
 		&self.iop_compiler
 	}
 

--- a/crates/verifier/src/zk_config.rs
+++ b/crates/verifier/src/zk_config.rs
@@ -15,6 +15,7 @@
 
 use binius_core::{constraint_system::ConstraintSystem, word::Word};
 use binius_field::BinaryField128bGhash as B128;
+use binius_hash::binary_merkle_tree::HashSuite;
 use binius_iop::{
 	basefold_compiler::BaseFoldZKVerifierCompiler,
 	channel::OracleSpec,
@@ -29,11 +30,10 @@ use binius_spartan_verifier::{
 };
 use binius_transcript::{VerifierTranscript, fiat_shamir::Challenger};
 use binius_utils::{DeserializeBytes, checked_arithmetics::log2_ceil_usize};
-use digest::{Digest, Output, block_api::BlockSizeUser};
+use digest::Output;
 
 use crate::{
 	config::LOG_WORDS_PER_ELEM,
-	hash::PseudoCompressionFunction,
 	verify::{IOPVerifier, SECURITY_BITS},
 };
 
@@ -41,29 +41,22 @@ use crate::{
 ///
 /// Wraps the Binius64 IOP verifier with a Spartan-based ZK wrapper. Call [`Self::setup`] with
 /// a constraint system, then [`Self::verify`] with public inputs and a proof transcript.
-#[derive(Debug, Clone)]
-pub struct ZKVerifier<MerkleHash, MerkleCompress>
-where
-	MerkleHash: Digest + BlockSizeUser,
-	MerkleCompress: PseudoCompressionFunction<Output<MerkleHash>, 2>,
-{
+#[derive(Clone)]
+pub struct ZKVerifier<H: HashSuite> {
 	inner_iop_verifier: IOPVerifier,
 	outer_iop_verifier: IronSpartanIOPVerifier<B128>,
-	basefold_compiler:
-		BaseFoldZKVerifierCompiler<B128, BinaryMerkleTreeScheme<B128, MerkleHash, MerkleCompress>>,
+	basefold_compiler: BaseFoldZKVerifierCompiler<B128, BinaryMerkleTreeScheme<B128, H>>,
 }
 
-impl<MerkleHash, MerkleCompress> ZKVerifier<MerkleHash, MerkleCompress>
+impl<H> ZKVerifier<H>
 where
-	MerkleHash: Digest + BlockSizeUser,
-	MerkleCompress: PseudoCompressionFunction<Output<MerkleHash>, 2>,
-	Output<MerkleHash>: DeserializeBytes,
+	H: HashSuite,
+	Output<H::LeafHash>: DeserializeBytes,
 {
 	/// Constructs a ZK verifier for a constraint system.
 	pub fn setup(
 		mut constraint_system: ConstraintSystem,
 		log_inv_rate: usize,
-		compression: MerkleCompress,
 	) -> Result<Self, Error> {
 		let _setup_guard = tracing::debug_span!("Setup ZK verifier").entered();
 
@@ -120,7 +113,7 @@ where
 		]
 		.concat();
 
-		let merkle_scheme = BinaryMerkleTreeScheme::new(compression);
+		let merkle_scheme = BinaryMerkleTreeScheme::<B128, H>::new();
 		let basefold_compiler = BaseFoldZKVerifierCompiler::new(
 			merkle_scheme,
 			oracle_specs,
@@ -149,8 +142,7 @@ where
 	/// Returns the BaseFold ZK verifier compiler.
 	pub fn basefold_compiler(
 		&self,
-	) -> &BaseFoldZKVerifierCompiler<B128, BinaryMerkleTreeScheme<B128, MerkleHash, MerkleCompress>>
-	{
+	) -> &BaseFoldZKVerifierCompiler<B128, BinaryMerkleTreeScheme<B128, H>> {
 		&self.basefold_compiler
 	}
 


### PR DESCRIPTION
## Summary
- Move binary_merkle_tree from binius-iop-prover into binius-hash so the Merkle utilities live next to the hash/compression traits, and split sha256 into its own top-level module under binius-hash.
- Add a HashSuite trait bundling the four Merkle hashing types (sequential + parallel leaf hash and 2-to-1 compression), with two reference impls: Sha256HashSuite and VisionHashSuite (Vision-6 leaves + Vision-4 compression).
- Migrate the user-facing entry points (Prover, Verifier, ZK variants, spartan-prover/verifier) and binary_merkle_tree::build* from per-callsite Merkle hash trait parameters to a single H: HashSuite parameter, dropping the redundant compression constructor argument.
- Collapse the four hash-specific example setup helpers into generic setup / setup_zk functions parameterized by H: HashSuite.

Note: VisionVerifier/VisionProver and friends now resolve to VisionHashSuite (Vision-6 leaves + Vision-4 compression); the previous aliases used Vision-4 leaves. CLI CompressionType::Vision4 is renamed to CompressionType::Vision.

## Test plan
- `cargo test`
- `cargo clippy --all --all-features --tests --benches --examples -- -D warnings`
- `cargo build --release` and run an example with both `--hash sha256` and `--hash vision`
