### PR TITLE
Use tracing-forest for profiling tree output (BINIUS-74)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,7 @@ transpose = "0.2.2"
 tracing = "0.1.38"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "fmt"] }
 tracing-profile = "0.10.11"
+tracing-forest = { version = "0.3.1", features = ["ansi", "env-filter"] }
 trait-set = "0.3.0"
 uninit = "0.6.2"
 z3 = "0.13.3"

--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -31,7 +31,9 @@ rand = { workspace = true, features = ["thread_rng"] }
 sha2.workspace = true
 sha3.workspace = true
 tiny-keccak = "2.0.2"
+tracing-forest.workspace = true
 tracing-profile.workspace = true
+tracing-subscriber.workspace = true
 tracing.workspace = true
 ureq.workspace = true
 

--- a/crates/examples/src/bin/prover.rs
+++ b/crates/examples/src/bin/prover.rs
@@ -41,7 +41,7 @@ struct Args {
 }
 
 fn main() -> Result<()> {
-	let _tracing_guard = tracing_profile::init_tracing().ok();
+	binius_examples::init_tracing();
 	let args = Args::parse();
 
 	// Read and deserialize constraint system

--- a/crates/examples/src/bin/verifier.rs
+++ b/crates/examples/src/bin/verifier.rs
@@ -37,7 +37,7 @@ struct Args {
 }
 
 fn main() -> Result<()> {
-	let _tracing_guard = tracing_profile::init_tracing().ok();
+	binius_examples::init_tracing();
 	let args = Args::parse();
 
 	// Read and deserialize constraint system

--- a/crates/examples/src/cli.rs
+++ b/crates/examples/src/cli.rs
@@ -559,41 +559,36 @@ where
 	/// Run the circuit with parsed ArgMatches (implementation).
 	#[allow(unused_variables)]
 	fn run_with_matches_impl(matches: clap::ArgMatches, circuit_name: &str) -> Result<()> {
-		// Initialize tracing once at the beginning for all commands
+		// Initialize tracing once at the beginning for all commands. In perfetto mode the
+		// returned guard must be held for the duration of the program to flush the trace.
+		#[cfg(feature = "perfetto")]
 		let _tracing_guard = {
-			#[cfg(feature = "perfetto")]
+			// Detect threading information
+			let thread_count = binius_utils::rayon::current_num_threads();
+			let thread_mode = if thread_count == 1 { "st" } else { "mt" };
+
+			let mut builder = tracing_profile::TraceFilenameBuilder::for_benchmark(circuit_name)
+				.output_dir("perfetto_traces")
+				.timestamp() // Add timestamp for uniqueness
+				.git_info() // Include git status
+				.platform() // Include OS info
+				.thread_mode(thread_mode);
+
+			// Try to extract params from the appropriate matches for richer context
+			// This will succeed for most commands (prove, stat, save, etc.)
+			// and fail gracefully for commands without params (like load-prove)
+			let matches_for_params = matches.subcommand().map(|(_, sub)| sub).unwrap_or(&matches);
+
+			if let Ok(params) = E::Params::from_arg_matches(matches_for_params)
+				&& let Some(param_summary) = E::param_summary(&params)
 			{
-				// Detect threading information
-				let thread_count = binius_utils::rayon::current_num_threads();
-				let thread_mode = if thread_count == 1 { "st" } else { "mt" };
-
-				let mut builder =
-					tracing_profile::TraceFilenameBuilder::for_benchmark(circuit_name)
-						.output_dir("perfetto_traces")
-						.timestamp() // Add timestamp for uniqueness
-						.git_info() // Include git status
-						.platform() // Include OS info
-						.thread_mode(thread_mode);
-
-				// Try to extract params from the appropriate matches for richer context
-				// This will succeed for most commands (prove, stat, save, etc.)
-				// and fail gracefully for commands without params (like load-prove)
-				let matches_for_params =
-					matches.subcommand().map(|(_, sub)| sub).unwrap_or(&matches);
-
-				if let Ok(params) = E::Params::from_arg_matches(matches_for_params)
-					&& let Some(param_summary) = E::param_summary(&params)
-				{
-					builder = builder.add("params", param_summary);
-				}
-
-				tracing_profile::init_tracing_with_builder(builder)?
+				builder = builder.add("params", param_summary);
 			}
-			#[cfg(not(feature = "perfetto"))]
-			{
-				tracing_profile::init_tracing()?
-			}
+
+			tracing_profile::init_tracing_with_builder(builder)?
 		};
+		#[cfg(not(feature = "perfetto"))]
+		crate::init_tracing();
 
 		// Check if a subcommand was used
 		match matches.subcommand() {

--- a/crates/examples/src/lib.rs
+++ b/crates/examples/src/lib.rs
@@ -22,6 +22,31 @@ use binius_verifier::{
 use clap::ValueEnum;
 pub use cli::Cli;
 use digest::Output;
+use tracing::level_filters::LevelFilter;
+use tracing_forest::ForestLayer;
+use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
+
+/// Initialize tracing with `tracing-forest`'s tree-formatted profiling output.
+///
+/// Installs a [`ForestLayer`], which prints a timing tree (span durations and their share of
+/// the total) for each root span as it closes. This replaces the human-readable
+/// `PrintTreeLayer` from `tracing-profile`.
+///
+/// Span verbosity defaults to `DEBUG` and can be overridden with `RUST_LOG`
+/// (e.g. `RUST_LOG=binius=trace`), matching the previous behavior.
+///
+/// Calling this when a global subscriber is already installed is a no-op, so it is safe to
+/// invoke from every example entry point.
+pub fn init_tracing() {
+	let env_filter = EnvFilter::builder()
+		.with_default_directive(LevelFilter::DEBUG.into())
+		.from_env_lossy();
+
+	let _ = tracing_subscriber::registry()
+		.with(env_filter)
+		.with(ForestLayer::default())
+		.try_init();
+}
 
 #[derive(Debug, Clone, ValueEnum)]
 pub enum CompressionType {


### PR DESCRIPTION
Resolves [BINIUS-74](https://linear.app/jimpo/issue/BINIUS-74/try-out-tracing-forest-instead-of-tracing-profile-printtreelayer).

## What this does

Swaps `tracing-profile`'s `PrintTreeLayer` for [`tracing-forest`](https://crates.io/crates/tracing-forest)'s `ForestLayer` for the **default (non-perfetto) human-readable profiling tree** in `binius-examples`. A new shared helper `binius_examples::init_tracing()` replaces the three direct `tracing_profile::init_tracing()` call sites (CLI, `prover` bin, `verifier` bin). The EnvFilter defaults to `DEBUG` and respects `RUST_LOG`, matching the previous verbosity.

**Perfetto mode is unchanged** — it still uses `tracing-profile` (`init_tracing_with_builder`), which exports the Perfetto trace *and* installs its own tree printer.

## Why forest

- **Dual `self% / total%` per node** (e.g. `0.33% / 100.00%`) — separates self-time from inclusive subtree time. `PrintTreeLayer` shows a single percentage. The most useful difference for profiling.
- **Cleaner event handling** — `info!`/`debug!` events render inline as `ｉ [info]: …` instead of `PrintTreeLayer`'s noisier `> event crates/examples/src/cli.rs:632 { message: … }: 1` lines.
- **Explicit `INFO`/`DEBUG` level column** on every line, so `RUST_LOG=…=info` can suppress the low-level (e.g. FRI) detail while keeping the phase tree.
- **Tree coherence under rayon held up** — span parentage is thread-local, so the risk was worker-thread spans detaching from the main-thread parent; in practice the prover's spans nested into one coherent tree.

## Follow-up

The default `Pretty` formatter loses two `PrintTreeLayer` niceties — blank lines between root spans, and `(N calls)`/`[...]` collapsing of negligible spans. Those are tracked in **[BINIUS-77](https://linear.app/jimpo/issue/BINIUS-77/custom-tracing-forest-formatter-for-examples-profiling-output)** (a custom `Formatter` over the same `ForestLayer`), out of scope here.

See the Linear issue for full `sha256` and `bip32` side-by-side output and discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)