### PR TITLE
Don't zero-pad messages in hash example circuits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ cargo build                    # Debug build
 cargo build --release          # Release build
 cargo test                     # Run tests
 cargo test -p <crate>          # Test specific crate
-cargo fmt                      # Format code
+cargo +nightly-2026-01-01 fmt  # Format code (pinned nightly; see .pre-commit-config.yaml)
 cargo clippy --all --all-features --tests --benches --examples -- -D warnings
 cargo doc --no-deps --document-private-items   # Build rustdoc
 typos                          # Check for typos

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,19 +13,18 @@ with automated tooling.
 
 ### Running automated checks
 
-You can run the formatter and linter with
+The codebase is formatted with a nightly version of `cargo fmt` because stable doesn't support all of the rustfmt
+options we use. You can run the formatter and linter with
 
 ```bash
-$ cargo fmt
+$ cargo +nightly-2026-01-01 fmt  # see .pre-commit-config.yaml for the exact nightly version checked by CI
 $ cargo clippy --all --all-features --tests --benches --examples -- -D warnings
 ```
 
-[Pre-commit](https://pre-commit.com/) hooks are configured to run `rustfmt`. The codebase is formatted with a nightly
-version of `cargo fmt` because stable doesn't support all of the rustfmt options we use. To run it, you can use:
+[Pre-commit](https://pre-commit.com/) hooks are configured to run `rustfmt`. You can also invoke it via pre-commit:
 
 ```bash
 $ pre-commit run rustfmt --all-files
-$ cargo +nightly-2026-01-01 fmt  # see .pre-commit-config.yaml for the exact nightly version checked by CI
 ```
 
 ### Documentation

--- a/crates/examples/src/circuits/blake2b.rs
+++ b/crates/examples/src/circuits/blake2b.rs
@@ -11,7 +11,6 @@ use crate::ExampleCircuit;
 /// Blake2b circuit example demonstrating the Blake2b hash function implementation
 pub struct Blake2bExample {
 	blake2b_circuit: Blake2bCircuit,
-	max_msg_len_bytes: usize,
 }
 
 /// Circuit parameters that affect structure (compile-time configuration)
@@ -45,27 +44,20 @@ impl ExampleCircuit for Blake2bExample {
 
 		let blake2b_circuit = Blake2bCircuit::new_with_length(builder, max_msg_len_bytes);
 
-		Ok(Self {
-			blake2b_circuit,
-			max_msg_len_bytes,
-		})
+		Ok(Self { blake2b_circuit })
 	}
 
 	fn populate_witness(&self, instance: Instance, w: &mut WitnessFiller) -> Result<()> {
 		// Step 1: Get raw message bytes
-		let raw_message =
-			utils::generate_message_bytes(instance.message_string, instance.message_len);
+		let message = utils::generate_message_bytes(instance.message_string, instance.message_len);
 
-		// Step 2: Zero-pad to maximum length
-		let padded_message = utils::zero_pad_message(raw_message, self.max_msg_len_bytes)?;
-
-		// Step 3: Compute digest using reference implementation
-		let expected_digest_vec = blake2b(&padded_message, 64);
+		// Step 2: Compute digest using reference implementation
+		let expected_digest_vec = blake2b(&message, 64);
 		let mut expected_digest = [0u8; 64];
 		expected_digest.copy_from_slice(&expected_digest_vec);
 
-		// Step 4: Populate witness values (Blake2b doesn't use len_bytes)
-		self.blake2b_circuit.populate_message(w, &padded_message);
+		// Step 3: Populate witness values (Blake2b doesn't use len_bytes)
+		self.blake2b_circuit.populate_message(w, &message);
 		self.blake2b_circuit.populate_digest(w, &expected_digest);
 
 		Ok(())

--- a/crates/examples/src/circuits/blake2s.rs
+++ b/crates/examples/src/circuits/blake2s.rs
@@ -50,19 +50,15 @@ impl ExampleCircuit for Blake2sExample {
 
 	fn populate_witness(&self, instance: Instance, w: &mut WitnessFiller) -> Result<()> {
 		// Step 1: Get raw message bytes
-		let raw_message =
-			utils::generate_message_bytes(instance.message_string, instance.message_len);
+		let message = utils::generate_message_bytes(instance.message_string, instance.message_len);
 
-		// Step 2: Zero-pad to maximum length
-		let padded_message = utils::zero_pad_message(raw_message, self.blake2s_gadget.length)?;
-
-		// Step 3: Compute digest using reference implementation
+		// Step 2: Compute digest using reference implementation
 		let mut hasher = Blake2s256::new();
-		hasher.update(&padded_message);
+		hasher.update(&message);
 		let digest: [u8; 32] = hasher.finalize().into();
 
-		// Step 4: Populate witness values (Blake2s doesn't use len_bytes)
-		self.blake2s_gadget.populate_message(w, &padded_message);
+		// Step 3: Populate witness values (Blake2s doesn't use len_bytes)
+		self.blake2s_gadget.populate_message(w, &message);
 		self.blake2s_gadget.populate_digest(w, &digest);
 
 		Ok(())

--- a/crates/examples/src/circuits/keccak.rs
+++ b/crates/examples/src/circuits/keccak.rs
@@ -11,7 +11,6 @@ use crate::ExampleCircuit;
 /// Keccak-256 hash circuit example
 pub struct KeccakExample {
 	keccak_hash: Keccak256,
-	max_len_bytes: usize,
 }
 
 #[derive(Args, Debug, Clone)]
@@ -50,26 +49,21 @@ impl ExampleCircuit for KeccakExample {
 
 		Ok(Self {
 			keccak_hash: keccak,
-			max_len_bytes,
 		})
 	}
 
 	fn populate_witness(&self, instance: Instance, w: &mut WitnessFiller) -> Result<()> {
 		// Step 1: Get raw message bytes
-		let raw_message =
-			utils::generate_message_bytes(instance.message_string, instance.message_len);
+		let message = utils::generate_message_bytes(instance.message_string, instance.message_len);
 
-		// Step 2: Zero-pad to maximum length
-		let padded_message = utils::zero_pad_message(raw_message, self.max_len_bytes)?;
-
-		// Step 3: Compute digest using reference implementation
+		// Step 2: Compute digest using reference implementation
 		let mut hasher = sha3::Keccak256::new();
-		hasher.update(&padded_message);
+		hasher.update(&message);
 		let digest: [u8; 32] = hasher.finalize().into();
 
-		// Step 4: Populate witness values
-		self.keccak_hash.populate_len_bytes(w, padded_message.len());
-		self.keccak_hash.populate_message(w, &padded_message);
+		// Step 3: Populate witness values
+		self.keccak_hash.populate_len_bytes(w, message.len());
+		self.keccak_hash.populate_message(w, &message);
 		self.keccak_hash.populate_digest(w, digest);
 
 		Ok(())

--- a/crates/examples/src/circuits/sha256.rs
+++ b/crates/examples/src/circuits/sha256.rs
@@ -57,20 +57,14 @@ impl ExampleCircuit for Sha256Example {
 
 	fn populate_witness(&self, instance: Instance, w: &mut WitnessFiller) -> Result<()> {
 		// Step 1: Get raw message bytes
-		let raw_message =
-			utils::generate_message_bytes(instance.message_string, instance.message_len);
+		let message = utils::generate_message_bytes(instance.message_string, instance.message_len);
 
-		// Step 2: Zero-pad to maximum length
-		let padded_message =
-			utils::zero_pad_message(raw_message, self.sha256_gadget.max_len_bytes())?;
+		// Step 2: Compute digest using reference implementation
+		let digest = sha2::Sha256::digest(&message);
 
-		// Step 3: Compute digest using reference implementation
-		let digest = sha2::Sha256::digest(&padded_message);
-
-		// Step 4: Populate witness values
-		self.sha256_gadget
-			.populate_len_bytes(w, padded_message.len());
-		self.sha256_gadget.populate_message(w, &padded_message);
+		// Step 3: Populate witness values
+		self.sha256_gadget.populate_len_bytes(w, message.len());
+		self.sha256_gadget.populate_message(w, &message);
 		self.sha256_gadget.populate_digest(w, digest.into());
 
 		Ok(())

--- a/crates/examples/src/circuits/sha512.rs
+++ b/crates/examples/src/circuits/sha512.rs
@@ -57,20 +57,14 @@ impl ExampleCircuit for Sha512Example {
 
 	fn populate_witness(&self, instance: Instance, w: &mut WitnessFiller) -> Result<()> {
 		// Step 1: Get raw message bytes
-		let raw_message =
-			utils::generate_message_bytes(instance.message_string, instance.message_len);
+		let message = utils::generate_message_bytes(instance.message_string, instance.message_len);
 
-		// Step 2: Zero-pad to maximum length
-		let padded_message =
-			utils::zero_pad_message(raw_message, self.sha512_gadget.max_len_bytes())?;
+		// Step 2: Compute digest using reference implementation
+		let digest = sha2::Sha512::digest(&message);
 
-		// Step 3: Compute digest using reference implementation
-		let digest = sha2::Sha512::digest(&padded_message);
-
-		// Step 4: Populate witness values
-		self.sha512_gadget
-			.populate_len_bytes(w, padded_message.len());
-		self.sha512_gadget.populate_message(w, &padded_message);
+		// Step 3: Populate witness values
+		self.sha512_gadget.populate_len_bytes(w, message.len());
+		self.sha512_gadget.populate_message(w, &message);
 		self.sha512_gadget.populate_digest(w, digest.into());
 
 		Ok(())

--- a/crates/examples/src/circuits/utils.rs
+++ b/crates/examples/src/circuits/utils.rs
@@ -78,27 +78,3 @@ pub fn generate_message_bytes(
 		message_bytes
 	}
 }
-
-/// Zero-pad message to maximum length.
-///
-/// Ensures the message doesn't exceed max_len and pads with zeros to reach max_len.
-///
-/// # Arguments
-/// * `message_bytes` - The original message bytes
-/// * `max_len` - The target length after padding
-///
-/// # Returns
-/// * `Ok(Vec<u8>)` - The padded message
-/// * `Err` - If the message exceeds max_len
-pub fn zero_pad_message(message_bytes: Vec<u8>, max_len: usize) -> Result<Vec<u8>> {
-	ensure!(
-		message_bytes.len() <= max_len,
-		"Message length ({}) exceeds maximum ({})",
-		message_bytes.len(),
-		max_len
-	);
-
-	let mut padded = message_bytes;
-	padded.resize(max_len, 0);
-	Ok(padded)
-}


### PR DESCRIPTION
## Summary
- Stop zero-padding raw messages in the sha256, sha512, blake2b, blake2s, and keccak example circuits — the gadgets handle padding internally.
- Remove the now-unused `utils::zero_pad_message` helper.
- Drop the unused `max_msg_len_bytes` / `max_len_bytes` fields from `Blake2bExample` and `KeccakExample`.

## Test plan
- `cargo check -p binius-examples`
- `cargo clippy -p binius-examples --tests -- -D warnings`
- `cargo test -p binius-examples`
