### PR TITLE
BINIUS-138: fix GHASH M512 Square impl on avx512f without vpclmulqdq

### DIFF
--- a/crates/field/src/arch/x86_64/packed_ghash_512.rs
+++ b/crates/field/src/arch/x86_64/packed_ghash_512.rs
@@ -80,9 +80,16 @@ cfg_if! {
 			}
 		}
 	} else {
-		// Potentially we could use an optimized square implementation here with a scaled underlier.
-		// But this case (an architecture with AVX512 but without VPCLMULQDQ) is pretty rare.
-		impl_square_with!(PackedBinaryGhash4x128b @ crate::arch::ReuseMultiplyStrategy);
+		// AVX-512 without VPCLMULQDQ is rare, so rather than a specialized square we reuse
+		// multiplication (x² = x·x). This must implement the `TaggedSquare<Ghash512Strategy>` that
+		// the macro-generated `Square` impl forwards to — emitting a second `Square` impl here would
+		// conflict with it.
+		impl TaggedSquare<Ghash512Strategy> for PackedBinaryGhash4x128b {
+			#[inline]
+			fn square(self) -> Self {
+				TaggedSquare::<crate::arch::ReuseMultiplyStrategy>::square(self)
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
Part of [BINIUS-138](https://linear.app/jimpo/issue/BINIUS-138/ghash-m512-fails-to-compile-on-x86-64-avx512f-without-vpclmulqdq).

## Problem

`binius-field` fails to compile on x86_64 when `avx512f` is enabled but `vpclmulqdq` is **not** (e.g. Skylake-X / Cascade Lake, reachable via `-C target-cpu=native`):

```
error[E0119]: conflicting implementations of trait `Square` for type
  `PackedPrimitiveType<arch::x86_64::m512::M512, ghash::BinaryField128bGhash>`
error[E0277]: the trait bound `PackedBinaryGhash4x128b: TaggedSquare<Ghash512Strategy>` is not satisfied
```

`define_packed_binary_field!` (called with `Ghash512Strategy` as the square strategy) already emits an `impl Square for PackedBinaryGhash4x128b` that forwards to `TaggedSquare::<Ghash512Strategy>::square`. The `else` (non-vpclmulqdq) branch then did `impl_square_with!(PackedBinaryGhash4x128b @ ReuseMultiplyStrategy)`, which expands to a **second** `impl Square` (→ E0119) and never implements `TaggedSquare<Ghash512Strategy>` (→ E0277).

This was latent: CI runs `-Ctarget-cpu=native` on heterogeneous GitHub runners, so it only triggers on an AVX-512 SKU that lacks `vpclmulqdq` (Ice Lake has it and dodges the path).

## Fix

In the `else` branch, implement `TaggedSquare<Ghash512Strategy>` (delegating to the reuse-multiply square, `x² = x·x`) rather than emitting a conflicting second `Square` impl — mirroring how `packed_ghash_256.rs` already structures both cfg branches. Behavior is unchanged (squaring still reuses multiplication in this rare config).

## Verification

On a machine with `avx512f` + `pclmulqdq` but not `vpclmulqdq` (the broken config):
- `RUSTFLAGS="-C target-cpu=native" cargo build/clippy -p binius-field` — now compiles, clippy `-D warnings` clean (previously failed to build).
- GHASH square/mul/invert tests (`test_square_packed_512`, …) pass under native.
- Portable `cargo test -p binius-field` — 219 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)