### PR TITLE
Upgrade jwt-simple to 0.12.16 and drop superboring pin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ profile.json
 Cargo.lock
 CLAUDE.local.md
 .claude/settings.local.json
+.claude/local/
 /.idea/
 **/.DS_Store
 /.vscode

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ hex-literal = "1.0.0"
 hmac = "0.13.0"
 hybrid-array = "0.4.7"
 itertools = "0.14.0"
-jwt-simple = { version = "0.12.14", default-features = false, features = [
+jwt-simple = { version = "0.12.16", default-features = false, features = [
     "pure-rust",
 ] }
 k256 = "0.13.4"

--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -30,9 +30,6 @@ peakmem-alloc = "0.3.0"
 rand = { workspace = true, features = ["thread_rng"] }
 sha2.workspace = true
 sha3.workspace = true
-# Pin this dependency of jwt-simple because the latest version depends on an RC for ml-dsa and is
-# causing issues.
-superboring = "=0.1.8"
 tiny-keccak = "2.0.2"
 tracing-profile.workspace = true
 tracing.workspace = true


### PR DESCRIPTION
## Summary
- Bump workspace `jwt-simple` 0.12.14 -> 0.12.16.
- Remove the `superboring = "=0.1.8"` pin (and its comment) from
  `binius-examples`. superboring was declared only to pin a transitive
  dependency of jwt-simple and is not used directly; it now resolves
  transitively at 0.1.11. This knowingly accepts the pre-release
  ml-dsa (0.1.0-rc.x) the pin was avoiding.
- Also bundles a small `[chore] gitignore .claude/local directory` commit.

## Test plan
- `cargo check --workspace --all-targets --all-features` (clean)
- `cargo test -p binius-examples` (15 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
