### PR TITLE
Add modular division gadget to halve secp256k1 slope multiplications

### DIFF
--- a/crates/circuits/src/bignum/prime_field.rs
+++ b/crates/circuits/src/bignum/prime_field.rs
@@ -1,3 +1,4 @@
+// Copyright 2026 The Binius Developers
 // Copyright 2025 Irreducible Inc.
 use binius_core::{consts::WORD_SIZE_BITS, word::Word};
 use binius_frontend::{CircuitBuilder, Wire, util::num_biguint_from_u64_limbs};
@@ -159,5 +160,68 @@ impl PseudoMersennePrimeField {
 		.constrain_cond(b, exists);
 
 		inverse
+	}
+
+	/// Field division.
+	///
+	/// Equivalent formula (for prime modulus): `(dividend * divisor ** (modulus - 2)) % modulus`,
+	/// i.e. `dividend / divisor (mod modulus)`.
+	///
+	/// This collapses a modular inverse followed by a multiplication into a single modular
+	/// reduction, halving the multiplication cost relative to `mul(dividend, inverse(divisor))`.
+	/// The returned `slope` is constrained by `slope * divisor = dividend + quotient * modulus`,
+	/// which is `slope * divisor ≡ dividend (mod modulus)`.
+	///
+	/// The wire parameter `exists` is a boolean-wire signifying the existence of the quotient
+	/// (i.e. that `divisor` is invertible modulo the modulus); if `exists` is false, the modular
+	/// reduction constraint is not applied. This is useful for avoiding overconstraining in
+	/// skipped parts of larger circuits. The `slope < modulus` range check is unconditional, so
+	/// when `exists` is false the returned value is an unconstrained dummy `< modulus`.
+	///
+	/// # Precondition and incompleteness
+	///
+	/// `dividend` must be reduced (`dividend < modulus`): it plays the role of the remainder in
+	/// the reduction `slope * divisor = dividend + quotient * modulus`. If `dividend >= modulus`
+	/// there is no non-negative `quotient` satisfying that equation, so (when `exists` is true)
+	/// the constraint system has no satisfying witness and proof generation fails — the gadget is
+	/// *incomplete* for unreduced dividends. Callers must reduce the dividend beforehand; the
+	/// field helpers [`add`](Self::add), [`sub`](Self::sub), [`mul`](Self::mul) and
+	/// [`square`](Self::square) all return reduced values. (This matches the standard ECDSA
+	/// convention of reducing the message hash to a scalar in `[0, n)` before computing
+	/// `u1`/`u2`.)
+	pub fn div(
+		&self,
+		b: &CircuitBuilder,
+		dividend: &BigUint,
+		divisor: &BigUint,
+		exists: Wire,
+	) -> BigUint {
+		assert!(
+			dividend.limbs.len() == self.limbs_len() && divisor.limbs.len() == self.limbs_len()
+		);
+		let (quotient, slope) =
+			b.mod_divide_hint(&dividend.limbs, &divisor.limbs, &self.modulus.limbs);
+
+		let zero = b.add_constant(Word::ZERO);
+
+		let quotient = BigUint { limbs: quotient };
+		let slope = BigUint { limbs: slope }.pad_limbs_to(self.limbs_len(), zero);
+
+		let product = textbook_mul(b, &slope, divisor);
+
+		b.assert_true("slope < modulus", biguint_lt(b, &slope, &self.modulus));
+
+		// constraint: slope * divisor = dividend + quotient * modulus
+		PseudoMersenneModReduce::new(
+			b,
+			&product,
+			self.modulus_po2,
+			&self.modulus_subtrahend,
+			&quotient,
+			dividend,
+		)
+		.constrain_cond(b, exists);
+
+		slope
 	}
 }

--- a/crates/circuits/src/bignum/tests.rs
+++ b/crates/circuits/src/bignum/tests.rs
@@ -1,3 +1,4 @@
+// Copyright 2026 The Binius Developers
 // Copyright 2025 Irreducible Inc.
 use std::iter::repeat_with;
 
@@ -191,6 +192,66 @@ fn test_prime_field() {
 
 	for (&a_limb, &b_limb) in result_big.limbs.iter().zip(&result.limbs) {
 		builder.assert_eq("circuit matches num_bigint::BigUint", a_limb, b_limb);
+	}
+
+	let cs = builder.build();
+	let mut w = cs.new_witness_filler();
+
+	cs.populate_wire_witness(&mut w).unwrap();
+	verify_constraints(cs.constraint_system(), &w.into_value_vec()).unwrap();
+}
+
+#[test]
+fn test_prime_field_div() {
+	let mut rng = StdRng::seed_from_u64(1);
+
+	let builder = CircuitBuilder::new();
+
+	let exists = builder.add_constant(Word::ALL_ONE);
+	let not_exists = builder.add_constant(Word::ZERO);
+
+	let subtrahend = 1u64 << 32 | 977;
+	let field = PseudoMersennePrimeField::new(&builder, 256, &[subtrahend]);
+	let modulus_big =
+		num_bigint::BigUint::from(2usize).pow(256) - num_bigint::BigUint::from(subtrahend);
+	let l = field.limbs_len();
+
+	// Random reduced dividend / invertible divisor: `div` must yield `dividend / divisor (mod p)`.
+	let mut checks = Vec::new();
+	for _ in 0..32 {
+		let dividend_big =
+			from_u64_limbs(repeat_with(|| rng.random()).take(l).collect::<Vec<u64>>())
+				% &modulus_big;
+		let mut divisor_big =
+			from_u64_limbs(repeat_with(|| rng.random()).take(l).collect::<Vec<u64>>())
+				% &modulus_big;
+		if divisor_big == num_bigint::BigUint::ZERO {
+			divisor_big = num_bigint::BigUint::from(1usize);
+		}
+
+		let dividend = BigUint::new_constant(&builder, &dividend_big).zero_extend(&builder, l);
+		let divisor = BigUint::new_constant(&builder, &divisor_big).zero_extend(&builder, l);
+
+		let slope = field.div(&builder, &dividend, &divisor, exists);
+
+		let expected_big =
+			(&dividend_big * divisor_big.modinv(&modulus_big).unwrap()) % &modulus_big;
+		let expected = BigUint::new_constant(&builder, &expected_big).zero_extend(&builder, l);
+		checks.push((slope, expected));
+	}
+
+	// divisor == 0 with exists == false: the reduction constraint is skipped, and the dummy
+	// slope still satisfies the unconditional `slope < modulus` range check.
+	let dividend = BigUint::new_constant(&builder, &num_bigint::BigUint::from(7usize))
+		.zero_extend(&builder, l);
+	let zero_divisor =
+		BigUint::new_constant(&builder, &num_bigint::BigUint::ZERO).zero_extend(&builder, l);
+	let _ = field.div(&builder, &dividend, &zero_divisor, not_exists);
+
+	for (slope, expected) in &checks {
+		for (&exp_limb, &got_limb) in expected.limbs.iter().zip(&slope.limbs) {
+			builder.assert_eq("div matches num_bigint", exp_limb, got_limb);
+		}
 	}
 
 	let cs = builder.build();

--- a/crates/circuits/src/ecdsa/bitcoin.rs
+++ b/crates/circuits/src/ecdsa/bitcoin.rs
@@ -1,3 +1,4 @@
+// Copyright 2026 The Binius Developers
 // Copyright 2025 Irreducible Inc.
 use binius_frontend::{CircuitBuilder, Wire, util::all_true};
 
@@ -37,9 +38,10 @@ pub fn verify(
 	let valid_r = b.band(b.bnot(r.is_zero(b)), biguint_lt(b, r, f_scalar.modulus()));
 	let valid_s = b.band(b.bnot(s.is_zero(b)), biguint_lt(b, s, f_scalar.modulus()));
 
-	let s_inverse = f_scalar.inverse(b, s, valid_s);
-	let u1 = f_scalar.mul(b, z, &s_inverse);
-	let u2 = f_scalar.mul(b, r, &s_inverse);
+	// u1 = z / s, u2 = r / s. `div` requires reduced dividends: `z` (the message hash) and
+	// `r` must be in `[0, n)`. `valid_s` gates the shared divisor `s`.
+	let u1 = f_scalar.div(b, z, s, valid_s);
+	let u2 = f_scalar.div(b, r, s, valid_s);
 
 	let nonce = shamirs_trick_endomorphism(b, &curve, &u1, &u2, pk);
 	let nonce_not_pai = b.bnot(nonce.is_point_at_infinity);

--- a/crates/circuits/src/ecdsa/ecrecover.rs
+++ b/crates/circuits/src/ecdsa/ecrecover.rs
@@ -1,3 +1,4 @@
+// Copyright 2026 The Binius Developers
 // Copyright 2025 Irreducible Inc.
 use binius_frontend::{CircuitBuilder, Wire, util::all_true};
 
@@ -36,9 +37,10 @@ pub fn ecrecover(
 	let valid_r = b.band(b.bnot(r.is_zero(b)), biguint_lt(b, r, f_scalar.modulus()));
 	let valid_s = b.band(b.bnot(s.is_zero(b)), biguint_lt(b, s, f_scalar.modulus()));
 
-	let r_inverse = f_scalar.inverse(b, r, valid_r);
-	let u1 = f_scalar.sub(b, &coord_zero(b), &f_scalar.mul(b, z, &r_inverse));
-	let u2 = f_scalar.mul(b, s, &r_inverse);
+	// u1 = -(z / r), u2 = s / r. `div` requires reduced dividends: `z` (the message hash)
+	// and `s` must be in `[0, n)`. `valid_r` gates the shared divisor `r`.
+	let u1 = f_scalar.sub(b, &coord_zero(b), &f_scalar.div(b, z, r, valid_r));
+	let u2 = f_scalar.div(b, s, r, valid_r);
 
 	let recovered_pk = shamirs_trick_endomorphism(b, &curve, &u1, &u2, nonce);
 

--- a/crates/circuits/src/secp256k1/curve.rs
+++ b/crates/circuits/src/secp256k1/curve.rs
@@ -1,3 +1,4 @@
+// Copyright 2026 The Binius Developers
 // Copyright 2025 Irreducible Inc.
 use binius_core::consts::WORD_SIZE_BITS;
 use binius_frontend::{CircuitBuilder, Wire};
@@ -205,8 +206,8 @@ impl Secp256k1 {
 		let x_diff = f_p.sub(b, &p2.x, &p1.x);
 		let y_diff_zero = y_diff.is_zero(b);
 		let x_diff_zero = x_diff.is_zero(b);
-		let x_diff_inverse = f_p.inverse(b, &x_diff, b.bnot(x_diff_zero));
-		let slope = f_p.mul(b, &y_diff, &x_diff_inverse);
+		// slope = y_diff / x_diff; y_diff is reduced (output of `sub`) as `div` requires.
+		let slope = f_p.div(b, &y_diff, &x_diff, b.bnot(x_diff_zero));
 		(slope, x_diff_zero, y_diff_zero)
 	}
 
@@ -218,8 +219,8 @@ impl Secp256k1 {
 		// secp256k1 does not allow y=0, but we still have to check to avoid overconstraining.
 		let y_zero = p.y.is_zero(b);
 		let y_by_2 = f_p.add(b, &p.y, &p.y);
-		let y_by_2_inverse = f_p.inverse(b, &y_by_2, b.bnot(y_zero));
-		f_p.mul(b, &x_sqr_by_3, &y_by_2_inverse)
+		// λ = 3x² / 2y; x_sqr_by_3 is reduced (output of `add`) as `div` requires.
+		f_p.div(b, &x_sqr_by_3, &y_by_2, b.bnot(y_zero))
 	}
 
 	fn sloped_add(

--- a/crates/examples/snapshots/ethsign.snap
+++ b/crates/examples/snapshots/ethsign.snap
@@ -1,28 +1,28 @@
 ethsign circuit
 --
 Gates & Instructions
-├─ Number of gates: 253,208
-└─ Number of evaluation instructions: 299,213
+├─ Number of gates: 218,930
+└─ Number of evaluation instructions: 261,739
 
 Constraints
-├─ AND constraints: 218,474 used (83.3% of 2^18)
-│  [▓▓▓▓▓▓▓▓░░] spare: 43,670
-├─ MUL constraints: 25,458 used (77.7% of 2^15)
-│  [▓▓▓▓▓▓▓░░░] spare: 7,310
-└─ Distinct value indices: 471,779
-   ├─ Distinct shifted value indices: 217,560
-   └─ Distinct unshifted value indices: 254,219
+├─ AND constraints: 191,166 used (72.9% of 2^18)
+│  [▓▓▓▓▓▓▓░░░] spare: 70,978
+├─ MUL constraints: 19,022 used (58.1% of 2^15)
+│  [▓▓▓▓▓░░░░░] spare: 13,746
+└─ Distinct value indices: 399,969
+   ├─ Distinct shifted value indices: 183,256
+   └─ Distinct unshifted value indices: 216,713
 
 Value Vector
 ├─ Public Section: 119 used (93.0% of 2^7)
 │  [▓▓▓▓▓▓▓▓▓░] spare: 9
 │  ├─ Constants: 90
 │  └─ Inout: 29
-├─ Private Section: 254,108 used (97.0%)
-│  [▓▓▓▓▓▓▓▓▓░] spare: 7,908
+├─ Private Section: 216,602 used (82.7%)
+│  [▓▓▓▓▓▓▓▓░░] spare: 45,414
 │  ├─ Witness: 42
-│  └─ Internal: 254,066
-├─ Total Committed: 254,227 used (97.0% of 2^18)
-│  [▓▓▓▓▓▓▓▓▓░] spare: 7,917
-└─ Scratch (uncommitted): 200,256
+│  └─ Internal: 216,560
+├─ Total Committed: 216,721 used (82.7% of 2^18)
+│  [▓▓▓▓▓▓▓▓░░] spare: 45,423
+└─ Scratch (uncommitted): 175,363
 

--- a/crates/frontend/src/compiler/hints/mod.rs
+++ b/crates/frontend/src/compiler/hints/mod.rs
@@ -1,3 +1,4 @@
+// Copyright 2026 The Binius Developers
 // Copyright 2025 Irreducible Inc.
 //! Hint system.
 //!
@@ -16,12 +17,14 @@ use binius_core::Word;
 mod big_uint_divide;
 mod big_uint_mod_pow;
 mod byte_vec_concat;
+mod mod_divide;
 mod mod_inverse;
 mod secp256k1_endosplit;
 
 pub use big_uint_divide::BigUintDivideHint;
 pub use big_uint_mod_pow::BigUintModPowHint;
 pub use byte_vec_concat::ByteVecConcatHint;
+pub use mod_divide::ModDivideHint;
 pub use mod_inverse::ModInverseHint;
 pub use secp256k1_endosplit::Secp256k1EndosplitHint;
 

--- a/crates/frontend/src/compiler/hints/mod_divide.rs
+++ b/crates/frontend/src/compiler/hints/mod_divide.rs
@@ -1,0 +1,95 @@
+// Copyright 2026 The Binius Developers
+//! Modular division hint implementation
+
+use binius_core::Word;
+
+use super::Hint;
+use crate::util::num_biguint_from_u64_limbs;
+
+/// ModDivide hint implementation.
+///
+/// Computes the modular quotient `slope = dividend * divisor^{-1} (mod modulus)` together with
+/// the integer `quotient` witnessing the reduction `slope * divisor = dividend + quotient *
+/// modulus`. Both outputs are set to zero when `divisor` is not invertible modulo `modulus`
+/// (e.g. `divisor == 0` or `gcd(divisor, modulus) > 1`).
+pub struct ModDivideHint;
+
+impl ModDivideHint {
+	pub fn new() -> Self {
+		Self
+	}
+}
+
+impl Default for ModDivideHint {
+	fn default() -> Self {
+		Self::new()
+	}
+}
+
+impl Hint for ModDivideHint {
+	const NAME: &'static str = "binius.mod_divide";
+
+	fn shape(&self, dimensions: &[usize]) -> (usize, usize) {
+		let [dividend_limbs, divisor_limbs, mod_limbs] = dimensions else {
+			panic!("ModDivide requires 3 dimensions");
+		};
+		(*dividend_limbs + *divisor_limbs + *mod_limbs, 2 * *mod_limbs)
+	}
+
+	fn execute(&self, dimensions: &[usize], inputs: &[Word], outputs: &mut [Word]) {
+		let [n_dividend, n_divisor, n_mod] = dimensions else {
+			panic!("ModDivide requires 3 dimensions");
+		};
+
+		let dividend_limbs = &inputs[0..*n_dividend];
+		let divisor_limbs = &inputs[*n_dividend..*n_dividend + *n_divisor];
+		let mod_limbs = &inputs[*n_dividend + *n_divisor..];
+
+		let dividend = num_biguint_from_u64_limbs(dividend_limbs.iter().map(|w| w.as_u64()));
+		let divisor = num_biguint_from_u64_limbs(divisor_limbs.iter().map(|w| w.as_u64()));
+		let modulus = num_biguint_from_u64_limbs(mod_limbs.iter().map(|w| w.as_u64()));
+
+		let zero = num_bigint::BigUint::ZERO;
+		let (quotient, slope) = if let Some(inverse) = divisor.modinv(&modulus) {
+			let slope = (&dividend * &inverse) % &modulus;
+			let numerator = &slope * &divisor;
+			// `slope * divisor ≡ dividend (mod modulus)`, so when `dividend < modulus` (the
+			// gadget's precondition) `numerator >= dividend` and `quotient` is a non-negative
+			// integer. If `dividend >= modulus` this subtraction would underflow; clamp to zero
+			// so witness generation never panics and let the (then unsatisfiable) reduction
+			// constraint surface the incompleteness. See `PseudoMersennePrimeField::div`.
+			let quotient = if numerator >= dividend {
+				(numerator - &dividend) / &modulus
+			} else {
+				zero.clone()
+			};
+			(quotient, slope)
+		} else {
+			(zero.clone(), zero)
+		};
+
+		assert_eq!(outputs.len(), 2 * *n_mod);
+		let (quotient_words, slope_words) = outputs.split_at_mut(*n_mod);
+
+		// Fill quotient limbs, ignoring any that exceed the output arity (only reachable when
+		// the precondition is violated) and zeroing the remainder.
+		for (i, limb) in quotient.iter_u64_digits().enumerate() {
+			if i < *n_mod {
+				quotient_words[i] = Word::from_u64(limb);
+			}
+		}
+		for i in quotient.iter_u64_digits().len()..*n_mod {
+			quotient_words[i] = Word::ZERO;
+		}
+
+		// Fill slope limbs and zero the remainder.
+		for (i, limb) in slope.iter_u64_digits().enumerate() {
+			if i < *n_mod {
+				slope_words[i] = Word::from_u64(limb);
+			}
+		}
+		for i in slope.iter_u64_digits().len()..*n_mod {
+			slope_words[i] = Word::ZERO;
+		}
+	}
+}

--- a/crates/frontend/src/compiler/mod.rs
+++ b/crates/frontend/src/compiler/mod.rs
@@ -13,7 +13,7 @@ use crate::compiler::{
 	constraint_builder::ConstraintBuilder,
 	gate_graph::{GateGraph, WireKind},
 	hints::{
-		BigUintDivideHint, BigUintModPowHint, Hint, HintRegistry, ModInverseHint,
+		BigUintDivideHint, BigUintModPowHint, Hint, HintRegistry, ModDivideHint, ModInverseHint,
 		Secp256k1EndosplitHint,
 	},
 	pathspec::PathSpec,
@@ -1215,6 +1215,38 @@ impl CircuitBuilder {
 		let mut out = self.call_hint(ModInverseHint::new(), &[base.len(), modulus.len()], &inputs);
 		let inverse = out.split_off(modulus.len());
 		(out, inverse)
+	}
+
+	/// Modular division.
+	///
+	/// Computes `dividend / divisor (mod modulus) = dividend * divisor^{-1} (mod modulus)`.
+	/// Returns a pair `(quotient, slope)` where `slope` is the modular quotient and `quotient`
+	/// is the non-negative integer satisfying `slope * divisor = dividend + quotient * modulus`.
+	/// Both are set to zero when `divisor` is not invertible modulo `modulus` (e.g. `divisor ==
+	/// 0`).
+	///
+	/// This is a hint - a deterministic computation that happens only on the prover side.
+	/// The result should be additionally constrained by using bignum circuits to check that
+	/// `slope * divisor = dividend + quotient * modulus`.
+	pub fn mod_divide_hint(
+		&self,
+		dividend: &[Wire],
+		divisor: &[Wire],
+		modulus: &[Wire],
+	) -> (Vec<Wire>, Vec<Wire>) {
+		let inputs: Vec<Wire> = dividend
+			.iter()
+			.chain(divisor)
+			.chain(modulus)
+			.copied()
+			.collect();
+		let mut out = self.call_hint(
+			ModDivideHint::new(),
+			&[dividend.len(), divisor.len(), modulus.len()],
+			&inputs,
+		);
+		let slope = out.split_off(modulus.len());
+		(out, slope)
 	}
 
 	/// Secp256k1 endomorphism split


### PR DESCRIPTION
## Summary
- Add a `mod_divide_hint` + `PseudoMersennePrimeField::div` gadget that constrains `slope * divisor = dividend + q*modulus` in one `textbook_mul` + one `PseudoMersenneModReduce`, replacing the inverse-then-mul pattern (2 modular muls → 1) for every EC slope.
- Swap the four sites: secp256k1 addition/doubling slopes, and the ecrecover / bitcoin `u1,u2` (shared divisor).
- `div` requires a reduced dividend (`< modulus`); it is documented as incomplete otherwise. Coordinate-field dividends are already reduced; scalar-field dividends (hash `z`, `r`/`s`) must be in `[0, n)`, per standard ECDSA (e.g. libsecp256k1 reduces the hash via `scalar_set_b32`).

## Results (full ecrecover circuit)
- MUL constraints: 25458 → 19022 (−25.3%)
- AND constraints: 216552 → 189244 (−12.6%)
- Per-slope micro-benchmark: 44 → 20 MUL, 188 → 86 AND.

## Test plan
- `cargo test -p binius-circuits -p binius-frontend` (329 + 147 tests pass; adds `test_prime_field_div`, including the `divisor == 0` / `exists == false` path)
- `cargo clippy -p binius-circuits -p binius-frontend --tests`

Closes BINIUS-55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
