### PR TITLE
BINIUS-99: remove InOut lazy evaluation from Spartan wrapper logic

### DIFF
--- a/crates/spartan-frontend/src/circuit_builder.rs
+++ b/crates/spartan-frontend/src/circuit_builder.rs
@@ -555,6 +555,14 @@ impl<'a, F: Field> InstanceGenerator<'a, F> {
 		PublicWire(Some(value))
 	}
 
+	/// The reconstructed public vector `[constants | inout | derived]` so far, of length
+	/// `1 << layout.log_public()`. Once every inout and alive-derived wire has been written, this
+	/// is the final public vector; reading it by reference (rather than consuming via
+	/// [`Self::build`]) lets callers keep the generator alive for wires that still reference it.
+	pub fn public(&self) -> &[F] {
+		&self.public
+	}
+
 	/// Returns the reconstructed public vector `[constants | inout | derived]`, of length
 	/// `1 << layout.log_public()`, ready to pass to `Verifier::verify`.
 	pub fn build(self) -> Vec<F> {

--- a/crates/spartan-frontend/src/circuit_builder.rs
+++ b/crates/spartan-frontend/src/circuit_builder.rs
@@ -495,6 +495,15 @@ impl<'a, F: Field> CircuitBuilder for WitnessGenerator<'a, F> {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PublicWire<F: Field>(Option<F>);
 
+impl<F: Field> PublicWire<F> {
+	/// The wire's value if it is public-derivable (constant, inout, or derived), else `None` for a
+	/// private/precommit wire whose value the verifier does not know.
+	#[inline]
+	pub fn value(self) -> Option<F> {
+		self.0
+	}
+}
+
 /// Reconstructs the public input vector `[constants | inout | derived]` on the verifier side by
 /// re-running the circuit function.
 ///

--- a/crates/spartan-prover/src/wrapper/replay_channel.rs
+++ b/crates/spartan-prover/src/wrapper/replay_channel.rs
@@ -4,7 +4,7 @@
 //! [`WitnessGenerator`], filling both inout and private wires in the outer witness.
 
 use std::{
-	cell::{Cell, RefCell},
+	cell::RefCell,
 	marker::PhantomData,
 	rc::{Rc, Weak},
 	vec::IntoIter as VecIntoIter,
@@ -20,102 +20,44 @@ use binius_spartan_frontend::{
 use binius_spartan_verifier::wrapper::circuit_elem::{CircuitElem, CircuitWire};
 
 /// [`CircuitWire`] backend over [`WitnessGenerator`] — used by [`ReplayChannel`] to evaluate
-/// arithmetic concretely while filling private witness wires.
-#[derive(Debug, Clone)]
-pub enum WitnessGenWire<'a, F: Field> {
-	Constant(F),
-	InOut(Rc<Cell<LazyInOut<F>>>),
-	Private(WitnessWire<F>, PhantomData<&'a ()>),
-}
+/// arithmetic concretely while filling the outer witness.
+///
+/// A thin newtype around [`WitnessWire`]: every operation evaluates on the generator, which routes
+/// the result to the public or private segment by the input wires' kinds (matching
+/// [`ConstraintBuilder`](binius_spartan_frontend::circuit_builder::ConstraintBuilder)). The
+/// lifetime ties the wire to the `&WitnessLayout` borrowed by its [`WitnessGenerator`].
+#[derive(Debug, Clone, Copy)]
+pub struct WitnessGenWire<'a, F: Field>(WitnessWire<F>, PhantomData<&'a ()>);
 
 impl<'a, F: Field> WitnessGenWire<'a, F> {
-	fn lazy_inout(value: F) -> Self {
-		Self::InOut(Rc::new(Cell::new(LazyInOut::Unmaterialized(value))))
-	}
-
-	pub fn private(wire: WitnessWire<F>) -> Self {
-		Self::Private(wire, PhantomData)
-	}
-
-	fn materialize(builder: &mut WitnessGeneratorWithAlloc<'a, F>, wire: &Self) -> WitnessWire<F> {
-		match wire {
-			Self::Constant(val) => builder.constant(*val),
-			Self::InOut(lazy_inout) => match lazy_inout.get() {
-				LazyInOut::Unmaterialized(value) => {
-					let witness_wire = builder.next_inout(value);
-					lazy_inout.set(LazyInOut::Materialized(witness_wire));
-					witness_wire
-				}
-				LazyInOut::Materialized(wire) => wire,
-			},
-			Self::Private(wire, _) => *wire,
-		}
+	pub fn new(wire: WitnessWire<F>) -> Self {
+		Self(wire, PhantomData)
 	}
 }
 
 impl<'a, F: Field> CircuitWire<F> for WitnessGenWire<'a, F> {
-	type Builder = WitnessGeneratorWithAlloc<'a, F>;
+	type Builder = WitnessGenerator<'a, F>;
 
 	fn combine<const IN: usize, const OUT: usize>(
 		builder: &mut Self::Builder,
 		wires: [&Self; IN],
-		f_op: impl Fn([F; IN]) -> [F; OUT],
+		_f_op: impl Fn([F; IN]) -> [F; OUT],
 		builder_op: impl Fn(&mut Self::Builder, [WitnessWire<F>; IN]) -> [WitnessWire<F>; OUT],
 	) -> [Self; OUT] {
-		let inner_values = array_util::try_map(wires, |wire| match wire {
-			Self::Constant(val) => Some(*val),
-			Self::InOut(lazy_inout) => Some(lazy_inout.get().val()),
-			Self::Private(..) => None,
-		});
-
-		if let Some(inner_values) = inner_values {
-			let ret_values = f_op(inner_values);
-			let all_constant = wires.iter().all(|wire| matches!(wire, Self::Constant(..)));
-			if all_constant {
-				ret_values.map(Self::Constant)
-			} else {
-				ret_values.map(Self::lazy_inout)
-			}
-		} else {
-			let inner_wires = wires.map(|wire| Self::materialize(builder, wire));
-			builder_op(builder, inner_wires).map(Self::private)
-		}
+		builder_op(builder, wires.map(|wire| wire.0)).map(Self::new)
 	}
 
 	fn combine_varlen(
 		builder: &mut Self::Builder,
 		wires: &[&Self],
 		n_out: usize,
-		f_op: impl FnOnce(&[F]) -> Vec<F>,
+		_f_op: impl FnOnce(&[F]) -> Vec<F>,
 		builder_op: impl FnOnce(&mut Self::Builder, &[WitnessWire<F>]) -> Vec<WitnessWire<F>>,
 	) -> Vec<Self> {
-		let inner_values = wires
-			.iter()
-			.map(|wire| match wire {
-				Self::Constant(val) => Some(*val),
-				Self::InOut(lazy_inout) => Some(lazy_inout.get().val()),
-				Self::Private(..) => None,
-			})
-			.collect::<Option<Vec<_>>>();
-
-		if let Some(inner_values) = inner_values {
-			let result = f_op(&inner_values);
-			debug_assert_eq!(result.len(), n_out);
-			let all_constant = wires.iter().all(|wire| matches!(wire, Self::Constant(..)));
-			if all_constant {
-				result.into_iter().map(Self::Constant).collect()
-			} else {
-				result.into_iter().map(Self::lazy_inout).collect()
-			}
-		} else {
-			let inner_wires = wires
-				.iter()
-				.map(|wire| Self::materialize(builder, wire))
-				.collect::<Vec<_>>();
-			let result = builder_op(builder, &inner_wires);
-			debug_assert_eq!(result.len(), n_out);
-			result.into_iter().map(Self::private).collect()
-		}
+		let inner_wires = wires.iter().map(|wire| wire.0).collect::<Vec<_>>();
+		let result = builder_op(builder, &inner_wires);
+		debug_assert_eq!(result.len(), n_out);
+		result.into_iter().map(Self::new).collect()
 	}
 }
 
@@ -129,7 +71,14 @@ impl<'a, F: Field> CircuitWire<F> for WitnessGenWire<'a, F> {
 /// the verifier's arithmetic runs on the returned [`CircuitElem`] values, the [`WitnessGenerator`]
 /// fills private wires.
 pub struct ReplayChannel<'a, F: Field> {
-	witness_gen: Rc<RefCell<WitnessGeneratorWithAlloc<'a, F>>>,
+	witness_gen: Rc<RefCell<WitnessGenerator<'a, F>>>,
+	/// Allocators for the InOut and Precommit segments. They live here, not on the
+	/// [`WitnessGenerator`], because allocating wires in interaction order is the channel's job;
+	/// the generator just writes a value to a given wire. Allocation order must match the symbolic
+	/// [`IronSpartanBuilderChannel`](binius_spartan_verifier::wrapper::IronSpartanBuilderChannel) so
+	/// the wire ids align with `layout`.
+	inout_alloc: WireAllocator,
+	precommit_alloc: WireAllocator,
 	keys: VecIntoIter<F>,
 	events: VecIntoIter<F>,
 }
@@ -140,7 +89,9 @@ impl<'a, F: Field> ReplayChannel<'a, F> {
 	/// TODO: Document args. Keys are the symmetric OTP keys for the received values.
 	pub fn new(layout: &'a WitnessLayout<F>, keys: Vec<F>, events: Vec<F>) -> Self {
 		Self {
-			witness_gen: Rc::new(RefCell::new(WitnessGeneratorWithAlloc::new(layout))),
+			witness_gen: Rc::new(RefCell::new(WitnessGenerator::new(layout))),
+			inout_alloc: WireAllocator::new(WireKind::InOut),
+			precommit_alloc: WireAllocator::new(WireKind::Precommit),
 			keys: keys.into_iter(),
 			events: events.into_iter(),
 		}
@@ -152,7 +103,9 @@ impl<'a, F: Field> ReplayChannel<'a, F> {
 			.next()
 			.unwrap_or_else(|| panic!("replay exhausted: no more events"));
 
-		CircuitElem::wire(&self.witness_gen, WitnessGenWire::lazy_inout(value))
+		let wire = self.inout_alloc.alloc();
+		let witness_wire = self.witness_gen.borrow_mut().write_inout(wire, value);
+		CircuitElem::wire(&self.witness_gen, WitnessGenWire::new(witness_wire))
 	}
 
 	fn next_precommit_elem(&mut self) -> CircuitElem<F, WitnessGenWire<'a, F>> {
@@ -161,8 +114,9 @@ impl<'a, F: Field> ReplayChannel<'a, F> {
 			.next()
 			.expect("precommit segment is sized incorrectly");
 
-		let witness_wire = self.witness_gen.borrow_mut().next_precommit(value);
-		CircuitElem::wire(&self.witness_gen, WitnessGenWire::private(witness_wire))
+		let wire = self.precommit_alloc.alloc();
+		let witness_wire = self.witness_gen.borrow_mut().write_precommit(wire, value);
+		CircuitElem::wire(&self.witness_gen, WitnessGenWire::new(witness_wire))
 	}
 
 	/// Consumes the channel and builds the outer witness.
@@ -193,11 +147,9 @@ impl<'a, F: Field> IPVerifierChannel<F> for ReplayChannel<'a, F> {
 
 	fn assert_zero(&mut self, val: Self::Elem) -> Result<(), binius_ip::channel::Error> {
 		match val {
-			CircuitElem::Constant(c)
-			| CircuitElem::Wire {
-				wire: WitnessGenWire::Constant(c),
-				..
-			} => {
+			// A compile-time constant is checked here; any other wire's value is checked by the
+			// witness generator, which records a constraint violation as a build error.
+			CircuitElem::Constant(c) => {
 				if c == F::ZERO {
 					Ok(())
 				} else {
@@ -205,19 +157,8 @@ impl<'a, F: Field> IPVerifierChannel<F> for ReplayChannel<'a, F> {
 				}
 			}
 			CircuitElem::Wire {
-				wire: WitnessGenWire::InOut(lazy_inout),
-				..
-			} => {
-				if lazy_inout.get().val() == F::ZERO {
-					Ok(())
-				} else {
-					Err(binius_ip::channel::Error::InvalidAssert)
-				}
-			}
-
-			CircuitElem::Wire {
 				builder,
-				wire: WitnessGenWire::Private(wire, _),
+				wire: WitnessGenWire(wire, _),
 			} => {
 				assert!(Weak::ptr_eq(&Rc::downgrade(&self.witness_gen), &builder));
 				self.witness_gen.borrow_mut().assert_zero(wire);
@@ -231,21 +172,30 @@ impl<'a, F: Field> IPVerifierChannel<F> for ReplayChannel<'a, F> {
 		inputs: &[Self::Elem],
 		f: impl FnOnce(&[F]) -> F,
 	) -> Self::Elem {
-		let input_refs = inputs.iter().collect::<Vec<_>>();
-		let outs = CircuitElem::combine_varlen(
-			&input_refs,
-			1,
-			move |inputs| vec![f(inputs)],
-			|_, _| {
-				// Self::Elem::combine_varlen will only call the builder_op closure if any inputs
-				// are non-public.
-				panic!("compute_public_value: input is not public")
-			},
-		);
-		outs.into_iter()
-			.next()
-			.expect("combine_varlen returns Vec with len = n_out; n_out = 1")
+		// The closure's result enters as a single inout wire (matching the symbolic builder), whose
+		// value the prover computes natively from the public-derived inputs. See
+		// `IronSpartanBuilderChannel::compute_public_value`.
+		let value = f(&extract_public_values(inputs));
+		let wire = self.inout_alloc.alloc();
+		let witness_wire = self.witness_gen.borrow_mut().write_inout(wire, value);
+		CircuitElem::wire(&self.witness_gen, WitnessGenWire::new(witness_wire))
 	}
+}
+
+/// Extracts the concrete field value of each input. The prover knows every wire's value (public or
+/// not), so no public-tag check is needed here — the [`IPVerifierChannel::compute_public_value`]
+/// contract is enforced verifier-side, where non-public inputs are value-less.
+fn extract_public_values<F: Field>(inputs: &[CircuitElem<F, WitnessGenWire<'_, F>>]) -> Vec<F> {
+	inputs
+		.iter()
+		.map(|elem| match elem {
+			CircuitElem::Constant(c) => *c,
+			CircuitElem::Wire {
+				wire: WitnessGenWire(wire, _),
+				..
+			} => wire.val(),
+		})
+		.collect()
 }
 
 impl<'r, 'a, F: Field> IOPVerifierChannel<'r, F> for ReplayChannel<'a, F> {
@@ -274,94 +224,6 @@ impl<'r, 'a, F: Field> IOPVerifierChannel<'r, F> for ReplayChannel<'a, F> {
 	}
 }
 
-#[derive(Debug, Clone, Copy)]
-
-pub enum LazyInOut<F: Field> {
-	Unmaterialized(F),
-	Materialized(WitnessWire<F>),
-}
-
-impl<F: Field> LazyInOut<F> {
-	pub fn val(self) -> F {
-		match self {
-			Self::Unmaterialized(value) => value,
-			Self::Materialized(wire) => wire.val(),
-		}
-	}
-}
-
-/// A [`WitnessGenerator`] decorator that internalizes [`WireAllocator`]s for the InOut and
-/// Precommit segments. Exposes `next_inout(value)` and `next_precommit(value)` for callers that
-/// allocate-and-write in one step (e.g. [`ReplayChannel`] and the lazy InOut materialization in
-/// [`WitnessGenWire`]).
-///
-/// All [`CircuitBuilder`] methods delegate to the inner [`WitnessGenerator`].
-#[derive(Debug)]
-pub struct WitnessGeneratorWithAlloc<'a, F: Field> {
-	inner: WitnessGenerator<'a, F>,
-	inout_alloc: WireAllocator,
-	precommit_alloc: WireAllocator,
-}
-
-impl<'a, F: Field> WitnessGeneratorWithAlloc<'a, F> {
-	pub fn new(layout: &'a WitnessLayout<F>) -> Self {
-		Self {
-			inner: WitnessGenerator::new(layout),
-			inout_alloc: WireAllocator::new(WireKind::InOut),
-			precommit_alloc: WireAllocator::new(WireKind::Precommit),
-		}
-	}
-
-	/// Allocates the next InOut wire and writes `value` to it.
-	pub fn next_inout(&mut self, value: F) -> WitnessWire<F> {
-		let wire = self.inout_alloc.alloc();
-		self.inner.write_inout(wire, value)
-	}
-
-	/// Allocates the next Precommit wire and writes `value` to it.
-	pub fn next_precommit(&mut self, value: F) -> WitnessWire<F> {
-		let wire = self.precommit_alloc.alloc();
-		self.inner.write_precommit(wire, value)
-	}
-
-	pub fn build(self) -> Result<Witness<F>, WitnessError> {
-		self.inner.build()
-	}
-}
-
-impl<'a, F: Field> CircuitBuilder for WitnessGeneratorWithAlloc<'a, F> {
-	type Wire = WitnessWire<F>;
-	type Field = F;
-
-	fn assert_zero(&mut self, wire: Self::Wire) {
-		self.inner.assert_zero(wire)
-	}
-
-	fn assert_eq(&mut self, lhs: Self::Wire, rhs: Self::Wire) {
-		self.inner.assert_eq(lhs, rhs)
-	}
-
-	fn constant(&mut self, val: F) -> Self::Wire {
-		self.inner.constant(val)
-	}
-
-	fn add(&mut self, lhs: Self::Wire, rhs: Self::Wire) -> Self::Wire {
-		self.inner.add(lhs, rhs)
-	}
-
-	fn mul(&mut self, lhs: Self::Wire, rhs: Self::Wire) -> Self::Wire {
-		self.inner.mul(lhs, rhs)
-	}
-
-	fn hint<H: Fn([F; IN]) -> [F; OUT], const IN: usize, const OUT: usize>(
-		&mut self,
-		inputs: [Self::Wire; IN],
-		f: H,
-	) -> [Self::Wire; OUT] {
-		self.inner.hint(inputs, f)
-	}
-}
-
 #[cfg(test)]
 mod tests {
 	use std::{cell::RefCell, rc::Rc};
@@ -369,14 +231,14 @@ mod tests {
 	use binius_field::{
 		BinaryField1b as B1, BinaryField128bGhash as B128, ExtensionField, field::FieldOps,
 	};
-	use binius_spartan_frontend::circuit_builder::ConstraintBuilder;
+	use binius_spartan_frontend::circuit_builder::{ConstraintBuilder, WitnessGenerator};
 	use binius_spartan_verifier::wrapper::{
 		builder_channel::BuilderWire, circuit_elem::CircuitElem,
 	};
 
-	use super::{WitnessGenWire, WitnessGeneratorWithAlloc};
+	use super::WitnessGenWire;
 
-	type BuildElem = CircuitElem<B128, BuilderWire<B128>>;
+	type BuildElem = CircuitElem<B128, BuilderWire>;
 	type WitnessElem<'a> = CircuitElem<B128, WitnessGenWire<'a, B128>>;
 
 	#[test]
@@ -396,7 +258,7 @@ mod tests {
 		let rc = Rc::new(RefCell::new(constraint_builder));
 		let mut elems: Vec<BuildElem> = inout_wires
 			.iter()
-			.map(|&w| BuildElem::wire(&rc, BuilderWire::Private(w)))
+			.map(|&w| BuildElem::wire(&rc, BuilderWire(w)))
 			.collect();
 
 		<BuildElem as FieldOps>::square_transpose::<FSub>(&mut elems);
@@ -415,16 +277,17 @@ mod tests {
 			.map(<B128 as ExtensionField<FSub>>::basis)
 			.collect();
 
-		let mut witness_gen = WitnessGeneratorWithAlloc::new(&layout);
-		let witness_wires: Vec<_> = test_values
+		let mut witness_gen = WitnessGenerator::new(&layout);
+		let witness_wires: Vec<_> = inout_wires
 			.iter()
-			.map(|&val| witness_gen.next_inout(val))
+			.zip(&test_values)
+			.map(|(&wire, &val)| witness_gen.write_inout(wire, val))
 			.collect();
 
 		let witness_rc = Rc::new(RefCell::new(witness_gen));
 		let mut witness_elems: Vec<WitnessElem> = witness_wires
 			.iter()
-			.map(|&w| WitnessElem::wire(&witness_rc, WitnessGenWire::private(w)))
+			.map(|&w| WitnessElem::wire(&witness_rc, WitnessGenWire::new(w)))
 			.collect();
 
 		<WitnessElem as FieldOps>::square_transpose::<FSub>(&mut witness_elems);

--- a/crates/spartan-prover/src/wrapper/replay_channel.rs
+++ b/crates/spartan-prover/src/wrapper/replay_channel.rs
@@ -41,7 +41,6 @@ impl<'a, F: Field> CircuitWire<F> for WitnessGenWire<'a, F> {
 	fn combine<const IN: usize, const OUT: usize>(
 		builder: &mut Self::Builder,
 		wires: [&Self; IN],
-		_f_op: impl Fn([F; IN]) -> [F; OUT],
 		builder_op: impl Fn(&mut Self::Builder, [WitnessWire<F>; IN]) -> [WitnessWire<F>; OUT],
 	) -> [Self; OUT] {
 		builder_op(builder, wires.map(|wire| wire.0)).map(Self::new)
@@ -51,7 +50,6 @@ impl<'a, F: Field> CircuitWire<F> for WitnessGenWire<'a, F> {
 		builder: &mut Self::Builder,
 		wires: &[&Self],
 		n_out: usize,
-		_f_op: impl FnOnce(&[F]) -> Vec<F>,
 		builder_op: impl FnOnce(&mut Self::Builder, &[WitnessWire<F>]) -> Vec<WitnessWire<F>>,
 	) -> Vec<Self> {
 		let inner_wires = wires.iter().map(|wire| wire.0).collect::<Vec<_>>();
@@ -75,8 +73,8 @@ pub struct ReplayChannel<'a, F: Field> {
 	/// Allocators for the InOut and Precommit segments. They live here, not on the
 	/// [`WitnessGenerator`], because allocating wires in interaction order is the channel's job;
 	/// the generator just writes a value to a given wire. Allocation order must match the symbolic
-	/// [`IronSpartanBuilderChannel`](binius_spartan_verifier::wrapper::IronSpartanBuilderChannel) so
-	/// the wire ids align with `layout`.
+	/// [`IronSpartanBuilderChannel`](binius_spartan_verifier::wrapper::IronSpartanBuilderChannel)
+	/// so the wire ids align with `layout`.
 	inout_alloc: WireAllocator,
 	precommit_alloc: WireAllocator,
 	keys: VecIntoIter<F>,

--- a/crates/spartan-prover/tests/wrapper_integration_test.rs
+++ b/crates/spartan-prover/tests/wrapper_integration_test.rs
@@ -192,7 +192,7 @@ fn test_zk_wrapped_prove_verify() {
 
 	let verifier_channel = zk_basefold_compiler.create_channel(&mut verifier_transcript);
 	let mut wrapped_verifier_channel =
-		ZKWrappedVerifierChannel::new(verifier_channel, &outer_iop_verifier)
+		ZKWrappedVerifierChannel::new(verifier_channel, &outer_iop_verifier, &outer_layout)
 			.expect("ZKWrappedVerifierChannel::new should succeed");
 
 	// Observe public input through the wrapped channel.

--- a/crates/spartan-verifier/src/wrapper/builder_channel.rs
+++ b/crates/spartan-verifier/src/wrapper/builder_channel.rs
@@ -34,7 +34,6 @@ impl<F: Field> CircuitWire<F> for BuilderWire {
 	fn combine<const IN: usize, const OUT: usize>(
 		builder: &mut Self::Builder,
 		wires: [&Self; IN],
-		_f_op: impl Fn([F; IN]) -> [F; OUT],
 		builder_op: impl Fn(&mut Self::Builder, [ConstraintWire; IN]) -> [ConstraintWire; OUT],
 	) -> [Self; OUT] {
 		builder_op(builder, wires.map(|wire| wire.0)).map(Self)
@@ -44,7 +43,6 @@ impl<F: Field> CircuitWire<F> for BuilderWire {
 		builder: &mut Self::Builder,
 		wires: &[&Self],
 		n_out: usize,
-		_f_op: impl FnOnce(&[F]) -> Vec<F>,
 		builder_op: impl FnOnce(&mut Self::Builder, &[ConstraintWire]) -> Vec<ConstraintWire>,
 	) -> Vec<Self> {
 		let inner_wires = wires.iter().map(|wire| wire.0).collect::<Vec<_>>();

--- a/crates/spartan-verifier/src/wrapper/builder_channel.rs
+++ b/crates/spartan-verifier/src/wrapper/builder_channel.rs
@@ -4,9 +4,7 @@
 //! and records the computation as constraints on a [`ConstraintBuilder`].
 
 use std::{
-	array,
-	cell::{Cell, RefCell},
-	iter::repeat_with,
+	cell::RefCell,
 	rc::{Rc, Weak},
 };
 
@@ -22,103 +20,37 @@ use super::circuit_elem::{CircuitElem, CircuitWire};
 
 /// [`CircuitWire`] backend over [`ConstraintBuilder`] — used by [`IronSpartanBuilderChannel`] to
 /// record arithmetic as constraints in a constraint system.
-#[derive(Debug, Clone)]
-pub enum BuilderWire<F> {
-	Constant(F),
-	InOut(Rc<Cell<Option<ConstraintWire>>>),
-	Private(ConstraintWire),
-}
+///
+/// A thin newtype around [`ConstraintWire`]: every operation records itself on the builder, which
+/// decides whether the output is a derived (public-derivable, no constraint) or private wire. The
+/// public-vs-private elision lives in [`ConstraintBuilder`], so this backend needs no tracking of
+/// its own.
+#[derive(Debug, Clone, Copy)]
+pub struct BuilderWire(pub ConstraintWire);
 
-impl<F: Field> BuilderWire<F> {
-	fn lazy_inout() -> Self {
-		Self::InOut(Rc::new(Cell::new(None)))
-	}
-
-	fn materialize(builder: &mut ConstraintBuilder<F>, wire: &Self) -> ConstraintWire {
-		match wire {
-			Self::Constant(val) => builder.constant(*val),
-			Self::InOut(maybe_wire) => {
-				if let Some(wire) = maybe_wire.get() {
-					wire
-				} else {
-					let wire = builder.alloc_inout();
-					maybe_wire.set(Some(wire));
-					wire
-				}
-			}
-			Self::Private(wire) => *wire,
-		}
-	}
-}
-
-impl<F: Field> CircuitWire<F> for BuilderWire<F> {
+impl<F: Field> CircuitWire<F> for BuilderWire {
 	type Builder = ConstraintBuilder<F>;
 
 	fn combine<const IN: usize, const OUT: usize>(
 		builder: &mut Self::Builder,
 		wires: [&Self; IN],
-		f_op: impl Fn([F; IN]) -> [F; OUT],
+		_f_op: impl Fn([F; IN]) -> [F; OUT],
 		builder_op: impl Fn(&mut Self::Builder, [ConstraintWire; IN]) -> [ConstraintWire; OUT],
 	) -> [Self; OUT] {
-		let inner_constants = array_util::try_map(wires, |wire| match wire {
-			Self::Constant(val) => Some(*val),
-			_ => None,
-		});
-
-		if let Some(inner_values) = inner_constants {
-			f_op(inner_values).map(Self::Constant)
-		} else {
-			let is_inout = wires
-				.iter()
-				.all(|wire| matches!(wire, Self::Constant(_) | Self::InOut(_)));
-			if is_inout {
-				array::from_fn(|_| Self::lazy_inout())
-			} else {
-				// If any of the inputs are private wires, then lazily materialize in inout wires
-				// and compute the result within the circuit.
-				let inner_wires = wires.map(|wire| Self::materialize(builder, wire));
-				builder_op(builder, inner_wires).map(Self::Private)
-			}
-		}
+		builder_op(builder, wires.map(|wire| wire.0)).map(Self)
 	}
 
 	fn combine_varlen(
 		builder: &mut Self::Builder,
 		wires: &[&Self],
 		n_out: usize,
-		f_op: impl FnOnce(&[F]) -> Vec<F>,
+		_f_op: impl FnOnce(&[F]) -> Vec<F>,
 		builder_op: impl FnOnce(&mut Self::Builder, &[ConstraintWire]) -> Vec<ConstraintWire>,
 	) -> Vec<Self> {
-		let inner_constants = wires
-			.iter()
-			.map(|wire| match wire {
-				Self::Constant(val) => Some(*val),
-				_ => None,
-			})
-			.collect::<Option<Vec<_>>>();
-
-		if let Some(inner_constants) = inner_constants {
-			let result = f_op(&inner_constants);
-			debug_assert_eq!(result.len(), n_out);
-			result.into_iter().map(Self::Constant).collect()
-		} else {
-			let is_inout = wires
-				.iter()
-				.all(|wire| matches!(wire, Self::Constant(_) | Self::InOut(_)));
-			if is_inout {
-				repeat_with(|| Self::lazy_inout()).take(n_out).collect()
-			} else {
-				// If any of the inputs are private wires, then lazily materialize in inout wires
-				// and compute the result within the circuit.
-				let inner_wires = wires
-					.iter()
-					.map(|wire| Self::materialize(builder, wire))
-					.collect::<Vec<_>>();
-				let result = builder_op(builder, &inner_wires);
-				debug_assert_eq!(result.len(), n_out);
-				result.into_iter().map(Self::Private).collect()
-			}
-		}
+		let inner_wires = wires.iter().map(|wire| wire.0).collect::<Vec<_>>();
+		let result = builder_op(builder, &inner_wires);
+		debug_assert_eq!(result.len(), n_out);
+		result.into_iter().map(Self).collect()
 	}
 }
 
@@ -149,13 +81,14 @@ impl<F: Field> IronSpartanBuilderChannel<F> {
 		}
 	}
 
-	fn alloc_inout_elem(&self) -> CircuitElem<F, BuilderWire<F>> {
-		CircuitElem::wire(&self.builder, BuilderWire::lazy_inout())
+	fn alloc_inout_elem(&self) -> CircuitElem<F, BuilderWire> {
+		let wire = self.builder.borrow_mut().alloc_inout();
+		CircuitElem::wire(&self.builder, BuilderWire(wire))
 	}
 
-	fn alloc_precommit_elem(&self) -> CircuitElem<F, BuilderWire<F>> {
+	fn alloc_precommit_elem(&self) -> CircuitElem<F, BuilderWire> {
 		let wire = self.builder.borrow_mut().alloc_precommit();
-		CircuitElem::wire(&self.builder, BuilderWire::Private(wire))
+		CircuitElem::wire(&self.builder, BuilderWire(wire))
 	}
 
 	/// Consumes the channel and returns the underlying [`ConstraintBuilder`].
@@ -170,7 +103,7 @@ impl<F: Field> IronSpartanBuilderChannel<F> {
 }
 
 impl<F: Field> IPVerifierChannel<F> for IronSpartanBuilderChannel<F> {
-	type Elem = CircuitElem<F, BuilderWire<F>>;
+	type Elem = CircuitElem<F, BuilderWire>;
 
 	fn recv_one(&mut self) -> Result<Self::Elem, binius_ip::channel::Error> {
 		// For each element that the inner prover sends, the wrapped prover allocates a one-time-pad
@@ -191,28 +124,21 @@ impl<F: Field> IPVerifierChannel<F> for IronSpartanBuilderChannel<F> {
 
 	fn assert_zero(&mut self, val: Self::Elem) -> Result<(), binius_ip::channel::Error> {
 		match val {
-			CircuitElem::Constant(c)
-			| CircuitElem::Wire {
-				wire: BuilderWire::Constant(c),
-				..
-			} => {
+			// A compile-time constant is checked here; a non-zero one is an unsatisfiable
+			// assertion.
+			CircuitElem::Constant(c) => {
 				if c == F::ZERO {
 					Ok(())
 				} else {
 					Err(binius_ip::channel::Error::InvalidAssert)
 				}
 			}
-			CircuitElem::Wire {
-				wire: BuilderWire::InOut(_),
-				..
-			} => {
-				// Nothing to do here. The value can be checked directly in
-				// ZKWrappedVerifierChannel.
-				Ok(())
-			}
+			// Record the assertion as a constraint over the wire (whether public-derivable or
+			// private). The outer verifier enforces it; with derived wires there is no need to
+			// special-case public values out of the constraint system.
 			CircuitElem::Wire {
 				builder,
-				wire: BuilderWire::Private(wire),
+				wire: BuilderWire(wire),
 			} => {
 				assert!(Weak::ptr_eq(&Rc::downgrade(&self.builder), &builder));
 				self.builder.borrow_mut().assert_zero(wire);
@@ -223,23 +149,14 @@ impl<F: Field> IPVerifierChannel<F> for IronSpartanBuilderChannel<F> {
 
 	fn compute_public_value(
 		&mut self,
-		inputs: &[Self::Elem],
-		f: impl FnOnce(&[F]) -> F,
+		_inputs: &[Self::Elem],
+		_f: impl FnOnce(&[F]) -> F,
 	) -> Self::Elem {
-		let input_refs = inputs.iter().collect::<Vec<_>>();
-		let outs = CircuitElem::combine_varlen(
-			&input_refs,
-			1,
-			move |inputs| vec![f(inputs)],
-			|_, _| {
-				// Self::Elem::combine_varlen will only call the builder_op closure if any inputs
-				// are non-public.
-				panic!("compute_public_value: input is not public")
-			},
-		);
-		outs.into_iter()
-			.next()
-			.expect("combine_varlen returns Vec with len = n_out; n_out = 1")
+		// The closure is an arbitrary native computation the constraint system cannot replay, so
+		// its result enters as a single inout wire (a public input the verifier supplies), rather
+		// than a sub-circuit's worth of constraints. The value is filled concretely by the
+		// instance/witness channels; symbolically we only allocate the wire.
+		self.alloc_inout_elem()
 	}
 }
 

--- a/crates/spartan-verifier/src/wrapper/circuit_elem.rs
+++ b/crates/spartan-verifier/src/wrapper/circuit_elem.rs
@@ -10,17 +10,18 @@
 //! - [`BuilderWire`](super::builder_channel::BuilderWire) over [`ConstraintBuilder`] — symbolic
 //!   constraint recording (used by
 //!   [`IronSpartanBuilderChannel`](super::builder_channel::IronSpartanBuilderChannel)).
-//! - [`WrappedWire`](super::zk_wrapped_channel::WrappedWire) over
-//!   [`InOutSegmentBuilder`](super::zk_wrapped_channel::InOutSegmentBuilder) — no constraint
-//!   recording; values are tracked as `Constant` / `InOut` / `Private` to distinguish what the
-//!   verifier does and does not know concretely, and lazily pushed to the outer public-input
-//!   segment (used by
+//! - [`WrappedWire`](super::zk_wrapped_channel::WrappedWire) over [`InstanceGenerator`] —
+//!   reconstructs the public-input vector during verification (used by
 //!   [`ZKWrappedVerifierChannel`](super::zk_wrapped_channel::ZKWrappedVerifierChannel)).
 //! - `WitnessGenWire` over [`WitnessGenerator`] — concrete evaluation that fills a witness (used by
 //!   `binius_spartan_prover::wrapper::ReplayChannel`).
 //!
+//! Each backend is a thin newtype over its builder's wire type; the public-vs-private elision lives
+//! in the builders ([`ConstraintBuilder`] derived wires), not in these wrappers.
+//!
 //! [`CircuitBuilder`]: binius_spartan_frontend::circuit_builder::CircuitBuilder
 //! [`ConstraintBuilder`]: binius_spartan_frontend::circuit_builder::ConstraintBuilder
+//! [`InstanceGenerator`]: binius_spartan_frontend::circuit_builder::InstanceGenerator
 //! [`WitnessGenerator`]: binius_spartan_frontend::circuit_builder::WitnessGenerator
 
 use std::{

--- a/crates/spartan-verifier/src/wrapper/circuit_elem.rs
+++ b/crates/spartan-verifier/src/wrapper/circuit_elem.rs
@@ -43,20 +43,21 @@ use super::gadgets;
 /// Backend-specific logic for combining wires under arithmetic operations.
 ///
 /// One method (`combine`, plus its variable-arity sibling `combine_varlen`) suffices for the
-/// arithmetic-trait impls on [`CircuitElem`]. Each impl decides whether to short-circuit constant
-/// inputs into a concrete value or to delegate to its underlying [`CircuitBuilder`].
+/// arithmetic-trait impls on [`CircuitElem`]. Each impl maps its wires through `op` on the
+/// underlying [`CircuitBuilder`], which decides how the operation is recorded or evaluated.
+/// Constant folding happens one level up in [`CircuitElem`], so these methods only ever run on
+/// builder-backed wires.
 pub trait CircuitWire<F: Field>: Sized {
 	type Builder: CircuitBuilder<Field = F>;
 
 	fn constant(builder: &mut Self::Builder, val: F) -> Self {
-		let [ret] = Self::combine(builder, [], |_| [val], |builder, _| [builder.constant(val)]);
+		let [ret] = Self::combine(builder, [], |builder, _| [builder.constant(val)]);
 		ret
 	}
 
 	fn combine<const IN: usize, const OUT: usize>(
 		builder: &mut Self::Builder,
 		wires: [&Self; IN],
-		f_op: impl Fn([F; IN]) -> [F; OUT],
 		op: impl Fn(
 			&mut Self::Builder,
 			[<Self::Builder as CircuitBuilder>::Wire; IN],
@@ -70,13 +71,12 @@ pub trait CircuitWire<F: Field>: Sized {
 	///
 	/// # Contract
 	///
-	/// `f_op` and `op` MUST return a `Vec` of length `n_out` whenever they are called. The impl
-	/// checks this with `debug_assert_eq!`.
+	/// `op` MUST return a `Vec` of length `n_out` whenever it is called. The impl checks this with
+	/// `debug_assert_eq!`.
 	fn combine_varlen(
 		builder: &mut Self::Builder,
 		wires: &[&Self],
 		n_out: usize,
-		f_op: impl FnOnce(&[F]) -> Vec<F>,
 		op: impl FnOnce(
 			&mut Self::Builder,
 			&[<Self::Builder as CircuitBuilder>::Wire],
@@ -157,7 +157,7 @@ where
 				}
 			});
 			let inner_wire_refs = inner_wires.each_ref().map(AsRef::as_ref);
-			W::combine(&mut *builder, inner_wire_refs, f_op, builder_op).map(|wire| Self::Wire {
+			W::combine(&mut *builder, inner_wire_refs, builder_op).map(|wire| Self::Wire {
 				builder: builder_ptr.clone(),
 				wire,
 			})
@@ -217,7 +217,7 @@ where
 				})
 				.collect::<Vec<_>>();
 			let inner_wire_refs = inner_wires.iter().map(AsRef::as_ref).collect::<Vec<_>>();
-			W::combine_varlen(&mut *builder, &inner_wire_refs, n_out, f_op, builder_op)
+			W::combine_varlen(&mut *builder, &inner_wire_refs, n_out, builder_op)
 				.into_iter()
 				.map(|wire| Self::Wire {
 					builder: builder_ptr.clone(),

--- a/crates/spartan-verifier/src/wrapper/mod.rs
+++ b/crates/spartan-verifier/src/wrapper/mod.rs
@@ -32,16 +32,16 @@ mod tests {
 	use super::*;
 	use crate::wrapper::{builder_channel::BuilderWire, circuit_elem::CircuitElem};
 
-	type BuildElem = CircuitElem<B128, BuilderWire<B128>>;
+	type BuildElem = CircuitElem<B128, BuilderWire>;
 
 	/// Helper to create a private-backed `BuildElem` wire from a ConstraintBuilder Rc for tests.
 	///
-	/// Uses a precommit wire (the real source of `BuilderWire::Private` in wrapper usage — the OTP
-	/// key) so that arithmetic on it stays private and records constraints. An inout-backed wire
-	/// would instead be elided into a derived wire with no constraint.
+	/// Uses a precommit wire (the real source of a private wire in wrapper usage — the OTP key) so
+	/// that arithmetic on it stays private and records constraints. An inout-backed wire would
+	/// instead be elided into a derived wire with no constraint.
 	fn alloc_private_wire(rc: &Rc<std::cell::RefCell<ConstraintBuilder<B128>>>) -> BuildElem {
 		let wire = rc.borrow_mut().alloc_precommit();
-		BuildElem::wire(rc, BuilderWire::Private(wire))
+		BuildElem::wire(rc, BuilderWire(wire))
 	}
 
 	#[test]

--- a/crates/spartan-verifier/src/wrapper/zk_wrapped_channel.rs
+++ b/crates/spartan-verifier/src/wrapper/zk_wrapped_channel.rs
@@ -55,7 +55,6 @@ impl<'a, F: Field> CircuitWire<F> for WrappedWire<'a, F> {
 	fn combine<const IN: usize, const OUT: usize>(
 		builder: &mut Self::Builder,
 		wires: [&Self; IN],
-		_f_op: impl Fn([F; IN]) -> [F; OUT],
 		builder_op: impl Fn(&mut Self::Builder, [PublicWire<F>; IN]) -> [PublicWire<F>; OUT],
 	) -> [Self; OUT] {
 		builder_op(builder, wires.map(|wire| wire.0)).map(Self::new)
@@ -65,7 +64,6 @@ impl<'a, F: Field> CircuitWire<F> for WrappedWire<'a, F> {
 		builder: &mut Self::Builder,
 		wires: &[&Self],
 		n_out: usize,
-		_f_op: impl FnOnce(&[F]) -> Vec<F>,
 		builder_op: impl FnOnce(&mut Self::Builder, &[PublicWire<F>]) -> Vec<PublicWire<F>>,
 	) -> Vec<Self> {
 		let inner_wires = wires.iter().map(|wire| wire.0).collect::<Vec<_>>();
@@ -102,8 +100,8 @@ where
 	/// Allocators for the InOut and Precommit segments. They live here, not on the
 	/// [`InstanceGenerator`], because allocating wires in interaction order is the channel's job;
 	/// the generator just writes a value to a given wire. Allocation order must match the symbolic
-	/// [`IronSpartanBuilderChannel`](super::builder_channel::IronSpartanBuilderChannel) so the wire
-	/// ids align with the outer layout.
+	/// [`IronSpartanBuilderChannel`](super::builder_channel::IronSpartanBuilderChannel) so the
+	/// wire ids align with the outer layout.
 	inout_alloc: WireAllocator,
 	precommit_alloc: WireAllocator,
 	/// Number of outer oracles still to be received on `inner_channel` after inner verification

--- a/crates/spartan-verifier/src/wrapper/zk_wrapped_channel.rs
+++ b/crates/spartan-verifier/src/wrapper/zk_wrapped_channel.rs
@@ -3,21 +3,15 @@
 //! ZK-wrapped verifier channel that delegates to a BaseFold ZK channel and an outer IOP verifier.
 //!
 //! [`ZKWrappedVerifierChannel`] wraps a [`BaseFoldZKVerifierChannel`] and an [`IOPVerifier`].
-//! Inner-channel values flow through the wrapper as lazy [`WrappedWire::InOut`] elements; an InOut
-//! is pushed into the outer constraint system's public-input segment only if the inner verifier
-//! forces materialization (the same way [`BuilderWire::InOut`] only allocates an InOut wire when
-//! the symbolic phase forces it). [`finish()`] prepends the outer constants to the materialized
-//! public values, pads to the required public size, and runs the outer verifier against the inner
-//! channel.
+//! Inner-channel values flow through the wrapper as [`WrappedWire`] elements backed by an
+//! [`InstanceGenerator`], which reconstructs the outer constraint system's public-input vector
+//! `[constants | inout | derived]` exactly as the prover's witness generator does — public-derived
+//! intermediate values are recomputed natively rather than tracked by the wrapper. [`finish()`]
+//! hands that public vector to the outer verifier and runs it against the inner channel.
 //!
-//! [`BuilderWire::InOut`]: super::builder_channel::BuilderWire
 //! [`finish()`]: ZKWrappedVerifierChannel::finish
 
-use std::{
-	array,
-	cell::{Cell, RefCell},
-	rc::Rc,
-};
+use std::{cell::RefCell, marker::PhantomData, rc::Rc};
 
 use binius_field::{BinaryField, Field};
 use binius_iop::{
@@ -26,7 +20,10 @@ use binius_iop::{
 	merkle_tree::MerkleTreeScheme,
 };
 use binius_ip::channel::IPVerifierChannel;
-use binius_spartan_frontend::circuit_builder::CircuitBuilder;
+use binius_spartan_frontend::{
+	circuit_builder::{InstanceGenerator, PublicWire, WireAllocator},
+	constraint_system::{WireKind, WitnessLayout},
+};
 use binius_transcript::fiat_shamir::Challenger;
 use binius_utils::DeserializeBytes;
 
@@ -35,184 +32,61 @@ use crate::{
 	wrapper::circuit_elem::{CircuitElem, CircuitWire},
 };
 
-/// [`CircuitWire`] backend used by [`ZKWrappedVerifierChannel`].
+/// [`CircuitWire`] backend over [`InstanceGenerator`] — used by [`ZKWrappedVerifierChannel`] to
+/// reconstruct the outer public-input vector during verification.
 ///
-/// Mirrors the verifier-side [`BuilderWire`](super::builder_channel::BuilderWire) and the
-/// prover-side `WitnessGenWire` (in `binius_spartan_prover::wrapper::replay_channel`):
-///
-/// - `Constant(F)` — known at compile time.
-/// - `InOut { value, is_materialized }` — F is known to the wrapper. Will be pushed to the outer
-///   constraint system's public-input segment if/when the wire is materialized (via the private
-///   `materialize` helper). `is_materialized` is shared via [`Rc`] so all clones of one logical
-///   wire push exactly once.
-/// - `Private` — F is unknown to the wrapper (analog of `BuilderWire::Private`; e.g. the precommit
-///   OTP key, never sent through the inner channel — it lives only in the outer prover's
-///   commitment, accessed by the outer verifier circuit).
-#[derive(Debug, Clone)]
-pub enum WrappedWire<F: Field> {
-	Constant(F),
-	InOut {
-		value: F,
-		is_materialized: Rc<Cell<bool>>,
-	},
-	Private,
-}
+/// A thin newtype around [`PublicWire`]: every operation evaluates on the generator, which fills
+/// the public segment (`constants`/`inout`/`derived`) and leaves private/precommit wires value-less
+/// — the verifier never learns the secrets, and by the soundness invariant no derived value depends
+/// on them. The lifetime ties the wire to the `&WitnessLayout` borrowed by its
+/// [`InstanceGenerator`].
+#[derive(Debug, Clone, Copy)]
+pub struct WrappedWire<'a, F: Field>(PublicWire<F>, PhantomData<&'a ()>);
 
-impl<F: Field> WrappedWire<F> {
-	fn lazy_inout(value: F) -> Self {
-		Self::InOut {
-			value,
-			is_materialized: Rc::new(Cell::new(false)),
-		}
-	}
-
-	/// If `wire` is an unmaterialized [`Self::InOut`], push its value into the
-	/// [`InOutSegmentBuilder`]'s public-values vec and mark it materialized. Otherwise no-op.
-	fn materialize(builder: &mut InOutSegmentBuilder<F>, wire: &Self) {
-		if let Self::InOut {
-			value,
-			is_materialized,
-		} = wire && !is_materialized.get()
-		{
-			builder.next_inout(*value);
-			is_materialized.set(true);
-		}
+impl<'a, F: Field> WrappedWire<'a, F> {
+	fn new(wire: PublicWire<F>) -> Self {
+		Self(wire, PhantomData)
 	}
 }
 
-impl<F: Field> CircuitWire<F> for WrappedWire<F> {
-	type Builder = InOutSegmentBuilder<F>;
+impl<'a, F: Field> CircuitWire<F> for WrappedWire<'a, F> {
+	type Builder = InstanceGenerator<'a, F>;
 
 	fn combine<const IN: usize, const OUT: usize>(
 		builder: &mut Self::Builder,
 		wires: [&Self; IN],
-		f_op: impl Fn([F; IN]) -> [F; OUT],
-		_builder_op: impl Fn(&mut Self::Builder, [(); IN]) -> [(); OUT],
+		_f_op: impl Fn([F; IN]) -> [F; OUT],
+		builder_op: impl Fn(&mut Self::Builder, [PublicWire<F>; IN]) -> [PublicWire<F>; OUT],
 	) -> [Self; OUT] {
-		let inner_values = array_util::try_map(wires, |wire| match wire {
-			Self::Constant(val) => Some(*val),
-			Self::InOut { value, .. } => Some(*value),
-			Self::Private => None,
-		});
-		if let Some(inner_values) = inner_values {
-			let ret_values = f_op(inner_values);
-			let all_constant = wires.iter().all(|w| matches!(w, Self::Constant(_)));
-			if all_constant {
-				ret_values.map(Self::Constant)
-			} else {
-				// Mix of Constant + InOut, no Private: fresh lazy InOut.
-				ret_values.map(Self::lazy_inout)
-			}
-		} else {
-			// Some Private: materialize all InOut inputs (push their F to public_values),
-			// result is Private.
-			for w in &wires {
-				Self::materialize(builder, w);
-			}
-			array::from_fn(|_| Self::Private)
-		}
+		builder_op(builder, wires.map(|wire| wire.0)).map(Self::new)
 	}
 
 	fn combine_varlen(
 		builder: &mut Self::Builder,
 		wires: &[&Self],
 		n_out: usize,
-		f_op: impl FnOnce(&[F]) -> Vec<F>,
-		_builder_op: impl FnOnce(&mut Self::Builder, &[()]) -> Vec<()>,
+		_f_op: impl FnOnce(&[F]) -> Vec<F>,
+		builder_op: impl FnOnce(&mut Self::Builder, &[PublicWire<F>]) -> Vec<PublicWire<F>>,
 	) -> Vec<Self> {
-		let inner_values = wires
-			.iter()
-			.map(|wire| match wire {
-				Self::Constant(val) => Some(*val),
-				Self::InOut { value, .. } => Some(*value),
-				Self::Private => None,
-			})
-			.collect::<Option<Vec<_>>>();
-		if let Some(inner_values) = inner_values {
-			let ret_values = f_op(&inner_values);
-			debug_assert_eq!(ret_values.len(), n_out);
-			let all_constant = wires.iter().all(|w| matches!(w, Self::Constant(_)));
-			if all_constant {
-				ret_values.into_iter().map(Self::Constant).collect()
-			} else {
-				ret_values.into_iter().map(Self::lazy_inout).collect()
-			}
-		} else {
-			for w in wires {
-				Self::materialize(builder, w);
-			}
-			(0..n_out).map(|_| Self::Private).collect()
-		}
-	}
-}
-
-/// [`CircuitBuilder`] backend used by [`ZKWrappedVerifierChannel`]. Has `Wire = ()` because the
-/// wrapper doesn't build a constraint system itself; its sole job is to accumulate the public
-/// values that `WrappedWire::InOut` materialization pushes (in materialization order, which
-/// matches the InOut allocation order in the outer constraint system built symbolically by
-/// [`IronSpartanBuilderChannel`](super::builder_channel::IronSpartanBuilderChannel)).
-///
-/// The `CircuitBuilder` methods (`assert_zero`, `add`, `mul`, `hint`, …) all return `()` and have
-/// no side effects: [`WrappedWire::combine`] never invokes `builder_op` because every value flows
-/// through `f_op` at the F level.
-#[derive(Debug, Default)]
-pub struct InOutSegmentBuilder<F> {
-	public_values: Vec<F>,
-}
-
-impl<F: Field> InOutSegmentBuilder<F> {
-	pub fn with_capacity(cap: usize) -> Self {
-		Self {
-			public_values: Vec::with_capacity(cap),
-		}
-	}
-
-	/// Records a freshly-materialized InOut value. Call order must match the order
-	/// [`BuilderWire::InOut`](super::builder_channel::BuilderWire) materializes in the symbolic
-	/// phase, so the resulting vec aligns 1:1 with the outer CS's InOut segment.
-	pub fn next_inout(&mut self, value: F) {
-		self.public_values.push(value);
-	}
-
-	pub fn into_public_values(self) -> Vec<F> {
-		self.public_values
-	}
-}
-
-impl<F: Field> CircuitBuilder for InOutSegmentBuilder<F> {
-	type Wire = ();
-	type Field = F;
-
-	fn assert_zero(&mut self, _wire: Self::Wire) {}
-
-	fn constant(&mut self, _val: Self::Field) -> Self::Wire {}
-
-	fn add(&mut self, _lhs: Self::Wire, _rhs: Self::Wire) -> Self::Wire {}
-
-	fn mul(&mut self, _lhs: Self::Wire, _rhs: Self::Wire) -> Self::Wire {}
-
-	fn hint<H: Fn([Self::Field; IN]) -> [Self::Field; OUT], const IN: usize, const OUT: usize>(
-		&mut self,
-		_inputs: [Self::Wire; IN],
-		_f: H,
-	) -> [Self::Wire; OUT] {
-		[(); OUT]
+		let inner_wires = wires.iter().map(|wire| wire.0).collect::<Vec<_>>();
+		let result = builder_op(builder, &inner_wires);
+		debug_assert_eq!(result.len(), n_out);
+		result.into_iter().map(Self::new).collect()
 	}
 }
 
 /// A verifier channel that wraps a [`BaseFoldZKVerifierChannel`] and an [`IOPVerifier`].
 ///
-/// `Self::Elem = CircuitElem<F, WrappedWire<F>>`. F values from the inner channel become lazy
-/// [`WrappedWire::InOut`] elements; the wrapper pushes them into `inout_builder`'s public-values
-/// vec only when arithmetic forces materialization (i.e. mixing with a [`WrappedWire::Private`],
-/// which is what `recv_one` arranges via its `inout - key` shape — same trigger as in
-/// [`IronSpartanBuilderChannel::recv_one`](super::builder_channel::IronSpartanBuilderChannel)).
-/// `sample` and `observe_one` return purely lazy InOuts that materialize only if the inner
-/// verifier later combines them with a Private.
+/// `Self::Elem = CircuitElem<F, WrappedWire<F>>`. F values received or sampled from the inner
+/// channel are written into the [`InstanceGenerator`]'s public segment as inout wires (in the same
+/// order the symbolic
+/// [`IronSpartanBuilderChannel`](super::builder_channel::IronSpartanBuilderChannel) allocates
+/// them); arithmetic over public values produces derived public values, and mixing with a precommit
+/// key (as `recv_one` arranges via `inout - key`) yields a value-less private result.
 ///
-/// `transparent` closures supplied via [`OracleLinearRelation`] must depend only on
-/// `Constant` and `InOut` inputs (sampled challenges), never on `Private` ones —
-/// `verify_oracle_relations` panics otherwise.
+/// `transparent` closures supplied via [`OracleLinearRelation`] must depend only on public inputs
+/// (constants and sampled challenges), never on private ones — `verify_oracle_relations` panics
+/// otherwise.
 pub struct ZKWrappedVerifierChannel<'a, F, MTScheme, Challenger_>
 where
 	F: BinaryField,
@@ -222,9 +96,16 @@ where
 	inner_channel: BaseFoldZKVerifierChannel<'a, F, MTScheme, Challenger_>,
 	outer_verifier: &'a IOPVerifier<F>,
 	precommit_oracle: BaseFoldZKOracle,
-	/// Owns the materialized public-values vec and exposes `next_inout(F)` for
-	/// [`WrappedWire::materialize`] to push into.
-	inout_builder: Rc<RefCell<InOutSegmentBuilder<F>>>,
+	/// Reconstructs the outer public-input vector as the channel replays the inner verifier;
+	/// `build()` yields the `[constants | inout | derived]` segment for the outer verify.
+	instance_gen: Rc<RefCell<InstanceGenerator<'a, F>>>,
+	/// Allocators for the InOut and Precommit segments. They live here, not on the
+	/// [`InstanceGenerator`], because allocating wires in interaction order is the channel's job;
+	/// the generator just writes a value to a given wire. Allocation order must match the symbolic
+	/// [`IronSpartanBuilderChannel`](super::builder_channel::IronSpartanBuilderChannel) so the wire
+	/// ids align with the outer layout.
+	inout_alloc: WireAllocator,
+	precommit_alloc: WireAllocator,
 	/// Number of outer oracles still to be received on `inner_channel` after inner verification
 	/// completes (i.e. the outer verifier's non-precommit oracles — private and mask).
 	n_outer_suffix_oracles: usize,
@@ -244,6 +125,9 @@ where
 	/// inner verification completes. `new` receives the outer precommit oracle from the inner
 	/// channel and stores the handle for use in [`Self::finish`].
 	///
+	/// `outer_layout` is the witness layout of the outer constraint system (the same layout the
+	/// prover used); it backs the [`InstanceGenerator`] that reconstructs the public-input vector.
+	///
 	/// # Panics
 	///
 	/// Panics if the channel's oracle specs do not match the expected layout
@@ -251,6 +135,7 @@ where
 	pub fn new(
 		mut inner_channel: BaseFoldZKVerifierChannel<'a, F, MTScheme, Challenger_>,
 		outer_verifier: &'a IOPVerifier<F>,
+		outer_layout: &'a WitnessLayout<F>,
 	) -> Result<Self, Error> {
 		let outer_oracle_specs = outer_verifier.oracle_specs();
 		let channel_oracle_specs = inner_channel.remaining_oracle_specs();
@@ -274,107 +159,103 @@ where
 
 		let precommit_oracle = inner_channel.recv_oracle()?;
 
-		let outer_public_size = 1 << outer_verifier.constraint_system().log_public();
 		Ok(Self {
 			inner_channel,
 			outer_verifier,
 			precommit_oracle,
-			inout_builder: Rc::new(RefCell::new(InOutSegmentBuilder::with_capacity(
-				outer_public_size,
-			))),
+			instance_gen: Rc::new(RefCell::new(InstanceGenerator::new(outer_layout))),
+			inout_alloc: WireAllocator::new(WireKind::InOut),
+			precommit_alloc: WireAllocator::new(WireKind::Precommit),
 			n_outer_suffix_oracles: suffix_len,
 		})
 	}
 
+	/// Allocates the next inout wire, writing `value` into the public segment, and wraps it as an
+	/// element. Allocation order must match the symbolic
+	/// [`IronSpartanBuilderChannel`](super::builder_channel::IronSpartanBuilderChannel).
+	fn alloc_inout_elem(&mut self, value: F) -> CircuitElem<F, WrappedWire<'a, F>> {
+		let wire = self.inout_alloc.alloc();
+		let public_wire = self.instance_gen.borrow_mut().write_inout(wire, value);
+		CircuitElem::wire(&self.instance_gen, WrappedWire::new(public_wire))
+	}
+
+	/// Allocates the next precommit wire (value-less to the verifier) as an element.
+	fn alloc_precommit_elem(&mut self) -> CircuitElem<F, WrappedWire<'a, F>> {
+		let wire = self.precommit_alloc.alloc();
+		let public_wire = self.instance_gen.borrow_mut().placeholder_precommit(wire);
+		CircuitElem::wire(&self.instance_gen, WrappedWire::new(public_wire))
+	}
+
 	/// Consumes the channel and runs the outer verifier.
 	///
-	/// Prepends the outer constraint system's constants to the materialized public values, pads to
-	/// the required public size, and runs [`IOPVerifier::verify`] against the inner channel.
+	/// Reads the outer public-input vector `[constants | inout | derived]` from the
+	/// [`InstanceGenerator`] and runs [`IOPVerifier::verify`] against the inner channel.
 	pub fn finish(self) -> Result<(), Error> {
-		let outer_cs = self.outer_verifier.constraint_system();
-		let public_size = 1 << outer_cs.log_public();
-
-		// Read the materialized public values by borrow rather than consuming the shared builder:
-		// the queued oracle relations (whose opening is deferred to `inner_channel.finish`) still
-		// hold references to it. The transparent closures never materialize new public values
-		// (their results are required to be non-`Private`), so the public segment is already
-		// final here.
-		let mut public = outer_cs.constants().to_vec();
-		public.extend(self.inout_builder.borrow().public_values.iter().copied());
-		public.resize(public_size, F::ZERO);
+		// The instance generator produced every public value (inout + alive-derived) as the inner
+		// verifier ran, so the public segment is already final here — read it by borrow. We must
+		// NOT consume the generator: the oracle relations queued onto `inner_channel` carry
+		// transparent closures that still hold (`Weak`) references to it, and opening them in
+		// `inner_channel.finish()` evaluates those closures. They only allocate dead derived wires
+		// (ids past the layout's count, so `layout.get` returns `None` and nothing is written), so
+		// the public vector read here stays correct.
+		let public = self.instance_gen.borrow().public().to_vec();
 
 		let mut inner_channel = self.inner_channel;
 		self.outer_verifier
 			.verify(self.precommit_oracle, public, &mut inner_channel)?;
 		// Both the inner and outer proofs queued their oracle relations onto `inner_channel`; run
-		// the single combined opening over all committed oracles now.
+		// the single combined opening over all committed oracles now. `instance_gen` stays alive in
+		// `self` for the duration, so the transparent closures' `Weak` upgrades succeed.
 		inner_channel.finish()?;
 		Ok(())
 	}
 }
 
-impl<F, MTScheme, Challenger_> IPVerifierChannel<F>
-	for ZKWrappedVerifierChannel<'_, F, MTScheme, Challenger_>
+impl<'a, F, MTScheme, Challenger_> IPVerifierChannel<F>
+	for ZKWrappedVerifierChannel<'a, F, MTScheme, Challenger_>
 where
 	F: BinaryField,
 	MTScheme: MerkleTreeScheme<F, Digest: DeserializeBytes>,
 	Challenger_: Challenger,
 {
-	type Elem = CircuitElem<F, WrappedWire<F>>;
+	type Elem = CircuitElem<F, WrappedWire<'a, F>>;
 
 	fn recv_one(&mut self) -> Result<Self::Elem, binius_ip::channel::Error> {
-		// Mirror `IronSpartanBuilderChannel::recv_one`'s shape: `inout - key`. The InOut carries
-		// the encrypted F received from the inner channel; the key is `Private` (the OTP key is
-		// not known to the wrapper). The subtraction triggers materialization of the InOut
-		// (pushing the encrypted F to `public_values`), and the result is `Private` — matching
-		// the symbolic phase's Private result wire.
+		// Mirror `IronSpartanBuilderChannel::recv_one`'s shape: `inout - key`. The inout carries
+		// the encrypted F received from the inner channel (written into the public segment); the
+		// key is a precommit wire whose value the verifier does not know (`PublicWire(None)`).
+		// The subtraction yields a private result, matching the symbolic phase's private result
+		// wire.
 		let val = self.inner_channel.recv_one()?;
-		let inout = CircuitElem::wire(&self.inout_builder, WrappedWire::lazy_inout(val));
-		let key = CircuitElem::wire(&self.inout_builder, WrappedWire::Private);
+		let inout = self.alloc_inout_elem(val);
+		let key = self.alloc_precommit_elem();
 		Ok(inout - key)
 	}
 
 	fn sample(&mut self) -> Self::Elem {
 		let val = self.inner_channel.sample();
-		CircuitElem::wire(&self.inout_builder, WrappedWire::lazy_inout(val))
+		self.alloc_inout_elem(val)
 	}
 
 	fn observe_one(&mut self, val: F) -> Self::Elem {
 		let elem = self.inner_channel.observe_one(val);
-		CircuitElem::wire(&self.inout_builder, WrappedWire::lazy_inout(elem))
+		self.alloc_inout_elem(elem)
 	}
 
 	fn assert_zero(&mut self, val: Self::Elem) -> Result<(), binius_ip::channel::Error> {
 		match val {
-			CircuitElem::Constant(c)
-			| CircuitElem::Wire {
-				wire: WrappedWire::Constant(c),
-				..
-			} => {
+			// A compile-time constant is checked here; a non-zero one is an unsatisfiable
+			// assertion.
+			CircuitElem::Constant(c) => {
 				if c == F::ZERO {
 					Ok(())
 				} else {
 					Err(binius_ip::channel::Error::InvalidAssert)
 				}
 			}
-			CircuitElem::Wire {
-				wire: WrappedWire::InOut { value, .. },
-				..
-			} => {
-				if value == F::ZERO {
-					Ok(())
-				} else {
-					Err(binius_ip::channel::Error::InvalidAssert)
-				}
-			}
-			CircuitElem::Wire {
-				wire: WrappedWire::Private,
-				..
-			} => {
-				// No-op: the corresponding constraint exists in the outer CS and is checked by
-				// the outer verifier.
-				Ok(())
-			}
+			// No-op for wires: the corresponding constraint was recorded symbolically and is
+			// checked by the outer verifier over the reconstructed public segment.
+			CircuitElem::Wire { .. } => Ok(()),
 		}
 	}
 
@@ -383,20 +264,11 @@ where
 		inputs: &[Self::Elem],
 		f: impl FnOnce(&[F]) -> F,
 	) -> Self::Elem {
-		let input_refs = inputs.iter().collect::<Vec<_>>();
-		let outs = CircuitElem::combine_varlen(
-			&input_refs,
-			1,
-			move |inputs| vec![f(inputs)],
-			|_, _| {
-				// Self::Elem::combine_varlen will only call the builder_op closure if any inputs
-				// are non-public.
-				panic!("compute_public_value: input is not public")
-			},
-		);
-		outs.into_iter()
-			.next()
-			.expect("combine_varlen returns Vec with len = n_out; n_out = 1")
+		// The closure's result enters as a single inout wire (matching the symbolic builder), whose
+		// value the verifier computes natively from the public-derived inputs. See
+		// `IronSpartanBuilderChannel::compute_public_value`.
+		let value = f(&extract_public_values(inputs));
+		self.alloc_inout_elem(value)
 	}
 }
 
@@ -427,67 +299,73 @@ where
 		&mut self,
 		oracle_relations: impl IntoIterator<Item = OracleLinearRelation<'a, Self::Oracle, Self::Elem>>,
 	) -> Result<(), binius_iop::channel::Error> {
-		let oracle_relations = oracle_relations
-			.into_iter()
-			.map(
-				|OracleLinearRelation {
-				     oracle,
-				     transparent,
-				     claim: _,
-				 }| {
-					// For each oracle opening, the prover sends the decrypted evaluation. Push it
-					// to public_values directly (it's a known InOut value the outer verifier
-					// reads) and rebuild the relation for the inner channel.
-					let decrypted_claim = self.inner_channel.recv_one()?;
-					self.inout_builder
-						.borrow_mut()
-						.next_inout(decrypted_claim);
+		let mut inner_relations = Vec::new();
+		for OracleLinearRelation {
+			oracle,
+			transparent,
+			claim,
+		} in oracle_relations
+		{
+			// For each oracle opening, the prover sends the decrypted evaluation. Allocate it as an
+			// inout wire (written into the public segment) and attest `claim == decrypted_claim`,
+			// exactly as the symbolic `IronSpartanBuilderChannel` does. The assertion is a no-op on
+			// values here, but evaluating `claim - decrypted_claim` keeps the instance generator's
+			// wire allocation aligned with the symbolic constraint system. Rebuild the relation
+			// with the decrypted value for the inner channel.
+			let decrypted_value = self.inner_channel.recv_one()?;
+			let decrypted_claim = self.alloc_inout_elem(decrypted_value);
+			self.assert_zero(claim - decrypted_claim)?;
 
-					// Wrap the sumcheck challenge coordinates for the transparent closure (which
-					// expects `CircuitElem`s). The closure can do further arithmetic; results are
-					// required to be value-known (Constant or InOut), never Private.
-					//
-					// HACK: the coordinates are sampled challenges, so they are wrapped as
-					// `Constant`s rather than builder-backed InOut wires. This frees the closure
-					// from holding a reference to `inout_builder`, and is sound only because the
-					// symbolic outer circuit (`IronSpartanBuilderChannel`) never invokes the
-					// transparent closure — it attests only `claim == decrypted_claim`, with the
-					// transparent evaluation performed out of circuit. This F->CircuitElem->F
-					// bridge should eventually be replaced by an F-level transparent evaluator.
-					let eval_fn = move |vals: &[F]| {
-						let wrapped_vals = vals
-							.iter()
-							.map(|val| CircuitElem::Constant(*val))
-							.collect::<Vec<_>>();
+			// Wrap the sumcheck challenge coordinates for the transparent closure (which expects
+			// `CircuitElem`s). The closure can do further arithmetic; results are required to be
+			// value-known (public), never private.
+			//
+			// HACK: the coordinates are sampled challenges, so they are wrapped as `Constant`s
+			// rather than builder-backed wires. This frees the closure from holding a reference to
+			// the instance generator, and is sound only because the symbolic outer circuit
+			// (`IronSpartanBuilderChannel`) never invokes the transparent closure — it attests only
+			// `claim == decrypted_claim`, with the transparent evaluation performed out of circuit.
+			// This F->CircuitElem->F bridge should eventually be replaced by an F-level transparent
+			// evaluator.
+			let eval_fn = move |vals: &[F]| {
+				let wrapped_vals = vals
+					.iter()
+					.map(|val| CircuitElem::Constant(*val))
+					.collect::<Vec<_>>();
 
-						match transparent(&wrapped_vals) {
-							CircuitElem::Constant(val)
-							| CircuitElem::Wire {
-								wire: WrappedWire::Constant(val),
-								..
-							}
-							| CircuitElem::Wire {
-								wire: WrappedWire::InOut { value: val, .. },
-								..
-							} => val,
-							CircuitElem::Wire {
-								wire: WrappedWire::Private,
-								..
-							} => {
-								panic!(
-									"precondition: the transparent polynomial evaluation must depend only on known values (constants or sampled challenges)"
-								);
-							}
-						}
-					};
-					Ok(OracleLinearRelation {
-						oracle,
-						claim: decrypted_claim,
-						transparent: Box::new(eval_fn),
-					})
-				},
-			)
-			.collect::<Result<Vec<_>, binius_iop::channel::Error>>()?;
-		self.inner_channel.verify_oracle_relations(oracle_relations)
+				match transparent(&wrapped_vals) {
+					CircuitElem::Constant(val) => val,
+					CircuitElem::Wire {
+						wire: WrappedWire(public_wire, _),
+						..
+					} => public_wire.value().expect(
+						"precondition: the transparent polynomial evaluation must depend only on known values (constants or sampled challenges)",
+					),
+				}
+			};
+			inner_relations.push(OracleLinearRelation {
+				oracle,
+				claim: decrypted_value,
+				transparent: Box::new(eval_fn),
+			});
+		}
+		self.inner_channel.verify_oracle_relations(inner_relations)
 	}
+}
+
+/// Extracts the concrete field value of each public-derived input. Panics if any input is not
+/// public (value-less), enforcing the [`IPVerifierChannel::compute_public_value`] contract.
+fn extract_public_values<F: Field>(inputs: &[CircuitElem<F, WrappedWire<'_, F>>]) -> Vec<F> {
+	inputs
+		.iter()
+		.map(|elem| match elem {
+			CircuitElem::Constant(c) => *c,
+			CircuitElem::Wire {
+				wire: WrappedWire(public_wire, _),
+				..
+			} => public_wire
+				.value()
+				.expect("compute_public_value: input is not public"),
+		})
+		.collect()
 }

--- a/crates/verifier/src/zk_config.rs
+++ b/crates/verifier/src/zk_config.rs
@@ -22,7 +22,10 @@ use binius_iop::{
 	fri::{self, MinProofSizeStrategy},
 	merkle_tree::BinaryMerkleTreeScheme,
 };
-use binius_spartan_frontend::{compiler::compile, constraint_system::BlindingInfo};
+use binius_spartan_frontend::{
+	compiler::compile,
+	constraint_system::{BlindingInfo, WitnessLayout},
+};
 use binius_spartan_verifier::{
 	IOPVerifier as IronSpartanIOPVerifier,
 	constraint_system::ConstraintSystemPadded,
@@ -49,6 +52,7 @@ use crate::{
 pub struct ZKVerifier<H: HashSuite> {
 	inner_iop_verifier: IOPVerifier,
 	outer_iop_verifier: IronSpartanIOPVerifier<B128>,
+	outer_layout: WitnessLayout<B128>,
 	basefold_compiler: BaseFoldZKVerifierCompiler<B128, BinaryMerkleTreeScheme<B128, H>>,
 }
 
@@ -85,7 +89,7 @@ where
 				.expect("symbolic verify should not fail");
 			builder_channel.finish()
 		};
-		let (outer_cs, _) = {
+		let (outer_cs, outer_layout) = {
 			let _guard = tracing::debug_span!("Compile ZK wrapper circuit").entered();
 			compile(outer_builder)
 		};
@@ -105,6 +109,7 @@ where
 			n_dummy_constraints: 2,
 		};
 		let outer_cs = ConstraintSystemPadded::new(outer_cs, blinding_info);
+		let outer_layout = outer_layout.with_blinding(outer_cs.blinding_info().clone());
 		let outer_iop_verifier = IronSpartanIOPVerifier::new(outer_cs);
 
 		// Transcript layout: outer precommit oracle first (committed at wrapper construction),
@@ -129,6 +134,7 @@ where
 		Ok(Self {
 			inner_iop_verifier,
 			outer_iop_verifier,
+			outer_layout,
 			basefold_compiler,
 		})
 	}
@@ -173,7 +179,8 @@ where
 	) -> Result<(), Error> {
 		// Create BaseFoldZK channel and wrap with outer verifier.
 		let channel = self.basefold_compiler.create_channel(transcript);
-		let mut wrapped_channel = ZKWrappedVerifierChannel::new(channel, &self.outer_iop_verifier)?;
+		let mut wrapped_channel =
+			ZKWrappedVerifierChannel::new(channel, &self.outer_iop_verifier, &self.outer_layout)?;
 
 		// Run the inner IOP verification through the wrapped channel.
 		{


### PR DESCRIPTION
Closes [BINIUS-99](https://linear.app/jimpo/issue/BINIUS-99/remove-the-inout-lazy-evaluation-from-spartan-wrapper-logic).

## Summary

The three `CircuitWire` backends in the Spartan wrapper (`BuilderWire`, `WrappedWire`, `WitnessGenWire`) each reimplemented "lazy inout": tracking values as `Constant`/`InOut`/`Private` and materializing inout wires only when mixed with a private wire. BINIUS-93 moved exactly that public-derivable elision into the frontend builders (derived wires get a public slot only when a surviving constraint references them), so the wrapper layer was redundant.

Each wire is now a thin newtype that delegates straight to its frontend builder; inout/precommit wires are allocated eagerly and the builder decides derived-vs-private:

- `BuilderWire(ConstraintWire)` → `ConstraintBuilder`
- `WrappedWire(PublicWire)` → `InstanceGenerator`
- `WitnessGenWire(WitnessWire)` → `WitnessGenerator`

The bespoke `InOutSegmentBuilder`, `WitnessGeneratorWithAlloc`, and `LazyInOut` are gone (net −645/+294 lines).

## Commits

1. **add allocate-and-write inout/precommit methods to witness/instance generators** — fold the inout/precommit `WireAllocator`s (previously in `WitnessGeneratorWithAlloc`) into `WitnessGenerator`, add a matching inout allocator + `next_inout`/`next_precommit` to `InstanceGenerator`, and add `PublicWire::value`. Pure frontend additions; existing `write_inout`/`write_precommit`/`placeholder_precommit` (the constraint-replay flow) stay.
2. **remove InOut lazy evaluation from Spartan wrapper channels** — the wrapper rewrite. The three channels now run identical arithmetic so the public vector (inout + derived) stays aligned across symbolic/instance/witness; `ZKWrappedVerifierChannel::new` gains `&outer_layout` (mirroring the prover side), threaded through `verifier::zk_config`.
3. **drop dead f_op parameter from CircuitWire::combine** — no impl uses the field-level closure anymore; `CircuitElem` keeps it for the all-constant fast path.

The three channels are coupled by the public-vector alignment invariant (the end-to-end `wrapper_integration_test` spans them), so commit 2 is necessarily atomic.

## Design decisions worth a look

A few choices here are mine, not dictated by the issue — flagging them so you can react in review:

- **`assert_zero` on public wires.** The symbolic builder now records a constraint for *every* wire (public-derivable or private) and the concrete verifier no-ops; the outer verifier enforces it over the reconstructed public segment. This replaces the old eager wrapper-side value check — rejection moves from the wrapper to the outer verifier, and the outer CS grows slightly. The alternative (symbolic no-op + concrete eager check) preserves the old behavior more literally; I chose the uniform path since derived wires make the special-casing unnecessary.
- **`compute_public_value` allocates a single inout wire.** The closure is an arbitrary native computation the CS can't replay, so its result enters as a supplied public input (inout), never a derived wire. This keeps the "one inout instead of a sub-circuit" optimization the HACK exists for; it now allocates eagerly rather than lazily.
- **`CircuitWire` could eventually go away.** With the three impls reduced to identical `builder_op` delegations, `CircuitElem` could be made generic over the `CircuitBuilder` directly and the trait dropped. Out of scope here (the issue framed the fix as newtypes), but noting it as a possible follow-up.

## Testing

`cargo test` for `binius-spartan-frontend`, `binius-spartan-verifier`, `binius-spartan-prover`, and the real ZK roundtrip in `binius-prover` (`prove_verify`, incl. `test_zk_prove_verify_sha256_preimage` and the signature-of-knowledge tests) all pass; clippy + fmt clean on the affected crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)