### PR TITLE
BINIUS-112: remove Field::invert

### DIFF
--- a/crates/field/benches/binary_field.rs
+++ b/crates/field/benches/binary_field.rs
@@ -77,10 +77,10 @@ struct InvertOp;
 
 impl FieldOperation for InvertOp {
 	const NAME: &'static str = "scalar/invert";
-	type Result<F> = Option<F>;
+	type Result<F> = F;
 
-	fn call<F: Field>(lhs: F, _: F) -> Option<F> {
-		lhs.try_invert()
+	fn call<F: Field>(lhs: F, _: F) -> F {
+		lhs.invert_or_zero()
 	}
 }
 

--- a/crates/field/src/aes_field.rs
+++ b/crates/field/src/aes_field.rs
@@ -113,11 +113,11 @@ mod tests {
 	}
 
 	fn check_invert(f: impl Field) {
-		let inversed = f.try_invert();
+		let inversed = f.invert_or_zero();
 		if f.is_zero() {
-			assert!(inversed.is_none());
+			assert!(inversed.is_zero());
 		} else {
-			assert_eq!(inversed.unwrap() * f, Field::ONE);
+			assert_eq!(inversed * f, Field::ONE);
 		}
 	}
 

--- a/crates/field/src/binary_field.rs
+++ b/crates/field/src/binary_field.rs
@@ -525,7 +525,10 @@ pub(crate) mod tests {
 	use proptest::prelude::*;
 
 	use super::BinaryField1b as BF1;
-	use crate::{AESTowerField8b, BinaryField, BinaryField1b, BinaryField128bGhash, Field};
+	use crate::{
+		AESTowerField8b, BinaryField, BinaryField1b, BinaryField128bGhash, Field,
+		arithmetic_traits::InvertOrZero,
+	};
 
 	#[test]
 	fn test_gf2_add() {
@@ -638,23 +641,25 @@ pub(crate) mod tests {
 
 	#[test]
 	fn test_inverse_on_zero() {
-		assert!(BinaryField1b::ZERO.try_invert().is_none());
-		assert!(AESTowerField8b::ZERO.try_invert().is_none());
-		assert!(BinaryField128bGhash::ZERO.try_invert().is_none());
+		assert!(BinaryField1b::ZERO.invert_or_zero().is_zero());
+		assert!(AESTowerField8b::ZERO.invert_or_zero().is_zero());
+		assert!(BinaryField128bGhash::ZERO.invert_or_zero().is_zero());
 	}
 
 	proptest! {
 		#[test]
 		fn test_inverse_8b(val in 1u8..) {
 			let x = AESTowerField8b::new(val);
-			let x_inverse = x.try_invert().unwrap();
+			// Safety: `val` is in `1..`, so `x` is non-zero.
+			let x_inverse = unsafe { x.invert() };
 			assert_eq!(x * x_inverse, AESTowerField8b::ONE);
 		}
 
 		#[test]
 		fn test_inverse_128b(val in 1u128..) {
 			let x = BinaryField128bGhash::from(val);
-			let x_inverse = x.try_invert().unwrap();
+			// Safety: `val` is in `1..`, so `x` is non-zero.
+			let x_inverse = unsafe { x.invert() };
 			assert_eq!(x * x_inverse, BinaryField128bGhash::ONE);
 		}
 	}

--- a/crates/field/src/field.rs
+++ b/crates/field/src/field.rs
@@ -91,13 +91,6 @@ pub trait Field:
 	#[must_use]
 	fn double(&self) -> Self;
 
-	/// Computes the multiplicative inverse of this element,
-	/// failing if the element is zero.
-	fn try_invert(&self) -> Option<Self> {
-		let inv = self.invert_or_zero();
-		(!inv.is_zero()).then_some(inv)
-	}
-
 	/// Exponentiates `self` by `exp`, where `exp` is a little-endian order integer
 	/// exponent.
 	fn pow<S: AsRef<[u64]>>(&self, exp: S) -> Self {

--- a/crates/field/src/ghash.rs
+++ b/crates/field/src/ghash.rs
@@ -550,10 +550,9 @@ mod tests {
 		for &value in &test_cases {
 			let field_val = BinaryField128bGhash::from(value);
 			let mul_inv_x_result = field_val.mul_inv_x();
-			let regular_mul_result = field_val
-				* BinaryField128bGhash::new(2u128)
-					.try_invert()
-					.expect("2 is invertible");
+			// Safety: 2 is a non-zero field element.
+			let regular_mul_result =
+				field_val * unsafe { BinaryField128bGhash::new(2u128).invert() };
 
 			assert_eq!(
 				mul_inv_x_result, regular_mul_result,

--- a/crates/field/src/ghash_sq.rs
+++ b/crates/field/src/ghash_sq.rs
@@ -328,9 +328,11 @@ mod tests {
 
 		#[test]
 		fn test_invert(a in arb_elem()) {
-			match a.try_invert() {
-				Some(inv) => prop_assert_eq!(a * inv, GhashSq256b::ONE),
-				None => prop_assert_eq!(a, GhashSq256b::ZERO),
+			let inv = a.invert_or_zero();
+			if a == GhashSq256b::ZERO {
+				prop_assert_eq!(inv, GhashSq256b::ZERO);
+			} else {
+				prop_assert_eq!(a * inv, GhashSq256b::ONE);
 			}
 		}
 

--- a/crates/math/src/batch_invert.rs
+++ b/crates/math/src/batch_invert.rs
@@ -3,7 +3,7 @@
 
 use std::iter;
 
-use binius_field::{Field, PackedField};
+use binius_field::{Field, PackedField, arithmetic_traits::InvertOrZero};
 
 /// Reusable batch inversion context that owns its scratch buffers.
 ///
@@ -162,9 +162,8 @@ fn batch_invert_nonzero_with_scratchpad<P: PackedField>(
 		if P::WIDTH == 1 {
 			// Direct scalar inversion
 			let scalar = packed.get(0);
-			let inv = scalar
-				.try_invert()
-				.expect("precondition: elements contains no zeros");
+			// Safety: precondition — `elements` contains no zeros.
+			let inv = unsafe { scalar.invert() };
 			packed.set(0, inv);
 		} else {
 			// Unpack, batch invert scalars, repack

--- a/crates/math/src/matrix.rs
+++ b/crates/math/src/matrix.rs
@@ -126,10 +126,9 @@ impl<F: Field> Matrix<F> {
 				out.swap_rows(i, pivot, &mut row_buffer);
 			}
 
-			// Normalize the pivot
-			let scalar = tmp[(i, i)]
-				.try_invert()
-				.expect("pivot is checked to be non-zero above");
+			// Normalize the pivot.
+			// Safety: the pivot is checked to be non-zero above.
+			let scalar = unsafe { tmp[(i, i)].invert() };
 			tmp.scale_row(i, scalar);
 			out.scale_row(i, scalar);
 

--- a/crates/math/src/ntt/domain_context.rs
+++ b/crates/math/src/ntt/domain_context.rs
@@ -36,7 +36,9 @@ fn generate_evals_from_subspace<F: BinaryField>(subspace: &BinarySubspace<F>) ->
 
 	// normalize so that evaluations of $W_i$ are replaced by evaluations of $hat{W}_i$
 	for evals_i in evals.iter_mut() {
-		let w_i_b_i_inverse = evals_i[0].try_invert().unwrap();
+		// Safety: `evals_i[0]` is the subspace-polynomial normalization value $W_i(b_i)$, which is
+		// non-zero by construction of the novel polynomial basis.
+		let w_i_b_i_inverse = unsafe { evals_i[0].invert() };
 		for eval_i_j in evals_i.iter_mut() {
 			*eval_i_j *= w_i_b_i_inverse;
 		}

--- a/crates/math/src/ntt/tests_evaluation.rs
+++ b/crates/math/src/ntt/tests_evaluation.rs
@@ -4,7 +4,7 @@
 
 use std::ops::{Add, AddAssign, Mul, MulAssign};
 
-use binius_field::{BinaryField, Field};
+use binius_field::{BinaryField, Field, arithmetic_traits::InvertOrZero};
 use rand::prelude::*;
 
 use crate::{
@@ -226,7 +226,8 @@ fn novel_basis<DC: DomainContext>(domain_context: &DC) -> Vec<Polynomial<DC::Fie
 	for i in 0..log_d {
 		let beta_i = domain.basis()[i];
 		let eval = w_hat[i].evaluate(beta_i);
-		w_hat[i] *= eval.try_invert().unwrap();
+		// Safety: `eval` is the normalization value $\hat{W}_i(\beta_i)$, non-zero by construction.
+		w_hat[i] *= unsafe { eval.invert() };
 	}
 
 	// construct novel polynomial basis

--- a/crates/math/src/tensor_algebra.rs
+++ b/crates/math/src/tensor_algebra.rs
@@ -217,7 +217,7 @@ where
 
 #[cfg(test)]
 mod tests {
-	use binius_field::{BinaryField1b as B1, Random};
+	use binius_field::{BinaryField1b as B1, Random, arithmetic_traits::InvertOrZero};
 	use rand::{SeedableRng, rngs::StdRng};
 
 	use super::*;
@@ -254,7 +254,8 @@ mod tests {
 		assert_eq!(elem.try_extract_vertical(), None);
 
 		// Scale back by the inverse to get back to the vertical subring.
-		let hztl_inv = hztl.try_invert().unwrap();
+		// Safety: `hztl` is the non-zero constant 1111.
+		let hztl_inv = unsafe { hztl.invert() };
 		let elem = elem.scale_horizontal(hztl_inv);
 		assert_eq!(elem.try_extract_vertical(), Some(vert));
 

--- a/crates/math/src/univariate.rs
+++ b/crates/math/src/univariate.rs
@@ -236,9 +236,9 @@ fn compute_barycentric_weights<F: Field>(points: &[F]) -> Vec<F> {
 				.filter(|&j| j != i)
 				.map(|j| points[i] - points[j])
 				.product::<F>();
-			product
-				.try_invert()
-				.expect("precondition: all points are distinct; invert only fails on 0")
+			// Safety: precondition — all points are distinct, so every difference (and thus the
+			// product) is non-zero.
+			unsafe { product.invert() }
 		})
 		.collect()
 }

--- a/crates/verifier/src/protocols/intmul/common.rs
+++ b/crates/verifier/src/protocols/intmul/common.rs
@@ -172,7 +172,9 @@ where
 	// Compute the normalization factors (conjugate - 1)^{-1} in F, then convert to E.
 	let inv_factors: Vec<E> = iterate(F::MULTIPLICATIVE_GENERATOR, |g| g.square())
 		.take(2 << k)
-		.map(|conjugate| E::from((conjugate - F::ONE).try_invert().expect("non-zero")))
+		// Safety: `conjugate` ranges over powers of the multiplicative generator, which has odd
+		// order, so `conjugate - 1` is never zero.
+		.map(|conjugate| E::from(unsafe { (conjugate - F::ONE).invert() }))
 		.collect();
 
 	let (lo_inv_factors, hi_inv_factors) = inv_factors.split_at(1 << k);


### PR DESCRIPTION
Closes BINIUS-112. Stacked on #1547 (BINIUS-107: add `InvertOrZero::invert`).

## Summary

Removes `Field::try_invert` (the `Option`-returning checked invert, renamed from `Field::invert` in #1547) and migrates every call site. Per the issue, each site is converted based on whether the input is guaranteed non-zero:

**→ `unsafe invert` (input guaranteed non-zero, with a `// Safety:` justification):**
- `math/src/matrix.rs` — pivot, checked non-zero immediately above
- `math/src/univariate.rs` — barycentric weights; points are distinct so the difference product is non-zero
- `math/src/batch_invert.rs` — precondition: no zero elements
- `math/src/ntt/domain_context.rs` — subspace normalization value, non-zero by construction
- `verifier/src/protocols/intmul/common.rs` — `conjugate - 1` over generator powers (odd order ⇒ never 1)
- Tests with non-zero values: `binary_field.rs` proptests, `ghash.rs`, `ntt/tests_evaluation.rs`, `tensor_algebra.rs`

**→ `invert_or_zero` (the site genuinely tests/handles the zero case):**
- `binary_field.rs::test_inverse_on_zero`, `aes_field.rs::check_invert`, `ghash_sq.rs::test_invert` — rewritten to assert `invert_or_zero()` returns zero on zero
- `field/benches/binary_field.rs` — the invert benchmark now measures `invert_or_zero`

No production code relied on the `Option`/`None` (zero) branch — every such site used `.expect()`/`.unwrap()`, i.e. treated zero as a bug. A few `use ...arithmetic_traits::InvertOrZero` imports were added where `Field` was previously the only trait in scope.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)