### PR TITLE
Add ZK signature of knowledge over a signed message

### DIFF
--- a/crates/examples/src/cli.rs
+++ b/crates/examples/src/cli.rs
@@ -226,6 +226,16 @@ where
 					.long("zk")
 					.help("Use the zero-knowledge proving config")
 					.action(clap::ArgAction::SetTrue),
+			)
+			.arg(
+				Arg::new("sign_message")
+					.long("sign-message")
+					.value_name("MESSAGE")
+					.requires("zk")
+					.help(
+						"Produce a zero-knowledge signature of knowledge over this message \
+						 instead of a plain proof of knowledge (requires --zk)",
+					),
 			);
 
 		// Augment with Params arguments at top level for default behavior
@@ -265,6 +275,16 @@ where
 					.long("zk")
 					.help("Use the zero-knowledge proving config")
 					.action(clap::ArgAction::SetTrue),
+			)
+			.arg(
+				Arg::new("sign_message")
+					.long("sign-message")
+					.value_name("MESSAGE")
+					.requires("zk")
+					.help(
+						"Produce a zero-knowledge signature of knowledge over this message \
+						 instead of a plain proof of knowledge (requires --zk)",
+					),
 			);
 		cmd = E::Params::augment_args(cmd);
 		cmd = E::Instance::augment_args(cmd);
@@ -475,10 +495,15 @@ where
 			.expect("has default value")
 			.clone();
 		let zk = matches.get_flag("zk");
+		let sign_message = matches.get_one::<String>("sign_message").cloned();
 		tracing::info!("Parsed compression type: {compression:?}");
 		if zk {
 			tracing::info!("Using zero-knowledge proving config");
 		}
+		if sign_message.is_some() {
+			tracing::info!("Producing a signature of knowledge over the provided message");
+		}
+		let message = sign_message.as_deref().map(str::as_bytes);
 
 		// Parse Params and Instance from matches
 		let params = E::Params::from_arg_matches(&matches)?;
@@ -523,12 +548,12 @@ where
 			(true, CompressionType::Sha256) => {
 				tracing::info!("Using SHA256 compression for Merkle tree");
 				let (verifier, prover) = setup_zk::<StdHashSuite>(cs, log_inv_rate as usize)?;
-				prove_verify_zk(&verifier, &prover, witness)?;
+				prove_verify_zk(&verifier, &prover, witness, message)?;
 			}
 			(true, CompressionType::Vision) => {
 				tracing::info!("Using Vision suite for Merkle tree");
 				let (verifier, prover) = setup_zk::<VisionHashSuite>(cs, log_inv_rate as usize)?;
-				prove_verify_zk(&verifier, &prover, witness)?;
+				prove_verify_zk(&verifier, &prover, witness, message)?;
 			}
 		}
 

--- a/crates/examples/src/lib.rs
+++ b/crates/examples/src/lib.rs
@@ -116,6 +116,7 @@ pub fn prove_verify_zk<H>(
 	verifier: &ZKVerifier<H>,
 	prover: &ZKProver<OptimalPackedB128, H>,
 	witness: ValueVec,
+	message: Option<&[u8]>,
 ) -> Result<()>
 where
 	H: HashSuite,
@@ -127,7 +128,12 @@ where
 		let _scope = tracing::info_span!("Prove").entered();
 		let mut prover_transcript = ProverTranscript::new(challenger.clone());
 		let mut rng = rand::rng();
-		prover.prove(witness.clone(), &mut rng, &mut prover_transcript)?;
+		match message {
+			Some(message) => {
+				prover.prove_sig(witness.clone(), message, &mut rng, &mut prover_transcript)?
+			}
+			None => prover.prove(witness.clone(), &mut rng, &mut prover_transcript)?,
+		}
 		prover_transcript.finalize()
 	};
 
@@ -135,7 +141,12 @@ where
 
 	let _scope = tracing::info_span!("Verify").entered();
 	let mut verifier_transcript = VerifierTranscript::new(challenger, proof);
-	verifier.verify(witness.public(), &mut verifier_transcript)?;
+	match message {
+		Some(message) => {
+			verifier.verify_sig(witness.public(), message, &mut verifier_transcript)?
+		}
+		None => verifier.verify(witness.public(), &mut verifier_transcript)?,
+	}
 	verifier_transcript.finalize()?;
 
 	Ok(())

--- a/crates/prover/src/zk_config.rs
+++ b/crates/prover/src/zk_config.rs
@@ -178,6 +178,21 @@ where
 
 		Ok(())
 	}
+
+	/// Generates a ZK signature of knowledge over `message`.
+	///
+	/// Binds `message` into the transcript before any other data, then runs the ordinary
+	/// [`Self::prove`] logic. See [`binius_verifier::signature`] for details.
+	pub fn prove_sig<Challenger_: Challenger>(
+		&self,
+		witness: ValueVec,
+		message: &[u8],
+		rng: impl CryptoRng,
+		transcript: &mut ProverTranscript<Challenger_>,
+	) -> Result<(), Error> {
+		binius_verifier::signature::observe_message::<H, _>(&mut transcript.observe(), message);
+		self.prove(witness, rng, transcript)
+	}
 }
 
 /// Error type for ZK proving.

--- a/crates/prover/tests/prove_verify.rs
+++ b/crates/prover/tests/prove_verify.rs
@@ -103,3 +103,70 @@ fn test_zk_prove_verify_sha256_preimage() {
 	let (cs, witness) = sha256_preimage_circuit();
 	prove_verify_zk(cs, witness);
 }
+
+/// Produces a ZK signature-of-knowledge proof over `sign_message`, then verifies it against
+/// `verify_message`. Returns whether verification (including transcript finalization) succeeded.
+///
+/// Signatures of knowledge are only supported by the ZK prover/verifier.
+fn sign_verify(
+	cs: ConstraintSystem,
+	witness: ValueVec,
+	sign_message: Option<&[u8]>,
+	verify_message: Option<&[u8]>,
+) -> bool {
+	const LOG_INV_RATE: usize = 1;
+
+	let zk_verifier = ZKVerifier::<StdHashSuite>::setup(cs, LOG_INV_RATE).unwrap();
+	let zk_prover =
+		ZKProver::<OptimalPackedB128, StdHashSuite>::setup(zk_verifier.clone()).unwrap();
+
+	let mut rng = StdRng::seed_from_u64(0);
+	let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
+	match sign_message {
+		Some(message) => zk_prover
+			.prove_sig(witness.clone(), message, &mut rng, &mut prover_transcript)
+			.unwrap(),
+		None => zk_prover
+			.prove(witness.clone(), &mut rng, &mut prover_transcript)
+			.unwrap(),
+	}
+
+	let mut verifier_transcript = prover_transcript.into_verifier();
+	let verify_ok = match verify_message {
+		Some(message) => zk_verifier
+			.verify_sig(witness.public(), message, &mut verifier_transcript)
+			.is_ok(),
+		None => zk_verifier
+			.verify(witness.public(), &mut verifier_transcript)
+			.is_ok(),
+	};
+	verify_ok && verifier_transcript.finalize().is_ok()
+}
+
+#[test]
+fn test_signature_of_knowledge_roundtrip() {
+	let (cs, witness) = sha256_preimage_circuit();
+	// Signing and verifying with the same message succeeds.
+	assert!(sign_verify(cs, witness, Some(b"hello world"), Some(b"hello world")));
+}
+
+#[test]
+fn test_signature_of_knowledge_wrong_message_fails() {
+	let (cs, witness) = sha256_preimage_circuit();
+	// A proof signed over one message must not verify against a different message.
+	assert!(!sign_verify(cs, witness, Some(b"hello world"), Some(b"goodbye world")));
+}
+
+#[test]
+fn test_signature_of_knowledge_missing_message_fails() {
+	let (cs, witness) = sha256_preimage_circuit();
+	// A signature of knowledge must not verify as a plain proof of knowledge (no message).
+	assert!(!sign_verify(cs, witness, Some(b"hello world"), None));
+}
+
+#[test]
+fn test_plain_proof_rejects_message() {
+	let (cs, witness) = sha256_preimage_circuit();
+	// A plain proof of knowledge must not verify when a message is supplied.
+	assert!(!sign_verify(cs, witness, None, Some(b"hello world")));
+}

--- a/crates/verifier/src/lib.rs
+++ b/crates/verifier/src/lib.rs
@@ -37,6 +37,7 @@ pub mod config;
 mod error;
 pub mod protocols;
 pub mod ring_switch;
+pub mod signature;
 mod verify;
 pub mod zk_config;
 

--- a/crates/verifier/src/signature.rs
+++ b/crates/verifier/src/signature.rs
@@ -1,0 +1,83 @@
+// Copyright 2026 The Binius Developers
+
+//! Signature of knowledge support.
+//!
+//! A Binius64 proof is a non-interactive proof of knowledge: an interactive protocol made
+//! non-interactive with the Fiat-Shamir transform. Such a proof can be converted into a
+//! *signature of knowledge* (SoK) over a message `m` by binding `m` into the Fiat-Shamir
+//! transcript before any other data is observed. The verifier then needs the message in order
+//! to recompute the same transcript and check the proof; a proof produced for one message does
+//! not verify against any other message.
+//!
+//! Rather than observing the message bytes directly, we observe the *hash* of the message,
+//! computed with the same hash function the Merkle commitment scheme uses for its leaves
+//! ([`HashSuite::LeafHash`]). This keeps the amount of data fed into the challenger fixed-size
+//! and independent of the message length, and insulates the construction from future changes to
+//! the transcript API.
+//!
+//! The message (and its hash) are *observed* into the transcript, not written to the proof tape:
+//! they affect the Fiat-Shamir challenges but are not part of the serialized proof. The verifier
+//! must supply the message out of band, exactly as a signature verifier supplies the signed
+//! message.
+//!
+//! Signing is only exposed on the zero-knowledge prover and verifier (`ZKProver::prove_sig` and
+//! [`ZKVerifier::verify_sig`](crate::zk_config::ZKVerifier::verify_sig)): a signature of knowledge
+//! should not reveal the witness it is signed under, and only the ZK configuration hides the
+//! witness. The [`observe_message`] helper below is generic over the hash suite and is shared by
+//! both.
+//!
+//! # Security analysis
+//!
+//! - **Binding / non-malleability.** The message hash is observed *first*, before the public input
+//!   and before the prover's witness commitment. Every subsequent Fiat-Shamir challenge therefore
+//!   depends on the message. An adversary who is given a valid proof for message `m` cannot maul it
+//!   into a valid proof for a different message `m'`: changing the message changes the first
+//!   challenger absorption and hence every sampled challenge, so the rest of the (replayed) proof
+//!   no longer satisfies the verifier's checks. This is the standard "strong Fiat-Shamir"
+//!   requirement that the full statement — here extended with the message — be bound into the
+//!   transcript.
+//!
+//! - **Reduction to collision resistance.** Because we bind `H(m)` rather than `m`, the binding is
+//!   only as strong as the collision resistance of `H = HashSuite::LeafHash`. If an adversary finds
+//!   `m != m'` with `H(m) = H(m')`, a signature on `m` also verifies for `m'`. The leaf hashes used
+//!   by the shipped suites (SHA-256, Vision) are collision resistant, so this is not a practical
+//!   concern; it is the same assumption the Merkle commitment already relies on.
+//!
+//! - **Knowledge soundness is preserved.** Observing extra public data at the start of the
+//!   transcript does not weaken the soundness of the underlying argument: it is equivalent to
+//!   running the original protocol on a statement augmented with a public message-hash that does
+//!   not participate in any constraint. A forger who cannot satisfy the constraint system still
+//!   cannot, for any message.
+//!
+//! - **Zero knowledge is preserved.** The message hash is public input to the Fiat-Shamir transform
+//!   and never touches the witness, so binding it leaks nothing about the witness in the ZK
+//!   configuration.
+//!
+//! - **Prover/verifier must agree on the mode.** Whether a message is bound, and what it is, is not
+//!   encoded in the proof. A verifier that checks a SoK proof without the message (or with the
+//!   wrong message) samples different challenges and rejects. Callers must therefore agree out of
+//!   band on whether a proof is a plain proof of knowledge or a signature of knowledge. Note that
+//!   an empty message (`Some(&[])`, which binds `H("")`) is distinct from no message at all
+//!   (`None`, which binds nothing).
+
+use binius_hash::binary_merkle_tree::HashSuite;
+use binius_transcript::{BufMut, TranscriptWriter};
+use digest::Digest;
+
+/// Observes the hash of a signed message into a transcript, turning a proof of knowledge into a
+/// signature of knowledge.
+///
+/// The message is hashed with `H::LeafHash` (the Merkle scheme's leaf hash) and the resulting
+/// digest is observed into the transcript via the provided observing writer. Both the prover and
+/// the verifier must call this with the same message *before any other transcript interaction*.
+///
+/// The `writer` must be an *observing* writer (obtained from `transcript.observe()`), so the
+/// digest is mixed into the Fiat-Shamir state without being written to the proof tape.
+pub fn observe_message<H, B>(writer: &mut TranscriptWriter<B>, message: &[u8])
+where
+	H: HashSuite,
+	B: BufMut,
+{
+	let digest = <H::LeafHash as Digest>::digest(message);
+	writer.write_bytes(digest.as_ref());
+}

--- a/crates/verifier/src/zk_config.rs
+++ b/crates/verifier/src/zk_config.rs
@@ -196,6 +196,20 @@ where
 
 		Ok(())
 	}
+
+	/// Verifies a ZK signature of knowledge over `message`.
+	///
+	/// Binds `message` into the transcript before any other data, then runs the ordinary
+	/// [`Self::verify`] checks. See [`crate::signature`] for details.
+	pub fn verify_sig<Challenger_: Challenger>(
+		&self,
+		public: &[Word],
+		message: &[u8],
+		transcript: &mut VerifierTranscript<Challenger_>,
+	) -> Result<(), Error> {
+		crate::signature::observe_message::<H, _>(&mut transcript.observe(), message);
+		self.verify(public, transcript)
+	}
 }
 
 /// Error type for ZK verification.


### PR DESCRIPTION
## Summary
- Turn the ZK proof of knowledge into a signature of knowledge by observing the hash of a message into the Fiat-Shamir transcript before any other data, so a proof only verifies against the message it was signed under.
- Hash the message with the Merkle scheme's leaf hash (`HashSuite::LeafHash`) for fixed-size absorption; the hash is observed, not written to the proof tape, so the verifier must supply the message out of band.
- Expose signing only on the ZK prover/verifier (`ZKProver::prove_sig` / `ZKVerifier::verify_sig`), since a SoK must not reveal its witness.
- Add a `--sign-message` CLI flag (requires `--zk`) to the examples framework. Security analysis lives in `crates/verifier/src/signature.rs`.

Closes BINIUS-53.

## Test plan
- `cargo test -p binius-prover --test prove_verify` — covers signing then verifying with matching, mismatched, and absent messages.
- `cargo clippy --all --all-features --tests --benches --examples -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
