### PR TITLE
BINIUS-107: add InvertOrZero::invert

### DIFF
--- a/crates/field/benches/binary_field.rs
+++ b/crates/field/benches/binary_field.rs
@@ -80,7 +80,7 @@ impl FieldOperation for InvertOp {
 	type Result<F> = Option<F>;
 
 	fn call<F: Field>(lhs: F, _: F) -> Option<F> {
-		lhs.invert()
+		lhs.try_invert()
 	}
 }
 

--- a/crates/field/src/aes_field.rs
+++ b/crates/field/src/aes_field.rs
@@ -113,7 +113,7 @@ mod tests {
 	}
 
 	fn check_invert(f: impl Field) {
-		let inversed = f.invert();
+		let inversed = f.try_invert();
 		if f.is_zero() {
 			assert!(inversed.is_none());
 		} else {

--- a/crates/field/src/arithmetic_traits.rs
+++ b/crates/field/src/arithmetic_traits.rs
@@ -63,6 +63,18 @@ pub(crate) use impl_trivial_wide_mul;
 pub trait InvertOrZero {
 	/// Returns the inverted value or zero in case when `self` is zero
 	fn invert_or_zero(self) -> Self;
+
+	/// Returns the multiplicative inverse.
+	///
+	/// ## Safety
+	/// Requires that `self` is non-zero. Behavior is undefined otherwise.
+	#[inline]
+	unsafe fn invert(self) -> Self
+	where
+		Self: Sized,
+	{
+		self.invert_or_zero()
+	}
 }
 
 /// Multiplication that is parameterized with some some strategy.

--- a/crates/field/src/binary_field.rs
+++ b/crates/field/src/binary_field.rs
@@ -638,23 +638,23 @@ pub(crate) mod tests {
 
 	#[test]
 	fn test_inverse_on_zero() {
-		assert!(BinaryField1b::ZERO.invert().is_none());
-		assert!(AESTowerField8b::ZERO.invert().is_none());
-		assert!(BinaryField128bGhash::ZERO.invert().is_none());
+		assert!(BinaryField1b::ZERO.try_invert().is_none());
+		assert!(AESTowerField8b::ZERO.try_invert().is_none());
+		assert!(BinaryField128bGhash::ZERO.try_invert().is_none());
 	}
 
 	proptest! {
 		#[test]
 		fn test_inverse_8b(val in 1u8..) {
 			let x = AESTowerField8b::new(val);
-			let x_inverse = x.invert().unwrap();
+			let x_inverse = x.try_invert().unwrap();
 			assert_eq!(x * x_inverse, AESTowerField8b::ONE);
 		}
 
 		#[test]
 		fn test_inverse_128b(val in 1u128..) {
 			let x = BinaryField128bGhash::from(val);
-			let x_inverse = x.invert().unwrap();
+			let x_inverse = x.try_invert().unwrap();
 			assert_eq!(x * x_inverse, BinaryField128bGhash::ONE);
 		}
 	}

--- a/crates/field/src/field.rs
+++ b/crates/field/src/field.rs
@@ -93,7 +93,7 @@ pub trait Field:
 
 	/// Computes the multiplicative inverse of this element,
 	/// failing if the element is zero.
-	fn invert(&self) -> Option<Self> {
+	fn try_invert(&self) -> Option<Self> {
 		let inv = self.invert_or_zero();
 		(!inv.is_zero()).then_some(inv)
 	}

--- a/crates/field/src/ghash.rs
+++ b/crates/field/src/ghash.rs
@@ -552,7 +552,7 @@ mod tests {
 			let mul_inv_x_result = field_val.mul_inv_x();
 			let regular_mul_result = field_val
 				* BinaryField128bGhash::new(2u128)
-					.invert()
+					.try_invert()
 					.expect("2 is invertible");
 
 			assert_eq!(

--- a/crates/field/src/ghash_sq.rs
+++ b/crates/field/src/ghash_sq.rs
@@ -328,7 +328,7 @@ mod tests {
 
 		#[test]
 		fn test_invert(a in arb_elem()) {
-			match a.invert() {
+			match a.try_invert() {
 				Some(inv) => prop_assert_eq!(a * inv, GhashSq256b::ONE),
 				None => prop_assert_eq!(a, GhashSq256b::ZERO),
 			}

--- a/crates/math/src/batch_invert.rs
+++ b/crates/math/src/batch_invert.rs
@@ -163,7 +163,7 @@ fn batch_invert_nonzero_with_scratchpad<P: PackedField>(
 			// Direct scalar inversion
 			let scalar = packed.get(0);
 			let inv = scalar
-				.invert()
+				.try_invert()
 				.expect("precondition: elements contains no zeros");
 			packed.set(0, inv);
 		} else {

--- a/crates/math/src/matrix.rs
+++ b/crates/math/src/matrix.rs
@@ -128,7 +128,7 @@ impl<F: Field> Matrix<F> {
 
 			// Normalize the pivot
 			let scalar = tmp[(i, i)]
-				.invert()
+				.try_invert()
 				.expect("pivot is checked to be non-zero above");
 			tmp.scale_row(i, scalar);
 			out.scale_row(i, scalar);

--- a/crates/math/src/ntt/domain_context.rs
+++ b/crates/math/src/ntt/domain_context.rs
@@ -36,7 +36,7 @@ fn generate_evals_from_subspace<F: BinaryField>(subspace: &BinarySubspace<F>) ->
 
 	// normalize so that evaluations of $W_i$ are replaced by evaluations of $hat{W}_i$
 	for evals_i in evals.iter_mut() {
-		let w_i_b_i_inverse = evals_i[0].invert().unwrap();
+		let w_i_b_i_inverse = evals_i[0].try_invert().unwrap();
 		for eval_i_j in evals_i.iter_mut() {
 			*eval_i_j *= w_i_b_i_inverse;
 		}

--- a/crates/math/src/ntt/tests_evaluation.rs
+++ b/crates/math/src/ntt/tests_evaluation.rs
@@ -226,7 +226,7 @@ fn novel_basis<DC: DomainContext>(domain_context: &DC) -> Vec<Polynomial<DC::Fie
 	for i in 0..log_d {
 		let beta_i = domain.basis()[i];
 		let eval = w_hat[i].evaluate(beta_i);
-		w_hat[i] *= eval.invert().unwrap();
+		w_hat[i] *= eval.try_invert().unwrap();
 	}
 
 	// construct novel polynomial basis

--- a/crates/math/src/tensor_algebra.rs
+++ b/crates/math/src/tensor_algebra.rs
@@ -254,7 +254,7 @@ mod tests {
 		assert_eq!(elem.try_extract_vertical(), None);
 
 		// Scale back by the inverse to get back to the vertical subring.
-		let hztl_inv = hztl.invert().unwrap();
+		let hztl_inv = hztl.try_invert().unwrap();
 		let elem = elem.scale_horizontal(hztl_inv);
 		assert_eq!(elem.try_extract_vertical(), Some(vert));
 

--- a/crates/math/src/univariate.rs
+++ b/crates/math/src/univariate.rs
@@ -237,7 +237,7 @@ fn compute_barycentric_weights<F: Field>(points: &[F]) -> Vec<F> {
 				.map(|j| points[i] - points[j])
 				.product::<F>();
 			product
-				.invert()
+				.try_invert()
 				.expect("precondition: all points are distinct; invert only fails on 0")
 		})
 		.collect()

--- a/crates/verifier/src/protocols/intmul/common.rs
+++ b/crates/verifier/src/protocols/intmul/common.rs
@@ -172,7 +172,7 @@ where
 	// Compute the normalization factors (conjugate - 1)^{-1} in F, then convert to E.
 	let inv_factors: Vec<E> = iterate(F::MULTIPLICATIVE_GENERATOR, |g| g.square())
 		.take(2 << k)
-		.map(|conjugate| E::from((conjugate - F::ONE).invert().expect("non-zero")))
+		.map(|conjugate| E::from((conjugate - F::ONE).try_invert().expect("non-zero")))
 		.collect();
 
 	let (lo_inv_factors, hi_inv_factors) = inv_factors.split_at(1 << k);


### PR DESCRIPTION
Closes BINIUS-107.

## Summary

Adds an `unsafe fn invert` to the `InvertOrZero` trait:

```rust
/// Returns the multiplicative inverse.
///
/// ## Safety
/// Requires that `self` is non-zero. Behavior is undefined otherwise.
unsafe fn invert(self) -> Self { self.invert_or_zero() }
```

The default body delegates to `invert_or_zero` (sound for non-zero inputs); specialized impls can later override it to exploit the non-zero precondition. Since `InvertOrZero` is a parent trait of `Field`/`PackedField`, every field and packed field gets it for free.

`InvertOrZero` gains a `Sized` bound — required for the default method body to move `self` and return `Self`. Every implementor is already `Sized`.

## Naming: `Field::invert` → `Field::try_invert`

Adding `InvertOrZero::invert` collides with the existing `Field::invert(&self) -> Option<Self>` (every field type would have two `invert` methods, making call sites ambiguous). This PR renames the checked, `Option`-returning method to `Field::try_invert` and updates all call sites — a pure mechanical rename, no behavior change. The actual per-site migration to `invert_or_zero` / `unsafe invert` and removal of `try_invert` happens in the follow-up #BINIUS-112.

This yields a clear trifecta:
- `invert_or_zero(self) -> Self` — returns zero on zero input
- `unsafe invert(self) -> Self` — UB on zero input (caller guarantees non-zero)
- `try_invert(&self) -> Option<Self>` — checked, `None` on zero

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)