### PR TITLE
Dependency upgrade sweep (criterion, sha3, ripemd, derive_more, cranelift-entity, peakmem-alloc)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,13 @@ cfg-if = "1.0.0"
 clap = { version = "4.5", features = ["derive"] }
 cranelift-entity = "0.132.0"
 criterion = { version = "0.8.0", default-features = false }
-derive_more = "0.99.17"
+derive_more = { version = "2.1.1", features = [
+    "add",
+    "add_assign",
+    "from",
+    "into",
+    "into_iterator",
+] }
 digest = "0.11.2"
 either = "1.11.0"
 getrandom = "0.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ seq-macro = "0.3.5"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 sha2 = "0.11.0"
-sha3 = "0.11.0"
+sha3 = "0.12.0"
 insta = "1.43.1"
 petgraph = "0.8.2"
 rustc-hash = "2.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ bytes = "1.7.2"
 cfg-if = "1.0.0"
 clap = { version = "4.5", features = ["derive"] }
 cranelift-entity = "0.121.1"
-criterion = { version = "0.7.0", default-features = false }
+criterion = { version = "0.8.0", default-features = false }
 derive_more = "0.99.17"
 digest = "0.11.2"
 either = "1.11.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ bytemuck = { version = "1.18.0", features = [
 bytes = "1.7.2"
 cfg-if = "1.0.0"
 clap = { version = "4.5", features = ["derive"] }
-cranelift-entity = "0.121.1"
+cranelift-entity = "0.132.0"
 criterion = { version = "0.8.0", default-features = false }
 derive_more = "0.99.17"
 digest = "0.11.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ rand = { version = "0.10.1", default-features = false, features = [
 ] }
 rayon = "1.10.0"
 regex = "1.10"
-ripemd = "0.1.3"
+ripemd = "0.2.0"
 rsa = { version = "0.9.8", features = ["sha2"] }
 rstest = "0.26.1"
 seq-macro = "0.3.5"

--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -26,7 +26,7 @@ digest.workspace = true
 ethsign = "0.9.0"
 hex.workspace = true
 jwt-simple.workspace = true
-peakmem-alloc = "0.2.0"
+peakmem-alloc = "0.3.0"
 rand = { workspace = true, features = ["thread_rng"] }
 sha2.workspace = true
 sha3.workspace = true

--- a/crates/examples/benches/blake2b.rs
+++ b/crates/examples/benches/blake2b.rs
@@ -6,13 +6,13 @@ use std::alloc::System;
 
 use binius_examples::circuits::blake2b::{Blake2bExample, Instance, Params};
 use criterion::{Criterion, Throughput, criterion_group, criterion_main};
-use peakmem_alloc::PeakAlloc;
+use peakmem_alloc::PeakMemAlloc;
 use utils::{ExampleBenchmark, HashBenchConfig, print_benchmark_header, run_cs_benchmark};
 
 // Global allocator that tracks peak memory usage
 
 #[global_allocator]
-static BLAKE2B_PEAK_ALLOC: PeakAlloc<System> = PeakAlloc::new(System);
+static BLAKE2B_PEAK_ALLOC: PeakMemAlloc<System> = PeakMemAlloc::new(System);
 
 struct Blake2bBenchmark {
 	config: HashBenchConfig,

--- a/crates/examples/benches/blake2s.rs
+++ b/crates/examples/benches/blake2s.rs
@@ -7,12 +7,12 @@ use std::alloc::System;
 
 use binius_examples::circuits::blake2s::{Blake2sExample, Instance, Params};
 use criterion::{Criterion, Throughput, criterion_group, criterion_main};
-use peakmem_alloc::PeakAlloc;
+use peakmem_alloc::PeakMemAlloc;
 use utils::{ExampleBenchmark, HashBenchConfig, print_benchmark_header, run_cs_benchmark};
 
 // Global allocator that tracks peak memory usage
 #[global_allocator]
-static BLAKE2S_PEAK_ALLOC: PeakAlloc<System> = PeakAlloc::new(System);
+static BLAKE2S_PEAK_ALLOC: PeakMemAlloc<System> = PeakMemAlloc::new(System);
 
 struct Blake2sBenchmark {
 	config: HashBenchConfig,

--- a/crates/examples/benches/ethsign.rs
+++ b/crates/examples/benches/ethsign.rs
@@ -6,12 +6,12 @@ use std::{alloc::System, env};
 
 use binius_examples::circuits::ethsign::{EthSignExample, Instance, Params};
 use criterion::{Criterion, Throughput, criterion_group, criterion_main};
-use peakmem_alloc::PeakAlloc;
+use peakmem_alloc::PeakMemAlloc;
 use utils::{ExampleBenchmark, SignBenchConfig, print_benchmark_header, run_cs_benchmark};
 
 // Global allocator that tracks peak memory usage
 #[global_allocator]
-static ETHSIGN_PEAK_ALLOC: PeakAlloc<System> = PeakAlloc::new(System);
+static ETHSIGN_PEAK_ALLOC: PeakMemAlloc<System> = PeakMemAlloc::new(System);
 
 struct EthSignBenchmark {
 	config: SignBenchConfig,

--- a/crates/examples/benches/hashsign.rs
+++ b/crates/examples/benches/hashsign.rs
@@ -6,12 +6,12 @@ use std::{alloc::System, env};
 
 use binius_examples::circuits::hashsign::{HashBasedSigExample, Instance, Params};
 use criterion::{Criterion, Throughput, criterion_group, criterion_main};
-use peakmem_alloc::PeakAlloc;
+use peakmem_alloc::PeakMemAlloc;
 use utils::{ExampleBenchmark, SignBenchConfig, print_benchmark_header, run_cs_benchmark};
 
 // Global allocator that tracks peak memory usage
 #[global_allocator]
-static HASHSIGN_PEAK_ALLOC: PeakAlloc<System> = PeakAlloc::new(System);
+static HASHSIGN_PEAK_ALLOC: PeakMemAlloc<System> = PeakMemAlloc::new(System);
 
 struct HashSignBenchmark {
 	config: SignBenchConfig,

--- a/crates/examples/benches/keccak.rs
+++ b/crates/examples/benches/keccak.rs
@@ -6,12 +6,12 @@ use std::alloc::System;
 
 use binius_examples::circuits::keccak::{Instance, KeccakExample, Params};
 use criterion::{Criterion, Throughput, criterion_group, criterion_main};
-use peakmem_alloc::PeakAlloc;
+use peakmem_alloc::PeakMemAlloc;
 use utils::{ExampleBenchmark, HashBenchConfig, print_benchmark_header, run_cs_benchmark};
 
 // Global allocator that tracks peak memory usage
 #[global_allocator]
-static KECCAK_PEAK_ALLOC: PeakAlloc<System> = PeakAlloc::new(System);
+static KECCAK_PEAK_ALLOC: PeakMemAlloc<System> = PeakMemAlloc::new(System);
 
 struct KeccakBenchmark {
 	config: HashBenchConfig,

--- a/crates/examples/benches/sha256.rs
+++ b/crates/examples/benches/sha256.rs
@@ -7,12 +7,12 @@ use std::alloc::System;
 
 use binius_examples::circuits::sha256::{Instance, Params, Sha256Example};
 use criterion::{Criterion, Throughput, criterion_group, criterion_main};
-use peakmem_alloc::PeakAlloc;
+use peakmem_alloc::PeakMemAlloc;
 use utils::{ExampleBenchmark, HashBenchConfig, print_benchmark_header, run_cs_benchmark};
 
 // Global allocator that tracks peak memory usage
 #[global_allocator]
-static SHA256_PEAK_ALLOC: PeakAlloc<System> = PeakAlloc::new(System);
+static SHA256_PEAK_ALLOC: PeakMemAlloc<System> = PeakMemAlloc::new(System);
 
 struct Sha256Benchmark {
 	config: HashBenchConfig,

--- a/crates/examples/benches/sha512.rs
+++ b/crates/examples/benches/sha512.rs
@@ -7,12 +7,12 @@ use std::alloc::System;
 
 use binius_examples::circuits::sha512::{Instance, Params, Sha512Example};
 use criterion::{Criterion, Throughput, criterion_group, criterion_main};
-use peakmem_alloc::PeakAlloc;
+use peakmem_alloc::PeakMemAlloc;
 use utils::{ExampleBenchmark, HashBenchConfig, print_benchmark_header, run_cs_benchmark};
 
 // Global allocator that tracks peak memory usage
 #[global_allocator]
-static SHA512_PEAK_ALLOC: PeakAlloc<System> = PeakAlloc::new(System);
+static SHA512_PEAK_ALLOC: PeakMemAlloc<System> = PeakMemAlloc::new(System);
 
 struct Sha512Benchmark {
 	config: HashBenchConfig,

--- a/crates/examples/benches/utils/runner.rs
+++ b/crates/examples/benches/utils/runner.rs
@@ -12,7 +12,7 @@ use binius_verifier::{
 	transcript::{ProverTranscript, VerifierTranscript},
 };
 use criterion::{BenchmarkId, Criterion, Throughput};
-use peakmem_alloc::PeakAllocTrait;
+use peakmem_alloc::PeakMemAllocTrait;
 
 /// Trait for standardized constraint system benchmarks
 pub trait ExampleBenchmark {
@@ -58,7 +58,7 @@ pub fn run_cs_benchmark<B: ExampleBenchmark>(
 	c: &mut Criterion,
 	benchmark: B,
 	group_prefix: &str,
-	peak_alloc: &impl PeakAllocTrait,
+	peak_alloc: &impl PeakMemAllocTrait,
 ) {
 	use super::reporting::{print_env_help, print_memory_stats, print_proof_size};
 


### PR DESCRIPTION
## Summary

Dependency maintenance sweep over the workspace's upgradable crates. Each
dependency was bumped, built, and tested in isolation; only upgrades that went
through cleanly (or with purely mechanical changes) are included here. Each is a
separate commit so they can be reviewed or reverted independently.

Note: `Cargo.lock` is gitignored, so every commit is just the `Cargo.toml`
change.

## Upgrades included

| Dep | Bump | Notes |
|---|---|---|
| `criterion` | 0.7 → 0.8.2 | no source changes; benches compile |
| `ripemd` | 0.1.3 → 0.2.0 | no source changes; circuits tests pass |
| `sha3` | 0.11 → 0.12 | no source changes; all 328 `binius-circuits` tests pass |
| `peakmem-alloc` | 0.2 → 0.3 | mechanical rename `PeakAlloc`→`PeakMemAlloc` / `PeakAllocTrait`→`PeakMemAllocTrait` across 8 bench harnesses |
| `cranelift-entity` | 0.121 → 0.132 | no source changes; 147 `binius-frontend` tests pass |
| `derive_more` | 0.99 → 2.1.1 | added per-derive feature flags (`add`, `add_assign`, `from`, `into`, `into_iterator`); no source changes |

## Deliberately left out

These were attempted and abandoned as non-trivial — listed here so they're not
silently dropped:

- **`z3` (0.13 → 0.20)** — major API break (removes the `'ctx` lifetime, changes
  nearly every constructor). 35 compile errors; needs a substantial rewrite of
  `smt_check.rs` + `main.rs`.
- **`bitcoin_hashes` (0.14 → 1.0)** — blocked by `bitcoin v0.32.7` (pins
  `bitcoin_hashes ^0.14`); requires a coupled `bitcoin` major bump plus an API
  change (`to_byte_array`→`as_byte_array`).
- **`jwt-simple` (0.12.16) + `superboring` (0.1.11)** — coupled; forces in
  `ml-dsa v0.1.0-rc.11` (a pre-release), which is the documented reason for the
  deliberate `superboring = "=0.1.8"` pin. Compiles, but reverses an intentional
  decision — left for a human call.
- **`generic-array` (0.14.7 → 0.14.9)** — pinned to `=0.14.7` by `crypto-common`
  in the `digest 0.10` stack; can't move without bumping the digest ecosystem.

## Caveat

The `derive_more` bump could not compile-check the **wasm32-only `m128.rs`** path
(no wasm32 target on the build host). Its derives are standard `From`/`Into` on a
newtype, so almost certainly fine, but unverified here. To confirm:
`rustup target add wasm32-unknown-unknown && cargo check -p binius-field --target wasm32-unknown-unknown`.

## Test plan

- `cargo check --workspace --all-targets --all-features` (clean)
- Per-upgrade: `cargo test` on the affected crate(s) — see table above

🤖 Generated with [Claude Code](https://claude.com/claude-code)
