### PR TITLE
BINIUS-137 (1/4): rename GhashMulStrategy to generic MulFromWideMul

### DIFF
--- a/crates/field/src/arch/aarch64/packed_ghash_128.rs
+++ b/crates/field/src/arch/aarch64/packed_ghash_128.rs
@@ -12,7 +12,7 @@ use crate::{
 	BinaryField128bGhash,
 	arch::{
 		portable::packed_macros::{portable_macros::*, *},
-		strategies::GhashMulStrategy,
+		strategies::MulFromWideMul,
 	},
 	arithmetic_traits::{
 		TaggedInvertOrZero, TaggedSquare, impl_invert_with, impl_mul_with, impl_square_with,
@@ -31,7 +31,7 @@ define_packed_binary_field!(
 	PackedBinaryGhash1x128b,
 	BinaryField128bGhash,
 	M128,
-	(GhashMulStrategy),
+	(MulFromWideMul),
 	(GhashStrategy),
 	(GhashStrategy),
 	(GhashWideMul)

--- a/crates/field/src/arch/portable/packed_ghash_128.rs
+++ b/crates/field/src/arch/portable/packed_ghash_128.rs
@@ -12,7 +12,7 @@ use super::{
 use crate::{
 	arch::{
 		portable::packed_macros::{portable_macros::*, *},
-		strategies::GhashMulStrategy,
+		strategies::MulFromWideMul,
 	},
 	arithmetic_traits::{TaggedInvertOrZero, TaggedSquare},
 	ghash::BinaryField128bGhash,
@@ -51,7 +51,7 @@ define_packed_binary_field!(
 	PackedBinaryGhash1x128b,
 	BinaryField128bGhash,
 	M128,
-	(GhashMulStrategy),
+	(MulFromWideMul),
 	(GhashStrategy),
 	(GhashStrategy),
 	(GhashWideMul)

--- a/crates/field/src/arch/portable/packed_ghash_256.rs
+++ b/crates/field/src/arch/portable/packed_ghash_256.rs
@@ -6,7 +6,7 @@ use super::{
 	m256::M256,
 	packed_macros::{portable_macros::*, *},
 };
-use crate::arch::strategies::{GhashMulStrategy, ScaledStrategy};
+use crate::arch::strategies::{MulFromWideMul, ScaledStrategy};
 
 define_packed_binary_fields!(
 	underlier: M256,
@@ -14,7 +14,7 @@ define_packed_binary_fields!(
 		packed_field {
 			name: PackedBinaryGhash2x128b,
 			scalar: BinaryField128bGhash,
-			mul:       (GhashMulStrategy),
+			mul:       (MulFromWideMul),
 			square:    (ScaledStrategy),
 			invert:    (ScaledStrategy),
 			wide_mul: (Scaled2xGhashWideMul),

--- a/crates/field/src/arch/portable/packed_ghash_512.rs
+++ b/crates/field/src/arch/portable/packed_ghash_512.rs
@@ -6,7 +6,7 @@ use super::{
 	m512::M512,
 	packed_macros::{portable_macros::*, *},
 };
-use crate::arch::strategies::{GhashMulStrategy, ScaledStrategy};
+use crate::arch::strategies::{MulFromWideMul, ScaledStrategy};
 
 define_packed_binary_fields!(
 	underlier: M512,
@@ -14,7 +14,7 @@ define_packed_binary_fields!(
 		packed_field {
 			name: PackedBinaryGhash4x128b,
 			scalar: BinaryField128bGhash,
-			mul:       (GhashMulStrategy),
+			mul:       (MulFromWideMul),
 			square:    (ScaledStrategy),
 			invert:    (ScaledStrategy),
 			wide_mul: (Scaled4xGhashWideMul),

--- a/crates/field/src/arch/strategies.rs
+++ b/crates/field/src/arch/strategies.rs
@@ -57,11 +57,11 @@ where
 }
 
 /// Strategy that defines multiplication as `reduce(wide_mul(a, b))`, deferring to the type's own
-/// [`WideMul`] impl. Used by every GHASH packing so the (CLMUL-accelerated or scaled) widening
-/// multiply is the single source of truth for both `Mul` and `WideMul`.
-pub struct GhashMulStrategy;
+/// [`WideMul`] impl, making the widening multiply the single source of truth for both `Mul` and
+/// `WideMul`. Used by every GHASH and AES packing.
+pub struct MulFromWideMul;
 
-impl<P: WideMul> TaggedMul<GhashMulStrategy> for P {
+impl<P: WideMul> TaggedMul<MulFromWideMul> for P {
 	#[inline]
 	fn mul(self, rhs: Self) -> Self {
 		P::reduce(P::wide_mul(self, rhs))

--- a/crates/field/src/arch/x86_64/packed_ghash_128.rs
+++ b/crates/field/src/arch/x86_64/packed_ghash_128.rs
@@ -19,7 +19,7 @@ use crate::{
 	BinaryField128bGhash,
 	arch::{
 		portable::packed_macros::{portable_macros::*, *},
-		strategies::GhashMulStrategy,
+		strategies::MulFromWideMul,
 	},
 	arithmetic_traits::{
 		TaggedInvertOrZero, TaggedSquare, impl_invert_with, impl_mul_with, impl_square_with,
@@ -86,7 +86,7 @@ define_packed_binary_field!(
 	PackedBinaryGhash1x128b,
 	BinaryField128bGhash,
 	M128,
-	(GhashMulStrategy),
+	(MulFromWideMul),
 	(GhashStrategy),
 	(GhashStrategy),
 	(GhashWideMul)

--- a/crates/field/src/arch/x86_64/packed_ghash_256.rs
+++ b/crates/field/src/arch/x86_64/packed_ghash_256.rs
@@ -15,7 +15,7 @@ use crate::{
 	BinaryField128bGhash,
 	arch::{
 		portable::packed_macros::{portable_macros::*, *},
-		strategies::GhashMulStrategy,
+		strategies::MulFromWideMul,
 		x86_64::m256::M256,
 	},
 	arithmetic_traits::{TaggedInvertOrZero, impl_invert_with, impl_mul_with, impl_square_with},
@@ -63,7 +63,7 @@ define_packed_binary_field!(
 	PackedBinaryGhash2x128b,
 	BinaryField128bGhash,
 	M256,
-	(GhashMulStrategy),
+	(MulFromWideMul),
 	(GhashSquareStrategy),
 	(Ghash256Strategy),
 	(GhashWideMul)

--- a/crates/field/src/arch/x86_64/packed_ghash_512.rs
+++ b/crates/field/src/arch/x86_64/packed_ghash_512.rs
@@ -19,7 +19,7 @@ use crate::{
 	BinaryField128bGhash,
 	arch::{
 		portable::packed_macros::{portable_macros::*, *},
-		strategies::GhashMulStrategy,
+		strategies::MulFromWideMul,
 	},
 	arithmetic_traits::{TaggedInvertOrZero, impl_invert_with, impl_mul_with, impl_square_with},
 };
@@ -68,7 +68,7 @@ define_packed_binary_field!(
 	PackedBinaryGhash4x128b,
 	BinaryField128bGhash,
 	M512,
-	(GhashMulStrategy),
+	(MulFromWideMul),
 	(GhashSquareStrategy),
 	(Ghash512Strategy),
 	(GhashWideMul)


### PR DESCRIPTION
Part of [BINIUS-137](https://linear.app/jimpo/issue/BINIUS-137/define-widemul-strategies-for-aes-packed-fields) — PR 1 of 4 (the [plan](https://linear.app/jimpo/issue/BINIUS-137/define-widemul-strategies-for-aes-packed-fields) is on the ticket).

Foundation for inverting AES `Mul`/`WideMul`. `GhashMulStrategy` is already fully generic — `impl<P: WideMul> TaggedMul<…> for P { mul = reduce(wide_mul(a,b)) }` — and is about to be used by AES packings too, so this renames it to the non-GHASH-specific **`MulFromWideMul`** (jimpo's chosen name) and updates its doc.

Pure mechanical rename across `strategies.rs` + the 7 `packed_ghash_*` modules; no behavior change.

Verification: native build + clippy `-D warnings` clean, portable `cargo test -p binius-field` 219 pass, aarch64 (`+neon,+aes`) checks; fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)