### PR TITLE
Scope the clippy pre-push hook to changed packages

### DIFF
--- a/crates/utils/src/rayon/iter/indexed_parallel_iterator.rs
+++ b/crates/utils/src/rayon/iter/indexed_parallel_iterator.rs
@@ -188,7 +188,10 @@ impl<L: IndexedParallelIteratorInner, R: IndexedParallelIteratorInner<Item = L::
 {
 }
 
-#[allow(private_bounds)]
+// `len` mirrors rayon's `IndexedParallelIterator::len`; this shim is only compiled when the
+// `rayon` feature is off, so without the allow a per-package clippy (no feature unification) flags
+// it even though the full-workspace lint never compiles this file.
+#[allow(private_bounds, clippy::len_without_is_empty)]
 pub trait IndexedParallelIterator:
 	ParallelIterator<Inner: IndexedParallelIteratorInner<Item = Self::Item>>
 {

--- a/prek.toml
+++ b/prek.toml
@@ -25,11 +25,11 @@ hooks = [
   },
   {
     id = "clippy",
-    name = "Run cargo clippy",
+    name = "Run cargo clippy on changed packages",
     types = ["rust"],
-    language = "rust",
-    entry = "cargo clippy --workspace --all-targets -- -D warnings",
-    pass_filenames = false,
+    language = "system",
+    entry = "bash tools/clippy-changed-packages.sh",
+    pass_filenames = true,
     stages = ["pre-push"]
   }
 ]

--- a/tools/clippy-changed-packages.sh
+++ b/tools/clippy-changed-packages.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# Runs `cargo clippy` scoped to the workspace packages that own the changed files
+# passed as arguments (deduped). Intended as a prek/pre-commit hook entry with
+# `pass_filenames = true` and `types = ["rust"]`.
+#
+# Exits 0 (no-op) if no argument resolves to a workspace package.
+set -euo pipefail
+
+(($# == 0)) && exit 0
+
+# "<manifest-dir>\t<package-name>" for every workspace member (no registry deps).
+members="$(cargo metadata --no-deps --format-version 1 \
+	| jq -r '.packages[] | "\(.manifest_path | rtrimstr("/Cargo.toml"))\t\(.name)"')"
+
+root="$(pwd)"
+declare -A seen=()
+args=()
+for f in "$@"; do
+	abs="$root/$f"
+	best_dir=""
+	best_name=""
+	# Pick the package whose manifest directory is the longest prefix of the file,
+	# so nested members (e.g. crates/frontend/ceck) resolve correctly.
+	while IFS=$'\t' read -r dir name; do
+		case "$abs" in
+		"$dir"/*) (("${#dir}" > "${#best_dir}")) && {
+			best_dir="$dir"
+			best_name="$name"
+		} ;;
+		esac
+	done <<<"$members" # here-string, not a pipe, so state survives in this shell
+	if [[ -n $best_name && -z ${seen["$best_name"]:-} ]]; then
+		seen["$best_name"]=1
+		args+=(--package "$best_name")
+	fi
+done
+
+((${#args[@]} == 0)) && exit 0
+
+echo "clippy: cargo clippy ${args[*]} --all-targets" >&2
+exec cargo clippy "${args[@]}" --all-targets -- -D warnings


### PR DESCRIPTION
## Summary

Scopes the `clippy` pre-push hook to the packages that actually changed, instead of always linting the whole workspace, for a faster pre-push check.

## Changes

- **`tools/clippy-changed-packages.sh`** (new) — takes the changed files passed by the hook, resolves each to its owning workspace package via `cargo metadata --no-deps` (longest manifest-dir prefix, so name≠dir and nested members like `ceck` resolve correctly), dedupes, and runs `cargo clippy --package … --all-targets -- -D warnings`. No-ops if nothing resolves to a package.
- **`prek.toml`** — the `clippy` hook now passes filenames to that script (`language = "system"`, `pass_filenames = true`), keeping `types = ["rust"]`.
- **`crates/utils/src/rayon/iter/indexed_parallel_iterator.rs`** — `#[allow(clippy::len_without_is_empty)]` on the maybe-rayon `IndexedParallelIterator` shim. A per-package clippy doesn't get `rayon` enabled by cross-crate feature unification, so this shim compiles and trips the lint; the full-workspace lint never sees it. The allow makes `binius-utils` lint clean in any feature config.

## Trade-off

The hook lints only the changed packages, **not** their reverse-dependencies — so a change to a core crate that breaks a dependent won't be caught locally. CI's full `--workspace --all-targets` clippy remains the backstop. This was a deliberate choice to keep the pre-push hook fast; reverse-dependency expansion can be added later from `cargo metadata`'s resolve graph if needed.

## Testing

- `prek run clippy --files … --hook-stage pre-push` passes; `types = ["rust"]` correctly drops non-Rust files.
- Mixed file lists dedupe to the right `--package` set (e.g. two `crates/hash/**` files + a `crates/field/**` file → `--package binius-hash --package binius-field`).
- `binius-utils` now lints clean standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
