### PR TITLE
Multi-oracle batched FRI with oracle padding (Lifted FRI)

### DIFF
--- a/crates/iop-prover/src/fri/fold.rs
+++ b/crates/iop-prover/src/fri/fold.rs
@@ -101,36 +101,44 @@ where
 			)));
 		}
 
-		// Temporary restriction: lifted FRI is not yet implemented, so every input oracle must
-		// reduce to exactly the first-round Reed-Solomon code. FRIParams only guarantees the
-		// inequality `log_msg_len - log_batch_size <= rs_code.log_dim()`.
+		// Each input oracle's Reed-Solomon dimension must not exceed the first-round (reduced) code
+		// dimension; smaller oracles are lifted (padded) to it. FRIParams only guarantees the
+		// inequality `log_msg_len - log_batch_size <= rs_code.log_dim()`, so validate it here
+		// rather than trusting the caller.
 		let log_dim = params.rs_code().log_dim();
+		let log_inv_rate = params.rs_code().log_inv_rate();
 		for spec in input_oracles {
-			assert_eq!(
-				spec.log_msg_len - spec.log_batch_size,
-				log_dim,
-				"lifted FRI is unsupported: input oracle dimension must equal rs_code.log_dim()"
-			);
+			if spec.log_msg_len - spec.log_batch_size > log_dim {
+				return Err(Error::InvalidArgs(format!(
+					"input oracle dimension {} exceeds the reduced code dimension {log_dim}",
+					spec.log_msg_len - spec.log_batch_size,
+				)));
+			}
 		}
 
 		let folders = iter::zip(committed_codewords, input_oracles)
 			.map(|((codeword, committed), spec)| {
-				let expected_log_len = params.rs_code().log_len() + spec.log_batch_size;
+				// The oracle's own codeword has dimension `log_msg_len - log_batch_size`, so its
+				// interleaved length is `log_msg_len + log_inv_rate`. It is lifted to the common
+				// first-round length by duplicating each entry `2^log_lift` times.
+				let oracle_log_dim = spec.log_msg_len - spec.log_batch_size;
+				let expected_log_len = spec.log_msg_len + log_inv_rate;
 				if codeword.log_len() != expected_log_len {
 					return Err(Error::InvalidArgs(
-						"interleaved codeword length must match the Reed-Solomon code length plus the \
-						 oracle's batch size"
+						"interleaved codeword length must match the oracle's Reed-Solomon code length \
+						 plus its batch size"
 							.to_string(),
 					));
 				}
 				Ok(ProxTestFolder {
 					log_batch_size: spec.log_batch_size,
+					log_lift: log_dim - oracle_log_dim,
 					codeword,
 					merkle_committed: committed,
 				})
 			})
 			.collect::<Result<Vec<_>, Error>>()?;
-		let batch_folder = BatchBrakedownFolder::new(folders);
+		let batch_folder = BatchBrakedownFolder::new(folders, params.rs_code().log_len());
 
 		let next_commit_round = Some(params.log_batch_size());
 		Ok(Self {
@@ -428,6 +436,9 @@ where
 
 pub struct ProxTestFolder<'a, P: PackedField, MTProver: MerkleTreeProver<P::Scalar>> {
 	log_batch_size: usize,
+	/// log2 the lift factor (oracle padding): how many times each folded codeword entry is
+	/// duplicated to reach the common first-round length. Zero when no lifting is needed.
+	log_lift: usize,
 	codeword: FieldBuffer<P>,
 	merkle_committed: &'a MTProver::Committed,
 }
@@ -449,6 +460,7 @@ where
 
 		let ProxTestFolder {
 			log_batch_size,
+			log_lift,
 			codeword,
 			merkle_committed,
 		} = self;
@@ -456,8 +468,13 @@ where
 		let log_len = codeword.log_len() - log_batch_size;
 		let folded_codeword =
 			fold_interleaved(codeword.to_ref(), challenges, log_len, log_batch_size);
-		let oracle =
-			BrakedownOracleProver::new(codeword, merkle_committed, merkle_prover, log_batch_size);
+		let oracle = BrakedownOracleProver::new(
+			codeword,
+			merkle_committed,
+			merkle_prover,
+			log_batch_size,
+			log_lift,
+		);
 		(folded_codeword, oracle)
 	}
 }
@@ -478,11 +495,14 @@ where
 	MTProver: MerkleTreeProver<F>,
 {
 	/// Constructs a batch folder from one or more interleaved-codeword folders.
-	pub fn new(folders: Vec<ProxTestFolder<'a, P, MTProver>>) -> Self {
+	///
+	/// `log_code_len` is the common (first-round) codeword length the folders combine into. Each
+	/// folder's own folded length must not exceed it; folders that fall short are lifted (their
+	/// folded codewords duplicated) up to `log_code_len` during [`Self::fold`].
+	pub fn new(folders: Vec<ProxTestFolder<'a, P, MTProver>>, log_code_len: usize) -> Self {
 		assert!(!folders.is_empty()); // precondition
-		let log_code_len = folders[0].log_folded_len();
-		for folder in &folders[1..] {
-			assert_eq!(folder.log_folded_len(), log_code_len);
+		for folder in &folders {
+			assert!(folder.log_folded_len() <= log_code_len);
 		}
 		Self {
 			log_code_len,
@@ -528,9 +548,14 @@ where
 		// TODO: Special cases when outer_challenges.len() = 0 or 1 for computational efficiency (to
 		// reduce # of scaling muls)
 		for ((folded_codeword, oracle), &scalar) in iter::zip(folds, outer_tensor.as_ref()) {
-			assert_eq!(folded_codeword.log_len(), combined_codeword.log_len()); // precondition
-			for (acc, &val) in iter::zip(combined_codeword.as_mut(), folded_codeword.as_ref()) {
-				*acc += val * scalar;
+			// Lift (pad) the folded codeword up to the common length by duplicating each entry
+			// `2^log_lift` times: the lifted entry at index `j` is the folded entry at `j >>
+			// log_lift` (a contiguous duplication, matching the Reed-Solomon codeword
+			// duplication identity).
+			let log_lift = self.log_code_len - folded_codeword.log_len();
+			let folded = folded_codeword.as_ref();
+			for (j, acc) in combined_codeword.as_mut().iter_mut().enumerate() {
+				*acc += folded[j >> log_lift] * scalar;
 			}
 			oracles.push(oracle);
 		}

--- a/crates/iop-prover/src/fri/query.rs
+++ b/crates/iop-prover/src/fri/query.rs
@@ -34,6 +34,10 @@ where
 	committed: &'a MerkleProver::Committed,
 	merkle_prover: &'a MerkleProver,
 	log_batch_size: usize,
+	/// log2 the lift factor (oracle padding). The committed codeword is virtually duplicated
+	/// `2^log_lift` times to reach the common first-round length; a query at global index `k`
+	/// opens the committed codeword at `k >> log_lift`. Zero when no lifting is needed.
+	log_lift: usize,
 }
 
 impl<'a, P, MerkleProver> BrakedownOracleProver<'a, P, MerkleProver>
@@ -42,17 +46,23 @@ where
 	MerkleProver: MerkleTreeProver<P::Scalar>,
 {
 	/// Constructs a new oracle prover wrapping a committed interleaved codeword.
+	///
+	/// `log_lift` is the oracle-padding lift factor (the committed codeword is virtually duplicated
+	/// `2^log_lift` times to reach the common first-round length); pass `0` when no lifting is
+	/// needed.
 	pub fn new(
 		codeword: FieldBuffer<P>,
 		committed: &'a MerkleProver::Committed,
 		merkle_prover: &'a MerkleProver,
 		log_batch_size: usize,
+		log_lift: usize,
 	) -> Self {
 		Self {
 			codeword,
 			committed,
 			merkle_prover,
 			log_batch_size,
+			log_lift,
 		}
 	}
 }
@@ -74,6 +84,7 @@ where
 			&self.codeword,
 			self.committed,
 			self.log_batch_size,
+			self.log_lift,
 			indices,
 			advice,
 		)
@@ -174,6 +185,7 @@ where
 			&self.codeword,
 			&self.committed,
 			self.coset_log_size,
+			0,
 			indices,
 			advice,
 		)
@@ -182,12 +194,15 @@ where
 
 /// Writes the optimal Merkle layer once, then a coset opening for each queried index.
 ///
-/// The coset is opened at the index directly, mirroring the verifier's `open_queries`.
+/// The coset is opened at the index directly, mirroring the verifier's `open_queries`. When the
+/// oracle is lifted (`log_lift > 0`), each global query index is translated to the committed
+/// codeword by dropping its low `log_lift` bits (the duplicated copies), mirroring the verifier.
 fn open_oracle_queries<F, P, MerkleProver, B>(
 	merkle_prover: &MerkleProver,
 	codeword: &FieldBuffer<P>,
 	committed: &MerkleProver::Committed,
 	coset_log_size: usize,
+	log_lift: usize,
 	indices: &[usize],
 	advice: &mut TranscriptWriter<B>,
 ) -> Result<(), Error>
@@ -208,7 +223,7 @@ where
 			merkle_prover,
 			codeword.to_ref(),
 			committed,
-			index,
+			index >> log_lift,
 			coset_log_size,
 			layer_depth,
 			advice,

--- a/crates/iop-prover/src/fri/tests.rs
+++ b/crates/iop-prover/src/fri/tests.rs
@@ -355,6 +355,174 @@ fn test_commit_prove_verify_batched_multi_oracle() {
 	assert_eq!(final_value, expected);
 }
 
+/// Full FRI round trip that batches initial oracles of **differing Reed-Solomon dimension**,
+/// forcing oracle padding (Lifted FRI).
+///
+/// The three input oracles have RS dimensions `[6, 8, 4]` with fixed batch sizes `[1, 1, 2]`, so
+/// the reduced (first-round) dimension is `max(6, 8, 4) = 8`. The dimension-6 and dimension-4
+/// oracles are smaller than the reduced code and must be lifted (their folded codewords duplicated
+/// `2^2` and `2^4` times) before they combine into the first-round codeword; the dimension-8 oracle
+/// needs no lifting (`eta = 0`), exercising both paths in one batch. Every per-oracle code is built
+/// from the same `domain_context` so the smaller subspaces are prefixes of the reduced one, as the
+/// duplication identity requires.
+#[test]
+fn test_commit_prove_verify_lifted_multi_oracle() {
+	type F = B128;
+	type P = PackedBinaryGhash1x128b;
+
+	let mut rng = StdRng::seed_from_u64(0);
+
+	let oracle_log_dims = [6usize, 8, 4];
+	let log_batch_sizes = [1usize, 1, 2];
+	let log_inv_rate = 2;
+	let n_test_queries = 3;
+	// The reduced (first-round) code dimension is the largest oracle dimension.
+	let reduced_log_dim = oracle_log_dims.iter().copied().max().unwrap();
+
+	let merkle_prover = BinaryMerkleTreeProver::<F, StdHashSuite>::new();
+
+	// A single shared domain context covers the reduced code; every per-oracle (smaller) code is
+	// derived from it so their subspaces are nested prefixes of the reduced subspace.
+	let subspace = BinarySubspace::with_dim(reduced_log_dim + log_inv_rate);
+	let domain_context = GenericOnTheFly::generate_from_subspace(&subspace);
+	let ntt = NeighborsLastSingleThread::new(domain_context);
+
+	// Each oracle has message length `log_dim + log_batch_size`, with its batch size fixed so the
+	// reduced dimension is forced to `reduced_log_dim`.
+	let oracle_specs = iter::zip(oracle_log_dims, log_batch_sizes)
+		.map(|(log_dim, log_batch_size)| PartialOracleSpec {
+			log_msg_len: log_dim + log_batch_size,
+			log_batch_size: Some(log_batch_size),
+		})
+		.collect::<Vec<_>>();
+	let (params, _proof_size) = FRIParams::<F>::optimal_for_batch(
+		ntt.domain_context(),
+		merkle_prover.scheme(),
+		&oracle_specs,
+		log_inv_rate,
+		n_test_queries,
+	);
+	assert_eq!(params.rs_code().log_dim(), reduced_log_dim);
+
+	// Commit each input oracle's interleaved codeword separately, using its own smaller code built
+	// from the shared domain context.
+	let mut messages = Vec::new();
+	let mut commitments = Vec::new();
+	let mut committeds = Vec::new();
+	let mut codewords = Vec::new();
+	for (&log_dim, &log_batch_size) in iter::zip(&oracle_log_dims, &log_batch_sizes) {
+		let rs_code = ReedSolomonCode::with_domain_context_subspace(
+			ntt.domain_context(),
+			log_dim,
+			log_inv_rate,
+		);
+		let oracle_params =
+			FRIParams::new(rs_code, log_batch_size, vec![], n_test_queries).unwrap();
+		let msg = random_field_buffer::<P>(&mut rng, log_dim + log_batch_size);
+		let CommitOutput {
+			commitment,
+			committed,
+			codeword,
+		} = commit_interleaved(&oracle_params, &ntt, &merkle_prover, msg.to_ref()).unwrap();
+		messages.push(msg);
+		commitments.push(commitment);
+		committeds.push(committed);
+		codewords.push(codeword);
+	}
+
+	// Run the prover: write the per-oracle codeword commitments, then fold.
+	let committed_codewords = iter::zip(codewords, &committeds).collect::<Vec<_>>();
+	let mut round_prover =
+		FRIFoldProver::new_batch(&params, &ntt, &merkle_prover, committed_codewords).unwrap();
+
+	let mut prover_challenger = ProverTranscript::new(StdChallenger::default());
+	for commitment in &commitments {
+		prover_challenger.message().write(commitment);
+	}
+
+	let fold_round_output = round_prover.execute_fold_round();
+	if let FoldRoundOutput::Commitment(round_commitment) = fold_round_output {
+		prover_challenger.message().write(&round_commitment);
+	}
+	for _ in 0..params.n_fold_rounds() {
+		let challenge = prover_challenger.sample();
+		round_prover.receive_challenge(challenge);
+
+		let fold_round_output = round_prover.execute_fold_round();
+		if let FoldRoundOutput::Commitment(round_commitment) = fold_round_output {
+			prover_challenger.message().write(&round_commitment);
+		}
+	}
+	round_prover.finish_proof(&mut prover_challenger).unwrap();
+
+	// Run the verifier.
+	let mut verifier_challenger = prover_challenger.into_verifier();
+	let read_commitments = commitments
+		.iter()
+		.map(|_| verifier_challenger.message().read().unwrap())
+		.collect::<Vec<_>>();
+
+	let mut verifier_challenges = Vec::with_capacity(params.n_fold_rounds());
+	let mut fri_fold_verifier = FRIFoldVerifier::new(&params);
+	fri_fold_verifier
+		.process_round(&mut verifier_challenger.message())
+		.unwrap();
+	for _ in 0..params.n_fold_rounds() {
+		verifier_challenges.push(verifier_challenger.sample());
+		fri_fold_verifier
+			.process_round(&mut verifier_challenger.message())
+			.unwrap();
+	}
+	let round_commitments = fri_fold_verifier.finalize().unwrap();
+
+	let verifier = FRIQueryVerifier::new_batch(
+		&params,
+		merkle_prover.scheme(),
+		&read_commitments,
+		&round_commitments,
+		&verifier_challenges,
+	)
+	.unwrap();
+	let final_value = verifier.verify(&mut verifier_challenger).unwrap();
+
+	// The first fold reduces oracle `i` by its inner challenges (the last `log_batch_size_i` of the
+	// first `max_log_batch_size` challenges) and combines the oracles with the outer-challenge
+	// tensor. The remaining `reduced_log_dim` tail challenges fold the combined codeword.
+	//
+	// Lifting oracle `i` embeds its codeword as `Enc_M(ZeroPadMSB_eta(m_i'))`, whose multilinear
+	// extension factors as `m_i'(low vars) * prod_j (1 - Y_j)` over the `eta_i = reduced_log_dim -
+	// log_dim_i` padded high variables. Folding `Enc_M(X)` evaluates `X` at the reversed tail
+	// challenges, so the padded high variables are bound by the first `eta_i` tail challenges
+	// (contributing the factor `prod (1 - tail_k)`), and the surviving `log_dim_i` tail challenges
+	// bind the real message. Hence the final value is
+	//   sum_i outer_tensor[i] * prod_{k<eta_i}(1 - tail_k)
+	//                          * evaluate(msg_i, reversed(inner_i ++ tail[eta_i..])).
+	let max_log_batch_size = log_batch_sizes.iter().copied().max().unwrap();
+	let first_fold_arity = params.log_batch_size();
+	let inner = &verifier_challenges[..max_log_batch_size];
+	let outer = &verifier_challenges[max_log_batch_size..first_fold_arity];
+	let tail = &verifier_challenges[first_fold_arity..];
+	let outer_tensor = eq_ind_partial_eval_scalars::<F>(outer);
+
+	let mut expected = F::ZERO;
+	for (i, ((msg, &log_batch_size), &log_dim)) in
+		iter::zip(iter::zip(&messages, &log_batch_sizes), &oracle_log_dims).enumerate()
+	{
+		let eta = reduced_log_dim - log_dim;
+		// The lift (oracle padding) factor from the zero-padded high message variables.
+		let pad_factor = tail[..eta].iter().map(|&t| F::ONE - t).product::<F>();
+		let inner_i = &inner[max_log_batch_size - log_batch_size..];
+		let mut eval_point = inner_i
+			.iter()
+			.chain(&tail[eta..])
+			.copied()
+			.collect::<Vec<_>>();
+		eval_point.reverse();
+		expected += outer_tensor[i] * pad_factor * evaluate(msg, &eval_point);
+	}
+	assert_eq!(final_value, expected);
+}
+
 /// Runs the FRI prover and returns the proof bytes along with the FRI params and Merkle scheme,
 /// so the caller can check the estimated proof size.
 fn generate_fri_proof<F, P>(

--- a/crates/iop/src/fri/batch.rs
+++ b/crates/iop/src/fri/batch.rs
@@ -50,19 +50,29 @@ where
 	challenges: Vec<F>,
 	commitment: Commitment<MTScheme::Digest>,
 	merkle_scheme: MTScheme,
+	/// log2 the lift factor (oracle padding). The committed codeword is virtually duplicated
+	/// `2^log_lift` times to reach the common first-round length; a query at global index `k`
+	/// reads the committed codeword at `k >> log_lift`. Zero when no lifting is needed.
+	log_lift: usize,
 }
 
 impl<F: BinaryField, MTScheme: MerkleTreeScheme<F>> BrakedownOracle<F, MTScheme> {
 	/// Constructs a new oracle from the committed interleaved codeword and the folding challenges.
+	///
+	/// `log_lift` is the oracle-padding lift factor (the committed codeword is virtually duplicated
+	/// `2^log_lift` times to reach the common first-round length); pass `0` when no lifting is
+	/// needed.
 	pub fn new(
 		challenges: Vec<F>,
 		commitment: Commitment<MTScheme::Digest>,
 		merkle_scheme: MTScheme,
+		log_lift: usize,
 	) -> Self {
 		Self {
 			challenges,
 			commitment,
 			merkle_scheme,
+			log_lift,
 		}
 	}
 }
@@ -71,7 +81,9 @@ impl<F: BinaryField, MTScheme: MerkleTreeScheme<F, Digest: DeserializeBytes>> Pr
 	for BrakedownOracle<F, MTScheme>
 {
 	fn log_len(&self) -> usize {
-		self.commitment.depth
+		// The virtual (lifted) oracle length: the committed tree depth duplicated `2^log_lift`
+		// times.
+		self.commitment.depth + self.log_lift
 	}
 
 	fn open_queries<B: Buf>(
@@ -80,11 +92,17 @@ impl<F: BinaryField, MTScheme: MerkleTreeScheme<F, Digest: DeserializeBytes>> Pr
 		advice: &mut TranscriptReader<B>,
 	) -> Result<Vec<F>, Error> {
 		assert!(indices.iter().all(|&index| index < 1 << self.log_len())); // precondition
+		// Translate each query on the virtual lifted oracle into a query on the committed codeword
+		// by dropping the low `log_lift` bits (the duplicated copies).
+		let lifted_indices = indices
+			.iter()
+			.map(|&index| index >> self.log_lift)
+			.collect::<Vec<_>>();
 		verify_query_openings(
 			&self.merkle_scheme,
 			&self.commitment,
 			self.challenges.len(),
-			indices,
+			&lifted_indices,
 			advice,
 		)?
 		.map(|opening| {
@@ -127,6 +145,13 @@ impl<F: BinaryField, MTScheme: MerkleTreeScheme<F, Digest: DeserializeBytes>> Pr
 	for BatchBrakedownOracle<F, MTScheme>
 {
 	fn log_len(&self) -> usize {
+		// Every bundled oracle reports the same virtual (lifted) length: the common first-round
+		// codeword length they are batched into.
+		debug_assert!(
+			self.oracles
+				.iter()
+				.all(|oracle| oracle.log_len() == self.oracles[0].log_len())
+		);
 		self.oracles[0].log_len()
 	}
 

--- a/crates/iop/src/fri/common.rs
+++ b/crates/iop/src/fri/common.rs
@@ -27,7 +27,8 @@ pub struct FRIParams<F> {
 	rs_code: ReedSolomonCode<F>,
 	/// Guaranteed to be non-empty.
 	input_oracles: Vec<OracleSpec>,
-	/// log2 the maximum message length of all input oracles.
+	/// log2 the maximum message length of all input oracles, after lifting each to the reduced
+	/// dimension. Equals `rs_code.log_dim() + max(input_oracles.log_batch_size)`.
 	max_log_msg_len: usize,
 	/// log2 ceiling of the number of input oracles.
 	log_n_oracles: usize,
@@ -185,11 +186,6 @@ where
 		}
 
 		let log_n_oracles = log2_ceil_usize(oracles.len());
-		let max_log_msg_len = oracles
-			.iter()
-			.map(|oracle| oracle.log_msg_len)
-			.max()
-			.expect("precondition: oracles is not empty");
 
 		let ChooseBatchSizeAndAritiesOutput {
 			proof_size,
@@ -197,6 +193,18 @@ where
 			oracle_specs,
 			fold_arities,
 		} = choose_batch_size_and_arities_multi(merkle_scheme, oracles, log_inv_rate, n_test_queries);
+
+		// After lifting, every input oracle sits at the reduced dimension with its own interleaved
+		// batch, so the effective maximum message length is the reduced dimension plus the largest
+		// batch size. This is what the first fold must consume (the inner, per-oracle interleave
+		// folds) before the `log_n_oracles` outer folds that batch the oracles together. Without
+		// lifting this equals `max(oracle.log_msg_len)`.
+		let max_log_batch_size = oracle_specs
+			.iter()
+			.map(|spec| spec.log_batch_size)
+			.max()
+			.expect("precondition: oracles is not empty");
+		let max_log_msg_len = reduced_log_msg_len + max_log_batch_size;
 
 		let rs_code = ReedSolomonCode::with_domain_context_subspace(
 			domain_context,

--- a/crates/iop/src/fri/verify.rs
+++ b/crates/iop/src/fri/verify.rs
@@ -101,16 +101,19 @@ where
 			)));
 		}
 
-		// Temporary restriction: lifted FRI is not yet implemented, so every input oracle must
-		// reduce to exactly the first-round Reed-Solomon code. FRIParams only guarantees the
-		// inequality `log_msg_len - log_batch_size <= rs_code.log_dim()`.
+		// Each input oracle's Reed-Solomon dimension must not exceed the first-round (reduced) code
+		// dimension; smaller oracles are lifted (padded) to it. FRIParams only guarantees the
+		// inequality `log_msg_len - log_batch_size <= rs_code.log_dim()`, so validate it here
+		// rather than trusting the caller.
 		let log_dim = params.rs_code().log_dim();
+		let log_inv_rate = params.rs_code().log_inv_rate();
 		for spec in params.input_oracles() {
-			assert_eq!(
-				spec.log_msg_len - spec.log_batch_size,
-				log_dim,
-				"lifted FRI is unsupported: input oracle dimension must equal rs_code.log_dim()"
-			);
+			if spec.log_msg_len - spec.log_batch_size > log_dim {
+				return Err(Error::InvalidArgs(format!(
+					"input oracle dimension {} exceeds the reduced code dimension {log_dim}",
+					spec.log_msg_len - spec.log_batch_size,
+				)));
+			}
 		}
 
 		// The committed codeword's Merkle tree has one coset per leaf, so its depth is the number
@@ -129,13 +132,20 @@ where
 		let outer_challenges = challenges[max_log_batch_size..params.log_batch_size()].to_vec();
 		let codeword_sub_oracles = iter::zip(codeword_commitments, params.input_oracles())
 			.map(|(commitment, spec)| {
+				// The oracle's own codeword has dimension `log_msg_len - log_batch_size`, so its
+				// Merkle tree depth is that plus the inverse rate. It is lifted to the common
+				// first-round length (`index_bits`) by duplicating each entry `2^log_lift` times.
+				let oracle_log_dim = spec.log_msg_len - spec.log_batch_size;
+				let depth = oracle_log_dim + log_inv_rate;
+				let log_lift = log_dim - oracle_log_dim;
 				BrakedownOracle::new(
 					inner_challenges[max_log_batch_size - spec.log_batch_size..].to_vec(),
 					Commitment {
 						root: commitment.clone(),
-						depth: index_bits,
+						depth,
 					},
 					vcs,
+					log_lift,
 				)
 			})
 			.collect();

--- a/crates/math/src/reed_solomon.rs
+++ b/crates/math/src/reed_solomon.rs
@@ -279,4 +279,82 @@ mod tests {
 		// Test where message length is less than the packing width and codeword length is greater.
 		test_encode_batch_helper::<PackedBinaryGhash4x128b>(1, 2, 0);
 	}
+
+	/// Pins the codeword-duplication identity that underlies Lifted FRI (oracle padding).
+	///
+	/// Lifting a message `π` of dimension `m` to a larger dimension `M = m + η` zero-pads it on
+	/// the most-significant hypercube coordinates (`ZeroPadMSB_η`). The novel-basis / bit-reversed
+	/// encoding turns this into a *duplication* of the codeword: encoding the lifted message over
+	/// the dimension-`M` code yields each entry of the dimension-`m` codeword repeated `2^η` times.
+	/// This test asserts the contiguous form `Enc_M(ZeroPadMSB_η(π))[j] == Enc_m(π)[j >> η]`, which
+	/// is the index translation Lifted FRI's prover and verifier rely on.
+	fn test_lift_duplicate_identity_helper<P: PackedField>(
+		log_dim_small: usize,
+		log_dim_large: usize,
+		log_inv_rate: usize,
+	) where
+		P::Scalar: BinaryField,
+	{
+		assert!(log_dim_small <= log_dim_large);
+		let eta = log_dim_large - log_dim_small;
+
+		let mut rng = StdRng::seed_from_u64(0);
+
+		// Both codes are derived from a single shared domain context covering the larger code, so
+		// the smaller code's subspace is the prefix the shared NTT twiddles expect.
+		let subspace = BinarySubspace::<P::Scalar>::with_dim(log_dim_large + log_inv_rate);
+		let domain_context = GenericPreExpanded::<P::Scalar>::generate_from_subspace(&subspace);
+		let ntt = NeighborsLastReference {
+			domain_context: &domain_context,
+		};
+
+		let rs_small = ReedSolomonCode::with_domain_context_subspace(
+			&domain_context,
+			log_dim_small,
+			log_inv_rate,
+		);
+		let rs_large = ReedSolomonCode::with_domain_context_subspace(
+			&domain_context,
+			log_dim_large,
+			log_inv_rate,
+		);
+
+		// Random message for the small code.
+		let msg_small = random_field_buffer::<P>(&mut rng, log_dim_small);
+
+		// ZeroPadMSB lift: the small message occupies the low `2^log_dim_small` hypercube values,
+		// the high coordinates are zero.
+		let mut msg_large = FieldBuffer::<P>::zeros(log_dim_large);
+		for (i, val) in msg_small.iter_scalars().enumerate() {
+			msg_large.set(i, val);
+		}
+
+		let enc_small = rs_small.encode_batch(&ntt, msg_small.to_ref(), 0);
+		let enc_large = rs_large.encode_batch(&ntt, msg_large.to_ref(), 0);
+
+		let small_scalars = enc_small.iter_scalars().collect::<Vec<_>>();
+		let large_scalars = enc_large.iter_scalars().collect::<Vec<_>>();
+		assert_eq!(small_scalars.len(), 1 << (log_dim_small + log_inv_rate));
+		assert_eq!(large_scalars.len(), 1 << (log_dim_large + log_inv_rate));
+
+		for (j, &large) in large_scalars.iter().enumerate() {
+			assert_eq!(
+				large,
+				small_scalars[j >> eta],
+				"lift identity failed at index {j} (eta = {eta})"
+			);
+		}
+	}
+
+	#[test]
+	fn test_lift_duplicate_identity() {
+		// eta = 0 degrades to plain equality.
+		test_lift_duplicate_identity_helper::<PackedBinaryGhash1x128b>(6, 6, 2);
+		// Non-trivial lifts of varying sizes.
+		test_lift_duplicate_identity_helper::<PackedBinaryGhash1x128b>(4, 6, 2);
+		test_lift_duplicate_identity_helper::<PackedBinaryGhash1x128b>(2, 8, 1);
+		test_lift_duplicate_identity_helper::<PackedBinaryGhash1x128b>(0, 4, 3);
+		// Same lifts with a wider packing width.
+		test_lift_duplicate_identity_helper::<PackedBinaryGhash4x128b>(4, 8, 2);
+	}
 }


### PR DESCRIPTION
## Summary
- Add oracle padding (Lifted FRI) to batched FRI: input oracles of smaller Reed-Solomon dimension are lifted to the reduced first-round dimension by codeword duplication, so a single batched proximity proof can mix oracles of differing sizes. Implements the whitepaper's Lifted BaseFold, unblocking Batched (ZK) BaseFold (BINIUS-48).
- Verifier: `BrakedownOracle` gains a lift factor and translates a query `k -> k >> log_lift` onto the smaller committed tree; `new_batch` validates `m_i <= M` (replacing a panicking assert) and wires per-oracle depth/lift.
- Prover: `BatchBrakedownFolder` duplicates each smaller folded codeword before the outer-tensor combine; `BrakedownOracleProver` translates query indices to match.
- Params: `optimal_for_batch` sizes the first fold as `M + max(log_batch_size)` so a small-dimension/large-batch oracle is not dropped from the batch (no-op when nothing is lifted).
- Tests: a Reed-Solomon duplication-identity test, and a full lifted-FRI round-trip over dims `[6, 8, 4]` (incl. `eta = 0`) checking the verifier accepts and the final value matches the analytical lifted formula.

## Test plan
- `cargo test -p binius-math --lib reed_solomon`
- `cargo test -p binius-iop --lib fri`
- `cargo test -p binius-iop-prover --lib fri`
- `cargo clippy -p binius-math -p binius-iop -p binius-iop-prover --all-features --tests -- -D warnings`

Closes BINIUS-51.
