### PR TITLE
BINIUS-114: switch multilinears to the monomial (infinity hypercube) basis

### DIFF
--- a/crates/ip-prover/src/sumcheck/batch_quadratic_mle.rs
+++ b/crates/ip-prover/src/sumcheck/batch_quadratic_mle.rs
@@ -200,11 +200,10 @@ where
 						let lo_i = splits_0_chunk[i].as_ref()[idx];
 						let hi_i = splits_1_chunk[i].as_ref()[idx];
 
-						// Compose once with the high half and once with the lo+hi combination.
-						// The lo+hi branch corresponds to evaluation at infinity for
-						// multilinears.
-						evals_1[i] = hi_i;
-						evals_inf[i] = lo_i + hi_i;
+						// Monomial basis: the two halves are the coefficients `[c0, c1]`, so
+						// `M(1) = c0 + c1` (lo + hi) and `M(∞) = c1` (hi, the leading coefficient).
+						evals_1[i] = lo_i + hi_i;
+						evals_inf[i] = hi_i;
 					}
 
 					// Apply the compositions for this equality term.

--- a/crates/ip-prover/src/sumcheck/bivariate_product.rs
+++ b/crates/ip-prover/src/sumcheck/bivariate_product.rs
@@ -75,13 +75,15 @@ impl<F: Field, P: PackedField<Scalar = F>> SumcheckProver<F> for BivariateProduc
 			(evals_a_0.as_ref(), evals_a_1.as_ref(), evals_b_0.as_ref(), evals_b_1.as_ref())
 				.into_par_iter()
 				.map(|(&evals_a_0_i, &evals_a_1_i, &evals_b_0_i, &evals_b_1_i)| {
-					// Evaluate M(∞) = M(0) + M(1)
-					let evals_a_inf_i = evals_a_0_i + evals_a_1_i;
-					let evals_b_inf_i = evals_b_0_i + evals_b_1_i;
+					// Monomial basis: the two halves are the coefficients `[c0, c1]` of the
+					// highest variable's polynomial, so `M(1) = c0 + c1` and `M(∞) = c1` (the
+					// high half / leading coefficient).
+					let evals_a_1_val = evals_a_0_i + evals_a_1_i;
+					let evals_b_1_val = evals_b_0_i + evals_b_1_i;
 
 					WideRoundEvals2 {
-						y_1: P::wide_mul(evals_a_1_i, evals_b_1_i),
-						y_inf: P::wide_mul(evals_a_inf_i, evals_b_inf_i),
+						y_1: P::wide_mul(evals_a_1_val, evals_b_1_val),
+						y_inf: P::wide_mul(evals_a_1_i, evals_b_1_i),
 					}
 				})
 				.reduce(WideRoundEvals2::default, |lhs, rhs| lhs + rhs);

--- a/crates/ip-prover/src/sumcheck/bivariate_product_multi_mle.rs
+++ b/crates/ip-prover/src/sumcheck/bivariate_product_multi_mle.rs
@@ -125,14 +125,16 @@ where
 							evals_a_1_chunk.as_ref(),
 							evals_b_1_chunk.as_ref()
 						) {
-							let evals_a_inf_i = evals_a_0_i + evals_a_1_i;
-							let evals_b_inf_i = evals_b_0_i + evals_b_1_i;
+							// Monomial basis: halves are coeffs `[c0, c1]`, so `M(1) = c0 + c1`
+							// (lo + hi) and `M(∞) = c1` (hi, the leading coefficient).
+							let evals_a_1_val = evals_a_0_i + evals_a_1_i;
+							let evals_b_1_val = evals_b_0_i + evals_b_1_i;
 
 							// The final multiply (by `evals_b_*_i`) of each product is accumulated
 							// in unreduced (wide) form; the wide accumulators persist across the
 							// whole fold and are reduced a single time at the end.
-							round_evals.y_1 += P::wide_mul(eq_i * evals_a_1_i, evals_b_1_i);
-							round_evals.y_inf += P::wide_mul(eq_i * evals_a_inf_i, evals_b_inf_i);
+							round_evals.y_1 += P::wide_mul(eq_i * evals_a_1_val, evals_b_1_val);
+							round_evals.y_inf += P::wide_mul(eq_i * evals_a_1_i, evals_b_1_i);
 						}
 					}
 

--- a/crates/ip-prover/src/sumcheck/multilinear_eval.rs
+++ b/crates/ip-prover/src/sumcheck/multilinear_eval.rs
@@ -84,14 +84,14 @@ impl<F: Field, P: PackedField<Scalar = F>> SumcheckProver<F> for MultilinearEval
 		// The eq expansion is over the lower `n_vars_remaining - 1` variables; the top (X = 1) half
 		// of the witness is the partial specialization of the highest variable at 1.
 		let eq_expansion = self.gruen32.eq_expansion();
-		let (_evals_0, evals_1) = self.witness.split_half_ref();
+		let (evals_0, evals_1) = self.witness.split_half_ref();
 		debug_assert_eq!(eq_expansion.log_len(), evals_1.log_len());
 
-		// R(1) = <M(.., X = 1), eq(.., z)>, the multilinear evaluation of the top half.
+		// R(1) = <M(.., X = 1), eq(.., z)>. Monomial basis: M(1) = c0 + c1 (the lo + hi halves).
 		// The products are accumulated in unreduced (wide) form and reduced once at the end.
-		let wide_y_1 = (evals_1.as_ref(), eq_expansion.as_ref())
+		let wide_y_1 = (evals_0.as_ref(), evals_1.as_ref(), eq_expansion.as_ref())
 			.into_par_iter()
-			.map(|(&evals_1_i, &eq_i)| P::wide_mul(evals_1_i, eq_i))
+			.map(|(&evals_0_i, &evals_1_i, &eq_i)| P::wide_mul(evals_0_i + evals_1_i, eq_i))
 			.reduce(<P as WideMul>::Output::default, |lhs, rhs| lhs + rhs);
 		let round_evals = RoundEvals1 {
 			y_1: P::reduce(wide_y_1),

--- a/crates/ip-prover/src/sumcheck/quadratic_mle.rs
+++ b/crates/ip-prover/src/sumcheck/quadratic_mle.rs
@@ -176,8 +176,10 @@ where
 				let mut evals_1 = [P::default(); N];
 				let mut evals_inf = [P::default(); N];
 				for j in 0..N {
-					evals_1[j] = splits_1[j].as_ref()[i];
-					evals_inf[j] = splits_0[j].as_ref()[i] + splits_1[j].as_ref()[i];
+					// Monomial basis: the two halves are coeffs `[c0, c1]`, so `M(1) = c0 + c1`
+					// and `M(∞) = c1` (the high half / leading coefficient).
+					evals_1[j] = splits_0[j].as_ref()[i] + splits_1[j].as_ref()[i];
+					evals_inf[j] = splits_1[j].as_ref()[i];
 				}
 
 				WideRoundEvals2 {
@@ -281,6 +283,60 @@ mod tests {
 	use super::*;
 	use crate::sumcheck::prove_single_mlecheck;
 
+	/// Computes the MLE-check claimed value in the monomial basis: the composite
+	/// `F = C(M_1, ..., M_N)` summed over the infinity hypercube and eq-weighted at `point`.
+	///
+	/// Equivalently `evaluate(F_proj, point)`, where `F_proj[v]` is `F` evaluated at the
+	/// infinity-hypercube vertex `v` (the coordinate is `∞` where `v`'s bit is set and `0`
+	/// otherwise). The recursion projects the top variable: its `0`-branch keeps the full
+	/// `composition`; its `∞`-branch keeps only the leading-degree part `infinity_composition`,
+	/// which is its own leading part on the remaining variables.
+	///
+	/// This is the basis-correct replacement for `evaluate(composition(coefficients), point)`,
+	/// which only agrees for homogeneous compositions.
+	fn composite_infinity_eval<F, P, const N: usize>(
+		multilinears: &[FieldBuffer<P>; N],
+		composition: impl Fn([P; N]) -> P,
+		infinity_composition: impl Fn([P; N]) -> P,
+		point: &[F],
+	) -> F
+	where
+		F: Field,
+		P: PackedField<Scalar = F>,
+	{
+		fn scalar<F: Field, P: PackedField<Scalar = F>, const N: usize>(
+			c: &impl Fn([P; N]) -> P,
+			vals: [F; N],
+		) -> F {
+			c(vals.map(P::broadcast)).iter().next().unwrap()
+		}
+		fn proj<F: Field, const N: usize>(
+			mls: [Vec<F>; N],
+			n: usize,
+			comp: &dyn Fn([F; N]) -> F,
+			inf: &dyn Fn([F; N]) -> F,
+		) -> Vec<F> {
+			if n == 0 {
+				return vec![comp(array::from_fn(|j| mls[j][0]))];
+			}
+			let half = 1usize << (n - 1);
+			let los: [Vec<F>; N] = array::from_fn(|j| mls[j][..half].to_vec());
+			let his: [Vec<F>; N] = array::from_fn(|j| mls[j][half..].to_vec());
+			let mut table = proj(los, n - 1, comp, inf);
+			// The ∞-branch keeps only the leading part, which is homogeneous, so it is its own
+			// leading part on deeper variables.
+			table.extend(proj(his, n - 1, inf, inf));
+			table
+		}
+
+		let n = point.len();
+		let coeffs: [Vec<F>; N] = array::from_fn(|j| multilinears[j].iter_scalars().collect());
+		let comp = |vals: [F; N]| scalar(&composition, vals);
+		let inf = |vals: [F; N]| scalar(&infinity_composition, vals);
+		let table = proj(coeffs, n, &comp, &inf);
+		evaluate(&FieldBuffer::<P>::from_values(&table), point)
+	}
+
 	fn test_mlecheck_prove_verify<F, P, Composition, InfinityComposition, const N: usize>(
 		prover: QuadraticMleCheckProver<P, Composition, InfinityComposition, N>,
 		composition: Composition,
@@ -354,17 +410,15 @@ mod tests {
 		// Generate random multilinear polynomials
 		let multilinears: [_; N] = array::from_fn(|_| random_field_buffer::<P>(&mut rng, n_vars));
 
-		// Compute product multilinear
-		let composite_vals = (0..1 << n_vars.saturating_sub(P::LOG_WIDTH))
-			.map(|i| {
-				let vals = array::from_fn(|j| multilinears[j].as_ref()[i]);
-				composition(vals)
-			})
-			.collect_vec();
-		let composite_vals = FieldBuffer::new(n_vars, composite_vals);
-
 		let eval_point = random_scalars::<F>(&mut rng, n_vars);
-		let eval_claim = evaluate(&composite_vals, &eval_point);
+		// Monomial basis: the claim is the composite summed over the infinity hypercube, not the
+		// multilinear extension of `composition(coefficients)`.
+		let eval_claim = composite_infinity_eval(
+			&multilinears,
+			&composition,
+			&infinity_composition,
+			&eval_point,
+		);
 
 		// Create the prover
 		let mlecheck_prover = QuadraticMleCheckProver::new(

--- a/crates/ip-prover/src/sumcheck/quadratic_mle.rs
+++ b/crates/ip-prover/src/sumcheck/quadratic_mle.rs
@@ -281,7 +281,10 @@ mod tests {
 	use rand::prelude::*;
 
 	use super::*;
-	use crate::sumcheck::prove_single_mlecheck;
+	use crate::{
+		channel::IPProverChannel,
+		sumcheck::{multilinear_eval::MultilinearEvalProver, prove_single_mlecheck},
+	};
 
 	/// Computes the MLE-check claimed value in the monomial basis: the composite
 	/// `F = C(M_1, ..., M_N)` summed over the infinity hypercube and eq-weighted at `point`.
@@ -511,5 +514,188 @@ mod tests {
 			expected = round.iter().map(|r| r.evaluate(challenge)).collect();
 			prover.fold(challenge).unwrap();
 		}
+	}
+
+	// EXPERIMENT (BINIUS-114): can the non-homogeneous mul-gate composite `A*B - C` be proven by
+	// SPLITTING the prover into a quadratic prover for the homogeneous product `A*B` and a separate
+	// prover for the multilinear `C`, batched with hardcoded weights `+1` / `-1`, while leaving the
+	// verifier as the unchanged single degree-2 `mlecheck::verify`?
+	//
+	// `make_c_prover` builds the `C` sub-prover (its framing varies across experiments) and
+	// `claim_c` chooses how `C`'s claim is computed. Returns `Ok(())` on a full verify, or `Err`
+	// describing the first inconsistency, so the driver can tabulate outcomes instead of
+	// panicking.
+	fn run_split_mul_gate_experiment<F, P, CProver>(
+		n_vars: usize,
+		claim_c: ClaimC,
+		make_c_prover: impl FnOnce(FieldBuffer<P>, Vec<F>, F) -> CProver,
+	) -> Result<(), String>
+	where
+		F: Field,
+		P: PackedField<Scalar = F>,
+		CProver: SumcheckProver<F>,
+	{
+		let mut rng = StdRng::seed_from_u64(0);
+
+		let multilinears: [FieldBuffer<P>; 3] =
+			array::from_fn(|_| random_field_buffer::<P>(&mut rng, n_vars));
+		let eval_point = random_scalars::<F>(&mut rng, n_vars);
+
+		let ab_multilinears = [multilinears[0].clone(), multilinears[1].clone()];
+		let claim_ab = composite_infinity_eval(
+			&ab_multilinears,
+			|[a, b]: [P; 2]| a * b,
+			|[a, b]: [P; 2]| a * b,
+			&eval_point,
+		);
+		// Two candidate claims for the `C` term:
+		// - `Eval`: the standalone monomial-basis multilinear evaluation `evaluate(C, point)`,
+		//   which is what `MultilinearEvalProver` proves. It includes `C`'s mass at every infinity
+		//   vertex.
+		// - `ConstCoeff`: `C`'s contribution *inside the degree-2 composite*, i.e. its
+		//   leading-degree-2 part summed over the infinity hypercube — `composite_infinity_eval(C,
+		//   inf = 0)`, which collapses to the constant coefficient `c[0]`. This is the value the
+		//   single quadratic prover (and `composite_infinity_eval(a*b - c, a*b)`) implicitly uses
+		//   for `-C`.
+		let claim_c_val = match claim_c {
+			ClaimC::Eval => evaluate(&multilinears[2], &eval_point),
+			ClaimC::ConstCoeff => composite_infinity_eval(
+				&[multilinears[2].clone()],
+				|[c]: [P; 1]| c,
+				|[_c]: [P; 1]| P::zero(),
+				&eval_point,
+			),
+		};
+
+		// Hardcoded batch weights: `A*B - C` (the two coincide in characteristic 2, written out
+		// anyway).
+		let weight_ab = F::ONE;
+		let weight_c = -F::ONE;
+		let verifier_claim = weight_ab * claim_ab + weight_c * claim_c_val;
+
+		let mut ab_prover = QuadraticMleCheckProver::new(
+			ab_multilinears,
+			|[a, b]: [P; 2]| a * b,
+			|[a, b]: [P; 2]| a * b,
+			eval_point.clone(),
+			claim_ab,
+		)
+		.unwrap();
+		let mut c_prover = make_c_prover(multilinears[2].clone(), eval_point.clone(), claim_c_val);
+
+		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
+		for _ in 0..n_vars {
+			let ab_round = ab_prover.execute().unwrap();
+			let c_round = c_prover.execute().unwrap();
+			// batched(X) = 1 * R_{A*B}(X) + (-1) * R_C(X). `RoundCoeffs` addition zero-pads the
+			// shorter polynomial, so a lower-degree `R_C` contributes only to the low
+			// coefficients and the degree-2 leading coefficient comes entirely from `R_{A*B}`.
+			let batched = ab_round[0].clone() * weight_ab + &(c_round[0].clone() * weight_c);
+			prover_transcript.send_many(mlecheck::RoundProof::truncate(batched).coeffs());
+			let challenge = prover_transcript.sample();
+			ab_prover.fold(challenge).unwrap();
+			c_prover.fold(challenge).unwrap();
+		}
+
+		let ab_evals = ab_prover.finish().unwrap();
+		let c_evals = c_prover.finish().unwrap();
+		let multilinear_evals = vec![ab_evals[0], ab_evals[1], c_evals[0]];
+		prover_transcript.message().write_slice(&multilinear_evals);
+
+		let mut verifier_transcript = prover_transcript.into_verifier();
+		let sumcheck_output =
+			mlecheck::verify(&eval_point, 2, verifier_claim, &mut verifier_transcript).unwrap();
+		let verifier_evals: Vec<F> = verifier_transcript.message().read_vec(3).unwrap();
+
+		let [a, b, c] = [verifier_evals[0], verifier_evals[1], verifier_evals[2]];
+		if a * b - c != sumcheck_output.eval {
+			return Err(format!("composite A*B - C != reduced eval (n_vars={n_vars})"));
+		}
+		let mut reduced_eval_point = sumcheck_output.challenges.clone();
+		reduced_eval_point.reverse();
+		for (multilinear, &claimed) in iter::zip(&multilinears, &verifier_evals) {
+			if evaluate(multilinear, &reduced_eval_point) != claimed {
+				return Err(format!("multilinear eval mismatch (n_vars={n_vars})"));
+			}
+		}
+		Ok(())
+	}
+
+	#[derive(Clone, Copy)]
+	enum ClaimC {
+		Eval,
+		ConstCoeff,
+	}
+
+	// Tabulates the split experiment across `C`-prover framings, claim choices, and sizes. Each row
+	// prints PASS/FAIL so the protocol-level conclusion is visible in the test output. The asserts
+	// at the end encode the empirically-observed conclusion.
+	#[test]
+	fn test_split_mul_gate_experiment_matrix() {
+		type P = OptimalPackedB128;
+		let sizes = [1usize, 2, 3, 8];
+
+		let eval_deg1 = |n, claim| {
+			run_split_mul_gate_experiment::<_, P, _>(n, claim, |witness, point, claim_val| {
+				MultilinearEvalProver::new(witness, &point, claim_val).unwrap()
+			})
+		};
+		let eval_deg2 = |n, claim| {
+			run_split_mul_gate_experiment::<_, P, _>(n, claim, |witness, point, claim_val| {
+				QuadraticMleCheckProver::new(
+					[witness],
+					|[c]: [P; 1]| c,
+					|[_c]: [P; 1]| P::zero(),
+					point,
+					claim_val,
+				)
+				.unwrap()
+			})
+		};
+
+		let print_row =
+			|name: &str, claim: ClaimC, run: &dyn Fn(usize, ClaimC) -> Result<(), String>| {
+				let claim_name = match claim {
+					ClaimC::Eval => "claim_C=evaluate(C)",
+					ClaimC::ConstCoeff => "claim_C=c[0]      ",
+				};
+				let results: Vec<String> = sizes
+					.iter()
+					.map(|&n| match run(n, claim) {
+						Ok(()) => format!("n={n}:PASS"),
+						Err(_) => format!("n={n}:FAIL"),
+					})
+					.collect();
+				println!("{name:32} | {claim_name} | {}", results.join("  "));
+			};
+
+		for claim in [ClaimC::Eval, ClaimC::ConstCoeff] {
+			print_row("MultilinearEvalProver (deg1)", claim, &eval_deg1);
+			print_row("QuadraticMleCheckProver  (deg2)", claim, &eval_deg2);
+		}
+
+		// Empirical conclusion (see printed matrix): under the UNCHANGED degree-2 verifier, no
+		// (framing, claim) combination proves `A*B - C` across multiple rounds. The only passing
+		// cells are single-round (`n_vars=1`), where there is no infinity-mass to carry between
+		// rounds.
+		//
+		// - deg2 framing + `claim_C=c[0]` reproduces the single quadratic prover exactly: it
+		//   carries the right claim but breaks for `n>=2` (the multi-round `-C` handling, the
+		//   original bug).
+		// - deg1 framing (`MultilinearEvalProver`) + `claim_C=evaluate(C)` proves the correct
+		//   standalone `C` claim, but that claim over-counts `C`'s infinity-vertex mass relative to
+		//   the degree-2 composite, and the degree-2 verifier's single `∞` slot cannot carry it —
+		//   fails even at n=1.
+		let passes_multiround = |run: &dyn Fn(usize, ClaimC) -> Result<(), String>, claim| {
+			[2usize, 3, 8].iter().all(|&n| run(n, claim).is_ok())
+		};
+		assert!(
+			!passes_multiround(&eval_deg1, ClaimC::Eval),
+			"deg1 + evaluate(C) unexpectedly verified across rounds"
+		);
+		assert!(
+			!passes_multiround(&eval_deg2, ClaimC::ConstCoeff),
+			"deg2 + c[0] unexpectedly verified across rounds"
+		);
 	}
 }

--- a/crates/ip-prover/src/sumcheck/round_evals.rs
+++ b/crates/ip-prover/src/sumcheck/round_evals.rs
@@ -74,16 +74,17 @@ impl<P: PackedField> RoundEvals2<P> {
 impl<F: Field> RoundEvals2<F> {
 	// Regular degree-2 interpolation routine.
 	pub fn interpolate(self, sum: F) -> RoundCoeffs<F> {
-		// Computing evaluation at 0 from sum claim and evaluation on 1.
-		let y_0 = sum - self.y_1;
+		// Monomial basis: the sumcheck claim is `sum = R(0) + R(∞)`, where `R(∞)` is the leading
+		// coefficient `y_inf`. So `R(0) = sum - R(∞)`.
+		let y_0 = sum - self.y_inf;
 		calculate_round_coeffs_from_evals_2(y_0, self.y_1, self.y_inf)
 	}
 
 	// Interpolation routine for evaluations on P'(x) in Mlechecks.
 	pub fn interpolate_eq(self, sum: F, alpha: F) -> RoundCoeffs<F> {
-		// We are given a sum claim on prime polynomial from the previous round, we also know that
-		//  sum = (1 - alpha) * P'(0) + alpha * P'(1)
-		let y_0 = (sum - self.y_1 * alpha) * (F::ONE - alpha).invert_or_zero();
+		// Monomial basis: the MLE-check claim is `sum = P'(0) + alpha * P'(∞)`, where `P'(∞)` is
+		// the leading coefficient `y_inf`. So `P'(0) = sum - alpha * P'(∞)` — no inversion needed.
+		let y_0 = sum - self.y_inf * alpha;
 		calculate_round_coeffs_from_evals_2(y_0, self.y_1, self.y_inf)
 	}
 }
@@ -189,15 +190,11 @@ fn calculate_round_coeffs_from_evals_2<F: Field>(y_0: F, y_1: F, y_inf: F) -> Ro
 	RoundCoeffs(vec![c_0, c_1, c_2])
 }
 
-// Multiplication of a polynomial in monomial form by eq(x, alpha).
+// Multiplication of a polynomial in monomial form by the monomial-basis eq indicator eq(α, X).
 pub fn round_coeffs_by_eq<F: Field>(prime: &RoundCoeffs<F>, alpha: F) -> RoundCoeffs<F> {
-	// eq(X, α) = (1 − α) + (2 α − 1) X
-	// NB: In characteristic 2, this expression can be simplified to 1 + α + challenge.
-	let (prime_by_constant_term, mut prime_by_linear_term) = if F::CHARACTERISTIC == 2 {
-		(prime.clone() * (F::ONE + alpha), prime.clone())
-	} else {
-		(prime.clone() * (F::ONE - alpha), prime.clone() * (alpha.double() - F::ONE))
-	};
+	// Monomial basis: eq̃(α, X) = 1 + α X, so prime · eq̃ = prime + α · (X · prime).
+	let prime_by_constant_term = prime.clone();
+	let mut prime_by_linear_term = prime.clone() * alpha;
 
 	prime_by_linear_term.0.insert(0, F::ZERO); // Multiply prime polynomial by X
 	prime_by_constant_term + &prime_by_linear_term

--- a/crates/ip-prover/src/sumcheck/selector_mle.rs
+++ b/crates/ip-prover/src/sumcheck/selector_mle.rs
@@ -179,14 +179,16 @@ where
 							selector_0_chunk.as_ref(),
 							selector_1_chunk.as_ref(),
 						) {
-							let selected_inf_i = selected_0_i + selected_1_i;
-							let selector_inf_i = selector_0_i + selector_1_i;
+							// Monomial basis: halves are coeffs `[c0, c1]`, so `M(1) = c0 + c1`
+							// (lo + hi) and `M(∞) = c1` (hi, the leading coefficient).
+							let selected_1_val = selected_0_i + selected_1_i;
+							let selector_1_val = selector_0_i + selector_1_i;
 
 							// selected * selector + (1 - selector)
 							// @one: selector * (selected - 1) + 1
 							// @inf: selector * selected (note that lower degree terms are dropped)
-							let y_1_prod = selector_1_i * (selected_1_i - P::one()) + P::one();
-							let y_inf_prod = selector_inf_i * selected_inf_i;
+							let y_1_prod = selector_1_val * (selected_1_val - P::one()) + P::one();
+							let y_inf_prod = selector_1_i * selected_1_i;
 							chunk_wide.y_1 += P::wide_mul(eq_i, y_1_prod);
 							chunk_wide.y_inf += P::wide_mul(eq_i, y_inf_prod);
 						}

--- a/crates/ip/src/mlecheck.rs
+++ b/crates/ip/src/mlecheck.rs
@@ -186,20 +186,21 @@ impl<F> RoundProof<F> {
 	/// Let $s$ denote the current round's claimed sum and $\alpha_i$ be the $i$'th coordinate of
 	/// the evaluation point.
 	///
-	/// The verifier expects the round polynomial $R_i$ to satisfy the identity
-	/// $s = (1 - \alpha) R(0) + \alpha R(1)$, or equivalently, $s = R(0) + (R(1) - R(0)) \alpha$.
+	/// In the monomial basis the verifier expects the round polynomial $R_i$ to satisfy the
+	/// identity $s = R(0) + \alpha R(\infty)$, where $R(\infty)$ is the leading coefficient $a_d$.
 	///
 	/// Using
 	///     $R(0) = a_0$
-	///     $R(1) = \sum_{j=0}^d a_j$
+	///     $R(\infty) = a_d$
 	/// There is a unique $a_0$ that allows $R$ to satisfy the above identity. Specifically,
-	/// $a_0 = s - \alpha \sum_{j=1}^d a_j$.
+	/// $a_0 = s - \alpha a_d$.
 	pub fn recover(self, eval: F, alpha: F) -> RoundCoeffs<F>
 	where
 		F: FieldOps,
 	{
 		let Self(RoundCoeffs(mut coeffs)) = self;
-		let first_coeff = eval - alpha * coeffs.iter().cloned().sum::<F>();
+		let leading = coeffs.last().cloned().unwrap_or_else(F::zero);
+		let first_coeff = eval - alpha * leading;
 		coeffs.insert(0, first_coeff);
 		RoundCoeffs(coeffs)
 	}
@@ -253,7 +254,7 @@ pub fn libra_eval<F: FieldOps>(
 #[cfg(test)]
 mod tests {
 	use binius_field::{Random, arch::OptimalB128 as B128};
-	use binius_math::{line::extrapolate_line_packed, test_utils::random_scalars};
+	use binius_math::test_utils::random_scalars;
 	use rand::prelude::*;
 
 	use super::*;
@@ -261,9 +262,11 @@ mod tests {
 	fn test_recover_with_degree<F: Field>(mut rng: impl Rng, alpha: F, degree: usize) {
 		let coeffs = RoundCoeffs(random_scalars(&mut rng, degree + 1));
 
+		// Monomial-basis MLE-check identity: eval = R(0) + alpha * R(∞), where R(∞) is the
+		// leading coefficient.
 		let v0 = coeffs.evaluate(F::ZERO);
-		let v1 = coeffs.evaluate(F::ONE);
-		let eval = extrapolate_line_packed(v0, v1, alpha);
+		let leading = coeffs.0.last().copied().unwrap_or(F::ZERO);
+		let eval = v0 + alpha * leading;
 
 		let proof = RoundProof::truncate(coeffs.clone());
 		assert_eq!(proof.recover(eval, alpha), coeffs);
@@ -274,7 +277,9 @@ mod tests {
 		let mut rng = StdRng::seed_from_u64(0);
 		let alpha = B128::random(&mut rng);
 
-		for degree in 0..4 {
+		// Degree must be positive: only then are R(0) and the leading coefficient R(∞) distinct
+		// coefficients, so truncating R(0) and recovering it from R(∞) is well-defined.
+		for degree in 1..4 {
 			// Test with random coordinate
 			test_recover_with_degree(&mut rng, alpha, degree);
 

--- a/crates/ip/src/sumcheck/common.rs
+++ b/crates/ip/src/sumcheck/common.rs
@@ -27,29 +27,29 @@ impl<F: FieldOps> RoundCoeffs<F> {
 }
 
 impl<F: Field> RoundCoeffs<F> {
-	/// The claimed sum $R(0) + R(1)$ that this round polynomial encodes.
+	/// The claimed sum $R(0) + R(\infty)$ that this round polynomial encodes.
 	///
 	/// For a sumcheck round polynomial, this is the round's claimed sum: the verifier expects the
-	/// identity $s = R(0) + R(1)$ (see [`RoundProof::recover`]). Note $R(0)$ is the constant
-	/// coefficient and $R(1)$ is the sum of all coefficients.
+	/// identity $s = R(0) + R(\infty)$ (see [`RoundProof::recover`]). Note $R(0)$ is the constant
+	/// coefficient and $R(\infty)$ is the leading (highest-degree) coefficient — the sum runs over
+	/// the infinity hypercube $\{0, \infty\}$.
 	pub fn sum_over_endpoints(&self) -> F {
 		let r_0 = self.0.first().copied().unwrap_or(F::ZERO);
-		let r_1: F = self.0.iter().copied().sum();
-		r_0 + r_1
+		let r_inf = self.0.last().copied().unwrap_or(F::ZERO);
+		r_0 + r_inf
 	}
 
-	/// The claimed value $(1 - \alpha) R(0) + \alpha R(1)$ that this round polynomial encodes in an
+	/// The claimed value $R(0) + \alpha R(\infty)$ that this round polynomial encodes in an
 	/// MLE-check.
 	///
-	/// This is the MLE-check analogue of [`Self::sum_over_endpoints`]: an MLE-check round
-	/// polynomial satisfies the identity $s = (1 - \alpha) R(0) + \alpha R(1)$, where $\alpha$ is
-	/// the round's evaluation-point coordinate (see [`crate::mlecheck::RoundProof::recover`]).
-	/// Equivalently, this is the linear extrapolation of $R$ from the endpoints $0$ and $1$ to the
-	/// point $\alpha$.
+	/// This is the MLE-check analogue of [`Self::sum_over_endpoints`]: in the monomial basis an
+	/// MLE-check round polynomial satisfies the identity $s = R(0) + \alpha R(\infty)$, where
+	/// $\alpha$ is the round's evaluation-point coordinate and $R(\infty)$ is the leading
+	/// coefficient (see [`crate::mlecheck::RoundProof::recover`]).
 	pub fn lerp_over_endpoints(&self, alpha: F) -> F {
 		let r_0 = self.0.first().copied().unwrap_or(F::ZERO);
-		let r_1: F = self.0.iter().copied().sum();
-		r_0 + alpha * (r_1 - r_0)
+		let r_inf = self.0.last().copied().unwrap_or(F::ZERO);
+		r_0 + alpha * r_inf
 	}
 }
 
@@ -108,9 +108,9 @@ impl<F> Index<usize> for RoundCoeffs<F> {
 /// A sumcheck round proof is a univariate polynomial in monomial basis with the coefficient of the
 /// highest-degree term truncated off.
 ///
-/// Since the verifier knows the claimed sum of the polynomial values at the points 0 and 1, the
-/// high-degree term coefficient can be easily recovered. Truncating the coefficient off saves a
-/// small amount of proof data.
+/// Since the verifier knows the claimed sum $R(0) + R(\infty)$ of the polynomial, and $R(\infty)$
+/// is itself the high-degree coefficient, that coefficient can be easily recovered. Truncating the
+/// coefficient off saves a small amount of proof data.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct RoundProof<F>(pub RoundCoeffs<F>);
 
@@ -131,13 +131,14 @@ impl<F: FieldOps> RoundProof<F> {
 	///
 	/// Let $s$ denote the current round's claimed sum.
 	/// The verifier expects the round polynomial $r_i$ to satisfy the identity
-	/// $s = r_i(0) + r_i(1)$.
+	/// $s = r_i(0) + r_i(\infty)$, where the sum runs over the infinity hypercube and
+	/// $r_i(\infty)$ is the leading coefficient $a_d$.
 	/// Using
 	///     $r_i(0) = a_0$
-	///     $r_i(1) = \sum_{j=0}^d a_j$
+	///     $r_i(\infty) = a_d$
 	/// There is a unique $a_d$ that allows $r_i$ to satisfy the above identity.
 	/// Specifically
-	///     $a_d = s - a_0 - \sum_{j=0}^{d-1} a_j$
+	///     $a_d = s - a_0$
 	///
 	/// Not sending the whole round polynomial is an optimization.
 	/// In the unoptimized version of the protocol, the verifier will halt and reject
@@ -148,7 +149,7 @@ impl<F: FieldOps> RoundProof<F> {
 	{
 		let Self(RoundCoeffs(mut coeffs)) = self;
 		let first_coeff = coeffs.first().cloned().unwrap_or_else(F::zero);
-		let last_coeff = sum - first_coeff - coeffs.iter().cloned().sum::<F>();
+		let last_coeff = sum - first_coeff;
 		coeffs.push(last_coeff);
 		RoundCoeffs(coeffs)
 	}

--- a/crates/math/src/multilinear/eq.rs
+++ b/crates/math/src/multilinear/eq.rs
@@ -29,7 +29,8 @@ use crate::FieldBuffer;
 ///
 /// # Formal Definition
 /// `values` is updated to contain the result of:
-/// $v \otimes (1 - r_0, r_0) \otimes \ldots \otimes (1 - r_{k-1}, r_{k-1})$
+/// $v \otimes (1, r_0) \otimes \ldots \otimes (1, r_{k-1})$
+/// (the monomial-basis eq indicator factors)
 /// which is now a vector of length $2^{n+k}$. If 2^{n+k} < P::WIDTH, then
 /// the result is packed into a single element of `values` where only the first
 /// 2^{n+k} elements have meaning.
@@ -61,9 +62,9 @@ fn tensor_prod_eq_ind<P: PackedField, Data: DerefMut<Target = [P]>>(
 		(lo.as_mut(), hi.as_mut())
 			.into_par_iter()
 			.for_each(|(lo_i, hi_i)| {
-				let prod = (*lo_i) * packed_r_i;
-				*lo_i -= prod;
-				*hi_i = prod;
+				// Monomial basis: the tensor factor is `(1, r_i)`, so the low half (the constant
+				// monomial coefficient) is unchanged and the high half is `lo * r_i`.
+				*hi_i = (*lo_i) * packed_r_i;
 			});
 	}
 }
@@ -73,7 +74,7 @@ fn tensor_prod_eq_ind<P: PackedField, Data: DerefMut<Target = [P]>>(
 /// # Formal definition
 /// This differs from `tensor_prod_eq_ind` in tensor product being applied on the left
 /// and in reversed order:
-/// $(1 - r_{k-1}, r_{k-1}) \otimes \ldots \otimes (1 - r_0, r_0) \otimes v$
+/// $(1, r_{k-1}) \otimes \ldots \otimes (1, r_0) \otimes v$
 ///
 /// # Implementation
 /// This operation is inplace, singlethreaded, and not very optimized. Main intent is to
@@ -98,7 +99,8 @@ pub fn tensor_prod_eq_ind_prepend<P: PackedField, Data: DerefMut<Target = [P]>>(
 		values.zero_extend(values.log_len() + 1);
 		for i in (0..values.len() / 2).rev() {
 			let eval = get_packed_slice(values.as_ref(), i);
-			set_packed_slice(values.as_mut(), 2 * i, eval * (P::Scalar::ONE - r_i));
+			// Monomial basis: factor `(1, r_i)` — low half unchanged, high half is `eval * r_i`.
+			set_packed_slice(values.as_mut(), 2 * i, eval);
 			set_packed_slice(values.as_mut(), 2 * i + 1, eval * r_i);
 		}
 	}
@@ -108,17 +110,19 @@ pub fn tensor_prod_eq_ind_prepend<P: PackedField, Data: DerefMut<Target = [P]>>(
 ///
 /// Given an $n$-coordinate point $r_0, ..., r_n$, this computes the partial evaluation of the
 /// equality indicator polynomial $\widetilde{eq}(X_0, ..., X_{n-1}, r_0, ..., r_{n-1})$ and
-/// returns its values over the $n$-dimensional hypercube.
+/// returns its monomial coefficients over the $n$-dimensional hypercube.
 ///
 /// The returned values are equal to the tensor product
 ///
 /// $$
-/// (1 - r_0, r_0) \otimes ... \otimes (1 - r_{n-1}, r_{n-1}).
+/// (1, r_0) \otimes ... \otimes (1, r_{n-1}),
 /// $$
 ///
-/// See [DP23], Section 2.1 for more information about the equality indicator polynomial.
+/// i.e. the monomial coefficients of $\widetilde{eq}(X, r) = \prod_i (1 + X_i r_i)$.
 ///
-/// [DP23]: <https://eprint.iacr.org/2023/1784>
+/// See [2026/762], Section 4.2 for the monomial-basis equality indicator.
+///
+/// [2026/762]: <https://eprint.iacr.org/2026/762>
 pub fn eq_ind_partial_eval<P: PackedField>(point: &[P::Scalar]) -> FieldBuffer<P> {
 	// The buffer needs to have the correct size: 2^max(point.len(), P::LOG_WIDTH) elements
 	// but since tensor_prod_eq_ind starts with log_n_values=0, we need the final size
@@ -132,9 +136,10 @@ pub fn eq_ind_partial_eval<P: PackedField>(point: &[P::Scalar]) -> FieldBuffer<P
 /// Truncate the equality indicator expansion to the low indexed variables.
 ///
 /// This routine computes $\widetilde{eq}(X_0, ..., X_{n'-1}, r_0, ..., r_{n'-1})$ from
-/// $\widetilde{eq}(X_0, ..., X_{n-1}, r_0, ..., r_{n-1})$ where $n' \le n$ by repeatedly summing
-/// field buffer "halves" inplace. The equality indicator expansion occupies a prefix of
-/// the field buffer; scalars after the truncated length are zeroed out.
+/// $\widetilde{eq}(X_0, ..., X_{n-1}, r_0, ..., r_{n-1})$ where $n' \le n$. In the monomial basis
+/// the expansion is the tensor $\bigotimes_i (1, r_i)$, whose low-variable restriction is exactly
+/// the prefix of monomial coefficients (those whose high-variable monomials are constant), so the
+/// truncation is a plain length truncation.
 ///
 /// ## Preconditions
 ///
@@ -148,38 +153,24 @@ pub fn eq_ind_truncate_low_inplace<P: PackedField, Data: DerefMut<Target = [P]>>
 		"precondition: truncated_log_len must be at most values.log_len()"
 	);
 
-	for log_len in (truncated_log_len..values.log_len()).rev() {
-		{
-			let mut split = values.split_half_mut();
-			let (mut lo, hi) = split.halves();
-			(lo.as_mut(), hi.as_ref())
-				.into_par_iter()
-				.for_each(|(zero, one)| {
-					*zero += *one;
-				});
-		}
-
-		values.truncate(log_len);
-	}
+	values.truncate(truncated_log_len);
 }
 
-/// Evaluates the 2-variate multilinear which indicates the equality condition over the hypercube.
+/// Evaluates the 2-variate multilinear which indicates the equality condition over the
+/// infinity hypercube.
 ///
-/// This evaluates the bivariate polynomial
-///
-/// $$
-/// \widetilde{eq}(X, Y) = X Y + (1 - X) (1 - Y)
-/// $$
-///
-/// In the special case of binary fields, the evaluation can be simplified to
+/// This evaluates the monomial-basis bivariate polynomial
 ///
 /// $$
-/// \widetilde{eq}(X, Y) = X + Y + 1
+/// \widetilde{eq}(X, Y) = 1 + X Y
 /// $$
+///
+/// the interpolant of the equality function on the infinity hypercube. See [2026/762], Section 4.2.
+///
+/// [2026/762]: <https://eprint.iacr.org/2026/762>
 #[inline(always)]
 pub fn eq_one_var<F: FieldOps>(x: F, y: F) -> F {
-	let one = F::one();
-	x.clone() * y.clone() + (one.clone() - x) * (one.clone() - y)
+	F::one() + x * y
 }
 
 /// Evaluates the equality indicator multilinear at a pair of coordinates.
@@ -187,14 +178,12 @@ pub fn eq_one_var<F: FieldOps>(x: F, y: F) -> F {
 /// This evaluates the 2n-variate multilinear polynomial
 ///
 /// $$
-/// \widetilde{eq}(X_0, \ldots, X_{n-1}, Y_0, \ldots, Y_{n-1}) = \prod_{i=0}^{n-1} X_i Y_i + (1 -
-/// X_i) (1 - Y_i) $$
+/// \widetilde{eq}(X_0, \ldots, X_{n-1}, Y_0, \ldots, Y_{n-1}) = \prod_{i=0}^{n-1} (1 + X_i Y_i)
+/// $$
 ///
-/// In the special case of binary fields, the evaluation can be simplified to
+/// See [2026/762], Section 4.2 for the monomial-basis equality indicator.
 ///
-/// See [DP23], Section 2.1 for more information about the equality indicator polynomial.
-///
-/// [DP23]: <https://eprint.iacr.org/2023/1784>
+/// [2026/762]: <https://eprint.iacr.org/2026/762>
 pub fn eq_ind<F: FieldOps>(x: &[F], y: &[F]) -> F {
 	assert_eq!(x.len(), y.len(), "pre-condition: x and y must be the same length");
 	iter::zip(x, y)
@@ -204,14 +193,15 @@ pub fn eq_ind<F: FieldOps>(x: &[F], y: &[F]) -> F {
 
 /// Evaluates the equality indicator multilinear with one operand fixed to all zeros.
 ///
-/// This is `eq_ind(0^n, point)`, which simplifies to
+/// This is `eq_ind(0^n, point)`. In the monomial basis $\widetilde{eq}(0, Y) = 1 + 0 \cdot Y = 1$,
+/// so this is identically `1`:
 ///
 /// $$
-/// \widetilde{eq}(0^n, Y_0, \ldots, Y_{n-1}) = \prod_{i=0}^{n-1} (1 - Y_i).
+/// \widetilde{eq}(0^n, Y_0, \ldots, Y_{n-1}) = \prod_{i=0}^{n-1} (1 + 0 \cdot Y_i) = 1.
 /// $$
 pub fn eq_ind_zero<F: FieldOps>(point: &[F]) -> F {
-	let one = F::one();
-	point.iter().map(|y| one.clone() - y.clone()).product()
+	let _ = point;
+	F::one()
 }
 
 /// Computes the partial evaluation of the equality indicator polynomial, returning scalars.
@@ -220,20 +210,18 @@ pub fn eq_ind_zero<F: FieldOps>(point: &[F]) -> F {
 /// a [`FieldBuffer`]. It computes the tensor product
 ///
 /// $$
-/// (1 - r_0, r_0) \otimes ... \otimes (1 - r_{n-1}, r_{n-1}).
+/// (1, r_0) \otimes ... \otimes (1, r_{n-1}).
 /// $$
 pub fn eq_ind_partial_eval_scalars<F: FieldOps>(point: &[F]) -> Vec<F> {
 	let mut result = Vec::with_capacity(1 << point.len());
 	result.push(F::one());
 
 	for r_i in point {
-		// Double the buffer size. For each existing value in 0..size,
-		// the lo half gets val * (1 - r_i) and the hi half gets val * r_i.
-		// Process in reverse so that writes to hi don't overwrite values we need.
+		// Double the buffer size. Monomial-basis factor `(1, r_i)`: the lo half (constant monomial
+		// coefficient) is unchanged and the hi half gets `val * r_i`.
 		let len = result.len();
 		for j in 0..len {
 			let prod = result[j].clone() * r_i.clone();
-			result[j] -= prod.clone();
 			result.push(prod);
 		}
 	}
@@ -245,7 +233,7 @@ mod tests {
 	use rand::prelude::*;
 
 	use super::*;
-	use crate::test_utils::{B128, Packed128b, index_to_hypercube_point, random_scalars};
+	use crate::test_utils::{B128, Packed128b, random_scalars};
 
 	type P = Packed128b;
 	type F = B128;
@@ -260,15 +248,17 @@ mod tests {
 		result.set(0, F::ONE);
 		tensor_prod_eq_ind(&mut result, &query);
 		let result_vec: Vec<F> = P::iter_slice(result.as_ref()).collect();
-		assert_eq!(
-			result_vec,
-			vec![
-				(F::ONE - v0) * (F::ONE - v1),
-				v0 * (F::ONE - v1),
-				(F::ONE - v0) * v1,
-				v0 * v1
-			]
-		);
+		// Monomial-basis tensor `(1, v0) ⊗ (1, v1)`.
+		assert_eq!(result_vec, vec![F::ONE, v0, v1, v0 * v1]);
+	}
+
+	/// Monomial coefficient of `eq_ind_partial_eval(point)` at hypercube `index`:
+	/// the product of `point[j]` over coordinates `j` whose bit is set in `index`.
+	fn monomial_coeff(point: &[F], index: usize) -> F {
+		(0..point.len())
+			.filter(|j| (index >> j) & 1 == 1)
+			.map(|j| point[j])
+			.product()
 	}
 
 	#[test]
@@ -290,8 +280,7 @@ mod tests {
 			assert_eq!(eq_expansion.log_len(), coords.len());
 			for i in 0..eq_expansion.len() {
 				let v = eq_expansion.get(i);
-				let hypercube_point = index_to_hypercube_point(coords.len(), i);
-				assert_eq!(v, eq_ind(&hypercube_point, &coords));
+				assert_eq!(v, monomial_coeff(&coords, i));
 			}
 		}
 	}
@@ -301,8 +290,8 @@ mod tests {
 		let mut rng = StdRng::seed_from_u64(0);
 		for n in 0..5 {
 			let point = random_scalars::<F>(&mut rng, n);
-			let expected: F = point.iter().map(|&r| F::ONE - r).product();
-			assert_eq!(eq_ind_zero(&point), expected);
+			// Monomial basis: eq(0; ·) is identically 1.
+			assert_eq!(eq_ind_zero(&point), F::ONE);
 			assert_eq!(eq_ind_zero(&point), eq_ind(&vec![F::ZERO; n], &point));
 		}
 	}
@@ -325,7 +314,7 @@ mod tests {
 		assert_eq!(result.log_len(), 1);
 		assert_eq!(result.len(), 2);
 		let result_mut = result;
-		assert_eq!(result_mut.get(0), F::ONE - r0);
+		assert_eq!(result_mut.get(0), F::ONE);
 		assert_eq!(result_mut.get(1), r0);
 	}
 
@@ -338,12 +327,7 @@ mod tests {
 		assert_eq!(result.log_len(), 2);
 		assert_eq!(result.len(), 4);
 		let result_vec: Vec<F> = P::iter_slice(result.as_ref()).collect();
-		let expected = vec![
-			(F::ONE - r0) * (F::ONE - r1),
-			r0 * (F::ONE - r1),
-			(F::ONE - r0) * r1,
-			r0 * r1,
-		];
+		let expected = vec![F::ONE, r0, r1, r0 * r1];
 		assert_eq!(result_vec, expected);
 	}
 
@@ -358,16 +342,7 @@ mod tests {
 		assert_eq!(result.len(), 8);
 		let result_vec: Vec<F> = P::iter_slice(result.as_ref()).collect();
 
-		let expected = vec![
-			(F::ONE - r0) * (F::ONE - r1) * (F::ONE - r2),
-			r0 * (F::ONE - r1) * (F::ONE - r2),
-			(F::ONE - r0) * r1 * (F::ONE - r2),
-			r0 * r1 * (F::ONE - r2),
-			(F::ONE - r0) * (F::ONE - r1) * r2,
-			r0 * (F::ONE - r1) * r2,
-			(F::ONE - r0) * r1 * r2,
-			r0 * r1 * r2,
-		];
+		let expected = vec![F::ONE, r0, r1, r0 * r1, r2, r0 * r2, r1 * r2, r0 * r1 * r2];
 		assert_eq!(result_vec, expected);
 	}
 
@@ -386,10 +361,8 @@ mod tests {
 		let result_mut = result;
 		let partial_eval_value = result_mut.get(index);
 
-		let index_bits = index_to_hypercube_point(n_vars, index);
-		let eq_ind_value = eq_ind(&point, &index_bits);
-
-		assert_eq!(partial_eval_value, eq_ind_value);
+		// In the monomial basis the entry is the monomial coefficient at `index`.
+		assert_eq!(partial_eval_value, monomial_coeff(&point, index));
 	}
 
 	#[test]

--- a/crates/math/src/multilinear/evaluate.rs
+++ b/crates/math/src/multilinear/evaluate.rs
@@ -21,7 +21,7 @@ use crate::{
 /// This approach uses O(sqrt(2^n)) memory instead of O(2^n).
 ///
 /// # Arguments
-/// * `evals` - A FieldBuffer containing the 2^n evaluations over the boolean hypercube
+/// * `evals` - A FieldBuffer containing the 2^n monomial coefficients over the boolean hypercube
 /// * `point` - The n coordinates at which to evaluate the polynomial
 ///
 /// # Returns
@@ -78,7 +78,8 @@ where
 /// modified in-place.
 ///
 /// # Arguments
-/// * `evals` - A [`FieldBuffer`] containing the $2^n$ evaluations over the boolean hypercube
+/// * `evals` - A [`FieldBuffer`] containing the $2^n$ monomial coefficients over the boolean
+///   hypercube
 /// * `coords` - The $n$ coordinates at which to evaluate the polynomial
 ///
 /// # Returns
@@ -111,13 +112,14 @@ where
 /// Evaluates a multilinear polynomial at a given point in-place using scalar operations.
 ///
 /// This is a simple variant of multilinear evaluation that works directly on slices of scalars
-/// with only a `FieldOps` bound. For each coordinate (highest to lowest), it folds the upper
-/// half into the lower half: `evals[j] += r * (evals[j + half] - evals[j])`.
+/// with only a `FieldOps` bound. For each coordinate (highest to lowest), it folds the upper half
+/// into the lower half using the monomial-basis rule `evals[j] += r * evals[j + half]` (the two
+/// halves are the coefficients `[c0, c1]` of the highest variable's polynomial `c0 + X * c1`).
 ///
 /// The final result is stored in `evals[0]` after all folds.
 ///
 /// # Arguments
-/// * `evals` - The 2^n evaluations over the boolean hypercube, modified in-place
+/// * `evals` - The 2^n monomial coefficients over the boolean hypercube, modified in-place
 /// * `point` - The n coordinates at which to evaluate the polynomial
 ///
 /// # Panics
@@ -132,8 +134,8 @@ pub fn evaluate_inplace_scalars<F: FieldOps>(
 	for (log_half_len, point_i) in point.iter().enumerate().rev() {
 		let half_len = 1 << log_half_len;
 		for j in 0..half_len {
-			let delta = evals[j + half_len].clone() - evals[j].clone();
-			evals[j] += point_i.clone() * delta;
+			let hi = evals[j + half_len].clone();
+			evals[j] += point_i.clone() * hi;
 		}
 	}
 	evals[0].clone()
@@ -201,14 +203,18 @@ mod tests {
 			let index = (rng.next_u32() as usize) % (1 << log_n);
 			let point = index_to_hypercube_point::<F>(log_n, index);
 
-			// Evaluate at the hypercube point
+			// Evaluate at the {0,1} hypercube point
 			let eval_result = evaluate(&buffer, &point);
 
-			// Get the value directly from the buffer
-			let direct_value = buffer.get(index);
+			// In the monomial basis the buffer holds coefficients, so the value at a {0,1} vertex
+			// is the sum of coefficients `c_w` over all `w` whose support is a subset of `index`
+			// (the zeta transform).
+			let expected: F = (0..(1usize << log_n))
+				.filter(|w| w & index == *w)
+				.map(|w| buffer.get(w))
+				.sum();
 
-			// They should be equal
-			assert_eq!(eval_result, direct_value);
+			assert_eq!(eval_result, expected);
 		}
 	}
 

--- a/crates/math/src/multilinear/fold.rs
+++ b/crates/math/src/multilinear/fold.rs
@@ -26,7 +26,10 @@ pub fn fold_highest_var_inplace<P: PackedField, Data: DerefMut<Target = [P]>>(
 		(lo.as_mut(), hi.as_mut())
 			.into_par_iter()
 			.for_each(|(zero, one)| {
-				*zero += broadcast_scalar * (*one - *zero);
+				// Monomial basis: the two halves are the coefficients `[c0, c1]` of the highest
+				// variable's polynomial `c0 + X * c1`, so partially evaluating at `scalar` gives
+				// `c0 + scalar * c1`.
+				*zero += broadcast_scalar * *one;
 			});
 	}
 


### PR DESCRIPTION
**Draft — work in progress, opened for early review** of [BINIUS-114](https://linear.app/jimpo/issue/BINIUS-114/switch-to-multilinear-monomial-basis). Per the issue, this is one large change split by commit, and some commits are intentionally red. **Not all tests pass yet** — see "Open question" below; there's an active discussion on the Linear issue.

Switches the multilinear polynomial representation from the {0,1} evaluation (Lagrange) basis to the **monomial basis** — i.e. evaluation on the *infinity hypercube* `{0,∞}ⁿ`, where a multilinear's value list is its monomial-coefficient vector. Grounded in eprint 2026/762 and the companion spec PR binius-zk/binius.xyz#117.

### Commits

**1. `eq` indicator + multilinear `fold` → monomial basis** (`crates/math/src/multilinear/{eq,fold,evaluate}.rs`)
- `eq̃(X,Y) = 1 + XY` (not the char-2 `1+X+Y`); tensor factor `(1−xᵢ, xᵢ) → (1, xᵢ)`; `eq_ind_zero` → identically 1; `eq_ind_truncate_low` → prefix truncation.
- `fold_highest_var_inplace`: `zero += r·(one−zero)` → `zero += r·one` (the two halves are now the coefficients `[c0, c1]`). Same change to the scalar evaluator.
- `eq_ind_partial_eval` now returns **monomial coefficients**, so it is no longer `eq_ind` at literal {0,1} vertices (only under projective {0,∞} evaluation); `evaluate` (an inner product with that tensor) stays correct unchanged. Unit tests rewritten to the monomial-coefficient / zeta-transform invariants.
- **binius-math: all lib tests pass, clippy `-D warnings` clean.**

**2. sumcheck & MLE-check round identities → monomial basis** (`crates/ip/src/{sumcheck/common,mlecheck}.rs`, `crates/ip-prover/src/sumcheck/*`)
- Bare sumcheck verifier check `R(0)+R(∞)=s`; `recover` → `a_d = s − a₀`.
- MLE-check: per-prover Karatsuba half-swap (`M(1)=lo+hi`, `M(∞)=hi`), `interpolate_eq` → `y₀ = s − α·y_inf` (the `(1−α)⁻¹` drops out), `recover` → `a₀ = eval − α·a_d`, `round_coeffs_by_eq` → `prime·(1+αX)`, `lerp_over_endpoints` → `r₀ + α·r_inf`. `gruen32` needs no change.
- **Green:** `test_bivariate_product_sumcheck`, and the **homogeneous** degree-2 MLE-checks (`a*b`, `(a+b)(c+d)`) at all sizes.

### Open question (blocking the rest)

Non-homogeneous / lower-degree composites — `a+b` and the mul gate `a*b − c` — reduce correctly at one round but fail across multiple rounds (the degree-2 framing's `∞ = X²`-coeff doesn't match the carried claim for the lower-degree terms). I've asked on the Linear issue whether the MLE-check round poly should be the bare prime (degree `d`, current) or the eq-weighted degree-`(d+1)` poly with `∞` extracting `x^{d+1}`, and whether a degree-1 composition should use a degree-1 prover.

### Still to come (after the above resolves)
- Ring-switch indicator evaluation (issue item 3).
- Downstream green-up across the workspace (prover/verifier/iop/spartan), then code review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)