### PR TITLE
Move get_unchecked and set_unchecked from PackedField to Divisible

### DIFF
--- a/crates/field/src/arch/aarch64/m128.rs
+++ b/crates/field/src/arch/aarch64/m128.rs
@@ -235,19 +235,13 @@ impl Divisible<u128> for M128 {
 	}
 
 	#[inline]
-	fn get(self, index: usize) -> u128 {
-		match index {
-			0 => self.into(),
-			_ => panic!("index out of bounds"),
-		}
+	unsafe fn get_unchecked(self, _index: usize) -> u128 {
+		self.into()
 	}
 
 	#[inline]
-	fn set(&mut self, index: usize, val: u128) {
-		match index {
-			0 => *self = Self::from(val),
-			_ => panic!("index out of bounds"),
-		}
+	unsafe fn set_unchecked(&mut self, _index: usize, val: u128) {
+		*self = Self::from(val);
 	}
 
 	#[inline]
@@ -280,23 +274,23 @@ impl Divisible<u64> for M128 {
 	}
 
 	#[inline]
-	fn get(self, index: usize) -> u64 {
+	unsafe fn get_unchecked(self, index: usize) -> u64 {
 		unsafe {
 			match index {
 				0 => vgetq_lane_u64(self.0, 0),
 				1 => vgetq_lane_u64(self.0, 1),
-				_ => panic!("index out of bounds"),
+				_ => core::hint::unreachable_unchecked(),
 			}
 		}
 	}
 
 	#[inline]
-	fn set(&mut self, index: usize, val: u64) {
+	unsafe fn set_unchecked(&mut self, index: usize, val: u64) {
 		*self = unsafe {
 			match index {
 				0 => Self(vsetq_lane_u64(val, self.0, 0)),
 				1 => Self(vsetq_lane_u64(val, self.0, 1)),
-				_ => panic!("index out of bounds"),
+				_ => core::hint::unreachable_unchecked(),
 			}
 		};
 	}
@@ -336,7 +330,7 @@ impl Divisible<u32> for M128 {
 	}
 
 	#[inline]
-	fn get(self, index: usize) -> u32 {
+	unsafe fn get_unchecked(self, index: usize) -> u32 {
 		unsafe {
 			let v: uint32x4_t = self.into();
 			match index {
@@ -344,13 +338,13 @@ impl Divisible<u32> for M128 {
 				1 => vgetq_lane_u32(v, 1),
 				2 => vgetq_lane_u32(v, 2),
 				3 => vgetq_lane_u32(v, 3),
-				_ => panic!("index out of bounds"),
+				_ => core::hint::unreachable_unchecked(),
 			}
 		}
 	}
 
 	#[inline]
-	fn set(&mut self, index: usize, val: u32) {
+	unsafe fn set_unchecked(&mut self, index: usize, val: u32) {
 		*self = unsafe {
 			let v: uint32x4_t = (*self).into();
 			match index {
@@ -358,7 +352,7 @@ impl Divisible<u32> for M128 {
 				1 => Self::from(vsetq_lane_u32(val, v, 1)),
 				2 => Self::from(vsetq_lane_u32(val, v, 2)),
 				3 => Self::from(vsetq_lane_u32(val, v, 3)),
-				_ => panic!("index out of bounds"),
+				_ => core::hint::unreachable_unchecked(),
 			}
 		};
 	}
@@ -398,7 +392,7 @@ impl Divisible<u16> for M128 {
 	}
 
 	#[inline]
-	fn get(self, index: usize) -> u16 {
+	unsafe fn get_unchecked(self, index: usize) -> u16 {
 		unsafe {
 			let v: uint16x8_t = self.into();
 			match index {
@@ -410,13 +404,13 @@ impl Divisible<u16> for M128 {
 				5 => vgetq_lane_u16(v, 5),
 				6 => vgetq_lane_u16(v, 6),
 				7 => vgetq_lane_u16(v, 7),
-				_ => panic!("index out of bounds"),
+				_ => core::hint::unreachable_unchecked(),
 			}
 		}
 	}
 
 	#[inline]
-	fn set(&mut self, index: usize, val: u16) {
+	unsafe fn set_unchecked(&mut self, index: usize, val: u16) {
 		*self = unsafe {
 			let v: uint16x8_t = (*self).into();
 			match index {
@@ -428,7 +422,7 @@ impl Divisible<u16> for M128 {
 				5 => Self::from(vsetq_lane_u16(val, v, 5)),
 				6 => Self::from(vsetq_lane_u16(val, v, 6)),
 				7 => Self::from(vsetq_lane_u16(val, v, 7)),
-				_ => panic!("index out of bounds"),
+				_ => core::hint::unreachable_unchecked(),
 			}
 		};
 	}
@@ -468,7 +462,7 @@ impl Divisible<u8> for M128 {
 	}
 
 	#[inline]
-	fn get(self, index: usize) -> u8 {
+	unsafe fn get_unchecked(self, index: usize) -> u8 {
 		unsafe {
 			let v: uint8x16_t = self.into();
 			match index {
@@ -488,13 +482,13 @@ impl Divisible<u8> for M128 {
 				13 => vgetq_lane_u8(v, 13),
 				14 => vgetq_lane_u8(v, 14),
 				15 => vgetq_lane_u8(v, 15),
-				_ => panic!("index out of bounds"),
+				_ => core::hint::unreachable_unchecked(),
 			}
 		}
 	}
 
 	#[inline]
-	fn set(&mut self, index: usize, val: u8) {
+	unsafe fn set_unchecked(&mut self, index: usize, val: u8) {
 		*self = unsafe {
 			let v: uint8x16_t = (*self).into();
 			match index {
@@ -514,7 +508,7 @@ impl Divisible<u8> for M128 {
 				13 => Self::from(vsetq_lane_u8(val, v, 13)),
 				14 => Self::from(vsetq_lane_u8(val, v, 14)),
 				15 => Self::from(vsetq_lane_u8(val, v, 15)),
-				_ => panic!("index out of bounds"),
+				_ => core::hint::unreachable_unchecked(),
 			}
 		};
 	}

--- a/crates/field/src/arch/portable/packed.rs
+++ b/crates/field/src/arch/portable/packed.rs
@@ -441,13 +441,23 @@ where
 	}
 
 	#[inline]
-	fn get(self, index: usize) -> Scalar {
-		Scalar::from_underlier(Divisible::<Scalar::Underlier>::get(self.0, index))
+	unsafe fn get_unchecked(self, index: usize) -> Scalar {
+		// Safety: `index < Self::N` by the caller's contract.
+		Scalar::from_underlier(unsafe {
+			Divisible::<Scalar::Underlier>::get_unchecked(self.0, index)
+		})
 	}
 
 	#[inline]
-	fn set(&mut self, index: usize, val: Scalar) {
-		<U as Divisible<Scalar::Underlier>>::set(&mut self.0, index, val.to_underlier());
+	unsafe fn set_unchecked(&mut self, index: usize, val: Scalar) {
+		// Safety: `index < Self::N` by the caller's contract.
+		unsafe {
+			<U as Divisible<Scalar::Underlier>>::set_unchecked(
+				&mut self.0,
+				index,
+				val.to_underlier(),
+			)
+		};
 	}
 
 	#[inline]
@@ -469,19 +479,9 @@ where
 	Scalar: BinaryField,
 {
 	// LOG_WIDTH defaults to `<Self as Divisible<Scalar>>::LOG_N`, the same `(U::BITS /
-	// Scalar::N_BITS).ilog2()` count.
-
-	#[inline]
-	unsafe fn get_unchecked(&self, i: usize) -> Self::Scalar {
-		Scalar::from_underlier(unsafe { self.0.get_subvalue(i) })
-	}
-
-	#[inline]
-	unsafe fn set_unchecked(&mut self, i: usize, scalar: Scalar) {
-		unsafe {
-			self.0.set_subvalue(i, scalar.to_underlier());
-		}
-	}
+	// Scalar::N_BITS).ilog2()` count. Scalar element access (`get_unchecked`/`set_unchecked`) is
+	// provided by the `Divisible<Scalar>` impl, which routes through `U:
+	// Divisible<Scalar::Underlier>`.
 
 	#[inline]
 	fn iter(&self) -> impl Iterator<Item = Self::Scalar> + Send + Clone + '_ {

--- a/crates/field/src/arch/x86_64/m128.rs
+++ b/crates/field/src/arch/x86_64/m128.rs
@@ -704,14 +704,12 @@ impl Divisible<u128> for M128 {
 	}
 
 	#[inline]
-	fn get(self, index: usize) -> u128 {
-		assert!(index == 0, "index out of bounds");
+	unsafe fn get_unchecked(self, _index: usize) -> u128 {
 		u128::from(self)
 	}
 
 	#[inline]
-	fn set(&mut self, index: usize, val: u128) {
-		assert!(index == 0, "index out of bounds");
+	unsafe fn set_unchecked(&mut self, _index: usize, val: u128) {
 		*self = Self::from(val);
 	}
 
@@ -745,23 +743,23 @@ impl Divisible<u64> for M128 {
 	}
 
 	#[inline]
-	fn get(self, index: usize) -> u64 {
+	unsafe fn get_unchecked(self, index: usize) -> u64 {
 		unsafe {
 			match index {
 				0 => _mm_extract_epi64(self.0, 0) as u64,
 				1 => _mm_extract_epi64(self.0, 1) as u64,
-				_ => panic!("index out of bounds"),
+				_ => core::hint::unreachable_unchecked(),
 			}
 		}
 	}
 
 	#[inline]
-	fn set(&mut self, index: usize, val: u64) {
+	unsafe fn set_unchecked(&mut self, index: usize, val: u64) {
 		*self = unsafe {
 			match index {
 				0 => Self(_mm_insert_epi64(self.0, val as i64, 0)),
 				1 => Self(_mm_insert_epi64(self.0, val as i64, 1)),
-				_ => panic!("index out of bounds"),
+				_ => core::hint::unreachable_unchecked(),
 			}
 		};
 	}
@@ -801,27 +799,27 @@ impl Divisible<u32> for M128 {
 	}
 
 	#[inline]
-	fn get(self, index: usize) -> u32 {
+	unsafe fn get_unchecked(self, index: usize) -> u32 {
 		unsafe {
 			match index {
 				0 => _mm_extract_epi32(self.0, 0) as u32,
 				1 => _mm_extract_epi32(self.0, 1) as u32,
 				2 => _mm_extract_epi32(self.0, 2) as u32,
 				3 => _mm_extract_epi32(self.0, 3) as u32,
-				_ => panic!("index out of bounds"),
+				_ => core::hint::unreachable_unchecked(),
 			}
 		}
 	}
 
 	#[inline]
-	fn set(&mut self, index: usize, val: u32) {
+	unsafe fn set_unchecked(&mut self, index: usize, val: u32) {
 		*self = unsafe {
 			match index {
 				0 => Self(_mm_insert_epi32(self.0, val as i32, 0)),
 				1 => Self(_mm_insert_epi32(self.0, val as i32, 1)),
 				2 => Self(_mm_insert_epi32(self.0, val as i32, 2)),
 				3 => Self(_mm_insert_epi32(self.0, val as i32, 3)),
-				_ => panic!("index out of bounds"),
+				_ => core::hint::unreachable_unchecked(),
 			}
 		};
 	}
@@ -861,7 +859,7 @@ impl Divisible<u16> for M128 {
 	}
 
 	#[inline]
-	fn get(self, index: usize) -> u16 {
+	unsafe fn get_unchecked(self, index: usize) -> u16 {
 		unsafe {
 			match index {
 				0 => _mm_extract_epi16(self.0, 0) as u16,
@@ -872,13 +870,13 @@ impl Divisible<u16> for M128 {
 				5 => _mm_extract_epi16(self.0, 5) as u16,
 				6 => _mm_extract_epi16(self.0, 6) as u16,
 				7 => _mm_extract_epi16(self.0, 7) as u16,
-				_ => panic!("index out of bounds"),
+				_ => core::hint::unreachable_unchecked(),
 			}
 		}
 	}
 
 	#[inline]
-	fn set(&mut self, index: usize, val: u16) {
+	unsafe fn set_unchecked(&mut self, index: usize, val: u16) {
 		*self = unsafe {
 			match index {
 				0 => Self(_mm_insert_epi16(self.0, val as i32, 0)),
@@ -889,7 +887,7 @@ impl Divisible<u16> for M128 {
 				5 => Self(_mm_insert_epi16(self.0, val as i32, 5)),
 				6 => Self(_mm_insert_epi16(self.0, val as i32, 6)),
 				7 => Self(_mm_insert_epi16(self.0, val as i32, 7)),
-				_ => panic!("index out of bounds"),
+				_ => core::hint::unreachable_unchecked(),
 			}
 		};
 	}
@@ -929,7 +927,7 @@ impl Divisible<u8> for M128 {
 	}
 
 	#[inline]
-	fn get(self, index: usize) -> u8 {
+	unsafe fn get_unchecked(self, index: usize) -> u8 {
 		unsafe {
 			match index {
 				0 => _mm_extract_epi8(self.0, 0) as u8,
@@ -948,13 +946,13 @@ impl Divisible<u8> for M128 {
 				13 => _mm_extract_epi8(self.0, 13) as u8,
 				14 => _mm_extract_epi8(self.0, 14) as u8,
 				15 => _mm_extract_epi8(self.0, 15) as u8,
-				_ => panic!("index out of bounds"),
+				_ => core::hint::unreachable_unchecked(),
 			}
 		}
 	}
 
 	#[inline]
-	fn set(&mut self, index: usize, val: u8) {
+	unsafe fn set_unchecked(&mut self, index: usize, val: u8) {
 		*self = unsafe {
 			match index {
 				0 => Self(_mm_insert_epi8(self.0, val as i32, 0)),
@@ -973,7 +971,7 @@ impl Divisible<u8> for M128 {
 				13 => Self(_mm_insert_epi8(self.0, val as i32, 13)),
 				14 => Self(_mm_insert_epi8(self.0, val as i32, 14)),
 				15 => Self(_mm_insert_epi8(self.0, val as i32, 15)),
-				_ => panic!("index out of bounds"),
+				_ => core::hint::unreachable_unchecked(),
 			}
 		};
 	}

--- a/crates/field/src/arch/x86_64/m256.rs
+++ b/crates/field/src/arch/x86_64/m256.rs
@@ -872,23 +872,23 @@ impl Divisible<M128> for M256 {
 	}
 
 	#[inline]
-	fn get(self, index: usize) -> M128 {
+	unsafe fn get_unchecked(self, index: usize) -> M128 {
 		unsafe {
 			match index {
 				0 => M128(_mm256_extracti128_si256(self.0, 0)),
 				1 => M128(_mm256_extracti128_si256(self.0, 1)),
-				_ => panic!("index out of bounds"),
+				_ => core::hint::unreachable_unchecked(),
 			}
 		}
 	}
 
 	#[inline]
-	fn set(&mut self, index: usize, val: M128) {
+	unsafe fn set_unchecked(&mut self, index: usize, val: M128) {
 		*self = unsafe {
 			match index {
 				0 => Self(_mm256_inserti128_si256(self.0, val.0, 0)),
 				1 => Self(_mm256_inserti128_si256(self.0, val.0, 1)),
-				_ => panic!("index out of bounds"),
+				_ => core::hint::unreachable_unchecked(),
 			}
 		};
 	}
@@ -928,13 +928,15 @@ impl Divisible<u128> for M256 {
 	}
 
 	#[inline]
-	fn get(self, index: usize) -> u128 {
-		u128::from(Divisible::<M128>::get(self, index))
+	unsafe fn get_unchecked(self, index: usize) -> u128 {
+		// Safety: `index < Self::N` by the caller's contract.
+		u128::from(unsafe { Divisible::<M128>::get_unchecked(self, index) })
 	}
 
 	#[inline]
-	fn set(&mut self, index: usize, val: u128) {
-		Divisible::<M128>::set(self, index, M128::from(val));
+	unsafe fn set_unchecked(&mut self, index: usize, val: u128) {
+		// Safety: `index < Self::N` by the caller's contract.
+		unsafe { Divisible::<M128>::set_unchecked(self, index, M128::from(val)) };
 	}
 
 	#[inline]
@@ -972,27 +974,27 @@ impl Divisible<u64> for M256 {
 	}
 
 	#[inline]
-	fn get(self, index: usize) -> u64 {
+	unsafe fn get_unchecked(self, index: usize) -> u64 {
 		unsafe {
 			match index {
 				0 => _mm256_extract_epi64(self.0, 0) as u64,
 				1 => _mm256_extract_epi64(self.0, 1) as u64,
 				2 => _mm256_extract_epi64(self.0, 2) as u64,
 				3 => _mm256_extract_epi64(self.0, 3) as u64,
-				_ => panic!("index out of bounds"),
+				_ => core::hint::unreachable_unchecked(),
 			}
 		}
 	}
 
 	#[inline]
-	fn set(&mut self, index: usize, val: u64) {
+	unsafe fn set_unchecked(&mut self, index: usize, val: u64) {
 		*self = unsafe {
 			match index {
 				0 => Self(_mm256_insert_epi64(self.0, val as i64, 0)),
 				1 => Self(_mm256_insert_epi64(self.0, val as i64, 1)),
 				2 => Self(_mm256_insert_epi64(self.0, val as i64, 2)),
 				3 => Self(_mm256_insert_epi64(self.0, val as i64, 3)),
-				_ => panic!("index out of bounds"),
+				_ => core::hint::unreachable_unchecked(),
 			}
 		};
 	}
@@ -1032,7 +1034,7 @@ impl Divisible<u32> for M256 {
 	}
 
 	#[inline]
-	fn get(self, index: usize) -> u32 {
+	unsafe fn get_unchecked(self, index: usize) -> u32 {
 		unsafe {
 			match index {
 				0 => _mm256_extract_epi32(self.0, 0) as u32,
@@ -1043,13 +1045,13 @@ impl Divisible<u32> for M256 {
 				5 => _mm256_extract_epi32(self.0, 5) as u32,
 				6 => _mm256_extract_epi32(self.0, 6) as u32,
 				7 => _mm256_extract_epi32(self.0, 7) as u32,
-				_ => panic!("index out of bounds"),
+				_ => core::hint::unreachable_unchecked(),
 			}
 		}
 	}
 
 	#[inline]
-	fn set(&mut self, index: usize, val: u32) {
+	unsafe fn set_unchecked(&mut self, index: usize, val: u32) {
 		*self = unsafe {
 			match index {
 				0 => Self(_mm256_insert_epi32(self.0, val as i32, 0)),
@@ -1060,7 +1062,7 @@ impl Divisible<u32> for M256 {
 				5 => Self(_mm256_insert_epi32(self.0, val as i32, 5)),
 				6 => Self(_mm256_insert_epi32(self.0, val as i32, 6)),
 				7 => Self(_mm256_insert_epi32(self.0, val as i32, 7)),
-				_ => panic!("index out of bounds"),
+				_ => core::hint::unreachable_unchecked(),
 			}
 		};
 	}
@@ -1100,7 +1102,7 @@ impl Divisible<u16> for M256 {
 	}
 
 	#[inline]
-	fn get(self, index: usize) -> u16 {
+	unsafe fn get_unchecked(self, index: usize) -> u16 {
 		unsafe {
 			match index {
 				0 => _mm256_extract_epi16(self.0, 0) as u16,
@@ -1119,13 +1121,13 @@ impl Divisible<u16> for M256 {
 				13 => _mm256_extract_epi16(self.0, 13) as u16,
 				14 => _mm256_extract_epi16(self.0, 14) as u16,
 				15 => _mm256_extract_epi16(self.0, 15) as u16,
-				_ => panic!("index out of bounds"),
+				_ => core::hint::unreachable_unchecked(),
 			}
 		}
 	}
 
 	#[inline]
-	fn set(&mut self, index: usize, val: u16) {
+	unsafe fn set_unchecked(&mut self, index: usize, val: u16) {
 		*self = unsafe {
 			match index {
 				0 => Self(_mm256_insert_epi16(self.0, val as i16, 0)),
@@ -1144,7 +1146,7 @@ impl Divisible<u16> for M256 {
 				13 => Self(_mm256_insert_epi16(self.0, val as i16, 13)),
 				14 => Self(_mm256_insert_epi16(self.0, val as i16, 14)),
 				15 => Self(_mm256_insert_epi16(self.0, val as i16, 15)),
-				_ => panic!("index out of bounds"),
+				_ => core::hint::unreachable_unchecked(),
 			}
 		};
 	}
@@ -1184,7 +1186,7 @@ impl Divisible<u8> for M256 {
 	}
 
 	#[inline]
-	fn get(self, index: usize) -> u8 {
+	unsafe fn get_unchecked(self, index: usize) -> u8 {
 		unsafe {
 			match index {
 				0 => _mm256_extract_epi8(self.0, 0) as u8,
@@ -1219,13 +1221,13 @@ impl Divisible<u8> for M256 {
 				29 => _mm256_extract_epi8(self.0, 29) as u8,
 				30 => _mm256_extract_epi8(self.0, 30) as u8,
 				31 => _mm256_extract_epi8(self.0, 31) as u8,
-				_ => panic!("index out of bounds"),
+				_ => core::hint::unreachable_unchecked(),
 			}
 		}
 	}
 
 	#[inline]
-	fn set(&mut self, index: usize, val: u8) {
+	unsafe fn set_unchecked(&mut self, index: usize, val: u8) {
 		*self = unsafe {
 			match index {
 				0 => Self(_mm256_insert_epi8(self.0, val as i8, 0)),
@@ -1260,7 +1262,7 @@ impl Divisible<u8> for M256 {
 				29 => Self(_mm256_insert_epi8(self.0, val as i8, 29)),
 				30 => Self(_mm256_insert_epi8(self.0, val as i8, 30)),
 				31 => Self(_mm256_insert_epi8(self.0, val as i8, 31)),
-				_ => panic!("index out of bounds"),
+				_ => core::hint::unreachable_unchecked(),
 			}
 		};
 	}

--- a/crates/field/src/arch/x86_64/m512.rs
+++ b/crates/field/src/arch/x86_64/m512.rs
@@ -884,23 +884,23 @@ impl Divisible<M256> for M512 {
 	}
 
 	#[inline]
-	fn get(self, index: usize) -> M256 {
+	unsafe fn get_unchecked(self, index: usize) -> M256 {
 		unsafe {
 			match index {
 				0 => M256(_mm512_extracti64x4_epi64(self.0, 0)),
 				1 => M256(_mm512_extracti64x4_epi64(self.0, 1)),
-				_ => panic!("index out of bounds"),
+				_ => core::hint::unreachable_unchecked(),
 			}
 		}
 	}
 
 	#[inline]
-	fn set(&mut self, index: usize, val: M256) {
+	unsafe fn set_unchecked(&mut self, index: usize, val: M256) {
 		*self = unsafe {
 			match index {
 				0 => Self(_mm512_inserti64x4(self.0, val.0, 0)),
 				1 => Self(_mm512_inserti64x4(self.0, val.0, 1)),
-				_ => panic!("index out of bounds"),
+				_ => core::hint::unreachable_unchecked(),
 			}
 		};
 	}
@@ -940,27 +940,27 @@ impl Divisible<M128> for M512 {
 	}
 
 	#[inline]
-	fn get(self, index: usize) -> M128 {
+	unsafe fn get_unchecked(self, index: usize) -> M128 {
 		unsafe {
 			match index {
 				0 => M128(_mm512_extracti32x4_epi32(self.0, 0)),
 				1 => M128(_mm512_extracti32x4_epi32(self.0, 1)),
 				2 => M128(_mm512_extracti32x4_epi32(self.0, 2)),
 				3 => M128(_mm512_extracti32x4_epi32(self.0, 3)),
-				_ => panic!("index out of bounds"),
+				_ => core::hint::unreachable_unchecked(),
 			}
 		}
 	}
 
 	#[inline]
-	fn set(&mut self, index: usize, val: M128) {
+	unsafe fn set_unchecked(&mut self, index: usize, val: M128) {
 		*self = unsafe {
 			match index {
 				0 => Self(_mm512_inserti32x4(self.0, val.0, 0)),
 				1 => Self(_mm512_inserti32x4(self.0, val.0, 1)),
 				2 => Self(_mm512_inserti32x4(self.0, val.0, 2)),
 				3 => Self(_mm512_inserti32x4(self.0, val.0, 3)),
-				_ => panic!("index out of bounds"),
+				_ => core::hint::unreachable_unchecked(),
 			}
 		};
 	}
@@ -1000,13 +1000,15 @@ impl Divisible<u128> for M512 {
 	}
 
 	#[inline]
-	fn get(self, index: usize) -> u128 {
-		u128::from(Divisible::<M128>::get(self, index))
+	unsafe fn get_unchecked(self, index: usize) -> u128 {
+		// Safety: `index < Self::N` by the caller's contract.
+		u128::from(unsafe { Divisible::<M128>::get_unchecked(self, index) })
 	}
 
 	#[inline]
-	fn set(&mut self, index: usize, val: u128) {
-		Divisible::<M128>::set(self, index, M128::from(val));
+	unsafe fn set_unchecked(&mut self, index: usize, val: u128) {
+		// Safety: `index < Self::N` by the caller's contract.
+		unsafe { Divisible::<M128>::set_unchecked(self, index, M128::from(val)) };
 	}
 
 	#[inline]
@@ -1044,21 +1046,29 @@ impl Divisible<u64> for M512 {
 	}
 
 	#[inline]
-	fn get(self, index: usize) -> u64 {
+	unsafe fn get_unchecked(self, index: usize) -> u64 {
 		// Extract M128 lane, then use M128's get
 		let lane_idx = index / 2;
 		let sub_idx = index % 2;
-		let lane = Divisible::<M128>::get(self, lane_idx);
-		Divisible::<u64>::get(lane, sub_idx)
+		// Safety: `index < Self::N` by the caller's contract, so `lane_idx` and `sub_idx` are
+		// in bounds.
+		unsafe {
+			let lane = Divisible::<M128>::get_unchecked(self, lane_idx);
+			Divisible::<u64>::get_unchecked(lane, sub_idx)
+		}
 	}
 
 	#[inline]
-	fn set(&mut self, index: usize, val: u64) {
+	unsafe fn set_unchecked(&mut self, index: usize, val: u64) {
 		let lane_idx = index / 2;
 		let sub_idx = index % 2;
-		let mut lane = Divisible::<M128>::get(*self, lane_idx);
-		Divisible::<u64>::set(&mut lane, sub_idx, val);
-		Divisible::<M128>::set(self, lane_idx, lane);
+		// Safety: `index < Self::N` by the caller's contract, so `lane_idx` and `sub_idx` are
+		// in bounds.
+		unsafe {
+			let mut lane = Divisible::<M128>::get_unchecked(*self, lane_idx);
+			Divisible::<u64>::set_unchecked(&mut lane, sub_idx, val);
+			Divisible::<M128>::set_unchecked(self, lane_idx, lane);
+		}
 	}
 
 	#[inline]
@@ -1096,21 +1106,29 @@ impl Divisible<u32> for M512 {
 	}
 
 	#[inline]
-	fn get(self, index: usize) -> u32 {
+	unsafe fn get_unchecked(self, index: usize) -> u32 {
 		// Extract M128 lane, then use M128's get
 		let lane_idx = index / 4;
 		let sub_idx = index % 4;
-		let lane = Divisible::<M128>::get(self, lane_idx);
-		Divisible::<u32>::get(lane, sub_idx)
+		// Safety: `index < Self::N` by the caller's contract, so `lane_idx` and `sub_idx` are
+		// in bounds.
+		unsafe {
+			let lane = Divisible::<M128>::get_unchecked(self, lane_idx);
+			Divisible::<u32>::get_unchecked(lane, sub_idx)
+		}
 	}
 
 	#[inline]
-	fn set(&mut self, index: usize, val: u32) {
+	unsafe fn set_unchecked(&mut self, index: usize, val: u32) {
 		let lane_idx = index / 4;
 		let sub_idx = index % 4;
-		let mut lane = Divisible::<M128>::get(*self, lane_idx);
-		Divisible::<u32>::set(&mut lane, sub_idx, val);
-		Divisible::<M128>::set(self, lane_idx, lane);
+		// Safety: `index < Self::N` by the caller's contract, so `lane_idx` and `sub_idx` are
+		// in bounds.
+		unsafe {
+			let mut lane = Divisible::<M128>::get_unchecked(*self, lane_idx);
+			Divisible::<u32>::set_unchecked(&mut lane, sub_idx, val);
+			Divisible::<M128>::set_unchecked(self, lane_idx, lane);
+		}
 	}
 
 	#[inline]
@@ -1148,21 +1166,29 @@ impl Divisible<u16> for M512 {
 	}
 
 	#[inline]
-	fn get(self, index: usize) -> u16 {
+	unsafe fn get_unchecked(self, index: usize) -> u16 {
 		// Extract M128 lane, then use M128's get
 		let lane_idx = index / 8;
 		let sub_idx = index % 8;
-		let lane = Divisible::<M128>::get(self, lane_idx);
-		Divisible::<u16>::get(lane, sub_idx)
+		// Safety: `index < Self::N` by the caller's contract, so `lane_idx` and `sub_idx` are
+		// in bounds.
+		unsafe {
+			let lane = Divisible::<M128>::get_unchecked(self, lane_idx);
+			Divisible::<u16>::get_unchecked(lane, sub_idx)
+		}
 	}
 
 	#[inline]
-	fn set(&mut self, index: usize, val: u16) {
+	unsafe fn set_unchecked(&mut self, index: usize, val: u16) {
 		let lane_idx = index / 8;
 		let sub_idx = index % 8;
-		let mut lane = Divisible::<M128>::get(*self, lane_idx);
-		Divisible::<u16>::set(&mut lane, sub_idx, val);
-		Divisible::<M128>::set(self, lane_idx, lane);
+		// Safety: `index < Self::N` by the caller's contract, so `lane_idx` and `sub_idx` are
+		// in bounds.
+		unsafe {
+			let mut lane = Divisible::<M128>::get_unchecked(*self, lane_idx);
+			Divisible::<u16>::set_unchecked(&mut lane, sub_idx, val);
+			Divisible::<M128>::set_unchecked(self, lane_idx, lane);
+		}
 	}
 
 	#[inline]
@@ -1200,21 +1226,29 @@ impl Divisible<u8> for M512 {
 	}
 
 	#[inline]
-	fn get(self, index: usize) -> u8 {
+	unsafe fn get_unchecked(self, index: usize) -> u8 {
 		// Extract M128 lane, then use M128's get
 		let lane_idx = index / 16;
 		let sub_idx = index % 16;
-		let lane = Divisible::<M128>::get(self, lane_idx);
-		Divisible::<u8>::get(lane, sub_idx)
+		// Safety: `index < Self::N` by the caller's contract, so `lane_idx` and `sub_idx` are
+		// in bounds.
+		unsafe {
+			let lane = Divisible::<M128>::get_unchecked(self, lane_idx);
+			Divisible::<u8>::get_unchecked(lane, sub_idx)
+		}
 	}
 
 	#[inline]
-	fn set(&mut self, index: usize, val: u8) {
+	unsafe fn set_unchecked(&mut self, index: usize, val: u8) {
 		let lane_idx = index / 16;
 		let sub_idx = index % 16;
-		let mut lane = Divisible::<M128>::get(*self, lane_idx);
-		Divisible::<u8>::set(&mut lane, sub_idx, val);
-		Divisible::<M128>::set(self, lane_idx, lane);
+		// Safety: `index < Self::N` by the caller's contract, so `lane_idx` and `sub_idx` are
+		// in bounds.
+		unsafe {
+			let mut lane = Divisible::<M128>::get_unchecked(*self, lane_idx);
+			Divisible::<u8>::set_unchecked(&mut lane, sub_idx, val);
+			Divisible::<M128>::set_unchecked(self, lane_idx, lane);
+		}
 	}
 
 	#[inline]

--- a/crates/field/src/binary_field.rs
+++ b/crates/field/src/binary_field.rs
@@ -258,14 +258,12 @@ macro_rules! binary_field {
 			}
 
 			#[inline]
-			fn get(self, index: usize) -> $name {
-				debug_assert_eq!(index, 0);
+			unsafe fn get_unchecked(self, _index: usize) -> $name {
 				self
 			}
 
 			#[inline]
-			fn set(&mut self, index: usize, val: $name) {
-				debug_assert_eq!(index, 0);
+			unsafe fn set_unchecked(&mut self, _index: usize, val: $name) {
 				*self = val;
 			}
 

--- a/crates/field/src/packed.rs
+++ b/crates/field/src/packed.rs
@@ -45,9 +45,9 @@ pub trait PackedField:
 	+ Random
 	+ WideMul<Output: Debug + Send + Sync + 'static>
 	+ 'static
-	// A packed field divides into its `WIDTH` scalars. Element access (`get`), broadcast, and the
-	// scalar iterators are provided by this supertrait; `set` is kept here as an in-place `&mut`
-	// convenience (see [`Self::set`]).
+	// A packed field divides into its `WIDTH` scalars. Scalar element access (`get`/`set` and
+	// their `_unchecked` variants), broadcast, and the scalar iterators are all provided by this
+	// supertrait.
 	+ Divisible<Self::Scalar>
 {
 	/// Base-2 logarithm of the number of field elements packed into one packed element.
@@ -59,16 +59,6 @@ pub trait PackedField:
 	///
 	/// WIDTH is guaranteed to equal 2^LOG_WIDTH.
 	const WIDTH: usize = 1 << Self::LOG_WIDTH;
-
-	/// Get the scalar at a given index without bounds checking.
-	/// # Safety
-	/// The caller must ensure that `i` is less than `WIDTH`.
-	unsafe fn get_unchecked(&self, i: usize) -> Self::Scalar;
-
-	/// Set the scalar at a given index without bounds checking.
-	/// # Safety
-	/// The caller must ensure that `i` is less than `WIDTH`.
-	unsafe fn set_unchecked(&mut self, i: usize, scalar: Self::Scalar);
 
 	#[inline]
 	fn into_iter(self) -> impl Iterator<Item = Self::Scalar> + Send + Clone {
@@ -405,16 +395,8 @@ impl<P: PackedField> RandomAccessSequenceMut<P::Scalar> for PackedSliceMut<'_, P
 
 impl<F: Field> PackedField for F {
 	// LOG_WIDTH defaults to `<Self as Divisible<Self>>::LOG_N`, which is 0 for a scalar field.
-
-	#[inline]
-	unsafe fn get_unchecked(&self, _i: usize) -> Self::Scalar {
-		*self
-	}
-
-	#[inline]
-	unsafe fn set_unchecked(&mut self, _i: usize, scalar: Self::Scalar) {
-		*self = scalar;
-	}
+	// Scalar element access (`get_unchecked`/`set_unchecked`) is provided by the reflexive
+	// `Divisible<Self>` impl.
 
 	#[inline]
 	fn iter(&self) -> impl Iterator<Item = Self::Scalar> + Send + Clone + '_ {

--- a/crates/field/src/underlier/divisible.rs
+++ b/crates/field/src/underlier/divisible.rs
@@ -40,14 +40,38 @@ pub trait Divisible<T>: Copy {
 	/// # Panics
 	///
 	/// Panics if `index >= Self::N`.
-	fn get(self, index: usize) -> T;
+	#[inline]
+	fn get(self, index: usize) -> T {
+		assert!(index < Self::N, "index {index} out of bounds (N = {})", Self::N);
+		// Safety: `index < Self::N` checked above.
+		unsafe { self.get_unchecked(index) }
+	}
 
 	/// Set element at index (LSB-first ordering), in place.
 	///
 	/// # Panics
 	///
 	/// Panics if `index >= Self::N`.
-	fn set(&mut self, index: usize, val: T);
+	#[inline]
+	fn set(&mut self, index: usize, val: T) {
+		assert!(index < Self::N, "index {index} out of bounds (N = {})", Self::N);
+		// Safety: `index < Self::N` checked above.
+		unsafe { self.set_unchecked(index, val) };
+	}
+
+	/// Get element at index (LSB-first ordering) without bounds checking.
+	///
+	/// # Safety
+	///
+	/// The caller must ensure that `index < Self::N`.
+	unsafe fn get_unchecked(self, index: usize) -> T;
+
+	/// Set element at index (LSB-first ordering) in place, without bounds checking.
+	///
+	/// # Safety
+	///
+	/// The caller must ensure that `index < Self::N`.
+	unsafe fn set_unchecked(&mut self, index: usize, val: T);
 
 	/// Create a value with `val` broadcast to all `N` positions.
 	fn broadcast(val: T) -> Self;
@@ -163,51 +187,77 @@ pub mod memcast {
 		})
 	}
 
-	/// Get element at index (LSB-first ordering).
+	/// Get element at index (LSB-first ordering) without bounds checking.
+	///
+	/// # Safety
+	///
+	/// The caller must ensure that `index < N`.
 	#[cfg(target_endian = "little")]
 	#[inline]
-	pub fn get<Big, Small, const N: usize>(value: &Big, index: usize) -> Small
+	pub unsafe fn get<Big, Small, const N: usize>(value: &Big, index: usize) -> Small
 	where
 		Big: Pod,
 		Small: Pod,
 	{
-		bytemuck::must_cast_ref::<Big, [Small; N]>(value)[index]
+		// Safety: the caller guarantees `index < N`.
+		unsafe { *bytemuck::must_cast_ref::<Big, [Small; N]>(value).get_unchecked(index) }
 	}
 
-	/// Get element at index (LSB-first ordering).
+	/// Get element at index (LSB-first ordering) without bounds checking.
+	///
+	/// # Safety
+	///
+	/// The caller must ensure that `index < N`.
 	#[cfg(target_endian = "big")]
 	#[inline]
-	pub fn get<Big, Small, const N: usize>(value: &Big, index: usize) -> Small
+	pub unsafe fn get<Big, Small, const N: usize>(value: &Big, index: usize) -> Small
 	where
 		Big: Pod,
 		Small: Pod,
 	{
-		bytemuck::must_cast_ref::<Big, [Small; N]>(value)[N - 1 - index]
+		// Safety: the caller guarantees `index < N`, so `N - 1 - index < N`.
+		unsafe { *bytemuck::must_cast_ref::<Big, [Small; N]>(value).get_unchecked(N - 1 - index) }
 	}
 
-	/// Set element at index (LSB-first ordering), returning modified value.
+	/// Set element at index (LSB-first ordering), returning modified value, without bounds
+	/// checking.
+	///
+	/// # Safety
+	///
+	/// The caller must ensure that `index < N`.
 	#[cfg(target_endian = "little")]
 	#[inline]
-	pub fn set<Big, Small, const N: usize>(value: &Big, index: usize, val: Small) -> Big
+	pub unsafe fn set<Big, Small, const N: usize>(value: &Big, index: usize, val: Small) -> Big
 	where
 		Big: Pod,
 		Small: Pod,
 	{
 		let mut arr = *bytemuck::must_cast_ref::<Big, [Small; N]>(value);
-		arr[index] = val;
+		// Safety: the caller guarantees `index < N`.
+		unsafe {
+			*arr.get_unchecked_mut(index) = val;
+		}
 		bytemuck::must_cast(arr)
 	}
 
-	/// Set element at index (LSB-first ordering), returning modified value.
+	/// Set element at index (LSB-first ordering), returning modified value, without bounds
+	/// checking.
+	///
+	/// # Safety
+	///
+	/// The caller must ensure that `index < N`.
 	#[cfg(target_endian = "big")]
 	#[inline]
-	pub fn set<Big, Small, const N: usize>(value: &Big, index: usize, val: Small) -> Big
+	pub unsafe fn set<Big, Small, const N: usize>(value: &Big, index: usize, val: Small) -> Big
 	where
 		Big: Pod,
 		Small: Pod,
 	{
 		let mut arr = *bytemuck::must_cast_ref::<Big, [Small; N]>(value);
-		arr[N - 1 - index] = val;
+		// Safety: the caller guarantees `index < N`, so `N - 1 - index < N`.
+		unsafe {
+			*arr.get_unchecked_mut(N - 1 - index) = val;
+		}
 		bytemuck::must_cast(arr)
 	}
 
@@ -259,34 +309,50 @@ pub mod memcast {
 pub mod bitmask {
 	use super::{Divisible, SmallU};
 
-	/// Get a sub-byte element at index (LSB-first ordering).
+	/// Get a sub-byte element at index (LSB-first ordering) without bounds checking.
+	///
+	/// # Safety
+	///
+	/// The caller must ensure that `index < Big::N` (over `SmallU<BITS>` elements).
 	#[inline]
-	pub fn get<Big, const BITS: usize>(value: Big, index: usize) -> SmallU<BITS>
+	pub unsafe fn get<Big, const BITS: usize>(value: Big, index: usize) -> SmallU<BITS>
 	where
 		Big: Divisible<u8>,
 	{
 		let elems_per_byte = 8 / BITS;
 		let byte_index = index / elems_per_byte;
 		let sub_index = index % elems_per_byte;
-		let byte = Divisible::<u8>::get(value, byte_index);
+		// Safety: `index < Big::N` over `SmallU<BITS>` implies `byte_index < Big::N` over `u8`.
+		let byte = unsafe { Divisible::<u8>::get_unchecked(value, byte_index) };
 		let shift = sub_index * BITS;
 		SmallU::<BITS>::new(byte >> shift)
 	}
 
-	/// Set a sub-byte element at index (LSB-first ordering), returning modified value.
+	/// Set a sub-byte element at index (LSB-first ordering), returning modified value, without
+	/// bounds checking.
+	///
+	/// # Safety
+	///
+	/// The caller must ensure that `index < Big::N` (over `SmallU<BITS>` elements).
 	#[inline]
-	pub fn set<Big, const BITS: usize>(mut value: Big, index: usize, val: SmallU<BITS>) -> Big
+	pub unsafe fn set<Big, const BITS: usize>(
+		mut value: Big,
+		index: usize,
+		val: SmallU<BITS>,
+	) -> Big
 	where
 		Big: Divisible<u8>,
 	{
 		let elems_per_byte = 8 / BITS;
 		let byte_index = index / elems_per_byte;
 		let sub_index = index % elems_per_byte;
-		let byte = Divisible::<u8>::get(value, byte_index);
+		// Safety: `index < Big::N` over `SmallU<BITS>` implies `byte_index < Big::N` over `u8`.
+		let byte = unsafe { Divisible::<u8>::get_unchecked(value, byte_index) };
 		let shift = sub_index * BITS;
 		let mask = (1u8 << BITS) - 1;
 		let new_byte = (byte & !(mask << shift)) | (val.val() << shift);
-		Divisible::<u8>::set(&mut value, byte_index, new_byte);
+		// Safety: `byte_index < Big::N` over `u8`, as above.
+		unsafe { Divisible::<u8>::set_unchecked(&mut value, byte_index, new_byte) };
 		value
 	}
 }
@@ -421,15 +487,17 @@ macro_rules! impl_divisible_memcast {
 				}
 
 				#[inline]
-				fn get(self, index: usize) -> $small {
+				unsafe fn get_unchecked(self, index: usize) -> $small {
 					const N: usize = size_of::<$big>() / size_of::<$small>();
-					$crate::underlier::memcast::get::<$big, $small, N>(&self, index)
+					// Safety: the caller guarantees `index < Self::N == N`.
+					unsafe { $crate::underlier::memcast::get::<$big, $small, N>(&self, index) }
 				}
 
 				#[inline]
-				fn set(&mut self, index: usize, val: $small) {
+				unsafe fn set_unchecked(&mut self, index: usize, val: $small) {
 					const N: usize = size_of::<$big>() / size_of::<$small>();
-					*self = $crate::underlier::memcast::set::<$big, $small, N>(&*self, index, val);
+					// Safety: the caller guarantees `index < Self::N == N`.
+					*self = unsafe { $crate::underlier::memcast::set::<$big, $small, N>(&*self, index, val) };
 				}
 
 				#[inline]
@@ -478,13 +546,13 @@ macro_rules! impl_divisible_bitmask {
 				}
 
 				#[inline]
-				fn get(self, index: usize) -> $crate::underlier::SmallU<$bits> {
+				unsafe fn get_unchecked(self, index: usize) -> $crate::underlier::SmallU<$bits> {
 					let shift = index * $bits;
 					$crate::underlier::SmallU::<$bits>::new(self >> shift)
 				}
 
 				#[inline]
-				fn set(&mut self, index: usize, val: $crate::underlier::SmallU<$bits>) {
+				unsafe fn set_unchecked(&mut self, index: usize, val: $crate::underlier::SmallU<$bits>) {
 					let shift = index * $bits;
 					let mask = (1u8 << $bits) - 1;
 					*self = (*self & !(mask << shift)) | (val.val() << shift);
@@ -548,13 +616,15 @@ macro_rules! impl_divisible_bitmask {
 				}
 
 				#[inline]
-				fn get(self, index: usize) -> $crate::underlier::SmallU<$bits> {
-					$crate::underlier::bitmask::get::<Self, $bits>(self, index)
+				unsafe fn get_unchecked(self, index: usize) -> $crate::underlier::SmallU<$bits> {
+					// Safety: the caller guarantees `index < Self::N`.
+					unsafe { $crate::underlier::bitmask::get::<Self, $bits>(self, index) }
 				}
 
 				#[inline]
-				fn set(&mut self, index: usize, val: $crate::underlier::SmallU<$bits>) {
-					*self = $crate::underlier::bitmask::set::<Self, $bits>(*self, index, val);
+				unsafe fn set_unchecked(&mut self, index: usize, val: $crate::underlier::SmallU<$bits>) {
+					// Safety: the caller guarantees `index < Self::N`.
+					*self = unsafe { $crate::underlier::bitmask::set::<Self, $bits>(*self, index, val) };
 				}
 
 				#[inline]
@@ -616,12 +686,12 @@ impl Divisible<SmallU<1>> for SmallU<2> {
 	}
 
 	#[inline]
-	fn get(self, index: usize) -> SmallU<1> {
+	unsafe fn get_unchecked(self, index: usize) -> SmallU<1> {
 		SmallU::<1>::new(self.val() >> index)
 	}
 
 	#[inline]
-	fn set(&mut self, index: usize, val: SmallU<1>) {
+	unsafe fn set_unchecked(&mut self, index: usize, val: SmallU<1>) {
 		let mask = 1u8 << index;
 		*self = SmallU::<2>::new((self.val() & !mask) | (val.val() << index));
 	}
@@ -664,12 +734,12 @@ impl Divisible<SmallU<1>> for SmallU<4> {
 	}
 
 	#[inline]
-	fn get(self, index: usize) -> SmallU<1> {
+	unsafe fn get_unchecked(self, index: usize) -> SmallU<1> {
 		SmallU::<1>::new(self.val() >> index)
 	}
 
 	#[inline]
-	fn set(&mut self, index: usize, val: SmallU<1>) {
+	unsafe fn set_unchecked(&mut self, index: usize, val: SmallU<1>) {
 		let mask = 1u8 << index;
 		*self = SmallU::<4>::new((self.val() & !mask) | (val.val() << index));
 	}
@@ -714,12 +784,12 @@ impl Divisible<SmallU<2>> for SmallU<4> {
 	}
 
 	#[inline]
-	fn get(self, index: usize) -> SmallU<2> {
+	unsafe fn get_unchecked(self, index: usize) -> SmallU<2> {
 		SmallU::<2>::new(self.val() >> (index * 2))
 	}
 
 	#[inline]
-	fn set(&mut self, index: usize, val: SmallU<2>) {
+	unsafe fn set_unchecked(&mut self, index: usize, val: SmallU<2>) {
 		let shift = index * 2;
 		let mask = 0b11u8 << shift;
 		*self = SmallU::<4>::new((self.val() & !mask) | (val.val() << shift));
@@ -767,14 +837,12 @@ macro_rules! impl_divisible_self {
 				}
 
 				#[inline]
-				fn get(self, index: usize) -> $ty {
-					debug_assert_eq!(index, 0);
+				unsafe fn get_unchecked(self, _index: usize) -> $ty {
 					self
 				}
 
 				#[inline]
-				fn set(&mut self, index: usize, val: $ty) {
-					debug_assert_eq!(index, 0);
+				unsafe fn set_unchecked(&mut self, _index: usize, val: $ty) {
 					*self = val;
 				}
 

--- a/crates/field/src/underlier/scaled.rs
+++ b/crates/field/src/underlier/scaled.rs
@@ -233,17 +233,21 @@ where
 	}
 
 	#[inline]
-	fn get(self, index: usize) -> T {
+	unsafe fn get_unchecked(self, index: usize) -> T {
 		let u_index = index >> <U as Divisible<T>>::LOG_N;
 		let sub_index = index & (<U as Divisible<T>>::N - 1);
-		Divisible::<T>::get(self.0[u_index], sub_index)
+		// Safety: `index < Self::N` by the caller's contract, so `sub_index < <U as
+		// Divisible<T>>::N` and `u_index < N`.
+		unsafe { Divisible::<T>::get_unchecked(*self.0.get_unchecked(u_index), sub_index) }
 	}
 
 	#[inline]
-	fn set(&mut self, index: usize, val: T) {
+	unsafe fn set_unchecked(&mut self, index: usize, val: T) {
 		let u_index = index >> <U as Divisible<T>>::LOG_N;
 		let sub_index = index & (<U as Divisible<T>>::N - 1);
-		Divisible::<T>::set(&mut self.0[u_index], sub_index, val);
+		// Safety: `index < Self::N` by the caller's contract, so `sub_index < <U as
+		// Divisible<T>>::N` and `u_index < N`.
+		unsafe { Divisible::<T>::set_unchecked(self.0.get_unchecked_mut(u_index), sub_index, val) };
 	}
 
 	#[inline]


### PR DESCRIPTION
Resolves [BINIUS-89](https://linear.app/jimpo/issue/BINIUS-89/move-packedfield-get-unchecked-and-set-unchecked-to-divisible).

Follows the BINIUS-87 cleanup (#1526, #1527): now that `Divisible` is a supertrait of `PackedField`, the unchecked scalar accessors belong on `Divisible` alongside `get`/`set`/`broadcast`.

## Change
- Move `get_unchecked`/`set_unchecked` onto the `Divisible` trait as the **required primitives**, and make `get`/`set` defaults that bounds-check then call them (the `Vec` pattern):
  ```rust
  unsafe fn get_unchecked(self, index: usize) -> T;
  unsafe fn set_unchecked(&mut self, index: usize, val: T);
  fn get(self, index: usize) -> T { assert!(index < Self::N, ..); unsafe { self.get_unchecked(index) } }
  fn set(&mut self, index: usize, val: T) { assert!(index < Self::N, ..); unsafe { self.set_unchecked(index, val) } }
  ```
  Each `Divisible` impl's former `get`/`set` body becomes its `*_unchecked` impl, so the bounds check lives only in the safe wrappers and the unchecked path is check-free.
- Make the unchecked impls genuinely zero-check: `N = 1` impls drop the index `match` (index is 0 by the precondition); the multi-index SIMD impls (`m128`/`m256`/`m512` x86_64 + aarch64) replace the `_ => panic!()` arm with `core::hint::unreachable_unchecked()`; the `memcast` and `ScaledUnderlier` bodies use `get_unchecked`/`get_unchecked_mut`. Delegating impls (`M256`/`M512` → `M128`, `ScaledUnderlier` → inner, `PackedPrimitiveType` → underlier) call the inner `*_unchecked`, so the path is check-free end to end.
- Remove `get_unchecked`/`set_unchecked` from the `PackedField` trait and its two impls (the blanket `impl<F: Field>` and `PackedPrimitiveType`); both inherit the `Divisible` methods via the supertrait. `PackedField`'s internal callers (`into_iter`, `iter`, `try_from_fn`) and the `get_packed_slice_unchecked`/`set_packed_slice_unchecked` helpers resolve through the supertrait bound with no call-site churn. The `RandomAccessSequence`/`RandomAccessSequenceMut` impls for `PackedSlice`/`PackedSliceMut` are a different trait and untouched.

## Test plan
- `cargo test --workspace` (CI) — green.
- `cargo +nightly-2026-01-01 fmt --check`, `cargo clippy --all --tests --benches --examples -- -D warnings`, `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --document-private-items --workspace`, aarch64 `cargo clippy --target aarch64-unknown-linux-gnu --all-targets -- -D warnings` (with `-Ctarget-feature=+neon,+aes,+sha2,+sha3`), and a `wasm32-wasip1` test build — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)