### PR TITLE
BINIUS-93: add public-derived wires to the IronSpartan frontend

### DIFF
--- a/crates/spartan-frontend/src/circuit_builder.rs
+++ b/crates/spartan-frontend/src/circuit_builder.rs
@@ -488,6 +488,124 @@ impl<'a, F: Field> CircuitBuilder for WitnessGenerator<'a, F> {
 	}
 }
 
+/// Wire type for [`InstanceGenerator`]: holds the field value of a public wire (a constant, inout,
+/// or derived value the verifier can compute) and is `None` for private/precommit wires, whose
+/// values the verifier does not know. A wire being `Some` mirrors [`WireKind::is_public`], so the
+/// derived-vs-private branching stays aligned with the other builders.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PublicWire<F: Field>(Option<F>);
+
+/// Reconstructs the public input vector `[constants | inout | derived]` on the verifier side by
+/// re-running the circuit function.
+///
+/// Implements [`CircuitBuilder`] with [`PublicWire`] as the wire type, structurally mirroring
+/// [`WitnessGenerator`], but it only computes the *public* segment. The verifier lacks the secret
+/// (precommit) values, so private wires carry no value; by the soundness invariant a derived wire
+/// never reads a secret, so every derived value is computable from the real public inputs alone.
+/// Derived wires are allocated in the same order as [`ConstraintBuilder`], keeping their ids
+/// aligned so [`WitnessLayout::get`] resolves each to the correct public slot.
+#[derive(Debug)]
+pub struct InstanceGenerator<'a, F: Field> {
+	derived_alloc: WireAllocator,
+	public: Vec<F>,
+	layout: &'a WitnessLayout<F>,
+}
+
+impl<'a, F: Field> InstanceGenerator<'a, F> {
+	pub fn new(layout: &'a WitnessLayout<F>) -> Self {
+		let mut public = zeroed_vec(layout.public_size());
+		public[..layout.constants.len()].copy_from_slice(&layout.constants);
+
+		Self {
+			derived_alloc: WireAllocator::new(WireKind::Derived),
+			public,
+			layout,
+		}
+	}
+
+	/// Writes a real inout value into its public slot.
+	pub fn write_inout(&mut self, wire: ConstraintWire, value: F) -> PublicWire<F> {
+		assert_eq!(wire.kind, WireKind::InOut);
+		self.write_public(wire, value)
+	}
+
+	/// Records a precommit wire as private (value unknown to the verifier). Per the soundness
+	/// invariant a secret never feeds a derived value, so the missing value is inert.
+	pub fn placeholder_precommit(&mut self, wire: ConstraintWire) -> PublicWire<F> {
+		assert_eq!(wire.kind, WireKind::Precommit);
+		PublicWire(None)
+	}
+
+	/// Writes `value` to the wire's public slot if it has one (i.e. it is alive), then returns the
+	/// wire carrying its value. Wires with no slot (pruned intermediates) are computed inline only.
+	fn write_public(&mut self, wire: ConstraintWire, value: F) -> PublicWire<F> {
+		if let Some(index) = self.layout.get(&wire) {
+			debug_assert_eq!(index.segment, WitnessSegment::Public);
+			self.public[index.index as usize] = value;
+		}
+		PublicWire(Some(value))
+	}
+
+	/// Returns the reconstructed public vector `[constants | inout | derived]`, of length
+	/// `1 << layout.log_public()`, ready to pass to `Verifier::verify`.
+	pub fn build(self) -> Vec<F> {
+		self.public
+	}
+}
+
+impl<'a, F: Field> CircuitBuilder for InstanceGenerator<'a, F> {
+	type Wire = PublicWire<F>;
+	type Field = F;
+
+	// Assertions are enforced as ordinary public-segment constraints by the verifier, so they are
+	// no-ops here. They must not allocate, to stay wire-id-aligned with the other builders.
+	fn assert_zero(&mut self, _wire: Self::Wire) {}
+
+	fn assert_eq(&mut self, _lhs: Self::Wire, _rhs: Self::Wire) {}
+
+	fn constant(&mut self, val: F) -> Self::Wire {
+		PublicWire(Some(val))
+	}
+
+	fn add(&mut self, lhs: Self::Wire, rhs: Self::Wire) -> Self::Wire {
+		match (lhs.0, rhs.0) {
+			(Some(lhs), Some(rhs)) => {
+				let wire = self.derived_alloc.alloc();
+				self.write_public(wire, lhs + rhs)
+			}
+			_ => PublicWire(None),
+		}
+	}
+
+	fn mul(&mut self, lhs: Self::Wire, rhs: Self::Wire) -> Self::Wire {
+		match (lhs.0, rhs.0) {
+			(Some(lhs), Some(rhs)) => {
+				let wire = self.derived_alloc.alloc();
+				self.write_public(wire, lhs * rhs)
+			}
+			_ => PublicWire(None),
+		}
+	}
+
+	fn hint<H: Fn([F; IN]) -> [F; OUT], const IN: usize, const OUT: usize>(
+		&mut self,
+		inputs: [Self::Wire; IN],
+		f: H,
+	) -> [Self::Wire; OUT] {
+		// Only invoke `f` when every input is public (its value is known); a non-derived hint would
+		// receive value-less inputs, so `f` is skipped to avoid panics on missing values.
+		if inputs.iter().all(|wire| wire.0.is_some()) {
+			let values = inputs.map(|wire| wire.0.expect("every input checked public above"));
+			f(values).map(|value| {
+				let wire = self.derived_alloc.alloc();
+				self.write_public(wire, value)
+			})
+		} else {
+			[PublicWire(None); OUT]
+		}
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use std::iter::successors;
@@ -620,5 +738,168 @@ mod tests {
 				}
 			}
 		}
+	}
+
+	/// A circuit mixing derived wires (a derived mul, a derived hint, a derived add) with a private
+	/// wire (a mul against a precommit input). Used by the sync test below.
+	///
+	/// `expected` must equal `((a * b) * (a * b).invert_or_zero() + b) * s` (see
+	/// [`mixed_expected`]), so that the witness is satisfiable.
+	fn mixed_circuit<Builder: CircuitBuilder>(
+		builder: &mut Builder,
+		a: Builder::Wire,
+		b: Builder::Wire,
+		s: Builder::Wire,
+		expected: Builder::Wire,
+	) {
+		use binius_field::arithmetic_traits::InvertOrZero;
+
+		let d = builder.mul(a, b); // derived (a, b public-derivable)
+		let [d_inv] = builder.hint([d], |[x]| [x.invert_or_zero()]); // derived hint
+		let one_check = builder.mul(d, d_inv); // derived (== 1 when d != 0)
+		let e = builder.add(one_check, b); // derived
+		let p = builder.mul(e, s); // private (s is precommit)
+		builder.assert_eq(p, expected);
+	}
+
+	// Computes the `expected` inout value for `mixed_circuit` from concrete inputs.
+	fn mixed_expected(a: B128, b: B128, s: B128) -> B128 {
+		use binius_field::arithmetic_traits::InvertOrZero;
+		let d = a * b;
+		let one_check = d * d.invert_or_zero();
+		(one_check + b) * s
+	}
+
+	#[test]
+	fn test_instance_generator_syncs_with_witness() {
+		use crate::compiler::compile;
+
+		let a_val = B128::new(3);
+		let b_val = B128::new(5);
+		let s_val = B128::new(7);
+		let expected_val = mixed_expected(a_val, b_val, s_val);
+
+		let mut cb = ConstraintBuilder::new();
+		let a = cb.alloc_inout();
+		let b = cb.alloc_inout();
+		let s = cb.alloc_precommit();
+		let expected = cb.alloc_inout();
+		mixed_circuit(&mut cb, a, b, s, expected);
+		let (cs, layout) = compile(cb);
+
+		// Witness generation (prover side) fills the full witness including the derived publics.
+		let mut wg = WitnessGenerator::new(&layout);
+		let a_w = wg.write_inout(a, a_val);
+		let b_w = wg.write_inout(b, b_val);
+		let s_w = wg.write_precommit(s, s_val);
+		let expected_w = wg.write_inout(expected, expected_val);
+		mixed_circuit(&mut wg, a_w, b_w, s_w, expected_w);
+		let witness = wg.build().expect("witness generation should succeed");
+		cs.validate(&witness);
+
+		// Instance generation (verifier side) reconstructs only the public segment, without the
+		// secret `s`. It must match the witness's public segment exactly.
+		let mut ig = InstanceGenerator::new(&layout);
+		let a_i = ig.write_inout(a, a_val);
+		let b_i = ig.write_inout(b, b_val);
+		let s_i = ig.placeholder_precommit(s);
+		let expected_i = ig.write_inout(expected, expected_val);
+		mixed_circuit(&mut ig, a_i, b_i, s_i, expected_i);
+		let public = ig.build();
+
+		assert_eq!(public, witness.public());
+	}
+
+	#[test]
+	fn test_derived_elision_no_private_wires() {
+		use crate::compiler::compile;
+
+		// A circuit that is a pure function of inout: x -> x^2 -> x^3, asserting x^3 == y.
+		let mut cb = ConstraintBuilder::new();
+		let x = cb.alloc_inout();
+		let y = cb.alloc_inout();
+		let x2 = cb.mul(x, x); // derived (intermediate, feeds only x3)
+		let x3 = cb.mul(x2, x); // derived (referenced by the assert)
+		cb.assert_eq(x3, y);
+		assert_eq!(x2.kind, WireKind::Derived);
+		assert_eq!(x3.kind, WireKind::Derived);
+		let (cs, layout) = compile(cb);
+
+		// No private wires or mul constraints from the chain; x2 is a pruned intermediate, so only
+		// x3 occupies a derived public slot.
+		assert_eq!(cs.n_private(), 0);
+		assert_eq!(layout.n_derived(), 1);
+
+		let x_val = B128::new(9);
+		let y_val = x_val * x_val * x_val;
+
+		let mut wg = WitnessGenerator::new(&layout);
+		let x_w = wg.write_inout(x, x_val);
+		let y_w = wg.write_inout(y, y_val);
+		let x2_w = wg.mul(x_w, x_w);
+		let x3_w = wg.mul(x2_w, x_w);
+		wg.assert_eq(x3_w, y_w);
+		let witness = wg.build().expect("witness generation should succeed");
+		cs.validate(&witness);
+	}
+
+	#[test]
+	fn test_derived_wire_in_constraint_maps_to_public() {
+		use crate::{compiler::compile, constraint_system::WitnessSegment};
+
+		// `e` is derived but consumed by a mul constraint that also references the private `p`.
+		let mut cb = ConstraintBuilder::new();
+		let a = cb.alloc_inout();
+		let b = cb.alloc_inout();
+		let s = cb.alloc_precommit();
+		let e = cb.add(a, b); // derived
+		let p = cb.mul(e, s); // private; mul constraint references derived `e`
+		cb.assert_zero(p);
+		assert_eq!(e.kind, WireKind::Derived);
+		let (cs, layout) = compile(cb);
+
+		// The derived wire resolves to a slot in the public segment.
+		let e_index = layout.get(&e).expect("alive derived wire must have a slot");
+		assert_eq!(e_index.segment, WitnessSegment::Public);
+
+		// Some surviving mul constraint references that public index.
+		let references_e = cs.mul_constraints().iter().any(|c| {
+			[&c.a, &c.b, &c.c]
+				.iter()
+				.any(|operand| operand.wires().contains(&e_index))
+		});
+		assert!(references_e, "derived wire's public index should appear in a mul constraint");
+
+		// And a consistent witness validates.
+		let a_val = B128::new(3);
+		let b_val = B128::new(5);
+		let s_val = B128::ZERO; // makes p = e * 0 = 0 so assert_zero(p) holds
+		let mut wg = WitnessGenerator::new(&layout);
+		let a_w = wg.write_inout(a, a_val);
+		let b_w = wg.write_inout(b, b_val);
+		let s_w = wg.write_precommit(s, s_val);
+		let e_w = wg.add(a_w, b_w);
+		let p_w = wg.mul(e_w, s_w);
+		wg.assert_zero(p_w);
+		let witness = wg.build().expect("witness generation should succeed");
+		cs.validate(&witness);
+	}
+
+	#[test]
+	fn test_pruned_derived_intermediate_has_no_slot() {
+		use crate::compiler::compile;
+
+		// x2 feeds only the derived x3; only x3 is referenced by a surviving constraint.
+		let mut cb = ConstraintBuilder::<B128>::new();
+		let x = cb.alloc_inout();
+		let y = cb.alloc_inout();
+		let x2 = cb.mul(x, x); // derived intermediate
+		let x3 = cb.mul(x2, x); // derived, referenced by assert
+		cb.assert_eq(x3, y);
+		let (_cs, layout) = compile(cb);
+
+		// The intermediate has no public slot; the alive one does.
+		assert!(layout.get(&x2).is_none(), "pruned derived intermediate must have no slot");
+		assert!(layout.get(&x3).is_some(), "referenced derived wire must have a slot");
 	}
 }

--- a/crates/spartan-frontend/src/circuit_builder.rs
+++ b/crates/spartan-frontend/src/circuit_builder.rs
@@ -1,4 +1,5 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 use std::{array, backtrace::Backtrace, collections::HashMap, mem};
 
@@ -91,6 +92,7 @@ pub enum WireStatus {
 pub struct ConstraintSystemIR<F: Field> {
 	pub(crate) constant_alloc: WireAllocator,
 	pub(crate) public_alloc: WireAllocator,
+	pub(crate) derived_alloc: WireAllocator,
 	pub(crate) precommit_alloc: WireAllocator,
 	pub(crate) private_alloc: WireAllocator,
 	pub(crate) constants: HashMap<F, u32>,
@@ -148,11 +150,27 @@ impl<F: Field> ConstraintSystemIR<F> {
 			.map(|&status| !matches!(status, WireStatus::Pruned))
 			.collect();
 
+		// A derived wire needs a public slot iff it is referenced by a surviving constraint. Scan
+		// the (now fully folded) mul constraints for derived ids; intermediate derived wires that
+		// feed only other derived wires are referenced nowhere and get no slot — the generators
+		// compute them inline and `layout.get` returns `None`.
+		let mut derived_alive = vec![false; self.derived_alloc.n_wires as usize];
+		for MulConstraint { a, b, c } in &self.mul_constraints {
+			for operand in [a, b, c] {
+				for wire in operand.wires() {
+					if wire.kind == WireKind::Derived {
+						derived_alive[wire.id as usize] = true;
+					}
+				}
+			}
+		}
+
 		// Create WitnessLayout
 		let layout = WitnessLayout::sparse(
 			constants.clone(),
 			self.public_alloc.n_wires,
 			self.precommit_alloc.n_wires,
+			&derived_alive,
 			&private_alive,
 		);
 
@@ -213,6 +231,7 @@ impl<F: Field> ConstraintBuilder<F> {
 			ir: ConstraintSystemIR {
 				constant_alloc: WireAllocator::new(WireKind::Constant),
 				public_alloc: WireAllocator::new(WireKind::InOut),
+				derived_alloc: WireAllocator::new(WireKind::Derived),
 				precommit_alloc: WireAllocator::new(WireKind::Precommit),
 				private_alloc: WireAllocator::new(WireKind::Private),
 				constants: HashMap::new(),
@@ -263,6 +282,11 @@ impl<F: Field> CircuitBuilder for ConstraintBuilder<F> {
 	}
 
 	fn add(&mut self, lhs: Self::Wire, rhs: Self::Wire) -> Self::Wire {
+		// If both inputs are public-derivable, the sum is too: allocate a derived wire in the
+		// public segment and emit no constraint. The verifier recomputes it itself.
+		if lhs.kind.is_public() && rhs.kind.is_public() {
+			return self.ir.derived_alloc.alloc();
+		}
 		let out = self.ir.private_alloc.alloc();
 		self.ir.private_wires_status.push(WireStatus::Unknown);
 		self.ir
@@ -272,6 +296,11 @@ impl<F: Field> CircuitBuilder for ConstraintBuilder<F> {
 	}
 
 	fn mul(&mut self, lhs: Self::Wire, rhs: Self::Wire) -> Self::Wire {
+		// If both inputs are public-derivable, the product is too: allocate a derived wire and emit
+		// no multiplication constraint.
+		if lhs.kind.is_public() && rhs.kind.is_public() {
+			return self.ir.derived_alloc.alloc();
+		}
 		let out = self.ir.private_alloc.alloc();
 		self.ir.private_wires_status.push(WireStatus::Unknown);
 		self.ir.mul_constraints.push(MulConstraint {
@@ -284,13 +313,20 @@ impl<F: Field> CircuitBuilder for ConstraintBuilder<F> {
 
 	fn hint<H: Fn([F; IN]) -> [F; OUT], const IN: usize, const OUT: usize>(
 		&mut self,
-		_inputs: [Self::Wire; IN],
+		inputs: [Self::Wire; IN],
 		_f: H,
 	) -> [Self::Wire; OUT] {
+		// A hint over only public-derivable inputs is itself public-derivable. (Hints emit no
+		// constraints regardless; only the allocator choice changes.)
+		let derived = inputs.iter().all(|wire| wire.kind.is_public());
 		array::from_fn(|_| {
-			let wire = self.ir.private_alloc.alloc();
-			self.ir.private_wires_status.push(WireStatus::Unknown);
-			wire
+			if derived {
+				self.ir.derived_alloc.alloc()
+			} else {
+				let wire = self.ir.private_alloc.alloc();
+				self.ir.private_wires_status.push(WireStatus::Unknown);
+				wire
+			}
 		})
 	}
 }
@@ -301,12 +337,22 @@ pub struct WitnessError {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct WitnessWire<F: Field>(F);
+pub struct WitnessWire<F: Field> {
+	val: F,
+	segment: WitnessSegment,
+}
 
 impl<F: Field> WitnessWire<F> {
 	#[inline]
 	pub fn val(self) -> F {
-		self.0
+		self.val
+	}
+
+	/// Whether this wire's value lives in the public segment, i.e. is public-derivable. Drives the
+	/// derived-vs-private allocation choice, matching [`ConstraintBuilder`].
+	#[inline]
+	fn is_public(self) -> bool {
+		self.segment == WitnessSegment::Public
 	}
 }
 
@@ -317,7 +363,8 @@ impl<F: Field> WitnessWire<F> {
 /// the first constraint violation as an error for debugging.
 #[derive(Debug)]
 pub struct WitnessGenerator<'a, F: Field> {
-	alloc: WireAllocator,
+	derived_alloc: WireAllocator,
+	private_alloc: WireAllocator,
 	public: Vec<F>,
 	precommit: Vec<F>,
 	private: Vec<F>,
@@ -334,7 +381,8 @@ impl<'a, F: Field> WitnessGenerator<'a, F> {
 		let private = zeroed_vec(layout.private_size());
 
 		Self {
-			alloc: WireAllocator::new(WireKind::Private),
+			derived_alloc: WireAllocator::new(WireKind::Derived),
+			private_alloc: WireAllocator::new(WireKind::Private),
 			public,
 			precommit,
 			private,
@@ -343,8 +391,14 @@ impl<'a, F: Field> WitnessGenerator<'a, F> {
 		}
 	}
 
-	fn alloc_value(&mut self, value: F) -> WitnessWire<F> {
-		let wire = self.alloc.alloc();
+	/// Allocates the output wire of an op, choosing the derived or private allocator from the input
+	/// kinds (matching [`ConstraintBuilder`]), and writes its value.
+	fn alloc_op_value(&mut self, all_derivable: bool, value: F) -> WitnessWire<F> {
+		let wire = if all_derivable {
+			self.derived_alloc.alloc()
+		} else {
+			self.private_alloc.alloc()
+		};
 		self.write_value(wire, value)
 	}
 
@@ -356,7 +410,10 @@ impl<'a, F: Field> WitnessGenerator<'a, F> {
 				WitnessSegment::Private => self.private[index.index as usize] = value,
 			}
 		}
-		WitnessWire(value)
+		WitnessWire {
+			val: value,
+			segment: wire.kind.segment(),
+		}
 	}
 
 	pub fn write_inout(&mut self, wire: ConstraintWire, value: F) -> WitnessWire<F> {
@@ -399,21 +456,26 @@ impl<'a, F: Field> CircuitBuilder for WitnessGenerator<'a, F> {
 	}
 
 	fn assert_eq(&mut self, lhs: Self::Wire, rhs: Self::Wire) {
-		if lhs != rhs {
+		if lhs.val() != rhs.val() {
 			self.record_error();
 		}
 	}
 
 	fn constant(&mut self, val: F) -> Self::Wire {
-		WitnessWire(val)
+		WitnessWire {
+			val,
+			segment: WitnessSegment::Public,
+		}
 	}
 
 	fn add(&mut self, lhs: Self::Wire, rhs: Self::Wire) -> Self::Wire {
-		self.alloc_value(lhs.val() + rhs.val())
+		let all_derivable = lhs.is_public() && rhs.is_public();
+		self.alloc_op_value(all_derivable, lhs.val() + rhs.val())
 	}
 
 	fn mul(&mut self, lhs: Self::Wire, rhs: Self::Wire) -> Self::Wire {
-		self.alloc_value(lhs.val() * rhs.val())
+		let all_derivable = lhs.is_public() && rhs.is_public();
+		self.alloc_op_value(all_derivable, lhs.val() * rhs.val())
 	}
 
 	fn hint<H: Fn([F; IN]) -> [F; OUT], const IN: usize, const OUT: usize>(
@@ -421,7 +483,8 @@ impl<'a, F: Field> CircuitBuilder for WitnessGenerator<'a, F> {
 		inputs: [Self::Wire; IN],
 		f: H,
 	) -> [Self::Wire; OUT] {
-		f(inputs.map(WitnessWire::val)).map(|value| self.alloc_value(value))
+		let all_derivable = inputs.iter().all(|wire| wire.is_public());
+		f(inputs.map(WitnessWire::val)).map(|value| self.alloc_op_value(all_derivable, value))
 	}
 }
 

--- a/crates/spartan-frontend/src/constraint_system.rs
+++ b/crates/spartan-frontend/src/constraint_system.rs
@@ -1,4 +1,5 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 use std::{
 	cmp::Ordering,
@@ -15,8 +16,35 @@ use smallvec::{SmallVec, smallvec};
 pub enum WireKind {
 	Constant,
 	InOut,
+	/// A wire whose value is a pure function of public-derivable inputs (constants, inout, and
+	/// other derived wires). Derived wires live in the public segment and emit no constraint; the
+	/// verifier recomputes them itself via the `InstanceGenerator`.
+	Derived,
 	Precommit,
 	Private,
+}
+
+impl WireKind {
+	/// The witness segment a wire of this kind lives in: constants, inout, and derived wires occupy
+	/// the public segment; precommit and private wires occupy their own segments.
+	pub fn segment(self) -> WitnessSegment {
+		match self {
+			WireKind::Constant | WireKind::InOut | WireKind::Derived => WitnessSegment::Public,
+			WireKind::Precommit => WitnessSegment::Precommit,
+			WireKind::Private => WitnessSegment::Private,
+		}
+	}
+
+	/// Returns whether this wire kind lives in the public segment: its value is determined once the
+	/// public inputs (constants and inout) are known, so the verifier can recompute it without any
+	/// secret data.
+	///
+	/// Shared by all `CircuitBuilder` implementations so they make identical derived-vs-private
+	/// decisions. The output of a binary op (or hint) is [`WireKind::Derived`] iff every input is
+	/// public, and [`WireKind::Private`] otherwise.
+	pub fn is_public(self) -> bool {
+		self.segment() == WitnessSegment::Public
+	}
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -334,11 +362,13 @@ pub struct BlindingInfo {
 pub struct WitnessLayout<F: Field> {
 	pub(crate) constants: Vec<F>,
 	n_inout: u32,
+	n_derived: u32,
 	n_precommit: u32,
 	n_private: u32,
 	log_public: u32,
 	log_precommit: u32,
 	log_private: u32,
+	derived_index_map: HashMap<u32, u32>,
 	private_index_map: HashMap<u32, u32>,
 }
 
@@ -347,12 +377,26 @@ impl<F: Field> WitnessLayout<F> {
 		constants: Vec<F>,
 		n_inout: u32,
 		n_precommit: u32,
+		derived_alive: &[bool],
 		private_alive: &[bool],
 	) -> Self {
 		let n_constants = constants.len() as u32;
-		let n_public = n_constants + n_inout;
-		let log_public = log2_ceil_usize(n_public as usize) as u32;
 		let log_precommit = log2_ceil_usize(n_precommit as usize) as u32;
+
+		// Derived wires occupy the public segment after constants and inout. Only derived wires
+		// referenced by a surviving constraint need a slot; intermediates that feed only other
+		// derived wires are computed inline by the generators and get no slot.
+		let derived_index_map = derived_alive
+			.iter()
+			.enumerate()
+			.filter(|(_, alive)| **alive)
+			.enumerate()
+			.map(|(new_idx, (id, _))| (id as u32, new_idx as u32))
+			.collect::<HashMap<_, _>>();
+
+		let n_derived = derived_index_map.len() as u32;
+		let n_public = n_constants + n_inout + n_derived;
+		let log_public = log2_ceil_usize(n_public as usize) as u32;
 
 		let private_index_map = private_alive
 			.iter()
@@ -368,11 +412,13 @@ impl<F: Field> WitnessLayout<F> {
 		Self {
 			constants,
 			n_inout,
+			n_derived,
 			n_precommit,
 			n_private,
 			log_public,
 			log_precommit,
 			log_private,
+			derived_index_map,
 			private_index_map,
 		}
 	}
@@ -417,6 +463,10 @@ impl<F: Field> WitnessLayout<F> {
 		self.n_inout as usize
 	}
 
+	pub fn n_derived(&self) -> usize {
+		self.n_derived as usize
+	}
+
 	pub fn n_precommit(&self) -> usize {
 		self.n_precommit as usize
 	}
@@ -452,6 +502,9 @@ impl<F: Field> WitnessLayout<F> {
 				assert!(wire.id < self.n_inout);
 				Some(WitnessIndex::public(self.constants.len() as u32 + wire.id))
 			}
+			WireKind::Derived => self.derived_index_map.get(&wire.id).map(|&derived_idx| {
+				WitnessIndex::public(self.constants.len() as u32 + self.n_inout + derived_idx)
+			}),
 			WireKind::Precommit => {
 				assert!(wire.id < self.n_precommit);
 				Some(WitnessIndex::precommit(wire.id))

--- a/crates/spartan-frontend/src/wire_elimination.rs
+++ b/crates/spartan-frontend/src/wire_elimination.rs
@@ -1,4 +1,5 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 use std::mem;
 
@@ -248,11 +249,13 @@ mod tests {
 
 	#[test]
 	fn test_wire_elimination_fibonacci() {
-		// Build constraint system for fibonacci(20)
+		// Build constraint system for fibonacci(20). Inputs are precommit (secret) wires so the
+		// mul chain stays private and exercises wire elimination — all-public inputs would instead
+		// be elided into derived wires, leaving nothing to eliminate.
 		let mut constraint_builder = ConstraintBuilder::new();
-		let x0 = constraint_builder.alloc_inout();
-		let x1 = constraint_builder.alloc_inout();
-		let xn = constraint_builder.alloc_inout();
+		let x0 = constraint_builder.alloc_precommit();
+		let x1 = constraint_builder.alloc_precommit();
+		let xn = constraint_builder.alloc_precommit();
 		let out = fibonacci(&mut constraint_builder, x0, x1, 20);
 		constraint_builder.assert_eq(out, xn);
 		let ir = constraint_builder.build();
@@ -262,9 +265,10 @@ mod tests {
 
 		// Generate witness for optimized constraint system
 		let mut witness_generator = WitnessGenerator::new(&layout);
-		let x0_val = witness_generator.write_inout(x0, B128::ONE);
-		let x1_val = witness_generator.write_inout(x1, B128::MULTIPLICATIVE_GENERATOR);
-		let xn_val = witness_generator.write_inout(xn, B128::MULTIPLICATIVE_GENERATOR.pow(6765));
+		let x0_val = witness_generator.write_precommit(x0, B128::ONE);
+		let x1_val = witness_generator.write_precommit(x1, B128::MULTIPLICATIVE_GENERATOR);
+		let xn_val =
+			witness_generator.write_precommit(xn, B128::MULTIPLICATIVE_GENERATOR.pow(6765));
 		let out_val = fibonacci(&mut witness_generator, x0_val, x1_val, 20);
 		witness_generator.assert_eq(out_val, xn_val);
 		let witness = witness_generator.build().unwrap();
@@ -300,9 +304,12 @@ mod tests {
 
 		let mut constraint_builder = ConstraintBuilder::new();
 
-		// Create 8 input wires and 1 sum wire
-		let inputs: Vec<_> = (0..8).map(|_| constraint_builder.alloc_inout()).collect();
-		let sum_wire = constraint_builder.alloc_inout();
+		// Create 8 input wires and 1 sum wire. Precommit (secret) inputs keep the add chain private
+		// so wire elimination has something to optimize (all-public inputs become derived wires).
+		let inputs: Vec<_> = (0..8)
+			.map(|_| constraint_builder.alloc_precommit())
+			.collect();
+		let sum_wire = constraint_builder.alloc_precommit();
 
 		// Build constraint system
 		let result = chain_adds(&mut constraint_builder, &inputs);
@@ -319,11 +326,11 @@ mod tests {
 		// Generate witness
 		let mut witness_generator = WitnessGenerator::new(&layout);
 		let input_wires: Vec<_> = iter::zip(&inputs, &input_values)
-			.map(|(&wire, &value)| witness_generator.write_inout(wire, value))
+			.map(|(&wire, &value)| witness_generator.write_precommit(wire, value))
 			.collect();
 
 		let result = chain_adds(&mut witness_generator, &input_wires);
-		let sum = witness_generator.write_inout(sum_wire, sum_value);
+		let sum = witness_generator.write_precommit(sum_wire, sum_value);
 		witness_generator.assert_eq(result, sum);
 		let witness = witness_generator.build().unwrap();
 
@@ -361,9 +368,13 @@ mod tests {
 
 		let mut constraint_builder = ConstraintBuilder::new();
 
-		// Create 40 input wires and 1 output wire
-		let inputs: Vec<_> = (0..40).map(|_| constraint_builder.alloc_inout()).collect();
-		let output = constraint_builder.alloc_inout();
+		// Create 40 input wires and 1 output wire. Precommit (secret) inputs keep the add/mul chain
+		// private so wire elimination operates on it; all-public inputs would be elided to derived
+		// wires with no constraints to optimize.
+		let inputs: Vec<_> = (0..40)
+			.map(|_| constraint_builder.alloc_precommit())
+			.collect();
+		let output = constraint_builder.alloc_precommit();
 
 		// Build constraint system
 		let result = chain_add_muls(&mut constraint_builder, &inputs);
@@ -393,11 +404,11 @@ mod tests {
 		// Generate witness
 		let mut witness_generator = WitnessGenerator::new(&layout);
 		let input_wires: Vec<_> = iter::zip(&inputs, &input_values)
-			.map(|(&wire, &value)| witness_generator.write_inout(wire, value))
+			.map(|(&wire, &value)| witness_generator.write_precommit(wire, value))
 			.collect();
 
 		let result = chain_add_muls(&mut witness_generator, &input_wires);
-		let sum = witness_generator.write_inout(output, output_value);
+		let sum = witness_generator.write_precommit(output, output_value);
 		witness_generator.assert_eq(result, sum);
 		let witness = witness_generator.build().unwrap();
 
@@ -487,8 +498,11 @@ mod tests {
 
 		let mut constraint_builder = ConstraintBuilder::new();
 
-		// Create 9 input wires
-		let inputs: Vec<_> = (0..9).map(|_| constraint_builder.alloc_inout()).collect();
+		// Create 9 input wires. Precommit (secret) inputs keep the grouped adds and the mul private
+		// so wire elimination runs (all-public inputs would be elided to derived wires).
+		let inputs: Vec<_> = (0..9)
+			.map(|_| constraint_builder.alloc_precommit())
+			.collect();
 
 		// Build constraint system: assert a * b = c where a, b, c are sums of 3 inputs each
 		let inputs_array: [_; 9] = inputs.clone().try_into().unwrap();
@@ -515,7 +529,7 @@ mod tests {
 		// Generate witness
 		let mut witness_generator = WitnessGenerator::new(&layout);
 		let input_wires: Vec<_> = iter::zip(&inputs, &input_values)
-			.map(|(&wire, &value)| witness_generator.write_inout(wire, value))
+			.map(|(&wire, &value)| witness_generator.write_precommit(wire, value))
 			.collect();
 
 		let input_wires_array: [_; 9] = input_wires.try_into().unwrap();

--- a/crates/spartan-prover/tests/integration_test.rs
+++ b/crates/spartan-prover/tests/integration_test.rs
@@ -1,12 +1,13 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-use binius_field::{BinaryField128bGhash as B128, Random, arch::OptimalPackedB128};
+use binius_field::{BinaryField128bGhash as B128, Field, Random, arch::OptimalPackedB128};
 use binius_hash::StdHashSuite;
 use binius_spartan_frontend::{
-	circuit_builder::{CircuitBuilder, ConstraintBuilder, WitnessGenerator},
+	circuit_builder::{CircuitBuilder, ConstraintBuilder, InstanceGenerator, WitnessGenerator},
 	circuits::powers,
 	compiler::compile,
+	constraint_system::Witness,
 };
 use binius_spartan_prover::Prover;
 use binius_spartan_verifier::{Verifier, config::StdChallenger};
@@ -33,6 +34,11 @@ fn test_power7_circuit_prover_verifier() {
 	power7_circuit(&mut constraint_builder, x_wire, y_wire);
 	let (cs, layout) = compile(constraint_builder);
 
+	// x and y are inout, so the whole x^7 power chain is public-derivable: the derived elision
+	// leaves no private wires and a single mul constraint (the folded assert_eq).
+	assert_eq!(cs.n_private(), 0);
+	assert_eq!(cs.mul_constraints().len(), 1);
+
 	// Setup prover and verifier
 	let log_inv_rate = 1;
 	let verifier =
@@ -58,8 +64,16 @@ fn test_power7_circuit_prover_verifier() {
 	// Validate witness satisfies constraints
 	cs.validate(&witness);
 
-	// Extract public inputs (constants + inout, padded to 2^log_public)
-	let public = witness.public().to_vec();
+	// The verifier reconstructs the public vector (constants + inout + derived) itself by
+	// re-running the circuit with an InstanceGenerator — it never trusts the prover's derived
+	// values. For x^7 with x, y inout, the whole power chain is derived, so this exercises the
+	// derived path and must match the witness's public segment.
+	let mut instance_gen = InstanceGenerator::new(&layout);
+	let x_instance = instance_gen.write_inout(x_wire, x_val);
+	let y_instance = instance_gen.write_inout(y_wire, y_val);
+	power7_circuit(&mut instance_gen, x_instance, y_instance);
+	let public = instance_gen.build();
+	assert_eq!(public, witness.public(), "InstanceGenerator public must match witness public");
 
 	// Generate proof
 	let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
@@ -73,4 +87,66 @@ fn test_power7_circuit_prover_verifier() {
 		.verify(&public, &mut verifier_transcript)
 		.expect("verify failed");
 	verifier_transcript.finalize().expect("finalize failed");
+}
+
+/// Soundness: a prover that tampers a derived value in its witness cannot pass verification,
+/// because the verifier independently recomputes the public segment via `InstanceGenerator` and
+/// never trusts the prover-supplied derived value.
+#[test]
+fn test_tampered_derived_value_fails_verification() {
+	let mut constraint_builder = ConstraintBuilder::new();
+	let x_wire = constraint_builder.alloc_inout();
+	let y_wire = constraint_builder.alloc_inout();
+	power7_circuit(&mut constraint_builder, x_wire, y_wire);
+	let (cs, layout) = compile(constraint_builder);
+
+	let log_inv_rate = 1;
+	let verifier =
+		Verifier::<_, StdHashSuite>::setup(cs, log_inv_rate).expect("verifier setup failed");
+	let prover = Prover::<OptimalPackedB128, StdHashSuite>::setup(verifier.clone())
+		.expect("prover setup failed");
+
+	let cs = verifier.constraint_system();
+	let layout = layout.with_blinding(cs.blinding_info().clone());
+
+	let mut rng = StdRng::seed_from_u64(0);
+	let x_val = B128::random(&mut rng);
+	let y_val = x_val * x_val * x_val * x_val * x_val * x_val * x_val; // x^7
+
+	// Honest witness.
+	let mut witness_gen = WitnessGenerator::new(&layout);
+	let x_assigned = witness_gen.write_inout(x_wire, x_val);
+	let y_assigned = witness_gen.write_inout(y_wire, y_val);
+	power7_circuit(&mut witness_gen, x_assigned, y_assigned);
+	let witness = witness_gen.build().expect("failed to build witness");
+
+	// The correct public segment, as the verifier recomputes it.
+	let mut instance_gen = InstanceGenerator::new(&layout);
+	let x_instance = instance_gen.write_inout(x_wire, x_val);
+	let y_instance = instance_gen.write_inout(y_wire, y_val);
+	power7_circuit(&mut instance_gen, x_instance, y_instance);
+	let correct_public = instance_gen.build();
+
+	// A malicious prover corrupts a derived value in its witness. Derived wires occupy the public
+	// segment right after the constants and inout values.
+	let derived_slot = layout.n_constants() + layout.n_inout();
+	let mut tampered_public = witness.public().to_vec();
+	tampered_public[derived_slot] += B128::ONE;
+	let tampered_witness =
+		Witness::new(tampered_public, witness.precommit().to_vec(), witness.private().to_vec());
+
+	// The prover observes its tampered public into the transcript while proving.
+	let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
+	prover
+		.prove(tampered_witness, &mut rng, &mut prover_transcript)
+		.expect("prove failed");
+
+	// The verifier verifies against the recomputed (correct) public and must reject the proof.
+	let mut verifier_transcript = prover_transcript.into_verifier();
+	assert!(
+		verifier
+			.verify(&correct_public, &mut verifier_transcript)
+			.is_err(),
+		"verification must fail when the prover tampers a derived value"
+	);
 }

--- a/crates/spartan-verifier/src/wrapper/mod.rs
+++ b/crates/spartan-verifier/src/wrapper/mod.rs
@@ -34,9 +34,13 @@ mod tests {
 
 	type BuildElem = CircuitElem<B128, BuilderWire<B128>>;
 
-	/// Helper to create a BuildElem wire from a ConstraintBuilder Rc for tests.
-	fn alloc_inout_wire(rc: &Rc<std::cell::RefCell<ConstraintBuilder<B128>>>) -> BuildElem {
-		let wire = rc.borrow_mut().alloc_inout();
+	/// Helper to create a private-backed `BuildElem` wire from a ConstraintBuilder Rc for tests.
+	///
+	/// Uses a precommit wire (the real source of `BuilderWire::Private` in wrapper usage — the OTP
+	/// key) so that arithmetic on it stays private and records constraints. An inout-backed wire
+	/// would instead be elided into a derived wire with no constraint.
+	fn alloc_private_wire(rc: &Rc<std::cell::RefCell<ConstraintBuilder<B128>>>) -> BuildElem {
+		let wire = rc.borrow_mut().alloc_precommit();
 		BuildElem::wire(rc, BuilderWire::Private(wire))
 	}
 
@@ -61,7 +65,7 @@ mod tests {
 	#[test]
 	fn test_constant_identity_shortcuts() {
 		let rc = Rc::new(std::cell::RefCell::new(ConstraintBuilder::<B128>::new()));
-		let elem = alloc_inout_wire(&rc);
+		let elem = alloc_private_wire(&rc);
 
 		// Adding zero returns the wire unchanged.
 		let result = elem.clone() + BuildElem::Constant(B128::ZERO);
@@ -79,8 +83,8 @@ mod tests {
 	#[test]
 	fn test_wire_addition_creates_constraint() {
 		let rc = Rc::new(std::cell::RefCell::new(ConstraintBuilder::<B128>::new()));
-		let a = alloc_inout_wire(&rc);
-		let b = alloc_inout_wire(&rc);
+		let a = alloc_private_wire(&rc);
+		let b = alloc_private_wire(&rc);
 
 		let _sum = a + b;
 		// The addition should produce constraints. After finalization, the zero constraint
@@ -92,8 +96,8 @@ mod tests {
 	#[test]
 	fn test_wire_multiplication_creates_constraint() {
 		let rc = Rc::new(std::cell::RefCell::new(ConstraintBuilder::<B128>::new()));
-		let a = alloc_inout_wire(&rc);
-		let b = alloc_inout_wire(&rc);
+		let a = alloc_private_wire(&rc);
+		let b = alloc_private_wire(&rc);
 
 		let _product = a * b;
 		let (cs, _layout) = Rc::try_unwrap(rc).unwrap().into_inner().build().finalize();
@@ -104,7 +108,7 @@ mod tests {
 	#[test]
 	fn test_invert_or_zero_creates_constraints() {
 		let rc = Rc::new(std::cell::RefCell::new(ConstraintBuilder::<B128>::new()));
-		let elem = alloc_inout_wire(&rc);
+		let elem = alloc_private_wire(&rc);
 
 		let _inv = elem.invert_or_zero();
 		let (cs, _layout) = Rc::try_unwrap(rc).unwrap().into_inner().build().finalize();

--- a/crates/spartan-verifier/tests/proof_size_test.rs
+++ b/crates/spartan-verifier/tests/proof_size_test.rs
@@ -60,5 +60,9 @@ fn test_ip_proof_size() {
 	// single combined FRI proof opening all oracles together. It is a slight underestimate because
 	// it does not account for some smaller BaseFold components (e.g. sumcheck coefficients within
 	// BaseFold, blinding elements for ZK).
-	assert_eq!(proof_size, 46848, "proof size regression");
+	//
+	// The power chain x^2..x^7 is public-derivable (x and y are inout), so those wires are now
+	// `Derived` and emit no mul constraints — only `assert_eq(x^7, y)` survives — shrinking the
+	// proof relative to the pre-derived-wire baseline of 46848.
+	assert_eq!(proof_size, 46784, "proof size regression");
 }


### PR DESCRIPTION
Closes [BINIUS-93](https://linear.app/jimpo/issue/BINIUS-93/add-public-derived-wires-to-the-ironspartan-frontend)

## Summary

Adds a `Derived` wire kind to the IronSpartan constraint system. When all inputs to `add`/`mul`/`hint` are public-derivable (`Constant`, `InOut`, or `Derived`), the output is `Derived` — no constraint is emitted and no private commitment is needed. Derived wires live in the public segment; the verifier recomputes them independently via a new `InstanceGenerator` before calling `verify`.

## Commits

1. **add Derived wire kind and public-derivable inference to spartan-frontend** — `WireKind::Derived`, shared `is_public_derivable` classifier, `ConstraintBuilder`/`WitnessGenerator` dual-allocator branching, derived liveness scan in `finalize`, `WitnessLayout` gains `n_derived`/`derived_index_map`, `WitnessWire` carries kind. Updates `wire_elimination` tests whose `n_private` counts shift.

2. **add InstanceGenerator for verifier-side public reconstruction** — `InstanceGenerator`: a `CircuitBuilder` impl run by the verifier to produce `[constants | inout | derived]`. Calls `f` for derived hints only; returns placeholder private wires without calling `f` on garbage secrets. Four new unit tests: sync, derived-elision, mixed, pruned-intermediate.

3. **build verifier public via InstanceGenerator in spartan-prover integration test** — Updates `integration_test.rs` to construct the public vector via `InstanceGenerator` instead of `witness.public()`. Adds a soundness negative test: prover tampers a derived wire; verifier rejects.

## Test results

- `binius-spartan-frontend`: 26 tests pass (4 new InstanceGenerator tests)
- `binius-spartan-verifier`: full suite pass (proof_size 46848 → 46784, one fewer derived slot committed)
- `binius-spartan-prover`: integration test + soundness test pass
- `cargo clippy --all --tests --benches --examples -- -D warnings`: clean
- `cargo +nightly-2026-01-01 fmt`: clean

---

🤖 Generated with [Claude Code](https://claude.ai/claude-code)