### PR TITLE
BINIUS-110: remove TowerFieldArithmetic trait

### DIFF
--- a/crates/field/src/aes_field.rs
+++ b/crates/field/src/aes_field.rs
@@ -18,7 +18,6 @@ use super::{
 	PackedExtension, PackedSubfield,
 	arithmetic_traits::InvertOrZero,
 	binary_field::{BinaryField, BinaryField1b, binary_field, impl_field_extension},
-	binary_field_arithmetic::TowerFieldArithmetic,
 	mul_by_binary_field_1b,
 };
 use crate::{

--- a/crates/field/src/binary_field.rs
+++ b/crates/field/src/binary_field.rs
@@ -13,10 +13,7 @@ use binius_utils::{
 };
 use bytemuck::Zeroable;
 
-use super::{
-	UnderlierType, WithUnderlier, binary_field_arithmetic::TowerFieldArithmetic,
-	extension::ExtensionField,
-};
+use super::{UnderlierType, WithUnderlier, extension::ExtensionField};
 use crate::{Field, underlier::U1};
 
 /// A finite field with characteristic 2.
@@ -139,16 +136,6 @@ macro_rules! binary_field {
 			}
 		}
 
-		impl Mul<Self> for $name {
-			type Output = Self;
-
-			fn mul(self, rhs: Self) -> Self::Output {
-				$crate::tracing::trace_multiplication!($name);
-
-				TowerFieldArithmetic::multiply(self, rhs)
-			}
-		}
-
 		impl Mul<&Self> for $name {
 			type Output = Self;
 
@@ -217,12 +204,6 @@ macro_rules! binary_field {
 			}
 		}
 
-
-		impl crate::arithmetic_traits::Square for $name {
-			fn square(self) -> Self {
-				TowerFieldArithmetic::square(self)
-			}
-		}
 
 		impl Field for $name {
 			const ZERO: Self = $name(<$typ as $crate::underlier::UnderlierType>::ZERO);

--- a/crates/field/src/binary_field_arithmetic.rs
+++ b/crates/field/src/binary_field_arithmetic.rs
@@ -1,13 +1,12 @@
 // Copyright 2023-2025 Irreducible Inc.
 
-use super::{arithmetic_traits::InvertOrZero, binary_field::*};
+use std::ops::Mul;
+
+use super::{
+	arithmetic_traits::{InvertOrZero, Square},
+	binary_field::{BinaryField1b, TowerField},
+};
 use crate::PackedField;
-
-pub(crate) trait TowerFieldArithmetic: TowerField {
-	fn multiply(self, rhs: Self) -> Self;
-
-	fn square(self) -> Self;
-}
 
 macro_rules! impl_arithmetic_using_packed {
 	($name:ident) => {
@@ -22,16 +21,21 @@ macro_rules! impl_arithmetic_using_packed {
 			}
 		}
 
-		impl TowerFieldArithmetic for $name {
+		impl ::core::ops::Mul<$name> for $name {
+			type Output = $name;
+
 			#[inline]
-			fn multiply(self, rhs: Self) -> Self {
+			fn mul(self, rhs: $name) -> $name {
 				use $crate::packed_extension::PackedSubfield;
 
+				$crate::tracing::trace_multiplication!($name);
 				$crate::binary_field_arithmetic::multiple_using_packed::<PackedSubfield<Self, Self>>(
 					self, rhs,
 				)
 			}
+		}
 
+		impl $crate::arithmetic_traits::Square for $name {
 			#[inline]
 			fn square(self) -> Self {
 				use $crate::packed_extension::PackedSubfield;
@@ -46,7 +50,6 @@ macro_rules! impl_arithmetic_using_packed {
 
 pub(crate) use impl_arithmetic_using_packed;
 
-// TODO: try to get rid of `TowerFieldArithmetic` and use `impl_arithmetic_using_packed` here
 impl TowerField for BinaryField1b {
 	fn min_tower_level(self) -> usize {
 		0
@@ -60,12 +63,18 @@ impl InvertOrZero for BinaryField1b {
 	}
 }
 
-impl TowerFieldArithmetic for BinaryField1b {
+#[allow(clippy::suspicious_arithmetic_impl)]
+impl Mul<BinaryField1b> for BinaryField1b {
+	type Output = Self;
+
 	#[inline]
-	fn multiply(self, rhs: Self) -> Self {
+	fn mul(self, rhs: Self) -> Self::Output {
+		crate::tracing::trace_multiplication!(BinaryField1b);
 		Self(self.0 & rhs.0)
 	}
+}
 
+impl Square for BinaryField1b {
 	#[inline]
 	fn square(self) -> Self {
 		self

--- a/crates/field/src/ghash.rs
+++ b/crates/field/src/ghash.rs
@@ -24,10 +24,9 @@ use super::{
 use crate::{
 	AESTowerField8b, Divisible, Field, PackedField, WideMul,
 	arch::{M128, packed_ghash_128::PackedBinaryGhash1x128b},
-	arithmetic_traits::InvertOrZero,
+	arithmetic_traits::{InvertOrZero, Square},
 	binary_field_arithmetic::{
-		TowerFieldArithmetic, invert_or_zero_using_packed, multiple_using_packed,
-		square_using_packed,
+		invert_or_zero_using_packed, multiple_using_packed, square_using_packed,
 	},
 	mul_by_binary_field_1b,
 	underlier::{U1, WithUnderlier},
@@ -125,11 +124,18 @@ impl TowerField for BinaryField128bGhash {
 
 // Cannot use `impl_arithmetic_using_packed!` because `PackedSubfield<Self, Self>` resolves
 // via `Underlier = u128`, but on SIMD targets `PackedBinaryGhash1x128b` uses `M128`.
-impl TowerFieldArithmetic for BinaryField128bGhash {
-	fn multiply(self, rhs: Self) -> Self {
+impl Mul<BinaryField128bGhash> for BinaryField128bGhash {
+	type Output = Self;
+
+	#[inline]
+	fn mul(self, rhs: Self) -> Self {
+		crate::tracing::trace_multiplication!(BinaryField128bGhash);
 		multiple_using_packed::<PackedBinaryGhash1x128b>(self, rhs)
 	}
+}
 
+impl Square for BinaryField128bGhash {
+	#[inline]
 	fn square(self) -> Self {
 		square_using_packed::<PackedBinaryGhash1x128b>(self)
 	}

--- a/crates/field/src/ghash_sq.rs
+++ b/crates/field/src/ghash_sq.rs
@@ -35,7 +35,6 @@ use crate::{
 	BinaryField128bGhash, Divisible, Field, PackedBinaryGhash2x128b, PackedField,
 	arch::{M128, M256, packed_256::m256_from_u128s},
 	arithmetic_traits::{InvertOrZero, Square, impl_trivial_wide_mul},
-	binary_field_arithmetic::TowerFieldArithmetic,
 	mul_by_binary_field_1b,
 	underlier::U1,
 };
@@ -114,11 +113,18 @@ impl TowerField for GhashSq256b {
 	}
 }
 
-impl TowerFieldArithmetic for GhashSq256b {
-	fn multiply(self, rhs: Self) -> Self {
+impl Mul<GhashSq256b> for GhashSq256b {
+	type Output = Self;
+
+	#[inline]
+	fn mul(self, rhs: Self) -> Self {
+		crate::tracing::trace_multiplication!(GhashSq256b);
 		Self::from_coeffs(mul(self.to_coeffs(), rhs.to_coeffs()))
 	}
+}
 
+impl Square for GhashSq256b {
+	#[inline]
 	fn square(self) -> Self {
 		Self::from_coeffs(square(self.to_coeffs()))
 	}


### PR DESCRIPTION
Closes BINIUS-110.

## Summary

Removes the `pub(crate) TowerFieldArithmetic` trait, which was a thin indirection layer between the `Mul<Self>` / `Square` impls generated by the `binary_field!` macro and the actual arithmetic (packed multiply/square or custom hand-coded operations).

**Before:** `binary_field!` generated `Mul<Self>` and `Square` by calling `TowerFieldArithmetic::multiply` / `TowerFieldArithmetic::square`; the trait impls then dispatched to the real arithmetic.

**After:** The dispatch is gone:
- `impl_arithmetic_using_packed!` now directly provides `Mul<$name>` and `Square for $name` (with the `trace_multiplication!` call preserved).
- `BinaryField1b`, `BinaryField128bGhash`, and `GhashSq256b` provide `Mul<Self>` and `Square` directly in their respective modules (same logic, one fewer hop).
- The delegating `Mul<&Self>` / `MulAssign` impls remain in `binary_field!` as before; they continue to delegate to `Mul<Self>`, which now resolves directly to the implementation.

All tracing, arithmetic correctness, and cross-arch behavior are preserved — this is a pure structural simplification with no behavior change.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)