### PR TITLE
Change SerializeBytes to fixed-size serialization (BINIUS-73)

### DIFF
--- a/crates/field/src/aes_field.rs
+++ b/crates/field/src/aes_field.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use binius_utils::{
-	DeserializeBytes, SerializationError, SerializeBytes,
+	DeserializeBytes, FixedSizeSerializeBytes, SerializationError, SerializeBytes,
 	bytes::{Buf, BufMut},
 };
 use bytemuck::{Pod, Zeroable};
@@ -90,6 +90,10 @@ impl DeserializeBytes for AESTowerField8b {
 	{
 		Ok(Self(DeserializeBytes::deserialize(read_buf)?))
 	}
+}
+
+impl FixedSizeSerializeBytes for AESTowerField8b {
+	const BYTE_SIZE: usize = 1;
 }
 
 #[cfg(test)]

--- a/crates/field/src/binary_field.rs
+++ b/crates/field/src/binary_field.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use binius_utils::{
-	DeserializeBytes, SerializationError, SerializeBytes,
+	DeserializeBytes, FixedSizeSerializeBytes, SerializationError, SerializeBytes,
 	bytes::{Buf, BufMut},
 };
 use bytemuck::Zeroable;
@@ -480,6 +480,10 @@ macro_rules! serialize_deserialize {
 }
 
 serialize_deserialize!(BinaryField1b);
+
+impl FixedSizeSerializeBytes for BinaryField1b {
+	const BYTE_SIZE: usize = 1;
+}
 
 impl BinaryField1b {
 	/// Creates value without checking that it is within valid range (0 or 1)

--- a/crates/field/src/field.rs
+++ b/crates/field/src/field.rs
@@ -8,7 +8,7 @@ use std::{
 	ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
 
-use binius_utils::{DeserializeBytes, SerializeBytes};
+use binius_utils::{DeserializeBytes, FixedSizeSerializeBytes, SerializeBytes};
 use bytemuck::Zeroable;
 
 use super::extension::ExtensionField;
@@ -57,6 +57,7 @@ pub trait Field:
 	+ Zeroable
 	+ SerializeBytes
 	+ DeserializeBytes
+	+ FixedSizeSerializeBytes
 	+ WideMul<Output: Debug + Send + Sync + 'static>
 {
 	/// The zero element of the field, the additive identity.

--- a/crates/field/src/ghash.rs
+++ b/crates/field/src/ghash.rs
@@ -12,7 +12,7 @@ use std::{
 };
 
 use binius_utils::{
-	DeserializeBytes, SerializationError, SerializeBytes,
+	DeserializeBytes, FixedSizeSerializeBytes, SerializationError, SerializeBytes,
 	bytes::{Buf, BufMut},
 };
 use bytemuck::{Pod, Zeroable};
@@ -134,6 +134,10 @@ impl DeserializeBytes for BinaryField128bGhash {
 	{
 		Ok(Self(DeserializeBytes::deserialize(read_buf)?))
 	}
+}
+
+impl FixedSizeSerializeBytes for BinaryField128bGhash {
+	const BYTE_SIZE: usize = 16;
 }
 
 impl From<AESTowerField8b> for BinaryField128bGhash {

--- a/crates/iop-prover/src/merkle_tree/mod.rs
+++ b/crates/iop-prover/src/merkle_tree/mod.rs
@@ -4,7 +4,7 @@ use binius_field::{Field, PackedField};
 use binius_iop::merkle_tree::{Commitment, MerkleTreeScheme};
 use binius_math::FieldSlice;
 use binius_transcript::{BufMut, TranscriptWriter};
-use binius_utils::rayon::prelude::*;
+use binius_utils::{FixedSizeSerializeBytes, rayon::prelude::*};
 
 pub mod prover;
 #[cfg(test)]
@@ -14,7 +14,7 @@ mod tests;
 ///
 /// This is separate from [`MerkleTreeScheme`] so that it may be implemented using a
 /// hardware-accelerated backend.
-pub trait MerkleTreeProver<T> {
+pub trait MerkleTreeProver<T: FixedSizeSerializeBytes> {
 	type Scheme: MerkleTreeScheme<T>;
 	/// Data generated during commitment required to generate opening proofs.
 	type Committed;

--- a/crates/iop/src/fri/batch.rs
+++ b/crates/iop/src/fri/batch.rs
@@ -3,7 +3,7 @@
 use binius_field::BinaryField;
 use binius_math::{line::extrapolate_line, multilinear, ntt::DomainContext};
 use binius_transcript::TranscriptReader;
-use binius_utils::DeserializeBytes;
+use binius_utils::{DeserializeBytes, FixedSizeSerializeBytes};
 use bytes::Buf;
 
 use crate::merkle_tree::{Commitment, MerkleTreeScheme};
@@ -45,6 +45,7 @@ pub trait ProxTestOracle<F: BinaryField> {
 /// [Brakedown]: <https://dl.acm.org/doi/10.1007/978-3-031-38545-2_7>
 pub struct BrakedownOracle<F, MTScheme>
 where
+	F: FixedSizeSerializeBytes,
 	MTScheme: MerkleTreeScheme<F>,
 {
 	challenges: Vec<F>,
@@ -124,6 +125,7 @@ impl<F: BinaryField, MTScheme: MerkleTreeScheme<F, Digest: DeserializeBytes>> Pr
 /// `BatchBrakedownFolder::fold`.
 pub struct BatchBrakedownOracle<F, MTScheme>
 where
+	F: FixedSizeSerializeBytes,
 	MTScheme: MerkleTreeScheme<F>,
 {
 	oracles: Vec<BrakedownOracle<F, MTScheme>>,
@@ -182,6 +184,7 @@ impl<F: BinaryField, MTScheme: MerkleTreeScheme<F, Digest: DeserializeBytes>> Pr
 /// single value using FRI folding.
 pub struct FRIOracle<F, MTScheme, DC>
 where
+	F: FixedSizeSerializeBytes,
 	MTScheme: MerkleTreeScheme<F>,
 	DC: DomainContext<Field = F>,
 {

--- a/crates/iop/src/fri/common.rs
+++ b/crates/iop/src/fri/common.rs
@@ -472,8 +472,6 @@ struct ReductionOptimizerEntry {
 struct ReductionOptimizer<'a, F, MTScheme> {
 	merkle_scheme: &'a MTScheme,
 	n_test_queries: usize,
-	/// The byte-size of a serialized field element, cached at construction.
-	value_size: usize,
 	_marker: PhantomData<F>,
 }
 
@@ -483,25 +481,16 @@ where
 	MTScheme: MerkleTreeScheme<F>,
 {
 	fn new(merkle_scheme: &'a MTScheme, n_test_queries: usize) -> Self {
-		// The byte-size of a serialized field element.
-		let value_size = {
-			let mut buf = Vec::new();
-			F::default()
-				.serialize(&mut buf)
-				.expect("default element can be serialized to a resizable buffer");
-			buf.len()
-		};
 		Self {
 			merkle_scheme,
 			n_test_queries,
-			value_size,
 			_marker: PhantomData,
 		}
 	}
 
 	fn compute_layer_reduction_size(&self, log_code_len: usize, arity: usize) -> usize {
 		// Each queried coset contains 2^arity values.
-		let leaf_size = self.value_size << arity;
+		let leaf_size = F::BYTE_SIZE << arity;
 		// One coset per test query.
 		let leaves_size = leaf_size * self.n_test_queries;
 
@@ -550,7 +539,7 @@ where
 
 			// Determine the proof size if this is the terminal codeword. In that case, the proof
 			// simply consists of the 2^(i + log_inv_rate) leaf values.
-			let terminal_proof_size = self.value_size << log_code_len;
+			let terminal_proof_size = F::BYTE_SIZE << log_code_len;
 			let terminal_entry = Entry {
 				proof_size: terminal_proof_size,
 				arity: None,

--- a/crates/iop/src/merkle_tree/merkle_tree_vcs.rs
+++ b/crates/iop/src/merkle_tree/merkle_tree_vcs.rs
@@ -2,6 +2,7 @@
 
 use auto_impl::auto_impl;
 use binius_transcript::{Buf, TranscriptReader};
+use binius_utils::FixedSizeSerializeBytes;
 
 use super::error::Error;
 
@@ -19,7 +20,7 @@ pub struct Commitment<Digest> {
 
 /// A Merkle tree scheme.
 #[auto_impl(&)]
-pub trait MerkleTreeScheme<T> {
+pub trait MerkleTreeScheme<T: FixedSizeSerializeBytes> {
 	type Digest: Clone + PartialEq + Eq;
 
 	/// Returns the optimal layer that the verifier should verify only once.

--- a/crates/iop/src/merkle_tree/scheme.rs
+++ b/crates/iop/src/merkle_tree/scheme.rs
@@ -6,7 +6,7 @@ use std::{array, fmt::Debug, marker::PhantomData};
 use binius_hash::{PseudoCompressionFunction, binary_merkle_tree::HashSuite, hash_serialize};
 use binius_transcript::{Buf, TranscriptReader};
 use binius_utils::{
-	DeserializeBytes, SerializeBytes,
+	FixedSizeSerializeBytes,
 	checked_arithmetics::{log2_ceil_usize, log2_strict_usize},
 };
 use digest::{Digest, Output};
@@ -50,7 +50,7 @@ impl<T, H: HashSuite> BinaryMerkleTreeScheme<T, H> {
 
 impl<T, H> BinaryMerkleTreeScheme<T, H>
 where
-	T: SerializeBytes + DeserializeBytes,
+	T: FixedSizeSerializeBytes,
 	H: HashSuite,
 {
 	fn compute_leaf_digest<B: Buf>(
@@ -65,7 +65,7 @@ where
 
 impl<T, H> MerkleTreeScheme<T> for BinaryMerkleTreeScheme<T, H>
 where
-	T: SerializeBytes + DeserializeBytes,
+	T: FixedSizeSerializeBytes,
 	H: HashSuite,
 {
 	type Digest = Output<H::LeafHash>;

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -21,4 +21,6 @@ pub mod sparse_index;
 pub mod strided_array;
 
 pub use bytes;
-pub use serialization::{DeserializeBytes, SerializationError, SerializeBytes};
+pub use serialization::{
+	DeserializeBytes, FixedSizeSerializeBytes, SerializationError, SerializeBytes,
+};

--- a/crates/utils/src/serialization.rs
+++ b/crates/utils/src/serialization.rs
@@ -4,17 +4,42 @@ use bytes::{Buf, BufMut};
 use hybrid_array::{Array, ArraySize};
 use thiserror::Error;
 
-/// Serialize data according to Mode param
+/// Serialize data to a byte buffer.
 pub trait SerializeBytes {
 	fn serialize(&self, write_buf: impl BufMut) -> Result<(), SerializationError>;
 }
 
-/// Deserialize data according to Mode param
-pub trait DeserializeBytes {
-	fn deserialize(read_buf: impl Buf) -> Result<Self, SerializationError>
-	where
-		Self: Sized;
+/// Deserialize data from a byte buffer.
+pub trait DeserializeBytes: Sized {
+	fn deserialize(read_buf: impl Buf) -> Result<Self, SerializationError>;
 }
+
+/// A type whose byte-serialized form has a fixed, compile-time-known size.
+///
+/// Implementors must guarantee that [`SerializeBytes::serialize`] writes exactly
+/// [`BYTE_SIZE`](Self::BYTE_SIZE) bytes and that [`DeserializeBytes::deserialize`] reads exactly
+/// [`BYTE_SIZE`](Self::BYTE_SIZE) bytes.
+pub trait FixedSizeSerializeBytes: SerializeBytes + DeserializeBytes {
+	/// The exact number of bytes written by `serialize` and read by `deserialize`.
+	const BYTE_SIZE: usize;
+}
+
+macro_rules! impl_fixed_size_serialize_bytes {
+	($ty:ty, $size:expr) => {
+		impl FixedSizeSerializeBytes for $ty {
+			const BYTE_SIZE: usize = $size;
+		}
+	};
+}
+
+impl_fixed_size_serialize_bytes!(u8, 1);
+impl_fixed_size_serialize_bytes!(u16, 2);
+impl_fixed_size_serialize_bytes!(u32, 4);
+impl_fixed_size_serialize_bytes!(u64, 8);
+impl_fixed_size_serialize_bytes!(u128, 16);
+// `usize` is serialized as a `u32`.
+impl_fixed_size_serialize_bytes!(usize, 4);
+impl_fixed_size_serialize_bytes!(bool, 1);
 
 #[derive(Error, Debug, Clone)]
 pub enum SerializationError {


### PR DESCRIPTION
Resolves [BINIUS-73](https://linear.app/jimpo/issue/BINIUS-73/change-serializebytes-to-fixed-size-serialization).

## Summary

Introduces a `FixedSizeSerializeBytes` marker trait for types whose byte-serialized form has a fixed, compile-time-known size, and requires it for Merkle-tree-committed values.

Per discussion on the issue, `SerializeBytes`/`DeserializeBytes` are kept for variable-size serialization (proof / constraint-system), and the new fixed-size requirement is layered on top rather than narrowing the existing traits.

## Changes (3 commits)

1. **Add `FixedSizeSerializeBytes` trait; require `Sized` on `DeserializeBytes`.**
   - `pub trait FixedSizeSerializeBytes: SerializeBytes + DeserializeBytes { const BYTE_SIZE: usize; }`. Contract: `serialize`/`deserialize` write/read exactly `BYTE_SIZE` bytes.
   - `DeserializeBytes: Sized` (its only method already required `Self: Sized`); the now-redundant method where-clause is dropped.
   - Impls for the fixed-size integer primitives + `bool` (`usize` serializes as `u32`, so `BYTE_SIZE == 4`).
2. **Implement `FixedSizeSerializeBytes` for `Field` types.**
   - Added as a supertrait of `Field` (not `PackedField`, which doesn't require `SerializeBytes`), and implemented for `BinaryField1b` (1), `AESTowerField8b` (1), `BinaryField128bGhash` (16).
3. **Require `FixedSizeSerializeBytes` in the Merkle-tree modules; use `BYTE_SIZE` in FRI.**
   - Tighten the value-type bound of `MerkleTreeScheme`, `MerkleTreeProver`, and the FRI oracle structs that depend on them.
   - Fix the `fri::common` TODO: the reduction optimizer now uses `F::BYTE_SIZE` directly instead of serializing a default field element into a throwaway `Vec` to measure its length.

## Testing

- `cargo test -p binius-utils -p binius-field -p binius-iop -p binius-iop-prover` — all pass.
- `cargo clippy --all-features --tests -p binius-utils -p binius-field -p binius-iop -p binius-iop-prover -- -D warnings` — clean.
- `cargo fmt` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
