### PR TITLE
Prove a truncated BIP32 tree (BINIUS-79)

### DIFF
--- a/crates/bip32-sig/Cargo.toml
+++ b/crates/bip32-sig/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow.workspace = true
+binius-circuits = { path = "../circuits" }
 binius-core = { path = "../core" }
 binius-examples = { path = "../examples", default-features = false }
 binius-frontend = { path = "../frontend" }
@@ -27,6 +28,7 @@ hex.workspace = true
 rand = { workspace = true, features = ["thread_rng"] }
 ripemd.workspace = true
 sha2.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 hex-literal.workspace = true

--- a/crates/bip32-sig/src/address.rs
+++ b/crates/bip32-sig/src/address.rs
@@ -18,7 +18,9 @@ use bitcoin::{
 use ripemd::{Digest as _, Ripemd160};
 use sha2::Sha256;
 
-/// Bit 31 of a derivation index marks a hardened child (matches `Bip32Example`).
+use crate::derive::DerivationInputs;
+
+/// Bit 31 of a derivation index marks a hardened child.
 pub const HARDENED_BIT: u32 = 0x8000_0000;
 
 /// All address types the demo supports. Each maps to its standard BIP purpose.
@@ -70,7 +72,7 @@ impl AddressType {
 }
 
 /// A BIP44-style path `m/purpose'/0'/account'/change/index` as raw indices (hardened bit set on the
-/// first three levels). Depth 5, matching the circuit's `max_depth`.
+/// first three levels). Depth 5: three hardened levels and a two-level non-hardened suffix.
 pub fn bip44_path(ty: AddressType, account: u32, change: u32, index: u32) -> Vec<u32> {
 	vec![
 		ty.purpose() | HARDENED_BIT,
@@ -142,6 +144,74 @@ pub fn derive_compressed_pubkey(seed: &[u8; 64], path: &[u32]) -> Result<Compres
 		.map_err(|e| anyhow::anyhow!("derivation failed: {e}"))?;
 	let pubkey = PublicKey::from_secret_key(&secp, &derived.private_key);
 	Ok(CompressedPublicKey(pubkey))
+}
+
+/// Map an arbitrary BIP32 path onto the truncated circuit's inputs.
+///
+/// The circuit reaches the start of its non-hardened chain by either the seed master key or a
+/// single hardened step from a parent extended private key. The split is therefore at the path's
+/// **last** hardened level: everything before it (any mix of hardened/non-hardened levels) is
+/// derived offline into `parent_xprivkey`, that last hardened level becomes the in-circuit hardened
+/// step, and the suffix after it — necessarily all non-hardened — becomes `path`. A path with no
+/// hardened levels derives straight from the seed master key. The only requirement is that the
+/// non-hardened suffix fit `max_depth`.
+pub fn split_derivation(
+	seed: &[u8; 64],
+	path: &[u32],
+	max_depth: usize,
+) -> Result<DerivationInputs> {
+	// Index of the last hardened level; everything after it is non-hardened by construction.
+	match path.iter().rposition(|&idx| idx & HARDENED_BIT != 0) {
+		None => {
+			// No hardened levels: derive straight from the seed master key.
+			ensure_suffix_fits(path.len(), max_depth)?;
+			Ok(DerivationInputs {
+				seed: *seed,
+				parent_xprivkey: [0u8; 64],
+				hardened_index: 0,
+				use_seed: true,
+				path: path.to_vec(),
+			})
+		}
+		Some(last) => {
+			let suffix = &path[last + 1..];
+			ensure_suffix_fits(suffix.len(), max_depth)?;
+			// Levels before the last hardened one (any mix) fold into the parent offline.
+			Ok(DerivationInputs {
+				seed: *seed,
+				parent_xprivkey: derive_xprivkey(seed, &path[..last])?,
+				hardened_index: path[last] & !HARDENED_BIT,
+				use_seed: false,
+				path: suffix.to_vec(),
+			})
+		}
+	}
+}
+
+/// Error if the non-hardened suffix is deeper than the circuit supports.
+fn ensure_suffix_fits(suffix_len: usize, max_depth: usize) -> Result<()> {
+	if suffix_len > max_depth {
+		bail!("non-hardened suffix depth {suffix_len} exceeds the circuit maximum of {max_depth}");
+	}
+	Ok(())
+}
+
+/// Derive the extended private key at `path` as the raw 64 bytes `private_key || chain_code`.
+fn derive_xprivkey(seed: &[u8; 64], path: &[u32]) -> Result<[u8; 64]> {
+	let secp = Secp256k1::new();
+	let master = Xpriv::new_master(NetworkKind::Main, seed)
+		.map_err(|e| anyhow::anyhow!("master key: {e}"))?;
+	let children: Vec<ChildNumber> = path
+		.iter()
+		.map(|&idx| child_number(idx))
+		.collect::<Result<_>>()?;
+	let xpriv = master
+		.derive_priv(&secp, &children)
+		.map_err(|e| anyhow::anyhow!("derivation failed: {e}"))?;
+	let mut raw = [0u8; 64];
+	raw[..32].copy_from_slice(&xpriv.private_key.secret_bytes());
+	raw[32..].copy_from_slice(&xpriv.chain_code.to_bytes());
+	Ok(raw)
 }
 
 /// SHA-256 of the 33-byte compressed public key — the circuit's public input.

--- a/crates/bip32-sig/src/circuit.rs
+++ b/crates/bip32-sig/src/circuit.rs
@@ -12,11 +12,7 @@ use binius_core::{
 	constraint_system::{ConstraintSystem, ValueVecLayout},
 	word::Word,
 };
-use binius_examples::{
-	ExampleCircuit,
-	circuits::bip32::{Bip32Example, Instance, Params},
-	setup_zk,
-};
+use binius_examples::setup_zk;
 use binius_frontend::{Circuit, CircuitBuilder};
 use binius_hash::StdHashSuite;
 use binius_utils::serialization::{DeserializeBytes, SerializeBytes};
@@ -26,9 +22,12 @@ use binius_verifier::{
 	zk_config::ZKVerifier,
 };
 
-/// BIP32 tree depth supported by the circuit (matches the `bip32` example default). A BIP44 path
-/// `m/purpose'/coin'/account'/change/index` is exactly this deep.
-pub const MAX_DEPTH: usize = 5;
+use crate::derive::{DerivationInputs, TruncatedBip32};
+
+/// Length of the non-hardened derivation chain the circuit supports. The starting key is reached by
+/// a single hardened step (or the seed master), so a BIP44 wallet maps onto a depth-2 non-hardened
+/// suffix `change/index`.
+pub const MAX_DEPTH: usize = 2;
 
 /// Log of the inverse rate for the proof system. Must match between prove and verify.
 pub const LOG_INV_RATE: usize = 3;
@@ -45,17 +44,12 @@ pub fn cs_cache_path() -> PathBuf {
 	PathBuf::from(CS_CACHE_FILE)
 }
 
-/// Build the circuit and the example wrapper used to populate witnesses.
-pub fn build_circuit() -> Result<(Circuit, Bip32Example)> {
+/// Build the circuit and the witness-population helper.
+pub fn build_circuit() -> Result<(Circuit, TruncatedBip32)> {
 	let mut builder = CircuitBuilder::new();
-	let example = Bip32Example::build(
-		Params {
-			max_depth: MAX_DEPTH,
-		},
-		&mut builder,
-	)?;
+	let circuit_def = TruncatedBip32::build(MAX_DEPTH, &mut builder);
 	let circuit = builder.build();
-	Ok((circuit, example))
+	Ok((circuit, circuit_def))
 }
 
 /// Serialize a constraint system to `path`, creating parent directories as needed.
@@ -112,16 +106,16 @@ pub struct Proof {
 	pub verify_time: Duration,
 }
 
-/// Generate a signature-of-knowledge proof for `(seed, path)` over `message`, and self-verify it.
+/// Generate a signature-of-knowledge proof for `inputs` over `message`, and self-verify it.
 ///
 /// The three phases are timed independently: setup (circuit build + prover/verifier setup) is
 /// witness-independent and is the part a future cache could elide; proving covers witness
 /// generation and `prove_sig`; verification is the self-check and is kept out of the proving time.
-pub fn prove(seed: &[u8; 64], path: &[u32], message: &[u8]) -> Result<Proof> {
+pub fn prove(inputs: &DerivationInputs, message: &[u8]) -> Result<Proof> {
 	// Phase 1 — setup: build the circuit and the prover/verifier. None of this depends on the
 	// witness, so it is the work a serialized setup would let us skip.
 	let setup_start = Instant::now();
-	let (circuit, example) = build_circuit()?;
+	let (circuit, circuit_def) = build_circuit()?;
 	let cs = circuit.constraint_system().clone();
 	let (verifier, prover) = setup_zk::<StdHashSuite>(cs, LOG_INV_RATE)?;
 	let setup_time = setup_start.elapsed();
@@ -129,11 +123,7 @@ pub fn prove(seed: &[u8; 64], path: &[u32], message: &[u8]) -> Result<Proof> {
 	// Phase 2 — witness generation + proving.
 	let proving_start = Instant::now();
 	let mut filler = circuit.new_witness_filler();
-	let instance = Instance {
-		seed: Some(hex::encode(seed)),
-		path: path.to_vec(),
-	};
-	example.populate_witness(instance, &mut filler)?;
+	circuit_def.populate_witness(inputs, &mut filler)?;
 	circuit.populate_wire_witness(&mut filler)?;
 	let witness = filler.into_value_vec();
 

--- a/crates/bip32-sig/src/derive.rs
+++ b/crates/bip32-sig/src/derive.rs
@@ -1,0 +1,425 @@
+// Copyright 2026 The Binius Developers
+//! The truncated-BIP32 circuit statement and its reference derivation oracle.
+//!
+//! The statement proves knowledge of a private witness whose derived compressed secp256k1 public
+//! key hashes (SHA-256) to a public digest. The witness derives that key by either:
+//!
+//! * starting from the seed master key (`use_seed`), or
+//! * taking a single hardened child step from a supplied parent extended private key,
+//!
+//! and then following a non-hardened-only path. Seed, parent key, hardened index, path, and depth
+//! are all private; only the SHA-256 digest is public (`inout`).
+
+use std::{array, iter};
+
+use anyhow::{Result, bail};
+use binius_circuits::{
+	bignum::select as select_biguint,
+	bitcoin::p2pkh_signature::compress_pubkey,
+	ecdsa::scalar_mul::scalar_mul,
+	multiplexer::multi_wire_multiplex,
+	secp256k1::{Secp256k1, Secp256k1Affine},
+	sha256::sha256_fixed,
+};
+use binius_core::word::Word;
+use binius_examples::circuits::bip32::{
+	extended_key_parts, hardened_child, master_from_seed, non_hardened_child,
+};
+use binius_frontend::{CircuitBuilder, Wire, WitnessFiller};
+use bitcoin::{
+	NetworkKind,
+	bip32::{ChainCode, ChildNumber, Fingerprint, Xpriv},
+	secp256k1::{PublicKey, Secp256k1 as BtcSecp256k1, SecretKey},
+};
+use sha2::{Digest, Sha256};
+
+/// Bit 31 of a derivation index marks a hardened child; valid indices are below it.
+const HARDENED_BIT: u32 = 0x8000_0000;
+
+/// Bit 63 of the packed index word carries the `use_seed` flag.
+const USE_SEED_BIT: u64 = 1 << 63;
+
+/// Number of 4-byte big-endian words in a SHA-256 digest.
+const N_HASH_WORDS: usize = 8;
+
+/// Circuit-native inputs for one truncated-BIP32 derivation.
+pub struct DerivationInputs {
+	/// 64-byte BIP32 seed (used only when `use_seed`).
+	pub seed: [u8; 64],
+	/// 64-byte extended private key `private_key || chain_code` (used when `!use_seed`).
+	pub parent_xprivkey: [u8; 64],
+	/// Hardened child index (31-bit) applied to `parent_xprivkey` (used when `!use_seed`).
+	pub hardened_index: u32,
+	/// Start from the seed master key instead of a hardened step from `parent_xprivkey`.
+	pub use_seed: bool,
+	/// Non-hardened derivation path; each index must be below `2^31`.
+	pub path: Vec<u32>,
+}
+
+/// The truncated-BIP32 circuit: asserts that the SHA-256 of the derived compressed public key
+/// equals the public digest.
+pub struct TruncatedBip32 {
+	seed: [Wire; 8],
+	parent_xprivkey: [Wire; 8],
+	hardened_index: Wire,
+	path: Vec<Wire>,
+	path_length: Wire,
+	expected_hash: [Wire; N_HASH_WORDS],
+	max_depth: usize,
+}
+
+impl TruncatedBip32 {
+	/// Build the circuit for a non-hardened chain of up to `max_depth` steps.
+	pub fn build(max_depth: usize, builder: &mut CircuitBuilder) -> Self {
+		let seed: [Wire; 8] = array::from_fn(|_| builder.add_witness());
+		let parent_xprivkey: [Wire; 8] = array::from_fn(|_| builder.add_witness());
+		let hardened_index = builder.add_witness();
+		let path: Vec<Wire> = (0..max_depth).map(|_| builder.add_witness()).collect();
+		let path_length = builder.add_witness();
+
+		let pubkey = truncated_derive_compressed(
+			builder,
+			&seed,
+			&parent_xprivkey,
+			hardened_index,
+			&path,
+			path_length,
+		);
+
+		// SHA-256 of the 33-byte compressed public key is the only public input.
+		let digest = sha256_fixed(builder, &pubkey, 33);
+		let expected_hash: [Wire; N_HASH_WORDS] = array::from_fn(|_| builder.add_inout());
+		for (idx, (&computed, &expected)) in digest.iter().zip(&expected_hash).enumerate() {
+			builder.assert_eq(format!("pubkey_hash[{idx}]"), computed, expected);
+		}
+
+		Self {
+			seed,
+			parent_xprivkey,
+			hardened_index,
+			path,
+			path_length,
+			expected_hash,
+			max_depth,
+		}
+	}
+
+	/// Populate the witness for `inputs`, computing the expected digest with a `bitcoin`-crate
+	/// oracle.
+	pub fn populate_witness(&self, inputs: &DerivationInputs, w: &mut WitnessFiller) -> Result<()> {
+		if inputs.path.len() > self.max_depth {
+			bail!("path depth {} exceeds max_depth {}", inputs.path.len(), self.max_depth);
+		}
+		if inputs.hardened_index >= HARDENED_BIT {
+			bail!("hardened index {} out of range (must be < 2^31)", inputs.hardened_index);
+		}
+		if let Some(&idx) = inputs.path.iter().find(|&&i| i >= HARDENED_BIT) {
+			bail!("path index {idx} must be non-hardened (< 2^31)");
+		}
+
+		pack_be_words(&inputs.seed, &self.seed, w);
+		pack_be_words(&inputs.parent_xprivkey, &self.parent_xprivkey, w);
+
+		let mut index_word = inputs.hardened_index as u64;
+		if inputs.use_seed {
+			index_word |= USE_SEED_BIT;
+		}
+		w[self.hardened_index] = Word::from_u64(index_word);
+
+		// Pad unused tail levels with index 0 (a normal child, never selected).
+		for i in 0..self.max_depth {
+			let idx = inputs.path.get(i).copied().unwrap_or(0);
+			w[self.path[i]] = Word::from_u64(idx as u64);
+		}
+		w[self.path_length] = Word::from_u64(inputs.path.len() as u64);
+
+		let pubkey = oracle_compressed_pubkey(inputs)?;
+		let hash: [u8; 32] = Sha256::digest(pubkey).into();
+		for (&wire, chunk) in iter::zip(&self.expected_hash, hash.chunks_exact(4)) {
+			let word = u32::from_be_bytes(chunk.try_into().expect("4-byte chunk"));
+			w[wire] = Word::from_u64(word as u64);
+		}
+
+		tracing::info!(
+			"truncated BIP32 compressed pubkey {} -> SHA-256 {} (use_seed {}, depth {})",
+			hex::encode(pubkey),
+			hex::encode(hash),
+			inputs.use_seed,
+			inputs.path.len()
+		);
+		Ok(())
+	}
+}
+
+/// Derive the compressed public key for the truncated tree: start from the seed master key or one
+/// hardened step from `parent_xprivkey` (selected on bit 63 of `hardened_index`), then run a
+/// non-hardened-only chain over `path`, selecting the level at `path_length` with a multiplexer.
+///
+/// Composed from the per-step gadgets in [`binius_examples::circuits::bip32`].
+fn truncated_derive_compressed(
+	b: &mut CircuitBuilder,
+	seed: &[Wire; 8],
+	parent_xprivkey: &[Wire; 8],
+	hardened_index: Wire,
+	path: &[Wire],
+	path_length: Wire,
+) -> Vec<Wire> {
+	let curve = Secp256k1::new(b);
+
+	// Starting extended private key: the seed master key, or one hardened step from the parent.
+	let (k_seed, c_seed) = master_from_seed(b, seed);
+	let (k_par, c_par) = extended_key_parts(parent_xprivkey);
+	let (k_hard, c_hard) = hardened_child(b, &curve, &k_par, &c_par, hardened_index);
+
+	// Bit 63 of `hardened_index` is the (MSB) `use_seed` flag selecting the master branch.
+	let mut k = select_biguint(b, hardened_index, &k_seed, &k_hard);
+	let mut c: [Wire; 4] = array::from_fn(|i| b.select(hardened_index, c_seed[i], c_hard[i]));
+
+	// Non-hardened chain. Run the full max_depth and select the public key at `path_length`. The
+	// compressed pubkey at each level is the parent for the next CKD and a multiplexer candidate.
+	let mut serp_levels: Vec<Vec<Wire>> = Vec::with_capacity(path.len() + 1);
+	for &index in path {
+		let point = scalar_mul(b, &curve, &k, Secp256k1Affine::generator(b));
+		serp_levels.push(compress_pubkey(b, &point.x, &point.y));
+		(k, c) = non_hardened_child(b, &curve, &k, &c, &point, index);
+	}
+	let point = scalar_mul(b, &curve, &k, Secp256k1Affine::generator(b));
+	serp_levels.push(compress_pubkey(b, &point.x, &point.y));
+
+	let refs: Vec<&[Wire]> = serp_levels.iter().map(Vec::as_slice).collect();
+	multi_wire_multiplex(b, &refs, path_length)
+}
+
+/// Pack 64 big-endian bytes into eight 64-bit words.
+fn pack_be_words(bytes: &[u8; 64], wires: &[Wire; 8], w: &mut WitnessFiller) {
+	for (&wire, chunk) in iter::zip(wires, bytes.chunks_exact(8)) {
+		w[wire] = Word::from_u64(u64::from_be_bytes(chunk.try_into().expect("8-byte chunk")));
+	}
+}
+
+/// Reference oracle mirroring the circuit statement: returns the 33-byte compressed public key.
+fn oracle_compressed_pubkey(inputs: &DerivationInputs) -> Result<[u8; 33]> {
+	let secp = BtcSecp256k1::new();
+
+	// Starting extended private key: seed master, or one hardened step from the parent.
+	let start = if inputs.use_seed {
+		Xpriv::new_master(NetworkKind::Main, &inputs.seed)
+			.map_err(|e| anyhow::anyhow!("invalid master key: {e}"))?
+	} else {
+		let parent = xpriv_from_raw(&inputs.parent_xprivkey)?;
+		let child = ChildNumber::from_hardened_idx(inputs.hardened_index)
+			.map_err(|e| anyhow::anyhow!("invalid hardened index: {e}"))?;
+		parent
+			.derive_priv(&secp, &[child])
+			.map_err(|e| anyhow::anyhow!("hardened derivation failed: {e}"))?
+	};
+
+	let children: Vec<ChildNumber> = inputs
+		.path
+		.iter()
+		.map(|&idx| {
+			ChildNumber::from_normal_idx(idx)
+				.map_err(|e| anyhow::anyhow!("invalid path index {idx}: {e}"))
+		})
+		.collect::<Result<_>>()?;
+	let derived = start
+		.derive_priv(&secp, &children)
+		.map_err(|e| anyhow::anyhow!("path derivation failed: {e}"))?;
+	let pubkey = PublicKey::from_secret_key(&secp, &derived.private_key);
+	Ok(pubkey.serialize())
+}
+
+/// Reconstruct an [`Xpriv`] from a raw 64-byte `private_key || chain_code` extended private key.
+/// Only the private key and chain code affect derivation, so the metadata fields are filled with
+/// the master-key defaults.
+fn xpriv_from_raw(raw: &[u8; 64]) -> Result<Xpriv> {
+	let private_key = SecretKey::from_slice(&raw[..32])
+		.map_err(|e| anyhow::anyhow!("invalid parent private key: {e}"))?;
+	let chain_code = ChainCode::from(<[u8; 32]>::try_from(&raw[32..]).expect("32-byte tail"));
+	Ok(Xpriv {
+		network: NetworkKind::Main,
+		depth: 0,
+		parent_fingerprint: Fingerprint::from([0u8; 4]),
+		child_number: ChildNumber::from_normal_idx(0).expect("0 is a valid normal index"),
+		private_key,
+		chain_code,
+	})
+}
+
+#[cfg(test)]
+mod tests {
+	use binius_core::verify::verify_constraints;
+	use binius_frontend::CircuitBuilder;
+
+	use super::*;
+
+	/// Build the circuit, populate it for `inputs`, and verify all constraints hold (the witness
+	/// population already checks the derived key against the `bitcoin`-crate oracle).
+	fn check(inputs: &DerivationInputs, max_depth: usize) {
+		let mut builder = CircuitBuilder::new();
+		let circuit_def = TruncatedBip32::build(max_depth, &mut builder);
+		let circuit = builder.build();
+
+		let mut w = circuit.new_witness_filler();
+		circuit_def
+			.populate_witness(inputs, &mut w)
+			.expect("populate witness");
+		circuit
+			.populate_wire_witness(&mut w)
+			.expect("witness population");
+		verify_constraints(circuit.constraint_system(), &w.into_value_vec())
+			.expect("constraints satisfied");
+	}
+
+	fn test_seed() -> [u8; 64] {
+		array::from_fn(|i| (i as u8).wrapping_mul(7).wrapping_add(1))
+	}
+
+	/// A deterministic 64-byte parent extended private key (a valid scalar followed by a chain
+	/// code).
+	fn test_parent_xprivkey() -> [u8; 64] {
+		array::from_fn(|i| (i as u8).wrapping_mul(5).wrapping_add(3))
+	}
+
+	#[test]
+	fn use_seed_with_non_hardened_path() {
+		check(
+			&DerivationInputs {
+				seed: test_seed(),
+				parent_xprivkey: test_parent_xprivkey(),
+				hardened_index: 0,
+				use_seed: true,
+				path: vec![1, 2],
+			},
+			2,
+		);
+	}
+
+	#[test]
+	fn hardened_parent_with_non_hardened_path() {
+		check(
+			&DerivationInputs {
+				seed: test_seed(),
+				parent_xprivkey: test_parent_xprivkey(),
+				hardened_index: 7,
+				use_seed: false,
+				path: vec![5, 1_000_000_000],
+			},
+			2,
+		);
+	}
+
+	#[test]
+	fn empty_path_outputs_starting_key() {
+		// path_length 0 must output the starting xprivkey's public key, for both branches.
+		check(
+			&DerivationInputs {
+				seed: test_seed(),
+				parent_xprivkey: test_parent_xprivkey(),
+				hardened_index: 0,
+				use_seed: true,
+				path: vec![],
+			},
+			2,
+		);
+		check(
+			&DerivationInputs {
+				seed: test_seed(),
+				parent_xprivkey: test_parent_xprivkey(),
+				hardened_index: 3,
+				use_seed: false,
+				path: vec![],
+			},
+			2,
+		);
+	}
+
+	#[test]
+	fn short_path_with_padding() {
+		// depth 1 within a max-depth-3 circuit exercises the multiplexer and the ignored tail.
+		check(
+			&DerivationInputs {
+				seed: test_seed(),
+				parent_xprivkey: test_parent_xprivkey(),
+				hardened_index: 0,
+				use_seed: false,
+				path: vec![9],
+			},
+			3,
+		);
+	}
+
+	#[test]
+	fn full_depth_hardened() {
+		check(
+			&DerivationInputs {
+				seed: test_seed(),
+				parent_xprivkey: test_parent_xprivkey(),
+				hardened_index: HARDENED_BIT - 1,
+				use_seed: false,
+				path: vec![0, 1, 2],
+			},
+			3,
+		);
+	}
+
+	/// The truncated derivation of a full BIP44 path (`split_derivation` → one in-circuit hardened
+	/// step → non-hardened suffix) must reproduce the same compressed public key as deriving the
+	/// whole path directly. This is what binds a generated proof to the wallet's real address.
+	#[test]
+	fn matches_full_bip44_derivation() {
+		use crate::address::{
+			AddressType, bip44_path, derive_compressed_pubkey, pubkey_sha256, split_derivation,
+		};
+
+		let seed = test_seed();
+		let path = bip44_path(AddressType::P2pkh, 3, 1, 7);
+		let inputs = split_derivation(&seed, &path, 2).expect("split BIP44 path");
+
+		// `check` confirms the circuit agrees with the oracle; the oracle here is shown to
+		// reproduce the full-path derivation. Together: the circuit reproduces the wallet's real
+		// public key.
+		check(&inputs, 2);
+		let truncated: [u8; 32] = Sha256::digest(oracle_compressed_pubkey(&inputs).unwrap()).into();
+		let full = derive_compressed_pubkey(&seed, &path).expect("full derivation");
+		assert_eq!(truncated, pubkey_sha256(&full));
+	}
+
+	/// `split_derivation` must handle hardened levels *following* non-hardened ones: it splits at
+	/// the last hardened level, folding the (mixed) prefix into the offline parent.
+	#[test]
+	fn matches_mixed_hardened_path() {
+		use crate::address::{derive_compressed_pubkey, pubkey_sha256, split_derivation};
+
+		let seed = test_seed();
+		let path = vec![0, 1 | HARDENED_BIT, 2]; // m/0/1'/2 — a hardened level after a non-hardened one
+		let inputs = split_derivation(&seed, &path, 2).expect("split mixed path");
+		assert!(!inputs.use_seed);
+
+		check(&inputs, 2);
+		let truncated: [u8; 32] = Sha256::digest(oracle_compressed_pubkey(&inputs).unwrap()).into();
+		let full = derive_compressed_pubkey(&seed, &path).expect("full derivation");
+		assert_eq!(truncated, pubkey_sha256(&full));
+	}
+
+	#[test]
+	fn rejects_hardened_path_index() {
+		let mut builder = CircuitBuilder::new();
+		let circuit_def = TruncatedBip32::build(2, &mut builder);
+		let circuit = builder.build();
+		let mut w = circuit.new_witness_filler();
+		let err = circuit_def
+			.populate_witness(
+				&DerivationInputs {
+					seed: test_seed(),
+					parent_xprivkey: test_parent_xprivkey(),
+					hardened_index: 0,
+					use_seed: true,
+					path: vec![HARDENED_BIT],
+				},
+				&mut w,
+			)
+			.unwrap_err();
+		assert!(err.to_string().contains("non-hardened"));
+	}
+}

--- a/crates/bip32-sig/src/main.rs
+++ b/crates/bip32-sig/src/main.rs
@@ -2,11 +2,12 @@
 //! Interactive CLI for BIP32 Bitcoin signatures of knowledge.
 //!
 //! Proves, in zero knowledge, that you control the seed behind a Bitcoin address and signs a
-//! message with it — without revealing the seed. A thin, friendly wrapper over the `bip32` circuit
-//! in `binius-examples`.
+//! message with it — without revealing the seed. A thin, friendly wrapper over the truncated-BIP32
+//! circuit in [`crate::derive`].
 
 mod address;
 mod circuit;
+mod derive;
 mod proof_file;
 
 use std::{
@@ -24,7 +25,7 @@ use sha2::{Digest, Sha256};
 use crate::{
 	address::{
 		AddressType, address_for, bind_address_to_hash, bip44_path, derive_compressed_pubkey,
-		format_path, parse_address, parse_path, scan_for_path,
+		format_path, parse_address, parse_path, scan_for_path, split_derivation,
 	},
 	circuit::{MAX_DEPTH, cs_cache_path, load_or_create_cs},
 	proof_file::ProofFile,
@@ -104,7 +105,8 @@ fn run_prove(use_existing: bool) -> Result<()> {
 	}
 
 	println!("\nGenerating proof…");
-	let proof = circuit::prove(&wallet.seed, &wallet.path, message.as_bytes())?;
+	let inputs = split_derivation(&wallet.seed, &wallet.path, MAX_DEPTH)?;
+	let proof = circuit::prove(&inputs, message.as_bytes())?;
 	let (setup_time, proving_time, verify_time) =
 		(proof.setup_time, proof.proving_time, proof.verify_time);
 
@@ -220,9 +222,8 @@ fn existing_address_wallet() -> Result<Wallet> {
 			println!("Path not found within {SCAN_LIMIT} addresses.");
 			let entered = prompt_line("Enter the BIP32 path manually (e.g. 44'/0'/0'/0/0): ")?;
 			let path = parse_path(&entered)?;
-			if path.len() > MAX_DEPTH {
-				bail!("path depth {} exceeds the circuit maximum of {MAX_DEPTH}", path.len());
-			}
+			// `split_derivation` (at proving time) enforces the truncated-circuit shape: hardened
+			// levels followed by a non-hardened suffix of at most `MAX_DEPTH`.
 			let pubkey = derive_compressed_pubkey(&seed, &path)?;
 			if address_for(ty, &pubkey) != address {
 				bail!("the entered path does not derive the given address");

--- a/crates/examples/src/circuits/bip32.rs
+++ b/crates/examples/src/circuits/bip32.rs
@@ -6,6 +6,10 @@
 //! maximum tree depth and the public key at the actual path depth is selected with a multiplexer,
 //! so the circuit shape is independent of the (witness) depth.
 //!
+//! The per-step building blocks are also exposed for composing other derivations:
+//! [`master_from_seed`], [`extended_key_parts`], [`hardened_child`], [`non_hardened_child`], and
+//! the branch-selecting [`child`].
+//!
 //! BIP32 spec: <https://en.bitcoin.it/wiki/BIP_0032>.
 //!
 //! # Word conventions
@@ -70,49 +74,18 @@ pub fn bip32_derive_compressed(
 	let max_depth = path.len();
 	let curve = Secp256k1::new(b);
 
-	// Master key: I = HMAC-SHA512("Bitcoin seed", seed). HMAC zero-pads the key to the block size,
-	// so the four trailing zero bytes of the second key word are exactly the padding the spec adds.
-	let key_words = [
-		b.add_constant_64(u64::from_be_bytes(*b"Bitcoin ")),
-		b.add_constant_64(u64::from_be_bytes([b's', b'e', b'e', b'd', 0, 0, 0, 0])),
-	];
-	let master = hmac_sha512_fixed(b, &key_words, seed, 64);
-	let mut k = il_scalar(&master);
-	let mut c = ir_words(&master);
+	let (mut k, mut c) = master_from_seed(b, seed);
 
 	// Compressed public key at every level 0..=max_depth: needed as the parent pubkey for any
 	// non-hardened step, and as the candidates for the depth multiplexer.
 	let mut serp_levels: Vec<Vec<Wire>> = Vec::with_capacity(max_depth + 1);
 
-	for level in 0..max_depth {
-		// Parent public key P = k * G.
+	for &index in path {
+		// Parent public key P = k * G, reused both as a multiplexer candidate and (for a
+		// non-hardened step) as the CKD input.
 		let point = scalar_mul(b, &curve, &k, Secp256k1Affine::generator(b));
 		serp_levels.push(compress_pubkey(b, &point.x, &point.y));
-
-		// Hardened iff bit 31 of the index is set (moved to the MSB for `select`).
-		let is_hardened = b.shl(path[level], 32);
-
-		// CKD data is `prefix || value[32] || ser32(index)` either way (37 bytes):
-		// hardened => 0x00 || ser256(k_par); normal => (0x02|0x03) || x_be.
-		let prefix_norm = compressed_prefix(b, &point.y);
-		let prefix = b.select(is_hardened, b.add_constant(Word::ZERO), prefix_norm);
-		// Select the 32-byte value field (the scalar `k` or the x-coordinate), then read it out as
-		// big-endian words (limb `3 - i` is the i-th most significant word).
-		let value_field = select_biguint(b, is_hardened, &k, &point.x);
-		let value = [
-			value_field.limbs[3],
-			value_field.limbs[2],
-			value_field.limbs[1],
-			value_field.limbs[0],
-		];
-
-		let message = assemble_message(b, prefix, &value, path[level]);
-		let i = hmac_sha512_fixed(b, &c, &message, 37);
-
-		// k_child = (parse256(I_L) + k_par) mod n ; c_child = I_R.
-		let il = il_scalar(&i);
-		k = curve.f_scalar().add(b, &il, &k);
-		c = ir_words(&i);
+		(k, c) = child(b, &curve, &k, &c, &point, index);
 	}
 
 	// Compressed public key for the deepest derived level.
@@ -121,6 +94,113 @@ pub fn bip32_derive_compressed(
 
 	let refs: Vec<&[Wire]> = serp_levels.iter().map(Vec::as_slice).collect();
 	multi_wire_multiplex(b, &refs, depth)
+}
+
+/// Master key from the BIP32 seed: `I = HMAC-SHA512("Bitcoin seed", seed)`, returned (via
+/// [`extended_key_parts`]) as the scalar `parse256(I_L)` and the chain code `I_R`.
+///
+/// HMAC zero-pads the key to the block size, so the four trailing zero bytes of the second key word
+/// are exactly the padding the spec adds.
+pub fn master_from_seed(b: &mut CircuitBuilder, seed: &[Wire; 8]) -> (BigUint, [Wire; 4]) {
+	let key_words = [
+		b.add_constant_64(u64::from_be_bytes(*b"Bitcoin ")),
+		b.add_constant_64(u64::from_be_bytes([b's', b'e', b'e', b'd', 0, 0, 0, 0])),
+	];
+	let master = hmac_sha512_fixed(b, &key_words, seed, 64);
+	extended_key_parts(&master)
+}
+
+/// Split a SHA-512-shaped 64-byte value `I = I_L || I_R` (eight big-endian 64-bit words — the
+/// layout of both an HMAC-SHA512 output and a raw BIP32 extended private key `private_key ||
+/// chain_code`) into the 256-bit scalar `parse256(I_L)` and the chain code `I_R` (four big-endian
+/// words, ready to use directly as an HMAC-SHA512 key).
+pub fn extended_key_parts(key: &[Wire; 8]) -> (BigUint, [Wire; 4]) {
+	(il_scalar(key), ir_words(key))
+}
+
+/// One BIP32 child-key-derivation step that selects between a hardened and a non-hardened child on
+/// bit 31 of `index`, sharing a single HMAC-SHA512.
+///
+/// `k_par`/`c_par` are the parent scalar and chain code; `parent_point` must be `k_par * G` (the
+/// non-hardened branch hashes the parent public key). Returns the child `(scalar, chain code)`.
+pub fn child(
+	b: &mut CircuitBuilder,
+	curve: &Secp256k1,
+	k_par: &BigUint,
+	c_par: &[Wire; 4],
+	parent_point: &Secp256k1Affine,
+	index: Wire,
+) -> (BigUint, [Wire; 4]) {
+	// Hardened iff bit 31 of the index is set (moved to the MSB for `select`).
+	let is_hardened = b.shl(index, 32);
+
+	// CKD data is `prefix || value[32] || ser32(index)` either way (37 bytes):
+	// hardened => 0x00 || ser256(k_par); normal => (0x02|0x03) || x_be.
+	let prefix_norm = compressed_prefix(b, &parent_point.y);
+	let prefix = b.select(is_hardened, b.add_constant(Word::ZERO), prefix_norm);
+	let value = select_biguint(b, is_hardened, k_par, &parent_point.x);
+
+	let message = assemble_message(b, prefix, &biguint_be_words(&value), index);
+	ckd_from_message(b, curve, k_par, c_par, &message)
+}
+
+/// One hardened BIP32 CKD step: `I = HMAC-SHA512(c_par, 0x00 || ser256(k_par) || ser32(index |
+/// 2^31))`. Any bits of `index` at or above bit 31 are ignored — the message assembly keeps only
+/// the low 32 and the hardened bit is forced on. Because it hashes the parent *scalar* directly, a
+/// hardened step needs no parent public key and therefore no scalar multiplication.
+pub fn hardened_child(
+	b: &mut CircuitBuilder,
+	curve: &Secp256k1,
+	k_par: &BigUint,
+	c_par: &[Wire; 4],
+	index: Wire,
+) -> (BigUint, [Wire; 4]) {
+	let hardened_index = b.bor(index, b.add_constant_64(HARDENED_BIT as u64));
+	let prefix = b.add_constant(Word::ZERO);
+	let message = assemble_message(b, prefix, &biguint_be_words(k_par), hardened_index);
+	ckd_from_message(b, curve, k_par, c_par, &message)
+}
+
+/// One non-hardened BIP32 CKD step: `I = HMAC-SHA512(c_par, ser_compressed(parent_point) ||
+/// ser32(index))`, where `parent_point` must be `k_par * G`. Only the low 31 bits of `index` are
+/// significant.
+pub fn non_hardened_child(
+	b: &mut CircuitBuilder,
+	curve: &Secp256k1,
+	k_par: &BigUint,
+	c_par: &[Wire; 4],
+	parent_point: &Secp256k1Affine,
+	index: Wire,
+) -> (BigUint, [Wire; 4]) {
+	let prefix = compressed_prefix(b, &parent_point.y);
+	let message = assemble_message(b, prefix, &biguint_be_words(&parent_point.x), index);
+	ckd_from_message(b, curve, k_par, c_par, &message)
+}
+
+/// Finish a CKD step from its assembled 37-byte message: `I = HMAC-SHA512(c_par, message)`, then
+/// `k_child = (parse256(I_L) + k_par) mod n` and `c_child = I_R`.
+fn ckd_from_message(
+	b: &mut CircuitBuilder,
+	curve: &Secp256k1,
+	k_par: &BigUint,
+	c_par: &[Wire; 4],
+	message: &[Wire; 5],
+) -> (BigUint, [Wire; 4]) {
+	let i = hmac_sha512_fixed(b, c_par, message, 37);
+	let (il, c) = extended_key_parts(&i);
+	let k = curve.f_scalar().add(b, &il, k_par);
+	(k, c)
+}
+
+/// The four 64-bit limbs of a 256-bit [`BigUint`] in big-endian word order (most significant
+/// first), the layout [`assemble_message`] expects for a 32-byte value field.
+fn biguint_be_words(value: &BigUint) -> [Wire; 4] {
+	[
+		value.limbs[3],
+		value.limbs[2],
+		value.limbs[1],
+		value.limbs[0],
+	]
 }
 
 /// Interpret the first 32 bytes (`I_L`) of a SHA-512 output as a 256-bit scalar (four little-endian


### PR DESCRIPTION
Implements the truncated-BIP32 circuit from [BINIUS-79](https://linear.app/jimpo/issue/BINIUS-79/update-circuit-for-truncated-bip32-tree), stacked on the BINIUS-60 `bip32-demo-cli` branch (hence the base; diff is just this change).

Instead of running a full BIP32 derivation in-circuit, this proves a pubkey hash derived from a **non-hardened-only** chain rooted at an xprivkey that is *either* the seed KDF master *or* a single hardened derivation from a supplied parent extended private key. The expensive hardened levels of a path are folded into the private `parent_xprivkey` witness offline, so the in-circuit path loop carries no hardened-vs-normal branching.

### Circuit statement (`binius-bip32-sig`)
- **Public input:** `pk_hash` — a SHA-256 digest.
- **Private:** `seed` (64 B), `parent_xprivkey` (64 B = `private_key ‖ chain_code`), `hardened_index` (31-bit; bit 63 carries the `use_seed` flag), non-hardened `path`, `path_length`.
- If `use_seed`, start from the seed master key; otherwise take one hardened step from `parent_xprivkey`. Then derive along the non-hardened `path`, SHA-256 the compressed public key, and assert it equals `pk_hash`.

### Commits
1. **Expose BIP32 per-step derivation primitives** — refactors the `bip32` module in `binius-examples` to expose `master_from_seed`, `extended_key_parts` (parse a 64-byte `private_key ‖ chain_code` into scalar + chain code), `hardened_child`, `non_hardened_child`, and the branch-selecting `child` (hardened vs. non-hardened sharing a single HMAC-SHA512). The hardened step uses the parent *scalar* directly — no scalar multiplication. The generic `bip32_derive_compressed` loop is rewritten to call `child`; its behavior and the standalone example are unchanged.
2. **Prove a truncated BIP32 tree in bip32-sig** — composes those primitives into the truncated derivation (`truncated_derive_compressed`), the circuit statement (`TruncatedBip32`), a `bitcoin`-crate reference oracle, and the CLI rewiring. `split_derivation` maps an arbitrary path onto the inputs by splitting at the path's **last** hardened level (any prefix mix is derived offline into `parent_xprivkey`). `MAX_DEPTH` is the non-hardened suffix depth (2); address-binding, proof-file format, and verify flow are unchanged.

The reusable per-step gadgets live in the library (`binius-examples`); the application-specific truncated composition lives in the consumer (`binius-bip32-sig`).

### Tests
Circuit tests for the seed and hardened-parent branches, `path_length = 0`, full depth, short-path padding, and hardened-path-index rejection; plus end-to-end checks that `split_derivation` reproduces the directly-derived public key for both a standard BIP44 path and a mixed path (`m/0/1'/2`, hardened after non-hardened). `cargo test` and crate-scoped `clippy` are green on `binius-bip32-sig` and `binius-examples`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)