### PR TITLE
Make Divisible a supertrait of PackedField and Field

### DIFF
--- a/crates/field/benches/packed_field_element_access.rs
+++ b/crates/field/benches/packed_field_element_access.rs
@@ -36,7 +36,7 @@ fn benchmark_set_impl<P: PackedField>(group: &mut BenchmarkGroup<'_, WallTime>, 
 		b.iter(|| {
 			indices_values
 				.iter()
-				.for_each(|(i, val)| value.set(*i, *val));
+				.for_each(|(i, val)| PackedField::set(&mut value, *i, *val));
 
 			value
 		})

--- a/crates/field/src/arch/aarch64/packed_aes_128.rs
+++ b/crates/field/src/arch/aarch64/packed_aes_128.rs
@@ -49,7 +49,7 @@ mod tests {
 	use proptest::prelude::*;
 
 	use super::*;
-	use crate::packed::PackedField;
+	use crate::Divisible;
 
 	proptest! {
 		#[test]

--- a/crates/field/src/arch/portable/packed.rs
+++ b/crates/field/src/arch/portable/packed.rs
@@ -415,6 +415,52 @@ where
 	}
 }
 
+// A packed field divides into its scalars, mirroring how its underlier divides into the scalar's
+// underlier. This is the supertrait obligation behind `PackedField: Divisible<Self::Scalar>`.
+impl<U, Scalar> Divisible<Scalar> for PackedPrimitiveType<U, Scalar>
+where
+	U: UnderlierWithBitOps + Divisible<Scalar::Underlier>,
+	Scalar: BinaryField,
+{
+	const LOG_N: usize = (U::BITS / Scalar::N_BITS).ilog2() as usize;
+
+	#[inline]
+	fn value_iter(value: Self) -> impl ExactSizeIterator<Item = Scalar> + Send + Clone {
+		Divisible::<Scalar::Underlier>::value_iter(value.0).map(Scalar::from_underlier)
+	}
+
+	#[inline]
+	fn ref_iter(value: &Self) -> impl ExactSizeIterator<Item = Scalar> + Send + Clone + '_ {
+		Divisible::<Scalar::Underlier>::ref_iter(&value.0).map(Scalar::from_underlier)
+	}
+
+	#[inline]
+	fn slice_iter(slice: &[Self]) -> impl ExactSizeIterator<Item = Scalar> + Send + Clone + '_ {
+		Divisible::<Scalar::Underlier>::slice_iter(Self::to_underliers_ref(slice))
+			.map(Scalar::from_underlier)
+	}
+
+	#[inline]
+	fn get(self, index: usize) -> Scalar {
+		Scalar::from_underlier(Divisible::<Scalar::Underlier>::get(self.0, index))
+	}
+
+	#[inline]
+	fn set(self, index: usize, val: Scalar) -> Self {
+		Divisible::<Scalar::Underlier>::set(self.0, index, val.to_underlier()).into()
+	}
+
+	#[inline]
+	fn broadcast(val: Scalar) -> Self {
+		<U as Divisible<Scalar::Underlier>>::broadcast(val.to_underlier()).into()
+	}
+
+	#[inline]
+	fn from_iter(iter: impl Iterator<Item = Scalar>) -> Self {
+		<U as Divisible<Scalar::Underlier>>::from_iter(iter.map(Scalar::to_underlier)).into()
+	}
+}
+
 impl<U, Scalar> PackedField for PackedPrimitiveType<U, Scalar>
 where
 	Self:

--- a/crates/field/src/arch/portable/packed.rs
+++ b/crates/field/src/arch/portable/packed.rs
@@ -468,7 +468,8 @@ where
 	U: UnderlierWithBitOps + Divisible<Scalar::Underlier>,
 	Scalar: BinaryField,
 {
-	const LOG_WIDTH: usize = (U::BITS / Scalar::N_BITS).ilog2() as usize;
+	// LOG_WIDTH defaults to `<Self as Divisible<Scalar>>::LOG_N`, the same `(U::BITS /
+	// Scalar::N_BITS).ilog2()` count.
 
 	#[inline]
 	unsafe fn get_unchecked(&self, i: usize) -> Self::Scalar {
@@ -531,11 +532,6 @@ where
 				.spread::<<Self::Scalar as WithUnderlier>::Underlier>(log_block_len, block_idx)
 				.into()
 		}
-	}
-
-	#[inline]
-	fn broadcast(scalar: Self::Scalar) -> Self {
-		Self::broadcast(scalar)
 	}
 
 	#[inline]

--- a/crates/field/src/arch/portable/packed_ghash_128.rs
+++ b/crates/field/src/arch/portable/packed_ghash_128.rs
@@ -9,6 +9,7 @@ use super::{
 	univariate_mul_utils_128::{Underlier64bLanes, Underlier128bLanes, bmul64},
 };
 use crate::{
+	Divisible,
 	arithmetic_traits::{
 		TaggedInvertOrZero, TaggedMul, TaggedSquare, impl_invert_with, impl_mul_with,
 		impl_square_with,

--- a/crates/field/src/arch/portable/pairwise_table_arithmetic.rs
+++ b/crates/field/src/arch/portable/pairwise_table_arithmetic.rs
@@ -2,7 +2,7 @@
 
 use super::packed::PackedPrimitiveType;
 use crate::{
-	AESTowerField8b,
+	AESTowerField8b, Divisible,
 	arch::PairwiseTableStrategy,
 	arithmetic_traits::{TaggedInvertOrZero, TaggedMul, TaggedSquare},
 	packed::PackedField,

--- a/crates/field/src/binary_field.rs
+++ b/crates/field/src/binary_field.rs
@@ -237,6 +237,49 @@ macro_rules! binary_field {
 			}
 		}
 
+		// A field element divides into exactly one element of itself. This makes the field a
+		// degenerate packed field of width one (see the blanket `PackedField for Field` impl).
+		impl $crate::Divisible<$name> for $name {
+			const LOG_N: usize = 0;
+
+			#[inline]
+			fn value_iter(value: Self) -> impl ExactSizeIterator<Item = $name> + Send + Clone {
+				std::iter::once(value)
+			}
+
+			#[inline]
+			fn ref_iter(value: &Self) -> impl ExactSizeIterator<Item = $name> + Send + Clone + '_ {
+				std::iter::once(*value)
+			}
+
+			#[inline]
+			fn slice_iter(slice: &[Self]) -> impl ExactSizeIterator<Item = $name> + Send + Clone + '_ {
+				slice.iter().copied()
+			}
+
+			#[inline]
+			fn get(self, index: usize) -> $name {
+				debug_assert_eq!(index, 0);
+				self
+			}
+
+			#[inline]
+			fn set(self, index: usize, val: $name) -> Self {
+				debug_assert_eq!(index, 0);
+				val
+			}
+
+			#[inline]
+			fn broadcast(val: $name) -> Self {
+				val
+			}
+
+			#[inline]
+			fn from_iter(mut iter: impl Iterator<Item = $name>) -> Self {
+				iter.next().unwrap_or(Self::ZERO)
+			}
+		}
+
 		impl ::rand::distr::Distribution<$name> for ::rand::distr::StandardUniform {
 			fn sample<R: ::rand::Rng + ?Sized>(&self, rng: &mut R) -> $name {
 				$name(::rand::distr::StandardUniform.sample(rng))

--- a/crates/field/src/field.rs
+++ b/crates/field/src/field.rs
@@ -13,7 +13,7 @@ use bytemuck::Zeroable;
 
 use super::extension::ExtensionField;
 use crate::{
-	Random, WideMul,
+	Divisible, Random, WideMul,
 	arithmetic_traits::{InvertOrZero, Square},
 };
 
@@ -59,6 +59,9 @@ pub trait Field:
 	+ DeserializeBytes
 	+ FixedSizeSerializeBytes
 	+ WideMul<Output: Debug + Send + Sync + 'static>
+	// A field is a degenerate packed field of width one, so it divides into a single copy of
+	// itself. This mirrors `PackedField: Divisible<Self::Scalar>` for the blanket packed impl.
+	+ Divisible<Self>
 {
 	/// The zero element of the field, the additive identity.
 	const ZERO: Self;

--- a/crates/field/src/ghash.rs
+++ b/crates/field/src/ghash.rs
@@ -22,7 +22,7 @@ use super::{
 	extension::ExtensionField,
 };
 use crate::{
-	AESTowerField8b, Field, PackedField, WideMul,
+	AESTowerField8b, Divisible, Field, PackedField, WideMul,
 	arch::packed_ghash_128::PackedBinaryGhash1x128b,
 	arithmetic_traits::InvertOrZero,
 	binary_field_arithmetic::{

--- a/crates/field/src/packed.rs
+++ b/crates/field/src/packed.rs
@@ -18,7 +18,7 @@ use binius_utils::{
 use bytemuck::Zeroable;
 
 use super::{PackedExtension, Random, arithmetic_traits::Square};
-use crate::{BinaryField, Field, WideMul, field::FieldOps};
+use crate::{BinaryField, Divisible, Field, WideMul, field::FieldOps};
 
 /// A packed field represents a vector of underlying field elements.
 ///
@@ -45,9 +45,15 @@ pub trait PackedField:
 	+ Random
 	+ WideMul<Output: Debug + Send + Sync + 'static>
 	+ 'static
+	// A packed field divides into its `WIDTH` scalars. Element access (`get`), broadcast, and the
+	// scalar iterators are provided by this supertrait; `set` is kept here as an in-place `&mut`
+	// convenience (see [`Self::set`]).
+	+ Divisible<Self::Scalar>
 {
 	/// Base-2 logarithm of the number of field elements packed into one packed element.
-	const LOG_WIDTH: usize;
+	///
+	/// This is the number of scalars the packed field divides into, i.e. its `Divisible` log-count.
+	const LOG_WIDTH: usize = <Self as Divisible<Self::Scalar>>::LOG_N;
 
 	/// The number of field elements packed into one packed element.
 	///
@@ -64,19 +70,12 @@ pub trait PackedField:
 	/// The caller must ensure that `i` is less than `WIDTH`.
 	unsafe fn set_unchecked(&mut self, i: usize, scalar: Self::Scalar);
 
-	/// Get the scalar at a given index.
+	/// Set the scalar at a given index, in place.
 	///
-	/// # Preconditions
-	///
-	/// * `i` must be less than `WIDTH`.
-	#[inline]
-	fn get(&self, i: usize) -> Self::Scalar {
-		assert!(i < Self::WIDTH, "index {i} out of range for width {}", Self::WIDTH);
-		// Safety: assertion above guarantees i < WIDTH
-		unsafe { self.get_unchecked(i) }
-	}
-
-	/// Set the scalar at a given index.
+	/// This is the `&mut self` counterpart to the by-value [`Divisible::set`]. Because `Divisible`
+	/// is a supertrait, both are in scope wherever a `PackedField` bound is visible, and method
+	/// resolution prefers the by-value `Divisible::set` for `packed.set(i, v)`. To call this
+	/// in-place version, use fully-qualified syntax: `PackedField::set(&mut packed, i, v)`.
 	///
 	/// # Preconditions
 	///
@@ -84,8 +83,7 @@ pub trait PackedField:
 	#[inline]
 	fn set(&mut self, i: usize, scalar: Self::Scalar) {
 		assert!(i < Self::WIDTH, "index {i} out of range for width {}", Self::WIDTH);
-		// Safety: assertion above guarantees i < WIDTH
-		unsafe { self.set_unchecked(i, scalar) }
+		*self = <Self as Divisible<Self::Scalar>>::set(*self, i, scalar);
 	}
 
 	#[inline]
@@ -111,12 +109,11 @@ pub trait PackedField:
 	#[inline(always)]
 	fn set_single(scalar: Self::Scalar) -> Self {
 		let mut result = Self::default();
-		result.set(0, scalar);
+		// UFCS to select the in-place `PackedField::set` over the by-value `Divisible::set`.
+		PackedField::set(&mut result, 0, scalar);
 
 		result
 	}
-
-	fn broadcast(scalar: Self::Scalar) -> Self;
 
 	/// Construct a packed field element from a function that returns scalar values by index.
 	fn from_fn(f: impl FnMut(usize) -> Self::Scalar) -> Self;
@@ -142,7 +139,8 @@ pub trait PackedField:
 	fn from_scalars(values: impl IntoIterator<Item = Self::Scalar>) -> Self {
 		let mut result = Self::default();
 		for (i, val) in values.into_iter().take(Self::WIDTH).enumerate() {
-			result.set(i, val);
+			// UFCS to select the in-place `PackedField::set` over the by-value `Divisible::set`.
+			PackedField::set(&mut result, i, val);
 		}
 		result
 	}
@@ -193,7 +191,7 @@ pub trait PackedField:
 	/// Spread takes a block of elements within a packed field and repeats them to the full packing
 	/// width.
 	///
-	/// Spread can be seen as an extension of the functionality of [`Self::broadcast`].
+	/// Spread can be seen as an extension of the functionality of [`Divisible::broadcast`].
 	///
 	/// ## Examples
 	///
@@ -425,7 +423,7 @@ impl<P: PackedField> RandomAccessSequenceMut<P::Scalar> for PackedSliceMut<'_, P
 }
 
 impl<F: Field> PackedField for F {
-	const LOG_WIDTH: usize = 0;
+	// LOG_WIDTH defaults to `<Self as Divisible<Self>>::LOG_N`, which is 0 for a scalar field.
 
 	#[inline]
 	unsafe fn get_unchecked(&self, _i: usize) -> Self::Scalar {
@@ -458,11 +456,6 @@ impl<F: Field> PackedField for F {
 
 	fn unzip(self, _other: Self, _log_block_len: usize) -> (Self, Self) {
 		panic!("cannot transpose when WIDTH = 1");
-	}
-
-	#[inline]
-	fn broadcast(scalar: Self::Scalar) -> Self {
-		scalar
 	}
 
 	#[inline]

--- a/crates/field/src/packed_binary_field.rs
+++ b/crates/field/src/packed_binary_field.rs
@@ -522,8 +522,8 @@ mod tests {
 		*,
 	};
 	use crate::{
-		PackedBinaryGhash1x128b, PackedBinaryGhash2x128b, PackedBinaryGhash4x128b, PackedField,
-		Random,
+		Divisible, PackedBinaryGhash1x128b, PackedBinaryGhash2x128b, PackedBinaryGhash4x128b,
+		PackedField, Random,
 		arithmetic_traits::{InvertOrZero, Square},
 		test_utils::check_transpose_all_heights,
 		underlier::{U2, U4},
@@ -559,7 +559,7 @@ mod tests {
 			.collect::<Vec<_>>();
 
 		for (i, val) in scalars.iter().enumerate() {
-			elem.set(i, *val);
+			PackedField::set(&mut elem, i, *val);
 		}
 		for (i, val) in scalars.iter().enumerate() {
 			assert_eq!(elem.get(i), *val);

--- a/crates/field/src/packed_ghash.rs
+++ b/crates/field/src/packed_ghash.rs
@@ -214,7 +214,7 @@ mod tests {
 		let mut val = PT::from_underlier(a.into());
 		for i in 0..WIDTH {
 			assert_eq!(val.get(i), BinaryField128bGhash::from(a[i]));
-			val.set(i, BinaryField128bGhash::from(b[i]));
+			PackedField::set(&mut val, i, BinaryField128bGhash::from(b[i]));
 			assert_eq!(val.get(i), BinaryField128bGhash::from(b[i]));
 		}
 	}

--- a/crates/math/src/batch_invert.rs
+++ b/crates/math/src/batch_invert.rs
@@ -106,7 +106,7 @@ impl<P: PackedField> BatchInversion<P> {
 				let scalar_idx = packed_idx * P::WIDTH + lane;
 				let scalar = packed.get(lane);
 				if scalar == P::Scalar::ZERO {
-					packed.set(lane, P::Scalar::ONE);
+					PackedField::set(packed, lane, P::Scalar::ONE);
 					self.is_zero[scalar_idx] = true;
 				} else {
 					self.is_zero[scalar_idx] = false;
@@ -122,7 +122,7 @@ impl<P: PackedField> BatchInversion<P> {
 			for lane in 0..P::WIDTH {
 				let scalar_idx = packed_idx * P::WIDTH + lane;
 				if self.is_zero[scalar_idx] {
-					packed.set(lane, P::Scalar::ZERO);
+					PackedField::set(packed, lane, P::Scalar::ZERO);
 				}
 			}
 		}
@@ -165,7 +165,7 @@ fn batch_invert_nonzero_with_scratchpad<P: PackedField>(
 			let inv = scalar
 				.invert()
 				.expect("precondition: elements contains no zeros");
-			packed.set(0, inv);
+			PackedField::set(packed, 0, inv);
 		} else {
 			// Unpack, batch invert scalars, repack
 			let mut scalars = packed.into_iter().collect::<Vec<_>>();

--- a/crates/math/src/field_buffer.rs
+++ b/crates/math/src/field_buffer.rs
@@ -410,7 +410,9 @@ impl<P: PackedField, Data: DerefMut<Target = [P]>> FieldBuffer<P, Data> {
 		if self.log_len < P::LOG_WIDTH {
 			let first_elem = self.values.first_mut().expect("values.len() >= 1");
 			for i in 1 << self.log_len..(1 << new_log_len).min(P::WIDTH) {
-				first_elem.set(i, P::Scalar::ZERO);
+				// UFCS to select the in-place `PackedField::set` over the by-value
+				// `Divisible::set`.
+				PackedField::set(first_elem, i, P::Scalar::ZERO);
 			}
 		}
 

--- a/crates/math/src/ntt/neighbors_last.rs
+++ b/crates/math/src/ntt/neighbors_last.rs
@@ -190,8 +190,12 @@ fn forward_breadth_first<P: PackedField>(
 
 			let block_start = block << log_block_size;
 			for j in 0..1 << log_half_block_size {
-				packed_twiddle_offset.set(block_start | j, twiddle0);
-				packed_twiddle_offset.set(block_start | j | (1 << log_half_block_size), twiddle1);
+				PackedField::set(&mut packed_twiddle_offset, block_start | j, twiddle0);
+				PackedField::set(
+					&mut packed_twiddle_offset,
+					block_start | j | (1 << log_half_block_size),
+					twiddle1,
+				);
 			}
 		}
 

--- a/crates/prover/src/and_reduction/ntt_lookup.rs
+++ b/crates/prover/src/and_reduction/ntt_lookup.rs
@@ -130,8 +130,14 @@ where
 
 					let packed_idx = eval_point_idx / PNTTDomain::WIDTH; // 0, 1, 2, or 3
 					let scalar_idx = eval_point_idx % PNTTDomain::WIDTH; // 0-15
-					lookup[eight_bit_chunk_idx][coefficient_as_bit_string as usize][packed_idx]
-						.set(scalar_idx, result);
+					// UFCS to select the in-place `PackedField::set` over the by-value
+					// `Divisible::set`.
+					PackedField::set(
+						&mut lookup[eight_bit_chunk_idx][coefficient_as_bit_string as usize]
+							[packed_idx],
+						scalar_idx,
+						result,
+					);
 				}
 			}
 		}

--- a/crates/prover/src/protocols/shift/phase_1.rs
+++ b/crates/prover/src/protocols/shift/phase_1.rs
@@ -193,7 +193,7 @@ fn build_g_parts<
 			let mut mask = P::zero();
 			for bit_index in 0..P::WIDTH {
 				if (i >> bit_index) & 1 == 1 {
-					mask.set(bit_index, all_ones_f);
+					PackedField::set(&mut mask, bit_index, all_ones_f);
 				}
 			}
 			mask.to_underlier()


### PR DESCRIPTION
Resolves [BINIUS-87](https://linear.app/jimpo/issue/BINIUS-87/add-divisibleselfscalar-as-parent-trait-to-packedfield) (PR 1 of 2).

Makes `Divisible` the single source of element access for packed fields: `PackedField` now requires `Divisible<Self::Scalar>` and `Field` requires `Divisible<Self>`. This is the "make an always-definable capability a parent trait" pattern — every implementer supplies it trivially, and callers/downstream signatures pay nothing.

## Commits

1. **Add `Divisible` impls for `PackedPrimitiveType` and field types** — additive, no behavior change. A reflexive `Divisible<Self>` (width 1) for every binary field via the `binary_field!` macro, and a generic `Divisible<Scalar> for PackedPrimitiveType<U, Scalar>` delegating to the underlier's `Divisible<Scalar::Underlier>`.
2. **Make `Divisible` a supertrait of `PackedField` and `Field`** — adds the supertrait bounds; removes `PackedField::{get, broadcast}` in favor of the `Divisible` methods (`get_unchecked`/`set_unchecked` and the `iter*`/`from_fn` helpers stay).

## The `set` collision

`Divisible::set(self, …) -> Self` (by-value) and a mutating `PackedField::set(&mut self, …)` share a name. Once `Divisible` is a supertrait, method resolution prefers the by-value receiver, so a bare `packed.set(i, v)` silently binds to `Divisible::set` and discards the result (caught early: it broke ~96 `binius-field` tests via `from_scalars`/`set_single`).

Per the issue discussion, `set` is the one method with a large mutation-rewrite ripple, so this PR **keeps `PackedField::set(&mut self)`** (its default now delegates to `Divisible::set`) and disambiguates the handful of in-place `.set()` call sites with UFCS `PackedField::set(&mut x, …)` — a mechanical, semantics-preserving change. A `# Note` on the method documents the shadowing. **PR 2 (stacked) removes `PackedField::set`.**

UFCS'd in-place sites: `binius-math` (`batch_invert`, `field_buffer`, `ntt/neighbors_last`), `binius-prover` (`and_reduction/ntt_lookup`, `shift/phase_1`), plus internal `set_single`/`from_scalars` and a couple of tests/benches. `get`/`broadcast` callers resolve to `Divisible` automatically in generic `P: PackedField` code (via the bound); a few concrete-typed sites in `binius-field` gained a `use Divisible`.

## Test plan

- `cargo test --workspace` — green (no behavior change; the silent-`.set()` audit was validated by the test suite catching the one site, `ntt_lookup`, that a build warning didn't).
- `cargo +nightly-2026-01-01 fmt --check` and `cargo clippy --all --tests --benches --examples -- -D warnings` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)