### PR TITLE
[transcript] Fix usize-to-le-bytes causing cross-arch transcript divergence

### DIFF
--- a/crates/transcript/src/fiat_shamir/hasher_challenger.rs
+++ b/crates/transcript/src/fiat_shamir/hasher_challenger.rs
@@ -95,7 +95,7 @@ where
 	H: Digest + Default + BlockSizeUser,
 {
 	fn into_observer(mut self) -> HasherObserver<H> {
-		Digest::update(&mut self.hasher, self.index.to_le_bytes());
+		Digest::update(&mut self.hasher, (self.index as u64).to_le_bytes());
 
 		HasherObserver {
 			hasher: self.hasher,


### PR DESCRIPTION
## Summary

- `HasherSampler::into_observer` called `self.index.to_le_bytes()` where `self.index: usize`
- On wasm32, `usize` is 32-bit → 4 bytes serialized into SHA-256
- On x86_64, `usize` is 64-bit → 8 bytes serialized into SHA-256
- Every sampler→observer transition therefore produced different-length byte sequences in the hasher, immediately diverging the Fiat-Shamir challenge stream
- Result: any proof generated on one architecture failed to verify on the other with `Channel(InvalidAssert)`

**Fix:** cast `self.index` to `u64` before `to_le_bytes()` so the wire format is always 8 bytes regardless of target pointer width.

## Root cause investigation

Reproduced using the `prove --output` / `verify` CLI subcommands from #1502:

```
# x86_64: prove and write proof to file
./target/release/examples/keccak prove --output /tmp/proof.bin

# wasm32: verify the x86_64 proof — fails before fix, passes after
wasmtime --dir /tmp target/wasm32-wasip1/release/examples/keccak.wasm verify /tmp/proof.bin
```

Before fix: `Error: channel error: invalid assertion: value is not zero`  
After fix: `Proof verified successfully.`

The unit tests in `hasher_challenger.rs` already hard-coded the 8-byte representation (e.g. `hasher.update([32, 0, 0, 0, 0, 0, 0, 0])`), confirming the intended behavior was always `u64`-width.

Fixes #1495

## Test plan

- [x] `cargo test -p binius-transcript` — all 5 tests pass
- [x] Native x86_64 prove + wasm32 verify succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)