### PR TITLE
BINIUS-102: remove TowerField trait

### DIFF
--- a/crates/field/src/aes_field.rs
+++ b/crates/field/src/aes_field.rs
@@ -21,7 +21,7 @@ use super::{
 	mul_by_binary_field_1b,
 };
 use crate::{
-	ExtensionField, Field, TowerField, binary_field_arithmetic::impl_arithmetic_using_packed,
+	ExtensionField, Field, binary_field_arithmetic::impl_arithmetic_using_packed,
 	linear_transformation::Transformation, underlier::U1,
 };
 
@@ -49,15 +49,6 @@ impl_field_extension!(BinaryField1b(U1) < @3 => AESTowerField8b(u8));
 mul_by_binary_field_1b!(AESTowerField8b);
 
 impl_arithmetic_using_packed!(AESTowerField8b);
-
-impl TowerField for AESTowerField8b {
-	fn min_tower_level(self) -> usize {
-		match self {
-			Self::ZERO | Self::ONE => 0,
-			_ => 3,
-		}
-	}
-}
 
 /// A 3- step transformation :
 /// 1. Cast to base b-bit packed field

--- a/crates/field/src/binary_field.rs
+++ b/crates/field/src/binary_field.rs
@@ -23,55 +23,6 @@ pub trait BinaryField:
 	const N_BITS: usize = Self::ORDER_EXPONENT;
 }
 
-/// A binary field *isomorphic* to a binary tower field.
-///
-/// The canonical binary field tower construction is specified in [DP23], section 2.3. This is a
-/// family of binary fields with extension degree $2^{\iota}$ for any tower height $\iota$. This
-/// trait can be implemented on any binary field *isomorphic* to the canonical tower field.
-///
-/// [DP23]: https://eprint.iacr.org/2023/1784
-pub trait TowerField: BinaryField {
-	/// The level $\iota$ in the tower, where this field is isomorphic to $T_{\iota}$.
-	const TOWER_LEVEL: usize = Self::N_BITS.ilog2() as usize;
-
-	/// Returns the smallest valid `TOWER_LEVEL` in the tower that can fit the same value.
-	///
-	/// Since which `TOWER_LEVEL` values are valid depends on the tower,
-	/// `F::Canonical::from(elem).min_tower_level()` can return a different result
-	/// from `elem.min_tower_level()`.
-	fn min_tower_level(self) -> usize;
-
-	/// Returns the i'th basis element of this field as an extension over the tower subfield with
-	/// level $\iota$.
-	///
-	/// # Preconditions
-	///
-	/// * `iota` must be at most `TOWER_LEVEL`.
-	/// * `i` must be less than `2^(TOWER_LEVEL - iota)`.
-	fn basis(iota: usize, i: usize) -> Self {
-		assert!(iota <= Self::TOWER_LEVEL, "iota {iota} exceeds tower level {}", Self::TOWER_LEVEL);
-		let n_basis_elts = 1 << (Self::TOWER_LEVEL - iota);
-		assert!(i < n_basis_elts, "index {i} out of range for {n_basis_elts} basis elements");
-		<Self as ExtensionField<BinaryField1b>>::basis(i << iota)
-	}
-}
-
-/// Returns the i'th basis element of `FExt` as a field extension of `FSub`.
-///
-/// This is an alias function for [`ExtensionField::basis`].
-///
-/// ## Pre-conditions
-///
-/// * `i` must be in the range $[0, d)$, where $d$ is the field extension degree.
-#[inline]
-pub fn ext_basis<FExt, FSub>(i: usize) -> FExt
-where
-	FSub: Field,
-	FExt: ExtensionField<FSub>,
-{
-	<FExt as ExtensionField<FSub>>::basis(i)
-}
-
 /// Macro to generate an implementation of a BinaryField.
 macro_rules! binary_field {
 	($vis:vis $name:ident($typ:ty), $gen:expr) => {

--- a/crates/field/src/binary_field_arithmetic.rs
+++ b/crates/field/src/binary_field_arithmetic.rs
@@ -4,7 +4,7 @@ use std::ops::Mul;
 
 use super::{
 	arithmetic_traits::{InvertOrZero, Square},
-	binary_field::{BinaryField1b, TowerField},
+	binary_field::BinaryField1b,
 };
 use crate::PackedField;
 
@@ -49,12 +49,6 @@ macro_rules! impl_arithmetic_using_packed {
 }
 
 pub(crate) use impl_arithmetic_using_packed;
-
-impl TowerField for BinaryField1b {
-	fn min_tower_level(self) -> usize {
-		0
-	}
-}
 
 impl InvertOrZero for BinaryField1b {
 	#[inline]

--- a/crates/field/src/ghash.rs
+++ b/crates/field/src/ghash.rs
@@ -5,7 +5,6 @@
 //! This is the GHASH field used in AES-GCM.
 
 use std::{
-	any::TypeId,
 	fmt::{Debug, Display, Formatter},
 	iter::{Product, Sum},
 	ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
@@ -18,7 +17,7 @@ use binius_utils::{
 use bytemuck::{Pod, Zeroable};
 
 use super::{
-	binary_field::{BinaryField, BinaryField1b, TowerField, binary_field, impl_field_extension},
+	binary_field::{BinaryField, BinaryField1b, binary_field, impl_field_extension},
 	extension::ExtensionField,
 };
 use crate::{
@@ -108,17 +107,6 @@ impl BinaryField128bGhash {
 		let result = shifted ^ (((1u128 << 127) | 0x43) & mask);
 
 		Self::new(result)
-	}
-}
-
-impl TowerField for BinaryField128bGhash {
-	fn min_tower_level(self) -> usize {
-		// `M128` is not structurally matchable, so compare against the constants directly.
-		if self == Self::ZERO || self == Self::ONE {
-			0
-		} else {
-			7
-		}
 	}
 }
 
@@ -437,12 +425,6 @@ impl From<AESTowerField8b> for BinaryField128bGhash {
 
 		BinaryField128bGhash::new(LOOKUP_TABLE[value.0 as usize])
 	}
-}
-
-#[inline(always)]
-pub fn is_ghash_tower<F: TowerField>() -> bool {
-	TypeId::of::<F>() == TypeId::of::<BinaryField128bGhash>()
-		|| TypeId::of::<F>() == TypeId::of::<BinaryField1b>()
 }
 
 #[cfg(test)]

--- a/crates/field/src/ghash_sq.rs
+++ b/crates/field/src/ghash_sq.rs
@@ -28,7 +28,7 @@ use binius_utils::{
 use bytemuck::{Pod, Zeroable};
 
 use super::{
-	binary_field::{BinaryField, BinaryField1b, TowerField, binary_field, impl_field_extension},
+	binary_field::{BinaryField, BinaryField1b, binary_field, impl_field_extension},
 	extension::ExtensionField,
 };
 use crate::{
@@ -97,20 +97,6 @@ fn square(x: [BinaryField128bGhash; 2]) -> [BinaryField128bGhash; 2] {
 	let t2 = t0_t2.get(1);
 
 	[t0 + t2.mul_inv_x(), t2]
-}
-
-impl TowerField for GhashSq256b {
-	fn min_tower_level(self) -> usize {
-		let [a, b] = self.to_coeffs();
-		if self == Self::ZERO || self == Self::ONE {
-			0
-		} else if b == BinaryField128bGhash::ZERO {
-			// Elements with no `Y` component lie in the GHASH subfield (tower level 7).
-			a.min_tower_level()
-		} else {
-			8
-		}
-	}
 }
 
 impl Mul<GhashSq256b> for GhashSq256b {


### PR DESCRIPTION
Closes BINIUS-102. Stacked on #1544 (BINIUS-110: remove `TowerFieldArithmetic` trait).

## Summary

Removes the `TowerField` trait and all associated dead code. After BINIUS-110 deleted `TowerFieldArithmetic` (which had `TowerField` as a supertrait), `TowerField` is unused: its methods have no call sites and it appears as a bound nowhere in the workspace.

**Deleted:**
- `pub trait TowerField` (`TOWER_LEVEL`, `min_tower_level`, `basis`) from `binary_field.rs`
- `pub fn ext_basis` from `binary_field.rs` (never called)
- `impl TowerField` for all four concrete fields: `BinaryField1b`, `AESTowerField8b`, `BinaryField128bGhash`, `GhashSq256b`
- `pub fn is_ghash_tower<F: TowerField>()` from `ghash.rs` (never called; its `TowerField` bound was vacuous since it didn't use any trait methods)
- `use std::any::TypeId` from `ghash.rs` (only needed by the now-deleted `is_ghash_tower`)

No behavior change — all deleted code was unreachable from any call site in the workspace.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)