### PR TITLE
BINIUS-103: remove the CircuitWire trait

### DIFF
--- a/crates/spartan-prover/src/wrapper/replay_channel.rs
+++ b/crates/spartan-prover/src/wrapper/replay_channel.rs
@@ -5,7 +5,6 @@
 
 use std::{
 	cell::RefCell,
-	marker::PhantomData,
 	rc::{Rc, Weak},
 	vec::IntoIter as VecIntoIter,
 };
@@ -14,50 +13,10 @@ use binius_field::Field;
 use binius_iop::channel::{IOPVerifierChannel, OracleLinearRelation, OracleSpec};
 use binius_ip::channel::IPVerifierChannel;
 use binius_spartan_frontend::{
-	circuit_builder::{CircuitBuilder, WireAllocator, WitnessError, WitnessGenerator, WitnessWire},
+	circuit_builder::{CircuitBuilder, WireAllocator, WitnessError, WitnessGenerator},
 	constraint_system::{WireKind, Witness, WitnessLayout},
 };
-use binius_spartan_verifier::wrapper::circuit_elem::{CircuitElem, CircuitWire};
-
-/// [`CircuitWire`] backend over [`WitnessGenerator`] — used by [`ReplayChannel`] to evaluate
-/// arithmetic concretely while filling the outer witness.
-///
-/// A thin newtype around [`WitnessWire`]: every operation evaluates on the generator, which routes
-/// the result to the public or private segment by the input wires' kinds (matching
-/// [`ConstraintBuilder`](binius_spartan_frontend::circuit_builder::ConstraintBuilder)). The
-/// lifetime ties the wire to the `&WitnessLayout` borrowed by its [`WitnessGenerator`].
-#[derive(Debug, Clone, Copy)]
-pub struct WitnessGenWire<'a, F: Field>(WitnessWire<F>, PhantomData<&'a ()>);
-
-impl<'a, F: Field> WitnessGenWire<'a, F> {
-	pub fn new(wire: WitnessWire<F>) -> Self {
-		Self(wire, PhantomData)
-	}
-}
-
-impl<'a, F: Field> CircuitWire<F> for WitnessGenWire<'a, F> {
-	type Builder = WitnessGenerator<'a, F>;
-
-	fn combine<const IN: usize, const OUT: usize>(
-		builder: &mut Self::Builder,
-		wires: [&Self; IN],
-		builder_op: impl Fn(&mut Self::Builder, [WitnessWire<F>; IN]) -> [WitnessWire<F>; OUT],
-	) -> [Self; OUT] {
-		builder_op(builder, wires.map(|wire| wire.0)).map(Self::new)
-	}
-
-	fn combine_varlen(
-		builder: &mut Self::Builder,
-		wires: &[&Self],
-		n_out: usize,
-		builder_op: impl FnOnce(&mut Self::Builder, &[WitnessWire<F>]) -> Vec<WitnessWire<F>>,
-	) -> Vec<Self> {
-		let inner_wires = wires.iter().map(|wire| wire.0).collect::<Vec<_>>();
-		let result = builder_op(builder, &inner_wires);
-		debug_assert_eq!(result.len(), n_out);
-		result.into_iter().map(Self::new).collect()
-	}
-}
+use binius_spartan_verifier::wrapper::circuit_elem::CircuitElem;
 
 /// A channel that replays recorded interaction values through a [`WitnessGenerator`], filling
 /// both inout and private wires in the outer witness.
@@ -95,7 +54,7 @@ impl<'a, F: Field> ReplayChannel<'a, F> {
 		}
 	}
 
-	fn next_inout_elem(&mut self) -> CircuitElem<F, WitnessGenWire<'a, F>> {
+	fn next_inout_elem(&mut self) -> CircuitElem<F, WitnessGenerator<'a, F>> {
 		let value = self
 			.events
 			.next()
@@ -103,10 +62,10 @@ impl<'a, F: Field> ReplayChannel<'a, F> {
 
 		let wire = self.inout_alloc.alloc();
 		let witness_wire = self.witness_gen.borrow_mut().write_inout(wire, value);
-		CircuitElem::wire(&self.witness_gen, WitnessGenWire::new(witness_wire))
+		CircuitElem::wire(&self.witness_gen, witness_wire)
 	}
 
-	fn next_precommit_elem(&mut self) -> CircuitElem<F, WitnessGenWire<'a, F>> {
+	fn next_precommit_elem(&mut self) -> CircuitElem<F, WitnessGenerator<'a, F>> {
 		let value = self
 			.keys
 			.next()
@@ -114,7 +73,7 @@ impl<'a, F: Field> ReplayChannel<'a, F> {
 
 		let wire = self.precommit_alloc.alloc();
 		let witness_wire = self.witness_gen.borrow_mut().write_precommit(wire, value);
-		CircuitElem::wire(&self.witness_gen, WitnessGenWire::new(witness_wire))
+		CircuitElem::wire(&self.witness_gen, witness_wire)
 	}
 
 	/// Consumes the channel and builds the outer witness.
@@ -127,7 +86,7 @@ impl<'a, F: Field> ReplayChannel<'a, F> {
 }
 
 impl<'a, F: Field> IPVerifierChannel<F> for ReplayChannel<'a, F> {
-	type Elem = CircuitElem<F, WitnessGenWire<'a, F>>;
+	type Elem = CircuitElem<F, WitnessGenerator<'a, F>>;
 
 	fn recv_one(&mut self) -> Result<Self::Elem, binius_ip::channel::Error> {
 		let encrypted_elem = self.next_inout_elem();
@@ -154,10 +113,7 @@ impl<'a, F: Field> IPVerifierChannel<F> for ReplayChannel<'a, F> {
 					Err(binius_ip::channel::Error::InvalidAssert)
 				}
 			}
-			CircuitElem::Wire {
-				builder,
-				wire: WitnessGenWire(wire, _),
-			} => {
+			CircuitElem::Wire { builder, wire } => {
 				assert!(Weak::ptr_eq(&Rc::downgrade(&self.witness_gen), &builder));
 				self.witness_gen.borrow_mut().assert_zero(wire);
 				Ok(())
@@ -176,22 +132,19 @@ impl<'a, F: Field> IPVerifierChannel<F> for ReplayChannel<'a, F> {
 		let value = f(&extract_public_values(inputs));
 		let wire = self.inout_alloc.alloc();
 		let witness_wire = self.witness_gen.borrow_mut().write_inout(wire, value);
-		CircuitElem::wire(&self.witness_gen, WitnessGenWire::new(witness_wire))
+		CircuitElem::wire(&self.witness_gen, witness_wire)
 	}
 }
 
 /// Extracts the concrete field value of each input. The prover knows every wire's value (public or
 /// not), so no public-tag check is needed here — the [`IPVerifierChannel::compute_public_value`]
 /// contract is enforced verifier-side, where non-public inputs are value-less.
-fn extract_public_values<F: Field>(inputs: &[CircuitElem<F, WitnessGenWire<'_, F>>]) -> Vec<F> {
+fn extract_public_values<F: Field>(inputs: &[CircuitElem<F, WitnessGenerator<'_, F>>]) -> Vec<F> {
 	inputs
 		.iter()
 		.map(|elem| match elem {
 			CircuitElem::Constant(c) => *c,
-			CircuitElem::Wire {
-				wire: WitnessGenWire(wire, _),
-				..
-			} => wire.val(),
+			CircuitElem::Wire { wire, .. } => wire.val(),
 		})
 		.collect()
 }
@@ -230,14 +183,10 @@ mod tests {
 		BinaryField1b as B1, BinaryField128bGhash as B128, ExtensionField, field::FieldOps,
 	};
 	use binius_spartan_frontend::circuit_builder::{ConstraintBuilder, WitnessGenerator};
-	use binius_spartan_verifier::wrapper::{
-		builder_channel::BuilderWire, circuit_elem::CircuitElem,
-	};
+	use binius_spartan_verifier::wrapper::circuit_elem::CircuitElem;
 
-	use super::WitnessGenWire;
-
-	type BuildElem = CircuitElem<B128, BuilderWire>;
-	type WitnessElem<'a> = CircuitElem<B128, WitnessGenWire<'a, B128>>;
+	type BuildElem = CircuitElem<B128, ConstraintBuilder<B128>>;
+	type WitnessElem<'a> = CircuitElem<B128, WitnessGenerator<'a, B128>>;
 
 	#[test]
 	fn test_square_transpose_wires() {
@@ -256,7 +205,7 @@ mod tests {
 		let rc = Rc::new(RefCell::new(constraint_builder));
 		let mut elems: Vec<BuildElem> = inout_wires
 			.iter()
-			.map(|&w| BuildElem::wire(&rc, BuilderWire(w)))
+			.map(|&w| BuildElem::wire(&rc, w))
 			.collect();
 
 		<BuildElem as FieldOps>::square_transpose::<FSub>(&mut elems);
@@ -285,7 +234,7 @@ mod tests {
 		let witness_rc = Rc::new(RefCell::new(witness_gen));
 		let mut witness_elems: Vec<WitnessElem> = witness_wires
 			.iter()
-			.map(|&w| WitnessElem::wire(&witness_rc, WitnessGenWire::new(w)))
+			.map(|&w| WitnessElem::wire(&witness_rc, w))
 			.collect();
 
 		<WitnessElem as FieldOps>::square_transpose::<FSub>(&mut witness_elems);

--- a/crates/spartan-verifier/src/wrapper/builder_channel.rs
+++ b/crates/spartan-verifier/src/wrapper/builder_channel.rs
@@ -11,46 +11,9 @@ use std::{
 use binius_field::Field;
 use binius_iop::channel::{IOPVerifierChannel, OracleLinearRelation, OracleSpec};
 use binius_ip::channel::IPVerifierChannel;
-use binius_spartan_frontend::{
-	circuit_builder::{CircuitBuilder, ConstraintBuilder},
-	constraint_system::ConstraintWire,
-};
+use binius_spartan_frontend::circuit_builder::{CircuitBuilder, ConstraintBuilder};
 
-use super::circuit_elem::{CircuitElem, CircuitWire};
-
-/// [`CircuitWire`] backend over [`ConstraintBuilder`] — used by [`IronSpartanBuilderChannel`] to
-/// record arithmetic as constraints in a constraint system.
-///
-/// A thin newtype around [`ConstraintWire`]: every operation records itself on the builder, which
-/// decides whether the output is a derived (public-derivable, no constraint) or private wire. The
-/// public-vs-private elision lives in [`ConstraintBuilder`], so this backend needs no tracking of
-/// its own.
-#[derive(Debug, Clone, Copy)]
-pub struct BuilderWire(pub ConstraintWire);
-
-impl<F: Field> CircuitWire<F> for BuilderWire {
-	type Builder = ConstraintBuilder<F>;
-
-	fn combine<const IN: usize, const OUT: usize>(
-		builder: &mut Self::Builder,
-		wires: [&Self; IN],
-		builder_op: impl Fn(&mut Self::Builder, [ConstraintWire; IN]) -> [ConstraintWire; OUT],
-	) -> [Self; OUT] {
-		builder_op(builder, wires.map(|wire| wire.0)).map(Self)
-	}
-
-	fn combine_varlen(
-		builder: &mut Self::Builder,
-		wires: &[&Self],
-		n_out: usize,
-		builder_op: impl FnOnce(&mut Self::Builder, &[ConstraintWire]) -> Vec<ConstraintWire>,
-	) -> Vec<Self> {
-		let inner_wires = wires.iter().map(|wire| wire.0).collect::<Vec<_>>();
-		let result = builder_op(builder, &inner_wires);
-		debug_assert_eq!(result.len(), n_out);
-		result.into_iter().map(Self).collect()
-	}
-}
+use super::circuit_elem::CircuitElem;
 
 /// A channel that symbolically executes a verifier, building up an IronSpartan constraint system.
 ///
@@ -79,14 +42,14 @@ impl<F: Field> IronSpartanBuilderChannel<F> {
 		}
 	}
 
-	fn alloc_inout_elem(&self) -> CircuitElem<F, BuilderWire> {
+	fn alloc_inout_elem(&self) -> CircuitElem<F, ConstraintBuilder<F>> {
 		let wire = self.builder.borrow_mut().alloc_inout();
-		CircuitElem::wire(&self.builder, BuilderWire(wire))
+		CircuitElem::wire(&self.builder, wire)
 	}
 
-	fn alloc_precommit_elem(&self) -> CircuitElem<F, BuilderWire> {
+	fn alloc_precommit_elem(&self) -> CircuitElem<F, ConstraintBuilder<F>> {
 		let wire = self.builder.borrow_mut().alloc_precommit();
-		CircuitElem::wire(&self.builder, BuilderWire(wire))
+		CircuitElem::wire(&self.builder, wire)
 	}
 
 	/// Consumes the channel and returns the underlying [`ConstraintBuilder`].
@@ -101,7 +64,7 @@ impl<F: Field> IronSpartanBuilderChannel<F> {
 }
 
 impl<F: Field> IPVerifierChannel<F> for IronSpartanBuilderChannel<F> {
-	type Elem = CircuitElem<F, BuilderWire>;
+	type Elem = CircuitElem<F, ConstraintBuilder<F>>;
 
 	fn recv_one(&mut self) -> Result<Self::Elem, binius_ip::channel::Error> {
 		// For each element that the inner prover sends, the wrapped prover allocates a one-time-pad
@@ -134,10 +97,7 @@ impl<F: Field> IPVerifierChannel<F> for IronSpartanBuilderChannel<F> {
 			// Record the assertion as a constraint over the wire (whether public-derivable or
 			// private). The outer verifier enforces it; with derived wires there is no need to
 			// special-case public values out of the constraint system.
-			CircuitElem::Wire {
-				builder,
-				wire: BuilderWire(wire),
-			} => {
+			CircuitElem::Wire { builder, wire } => {
 				assert!(Weak::ptr_eq(&Rc::downgrade(&self.builder), &builder));
 				self.builder.borrow_mut().assert_zero(wire);
 				Ok(())

--- a/crates/spartan-verifier/src/wrapper/circuit_elem.rs
+++ b/crates/spartan-verifier/src/wrapper/circuit_elem.rs
@@ -1,23 +1,19 @@
 // Copyright 2026 The Binius Developers
 
-//! Generic field element types over a pluggable circuit-wire backend.
+//! Generic field element over a pluggable [`CircuitBuilder`] backend.
 //!
-//! [`CircuitElem<F, W>`] is a field element parameterized by a [`CircuitWire<F>`] impl. The
-//! [`CircuitWire`] trait hides backend-specific wire-combination logic behind a single `combine`
-//! operation, so the arithmetic trait impls on [`CircuitElem`] are written once and reused across
-//! all backends. Each backend lives next to the channel that uses it:
+//! [`CircuitElem<F, B>`] is a field element that is either a known `Constant` or a `Wire` in a
+//! [`CircuitBuilder`] `B`. The arithmetic-trait impls on [`CircuitElem`] are written once and
+//! reused across all backends; each operation either folds constants at the `F` level or delegates
+//! to the builder's `add`/`mul`/`hint`/… on the wire type `B::Wire`. The backends are the frontend
+//! builders themselves:
 //!
-//! - [`BuilderWire`](super::builder_channel::BuilderWire) over [`ConstraintBuilder`] — symbolic
-//!   constraint recording (used by
+//! - [`ConstraintBuilder`] — symbolic constraint recording (used by
 //!   [`IronSpartanBuilderChannel`](super::builder_channel::IronSpartanBuilderChannel)).
-//! - [`WrappedWire`](super::zk_wrapped_channel::WrappedWire) over [`InstanceGenerator`] —
-//!   reconstructs the public-input vector during verification (used by
+//! - [`InstanceGenerator`] — reconstructs the public-input vector during verification (used by
 //!   [`ZKWrappedVerifierChannel`](super::zk_wrapped_channel::ZKWrappedVerifierChannel)).
-//! - `WitnessGenWire` over [`WitnessGenerator`] — concrete evaluation that fills a witness (used by
+//! - [`WitnessGenerator`] — concrete evaluation that fills a witness (used by
 //!   `binius_spartan_prover::wrapper::ReplayChannel`).
-//!
-//! Each backend is a thin newtype over its builder's wire type; the public-vs-private elision lives
-//! in the builders ([`ConstraintBuilder`] derived wires), not in these wrappers.
 //!
 //! [`CircuitBuilder`]: binius_spartan_frontend::circuit_builder::CircuitBuilder
 //! [`ConstraintBuilder`]: binius_spartan_frontend::circuit_builder::ConstraintBuilder
@@ -26,6 +22,7 @@
 
 use std::{
 	cell::RefCell,
+	fmt,
 	iter::{Product, Sum},
 	ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 	rc::{Rc, Weak},
@@ -40,98 +37,67 @@ use binius_spartan_frontend::circuit_builder::CircuitBuilder;
 
 use super::gadgets;
 
-/// Backend-specific logic for combining wires under arithmetic operations.
+/// A field element that is either a known constant or a wire in a [`CircuitBuilder`] `B`.
 ///
-/// One method (`combine`, plus its variable-arity sibling `combine_varlen`) suffices for the
-/// arithmetic-trait impls on [`CircuitElem`]. Each impl maps its wires through `op` on the
-/// underlying [`CircuitBuilder`], which decides how the operation is recorded or evaluated.
-/// Constant folding happens one level up in [`CircuitElem`], so these methods only ever run on
-/// builder-backed wires.
-pub trait CircuitWire<F: Field>: Sized {
-	type Builder: CircuitBuilder<Field = F>;
-
-	fn constant(builder: &mut Self::Builder, val: F) -> Self {
-		let [ret] = Self::combine(builder, [], |builder, _| [builder.constant(val)]);
-		ret
-	}
-
-	fn combine<const IN: usize, const OUT: usize>(
-		builder: &mut Self::Builder,
-		wires: [&Self; IN],
-		op: impl Fn(
-			&mut Self::Builder,
-			[<Self::Builder as CircuitBuilder>::Wire; IN],
-		) -> [<Self::Builder as CircuitBuilder>::Wire; OUT],
-	) -> [Self; OUT];
-
-	/// Variable-arity version of [`Self::combine`].
-	///
-	/// Used by operations whose input/output sizes are determined at runtime (e.g. delegating to
-	/// a `&[B::Wire]`-taking gadget like `square_transpose`).
-	///
-	/// # Contract
-	///
-	/// `op` MUST return a `Vec` of length `n_out` whenever it is called. The impl checks this with
-	/// `debug_assert_eq!`.
-	fn combine_varlen(
-		builder: &mut Self::Builder,
-		wires: &[&Self],
-		n_out: usize,
-		op: impl FnOnce(
-			&mut Self::Builder,
-			&[<Self::Builder as CircuitBuilder>::Wire],
-		) -> Vec<<Self::Builder as CircuitBuilder>::Wire>,
-	) -> Vec<Self>;
-}
-
-/// A field element that is either a known constant or a wire in a [`CircuitBuilder`].
-///
-/// The behaviour of arithmetic on `Wire` values is determined by the `W: CircuitWire<F>` impl —
-/// see the module docs for the available backends. The `Wire` variant holds a [`Weak`] reference
-/// to the shared builder; it must outlive any operation performed on the element.
-#[derive(Debug)]
-pub enum CircuitElem<F: Field, W: CircuitWire<F>> {
+/// The `Wire` variant holds a [`Weak`] reference to the shared builder; it must outlive any
+/// operation performed on the element. Arithmetic over all-`Constant` operands folds at the `F`
+/// level without touching a builder; any `Wire` operand routes the operation through `B`.
+pub enum CircuitElem<F: Field, B: CircuitBuilder<Field = F>> {
 	Constant(F),
 	Wire {
-		builder: Weak<RefCell<W::Builder>>,
-		wire: W,
+		builder: Weak<RefCell<B>>,
+		wire: B::Wire,
 	},
 }
 
-// Manual `Clone` impl that does not require `W::Builder: Clone` (the derived impl would, even
-// though `Weak<T>: Clone` for any `T`).
-impl<F: Field, W: CircuitWire<F> + Clone> Clone for CircuitElem<F, W> {
+// Manual `Debug`: the derived impl would bound the type parameter `B: Debug`, but the field is the
+// associated type `B::Wire`, so we bound that instead.
+impl<F: Field, B: CircuitBuilder<Field = F>> fmt::Debug for CircuitElem<F, B>
+where
+	B::Wire: fmt::Debug,
+{
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		match self {
+			Self::Constant(c) => f.debug_tuple("Constant").field(c).finish(),
+			Self::Wire { wire, .. } => f.debug_struct("Wire").field("wire", wire).finish(),
+		}
+	}
+}
+
+// Manual `Clone` that does not require `B: Clone` (the derived impl would, even though
+// `Weak<T>: Clone` for any `T` and `B::Wire: Copy`).
+impl<F: Field, B: CircuitBuilder<Field = F>> Clone for CircuitElem<F, B> {
 	fn clone(&self) -> Self {
 		match self {
 			Self::Constant(c) => Self::Constant(*c),
 			Self::Wire { builder, wire } => Self::Wire {
 				builder: builder.clone(),
-				wire: wire.clone(),
+				wire: *wire,
 			},
 		}
 	}
 }
 
-impl<F, W> CircuitElem<F, W>
+impl<F, B> CircuitElem<F, B>
 where
 	F: Field,
-	W: CircuitWire<F>,
+	B: CircuitBuilder<Field = F>,
 {
 	/// Construct a [`Self::Wire`] anchored to a shared builder via a [`Weak`] reference.
-	pub fn wire(builder: &Rc<RefCell<W::Builder>>, wire: W) -> Self {
+	pub fn wire(builder: &Rc<RefCell<B>>, wire: B::Wire) -> Self {
 		Self::Wire {
 			builder: Rc::downgrade(builder),
 			wire,
 		}
 	}
 
+	/// Combine `elems` under an operation. If every input is a `Constant`, fold at the `F` level
+	/// via `f_op` (no builder is touched). Otherwise convert constants to wires on the shared
+	/// builder and run `builder_op` over the wires.
 	pub fn combine<const IN: usize, const OUT: usize>(
 		elems: [&Self; IN],
 		f_op: impl Fn([F; IN]) -> [F; OUT],
-		builder_op: impl Fn(
-			&mut W::Builder,
-			[<W::Builder as CircuitBuilder>::Wire; IN],
-		) -> [<W::Builder as CircuitBuilder>::Wire; OUT],
+		builder_op: impl Fn(&mut B, [B::Wire; IN]) -> [B::Wire; OUT],
 	) -> [Self; OUT] {
 		let builder = elems.iter().find_map(|elem| match elem {
 			Self::Wire { builder, .. } => Some(builder),
@@ -144,7 +110,7 @@ where
 			};
 			let mut builder = builder.borrow_mut();
 			let inner_wires = elems.map(|elem| match elem {
-				Self::Constant(val) => OwnedOrRef::Owned(W::constant(&mut *builder, *val)),
+				Self::Constant(val) => builder.constant(*val),
 				Self::Wire {
 					builder: other_builder_ptr,
 					wire,
@@ -153,11 +119,10 @@ where
 						Weak::ptr_eq(builder_ptr, other_builder_ptr),
 						"all combined CircuitElems must come from the same channel"
 					);
-					OwnedOrRef::Ref(wire)
+					*wire
 				}
 			});
-			let inner_wire_refs = inner_wires.each_ref().map(AsRef::as_ref);
-			W::combine(&mut *builder, inner_wire_refs, builder_op).map(|wire| Self::Wire {
+			builder_op(&mut builder, inner_wires).map(|wire| Self::Wire {
 				builder: builder_ptr.clone(),
 				wire,
 			})
@@ -177,16 +142,12 @@ where
 	/// Variable-arity sibling of [`Self::combine`].
 	///
 	/// `f_op` and `builder_op` must return a `Vec` of length `n_out`; checked via
-	/// `debug_assert_eq!` inside [`CircuitWire::combine_varlen`] (and here, for the
-	/// all-constants branch).
+	/// `debug_assert_eq!`.
 	pub fn combine_varlen(
 		elems: &[&Self],
 		n_out: usize,
 		f_op: impl FnOnce(&[F]) -> Vec<F>,
-		builder_op: impl FnOnce(
-			&mut W::Builder,
-			&[<W::Builder as CircuitBuilder>::Wire],
-		) -> Vec<<W::Builder as CircuitBuilder>::Wire>,
+		builder_op: impl FnOnce(&mut B, &[B::Wire]) -> Vec<B::Wire>,
 	) -> Vec<Self> {
 		let builder = elems.iter().find_map(|elem| match elem {
 			Self::Wire { builder, .. } => Some(builder),
@@ -203,7 +164,7 @@ where
 			let inner_wires = elems
 				.iter()
 				.map(|elem| match elem {
-					Self::Constant(val) => OwnedOrRef::Owned(W::constant(&mut *builder, *val)),
+					Self::Constant(val) => builder.constant(*val),
 					Self::Wire {
 						builder: other_builder_ptr,
 						wire,
@@ -212,12 +173,13 @@ where
 							Weak::ptr_eq(builder_ptr, other_builder_ptr),
 							"all combined CircuitElems must come from the same channel"
 						);
-						OwnedOrRef::Ref(wire)
+						*wire
 					}
 				})
 				.collect::<Vec<_>>();
-			let inner_wire_refs = inner_wires.iter().map(AsRef::as_ref).collect::<Vec<_>>();
-			W::combine_varlen(&mut *builder, &inner_wire_refs, n_out, builder_op)
+			let result = builder_op(&mut builder, &inner_wires);
+			debug_assert_eq!(result.len(), n_out);
+			result
 				.into_iter()
 				.map(|wire| Self::Wire {
 					builder: builder_ptr.clone(),
@@ -245,7 +207,7 @@ where
 
 // In characteristic 2, negation is identity.
 // TODO: For the sake of purity, it would be nice for CircuitBuilder to have a neg method
-impl<F: Field, W: CircuitWire<F>> Neg for CircuitElem<F, W> {
+impl<F: Field, B: CircuitBuilder<Field = F>> Neg for CircuitElem<F, B> {
 	type Output = Self;
 
 	fn neg(self) -> Self {
@@ -253,7 +215,7 @@ impl<F: Field, W: CircuitWire<F>> Neg for CircuitElem<F, W> {
 	}
 }
 
-impl<F: Field, W: CircuitWire<F>> Add for CircuitElem<F, W> {
+impl<F: Field, B: CircuitBuilder<Field = F>> Add for CircuitElem<F, B> {
 	type Output = Self;
 
 	fn add(self, rhs: Self) -> Self {
@@ -261,7 +223,7 @@ impl<F: Field, W: CircuitWire<F>> Add for CircuitElem<F, W> {
 	}
 }
 
-impl<F: Field, W: CircuitWire<F>> Sub for CircuitElem<F, W> {
+impl<F: Field, B: CircuitBuilder<Field = F>> Sub for CircuitElem<F, B> {
 	type Output = Self;
 
 	fn sub(self, rhs: Self) -> Self {
@@ -269,7 +231,7 @@ impl<F: Field, W: CircuitWire<F>> Sub for CircuitElem<F, W> {
 	}
 }
 
-impl<F: Field, W: CircuitWire<F>> Mul for CircuitElem<F, W> {
+impl<F: Field, B: CircuitBuilder<Field = F>> Mul for CircuitElem<F, B> {
 	type Output = Self;
 
 	fn mul(self, rhs: Self) -> Self {
@@ -279,10 +241,10 @@ impl<F: Field, W: CircuitWire<F>> Mul for CircuitElem<F, W> {
 
 // By-reference variants: clone and delegate.
 
-impl<F, W> Add<&Self> for CircuitElem<F, W>
+impl<F, B> Add<&Self> for CircuitElem<F, B>
 where
 	F: Field,
-	W: CircuitWire<F>,
+	B: CircuitBuilder<Field = F>,
 {
 	type Output = Self;
 
@@ -291,10 +253,10 @@ where
 	}
 }
 
-impl<F, W> Sub<&Self> for CircuitElem<F, W>
+impl<F, B> Sub<&Self> for CircuitElem<F, B>
 where
 	F: Field,
-	W: CircuitWire<F>,
+	B: CircuitBuilder<Field = F>,
 {
 	type Output = Self;
 
@@ -303,10 +265,10 @@ where
 	}
 }
 
-impl<F, W> Mul<&Self> for CircuitElem<F, W>
+impl<F, B> Mul<&Self> for CircuitElem<F, B>
 where
 	F: Field,
-	W: CircuitWire<F>,
+	B: CircuitBuilder<Field = F>,
 {
 	type Output = Self;
 
@@ -315,12 +277,12 @@ where
 	}
 }
 
-impl<F, W> Add for &CircuitElem<F, W>
+impl<F, B> Add for &CircuitElem<F, B>
 where
 	F: Field,
-	W: CircuitWire<F>,
+	B: CircuitBuilder<Field = F>,
 {
-	type Output = CircuitElem<F, W>;
+	type Output = CircuitElem<F, B>;
 
 	fn add(self, rhs: Self) -> Self::Output {
 		let [ret] = CircuitElem::combine(
@@ -332,12 +294,12 @@ where
 	}
 }
 
-impl<F, W> Sub for &CircuitElem<F, W>
+impl<F, B> Sub for &CircuitElem<F, B>
 where
 	F: Field,
-	W: CircuitWire<F>,
+	B: CircuitBuilder<Field = F>,
 {
-	type Output = CircuitElem<F, W>;
+	type Output = CircuitElem<F, B>;
 
 	fn sub(self, rhs: Self) -> Self::Output {
 		let [ret] = CircuitElem::combine(
@@ -349,12 +311,12 @@ where
 	}
 }
 
-impl<F, W> Mul for &CircuitElem<F, W>
+impl<F, B> Mul for &CircuitElem<F, B>
 where
 	F: Field,
-	W: CircuitWire<F>,
+	B: CircuitBuilder<Field = F>,
 {
-	type Output = CircuitElem<F, W>;
+	type Output = CircuitElem<F, B>;
 
 	fn mul(self, rhs: Self) -> Self::Output {
 		// Short-circuit `wire * 0 = 0` so the wrapper does not allocate a multiplication
@@ -373,39 +335,39 @@ where
 	}
 }
 
-// Assign variants — use mem::replace to avoid requiring B: Clone.
+// Assign variants.
 
-impl<F: Field, W: CircuitWire<F>> AddAssign for CircuitElem<F, W> {
+impl<F: Field, B: CircuitBuilder<Field = F>> AddAssign for CircuitElem<F, B> {
 	fn add_assign(&mut self, rhs: Self) {
 		*self = &*self + &rhs;
 	}
 }
 
-impl<F: Field, W: CircuitWire<F>> SubAssign for CircuitElem<F, W> {
+impl<F: Field, B: CircuitBuilder<Field = F>> SubAssign for CircuitElem<F, B> {
 	fn sub_assign(&mut self, rhs: Self) {
 		*self = &*self - &rhs;
 	}
 }
 
-impl<F: Field, W: CircuitWire<F>> MulAssign for CircuitElem<F, W> {
+impl<F: Field, B: CircuitBuilder<Field = F>> MulAssign for CircuitElem<F, B> {
 	fn mul_assign(&mut self, rhs: Self) {
 		*self = &*self * &rhs;
 	}
 }
 
-impl<F: Field, W: CircuitWire<F>> AddAssign<&Self> for CircuitElem<F, W> {
+impl<F: Field, B: CircuitBuilder<Field = F>> AddAssign<&Self> for CircuitElem<F, B> {
 	fn add_assign(&mut self, rhs: &Self) {
 		*self = &*self + rhs;
 	}
 }
 
-impl<F: Field, W: CircuitWire<F>> SubAssign<&Self> for CircuitElem<F, W> {
+impl<F: Field, B: CircuitBuilder<Field = F>> SubAssign<&Self> for CircuitElem<F, B> {
 	fn sub_assign(&mut self, rhs: &Self) {
 		*self = &*self - rhs;
 	}
 }
 
-impl<F: Field, W: CircuitWire<F>> MulAssign<&Self> for CircuitElem<F, W> {
+impl<F: Field, B: CircuitBuilder<Field = F>> MulAssign<&Self> for CircuitElem<F, B> {
 	fn mul_assign(&mut self, rhs: &Self) {
 		*self = &*self * rhs;
 	}
@@ -413,38 +375,38 @@ impl<F: Field, W: CircuitWire<F>> MulAssign<&Self> for CircuitElem<F, W> {
 
 // Sum and Product
 
-impl<F: Field, W: CircuitWire<F>> Sum for CircuitElem<F, W> {
+impl<F: Field, B: CircuitBuilder<Field = F>> Sum for CircuitElem<F, B> {
 	fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
 		iter.fold(CircuitElem::Constant(F::ZERO), |acc, x| acc + x)
 	}
 }
 
-impl<'a, F: Field, W: CircuitWire<F>> Sum<&'a Self> for CircuitElem<F, W> {
+impl<'a, F: Field, B: CircuitBuilder<Field = F>> Sum<&'a Self> for CircuitElem<F, B> {
 	fn sum<I: Iterator<Item = &'a Self>>(iter: I) -> Self {
 		iter.fold(Self::Constant(F::ZERO), |acc, x| acc + x)
 	}
 }
 
-impl<F: Field, W: CircuitWire<F>> Product for CircuitElem<F, W> {
+impl<F: Field, B: CircuitBuilder<Field = F>> Product for CircuitElem<F, B> {
 	fn product<I: Iterator<Item = Self>>(iter: I) -> Self {
 		iter.fold(Self::Constant(F::ONE), |acc, x| acc * x)
 	}
 }
 
-impl<'a, F: Field, W: CircuitWire<F>> Product<&'a Self> for CircuitElem<F, W> {
+impl<'a, F: Field, B: CircuitBuilder<Field = F>> Product<&'a Self> for CircuitElem<F, B> {
 	fn product<I: Iterator<Item = &'a Self>>(iter: I) -> Self {
 		iter.fold(Self::Constant(F::ONE), |acc, x| acc * x)
 	}
 }
 
-impl<F: Field, W: CircuitWire<F>> Square for CircuitElem<F, W> {
+impl<F: Field, B: CircuitBuilder<Field = F>> Square for CircuitElem<F, B> {
 	fn square(self) -> Self {
 		let [ret] = Self::combine([&self], |[x]| [x.square()], |builder, [x]| [builder.mul(x, x)]);
 		ret
 	}
 }
 
-impl<F: Field, W: CircuitWire<F>> InvertOrZero for CircuitElem<F, W> {
+impl<F: Field, B: CircuitBuilder<Field = F>> InvertOrZero for CircuitElem<F, B> {
 	fn invert_or_zero(self) -> Self {
 		let [ret] = Self::combine(
 			[&self],
@@ -461,7 +423,7 @@ impl<F: Field, W: CircuitWire<F>> InvertOrZero for CircuitElem<F, W> {
 	}
 }
 
-impl<F: Field, W: CircuitWire<F> + Clone> FieldOps for CircuitElem<F, W> {
+impl<F: Field, B: CircuitBuilder<Field = F>> FieldOps for CircuitElem<F, B> {
 	type Scalar = F;
 
 	fn zero() -> Self {
@@ -500,23 +462,8 @@ impl<F: Field, W: CircuitWire<F> + Clone> FieldOps for CircuitElem<F, W> {
 	}
 }
 
-impl<F: Field, W: CircuitWire<F>> From<F> for CircuitElem<F, W> {
+impl<F: Field, B: CircuitBuilder<Field = F>> From<F> for CircuitElem<F, B> {
 	fn from(val: F) -> Self {
 		Self::Constant(val)
-	}
-}
-
-#[derive(Debug)]
-enum OwnedOrRef<'a, T> {
-	Owned(T),
-	Ref(&'a T),
-}
-
-impl<'a, T> AsRef<T> for OwnedOrRef<'a, T> {
-	fn as_ref(&self) -> &T {
-		match self {
-			Self::Owned(ret) => ret,
-			Self::Ref(ret) => ret,
-		}
 	}
 }

--- a/crates/spartan-verifier/src/wrapper/mod.rs
+++ b/crates/spartan-verifier/src/wrapper/mod.rs
@@ -30,9 +30,9 @@ mod tests {
 	use rand::{SeedableRng, rngs::StdRng};
 
 	use super::*;
-	use crate::wrapper::{builder_channel::BuilderWire, circuit_elem::CircuitElem};
+	use crate::wrapper::circuit_elem::CircuitElem;
 
-	type BuildElem = CircuitElem<B128, BuilderWire>;
+	type BuildElem = CircuitElem<B128, ConstraintBuilder<B128>>;
 
 	/// Helper to create a private-backed `BuildElem` wire from a ConstraintBuilder Rc for tests.
 	///
@@ -41,7 +41,7 @@ mod tests {
 	/// instead be elided into a derived wire with no constraint.
 	fn alloc_private_wire(rc: &Rc<std::cell::RefCell<ConstraintBuilder<B128>>>) -> BuildElem {
 		let wire = rc.borrow_mut().alloc_precommit();
-		BuildElem::wire(rc, BuilderWire(wire))
+		BuildElem::wire(rc, wire)
 	}
 
 	#[test]

--- a/crates/spartan-verifier/src/wrapper/zk_wrapped_channel.rs
+++ b/crates/spartan-verifier/src/wrapper/zk_wrapped_channel.rs
@@ -3,7 +3,7 @@
 //! ZK-wrapped verifier channel that delegates to a BaseFold ZK channel and an outer IOP verifier.
 //!
 //! [`ZKWrappedVerifierChannel`] wraps a [`BaseFoldZKVerifierChannel`] and an [`IOPVerifier`].
-//! Inner-channel values flow through the wrapper as [`WrappedWire`] elements backed by an
+//! Inner-channel values flow through the wrapper as `CircuitElem`s backed by an
 //! [`InstanceGenerator`], which reconstructs the outer constraint system's public-input vector
 //! `[constants | inout | derived]` exactly as the prover's witness generator does — public-derived
 //! intermediate values are recomputed natively rather than tracked by the wrapper. [`finish()`]
@@ -11,7 +11,7 @@
 //!
 //! [`finish()`]: ZKWrappedVerifierChannel::finish
 
-use std::{cell::RefCell, marker::PhantomData, rc::Rc};
+use std::{cell::RefCell, rc::Rc};
 
 use binius_field::{BinaryField, Field};
 use binius_iop::{
@@ -21,61 +21,17 @@ use binius_iop::{
 };
 use binius_ip::channel::IPVerifierChannel;
 use binius_spartan_frontend::{
-	circuit_builder::{InstanceGenerator, PublicWire, WireAllocator},
+	circuit_builder::{InstanceGenerator, WireAllocator},
 	constraint_system::{WireKind, WitnessLayout},
 };
 use binius_transcript::fiat_shamir::Challenger;
 use binius_utils::DeserializeBytes;
 
-use crate::{
-	Error, IOPVerifier,
-	wrapper::circuit_elem::{CircuitElem, CircuitWire},
-};
-
-/// [`CircuitWire`] backend over [`InstanceGenerator`] — used by [`ZKWrappedVerifierChannel`] to
-/// reconstruct the outer public-input vector during verification.
-///
-/// A thin newtype around [`PublicWire`]: every operation evaluates on the generator, which fills
-/// the public segment (`constants`/`inout`/`derived`) and leaves private/precommit wires value-less
-/// — the verifier never learns the secrets, and by the soundness invariant no derived value depends
-/// on them. The lifetime ties the wire to the `&WitnessLayout` borrowed by its
-/// [`InstanceGenerator`].
-#[derive(Debug, Clone, Copy)]
-pub struct WrappedWire<'a, F: Field>(PublicWire<F>, PhantomData<&'a ()>);
-
-impl<'a, F: Field> WrappedWire<'a, F> {
-	fn new(wire: PublicWire<F>) -> Self {
-		Self(wire, PhantomData)
-	}
-}
-
-impl<'a, F: Field> CircuitWire<F> for WrappedWire<'a, F> {
-	type Builder = InstanceGenerator<'a, F>;
-
-	fn combine<const IN: usize, const OUT: usize>(
-		builder: &mut Self::Builder,
-		wires: [&Self; IN],
-		builder_op: impl Fn(&mut Self::Builder, [PublicWire<F>; IN]) -> [PublicWire<F>; OUT],
-	) -> [Self; OUT] {
-		builder_op(builder, wires.map(|wire| wire.0)).map(Self::new)
-	}
-
-	fn combine_varlen(
-		builder: &mut Self::Builder,
-		wires: &[&Self],
-		n_out: usize,
-		builder_op: impl FnOnce(&mut Self::Builder, &[PublicWire<F>]) -> Vec<PublicWire<F>>,
-	) -> Vec<Self> {
-		let inner_wires = wires.iter().map(|wire| wire.0).collect::<Vec<_>>();
-		let result = builder_op(builder, &inner_wires);
-		debug_assert_eq!(result.len(), n_out);
-		result.into_iter().map(Self::new).collect()
-	}
-}
+use crate::{Error, IOPVerifier, wrapper::circuit_elem::CircuitElem};
 
 /// A verifier channel that wraps a [`BaseFoldZKVerifierChannel`] and an [`IOPVerifier`].
 ///
-/// `Self::Elem = CircuitElem<F, WrappedWire<F>>`. F values received or sampled from the inner
+/// `Self::Elem = CircuitElem<F, InstanceGenerator>`. F values received or sampled from the inner
 /// channel are written into the [`InstanceGenerator`]'s public segment as inout wires (in the same
 /// order the symbolic
 /// [`IronSpartanBuilderChannel`](super::builder_channel::IronSpartanBuilderChannel) allocates
@@ -171,17 +127,17 @@ where
 	/// Allocates the next inout wire, writing `value` into the public segment, and wraps it as an
 	/// element. Allocation order must match the symbolic
 	/// [`IronSpartanBuilderChannel`](super::builder_channel::IronSpartanBuilderChannel).
-	fn alloc_inout_elem(&mut self, value: F) -> CircuitElem<F, WrappedWire<'a, F>> {
+	fn alloc_inout_elem(&mut self, value: F) -> CircuitElem<F, InstanceGenerator<'a, F>> {
 		let wire = self.inout_alloc.alloc();
 		let public_wire = self.instance_gen.borrow_mut().write_inout(wire, value);
-		CircuitElem::wire(&self.instance_gen, WrappedWire::new(public_wire))
+		CircuitElem::wire(&self.instance_gen, public_wire)
 	}
 
 	/// Allocates the next precommit wire (value-less to the verifier) as an element.
-	fn alloc_precommit_elem(&mut self) -> CircuitElem<F, WrappedWire<'a, F>> {
+	fn alloc_precommit_elem(&mut self) -> CircuitElem<F, InstanceGenerator<'a, F>> {
 		let wire = self.precommit_alloc.alloc();
 		let public_wire = self.instance_gen.borrow_mut().placeholder_precommit(wire);
-		CircuitElem::wire(&self.instance_gen, WrappedWire::new(public_wire))
+		CircuitElem::wire(&self.instance_gen, public_wire)
 	}
 
 	/// Consumes the channel and runs the outer verifier.
@@ -216,7 +172,7 @@ where
 	MTScheme: MerkleTreeScheme<F, Digest: DeserializeBytes>,
 	Challenger_: Challenger,
 {
-	type Elem = CircuitElem<F, WrappedWire<'a, F>>;
+	type Elem = CircuitElem<F, InstanceGenerator<'a, F>>;
 
 	fn recv_one(&mut self) -> Result<Self::Elem, binius_ip::channel::Error> {
 		// Mirror `IronSpartanBuilderChannel::recv_one`'s shape: `inout - key`. The inout carries
@@ -333,10 +289,7 @@ where
 
 				match transparent(&wrapped_vals) {
 					CircuitElem::Constant(val) => val,
-					CircuitElem::Wire {
-						wire: WrappedWire(public_wire, _),
-						..
-					} => public_wire.value().expect(
+					CircuitElem::Wire { wire, .. } => wire.value().expect(
 						"precondition: the transparent polynomial evaluation must depend only on known values (constants or sampled challenges)",
 					),
 				}
@@ -353,15 +306,12 @@ where
 
 /// Extracts the concrete field value of each public-derived input. Panics if any input is not
 /// public (value-less), enforcing the [`IPVerifierChannel::compute_public_value`] contract.
-fn extract_public_values<F: Field>(inputs: &[CircuitElem<F, WrappedWire<'_, F>>]) -> Vec<F> {
+fn extract_public_values<F: Field>(inputs: &[CircuitElem<F, InstanceGenerator<'_, F>>]) -> Vec<F> {
 	inputs
 		.iter()
 		.map(|elem| match elem {
 			CircuitElem::Constant(c) => *c,
-			CircuitElem::Wire {
-				wire: WrappedWire(public_wire, _),
-				..
-			} => public_wire
+			CircuitElem::Wire { wire, .. } => wire
 				.value()
 				.expect("compute_public_value: input is not public"),
 		})


### PR DESCRIPTION
Closes [BINIUS-103](https://linear.app/jimpo/issue/BINIUS-103/remove-the-circuitwire-trait).

## Summary

After BINIUS-99 the three `CircuitWire` impls (`BuilderWire`, `WrappedWire`, `WitnessGenWire`) were identical thin newtypes delegating to their frontend builder, so the trait was pure indirection. This makes `CircuitElem` generic over the `CircuitBuilder` directly, as the issue specified:

```rust
pub enum CircuitElem<F: Field, B: CircuitBuilder<Field = F>> {
    Constant(F),
    Wire { builder: Weak<RefCell<B>>, wire: B::Wire },
}
```

`combine`/`combine_varlen` now call `builder.constant(..)` and the `builder_op` directly. Removed: the `CircuitWire` trait, the `BuilderWire`/`WrappedWire`/`WitnessGenWire` newtypes, and the `OwnedOrRef` helper (no longer needed since `B::Wire: Copy` lets the wire array be built inline). Each channel's `Elem` is now `CircuitElem<F, ConstraintBuilder<F>>` / `<F, InstanceGenerator<'a, F>>` / `<F, WitnessGenerator<'a, F>>`, and pattern matches destructure the bare `B::Wire`.

Net −323/+129; behavior-preserving (the public-vector alignment from BINIUS-99 is untouched).

## Notes

- `Debug` and `Clone` are manual impls: a derived `Debug` would bound `B: Debug` but the field is the associated type `B::Wire`, so it's bounded as `where B::Wire: Debug`; `Clone` needs no `B: Clone` since `B::Wire: Copy`.
- The `wire * 0 = 0` short-circuit and the all-`Constant` `f_op` fast path in `combine` are preserved.

## Testing

`cargo test` for `binius-spartan-frontend`, `binius-spartan-verifier`, `binius-spartan-prover`, and the real ZK roundtrip in `binius-prover` (`prove_verify`, incl. `test_zk_prove_verify_sha256_preimage` + signature-of-knowledge) all pass; clippy, fmt, and `cargo doc --document-private-items -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)