### PR TITLE
Generalize FRI inner-challenge routing to a per-oracle skip window

### DIFF
--- a/crates/iop-prover/src/basefold.rs
+++ b/crates/iop-prover/src/basefold.rs
@@ -467,6 +467,7 @@ mod test {
 			&[PartialOracleSpec {
 				log_msg_len: n_vars + 1,
 				log_batch_size: Some(1),
+				skip_batch_challenges: 0,
 			}],
 			LOG_INV_RATE,
 			32,

--- a/crates/iop-prover/src/basefold_compiler.rs
+++ b/crates/iop-prover/src/basefold_compiler.rs
@@ -206,6 +206,7 @@ where
 				log_msg_len: spec.log_msg_len + 1,
 				// Batch size is 2 for message and mask
 				log_batch_size: Some(1),
+				skip_batch_challenges: 0,
 			})
 			.collect();
 		let (fri_params, _) = FRIParams::optimal_for_batch(

--- a/crates/iop-prover/src/fri/fold.rs
+++ b/crates/iop-prover/src/fri/fold.rs
@@ -136,6 +136,7 @@ where
 				);
 				ProxTestFolder {
 					log_batch_size: spec.log_batch_size,
+					skip_batch_challenges: spec.skip_batch_challenges,
 					log_lift: log_dim - oracle_log_dim,
 					codeword,
 					merkle_committed: committed,
@@ -402,6 +403,10 @@ where
 
 pub struct ProxTestFolder<'a, P: PackedField, MTProver: MerkleTreeProver<P::Scalar>> {
 	log_batch_size: usize,
+	/// The number of leading inner challenges this oracle skips before its batch fold. The oracle
+	/// folds with the window `inner[skip_batch_challenges .. skip_batch_challenges +
+	/// log_batch_size]`.
+	skip_batch_challenges: usize,
 	/// log2 the lift factor (oracle padding): how many times each folded codeword entry is
 	/// duplicated to reach the common first-round length. Zero when no lifting is needed.
 	log_lift: usize,
@@ -466,14 +471,14 @@ where
 		merkle_prover: &'a MTProver,
 		challenges: &[F],
 	) -> (FieldBuffer<F>, BatchBrakedownOracleProver<'a, P, MTProver>) {
-		let max_log_batch_size = self
+		let max_inner_challenges = self
 			.folders
 			.iter()
-			.map(|folder| folder.log_batch_size)
+			.map(|folder| folder.skip_batch_challenges + folder.log_batch_size)
 			.max()
 			.expect("folders is not empty by struct invariant");
 
-		let (inner_challenges, outer_challenges) = challenges.split_at(max_log_batch_size);
+		let (inner_challenges, outer_challenges) = challenges.split_at(max_inner_challenges);
 		let outer_tensor = eq_ind_partial_eval::<F>(outer_challenges);
 
 		let mut combined_codeword = FieldBuffer::zeros(self.log_code_len);
@@ -483,16 +488,18 @@ where
 		for (folder, &scalar) in iter::zip(self.folders, outer_tensor.as_ref()) {
 			let ProxTestFolder {
 				log_batch_size,
+				skip_batch_challenges,
 				log_lift,
 				codeword,
 				merkle_committed,
 			} = folder;
-			let start_idx = max_log_batch_size - log_batch_size;
 
 			// Fold the outer-challenge tensor value into the inner folding tensor so that every
 			// folded entry comes out already scaled by `scalar`. This replaces one scaling mul per
 			// (lifted) output entry with a single pass over the `2^log_batch_size`-element tensor.
-			let mut tensor = eq_ind_partial_eval::<P>(&inner_challenges[start_idx..]);
+			let mut tensor = eq_ind_partial_eval::<P>(
+				&inner_challenges[skip_batch_challenges..skip_batch_challenges + log_batch_size],
+			);
 			let scalar_broadcast = P::broadcast(scalar);
 			for packed in tensor.as_mut() {
 				*packed *= scalar_broadcast;

--- a/crates/iop-prover/src/fri/tests.rs
+++ b/crates/iop-prover/src/fri/tests.rs
@@ -245,6 +245,7 @@ fn test_commit_prove_verify_batched_multi_oracle() {
 		.map(|&log_batch_size| PartialOracleSpec {
 			log_msg_len: log_dim + log_batch_size,
 			log_batch_size: Some(log_batch_size),
+			skip_batch_challenges: 0,
 		})
 		.collect::<Vec<_>>();
 	let (params, _proof_size) = FRIParams::<F>::optimal_for_batch(
@@ -330,10 +331,11 @@ fn test_commit_prove_verify_batched_multi_oracle() {
 	);
 	let final_value = verifier.verify(&mut verifier_challenger).unwrap();
 
-	// The first fold reduces oracle `i` by its inner challenges (the last `log_batch_size_i` of the
-	// first `max_log_batch_size` challenges) and combines the oracles with the outer-challenge
-	// tensor. The remaining (tail) challenges fold the shared reduced codeword. So the final value
-	// is   sum_i outer_tensor[i] * evaluate(msg_i, reversed(inner_i ++ tail)).
+	// The first fold reduces oracle `i` by its inner challenges (with all skips zero here, the
+	// first `log_batch_size_i` of the `max_log_batch_size` inner challenges) and combines the
+	// oracles with the outer-challenge tensor. The remaining (tail) challenges fold the shared
+	// reduced codeword. So the final value is   sum_i outer_tensor[i] * evaluate(msg_i,
+	// reversed(inner_i ++ tail)).
 	let max_log_batch_size = log_batch_sizes.iter().copied().max().unwrap();
 	let first_fold_arity = params.log_batch_size();
 	let inner = &verifier_challenges[..max_log_batch_size];
@@ -343,7 +345,154 @@ fn test_commit_prove_verify_batched_multi_oracle() {
 
 	let mut expected = F::ZERO;
 	for (i, (msg, &log_batch_size)) in iter::zip(&messages, &log_batch_sizes).enumerate() {
-		let inner_i = &inner[max_log_batch_size - log_batch_size..];
+		let inner_i = &inner[..log_batch_size];
+		let mut eval_point = inner_i.iter().chain(tail).copied().collect::<Vec<_>>();
+		eval_point.reverse();
+		expected += outer_tensor[i] * evaluate(msg, &eval_point);
+	}
+	assert_eq!(final_value, expected);
+}
+
+/// Full FRI round trip that batches oracles consuming **disjoint inner-challenge windows** via
+/// per-oracle `skip_batch_challenges`.
+///
+/// Oracle 0 has `skip_batch_challenges = 0`, `log_batch_size = 1`, so it folds with `inner[0]`
+/// alone — the position a ZK BaseFold oracle reserves for its shared masking challenge γ. Oracle 1
+/// has `skip_batch_challenges = 1`, `log_batch_size = 2`, so it skips `inner[0]` and folds with
+/// `inner[1..3]`. The first fold therefore draws `max(0 + 1, 1 + 2) = 3` inner challenges, and the
+/// two oracles overlap in none of them. This is the routing the homogeneous suffix convention could
+/// not express (it would hand Oracle 0 the *last* inner challenge instead of `inner[0]`).
+#[test]
+fn test_commit_prove_verify_batched_mixed_skip() {
+	type F = B128;
+	type P = PackedBinaryGhash1x128b;
+
+	let mut rng = StdRng::seed_from_u64(0);
+
+	let log_dim = 8;
+	let log_inv_rate = 2;
+	// (log_batch_size, skip_batch_challenges) per oracle.
+	let oracle_params_spec = [(1usize, 0usize), (2usize, 1usize)];
+	let n_test_queries = 3;
+
+	let merkle_prover = BinaryMerkleTreeProver::<F, StdHashSuite>::new();
+
+	// Every oracle reduces to the shared dimension `log_dim`, so no lifting is exercised here — the
+	// focus is the inner-challenge windowing.
+	let subspace = BinarySubspace::with_dim(log_dim + log_inv_rate);
+	let domain_context = GenericOnTheFly::generate_from_subspace(&subspace);
+	let ntt = NeighborsLastSingleThread::new(domain_context);
+
+	let oracle_specs = oracle_params_spec
+		.iter()
+		.map(|&(log_batch_size, skip_batch_challenges)| PartialOracleSpec {
+			log_msg_len: log_dim + log_batch_size,
+			log_batch_size: Some(log_batch_size),
+			skip_batch_challenges,
+		})
+		.collect::<Vec<_>>();
+	let (params, _proof_size) = FRIParams::<F>::optimal_for_batch(
+		ntt.domain_context(),
+		merkle_prover.scheme(),
+		&oracle_specs,
+		log_inv_rate,
+		n_test_queries,
+	);
+	assert_eq!(params.rs_code().log_dim(), log_dim);
+
+	// Commit each input oracle's interleaved codeword separately.
+	let mut messages = Vec::new();
+	let mut commitments = Vec::new();
+	let mut committeds = Vec::new();
+	let mut codewords = Vec::new();
+	for &(log_batch_size, _) in &oracle_params_spec {
+		let oracle_params =
+			FRIParams::new(params.rs_code().clone(), log_batch_size, vec![], n_test_queries);
+		let msg = random_field_buffer::<P>(&mut rng, log_dim + log_batch_size);
+		let CommitOutput {
+			commitment,
+			committed,
+			codeword,
+		} = commit_interleaved(&oracle_params, 0, &ntt, &merkle_prover, msg.to_ref());
+		messages.push(msg);
+		commitments.push(commitment);
+		committeds.push(committed);
+		codewords.push(codeword);
+	}
+
+	// Run the prover: write the per-oracle codeword commitments, then fold.
+	let committed_codewords = iter::zip(codewords, &committeds).collect::<Vec<_>>();
+	let mut round_prover =
+		FRIFoldProver::new_batch(&params, &ntt, &merkle_prover, committed_codewords);
+
+	let mut prover_challenger = ProverTranscript::new(StdChallenger::default());
+	for commitment in &commitments {
+		prover_challenger.message().write(commitment);
+	}
+
+	let fold_round_output = round_prover.execute_fold_round();
+	if let FoldRoundOutput::Commitment(round_commitment) = fold_round_output {
+		prover_challenger.message().write(&round_commitment);
+	}
+	for _ in 0..params.n_fold_rounds() {
+		let challenge = prover_challenger.sample();
+		round_prover.receive_challenge(challenge);
+
+		let fold_round_output = round_prover.execute_fold_round();
+		if let FoldRoundOutput::Commitment(round_commitment) = fold_round_output {
+			prover_challenger.message().write(&round_commitment);
+		}
+	}
+	round_prover.finish_proof(&mut prover_challenger);
+
+	// Run the verifier.
+	let mut verifier_challenger = prover_challenger.into_verifier();
+	let read_commitments = commitments
+		.iter()
+		.map(|_| verifier_challenger.message().read().unwrap())
+		.collect::<Vec<_>>();
+
+	let mut verifier_challenges = Vec::with_capacity(params.n_fold_rounds());
+	let mut fri_fold_verifier = FRIFoldVerifier::new(&params);
+	fri_fold_verifier
+		.process_round(&mut verifier_challenger.message())
+		.unwrap();
+	for _ in 0..params.n_fold_rounds() {
+		verifier_challenges.push(verifier_challenger.sample());
+		fri_fold_verifier
+			.process_round(&mut verifier_challenger.message())
+			.unwrap();
+	}
+	let round_commitments = fri_fold_verifier.finalize();
+
+	let verifier = FRIQueryVerifier::new_batch(
+		&params,
+		merkle_prover.scheme(),
+		&read_commitments,
+		&round_commitments,
+		&verifier_challenges,
+	);
+	let final_value = verifier.verify(&mut verifier_challenger).unwrap();
+
+	// Each oracle folds with the window `inner[skip .. skip + log_batch_size]`, so the inner
+	// segment spans `max(skip + log_batch_size)` challenges. The remaining (tail) challenges fold
+	// the shared reduced codeword. So the final value is
+	//   sum_i outer_tensor[i] * evaluate(msg_i, reversed(inner_i ++ tail)).
+	let max_inner = oracle_params_spec
+		.iter()
+		.map(|&(log_batch_size, skip)| skip + log_batch_size)
+		.max()
+		.unwrap();
+	let first_fold_arity = params.log_batch_size();
+	let inner = &verifier_challenges[..max_inner];
+	let outer = &verifier_challenges[max_inner..first_fold_arity];
+	let tail = &verifier_challenges[first_fold_arity..];
+	let outer_tensor = eq_ind_partial_eval_scalars::<F>(outer);
+
+	let mut expected = F::ZERO;
+	for (i, (msg, &(log_batch_size, skip))) in iter::zip(&messages, &oracle_params_spec).enumerate()
+	{
+		let inner_i = &inner[skip..skip + log_batch_size];
 		let mut eval_point = inner_i.iter().chain(tail).copied().collect::<Vec<_>>();
 		eval_point.reverse();
 		expected += outer_tensor[i] * evaluate(msg, &eval_point);
@@ -389,6 +538,7 @@ fn test_commit_prove_verify_lifted_multi_oracle() {
 		.map(|(log_dim, log_batch_size)| PartialOracleSpec {
 			log_msg_len: log_dim + log_batch_size,
 			log_batch_size: Some(log_batch_size),
+			skip_batch_challenges: 0,
 		})
 		.collect::<Vec<_>>();
 	let (params, _proof_size) = FRIParams::<F>::optimal_for_batch(
@@ -479,9 +629,10 @@ fn test_commit_prove_verify_lifted_multi_oracle() {
 	);
 	let final_value = verifier.verify(&mut verifier_challenger).unwrap();
 
-	// The first fold reduces oracle `i` by its inner challenges (the last `log_batch_size_i` of the
-	// first `max_log_batch_size` challenges) and combines the oracles with the outer-challenge
-	// tensor. The remaining `reduced_log_dim` tail challenges fold the combined codeword.
+	// The first fold reduces oracle `i` by its inner challenges (with all skips zero here, the
+	// first `log_batch_size_i` of the `max_log_batch_size` inner challenges) and combines the
+	// oracles with the outer-challenge tensor. The remaining `reduced_log_dim` tail challenges
+	// fold the combined codeword.
 	//
 	// Lifting oracle `i` embeds its codeword as `Enc_M(ZeroPadMSB_eta(m_i'))`, whose multilinear
 	// extension factors as `m_i'(low vars) * prod_j (1 - Y_j)` over the `eta_i = reduced_log_dim -
@@ -505,7 +656,7 @@ fn test_commit_prove_verify_lifted_multi_oracle() {
 		let eta = reduced_log_dim - log_dim;
 		// The lift (oracle padding) factor from the zero-padded high message variables.
 		let pad_factor = tail[..eta].iter().map(|&t| F::ONE - t).product::<F>();
-		let inner_i = &inner[max_log_batch_size - log_batch_size..];
+		let inner_i = &inner[..log_batch_size];
 		let mut eval_point = inner_i
 			.iter()
 			.chain(&tail[eta..])

--- a/crates/iop/src/basefold_compiler.rs
+++ b/crates/iop/src/basefold_compiler.rs
@@ -207,6 +207,7 @@ where
 			.map(|spec| PartialOracleSpec {
 				log_msg_len: spec.log_msg_len + 1,
 				log_batch_size: Some(1),
+				skip_batch_challenges: 0,
 			})
 			.collect();
 		let (fri_params, _) = FRIParams::optimal_for_batch(

--- a/crates/iop/src/fri/common.rs
+++ b/crates/iop/src/fri/common.rs
@@ -1,4 +1,5 @@
 // Copyright 2024-2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 use std::marker::PhantomData;
 
@@ -27,7 +28,8 @@ pub struct FRIParams<F> {
 	/// Guaranteed to be non-empty.
 	input_oracles: Vec<OracleSpec>,
 	/// log2 the maximum message length of all input oracles, after lifting each to the reduced
-	/// dimension. Equals `rs_code.log_dim() + max(input_oracles.log_batch_size)`.
+	/// dimension. Equals `rs_code.log_dim() + max(skip_batch_challenges + log_batch_size)` over
+	/// the input oracles (the inner challenges the first fold must draw).
 	max_log_msg_len: usize,
 	/// log2 ceiling of the number of input oracles.
 	log_n_oracles: usize,
@@ -46,6 +48,17 @@ pub struct OracleSpec {
 	pub log_msg_len: usize,
 	/// log2 the interleaved batch size.
 	pub log_batch_size: usize,
+	/// The number of leading inner challenges this oracle skips before its batch fold.
+	///
+	/// The first fold draws `max(skip_batch_challenges + log_batch_size)` inner challenges across
+	/// all oracles; oracle `i` folds its interleaved batch with the window
+	/// `inner_challenges[skip_batch_challenges .. skip_batch_challenges + log_batch_size]`. This
+	/// lets distinct oracles consume distinct (or overlapping) inner challenges — needed when a
+	/// leading inner challenge is reserved for one group of oracles (e.g. the shared masking
+	/// challenge of ZK BaseFold oracles) while others must skip it. It is `0` in the homogeneous
+	/// case, recovering the convention where every oracle folds with a prefix of the inner
+	/// challenges.
+	pub skip_batch_challenges: usize,
 }
 
 /// A partially specified oracle specification.
@@ -60,6 +73,10 @@ pub struct PartialOracleSpec {
 	///
 	/// This field is Some if the log_batch_size is fixed, and None if it's flexible.
 	pub log_batch_size: Option<usize>,
+	/// The number of leading inner challenges this oracle skips before its batch fold.
+	///
+	/// See [`OracleSpec::skip_batch_challenges`]. `0` in the homogeneous case.
+	pub skip_batch_challenges: usize,
 }
 
 impl<F> FRIParams<F>
@@ -84,6 +101,7 @@ where
 		let oracle_spec = OracleSpec {
 			log_msg_len: rs_code.log_dim() + log_batch_size,
 			log_batch_size,
+			skip_batch_challenges: 0,
 		};
 		let log_n_oracles = 0;
 		let max_log_msg_len = oracle_spec.log_msg_len;
@@ -197,16 +215,18 @@ where
 		} = choose_batch_size_and_arities_multi(merkle_scheme, oracles, log_inv_rate, n_test_queries);
 
 		// After lifting, every input oracle sits at the reduced dimension with its own interleaved
-		// batch, so the effective maximum message length is the reduced dimension plus the largest
-		// batch size. This is what the first fold must consume (the inner, per-oracle interleave
-		// folds) before the `log_n_oracles` outer folds that batch the oracles together. Without
-		// lifting this equals `max(oracle.log_msg_len)`.
-		let max_log_batch_size = oracle_specs
+		// batch, so the effective maximum message length is the reduced dimension plus the number
+		// of inner challenges the first fold must draw. Each oracle consumes the window
+		// `inner[skip_batch_challenges .. skip_batch_challenges + log_batch_size]`, so the first
+		// fold must draw `max(skip_batch_challenges + log_batch_size)` inner challenges before
+		// the `log_n_oracles` outer folds that batch the oracles together. With no skips this
+		// equals `max(oracle.log_batch_size)`.
+		let max_inner_challenges = oracle_specs
 			.iter()
-			.map(|spec| spec.log_batch_size)
+			.map(|spec| spec.skip_batch_challenges + spec.log_batch_size)
 			.max()
 			.expect("precondition: oracles is not empty");
-		let max_log_msg_len = reduced_log_msg_len + max_log_batch_size;
+		let max_log_msg_len = reduced_log_msg_len + max_inner_challenges;
 
 		let rs_code = ReedSolomonCode::with_domain_context_subspace(
 			domain_context,
@@ -417,6 +437,7 @@ where
 			OracleSpec {
 				log_msg_len: oracle.log_msg_len,
 				log_batch_size,
+				skip_batch_challenges: oracle.skip_batch_challenges,
 			}
 		})
 		.collect();
@@ -831,14 +852,17 @@ mod tests {
 			PartialOracleSpec {
 				log_msg_len: 10,
 				log_batch_size: Some(1),
+				skip_batch_challenges: 0,
 			},
 			PartialOracleSpec {
 				log_msg_len: 12,
 				log_batch_size: Some(1),
+				skip_batch_challenges: 0,
 			},
 			PartialOracleSpec {
 				log_msg_len: 16,
 				log_batch_size: None,
+				skip_batch_challenges: 0,
 			},
 		];
 

--- a/crates/iop/src/fri/verify.rs
+++ b/crates/iop/src/fri/verify.rs
@@ -1,4 +1,5 @@
 // Copyright 2024-2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 use std::iter::{self, repeat_with};
 
@@ -119,15 +120,16 @@ where
 		let index_bits = params.index_bits();
 		// The first fold consumes `log_batch_size()` challenges, split into the inner challenges
 		// (folding each input oracle's interleaving) and the outer challenges (batching the oracles
-		// together). Oracle `i` uses the last `log_batch_size_i` inner challenges.
-		let max_log_batch_size = params
+		// together). Oracle `i` folds its interleaved batch with the inner-challenge window
+		// `inner[skip_batch_challenges_i .. skip_batch_challenges_i + log_batch_size_i]`.
+		let max_inner_challenges = params
 			.input_oracles()
 			.iter()
-			.map(|spec| spec.log_batch_size)
+			.map(|spec| spec.skip_batch_challenges + spec.log_batch_size)
 			.max()
 			.expect("input_oracles is non-empty as an invariant");
-		let inner_challenges = &challenges[..max_log_batch_size];
-		let outer_challenges = challenges[max_log_batch_size..params.log_batch_size()].to_vec();
+		let inner_challenges = &challenges[..max_inner_challenges];
+		let outer_challenges = challenges[max_inner_challenges..params.log_batch_size()].to_vec();
 		let codeword_sub_oracles = iter::zip(codeword_commitments, params.input_oracles())
 			.map(|(commitment, spec)| {
 				// The oracle's own codeword has dimension `log_msg_len - log_batch_size`, so its
@@ -136,8 +138,9 @@ where
 				let oracle_log_dim = spec.log_msg_len - spec.log_batch_size;
 				let depth = oracle_log_dim + log_inv_rate;
 				let log_lift = log_dim - oracle_log_dim;
+				let inner_start = spec.skip_batch_challenges;
 				BrakedownOracle::new(
-					inner_challenges[max_log_batch_size - spec.log_batch_size..].to_vec(),
+					inner_challenges[inner_start..inner_start + spec.log_batch_size].to_vec(),
 					Commitment {
 						root: commitment.clone(),
 						depth,


### PR DESCRIPTION
Prerequisite FRI-layer change for BINIUS-69 (combining the ZK and non-ZK BaseFold compilers). Closes BINIUS-94.

## Problem

The batched FRI folder routes each input oracle's batch fold to a **suffix** of the inner challenges — `crates/iop/src/fri/verify.rs` and the prover mirror in `crates/iop-prover/src/fri/fold.rs` slice `inner_challenges[max_log_batch_size − log_batch_size_i ..]`.

That's correct for the homogeneous cases we ship today, but it breaks for a **mixed** batch where any non-ZK oracle has `log_batch_size > 0`:

- A ZK oracle (batch 1) must fold with **γ = `inner[0]`**, because γ is doing double duty as the mask-blind for the committed `[π ‖ ω]`.
- A non-ZK oracle must fold with the inner challenges **after** γ.
- Once `max_log_batch_size > 1`, the suffix convention hands the ZK oracle the *last* inner challenge instead of γ.

## Change

Add a per-oracle `skip_batch_challenges: usize` to the FRI `OracleSpec`/`PartialOracleSpec`. The FRI layer stays ZK-agnostic — it never branches on `is_zk`; it reads `(skip, log_batch_size)` per oracle and folds with the window `inner_challenges[skip .. skip + log_batch_size]`. The first fold now draws `max_i(skip_i + log_batch_size_i)` inner challenges, propagated through `max_log_msg_len` / `n_fold_rounds`.

BaseFold will set the skips (BINIUS-69): `0` for ZK oracles (they grab γ at the front), `1` for non-ZK oracles when ≥1 ZK oracle is present (they skip γ).

## No regression

Every existing caller passes `skip = 0`, which recovers the prefix-of-inner-challenges convention:
- All-ZK BaseFold (every batch 1, skip 0 → `inner[0..1] = [γ]`) is byte-identical to today's suffix-when-`max = 1`.
- Single-oracle non-ZK is unchanged.

The behavior change is confined to multi-oracle heterogeneous-batch folds, which today are exercised only by the FRI folder's own tests. Those tests' manual fold references move suffix → prefix to match.

## Tests

- Existing FRI + BaseFold suites pass unchanged (`binius-iop`, `binius-iop-prover`, plus `binius-verifier`/`binius-prover`/`binius-spartan-{prover,verifier}` reverse-dep round trips).
- New `test_commit_prove_verify_batched_mixed_skip`: oracle 0 (`skip 0`, batch 1) folds with `inner[0]` (the γ slot) while oracle 1 (`skip 1`, batch 2) folds with `inner[1..3]` — disjoint windows, `max(0+1, 1+2) = 3` inner challenges — verifying the routing the homogeneous suffix convention could not express.

🤖 Generated with [Claude Code](https://claude.com/claude-code)