### PR TITLE
Make portable M128 a wrapper struct over u128 (BINIUS-104)

### DIFF
--- a/crates/field/src/arch/aarch64/m128.rs
+++ b/crates/field/src/arch/aarch64/m128.rs
@@ -271,48 +271,6 @@ impl Divisible<u128> for M128 {
 	}
 }
 
-// The reverse of `Divisible<u128> for M128`: a `u128` holds exactly one `M128` (a width-1
-// reinterpret). Needed because `BinaryField128bGhash`'s underlier is `M128` while the portable
-// `PackedBinaryGhash1x128b` packs it in a `u128`.
-impl Divisible<M128> for u128 {
-	const LOG_N: usize = 0;
-
-	#[inline]
-	fn value_iter(value: Self) -> impl ExactSizeIterator<Item = M128> + Send + Clone {
-		std::iter::once(M128::from(value))
-	}
-
-	#[inline]
-	fn ref_iter(value: &Self) -> impl ExactSizeIterator<Item = M128> + Send + Clone + '_ {
-		std::iter::once(M128::from(*value))
-	}
-
-	#[inline]
-	fn slice_iter(slice: &[Self]) -> impl ExactSizeIterator<Item = M128> + Send + Clone + '_ {
-		slice.iter().map(|&v| M128::from(v))
-	}
-
-	#[inline]
-	unsafe fn get_unchecked(&self, _index: usize) -> M128 {
-		M128::from(*self)
-	}
-
-	#[inline]
-	unsafe fn set_unchecked(&mut self, _index: usize, val: M128) {
-		*self = u128::from(val);
-	}
-
-	#[inline]
-	fn broadcast(val: M128) -> Self {
-		u128::from(val)
-	}
-
-	#[inline]
-	fn from_iter(mut iter: impl Iterator<Item = M128>) -> Self {
-		iter.next().map(u128::from).unwrap_or(0)
-	}
-}
-
 impl Divisible<u64> for M128 {
 	const LOG_N: usize = 1;
 

--- a/crates/field/src/arch/aarch64/mod.rs
+++ b/crates/field/src/arch/aarch64/mod.rs
@@ -17,6 +17,6 @@ cfg_if! {
 		pub use super::portable::packed_aes_128;
 		pub use super::portable::packed_ghash_128;
 
-		pub use super::portable::packed_128::M128;
+		pub use super::portable::m128::M128;
 	}
 }

--- a/crates/field/src/arch/aarch64/packed_ghash_128.rs
+++ b/crates/field/src/arch/aarch64/packed_ghash_128.rs
@@ -17,8 +17,8 @@ use crate::{
 		shared::ghash::{self, ClMulUnderlier},
 	},
 	arithmetic_traits::{
-		InvertOrZero, TaggedInvertOrZero, TaggedMul, TaggedSquare, WideMul, impl_invert_with,
-		impl_mul_with, impl_square_with,
+		TaggedInvertOrZero, TaggedMul, TaggedSquare, WideMul, impl_invert_with, impl_mul_with,
+		impl_square_with,
 	},
 };
 
@@ -98,13 +98,13 @@ impl WideMul for PackedBinaryGhash1x128b {
 	}
 }
 
-// Implement TaggedInvertOrZero for GhashStrategy (uses portable fallback)
+// Implement TaggedInvertOrZero for GhashStrategy (software fallback — no CLMUL invert)
 impl TaggedInvertOrZero<GhashStrategy> for PackedBinaryGhash1x128b {
 	fn invert_or_zero(self) -> Self {
-		let portable = super::super::portable::packed_ghash_128::PackedBinaryGhash1x128b::from(
-			u128::from(self.to_underlier()),
-		);
+		use crate::{
+			Divisible, arch::portable::packed_ghash_128::ghash_invert_or_zero, packed::PackedField,
+		};
 
-		Self::from_underlier(InvertOrZero::invert_or_zero(portable).to_underlier().into())
+		Self::set_single(ghash_invert_or_zero(self.get(0)))
 	}
 }

--- a/crates/field/src/arch/mod.rs
+++ b/crates/field/src/arch/mod.rs
@@ -27,28 +27,11 @@ cfg_if! {
 
 		mod wasm32;
 		pub use wasm32::{packed_ghash_128, packed_ghash_256};
-		pub use portable::{packed_128::{self, M128}, packed_256::{self, M256}, packed_512, packed_aes_128, packed_aes_256, packed_aes_512, packed_ghash_512};
+		pub use portable::{m128::M128, packed_128, packed_256::{self, M256}, packed_512, packed_aes_128, packed_aes_256, packed_aes_512, packed_ghash_512};
 	} else {
 		mod portable;
-		pub use u128 as M128;
-		pub use portable::{packed_128::{self, M128}, packed_256::{self, M256}, packed_512, packed_aes_128, packed_aes_256, packed_aes_512, packed_ghash_128, packed_ghash_256, packed_ghash_512};
+		pub use portable::{m128::M128, packed_128, packed_256::{self, M256}, packed_512, packed_aes_128, packed_aes_256, packed_aes_512, packed_ghash_128, packed_ghash_256, packed_ghash_512};
 	}
-}
-
-/// Builds an [`M128`] from a `u128` in a `const` context.
-///
-/// `M128` is the architecture-chosen 128-bit underlier — a SIMD register on x86_64/aarch64, plain
-/// `u128` elsewhere. `From<u128>` is not `const`, so this helper is used where a const `M128`
-/// constant is needed (e.g. a field's multiplicative generator).
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-pub(crate) const fn m128_from_u128(value: u128) -> M128 {
-	M128::from_u128(value)
-}
-
-/// Builds an [`M128`] from a `u128` in a `const` context. See the SIMD variant for details.
-#[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
-pub(crate) const fn m128_from_u128(value: u128) -> M128 {
-	value
 }
 
 pub use arch_optimal::*;

--- a/crates/field/src/arch/portable/m128.rs
+++ b/crates/field/src/arch/portable/m128.rs
@@ -1,0 +1,233 @@
+// Copyright 2026 The Binius Developers
+
+use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Not, Shl, Shr};
+
+use binius_utils::{
+	DeserializeBytes, SerializationError, SerializeBytes,
+	bytes::{Buf, BufMut},
+	serialization::{assert_enough_data_for, assert_enough_space_for},
+};
+use bytemuck::{Pod, Zeroable};
+use derive_more::{From, Into};
+use rand::{
+	distr::{Distribution, StandardUniform},
+	prelude::*,
+};
+
+use crate::{
+	BinaryField,
+	arch::portable::packed::PackedPrimitiveType,
+	underlier::{
+		Divisible, NumCast, SmallU, UnderlierType, impl_divisible_bitmask, impl_divisible_memcast,
+		impl_divisible_self,
+	},
+};
+
+/// 128-bit underlier for the portable build — a transparent wrapper over `u128`.
+///
+/// On x86_64/aarch64 `M128` is a SIMD register and on wasm32 (with `simd128`) a `v128`; here it is
+/// a plain `u128` newtype. Wrapping rather than aliasing `u128` keeps `M128` a distinct type on
+/// every target, so the `M128 <-> u128` conversions never collide with `u128`'s own reflexive
+/// impls and the architecture-gated `BinaryField128bGhash` conversions need no cfg gate.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default, From, Into)]
+#[repr(transparent)]
+pub struct M128(u128);
+
+impl M128 {
+	#[inline(always)]
+	pub const fn from_u128(value: u128) -> Self {
+		Self(value)
+	}
+}
+
+impl From<u64> for M128 {
+	#[inline(always)]
+	fn from(value: u64) -> Self {
+		Self(value as u128)
+	}
+}
+impl From<u32> for M128 {
+	#[inline(always)]
+	fn from(value: u32) -> Self {
+		Self(value as u128)
+	}
+}
+impl From<u16> for M128 {
+	#[inline(always)]
+	fn from(value: u16) -> Self {
+		Self(value as u128)
+	}
+}
+impl From<u8> for M128 {
+	#[inline(always)]
+	fn from(value: u8) -> Self {
+		Self(value as u128)
+	}
+}
+
+impl<const N: usize> From<SmallU<N>> for M128 {
+	#[inline(always)]
+	fn from(value: SmallU<N>) -> Self {
+		Self(value.val() as u128)
+	}
+}
+
+impl<U: NumCast<u128>> NumCast<M128> for U {
+	#[inline(always)]
+	fn num_cast_from(val: M128) -> Self {
+		Self::num_cast_from(val.0)
+	}
+}
+
+impl SerializeBytes for M128 {
+	fn serialize(&self, mut write_buf: impl BufMut) -> Result<(), SerializationError> {
+		assert_enough_space_for(&write_buf, std::mem::size_of::<Self>())?;
+		write_buf.put_u128_le(self.0);
+		Ok(())
+	}
+}
+
+impl DeserializeBytes for M128 {
+	fn deserialize(mut read_buf: impl Buf) -> Result<Self, SerializationError>
+	where
+		Self: Sized,
+	{
+		assert_enough_data_for(&read_buf, std::mem::size_of::<Self>())?;
+		Ok(Self(read_buf.get_u128_le()))
+	}
+}
+
+unsafe impl Zeroable for M128 {}
+
+unsafe impl Pod for M128 {}
+
+impl_divisible_memcast!(M128, u128, u64, u32, u16, u8);
+impl_divisible_bitmask!(M128, 1, 2, 4);
+impl_divisible_self!(M128);
+
+impl BitAnd for M128 {
+	type Output = Self;
+
+	#[inline(always)]
+	fn bitand(self, rhs: Self) -> Self::Output {
+		Self(self.0 & rhs.0)
+	}
+}
+
+impl BitAndAssign for M128 {
+	#[inline(always)]
+	fn bitand_assign(&mut self, rhs: Self) {
+		self.0 &= rhs.0;
+	}
+}
+
+impl BitOr for M128 {
+	type Output = Self;
+
+	#[inline(always)]
+	fn bitor(self, rhs: Self) -> Self::Output {
+		Self(self.0 | rhs.0)
+	}
+}
+
+impl BitOrAssign for M128 {
+	#[inline(always)]
+	fn bitor_assign(&mut self, rhs: Self) {
+		self.0 |= rhs.0;
+	}
+}
+
+impl BitXor for M128 {
+	type Output = Self;
+
+	#[inline(always)]
+	fn bitxor(self, rhs: Self) -> Self::Output {
+		Self(self.0 ^ rhs.0)
+	}
+}
+
+impl BitXorAssign for M128 {
+	#[inline(always)]
+	fn bitxor_assign(&mut self, rhs: Self) {
+		self.0 ^= rhs.0;
+	}
+}
+
+impl Not for M128 {
+	type Output = Self;
+
+	#[inline(always)]
+	fn not(self) -> Self::Output {
+		Self(!self.0)
+	}
+}
+
+impl Shl<usize> for M128 {
+	type Output = Self;
+
+	#[inline(always)]
+	fn shl(self, rhs: usize) -> Self::Output {
+		Self(self.0 << rhs)
+	}
+}
+
+impl Shr<usize> for M128 {
+	type Output = Self;
+
+	#[inline(always)]
+	fn shr(self, rhs: usize) -> Self::Output {
+		Self(self.0 >> rhs)
+	}
+}
+
+impl Distribution<M128> for StandardUniform {
+	#[inline]
+	fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> M128 {
+		M128(rng.random())
+	}
+}
+
+impl std::fmt::Display for M128 {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		write!(f, "{:032X}", self.0)
+	}
+}
+
+impl std::fmt::Debug for M128 {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		write!(f, "M128({self})")
+	}
+}
+
+impl std::fmt::LowerHex for M128 {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		std::fmt::LowerHex::fmt(&self.0, f)
+	}
+}
+
+impl UnderlierType for M128 {
+	const LOG_BITS: usize = 7;
+	const ZERO: Self = Self(0);
+	const ONE: Self = Self(1);
+	const ONES: Self = Self(u128::MAX);
+
+	#[inline(always)]
+	fn interleave(self, other: Self, log_block_len: usize) -> (Self, Self) {
+		let (a, b) = self.0.interleave(other.0, log_block_len);
+		(Self(a), Self(b))
+	}
+}
+
+impl<Scalar: BinaryField> From<u128> for PackedPrimitiveType<M128, Scalar> {
+	#[inline]
+	fn from(value: u128) -> Self {
+		Self::from(M128::from(value))
+	}
+}
+
+impl<Scalar: BinaryField> From<PackedPrimitiveType<M128, Scalar>> for u128 {
+	#[inline]
+	fn from(value: PackedPrimitiveType<M128, Scalar>) -> Self {
+		value.to_underlier().into()
+	}
+}

--- a/crates/field/src/arch/portable/mod.rs
+++ b/crates/field/src/arch/portable/mod.rs
@@ -1,7 +1,10 @@
 // Copyright 2023-2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 pub(crate) mod packed;
 pub(crate) mod packed_macros;
+
+pub mod m128;
 
 pub mod packed_1;
 pub mod packed_128;

--- a/crates/field/src/arch/portable/packed_128.rs
+++ b/crates/field/src/arch/portable/packed_128.rs
@@ -1,11 +1,11 @@
 // Copyright 2024-2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
+use super::m128::M128;
 use crate::arch::{
 	BitwiseAndStrategy,
 	portable::packed_macros::{portable_macros::*, *},
 };
-
-pub type M128 = u128;
 
 define_packed_binary_fields!(
 	underlier: M128,

--- a/crates/field/src/arch/portable/packed_aes_128.rs
+++ b/crates/field/src/arch/portable/packed_aes_128.rs
@@ -1,5 +1,7 @@
 // Copyright 2024-2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
+use super::m128::M128;
 use crate::{
 	arch::{
 		PairwiseTableStrategy,
@@ -9,7 +11,7 @@ use crate::{
 };
 
 define_packed_binary_fields!(
-	underlier: u128,
+	underlier: M128,
 	packed_fields: [
 		packed_field {
 			name: PackedAESBinaryField16x8b,

--- a/crates/field/src/arch/portable/packed_ghash_128.rs
+++ b/crates/field/src/arch/portable/packed_ghash_128.rs
@@ -4,20 +4,11 @@
 //! Portable implementation of packed GHASH field operations.
 
 use super::{
+	m128::M128,
 	nibble_invert_128b::nibble_invert_128b,
-	packed_macros::{portable_macros::*, *},
-	univariate_mul_utils_128::{Underlier64bLanes, Underlier128bLanes, bmul64},
+	univariate_mul_utils_128::{Underlier64bLanes, Underlier128bLanes, bmul64, spread_bits_64},
 };
-use crate::{
-	Divisible,
-	arithmetic_traits::{
-		TaggedInvertOrZero, TaggedMul, TaggedSquare, impl_invert_with, impl_mul_with,
-		impl_square_with,
-	},
-	ghash::BinaryField128bGhash,
-	packed::PackedField,
-	underlier::WithUnderlier,
-};
+use crate::{ghash::BinaryField128bGhash, underlier::WithUnderlier};
 
 /// Strategy for GHASH field arithmetic operations.
 pub struct GhashStrategy;
@@ -98,46 +89,109 @@ fn reduce_64<U: Underlier128bLanes>(
 	U::join_u64s(v1, v0)
 }
 
-// Define PackedBinaryGhash1x128b using the macro
-define_packed_binary_field!(
-	PackedBinaryGhash1x128b,
-	BinaryField128bGhash,
-	u128,
-	(GhashStrategy),
-	(GhashStrategy),
-	(GhashStrategy),
-	(None)
-);
+// `M128` packs its GHASH 64-bit lanes the same way `u128` does — delegate through `u128`.
+impl Underlier128bLanes for M128 {
+	type U64 = u64;
 
-// Implement TaggedMul for GhashStrategy
-impl TaggedMul<GhashStrategy> for PackedBinaryGhash1x128b {
-	#[inline]
-	fn mul(self, rhs: Self) -> Self {
-		ghash_mul(self.0, rhs.0).into()
+	#[inline(always)]
+	fn split_hi_lo_64(self) -> (u64, u64) {
+		u128::from(self).split_hi_lo_64()
+	}
+
+	#[inline(always)]
+	fn join_u64s(high: u64, low: u64) -> Self {
+		Self::from(u128::join_u64s(high, low))
+	}
+
+	#[inline(always)]
+	fn broadcast_64(val: u64) -> Self {
+		Self::from(u128::broadcast_64(val))
+	}
+
+	#[inline(always)]
+	fn spread_bits_128(self) -> (Self, Self) {
+		let (hi, lo) = self.split_hi_lo_64();
+		(Self::from(spread_bits_64(hi)), Self::from(spread_bits_64(lo)))
 	}
 }
 
-// Implement TaggedSquare for GhashStrategy
-impl TaggedSquare<GhashStrategy> for PackedBinaryGhash1x128b {
-	#[inline]
-	fn square(self) -> Self {
-		ghash_square(self.0).into()
-	}
+/// Software GHASH inversion via the generic nibble algorithm, shared by every architecture: the
+/// SIMD `packed_ghash_128`s have no CLMUL fast path for inversion and call this. It takes the
+/// scalar directly, so it is independent of how the caller's packed field is laid out.
+pub(crate) fn ghash_invert_or_zero(value: BinaryField128bGhash) -> BinaryField128bGhash {
+	nibble_invert_128b(
+		value,
+		|f| f.to_underlier().into(), // GHASH uses direct representation (no Montgomery form)
+		&GHASH_NIBBLE_POW_2_N_TABLE,
+	)
 }
 
-// Implement WideMul (trivial: no CLMUL, just regular multiply)
-crate::arithmetic_traits::impl_trivial_wide_mul!(PackedBinaryGhash1x128b);
+// The portable GHASH backend, packed over `M128`. Compiled only on the arches that use the portable
+// GHASH — those without a SIMD `M128`, where `arch::M128` is the `u128`-newtype struct — mirroring
+// the SIMD-`M128` cfgs in `{x86_64,aarch64}/mod.rs`. On the SIMD arches `BinaryField128bGhash`'s
+// underlier is the SIMD `M128`, so a width-1 `PackedPrimitiveType<M128, _>` defined here (over the
+// distinct struct `M128`) could not `get`/`set_single`; those arches use their own
+// `packed_ghash_128` and reach the software kernels through `ghash_mul`/`ghash_square`/
+// `ghash_invert_or_zero` above.
+#[cfg(not(any(
+	all(target_arch = "x86_64", target_feature = "sse2"),
+	all(
+		target_arch = "aarch64",
+		target_feature = "neon",
+		target_feature = "aes"
+	)
+)))]
+pub use portable_backend::PackedBinaryGhash1x128b;
 
-// Implement TaggedInvertOrZero for GhashStrategy
-impl TaggedInvertOrZero<GhashStrategy> for PackedBinaryGhash1x128b {
-	fn invert_or_zero(self) -> Self {
-		// Use the generic nibble-based inversion algorithm
-		let result = nibble_invert_128b(
-			self.get(0),
-			|f| f.to_underlier().into(), // GHASH uses direct representation (no Montgomery form)
-			&GHASH_NIBBLE_POW_2_N_TABLE,
-		);
-		Self::set_single(result)
+#[cfg(not(any(
+	all(target_arch = "x86_64", target_feature = "sse2"),
+	all(
+		target_arch = "aarch64",
+		target_feature = "neon",
+		target_feature = "aes"
+	)
+)))]
+mod portable_backend {
+	use super::{
+		BinaryField128bGhash, GhashStrategy, M128, ghash_invert_or_zero, ghash_mul, ghash_square,
+	};
+	use crate::{
+		Divisible,
+		arch::portable::packed_macros::{portable_macros::*, *},
+		arithmetic_traits::{TaggedInvertOrZero, TaggedMul, TaggedSquare},
+		packed::PackedField,
+	};
+
+	define_packed_binary_field!(
+		PackedBinaryGhash1x128b,
+		BinaryField128bGhash,
+		M128,
+		(GhashStrategy),
+		(GhashStrategy),
+		(GhashStrategy),
+		(None)
+	);
+
+	impl TaggedMul<GhashStrategy> for PackedBinaryGhash1x128b {
+		#[inline]
+		fn mul(self, rhs: Self) -> Self {
+			ghash_mul(self.0, rhs.0).into()
+		}
+	}
+
+	impl TaggedSquare<GhashStrategy> for PackedBinaryGhash1x128b {
+		#[inline]
+		fn square(self) -> Self {
+			ghash_square(self.0).into()
+		}
+	}
+
+	crate::arithmetic_traits::impl_trivial_wide_mul!(PackedBinaryGhash1x128b);
+
+	impl TaggedInvertOrZero<GhashStrategy> for PackedBinaryGhash1x128b {
+		fn invert_or_zero(self) -> Self {
+			Self::set_single(ghash_invert_or_zero(self.get(0)))
+		}
 	}
 }
 

--- a/crates/field/src/arch/x86_64/m128.rs
+++ b/crates/field/src/arch/x86_64/m128.rs
@@ -737,48 +737,6 @@ impl Divisible<u128> for M128 {
 	}
 }
 
-// The reverse of `Divisible<u128> for M128`: a `u128` holds exactly one `M128` (a width-1
-// reinterpret). Needed because `BinaryField128bGhash`'s underlier is `M128` while the portable
-// `PackedBinaryGhash1x128b` packs it in a `u128`.
-impl Divisible<M128> for u128 {
-	const LOG_N: usize = 0;
-
-	#[inline]
-	fn value_iter(value: Self) -> impl ExactSizeIterator<Item = M128> + Send + Clone {
-		std::iter::once(M128::from(value))
-	}
-
-	#[inline]
-	fn ref_iter(value: &Self) -> impl ExactSizeIterator<Item = M128> + Send + Clone + '_ {
-		std::iter::once(M128::from(*value))
-	}
-
-	#[inline]
-	fn slice_iter(slice: &[Self]) -> impl ExactSizeIterator<Item = M128> + Send + Clone + '_ {
-		slice.iter().map(|&v| M128::from(v))
-	}
-
-	#[inline]
-	unsafe fn get_unchecked(&self, _index: usize) -> M128 {
-		M128::from(*self)
-	}
-
-	#[inline]
-	unsafe fn set_unchecked(&mut self, _index: usize, val: M128) {
-		*self = u128::from(val);
-	}
-
-	#[inline]
-	fn broadcast(val: M128) -> Self {
-		u128::from(val)
-	}
-
-	#[inline]
-	fn from_iter(mut iter: impl Iterator<Item = M128>) -> Self {
-		iter.next().map(u128::from).unwrap_or(0)
-	}
-}
-
 impl Divisible<u64> for M128 {
 	const LOG_N: usize = 1;
 

--- a/crates/field/src/arch/x86_64/packed_ghash_128.rs
+++ b/crates/field/src/arch/x86_64/packed_ghash_128.rs
@@ -14,7 +14,7 @@ use crate::{
 	BinaryField128bGhash,
 	arch::portable::packed_macros::{portable_macros::*, *},
 	arithmetic_traits::{
-		InvertOrZero, TaggedInvertOrZero, TaggedMul, TaggedSquare, impl_invert_with, impl_mul_with,
+		TaggedInvertOrZero, TaggedMul, TaggedSquare, impl_invert_with, impl_mul_with,
 		impl_square_with,
 	},
 };
@@ -65,12 +65,10 @@ cfg_if! {
 		impl TaggedMul<GhashStrategy> for PackedBinaryGhash1x128b {
 			#[inline]
 			fn mul(self, rhs: Self) -> Self {
-				use super::super::portable::packed_ghash_128::PackedBinaryGhash1x128b as PortablePackedBinaryGhash1x128b;
+				use super::super::portable::packed_ghash_128::ghash_mul;
 
-				let portable_lhs = PortablePackedBinaryGhash1x128b::from(u128::from(self.to_underlier()));
-				let portable_rhs = PortablePackedBinaryGhash1x128b::from(u128::from(rhs.to_underlier()));
-
-				Self::from_underlier(std::ops::Mul::mul(portable_lhs, portable_rhs).to_underlier().into())
+				let product = ghash_mul(u128::from(self.to_underlier()), u128::from(rhs.to_underlier()));
+				Self::from_underlier(M128::from(product))
 			}
 		}
 	}
@@ -91,11 +89,9 @@ cfg_if! {
 		impl TaggedSquare<GhashStrategy> for PackedBinaryGhash1x128b {
 			#[inline]
 			fn square(self) -> Self {
-				use super::super::portable::packed_ghash_128::PackedBinaryGhash1x128b as PortablePackedBinaryGhash1x128b;
+				use super::super::portable::packed_ghash_128::ghash_square;
 
-				let portable_val = PortablePackedBinaryGhash1x128b::from(u128::from(self.to_underlier()));
-
-				Self::from_underlier(crate::arithmetic_traits::Square::square(portable_val).to_underlier().into())
+				Self::from_underlier(M128::from(ghash_square(u128::from(self.to_underlier()))))
 			}
 		}
 	}
@@ -122,13 +118,13 @@ cfg_if! {
 	}
 }
 
-// Implement TaggedInvertOrZero for GhashStrategy (always uses portable fallback)
+// Implement TaggedInvertOrZero for GhashStrategy (software fallback — no CLMUL invert)
 impl TaggedInvertOrZero<GhashStrategy> for PackedBinaryGhash1x128b {
 	fn invert_or_zero(self) -> Self {
-		let portable = super::super::portable::packed_ghash_128::PackedBinaryGhash1x128b::from(
-			u128::from(self.to_underlier()),
-		);
+		use crate::{
+			Divisible, arch::portable::packed_ghash_128::ghash_invert_or_zero, packed::PackedField,
+		};
 
-		Self::from_underlier(InvertOrZero::invert_or_zero(portable).to_underlier().into())
+		Self::set_single(ghash_invert_or_zero(self.get(0)))
 	}
 }

--- a/crates/field/src/ghash.rs
+++ b/crates/field/src/ghash.rs
@@ -23,7 +23,7 @@ use super::{
 };
 use crate::{
 	AESTowerField8b, Divisible, Field, PackedField, WideMul,
-	arch::{M128, m128_from_u128, packed_ghash_128::PackedBinaryGhash1x128b},
+	arch::{M128, packed_ghash_128::PackedBinaryGhash1x128b},
 	arithmetic_traits::InvertOrZero,
 	binary_field_arithmetic::{
 		TowerFieldArithmetic, invert_or_zero_using_packed, multiple_using_packed,
@@ -33,20 +33,17 @@ use crate::{
 	underlier::{U1, WithUnderlier},
 };
 
-binary_field!(pub BinaryField128bGhash(M128), m128_from_u128(0x494ef99794d5244f9152df59d87a9186));
+binary_field!(pub BinaryField128bGhash(M128), M128::from_u128(0x494ef99794d5244f9152df59d87a9186));
 
 // Convenience `u128` conversions. `binary_field!` already provides `From<M128>`/`From<.. for
-// M128>`; on wasm/portable `M128 = u128`, so those *are* the `u128` conversions and these would
-// collide — hence the arch gate. On x86_64/aarch64 (where `M128` is a SIMD struct) they let callers
-// keep constructing/inspecting `BinaryField128bGhash` via `u128`.
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+// M128>`; these let callers keep constructing/inspecting `BinaryField128bGhash` via `u128`. `M128`
+// is a distinct type from `u128` on every target, so these never collide with the macro's impls.
 impl From<u128> for BinaryField128bGhash {
 	fn from(value: u128) -> Self {
 		Self(M128::from(value))
 	}
 }
 
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 impl From<BinaryField128bGhash> for u128 {
 	fn from(value: BinaryField128bGhash) -> Self {
 		value.0.into()
@@ -77,9 +74,9 @@ unsafe impl Pod for BinaryField128bGhash {}
 
 impl BinaryField128bGhash {
 	/// Constructs an element from its `u128` value. The underlier is `M128`, but `u128` is the
-	/// ergonomic constructor type, so this converts (a no-op where `M128 = u128`).
+	/// ergonomic constructor type, so this converts.
 	pub const fn new(value: u128) -> Self {
-		Self(m128_from_u128(value))
+		Self(M128::from_u128(value))
 	}
 
 	#[inline]


### PR DESCRIPTION
Closes [BINIUS-104](https://linear.app/jimpo/issue/BINIUS-104/make-portable-m128-a-wrapper-struct-over-u128). Follow-up to BINIUS-101 (#1540).

Replaces the portable `pub type M128 = u128` alias with a `#[repr(transparent)] struct M128(u128)`, so `M128` is a distinct type from `u128` on **every** target (mirroring the SIMD `M128` structs on x86_64/aarch64/wasm32). New `crates/field/src/arch/portable/m128.rs` carries the full underlier surface — mostly derives + `impl_divisible_memcast!`/`bitmask!`/`self!`, plus one-line delegations to `u128`.

`M128` is now the underlier for **all** portable packed fields (`packed_128`, `packed_aes_128`, `packed_ghash_128`); the scaled 256/512 fields remain `ScaledUnderlier<M128, N>`. There are no `u128`-backed packed fields.

With `M128` uniformly distinct from `u128`:
- the `#[cfg(any(x86_64, aarch64))]` gates on the `u128` ↔ `BinaryField128bGhash` conversions in `ghash.rs` are dropped (they no longer collide with the `binary_field!`-generated `From` impls);
- `m128_from_u128` collapses to a single non-cfg `const fn`;
- the now-dead reinterpreting `Divisible<M128> for u128` is removed from `x86_64/m128.rs` + `aarch64/m128.rs`;
- the latent `pub use u128 as M128` (a dormant E0252) in the portable-fallback arch branch is removed.

### GHASH software kernels as free functions
Portable `PackedBinaryGhash1x128b` is `M128`-backed. The catch: where a SIMD `M128` exists, `BinaryField128bGhash`'s underlier *is* that SIMD type, so a width-1 `PackedPrimitiveType` over the distinct portable struct `M128` can't `get`/`set_single` — and `mod portable` is dead-compiled there. So the GHASH software kernels are free functions — `ghash_mul`/`ghash_square` and a new `ghash_invert_or_zero(scalar)` — which the x86_64/aarch64 `packed_ghash_128`s call directly for their software fallbacks (no-CLMUL mul/square, and invert which has no CLMUL path), instead of constructing a portable packed type. The portable `M128` `PackedBinaryGhash1x128b` then lives in a small `portable_backend` submodule gated to the no-SIMD-`M128` arches, mirroring how `{x86_64,aarch64}/mod.rs` gate their own `packed_ghash_128`.

### Verification
- x86_64: `cargo test -p binius-field` (213 lib tests) + `cargo clippy -p binius-field --tests --benches -- -D warnings`: green.
- wasm32-unknown-unknown: `cargo build -p binius-field`: green.
- wasm32-wasip1: full `wasm-tests` set (`cargo test -p binius-math -p binius-field -p binius-prover -p binius-verifier` via wasmtime): green — exercises the live portable `M128` GHASH/scaled fields.
- aarch64: `cargo clippy`/`build` with `+neon,+aes` and `build` with `-aes` (the no-SIMD path): green.

The portable-fallback `else` arch branch has no CI target, so it is reasoned-correct rather than build-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)