### PR TITLE
Remove ignored transform argument from define_packed_binary_field macros

### DIFF
--- a/crates/field/src/arch/aarch64/packed_128.rs
+++ b/crates/field/src/arch/aarch64/packed_128.rs
@@ -15,7 +15,6 @@ define_packed_binary_fields!(
 			mul: (BitwiseAndStrategy),
 			square: (BitwiseAndStrategy),
 			invert: (BitwiseAndStrategy),
-			transform: (PackedStrategy),
 		},
 	]
 );

--- a/crates/field/src/arch/aarch64/packed_ghash_128.rs
+++ b/crates/field/src/arch/aarch64/packed_ghash_128.rs
@@ -60,8 +60,7 @@ define_packed_binary_field!(
 	M128,
 	(GhashStrategy),
 	(GhashStrategy),
-	(GhashStrategy),
-	(None)
+	(GhashStrategy)
 );
 
 // Implement TaggedMul for GhashStrategy

--- a/crates/field/src/arch/portable/packed_1.rs
+++ b/crates/field/src/arch/portable/packed_1.rs
@@ -17,7 +17,6 @@ define_packed_binary_fields!(
 			mul: (BitwiseAndStrategy),
 			square: (BitwiseAndStrategy),
 			invert: (BitwiseAndStrategy),
-			transform: (PackedStrategy),
 		},
 	]
 );

--- a/crates/field/src/arch/portable/packed_128.rs
+++ b/crates/field/src/arch/portable/packed_128.rs
@@ -16,7 +16,6 @@ define_packed_binary_fields!(
 			mul: (BitwiseAndStrategy),
 			square: (BitwiseAndStrategy),
 			invert: (BitwiseAndStrategy),
-			transform: (PackedStrategy),
 		},
 	]
 );

--- a/crates/field/src/arch/portable/packed_16.rs
+++ b/crates/field/src/arch/portable/packed_16.rs
@@ -14,7 +14,6 @@ define_packed_binary_fields!(
 			mul: (BitwiseAndStrategy),
 			square: (BitwiseAndStrategy),
 			invert: (BitwiseAndStrategy),
-			transform: (PackedStrategy),
 		},
 	]
 );

--- a/crates/field/src/arch/portable/packed_2.rs
+++ b/crates/field/src/arch/portable/packed_2.rs
@@ -17,7 +17,6 @@ define_packed_binary_fields!(
 			mul: (BitwiseAndStrategy),
 			square: (BitwiseAndStrategy),
 			invert: (BitwiseAndStrategy),
-			transform: (PackedStrategy),
 		},
 	]
 );

--- a/crates/field/src/arch/portable/packed_256.rs
+++ b/crates/field/src/arch/portable/packed_256.rs
@@ -24,7 +24,6 @@ define_packed_binary_fields!(
 			mul:       (ScaledStrategy),
 			square:    (ScaledStrategy),
 			invert:    (ScaledStrategy),
-			transform: (ScaledStrategy),
 		},
 	]
 );

--- a/crates/field/src/arch/portable/packed_32.rs
+++ b/crates/field/src/arch/portable/packed_32.rs
@@ -14,7 +14,6 @@ define_packed_binary_fields!(
 			mul: (BitwiseAndStrategy),
 			square: (BitwiseAndStrategy),
 			invert: (BitwiseAndStrategy),
-			transform: (PackedStrategy),
 		},
 	]
 );

--- a/crates/field/src/arch/portable/packed_4.rs
+++ b/crates/field/src/arch/portable/packed_4.rs
@@ -17,7 +17,6 @@ define_packed_binary_fields!(
 			mul: (BitwiseAndStrategy),
 			square: (BitwiseAndStrategy),
 			invert: (BitwiseAndStrategy),
-			transform: (PackedStrategy),
 		},
 	]
 );

--- a/crates/field/src/arch/portable/packed_512.rs
+++ b/crates/field/src/arch/portable/packed_512.rs
@@ -20,7 +20,6 @@ define_packed_binary_fields!(
 			mul:       (ScaledStrategy),
 			square:    (ScaledStrategy),
 			invert:    (ScaledStrategy),
-			transform: (ScaledStrategy),
 		},
 	]
 );

--- a/crates/field/src/arch/portable/packed_64.rs
+++ b/crates/field/src/arch/portable/packed_64.rs
@@ -14,7 +14,6 @@ define_packed_binary_fields!(
 			mul: (BitwiseAndStrategy),
 			square: (BitwiseAndStrategy),
 			invert: (BitwiseAndStrategy),
-			transform: (PackedStrategy),
 		},
 	]
 );

--- a/crates/field/src/arch/portable/packed_8.rs
+++ b/crates/field/src/arch/portable/packed_8.rs
@@ -14,7 +14,6 @@ define_packed_binary_fields!(
 			mul: (BitwiseAndStrategy),
 			square: (BitwiseAndStrategy),
 			invert: (BitwiseAndStrategy),
-			transform: (PackedStrategy),
 		},
 	]
 );

--- a/crates/field/src/arch/portable/packed_aes_128.rs
+++ b/crates/field/src/arch/portable/packed_aes_128.rs
@@ -19,7 +19,6 @@ define_packed_binary_fields!(
 			mul: (PairwiseTableStrategy),
 			square: (PairwiseTableStrategy),
 			invert: (PairwiseTableStrategy),
-			transform: (PackedStrategy),
 		},
 	]
 );

--- a/crates/field/src/arch/portable/packed_aes_16.rs
+++ b/crates/field/src/arch/portable/packed_aes_16.rs
@@ -17,7 +17,6 @@ define_packed_binary_fields!(
 			mul: (PairwiseTableStrategy),
 			square: (PairwiseTableStrategy),
 			invert: (PairwiseTableStrategy),
-			transform: (PackedStrategy),
 		},
 	]
 );

--- a/crates/field/src/arch/portable/packed_aes_256.rs
+++ b/crates/field/src/arch/portable/packed_aes_256.rs
@@ -15,7 +15,6 @@ define_packed_binary_fields!(
 			mul:       (ScaledStrategy),
 			square:    (ScaledStrategy),
 			invert:    (ScaledStrategy),
-			transform: (ScaledStrategy),
 		},
 	]
 );

--- a/crates/field/src/arch/portable/packed_aes_32.rs
+++ b/crates/field/src/arch/portable/packed_aes_32.rs
@@ -19,7 +19,6 @@ define_packed_binary_fields!(
 			mul:       (if gfni_x86 PackedAESBinaryField16x8b else PairwiseTableStrategy),
 			square:    (PairwiseTableStrategy),
 			invert:    (if gfni_x86 PackedAESBinaryField16x8b else PairwiseTableStrategy),
-			transform: (PackedStrategy),
 		},
 	]
 );

--- a/crates/field/src/arch/portable/packed_aes_512.rs
+++ b/crates/field/src/arch/portable/packed_aes_512.rs
@@ -15,7 +15,6 @@ define_packed_binary_fields!(
 			mul:       (ScaledStrategy),
 			square:    (ScaledStrategy),
 			invert:    (ScaledStrategy),
-			transform: (ScaledStrategy),
 		},
 	]
 );

--- a/crates/field/src/arch/portable/packed_aes_64.rs
+++ b/crates/field/src/arch/portable/packed_aes_64.rs
@@ -16,7 +16,6 @@ define_packed_binary_fields!(
 			mul:       (if gfni_x86 PackedAESBinaryField16x8b else PairwiseTableStrategy),
 			square:    (if gfni_x86 PackedAESBinaryField16x8b else PairwiseTableStrategy),
 			invert:    (if gfni_x86 PackedAESBinaryField16x8b else PairwiseTableStrategy),
-			transform: (PackedStrategy),
 		},
 	]
 );

--- a/crates/field/src/arch/portable/packed_aes_8.rs
+++ b/crates/field/src/arch/portable/packed_aes_8.rs
@@ -17,7 +17,6 @@ define_packed_binary_fields!(
 			mul: (PairwiseTableStrategy),
 			square: (PairwiseTableStrategy),
 			invert: (PairwiseTableStrategy),
-			transform: (PairwiseStrategy),
 		},
 	]
 );

--- a/crates/field/src/arch/portable/packed_ghash_128.rs
+++ b/crates/field/src/arch/portable/packed_ghash_128.rs
@@ -125,8 +125,7 @@ define_packed_binary_field!(
 	M128,
 	(GhashStrategy),
 	(GhashStrategy),
-	(GhashStrategy),
-	(None)
+	(GhashStrategy)
 );
 
 impl TaggedMul<GhashStrategy> for PackedBinaryGhash1x128b {

--- a/crates/field/src/arch/portable/packed_ghash_256.rs
+++ b/crates/field/src/arch/portable/packed_ghash_256.rs
@@ -16,7 +16,6 @@ define_packed_binary_fields!(
 			mul:       (ScaledStrategy),
 			square:    (ScaledStrategy),
 			invert:    (ScaledStrategy),
-			transform: (None),
 		},
 	]
 );

--- a/crates/field/src/arch/portable/packed_ghash_512.rs
+++ b/crates/field/src/arch/portable/packed_ghash_512.rs
@@ -16,7 +16,6 @@ define_packed_binary_fields!(
 			mul:       (ScaledStrategy),
 			square:    (ScaledStrategy),
 			invert:    (ScaledStrategy),
-			transform: (None),
 		},
 	]
 );

--- a/crates/field/src/arch/portable/packed_macros.rs
+++ b/crates/field/src/arch/portable/packed_macros.rs
@@ -12,7 +12,6 @@ macro_rules! define_packed_binary_fields {
                     mul: ($($mul:tt)*),
                     square: ($($square:tt)*),
                     invert: ($($invert:tt)*),
-                    transform: ($($transform:tt)*),
                 }
             ),* $(,)?
         ]
@@ -24,8 +23,7 @@ macro_rules! define_packed_binary_fields {
                 $underlier,
                 ($($mul)*),
                 ($($square)*),
-                ($($invert)*),
-                ($($transform)*)
+                ($($invert)*)
             );
 
             // Every packed field is a `WideMul` (it's a parent trait of `PackedField`). All
@@ -51,8 +49,7 @@ macro_rules! define_packed_binary_field {
 		$name:ident, $scalar:path, $underlier:ident,
 		($($mul:tt)*),
 		($($square:tt)*),
-		($($invert:tt)*),
-		($($transform:tt)*)
+		($($invert:tt)*)
 	) => {
 		// Define packed field types
 		pub type $name = $crate::arch::PackedPrimitiveType<$underlier, $scalar>;
@@ -68,9 +65,6 @@ macro_rules! define_packed_binary_field {
 
 		// Define invert
 		impl_strategy!(impl_invert_with    $name, ($($invert)*));
-
-		// Define linear transformations
-		//impl_transformation!($name, ($($transform)*));
 	};
 }
 

--- a/crates/field/src/arch/x86_64/packed_128.rs
+++ b/crates/field/src/arch/x86_64/packed_128.rs
@@ -15,7 +15,6 @@ define_packed_binary_fields!(
 			mul:       (BitwiseAndStrategy),
 			square:    (BitwiseAndStrategy),
 			invert:    (BitwiseAndStrategy),
-			transform: (None),
 		},
 	]
 );

--- a/crates/field/src/arch/x86_64/packed_256.rs
+++ b/crates/field/src/arch/x86_64/packed_256.rs
@@ -19,7 +19,6 @@ define_packed_binary_fields!(
 			mul:       (BitwiseAndStrategy),
 			square:    (BitwiseAndStrategy),
 			invert:    (BitwiseAndStrategy),
-			transform: (SimdStrategy),
 		},
 	]
 );

--- a/crates/field/src/arch/x86_64/packed_512.rs
+++ b/crates/field/src/arch/x86_64/packed_512.rs
@@ -15,7 +15,6 @@ define_packed_binary_fields!(
 			mul:       (BitwiseAndStrategy),
 			square:    (BitwiseAndStrategy),
 			invert:    (BitwiseAndStrategy),
-			transform: (SimdStrategy),
 		},
 	]
 );

--- a/crates/field/src/arch/x86_64/packed_aes_128.rs
+++ b/crates/field/src/arch/x86_64/packed_aes_128.rs
@@ -17,7 +17,6 @@ define_packed_binary_fields!(
 			mul:       (if gfni GfniStrategy else PairwiseTableStrategy),
 			square:    (if gfni ReuseMultiplyStrategy else PairwiseTableStrategy),
 			invert:    (if gfni GfniStrategy else PairwiseTableStrategy),
-			transform: (if gfni GfniStrategy else SimdStrategy),
 		},
 	]
 );

--- a/crates/field/src/arch/x86_64/packed_aes_256.rs
+++ b/crates/field/src/arch/x86_64/packed_aes_256.rs
@@ -17,7 +17,6 @@ define_packed_binary_fields!(
 			mul:       (if gfni GfniStrategy else PairwiseTableStrategy),
 			square:    (if gfni ReuseMultiplyStrategy else PairwiseTableStrategy),
 			invert:    (if gfni GfniStrategy else PairwiseTableStrategy),
-			transform: (if gfni GfniStrategy else SimdStrategy),
 		},
 	]
 );

--- a/crates/field/src/arch/x86_64/packed_aes_512.rs
+++ b/crates/field/src/arch/x86_64/packed_aes_512.rs
@@ -17,7 +17,6 @@ define_packed_binary_fields!(
 			mul:       (if gfni GfniStrategy else PairwiseTableStrategy),
 			square:    (if gfni ReuseMultiplyStrategy else PairwiseTableStrategy),
 			invert:    (if gfni GfniStrategy else PairwiseTableStrategy),
-			transform: (if gfni GfniStrategy else SimdStrategy),
 		},
 	]
 );

--- a/crates/field/src/arch/x86_64/packed_ghash_128.rs
+++ b/crates/field/src/arch/x86_64/packed_ghash_128.rs
@@ -45,8 +45,7 @@ define_packed_binary_field!(
 	M128,
 	(GhashStrategy),
 	(GhashStrategy),
-	(GhashStrategy),
-	(None)
+	(GhashStrategy)
 );
 
 // Implement TaggedMul for GhashStrategy

--- a/crates/field/src/arch/x86_64/packed_ghash_256.rs
+++ b/crates/field/src/arch/x86_64/packed_ghash_256.rs
@@ -59,8 +59,7 @@ define_packed_binary_field!(
 	M256,
 	(Ghash256Strategy),
 	(Ghash256Strategy),
-	(Ghash256Strategy),
-	(None)
+	(Ghash256Strategy)
 );
 
 // Implement TaggedMul for Ghash256Strategy

--- a/crates/field/src/arch/x86_64/packed_ghash_512.rs
+++ b/crates/field/src/arch/x86_64/packed_ghash_512.rs
@@ -52,8 +52,7 @@ define_packed_binary_field!(
 	M512,
 	(Ghash512Strategy),
 	(Ghash512Strategy),
-	(Ghash512Strategy),
-	(None)
+	(Ghash512Strategy)
 );
 
 // Implement TaggedMul for Ghash512Strategy


### PR DESCRIPTION
The transform argument in both define_packed_binary_field and define_packed_binary_fields was accepted by the macro pattern but never used — the only reference was a commented-out impl_transformation\! call. Remove the parameter from both macro definitions and all call sites.