### PR TITLE
[fri] Rebuild query phase on ProxTestOracle and batch oracles

### DIFF
--- a/crates/iop-prover/src/basefold.rs
+++ b/crates/iop-prover/src/basefold.rs
@@ -77,7 +77,7 @@ where
 		fri_folder: FRIFoldProver<'a, F, P, NTT, MerkleProver>,
 	) -> Self {
 		assert_eq!(multilinear.log_len(), transparent_multilinear.log_len());
-		assert_eq!(multilinear.log_len(), fri_folder.n_rounds() - fri_folder.curr_round());
+		assert_eq!(multilinear.log_len(), fri_folder.n_rounds_remaining());
 
 		let sumcheck_prover =
 			BivariateProductSumcheckProver::new([multilinear, transparent_multilinear], claim)
@@ -105,7 +105,7 @@ where
 			.execute()?
 			.try_into()
 			.expect("sumcheck_prover proves only one multivariate");
-		let commitment = self.fri_folder.execute_fold_round()?;
+		let commitment = self.fri_folder.execute_fold_round();
 		Ok((round_coeffs, commitment))
 	}
 
@@ -155,7 +155,7 @@ where
 	/// ## Arguments
 	/// * `prover_challenger` - the prover's mutable transcript
 	fn finish<T: Challenger>(mut self, transcript: &mut ProverTranscript<T>) -> Result<(), Error> {
-		let commitment = self.fri_folder.execute_fold_round()?;
+		let commitment = self.fri_folder.execute_fold_round();
 		if let FoldRoundOutput::Commitment(commitment) = commitment {
 			transcript.message().write(&commitment);
 		}

--- a/crates/iop-prover/src/fri/fold.rs
+++ b/crates/iop-prover/src/fri/fold.rs
@@ -69,7 +69,7 @@ where
 	MerkleScheme: MerkleTreeScheme<F, Digest: SerializeBytes>,
 	MerkleProver: MerkleTreeProver<F, Scheme = MerkleScheme>,
 {
-	/// Constructs a new folder.
+	/// Constructs a new folder for a single committed input oracle.
 	pub fn new(
 		params: &'a FRIParams<F>,
 		ntt: &'a NTT,
@@ -77,20 +77,60 @@ where
 		committed_codeword: FieldBuffer<P>,
 		committed: &'a MerkleProver::Committed,
 	) -> Result<Self, Error> {
-		if committed_codeword.len() < 1 << params.log_len() {
-			return Err(Error::InvalidArgs(
-				"Reed-Solomon code length must match interleaved codeword length".to_string(),
-			));
+		Self::new_batch(params, ntt, merkle_prover, vec![(committed_codeword, committed)])
+	}
+
+	/// Constructs a new folder for a batch of committed input oracles.
+	///
+	/// The input oracles share the Reed-Solomon code but may have differing batch sizes; they are
+	/// folded and combined into a single first-round codeword. The codewords must be supplied in
+	/// the same order as [`FRIParams::input_oracles`], and each must match its oracle's batch
+	/// size.
+	pub fn new_batch(
+		params: &'a FRIParams<F>,
+		ntt: &'a NTT,
+		merkle_prover: &'a MerkleProver,
+		committed_codewords: Vec<(FieldBuffer<P>, &'a MerkleProver::Committed)>,
+	) -> Result<Self, Error> {
+		let input_oracles = params.input_oracles();
+		if committed_codewords.len() != input_oracles.len() {
+			return Err(Error::InvalidArgs(format!(
+				"got {} committed codewords, expected {}",
+				committed_codewords.len(),
+				input_oracles.len(),
+			)));
 		}
 
-		let codeword_folder = ProxTestFolder {
-			log_batch_size: params.log_batch_size(),
-			codeword: committed_codeword,
-			merkle_committed: committed,
-		};
-		// The first fold currently batches a single committed codeword; in the future it will batch
-		// several distinct oracles here.
-		let batch_folder = BatchBrakedownFolder::new(vec![codeword_folder]);
+		// Temporary restriction: lifted FRI is not yet implemented, so every input oracle must
+		// reduce to exactly the first-round Reed-Solomon code. FRIParams only guarantees the
+		// inequality `log_msg_len - log_batch_size <= rs_code.log_dim()`.
+		let log_dim = params.rs_code().log_dim();
+		for spec in input_oracles {
+			assert_eq!(
+				spec.log_msg_len - spec.log_batch_size,
+				log_dim,
+				"lifted FRI is unsupported: input oracle dimension must equal rs_code.log_dim()"
+			);
+		}
+
+		let folders = iter::zip(committed_codewords, input_oracles)
+			.map(|((codeword, committed), spec)| {
+				let expected_log_len = params.rs_code().log_len() + spec.log_batch_size;
+				if codeword.log_len() != expected_log_len {
+					return Err(Error::InvalidArgs(
+						"interleaved codeword length must match the Reed-Solomon code length plus the \
+						 oracle's batch size"
+							.to_string(),
+					));
+				}
+				Ok(ProxTestFolder {
+					log_batch_size: spec.log_batch_size,
+					codeword,
+					merkle_committed: committed,
+				})
+			})
+			.collect::<Result<Vec<_>, Error>>()?;
+		let batch_folder = BatchBrakedownFolder::new(folders);
 
 		let next_commit_round = Some(params.log_batch_size());
 		Ok(Self {
@@ -485,7 +525,8 @@ where
 		let outer_tensor = eq_ind_partial_eval::<F>(outer_challenges);
 		let mut combined_codeword = FieldBuffer::zeros(self.log_code_len);
 		let mut oracles = Vec::with_capacity(n_folders);
-		// TODO: Special cases when outer_challenges.len() = 0 or 1 for computational efficiency (to reduce # of scaling muls)
+		// TODO: Special cases when outer_challenges.len() = 0 or 1 for computational efficiency (to
+		// reduce # of scaling muls)
 		for ((folded_codeword, oracle), &scalar) in iter::zip(folds, outer_tensor.as_ref()) {
 			assert_eq!(folded_codeword.log_len(), combined_codeword.log_len()); // precondition
 			for (acc, &val) in iter::zip(combined_codeword.as_mut(), folded_codeword.as_ref()) {

--- a/crates/iop-prover/src/fri/fold.rs
+++ b/crates/iop-prover/src/fri/fold.rs
@@ -226,19 +226,20 @@ where
 		Challenger_: Challenger,
 	{
 		let (terminate_codeword, query_prover) = self.finalize()?;
-		let mut advice = transcript.decommitment();
-		advice.write_scalar_slice(terminate_codeword.as_ref());
 
-		let layers = query_prover.vcs_optimal_layers()?;
-		for layer in layers {
-			advice.write_slice(&layer);
-		}
-
+		// Sample all query indices before writing the (per-oracle batched) query openings. The
+		// decommitment advice is not absorbed by the challenger, so this matches the verifier
+		// sampling all indices up front.
 		let params = query_prover.params;
-		for _ in 0..params.n_test_queries() {
-			let index = transcript.sample_bits(params.index_bits()) as usize;
-			query_prover.prove_query(index, &mut transcript.decommitment())?;
-		}
+		let indices = (0..params.n_test_queries())
+			.map(|_| transcript.sample_bits(params.index_bits()) as usize)
+			.collect::<Vec<_>>();
+
+		// Write the per-oracle batched query openings, then the terminal codeword in full.
+		query_prover.prove_queries(&indices, &mut transcript.decommitment())?;
+		transcript
+			.decommitment()
+			.write_scalar_slice(terminate_codeword.as_ref());
 
 		Ok(())
 	}

--- a/crates/iop-prover/src/fri/fold.rs
+++ b/crates/iop-prover/src/fri/fold.rs
@@ -208,13 +208,13 @@ where
 			..
 		} = self;
 
-		let query_prover = FRIQueryProver {
+		let query_prover = FRIQueryProver::new(
 			params,
 			codeword,
 			codeword_committed,
 			round_committed,
 			merkle_prover,
-		};
+		);
 		Ok((terminate_codeword, query_prover))
 	}
 
@@ -225,14 +225,15 @@ where
 	where
 		Challenger_: Challenger,
 	{
+		let n_test_queries = self.params.n_test_queries();
+		let index_bits = self.params.index_bits();
 		let (terminate_codeword, query_prover) = self.finalize()?;
 
 		// Sample all query indices before writing the (per-oracle batched) query openings. The
 		// decommitment advice is not absorbed by the challenger, so this matches the verifier
 		// sampling all indices up front.
-		let params = query_prover.params;
-		let indices = (0..params.n_test_queries())
-			.map(|_| transcript.sample_bits(params.index_bits()) as usize)
+		let indices = (0..n_test_queries)
+			.map(|_| transcript.sample_bits(index_bits) as usize)
 			.collect::<Vec<_>>();
 
 		// Write the per-oracle batched query openings, then the terminal codeword in full.

--- a/crates/iop-prover/src/fri/fold.rs
+++ b/crates/iop-prover/src/fri/fold.rs
@@ -1,5 +1,7 @@
 // Copyright 2024-2025 Irreducible Inc.
 
+use std::{iter, mem};
+
 use binius_field::{BinaryField, Field, PackedField};
 use binius_iop::{
 	fri::{FRIParams, fold::fold_chunk},
@@ -13,11 +15,14 @@ use binius_transcript::{
 	ProverTranscript,
 	fiat_shamir::{CanSampleBits, Challenger},
 };
-use binius_utils::{SerializeBytes, checked_arithmetics::log2_strict_usize, rayon::prelude::*};
+use binius_utils::{SerializeBytes, checked_arithmetics::log2_ceil_usize, rayon::prelude::*};
 use tracing::instrument;
 
 use super::{error::Error, query::FRIQueryProver};
-use crate::merkle_tree::MerkleTreeProver;
+use crate::{
+	fri::{BatchBrakedownOracleProver, BrakedownOracleProver, FRIOracleProver},
+	merkle_tree::MerkleTreeProver,
+};
 
 /// The type of the termination round codeword in the FRI protocol.
 pub type TerminateCodeword<F> = FieldBuffer<F>;
@@ -27,6 +32,19 @@ pub enum FoldRoundOutput<VCSCommitment> {
 	Commitment(VCSCommitment),
 }
 
+enum FRIFolderState<'a, P, MTProver>
+where
+	P: PackedField,
+	MTProver: MerkleTreeProver<P::Scalar>,
+{
+	FirstFold(BatchBrakedownFolder<'a, P, MTProver>),
+	LaterFolds {
+		first_oracle: BatchBrakedownOracleProver<'a, P, MTProver>,
+		last_codeword: FieldBuffer<P::Scalar>,
+		last_committed: MTProver::Committed,
+		round_oracles: Vec<FRIOracleProver<'a, P::Scalar, MTProver>>,
+	},
+}
 /// A stateful prover for the FRI fold phase.
 pub struct FRIFoldProver<'a, F, P, NTT, MerkleProver>
 where
@@ -37,9 +55,7 @@ where
 	params: &'a FRIParams<F>,
 	ntt: &'a NTT,
 	merkle_prover: &'a MerkleProver,
-	codeword: FieldBuffer<P>,
-	codeword_committed: &'a MerkleProver::Committed,
-	round_committed: Vec<(FieldBuffer<F>, MerkleProver::Committed)>,
+	state: Option<FRIFolderState<'a, P, MerkleProver>>,
 	curr_round: usize,
 	next_commit_round: Option<usize>,
 	unprocessed_challenges: Vec<F>,
@@ -67,14 +83,21 @@ where
 			));
 		}
 
+		let codeword_folder = ProxTestFolder {
+			log_batch_size: params.log_batch_size(),
+			codeword: committed_codeword,
+			merkle_committed: committed,
+		};
+		// The first fold currently batches a single committed codeword; in the future it will batch
+		// several distinct oracles here.
+		let batch_folder = BatchBrakedownFolder::new(vec![codeword_folder]);
+
 		let next_commit_round = Some(params.log_batch_size());
 		Ok(Self {
 			params,
 			ntt,
 			merkle_prover,
-			codeword: committed_codeword,
-			codeword_committed: committed,
-			round_committed: Vec::with_capacity(params.n_oracles()),
+			state: Some(FRIFolderState::FirstFold(batch_folder)),
 			curr_round: 0,
 			next_commit_round,
 			unprocessed_challenges: Vec::with_capacity(params.rs_code().log_dim()),
@@ -87,16 +110,8 @@ where
 	}
 
 	/// Number of times `execute_fold_round` has been called.
-	pub const fn curr_round(&self) -> usize {
-		self.curr_round
-	}
-
-	/// The length of the current codeword.
-	pub fn current_codeword_len(&self) -> usize {
-		match self.round_committed.last() {
-			Some((codeword, _)) => codeword.len(),
-			None => self.codeword.len(),
-		}
+	pub fn n_rounds_remaining(&self) -> usize {
+		self.n_rounds() - self.curr_round
 	}
 
 	fn is_commitment_round(&self) -> bool {
@@ -114,61 +129,113 @@ where
 	/// As a memory efficient optimization, this method may not actually do the folding, but instead
 	/// accumulate the folding challenge for processing at a later time. This saves us from storing
 	/// intermediate folded codewords.
-	pub fn execute_fold_round(&mut self) -> Result<FoldRoundOutput<MerkleScheme::Digest>, Error> {
+	pub fn execute_fold_round(&mut self) -> FoldRoundOutput<MerkleScheme::Digest> {
 		if !self.is_commitment_round() {
-			return Ok(FoldRoundOutput::NoCommitment);
+			return FoldRoundOutput::NoCommitment;
 		}
 
-		let _fri_round_scope = tracing::debug_span!(
-			"FRI Round",
-			log_len = log2_strict_usize(self.current_codeword_len()),
-			arity = self.unprocessed_challenges.len()
-		)
-		.entered();
+		let state = self
+			.state
+			.take()
+			.expect("state is always Some by struct invariant");
 
-		// Fold the last codeword with the accumulated folding challenges.
-		let fri_fold_span = tracing::debug_span!("FRI Fold").entered();
-		let folded_codeword = match self.round_committed.last() {
-			Some((prev_codeword, _)) => {
+		let (root, new_state) = match state {
+			FRIFolderState::FirstFold(folder) => {
+				let _scope = tracing::debug_span!(
+					"FRI Initial Fold",
+					log_len = folder.log_len(),
+					arity = self.unprocessed_challenges.len()
+				)
+				.entered();
+
+				// Fold the batch of interleaved codewords that were originally committed into a
+				// single codeword with the same block length, and turn them into a batched
+				// Brakedown query oracle.
+				let challenges = mem::take(&mut self.unprocessed_challenges);
+				let (folded_codeword, first_oracle) = folder.fold(self.merkle_prover, &challenges);
+
+				let next_arity = self.params.fold_arities().first().copied();
+				let (root, last_committed) = self.commit_round(&folded_codeword, next_arity);
+
+				let new_state = FRIFolderState::LaterFolds {
+					first_oracle,
+					last_codeword: folded_codeword,
+					last_committed,
+					round_oracles: Vec::with_capacity(self.params.fold_arities().len()),
+				};
+				(root, new_state)
+			}
+			FRIFolderState::LaterFolds {
+				first_oracle,
+				last_codeword,
+				last_committed,
+				mut round_oracles,
+			} => {
+				let _fri_round_scope = tracing::debug_span!(
+					"FRI Round Fold",
+					log_len = last_codeword.log_len(),
+					arity = self.unprocessed_challenges.len()
+				)
+				.entered();
+
 				// Fold a full codeword committed in the previous FRI round into a codeword with
 				// reduced dimension and rate.
-				fold_codeword(self.ntt, prev_codeword.to_ref(), &self.unprocessed_challenges)
-			}
-			None => {
-				// Fold the interleaved codeword that was originally committed into a single
-				// codeword with the same block length.
-				fold_interleaved(
-					self.codeword.to_ref(),
-					&self.unprocessed_challenges,
-					self.params.rs_code().log_len(),
-					self.params.log_batch_size(),
-				)
+				let challenges = mem::take(&mut self.unprocessed_challenges);
+				let fri_fold_span = tracing::debug_span!("FRI Fold").entered();
+				let folded_codeword = fold_codeword(self.ntt, last_codeword.to_ref(), &challenges);
+				drop(fri_fold_span);
+				let oracle = FRIOracleProver::new(
+					last_codeword,
+					last_committed,
+					self.merkle_prover,
+					challenges.len(),
+				);
+
+				let next_arity = self
+					.params
+					.fold_arities()
+					.get(round_oracles.len() + 1)
+					.copied();
+				let (root, last_committed) = self.commit_round(&folded_codeword, next_arity);
+
+				round_oracles.push(oracle);
+				let new_state = FRIFolderState::LaterFolds {
+					first_oracle,
+					last_codeword: folded_codeword,
+					last_committed,
+					round_oracles,
+				};
+				(root, new_state)
 			}
 		};
-		drop(fri_fold_span);
-		self.unprocessed_challenges.clear();
 
-		// take the first arity as coset_log_len, or use inv_rate if arities are empty
-		let next_arity = self
-			.params
-			.fold_arities()
-			.get(self.round_committed.len())
-			.copied();
+		self.state = Some(new_state);
+		FoldRoundOutput::Commitment(root)
+	}
+
+	/// Commits to a folded codeword, advancing `next_commit_round` for the next fold.
+	///
+	/// The coset size is determined by the arity of the *next* fold round, or by the number of
+	/// final challenges once there are no more committed rounds (the terminal codeword).
+	fn commit_round(
+		&mut self,
+		folded_codeword: &FieldBuffer<F>,
+		next_arity: Option<usize>,
+	) -> (MerkleScheme::Digest, MerkleProver::Committed) {
 		let log_coset_size = next_arity.unwrap_or_else(|| self.params.n_final_challenges());
 		let coset_size = 1 << log_coset_size;
-		let merkle_tree_span = tracing::debug_span!("Merkle Tree").entered();
+
+		let _merkle_tree_span = tracing::debug_span!("Merkle Tree").entered();
 		let (commitment, committed) = self
 			.merkle_prover
-			.commit(folded_codeword.as_ref(), coset_size)?;
-		drop(merkle_tree_span);
+			.commit(folded_codeword.as_ref(), coset_size)
+			.expect("merkle commitment cannot fail for a valid codeword");
 
-		self.next_commit_round = self.next_commit_round.take().and_then(|next_commit_round| {
-			let arity = next_arity?;
-			Some(next_commit_round + arity)
-		});
+		// The next commitment lands `next_arity` rounds after the current one. Once there is no
+		// next arity, this is the terminal codeword and no further commitments are made.
+		self.next_commit_round = next_arity.map(|arity| self.curr_round + arity);
 
-		self.round_committed.push((folded_codeword, committed));
-		Ok(FoldRoundOutput::Commitment(commitment.root))
+		(commitment.root, committed)
 	}
 
 	/// Finalizes the FRI folding process.
@@ -188,34 +255,31 @@ where
 			return Err(Error::EarlyProverFinish);
 		}
 
-		let terminate_codeword = self
-			.round_committed
-			.last()
-			.map(|(codeword, _)| codeword.clone())
-			.unwrap_or_else(|| {
-				let scalars: Vec<F> = self.codeword.iter_scalars().collect();
-				FieldBuffer::from_values(&scalars)
-			});
-
 		self.unprocessed_challenges.clear();
 
-		let Self {
-			params,
-			codeword,
-			codeword_committed,
-			round_committed,
-			merkle_prover,
-			..
-		} = self;
-
-		let query_prover = FRIQueryProver::new(
-			params,
-			codeword,
-			codeword_committed,
-			round_committed,
-			merkle_prover,
-		);
-		Ok((terminate_codeword, query_prover))
+		match self
+			.state
+			.take()
+			.expect("state is always Some by struct invariant")
+		{
+			// The final fold round produced the terminal codeword and committed the prior one, so
+			// the state is always `LaterFolds` once `curr_round` reaches `n_rounds`. The
+			// terminal codeword is sent in full and therefore is not wrapped in a query oracle.
+			FRIFolderState::LaterFolds {
+				first_oracle,
+				last_codeword,
+				round_oracles,
+				..
+			} => {
+				let query_prover = FRIQueryProver::new(first_oracle, round_oracles);
+				Ok((last_codeword, query_prover))
+			}
+			// The first fold fires at `curr_round == log_batch_size <= n_rounds` and
+			// `execute_fold_round` runs every round, so the first fold always precedes `finalize`.
+			FRIFolderState::FirstFold(_) => {
+				unreachable!("the first fold always runs before curr_round reaches n_rounds")
+			}
+		}
 	}
 
 	pub fn finish_proof<Challenger_>(
@@ -320,6 +384,118 @@ where
 		)
 		.collect();
 	FieldBuffer::new(folded_log_len, values.into_boxed_slice())
+}
+
+pub struct ProxTestFolder<'a, P: PackedField, MTProver: MerkleTreeProver<P::Scalar>> {
+	log_batch_size: usize,
+	codeword: FieldBuffer<P>,
+	merkle_committed: &'a MTProver::Committed,
+}
+
+impl<'a, F: Field, P: PackedField<Scalar = F>, MTProver> ProxTestFolder<'a, P, MTProver>
+where
+	MTProver: MerkleTreeProver<F>,
+{
+	pub fn log_folded_len(&self) -> usize {
+		self.codeword.log_len() - self.log_batch_size
+	}
+
+	pub fn fold(
+		self,
+		merkle_prover: &'a MTProver,
+		challenges: &[F],
+	) -> (FieldBuffer<F>, BrakedownOracleProver<'a, P, MTProver>) {
+		assert_eq!(challenges.len(), self.log_batch_size); // precondition
+
+		let ProxTestFolder {
+			log_batch_size,
+			codeword,
+			merkle_committed,
+		} = self;
+
+		let log_len = codeword.log_len() - log_batch_size;
+		let folded_codeword =
+			fold_interleaved(codeword.to_ref(), challenges, log_len, log_batch_size);
+		let oracle =
+			BrakedownOracleProver::new(codeword, merkle_committed, merkle_prover, log_batch_size);
+		(folded_codeword, oracle)
+	}
+}
+
+/// Folds and commits a batch of interleaved codewords that share a folded length.
+///
+/// Each [`ProxTestFolder`] is committed separately and folds (by the same challenges) to a codeword
+/// of the common length `codeword.log_len() - log_batch_size`. The folded codewords are summed into
+/// a single codeword that continues through the FRI rounds, and the per-commitment
+/// [`BrakedownOracleProver`]s are bundled into a [`BatchBrakedownOracleProver`].
+pub struct BatchBrakedownFolder<'a, P: PackedField, MTProver: MerkleTreeProver<P::Scalar>> {
+	log_code_len: usize,
+	folders: Vec<ProxTestFolder<'a, P, MTProver>>,
+}
+
+impl<'a, F: Field, P: PackedField<Scalar = F>, MTProver> BatchBrakedownFolder<'a, P, MTProver>
+where
+	MTProver: MerkleTreeProver<F>,
+{
+	/// Constructs a batch folder from one or more interleaved-codeword folders.
+	pub fn new(folders: Vec<ProxTestFolder<'a, P, MTProver>>) -> Self {
+		assert!(!folders.is_empty()); // precondition
+		let log_code_len = folders[0].log_folded_len();
+		for folder in &folders[1..] {
+			assert_eq!(folder.log_folded_len(), log_code_len);
+		}
+		Self {
+			log_code_len,
+			folders,
+		}
+	}
+
+	/// Log2 length of the (interleaved) codewords being folded.
+	fn log_len(&self) -> usize {
+		let max_folder_log_len = self
+			.folders
+			.iter()
+			.map(|folder| folder.codeword.log_len())
+			.max()
+			.expect("folders is not empty by struct invariant");
+		let log_folders = log2_ceil_usize(self.folders.len());
+		max_folder_log_len + log_folders
+	}
+
+	pub fn fold(
+		self,
+		merkle_prover: &'a MTProver,
+		challenges: &[F],
+	) -> (FieldBuffer<F>, BatchBrakedownOracleProver<'a, P, MTProver>) {
+		let max_log_batch_size = self
+			.folders
+			.iter()
+			.map(|folder| folder.log_batch_size)
+			.max()
+			.expect("folders is not empty by struct invariant");
+
+		let (inner_challenges, outer_challenges) = challenges.split_at(max_log_batch_size);
+
+		let n_folders = self.folders.len();
+		let folds = self.folders.into_iter().map(|folder| {
+			let start_idx = max_log_batch_size - folder.log_batch_size;
+			folder.fold(merkle_prover, &inner_challenges[start_idx..])
+		});
+
+		let outer_tensor = eq_ind_partial_eval::<F>(outer_challenges);
+		let mut combined_codeword = FieldBuffer::zeros(self.log_code_len);
+		let mut oracles = Vec::with_capacity(n_folders);
+		// TODO: Special cases when outer_challenges.len() = 0 or 1 for computational efficiency (to reduce # of scaling muls)
+		for ((folded_codeword, oracle), &scalar) in iter::zip(folds, outer_tensor.as_ref()) {
+			assert_eq!(folded_codeword.log_len(), combined_codeword.log_len()); // precondition
+			for (acc, &val) in iter::zip(combined_codeword.as_mut(), folded_codeword.as_ref()) {
+				*acc += val * scalar;
+			}
+			oracles.push(oracle);
+		}
+
+		(combined_codeword, BatchBrakedownOracleProver::new(oracles))
+	}
 }
 
 #[cfg(test)]

--- a/crates/iop-prover/src/fri/query.rs
+++ b/crates/iop-prover/src/fri/query.rs
@@ -10,8 +10,175 @@ use tracing::instrument;
 
 use crate::{fri::Error, merkle_tree::MerkleTreeProver};
 
+/// The prover counterpart of a [`ProxTestOracle`], producing the per-oracle query openings.
+///
+/// [`ProxTestOracle`]: binius_iop::fri::ProxTestOracle
+pub trait ProxTestOracleProver<F> {
+	/// Writes the per-oracle batched query openings: the oracle's optimal Merkle layer once,
+	/// followed by each queried coset's values and Merkle opening proof.
+	fn open_queries<B: BufMut>(
+		&self,
+		indices: &[usize],
+		advice: &mut TranscriptWriter<B>,
+	) -> Result<(), Error>;
+}
+
+/// The [`ProxTestOracleProver`] for a [Brakedown]-style interleaved code proximity check.
+///
+/// [Brakedown]: <https://dl.acm.org/doi/10.1007/978-3-031-38545-2_7>
+pub struct BrakedownOracleProver<'a, P, MerkleProver>
+where
+	P: PackedField,
+	MerkleProver: MerkleTreeProver<P::Scalar>,
+{
+	codeword: FieldBuffer<P>,
+	committed: &'a MerkleProver::Committed,
+	merkle_prover: &'a MerkleProver,
+	coset_log_size: usize,
+}
+
+impl<'a, P, MerkleProver> BrakedownOracleProver<'a, P, MerkleProver>
+where
+	P: PackedField,
+	MerkleProver: MerkleTreeProver<P::Scalar>,
+{
+	/// Constructs a new oracle prover wrapping a committed interleaved codeword.
+	pub fn new(
+		codeword: FieldBuffer<P>,
+		committed: &'a MerkleProver::Committed,
+		merkle_prover: &'a MerkleProver,
+		coset_log_size: usize,
+	) -> Self {
+		Self {
+			codeword,
+			committed,
+			merkle_prover,
+			coset_log_size,
+		}
+	}
+}
+
+impl<F, P, MerkleProver, VCS> ProxTestOracleProver<F> for BrakedownOracleProver<'_, P, MerkleProver>
+where
+	F: BinaryField,
+	P: PackedField<Scalar = F>,
+	MerkleProver: MerkleTreeProver<F, Scheme = VCS>,
+	VCS: MerkleTreeScheme<F, Digest: SerializeBytes>,
+{
+	fn open_queries<B: BufMut>(
+		&self,
+		indices: &[usize],
+		advice: &mut TranscriptWriter<B>,
+	) -> Result<(), Error> {
+		open_oracle_queries(
+			self.merkle_prover,
+			&self.codeword,
+			self.committed,
+			self.coset_log_size,
+			indices,
+			advice,
+		)
+	}
+}
+
+/// The [`ProxTestOracleProver`] for a FRI-style code proximity check.
+pub struct FRIOracleProver<'a, F, MerkleProver>
+where
+	F: BinaryField,
+	MerkleProver: MerkleTreeProver<F>,
+{
+	codeword: FieldBuffer<F>,
+	committed: MerkleProver::Committed,
+	merkle_prover: &'a MerkleProver,
+	coset_log_size: usize,
+}
+
+impl<'a, F, MerkleProver> FRIOracleProver<'a, F, MerkleProver>
+where
+	F: BinaryField,
+	MerkleProver: MerkleTreeProver<F>,
+{
+	/// Constructs a new oracle prover wrapping a committed fold-round codeword.
+	pub fn new(
+		codeword: FieldBuffer<F>,
+		committed: MerkleProver::Committed,
+		merkle_prover: &'a MerkleProver,
+		coset_log_size: usize,
+	) -> Self {
+		Self {
+			codeword,
+			committed,
+			merkle_prover,
+			coset_log_size,
+		}
+	}
+}
+
+impl<F, MerkleProver, VCS> ProxTestOracleProver<F> for FRIOracleProver<'_, F, MerkleProver>
+where
+	F: BinaryField,
+	MerkleProver: MerkleTreeProver<F, Scheme = VCS>,
+	VCS: MerkleTreeScheme<F, Digest: SerializeBytes>,
+{
+	fn open_queries<B: BufMut>(
+		&self,
+		indices: &[usize],
+		advice: &mut TranscriptWriter<B>,
+	) -> Result<(), Error> {
+		open_oracle_queries(
+			self.merkle_prover,
+			&self.codeword,
+			&self.committed,
+			self.coset_log_size,
+			indices,
+			advice,
+		)
+	}
+}
+
+/// Writes the optimal Merkle layer once, then a coset opening for each queried index.
+///
+/// The coset is opened at the index directly, mirroring the verifier's `open_queries`.
+fn open_oracle_queries<F, P, MerkleProver, B>(
+	merkle_prover: &MerkleProver,
+	codeword: &FieldBuffer<P>,
+	committed: &MerkleProver::Committed,
+	coset_log_size: usize,
+	indices: &[usize],
+	advice: &mut TranscriptWriter<B>,
+) -> Result<(), Error>
+where
+	F: BinaryField,
+	P: PackedField<Scalar = F>,
+	MerkleProver: MerkleTreeProver<F>,
+	<MerkleProver::Scheme as MerkleTreeScheme<F>>::Digest: SerializeBytes,
+	B: BufMut,
+{
+	let scheme = merkle_prover.scheme();
+	// The Merkle tree has one coset per leaf, so its depth is the codeword length minus the coset.
+	let tree_depth = codeword.log_len() - coset_log_size;
+	let layer_depth = scheme.optimal_verify_layer(indices.len(), tree_depth);
+	advice.write_slice(merkle_prover.layer(committed, layer_depth)?);
+	for &index in indices {
+		prove_coset_opening(
+			merkle_prover,
+			codeword.to_ref(),
+			committed,
+			index,
+			coset_log_size,
+			layer_depth,
+			advice,
+		)?;
+	}
+
+	Ok(())
+}
+
 /// A prover for the FRI query phase.
-#[derive(Debug)]
+///
+/// This is a composition of [`ProxTestOracleProver`]s mirroring the verifier's `FRIQueryVerifier`:
+/// a [`BrakedownOracleProver`] for the codeword's interleaved reduction, then one
+/// [`FRIOracleProver`] per fold arity for the subsequent reductions.
 pub struct FRIQueryProver<'a, F, P, MerkleProver, VCS>
 where
 	F: BinaryField,
@@ -19,23 +186,53 @@ where
 	MerkleProver: MerkleTreeProver<F, Scheme = VCS>,
 	VCS: MerkleTreeScheme<F>,
 {
-	pub(super) params: &'a FRIParams<F>,
-	pub(super) codeword: FieldBuffer<P>,
-	pub(super) codeword_committed: &'a MerkleProver::Committed,
-	pub(super) round_committed: Vec<(FieldBuffer<F>, MerkleProver::Committed)>,
-	pub(super) merkle_prover: &'a MerkleProver,
+	codeword_oracle: BrakedownOracleProver<'a, P, MerkleProver>,
+	fri_oracles: Vec<FRIOracleProver<'a, F, MerkleProver>>,
 }
 
-impl<F, P, MerkleProver, VCS> FRIQueryProver<'_, F, P, MerkleProver, VCS>
+impl<'a, F, P, MerkleProver, VCS> FRIQueryProver<'a, F, P, MerkleProver, VCS>
 where
 	F: BinaryField,
 	P: PackedField<Scalar = F>,
 	MerkleProver: MerkleTreeProver<F, Scheme = VCS>,
 	VCS: MerkleTreeScheme<F>,
 {
+	/// Constructs a query prover from the committed codeword and fold-round codewords.
+	///
+	/// `round_committed` holds one entry per fold arity followed by the terminal codeword, which is
+	/// sent in full and therefore excluded here.
+	pub fn new(
+		params: &FRIParams<F>,
+		codeword: FieldBuffer<P>,
+		codeword_committed: &'a MerkleProver::Committed,
+		round_committed: Vec<(FieldBuffer<F>, MerkleProver::Committed)>,
+		merkle_prover: &'a MerkleProver,
+	) -> Self {
+		let codeword_oracle = BrakedownOracleProver::new(
+			codeword,
+			codeword_committed,
+			merkle_prover,
+			params.log_batch_size(),
+		);
+
+		let fri_oracles = round_committed
+			.into_iter()
+			.take(params.fold_arities().len())
+			.zip(params.fold_arities().iter().copied())
+			.map(|((codeword, committed), arity)| {
+				FRIOracleProver::new(codeword, committed, merkle_prover, arity)
+			})
+			.collect();
+
+		Self {
+			codeword_oracle,
+			fri_oracles,
+		}
+	}
+
 	/// Number of oracles sent during the fold rounds.
 	pub fn n_oracles(&self) -> usize {
-		self.params.n_oracles()
+		1 + self.fri_oracles.len()
 	}
 
 	/// Proves the FRI challenge queries, batched per oracle.
@@ -58,53 +255,16 @@ where
 		B: BufMut,
 		VCS::Digest: SerializeBytes,
 	{
-		let scheme = self.merkle_prover.scheme();
-		let n_queries = indices.len();
+		self.codeword_oracle.open_queries(indices, advice)?;
 
-		// The codeword oracle, opened as interleaved cosets. Its Merkle tree has one coset per
-		// leaf, so its depth is the number of index bits.
-		let mut tree_depth = self.params.index_bits();
-		let layer_depth = scheme.optimal_verify_layer(n_queries, tree_depth);
-		let layer = self
-			.merkle_prover
-			.layer(self.codeword_committed, layer_depth)?;
-		advice.write_slice(layer);
-		for &index in indices {
-			prove_coset_opening(
-				self.merkle_prover,
-				self.codeword.to_ref(),
-				self.codeword_committed,
-				index,
-				self.params.log_batch_size(),
-				layer_depth,
-				advice,
-			)?;
-		}
-
-		// The fold-round oracles, excluding the terminal codeword which is sent in full.
-		let round_committed_excluding_terminal =
-			&self.round_committed[..self.round_committed.len() - 1];
-		let mut shift = 0;
-		for ((codeword, committed), &arity) in round_committed_excluding_terminal
-			.iter()
-			.zip(self.params.fold_arities())
-		{
-			shift += arity;
-			tree_depth -= arity;
-			let layer_depth = scheme.optimal_verify_layer(n_queries, tree_depth);
-			let layer = self.merkle_prover.layer(committed, layer_depth)?;
-			advice.write_slice(layer);
-			for &index in indices {
-				prove_coset_opening(
-					self.merkle_prover,
-					codeword.to_ref(),
-					committed,
-					index >> shift,
-					arity,
-					layer_depth,
-					advice,
-				)?;
+		// Each subsequent oracle indexes the previous virtual oracle, so shift the query indices
+		// right by the round's arity before opening it.
+		let mut indices = indices.to_vec();
+		for fri_oracle in &self.fri_oracles {
+			for index in &mut indices {
+				*index >>= fri_oracle.coset_log_size;
 			}
+			fri_oracle.open_queries(&indices, advice)?;
 		}
 
 		Ok(())

--- a/crates/iop-prover/src/fri/query.rs
+++ b/crates/iop-prover/src/fri/query.rs
@@ -1,16 +1,11 @@
 // Copyright 2025 Irreducible Inc.
 
-use std::iter;
-
 use binius_field::{BinaryField, PackedField};
-use binius_iop::{
-	fri::{FRIParams, vcs_optimal_layers_depths_iter},
-	merkle_tree::MerkleTreeScheme,
-};
+use binius_iop::{fri::FRIParams, merkle_tree::MerkleTreeScheme};
 use binius_math::{FieldBuffer, FieldSlice};
 use binius_transcript::TranscriptWriter;
+use binius_utils::SerializeBytes;
 use bytes::BufMut;
-use itertools::izip;
 use tracing::instrument;
 
 use crate::{fri::Error, merkle_tree::MerkleTreeProver};
@@ -43,70 +38,76 @@ where
 		self.params.n_oracles()
 	}
 
-	/// Proves a FRI challenge query.
+	/// Proves the FRI challenge queries, batched per oracle.
+	///
+	/// For each committed oracle (the codeword first, then each fold-round oracle excluding the
+	/// terminal codeword) this writes the oracle's optimal Merkle layer once, followed by the coset
+	/// opening for each query index. This per-oracle batched layout matches the verifier, which
+	/// reads each oracle's layer and then all of its query openings together.
 	///
 	/// ## Arguments
 	///
-	/// * `index` - an index into the original codeword domain
-	#[instrument(skip_all, name = "fri::FRIQueryProver::prove_query", level = "debug")]
-	pub fn prove_query<B>(
+	/// * `indices` - the sampled query indices into the original codeword domain
+	#[instrument(skip_all, name = "fri::FRIQueryProver::prove_queries", level = "debug")]
+	pub fn prove_queries<B>(
 		&self,
-		mut index: usize,
+		indices: &[usize],
 		advice: &mut TranscriptWriter<B>,
 	) -> Result<(), Error>
 	where
 		B: BufMut,
+		VCS::Digest: SerializeBytes,
 	{
-		let mut layer_depths_iter =
-			vcs_optimal_layers_depths_iter(self.params, self.merkle_prover.scheme());
-		let first_layer_depth = layer_depths_iter
-			.next()
-			.expect("not empty by post-condition");
+		let scheme = self.merkle_prover.scheme();
+		let n_queries = indices.len();
 
-		prove_coset_opening(
-			self.merkle_prover,
-			self.codeword.to_ref(),
-			self.codeword_committed,
-			index,
-			self.params.log_batch_size(),
-			first_layer_depth,
-			advice,
-		)?;
-
-		for ((codeword, committed), &arity, optimal_layer_depth) in
-			izip!(&self.round_committed, self.params.fold_arities(), layer_depths_iter)
-		{
-			index >>= arity;
+		// The codeword oracle, opened as interleaved cosets. Its Merkle tree has one coset per
+		// leaf, so its depth is the number of index bits.
+		let mut tree_depth = self.params.index_bits();
+		let layer_depth = scheme.optimal_verify_layer(n_queries, tree_depth);
+		let layer = self
+			.merkle_prover
+			.layer(self.codeword_committed, layer_depth)?;
+		advice.write_slice(layer);
+		for &index in indices {
 			prove_coset_opening(
 				self.merkle_prover,
-				codeword.to_ref(),
-				committed,
+				self.codeword.to_ref(),
+				self.codeword_committed,
 				index,
-				arity,
-				optimal_layer_depth,
+				self.params.log_batch_size(),
+				layer_depth,
 				advice,
 			)?;
 		}
 
-		Ok(())
-	}
-
-	pub fn vcs_optimal_layers(&self) -> Result<Vec<Vec<VCS::Digest>>, Error> {
+		// The fold-round oracles, excluding the terminal codeword which is sent in full.
 		let round_committed_excluding_terminal =
 			&self.round_committed[..self.round_committed.len() - 1];
-		let committed_iter = iter::once(self.codeword_committed).chain(
-			round_committed_excluding_terminal
-				.iter()
-				.map(|(_, committed)| committed),
-		);
+		let mut shift = 0;
+		for ((codeword, committed), &arity) in round_committed_excluding_terminal
+			.iter()
+			.zip(self.params.fold_arities())
+		{
+			shift += arity;
+			tree_depth -= arity;
+			let layer_depth = scheme.optimal_verify_layer(n_queries, tree_depth);
+			let layer = self.merkle_prover.layer(committed, layer_depth)?;
+			advice.write_slice(layer);
+			for &index in indices {
+				prove_coset_opening(
+					self.merkle_prover,
+					codeword.to_ref(),
+					committed,
+					index >> shift,
+					arity,
+					layer_depth,
+					advice,
+				)?;
+			}
+		}
 
-		committed_iter
-			.zip(vcs_optimal_layers_depths_iter(self.params, self.merkle_prover.scheme()))
-			.map(|(committed, optimal_layer_depth)| {
-				let layer = self.merkle_prover.layer(committed, optimal_layer_depth)?;
-				Ok(layer.to_vec())
-			})
-			.collect::<Result<Vec<_>, _>>()
+		Ok(())
 	}
 }
 

--- a/crates/iop-prover/src/fri/query.rs
+++ b/crates/iop-prover/src/fri/query.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 Irreducible Inc.
 
-use binius_field::{BinaryField, PackedField};
-use binius_iop::{fri::FRIParams, merkle_tree::MerkleTreeScheme};
+use binius_field::{BinaryField, Field, PackedField};
+use binius_iop::merkle_tree::MerkleTreeScheme;
 use binius_math::{FieldBuffer, FieldSlice};
 use binius_transcript::TranscriptWriter;
 use binius_utils::SerializeBytes;
@@ -10,9 +10,8 @@ use tracing::instrument;
 
 use crate::{fri::Error, merkle_tree::MerkleTreeProver};
 
-/// The prover counterpart of a [`ProxTestOracle`], producing the per-oracle query openings.
-///
-/// [`ProxTestOracle`]: binius_iop::fri::ProxTestOracle
+/// The prover counterpart of a `ProxTestOracle` (verifier side), producing the per-oracle query
+/// openings.
 pub trait ProxTestOracleProver<F> {
 	/// Writes the per-oracle batched query openings: the oracle's optimal Merkle layer once,
 	/// followed by each queried coset's values and Merkle opening proof.
@@ -34,7 +33,7 @@ where
 	codeword: FieldBuffer<P>,
 	committed: &'a MerkleProver::Committed,
 	merkle_prover: &'a MerkleProver,
-	coset_log_size: usize,
+	log_batch_size: usize,
 }
 
 impl<'a, P, MerkleProver> BrakedownOracleProver<'a, P, MerkleProver>
@@ -47,13 +46,13 @@ where
 		codeword: FieldBuffer<P>,
 		committed: &'a MerkleProver::Committed,
 		merkle_prover: &'a MerkleProver,
-		coset_log_size: usize,
+		log_batch_size: usize,
 	) -> Self {
 		Self {
 			codeword,
 			committed,
 			merkle_prover,
-			coset_log_size,
+			log_batch_size,
 		}
 	}
 }
@@ -74,17 +73,62 @@ where
 			self.merkle_prover,
 			&self.codeword,
 			self.committed,
-			self.coset_log_size,
+			self.log_batch_size,
 			indices,
 			advice,
 		)
 	}
 }
 
+/// A [`ProxTestOracleProver`] bundling several separately committed [`BrakedownOracleProver`]s.
+///
+/// The bundled oracles all wrap interleaved codewords of the same length that are batched into a
+/// single folded codeword during the first FRI fold. Their query openings are written sequentially,
+/// one oracle's full decommitment after another, so the verifier reads each committed oracle's
+/// advice in turn.
+pub struct BatchBrakedownOracleProver<'a, P, MerkleProver>
+where
+	P: PackedField,
+	MerkleProver: MerkleTreeProver<P::Scalar>,
+{
+	oracles: Vec<BrakedownOracleProver<'a, P, MerkleProver>>,
+}
+
+impl<'a, P, MerkleProver> BatchBrakedownOracleProver<'a, P, MerkleProver>
+where
+	P: PackedField,
+	MerkleProver: MerkleTreeProver<P::Scalar>,
+{
+	/// Constructs a batch oracle prover from the per-commitment oracle provers.
+	pub fn new(oracles: Vec<BrakedownOracleProver<'a, P, MerkleProver>>) -> Self {
+		Self { oracles }
+	}
+}
+
+impl<F, P, MerkleProver, VCS> ProxTestOracleProver<F>
+	for BatchBrakedownOracleProver<'_, P, MerkleProver>
+where
+	F: BinaryField,
+	P: PackedField<Scalar = F>,
+	MerkleProver: MerkleTreeProver<F, Scheme = VCS>,
+	VCS: MerkleTreeScheme<F, Digest: SerializeBytes>,
+{
+	fn open_queries<B: BufMut>(
+		&self,
+		indices: &[usize],
+		advice: &mut TranscriptWriter<B>,
+	) -> Result<(), Error> {
+		for oracle in &self.oracles {
+			oracle.open_queries(indices, advice)?;
+		}
+		Ok(())
+	}
+}
+
 /// The [`ProxTestOracleProver`] for a FRI-style code proximity check.
 pub struct FRIOracleProver<'a, F, MerkleProver>
 where
-	F: BinaryField,
+	F: Field,
 	MerkleProver: MerkleTreeProver<F>,
 {
 	codeword: FieldBuffer<F>,
@@ -177,7 +221,7 @@ where
 /// A prover for the FRI query phase.
 ///
 /// This is a composition of [`ProxTestOracleProver`]s mirroring the verifier's `FRIQueryVerifier`:
-/// a [`BrakedownOracleProver`] for the codeword's interleaved reduction, then one
+/// a [`BatchBrakedownOracleProver`] for the codeword's interleaved reduction, then one
 /// [`FRIOracleProver`] per fold arity for the subsequent reductions.
 pub struct FRIQueryProver<'a, F, P, MerkleProver, VCS>
 where
@@ -186,7 +230,7 @@ where
 	MerkleProver: MerkleTreeProver<F, Scheme = VCS>,
 	VCS: MerkleTreeScheme<F>,
 {
-	codeword_oracle: BrakedownOracleProver<'a, P, MerkleProver>,
+	codeword_oracle: BatchBrakedownOracleProver<'a, P, MerkleProver>,
 	fri_oracles: Vec<FRIOracleProver<'a, F, MerkleProver>>,
 }
 
@@ -197,33 +241,15 @@ where
 	MerkleProver: MerkleTreeProver<F, Scheme = VCS>,
 	VCS: MerkleTreeScheme<F>,
 {
-	/// Constructs a query prover from the committed codeword and fold-round codewords.
+	/// Constructs a query prover from the per-oracle provers built during the fold phase.
 	///
-	/// `round_committed` holds one entry per fold arity followed by the terminal codeword, which is
-	/// sent in full and therefore excluded here.
+	/// `codeword_oracle` is the [`BatchBrakedownOracleProver`] for the originally committed
+	/// interleaved codeword(s), and `fri_oracles` holds one [`FRIOracleProver`] per fold arity. The
+	/// terminal codeword is sent in full and therefore is not represented here.
 	pub fn new(
-		params: &FRIParams<F>,
-		codeword: FieldBuffer<P>,
-		codeword_committed: &'a MerkleProver::Committed,
-		round_committed: Vec<(FieldBuffer<F>, MerkleProver::Committed)>,
-		merkle_prover: &'a MerkleProver,
+		codeword_oracle: BatchBrakedownOracleProver<'a, P, MerkleProver>,
+		fri_oracles: Vec<FRIOracleProver<'a, F, MerkleProver>>,
 	) -> Self {
-		let codeword_oracle = BrakedownOracleProver::new(
-			codeword,
-			codeword_committed,
-			merkle_prover,
-			params.log_batch_size(),
-		);
-
-		let fri_oracles = round_committed
-			.into_iter()
-			.take(params.fold_arities().len())
-			.zip(params.fold_arities().iter().copied())
-			.map(|((codeword, committed), arity)| {
-				FRIOracleProver::new(codeword, committed, merkle_prover, arity)
-			})
-			.collect();
-
 		Self {
 			codeword_oracle,
 			fri_oracles,

--- a/crates/iop-prover/src/fri/tests.rs
+++ b/crates/iop-prover/src/fri/tests.rs
@@ -18,11 +18,10 @@ use binius_transcript::{
 	ProverTranscript,
 	fiat_shamir::{CanSample, HasherChallenger},
 };
-use binius_utils::checked_arithmetics::log2_strict_usize;
 use rand::prelude::*;
 
 use super::{CommitOutput, FRIFoldProver, FoldRoundOutput, commit_interleaved};
-use crate::merkle_tree::{MerkleTreeProver, prover::BinaryMerkleTreeProver};
+use crate::merkle_tree::prover::BinaryMerkleTreeProver;
 
 type StdChallenger = HasherChallenger<StdDigest>;
 
@@ -124,35 +123,16 @@ fn test_commit_prove_verify_success<F, P>(
 	)
 	.unwrap();
 
-	let mut cloned_verifier_challenger = verifier_challenger.clone();
-
-	let terminate_codeword_len =
-		1 << (params.n_final_challenges() + params.rs_code().log_inv_rate());
-
-	let mut advice = verifier_challenger.decommitment();
-	let terminate_codeword: Vec<F> = advice.read_scalar_slice(terminate_codeword_len).unwrap();
-
-	let log_batch_size =
-		log2_strict_usize(terminate_codeword.len()).saturating_sub(params.rs_code().log_inv_rate());
-
-	let (commitment, tree) = merkle_prover
-		.commit(&terminate_codeword, 1 << log_batch_size)
-		.unwrap();
-
-	// Ensure that the terminate_codeword commitment is correct
-	let last_round_commitment = round_commitments.last().unwrap_or(&codeword_commitment);
-	assert_eq!(*last_round_commitment, commitment.root);
-
-	// Verify that the Merkle tree has exactly inv_rate leaves.
-	assert_eq!(tree.log_len, params.rs_code().log_inv_rate());
-
+	// The verifier checks the terminal codeword against its commitment internally (the terminal
+	// codeword is sent in full at the end of the query phase).
+	//
 	// check c == t(r'_0, ..., r'_{\ell-1})
 	// note that the prover is claiming that the final_message is [c]
 	let mut eval_point = verifier_challenges.clone();
 	eval_point.reverse();
 	let computed_eval = evaluate(&msg, &eval_point);
 
-	let final_fri_value = verifier.verify(&mut cloned_verifier_challenger).unwrap();
+	let final_fri_value = verifier.verify(&mut verifier_challenger).unwrap();
 	assert_eq!(computed_eval, final_fri_value);
 }
 

--- a/crates/iop-prover/src/fri/tests.rs
+++ b/crates/iop-prover/src/fri/tests.rs
@@ -1,17 +1,19 @@
 // Copyright 2024-2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-use std::vec;
+use std::{iter, vec};
 
 use binius_field::{
-	BinaryField, BinaryField128bGhash as B128, PackedBinaryGhash1x128b, PackedField,
+	BinaryField, BinaryField128bGhash as B128, Field, PackedBinaryGhash1x128b, PackedField,
 };
 use binius_hash::{StdDigest, StdHashSuite};
-use binius_iop::fri::{self, FRIFoldVerifier, FRIParams, verify::FRIQueryVerifier};
+use binius_iop::fri::{
+	self, FRIFoldVerifier, FRIParams, PartialOracleSpec, verify::FRIQueryVerifier,
+};
 use binius_math::{
 	BinarySubspace, ReedSolomonCode,
-	multilinear::evaluate::evaluate,
-	ntt::{NeighborsLastSingleThread, domain_context::GenericOnTheFly},
+	multilinear::{eq::eq_ind_partial_eval_scalars, evaluate::evaluate},
+	ntt::{AdditiveNTT, NeighborsLastSingleThread, domain_context::GenericOnTheFly},
 	test_utils::{Packed128b, random_field_buffer},
 };
 use binius_transcript::{
@@ -210,6 +212,147 @@ fn test_commit_prove_verify_success_without_folding() {
 		log_batch_size,
 		&[],
 	);
+}
+
+/// Full FRI round trip that batches several initial oracles in the first fold.
+///
+/// The three input oracles share the same Reed-Solomon code (dimension and inverse rate) but have
+/// differing batch sizes (1, 1, 2). The prover commits each interleaved codeword separately, folds
+/// and combines them into a single first-round codeword via [`FRIFoldProver::new_batch`], and the
+/// verifier reconstructs the same combined oracle via [`FRIQueryVerifier::new_batch`].
+#[test]
+fn test_commit_prove_verify_batched_multi_oracle() {
+	type F = B128;
+	type P = PackedBinaryGhash1x128b;
+
+	let mut rng = StdRng::seed_from_u64(0);
+
+	let log_dim = 8;
+	let log_inv_rate = 2;
+	let log_batch_sizes = [1usize, 1, 2];
+	let n_test_queries = 3;
+
+	let merkle_prover = BinaryMerkleTreeProver::<F, StdHashSuite>::new();
+
+	// The reduced Reed-Solomon code is shared by every input oracle, so the domain only needs to
+	// cover its length.
+	let subspace = BinarySubspace::with_dim(log_dim + log_inv_rate);
+	let domain_context = GenericOnTheFly::generate_from_subspace(&subspace);
+	let ntt = NeighborsLastSingleThread::new(domain_context);
+
+	// Each oracle has RS dimension `log_dim`, hence message length `log_dim + log_batch_size`.
+	// Fixing every batch size forces the reduced (first-round) dimension to `log_dim`.
+	let oracle_specs = log_batch_sizes
+		.iter()
+		.map(|&log_batch_size| PartialOracleSpec {
+			log_msg_len: log_dim + log_batch_size,
+			log_batch_size: Some(log_batch_size),
+		})
+		.collect::<Vec<_>>();
+	let (params, _proof_size) = FRIParams::<F>::optimal_for_batch(
+		ntt.domain_context(),
+		merkle_prover.scheme(),
+		&oracle_specs,
+		log_inv_rate,
+		n_test_queries,
+	);
+	assert_eq!(params.rs_code().log_dim(), log_dim);
+
+	// Commit each input oracle's interleaved codeword separately.
+	let mut messages = Vec::new();
+	let mut commitments = Vec::new();
+	let mut committeds = Vec::new();
+	let mut codewords = Vec::new();
+	for &log_batch_size in &log_batch_sizes {
+		let oracle_params =
+			FRIParams::new(params.rs_code().clone(), log_batch_size, vec![], n_test_queries)
+				.unwrap();
+		let msg = random_field_buffer::<P>(&mut rng, log_dim + log_batch_size);
+		let CommitOutput {
+			commitment,
+			committed,
+			codeword,
+		} = commit_interleaved(&oracle_params, &ntt, &merkle_prover, msg.to_ref()).unwrap();
+		messages.push(msg);
+		commitments.push(commitment);
+		committeds.push(committed);
+		codewords.push(codeword);
+	}
+
+	// Run the prover: write the per-oracle codeword commitments, then fold.
+	let committed_codewords = iter::zip(codewords, &committeds).collect::<Vec<_>>();
+	let mut round_prover =
+		FRIFoldProver::new_batch(&params, &ntt, &merkle_prover, committed_codewords).unwrap();
+
+	let mut prover_challenger = ProverTranscript::new(StdChallenger::default());
+	for commitment in &commitments {
+		prover_challenger.message().write(commitment);
+	}
+
+	let fold_round_output = round_prover.execute_fold_round();
+	if let FoldRoundOutput::Commitment(round_commitment) = fold_round_output {
+		prover_challenger.message().write(&round_commitment);
+	}
+	for _ in 0..params.n_fold_rounds() {
+		let challenge = prover_challenger.sample();
+		round_prover.receive_challenge(challenge);
+
+		let fold_round_output = round_prover.execute_fold_round();
+		if let FoldRoundOutput::Commitment(round_commitment) = fold_round_output {
+			prover_challenger.message().write(&round_commitment);
+		}
+	}
+	round_prover.finish_proof(&mut prover_challenger).unwrap();
+
+	// Run the verifier.
+	let mut verifier_challenger = prover_challenger.into_verifier();
+	let read_commitments = commitments
+		.iter()
+		.map(|_| verifier_challenger.message().read().unwrap())
+		.collect::<Vec<_>>();
+
+	let mut verifier_challenges = Vec::with_capacity(params.n_fold_rounds());
+	let mut fri_fold_verifier = FRIFoldVerifier::new(&params);
+	fri_fold_verifier
+		.process_round(&mut verifier_challenger.message())
+		.unwrap();
+	for _ in 0..params.n_fold_rounds() {
+		verifier_challenges.push(verifier_challenger.sample());
+		fri_fold_verifier
+			.process_round(&mut verifier_challenger.message())
+			.unwrap();
+	}
+	let round_commitments = fri_fold_verifier.finalize().unwrap();
+
+	let verifier = FRIQueryVerifier::new_batch(
+		&params,
+		merkle_prover.scheme(),
+		&read_commitments,
+		&round_commitments,
+		&verifier_challenges,
+	)
+	.unwrap();
+	let final_value = verifier.verify(&mut verifier_challenger).unwrap();
+
+	// The first fold reduces oracle `i` by its inner challenges (the last `log_batch_size_i` of the
+	// first `max_log_batch_size` challenges) and combines the oracles with the outer-challenge
+	// tensor. The remaining (tail) challenges fold the shared reduced codeword. So the final value
+	// is   sum_i outer_tensor[i] * evaluate(msg_i, reversed(inner_i ++ tail)).
+	let max_log_batch_size = log_batch_sizes.iter().copied().max().unwrap();
+	let first_fold_arity = params.log_batch_size();
+	let inner = &verifier_challenges[..max_log_batch_size];
+	let outer = &verifier_challenges[max_log_batch_size..first_fold_arity];
+	let tail = &verifier_challenges[first_fold_arity..];
+	let outer_tensor = eq_ind_partial_eval_scalars::<F>(outer);
+
+	let mut expected = F::ZERO;
+	for (i, (msg, &log_batch_size)) in iter::zip(&messages, &log_batch_sizes).enumerate() {
+		let inner_i = &inner[max_log_batch_size - log_batch_size..];
+		let mut eval_point = inner_i.iter().chain(tail).copied().collect::<Vec<_>>();
+		eval_point.reverse();
+		expected += outer_tensor[i] * evaluate(msg, &eval_point);
+	}
+	assert_eq!(final_value, expected);
 }
 
 /// Runs the FRI prover and returns the proof bytes along with the FRI params and Merkle scheme,

--- a/crates/iop-prover/src/fri/tests.rs
+++ b/crates/iop-prover/src/fri/tests.rs
@@ -70,7 +70,7 @@ fn test_commit_prove_verify_success<F, P>(
 
 	// Note: The prover does an initial fold round before receiving any challenges
 	// This is round 0, which won't produce a commitment when log_batch_size > 0
-	let fold_round_output = round_prover.execute_fold_round().unwrap();
+	let fold_round_output = round_prover.execute_fold_round();
 	if let FoldRoundOutput::Commitment(round_commitment) = fold_round_output {
 		prover_challenger.message().write(&round_commitment);
 	}
@@ -79,7 +79,7 @@ fn test_commit_prove_verify_success<F, P>(
 		let challenge = prover_challenger.sample();
 		round_prover.receive_challenge(challenge);
 
-		let fold_round_output = round_prover.execute_fold_round().unwrap();
+		let fold_round_output = round_prover.execute_fold_round();
 		if let FoldRoundOutput::Commitment(round_commitment) = fold_round_output {
 			prover_challenger.message().write(&round_commitment);
 		}
@@ -253,7 +253,7 @@ where
 	let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 	prover_transcript.message().write(&codeword_commitment);
 
-	let fold_round_output = round_prover.execute_fold_round().unwrap();
+	let fold_round_output = round_prover.execute_fold_round();
 	if let FoldRoundOutput::Commitment(round_commitment) = fold_round_output {
 		prover_transcript.message().write(&round_commitment);
 	}
@@ -262,7 +262,7 @@ where
 		let challenge = prover_transcript.sample();
 		round_prover.receive_challenge(challenge);
 
-		let fold_round_output = round_prover.execute_fold_round().unwrap();
+		let fold_round_output = round_prover.execute_fold_round();
 		if let FoldRoundOutput::Commitment(round_commitment) = fold_round_output {
 			prover_transcript.message().write(&round_commitment);
 		}

--- a/crates/iop/Cargo.toml
+++ b/crates/iop/Cargo.toml
@@ -14,6 +14,7 @@ binius-ip = { path = "../ip" }
 binius-math = { path = "../math" }
 binius-transcript = { path = "../transcript" }
 binius-utils = { path = "../utils" }
+auto_impl.workspace = true
 bytes.workspace = true
 digest.workspace = true
 getset.workspace = true

--- a/crates/iop/src/fri/batch.rs
+++ b/crates/iop/src/fri/batch.rs
@@ -96,6 +96,60 @@ impl<F: BinaryField, MTScheme: MerkleTreeScheme<F, Digest: DeserializeBytes>> Pr
 	}
 }
 
+/// A [ProxTestOracle] bundling several separately committed [BrakedownOracle]s.
+///
+/// The bundled oracles wrap interleaved codewords of equal folded length that the prover batched
+/// into a single folded codeword via the outer-challenge tensor expansion. Their query openings are
+/// read sequentially, one oracle's full decommitment after another, and the per-query folded values
+/// are combined as `\sum_i values_i[q] * outer_tensor[i]`, where
+/// `outer_tensor = eq_ind_partial_eval(outer_challenges)`. This mirrors the prover's
+/// `BatchBrakedownFolder::fold`.
+pub struct BatchBrakedownOracle<F, MTScheme>
+where
+	MTScheme: MerkleTreeScheme<F>,
+{
+	oracles: Vec<BrakedownOracle<F, MTScheme>>,
+	outer_challenges: Vec<F>,
+}
+
+impl<F: BinaryField, MTScheme: MerkleTreeScheme<F>> BatchBrakedownOracle<F, MTScheme> {
+	/// Constructs a batch oracle from the per-commitment oracles and the batching challenges.
+	pub fn new(oracles: Vec<BrakedownOracle<F, MTScheme>>, outer_challenges: Vec<F>) -> Self {
+		assert!(!oracles.is_empty()); // precondition
+		Self {
+			oracles,
+			outer_challenges,
+		}
+	}
+}
+
+impl<F: BinaryField, MTScheme: MerkleTreeScheme<F, Digest: DeserializeBytes>> ProxTestOracle<F>
+	for BatchBrakedownOracle<F, MTScheme>
+{
+	fn log_len(&self) -> usize {
+		self.oracles[0].log_len()
+	}
+
+	fn open_queries<B: Buf>(
+		&self,
+		indices: &[usize],
+		advice: &mut TranscriptReader<B>,
+	) -> Result<Vec<F>, Error> {
+		// Read each bundled oracle's openings in commit order (matching the prover), then combine
+		// across oracles by the outer-challenge tensor expansion:
+		// combined[q] = \sum_i values_i[q] * outer_tensor[i].
+		let outer_tensor = multilinear::eq::eq_ind_partial_eval::<F>(&self.outer_challenges);
+		let mut combined = vec![F::ZERO; indices.len()];
+		for (oracle, &scalar) in self.oracles.iter().zip(outer_tensor.as_ref()) {
+			let values = oracle.open_queries(indices, advice)?;
+			for (acc, value) in combined.iter_mut().zip(values) {
+				*acc += value * scalar;
+			}
+		}
+		Ok(combined)
+	}
+}
+
 /// A [ProxTestOracle] implementation for a FRI-style code proximity check.
 ///
 /// Note that this is distinct from the full FRI query-phase verifier in the `verify` module. This

--- a/crates/iop/src/fri/batch.rs
+++ b/crates/iop/src/fri/batch.rs
@@ -16,15 +16,24 @@ use crate::merkle_tree::{Commitment, MerkleTreeScheme};
 /// 3. the verifier opens Merkle commitments at those indices and performs consistency checks on the
 ///    committed values
 pub trait ProxQueryVerifier<F: BinaryField> {
-	/// Verify decommitted prover advice for satisfying values at the committed indices.
+	/// The base-2 logarithm of the length of the virtual oracle.
+	///
+	/// The virtual oracle is defined by the committed oracle and the folding challenges. Indices
+	/// passed to [`Self::open_queries`] must lie in the range `0..2^self.log_len()`.
+	fn log_len(&self) -> usize;
+
+	/// Opens queried locations on the virtual oracle.
 	///
 	/// This has a batch interface for verifying multiple queries because opening multiple Merkle
 	/// tree locations at once amortizes the proof size.
 	///
+	/// ## Preconditions
+	/// The `indices` must lie in the range `0..2^self.log_len()`.
+	///
 	/// ## Returns
 	/// The values of the virtual oracle at the queried indices. The virtual oracle is defined by
 	/// the committed oracle and the folding challenges.
-	fn verify_queries<B: Buf>(
+	fn open_queries<B: Buf>(
 		&self,
 		indices: &[usize],
 		advice: &mut TranscriptReader<B>,
@@ -32,7 +41,7 @@ pub trait ProxQueryVerifier<F: BinaryField> {
 }
 
 /// A [ProxQueryVerifier] implementation for a [Brakedown]-style interleaved code proximity check.
-/// 
+///
 /// [Brakedown]: <https://dl.acm.org/doi/10.1007/978-3-031-38545-2_7>
 pub struct BrakedownQueryVerifier<F, MTScheme>
 where
@@ -46,7 +55,11 @@ where
 impl<F: BinaryField, MTScheme: MerkleTreeScheme<F, Digest: DeserializeBytes>> ProxQueryVerifier<F>
 	for BrakedownQueryVerifier<F, MTScheme>
 {
-	fn verify_queries<B: Buf>(
+	fn log_len(&self) -> usize {
+		self.commitment.depth
+	}
+
+	fn open_queries<B: Buf>(
 		&self,
 		indices: &[usize],
 		advice: &mut TranscriptReader<B>,
@@ -89,6 +102,11 @@ where
 	MTScheme: MerkleTreeScheme<F>,
 	DC: DomainContext<Field = F>,
 {
+	/// The base-2 log of the size of each coset opened from the committed oracle.
+	fn coset_log_size(&self) -> usize {
+		self.challenges.len()
+	}
+
 	/// Folds an opened coset into a single value.
 	///
 	/// This implements the fold operation from Definition 4.6 of [DP24], reading twiddle factors
@@ -103,8 +121,8 @@ where
 		let mut log_size = n_challenges;
 		for &challenge in &self.challenges {
 			for index_offset in 0..1 << (log_size - 1) {
-				// Perform the inverse additive NTT butterfly, then extrapolate the resulting line at
-				// the folding challenge.
+				// Perform the inverse additive NTT butterfly, then extrapolate the resulting line
+				// at the folding challenge.
 				let mut u = values[index_offset << 1];
 				let mut v = values[(index_offset << 1) | 1];
 				let twiddle = self
@@ -123,13 +141,74 @@ where
 	}
 }
 
+impl<F, MTScheme, DC> FRIQueryVerifier<F, MTScheme, DC>
+where
+	F: BinaryField,
+	MTScheme: MerkleTreeScheme<F, Digest: DeserializeBytes>,
+	DC: DomainContext<Field = F>,
+{
+	/// Opens queried locations on the base codeword, reducing claims about it to the virtual
+	/// oracle.
+	///
+	/// Whereas [`Self::open_queries`] indexes the virtual oracle, this indexes the base codeword:
+	/// each index lies in the range `0..2^(self.log_len() + self.coset_log_size())` and splits into
+	/// the high `self.log_len()` bits (the coset index into the committed oracle) and the low
+	/// `self.coset_log_size()` bits (the offset within the coset). For each query, the opened coset
+	/// value at that offset is checked against `claims[i]`, after which the coset is folded into
+	/// the virtual oracle value as in [`Self::open_queries`].
+	///
+	/// ## Preconditions
+	/// `claims` must have the same length as `indices`, and the indices must lie in the range
+	/// `0..2^(self.log_len() + self.coset_log_size())`.
+	///
+	/// ## Returns
+	/// The values of the virtual oracle at the queried coset indices.
+	pub fn reduce_queries<B: Buf>(
+		&self,
+		indices: &[usize],
+		claims: &[F],
+		advice: &mut TranscriptReader<B>,
+	) -> Result<Vec<F>, Error> {
+		assert_eq!(indices.len(), claims.len()); // precondition
+
+		let coset_log_size = self.coset_log_size();
+		let coset_mask = (1 << coset_log_size) - 1;
+		let coset_indices = indices
+			.iter()
+			.map(|&index| index >> coset_log_size)
+			.collect::<Vec<_>>();
+
+		verify_query_openings(
+			&self.merkle_scheme,
+			&self.commitment,
+			coset_log_size,
+			&coset_indices,
+			advice,
+		)?
+		.zip(indices.iter().zip(claims))
+		.map(|(opening, (&index, &claim))| {
+			let (coset_index, values) = opening?;
+			// Verify the claimed base-codeword value against the opened coset.
+			if values[index & coset_mask] != claim {
+				return Err(Error::ClaimMismatch { index });
+			}
+			Ok(self.fold_coset(coset_index, values))
+		})
+		.collect()
+	}
+}
+
 impl<F, MTScheme, DC> ProxQueryVerifier<F> for FRIQueryVerifier<F, MTScheme, DC>
 where
 	F: BinaryField,
 	MTScheme: MerkleTreeScheme<F, Digest: DeserializeBytes>,
 	DC: DomainContext<Field = F>,
 {
-	fn verify_queries<B: Buf>(
+	fn log_len(&self) -> usize {
+		self.commitment.depth
+	}
+
+	fn open_queries<B: Buf>(
 		&self,
 		indices: &[usize],
 		advice: &mut TranscriptReader<B>,
@@ -191,8 +270,10 @@ where
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
+	#[error("claimed value at index {index} does not match the committed codeword")]
+	ClaimMismatch { index: usize },
 	#[error("Merkle tree error: {0}")]
-	MerkleError(#[from] crate::merkle_tree::Error),
+	Merkle(#[from] crate::merkle_tree::Error),
 	#[error("transcript error: {0}")]
-	TranscriptError(#[from] binius_transcript::Error),
+	Transcript(#[from] binius_transcript::Error),
 }

--- a/crates/iop/src/fri/batch.rs
+++ b/crates/iop/src/fri/batch.rs
@@ -1,0 +1,91 @@
+// Copyright 2026 The Binius Developers
+
+use binius_field::BinaryField;
+use binius_math::multilinear;
+use binius_transcript::TranscriptReader;
+use binius_utils::DeserializeBytes;
+use bytes::Buf;
+
+use crate::merkle_tree::{Commitment, MerkleTreeScheme};
+/// A verification interface for the query phase of a code proximity test.
+///
+/// The interactive code proximity tests used in this project (eg. FRI) follow the structure of:
+///
+/// 1. the verifier and prover interactively and randomly fold the codeword
+/// 2. the verifier randomly samples codeword symbol indices
+/// 3. the verifier opens Merkle commitments at those indices and performs consistency checks on the
+///    committed values
+pub trait ProxQueryVerifier<F: BinaryField> {
+	/// Verify decommitted prover advice for satisfying values at the committed indices.
+	///
+	/// This has a batch interface for verifying multiple queries because opening multiple Merkle
+	/// tree locations at once amortizes the proof size.
+	///
+	/// ## Returns
+	/// The values of the virtual oracle at the queried indices. The virtual oracle is defined by
+	/// the committed oracle and the folding challenges.
+	fn verify_queries<B: Buf>(
+		&self,
+		indices: &[usize],
+		advice: &mut TranscriptReader<B>,
+	) -> Result<Vec<F>, Error>;
+}
+
+/// A [ProxQueryVerifier] implementation for a [Brakedown]-style interleaved code proximity check.
+/// 
+/// [Brakedown]: <https://dl.acm.org/doi/10.1007/978-3-031-38545-2_7>
+pub struct BrakedownQueryVerifier<F, MTScheme>
+where
+	MTScheme: MerkleTreeScheme<F>,
+{
+	challenges: Vec<F>,
+	commitment: Commitment<MTScheme::Digest>,
+	merkle_scheme: MTScheme,
+}
+
+impl<F: BinaryField, MTScheme: MerkleTreeScheme<F, Digest: DeserializeBytes>> ProxQueryVerifier<F>
+	for BrakedownQueryVerifier<F, MTScheme>
+{
+	fn verify_queries<B: Buf>(
+		&self,
+		indices: &[usize],
+		advice: &mut TranscriptReader<B>,
+	) -> Result<Vec<F>, Error> {
+		let tree_depth = self.commitment.depth;
+		let layer_depth = self
+			.merkle_scheme
+			.optimal_verify_layer(indices.len(), tree_depth);
+		let layer_digests = advice.read_vec(1 << layer_depth)?;
+		self.merkle_scheme
+			.verify_layer(&self.commitment.root, layer_depth, &layer_digests)?;
+
+		indices
+			.iter()
+			.map(|&index| {
+				// Receive the interleaved codeword symbol at the index and verify their consistency
+				// with the commitment.
+				let values = advice.read_scalar_slice::<F>(1 << self.challenges.len())?;
+				self.merkle_scheme.verify_opening(
+					index,
+					&values,
+					layer_depth,
+					tree_depth,
+					&layer_digests,
+					advice,
+				)?;
+
+				let folded_value =
+					multilinear::evaluate::evaluate_inplace_scalars(values, &self.challenges);
+				Ok(folded_value)
+			})
+			.collect()
+	}
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+	#[error("Merkle tree error: {0}")]
+	MerkleError(#[from] crate::merkle_tree::Error),
+	#[error("transcript error: {0}")]
+	TranscriptError(#[from] binius_transcript::Error),
+}

--- a/crates/iop/src/fri/batch.rs
+++ b/crates/iop/src/fri/batch.rs
@@ -1,7 +1,7 @@
 // Copyright 2026 The Binius Developers
 
 use binius_field::BinaryField;
-use binius_math::multilinear;
+use binius_math::{line::extrapolate_line, multilinear, ntt::DomainContext};
 use binius_transcript::TranscriptReader;
 use binius_utils::DeserializeBytes;
 use bytes::Buf;
@@ -51,35 +51,142 @@ impl<F: BinaryField, MTScheme: MerkleTreeScheme<F, Digest: DeserializeBytes>> Pr
 		indices: &[usize],
 		advice: &mut TranscriptReader<B>,
 	) -> Result<Vec<F>, Error> {
-		let tree_depth = self.commitment.depth;
-		let layer_depth = self
-			.merkle_scheme
-			.optimal_verify_layer(indices.len(), tree_depth);
-		let layer_digests = advice.read_vec(1 << layer_depth)?;
-		self.merkle_scheme
-			.verify_layer(&self.commitment.root, layer_depth, &layer_digests)?;
-
-		indices
-			.iter()
-			.map(|&index| {
-				// Receive the interleaved codeword symbol at the index and verify their consistency
-				// with the commitment.
-				let values = advice.read_scalar_slice::<F>(1 << self.challenges.len())?;
-				self.merkle_scheme.verify_opening(
-					index,
-					&values,
-					layer_depth,
-					tree_depth,
-					&layer_digests,
-					advice,
-				)?;
-
-				let folded_value =
-					multilinear::evaluate::evaluate_inplace_scalars(values, &self.challenges);
-				Ok(folded_value)
-			})
-			.collect()
+		verify_query_openings(
+			&self.merkle_scheme,
+			&self.commitment,
+			self.challenges.len(),
+			indices,
+			advice,
+		)?
+		.map(|opening| {
+			let (_index, values) = opening?;
+			// Fold the coset using a multilinear tensor fold over the challenges.
+			Ok(multilinear::evaluate::evaluate_inplace_scalars(values, &self.challenges))
+		})
+		.collect()
 	}
+}
+
+/// A [ProxQueryVerifier] implementation for a FRI-style code proximity check.
+///
+/// Note that this is distinct from the `FRIQueryVerifier` in the `verify` module, which implements
+/// the full FRI query phase. This one only verifies the openings of a single committed oracle and
+/// folds each opened coset into a single value using FRI folding.
+pub struct FRIQueryVerifier<F, MTScheme, DC>
+where
+	MTScheme: MerkleTreeScheme<F>,
+	DC: DomainContext<Field = F>,
+{
+	challenges: Vec<F>,
+	commitment: Commitment<MTScheme::Digest>,
+	merkle_scheme: MTScheme,
+	domain_context: DC,
+}
+
+impl<F, MTScheme, DC> FRIQueryVerifier<F, MTScheme, DC>
+where
+	F: BinaryField,
+	MTScheme: MerkleTreeScheme<F>,
+	DC: DomainContext<Field = F>,
+{
+	/// Folds an opened coset into a single value.
+	///
+	/// This implements the fold operation from Definition 4.6 of [DP24], reading twiddle factors
+	/// directly from the held [`DomainContext`]. The twiddle layer is absolute within the full NTT
+	/// domain; for the committed oracle the codeword length in log terms is the Merkle tree depth
+	/// plus the number of folding challenges (one coset per leaf).
+	///
+	/// [DP24]: <https://eprint.iacr.org/2024/504>
+	fn fold_coset(&self, chunk_index: usize, mut values: Vec<F>) -> F {
+		let n_challenges = self.challenges.len();
+		let mut log_len = self.commitment.depth + n_challenges;
+		let mut log_size = n_challenges;
+		for &challenge in &self.challenges {
+			for index_offset in 0..1 << (log_size - 1) {
+				// Perform the inverse additive NTT butterfly, then extrapolate the resulting line at
+				// the folding challenge.
+				let mut u = values[index_offset << 1];
+				let mut v = values[(index_offset << 1) | 1];
+				let twiddle = self
+					.domain_context
+					.twiddle(log_len - 1, (chunk_index << (log_size - 1)) | index_offset);
+				v += u;
+				u += v * twiddle;
+				values[index_offset] = extrapolate_line(u, v, challenge);
+			}
+
+			log_len -= 1;
+			log_size -= 1;
+		}
+
+		values[0]
+	}
+}
+
+impl<F, MTScheme, DC> ProxQueryVerifier<F> for FRIQueryVerifier<F, MTScheme, DC>
+where
+	F: BinaryField,
+	MTScheme: MerkleTreeScheme<F, Digest: DeserializeBytes>,
+	DC: DomainContext<Field = F>,
+{
+	fn verify_queries<B: Buf>(
+		&self,
+		indices: &[usize],
+		advice: &mut TranscriptReader<B>,
+	) -> Result<Vec<F>, Error> {
+		verify_query_openings(
+			&self.merkle_scheme,
+			&self.commitment,
+			self.challenges.len(),
+			indices,
+			advice,
+		)?
+		.map(|opening| {
+			let (index, values) = opening?;
+			Ok(self.fold_coset(index, values))
+		})
+		.collect()
+	}
+}
+
+/// Verifies the Merkle openings shared by the [ProxQueryVerifier] implementations.
+///
+/// First decommits and verifies the optimal internal layer of the Merkle tree, then returns a lazy
+/// iterator that, for each queried index, reads the opened coset of `1 << coset_log_size` values
+/// from the advice and verifies its opening against that layer. Each item is the queried index
+/// paired with the verified coset values.
+fn verify_query_openings<'a, F, MTScheme, B>(
+	merkle_scheme: &'a MTScheme,
+	commitment: &'a Commitment<MTScheme::Digest>,
+	coset_log_size: usize,
+	indices: &'a [usize],
+	advice: &'a mut TranscriptReader<B>,
+) -> Result<impl Iterator<Item = Result<(usize, Vec<F>), Error>> + 'a, Error>
+where
+	F: BinaryField,
+	MTScheme: MerkleTreeScheme<F, Digest: DeserializeBytes>,
+	B: Buf,
+{
+	let tree_depth = commitment.depth;
+	let layer_depth = merkle_scheme.optimal_verify_layer(indices.len(), tree_depth);
+	let layer_digests = advice.read_vec(1 << layer_depth)?;
+	merkle_scheme.verify_layer(&commitment.root, layer_depth, &layer_digests)?;
+
+	let openings = indices.iter().map(move |&index| {
+		// Receive the codeword symbols of the coset at the index and verify their consistency with
+		// the commitment.
+		let values = advice.read_scalar_slice::<F>(1 << coset_log_size)?;
+		merkle_scheme.verify_opening(
+			index,
+			&values,
+			layer_depth,
+			tree_depth,
+			&layer_digests,
+			advice,
+		)?;
+		Ok((index, values))
+	});
+	Ok(openings)
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/iop/src/fri/batch.rs
+++ b/crates/iop/src/fri/batch.rs
@@ -7,15 +7,15 @@ use binius_utils::DeserializeBytes;
 use bytes::Buf;
 
 use crate::merkle_tree::{Commitment, MerkleTreeScheme};
-/// A verification interface for the query phase of a code proximity test.
+/// A virtual oracle for a code proximity test.
 ///
-/// The interactive code proximity tests used in this project (eg. FRI) follow the structure of:
-///
-/// 1. the verifier and prover interactively and randomly fold the codeword
-/// 2. the verifier randomly samples codeword symbol indices
-/// 3. the verifier opens Merkle commitments at those indices and performs consistency checks on the
-///    committed values
-pub trait ProxQueryVerifier<F: BinaryField> {
+/// The interactive code proximity tests used in this project (eg. FRI) commit to a codeword and
+/// then interactively fold it with random challenges. This trait represents the resulting *virtual
+/// oracle*: the folded codeword, whose values are not committed directly but are instead recovered
+/// on demand by opening the committed oracle at the queried indices and applying the folding. An
+/// implementation therefore holds the committed oracle along with the folding challenges, and
+/// verifies decommitted prover advice in order to evaluate the virtual oracle at queried locations.
+pub trait ProxTestOracle<F: BinaryField> {
 	/// The base-2 logarithm of the length of the virtual oracle.
 	///
 	/// The virtual oracle is defined by the committed oracle and the folding challenges. Indices
@@ -40,10 +40,10 @@ pub trait ProxQueryVerifier<F: BinaryField> {
 	) -> Result<Vec<F>, Error>;
 }
 
-/// A [ProxQueryVerifier] implementation for a [Brakedown]-style interleaved code proximity check.
+/// A [ProxTestOracle] implementation for a [Brakedown]-style interleaved code proximity check.
 ///
 /// [Brakedown]: <https://dl.acm.org/doi/10.1007/978-3-031-38545-2_7>
-pub struct BrakedownQueryVerifier<F, MTScheme>
+pub struct BrakedownOracle<F, MTScheme>
 where
 	MTScheme: MerkleTreeScheme<F>,
 {
@@ -52,8 +52,8 @@ where
 	merkle_scheme: MTScheme,
 }
 
-impl<F: BinaryField, MTScheme: MerkleTreeScheme<F, Digest: DeserializeBytes>> ProxQueryVerifier<F>
-	for BrakedownQueryVerifier<F, MTScheme>
+impl<F: BinaryField, MTScheme: MerkleTreeScheme<F, Digest: DeserializeBytes>> ProxTestOracle<F>
+	for BrakedownOracle<F, MTScheme>
 {
 	fn log_len(&self) -> usize {
 		self.commitment.depth
@@ -80,12 +80,12 @@ impl<F: BinaryField, MTScheme: MerkleTreeScheme<F, Digest: DeserializeBytes>> Pr
 	}
 }
 
-/// A [ProxQueryVerifier] implementation for a FRI-style code proximity check.
+/// A [ProxTestOracle] implementation for a FRI-style code proximity check.
 ///
-/// Note that this is distinct from the `FRIQueryVerifier` in the `verify` module, which implements
-/// the full FRI query phase. This one only verifies the openings of a single committed oracle and
-/// folds each opened coset into a single value using FRI folding.
-pub struct FRIQueryVerifier<F, MTScheme, DC>
+/// Note that this is distinct from the full FRI query-phase verifier in the `verify` module. This
+/// one only verifies the openings of a single committed oracle and folds each opened coset into a
+/// single value using FRI folding.
+pub struct FRIOracle<F, MTScheme, DC>
 where
 	MTScheme: MerkleTreeScheme<F>,
 	DC: DomainContext<Field = F>,
@@ -96,7 +96,7 @@ where
 	domain_context: DC,
 }
 
-impl<F, MTScheme, DC> FRIQueryVerifier<F, MTScheme, DC>
+impl<F, MTScheme, DC> FRIOracle<F, MTScheme, DC>
 where
 	F: BinaryField,
 	MTScheme: MerkleTreeScheme<F>,
@@ -141,7 +141,7 @@ where
 	}
 }
 
-impl<F, MTScheme, DC> FRIQueryVerifier<F, MTScheme, DC>
+impl<F, MTScheme, DC> FRIOracle<F, MTScheme, DC>
 where
 	F: BinaryField,
 	MTScheme: MerkleTreeScheme<F, Digest: DeserializeBytes>,
@@ -198,7 +198,7 @@ where
 	}
 }
 
-impl<F, MTScheme, DC> ProxQueryVerifier<F> for FRIQueryVerifier<F, MTScheme, DC>
+impl<F, MTScheme, DC> ProxTestOracle<F> for FRIOracle<F, MTScheme, DC>
 where
 	F: BinaryField,
 	MTScheme: MerkleTreeScheme<F, Digest: DeserializeBytes>,
@@ -228,7 +228,7 @@ where
 	}
 }
 
-/// Verifies the Merkle openings shared by the [ProxQueryVerifier] implementations.
+/// Verifies the Merkle openings shared by the [ProxTestOracle] implementations.
 ///
 /// First decommits and verifies the optimal internal layer of the Merkle tree, then returns a lazy
 /// iterator that, for each queried index, reads the opened coset of `1 << coset_log_size` values

--- a/crates/iop/src/fri/batch.rs
+++ b/crates/iop/src/fri/batch.rs
@@ -52,6 +52,21 @@ where
 	merkle_scheme: MTScheme,
 }
 
+impl<F: BinaryField, MTScheme: MerkleTreeScheme<F>> BrakedownOracle<F, MTScheme> {
+	/// Constructs a new oracle from the committed interleaved codeword and the folding challenges.
+	pub fn new(
+		challenges: Vec<F>,
+		commitment: Commitment<MTScheme::Digest>,
+		merkle_scheme: MTScheme,
+	) -> Self {
+		Self {
+			challenges,
+			commitment,
+			merkle_scheme,
+		}
+	}
+}
+
 impl<F: BinaryField, MTScheme: MerkleTreeScheme<F, Digest: DeserializeBytes>> ProxTestOracle<F>
 	for BrakedownOracle<F, MTScheme>
 {
@@ -64,6 +79,7 @@ impl<F: BinaryField, MTScheme: MerkleTreeScheme<F, Digest: DeserializeBytes>> Pr
 		indices: &[usize],
 		advice: &mut TranscriptReader<B>,
 	) -> Result<Vec<F>, Error> {
+		assert!(indices.iter().all(|&index| index < 1 << self.log_len())); // precondition
 		verify_query_openings(
 			&self.merkle_scheme,
 			&self.commitment,
@@ -102,6 +118,22 @@ where
 	MTScheme: MerkleTreeScheme<F>,
 	DC: DomainContext<Field = F>,
 {
+	/// Constructs a new oracle from a committed oracle, its folding challenges, and the domain
+	/// context providing the FRI fold twiddles.
+	pub fn new(
+		challenges: Vec<F>,
+		commitment: Commitment<MTScheme::Digest>,
+		merkle_scheme: MTScheme,
+		domain_context: DC,
+	) -> Self {
+		Self {
+			challenges,
+			commitment,
+			merkle_scheme,
+			domain_context,
+		}
+	}
+
 	/// The base-2 log of the size of each coset opened from the committed oracle.
 	fn coset_log_size(&self) -> usize {
 		self.challenges.len()
@@ -109,36 +141,57 @@ where
 
 	/// Folds an opened coset into a single value.
 	///
-	/// This implements the fold operation from Definition 4.6 of [DP24], reading twiddle factors
-	/// directly from the held [`DomainContext`]. The twiddle layer is absolute within the full NTT
-	/// domain; for the committed oracle the codeword length in log terms is the Merkle tree depth
-	/// plus the number of folding challenges (one coset per leaf).
-	///
-	/// [DP24]: <https://eprint.iacr.org/2024/504>
-	fn fold_coset(&self, chunk_index: usize, mut values: Vec<F>) -> F {
-		let n_challenges = self.challenges.len();
-		let mut log_len = self.commitment.depth + n_challenges;
-		let mut log_size = n_challenges;
-		for &challenge in &self.challenges {
-			for index_offset in 0..1 << (log_size - 1) {
-				// Perform the inverse additive NTT butterfly, then extrapolate the resulting line
-				// at the folding challenge.
-				let mut u = values[index_offset << 1];
-				let mut v = values[(index_offset << 1) | 1];
-				let twiddle = self
-					.domain_context
-					.twiddle(log_len - 1, (chunk_index << (log_size - 1)) | index_offset);
-				v += u;
-				u += v * twiddle;
-				values[index_offset] = extrapolate_line(u, v, challenge);
-			}
+	/// The committed oracle's codeword length in log terms is the Merkle tree depth plus the number
+	/// of folding challenges (one coset per leaf), which is the `log_len` consumed by
+	/// [`fold_coset`].
+	fn fold_coset(&self, chunk_index: usize, values: Vec<F>) -> F {
+		fold_coset(
+			&self.domain_context,
+			self.commitment.depth + self.challenges.len(),
+			chunk_index,
+			&self.challenges,
+			values,
+		)
+	}
+}
 
-			log_len -= 1;
-			log_size -= 1;
+/// Folds a coset of a codeword into a single value with the given folding challenges.
+///
+/// This implements the fold operation from Definition 4.6 of [DP24], reading twiddle factors from
+/// the domain context. `log_len` is the base-2 log of the length of the codeword the coset belongs
+/// to; the twiddle layer is absolute within the full NTT domain and decreases with each challenge.
+///
+/// [DP24]: <https://eprint.iacr.org/2024/504>
+pub fn fold_coset<F, DC>(
+	domain_context: &DC,
+	mut log_len: usize,
+	chunk_index: usize,
+	challenges: &[F],
+	mut values: Vec<F>,
+) -> F
+where
+	F: BinaryField,
+	DC: DomainContext<Field = F>,
+{
+	let mut log_size = challenges.len();
+	for &challenge in challenges {
+		for index_offset in 0..1 << (log_size - 1) {
+			// Perform the inverse additive NTT butterfly, then extrapolate the resulting line at
+			// the folding challenge.
+			let mut u = values[index_offset << 1];
+			let mut v = values[(index_offset << 1) | 1];
+			let twiddle =
+				domain_context.twiddle(log_len - 1, (chunk_index << (log_size - 1)) | index_offset);
+			v += u;
+			u += v * twiddle;
+			values[index_offset] = extrapolate_line(u, v, challenge);
 		}
 
-		values[0]
+		log_len -= 1;
+		log_size -= 1;
 	}
+
+	values[0]
 }
 
 impl<F, MTScheme, DC> FRIOracle<F, MTScheme, DC>
@@ -170,6 +223,11 @@ where
 		advice: &mut TranscriptReader<B>,
 	) -> Result<Vec<F>, Error> {
 		assert_eq!(indices.len(), claims.len()); // precondition
+		assert!(
+			indices
+				.iter()
+				.all(|&index| index < 1 << (self.log_len() + self.coset_log_size()))
+		); // precondition
 
 		let coset_log_size = self.coset_log_size();
 		let coset_mask = (1 << coset_log_size) - 1;
@@ -213,6 +271,7 @@ where
 		indices: &[usize],
 		advice: &mut TranscriptReader<B>,
 	) -> Result<Vec<F>, Error> {
+		assert!(indices.iter().all(|&index| index < 1 << self.log_len())); // precondition
 		verify_query_openings(
 			&self.merkle_scheme,
 			&self.commitment,

--- a/crates/iop/src/fri/common.rs
+++ b/crates/iop/src/fri/common.rs
@@ -26,7 +26,6 @@ pub struct FRIParams<F> {
 	#[getset(get = "pub")]
 	rs_code: ReedSolomonCode<F>,
 	/// Guaranteed to be non-empty.
-	#[allow(unused)]
 	input_oracles: Vec<OracleSpec>,
 	/// log2 the maximum message length of all input oracles.
 	max_log_msg_len: usize,
@@ -247,6 +246,11 @@ where
 	/// The reduction arities between each oracle sent to the verifier.
 	pub fn fold_arities(&self) -> &[usize] {
 		&self.fold_arities
+	}
+
+	/// The specifications of the input oracles batched into the first-round FRI oracle.
+	pub fn input_oracles(&self) -> &[OracleSpec] {
+		&self.input_oracles
 	}
 
 	/// The arity of the reduction to the first round oracle.

--- a/crates/iop/src/fri/common.rs
+++ b/crates/iop/src/fri/common.rs
@@ -1,6 +1,6 @@
 // Copyright 2024-2025 Irreducible Inc.
 
-use std::{iter, marker::PhantomData};
+use std::marker::PhantomData;
 
 use binius_field::{BinaryField, Field};
 use binius_math::{ntt::DomainContext, reed_solomon::ReedSolomonCode};
@@ -308,23 +308,6 @@ where
 			(log_batch_size, fold_arities)
 		}
 	}
-}
-
-/// This layer allows minimizing the proof size.
-pub fn vcs_optimal_layers_depths_iter<'a, F, VCS>(
-	fri_params: &'a FRIParams<F>,
-	vcs: &'a VCS,
-) -> impl Iterator<Item = usize> + 'a
-where
-	VCS: MerkleTreeScheme<F>,
-	F: BinaryField,
-{
-	iter::once(fri_params.log_batch_size())
-		.chain(fri_params.fold_arities().iter().copied())
-		.scan(fri_params.log_len(), |log_n_cosets, arity| {
-			*log_n_cosets -= arity;
-			Some(vcs.optimal_verify_layer(fri_params.n_test_queries(), *log_n_cosets))
-		})
 }
 
 struct ChooseBatchSizeAndAritiesOutput {

--- a/crates/iop/src/fri/error.rs
+++ b/crates/iop/src/fri/error.rs
@@ -1,5 +1,6 @@
 // Copyright 2024-2025 Irreducible Inc.
 
+use super::batch;
 use crate::merkle_tree;
 
 #[derive(Debug, thiserror::Error)]
@@ -23,6 +24,20 @@ impl From<merkle_tree::Error> for Error {
 		match err {
 			merkle_tree::Error::Verification(err) => Self::Verification(err.into()),
 			_ => Self::MerkleError(err),
+		}
+	}
+}
+
+impl From<batch::Error> for Error {
+	fn from(err: batch::Error) -> Self {
+		match err {
+			batch::Error::Merkle(err) => err.into(),
+			batch::Error::Transcript(err) => Self::TranscriptError(err),
+			batch::Error::ClaimMismatch { index } => VerificationError::IncorrectFold {
+				query_round: 0,
+				index,
+			}
+			.into(),
 		}
 	}
 }

--- a/crates/iop/src/fri/mod.rs
+++ b/crates/iop/src/fri/mod.rs
@@ -23,6 +23,7 @@
 //! [BBHR17]: <https://eccc.weizmann.ac.il/report/2017/134/>
 //! [DP24]: <https://eprint.iacr.org/2024/504>
 
+mod batch;
 mod common;
 mod error;
 pub mod fold;

--- a/crates/iop/src/fri/size_estimation.rs
+++ b/crates/iop/src/fri/size_estimation.rs
@@ -4,7 +4,7 @@ use std::iter;
 
 use binius_field::BinaryField;
 
-use super::common::{FRIParams, vcs_optimal_layers_depths_iter};
+use super::common::FRIParams;
 use crate::merkle_tree::MerkleTreeScheme;
 
 /// Computes the exact byte-size of a FRI proof (including the initial commitment) without running
@@ -50,21 +50,22 @@ where
 		.collect();
 
 	// Compute the Merkle proof sizes and coset value sizes across all n_oracles non-terminal
-	// oracles. vcs_optimal_layers_depths_iter yields layer depths in the same order as arities.
-	let layer_depths: Vec<usize> = vcs_optimal_layers_depths_iter(params, vcs).collect();
-
+	// oracles.
 	let mut merkle_sizes = 0;
 	let mut coset_values_size = 0;
 	let mut log_n_cosets = params.log_len();
 
-	for (i, &arity) in arities.iter().enumerate() {
+	for &arity in &arities {
 		log_n_cosets -= arity;
+
+		// The optimal layer the verifier decommits once for this oracle's tree.
+		let layer_depth = vcs.optimal_verify_layer(n_test_queries, log_n_cosets);
 
 		// VCS proof_size covers both the 2^layer_depth layer digests sent once AND the
 		// (tree_depth - layer_depth) * n_test_queries branch digests sent across all queries.
 		let tree_len = 1 << log_n_cosets;
 		merkle_sizes += vcs
-			.proof_size(tree_len, n_test_queries, layer_depths[i])
+			.proof_size(tree_len, n_test_queries, layer_depth)
 			.expect("layer depth computed with optimal_verify_layer must be valid");
 
 		// Each query opens a coset of 2^arity field values for this oracle.

--- a/crates/iop/src/fri/verify.rs
+++ b/crates/iop/src/fri/verify.rs
@@ -12,7 +12,7 @@ use binius_utils::DeserializeBytes;
 use bytes::Buf;
 
 use super::{
-	batch::{BrakedownOracle, FRIOracle, ProxTestOracle, fold_coset},
+	batch::{BatchBrakedownOracle, BrakedownOracle, FRIOracle, ProxTestOracle, fold_coset},
 	common::FRIParams,
 	error::{Error, VerificationError},
 };
@@ -23,9 +23,9 @@ use crate::merkle_tree::{Commitment, MerkleTreeScheme};
 /// The verifier is instantiated after the folding rounds and is used to test consistency of the
 /// round messages and the original purported codeword.
 ///
-/// Internally, this is a composition of [`ProxTestOracle`]s: a [`BrakedownOracle`] performs the
-/// first, interleaved reduction of the committed codeword, then one [`FRIOracle`] per fold arity
-/// performs each subsequent FRI reduction. The verifier orchestrates the consistency checks
+/// Internally, this is a composition of `ProxTestOracle`s: a `BatchBrakedownOracle` performs
+/// the first, interleaved reduction of the committed codeword(s), then one `FRIOracle` per fold
+/// arity performs each subsequent FRI reduction. The verifier orchestrates the consistency checks
 /// between these oracles and the final, fully-folded terminal codeword.
 pub struct FRIQueryVerifier<'a, F, VCS>
 where
@@ -38,8 +38,8 @@ where
 	terminal_commitment: &'a VCS::Digest,
 	/// The folding challenges applied after the last committed oracle.
 	final_challenges: &'a [F],
-	/// Performs the first, interleaved reduction of the committed codeword.
-	codeword_oracle: BrakedownOracle<F, &'a VCS>,
+	/// Performs the first, interleaved reduction of the committed codeword(s).
+	codeword_oracle: BatchBrakedownOracle<F, &'a VCS>,
 	/// Performs each subsequent FRI reduction, one per fold arity.
 	fri_oracles: Vec<FRIOracle<F, &'a VCS, GenericOnTheFly<F>>>,
 }
@@ -75,13 +75,18 @@ where
 		// The committed codeword's Merkle tree has one coset per leaf, so its depth is the number
 		// of index bits.
 		let index_bits = params.index_bits();
-		let codeword_oracle = BrakedownOracle::new(
-			challenges[..params.log_batch_size()].to_vec(),
-			Commitment {
-				root: codeword_commitment.clone(),
-				depth: index_bits,
-			},
-			vcs,
+		// A single committed codeword (one-item batch) needs no batching weighting, so the outer
+		// challenges are empty and the combination reduces to the lone oracle's folded values.
+		let codeword_oracle = BatchBrakedownOracle::new(
+			vec![BrakedownOracle::new(
+				challenges[..params.log_batch_size()].to_vec(),
+				Commitment {
+					root: codeword_commitment.clone(),
+					depth: index_bits,
+				},
+				vcs,
+			)],
+			Vec::new(),
 		);
 
 		// All FRI reductions fold cosets of the same Reed–Solomon codeword domain, so they share a

--- a/crates/iop/src/fri/verify.rs
+++ b/crates/iop/src/fri/verify.rs
@@ -101,6 +101,7 @@ where
 	where
 		Challenger_: Challenger,
 	{
+		// TODO: We can prob take in this ntt as a struct param.
 		let subspace = self.params.rs_code().subspace();
 		let domain_context = GenericOnTheFly::generate_from_subspace(subspace);
 		let ntt = NeighborsLastSingleThread::new(domain_context);

--- a/crates/iop/src/fri/verify.rs
+++ b/crates/iop/src/fri/verify.rs
@@ -1,50 +1,47 @@
 // Copyright 2024-2025 Irreducible Inc.
 
-use std::iter;
+use std::iter::{self, repeat_with};
 
 use binius_field::BinaryField;
-use binius_math::{
-	FieldBuffer,
-	multilinear::eq::eq_ind_partial_eval,
-	ntt::{AdditiveNTT, NeighborsLastSingleThread, domain_context::GenericOnTheFly},
-};
+use binius_math::ntt::domain_context::GenericOnTheFly;
 use binius_transcript::{
 	TranscriptReader, VerifierTranscript,
 	fiat_shamir::{CanSampleBits, Challenger},
 };
 use binius_utils::DeserializeBytes;
 use bytes::Buf;
-use itertools::izip;
 
 use super::{
-	common::{FRIParams, vcs_optimal_layers_depths_iter},
+	batch::{BrakedownOracle, FRIOracle, ProxTestOracle, fold_coset},
+	common::FRIParams,
 	error::{Error, VerificationError},
 };
-use crate::{
-	fri::fold::{fold_chunk, fold_interleaved_chunk},
-	merkle_tree::MerkleTreeScheme,
-};
+use crate::merkle_tree::{Commitment, MerkleTreeScheme};
 
 /// A verifier for the FRI query phase.
 ///
 /// The verifier is instantiated after the folding rounds and is used to test consistency of the
 /// round messages and the original purported codeword.
-#[derive(Debug)]
+///
+/// Internally, this is a composition of [`ProxTestOracle`]s: a [`BrakedownOracle`] performs the
+/// first, interleaved reduction of the committed codeword, then one [`FRIOracle`] per fold arity
+/// performs each subsequent FRI reduction. The verifier orchestrates the consistency checks
+/// between these oracles and the final, fully-folded terminal codeword.
 pub struct FRIQueryVerifier<'a, F, VCS>
 where
 	F: BinaryField,
 	VCS: MerkleTreeScheme<F>,
 {
-	vcs: &'a VCS,
 	params: &'a FRIParams<F>,
-	/// Received commitment to the codeword.
-	codeword_commitment: &'a VCS::Digest,
-	/// Received commitments to the round messages.
-	round_commitments: &'a [VCS::Digest],
-	/// The challenges for each round.
-	interleave_tensor: FieldBuffer<F>,
-	/// The challenges for each round.
-	fold_challenges: &'a [F],
+	vcs: &'a VCS,
+	/// Commitment to the fully-folded terminal codeword, sent in full by the prover.
+	terminal_commitment: &'a VCS::Digest,
+	/// The folding challenges applied after the last committed oracle.
+	final_challenges: &'a [F],
+	/// Performs the first, interleaved reduction of the committed codeword.
+	codeword_oracle: BrakedownOracle<F, &'a VCS>,
+	/// Performs each subsequent FRI reduction, one per fold arity.
+	fri_oracles: Vec<FRIOracle<F, &'a VCS, GenericOnTheFly<F>>>,
 }
 
 impl<'a, F, VCS> FRIQueryVerifier<'a, F, VCS>
@@ -52,7 +49,6 @@ where
 	F: BinaryField,
 	VCS: MerkleTreeScheme<F, Digest: DeserializeBytes>,
 {
-	#[allow(clippy::too_many_arguments)]
 	pub fn new(
 		params: &'a FRIParams<F>,
 		vcs: &'a VCS,
@@ -76,16 +72,50 @@ where
 			)));
 		}
 
-		let (interleave_challenges, fold_challenges) = challenges.split_at(params.log_batch_size());
+		// The committed codeword's Merkle tree has one coset per leaf, so its depth is the number
+		// of index bits.
+		let index_bits = params.index_bits();
+		let codeword_oracle = BrakedownOracle::new(
+			challenges[..params.log_batch_size()].to_vec(),
+			Commitment {
+				root: codeword_commitment.clone(),
+				depth: index_bits,
+			},
+			vcs,
+		);
 
-		let interleave_tensor = eq_ind_partial_eval(interleave_challenges);
+		// All FRI reductions fold cosets of the same Reed–Solomon codeword domain, so they share a
+		// single domain context.
+		let domain_context = GenericOnTheFly::generate_from_subspace(params.rs_code().subspace());
+		let mut fri_oracles = Vec::with_capacity(params.fold_arities().len());
+		let mut depth = index_bits;
+		let mut fold_round = params.log_batch_size();
+		for (round_commitment, &arity) in iter::zip(round_commitments, params.fold_arities()) {
+			depth -= arity;
+			fri_oracles.push(FRIOracle::new(
+				challenges[fold_round..fold_round + arity].to_vec(),
+				Commitment {
+					root: round_commitment.clone(),
+					depth,
+				},
+				vcs,
+				domain_context.clone(),
+			));
+			fold_round += arity;
+		}
+
+		let final_challenges = &challenges[fold_round..];
+		let terminal_commitment = round_commitments
+			.last()
+			.expect("round_commitments is non-empty as an invariant");
+
 		Ok(Self {
 			params,
 			vcs,
-			codeword_commitment,
-			round_commitments,
-			interleave_tensor,
-			fold_challenges,
+			terminal_commitment,
+			final_challenges,
+			codeword_oracle,
+			fri_oracles,
 		})
 	}
 
@@ -101,84 +131,90 @@ where
 	where
 		Challenger_: Challenger,
 	{
-		// TODO: We can prob take in this ntt as a struct param.
-		let subspace = self.params.rs_code().subspace();
-		let domain_context = GenericOnTheFly::generate_from_subspace(subspace);
-		let ntt = NeighborsLastSingleThread::new(domain_context);
+		// Sample all query indices up front to facilitate batched Merkle openings.
+		let mut indices = repeat_with(|| transcript.sample_bits(self.params.index_bits()) as usize)
+			.take(self.params.n_test_queries())
+			.collect::<Vec<_>>();
 
-		// Verify that the last oracle sent is a codeword.
-		let terminate_codeword_len =
-			1 << (self.params.n_final_challenges() + self.params.rs_code().log_inv_rate());
+		// Open and reduce the queries through each oracle in turn, reading the per-oracle batched
+		// openings from a single continuous decommitment stream.
 		let mut advice = transcript.decommitment();
-		let terminate_codeword = advice
-			.read_scalar_slice(terminate_codeword_len)
-			.map_err(Error::TranscriptError)?;
-		let final_value = self.verify_last_oracle(&ntt, &terminate_codeword, &mut advice)?;
-
-		// Verify that the provided layers match the commitments.
-		let layers = vcs_optimal_layers_depths_iter(self.params, self.vcs)
-			.map(|layer_depth| advice.read_vec(1 << layer_depth))
-			.collect::<Result<Vec<_>, _>>()?;
-		for (commitment, layer_depth, layer) in izip!(
-			iter::once(self.codeword_commitment).chain(self.round_commitments),
-			vcs_optimal_layers_depths_iter(self.params, self.vcs),
-			&layers
-		) {
-			self.vcs.verify_layer(commitment, layer_depth, layer)?;
+		let mut claims = self.codeword_oracle.open_queries(&indices, &mut advice)?;
+		for (query_round, (oracle, &arity)) in self
+			.fri_oracles
+			.iter()
+			.zip(self.params.fold_arities())
+			.enumerate()
+		{
+			claims = oracle
+				.reduce_queries(&indices, &claims, &mut advice)
+				.map_err(|err| match err {
+					super::batch::Error::ClaimMismatch { index } => {
+						VerificationError::IncorrectFold { query_round, index }.into()
+					}
+					err => Error::from(err),
+				})?;
+			for index in &mut indices {
+				*index >>= arity;
+			}
 		}
 
-		// Verify the random openings against the decommitted layers.
-		for _ in 0..self.params.n_test_queries() {
-			let index = transcript.sample_bits(self.params.index_bits()) as usize;
-			self.verify_query(
-				index,
-				&ntt,
-				&terminate_codeword,
-				&layers,
-				&mut transcript.decommitment(),
-			)?
-		}
-
-		Ok(final_value)
+		// Check the fully-reduced queries against the terminal codeword sent in full.
+		self.verify_terminal_queries(&claims, &indices, &mut advice)
 	}
 
-	/// Verifies that the last oracle sent is a codeword.
+	/// Verifies the terminal codeword the prover sends in full at the end of the query phase.
 	///
-	/// Returns the fully-folded message value.
-	pub fn verify_last_oracle<B: Buf>(
+	/// Reads the terminal codeword from the transcript and checks it against its commitment, then
+	/// checks that the fully-reduced query `claims` match it at the queried `indices`. Finally it
+	/// folds each coset of the terminal codeword and checks they are equal, i.e. that it is a
+	/// repetition codeword of the claimed low degree, and returns the fully-folded message value.
+	fn verify_terminal_queries<B: Buf>(
 		&self,
-		ntt: &impl AdditiveNTT<Field = F>,
-		terminate_codeword: &[F],
+		claims: &[F],
+		indices: &[usize],
 		advice: &mut TranscriptReader<B>,
 	) -> Result<F, Error> {
 		let n_final_challenges = self.params.n_final_challenges();
-		let terminal_commitment = self
-			.round_commitments
-			.last()
-			.expect("round_commitments is non-empty as an invariant");
+		let log_inv_rate = self.params.rs_code().log_inv_rate();
+		let terminate_codeword_len = 1 << (n_final_challenges + log_inv_rate);
 
+		let terminate_codeword = advice
+			.read_scalar_slice::<F>(terminate_codeword_len)
+			.map_err(Error::TranscriptError)?;
 		self.vcs.verify_vector(
-			terminal_commitment,
-			terminate_codeword,
+			self.terminal_commitment,
+			&terminate_codeword,
 			1 << n_final_challenges,
 			advice,
 		)?;
 
-		let n_prior_challenges = self.fold_challenges.len() - n_final_challenges;
-		let final_challenges = &self.fold_challenges[n_prior_challenges..];
+		// Check the fully-reduced claims against the terminal codeword the verifier holds in full.
+		for (&claim, &index) in iter::zip(claims, indices) {
+			if claim != terminate_codeword[index] {
+				return Err(VerificationError::IncorrectFold {
+					query_round: self.n_oracles() - 1,
+					index,
+				}
+				.into());
+			}
+		}
 
-		let mut scratch_buffer = vec![F::default(); 1 << n_final_challenges];
+		// Fold each coset of the terminal codeword and check that the folds are all equal, i.e.
+		// that the codeword has the claimed low degree.
+		let domain_context =
+			GenericOnTheFly::generate_from_subspace(self.params.rs_code().subspace());
+		let log_len = n_final_challenges + log_inv_rate;
 		let repetition_codeword = terminate_codeword
 			.chunks(1 << n_final_challenges)
 			.enumerate()
-			.map(|(i, coset_values)| {
-				scratch_buffer.copy_from_slice(coset_values);
-				fold_chunk(
-					ntt,
-					n_final_challenges + self.params.rs_code().log_inv_rate(),
-					i,
-					&mut scratch_buffer,
-					final_challenges,
+			.map(|(coset_index, coset)| {
+				fold_coset(
+					&domain_context,
+					log_len,
+					coset_index,
+					self.final_challenges,
+					coset.to_vec(),
 				)
 			})
 			.collect::<Vec<_>>();
@@ -195,125 +231,4 @@ where
 
 		Ok(final_value)
 	}
-
-	/// Verifies a FRI challenge query.
-	///
-	/// A FRI challenge query tests for consistency between all consecutive oracles sent by the
-	/// prover. The verifier has full access to the last oracle sent, and this is probabilistically
-	/// verified to be a codeword by `Self::verify_last_oracle`.
-	///
-	/// ## Arguments
-	///
-	/// * `index` - an index into the original codeword domain
-	/// * `proof` - a query proof
-	pub fn verify_query<B: Buf>(
-		&self,
-		mut index: usize,
-		ntt: &impl AdditiveNTT<Field = F>,
-		terminate_codeword: &[F],
-		layers: &[Vec<VCS::Digest>],
-		advice: &mut TranscriptReader<B>,
-	) -> Result<(), Error> {
-		let mut layer_depths_iter = vcs_optimal_layers_depths_iter(self.params, self.vcs);
-		let mut layers_iter = layers.iter();
-
-		// Check the first fold round before the main loop. It is special because in the first
-		// round we need to fold as an interleaved chunk instead of a regular coset.
-		let first_layer_depth = layer_depths_iter
-			.next()
-			.expect("protocol guarantees at least one commitment opening");
-		let first_layer = layers_iter
-			.next()
-			.expect("protocol guarantees at least one commitment opening");
-		let values = verify_coset_opening(
-			self.vcs,
-			index,
-			self.params.log_batch_size(),
-			first_layer_depth,
-			self.params.index_bits(),
-			first_layer,
-			advice,
-		)?;
-		let mut next_value = fold_interleaved_chunk(
-			self.params.log_batch_size(),
-			&values,
-			self.interleave_tensor.as_ref(),
-		);
-
-		// This is the round of the folding phase that the codeword to be folded is committed to.
-		let mut fold_round = 0;
-		let mut log_n_cosets = self.params.index_bits();
-		for (i, (&arity, layer, optimal_layer_depth)) in
-			izip!(self.params.fold_arities(), layers_iter, layer_depths_iter).enumerate()
-		{
-			let coset_index = index >> arity;
-			log_n_cosets -= arity;
-
-			let mut values = verify_coset_opening(
-				self.vcs,
-				coset_index,
-				arity,
-				optimal_layer_depth,
-				log_n_cosets,
-				layer,
-				advice,
-			)?;
-
-			if next_value != values[index % (1 << arity)] {
-				return Err(VerificationError::IncorrectFold {
-					query_round: i,
-					index,
-				}
-				.into());
-			}
-
-			next_value = fold_chunk(
-				ntt,
-				self.params.rs_code().log_len() - fold_round,
-				coset_index,
-				&mut values,
-				&self.fold_challenges[fold_round..fold_round + arity],
-			);
-			index = coset_index;
-			fold_round += arity;
-		}
-
-		if next_value != terminate_codeword[index] {
-			return Err(VerificationError::IncorrectFold {
-				query_round: self.n_oracles() - 1,
-				index,
-			}
-			.into());
-		}
-
-		Ok(())
-	}
-}
-
-/// Verifies that the coset opening provided in the proof is consistent with the VCS commitment.
-#[allow(clippy::too_many_arguments)]
-fn verify_coset_opening<F, MTScheme, B>(
-	vcs: &MTScheme,
-	coset_index: usize,
-	log_coset_size: usize,
-	optimal_layer_depth: usize,
-	tree_depth: usize,
-	layer_digests: &[MTScheme::Digest],
-	advice: &mut TranscriptReader<B>,
-) -> Result<Vec<F>, Error>
-where
-	F: BinaryField,
-	MTScheme: MerkleTreeScheme<F>,
-	B: Buf,
-{
-	let values = advice.read_scalar_slice::<F>(1 << log_coset_size)?;
-	vcs.verify_opening(
-		coset_index,
-		&values,
-		optimal_layer_depth,
-		tree_depth,
-		layer_digests,
-		advice,
-	)?;
-	Ok(values)
 }

--- a/crates/iop/src/fri/verify.rs
+++ b/crates/iop/src/fri/verify.rs
@@ -56,6 +56,35 @@ where
 		round_commitments: &'a [VCS::Digest],
 		challenges: &'a [F],
 	) -> Result<Self, Error> {
+		Self::new_batch(
+			params,
+			vcs,
+			std::slice::from_ref(codeword_commitment),
+			round_commitments,
+			challenges,
+		)
+	}
+
+	/// Constructs a query verifier for a batch of committed input oracles.
+	///
+	/// The input oracles share the Reed-Solomon code but may have differing batch sizes; they are
+	/// reduced into a single first-round FRI oracle. The commitments must be supplied in the same
+	/// order as [`FRIParams::input_oracles`].
+	pub fn new_batch(
+		params: &'a FRIParams<F>,
+		vcs: &'a VCS,
+		codeword_commitments: &'a [VCS::Digest],
+		round_commitments: &'a [VCS::Digest],
+		challenges: &'a [F],
+	) -> Result<Self, Error> {
+		if codeword_commitments.len() != params.input_oracles().len() {
+			return Err(Error::InvalidArgs(format!(
+				"got {} codeword commitments, expected {}",
+				codeword_commitments.len(),
+				params.input_oracles().len(),
+			)));
+		}
+
 		if round_commitments.len() != params.n_oracles() {
 			return Err(Error::InvalidArgs(format!(
 				"got {} round commitments, expected {}",
@@ -72,22 +101,45 @@ where
 			)));
 		}
 
+		// Temporary restriction: lifted FRI is not yet implemented, so every input oracle must
+		// reduce to exactly the first-round Reed-Solomon code. FRIParams only guarantees the
+		// inequality `log_msg_len - log_batch_size <= rs_code.log_dim()`.
+		let log_dim = params.rs_code().log_dim();
+		for spec in params.input_oracles() {
+			assert_eq!(
+				spec.log_msg_len - spec.log_batch_size,
+				log_dim,
+				"lifted FRI is unsupported: input oracle dimension must equal rs_code.log_dim()"
+			);
+		}
+
 		// The committed codeword's Merkle tree has one coset per leaf, so its depth is the number
 		// of index bits.
 		let index_bits = params.index_bits();
-		// A single committed codeword (one-item batch) needs no batching weighting, so the outer
-		// challenges are empty and the combination reduces to the lone oracle's folded values.
-		let codeword_oracle = BatchBrakedownOracle::new(
-			vec![BrakedownOracle::new(
-				challenges[..params.log_batch_size()].to_vec(),
-				Commitment {
-					root: codeword_commitment.clone(),
-					depth: index_bits,
-				},
-				vcs,
-			)],
-			Vec::new(),
-		);
+		// The first fold consumes `log_batch_size()` challenges, split into the inner challenges
+		// (folding each input oracle's interleaving) and the outer challenges (batching the oracles
+		// together). Oracle `i` uses the last `log_batch_size_i` inner challenges.
+		let max_log_batch_size = params
+			.input_oracles()
+			.iter()
+			.map(|spec| spec.log_batch_size)
+			.max()
+			.expect("input_oracles is non-empty as an invariant");
+		let inner_challenges = &challenges[..max_log_batch_size];
+		let outer_challenges = challenges[max_log_batch_size..params.log_batch_size()].to_vec();
+		let codeword_sub_oracles = iter::zip(codeword_commitments, params.input_oracles())
+			.map(|(commitment, spec)| {
+				BrakedownOracle::new(
+					inner_challenges[max_log_batch_size - spec.log_batch_size..].to_vec(),
+					Commitment {
+						root: commitment.clone(),
+						depth: index_bits,
+					},
+					vcs,
+				)
+			})
+			.collect();
+		let codeword_oracle = BatchBrakedownOracle::new(codeword_sub_oracles, outer_challenges);
 
 		// All FRI reductions fold cosets of the same Reed–Solomon codeword domain, so they share a
 		// single domain context.

--- a/crates/iop/src/merkle_tree/merkle_tree_vcs.rs
+++ b/crates/iop/src/merkle_tree/merkle_tree_vcs.rs
@@ -1,5 +1,6 @@
 // Copyright 2024-2025 Irreducible Inc.
 
+use auto_impl::auto_impl;
 use binius_transcript::{Buf, TranscriptReader};
 
 use super::error::Error;
@@ -17,6 +18,7 @@ pub struct Commitment<Digest> {
 }
 
 /// A Merkle tree scheme.
+#[auto_impl(&)]
 pub trait MerkleTreeScheme<T> {
 	type Digest: Clone + PartialEq + Eq;
 

--- a/crates/math/src/ntt/domain_context.rs
+++ b/crates/math/src/ntt/domain_context.rs
@@ -51,7 +51,7 @@ fn generate_evals_from_subspace<F: BinaryField>(subspace: &BinarySubspace<F>) ->
 /// folding. In both cases, all twiddles will be accessed eventually, so they might as well be
 /// precomputed. But it could possibly be used e.g. in the FRI verifier, which only accesses a few
 /// selected twiddles.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct GenericOnTheFly<F> {
 	/// The subspace polynomial evaluations.
 	///


### PR DESCRIPTION
## Summary
- Rebuild the FRI query phase around a modular `ProxTestOracle` / `ProxTestOracleProver` abstraction: a Brakedown oracle for the interleaved reduction and one FRI oracle per fold arity, sharing common Merkle opening logic.
- Separate the first fold from later folds in `FRIFoldProver` via an explicit state machine, and compose `FRIQueryProver` from the per-oracle provers.
- Batch multiple committed input oracles into the single first-round codeword: `BatchBrakedownFolder` / `BatchBrakedownOracleProver` (prover) and `BatchBrakedownOracle` (verifier), combined via the outer-challenge tensor expansion.
- Wire multi-oracle support through `FRIFoldProver::new_batch` and `FRIQueryVerifier::new_batch` (single-oracle `new` delegates), with a temporary assertion that each input oracle reduces exactly to the first-round code (lifted FRI not yet implemented).

## Test plan
- `cargo test -p binius-iop -p binius-iop-prover`
- New `test_commit_prove_verify_batched_multi_oracle` (3 oracles, one shared RS code, log_batch_sizes 1/1/2) checks the verifier's final value equals the independently computed tensor-weighted combination of per-oracle evaluations.
- `cargo clippy -p binius-iop -p binius-iop-prover --all-features --tests -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
