### PR TITLE
[prover] Run bitand reduced prover over packed fields

### DIFF
--- a/crates/prover/src/and_reduction/prover.rs
+++ b/crates/prover/src/and_reduction/prover.rs
@@ -48,8 +48,7 @@ impl<FChallenge, PNTTDomain> OblongZerocheckProver<FChallenge, PNTTDomain>
 where
 	FChallenge: Field + From<PNTTDomain::Scalar> + BinaryField,
 	PNTTDomain: PackedField + PackedExtension<B1, PackedSubfield = PackedBinaryField128x1b>,
-	u8: From<PNTTDomain::Scalar>,
-	PNTTDomain::Scalar: From<u8> + BinaryField,
+	PNTTDomain::Scalar: BinaryField,
 {
 	/// Creates a new oblong zerocheck prover for AND constraint reduction.
 	///

--- a/crates/prover/src/and_reduction/prover.rs
+++ b/crates/prover/src/and_reduction/prover.rs
@@ -1,4 +1,6 @@
 // Copyright 2025 Irreducible Inc.
+use std::marker::PhantomData;
+
 use binius_core::word::Word;
 use binius_field::{
 	BinaryField, Field, PackedBinaryField128x1b, PackedExtension, PackedField,
@@ -30,10 +32,15 @@ use crate::{
 /// Prover for the AND constraint reduction protocol via oblong univariate zerocheck.
 ///
 /// See [`binius_verifier::protocols::bitand`] for the protocol specification.
-pub struct OblongZerocheckProver<FChallenge, PNTTDomain>
+///
+/// The type parameter `PChallenge` is the packed field over the challenge field `FChallenge` used
+/// for the multilinear sumcheck rounds that follow the univariate round. Packing these rounds over
+/// a wide field provides SIMD acceleration.
+pub struct OblongZerocheckProver<FChallenge, PNTTDomain, PChallenge>
 where
 	FChallenge: Field + From<PNTTDomain::Scalar> + BinaryField,
 	PNTTDomain: PackedField,
+	PChallenge: PackedField<Scalar = FChallenge>,
 {
 	first_col: Vec<Word>,
 	second_col: Vec<Word>,
@@ -42,13 +49,15 @@ where
 	small_field_zerocheck_challenges: Vec<PNTTDomain::Scalar>,
 	univariate_round_message: [FChallenge; ROWS_PER_HYPERCUBE_VERTEX],
 	univariate_round_message_domain: BinarySubspace<FChallenge>,
+	_marker: PhantomData<PChallenge>,
 }
 
-impl<FChallenge, PNTTDomain> OblongZerocheckProver<FChallenge, PNTTDomain>
+impl<FChallenge, PNTTDomain, PChallenge> OblongZerocheckProver<FChallenge, PNTTDomain, PChallenge>
 where
 	FChallenge: Field + From<PNTTDomain::Scalar> + BinaryField,
 	PNTTDomain: PackedField + PackedExtension<B1, PackedSubfield = PackedBinaryField128x1b>,
 	PNTTDomain::Scalar: BinaryField,
+	PChallenge: PackedField<Scalar = FChallenge>,
 {
 	/// Creates a new oblong zerocheck prover for AND constraint reduction.
 	///
@@ -108,6 +117,7 @@ where
 			univariate_round_message,
 			big_field_zerocheck_challenges,
 			univariate_round_message_domain: prover_message_domain.isomorphic(),
+			_marker: PhantomData,
 		}
 	}
 
@@ -170,7 +180,7 @@ where
 				.create(&lagrange_evals);
 
 		let proving_polys = [&self.first_col, &self.second_col, &self.third_col]
-			.map(|col| fold_words_with_transform::<_, FChallenge, _>(&transform, col));
+			.map(|col| fold_words_with_transform::<_, PChallenge, _>(&transform, col));
 
 		let upcasted_small_field_challenges: Vec<_> = self
 			.small_field_zerocheck_challenges
@@ -276,6 +286,7 @@ mod test {
 	use binius_core::word::Word;
 	use binius_field::{
 		AESTowerField8b, PackedAESBinaryField16x8b,
+		arch::OptimalPackedB128,
 		linear_transformation::{
 			BytewiseLookupTransformationFactory, LinearTransformationFactory,
 			OutputWrappingTransformationFactory,
@@ -325,7 +336,7 @@ mod test {
 		// Prover is instantiated
 		let big_field_zerocheck_challenges =
 			prover_challenger.sample_vec(log_num_rows - SKIPPED_VARS - 3);
-		let prover = OblongZerocheckProver::<_, PackedAESBinaryField16x8b>::new(
+		let prover = OblongZerocheckProver::<_, PackedAESBinaryField16x8b, OptimalPackedB128>::new(
 			first_mlv.clone(),
 			second_mlv.clone(),
 			third_mlv.clone(),

--- a/crates/prover/src/and_reduction/prover_setup.rs
+++ b/crates/prover/src/and_reduction/prover_setup.rs
@@ -27,8 +27,7 @@ pub fn ntt_lookup_from_prover_message_domain<PNTTDomain>(
 	prover_message_domain: BinarySubspace<PNTTDomain::Scalar>,
 ) -> NTTLookup<PNTTDomain>
 where
-	PNTTDomain: PackedField,
-	PNTTDomain::Scalar: BinaryField + From<u8>,
+	PNTTDomain: PackedField<Scalar: BinaryField>,
 {
 	assert!(prover_message_domain.dim() >= 1);
 	let basis = prover_message_domain.basis();

--- a/crates/prover/src/and_reduction/sumcheck_round_messages.rs
+++ b/crates/prover/src/and_reduction/sumcheck_round_messages.rs
@@ -70,7 +70,6 @@ where
 	FChallenge: Field + From<PNTTDomain::Scalar> + BinaryField,
 	PNTTDomain: PackedExtension<B1, PackedSubfield = PackedBinaryField128x1b>,
 	PNTTDomain::Scalar: BinaryField,
-	u8: From<PNTTDomain::Scalar>,
 {
 	// This assertion is used as a workaround for Rust's limited support for const-generics,
 	// ideally we would just use PNTTDomain::WIDTH everywhere instead, but since this function only

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -153,7 +153,7 @@ impl IOPProver {
 				c_eval,
 				z_challenge,
 				eval_point,
-			} = prove_bitand_reduction::<B128, _>(bitand_witness, &mut channel)?;
+			} = prove_bitand_reduction::<B128, P, _>(bitand_witness, &mut channel)?;
 			OperatorData {
 				evals: vec![a_eval, b_eval, c_eval],
 				r_zhat_prime: z_challenge,
@@ -416,12 +416,13 @@ fn pack_witness<P: PackedField<Scalar = B128>>(
 	Ok(padded_witness_elems)
 }
 
-fn prove_bitand_reduction<F, Channel>(
+fn prove_bitand_reduction<F, PChallenge, Channel>(
 	witness: AndCheckWitness,
 	channel: &mut Channel,
 ) -> Result<AndCheckOutput<F>, Error>
 where
 	F: BinaryField + From<B8>,
+	PChallenge: PackedField<Scalar = F>,
 	Channel: binius_ip_prover::channel::IPProverChannel<F>,
 {
 	let prover_message_domain = BinarySubspace::<B8>::with_dim(LOG_WORD_SIZE_BITS + 1);
@@ -435,7 +436,7 @@ where
 	let big_field_zerocheck_challenges =
 		channel.sample_many(log_constraint_count - small_field_zerocheck_challenges.len());
 
-	let prover = OblongZerocheckProver::<_, PackedAESBinaryField16x8b>::new(
+	let prover = OblongZerocheckProver::<_, PackedAESBinaryField16x8b, PChallenge>::new(
 		a,
 		b,
 		c,


### PR DESCRIPTION
## Summary

Runs the bitand reduction prover's post-univariate sumcheck rounds over a wide packed field instead of the scalar challenge field, for SIMD acceleration. Closes BINIUS-32.

This PR bundles two commits:

1. **`[prover] Type bound cleanup in bitand prover`** — preparatory type-bound cleanup.
2. **`[prover] Run bitand reduced prover over packed fields`** — the BINIUS-32 change.

## The change (BINIUS-32)

After the univariate round, `OblongZerocheckProver::fold_and_send_reduced_prover` folds the words and hands them to a `QuadraticMleCheckProver`. It was passing `FChallenge` itself as the `P` (packed) type parameter to `fold_words_with_transform`, so each folded word became a width-1 packed element — the remaining sumcheck rounds ran over the scalar challenge field with no packing.

- Add `PChallenge: PackedField<Scalar = FChallenge>` as a third type parameter on `OblongZerocheckProver` (with a `PhantomData` field, since no struct field otherwise uses it), and fold via `fold_words_with_transform::<_, PChallenge, _>`. The downstream `QuadraticMleCheckProver` and its `a*b - c` compositions then operate on packed elements; `eval_point`/`eval_claim` stay scalar.
- `prove_bitand_reduction` gains a matching `PChallenge` parameter; the call site threads the outer prover's optimal packed field `P` (`Scalar = B128`) into it, matching the existing `prove_intmul_reduction` / `prove_shift_reduction` call sites.

The downstream machinery (`fold_words_with_transform`, `QuadraticMleCheckProver`, `MleCheckProver`, `prove_single_mlecheck`) was already generic over the packed field, so no changes were needed there. The verifier is unaffected — it already folds the scalar challenge field, so the existing transcript test cross-checks the packed prover against the scalar verifier.

## Testing

- `cargo test -p binius-prover and_reduction` — passes, including `test_transcript_prover_verifies` (full prove+verify roundtrip)
- `cargo test -p binius-prover --test prove_verify` — passes (SHA-256 preimage + ZK / signature-of-knowledge end-to-end proofs)
- `cargo clippy -p binius-prover --all-features --tests -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
