### PR TITLE
BINIUS-108: remove UnderlierType::get_subvalue and set_subvalue

### DIFF
--- a/crates/field/src/arch/portable/packed.rs
+++ b/crates/field/src/arch/portable/packed.rs
@@ -138,7 +138,11 @@ impl<U: UnderlierType + Divisible<Scalar::Underlier>, Scalar: BinaryField> Debug
 		let width = checked_int_div(U::BITS, Scalar::N_BITS);
 		let values_str = (0..width)
 			// Safety: `i` ranges over `0..width`, the number of scalars packed in `U`.
-			.map(|i| Scalar::from_underlier(unsafe { self.0.get_subvalue(i) }))
+			.map(|i| {
+				Scalar::from_underlier(unsafe {
+					Divisible::<Scalar::Underlier>::get_unchecked(&self.0, i)
+				})
+			})
 			.map(|value| format!("{value}"))
 			.collect::<Vec<_>>()
 			.join(",");

--- a/crates/field/src/arch/x86_64/packed_ghash_256.rs
+++ b/crates/field/src/arch/x86_64/packed_ghash_256.rs
@@ -19,7 +19,7 @@ use crate::{
 		TaggedInvertOrZero, TaggedMul, TaggedSquare, impl_invert_with, impl_mul_with,
 		impl_square_with,
 	},
-	underlier::UnderlierType,
+	underlier::Divisible,
 };
 // Only used by the CLMUL-accelerated `WideMul` impl below.
 #[cfg(target_feature = "vpclmulqdq")]
@@ -77,10 +77,10 @@ cfg_if! {
 				// Fallback: perform scalar multiplication on each 128-bit element
 				let mut result_underlier = self.to_underlier();
 				unsafe {
-					let self_0 = self.to_underlier().get_subvalue::<M128>(0);
-					let self_1 = self.to_underlier().get_subvalue::<M128>(1);
-					let rhs_0 = rhs.to_underlier().get_subvalue::<M128>(0);
-					let rhs_1 = rhs.to_underlier().get_subvalue::<M128>(1);
+					let self_0 = Divisible::<M128>::get_unchecked(&self.to_underlier(), 0);
+					let self_1 = Divisible::<M128>::get_unchecked(&self.to_underlier(), 1);
+					let rhs_0 = Divisible::<M128>::get_unchecked(&rhs.to_underlier(), 0);
+					let rhs_1 = Divisible::<M128>::get_unchecked(&rhs.to_underlier(), 1);
 
 					let result_0 = std::ops::Mul::mul(
 						PackedBinaryGhash1x128b::from(self_0),
@@ -91,8 +91,8 @@ cfg_if! {
 						PackedBinaryGhash1x128b::from(rhs_1),
 					);
 
-					result_underlier.set_subvalue(0, result_0.to_underlier());
-					result_underlier.set_subvalue(1, result_1.to_underlier());
+					Divisible::<M128>::set_unchecked(&mut result_underlier, 0, result_0.to_underlier());
+					Divisible::<M128>::set_unchecked(&mut result_underlier, 1, result_1.to_underlier());
 				}
 
 				Self::from_underlier(result_underlier)
@@ -116,14 +116,14 @@ cfg_if! {
 			fn square(self) -> Self {
 				let mut result_underlier = self.to_underlier();
 				unsafe {
-					let self_0 = self.to_underlier().get_subvalue::<M128>(0);
-					let self_1 = self.to_underlier().get_subvalue::<M128>(1);
+					let self_0 = Divisible::<M128>::get_unchecked(&self.to_underlier(), 0);
+					let self_1 = Divisible::<M128>::get_unchecked(&self.to_underlier(), 1);
 
 					let result_0 = crate::arithmetic_traits::Square::square(PackedBinaryGhash1x128b::from(self_0));
 					let result_1 = crate::arithmetic_traits::Square::square(PackedBinaryGhash1x128b::from(self_1));
 
-					result_underlier.set_subvalue(0, result_0.to_underlier());
-					result_underlier.set_subvalue(1, result_1.to_underlier());
+					Divisible::<M128>::set_unchecked(&mut result_underlier, 0, result_0.to_underlier());
+					Divisible::<M128>::set_unchecked(&mut result_underlier, 1, result_1.to_underlier());
 				}
 
 				Self::from_underlier(result_underlier)
@@ -158,8 +158,8 @@ impl TaggedInvertOrZero<Ghash256Strategy> for PackedBinaryGhash2x128b {
 	fn invert_or_zero(self) -> Self {
 		let mut result_underlier = self.to_underlier();
 		unsafe {
-			let self_0 = self.to_underlier().get_subvalue::<M128>(0);
-			let self_1 = self.to_underlier().get_subvalue::<M128>(1);
+			let self_0 = Divisible::<M128>::get_unchecked(&self.to_underlier(), 0);
+			let self_1 = Divisible::<M128>::get_unchecked(&self.to_underlier(), 1);
 
 			// Use the x86_64 scalar invert for each element
 			let result_0 = crate::arithmetic_traits::InvertOrZero::invert_or_zero(
@@ -169,8 +169,8 @@ impl TaggedInvertOrZero<Ghash256Strategy> for PackedBinaryGhash2x128b {
 				PackedBinaryGhash1x128b::from(self_1),
 			);
 
-			result_underlier.set_subvalue(0, result_0.to_underlier());
-			result_underlier.set_subvalue(1, result_1.to_underlier());
+			Divisible::<M128>::set_unchecked(&mut result_underlier, 0, result_0.to_underlier());
+			Divisible::<M128>::set_unchecked(&mut result_underlier, 1, result_1.to_underlier());
 		}
 
 		Self::from_underlier(result_underlier)

--- a/crates/field/src/arch/x86_64/packed_ghash_512.rs
+++ b/crates/field/src/arch/x86_64/packed_ghash_512.rs
@@ -75,14 +75,14 @@ cfg_if! {
 				// Fallback: perform scalar multiplication on each 128-bit element
 				let mut result_underlier = self.to_underlier();
 				unsafe {
-					let self_0 = self.to_underlier().get_subvalue::<u128>(0);
-					let self_1 = self.to_underlier().get_subvalue::<u128>(1);
-					let self_2 = self.to_underlier().get_subvalue::<u128>(2);
-					let self_3 = self.to_underlier().get_subvalue::<u128>(3);
-					let rhs_0 = rhs.to_underlier().get_subvalue::<u128>(0);
-					let rhs_1 = rhs.to_underlier().get_subvalue::<u128>(1);
-					let rhs_2 = rhs.to_underlier().get_subvalue::<u128>(2);
-					let rhs_3 = rhs.to_underlier().get_subvalue::<u128>(3);
+					let self_0 = Divisible::<u128>::get_unchecked(&self.to_underlier(), 0);
+					let self_1 = Divisible::<u128>::get_unchecked(&self.to_underlier(), 1);
+					let self_2 = Divisible::<u128>::get_unchecked(&self.to_underlier(), 2);
+					let self_3 = Divisible::<u128>::get_unchecked(&self.to_underlier(), 3);
+					let rhs_0 = Divisible::<u128>::get_unchecked(&rhs.to_underlier(), 0);
+					let rhs_1 = Divisible::<u128>::get_unchecked(&rhs.to_underlier(), 1);
+					let rhs_2 = Divisible::<u128>::get_unchecked(&rhs.to_underlier(), 2);
+					let rhs_3 = Divisible::<u128>::get_unchecked(&rhs.to_underlier(), 3);
 
 					// Use the portable scalar multiplication for each element
 					use super::super::portable::packed_ghash_128::PackedBinaryGhash1x128b as PortablePackedBinaryGhash1x128b;
@@ -103,10 +103,10 @@ cfg_if! {
 						PortablePackedBinaryGhash1x128b::from(rhs_3),
 					);
 
-					result_underlier.set_subvalue(0, result_0.to_underlier());
-					result_underlier.set_subvalue(1, result_1.to_underlier());
-					result_underlier.set_subvalue(2, result_2.to_underlier());
-					result_underlier.set_subvalue(3, result_3.to_underlier());
+					Divisible::<u128>::set_unchecked(&mut result_underlier, 0, result_0.to_underlier());
+					Divisible::<u128>::set_unchecked(&mut result_underlier, 1, result_1.to_underlier());
+					Divisible::<u128>::set_unchecked(&mut result_underlier, 2, result_2.to_underlier());
+					Divisible::<u128>::set_unchecked(&mut result_underlier, 3, result_3.to_underlier());
 				}
 
 				Self::from_underlier(result_underlier)

--- a/crates/field/src/binary_field.rs
+++ b/crates/field/src/binary_field.rs
@@ -436,8 +436,13 @@ macro_rules! impl_field_extension {
 
 			#[inline]
 			unsafe fn get_base_unchecked(&self, i: usize) -> $subfield_name {
-				use $crate::underlier::{UnderlierType, WithUnderlier};
-				unsafe { $subfield_name::from_underlier(self.to_underlier().get_subvalue(i)) }
+				use $crate::underlier::{Divisible, WithUnderlier};
+				// Safety: the caller guarantees `i < Self::N` (over subfield elements).
+				unsafe {
+					$subfield_name::from_underlier(Divisible::<
+						<$subfield_name as WithUnderlier>::Underlier,
+					>::get_unchecked(&self.to_underlier(), i))
+				}
 			}
 
 			#[inline]

--- a/crates/field/src/underlier/underlier_type.rs
+++ b/crates/field/src/underlier/underlier_type.rs
@@ -5,7 +5,6 @@ use std::{
 	ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Not, Shl, Shr},
 };
 
-use binius_utils::checked_arithmetics::checked_int_div;
 use bytemuck::{NoUninit, TransparentWrapper, Zeroable};
 
 use super::{U1, underlier_with_bit_ops::spread_fallback};
@@ -85,42 +84,6 @@ pub trait UnderlierType:
 		Self: Divisible<T>,
 	{
 		Divisible::<T>::broadcast(value)
-	}
-
-	/// Gets the subvalue from the given position.
-	/// Function panics in case when index is out of range.
-	///
-	/// # Safety
-	/// `i` must be less than `Self::BITS/T::BITS`.
-	#[inline]
-	unsafe fn get_subvalue<T>(&self, i: usize) -> T
-	where
-		T: UnderlierType,
-		Self: Divisible<T>,
-	{
-		debug_assert!(
-			i < checked_int_div(Self::BITS, T::BITS),
-			"i: {} Self::BITS: {}, T::BITS: {}",
-			i,
-			Self::BITS,
-			T::BITS
-		);
-		Divisible::<T>::get(self, i)
-	}
-
-	/// Sets the subvalue in the given position.
-	/// Function panics in case when index is out of range.
-	///
-	/// # Safety
-	/// `i` must be less than `Self::BITS/T::BITS`.
-	#[inline]
-	unsafe fn set_subvalue<T>(&mut self, i: usize, val: T)
-	where
-		T: UnderlierType,
-		Self: Divisible<T>,
-	{
-		debug_assert!(i < checked_int_div(Self::BITS, T::BITS));
-		Divisible::<T>::set(self, i, val);
 	}
 
 	/// Spread takes a block of sub_elements of `T` type within the current value and

--- a/crates/field/src/underlier/underlier_with_bit_ops.rs
+++ b/crates/field/src/underlier/underlier_with_bit_ops.rs
@@ -35,8 +35,15 @@ where
 	let block_offset = block_idx << log_block_len;
 	let log_repeat = U::LOG_BITS - T::LOG_BITS - log_block_len;
 	for i in 0..1 << log_block_len {
+		// Safety: `block_offset + i < block_offset + block_len <= U::BITS / T::BITS`
+		// (precondition), and `i << log_repeat < U::BITS / T::BITS` (by the loop bound and
+		// log_repeat definition).
 		unsafe {
-			result.set_subvalue(i << log_repeat, value.get_subvalue::<T>(block_offset + i));
+			Divisible::<T>::set_unchecked(
+				&mut result,
+				i << log_repeat,
+				Divisible::<T>::get_unchecked(&value, block_offset + i),
+			);
 		}
 	}
 
@@ -111,7 +118,10 @@ where
 	U: UnderlierType + From<T> + Divisible<T>,
 	T: UnderlierType + NumCast<U>,
 {
-	std::array::from_fn(|i| unsafe { value.get_subvalue::<T>(block_idx * BLOCK_LEN + i) })
+	// Safety: `block_idx * BLOCK_LEN + i < U::BITS / T::BITS` by the function preconditions.
+	std::array::from_fn(|i| unsafe {
+		Divisible::<T>::get_unchecked(&value, block_idx * BLOCK_LEN + i)
+	})
 }
 
 /// A helper functions for implementing `UnderlierType::spread` for SIMD types.
@@ -186,63 +196,53 @@ mod tests {
 	}
 
 	#[test]
-	fn test_get_subvalue() {
+	fn test_divisible_get_u32() {
 		let value = 0xab12cd34u32;
 
-		unsafe {
-			assert_eq!(value.get_subvalue::<U1>(0), U1::new(0));
-			assert_eq!(value.get_subvalue::<U1>(1), U1::new(0));
-			assert_eq!(value.get_subvalue::<U1>(2), U1::new(1));
-			assert_eq!(value.get_subvalue::<U1>(31), U1::new(1));
+		assert_eq!(Divisible::<U1>::get(&value, 0), U1::new(0));
+		assert_eq!(Divisible::<U1>::get(&value, 1), U1::new(0));
+		assert_eq!(Divisible::<U1>::get(&value, 2), U1::new(1));
+		assert_eq!(Divisible::<U1>::get(&value, 31), U1::new(1));
 
-			assert_eq!(value.get_subvalue::<U2>(0), U2::new(0));
-			assert_eq!(value.get_subvalue::<U2>(1), U2::new(1));
-			assert_eq!(value.get_subvalue::<U2>(2), U2::new(3));
-			assert_eq!(value.get_subvalue::<U2>(15), U2::new(2));
+		assert_eq!(Divisible::<U2>::get(&value, 0), U2::new(0));
+		assert_eq!(Divisible::<U2>::get(&value, 1), U2::new(1));
+		assert_eq!(Divisible::<U2>::get(&value, 2), U2::new(3));
+		assert_eq!(Divisible::<U2>::get(&value, 15), U2::new(2));
 
-			assert_eq!(value.get_subvalue::<U4>(0), U4::new(4));
-			assert_eq!(value.get_subvalue::<U4>(1), U4::new(3));
-			assert_eq!(value.get_subvalue::<U4>(2), U4::new(13));
-			assert_eq!(value.get_subvalue::<U4>(7), U4::new(10));
+		assert_eq!(Divisible::<U4>::get(&value, 0), U4::new(4));
+		assert_eq!(Divisible::<U4>::get(&value, 1), U4::new(3));
+		assert_eq!(Divisible::<U4>::get(&value, 2), U4::new(13));
+		assert_eq!(Divisible::<U4>::get(&value, 7), U4::new(10));
 
-			assert_eq!(value.get_subvalue::<u8>(0), 0x34u8);
-			assert_eq!(value.get_subvalue::<u8>(1), 0xcdu8);
-			assert_eq!(value.get_subvalue::<u8>(2), 0x12u8);
-			assert_eq!(value.get_subvalue::<u8>(3), 0xabu8);
-		}
+		assert_eq!(Divisible::<u8>::get(&value, 0), 0x34u8);
+		assert_eq!(Divisible::<u8>::get(&value, 1), 0xcdu8);
+		assert_eq!(Divisible::<u8>::get(&value, 2), 0x12u8);
+		assert_eq!(Divisible::<u8>::get(&value, 3), 0xabu8);
 	}
 
 	proptest! {
 		#[test]
-		fn test_set_subvalue_1b(mut init_val in any::<u32>(), i in 0usize..31, val in bits::u8::masked(1)) {
-			unsafe {
-				init_val.set_subvalue(i, U1::new(val));
-				assert_eq!(init_val.get_subvalue::<U1>(i), U1::new(val));
-			}
+		fn test_divisible_set_1b(mut init_val in any::<u32>(), i in 0usize..31, val in bits::u8::masked(1)) {
+			Divisible::<U1>::set(&mut init_val, i, U1::new(val));
+			assert_eq!(Divisible::<U1>::get(&init_val, i), U1::new(val));
 		}
 
 		#[test]
-		fn test_set_subvalue_2b(mut init_val in any::<u32>(), i in 0usize..15, val in bits::u8::masked(3)) {
-			unsafe {
-				init_val.set_subvalue(i, U2::new(val));
-				assert_eq!(init_val.get_subvalue::<U2>(i), U2::new(val));
-			}
+		fn test_divisible_set_2b(mut init_val in any::<u32>(), i in 0usize..15, val in bits::u8::masked(3)) {
+			Divisible::<U2>::set(&mut init_val, i, U2::new(val));
+			assert_eq!(Divisible::<U2>::get(&init_val, i), U2::new(val));
 		}
 
 		#[test]
-		fn test_set_subvalue_4b(mut init_val in any::<u32>(), i in 0usize..7, val in bits::u8::masked(7)) {
-			unsafe {
-				init_val.set_subvalue(i, U4::new(val));
-				assert_eq!(init_val.get_subvalue::<U4>(i), U4::new(val));
-			}
+		fn test_divisible_set_4b(mut init_val in any::<u32>(), i in 0usize..7, val in bits::u8::masked(7)) {
+			Divisible::<U4>::set(&mut init_val, i, U4::new(val));
+			assert_eq!(Divisible::<U4>::get(&init_val, i), U4::new(val));
 		}
 
 		#[test]
-		fn test_set_subvalue_8b(mut init_val in any::<u32>(), i in 0usize..3, val in bits::u8::masked(15)) {
-			unsafe {
-				init_val.set_subvalue(i, val);
-				assert_eq!(init_val.get_subvalue::<u8>(i), val);
-			}
+		fn test_divisible_set_8b(mut init_val in any::<u32>(), i in 0usize..3, val in bits::u8::masked(15)) {
+			Divisible::<u8>::set(&mut init_val, i, val);
+			assert_eq!(Divisible::<u8>::get(&init_val, i), val);
 		}
 	}
 }


### PR DESCRIPTION
Closes BINIUS-108.

## Summary

Removes `UnderlierType::get_subvalue` and `UnderlierType::set_subvalue`, which were thin wrappers around `Divisible::<T>::get` / `Divisible::<T>::set` with an extra `debug_assert!` on the index. Call sites are updated to call `Divisible` directly.

**Replacement strategy per call site:**

- **`underlier_with_bit_ops.rs` (production)**: Both call sites are inside `unsafe` functions where the index bounds have been established by the function's own preconditions — replaced with `Divisible::<T>::get_unchecked` / `set_unchecked` and documented Safety comments.
- **`binary_field.rs` (`get_base_unchecked` macro)**: Already an `unsafe fn` whose contract guarantees `i < Self::N` — replaced with `Divisible::get_unchecked`.
- **`arch/portable/packed.rs` (Display impl)**: Index ranges over `0..width` (the count of packed scalars) — replaced with `Divisible::get_unchecked`.
- **`arch/x86_64/packed_ghash_256.rs` / `packed_ghash_512.rs`**: Literal indices (0, 1, 2, 3) all within bounds — replaced with `Divisible::get_unchecked` / `set_unchecked`.

**Tests**: Renamed `test_get_subvalue` → `test_divisible_get_u32` and `test_set_subvalue_*` → `test_divisible_set_*`. Updated to use `Divisible::get` / `Divisible::set` (safe versions) since the test indices are always in range. The unnecessary `unsafe` blocks around the test calls are also removed.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)