### PR TITLE
Consolidate secp256k1 EC multiplication onto GLV-Straus MSM (BINIUS-76)

### DIFF
--- a/crates/circuits/src/bitcoin/p2pkh_signature.rs
+++ b/crates/circuits/src/bitcoin/p2pkh_signature.rs
@@ -1,3 +1,4 @@
+// Copyright 2026 The Binius Developers
 // Copyright 2025 Irreducible Inc.
 
 use binius_core::word::Word;
@@ -6,7 +7,7 @@ use binius_frontend::{CircuitBuilder, Wire};
 use crate::{
 	bignum::BigUint,
 	bytes::swap_bytes_32,
-	ecdsa::scalar_mul::scalar_mul_naive,
+	ecdsa::scalar_mul::scalar_mul,
 	ripemd::ripemd160_fixed,
 	secp256k1::{Secp256k1, Secp256k1Affine},
 	sha256::sha256_fixed,
@@ -56,7 +57,7 @@ pub fn build_p2pkh_circuit(
 	let curve = Secp256k1::new(builder);
 	let generator = Secp256k1Affine::generator(builder);
 
-	let public_key_point = scalar_mul_naive(builder, &curve, 256, private_key, generator);
+	let public_key_point = scalar_mul(builder, &curve, private_key, generator);
 
 	// Step 2: Compress public key - (x, y) → 33-byte compressed format
 	let compressed_pubkey = compress_pubkey(builder, &public_key_point.x, &public_key_point.y);
@@ -238,7 +239,7 @@ mod tests {
 		// Compute pubkey in the circuit
 		let curve = Secp256k1::new(&builder);
 		let generator = Secp256k1Affine::generator(&builder);
-		let pub_point = scalar_mul_naive(&builder, &curve, 256, &private_key, generator);
+		let pub_point = scalar_mul(&builder, &curve, &private_key, generator);
 		let compressed = compress_pubkey(&builder, &pub_point.x, &pub_point.y);
 
 		for i in 0..9 {

--- a/crates/circuits/src/ecdsa/bitcoin.rs
+++ b/crates/circuits/src/ecdsa/bitcoin.rs
@@ -2,7 +2,7 @@
 // Copyright 2025 Irreducible Inc.
 use binius_frontend::{CircuitBuilder, Wire, util::all_true};
 
-use super::scalar_mul::shamirs_trick_endomorphism;
+use super::scalar_mul::{MSM_WINDOW, msm_strauss_endo};
 use crate::{
 	bignum::{BigUint, biguint_lt},
 	secp256k1::{Secp256k1, Secp256k1Affine},
@@ -43,7 +43,9 @@ pub fn verify(
 	let u1 = f_scalar.div(b, z, s, valid_s);
 	let u2 = f_scalar.div(b, r, s, valid_s);
 
-	let nonce = shamirs_trick_endomorphism(b, &curve, &u1, &u2, pk);
+	// Recover the candidate nonce point as the multi-scalar multiplication `u1*G + u2*PK`.
+	let g = Secp256k1Affine::generator(b);
+	let nonce = msm_strauss_endo(b, &curve, MSM_WINDOW, &[u1, u2], &[g, pk]);
 	let nonce_not_pai = b.bnot(nonce.is_point_at_infinity);
 	let r_diff = curve.f_p().sub(b, &nonce.x, r);
 

--- a/crates/circuits/src/ecdsa/ecrecover.rs
+++ b/crates/circuits/src/ecdsa/ecrecover.rs
@@ -2,7 +2,7 @@
 // Copyright 2025 Irreducible Inc.
 use binius_frontend::{CircuitBuilder, Wire, util::all_true};
 
-use super::scalar_mul::shamirs_trick_endomorphism;
+use super::scalar_mul::{MSM_WINDOW, msm_strauss_endo};
 use crate::{
 	bignum::{BigUint, biguint_lt},
 	secp256k1::{Secp256k1, Secp256k1Affine, coord_zero},
@@ -42,7 +42,9 @@ pub fn ecrecover(
 	let u1 = f_scalar.sub(b, &coord_zero(b), &f_scalar.div(b, z, r, valid_r));
 	let u2 = f_scalar.div(b, s, r, valid_r);
 
-	let recovered_pk = shamirs_trick_endomorphism(b, &curve, &u1, &u2, nonce);
+	// Recover the public key as the multi-scalar multiplication `u1*G + u2*R`.
+	let g = Secp256k1Affine::generator(b);
+	let recovered_pk = msm_strauss_endo(b, &curve, MSM_WINDOW, &[u1, u2], &[g, nonce]);
 
 	let conditions = [valid_r, valid_s, nonce_not_pai];
 	recovered_pk.pai_unless(b, all_true(b, conditions))

--- a/crates/circuits/src/ecdsa/scalar_mul.rs
+++ b/crates/circuits/src/ecdsa/scalar_mul.rs
@@ -6,68 +6,17 @@ use binius_frontend::{CircuitBuilder, Wire};
 use crate::{
 	bignum::{BigUint, assert_eq, select as select_biguint},
 	multiplexer::multi_wire_multiplex,
-	secp256k1::{
-		N_LIMBS, Secp256k1, Secp256k1Affine, coord_lambda, coord_zero,
-		select as select_secp256k1_affine,
-	},
+	secp256k1::{N_LIMBS, Secp256k1, Secp256k1Affine, coord_lambda, coord_zero},
 };
 
-/// Compute scalar multiplication `point * scalar` using the naive double-and-add algorithm.
-///
-/// This implementation does not use the secp256k1 endomorphism optimization.
-///
-/// # Parameters
-/// - `b`: The circuit builder
-/// - `curve`: The secp256k1 curve instance
-/// - `bits`: Number of bits to process in the scalar
-/// - `scalar`: The scalar to multiply by (as a BigUint, must have enough limbs for bits)
-/// - `point`: The point to multiply (in affine coordinates)
-///
-/// # Returns
-/// The result of `point * scalar` in affine coordinates
-pub fn scalar_mul_naive(
-	b: &CircuitBuilder,
-	curve: &Secp256k1,
-	bits: usize,
-	scalar: &BigUint,
-	point: Secp256k1Affine,
-) -> Secp256k1Affine {
-	// Ensure scalar has enough limbs for the requested bits
-	let required_limbs = bits.div_ceil(WORD_SIZE_BITS);
-	assert!(
-		scalar.limbs.len() >= required_limbs,
-		"scalar must have at least {} limbs for {} bits, but has {}",
-		required_limbs,
-		bits,
-		scalar.limbs.len()
-	);
-
-	let mut acc = Secp256k1Affine::point_at_infinity(b);
-
-	for bit_index in (0..bits).rev() {
-		let limb = bit_index / WORD_SIZE_BITS;
-		let bit = bit_index % WORD_SIZE_BITS;
-
-		if bit_index != bits - 1 {
-			acc = curve.double(b, &acc);
-		}
-
-		let scalar_bit = b.shl(scalar.limbs[limb], (WORD_SIZE_BITS - 1 - bit) as u32);
-
-		// Add the selected point to the accumulator
-		let acc_plus_point = curve.add_incomplete(b, &acc, &point);
-
-		// Select whether to add point to accumulator based on scalar bit
-		acc = select_secp256k1_affine(b, scalar_bit, &acc_plus_point, &acc);
-	}
-
-	acc
-}
+/// Optimal Straus window size (in bits) for secp256k1 multi-scalar multiplications; see
+/// [`msm_strauss_endo`].
+pub const MSM_WINDOW: usize = 4;
 
 /// Compute scalar multiplication `point * scalar` using the secp256k1 endomorphism optimization.
 ///
-/// This implementation uses the curve's endomorphism to split the scalar into two ~128-bit
-/// components, reducing the number of doublings from 256 to 128.
+/// Implemented as a single-point [`msm_strauss_endo`] (GLV fixed-window Straus) — see there for the
+/// algorithm.
 ///
 /// # Parameters
 /// - `b`: The circuit builder
@@ -84,169 +33,7 @@ pub fn scalar_mul(
 	scalar: &BigUint,
 	point: Secp256k1Affine,
 ) -> Secp256k1Affine {
-	assert_eq!(scalar.limbs.len(), N_LIMBS);
-
-	// Nondeterministically split the scalar, constrain the split
-	let (k1_neg, k2_neg, k1_abs, k2_abs) = b.secp256k1_endomorphism_split_hint(&scalar.limbs);
-
-	check_endomorphism_split(b, curve, k1_neg, k2_neg, k1_abs, k2_abs, scalar);
-
-	// Compute the endomorphism of the point
-	let point_endo = curve.endomorphism(b, &point);
-
-	// The split returns "signed scalars" (which is required to fit them into 128 bits).
-	// Negate the base if needed to only care about positive exponents.
-	let p1 = curve.negate_if(b, k1_neg, &point);
-	let p2 = curve.negate_if(b, k2_neg, &point_endo);
-
-	// Compute the 4-element lookup table: {0, P1, P2, P1+P2}
-	let lookup = vec![
-		Secp256k1Affine::point_at_infinity(b),
-		p1.clone(),
-		p2.clone(),
-		curve.add_incomplete(b, &p1, &p2),
-	];
-
-	let mut acc = Secp256k1Affine::point_at_infinity(b);
-
-	for bit_index in (0..128).rev() {
-		let limb = bit_index / WORD_SIZE_BITS;
-		let bit = bit_index % WORD_SIZE_BITS;
-
-		if bit_index != 127 {
-			acc = curve.double(b, &acc);
-		}
-
-		// Extract the current bit from each scalar component
-		let k1_bit = b.shl(k1_abs[limb], (WORD_SIZE_BITS - 1 - bit) as u32);
-		let k2_bit = b.shl(k2_abs[limb], (WORD_SIZE_BITS - 1 - bit) as u32);
-
-		// Perform 2-bit lookup using nested selection
-		// This selects one of the 4 lookup table entries based on the two bits
-		let mut level = lookup.clone();
-		for sel_bit in [k1_bit, k2_bit] {
-			let next_level = level
-				.chunks(2)
-				.map(|pair| {
-					assert_eq!(pair.len(), 2);
-					select_secp256k1_affine(b, sel_bit, &pair[1], &pair[0])
-				})
-				.collect();
-			level = next_level;
-		}
-
-		assert_eq!(level.len(), 1);
-		acc = curve.add_incomplete(b, &acc, &level[0]);
-	}
-
-	acc
-}
-
-/// A common trick to save doublings when computing multiexponentiations of the form
-/// `G*g_mult + PK*pk_mult` - instead of doing two scalar multiplications separately and
-/// adding their results, we share the doubling step of double-and-add.
-///
-/// For secp256k1, we can go one step further: the curve has an endomorphism `λ (x, y) = (βx, y)`
-/// where `λ³=1 (mod n)` and `β³=1 (mod p)` (`n` being the scalar field modulus and `p` coordinate
-/// field one). For a 256-bit scalar `k` it is possible to split it into `k1` and `k2` such that
-/// `k1 + λ k2 = k (mod n)` and both `k1` and `k2` are no farther than `2^128` from zero.
-///
-/// Using the above fact, we can "split" both the G and PK 256-bit multiplier scalars into a total
-/// of four 128-bit subscalars. Instead of 4-wide lookup in `shamirs_trick_naive`, we do a 16-wide
-/// lookup for all subset sums of `{G, G_endo, PK, PK_endo}`, where `*_endo` points are obtained via
-/// endomorphism. This halves the total number of doublings and additions at a cost of a larger
-/// precomputation, but the eventual savings are still in the order of 2x.
-///
-/// Returns `G*g_mult + PK*pk_mult`.
-pub fn shamirs_trick_endomorphism(
-	b: &CircuitBuilder,
-	curve: &Secp256k1,
-	g_mult: &BigUint,
-	pk_mult: &BigUint,
-	pk: Secp256k1Affine,
-) -> Secp256k1Affine {
-	assert_eq!(g_mult.limbs.len(), N_LIMBS);
-	assert_eq!(pk_mult.limbs.len(), N_LIMBS);
-
-	// Nondeterministically split both scalars, constrain the splits
-	let (g1_mult_neg, g2_mult_neg, g1_mult_abs, g2_mult_abs) =
-		b.secp256k1_endomorphism_split_hint(&g_mult.limbs);
-
-	check_endomorphism_split(b, curve, g1_mult_neg, g2_mult_neg, g1_mult_abs, g2_mult_abs, g_mult);
-
-	let (pk1_mult_neg, pk2_mult_neg, pk1_mult_abs, pk2_mult_abs) =
-		b.secp256k1_endomorphism_split_hint(&pk_mult.limbs);
-
-	check_endomorphism_split(
-		b,
-		curve,
-		pk1_mult_neg,
-		pk2_mult_neg,
-		pk1_mult_abs,
-		pk2_mult_abs,
-		pk_mult,
-	);
-
-	// Compute the endomorphisms
-	let g = Secp256k1Affine::generator(b);
-	let g_endo = curve.endomorphism(b, &g);
-	let pk_endo = curve.endomorphism(b, &pk);
-
-	// The split returns "signed scalars" (which is required to fit them into 128 bits).
-	// Negate the base if needed to only care about positive exponents.
-	let g1 = curve.negate_if(b, g1_mult_neg, &g);
-	let g2 = curve.negate_if(b, g2_mult_neg, &g_endo);
-
-	let pk1 = curve.negate_if(b, pk1_mult_neg, &pk);
-	let pk2 = curve.negate_if(b, pk2_mult_neg, &pk_endo);
-
-	// Compute subset sums of {G, G_endo, PK, PK_endo} using a total of 11 additions
-	let mut lookup = Vec::with_capacity(16);
-	lookup.push(Secp256k1Affine::point_at_infinity(b));
-	for (i, pt) in [g1, g2, pk1, pk2].into_iter().enumerate() {
-		lookup.push(pt.clone());
-		for j in 1..1 << i {
-			lookup.push(curve.add_incomplete(b, &lookup[j], &pt));
-		}
-	}
-
-	let mut acc = Secp256k1Affine::point_at_infinity(b);
-
-	for bit_index in (0..128).rev() {
-		let limb = bit_index / WORD_SIZE_BITS;
-		let bit = bit_index % WORD_SIZE_BITS;
-
-		if bit_index != 127 {
-			acc = curve.double(b, &acc);
-		}
-
-		// This is essentially an inlined multi wire multiplexer, but due to the fact
-		// it uses affine point conditional selections and separate wires instead of masks
-		// it's simpler to inline it there.
-		// TODO: replace it with a multiplexer once the abstraction is mature enough
-		let g1_mult_bit = b.shl(g1_mult_abs[limb], (WORD_SIZE_BITS - 1 - bit) as u32);
-		let g2_mult_bit = b.shl(g2_mult_abs[limb], (WORD_SIZE_BITS - 1 - bit) as u32);
-		let pk1_mult_bit = b.shl(pk1_mult_abs[limb], (WORD_SIZE_BITS - 1 - bit) as u32);
-		let pk2_mult_bit = b.shl(pk2_mult_abs[limb], (WORD_SIZE_BITS - 1 - bit) as u32);
-
-		let mut level = lookup.clone();
-		for sel_bit in [g1_mult_bit, g2_mult_bit, pk1_mult_bit, pk2_mult_bit] {
-			let next_level = level
-				.chunks(2)
-				.map(|pair| {
-					assert_eq!(pair.len(), 2);
-					select_secp256k1_affine(b, sel_bit, &pair[1], &pair[0])
-				})
-				.collect();
-
-			level = next_level;
-		}
-
-		assert_eq!(level.len(), 1);
-		acc = curve.add_incomplete(b, &acc, &level[0]);
-	}
-
-	acc
+	msm_strauss_endo(b, curve, MSM_WINDOW, std::slice::from_ref(scalar), &[point])
 }
 
 // Constrain the return value of `CircuitBuilder::secp256k1_endomorphism_split_hint`.
@@ -283,135 +70,33 @@ fn check_endomorphism_split(
 	);
 }
 
-/// A common trick to save doublings when computing multiexponentiations of the form
-/// `G*g_mult + PK*pk_mult` - instead of doing two scalar multiplications separately and
-/// adding their results, we share the doubling step of double-and-add.
-///
-/// This implementation relies on group axioms only. It is currently unused for secp256k1
-/// but may prove useful for other curves.
-#[allow(unused)]
-pub fn shamirs_trick_naive(
-	b: &CircuitBuilder,
-	curve: &Secp256k1,
-	bits: usize,
-	g_mult: &BigUint,
-	pk_mult: &BigUint,
-	pk: Secp256k1Affine,
-) -> Secp256k1Affine {
-	let g = Secp256k1Affine::generator(b);
-	let g_pk = curve.add(b, &g, &pk);
-
-	let mut acc = Secp256k1Affine::point_at_infinity(b);
-
-	for bit_index in (0..bits).rev() {
-		let limb = bit_index / WORD_SIZE_BITS;
-		let bit = bit_index % WORD_SIZE_BITS;
-
-		if bit_index != bits - 1 {
-			acc = curve.double(b, &acc);
-		}
-
-		let g_mult_bit = b.shl(g_mult.limbs[limb], (WORD_SIZE_BITS - 1 - bit) as u32);
-		let pk_mult_bit = b.shl(pk_mult.limbs[limb], (WORD_SIZE_BITS - 1 - bit) as u32);
-
-		// A 3-to-1 mux
-		let x =
-			select_biguint(b, pk_mult_bit, &select_biguint(b, g_mult_bit, &g_pk.x, &pk.x), &g.x);
-		let y =
-			select_biguint(b, pk_mult_bit, &select_biguint(b, g_mult_bit, &g_pk.y, &pk.y), &g.y);
-
-		// Point at infinity flag is a single wire, allowing us to save a BigUint select.
-		let is_point_at_infinity = b.band(b.bnot(g_mult_bit), b.bnot(pk_mult_bit));
-
-		// Addition implementation is incomplete (it handles pai, but not doubling). When
-		// the mask is zero, pai-to-pai support is needed. The probability of accumulator
-		// assuming value G, PK, or G+PK at any point in the computation is vanishingly low.
-		// We assert false in this case, resulting in a completeness gap.
-		acc = curve.add_incomplete(
-			b,
-			&acc,
-			&Secp256k1Affine {
-				x,
-				y,
-				is_point_at_infinity,
-			},
-		);
-	}
-
-	acc
-}
-
 /// Compute a multi-scalar multiplication `Σ_i scalars[i] · points[i]` over secp256k1 using the
-/// fixed-window (Straus) algorithm.
+/// fixed-window (Straus) algorithm combined with the GLV endomorphism.
 ///
 /// `n = points.len()` must equal `scalars.len()`; both `n` and the window size `window` (in bits)
 /// are statically known to the circuit. Each scalar is a 256-bit value (`N_LIMBS` limbs).
 ///
-/// For each point `P_i` a table of its `2^window` small multiples `{0·P_i, …, (2^window − 1)·P_i}`
-/// is precomputed. The exponents are then consumed `window` bits at a time from the most
-/// significant window down: at each of the `ceil(256 / window)` steps every point contributes the
-/// multiple selected by its current window (via [`multi_wire_multiplex`]), and the accumulator is
-/// doubled `window` times *between* steps (skipped on the first window). Unlike Shamir's trick, the
-/// total table size is `n · 2^window` — linear in `n` — so it scales to larger `n`.
-///
-/// `window = 4` is typically optimal. A window of 1 degenerates to a per-point double-and-add
-/// sharing the doublings. See [`msm_strauss_endo`] for the GLV-endomorphism variant.
-///
-/// # Completeness gap
-///
-/// Point additions use [`Secp256k1::add_incomplete`], which asserts false when its inputs are equal
-/// (it handles the point at infinity but not doubling). As with the other routines here, the
-/// probability of the accumulator or a table entry hitting such a collision for independent inputs
-/// is vanishingly low.
-///
-/// # Panics
-///
-/// Panics if `scalars.len() != points.len()`, if `n == 0`, if `window` is not in
-/// `1..WORD_SIZE_BITS`, or if any scalar does not have exactly `N_LIMBS` limbs.
-pub fn msm_strauss(
-	b: &CircuitBuilder,
-	curve: &Secp256k1,
-	window: usize,
-	scalars: &[BigUint],
-	points: &[Secp256k1Affine],
-) -> Secp256k1Affine {
-	let n = points.len();
-	assert_eq!(scalars.len(), n, "scalars and points must have the same length");
-	assert!(n >= 1, "MSM requires at least one point");
-	assert!(0 < window && window < WORD_SIZE_BITS, "window must be in 1..WORD_SIZE_BITS");
-	for scalar in scalars {
-		assert_eq!(scalar.limbs.len(), N_LIMBS);
-	}
-
-	// Use each point directly as a base point and its full 256-bit scalar as the exponent.
-	let tables = points
-		.iter()
-		.map(|point| build_strauss_table(b, curve, point, window))
-		.collect::<Vec<_>>();
-	let subscalars = scalars
-		.iter()
-		.map(|s| s.limbs.as_slice())
-		.collect::<Vec<_>>();
-	strauss_accumulate(b, curve, &tables, &subscalars, window, N_LIMBS * WORD_SIZE_BITS)
-}
-
-/// Compute a multi-scalar multiplication `Σ_i scalars[i] · points[i]` over secp256k1 using the
-/// fixed-window (Straus) algorithm combined with the GLV endomorphism.
-///
 /// Every `(scalar, point)` pair is endomorphism-split into two ~128-bit signed subscalars and two
-/// base points (`P` and `endo(P)`, conditionally negated to positive subscalars), so the `n`-point
-/// 256-bit MSM becomes a `2n`-point 128-bit one. Relative to [`msm_strauss`] this halves the number
-/// of doublings (128 vs 256) and the windows per point, while doubling the number of small-multiple
-/// tables and adding one endomorphism-split constraint per scalar.
+/// base points (`P` and `φ(P)`, conditionally negated to positive subscalars), turning the
+/// `n`-point 256-bit MSM into a `2n`-point 128-bit one (128 doublings instead of 256). For each
+/// base point a table of its `2^window` small multiples is precomputed, and the 128-bit exponents
+/// are consumed `window` bits at a time, from the top down: at each step every base point adds the
+/// multiple selected by its current window (via [`multi_wire_multiplex`]), and the accumulator is
+/// doubled `window` times between steps (skipped on the first window). The table size is
+/// `2n · 2^window` — linear in `n` — so it scales to larger `n`.
 ///
 /// The `φ(P)` table is *not* recomputed with point additions: since `φ` is a homomorphism,
 /// `φ(P)`'s small multiples are `φ` applied to `P`'s small multiples (`x · φ(P) = φ(x · P)`), i.e.
 /// one field multiplication of each entry's x-coordinate by `β` rather than another
 /// `2^window`-entry point-addition chain.
 ///
-/// The window-lookup count and addition count are unchanged versus plain [`msm_strauss`]; the win
-/// is the halved doubling chain. `window = 4` is typically optimal. The completeness-gap caveat of
-/// [`msm_strauss`] applies here too.
+/// `window = 4` (see [`MSM_WINDOW`]) is typically optimal.
+///
+/// # Completeness gap
+///
+/// Point additions use [`Secp256k1::add_incomplete`], which asserts false when its inputs are equal
+/// (it handles the point at infinity but not doubling). The probability of the accumulator or a
+/// table entry hitting such a collision for independent inputs is vanishingly low.
 ///
 /// # Panics
 ///
@@ -493,7 +178,7 @@ fn build_strauss_table(
 	table
 }
 
-/// Shared core of [`msm_strauss`] and [`msm_strauss_endo`]: fixed-window double-and-add over the
+/// Core of [`msm_strauss_endo`]: fixed-window double-and-add over the
 /// `m = tables.len()` base points whose `2^window`-entry small-multiple `tables` are precomputed
 /// and whose exponents (`subscalars[i]`, bounded by `exponent_bits`) are consumed `window` bits at
 /// a time.
@@ -602,51 +287,6 @@ mod tests {
 		bignum::{BigUint, assert_eq},
 		secp256k1::{Secp256k1, Secp256k1Affine},
 	};
-
-	#[test]
-	fn test_scalar_mul_naive() {
-		let builder = CircuitBuilder::new();
-		let curve = Secp256k1::new(&builder);
-
-		// Test with scalar = 69
-		let scalar_value = 69u64;
-
-		// Use k256 to compute the expected result
-		let k256_scalar = Scalar::from(scalar_value);
-		let k256_point = ProjectivePoint::mul_by_generator(&k256_scalar).to_affine();
-
-		// Extract coordinates from k256 result
-		let point_bytes = k256_point.to_encoded_point(false).to_bytes();
-		// The uncompressed format is: 0x04 || x || y (65 bytes total)
-		// We need to extract x and y coordinates (32 bytes each)
-		let x_coord = num_bigint::BigUint::from_bytes_be(&point_bytes[1..33]);
-		let y_coord = num_bigint::BigUint::from_bytes_be(&point_bytes[33..65]);
-
-		// Create our scalar as BigUint
-		let scalar = BigUint::new_constant(&builder, &num_bigint::BigUint::from(scalar_value));
-
-		// Create expected coordinates as BigUint
-		let expected_x = BigUint::new_constant(&builder, &x_coord);
-		let expected_y = BigUint::new_constant(&builder, &y_coord);
-
-		// Get the generator point
-		let generator = Secp256k1Affine::generator(&builder);
-
-		// Perform scalar multiplication with our implementation
-		let result = scalar_mul_naive(&builder, &curve, 7, &scalar, generator);
-
-		// Check that the result matches the expected point
-		assert_eq(&builder, "result_x", &result.x, &expected_x);
-		assert_eq(&builder, "result_y", &result.y, &expected_y);
-
-		// Build and verify the circuit
-		let cs = builder.build();
-		let mut w = cs.new_witness_filler();
-		assert!(cs.populate_wire_witness(&mut w).is_ok());
-
-		// Also verify the point is not at infinity
-		assert_eq!(w[result.is_point_at_infinity], Word::ZERO);
-	}
 
 	#[test]
 	fn test_scalar_mul_with_endomorphism() {
@@ -758,31 +398,14 @@ mod tests {
 		assert_eq!(w[result.is_point_at_infinity], Word::ZERO);
 	}
 
-	// Window of 2 divides both 64 and 256, so windows never cross a limb boundary.
+	// Window of 1 degenerates to a per-point double-and-add with shared doublings.
 	#[test]
-	fn test_msm_strauss_window2() {
-		check_msm_strauss(msm_strauss, 2, 1, 0);
-		check_msm_strauss(msm_strauss, 2, 2, 1);
-		check_msm_strauss(msm_strauss, 2, 3, 2);
+	fn test_msm_strauss_endo_window1() {
+		check_msm_strauss(msm_strauss_endo, 1, 1, 6);
+		check_msm_strauss(msm_strauss_endo, 1, 2, 0);
 	}
 
-	// Window of 3 does not divide 64, so windows cross limb boundaries and the top window reads
-	// past bit 255 — exercising both the cross-limb extraction and the out-of-range bit guard.
-	#[test]
-	fn test_msm_strauss_window3() {
-		check_msm_strauss(msm_strauss, 3, 1, 3);
-		check_msm_strauss(msm_strauss, 3, 2, 4);
-		check_msm_strauss(msm_strauss, 3, 3, 5);
-	}
-
-	// A window of 1 degenerates to plain double-and-add with shared doublings.
-	#[test]
-	fn test_msm_strauss_window1() {
-		check_msm_strauss(msm_strauss, 1, 2, 6);
-	}
-
-	// GLV variant: the 128-bit subscalars mean window 3 (43 windows → 129 bits) still exercises the
-	// cross-limb extraction and out-of-range guard, now at the 128-bit boundary.
+	// Window 2 divides both 64 and 128, so windows never cross a limb boundary.
 	#[test]
 	fn test_msm_strauss_endo_window2() {
 		check_msm_strauss(msm_strauss_endo, 2, 1, 7);
@@ -790,6 +413,8 @@ mod tests {
 		check_msm_strauss(msm_strauss_endo, 2, 3, 9);
 	}
 
+	// Window 3 (43 windows → 129 bits) exercises cross-limb extraction and the out-of-range guard
+	// at the 128-bit subscalar boundary.
 	#[test]
 	fn test_msm_strauss_endo_window3() {
 		check_msm_strauss(msm_strauss_endo, 3, 1, 10);

--- a/crates/examples/snapshots/bitcoin_p2pkh.snap
+++ b/crates/examples/snapshots/bitcoin_p2pkh.snap
@@ -1,28 +1,28 @@
 bitcoin_p2pkh circuit
 --
 Gates & Instructions
-├─ Number of gates: 378,219
-└─ Number of evaluation instructions: 459,714
+├─ Number of gates: 168,727
+└─ Number of evaluation instructions: 201,906
 
 Constraints
-├─ AND constraints: 331,882 used (63.3% of 2^19)
-│  [▓▓▓▓▓▓░░░░] spare: 192,406
-├─ MUL constraints: 36,272 used (55.3% of 2^16)
-│  [▓▓▓▓▓░░░░░] spare: 29,264
-└─ Distinct value indices: 723,831
-   ├─ Distinct shifted value indices: 343,307
-   └─ Distinct unshifted value indices: 380,524
+├─ AND constraints: 148,248 used (56.6% of 2^18)
+│  [▓▓▓▓▓░░░░░] spare: 113,896
+├─ MUL constraints: 15,198 used (92.8% of 2^14)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 1,186
+└─ Distinct value indices: 315,146
+   ├─ Distinct shifted value indices: 146,276
+   └─ Distinct unshifted value indices: 168,870
 
 Value Vector
-├─ Public Section: 115 used (89.8% of 2^7)
-│  [▓▓▓▓▓▓▓▓░░] spare: 13
-│  ├─ Constants: 115
+├─ Public Section: 123 used (96.1% of 2^7)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 5
+│  ├─ Constants: 123
 │  └─ Inout: 0
-├─ Private Section: 380,417 used (72.6%)
-│  [▓▓▓▓▓▓▓░░░] spare: 143,743
+├─ Private Section: 168,751 used (64.4%)
+│  [▓▓▓▓▓▓░░░░] spare: 93,265
 │  ├─ Witness: 9
-│  └─ Internal: 380,408
-├─ Total Committed: 380,532 used (72.6% of 2^19)
-│  [▓▓▓▓▓▓▓░░░] spare: 143,756
-└─ Scratch (uncommitted): 329,106
+│  └─ Internal: 168,742
+├─ Total Committed: 168,874 used (64.4% of 2^18)
+│  [▓▓▓▓▓▓░░░░] spare: 93,270
+└─ Scratch (uncommitted): 137,139
 

--- a/crates/examples/snapshots/ec_msm.snap
+++ b/crates/examples/snapshots/ec_msm.snap
@@ -1,28 +1,28 @@
 ec_msm circuit
 --
 Gates & Instructions
-├─ Number of gates: 388,484
-└─ Number of evaluation instructions: 470,550
+├─ Number of gates: 233,412
+└─ Number of evaluation instructions: 278,916
 
 Constraints
-├─ AND constraints: 342,876 used (65.4% of 2^19)
-│  [▓▓▓▓▓▓░░░░] spare: 181,412
-├─ MUL constraints: 36,596 used (55.8% of 2^16)
-│  [▓▓▓▓▓░░░░░] spare: 28,940
-└─ Distinct value indices: 741,282
-   ├─ Distinct shifted value indices: 349,406
-   └─ Distinct unshifted value indices: 391,876
+├─ AND constraints: 207,242 used (79.1% of 2^18)
+│  [▓▓▓▓▓▓▓░░░] spare: 54,902
+├─ MUL constraints: 20,596 used (62.9% of 2^15)
+│  [▓▓▓▓▓▓░░░░] spare: 12,172
+└─ Distinct value indices: 432,599
+   ├─ Distinct shifted value indices: 197,668
+   └─ Distinct unshifted value indices: 234,931
 
 Value Vector
-├─ Public Section: 44 used (68.8% of 2^6)
-│  [▓▓▓▓▓▓░░░░] spare: 20
-│  ├─ Constants: 12
+├─ Public Section: 52 used (81.2% of 2^6)
+│  [▓▓▓▓▓▓▓▓░░] spare: 12
+│  ├─ Constants: 20
 │  └─ Inout: 32
-├─ Private Section: 391,838 used (74.7%)
-│  [▓▓▓▓▓▓▓░░░] spare: 132,386
+├─ Private Section: 234,884 used (89.6%)
+│  [▓▓▓▓▓▓▓▓░░] spare: 27,196
 │  ├─ Witness: 0
-│  └─ Internal: 391,838
-├─ Total Committed: 391,882 used (74.7% of 2^19)
-│  [▓▓▓▓▓▓▓░░░] spare: 132,406
-└─ Scratch (uncommitted): 329,242
+│  └─ Internal: 234,884
+├─ Total Committed: 234,936 used (89.6% of 2^18)
+│  [▓▓▓▓▓▓▓▓░░] spare: 27,208
+└─ Scratch (uncommitted): 183,962
 

--- a/crates/examples/snapshots/ethsign.snap
+++ b/crates/examples/snapshots/ethsign.snap
@@ -1,28 +1,28 @@
 ethsign circuit
 --
 Gates & Instructions
-├─ Number of gates: 218,930
-└─ Number of evaluation instructions: 261,739
+├─ Number of gates: 239,650
+└─ Number of evaluation instructions: 285,350
 
 Constraints
-├─ AND constraints: 191,166 used (72.9% of 2^18)
-│  [▓▓▓▓▓▓▓░░░] spare: 70,978
-├─ MUL constraints: 19,022 used (58.1% of 2^15)
-│  [▓▓▓▓▓░░░░░] spare: 13,746
-└─ Distinct value indices: 399,942
-   ├─ Distinct shifted value indices: 183,230
-   └─ Distinct unshifted value indices: 216,712
+├─ AND constraints: 209,179 used (79.8% of 2^18)
+│  [▓▓▓▓▓▓▓░░░] spare: 52,965
+├─ MUL constraints: 20,592 used (62.8% of 2^15)
+│  [▓▓▓▓▓▓░░░░] spare: 12,176
+└─ Distinct value indices: 438,353
+   ├─ Distinct shifted value indices: 201,442
+   └─ Distinct unshifted value indices: 236,911
 
 Value Vector
 ├─ Public Section: 119 used (93.0% of 2^7)
 │  [▓▓▓▓▓▓▓▓▓░] spare: 9
 │  ├─ Constants: 90
 │  └─ Inout: 29
-├─ Private Section: 216,602 used (82.7%)
-│  [▓▓▓▓▓▓▓▓░░] spare: 45,414
+├─ Private Section: 236,801 used (90.4%)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 25,215
 │  ├─ Witness: 42
-│  └─ Internal: 216,560
-├─ Total Committed: 216,721 used (82.7% of 2^18)
-│  [▓▓▓▓▓▓▓▓░░] spare: 45,423
-└─ Scratch (uncommitted): 175,363
+│  └─ Internal: 236,759
+├─ Total Committed: 236,920 used (90.4% of 2^18)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 25,224
+└─ Scratch (uncommitted): 188,532
 

--- a/crates/examples/src/circuits/ec_msm.rs
+++ b/crates/examples/src/circuits/ec_msm.rs
@@ -4,7 +4,7 @@ use std::iter;
 use anyhow::Result;
 use binius_circuits::{
 	bignum::{BigUint, assert_eq},
-	ecdsa::scalar_mul::{msm_strauss, msm_strauss_endo},
+	ecdsa::scalar_mul::msm_strauss_endo,
 	secp256k1::{N_LIMBS, Secp256k1, Secp256k1Affine},
 };
 use binius_core::word::Word;
@@ -19,8 +19,8 @@ use rand::prelude::*;
 use crate::ExampleCircuit;
 
 /// Example circuit that computes a multi-scalar multiplication `Σ_i scalars[i] · points[i]` over
-/// secp256k1 with a statically-known number of points, using the fixed-window (Straus) algorithm
-/// (see [`msm_strauss`]).
+/// secp256k1 with a statically-known number of points, using the GLV fixed-window (Straus)
+/// algorithm (see [`msm_strauss_endo`]).
 ///
 /// The points and scalars are public inputs (the points are constrained to lie on the curve), and
 /// the claimed result is a public input that the circuit checks against the in-circuit MSM.
@@ -51,11 +51,8 @@ pub struct Params {
 	#[arg(short = 'n', long, default_value_t = 2, value_parser = clap::value_parser!(u16).range(1..))]
 	pub n_points: u16,
 	/// Window size in bits for the Straus algorithm (4 is typically optimal)
-	#[arg(short = 'w', long, default_value_t = 2, value_parser = clap::value_parser!(u16).range(1..64))]
+	#[arg(short = 'w', long, default_value_t = 4, value_parser = clap::value_parser!(u16).range(1..64))]
 	pub window: u16,
-	/// Combine Straus with the GLV endomorphism (2n base points, 128-bit exponents)
-	#[arg(short = 'e', long, default_value_t = false)]
-	pub endomorphism: bool,
 }
 
 #[derive(Args, Debug, Clone)]
@@ -91,11 +88,7 @@ impl ExampleCircuit for EcMsmExample {
 			.collect::<Vec<_>>();
 
 		let window = params.window as usize;
-		let result = if params.endomorphism {
-			msm_strauss_endo(builder, &curve, window, &scalars, &affine_points)
-		} else {
-			msm_strauss(builder, &curve, window, &scalars, &affine_points)
-		};
+		let result = msm_strauss_endo(builder, &curve, window, &scalars, &affine_points);
 
 		let expected = AffinePoint::new_inout(builder);
 		assert_eq(builder, "msm_result_x", &result.x, &expected.x);
@@ -135,8 +128,7 @@ impl ExampleCircuit for EcMsmExample {
 	}
 
 	fn param_summary(params: &Self::Params) -> Option<String> {
-		let glv = if params.endomorphism { "-glv" } else { "" };
-		Some(format!("{}p-w{}{glv}", params.n_points, params.window))
+		Some(format!("{}p-w{}", params.n_points, params.window))
 	}
 }
 


### PR DESCRIPTION
## Summary

Makes **GLV-Straus (`msm_strauss_endo`) the single secp256k1 elliptic-curve multiplication routine** and removes everything it subsumes. Rebased onto the now-merged #1516.

## Changes

- `ecdsa::ecrecover` and `ecdsa::bitcoin::verify`: `u1·G + u2·P` via `msm_strauss_endo(MSM_WINDOW, [u1, u2], [G, P])` instead of `shamirs_trick_endomorphism`.
- `ecdsa::scalar_mul::scalar_mul`: reimplemented as a single-point `msm_strauss_endo(MSM_WINDOW, [scalar], [point])`.
- `bitcoin::p2pkh`: `private_key·G` now uses `scalar_mul` (→ MSM) instead of `scalar_mul_naive`.
- Removed `shamirs_trick_endomorphism`, `shamirs_trick_naive`, `scalar_mul_naive`, **and the plain (non-GLV) `msm_strauss`** — GLV-Straus is always at least as good, so it's the only variant kept. `scalar_mul.rs` drops ~440 lines.
- Added `MSM_WINDOW = 4` (the empirically-optimal Straus window); `ec_msm` example now always uses `msm_strauss_endo` (dropped the `-e` toggle; default `-w 4`).
- Re-blessed snapshots:
  - `bitcoin_p2pkh`: 380,532 → **168,874 committed (−56%)** — GLV-Straus is far cheaper than the old naive double-and-add.
  - `ethsign`: 216,721 → 236,920 (+9.3%, the GLV-Straus-vs-endo-Shamir delta at n=2).
  - `ec_msm`: re-blessed (example default is now GLV-Straus, w=4).

## Why accept the ECDSA n=2 regression

Endo-Shamir is ~6–9% smaller than GLV-Straus only at n=2–3; GLV-Straus wins everywhere else and scales linearly. Keeping separate routines purely for the 2-point case isn't worth the extra implementations. (For the single-scalar `p2pkh` path it's a large *win*.)

## Testing

- `cargo test -p binius-circuits --lib ecdsa` / `… p2pkh` pass, including `test_ecdsa_recover_test_vector`, `test_bitcoin_ecdsa_test_vector`, `test_p2pkh_circuit_privkey_external`, `test_scalar_mul_with_endomorphism`, and the `msm_strauss_endo` window-1/2/3 k256 tests.
- crate-scoped clippy + fmt clean; `cargo doc --document-private-items` has no broken links; `ethsign`/`bitcoin_p2pkh`/`ec_msm` snapshots verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)