### PR TITLE
BINIUS-137 (4/4): aarch64 vmull_p8 AES WideMul

### DIFF
--- a/crates/field/src/arch/aarch64/packed_aes_128.rs
+++ b/crates/field/src/arch/aarch64/packed_aes_128.rs
@@ -1,44 +1,47 @@
 // Copyright 2024-2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-use std::ops::Mul;
-
 use super::{
 	m128::M128,
-	simd_arithmetic::{
-		packed_aes_16x8b_invert_or_zero, packed_aes_16x8b_multiply, packed_aes_16x8b_square,
-	},
+	simd_arithmetic::{VmullWideMul, packed_aes_16x8b_invert_or_zero, packed_aes_16x8b_square},
 };
 use crate::{
 	aes_field::AESTowerField8b,
-	arch::portable::packed::PackedPrimitiveType,
-	arithmetic_traits::{InvertOrZero, Square},
+	arch::{
+		portable::packed_macros::{portable_macros::*, *},
+		strategies::MulFromWideMul,
+	},
+	arithmetic_traits::{
+		TaggedInvertOrZero, TaggedSquare, impl_invert_with, impl_mul_with, impl_square_with,
+	},
 	underlier::WithUnderlier,
 };
 
-pub type PackedAESBinaryField16x8b = PackedPrimitiveType<M128, AESTowerField8b>;
+/// Strategy for aarch64 AES square/invert, both backed by `vqtbl` lookup tables.
+pub struct AesStrategy;
 
-// Defined by hand rather than via `define_packed_binary_fields!`, so the trivial `WideMul` impl
-// (a parent trait of `PackedField`) must be emitted explicitly here.
-crate::arithmetic_traits::impl_trivial_wide_mul!(PackedAESBinaryField16x8b);
+// Define PackedAESBinaryField16x8b using the macro. `Mul` is derived from `WideMul` (supplied by
+// the `VmullWideMul` wrapper, whose `vmull_p8` multiply already produces the reduced byte); square
+// and invert use lookup tables via `AesStrategy`.
+define_packed_binary_field!(
+	PackedAESBinaryField16x8b,
+	AESTowerField8b,
+	M128,
+	(MulFromWideMul),
+	(AesStrategy),
+	(AesStrategy),
+	(VmullWideMul)
+);
 
-impl Mul for PackedAESBinaryField16x8b {
-	type Output = Self;
-
-	fn mul(self, rhs: Self) -> Self {
-		crate::tracing::trace_multiplication!(PackedAESBinaryField16x8b);
-
-		self.mutate_underlier(|underlier| packed_aes_16x8b_multiply(underlier, rhs.to_underlier()))
-	}
-}
-
-impl Square for PackedAESBinaryField16x8b {
+impl TaggedSquare<AesStrategy> for PackedAESBinaryField16x8b {
+	#[inline]
 	fn square(self) -> Self {
 		self.mutate_underlier(packed_aes_16x8b_square)
 	}
 }
 
-impl InvertOrZero for PackedAESBinaryField16x8b {
+impl TaggedInvertOrZero<AesStrategy> for PackedAESBinaryField16x8b {
+	#[inline]
 	fn invert_or_zero(self) -> Self {
 		self.mutate_underlier(packed_aes_16x8b_invert_or_zero)
 	}
@@ -49,7 +52,7 @@ mod tests {
 	use proptest::prelude::*;
 
 	use super::*;
-	use crate::Divisible;
+	use crate::{Divisible, arithmetic_traits::Square};
 
 	proptest! {
 		#[test]

--- a/crates/field/src/arch/aarch64/simd_arithmetic.rs
+++ b/crates/field/src/arch/aarch64/simd_arithmetic.rs
@@ -1,9 +1,19 @@
 // Copyright 2024-2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-use std::arch::aarch64::*;
+use std::{
+	arch::aarch64::*,
+	iter::Sum,
+	ops::{Add, AddAssign, Sub, SubAssign},
+};
+
+use bytemuck::TransparentWrapper;
 
 use super::m128::M128;
+use crate::{
+	aes_field::AESTowerField8b, arch::portable::packed::PackedPrimitiveType,
+	arithmetic_traits::WideMul,
+};
 
 #[inline]
 pub fn packed_aes_16x8b_invert_or_zero(x: M128) -> M128 {
@@ -53,18 +63,95 @@ pub fn packed_aes_16x8b_square(x: M128) -> M128 {
 	}
 }
 
+/// The unreduced product of two [`PackedAESBinaryField16x8b`](PackedPrimitiveType) values: the 16
+/// per-byte carryless products, split into their low bytes (`lo`, which need no reduction) and high
+/// bytes (`hi`, the overflow above `x^7` still to be folded down). Both the carryless multiply and
+/// the GF(2^8) reduction are linear, so products accumulate by XOR and reduce once at the end via
+/// [`packed_aes_16x8b_reduce`].
+#[derive(Clone, Copy, Default, Debug)]
+pub struct WideAes16x8bProduct {
+	lo: M128,
+	hi: M128,
+}
+
+impl Add for WideAes16x8bProduct {
+	type Output = Self;
+
+	#[inline]
+	fn add(self, rhs: Self) -> Self {
+		Self {
+			lo: self.lo ^ rhs.lo,
+			hi: self.hi ^ rhs.hi,
+		}
+	}
+}
+
+impl AddAssign for WideAes16x8bProduct {
+	#[inline]
+	fn add_assign(&mut self, rhs: Self) {
+		self.lo ^= rhs.lo;
+		self.hi ^= rhs.hi;
+	}
+}
+
+// In characteristic 2, subtraction is identical to addition (XOR).
+impl Sub for WideAes16x8bProduct {
+	type Output = Self;
+
+	#[inline]
+	fn sub(self, rhs: Self) -> Self {
+		Self {
+			lo: self.lo ^ rhs.lo,
+			hi: self.hi ^ rhs.hi,
+		}
+	}
+}
+
+impl SubAssign for WideAes16x8bProduct {
+	#[inline]
+	fn sub_assign(&mut self, rhs: Self) {
+		self.lo ^= rhs.lo;
+		self.hi ^= rhs.hi;
+	}
+}
+
+impl Sum for WideAes16x8bProduct {
+	#[inline]
+	fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+		iter.fold(Self::default(), |acc, x| acc + x)
+	}
+}
+
+/// Widening (unreduced) GF(2^8) multiply of the packed bytes via `vmull_p8`, deferring reduction.
+/// See <https://doc.rust-lang.org/beta/core/arch/x86_64/fn._mm_gf2p8mul_epi8.html>.
 #[inline]
-pub fn packed_aes_16x8b_multiply(a: M128, b: M128) -> M128 {
-	//! Performs a multiplication in GF(2^8) on the packed bytes.
-	//! See <https://doc.rust-lang.org/beta/core/arch/x86_64/fn._mm_gf2p8mul_epi8.html>
+pub fn packed_aes_16x8b_wide_mul(a: M128, b: M128) -> WideAes16x8bProduct {
 	unsafe {
 		let a = vreinterpretq_p8_p128(a.into());
 		let b = vreinterpretq_p8_p128(b.into());
 		let c0 = vreinterpretq_p8_p16(vmull_p8(vget_low_p8(a), vget_low_p8(b)));
 		let c1 = vreinterpretq_p8_p16(vmull_p8(vget_high_p8(a), vget_high_p8(b)));
 
-		// Reduces the 16-bit output of a carryless multiplication to 8 bits using equation 22 in
-		// https://www.intel.com/content/dam/develop/external/us/en/documents/clmul-wp-rev-2-02-2014-04-20.pdf
+		// Deinterleave the 16 per-byte carryless products into their low bytes (`lo`) and high
+		// bytes (`hi`, the part above `x^7` that the reduction folds back down).
+		let cl = vuzp1q_p8(c0, c1);
+		let ch = vuzp2q_p8(c0, c1);
+
+		WideAes16x8bProduct {
+			lo: vreinterpretq_p128_p8(cl).into(),
+			hi: vreinterpretq_p128_p8(ch).into(),
+		}
+	}
+}
+
+/// Reduces an accumulated [`WideAes16x8bProduct`] back to the packed GF(2^8) bytes.
+#[inline]
+pub fn packed_aes_16x8b_reduce(wide: WideAes16x8bProduct) -> M128 {
+	// Reduces the 16-bit output of a carryless multiplication to 8 bits using equation 22 in
+	// https://www.intel.com/content/dam/develop/external/us/en/documents/clmul-wp-rev-2-02-2014-04-20.pdf
+	unsafe {
+		let cl = vreinterpretq_p8_p128(wide.lo.into());
+		let ch = vreinterpretq_p8_p128(wide.hi.into());
 
 		// Since q+(x) doesn't fit into 8 bits, we right shift the polynomial (divide by x) and
 		// correct for this later. This works because q+(x) is divisible by x/the last polynomial
@@ -73,9 +160,6 @@ pub fn packed_aes_16x8b_multiply(a: M128, b: M128) -> M128 {
 
 		// q*(x) = x^4 + x^3 + x + 1 = 0b00011011 = 0x1b
 		const QSTAR: poly8x8_t = unsafe { std::mem::transmute(0x1b1b1b1b1b1b1b1b_u64) };
-
-		let cl = vuzp1q_p8(c0, c1);
-		let ch = vuzp2q_p8(c0, c1);
 
 		let tmp0 = vmull_p8(vget_low_p8(ch), QPLUS_RSH1);
 		let tmp1 = vmull_p8(vget_high_p8(ch), QPLUS_RSH1);
@@ -90,6 +174,28 @@ pub fn packed_aes_16x8b_multiply(a: M128, b: M128) -> M128 {
 		let tmp_lo = vuzp1q_p8(tmp0, tmp1);
 
 		vreinterpretq_p128_p8(vaddq_p8(cl, tmp_lo)).into()
+	}
+}
+
+/// Widening-multiply wrapper for the aarch64 `vmull_p8` AES packing, mirroring the GHASH
+/// [`GhashClMulWideMul`](super::arithmetic::ghash::GhashClMulWideMul) pattern: `wide_mul` runs the
+/// carryless multiply (deferring reduction) and `reduce` folds the high bytes back down. The packed
+/// field forwards its `WideMul` to this via the `define_packed_binary_field!` macro.
+#[repr(transparent)]
+#[derive(TransparentWrapper)]
+pub struct VmullWideMul<T>(T);
+
+impl WideMul for VmullWideMul<PackedPrimitiveType<M128, AESTowerField8b>> {
+	type Output = WideAes16x8bProduct;
+
+	#[inline]
+	fn wide_mul(a: Self, b: Self) -> Self::Output {
+		packed_aes_16x8b_wide_mul(Self::peel(a).to_underlier(), Self::peel(b).to_underlier())
+	}
+
+	#[inline]
+	fn reduce(wide: Self::Output) -> Self {
+		Self::wrap(PackedPrimitiveType::from_underlier(packed_aes_16x8b_reduce(wide)))
 	}
 }
 


### PR DESCRIPTION
Part of [BINIUS-137](https://linear.app/jimpo/issue/BINIUS-137/define-widemul-strategies-for-aes-packed-fields) — PR 4 of 4 (final). Builds on #1576.

Completes the `WideMul`-primary migration for AES packings by converting the **aarch64** path (issue strategy #4): the `vmull_p8` GF(2⁸) multiply is split into a deferred-reduction `wide_mul` + `reduce` behind a wrapper struct, mirroring the GHASH `GhashClMulWideMul` pattern, and the packed field is driven through the `define_packed_binary_field!` macro so its `Mul` derives from `WideMul`.

### Changes
- **`aarch64/simd_arithmetic.rs`**: split `packed_aes_16x8b_multiply` into `packed_aes_16x8b_wide_mul` (carryless `vmull_p8` multiply, no reduction) and `packed_aes_16x8b_reduce` (Barrett fold). The unreduced product is a new `WideAes16x8bProduct { lo, hi }` — the 16 per-byte carryless products' low bytes and high (overflow) bytes — which accumulates by XOR and reduces once (both steps are linear). A `VmullWideMul<T>` `TransparentWrapper` carries the `WideMul` impl (`Output = WideAes16x8bProduct`).
- **`aarch64/packed_aes_128.rs`**: `PackedAESBinaryField16x8b` now uses `define_packed_binary_field!`, forwarding `WideMul` to `VmullWideMul` and deriving `Mul = MulFromWideMul`. Square/invert move to a lookup-table `AesStrategy` (`TaggedSquare`/`TaggedInvertOrZero`).

With this, all AES packings across every backend (portable lookup/elementwise, x86_64 GFNI, scaled M256/M512, and now aarch64 `vmull_p8`) obtain `Mul` from `WideMul` — matching GHASH, as the issue specified. Exposing a real `wide_mul`/`reduce` split (rather than `Output = Self`) leaves room for later deferred-reduction refactors.

### Verification
- Cross-compiles + clippy `-D warnings`: aarch64 (`+neon,+aes`); native (x86_64) build; portable `cargo test -p binius-field` (212) green; fmt clean.
- **aarch64 `vmull_p8` runtime**: can't run on this x86_64 host, so multiply correctness is covered by CI's `rust-checks-arm64`. The `vmull_p8` / reduction instruction sequence is byte-for-byte the original — only refactored into the two functions — and `test_square_equals_self_mul_self` exercises the `Mul = reduce(wide_mul)` path on arm64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)