### PR TITLE
BINIUS-125: align ValueVec words to a 16-byte boundary to speed up copy

### DIFF
--- a/crates/core/src/constraint_system.rs
+++ b/crates/core/src/constraint_system.rs
@@ -3,10 +3,11 @@
 
 use std::{
 	borrow::Cow,
-	ops::{Index, IndexMut},
+	ops::{Deref, DerefMut, Index, IndexMut},
 };
 
 use binius_utils::serialization::{DeserializeBytes, SerializationError, SerializeBytes};
+use bytemuck::{Pod, Zeroable};
 use bytes::{Buf, BufMut};
 
 use crate::{consts, error::ConstraintSystemError, word::Word};
@@ -763,6 +764,69 @@ impl DeserializeBytes for ValueVecLayout {
 	}
 }
 
+/// A 16-byte-aligned pair of words, the storage block of the aligned word buffer.
+///
+/// - A word is 8 bytes, so a plain vector of words only lands on a 16-byte boundary half the time.
+/// - Two words inside a 16-byte-aligned block force every allocation onto that boundary.
+#[derive(Clone, Copy, Debug)]
+#[repr(C, align(16))]
+struct WordPair([Word; 2]);
+
+// SAFETY: the two impls below assert that any bit pattern is a valid `WordPair`.
+// - Each word is plain-old-data, so every field is plain-old-data.
+// - Two 8-byte words exactly fill the 16-byte size, leaving no padding bytes.
+unsafe impl Zeroable for WordPair {}
+unsafe impl Pod for WordPair {}
+
+/// A heap-allocated buffer of words whose first element is 16-byte aligned.
+///
+/// The value vector is copied in bulk on the prover's hot path:
+/// - cloned wholesale,
+/// - packed into field elements,
+/// - sliced out into owned vectors.
+///
+/// A 16-byte-aligned start keeps each of those copies on the aligned SIMD `memcpy` path.
+/// An 8-byte-aligned plain vector would instead pay a misalignment prologue half the time.
+///
+/// Storage groups two words per block, so capacity rounds up to an even count.
+/// The valid word count is tracked separately from the block count.
+/// An odd count leaves the last block's second word as zeroed, unused padding.
+#[derive(Clone, Debug)]
+struct AlignedWords {
+	/// Backing store of 16-byte-aligned blocks, one block per two words.
+	blocks: Vec<WordPair>,
+	/// Number of valid words, at most twice the block count.
+	len: usize,
+}
+
+impl AlignedWords {
+	/// Allocates a 16-byte-aligned buffer of `len` zeroed words.
+	fn zeroed(len: usize) -> Self {
+		Self {
+			// Round up to whole blocks; the macro zero-fills, so every word starts at zero.
+			blocks: vec![WordPair([Word::ZERO; 2]); len.div_ceil(2)],
+			len,
+		}
+	}
+}
+
+impl Deref for AlignedWords {
+	type Target = [Word];
+
+	fn deref(&self) -> &[Word] {
+		// Reinterpret the aligned blocks as twice as many words.
+		// Slice to the valid count, dropping the padding word of an odd buffer.
+		&bytemuck::cast_slice(&self.blocks)[..self.len]
+	}
+}
+
+impl DerefMut for AlignedWords {
+	fn deref_mut(&mut self) -> &mut [Word] {
+		// Same reinterpretation as the shared view, but handing out mutable words.
+		&mut bytemuck::cast_slice_mut(&mut self.blocks)[..self.len]
+	}
+}
+
 /// The vector of values used in constraint evaluation and proof generation.
 ///
 /// `ValueVec` is the concrete instantiation of values that satisfy (or should satisfy) a
@@ -770,10 +834,15 @@ impl DeserializeBytes for ValueVecLayout {
 /// as the primary data structure for both constraint evaluation and polynomial commitment.
 ///
 /// Between these sections, there may be padding regions to satisfy alignment requirements.
+///
+/// The words live in a buffer that starts on a 16-byte boundary.
+/// That keeps the frequent bulk copies of the vector on the aligned SIMD `memcpy` path.
 #[derive(Clone, Debug)]
 pub struct ValueVec {
+	/// Section offsets and counts that partition the words below.
 	layout: ValueVecLayout,
-	data: Vec<Word>,
+	/// The committed words followed by the scratch tail, 16-byte aligned.
+	data: AlignedWords,
 }
 
 impl ValueVec {
@@ -784,7 +853,7 @@ impl ValueVec {
 		let size = layout.committed_total_len + layout.n_scratch;
 		ValueVec {
 			layout,
-			data: vec![Word::ZERO; size],
+			data: AlignedWords::zeroed(size),
 		}
 	}
 
@@ -804,11 +873,14 @@ impl ValueVec {
 			});
 		}
 
+		// Full buffer = committed words + scratch tail.
 		let full_len = layout.committed_total_len + layout.n_scratch;
-		let mut data = public;
-		data.reserve(full_len);
-		data.extend_from_slice(&private);
-		data.resize(full_len, Word::ZERO);
+		// Fresh 16-byte-aligned buffer; the scratch tail past the committed words stays zeroed.
+		let mut data = AlignedWords::zeroed(full_len);
+		// Public words occupy the front of the committed region.
+		data[..public.len()].copy_from_slice(&public);
+		// Private words follow, filling the rest of the committed region.
+		data[public.len()..committed_len].copy_from_slice(&private);
 
 		Ok(ValueVec { layout, data })
 	}
@@ -1118,6 +1190,7 @@ impl<'a> std::ops::Deref for Proof<'a> {
 
 #[cfg(test)]
 mod serialization_tests {
+	use proptest::{collection, prelude::any, prop_assert_eq, proptest};
 	use rand::prelude::*;
 
 	use super::*;
@@ -2371,6 +2444,98 @@ mod serialization_tests {
 				"Expected OutOfRangeValueIndex to be detected before padding check, got: {:?}",
 				other
 			),
+		}
+	}
+	// The property that makes the optimization work: the first word sits on a 16-byte boundary.
+	fn assert_16_byte_aligned(words: &[Word]) {
+		assert_eq!(words.as_ptr() as usize % 16, 0);
+	}
+
+	#[test]
+	fn zeroed_is_aligned_zero_filled_and_correct_length() {
+		// Cases:
+		//   0      -> empty buffer, no blocks
+		//   1, 3   -> odd, so the last block's second word is padding
+		//   2, 16  -> even, every block fully used
+		//   17     -> odd and spans many blocks
+		for len in [0, 1, 2, 3, 16, 17] {
+			let words = AlignedWords::zeroed(len);
+			// The view reports the requested word count, not the rounded-up block capacity.
+			assert_eq!(words.len(), len);
+			// Alignment must hold for every length, including the empty buffer.
+			assert_16_byte_aligned(&words);
+			// A freshly allocated buffer is entirely zero.
+			assert!(words.iter().all(|&w| w == Word::ZERO));
+		}
+	}
+
+	#[test]
+	fn deref_mut_writes_are_visible_through_deref() {
+		// Length 5 is odd, so the last block holds one valid word and one padding word.
+		let mut words = AlignedWords::zeroed(5);
+		// Write 1..=5 through the mutable view; this must not touch the padding word.
+		for (i, w) in words.iter_mut().enumerate() {
+			*w = Word::from_u64(i as u64 + 1);
+		}
+		// The shared view reads back exactly the five words written.
+		assert_eq!(
+			&*words,
+			&[
+				Word::from_u64(1),
+				Word::from_u64(2),
+				Word::from_u64(3),
+				Word::from_u64(4),
+				Word::from_u64(5),
+			]
+		);
+	}
+
+	proptest! {
+		#[test]
+		fn value_vec_preserves_words_and_alignment(
+			public in collection::vec(any::<u64>(), 4..32usize),
+			n_witness in 0..32usize,
+			n_scratch in 0..16usize,
+		) {
+			// Public words come straight from the strategy; private words use a recognizable pattern.
+			let public: Vec<Word> = public.into_iter().map(Word).collect();
+			let private: Vec<Word> = (0..n_witness).map(|i| Word::from_u64(0xdead_0000 + i as u64)).collect();
+
+			// The public section is padded to a power of two.
+			// The witness section follows it, then the scratch tail.
+			//
+			//     [0, offset_witness)                    -> public  (power of two)
+			//     [offset_witness, committed_total_len)  -> witness
+			//     [committed_total_len, +n_scratch)      -> scratch
+			let offset_witness = public.len().next_power_of_two();
+			let committed_total_len = offset_witness + private.len();
+			let layout = ValueVecLayout {
+				n_const: 0,
+				n_inout: public.len(),
+				n_witness: private.len(),
+				n_internal: 0,
+				offset_inout: 0,
+				offset_witness,
+				committed_total_len,
+				n_scratch,
+			};
+
+			// The public input must fill its whole power-of-two section, so zero-pad it.
+			let mut public_padded = public.clone();
+			public_padded.resize(offset_witness, Word::ZERO);
+
+			let vv = ValueVec::new_from_data(layout, public_padded.clone(), private.clone()).unwrap();
+
+			// Alignment survives construction for any word count.
+			assert_16_byte_aligned(vv.combined_witness());
+			// Both sections read back byte-for-byte what went in.
+			prop_assert_eq!(vv.public(), &public_padded[..]);
+			prop_assert_eq!(vv.witness(), &private[..]);
+
+			// The scratch tail past the committed words is zeroed and addressable.
+			for i in committed_total_len..committed_total_len + n_scratch {
+				prop_assert_eq!(vv.get(i), Word::ZERO);
+			}
 		}
 	}
 }

--- a/crates/core/src/word.rs
+++ b/crates/core/src/word.rs
@@ -7,11 +7,16 @@ use std::{
 };
 
 use binius_utils::serialization::{DeserializeBytes, SerializationError, SerializeBytes};
+use bytemuck::{Pod, Zeroable};
 use bytes::{Buf, BufMut};
 
 /// [`Word`] is 64-bit value and is a fundamental unit of data in Binius64. All computation and
 /// constraints operate on it.
-#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+///
+/// The transparent layout matches the inner 64-bit integer exactly.
+/// That lets slices of words be reinterpreted as raw bytes, and back, for zero-copy bulk copies.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Pod, Zeroable)]
+#[repr(transparent)]
 pub struct Word(pub u64);
 
 impl Word {


### PR DESCRIPTION
Closes [BINIUS-125](https://linear.app/jimpo/issue/BINIUS-125/align-words-in-valuevec-to-16-byte-boundary-to-speed-up-copy).

## What

Force the word storage inside `ValueVec` to start on a 16-byte boundary so the frequent bulk copies on the prover's hot path take the aligned SIMD `memcpy` path.

## Why

The value vector is copied constantly — cloned wholesale, packed into field elements, and sliced out to owned `Vec`s.

A `Word` is 8 bytes, so a plain `Vec<Word>` is only 8-byte aligned. Its buffer lands on a 16-byte boundary only about half the time (by luck of the allocator), and the other half every `memcpy` pays a misalignment prologue instead of running the aligned SIMD loop.

## How

- Store words two-at-a-time inside a `#[repr(C, align(16))]` `WordPair` block. A `Vec<WordPair>` therefore always starts on a 16-byte boundary — guaranteed, not by luck — at **zero memory overhead** (two 8-byte words exactly fill the 16-byte block).
- The new buffer derefs to `&[Word]` via a zero-copy `bytemuck` reinterpret, so the public `ValueVec` API is completely unchanged. The section offsets are even, so the inner sub-slices (`public`, `witness`, …) stay 16-byte aligned too.
- `Word` is now `#[repr(transparent)]` and derives `Pod`/`Zeroable` so word slices can be reinterpreted as bytes and back.

## Trade-off

`new_from_data` now copies the public + private words into one fresh aligned buffer instead of reusing the incoming public `Vec`. That's one extra copy at witness-reconstruction setup, traded for aligned copies on the hot path forever after.

## Tests

Added to the core test module:
- alignment + zero-fill + length across empty / odd / even / multi-block lengths,
- mutable-view writes are visible through the shared view without touching the padding word,
- a proptest asserting `new_from_data` preserves both sections byte-for-byte, keeps 16-byte alignment for any word count, and zero-fills the scratch tail.

`cargo test -p binius-core`, `cargo clippy -p binius-core --all-targets`, and `cargo build --workspace` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
