### PR TITLE
BINIUS-85: Add Maskable trait for branchless conditional lane masking

### DIFF
--- a/crates/field/src/arch/portable/packed.rs
+++ b/crates/field/src/arch/portable/packed.rs
@@ -22,7 +22,7 @@ use rand::{
 };
 
 use crate::{
-	BinaryField, Divisible, ExtensionField, Field, PackedField, WideMul,
+	BinaryField, Divisible, ExtensionField, Field, Maskable, PackedField, WideMul,
 	arithmetic_traits::{InvertOrZero, Square},
 	field::FieldOps,
 	underlier::{NumCast, UnderlierType, WithUnderlier},
@@ -468,6 +468,34 @@ where
 	#[inline]
 	fn from_iter(iter: impl Iterator<Item = Scalar>) -> Self {
 		<U as Divisible<Scalar::Underlier>>::from_iter(iter.map(Scalar::to_underlier)).into()
+	}
+}
+
+// Lane masking lowers to a single bitwise AND against an all-ones/all-zeros per-lane mask, the same
+// operation the shift protocol previously performed by reaching into the underlier directly.
+impl<U, Scalar> Maskable<Scalar> for PackedPrimitiveType<U, Scalar>
+where
+	U: UnderlierType + Divisible<Scalar::Underlier>,
+	Scalar: BinaryField,
+{
+	type Mask = U;
+
+	#[inline]
+	fn make_mask(selectors: impl Iterator<Item = bool>) -> U {
+		// Build a per-lane all-ones/all-zeros sub-underlier for each scalar slot and pack into U.
+		// A selected lane produces fill_with_bit(1) (every bit set); unselected gives ZERO.
+		<U as Divisible<Scalar::Underlier>>::from_iter(
+			selectors
+				.take(<Self as Divisible<Scalar>>::N)
+				.map(|selected| {
+					<Scalar::Underlier as UnderlierType>::fill_with_bit(u8::from(selected))
+				}),
+		)
+	}
+
+	#[inline]
+	fn select(&self, mask: &U) -> Self {
+		Self::from_underlier(self.to_underlier() & *mask)
 	}
 }
 

--- a/crates/field/src/binary_field.rs
+++ b/crates/field/src/binary_field.rs
@@ -278,6 +278,25 @@ macro_rules! binary_field {
 			}
 		}
 
+		// As a width-one packed field, a field element is masked by its single selector: kept
+		// when selected, otherwise zeroed. Uses the same underlier bitmask strategy as
+		// PackedPrimitiveType so the mask type and AND operation are consistent.
+		impl $crate::Maskable<$name> for $name {
+			type Mask = $typ;
+
+			#[inline]
+			fn make_mask(mut selectors: impl Iterator<Item = bool>) -> $typ {
+				<$typ as $crate::underlier::UnderlierType>::fill_with_bit(
+					u8::from(selectors.next().unwrap_or(false)),
+				)
+			}
+
+			#[inline]
+			fn select(&self, mask: &$typ) -> Self {
+				Self(self.0 & *mask)
+			}
+		}
+
 		impl ::rand::distr::Distribution<$name> for ::rand::distr::StandardUniform {
 			fn sample<R: ::rand::Rng + ?Sized>(&self, rng: &mut R) -> $name {
 				$name(::rand::distr::StandardUniform.sample(rng))

--- a/crates/field/src/field.rs
+++ b/crates/field/src/field.rs
@@ -13,7 +13,7 @@ use bytemuck::Zeroable;
 
 use super::extension::ExtensionField;
 use crate::{
-	Divisible, Random, WideMul,
+	Divisible, Maskable, Random, WideMul,
 	arithmetic_traits::{InvertOrZero, Square},
 };
 
@@ -62,6 +62,9 @@ pub trait Field:
 	// A field is a degenerate packed field of width one, so it divides into a single copy of
 	// itself. This mirrors `PackedField: Divisible<Self::Scalar>` for the blanket packed impl.
 	+ Divisible<Self>
+	// A field is maskable as a width-one packed field, mirroring
+	// `PackedField: Maskable<Self::Scalar>`.
+	+ Maskable<Self>
 {
 	/// The zero element of the field, the additive identity.
 	const ZERO: Self;

--- a/crates/field/src/lib.rs
+++ b/crates/field/src/lib.rs
@@ -50,4 +50,4 @@ pub use packed_extension_ops::*;
 pub use packed_ghash::*;
 pub use random::Random;
 pub use transpose::square_transpose;
-pub use underlier::{Divisible, UnderlierType, WithUnderlier};
+pub use underlier::{Divisible, Maskable, UnderlierType, WithUnderlier};

--- a/crates/field/src/packed.rs
+++ b/crates/field/src/packed.rs
@@ -18,7 +18,7 @@ use binius_utils::{
 use bytemuck::Zeroable;
 
 use super::{PackedExtension, Random, arithmetic_traits::Square};
-use crate::{BinaryField, Divisible, Field, WideMul, field::FieldOps};
+use crate::{BinaryField, Divisible, Field, Maskable, WideMul, field::FieldOps};
 
 /// A packed field represents a vector of underlying field elements.
 ///
@@ -49,6 +49,8 @@ pub trait PackedField:
 	// their `_unchecked` variants), broadcast, and the scalar iterators are all provided by this
 	// supertrait.
 	+ Divisible<Self::Scalar>
+	// A packed field supports branchless per-lane masking over its scalars.
+	+ Maskable<Self::Scalar>
 {
 	/// Base-2 logarithm of the number of field elements packed into one packed element.
 	///

--- a/crates/field/src/underlier/maskable.rs
+++ b/crates/field/src/underlier/maskable.rs
@@ -1,0 +1,44 @@
+// Copyright 2026 The Binius Developers
+
+use bytemuck::Zeroable;
+
+use super::divisible::Divisible;
+
+/// Branchless conditional lane selection for fields and packed fields.
+///
+/// `Maskable<T>` keeps a chosen subset of a value's `T`-lanes and zeroes the rest, against a
+/// precomputed [`Self::Mask`]. It is the high-level, underlier-free primitive behind the branchless
+/// masked accumulation in the shift protocol: a mask is built once with [`make_mask`] and reused
+/// across many [`select`] calls, so the per-call cost is a single bitwise AND on a binary field.
+///
+/// It is a parent trait of [`Field`](crate::Field) (`Maskable<Self>`, a single lane) and
+/// [`PackedField`](crate::PackedField) (`Maskable<Self::Scalar>`, one entry per packed lane),
+/// mirroring how [`Divisible`] is a parent trait of both.
+///
+/// [`make_mask`]: Maskable::make_mask
+/// [`select`]: Maskable::select
+pub trait Maskable<T>: Divisible<T> + Copy + Zeroable {
+	/// A precomputed mask selecting which `T`-lanes [`select`](Maskable::select) keeps.
+	///
+	/// `Send + Sync` so a precomputed mask table can be shared across threads (e.g. a parallel
+	/// fold over a precomputed `Vec<Self::Mask>`).
+	type Mask: Send + Sync;
+
+	/// Builds a mask from per-lane boolean selectors, in LSB-to-MSB lane order (the same ordering
+	/// as [`Divisible`]). Consumes at most [`Divisible::N`] selectors; any lane past the end of the
+	/// iterator, or whose selector is `false`, is not selected.
+	fn make_mask(selectors: impl Iterator<Item = bool>) -> Self::Mask;
+
+	/// Returns a value keeping the lanes selected when `mask` was built and zeroing the rest.
+	///
+	/// For a `mask` built by `Self::make_mask(selectors)`, this equals
+	///
+	/// ```text
+	/// Self::from_iter(zip(self.ref_iter(), selectors)
+	///     .map(|(val, selected)| if selected { val } else { <zero> }))
+	/// ```
+	///
+	/// but branchless: on a binary field each selected lane of the mask is all-ones and each
+	/// unselected lane all-zeros, so this is a single bitwise AND.
+	fn select(&self, mask: &Self::Mask) -> Self;
+}

--- a/crates/field/src/underlier/mod.rs
+++ b/crates/field/src/underlier/mod.rs
@@ -1,6 +1,8 @@
 // Copyright 2024-2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 pub(crate) mod divisible;
+pub(crate) mod maskable;
 mod scaled;
 mod small_uint;
 mod underlier_impls;
@@ -8,6 +10,7 @@ mod underlier_type;
 mod underlier_with_bit_ops;
 
 pub use divisible::*;
+pub use maskable::*;
 pub use scaled::ScaledUnderlier;
 pub use small_uint::*;
 pub use underlier_type::*;

--- a/crates/prover/src/protocols/shift/phase_1.rs
+++ b/crates/prover/src/protocols/shift/phase_1.rs
@@ -3,9 +3,7 @@
 use std::{iter, ops::Range};
 
 use binius_core::word::Word;
-use binius_field::{
-	AESTowerField8b, BinaryField, Field, PackedField, UnderlierType, WithUnderlier,
-};
+use binius_field::{AESTowerField8b, BinaryField, Field, PackedField};
 use binius_ip_prover::channel::IPProverChannel;
 use binius_math::{FieldBuffer, inner_product::inner_product_buffers};
 use binius_utils::rayon::prelude::*;
@@ -45,8 +43,8 @@ pub fn prove_phase_1<F, P, Channel>(
 	channel: &mut Channel,
 ) -> Result<SumcheckOutput<F>, Error>
 where
-	F: BinaryField + From<AESTowerField8b> + WithUnderlier<Underlier: UnderlierType>,
-	P: PackedField<Scalar = F> + WithUnderlier<Underlier: UnderlierType>,
+	F: BinaryField + From<AESTowerField8b>,
+	P: PackedField<Scalar = F>,
 	Channel: IPProverChannel<F>,
 {
 	let g_parts = build_g_parts::<_, P>(words, key_collection, bitand_data, intmul_data)?;
@@ -168,10 +166,7 @@ fn run_phase_1_sumcheck<F: Field, P: PackedField<Scalar = F>, Channel: IPProverC
 /// Used in phase 1 to construct the constant size g multilinears
 /// that will participate in the phase 1 sumcheck protocol.
 #[instrument(skip_all, name = "build_g_parts")]
-fn build_g_parts<
-	F: BinaryField + WithUnderlier<Underlier: UnderlierType>,
-	P: PackedField<Scalar = F> + WithUnderlier<Underlier: UnderlierType>,
->(
+fn build_g_parts<F: BinaryField, P: PackedField<Scalar = F>>(
 	words: &[Word],
 	key_collection: &KeyCollection,
 	bitand_operator_data: &PreparedOperatorData<F>,
@@ -184,20 +179,10 @@ fn build_g_parts<
 		"the optimizations below work only when the width of `P` is less than 8 (which is true for all packed 128b fields we use for now)"
 	);
 
-	// Field element that is represented by all ones
-	let all_ones_f = F::from_underlier(UnderlierType::fill_with_bit(1));
-	// Map from u8 with `P::WIDTH` meaningful bits to the `P` where each element has
-	// all zeroes or all ones depending on the corresponding bit value.
+	// Map from a u8 with `P::WIDTH` meaningful bits to the lane mask selecting exactly those lanes,
+	// precomputed once and reused across every accumulator below.
 	let packed_masks_map = (0..1 << P::WIDTH)
-		.map(|i| {
-			let mut mask = P::zero();
-			for bit_index in 0..P::WIDTH {
-				if (i >> bit_index) & 1 == 1 {
-					mask.set(bit_index, all_ones_f);
-				}
-			}
-			mask.to_underlier()
-		})
+		.map(|i| P::make_mask((0..P::WIDTH).map(|bit_index| (i >> bit_index) & 1 == 1)))
 		.collect::<Vec<_>>();
 	// A mask for low `P::WIDTH` bits.
 	let low_bits_mask = (1u8 << P::WIDTH) - 1;
@@ -217,7 +202,7 @@ fn build_g_parts<
 					};
 
 					let acc = key.accumulate(&key_collection.constraint_indices, operator_data);
-					let acc_underlier = P::broadcast(acc).to_underlier();
+					let acc_packed = P::broadcast(acc);
 
 					// The following loop is an optimized version of the following
 					// for i in 0..WORD_SIZE_BITS {
@@ -239,8 +224,7 @@ fn build_g_parts<
 								// Safety:
 								// - `packed_masks_map` is guaranteed to have enough elements to be
 								//   indexed with a `P::WIDTH`-bits value.
-								let packed_mask =
-									*packed_masks_map.get_unchecked(packed_mask_index);
+								let packed_mask = packed_masks_map.get_unchecked(packed_mask_index);
 
 								// Safety:
 								// - `values` is guaranteed to be (8 >> P::LOG_WIDTH) elements long
@@ -248,7 +232,7 @@ fn build_g_parts<
 								// - `value_index` is always in bounds because we iterate over 0..(8
 								//   >> P::LOG_WIDTH)
 								*values.get_unchecked_mut(value_index) +=
-									P::from_underlier(packed_mask & acc_underlier);
+									acc_packed.select(packed_mask);
 							}
 						}
 					}

--- a/crates/prover/src/protocols/shift/prove.rs
+++ b/crates/prover/src/protocols/shift/prove.rs
@@ -1,9 +1,7 @@
 // Copyright 2025 Irreducible Inc.
 
 use binius_core::word::Word;
-use binius_field::{
-	AESTowerField8b, BinaryField, Field, PackedField, UnderlierType, WithUnderlier, util::powers,
-};
+use binius_field::{AESTowerField8b, BinaryField, Field, PackedField, util::powers};
 use binius_ip_prover::channel::IPProverChannel;
 use binius_math::{
 	FieldBuffer, inner_product::inner_product, multilinear::eq::eq_ind_partial_eval,
@@ -104,8 +102,8 @@ pub fn prove<F, P, Channel>(
 	channel: &mut Channel,
 ) -> Result<SumcheckOutput<F>, Error>
 where
-	F: BinaryField + From<AESTowerField8b> + WithUnderlier<Underlier: UnderlierType>,
-	P: PackedField<Scalar = F> + WithUnderlier<Underlier: UnderlierType>,
+	F: BinaryField + From<AESTowerField8b>,
+	P: PackedField<Scalar = F>,
 	Channel: IPProverChannel<F>,
 {
 	// Sample lambdas, one for each operator.

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -7,7 +7,7 @@ use binius_core::{
 };
 use binius_field::{
 	AESTowerField8b as B8, BinaryField, ExtensionField, PackedAESBinaryField16x8b, PackedExtension,
-	PackedField, UnderlierType, WithUnderlier,
+	PackedField,
 };
 use binius_hash::binary_merkle_tree::HashSuite;
 use binius_iop_prover::{
@@ -96,10 +96,7 @@ impl IOPProver {
 	/// For most users, [`Prover::prove`] is the simpler interface.
 	pub fn prove<P, Channel>(&self, witness: ValueVec, mut channel: Channel) -> Result<(), Error>
 	where
-		P: PackedField<Scalar = B128>
-			+ PackedExtension<B128>
-			+ PackedExtension<B1>
-			+ WithUnderlier<Underlier: UnderlierType>,
+		P: PackedField<Scalar = B128> + PackedExtension<B128> + PackedExtension<B1>,
 		Channel: IOPProverChannel<P>,
 	{
 		let cs = &self.constraint_system;
@@ -270,10 +267,7 @@ where
 
 impl<P, H> Prover<P, H>
 where
-	P: PackedField<Scalar = B128>
-		+ PackedExtension<B128>
-		+ PackedExtension<B1>
-		+ WithUnderlier<Underlier: UnderlierType>,
+	P: PackedField<Scalar = B128> + PackedExtension<B128> + PackedExtension<B1>,
 	H: HashSuite,
 	Output<H::LeafHash>: SerializeBytes,
 {

--- a/crates/prover/src/zk_config.rs
+++ b/crates/prover/src/zk_config.rs
@@ -10,9 +10,7 @@ use binius_core::{
 	constraint_system::{ConstraintSystem, ValueVec},
 	word::Word,
 };
-use binius_field::{
-	BinaryField128bGhash as B128, PackedExtension, PackedField, UnderlierType, WithUnderlier,
-};
+use binius_field::{BinaryField128bGhash as B128, PackedExtension, PackedField};
 use binius_hash::binary_merkle_tree::HashSuite;
 use binius_iop_prover::basefold_compiler::BaseFoldZKProverCompiler;
 use binius_math::ntt::{NeighborsLastMultiThread, domain_context::GenericPreExpanded};
@@ -57,8 +55,7 @@ impl<P, H> ZKProver<P, H>
 where
 	P: PackedField<Scalar = B128>
 		+ PackedExtension<B128>
-		+ PackedExtension<binius_verifier::config::B1>
-		+ WithUnderlier<Underlier: UnderlierType>,
+		+ PackedExtension<binius_verifier::config::B1>,
 	H: HashSuite,
 	Output<H::LeafHash>: SerializeBytes,
 {
@@ -230,8 +227,7 @@ impl<P, H> SerializeBytes for ZKProver<P, H>
 where
 	P: PackedField<Scalar = B128>
 		+ PackedExtension<B128>
-		+ PackedExtension<binius_verifier::config::B1>
-		+ WithUnderlier<Underlier: UnderlierType>,
+		+ PackedExtension<binius_verifier::config::B1>,
 	H: HashSuite,
 	Output<H::LeafHash>: SerializeBytes + DeserializeBytes,
 {
@@ -254,8 +250,7 @@ impl<P, H> DeserializeBytes for ZKProver<P, H>
 where
 	P: PackedField<Scalar = B128>
 		+ PackedExtension<B128>
-		+ PackedExtension<binius_verifier::config::B1>
-		+ WithUnderlier<Underlier: UnderlierType>,
+		+ PackedExtension<binius_verifier::config::B1>,
 	H: HashSuite,
 	Output<H::LeafHash>: SerializeBytes + DeserializeBytes,
 {


### PR DESCRIPTION
Closes BINIUS-85.

## Summary

Adds a `Maskable<T>` trait to the field crate and migrates the shift protocol's branchless masking off direct underlier access.

**New trait** (`crates/field/src/underlier/maskable.rs`):
```rust
pub trait Maskable<T>: Divisible<T> + Copy + Zeroable {
    type Mask: Send + Sync;
    fn make_mask(selectors: impl Iterator<Item = bool>) -> Self::Mask;
    fn select(&self, mask: &Self::Mask) -> Self;
}
```
`Maskable<T>` is now a parent trait of both `Field` (as `Maskable<Self>`) and `PackedField` (as `Maskable<Self::Scalar>`), mirroring the existing `Divisible` pattern.

**Implementations:**
- `BinaryField` types via the `binary_field!` macro: `Mask = $typ` (the underlier integer), `make_mask` uses `fill_with_bit(0/1)`, `select` is `Self(self.0 & *mask)` — same AND-with-bitmask strategy as `PackedPrimitiveType`.
- `PackedPrimitiveType<U, Scalar>`: `Mask = U` (the packed underlier), `make_mask` uses `<U as Divisible<Scalar::Underlier>>::from_iter(selectors.map(|s| fill_with_bit(u8::from(s))))`, `select` is a single bitwise AND — `from_underlier(self.to_underlier() & *mask)`.

The `Send + Sync` bound on `Mask` (beyond jimpo's sketch) is needed so a precomputed `Vec<Self::Mask>` mask table can be shared across rayon threads.

**Prover migration** (`crates/prover/src/protocols/shift/phase_1.rs`):
- Precomputes the mask table via `make_mask` and accumulates with `select`, replacing manual underlier bit manipulation.
- Drops `WithUnderlier` bounds from `phase_1.rs`, `shift/prove.rs`, `prover/src/prove.rs`, and `prover/src/zk_config.rs` (3 impl sites) — the direct underlier access is now fully encapsulated in `Maskable`.

## Performance

Measured on the `shift_reduction` benchmark (log2_size=12, sequential, `RUSTFLAGS="-C target-cpu=native"`):

| | Median | Range |
|---|---|---|
| `main` (8884039d) | 86.8 ms | 82–95 ms (noisy) |
| this branch | 77.2 ms | 76–79 ms |

The branch is within noise — the codegen is identical (`select` lowers to `from_underlier(acc & mask)`, same precomputed table as before). The ~11% difference is measurement noise on a loaded machine; do not read it as a speedup claim.

---

🤖 Generated with [Claude Code](https://claude.ai/claude-code)