### PR TITLE
secp256k1 multi-scalar multiplication gadget and ec_msm example (BINIUS-76)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        example: [ethsign, zklogin, sha256, sha512, keccak, blake2s, blake3_compress, hashsign]
+        example: [ethsign, zklogin, sha256, sha512, keccak, blake2s, blake3_compress, hashsign, ec_msm]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6

--- a/crates/circuits/src/ecdsa/scalar_mul.rs
+++ b/crates/circuits/src/ecdsa/scalar_mul.rs
@@ -1,9 +1,13 @@
+// Copyright 2026 The Binius Developers
 // Copyright 2025 Irreducible Inc.
-use binius_core::consts::WORD_SIZE_BITS;
+use std::iter;
+
+use binius_core::{consts::WORD_SIZE_BITS, word::Word};
 use binius_frontend::{CircuitBuilder, Wire};
 
 use crate::{
 	bignum::{BigUint, assert_eq, select as select_biguint},
+	multiplexer::multi_wire_multiplex,
 	secp256k1::{
 		N_LIMBS, Secp256k1, Secp256k1Affine, coord_lambda, coord_zero,
 		select as select_secp256k1_affine,
@@ -247,6 +251,202 @@ pub fn shamirs_trick_endomorphism(
 	acc
 }
 
+/// Compute a multi-scalar multiplication `Σ_i scalars[i] · points[i]` over secp256k1 using
+/// Shamir's trick combined with the curve endomorphism.
+///
+/// `n = points.len()` must equal `scalars.len()` and is statically known to the circuit. Each
+/// scalar is a 256-bit value (`N_LIMBS` limbs). Using the endomorphism `λ`, every
+/// `(point, scalar)` pair is split into two ~128-bit signed subscalars and two base points (`P`
+/// and `endo(P)`), each conditionally negated so that only positive subscalars remain. This
+/// yields `2n` base points, a `2^(2n)`-entry table of all their subset sums, and a main loop of
+/// just 128 conditional additions (versus 256 without the endomorphism — see [`msm_naive`]). It
+/// is the `n`-point generalization of [`shamirs_trick_endomorphism`] (which is the `n = 2` special
+/// case with the generator as one of the points).
+///
+/// The endomorphism halves the number of doublings at the cost of squaring the table size, so it
+/// wins for small `n` but is overtaken by [`msm_naive`] once the `2^(2n)` precomputation dominates.
+///
+/// # Completeness gap
+///
+/// Point additions use [`Secp256k1::add_incomplete`], which asserts false when its inputs are
+/// equal (it handles the point at infinity but not doubling). As with [`scalar_mul`] and
+/// [`shamirs_trick_endomorphism`], the probability of the accumulator or a table entry hitting
+/// such a collision for independent inputs is vanishingly low.
+///
+/// # Panics
+///
+/// Panics if `scalars.len() != points.len()`, if `n == 0`, or if any scalar does not have exactly
+/// `N_LIMBS` limbs.
+pub fn msm(
+	b: &CircuitBuilder,
+	curve: &Secp256k1,
+	scalars: &[BigUint],
+	points: &[Secp256k1Affine],
+) -> Secp256k1Affine {
+	let n = points.len();
+	assert_eq!(scalars.len(), n, "scalars and points must have the same length");
+	assert!(n >= 1, "MSM requires at least one point");
+
+	// Split every scalar via the endomorphism, collecting the 2n positive base points together
+	// with their 128-bit subscalar magnitudes (each is `[Wire; 2]`, little-endian).
+	let mut base_points = Vec::with_capacity(2 * n);
+	let mut subscalars = Vec::with_capacity(2 * n);
+	for (scalar, point) in iter::zip(scalars, points) {
+		assert_eq!(scalar.limbs.len(), N_LIMBS);
+
+		let (k1_neg, k2_neg, k1_abs, k2_abs) = b.secp256k1_endomorphism_split_hint(&scalar.limbs);
+		check_endomorphism_split(b, curve, k1_neg, k2_neg, k1_abs, k2_abs, scalar);
+
+		let point_endo = curve.endomorphism(b, point);
+		base_points.push(curve.negate_if(b, k1_neg, point));
+		subscalars.push(k1_abs);
+		base_points.push(curve.negate_if(b, k2_neg, &point_endo));
+		subscalars.push(k2_abs);
+	}
+
+	let subscalar_refs = subscalars
+		.iter()
+		.map(<[Wire; 2]>::as_slice)
+		.collect::<Vec<_>>();
+	// Each subscalar magnitude fits in 128 bits, so 128 conditional additions suffice.
+	shamir_accumulate(b, curve, &base_points, &subscalar_refs, 128)
+}
+
+/// Compute a multi-scalar multiplication `Σ_i scalars[i] · points[i]` over secp256k1 using
+/// Shamir's trick *without* the curve endomorphism.
+///
+/// `n = points.len()` must equal `scalars.len()` and is statically known to the circuit. Each
+/// scalar is a 256-bit value (`N_LIMBS` limbs). The `n` points are used directly as base points,
+/// giving a `2^n`-entry subset-sum table and a main loop of 256 conditional additions.
+///
+/// Compared to [`msm`], this trades twice as many doublings/additions for a quadratically smaller
+/// table. It is therefore the cheaper strategy once `n` is large enough that the endomorphism's
+/// `2^(2n)` precomputation dominates.
+///
+/// The completeness-gap caveat of [`msm`] applies here too.
+///
+/// # Panics
+///
+/// Panics if `scalars.len() != points.len()`, if `n == 0`, or if any scalar does not have exactly
+/// `N_LIMBS` limbs.
+pub fn msm_naive(
+	b: &CircuitBuilder,
+	curve: &Secp256k1,
+	scalars: &[BigUint],
+	points: &[Secp256k1Affine],
+) -> Secp256k1Affine {
+	let n = points.len();
+	assert_eq!(scalars.len(), n, "scalars and points must have the same length");
+	assert!(n >= 1, "MSM requires at least one point");
+	for scalar in scalars {
+		assert_eq!(scalar.limbs.len(), N_LIMBS);
+	}
+
+	let subscalar_refs = scalars
+		.iter()
+		.map(|s| s.limbs.as_slice())
+		.collect::<Vec<_>>();
+	// Full 256-bit scalars, so 256 conditional additions are required.
+	shamir_accumulate(b, curve, points, &subscalar_refs, 256)
+}
+
+/// Shared core of [`msm`] and [`msm_naive`]: double-and-add over `n_iters` bits, selecting at each
+/// step which subset sum of `base_points` to add via Shamir's trick.
+///
+/// Precomputes a `2^m`-entry table of all subset sums of the `m` base points
+/// (`table[mask] = Σ_{i : bit i of mask set} base_points[i]`), then for each bit position from
+/// `n_iters - 1` down to 0 doubles the accumulator and adds the subset sum selected by that bit of
+/// each subscalar. `subscalars[i]` supplies base point `i`'s exponent bit (it must have enough
+/// limbs to cover `n_iters` bits).
+///
+/// The per-iteration lookup uses [`multi_wire_multiplex`], indexing the flattened table by a
+/// selector word whose bit `i` is base point `i`'s current exponent bit — matching the table
+/// layout.
+fn shamir_accumulate(
+	b: &CircuitBuilder,
+	curve: &Secp256k1,
+	base_points: &[Secp256k1Affine],
+	subscalars: &[&[Wire]],
+	n_iters: usize,
+) -> Secp256k1Affine {
+	let m = base_points.len();
+	assert_eq!(subscalars.len(), m, "one subscalar per base point");
+	// The m exponent bits per iteration are packed into a single-word multiplexer selector.
+	assert!(
+		m < WORD_SIZE_BITS,
+		"Shamir's trick supports at most {} base points",
+		WORD_SIZE_BITS - 1
+	);
+
+	// Precompute the 2^m table of all subset sums of the base points.
+	let mut table = Vec::with_capacity(1 << m);
+	table.push(Secp256k1Affine::point_at_infinity(b));
+	for (i, pt) in base_points.iter().enumerate() {
+		table.push(pt.clone());
+		for j in 1..1 << i {
+			table.push(curve.add_incomplete(b, &table[j], pt));
+		}
+	}
+
+	// Flatten each table entry into its constituent wires so the lookup can use the multi-wire
+	// multiplexer, which selects across `2^m` groups using `m` bits of the selector word.
+	let table_flat: Vec<Vec<Wire>> = table.iter().map(point_to_wires).collect();
+	let table_refs: Vec<&[Wire]> = table_flat.iter().map(Vec::as_slice).collect();
+
+	let one = b.add_constant_64(1);
+	let mut acc = Secp256k1Affine::point_at_infinity(b);
+
+	for bit_index in (0..n_iters).rev() {
+		let limb = bit_index / WORD_SIZE_BITS;
+		let bit = bit_index % WORD_SIZE_BITS;
+
+		if bit_index != n_iters - 1 {
+			acc = curve.double(b, &acc);
+		}
+
+		// Build the multiplexer selector. `multi_wire_multiplex` uses selector bit `i` as bit `i`
+		// of the table index, so we place base point `i`'s current exponent bit at position `i`,
+		// matching the subset-sum table layout (`table[mask]` includes base `i` iff bit `i` set).
+		let mut sel = b.add_constant(Word::ZERO);
+		for (i, subscalar) in subscalars.iter().enumerate() {
+			let bit_val = b.band(b.shr(subscalar[limb], bit as u32), one);
+			sel = b.bor(sel, b.shl(bit_val, i as u32));
+		}
+
+		let selected = point_from_wires(&multi_wire_multiplex(b, &table_refs, sel));
+		acc = curve.add_incomplete(b, &acc, &selected);
+	}
+
+	acc
+}
+
+// Flatten an affine point into its constituent wires: x limbs, then y limbs, then the
+// point-at-infinity flag. Inverse of `point_from_wires`.
+fn point_to_wires(p: &Secp256k1Affine) -> Vec<Wire> {
+	assert_eq!(p.x.limbs.len(), N_LIMBS);
+	assert_eq!(p.y.limbs.len(), N_LIMBS);
+
+	let mut wires = Vec::with_capacity(2 * N_LIMBS + 1);
+	wires.extend_from_slice(&p.x.limbs);
+	wires.extend_from_slice(&p.y.limbs);
+	wires.push(p.is_point_at_infinity);
+	wires
+}
+
+// Reconstruct an affine point from the flat wire layout produced by `point_to_wires`.
+fn point_from_wires(wires: &[Wire]) -> Secp256k1Affine {
+	assert_eq!(wires.len(), 2 * N_LIMBS + 1);
+	Secp256k1Affine {
+		x: BigUint {
+			limbs: wires[..N_LIMBS].to_vec(),
+		},
+		y: BigUint {
+			limbs: wires[N_LIMBS..2 * N_LIMBS].to_vec(),
+		},
+		is_point_at_infinity: wires[2 * N_LIMBS],
+	}
+}
+
 // Constrain the return value of `CircuitBuilder::secp256k1_endomorphism_split_hint`.
 // Verifies that `k1 + λ k2 = k (mod n)` where `n` is scalar field modulus.
 fn check_endomorphism_split(
@@ -445,5 +645,99 @@ mod tests {
 
 		// Verify the point is not at infinity
 		assert_eq!(w[result.is_point_at_infinity], Word::ZERO);
+	}
+
+	type MsmFn = fn(&CircuitBuilder, &Secp256k1, &[BigUint], &[Secp256k1Affine]) -> Secp256k1Affine;
+
+	// Build an MSM circuit (using `msm_fn`) over `n` random (scalar, point) pairs derived from
+	// `seed`, compare the result against a k256-computed reference, and verify the witness
+	// populates successfully.
+	fn check_msm(msm_fn: MsmFn, n: usize, seed: u64) {
+		let builder = CircuitBuilder::new();
+		let curve = Secp256k1::new(&builder);
+		let mut rng = StdRng::seed_from_u64(seed);
+
+		let mut scalars = Vec::with_capacity(n);
+		let mut points = Vec::with_capacity(n);
+		let mut expected = ProjectivePoint::IDENTITY;
+
+		for _ in 0..n {
+			// Random 256-bit multiplier scalar.
+			let mut scalar_bytes = [0u8; 32];
+			rng.fill(&mut scalar_bytes);
+			let k256_scalar = Scalar::from_uint_unchecked(U256::from_be_slice(&scalar_bytes));
+
+			// Random curve point, generated as `g^r` so it is guaranteed on-curve.
+			let mut point_seed = [0u8; 32];
+			rng.fill(&mut point_seed);
+			let r = Scalar::from_uint_unchecked(U256::from_be_slice(&point_seed));
+			let point = ProjectivePoint::mul_by_generator(&r);
+
+			expected += point * k256_scalar;
+
+			let scalar_bigint = num_bigint::BigUint::from_bytes_be(&scalar_bytes);
+			scalars.push(
+				BigUint::new_constant(&builder, &scalar_bigint).zero_extend(&builder, N_LIMBS),
+			);
+
+			let point_bytes = point.to_affine().to_encoded_point(false).to_bytes();
+			let x_coord = num_bigint::BigUint::from_bytes_be(&point_bytes[1..33]);
+			let y_coord = num_bigint::BigUint::from_bytes_be(&point_bytes[33..65]);
+			points.push(Secp256k1Affine {
+				x: BigUint::new_constant(&builder, &x_coord).zero_extend(&builder, N_LIMBS),
+				y: BigUint::new_constant(&builder, &y_coord).zero_extend(&builder, N_LIMBS),
+				is_point_at_infinity: builder.add_constant(Word::ZERO),
+			});
+		}
+
+		let result = msm_fn(&builder, &curve, &scalars, &points);
+
+		let expected_bytes = expected.to_affine().to_encoded_point(false).to_bytes();
+		let expected_x = BigUint::new_constant(
+			&builder,
+			&num_bigint::BigUint::from_bytes_be(&expected_bytes[1..33]),
+		);
+		let expected_y = BigUint::new_constant(
+			&builder,
+			&num_bigint::BigUint::from_bytes_be(&expected_bytes[33..65]),
+		);
+
+		assert_eq(&builder, "msm_x", &result.x, &expected_x);
+		assert_eq(&builder, "msm_y", &result.y, &expected_y);
+
+		let cs = builder.build();
+		let mut w = cs.new_witness_filler();
+		assert!(cs.populate_wire_witness(&mut w).is_ok());
+		assert_eq!(w[result.is_point_at_infinity], Word::ZERO);
+	}
+
+	#[test]
+	fn test_msm_single_point() {
+		check_msm(msm, 1, 0);
+	}
+
+	#[test]
+	fn test_msm_two_points() {
+		check_msm(msm, 2, 1);
+	}
+
+	#[test]
+	fn test_msm_three_points() {
+		check_msm(msm, 3, 2);
+	}
+
+	#[test]
+	fn test_msm_naive_single_point() {
+		check_msm(msm_naive, 1, 0);
+	}
+
+	#[test]
+	fn test_msm_naive_two_points() {
+		check_msm(msm_naive, 2, 1);
+	}
+
+	#[test]
+	fn test_msm_naive_three_points() {
+		check_msm(msm_naive, 3, 2);
 	}
 }

--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -26,6 +26,8 @@ digest.workspace = true
 ethsign = "0.9.0"
 hex.workspace = true
 jwt-simple.workspace = true
+k256 = { workspace = true, features = ["arithmetic"] }
+num-bigint = { workspace = true }
 peakmem-alloc = "0.3.0"
 rand = { workspace = true, features = ["thread_rng"] }
 sha2.workspace = true

--- a/crates/examples/examples/ec_msm.rs
+++ b/crates/examples/examples/ec_msm.rs
@@ -1,0 +1,9 @@
+// Copyright 2026 The Binius Developers
+use anyhow::Result;
+use binius_examples::{Cli, circuits::ec_msm::EcMsmExample};
+
+fn main() -> Result<()> {
+	Cli::<EcMsmExample>::new("ec_msm")
+		.about("secp256k1 multi-scalar multiplication example")
+		.run()
+}

--- a/crates/examples/snapshots/ec_msm.snap
+++ b/crates/examples/snapshots/ec_msm.snap
@@ -1,0 +1,28 @@
+ec_msm circuit
+--
+Gates & Instructions
+├─ Number of gates: 218,836
+└─ Number of evaluation instructions: 261,449
+
+Constraints
+├─ AND constraints: 194,349 used (74.1% of 2^18)
+│  [▓▓▓▓▓▓▓░░░] spare: 67,795
+├─ MUL constraints: 19,026 used (58.1% of 2^15)
+│  [▓▓▓▓▓░░░░░] spare: 13,742
+└─ Distinct value indices: 404,300
+   ├─ Distinct shifted value indices: 184,448
+   └─ Distinct unshifted value indices: 219,852
+
+Value Vector
+├─ Public Section: 52 used (81.2% of 2^6)
+│  [▓▓▓▓▓▓▓▓░░] spare: 12
+│  ├─ Constants: 20
+│  └─ Inout: 32
+├─ Private Section: 219,805 used (83.9%)
+│  [▓▓▓▓▓▓▓▓░░] spare: 42,275
+│  ├─ Witness: 0
+│  └─ Internal: 219,805
+├─ Total Committed: 219,857 used (83.9% of 2^18)
+│  [▓▓▓▓▓▓▓▓░░] spare: 42,287
+└─ Scratch (uncommitted): 171,817
+

--- a/crates/examples/src/circuits/ec_msm.rs
+++ b/crates/examples/src/circuits/ec_msm.rs
@@ -1,0 +1,157 @@
+// Copyright 2026 The Binius Developers
+use std::iter;
+
+use anyhow::Result;
+use binius_circuits::{
+	bignum::{BigUint, assert_eq},
+	ecdsa::scalar_mul::{msm, msm_naive},
+	secp256k1::{N_LIMBS, Secp256k1, Secp256k1Affine},
+};
+use binius_core::word::Word;
+use binius_frontend::{CircuitBuilder, WitnessFiller};
+use clap::Args;
+use k256::{
+	ProjectivePoint, Scalar, U256,
+	elliptic_curve::{ops::MulByGenerator, scalar::FromUintUnchecked, sec1::ToEncodedPoint},
+};
+use rand::prelude::*;
+
+use crate::ExampleCircuit;
+
+/// Example circuit that computes a multi-scalar multiplication `Σ_i scalars[i] · points[i]` over
+/// secp256k1 with a statically-known number of points, using Shamir's trick combined with the
+/// curve endomorphism (see [`msm`]).
+///
+/// The points and scalars are public inputs (the points are constrained to lie on the curve), and
+/// the claimed result is a public input that the circuit checks against the in-circuit MSM.
+pub struct EcMsmExample {
+	scalars: Vec<BigUint>,
+	points: Vec<AffinePoint>,
+	expected: AffinePoint,
+}
+
+/// Public input wires for an affine secp256k1 point (assumed not to be the point at infinity).
+struct AffinePoint {
+	x: BigUint,
+	y: BigUint,
+}
+
+impl AffinePoint {
+	fn new_inout(builder: &mut CircuitBuilder) -> Self {
+		Self {
+			x: BigUint::new_inout(builder, N_LIMBS),
+			y: BigUint::new_inout(builder, N_LIMBS),
+		}
+	}
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct Params {
+	/// Number of (scalar, point) pairs in the multi-scalar multiplication
+	#[arg(short = 'n', long, default_value_t = 2, value_parser = clap::value_parser!(u16).range(1..))]
+	pub n_points: u16,
+	/// Use plain Shamir's trick (2^n table, 256 adds) instead of the endomorphism-split variant
+	#[arg(long, default_value_t = false)]
+	pub no_endomorphism: bool,
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct Instance {}
+
+impl ExampleCircuit for EcMsmExample {
+	type Params = Params;
+	type Instance = Instance;
+
+	fn build(params: Params, builder: &mut CircuitBuilder) -> Result<Self> {
+		let n_points = params.n_points as usize;
+		let curve = Secp256k1::new(builder);
+
+		let scalars = (0..n_points)
+			.map(|_| BigUint::new_inout(builder, N_LIMBS))
+			.collect::<Vec<_>>();
+		let points = (0..n_points)
+			.map(|_| AffinePoint::new_inout(builder))
+			.collect::<Vec<_>>();
+
+		// Build affine inputs and constrain each to be a valid curve point.
+		let affine_points = points
+			.iter()
+			.map(|p| {
+				let point = Secp256k1Affine {
+					x: p.x.clone(),
+					y: p.y.clone(),
+					is_point_at_infinity: builder.add_constant(Word::ZERO),
+				};
+				curve.assert_on_curve(builder, &point);
+				point
+			})
+			.collect::<Vec<_>>();
+
+		let result = if params.no_endomorphism {
+			msm_naive(builder, &curve, &scalars, &affine_points)
+		} else {
+			msm(builder, &curve, &scalars, &affine_points)
+		};
+
+		let expected = AffinePoint::new_inout(builder);
+		assert_eq(builder, "msm_result_x", &result.x, &expected.x);
+		assert_eq(builder, "msm_result_y", &result.y, &expected.y);
+
+		Ok(Self {
+			scalars,
+			points,
+			expected,
+		})
+	}
+
+	fn populate_witness(&self, _instance: Instance, w: &mut WitnessFiller) -> Result<()> {
+		let mut rng = StdRng::seed_from_u64(42);
+		let mut expected = ProjectivePoint::IDENTITY;
+
+		for (scalar, point) in iter::zip(&self.scalars, &self.points) {
+			// Random 256-bit multiplier scalar.
+			let mut scalar_bytes = [0u8; 32];
+			rng.fill(&mut scalar_bytes);
+			let k256_scalar = Scalar::from_uint_unchecked(U256::from_be_slice(&scalar_bytes));
+
+			// Random curve point, generated as `g^r` so that it is guaranteed on-curve.
+			let mut point_seed = [0u8; 32];
+			rng.fill(&mut point_seed);
+			let r = Scalar::from_uint_unchecked(U256::from_be_slice(&point_seed));
+			let p = ProjectivePoint::mul_by_generator(&r);
+			expected += p * k256_scalar;
+
+			scalar.populate_limbs(w, &le_limbs(&num_bigint::BigUint::from_bytes_be(&scalar_bytes)));
+			populate_point(w, &p, &point.x, &point.y);
+		}
+
+		populate_point(w, &expected, &self.expected.x, &self.expected.y);
+
+		Ok(())
+	}
+
+	fn param_summary(params: &Self::Params) -> Option<String> {
+		let strategy = if params.no_endomorphism {
+			"naive"
+		} else {
+			"endo"
+		};
+		Some(format!("{}p-{strategy}", params.n_points))
+	}
+}
+
+/// Populate the `x` and `y` limb wires from a k256 projective point's affine coordinates.
+fn populate_point(w: &mut WitnessFiller, p: &ProjectivePoint, x: &BigUint, y: &BigUint) {
+	let bytes = p.to_affine().to_encoded_point(false).to_bytes();
+	// Uncompressed SEC1 encoding: `0x04 || x (32 bytes) || y (32 bytes)`.
+	x.populate_limbs(w, &le_limbs(&num_bigint::BigUint::from_bytes_be(&bytes[1..33])));
+	y.populate_limbs(w, &le_limbs(&num_bigint::BigUint::from_bytes_be(&bytes[33..65])));
+}
+
+/// Decompose a big integer into exactly `N_LIMBS` little-endian 64-bit limbs (zero-padded).
+fn le_limbs(value: &num_bigint::BigUint) -> Vec<u64> {
+	let mut limbs = value.to_u64_digits();
+	assert!(limbs.len() <= N_LIMBS, "value exceeds {N_LIMBS} limbs");
+	limbs.resize(N_LIMBS, 0);
+	limbs
+}

--- a/crates/examples/src/circuits/mod.rs
+++ b/crates/examples/src/circuits/mod.rs
@@ -1,3 +1,4 @@
+// Copyright 2026 The Binius Developers
 // Copyright 2025 Irreducible Inc.
 pub mod bip32;
 pub mod bitcoin_block_contains_transaction;
@@ -6,6 +7,7 @@ pub mod bitcoin_p2pkh;
 pub mod blake2b;
 pub mod blake2s;
 pub mod blake3_compress;
+pub mod ec_msm;
 pub mod ethsign;
 pub mod hashsign;
 pub mod keccak;


### PR DESCRIPTION
## Summary

Adds a general **multi-scalar multiplication (MSM)** gadget for secp256k1 — `Σ_i scalars[i] · points[i]` over `n` statically-known points with 256-bit scalars — plus an `ec_msm` example that exercises it.

Resolves [BINIUS-76](https://linear.app/jimpo/issue/BINIUS-76/msm-circuit-for-secp256k1).

## Approach

The gadget uses Shamir's trick combined with the curve endomorphism. Each `(point, scalar)` pair is endomorphism-split into two ~128-bit signed subscalars and two base points (`P` and `endo(P)`), conditionally negated to positive subscalars. This yields `2n` base points, a `2^(2n)`-entry table of all their subset sums, and a main loop of just **128** conditional additions (instead of 256). It is the `n`-point generalization of the existing `shamirs_trick_endomorphism` (which is the `n = 2`, generator-as-one-point special case).

Each loop iteration's subset-sum lookup is done with the `multi_wire_multiplex` gadget: the `2n` exponent bits are packed into a single-word selector that indexes the flattened table — replacing the inlined point-selection trees used by the existing routines (per the standing `TODO` in `scalar_mul.rs`).

## Commits

1. **Add secp256k1 n-point MSM gadget** — `msm()` in `ecdsa::scalar_mul`, with unit tests comparing against `k256` for `n = 1, 2, 3`.
2. **Add ec_msm example circuit** — public points + scalars + claimed result; the circuit constrains each input point on-curve and checks the in-circuit MSM. Default `-n 2`; on-curve points and scalars generated from a seeded RNG, reference result computed with `k256`.

## Testing

- `cargo test -p binius-circuits --lib ecdsa::scalar_mul` — passes (`msm` n=1/2/3 plus existing routines).
- `cargo run --release -p binius-examples --example ec_msm -- prove` proves and verifies for `n = 1, 2, 3`.
- `cargo +nightly-2026-01-01 fmt --check` and crate-scoped `cargo clippy ... -D warnings` clean.
- Snapshot blessed for `ec_msm` (default `n = 2`).

## Notes

As with `scalar_mul`/`shamirs_trick_endomorphism`, the additions use `add_incomplete`, leaving the same vanishingly-low-probability completeness gap on a doubling collision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
