### PR TITLE
Add WideMul trait for deferred-reduction GF(2^128) multiply

### DIFF
--- a/crates/field/Cargo.toml
+++ b/crates/field/Cargo.toml
@@ -79,3 +79,7 @@ harness = false
 [[bench]]
 name = "main_field_binary_ops"
 harness = false
+
+[[bench]]
+name = "ghash_widening"
+harness = false

--- a/crates/field/benches/ghash_widening.rs
+++ b/crates/field/benches/ghash_widening.rs
@@ -1,0 +1,56 @@
+// Copyright 2026 The Binius Developers
+
+//! Benchmark widening (deferred-reduction) `GF(2^128)` multiplication against full multiplication.
+//!
+//! Measures the inner-product pattern `sum_i a_i * b_i` two ways: a full multiply per term (which
+//! reduces every product), and a widening multiply that accumulates unreduced products and reduces
+//! once at the end.
+
+use std::hint::black_box;
+
+use binius_field::{PackedField, WideMul, arch::OptimalPackedB128};
+use criterion::{
+	BenchmarkGroup, Criterion, Throughput, criterion_group, criterion_main, measurement::WallTime,
+};
+
+fn bench_at_n<P: PackedField>(group: &mut BenchmarkGroup<'_, WallTime>, label: &str, n: usize) {
+	let mut rng = rand::rng();
+	let a_vals: Vec<P> = (0..n).map(|_| P::random(&mut rng)).collect();
+	let b_vals: Vec<P> = (0..n).map(|_| P::random(&mut rng)).collect();
+
+	group.throughput(Throughput::Elements((n * P::WIDTH) as u64));
+
+	group.bench_function(format!("full_mul/{label}/n={n}"), |b| {
+		b.iter(|| {
+			let mut acc = P::default();
+			for i in 0..n {
+				acc += black_box(a_vals[i]) * black_box(b_vals[i]);
+			}
+			black_box(acc)
+		})
+	});
+
+	group.bench_function(format!("wide_mul/{label}/n={n}"), |b| {
+		b.iter(|| {
+			let mut acc = <P as WideMul>::Output::default();
+			for i in 0..n {
+				acc += P::wide_mul(black_box(a_vals[i]), black_box(b_vals[i]));
+			}
+			black_box(P::reduce(acc))
+		})
+	});
+}
+
+fn bench_ghash_widening(c: &mut Criterion) {
+	let mut group = c.benchmark_group("ghash_widening");
+
+	let label = format!("OptimalPacked_{}x128b", OptimalPackedB128::WIDTH);
+	for &n in &[16, 256, 4096] {
+		bench_at_n::<OptimalPackedB128>(&mut group, &label, n);
+	}
+
+	group.finish();
+}
+
+criterion_group!(benches, bench_ghash_widening);
+criterion_main!(benches);

--- a/crates/field/src/aes_field.rs
+++ b/crates/field/src/aes_field.rs
@@ -1,4 +1,5 @@
 // Copyright 2024-2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 use std::{
 	fmt::{Debug, Display, Formatter},
@@ -33,6 +34,8 @@ use crate::{
 //    AESTowerField16b.
 //  ...
 binary_field!(pub AESTowerField8b(u8), 0xD0);
+
+crate::arithmetic_traits::impl_trivial_wide_mul!(AESTowerField8b);
 
 unsafe impl Pod for AESTowerField8b {}
 

--- a/crates/field/src/arch/aarch64/packed_aes_128.rs
+++ b/crates/field/src/arch/aarch64/packed_aes_128.rs
@@ -18,6 +18,10 @@ use crate::{
 
 pub type PackedAESBinaryField16x8b = PackedPrimitiveType<M128, AESTowerField8b>;
 
+// Defined by hand rather than via `define_packed_binary_fields!`, so the trivial `WideMul` impl
+// (a parent trait of `PackedField`) must be emitted explicitly here.
+crate::arithmetic_traits::impl_trivial_wide_mul!(PackedAESBinaryField16x8b);
+
 impl Mul for PackedAESBinaryField16x8b {
 	type Output = Self;
 

--- a/crates/field/src/arch/aarch64/packed_ghash_128.rs
+++ b/crates/field/src/arch/aarch64/packed_ghash_128.rs
@@ -1,4 +1,5 @@
 // Copyright 2023-2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 // Copyright (c) 2019-2023 RustCrypto Developers
 
 //! ARMv8 `PMULL`-accelerated implementation of GHASH.
@@ -13,11 +14,11 @@ use crate::{
 	BinaryField128bGhash,
 	arch::{
 		portable::packed_macros::{portable_macros::*, *},
-		shared::ghash::ClMulUnderlier,
+		shared::ghash::{self, ClMulUnderlier},
 	},
 	arithmetic_traits::{
-		InvertOrZero, TaggedInvertOrZero, TaggedMul, TaggedSquare, impl_invert_with, impl_mul_with,
-		impl_square_with,
+		InvertOrZero, TaggedInvertOrZero, TaggedMul, TaggedSquare, WideMul, impl_invert_with,
+		impl_mul_with, impl_square_with,
 	},
 };
 
@@ -79,6 +80,21 @@ impl TaggedSquare<GhashStrategy> for PackedBinaryGhash1x128b {
 	#[inline]
 	fn square(self) -> Self {
 		Self::from_underlier(crate::arch::shared::ghash::square_clmul(self.to_underlier()))
+	}
+}
+
+// Implement WideMul
+impl WideMul for PackedBinaryGhash1x128b {
+	type Output = ghash::WideGhashProduct<M128>;
+
+	#[inline]
+	fn wide_mul(a: Self, b: Self) -> Self::Output {
+		ghash::WideGhashProduct::wide_mul(a.to_underlier(), b.to_underlier())
+	}
+
+	#[inline]
+	fn reduce(wide: Self::Output) -> Self {
+		Self::from_underlier(wide.reduce())
 	}
 }
 

--- a/crates/field/src/arch/portable/packed.rs
+++ b/crates/field/src/arch/portable/packed.rs
@@ -1,4 +1,5 @@
 // Copyright 2024-2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 // This is because derive(bytemuck::TransparentWrapper) adds some type constraints to
 // PackedPrimitiveType in addition to the type constraints we define. Even more, annoying, the
@@ -21,7 +22,7 @@ use rand::{
 };
 
 use crate::{
-	BinaryField, Divisible, ExtensionField, Field, PackedField,
+	BinaryField, Divisible, ExtensionField, Field, PackedField, WideMul,
 	arithmetic_traits::{InvertOrZero, Square},
 	field::FieldOps,
 	underlier::{NumCast, UnderlierType, UnderlierWithBitOps, WithUnderlier},
@@ -126,14 +127,18 @@ unsafe impl<U: UnderlierType, Scalar: BinaryField> WithUnderlier
 	}
 }
 
-impl<U: UnderlierWithBitOps, Scalar: BinaryField> Debug for PackedPrimitiveType<U, Scalar>
-where
-	Self: PackedField,
+// Note: this bound is deliberately phrased in terms of `Divisible` rather than `Self:
+// PackedField`. `PackedField` now has `WideMul<Output: Debug>` as a parent trait, and the trivial
+// `WideMul` impl sets `Output = Self`, so a `Self: PackedField` bound here would make `Debug`
+// depend on itself and overflow trait resolution.
+impl<U: UnderlierWithBitOps + Divisible<Scalar::Underlier>, Scalar: BinaryField> Debug
+	for PackedPrimitiveType<U, Scalar>
 {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		let width = checked_int_div(U::BITS, Scalar::N_BITS);
-		let values_str = self
-			.iter()
+		let values_str = (0..width)
+			// Safety: `i` ranges over `0..width`, the number of scalars packed in `U`.
+			.map(|i| Scalar::from_underlier(unsafe { self.0.get_subvalue(i) }))
 			.map(|value| format!("{value}"))
 			.collect::<Vec<_>>()
 			.join(",");
@@ -412,7 +417,8 @@ where
 
 impl<U, Scalar> PackedField for PackedPrimitiveType<U, Scalar>
 where
-	Self: Square + InvertOrZero + Mul<Output = Self>,
+	Self:
+		Square + InvertOrZero + Mul<Output = Self> + WideMul<Output: Debug + Send + Sync + 'static>,
 	U: UnderlierWithBitOps + Divisible<Scalar::Underlier>,
 	Scalar: BinaryField,
 {

--- a/crates/field/src/arch/portable/packed_ghash_128.rs
+++ b/crates/field/src/arch/portable/packed_ghash_128.rs
@@ -1,4 +1,5 @@
 // Copyright 2023-2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 //! Portable implementation of packed GHASH field operations.
 
@@ -122,6 +123,9 @@ impl TaggedSquare<GhashStrategy> for PackedBinaryGhash1x128b {
 		ghash_square(self.0).into()
 	}
 }
+
+// Implement WideMul (trivial: no CLMUL, just regular multiply)
+crate::arithmetic_traits::impl_trivial_wide_mul!(PackedBinaryGhash1x128b);
 
 // Implement TaggedInvertOrZero for GhashStrategy
 impl TaggedInvertOrZero<GhashStrategy> for PackedBinaryGhash1x128b {

--- a/crates/field/src/arch/portable/packed_ghash_256.rs
+++ b/crates/field/src/arch/portable/packed_ghash_256.rs
@@ -1,4 +1,5 @@
 // Copyright 2024-2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 use super::{
 	packed_256::M256,
@@ -19,3 +20,5 @@ define_packed_binary_fields!(
 		},
 	]
 );
+
+crate::arithmetic_traits::impl_trivial_wide_mul!(PackedBinaryGhash2x128b);

--- a/crates/field/src/arch/portable/packed_ghash_512.rs
+++ b/crates/field/src/arch/portable/packed_ghash_512.rs
@@ -1,4 +1,5 @@
 // Copyright 2024-2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 use super::{
 	packed_512::M512,
@@ -19,3 +20,5 @@ define_packed_binary_fields!(
 		},
 	]
 );
+
+crate::arithmetic_traits::impl_trivial_wide_mul!(PackedBinaryGhash4x128b);

--- a/crates/field/src/arch/portable/packed_macros.rs
+++ b/crates/field/src/arch/portable/packed_macros.rs
@@ -1,4 +1,5 @@
 // Copyright 2024-2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 macro_rules! define_packed_binary_fields {
     (
@@ -26,8 +27,23 @@ macro_rules! define_packed_binary_fields {
                 ($($invert)*),
                 ($($transform)*)
             );
+
+            // Every packed field is a `WideMul` (it's a parent trait of `PackedField`). All
+            // packings except `GF(2^128)` use the trivial implementation; the `GF(2^128)`
+            // packings provide their own CLMUL-accelerated (or, on backends without CLMUL,
+            // trivial) impl, so the macro must not emit a conflicting one for them.
+            maybe_impl_trivial_wide_mul!($scalar, $name);
         )*
     };
+}
+
+/// Emits a trivial [`WideMul`](crate::WideMul) impl for every scalar except
+/// `BinaryField128bGhash`, whose packings implement `WideMul` themselves.
+macro_rules! maybe_impl_trivial_wide_mul {
+	(BinaryField128bGhash, $name:ident) => {};
+	($scalar:ident, $name:ident) => {
+		$crate::arithmetic_traits::impl_trivial_wide_mul!($name);
+	};
 }
 
 macro_rules! define_packed_binary_field {
@@ -85,6 +101,7 @@ macro_rules! impl_serialize_deserialize_for_packed_binary_field {
 pub(crate) use define_packed_binary_field;
 pub(crate) use define_packed_binary_fields;
 pub(crate) use impl_serialize_deserialize_for_packed_binary_field;
+pub(crate) use maybe_impl_trivial_wide_mul;
 
 pub(crate) use crate::arithmetic_traits::{impl_invert_with, impl_mul_with, impl_square_with};
 

--- a/crates/field/src/arch/shared/ghash.rs
+++ b/crates/field/src/arch/shared/ghash.rs
@@ -1,4 +1,12 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
+
+// Items in this module are conditionally used by architecture-specific GHASH backends. On
+// targets where none of those backends are compiled (e.g. wasm32 without simd128), the entire
+// module is unused, so allow dead code here rather than sprinkling attributes on every item.
+#![allow(dead_code)]
+
+use std::ops::{Add, AddAssign, Sub, SubAssign};
 
 use crate::{Divisible, underlier::UnderlierWithBitOps};
 
@@ -15,7 +23,6 @@ pub trait ClMulUnderlier: UnderlierWithBitOps + Divisible<u128> {
 }
 
 #[inline]
-#[allow(dead_code)]
 pub fn mul_clmul<U: ClMulUnderlier>(x: U, y: U) -> U {
 	// Based on the C++ reference implementation
 	// The algorithm performs polynomial multiplication followed by reduction
@@ -46,7 +53,6 @@ pub fn mul_clmul<U: ClMulUnderlier>(x: U, y: U) -> U {
 
 /// The version of the multiplication for optimized suqare operation.
 #[inline]
-#[allow(dead_code)]
 pub fn square_clmul<U: ClMulUnderlier>(x: U) -> U {
 	// t1 from the previous function is always zero for squaring
 	// t2 = x.hi * x.hi
@@ -91,4 +97,121 @@ fn gf2_128_shift_reduce<U: ClMulUnderlier>(t: U) -> U {
 	result ^= U::clmulepi64::<0x01>(t, poly);
 
 	result
+}
+
+/// An unreduced product of two `GF(2^128)` elements, stored as three 128-bit limbs
+/// `(lo, hi, mid)` where `mid = cross_a XOR cross_b`. Values of this type can be summed by XOR
+/// and reduced once at the end via [`reduce`](WideGhashProduct::reduce).
+///
+/// Uses the "schoolbook" form: 4 independent CLMULs for the multiply and 2 reduction CLMULs per
+/// reduce.
+#[derive(Clone, Copy, Default, Debug)]
+pub struct WideGhashProduct<U: ClMulUnderlier> {
+	lo: U,
+	hi: U,
+	mid: U,
+}
+
+impl<U: ClMulUnderlier> WideGhashProduct<U> {
+	/// Widening multiply with 4 independent CLMULs, no reduction.
+	#[inline]
+	pub fn wide_mul(x: U, y: U) -> Self {
+		let lo = U::clmulepi64::<0x00>(x, y);
+		let hi = U::clmulepi64::<0x11>(x, y);
+		let cross_a = U::clmulepi64::<0x01>(x, y);
+		let cross_b = U::clmulepi64::<0x10>(x, y);
+		Self {
+			lo,
+			hi,
+			mid: cross_a ^ cross_b,
+		}
+	}
+
+	/// Reduce the accumulated wide product to a single GF(2^128) element.
+	/// Costs 2 CLMULs (the reduction steps).
+	#[inline]
+	pub fn reduce(self) -> U {
+		let t1 = gf2_128_reduce(self.mid, self.hi);
+		gf2_128_reduce(self.lo, t1)
+	}
+}
+
+impl<U: ClMulUnderlier> Add for WideGhashProduct<U> {
+	type Output = Self;
+
+	#[inline]
+	fn add(self, rhs: Self) -> Self {
+		Self {
+			lo: self.lo ^ rhs.lo,
+			hi: self.hi ^ rhs.hi,
+			mid: self.mid ^ rhs.mid,
+		}
+	}
+}
+
+impl<U: ClMulUnderlier> AddAssign for WideGhashProduct<U> {
+	#[inline]
+	fn add_assign(&mut self, rhs: Self) {
+		self.lo ^= rhs.lo;
+		self.hi ^= rhs.hi;
+		self.mid ^= rhs.mid;
+	}
+}
+
+// In characteristic 2, subtraction is identical to addition (XOR).
+impl<U: ClMulUnderlier> Sub for WideGhashProduct<U> {
+	type Output = Self;
+
+	#[inline]
+	fn sub(self, rhs: Self) -> Self {
+		Self {
+			lo: self.lo ^ rhs.lo,
+			hi: self.hi ^ rhs.hi,
+			mid: self.mid ^ rhs.mid,
+		}
+	}
+}
+
+impl<U: ClMulUnderlier> SubAssign for WideGhashProduct<U> {
+	#[inline]
+	fn sub_assign(&mut self, rhs: Self) {
+		self.lo ^= rhs.lo;
+		self.hi ^= rhs.hi;
+		self.mid ^= rhs.mid;
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use rand::{SeedableRng, rngs::StdRng};
+
+	use crate::{Random, WideMul, arch::OptimalPackedB128};
+
+	/// Stress-test accumulation of many widening products. Correctness / linearity for each
+	/// individual packed width is covered by the proptest suite in `packed_ghash.rs`.
+	#[test]
+	fn test_wide_mul_accumulation() {
+		type P = OptimalPackedB128;
+
+		let mut rng = StdRng::seed_from_u64(999);
+		let n = 64;
+
+		let a_vals: Vec<P> = (0..n).map(|_| P::random(&mut rng)).collect();
+		let b_vals: Vec<P> = (0..n).map(|_| P::random(&mut rng)).collect();
+
+		let wide_sum = a_vals
+			.iter()
+			.zip(b_vals.iter())
+			.map(|(&a, &b)| P::wide_mul(a, b))
+			.fold(<P as WideMul>::Output::default(), |acc, w| acc + w);
+		let reduced = P::reduce(wide_sum);
+
+		let direct_sum: P = a_vals
+			.iter()
+			.zip(b_vals.iter())
+			.map(|(&a, &b)| a * b)
+			.fold(P::default(), |acc, p| acc + p);
+
+		assert_eq!(reduced, direct_sum);
+	}
 }

--- a/crates/field/src/arch/wasm32/packed_ghash_128.rs
+++ b/crates/field/src/arch/wasm32/packed_ghash_128.rs
@@ -1,4 +1,5 @@
 // Copyright 2023-2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 // Copyright (c) 2019-2023 RustCrypto Developers
 
 //! WASM32 implementation of GHASH.
@@ -82,6 +83,9 @@ impl InvertOrZero for PackedBinaryGhash1x128b {
 		Self::from_underlier(InvertOrZero::invert_or_zero(portable).to_underlier().into())
 	}
 }
+
+// Implement WideMul (trivial: no CLMUL, just regular multiply)
+crate::arithmetic_traits::impl_trivial_wide_mul!(PackedBinaryGhash1x128b);
 
 // Define linear transformations
 impl_transformation_with_strategy!(PackedBinaryGhash1x128b, PairwiseStrategy);

--- a/crates/field/src/arch/x86_64/packed_ghash_128.rs
+++ b/crates/field/src/arch/x86_64/packed_ghash_128.rs
@@ -1,4 +1,5 @@
 // Copyright 2024-2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 //! PCLMULQDQ-accelerated implementation of GHASH for x86_64.
 //!
@@ -17,9 +18,12 @@ use crate::{
 		impl_square_with,
 	},
 };
+// Only used by the CLMUL-accelerated `ClMulUnderlier` and `WideMul` impls below.
+#[cfg(target_feature = "pclmulqdq")]
+use crate::{arch::shared::ghash, arithmetic_traits::WideMul};
 
 #[cfg(target_feature = "pclmulqdq")]
-impl crate::arch::shared::ghash::ClMulUnderlier for M128 {
+impl ghash::ClMulUnderlier for M128 {
 	#[inline]
 	fn clmulepi64<const IMM8: i32>(a: Self, b: Self) -> Self {
 		unsafe { std::arch::x86_64::_mm_clmulepi64_si128::<IMM8>(a.into(), b.into()) }.into()
@@ -94,6 +98,27 @@ cfg_if! {
 				Self::from_underlier(crate::arithmetic_traits::Square::square(portable_val).to_underlier().into())
 			}
 		}
+	}
+}
+
+// Implement WideMul
+cfg_if! {
+	if #[cfg(target_feature = "pclmulqdq")] {
+		impl WideMul for PackedBinaryGhash1x128b {
+			type Output = ghash::WideGhashProduct<M128>;
+
+			#[inline]
+			fn wide_mul(a: Self, b: Self) -> Self::Output {
+				ghash::WideGhashProduct::wide_mul(a.to_underlier(), b.to_underlier())
+			}
+
+			#[inline]
+			fn reduce(wide: Self::Output) -> Self {
+				Self::from_underlier(wide.reduce())
+			}
+		}
+	} else {
+		crate::arithmetic_traits::impl_trivial_wide_mul!(PackedBinaryGhash1x128b);
 	}
 }
 

--- a/crates/field/src/arch/x86_64/packed_ghash_256.rs
+++ b/crates/field/src/arch/x86_64/packed_ghash_256.rs
@@ -1,4 +1,5 @@
 // Copyright 2024-2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 //! VPCLMULQDQ-accelerated implementation of GHASH for x86_64 AVX2.
 //!
@@ -20,6 +21,9 @@ use crate::{
 	},
 	underlier::UnderlierWithBitOps,
 };
+// Only used by the CLMUL-accelerated `WideMul` impl below.
+#[cfg(target_feature = "vpclmulqdq")]
+use crate::{arch::shared::ghash, arithmetic_traits::WideMul};
 
 #[cfg(target_feature = "vpclmulqdq")]
 mod vpclmulqdq {
@@ -125,6 +129,27 @@ cfg_if! {
 				Self::from_underlier(result_underlier)
 			}
 		}
+	}
+}
+
+// Implement WideMul
+cfg_if! {
+	if #[cfg(target_feature = "vpclmulqdq")] {
+		impl WideMul for PackedBinaryGhash2x128b {
+			type Output = ghash::WideGhashProduct<M256>;
+
+			#[inline]
+			fn wide_mul(a: Self, b: Self) -> Self::Output {
+				ghash::WideGhashProduct::wide_mul(a.to_underlier(), b.to_underlier())
+			}
+
+			#[inline]
+			fn reduce(wide: Self::Output) -> Self {
+				Self::from_underlier(wide.reduce())
+			}
+		}
+	} else {
+		crate::arithmetic_traits::impl_trivial_wide_mul!(PackedBinaryGhash2x128b);
 	}
 }
 

--- a/crates/field/src/arch/x86_64/packed_ghash_512.rs
+++ b/crates/field/src/arch/x86_64/packed_ghash_512.rs
@@ -1,4 +1,5 @@
 // Copyright 2024-2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 //! VPCLMULQDQ-accelerated implementation of GHASH for x86_64 AVX-512.
 //!
@@ -18,9 +19,12 @@ use crate::{
 	},
 	underlier::UnderlierWithBitOps,
 };
+// Only used by the CLMUL-accelerated `ClMulUnderlier` and `WideMul` impls below.
+#[cfg(all(target_feature = "vpclmulqdq", target_feature = "avx512f"))]
+use crate::{arch::shared::ghash, arithmetic_traits::WideMul};
 
 #[cfg(all(target_feature = "vpclmulqdq", target_feature = "avx512f"))]
-impl crate::arch::shared::ghash::ClMulUnderlier for M512 {
+impl ghash::ClMulUnderlier for M512 {
 	#[inline]
 	fn clmulepi64<const IMM8: i32>(a: Self, b: Self) -> Self {
 		unsafe { std::arch::x86_64::_mm512_clmulepi64_epi128::<IMM8>(a.into(), b.into()) }.into()
@@ -126,6 +130,27 @@ cfg_if! {
 		// Potentially we could use an optimized square implementation here with a scaled underlier.
 		// But this case (an architecture with AVX512 but without VPCLMULQDQ) is pretty rare.
 		impl_square_with!(PackedBinaryGhash4x128b @ crate::arch::ReuseMultiplyStrategy);
+	}
+}
+
+// Implement WideMul
+cfg_if! {
+	if #[cfg(all(target_feature = "vpclmulqdq", target_feature = "avx512f"))] {
+		impl WideMul for PackedBinaryGhash4x128b {
+			type Output = ghash::WideGhashProduct<M512>;
+
+			#[inline]
+			fn wide_mul(a: Self, b: Self) -> Self::Output {
+				ghash::WideGhashProduct::wide_mul(a.to_underlier(), b.to_underlier())
+			}
+
+			#[inline]
+			fn reduce(wide: Self::Output) -> Self {
+				Self::from_underlier(wide.reduce())
+			}
+		}
+	} else {
+		crate::arithmetic_traits::impl_trivial_wide_mul!(PackedBinaryGhash4x128b);
 	}
 }
 

--- a/crates/field/src/arithmetic_traits.rs
+++ b/crates/field/src/arithmetic_traits.rs
@@ -1,10 +1,58 @@
 // Copyright 2024-2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
+
+use std::ops::{Add, AddAssign, Sub, SubAssign};
 
 /// Value that can be multiplied by itself
 pub trait Square {
 	/// Returns the value multiplied by itself
 	fn square(self) -> Self;
 }
+
+/// A field type that supports widening (unreduced) multiplication.
+///
+/// The multiply phase produces an [`Output`](Self::Output) value that can be accumulated via
+/// addition without overflow (XOR in characteristic 2). A single [`reduce`](Self::reduce) call at
+/// the end converts back to the field representation. For `GF(2^128)` inner products this lets us
+/// amortize the reduction across many products, which is a net win when reductions are comparable
+/// in cost to the widening multiply itself.
+///
+/// `WideMul` is a parent trait of both [`Field`](crate::Field) and
+/// [`PackedField`](crate::PackedField), so every field and packed field supports it (and each type
+/// implements it directly, leaving room for specialized impls). Most types use the trivial
+/// implementation — multiply eagerly, reduce to the identity — except the `GF(2^128)` scalar field
+/// and its CLMUL-accelerated packings (x86_64 and AArch64), which defer the reduction by
+/// accumulating an unreduced `WideGhashProduct`.
+pub trait WideMul: Sized {
+	type Output: Default
+		+ Add<Output = Self::Output>
+		+ AddAssign
+		+ Sub<Output = Self::Output>
+		+ SubAssign;
+
+	fn wide_mul(a: Self, b: Self) -> Self::Output;
+	fn reduce(wide: Self::Output) -> Self;
+}
+
+macro_rules! impl_trivial_wide_mul {
+	($name:ty) => {
+		impl $crate::arithmetic_traits::WideMul for $name {
+			type Output = Self;
+
+			#[inline]
+			fn wide_mul(a: Self, b: Self) -> Self {
+				a * b
+			}
+
+			#[inline]
+			fn reduce(wide: Self) -> Self {
+				wide
+			}
+		}
+	};
+}
+
+pub(crate) use impl_trivial_wide_mul;
 
 /// Value that can be inverted
 pub trait InvertOrZero {

--- a/crates/field/src/binary_field.rs
+++ b/crates/field/src/binary_field.rs
@@ -1,4 +1,5 @@
 // Copyright 2023-2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 use std::{
 	fmt::{Debug, Display, Formatter},
@@ -459,6 +460,8 @@ macro_rules! impl_field_extension {
 pub(crate) use impl_field_extension;
 
 binary_field!(pub BinaryField1b(U1), U1::new(0x1));
+
+crate::arithmetic_traits::impl_trivial_wide_mul!(BinaryField1b);
 
 macro_rules! serialize_deserialize {
 	($bin_type:ty) => {

--- a/crates/field/src/field.rs
+++ b/crates/field/src/field.rs
@@ -1,4 +1,5 @@
 // Copyright 2024-2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 use std::{
 	fmt::{Debug, Display},
@@ -12,7 +13,7 @@ use bytemuck::Zeroable;
 
 use super::extension::ExtensionField;
 use crate::{
-	Random,
+	Random, WideMul,
 	arithmetic_traits::{InvertOrZero, Square},
 };
 
@@ -56,6 +57,7 @@ pub trait Field:
 	+ Zeroable
 	+ SerializeBytes
 	+ DeserializeBytes
+	+ WideMul<Output: Debug + Send + Sync + 'static>
 {
 	/// The zero element of the field, the additive identity.
 	const ZERO: Self;

--- a/crates/field/src/ghash.rs
+++ b/crates/field/src/ghash.rs
@@ -1,4 +1,5 @@
 // Copyright 2023-2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 //! Binary field implementation of GF(2^128) with a modulus of X^128 + X^7 + X^2 + X + 1.
 //! This is the GHASH field used in AES-GCM.
@@ -21,7 +22,7 @@ use super::{
 	extension::ExtensionField,
 };
 use crate::{
-	AESTowerField8b, Field,
+	AESTowerField8b, Field, PackedField, WideMul,
 	arch::packed_ghash_128::PackedBinaryGhash1x128b,
 	arithmetic_traits::InvertOrZero,
 	binary_field_arithmetic::{
@@ -33,6 +34,26 @@ use crate::{
 };
 
 binary_field!(pub BinaryField128bGhash(u128), 0x494ef99794d5244f9152df59d87a9186);
+
+// Deferred-reduction widening multiply, implemented by reusing the width-1 packed GHASH type. On
+// CLMUL backends `Output` is an unreduced `WideGhashProduct`, so accumulating products reduces
+// only once at the end; on portable backends it falls back to the trivial (eager) multiply.
+impl WideMul for BinaryField128bGhash {
+	type Output = <PackedBinaryGhash1x128b as WideMul>::Output;
+
+	#[inline]
+	fn wide_mul(a: Self, b: Self) -> Self::Output {
+		PackedBinaryGhash1x128b::wide_mul(
+			PackedBinaryGhash1x128b::set_single(a),
+			PackedBinaryGhash1x128b::set_single(b),
+		)
+	}
+
+	#[inline]
+	fn reduce(wide: Self::Output) -> Self {
+		PackedBinaryGhash1x128b::reduce(wide).get(0)
+	}
+}
 
 unsafe impl Pod for BinaryField128bGhash {}
 
@@ -531,6 +552,27 @@ mod tests {
 			let converted_a = BinaryField128bGhash::from(a_val);
 			let converted_b = BinaryField128bGhash::from(b_val);
 			assert_eq!(BinaryField128bGhash::from(a_val * b_val), converted_a * converted_b);
+		}
+
+		#[test]
+		fn test_wide_mul_correctness(a in any::<u128>(), b in any::<u128>()) {
+			let a = BinaryField128bGhash::new(a);
+			let b = BinaryField128bGhash::new(b);
+			let reduced = BinaryField128bGhash::reduce(BinaryField128bGhash::wide_mul(a, b));
+			assert_eq!(reduced, a * b);
+		}
+
+		// Exercises the point of the trait: accumulate two unreduced products, reduce once.
+		#[test]
+		fn test_wide_mul_deferred_accumulation(
+			a1 in any::<u128>(), b1 in any::<u128>(),
+			a2 in any::<u128>(), b2 in any::<u128>(),
+		) {
+			let (a1, b1) = (BinaryField128bGhash::new(a1), BinaryField128bGhash::new(b1));
+			let (a2, b2) = (BinaryField128bGhash::new(a2), BinaryField128bGhash::new(b2));
+			let wide =
+				BinaryField128bGhash::wide_mul(a1, b1) + BinaryField128bGhash::wide_mul(a2, b2);
+			assert_eq!(BinaryField128bGhash::reduce(wide), a1 * b1 + a2 * b2);
 		}
 	}
 }

--- a/crates/field/src/lib.rs
+++ b/crates/field/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright 2023-2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 #![warn(rustdoc::missing_crate_level_docs)]
 
@@ -36,6 +37,7 @@ mod underlier;
 pub mod util;
 
 pub use aes_field::*;
+pub use arithmetic_traits::WideMul;
 pub use binary_field::*;
 pub use extension::*;
 pub use field::{Field, FieldOps};

--- a/crates/field/src/packed.rs
+++ b/crates/field/src/packed.rs
@@ -1,4 +1,5 @@
 // Copyright 2023-2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 //! Traits for packed field elements which support SIMD implementations.
 //!
@@ -17,7 +18,7 @@ use binius_utils::{
 use bytemuck::Zeroable;
 
 use super::{PackedExtension, Random, arithmetic_traits::Square};
-use crate::{BinaryField, Field, field::FieldOps};
+use crate::{BinaryField, Field, WideMul, field::FieldOps};
 
 /// A packed field represents a vector of underlying field elements.
 ///
@@ -42,6 +43,7 @@ pub trait PackedField:
 	+ Sync
 	+ Zeroable
 	+ Random
+	+ WideMul<Output: Debug + Send + Sync + 'static>
 	+ 'static
 {
 	/// Base-2 logarithm of the number of field elements packed into one packed element.

--- a/crates/field/src/packed_ghash.rs
+++ b/crates/field/src/packed_ghash.rs
@@ -1,4 +1,5 @@
 // Copyright 2024-2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 pub use crate::arch::{
 	packed_ghash_128::PackedBinaryGhash1x128b, packed_ghash_256::PackedBinaryGhash2x128b,
@@ -100,9 +101,91 @@ mod test_utils {
 		};
 	}
 
+	macro_rules! define_wide_mul_tests {
+		() => {
+			fn check_widening_correctness<P>(a: P::Underlier, b: P::Underlier)
+			where
+				P: $crate::PackedField<Scalar = $crate::BinaryField128bGhash>
+					+ $crate::WideMul
+					+ $crate::underlier::WithUnderlier,
+			{
+				let a = P::from_underlier(a);
+				let b = P::from_underlier(b);
+				let wide = P::wide_mul(a, b);
+				let reduced = P::reduce(wide);
+				assert_eq!(reduced, a * b);
+			}
+
+			fn check_widening_linearity<P>(
+				a1: P::Underlier,
+				b1: P::Underlier,
+				a2: P::Underlier,
+				b2: P::Underlier,
+			) where
+				P: $crate::PackedField<Scalar = $crate::BinaryField128bGhash>
+					+ $crate::WideMul
+					+ $crate::underlier::WithUnderlier,
+			{
+				let (a1, b1) = (P::from_underlier(a1), P::from_underlier(b1));
+				let (a2, b2) = (P::from_underlier(a2), P::from_underlier(b2));
+				let sum_reduced =
+					P::reduce(P::wide_mul(a1, b1) + P::wide_mul(a2, b2));
+				assert_eq!(sum_reduced, a1 * b1 + a2 * b2);
+			}
+
+			proptest! {
+				#[test]
+				fn test_wide_mul_correctness_128(a in any::<u128>(), b in any::<u128>()) {
+					check_widening_correctness::<$crate::arch::packed_ghash_128::PackedBinaryGhash1x128b>(a.into(), b.into());
+				}
+
+				#[test]
+				fn test_wide_mul_correctness_256(a in any::<[u128; 2]>(), b in any::<[u128; 2]>()) {
+					check_widening_correctness::<$crate::arch::packed_ghash_256::PackedBinaryGhash2x128b>(a.into(), b.into());
+				}
+
+				#[test]
+				fn test_wide_mul_correctness_512(a in any::<[u128; 4]>(), b in any::<[u128; 4]>()) {
+					check_widening_correctness::<$crate::arch::packed_ghash_512::PackedBinaryGhash4x128b>(a.into(), b.into());
+				}
+
+				#[test]
+				fn test_wide_mul_linearity_128(
+					a1 in any::<u128>(), b1 in any::<u128>(),
+					a2 in any::<u128>(), b2 in any::<u128>(),
+				) {
+					check_widening_linearity::<$crate::arch::packed_ghash_128::PackedBinaryGhash1x128b>(
+						a1.into(), b1.into(), a2.into(), b2.into(),
+					);
+				}
+
+				#[test]
+				fn test_wide_mul_linearity_256(
+					a1 in any::<[u128; 2]>(), b1 in any::<[u128; 2]>(),
+					a2 in any::<[u128; 2]>(), b2 in any::<[u128; 2]>(),
+				) {
+					check_widening_linearity::<$crate::arch::packed_ghash_256::PackedBinaryGhash2x128b>(
+						a1.into(), b1.into(), a2.into(), b2.into(),
+					);
+				}
+
+				#[test]
+				fn test_wide_mul_linearity_512(
+					a1 in any::<[u128; 4]>(), b1 in any::<[u128; 4]>(),
+					a2 in any::<[u128; 4]>(), b2 in any::<[u128; 4]>(),
+				) {
+					check_widening_linearity::<$crate::arch::packed_ghash_512::PackedBinaryGhash4x128b>(
+						a1.into(), b1.into(), a2.into(), b2.into(),
+					);
+				}
+			}
+		};
+	}
+
 	pub(crate) use define_invert_tests;
 	pub(crate) use define_multiply_tests;
 	pub(crate) use define_square_tests;
+	pub(crate) use define_wide_mul_tests;
 }
 
 #[cfg(test)]
@@ -111,7 +194,9 @@ mod tests {
 
 	use proptest::{arbitrary::any, proptest};
 
-	use super::test_utils::{define_invert_tests, define_multiply_tests, define_square_tests};
+	use super::test_utils::{
+		define_invert_tests, define_multiply_tests, define_square_tests, define_wide_mul_tests,
+	};
 	use crate::{
 		BinaryField128bGhash, PackedField,
 		arch::{
@@ -151,4 +236,39 @@ mod tests {
 	define_square_tests!(Square::square, PackedField);
 
 	define_invert_tests!(InvertOrZero::invert_or_zero, PackedField);
+
+	define_wide_mul_tests!();
+
+	#[test]
+	fn test_wide_mul_zero_inputs() {
+		use crate::{
+			WideMul, arch::packed_ghash_128::PackedBinaryGhash1x128b as P, field::FieldOps,
+		};
+
+		let zero = P::default();
+		let one = P::one();
+
+		assert_eq!(P::reduce(P::wide_mul(zero, zero)), zero);
+		assert_eq!(P::reduce(P::wide_mul(zero, one)), zero);
+		assert_eq!(P::reduce(P::wide_mul(one, zero)), zero);
+		assert_eq!(P::reduce(P::wide_mul(one, one)), one);
+
+		let wide_zero = <P as WideMul>::Output::default();
+		assert_eq!(P::reduce(wide_zero), zero);
+	}
+
+	#[test]
+	fn test_wide_mul_single_accumulation() {
+		use rand::{SeedableRng, rngs::StdRng};
+
+		use crate::{Random, WideMul, arch::packed_ghash_128::PackedBinaryGhash1x128b as P};
+
+		let mut rng = StdRng::seed_from_u64(77);
+		let a = P::random(&mut rng);
+		let b = P::random(&mut rng);
+
+		let wide = P::wide_mul(a, b);
+		let sum = wide + <P as WideMul>::Output::default();
+		assert_eq!(P::reduce(sum), a * b);
+	}
 }


### PR DESCRIPTION
## Summary

Isolates the `binius-field` half of #1454 per [jimpo's review](https://github.com/binius-zk/binius64/pull/1454#pullrequestreview-4357159068). Introduces `WideMul`, which separates the multiply step (an unreduced "wide" product) from the reduction step so that GF(2^128) inner products can amortize the per-word reduction across an entire accumulator — the basis for the delayed-reduction sumcheck optimization. Prover-side adoption of the trait follows in a separate PR.

Original work by Quang Dao (@quangvdao commit author preserved).

## Changes vs. #1454, addressing review

- **`WideMul` is a parent trait of `PackedField`** (not a propagated bound). Every packed field implements it: the trivial impl (eager multiply, identity reduce) for all fields except the CLMUL-accelerated GF(2^128) packings. Non-GHASH packed types get the trivial impl via a `define_packed_binary_fields!` macro dispatch that skips `BinaryField128bGhash`; the blanket `PackedField` impls gain a `Self: WideMul` bound.
- **Renames** per review: `WideningMul`→`WideMul`, `type Wide`→`Output`, `widening_mul`→`wide_mul`, `reduce_wide`→`reduce`.
- **Narrowed associated-type bound**: `Output: Default + Add + AddAssign + Sub + SubAssign` (added `Sub`/`SubAssign` to the wide-product type); `Debug + Send + Sync + 'static` live on the `PackedField` supertrait bound.
- **Benchmark moved out of `arith-bench`** (which shouldn't depend on `binius-field`) into `crates/field/benches/ghash_widening.rs`. The `inner_product_wide` bench, which needs `binius-math`, is deferred to the prover-side PR.
- **Dropped `WideKaratsubaGhashProduct`.** Benchmarked schoolbook vs. Karatsuba on x86_64 (pclmulqdq + vpclmulqdq): Karatsuba was parity-to-~10% slower across M128/M256, so x86 now uses the schoolbook `WideGhashProduct` like AArch64. This removes the second wide-product type, the `xor_halves` CLMUL helper, and the per-arch `cfg_if` branching. (Measured on a noisy virtualized host; happy to revisit with bare-metal numbers.)

## Correctness / verification

- proptest correctness + linearity across all packed widths, plus an accumulation stress test (`crates/field/src/packed_ghash.rs`, `arch/shared/ghash.rs`).
- `cargo test` green for `binius-field`, `binius-ip-prover`, `binius-spartan-prover`, `binius-prover`; workspace `cargo build` green; `binius-field` builds for `wasm32-wasip1`.
- `cargo fmt` clean; `cargo clippy` clean for `binius-field`.