### PR TITLE
Remove zero constant wires from compiled operands

### DIFF
--- a/crates/examples/snapshots/bitcoin_headers.snap
+++ b/crates/examples/snapshots/bitcoin_headers.snap
@@ -9,9 +9,9 @@ Constraints
 │  [▓▓▓▓▓▓▓▓▓░] spare: 888
 ├─ MUL constraints: 0 used (0.0% of 2^0)
 │  [░░░░░░░░░░] spare: 1
-└─ Distinct value indices: 73,028
-   ├─ Distinct shifted value indices: 41,323
-   └─ Distinct unshifted value indices: 31,705
+└─ Distinct value indices: 73,026
+   ├─ Distinct shifted value indices: 41,322
+   └─ Distinct unshifted value indices: 31,704
 
 Value Vector
 ├─ Public Section: 111 used (86.7% of 2^7)

--- a/crates/examples/snapshots/bitcoin_p2pkh.snap
+++ b/crates/examples/snapshots/bitcoin_p2pkh.snap
@@ -1,28 +1,28 @@
 bitcoin_p2pkh circuit
 --
 Gates & Instructions
-├─ Number of gates: 443,627
-└─ Number of evaluation instructions: 531,254
+├─ Number of gates: 378,219
+└─ Number of evaluation instructions: 459,714
 
 Constraints
-├─ AND constraints: 384,004 used (73.2% of 2^19)
-│  [▓▓▓▓▓▓▓░░░] spare: 140,284
-├─ MUL constraints: 48,536 used (74.1% of 2^16)
-│  [▓▓▓▓▓▓▓░░░] spare: 17,000
-└─ Distinct value indices: 860,789
-   ├─ Distinct shifted value indices: 408,723
-   └─ Distinct unshifted value indices: 452,066
+├─ AND constraints: 331,882 used (63.3% of 2^19)
+│  [▓▓▓▓▓▓░░░░] spare: 192,406
+├─ MUL constraints: 36,272 used (55.3% of 2^16)
+│  [▓▓▓▓▓░░░░░] spare: 29,264
+└─ Distinct value indices: 723,831
+   ├─ Distinct shifted value indices: 343,307
+   └─ Distinct unshifted value indices: 380,524
 
 Value Vector
 ├─ Public Section: 115 used (89.8% of 2^7)
 │  [▓▓▓▓▓▓▓▓░░] spare: 13
 │  ├─ Constants: 115
 │  └─ Inout: 0
-├─ Private Section: 451,957 used (86.2%)
-│  [▓▓▓▓▓▓▓▓░░] spare: 72,203
+├─ Private Section: 380,417 used (72.6%)
+│  [▓▓▓▓▓▓▓░░░] spare: 143,743
 │  ├─ Witness: 9
-│  └─ Internal: 451,948
-├─ Total Committed: 452,072 used (86.2% of 2^19)
-│  [▓▓▓▓▓▓▓▓░░] spare: 72,216
-└─ Scratch (uncommitted): 376,629
+│  └─ Internal: 380,408
+├─ Total Committed: 380,532 used (72.6% of 2^19)
+│  [▓▓▓▓▓▓▓░░░] spare: 143,756
+└─ Scratch (uncommitted): 329,106
 

--- a/crates/examples/snapshots/blake2b.snap
+++ b/crates/examples/snapshots/blake2b.snap
@@ -9,9 +9,9 @@ Constraints
 │  [▓▓▓▓▓▓▓▓▓░] spare: 29
 ├─ MUL constraints: 0 used (0.0% of 2^0)
 │  [░░░░░░░░░░] spare: 1
-└─ Distinct value indices: 21,679
-   ├─ Distinct shifted value indices: 13,374
-   └─ Distinct unshifted value indices: 8,305
+└─ Distinct value indices: 21,675
+   ├─ Distinct shifted value indices: 13,371
+   └─ Distinct unshifted value indices: 8,304
 
 Value Vector
 ├─ Public Section: 19 used (59.4% of 2^5)

--- a/crates/examples/snapshots/blake2s.snap
+++ b/crates/examples/snapshots/blake2s.snap
@@ -9,9 +9,9 @@ Constraints
 │  [▓▓▓▓▓▓▓▓░░] spare: 2,728
 ├─ MUL constraints: 0 used (0.0% of 2^0)
 │  [░░░░░░░░░░] spare: 1
-└─ Distinct value indices: 35,723
-   ├─ Distinct shifted value indices: 21,920
-   └─ Distinct unshifted value indices: 13,803
+└─ Distinct value indices: 35,720
+   ├─ Distinct shifted value indices: 21,918
+   └─ Distinct unshifted value indices: 13,802
 
 Value Vector
 ├─ Public Section: 28 used (87.5% of 2^5)

--- a/crates/examples/snapshots/ethsign.snap
+++ b/crates/examples/snapshots/ethsign.snap
@@ -9,9 +9,9 @@ Constraints
 │  [▓▓▓▓▓▓▓░░░] spare: 70,978
 ├─ MUL constraints: 19,022 used (58.1% of 2^15)
 │  [▓▓▓▓▓░░░░░] spare: 13,746
-└─ Distinct value indices: 399,969
-   ├─ Distinct shifted value indices: 183,256
-   └─ Distinct unshifted value indices: 216,713
+└─ Distinct value indices: 399,942
+   ├─ Distinct shifted value indices: 183,230
+   └─ Distinct unshifted value indices: 216,712
 
 Value Vector
 ├─ Public Section: 119 used (93.0% of 2^7)

--- a/crates/examples/snapshots/hashsign.snap
+++ b/crates/examples/snapshots/hashsign.snap
@@ -9,9 +9,9 @@ Constraints
 │  [▓▓▓▓▓░░░░░] spare: 907,166
 ├─ MUL constraints: 0 used (0.0% of 2^0)
 │  [░░░░░░░░░░] spare: 1
-└─ Distinct value indices: 2,258,650
-   ├─ Distinct shifted value indices: 1,077,809
-   └─ Distinct unshifted value indices: 1,180,841
+└─ Distinct value indices: 2,258,623
+   ├─ Distinct shifted value indices: 1,077,783
+   └─ Distinct unshifted value indices: 1,180,840
 
 Value Vector
 ├─ Public Section: 392 used (76.6% of 2^9)

--- a/crates/examples/snapshots/keccak.snap
+++ b/crates/examples/snapshots/keccak.snap
@@ -9,9 +9,9 @@ Constraints
 │  [▓▓▓▓▓▓▓▓░░] spare: 1,278
 ├─ MUL constraints: 0 used (0.0% of 2^0)
 │  [░░░░░░░░░░] spare: 1
-└─ Distinct value indices: 21,856
-   ├─ Distinct shifted value indices: 14,755
-   └─ Distinct unshifted value indices: 7,101
+└─ Distinct value indices: 21,831
+   ├─ Distinct shifted value indices: 14,731
+   └─ Distinct unshifted value indices: 7,100
 
 Value Vector
 ├─ Public Section: 320 used (62.5% of 2^9)

--- a/crates/examples/snapshots/sha256.snap
+++ b/crates/examples/snapshots/sha256.snap
@@ -9,9 +9,9 @@ Constraints
 │  [▓▓▓▓▓░░░░░] spare: 15,822
 ├─ MUL constraints: 0 used (0.0% of 2^0)
 │  [░░░░░░░░░░] spare: 1
-└─ Distinct value indices: 39,499
+└─ Distinct value indices: 39,498
    ├─ Distinct shifted value indices: 22,458
-   └─ Distinct unshifted value indices: 17,041
+   └─ Distinct unshifted value indices: 17,040
 
 Value Vector
 ├─ Public Section: 357 used (69.7% of 2^9)

--- a/crates/examples/snapshots/sha512.snap
+++ b/crates/examples/snapshots/sha512.snap
@@ -9,9 +9,9 @@ Constraints
 │  [▓▓▓▓▓▓▓░░░] spare: 4,303
 ├─ MUL constraints: 0 used (0.0% of 2^0)
 │  [░░░░░░░░░░] spare: 1
-└─ Distinct value indices: 28,761
+└─ Distinct value indices: 28,760
    ├─ Distinct shifted value indices: 16,302
-   └─ Distinct unshifted value indices: 12,459
+   └─ Distinct unshifted value indices: 12,458
 
 Value Vector
 ├─ Public Section: 387 used (75.6% of 2^9)

--- a/crates/examples/snapshots/zklogin.snap
+++ b/crates/examples/snapshots/zklogin.snap
@@ -9,9 +9,9 @@ Constraints
 │  [▓▓▓▓▓▓▓▓░░] spare: 93,555
 ├─ MUL constraints: 8,262 used (50.4% of 2^14)
 │  [▓▓▓▓▓░░░░░] spare: 8,122
-└─ Distinct value indices: 795,490
-   ├─ Distinct shifted value indices: 362,564
-   └─ Distinct unshifted value indices: 432,926
+└─ Distinct value indices: 795,488
+   ├─ Distinct shifted value indices: 362,563
+   └─ Distinct unshifted value indices: 432,925
 
 Value Vector
 ├─ Public Section: 974 used (95.1% of 2^10)

--- a/crates/frontend/src/compiler/mod.rs
+++ b/crates/frontend/src/compiler/mod.rs
@@ -268,7 +268,30 @@ impl CircuitBuilder {
 			}
 			value_vec_alloc.into_assignment()
 		};
-		let (and_constraints, mul_constraints) = builder.build(&wire_mapping, all_one);
+		let (mut and_constraints, mut mul_constraints) = builder.build(&wire_mapping, all_one);
+
+		// Filter zero constant terms from all operands. Any shift of Word::ZERO is zero, so
+		// terms referencing a zero constant contribute nothing to an XOR operand.
+		let n_const = value_vec_layout.n_const;
+		{
+			let filter_zeros = |operand: &mut Vec<_>| {
+				operand.retain(|term: &binius_core::constraint_system::ShiftedValueIndex| {
+					let idx = term.value_index.0 as usize;
+					idx >= n_const || constants[idx] != Word::ZERO
+				});
+			};
+			for c in &mut and_constraints {
+				filter_zeros(&mut c.a);
+				filter_zeros(&mut c.b);
+				filter_zeros(&mut c.c);
+			}
+			for c in &mut mul_constraints {
+				filter_zeros(&mut c.a);
+				filter_zeros(&mut c.b);
+				filter_zeros(&mut c.hi);
+				filter_zeros(&mut c.lo);
+			}
+		}
 
 		let cs =
 			ConstraintSystem::new(constants, value_vec_layout, and_constraints, mul_constraints);

--- a/crates/frontend/src/compiler/tests.rs
+++ b/crates/frontend/src/compiler/tests.rs
@@ -714,3 +714,50 @@ proptest! {
 		verify_constraints(cs, &w.value_vec).unwrap();
 	}
 }
+
+#[test]
+fn test_zero_constant_not_in_binius64_operands() {
+	// Build a circuit where a zero constant is used as a gate input; after compilation
+	// the zero constant term must be absent from all constraint operands.
+	let builder = CircuitBuilder::new();
+	let a = builder.add_inout();
+	let b = builder.add_inout();
+	let zero = builder.add_constant(Word::ZERO);
+	let (sum, _cout) = builder.iadd_cin_cout(a, b, zero);
+	let expected = builder.add_inout();
+	builder.assert_false("check", builder.bxor(sum, expected));
+	let circuit = builder.build();
+
+	let cs = circuit.constraint_system();
+	let constants = &cs.constants;
+
+	let zero_const_indices: std::collections::HashSet<usize> = constants
+		.iter()
+		.enumerate()
+		.filter(|&(_, v)| *v == Word::ZERO)
+		.map(|(i, _)| i)
+		.collect();
+
+	for constraint in &cs.and_constraints {
+		for operand in [&constraint.a, &constraint.b, &constraint.c] {
+			for term in operand {
+				assert!(
+					!zero_const_indices.contains(&(term.value_index.0 as usize)),
+					"zero constant at ValueIndex({}) found in AND operand",
+					term.value_index.0
+				);
+			}
+		}
+	}
+	for constraint in &cs.mul_constraints {
+		for operand in [&constraint.a, &constraint.b, &constraint.hi, &constraint.lo] {
+			for term in operand {
+				assert!(
+					!zero_const_indices.contains(&(term.value_index.0 as usize)),
+					"zero constant at ValueIndex({}) found in MUL operand",
+					term.value_index.0
+				);
+			}
+		}
+	}
+}

--- a/crates/spartan-frontend/src/circuit_builder.rs
+++ b/crates/spartan-frontend/src/circuit_builder.rs
@@ -119,6 +119,9 @@ impl<F: Field> ConstraintSystemIR<F> {
 			id: *one_id,
 		};
 
+		// Capture the zero constant wire id before consuming self.constants
+		let zero_const_id: Option<u32> = self.constants.get(&F::ZERO).copied();
+
 		// Convert constants HashMap to Vec
 		let mut constants = zeroed_vec(self.constant_alloc.n_wires as usize);
 		for (val, id) in self.constants {
@@ -153,11 +156,12 @@ impl<F: Field> ConstraintSystemIR<F> {
 			&private_alive,
 		);
 
-		// Map all ConstraintWire to WitnessIndex
+		// Map all ConstraintWire to WitnessIndex, filtering out zero constant wires.
 		let map_operand = |operand: &Operand<ConstraintWire>| -> Operand<WitnessIndex> {
 			let indices: SmallVec<[WitnessIndex; 4]> = operand
 				.wires()
 				.iter()
+				.filter(|wire| !(wire.kind == WireKind::Constant && zero_const_id == Some(wire.id)))
 				.filter_map(|wire| layout.get(wire))
 				.collect();
 			Operand::new(indices)
@@ -516,5 +520,42 @@ mod tests {
 		witness_generator.assert_eq(sum_wire, expected_wire);
 
 		assert!(witness_generator.build().is_err());
+	}
+
+	#[test]
+	fn test_zero_constant_not_in_final_operands() {
+		use crate::{compiler::compile, constraint_system::WitnessSegment};
+
+		// Build a circuit where a zero constant is added to a wire; after compilation the
+		// zero constant term must be absent from all mul-constraint operands.
+		let mut builder = ConstraintBuilder::new();
+		let x = builder.alloc_inout();
+		let zero = builder.constant(B128::ZERO);
+		let sum = builder.add(x, zero);
+		let y = builder.alloc_inout();
+		builder.assert_eq(sum, y);
+
+		let (cs, _layout) = compile(builder);
+
+		let zero_constant_indices: std::collections::HashSet<u32> = cs
+			.constants()
+			.iter()
+			.enumerate()
+			.filter(|&(_, c)| *c == B128::ZERO)
+			.map(|(i, _)| i as u32)
+			.collect();
+
+		for constraint in cs.mul_constraints() {
+			for operand in [&constraint.a, &constraint.b, &constraint.c] {
+				for wire_idx in operand.wires() {
+					assert!(
+						!(wire_idx.segment == WitnessSegment::Public
+							&& zero_constant_indices.contains(&wire_idx.index)),
+						"zero constant found in compiled operand at WitnessIndex::public({})",
+						wire_idx.index
+					);
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Fixes [BINIUS-68](https://linear.app/jimpo/issue/BINIUS-68/ensure-zero-constant-wires-are-removed).

In both the Binius64 and IronSpartan constraint systems, zero constant wires were surviving into final compiled operands. Since any shift of zero is zero, these terms contribute nothing to an XOR operand and should be eliminated during compilation.

## Investigation

Confirmed the bug in both systems with repro circuits:
- **Binius64**: a zero constant `ValueIndex(0)` appeared in AND operands of a simple `iadd_cin_cout` circuit with a zero carry-in.
- **IronSpartan**: a zero constant `WitnessIndex::public(0)` appeared in a `MulConstraint` operand of a simple `add(x, zero)` circuit.

## Fix

- **binius-frontend** (`compiler/mod.rs`): after building constraints, filter any `ShiftedValueIndex` term whose `value_index` maps to a `Word::ZERO` constant (checked by index, not sort order).
- **binius-spartan-frontend** (`circuit_builder.rs` `finalize()`): skip the zero constant wire when mapping `ConstraintWire` → `WitnessIndex`.

Both fixes run after wire elimination, so they don't interact with the optimization pass.

**Note:** The zero constant remains allocated in the constants vector (removing it would require reindexing, which is invasive) but is unreferenced in all operands after compilation.

## Testing

- Added regression tests to both crates (`test_zero_constant_not_in_final_operands`, `test_zero_constant_not_in_binius64_operands`).
- All existing tests pass.
- Re-blessed example snapshots, which now reflect the reduced operand sizes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)