### PR TITLE
BINIUS-132: generic serialize impls for PackedPrimitiveType

### DIFF
--- a/crates/field/src/arch/portable/packed.rs
+++ b/crates/field/src/arch/portable/packed.rs
@@ -14,7 +14,12 @@ use std::{
 	ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
 
-use binius_utils::{checked_arithmetics::checked_int_div, iter::IterExtensions};
+use binius_utils::{
+	DeserializeBytes, FixedSizeSerializeBytes, SerializationError, SerializeBytes,
+	bytes::{Buf, BufMut},
+	checked_arithmetics::checked_int_div,
+	iter::IterExtensions,
+};
 use bytemuck::{Pod, TransparentWrapper, Zeroable};
 use rand::{
 	Rng,
@@ -156,6 +161,31 @@ impl<U: UnderlierType, Scalar: BinaryField> From<U> for PackedPrimitiveType<U, S
 	fn from(val: U) -> Self {
 		Self(val, PhantomData)
 	}
+}
+
+// Serialization forwards to the underlier, which is a transparent wrapper of `Self`. These are
+// available whenever the underlier implements the corresponding trait, so a single generic impl
+// covers every `PackedPrimitiveType` rather than a per-type macro expansion.
+impl<U: UnderlierType + SerializeBytes, Scalar: BinaryField> SerializeBytes
+	for PackedPrimitiveType<U, Scalar>
+{
+	fn serialize(&self, write_buf: impl BufMut) -> Result<(), SerializationError> {
+		self.0.serialize(write_buf)
+	}
+}
+
+impl<U: UnderlierType + DeserializeBytes, Scalar: BinaryField> DeserializeBytes
+	for PackedPrimitiveType<U, Scalar>
+{
+	fn deserialize(read_buf: impl Buf) -> Result<Self, SerializationError> {
+		Ok(Self(U::deserialize(read_buf)?, PhantomData))
+	}
+}
+
+impl<U: UnderlierType + FixedSizeSerializeBytes, Scalar: BinaryField> FixedSizeSerializeBytes
+	for PackedPrimitiveType<U, Scalar>
+{
+	const BYTE_SIZE: usize = U::BYTE_SIZE;
 }
 
 impl<U: UnderlierType, Scalar: BinaryField> Neg for PackedPrimitiveType<U, Scalar> {

--- a/crates/field/src/arch/portable/packed_macros.rs
+++ b/crates/field/src/arch/portable/packed_macros.rs
@@ -42,8 +42,8 @@ macro_rules! define_packed_binary_field {
 		// Define packed field types
 		pub type $name = $crate::arch::PackedPrimitiveType<$underlier, $scalar>;
 
-		// Define serialization and deserialization
-		impl_serialize_deserialize_for_packed_binary_field!($name);
+		// Serialization is provided by a single generic impl on `PackedPrimitiveType` (see
+		// `packed.rs`), so no per-type impl is needed here.
 
 		// Define multiplication
 		impl_strategy!(impl_mul_with       $name, ($($mul)*));
@@ -80,33 +80,8 @@ macro_rules! define_packed_binary_field {
 	};
 }
 
-macro_rules! impl_serialize_deserialize_for_packed_binary_field {
-	($bin_type:ty) => {
-		impl binius_utils::SerializeBytes for $bin_type {
-			fn serialize(
-				&self,
-				write_buf: impl binius_utils::bytes::BufMut,
-			) -> Result<(), binius_utils::SerializationError> {
-				self.0.serialize(write_buf)
-			}
-		}
-
-		impl binius_utils::DeserializeBytes for $bin_type {
-			fn deserialize(
-				read_buf: impl binius_utils::bytes::Buf,
-			) -> Result<Self, binius_utils::SerializationError> {
-				Ok(Self(
-					binius_utils::DeserializeBytes::deserialize(read_buf)?,
-					std::marker::PhantomData,
-				))
-			}
-		}
-	};
-}
-
 pub(crate) use define_packed_binary_field;
 pub(crate) use define_packed_binary_fields;
-pub(crate) use impl_serialize_deserialize_for_packed_binary_field;
 
 // Re-exported so the `wide_mul: (TrivialWideMul)` argument resolves at every macro call site
 // that glob-imports this module.

--- a/crates/field/src/packed_binary_field.rs
+++ b/crates/field/src/packed_binary_field.rs
@@ -1,4 +1,5 @@
 // Copyright 2023-2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 pub use crate::arch::{
 	packed_1::*, packed_2::*, packed_4::*, packed_8::*, packed_16::*, packed_32::*, packed_64::*,
@@ -510,9 +511,11 @@ pub mod test_utils {
 
 #[cfg(test)]
 mod tests {
-	use std::{iter::repeat_with, ops::Mul};
+	use std::{fmt::Debug, iter::repeat_with, ops::Mul};
 
-	use binius_utils::{DeserializeBytes, SerializeBytes, bytes::BytesMut};
+	use binius_utils::{
+		DeserializeBytes, FixedSizeSerializeBytes, SerializeBytes, bytes::BytesMut,
+	};
 	use proptest::prelude::*;
 	use rand::prelude::*;
 	use test_utils::check_interleave_all_heights;
@@ -776,5 +779,36 @@ mod tests {
 			check_transpose_all_heights::<PackedAESBinaryField64x8b>(a_val.into(), b_val.into());
 			check_transpose_all_heights::<PackedBinaryGhash4x128b>(a_val.into(), b_val.into());
 		}
+	}
+
+	// The generic `SerializeBytes`/`DeserializeBytes` impls on `PackedPrimitiveType` round-trip
+	// across both integer underliers and (where applicable) SIMD underliers.
+	#[test]
+	fn test_serialize_roundtrip() {
+		fn check_roundtrip<
+			P: PackedField + SerializeBytes + DeserializeBytes + PartialEq + Debug,
+		>(
+			rng: &mut StdRng,
+		) {
+			let value = P::random(rng);
+			let mut buf = BytesMut::new();
+			value.serialize(&mut buf).unwrap();
+			let deserialized = P::deserialize(buf.freeze()).unwrap();
+			assert_eq!(value, deserialized);
+		}
+
+		let mut rng = StdRng::seed_from_u64(0);
+		check_roundtrip::<PackedBinaryField8x1b>(&mut rng);
+		check_roundtrip::<PackedBinaryField64x1b>(&mut rng);
+		check_roundtrip::<PackedBinaryField128x1b>(&mut rng);
+		check_roundtrip::<PackedBinaryGhash1x128b>(&mut rng);
+	}
+
+	// `FixedSizeSerializeBytes` propagates from the underlier. Integer-backed packed fields (here,
+	// `u8`- and `u64`-backed on every arch) report the underlier's byte size.
+	#[test]
+	fn test_fixed_size_byte_size() {
+		assert_eq!(<PackedBinaryField8x1b as FixedSizeSerializeBytes>::BYTE_SIZE, 1);
+		assert_eq!(<PackedBinaryField64x1b as FixedSizeSerializeBytes>::BYTE_SIZE, 8);
 	}
 }


### PR DESCRIPTION
Closes [BINIUS-132](https://linear.app/jimpo/issue/BINIUS-132/generic-impl-serialize-traits-for-packedprimitive-type).

Replaces the per-type `impl_serialize_deserialize_for_packed_binary_field!` macro with single generic impls on `PackedPrimitiveType<U, Scalar>`, each gated on the underlier implementing the corresponding trait:

- `SerializeBytes` / `DeserializeBytes` — forward to the underlier (every current underlier already implements these, so this covers every packed type the macro did).
- `FixedSizeSerializeBytes` (new) — `BYTE_SIZE = U::BYTE_SIZE`, available wherever the underlier is fixed-size.

The macro and its `pub(crate) use` export are removed. Net effect is less code and no per-type expansion.

### Tests
- `test_serialize_roundtrip` — serialize→deserialize round-trip across integer- and SIMD-backed packed types.
- `test_fixed_size_byte_size` — `BYTE_SIZE` propagation for `u8`/`u64`-backed types.

### Verification
- `cargo test -p binius-field` (237 pass), workspace `cargo clippy --all --tests --benches --examples -- -D warnings` green, fmt clean.
- Cross-compiled `binius-field` for `aarch64` (`+neon,+aes`) and `wasm32-unknown-unknown` — both build.

### Flag for review (taste)
`FixedSizeSerializeBytes` ends up **arch-dependent** on the SIMD-backed packed types: the SIMD underliers (`M128`/`M256`/`M512`) don't implement `FixedSizeSerializeBytes`, so e.g. `PackedBinaryField128x1b` is fixed-size on the portable fallback (u128 underlier) but not on x86_64 native (M128). I kept to the issue's "when its underlier type has that trait" scoping. If you'd rather it be uniform, the natural follow-up is to impl `FixedSizeSerializeBytes` for the SIMD underliers (16/32/64 bytes, matching their existing `serialize`) — happy to fold that in here or as a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)