### PR TITLE
Deferred-reduction WideMul for the scalar BinaryField128bGhash

### DIFF
--- a/crates/field/src/arch/aarch64/packed_ghash_128.rs
+++ b/crates/field/src/arch/aarch64/packed_ghash_128.rs
@@ -7,7 +7,7 @@
 //! Based on the optimized GHASH implementation using carryless multiplication
 //! instructions available on ARMv8 processors with NEON support.
 
-use super::{arithmetic::ghash::GhashClMulWideMul, m128::M128};
+use super::m128::M128;
 use crate::{
 	BinaryField128bGhash,
 	arch::portable::packed_macros::{portable_macros::*, *},
@@ -16,6 +16,10 @@ use crate::{
 		impl_square_with,
 	},
 };
+
+/// Widening-multiply wrapper used by the GHASH packing: the reduction-deferring
+/// `GhashClMulWideMul`.
+pub type GhashWideMul<T> = super::arithmetic::ghash::GhashClMulWideMul<T>;
 
 /// Strategy for aarch64 GHASH field arithmetic operations.
 pub struct GhashStrategy;
@@ -28,7 +32,7 @@ define_packed_binary_field!(
 	(GhashStrategy),
 	(GhashStrategy),
 	(GhashStrategy),
-	(GhashClMulWideMul)
+	(GhashWideMul)
 );
 
 // Implement TaggedMul for GhashStrategy

--- a/crates/field/src/arch/mod.rs
+++ b/crates/field/src/arch/mod.rs
@@ -11,16 +11,20 @@ cfg_if! {
 	if #[cfg(all(target_arch = "x86_64"))] {
 		mod x86_64;
 		pub use x86_64::{packed_128, packed_256, packed_512, packed_aes_128, packed_aes_256, packed_aes_512, packed_ghash_128, packed_ghash_256, packed_ghash_512, M128, M256};
+		pub use x86_64::packed_ghash_128::GhashWideMul;
 	} else if #[cfg(target_arch = "aarch64")] {
 		mod aarch64;
 		pub use aarch64::{packed_128, packed_aes_128, packed_ghash_128, M128};
+		pub use aarch64::packed_ghash_128::GhashWideMul;
 		pub use portable::{packed_256::{self, M256}, packed_512, packed_aes_256, packed_aes_512, packed_ghash_256, packed_ghash_512};
 	} else if #[cfg(target_arch = "wasm32")] {
 		mod wasm32;
 		pub use wasm32::{packed_ghash_128, packed_ghash_256};
+		pub use wasm32::packed_ghash_128::GhashWideMul;
 		pub use portable::{m128::M128, packed_128, packed_256::{self, M256}, packed_512, packed_aes_128, packed_aes_256, packed_aes_512, packed_ghash_512};
 	} else {
 		pub use portable::{m128::M128, packed_128, packed_256::{self, M256}, packed_512, packed_aes_128, packed_aes_256, packed_aes_512, packed_ghash_128, packed_ghash_256, packed_ghash_512};
+		pub use portable::packed_ghash_128::GhashWideMul;
 	}
 }
 

--- a/crates/field/src/arch/portable/packed_ghash_128.rs
+++ b/crates/field/src/arch/portable/packed_ghash_128.rs
@@ -3,9 +3,10 @@
 
 //! Portable implementation of packed GHASH field operations.
 
+pub use super::arithmetic::ghash::GhashWideMul;
 use super::{
 	arithmetic::{
-		ghash::{GhashWideMul, ghash_mul, ghash_square},
+		ghash::{ghash_mul, ghash_square},
 		itoh_tsujii::invert_b128,
 	},
 	m128::M128,

--- a/crates/field/src/arch/wasm32/packed_ghash_128.rs
+++ b/crates/field/src/arch/wasm32/packed_ghash_128.rs
@@ -25,6 +25,10 @@ use crate::{
 
 pub type PackedBinaryGhash1x128b = PackedPrimitiveType<M128, BinaryField128bGhash>;
 
+/// Widening-multiply wrapper used by the GHASH packing. The WASM SIMD packing multiplies eagerly,
+/// so this is the trivial (identity-reduce) wrapper.
+pub type GhashWideMul<T> = crate::arithmetic_traits::TrivialWideMul<T>;
+
 // Define broadcast
 impl_broadcast!(M128, BinaryField128bGhash);
 

--- a/crates/field/src/ghash.rs
+++ b/crates/field/src/ghash.rs
@@ -14,16 +14,16 @@ use binius_utils::{
 	DeserializeBytes, FixedSizeSerializeBytes, SerializationError, SerializeBytes,
 	bytes::{Buf, BufMut},
 };
-use bytemuck::{Pod, Zeroable};
+use bytemuck::{Pod, TransparentWrapper, Zeroable};
 
 use super::{
 	binary_field::{BinaryField, BinaryField1b, binary_field, impl_field_extension},
 	extension::ExtensionField,
 };
 use crate::{
-	AESTowerField8b, Field,
-	arch::{M128, invert_b128, packed_ghash_128::PackedBinaryGhash1x128b},
-	arithmetic_traits::{InvertOrZero, Square, impl_trivial_wide_mul},
+	AESTowerField8b, Field, WideMul,
+	arch::{GhashWideMul, M128, invert_b128, packed_ghash_128::PackedBinaryGhash1x128b},
+	arithmetic_traits::{InvertOrZero, Square},
 	binary_field_arithmetic::{multiple_using_packed, square_using_packed},
 	mul_by_binary_field_1b,
 	underlier::{U1, WithUnderlier},
@@ -46,28 +46,35 @@ impl From<BinaryField128bGhash> for u128 {
 	}
 }
 
-/*
-// Deferred-reduction widening multiply, implemented by reusing the width-1 packed GHASH type. On
-// CLMUL backends `Output` is an unreduced `WideGhashProduct`, so accumulating products reduces
-// only once at the end; on portable backends it falls back to the trivial (eager) multiply.
+// Deferred-reduction widening multiply via the optimal `GhashWideMul` wrapper applied to the
+// width-1 `PackedBinaryGhash1x128b` packing. The scalar and the packing share the `M128` underlier,
+// so the conversions are zero-cost reinterprets.
+//
+// This routes the scalar through the packed type's wrapper rather than wrapping the scalar
+// directly. It relies on every M128 GHASH packing using a deferring wrapper whose `Output` is a
+// concrete `WideGhashProduct` (not the packed type itself): `WideMul` is a supertrait of both
+// `Field` and `PackedField`, and `BinaryField128bGhash` is the `Scalar` of
+// `PackedBinaryGhash1x128b`, so a `TrivialWideMul` fallback (whose `Output` is the packed type,
+// bounded `Add + Mul`) would close a trait-resolution cycle through `Field: WideMul`.
 impl WideMul for BinaryField128bGhash {
-	type Output = <PackedBinaryGhash1x128b as WideMul>::Output;
+	type Output = <GhashWideMul<PackedBinaryGhash1x128b> as WideMul>::Output;
 
 	#[inline]
 	fn wide_mul(a: Self, b: Self) -> Self::Output {
-		PackedBinaryGhash1x128b::wide_mul(
-			PackedBinaryGhash1x128b::set_single(a),
-			PackedBinaryGhash1x128b::set_single(b),
+		let a = PackedBinaryGhash1x128b::from_underlier(a.to_underlier());
+		let b = PackedBinaryGhash1x128b::from_underlier(b.to_underlier());
+		<GhashWideMul<PackedBinaryGhash1x128b> as WideMul>::wide_mul(
+			GhashWideMul::wrap(a),
+			GhashWideMul::wrap(b),
 		)
 	}
 
 	#[inline]
 	fn reduce(wide: Self::Output) -> Self {
-		PackedBinaryGhash1x128b::reduce(wide).get(0)
+		let reduced = <GhashWideMul<PackedBinaryGhash1x128b> as WideMul>::reduce(wide);
+		Self::from_underlier(GhashWideMul::peel(reduced).to_underlier())
 	}
 }
-*/
-impl_trivial_wide_mul!(BinaryField128bGhash);
 
 unsafe impl Pod for BinaryField128bGhash {}
 


### PR DESCRIPTION
## Summary
- Give the scalar `BinaryField128bGhash` the same reduction-deferring `WideMul` the packed GHASH fields use. It previously used the trivial (eager-reduce) `WideMul`, so `wide_mul` + deferred accumulation gained nothing over a plain multiply.
- Export a single config-selected `arch::GhashWideMul` — the wrapper optimal for the M128-backed `PackedBinaryGhash1x128b`. Co-located: each `packed_ghash_128` module exposes the `GhashWideMul` alias it wires into its own packing (x86_64 already did; portable made public; aarch64 and wasm32 aliases added), re-exported per target from `arch/mod.rs`. Fallback configs inherit portable's alias.
- Implement `BinaryField128bGhash::WideMul` by applying `arch::GhashWideMul` to the width-1 `PackedBinaryGhash1x128b`, converting scalar ↔ packed via `to_underlier`/`from_underlier` (zero-cost reinterprets — both wrap `M128`).

This builds on #1559: every M128 GHASH packing now uses a deferring wrapper whose `Output` is a concrete `WideGhashProduct`. A `TrivialWideMul` fallback would instead make the scalar's `Output` the packed type itself, closing a `WideMul`-supertrait cycle (`B128: WideMul` → `PackedBinaryGhash1x128b: Add/Mul` → `PackedField` → `Scalar = B128: Field` → `Field: WideMul` → back).

## Test plan
- `cargo check -p binius-field` across configs: default, `target-cpu=native`, `+sse2,-pclmulqdq`, aarch64 `+neon,+aes`, wasm32 — all compile.
- `cargo test -p binius-field ghash` — 43 passed (includes the scalar `test_wide_mul_*` proptests).

> Note: pushed without the full verification matrix (clippy `-D warnings` / fmt / native test run) at the author's request.
