### PR TITLE
feat(frontend): expose eval-form bytecode + value-vec accessors

### DIFF
--- a/crates/circuits/src/keccak/mod.rs
+++ b/crates/circuits/src/keccak/mod.rs
@@ -30,6 +30,13 @@ pub struct Keccak256 {
 }
 
 impl Keccak256 {
+	/// The padded-message witness wires (keccak padding applied; filled by
+	/// [`Self::populate_message`]). Exposed for external evaluators that fill the
+	/// witness without the frontend filler (mirrors the public `message`/`digest`).
+	pub fn padded_message(&self) -> &[Wire] {
+		&self.padded_message
+	}
+
 	/// Create a new keccak circuit using the circuit builder
 	///
 	/// # Arguments

--- a/crates/circuits/src/keccak/mod.rs
+++ b/crates/circuits/src/keccak/mod.rs
@@ -30,9 +30,7 @@ pub struct Keccak256 {
 }
 
 impl Keccak256 {
-	/// The padded-message witness wires (keccak padding applied; filled by
-	/// [`Self::populate_message`]). Exposed for external evaluators that fill the
-	/// witness without the frontend filler (mirrors the public `message`/`digest`).
+	/// Returns the padded-message witness wires (filled by [`Self::populate_message`]).
 	pub fn padded_message(&self) -> &[Wire] {
 		&self.padded_message
 	}

--- a/crates/frontend/src/compiler/circuit.rs
+++ b/crates/frontend/src/compiler/circuit.rs
@@ -47,6 +47,16 @@ impl<'a> WitnessFiller<'a> {
 	pub fn into_value_vec(self) -> ValueVec {
 		self.value_vec
 	}
+
+	/// Returns a reference to the underlying value vector.
+	pub fn value_vec(&self) -> &ValueVec {
+		&self.value_vec
+	}
+
+	/// Returns a mutable reference to the underlying value vector.
+	pub fn value_vec_mut(&mut self) -> &mut ValueVec {
+		&mut self.value_vec
+	}
 }
 
 impl<'a> std::ops::Index<Wire> for WitnessFiller<'a> {
@@ -145,6 +155,11 @@ impl Circuit {
 	/// Returns the constraint system for this circuit.
 	pub fn constraint_system(&self) -> &ConstraintSystem {
 		&self.constraint_system
+	}
+
+	/// Returns the evaluation form (witness-filling bytecode) for this circuit.
+	pub fn eval_form(&self) -> &EvalForm {
+		&self.eval_form
 	}
 
 	/// Returns the number of gates in this circuit.

--- a/crates/frontend/src/compiler/eval_form/mod.rs
+++ b/crates/frontend/src/compiler/eval_form/mod.rs
@@ -90,4 +90,9 @@ impl EvalForm {
 	pub fn n_eval_insn(&self) -> usize {
 		self.n_eval_insn
 	}
+
+	/// Returns the compiled evaluation bytecode.
+	pub fn bytecode(&self) -> &[u8] {
+		&self.bytecode
+	}
 }


### PR DESCRIPTION
Three read-only accessors, no behavioral change:

- `Circuit::eval_form() -> &EvalForm`
- `EvalForm::bytecode() -> &[u8]`
- `WitnessFiller::value_vec()` / `value_vec_mut() -> &/&mut ValueVec`

### Why
We build a fresh per-shape Binius64 circuit for almost every Ethereum block — proving the block's receipts trie is fully indexed — so `CircuitBuilder::build`'s constraint lowering dominates our prover time (~25 s at our circuit sizes). The lowering is needed only to drive `populate_wire_witness`; the witness fill itself is the `EvalForm` bytecode, which is a flat register program over value-vec indices and is composable per gadget.

Exposing the bytecode lets an external evaluator extract per-gadget eval programs once and replay them per block — skipping the lowering for repeated circuit shapes while staying byte-identical to the frontend. These accessors are the minimal surface needed; happy to adjust naming/visibility to your preference (e.g. behind a `cfg` or a dedicated trait) if you'd rather not widen the public API.
