### PR TITLE
BINIUS-133: rewrite sha256 Compress struct as a function gadget

### DIFF
--- a/crates/circuits/src/sha256/compress.rs
+++ b/crates/circuits/src/sha256/compress.rs
@@ -1,6 +1,6 @@
 // Copyright 2025 Irreducible Inc.
 use binius_core::word::Word;
-use binius_frontend::{CircuitBuilder, Wire};
+use binius_frontend::{CircuitBuilder, Wire, WitnessFiller};
 
 const IV: [u32; 8] = [
 	0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19,
@@ -58,81 +58,74 @@ impl State {
 	}
 }
 
-/// SHA-256 compress function.
-pub struct Compress {
-	pub state_in: State,
-	pub state_out: State,
-	pub m: [Wire; 16],
-}
+/// SHA-256 compression function.
+///
+/// Runs the message schedule and 64 rounds over `state_in` for a single 512-bit block, then adds
+/// the round output back into `state_in`, returning the updated state.
+///
+/// # Arguments
+///
+/// - `state_in`: the 8-word input state (each word in the low 32 bits of a wire).
+/// - `m`: 16 message words for this block, each a 32-bit big-endian word in the low 32 bits of a
+///   wire.
+///
+/// It is a PRECONDITION that the high halves of the `m` wires be empty, i.e. `m[i] & 0xffffffff ==
+/// m[i]` must hold for each wire. It is the caller's responsibility to ensure this; otherwise the
+/// gadget's behavior is undefined / insecure.
+///
+/// # Returns
+///
+/// The updated 8-word state.
+pub fn sha256_compress(builder: &CircuitBuilder, state_in: State, m: [Wire; 16]) -> State {
+	// ---- message-schedule ----
+	// W[0..15] = block_words
+	// for t = 16 .. 63:
+	//     s0   = σ0(W[t-15])
+	//     s1   = σ1(W[t-2])
+	//     (p, _)  = Add32(W[t-16], s0)
+	//     (q, _)  = Add32(p, W[t-7])
+	//     (W[t],_) = Add32(q, s1)
 
-impl Compress {
-	pub fn new(builder: &CircuitBuilder, state_in: State, m: [Wire; 16]) -> Self {
-		// it is a PRECONDITION of this gadget that the high halves of the wires fed in be empty.
-		// that is, `m[i] & 0xffffffff == m[i]` must hold for each wire `i` passed in.
-		// it is the caller's responsibility to ensure that this is the case for all wires.
-		// if this isn't true, then the behavior becomes undefined / the gadget becomes insecure.
+	let mut w: Vec<Wire> = Vec::with_capacity(64);
+	// W[0..15] = block_words
+	w.extend_from_slice(&m);
 
-		// ---- message-schedule ----
-		// W[0..15] = block_words
-		// for t = 16 .. 63:
-		//     s0   = σ0(W[t-15])
-		//     s1   = σ1(W[t-2])
-		//     (p, _)  = Add32(W[t-16], s0)
-		//     (q, _)  = Add32(p, W[t-7])
-		//     (W[t],_) = Add32(q, s1)
-
-		let mut w: Vec<Wire> = Vec::with_capacity(64);
-		// W[0..15] = block_words
-		w.extend_from_slice(&m);
-
-		// W[16..63] computed from previous W values
-		for t in 16..64 {
-			let s0 = small_sigma_0(builder, w[t - 15]);
-			let s1 = small_sigma_1(builder, w[t - 2]);
-			let p = builder.iadd_32(w[t - 16], s0);
-			let q = builder.iadd_32(p, w[t - 7]);
-			w.push(builder.iadd_32(q, s1));
-		}
-
-		let w: &[Wire; 64] = (&*w).try_into().unwrap();
-		let mut state = state_in.clone();
-		for t in 0..64 {
-			state = round(builder, t, state, w);
-		}
-
-		// Add the compressed chunk to the current hash value
-		let state_out = State([
-			builder.iadd_32(state_in.0[0], state.0[0]),
-			builder.iadd_32(state_in.0[1], state.0[1]),
-			builder.iadd_32(state_in.0[2], state.0[2]),
-			builder.iadd_32(state_in.0[3], state.0[3]),
-			builder.iadd_32(state_in.0[4], state.0[4]),
-			builder.iadd_32(state_in.0[5], state.0[5]),
-			builder.iadd_32(state_in.0[6], state.0[6]),
-			builder.iadd_32(state_in.0[7], state.0[7]),
-		]);
-
-		Compress {
-			state_in,
-			state_out,
-			m,
-		}
+	// W[16..63] computed from previous W values
+	for t in 16..64 {
+		let s0 = small_sigma_0(builder, w[t - 15]);
+		let s1 = small_sigma_1(builder, w[t - 2]);
+		let p = builder.iadd_32(w[t - 16], s0);
+		let q = builder.iadd_32(p, w[t - 7]);
+		w.push(builder.iadd_32(q, s1));
 	}
 
-	pub fn populate_m(&self, w: &mut binius_frontend::WitnessFiller, m: [u8; 64]) {
-		debug_assert_eq!(self.m.len(), 16);
+	let w: &[Wire; 64] = (&*w).try_into().unwrap();
+	let mut state = state_in.clone();
+	for t in 0..64 {
+		state = round(builder, t, state, w);
+	}
 
-		for i in 0..16 {
-			let j = i * 4;
-			// Assemble a 32-bit big-endian word and widen to 64 bits.
-			let limb = ((m[j] as u64) << 24)
-				| ((m[j + 1] as u64) << 16)
-				| ((m[j + 2] as u64) << 8)
-				| (m[j + 3] as u64);
+	// Add the compressed chunk to the current hash value
+	State([
+		builder.iadd_32(state_in.0[0], state.0[0]),
+		builder.iadd_32(state_in.0[1], state.0[1]),
+		builder.iadd_32(state_in.0[2], state.0[2]),
+		builder.iadd_32(state_in.0[3], state.0[3]),
+		builder.iadd_32(state_in.0[4], state.0[4]),
+		builder.iadd_32(state_in.0[5], state.0[5]),
+		builder.iadd_32(state_in.0[6], state.0[6]),
+		builder.iadd_32(state_in.0[7], state.0[7]),
+	])
+}
 
-			// Write it to the witness.  Word is a thin wrapper around u64.
-			w[self.m[i]] = Word(limb);
-		}
+/// Populates the 16 message-block wires of a [`sha256_compress`] block from its 64 message bytes.
+///
+/// The bytes are packed big-endian into 16 32-bit words, one per wire, with the high 32 bits left
+/// zero — matching the precondition on `m` documented in [`sha256_compress`].
+pub fn populate_message_block(w: &mut WitnessFiller, m: &[Wire; 16], bytes: [u8; 64]) {
+	for (wire, chunk) in m.iter().zip(bytes.chunks_exact(4)) {
+		let word = u32::from_be_bytes(chunk.try_into().unwrap());
+		w[*wire] = Word(word as u64);
 	}
 }
 
@@ -216,7 +209,7 @@ mod tests {
 	use binius_core::{verify::verify_constraints, word::Word};
 	use binius_frontend::{CircuitBuilder, Wire};
 
-	use super::{Compress, State};
+	use super::{State, populate_message_block, sha256_compress};
 
 	/// A test circuit that proves a knowledge of preimage for a given state vector S in
 	///
@@ -241,11 +234,11 @@ mod tests {
 		let state = State::iv(&circuit);
 		let input: [Wire; 16] = std::array::from_fn(|_| circuit.add_witness());
 		let output: [Wire; 8] = std::array::from_fn(|_| circuit.add_inout());
-		let compress = Compress::new(&circuit, state, input);
+		let state_out = sha256_compress(&circuit, state, input);
 
 		// Mask to only low 32-bit.
 		let mask32 = circuit.add_constant(Word::MASK_32);
-		for (i, (actual_x, expected_x)) in compress.state_out.0.iter().zip(output).enumerate() {
+		for (i, (actual_x, expected_x)) in state_out.0.iter().zip(output).enumerate() {
 			circuit.assert_eq(
 				format!("preimage_eq[{i}]"),
 				circuit.band(*actual_x, mask32),
@@ -258,7 +251,7 @@ mod tests {
 		let mut w = circuit.new_witness_filler();
 
 		// Populate the input message for the compression function.
-		compress.populate_m(&mut w, preimage);
+		populate_message_block(&mut w, &input, preimage);
 
 		for (i, &output) in output.iter().enumerate() {
 			w[output] = Word(expected_state[i] as u64);
@@ -275,7 +268,7 @@ mod tests {
 		const N: usize = 3;
 		let circuit = CircuitBuilder::new();
 
-		let mut compress_vec = Vec::with_capacity(N);
+		let mut m_vec = Vec::with_capacity(N);
 
 		// First, declare the initial state.
 		let mut state = State::iv(&circuit);
@@ -291,18 +284,17 @@ mod tests {
 			} else {
 				std::array::from_fn(|_| sha256_builder.add_witness())
 			};
-			let compress = Compress::new(&sha256_builder, state, m);
-			state = compress.state_out.clone();
+			state = sha256_compress(&sha256_builder, state, m);
 
-			compress_vec.push(compress);
+			m_vec.push(m);
 		}
 
 		let circuit = circuit.build();
 		let cs = circuit.constraint_system();
 		let mut w = circuit.new_witness_filler();
 
-		for compress in &compress_vec {
-			compress.populate_m(&mut w, [0; 64]);
+		for m in &m_vec {
+			populate_message_block(&mut w, m, [0; 64]);
 		}
 		circuit.populate_wire_witness(&mut w).unwrap();
 
@@ -315,7 +307,7 @@ mod tests {
 		const N: usize = 3;
 		let circuit = CircuitBuilder::new();
 
-		let mut compress_vec = Vec::with_capacity(N);
+		let mut m_vec = Vec::with_capacity(N);
 
 		for i in 0..N {
 			// Create a new subcircuit builder
@@ -324,17 +316,17 @@ mod tests {
 			// Each SHA-256 instance gets its own IV and input (all committed)
 			let state = State::iv(&sha256_builder);
 			let m: [Wire; 16] = std::array::from_fn(|_| sha256_builder.add_inout());
-			let compress = Compress::new(&sha256_builder, state, m);
+			sha256_compress(&sha256_builder, state, m);
 
-			compress_vec.push(compress);
+			m_vec.push(m);
 		}
 
 		let circuit = circuit.build();
 		let cs = circuit.constraint_system();
 		let mut w = circuit.new_witness_filler();
 
-		for compress in &compress_vec {
-			compress.populate_m(&mut w, [0; 64]);
+		for m in &m_vec {
+			populate_message_block(&mut w, m, [0; 64]);
 		}
 		circuit.populate_wire_witness(&mut w).unwrap();
 

--- a/crates/circuits/src/sha256/mod.rs
+++ b/crates/circuits/src/sha256/mod.rs
@@ -6,7 +6,7 @@ use binius_core::{
 	word::Word,
 };
 use binius_frontend::{CircuitBuilder, Wire, WitnessFiller};
-pub use compress::{Compress, State};
+pub use compress::{State, populate_message_block, sha256_compress};
 
 use crate::{
 	bytes::{swap_bytes, swap_bytes_32},
@@ -47,15 +47,15 @@ pub struct Sha256 {
 	/// This circuit will run enough hash blocks to process the entire message.
 	pub message: Vec<Wire>,
 
-	/// Compression gadgets for each 512-bit block.
+	/// Message-block input wires for each 512-bit block.
 	///
-	/// Each compression gadget processes one 512-bit (64-byte) block of the padded message.
-	/// The gadgets are chained together, with each taking the output state from the previous
-	/// compression as input. The first compression starts from the SHA-256 initialization vector.
+	/// Each entry holds the 16 message words fed into one [`sha256_compress`] call (one 512-bit /
+	/// 64-byte block of the padded message). They are retained so witness population can fill them
+	/// via [`populate_message_block`].
 	///
-	/// The number of compression gadgets is `ceil((max_len_bytes + 9) / 64)`, accounting for
-	/// the minimum 9 bytes of padding (1 byte for 0x80 delimiter + 8 bytes for length).
-	compress: Vec<Compress>,
+	/// The number of blocks is `ceil((max_len_bytes + 9) / 64)`, accounting for the minimum 9
+	/// bytes of padding (1 byte for 0x80 delimiter + 8 bytes for length).
+	block_messages: Vec<[Wire; 16]>,
 }
 
 impl Sha256 {
@@ -149,24 +149,25 @@ impl Sha256 {
 		let padded_evens: Vec<Wire> = (0..n_words).map(|_| builder.add_witness()).collect();
 		let padded_odds: Vec<Wire> = (0..n_words).map(|_| builder.add_witness()).collect();
 
-		let mut compress = Vec::with_capacity(n_blocks);
+		let mut block_messages = Vec::with_capacity(n_blocks);
 		let mut states = Vec::with_capacity(n_blocks + 1);
 		states.push(State::iv(builder));
 		for block_no in 0..n_blocks {
-			let c = Compress::new(
+			// grab appropriate interleaved wires, in order to feed into compression gadget.
+			let m: [Wire; 16] = std::array::from_fn(|i| {
+				if i & 1 == 0 {
+					padded_evens[block_no << 3 | i >> 1]
+				} else {
+					padded_odds[block_no << 3 | i >> 1]
+				}
+			});
+			let state_out = sha256_compress(
 				&builder.subcircuit(format!("compress[{block_no}]")),
 				states[block_no].clone(),
-				// grab appropriate interleaved wires, in order to feed into compression gadget.
-				std::array::from_fn(|i| {
-					if i & 1 == 0 {
-						padded_evens[block_no << 3 | i >> 1]
-					} else {
-						padded_odds[block_no << 3 | i >> 1]
-					}
-				}),
+				m,
 			);
-			states.push(c.state_out.clone());
-			compress.push(c);
+			states.push(state_out);
+			block_messages.push(m);
 		}
 
 		// ---- 2a. SHA-256 padding position calculation
@@ -354,7 +355,7 @@ impl Sha256 {
 			len_bytes,
 			digest,
 			message,
-			compress,
+			block_messages,
 		}
 	}
 
@@ -426,7 +427,7 @@ impl Sha256 {
 			self.max_len_bytes()
 		);
 
-		let n_blocks = self.compress.len();
+		let n_blocks = self.block_messages.len();
 		let mut padded_message_bytes = vec![0u8; n_blocks * 64];
 
 		// Apply SHA-256 padding
@@ -476,10 +477,10 @@ impl Sha256 {
 			w[*wire] = Word(word);
 		}
 
-		for (i, compress) in self.compress.iter().enumerate() {
+		for (i, m) in self.block_messages.iter().enumerate() {
 			let block_start = i * 64;
 			let block = &padded_message_bytes[block_start..block_start + 64];
-			compress.populate_m(w, block.try_into().unwrap());
+			populate_message_block(w, m, block.try_into().unwrap());
 		}
 	}
 }
@@ -589,13 +590,11 @@ pub fn sha256_fixed(builder: &CircuitBuilder, message: &[Wire], len_bytes: usize
 		|state, (block_idx, block)| {
 			let block_message: [Wire; 16] = block.try_into().unwrap();
 
-			let compress = Compress::new(
+			sha256_compress(
 				&builder.subcircuit(format!("sha256_fixed_compress[{}]", block_idx)),
 				state.clone(),
 				block_message,
-			);
-
-			compress.state_out
+			)
 		},
 	);
 

--- a/crates/prover/tests/prove_verify.rs
+++ b/crates/prover/tests/prove_verify.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-use binius_circuits::sha256::{Compress, State};
+use binius_circuits::sha256::{State, populate_message_block, sha256_compress};
 use binius_core::{
 	constraint_system::{ConstraintSystem, ValueVec},
 	word::Word,
@@ -104,11 +104,11 @@ fn sha256_preimage_circuit() -> (ConstraintSystem, ValueVec) {
 	let state = State::iv(&circuit);
 	let input: [Wire; 16] = std::array::from_fn(|_| circuit.add_witness());
 	let output: [Wire; 8] = std::array::from_fn(|_| circuit.add_inout());
-	let compress = Compress::new(&circuit, state, input);
+	let state_out = sha256_compress(&circuit, state, input);
 
 	// Mask to only low 32-bit.
 	let mask32 = circuit.add_constant(Word::MASK_32);
-	for (actual_x, expected_x) in compress.state_out.0.iter().zip(output) {
+	for (actual_x, expected_x) in state_out.0.iter().zip(output) {
 		circuit.assert_eq("eq", circuit.band(*actual_x, mask32), expected_x);
 	}
 
@@ -116,7 +116,7 @@ fn sha256_preimage_circuit() -> (ConstraintSystem, ValueVec) {
 	let mut w = circuit.new_witness_filler();
 
 	// Populate the input message for the compression function.
-	compress.populate_m(&mut w, preimage);
+	populate_message_block(&mut w, &input, preimage);
 
 	for (i, &output) in output.iter().enumerate() {
 		w[output] = Word(expected_state[i] as u64);


### PR DESCRIPTION
Rewrites the SHA-256 `Compress` struct as a free-function gadget, mirroring the established `blake3_compress` pattern ([BINIUS-133](https://linear.app/jimpo/issue/BINIUS-133/rewrite-compress-struct-in-sha2), sub-issue of BINIUS-126).

## What

- **`Compress` struct + `impl` → `sha256_compress(builder, state_in, m) -> State`.** A plain function that runs the message schedule + 64 rounds and returns the updated state, instead of a struct that stored `state_in` / `state_out` / `m`.
- **`Compress::populate_m` → free function `populate_message_schedule(w, &m, bytes)`.** The method only existed to reach the `m` wires the struct held onto; as a free function it takes those wires explicitly, so nothing needs to be retained just to fill the witness.
- **Call sites updated:**
  - `Sha256` now stores `block_messages: Vec<[Wire; 16]>` (the per-block message wires) instead of `compress: Vec<Compress>`, and fills them with `populate_message_schedule` during witness population.
  - `sha256_fixed` calls `sha256_compress` directly and returns its state.
  - The three `compress.rs` unit tests and `prover/tests/prove_verify.rs` updated to the function API.

## Why

`blake3` already exposes its compression as a free function (`blake3_compress`) with no wrapping struct; this brings `sha256` in line. The struct's only role beyond computing the output state was holding `m` for later witness population, which the free `populate_message_schedule` covers without retaining a per-block object.

Behavior-preserving — the constraint construction is identical; only the API shape changes.

## Verification

```
cargo test -p binius-circuits sha256                       ✅ 33 passed
cargo test -p binius-prover --test prove_verify sha256     ✅ 2 passed
prek run --stage pre-push --all-files clippy               ✅ Passed
prek run --all-files rustfmt                               ✅ Passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)