### PR TITLE
BINIUS-128: define GHASH multiplication via WideMul

### DIFF
--- a/crates/field/src/arch/aarch64/arithmetic/ghash.rs
+++ b/crates/field/src/arch/aarch64/arithmetic/ghash.rs
@@ -73,26 +73,6 @@ fn gf2_128_shift_reduce(t: M128) -> M128 {
 	result
 }
 
-#[inline]
-pub fn mul_clmul(x: M128, y: M128) -> M128 {
-	// t1a = x.lo * y.hi
-	let t1a = pmull::<0x01>(x, y);
-	// t1b = x.hi * y.lo
-	let t1b = pmull::<0x10>(x, y);
-	// t1 = t1a + t1b (XOR in binary field)
-	let mut t1 = t1a ^ t1b;
-	// t2 = x.hi * y.hi
-	let t2 = pmull::<0x11>(x, y);
-	// Reduce t1 and t2
-	t1 = gf2_128_reduce(t1, t2);
-	// t0 = x.lo * y.lo
-	let mut t0 = pmull::<0x00>(x, y);
-	// Final reduction
-	t0 = gf2_128_reduce(t0, t1);
-
-	t0
-}
-
 /// The version of the multiplication optimized for the square operation.
 #[inline]
 pub fn square_clmul(x: M128) -> M128 {

--- a/crates/field/src/arch/aarch64/packed_ghash_128.rs
+++ b/crates/field/src/arch/aarch64/packed_ghash_128.rs
@@ -10,10 +10,12 @@
 use super::m128::M128;
 use crate::{
 	BinaryField128bGhash,
-	arch::portable::packed_macros::{portable_macros::*, *},
+	arch::{
+		portable::packed_macros::{portable_macros::*, *},
+		strategies::GhashMulStrategy,
+	},
 	arithmetic_traits::{
-		TaggedInvertOrZero, TaggedMul, TaggedSquare, impl_invert_with, impl_mul_with,
-		impl_square_with,
+		TaggedInvertOrZero, TaggedSquare, impl_invert_with, impl_mul_with, impl_square_with,
 	},
 };
 
@@ -29,22 +31,11 @@ define_packed_binary_field!(
 	PackedBinaryGhash1x128b,
 	BinaryField128bGhash,
 	M128,
-	(GhashStrategy),
+	(GhashMulStrategy),
 	(GhashStrategy),
 	(GhashStrategy),
 	(GhashWideMul)
 );
-
-// Implement TaggedMul for GhashStrategy
-impl TaggedMul<GhashStrategy> for PackedBinaryGhash1x128b {
-	#[inline]
-	fn mul(self, rhs: Self) -> Self {
-		Self::from_underlier(super::arithmetic::ghash::mul_clmul(
-			self.to_underlier(),
-			rhs.to_underlier(),
-		))
-	}
-}
 
 // Implement TaggedSquare for GhashStrategy
 impl TaggedSquare<GhashStrategy> for PackedBinaryGhash1x128b {

--- a/crates/field/src/arch/portable/arithmetic/ghash_scaled.rs
+++ b/crates/field/src/arch/portable/arithmetic/ghash_scaled.rs
@@ -1,0 +1,142 @@
+// Copyright 2026 The Binius Developers
+
+//! Scaled deferred-reduction GHASH widening multiply for multi-lane packings.
+//!
+//! A 256- or 512-bit GHASH packing is a vector of independent 128-bit GHASH elements. When no
+//! wide-vector carryless multiply is available (e.g. no VPCLMULQDQ, or the portable build), the
+//! widening multiply is built by applying the width-1 GHASH [`WideMul`] — itself CLMUL-accelerated
+//! when possible, portable schoolbook otherwise — to each 128-bit lane. This keeps every GHASH
+//! packing on a *deferring* `WideMul` (never the eager `TrivialWideMul`), so a sum of products
+//! reduces once per lane at the end.
+//!
+//! [`ScaledGhashWideMul`] is the wrapper passed as the `wide_mul` strategy of the packing macro. A
+//! single generic [`WideMul`] impl covers every multi-lane packing — both the portable
+//! `ScaledUnderlier` packings and the x86_64 SIMD `M256`/`M512` ones — by splitting the underlier
+//! into its 128-bit lanes via [`Divisible`]. The const parameter `N` is the lane count, which must
+//! equal `<U as Divisible<M128>>::N` for the underlying packed type.
+
+use std::{
+	array,
+	iter::Sum,
+	ops::{Add, AddAssign, Sub, SubAssign},
+};
+
+use bytemuck::TransparentWrapper;
+
+use crate::{
+	BinaryField,
+	arch::{M128, PackedPrimitiveType},
+	arithmetic_traits::WideMul,
+	underlier::{Divisible, UnderlierType},
+};
+
+/// The unreduced product of a multi-lane GHASH packing: one independent width-1 widening product
+/// per 128-bit lane. Lanes accumulate and reduce independently, mirroring the packing's structure.
+/// The const parameter `N` is the lane count.
+#[derive(Clone, Copy, Debug)]
+pub struct ScaledWideGhashProduct<O, const N: usize>([O; N]);
+
+impl<O: Copy + Default, const N: usize> Default for ScaledWideGhashProduct<O, N> {
+	#[inline]
+	fn default() -> Self {
+		Self([O::default(); N])
+	}
+}
+
+impl<O: Copy + Add<Output = O>, const N: usize> Add for ScaledWideGhashProduct<O, N> {
+	type Output = Self;
+
+	#[inline]
+	fn add(self, rhs: Self) -> Self {
+		Self(array::from_fn(|i| self.0[i] + rhs.0[i]))
+	}
+}
+
+impl<O: Copy + Add<Output = O>, const N: usize> AddAssign for ScaledWideGhashProduct<O, N> {
+	#[inline]
+	fn add_assign(&mut self, rhs: Self) {
+		*self = *self + rhs;
+	}
+}
+
+impl<O: Copy + Sub<Output = O>, const N: usize> Sub for ScaledWideGhashProduct<O, N> {
+	type Output = Self;
+
+	#[inline]
+	fn sub(self, rhs: Self) -> Self {
+		Self(array::from_fn(|i| self.0[i] - rhs.0[i]))
+	}
+}
+
+impl<O: Copy + Sub<Output = O>, const N: usize> SubAssign for ScaledWideGhashProduct<O, N> {
+	#[inline]
+	fn sub_assign(&mut self, rhs: Self) {
+		*self = *self - rhs;
+	}
+}
+
+impl<O: Copy + Default + Add<Output = O>, const N: usize> Sum for ScaledWideGhashProduct<O, N> {
+	#[inline]
+	fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+		iter.fold(Self::default(), |acc, x| acc + x)
+	}
+}
+
+/// Widening-multiply wrapper for a multi-lane GHASH packing, applying the width-1 GHASH `WideMul`
+/// to each 128-bit lane of the packing's underlier. The const parameter `N` is the number of
+/// 128-bit lanes and must equal `<U as Divisible<M128>>::N` for the packed type's underlier.
+///
+/// Use the lane-count aliases [`Scaled2xGhashWideMul`] and [`Scaled4xGhashWideMul`] to avoid
+/// repeating the const argument at each call site.
+#[derive(TransparentWrapper)]
+#[repr(transparent)]
+pub struct ScaledGhashWideMul<T, const N: usize>(pub T);
+
+/// The width-1 GHASH packing for the active arch's 128-bit underlier — the per-lane field whose
+/// `WideMul` (CLMUL-accelerated or portable schoolbook) drives each lane.
+type Lane<Scalar> = PackedPrimitiveType<M128, Scalar>;
+
+impl<U, Scalar, const N: usize> WideMul for ScaledGhashWideMul<PackedPrimitiveType<U, Scalar>, N>
+where
+	U: UnderlierType + Divisible<M128>,
+	Scalar: BinaryField,
+	Lane<Scalar>: WideMul,
+	<Lane<Scalar> as WideMul>::Output: Copy + Default,
+{
+	type Output = ScaledWideGhashProduct<<Lane<Scalar> as WideMul>::Output, N>;
+
+	#[inline]
+	fn wide_mul(a: Self, b: Self) -> Self::Output {
+		debug_assert_eq!(N, <U as Divisible<M128>>::N, "N must equal Divisible<M128>::N");
+
+		let a = Self::peel(a).to_underlier();
+		let b = Self::peel(b).to_underlier();
+
+		let mut out = [<Lane<Scalar> as WideMul>::Output::default(); N];
+		for (slot, (lhs, rhs)) in out
+			.iter_mut()
+			.zip(<U as Divisible<M128>>::value_iter(a).zip(<U as Divisible<M128>>::value_iter(b)))
+		{
+			*slot = <Lane<Scalar>>::wide_mul(
+				Lane::<Scalar>::from_underlier(lhs),
+				Lane::<Scalar>::from_underlier(rhs),
+			);
+		}
+		ScaledWideGhashProduct(out)
+	}
+
+	#[inline]
+	fn reduce(wide: Self::Output) -> Self {
+		let lanes = wide
+			.0
+			.into_iter()
+			.map(|product| <Lane<Scalar> as WideMul>::reduce(product).to_underlier());
+		Self::wrap(PackedPrimitiveType::from_underlier(<U as Divisible<M128>>::from_iter(lanes)))
+	}
+}
+
+/// Convenience alias for the 2-lane (256-bit) scaled GHASH widening multiply.
+pub type Scaled2xGhashWideMul<T> = ScaledGhashWideMul<T, 2>;
+
+/// Convenience alias for the 4-lane (512-bit) scaled GHASH widening multiply.
+pub type Scaled4xGhashWideMul<T> = ScaledGhashWideMul<T, 4>;

--- a/crates/field/src/arch/portable/arithmetic/mod.rs
+++ b/crates/field/src/arch/portable/arithmetic/mod.rs
@@ -1,4 +1,5 @@
 // Copyright 2026 The Binius Developers
 
 pub mod ghash;
+pub mod ghash_scaled;
 pub mod itoh_tsujii;

--- a/crates/field/src/arch/portable/packed_ghash_128.rs
+++ b/crates/field/src/arch/portable/packed_ghash_128.rs
@@ -5,16 +5,16 @@
 
 pub use super::arithmetic::ghash::GhashWideMul;
 use super::{
-	arithmetic::{
-		ghash::{ghash_mul, ghash_square},
-		itoh_tsujii::invert_b128,
-	},
+	arithmetic::{ghash::ghash_square, itoh_tsujii::invert_b128},
 	m128::M128,
 	univariate_mul_utils_128::{Underlier128bLanes, spread_bits_64},
 };
 use crate::{
-	arch::portable::packed_macros::{portable_macros::*, *},
-	arithmetic_traits::{TaggedInvertOrZero, TaggedMul, TaggedSquare},
+	arch::{
+		portable::packed_macros::{portable_macros::*, *},
+		strategies::GhashMulStrategy,
+	},
+	arithmetic_traits::{TaggedInvertOrZero, TaggedSquare},
 	ghash::BinaryField128bGhash,
 };
 
@@ -51,18 +51,11 @@ define_packed_binary_field!(
 	PackedBinaryGhash1x128b,
 	BinaryField128bGhash,
 	M128,
-	(GhashStrategy),
+	(GhashMulStrategy),
 	(GhashStrategy),
 	(GhashStrategy),
 	(GhashWideMul)
 );
-
-impl TaggedMul<GhashStrategy> for PackedBinaryGhash1x128b {
-	#[inline]
-	fn mul(self, rhs: Self) -> Self {
-		ghash_mul(self.0, rhs.0).into()
-	}
-}
 
 impl TaggedSquare<GhashStrategy> for PackedBinaryGhash1x128b {
 	#[inline]

--- a/crates/field/src/arch/portable/packed_ghash_256.rs
+++ b/crates/field/src/arch/portable/packed_ghash_256.rs
@@ -2,10 +2,11 @@
 // Copyright 2026 The Binius Developers
 
 use super::{
+	arithmetic::ghash_scaled::Scaled2xGhashWideMul,
 	packed_256::M256,
 	packed_macros::{portable_macros::*, *},
 };
-use crate::arch::strategies::ScaledStrategy;
+use crate::arch::strategies::{GhashMulStrategy, ScaledStrategy};
 
 define_packed_binary_fields!(
 	underlier: M256,
@@ -13,10 +14,10 @@ define_packed_binary_fields!(
 		packed_field {
 			name: PackedBinaryGhash2x128b,
 			scalar: BinaryField128bGhash,
-			mul:       (ScaledStrategy),
+			mul:       (GhashMulStrategy),
 			square:    (ScaledStrategy),
 			invert:    (ScaledStrategy),
-			wide_mul: (TrivialWideMul),
+			wide_mul: (Scaled2xGhashWideMul),
 		},
 	]
 );

--- a/crates/field/src/arch/portable/packed_ghash_512.rs
+++ b/crates/field/src/arch/portable/packed_ghash_512.rs
@@ -2,10 +2,11 @@
 // Copyright 2026 The Binius Developers
 
 use super::{
+	arithmetic::ghash_scaled::Scaled4xGhashWideMul,
 	packed_512::M512,
 	packed_macros::{portable_macros::*, *},
 };
-use crate::arch::strategies::ScaledStrategy;
+use crate::arch::strategies::{GhashMulStrategy, ScaledStrategy};
 
 define_packed_binary_fields!(
 	underlier: M512,
@@ -13,10 +14,10 @@ define_packed_binary_fields!(
 		packed_field {
 			name: PackedBinaryGhash4x128b,
 			scalar: BinaryField128bGhash,
-			mul:       (ScaledStrategy),
+			mul:       (GhashMulStrategy),
 			square:    (ScaledStrategy),
 			invert:    (ScaledStrategy),
-			wide_mul: (TrivialWideMul),
+			wide_mul: (Scaled4xGhashWideMul),
 		},
 	]
 );

--- a/crates/field/src/arch/strategies.rs
+++ b/crates/field/src/arch/strategies.rs
@@ -1,4 +1,7 @@
 // Copyright 2024-2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
+
+use crate::arithmetic_traits::{TaggedMul, WideMul};
 
 /// Packed strategy for arithmetic operations.
 /// (Uses arithmetic operations with underlier and subfield to simultaneously calculate the result
@@ -25,3 +28,15 @@ pub struct BitwiseAndStrategy;
 
 /// Strategy for ScaledUnderlier operations that delegate to sub-underlier operations.
 pub struct ScaledStrategy;
+
+/// Strategy that defines multiplication as `reduce(wide_mul(a, b))`, deferring to the type's own
+/// [`WideMul`] impl. Used by every GHASH packing so the (CLMUL-accelerated or scaled) widening
+/// multiply is the single source of truth for both `Mul` and `WideMul`.
+pub struct GhashMulStrategy;
+
+impl<P: WideMul> TaggedMul<GhashMulStrategy> for P {
+	#[inline]
+	fn mul(self, rhs: Self) -> Self {
+		P::reduce(P::wide_mul(self, rhs))
+	}
+}

--- a/crates/field/src/arch/wasm32/packed_ghash_128.rs
+++ b/crates/field/src/arch/wasm32/packed_ghash_128.rs
@@ -9,36 +9,38 @@
 
 use std::{arch::wasm32::*, ops::Mul};
 
+use bytemuck::TransparentWrapper;
+
 use super::{super::portable::packed::PackedPrimitiveType, m128::M128};
 use crate::{
 	BinaryField128bGhash,
 	arch::{
 		PairwiseStrategy,
 		portable::{
-			arithmetic::ghash::ghash_mul,
 			packed_macros::impl_broadcast,
 			univariate_mul_utils_128::{Underlier128bLanes, spread_bits_64},
 		},
 	},
-	arithmetic_traits::{InvertOrZero, Square, impl_transformation_with_strategy},
+	arithmetic_traits::{InvertOrZero, Square, WideMul, impl_transformation_with_strategy},
 };
 
 pub type PackedBinaryGhash1x128b = PackedPrimitiveType<M128, BinaryField128bGhash>;
 
-/// Widening-multiply wrapper used by the GHASH packing. The WASM SIMD packing multiplies eagerly,
-/// so this is the trivial (identity-reduce) wrapper.
-pub type GhashWideMul<T> = crate::arithmetic_traits::TrivialWideMul<T>;
+/// Widening-multiply wrapper used by the GHASH packing: the reduction-deferring portable
+/// [`GhashWideMul`](crate::arch::portable::arithmetic::ghash::GhashWideMul). The WASM SIMD `M128`
+/// implements [`Underlier128bLanes`], so the portable schoolbook widening multiply applies.
+pub type GhashWideMul<T> = crate::arch::portable::arithmetic::ghash::GhashWideMul<T>;
 
 // Define broadcast
 impl_broadcast!(M128, BinaryField128bGhash);
 
-// Define multiply
+// Define multiply as `reduce(wide_mul)`, deferring to the widening multiply below.
 impl Mul for PackedBinaryGhash1x128b {
 	type Output = Self;
 
 	#[inline]
 	fn mul(self, rhs: Self) -> Self::Output {
-		Self::from_underlier(ghash_mul(self.0, rhs.0))
+		Self::reduce(Self::wide_mul(self, rhs))
 	}
 }
 
@@ -85,8 +87,20 @@ impl InvertOrZero for PackedBinaryGhash1x128b {
 	}
 }
 
-// Implement WideMul (trivial: no CLMUL, just regular multiply)
-crate::arithmetic_traits::impl_trivial_wide_mul!(PackedBinaryGhash1x128b);
+// Implement the deferring widening multiply via the portable `GhashWideMul` wrapper.
+impl WideMul for PackedBinaryGhash1x128b {
+	type Output = <GhashWideMul<Self> as WideMul>::Output;
+
+	#[inline]
+	fn wide_mul(a: Self, b: Self) -> Self::Output {
+		<GhashWideMul<Self> as WideMul>::wide_mul(GhashWideMul::wrap(a), GhashWideMul::wrap(b))
+	}
+
+	#[inline]
+	fn reduce(wide: Self::Output) -> Self {
+		GhashWideMul::peel(<GhashWideMul<Self> as WideMul>::reduce(wide))
+	}
+}
 
 // Define linear transformations
 impl_transformation_with_strategy!(PackedBinaryGhash1x128b, PairwiseStrategy);

--- a/crates/field/src/arch/x86_64/arithmetic/ghash.rs
+++ b/crates/field/src/arch/x86_64/arithmetic/ghash.rs
@@ -33,35 +33,6 @@ pub trait ClMulUnderlier: UnderlierType + Divisible<u128> {
 	fn move_64_to_hi(a: Self) -> Self;
 }
 
-#[inline]
-pub fn mul_clmul<U: ClMulUnderlier>(x: U, y: U) -> U {
-	// Based on the C++ reference implementation
-	// The algorithm performs polynomial multiplication followed by reduction
-
-	// t1a = x.lo * y.hi
-	let t1a = U::clmulepi64::<0x01>(x, y);
-
-	// t1b = x.hi * y.lo
-	let t1b = U::clmulepi64::<0x10>(x, y);
-
-	// t1 = t1a + t1b (XOR in binary field)
-	let mut t1 = t1a ^ t1b;
-
-	// t2 = x.hi * y.hi
-	let t2 = U::clmulepi64::<0x11>(x, y);
-
-	// Reduce t1 and t2
-	t1 = gf2_128_reduce(t1, t2);
-
-	// t0 = x.lo * y.lo
-	let mut t0 = U::clmulepi64::<0x00>(x, y);
-
-	// Final reduction
-	t0 = gf2_128_reduce(t0, t1);
-
-	t0
-}
-
 /// The version of the multiplication for optimized suqare operation.
 #[inline]
 pub fn square_clmul<U: ClMulUnderlier>(x: U) -> U {

--- a/crates/field/src/arch/x86_64/packed_ghash_128.rs
+++ b/crates/field/src/arch/x86_64/packed_ghash_128.rs
@@ -17,10 +17,12 @@ use crate::arch::portable::univariate_mul_utils_128::{Underlier128bLanes, spread
 use crate::arch::x86_64::arithmetic::ghash;
 use crate::{
 	BinaryField128bGhash,
-	arch::portable::packed_macros::{portable_macros::*, *},
+	arch::{
+		portable::packed_macros::{portable_macros::*, *},
+		strategies::GhashMulStrategy,
+	},
 	arithmetic_traits::{
-		TaggedInvertOrZero, TaggedMul, TaggedSquare, impl_invert_with, impl_mul_with,
-		impl_square_with,
+		TaggedInvertOrZero, TaggedSquare, impl_invert_with, impl_mul_with, impl_square_with,
 	},
 };
 
@@ -84,35 +86,11 @@ define_packed_binary_field!(
 	PackedBinaryGhash1x128b,
 	BinaryField128bGhash,
 	M128,
-	(GhashStrategy),
+	(GhashMulStrategy),
 	(GhashStrategy),
 	(GhashStrategy),
 	(GhashWideMul)
 );
-
-// Implement TaggedMul for GhashStrategy
-cfg_if! {
-	if #[cfg(target_feature = "pclmulqdq")] {
-		impl TaggedMul<GhashStrategy> for PackedBinaryGhash1x128b {
-			#[inline]
-			fn mul(self, rhs: Self) -> Self {
-				Self::from_underlier(crate::arch::x86_64::arithmetic::ghash::mul_clmul(
-					self.to_underlier(),
-					rhs.to_underlier(),
-				))
-			}
-		}
-	} else {
-		impl TaggedMul<GhashStrategy> for PackedBinaryGhash1x128b {
-			#[inline]
-			fn mul(self, rhs: Self) -> Self {
-				use super::super::portable::arithmetic::ghash::ghash_mul;
-
-				Self::from_underlier(ghash_mul(self.to_underlier(), rhs.to_underlier()))
-			}
-		}
-	}
-}
 
 // Implement TaggedSquare for GhashStrategy
 cfg_if! {

--- a/crates/field/src/arch/x86_64/packed_ghash_256.rs
+++ b/crates/field/src/arch/x86_64/packed_ghash_256.rs
@@ -13,26 +13,30 @@ use crate::{
 	BinaryField128bGhash,
 	arch::{
 		portable::packed_macros::{portable_macros::*, *},
+		strategies::GhashMulStrategy,
 		x86_64::m256::M256,
 	},
 	arithmetic_traits::{
-		TaggedInvertOrZero, TaggedMul, TaggedSquare, impl_invert_with, impl_mul_with,
-		impl_square_with,
+		TaggedInvertOrZero, TaggedSquare, impl_invert_with, impl_mul_with, impl_square_with,
 	},
 };
-// Only used by the element-wise fallback when VPCLMULQDQ is unavailable.
+// Only used by the element-wise square fallback when VPCLMULQDQ is unavailable.
 #[cfg(not(target_feature = "vpclmulqdq"))]
 use crate::{
-	arch::x86_64::{m128::M128, packed_ghash_128::PackedBinaryGhash1x128b},
+	arch::{
+		portable::arithmetic::ghash_scaled::Scaled2xGhashWideMul,
+		x86_64::{m128::M128, packed_ghash_128::PackedBinaryGhash1x128b},
+	},
 	underlier::Divisible,
 };
 
-/// Widening-multiply wrapper used by the GHASH packing: the reduction-deferring
-/// `GhashClMulWideMul` when VPCLMULQDQ is available, otherwise an eager `TrivialWideMul`.
+/// Widening-multiply wrapper used by the GHASH packing: the reduction-deferring vectorized
+/// `GhashClMulWideMul` when VPCLMULQDQ is available, otherwise the per-lane `ScaledGhashWideMul`
+/// (which still defers reduction, applying the width-1 GHASH `WideMul` to each 128-bit lane).
 #[cfg(target_feature = "vpclmulqdq")]
 pub type GhashWideMul<T> = crate::arch::x86_64::arithmetic::ghash::GhashClMulWideMul<T>;
 #[cfg(not(target_feature = "vpclmulqdq"))]
-pub type GhashWideMul<T> = TrivialWideMul<T>;
+pub type GhashWideMul<T> = Scaled2xGhashWideMul<T>;
 
 #[cfg(target_feature = "vpclmulqdq")]
 mod vpclmulqdq {
@@ -61,54 +65,11 @@ define_packed_binary_field!(
 	PackedBinaryGhash2x128b,
 	BinaryField128bGhash,
 	M256,
-	(Ghash256Strategy),
+	(GhashMulStrategy),
 	(Ghash256Strategy),
 	(Ghash256Strategy),
 	(GhashWideMul)
 );
-
-// Implement TaggedMul for Ghash256Strategy
-cfg_if! {
-	if #[cfg(target_feature = "vpclmulqdq")] {
-		impl TaggedMul<Ghash256Strategy> for PackedBinaryGhash2x128b {
-			#[inline]
-			fn mul(self, rhs: Self) -> Self {
-				Self::from_underlier(crate::arch::x86_64::arithmetic::ghash::mul_clmul(
-					self.to_underlier(),
-					rhs.to_underlier(),
-				))
-			}
-		}
-	} else {
-		impl TaggedMul<Ghash256Strategy> for PackedBinaryGhash2x128b {
-			#[inline]
-			fn mul(self, rhs: Self) -> Self {
-				// Fallback: perform scalar multiplication on each 128-bit element
-				let mut result_underlier = self.to_underlier();
-				unsafe {
-					let self_0 = Divisible::<M128>::get_unchecked(&self.to_underlier(), 0);
-					let self_1 = Divisible::<M128>::get_unchecked(&self.to_underlier(), 1);
-					let rhs_0 = Divisible::<M128>::get_unchecked(&rhs.to_underlier(), 0);
-					let rhs_1 = Divisible::<M128>::get_unchecked(&rhs.to_underlier(), 1);
-
-					let result_0 = std::ops::Mul::mul(
-						PackedBinaryGhash1x128b::from(self_0),
-						PackedBinaryGhash1x128b::from(rhs_0),
-					);
-					let result_1 = std::ops::Mul::mul(
-						PackedBinaryGhash1x128b::from(self_1),
-						PackedBinaryGhash1x128b::from(rhs_1),
-					);
-
-					Divisible::<M128>::set_unchecked(&mut result_underlier, 0, result_0.to_underlier());
-					Divisible::<M128>::set_unchecked(&mut result_underlier, 1, result_1.to_underlier());
-				}
-
-				Self::from_underlier(result_underlier)
-			}
-		}
-	}
-}
 
 // Implement TaggedSquare for Ghash256Strategy
 cfg_if! {

--- a/crates/field/src/arch/x86_64/packed_ghash_512.rs
+++ b/crates/field/src/arch/x86_64/packed_ghash_512.rs
@@ -10,26 +10,30 @@
 use cfg_if::cfg_if;
 
 use super::m512::M512;
+#[cfg(not(all(target_feature = "vpclmulqdq", target_feature = "avx512f")))]
+use crate::arch::portable::arithmetic::ghash_scaled::Scaled4xGhashWideMul;
 // Used by the CLMUL-accelerated `ClMulUnderlier` impl and the `GhashWideMul` alias below.
 #[cfg(all(target_feature = "vpclmulqdq", target_feature = "avx512f"))]
 use crate::arch::x86_64::arithmetic::ghash;
 use crate::{
 	BinaryField128bGhash,
-	arch::portable::packed_macros::{portable_macros::*, *},
-	arithmetic_traits::{
-		TaggedInvertOrZero, TaggedMul, TaggedSquare, impl_invert_with, impl_mul_with,
-		impl_square_with,
+	arch::{
+		portable::packed_macros::{portable_macros::*, *},
+		strategies::GhashMulStrategy,
 	},
-	underlier::Divisible,
+	arithmetic_traits::{
+		TaggedInvertOrZero, TaggedSquare, impl_invert_with, impl_mul_with, impl_square_with,
+	},
 };
 
-/// Widening-multiply wrapper used by the GHASH packing: the reduction-deferring
+/// Widening-multiply wrapper used by the GHASH packing: the reduction-deferring vectorized
 /// [`GhashClMulWideMul`](ghash::GhashClMulWideMul) when VPCLMULQDQ + AVX-512 are available,
-/// otherwise an eager [`TrivialWideMul`].
+/// otherwise the per-lane [`ScaledGhashWideMul`] (still deferring, applying the width-1 GHASH
+/// `WideMul` to each 128-bit lane).
 #[cfg(all(target_feature = "vpclmulqdq", target_feature = "avx512f"))]
 pub type GhashWideMul<T> = ghash::GhashClMulWideMul<T>;
 #[cfg(not(all(target_feature = "vpclmulqdq", target_feature = "avx512f")))]
-pub type GhashWideMul<T> = TrivialWideMul<T>;
+pub type GhashWideMul<T> = Scaled4xGhashWideMul<T>;
 
 #[cfg(all(target_feature = "vpclmulqdq", target_feature = "avx512f"))]
 impl ghash::ClMulUnderlier for M512 {
@@ -58,70 +62,11 @@ define_packed_binary_field!(
 	PackedBinaryGhash4x128b,
 	BinaryField128bGhash,
 	M512,
-	(Ghash512Strategy),
+	(GhashMulStrategy),
 	(Ghash512Strategy),
 	(Ghash512Strategy),
 	(GhashWideMul)
 );
-
-// Implement TaggedMul for Ghash512Strategy
-cfg_if! {
-	if #[cfg(all(target_feature = "vpclmulqdq", target_feature = "avx512f"))] {
-		impl TaggedMul<Ghash512Strategy> for PackedBinaryGhash4x128b {
-			#[inline]
-			fn mul(self, rhs: Self) -> Self {
-				Self::from_underlier(crate::arch::x86_64::arithmetic::ghash::mul_clmul(
-					self.to_underlier(),
-					rhs.to_underlier(),
-				))
-			}
-		}
-	} else {
-		impl TaggedMul<Ghash512Strategy> for PackedBinaryGhash4x128b {
-			#[inline]
-			fn mul(self, rhs: Self) -> Self {
-				// Fallback: perform scalar multiplication on each 128-bit element
-				let mut result_underlier = self.to_underlier();
-				unsafe {
-					let self_0 = Divisible::<u128>::get_unchecked(&self.to_underlier(), 0);
-					let self_1 = Divisible::<u128>::get_unchecked(&self.to_underlier(), 1);
-					let self_2 = Divisible::<u128>::get_unchecked(&self.to_underlier(), 2);
-					let self_3 = Divisible::<u128>::get_unchecked(&self.to_underlier(), 3);
-					let rhs_0 = Divisible::<u128>::get_unchecked(&rhs.to_underlier(), 0);
-					let rhs_1 = Divisible::<u128>::get_unchecked(&rhs.to_underlier(), 1);
-					let rhs_2 = Divisible::<u128>::get_unchecked(&rhs.to_underlier(), 2);
-					let rhs_3 = Divisible::<u128>::get_unchecked(&rhs.to_underlier(), 3);
-
-					// Use the portable scalar multiplication for each element
-					use super::super::portable::packed_ghash_128::PackedBinaryGhash1x128b as PortablePackedBinaryGhash1x128b;
-					let result_0 = std::ops::Mul::mul(
-						PortablePackedBinaryGhash1x128b::from(self_0),
-						PortablePackedBinaryGhash1x128b::from(rhs_0),
-					);
-					let result_1 = std::ops::Mul::mul(
-						PortablePackedBinaryGhash1x128b::from(self_1),
-						PortablePackedBinaryGhash1x128b::from(rhs_1),
-					);
-					let result_2 = std::ops::Mul::mul(
-						PortablePackedBinaryGhash1x128b::from(self_2),
-						PortablePackedBinaryGhash1x128b::from(rhs_2),
-					);
-					let result_3 = std::ops::Mul::mul(
-						PortablePackedBinaryGhash1x128b::from(self_3),
-						PortablePackedBinaryGhash1x128b::from(rhs_3),
-					);
-
-					Divisible::<u128>::set_unchecked(&mut result_underlier, 0, result_0.to_underlier());
-					Divisible::<u128>::set_unchecked(&mut result_underlier, 1, result_1.to_underlier());
-					Divisible::<u128>::set_unchecked(&mut result_underlier, 2, result_2.to_underlier());
-					Divisible::<u128>::set_unchecked(&mut result_underlier, 3, result_3.to_underlier());
-				}
-
-				Self::from_underlier(result_underlier)
-			}
-		}
-	}
-}
 
 // Implement TaggedSquare for Ghash512Strategy
 cfg_if! {

--- a/crates/field/src/ghash.rs
+++ b/crates/field/src/ghash.rs
@@ -24,7 +24,7 @@ use crate::{
 	AESTowerField8b, Field, WideMul,
 	arch::{GhashWideMul, M128, invert_b128, packed_ghash_128::PackedBinaryGhash1x128b},
 	arithmetic_traits::{InvertOrZero, Square},
-	binary_field_arithmetic::{multiple_using_packed, square_using_packed},
+	binary_field_arithmetic::square_using_packed,
 	mul_by_binary_field_1b,
 	underlier::{U1, WithUnderlier},
 };
@@ -118,15 +118,16 @@ impl BinaryField128bGhash {
 	}
 }
 
-// Cannot use `impl_arithmetic_using_packed!` because `PackedSubfield<Self, Self>` resolves
-// via `Underlier = u128`, but on SIMD targets `PackedBinaryGhash1x128b` uses `M128`.
+// Multiplication is `reduce(wide_mul)`, deferring to the scalar's own `WideMul` impl above (which
+// routes through the optimal `GhashWideMul` packing). This keeps the widening multiply as the
+// single source of truth for both `Mul` and `WideMul`.
 impl Mul<BinaryField128bGhash> for BinaryField128bGhash {
 	type Output = Self;
 
 	#[inline]
 	fn mul(self, rhs: Self) -> Self {
 		crate::tracing::trace_multiplication!(BinaryField128bGhash);
-		multiple_using_packed::<PackedBinaryGhash1x128b>(self, rhs)
+		Self::reduce(Self::wide_mul(self, rhs))
 	}
 }
 


### PR DESCRIPTION
Defines multiplication for every GHASH packing (and the `BinaryField128bGhash` scalar) as `reduce(wide_mul)`, so the widening multiply is the single source of truth for both `Mul` and `WideMul` ([BINIUS-128](https://linear.app/jimpo/issue/BINIUS-128)). Builds on #1560 (scalar `WideMul`).

## What changed

- **`GhashMulStrategy`** (`arch/strategies.rs`): a blanket `impl<P: WideMul> TaggedMul<GhashMulStrategy> for P` computing `reduce(wide_mul(a, b))`. Every GHASH packing now passes `mul: (GhashMulStrategy)` to the packing macro (the macro itself is unchanged). The bespoke per-arch `TaggedMul` impls and the now-redundant `mul_clmul` (x86_64 + aarch64 arithmetic modules) are deleted.

- **No more `TrivialWideMul` on any GHASH packing.** The multi-lane fallbacks (portable 256/512, and the non-VPCLMULQDQ x86_64 256/512 paths) now use a new deferring **`ScaledGhashWideMul`** (`arch/portable/arithmetic/ghash_scaled.rs`): it splits the packing into 128-bit lanes via `Divisible<M128>` and applies the width-1 GHASH `WideMul` per lane — CLMUL-accelerated where available, portable schoolbook otherwise. The vectorized VPCLMULQDQ 256/512 path keeps `GhashClMulWideMul` (does both/all lanes in parallel — faster than splitting).

- **wasm32** width-1 GHASH switches from `TrivialWideMul` to the portable deferring `GhashWideMul` (its SIMD `M128` already implements `Underlier128bLanes`).

- **Scalar `BinaryField128bGhash::mul`** is now `Self::reduce(Self::wide_mul(self, rhs))`.

## Behavior-preserving

`reduce(wide_mul)` is algorithmically identical to the old fused `mul_clmul` (same 4 multiply + 2 reduction CLMULs, same reduction order); the scaled fallback reproduces the old per-lane element-wise multiply exactly. Verified against the scalar reference by the existing proptests.

## Verification

- `cargo test -p binius-field --lib` native (236 passed) — covers 128 CLMUL, 256 vectorized `reduce(wide_mul)`, and 512 **scaled fallback** (this CPU has pclmulqdq+vpclmulqdq+avx2 but no avx512f).
- Same with all CLMUL features disabled (227 passed) — covers portable-128 + scaled-256/512 via the portable width-1 field.
- Cross-compile matrix (per `CONTRIBUTING.md`): aarch64 `+neon,+aes`; x86_64 `+pclmulqdq`, `+avx2,+vpclmulqdq`, `+avx512f,+vpclmulqdq`, and full portable fallback; wasm32-wasip1 / wasm32-unknown-unknown — all clean.
- `cargo clippy -p binius-field` on both the CLMUL and portable paths, `cargo +nightly-2026-01-01 fmt --check`, `cargo doc -D warnings`, and a full `cargo build --workspace` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)