### PR TITLE
BINIUS-91: merge UnderlierWithBitOps into UnderlierType

### DIFF
--- a/crates/field/src/arch/aarch64/m128.rs
+++ b/crates/field/src/arch/aarch64/m128.rs
@@ -20,7 +20,7 @@ use super::super::portable::{
 use crate::{
 	BinaryField,
 	underlier::{
-		NumCast, SmallU, UnderlierType, UnderlierWithBitOps,
+		NumCast, SmallU, UnderlierType,
 		divisible::{Divisible, mapget},
 		impl_divisible_bitmask,
 	},
@@ -622,9 +622,6 @@ impl std::fmt::Debug for M128 {
 
 impl UnderlierType for M128 {
 	const LOG_BITS: usize = 7;
-}
-
-impl UnderlierWithBitOps for M128 {
 	const ZERO: Self = Self::from_u128(0);
 	const ONE: Self = Self::from_u128(1);
 	const ONES: Self = Self::from_u128(u128::MAX);

--- a/crates/field/src/arch/portable/bitwise_and_arithmetic.rs
+++ b/crates/field/src/arch/portable/bitwise_and_arithmetic.rs
@@ -5,28 +5,24 @@ use crate::{
 	BinaryField1b,
 	arch::BitwiseAndStrategy,
 	arithmetic_traits::{TaggedInvertOrZero, TaggedMul, TaggedSquare},
-	underlier::UnderlierWithBitOps,
+	underlier::UnderlierType,
 };
 
-impl<U: UnderlierWithBitOps> TaggedMul<BitwiseAndStrategy>
-	for PackedPrimitiveType<U, BinaryField1b>
-{
+impl<U: UnderlierType> TaggedMul<BitwiseAndStrategy> for PackedPrimitiveType<U, BinaryField1b> {
 	#[inline]
 	fn mul(self, rhs: Self) -> Self {
 		(self.0 & rhs.0).into()
 	}
 }
 
-impl<U: UnderlierWithBitOps> TaggedSquare<BitwiseAndStrategy>
-	for PackedPrimitiveType<U, BinaryField1b>
-{
+impl<U: UnderlierType> TaggedSquare<BitwiseAndStrategy> for PackedPrimitiveType<U, BinaryField1b> {
 	#[inline]
 	fn square(self) -> Self {
 		self
 	}
 }
 
-impl<U: UnderlierWithBitOps> TaggedInvertOrZero<BitwiseAndStrategy>
+impl<U: UnderlierType> TaggedInvertOrZero<BitwiseAndStrategy>
 	for PackedPrimitiveType<U, BinaryField1b>
 {
 	#[inline]

--- a/crates/field/src/arch/portable/packed.rs
+++ b/crates/field/src/arch/portable/packed.rs
@@ -25,7 +25,7 @@ use crate::{
 	BinaryField, Divisible, ExtensionField, Field, PackedField, WideMul,
 	arithmetic_traits::{InvertOrZero, Square},
 	field::FieldOps,
-	underlier::{NumCast, UnderlierType, UnderlierWithBitOps, WithUnderlier},
+	underlier::{NumCast, UnderlierType, WithUnderlier},
 };
 
 #[derive(PartialEq, Eq, Clone, Copy, Default, bytemuck::TransparentWrapper)]
@@ -62,7 +62,7 @@ impl<U: UnderlierType, Scalar: BinaryField> PackedPrimitiveType<U, Scalar> {
 	}
 }
 
-impl<U: UnderlierWithBitOps + Divisible<Scalar::Underlier>, Scalar: BinaryField>
+impl<U: UnderlierType + Divisible<Scalar::Underlier>, Scalar: BinaryField>
 	PackedPrimitiveType<U, Scalar>
 {
 	#[inline]
@@ -131,7 +131,7 @@ unsafe impl<U: UnderlierType, Scalar: BinaryField> WithUnderlier
 // PackedField`. `PackedField` now has `WideMul<Output: Debug>` as a parent trait, and the trivial
 // `WideMul` impl sets `Output = Self`, so a `Self: PackedField` bound here would make `Debug`
 // depend on itself and overflow trait resolution.
-impl<U: UnderlierWithBitOps + Divisible<Scalar::Underlier>, Scalar: BinaryField> Debug
+impl<U: UnderlierType + Divisible<Scalar::Underlier>, Scalar: BinaryField> Debug
 	for PackedPrimitiveType<U, Scalar>
 {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -154,7 +154,7 @@ impl<U: UnderlierType, Scalar: BinaryField> From<U> for PackedPrimitiveType<U, S
 	}
 }
 
-impl<U: UnderlierWithBitOps, Scalar: BinaryField> Neg for PackedPrimitiveType<U, Scalar> {
+impl<U: UnderlierType, Scalar: BinaryField> Neg for PackedPrimitiveType<U, Scalar> {
 	type Output = Self;
 
 	#[inline]
@@ -163,7 +163,7 @@ impl<U: UnderlierWithBitOps, Scalar: BinaryField> Neg for PackedPrimitiveType<U,
 	}
 }
 
-impl<U: UnderlierWithBitOps, Scalar: BinaryField> Add for PackedPrimitiveType<U, Scalar> {
+impl<U: UnderlierType, Scalar: BinaryField> Add for PackedPrimitiveType<U, Scalar> {
 	type Output = Self;
 
 	#[inline]
@@ -173,7 +173,7 @@ impl<U: UnderlierWithBitOps, Scalar: BinaryField> Add for PackedPrimitiveType<U,
 	}
 }
 
-impl<U: UnderlierWithBitOps, Scalar: BinaryField> Add<&Self> for PackedPrimitiveType<U, Scalar> {
+impl<U: UnderlierType, Scalar: BinaryField> Add<&Self> for PackedPrimitiveType<U, Scalar> {
 	type Output = Self;
 
 	#[inline]
@@ -183,7 +183,7 @@ impl<U: UnderlierWithBitOps, Scalar: BinaryField> Add<&Self> for PackedPrimitive
 	}
 }
 
-impl<U: UnderlierWithBitOps, Scalar: BinaryField> Sub for PackedPrimitiveType<U, Scalar> {
+impl<U: UnderlierType, Scalar: BinaryField> Sub for PackedPrimitiveType<U, Scalar> {
 	type Output = Self;
 
 	#[inline]
@@ -193,7 +193,7 @@ impl<U: UnderlierWithBitOps, Scalar: BinaryField> Sub for PackedPrimitiveType<U,
 	}
 }
 
-impl<U: UnderlierWithBitOps, Scalar: BinaryField> Sub<&Self> for PackedPrimitiveType<U, Scalar> {
+impl<U: UnderlierType, Scalar: BinaryField> Sub<&Self> for PackedPrimitiveType<U, Scalar> {
 	type Output = Self;
 
 	#[inline]
@@ -257,7 +257,7 @@ where
 	}
 }
 
-impl<U: UnderlierWithBitOps + Divisible<Scalar::Underlier>, Scalar: BinaryField> Add<Scalar>
+impl<U: UnderlierType + Divisible<Scalar::Underlier>, Scalar: BinaryField> Add<Scalar>
 	for PackedPrimitiveType<U, Scalar>
 {
 	type Output = Self;
@@ -267,7 +267,7 @@ impl<U: UnderlierWithBitOps + Divisible<Scalar::Underlier>, Scalar: BinaryField>
 	}
 }
 
-impl<U: UnderlierWithBitOps + Divisible<Scalar::Underlier>, Scalar: BinaryField> Sub<Scalar>
+impl<U: UnderlierType + Divisible<Scalar::Underlier>, Scalar: BinaryField> Sub<Scalar>
 	for PackedPrimitiveType<U, Scalar>
 {
 	type Output = Self;
@@ -277,7 +277,7 @@ impl<U: UnderlierWithBitOps + Divisible<Scalar::Underlier>, Scalar: BinaryField>
 	}
 }
 
-impl<U: UnderlierWithBitOps + Divisible<Scalar::Underlier>, Scalar: BinaryField> Mul<Scalar>
+impl<U: UnderlierType + Divisible<Scalar::Underlier>, Scalar: BinaryField> Mul<Scalar>
 	for PackedPrimitiveType<U, Scalar>
 where
 	Self: Mul<Output = Self>,
@@ -289,7 +289,7 @@ where
 	}
 }
 
-impl<U: UnderlierWithBitOps + Divisible<Scalar::Underlier>, Scalar: BinaryField> AddAssign<Scalar>
+impl<U: UnderlierType + Divisible<Scalar::Underlier>, Scalar: BinaryField> AddAssign<Scalar>
 	for PackedPrimitiveType<U, Scalar>
 {
 	fn add_assign(&mut self, rhs: Scalar) {
@@ -297,7 +297,7 @@ impl<U: UnderlierWithBitOps + Divisible<Scalar::Underlier>, Scalar: BinaryField>
 	}
 }
 
-impl<U: UnderlierWithBitOps + Divisible<Scalar::Underlier>, Scalar: BinaryField> SubAssign<Scalar>
+impl<U: UnderlierType + Divisible<Scalar::Underlier>, Scalar: BinaryField> SubAssign<Scalar>
 	for PackedPrimitiveType<U, Scalar>
 {
 	fn sub_assign(&mut self, rhs: Scalar) {
@@ -305,7 +305,7 @@ impl<U: UnderlierWithBitOps + Divisible<Scalar::Underlier>, Scalar: BinaryField>
 	}
 }
 
-impl<U: UnderlierWithBitOps + Divisible<Scalar::Underlier>, Scalar: BinaryField> MulAssign<Scalar>
+impl<U: UnderlierType + Divisible<Scalar::Underlier>, Scalar: BinaryField> MulAssign<Scalar>
 	for PackedPrimitiveType<U, Scalar>
 where
 	Self: MulAssign<Self>,
@@ -333,7 +333,7 @@ where
 	}
 }
 
-impl<U: UnderlierWithBitOps + Divisible<Scalar::Underlier>, Scalar: BinaryField> Product
+impl<U: UnderlierType + Divisible<Scalar::Underlier>, Scalar: BinaryField> Product
 	for PackedPrimitiveType<U, Scalar>
 where
 	Self: Mul<Output = Self>,
@@ -343,8 +343,8 @@ where
 	}
 }
 
-impl<'a, U: UnderlierWithBitOps + Divisible<Scalar::Underlier>, Scalar: BinaryField>
-	Product<&'a Self> for PackedPrimitiveType<U, Scalar>
+impl<'a, U: UnderlierType + Divisible<Scalar::Underlier>, Scalar: BinaryField> Product<&'a Self>
+	for PackedPrimitiveType<U, Scalar>
 where
 	Self: Mul<Output = Self>,
 {
@@ -375,7 +375,7 @@ unsafe impl<U: UnderlierType + Pod, Scalar: BinaryField> Pod for PackedPrimitive
 impl<U, Scalar> FieldOps for PackedPrimitiveType<U, Scalar>
 where
 	Self: Square + InvertOrZero + Mul<Output = Self>,
-	U: UnderlierWithBitOps + Divisible<Scalar::Underlier>,
+	U: UnderlierType + Divisible<Scalar::Underlier>,
 	Scalar: BinaryField,
 {
 	type Scalar = Scalar;
@@ -419,7 +419,7 @@ where
 // underlier. This is the supertrait obligation behind `PackedField: Divisible<Self::Scalar>`.
 impl<U, Scalar> Divisible<Scalar> for PackedPrimitiveType<U, Scalar>
 where
-	U: UnderlierWithBitOps + Divisible<Scalar::Underlier>,
+	U: UnderlierType + Divisible<Scalar::Underlier>,
 	Scalar: BinaryField,
 {
 	const LOG_N: usize = (U::BITS / Scalar::N_BITS).ilog2() as usize;
@@ -475,7 +475,7 @@ impl<U, Scalar> PackedField for PackedPrimitiveType<U, Scalar>
 where
 	Self:
 		Square + InvertOrZero + Mul<Output = Self> + WideMul<Output: Debug + Send + Sync + 'static>,
-	U: UnderlierWithBitOps + Divisible<Scalar::Underlier>,
+	U: UnderlierType + Divisible<Scalar::Underlier>,
 	Scalar: BinaryField,
 {
 	// LOG_WIDTH defaults to `<Self as Divisible<Scalar>>::LOG_N`, the same `(U::BITS /

--- a/crates/field/src/arch/portable/packed_arithmetic.rs
+++ b/crates/field/src/arch/portable/packed_arithmetic.rs
@@ -5,13 +5,13 @@ use crate::{
 	binary_field::BinaryField,
 	linear_transformation::{FieldLinearTransformation, Transformation},
 	packed::PackedBinaryField,
-	underlier::{UnderlierWithBitOps, WithUnderlier},
+	underlier::{UnderlierType, WithUnderlier},
 };
 
 /// Interleave using the provided even mask slice.
 ///
 /// See [Hacker's Delight](https://dl.acm.org/doi/10.5555/2462741), Section 7-3.
-pub fn interleave_with_mask<U: UnderlierWithBitOps>(
+pub fn interleave_with_mask<U: UnderlierType>(
 	a: U,
 	b: U,
 	log_block_len: usize,
@@ -76,7 +76,7 @@ where
 }
 
 /// Broadcast lowest field for each element, e.g. `[<0001><0000>] -> [<1111><0000>]`
-fn broadcast_lowest_bit<U: UnderlierWithBitOps>(mut data: U, log_packed_bits: usize) -> U {
+fn broadcast_lowest_bit<U: UnderlierType>(mut data: U, log_packed_bits: usize) -> U {
 	for i in 0..log_packed_bits {
 		data |= data << (1 << i)
 	}
@@ -90,7 +90,7 @@ where
 	OP: PackedField<Scalar = OF> + WithUnderlier<Underlier = U>,
 	IF: BinaryField,
 	OF: BinaryField,
-	U: UnderlierWithBitOps,
+	U: UnderlierType,
 {
 	fn transform(&self, input: &IP) -> OP {
 		let mut result = OP::zero();

--- a/crates/field/src/arch/portable/scaled_arithmetic.rs
+++ b/crates/field/src/arch/portable/scaled_arithmetic.rs
@@ -35,7 +35,7 @@ where
 {
 	fn square(self) -> Self {
 		Self::wrap(ScaledUnderlier(self.0.0.map(|sub_underlier| {
-			PackedPrimitiveType::peel(PackedPrimitiveType::wrap(sub_underlier).square())
+			PackedPrimitiveType::peel(Square::square(PackedPrimitiveType::wrap(sub_underlier)))
 		})))
 	}
 }
@@ -47,7 +47,9 @@ where
 {
 	fn invert_or_zero(self) -> Self {
 		Self::wrap(ScaledUnderlier(self.0.0.map(|sub_underlier| {
-			PackedPrimitiveType::peel(PackedPrimitiveType::wrap(sub_underlier).invert_or_zero())
+			PackedPrimitiveType::peel(InvertOrZero::invert_or_zero(PackedPrimitiveType::wrap(
+				sub_underlier,
+			)))
 		})))
 	}
 }

--- a/crates/field/src/arch/portable/univariate_mul_utils_128.rs
+++ b/crates/field/src/arch/portable/univariate_mul_utils_128.rs
@@ -23,10 +23,10 @@
 //! Which in turn was adapted from BearSSL's `ghash_ctmul64.c`:
 //! <https://bearssl.org/gitweb/?p=BearSSL;a=blob;f=src/hash/ghash_ctmul64.c;hb=4b6046412>
 
-use crate::underlier::UnderlierWithBitOps;
+use crate::underlier::UnderlierType;
 
 /// Trait for 64-bit underliers that can be used in carryless multiplication.
-pub trait Underlier64bLanes: UnderlierWithBitOps {
+pub trait Underlier64bLanes: UnderlierType {
 	/// Reverse the bits of the 64-bit lanes.
 	fn reverse_bits_64(self) -> Self;
 
@@ -69,7 +69,7 @@ impl Underlier64bLanes for u64 {
 }
 
 /// Trait for 128-bit underliers that can be used in carryless multiplication.
-pub trait Underlier128bLanes: UnderlierWithBitOps {
+pub trait Underlier128bLanes: UnderlierType {
 	/// The twice smaller type containing the 64-bit lanes.
 	type U64: Underlier64bLanes;
 

--- a/crates/field/src/arch/shared/ghash.rs
+++ b/crates/field/src/arch/shared/ghash.rs
@@ -11,11 +11,11 @@ use std::{
 	ops::{Add, AddAssign, Sub, SubAssign},
 };
 
-use crate::{Divisible, underlier::UnderlierWithBitOps};
+use crate::{Divisible, underlier::UnderlierType};
 
 /// Trait for underliers that support CLMUL operations which are needed for the
 /// GHASH multiplication algorithm.
-pub trait ClMulUnderlier: UnderlierWithBitOps + Divisible<u128> {
+pub trait ClMulUnderlier: UnderlierType + Divisible<u128> {
 	/// Performs CLMUL operation on two 64-bit values that are selected from 128-bit lanes
 	/// by the bytes of the IMM8 parameter.
 	fn clmulepi64<const IMM8: i32>(a: Self, b: Self) -> Self;
@@ -79,7 +79,7 @@ const POLY: u128 = 0x87;
 /// Performs reduction step: returns t0 + x^64 * t1
 #[inline]
 fn gf2_128_reduce<U: ClMulUnderlier>(mut t0: U, t1: U) -> U {
-	let poly = <U as UnderlierWithBitOps>::broadcast_subvalue(POLY);
+	let poly = <U as UnderlierType>::broadcast_subvalue(POLY);
 
 	// t0 = t0 XOR (t1 << 64)
 	// In SIMD, left shift by 64 bits is shifting by 8 bytes
@@ -94,7 +94,7 @@ fn gf2_128_reduce<U: ClMulUnderlier>(mut t0: U, t1: U) -> U {
 
 /// Returns a `x^64 * t` after reduction.
 fn gf2_128_shift_reduce<U: ClMulUnderlier>(t: U) -> U {
-	let poly = <U as UnderlierWithBitOps>::broadcast_subvalue(POLY);
+	let poly = <U as UnderlierType>::broadcast_subvalue(POLY);
 	let mut result = U::move_64_to_hi(t);
 
 	result ^= U::clmulepi64::<0x01>(t, poly);

--- a/crates/field/src/arch/wasm32/m128.rs
+++ b/crates/field/src/arch/wasm32/m128.rs
@@ -18,8 +18,8 @@ use crate::{
 	BinaryField, Random,
 	arch::portable::{packed::PackedPrimitiveType, packed_arithmetic::interleave_mask_even},
 	underlier::{
-		NumCast, SmallU, U1, U2, U4, UnderlierType, UnderlierWithBitOps, WithUnderlier,
-		impl_divisible_bitmask, impl_divisible_memcast,
+		NumCast, SmallU, U1, U2, U4, UnderlierType, WithUnderlier, impl_divisible_bitmask,
+		impl_divisible_memcast,
 	},
 };
 
@@ -280,9 +280,6 @@ impl std::fmt::Debug for M128 {
 
 impl UnderlierType for M128 {
 	const LOG_BITS: usize = 7;
-}
-
-impl UnderlierWithBitOps for M128 {
 	const ZERO: Self = { Self(u64x2(0, 0)) };
 	const ONE: Self = { Self(u64x2(1, 0)) };
 	const ONES: Self = { Self(u64x2(u64::MAX, u64::MAX)) };

--- a/crates/field/src/arch/x86_64/m128.rs
+++ b/crates/field/src/arch/x86_64/m128.rs
@@ -22,8 +22,8 @@ use crate::{
 	BinaryField,
 	arch::portable::packed::PackedPrimitiveType,
 	underlier::{
-		Divisible, NumCast, SmallU, SpreadToByte, U2, U4, UnderlierType, UnderlierWithBitOps,
-		impl_divisible_bitmask, mapget, spread_fallback,
+		Divisible, NumCast, SmallU, SpreadToByte, U2, U4, UnderlierType, impl_divisible_bitmask,
+		mapget, spread_fallback,
 	},
 };
 
@@ -324,9 +324,6 @@ pub(super) use m128_from_u128;
 
 impl UnderlierType for M128 {
 	const LOG_BITS: usize = 7;
-}
-
-impl UnderlierWithBitOps for M128 {
 	const ZERO: Self = { Self(m128_from_u128!(0)) };
 	const ONE: Self = { Self(m128_from_u128!(1)) };
 	const ONES: Self = { Self(m128_from_u128!(u128::MAX)) };
@@ -346,7 +343,7 @@ impl UnderlierWithBitOps for M128 {
 	#[inline(always)]
 	unsafe fn spread<T>(self, log_block_len: usize, block_idx: usize) -> Self
 	where
-		T: UnderlierWithBitOps,
+		T: UnderlierType,
 		Self: Divisible<T>,
 	{
 		match T::LOG_BITS {

--- a/crates/field/src/arch/x86_64/m256.rs
+++ b/crates/field/src/arch/x86_64/m256.rs
@@ -19,8 +19,8 @@ use crate::{
 	BinaryField,
 	arch::portable::packed::PackedPrimitiveType,
 	underlier::{
-		Divisible, NumCast, SmallU, U1, U2, U4, UnderlierType, UnderlierWithBitOps,
-		get_block_values, get_spread_bytes, impl_divisible_bitmask, mapget, spread_fallback,
+		Divisible, NumCast, SmallU, U1, U2, U4, UnderlierType, get_block_values, get_spread_bytes,
+		impl_divisible_bitmask, mapget, spread_fallback,
 	},
 };
 
@@ -317,9 +317,6 @@ use super::m128::M128;
 
 impl UnderlierType for M256 {
 	const LOG_BITS: usize = 8;
-}
-
-impl UnderlierWithBitOps for M256 {
 	const ZERO: Self = { Self(m256_from_u128s!(0, 0,)) };
 	const ONE: Self = { Self(m256_from_u128s!(1, 0,)) };
 	const ONES: Self = { Self(m256_from_u128s!(u128::MAX, u128::MAX,)) };
@@ -327,7 +324,7 @@ impl UnderlierWithBitOps for M256 {
 	#[inline(always)]
 	unsafe fn spread<T>(self, log_block_len: usize, block_idx: usize) -> Self
 	where
-		T: UnderlierWithBitOps,
+		T: UnderlierType,
 		Self: Divisible<T>,
 	{
 		match T::LOG_BITS {

--- a/crates/field/src/arch/x86_64/m512.rs
+++ b/crates/field/src/arch/x86_64/m512.rs
@@ -21,8 +21,8 @@ use crate::{
 		x86_64::{m128::M128, m256::M256},
 	},
 	underlier::{
-		Divisible, NumCast, SmallU, U1, U2, U4, UnderlierType, UnderlierWithBitOps,
-		get_block_values, get_spread_bytes, impl_divisible_bitmask, mapget, spread_fallback,
+		Divisible, NumCast, SmallU, U1, U2, U4, UnderlierType, get_block_values, get_spread_bytes,
+		impl_divisible_bitmask, mapget, spread_fallback,
 	},
 };
 
@@ -367,9 +367,6 @@ pub(super) use m512_from_u128s;
 
 impl UnderlierType for M512 {
 	const LOG_BITS: usize = 9;
-}
-
-impl UnderlierWithBitOps for M512 {
 	const ZERO: Self = { Self(m512_from_u128s!(0, 0, 0, 0,)) };
 	const ONE: Self = { Self(m512_from_u128s!(1, 0, 0, 0,)) };
 	const ONES: Self = { Self(m512_from_u128s!(u128::MAX, u128::MAX, u128::MAX, u128::MAX,)) };
@@ -389,7 +386,7 @@ impl UnderlierWithBitOps for M512 {
 	#[inline(always)]
 	unsafe fn spread<T>(self, log_block_len: usize, block_idx: usize) -> Self
 	where
-		T: UnderlierWithBitOps,
+		T: UnderlierType,
 		Self: Divisible<T>,
 	{
 		match T::LOG_BITS {

--- a/crates/field/src/arch/x86_64/packed_ghash_256.rs
+++ b/crates/field/src/arch/x86_64/packed_ghash_256.rs
@@ -19,7 +19,7 @@ use crate::{
 		TaggedInvertOrZero, TaggedMul, TaggedSquare, impl_invert_with, impl_mul_with,
 		impl_square_with,
 	},
-	underlier::UnderlierWithBitOps,
+	underlier::UnderlierType,
 };
 // Only used by the CLMUL-accelerated `WideMul` impl below.
 #[cfg(target_feature = "vpclmulqdq")]

--- a/crates/field/src/arch/x86_64/packed_ghash_512.rs
+++ b/crates/field/src/arch/x86_64/packed_ghash_512.rs
@@ -17,7 +17,7 @@ use crate::{
 		InvertOrZero, TaggedInvertOrZero, TaggedMul, TaggedSquare, impl_invert_with, impl_mul_with,
 		impl_square_with,
 	},
-	underlier::UnderlierWithBitOps,
+	underlier::UnderlierType,
 };
 // Only used by the CLMUL-accelerated `ClMulUnderlier` and `WideMul` impls below.
 #[cfg(all(target_feature = "vpclmulqdq", target_feature = "avx512f"))]

--- a/crates/field/src/arch/x86_64/simd/simd_arithmetic.rs
+++ b/crates/field/src/arch/x86_64/simd/simd_arithmetic.rs
@@ -2,10 +2,10 @@
 
 use std::{any::TypeId, arch::x86_64::*};
 
-use crate::{BinaryField, aes_field::AESTowerField8b, underlier::UnderlierWithBitOps};
+use crate::{BinaryField, aes_field::AESTowerField8b, underlier::UnderlierType};
 
 #[allow(dead_code)]
-pub trait TowerSimdType: Sized + Copy + UnderlierWithBitOps {
+pub trait TowerSimdType: Sized + Copy + UnderlierType {
 	/// Blend odd and even elements
 	fn blend_odd_even<Scalar: BinaryField>(a: Self, b: Self) -> Self;
 	/// Set alpha to even elements

--- a/crates/field/src/binary_field.rs
+++ b/crates/field/src/binary_field.rs
@@ -14,14 +14,14 @@ use binius_utils::{
 use bytemuck::Zeroable;
 
 use super::{
-	UnderlierWithBitOps, WithUnderlier, binary_field_arithmetic::TowerFieldArithmetic,
+	UnderlierType, WithUnderlier, binary_field_arithmetic::TowerFieldArithmetic,
 	extension::ExtensionField,
 };
 use crate::{Field, underlier::U1};
 
 /// A finite field with characteristic 2.
 pub trait BinaryField:
-	ExtensionField<BinaryField1b> + WithUnderlier<Underlier: UnderlierWithBitOps>
+	ExtensionField<BinaryField1b> + WithUnderlier<Underlier: UnderlierType>
 {
 	const N_BITS: usize = Self::ORDER_EXPONENT;
 }
@@ -226,8 +226,8 @@ macro_rules! binary_field {
 		}
 
 		impl Field for $name {
-			const ZERO: Self = $name::new(<$typ as $crate::underlier::UnderlierWithBitOps>::ZERO);
-			const ONE: Self = $name::new(<$typ as $crate::underlier::UnderlierWithBitOps>::ONE);
+			const ZERO: Self = $name::new(<$typ as $crate::underlier::UnderlierType>::ZERO);
+			const ONE: Self = $name::new(<$typ as $crate::underlier::UnderlierType>::ONE);
 			const CHARACTERISTIC: usize = 2;
 			const ORDER_EXPONENT: usize = <$typ as $crate::underlier::UnderlierType>::BITS;
 			const MULTIPLICATIVE_GENERATOR: $name = $name($gen);
@@ -324,7 +324,7 @@ macro_rules! mul_by_binary_field_1b {
 			#[inline]
 			#[allow(clippy::suspicious_arithmetic_impl)]
 			fn mul(self, rhs: BinaryField1b) -> Self::Output {
-				use $crate::underlier::{UnderlierWithBitOps, WithUnderlier};
+				use $crate::underlier::{UnderlierType, WithUnderlier};
 
 				$crate::tracing::trace_multiplication!(BinaryField128b, BinaryField1b);
 
@@ -346,7 +346,7 @@ macro_rules! impl_field_extension {
 				use $crate::underlier::NumCast;
 
 				if elem.0 >> $subfield_name::N_BITS
-					== <$typ as $crate::underlier::UnderlierWithBitOps>::ZERO
+					== <$typ as $crate::underlier::UnderlierType>::ZERO
 				{
 					Ok($subfield_name::new(<$subfield_typ>::num_cast_from(elem.val())))
 				} else {
@@ -434,7 +434,7 @@ macro_rules! impl_field_extension {
 
 			#[inline]
 			fn basis(i: usize) -> Self {
-				use $crate::underlier::UnderlierWithBitOps;
+				use $crate::underlier::UnderlierType;
 
 				assert!(
 					i < 1 << $log_degree,
@@ -450,7 +450,7 @@ macro_rules! impl_field_extension {
 				base_elems: impl IntoIterator<Item = $subfield_name>,
 				log_stride: usize,
 			) -> Self {
-				use $crate::underlier::UnderlierWithBitOps;
+				use $crate::underlier::UnderlierType;
 
 				debug_assert!($name::N_BITS.is_power_of_two());
 				let shift_step = ($subfield_name::N_BITS << log_stride) & ($name::N_BITS - 1);
@@ -486,7 +486,7 @@ macro_rules! impl_field_extension {
 
 			#[inline]
 			unsafe fn get_base_unchecked(&self, i: usize) -> $subfield_name {
-				use $crate::underlier::{UnderlierWithBitOps, WithUnderlier};
+				use $crate::underlier::{UnderlierType, WithUnderlier};
 				unsafe { $subfield_name::from_underlier(self.to_underlier().get_subvalue(i)) }
 			}
 

--- a/crates/field/src/lib.rs
+++ b/crates/field/src/lib.rs
@@ -50,4 +50,4 @@ pub use packed_extension_ops::*;
 pub use packed_ghash::*;
 pub use random::Random;
 pub use transpose::square_transpose;
-pub use underlier::{Divisible, UnderlierWithBitOps, WithUnderlier};
+pub use underlier::{Divisible, UnderlierType, WithUnderlier};

--- a/crates/field/src/linear_transformation.rs
+++ b/crates/field/src/linear_transformation.rs
@@ -5,9 +5,8 @@ use std::{iter, marker::PhantomData, ops::BitXor};
 use rand::prelude::*;
 
 use crate::{
-	BinaryField, BinaryField1b, ExtensionField, UnderlierWithBitOps, WithUnderlier,
-	packed::PackedBinaryField,
-	underlier::{Divisible, UnderlierType},
+	BinaryField, BinaryField1b, ExtensionField, UnderlierType, WithUnderlier,
+	packed::PackedBinaryField, underlier::Divisible,
 };
 
 /// Generic transformation trait that is used both for scalars and packed fields
@@ -91,7 +90,7 @@ pub struct BytewiseLookupTransformation<UIn, UOut> {
 impl<UIn, UOut> BytewiseLookupTransformation<UIn, UOut>
 where
 	UIn: UnderlierType + Divisible<u8>,
-	UOut: UnderlierWithBitOps,
+	UOut: UnderlierType,
 {
 	pub fn new(cols: &[UOut]) -> Self {
 		assert!(LOG_BITS_PER_BYTE <= UIn::LOG_BITS);
@@ -118,7 +117,7 @@ where
 impl<UIn, UOut> Transformation<UIn, UOut> for BytewiseLookupTransformation<UIn, UOut>
 where
 	UIn: UnderlierType + Divisible<u8>,
-	UOut: UnderlierWithBitOps,
+	UOut: UnderlierType,
 {
 	fn transform(&self, data: &UIn) -> UOut {
 		Divisible::<u8>::ref_iter(data)
@@ -136,7 +135,7 @@ where
 	}
 }
 
-fn expand_subset_xors<U: UnderlierWithBitOps, const N: usize, const N_EXP2: usize>(
+fn expand_subset_xors<U: UnderlierType, const N: usize, const N_EXP2: usize>(
 	elems: [U; N],
 ) -> [U; N_EXP2] {
 	assert_eq!(N_EXP2, 1 << N);
@@ -166,7 +165,7 @@ pub trait LinearTransformationFactory<Input, Output> {
 impl<UIn, UOut> LinearTransformationFactory<UIn, UOut> for BytewiseLookupTransformationFactory
 where
 	UIn: UnderlierType + Divisible<u8>,
-	UOut: UnderlierWithBitOps,
+	UOut: UnderlierType,
 {
 	type Transform = BytewiseLookupTransformation<UIn, UOut>;
 

--- a/crates/field/src/underlier/mod.rs
+++ b/crates/field/src/underlier/mod.rs
@@ -11,4 +11,8 @@ pub use divisible::*;
 pub use scaled::ScaledUnderlier;
 pub use small_uint::*;
 pub use underlier_type::*;
-pub use underlier_with_bit_ops::*;
+// The re-exported items are bit-op helpers used only by the SIMD arch backends (and tests), so
+// on targets without a SIMD backend (e.g. portable wasm32) nothing consumes them through this
+// glob.
+#[allow(unused_imports)]
+pub(crate) use underlier_with_bit_ops::*;

--- a/crates/field/src/underlier/scaled.rs
+++ b/crates/field/src/underlier/scaled.rs
@@ -16,7 +16,7 @@ use rand::{
 	distr::{Distribution, StandardUniform},
 };
 
-use super::{Divisible, NumCast, UnderlierType, UnderlierWithBitOps, mapget};
+use super::{Divisible, NumCast, UnderlierType, mapget};
 use crate::Random;
 
 /// A type that represents N elements of the same underlier type.
@@ -57,10 +57,6 @@ impl<T: Copy, U: From<[T; 2]>> From<[T; 4]> for ScaledUnderlier<U, 2> {
 
 unsafe impl<U: Zeroable, const N: usize> Zeroable for ScaledUnderlier<U, N> {}
 unsafe impl<U: Pod, const N: usize> Pod for ScaledUnderlier<U, N> {}
-
-impl<U: UnderlierType + Pod, const N: usize> UnderlierType for ScaledUnderlier<U, N> {
-	const LOG_BITS: usize = U::LOG_BITS + checked_log_2(N);
-}
 
 impl<U: BitAnd<Output = U> + Copy, const N: usize> BitAnd for ScaledUnderlier<U, N> {
 	type Output = Self;
@@ -110,7 +106,7 @@ impl<U: BitXorAssign + Copy, const N: usize> BitXorAssign for ScaledUnderlier<U,
 	}
 }
 
-impl<U: UnderlierWithBitOps, const N: usize> Shr<usize> for ScaledUnderlier<U, N> {
+impl<U: UnderlierType, const N: usize> Shr<usize> for ScaledUnderlier<U, N> {
 	type Output = Self;
 
 	fn shr(self, rhs: usize) -> Self::Output {
@@ -130,7 +126,7 @@ impl<U: UnderlierWithBitOps, const N: usize> Shr<usize> for ScaledUnderlier<U, N
 	}
 }
 
-impl<U: UnderlierWithBitOps, const N: usize> Shl<usize> for ScaledUnderlier<U, N> {
+impl<U: UnderlierType, const N: usize> Shl<usize> for ScaledUnderlier<U, N> {
 	type Output = Self;
 
 	fn shl(self, rhs: usize) -> Self::Output {
@@ -158,7 +154,9 @@ impl<U: Not<Output = U>, const N: usize> Not for ScaledUnderlier<U, N> {
 	}
 }
 
-impl<U: UnderlierWithBitOps + Pod, const N: usize> UnderlierWithBitOps for ScaledUnderlier<U, N> {
+impl<U: UnderlierType + Pod, const N: usize> UnderlierType for ScaledUnderlier<U, N> {
+	const LOG_BITS: usize = U::LOG_BITS + checked_log_2(N);
+
 	const ZERO: Self = Self([U::ZERO; N]);
 	const ONE: Self = {
 		let mut arr = [U::ZERO; N];

--- a/crates/field/src/underlier/small_uint.rs
+++ b/crates/field/src/underlier/small_uint.rs
@@ -19,7 +19,7 @@ use rand::{
 	prelude::*,
 };
 
-use super::{UnderlierType, underlier_with_bit_ops::UnderlierWithBitOps};
+use super::UnderlierType;
 use crate::arch::{interleave_mask_even, interleave_with_mask};
 
 /// Unsigned type with a size strictly less than 8 bits.
@@ -136,11 +136,9 @@ impl<const N: usize> Not for SmallU<N> {
 
 unsafe impl<const N: usize> NoUninit for SmallU<N> {}
 
-impl<const N: usize> UnderlierType for SmallU<N> {
-	const LOG_BITS: usize = checked_log_2(N);
-}
+impl UnderlierType for U1 {
+	const LOG_BITS: usize = checked_log_2(1);
 
-impl UnderlierWithBitOps for U1 {
 	const ZERO: Self = Self(0);
 	const ONE: Self = Self(1);
 	const ONES: Self = Self(1);
@@ -150,7 +148,9 @@ impl UnderlierWithBitOps for U1 {
 	}
 }
 
-impl UnderlierWithBitOps for U2 {
+impl UnderlierType for U2 {
+	const LOG_BITS: usize = checked_log_2(2);
+
 	const ZERO: Self = Self(0);
 	const ONE: Self = Self(1);
 	const ONES: Self = Self(0b11);
@@ -161,7 +161,9 @@ impl UnderlierWithBitOps for U2 {
 	}
 }
 
-impl UnderlierWithBitOps for U4 {
+impl UnderlierType for U4 {
+	const LOG_BITS: usize = checked_log_2(4);
+
 	const ZERO: Self = Self(0);
 	const ONE: Self = Self(1);
 	const ONES: Self = Self(0b1111);

--- a/crates/field/src/underlier/underlier_impls.rs
+++ b/crates/field/src/underlier/underlier_impls.rs
@@ -3,110 +3,34 @@
 use super::{
 	small_uint::{U1, U2, U4},
 	underlier_type::{NumCast, UnderlierType},
-	underlier_with_bit_ops::UnderlierWithBitOps,
 };
 use crate::arch::{interleave_mask_even, interleave_with_mask};
 
 macro_rules! impl_underlier_type {
-	($name:ty) => {
+	($name:ty, $($mask_idx:literal),+) => {
 		impl UnderlierType for $name {
 			const LOG_BITS: usize =
 				binius_utils::checked_arithmetics::checked_log_2(Self::BITS as _);
+
+			const ZERO: Self = 0;
+			const ONE: Self = 1;
+			const ONES: Self = Self::MAX;
+
+			fn interleave(self, other: Self, log_block_len: usize) -> (Self, Self) {
+				const MASKS: &[$name] = &[
+					$(interleave_mask_even!($name, $mask_idx)),+
+				];
+				interleave_with_mask(self, other, log_block_len, MASKS)
+			}
 		}
 	};
-	() => {};
-	($name:ty, $($tail:ty),+) => {
-		impl_underlier_type!($name);
-		impl_underlier_type!($($tail),+);
-	}
 }
 
-impl_underlier_type!(u8, u16, u32, u64, u128);
-
-impl UnderlierWithBitOps for u8 {
-	const ZERO: Self = 0;
-	const ONE: Self = 1;
-	const ONES: Self = Self::MAX;
-
-	fn interleave(self, other: Self, log_block_len: usize) -> (Self, Self) {
-		const MASKS: &[u8] = &[
-			interleave_mask_even!(u8, 0),
-			interleave_mask_even!(u8, 1),
-			interleave_mask_even!(u8, 2),
-		];
-		interleave_with_mask(self, other, log_block_len, MASKS)
-	}
-}
-
-impl UnderlierWithBitOps for u16 {
-	const ZERO: Self = 0;
-	const ONE: Self = 1;
-	const ONES: Self = Self::MAX;
-
-	fn interleave(self, other: Self, log_block_len: usize) -> (Self, Self) {
-		const MASKS: &[u16] = &[
-			interleave_mask_even!(u16, 0),
-			interleave_mask_even!(u16, 1),
-			interleave_mask_even!(u16, 2),
-			interleave_mask_even!(u16, 3),
-		];
-		interleave_with_mask(self, other, log_block_len, MASKS)
-	}
-}
-
-impl UnderlierWithBitOps for u32 {
-	const ZERO: Self = 0;
-	const ONE: Self = 1;
-	const ONES: Self = Self::MAX;
-
-	fn interleave(self, other: Self, log_block_len: usize) -> (Self, Self) {
-		const MASKS: &[u32] = &[
-			interleave_mask_even!(u32, 0),
-			interleave_mask_even!(u32, 1),
-			interleave_mask_even!(u32, 2),
-			interleave_mask_even!(u32, 3),
-			interleave_mask_even!(u32, 4),
-		];
-		interleave_with_mask(self, other, log_block_len, MASKS)
-	}
-}
-
-impl UnderlierWithBitOps for u64 {
-	const ZERO: Self = 0;
-	const ONE: Self = 1;
-	const ONES: Self = Self::MAX;
-
-	fn interleave(self, other: Self, log_block_len: usize) -> (Self, Self) {
-		const MASKS: &[u64] = &[
-			interleave_mask_even!(u64, 0),
-			interleave_mask_even!(u64, 1),
-			interleave_mask_even!(u64, 2),
-			interleave_mask_even!(u64, 3),
-			interleave_mask_even!(u64, 4),
-			interleave_mask_even!(u64, 5),
-		];
-		interleave_with_mask(self, other, log_block_len, MASKS)
-	}
-}
-
-impl UnderlierWithBitOps for u128 {
-	const ZERO: Self = 0;
-	const ONE: Self = 1;
-	const ONES: Self = Self::MAX;
-
-	fn interleave(self, other: Self, log_block_len: usize) -> (Self, Self) {
-		const MASKS: &[u128] = &[
-			interleave_mask_even!(u128, 0),
-			interleave_mask_even!(u128, 1),
-			interleave_mask_even!(u128, 2),
-			interleave_mask_even!(u128, 3),
-			interleave_mask_even!(u128, 4),
-			interleave_mask_even!(u128, 5),
-			interleave_mask_even!(u128, 6),
-		];
-		interleave_with_mask(self, other, log_block_len, MASKS)
-	}
-}
+impl_underlier_type!(u8, 0, 1, 2);
+impl_underlier_type!(u16, 0, 1, 2, 3);
+impl_underlier_type!(u32, 0, 1, 2, 3, 4);
+impl_underlier_type!(u64, 0, 1, 2, 3, 4, 5);
+impl_underlier_type!(u128, 0, 1, 2, 3, 4, 5, 6);
 
 macro_rules! impl_num_cast {
 	(@pair U1, U2) => {impl_num_cast!(@small_u_from_small_u U1, U2);};

--- a/crates/field/src/underlier/underlier_type.rs
+++ b/crates/field/src/underlier/underlier_type.rs
@@ -1,21 +1,142 @@
 // Copyright 2024-2025 Irreducible Inc.
 
-use std::fmt::Debug;
+use std::{
+	fmt::Debug,
+	ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Not, Shl, Shr},
+};
 
+use binius_utils::checked_arithmetics::checked_int_div;
 use bytemuck::{NoUninit, TransparentWrapper, Zeroable};
 
-use crate::Random;
+use super::{U1, underlier_with_bit_ops::spread_fallback};
+use crate::{Divisible, Random};
 
 /// Primitive integer underlying a binary field or packed binary field implementation.
 /// Note that this type is not guaranteed to be POD, U1, U2 and U4 have some unused bits.
 pub trait UnderlierType:
-	Debug + Default + Eq + Ord + Copy + Random + NoUninit + Zeroable + Sized + Send + Sync + 'static
+	Debug
+	+ Default
+	+ Eq
+	+ Ord
+	+ Copy
+	+ Random
+	+ NoUninit
+	+ Zeroable
+	+ Sized
+	+ Send
+	+ Sync
+	+ 'static
+	+ BitAnd<Self, Output = Self>
+	+ BitAndAssign<Self>
+	+ BitOr<Self, Output = Self>
+	+ BitOrAssign<Self>
+	+ BitXor<Self, Output = Self>
+	+ BitXorAssign<Self>
+	+ Shr<usize, Output = Self>
+	+ Shl<usize, Output = Self>
+	+ Not<Output = Self>
+	+ Divisible<U1>
 {
 	/// Number of bits in value
 	const LOG_BITS: usize;
 	/// Number of bits used to represent a value.
 	/// This may not be equal to the number of bits in a type instance.
 	const BITS: usize = 1 << Self::LOG_BITS;
+
+	const ZERO: Self;
+	const ONE: Self;
+	const ONES: Self;
+
+	/// Fill value with the given bit
+	/// `val` must be 0 or 1.
+	fn fill_with_bit(val: u8) -> Self {
+		Self::broadcast_subvalue(U1::new(val))
+	}
+
+	/// Interleave with the given bit size
+	fn interleave(self, other: Self, log_block_len: usize) -> (Self, Self);
+
+	/// Transpose with the given bit size
+	fn transpose(mut self, mut other: Self, log_block_len: usize) -> (Self, Self) {
+		assert!(log_block_len < Self::LOG_BITS);
+
+		for log_block_len in (log_block_len..Self::LOG_BITS).rev() {
+			(self, other) = self.interleave(other, log_block_len);
+		}
+
+		(self, other)
+	}
+
+	#[inline]
+	fn from_fn<T>(f: impl FnMut(usize) -> T) -> Self
+	where
+		T: UnderlierType,
+		Self: Divisible<T>,
+	{
+		Self::from_iter((0..<Self as Divisible<T>>::N).map(f))
+	}
+
+	/// Broadcast subvalue to fill `Self`.
+	/// `Self::BITS/T::BITS` is supposed to be a power of 2.
+	#[inline]
+	fn broadcast_subvalue<T>(value: T) -> Self
+	where
+		T: UnderlierType,
+		Self: Divisible<T>,
+	{
+		Divisible::<T>::broadcast(value)
+	}
+
+	/// Gets the subvalue from the given position.
+	/// Function panics in case when index is out of range.
+	///
+	/// # Safety
+	/// `i` must be less than `Self::BITS/T::BITS`.
+	#[inline]
+	unsafe fn get_subvalue<T>(&self, i: usize) -> T
+	where
+		T: UnderlierType,
+		Self: Divisible<T>,
+	{
+		debug_assert!(
+			i < checked_int_div(Self::BITS, T::BITS),
+			"i: {} Self::BITS: {}, T::BITS: {}",
+			i,
+			Self::BITS,
+			T::BITS
+		);
+		Divisible::<T>::get(*self, i)
+	}
+
+	/// Sets the subvalue in the given position.
+	/// Function panics in case when index is out of range.
+	///
+	/// # Safety
+	/// `i` must be less than `Self::BITS/T::BITS`.
+	#[inline]
+	unsafe fn set_subvalue<T>(&mut self, i: usize, val: T)
+	where
+		T: UnderlierType,
+		Self: Divisible<T>,
+	{
+		debug_assert!(i < checked_int_div(Self::BITS, T::BITS));
+		Divisible::<T>::set(self, i, val);
+	}
+
+	/// Spread takes a block of sub_elements of `T` type within the current value and
+	/// repeats them to the full underlier width.
+	///
+	/// # Safety
+	/// `log_block_len + T::LOG_BITS` must be less than or equal to `Self::LOG_BITS`.
+	/// `block_idx` must be less than `1 << (Self::LOG_BITS - log_block_len)`.
+	#[inline]
+	unsafe fn spread<T>(self, log_block_len: usize, block_idx: usize) -> Self
+	where
+		T: UnderlierType,
+		Self: Divisible<T>,
+	{
+		unsafe { spread_fallback::<Self, T>(self, log_block_len, block_idx) }
+	}
 }
 
 /// A type that is transparently backed by an underlier.

--- a/crates/field/src/underlier/underlier_with_bit_ops.rs
+++ b/crates/field/src/underlier/underlier_with_bit_ops.rs
@@ -1,124 +1,10 @@
 // Copyright 2024-2025 Irreducible Inc.
 
-use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Not, Shl, Shr};
-
-use binius_utils::checked_arithmetics::checked_int_div;
-
 use super::{
 	U1, U2, U4,
 	underlier_type::{NumCast, UnderlierType},
 };
 use crate::Divisible;
-
-/// Underlier type that supports bit arithmetic.
-pub trait UnderlierWithBitOps:
-	UnderlierType
-	+ BitAnd<Self, Output = Self>
-	+ BitAndAssign<Self>
-	+ BitOr<Self, Output = Self>
-	+ BitOrAssign<Self>
-	+ BitXor<Self, Output = Self>
-	+ BitXorAssign<Self>
-	+ Shr<usize, Output = Self>
-	+ Shl<usize, Output = Self>
-	+ Not<Output = Self>
-	+ Divisible<U1>
-{
-	const ZERO: Self;
-	const ONE: Self;
-	const ONES: Self;
-
-	/// Fill value with the given bit
-	/// `val` must be 0 or 1.
-	fn fill_with_bit(val: u8) -> Self {
-		Self::broadcast_subvalue(U1::new(val))
-	}
-
-	/// Interleave with the given bit size
-	fn interleave(self, other: Self, log_block_len: usize) -> (Self, Self);
-
-	/// Transpose with the given bit size
-	fn transpose(mut self, mut other: Self, log_block_len: usize) -> (Self, Self) {
-		assert!(log_block_len < Self::LOG_BITS);
-
-		for log_block_len in (log_block_len..Self::LOG_BITS).rev() {
-			(self, other) = self.interleave(other, log_block_len);
-		}
-
-		(self, other)
-	}
-
-	#[inline]
-	fn from_fn<T>(f: impl FnMut(usize) -> T) -> Self
-	where
-		T: UnderlierType,
-		Self: Divisible<T>,
-	{
-		Self::from_iter((0..<Self as Divisible<T>>::N).map(f))
-	}
-
-	/// Broadcast subvalue to fill `Self`.
-	/// `Self::BITS/T::BITS` is supposed to be a power of 2.
-	#[inline]
-	fn broadcast_subvalue<T>(value: T) -> Self
-	where
-		T: UnderlierType,
-		Self: Divisible<T>,
-	{
-		Divisible::<T>::broadcast(value)
-	}
-
-	/// Gets the subvalue from the given position.
-	/// Function panics in case when index is out of range.
-	///
-	/// # Safety
-	/// `i` must be less than `Self::BITS/T::BITS`.
-	#[inline]
-	unsafe fn get_subvalue<T>(&self, i: usize) -> T
-	where
-		T: UnderlierType,
-		Self: Divisible<T>,
-	{
-		debug_assert!(
-			i < checked_int_div(Self::BITS, T::BITS),
-			"i: {} Self::BITS: {}, T::BITS: {}",
-			i,
-			Self::BITS,
-			T::BITS
-		);
-		Divisible::<T>::get(*self, i)
-	}
-
-	/// Sets the subvalue in the given position.
-	/// Function panics in case when index is out of range.
-	///
-	/// # Safety
-	/// `i` must be less than `Self::BITS/T::BITS`.
-	#[inline]
-	unsafe fn set_subvalue<T>(&mut self, i: usize, val: T)
-	where
-		T: UnderlierWithBitOps,
-		Self: Divisible<T>,
-	{
-		debug_assert!(i < checked_int_div(Self::BITS, T::BITS));
-		Divisible::<T>::set(self, i, val);
-	}
-
-	/// Spread takes a block of sub_elements of `T` type within the current value and
-	/// repeats them to the full underlier width.
-	///
-	/// # Safety
-	/// `log_block_len + T::LOG_BITS` must be less than or equal to `Self::LOG_BITS`.
-	/// `block_idx` must be less than `1 << (Self::LOG_BITS - log_block_len)`.
-	#[inline]
-	unsafe fn spread<T>(self, log_block_len: usize, block_idx: usize) -> Self
-	where
-		T: UnderlierWithBitOps,
-		Self: Divisible<T>,
-	{
-		unsafe { spread_fallback::<Self, T>(self, log_block_len, block_idx) }
-	}
-}
 
 /// Fallback implementation of `spread` method.
 ///
@@ -127,8 +13,8 @@ pub trait UnderlierWithBitOps:
 /// `block_idx` must be less than `1 << (U::LOG_BITS - log_block_len)`.
 pub(crate) unsafe fn spread_fallback<U, T>(value: U, log_block_len: usize, block_idx: usize) -> U
 where
-	U: UnderlierWithBitOps + Divisible<T>,
-	T: UnderlierWithBitOps,
+	U: UnderlierType + Divisible<T>,
+	T: UnderlierType,
 {
 	debug_assert!(
 		log_block_len + T::LOG_BITS <= U::LOG_BITS,
@@ -163,7 +49,7 @@ where
 
 #[cfg(test)]
 #[allow(unused)]
-pub(crate) fn single_element_mask_bits<T: UnderlierWithBitOps>(bits_count: usize) -> T {
+pub(crate) fn single_element_mask_bits<T: UnderlierType>(bits_count: usize) -> T {
 	use binius_utils::checked_arithmetics::checked_log_2;
 
 	if bits_count == T::BITS {
@@ -211,7 +97,7 @@ impl SpreadToByte for U4 {
 	}
 }
 
-/// A helper functions for implementing `UnderlierWithBitOps::spread_unchecked` for SIMD types.
+/// A helper functions for implementing `UnderlierType::spread` for SIMD types.
 ///
 /// # Safety
 /// `log_block_len + T::LOG_BITS` must be less than or equal to `U::LOG_BITS`.
@@ -222,13 +108,13 @@ pub(crate) unsafe fn get_block_values<U, T, const BLOCK_LEN: usize>(
 	block_idx: usize,
 ) -> [T; BLOCK_LEN]
 where
-	U: UnderlierWithBitOps + From<T> + Divisible<T>,
+	U: UnderlierType + From<T> + Divisible<T>,
 	T: UnderlierType + NumCast<U>,
 {
 	std::array::from_fn(|i| unsafe { value.get_subvalue::<T>(block_idx * BLOCK_LEN + i) })
 }
 
-/// A helper functions for implementing `UnderlierWithBitOps::spread_unchecked` for SIMD types.
+/// A helper functions for implementing `UnderlierType::spread` for SIMD types.
 ///
 /// # Safety
 /// `log_block_len + T::LOG_BITS` must be less than or equal to `U::LOG_BITS`.
@@ -239,7 +125,7 @@ pub(crate) unsafe fn get_spread_bytes<U, T, const BLOCK_LEN: usize>(
 	block_idx: usize,
 ) -> [u8; BLOCK_LEN]
 where
-	U: UnderlierWithBitOps + From<T> + Divisible<T>,
+	U: UnderlierType + From<T> + Divisible<T>,
 	T: UnderlierType + SpreadToByte + NumCast<U>,
 {
 	unsafe { get_block_values::<U, T, BLOCK_LEN>(value, block_idx) }

--- a/crates/prover/src/protocols/shift/phase_1.rs
+++ b/crates/prover/src/protocols/shift/phase_1.rs
@@ -4,7 +4,7 @@ use std::{iter, ops::Range};
 
 use binius_core::word::Word;
 use binius_field::{
-	AESTowerField8b, BinaryField, Field, PackedField, UnderlierWithBitOps, WithUnderlier,
+	AESTowerField8b, BinaryField, Field, PackedField, UnderlierType, WithUnderlier,
 };
 use binius_ip_prover::channel::IPProverChannel;
 use binius_math::{FieldBuffer, inner_product::inner_product_buffers};
@@ -45,8 +45,8 @@ pub fn prove_phase_1<F, P, Channel>(
 	channel: &mut Channel,
 ) -> Result<SumcheckOutput<F>, Error>
 where
-	F: BinaryField + From<AESTowerField8b> + WithUnderlier<Underlier: UnderlierWithBitOps>,
-	P: PackedField<Scalar = F> + WithUnderlier<Underlier: UnderlierWithBitOps>,
+	F: BinaryField + From<AESTowerField8b> + WithUnderlier<Underlier: UnderlierType>,
+	P: PackedField<Scalar = F> + WithUnderlier<Underlier: UnderlierType>,
 	Channel: IPProverChannel<F>,
 {
 	let g_parts = build_g_parts::<_, P>(words, key_collection, bitand_data, intmul_data)?;
@@ -169,8 +169,8 @@ fn run_phase_1_sumcheck<F: Field, P: PackedField<Scalar = F>, Channel: IPProverC
 /// that will participate in the phase 1 sumcheck protocol.
 #[instrument(skip_all, name = "build_g_parts")]
 fn build_g_parts<
-	F: BinaryField + WithUnderlier<Underlier: UnderlierWithBitOps>,
-	P: PackedField<Scalar = F> + WithUnderlier<Underlier: UnderlierWithBitOps>,
+	F: BinaryField + WithUnderlier<Underlier: UnderlierType>,
+	P: PackedField<Scalar = F> + WithUnderlier<Underlier: UnderlierType>,
 >(
 	words: &[Word],
 	key_collection: &KeyCollection,
@@ -185,7 +185,7 @@ fn build_g_parts<
 	);
 
 	// Field element that is represented by all ones
-	let all_ones_f = F::from_underlier(UnderlierWithBitOps::fill_with_bit(1));
+	let all_ones_f = F::from_underlier(UnderlierType::fill_with_bit(1));
 	// Map from u8 with `P::WIDTH` meaningful bits to the `P` where each element has
 	// all zeroes or all ones depending on the corresponding bit value.
 	let packed_masks_map = (0..1 << P::WIDTH)

--- a/crates/prover/src/protocols/shift/prove.rs
+++ b/crates/prover/src/protocols/shift/prove.rs
@@ -2,8 +2,7 @@
 
 use binius_core::word::Word;
 use binius_field::{
-	AESTowerField8b, BinaryField, Field, PackedField, UnderlierWithBitOps, WithUnderlier,
-	util::powers,
+	AESTowerField8b, BinaryField, Field, PackedField, UnderlierType, WithUnderlier, util::powers,
 };
 use binius_ip_prover::channel::IPProverChannel;
 use binius_math::{
@@ -105,8 +104,8 @@ pub fn prove<F, P, Channel>(
 	channel: &mut Channel,
 ) -> Result<SumcheckOutput<F>, Error>
 where
-	F: BinaryField + From<AESTowerField8b> + WithUnderlier<Underlier: UnderlierWithBitOps>,
-	P: PackedField<Scalar = F> + WithUnderlier<Underlier: UnderlierWithBitOps>,
+	F: BinaryField + From<AESTowerField8b> + WithUnderlier<Underlier: UnderlierType>,
+	P: PackedField<Scalar = F> + WithUnderlier<Underlier: UnderlierType>,
 	Channel: IPProverChannel<F>,
 {
 	// Sample lambdas, one for each operator.

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -7,7 +7,7 @@ use binius_core::{
 };
 use binius_field::{
 	AESTowerField8b as B8, BinaryField, ExtensionField, PackedAESBinaryField16x8b, PackedExtension,
-	PackedField, UnderlierWithBitOps, WithUnderlier,
+	PackedField, UnderlierType, WithUnderlier,
 };
 use binius_hash::binary_merkle_tree::HashSuite;
 use binius_iop_prover::{
@@ -99,7 +99,7 @@ impl IOPProver {
 		P: PackedField<Scalar = B128>
 			+ PackedExtension<B128>
 			+ PackedExtension<B1>
-			+ WithUnderlier<Underlier: UnderlierWithBitOps>,
+			+ WithUnderlier<Underlier: UnderlierType>,
 		Channel: IOPProverChannel<P>,
 	{
 		let cs = &self.constraint_system;
@@ -273,7 +273,7 @@ where
 	P: PackedField<Scalar = B128>
 		+ PackedExtension<B128>
 		+ PackedExtension<B1>
-		+ WithUnderlier<Underlier: UnderlierWithBitOps>,
+		+ WithUnderlier<Underlier: UnderlierType>,
 	H: HashSuite,
 	Output<H::LeafHash>: SerializeBytes,
 {

--- a/crates/prover/src/zk_config.rs
+++ b/crates/prover/src/zk_config.rs
@@ -11,7 +11,7 @@ use binius_core::{
 	word::Word,
 };
 use binius_field::{
-	BinaryField128bGhash as B128, PackedExtension, PackedField, UnderlierWithBitOps, WithUnderlier,
+	BinaryField128bGhash as B128, PackedExtension, PackedField, UnderlierType, WithUnderlier,
 };
 use binius_hash::binary_merkle_tree::HashSuite;
 use binius_iop_prover::basefold_compiler::BaseFoldZKProverCompiler;
@@ -58,7 +58,7 @@ where
 	P: PackedField<Scalar = B128>
 		+ PackedExtension<B128>
 		+ PackedExtension<binius_verifier::config::B1>
-		+ WithUnderlier<Underlier: UnderlierWithBitOps>,
+		+ WithUnderlier<Underlier: UnderlierType>,
 	H: HashSuite,
 	Output<H::LeafHash>: SerializeBytes,
 {
@@ -231,7 +231,7 @@ where
 	P: PackedField<Scalar = B128>
 		+ PackedExtension<B128>
 		+ PackedExtension<binius_verifier::config::B1>
-		+ WithUnderlier<Underlier: UnderlierWithBitOps>,
+		+ WithUnderlier<Underlier: UnderlierType>,
 	H: HashSuite,
 	Output<H::LeafHash>: SerializeBytes + DeserializeBytes,
 {
@@ -255,7 +255,7 @@ where
 	P: PackedField<Scalar = B128>
 		+ PackedExtension<B128>
 		+ PackedExtension<binius_verifier::config::B1>
-		+ WithUnderlier<Underlier: UnderlierWithBitOps>,
+		+ WithUnderlier<Underlier: UnderlierType>,
 	H: HashSuite,
 	Output<H::LeafHash>: SerializeBytes + DeserializeBytes,
 {


### PR DESCRIPTION
Closes [BINIUS-91](https://linear.app/jimpo/issue/BINIUS-91/merge-underlierwithbitops-into-underliertype)

## Summary

Folds the `UnderlierWithBitOps` trait into `UnderlierType` and removes it. `UnderlierType` now carries the bit-op supertraits (`BitAnd`/`BitOr`/`BitXor`/`Shl`/`Shr`/`Not` + assign variants, `Divisible<U1>`), the `ZERO`/`ONE`/`ONES` constants, and the `interleave`/`transpose`/`from_fn`/`broadcast_subvalue`/`get_subvalue`/`set_subvalue`/`spread` methods.

Every type that implemented `UnderlierWithBitOps` already implemented `UnderlierType`, so this is a pure consolidation. Each impl site merges its two `impl` blocks into one, and the `+ UnderlierWithBitOps` / `WithUnderlier<Underlier: UnderlierWithBitOps>` bound that was threaded through `binius-field` and `binius-prover` call sites collapses to `UnderlierType`. This trims the field crate's public surface — callers name one trait instead of two.

## Notable points

- `underlier_impls.rs`: the `impl_underlier_type!` macro now takes the interleave mask indices per type and generates the full merged impl in one block (replacing the old separate macro + hand-written `UnderlierWithBitOps` impls).
- `small_uint.rs`: the generic `impl<const N> UnderlierType for SmallU<N>` becomes three concrete impls for `U1`/`U2`/`U4`, since `interleave` differs per type and only those three are instantiated.
- `scaled_arithmetic.rs`: two `.square()`/`.invert_or_zero()` calls are now spelled `Square::square(..)` / `InvertOrZero::invert_or_zero(..)` — widening the bound to `UnderlierType` brought the `Tagged*` impls into scope, making the bare method calls ambiguous (E0034). The fully-qualified form preserves the prior resolution (and for `BinaryField1b` the two are equivalent).
- The bit-op helper functions (`spread_fallback`, `SpreadToByte`, `get_block_values`, `get_spread_bytes`, `single_element_mask_bits`) stay in `underlier_with_bit_ops.rs`, rebound to `UnderlierType`. The file keeps its name since it still holds underlier bit-op utilities — happy to rename if preferred.

## Verification

- `cargo test -p binius-field`: green
- `cargo check --target aarch64-unknown-linux-gnu -p binius-field` and `--target wasm32-wasip1`: green (covers the cfg-gated SIMD impls)
- `cargo clippy --all --tests --benches --examples -- -D warnings`: clean
- `cargo +nightly-2026-01-01 fmt`: clean

---

🤖 Generated with [Claude Code](https://claude.ai/claude-code)