### PR TITLE
BINIUS-118: add coding guidelines section to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,10 @@ For optimal performance: `export RUSTFLAGS="-C target-cpu=native"`
 | **Circuit** | High-level representation of computation built with `CircuitBuilder` |
 | **Constraint system** | Low-level AND/MUL constraints compiled from a circuit |
 
+## Coding Guidelines
+
+**Code comments explain current behavior, not change history.** Do not write comments that reference how the code used to work ("Previously X", "Changed from A to B", "Used to call Y"). Comments must make sense in the context of the current code, independently of its history. Context about what changed and why belongs in the commit description and PR body, not in source code.
+
 ## Documentation
 
 ### Development Guidelines


### PR DESCRIPTION
Adds a **Coding Guidelines** section to `AGENTS.md` ([BINIUS-118](https://linear.app/jimpo/issue/BINIUS-118/update-agentsmd-for-inline-documentation-guidance)).

The new rule: code comments explain current behavior only — not how the code used to work. Change-context belongs in the commit description and PR body, not in source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)