### PR TITLE
Restructure GHASH multiplication with deferred-reduction wide-mul

### DIFF
--- a/crates/field/src/arch/aarch64/arithmetic/ghash.rs
+++ b/crates/field/src/arch/aarch64/arithmetic/ghash.rs
@@ -1,0 +1,221 @@
+// Copyright 2023-2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
+// Copyright (c) 2019-2023 RustCrypto Developers
+
+//! ARMv8 `PMULL`-accelerated GHASH arithmetic.
+//!
+//! Unlike the x86_64 backend, aarch64 only ever operates on a single 128-bit lane (`M128`), so
+//! this module calls the `PMULL` intrinsics directly rather than abstracting over an underlier
+//! trait.
+
+// The widening-multiply wrapper is currently unused (the packed type uses `TrivialWideMul`), so
+// allow dead code rather than annotating each item.
+#![allow(dead_code)]
+
+use core::arch::aarch64::*;
+use std::{
+	iter::Sum,
+	ops::{Add, AddAssign, Sub, SubAssign},
+};
+
+use bytemuck::TransparentWrapper;
+
+use super::super::m128::M128;
+use crate::{BinaryField128bGhash as GhashB128, WideMul, arch::PackedPrimitiveType};
+
+// The reduction polynomial x^128 + x^7 + x^2 + x + 1 is represented as 0x87.
+const POLY: u128 = 0x87;
+
+/// Carryless multiply of two 64-bit lanes selected from the 128-bit inputs by the bytes of
+/// `IMM8`, matching the semantics of x86_64's `clmulepi64`.
+#[inline]
+fn pmull<const IMM8: i32>(a: M128, b: M128) -> M128 {
+	let a_u64x2: uint64x2_t = a.into();
+	let b_u64x2: uint64x2_t = b.into();
+
+	let result = match IMM8 {
+		0x00 => unsafe { vmull_p64(vgetq_lane_u64(a_u64x2, 0), vgetq_lane_u64(b_u64x2, 0)) },
+		0x11 => unsafe { vmull_p64(vgetq_lane_u64(a_u64x2, 1), vgetq_lane_u64(b_u64x2, 1)) },
+		0x10 => unsafe { vmull_p64(vgetq_lane_u64(a_u64x2, 0), vgetq_lane_u64(b_u64x2, 1)) },
+		0x01 => unsafe { vmull_p64(vgetq_lane_u64(a_u64x2, 1), vgetq_lane_u64(b_u64x2, 0)) },
+		_ => panic!("Unsupported IMM8 value for clmulepi64"),
+	};
+
+	unsafe { std::mem::transmute::<u128, uint64x2_t>(result) }.into()
+}
+
+/// Shifts the lower 64 bits to the upper 64 bits and zeroes the lower 64 bits.
+#[inline]
+fn move_64_to_hi(a: M128) -> M128 {
+	let a_bytes: uint8x16_t = a.into();
+	// Shift left by 8 bytes
+	unsafe {
+		let zero = vdupq_n_u8(0);
+		vextq_u8::<8>(zero, a_bytes).into()
+	}
+}
+
+/// Performs reduction step: returns t0 + x^64 * t1
+#[inline]
+fn gf2_128_reduce(mut t0: M128, t1: M128) -> M128 {
+	let poly = M128::from_u128(POLY);
+
+	t0 ^= move_64_to_hi(t1);
+	t0 ^= pmull::<0x01>(t1, poly);
+
+	t0
+}
+
+/// Returns `x^64 * t` after reduction.
+#[inline]
+fn gf2_128_shift_reduce(t: M128) -> M128 {
+	let poly = M128::from_u128(POLY);
+	let mut result = move_64_to_hi(t);
+
+	result ^= pmull::<0x01>(t, poly);
+
+	result
+}
+
+#[inline]
+pub fn mul_clmul(x: M128, y: M128) -> M128 {
+	// t1a = x.lo * y.hi
+	let t1a = pmull::<0x01>(x, y);
+	// t1b = x.hi * y.lo
+	let t1b = pmull::<0x10>(x, y);
+	// t1 = t1a + t1b (XOR in binary field)
+	let mut t1 = t1a ^ t1b;
+	// t2 = x.hi * y.hi
+	let t2 = pmull::<0x11>(x, y);
+	// Reduce t1 and t2
+	t1 = gf2_128_reduce(t1, t2);
+	// t0 = x.lo * y.lo
+	let mut t0 = pmull::<0x00>(x, y);
+	// Final reduction
+	t0 = gf2_128_reduce(t0, t1);
+
+	t0
+}
+
+/// The version of the multiplication optimized for the square operation.
+#[inline]
+pub fn square_clmul(x: M128) -> M128 {
+	// t1 from the multiply is always zero for squaring; t2 = x.hi * x.hi
+	let t2 = pmull::<0x11>(x, x);
+	// Calculate t1 * x^64
+	let t1 = gf2_128_shift_reduce(t2);
+	// t0 = x.lo * x.lo
+	let mut t0 = pmull::<0x00>(x, x);
+	// Final reduction
+	t0 = gf2_128_reduce(t0, t1);
+
+	t0
+}
+
+/// An unreduced product of two `GF(2^128)` elements, stored as three 128-bit limbs
+/// `(lo, hi, mid)` where `mid = cross_a XOR cross_b`. Values of this type can be summed by XOR
+/// and reduced once at the end via [`reduce`](WideGhashProduct::reduce).
+///
+/// Uses the "schoolbook" form: 4 independent CLMULs for the multiply and 2 reduction CLMULs per
+/// reduce.
+#[derive(Clone, Copy, Default, Debug)]
+pub struct WideGhashProduct {
+	lo: M128,
+	hi: M128,
+	mid: M128,
+}
+
+impl WideGhashProduct {
+	/// Widening multiply with 4 independent CLMULs, no reduction.
+	#[inline]
+	pub fn wide_mul(x: M128, y: M128) -> Self {
+		let lo = pmull::<0x00>(x, y);
+		let hi = pmull::<0x11>(x, y);
+		let cross_a = pmull::<0x01>(x, y);
+		let cross_b = pmull::<0x10>(x, y);
+		Self {
+			lo,
+			hi,
+			mid: cross_a ^ cross_b,
+		}
+	}
+
+	/// Reduce the accumulated wide product to a single GF(2^128) element.
+	/// Costs 2 CLMULs (the reduction steps).
+	#[inline]
+	pub fn reduce(self) -> M128 {
+		let t1 = gf2_128_reduce(self.mid, self.hi);
+		gf2_128_reduce(self.lo, t1)
+	}
+}
+
+impl Add for WideGhashProduct {
+	type Output = Self;
+
+	#[inline]
+	fn add(self, rhs: Self) -> Self {
+		Self {
+			lo: self.lo ^ rhs.lo,
+			hi: self.hi ^ rhs.hi,
+			mid: self.mid ^ rhs.mid,
+		}
+	}
+}
+
+impl AddAssign for WideGhashProduct {
+	#[inline]
+	fn add_assign(&mut self, rhs: Self) {
+		self.lo ^= rhs.lo;
+		self.hi ^= rhs.hi;
+		self.mid ^= rhs.mid;
+	}
+}
+
+impl Sum for WideGhashProduct {
+	#[inline]
+	fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+		iter.fold(Self::default(), |acc, x| acc + x)
+	}
+}
+
+// In characteristic 2, subtraction is identical to addition (XOR).
+impl Sub for WideGhashProduct {
+	type Output = Self;
+
+	#[inline]
+	fn sub(self, rhs: Self) -> Self {
+		Self {
+			lo: self.lo ^ rhs.lo,
+			hi: self.hi ^ rhs.hi,
+			mid: self.mid ^ rhs.mid,
+		}
+	}
+}
+
+impl SubAssign for WideGhashProduct {
+	#[inline]
+	fn sub_assign(&mut self, rhs: Self) {
+		self.lo ^= rhs.lo;
+		self.hi ^= rhs.hi;
+		self.mid ^= rhs.mid;
+	}
+}
+
+#[repr(transparent)]
+#[derive(bytemuck::TransparentWrapper)]
+pub struct GhashClMulWideMul<T>(T);
+
+impl WideMul for GhashClMulWideMul<PackedPrimitiveType<M128, GhashB128>> {
+	type Output = WideGhashProduct;
+
+	fn wide_mul(a: Self, b: Self) -> Self::Output {
+		WideGhashProduct::wide_mul(
+			PackedPrimitiveType::peel(Self::peel(a)),
+			PackedPrimitiveType::peel(Self::peel(b)),
+		)
+	}
+
+	fn reduce(wide: Self::Output) -> Self {
+		Self::wrap(PackedPrimitiveType::wrap(wide.reduce()))
+	}
+}

--- a/crates/field/src/arch/aarch64/arithmetic/ghash.rs
+++ b/crates/field/src/arch/aarch64/arithmetic/ghash.rs
@@ -8,10 +8,6 @@
 //! this module calls the `PMULL` intrinsics directly rather than abstracting over an underlier
 //! trait.
 
-// The widening-multiply wrapper is currently unused (the packed type uses `TrivialWideMul`), so
-// allow dead code rather than annotating each item.
-#![allow(dead_code)]
-
 use core::arch::aarch64::*;
 use std::{
 	iter::Sum,

--- a/crates/field/src/arch/aarch64/arithmetic/mod.rs
+++ b/crates/field/src/arch/aarch64/arithmetic/mod.rs
@@ -1,4 +1,3 @@
 // Copyright 2026 The Binius Developers
 
 pub mod ghash;
-pub mod itoh_tsujii;

--- a/crates/field/src/arch/aarch64/mod.rs
+++ b/crates/field/src/arch/aarch64/mod.rs
@@ -7,6 +7,8 @@ cfg_if! {
 		pub(super) mod m128;
 		pub(super) mod simd_arithmetic;
 
+		pub mod arithmetic;
+
 		pub mod packed_128;
 		pub mod packed_aes_128;
 		pub mod packed_ghash_128;

--- a/crates/field/src/arch/aarch64/packed_128.rs
+++ b/crates/field/src/arch/aarch64/packed_128.rs
@@ -15,6 +15,7 @@ define_packed_binary_fields!(
 			mul: (BitwiseAndStrategy),
 			square: (BitwiseAndStrategy),
 			invert: (BitwiseAndStrategy),
+			wide_mul: (TrivialWideMul),
 		},
 	]
 );

--- a/crates/field/src/arch/aarch64/packed_ghash_128.rs
+++ b/crates/field/src/arch/aarch64/packed_ghash_128.rs
@@ -7,48 +7,15 @@
 //! Based on the optimized GHASH implementation using carryless multiplication
 //! instructions available on ARMv8 processors with NEON support.
 
-use core::arch::aarch64::*;
-
 use super::m128::M128;
 use crate::{
 	BinaryField128bGhash,
-	arch::{
-		portable::packed_macros::{portable_macros::*, *},
-		shared::ghash::ClMulUnderlier,
-	},
+	arch::portable::packed_macros::{portable_macros::*, *},
 	arithmetic_traits::{
 		TaggedInvertOrZero, TaggedMul, TaggedSquare, impl_invert_with, impl_mul_with,
 		impl_square_with,
 	},
 };
-
-impl ClMulUnderlier for M128 {
-	#[inline]
-	fn clmulepi64<const IMM8: i32>(a: Self, b: Self) -> Self {
-		let a_u64x2: uint64x2_t = a.into();
-		let b_u64x2: uint64x2_t = b.into();
-
-		let result = match IMM8 {
-			0x00 => unsafe { vmull_p64(vgetq_lane_u64(a_u64x2, 0), vgetq_lane_u64(b_u64x2, 0)) },
-			0x11 => unsafe { vmull_p64(vgetq_lane_u64(a_u64x2, 1), vgetq_lane_u64(b_u64x2, 1)) },
-			0x10 => unsafe { vmull_p64(vgetq_lane_u64(a_u64x2, 0), vgetq_lane_u64(b_u64x2, 1)) },
-			0x01 => unsafe { vmull_p64(vgetq_lane_u64(a_u64x2, 1), vgetq_lane_u64(b_u64x2, 0)) },
-			_ => panic!("Unsupported IMM8 value for clmulepi64"),
-		};
-
-		unsafe { std::mem::transmute::<u128, uint64x2_t>(result) }.into()
-	}
-
-	#[inline]
-	fn move_64_to_hi(a: Self) -> Self {
-		let a_bytes: uint8x16_t = a.into();
-		// Shift left by 8 bytes
-		unsafe {
-			let zero = vdupq_n_u8(0);
-			vextq_u8::<8>(zero, a_bytes).into()
-		}
-	}
-}
 
 /// Strategy for aarch64 GHASH field arithmetic operations.
 pub struct GhashStrategy;
@@ -68,7 +35,7 @@ define_packed_binary_field!(
 impl TaggedMul<GhashStrategy> for PackedBinaryGhash1x128b {
 	#[inline]
 	fn mul(self, rhs: Self) -> Self {
-		Self::from_underlier(crate::arch::shared::ghash::mul_clmul(
+		Self::from_underlier(super::arithmetic::ghash::mul_clmul(
 			self.to_underlier(),
 			rhs.to_underlier(),
 		))
@@ -79,22 +46,7 @@ impl TaggedMul<GhashStrategy> for PackedBinaryGhash1x128b {
 impl TaggedSquare<GhashStrategy> for PackedBinaryGhash1x128b {
 	#[inline]
 	fn square(self) -> Self {
-		Self::from_underlier(crate::arch::shared::ghash::square_clmul(self.to_underlier()))
-	}
-}
-
-// Implement WideMul
-impl WideMul for PackedBinaryGhash1x128b {
-	type Output = ghash::WideGhashProduct<M128>;
-
-	#[inline]
-	fn wide_mul(a: Self, b: Self) -> Self::Output {
-		ghash::WideGhashProduct::wide_mul(a.to_underlier(), b.to_underlier())
-	}
-
-	#[inline]
-	fn reduce(wide: Self::Output) -> Self {
-		Self::from_underlier(wide.reduce())
+		Self::from_underlier(super::arithmetic::ghash::square_clmul(self.to_underlier()))
 	}
 }
 

--- a/crates/field/src/arch/aarch64/packed_ghash_128.rs
+++ b/crates/field/src/arch/aarch64/packed_ghash_128.rs
@@ -7,7 +7,7 @@
 //! Based on the optimized GHASH implementation using carryless multiplication
 //! instructions available on ARMv8 processors with NEON support.
 
-use super::m128::M128;
+use super::{arithmetic::ghash::GhashClMulWideMul, m128::M128};
 use crate::{
 	BinaryField128bGhash,
 	arch::portable::packed_macros::{portable_macros::*, *},
@@ -28,7 +28,7 @@ define_packed_binary_field!(
 	(GhashStrategy),
 	(GhashStrategy),
 	(GhashStrategy),
-	(TrivialWideMul)
+	(GhashClMulWideMul)
 );
 
 // Implement TaggedMul for GhashStrategy

--- a/crates/field/src/arch/aarch64/packed_ghash_128.rs
+++ b/crates/field/src/arch/aarch64/packed_ghash_128.rs
@@ -14,10 +14,10 @@ use crate::{
 	BinaryField128bGhash,
 	arch::{
 		portable::packed_macros::{portable_macros::*, *},
-		shared::ghash::{self, ClMulUnderlier},
+		shared::ghash::ClMulUnderlier,
 	},
 	arithmetic_traits::{
-		TaggedInvertOrZero, TaggedMul, TaggedSquare, WideMul, impl_invert_with, impl_mul_with,
+		TaggedInvertOrZero, TaggedMul, TaggedSquare, impl_invert_with, impl_mul_with,
 		impl_square_with,
 	},
 };
@@ -60,7 +60,8 @@ define_packed_binary_field!(
 	M128,
 	(GhashStrategy),
 	(GhashStrategy),
-	(GhashStrategy)
+	(GhashStrategy),
+	(TrivialWideMul)
 );
 
 // Implement TaggedMul for GhashStrategy

--- a/crates/field/src/arch/mod.rs
+++ b/crates/field/src/arch/mod.rs
@@ -5,7 +5,6 @@ use cfg_if::cfg_if;
 
 mod arch_optimal;
 pub mod portable;
-mod shared;
 mod strategies;
 
 cfg_if! {

--- a/crates/field/src/arch/portable/arithmetic/ghash.rs
+++ b/crates/field/src/arch/portable/arithmetic/ghash.rs
@@ -3,10 +3,6 @@
 
 //! Portable (software) implementation of GHASH field multiplication.
 
-// The widening-multiply wrapper is currently unused (the packed type uses `TrivialWideMul`), so
-// allow dead code rather than annotating each item.
-#![allow(dead_code)]
-
 use std::{
 	iter::Sum,
 	ops::{Add, AddAssign, Sub, SubAssign},
@@ -201,5 +197,37 @@ impl WideMul for GhashWideMul<PackedPrimitiveType<M128, GhashB128>> {
 	#[inline]
 	fn reduce(wide: Self::Output) -> Self {
 		Self::wrap(PackedPrimitiveType::wrap(wide.reduce()))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use proptest::{prelude::any, proptest};
+
+	use super::{super::super::m128::M128, ghash_mul, ghash_wide_mul};
+
+	// Exercises the deferred wide-mul building blocks (`ghash_wide_mul` + `WideGhashProduct`) that
+	// `GhashWideMul` wraps, directly on the portable `M128`. This runs on every host, whereas the
+	// portable `PackedBinaryGhash1x128b` is only a usable `PackedField` on targets where it is the
+	// re-exported b128 type (covered there by the proptests in `packed_ghash.rs`).
+	proptest! {
+		// The split must agree with the fused multiply: wide-multiply then reduce == ghash_mul.
+		#[test]
+		fn wide_mul_then_reduce_matches_ghash_mul(a in any::<u128>(), b in any::<u128>()) {
+			let (a, b) = (M128::from(a), M128::from(b));
+			assert_eq!(ghash_wide_mul(a, b).reduce(), ghash_mul(a, b));
+		}
+
+		// Accumulate two unreduced products and reduce once.
+		#[test]
+		fn wide_mul_deferred_accumulation(
+			a1 in any::<u128>(), b1 in any::<u128>(),
+			a2 in any::<u128>(), b2 in any::<u128>(),
+		) {
+			let (a1, b1) = (M128::from(a1), M128::from(b1));
+			let (a2, b2) = (M128::from(a2), M128::from(b2));
+			let acc = ghash_wide_mul(a1, b1) + ghash_wide_mul(a2, b2);
+			assert_eq!(acc.reduce(), ghash_mul(a1, b1) ^ ghash_mul(a2, b2));
+		}
 	}
 }

--- a/crates/field/src/arch/portable/arithmetic/ghash.rs
+++ b/crates/field/src/arch/portable/arithmetic/ghash.rs
@@ -7,6 +7,11 @@
 // allow dead code rather than annotating each item.
 #![allow(dead_code)]
 
+use std::{
+	iter::Sum,
+	ops::{Add, AddAssign, Sub, SubAssign},
+};
+
 use bytemuck::TransparentWrapper;
 
 use super::super::{
@@ -25,6 +30,14 @@ use crate::{BinaryField128bGhash as GhashB128, WideMul, arch::PackedPrimitiveTyp
 /// a valid GHASH field multiplication with the modified representation.
 #[inline]
 pub fn ghash_mul<U: Underlier128bLanes>(x: U, y: U) -> U {
+	ghash_wide_mul(x, y).reduce()
+}
+
+/// Widening multiply: the schoolbook polynomial product of two GHASH field elements, without the
+/// modular reduction. The unreduced result can be accumulated by XOR and reduced once at the end
+/// via [`WideGhashProduct::reduce`].
+#[inline]
+pub fn ghash_wide_mul<U: Underlier128bLanes>(x: U, y: U) -> WideGhashProduct<U> {
 	// Convert to U64x2 representation
 	let (x1, x0) = U::split_hi_lo_64(x);
 	let (y1, y0) = U::split_hi_lo_64(y);
@@ -54,12 +67,12 @@ pub fn ghash_mul<U: Underlier128bLanes>(x: U, y: U) -> U {
 	z1h = z1h.reverse_bits_64().shr_64(1);
 	z2h = z2h.reverse_bits_64().shr_64(1);
 
-	let v0 = z0;
-	let v1 = z0h ^ z2;
-	let v2 = z1 ^ z2h;
-	let v3 = z1h;
-
-	reduce_64(v0, v1, v2, v3)
+	WideGhashProduct {
+		v0: z0,
+		v1: z0h ^ z2,
+		v2: z1 ^ z2h,
+		v3: z1h,
+	}
 }
 
 #[inline]
@@ -91,27 +104,102 @@ fn reduce_64<U: Underlier128bLanes>(
 	U::join_u64s(v1, v0)
 }
 
+/// An unreduced GHASH product, stored as the four 64-bit limbs `(v0, v1, v2, v3)` of the 256-bit
+/// schoolbook product. Values of this type can be summed by XOR and reduced once at the end via
+/// [`reduce`](WideGhashProduct::reduce).
+#[derive(Clone, Copy, Default, Debug)]
+pub struct WideGhashProduct<U: Underlier128bLanes> {
+	v0: U::U64,
+	v1: U::U64,
+	v2: U::U64,
+	v3: U::U64,
+}
+
+impl<U: Underlier128bLanes> WideGhashProduct<U> {
+	/// Reduce the accumulated wide product to a single GF(2^128) element.
+	#[inline]
+	pub fn reduce(self) -> U {
+		reduce_64(self.v0, self.v1, self.v2, self.v3)
+	}
+}
+
+impl<U: Underlier128bLanes> Add for WideGhashProduct<U> {
+	type Output = Self;
+
+	#[inline]
+	fn add(self, rhs: Self) -> Self {
+		Self {
+			v0: self.v0 ^ rhs.v0,
+			v1: self.v1 ^ rhs.v1,
+			v2: self.v2 ^ rhs.v2,
+			v3: self.v3 ^ rhs.v3,
+		}
+	}
+}
+
+impl<U: Underlier128bLanes> AddAssign for WideGhashProduct<U> {
+	#[inline]
+	fn add_assign(&mut self, rhs: Self) {
+		self.v0 ^= rhs.v0;
+		self.v1 ^= rhs.v1;
+		self.v2 ^= rhs.v2;
+		self.v3 ^= rhs.v3;
+	}
+}
+
+impl<U: Underlier128bLanes> Sum for WideGhashProduct<U> {
+	#[inline]
+	fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+		iter.fold(Self::default(), |acc, x| acc + x)
+	}
+}
+
+// In characteristic 2, subtraction is identical to addition (XOR).
+impl<U: Underlier128bLanes> Sub for WideGhashProduct<U> {
+	type Output = Self;
+
+	#[inline]
+	fn sub(self, rhs: Self) -> Self {
+		Self {
+			v0: self.v0 ^ rhs.v0,
+			v1: self.v1 ^ rhs.v1,
+			v2: self.v2 ^ rhs.v2,
+			v3: self.v3 ^ rhs.v3,
+		}
+	}
+}
+
+impl<U: Underlier128bLanes> SubAssign for WideGhashProduct<U> {
+	#[inline]
+	fn sub_assign(&mut self, rhs: Self) {
+		self.v0 ^= rhs.v0;
+		self.v1 ^= rhs.v1;
+		self.v2 ^= rhs.v2;
+		self.v3 ^= rhs.v3;
+	}
+}
+
 /// Widening-multiply wrapper for the portable GHASH packing.
 ///
-/// The portable backend has no unreduced product representation, so this is an eager multiply:
-/// [`wide_mul`](WideMul::wide_mul) computes the fully reduced product via [`ghash_mul`] and
-/// [`reduce`](WideMul::reduce) is the identity.
+/// [`wide_mul`](WideMul::wide_mul) computes the unreduced schoolbook product via
+/// [`ghash_wide_mul`], and [`reduce`](WideMul::reduce) performs the GHASH modular reduction. This
+/// defers the reduction so a sum of products is reduced only once.
 #[repr(transparent)]
 #[derive(bytemuck::TransparentWrapper)]
 pub struct GhashWideMul<T>(T);
 
 impl WideMul for GhashWideMul<PackedPrimitiveType<M128, GhashB128>> {
-	type Output = PackedPrimitiveType<M128, GhashB128>;
+	type Output = WideGhashProduct<M128>;
 
 	#[inline]
 	fn wide_mul(a: Self, b: Self) -> Self::Output {
 		let a = PackedPrimitiveType::peel(Self::peel(a));
 		let b = PackedPrimitiveType::peel(Self::peel(b));
-		PackedPrimitiveType::wrap(ghash_mul(a, b))
+		ghash_wide_mul(a, b)
 	}
 
 	#[inline]
 	fn reduce(wide: Self::Output) -> Self {
-		Self::wrap(wide)
+		Self::wrap(PackedPrimitiveType::wrap(wide.reduce()))
 	}
 }

--- a/crates/field/src/arch/portable/arithmetic/ghash.rs
+++ b/crates/field/src/arch/portable/arithmetic/ghash.rs
@@ -10,10 +10,7 @@ use std::{
 
 use bytemuck::TransparentWrapper;
 
-use super::super::{
-	m128::M128,
-	univariate_mul_utils_128::{Underlier64bLanes, Underlier128bLanes, bmul64},
-};
+use super::super::univariate_mul_utils_128::{Underlier64bLanes, Underlier128bLanes, bmul64};
 use crate::{BinaryField128bGhash as GhashB128, WideMul, arch::PackedPrimitiveType};
 
 /// Multiply two GHASH field elements using software implementation.
@@ -184,8 +181,8 @@ impl<U: Underlier128bLanes> SubAssign for WideGhashProduct<U> {
 #[derive(bytemuck::TransparentWrapper)]
 pub struct GhashWideMul<T>(T);
 
-impl WideMul for GhashWideMul<PackedPrimitiveType<M128, GhashB128>> {
-	type Output = WideGhashProduct<M128>;
+impl<U: Underlier128bLanes> WideMul for GhashWideMul<PackedPrimitiveType<U, GhashB128>> {
+	type Output = WideGhashProduct<U>;
 
 	#[inline]
 	fn wide_mul(a: Self, b: Self) -> Self::Output {

--- a/crates/field/src/arch/portable/arithmetic/ghash.rs
+++ b/crates/field/src/arch/portable/arithmetic/ghash.rs
@@ -1,0 +1,117 @@
+// Copyright 2023-2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
+
+//! Portable (software) implementation of GHASH field multiplication.
+
+// The widening-multiply wrapper is currently unused (the packed type uses `TrivialWideMul`), so
+// allow dead code rather than annotating each item.
+#![allow(dead_code)]
+
+use bytemuck::TransparentWrapper;
+
+use super::super::{
+	m128::M128,
+	univariate_mul_utils_128::{Underlier64bLanes, Underlier128bLanes, bmul64},
+};
+use crate::{BinaryField128bGhash as GhashB128, WideMul, arch::PackedPrimitiveType};
+
+/// Multiply two GHASH field elements using software implementation.
+///
+/// Method described at:
+/// * <https://www.bearssl.org/constanttime.html#ghash-for-gcm>
+/// * <https://crypto.stackexchange.com/questions/66448/how-does-bearssls-gcm-modular-reduction-work/66462#66462>
+///
+/// This code does not conform to the bit-endianness requirements of the GCM specification, but is
+/// a valid GHASH field multiplication with the modified representation.
+#[inline]
+pub fn ghash_mul<U: Underlier128bLanes>(x: U, y: U) -> U {
+	// Convert to U64x2 representation
+	let (x1, x0) = U::split_hi_lo_64(x);
+	let (y1, y0) = U::split_hi_lo_64(y);
+
+	// Perform multiplication
+	let x0r = x0.reverse_bits_64();
+	let x1r = x1.reverse_bits_64();
+	let x2 = x0 ^ x1;
+	let x2r = x0r ^ x1r;
+
+	let y0r = y0.reverse_bits_64();
+	let y1r = y1.reverse_bits_64();
+	let y2 = y0 ^ y1;
+	let y2r = y0r ^ y1r;
+
+	let z0 = bmul64(y0, x0);
+	let z1 = bmul64(y1, x1);
+	let mut z2 = bmul64(y2, x2);
+
+	let mut z0h = bmul64(y0r, x0r);
+	let mut z1h = bmul64(y1r, x1r);
+	let mut z2h = bmul64(y2r, x2r);
+
+	z2 ^= z0 ^ z1;
+	z2h ^= z0h ^ z1h;
+	z0h = z0h.reverse_bits_64().shr_64(1);
+	z1h = z1h.reverse_bits_64().shr_64(1);
+	z2h = z2h.reverse_bits_64().shr_64(1);
+
+	let v0 = z0;
+	let v1 = z0h ^ z2;
+	let v2 = z1 ^ z2h;
+	let v3 = z1h;
+
+	reduce_64(v0, v1, v2, v3)
+}
+
+#[inline]
+pub fn ghash_square<U: Underlier128bLanes>(x: U) -> U {
+	// Squared value in the polynomial basis is just a value with bits interleaved with zeroes.
+	let (hi, lo) = x.spread_bits_128();
+
+	let (v3, v2) = hi.split_hi_lo_64();
+	let (v1, v0) = lo.split_hi_lo_64();
+
+	reduce_64(v0, v1, v2, v3)
+}
+
+/// Reduce a 256-bit value represented as four 64-bit values by the GHASH polynomial.
+#[inline]
+fn reduce_64<U: Underlier128bLanes>(
+	mut v0: U::U64,
+	mut v1: U::U64,
+	mut v2: U::U64,
+	v3: U::U64,
+) -> U {
+	// Reduce modulo X^64 + X^7 + X^2 + X + 1.
+	v1 ^= v3 ^ v3.shl_64(1) ^ v3.shl_64(2) ^ v3.shl_64(7);
+	v2 ^= v3.shr_64(63) ^ v3.shr_64(62) ^ v3.shr_64(57);
+	v0 ^= v2 ^ v2.shl_64(1) ^ v2.shl_64(2) ^ v2.shl_64(7);
+	v1 ^= v2.shr_64(63) ^ v2.shr_64(62) ^ v2.shr_64(57);
+
+	// Convert back to 128-bit lanes
+	U::join_u64s(v1, v0)
+}
+
+/// Widening-multiply wrapper for the portable GHASH packing.
+///
+/// The portable backend has no unreduced product representation, so this is an eager multiply:
+/// [`wide_mul`](WideMul::wide_mul) computes the fully reduced product via [`ghash_mul`] and
+/// [`reduce`](WideMul::reduce) is the identity.
+#[repr(transparent)]
+#[derive(bytemuck::TransparentWrapper)]
+pub struct GhashWideMul<T>(T);
+
+impl WideMul for GhashWideMul<PackedPrimitiveType<M128, GhashB128>> {
+	type Output = PackedPrimitiveType<M128, GhashB128>;
+
+	#[inline]
+	fn wide_mul(a: Self, b: Self) -> Self::Output {
+		let a = PackedPrimitiveType::peel(Self::peel(a));
+		let b = PackedPrimitiveType::peel(Self::peel(b));
+		PackedPrimitiveType::wrap(ghash_mul(a, b))
+	}
+
+	#[inline]
+	fn reduce(wide: Self::Output) -> Self {
+		Self::wrap(wide)
+	}
+}

--- a/crates/field/src/arch/portable/packed_1.rs
+++ b/crates/field/src/arch/portable/packed_1.rs
@@ -17,6 +17,7 @@ define_packed_binary_fields!(
 			mul: (BitwiseAndStrategy),
 			square: (BitwiseAndStrategy),
 			invert: (BitwiseAndStrategy),
+			wide_mul: (TrivialWideMul),
 		},
 	]
 );

--- a/crates/field/src/arch/portable/packed_128.rs
+++ b/crates/field/src/arch/portable/packed_128.rs
@@ -16,6 +16,7 @@ define_packed_binary_fields!(
 			mul: (BitwiseAndStrategy),
 			square: (BitwiseAndStrategy),
 			invert: (BitwiseAndStrategy),
+			wide_mul: (TrivialWideMul),
 		},
 	]
 );

--- a/crates/field/src/arch/portable/packed_16.rs
+++ b/crates/field/src/arch/portable/packed_16.rs
@@ -14,6 +14,7 @@ define_packed_binary_fields!(
 			mul: (BitwiseAndStrategy),
 			square: (BitwiseAndStrategy),
 			invert: (BitwiseAndStrategy),
+			wide_mul: (TrivialWideMul),
 		},
 	]
 );

--- a/crates/field/src/arch/portable/packed_2.rs
+++ b/crates/field/src/arch/portable/packed_2.rs
@@ -17,6 +17,7 @@ define_packed_binary_fields!(
 			mul: (BitwiseAndStrategy),
 			square: (BitwiseAndStrategy),
 			invert: (BitwiseAndStrategy),
+			wide_mul: (TrivialWideMul),
 		},
 	]
 );

--- a/crates/field/src/arch/portable/packed_256.rs
+++ b/crates/field/src/arch/portable/packed_256.rs
@@ -24,6 +24,7 @@ define_packed_binary_fields!(
 			mul:       (ScaledStrategy),
 			square:    (ScaledStrategy),
 			invert:    (ScaledStrategy),
+			wide_mul: (TrivialWideMul),
 		},
 	]
 );

--- a/crates/field/src/arch/portable/packed_32.rs
+++ b/crates/field/src/arch/portable/packed_32.rs
@@ -14,6 +14,7 @@ define_packed_binary_fields!(
 			mul: (BitwiseAndStrategy),
 			square: (BitwiseAndStrategy),
 			invert: (BitwiseAndStrategy),
+			wide_mul: (TrivialWideMul),
 		},
 	]
 );

--- a/crates/field/src/arch/portable/packed_4.rs
+++ b/crates/field/src/arch/portable/packed_4.rs
@@ -17,6 +17,7 @@ define_packed_binary_fields!(
 			mul: (BitwiseAndStrategy),
 			square: (BitwiseAndStrategy),
 			invert: (BitwiseAndStrategy),
+			wide_mul: (TrivialWideMul),
 		},
 	]
 );

--- a/crates/field/src/arch/portable/packed_512.rs
+++ b/crates/field/src/arch/portable/packed_512.rs
@@ -20,6 +20,7 @@ define_packed_binary_fields!(
 			mul:       (ScaledStrategy),
 			square:    (ScaledStrategy),
 			invert:    (ScaledStrategy),
+			wide_mul: (TrivialWideMul),
 		},
 	]
 );

--- a/crates/field/src/arch/portable/packed_64.rs
+++ b/crates/field/src/arch/portable/packed_64.rs
@@ -14,6 +14,7 @@ define_packed_binary_fields!(
 			mul: (BitwiseAndStrategy),
 			square: (BitwiseAndStrategy),
 			invert: (BitwiseAndStrategy),
+			wide_mul: (TrivialWideMul),
 		},
 	]
 );

--- a/crates/field/src/arch/portable/packed_8.rs
+++ b/crates/field/src/arch/portable/packed_8.rs
@@ -14,6 +14,7 @@ define_packed_binary_fields!(
 			mul: (BitwiseAndStrategy),
 			square: (BitwiseAndStrategy),
 			invert: (BitwiseAndStrategy),
+			wide_mul: (TrivialWideMul),
 		},
 	]
 );

--- a/crates/field/src/arch/portable/packed_aes_128.rs
+++ b/crates/field/src/arch/portable/packed_aes_128.rs
@@ -19,6 +19,7 @@ define_packed_binary_fields!(
 			mul: (PairwiseTableStrategy),
 			square: (PairwiseTableStrategy),
 			invert: (PairwiseTableStrategy),
+			wide_mul: (TrivialWideMul),
 		},
 	]
 );

--- a/crates/field/src/arch/portable/packed_aes_16.rs
+++ b/crates/field/src/arch/portable/packed_aes_16.rs
@@ -17,6 +17,7 @@ define_packed_binary_fields!(
 			mul: (PairwiseTableStrategy),
 			square: (PairwiseTableStrategy),
 			invert: (PairwiseTableStrategy),
+			wide_mul: (TrivialWideMul),
 		},
 	]
 );

--- a/crates/field/src/arch/portable/packed_aes_256.rs
+++ b/crates/field/src/arch/portable/packed_aes_256.rs
@@ -15,6 +15,7 @@ define_packed_binary_fields!(
 			mul:       (ScaledStrategy),
 			square:    (ScaledStrategy),
 			invert:    (ScaledStrategy),
+			wide_mul: (TrivialWideMul),
 		},
 	]
 );

--- a/crates/field/src/arch/portable/packed_aes_32.rs
+++ b/crates/field/src/arch/portable/packed_aes_32.rs
@@ -19,6 +19,7 @@ define_packed_binary_fields!(
 			mul:       (if gfni_x86 PackedAESBinaryField16x8b else PairwiseTableStrategy),
 			square:    (PairwiseTableStrategy),
 			invert:    (if gfni_x86 PackedAESBinaryField16x8b else PairwiseTableStrategy),
+			wide_mul: (TrivialWideMul),
 		},
 	]
 );

--- a/crates/field/src/arch/portable/packed_aes_512.rs
+++ b/crates/field/src/arch/portable/packed_aes_512.rs
@@ -15,6 +15,7 @@ define_packed_binary_fields!(
 			mul:       (ScaledStrategy),
 			square:    (ScaledStrategy),
 			invert:    (ScaledStrategy),
+			wide_mul: (TrivialWideMul),
 		},
 	]
 );

--- a/crates/field/src/arch/portable/packed_aes_64.rs
+++ b/crates/field/src/arch/portable/packed_aes_64.rs
@@ -16,6 +16,7 @@ define_packed_binary_fields!(
 			mul:       (if gfni_x86 PackedAESBinaryField16x8b else PairwiseTableStrategy),
 			square:    (if gfni_x86 PackedAESBinaryField16x8b else PairwiseTableStrategy),
 			invert:    (if gfni_x86 PackedAESBinaryField16x8b else PairwiseTableStrategy),
+			wide_mul: (TrivialWideMul),
 		},
 	]
 );

--- a/crates/field/src/arch/portable/packed_aes_8.rs
+++ b/crates/field/src/arch/portable/packed_aes_8.rs
@@ -17,6 +17,7 @@ define_packed_binary_fields!(
 			mul: (PairwiseTableStrategy),
 			square: (PairwiseTableStrategy),
 			invert: (PairwiseTableStrategy),
+			wide_mul: (TrivialWideMul),
 		},
 	]
 );

--- a/crates/field/src/arch/portable/packed_ghash_128.rs
+++ b/crates/field/src/arch/portable/packed_ghash_128.rs
@@ -4,9 +4,12 @@
 //! Portable implementation of packed GHASH field operations.
 
 use super::{
-	arithmetic::itoh_tsujii::invert_b128,
+	arithmetic::{
+		ghash::{ghash_mul, ghash_square},
+		itoh_tsujii::invert_b128,
+	},
 	m128::M128,
-	univariate_mul_utils_128::{Underlier64bLanes, Underlier128bLanes, bmul64, spread_bits_64},
+	univariate_mul_utils_128::{Underlier128bLanes, spread_bits_64},
 };
 use crate::{
 	arch::portable::packed_macros::{portable_macros::*, *},
@@ -16,82 +19,6 @@ use crate::{
 
 /// Strategy for GHASH field arithmetic operations.
 pub struct GhashStrategy;
-
-/// Multiply two GHASH field elements using software implementation.
-///
-/// Method described at:
-/// * <https://www.bearssl.org/constanttime.html#ghash-for-gcm>
-/// * <https://crypto.stackexchange.com/questions/66448/how-does-bearssls-gcm-modular-reduction-work/66462#66462>
-///
-/// This code does not conform to the bit-endianness requirements of the GCM specification, but is
-/// a valid GHASH field multiplication with the modified representation.
-#[inline]
-pub fn ghash_mul<U: Underlier128bLanes>(x: U, y: U) -> U {
-	// Convert to U64x2 representation
-	let (x1, x0) = U::split_hi_lo_64(x);
-	let (y1, y0) = U::split_hi_lo_64(y);
-
-	// Perform multiplication
-	let x0r = x0.reverse_bits_64();
-	let x1r = x1.reverse_bits_64();
-	let x2 = x0 ^ x1;
-	let x2r = x0r ^ x1r;
-
-	let y0r = y0.reverse_bits_64();
-	let y1r = y1.reverse_bits_64();
-	let y2 = y0 ^ y1;
-	let y2r = y0r ^ y1r;
-
-	let z0 = bmul64(y0, x0);
-	let z1 = bmul64(y1, x1);
-	let mut z2 = bmul64(y2, x2);
-
-	let mut z0h = bmul64(y0r, x0r);
-	let mut z1h = bmul64(y1r, x1r);
-	let mut z2h = bmul64(y2r, x2r);
-
-	z2 ^= z0 ^ z1;
-	z2h ^= z0h ^ z1h;
-	z0h = z0h.reverse_bits_64().shr_64(1);
-	z1h = z1h.reverse_bits_64().shr_64(1);
-	z2h = z2h.reverse_bits_64().shr_64(1);
-
-	let v0 = z0;
-	let v1 = z0h ^ z2;
-	let v2 = z1 ^ z2h;
-	let v3 = z1h;
-
-	reduce_64(v0, v1, v2, v3)
-}
-
-#[inline]
-pub fn ghash_square<U: Underlier128bLanes>(x: U) -> U {
-	// Squared value in the polynomial basis is just a value with bits interleaved with zeroes.
-	let (hi, lo) = x.spread_bits_128();
-
-	let (v3, v2) = hi.split_hi_lo_64();
-	let (v1, v0) = lo.split_hi_lo_64();
-
-	reduce_64(v0, v1, v2, v3)
-}
-
-/// Reduce a 256-bit value represented as four 64-bit values by the GHASH polynomial.
-#[inline]
-fn reduce_64<U: Underlier128bLanes>(
-	mut v0: U::U64,
-	mut v1: U::U64,
-	mut v2: U::U64,
-	v3: U::U64,
-) -> U {
-	// Reduce modulo X^64 + X^7 + X^2 + X + 1.
-	v1 ^= v3 ^ v3.shl_64(1) ^ v3.shl_64(2) ^ v3.shl_64(7);
-	v2 ^= v3.shr_64(63) ^ v3.shr_64(62) ^ v3.shr_64(57);
-	v0 ^= v2 ^ v2.shl_64(1) ^ v2.shl_64(2) ^ v2.shl_64(7);
-	v1 ^= v2.shr_64(63) ^ v2.shr_64(62) ^ v2.shr_64(57);
-
-	// Convert back to 128-bit lanes
-	U::join_u64s(v1, v0)
-}
 
 // `M128` packs its GHASH 64-bit lanes the same way `u128` does — delegate through `u128`.
 impl Underlier128bLanes for M128 {

--- a/crates/field/src/arch/portable/packed_ghash_128.rs
+++ b/crates/field/src/arch/portable/packed_ghash_128.rs
@@ -125,7 +125,8 @@ define_packed_binary_field!(
 	M128,
 	(GhashStrategy),
 	(GhashStrategy),
-	(GhashStrategy)
+	(GhashStrategy),
+	(TrivialWideMul)
 );
 
 impl TaggedMul<GhashStrategy> for PackedBinaryGhash1x128b {
@@ -141,8 +142,6 @@ impl TaggedSquare<GhashStrategy> for PackedBinaryGhash1x128b {
 		ghash_square(self.0).into()
 	}
 }
-
-crate::arithmetic_traits::impl_trivial_wide_mul!(PackedBinaryGhash1x128b);
 
 impl TaggedInvertOrZero<GhashStrategy> for PackedBinaryGhash1x128b {
 	#[inline]

--- a/crates/field/src/arch/portable/packed_ghash_128.rs
+++ b/crates/field/src/arch/portable/packed_ghash_128.rs
@@ -5,7 +5,7 @@
 
 use super::{
 	arithmetic::{
-		ghash::{ghash_mul, ghash_square},
+		ghash::{GhashWideMul, ghash_mul, ghash_square},
 		itoh_tsujii::invert_b128,
 	},
 	m128::M128,
@@ -53,7 +53,7 @@ define_packed_binary_field!(
 	(GhashStrategy),
 	(GhashStrategy),
 	(GhashStrategy),
-	(TrivialWideMul)
+	(GhashWideMul)
 );
 
 impl TaggedMul<GhashStrategy> for PackedBinaryGhash1x128b {

--- a/crates/field/src/arch/portable/packed_ghash_256.rs
+++ b/crates/field/src/arch/portable/packed_ghash_256.rs
@@ -16,8 +16,7 @@ define_packed_binary_fields!(
 			mul:       (ScaledStrategy),
 			square:    (ScaledStrategy),
 			invert:    (ScaledStrategy),
+			wide_mul: (TrivialWideMul),
 		},
 	]
 );
-
-crate::arithmetic_traits::impl_trivial_wide_mul!(PackedBinaryGhash2x128b);

--- a/crates/field/src/arch/portable/packed_ghash_512.rs
+++ b/crates/field/src/arch/portable/packed_ghash_512.rs
@@ -16,8 +16,7 @@ define_packed_binary_fields!(
 			mul:       (ScaledStrategy),
 			square:    (ScaledStrategy),
 			invert:    (ScaledStrategy),
+			wide_mul: (TrivialWideMul),
 		},
 	]
 );
-
-crate::arithmetic_traits::impl_trivial_wide_mul!(PackedBinaryGhash4x128b);

--- a/crates/field/src/arch/portable/packed_macros.rs
+++ b/crates/field/src/arch/portable/packed_macros.rs
@@ -108,8 +108,8 @@ pub(crate) use define_packed_binary_field;
 pub(crate) use define_packed_binary_fields;
 pub(crate) use impl_serialize_deserialize_for_packed_binary_field;
 
-// Re-exported so the `wide_mul: (TrivialWideMul)` argument resolves at every macro call site that
-// glob-imports this module.
+// Re-exported so the `wide_mul: (TrivialWideMul)` argument resolves at every macro call site
+// that glob-imports this module.
 pub(crate) use crate::arithmetic_traits::TrivialWideMul;
 pub(crate) use crate::arithmetic_traits::{impl_invert_with, impl_mul_with, impl_square_with};
 

--- a/crates/field/src/arch/portable/packed_macros.rs
+++ b/crates/field/src/arch/portable/packed_macros.rs
@@ -12,6 +12,7 @@ macro_rules! define_packed_binary_fields {
                     mul: ($($mul:tt)*),
                     square: ($($square:tt)*),
                     invert: ($($invert:tt)*),
+                    wide_mul: ($($wide_mul:tt)*),
                 }
             ),* $(,)?
         ]
@@ -23,25 +24,11 @@ macro_rules! define_packed_binary_fields {
                 $underlier,
                 ($($mul)*),
                 ($($square)*),
-                ($($invert)*)
+                ($($invert)*),
+                ($($wide_mul)*)
             );
-
-            // Every packed field is a `WideMul` (it's a parent trait of `PackedField`). All
-            // packings except `GF(2^128)` use the trivial implementation; the `GF(2^128)`
-            // packings provide their own CLMUL-accelerated (or, on backends without CLMUL,
-            // trivial) impl, so the macro must not emit a conflicting one for them.
-            maybe_impl_trivial_wide_mul!($scalar, $name);
         )*
     };
-}
-
-/// Emits a trivial [`WideMul`](crate::WideMul) impl for every scalar except
-/// `BinaryField128bGhash`, whose packings implement `WideMul` themselves.
-macro_rules! maybe_impl_trivial_wide_mul {
-	(BinaryField128bGhash, $name:ident) => {};
-	($scalar:ident, $name:ident) => {
-		$crate::arithmetic_traits::impl_trivial_wide_mul!($name);
-	};
 }
 
 macro_rules! define_packed_binary_field {
@@ -49,7 +36,8 @@ macro_rules! define_packed_binary_field {
 		$name:ident, $scalar:path, $underlier:ident,
 		($($mul:tt)*),
 		($($square:tt)*),
-		($($invert:tt)*)
+		($($invert:tt)*),
+		($($wide_mul:tt)*)
 	) => {
 		// Define packed field types
 		pub type $name = $crate::arch::PackedPrimitiveType<$underlier, $scalar>;
@@ -65,6 +53,30 @@ macro_rules! define_packed_binary_field {
 
 		// Define invert
 		impl_strategy!(impl_invert_with    $name, ($($invert)*));
+
+		// Define widening multiplication. Every packed field is a `WideMul` (it's a parent trait
+		// of `PackedField`). The caller passes a wrapper struct (a `TransparentWrapper` around this
+		// packed field) that carries the actual `WideMul` impl; here we forward to it by wrapping
+		// the inputs and peeling the reduced result.
+		impl $crate::arithmetic_traits::WideMul for $name {
+			type Output =
+				<$($wide_mul)* <$name> as $crate::arithmetic_traits::WideMul>::Output;
+
+			#[inline]
+			fn wide_mul(a: Self, b: Self) -> Self::Output {
+				<$($wide_mul)* <$name> as $crate::arithmetic_traits::WideMul>::wide_mul(
+					<$($wide_mul)* <$name> as ::bytemuck::TransparentWrapper<$name>>::wrap(a),
+					<$($wide_mul)* <$name> as ::bytemuck::TransparentWrapper<$name>>::wrap(b),
+				)
+			}
+
+			#[inline]
+			fn reduce(wide: Self::Output) -> Self {
+				<$($wide_mul)* <$name> as ::bytemuck::TransparentWrapper<$name>>::peel(
+					<$($wide_mul)* <$name> as $crate::arithmetic_traits::WideMul>::reduce(wide),
+				)
+			}
+		}
 	};
 }
 
@@ -95,8 +107,10 @@ macro_rules! impl_serialize_deserialize_for_packed_binary_field {
 pub(crate) use define_packed_binary_field;
 pub(crate) use define_packed_binary_fields;
 pub(crate) use impl_serialize_deserialize_for_packed_binary_field;
-pub(crate) use maybe_impl_trivial_wide_mul;
 
+// Re-exported so the `wide_mul: (TrivialWideMul)` argument resolves at every macro call site that
+// glob-imports this module.
+pub(crate) use crate::arithmetic_traits::TrivialWideMul;
 pub(crate) use crate::arithmetic_traits::{impl_invert_with, impl_mul_with, impl_square_with};
 
 pub(crate) mod portable_macros {

--- a/crates/field/src/arch/shared/ghash.rs
+++ b/crates/field/src/arch/shared/ghash.rs
@@ -11,7 +11,12 @@ use std::{
 	ops::{Add, AddAssign, Sub, SubAssign},
 };
 
-use crate::{Divisible, underlier::UnderlierType};
+use bytemuck::TransparentWrapper;
+
+use crate::{
+	BinaryField128bGhash as GhashB128, Divisible, WideMul, arch::PackedPrimitiveType,
+	underlier::UnderlierType,
+};
 
 /// Trait for underliers that support CLMUL operations which are needed for the
 /// GHASH multiplication algorithm.
@@ -188,6 +193,25 @@ impl<U: ClMulUnderlier> SubAssign for WideGhashProduct<U> {
 		self.lo ^= rhs.lo;
 		self.hi ^= rhs.hi;
 		self.mid ^= rhs.mid;
+	}
+}
+
+#[repr(transparent)]
+#[derive(bytemuck::TransparentWrapper)]
+pub struct WideGhashMul<T>(T);
+
+impl<U: ClMulUnderlier> WideMul for WideGhashMul<PackedPrimitiveType<U, GhashB128>> {
+	type Output = WideGhashProduct<U>;
+
+	fn wide_mul(a: Self, b: Self) -> Self::Output {
+		WideGhashProduct::wide_mul(
+			PackedPrimitiveType::peel(Self::peel(a)),
+			PackedPrimitiveType::peel(Self::peel(b)),
+		)
+	}
+
+	fn reduce(wide: Self::Output) -> Self {
+		Self::wrap(PackedPrimitiveType::wrap(wide.reduce()))
 	}
 }
 

--- a/crates/field/src/arch/shared/mod.rs
+++ b/crates/field/src/arch/shared/mod.rs
@@ -1,3 +1,0 @@
-// Copyright 2025 Irreducible Inc.
-
-pub mod ghash;

--- a/crates/field/src/arch/wasm32/packed_ghash_128.rs
+++ b/crates/field/src/arch/wasm32/packed_ghash_128.rs
@@ -15,7 +15,7 @@ use crate::{
 	arch::{
 		PairwiseStrategy,
 		portable::{
-			packed_ghash_128::ghash_mul,
+			arithmetic::ghash::ghash_mul,
 			packed_macros::impl_broadcast,
 			univariate_mul_utils_128::{Underlier128bLanes, spread_bits_64},
 		},
@@ -67,7 +67,7 @@ impl Underlier128bLanes for M128 {
 impl Square for PackedBinaryGhash1x128b {
 	#[inline]
 	fn square(self) -> Self {
-		Self::from_underlier(crate::arch::portable::packed_ghash_128::ghash_square(
+		Self::from_underlier(crate::arch::portable::arithmetic::ghash::ghash_square(
 			self.to_underlier(),
 		))
 	}

--- a/crates/field/src/arch/x86_64/arithmetic/ghash.rs
+++ b/crates/field/src/arch/x86_64/arithmetic/ghash.rs
@@ -1,9 +1,9 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-// Items in this module are conditionally used by architecture-specific GHASH backends. On
-// targets where none of those backends are compiled (e.g. wasm32 without simd128), the entire
-// module is unused, so allow dead code here rather than sprinkling attributes on every item.
+// Items in this module are conditionally used by the x86_64 GHASH backends. Depending on which
+// CLMUL target features are enabled, some items may be unused, so allow dead code here rather
+// than sprinkling attributes on every item.
 #![allow(dead_code)]
 
 use std::{
@@ -20,6 +20,9 @@ use crate::{
 
 /// Trait for underliers that support CLMUL operations which are needed for the
 /// GHASH multiplication algorithm.
+///
+/// On x86_64 this abstracts over the `M128`/`M256`/`M512` wrappers for `__m128i`/`__m256i`/
+/// `__m512i`, so the same algorithm code drives PCLMULQDQ and VPCLMULQDQ.
 pub trait ClMulUnderlier: UnderlierType + Divisible<u128> {
 	/// Performs CLMUL operation on two 64-bit values that are selected from 128-bit lanes
 	/// by the bytes of the IMM8 parameter.
@@ -198,9 +201,9 @@ impl<U: ClMulUnderlier> SubAssign for WideGhashProduct<U> {
 
 #[repr(transparent)]
 #[derive(bytemuck::TransparentWrapper)]
-pub struct WideGhashMul<T>(T);
+pub struct GhashClMulWideMul<T>(T);
 
-impl<U: ClMulUnderlier> WideMul for WideGhashMul<PackedPrimitiveType<U, GhashB128>> {
+impl<U: ClMulUnderlier> WideMul for GhashClMulWideMul<PackedPrimitiveType<U, GhashB128>> {
 	type Output = WideGhashProduct<U>;
 
 	fn wide_mul(a: Self, b: Self) -> Self::Output {

--- a/crates/field/src/arch/x86_64/arithmetic/mod.rs
+++ b/crates/field/src/arch/x86_64/arithmetic/mod.rs
@@ -1,4 +1,3 @@
 // Copyright 2026 The Binius Developers
 
 pub mod ghash;
-pub mod itoh_tsujii;

--- a/crates/field/src/arch/x86_64/mod.rs
+++ b/crates/field/src/arch/x86_64/mod.rs
@@ -2,6 +2,8 @@
 
 use cfg_if::cfg_if;
 
+pub mod arithmetic;
+
 #[cfg(target_feature = "gfni")]
 mod gfni;
 

--- a/crates/field/src/arch/x86_64/packed_128.rs
+++ b/crates/field/src/arch/x86_64/packed_128.rs
@@ -15,6 +15,7 @@ define_packed_binary_fields!(
 			mul:       (BitwiseAndStrategy),
 			square:    (BitwiseAndStrategy),
 			invert:    (BitwiseAndStrategy),
+			wide_mul: (TrivialWideMul),
 		},
 	]
 );

--- a/crates/field/src/arch/x86_64/packed_256.rs
+++ b/crates/field/src/arch/x86_64/packed_256.rs
@@ -19,6 +19,7 @@ define_packed_binary_fields!(
 			mul:       (BitwiseAndStrategy),
 			square:    (BitwiseAndStrategy),
 			invert:    (BitwiseAndStrategy),
+			wide_mul: (TrivialWideMul),
 		},
 	]
 );

--- a/crates/field/src/arch/x86_64/packed_512.rs
+++ b/crates/field/src/arch/x86_64/packed_512.rs
@@ -15,6 +15,7 @@ define_packed_binary_fields!(
 			mul:       (BitwiseAndStrategy),
 			square:    (BitwiseAndStrategy),
 			invert:    (BitwiseAndStrategy),
+			wide_mul: (TrivialWideMul),
 		},
 	]
 );

--- a/crates/field/src/arch/x86_64/packed_aes_128.rs
+++ b/crates/field/src/arch/x86_64/packed_aes_128.rs
@@ -17,6 +17,7 @@ define_packed_binary_fields!(
 			mul:       (if gfni GfniStrategy else PairwiseTableStrategy),
 			square:    (if gfni ReuseMultiplyStrategy else PairwiseTableStrategy),
 			invert:    (if gfni GfniStrategy else PairwiseTableStrategy),
+			wide_mul: (TrivialWideMul),
 		},
 	]
 );

--- a/crates/field/src/arch/x86_64/packed_aes_256.rs
+++ b/crates/field/src/arch/x86_64/packed_aes_256.rs
@@ -17,6 +17,7 @@ define_packed_binary_fields!(
 			mul:       (if gfni GfniStrategy else PairwiseTableStrategy),
 			square:    (if gfni ReuseMultiplyStrategy else PairwiseTableStrategy),
 			invert:    (if gfni GfniStrategy else PairwiseTableStrategy),
+			wide_mul: (TrivialWideMul),
 		},
 	]
 );

--- a/crates/field/src/arch/x86_64/packed_aes_512.rs
+++ b/crates/field/src/arch/x86_64/packed_aes_512.rs
@@ -17,6 +17,7 @@ define_packed_binary_fields!(
 			mul:       (if gfni GfniStrategy else PairwiseTableStrategy),
 			square:    (if gfni ReuseMultiplyStrategy else PairwiseTableStrategy),
 			invert:    (if gfni GfniStrategy else PairwiseTableStrategy),
+			wide_mul: (TrivialWideMul),
 		},
 	]
 );

--- a/crates/field/src/arch/x86_64/packed_ghash_128.rs
+++ b/crates/field/src/arch/x86_64/packed_ghash_128.rs
@@ -10,7 +10,7 @@
 use cfg_if::cfg_if;
 
 use super::m128::M128;
-// Only used by the CLMUL-accelerated `ClMulUnderlier` impl below.
+// Used by the CLMUL-accelerated `ClMulUnderlier` impl and the `GhashWideMul` alias below.
 #[cfg(target_feature = "pclmulqdq")]
 use crate::arch::x86_64::arithmetic::ghash;
 use crate::{
@@ -21,6 +21,14 @@ use crate::{
 		impl_square_with,
 	},
 };
+
+/// Widening-multiply wrapper used by the GHASH packing: the reduction-deferring
+/// [`GhashClMulWideMul`](ghash::GhashClMulWideMul) when PCLMULQDQ is available, otherwise an eager
+/// [`TrivialWideMul`].
+#[cfg(target_feature = "pclmulqdq")]
+pub type GhashWideMul<T> = ghash::GhashClMulWideMul<T>;
+#[cfg(not(target_feature = "pclmulqdq"))]
+pub type GhashWideMul<T> = TrivialWideMul<T>;
 
 #[cfg(target_feature = "pclmulqdq")]
 impl ghash::ClMulUnderlier for M128 {
@@ -46,7 +54,7 @@ define_packed_binary_field!(
 	(GhashStrategy),
 	(GhashStrategy),
 	(GhashStrategy),
-	(TrivialWideMul)
+	(GhashWideMul)
 );
 
 // Implement TaggedMul for GhashStrategy

--- a/crates/field/src/arch/x86_64/packed_ghash_128.rs
+++ b/crates/field/src/arch/x86_64/packed_ghash_128.rs
@@ -10,6 +10,9 @@
 use cfg_if::cfg_if;
 
 use super::m128::M128;
+// Only used by the CLMUL-accelerated `ClMulUnderlier` impl below.
+#[cfg(target_feature = "pclmulqdq")]
+use crate::arch::x86_64::arithmetic::ghash;
 use crate::{
 	BinaryField128bGhash,
 	arch::portable::packed_macros::{portable_macros::*, *},
@@ -18,9 +21,6 @@ use crate::{
 		impl_square_with,
 	},
 };
-// Only used by the CLMUL-accelerated `ClMulUnderlier` impl below.
-#[cfg(target_feature = "pclmulqdq")]
-use crate::arch::shared::ghash;
 
 #[cfg(target_feature = "pclmulqdq")]
 impl ghash::ClMulUnderlier for M128 {
@@ -55,7 +55,7 @@ cfg_if! {
 		impl TaggedMul<GhashStrategy> for PackedBinaryGhash1x128b {
 			#[inline]
 			fn mul(self, rhs: Self) -> Self {
-				Self::from_underlier(crate::arch::shared::ghash::mul_clmul(
+				Self::from_underlier(crate::arch::x86_64::arithmetic::ghash::mul_clmul(
 					self.to_underlier(),
 					rhs.to_underlier(),
 				))
@@ -65,7 +65,7 @@ cfg_if! {
 		impl TaggedMul<GhashStrategy> for PackedBinaryGhash1x128b {
 			#[inline]
 			fn mul(self, rhs: Self) -> Self {
-				use super::super::portable::packed_ghash_128::ghash_mul;
+				use super::super::portable::arithmetic::ghash::ghash_mul;
 
 				let product = ghash_mul(u128::from(self.to_underlier()), u128::from(rhs.to_underlier()));
 				Self::from_underlier(M128::from(product))
@@ -80,7 +80,7 @@ cfg_if! {
 		impl TaggedSquare<GhashStrategy> for PackedBinaryGhash1x128b {
 			#[inline]
 			fn square(self) -> Self {
-				Self::from_underlier(crate::arch::shared::ghash::square_clmul(
+				Self::from_underlier(crate::arch::x86_64::arithmetic::ghash::square_clmul(
 					self.to_underlier(),
 				))
 			}
@@ -89,7 +89,7 @@ cfg_if! {
 		impl TaggedSquare<GhashStrategy> for PackedBinaryGhash1x128b {
 			#[inline]
 			fn square(self) -> Self {
-				use super::super::portable::packed_ghash_128::ghash_square;
+				use super::super::portable::arithmetic::ghash::ghash_square;
 
 				Self::from_underlier(M128::from(ghash_square(u128::from(self.to_underlier()))))
 			}

--- a/crates/field/src/arch/x86_64/packed_ghash_128.rs
+++ b/crates/field/src/arch/x86_64/packed_ghash_128.rs
@@ -18,9 +18,9 @@ use crate::{
 		impl_square_with,
 	},
 };
-// Only used by the CLMUL-accelerated `ClMulUnderlier` and `WideMul` impls below.
+// Only used by the CLMUL-accelerated `ClMulUnderlier` impl below.
 #[cfg(target_feature = "pclmulqdq")]
-use crate::{arch::shared::ghash, arithmetic_traits::WideMul};
+use crate::arch::shared::ghash;
 
 #[cfg(target_feature = "pclmulqdq")]
 impl ghash::ClMulUnderlier for M128 {
@@ -45,7 +45,8 @@ define_packed_binary_field!(
 	M128,
 	(GhashStrategy),
 	(GhashStrategy),
-	(GhashStrategy)
+	(GhashStrategy),
+	(TrivialWideMul)
 );
 
 // Implement TaggedMul for GhashStrategy
@@ -93,27 +94,6 @@ cfg_if! {
 				Self::from_underlier(M128::from(ghash_square(u128::from(self.to_underlier()))))
 			}
 		}
-	}
-}
-
-// Implement WideMul
-cfg_if! {
-	if #[cfg(target_feature = "pclmulqdq")] {
-		impl WideMul for PackedBinaryGhash1x128b {
-			type Output = ghash::WideGhashProduct<M128>;
-
-			#[inline]
-			fn wide_mul(a: Self, b: Self) -> Self::Output {
-				ghash::WideGhashProduct::wide_mul(a.to_underlier(), b.to_underlier())
-			}
-
-			#[inline]
-			fn reduce(wide: Self::Output) -> Self {
-				Self::from_underlier(wide.reduce())
-			}
-		}
-	} else {
-		crate::arithmetic_traits::impl_trivial_wide_mul!(PackedBinaryGhash1x128b);
 	}
 }
 

--- a/crates/field/src/arch/x86_64/packed_ghash_256.rs
+++ b/crates/field/src/arch/x86_64/packed_ghash_256.rs
@@ -20,9 +20,6 @@ use crate::{
 		impl_square_with,
 	},
 };
-// Only used by the CLMUL-accelerated `WideMul` impl below.
-#[cfg(target_feature = "vpclmulqdq")]
-use crate::{arch::shared::ghash, arithmetic_traits::WideMul};
 // Only used by the element-wise fallback when VPCLMULQDQ is unavailable.
 #[cfg(not(target_feature = "vpclmulqdq"))]
 use crate::{
@@ -33,7 +30,7 @@ use crate::{
 #[cfg(target_feature = "vpclmulqdq")]
 mod vpclmulqdq {
 	use super::*;
-	use crate::arch::shared::ghash::ClMulUnderlier;
+	use crate::arch::x86_64::arithmetic::ghash::ClMulUnderlier;
 
 	impl ClMulUnderlier for M256 {
 		#[inline]
@@ -69,7 +66,7 @@ cfg_if! {
 		impl TaggedMul<Ghash256Strategy> for PackedBinaryGhash2x128b {
 			#[inline]
 			fn mul(self, rhs: Self) -> Self {
-				Self::from_underlier(crate::arch::shared::ghash::mul_clmul(
+				Self::from_underlier(crate::arch::x86_64::arithmetic::ghash::mul_clmul(
 					self.to_underlier(),
 					rhs.to_underlier(),
 				))
@@ -112,7 +109,7 @@ cfg_if! {
 		impl TaggedSquare<Ghash256Strategy> for PackedBinaryGhash2x128b {
 			#[inline]
 			fn square(self) -> Self {
-				Self::from_underlier(crate::arch::shared::ghash::square_clmul(self.to_underlier()))
+				Self::from_underlier(crate::arch::x86_64::arithmetic::ghash::square_clmul(self.to_underlier()))
 			}
 		}
 	} else {

--- a/crates/field/src/arch/x86_64/packed_ghash_256.rs
+++ b/crates/field/src/arch/x86_64/packed_ghash_256.rs
@@ -59,7 +59,8 @@ define_packed_binary_field!(
 	M256,
 	(Ghash256Strategy),
 	(Ghash256Strategy),
-	(Ghash256Strategy)
+	(Ghash256Strategy),
+	(TrivialWideMul)
 );
 
 // Implement TaggedMul for Ghash256Strategy
@@ -133,27 +134,6 @@ cfg_if! {
 				Self::from_underlier(result_underlier)
 			}
 		}
-	}
-}
-
-// Implement WideMul
-cfg_if! {
-	if #[cfg(target_feature = "vpclmulqdq")] {
-		impl WideMul for PackedBinaryGhash2x128b {
-			type Output = ghash::WideGhashProduct<M256>;
-
-			#[inline]
-			fn wide_mul(a: Self, b: Self) -> Self::Output {
-				ghash::WideGhashProduct::wide_mul(a.to_underlier(), b.to_underlier())
-			}
-
-			#[inline]
-			fn reduce(wide: Self::Output) -> Self {
-				Self::from_underlier(wide.reduce())
-			}
-		}
-	} else {
-		crate::arithmetic_traits::impl_trivial_wide_mul!(PackedBinaryGhash2x128b);
 	}
 }
 

--- a/crates/field/src/arch/x86_64/packed_ghash_256.rs
+++ b/crates/field/src/arch/x86_64/packed_ghash_256.rs
@@ -27,6 +27,13 @@ use crate::{
 	underlier::Divisible,
 };
 
+/// Widening-multiply wrapper used by the GHASH packing: the reduction-deferring
+/// `GhashClMulWideMul` when VPCLMULQDQ is available, otherwise an eager `TrivialWideMul`.
+#[cfg(target_feature = "vpclmulqdq")]
+pub type GhashWideMul<T> = crate::arch::x86_64::arithmetic::ghash::GhashClMulWideMul<T>;
+#[cfg(not(target_feature = "vpclmulqdq"))]
+pub type GhashWideMul<T> = TrivialWideMul<T>;
+
 #[cfg(target_feature = "vpclmulqdq")]
 mod vpclmulqdq {
 	use super::*;
@@ -57,7 +64,7 @@ define_packed_binary_field!(
 	(Ghash256Strategy),
 	(Ghash256Strategy),
 	(Ghash256Strategy),
-	(TrivialWideMul)
+	(GhashWideMul)
 );
 
 // Implement TaggedMul for Ghash256Strategy

--- a/crates/field/src/arch/x86_64/packed_ghash_512.rs
+++ b/crates/field/src/arch/x86_64/packed_ghash_512.rs
@@ -10,7 +10,7 @@
 use cfg_if::cfg_if;
 
 use super::m512::M512;
-// Only used by the CLMUL-accelerated `ClMulUnderlier` impl below.
+// Used by the CLMUL-accelerated `ClMulUnderlier` impl and the `GhashWideMul` alias below.
 #[cfg(all(target_feature = "vpclmulqdq", target_feature = "avx512f"))]
 use crate::arch::x86_64::arithmetic::ghash;
 use crate::{
@@ -22,6 +22,14 @@ use crate::{
 	},
 	underlier::Divisible,
 };
+
+/// Widening-multiply wrapper used by the GHASH packing: the reduction-deferring
+/// [`GhashClMulWideMul`](ghash::GhashClMulWideMul) when VPCLMULQDQ + AVX-512 are available,
+/// otherwise an eager [`TrivialWideMul`].
+#[cfg(all(target_feature = "vpclmulqdq", target_feature = "avx512f"))]
+pub type GhashWideMul<T> = ghash::GhashClMulWideMul<T>;
+#[cfg(not(all(target_feature = "vpclmulqdq", target_feature = "avx512f")))]
+pub type GhashWideMul<T> = TrivialWideMul<T>;
 
 #[cfg(all(target_feature = "vpclmulqdq", target_feature = "avx512f"))]
 impl ghash::ClMulUnderlier for M512 {
@@ -53,7 +61,7 @@ define_packed_binary_field!(
 	(Ghash512Strategy),
 	(Ghash512Strategy),
 	(Ghash512Strategy),
-	(TrivialWideMul)
+	(GhashWideMul)
 );
 
 // Implement TaggedMul for Ghash512Strategy

--- a/crates/field/src/arch/x86_64/packed_ghash_512.rs
+++ b/crates/field/src/arch/x86_64/packed_ghash_512.rs
@@ -10,6 +10,9 @@
 use cfg_if::cfg_if;
 
 use super::m512::M512;
+// Only used by the CLMUL-accelerated `ClMulUnderlier` impl below.
+#[cfg(all(target_feature = "vpclmulqdq", target_feature = "avx512f"))]
+use crate::arch::x86_64::arithmetic::ghash;
 use crate::{
 	BinaryField128bGhash,
 	arch::portable::packed_macros::{portable_macros::*, *},
@@ -19,9 +22,6 @@ use crate::{
 	},
 	underlier::Divisible,
 };
-// Only used by the CLMUL-accelerated `ClMulUnderlier` impl below.
-#[cfg(all(target_feature = "vpclmulqdq", target_feature = "avx512f"))]
-use crate::arch::shared::ghash;
 
 #[cfg(all(target_feature = "vpclmulqdq", target_feature = "avx512f"))]
 impl ghash::ClMulUnderlier for M512 {
@@ -62,7 +62,7 @@ cfg_if! {
 		impl TaggedMul<Ghash512Strategy> for PackedBinaryGhash4x128b {
 			#[inline]
 			fn mul(self, rhs: Self) -> Self {
-				Self::from_underlier(crate::arch::shared::ghash::mul_clmul(
+				Self::from_underlier(crate::arch::x86_64::arithmetic::ghash::mul_clmul(
 					self.to_underlier(),
 					rhs.to_underlier(),
 				))
@@ -121,7 +121,7 @@ cfg_if! {
 		impl TaggedSquare<Ghash512Strategy> for PackedBinaryGhash4x128b {
 			#[inline]
 			fn square(self) -> Self {
-				Self::from_underlier(crate::arch::shared::ghash::square_clmul(
+				Self::from_underlier(crate::arch::x86_64::arithmetic::ghash::square_clmul(
 					self.to_underlier(),
 				))
 			}

--- a/crates/field/src/arch/x86_64/packed_ghash_512.rs
+++ b/crates/field/src/arch/x86_64/packed_ghash_512.rs
@@ -19,9 +19,9 @@ use crate::{
 	},
 	underlier::Divisible,
 };
-// Only used by the CLMUL-accelerated `ClMulUnderlier` and `WideMul` impls below.
+// Only used by the CLMUL-accelerated `ClMulUnderlier` impl below.
 #[cfg(all(target_feature = "vpclmulqdq", target_feature = "avx512f"))]
-use crate::{arch::shared::ghash, arithmetic_traits::WideMul};
+use crate::arch::shared::ghash;
 
 #[cfg(all(target_feature = "vpclmulqdq", target_feature = "avx512f"))]
 impl ghash::ClMulUnderlier for M512 {
@@ -52,7 +52,8 @@ define_packed_binary_field!(
 	M512,
 	(Ghash512Strategy),
 	(Ghash512Strategy),
-	(Ghash512Strategy)
+	(Ghash512Strategy),
+	(TrivialWideMul)
 );
 
 // Implement TaggedMul for Ghash512Strategy
@@ -129,27 +130,6 @@ cfg_if! {
 		// Potentially we could use an optimized square implementation here with a scaled underlier.
 		// But this case (an architecture with AVX512 but without VPCLMULQDQ) is pretty rare.
 		impl_square_with!(PackedBinaryGhash4x128b @ crate::arch::ReuseMultiplyStrategy);
-	}
-}
-
-// Implement WideMul
-cfg_if! {
-	if #[cfg(all(target_feature = "vpclmulqdq", target_feature = "avx512f"))] {
-		impl WideMul for PackedBinaryGhash4x128b {
-			type Output = ghash::WideGhashProduct<M512>;
-
-			#[inline]
-			fn wide_mul(a: Self, b: Self) -> Self::Output {
-				ghash::WideGhashProduct::wide_mul(a.to_underlier(), b.to_underlier())
-			}
-
-			#[inline]
-			fn reduce(wide: Self::Output) -> Self {
-				Self::from_underlier(wide.reduce())
-			}
-		}
-	} else {
-		crate::arithmetic_traits::impl_trivial_wide_mul!(PackedBinaryGhash4x128b);
 	}
 }
 

--- a/crates/field/src/arithmetic_traits.rs
+++ b/crates/field/src/arithmetic_traits.rs
@@ -3,8 +3,10 @@
 
 use std::{
 	iter::Sum,
-	ops::{Add, AddAssign, Sub, SubAssign},
+	ops::{Add, AddAssign, Mul, Sub, SubAssign},
 };
+
+use bytemuck::TransparentWrapper;
 
 /// Value that can be multiplied by itself
 pub trait Square {
@@ -37,6 +39,34 @@ pub trait WideMul: Sized {
 
 	fn wide_mul(a: Self, b: Self) -> Self::Output;
 	fn reduce(wide: Self::Output) -> Self;
+}
+
+#[derive(TransparentWrapper)]
+#[repr(transparent)]
+pub struct TrivialWideMul<T>(T);
+
+impl<T> WideMul for TrivialWideMul<T>
+where
+	T: Default
+		+ Clone
+		+ Sum
+		+ Add<Output = T>
+		+ AddAssign
+		+ Sub<Output = T>
+		+ SubAssign
+		+ Mul<Output = T>,
+{
+	type Output = T;
+
+	#[inline]
+	fn wide_mul(a: Self, b: Self) -> T {
+		Self::peel(a) * Self::peel(b)
+	}
+
+	#[inline]
+	fn reduce(wide: T) -> Self {
+		Self::wrap(wide)
+	}
 }
 
 macro_rules! impl_trivial_wide_mul {

--- a/crates/field/src/ghash.rs
+++ b/crates/field/src/ghash.rs
@@ -21,9 +21,9 @@ use super::{
 	extension::ExtensionField,
 };
 use crate::{
-	AESTowerField8b, Divisible, Field, PackedField, WideMul,
+	AESTowerField8b, Field,
 	arch::{M128, invert_b128, packed_ghash_128::PackedBinaryGhash1x128b},
-	arithmetic_traits::{InvertOrZero, Square},
+	arithmetic_traits::{InvertOrZero, Square, impl_trivial_wide_mul},
 	binary_field_arithmetic::{multiple_using_packed, square_using_packed},
 	mul_by_binary_field_1b,
 	underlier::{U1, WithUnderlier},
@@ -46,6 +46,7 @@ impl From<BinaryField128bGhash> for u128 {
 	}
 }
 
+/*
 // Deferred-reduction widening multiply, implemented by reusing the width-1 packed GHASH type. On
 // CLMUL backends `Output` is an unreduced `WideGhashProduct`, so accumulating products reduces
 // only once at the end; on portable backends it falls back to the trivial (eager) multiply.
@@ -65,6 +66,8 @@ impl WideMul for BinaryField128bGhash {
 		PackedBinaryGhash1x128b::reduce(wide).get(0)
 	}
 }
+*/
+impl_trivial_wide_mul!(BinaryField128bGhash);
 
 unsafe impl Pod for BinaryField128bGhash {}
 

--- a/crates/field/src/ghash.rs
+++ b/crates/field/src/ghash.rs
@@ -433,7 +433,7 @@ mod tests {
 	use proptest::{prelude::any, proptest};
 
 	use super::*;
-	use crate::binary_field::tests::is_binary_field_valid_generator;
+	use crate::{WideMul, binary_field::tests::is_binary_field_valid_generator};
 
 	#[test]
 	fn test_ghash_mul() {


### PR DESCRIPTION
## Summary
- Restructure GHASH (GF(2^128)) multiplication into per-arch `arch::{x86_64,aarch64,portable}::arithmetic::ghash` modules, deleting the shared module. x86_64 keeps the `ClMulUnderlier` trait abstracting `M128`/`M256`/`M512` (PCLMULQDQ/VPCLMULQDQ); aarch64 is a concrete `M128`-only PMULL implementation with no trait indirection; portable holds the software implementation.
- Add a `WideMul` widening multiply that **defers** the GHASH modular reduction: products accumulate unreduced (XOR) and are reduced once at the end. Packed GHASH fields forward through a `GhashWideMul` wrapper via the `define_packed_binary_field!` macro.
- Wire the deferring wrapper into the portable, aarch64, and x86_64 packings. On x86_64 the choice is per-underlier and config-dependent: each packed module aliases `GhashWideMul` to the reduction-deferring `GhashClMulWideMul` when its CLMUL feature is present (`pclmulqdq` / `vpclmulqdq` / `vpclmulqdq+avx512f`), else to the eager `TrivialWideMul` — necessary because e.g. `avx2 + pclmulqdq` without `vpclmulqdq` must defer `M128` while `M256` falls back.
- Generalize the portable `GhashWideMul` to any `U: Underlier128bLanes`.

## Test plan
- `cargo test -p binius-field` (default) — 227 pass
- `RUSTFLAGS="-C target-cpu=native" cargo test -p binius-field` — 236 pass
- `cargo clippy -p binius-field --all-features --tests -- -D warnings` (default + native) — clean
- aarch64 (neon+aes) and wasm32 `cargo check` — clean
- Discriminating x86_64 config `+avx2,+pclmulqdq` (no `vpclmulqdq`), where `M128` defers and `M256` falls back in one build — clippy `-D warnings` clean
