### PR TITLE
[iop] Batch the first sumcheck in the ZK BaseFold compiler

### DIFF
--- a/crates/iop-prover/src/basefold.rs
+++ b/crates/iop-prover/src/basefold.rs
@@ -3,9 +3,10 @@
 
 use binius_field::{BinaryField, PackedField};
 use binius_iop::merkle_tree::MerkleTreeScheme;
-use binius_ip::sumcheck::RoundCoeffs;
+use binius_ip::{mlecheck, sumcheck::RoundCoeffs};
 use binius_ip_prover::sumcheck::{
 	bivariate_product::BivariateProductSumcheckProver, common::SumcheckProver,
+	multilinear_eval::MultilinearEvalProver,
 };
 use binius_math::{
 	FieldBuffer, inner_product::inner_product_par, line::extrapolate_line_packed, ntt::AdditiveNTT,
@@ -232,6 +233,84 @@ where
 	BaseFoldProver::new(multilinear, transparent_multilinear, batched_sum, fri_folder)
 }
 
+/// Proves a multilinear evaluation claim `witness(eval_point) = eval_claim` by interleaving an
+/// [`MultilinearEvalProver`] MLE-check with FRI folding (the second, FRI-interleaved sumcheck of
+/// the Batched ZK BaseFold construction).
+///
+/// Unlike [`prove_zk`], the masked oracle `π' = π + γ·ω` has already been formed by the caller (it
+/// is passed as `witness`) and the linear opening claim has already been reduced to this point
+/// evaluation by a prior batched sumcheck. Here we only run the degree-1 MLE-check on `witness`
+/// against `eval_point`, interleaved with the FRI codeword of the committed interleaved `[π ‖ ω]`.
+///
+/// ## Arguments
+///
+/// * `witness` - the masked oracle multilinear `π'` with `log_len = n`
+/// * `eval_point` - the evaluation point `ρ` with `len = n`, in low-to-high variable order
+/// * `eval_claim` - the claimed value `π'(ρ)`
+/// * `batch_challenge` - the masking challenge `γ`; folds the interleaved `[π ‖ ω]` codeword down
+///   to the codeword of `π'` in the FRI unbatch round
+/// * `fri_folder` - the FRI fold prover over the `[π ‖ ω]` codeword, with `n_rounds == n + 1`
+/// * `transcript` - the prover transcript
+///
+/// The final FRI value equals the final MLE-check value `π'(r)` (see
+/// [`binius_iop::basefold::mlecheck_fri_consistency`]).
+pub fn prove_mlecheck_basefold_zk<'a, F, P, NTT, MerkleScheme, MerkleProver, Challenger_>(
+	witness: FieldBuffer<P>,
+	eval_point: &[F],
+	eval_claim: F,
+	batch_challenge: F,
+	mut fri_folder: FRIFoldProver<'a, F, P, NTT, MerkleProver>,
+	transcript: &mut ProverTranscript<Challenger_>,
+) -> Result<(), Error>
+where
+	F: BinaryField,
+	P: PackedField<Scalar = F>,
+	NTT: AdditiveNTT<Field = F> + Sync,
+	MerkleScheme: MerkleTreeScheme<F, Digest: SerializeBytes>,
+	MerkleProver: MerkleTreeProver<F, Scheme = MerkleScheme>,
+	Challenger_: Challenger,
+{
+	let _scope = tracing::debug_span!("Basefold MLE-check ZK").entered();
+
+	let n_vars = witness.log_len();
+	assert_eq!(eval_point.len(), n_vars);
+	// The FRI folder operates on the codeword of the interleaved (π ‖ ω) polynomial, so
+	// `n_rounds == n + 1`.
+	assert_eq!(n_vars + 1, fri_folder.n_rounds());
+
+	// Unbatch round: fold the interleaved (π ‖ ω) codeword at the masking challenge to obtain the
+	// codeword of π'. No commitment is produced at this round.
+	fri_folder.receive_challenge(batch_challenge);
+
+	let mut sumcheck = MultilinearEvalProver::new(witness, eval_point, eval_claim)?;
+	for _ in 0..n_vars {
+		let mut round_coeffs_vec = sumcheck.execute()?;
+		let round_coeffs = round_coeffs_vec
+			.pop()
+			.expect("MultilinearEvalProver proves exactly one claim");
+		let commitment = fri_folder.execute_fold_round();
+
+		transcript
+			.message()
+			.write_scalar_slice(mlecheck::RoundProof::truncate(round_coeffs).coeffs());
+		if let FoldRoundOutput::Commitment(commitment) = commitment {
+			transcript.message().write(&commitment);
+		}
+
+		let challenge = transcript.sample();
+		sumcheck.fold(challenge)?;
+		fri_folder.receive_challenge(challenge);
+	}
+
+	let commitment = fri_folder.execute_fold_round();
+	if let FoldRoundOutput::Commitment(commitment) = commitment {
+		transcript.message().write(&commitment);
+	}
+	fri_folder.finish_proof(transcript);
+
+	Ok(())
+}
+
 #[cfg(test)]
 mod test {
 	use anyhow::{Result, bail};
@@ -244,16 +323,21 @@ mod test {
 	use binius_math::{
 		BinarySubspace, FieldBuffer,
 		inner_product::inner_product_buffers,
+		line::extrapolate_line_packed,
 		multilinear::eq::eq_ind_partial_eval,
 		ntt::{AdditiveNTT, NeighborsLastSingleThread, domain_context::GenericOnTheFly},
 		test_utils::{random_field_buffer, random_scalars},
 	};
-	use binius_transcript::{ProverTranscript, fiat_shamir::HasherChallenger};
+	use binius_transcript::{
+		ProverTranscript,
+		fiat_shamir::{CanSample, HasherChallenger},
+	};
+	use binius_utils::rayon::prelude::*;
 	use rand::{SeedableRng, rngs::StdRng};
 
-	use super::{BaseFoldProver, prove_zk};
+	use super::{BaseFoldProver, prove_mlecheck_basefold_zk, prove_zk};
 	use crate::{
-		fri::{self, CommitOutput, FRIFoldProver},
+		fri::{self, CommitMaskedOutput, CommitOutput, FRIFoldProver},
 		merkle_tree::prover::BinaryMerkleTreeProver,
 	};
 
@@ -520,5 +604,129 @@ mod test {
 
 		run_basefold_prove_and_verify::<_, P>(multilinear, evaluation_point, evaluation_claim)
 			.unwrap();
+	}
+
+	/// Drives [`prove_mlecheck_basefold_zk`] against
+	/// [`binius_iop::basefold::verify_mlecheck_basefold_zk`]: commits the interleaved (π ‖ ω)
+	/// codeword, samples the masking challenge γ, forms π' = (1-γ)π + γω, and proves/verifies the
+	/// point-evaluation claim π'(ρ). If `tamper`, the claim is corrupted and verification must
+	/// fail.
+	fn run_mlecheck_basefold_zk_prove_and_verify<F, P>(
+		witness: FieldBuffer<P>,
+		evaluation_point: Vec<F>,
+		tamper: bool,
+	) -> Result<()>
+	where
+		F: BinaryField,
+		P: PackedField<Scalar = F> + PackedExtension<F>,
+	{
+		let n_vars = evaluation_point.len();
+		assert_eq!(witness.log_len(), n_vars);
+
+		let merkle_prover = BinaryMerkleTreeProver::<F, StdHashSuite>::new();
+
+		let subspace = BinarySubspace::with_dim(n_vars + LOG_INV_RATE);
+		let domain_context = GenericOnTheFly::generate_from_subspace(&subspace);
+		let ntt = NeighborsLastSingleThread::new(domain_context);
+
+		let fri_params = binius_iop::fri::FRIParams::with_strategy(
+			ntt.domain_context(),
+			merkle_prover.scheme(),
+			n_vars + 1,
+			Some(1),
+			LOG_INV_RATE,
+			32,
+			&ConstantArityStrategy::new(2),
+		);
+
+		// Commit the interleaved (witness ‖ mask), generating the mask internally.
+		let mut commit_rng = StdRng::seed_from_u64(7);
+		let CommitMaskedOutput {
+			commitment: codeword_commitment,
+			committed: codeword_committed,
+			codeword,
+			mask,
+		} = fri::commit_masked(&fri_params, &ntt, &merkle_prover, witness.to_ref(), &mut commit_rng);
+
+		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
+		prover_transcript.message().write(&codeword_commitment);
+
+		// Sample the masking challenge γ and form π' = (1-γ)·witness + γ·mask.
+		let batch_challenge: F = prover_transcript.sample();
+		let mut witness_prime = witness.clone();
+		let gamma_broadcast = P::broadcast(batch_challenge);
+		(witness_prime.as_mut(), mask.as_ref())
+			.into_par_iter()
+			.for_each(|(w, &m)| {
+				*w = extrapolate_line_packed(*w, m, gamma_broadcast);
+			});
+
+		let eval_point_eq = eq_ind_partial_eval::<P>(&evaluation_point);
+		let mut eval_claim = inner_product_buffers(&witness_prime, &eval_point_eq);
+		if tamper {
+			eval_claim += F::ONE;
+		}
+
+		let fri_folder =
+			FRIFoldProver::new(&fri_params, &ntt, &merkle_prover, codeword, &codeword_committed);
+		prove_mlecheck_basefold_zk(
+			witness_prime,
+			&evaluation_point,
+			eval_claim,
+			batch_challenge,
+			fri_folder,
+			&mut prover_transcript,
+		)?;
+
+		let mut verifier_transcript = prover_transcript.into_verifier();
+		let retrieved_commitment = verifier_transcript.message().read()?;
+		let batch_challenge_v: F = verifier_transcript.sample();
+
+		let verifier_basefold::ReducedOutput {
+			final_fri_value,
+			final_sumcheck_value,
+			..
+		} = verifier_basefold::verify_mlecheck_basefold_zk(
+			&fri_params,
+			merkle_prover.scheme(),
+			retrieved_commitment,
+			eval_claim,
+			&evaluation_point,
+			batch_challenge_v,
+			&mut verifier_transcript,
+		)?;
+
+		if !verifier_basefold::mlecheck_fri_consistency(final_fri_value, final_sumcheck_value) {
+			bail!("MLE-check and FRI are inconsistent");
+		}
+
+		Ok(())
+	}
+
+	#[test]
+	fn test_mlecheck_basefold_zk_valid_proof() {
+		type P = PackedBinaryGhash1x128b;
+
+		let n_vars = 8;
+		let mut rng = StdRng::seed_from_u64(0);
+		let witness = random_field_buffer::<P>(&mut rng, n_vars);
+		let evaluation_point = random_scalars(&mut rng, n_vars);
+
+		run_mlecheck_basefold_zk_prove_and_verify::<_, P>(witness, evaluation_point, false)
+			.unwrap();
+	}
+
+	#[test]
+	fn test_mlecheck_basefold_zk_invalid_proof() {
+		type P = PackedBinaryGhash1x128b;
+
+		let n_vars = 8;
+		let mut rng = StdRng::seed_from_u64(0);
+		let witness = random_field_buffer::<P>(&mut rng, n_vars);
+		let evaluation_point = random_scalars(&mut rng, n_vars);
+
+		let result =
+			run_mlecheck_basefold_zk_prove_and_verify::<_, P>(witness, evaluation_point, true);
+		assert!(result.is_err());
 	}
 }

--- a/crates/iop-prover/src/basefold.rs
+++ b/crates/iop-prover/src/basefold.rs
@@ -8,14 +8,12 @@ use binius_ip_prover::sumcheck::{
 	bivariate_product::BivariateProductSumcheckProver, common::SumcheckProver,
 	multilinear_eval::MultilinearEvalProver,
 };
-use binius_math::{
-	FieldBuffer, inner_product::inner_product_par, line::extrapolate_line_packed, ntt::AdditiveNTT,
-};
+use binius_math::{FieldBuffer, ntt::AdditiveNTT};
 use binius_transcript::{
 	ProverTranscript,
 	fiat_shamir::{CanSample, Challenger},
 };
-use binius_utils::{SerializeBytes, rayon::prelude::*};
+use binius_utils::SerializeBytes;
 
 use crate::{
 	fri::{FRIFoldProver, FoldRoundOutput},
@@ -163,84 +161,14 @@ where
 	}
 }
 
-/// Performs ZK batching setup and returns a BaseFoldProver for the remaining protocol.
-///
-/// This handles the zero-knowledge case where the witness is blinded with a random mask.
-/// It performs the initial unbatch round and returns a prover configured for the remaining
-/// n rounds of sumcheck + FRI.
-///
-/// ## Arguments
-///
-/// * `multilinear` - batched (witness || mask) polynomial with log_len = n+1
-/// * `transparent_multilinear` - l_poly with log_len = n
-/// * `claim` - the original sumcheck claim (before ZK batching)
-/// * `fri_folder` - FRI fold prover with n_rounds = n+1
-/// * `transcript` - prover transcript
-///
-/// ## Returns
-///
-/// A `BaseFoldProver` configured for the remaining n rounds. Caller should call
-/// `.prove(transcript)`.
-pub fn prove_zk<'a, F, P, NTT, MerkleScheme, MerkleProver, Challenger_>(
-	mut multilinear: FieldBuffer<P>,
-	mask: FieldBuffer<P>,
-	transparent_multilinear: FieldBuffer<P>,
-	sum_claim: F,
-	mut fri_folder: FRIFoldProver<'a, F, P, NTT, MerkleProver>,
-	transcript: &mut ProverTranscript<Challenger_>,
-) -> BaseFoldProver<'a, F, P, NTT, MerkleProver>
-where
-	F: BinaryField,
-	P: PackedField<Scalar = F>,
-	NTT: AdditiveNTT<Field = F> + Sync,
-	MerkleScheme: MerkleTreeScheme<F, Digest: SerializeBytes>,
-	MerkleProver: MerkleTreeProver<F, Scheme = MerkleScheme>,
-	Challenger_: Challenger,
-{
-	let _scope = tracing::debug_span!("Basefold ZK setup").entered();
-
-	// The FRI folder operates on the codeword of the combined (witness || mask) polynomial,
-	// so `n_rounds == multilinear.log_len() + 1`.
-	let n_rounds = fri_folder.n_rounds();
-	assert_eq!(multilinear.log_len() + 1, n_rounds);
-	assert_eq!(mask.log_len(), multilinear.log_len());
-	assert_eq!(transparent_multilinear.log_len(), multilinear.log_len());
-
-	// Compute blinding_eval = sum_x[mask * l_poly]
-	// The verifier will compute sum = (1-r)*claim + r*blinding_eval using linear interpolation.
-	let mask_claim = inner_product_par(&mask, &transparent_multilinear);
-
-	// Write blinding_eval to transcript
-	transcript.message().write(&mask_claim);
-
-	// Sample batch challenge (before FRI fold round, matching verifier order)
-	let batch_challenge: F = transcript.sample();
-
-	// Receive batch challenge to advance to round 1 (no commitment at batch round)
-	fri_folder.receive_challenge(batch_challenge);
-
-	// Fold multilinear at its last variable.
-	let batch_challenge_broadcast = P::broadcast(batch_challenge);
-	(multilinear.as_mut(), mask.as_ref())
-		.into_par_iter()
-		.for_each(|(multilinear_i, mask_i)| {
-			*multilinear_i =
-				extrapolate_line_packed(*multilinear_i, *mask_i, batch_challenge_broadcast);
-		});
-
-	// Compute the batched sum using linear interpolation.
-	let batched_sum = extrapolate_line_packed(sum_claim, mask_claim, batch_challenge);
-	BaseFoldProver::new(multilinear, transparent_multilinear, batched_sum, fri_folder)
-}
-
 /// Proves a multilinear evaluation claim `witness(eval_point) = eval_claim` by interleaving an
 /// [`MultilinearEvalProver`] MLE-check with FRI folding (the second, FRI-interleaved sumcheck of
 /// the Batched ZK BaseFold construction).
 ///
-/// Unlike [`prove_zk`], the masked oracle `π' = π + γ·ω` has already been formed by the caller (it
-/// is passed as `witness`) and the linear opening claim has already been reduced to this point
-/// evaluation by a prior batched sumcheck. Here we only run the degree-1 MLE-check on `witness`
-/// against `eval_point`, interleaved with the FRI codeword of the committed interleaved `[π ‖ ω]`.
+/// The masked oracle `π' = π + γ·ω` has already been formed by the caller (it is passed as
+/// `witness`) and the linear opening claim has already been reduced to this point evaluation by a
+/// prior batched sumcheck. Here we only run the degree-1 MLE-check on `witness` against
+/// `eval_point`, interleaved with the FRI codeword of the committed interleaved `[π ‖ ω]`.
 ///
 /// ## Arguments
 ///
@@ -335,7 +263,7 @@ mod test {
 	use binius_utils::rayon::prelude::*;
 	use rand::{SeedableRng, rngs::StdRng};
 
-	use super::{BaseFoldProver, prove_mlecheck_basefold_zk, prove_zk};
+	use super::{BaseFoldProver, prove_mlecheck_basefold_zk};
 	use crate::{
 		fri::{self, CommitMaskedOutput, CommitOutput, FRIFoldProver},
 		merkle_tree::prover::BinaryMerkleTreeProver,
@@ -443,121 +371,6 @@ mod test {
 		P: PackedField<Scalar = F>,
 	{
 		*claim += P::Scalar::ONE
-	}
-
-	fn run_basefold_zk_prove_and_verify<F, P>(
-		witness: FieldBuffer<P>,
-		mask: FieldBuffer<P>,
-		evaluation_point: Vec<F>,
-		evaluation_claim: F,
-	) -> Result<()>
-	where
-		F: BinaryField,
-		P: PackedField<Scalar = F> + PackedExtension<F>,
-	{
-		let n_vars = evaluation_point.len();
-		assert_eq!(witness.log_len(), n_vars);
-		assert_eq!(mask.log_len(), n_vars);
-
-		let eval_point_eq = eq_ind_partial_eval::<P>(&evaluation_point);
-
-		let merkle_prover = BinaryMerkleTreeProver::<F, StdHashSuite>::new();
-
-		// Setup NTT with subspace dimension = witness.log_len + LOG_INV_RATE
-		let subspace = BinarySubspace::with_dim(n_vars + LOG_INV_RATE);
-		let domain_context = GenericOnTheFly::generate_from_subspace(&subspace);
-		let ntt = NeighborsLastSingleThread::new(domain_context);
-
-		// Create FRI params with log_batch_size = 1
-		let fri_params = binius_iop::fri::FRIParams::with_strategy(
-			ntt.domain_context(),
-			merkle_prover.scheme(),
-			n_vars + 1,
-			Some(1),
-			LOG_INV_RATE,
-			32,
-			&ConstantArityStrategy::new(2),
-		);
-
-		// Build the combined (witness || mask) buffer for commitment.
-		let combined_values: Vec<P> = witness
-			.as_ref()
-			.iter()
-			.chain(mask.as_ref())
-			.copied()
-			.collect();
-		let witness_plus_mask = FieldBuffer::new(n_vars + 1, combined_values.into_boxed_slice());
-
-		// Commit batched multilinear
-		let CommitOutput {
-			commitment: codeword_commitment,
-			committed: codeword_committed,
-			codeword,
-		} = fri::commit_interleaved(&fri_params, &ntt, &merkle_prover, witness_plus_mask.to_ref());
-
-		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
-		prover_transcript.message().write(&codeword_commitment);
-
-		let fri_folder =
-			FRIFoldProver::new(&fri_params, &ntt, &merkle_prover, codeword, &codeword_committed);
-
-		// Run prove_zk then continue with basefold prover
-		let prover = prove_zk(
-			witness,
-			mask,
-			eval_point_eq,
-			evaluation_claim,
-			fri_folder,
-			&mut prover_transcript,
-		);
-		prover.prove(&mut prover_transcript)?;
-
-		// Verify
-		let mut verifier_transcript = prover_transcript.into_verifier();
-		let retrieved_commitment = verifier_transcript.message().read()?;
-
-		let verifier_basefold::ReducedOutput {
-			final_fri_value,
-			final_sumcheck_value,
-			challenges,
-		} = verifier_basefold::verify_zk(
-			&fri_params,
-			merkle_prover.scheme(),
-			retrieved_commitment,
-			evaluation_claim,
-			&mut verifier_transcript,
-		)?;
-
-		// Check consistency - skip batch challenge (challenges[0])
-		let sumcheck_challenges = challenges[1..].to_vec();
-		if !verifier_basefold::sumcheck_fri_consistency(
-			final_fri_value,
-			final_sumcheck_value,
-			&evaluation_point,
-			sumcheck_challenges,
-		) {
-			bail!("Sumcheck and FRI are inconsistent");
-		}
-
-		Ok(())
-	}
-
-	#[test]
-	fn test_basefold_zk_valid_proof() {
-		type P = PackedBinaryGhash1x128b;
-
-		let n_vars = 8;
-		let mut rng = StdRng::seed_from_u64(0);
-
-		let witness = random_field_buffer::<P>(&mut rng, n_vars);
-		let mask = random_field_buffer::<P>(&mut rng, n_vars);
-		let evaluation_point = random_scalars(&mut rng, n_vars);
-
-		let eval_point_eq = eq_ind_partial_eval::<P>(&evaluation_point);
-		let evaluation_claim = inner_product_buffers(&witness, &eval_point_eq);
-
-		run_basefold_zk_prove_and_verify::<_, P>(witness, mask, evaluation_point, evaluation_claim)
-			.unwrap();
 	}
 
 	#[test]

--- a/crates/iop-prover/src/basefold_zk_channel.rs
+++ b/crates/iop-prover/src/basefold_zk_channel.rs
@@ -9,17 +9,26 @@
 
 use binius_field::{BinaryField, PackedField};
 use binius_iop::{channel::OracleSpec, fri::FRIParams, merkle_tree::MerkleTreeScheme};
-use binius_ip_prover::channel::IPProverChannel;
-use binius_math::{FieldBuffer, FieldSlice, ntt::AdditiveNTT};
+use binius_ip_prover::{
+	channel::IPProverChannel,
+	sumcheck::{
+		PaddedSumcheckDecorator, batch::batch_prove,
+		bivariate_product::BivariateProductSumcheckProver,
+	},
+};
+use binius_math::{
+	FieldBuffer, FieldSlice, inner_product::inner_product_par, line::extrapolate_line_packed,
+	ntt::AdditiveNTT,
+};
 use binius_transcript::{
 	ProverTranscript,
 	fiat_shamir::{CanSample, Challenger},
 };
-use binius_utils::SerializeBytes;
+use binius_utils::{SerializeBytes, rayon::prelude::*};
 use rand::{Rng, SeedableRng, rngs::StdRng};
 
 use crate::{
-	basefold,
+	basefold::prove_mlecheck_basefold_zk,
 	basefold_compiler::BaseFoldZKProverCompiler,
 	channel::IOPProverChannel,
 	fri::{self, CommitMaskedOutput, FRIFoldProver},
@@ -217,42 +226,104 @@ where
 			Item = (Self::Oracle, FieldBuffer<P>, FieldBuffer<P>, P::Scalar),
 		>,
 	) {
-		for (oracle, message, transparent_poly, eval_claim) in oracle_relations {
-			let index = oracle.index;
+		let relations: Vec<_> = oracle_relations.into_iter().collect();
+		if relations.is_empty() {
+			return;
+		}
+
+		let indices: Vec<usize> = relations.iter().map(|(oracle, ..)| oracle.index).collect();
+		for &index in &indices {
 			assert!(
 				index < self.committed_oracles.len(),
 				"oracle index {index} out of bounds, expected < {}",
 				self.committed_oracles.len()
 			);
+		}
+		let n_vars: Vec<usize> = indices
+			.iter()
+			.map(|&i| self.oracle_specs[i].log_msg_len)
+			.collect();
+		let max_n = *n_vars.iter().max().expect("relations is non-empty");
 
-			let fri_params = &self.fri_params[index];
-			let committed_data = &self.committed_oracles[index];
+		// === Masking step (whitepaper 7.2) ===
+		// Send the masked inner products σ_i = ⟨ω_i, t_i⟩, then sample a single masking challenge
+		// γ.
+		let sigmas: Vec<F> = relations
+			.iter()
+			.zip(&indices)
+			.map(|((_, _, transparent, _), &index)| {
+				inner_product_par(&self.committed_oracles[index].mask, transparent)
+			})
+			.collect();
+		self.send_many(&sigmas);
+		let gamma: F = self.sample();
+		let gamma_broadcast = P::broadcast(gamma);
+
+		// === Phase A: batched sumcheck on the masked claims ⟨π_i', t_i⟩ = s_i' ===
+		// Form π_i' = (1-γ)π_i + γω_i (keep a clone for Phase B), pad each prover to `max_n`.
+		let mut witness_primes = Vec::with_capacity(relations.len());
+		let mut provers = Vec::with_capacity(relations.len());
+		for ((((_, mut message, transparent, claim), &index), &n_i), &sigma) in relations
+			.into_iter()
+			.zip(&indices)
+			.zip(&n_vars)
+			.zip(&sigmas)
+		{
 			assert_eq!(
 				message.log_len(),
-				self.oracle_specs[index].log_msg_len,
+				n_i,
 				"oracle message log_len mismatch for oracle {index}"
 			);
+			let mask = &self.committed_oracles[index].mask;
+			(message.as_mut(), mask.as_ref())
+				.into_par_iter()
+				.for_each(|(message_i, &mask_i)| {
+					*message_i = extrapolate_line_packed(*message_i, mask_i, gamma_broadcast);
+				});
+			witness_primes.push(message.clone());
 
+			let sum_prime = extrapolate_line_packed(claim, sigma, gamma);
+			let inner = BivariateProductSumcheckProver::new([message, transparent], sum_prime)
+				.expect("π_i' and t_i have equal length");
+			provers.push(PaddedSumcheckDecorator::new(inner, max_n - n_i));
+		}
+
+		let output = batch_prove(provers, self).expect("batched sumcheck proving should succeed");
+
+		// Reduced oracle evaluations α_i = π_i'(ρ_i); `output.challenges` is already reversed to
+		// low-to-high (variable-indexed) order, so ρ_i is its first n_i coordinates.
+		let alphas: Vec<F> = output
+			.multilinear_evals
+			.iter()
+			.map(|evals| evals[0])
+			.collect();
+		self.send_many(&alphas);
+
+		// === Phase B: per-oracle BaseFold FRI interleaved with a MultilinearEvalProver ===
+		for (((witness_prime, &index), &n_i), &alpha) in witness_primes
+			.into_iter()
+			.zip(&indices)
+			.zip(&n_vars)
+			.zip(&alphas)
+		{
+			let eval_point = output.challenges[..n_i].to_vec();
+			let committed = &self.committed_oracles[index];
 			let fri_folder = FRIFoldProver::new(
-				fri_params,
+				&self.fri_params[index],
 				self.ntt,
 				self.merkle_prover,
-				committed_data.codeword.clone(),
-				&committed_data.committed,
+				committed.codeword.clone(),
+				&committed.committed,
 			);
-
-			// Always use ZK variant.
-			let prover = basefold::prove_zk(
-				message,
-				committed_data.mask.clone(),
-				transparent_poly,
-				eval_claim,
+			prove_mlecheck_basefold_zk(
+				witness_prime,
+				&eval_point,
+				alpha,
+				gamma,
 				fri_folder,
 				self.transcript,
-			);
-			prover
-				.prove(self.transcript)
-				.expect("BaseFold ZK proof should succeed");
+			)
+			.expect("MLE-check BaseFold proof should succeed");
 		}
 	}
 }

--- a/crates/iop/src/basefold.rs
+++ b/crates/iop/src/basefold.rs
@@ -21,7 +21,10 @@
 //! [BCS16]: <https://eprint.iacr.org/2016/116>
 
 use binius_field::{BinaryField, Field};
-use binius_ip::sumcheck::{RoundCoeffs, RoundProof};
+use binius_ip::{
+	mlecheck,
+	sumcheck::{RoundCoeffs, RoundProof},
+};
 use binius_math::{line::extrapolate_line_packed, multilinear::eq::eq_ind};
 use binius_transcript::{
 	self as transcript, VerifierTranscript,
@@ -167,6 +170,84 @@ where
 	})
 }
 
+/// Verifies a multilinear-evaluation BaseFold opening that interleaves a degree-1 MLE-check with
+/// FRI (the FRI-interleaved sumcheck of the Batched ZK BaseFold construction).
+///
+/// This is the verifier counterpart of `binius_iop_prover::basefold::prove_mlecheck_basefold_zk`.
+/// The masked oracle's opening claim
+/// has already been reduced to a point-evaluation claim `π'(eval_point) = eval_claim` by a prior
+/// batched sumcheck; this routine checks that claim against the committed codeword.
+///
+/// ## Arguments
+///
+/// * `eval_claim` - the claimed value `π'(eval_point)`
+/// * `eval_point` - the evaluation point `ρ` (length `n`), in low-to-high variable order
+/// * `batch_challenge` - the masking challenge `γ` used in the FRI unbatch round
+///
+/// The returned `challenges` begin with `batch_challenge` followed by the `n` MLE-check challenges.
+/// Use [`mlecheck_fri_consistency`] to check the reduced values.
+pub fn verify_mlecheck_basefold_zk<F, MTScheme, Challenger_>(
+	fri_params: &FRIParams<F>,
+	merkle_scheme: &MTScheme,
+	codeword_commitment: MTScheme::Digest,
+	eval_claim: F,
+	eval_point: &[F],
+	batch_challenge: F,
+	transcript: &mut VerifierTranscript<Challenger_>,
+) -> Result<ReducedOutput<F>, Error>
+where
+	F: BinaryField,
+	Challenger_: Challenger,
+	MTScheme: MerkleTreeScheme<F, Digest: DeserializeBytes>,
+{
+	// The MLE-check round polynomial is degree 1 (the composite is the multilinear itself).
+	const DEGREE: usize = 1;
+
+	assert_eq!(fri_params.log_batch_size(), 1); // precondition
+
+	let n_vars = fri_params.rs_code().log_dim();
+	assert_eq!(eval_point.len(), n_vars);
+	let mut challenges = Vec::with_capacity(n_vars + 1);
+
+	let mut fri_fold_verifier = FRIFoldVerifier::new(fri_params);
+
+	// Unbatch round: the FRI folds the interleaved (π ‖ ω) codeword at the masking challenge.
+	fri_fold_verifier.process_round(&mut transcript.message())?;
+	challenges.push(batch_challenge);
+
+	let mut sum = eval_claim;
+	for round in 0..n_vars {
+		let round_proof = mlecheck::RoundProof(RoundCoeffs(transcript.message().read_vec(DEGREE)?));
+		fri_fold_verifier.process_round(&mut transcript.message())?;
+
+		// MLE-check binds variables high-to-low, so round `i` uses coordinate `eval_point[n-1-i]`.
+		let alpha = eval_point[n_vars - 1 - round];
+		let round_coeffs = round_proof.recover(sum, alpha);
+		let challenge = transcript.sample();
+		sum = round_coeffs.evaluate(challenge);
+		challenges.push(challenge);
+	}
+
+	fri_fold_verifier.process_round(&mut transcript.message())?;
+	let round_commitments = fri_fold_verifier.finalize();
+
+	let fri_verifier = FRIQueryVerifier::new(
+		fri_params,
+		merkle_scheme,
+		&codeword_commitment,
+		&round_commitments,
+		&challenges,
+	);
+
+	let final_fri_value = fri_verifier.verify(transcript)?;
+
+	Ok(ReducedOutput {
+		final_fri_value,
+		final_sumcheck_value: sum,
+		challenges,
+	})
+}
+
 /// Output type of the [`verify`] function.
 pub struct ReducedOutput<F> {
 	pub final_fri_value: F,
@@ -197,6 +278,17 @@ pub fn sumcheck_fri_consistency<F: Field>(
 ) -> bool {
 	challenges.reverse();
 	fri_final_oracle * eq_ind(evaluation_point, &challenges) == sumcheck_final_claim
+}
+
+/// Verifies that the final FRI oracle is consistent with the MLE-check from
+/// [`verify_mlecheck_basefold_zk`].
+///
+/// In an MLE-check the equality-indicator factor is folded into the round-proof recovery, so the
+/// final reduced value is the multilinear evaluation `π'(r)` with no extra factor. The final FRI
+/// value is the same `π'(r)`, so consistency is plain equality (contrast
+/// [`sumcheck_fri_consistency`], where the transparent operand contributes an `eq` factor).
+pub fn mlecheck_fri_consistency<F: Field>(fri_final_oracle: F, sumcheck_final_claim: F) -> bool {
+	fri_final_oracle == sumcheck_final_claim
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/iop/src/basefold.rs
+++ b/crates/iop/src/basefold.rs
@@ -25,7 +25,7 @@ use binius_ip::{
 	mlecheck,
 	sumcheck::{RoundCoeffs, RoundProof},
 };
-use binius_math::{line::extrapolate_line_packed, multilinear::eq::eq_ind};
+use binius_math::multilinear::eq::eq_ind;
 use binius_transcript::{
 	self as transcript, VerifierTranscript,
 	fiat_shamir::{CanSample, Challenger},
@@ -88,71 +88,6 @@ where
 	fri_fold_verifier.process_round(&mut transcript.message())?;
 	let round_commitments = fri_fold_verifier.finalize();
 
-	let fri_verifier = FRIQueryVerifier::new(
-		fri_params,
-		merkle_scheme,
-		&codeword_commitment,
-		&round_commitments,
-		&challenges,
-	);
-
-	let final_fri_value = fri_verifier.verify(transcript)?;
-
-	Ok(ReducedOutput {
-		final_fri_value,
-		final_sumcheck_value: sum,
-		challenges,
-	})
-}
-
-pub fn verify_zk<F, MTScheme, Challenger_>(
-	fri_params: &FRIParams<F>,
-	merkle_scheme: &MTScheme,
-	codeword_commitment: MTScheme::Digest,
-	sum_claim: F,
-	transcript: &mut VerifierTranscript<Challenger_>,
-) -> Result<ReducedOutput<F>, Error>
-where
-	F: BinaryField,
-	Challenger_: Challenger,
-	MTScheme: MerkleTreeScheme<F, Digest: DeserializeBytes>,
-{
-	// The multivariate polynomial evaluated is a degree-2 multilinear composite.
-	const DEGREE: usize = 2;
-
-	assert_eq!(fri_params.log_batch_size(), 1); // precondition
-
-	// Read the evaluation claim for the mask from the transcript.
-	let mask_claim = transcript.message().read::<F>()?;
-
-	let n_vars = fri_params.rs_code().log_dim();
-	let mut challenges = Vec::with_capacity(n_vars + 1);
-
-	let mut fri_fold_verifier = FRIFoldVerifier::new(fri_params);
-
-	let batch_challenge = transcript.sample();
-
-	// Compute the batched sum using linear interpolation.
-	let mut sum = extrapolate_line_packed(sum_claim, mask_claim, batch_challenge);
-
-	fri_fold_verifier.process_round(&mut transcript.message())?;
-	challenges.push(batch_challenge);
-
-	for _ in 0..n_vars {
-		let round_proof = RoundProof(RoundCoeffs(transcript.message().read_vec(DEGREE)?));
-		fri_fold_verifier.process_round(&mut transcript.message())?;
-
-		let round_coeffs = round_proof.recover(sum);
-		let challenge = transcript.sample();
-		sum = round_coeffs.evaluate(challenge);
-		challenges.push(challenge);
-	}
-
-	// Finalize and get commitments
-	fri_fold_verifier.process_round(&mut transcript.message())?;
-	let round_commitments = fri_fold_verifier.finalize();
-
-	// TODO: Make all commitments after the first non-hiding
 	let fri_verifier = FRIQueryVerifier::new(
 		fri_params,
 		merkle_scheme,

--- a/crates/iop/src/basefold_zk_channel.rs
+++ b/crates/iop/src/basefold_zk_channel.rs
@@ -6,13 +6,22 @@
 //! using FRI commitment and ZK BaseFold opening protocols. Unlike [`super::basefold_channel`],
 //! this channel always applies zero-knowledge blinding to all oracles.
 
+use std::iter;
+
 use binius_field::BinaryField;
-use binius_ip::channel::IPVerifierChannel;
+use binius_ip::{
+	channel::IPVerifierChannel,
+	sumcheck::{self, BatchSumcheckOutput},
+};
+use binius_math::{
+	line::extrapolate_line_packed, multilinear::eq::eq_ind_zero, univariate::evaluate_univariate,
+};
 use binius_transcript::{
 	VerifierTranscript,
 	fiat_shamir::{CanSample, Challenger},
 };
 use binius_utils::DeserializeBytes;
+use itertools::izip;
 
 use crate::{
 	basefold,
@@ -184,37 +193,78 @@ where
 		&mut self,
 		oracle_relations: impl IntoIterator<Item = OracleLinearRelation<'a, Self::Oracle, Self::Elem>>,
 	) -> Result<(), Error> {
-		for relation in oracle_relations {
-			let index = relation.oracle.index;
+		let relations = oracle_relations.into_iter().collect::<Vec<_>>();
+		if relations.is_empty() {
+			return Ok(());
+		}
+
+		let indices: Vec<usize> = relations.iter().map(|r| r.oracle.index).collect();
+		for &index in &indices {
 			assert!(
 				index < self.oracle_commitments.len(),
 				"oracle index {index} out of bounds, expected < {}",
 				self.oracle_commitments.len()
 			);
+		}
+		let n_vars: Vec<usize> = indices
+			.iter()
+			.map(|&i| self.oracle_specs[i].log_msg_len)
+			.collect();
+		let max_n = *n_vars.iter().max().expect("relations is non-empty");
 
-			let fri_params = &self.fri_params[index];
+		// === Masking step ===
+		// Read the masked inner products σ_i, sample γ, and form the masked claims s_i'.
+		let sigmas = self.recv_many(relations.len())?;
+		let gamma = self.sample();
+		let sum_primes = iter::zip(&relations, sigmas)
+			.map(|(relation, sigma)| extrapolate_line_packed(relation.claim, sigma, gamma))
+			.collect::<Vec<_>>();
+
+		// === Phase A: batched sumcheck on the masked claims (degree 2, bivariate product) ===
+		let BatchSumcheckOutput {
+			batch_coeff: sumcheck_batch_coeff,
+			eval: sumcheck_reduced_eval,
+			challenges: sumcheck_challenges,
+		} = sumcheck::batch_verify::<F, _>(max_n, 2, &sum_primes, self.transcript)?;
+		let alphas = self.recv_many(relations.len())?;
+
+		// `batch_verify` returns binding-order challenges; reverse to variable-indexed
+		// (low-to-high).
+		let mut point = sumcheck_challenges;
+		point.reverse();
+
+		// Reduce the batched claim: each oracle contributes α_i · t_i(ρ_i) · eq(0^extra, padding),
+		// combined with the batching coefficient.
+		let contributions: Vec<F> = izip!(relations, &n_vars, &alphas)
+			.map(|(relation, &n_i, &alpha_i)| {
+				let (eval_coords, padding_coords) = point.split_at(n_i);
+				let pad_eq = eq_ind_zero(padding_coords);
+				let transparent_eval = (relation.transparent)(eval_coords);
+				alpha_i * transparent_eval * pad_eq
+			})
+			.collect();
+		let expected = evaluate_univariate(&contributions, sumcheck_batch_coeff);
+		self.assert_zero(sumcheck_reduced_eval - expected)?;
+
+		// === Phase B: per-oracle MLE-check BaseFold verification ===
+		for (index, alpha, n_i) in izip!(indices, alphas, n_vars) {
 			let commitment = self.oracle_commitments[index].clone();
-
-			// Always use ZK verification.
 			let basefold::ReducedOutput {
 				final_fri_value,
 				final_sumcheck_value,
-				challenges,
-			} = basefold::verify_zk(
-				fri_params,
+				..
+			} = basefold::verify_mlecheck_basefold_zk(
+				&self.fri_params[index],
 				self.merkle_scheme,
 				commitment,
-				relation.claim,
+				alpha,
+				&point[..n_i],
+				gamma,
 				self.transcript,
 			)?;
 
-			// Strip batch challenge (challenges[0]) and reverse remaining for eval point.
-			let mut eval_point: Vec<F> = challenges[1..].to_vec();
-			eval_point.reverse();
-
-			let transparent_eval = (relation.transparent)(&eval_point);
-
-			self.assert_zero(final_sumcheck_value - final_fri_value * transparent_eval)?;
+			// The MLE-check internalizes the eq factor, so consistency is plain equality.
+			self.assert_zero(final_sumcheck_value - final_fri_value)?;
 		}
 
 		Ok(())

--- a/crates/iop/src/channel.rs
+++ b/crates/iop/src/channel.rs
@@ -28,6 +28,8 @@ pub enum Error {
 	BaseFold(#[from] basefold::Error),
 	#[error("IP channel error: {0}")]
 	IPChannel(#[from] binius_ip::channel::Error),
+	#[error("sumcheck error: {0}")]
+	Sumcheck(#[from] binius_ip::sumcheck::Error),
 }
 
 /// Specification for an oracle to be committed in the IOP.

--- a/crates/ip-prover/src/sumcheck/mod.rs
+++ b/crates/ip-prover/src/sumcheck/mod.rs
@@ -9,6 +9,7 @@ pub mod common;
 mod error;
 pub mod gruen32;
 mod mle_to_sumcheck;
+pub mod multilinear_eval;
 mod padded;
 mod prove;
 pub mod quadratic_mle;

--- a/crates/ip-prover/src/sumcheck/multilinear_eval.rs
+++ b/crates/ip-prover/src/sumcheck/multilinear_eval.rs
@@ -1,0 +1,272 @@
+// Copyright 2026 Irreducible Inc.
+
+use binius_field::{Field, PackedField};
+use binius_ip::sumcheck::RoundCoeffs;
+use binius_math::{FieldBuffer, multilinear::fold::fold_highest_var_inplace};
+use binius_utils::rayon::prelude::*;
+
+use super::{
+	common::{MleCheckProver, SumcheckProver},
+	error::Error,
+	gruen32::Gruen32,
+	round_evals::RoundEvals1,
+};
+
+/// An [`MleCheckProver`] for the multilinear extension evaluation of a single multilinear
+/// polynomial over the challenge field.
+///
+/// Given a multilinear polynomial $M$ over the field $F$ and a claim $M(z) = s$, this proves the
+/// MLE-check relation $s = \sum_{v \in B_n} M(v) \cdot \text{eq}(v, z)$ (which, since $M$ is
+/// multilinear, holds iff $M(z) = s$). It is the large-field analogue of [`RerandMlecheckProver`],
+/// which handles 1-bit multilinears; this prover handles a single multilinear over $F$.
+///
+/// Because $M$ is multilinear, each round polynomial is degree 1. The prover folds the witness with
+/// each challenge, and in each round computes the round polynomial's evaluation at 1 by taking the
+/// top half of the folded witness (the partial specialization at the highest variable = 1) and
+/// dotting it with the [`Gruen32`] equality-indicator expansion over the remaining variables.
+///
+/// [`RerandMlecheckProver`]: super::rerand_mle::RerandMlecheckProver
+#[derive(Debug, Clone)]
+pub struct MultilinearEvalProver<P: PackedField> {
+	witness: FieldBuffer<P>,
+	gruen32: Gruen32<P>,
+	last_coeffs_or_sum: RoundCoeffsOrSum<P::Scalar>,
+}
+
+impl<F: Field, P: PackedField<Scalar = F>> MultilinearEvalProver<P> {
+	/// Constructs a prover for the multilinear `witness`, given the evaluation point `eval_point`
+	/// and the claimed evaluation `eval_claim` of the multilinear extension at that point.
+	///
+	/// Returns [`Error::MultilinearSizeMismatch`] if the witness length does not match the
+	/// evaluation point length.
+	pub fn new(witness: FieldBuffer<P>, eval_point: &[F], eval_claim: F) -> Result<Self, Error> {
+		if witness.log_len() != eval_point.len() {
+			return Err(Error::MultilinearSizeMismatch);
+		}
+
+		Ok(Self {
+			witness,
+			gruen32: Gruen32::new(eval_point),
+			last_coeffs_or_sum: RoundCoeffsOrSum::Sum(eval_claim),
+		})
+	}
+}
+
+impl<F: Field, P: PackedField<Scalar = F>> SumcheckProver<F> for MultilinearEvalProver<P> {
+	fn n_vars(&self) -> usize {
+		self.gruen32.n_vars_remaining()
+	}
+
+	fn n_claims(&self) -> usize {
+		1
+	}
+
+	fn round_claim(&self) -> Vec<F> {
+		let claim = match &self.last_coeffs_or_sum {
+			RoundCoeffsOrSum::Sum(sum) => *sum,
+			RoundCoeffsOrSum::Coeffs(coeffs) => {
+				coeffs.lerp_over_endpoints(self.gruen32.next_coordinate())
+			}
+		};
+		vec![claim]
+	}
+
+	fn execute(&mut self) -> Result<Vec<RoundCoeffs<F>>, Error> {
+		let RoundCoeffsOrSum::Sum(sum) = &self.last_coeffs_or_sum else {
+			return Err(Error::ExpectedFold);
+		};
+		let sum = *sum;
+
+		let n_vars_remaining = self.n_vars();
+		assert!(n_vars_remaining > 0);
+
+		// The eq expansion is over the lower `n_vars_remaining - 1` variables; the top (X = 1) half
+		// of the witness is the partial specialization of the highest variable at 1.
+		let eq_expansion = self.gruen32.eq_expansion();
+		let (_evals_0, evals_1) = self.witness.split_half_ref();
+		debug_assert_eq!(eq_expansion.log_len(), evals_1.log_len());
+
+		// R(1) = <M(.., X = 1), eq(.., z)>, the multilinear evaluation of the top half.
+		let round_evals = (evals_1.as_ref(), eq_expansion.as_ref())
+			.into_par_iter()
+			.map(|(&evals_1_i, &eq_i)| RoundEvals1 {
+				y_1: evals_1_i * eq_i,
+			})
+			.reduce(RoundEvals1::default, |lhs, rhs| lhs + &rhs);
+
+		let alpha = self.gruen32.next_coordinate();
+		let round_coeffs = round_evals
+			.sum_scalars(n_vars_remaining)
+			.interpolate_eq(sum, alpha);
+
+		self.last_coeffs_or_sum = RoundCoeffsOrSum::Coeffs(round_coeffs.clone());
+		Ok(vec![round_coeffs])
+	}
+
+	fn fold(&mut self, challenge: F) -> Result<(), Error> {
+		let RoundCoeffsOrSum::Coeffs(coeffs) = &self.last_coeffs_or_sum else {
+			return Err(Error::ExpectedExecute);
+		};
+
+		assert!(self.n_vars() > 0);
+
+		let sum = coeffs.evaluate(challenge);
+
+		fold_highest_var_inplace(&mut self.witness, challenge);
+		self.gruen32.fold(challenge);
+
+		self.last_coeffs_or_sum = RoundCoeffsOrSum::Sum(sum);
+		Ok(())
+	}
+
+	fn finish(self) -> Result<Vec<F>, Error> {
+		if self.n_vars() > 0 {
+			let error = match self.last_coeffs_or_sum {
+				RoundCoeffsOrSum::Coeffs(_) => Error::ExpectedFold,
+				RoundCoeffsOrSum::Sum(_) => Error::ExpectedExecute,
+			};
+			return Err(error);
+		}
+
+		debug_assert_eq!(self.witness.log_len(), 0);
+		Ok(vec![self.witness.get(0)])
+	}
+}
+
+impl<F: Field, P: PackedField<Scalar = F>> MleCheckProver<F> for MultilinearEvalProver<P> {
+	fn eval_point(&self) -> &[F] {
+		self.gruen32.eval_point()
+	}
+}
+
+#[derive(Debug, Clone)]
+enum RoundCoeffsOrSum<F: Field> {
+	Coeffs(RoundCoeffs<F>),
+	Sum(F),
+}
+
+#[cfg(test)]
+mod tests {
+	use binius_field::{
+		FieldOps, Random,
+		arch::{OptimalB128, OptimalPackedB128},
+	};
+	use binius_ip::mlecheck;
+	use binius_math::{
+		multilinear::evaluate::evaluate,
+		test_utils::{random_field_buffer, random_scalars},
+	};
+	use binius_transcript::{ProverTranscript, fiat_shamir::HasherChallenger};
+	use rand::prelude::*;
+
+	use super::*;
+	use crate::sumcheck::{prove_single_mlecheck, quadratic_mle::QuadraticMleCheckProver};
+
+	type F = OptimalB128;
+	type P = OptimalPackedB128;
+	type StdChallenger = HasherChallenger<sha2::Sha256>;
+
+	// A `QuadraticMleCheckProver` with the identity composition (and zero infinity composition) is
+	// a degree-1 MLE-check over a single multilinear — exactly what `MultilinearEvalProver`
+	// computes, just with the high (always-zero) degree-2 coefficient included. Drive both in
+	// lockstep and compare round polynomials and final evaluations.
+	#[test]
+	fn test_conformance_with_quadratic_mlecheck() {
+		let mut rng = StdRng::seed_from_u64(0);
+		let n_vars = 8;
+
+		let witness = random_field_buffer::<P>(&mut rng, n_vars);
+		let eval_point = random_scalars::<F>(&mut rng, n_vars);
+		let eval_claim = evaluate(&witness, &eval_point);
+
+		let mut eval_prover =
+			MultilinearEvalProver::new(witness.clone(), &eval_point, eval_claim).unwrap();
+		let mut quadratic_prover = QuadraticMleCheckProver::new(
+			[witness],
+			|[a]: [P; 1]| a,
+			|[_a]: [P; 1]| P::zero(),
+			eval_point.clone(),
+			eval_claim,
+		)
+		.unwrap();
+
+		for _ in 0..n_vars {
+			let eval_round = eval_prover.execute().unwrap();
+			let mut quadratic_round = quadratic_prover.execute().unwrap();
+			assert_eq!(eval_round.len(), 1);
+			assert_eq!(quadratic_round.len(), 1);
+
+			// The quadratic prover sizes its round polynomial for degree 2; the leading coefficient
+			// is zero because the composition is multilinear.
+			assert_eq!(quadratic_round[0].0.pop(), Some(F::ZERO));
+			assert_eq!(eval_round[0], quadratic_round[0]);
+
+			// `round_claim` must agree across both provers and be stable across execute.
+			assert_eq!(eval_prover.round_claim(), quadratic_prover.round_claim());
+
+			let challenge = F::random(&mut rng);
+			eval_prover.fold(challenge).unwrap();
+			quadratic_prover.fold(challenge).unwrap();
+		}
+
+		assert_eq!(eval_prover.finish().unwrap(), quadratic_prover.finish().unwrap());
+	}
+
+	// Full prove/verify roundtrip through the MLE-check protocol.
+	#[test]
+	fn test_prove_verify_roundtrip() {
+		let mut rng = StdRng::seed_from_u64(1);
+		let n_vars = 7;
+
+		let witness = random_field_buffer::<P>(&mut rng, n_vars);
+		let eval_point = random_scalars::<F>(&mut rng, n_vars);
+		let eval_claim = evaluate(&witness, &eval_point);
+
+		let prover = MultilinearEvalProver::new(witness.clone(), &eval_point, eval_claim).unwrap();
+
+		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
+		let output = prove_single_mlecheck(prover, &mut prover_transcript).unwrap();
+		prover_transcript
+			.message()
+			.write_slice(&output.multilinear_evals);
+
+		let mut verifier_transcript = prover_transcript.into_verifier();
+		let sumcheck_output =
+			mlecheck::verify::<F, _>(&eval_point, 1, eval_claim, &mut verifier_transcript).unwrap();
+		let multilinear_evals: Vec<F> = verifier_transcript.message().read_vec(1).unwrap();
+
+		assert_eq!(output.challenges, sumcheck_output.challenges);
+
+		// The reduced MLE-check evaluation is the witness multilinear at the challenge point.
+		assert_eq!(multilinear_evals[0], sumcheck_output.eval);
+
+		let mut reduced_point = sumcheck_output.challenges.clone();
+		reduced_point.reverse();
+		assert_eq!(evaluate(&witness, &reduced_point), multilinear_evals[0]);
+	}
+
+	// `round_claim` must return the same value before and after `execute` (lerp recovery), and the
+	// post-fold claim must equal the round polynomial evaluated at the challenge.
+	#[test]
+	fn test_round_claim_invariant() {
+		let mut rng = StdRng::seed_from_u64(2);
+		let n_vars = 6;
+
+		let witness = random_field_buffer::<P>(&mut rng, n_vars);
+		let eval_point = random_scalars::<F>(&mut rng, n_vars);
+		let eval_claim = evaluate(&witness, &eval_point);
+
+		let mut prover = MultilinearEvalProver::new(witness, &eval_point, eval_claim).unwrap();
+		assert_eq!(prover.round_claim(), vec![eval_claim]);
+
+		for _ in 0..n_vars {
+			let before = prover.round_claim();
+			let round = prover.execute().unwrap();
+			assert_eq!(prover.round_claim(), before);
+			let challenge = F::random(&mut rng);
+			let expected_next = round[0].evaluate(challenge);
+			prover.fold(challenge).unwrap();
+			assert_eq!(prover.round_claim(), vec![expected_next]);
+		}
+	}
+}

--- a/crates/math/src/multilinear/eq.rs
+++ b/crates/math/src/multilinear/eq.rs
@@ -202,6 +202,18 @@ pub fn eq_ind<F: FieldOps>(x: &[F], y: &[F]) -> F {
 		.product()
 }
 
+/// Evaluates the equality indicator multilinear with one operand fixed to all zeros.
+///
+/// This is `eq_ind(0^n, point)`, which simplifies to
+///
+/// $$
+/// \widetilde{eq}(0^n, Y_0, \ldots, Y_{n-1}) = \prod_{i=0}^{n-1} (1 - Y_i).
+/// $$
+pub fn eq_ind_zero<F: FieldOps>(point: &[F]) -> F {
+	let one = F::one();
+	point.iter().map(|y| one.clone() - y.clone()).product()
+}
+
 /// Computes the partial evaluation of the equality indicator polynomial, returning scalars.
 ///
 /// This is a scalar-only variant of [`eq_ind_partial_eval`] that returns a `Vec<F>` instead of
@@ -281,6 +293,17 @@ mod tests {
 				let hypercube_point = index_to_hypercube_point(coords.len(), i);
 				assert_eq!(v, eq_ind(&hypercube_point, &coords));
 			}
+		}
+	}
+
+	#[test]
+	fn test_eq_ind_zero() {
+		let mut rng = StdRng::seed_from_u64(0);
+		for n in 0..5 {
+			let point = random_scalars::<F>(&mut rng, n);
+			let expected: F = point.iter().map(|&r| F::ONE - r).product();
+			assert_eq!(eq_ind_zero(&point), expected);
+			assert_eq!(eq_ind_zero(&point), eq_ind(&vec![F::ZERO; n], &point));
 		}
 	}
 


### PR DESCRIPTION
## Summary

Restructures the ZK BaseFold compiler into the two-sumcheck form of the
Batched ZK BaseFold construction (whitepaper 7.2 / 5.4), built on two
new primitives. Three commits:

- **[ip-prover] Add MultilinearEvalProver** — an `MleCheckProver` for the
  MLE evaluation of a single large-field multilinear (degree-1 rounds via
  Gruen32 eq expansion); large-field analogue of `RerandMlecheckProver`.
- **[iop] Add MLE-check ZK BaseFold opening** — a BaseFold opening that
  interleaves the degree-1 MLE-check with FRI folding, proving a bare
  point-evaluation π'(ρ) = α against the committed (π ‖ ω) codeword. The
  masking challenge γ is consumed as the FRI unbatch round; eq is
  internalized so consistency is plain equality. Additive; existing
  degree-2 path untouched.
- **[iop] Batch the first sumcheck** — replaces per-oracle fused
  sumcheck+FRI with: (1) masking step sending σ_i = ⟨ω_i, t_i⟩ and a
  single γ; (2) Phase A, one batched degree-2 sumcheck over all
  ⟨π_i', t_i⟩ = s_i' (padded to max vars via PaddedSumcheckDecorator);
  (3) Phase B, per-oracle MLE-check BaseFold FRI. Removes the now-unused
  degree-2 prove_zk/verify_zk. Adds eq_ind_zero helper and a Sumcheck
  variant to the IOP channel Error.

## Test plan

- `cargo test -p binius-iop -p binius-iop-prover -p binius-math`
- `cargo test` (end-to-end spartan/example tests, incl. the two-oracle
  unequal-size 6/8-variable padding case)
- `cargo clippy --all --all-features --tests --benches --examples -- -D warnings`
