### PR TITLE
[iop] Batch ZK BaseFold oracle openings into one combined FRI

### DIFF
--- a/crates/iop-prover/src/basefold.rs
+++ b/crates/iop-prover/src/basefold.rs
@@ -161,32 +161,40 @@ where
 	}
 }
 
-/// Proves a multilinear evaluation claim `witness(eval_point) = eval_claim` by interleaving an
-/// [`MultilinearEvalProver`] MLE-check with FRI folding (the second, FRI-interleaved sumcheck of
-/// the Batched ZK BaseFold construction).
+/// Proves a *combined* multilinear evaluation claim `𝛑(eval_point) = eval_claim` by interleaving a
+/// single [`MultilinearEvalProver`] MLE-check with a single combined FRI over the
+/// piecewise-concatenated oracle of the Batched ZK BaseFold construction (whitepaper §7.2 /
+/// §sec:batched-basefold Step 2).
 ///
-/// The masked oracle `π' = π + γ·ω` has already been formed by the caller (it is passed as
-/// `witness`) and the linear opening claim has already been reduced to this point evaluation by a
-/// prior batched sumcheck. Here we only run the degree-1 MLE-check on `witness` against
-/// `eval_point`, interleaved with the FRI codeword of the committed interleaved `[π ‖ ω]`.
+/// A prior batched sumcheck reduced the `k` masked opening claims to per-oracle point-evaluation
+/// claims `π_i'(ρ_i) = α_i` at a shared point `r ∈ K^𝐧` (`𝐧 = max_i n_i`). The caller has collapsed
+/// the oracle-index variables up front at sampled batching challenges `r'` into a single combined
+/// multilinear `𝛑(X) = Σ_i e[i]·π_i^↑(X)`, `e = eq_ind_partial_eval(r')` (passed as `witness`),
+/// with target `s' = 𝛑(r)`. Here we run the degree-1 MLE-check on `𝛑` against `r`, interleaved with
+/// the FRI codeword built (via [`FRIFoldProver::new_batch`]) from the `k` committed interleaved
+/// `[π_i ‖ ω_i]` codewords.
 ///
 /// ## Arguments
 ///
-/// * `witness` - the masked oracle multilinear `π'` with `log_len = n`
-/// * `eval_point` - the evaluation point `ρ` with `len = n`, in low-to-high variable order
-/// * `eval_claim` - the claimed value `π'(ρ)`
-/// * `batch_challenge` - the masking challenge `γ`; folds the interleaved `[π ‖ ω]` codeword down
-///   to the codeword of `π'` in the FRI unbatch round
-/// * `fri_folder` - the FRI fold prover over the `[π ‖ ω]` codeword, with `n_rounds == n + 1`
+/// * `witness` - the combined oracle multilinear `𝛑` with `log_len = 𝐧`
+/// * `eval_point` - the point `r` with `len = 𝐧`, in low-to-high variable order
+/// * `eval_claim` - the combined target `s' = 𝛑(r)`
+/// * `batch_challenge` - the masking challenge `γ`; folds each interleaved `[π_i ‖ ω_i]` codeword
+///   down to the codeword of `π_i'` in the FRI inner (unbatch) round
+/// * `outer_challenges` - the batching challenges `r'` (`len = log_n_oracles`); combine the `k`
+///   lifted codewords in the FRI outer (oracle-combine) rounds
+/// * `fri_folder` - the combined FRI fold prover, with `n_rounds == 𝐧 + 1 + log_n_oracles`
 /// * `transcript` - the prover transcript
 ///
-/// The final FRI value equals the final MLE-check value `π'(r)` (see
+/// The final FRI value equals the final MLE-check value `𝛑(r)` (see
 /// [`binius_iop::basefold::mlecheck_fri_consistency`]).
-pub fn prove_mlecheck_basefold_zk<'a, F, P, NTT, MerkleScheme, MerkleProver, Challenger_>(
+#[allow(clippy::too_many_arguments)]
+pub fn prove_mlecheck_basefold_zk_batch<'a, F, P, NTT, MerkleScheme, MerkleProver, Challenger_>(
 	witness: FieldBuffer<P>,
 	eval_point: &[F],
 	eval_claim: F,
 	batch_challenge: F,
+	outer_challenges: &[F],
 	mut fri_folder: FRIFoldProver<'a, F, P, NTT, MerkleProver>,
 	transcript: &mut ProverTranscript<Challenger_>,
 ) -> Result<(), Error>
@@ -198,17 +206,21 @@ where
 	MerkleProver: MerkleTreeProver<F, Scheme = MerkleScheme>,
 	Challenger_: Challenger,
 {
-	let _scope = tracing::debug_span!("Basefold MLE-check ZK").entered();
+	let _scope = tracing::debug_span!("Basefold MLE-check ZK (batched)").entered();
 
 	let n_vars = witness.log_len();
 	assert_eq!(eval_point.len(), n_vars);
-	// The FRI folder operates on the codeword of the interleaved (π ‖ ω) polynomial, so
-	// `n_rounds == n + 1`.
-	assert_eq!(n_vars + 1, fri_folder.n_rounds());
+	// The FRI folder has one inner (unbatch) round, `log_n_oracles` outer (oracle-combine) rounds,
+	// and `𝐧` standard fold rounds.
+	assert_eq!(n_vars + 1 + outer_challenges.len(), fri_folder.n_rounds());
 
-	// Unbatch round: fold the interleaved (π ‖ ω) codeword at the masking challenge to obtain the
-	// codeword of π'. No commitment is produced at this round.
+	// Inner (unbatch) round: fold every interleaved (π_i ‖ ω_i) codeword at the masking challenge.
 	fri_folder.receive_challenge(batch_challenge);
+	// Outer rounds: combine the k lifted codewords at the batching challenges r'. These carry no
+	// sumcheck round-polynomial; the folder applies them lazily with γ at the first commit round.
+	for &outer_challenge in outer_challenges {
+		fri_folder.receive_challenge(outer_challenge);
+	}
 
 	let mut sumcheck = MultilinearEvalProver::new(witness, eval_point, eval_claim)?;
 	for _ in 0..n_vars {
@@ -247,7 +259,10 @@ mod test {
 		PackedExtension, PackedField,
 	};
 	use binius_hash::{StdDigest, StdHashSuite};
-	use binius_iop::{basefold as verifier_basefold, fri::ConstantArityStrategy};
+	use binius_iop::{
+		basefold as verifier_basefold,
+		fri::{ConstantArityStrategy, PartialOracleSpec},
+	};
 	use binius_math::{
 		BinarySubspace, FieldBuffer,
 		inner_product::inner_product_buffers,
@@ -263,7 +278,7 @@ mod test {
 	use binius_utils::rayon::prelude::*;
 	use rand::{SeedableRng, rngs::StdRng};
 
-	use super::{BaseFoldProver, prove_mlecheck_basefold_zk};
+	use super::{BaseFoldProver, prove_mlecheck_basefold_zk_batch};
 	use crate::{
 		fri::{self, CommitMaskedOutput, CommitOutput, FRIFoldProver},
 		merkle_tree::prover::BinaryMerkleTreeProver,
@@ -310,7 +325,7 @@ mod test {
 			commitment: codeword_commitment,
 			committed: codeword_committed,
 			codeword,
-		} = fri::commit_interleaved(&fri_params, &ntt, &merkle_prover, multilinear.to_ref());
+		} = fri::commit_interleaved(&fri_params, 0, &ntt, &merkle_prover, multilinear.to_ref());
 
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 		prover_transcript.message().write(&codeword_commitment);
@@ -419,11 +434,12 @@ mod test {
 			.unwrap();
 	}
 
-	/// Drives [`prove_mlecheck_basefold_zk`] against
-	/// [`binius_iop::basefold::verify_mlecheck_basefold_zk`]: commits the interleaved (π ‖ ω)
-	/// codeword, samples the masking challenge γ, forms π' = (1-γ)π + γω, and proves/verifies the
-	/// point-evaluation claim π'(ρ). If `tamper`, the claim is corrupted and verification must
-	/// fail.
+	/// Drives [`prove_mlecheck_basefold_zk_batch`] against
+	/// [`binius_iop::basefold::verify_mlecheck_basefold_zk_batch`] for a single oracle (`k = 1`, no
+	/// outer rounds): commits the interleaved (π ‖ ω) codeword, samples the masking challenge γ,
+	/// forms π' = (1-γ)π + γω, and proves/verifies the point-evaluation claim π'(ρ) via the
+	/// combined FRI path. If `tamper`, the claim is corrupted and verification must fail. (The
+	/// multi-oracle path is exercised end-to-end by the channel tests.)
 	fn run_mlecheck_basefold_zk_prove_and_verify<F, P>(
 		witness: FieldBuffer<P>,
 		evaluation_point: Vec<F>,
@@ -438,18 +454,22 @@ mod test {
 
 		let merkle_prover = BinaryMerkleTreeProver::<F, StdHashSuite>::new();
 
-		let subspace = BinarySubspace::with_dim(n_vars + LOG_INV_RATE);
+		let subspace = BinarySubspace::with_dim(n_vars + 1 + LOG_INV_RATE);
 		let domain_context = GenericOnTheFly::generate_from_subspace(&subspace);
 		let ntt = NeighborsLastSingleThread::new(domain_context);
 
-		let fri_params = binius_iop::fri::FRIParams::with_strategy(
+		// For a single oracle the combined opening params (`optimal_for_batch`) also satisfy
+		// `commit_masked`'s preconditions (`log_batch_size() == 1`, `rs_code().log_dim() ==
+		// n_vars`).
+		let (fri_params, _) = binius_iop::fri::FRIParams::optimal_for_batch(
 			ntt.domain_context(),
 			merkle_prover.scheme(),
-			n_vars + 1,
-			Some(1),
+			&[PartialOracleSpec {
+				log_msg_len: n_vars + 1,
+				log_batch_size: Some(1),
+			}],
 			LOG_INV_RATE,
 			32,
-			&ConstantArityStrategy::new(2),
 		);
 
 		// Commit the interleaved (witness ‖ mask), generating the mask internally.
@@ -459,7 +479,14 @@ mod test {
 			committed: codeword_committed,
 			codeword,
 			mask,
-		} = fri::commit_masked(&fri_params, &ntt, &merkle_prover, witness.to_ref(), &mut commit_rng);
+		} = fri::commit_masked(
+			&fri_params,
+			0,
+			&ntt,
+			&merkle_prover,
+			witness.to_ref(),
+			&mut commit_rng,
+		);
 
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 		prover_transcript.message().write(&codeword_commitment);
@@ -480,13 +507,18 @@ mod test {
 			eval_claim += F::ONE;
 		}
 
-		let fri_folder =
-			FRIFoldProver::new(&fri_params, &ntt, &merkle_prover, codeword, &codeword_committed);
-		prove_mlecheck_basefold_zk(
+		let fri_folder = FRIFoldProver::new_batch(
+			&fri_params,
+			&ntt,
+			&merkle_prover,
+			vec![(codeword, &codeword_committed)],
+		);
+		prove_mlecheck_basefold_zk_batch(
 			witness_prime,
 			&evaluation_point,
 			eval_claim,
 			batch_challenge,
+			&[],
 			fri_folder,
 			&mut prover_transcript,
 		)?;
@@ -499,13 +531,14 @@ mod test {
 			final_fri_value,
 			final_sumcheck_value,
 			..
-		} = verifier_basefold::verify_mlecheck_basefold_zk(
+		} = verifier_basefold::verify_mlecheck_basefold_zk_batch(
 			&fri_params,
 			merkle_prover.scheme(),
-			retrieved_commitment,
+			&[retrieved_commitment],
 			eval_claim,
 			&evaluation_point,
 			batch_challenge_v,
+			&[],
 			&mut verifier_transcript,
 		)?;
 

--- a/crates/iop-prover/src/basefold_channel.rs
+++ b/crates/iop-prover/src/basefold_channel.rs
@@ -237,7 +237,7 @@ where
 			commitment,
 			committed,
 			codeword,
-		} = fri::commit_interleaved(fri_params, self.ntt, self.merkle_prover, buffer);
+		} = fri::commit_interleaved(fri_params, 0, self.ntt, self.merkle_prover, buffer);
 
 		// Send commitment via transcript
 		self.transcript.message().write(&commitment);

--- a/crates/iop-prover/src/basefold_compiler.rs
+++ b/crates/iop-prover/src/basefold_compiler.rs
@@ -11,7 +11,7 @@ use binius_field::{BinaryField, PackedField};
 use binius_iop::{
 	basefold_compiler::{BaseFoldVerifierCompiler, BaseFoldZKVerifierCompiler},
 	channel::OracleSpec,
-	fri::FRIParams,
+	fri::{FRIParams, PartialOracleSpec},
 	merkle_tree::MerkleTreeScheme,
 };
 use binius_math::ntt::AdditiveNTT;
@@ -169,7 +169,8 @@ where
 	ntt: NTT,
 	merkle_prover: MerkleProver_,
 	oracle_specs: Vec<OracleSpec>,
-	fri_params: Vec<FRIParams<P::Scalar>>,
+	/// The combined FRI parameters over **all** oracles.
+	fri_params: FRIParams<P::Scalar>,
 	_p_marker: PhantomData<P>,
 }
 
@@ -192,24 +193,28 @@ where
 		log_inv_rate: usize,
 		n_test_queries: usize,
 	) -> Self {
-		use binius_iop::fri::MinProofSizeStrategy;
+		assert!(
+			!oracle_specs.is_empty(),
+			"BaseFoldZKProverCompiler requires at least one oracle spec"
+		);
 
-		let fri_params = oracle_specs
+		// The single combined FRI parameters over all oracles.
+		let partial_specs: Vec<PartialOracleSpec> = oracle_specs
 			.iter()
-			.map(|spec| {
-				let log_msg_len = spec.log_msg_len + 1;
-				let log_batch_size = Some(1);
-				FRIParams::with_strategy(
-					ntt.domain_context(),
-					merkle_prover.scheme(),
-					log_msg_len,
-					log_batch_size,
-					log_inv_rate,
-					n_test_queries,
-					&MinProofSizeStrategy,
-				)
+			.map(|spec| PartialOracleSpec {
+				// Oracle includes message and equal length mask
+				log_msg_len: spec.log_msg_len + 1,
+				// Batch size is 2 for message and mask
+				log_batch_size: Some(1),
 			})
 			.collect();
+		let (fri_params, _) = FRIParams::optimal_for_batch(
+			ntt.domain_context(),
+			merkle_prover.scheme(),
+			&partial_specs,
+			log_inv_rate,
+			n_test_queries,
+		);
 
 		Self {
 			ntt,
@@ -232,7 +237,7 @@ where
 			ntt,
 			merkle_prover,
 			oracle_specs: verifier_compiler.oracle_specs().to_vec(),
-			fri_params: verifier_compiler.fri_params().to_vec(),
+			fri_params: verifier_compiler.fri_params().clone(),
 			_p_marker: PhantomData,
 		}
 	}
@@ -252,8 +257,8 @@ where
 		&self.oracle_specs
 	}
 
-	/// Returns a reference to the precomputed FRI parameters.
-	pub fn fri_params(&self) -> &[FRIParams<F>] {
+	/// Returns a reference to the precomputed combined FRI parameters.
+	pub fn fri_params(&self) -> &FRIParams<F> {
 		&self.fri_params
 	}
 

--- a/crates/iop-prover/src/basefold_zk_channel.rs
+++ b/crates/iop-prover/src/basefold_zk_channel.rs
@@ -80,8 +80,13 @@ where
 	ntt: &'a NTT,
 	merkle_prover: &'a MerkleProver_,
 	oracle_specs: Vec<OracleSpec>,
+	/// Per-oracle FRI parameters (`log_batch_size = 1`), used for `commit_masked` and the
+	/// per-oracle BaseFold openings in [`Self::finish`].
 	fri_params: Vec<FRIParams<F>>,
 	committed_oracles: Vec<CommittedOracleData<P, MerkleProver_::Committed>>,
+	/// Oracle relations queued by [`Self::prove_oracle_relations`], opened together in
+	/// [`Self::finish`]. Each entry is `(oracle_index, message π_i, transparent t_i, claim s_i)`.
+	queue: Vec<(usize, FieldBuffer<P>, FieldBuffer<P>, F)>,
 	next_oracle_index: usize,
 	rng: StdRng,
 }
@@ -111,6 +116,7 @@ where
 			oracle_specs: compiler.oracle_specs().to_vec(),
 			fri_params: compiler.fri_params().to_vec(),
 			committed_oracles: Vec::new(),
+			queue: Vec::new(),
 			next_oracle_index: 0,
 			rng: StdRng::from_rng(&mut rng),
 		}
@@ -121,10 +127,164 @@ where
 		self.transcript
 	}
 
-	/// Consumes the channel, asserting all oracle specs have been consumed.
+	/// Consumes the channel and proves the single combined opening over **all** committed oracles.
+	///
+	/// All oracle relations queued by
+	/// [`prove_oracle_relations`](IOPProverChannel::prove_oracle_relations) across every call are
+	/// processed here in one batch: masking, one batched sumcheck reducing the masked claims to a
+	/// shared point `r`, then one combined FRI opening over every committed oracle
+	/// (in oracle-index order). Mirrors [`BaseFoldZKVerifierChannel::finish`].
+	///
+	/// [`BaseFoldZKVerifierChannel::finish`]: binius_iop::basefold_zk_channel::BaseFoldZKVerifierChannel::finish
 	pub fn finish(self) {
-		let n_remaining = self.oracle_specs.len() - self.next_oracle_index;
+		let Self {
+			transcript,
+			ntt,
+			merkle_prover,
+			oracle_specs,
+			fri_params,
+			committed_oracles,
+			queue,
+			next_oracle_index,
+			rng: _,
+		} = self;
+
+		let n_remaining = oracle_specs.len() - next_oracle_index;
 		assert!(n_remaining == 0, "finish called but {n_remaining} oracle specs remaining",);
+
+		if queue.is_empty() {
+			return;
+		}
+
+		prove_batch_zk_basefold(
+			transcript,
+			ntt,
+			merkle_prover,
+			&oracle_specs,
+			&fri_params,
+			committed_oracles,
+			queue,
+		);
+	}
+}
+
+/// Proves the combined ZK BaseFold opening over all committed oracles.
+///
+/// This drives `channel` — the [`ProverTranscript`] taken from the destructured
+/// [`BaseFoldZKProverChannel`] — through its [`IPProverChannel`] interface: it sends the masked
+/// inner products σ_i, runs one batched sumcheck reducing the masked claims to a shared point `r`,
+/// then opens each committed oracle with its own FRI parameters. Mirrors
+/// [`binius_iop::basefold_zk_channel::BaseFoldZKVerifierChannel::finish`].
+///
+/// The masking inner products and the batched sumcheck process the `relations` in arrival order (so
+/// each reduced eval lines up with its batched-claim coefficient), while the per-oracle evaluations
+/// α_i and the FRI openings are emitted in oracle-index order. Each relation carries its oracle's
+/// index, so the two orders are reconciled by indexing rather than by sorting the relations; the
+/// per-oracle data (`oracle_specs`, `fri_params`, `committed_oracles`) is all indexed by oracle
+/// index.
+///
+/// `channel` is the concrete [`ProverTranscript`] rather than an arbitrary [`IPProverChannel`]
+/// because the Phase-B FRI openings write Merkle query proofs, which fall outside that interface.
+#[allow(clippy::too_many_arguments)]
+fn prove_batch_zk_basefold<F, P, NTT, MerkleScheme, MerkleProver_, Challenger_>(
+	channel: &mut ProverTranscript<Challenger_>,
+	ntt: &NTT,
+	merkle_prover: &MerkleProver_,
+	oracle_specs: &[OracleSpec],
+	fri_params: &[FRIParams<F>],
+	committed_oracles: Vec<CommittedOracleData<P, MerkleProver_::Committed>>,
+	relations: Vec<(usize, FieldBuffer<P>, FieldBuffer<P>, F)>,
+) where
+	F: BinaryField,
+	P: PackedField<Scalar = F>,
+	NTT: AdditiveNTT<Field = F> + Sync,
+	MerkleScheme: MerkleTreeScheme<F, Digest: SerializeBytes>,
+	MerkleProver_: MerkleTreeProver<F, Scheme = MerkleScheme>,
+	Challenger_: Challenger,
+{
+	let n_committed = committed_oracles.len();
+	assert_eq!(relations.len(), n_committed, "expects exactly one relation per committed oracle",);
+
+	let n_vars: Vec<usize> = (0..n_committed)
+		.map(|i| oracle_specs[i].log_msg_len)
+		.collect();
+	let max_n = *n_vars.iter().max().expect("relations is non-empty");
+
+	// === Masking step (whitepaper 7.2) ===
+	// Send the masked inner products σ_i = ⟨ω_i, t_i⟩, then sample a single masking challenge γ.
+	let sigmas: Vec<F> = relations
+		.iter()
+		.map(|(index, _, transparent, _)| {
+			inner_product_par(&committed_oracles[*index].mask, transparent)
+		})
+		.collect();
+	channel.send_many(&sigmas);
+	let gamma = IPProverChannel::<F>::sample(channel);
+	let gamma_broadcast = P::broadcast(gamma);
+
+	// === Phase A: batched sumcheck on the masked claims ⟨π_i', t_i⟩ = s_i' ===
+	// Register provers in arrival order; form π_i' = (1-γ)π_i + γω_i, storing each clone for Phase
+	// B keyed by oracle index, and pad each prover to `max_n`. `prover_oracle_indices` records the
+	// oracle index behind each (arrival-order) prover so the reduced evals can be scattered back
+	// into oracle-index order.
+	let mut witness_primes: Vec<Option<FieldBuffer<P>>> = (0..n_committed).map(|_| None).collect();
+	let mut prover_oracle_indices = Vec::with_capacity(n_committed);
+	let mut provers = Vec::with_capacity(n_committed);
+	for ((index, mut message, transparent, claim), &sigma) in relations.into_iter().zip(&sigmas) {
+		let n_i = n_vars[index];
+		assert_eq!(message.log_len(), n_i, "oracle message log_len mismatch for oracle {index}");
+		let mask = &committed_oracles[index].mask;
+		(message.as_mut(), mask.as_ref())
+			.into_par_iter()
+			.for_each(|(message_i, &mask_i)| {
+				*message_i = extrapolate_line_packed(*message_i, mask_i, gamma_broadcast);
+			});
+		witness_primes[index] = Some(message.clone());
+		prover_oracle_indices.push(index);
+
+		let sum_prime = extrapolate_line_packed(claim, sigma, gamma);
+		let inner = BivariateProductSumcheckProver::new([message, transparent], sum_prime)
+			.expect("π_i' and t_i have equal length");
+		provers.push(PaddedSumcheckDecorator::new(inner, max_n - n_i));
+	}
+
+	let output = batch_prove(provers, channel).expect("batched sumcheck proving should succeed");
+
+	// Reduced oracle evaluations α_i = π_i'(ρ_i) come out in arrival order; scatter them into
+	// oracle-index order to match how the verifier indexes them. `output.challenges` is already
+	// reversed to low-to-high (variable-indexed) order, so ρ_i is its first n_i coords.
+	let mut alphas = vec![F::ZERO; n_committed];
+	for (eval_pos, &index) in prover_oracle_indices.iter().enumerate() {
+		alphas[index] = output.multilinear_evals[eval_pos][0];
+	}
+	channel.send_many(&alphas);
+
+	// === Phase B: per-oracle BaseFold FRI interleaved with a MultilinearEvalProver ===
+	// Open each committed oracle at its evaluation point ρ_i = point[..n_i] in oracle-index order,
+	// matching the order the verifier opens them in, using each oracle's FRI parameters.
+	let point = &output.challenges;
+	for (index, witness_prime) in witness_primes.into_iter().enumerate() {
+		let witness_prime =
+			witness_prime.expect("every committed oracle carries exactly one queued relation");
+		let n_i = n_vars[index];
+		let eval_point = point[..n_i].to_vec();
+		let committed = &committed_oracles[index];
+		let fri_folder = FRIFoldProver::new(
+			&fri_params[index],
+			ntt,
+			merkle_prover,
+			committed.codeword.clone(),
+			&committed.committed,
+		);
+		prove_mlecheck_basefold_zk(
+			witness_prime,
+			&eval_point,
+			alphas[index],
+			gamma,
+			fri_folder,
+			channel,
+		)
+		.expect("MLE-check BaseFold proof should succeed");
 	}
 }
 
@@ -226,111 +386,25 @@ where
 			Item = (Self::Oracle, FieldBuffer<P>, FieldBuffer<P>, P::Scalar),
 		>,
 	) {
-		let relations: Vec<_> = oracle_relations.into_iter().collect();
-		if relations.is_empty() {
-			return;
-		}
-
-		let indices: Vec<usize> = relations.iter().map(|(oracle, ..)| oracle.index).collect();
-		for &index in &indices {
+		// Queue the relations; the actual opening (masking + sumcheck + combined FRI) happens once,
+		// over all committed oracles, in [`Self::finish`].
+		for (oracle, message, transparent, claim) in oracle_relations {
 			assert!(
-				index < self.committed_oracles.len(),
-				"oracle index {index} out of bounds, expected < {}",
+				oracle.index < self.committed_oracles.len(),
+				"oracle index {} out of bounds, expected < {}",
+				oracle.index,
 				self.committed_oracles.len()
 			);
-		}
-		let n_vars: Vec<usize> = indices
-			.iter()
-			.map(|&i| self.oracle_specs[i].log_msg_len)
-			.collect();
-		let max_n = *n_vars.iter().max().expect("relations is non-empty");
-
-		// === Masking step (whitepaper 7.2) ===
-		// Send the masked inner products σ_i = ⟨ω_i, t_i⟩, then sample a single masking challenge
-		// γ.
-		let sigmas: Vec<F> = relations
-			.iter()
-			.zip(&indices)
-			.map(|((_, _, transparent, _), &index)| {
-				inner_product_par(&self.committed_oracles[index].mask, transparent)
-			})
-			.collect();
-		self.send_many(&sigmas);
-		let gamma: F = self.sample();
-		let gamma_broadcast = P::broadcast(gamma);
-
-		// === Phase A: batched sumcheck on the masked claims ⟨π_i', t_i⟩ = s_i' ===
-		// Form π_i' = (1-γ)π_i + γω_i (keep a clone for Phase B), pad each prover to `max_n`.
-		let mut witness_primes = Vec::with_capacity(relations.len());
-		let mut provers = Vec::with_capacity(relations.len());
-		for ((((_, mut message, transparent, claim), &index), &n_i), &sigma) in relations
-			.into_iter()
-			.zip(&indices)
-			.zip(&n_vars)
-			.zip(&sigmas)
-		{
-			assert_eq!(
-				message.log_len(),
-				n_i,
-				"oracle message log_len mismatch for oracle {index}"
-			);
-			let mask = &self.committed_oracles[index].mask;
-			(message.as_mut(), mask.as_ref())
-				.into_par_iter()
-				.for_each(|(message_i, &mask_i)| {
-					*message_i = extrapolate_line_packed(*message_i, mask_i, gamma_broadcast);
-				});
-			witness_primes.push(message.clone());
-
-			let sum_prime = extrapolate_line_packed(claim, sigma, gamma);
-			let inner = BivariateProductSumcheckProver::new([message, transparent], sum_prime)
-				.expect("π_i' and t_i have equal length");
-			provers.push(PaddedSumcheckDecorator::new(inner, max_n - n_i));
-		}
-
-		let output = batch_prove(provers, self).expect("batched sumcheck proving should succeed");
-
-		// Reduced oracle evaluations α_i = π_i'(ρ_i); `output.challenges` is already reversed to
-		// low-to-high (variable-indexed) order, so ρ_i is its first n_i coordinates.
-		let alphas: Vec<F> = output
-			.multilinear_evals
-			.iter()
-			.map(|evals| evals[0])
-			.collect();
-		self.send_many(&alphas);
-
-		// === Phase B: per-oracle BaseFold FRI interleaved with a MultilinearEvalProver ===
-		for (((witness_prime, &index), &n_i), &alpha) in witness_primes
-			.into_iter()
-			.zip(&indices)
-			.zip(&n_vars)
-			.zip(&alphas)
-		{
-			let eval_point = output.challenges[..n_i].to_vec();
-			let committed = &self.committed_oracles[index];
-			let fri_folder = FRIFoldProver::new(
-				&self.fri_params[index],
-				self.ntt,
-				self.merkle_prover,
-				committed.codeword.clone(),
-				&committed.committed,
-			);
-			prove_mlecheck_basefold_zk(
-				witness_prime,
-				&eval_point,
-				alpha,
-				gamma,
-				fri_folder,
-				self.transcript,
-			)
-			.expect("MLE-check BaseFold proof should succeed");
+			self.queue.push((oracle.index, message, transparent, claim));
 		}
 	}
 }
 
 #[cfg(test)]
 mod tests {
-	use binius_field::{BinaryField, BinaryField128bGhash, PackedBinaryGhash1x128b, PackedField};
+	use binius_field::{
+		BinaryField, BinaryField128bGhash, Field, PackedBinaryGhash1x128b, PackedField,
+	};
 	use binius_hash::{StdDigest, StdHashSuite};
 	use binius_iop::{
 		basefold_compiler::BaseFoldZKVerifierCompiler,
@@ -434,6 +508,7 @@ mod tests {
 			transparent_poly.clone(),
 			eval_claim,
 		)]);
+		prover_channel.finish();
 
 		// === VERIFIER SIDE ===
 		let mut verifier_transcript = prover_transcript.into_verifier();
@@ -451,6 +526,7 @@ mod tests {
 				claim: eval_claim,
 			}])
 			.unwrap();
+		verifier_channel.finish().unwrap();
 	}
 
 	#[test]
@@ -506,6 +582,7 @@ mod tests {
 			(oracle_1, buffer_1, transparent_poly_1.clone(), eval_claim_1),
 			(oracle_2, buffer_2, transparent_poly_2.clone(), eval_claim_2),
 		]);
+		prover_channel.finish();
 
 		// === VERIFIER SIDE ===
 		let mut verifier_transcript = prover_transcript.into_verifier();
@@ -537,5 +614,106 @@ mod tests {
 				},
 			])
 			.unwrap();
+		verifier_channel.finish().unwrap();
+	}
+
+	/// Runs a full prove/verify cycle of the Batched ZK BaseFold channel over oracles of the given
+	/// sizes. If `tamper`, the verifier's claim on the first oracle is corrupted; verification must
+	/// then fail. Returns whether verification accepted.
+	fn run_zk_channel(n_vars_list: &[usize], tamper: bool) -> bool {
+		type F = BinaryField128bGhash;
+		type P = PackedBinaryGhash1x128b;
+
+		let mut rng = StdRng::seed_from_u64(0);
+		let data: Vec<(FieldBuffer<P>, FieldBuffer<P>, F)> = n_vars_list
+			.iter()
+			.map(|&n| generate_zk_oracle_data::<F, P, _>(&mut rng, n))
+			.collect();
+
+		let n_test_queries = calculate_n_test_queries(SECURITY_BITS, LOG_INV_RATE);
+		let oracle_specs: Vec<OracleSpec> = n_vars_list
+			.iter()
+			.map(|&n| OracleSpec { log_msg_len: n })
+			.collect();
+
+		let merkle_prover = make_merkle_prover();
+		let verifier_compiler = BaseFoldZKVerifierCompiler::new(
+			merkle_prover.scheme().clone(),
+			oracle_specs,
+			LOG_INV_RATE,
+			n_test_queries,
+			&MinProofSizeStrategy,
+		);
+
+		// === PROVER SIDE ===
+		let ntt = make_ntt(verifier_compiler.max_subspace());
+		let prover_compiler = BaseFoldZKProverCompiler::<P, _, _>::from_verifier_compiler(
+			&verifier_compiler,
+			ntt,
+			merkle_prover,
+		);
+
+		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
+		let prover_rng = StdRng::seed_from_u64(1);
+		let mut prover_channel = prover_compiler.create_channel(&mut prover_transcript, prover_rng);
+
+		let oracles: Vec<_> = data
+			.iter()
+			.map(|(buffer, _, _)| prover_channel.send_oracle(buffer.to_ref()))
+			.collect();
+		let prover_relations: Vec<_> = oracles
+			.into_iter()
+			.zip(&data)
+			.map(|(oracle, (buffer, transparent, claim))| {
+				(oracle, buffer.clone(), transparent.clone(), *claim)
+			})
+			.collect();
+		prover_channel.prove_oracle_relations(prover_relations);
+		prover_channel.finish();
+
+		// === VERIFIER SIDE ===
+		let mut verifier_transcript = prover_transcript.into_verifier();
+		let mut verifier_channel = verifier_compiler.create_channel(&mut verifier_transcript);
+
+		let v_oracles: Vec<_> = (0..n_vars_list.len())
+			.map(|_| verifier_channel.recv_oracle().unwrap())
+			.collect();
+		let relations: Vec<_> = v_oracles
+			.into_iter()
+			.zip(&data)
+			.enumerate()
+			.map(|(i, (oracle, (_, transparent, claim)))| {
+				let transparent = transparent.clone();
+				let claim = if tamper && i == 0 {
+					*claim + F::ONE
+				} else {
+					*claim
+				};
+				OracleLinearRelation {
+					oracle,
+					transparent: Box::new(move |point: &[F]| {
+						let eq = eq_ind_partial_eval::<P>(point);
+						inner_product_buffers(&transparent, &eq)
+					}),
+					claim,
+				}
+			})
+			.collect();
+		verifier_channel
+			.verify_oracle_relations(relations)
+			.expect("verify_oracle_relations only queues");
+		verifier_channel.finish().is_ok()
+	}
+
+	#[test]
+	fn test_basefold_zk_channel_three_oracles_non_power_of_two() {
+		// 3 oracles (not a power of two) of unequal sizes: exercises oracle padding (Lifted FRI)
+		// and the `⌈log 3⌉ = 2` outer oracle-combine rounds.
+		assert!(run_zk_channel(&[5, 6, 8], false));
+	}
+
+	#[test]
+	fn test_basefold_zk_channel_invalid_proof() {
+		assert!(!run_zk_channel(&[6, 8], true));
 	}
 }

--- a/crates/iop-prover/src/basefold_zk_channel.rs
+++ b/crates/iop-prover/src/basefold_zk_channel.rs
@@ -7,28 +7,31 @@
 //! this channel always applies zero-knowledge blinding to all oracles by generating masks
 //! internally.
 
+use std::iter;
+
 use binius_field::{BinaryField, PackedField};
 use binius_iop::{channel::OracleSpec, fri::FRIParams, merkle_tree::MerkleTreeScheme};
 use binius_ip_prover::{
 	channel::IPProverChannel,
-	sumcheck::{
-		PaddedSumcheckDecorator, batch::batch_prove,
-		bivariate_product::BivariateProductSumcheckProver,
-	},
+	sumcheck::{self, PaddedSumcheckDecorator, bivariate_product::BivariateProductSumcheckProver},
 };
 use binius_math::{
-	FieldBuffer, FieldSlice, inner_product::inner_product_par, line::extrapolate_line_packed,
+	FieldBuffer, FieldSlice,
+	inner_product::inner_product_par,
+	line::{extrapolate_line, extrapolate_line_packed},
+	multilinear::eq::{eq_ind_partial_eval_scalars, eq_ind_zero},
 	ntt::AdditiveNTT,
 };
 use binius_transcript::{
 	ProverTranscript,
 	fiat_shamir::{CanSample, Challenger},
 };
-use binius_utils::{SerializeBytes, rayon::prelude::*};
+use binius_utils::{SerializeBytes, checked_arithmetics::log2_ceil_usize, rayon::prelude::*};
+use itertools::izip;
 use rand::{Rng, SeedableRng, rngs::StdRng};
 
 use crate::{
-	basefold::prove_mlecheck_basefold_zk,
+	basefold::prove_mlecheck_basefold_zk_batch,
 	basefold_compiler::BaseFoldZKProverCompiler,
 	channel::IOPProverChannel,
 	fri::{self, CommitMaskedOutput, FRIFoldProver},
@@ -80,9 +83,8 @@ where
 	ntt: &'a NTT,
 	merkle_prover: &'a MerkleProver_,
 	oracle_specs: Vec<OracleSpec>,
-	/// Per-oracle FRI parameters (`log_batch_size = 1`), used for `commit_masked` and the
-	/// per-oracle BaseFold openings in [`Self::finish`].
-	fri_params: Vec<FRIParams<F>>,
+	/// The combined FRI parameters over all committed oracles.
+	fri_params: FRIParams<F>,
 	committed_oracles: Vec<CommittedOracleData<P, MerkleProver_::Committed>>,
 	/// Oracle relations queued by [`Self::prove_oracle_relations`], opened together in
 	/// [`Self::finish`]. Each entry is `(oracle_index, message π_i, transparent t_i, claim s_i)`.
@@ -114,7 +116,7 @@ where
 			ntt: compiler.ntt(),
 			merkle_prover: compiler.merkle_prover(),
 			oracle_specs: compiler.oracle_specs().to_vec(),
-			fri_params: compiler.fri_params().to_vec(),
+			fri_params: compiler.fri_params().clone(),
 			committed_oracles: Vec::new(),
 			queue: Vec::new(),
 			next_oracle_index: 0,
@@ -191,7 +193,7 @@ fn prove_batch_zk_basefold<F, P, NTT, MerkleScheme, MerkleProver_, Challenger_>(
 	ntt: &NTT,
 	merkle_prover: &MerkleProver_,
 	oracle_specs: &[OracleSpec],
-	fri_params: &[FRIParams<F>],
+	fri_params: &FRIParams<F>,
 	committed_oracles: Vec<CommittedOracleData<P, MerkleProver_::Committed>>,
 	relations: Vec<(usize, FieldBuffer<P>, FieldBuffer<P>, F)>,
 ) where
@@ -203,22 +205,25 @@ fn prove_batch_zk_basefold<F, P, NTT, MerkleScheme, MerkleProver_, Challenger_>(
 	Challenger_: Challenger,
 {
 	let n_committed = committed_oracles.len();
+	assert_eq!(oracle_specs.len(), n_committed);
+
+	// TODO: Remove this limitation, it shouldn't be necessary. It is currently because of how the
+	// sumcheck reduces to the multilinear evaluations (alphas).
 	assert_eq!(relations.len(), n_committed, "expects exactly one relation per committed oracle",);
 
-	let n_vars: Vec<usize> = (0..n_committed)
-		.map(|i| oracle_specs[i].log_msg_len)
-		.collect();
-	let max_n = *n_vars.iter().max().expect("relations is non-empty");
+	// `𝐧 = max_i n_i`, the dimension of the combined codeword.
+	let max_n = fri_params.rs_code().log_dim();
 
 	// === Masking step (whitepaper 7.2) ===
 	// Send the masked inner products σ_i = ⟨ω_i, t_i⟩, then sample a single masking challenge γ.
-	let sigmas: Vec<F> = relations
+	let sigmas = relations
 		.iter()
 		.map(|(index, _, transparent, _)| {
 			inner_product_par(&committed_oracles[*index].mask, transparent)
 		})
-		.collect();
+		.collect::<Vec<_>>();
 	channel.send_many(&sigmas);
+
 	let gamma = IPProverChannel::<F>::sample(channel);
 	let gamma_broadcast = P::broadcast(gamma);
 
@@ -227,13 +232,17 @@ fn prove_batch_zk_basefold<F, P, NTT, MerkleScheme, MerkleProver_, Challenger_>(
 	// B keyed by oracle index, and pad each prover to `max_n`. `prover_oracle_indices` records the
 	// oracle index behind each (arrival-order) prover so the reduced evals can be scattered back
 	// into oracle-index order.
-	let mut witness_primes: Vec<Option<FieldBuffer<P>>> = (0..n_committed).map(|_| None).collect();
+	let mut witness_primes = vec![None; n_committed];
 	let mut prover_oracle_indices = Vec::with_capacity(n_committed);
 	let mut provers = Vec::with_capacity(n_committed);
-	for ((index, mut message, transparent, claim), &sigma) in relations.into_iter().zip(&sigmas) {
-		let n_i = n_vars[index];
-		assert_eq!(message.log_len(), n_i, "oracle message log_len mismatch for oracle {index}");
+	for ((index, mut message, transparent, claim), sigma) in iter::zip(relations, sigmas) {
+		let n_i = oracle_specs[index].log_msg_len;
+		assert_eq!(message.log_len(), n_i); // pre-condition
+		assert_eq!(transparent.log_len(), n_i); // pre-condition
+
 		let mask = &committed_oracles[index].mask;
+
+		// Modify the message π_i to be the blinded message π_i'.
 		(message.as_mut(), mask.as_ref())
 			.into_par_iter()
 			.for_each(|(message_i, &mask_i)| {
@@ -242,50 +251,80 @@ fn prove_batch_zk_basefold<F, P, NTT, MerkleScheme, MerkleProver_, Challenger_>(
 		witness_primes[index] = Some(message.clone());
 		prover_oracle_indices.push(index);
 
-		let sum_prime = extrapolate_line_packed(claim, sigma, gamma);
+		let sum_prime = extrapolate_line(claim, sigma, gamma);
 		let inner = BivariateProductSumcheckProver::new([message, transparent], sum_prime)
 			.expect("π_i' and t_i have equal length");
 		provers.push(PaddedSumcheckDecorator::new(inner, max_n - n_i));
 	}
 
-	let output = batch_prove(provers, channel).expect("batched sumcheck proving should succeed");
+	let output =
+		sumcheck::batch_prove(provers, channel).expect("batched sumcheck proving should succeed");
 
 	// Reduced oracle evaluations α_i = π_i'(ρ_i) come out in arrival order; scatter them into
 	// oracle-index order to match how the verifier indexes them. `output.challenges` is already
 	// reversed to low-to-high (variable-indexed) order, so ρ_i is its first n_i coords.
+	//
+	// TODO: This will fail if one oracle isn't opened. For robustness, we should do a regular
+	// multilinear evaluation in that case.
 	let mut alphas = vec![F::ZERO; n_committed];
 	for (eval_pos, &index) in prover_oracle_indices.iter().enumerate() {
 		alphas[index] = output.multilinear_evals[eval_pos][0];
 	}
 	channel.send_many(&alphas);
 
-	// === Phase B: per-oracle BaseFold FRI interleaved with a MultilinearEvalProver ===
-	// Open each committed oracle at its evaluation point ρ_i = point[..n_i] in oracle-index order,
-	// matching the order the verifier opens them in, using each oracle's FRI parameters.
+	// === Phase B: single combined-FRI MLE-check over the piecewise-concatenated oracle ===
+	// Collapse the oracle-index variables up front at sampled batching challenges `r'`: build the
+	// combined multilinear 𝛑(X) = Σ_i e[i]·π_i^↑(X) with e = eq(·, r') into one 2^𝐧 buffer, and the
+	// combined target s' = 𝛑(r) = Σ_i e[i]·α_i·∏_{j≥n_i}(1 - r_j).
 	let point = &output.challenges;
-	for (index, witness_prime) in witness_primes.into_iter().enumerate() {
+	let log_n_oracles = log2_ceil_usize(n_committed);
+	let outer_challenges = channel.sample_many(log_n_oracles);
+	let eq_tensor = eq_ind_partial_eval_scalars(&outer_challenges);
+
+	let mut combined = FieldBuffer::<P>::zeros(max_n);
+	let mut s_prime = F::ZERO;
+	for (witness_prime, scalar, alpha_i) in izip!(witness_primes, eq_tensor, alphas) {
 		let witness_prime =
 			witness_prime.expect("every committed oracle carries exactly one queued relation");
-		let n_i = n_vars[index];
-		let eval_point = point[..n_i].to_vec();
-		let committed = &committed_oracles[index];
-		let fri_folder = FRIFoldProver::new(
-			&fri_params[index],
-			ntt,
-			merkle_prover,
-			committed.codeword.clone(),
-			&committed.committed,
-		);
-		prove_mlecheck_basefold_zk(
-			witness_prime,
-			&eval_point,
-			alphas[index],
-			gamma,
-			fri_folder,
-			channel,
-		)
-		.expect("MLE-check BaseFold proof should succeed");
+		let n_i = witness_prime.log_len();
+		// Add scalar · π_i^↑ into the low 2^{n_i} block of the combined buffer (the high block is
+		// the ZeroPadMSB lift, left as the zeros already in `combined`).
+		if n_i >= P::LOG_WIDTH {
+			let scalar_p = P::broadcast(scalar);
+			let src = witness_prime.as_ref();
+			combined.as_mut()[..src.len()]
+				.par_iter_mut()
+				.zip(src)
+				.for_each(|(dst, &w)| {
+					*dst += scalar_p * w;
+				});
+		} else {
+			let src = P::from_scalars(witness_prime.iter_scalars());
+			combined.as_mut()[0] += src;
+		}
+		s_prime += scalar * alpha_i * eq_ind_zero(&point[n_i..]);
 	}
+
+	// Codeword commitments in oracle-index order, matching `open_fri_params.input_oracles()`.
+	let (committed_codewords, committeds) = committed_oracles
+		.into_iter()
+		.map(|committed| (committed.codeword, committed.committed))
+		.unzip::<_, _, Vec<_>, Vec<_>>();
+	// TODO: Annoying that we need to pass references for committeds. Maybe we can change the
+	// FRIFoldProver constructor.
+	let committed_codewords = iter::zip(committed_codewords, &committeds).collect();
+
+	let fri_folder = FRIFoldProver::new_batch(fri_params, ntt, merkle_prover, committed_codewords);
+	prove_mlecheck_basefold_zk_batch(
+		combined,
+		point,
+		s_prime,
+		gamma,
+		&outer_challenges,
+		fri_folder,
+		channel,
+	)
+	.expect("combined MLE-check BaseFold proof should succeed");
 }
 
 impl<'a, F, P, NTT, MerkleScheme, MerkleProver_, Challenger_> IPProverChannel<F>
@@ -341,7 +380,6 @@ where
 
 		let index = self.next_oracle_index;
 		let spec = &remaining[0];
-		let fri_params = &self.fri_params[index];
 
 		// ZK channel expects raw witness buffer (NOT doubled).
 		assert_eq!(
@@ -352,14 +390,16 @@ where
 			buffer.log_len()
 		);
 
-		// Generate mask, interleave, and commit via commit_masked.
+		// Generate mask, interleave, and commit oracle `index` of the combined FRI parameters via
+		// commit_masked.
 		let CommitMaskedOutput {
 			commitment,
 			committed,
 			codeword,
 			mask,
 		} = fri::commit_masked(
-			fri_params,
+			&self.fri_params,
+			index,
 			self.ntt,
 			self.merkle_prover,
 			buffer.to_ref(),

--- a/crates/iop-prover/src/fri/commit.rs
+++ b/crates/iop-prover/src/fri/commit.rs
@@ -5,7 +5,7 @@ use std::iter;
 
 use binius_field::{BinaryField, PackedField};
 use binius_iop::{fri::FRIParams, merkle_tree::MerkleTreeScheme};
-use binius_math::{FieldBuffer, FieldSlice, ntt::AdditiveNTT};
+use binius_math::{FieldBuffer, FieldSlice, ntt::AdditiveNTT, reed_solomon::ReedSolomonCode};
 use binius_utils::{rand::par_rand, rayon::prelude::*};
 use rand::{CryptoRng, rngs::StdRng};
 
@@ -18,20 +18,27 @@ pub struct CommitOutput<P: PackedField, VCSCommitment, VCSCommitted> {
 	pub codeword: FieldBuffer<P>,
 }
 
-/// Encodes and commits the input message.
+/// Encodes and commits one input oracle's interleaved message.
+///
+/// `params` are the (possibly batched) FRI parameters and `oracle_index` selects which oracle of
+/// [`FRIParams::input_oracles`] is committed. The oracle is Reed–Solomon encoded at its own
+/// dimension — which may be smaller than the batched code's reduced dimension — over the same
+/// subspace and rate; the lift to the reduced dimension is applied later during the combined fold.
 ///
 /// ## Arguments
 ///
-/// * `rs_code` - the Reed-Solomon code to use for encoding
-/// * `params` - common FRI protocol parameters.
-/// * `merkle_prover` - the merke tree prover to use for committing
-/// * `message` - the interleaved message to encode and commit
+/// * `params` - the (possibly batched) FRI protocol parameters.
+/// * `oracle_index` - the index into [`FRIParams::input_oracles`] of the oracle being committed.
+/// * `ntt` - the additive NTT for Reed-Solomon encoding.
+/// * `merkle_prover` - the merkle tree prover to use for committing.
+/// * `message` - the interleaved message to encode and commit.
 ///
 /// ## Preconditions
 ///
-/// * `message.log_len()` must equal `params.log_msg_len()`.
+/// * `message.log_len()` must equal `params.input_oracles()[oracle_index].log_msg_len`.
 pub fn commit_interleaved<F, P, NTT, MerkleProver, VCS>(
 	params: &FRIParams<F>,
+	oracle_index: usize,
 	ntt: &NTT,
 	merkle_prover: &MerkleProver,
 	message: FieldSlice<P>,
@@ -43,14 +50,21 @@ where
 	MerkleProver: MerkleTreeProver<F, Scheme = VCS>,
 	VCS: MerkleTreeScheme<F>,
 {
+	let oracle_spec = &params.input_oracles()[oracle_index];
+	let log_batch_size = oracle_spec.log_batch_size;
+	let oracle_log_dim = oracle_spec.log_msg_len - log_batch_size;
+
 	assert_eq!(
 		message.log_len(),
-		params.log_msg_len(),
-		"precondition: interleaved message length must match code parameters"
+		oracle_spec.log_msg_len,
+		"precondition: interleaved message length must match the oracle's spec"
 	);
 
-	let rs_code = params.rs_code();
-	let log_batch_size = params.log_batch_size();
+	// Encode this oracle at its own dimension (≤ the batched code's reduced dimension), over the
+	// same subspace and rate as the batched code. `encode_batch` checks the subspace matches the
+	// NTT, which is how the per-oracle codeword stays consistent with the combined fold's lift.
+	let rs_code =
+		ReedSolomonCode::with_ntt_subspace(ntt, oracle_log_dim, params.rs_code().log_inv_rate());
 
 	let _scope = tracing::debug_span!(
 		"FRI Commit",
@@ -98,8 +112,9 @@ pub struct CommitMaskedOutput<P: PackedField, VCSCommitment, VCSCommitted> {
 ///
 /// ## Arguments
 ///
-/// * `params` - FRI parameters. Must have `log_batch_size() == 1` and `rs_code().log_dim() ==
-///   message.log_len()`.
+/// * `params` - the (possibly batched) FRI parameters.
+/// * `oracle_index` - the index into [`FRIParams::input_oracles`] of the oracle being committed;
+///   its spec must have `log_batch_size == 1` and `log_msg_len - 1 == message.log_len()`.
 /// * `ntt` - the additive NTT for Reed-Solomon encoding
 /// * `merkle_prover` - the Merkle tree prover for commitments
 /// * `message` - the raw message to commit (not doubled)
@@ -111,6 +126,7 @@ pub struct CommitMaskedOutput<P: PackedField, VCSCommitment, VCSCommitted> {
 /// the generated mask buffer.
 pub fn commit_masked<F, P, NTT, MerkleProver, VCS>(
 	params: &FRIParams<F>,
+	oracle_index: usize,
 	ntt: &NTT,
 	merkle_prover: &MerkleProver,
 	message: FieldSlice<P>,
@@ -123,11 +139,12 @@ where
 	MerkleProver: MerkleTreeProver<F, Scheme = VCS>,
 	VCS: MerkleTreeScheme<F>,
 {
-	assert_eq!(params.log_batch_size(), 1, "commit_masked requires log_batch_size == 1");
+	let oracle_spec = &params.input_oracles()[oracle_index];
+	assert_eq!(oracle_spec.log_batch_size, 1, "commit_masked requires log_batch_size == 1");
 	assert_eq!(
-		params.rs_code().log_dim(),
+		oracle_spec.log_msg_len - 1,
 		message.log_len(),
-		"commit_masked requires rs_code().log_dim() == message.log_len()"
+		"commit_masked requires the oracle's message dimension to match the message length"
 	);
 
 	// Generate random mask of equal length to message.
@@ -155,7 +172,7 @@ where
 		commitment,
 		committed,
 		codeword,
-	} = commit_interleaved(params, ntt, merkle_prover, combined.to_ref());
+	} = commit_interleaved(params, oracle_index, ntt, merkle_prover, combined.to_ref());
 
 	CommitMaskedOutput {
 		commitment,
@@ -250,7 +267,7 @@ mod tests {
 		let message = random_field_buffer::<P>(&mut rng, log_dim);
 
 		let output: CommitMaskedOutput<P, _, _> =
-			commit_masked(&params, &ntt, &merkle_prover, message.to_ref(), &mut rng);
+			commit_masked(&params, 0, &ntt, &merkle_prover, message.to_ref(), &mut rng);
 
 		// Verify mask has correct dimensions.
 		assert_eq!(output.mask.log_len(), log_dim);

--- a/crates/iop-prover/src/fri/tests.rs
+++ b/crates/iop-prover/src/fri/tests.rs
@@ -60,7 +60,7 @@ fn test_commit_prove_verify_success<F, P>(
 		commitment: mut codeword_commitment,
 		committed: codeword_committed,
 		codeword,
-	} = commit_interleaved(&params, &ntt, &merkle_prover, msg.to_ref());
+	} = commit_interleaved(&params, 0, &ntt, &merkle_prover, msg.to_ref());
 
 	// Run the prover to generate the proximity proof
 	let mut round_prover =
@@ -269,7 +269,7 @@ fn test_commit_prove_verify_batched_multi_oracle() {
 			commitment,
 			committed,
 			codeword,
-		} = commit_interleaved(&oracle_params, &ntt, &merkle_prover, msg.to_ref());
+		} = commit_interleaved(&oracle_params, 0, &ntt, &merkle_prover, msg.to_ref());
 		messages.push(msg);
 		commitments.push(commitment);
 		committeds.push(committed);
@@ -418,7 +418,7 @@ fn test_commit_prove_verify_lifted_multi_oracle() {
 			commitment,
 			committed,
 			codeword,
-		} = commit_interleaved(&oracle_params, &ntt, &merkle_prover, msg.to_ref());
+		} = commit_interleaved(&oracle_params, 0, &ntt, &merkle_prover, msg.to_ref());
 		messages.push(msg);
 		commitments.push(commitment);
 		committeds.push(committed);
@@ -549,7 +549,7 @@ where
 		commitment: codeword_commitment,
 		committed: codeword_committed,
 		codeword,
-	} = commit_interleaved(&params, &ntt, &merkle_prover, msg.to_ref());
+	} = commit_interleaved(&params, 0, &ntt, &merkle_prover, msg.to_ref());
 
 	let mut round_prover =
 		FRIFoldProver::new(&params, &ntt, &merkle_prover, codeword, &codeword_committed);

--- a/crates/iop/src/basefold.rs
+++ b/crates/iop/src/basefold.rs
@@ -110,7 +110,7 @@ where
 /// construction (whitepaper §7.2 / §sec:batched-basefold Step 2).
 ///
 /// This is the verifier counterpart of
-/// [`binius_iop_prover::basefold::prove_mlecheck_basefold_zk_batch`]. A prior batched sumcheck has
+/// `binius_iop_prover::basefold::prove_mlecheck_basefold_zk_batch`. A prior batched sumcheck has
 /// reduced the `k` masked opening claims to per-oracle point-evaluation claims `π_i'(ρ_i) = α_i` at
 /// a shared point `r ∈ K^𝐧` (`𝐧 = max_i n_i`). The oracle-index variables are then collapsed up
 /// front at sampled batching challenges `r'` into a single combined multilinear

--- a/crates/iop/src/basefold.rs
+++ b/crates/iop/src/basefold.rs
@@ -30,7 +30,7 @@ use binius_transcript::{
 	self as transcript, VerifierTranscript,
 	fiat_shamir::{CanSample, Challenger},
 };
-use binius_utils::DeserializeBytes;
+use binius_utils::{DeserializeBytes, checked_arithmetics::log2_ceil_usize};
 
 use crate::{
 	fri::{self, FRIFoldVerifier, FRIParams, verify::FRIQueryVerifier},
@@ -105,29 +105,38 @@ where
 	})
 }
 
-/// Verifies a multilinear-evaluation BaseFold opening that interleaves a degree-1 MLE-check with
-/// FRI (the FRI-interleaved sumcheck of the Batched ZK BaseFold construction).
+/// Verifies a *combined* multilinear-evaluation BaseFold opening: a single degree-1 MLE-check
+/// interleaved with a single FRI over the piecewise-concatenated oracle of the Batched ZK BaseFold
+/// construction (whitepaper §7.2 / §sec:batched-basefold Step 2).
 ///
-/// This is the verifier counterpart of `binius_iop_prover::basefold::prove_mlecheck_basefold_zk`.
-/// The masked oracle's opening claim
-/// has already been reduced to a point-evaluation claim `π'(eval_point) = eval_claim` by a prior
-/// batched sumcheck; this routine checks that claim against the committed codeword.
+/// This is the verifier counterpart of
+/// [`binius_iop_prover::basefold::prove_mlecheck_basefold_zk_batch`]. A prior batched sumcheck has
+/// reduced the `k` masked opening claims to per-oracle point-evaluation claims `π_i'(ρ_i) = α_i` at
+/// a shared point `r ∈ K^𝐧` (`𝐧 = max_i n_i`). The oracle-index variables are then collapsed up
+/// front at sampled batching challenges `r'` into a single combined multilinear
+/// `𝛑(X) = Σ_i e[i] · π_i^↑(X)`, `e = eq_ind_partial_eval(r')`, with target `s' = 𝛑(r)`; this
+/// routine checks `𝛑(r) = s'` against the `k` committed codewords via one combined FRI.
 ///
 /// ## Arguments
 ///
-/// * `eval_claim` - the claimed value `π'(eval_point)`
-/// * `eval_point` - the evaluation point `ρ` (length `n`), in low-to-high variable order
-/// * `batch_challenge` - the masking challenge `γ` used in the FRI unbatch round
+/// * `codeword_commitments` - one per oracle, in the same order as [`FRIParams::input_oracles`].
+/// * `eval_claim` - the combined target `s'`.
+/// * `eval_point` - the point `r` (length `𝐧 = fri_params.rs_code().log_dim()`), low-to-high order.
+/// * `batch_challenge` - the masking challenge `γ` used in the FRI inner (unbatch) round.
+/// * `outer_challenges` - the batching challenges `r'` (length `log_n_oracles`) used in the FRI
+///   outer (oracle-combine) rounds.
 ///
-/// The returned `challenges` begin with `batch_challenge` followed by the `n` MLE-check challenges.
-/// Use [`mlecheck_fri_consistency`] to check the reduced values.
-pub fn verify_mlecheck_basefold_zk<F, MTScheme, Challenger_>(
+/// The returned `challenges` are the FRI fold challenges `[γ] ++ r' ++ fresh_X`. Use
+/// [`mlecheck_fri_consistency`] to check the reduced values.
+#[allow(clippy::too_many_arguments)]
+pub fn verify_mlecheck_basefold_zk_batch<F, MTScheme, Challenger_>(
 	fri_params: &FRIParams<F>,
 	merkle_scheme: &MTScheme,
-	codeword_commitment: MTScheme::Digest,
+	codeword_commitments: &[MTScheme::Digest],
 	eval_claim: F,
 	eval_point: &[F],
 	batch_challenge: F,
+	outer_challenges: &[F],
 	transcript: &mut VerifierTranscript<Challenger_>,
 ) -> Result<ReducedOutput<F>, Error>
 where
@@ -138,18 +147,40 @@ where
 	// The MLE-check round polynomial is degree 1 (the composite is the multilinear itself).
 	const DEGREE: usize = 1;
 
-	assert_eq!(fri_params.log_batch_size(), 1); // precondition
+	// ZK precondition: each oracle is the interleaved (π ‖ ω) mask codeword, so the inner reduction
+	// is a single round folding at `γ`.
+	let max_log_batch_size = fri_params
+		.input_oracles()
+		.iter()
+		.map(|spec| spec.log_batch_size)
+		.max()
+		.expect("input_oracles is non-empty");
+	assert_eq!(max_log_batch_size, 1);
 
+	let log_n_oracles = log2_ceil_usize(fri_params.input_oracles().len());
+	assert_eq!(outer_challenges.len(), log_n_oracles);
+
+	// The combined codeword (after the inner unbatch and the `log_n_oracles` outer oracle-combine
+	// rounds) is a level-𝐧 codeword; the MLE-check therefore runs over `𝐧` variables.
 	let n_vars = fri_params.rs_code().log_dim();
 	assert_eq!(eval_point.len(), n_vars);
-	let mut challenges = Vec::with_capacity(n_vars + 1);
 
+	let mut challenges = Vec::with_capacity(n_vars + 1 + log_n_oracles);
 	let mut fri_fold_verifier = FRIFoldVerifier::new(fri_params);
 
-	// Unbatch round: the FRI folds the interleaved (π ‖ ω) codeword at the masking challenge.
+	// Inner (unbatch) round: fold every interleaved (π_i ‖ ω_i) codeword at the masking challenge.
 	fri_fold_verifier.process_round(&mut transcript.message())?;
 	challenges.push(batch_challenge);
 
+	// Outer rounds: combine the `k` lifted codewords at the batching challenges `r'`. These carry
+	// no sumcheck round-polynomial (the oracle-index variables are collapsed deterministically).
+	for &outer_challenge in outer_challenges {
+		fri_fold_verifier.process_round(&mut transcript.message())?;
+		challenges.push(outer_challenge);
+	}
+
+	// Standard rounds: the only sumcheck (MLE-check) rounds, folding the combined codeword at the
+	// fresh challenges over the `𝐧` variables `X`.
 	let mut sum = eval_claim;
 	for round in 0..n_vars {
 		let round_proof = mlecheck::RoundProof(RoundCoeffs(transcript.message().read_vec(DEGREE)?));
@@ -166,10 +197,10 @@ where
 	fri_fold_verifier.process_round(&mut transcript.message())?;
 	let round_commitments = fri_fold_verifier.finalize();
 
-	let fri_verifier = FRIQueryVerifier::new(
+	let fri_verifier = FRIQueryVerifier::new_batch(
 		fri_params,
 		merkle_scheme,
-		&codeword_commitment,
+		codeword_commitments,
 		&round_commitments,
 		&challenges,
 	);
@@ -216,7 +247,7 @@ pub fn sumcheck_fri_consistency<F: Field>(
 }
 
 /// Verifies that the final FRI oracle is consistent with the MLE-check from
-/// [`verify_mlecheck_basefold_zk`].
+/// [`verify_mlecheck_basefold_zk_batch`].
 ///
 /// In an MLE-check the equality-indicator factor is folded into the round-proof recovery, so the
 /// final reduced value is the multilinear evaluation `π'(r)` with no extra factor. The final FRI

--- a/crates/iop/src/basefold_channel.rs
+++ b/crates/iop/src/basefold_channel.rs
@@ -159,7 +159,7 @@ where
 	}
 }
 
-impl<F, MerkleScheme_, Challenger_> IOPVerifierChannel<F>
+impl<'r, F, MerkleScheme_, Challenger_> IOPVerifierChannel<'r, F>
 	for BaseFoldVerifierChannel<'_, F, MerkleScheme_, Challenger_>
 where
 	F: BinaryField,
@@ -193,9 +193,9 @@ where
 		Ok(BaseFoldOracle { index })
 	}
 
-	fn verify_oracle_relations<'a>(
+	fn verify_oracle_relations(
 		&mut self,
-		oracle_relations: impl IntoIterator<Item = OracleLinearRelation<'a, Self::Oracle, Self::Elem>>,
+		oracle_relations: impl IntoIterator<Item = OracleLinearRelation<'r, Self::Oracle, Self::Elem>>,
 	) -> Result<(), Error> {
 		// Process each oracle relation with its own BaseFold verification
 		for relation in oracle_relations {

--- a/crates/iop/src/basefold_compiler.rs
+++ b/crates/iop/src/basefold_compiler.rs
@@ -14,7 +14,7 @@ use crate::{
 	basefold_channel::BaseFoldVerifierChannel,
 	basefold_zk_channel::BaseFoldZKVerifierChannel,
 	channel::OracleSpec,
-	fri::{AritySelectionStrategy, FRIParams},
+	fri::{AritySelectionStrategy, FRIParams, PartialOracleSpec},
 	merkle_tree::MerkleTreeScheme,
 	size_tracking_channel::SizeTrackingChannel,
 };
@@ -163,7 +163,7 @@ where
 {
 	merkle_scheme: MerkleScheme_,
 	oracle_specs: Vec<OracleSpec>,
-	fri_params: Vec<FRIParams<F>>,
+	fri_params: FRIParams<F>,
 }
 
 impl<F, MerkleScheme_> BaseFoldZKVerifierCompiler<F, MerkleScheme_>
@@ -173,44 +173,49 @@ where
 {
 	/// Creates a new ZK compiler with precomputed FRI parameters.
 	///
-	/// All oracle specs are treated as ZK: FRI parameters use `log_msg_len + 1` and
-	/// `log_batch_size = 1`.
+	/// All oracle specs are treated as ZK: the combined FRI parameters use `log_msg_len + 1` and
+	/// `log_batch_size = 1` per oracle. Requires at least one oracle spec.
 	pub fn new<Strategy>(
 		merkle_scheme: MerkleScheme_,
 		oracle_specs: Vec<OracleSpec>,
 		log_inv_rate: usize,
 		n_test_queries: usize,
-		arity_strategy: &Strategy,
+		_arity_strategy: &Strategy,
 	) -> Self
 	where
 		Strategy: AritySelectionStrategy,
 	{
+		assert!(
+			!oracle_specs.is_empty(),
+			"BaseFoldZKVerifierCompiler requires at least one oracle spec"
+		);
+
 		// ZK adds 1 to each message length; compute max code length across all oracles.
 		let max_log_code_len = oracle_specs
 			.iter()
 			.map(|spec| spec.log_msg_len + 1)
 			.max()
-			.unwrap_or(0)
+			.expect("oracle_specs is non-empty")
 			+ log_inv_rate;
 		let subspace = BinarySubspace::with_dim(max_log_code_len);
 		let domain_context = GenericOnTheFly::generate_from_subspace(&subspace);
 
-		let fri_params = oracle_specs
+		// The single combined FRI parameters over all oracles. `optimal_for_batch` chooses the fold
+		// arities to minimize proof size, so `_arity_strategy` is not consulted here.
+		let partial_specs: Vec<PartialOracleSpec> = oracle_specs
 			.iter()
-			.map(|spec| {
-				let log_msg_len = spec.log_msg_len + 1;
-				let log_batch_size = Some(1);
-				FRIParams::with_strategy(
-					&domain_context,
-					&merkle_scheme,
-					log_msg_len,
-					log_batch_size,
-					log_inv_rate,
-					n_test_queries,
-					arity_strategy,
-				)
+			.map(|spec| PartialOracleSpec {
+				log_msg_len: spec.log_msg_len + 1,
+				log_batch_size: Some(1),
 			})
 			.collect();
+		let (fri_params, _) = FRIParams::optimal_for_batch(
+			&domain_context,
+			&merkle_scheme,
+			&partial_specs,
+			log_inv_rate,
+			n_test_queries,
+		);
 
 		Self {
 			merkle_scheme,
@@ -224,8 +229,8 @@ where
 		&self.oracle_specs
 	}
 
-	/// Returns a reference to the precomputed FRI parameters.
-	pub fn fri_params(&self) -> &[FRIParams<F>] {
+	/// Returns a reference to the precomputed combined FRI parameters.
+	pub fn fri_params(&self) -> &FRIParams<F> {
 		&self.fri_params
 	}
 
@@ -234,18 +239,18 @@ where
 		&self.merkle_scheme
 	}
 
-	/// Returns the Reed-Solomon code subspace with the largest dimension.
+	/// Returns the Reed-Solomon code subspace of the combined FRI parameters (the largest needed).
 	pub fn max_subspace(&self) -> &BinarySubspace<F> {
-		self.fri_params
-			.iter()
-			.max_by_key(|p| p.rs_code().log_len())
-			.map(|p| p.rs_code().subspace())
-			.expect("fri_params is non-empty")
+		self.fri_params.rs_code().subspace()
 	}
 
 	/// Creates a [`SizeTrackingChannel`] from this compiler's oracle specs.
 	pub fn create_size_tracking_channel(&self) -> SizeTrackingChannel<'_, F, MerkleScheme_> {
-		SizeTrackingChannel::new(self.oracle_specs.clone(), &self.fri_params, &self.merkle_scheme)
+		SizeTrackingChannel::new(
+			self.oracle_specs.clone(),
+			std::slice::from_ref(&self.fri_params),
+			&self.merkle_scheme,
+		)
 	}
 
 	/// Creates a ZK verifier channel from this compiler and a transcript.

--- a/crates/iop/src/basefold_zk_channel.rs
+++ b/crates/iop/src/basefold_zk_channel.rs
@@ -56,8 +56,13 @@ where
 	transcript: &'a mut VerifierTranscript<Challenger_>,
 	merkle_scheme: &'a MerkleScheme_,
 	oracle_specs: &'a [OracleSpec],
+	/// Per-oracle FRI parameters (`log_batch_size = 1`), one per oracle, used for the per-oracle
+	/// BaseFold openings in [`Self::finish`].
 	fri_params: &'a [FRIParams<F>],
 	oracle_commitments: Vec<MerkleScheme_::Digest>,
+	/// Oracle relations queued by [`Self::verify_oracle_relations`], opened together in
+	/// [`Self::finish`].
+	queue: Vec<OracleLinearRelation<'a, BaseFoldZKOracle, F>>,
 	next_oracle_index: usize,
 }
 
@@ -83,6 +88,7 @@ where
 			oracle_specs,
 			fri_params,
 			oracle_commitments: Vec::new(),
+			queue: Vec::new(),
 			next_oracle_index: 0,
 		}
 	}
@@ -92,11 +98,144 @@ where
 		self.transcript
 	}
 
-	/// Consumes the channel, asserting all oracle specs have been consumed.
-	pub fn finish(self) {
-		let n_remaining = self.oracle_specs.len() - self.next_oracle_index;
+	/// Consumes the channel and verifies the single combined opening over **all** committed
+	/// oracles.
+	///
+	/// All oracle relations queued by
+	/// [`verify_oracle_relations`](IOPVerifierChannel::verify_oracle_relations) across every call
+	/// are processed here in one batch: masking, one batched sumcheck reducing the masked claims
+	/// to a shared point `r`, then one combined FRI opening over every committed oracle
+	/// (in oracle-index order). Because the whole opening is deferred to this point, every oracle
+	/// is committed and there is a single sumcheck point, so the precomputed combined `FRIParams`
+	/// (`optimal_for_batch` over all oracle specs) serves the opening.
+	pub fn finish(self) -> Result<(), Error> {
+		let Self {
+			transcript,
+			merkle_scheme,
+			oracle_specs,
+			fri_params,
+			oracle_commitments,
+			queue,
+			next_oracle_index,
+		} = self;
+
+		let n_remaining = oracle_specs.len() - next_oracle_index;
 		assert!(n_remaining == 0, "finish called but {n_remaining} oracle specs remaining",);
+
+		if queue.is_empty() {
+			return Ok(());
+		}
+
+		verify_batch_zk_basefold(
+			transcript,
+			merkle_scheme,
+			oracle_specs,
+			fri_params,
+			oracle_commitments,
+			queue,
+		)
 	}
+}
+
+/// Verifies the combined ZK BaseFold opening over all committed oracles.
+///
+/// This drives `channel` — the [`VerifierTranscript`] taken from the destructured
+/// [`BaseFoldZKVerifierChannel`] — through its [`IPVerifierChannel`] interface: it reads the masked
+/// inner products σ_i, runs one batched sumcheck reducing the masked claims to a shared point `r`,
+/// then opens each committed oracle with its own FRI parameters.
+///
+/// The masking inner products and the batched sumcheck process the `relations` in arrival order (so
+/// each reduced eval lines up with its batched-claim coefficient), while the per-oracle evaluations
+/// α_i and the FRI openings are emitted in oracle-index order. Each relation carries its oracle's
+/// index, so the two orders are reconciled by indexing rather than by sorting the relations; the
+/// per-oracle data (`oracle_specs`, `fri_params`, `oracle_commitments`) is all indexed by oracle
+/// index.
+///
+/// `channel` is the concrete [`VerifierTranscript`] rather than an arbitrary [`IPVerifierChannel`]
+/// because the Phase-B FRI openings read Merkle query proofs, which fall outside that interface.
+fn verify_batch_zk_basefold<F, MerkleScheme_, Challenger_>(
+	channel: &mut VerifierTranscript<Challenger_>,
+	merkle_scheme: &MerkleScheme_,
+	oracle_specs: &[OracleSpec],
+	fri_params: &[FRIParams<F>],
+	oracle_commitments: Vec<MerkleScheme_::Digest>,
+	relations: Vec<OracleLinearRelation<'_, BaseFoldZKOracle, F>>,
+) -> Result<(), Error>
+where
+	F: BinaryField,
+	MerkleScheme_: MerkleTreeScheme<F, Digest: DeserializeBytes>,
+	Challenger_: Challenger,
+{
+	let n_committed = oracle_commitments.len();
+	assert_eq!(relations.len(), n_committed, "expects exactly one relation per committed oracle",);
+
+	let n_vars: Vec<usize> = (0..n_committed)
+		.map(|i| oracle_specs[i].log_msg_len)
+		.collect();
+	let max_n = *n_vars.iter().max().expect("relations is non-empty");
+
+	// === Masking step ===
+	// Read the masked inner products σ_i, sample γ, and form the masked claims s_i'.
+	let sigmas = channel.recv_many(n_committed)?;
+	let gamma = IPVerifierChannel::<F>::sample(channel);
+	let sum_primes = iter::zip(&relations, sigmas)
+		.map(|(relation, sigma)| extrapolate_line_packed(relation.claim, sigma, gamma))
+		.collect::<Vec<_>>();
+
+	// === Phase A: batched sumcheck on the masked claims (degree 2, bivariate product) ===
+	let BatchSumcheckOutput {
+		batch_coeff: sumcheck_batch_coeff,
+		eval: sumcheck_reduced_eval,
+		challenges: sumcheck_challenges,
+	} = sumcheck::batch_verify::<F, _>(max_n, 2, &sum_primes, channel)?;
+
+	// Receive the evaluation of each oracle at the challenge point.
+	let alphas = channel.recv_many(n_committed)?;
+
+	// `batch_verify` returns binding-order challenges; reverse to variable-indexed (low-to-high).
+	let mut point = sumcheck_challenges;
+	point.reverse();
+
+	// Reduce the batched claim: each oracle contributes α_i · t_i(ρ_i) · eq(0^extra, padding).
+	let contributions = relations
+		.into_iter()
+		.map(|relation| {
+			let alpha_i = alphas[relation.oracle.index];
+			let n_i = n_vars[relation.oracle.index];
+			let (eval_coords, padding_coords) = point.split_at(n_i);
+			let pad_eq = eq_ind_zero(padding_coords);
+			let transparent_eval = (relation.transparent)(eval_coords);
+			alpha_i * transparent_eval * pad_eq
+		})
+		.collect::<Vec<_>>();
+	let expected = evaluate_univariate(&contributions, sumcheck_batch_coeff);
+	channel.assert_zero(sumcheck_reduced_eval - expected)?;
+
+	// === Phase B: per-oracle MLE-check BaseFold verification ===
+	// Open each committed oracle at its evaluation point ρ_i = point[..n_i] in oracle-index order,
+	// using its own FRI parameters.
+	for (alpha_i, n_i, commitment, fri_params) in
+		izip!(alphas, n_vars, oracle_commitments, fri_params)
+	{
+		let basefold::ReducedOutput {
+			final_fri_value,
+			final_sumcheck_value,
+			..
+		} = basefold::verify_mlecheck_basefold_zk(
+			fri_params,
+			merkle_scheme,
+			commitment,
+			alpha_i,
+			&point[..n_i],
+			gamma,
+			channel,
+		)?;
+
+		// The MLE-check internalizes the eq factor, so consistency is plain equality.
+		channel.assert_zero(final_sumcheck_value - final_fri_value)?;
+	}
+
+	Ok(())
 }
 
 impl<F, MerkleScheme_, Challenger_> IPVerifierChannel<F>
@@ -156,8 +295,8 @@ where
 	}
 }
 
-impl<F, MerkleScheme_, Challenger_> IOPVerifierChannel<F>
-	for BaseFoldZKVerifierChannel<'_, F, MerkleScheme_, Challenger_>
+impl<'a, F, MerkleScheme_, Challenger_> IOPVerifierChannel<'a, F>
+	for BaseFoldZKVerifierChannel<'a, F, MerkleScheme_, Challenger_>
 where
 	F: BinaryField,
 	MerkleScheme_: MerkleTreeScheme<F, Digest: DeserializeBytes>,
@@ -189,84 +328,21 @@ where
 		Ok(BaseFoldZKOracle { index })
 	}
 
-	fn verify_oracle_relations<'a>(
+	fn verify_oracle_relations(
 		&mut self,
 		oracle_relations: impl IntoIterator<Item = OracleLinearRelation<'a, Self::Oracle, Self::Elem>>,
 	) -> Result<(), Error> {
-		let relations = oracle_relations.into_iter().collect::<Vec<_>>();
-		if relations.is_empty() {
-			return Ok(());
-		}
-
-		let indices: Vec<usize> = relations.iter().map(|r| r.oracle.index).collect();
-		for &index in &indices {
+		// Queue the relations; the actual opening (masking + sumcheck + combined FRI) happens once,
+		// over all committed oracles, in [`Self::finish`].
+		for relation in oracle_relations {
 			assert!(
-				index < self.oracle_commitments.len(),
-				"oracle index {index} out of bounds, expected < {}",
+				relation.oracle.index < self.oracle_commitments.len(),
+				"oracle index {} out of bounds, expected < {}",
+				relation.oracle.index,
 				self.oracle_commitments.len()
 			);
+			self.queue.push(relation);
 		}
-		let n_vars: Vec<usize> = indices
-			.iter()
-			.map(|&i| self.oracle_specs[i].log_msg_len)
-			.collect();
-		let max_n = *n_vars.iter().max().expect("relations is non-empty");
-
-		// === Masking step ===
-		// Read the masked inner products σ_i, sample γ, and form the masked claims s_i'.
-		let sigmas = self.recv_many(relations.len())?;
-		let gamma = self.sample();
-		let sum_primes = iter::zip(&relations, sigmas)
-			.map(|(relation, sigma)| extrapolate_line_packed(relation.claim, sigma, gamma))
-			.collect::<Vec<_>>();
-
-		// === Phase A: batched sumcheck on the masked claims (degree 2, bivariate product) ===
-		let BatchSumcheckOutput {
-			batch_coeff: sumcheck_batch_coeff,
-			eval: sumcheck_reduced_eval,
-			challenges: sumcheck_challenges,
-		} = sumcheck::batch_verify::<F, _>(max_n, 2, &sum_primes, self.transcript)?;
-		let alphas = self.recv_many(relations.len())?;
-
-		// `batch_verify` returns binding-order challenges; reverse to variable-indexed
-		// (low-to-high).
-		let mut point = sumcheck_challenges;
-		point.reverse();
-
-		// Reduce the batched claim: each oracle contributes α_i · t_i(ρ_i) · eq(0^extra, padding),
-		// combined with the batching coefficient.
-		let contributions: Vec<F> = izip!(relations, &n_vars, &alphas)
-			.map(|(relation, &n_i, &alpha_i)| {
-				let (eval_coords, padding_coords) = point.split_at(n_i);
-				let pad_eq = eq_ind_zero(padding_coords);
-				let transparent_eval = (relation.transparent)(eval_coords);
-				alpha_i * transparent_eval * pad_eq
-			})
-			.collect();
-		let expected = evaluate_univariate(&contributions, sumcheck_batch_coeff);
-		self.assert_zero(sumcheck_reduced_eval - expected)?;
-
-		// === Phase B: per-oracle MLE-check BaseFold verification ===
-		for (index, alpha, n_i) in izip!(indices, alphas, n_vars) {
-			let commitment = self.oracle_commitments[index].clone();
-			let basefold::ReducedOutput {
-				final_fri_value,
-				final_sumcheck_value,
-				..
-			} = basefold::verify_mlecheck_basefold_zk(
-				&self.fri_params[index],
-				self.merkle_scheme,
-				commitment,
-				alpha,
-				&point[..n_i],
-				gamma,
-				self.transcript,
-			)?;
-
-			// The MLE-check internalizes the eq factor, so consistency is plain equality.
-			self.assert_zero(final_sumcheck_value - final_fri_value)?;
-		}
-
 		Ok(())
 	}
 }

--- a/crates/iop/src/basefold_zk_channel.rs
+++ b/crates/iop/src/basefold_zk_channel.rs
@@ -14,14 +14,15 @@ use binius_ip::{
 	sumcheck::{self, BatchSumcheckOutput},
 };
 use binius_math::{
-	line::extrapolate_line_packed, multilinear::eq::eq_ind_zero, univariate::evaluate_univariate,
+	line::extrapolate_line_packed,
+	multilinear::eq::{eq_ind_partial_eval_scalars, eq_ind_zero},
+	univariate::evaluate_univariate,
 };
 use binius_transcript::{
 	VerifierTranscript,
 	fiat_shamir::{CanSample, Challenger},
 };
-use binius_utils::DeserializeBytes;
-use itertools::izip;
+use binius_utils::{DeserializeBytes, checked_arithmetics::log2_ceil_usize};
 
 use crate::{
 	basefold,
@@ -56,9 +57,7 @@ where
 	transcript: &'a mut VerifierTranscript<Challenger_>,
 	merkle_scheme: &'a MerkleScheme_,
 	oracle_specs: &'a [OracleSpec],
-	/// Per-oracle FRI parameters (`log_batch_size = 1`), one per oracle, used for the per-oracle
-	/// BaseFold openings in [`Self::finish`].
-	fri_params: &'a [FRIParams<F>],
+	fri_params: &'a FRIParams<F>,
 	oracle_commitments: Vec<MerkleScheme_::Digest>,
 	/// Oracle relations queued by [`Self::verify_oracle_relations`], opened together in
 	/// [`Self::finish`].
@@ -80,7 +79,7 @@ where
 		transcript: &'a mut VerifierTranscript<Challenger_>,
 		merkle_scheme: &'a MerkleScheme_,
 		oracle_specs: &'a [OracleSpec],
-		fri_params: &'a [FRIParams<F>],
+		fri_params: &'a FRIParams<F>,
 	) -> Self {
 		Self {
 			transcript,
@@ -142,22 +141,27 @@ where
 /// This drives `channel` — the [`VerifierTranscript`] taken from the destructured
 /// [`BaseFoldZKVerifierChannel`] — through its [`IPVerifierChannel`] interface: it reads the masked
 /// inner products σ_i, runs one batched sumcheck reducing the masked claims to a shared point `r`,
-/// then opens each committed oracle with its own FRI parameters.
+/// then opens all committed oracles together with a single combined FRI over the
+/// piecewise-concatenated oracle.
 ///
 /// The masking inner products and the batched sumcheck process the `relations` in arrival order (so
 /// each reduced eval lines up with its batched-claim coefficient), while the per-oracle evaluations
-/// α_i and the FRI openings are emitted in oracle-index order. Each relation carries its oracle's
-/// index, so the two orders are reconciled by indexing rather than by sorting the relations; the
-/// per-oracle data (`oracle_specs`, `fri_params`, `oracle_commitments`) is all indexed by oracle
-/// index.
+/// α_i are indexed by oracle index. Each relation carries its oracle's index, so the two orders are
+/// reconciled by indexing rather than by sorting the relations; `oracle_specs` and
+/// `oracle_commitments` are indexed by oracle index.
+///
+/// Phase B collapses the oracle-index variables up front at sampled batching challenges `r'`: the
+/// combined target is `s' = Σ_i e[i]·α_i·∏_{j≥n_i}(1 - r_j)` with `e = eq_ind_partial_eval(r')`,
+/// and the single combined FRI (`fri_params`) opens all `k` committed `[π_i ‖ ω_i]` codewords.
 ///
 /// `channel` is the concrete [`VerifierTranscript`] rather than an arbitrary [`IPVerifierChannel`]
 /// because the Phase-B FRI openings read Merkle query proofs, which fall outside that interface.
+#[allow(clippy::too_many_arguments)]
 fn verify_batch_zk_basefold<F, MerkleScheme_, Challenger_>(
 	channel: &mut VerifierTranscript<Challenger_>,
 	merkle_scheme: &MerkleScheme_,
 	oracle_specs: &[OracleSpec],
-	fri_params: &[FRIParams<F>],
+	fri_params: &FRIParams<F>,
 	oracle_commitments: Vec<MerkleScheme_::Digest>,
 	relations: Vec<OracleLinearRelation<'_, BaseFoldZKOracle, F>>,
 ) -> Result<(), Error>
@@ -172,7 +176,8 @@ where
 	let n_vars: Vec<usize> = (0..n_committed)
 		.map(|i| oracle_specs[i].log_msg_len)
 		.collect();
-	let max_n = *n_vars.iter().max().expect("relations is non-empty");
+	// `𝐧 = max_i n_i`, the dimension of the combined codeword.
+	let max_n = fri_params.rs_code().log_dim();
 
 	// === Masking step ===
 	// Read the masked inner products σ_i, sample γ, and form the masked claims s_i'.
@@ -190,7 +195,7 @@ where
 	} = sumcheck::batch_verify::<F, _>(max_n, 2, &sum_primes, channel)?;
 
 	// Receive the evaluation of each oracle at the challenge point.
-	let alphas = channel.recv_many(n_committed)?;
+	let alphas: Vec<F> = channel.recv_many(n_committed)?;
 
 	// `batch_verify` returns binding-order challenges; reverse to variable-indexed (low-to-high).
 	let mut point = sumcheck_challenges;
@@ -211,29 +216,37 @@ where
 	let expected = evaluate_univariate(&contributions, sumcheck_batch_coeff);
 	channel.assert_zero(sumcheck_reduced_eval - expected)?;
 
-	// === Phase B: per-oracle MLE-check BaseFold verification ===
-	// Open each committed oracle at its evaluation point ρ_i = point[..n_i] in oracle-index order,
-	// using its own FRI parameters.
-	for (alpha_i, n_i, commitment, fri_params) in
-		izip!(alphas, n_vars, oracle_commitments, fri_params)
-	{
-		let basefold::ReducedOutput {
-			final_fri_value,
-			final_sumcheck_value,
-			..
-		} = basefold::verify_mlecheck_basefold_zk(
-			fri_params,
-			merkle_scheme,
-			commitment,
-			alpha_i,
-			&point[..n_i],
-			gamma,
-			channel,
-		)?;
+	// === Phase B: single combined-FRI MLE-check over the piecewise-concatenated oracle ===
+	// Collapse the oracle-index variables up front at sampled batching challenges `r'`: the
+	// combined multilinear is 𝛑(X) = Σ_i e[i]·π_i^↑(X) with e = eq(·, r'), and the combined target
+	// is s' = 𝛑(r) = Σ_i e[i]·α_i·∏_{j≥n_i}(1 - r_j).
+	let log_n_oracles = log2_ceil_usize(n_committed);
+	let outer_challenges: Vec<F> = (0..log_n_oracles)
+		.map(|_| IPVerifierChannel::<F>::sample(channel))
+		.collect();
+	let eq_tensor = eq_ind_partial_eval_scalars::<F>(&outer_challenges);
+	let s_prime = iter::zip(&alphas, &n_vars)
+		.enumerate()
+		.map(|(i, (&alpha_i, &n_i))| eq_tensor[i] * alpha_i * eq_ind_zero(&point[n_i..]))
+		.sum::<F>();
 
-		// The MLE-check internalizes the eq factor, so consistency is plain equality.
-		channel.assert_zero(final_sumcheck_value - final_fri_value)?;
-	}
+	let basefold::ReducedOutput {
+		final_fri_value,
+		final_sumcheck_value,
+		..
+	} = basefold::verify_mlecheck_basefold_zk_batch(
+		fri_params,
+		merkle_scheme,
+		&oracle_commitments,
+		s_prime,
+		&point,
+		gamma,
+		&outer_challenges,
+		channel,
+	)?;
+
+	// The MLE-check internalizes the eq factor, so consistency is plain equality.
+	channel.assert_zero(final_sumcheck_value - final_fri_value)?;
 
 	Ok(())
 }

--- a/crates/iop/src/channel.rs
+++ b/crates/iop/src/channel.rs
@@ -73,7 +73,7 @@ pub struct OracleLinearRelation<'a, Oracle, Elem> {
 /// The caller must call `recv_oracle()` exactly `remaining_oracle_specs().len()` times before
 /// calling `verify_oracle_relations()`. The oracles must be received in order and match their
 /// specifications.
-pub trait IOPVerifierChannel<F: Field>: IPVerifierChannel<F> {
+pub trait IOPVerifierChannel<'r, F: Field>: IPVerifierChannel<F> {
 	type Oracle: Clone;
 
 	/// Returns the specifications for the remaining oracles to be received.
@@ -88,22 +88,21 @@ pub trait IOPVerifierChannel<F: Field>: IPVerifierChannel<F> {
 	/// `remaining_oracle_specs()` must be non-empty.
 	fn recv_oracle(&mut self) -> Result<Self::Oracle, Error>;
 
-	/// Verifies all oracle linear relations by running opening protocols.
+	/// Queues oracle linear relations to be opened.
 	///
-	/// For each oracle relation, this method:
-	/// 1. Runs the opening protocol (e.g., BaseFold) to obtain the oracle evaluation and challenge
-	///    point
-	/// 2. Evaluates the transparent polynomial at the challenge point
-	/// 3. Verifies that `eval_numerator == eval_denominator * transparent_eval` using `assert_zero`
-	///    on the underlying channel
+	/// Implementations may either verify the relations immediately, or queue them and defer the
+	/// actual opening (masking + sumcheck + FRI) to [`finish`](Self::finish). Either way, each
+	/// relation asserts that `<oracle_poly, transparent_poly> = claim`.
+	///
+	/// The relation lifetime `'r` is a parameter of the trait so that deferring implementations can
+	/// store the (possibly borrowed) transparent closures until `finish()`.
 	///
 	/// # Preconditions
 	///
-	/// * `remaining_oracle_specs()` must be empty (all oracles received).
 	/// * All oracle handles in `oracle_relations` must be valid handles returned by
 	///   `recv_oracle()`.
-	fn verify_oracle_relations<'a>(
+	fn verify_oracle_relations(
 		&mut self,
-		oracle_relations: impl IntoIterator<Item = OracleLinearRelation<'a, Self::Oracle, Self::Elem>>,
+		oracle_relations: impl IntoIterator<Item = OracleLinearRelation<'r, Self::Oracle, Self::Elem>>,
 	) -> Result<(), Error>;
 }

--- a/crates/iop/src/channel.rs
+++ b/crates/iop/src/channel.rs
@@ -91,7 +91,7 @@ pub trait IOPVerifierChannel<'r, F: Field>: IPVerifierChannel<F> {
 	/// Queues oracle linear relations to be opened.
 	///
 	/// Implementations may either verify the relations immediately, or queue them and defer the
-	/// actual opening (masking + sumcheck + FRI) to [`finish`](Self::finish). Either way, each
+	/// actual opening (masking + sumcheck + FRI) to `finish()`. Either way, each
 	/// relation asserts that `<oracle_poly, transparent_poly> = claim`.
 	///
 	/// The relation lifetime `'r` is a parameter of the trait so that deferring implementations can

--- a/crates/iop/src/naive_channel.rs
+++ b/crates/iop/src/naive_channel.rs
@@ -139,7 +139,7 @@ where
 	}
 }
 
-impl<F, Challenger_> IOPVerifierChannel<F> for NaiveVerifierChannel<'_, F, Challenger_>
+impl<'r, F, Challenger_> IOPVerifierChannel<'r, F> for NaiveVerifierChannel<'_, F, Challenger_>
 where
 	F: Field,
 	Challenger_: Challenger,
@@ -175,9 +175,9 @@ where
 		Ok(NaiveOracle { index })
 	}
 
-	fn verify_oracle_relations<'a>(
+	fn verify_oracle_relations(
 		&mut self,
-		oracle_relations: impl IntoIterator<Item = OracleLinearRelation<'a, Self::Oracle, F>>,
+		oracle_relations: impl IntoIterator<Item = OracleLinearRelation<'r, Self::Oracle, F>>,
 	) -> Result<(), Error> {
 		for relation in oracle_relations {
 			let index = relation.oracle.index;

--- a/crates/iop/src/size_tracking_channel.rs
+++ b/crates/iop/src/size_tracking_channel.rs
@@ -121,7 +121,7 @@ impl<F: BinaryField, MerkleScheme_: MerkleTreeScheme<F>> IPVerifierChannel<F>
 	}
 }
 
-impl<F: BinaryField, MerkleScheme_: MerkleTreeScheme<F>> IOPVerifierChannel<F>
+impl<'r, F: BinaryField, MerkleScheme_: MerkleTreeScheme<F>> IOPVerifierChannel<'r, F>
 	for SizeTrackingChannel<'_, F, MerkleScheme_>
 {
 	type Oracle = ();
@@ -136,9 +136,9 @@ impl<F: BinaryField, MerkleScheme_: MerkleTreeScheme<F>> IOPVerifierChannel<F>
 		Ok(())
 	}
 
-	fn verify_oracle_relations<'a>(
+	fn verify_oracle_relations(
 		&mut self,
-		_oracle_relations: impl IntoIterator<Item = OracleLinearRelation<'a, Self::Oracle, Self::Elem>>,
+		_oracle_relations: impl IntoIterator<Item = OracleLinearRelation<'r, Self::Oracle, Self::Elem>>,
 	) -> Result<(), Error> {
 		// Add FRI proof sizes for all oracles. This accounts for the dominant component of
 		// BaseFold proofs (FRI decommitments) but is missing smaller elements (e.g. sumcheck

--- a/crates/ip-prover/src/sumcheck/mod.rs
+++ b/crates/ip-prover/src/sumcheck/mod.rs
@@ -23,3 +23,5 @@ pub use padded::*;
 pub use prove::*;
 pub mod frac_add_mle;
 pub mod zk_mlecheck;
+
+pub use batch::batch_prove;

--- a/crates/spartan-prover/src/lib.rs
+++ b/crates/spartan-prover/src/lib.rs
@@ -181,7 +181,7 @@ impl<F: Field> IOPProver<F> {
 		precommit_oracle: Channel::Oracle,
 		precommit_packed: FieldBuffer<P>,
 		mut rng: impl CryptoRng,
-		mut channel: Channel,
+		channel: &mut Channel,
 	) -> Result<(), Error>
 	where
 		F: BinaryField,
@@ -268,7 +268,7 @@ impl<F: Field> IOPProver<F> {
 			precommit_packed.to_ref(),
 			private_packed.to_ref(),
 			mulcheck_mask,
-			&mut channel,
+			&mut *channel,
 		)?;
 
 		// λ is the batching challenge for the constraint operands
@@ -309,7 +309,7 @@ impl<F: Field> IOPProver<F> {
 		let libra_eval_tensor =
 			zk_mlecheck::expand_libra_eval::<P>(&r_x, n_vars, mask_degree, m_n, m_d);
 
-		// Prove all oracle relations
+		// Prove all oracle relations.
 		channel.prove_oracle_relations([
 			(precommit_oracle, precommit_packed, precommit_wiring_poly, precommit_claim),
 			(private_oracle, private_packed, private_wiring_poly, private_claim),
@@ -395,8 +395,17 @@ where
 		let (precommit_oracle, precommit_packed) =
 			self.iop_prover
 				.commit_precommit::<P, _>(&witness, &mut rng, &mut channel);
-		self.iop_prover
-			.prove::<P, _>(witness, precommit_oracle, precommit_packed, rng, channel)
+		// The IOP prover only queues the oracle relations; `finish` runs the single combined
+		// opening.
+		self.iop_prover.prove::<P, _>(
+			witness,
+			precommit_oracle,
+			precommit_packed,
+			rng,
+			&mut channel,
+		)?;
+		channel.finish();
+		Ok(())
 	}
 }
 

--- a/crates/spartan-prover/src/wrapper/replay_channel.rs
+++ b/crates/spartan-prover/src/wrapper/replay_channel.rs
@@ -248,7 +248,7 @@ impl<'a, F: Field> IPVerifierChannel<F> for ReplayChannel<'a, F> {
 	}
 }
 
-impl<'a, F: Field> IOPVerifierChannel<F> for ReplayChannel<'a, F> {
+impl<'r, 'a, F: Field> IOPVerifierChannel<'r, F> for ReplayChannel<'a, F> {
 	type Oracle = ();
 
 	fn remaining_oracle_specs(&self) -> &[OracleSpec] {
@@ -259,9 +259,9 @@ impl<'a, F: Field> IOPVerifierChannel<F> for ReplayChannel<'a, F> {
 		Ok(())
 	}
 
-	fn verify_oracle_relations<'b>(
+	fn verify_oracle_relations(
 		&mut self,
-		oracle_relations: impl IntoIterator<Item = OracleLinearRelation<'b, Self::Oracle, Self::Elem>>,
+		oracle_relations: impl IntoIterator<Item = OracleLinearRelation<'r, Self::Oracle, Self::Elem>>,
 	) -> Result<(), binius_iop::channel::Error> {
 		// For each oracle opening, the prover sends the decrypted evaluation. The outer verifier
 		// checks in the circuit equality of this value with the expected expression over encrypted

--- a/crates/spartan-prover/src/wrapper/zk_wrapped_prover_channel.rs
+++ b/crates/spartan-prover/src/wrapper/zk_wrapped_prover_channel.rs
@@ -191,7 +191,7 @@ where
 		let _ = tracing::debug_span!("Proving ZK wrapper proof").entered();
 
 		let Self {
-			inner_channel,
+			mut inner_channel,
 			outer_prover,
 			outer_layout,
 			replay_fn,
@@ -220,8 +220,11 @@ where
 			precommit_oracle,
 			precommit_packed,
 			rng,
-			inner_channel,
+			&mut inner_channel,
 		)?;
+		// Both the inner and outer proofs queued their oracle relations onto `inner_channel`; run
+		// the single combined opening over all committed oracles now.
+		inner_channel.finish();
 		Ok(())
 	}
 }

--- a/crates/spartan-prover/tests/wrapper_integration_test.rs
+++ b/crates/spartan-prover/tests/wrapper_integration_test.rs
@@ -175,7 +175,7 @@ fn test_zk_wrapped_prove_verify() {
 			inner_precommit_oracle,
 			inner_precommit_packed,
 			&mut rng,
-			channel_ref,
+			&mut channel_ref,
 		)
 		.expect("inner prove failed");
 

--- a/crates/spartan-verifier/src/lib.rs
+++ b/crates/spartan-verifier/src/lib.rs
@@ -33,7 +33,7 @@ pub mod constraint_system;
 pub mod wiring;
 pub mod wrapper;
 
-use std::slice;
+use std::{rc::Rc, slice};
 
 use binius_field::{BinaryField, Field, field::FieldOps};
 use binius_hash::binary_merkle_tree::HashSuite;
@@ -144,15 +144,16 @@ impl<F: Field> IOPVerifier<F> {
 	/// # Returns
 	///
 	/// `Ok(())` if the proof is valid, `Err(_)` otherwise.
-	pub fn verify<Channel>(
-		&self,
+	pub fn verify<'r, Channel>(
+		&'r self,
 		precommit_oracle: Channel::Oracle,
 		public: Vec<Channel::Elem>,
 		channel: &mut Channel,
 	) -> Result<(), Error>
 	where
 		F: BinaryField,
-		Channel: IOPVerifierChannel<F>,
+		Channel: IOPVerifierChannel<'r, F>,
+		Channel::Elem: 'r,
 	{
 		let cs = &self.constraint_system;
 
@@ -183,8 +184,11 @@ impl<F: Field> IOPVerifier<F> {
 		// Batch together the constraint operand evaluation claims.
 		let batched_sum = evaluate_univariate(&[a_eval, b_eval, c_eval], lambda.clone());
 
-		// Compute rₓ^⊤ (M_A + λ M_B + λ² M_C) x
-		let r_x_tensor = eq_ind_partial_eval_scalars(&r_x);
+		// Compute rₓ^⊤ (M_A + λ M_B + λ² M_C) x. Shared via `Rc` so the transparent closures can
+		// own it and outlive this call (the opening is deferred to the channel's `finish()`). `Rc`
+		// suffices over `Arc` because the closures (`TransparentEvalFn`, no `Send` bound) and the
+		// channel never cross a thread boundary.
+		let r_x_tensor: Rc<[Channel::Elem]> = eq_ind_partial_eval_scalars(&r_x).into();
 
 		// The public-segment contribution to the operand evaluations is purely a function of
 		// public-channel inputs (the public scalars, λ, and rₓ). Trade in those Elems for plain
@@ -219,10 +223,14 @@ impl<F: Field> IOPVerifier<F> {
 		let private_claim = batched_sum - public_eval - precommit_claim.clone();
 
 		// Build transparent closures for each oracle relation
-		let precommit_transparent =
-			wiring::eval_transparent(cs, WitnessSegment::Precommit, &r_x_tensor, lambda.clone());
+		let precommit_transparent = wiring::eval_transparent(
+			cs,
+			WitnessSegment::Precommit,
+			r_x_tensor.clone(),
+			lambda.clone(),
+		);
 		let private_transparent =
-			wiring::eval_transparent(cs, WitnessSegment::Private, &r_x_tensor, lambda);
+			wiring::eval_transparent(cs, WitnessSegment::Private, r_x_tensor.clone(), lambda);
 		let mask_transparent = mask_transparent(cs, &r_x);
 
 		// Verify all oracle relations
@@ -322,11 +330,13 @@ where
 		// Verifier observes the public input (includes it in Fiat-Shamir).
 		transcript.observe().write_slice(public);
 
-		// Create channel, receive the precommit oracle, and delegate to IOPVerifier::verify.
+		// Create channel, receive the precommit oracle, and delegate to IOPVerifier::verify. The
+		// IOP verifier only queues the oracle relations; `finish` runs the single combined opening.
 		let mut channel = self.basefold_compiler.create_channel(transcript);
 		let precommit_oracle = channel.recv_oracle()?;
 		self.iop_verifier
-			.verify(precommit_oracle, public.to_vec(), &mut channel)
+			.verify(precommit_oracle, public.to_vec(), &mut channel)?;
+		Ok(channel.finish()?)
 	}
 }
 

--- a/crates/spartan-verifier/src/wiring.rs
+++ b/crates/spartan-verifier/src/wiring.rs
@@ -1,6 +1,6 @@
 // Copyright 2025 Irreducible Inc.
 
-use std::iter;
+use std::{iter, rc::Rc};
 
 use binius_field::{Field, field::FieldOps};
 use binius_math::{multilinear::eq::eq_ind_partial_eval_scalars, univariate::evaluate_univariate};
@@ -12,11 +12,14 @@ use crate::constraint_system::ConstraintSystemPadded;
 ///
 /// The returned closure computes the expected evaluation of the wiring MLE for the given
 /// segment, batched with lambda, given a challenge point from the BaseFold opening.
-/// `r_x_tensor` is the eq-indicator partial evaluation at r_x.
+/// `r_x_tensor` is the eq-indicator partial evaluation at r_x; it is taken as a shared `Rc` so the
+/// returned closure owns it (the opening is deferred to the channel's `finish()`, so the closure
+/// must outlive the local `r_x_tensor`). The closure still borrows `constraint_system`, which is
+/// long-lived.
 pub fn eval_transparent<'a, G: Field, F: FieldOps + 'a>(
 	constraint_system: &'a ConstraintSystemPadded<G>,
 	segment: WitnessSegment,
-	r_x_tensor: &'a [F],
+	r_x_tensor: Rc<[F]>,
 	lambda: F,
 ) -> binius_iop::channel::TransparentEvalFn<'a, F> {
 	Box::new(move |r_y: &[F]| {
@@ -24,7 +27,7 @@ pub fn eval_transparent<'a, G: Field, F: FieldOps + 'a>(
 			constraint_system.mul_constraints(),
 			segment,
 			lambda.clone(),
-			r_x_tensor,
+			&r_x_tensor,
 			r_y,
 		)
 	})

--- a/crates/spartan-verifier/src/wrapper/builder_channel.rs
+++ b/crates/spartan-verifier/src/wrapper/builder_channel.rs
@@ -243,7 +243,7 @@ impl<F: Field> IPVerifierChannel<F> for IronSpartanBuilderChannel<F> {
 	}
 }
 
-impl<F: Field> IOPVerifierChannel<F> for IronSpartanBuilderChannel<F> {
+impl<'r, F: Field> IOPVerifierChannel<'r, F> for IronSpartanBuilderChannel<F> {
 	type Oracle = ();
 
 	fn remaining_oracle_specs(&self) -> &[OracleSpec] {
@@ -254,9 +254,9 @@ impl<F: Field> IOPVerifierChannel<F> for IronSpartanBuilderChannel<F> {
 		Ok(())
 	}
 
-	fn verify_oracle_relations<'a>(
+	fn verify_oracle_relations(
 		&mut self,
-		oracle_relations: impl IntoIterator<Item = OracleLinearRelation<'a, Self::Oracle, Self::Elem>>,
+		oracle_relations: impl IntoIterator<Item = OracleLinearRelation<'r, Self::Oracle, Self::Elem>>,
 	) -> Result<(), binius_iop::channel::Error> {
 		// For each oracle opening, the prover sends the decrypted evaluation. The outer verifier
 		// checks in the circuit equality of this value with the expected expression over encrypted

--- a/crates/spartan-verifier/src/wrapper/zk_wrapped_channel.rs
+++ b/crates/spartan-verifier/src/wrapper/zk_wrapped_channel.rs
@@ -294,17 +294,21 @@ where
 		let outer_cs = self.outer_verifier.constraint_system();
 		let public_size = 1 << outer_cs.log_public();
 
-		let inout_builder = Rc::try_unwrap(self.inout_builder)
-			.expect("CircuitElem values should only hold Weak references")
-			.into_inner();
-
+		// Read the materialized public values by borrow rather than consuming the shared builder:
+		// the queued oracle relations (whose opening is deferred to `inner_channel.finish`) still
+		// hold references to it. The transparent closures never materialize new public values
+		// (their results are required to be non-`Private`), so the public segment is already
+		// final here.
 		let mut public = outer_cs.constants().to_vec();
-		public.extend(inout_builder.into_public_values());
+		public.extend(self.inout_builder.borrow().public_values.iter().copied());
 		public.resize(public_size, F::ZERO);
 
 		let mut inner_channel = self.inner_channel;
 		self.outer_verifier
 			.verify(self.precommit_oracle, public, &mut inner_channel)?;
+		// Both the inner and outer proofs queued their oracle relations onto `inner_channel`; run
+		// the single combined opening over all committed oracles now.
+		inner_channel.finish()?;
 		Ok(())
 	}
 }
@@ -396,8 +400,8 @@ where
 	}
 }
 
-impl<F, MTScheme, Challenger_> IOPVerifierChannel<F>
-	for ZKWrappedVerifierChannel<'_, F, MTScheme, Challenger_>
+impl<'a, F, MTScheme, Challenger_> IOPVerifierChannel<'a, F>
+	for ZKWrappedVerifierChannel<'a, F, MTScheme, Challenger_>
 where
 	F: BinaryField,
 	MTScheme: MerkleTreeScheme<F, Digest: DeserializeBytes>,
@@ -419,9 +423,9 @@ where
 		self.inner_channel.recv_oracle()
 	}
 
-	fn verify_oracle_relations<'b>(
+	fn verify_oracle_relations(
 		&mut self,
-		oracle_relations: impl IntoIterator<Item = OracleLinearRelation<'b, Self::Oracle, Self::Elem>>,
+		oracle_relations: impl IntoIterator<Item = OracleLinearRelation<'a, Self::Oracle, Self::Elem>>,
 	) -> Result<(), binius_iop::channel::Error> {
 		let oracle_relations = oracle_relations
 			.into_iter()
@@ -439,15 +443,21 @@ where
 						.borrow_mut()
 						.next_inout(decrypted_claim);
 
-					let builder = self.inout_builder.clone();
-
-					// Wrap F values as lazy InOut for the transparent closure (which expects
-					// CircuitElems). The closure can do further arithmetic; results are required
-					// to be value-known (Constant or InOut), never Private.
+					// Wrap the sumcheck challenge coordinates for the transparent closure (which
+					// expects `CircuitElem`s). The closure can do further arithmetic; results are
+					// required to be value-known (Constant or InOut), never Private.
+					//
+					// HACK: the coordinates are sampled challenges, so they are wrapped as
+					// `Constant`s rather than builder-backed InOut wires. This frees the closure
+					// from holding a reference to `inout_builder`, and is sound only because the
+					// symbolic outer circuit (`IronSpartanBuilderChannel`) never invokes the
+					// transparent closure — it attests only `claim == decrypted_claim`, with the
+					// transparent evaluation performed out of circuit. This F->CircuitElem->F
+					// bridge should eventually be replaced by an F-level transparent evaluator.
 					let eval_fn = move |vals: &[F]| {
 						let wrapped_vals = vals
 							.iter()
-							.map(|val| CircuitElem::wire(&builder, WrappedWire::lazy_inout(*val)))
+							.map(|val| CircuitElem::Constant(*val))
 							.collect::<Vec<_>>();
 
 						match transparent(&wrapped_vals) {

--- a/crates/spartan-verifier/tests/proof_size_test.rs
+++ b/crates/spartan-verifier/tests/proof_size_test.rs
@@ -56,9 +56,9 @@ fn test_ip_proof_size() {
 	let proof_size = channel.proof_size();
 
 	// Hardcoded expected value to detect proof size regressions.
-	// This measures IP-layer bytes (sumcheck rounds, oracle commitments, evaluations) plus
-	// FRI proof sizes. It is a slight underestimate because it does not account for some
-	// smaller BaseFold components (e.g. sumcheck coefficients within BaseFold, blinding
-	// elements for ZK).
-	assert_eq!(proof_size, 106496, "proof size regression");
+	// This measures IP-layer bytes (sumcheck rounds, oracle commitments, evaluations) plus the
+	// single combined FRI proof opening all oracles together. It is a slight underestimate because
+	// it does not account for some smaller BaseFold components (e.g. sumcheck coefficients within
+	// BaseFold, blinding elements for ZK).
+	assert_eq!(proof_size, 46848, "proof size regression");
 }

--- a/crates/verifier/src/verify.rs
+++ b/crates/verifier/src/verify.rs
@@ -102,10 +102,10 @@ impl IOPVerifier {
 	///
 	/// This is the core verification logic, independent of the specific IOP compilation strategy.
 	/// For most users, [`Verifier::verify`] is the simpler interface.
-	pub fn verify<Channel>(&self, public: &[Word], channel: &mut Channel) -> Result<(), Error>
+	pub fn verify<'r, Channel>(&self, public: &[Word], channel: &mut Channel) -> Result<(), Error>
 	where
-		Channel: IOPVerifierChannel<B128>,
-		Channel::Elem: FieldOps<Scalar = B128> + From<B128>,
+		Channel: IOPVerifierChannel<'r, B128>,
+		Channel::Elem: FieldOps<Scalar = B128> + From<B128> + 'r,
 	{
 		// Check that the public input length is correct
 		if public.len() != 1 << self.log_public_words() {


### PR DESCRIPTION
## Summary
- Defer all ZK BaseFold oracle openings to channel `finish()`:
  `prove/verify_oracle_relations` now queue relations, and masking + one
  batched sumcheck + the FRI opening run once over all committed oracles.
  This lets a shared channel (the ZK wrapper) open the inner and outer
  Spartan proofs' oracles together in one opening.
- Replace the per-oracle Phase-B BaseFold openings with a single combined
  FRI over the piecewise-concatenated oracle (whitepaper §7.2): collapse the
  oracle-index variables at sampled challenges r', materialize the combined
  multilinear 𝛑(X)=Σ e[i]·π_i^↑(X) into one 2^𝐧 buffer, and run one MLE-check
  interleaved with one `FRIFoldProver::new_batch` over the k committed
  [π_i ‖ ω_i] codewords.
- Unify on a single combined `FRIParams` used both to commit each oracle (by
  index, via `commit_masked`/`commit_interleaved`) and for the combined
  opening; the per-oracle `FRIParams` vectors are gone.
- Proof size drops substantially: the spartan `proof_size_test` goes from
  106496 to 46848 bytes, since one combined FRI replaces k separate openings.

## Test plan
- `cargo test -p binius-iop -p binius-iop-prover -p binius-spartan-prover -p binius-spartan-verifier -p binius-prover -p binius-verifier -p binius-examples`
- `cargo clippy -p binius-iop -p binius-iop-prover --no-deps --tests`
- `cargo +nightly fmt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
