### PR TITLE
BINIUS-88: remove Copy supertrait from Divisible&lt;T&gt;

### DIFF
--- a/crates/field/src/arch/aarch64/m128.rs
+++ b/crates/field/src/arch/aarch64/m128.rs
@@ -235,8 +235,8 @@ impl Divisible<u128> for M128 {
 	}
 
 	#[inline]
-	unsafe fn get_unchecked(self, _index: usize) -> u128 {
-		self.into()
+	unsafe fn get_unchecked(&self, _index: usize) -> u128 {
+		(*self).into()
 	}
 
 	#[inline]
@@ -274,7 +274,7 @@ impl Divisible<u64> for M128 {
 	}
 
 	#[inline]
-	unsafe fn get_unchecked(self, index: usize) -> u64 {
+	unsafe fn get_unchecked(&self, index: usize) -> u64 {
 		unsafe {
 			match index {
 				0 => vgetq_lane_u64(self.0, 0),
@@ -330,9 +330,9 @@ impl Divisible<u32> for M128 {
 	}
 
 	#[inline]
-	unsafe fn get_unchecked(self, index: usize) -> u32 {
+	unsafe fn get_unchecked(&self, index: usize) -> u32 {
 		unsafe {
-			let v: uint32x4_t = self.into();
+			let v: uint32x4_t = (*self).into();
 			match index {
 				0 => vgetq_lane_u32(v, 0),
 				1 => vgetq_lane_u32(v, 1),
@@ -392,9 +392,9 @@ impl Divisible<u16> for M128 {
 	}
 
 	#[inline]
-	unsafe fn get_unchecked(self, index: usize) -> u16 {
+	unsafe fn get_unchecked(&self, index: usize) -> u16 {
 		unsafe {
-			let v: uint16x8_t = self.into();
+			let v: uint16x8_t = (*self).into();
 			match index {
 				0 => vgetq_lane_u16(v, 0),
 				1 => vgetq_lane_u16(v, 1),
@@ -462,9 +462,9 @@ impl Divisible<u8> for M128 {
 	}
 
 	#[inline]
-	unsafe fn get_unchecked(self, index: usize) -> u8 {
+	unsafe fn get_unchecked(&self, index: usize) -> u8 {
 		unsafe {
-			let v: uint8x16_t = self.into();
+			let v: uint8x16_t = (*self).into();
 			match index {
 				0 => vgetq_lane_u8(v, 0),
 				1 => vgetq_lane_u8(v, 1),

--- a/crates/field/src/arch/portable/packed.rs
+++ b/crates/field/src/arch/portable/packed.rs
@@ -441,10 +441,10 @@ where
 	}
 
 	#[inline]
-	unsafe fn get_unchecked(self, index: usize) -> Scalar {
+	unsafe fn get_unchecked(&self, index: usize) -> Scalar {
 		// Safety: `index < Self::N` by the caller's contract.
 		Scalar::from_underlier(unsafe {
-			Divisible::<Scalar::Underlier>::get_unchecked(self.0, index)
+			Divisible::<Scalar::Underlier>::get_unchecked(&self.0, index)
 		})
 	}
 

--- a/crates/field/src/arch/x86_64/m128.rs
+++ b/crates/field/src/arch/x86_64/m128.rs
@@ -701,8 +701,8 @@ impl Divisible<u128> for M128 {
 	}
 
 	#[inline]
-	unsafe fn get_unchecked(self, _index: usize) -> u128 {
-		u128::from(self)
+	unsafe fn get_unchecked(&self, _index: usize) -> u128 {
+		u128::from(*self)
 	}
 
 	#[inline]
@@ -740,7 +740,7 @@ impl Divisible<u64> for M128 {
 	}
 
 	#[inline]
-	unsafe fn get_unchecked(self, index: usize) -> u64 {
+	unsafe fn get_unchecked(&self, index: usize) -> u64 {
 		unsafe {
 			match index {
 				0 => _mm_extract_epi64(self.0, 0) as u64,
@@ -796,7 +796,7 @@ impl Divisible<u32> for M128 {
 	}
 
 	#[inline]
-	unsafe fn get_unchecked(self, index: usize) -> u32 {
+	unsafe fn get_unchecked(&self, index: usize) -> u32 {
 		unsafe {
 			match index {
 				0 => _mm_extract_epi32(self.0, 0) as u32,
@@ -856,7 +856,7 @@ impl Divisible<u16> for M128 {
 	}
 
 	#[inline]
-	unsafe fn get_unchecked(self, index: usize) -> u16 {
+	unsafe fn get_unchecked(&self, index: usize) -> u16 {
 		unsafe {
 			match index {
 				0 => _mm_extract_epi16(self.0, 0) as u16,
@@ -924,7 +924,7 @@ impl Divisible<u8> for M128 {
 	}
 
 	#[inline]
-	unsafe fn get_unchecked(self, index: usize) -> u8 {
+	unsafe fn get_unchecked(&self, index: usize) -> u8 {
 		unsafe {
 			match index {
 				0 => _mm_extract_epi8(self.0, 0) as u8,

--- a/crates/field/src/arch/x86_64/m256.rs
+++ b/crates/field/src/arch/x86_64/m256.rs
@@ -869,7 +869,7 @@ impl Divisible<M128> for M256 {
 	}
 
 	#[inline]
-	unsafe fn get_unchecked(self, index: usize) -> M128 {
+	unsafe fn get_unchecked(&self, index: usize) -> M128 {
 		unsafe {
 			match index {
 				0 => M128(_mm256_extracti128_si256(self.0, 0)),
@@ -925,7 +925,7 @@ impl Divisible<u128> for M256 {
 	}
 
 	#[inline]
-	unsafe fn get_unchecked(self, index: usize) -> u128 {
+	unsafe fn get_unchecked(&self, index: usize) -> u128 {
 		// Safety: `index < Self::N` by the caller's contract.
 		u128::from(unsafe { Divisible::<M128>::get_unchecked(self, index) })
 	}
@@ -971,7 +971,7 @@ impl Divisible<u64> for M256 {
 	}
 
 	#[inline]
-	unsafe fn get_unchecked(self, index: usize) -> u64 {
+	unsafe fn get_unchecked(&self, index: usize) -> u64 {
 		unsafe {
 			match index {
 				0 => _mm256_extract_epi64(self.0, 0) as u64,
@@ -1031,7 +1031,7 @@ impl Divisible<u32> for M256 {
 	}
 
 	#[inline]
-	unsafe fn get_unchecked(self, index: usize) -> u32 {
+	unsafe fn get_unchecked(&self, index: usize) -> u32 {
 		unsafe {
 			match index {
 				0 => _mm256_extract_epi32(self.0, 0) as u32,
@@ -1099,7 +1099,7 @@ impl Divisible<u16> for M256 {
 	}
 
 	#[inline]
-	unsafe fn get_unchecked(self, index: usize) -> u16 {
+	unsafe fn get_unchecked(&self, index: usize) -> u16 {
 		unsafe {
 			match index {
 				0 => _mm256_extract_epi16(self.0, 0) as u16,
@@ -1183,7 +1183,7 @@ impl Divisible<u8> for M256 {
 	}
 
 	#[inline]
-	unsafe fn get_unchecked(self, index: usize) -> u8 {
+	unsafe fn get_unchecked(&self, index: usize) -> u8 {
 		unsafe {
 			match index {
 				0 => _mm256_extract_epi8(self.0, 0) as u8,

--- a/crates/field/src/arch/x86_64/m512.rs
+++ b/crates/field/src/arch/x86_64/m512.rs
@@ -881,7 +881,7 @@ impl Divisible<M256> for M512 {
 	}
 
 	#[inline]
-	unsafe fn get_unchecked(self, index: usize) -> M256 {
+	unsafe fn get_unchecked(&self, index: usize) -> M256 {
 		unsafe {
 			match index {
 				0 => M256(_mm512_extracti64x4_epi64(self.0, 0)),
@@ -937,7 +937,7 @@ impl Divisible<M128> for M512 {
 	}
 
 	#[inline]
-	unsafe fn get_unchecked(self, index: usize) -> M128 {
+	unsafe fn get_unchecked(&self, index: usize) -> M128 {
 		unsafe {
 			match index {
 				0 => M128(_mm512_extracti32x4_epi32(self.0, 0)),
@@ -997,7 +997,7 @@ impl Divisible<u128> for M512 {
 	}
 
 	#[inline]
-	unsafe fn get_unchecked(self, index: usize) -> u128 {
+	unsafe fn get_unchecked(&self, index: usize) -> u128 {
 		// Safety: `index < Self::N` by the caller's contract.
 		u128::from(unsafe { Divisible::<M128>::get_unchecked(self, index) })
 	}
@@ -1043,7 +1043,7 @@ impl Divisible<u64> for M512 {
 	}
 
 	#[inline]
-	unsafe fn get_unchecked(self, index: usize) -> u64 {
+	unsafe fn get_unchecked(&self, index: usize) -> u64 {
 		// Extract M128 lane, then use M128's get
 		let lane_idx = index / 2;
 		let sub_idx = index % 2;
@@ -1051,7 +1051,7 @@ impl Divisible<u64> for M512 {
 		// in bounds.
 		unsafe {
 			let lane = Divisible::<M128>::get_unchecked(self, lane_idx);
-			Divisible::<u64>::get_unchecked(lane, sub_idx)
+			Divisible::<u64>::get_unchecked(&lane, sub_idx)
 		}
 	}
 
@@ -1062,7 +1062,7 @@ impl Divisible<u64> for M512 {
 		// Safety: `index < Self::N` by the caller's contract, so `lane_idx` and `sub_idx` are
 		// in bounds.
 		unsafe {
-			let mut lane = Divisible::<M128>::get_unchecked(*self, lane_idx);
+			let mut lane = Divisible::<M128>::get_unchecked(&*self, lane_idx);
 			Divisible::<u64>::set_unchecked(&mut lane, sub_idx, val);
 			Divisible::<M128>::set_unchecked(self, lane_idx, lane);
 		}
@@ -1103,7 +1103,7 @@ impl Divisible<u32> for M512 {
 	}
 
 	#[inline]
-	unsafe fn get_unchecked(self, index: usize) -> u32 {
+	unsafe fn get_unchecked(&self, index: usize) -> u32 {
 		// Extract M128 lane, then use M128's get
 		let lane_idx = index / 4;
 		let sub_idx = index % 4;
@@ -1111,7 +1111,7 @@ impl Divisible<u32> for M512 {
 		// in bounds.
 		unsafe {
 			let lane = Divisible::<M128>::get_unchecked(self, lane_idx);
-			Divisible::<u32>::get_unchecked(lane, sub_idx)
+			Divisible::<u32>::get_unchecked(&lane, sub_idx)
 		}
 	}
 
@@ -1122,7 +1122,7 @@ impl Divisible<u32> for M512 {
 		// Safety: `index < Self::N` by the caller's contract, so `lane_idx` and `sub_idx` are
 		// in bounds.
 		unsafe {
-			let mut lane = Divisible::<M128>::get_unchecked(*self, lane_idx);
+			let mut lane = Divisible::<M128>::get_unchecked(&*self, lane_idx);
 			Divisible::<u32>::set_unchecked(&mut lane, sub_idx, val);
 			Divisible::<M128>::set_unchecked(self, lane_idx, lane);
 		}
@@ -1163,7 +1163,7 @@ impl Divisible<u16> for M512 {
 	}
 
 	#[inline]
-	unsafe fn get_unchecked(self, index: usize) -> u16 {
+	unsafe fn get_unchecked(&self, index: usize) -> u16 {
 		// Extract M128 lane, then use M128's get
 		let lane_idx = index / 8;
 		let sub_idx = index % 8;
@@ -1171,7 +1171,7 @@ impl Divisible<u16> for M512 {
 		// in bounds.
 		unsafe {
 			let lane = Divisible::<M128>::get_unchecked(self, lane_idx);
-			Divisible::<u16>::get_unchecked(lane, sub_idx)
+			Divisible::<u16>::get_unchecked(&lane, sub_idx)
 		}
 	}
 
@@ -1182,7 +1182,7 @@ impl Divisible<u16> for M512 {
 		// Safety: `index < Self::N` by the caller's contract, so `lane_idx` and `sub_idx` are
 		// in bounds.
 		unsafe {
-			let mut lane = Divisible::<M128>::get_unchecked(*self, lane_idx);
+			let mut lane = Divisible::<M128>::get_unchecked(&*self, lane_idx);
 			Divisible::<u16>::set_unchecked(&mut lane, sub_idx, val);
 			Divisible::<M128>::set_unchecked(self, lane_idx, lane);
 		}
@@ -1223,7 +1223,7 @@ impl Divisible<u8> for M512 {
 	}
 
 	#[inline]
-	unsafe fn get_unchecked(self, index: usize) -> u8 {
+	unsafe fn get_unchecked(&self, index: usize) -> u8 {
 		// Extract M128 lane, then use M128's get
 		let lane_idx = index / 16;
 		let sub_idx = index % 16;
@@ -1231,7 +1231,7 @@ impl Divisible<u8> for M512 {
 		// in bounds.
 		unsafe {
 			let lane = Divisible::<M128>::get_unchecked(self, lane_idx);
-			Divisible::<u8>::get_unchecked(lane, sub_idx)
+			Divisible::<u8>::get_unchecked(&lane, sub_idx)
 		}
 	}
 
@@ -1242,7 +1242,7 @@ impl Divisible<u8> for M512 {
 		// Safety: `index < Self::N` by the caller's contract, so `lane_idx` and `sub_idx` are
 		// in bounds.
 		unsafe {
-			let mut lane = Divisible::<M128>::get_unchecked(*self, lane_idx);
+			let mut lane = Divisible::<M128>::get_unchecked(&*self, lane_idx);
 			Divisible::<u8>::set_unchecked(&mut lane, sub_idx, val);
 			Divisible::<M128>::set_unchecked(self, lane_idx, lane);
 		}

--- a/crates/field/src/binary_field.rs
+++ b/crates/field/src/binary_field.rs
@@ -258,8 +258,8 @@ macro_rules! binary_field {
 			}
 
 			#[inline]
-			unsafe fn get_unchecked(self, _index: usize) -> $name {
-				self
+			unsafe fn get_unchecked(&self, _index: usize) -> $name {
+				*self
 			}
 
 			#[inline]

--- a/crates/field/src/underlier/divisible.rs
+++ b/crates/field/src/underlier/divisible.rs
@@ -19,7 +19,7 @@ use std::mem::size_of;
 /// This abstraction allows code to work with subdivided underliers in a platform-independent way
 /// while maintaining the invariant that the first element always represents the least significant
 /// portion of the value.
-pub trait Divisible<T>: Copy {
+pub trait Divisible<T>: Sized {
 	/// The log2 of the number of `T` elements that fit in `Self`.
 	const LOG_N: usize;
 
@@ -41,7 +41,7 @@ pub trait Divisible<T>: Copy {
 	///
 	/// Panics if `index >= Self::N`.
 	#[inline]
-	fn get(self, index: usize) -> T {
+	fn get(&self, index: usize) -> T {
 		assert!(index < Self::N, "index {index} out of bounds (N = {})", Self::N);
 		// Safety: `index < Self::N` checked above.
 		unsafe { self.get_unchecked(index) }
@@ -64,7 +64,7 @@ pub trait Divisible<T>: Copy {
 	/// # Safety
 	///
 	/// The caller must ensure that `index < Self::N`.
-	unsafe fn get_unchecked(self, index: usize) -> T;
+	unsafe fn get_unchecked(&self, index: usize) -> T;
 
 	/// Set element at index (LSB-first ordering) in place, without bounds checking.
 	///
@@ -323,7 +323,7 @@ pub mod bitmask {
 		let byte_index = index / elems_per_byte;
 		let sub_index = index % elems_per_byte;
 		// Safety: `index < Big::N` over `SmallU<BITS>` implies `byte_index < Big::N` over `u8`.
-		let byte = unsafe { Divisible::<u8>::get_unchecked(value, byte_index) };
+		let byte = unsafe { Divisible::<u8>::get_unchecked(&value, byte_index) };
 		let shift = sub_index * BITS;
 		SmallU::<BITS>::new(byte >> shift)
 	}
@@ -347,7 +347,7 @@ pub mod bitmask {
 		let byte_index = index / elems_per_byte;
 		let sub_index = index % elems_per_byte;
 		// Safety: `index < Big::N` over `SmallU<BITS>` implies `byte_index < Big::N` over `u8`.
-		let byte = unsafe { Divisible::<u8>::get_unchecked(value, byte_index) };
+		let byte = unsafe { Divisible::<u8>::get_unchecked(&value, byte_index) };
 		let shift = sub_index * BITS;
 		let mask = (1u8 << BITS) - 1;
 		let new_byte = (byte & !(mask << shift)) | (val.val() << shift);
@@ -370,10 +370,10 @@ pub mod mapget {
 	#[inline]
 	pub fn value_iter<Big, Small>(value: Big) -> impl ExactSizeIterator<Item = Small> + Send + Clone
 	where
-		Big: Divisible<Small> + Send,
+		Big: Divisible<Small> + Send + Clone,
 		Small: Send,
 	{
-		(0..Big::N).map_skippable(move |i| Divisible::<Small>::get(value, i))
+		(0..Big::N).map_skippable(move |i| Divisible::<Small>::get(&value, i))
 	}
 
 	/// Create a slice iterator by computing global index and using get.
@@ -389,7 +389,7 @@ pub mod mapget {
 		(0..total).map_skippable(move |global_idx| {
 			let elem_idx = global_idx / Big::N;
 			let sub_idx = global_idx % Big::N;
-			Divisible::<Small>::get(slice[elem_idx], sub_idx)
+			Divisible::<Small>::get(&slice[elem_idx], sub_idx)
 		})
 	}
 }
@@ -487,10 +487,10 @@ macro_rules! impl_divisible_memcast {
 				}
 
 				#[inline]
-				unsafe fn get_unchecked(self, index: usize) -> $small {
+				unsafe fn get_unchecked(&self, index: usize) -> $small {
 					const N: usize = size_of::<$big>() / size_of::<$small>();
 					// Safety: the caller guarantees `index < Self::N == N`.
-					unsafe { $crate::underlier::memcast::get::<$big, $small, N>(&self, index) }
+					unsafe { $crate::underlier::memcast::get::<$big, $small, N>(self, index) }
 				}
 
 				#[inline]
@@ -546,9 +546,9 @@ macro_rules! impl_divisible_bitmask {
 				}
 
 				#[inline]
-				unsafe fn get_unchecked(self, index: usize) -> $crate::underlier::SmallU<$bits> {
+				unsafe fn get_unchecked(&self, index: usize) -> $crate::underlier::SmallU<$bits> {
 					let shift = index * $bits;
-					$crate::underlier::SmallU::<$bits>::new(self >> shift)
+					$crate::underlier::SmallU::<$bits>::new(*self >> shift)
 				}
 
 				#[inline]
@@ -616,9 +616,9 @@ macro_rules! impl_divisible_bitmask {
 				}
 
 				#[inline]
-				unsafe fn get_unchecked(self, index: usize) -> $crate::underlier::SmallU<$bits> {
+				unsafe fn get_unchecked(&self, index: usize) -> $crate::underlier::SmallU<$bits> {
 					// Safety: the caller guarantees `index < Self::N`.
-					unsafe { $crate::underlier::bitmask::get::<Self, $bits>(self, index) }
+					unsafe { $crate::underlier::bitmask::get::<Self, $bits>(*self, index) }
 				}
 
 				#[inline]
@@ -686,7 +686,7 @@ impl Divisible<SmallU<1>> for SmallU<2> {
 	}
 
 	#[inline]
-	unsafe fn get_unchecked(self, index: usize) -> SmallU<1> {
+	unsafe fn get_unchecked(&self, index: usize) -> SmallU<1> {
 		SmallU::<1>::new(self.val() >> index)
 	}
 
@@ -734,7 +734,7 @@ impl Divisible<SmallU<1>> for SmallU<4> {
 	}
 
 	#[inline]
-	unsafe fn get_unchecked(self, index: usize) -> SmallU<1> {
+	unsafe fn get_unchecked(&self, index: usize) -> SmallU<1> {
 		SmallU::<1>::new(self.val() >> index)
 	}
 
@@ -784,7 +784,7 @@ impl Divisible<SmallU<2>> for SmallU<4> {
 	}
 
 	#[inline]
-	unsafe fn get_unchecked(self, index: usize) -> SmallU<2> {
+	unsafe fn get_unchecked(&self, index: usize) -> SmallU<2> {
 		SmallU::<2>::new(self.val() >> (index * 2))
 	}
 
@@ -837,8 +837,8 @@ macro_rules! impl_divisible_self {
 				}
 
 				#[inline]
-				unsafe fn get_unchecked(self, _index: usize) -> $ty {
-					self
+				unsafe fn get_unchecked(&self, _index: usize) -> $ty {
+					*self
 				}
 
 				#[inline]
@@ -872,8 +872,8 @@ mod tests {
 		let val: u8 = 0x34;
 
 		// Test get - LSB first: nibbles
-		assert_eq!(Divisible::<U4>::get(val, 0), U4::new(0x4));
-		assert_eq!(Divisible::<U4>::get(val, 1), U4::new(0x3));
+		assert_eq!(Divisible::<U4>::get(&val, 0), U4::new(0x4));
+		assert_eq!(Divisible::<U4>::get(&val, 1), U4::new(0x3));
 
 		// Test set
 		let mut modified = val;
@@ -910,10 +910,10 @@ mod tests {
 		let val: u16 = 0x1234;
 
 		// Test get - LSB first: nibbles
-		assert_eq!(Divisible::<U4>::get(val, 0), U4::new(0x4));
-		assert_eq!(Divisible::<U4>::get(val, 1), U4::new(0x3));
-		assert_eq!(Divisible::<U4>::get(val, 2), U4::new(0x2));
-		assert_eq!(Divisible::<U4>::get(val, 3), U4::new(0x1));
+		assert_eq!(Divisible::<U4>::get(&val, 0), U4::new(0x4));
+		assert_eq!(Divisible::<U4>::get(&val, 1), U4::new(0x3));
+		assert_eq!(Divisible::<U4>::get(&val, 2), U4::new(0x2));
+		assert_eq!(Divisible::<U4>::get(&val, 3), U4::new(0x1));
 
 		// Test set
 		let mut modified = val;
@@ -933,9 +933,9 @@ mod tests {
 		let val: u16 = 0b1011001011010011;
 
 		// Test get - LSB first: 2-bit chunks
-		assert_eq!(Divisible::<U2>::get(val, 0), U2::new(0b11)); // bits 0-1
-		assert_eq!(Divisible::<U2>::get(val, 1), U2::new(0b00)); // bits 2-3
-		assert_eq!(Divisible::<U2>::get(val, 7), U2::new(0b10)); // bits 14-15
+		assert_eq!(Divisible::<U2>::get(&val, 0), U2::new(0b11)); // bits 0-1
+		assert_eq!(Divisible::<U2>::get(&val, 1), U2::new(0b00)); // bits 2-3
+		assert_eq!(Divisible::<U2>::get(&val, 7), U2::new(0b10)); // bits 14-15
 
 		// Test ref_iter
 		let parts: Vec<U2> = Divisible::<U2>::ref_iter(&val).collect();
@@ -950,9 +950,9 @@ mod tests {
 		let val: u16 = 0b1010110000110101;
 
 		// Test get - LSB first: individual bits
-		assert_eq!(Divisible::<U1>::get(val, 0), U1::new(1)); // bit 0
-		assert_eq!(Divisible::<U1>::get(val, 1), U1::new(0)); // bit 1
-		assert_eq!(Divisible::<U1>::get(val, 15), U1::new(1)); // bit 15
+		assert_eq!(Divisible::<U1>::get(&val, 0), U1::new(1)); // bit 0
+		assert_eq!(Divisible::<U1>::get(&val, 1), U1::new(0)); // bit 1
+		assert_eq!(Divisible::<U1>::get(&val, 15), U1::new(1)); // bit 15
 
 		// Test set
 		let mut modified = val;
@@ -971,9 +971,9 @@ mod tests {
 		let val: u64 = 0x123456789ABCDEF0;
 
 		// Test get - LSB first: nibbles
-		assert_eq!(Divisible::<U4>::get(val, 0), U4::new(0x0));
-		assert_eq!(Divisible::<U4>::get(val, 1), U4::new(0xF));
-		assert_eq!(Divisible::<U4>::get(val, 15), U4::new(0x1));
+		assert_eq!(Divisible::<U4>::get(&val, 0), U4::new(0x0));
+		assert_eq!(Divisible::<U4>::get(&val, 1), U4::new(0xF));
+		assert_eq!(Divisible::<U4>::get(&val, 15), U4::new(0x1));
 
 		// Test ref_iter
 		let parts: Vec<U4> = Divisible::<U4>::ref_iter(&val).collect();

--- a/crates/field/src/underlier/scaled.rs
+++ b/crates/field/src/underlier/scaled.rs
@@ -231,12 +231,12 @@ where
 	}
 
 	#[inline]
-	unsafe fn get_unchecked(self, index: usize) -> T {
+	unsafe fn get_unchecked(&self, index: usize) -> T {
 		let u_index = index >> <U as Divisible<T>>::LOG_N;
 		let sub_index = index & (<U as Divisible<T>>::N - 1);
 		// Safety: `index < Self::N` by the caller's contract, so `sub_index < <U as
 		// Divisible<T>>::N` and `u_index < N`.
-		unsafe { Divisible::<T>::get_unchecked(*self.0.get_unchecked(u_index), sub_index) }
+		unsafe { Divisible::<T>::get_unchecked(self.0.get_unchecked(u_index), sub_index) }
 	}
 
 	#[inline]

--- a/crates/field/src/underlier/underlier_type.rs
+++ b/crates/field/src/underlier/underlier_type.rs
@@ -105,7 +105,7 @@ pub trait UnderlierType:
 			Self::BITS,
 			T::BITS
 		);
-		Divisible::<T>::get(*self, i)
+		Divisible::<T>::get(self, i)
 	}
 
 	/// Sets the subvalue in the given position.


### PR DESCRIPTION
Resolves [BINIUS-88](https://linear.app/jimpo/issue/BINIUS-88/remove-copy-supertrait-from-divisiblet).

## What this does

Drops the `Copy` supertrait from `Divisible<T>`. The bound wasn't necessary — the only thing that required `Self: Copy` was that `get`/`get_unchecked` took `self` by value. Per the issue's suggestion, those now take `&self`, and the supertrait is relaxed to the minimal `Sized` (still needed because `broadcast`/`from_iter` return `Self`).

## Changes (single commit, `binius-field` only)

- `trait Divisible<T>: Copy` → `trait Divisible<T>: Sized`.
- `fn get(self, ..)` / `unsafe fn get_unchecked(self, ..)` → `&self`, across the trait and every impl (portable, x86_64 m128/m256/m512, aarch64 m128, reflexive `binary_field!`/self macros, `SmallU`, `ScaledUnderlier`).
- Call sites adjusted to pass references (`&value`, `&self.0`, `(*self).into()` on the aarch64 SIMD paths where an owned `From` conversion is needed).
- One internal helper bound added: `mapget::value_iter` gains `Big: Clone` — its owning closure must be `Clone` to satisfy the iterator's `+ Clone` contract, which `Copy` previously provided for free. Every underlier is `Clone`, so this is invisible to callers and stays inside the crate.

`set`/`set_unchecked` already took `&mut self`, so no change there. The removal needed no `+ Copy`/`+ Clone` bounds added to any downstream generic — the supertrait really was unnecessary.

## Verification

Workspace build + tests, x86_64 clippy, aarch64 clippy (`+neon,+aes,+sha2,+sha3`), rustdoc, wasm32-wasip1 build, and fmt all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)