### PR TITLE
secp256k1 Straus fixed-window MSM gadget (BINIUS-76)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        example: [ethsign, zklogin, sha256, sha512, keccak, blake2s, blake3_compress, hashsign]
+        example: [ethsign, zklogin, sha256, sha512, keccak, blake2s, blake3_compress, hashsign, ec_msm]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6

--- a/crates/circuits/src/ecdsa/scalar_mul.rs
+++ b/crates/circuits/src/ecdsa/scalar_mul.rs
@@ -1,9 +1,11 @@
+// Copyright 2026 The Binius Developers
 // Copyright 2025 Irreducible Inc.
-use binius_core::consts::WORD_SIZE_BITS;
+use binius_core::{consts::WORD_SIZE_BITS, word::Word};
 use binius_frontend::{CircuitBuilder, Wire};
 
 use crate::{
 	bignum::{BigUint, assert_eq, select as select_biguint},
+	multiplexer::multi_wire_multiplex,
 	secp256k1::{
 		N_LIMBS, Secp256k1, Secp256k1Affine, coord_lambda, coord_zero,
 		select as select_secp256k1_affine,
@@ -339,6 +341,252 @@ pub fn shamirs_trick_naive(
 	acc
 }
 
+/// Compute a multi-scalar multiplication `Σ_i scalars[i] · points[i]` over secp256k1 using the
+/// fixed-window (Straus) algorithm.
+///
+/// `n = points.len()` must equal `scalars.len()`; both `n` and the window size `window` (in bits)
+/// are statically known to the circuit. Each scalar is a 256-bit value (`N_LIMBS` limbs).
+///
+/// For each point `P_i` a table of its `2^window` small multiples `{0·P_i, …, (2^window − 1)·P_i}`
+/// is precomputed. The exponents are then consumed `window` bits at a time from the most
+/// significant window down: at each of the `ceil(256 / window)` steps every point contributes the
+/// multiple selected by its current window (via [`multi_wire_multiplex`]), and the accumulator is
+/// doubled `window` times *between* steps (skipped on the first window). Unlike Shamir's trick, the
+/// total table size is `n · 2^window` — linear in `n` — so it scales to larger `n`.
+///
+/// `window = 4` is typically optimal. A window of 1 degenerates to a per-point double-and-add
+/// sharing the doublings. See [`msm_strauss_endo`] for the GLV-endomorphism variant.
+///
+/// # Completeness gap
+///
+/// Point additions use [`Secp256k1::add_incomplete`], which asserts false when its inputs are equal
+/// (it handles the point at infinity but not doubling). As with the other routines here, the
+/// probability of the accumulator or a table entry hitting such a collision for independent inputs
+/// is vanishingly low.
+///
+/// # Panics
+///
+/// Panics if `scalars.len() != points.len()`, if `n == 0`, if `window` is not in
+/// `1..WORD_SIZE_BITS`, or if any scalar does not have exactly `N_LIMBS` limbs.
+pub fn msm_strauss(
+	b: &CircuitBuilder,
+	curve: &Secp256k1,
+	window: usize,
+	scalars: &[BigUint],
+	points: &[Secp256k1Affine],
+) -> Secp256k1Affine {
+	let n = points.len();
+	assert_eq!(scalars.len(), n, "scalars and points must have the same length");
+	assert!(n >= 1, "MSM requires at least one point");
+	assert!(0 < window && window < WORD_SIZE_BITS, "window must be in 1..WORD_SIZE_BITS");
+	for scalar in scalars {
+		assert_eq!(scalar.limbs.len(), N_LIMBS);
+	}
+
+	// Use each point directly as a base point and its full 256-bit scalar as the exponent.
+	let tables = points
+		.iter()
+		.map(|point| build_strauss_table(b, curve, point, window))
+		.collect::<Vec<_>>();
+	let subscalars = scalars
+		.iter()
+		.map(|s| s.limbs.as_slice())
+		.collect::<Vec<_>>();
+	strauss_accumulate(b, curve, &tables, &subscalars, window, N_LIMBS * WORD_SIZE_BITS)
+}
+
+/// Compute a multi-scalar multiplication `Σ_i scalars[i] · points[i]` over secp256k1 using the
+/// fixed-window (Straus) algorithm combined with the GLV endomorphism.
+///
+/// Every `(scalar, point)` pair is endomorphism-split into two ~128-bit signed subscalars and two
+/// base points (`P` and `endo(P)`, conditionally negated to positive subscalars), so the `n`-point
+/// 256-bit MSM becomes a `2n`-point 128-bit one. Relative to [`msm_strauss`] this halves the number
+/// of doublings (128 vs 256) and the windows per point, while doubling the number of small-multiple
+/// tables and adding one endomorphism-split constraint per scalar.
+///
+/// The `φ(P)` table is *not* recomputed with point additions: since `φ` is a homomorphism,
+/// `φ(P)`'s small multiples are `φ` applied to `P`'s small multiples (`x · φ(P) = φ(x · P)`), i.e.
+/// one field multiplication of each entry's x-coordinate by `β` rather than another
+/// `2^window`-entry point-addition chain.
+///
+/// The window-lookup count and addition count are unchanged versus plain [`msm_strauss`]; the win
+/// is the halved doubling chain. `window = 4` is typically optimal. The completeness-gap caveat of
+/// [`msm_strauss`] applies here too.
+///
+/// # Panics
+///
+/// Panics if `scalars.len() != points.len()`, if `n == 0`, if `window` is not in
+/// `1..WORD_SIZE_BITS`, or if any scalar does not have exactly `N_LIMBS` limbs.
+pub fn msm_strauss_endo(
+	b: &CircuitBuilder,
+	curve: &Secp256k1,
+	window: usize,
+	scalars: &[BigUint],
+	points: &[Secp256k1Affine],
+) -> Secp256k1Affine {
+	let n = points.len();
+	assert_eq!(scalars.len(), n, "scalars and points must have the same length");
+	assert!(n >= 1, "MSM requires at least one point");
+	assert!(0 < window && window < WORD_SIZE_BITS, "window must be in 1..WORD_SIZE_BITS");
+
+	// Split each scalar via the endomorphism into two base points (`±P`, `±φ(P)`) with 128-bit
+	// subscalars. Build `±P`'s table with point additions, then derive `±φ(P)`'s table by applying
+	// `φ` entrywise rather than recomputing it.
+	let mut tables = Vec::with_capacity(2 * n);
+	let mut subscalars = Vec::with_capacity(2 * n);
+	for (scalar, point) in scalars.iter().zip(points) {
+		assert_eq!(scalar.limbs.len(), N_LIMBS);
+
+		let (k1_neg, k2_neg, k1_abs, k2_abs) = b.secp256k1_endomorphism_split_hint(&scalar.limbs);
+		check_endomorphism_split(b, curve, k1_neg, k2_neg, k1_abs, k2_abs, scalar);
+
+		// Table for the (possibly negated) base point `±P`, built with point additions.
+		let base = curve.negate_if(b, k1_neg, point);
+		let table_p = build_strauss_table(b, curve, &base, window);
+
+		// Table for `±φ(P)`: `φ(x · P) = x · φ(P)`, so apply `φ` to each entry. `φ` commutes with
+		// negation, so the only correction is the relative sign of the two subscalars.
+		let rel_neg = b.bxor(k1_neg, k2_neg);
+		let table_phi = table_p
+			.iter()
+			.map(|q| {
+				let phi = curve.endomorphism(b, q);
+				curve.negate_if(b, rel_neg, &phi)
+			})
+			.collect::<Vec<_>>();
+
+		tables.push(table_p);
+		subscalars.push(k1_abs);
+		tables.push(table_phi);
+		subscalars.push(k2_abs);
+	}
+
+	let subscalar_refs = subscalars
+		.iter()
+		.map(<[Wire; 2]>::as_slice)
+		.collect::<Vec<_>>();
+	// Each endomorphism subscalar magnitude fits in 128 bits.
+	strauss_accumulate(b, curve, &tables, &subscalar_refs, window, 128)
+}
+
+/// Build the table of small multiples `{0·P, 1·P, …, (2^window − 1)·P}` of a base point.
+///
+/// `table[2]` is a doubling (`add_incomplete` rejects equal inputs); every larger multiple is the
+/// previous one plus `P`.
+fn build_strauss_table(
+	b: &CircuitBuilder,
+	curve: &Secp256k1,
+	point: &Secp256k1Affine,
+	window: usize,
+) -> Vec<Secp256k1Affine> {
+	let mut table = Vec::with_capacity(1 << window);
+	table.push(Secp256k1Affine::point_at_infinity(b));
+	table.push(point.clone());
+	for x in 2..1 << window {
+		let multiple = if x == 2 {
+			curve.double(b, point)
+		} else {
+			curve.add_incomplete(b, &table[x - 1], point)
+		};
+		table.push(multiple);
+	}
+	table
+}
+
+/// Shared core of [`msm_strauss`] and [`msm_strauss_endo`]: fixed-window double-and-add over the
+/// `m = tables.len()` base points whose `2^window`-entry small-multiple `tables` are precomputed
+/// and whose exponents (`subscalars[i]`, bounded by `exponent_bits`) are consumed `window` bits at
+/// a time.
+///
+/// At each of the `ceil(exponent_bits / window)` steps every base point contributes the multiple
+/// selected by its current window (via [`multi_wire_multiplex`]), and the accumulator is doubled
+/// `window` times between steps (skipped on the first, most-significant window).
+fn strauss_accumulate(
+	b: &CircuitBuilder,
+	curve: &Secp256k1,
+	tables: &[Vec<Secp256k1Affine>],
+	subscalars: &[&[Wire]],
+	window: usize,
+	exponent_bits: usize,
+) -> Secp256k1Affine {
+	assert_eq!(subscalars.len(), tables.len(), "one subscalar per base point");
+
+	// Flatten each table entry into its constituent wires for the multi-wire multiplexer.
+	let tables_flat: Vec<Vec<Vec<Wire>>> = tables
+		.iter()
+		.map(|table| table.iter().map(point_to_wires).collect())
+		.collect();
+	let table_refs: Vec<Vec<&[Wire]>> = tables_flat
+		.iter()
+		.map(|table| table.iter().map(Vec::as_slice).collect())
+		.collect();
+
+	let one = b.add_constant_64(1);
+	let n_windows = exponent_bits.div_ceil(window);
+	let mut acc = Secp256k1Affine::point_at_infinity(b);
+
+	for w_idx in (0..n_windows).rev() {
+		// Double `window` times between windows (skipped on the first, most-significant window so
+		// the result is not over-multiplied by `2^window`).
+		if w_idx != n_windows - 1 {
+			for _ in 0..window {
+				acc = curve.double(b, &acc);
+			}
+		}
+
+		let base_bit = w_idx * window;
+		for (point_idx, subscalar) in subscalars.iter().enumerate() {
+			// Pack this base point's `window`-bit exponent chunk into a selector word, bit by bit
+			// so that windows crossing 64-bit limb boundaries (and bit positions past
+			// `exponent_bits`) are handled uniformly. `multi_wire_multiplex` reads selector bit
+			// `j` as bit `j` of the table index, matching `table[x] = x · P`.
+			let mut sel = b.add_constant(Word::ZERO);
+			for j in 0..window {
+				let bit_index = base_bit + j;
+				if bit_index >= exponent_bits {
+					continue; // past the top of the exponent — contributes a zero bit
+				}
+				let limb = bit_index / WORD_SIZE_BITS;
+				let bit = bit_index % WORD_SIZE_BITS;
+				let bit_val = b.band(b.shr(subscalar[limb], bit as u32), one);
+				sel = b.bor(sel, b.shl(bit_val, j as u32));
+			}
+
+			let selected = point_from_wires(&multi_wire_multiplex(b, &table_refs[point_idx], sel));
+			acc = curve.add_incomplete(b, &acc, &selected);
+		}
+	}
+
+	acc
+}
+
+// Flatten an affine point into its constituent wires: x limbs, then y limbs, then the
+// point-at-infinity flag. Inverse of `point_from_wires`.
+fn point_to_wires(p: &Secp256k1Affine) -> Vec<Wire> {
+	assert_eq!(p.x.limbs.len(), N_LIMBS);
+	assert_eq!(p.y.limbs.len(), N_LIMBS);
+
+	let mut wires = Vec::with_capacity(2 * N_LIMBS + 1);
+	wires.extend_from_slice(&p.x.limbs);
+	wires.extend_from_slice(&p.y.limbs);
+	wires.push(p.is_point_at_infinity);
+	wires
+}
+
+// Reconstruct an affine point from the flat wire layout produced by `point_to_wires`.
+fn point_from_wires(wires: &[Wire]) -> Secp256k1Affine {
+	assert_eq!(wires.len(), 2 * N_LIMBS + 1);
+	Secp256k1Affine {
+		x: BigUint {
+			limbs: wires[..N_LIMBS].to_vec(),
+		},
+		y: BigUint {
+			limbs: wires[N_LIMBS..2 * N_LIMBS].to_vec(),
+		},
+		is_point_at_infinity: wires[2 * N_LIMBS],
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use binius_core::word::Word;
@@ -445,5 +693,107 @@ mod tests {
 
 		// Verify the point is not at infinity
 		assert_eq!(w[result.is_point_at_infinity], Word::ZERO);
+	}
+
+	type StraussFn =
+		fn(&CircuitBuilder, &Secp256k1, usize, &[BigUint], &[Secp256k1Affine]) -> Secp256k1Affine;
+
+	// Build a Straus MSM circuit (using `msm_fn` with the given `window`) over `n` random
+	// (scalar, point) pairs derived from `seed`, compare against a k256 reference, and verify the
+	// witness populates.
+	fn check_msm_strauss(msm_fn: StraussFn, window: usize, n: usize, seed: u64) {
+		let builder = CircuitBuilder::new();
+		let curve = Secp256k1::new(&builder);
+		let mut rng = StdRng::seed_from_u64(seed);
+
+		let mut scalars = Vec::with_capacity(n);
+		let mut points = Vec::with_capacity(n);
+		let mut expected = ProjectivePoint::IDENTITY;
+
+		for _ in 0..n {
+			let mut scalar_bytes = [0u8; 32];
+			rng.fill(&mut scalar_bytes);
+			let k256_scalar = Scalar::from_uint_unchecked(U256::from_be_slice(&scalar_bytes));
+
+			// Random curve point, generated as `g^r` so it is guaranteed on-curve.
+			let mut point_seed = [0u8; 32];
+			rng.fill(&mut point_seed);
+			let r = Scalar::from_uint_unchecked(U256::from_be_slice(&point_seed));
+			let point = ProjectivePoint::mul_by_generator(&r);
+			expected += point * k256_scalar;
+
+			let scalar_bigint = num_bigint::BigUint::from_bytes_be(&scalar_bytes);
+			scalars.push(
+				BigUint::new_constant(&builder, &scalar_bigint).zero_extend(&builder, N_LIMBS),
+			);
+
+			let point_bytes = point.to_affine().to_encoded_point(false).to_bytes();
+			let x_coord = num_bigint::BigUint::from_bytes_be(&point_bytes[1..33]);
+			let y_coord = num_bigint::BigUint::from_bytes_be(&point_bytes[33..65]);
+			points.push(Secp256k1Affine {
+				x: BigUint::new_constant(&builder, &x_coord).zero_extend(&builder, N_LIMBS),
+				y: BigUint::new_constant(&builder, &y_coord).zero_extend(&builder, N_LIMBS),
+				is_point_at_infinity: builder.add_constant(Word::ZERO),
+			});
+		}
+
+		let result = msm_fn(&builder, &curve, window, &scalars, &points);
+
+		let expected_bytes = expected.to_affine().to_encoded_point(false).to_bytes();
+		let expected_x = BigUint::new_constant(
+			&builder,
+			&num_bigint::BigUint::from_bytes_be(&expected_bytes[1..33]),
+		);
+		let expected_y = BigUint::new_constant(
+			&builder,
+			&num_bigint::BigUint::from_bytes_be(&expected_bytes[33..65]),
+		);
+
+		assert_eq(&builder, "msm_x", &result.x, &expected_x);
+		assert_eq(&builder, "msm_y", &result.y, &expected_y);
+
+		let cs = builder.build();
+		let mut w = cs.new_witness_filler();
+		assert!(cs.populate_wire_witness(&mut w).is_ok());
+		assert_eq!(w[result.is_point_at_infinity], Word::ZERO);
+	}
+
+	// Window of 2 divides both 64 and 256, so windows never cross a limb boundary.
+	#[test]
+	fn test_msm_strauss_window2() {
+		check_msm_strauss(msm_strauss, 2, 1, 0);
+		check_msm_strauss(msm_strauss, 2, 2, 1);
+		check_msm_strauss(msm_strauss, 2, 3, 2);
+	}
+
+	// Window of 3 does not divide 64, so windows cross limb boundaries and the top window reads
+	// past bit 255 — exercising both the cross-limb extraction and the out-of-range bit guard.
+	#[test]
+	fn test_msm_strauss_window3() {
+		check_msm_strauss(msm_strauss, 3, 1, 3);
+		check_msm_strauss(msm_strauss, 3, 2, 4);
+		check_msm_strauss(msm_strauss, 3, 3, 5);
+	}
+
+	// A window of 1 degenerates to plain double-and-add with shared doublings.
+	#[test]
+	fn test_msm_strauss_window1() {
+		check_msm_strauss(msm_strauss, 1, 2, 6);
+	}
+
+	// GLV variant: the 128-bit subscalars mean window 3 (43 windows → 129 bits) still exercises the
+	// cross-limb extraction and out-of-range guard, now at the 128-bit boundary.
+	#[test]
+	fn test_msm_strauss_endo_window2() {
+		check_msm_strauss(msm_strauss_endo, 2, 1, 7);
+		check_msm_strauss(msm_strauss_endo, 2, 2, 8);
+		check_msm_strauss(msm_strauss_endo, 2, 3, 9);
+	}
+
+	#[test]
+	fn test_msm_strauss_endo_window3() {
+		check_msm_strauss(msm_strauss_endo, 3, 1, 10);
+		check_msm_strauss(msm_strauss_endo, 3, 2, 11);
+		check_msm_strauss(msm_strauss_endo, 3, 3, 12);
 	}
 }

--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -26,6 +26,8 @@ digest.workspace = true
 ethsign = "0.9.0"
 hex.workspace = true
 jwt-simple.workspace = true
+k256 = { workspace = true, features = ["arithmetic"] }
+num-bigint = { workspace = true }
 peakmem-alloc = "0.3.0"
 rand = { workspace = true, features = ["thread_rng"] }
 sha2.workspace = true

--- a/crates/examples/examples/ec_msm.rs
+++ b/crates/examples/examples/ec_msm.rs
@@ -1,0 +1,9 @@
+// Copyright 2026 The Binius Developers
+use anyhow::Result;
+use binius_examples::{Cli, circuits::ec_msm::EcMsmExample};
+
+fn main() -> Result<()> {
+	Cli::<EcMsmExample>::new("ec_msm")
+		.about("secp256k1 multi-scalar multiplication example (Straus fixed-window)")
+		.run()
+}

--- a/crates/examples/snapshots/ec_msm.snap
+++ b/crates/examples/snapshots/ec_msm.snap
@@ -1,0 +1,28 @@
+ec_msm circuit
+--
+Gates & Instructions
+├─ Number of gates: 388,484
+└─ Number of evaluation instructions: 470,550
+
+Constraints
+├─ AND constraints: 342,876 used (65.4% of 2^19)
+│  [▓▓▓▓▓▓░░░░] spare: 181,412
+├─ MUL constraints: 36,596 used (55.8% of 2^16)
+│  [▓▓▓▓▓░░░░░] spare: 28,940
+└─ Distinct value indices: 741,282
+   ├─ Distinct shifted value indices: 349,406
+   └─ Distinct unshifted value indices: 391,876
+
+Value Vector
+├─ Public Section: 44 used (68.8% of 2^6)
+│  [▓▓▓▓▓▓░░░░] spare: 20
+│  ├─ Constants: 12
+│  └─ Inout: 32
+├─ Private Section: 391,838 used (74.7%)
+│  [▓▓▓▓▓▓▓░░░] spare: 132,386
+│  ├─ Witness: 0
+│  └─ Internal: 391,838
+├─ Total Committed: 391,882 used (74.7% of 2^19)
+│  [▓▓▓▓▓▓▓░░░] spare: 132,406
+└─ Scratch (uncommitted): 329,242
+

--- a/crates/examples/src/circuits/ec_msm.rs
+++ b/crates/examples/src/circuits/ec_msm.rs
@@ -1,0 +1,157 @@
+// Copyright 2026 The Binius Developers
+use std::iter;
+
+use anyhow::Result;
+use binius_circuits::{
+	bignum::{BigUint, assert_eq},
+	ecdsa::scalar_mul::{msm_strauss, msm_strauss_endo},
+	secp256k1::{N_LIMBS, Secp256k1, Secp256k1Affine},
+};
+use binius_core::word::Word;
+use binius_frontend::{CircuitBuilder, WitnessFiller};
+use clap::Args;
+use k256::{
+	ProjectivePoint, Scalar, U256,
+	elliptic_curve::{ops::MulByGenerator, scalar::FromUintUnchecked, sec1::ToEncodedPoint},
+};
+use rand::prelude::*;
+
+use crate::ExampleCircuit;
+
+/// Example circuit that computes a multi-scalar multiplication `Σ_i scalars[i] · points[i]` over
+/// secp256k1 with a statically-known number of points, using the fixed-window (Straus) algorithm
+/// (see [`msm_strauss`]).
+///
+/// The points and scalars are public inputs (the points are constrained to lie on the curve), and
+/// the claimed result is a public input that the circuit checks against the in-circuit MSM.
+pub struct EcMsmExample {
+	scalars: Vec<BigUint>,
+	points: Vec<AffinePoint>,
+	expected: AffinePoint,
+}
+
+/// Public input wires for an affine secp256k1 point (assumed not to be the point at infinity).
+struct AffinePoint {
+	x: BigUint,
+	y: BigUint,
+}
+
+impl AffinePoint {
+	fn new_inout(builder: &mut CircuitBuilder) -> Self {
+		Self {
+			x: BigUint::new_inout(builder, N_LIMBS),
+			y: BigUint::new_inout(builder, N_LIMBS),
+		}
+	}
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct Params {
+	/// Number of (scalar, point) pairs in the multi-scalar multiplication
+	#[arg(short = 'n', long, default_value_t = 2, value_parser = clap::value_parser!(u16).range(1..))]
+	pub n_points: u16,
+	/// Window size in bits for the Straus algorithm (4 is typically optimal)
+	#[arg(short = 'w', long, default_value_t = 2, value_parser = clap::value_parser!(u16).range(1..64))]
+	pub window: u16,
+	/// Combine Straus with the GLV endomorphism (2n base points, 128-bit exponents)
+	#[arg(short = 'e', long, default_value_t = false)]
+	pub endomorphism: bool,
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct Instance {}
+
+impl ExampleCircuit for EcMsmExample {
+	type Params = Params;
+	type Instance = Instance;
+
+	fn build(params: Params, builder: &mut CircuitBuilder) -> Result<Self> {
+		let n_points = params.n_points as usize;
+		let curve = Secp256k1::new(builder);
+
+		let scalars = (0..n_points)
+			.map(|_| BigUint::new_inout(builder, N_LIMBS))
+			.collect::<Vec<_>>();
+		let points = (0..n_points)
+			.map(|_| AffinePoint::new_inout(builder))
+			.collect::<Vec<_>>();
+
+		// Build affine inputs and constrain each to be a valid curve point.
+		let affine_points = points
+			.iter()
+			.map(|p| {
+				let point = Secp256k1Affine {
+					x: p.x.clone(),
+					y: p.y.clone(),
+					is_point_at_infinity: builder.add_constant(Word::ZERO),
+				};
+				curve.assert_on_curve(builder, &point);
+				point
+			})
+			.collect::<Vec<_>>();
+
+		let window = params.window as usize;
+		let result = if params.endomorphism {
+			msm_strauss_endo(builder, &curve, window, &scalars, &affine_points)
+		} else {
+			msm_strauss(builder, &curve, window, &scalars, &affine_points)
+		};
+
+		let expected = AffinePoint::new_inout(builder);
+		assert_eq(builder, "msm_result_x", &result.x, &expected.x);
+		assert_eq(builder, "msm_result_y", &result.y, &expected.y);
+
+		Ok(Self {
+			scalars,
+			points,
+			expected,
+		})
+	}
+
+	fn populate_witness(&self, _instance: Instance, w: &mut WitnessFiller) -> Result<()> {
+		let mut rng = StdRng::seed_from_u64(42);
+		let mut expected = ProjectivePoint::IDENTITY;
+
+		for (scalar, point) in iter::zip(&self.scalars, &self.points) {
+			// Random 256-bit multiplier scalar.
+			let mut scalar_bytes = [0u8; 32];
+			rng.fill(&mut scalar_bytes);
+			let k256_scalar = Scalar::from_uint_unchecked(U256::from_be_slice(&scalar_bytes));
+
+			// Random curve point, generated as `g^r` so that it is guaranteed on-curve.
+			let mut point_seed = [0u8; 32];
+			rng.fill(&mut point_seed);
+			let r = Scalar::from_uint_unchecked(U256::from_be_slice(&point_seed));
+			let p = ProjectivePoint::mul_by_generator(&r);
+			expected += p * k256_scalar;
+
+			scalar.populate_limbs(w, &le_limbs(&num_bigint::BigUint::from_bytes_be(&scalar_bytes)));
+			populate_point(w, &p, &point.x, &point.y);
+		}
+
+		populate_point(w, &expected, &self.expected.x, &self.expected.y);
+
+		Ok(())
+	}
+
+	fn param_summary(params: &Self::Params) -> Option<String> {
+		let glv = if params.endomorphism { "-glv" } else { "" };
+		Some(format!("{}p-w{}{glv}", params.n_points, params.window))
+	}
+}
+
+/// Populate the `x` and `y` limb wires from a k256 projective point's affine coordinates.
+fn populate_point(w: &mut WitnessFiller, p: &ProjectivePoint, x: &BigUint, y: &BigUint) {
+	let bytes = p.to_affine().to_encoded_point(false).to_bytes();
+	// Uncompressed SEC1 encoding: `0x04 || x (32 bytes) || y (32 bytes)`.
+	x.populate_limbs(w, &le_limbs(&num_bigint::BigUint::from_bytes_be(&bytes[1..33])));
+	y.populate_limbs(w, &le_limbs(&num_bigint::BigUint::from_bytes_be(&bytes[33..65])));
+}
+
+/// Decompose a big integer into exactly `N_LIMBS` little-endian 64-bit limbs (zero-padded).
+fn le_limbs(value: &num_bigint::BigUint) -> Vec<u64> {
+	let mut limbs = value.to_u64_digits();
+	assert!(limbs.len() <= N_LIMBS, "value exceeds {N_LIMBS} limbs");
+	limbs.resize(N_LIMBS, 0);
+	limbs
+}

--- a/crates/examples/src/circuits/mod.rs
+++ b/crates/examples/src/circuits/mod.rs
@@ -1,3 +1,4 @@
+// Copyright 2026 The Binius Developers
 // Copyright 2025 Irreducible Inc.
 pub mod bip32;
 pub mod bitcoin_block_contains_transaction;
@@ -6,6 +7,7 @@ pub mod bitcoin_p2pkh;
 pub mod blake2b;
 pub mod blake2s;
 pub mod blake3_compress;
+pub mod ec_msm;
 pub mod ethsign;
 pub mod hashsign;
 pub mod keccak;


### PR DESCRIPTION
## Summary

Adds **fixed-window (Straus) multi-scalar multiplication** gadgets for secp256k1 — `msm_strauss` (plain) and `msm_strauss_endo` (GLV-endomorphism variant) — plus an `ec_msm` example. The table is `n · 2^window` (linear in `n`), so unlike Shamir's trick it scales to larger point counts.

Fresh branch off `main`, exploring [BINIUS-76](https://linear.app/jimpo/issue/BINIUS-76/msm-circuit-for-secp256k1) (parallel to the Shamir-trick variants in #1515).

## Algorithm

For each base point `P_i`, precompute its `2^window` small multiples `{0·P_i, …, (2^window−1)·P_i}`. Consume exponents `window` bits at a time from the top down: each step, every point adds the multiple selected by its current window (via `multi_wire_multiplex`), and the accumulator is doubled `window` times between steps (skipped on the first window, so the result isn't over-multiplied by `2^window`). Window bits are extracted bit-by-bit, so windows crossing 64-bit limb boundaries and bit positions past the exponent length are handled uniformly.

`msm_strauss_endo` GLV-splits each scalar into two 128-bit subscalars / two base points (`P`, `φ(P)`), turning the `n`-point/256-bit MSM into a `2n`-point/128-bit one — halving the doublings (256→128). The `φ(P)` table is **not** recomputed: since `φ` is a homomorphism, `x·φ(P) = φ(x·P)`, so it's derived from the `P` table by one `β`-multiply per entry (`table_φP[x] = negate_if(k1_neg ⊕ k2_neg, φ(table_P[x]))`). Both variants share `build_strauss_table` / `strauss_accumulate`.

## Commits

1. **Add secp256k1 Straus fixed-window MSM gadget** — `msm_strauss`, `msm_strauss_endo`, shared `build_strauss_table` / `strauss_accumulate`; k256 unit tests for window 1/2/3 (window 3 exercises cross-limb extraction and the out-of-range bit guard, for both 256- and 128-bit exponents).
2. **Add ec_msm example with Straus MSM** — public points + scalars + claimed result, points constrained on-curve; flags `-n` (points), `-w` (window), `-e` (GLV). Registered in the CI snapshot matrix.

## Benchmark (Total committed, optimal window = 4)

| n | endo Shamir (#1515) | naive Shamir (#1515) | Straus w4 | **GLV-Straus w4** | best |
|---|---:|---:|---:|---:|:--|
| 1 | 195,479 | 381,362 | 266,316 | **167,144** | GLV-Straus |
| 2 | **219,857** | 389,903 | 330,760 | 234,936 | endo Shamir |
| 3 | 309,899 | 404,396 | 395,204 | **302,728** | GLV-Straus |
| 4 | 662,597 | 430,793 | 459,648 | **370,520** | GLV-Straus |
| 6 | 7,671,737 | 578,819 | 588,536 | **506,104** | GLV-Straus |
| 8 | — | — | 717,424 | **641,688** | GLV-Straus |

**GLV-Straus (window 4) is the best single general-purpose gadget** — best at every n except n=2 (endo-Shamir edges it by ~6%), and scales linearly.

## Testing

- `cargo test -p binius-circuits --lib ecdsa::scalar_mul::tests::test_msm_strauss` — passes (plain + GLV, window 1/2/3).
- `cargo run --release -p binius-examples --example ec_msm -- prove [-e] [-w N]` proves+verifies.
- fmt + crate-scoped clippy clean; snapshot blessed for `ec_msm`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)