### PR TITLE
BINIUS-140: use blake3_compress_2x_seq in blake3_fixed (~42% fewer AND gates)

### DIFF
--- a/crates/circuits/src/blake3/compress.rs
+++ b/crates/circuits/src/blake3/compress.rs
@@ -200,8 +200,8 @@ fn round(builder: &CircuitBuilder, state: &mut [Wire; 16], msg: &[Wire; 16], rou
 ///
 /// - `cv`: input chaining value for the first compression (8 words).
 /// - `blocks`: the two message blocks (`blocks[0]` for C1, `blocks[1]` for C2), 16 words each.
-/// - `counter`: the 64-bit block counter for the first compression. The second compression's
-///   counter is this one incremented by one (the two compressions form a sequence).
+/// - `counter`: the 64-bit block counter, shared by both compressions. Sequential chaining only
+///   happens within a single BLAKE3 chunk, where every block carries the chunk counter unchanged.
 /// - `block_lens`: per-compression block lengths.
 /// - `flags`: per-compression flags.
 ///
@@ -244,10 +244,13 @@ pub fn blake3_compress_2x_seq(
 
 	let merged_block: [Wire; 16] = array::from_fn(|i| pack(clear(blocks[1][i]), blocks[0][i]));
 
-	// The second compression's counter is the first's incremented by one.
-	let (counter2, _carry) = builder.iadd(counter, builder.add_constant_64(1));
-	let merged_counter_lo = pack(clear(counter2), counter);
-	let merged_counter_hi = pack(builder.shr(counter2, 32), builder.shr(counter, 32));
+	// Both compressions share the same block counter. Sequential chaining (C2 takes C1's output
+	// as its input chaining value) only occurs within a single BLAKE3 chunk, and every block in a
+	// chunk carries the chunk counter unchanged.
+	let counter_lo = clear(counter);
+	let counter_hi = builder.shr(counter, 32);
+	let merged_counter_lo = pack(counter_lo, counter_lo);
+	let merged_counter_hi = pack(counter_hi, counter_hi);
 	let merged_block_len = pack(clear(block_lens[1]), block_lens[0]);
 	let merged_flags = pack(clear(flags[1]), flags[0]);
 
@@ -654,9 +657,9 @@ mod tests {
 		w[block_len2_w] = Word(block_len2 as u64);
 		w[flags2_w] = Word(flags2 as u64);
 
-		// Expected: the first compression feeds the second; the second's counter is one greater.
+		// Expected: the first compression feeds the second; both share the same counter.
 		let c1 = ref_compress(&cv, &block1, counter, block_len1, flags1);
-		let c2 = ref_compress(&c1, &block2, counter + 1, block_len2, flags2);
+		let c2 = ref_compress(&c1, &block2, counter, block_len2, flags2);
 		for i in 0..8 {
 			w[out_inout[i]] = Word(pack2x(c2[i], c1[i]));
 		}
@@ -689,7 +692,7 @@ mod tests {
 		);
 		let exp_c1 = ref_compress(&cv, &block1, 0, 64, super::super::CHUNK_START);
 		let exp_c2 =
-			ref_compress(&exp_c1, &block2, 1, 64, super::super::CHUNK_END | super::super::ROOT);
+			ref_compress(&exp_c1, &block2, 0, 64, super::super::CHUNK_END | super::super::ROOT);
 		assert_eq!(c1, exp_c1);
 		assert_eq!(c2, exp_c2);
 	}
@@ -709,8 +712,8 @@ mod tests {
 		let block1: [u32; 16] = array::from_fn(|i| (i as u32).wrapping_mul(0x0101_0101));
 		let block2: [u32; 16] = array::from_fn(|i| (i as u32).wrapping_mul(0xDEAD_BEEFu32));
 		// Distinct block lengths / flags per compression exercise the lane packing of every
-		// parameter. The counter has a nonzero high half and a low half of all ones, so the
-		// in-circuit `+1` for the second compression carries across the 32-bit boundary.
+		// parameter. The counter has a nonzero high half so both 32-bit halves are packed into
+		// both lanes.
 		let counter: u64 = 0x0000_0001_FFFF_FFFF;
 		let (c2, c1) = run_compress_2x_seq(
 			cv,
@@ -723,7 +726,7 @@ mod tests {
 			super::super::CHUNK_END,
 		);
 		let exp_c1 = ref_compress(&cv, &block1, counter, 64, super::super::CHUNK_START);
-		let exp_c2 = ref_compress(&exp_c1, &block2, counter + 1, 40, super::super::CHUNK_END);
+		let exp_c2 = ref_compress(&exp_c1, &block2, counter, 40, super::super::CHUNK_END);
 		assert_eq!(c1, exp_c1);
 		assert_eq!(c2, exp_c2);
 	}

--- a/crates/circuits/src/blake3/mod.rs
+++ b/crates/circuits/src/blake3/mod.rs
@@ -16,6 +16,8 @@
 use binius_core::word::Word;
 use binius_frontend::{CircuitBuilder, Wire};
 
+use crate::util::clear_high_bits;
+
 pub mod compress;
 
 pub use compress::{blake3_compress, blake3_compress_2x, blake3_compress_2x_seq};
@@ -115,41 +117,70 @@ pub fn blake3_fixed(builder: &CircuitBuilder, message: &[Wire], len_bytes: usize
 	}
 	padded.resize(n_padded_words, zero);
 
-	// Constants used each block.
+	// All blocks of a single chunk share the chunk counter (0).
 	let counter = zero;
-	let flag_start = builder.add_constant(Word(CHUNK_START as u64));
-	let flag_end_root = builder.add_constant(Word((CHUNK_END | ROOT) as u64));
-	let flag_start_end_root = builder.add_constant(Word((CHUNK_START | CHUNK_END | ROOT) as u64));
-	let flag_zero = zero;
+
+	// Per-block message words, byte lengths, and domain-separation flags.
+	let mut blocks: Vec<[Wire; 16]> = (0..n_blocks)
+		.map(|j| std::array::from_fn(|i| padded[j * 16 + i]))
+		.collect();
+	let mut block_lens: Vec<Wire> = (0..n_blocks)
+		.map(|j| {
+			let len = if j + 1 == n_blocks {
+				len_bytes - j * BLOCK_BYTES
+			} else {
+				BLOCK_BYTES
+			};
+			builder.add_constant(Word(len as u64))
+		})
+		.collect();
+	let mut flags: Vec<Wire> = (0..n_blocks)
+		.map(|j| {
+			let start = if j == 0 { CHUNK_START } else { 0 };
+			let end = if j + 1 == n_blocks {
+				CHUNK_END | ROOT
+			} else {
+				0
+			};
+			builder.add_constant(Word((start | end) as u64))
+		})
+		.collect();
+
+	// Pad to an even block count with one unused dummy block so the blocks pair up uniformly.
+	let odd = n_blocks % 2 == 1;
+	if odd {
+		blocks.push([zero; 16]);
+		block_lens.push(zero);
+		flags.push(zero);
+	}
 
 	// Initial chaining value = IV.
 	let mut cv: [Wire; 8] = std::array::from_fn(|i| builder.add_constant(Word(IV[i] as u64)));
 
-	for block_idx in 0..n_blocks {
-		let block: [Wire; 16] = std::array::from_fn(|i| padded[block_idx * 16 + i]);
-
-		let block_byte_count = if block_idx + 1 == n_blocks {
-			len_bytes - block_idx * BLOCK_BYTES
-		} else {
-			BLOCK_BYTES
-		};
-		let block_len = builder.add_constant(Word(block_byte_count as u64));
-
-		let flags = match (block_idx == 0, block_idx + 1 == n_blocks) {
-			(true, true) => flag_start_end_root,
-			(true, false) => flag_start,
-			(false, true) => flag_end_root,
-			(false, false) => flag_zero,
-		};
-
-		cv = blake3_compress(
-			&builder.subcircuit(format!("blake3_fixed_compress[{block_idx}]")),
+	// Compress two blocks at a time: `blake3_compress_2x_seq` chains two sequential block
+	// compressions through a single parallel core, roughly halving the per-block cost.
+	let n_pairs = blocks.len() / 2;
+	for pair in 0..n_pairs {
+		let (lo, hi) = (2 * pair, 2 * pair + 1);
+		let out = blake3_compress_2x_seq(
+			&builder.subcircuit(format!("blake3_fixed_compress[{pair}]")),
 			cv,
-			block,
+			[blocks[lo], blocks[hi]],
 			counter,
-			block_len,
-			flags,
+			[block_lens[lo], block_lens[hi]],
+			[flags[lo], flags[hi]],
 		);
+		// The chaining value after the pair is the second compression's output, in the low 32 bits
+		// of each word. On a trailing odd block the second lane is the unused dummy, so the chunk's
+		// chaining value is instead the first compression's output, in the high 32 bits.
+		let last_odd = odd && pair + 1 == n_pairs;
+		cv = std::array::from_fn(|i| {
+			if last_odd {
+				builder.shr(out[i], 32)
+			} else {
+				clear_high_bits(builder, out[i], 32)
+			}
+		});
 	}
 
 	cv
@@ -222,7 +253,11 @@ mod tests {
 
 	#[test]
 	fn block_boundaries() {
-		for &len in &[1usize, 63, 64, 65, 127, 128, 511, 512, 1023, 1024] {
+		// Lengths chosen to cover 1..=16 blocks, including odd block counts (3, 5, 7) that
+		// exercise the trailing single-block compression after the 2x-sequential pairs.
+		for &len in &[
+			1usize, 63, 64, 65, 127, 128, 129, 192, 256, 257, 320, 448, 511, 512, 1023, 1024,
+		] {
 			let input: Vec<u8> = (0..len).map(|i| (i * 37 + 1) as u8).collect();
 			check(&input);
 		}


### PR DESCRIPTION
## Summary

[BINIUS-140](https://linear.app/jimpo/issue/BINIUS-140/fixed-length-blake3-hash-gadget-for-length-1024-bytes) asks for the single-chunk `blake3_fixed` gadget (≤1024 bytes) to use `blake3_compress_2x_seq` for efficiency. The gadget already existed on `main` (the `sha256_fixed`-style signature was already in place) but compressed blocks **sequentially, one `blake3_compress` per 64-byte block** (up to 16). This PR pairs adjacent block compressions onto the shared 2× parallel core, roughly halving the dominant compression cost.

Two cohesive commits:

1. **Share the block counter across `blake3_compress_2x_seq` compressions.** The primitive hardcoded `counter2 = counter + 1` for the second compression. That is wrong for chaining two blocks *within a single chunk*: BLAKE3 blocks in a chunk all carry the **same** chunk counter (the existing `blake3_fixed` correctly passes `counter = 0` to every block). Sequential CV-chaining (`C2 = compress(C1, …)`) only ever happens within a chunk, so the counter is now shared by both compressions rather than incremented. No non-test callers existed, so the API change is contained to this commit.

2. **Pair sequential block compressions in `blake3_fixed`.** A single loop of `ceil(n_blocks / 2)` iterations, each calling `blake3_compress_2x_seq`. Per-block message words / lengths / flags are built as vectors and padded with one unused dummy block when `n_blocks` is odd, so every iteration pairs uniformly. The running chaining value is the second compression's output (low 32 bits of each word); for a trailing odd block the second lane is the dummy, so the result is taken from the first compression's output (high 32 bits) instead. Behavior is unchanged — verified against `blake3::hash`.

## Performance (AND constraints, the dominant gate; MUL is 0 throughout)

| message len | blocks | before | after | Δ |
|---|---|---|---|---|
| 64 B | 1 | 634 | 681 | +7.4% |
| 128 B | 2 | 1220 | 689 | −43.5% |
| 512 B | 8 | 4742 | 2756 | −41.9% |
| 1024 B | 16 | 9442 | 5512 | −41.6% |

Multi-block messages drop ~42%. A single-block message (≤64 B) costs ~47 more AND constraints, because it now runs `2x_seq` with a dummy second lane rather than a lone `blake3_compress` — the cost of the uniform single-loop structure.

## Testing

- `cargo test -p binius-circuits` — all 351 pass.
- `blake3_fixed` `block_boundaries` extended to cover odd block counts (3, 5, 7 blocks) that exercise the trailing-odd-block path.
- `blake3_compress_2x_seq` tests updated to the shared-counter semantics.
- `cargo +nightly-2026-01-01 fmt --check` and full-workspace `cargo clippy --all --tests --benches --examples -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)