### PR TITLE
BINIUS-139: generic GHASH square strategies for x86_64 without vpclmulqdq

### DIFF
--- a/crates/field/src/arch/strategies.rs
+++ b/crates/field/src/arch/strategies.rs
@@ -1,7 +1,14 @@
 // Copyright 2024-2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-use crate::arithmetic_traits::{TaggedMul, WideMul};
+use std::marker::PhantomData;
+
+use crate::{
+	BinaryField,
+	arch::PackedPrimitiveType,
+	arithmetic_traits::{Square, TaggedMul, TaggedSquare, WideMul},
+	underlier::{Divisible, UnderlierType},
+};
 
 /// Packed strategy for arithmetic operations.
 /// (Uses arithmetic operations with underlier and subfield to simultaneously calculate the result
@@ -25,6 +32,29 @@ pub struct GfniSpecializedStrategy512b;
 
 /// Strategy for ScaledUnderlier operations that delegate to sub-underlier operations.
 pub struct ScaledStrategy;
+
+/// Strategy that squares by dividing the underlier into `SubU`-sized lanes, squaring each lane as a
+/// `PackedPrimitiveType<SubU, F>`, and recombining. A generic fallback for packings that lack a
+/// specialized full-width square.
+pub struct DivideStrategy<SubU>(PhantomData<SubU>);
+
+impl<U, SubU, F> TaggedSquare<DivideStrategy<SubU>> for PackedPrimitiveType<U, F>
+where
+	U: UnderlierType + Divisible<SubU>,
+	SubU: UnderlierType,
+	F: BinaryField,
+	PackedPrimitiveType<SubU, F>: Square,
+{
+	#[inline]
+	fn square(self) -> Self {
+		let squared = Divisible::<SubU>::value_iter(self.to_underlier()).map(|lane| {
+			PackedPrimitiveType::<SubU, F>::from_underlier(lane)
+				.square()
+				.to_underlier()
+		});
+		Self::from_underlier(Divisible::<SubU>::from_iter(squared))
+	}
+}
 
 /// Strategy that defines multiplication as `reduce(wide_mul(a, b))`, deferring to the type's own
 /// [`WideMul`] impl. Used by every GHASH packing so the (CLMUL-accelerated or scaled) widening

--- a/crates/field/src/arch/x86_64/arithmetic/ghash.rs
+++ b/crates/field/src/arch/x86_64/arithmetic/ghash.rs
@@ -15,7 +15,7 @@ use bytemuck::TransparentWrapper;
 
 use crate::{
 	BinaryField128bGhash as GhashB128, Divisible, WideMul, arch::PackedPrimitiveType,
-	underlier::UnderlierType,
+	arithmetic_traits::TaggedSquare, underlier::UnderlierType,
 };
 
 /// Trait for underliers that support CLMUL operations which are needed for the
@@ -50,6 +50,20 @@ pub fn square_clmul<U: ClMulUnderlier>(x: U) -> U {
 	t0 = gf2_128_reduce(t0, t1);
 
 	t0
+}
+
+/// Strategy for the full-width GHASH square via CLMUL, available for any [`ClMulUnderlier`] — this
+/// single impl covers `M256`/`M512` (and `M128`) whenever the corresponding CLMUL target feature is
+/// present.
+pub struct GhashClMulSquareStrategy;
+
+impl<U: ClMulUnderlier> TaggedSquare<GhashClMulSquareStrategy>
+	for PackedPrimitiveType<U, GhashB128>
+{
+	#[inline]
+	fn square(self) -> Self {
+		Self::from_underlier(square_clmul(self.to_underlier()))
+	}
 }
 
 // The reduction polynomial x^128 + x^7 + x^2 + x + 1 is represented as 0x87

--- a/crates/field/src/arch/x86_64/packed_ghash_256.rs
+++ b/crates/field/src/arch/x86_64/packed_ghash_256.rs
@@ -7,8 +7,10 @@
 //! available on modern x86_64 processors with AVX2 support. The implementation follows
 //! the algorithm described in the GHASH specification with polynomial x^128 + x^7 + x^2 + x + 1.
 
-use cfg_if::cfg_if;
-
+// Used by the `GhashWideMul` and `GhashSquareStrategy` fallbacks when VPCLMULQDQ is
+// unavailable.
+#[cfg(not(target_feature = "vpclmulqdq"))]
+use crate::arch::{portable::arithmetic::ghash_scaled::Scaled2xGhashWideMul, x86_64::m128::M128};
 use crate::{
 	BinaryField128bGhash,
 	arch::{
@@ -16,18 +18,7 @@ use crate::{
 		strategies::GhashMulStrategy,
 		x86_64::m256::M256,
 	},
-	arithmetic_traits::{
-		TaggedInvertOrZero, TaggedSquare, impl_invert_with, impl_mul_with, impl_square_with,
-	},
-};
-// Only used by the element-wise square fallback when VPCLMULQDQ is unavailable.
-#[cfg(not(target_feature = "vpclmulqdq"))]
-use crate::{
-	arch::{
-		portable::arithmetic::ghash_scaled::Scaled2xGhashWideMul,
-		x86_64::{m128::M128, packed_ghash_128::PackedBinaryGhash1x128b},
-	},
-	underlier::Divisible,
+	arithmetic_traits::{TaggedInvertOrZero, impl_invert_with, impl_mul_with, impl_square_with},
 };
 
 /// Widening-multiply wrapper used by the GHASH packing: the reduction-deferring vectorized
@@ -37,6 +28,13 @@ use crate::{
 pub type GhashWideMul<T> = crate::arch::x86_64::arithmetic::ghash::GhashClMulWideMul<T>;
 #[cfg(not(target_feature = "vpclmulqdq"))]
 pub type GhashWideMul<T> = Scaled2xGhashWideMul<T>;
+
+/// Square strategy for the GHASH packing: a full-width CLMUL square when VPCLMULQDQ is available,
+/// otherwise divide into 128-bit lanes and square each (the 1×128b GHASH square uses PCLMULQDQ).
+#[cfg(target_feature = "vpclmulqdq")]
+pub type GhashSquareStrategy = crate::arch::x86_64::arithmetic::ghash::GhashClMulSquareStrategy;
+#[cfg(not(target_feature = "vpclmulqdq"))]
+pub type GhashSquareStrategy = crate::arch::DivideStrategy<M128>;
 
 #[cfg(target_feature = "vpclmulqdq")]
 mod vpclmulqdq {
@@ -66,41 +64,10 @@ define_packed_binary_field!(
 	BinaryField128bGhash,
 	M256,
 	(GhashMulStrategy),
-	(Ghash256Strategy),
+	(GhashSquareStrategy),
 	(Ghash256Strategy),
 	(GhashWideMul)
 );
-
-// Implement TaggedSquare for Ghash256Strategy
-cfg_if! {
-	if #[cfg(target_feature = "vpclmulqdq")] {
-		impl TaggedSquare<Ghash256Strategy> for PackedBinaryGhash2x128b {
-			#[inline]
-			fn square(self) -> Self {
-				Self::from_underlier(crate::arch::x86_64::arithmetic::ghash::square_clmul(self.to_underlier()))
-			}
-		}
-	} else {
-		impl TaggedSquare<Ghash256Strategy> for PackedBinaryGhash2x128b {
-			#[inline]
-			fn square(self) -> Self {
-				let mut result_underlier = self.to_underlier();
-				unsafe {
-					let self_0 = Divisible::<M128>::get_unchecked(&self.to_underlier(), 0);
-					let self_1 = Divisible::<M128>::get_unchecked(&self.to_underlier(), 1);
-
-					let result_0 = crate::arithmetic_traits::Square::square(PackedBinaryGhash1x128b::from(self_0));
-					let result_1 = crate::arithmetic_traits::Square::square(PackedBinaryGhash1x128b::from(self_1));
-
-					Divisible::<M128>::set_unchecked(&mut result_underlier, 0, result_0.to_underlier());
-					Divisible::<M128>::set_unchecked(&mut result_underlier, 1, result_1.to_underlier());
-				}
-
-				Self::from_underlier(result_underlier)
-			}
-		}
-	}
-}
 
 // Implement TaggedInvertOrZero for Ghash256Strategy (Itoh-Tsujii over the full 256-bit vector)
 impl TaggedInvertOrZero<Ghash256Strategy> for PackedBinaryGhash2x128b {

--- a/crates/field/src/arch/x86_64/packed_ghash_512.rs
+++ b/crates/field/src/arch/x86_64/packed_ghash_512.rs
@@ -7,23 +7,21 @@
 //! available on modern x86_64 processors with AVX-512 support. The implementation follows
 //! the algorithm described in the GHASH specification with polynomial x^128 + x^7 + x^2 + x + 1.
 
-use cfg_if::cfg_if;
-
 use super::m512::M512;
-#[cfg(not(all(target_feature = "vpclmulqdq", target_feature = "avx512f")))]
-use crate::arch::portable::arithmetic::ghash_scaled::Scaled4xGhashWideMul;
 // Used by the CLMUL-accelerated `ClMulUnderlier` impl and the `GhashWideMul` alias below.
 #[cfg(all(target_feature = "vpclmulqdq", target_feature = "avx512f"))]
 use crate::arch::x86_64::arithmetic::ghash;
+// Used by the `GhashWideMul` and `GhashSquareStrategy` fallbacks when VPCLMULQDQ is
+// unavailable.
+#[cfg(not(all(target_feature = "vpclmulqdq", target_feature = "avx512f")))]
+use crate::arch::{portable::arithmetic::ghash_scaled::Scaled4xGhashWideMul, x86_64::m128::M128};
 use crate::{
 	BinaryField128bGhash,
 	arch::{
 		portable::packed_macros::{portable_macros::*, *},
 		strategies::GhashMulStrategy,
 	},
-	arithmetic_traits::{
-		TaggedInvertOrZero, TaggedSquare, impl_invert_with, impl_mul_with, impl_square_with,
-	},
+	arithmetic_traits::{TaggedInvertOrZero, impl_invert_with, impl_mul_with, impl_square_with},
 };
 
 /// Widening-multiply wrapper used by the GHASH packing: the reduction-deferring vectorized
@@ -34,6 +32,14 @@ use crate::{
 pub type GhashWideMul<T> = ghash::GhashClMulWideMul<T>;
 #[cfg(not(all(target_feature = "vpclmulqdq", target_feature = "avx512f")))]
 pub type GhashWideMul<T> = Scaled4xGhashWideMul<T>;
+
+/// Square strategy for the GHASH packing: a full-width CLMUL square when VPCLMULQDQ + AVX-512 are
+/// available, otherwise divide into 128-bit lanes and square each (the 1×128b GHASH square uses
+/// PCLMULQDQ).
+#[cfg(all(target_feature = "vpclmulqdq", target_feature = "avx512f"))]
+pub type GhashSquareStrategy = ghash::GhashClMulSquareStrategy;
+#[cfg(not(all(target_feature = "vpclmulqdq", target_feature = "avx512f")))]
+pub type GhashSquareStrategy = crate::arch::DivideStrategy<M128>;
 
 #[cfg(all(target_feature = "vpclmulqdq", target_feature = "avx512f"))]
 impl ghash::ClMulUnderlier for M512 {
@@ -63,35 +69,10 @@ define_packed_binary_field!(
 	BinaryField128bGhash,
 	M512,
 	(GhashMulStrategy),
-	(Ghash512Strategy),
+	(GhashSquareStrategy),
 	(Ghash512Strategy),
 	(GhashWideMul)
 );
-
-// Implement TaggedSquare for Ghash512Strategy
-cfg_if! {
-	if #[cfg(all(target_feature = "vpclmulqdq", target_feature = "avx512f"))] {
-		impl TaggedSquare<Ghash512Strategy> for PackedBinaryGhash4x128b {
-			#[inline]
-			fn square(self) -> Self {
-				Self::from_underlier(crate::arch::x86_64::arithmetic::ghash::square_clmul(
-					self.to_underlier(),
-				))
-			}
-		}
-	} else {
-		// AVX-512 without VPCLMULQDQ is rare, so rather than a specialized square we reuse
-		// multiplication (x² = x·x). This must implement the `TaggedSquare<Ghash512Strategy>` that
-		// the macro-generated `Square` impl forwards to — emitting a second `Square` impl here would
-		// conflict with it.
-		impl TaggedSquare<Ghash512Strategy> for PackedBinaryGhash4x128b {
-			#[inline]
-			fn square(self) -> Self {
-				TaggedSquare::<crate::arch::ReuseMultiplyStrategy>::square(self)
-			}
-		}
-	}
-}
 
 // Implement TaggedInvertOrZero for Ghash512Strategy (Itoh-Tsujii over the full 512-bit vector)
 impl TaggedInvertOrZero<Ghash512Strategy> for PackedBinaryGhash4x128b {


### PR DESCRIPTION
Part of [BINIUS-139](https://linear.app/jimpo/issue/BINIUS-139/handle-x86-64-with-no-vpclmulqdq-better).

Follow-up to #1571, which left the `avx512f && !vpclmulqdq` GHASH square as a coarse reuse-multiply fallback. This replaces the per-module hand-written square impls in `packed_ghash_256`/`packed_ghash_512` with two reusable strategies, cfg-aliased exactly like `GhashWideMul`.

### Changes
- **`GhashClMulSquareStrategy`** (`arch/x86_64/arithmetic/ghash.rs`): one `impl<U: ClMulUnderlier> TaggedSquare<…> for PackedPrimitiveType<U, BinaryField128bGhash>` using `square_clmul` — covers M256 and M512 (and M128) wherever the CLMUL feature is present, replacing two copies of the same body.
- **`DivideStrategy<SubU>`** (`arch/strategies.rs`): generic fallback — `impl<U, SubU, F> TaggedSquare<DivideStrategy<SubU>> for PackedPrimitiveType<U, F> where U: Divisible<SubU>, PackedPrimitiveType<SubU, F>: Square`. Divides the underlier into `SubU` lanes (functional `value_iter().map(square).from_iter()`), squaring each independently. Generalizes the old hand-written 256 fallback (and drops its `unsafe`).
- Each module now cfg-aliases `GhashSquareStrategy` to `GhashClMulSquareStrategy` (CLMUL present) or `DivideStrategy<M128>` (fallback), and passes it to `define_packed_binary_field!` — mirroring how `wide_mul` already selects its strategy. The hand-written `cfg_if! { TaggedSquare<Ghash{256,512}Strategy> }` blocks are removed (net −50 LOC of duplicated arch code).

### Verification
- Compiles across: native (`avx512f`, no `vpclmulqdq` → exercises `DivideStrategy`), `+avx2+vpclmulqdq`, `+avx2+avx512f+vpclmulqdq` (→ `GhashClMulSquareStrategy` on M256+M512), sse2-baseline, aarch64 (`+neon,+aes`), wasm32.
- Native square tests pass — `packed_ghash::test_square_packed_256`/`512` exercise the new `DivideStrategy<M128>` fallback on this CPU and match the reference.
- Portable `cargo test -p binius-field` — 219 pass; crate clippy `-D warnings` + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)