### PR TITLE
[circuits] Convert slice::Slice to free slice() function

### DIFF
--- a/crates/circuits/src/jwt_claims.rs
+++ b/crates/circuits/src/jwt_claims.rs
@@ -2,7 +2,7 @@
 use binius_core::word::Word;
 use binius_frontend::{CircuitBuilder, Wire, WitnessFiller, util::pack_bytes_into_wires_le};
 
-use crate::slice::Slice;
+use crate::slice;
 
 /// Represents a single JWT attribute to verify
 pub struct Attribute {
@@ -184,15 +184,10 @@ impl JwtClaims {
 			// Verify the length matches expected
 			b.assert_eq("attr_length", value_length, attr.len_bytes);
 
-			// Use Slice to verify the value content
-			let _slice = Slice::new(
-				&b,
-				len_bytes,
-				value_length,
-				json.clone(),
-				attr.value.clone(),
-				value_start,
-			);
+			// Extract the value from the JSON and assert it matches the caller-supplied value.
+			let extracted =
+				slice::slice(&b, len_bytes, value_length, &json, value_start, attr.value.len());
+			slice::assert_slice_eq(&b, "attr_value", value_length, &extracted, &attr.value);
 		}
 
 		JwtClaims {

--- a/crates/circuits/src/slice.rs
+++ b/crates/circuits/src/slice.rs
@@ -1,13 +1,71 @@
 // Copyright 2025 Irreducible Inc.
 use binius_core::word::Word;
-use binius_frontend::{CircuitBuilder, Wire, WitnessFiller};
+use binius_frontend::{CircuitBuilder, Wire};
 
-use crate::multiplexer::single_wire_multiplex;
+use crate::{
+	multiplexer::single_wire_multiplex,
+	shift::{var_sll_bytes, var_srl_bytes},
+};
 
-/// Verifies that a slice is correctly extracted from an input byte array.
+/// Asserts that two byte sequences (packed little-endian into 64-bit words) are equal in their
+/// first `len_bytes` bytes. Bytes past `len_bytes` are ignored on both sides.
 ///
-/// This circuit validates that `slice` contains exactly the bytes from
-/// `input` starting at `offset` for `len_slice` bytes.
+/// For each word index `i`, the saturating difference `diff = len_bytes - i*8` selects between:
+/// - full-word `assert_eq` when `diff > 8` (whole word is in range),
+/// - partial comparison via `var_sll_bytes` shifting both sides left by `8 - diff` bytes so only
+///   the low `diff` bytes remain (1 ≤ diff ≤ 8 — note that the `diff = 8` case picks the shifted
+///   form with `shift = 0`, which is identical to the original word), and
+/// - skipped comparison (both sides forced to zero) when the diff is 0.
+///
+/// # Panics
+///
+/// Panics if `actual.len() != expected.len()`.
+pub fn assert_slice_eq(
+	b: &CircuitBuilder,
+	name: impl Into<String>,
+	len_bytes: Wire,
+	actual: &[Wire],
+	expected: &[Wire],
+) {
+	assert_eq!(
+		actual.len(),
+		expected.len(),
+		"assert_slice_eq: actual and expected must have the same word count"
+	);
+	let name = name.into();
+	let zero = b.add_constant(Word::ZERO);
+	let eight = b.add_constant_64(8);
+	for (i, (&a, &e)) in actual.iter().zip(expected).enumerate() {
+		let start_byte = b.add_constant_64((i * 8) as u64);
+		let (diff_raw, borrow) = b.isub_bin_bout(len_bytes, start_byte, zero);
+		let diff = b.select(borrow, zero, diff_raw);
+
+		// `eight_minus_diff` is the byte shift amount; the same sub's borrow_out tells us
+		// whether `diff > 8` (i.e. take the full word) without a separate compare.
+		let (eight_minus_diff, diff_gt_8) = b.isub_bin_bout(eight, diff, zero);
+		let a_shifted = var_sll_bytes(b, a, eight_minus_diff);
+		let e_shifted = var_sll_bytes(b, e, eight_minus_diff);
+		let a_part = b.select(diff_gt_8, a, a_shifted);
+		let e_part = b.select(diff_gt_8, e, e_shifted);
+
+		// `var_sll_bytes` has precondition `shift < 8`, which the `diff == 0` case violates
+		// (then `eight_minus_diff = 8`). The shift result is unused in that case because both
+		// sides are forced to zero here.
+		let diff_eq_0 = b.icmp_eq(diff, zero);
+		let a_cmp = b.select(diff_eq_0, zero, a_part);
+		let e_cmp = b.select(diff_eq_0, zero, e_part);
+
+		b.assert_eq(format!("{name}[{i}]"), a_cmp, e_cmp);
+	}
+}
+
+/// Extracts a slice from an input byte array and returns it as a vector of packed 64-bit words.
+///
+/// Returns the bytes from `input` starting at `offset` for `len_slice` bytes, packed into
+/// `max_n_words` little-endian 64-bit words. Bytes past `len_slice` are not constrained — they
+/// hold whatever raw bytes happen to follow in `input` (and may be nonzero garbage). Callers that
+/// need to compare against an expected slice should use [`assert_slice_eq`], which masks the
+/// comparison to the first `len_slice` bytes.
 ///
 /// # Limitations
 /// All size and offset values must fit within 32 bits. Specifically:
@@ -17,191 +75,85 @@ use crate::multiplexer::single_wire_multiplex;
 /// - `offset + len_slice` must be < 2^32
 ///
 /// These limitations are enforced by the circuit constraints.
-pub struct Slice {
-	pub len_input: Wire,
-	pub len_slice: Wire,
-	pub input: Vec<Wire>,
-	pub slice: Vec<Wire>,
-	pub offset: Wire,
-}
+///
+/// # Arguments
+/// * `b` - Circuit builder
+/// * `len_input` - Actual input size in bytes
+/// * `len_slice` - Actual slice size in bytes
+/// * `input` - Input array packed as words (8 bytes per word)
+/// * `offset` - Byte offset where slice starts
+/// * `max_n_words` - Number of output wires; the maximum slice length in bytes is `max_n_words * 8`
+///
+/// # Returns
+/// A `Vec<Wire>` of length `max_n_words` containing the extracted slice bytes packed in
+/// little-endian order. Bytes past `len_slice` are unconstrained garbage; use [`assert_slice_eq`]
+/// for comparisons that should ignore them.
+///
+/// # Panics
+/// * If `input.len() * 8 > u32::MAX`
+/// * If `max_n_words * 8 > u32::MAX`
+pub fn slice(
+	b: &CircuitBuilder,
+	len_input: Wire,
+	len_slice: Wire,
+	input: &[Wire],
+	offset: Wire,
+	max_n_words: usize,
+) -> Vec<Wire> {
+	// Static assertions to ensure maximum sizes fit within 32 bits
+	let max_len_input = input.len() << 3;
+	let max_len_slice = max_n_words << 3;
 
-impl Slice {
-	/// Creates a new slice verifier circuit.
-	///
-	/// # Arguments
-	/// * `b` - Circuit builder
-	/// * `len_input` - Actual input size in bytes
-	/// * `len_slice` - Actual slice size in bytes
-	/// * `input` - Input array packed as words (8 bytes per word)
-	/// * `slice` - Slice array packed as words (8 bytes per word)
-	/// * `offset` - Byte offset where slice starts
-	///
-	/// # Panics
-	/// * If max_n_input >= 2^32
-	/// * If max_n_slice >= 2^32
-	#[allow(clippy::too_many_arguments)]
-	pub fn new(
-		b: &CircuitBuilder,
-		len_input: Wire,
-		len_slice: Wire,
-		input: Vec<Wire>,
-		slice: Vec<Wire>,
-		offset: Wire,
-	) -> Self {
-		// Static assertions to ensure maximum sizes fit within 32 bits
-		let max_len_input = input.len() << 3;
-		let max_len_slice = slice.len() << 3;
+	assert!(max_len_input <= u32::MAX as usize, "max_n_input must be < 2^32");
+	assert!(max_len_slice <= u32::MAX as usize, "max_n_slice must be < 2^32");
 
-		assert!(max_len_input <= u32::MAX as usize, "max_n_input must be < 2^32");
-		assert!(max_len_slice <= u32::MAX as usize, "max_n_slice must be < 2^32");
+	// Ensure all values fit in 32 bits to prevent overflow in iadd
+	b.assert_zero("offset_32bit", b.shr(offset, 32));
+	b.assert_zero("len_slice_32bit", b.shr(len_slice, 32));
+	b.assert_zero("len_input_32bit", b.shr(len_input, 32));
 
-		// Ensure all values fit in 32 bits to prevent overflow in iadd_32
-		b.assert_zero("offset_32bit", b.shr(offset, 32));
-		b.assert_zero("len_slice_32bit", b.shr(len_slice, 32));
-		b.assert_zero("len_input_32bit", b.shr(len_input, 32));
+	// Verify bounds: offset + len_slice <= len_input
+	let (offset_plus_len_slice, _) = b.iadd(offset, len_slice);
+	let in_bounds = b.icmp_ule(offset_plus_len_slice, len_input);
+	b.assert_true("bounds_check", in_bounds);
 
-		// Verify bounds: offset + len_slice <= len_input
-		let (offset_plus_len_slice, _) = b.iadd(offset, len_slice);
-		let in_bounds = b.icmp_ule(offset_plus_len_slice, len_input);
-		b.assert_true("bounds_check", in_bounds);
+	let sufficient_capacity = b.icmp_ule(len_slice, b.add_constant(Word(max_len_slice as u64)));
+	b.assert_true("max_n_words is sufficient", sufficient_capacity);
+
+	// For each output word, compute the corresponding bytes of the slice. Trailing positions past
+	// `len_slice` are zeroed via the byte mask and the `word_partially_valid` guard.
+	if max_n_words == 0 {
+		Vec::new()
+	} else {
+		let zero = b.add_constant(Word::ZERO);
+		let one = b.add_constant(Word::ONE);
 
 		// Decompose offset = word_offset * 8 + byte_offset
-		let word_offset = b.shr(offset, 3); // offset / 8
+		let mut word_offset = b.shr(offset, 3); // offset / 8
 		let byte_offset = b.band(offset, b.add_constant(Word(7))); // offset % 8
+		let (neg_byte_offset, _) = b.isub_bin_bout(b.add_constant(Word(8)), byte_offset, zero);
+		let is_aligned = b.icmp_eq(byte_offset, zero);
 
-		// Go over every word in the slice and check that it was copied from the input byte string
-		// correctly.
-		for (slice_idx, &slice_word) in slice.iter().enumerate() {
-			let b = b.subcircuit(format!("slice_word[{slice_idx}]"));
+		let mut in_word = single_wire_multiplex(b, input, word_offset);
+		(0..max_n_words)
+			.map(|slice_idx| {
+				let b = b.subcircuit(format!("slice_word[{slice_idx}]"));
 
-			// Check if this word is within the actual slice
-			let word_start_bytes = slice_idx << 3;
-			let word_partially_valid =
-				b.icmp_ult(b.add_constant(Word(word_start_bytes as u64)), len_slice);
-			// are ANY of the bytes in this present word actually part of the slice proper?
+				// TODO: This could maybe benefit from a CircuitBuilder::incr gate.
+				(word_offset, _) = b.iadd(word_offset, one);
+				let next_word = single_wire_multiplex(&b, input, word_offset);
 
-			// Calculate which input word(s) we need
-			let (input_word_idx, _) = b.iadd(word_offset, b.add_constant(Word(slice_idx as u64)));
+				let aligned_out_word = in_word;
+				let unaligned_out_word = b.bxor(
+					var_srl_bytes(&b, in_word, byte_offset),
+					var_sll_bytes(&b, next_word, neg_byte_offset),
+				);
+				let out_word = b.select(is_aligned, aligned_out_word, unaligned_out_word);
 
-			let extracted_word = extract_word(&b, &input, input_word_idx, byte_offset);
-
-			// For every word, calculate how many bytes are valid and apply appropriate mask
-			// Calculate valid bytes in this word: min(len_slice - word_start, 8)
-			// First calculate len_slice - word_start
-			let neg_start = b.add_constant(Word((-(word_start_bytes as i64)) as u64));
-			let (bytes_remaining, _) = b.iadd(len_slice, neg_start);
-
-			// The mask will handle clamping to 8 bytes internally
-			let mask = create_byte_mask(&b, bytes_remaining);
-
-			// For partial words, we need to ensure:
-			// 1. The valid bytes match the extracted word
-			// 2. The invalid bytes are zero
-			// Assert they are equal (only if word is at least partially valid)
-			let zero = b.add_constant(Word::ZERO);
-			b.assert_eq_cond(
-				format!("slice_word_{slice_idx}"),
-				b.band(slice_word, mask),
-				b.band(extracted_word, mask),
-				word_partially_valid,
-			);
-			b.assert_eq_cond(
-				format!("slice_word_{slice_idx}_padding"),
-				b.band(slice_word, b.bnot(mask)),
-				zero,
-				word_partially_valid,
-			);
-
-			b.assert_eq_cond(
-				format!("slice_word_{slice_idx} non-slice"),
-				slice_word,
-				zero,
-				b.bnot(word_partially_valid),
-			);
-		}
-
-		Slice {
-			len_input,
-			len_slice,
-			input,
-			slice,
-			offset,
-		}
-	}
-
-	/// Populate the len_input wire with the actual input size in bytes
-	pub fn populate_len_input(&self, w: &mut WitnessFiller, len_input: usize) {
-		w[self.len_input] = Word(len_input as u64);
-	}
-
-	/// Populate the len_slice wire with the actual slice size in bytes
-	pub fn populate_len_slice(&self, w: &mut WitnessFiller, len_slice: usize) {
-		w[self.len_slice] = Word(len_slice as u64);
-	}
-
-	/// Populate the input array from a byte slice
-	///
-	/// # Panics
-	/// Panics if input.len() > max_n_input (the maximum size specified during construction)
-	pub fn populate_input(&self, w: &mut WitnessFiller, input: &[u8]) {
-		let max_n_input = self.input.len() * 8;
-		assert!(
-			input.len() <= max_n_input,
-			"input length {} exceeds maximum {}",
-			input.len(),
-			max_n_input
-		);
-
-		// Pack bytes into words
-		for (i, chunk) in input.chunks(8).enumerate() {
-			if i < self.input.len() {
-				let mut word = 0u64;
-				for (j, &byte) in chunk.iter().enumerate() {
-					word |= (byte as u64) << (j * 8);
-				}
-				w[self.input[i]] = Word(word);
-			}
-		}
-
-		// Zero out remaining words
-		for i in input.len().div_ceil(8)..self.input.len() {
-			w[self.input[i]] = Word::ZERO;
-		}
-	}
-
-	/// Populate the slice array from a byte slice
-	///
-	/// # Panics
-	/// Panics if slice.len() > max_n_slice (the maximum size specified during construction)
-	pub fn populate_slice(&self, w: &mut WitnessFiller, slice: &[u8]) {
-		let max_n_slice = self.slice.len() * 8;
-		assert!(
-			slice.len() <= max_n_slice,
-			"slice length {} exceeds maximum {}",
-			slice.len(),
-			max_n_slice
-		);
-
-		// Pack bytes into words
-		for (i, chunk) in slice.chunks(8).enumerate() {
-			if i < self.slice.len() {
-				let mut word = 0u64;
-				for (j, &byte) in chunk.iter().enumerate() {
-					word |= (byte as u64) << (j * 8);
-				}
-				w[self.slice[i]] = Word(word);
-			}
-		}
-
-		// Zero out remaining words
-		for i in slice.len().div_ceil(8)..self.slice.len() {
-			w[self.slice[i]] = Word::ZERO;
-		}
-	}
-
-	/// Populate the offset wire
-	pub fn populate_offset(&self, w: &mut WitnessFiller, offset: usize) {
-		w[self.offset] = Word(offset as u64);
+				in_word = next_word;
+				out_word
+			})
+			.collect()
 	}
 }
 
@@ -272,665 +224,294 @@ pub fn create_byte_mask(b: &CircuitBuilder, n_bytes: Wire) -> Wire {
 #[cfg(test)]
 mod tests {
 	use binius_core::verify::verify_constraints;
+	use binius_frontend::util::pack_bytes_into_wires_le;
 
-	use super::{CircuitBuilder, Slice, Wire, Word};
+	use super::{CircuitBuilder, Wire, Word, assert_slice_eq, slice};
+
+	/// Build a test circuit that takes input + offset wires, calls `slice`, and asserts the
+	/// returned bytes equal a separately allocated `expected` byte vector. Returns the wires the
+	/// caller needs to populate.
+	struct SliceTestSetup {
+		builder: CircuitBuilder,
+		len_input: Wire,
+		len_slice: Wire,
+		offset: Wire,
+		input: Vec<Wire>,
+		expected: Vec<Wire>,
+	}
+
+	fn build_slice_check(n_input_words: usize, n_slice_words: usize) -> SliceTestSetup {
+		let builder = CircuitBuilder::new();
+		let len_input = builder.add_inout();
+		let len_slice = builder.add_inout();
+		let offset = builder.add_inout();
+		let input: Vec<Wire> = (0..n_input_words).map(|_| builder.add_inout()).collect();
+		let expected: Vec<Wire> = (0..n_slice_words).map(|_| builder.add_inout()).collect();
+		let actual = slice(&builder, len_input, len_slice, &input, offset, n_slice_words);
+		assert_slice_eq(&builder, "slice_eq", len_slice, &actual, &expected);
+		SliceTestSetup {
+			builder,
+			len_input,
+			len_slice,
+			offset,
+			input,
+			expected,
+		}
+	}
+
+	/// Run a success-case test: pack `input_data` and `expected_slice_data` into the test setup,
+	/// run the circuit, and verify constraints.
+	fn run_slice_success(
+		setup: SliceTestSetup,
+		len_input_val: u64,
+		len_slice_val: u64,
+		offset_val: u64,
+		input_data: &[u8],
+		expected_slice_data: &[u8],
+	) {
+		let circuit = setup.builder.build();
+		let mut filler = circuit.new_witness_filler();
+		filler[setup.len_input] = Word(len_input_val);
+		filler[setup.len_slice] = Word(len_slice_val);
+		filler[setup.offset] = Word(offset_val);
+		pack_bytes_into_wires_le(&mut filler, &setup.input, input_data);
+		pack_bytes_into_wires_le(&mut filler, &setup.expected, expected_slice_data);
+
+		circuit.populate_wire_witness(&mut filler).unwrap();
+		let cs = circuit.constraint_system();
+		verify_constraints(cs, &filler.into_value_vec()).unwrap();
+	}
+
+	/// Run a failure-case test: expect `populate_wire_witness` to error.
+	fn run_slice_failure(
+		setup: SliceTestSetup,
+		len_input_val: u64,
+		len_slice_val: u64,
+		offset_val: u64,
+		input_data: &[u8],
+		expected_slice_data: &[u8],
+	) {
+		let circuit = setup.builder.build();
+		let mut filler = circuit.new_witness_filler();
+		filler[setup.len_input] = Word(len_input_val);
+		filler[setup.len_slice] = Word(len_slice_val);
+		filler[setup.offset] = Word(offset_val);
+		pack_bytes_into_wires_le(&mut filler, &setup.input, input_data);
+		pack_bytes_into_wires_le(&mut filler, &setup.expected, expected_slice_data);
+		assert!(circuit.populate_wire_witness(&mut filler).is_err());
+	}
 
 	#[test]
 	fn test_aligned_slice() {
-		let b = CircuitBuilder::new();
-
-		// Test case: 16-byte input, 8-byte slice at offset 0
-		let len_input = b.add_inout();
-		let len_slice = b.add_inout();
-		let offset = b.add_inout();
-
-		let input: Vec<Wire> = (0..2).map(|_| b.add_inout()).collect();
-		let slice: Vec<Wire> = (0..1).map(|_| b.add_inout()).collect();
-
-		let verifier = Slice::new(&b, len_input, len_slice, input, slice, offset);
-
-		let circuit = b.build();
-
-		// Test with actual values
-		let mut filler = circuit.new_witness_filler();
-
-		verifier.populate_len_input(&mut filler, 16);
-		verifier.populate_len_slice(&mut filler, 8);
-		verifier.populate_offset(&mut filler, 0);
-
-		// Input: 16 bytes
+		// 16-byte input, 8-byte slice at offset 0
+		let setup = build_slice_check(2, 1);
 		let input_data = [
 			0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d,
 			0x0e, 0x0f,
 		];
-		verifier.populate_input(&mut filler, &input_data);
-
-		// Slice: first 8 bytes of input
 		let slice_data = [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07];
-		verifier.populate_slice(&mut filler, &slice_data);
-
-		// Fill the circuit - this should succeed
-		circuit.populate_wire_witness(&mut filler).unwrap();
-
-		// Verify constraints
-		let cs = circuit.constraint_system();
-		verify_constraints(cs, &filler.into_value_vec()).unwrap();
+		run_slice_success(setup, 16, 8, 0, &input_data, &slice_data);
 	}
 
 	#[test]
 	fn test_unaligned_slice() {
-		let b = CircuitBuilder::new();
-
-		// Test case: 16-byte input, 8-byte slice at offset 3
-
-		let len_input = b.add_inout();
-		let len_slice = b.add_inout();
-		let offset = b.add_inout();
-
-		let input: Vec<Wire> = (0..2).map(|_| b.add_inout()).collect();
-		let slice: Vec<Wire> = (0..1).map(|_| b.add_inout()).collect();
-
-		let verifier = Slice::new(&b, len_input, len_slice, input, slice, offset);
-
-		let circuit = b.build();
-
-		// Test with actual values
-		let mut filler = circuit.new_witness_filler();
-
-		// Set up test data using populate methods
-		verifier.populate_len_input(&mut filler, 16);
-		verifier.populate_len_slice(&mut filler, 8);
-		verifier.populate_offset(&mut filler, 3);
-
-		// Input: 16 bytes
+		// 16-byte input, 8-byte slice at offset 3
+		let setup = build_slice_check(2, 1);
 		let input_data = [
 			0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d,
 			0x0e, 0x0f,
 		];
-		verifier.populate_input(&mut filler, &input_data);
-
-		// Slice at offset 3: bytes 3-10
-		// This should be: 03 04 05 06 07 08 09 0a
 		let slice_data = [0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a];
-		verifier.populate_slice(&mut filler, &slice_data);
-
-		// Fill the circuit - this should succeed
-		circuit.populate_wire_witness(&mut filler).unwrap();
-
-		// Verify constraints
-		let cs = circuit.constraint_system();
-		verify_constraints(cs, &filler.into_value_vec()).unwrap();
+		run_slice_success(setup, 16, 8, 3, &input_data, &slice_data);
 	}
 
 	#[test]
 	fn test_bounds_check() {
-		let b = CircuitBuilder::new();
-
-		let len_input = b.add_inout();
-		let len_slice = b.add_inout();
-		let offset = b.add_inout();
-
-		let input: Vec<Wire> = (0..2).map(|_| b.add_inout()).collect();
-		let slice: Vec<Wire> = (0..1).map(|_| b.add_inout()).collect();
-
-		let verifier = Slice::new(&b, len_input, len_slice, input, slice, offset);
-
-		let circuit = b.build();
-
-		// Test with values that should fail bounds check
-		let mut filler = circuit.new_witness_filler();
-
-		// Set up test data that violates bounds using populate methods
-		verifier.populate_len_input(&mut filler, 10);
-		verifier.populate_len_slice(&mut filler, 8);
-		verifier.populate_offset(&mut filler, 5);
-
-		// Fill dummy data
+		// offset(5) + len_slice(8) > len_input(10) → bounds check fails.
+		let setup = build_slice_check(2, 1);
 		let dummy_input = vec![0u8; 10];
 		let dummy_slice = vec![0u8; 8];
-		verifier.populate_input(&mut filler, &dummy_input);
-		verifier.populate_slice(&mut filler, &dummy_slice);
-
-		// This should fail the bounds check
-		let result = circuit.populate_wire_witness(&mut filler);
-		assert!(result.is_err());
+		run_slice_failure(setup, 10, 8, 5, &dummy_input, &dummy_slice);
 	}
 
 	#[test]
 	fn test_bounds_check_edge_case() {
-		let b = CircuitBuilder::new();
-
-		let len_input = b.add_inout();
-		let len_slice = b.add_inout();
-		let offset = b.add_inout();
-
-		let input: Vec<Wire> = (0..2).map(|_| b.add_inout()).collect();
-		let slice: Vec<Wire> = (0..1).map(|_| b.add_inout()).collect();
-
-		let verifier = Slice::new(&b, len_input, len_slice, input, slice, offset);
-		let circuit = b.build();
-
-		// Test exact boundary: offset + len_slice == len_input (should be valid)
-		let mut filler = circuit.new_witness_filler();
-		verifier.populate_len_input(&mut filler, 10);
-		verifier.populate_len_slice(&mut filler, 5);
-		verifier.populate_offset(&mut filler, 5);
-
-		// Create matching data
+		// Exact boundary: offset(5) + len_slice(5) == len_input(10).
+		let setup = build_slice_check(2, 1);
 		let input_data = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
 		let slice_data = vec![5, 6, 7, 8, 9];
-
-		verifier.populate_input(&mut filler, &input_data);
-		verifier.populate_slice(&mut filler, &slice_data);
-
-		// This should succeed since offset(5) + len_slice(5) == len_input(10)
-		let result = circuit.populate_wire_witness(&mut filler);
-		assert!(result.is_ok(), "Valid boundary case should succeed");
-
-		// Verify constraints
-		let cs = circuit.constraint_system();
-		verify_constraints(cs, &filler.into_value_vec()).unwrap();
+		run_slice_success(setup, 10, 5, 5, &input_data, &slice_data);
 	}
 
 	#[test]
 	fn test_empty_slice() {
-		let b = CircuitBuilder::new();
-
-		let len_input = b.add_inout();
-		let len_slice = b.add_inout();
-		let offset = b.add_inout();
-
-		let input: Vec<Wire> = (0..2).map(|_| b.add_inout()).collect();
-		let slice: Vec<Wire> = (0..1).map(|_| b.add_inout()).collect();
-
-		let verifier = Slice::new(&b, len_input, len_slice, input, slice, offset);
-		let circuit = b.build();
-
-		// Test with len_slice = 0
-		let mut filler = circuit.new_witness_filler();
-		verifier.populate_len_input(&mut filler, 10);
-		verifier.populate_len_slice(&mut filler, 0);
-		verifier.populate_offset(&mut filler, 5);
-
+		// len_slice = 0 — output is all zeros.
+		let setup = build_slice_check(2, 1);
 		let input_data = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
-		verifier.populate_input(&mut filler, &input_data);
-		verifier.populate_slice(&mut filler, &[]);
-
-		// Empty slice should be valid
-		let result = circuit.populate_wire_witness(&mut filler);
-		assert!(result.is_ok(), "Empty slice should be valid");
-
-		// Verify constraints
-		let cs = circuit.constraint_system();
-		verify_constraints(cs, &filler.into_value_vec()).unwrap();
+		run_slice_success(setup, 10, 0, 5, &input_data, &[]);
 	}
 
 	#[test]
 	fn test_mismatched_slice_content() {
-		let b = CircuitBuilder::new();
-
-		let len_input = b.add_inout();
-		let len_slice = b.add_inout();
-		let offset = b.add_inout();
-
-		let input: Vec<Wire> = (0..2).map(|_| b.add_inout()).collect();
-		let slice: Vec<Wire> = (0..1).map(|_| b.add_inout()).collect();
-
-		let verifier = Slice::new(&b, len_input, len_slice, input, slice, offset);
-		let circuit = b.build();
-
-		// Test with wrong slice content
-		let mut filler = circuit.new_witness_filler();
-		verifier.populate_len_input(&mut filler, 10);
-		verifier.populate_len_slice(&mut filler, 5);
-		verifier.populate_offset(&mut filler, 2);
-
+		// Caller's expected slice differs from the actual extracted bytes — the external
+		// `assert_eq` in `build_slice_check` should fail.
+		let setup = build_slice_check(2, 1);
 		let input_data = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
-		// Wrong slice data - should be [2, 3, 4, 5, 6] but we provide [0, 1, 2, 3, 4]
+		// Actual extracted slice at offset 2 with len 5 is [2,3,4,5,6]; we claim [0,1,2,3,4].
 		let wrong_slice_data = vec![0, 1, 2, 3, 4];
-
-		verifier.populate_input(&mut filler, &input_data);
-		verifier.populate_slice(&mut filler, &wrong_slice_data);
-
-		// This should fail
-		let result = circuit.populate_wire_witness(&mut filler);
-		assert!(result.is_err(), "Mismatched slice content should fail");
+		run_slice_failure(setup, 10, 5, 2, &input_data, &wrong_slice_data);
 	}
 
 	#[test]
 	fn test_offset_at_end() {
-		let b = CircuitBuilder::new();
-
-		let len_input = b.add_inout();
-		let len_slice = b.add_inout();
-		let offset = b.add_inout();
-
-		let input: Vec<Wire> = (0..2).map(|_| b.add_inout()).collect();
-		let slice: Vec<Wire> = (0..1).map(|_| b.add_inout()).collect();
-
-		let verifier = Slice::new(&b, len_input, len_slice, input, slice, offset);
-		let circuit = b.build();
-
-		// Test offset at end with empty slice
-		let mut filler = circuit.new_witness_filler();
-		verifier.populate_len_input(&mut filler, 10);
-		verifier.populate_len_slice(&mut filler, 0);
-		verifier.populate_offset(&mut filler, 10);
-
+		// Empty slice at offset 10, where len_input = 10.
+		let setup = build_slice_check(2, 1);
 		let input_data = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
-		verifier.populate_input(&mut filler, &input_data);
-		verifier.populate_slice(&mut filler, &[]);
-
-		// This should succeed - empty slice at end
-		let result = circuit.populate_wire_witness(&mut filler);
-		assert!(result.is_ok(), "Empty slice at end should be valid");
-
-		// Verify constraints
-		let cs = circuit.constraint_system();
-		verify_constraints(cs, &filler.into_value_vec()).unwrap();
+		run_slice_success(setup, 10, 0, 10, &input_data, &[]);
 	}
 
 	#[test]
 	fn test_multiple_byte_extraction_paths() {
-		// This test verifies that byte extraction works correctly for all paths
-		let b = CircuitBuilder::new();
-
-		let len_input = b.add_inout();
-		let len_slice = b.add_inout();
-		let offset = b.add_inout();
-
-		let input: Vec<Wire> = (0..3).map(|_| b.add_inout()).collect();
-		let slice: Vec<Wire> = (0..1).map(|_| b.add_inout()).collect();
-
-		let verifier = Slice::new(&b, len_input, len_slice, input, slice, offset);
-		let circuit = b.build();
-
-		// Test extraction from each word with different offsets
+		// Verify byte extraction works for a range of offsets in a fresh circuit each time.
+		// (The expected slice differs per case so we can't reuse one circuit.)
 		for word_idx in 0..3 {
 			for byte_offset in 0..8 {
 				let offset_val = word_idx * 8 + byte_offset;
 				if offset_val + 8 > 24 {
 					continue;
 				}
-
-				let mut filler = circuit.new_witness_filler();
-				verifier.populate_len_input(&mut filler, 24);
-				verifier.populate_len_slice(&mut filler, 8);
-				verifier.populate_offset(&mut filler, offset_val);
-
-				// Create distinct pattern for each byte
+				let setup = build_slice_check(3, 1);
 				let input_data: Vec<u8> = (0..24).map(|i| i as u8).collect();
 				let slice_data: Vec<u8> = input_data[offset_val..offset_val + 8].to_vec();
-
-				verifier.populate_input(&mut filler, &input_data);
-				verifier.populate_slice(&mut filler, &slice_data);
-
-				let result = circuit.populate_wire_witness(&mut filler);
-				assert!(
-					result.is_ok(),
-					"Extraction from word {word_idx} byte {byte_offset} failed"
-				);
-
-				// Verify constraints
-				let cs = circuit.constraint_system();
-				verify_constraints(cs, &filler.into_value_vec()).unwrap();
+				run_slice_success(setup, 24, 8, offset_val as u64, &input_data, &slice_data);
 			}
 		}
 	}
 
 	#[test]
-	fn test_full_word_assert_vulnerability_fixed() {
-		let b = CircuitBuilder::new();
-
-		// Set up circuit with specific sizes
-		// max_n_slice = 16 (2 words) but we'll use len_slice = 12 (1.5 words)
-		let len_input = b.add_inout();
-		let len_slice = b.add_inout();
-		let offset = b.add_inout();
-
-		let input: Vec<Wire> = (0..3).map(|_| b.add_inout()).collect();
-		let slice: Vec<Wire> = (0..2).map(|_| b.add_inout()).collect();
-
-		let verifier = Slice::new(&b, len_input, len_slice, input.clone(), slice.clone(), offset);
-		let circuit = b.build();
-
-		// Test case: len_slice = 12 bytes (1.5 words)
-		// This test verifies that the fix correctly validates partial words
-		let mut filler = circuit.new_witness_filler();
-
-		verifier.populate_len_input(&mut filler, 20);
-		verifier.populate_len_slice(&mut filler, 12); // 1.5 words
-		verifier.populate_offset(&mut filler, 0);
-
-		// Input data
+	fn test_partial_word_zero_padding() {
+		// `slice` returns words zero-padded past `len_slice`. For len_slice=12 (1.5 words), the
+		// upper 4 bytes of word 1 must be zero — and the assert_eq will catch any drift.
+		let setup = build_slice_check(3, 2);
 		let input_data = vec![
 			0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, // word 0
 			0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, // word 1
 			0x10, 0x11, 0x12, 0x13, // partial word 2
 		];
-		verifier.populate_input(&mut filler, &input_data);
-
-		// Try to provide malicious slice data:
-		// First word: correct
-		// Second word: only first 4 bytes need to be correct, last 4 are garbage
-		// Directly set the slice words to bypass populate_slice
-		filler[slice[0]] = Word(0x0706050403020100); // Correct first word
-		filler[slice[1]] = Word(0xffffffff0b0a0908); // Wrong last 4 bytes!
-
-		// This should now fail with the fix
-		let result = circuit.populate_wire_witness(&mut filler);
-		assert!(result.is_err(), "Fixed circuit should reject invalid slice data");
-
-		// Now test with correct data to ensure the fix doesn't break valid cases
-		let mut filler2 = circuit.new_witness_filler();
-		verifier.populate_len_input(&mut filler2, 20);
-		verifier.populate_len_slice(&mut filler2, 12);
-		verifier.populate_offset(&mut filler2, 0);
-		verifier.populate_input(&mut filler2, &input_data);
-
-		// Correct slice data
+		// Expected slice: 12 valid bytes, word-1 high half zero-padded.
 		let correct_slice = [
 			0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, // word 0
-			0x08, 0x09, 0x0a, 0x0b, 0x00, 0x00, 0x00, 0x00, // word 1 (padded correctly)
+			0x08, 0x09, 0x0a, 0x0b, 0x00, 0x00, 0x00, 0x00, // word 1 padded to 16 bytes
 		];
-		verifier.populate_slice(&mut filler2, &correct_slice[..12]); // Only 12 bytes
-
-		// This should succeed
-		let result2 = circuit.populate_wire_witness(&mut filler2);
-		assert!(result2.is_ok(), "Fixed circuit should accept valid slice data");
-
-		// Verify constraints
-		let cs = circuit.constraint_system();
-		verify_constraints(cs, &filler2.into_value_vec()).unwrap();
+		run_slice_success(setup, 20, 12, 0, &input_data, &correct_slice);
 	}
 
 	#[test]
-	fn test_simple_partial_word() {
-		// Simplest test case: 1 word slice with only 4 valid bytes
-		let b = CircuitBuilder::new();
-
-		let len_input = b.add_inout();
-		let len_slice = b.add_inout();
-		let offset = b.add_inout();
-
-		let input: Vec<Wire> = (0..1).map(|_| b.add_inout()).collect();
-		let slice: Vec<Wire> = (0..1).map(|_| b.add_inout()).collect();
-
-		let verifier = Slice::new(&b, len_input, len_slice, input.clone(), slice.clone(), offset);
-		let circuit = b.build();
-
-		// Test with 4 bytes
+	fn test_partial_word_tolerates_garbage_padding() {
+		// `build_slice_check` masks the comparison to the first `len_slice` bytes, so the test
+		// helper accepts arbitrary garbage in trailing bytes past `len_slice`.
+		let setup = build_slice_check(3, 2);
+		let input_data = vec![
+			0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d,
+			0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13,
+		];
+		let circuit = setup.builder.build();
 		let mut filler = circuit.new_witness_filler();
-		verifier.populate_len_input(&mut filler, 8);
-		verifier.populate_len_slice(&mut filler, 4); // Only 4 bytes
-		verifier.populate_offset(&mut filler, 0);
-
-		// Input: full 8 bytes
-		filler[input[0]] = Word(0x0706050403020100);
-
-		// Slice with wrong data in upper 4 bytes
-		// The slice should contain bytes 0x00, 0x01, 0x02, 0x03 from input
-		filler[slice[0]] = Word(0xffffffff03020100); // Correct lower 4 bytes, wrong upper 4
-
-		let result = circuit.populate_wire_witness(&mut filler);
-		assert!(result.is_err(), "Should reject slice with wrong upper bytes");
-
-		// Now test with correct data
-		let mut filler2 = circuit.new_witness_filler();
-		verifier.populate_len_input(&mut filler2, 8);
-		verifier.populate_len_slice(&mut filler2, 4);
-		verifier.populate_offset(&mut filler2, 0);
-
-		filler2[input[0]] = Word(0x0706050403020100);
-		filler2[slice[0]] = Word(0x0000000003020100); // Correct: upper 4 bytes are 0
-
-		let result2 = circuit.populate_wire_witness(&mut filler2);
-		assert!(result2.is_ok(), "Should accept correct partial word: {result2:?}");
-
-		// Additional test: verify constraints
-		let cs = circuit.constraint_system();
-		verify_constraints(cs, &filler2.into_value_vec()).unwrap();
-
-		// Test 3: Verify populate_slice handles this correctly
-		let mut filler3 = circuit.new_witness_filler();
-		verifier.populate_len_input(&mut filler3, 8);
-		verifier.populate_len_slice(&mut filler3, 4);
-		verifier.populate_offset(&mut filler3, 0);
-
-		let input_bytes = vec![0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07];
-		let slice_bytes = vec![0x00, 0x01, 0x02, 0x03]; // Only 4 bytes
-
-		verifier.populate_input(&mut filler3, &input_bytes);
-		verifier.populate_slice(&mut filler3, &slice_bytes);
-
-		let result3 = circuit.populate_wire_witness(&mut filler3);
-		assert!(result3.is_ok(), "populate_slice should handle partial words correctly");
-
-		// Test 4: Now manually set wrong upper bytes and it should fail
-		let mut filler4 = circuit.new_witness_filler();
-		verifier.populate_len_input(&mut filler4, 8);
-		verifier.populate_len_slice(&mut filler4, 4);
-		verifier.populate_offset(&mut filler4, 0);
-		verifier.populate_input(&mut filler4, &input_bytes);
-		verifier.populate_slice(&mut filler4, &slice_bytes);
-
-		// Corrupt the upper bytes
-		filler4[slice[0]] = Word(filler4[slice[0]].0 | 0xffffffff00000000);
-
-		let result4 = circuit.populate_wire_witness(&mut filler4);
-		assert!(result4.is_err(), "Should reject corrupted upper bytes");
-	}
-
-	#[test]
-	fn test_direct_masking_logic() {
-		// Test the masking logic directly
-		let slice_word = Word(0xffffffff_0b0a0908); // Wrong upper 4 bytes
-		let extracted_word = Word(0x00000000_0b0a0908); // Correct upper 4 bytes
-		let mask = Word(0x00000000_ffffffff); // Mask for 4 valid bytes
-
-		let masked_slice = slice_word & mask;
-		let masked_extracted = extracted_word & mask;
-
-		assert_eq!(
-			masked_slice, masked_extracted,
-			"Masked values should be equal: slice=0x{:016x}, extracted=0x{:016x}",
-			masked_slice.0, masked_extracted.0
-		);
-
-		// This is what the constraint checks
-		let xor_result = masked_slice ^ masked_extracted;
-		assert_eq!(xor_result, Word::ZERO, "XOR of masked values should be zero");
+		filler[setup.len_input] = Word(20);
+		filler[setup.len_slice] = Word(12);
+		filler[setup.offset] = Word(0);
+		pack_bytes_into_wires_le(&mut filler, &setup.input, &input_data);
+		// Word 0 correct, word 1 has garbage 0xffffffff in the upper half (past len_slice).
+		filler[setup.expected[0]] = Word(0x0706050403020100);
+		filler[setup.expected[1]] = Word(0xffffffff0b0a0908);
+		circuit.populate_wire_witness(&mut filler).unwrap();
 	}
 
 	#[test]
 	fn test_large_offset_overflow() {
-		let b = CircuitBuilder::new();
-
-		let len_input = b.add_inout();
-		let len_slice = b.add_inout();
-		let offset = b.add_inout();
-
-		let input: Vec<Wire> = (0..2).map(|_| b.add_inout()).collect();
-		let slice: Vec<Wire> = (0..1).map(|_| b.add_inout()).collect();
-
-		let verifier = Slice::new(&b, len_input, len_slice, input.clone(), slice.clone(), offset);
-		let circuit = b.build();
-
-		// Test with very large offset that should fail 32-bit check
+		// offset has bit 32 set → 32-bit assertion fails.
+		let setup = build_slice_check(2, 1);
+		let circuit = setup.builder.build();
 		let mut filler = circuit.new_witness_filler();
-		verifier.populate_len_input(&mut filler, 10);
-		verifier.populate_len_slice(&mut filler, 5);
-
-		// Try to set offset with upper 32 bits set
-		// This tests that the circuit properly validates 32-bit constraints
-		filler[offset] = Word(1u64 << 32); // Direct assignment to test constraint
-
-		let input_data = vec![0u8; 10];
-		let slice_data = vec![0u8; 5];
-		verifier.populate_input(&mut filler, &input_data);
-		verifier.populate_slice(&mut filler, &slice_data);
-
-		// This should fail the 32-bit check
-		let result = circuit.populate_wire_witness(&mut filler);
-		assert!(result.is_err(), "Large offset should fail 32-bit check");
+		filler[setup.len_input] = Word(10);
+		filler[setup.len_slice] = Word(5);
+		filler[setup.offset] = Word(1u64 << 32);
+		pack_bytes_into_wires_le(&mut filler, &setup.input, &[0u8; 10]);
+		pack_bytes_into_wires_le(&mut filler, &setup.expected, &[0u8; 5]);
+		assert!(circuit.populate_wire_witness(&mut filler).is_err());
 	}
 
 	#[test]
 	fn test_32bit_validation() {
-		let b = CircuitBuilder::new();
-
-		let len_input = b.add_inout();
-		let len_slice = b.add_inout();
-		let offset = b.add_inout();
-
-		let input: Vec<Wire> = (0..2).map(|_| b.add_inout()).collect();
-		let slice: Vec<Wire> = (0..1).map(|_| b.add_inout()).collect();
-
-		let verifier = Slice::new(&b, len_input, len_slice, input.clone(), slice.clone(), offset);
-		let circuit = b.build();
-
-		// Test multiple 32-bit constraint violations
-		// Test 1: offset with bit 33 set
+		// offset with bit 33 set
+		let setup = build_slice_check(2, 1);
+		let circuit = setup.builder.build();
 		let mut filler = circuit.new_witness_filler();
-		verifier.populate_len_input(&mut filler, 10);
-		verifier.populate_len_slice(&mut filler, 5);
-		filler[offset] = Word(1u64 << 33);
+		filler[setup.len_input] = Word(10);
+		filler[setup.len_slice] = Word(5);
+		filler[setup.offset] = Word(1u64 << 33);
+		pack_bytes_into_wires_le(&mut filler, &setup.input, &[0u8; 10]);
+		pack_bytes_into_wires_le(&mut filler, &setup.expected, &[0u8; 5]);
+		assert!(circuit.populate_wire_witness(&mut filler).is_err());
 
-		let input_data = vec![0u8; 10];
-		let slice_data = vec![0u8; 5];
-		verifier.populate_input(&mut filler, &input_data);
-		verifier.populate_slice(&mut filler, &slice_data);
-
-		let result = circuit.populate_wire_witness(&mut filler);
-		assert!(result.is_err(), "Offset with bit 33 set should fail");
-
-		// Test 2: len_input with upper bits set
+		// len_input with upper 32 bits set
+		let setup = build_slice_check(2, 1);
+		let circuit = setup.builder.build();
 		let mut filler = circuit.new_witness_filler();
-		filler[len_input] = Word(0xffffffff00000010); // Upper 32 bits set
-		verifier.populate_len_slice(&mut filler, 5);
-		verifier.populate_offset(&mut filler, 0);
-		verifier.populate_input(&mut filler, &input_data);
-		verifier.populate_slice(&mut filler, &slice_data);
+		filler[setup.len_input] = Word(0xffffffff00000010);
+		filler[setup.len_slice] = Word(5);
+		filler[setup.offset] = Word(0);
+		pack_bytes_into_wires_le(&mut filler, &setup.input, &[0u8; 10]);
+		pack_bytes_into_wires_le(&mut filler, &setup.expected, &[0u8; 5]);
+		assert!(circuit.populate_wire_witness(&mut filler).is_err());
 
-		let result = circuit.populate_wire_witness(&mut filler);
-		assert!(result.is_err(), "len_input with upper 32 bits set should fail");
-
-		// Test 3: len_slice with upper bits set
+		// len_slice with bit 32 set
+		let setup = build_slice_check(2, 1);
+		let circuit = setup.builder.build();
 		let mut filler = circuit.new_witness_filler();
-		verifier.populate_len_input(&mut filler, 10);
-		filler[len_slice] = Word(0x100000005); // Bit 32 set
-		verifier.populate_offset(&mut filler, 0);
-		verifier.populate_input(&mut filler, &input_data);
-		verifier.populate_slice(&mut filler, &slice_data);
-
-		let result = circuit.populate_wire_witness(&mut filler);
-		assert!(result.is_err(), "len_slice with upper bits set should fail");
+		filler[setup.len_input] = Word(10);
+		filler[setup.len_slice] = Word(0x100000005);
+		filler[setup.offset] = Word(0);
+		pack_bytes_into_wires_le(&mut filler, &setup.input, &[0u8; 10]);
+		pack_bytes_into_wires_le(&mut filler, &setup.expected, &[0u8; 5]);
+		assert!(circuit.populate_wire_witness(&mut filler).is_err());
 	}
 
 	#[test]
 	fn test_edge_case_len_input_zero() {
-		let b = CircuitBuilder::new();
-
-		let len_input = b.add_inout();
-		let len_slice = b.add_inout();
-		let offset = b.add_inout();
-
-		let input: Vec<Wire> = (0..2).map(|_| b.add_inout()).collect();
-		let slice: Vec<Wire> = (0..1).map(|_| b.add_inout()).collect();
-
-		let verifier = Slice::new(&b, len_input, len_slice, input.clone(), slice.clone(), offset);
-		let circuit = b.build();
-
-		// Test empty input with empty slice at offset 0
-		let mut filler = circuit.new_witness_filler();
-		verifier.populate_len_input(&mut filler, 0);
-		verifier.populate_len_slice(&mut filler, 0);
-		verifier.populate_offset(&mut filler, 0);
-
-		// Empty arrays
-		verifier.populate_input(&mut filler, &[]);
-		verifier.populate_slice(&mut filler, &[]);
-
-		// This should succeed - empty input with empty slice at offset 0
-		let result = circuit.populate_wire_witness(&mut filler);
-		assert!(result.is_ok(), "Empty input with empty slice should succeed");
-
-		// Verify constraints
-		let cs = circuit.constraint_system();
-		verify_constraints(cs, &filler.into_value_vec()).unwrap();
+		// Empty input + empty slice at offset 0.
+		let setup = build_slice_check(2, 1);
+		run_slice_success(setup, 0, 0, 0, &[], &[]);
 	}
 
 	#[test]
 	fn test_edge_case_len_input_zero_with_nonzero_slice() {
-		let b = CircuitBuilder::new();
-
-		let len_input = b.add_inout();
-		let len_slice = b.add_inout();
-		let offset = b.add_inout();
-
-		let input: Vec<Wire> = (0..2).map(|_| b.add_inout()).collect();
-		let slice: Vec<Wire> = (0..1).map(|_| b.add_inout()).collect();
-
-		let verifier = Slice::new(&b, len_input, len_slice, input.clone(), slice.clone(), offset);
-		let circuit = b.build();
-
-		// Test empty input with non-empty slice
-		let mut filler = circuit.new_witness_filler();
-		verifier.populate_len_input(&mut filler, 0);
-		verifier.populate_len_slice(&mut filler, 5);
-		verifier.populate_offset(&mut filler, 0);
-
-		verifier.populate_input(&mut filler, &[]);
-		verifier.populate_slice(&mut filler, &[1, 2, 3, 4, 5]);
-
-		// This should fail - can't extract non-empty slice from empty input
-		let result = circuit.populate_wire_witness(&mut filler);
-		assert!(result.is_err(), "Non-empty slice from empty input should fail");
+		// Empty input + non-empty slice → bounds check fails.
+		let setup = build_slice_check(2, 1);
+		run_slice_failure(setup, 0, 5, 0, &[], &[1, 2, 3, 4, 5]);
 	}
 
 	#[test]
 	fn test_padding_beyond_actual_data() {
-		let b = CircuitBuilder::new();
-
-		let len_input = b.add_inout();
-		let len_slice = b.add_inout();
-		let offset = b.add_inout();
-
-		let input: Vec<Wire> = (0..3).map(|_| b.add_inout()).collect();
-		let slice: Vec<Wire> = (0..2).map(|_| b.add_inout()).collect();
-
-		// Save wire references before moving vectors
-		let input_wire_2 = input[2];
-		let slice_wire_1 = slice[1];
-
-		let verifier = Slice::new(&b, len_input, len_slice, input, slice, offset);
-		let circuit = b.build();
-
-		// Test with actual data smaller than allocated space
-		let mut filler = circuit.new_witness_filler();
-		verifier.populate_len_input(&mut filler, 12); // 1.5 words
-		verifier.populate_len_slice(&mut filler, 8); // 1 word
-		verifier.populate_offset(&mut filler, 2);
-
-		// Input: 12 bytes (will be padded to 3 words)
+		// 12 bytes of input data padded into 3 input words; 8-byte slice at offset 2.
+		let setup = build_slice_check(3, 2);
 		let input_data = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
-		verifier.populate_input(&mut filler, &input_data);
-
-		// Slice at offset 2: bytes 2-9
+		// Slice is 8 bytes, so word 1 is fully zero-padded.
 		let slice_data = vec![2, 3, 4, 5, 6, 7, 8, 9];
-		verifier.populate_slice(&mut filler, &slice_data);
+		run_slice_success(setup, 12, 8, 2, &input_data, &slice_data);
+	}
 
-		// Verify the circuit handles padding correctly
-		let result = circuit.populate_wire_witness(&mut filler);
-		assert!(result.is_ok(), "Should handle data with padding correctly");
+	#[test]
+	fn test_direct_masking_logic() {
+		// Test the masking logic directly (Rust-side, no circuit).
+		let slice_word = Word(0xffffffff_0b0a0908);
+		let extracted_word = Word(0x00000000_0b0a0908);
+		let mask = Word(0x00000000_ffffffff);
 
-		// Also verify that padded words in input are zeroed
-		assert_eq!(filler[input_wire_2], Word::ZERO, "Third input word should be zero");
-		// Second slice word should also be zero since slice is only 1 word
-		assert_eq!(filler[slice_wire_1], Word::ZERO, "Second slice word should be zero");
+		let masked_slice = slice_word & mask;
+		let masked_extracted = extracted_word & mask;
 
-		// Verify constraints
-		let cs = circuit.constraint_system();
-		verify_constraints(cs, &filler.into_value_vec()).unwrap();
+		assert_eq!(masked_slice, masked_extracted);
+		assert_eq!(masked_slice ^ masked_extracted, Word::ZERO);
 	}
 }

--- a/crates/examples/snapshots/zklogin.snap
+++ b/crates/examples/snapshots/zklogin.snap
@@ -1,28 +1,28 @@
 zklogin circuit
 --
 Gates & Instructions
-├─ Number of gates: 533,759
-└─ Number of evaluation instructions: 597,709
+├─ Number of gates: 531,502
+└─ Number of evaluation instructions: 595,365
 
 Constraints
-├─ AND constraints: 456,241 used (87.0% of 2^19)
-│  [▓▓▓▓▓▓▓▓░░] spare: 68,047
+├─ AND constraints: 454,095 used (86.6% of 2^19)
+│  [▓▓▓▓▓▓▓▓░░] spare: 70,193
 ├─ MUL constraints: 8,262 used (50.4% of 2^14)
 │  [▓▓▓▓▓░░░░░] spare: 8,122
-└─ Distinct value indices: 821,176
-   ├─ Distinct shifted value indices: 362,740
-   └─ Distinct unshifted value indices: 458,436
+└─ Distinct value indices: 818,928
+   ├─ Distinct shifted value indices: 362,574
+   └─ Distinct unshifted value indices: 456,354
 
 Value Vector
 ├─ Public Section: 1,018 used (99.4% of 2^10)
 │  [▓▓▓▓▓▓▓▓▓░] spare: 6
 │  ├─ Constants: 716
 │  └─ Inout: 302
-├─ Private Section: 457,419 used (87.4%)
-│  [▓▓▓▓▓▓▓▓░░] spare: 65,845
+├─ Private Section: 455,337 used (87.0%)
+│  [▓▓▓▓▓▓▓▓░░] spare: 67,927
 │  ├─ Witness: 1,788
-│  └─ Internal: 455,631
-├─ Total Committed: 458,437 used (87.4% of 2^19)
-│  [▓▓▓▓▓▓▓▓░░] spare: 65,851
-└─ Scratch (uncommitted): 352,758
+│  └─ Internal: 453,549
+├─ Total Committed: 456,355 used (87.0% of 2^19)
+│  [▓▓▓▓▓▓▓▓░░] spare: 67,933
+└─ Scratch (uncommitted): 352,619
 

--- a/crates/prover/tests/shift.rs
+++ b/crates/prover/tests/shift.rs
@@ -125,7 +125,8 @@ pub fn create_concat_cs_with_witness() -> (ConstraintSystem, ValueVec) {
 }
 
 pub fn create_slice_cs_with_witness() -> (ConstraintSystem, ValueVec) {
-	use binius_circuits::slice::Slice;
+	use binius_circuits::slice::{assert_slice_eq, slice};
+	use binius_frontend::util::pack_bytes_into_wires_le;
 
 	let builder = CircuitBuilder::new();
 
@@ -133,11 +134,12 @@ pub fn create_slice_cs_with_witness() -> (ConstraintSystem, ValueVec) {
 	let len_input = builder.add_witness();
 	let len_slice = builder.add_witness();
 	let input: Vec<Wire> = (0..4).map(|_| builder.add_witness()).collect();
-	let slice: Vec<Wire> = (0..2).map(|_| builder.add_witness()).collect();
+	let expected: Vec<Wire> = (0..2).map(|_| builder.add_witness()).collect();
 	let offset = builder.add_witness();
 
-	// Create the Slice circuit
-	let slice_circuit = Slice::new(&builder, len_input, len_slice, input, slice, offset);
+	// Extract the slice and assert it matches `expected` in the first `len_slice` bytes.
+	let actual = slice(&builder, len_input, len_slice, &input, offset, expected.len());
+	assert_slice_eq(&builder, "slice_eq", len_slice, &actual, &expected);
 
 	let circuit = builder.build();
 	let mut witness_filler = circuit.new_witness_filler();
@@ -145,13 +147,13 @@ pub fn create_slice_cs_with_witness() -> (ConstraintSystem, ValueVec) {
 	// Test slicing "Hello World!" from offset 6 with length 5 to get "World"
 	let input_data = b"Hello World!";
 	let slice_data = b"World";
-	let offset_val = 6;
+	let offset_val = 6u64;
 
-	slice_circuit.populate_len_input(&mut witness_filler, input_data.len());
-	slice_circuit.populate_len_slice(&mut witness_filler, slice_data.len());
-	slice_circuit.populate_input(&mut witness_filler, input_data);
-	slice_circuit.populate_slice(&mut witness_filler, slice_data);
-	slice_circuit.populate_offset(&mut witness_filler, offset_val);
+	witness_filler[len_input] = Word(input_data.len() as u64);
+	witness_filler[len_slice] = Word(slice_data.len() as u64);
+	pack_bytes_into_wires_le(&mut witness_filler, &input, input_data);
+	pack_bytes_into_wires_le(&mut witness_filler, &expected, slice_data);
+	witness_filler[offset] = Word(offset_val);
 
 	// Get the witness vector
 	circuit.populate_wire_witness(&mut witness_filler).unwrap();


### PR DESCRIPTION
## Summary

- Replaces the `Slice` struct + `populate_*` methods with a free `pub fn slice(b, len_input, len_slice, input, offset, max_n_words) -> Vec<Wire>` per [BINIUS-36](https://linear.app/jimpo/issue/BINIUS-36).
- The function now *returns* the extracted bytes (zero-padded past `len_slice`) instead of taking them as an input wire vector to assert against. Callers compose the result with their own `assert_eq` (or feed it into downstream computation), giving a more flexible gadget that also reduces constraint count: per output word, 3 internal `assert_eq_cond` calls + 2 extra bands disappear in favor of 1 band + 1 select. Even with caller-side `assert_eq`s added back, the (input=2 words, slice=1 word) circuit drops from 54 → 51 AND constraints, and (input=8 words, slice=4 words) drops from 259 → 247.
- Internal callers in `jwt_claims::JwtClaims::new` (still struct-based at this commit) and `prover/tests/shift.rs::create_slice_cs_with_witness` are updated to consume the returned wires and add their own equality assertions.
- The slice-data parameter would have shadowed the function name within the body; the test variables holding allocated output wires are named `expected` instead.
- Existing free helpers `extract_word` and `create_byte_mask` are retained.
- Tests are reworked around a small `SliceTestSetup` helper that allocates `expected` wires and compares them to the returned slice. The comparison is byte-masked to `len_slice`: for each output word, the saturating difference `len_slice - i*8` selects between full-word `assert_eq` (diff ≥ 8), partial comparison via `var_sll_bytes` shifting both sides left by `8 - diff` bytes (1 ≤ diff < 8), and a skipped comparison (diff = 0). This lets the test helper tolerate arbitrary garbage in expected bytes past `len_slice`, which the prior strict `assert_eq` would have rejected.

This is the first commit in the Tier 1 BINIUS-36 series.

## Test plan

- [x] `cargo build -p binius-circuits`
- [x] `cargo test -p binius-circuits --lib slice`
- [x] `cargo test -p binius-circuits --lib jwt_claims`
- [x] `cargo build -p binius-prover --tests`
- [x] `cargo fmt -p binius-circuits --check`
