### PR TITLE
Change BinaryField128bGhash underlier to M128 (BINIUS-101)

### DIFF
--- a/crates/field/src/aes_field.rs
+++ b/crates/field/src/aes_field.rs
@@ -35,6 +35,12 @@ use crate::{
 //  ...
 binary_field!(pub AESTowerField8b(u8), 0xD0);
 
+impl AESTowerField8b {
+	pub const fn new(value: u8) -> Self {
+		Self(value)
+	}
+}
+
 crate::arithmetic_traits::impl_trivial_wide_mul!(AESTowerField8b);
 
 unsafe impl Pod for AESTowerField8b {}

--- a/crates/field/src/arch/aarch64/m128.rs
+++ b/crates/field/src/arch/aarch64/m128.rs
@@ -1,4 +1,5 @@
 // Copyright 2024-2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 use std::{
 	arch::aarch64::*,
@@ -22,7 +23,7 @@ use crate::{
 	underlier::{
 		NumCast, SmallU, UnderlierType,
 		divisible::{Divisible, mapget},
-		impl_divisible_bitmask,
+		impl_divisible_bitmask, impl_divisible_self,
 	},
 };
 
@@ -226,6 +227,9 @@ impl DeserializeBytes for M128 {
 
 impl_divisible_bitmask!(M128, 1, 2, 4);
 
+// Reflexive divisibility, needed when M128 is itself a field underlier (a width-1 packed field).
+impl_divisible_self!(M128);
+
 // Manual Divisible implementations using NEON intrinsics
 
 impl Divisible<u128> for M128 {
@@ -264,6 +268,48 @@ impl Divisible<u128> for M128 {
 	#[inline]
 	fn from_iter(mut iter: impl Iterator<Item = u128>) -> Self {
 		iter.next().map(Self::from).unwrap_or(Self::ZERO)
+	}
+}
+
+// The reverse of `Divisible<u128> for M128`: a `u128` holds exactly one `M128` (a width-1
+// reinterpret). Needed because `BinaryField128bGhash`'s underlier is `M128` while the portable
+// `PackedBinaryGhash1x128b` packs it in a `u128`.
+impl Divisible<M128> for u128 {
+	const LOG_N: usize = 0;
+
+	#[inline]
+	fn value_iter(value: Self) -> impl ExactSizeIterator<Item = M128> + Send + Clone {
+		std::iter::once(M128::from(value))
+	}
+
+	#[inline]
+	fn ref_iter(value: &Self) -> impl ExactSizeIterator<Item = M128> + Send + Clone + '_ {
+		std::iter::once(M128::from(*value))
+	}
+
+	#[inline]
+	fn slice_iter(slice: &[Self]) -> impl ExactSizeIterator<Item = M128> + Send + Clone + '_ {
+		slice.iter().map(|&v| M128::from(v))
+	}
+
+	#[inline]
+	unsafe fn get_unchecked(&self, _index: usize) -> M128 {
+		M128::from(*self)
+	}
+
+	#[inline]
+	unsafe fn set_unchecked(&mut self, _index: usize, val: M128) {
+		*self = u128::from(val);
+	}
+
+	#[inline]
+	fn broadcast(val: M128) -> Self {
+		u128::from(val)
+	}
+
+	#[inline]
+	fn from_iter(mut iter: impl Iterator<Item = M128>) -> Self {
+		iter.next().map(u128::from).unwrap_or(0)
 	}
 }
 

--- a/crates/field/src/arch/aarch64/m128.rs
+++ b/crates/field/src/arch/aarch64/m128.rs
@@ -79,6 +79,18 @@ impl Ord for M128 {
 	}
 }
 
+impl std::hash::Hash for M128 {
+	fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+		u128::from(*self).hash(state);
+	}
+}
+
+impl std::fmt::LowerHex for M128 {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		std::fmt::LowerHex::fmt(&u128::from(*self), f)
+	}
+}
+
 unsafe impl Zeroable for M128 {}
 unsafe impl Pod for M128 {}
 

--- a/crates/field/src/arch/mod.rs
+++ b/crates/field/src/arch/mod.rs
@@ -1,4 +1,5 @@
 // Copyright 2023-2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 use cfg_if::cfg_if;
 
@@ -32,6 +33,22 @@ cfg_if! {
 		pub use u128 as M128;
 		pub use portable::{packed_128::{self, M128}, packed_256::{self, M256}, packed_512, packed_aes_128, packed_aes_256, packed_aes_512, packed_ghash_128, packed_ghash_256, packed_ghash_512};
 	}
+}
+
+/// Builds an [`M128`] from a `u128` in a `const` context.
+///
+/// `M128` is the architecture-chosen 128-bit underlier — a SIMD register on x86_64/aarch64, plain
+/// `u128` elsewhere. `From<u128>` is not `const`, so this helper is used where a const `M128`
+/// constant is needed (e.g. a field's multiplicative generator).
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+pub(crate) const fn m128_from_u128(value: u128) -> M128 {
+	M128::from_u128(value)
+}
+
+/// Builds an [`M128`] from a `u128` in a `const` context. See the SIMD variant for details.
+#[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+pub(crate) const fn m128_from_u128(value: u128) -> M128 {
+	value
 }
 
 pub use arch_optimal::*;

--- a/crates/field/src/arch/portable/nibble_invert_128b.rs
+++ b/crates/field/src/arch/portable/nibble_invert_128b.rs
@@ -1,4 +1,5 @@
 // Copyright 2023-2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 //! Generic nibble-based inversion algorithm for 128-bit binary fields.
 //!
@@ -27,7 +28,8 @@ pub(super) fn nibble_invert_128b<F>(
 	nibble_table: &[[[u128; 16]; 32]; 6],
 ) -> F
 where
-	F: Field + WithUnderlier<Underlier = u128> + Square,
+	F: Field + WithUnderlier + Square,
+	F::Underlier: From<u128> + Into<u128>,
 {
 	// Computes value^{2^128-2}
 	// value * value^(2^128 - 2) = value^(2^128-1) = 1 if value != 0
@@ -71,7 +73,8 @@ pub(super) fn pow_2_2_n<F>(
 	nibble_table: &[[[u128; 16]; 32]; 6],
 ) -> F
 where
-	F: Field + WithUnderlier<Underlier = u128> + Square,
+	F: Field + WithUnderlier + Square,
+	F::Underlier: From<u128> + Into<u128>,
 {
 	match n {
 		// value^(2^(2^0)) = value^2
@@ -87,7 +90,7 @@ where
 				})
 				.fold(0, BitXor::bitxor);
 
-			F::from_underlier(result)
+			F::from_underlier(result.into())
 		}
 		_ => value,
 	}
@@ -111,7 +114,7 @@ pub fn generate_nibble_pow_2_n_table<F>(
 	to_u128: impl Fn(F) -> u128,
 ) -> [[[u128; 16]; 32]; 6]
 where
-	F: Field + WithUnderlier<Underlier = u128> + Square,
+	F: Field + WithUnderlier + Square,
 {
 	let mut results = [[[0u128; 16]; 32]; 6];
 

--- a/crates/field/src/arch/portable/packed_ghash_128.rs
+++ b/crates/field/src/arch/portable/packed_ghash_128.rs
@@ -134,7 +134,7 @@ impl TaggedInvertOrZero<GhashStrategy> for PackedBinaryGhash1x128b {
 		// Use the generic nibble-based inversion algorithm
 		let result = nibble_invert_128b(
 			self.get(0),
-			|f| f.to_underlier(), // GHASH uses direct representation (no Montgomery form)
+			|f| f.to_underlier().into(), // GHASH uses direct representation (no Montgomery form)
 			&GHASH_NIBBLE_POW_2_N_TABLE,
 		);
 		Self::set_single(result)
@@ -3559,8 +3559,8 @@ mod tests {
 	proptest! {
 		#[test]
 		fn test_pow_2_2_n(a_val in any::<u128>(), n in 1..4usize) {
-			let a = BinaryField128bGhash::new(a_val);
-			let result = pow_2_2_n(a, n, &|val| val.to_underlier(), &GHASH_NIBBLE_POW_2_N_TABLE);
+			let a = BinaryField128bGhash::from(a_val);
+			let result = pow_2_2_n(a, n, &|val| val.to_underlier().into(), &GHASH_NIBBLE_POW_2_N_TABLE);
 			let mut expected = a;
 			for _ in 0..((1 << (1 << n)) - 1) {
 				expected *= a;
@@ -3574,8 +3574,10 @@ mod tests {
 	#[test]
 	#[ignore]
 	fn generate_ghash_nibble_pow_2_n_table() {
-		let table =
-			generate_nibble_pow_2_n_table(BinaryField128bGhash::new, |field| field.to_underlier());
+		let table = generate_nibble_pow_2_n_table(
+			|v: u128| BinaryField128bGhash::from(v),
+			|field| field.to_underlier().into(),
+		);
 
 		print_nibble_table(&table, "GHASH_NIBBLE_POW_2_N_TABLE");
 	}

--- a/crates/field/src/arch/x86_64/m128.rs
+++ b/crates/field/src/arch/x86_64/m128.rs
@@ -1,4 +1,5 @@
 // Copyright 2024-2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 use std::{
 	arch::x86_64::*,
@@ -23,7 +24,7 @@ use crate::{
 	arch::portable::packed::PackedPrimitiveType,
 	underlier::{
 		Divisible, NumCast, SmallU, SpreadToByte, U2, U4, UnderlierType, impl_divisible_bitmask,
-		mapget, spread_fallback,
+		impl_divisible_self, mapget, spread_fallback,
 	},
 };
 
@@ -694,6 +695,9 @@ unsafe fn interleave_bits_imm<const BLOCK_LEN: i32>(
 
 // Divisible implementations using SIMD extract/insert intrinsics
 
+// Reflexive divisibility, needed when M128 is itself a field underlier (a width-1 packed field).
+impl_divisible_self!(M128);
+
 impl Divisible<u128> for M128 {
 	const LOG_N: usize = 0;
 
@@ -730,6 +734,48 @@ impl Divisible<u128> for M128 {
 	#[inline]
 	fn from_iter(mut iter: impl Iterator<Item = u128>) -> Self {
 		iter.next().map(Self::from).unwrap_or(Self::ZERO)
+	}
+}
+
+// The reverse of `Divisible<u128> for M128`: a `u128` holds exactly one `M128` (a width-1
+// reinterpret). Needed because `BinaryField128bGhash`'s underlier is `M128` while the portable
+// `PackedBinaryGhash1x128b` packs it in a `u128`.
+impl Divisible<M128> for u128 {
+	const LOG_N: usize = 0;
+
+	#[inline]
+	fn value_iter(value: Self) -> impl ExactSizeIterator<Item = M128> + Send + Clone {
+		std::iter::once(M128::from(value))
+	}
+
+	#[inline]
+	fn ref_iter(value: &Self) -> impl ExactSizeIterator<Item = M128> + Send + Clone + '_ {
+		std::iter::once(M128::from(*value))
+	}
+
+	#[inline]
+	fn slice_iter(slice: &[Self]) -> impl ExactSizeIterator<Item = M128> + Send + Clone + '_ {
+		slice.iter().map(|&v| M128::from(v))
+	}
+
+	#[inline]
+	unsafe fn get_unchecked(&self, _index: usize) -> M128 {
+		M128::from(*self)
+	}
+
+	#[inline]
+	unsafe fn set_unchecked(&mut self, _index: usize, val: M128) {
+		*self = u128::from(val);
+	}
+
+	#[inline]
+	fn broadcast(val: M128) -> Self {
+		u128::from(val)
+	}
+
+	#[inline]
+	fn from_iter(mut iter: impl Iterator<Item = M128>) -> Self {
+		iter.next().map(u128::from).unwrap_or(0)
 	}
 }
 

--- a/crates/field/src/arch/x86_64/m128.rs
+++ b/crates/field/src/arch/x86_64/m128.rs
@@ -291,6 +291,18 @@ impl Ord for M128 {
 	}
 }
 
+impl std::hash::Hash for M128 {
+	fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+		u128::from(*self).hash(state);
+	}
+}
+
+impl std::fmt::LowerHex for M128 {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		std::fmt::LowerHex::fmt(&u128::from(*self), f)
+	}
+}
+
 impl Distribution<M128> for StandardUniform {
 	fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> M128 {
 		M128(rng.random())

--- a/crates/field/src/binary_field.rs
+++ b/crates/field/src/binary_field.rs
@@ -82,11 +82,10 @@ macro_rules! binary_field {
 		#[repr(transparent)]
 		$vis struct $name(pub(crate) $typ);
 
+		// NOTE: `new` is intentionally NOT generated here. Each field defines its own `new` so it
+		// can take an ergonomic constructor type independent of the underlier (e.g.
+		// `BinaryField128bGhash::new` takes `u128` even though its underlier is `M128`).
 		impl $name {
-			pub const fn new(value: $typ) -> Self {
-				Self(value)
-			}
-
 			pub const fn val(self) -> $typ {
 				self.0
 			}
@@ -226,8 +225,8 @@ macro_rules! binary_field {
 		}
 
 		impl Field for $name {
-			const ZERO: Self = $name::new(<$typ as $crate::underlier::UnderlierType>::ZERO);
-			const ONE: Self = $name::new(<$typ as $crate::underlier::UnderlierType>::ONE);
+			const ZERO: Self = $name(<$typ as $crate::underlier::UnderlierType>::ZERO);
+			const ONE: Self = $name(<$typ as $crate::underlier::UnderlierType>::ONE);
 			const CHARACTERISTIC: usize = 2;
 			const ORDER_EXPONENT: usize = <$typ as $crate::underlier::UnderlierType>::BITS;
 			const MULTIPLICATIVE_GENERATOR: $name = $name($gen);
@@ -367,7 +366,7 @@ macro_rules! impl_field_extension {
 				if elem.0 >> $subfield_name::N_BITS
 					== <$typ as $crate::underlier::UnderlierType>::ZERO
 				{
-					Ok($subfield_name::new(<$subfield_typ>::num_cast_from(elem.val())))
+					Ok($subfield_name(<$subfield_typ>::num_cast_from(elem.val())))
 				} else {
 					Err(())
 				}
@@ -377,7 +376,7 @@ macro_rules! impl_field_extension {
 		impl From<$subfield_name> for $name {
 			#[inline]
 			fn from(elem: $subfield_name) -> Self {
-				$name::new(<$typ>::from(elem.val()))
+				$name(<$typ>::from(elem.val()))
 			}
 		}
 
@@ -461,7 +460,7 @@ macro_rules! impl_field_extension {
 					i,
 					1 << $log_degree
 				);
-				Self::new(<$typ>::ONE << (i * $subfield_name::N_BITS))
+				Self(<$typ>::ONE << (i * $subfield_name::N_BITS))
 			}
 
 			#[inline]
@@ -482,7 +481,7 @@ macro_rules! impl_field_extension {
 					shift += shift_step;
 				}
 
-				Self::new(value)
+				Self(value)
 			}
 
 			#[inline]
@@ -546,6 +545,10 @@ impl FixedSizeSerializeBytes for BinaryField1b {
 }
 
 impl BinaryField1b {
+	pub const fn new(value: U1) -> Self {
+		Self(value)
+	}
+
 	/// Creates value without checking that it is within valid range (0 or 1)
 	///
 	/// # Safety
@@ -691,7 +694,7 @@ pub(crate) mod tests {
 		assert_eq!(format!("{}", BinaryField1b::from(1)), "0x1");
 		assert_eq!(format!("{}", AESTowerField8b::from(3)), "0x03");
 		assert_eq!(
-			format!("{}", BinaryField128bGhash::from(5)),
+			format!("{}", BinaryField128bGhash::new(5)),
 			"0x00000000000000000000000000000005"
 		);
 	}
@@ -713,7 +716,7 @@ pub(crate) mod tests {
 
 		#[test]
 		fn test_inverse_128b(val in 1u128..) {
-			let x = BinaryField128bGhash::new(val);
+			let x = BinaryField128bGhash::from(val);
 			let x_inverse = x.invert().unwrap();
 			assert_eq!(x * x_inverse, BinaryField128bGhash::ONE);
 		}

--- a/crates/field/src/ghash.rs
+++ b/crates/field/src/ghash.rs
@@ -23,7 +23,7 @@ use super::{
 };
 use crate::{
 	AESTowerField8b, Divisible, Field, PackedField, WideMul,
-	arch::packed_ghash_128::PackedBinaryGhash1x128b,
+	arch::{M128, m128_from_u128, packed_ghash_128::PackedBinaryGhash1x128b},
 	arithmetic_traits::InvertOrZero,
 	binary_field_arithmetic::{
 		TowerFieldArithmetic, invert_or_zero_using_packed, multiple_using_packed,
@@ -33,7 +33,25 @@ use crate::{
 	underlier::{U1, WithUnderlier},
 };
 
-binary_field!(pub BinaryField128bGhash(u128), 0x494ef99794d5244f9152df59d87a9186);
+binary_field!(pub BinaryField128bGhash(M128), m128_from_u128(0x494ef99794d5244f9152df59d87a9186));
+
+// Convenience `u128` conversions. `binary_field!` already provides `From<M128>`/`From<.. for
+// M128>`; on wasm/portable `M128 = u128`, so those *are* the `u128` conversions and these would
+// collide — hence the arch gate. On x86_64/aarch64 (where `M128` is a SIMD struct) they let callers
+// keep constructing/inspecting `BinaryField128bGhash` via `u128`.
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+impl From<u128> for BinaryField128bGhash {
+	fn from(value: u128) -> Self {
+		Self(M128::from(value))
+	}
+}
+
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+impl From<BinaryField128bGhash> for u128 {
+	fn from(value: BinaryField128bGhash) -> Self {
+		value.0.into()
+	}
+}
 
 // Deferred-reduction widening multiply, implemented by reusing the width-1 packed GHASH type. On
 // CLMUL backends `Output` is an unreduced `WideGhashProduct`, so accumulating products reduces
@@ -58,9 +76,16 @@ impl WideMul for BinaryField128bGhash {
 unsafe impl Pod for BinaryField128bGhash {}
 
 impl BinaryField128bGhash {
+	/// Constructs an element from its `u128` value. The underlier is `M128`, but `u128` is the
+	/// ergonomic constructor type, so this converts (a no-op where `M128 = u128`).
+	pub const fn new(value: u128) -> Self {
+		Self(m128_from_u128(value))
+	}
+
 	#[inline]
 	pub fn mul_x(self) -> Self {
-		let val = self.to_underlier();
+		// These scalar bit manipulations are simplest over `u128`; the underlier is `M128`.
+		let val: u128 = self.to_underlier().into();
 		let shifted = val << 1;
 
 		// GHASH irreducible polynomial: x^128 + x^7 + x^2 + x + 1
@@ -69,12 +94,13 @@ impl BinaryField128bGhash {
 		let mask = (val >> 127).wrapping_neg();
 		let result = shifted ^ (0x87 & mask);
 
-		Self::from_underlier(result)
+		Self::new(result)
 	}
 
 	#[inline]
 	pub fn mul_inv_x(self) -> Self {
-		let val = self.to_underlier();
+		// These scalar bit manipulations are simplest over `u128`; the underlier is `M128`.
+		let val: u128 = self.to_underlier().into();
 		let shifted = val >> 1;
 
 		// If low bit was set, we need to add compensation for the remainder
@@ -85,15 +111,17 @@ impl BinaryField128bGhash {
 		let mask = (val & 1).wrapping_neg();
 		let result = shifted ^ (((1u128 << 127) | 0x43) & mask);
 
-		Self::from_underlier(result)
+		Self::new(result)
 	}
 }
 
 impl TowerField for BinaryField128bGhash {
 	fn min_tower_level(self) -> usize {
-		match self {
-			Self::ZERO | Self::ONE => 0,
-			_ => 7,
+		// `M128` is not structurally matchable, so compare against the constants directly.
+		if self == Self::ZERO || self == Self::ONE {
+			0
+		} else {
+			7
 		}
 	}
 }
@@ -117,7 +145,7 @@ impl InvertOrZero for BinaryField128bGhash {
 	}
 }
 
-impl_field_extension!(BinaryField1b(U1) < @7 => BinaryField128bGhash(u128));
+impl_field_extension!(BinaryField1b(U1) < @7 => BinaryField128bGhash(M128));
 
 mul_by_binary_field_1b!(BinaryField128bGhash);
 
@@ -143,266 +171,268 @@ impl FixedSizeSerializeBytes for BinaryField128bGhash {
 impl From<AESTowerField8b> for BinaryField128bGhash {
 	#[inline]
 	fn from(value: AESTowerField8b) -> Self {
-		const LOOKUP_TABLE: [BinaryField128bGhash; 256] = [
-			BinaryField128bGhash(0x00000000000000000000000000000000),
-			BinaryField128bGhash(0x00000000000000000000000000000001),
-			BinaryField128bGhash(0x0dcb364640a222fe6b8330483c2e9849),
-			BinaryField128bGhash(0x0dcb364640a222fe6b8330483c2e9848),
-			BinaryField128bGhash(0x3d5bd35c94646a247573da4a5f7710ed),
-			BinaryField128bGhash(0x3d5bd35c94646a247573da4a5f7710ec),
-			BinaryField128bGhash(0x3090e51ad4c648da1ef0ea02635988a4),
-			BinaryField128bGhash(0x3090e51ad4c648da1ef0ea02635988a5),
-			BinaryField128bGhash(0x6d58c4e181f9199f41a12db1f974f3ac),
-			BinaryField128bGhash(0x6d58c4e181f9199f41a12db1f974f3ad),
-			BinaryField128bGhash(0x6093f2a7c15b3b612a221df9c55a6be5),
-			BinaryField128bGhash(0x6093f2a7c15b3b612a221df9c55a6be4),
-			BinaryField128bGhash(0x500317bd159d73bb34d2f7fba603e341),
-			BinaryField128bGhash(0x500317bd159d73bb34d2f7fba603e340),
-			BinaryField128bGhash(0x5dc821fb553f51455f51c7b39a2d7b08),
-			BinaryField128bGhash(0x5dc821fb553f51455f51c7b39a2d7b09),
-			BinaryField128bGhash(0xa72ec17764d7ced55e2f716f4ede412f),
-			BinaryField128bGhash(0xa72ec17764d7ced55e2f716f4ede412e),
-			BinaryField128bGhash(0xaae5f7312475ec2b35ac412772f0d966),
-			BinaryField128bGhash(0xaae5f7312475ec2b35ac412772f0d967),
-			BinaryField128bGhash(0x9a75122bf0b3a4f12b5cab2511a951c2),
-			BinaryField128bGhash(0x9a75122bf0b3a4f12b5cab2511a951c3),
-			BinaryField128bGhash(0x97be246db011860f40df9b6d2d87c98b),
-			BinaryField128bGhash(0x97be246db011860f40df9b6d2d87c98a),
-			BinaryField128bGhash(0xca760596e52ed74a1f8e5cdeb7aab283),
-			BinaryField128bGhash(0xca760596e52ed74a1f8e5cdeb7aab282),
-			BinaryField128bGhash(0xc7bd33d0a58cf5b4740d6c968b842aca),
-			BinaryField128bGhash(0xc7bd33d0a58cf5b4740d6c968b842acb),
-			BinaryField128bGhash(0xf72dd6ca714abd6e6afd8694e8dda26e),
-			BinaryField128bGhash(0xf72dd6ca714abd6e6afd8694e8dda26f),
-			BinaryField128bGhash(0xfae6e08c31e89f90017eb6dcd4f33a27),
-			BinaryField128bGhash(0xfae6e08c31e89f90017eb6dcd4f33a26),
-			BinaryField128bGhash(0x4d52354a3a3d8c865cb10fbabcf00118),
-			BinaryField128bGhash(0x4d52354a3a3d8c865cb10fbabcf00119),
-			BinaryField128bGhash(0x4099030c7a9fae7837323ff280de9951),
-			BinaryField128bGhash(0x4099030c7a9fae7837323ff280de9950),
-			BinaryField128bGhash(0x7009e616ae59e6a229c2d5f0e38711f5),
-			BinaryField128bGhash(0x7009e616ae59e6a229c2d5f0e38711f4),
-			BinaryField128bGhash(0x7dc2d050eefbc45c4241e5b8dfa989bc),
-			BinaryField128bGhash(0x7dc2d050eefbc45c4241e5b8dfa989bd),
-			BinaryField128bGhash(0x200af1abbbc495191d10220b4584f2b4),
-			BinaryField128bGhash(0x200af1abbbc495191d10220b4584f2b5),
-			BinaryField128bGhash(0x2dc1c7edfb66b7e77693124379aa6afd),
-			BinaryField128bGhash(0x2dc1c7edfb66b7e77693124379aa6afc),
-			BinaryField128bGhash(0x1d5122f72fa0ff3d6863f8411af3e259),
-			BinaryField128bGhash(0x1d5122f72fa0ff3d6863f8411af3e258),
-			BinaryField128bGhash(0x109a14b16f02ddc303e0c80926dd7a10),
-			BinaryField128bGhash(0x109a14b16f02ddc303e0c80926dd7a11),
-			BinaryField128bGhash(0xea7cf43d5eea4253029e7ed5f22e4037),
-			BinaryField128bGhash(0xea7cf43d5eea4253029e7ed5f22e4036),
-			BinaryField128bGhash(0xe7b7c27b1e4860ad691d4e9dce00d87e),
-			BinaryField128bGhash(0xe7b7c27b1e4860ad691d4e9dce00d87f),
-			BinaryField128bGhash(0xd7272761ca8e287777eda49fad5950da),
-			BinaryField128bGhash(0xd7272761ca8e287777eda49fad5950db),
-			BinaryField128bGhash(0xdaec11278a2c0a891c6e94d79177c893),
-			BinaryField128bGhash(0xdaec11278a2c0a891c6e94d79177c892),
-			BinaryField128bGhash(0x872430dcdf135bcc433f53640b5ab39b),
-			BinaryField128bGhash(0x872430dcdf135bcc433f53640b5ab39a),
-			BinaryField128bGhash(0x8aef069a9fb1793228bc632c37742bd2),
-			BinaryField128bGhash(0x8aef069a9fb1793228bc632c37742bd3),
-			BinaryField128bGhash(0xba7fe3804b7731e8364c892e542da376),
-			BinaryField128bGhash(0xba7fe3804b7731e8364c892e542da377),
-			BinaryField128bGhash(0xb7b4d5c60bd513165dcfb96668033b3f),
-			BinaryField128bGhash(0xb7b4d5c60bd513165dcfb96668033b3e),
-			BinaryField128bGhash(0x553e92e8bc0ae9a795ed1f57f3632d4d),
-			BinaryField128bGhash(0x553e92e8bc0ae9a795ed1f57f3632d4c),
-			BinaryField128bGhash(0x58f5a4aefca8cb59fe6e2f1fcf4db504),
-			BinaryField128bGhash(0x58f5a4aefca8cb59fe6e2f1fcf4db505),
-			BinaryField128bGhash(0x686541b4286e8383e09ec51dac143da0),
-			BinaryField128bGhash(0x686541b4286e8383e09ec51dac143da1),
-			BinaryField128bGhash(0x65ae77f268cca17d8b1df555903aa5e9),
-			BinaryField128bGhash(0x65ae77f268cca17d8b1df555903aa5e8),
-			BinaryField128bGhash(0x386656093df3f038d44c32e60a17dee1),
-			BinaryField128bGhash(0x386656093df3f038d44c32e60a17dee0),
-			BinaryField128bGhash(0x35ad604f7d51d2c6bfcf02ae363946a8),
-			BinaryField128bGhash(0x35ad604f7d51d2c6bfcf02ae363946a9),
-			BinaryField128bGhash(0x053d8555a9979a1ca13fe8ac5560ce0c),
-			BinaryField128bGhash(0x053d8555a9979a1ca13fe8ac5560ce0d),
-			BinaryField128bGhash(0x08f6b313e935b8e2cabcd8e4694e5645),
-			BinaryField128bGhash(0x08f6b313e935b8e2cabcd8e4694e5644),
-			BinaryField128bGhash(0xf210539fd8dd2772cbc26e38bdbd6c62),
-			BinaryField128bGhash(0xf210539fd8dd2772cbc26e38bdbd6c63),
-			BinaryField128bGhash(0xffdb65d9987f058ca0415e708193f42b),
-			BinaryField128bGhash(0xffdb65d9987f058ca0415e708193f42a),
-			BinaryField128bGhash(0xcf4b80c34cb94d56beb1b472e2ca7c8f),
-			BinaryField128bGhash(0xcf4b80c34cb94d56beb1b472e2ca7c8e),
-			BinaryField128bGhash(0xc280b6850c1b6fa8d532843adee4e4c6),
-			BinaryField128bGhash(0xc280b6850c1b6fa8d532843adee4e4c7),
-			BinaryField128bGhash(0x9f48977e59243eed8a63438944c99fce),
-			BinaryField128bGhash(0x9f48977e59243eed8a63438944c99fcf),
-			BinaryField128bGhash(0x9283a13819861c13e1e073c178e70787),
-			BinaryField128bGhash(0x9283a13819861c13e1e073c178e70786),
-			BinaryField128bGhash(0xa2134422cd4054c9ff1099c31bbe8f23),
-			BinaryField128bGhash(0xa2134422cd4054c9ff1099c31bbe8f22),
-			BinaryField128bGhash(0xafd872648de276379493a98b2790176a),
-			BinaryField128bGhash(0xafd872648de276379493a98b2790176b),
-			BinaryField128bGhash(0x186ca7a286376521c95c10ed4f932c55),
-			BinaryField128bGhash(0x186ca7a286376521c95c10ed4f932c54),
-			BinaryField128bGhash(0x15a791e4c69547dfa2df20a573bdb41c),
-			BinaryField128bGhash(0x15a791e4c69547dfa2df20a573bdb41d),
-			BinaryField128bGhash(0x253774fe12530f05bc2fcaa710e43cb8),
-			BinaryField128bGhash(0x253774fe12530f05bc2fcaa710e43cb9),
-			BinaryField128bGhash(0x28fc42b852f12dfbd7acfaef2ccaa4f1),
-			BinaryField128bGhash(0x28fc42b852f12dfbd7acfaef2ccaa4f0),
-			BinaryField128bGhash(0x7534634307ce7cbe88fd3d5cb6e7dff9),
-			BinaryField128bGhash(0x7534634307ce7cbe88fd3d5cb6e7dff8),
-			BinaryField128bGhash(0x78ff5505476c5e40e37e0d148ac947b0),
-			BinaryField128bGhash(0x78ff5505476c5e40e37e0d148ac947b1),
-			BinaryField128bGhash(0x486fb01f93aa169afd8ee716e990cf14),
-			BinaryField128bGhash(0x486fb01f93aa169afd8ee716e990cf15),
-			BinaryField128bGhash(0x45a48659d3083464960dd75ed5be575d),
-			BinaryField128bGhash(0x45a48659d3083464960dd75ed5be575c),
-			BinaryField128bGhash(0xbf4266d5e2e0abf497736182014d6d7a),
-			BinaryField128bGhash(0xbf4266d5e2e0abf497736182014d6d7b),
-			BinaryField128bGhash(0xb2895093a242890afcf051ca3d63f533),
-			BinaryField128bGhash(0xb2895093a242890afcf051ca3d63f532),
-			BinaryField128bGhash(0x8219b5897684c1d0e200bbc85e3a7d97),
-			BinaryField128bGhash(0x8219b5897684c1d0e200bbc85e3a7d96),
-			BinaryField128bGhash(0x8fd283cf3626e32e89838b806214e5de),
-			BinaryField128bGhash(0x8fd283cf3626e32e89838b806214e5df),
-			BinaryField128bGhash(0xd21aa2346319b26bd6d24c33f8399ed6),
-			BinaryField128bGhash(0xd21aa2346319b26bd6d24c33f8399ed7),
-			BinaryField128bGhash(0xdfd1947223bb9095bd517c7bc417069f),
-			BinaryField128bGhash(0xdfd1947223bb9095bd517c7bc417069e),
-			BinaryField128bGhash(0xef417168f77dd84fa3a19679a74e8e3b),
-			BinaryField128bGhash(0xef417168f77dd84fa3a19679a74e8e3a),
-			BinaryField128bGhash(0xe28a472eb7dffab1c822a6319b601672),
-			BinaryField128bGhash(0xe28a472eb7dffab1c822a6319b601673),
-			BinaryField128bGhash(0x93252331bf042b11512625b1f09fa87e),
-			BinaryField128bGhash(0x93252331bf042b11512625b1f09fa87f),
-			BinaryField128bGhash(0x9eee1577ffa609ef3aa515f9ccb13037),
-			BinaryField128bGhash(0x9eee1577ffa609ef3aa515f9ccb13036),
-			BinaryField128bGhash(0xae7ef06d2b6041352455fffbafe8b893),
-			BinaryField128bGhash(0xae7ef06d2b6041352455fffbafe8b892),
-			BinaryField128bGhash(0xa3b5c62b6bc263cb4fd6cfb393c620da),
-			BinaryField128bGhash(0xa3b5c62b6bc263cb4fd6cfb393c620db),
-			BinaryField128bGhash(0xfe7de7d03efd328e1087080009eb5bd2),
-			BinaryField128bGhash(0xfe7de7d03efd328e1087080009eb5bd3),
-			BinaryField128bGhash(0xf3b6d1967e5f10707b04384835c5c39b),
-			BinaryField128bGhash(0xf3b6d1967e5f10707b04384835c5c39a),
-			BinaryField128bGhash(0xc326348caa9958aa65f4d24a569c4b3f),
-			BinaryField128bGhash(0xc326348caa9958aa65f4d24a569c4b3e),
-			BinaryField128bGhash(0xceed02caea3b7a540e77e2026ab2d376),
-			BinaryField128bGhash(0xceed02caea3b7a540e77e2026ab2d377),
-			BinaryField128bGhash(0x340be246dbd3e5c40f0954debe41e951),
-			BinaryField128bGhash(0x340be246dbd3e5c40f0954debe41e950),
-			BinaryField128bGhash(0x39c0d4009b71c73a648a6496826f7118),
-			BinaryField128bGhash(0x39c0d4009b71c73a648a6496826f7119),
-			BinaryField128bGhash(0x0950311a4fb78fe07a7a8e94e136f9bc),
-			BinaryField128bGhash(0x0950311a4fb78fe07a7a8e94e136f9bd),
-			BinaryField128bGhash(0x049b075c0f15ad1e11f9bedcdd1861f5),
-			BinaryField128bGhash(0x049b075c0f15ad1e11f9bedcdd1861f4),
-			BinaryField128bGhash(0x595326a75a2afc5b4ea8796f47351afd),
-			BinaryField128bGhash(0x595326a75a2afc5b4ea8796f47351afc),
-			BinaryField128bGhash(0x549810e11a88dea5252b49277b1b82b4),
-			BinaryField128bGhash(0x549810e11a88dea5252b49277b1b82b5),
-			BinaryField128bGhash(0x6408f5fbce4e967f3bdba32518420a10),
-			BinaryField128bGhash(0x6408f5fbce4e967f3bdba32518420a11),
-			BinaryField128bGhash(0x69c3c3bd8eecb4815058936d246c9259),
-			BinaryField128bGhash(0x69c3c3bd8eecb4815058936d246c9258),
-			BinaryField128bGhash(0xde77167b8539a7970d972a0b4c6fa966),
-			BinaryField128bGhash(0xde77167b8539a7970d972a0b4c6fa967),
-			BinaryField128bGhash(0xd3bc203dc59b856966141a437041312f),
-			BinaryField128bGhash(0xd3bc203dc59b856966141a437041312e),
-			BinaryField128bGhash(0xe32cc527115dcdb378e4f0411318b98b),
-			BinaryField128bGhash(0xe32cc527115dcdb378e4f0411318b98a),
-			BinaryField128bGhash(0xeee7f36151ffef4d1367c0092f3621c2),
-			BinaryField128bGhash(0xeee7f36151ffef4d1367c0092f3621c3),
-			BinaryField128bGhash(0xb32fd29a04c0be084c3607bab51b5aca),
-			BinaryField128bGhash(0xb32fd29a04c0be084c3607bab51b5acb),
-			BinaryField128bGhash(0xbee4e4dc44629cf627b537f28935c283),
-			BinaryField128bGhash(0xbee4e4dc44629cf627b537f28935c282),
-			BinaryField128bGhash(0x8e7401c690a4d42c3945ddf0ea6c4a27),
-			BinaryField128bGhash(0x8e7401c690a4d42c3945ddf0ea6c4a26),
-			BinaryField128bGhash(0x83bf3780d006f6d252c6edb8d642d26e),
-			BinaryField128bGhash(0x83bf3780d006f6d252c6edb8d642d26f),
-			BinaryField128bGhash(0x7959d70ce1ee694253b85b6402b1e849),
-			BinaryField128bGhash(0x7959d70ce1ee694253b85b6402b1e848),
-			BinaryField128bGhash(0x7492e14aa14c4bbc383b6b2c3e9f7000),
-			BinaryField128bGhash(0x7492e14aa14c4bbc383b6b2c3e9f7001),
-			BinaryField128bGhash(0x44020450758a036626cb812e5dc6f8a4),
-			BinaryField128bGhash(0x44020450758a036626cb812e5dc6f8a5),
-			BinaryField128bGhash(0x49c93216352821984d48b16661e860ed),
-			BinaryField128bGhash(0x49c93216352821984d48b16661e860ec),
-			BinaryField128bGhash(0x140113ed601770dd121976d5fbc51be5),
-			BinaryField128bGhash(0x140113ed601770dd121976d5fbc51be4),
-			BinaryField128bGhash(0x19ca25ab20b55223799a469dc7eb83ac),
-			BinaryField128bGhash(0x19ca25ab20b55223799a469dc7eb83ad),
-			BinaryField128bGhash(0x295ac0b1f4731af9676aac9fa4b20b08),
-			BinaryField128bGhash(0x295ac0b1f4731af9676aac9fa4b20b09),
-			BinaryField128bGhash(0x2491f6f7b4d138070ce99cd7989c9341),
-			BinaryField128bGhash(0x2491f6f7b4d138070ce99cd7989c9340),
-			BinaryField128bGhash(0xc61bb1d9030ec2b6c4cb3ae603fc8533),
-			BinaryField128bGhash(0xc61bb1d9030ec2b6c4cb3ae603fc8532),
-			BinaryField128bGhash(0xcbd0879f43ace048af480aae3fd21d7a),
-			BinaryField128bGhash(0xcbd0879f43ace048af480aae3fd21d7b),
-			BinaryField128bGhash(0xfb406285976aa892b1b8e0ac5c8b95de),
-			BinaryField128bGhash(0xfb406285976aa892b1b8e0ac5c8b95df),
-			BinaryField128bGhash(0xf68b54c3d7c88a6cda3bd0e460a50d97),
-			BinaryField128bGhash(0xf68b54c3d7c88a6cda3bd0e460a50d96),
-			BinaryField128bGhash(0xab43753882f7db29856a1757fa88769f),
-			BinaryField128bGhash(0xab43753882f7db29856a1757fa88769e),
-			BinaryField128bGhash(0xa688437ec255f9d7eee9271fc6a6eed6),
-			BinaryField128bGhash(0xa688437ec255f9d7eee9271fc6a6eed7),
-			BinaryField128bGhash(0x9618a6641693b10df019cd1da5ff6672),
-			BinaryField128bGhash(0x9618a6641693b10df019cd1da5ff6673),
-			BinaryField128bGhash(0x9bd39022563193f39b9afd5599d1fe3b),
-			BinaryField128bGhash(0x9bd39022563193f39b9afd5599d1fe3a),
-			BinaryField128bGhash(0x613570ae67d90c639ae44b894d22c41c),
-			BinaryField128bGhash(0x613570ae67d90c639ae44b894d22c41d),
-			BinaryField128bGhash(0x6cfe46e8277b2e9df1677bc1710c5c55),
-			BinaryField128bGhash(0x6cfe46e8277b2e9df1677bc1710c5c54),
-			BinaryField128bGhash(0x5c6ea3f2f3bd6647ef9791c31255d4f1),
-			BinaryField128bGhash(0x5c6ea3f2f3bd6647ef9791c31255d4f0),
-			BinaryField128bGhash(0x51a595b4b31f44b98414a18b2e7b4cb8),
-			BinaryField128bGhash(0x51a595b4b31f44b98414a18b2e7b4cb9),
-			BinaryField128bGhash(0x0c6db44fe62015fcdb456638b45637b0),
-			BinaryField128bGhash(0x0c6db44fe62015fcdb456638b45637b1),
-			BinaryField128bGhash(0x01a68209a6823702b0c656708878aff9),
-			BinaryField128bGhash(0x01a68209a6823702b0c656708878aff8),
-			BinaryField128bGhash(0x3136671372447fd8ae36bc72eb21275d),
-			BinaryField128bGhash(0x3136671372447fd8ae36bc72eb21275c),
-			BinaryField128bGhash(0x3cfd515532e65d26c5b58c3ad70fbf14),
-			BinaryField128bGhash(0x3cfd515532e65d26c5b58c3ad70fbf15),
-			BinaryField128bGhash(0x8b49849339334e30987a355cbf0c842b),
-			BinaryField128bGhash(0x8b49849339334e30987a355cbf0c842a),
-			BinaryField128bGhash(0x8682b2d579916ccef3f9051483221c62),
-			BinaryField128bGhash(0x8682b2d579916ccef3f9051483221c63),
-			BinaryField128bGhash(0xb61257cfad572414ed09ef16e07b94c6),
-			BinaryField128bGhash(0xb61257cfad572414ed09ef16e07b94c7),
-			BinaryField128bGhash(0xbbd96189edf506ea868adf5edc550c8f),
-			BinaryField128bGhash(0xbbd96189edf506ea868adf5edc550c8e),
-			BinaryField128bGhash(0xe6114072b8ca57afd9db18ed46787787),
-			BinaryField128bGhash(0xe6114072b8ca57afd9db18ed46787786),
-			BinaryField128bGhash(0xebda7634f8687551b25828a57a56efce),
-			BinaryField128bGhash(0xebda7634f8687551b25828a57a56efcf),
-			BinaryField128bGhash(0xdb4a932e2cae3d8baca8c2a7190f676a),
-			BinaryField128bGhash(0xdb4a932e2cae3d8baca8c2a7190f676b),
-			BinaryField128bGhash(0xd681a5686c0c1f75c72bf2ef2521ff23),
-			BinaryField128bGhash(0xd681a5686c0c1f75c72bf2ef2521ff22),
-			BinaryField128bGhash(0x2c6745e45de480e5c6554433f1d2c504),
-			BinaryField128bGhash(0x2c6745e45de480e5c6554433f1d2c505),
-			BinaryField128bGhash(0x21ac73a21d46a21badd6747bcdfc5d4d),
-			BinaryField128bGhash(0x21ac73a21d46a21badd6747bcdfc5d4c),
-			BinaryField128bGhash(0x113c96b8c980eac1b3269e79aea5d5e9),
-			BinaryField128bGhash(0x113c96b8c980eac1b3269e79aea5d5e8),
-			BinaryField128bGhash(0x1cf7a0fe8922c83fd8a5ae31928b4da0),
-			BinaryField128bGhash(0x1cf7a0fe8922c83fd8a5ae31928b4da1),
-			BinaryField128bGhash(0x413f8105dc1d997a87f4698208a636a8),
-			BinaryField128bGhash(0x413f8105dc1d997a87f4698208a636a9),
-			BinaryField128bGhash(0x4cf4b7439cbfbb84ec7759ca3488aee1),
-			BinaryField128bGhash(0x4cf4b7439cbfbb84ec7759ca3488aee0),
-			BinaryField128bGhash(0x7c6452594879f35ef287b3c857d12645),
-			BinaryField128bGhash(0x7c6452594879f35ef287b3c857d12644),
-			BinaryField128bGhash(0x71af641f08dbd1a0990483806bffbe0c),
-			BinaryField128bGhash(0x71af641f08dbd1a0990483806bffbe0d),
+		// Raw GHASH values as `u128`, converted to the `M128` underlier at the lookup site so the
+		// table needs no const `M128` construction.
+		const LOOKUP_TABLE: [u128; 256] = [
+			0x00000000000000000000000000000000,
+			0x00000000000000000000000000000001,
+			0x0dcb364640a222fe6b8330483c2e9849,
+			0x0dcb364640a222fe6b8330483c2e9848,
+			0x3d5bd35c94646a247573da4a5f7710ed,
+			0x3d5bd35c94646a247573da4a5f7710ec,
+			0x3090e51ad4c648da1ef0ea02635988a4,
+			0x3090e51ad4c648da1ef0ea02635988a5,
+			0x6d58c4e181f9199f41a12db1f974f3ac,
+			0x6d58c4e181f9199f41a12db1f974f3ad,
+			0x6093f2a7c15b3b612a221df9c55a6be5,
+			0x6093f2a7c15b3b612a221df9c55a6be4,
+			0x500317bd159d73bb34d2f7fba603e341,
+			0x500317bd159d73bb34d2f7fba603e340,
+			0x5dc821fb553f51455f51c7b39a2d7b08,
+			0x5dc821fb553f51455f51c7b39a2d7b09,
+			0xa72ec17764d7ced55e2f716f4ede412f,
+			0xa72ec17764d7ced55e2f716f4ede412e,
+			0xaae5f7312475ec2b35ac412772f0d966,
+			0xaae5f7312475ec2b35ac412772f0d967,
+			0x9a75122bf0b3a4f12b5cab2511a951c2,
+			0x9a75122bf0b3a4f12b5cab2511a951c3,
+			0x97be246db011860f40df9b6d2d87c98b,
+			0x97be246db011860f40df9b6d2d87c98a,
+			0xca760596e52ed74a1f8e5cdeb7aab283,
+			0xca760596e52ed74a1f8e5cdeb7aab282,
+			0xc7bd33d0a58cf5b4740d6c968b842aca,
+			0xc7bd33d0a58cf5b4740d6c968b842acb,
+			0xf72dd6ca714abd6e6afd8694e8dda26e,
+			0xf72dd6ca714abd6e6afd8694e8dda26f,
+			0xfae6e08c31e89f90017eb6dcd4f33a27,
+			0xfae6e08c31e89f90017eb6dcd4f33a26,
+			0x4d52354a3a3d8c865cb10fbabcf00118,
+			0x4d52354a3a3d8c865cb10fbabcf00119,
+			0x4099030c7a9fae7837323ff280de9951,
+			0x4099030c7a9fae7837323ff280de9950,
+			0x7009e616ae59e6a229c2d5f0e38711f5,
+			0x7009e616ae59e6a229c2d5f0e38711f4,
+			0x7dc2d050eefbc45c4241e5b8dfa989bc,
+			0x7dc2d050eefbc45c4241e5b8dfa989bd,
+			0x200af1abbbc495191d10220b4584f2b4,
+			0x200af1abbbc495191d10220b4584f2b5,
+			0x2dc1c7edfb66b7e77693124379aa6afd,
+			0x2dc1c7edfb66b7e77693124379aa6afc,
+			0x1d5122f72fa0ff3d6863f8411af3e259,
+			0x1d5122f72fa0ff3d6863f8411af3e258,
+			0x109a14b16f02ddc303e0c80926dd7a10,
+			0x109a14b16f02ddc303e0c80926dd7a11,
+			0xea7cf43d5eea4253029e7ed5f22e4037,
+			0xea7cf43d5eea4253029e7ed5f22e4036,
+			0xe7b7c27b1e4860ad691d4e9dce00d87e,
+			0xe7b7c27b1e4860ad691d4e9dce00d87f,
+			0xd7272761ca8e287777eda49fad5950da,
+			0xd7272761ca8e287777eda49fad5950db,
+			0xdaec11278a2c0a891c6e94d79177c893,
+			0xdaec11278a2c0a891c6e94d79177c892,
+			0x872430dcdf135bcc433f53640b5ab39b,
+			0x872430dcdf135bcc433f53640b5ab39a,
+			0x8aef069a9fb1793228bc632c37742bd2,
+			0x8aef069a9fb1793228bc632c37742bd3,
+			0xba7fe3804b7731e8364c892e542da376,
+			0xba7fe3804b7731e8364c892e542da377,
+			0xb7b4d5c60bd513165dcfb96668033b3f,
+			0xb7b4d5c60bd513165dcfb96668033b3e,
+			0x553e92e8bc0ae9a795ed1f57f3632d4d,
+			0x553e92e8bc0ae9a795ed1f57f3632d4c,
+			0x58f5a4aefca8cb59fe6e2f1fcf4db504,
+			0x58f5a4aefca8cb59fe6e2f1fcf4db505,
+			0x686541b4286e8383e09ec51dac143da0,
+			0x686541b4286e8383e09ec51dac143da1,
+			0x65ae77f268cca17d8b1df555903aa5e9,
+			0x65ae77f268cca17d8b1df555903aa5e8,
+			0x386656093df3f038d44c32e60a17dee1,
+			0x386656093df3f038d44c32e60a17dee0,
+			0x35ad604f7d51d2c6bfcf02ae363946a8,
+			0x35ad604f7d51d2c6bfcf02ae363946a9,
+			0x053d8555a9979a1ca13fe8ac5560ce0c,
+			0x053d8555a9979a1ca13fe8ac5560ce0d,
+			0x08f6b313e935b8e2cabcd8e4694e5645,
+			0x08f6b313e935b8e2cabcd8e4694e5644,
+			0xf210539fd8dd2772cbc26e38bdbd6c62,
+			0xf210539fd8dd2772cbc26e38bdbd6c63,
+			0xffdb65d9987f058ca0415e708193f42b,
+			0xffdb65d9987f058ca0415e708193f42a,
+			0xcf4b80c34cb94d56beb1b472e2ca7c8f,
+			0xcf4b80c34cb94d56beb1b472e2ca7c8e,
+			0xc280b6850c1b6fa8d532843adee4e4c6,
+			0xc280b6850c1b6fa8d532843adee4e4c7,
+			0x9f48977e59243eed8a63438944c99fce,
+			0x9f48977e59243eed8a63438944c99fcf,
+			0x9283a13819861c13e1e073c178e70787,
+			0x9283a13819861c13e1e073c178e70786,
+			0xa2134422cd4054c9ff1099c31bbe8f23,
+			0xa2134422cd4054c9ff1099c31bbe8f22,
+			0xafd872648de276379493a98b2790176a,
+			0xafd872648de276379493a98b2790176b,
+			0x186ca7a286376521c95c10ed4f932c55,
+			0x186ca7a286376521c95c10ed4f932c54,
+			0x15a791e4c69547dfa2df20a573bdb41c,
+			0x15a791e4c69547dfa2df20a573bdb41d,
+			0x253774fe12530f05bc2fcaa710e43cb8,
+			0x253774fe12530f05bc2fcaa710e43cb9,
+			0x28fc42b852f12dfbd7acfaef2ccaa4f1,
+			0x28fc42b852f12dfbd7acfaef2ccaa4f0,
+			0x7534634307ce7cbe88fd3d5cb6e7dff9,
+			0x7534634307ce7cbe88fd3d5cb6e7dff8,
+			0x78ff5505476c5e40e37e0d148ac947b0,
+			0x78ff5505476c5e40e37e0d148ac947b1,
+			0x486fb01f93aa169afd8ee716e990cf14,
+			0x486fb01f93aa169afd8ee716e990cf15,
+			0x45a48659d3083464960dd75ed5be575d,
+			0x45a48659d3083464960dd75ed5be575c,
+			0xbf4266d5e2e0abf497736182014d6d7a,
+			0xbf4266d5e2e0abf497736182014d6d7b,
+			0xb2895093a242890afcf051ca3d63f533,
+			0xb2895093a242890afcf051ca3d63f532,
+			0x8219b5897684c1d0e200bbc85e3a7d97,
+			0x8219b5897684c1d0e200bbc85e3a7d96,
+			0x8fd283cf3626e32e89838b806214e5de,
+			0x8fd283cf3626e32e89838b806214e5df,
+			0xd21aa2346319b26bd6d24c33f8399ed6,
+			0xd21aa2346319b26bd6d24c33f8399ed7,
+			0xdfd1947223bb9095bd517c7bc417069f,
+			0xdfd1947223bb9095bd517c7bc417069e,
+			0xef417168f77dd84fa3a19679a74e8e3b,
+			0xef417168f77dd84fa3a19679a74e8e3a,
+			0xe28a472eb7dffab1c822a6319b601672,
+			0xe28a472eb7dffab1c822a6319b601673,
+			0x93252331bf042b11512625b1f09fa87e,
+			0x93252331bf042b11512625b1f09fa87f,
+			0x9eee1577ffa609ef3aa515f9ccb13037,
+			0x9eee1577ffa609ef3aa515f9ccb13036,
+			0xae7ef06d2b6041352455fffbafe8b893,
+			0xae7ef06d2b6041352455fffbafe8b892,
+			0xa3b5c62b6bc263cb4fd6cfb393c620da,
+			0xa3b5c62b6bc263cb4fd6cfb393c620db,
+			0xfe7de7d03efd328e1087080009eb5bd2,
+			0xfe7de7d03efd328e1087080009eb5bd3,
+			0xf3b6d1967e5f10707b04384835c5c39b,
+			0xf3b6d1967e5f10707b04384835c5c39a,
+			0xc326348caa9958aa65f4d24a569c4b3f,
+			0xc326348caa9958aa65f4d24a569c4b3e,
+			0xceed02caea3b7a540e77e2026ab2d376,
+			0xceed02caea3b7a540e77e2026ab2d377,
+			0x340be246dbd3e5c40f0954debe41e951,
+			0x340be246dbd3e5c40f0954debe41e950,
+			0x39c0d4009b71c73a648a6496826f7118,
+			0x39c0d4009b71c73a648a6496826f7119,
+			0x0950311a4fb78fe07a7a8e94e136f9bc,
+			0x0950311a4fb78fe07a7a8e94e136f9bd,
+			0x049b075c0f15ad1e11f9bedcdd1861f5,
+			0x049b075c0f15ad1e11f9bedcdd1861f4,
+			0x595326a75a2afc5b4ea8796f47351afd,
+			0x595326a75a2afc5b4ea8796f47351afc,
+			0x549810e11a88dea5252b49277b1b82b4,
+			0x549810e11a88dea5252b49277b1b82b5,
+			0x6408f5fbce4e967f3bdba32518420a10,
+			0x6408f5fbce4e967f3bdba32518420a11,
+			0x69c3c3bd8eecb4815058936d246c9259,
+			0x69c3c3bd8eecb4815058936d246c9258,
+			0xde77167b8539a7970d972a0b4c6fa966,
+			0xde77167b8539a7970d972a0b4c6fa967,
+			0xd3bc203dc59b856966141a437041312f,
+			0xd3bc203dc59b856966141a437041312e,
+			0xe32cc527115dcdb378e4f0411318b98b,
+			0xe32cc527115dcdb378e4f0411318b98a,
+			0xeee7f36151ffef4d1367c0092f3621c2,
+			0xeee7f36151ffef4d1367c0092f3621c3,
+			0xb32fd29a04c0be084c3607bab51b5aca,
+			0xb32fd29a04c0be084c3607bab51b5acb,
+			0xbee4e4dc44629cf627b537f28935c283,
+			0xbee4e4dc44629cf627b537f28935c282,
+			0x8e7401c690a4d42c3945ddf0ea6c4a27,
+			0x8e7401c690a4d42c3945ddf0ea6c4a26,
+			0x83bf3780d006f6d252c6edb8d642d26e,
+			0x83bf3780d006f6d252c6edb8d642d26f,
+			0x7959d70ce1ee694253b85b6402b1e849,
+			0x7959d70ce1ee694253b85b6402b1e848,
+			0x7492e14aa14c4bbc383b6b2c3e9f7000,
+			0x7492e14aa14c4bbc383b6b2c3e9f7001,
+			0x44020450758a036626cb812e5dc6f8a4,
+			0x44020450758a036626cb812e5dc6f8a5,
+			0x49c93216352821984d48b16661e860ed,
+			0x49c93216352821984d48b16661e860ec,
+			0x140113ed601770dd121976d5fbc51be5,
+			0x140113ed601770dd121976d5fbc51be4,
+			0x19ca25ab20b55223799a469dc7eb83ac,
+			0x19ca25ab20b55223799a469dc7eb83ad,
+			0x295ac0b1f4731af9676aac9fa4b20b08,
+			0x295ac0b1f4731af9676aac9fa4b20b09,
+			0x2491f6f7b4d138070ce99cd7989c9341,
+			0x2491f6f7b4d138070ce99cd7989c9340,
+			0xc61bb1d9030ec2b6c4cb3ae603fc8533,
+			0xc61bb1d9030ec2b6c4cb3ae603fc8532,
+			0xcbd0879f43ace048af480aae3fd21d7a,
+			0xcbd0879f43ace048af480aae3fd21d7b,
+			0xfb406285976aa892b1b8e0ac5c8b95de,
+			0xfb406285976aa892b1b8e0ac5c8b95df,
+			0xf68b54c3d7c88a6cda3bd0e460a50d97,
+			0xf68b54c3d7c88a6cda3bd0e460a50d96,
+			0xab43753882f7db29856a1757fa88769f,
+			0xab43753882f7db29856a1757fa88769e,
+			0xa688437ec255f9d7eee9271fc6a6eed6,
+			0xa688437ec255f9d7eee9271fc6a6eed7,
+			0x9618a6641693b10df019cd1da5ff6672,
+			0x9618a6641693b10df019cd1da5ff6673,
+			0x9bd39022563193f39b9afd5599d1fe3b,
+			0x9bd39022563193f39b9afd5599d1fe3a,
+			0x613570ae67d90c639ae44b894d22c41c,
+			0x613570ae67d90c639ae44b894d22c41d,
+			0x6cfe46e8277b2e9df1677bc1710c5c55,
+			0x6cfe46e8277b2e9df1677bc1710c5c54,
+			0x5c6ea3f2f3bd6647ef9791c31255d4f1,
+			0x5c6ea3f2f3bd6647ef9791c31255d4f0,
+			0x51a595b4b31f44b98414a18b2e7b4cb8,
+			0x51a595b4b31f44b98414a18b2e7b4cb9,
+			0x0c6db44fe62015fcdb456638b45637b0,
+			0x0c6db44fe62015fcdb456638b45637b1,
+			0x01a68209a6823702b0c656708878aff9,
+			0x01a68209a6823702b0c656708878aff8,
+			0x3136671372447fd8ae36bc72eb21275d,
+			0x3136671372447fd8ae36bc72eb21275c,
+			0x3cfd515532e65d26c5b58c3ad70fbf14,
+			0x3cfd515532e65d26c5b58c3ad70fbf15,
+			0x8b49849339334e30987a355cbf0c842b,
+			0x8b49849339334e30987a355cbf0c842a,
+			0x8682b2d579916ccef3f9051483221c62,
+			0x8682b2d579916ccef3f9051483221c63,
+			0xb61257cfad572414ed09ef16e07b94c6,
+			0xb61257cfad572414ed09ef16e07b94c7,
+			0xbbd96189edf506ea868adf5edc550c8f,
+			0xbbd96189edf506ea868adf5edc550c8e,
+			0xe6114072b8ca57afd9db18ed46787787,
+			0xe6114072b8ca57afd9db18ed46787786,
+			0xebda7634f8687551b25828a57a56efce,
+			0xebda7634f8687551b25828a57a56efcf,
+			0xdb4a932e2cae3d8baca8c2a7190f676a,
+			0xdb4a932e2cae3d8baca8c2a7190f676b,
+			0xd681a5686c0c1f75c72bf2ef2521ff23,
+			0xd681a5686c0c1f75c72bf2ef2521ff22,
+			0x2c6745e45de480e5c6554433f1d2c504,
+			0x2c6745e45de480e5c6554433f1d2c505,
+			0x21ac73a21d46a21badd6747bcdfc5d4d,
+			0x21ac73a21d46a21badd6747bcdfc5d4c,
+			0x113c96b8c980eac1b3269e79aea5d5e9,
+			0x113c96b8c980eac1b3269e79aea5d5e8,
+			0x1cf7a0fe8922c83fd8a5ae31928b4da0,
+			0x1cf7a0fe8922c83fd8a5ae31928b4da1,
+			0x413f8105dc1d997a87f4698208a636a8,
+			0x413f8105dc1d997a87f4698208a636a9,
+			0x4cf4b7439cbfbb84ec7759ca3488aee1,
+			0x4cf4b7439cbfbb84ec7759ca3488aee0,
+			0x7c6452594879f35ef287b3c857d12645,
+			0x7c6452594879f35ef287b3c857d12644,
+			0x71af641f08dbd1a0990483806bffbe0c,
+			0x71af641f08dbd1a0990483806bffbe0d,
 		];
 
-		LOOKUP_TABLE[value.0 as usize]
+		BinaryField128bGhash::new(LOOKUP_TABLE[value.0 as usize])
 	}
 }
 
@@ -421,68 +451,68 @@ mod tests {
 
 	#[test]
 	fn test_ghash_mul() {
-		let a = BinaryField128bGhash(1u128);
-		let b = BinaryField128bGhash(1u128);
+		let a = BinaryField128bGhash::new(1u128);
+		let b = BinaryField128bGhash::new(1u128);
 		let c = a * b;
 
-		assert_eq!(c, BinaryField128bGhash::from(1u128));
+		assert_eq!(c, BinaryField128bGhash::new(1u128));
 
-		let a = BinaryField128bGhash(1u128);
-		let b = BinaryField128bGhash(2u128);
+		let a = BinaryField128bGhash::new(1u128);
+		let b = BinaryField128bGhash::new(2u128);
 		let c = a * b;
 
-		assert_eq!(c, BinaryField128bGhash::from(2u128));
+		assert_eq!(c, BinaryField128bGhash::new(2u128));
 
-		let a = BinaryField128bGhash(1u128);
-		let b = BinaryField128bGhash(1297182698762987u128);
+		let a = BinaryField128bGhash::new(1u128);
+		let b = BinaryField128bGhash::new(1297182698762987u128);
 		let c = a * b;
 
-		assert_eq!(c, BinaryField128bGhash::from(1297182698762987u128));
+		assert_eq!(c, BinaryField128bGhash::new(1297182698762987u128));
 
-		let a = BinaryField128bGhash(2u128);
-		let b = BinaryField128bGhash(2u128);
+		let a = BinaryField128bGhash::new(2u128);
+		let b = BinaryField128bGhash::new(2u128);
 		let c = a * b;
 
-		assert_eq!(c, BinaryField128bGhash::from(4u128));
+		assert_eq!(c, BinaryField128bGhash::new(4u128));
 
-		let a = BinaryField128bGhash(2u128);
-		let b = BinaryField128bGhash(3u128);
+		let a = BinaryField128bGhash::new(2u128);
+		let b = BinaryField128bGhash::new(3u128);
 		let c = a * b;
 
-		assert_eq!(c, BinaryField128bGhash::from(6u128));
+		assert_eq!(c, BinaryField128bGhash::new(6u128));
 
-		let a = BinaryField128bGhash(3u128);
-		let b = BinaryField128bGhash(3u128);
+		let a = BinaryField128bGhash::new(3u128);
+		let b = BinaryField128bGhash::new(3u128);
 		let c = a * b;
 
-		assert_eq!(c, BinaryField128bGhash::from(5u128));
+		assert_eq!(c, BinaryField128bGhash::new(5u128));
 
-		let a = BinaryField128bGhash(1u128 << 127);
-		let b = BinaryField128bGhash(2u128);
+		let a = BinaryField128bGhash::from(1u128 << 127);
+		let b = BinaryField128bGhash::new(2u128);
 		let c = a * b;
 
 		assert_eq!(c, BinaryField128bGhash::from(0b10000111));
 
-		let a = BinaryField128bGhash((1u128 << 127) + 1);
-		let b = BinaryField128bGhash(2u128);
+		let a = BinaryField128bGhash::from((1u128 << 127) + 1);
+		let b = BinaryField128bGhash::new(2u128);
 		let c = a * b;
 
 		assert_eq!(c, BinaryField128bGhash::from(0b10000101));
 
-		let a = BinaryField128bGhash(3u128 << 126);
-		let b = BinaryField128bGhash(2u128);
+		let a = BinaryField128bGhash::from(3u128 << 126);
+		let b = BinaryField128bGhash::new(2u128);
 		let c = a * b;
 
 		assert_eq!(c, BinaryField128bGhash::from(0b10000111 + (1u128 << 127)));
 
-		let a = BinaryField128bGhash(1u128 << 127);
-		let b = BinaryField128bGhash(4u128);
+		let a = BinaryField128bGhash::from(1u128 << 127);
+		let b = BinaryField128bGhash::new(4u128);
 		let c = a * b;
 
 		assert_eq!(c, BinaryField128bGhash::from(0b10000111 << 1));
 
-		let a = BinaryField128bGhash(1u128 << 127);
-		let b = BinaryField128bGhash(1u128 << 122);
+		let a = BinaryField128bGhash::from(1u128 << 127);
+		let b = BinaryField128bGhash::from(1u128 << 122);
 		let c = a * b;
 
 		assert_eq!(c, BinaryField128bGhash::from((0b00000111 << 121) + 0b10000111));
@@ -507,7 +537,7 @@ mod tests {
 		];
 
 		for &value in &test_cases {
-			let field_val = BinaryField128bGhash::new(value);
+			let field_val = BinaryField128bGhash::from(value);
 			let mul_x_result = field_val.mul_x();
 			let regular_mul_result = field_val * BinaryField128bGhash::new(2u128);
 
@@ -533,7 +563,7 @@ mod tests {
 		];
 
 		for &value in &test_cases {
-			let field_val = BinaryField128bGhash::new(value);
+			let field_val = BinaryField128bGhash::from(value);
 			let mul_inv_x_result = field_val.mul_inv_x();
 			let regular_mul_result = field_val
 				* BinaryField128bGhash::new(2u128)
@@ -560,8 +590,8 @@ mod tests {
 
 		#[test]
 		fn test_wide_mul_correctness(a in any::<u128>(), b in any::<u128>()) {
-			let a = BinaryField128bGhash::new(a);
-			let b = BinaryField128bGhash::new(b);
+			let a = BinaryField128bGhash::from(a);
+			let b = BinaryField128bGhash::from(b);
 			let reduced = BinaryField128bGhash::reduce(BinaryField128bGhash::wide_mul(a, b));
 			assert_eq!(reduced, a * b);
 		}
@@ -572,8 +602,8 @@ mod tests {
 			a1 in any::<u128>(), b1 in any::<u128>(),
 			a2 in any::<u128>(), b2 in any::<u128>(),
 		) {
-			let (a1, b1) = (BinaryField128bGhash::new(a1), BinaryField128bGhash::new(b1));
-			let (a2, b2) = (BinaryField128bGhash::new(a2), BinaryField128bGhash::new(b2));
+			let (a1, b1) = (BinaryField128bGhash::from(a1), BinaryField128bGhash::from(b1));
+			let (a2, b2) = (BinaryField128bGhash::from(a2), BinaryField128bGhash::from(b2));
 			let wide =
 				BinaryField128bGhash::wide_mul(a1, b1) + BinaryField128bGhash::wide_mul(a2, b2);
 			assert_eq!(BinaryField128bGhash::reduce(wide), a1 * b1 + a2 * b2);

--- a/crates/field/src/tests.rs
+++ b/crates/field/src/tests.rs
@@ -1,4 +1,5 @@
 // Copyright 2024-2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 use std::iter;
 
@@ -21,8 +22,8 @@ fn test_field_text_debug() {
 	assert_eq!(
 		format!(
 			"{:?}",
-			PackedBinaryGhash1x128b::broadcast(BinaryField128bGhash::new(
-				162259276829213363391578010288127
+			PackedBinaryGhash1x128b::broadcast(BinaryField128bGhash::from(
+				162259276829213363391578010288127u128
 			))
 		),
 		"Packed1x128([0x000007ffffffffffffffffffffffffff])"

--- a/crates/field/src/underlier/divisible.rs
+++ b/crates/field/src/underlier/divisible.rs
@@ -1,4 +1,5 @@
 // Copyright 2024-2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 use std::mem::size_of;
 
@@ -859,6 +860,9 @@ macro_rules! impl_divisible_self {
 		)+
 	};
 }
+
+#[allow(unused)]
+pub(crate) use impl_divisible_self;
 
 impl_divisible_self!(u8, u16, u32, u64, u128, SmallU<1>, SmallU<2>, SmallU<4>);
 

--- a/crates/math/src/field_buffer.rs
+++ b/crates/math/src/field_buffer.rs
@@ -1,4 +1,5 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 use std::{
 	ops::{Deref, DerefMut, Index, IndexMut},
@@ -981,7 +982,7 @@ mod tests {
 				let mut chunk = chunk_wrapper.get();
 				for i in 0..1 << log_chunk_size {
 					let old_val = chunk.get(i);
-					chunk.set(i, F::new(old_val.val() * 10));
+					chunk.set(i, F::new(u128::from(old_val.val()) * 10));
 				}
 				// chunk_wrapper drops here and writes back changes
 			}

--- a/crates/prover/src/ring_switch.rs
+++ b/crates/prover/src/ring_switch.rs
@@ -1,4 +1,5 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 use std::{iter, ops::Deref};
 
@@ -146,7 +147,7 @@ where
 
 	elems.as_mut().par_iter_mut().for_each(|packed_elem| {
 		*packed_elem = P::from_scalars(packed_elem.into_iter().map(|scalar| {
-			let bytes = scalar.val().to_le_bytes();
+			let bytes = u128::from(scalar.val()).to_le_bytes();
 			bytes
 				.into_iter()
 				.enumerate()
@@ -232,7 +233,7 @@ where
 					{
 						let acc = acc.as_mut();
 						for (j, mat_elem) in mat_scalars.iter().enumerate() {
-							let elem_bytes = mat_elem.val().to_le_bytes();
+							let elem_bytes = u128::from(mat_elem.val()).to_le_bytes();
 							for (i, &byte) in elem_bytes.iter().enumerate() {
 								acc[(i << 3) | j] += lookup[byte as usize & 0x0F];
 								acc[(i << 3) | (1 << 2) | j] += lookup[byte as usize >> 4];


### PR DESCRIPTION
Closes [BINIUS-101](https://linear.app/jimpo/issue/BINIUS-101/change-binaryfield128bghash-underlier-to-m128).

Changes `BinaryField128bGhash`'s underlier from `u128` to `M128` (the architecture-chosen 128-bit underlier — a SIMD register on x86_64/aarch64, `u128` elsewhere).

Per the discussion on the issue, this keeps construction ergonomic (option C): `BinaryField128bGhash::new` still takes `u128`, so no caller migration is needed — the only downstream changes are 3 sites that did `u128` arithmetic on `.val()`.

### Commits
1. **Add Hash and LowerHex impls to M128** — the two trait impls a SIMD type needs to back a `binary_field!` field (x86_64 + aarch64 structs; on wasm/portable `M128 = u128` already has them).
2. **Change BinaryField128bGhash underlier to M128** — everything else.

### What the change entails
- **`new` moved out of `binary_field!`**: the macro no longer generates `new` (internal uses switched to the tuple constructor). Each field now defines its own `new` — `BinaryField1b::new(U1)`, `AESTowerField8b::new(u8)`, and `BinaryField128bGhash::new(u128)` (converts to `M128` via a new `const arch::m128_from_u128`, since `From<u128>` isn't `const`).
- **`u128` conversions**: cfg-gated `From<u128>` / `From<BinaryField128bGhash> for u128` on x86_64/aarch64 (on wasm/portable the macro's `From<M128>` already is the `u128` conversion).
- **`Divisible`**: reflexive `Divisible<M128>` (needed for the width-1 packed field) and a reinterpreting `Divisible<M128> for u128` (symmetric to the existing `M128: Divisible<u128>`; needed because the portable `PackedBinaryGhash1x128b` packs the `M128`-underlier scalar in a `u128`).
- **Portable nibble inversion**: `nibble_invert_128b`'s bound relaxed from `WithUnderlier<Underlier = u128>` to `WithUnderlier` + `Underlier: From<u128> + Into<u128>`, converting at the boundary.
- **`ghash.rs`**: `mul_x`/`mul_inv_x` compute over `u128`; the 256-entry AES lookup table stays `[u128; 256]` (wrapped at the lookup site); `min_tower_level` uses `==` instead of a pattern match (`M128` isn't structurally matchable).
- **Downstream (3 sites)**: `binius-math::trace_one_element` is unaffected (`new(u128)`); `field_buffer` test and `prover::ring_switch` (×2) convert `.val()` (now `M128`) to `u128` for byte/integer ops.

### Verification
- Full workspace `cargo clippy --all --tests --benches --examples -- -D warnings`: green.
- `cargo test -p binius-field -p binius-math`: pass. binius-field: 213 lib tests pass.
- Cross-arch: aarch64 `cargo check` (with `+neon,+aes`) and wasm32 build both clean.

### Notes for review
- The reinterpreting `Divisible<M128> for u128` is the one non-obvious addition; it mirrors the existing reverse impl and is only reachable on x86_64/aarch64 (on wasm/portable `M128 = u128`, so the reflexive impl covers it).
- Touches the same `BinaryField128bGhash` foundation as BINIUS-56 (`GhashSq256b`, PR #1537). Whichever merges second needs a trivial rebase fixup in `ghash_sq.rs` (it constructs via the tuple/`from_coeffs`, and `new` is no longer macro-generated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)