### PR TITLE
BINIUS-141: lift Ghash packed field definitions into binius_field::packed_ghash

### DIFF
--- a/crates/field/benches/ghash_invert.rs
+++ b/crates/field/benches/ghash_invert.rs
@@ -9,11 +9,8 @@
 use std::hint::black_box;
 
 use binius_field::{
-	BinaryField128bGhash as GhashB128, PackedField,
-	arch::{
-		packed_ghash_128::PackedBinaryGhash1x128b, packed_ghash_256::PackedBinaryGhash2x128b,
-		packed_ghash_512::PackedBinaryGhash4x128b,
-	},
+	BinaryField128bGhash as GhashB128, PackedBinaryGhash1x128b, PackedBinaryGhash2x128b,
+	PackedBinaryGhash4x128b, PackedField,
 };
 use criterion::{
 	BenchmarkGroup, Criterion, Throughput, criterion_group, criterion_main, measurement::WallTime,

--- a/crates/field/benches/packed_field_invert.rs
+++ b/crates/field/benches/packed_field_invert.rs
@@ -3,11 +3,9 @@
 mod packed_field_utils;
 
 use binius_field::{
-	PackedBinaryField128x1b, PackedBinaryField256x1b, PackedBinaryField512x1b, PackedField,
-	arch::{
-		packed_aes_128::*, packed_aes_256::*, packed_aes_512::*, packed_ghash_128::*,
-		packed_ghash_256::*, packed_ghash_512::*,
-	},
+	PackedBinaryField128x1b, PackedBinaryField256x1b, PackedBinaryField512x1b,
+	PackedBinaryGhash1x128b, PackedBinaryGhash2x128b, PackedBinaryGhash4x128b, PackedField,
+	arch::{packed_aes_128::*, packed_aes_256::*, packed_aes_512::*},
 };
 use cfg_if::cfg_if;
 use criterion::criterion_main;

--- a/crates/field/benches/packed_field_multiply.rs
+++ b/crates/field/benches/packed_field_multiply.rs
@@ -6,10 +6,8 @@ use std::ops::Mul;
 
 use binius_field::{
 	PackedBinaryField128x1b, PackedBinaryField256x1b, PackedBinaryField512x1b,
-	arch::{
-		packed_aes_128::*, packed_aes_256::*, packed_aes_512::*, packed_ghash_128::*,
-		packed_ghash_256::*, packed_ghash_512::*,
-	},
+	PackedBinaryGhash1x128b, PackedBinaryGhash2x128b, PackedBinaryGhash4x128b,
+	arch::{packed_aes_128::*, packed_aes_256::*, packed_aes_512::*},
 };
 use cfg_if::cfg_if;
 use criterion::criterion_main;

--- a/crates/field/benches/packed_field_square.rs
+++ b/crates/field/benches/packed_field_square.rs
@@ -3,11 +3,9 @@
 mod packed_field_utils;
 
 use binius_field::{
-	PackedBinaryField128x1b, PackedBinaryField256x1b, PackedBinaryField512x1b, PackedField,
-	arch::{
-		packed_aes_128::*, packed_aes_256::*, packed_aes_512::*, packed_ghash_128::*,
-		packed_ghash_256::*, packed_ghash_512::*,
-	},
+	PackedBinaryField128x1b, PackedBinaryField256x1b, PackedBinaryField512x1b,
+	PackedBinaryGhash1x128b, PackedBinaryGhash2x128b, PackedBinaryGhash4x128b, PackedField,
+	arch::{packed_aes_128::*, packed_aes_256::*, packed_aes_512::*},
 };
 use cfg_if::cfg_if;
 use criterion::criterion_main;

--- a/crates/field/src/arch/aarch64/packed_ghash_128.rs
+++ b/crates/field/src/arch/aarch64/packed_ghash_128.rs
@@ -10,35 +10,25 @@
 use super::m128::M128;
 use crate::{
 	BinaryField128bGhash,
-	arch::{
-		portable::packed_macros::{portable_macros::*, *},
-		strategies::MulFromWideMul,
-	},
-	arithmetic_traits::{
-		TaggedInvertOrZero, TaggedSquare, impl_invert_with, impl_mul_with, impl_square_with,
-	},
+	arch::PackedPrimitiveType,
+	arithmetic_traits::{TaggedInvertOrZero, TaggedSquare},
 };
 
 /// Widening-multiply wrapper used by the GHASH packing: the reduction-deferring
 /// `GhashClMulWideMul`.
-pub type GhashWideMul<T> = super::arithmetic::ghash::GhashClMulWideMul<T>;
+pub type GhashWideMul1x<T> = super::arithmetic::ghash::GhashClMulWideMul<T>;
+
+/// Square strategy for the `PackedBinaryGhash1x128b` packing.
+pub type GhashSquare1x = GhashStrategy;
+
+/// Invert strategy for the `PackedBinaryGhash1x128b` packing.
+pub type GhashInvert1x = GhashStrategy;
 
 /// Strategy for aarch64 GHASH field arithmetic operations.
 pub struct GhashStrategy;
 
-// Define PackedBinaryGhash1x128b using the macro
-define_packed_binary_field!(
-	PackedBinaryGhash1x128b,
-	BinaryField128bGhash,
-	M128,
-	(MulFromWideMul),
-	(GhashStrategy),
-	(GhashStrategy),
-	(GhashWideMul)
-);
-
 // Implement TaggedSquare for GhashStrategy
-impl TaggedSquare<GhashStrategy> for PackedBinaryGhash1x128b {
+impl TaggedSquare<GhashStrategy> for PackedPrimitiveType<M128, BinaryField128bGhash> {
 	#[inline]
 	fn square(self) -> Self {
 		Self::from_underlier(super::arithmetic::ghash::square_clmul(self.to_underlier()))
@@ -46,7 +36,7 @@ impl TaggedSquare<GhashStrategy> for PackedBinaryGhash1x128b {
 }
 
 // Implement TaggedInvertOrZero for GhashStrategy (Itoh-Tsujii — no CLMUL invert)
-impl TaggedInvertOrZero<GhashStrategy> for PackedBinaryGhash1x128b {
+impl TaggedInvertOrZero<GhashStrategy> for PackedPrimitiveType<M128, BinaryField128bGhash> {
 	#[inline]
 	fn invert_or_zero(self) -> Self {
 		crate::arch::invert_b128(self)

--- a/crates/field/src/arch/mod.rs
+++ b/crates/field/src/arch/mod.rs
@@ -11,20 +11,28 @@ cfg_if! {
 	if #[cfg(all(target_arch = "x86_64"))] {
 		mod x86_64;
 		pub use x86_64::{packed_aes_128, packed_aes_256, packed_aes_512, packed_ghash_128, packed_ghash_256, packed_ghash_512, M128, M256, M512, m256_from_u128s};
-		pub use x86_64::packed_ghash_128::GhashWideMul;
+		pub use x86_64::packed_ghash_128::{GhashWideMul1x, GhashSquare1x, GhashInvert1x};
+		pub use x86_64::packed_ghash_256::{GhashWideMul2x, GhashSquare2x, GhashInvert2x};
+		pub use x86_64::packed_ghash_512::{GhashWideMul4x, GhashSquare4x, GhashInvert4x};
 	} else if #[cfg(target_arch = "aarch64")] {
 		mod aarch64;
 		pub use aarch64::{packed_aes_128, packed_ghash_128, M128, M256, M512, m256_from_u128s};
-		pub use aarch64::packed_ghash_128::GhashWideMul;
+		pub use aarch64::packed_ghash_128::{GhashWideMul1x, GhashSquare1x, GhashInvert1x};
 		pub use portable::{packed_aes_256, packed_aes_512, packed_ghash_256, packed_ghash_512};
+		pub use portable::packed_ghash_256::{GhashWideMul2x, GhashSquare2x, GhashInvert2x};
+		pub use portable::packed_ghash_512::{GhashWideMul4x, GhashSquare4x, GhashInvert4x};
 	} else if #[cfg(target_arch = "wasm32")] {
 		mod wasm32;
 		pub use wasm32::{packed_ghash_128, packed_ghash_256};
-		pub use wasm32::packed_ghash_128::GhashWideMul;
+		pub use wasm32::packed_ghash_128::{GhashWideMul1x, GhashSquare1x, GhashInvert1x};
 		pub use portable::{M128, M256, M512, m256_from_u128s, packed_aes_128, packed_aes_256, packed_aes_512, packed_ghash_512};
+		pub use portable::packed_ghash_256::{GhashWideMul2x, GhashSquare2x, GhashInvert2x};
+		pub use portable::packed_ghash_512::{GhashWideMul4x, GhashSquare4x, GhashInvert4x};
 	} else {
 		pub use portable::{M128, M256, M512, m256_from_u128s, packed_aes_128, packed_aes_256, packed_aes_512, packed_ghash_128, packed_ghash_256, packed_ghash_512};
-		pub use portable::packed_ghash_128::GhashWideMul;
+		pub use portable::packed_ghash_128::{GhashWideMul1x, GhashSquare1x, GhashInvert1x};
+		pub use portable::packed_ghash_256::{GhashWideMul2x, GhashSquare2x, GhashInvert2x};
+		pub use portable::packed_ghash_512::{GhashWideMul4x, GhashSquare4x, GhashInvert4x};
 	}
 }
 

--- a/crates/field/src/arch/portable/arithmetic/itoh_tsujii.rs
+++ b/crates/field/src/arch/portable/arithmetic/itoh_tsujii.rs
@@ -144,12 +144,7 @@ mod tests {
 	use proptest::prelude::*;
 
 	use super::*;
-	use crate::{
-		Field, PackedField,
-		arch::{
-			packed_ghash_128::PackedBinaryGhash1x128b, packed_ghash_256::PackedBinaryGhash2x128b,
-		},
-	};
+	use crate::{Field, PackedBinaryGhash1x128b, PackedBinaryGhash2x128b, PackedField};
 
 	#[test]
 	fn test_compute_power_map_matrix_is_squaring() {

--- a/crates/field/src/arch/portable/packed_ghash_128.rs
+++ b/crates/field/src/arch/portable/packed_ghash_128.rs
@@ -3,20 +3,25 @@
 
 //! Portable implementation of packed GHASH field operations.
 
-pub use super::arithmetic::ghash::GhashWideMul;
 use super::{
 	arithmetic::{ghash::ghash_square, itoh_tsujii::invert_b128},
 	m128::M128,
 	univariate_mul_utils_128::{Underlier128bLanes, spread_bits_64},
 };
 use crate::{
-	arch::{
-		portable::packed_macros::{portable_macros::*, *},
-		strategies::MulFromWideMul,
-	},
+	arch::PackedPrimitiveType,
 	arithmetic_traits::{TaggedInvertOrZero, TaggedSquare},
 	ghash::BinaryField128bGhash,
 };
+
+/// Widening-multiply wrapper used by the `PackedBinaryGhash1x128b` packing.
+pub type GhashWideMul1x<T> = super::arithmetic::ghash::GhashWideMul<T>;
+
+/// Square strategy for the `PackedBinaryGhash1x128b` packing.
+pub type GhashSquare1x = GhashStrategy;
+
+/// Invert strategy for the `PackedBinaryGhash1x128b` packing.
+pub type GhashInvert1x = GhashStrategy;
 
 /// Strategy for GHASH field arithmetic operations.
 pub struct GhashStrategy;
@@ -47,24 +52,14 @@ impl Underlier128bLanes for M128 {
 	}
 }
 
-define_packed_binary_field!(
-	PackedBinaryGhash1x128b,
-	BinaryField128bGhash,
-	M128,
-	(MulFromWideMul),
-	(GhashStrategy),
-	(GhashStrategy),
-	(GhashWideMul)
-);
-
-impl TaggedSquare<GhashStrategy> for PackedBinaryGhash1x128b {
+impl TaggedSquare<GhashStrategy> for PackedPrimitiveType<M128, BinaryField128bGhash> {
 	#[inline]
 	fn square(self) -> Self {
 		ghash_square(self.0).into()
 	}
 }
 
-impl TaggedInvertOrZero<GhashStrategy> for PackedBinaryGhash1x128b {
+impl TaggedInvertOrZero<GhashStrategy> for PackedPrimitiveType<M128, BinaryField128bGhash> {
 	#[inline]
 	fn invert_or_zero(self) -> Self {
 		// This portable type's underlier is the portable `M128`, which on SIMD targets differs from

--- a/crates/field/src/arch/portable/packed_ghash_256.rs
+++ b/crates/field/src/arch/portable/packed_ghash_256.rs
@@ -1,23 +1,14 @@
 // Copyright 2024-2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-use super::{
-	m256::M256,
-	packed_macros::{portable_macros::*, *},
-	scaled_arithmetic::Scaled2xWideMul,
-};
-use crate::arch::strategies::{MulFromWideMul, ScaledStrategy};
+use super::scaled_arithmetic::Scaled2xWideMul;
+use crate::arch::strategies::ScaledStrategy;
 
-define_packed_binary_fields!(
-	underlier: M256,
-	packed_fields: [
-		packed_field {
-			name: PackedBinaryGhash2x128b,
-			scalar: BinaryField128bGhash,
-			mul:       (MulFromWideMul),
-			square:    (ScaledStrategy),
-			invert:    (ScaledStrategy),
-			wide_mul: (Scaled2xWideMul),
-		},
-	]
-);
+/// Widening-multiply wrapper used by the `PackedBinaryGhash2x128b` packing.
+pub type GhashWideMul2x<T> = Scaled2xWideMul<T>;
+
+/// Square strategy for the `PackedBinaryGhash2x128b` packing.
+pub type GhashSquare2x = ScaledStrategy;
+
+/// Invert strategy for the `PackedBinaryGhash2x128b` packing.
+pub type GhashInvert2x = ScaledStrategy;

--- a/crates/field/src/arch/portable/packed_ghash_512.rs
+++ b/crates/field/src/arch/portable/packed_ghash_512.rs
@@ -1,23 +1,14 @@
 // Copyright 2024-2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-use super::{
-	m512::M512,
-	packed_macros::{portable_macros::*, *},
-	scaled_arithmetic::Scaled4xWideMul,
-};
-use crate::arch::strategies::{MulFromWideMul, ScaledStrategy};
+use super::scaled_arithmetic::Scaled4xWideMul;
+use crate::arch::strategies::ScaledStrategy;
 
-define_packed_binary_fields!(
-	underlier: M512,
-	packed_fields: [
-		packed_field {
-			name: PackedBinaryGhash4x128b,
-			scalar: BinaryField128bGhash,
-			mul:       (MulFromWideMul),
-			square:    (ScaledStrategy),
-			invert:    (ScaledStrategy),
-			wide_mul: (Scaled4xWideMul),
-		},
-	]
-);
+/// Widening-multiply wrapper used by the `PackedBinaryGhash4x128b` packing.
+pub type GhashWideMul4x<T> = Scaled4xWideMul<T>;
+
+/// Square strategy for the `PackedBinaryGhash4x128b` packing.
+pub type GhashSquare4x = ScaledStrategy;
+
+/// Invert strategy for the `PackedBinaryGhash4x128b` packing.
+pub type GhashInvert4x = ScaledStrategy;

--- a/crates/field/src/arch/wasm32/packed_ghash_128.rs
+++ b/crates/field/src/arch/wasm32/packed_ghash_128.rs
@@ -7,9 +7,7 @@
 //! Based on the portable GHASH implementation adapted for WebAssembly
 //! using WASM SIMD instructions where available.
 
-use std::{arch::wasm32::*, ops::Mul};
-
-use bytemuck::TransparentWrapper;
+use std::arch::wasm32::*;
 
 use super::{super::portable::packed::PackedPrimitiveType, m128::M128};
 use crate::{
@@ -21,28 +19,25 @@ use crate::{
 			univariate_mul_utils_128::{Underlier128bLanes, spread_bits_64},
 		},
 	},
-	arithmetic_traits::{InvertOrZero, Square, WideMul, impl_transformation_with_strategy},
+	arithmetic_traits::{TaggedInvertOrZero, TaggedSquare, impl_transformation_with_strategy},
 };
-
-pub type PackedBinaryGhash1x128b = PackedPrimitiveType<M128, BinaryField128bGhash>;
 
 /// Widening-multiply wrapper used by the GHASH packing: the reduction-deferring portable
 /// [`GhashWideMul`](crate::arch::portable::arithmetic::ghash::GhashWideMul). The WASM SIMD `M128`
 /// implements [`Underlier128bLanes`], so the portable schoolbook widening multiply applies.
-pub type GhashWideMul<T> = crate::arch::portable::arithmetic::ghash::GhashWideMul<T>;
+pub type GhashWideMul1x<T> = crate::arch::portable::arithmetic::ghash::GhashWideMul<T>;
+
+/// Square strategy for the `PackedBinaryGhash1x128b` packing.
+pub type GhashSquare1x = GhashStrategy;
+
+/// Invert strategy for the `PackedBinaryGhash1x128b` packing.
+pub type GhashInvert1x = GhashStrategy;
+
+/// Strategy for WASM32 GHASH field arithmetic operations.
+pub struct GhashStrategy;
 
 // Define broadcast
 impl_broadcast!(M128, BinaryField128bGhash);
-
-// Define multiply as `reduce(wide_mul)`, deferring to the widening multiply below.
-impl Mul for PackedBinaryGhash1x128b {
-	type Output = Self;
-
-	#[inline]
-	fn mul(self, rhs: Self) -> Self::Output {
-		Self::reduce(Self::wide_mul(self, rhs))
-	}
-}
 
 impl Underlier128bLanes for M128 {
 	type U64 = u64;
@@ -70,7 +65,7 @@ impl Underlier128bLanes for M128 {
 	}
 }
 
-impl Square for PackedBinaryGhash1x128b {
+impl TaggedSquare<GhashStrategy> for PackedPrimitiveType<M128, BinaryField128bGhash> {
 	#[inline]
 	fn square(self) -> Self {
 		Self::from_underlier(crate::arch::portable::arithmetic::ghash::ghash_square(
@@ -79,28 +74,15 @@ impl Square for PackedBinaryGhash1x128b {
 	}
 }
 
-// Define invert
-impl InvertOrZero for PackedBinaryGhash1x128b {
+impl TaggedInvertOrZero<GhashStrategy> for PackedPrimitiveType<M128, BinaryField128bGhash> {
 	#[inline]
 	fn invert_or_zero(self) -> Self {
 		crate::arch::invert_b128(self)
 	}
 }
 
-// Implement the deferring widening multiply via the portable `GhashWideMul` wrapper.
-impl WideMul for PackedBinaryGhash1x128b {
-	type Output = <GhashWideMul<Self> as WideMul>::Output;
-
-	#[inline]
-	fn wide_mul(a: Self, b: Self) -> Self::Output {
-		<GhashWideMul<Self> as WideMul>::wide_mul(GhashWideMul::wrap(a), GhashWideMul::wrap(b))
-	}
-
-	#[inline]
-	fn reduce(wide: Self::Output) -> Self {
-		GhashWideMul::peel(<GhashWideMul<Self> as WideMul>::reduce(wide))
-	}
-}
-
 // Define linear transformations
-impl_transformation_with_strategy!(PackedBinaryGhash1x128b, PairwiseStrategy);
+impl_transformation_with_strategy!(
+	PackedPrimitiveType<M128, BinaryField128bGhash>,
+	PairwiseStrategy
+);

--- a/crates/field/src/arch/x86_64/packed_ghash_128.rs
+++ b/crates/field/src/arch/x86_64/packed_ghash_128.rs
@@ -17,13 +17,8 @@ use crate::arch::portable::univariate_mul_utils_128::{Underlier128bLanes, spread
 use crate::arch::x86_64::arithmetic::ghash;
 use crate::{
 	BinaryField128bGhash,
-	arch::{
-		portable::packed_macros::{portable_macros::*, *},
-		strategies::MulFromWideMul,
-	},
-	arithmetic_traits::{
-		TaggedInvertOrZero, TaggedSquare, impl_invert_with, impl_mul_with, impl_square_with,
-	},
+	arch::PackedPrimitiveType,
+	arithmetic_traits::{TaggedInvertOrZero, TaggedSquare},
 };
 
 /// Widening-multiply wrapper used by the GHASH packing: the reduction-deferring
@@ -31,9 +26,15 @@ use crate::{
 /// portable [`GhashWideMul`](crate::arch::portable::arithmetic::ghash::GhashWideMul) which also
 /// defers reduction for deferred-reduction sum-of-products.
 #[cfg(target_feature = "pclmulqdq")]
-pub type GhashWideMul<T> = ghash::GhashClMulWideMul<T>;
+pub type GhashWideMul1x<T> = ghash::GhashClMulWideMul<T>;
 #[cfg(not(target_feature = "pclmulqdq"))]
-pub type GhashWideMul<T> = crate::arch::portable::arithmetic::ghash::GhashWideMul<T>;
+pub type GhashWideMul1x<T> = crate::arch::portable::arithmetic::ghash::GhashWideMul<T>;
+
+/// Square strategy for the `PackedBinaryGhash1x128b` packing.
+pub type GhashSquare1x = GhashStrategy;
+
+/// Invert strategy for the `PackedBinaryGhash1x128b` packing.
+pub type GhashInvert1x = GhashStrategy;
 
 /// `Underlier128bLanes` for x86_64 `M128` — required for the portable `GhashWideMul` fallback.
 ///
@@ -81,21 +82,10 @@ impl ghash::ClMulUnderlier for M128 {
 /// Strategy for x86_64 GHASH field arithmetic operations.
 pub struct GhashStrategy;
 
-// Define PackedBinaryGhash1x128b using the macro
-define_packed_binary_field!(
-	PackedBinaryGhash1x128b,
-	BinaryField128bGhash,
-	M128,
-	(MulFromWideMul),
-	(GhashStrategy),
-	(GhashStrategy),
-	(GhashWideMul)
-);
-
 // Implement TaggedSquare for GhashStrategy
 cfg_if! {
 	if #[cfg(target_feature = "pclmulqdq")] {
-		impl TaggedSquare<GhashStrategy> for PackedBinaryGhash1x128b {
+		impl TaggedSquare<GhashStrategy> for PackedPrimitiveType<M128, BinaryField128bGhash> {
 			#[inline]
 			fn square(self) -> Self {
 				Self::from_underlier(crate::arch::x86_64::arithmetic::ghash::square_clmul(
@@ -104,7 +94,7 @@ cfg_if! {
 			}
 		}
 	} else {
-		impl TaggedSquare<GhashStrategy> for PackedBinaryGhash1x128b {
+		impl TaggedSquare<GhashStrategy> for PackedPrimitiveType<M128, BinaryField128bGhash> {
 			#[inline]
 			fn square(self) -> Self {
 				use super::super::portable::arithmetic::ghash::ghash_square;
@@ -116,7 +106,7 @@ cfg_if! {
 }
 
 // Implement TaggedInvertOrZero for GhashStrategy (Itoh-Tsujii — no CLMUL invert)
-impl TaggedInvertOrZero<GhashStrategy> for PackedBinaryGhash1x128b {
+impl TaggedInvertOrZero<GhashStrategy> for PackedPrimitiveType<M128, BinaryField128bGhash> {
 	#[inline]
 	fn invert_or_zero(self) -> Self {
 		crate::arch::invert_b128(self)

--- a/crates/field/src/arch/x86_64/packed_ghash_256.rs
+++ b/crates/field/src/arch/x86_64/packed_ghash_256.rs
@@ -13,28 +13,27 @@
 use crate::arch::{portable::scaled_arithmetic::Scaled2xWideMul, x86_64::m128::M128};
 use crate::{
 	BinaryField128bGhash,
-	arch::{
-		portable::packed_macros::{portable_macros::*, *},
-		strategies::MulFromWideMul,
-		x86_64::m256::M256,
-	},
-	arithmetic_traits::{TaggedInvertOrZero, impl_invert_with, impl_mul_with, impl_square_with},
+	arch::{PackedPrimitiveType, x86_64::m256::M256},
+	arithmetic_traits::TaggedInvertOrZero,
 };
 
 /// Widening-multiply wrapper used by the GHASH packing: the reduction-deferring vectorized
 /// `GhashClMulWideMul` when VPCLMULQDQ is available, otherwise the per-lane `ScaledWideMul`
 /// (which still defers reduction, applying the width-1 GHASH `WideMul` to each 128-bit lane).
 #[cfg(target_feature = "vpclmulqdq")]
-pub type GhashWideMul<T> = crate::arch::x86_64::arithmetic::ghash::GhashClMulWideMul<T>;
+pub type GhashWideMul2x<T> = crate::arch::x86_64::arithmetic::ghash::GhashClMulWideMul<T>;
 #[cfg(not(target_feature = "vpclmulqdq"))]
-pub type GhashWideMul<T> = Scaled2xWideMul<T>;
+pub type GhashWideMul2x<T> = Scaled2xWideMul<T>;
 
 /// Square strategy for the GHASH packing: a full-width CLMUL square when VPCLMULQDQ is available,
 /// otherwise divide into 128-bit lanes and square each (the 1×128b GHASH square uses PCLMULQDQ).
 #[cfg(target_feature = "vpclmulqdq")]
-pub type GhashSquareStrategy = crate::arch::x86_64::arithmetic::ghash::GhashClMulSquareStrategy;
+pub type GhashSquare2x = crate::arch::x86_64::arithmetic::ghash::GhashClMulSquareStrategy;
 #[cfg(not(target_feature = "vpclmulqdq"))]
-pub type GhashSquareStrategy = crate::arch::DivideStrategy<M128>;
+pub type GhashSquare2x = crate::arch::DivideStrategy<M128>;
+
+/// Invert strategy for the `PackedBinaryGhash2x128b` packing.
+pub type GhashInvert2x = Ghash256Strategy;
 
 #[cfg(target_feature = "vpclmulqdq")]
 mod vpclmulqdq {
@@ -58,19 +57,8 @@ mod vpclmulqdq {
 /// Strategy for x86_64 AVX2 GHASH field arithmetic operations.
 pub struct Ghash256Strategy;
 
-// Define PackedBinaryGhash2x128b using the macro
-define_packed_binary_field!(
-	PackedBinaryGhash2x128b,
-	BinaryField128bGhash,
-	M256,
-	(MulFromWideMul),
-	(GhashSquareStrategy),
-	(Ghash256Strategy),
-	(GhashWideMul)
-);
-
 // Implement TaggedInvertOrZero for Ghash256Strategy (Itoh-Tsujii over the full 256-bit vector)
-impl TaggedInvertOrZero<Ghash256Strategy> for PackedBinaryGhash2x128b {
+impl TaggedInvertOrZero<Ghash256Strategy> for PackedPrimitiveType<M256, BinaryField128bGhash> {
 	#[inline]
 	fn invert_or_zero(self) -> Self {
 		crate::arch::invert_b128(self)

--- a/crates/field/src/arch/x86_64/packed_ghash_512.rs
+++ b/crates/field/src/arch/x86_64/packed_ghash_512.rs
@@ -16,12 +16,7 @@ use crate::arch::x86_64::arithmetic::ghash;
 #[cfg(not(all(target_feature = "vpclmulqdq", target_feature = "avx512f")))]
 use crate::arch::{portable::scaled_arithmetic::Scaled4xWideMul, x86_64::m128::M128};
 use crate::{
-	BinaryField128bGhash,
-	arch::{
-		portable::packed_macros::{portable_macros::*, *},
-		strategies::MulFromWideMul,
-	},
-	arithmetic_traits::{TaggedInvertOrZero, impl_invert_with, impl_mul_with, impl_square_with},
+	BinaryField128bGhash, arch::PackedPrimitiveType, arithmetic_traits::TaggedInvertOrZero,
 };
 
 /// Widening-multiply wrapper used by the GHASH packing: the reduction-deferring vectorized
@@ -29,17 +24,20 @@ use crate::{
 /// otherwise the per-lane [`ScaledWideMul`] (still deferring, applying the width-1 GHASH
 /// `WideMul` to each 128-bit lane).
 #[cfg(all(target_feature = "vpclmulqdq", target_feature = "avx512f"))]
-pub type GhashWideMul<T> = ghash::GhashClMulWideMul<T>;
+pub type GhashWideMul4x<T> = ghash::GhashClMulWideMul<T>;
 #[cfg(not(all(target_feature = "vpclmulqdq", target_feature = "avx512f")))]
-pub type GhashWideMul<T> = Scaled4xWideMul<T>;
+pub type GhashWideMul4x<T> = Scaled4xWideMul<T>;
 
 /// Square strategy for the GHASH packing: a full-width CLMUL square when VPCLMULQDQ + AVX-512 are
 /// available, otherwise divide into 128-bit lanes and square each (the 1×128b GHASH square uses
 /// PCLMULQDQ).
 #[cfg(all(target_feature = "vpclmulqdq", target_feature = "avx512f"))]
-pub type GhashSquareStrategy = ghash::GhashClMulSquareStrategy;
+pub type GhashSquare4x = ghash::GhashClMulSquareStrategy;
 #[cfg(not(all(target_feature = "vpclmulqdq", target_feature = "avx512f")))]
-pub type GhashSquareStrategy = crate::arch::DivideStrategy<M128>;
+pub type GhashSquare4x = crate::arch::DivideStrategy<M128>;
+
+/// Invert strategy for the `PackedBinaryGhash4x128b` packing.
+pub type GhashInvert4x = Ghash512Strategy;
 
 #[cfg(all(target_feature = "vpclmulqdq", target_feature = "avx512f"))]
 impl ghash::ClMulUnderlier for M512 {
@@ -63,19 +61,8 @@ impl ghash::ClMulUnderlier for M512 {
 /// Strategy for x86_64 AVX-512 GHASH field arithmetic operations.
 pub struct Ghash512Strategy;
 
-// Define PackedBinaryGhash4x128b using the macro
-define_packed_binary_field!(
-	PackedBinaryGhash4x128b,
-	BinaryField128bGhash,
-	M512,
-	(MulFromWideMul),
-	(GhashSquareStrategy),
-	(Ghash512Strategy),
-	(GhashWideMul)
-);
-
 // Implement TaggedInvertOrZero for Ghash512Strategy (Itoh-Tsujii over the full 512-bit vector)
-impl TaggedInvertOrZero<Ghash512Strategy> for PackedBinaryGhash4x128b {
+impl TaggedInvertOrZero<Ghash512Strategy> for PackedPrimitiveType<M512, BinaryField128bGhash> {
 	#[inline]
 	fn invert_or_zero(self) -> Self {
 		crate::arch::invert_b128(self)

--- a/crates/field/src/ghash.rs
+++ b/crates/field/src/ghash.rs
@@ -21,8 +21,8 @@ use super::{
 	extension::ExtensionField,
 };
 use crate::{
-	AESTowerField8b, Field, WideMul,
-	arch::{GhashWideMul, M128, invert_b128, packed_ghash_128::PackedBinaryGhash1x128b},
+	AESTowerField8b, Field, PackedBinaryGhash1x128b, WideMul,
+	arch::{GhashWideMul1x, M128, invert_b128},
 	arithmetic_traits::{InvertOrZero, Square},
 	binary_field_arithmetic::square_using_packed,
 	mul_by_binary_field_1b,
@@ -57,22 +57,22 @@ impl From<BinaryField128bGhash> for u128 {
 // `PackedBinaryGhash1x128b`, so a `TrivialWideMul` fallback (whose `Output` is the packed type,
 // bounded `Add + Mul`) would close a trait-resolution cycle through `Field: WideMul`.
 impl WideMul for BinaryField128bGhash {
-	type Output = <GhashWideMul<PackedBinaryGhash1x128b> as WideMul>::Output;
+	type Output = <GhashWideMul1x<PackedBinaryGhash1x128b> as WideMul>::Output;
 
 	#[inline]
 	fn wide_mul(a: Self, b: Self) -> Self::Output {
 		let a = PackedBinaryGhash1x128b::from_underlier(a.to_underlier());
 		let b = PackedBinaryGhash1x128b::from_underlier(b.to_underlier());
-		<GhashWideMul<PackedBinaryGhash1x128b> as WideMul>::wide_mul(
-			GhashWideMul::wrap(a),
-			GhashWideMul::wrap(b),
+		<GhashWideMul1x<PackedBinaryGhash1x128b> as WideMul>::wide_mul(
+			GhashWideMul1x::wrap(a),
+			GhashWideMul1x::wrap(b),
 		)
 	}
 
 	#[inline]
 	fn reduce(wide: Self::Output) -> Self {
-		let reduced = <GhashWideMul<PackedBinaryGhash1x128b> as WideMul>::reduce(wide);
-		Self::from_underlier(GhashWideMul::peel(reduced).to_underlier())
+		let reduced = <GhashWideMul1x<PackedBinaryGhash1x128b> as WideMul>::reduce(wide);
+		Self::from_underlier(GhashWideMul1x::peel(reduced).to_underlier())
 	}
 }
 

--- a/crates/field/src/packed_binary_field.rs
+++ b/crates/field/src/packed_binary_field.rs
@@ -276,7 +276,7 @@ pub mod test_utils {
 				fn test_mul_packed_128(a_val in proptest::prelude::any::<u128>(), b_val in proptest::prelude::any::<u128>()) {
 					use $crate::PackedBinaryField128x1b;
 					use $crate::arch::packed_aes_128::*;
-					use $crate::arch::packed_ghash_128::*;
+					use $crate::PackedBinaryGhash1x128b;
 
 					TestMult::<PackedBinaryField128x1b>::test_mul(a_val.into(), b_val.into());
 					TestMult::<PackedAESBinaryField16x8b>::test_mul(a_val.into(), b_val.into());
@@ -287,7 +287,7 @@ pub mod test_utils {
 				fn test_mul_packed_256(a_val in proptest::prelude::any::<[u128; 2]>(), b_val in proptest::prelude::any::<[u128; 2]>()) {
 					use $crate::PackedBinaryField256x1b;
 					use $crate::arch::packed_aes_256::*;
-					use $crate::arch::packed_ghash_256::*;
+					use $crate::PackedBinaryGhash2x128b;
 
 					TestMult::<PackedBinaryField256x1b>::test_mul(a_val.into(), b_val.into());
 					TestMult::<PackedAESBinaryField32x8b>::test_mul(a_val.into(), b_val.into());
@@ -298,7 +298,7 @@ pub mod test_utils {
 				fn test_mul_packed_512(a_val in proptest::prelude::any::<[u128; 4]>(), b_val in proptest::prelude::any::<[u128; 4]>()) {
 					use $crate::PackedBinaryField512x1b;
 					use $crate::arch::packed_aes_512::*;
-					use $crate::arch::packed_ghash_512::*;
+					use $crate::PackedBinaryGhash4x128b;
 
 					TestMult::<PackedBinaryField512x1b>::test_mul(a_val.into(), b_val.into());
 					TestMult::<PackedAESBinaryField64x8b>::test_mul(a_val.into(), b_val.into());
@@ -352,7 +352,7 @@ pub mod test_utils {
 				fn test_square_packed_128(a_val in proptest::prelude::any::<u128>()) {
 					use $crate::PackedBinaryField128x1b;
 					use $crate::arch::packed_aes_128::*;
-					use $crate::arch::packed_ghash_128::*;
+					use $crate::PackedBinaryGhash1x128b;
 
 					TestSquare::<PackedBinaryField128x1b>::test_square(a_val.into());
 					TestSquare::<PackedAESBinaryField16x8b>::test_square(a_val.into());
@@ -363,7 +363,7 @@ pub mod test_utils {
 				fn test_square_packed_256(a_val in proptest::prelude::any::<[u128; 2]>()) {
 					use $crate::PackedBinaryField256x1b;
 					use $crate::arch::packed_aes_256::*;
-					use $crate::arch::packed_ghash_256::*;
+					use $crate::PackedBinaryGhash2x128b;
 
 					TestSquare::<PackedBinaryField256x1b>::test_square(a_val.into());
 					TestSquare::<PackedAESBinaryField32x8b>::test_square(a_val.into());
@@ -374,7 +374,7 @@ pub mod test_utils {
 				fn test_square_packed_512(a_val in proptest::prelude::any::<[u128; 4]>()) {
 					use $crate::PackedBinaryField512x1b;
 					use $crate::arch::packed_aes_512::*;
-					use $crate::arch::packed_ghash_512::*;
+					use $crate::PackedBinaryGhash4x128b;
 
 					TestSquare::<PackedBinaryField512x1b>::test_square(a_val.into());
 					TestSquare::<PackedAESBinaryField64x8b>::test_square(a_val.into());
@@ -428,7 +428,7 @@ pub mod test_utils {
 				fn test_invert_packed_128(a_val in proptest::prelude::any::<u128>()) {
 					use $crate::PackedBinaryField128x1b;
 					use $crate::arch::packed_aes_128::*;
-					use $crate::arch::packed_ghash_128::*;
+					use $crate::PackedBinaryGhash1x128b;
 
 					TestInvert::<PackedBinaryField128x1b>::test_invert(a_val.into());
 					TestInvert::<PackedAESBinaryField16x8b>::test_invert(a_val.into());
@@ -439,7 +439,7 @@ pub mod test_utils {
 				fn test_invert_packed_256(a_val in proptest::prelude::any::<[u128; 2]>()) {
 					use $crate::PackedBinaryField256x1b;
 					use $crate::arch::packed_aes_256::*;
-					use $crate::arch::packed_ghash_256::*;
+					use $crate::PackedBinaryGhash2x128b;
 
 					TestInvert::<PackedBinaryField256x1b>::test_invert(a_val.into());
 					TestInvert::<PackedAESBinaryField32x8b>::test_invert(a_val.into());
@@ -450,7 +450,7 @@ pub mod test_utils {
 				fn test_invert_packed_512(a_val in proptest::prelude::any::<[u128; 4]>()) {
 					use $crate::PackedBinaryField512x1b;
 					use $crate::arch::packed_aes_512::*;
-					use $crate::arch::packed_ghash_512::*;
+					use $crate::PackedBinaryGhash4x128b;
 
 					TestInvert::<PackedBinaryField512x1b>::test_invert(a_val.into());
 					TestInvert::<PackedAESBinaryField64x8b>::test_invert(a_val.into());

--- a/crates/field/src/packed_ghash.rs
+++ b/crates/field/src/packed_ghash.rs
@@ -1,10 +1,44 @@
 // Copyright 2024-2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-pub use crate::arch::{
-	packed_ghash_128::PackedBinaryGhash1x128b, packed_ghash_256::PackedBinaryGhash2x128b,
-	packed_ghash_512::PackedBinaryGhash4x128b,
+use crate::{
+	BinaryField128bGhash,
+	arch::{
+		GhashInvert1x, GhashInvert2x, GhashInvert4x, GhashSquare1x, GhashSquare2x, GhashSquare4x,
+		GhashWideMul1x, GhashWideMul2x, GhashWideMul4x, M128, M256, M512, MulFromWideMul,
+		portable::packed_macros::{portable_macros::*, *},
+	},
 };
+
+define_packed_binary_field!(
+	PackedBinaryGhash1x128b,
+	BinaryField128bGhash,
+	M128,
+	(MulFromWideMul),
+	(GhashSquare1x),
+	(GhashInvert1x),
+	(GhashWideMul1x)
+);
+
+define_packed_binary_field!(
+	PackedBinaryGhash2x128b,
+	BinaryField128bGhash,
+	M256,
+	(MulFromWideMul),
+	(GhashSquare2x),
+	(GhashInvert2x),
+	(GhashWideMul2x)
+);
+
+define_packed_binary_field!(
+	PackedBinaryGhash4x128b,
+	BinaryField128bGhash,
+	M512,
+	(MulFromWideMul),
+	(GhashSquare4x),
+	(GhashInvert4x),
+	(GhashWideMul4x)
+);
 
 #[cfg(test)]
 mod test_utils {
@@ -20,7 +54,7 @@ mod test_utils {
 			proptest! {
 				#[test]
 				fn test_mul_packed_128(a_val in any::<u128>(), b_val in any::<u128>()) {
-					TestMult::<$crate::arch::packed_ghash_128::PackedBinaryGhash1x128b>::test_mul(
+					TestMult::<$crate::PackedBinaryGhash1x128b>::test_mul(
 						a_val.into(),
 						b_val.into(),
 					);
@@ -28,7 +62,7 @@ mod test_utils {
 
 				#[test]
 				fn test_mul_packed_256(a_val in any::<[u128; 2]>(), b_val in any::<[u128; 2]>()) {
-					TestMult::<$crate::arch::packed_ghash_256::PackedBinaryGhash2x128b>::test_mul(
+					TestMult::<$crate::PackedBinaryGhash2x128b>::test_mul(
 						a_val.into(),
 						b_val.into(),
 					);
@@ -36,7 +70,7 @@ mod test_utils {
 
 				#[test]
 				fn test_mul_packed_512(a_val in any::<[u128; 4]>(), b_val in any::<[u128; 4]>()) {
-					TestMult::<$crate::arch::packed_ghash_512::PackedBinaryGhash4x128b>::test_mul(
+					TestMult::<$crate::PackedBinaryGhash4x128b>::test_mul(
 						a_val.into(),
 						b_val.into(),
 					);
@@ -57,17 +91,17 @@ mod test_utils {
 			proptest! {
 				#[test]
 				fn test_square_packed_128(a_val in any::<u128>()) {
-					TestSquare::<$crate::arch::packed_ghash_128::PackedBinaryGhash1x128b>::test_square(a_val.into());
+					TestSquare::<$crate::PackedBinaryGhash1x128b>::test_square(a_val.into());
 				}
 
 				#[test]
 				fn test_square_packed_256(a_val in any::<[u128; 2]>()) {
-					TestSquare::<$crate::arch::packed_ghash_256::PackedBinaryGhash2x128b>::test_square(a_val.into());
+					TestSquare::<$crate::PackedBinaryGhash2x128b>::test_square(a_val.into());
 				}
 
 				#[test]
 				fn test_square_packed_512(a_val in any::<[u128; 4]>()) {
-					TestSquare::<$crate::arch::packed_ghash_512::PackedBinaryGhash4x128b>::test_square(a_val.into());
+					TestSquare::<$crate::PackedBinaryGhash4x128b>::test_square(a_val.into());
 				}
 			}
 		};
@@ -85,17 +119,17 @@ mod test_utils {
 			proptest! {
 				#[test]
 				fn test_invert_packed_128(a_val in any::<u128>()) {
-					TestInvert::<$crate::arch::packed_ghash_128::PackedBinaryGhash1x128b>::test_invert(a_val.into());
+					TestInvert::<$crate::PackedBinaryGhash1x128b>::test_invert(a_val.into());
 				}
 
 				#[test]
 				fn test_invert_packed_256(a_val in any::<[u128; 2]>()) {
-					TestInvert::<$crate::arch::packed_ghash_256::PackedBinaryGhash2x128b>::test_invert(a_val.into());
+					TestInvert::<$crate::PackedBinaryGhash2x128b>::test_invert(a_val.into());
 				}
 
 				#[test]
 				fn test_invert_packed_512(a_val in any::<[u128; 4]>()) {
-					TestInvert::<$crate::arch::packed_ghash_512::PackedBinaryGhash4x128b>::test_invert(a_val.into());
+					TestInvert::<$crate::PackedBinaryGhash4x128b>::test_invert(a_val.into());
 				}
 			}
 		};
@@ -128,25 +162,24 @@ mod test_utils {
 			{
 				let (a1, b1) = (P::from_underlier(a1), P::from_underlier(b1));
 				let (a2, b2) = (P::from_underlier(a2), P::from_underlier(b2));
-				let sum_reduced =
-					P::reduce(P::wide_mul(a1, b1) + P::wide_mul(a2, b2));
+				let sum_reduced = P::reduce(P::wide_mul(a1, b1) + P::wide_mul(a2, b2));
 				assert_eq!(sum_reduced, a1 * b1 + a2 * b2);
 			}
 
 			proptest! {
 				#[test]
 				fn test_wide_mul_correctness_128(a in any::<u128>(), b in any::<u128>()) {
-					check_widening_correctness::<$crate::arch::packed_ghash_128::PackedBinaryGhash1x128b>(a.into(), b.into());
+					check_widening_correctness::<$crate::PackedBinaryGhash1x128b>(a.into(), b.into());
 				}
 
 				#[test]
 				fn test_wide_mul_correctness_256(a in any::<[u128; 2]>(), b in any::<[u128; 2]>()) {
-					check_widening_correctness::<$crate::arch::packed_ghash_256::PackedBinaryGhash2x128b>(a.into(), b.into());
+					check_widening_correctness::<$crate::PackedBinaryGhash2x128b>(a.into(), b.into());
 				}
 
 				#[test]
 				fn test_wide_mul_correctness_512(a in any::<[u128; 4]>(), b in any::<[u128; 4]>()) {
-					check_widening_correctness::<$crate::arch::packed_ghash_512::PackedBinaryGhash4x128b>(a.into(), b.into());
+					check_widening_correctness::<$crate::PackedBinaryGhash4x128b>(a.into(), b.into());
 				}
 
 				#[test]
@@ -154,7 +187,7 @@ mod test_utils {
 					a1 in any::<u128>(), b1 in any::<u128>(),
 					a2 in any::<u128>(), b2 in any::<u128>(),
 				) {
-					check_widening_linearity::<$crate::arch::packed_ghash_128::PackedBinaryGhash1x128b>(
+					check_widening_linearity::<$crate::PackedBinaryGhash1x128b>(
 						a1.into(), b1.into(), a2.into(), b2.into(),
 					);
 				}
@@ -164,7 +197,7 @@ mod test_utils {
 					a1 in any::<[u128; 2]>(), b1 in any::<[u128; 2]>(),
 					a2 in any::<[u128; 2]>(), b2 in any::<[u128; 2]>(),
 				) {
-					check_widening_linearity::<$crate::arch::packed_ghash_256::PackedBinaryGhash2x128b>(
+					check_widening_linearity::<$crate::PackedBinaryGhash2x128b>(
 						a1.into(), b1.into(), a2.into(), b2.into(),
 					);
 				}
@@ -174,7 +207,7 @@ mod test_utils {
 					a1 in any::<[u128; 4]>(), b1 in any::<[u128; 4]>(),
 					a2 in any::<[u128; 4]>(), b2 in any::<[u128; 4]>(),
 				) {
-					check_widening_linearity::<$crate::arch::packed_ghash_512::PackedBinaryGhash4x128b>(
+					check_widening_linearity::<$crate::PackedBinaryGhash4x128b>(
 						a1.into(), b1.into(), a2.into(), b2.into(),
 					);
 				}
@@ -194,14 +227,14 @@ mod tests {
 
 	use proptest::{arbitrary::any, proptest};
 
-	use super::test_utils::{
-		define_invert_tests, define_multiply_tests, define_square_tests, define_wide_mul_tests,
+	use super::{
+		PackedBinaryGhash2x128b, PackedBinaryGhash4x128b,
+		test_utils::{
+			define_invert_tests, define_multiply_tests, define_square_tests, define_wide_mul_tests,
+		},
 	};
 	use crate::{
 		BinaryField128bGhash, PackedField,
-		arch::{
-			packed_ghash_256::PackedBinaryGhash2x128b, packed_ghash_512::PackedBinaryGhash4x128b,
-		},
 		arithmetic_traits::{InvertOrZero, Square},
 		underlier::WithUnderlier,
 	};
@@ -241,9 +274,8 @@ mod tests {
 
 	#[test]
 	fn test_wide_mul_zero_inputs() {
-		use crate::{
-			WideMul, arch::packed_ghash_128::PackedBinaryGhash1x128b as P, field::FieldOps,
-		};
+		use super::PackedBinaryGhash1x128b as P;
+		use crate::{WideMul, field::FieldOps};
 
 		let zero = P::default();
 		let one = P::one();
@@ -261,7 +293,8 @@ mod tests {
 	fn test_wide_mul_single_accumulation() {
 		use rand::{SeedableRng, rngs::StdRng};
 
-		use crate::{Random, WideMul, arch::packed_ghash_128::PackedBinaryGhash1x128b as P};
+		use super::PackedBinaryGhash1x128b as P;
+		use crate::{Random, WideMul};
 
 		let mut rng = StdRng::seed_from_u64(77);
 		let a = P::random(&mut rng);


### PR DESCRIPTION
Closes [BINIUS-141](https://linear.app/jimpo/issue/BINIUS-141/lift-ghash-packed-field-definitions-into-binius-fieldpacked-ghash). The Ghash analogue of BINIUS-135 (#1569).

Today the `PackedBinaryGhash{1,2,4}x128b` types + their `define_packed_binary_field!` calls are duplicated across `arch/{portable,x86_64,aarch64,wasm32}/packed_ghash_{128,256,512}.rs`, and the root `packed_ghash` module merely re-exports them. Unlike B1 (whose arithmetic is arch-independent, so it collapsed to a blanket impl), Ghash strategies vary by arch **and** target feature, so the lift centralizes the *type + macro call* while the *strategies* come from `arch` (cfg-selected up the tree, as the ticket describes).

### Changes
- **`packed_ghash.rs`**: now owns the 3 type aliases + `define_packed_binary_field!` calls, consuming uniform per-arch strategy aliases from `crate::arch`:
  ```rust
  define_packed_binary_field!(PackedBinaryGhash1x128b, BinaryField128bGhash, M128,
      (MulFromWideMul), (GhashSquare1x), (GhashInvert1x), (GhashWideMul1x));   // …2x/M256, …4x/M512
  ```
- **arch submodules** (`packed_ghash_{128,256,512}.rs`): keep only their strategy types + `Tagged{Square,InvertOrZero}` / `ClMulUnderlier` / `Underlier128bLanes` impls (retargeted from the now-lifted alias to the structural `PackedPrimitiveType<M…, BinaryField128bGhash>`), and expose them under uniform width-indexed names `GhashWideMul{1,2,4}x` / `GhashSquare{…}` / `GhashInvert{…}`. The per-feature choices (pclmulqdq / vpclmulqdq+avx512 / pmull / portable schoolbook / scaled fallback) stay exactly as before behind the same cfgs.
- **`arch/mod.rs`**: cfg-routes the 9 uniform names per arch (aarch64/wasm32 take 2x/4x from portable).
- Net **−50 lines** (de-duplication). Pure refactor — no behavior change. The wasm32 1×128b path moves from hand-written `Mul`/`Square`/`InvertOrZero`/`WideMul` impls to the same strategy/macro mechanism (its `Mul` was already `reduce(wide_mul)` = `MulFromWideMul`, and `WideMul` already forwarded to the portable `GhashWideMul` wrapper the macro now uses).

### Verification
- Portable `cargo test -p binius-field` (212) green; native build + clippy `-D warnings`; **full `cargo build --workspace`** green (no downstream breakage — dependents use only the unchanged public API `binius_field::PackedBinaryGhash*`); fmt clean.
- aarch64 (`+neon,+aes`) clippy `-D warnings`; vanilla `wasm32-unknown-unknown` build (the configs CI builds). The vpclmulqdq/avx512f/pmull runtimes are CI-gated as usual (`rust-checks-*`); those paths only had alias renames (no logic change), and their impls are generic over the underlier so they resolve identically at the lifted call site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)