### PR TITLE
Make ZKProver/ZKVerifier serializable for cross-process reuse (BINIUS-81)

### DIFF
--- a/crates/prover/src/zk_config.rs
+++ b/crates/prover/src/zk_config.rs
@@ -6,7 +6,10 @@
 //! Spartan-based zero-knowledge wrapper. The prover counterpart to
 //! [`binius_verifier::zk_config::ZKVerifier`].
 
-use binius_core::{constraint_system::ValueVec, word::Word};
+use binius_core::{
+	constraint_system::{ConstraintSystem, ValueVec},
+	word::Word,
+};
 use binius_field::{
 	BinaryField128bGhash as B128, PackedExtension, PackedField, UnderlierWithBitOps, WithUnderlier,
 };
@@ -19,13 +22,16 @@ use binius_spartan_verifier::{
 	constraint_system::ConstraintSystemPadded, wrapper::IronSpartanBuilderChannel,
 };
 use binius_transcript::{ProverTranscript, fiat_shamir::Challenger};
-use binius_utils::SerializeBytes;
+use binius_utils::{DeserializeBytes, SerializeBytes, serialization::SerializationError};
 use binius_verifier::{IOPVerifier, zk_config::ZKVerifier};
+use bytes::{Buf, BufMut};
 use digest::Output;
 use rand::CryptoRng;
 
 use crate::{
-	IOPProver, merkle_tree::prover::BinaryMerkleTreeProver, protocols::shift::build_key_collection,
+	IOPProver,
+	merkle_tree::prover::BinaryMerkleTreeProver,
+	protocols::shift::{KeyCollection, build_key_collection},
 };
 
 type ProverNTT<F> = NeighborsLastMultiThread<GenericPreExpanded<F>>;
@@ -58,12 +64,22 @@ where
 {
 	/// Constructs a ZK prover from a [`ZKVerifier`].
 	pub fn setup(zk_verifier: ZKVerifier<H>) -> Result<Self, Error> {
-		// Build the inner IOPProver.
-		let inner_iop_verifier = zk_verifier.inner_iop_verifier().clone();
 		let key_collection = {
 			let _guard = tracing::debug_span!("Build key collection").entered();
-			build_key_collection(inner_iop_verifier.constraint_system())
+			build_key_collection(zk_verifier.inner_iop_verifier().constraint_system())
 		};
+		Self::setup_with_key_collection(zk_verifier, key_collection)
+	}
+
+	/// Constructs a ZK prover from a verifier and a prebuilt [`KeyCollection`], skipping the
+	/// dominant key-collection build. Private: external callers use [`Self::setup`], or
+	/// [`DeserializeBytes::deserialize`] to reuse a serialized prover.
+	fn setup_with_key_collection(
+		zk_verifier: ZKVerifier<H>,
+		key_collection: KeyCollection,
+	) -> Result<Self, Error> {
+		// Build the inner IOPProver.
+		let inner_iop_verifier = zk_verifier.inner_iop_verifier().clone();
 		let inner_iop_prover = IOPProver::new(inner_iop_verifier.clone(), key_collection);
 
 		// Re-derive the outer constraint system and layout via symbolic execution.
@@ -204,6 +220,60 @@ where
 	) -> Result<(), Error> {
 		binius_verifier::signature::observe_message::<H, _>(&mut transcript.observe(), message);
 		self.prove(witness, rng, transcript)
+	}
+}
+
+/// Serializes the seed a [`ZKProver`] is built from — constraint system, `log_inv_rate`, and the
+/// prebuilt [`KeyCollection`]. On [`DeserializeBytes::deserialize`] the key collection (the
+/// dominant setup cost) is reused as-is while the cheaper derived state is recomputed.
+impl<P, H> SerializeBytes for ZKProver<P, H>
+where
+	P: PackedField<Scalar = B128>
+		+ PackedExtension<B128>
+		+ PackedExtension<binius_verifier::config::B1>
+		+ WithUnderlier<Underlier: UnderlierWithBitOps>,
+	H: HashSuite,
+	Output<H::LeafHash>: SerializeBytes + DeserializeBytes,
+{
+	fn serialize(&self, mut write_buf: impl BufMut) -> Result<(), SerializationError> {
+		const VERSION: u32 = 1;
+		VERSION.serialize(&mut write_buf)?;
+		self.inner_iop_verifier
+			.constraint_system()
+			.serialize(&mut write_buf)?;
+		self.basefold_compiler
+			.fri_params()
+			.rs_code()
+			.log_inv_rate()
+			.serialize(&mut write_buf)?;
+		self.inner_iop_prover.key_collection().serialize(write_buf)
+	}
+}
+
+impl<P, H> DeserializeBytes for ZKProver<P, H>
+where
+	P: PackedField<Scalar = B128>
+		+ PackedExtension<B128>
+		+ PackedExtension<binius_verifier::config::B1>
+		+ WithUnderlier<Underlier: UnderlierWithBitOps>,
+	H: HashSuite,
+	Output<H::LeafHash>: SerializeBytes + DeserializeBytes,
+{
+	fn deserialize(mut read_buf: impl Buf) -> Result<Self, SerializationError> {
+		const VERSION: u32 = 1;
+		let version = u32::deserialize(&mut read_buf)?;
+		if version != VERSION {
+			return Err(SerializationError::InvalidConstruction {
+				name: "ZKProver::version",
+			});
+		}
+		let constraint_system = ConstraintSystem::deserialize(&mut read_buf)?;
+		let log_inv_rate = usize::deserialize(&mut read_buf)?;
+		let key_collection = KeyCollection::deserialize(&mut read_buf)?;
+		let zk_verifier = ZKVerifier::setup(constraint_system, log_inv_rate)
+			.map_err(|_| SerializationError::InvalidConstruction { name: "ZKProver" })?;
+		Self::setup_with_key_collection(zk_verifier, key_collection)
+			.map_err(|_| SerializationError::InvalidConstruction { name: "ZKProver" })
 	}
 }
 

--- a/crates/prover/tests/prove_verify.rs
+++ b/crates/prover/tests/prove_verify.rs
@@ -1,4 +1,5 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 use binius_circuits::sha256::{Compress, State};
 use binius_core::{
@@ -10,6 +11,7 @@ use binius_frontend::{CircuitBuilder, Wire};
 use binius_hash::StdHashSuite;
 use binius_prover::{Prover, zk_config::ZKProver};
 use binius_transcript::ProverTranscript;
+use binius_utils::{DeserializeBytes, SerializeBytes};
 use binius_verifier::{Verifier, config::StdChallenger, zk_config::ZKVerifier};
 use rand::{SeedableRng, rngs::StdRng};
 
@@ -39,6 +41,38 @@ fn prove_verify_zk(cs: ConstraintSystem, witness: ValueVec) {
 
 	let zk_prover =
 		ZKProver::<OptimalPackedB128, StdHashSuite>::setup(zk_verifier.clone()).unwrap();
+
+	let mut rng = StdRng::seed_from_u64(0);
+	let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
+	zk_prover
+		.prove(witness.clone(), &mut rng, &mut prover_transcript)
+		.unwrap();
+
+	let mut verifier_transcript = prover_transcript.into_verifier();
+	zk_verifier
+		.verify(witness.public(), &mut verifier_transcript)
+		.unwrap();
+	verifier_transcript.finalize().unwrap();
+}
+
+fn prove_verify_zk_serialized(cs: ConstraintSystem, witness: ValueVec) {
+	const LOG_INV_RATE: usize = 1;
+
+	let zk_verifier = ZKVerifier::<StdHashSuite>::setup(cs, LOG_INV_RATE).unwrap();
+	let zk_prover =
+		ZKProver::<OptimalPackedB128, StdHashSuite>::setup(zk_verifier.clone()).unwrap();
+
+	// Round-trip both through serialization, mimicking save-to-disk / reload-in-a-fresh-process.
+	// The reloaded prover (which reuses the deserialized KeyCollection and recomputes the cheaper
+	// derived state) must produce a proof the reloaded verifier accepts.
+	let mut prover_bytes = Vec::new();
+	zk_prover.serialize(&mut prover_bytes).unwrap();
+	let zk_prover =
+		ZKProver::<OptimalPackedB128, StdHashSuite>::deserialize(prover_bytes.as_slice()).unwrap();
+
+	let mut verifier_bytes = Vec::new();
+	zk_verifier.serialize(&mut verifier_bytes).unwrap();
+	let zk_verifier = ZKVerifier::<StdHashSuite>::deserialize(verifier_bytes.as_slice()).unwrap();
 
 	let mut rng = StdRng::seed_from_u64(0);
 	let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
@@ -102,6 +136,12 @@ fn test_prove_verify_sha256_preimage() {
 fn test_zk_prove_verify_sha256_preimage() {
 	let (cs, witness) = sha256_preimage_circuit();
 	prove_verify_zk(cs, witness);
+}
+
+#[test]
+fn test_zk_prove_verify_serialized() {
+	let (cs, witness) = sha256_preimage_circuit();
+	prove_verify_zk_serialized(cs, witness);
 }
 
 /// Produces a ZK signature-of-knowledge proof over `sign_message`, then verifies it against

--- a/crates/verifier/src/zk_config.rs
+++ b/crates/verifier/src/zk_config.rs
@@ -29,7 +29,11 @@ use binius_spartan_verifier::{
 	wrapper::{IronSpartanBuilderChannel, ZKWrappedVerifierChannel},
 };
 use binius_transcript::{VerifierTranscript, fiat_shamir::Challenger};
-use binius_utils::{DeserializeBytes, checked_arithmetics::log2_ceil_usize};
+use binius_utils::{
+	DeserializeBytes, SerializeBytes, checked_arithmetics::log2_ceil_usize,
+	serialization::SerializationError,
+};
+use bytes::{Buf, BufMut};
 use digest::Output;
 
 use crate::{
@@ -156,6 +160,11 @@ where
 		self.inner_iop_verifier.log_public_words()
 	}
 
+	/// Returns the log of the inverse Reed–Solomon rate this verifier was set up with.
+	pub fn log_inv_rate(&self) -> usize {
+		self.basefold_compiler.fri_params().rs_code().log_inv_rate()
+	}
+
 	/// Verifies a ZK proof against the constraint system.
 	pub fn verify<Challenger_: Challenger>(
 		&self,
@@ -209,6 +218,42 @@ where
 	) -> Result<(), Error> {
 		crate::signature::observe_message::<H, _>(&mut transcript.observe(), message);
 		self.verify(public, transcript)
+	}
+}
+
+/// Serializes the seed a [`ZKVerifier`] is built from — its constraint system and
+/// `log_inv_rate`. The derived state (outer constraint system, oracle specs, BaseFold compiler)
+/// is recomputed on [`DeserializeBytes::deserialize`], which is cheap relative to proving.
+impl<H> SerializeBytes for ZKVerifier<H>
+where
+	H: HashSuite,
+	Output<H::LeafHash>: DeserializeBytes,
+{
+	fn serialize(&self, mut write_buf: impl BufMut) -> Result<(), SerializationError> {
+		const VERSION: u32 = 1;
+		VERSION.serialize(&mut write_buf)?;
+		self.constraint_system().serialize(&mut write_buf)?;
+		self.log_inv_rate().serialize(write_buf)
+	}
+}
+
+impl<H> DeserializeBytes for ZKVerifier<H>
+where
+	H: HashSuite,
+	Output<H::LeafHash>: DeserializeBytes,
+{
+	fn deserialize(mut read_buf: impl Buf) -> Result<Self, SerializationError> {
+		const VERSION: u32 = 1;
+		let version = u32::deserialize(&mut read_buf)?;
+		if version != VERSION {
+			return Err(SerializationError::InvalidConstruction {
+				name: "ZKVerifier::version",
+			});
+		}
+		let constraint_system = ConstraintSystem::deserialize(&mut read_buf)?;
+		let log_inv_rate = usize::deserialize(&mut read_buf)?;
+		Self::setup(constraint_system, log_inv_rate)
+			.map_err(|_| SerializationError::InvalidConstruction { name: "ZKVerifier" })
 	}
 }
 


### PR DESCRIPTION
## Summary

Phase 2 of [BINIUS-61](https://linear.app/jimpo/issue/BINIUS-61) (parent), tracked as [BINIUS-81](https://linear.app/jimpo/issue/BINIUS-81). The Phase 0 measurement showed `build_key_collection` is the dominant ZK-setup cost (~53% / ~620 ms on the depth-5 BIP32 circuit). It's witness-independent, so it can be built once, serialized, and reloaded in a fresh process to skip the rebuild — the high-leverage cold-start win.

Implemented per review feedback as `SerializeBytes`/`DeserializeBytes` **on the structs** rather than exposing `KeyCollection` through a `setup_with_key_collection` signature:

1. **`Implement SerializeBytes/DeserializeBytes for ZKVerifier`** — `ZKVerifier` retains `log_inv_rate` and serializes as its seed `(constraint_system, log_inv_rate)`; `deserialize` reconstructs the derived state (outer CS, oracle specs, BaseFold compiler) by routing through `setup`.
2. **`Add SerializeBytes/DeserializeBytes for ZKProver; privatize key-collection injection`** — `ZKProver` serializes as `(constraint_system, log_inv_rate, key_collection)`; `deserialize` reuses the deserialized `KeyCollection` (the ~620 ms part) and recomputes the cheaper derived state (symbolic-exec / outer circuit ~27 ms, NTT domain ~3.5 ms). `setup_with_key_collection` is now **private**, used only by `setup` and `deserialize`, so the public surface is `setup` / `serialize` / `deserialize` (no `KeyCollection` leak). Setup/validation failures in `deserialize` map to `SerializationError::InvalidConstruction`.

So a process with a serialized `ZKProver` calls `ZKProver::deserialize(bytes)` instead of `ZKProver::setup(verifier)` and skips the dominant cost. The blob is self-contained (embeds the CS); NTT sharding is thread-count-dependent but internal to proving, so a blob is portable across machines.

## Validation

`cargo test -p binius-prover --test prove_verify` — new `test_zk_prove_verify_serialized` round-trips both structs through serialize/deserialize, then proves with the reloaded prover and verifies with the reloaded verifier (accept, not byte-equality — ZK proofs are randomized).

## Scope

CLI plumbing is out of scope here (under this design the CLI would load a serialized `ZKProver`, not a `KeyCollection`); the real consumer is the `binius-bip32-sig` CLI, gated on BINIUS-60. Phase 1 (de-dup symbolic-exec, ~27 ms) and Phase 3 (serialize NTT, ~3.5 ms) remain dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)