### PR TITLE
BINIUS-69: heterogeneous mixed ZK/non-ZK BaseFold opening

### DIFF
--- a/crates/iop-prover/src/basefold.rs
+++ b/crates/iop-prover/src/basefold.rs
@@ -183,6 +183,9 @@ where
 ///   down to the codeword of `π_i'` in the FRI inner (unbatch) round
 /// * `outer_challenges` - the batching challenges `r'` (`len = log_n_oracles`); combine the `k`
 ///   lifted codewords in the FRI outer (oracle-combine) rounds
+/// * `reduced_log_dim` - the reduced (first-round) code dimension `D = rs_code().log_dim()`. The
+///   leading `max_n - D` standard rounds are the non-ZK oracles' batch folds, fed to the folder as
+///   inner challenges; only the trailing `D` rounds are genuine FRI fold rounds.
 /// * `fri_folder` - the combined FRI fold prover, with `n_rounds == 𝐧 + 1 + log_n_oracles`
 /// * `transcript` - the prover transcript
 ///
@@ -195,6 +198,7 @@ pub fn prove_mlecheck_basefold_zk_batch<'a, F, P, NTT, MerkleScheme, MerkleProve
 	eval_claim: F,
 	batch_challenge: Option<F>,
 	outer_challenges: &[F],
+	reduced_log_dim: usize,
 	mut fri_folder: FRIFoldProver<'a, F, P, NTT, MerkleProver>,
 	transcript: &mut ProverTranscript<Challenger_>,
 ) -> Result<(), Error>
@@ -218,19 +222,31 @@ where
 	let n_inner = usize::from(batch_challenge.is_some());
 	assert_eq!(n_vars + n_inner + outer_challenges.len(), fri_folder.n_rounds());
 
+	// The leading `max_n - D` standard rounds carry the non-ZK oracles' batch folds; only the
+	// trailing `D` are genuine FRI rounds. The folder's FirstFold consumes its accumulated
+	// challenges as `[inner-batch | outer]`, where the inner-batch challenges are γ (if any)
+	// followed by those `max_n - D` leading challenges, so the outer challenges must be fed only
+	// once the leading ones are in.
+	assert!(reduced_log_dim <= n_vars);
+	let n_leading = n_vars - reduced_log_dim;
+
 	// Inner (unbatch) round: fold every interleaved (π_i ‖ ω_i) ZK codeword at the masking
 	// challenge.
 	if let Some(gamma) = batch_challenge {
 		fri_folder.receive_challenge(gamma);
 	}
-	// Outer rounds: combine the k lifted codewords at the batching challenges r'. These carry no
-	// sumcheck round-polynomial; the folder applies them lazily at the first commit round.
-	for &outer_challenge in outer_challenges {
-		fri_folder.receive_challenge(outer_challenge);
-	}
 
 	let mut sumcheck = MultilinearEvalProver::new(witness, eval_point, eval_claim)?;
-	for _ in 0..n_vars {
+	for round in 0..n_vars {
+		// Once the leading batch-fold challenges are accumulated, feed the outer (oracle-combine)
+		// challenges so they land in the FirstFold's outer window. For an all-ZK batch
+		// `n_leading == 0`, matching the original "feed γ then outers up front" order.
+		if round == n_leading {
+			for &outer_challenge in outer_challenges {
+				fri_folder.receive_challenge(outer_challenge);
+			}
+		}
+
 		let mut round_coeffs_vec = sumcheck.execute()?;
 		let round_coeffs = round_coeffs_vec
 			.pop()
@@ -247,6 +263,13 @@ where
 		let challenge = transcript.sample();
 		sumcheck.fold(challenge)?;
 		fri_folder.receive_challenge(challenge);
+	}
+	// When `D == 0` the leading window spans every standard round, so the outer challenges follow
+	// them here, before the final fold.
+	if n_leading == n_vars {
+		for &outer_challenge in outer_challenges {
+			fri_folder.receive_challenge(outer_challenge);
+		}
 	}
 
 	let commitment = fri_folder.execute_fold_round();
@@ -522,6 +545,7 @@ mod test {
 			eval_claim,
 			Some(batch_challenge),
 			&[],
+			fri_params.rs_code().log_dim(),
 			fri_folder,
 			&mut prover_transcript,
 		)?;

--- a/crates/iop-prover/src/basefold.rs
+++ b/crates/iop-prover/src/basefold.rs
@@ -193,7 +193,7 @@ pub fn prove_mlecheck_basefold_zk_batch<'a, F, P, NTT, MerkleScheme, MerkleProve
 	witness: FieldBuffer<P>,
 	eval_point: &[F],
 	eval_claim: F,
-	batch_challenge: F,
+	batch_challenge: Option<F>,
 	outer_challenges: &[F],
 	mut fri_folder: FRIFoldProver<'a, F, P, NTT, MerkleProver>,
 	transcript: &mut ProverTranscript<Challenger_>,
@@ -210,14 +210,21 @@ where
 
 	let n_vars = witness.log_len();
 	assert_eq!(eval_point.len(), n_vars);
-	// The FRI folder has one inner (unbatch) round, `log_n_oracles` outer (oracle-combine) rounds,
-	// and `𝐧` standard fold rounds.
-	assert_eq!(n_vars + 1 + outer_challenges.len(), fri_folder.n_rounds());
+	// The FRI folder has `n_inner` inner (unbatch) rounds — one for the shared mask challenge γ
+	// when any ZK oracle is present, none otherwise — `log_n_oracles` outer (oracle-combine)
+	// rounds, and `𝐧` standard fold rounds. The non-ZK oracles' batch-fold challenges are drawn
+	// from the leading standard rounds and routed to each oracle via its `skip_batch_challenges`
+	// window in the folder.
+	let n_inner = usize::from(batch_challenge.is_some());
+	assert_eq!(n_vars + n_inner + outer_challenges.len(), fri_folder.n_rounds());
 
-	// Inner (unbatch) round: fold every interleaved (π_i ‖ ω_i) codeword at the masking challenge.
-	fri_folder.receive_challenge(batch_challenge);
+	// Inner (unbatch) round: fold every interleaved (π_i ‖ ω_i) ZK codeword at the masking
+	// challenge.
+	if let Some(gamma) = batch_challenge {
+		fri_folder.receive_challenge(gamma);
+	}
 	// Outer rounds: combine the k lifted codewords at the batching challenges r'. These carry no
-	// sumcheck round-polynomial; the folder applies them lazily with γ at the first commit round.
+	// sumcheck round-polynomial; the folder applies them lazily at the first commit round.
 	for &outer_challenge in outer_challenges {
 		fri_folder.receive_challenge(outer_challenge);
 	}
@@ -513,7 +520,7 @@ mod test {
 			witness_prime,
 			&evaluation_point,
 			eval_claim,
-			batch_challenge,
+			Some(batch_challenge),
 			&[],
 			fri_folder,
 			&mut prover_transcript,
@@ -533,7 +540,7 @@ mod test {
 			&[retrieved_commitment],
 			eval_claim,
 			&evaluation_point,
-			batch_challenge_v,
+			Some(batch_challenge_v),
 			&[],
 			&mut verifier_transcript,
 		)?;

--- a/crates/iop-prover/src/basefold_zk_channel.rs
+++ b/crates/iop-prover/src/basefold_zk_channel.rs
@@ -16,7 +16,7 @@ use binius_ip_prover::{
 	sumcheck::{self, PaddedSumcheckDecorator, bivariate_product::BivariateProductSumcheckProver},
 };
 use binius_math::{
-	FieldBuffer, FieldSlice,
+	FieldBuffer, FieldSlice, FieldSliceMut,
 	inner_product::inner_product_par,
 	line::{extrapolate_line, extrapolate_line_packed},
 	multilinear::eq::{eq_ind_partial_eval_scalars, eq_ind_zero},
@@ -222,7 +222,6 @@ fn prove_batch_zk_basefold<F, P, NTT, MerkleScheme, MerkleProver_, Challenger_>(
 	// Only ZK oracles are masked. Send their σ_i = ⟨ω_i, t_i⟩ (one per ZK oracle, in relation
 	// order), then sample the single shared masking challenge γ — skipped entirely when no ZK
 	// oracle is present.
-	let n_zk = oracle_specs.iter().filter(|spec| spec.is_zk).count();
 	let sigmas = relations
 		.iter()
 		.filter(|(index, _, _, _)| oracle_specs[*index].is_zk)
@@ -236,8 +235,7 @@ fn prove_batch_zk_basefold<F, P, NTT, MerkleScheme, MerkleProver_, Challenger_>(
 		.collect::<Vec<_>>();
 	channel.send_many(&sigmas);
 
-	let gamma = (n_zk > 0).then(|| IPProverChannel::<F>::sample(channel));
-	let gamma_broadcast = gamma.map(P::broadcast);
+	let gamma = (!sigmas.is_empty()).then(|| IPProverChannel::<F>::sample(channel));
 
 	// === Phase A: batched sumcheck on the masked claims ⟨π_i', t_i⟩ = s_i' ===
 	// Register provers in arrival order; form π_i' = (1-γ)π_i + γω_i, storing each clone for Phase
@@ -247,7 +245,7 @@ fn prove_batch_zk_basefold<F, P, NTT, MerkleScheme, MerkleProver_, Challenger_>(
 	let mut witness_primes = vec![None; n_committed];
 	let mut prover_oracle_indices = Vec::with_capacity(n_committed);
 	let mut provers = Vec::with_capacity(n_committed);
-	let mut sigma_iter = sigmas.iter().copied();
+	let mut sigma_iter = sigmas.into_iter();
 	for (index, mut message, transparent, claim) in relations {
 		let n_i = oracle_specs[index].log_msg_len;
 		assert_eq!(message.log_len(), n_i); // pre-condition
@@ -261,22 +259,27 @@ fn prove_batch_zk_basefold<F, P, NTT, MerkleScheme, MerkleProver_, Challenger_>(
 				.mask
 				.as_ref()
 				.expect("ZK oracle carries a mask");
-			let gamma_broadcast = gamma_broadcast.expect("γ sampled when ZK oracles present");
+			let gamma = gamma.expect("γ sampled when ZK oracles present");
+
+			let gamma_broadcast = P::broadcast(gamma);
 			(message.as_mut(), mask.as_ref())
 				.into_par_iter()
 				.for_each(|(message_i, &mask_i)| {
 					*message_i = extrapolate_line_packed(*message_i, mask_i, gamma_broadcast);
 				});
-			extrapolate_line(claim, sigma, gamma.expect("γ sampled when ZK oracles present"))
+
+			extrapolate_line(claim, sigma, gamma)
 		} else {
 			claim
 		};
-		witness_primes[index] = Some(message.clone());
-		prover_oracle_indices.push(index);
 
-		let inner = BivariateProductSumcheckProver::new([message, transparent], sum_prime)
+		// TODO: We could cut the size of the message.clone() if the SumcheckProver accepted Cow
+		let inner = BivariateProductSumcheckProver::new([message.clone(), transparent], sum_prime)
 			.expect("π_i' and t_i have equal length");
 		provers.push(PaddedSumcheckDecorator::new(inner, max_n - n_i));
+
+		witness_primes[index] = Some(message.clone());
+		prover_oracle_indices.push(index);
 	}
 
 	let output =
@@ -303,11 +306,10 @@ fn prove_batch_zk_basefold<F, P, NTT, MerkleScheme, MerkleProver_, Challenger_>(
 	let outer_challenges = channel.sample_many(log_n_oracles);
 	let eq_tensor = eq_ind_partial_eval_scalars(&outer_challenges);
 
-	let input_oracles = fri_params.input_oracles();
 	let mut combined = FieldBuffer::<P>::zeros(max_n);
 	let mut s_prime = F::ZERO;
-	for (i, (witness_prime, scalar, alpha_i)) in
-		izip!(witness_primes, eq_tensor, alphas).enumerate()
+	for (fri_oracle, witness_prime, eq_i, alpha_i) in
+		izip!(fri_params.input_oracles(), witness_primes, eq_tensor, alphas)
 	{
 		let witness_prime =
 			witness_prime.expect("every committed oracle carries exactly one queued relation");
@@ -315,46 +317,26 @@ fn prove_batch_zk_basefold<F, P, NTT, MerkleScheme, MerkleProver_, Challenger_>(
 		// Each oracle occupies the low 2^{n_i} of every 2^{log_lift}·2^{n_i}-sized lift block, and
 		// that block is *repeated* across the 2^{log_repeat} high dims so the small oracle is
 		// constant along them (matching the FRI lift/repeat structure).
-		let log_lift = input_oracles[i].log_lift;
-		let log_repeat = max_n - n_i - log_lift;
-		let scalar_p = P::broadcast(scalar);
-		if log_repeat == 0 {
-			// Low-block placement (zero-pad lift only); identical to the all-ZK path.
-			if n_i >= P::LOG_WIDTH {
-				let src = witness_prime.as_ref();
-				combined.as_mut()[..src.len()]
-					.par_iter_mut()
-					.zip(src)
-					.for_each(|(dst, &w)| {
-						*dst += scalar_p * w;
-					});
-			} else {
-				let src = P::from_scalars(witness_prime.iter_scalars());
-				combined.as_mut()[0] += src;
-			}
-		} else {
-			// Repeat placement: add scalar · π_i' into the first 2^{n_i} entries of each of the
-			// 2^{log_repeat} chunks of size 2^{n_i + log_lift}.
-			assert!(
-				n_i + log_lift >= P::LOG_WIDTH,
-				"repeat placement requires whole-packed lift blocks",
-			);
-			let chunk_packed = 1usize << (n_i + log_lift - P::LOG_WIDTH);
-			let src = witness_prime.as_ref();
-			combined
-				.as_mut()
-				.par_chunks_mut(chunk_packed)
-				.for_each(|chunk| {
-					chunk[..src.len()]
-						.iter_mut()
-						.zip(src)
-						.for_each(|(dst, &w)| {
-							*dst += scalar_p * w;
-						});
-				});
-		}
+		let log_lift = fri_oracle.log_lift;
+
+		// Repeat placement: add scalar · π_i' into the first 2^{n_i} entries of each of the
+		// 2^{log_repeat} chunks of size 2^{n_i + log_lift}.
+		assert!(
+			n_i + log_lift >= P::LOG_WIDTH,
+			"repeat placement requires whole-packed lift blocks",
+		);
+		let scalar_broadcast = P::broadcast(eq_i);
+		let chunk_packed = 1usize << (n_i + log_lift - P::LOG_WIDTH);
+		combined
+			.as_mut()
+			.par_chunks_mut(chunk_packed)
+			.for_each(|chunk| {
+				let chunk_buf = FieldSliceMut::from_slice(n_i + log_lift, chunk);
+				accumulate_scaled_buffer(chunk_buf, witness_prime.to_ref(), scalar_broadcast);
+			});
+
 		// Repeat dims contribute 1; only the lift dims contribute an eq-to-zero factor.
-		s_prime += scalar * alpha_i * eq_ind_zero(&point[n_i..n_i + log_lift]);
+		s_prime += eq_i * alpha_i * eq_ind_zero(&point[n_i..][..log_lift]);
 	}
 
 	// Codeword commitments in oracle-index order, matching `open_fri_params.input_oracles()`.
@@ -377,6 +359,25 @@ fn prove_batch_zk_basefold<F, P, NTT, MerkleScheme, MerkleProver_, Challenger_>(
 		channel,
 	)
 	.expect("combined MLE-check BaseFold proof should succeed");
+}
+
+fn accumulate_scaled_buffer<P: PackedField>(
+	mut dst: FieldSliceMut<P>,
+	src: FieldSlice<P>,
+	scalar_broadcast: P,
+) {
+	if src.log_len() >= P::LOG_WIDTH {
+		let src = src.as_ref();
+		dst.as_mut()
+			.par_iter_mut()
+			.zip(src.as_ref())
+			.for_each(|(dst_i, src_i)| {
+				*dst_i += scalar_broadcast * *src_i;
+			});
+	} else {
+		let src = P::from_scalars(src.iter_scalars());
+		dst.as_mut()[0] += scalar_broadcast * src;
+	}
 }
 
 impl<'a, F, P, NTT, MerkleScheme, MerkleProver_, Challenger_> IPProverChannel<F>

--- a/crates/iop-prover/src/basefold_zk_channel.rs
+++ b/crates/iop-prover/src/basefold_zk_channel.rs
@@ -34,7 +34,7 @@ use crate::{
 	basefold::prove_mlecheck_basefold_zk_batch,
 	basefold_compiler::BaseFoldZKProverCompiler,
 	channel::IOPProverChannel,
-	fri::{self, CommitMaskedOutput, FRIFoldProver},
+	fri::{self, CommitMaskedOutput, CommitOutput, FRIFoldProver},
 	merkle_tree::MerkleTreeProver,
 };
 
@@ -46,9 +46,9 @@ pub struct BaseFoldZKOracle {
 
 /// Committed oracle data stored internally.
 struct CommittedOracleData<P: PackedField, Committed> {
-	/// The mask buffer generated during [`fri::commit_masked`]. Held by the channel because it is
-	/// the only party that knows it.
-	mask: FieldBuffer<P>,
+	/// The mask buffer generated during [`fri::commit_masked`] for a ZK oracle, held by the
+	/// channel because it is the only party that knows it. `None` for a non-ZK (unmasked) oracle.
+	mask: Option<FieldBuffer<P>>,
 	/// RS-encoded codeword.
 	codeword: FieldBuffer<P>,
 	/// Merkle commitment data for query proofs.
@@ -211,21 +211,33 @@ fn prove_batch_zk_basefold<F, P, NTT, MerkleScheme, MerkleProver_, Challenger_>(
 	// sumcheck reduces to the multilinear evaluations (alphas).
 	assert_eq!(relations.len(), n_committed, "expects exactly one relation per committed oracle",);
 
-	// `𝐧 = max_i n_i`, the dimension of the combined codeword.
-	let max_n = fri_params.rs_code().log_dim();
+	// `𝐧 = max_i log_msg_len_i`, the variable count of the combined opening / materialized buffer.
+	let max_n = oracle_specs
+		.iter()
+		.map(|spec| spec.log_msg_len)
+		.max()
+		.expect("at least one oracle");
 
 	// === Masking step (whitepaper 7.2) ===
-	// Send the masked inner products σ_i = ⟨ω_i, t_i⟩, then sample a single masking challenge γ.
+	// Only ZK oracles are masked. Send their σ_i = ⟨ω_i, t_i⟩ (one per ZK oracle, in relation
+	// order), then sample the single shared masking challenge γ — skipped entirely when no ZK
+	// oracle is present.
+	let n_zk = oracle_specs.iter().filter(|spec| spec.is_zk).count();
 	let sigmas = relations
 		.iter()
+		.filter(|(index, _, _, _)| oracle_specs[*index].is_zk)
 		.map(|(index, _, transparent, _)| {
-			inner_product_par(&committed_oracles[*index].mask, transparent)
+			let mask = committed_oracles[*index]
+				.mask
+				.as_ref()
+				.expect("ZK oracle carries a mask");
+			inner_product_par(mask, transparent)
 		})
 		.collect::<Vec<_>>();
 	channel.send_many(&sigmas);
 
-	let gamma = IPProverChannel::<F>::sample(channel);
-	let gamma_broadcast = P::broadcast(gamma);
+	let gamma = (n_zk > 0).then(|| IPProverChannel::<F>::sample(channel));
+	let gamma_broadcast = gamma.map(P::broadcast);
 
 	// === Phase A: batched sumcheck on the masked claims ⟨π_i', t_i⟩ = s_i' ===
 	// Register provers in arrival order; form π_i' = (1-γ)π_i + γω_i, storing each clone for Phase
@@ -235,23 +247,33 @@ fn prove_batch_zk_basefold<F, P, NTT, MerkleScheme, MerkleProver_, Challenger_>(
 	let mut witness_primes = vec![None; n_committed];
 	let mut prover_oracle_indices = Vec::with_capacity(n_committed);
 	let mut provers = Vec::with_capacity(n_committed);
-	for ((index, mut message, transparent, claim), sigma) in iter::zip(relations, sigmas) {
+	let mut sigma_iter = sigmas.iter().copied();
+	for (index, mut message, transparent, claim) in relations {
 		let n_i = oracle_specs[index].log_msg_len;
 		assert_eq!(message.log_len(), n_i); // pre-condition
 		assert_eq!(transparent.log_len(), n_i); // pre-condition
 
-		let mask = &committed_oracles[index].mask;
-
-		// Modify the message π_i to be the blinded message π_i'.
-		(message.as_mut(), mask.as_ref())
-			.into_par_iter()
-			.for_each(|(message_i, &mask_i)| {
-				*message_i = extrapolate_line_packed(*message_i, mask_i, gamma_broadcast);
-			});
+		// ZK oracle: blind the message π_i' = (1-γ)π_i + γω_i and mask the claim with σ_i.
+		// Non-ZK oracle: the message and claim pass through unmasked.
+		let sum_prime = if oracle_specs[index].is_zk {
+			let sigma = sigma_iter.next().expect("one σ per ZK oracle");
+			let mask = committed_oracles[index]
+				.mask
+				.as_ref()
+				.expect("ZK oracle carries a mask");
+			let gamma_broadcast = gamma_broadcast.expect("γ sampled when ZK oracles present");
+			(message.as_mut(), mask.as_ref())
+				.into_par_iter()
+				.for_each(|(message_i, &mask_i)| {
+					*message_i = extrapolate_line_packed(*message_i, mask_i, gamma_broadcast);
+				});
+			extrapolate_line(claim, sigma, gamma.expect("γ sampled when ZK oracles present"))
+		} else {
+			claim
+		};
 		witness_primes[index] = Some(message.clone());
 		prover_oracle_indices.push(index);
 
-		let sum_prime = extrapolate_line(claim, sigma, gamma);
 		let inner = BivariateProductSumcheckProver::new([message, transparent], sum_prime)
 			.expect("π_i' and t_i have equal length");
 		provers.push(PaddedSumcheckDecorator::new(inner, max_n - n_i));
@@ -281,28 +303,58 @@ fn prove_batch_zk_basefold<F, P, NTT, MerkleScheme, MerkleProver_, Challenger_>(
 	let outer_challenges = channel.sample_many(log_n_oracles);
 	let eq_tensor = eq_ind_partial_eval_scalars(&outer_challenges);
 
+	let input_oracles = fri_params.input_oracles();
 	let mut combined = FieldBuffer::<P>::zeros(max_n);
 	let mut s_prime = F::ZERO;
-	for (witness_prime, scalar, alpha_i) in izip!(witness_primes, eq_tensor, alphas) {
+	for (i, (witness_prime, scalar, alpha_i)) in
+		izip!(witness_primes, eq_tensor, alphas).enumerate()
+	{
 		let witness_prime =
 			witness_prime.expect("every committed oracle carries exactly one queued relation");
 		let n_i = witness_prime.log_len();
-		// Add scalar · π_i^↑ into the low 2^{n_i} block of the combined buffer (the high block is
-		// the ZeroPadMSB lift, left as the zeros already in `combined`).
-		if n_i >= P::LOG_WIDTH {
-			let scalar_p = P::broadcast(scalar);
-			let src = witness_prime.as_ref();
-			combined.as_mut()[..src.len()]
-				.par_iter_mut()
-				.zip(src)
-				.for_each(|(dst, &w)| {
-					*dst += scalar_p * w;
-				});
+		// Each oracle occupies the low 2^{n_i} of every 2^{log_lift}·2^{n_i}-sized lift block, and
+		// that block is *repeated* across the 2^{log_repeat} high dims so the small oracle is
+		// constant along them (matching the FRI lift/repeat structure).
+		let log_lift = input_oracles[i].log_lift;
+		let log_repeat = max_n - n_i - log_lift;
+		let scalar_p = P::broadcast(scalar);
+		if log_repeat == 0 {
+			// Low-block placement (zero-pad lift only); identical to the all-ZK path.
+			if n_i >= P::LOG_WIDTH {
+				let src = witness_prime.as_ref();
+				combined.as_mut()[..src.len()]
+					.par_iter_mut()
+					.zip(src)
+					.for_each(|(dst, &w)| {
+						*dst += scalar_p * w;
+					});
+			} else {
+				let src = P::from_scalars(witness_prime.iter_scalars());
+				combined.as_mut()[0] += src;
+			}
 		} else {
-			let src = P::from_scalars(witness_prime.iter_scalars());
-			combined.as_mut()[0] += src;
+			// Repeat placement: add scalar · π_i' into the first 2^{n_i} entries of each of the
+			// 2^{log_repeat} chunks of size 2^{n_i + log_lift}.
+			assert!(
+				n_i + log_lift >= P::LOG_WIDTH,
+				"repeat placement requires whole-packed lift blocks",
+			);
+			let chunk_packed = 1usize << (n_i + log_lift - P::LOG_WIDTH);
+			let src = witness_prime.as_ref();
+			combined
+				.as_mut()
+				.par_chunks_mut(chunk_packed)
+				.for_each(|chunk| {
+					chunk[..src.len()]
+						.iter_mut()
+						.zip(src)
+						.for_each(|(dst, &w)| {
+							*dst += scalar_p * w;
+						});
+				});
 		}
-		s_prime += scalar * alpha_i * eq_ind_zero(&point[n_i..]);
+		// Repeat dims contribute 1; only the lift dims contribute an eq-to-zero factor.
+		s_prime += scalar * alpha_i * eq_ind_zero(&point[n_i..n_i + log_lift]);
 	}
 
 	// Codeword commitments in oracle-index order, matching `open_fri_params.input_oracles()`.
@@ -390,21 +442,37 @@ where
 			buffer.log_len()
 		);
 
-		// Generate mask, interleave, and commit oracle `index` of the combined FRI parameters via
-		// commit_masked.
-		let CommitMaskedOutput {
-			commitment,
-			committed,
-			codeword,
-			mask,
-		} = fri::commit_masked(
-			&self.fri_params,
-			index,
-			self.ntt,
-			self.merkle_prover,
-			buffer.to_ref(),
-			&mut self.rng,
-		);
+		// Commit oracle `index` of the combined FRI parameters. ZK oracles interleave a fresh mask
+		// (`commit_masked`); non-ZK oracles commit the message alone (`commit_interleaved`).
+		let (commitment, committed, codeword, mask) = if spec.is_zk {
+			let CommitMaskedOutput {
+				commitment,
+				committed,
+				codeword,
+				mask,
+			} = fri::commit_masked(
+				&self.fri_params,
+				index,
+				self.ntt,
+				self.merkle_prover,
+				buffer.to_ref(),
+				&mut self.rng,
+			);
+			(commitment, committed, codeword, Some(mask))
+		} else {
+			let CommitOutput {
+				commitment,
+				committed,
+				codeword,
+			} = fri::commit_interleaved(
+				&self.fri_params,
+				index,
+				self.ntt,
+				self.merkle_prover,
+				buffer.to_ref(),
+			);
+			(commitment, committed, codeword, None)
+		};
 
 		// Send commitment via transcript.
 		self.transcript.message().write(&commitment);
@@ -734,11 +802,130 @@ mod tests {
 		verifier_channel.finish().is_ok()
 	}
 
+	/// Like `run_zk_channel` but with per-oracle `(n_vars, is_zk)` flags, exercising the mixed
+	/// ZK/non-ZK opening. If `tamper`, the verifier's claim on the first oracle is corrupted.
+	fn run_mixed_channel(specs: &[(usize, bool)], tamper: bool) -> bool {
+		type F = BinaryField128bGhash;
+		type P = PackedBinaryGhash1x128b;
+
+		let mut rng = StdRng::seed_from_u64(0);
+		let data: Vec<(FieldBuffer<P>, FieldBuffer<P>, F)> = specs
+			.iter()
+			.map(|&(n, _)| generate_zk_oracle_data::<F, P, _>(&mut rng, n))
+			.collect();
+
+		let n_test_queries = calculate_n_test_queries(SECURITY_BITS, LOG_INV_RATE);
+		let oracle_specs: Vec<OracleSpec> = specs
+			.iter()
+			.map(|&(n, is_zk)| {
+				if is_zk {
+					OracleSpec::new_zk(n)
+				} else {
+					OracleSpec::new(n)
+				}
+			})
+			.collect();
+
+		let merkle_prover = make_merkle_prover();
+		let verifier_compiler = BaseFoldZKVerifierCompiler::new(
+			merkle_prover.scheme().clone(),
+			oracle_specs,
+			LOG_INV_RATE,
+			n_test_queries,
+			&MinProofSizeStrategy,
+		);
+
+		let ntt = make_ntt(verifier_compiler.max_subspace());
+		let prover_compiler = BaseFoldZKProverCompiler::<P, _, _>::from_verifier_compiler(
+			&verifier_compiler,
+			ntt,
+			merkle_prover,
+		);
+
+		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
+		let prover_rng = StdRng::seed_from_u64(1);
+		let mut prover_channel = prover_compiler.create_channel(&mut prover_transcript, prover_rng);
+
+		let oracles: Vec<_> = data
+			.iter()
+			.map(|(buffer, _, _)| prover_channel.send_oracle(buffer.to_ref()))
+			.collect();
+		let prover_relations: Vec<_> = oracles
+			.into_iter()
+			.zip(&data)
+			.map(|(oracle, (buffer, transparent, claim))| {
+				(oracle, buffer.clone(), transparent.clone(), *claim)
+			})
+			.collect();
+		prover_channel.prove_oracle_relations(prover_relations);
+		prover_channel.finish();
+
+		let mut verifier_transcript = prover_transcript.into_verifier();
+		let mut verifier_channel = verifier_compiler.create_channel(&mut verifier_transcript);
+
+		let v_oracles: Vec<_> = (0..specs.len())
+			.map(|_| verifier_channel.recv_oracle().unwrap())
+			.collect();
+		let relations: Vec<_> = v_oracles
+			.into_iter()
+			.zip(&data)
+			.enumerate()
+			.map(|(i, (oracle, (_, transparent, claim)))| {
+				let transparent = transparent.clone();
+				let claim = if tamper && i == 0 {
+					*claim + F::ONE
+				} else {
+					*claim
+				};
+				OracleLinearRelation {
+					oracle,
+					transparent: Box::new(move |point: &[F]| {
+						let eq = eq_ind_partial_eval::<P>(point);
+						inner_product_buffers(&transparent, &eq)
+					}),
+					claim,
+				}
+			})
+			.collect();
+		verifier_channel
+			.verify_oracle_relations(relations)
+			.expect("verify_oracle_relations only queues");
+		verifier_channel.finish().is_ok()
+	}
+
 	#[test]
 	fn test_basefold_zk_channel_three_oracles_non_power_of_two() {
 		// 3 oracles (not a power of two) of unequal sizes: exercises oracle padding (Lifted FRI)
 		// and the `⌈log 3⌉ = 2` outer oracle-combine rounds.
 		assert!(run_zk_channel(&[5, 6, 8], false));
+	}
+
+	// WIP (BINIUS-69): the mixed/zero-ZK opening fails Phase-B FRI consistency when the optimizer
+	// gives a non-ZK oracle log_batch_size > 0. Root cause: prove/verify_mlecheck feed the FRI
+	// folder its outer (oracle-combine) challenges *before* the leading MLE rounds that supply the
+	// non-ZK batch-fold challenges, so the FirstFold's `[inner | outer]` split routes them to the
+	// wrong windows. Needs the outer challenges fed after the batch-fold rounds. All-ZK is
+	// unaffected (max_inner == 1).
+	#[test]
+	#[ignore = "WIP: heterogeneous Phase-B FRI challenge ordering (see comment)"]
+	fn test_basefold_zk_channel_mixed_zk_non_zk() {
+		// One non-ZK oracle (8 vars) and one ZK oracle (6 vars): exercises conditional masking,
+		// the heterogeneous combined-buffer lift/repeat placement, and the non-ZK unmasked commit.
+		assert!(run_mixed_channel(&[(8, false), (6, true)], false));
+	}
+
+	#[test]
+	#[ignore = "WIP: heterogeneous Phase-B FRI challenge ordering (see comment)"]
+	fn test_basefold_zk_channel_zero_zk() {
+		// All non-ZK oracles: γ must never be sampled and the proof must still verify.
+		assert!(run_mixed_channel(&[(6, false), (8, false)], false));
+	}
+
+	#[test]
+	#[ignore = "WIP: heterogeneous Phase-B FRI challenge ordering (see comment)"]
+	fn test_basefold_zk_channel_mixed_invalid_proof() {
+		// Tampering the claim on a mixed batch must be rejected.
+		assert!(!run_mixed_channel(&[(8, false), (6, true)], true));
 	}
 
 	#[test]

--- a/crates/iop-prover/src/basefold_zk_channel.rs
+++ b/crates/iop-prover/src/basefold_zk_channel.rs
@@ -355,6 +355,7 @@ fn prove_batch_zk_basefold<F, P, NTT, MerkleScheme, MerkleProver_, Challenger_>(
 		s_prime,
 		gamma,
 		&outer_challenges,
+		fri_params.rs_code().log_dim(),
 		fri_folder,
 		channel,
 	)
@@ -901,14 +902,11 @@ mod tests {
 		assert!(run_zk_channel(&[5, 6, 8], false));
 	}
 
-	// WIP (BINIUS-69): the mixed/zero-ZK opening fails Phase-B FRI consistency when the optimizer
-	// gives a non-ZK oracle log_batch_size > 0. Root cause: prove/verify_mlecheck feed the FRI
-	// folder its outer (oracle-combine) challenges *before* the leading MLE rounds that supply the
-	// non-ZK batch-fold challenges, so the FirstFold's `[inner | outer]` split routes them to the
-	// wrong windows. Needs the outer challenges fed after the batch-fold rounds. All-ZK is
-	// unaffected (max_inner == 1).
+	// Heterogeneous mixed/zero-ZK openings: the non-ZK oracles' batch-fold challenges come from the
+	// leading `max_n - D` MLE rounds, so prove/verify_mlecheck feed the FRI folder's outer
+	// (oracle-combine) challenges *after* those rounds, landing them in the FirstFold's outer
+	// window. All-ZK (`n_leading == 0`) is unaffected: the outers still precede every MLE round.
 	#[test]
-	#[ignore = "WIP: heterogeneous Phase-B FRI challenge ordering (see comment)"]
 	fn test_basefold_zk_channel_mixed_zk_non_zk() {
 		// One non-ZK oracle (8 vars) and one ZK oracle (6 vars): exercises conditional masking,
 		// the heterogeneous combined-buffer lift/repeat placement, and the non-ZK unmasked commit.
@@ -916,14 +914,12 @@ mod tests {
 	}
 
 	#[test]
-	#[ignore = "WIP: heterogeneous Phase-B FRI challenge ordering (see comment)"]
 	fn test_basefold_zk_channel_zero_zk() {
 		// All non-ZK oracles: γ must never be sampled and the proof must still verify.
 		assert!(run_mixed_channel(&[(6, false), (8, false)], false));
 	}
 
 	#[test]
-	#[ignore = "WIP: heterogeneous Phase-B FRI challenge ordering (see comment)"]
 	fn test_basefold_zk_channel_mixed_invalid_proof() {
 		// Tampering the claim on a mixed batch must be rejected.
 		assert!(!run_mixed_channel(&[(8, false), (6, true)], true));

--- a/crates/iop/src/basefold.rs
+++ b/crates/iop/src/basefold.rs
@@ -126,7 +126,10 @@ where
 /// * `outer_challenges` - the batching challenges `r'` (length `log_n_oracles`) used in the FRI
 ///   outer (oracle-combine) rounds.
 ///
-/// The returned `challenges` are the FRI fold challenges `[γ] ++ r' ++ fresh_X`. Use
+/// The leading `max_n - D` standard rounds (`D = fri_params.rs_code().log_dim()`, the reduced
+/// first-round code dimension) carry the non-ZK oracles' batch folds; only the trailing `D` are
+/// genuine FRI fold rounds. The returned `challenges` are the FRI fold challenges
+/// `[γ] ++ leading_X ++ r' ++ trailing_X`, matching the prover's feed order. Use
 /// [`mlecheck_fri_consistency`] to check the reduced values.
 #[allow(clippy::too_many_arguments)]
 pub fn verify_mlecheck_basefold_zk_batch<F, MTScheme, Challenger_>(
@@ -157,8 +160,13 @@ where
 	let n_vars = eval_point.len();
 
 	// `n_inner` inner (unbatch) rounds: one for the shared mask challenge γ when any ZK oracle is
-	// present, none otherwise.
+	// present, none otherwise. The leading `n_leading = max_n - D` standard rounds carry the non-ZK
+	// oracles' batch folds (inner challenges); the outer (oracle-combine) challenges follow them so
+	// they land in the FirstFold's outer window, exactly mirroring the prover's feed order.
 	let n_inner = usize::from(batch_challenge.is_some());
+	let reduced_log_dim = fri_params.rs_code().log_dim();
+	assert!(reduced_log_dim <= n_vars);
+	let n_leading = n_vars - reduced_log_dim;
 	let mut challenges = Vec::with_capacity(n_vars + n_inner + log_n_oracles);
 	let mut fri_fold_verifier = FRIFoldVerifier::new(fri_params);
 
@@ -169,17 +177,19 @@ where
 		challenges.push(gamma);
 	}
 
-	// Outer rounds: combine the `k` lifted codewords at the batching challenges `r'`. These carry
-	// no sumcheck round-polynomial (the oracle-index variables are collapsed deterministically).
-	for &outer_challenge in outer_challenges {
-		fri_fold_verifier.process_round(&mut transcript.message())?;
-		challenges.push(outer_challenge);
-	}
-
 	// Standard rounds: the only sumcheck (MLE-check) rounds, folding the combined codeword at the
-	// fresh challenges over the `𝐧` variables `X`.
+	// fresh challenges over the `𝐧` variables `X`. The outer (oracle-combine) challenges — which
+	// carry no sumcheck round-polynomial — are processed once the leading batch-fold challenges are
+	// in (all-ZK has `n_leading == 0`, so they precede every standard round as before).
 	let mut sum = eval_claim;
 	for round in 0..n_vars {
+		if round == n_leading {
+			for &outer_challenge in outer_challenges {
+				fri_fold_verifier.process_round(&mut transcript.message())?;
+				challenges.push(outer_challenge);
+			}
+		}
+
 		let round_proof = mlecheck::RoundProof(RoundCoeffs(transcript.message().read_vec(DEGREE)?));
 		fri_fold_verifier.process_round(&mut transcript.message())?;
 
@@ -189,6 +199,14 @@ where
 		let challenge = transcript.sample();
 		sum = round_coeffs.evaluate(challenge);
 		challenges.push(challenge);
+	}
+	// When `D == 0` the leading window spans every standard round, so the outer challenges follow
+	// them here, before the final fold.
+	if n_leading == n_vars {
+		for &outer_challenge in outer_challenges {
+			fri_fold_verifier.process_round(&mut transcript.message())?;
+			challenges.push(outer_challenge);
+		}
 	}
 
 	fri_fold_verifier.process_round(&mut transcript.message())?;

--- a/crates/iop/src/basefold.rs
+++ b/crates/iop/src/basefold.rs
@@ -135,7 +135,7 @@ pub fn verify_mlecheck_basefold_zk_batch<F, MTScheme, Challenger_>(
 	codeword_commitments: &[MTScheme::Digest],
 	eval_claim: F,
 	eval_point: &[F],
-	batch_challenge: F,
+	batch_challenge: Option<F>,
 	outer_challenges: &[F],
 	transcript: &mut VerifierTranscript<Challenger_>,
 ) -> Result<ReducedOutput<F>, Error>
@@ -147,30 +147,27 @@ where
 	// The MLE-check round polynomial is degree 1 (the composite is the multilinear itself).
 	const DEGREE: usize = 1;
 
-	// ZK precondition: each oracle is the interleaved (π ‖ ω) mask codeword, so the inner reduction
-	// is a single round folding at `γ`.
-	let max_log_batch_size = fri_params
-		.input_oracles()
-		.iter()
-		.map(|spec| spec.log_batch_size)
-		.max()
-		.expect("input_oracles is non-empty");
-	assert_eq!(max_log_batch_size, 1);
-
 	let log_n_oracles = log2_ceil_usize(fri_params.input_oracles().len());
 	assert_eq!(outer_challenges.len(), log_n_oracles);
 
-	// The combined codeword (after the inner unbatch and the `log_n_oracles` outer oracle-combine
-	// rounds) is a level-𝐧 codeword; the MLE-check therefore runs over `𝐧` variables.
-	let n_vars = fri_params.rs_code().log_dim();
-	assert_eq!(eval_point.len(), n_vars);
+	// The MLE-check runs over the combined opening's `𝐧 = max_i log_msg_len_i` variables, supplied
+	// as `eval_point`. For an all-ZK batch this equals `rs_code().log_dim()`; with non-ZK oracles
+	// it can exceed it, since those oracles fold their batch dimensions within the leading MLE
+	// rounds.
+	let n_vars = eval_point.len();
 
-	let mut challenges = Vec::with_capacity(n_vars + 1 + log_n_oracles);
+	// `n_inner` inner (unbatch) rounds: one for the shared mask challenge γ when any ZK oracle is
+	// present, none otherwise.
+	let n_inner = usize::from(batch_challenge.is_some());
+	let mut challenges = Vec::with_capacity(n_vars + n_inner + log_n_oracles);
 	let mut fri_fold_verifier = FRIFoldVerifier::new(fri_params);
 
-	// Inner (unbatch) round: fold every interleaved (π_i ‖ ω_i) codeword at the masking challenge.
-	fri_fold_verifier.process_round(&mut transcript.message())?;
-	challenges.push(batch_challenge);
+	// Inner (unbatch) round: fold every interleaved (π_i ‖ ω_i) ZK codeword at the masking
+	// challenge.
+	if let Some(gamma) = batch_challenge {
+		fri_fold_verifier.process_round(&mut transcript.message())?;
+		challenges.push(gamma);
+	}
 
 	// Outer rounds: combine the `k` lifted codewords at the batching challenges `r'`. These carry
 	// no sumcheck round-polynomial (the oracle-index variables are collapsed deterministically).

--- a/crates/iop/src/basefold_zk_channel.rs
+++ b/crates/iop/src/basefold_zk_channel.rs
@@ -6,8 +6,6 @@
 //! using FRI commitment and ZK BaseFold opening protocols. Unlike [`super::basefold_channel`],
 //! this channel always applies zero-knowledge blinding to all oracles.
 
-use std::iter;
-
 use binius_field::BinaryField;
 use binius_ip::{
 	channel::IPVerifierChannel,
@@ -23,6 +21,7 @@ use binius_transcript::{
 	fiat_shamir::{CanSample, Challenger},
 };
 use binius_utils::{DeserializeBytes, checked_arithmetics::log2_ceil_usize};
+use itertools::izip;
 
 use crate::{
 	basefold,
@@ -171,20 +170,21 @@ where
 	Challenger_: Challenger,
 {
 	let n_committed = oracle_commitments.len();
-	assert_eq!(relations.len(), n_committed, "expects exactly one relation per committed oracle",);
 
-	let n_vars: Vec<usize> = (0..n_committed)
-		.map(|i| oracle_specs[i].log_msg_len)
-		.collect();
 	// `𝐧 = max_i log_msg_len_i`, the variable count of the combined opening / materialized buffer.
-	let max_n = n_vars.iter().copied().max().expect("at least one oracle");
+	let max_n = oracle_specs
+		.iter()
+		.map(|spec| spec.log_msg_len)
+		.max()
+		.expect("at least one oracle");
 
 	// === Masking step ===
 	// Only ZK oracles are masked: read their σ_i (one per ZK oracle, in relation order) and sample
 	// the single shared γ. With no ZK oracle, γ is never sampled.
 	let n_zk = oracle_specs.iter().filter(|s| s.is_zk).count();
 	let sigmas = channel.recv_many(n_zk)?;
-	let gamma = (n_zk > 0).then(|| IPVerifierChannel::<F>::sample(channel));
+	let gamma = (!sigmas.is_empty()).then(|| IPVerifierChannel::<F>::sample(channel));
+
 	// Masked claim per relation: ZK → s_i' = extrapolate_line(claim, σ_i, γ); non-ZK → s_i' =
 	// claim.
 	let mut sigma_iter = sigmas.into_iter();
@@ -223,7 +223,7 @@ where
 		.into_iter()
 		.map(|relation| {
 			let alpha_i = alphas[relation.oracle.index];
-			let n_i = n_vars[relation.oracle.index];
+			let n_i = oracle_specs[relation.oracle.index].log_msg_len;
 			let (eval_coords, padding_coords) = point.split_at(n_i);
 			let pad_eq = eq_ind_zero(padding_coords);
 			let transparent_eval = (relation.transparent)(eval_coords);
@@ -238,20 +238,17 @@ where
 	// combined multilinear is 𝛑(X) = Σ_i e[i]·π_i^↑(X) with e = eq(·, r'), and the combined target
 	// is s' = 𝛑(r) = Σ_i e[i]·α_i·∏_{j≥n_i}(1 - r_j).
 	let log_n_oracles = log2_ceil_usize(n_committed);
-	let outer_challenges: Vec<F> = (0..log_n_oracles)
-		.map(|_| IPVerifierChannel::<F>::sample(channel))
-		.collect();
+	let outer_challenges = channel.sample_many(log_n_oracles);
 	let eq_tensor = eq_ind_partial_eval_scalars::<F>(&outer_challenges);
 	// In the combined buffer each oracle is zero-padded over its `log_lift` dims and *repeated*
 	// over the remaining `log_repeat = max_n - n_i - log_lift` high dims, so its evaluation at
 	// `point` picks up the eq-to-zero factor over the lift dims only (the repeat dims contribute
 	// 1).
-	let input_oracles = fri_params.input_oracles();
-	let s_prime = iter::zip(&alphas, &n_vars)
-		.enumerate()
-		.map(|(i, (&alpha_i, &n_i))| {
-			let log_lift = input_oracles[i].log_lift;
-			eq_tensor[i] * alpha_i * eq_ind_zero(&point[n_i..n_i + log_lift])
+	let s_prime = izip!(fri_params.input_oracles(), oracle_specs, eq_tensor, alphas)
+		.map(|(fri_oracle, spec, eq_i, alpha_i)| {
+			let n_i = spec.log_msg_len;
+			let log_lift = fri_oracle.log_lift;
+			eq_i * alpha_i * eq_ind_zero(&point[n_i..][..log_lift])
 		})
 		.sum::<F>();
 

--- a/crates/iop/src/basefold_zk_channel.rs
+++ b/crates/iop/src/basefold_zk_channel.rs
@@ -176,15 +176,32 @@ where
 	let n_vars: Vec<usize> = (0..n_committed)
 		.map(|i| oracle_specs[i].log_msg_len)
 		.collect();
-	// `𝐧 = max_i n_i`, the dimension of the combined codeword.
-	let max_n = fri_params.rs_code().log_dim();
+	// `𝐧 = max_i log_msg_len_i`, the variable count of the combined opening / materialized buffer.
+	let max_n = n_vars.iter().copied().max().expect("at least one oracle");
 
 	// === Masking step ===
-	// Read the masked inner products σ_i, sample γ, and form the masked claims s_i'.
-	let sigmas = channel.recv_many(n_committed)?;
-	let gamma = IPVerifierChannel::<F>::sample(channel);
-	let sum_primes = iter::zip(&relations, sigmas)
-		.map(|(relation, sigma)| extrapolate_line_packed(relation.claim, sigma, gamma))
+	// Only ZK oracles are masked: read their σ_i (one per ZK oracle, in relation order) and sample
+	// the single shared γ. With no ZK oracle, γ is never sampled.
+	let n_zk = oracle_specs.iter().filter(|s| s.is_zk).count();
+	let sigmas = channel.recv_many(n_zk)?;
+	let gamma = (n_zk > 0).then(|| IPVerifierChannel::<F>::sample(channel));
+	// Masked claim per relation: ZK → s_i' = extrapolate_line(claim, σ_i, γ); non-ZK → s_i' =
+	// claim.
+	let mut sigma_iter = sigmas.into_iter();
+	let sum_primes = relations
+		.iter()
+		.map(|relation| {
+			if oracle_specs[relation.oracle.index].is_zk {
+				let sigma = sigma_iter.next().expect("one σ per ZK oracle");
+				extrapolate_line_packed(
+					relation.claim,
+					sigma,
+					gamma.expect("γ sampled when ZK oracles present"),
+				)
+			} else {
+				relation.claim
+			}
+		})
 		.collect::<Vec<_>>();
 
 	// === Phase A: batched sumcheck on the masked claims (degree 2, bivariate product) ===
@@ -225,9 +242,17 @@ where
 		.map(|_| IPVerifierChannel::<F>::sample(channel))
 		.collect();
 	let eq_tensor = eq_ind_partial_eval_scalars::<F>(&outer_challenges);
+	// In the combined buffer each oracle is zero-padded over its `log_lift` dims and *repeated*
+	// over the remaining `log_repeat = max_n - n_i - log_lift` high dims, so its evaluation at
+	// `point` picks up the eq-to-zero factor over the lift dims only (the repeat dims contribute
+	// 1).
+	let input_oracles = fri_params.input_oracles();
 	let s_prime = iter::zip(&alphas, &n_vars)
 		.enumerate()
-		.map(|(i, (&alpha_i, &n_i))| eq_tensor[i] * alpha_i * eq_ind_zero(&point[n_i..]))
+		.map(|(i, (&alpha_i, &n_i))| {
+			let log_lift = input_oracles[i].log_lift;
+			eq_tensor[i] * alpha_i * eq_ind_zero(&point[n_i..n_i + log_lift])
+		})
 		.sum::<F>();
 
 	let basefold::ReducedOutput {


### PR DESCRIPTION
## Summary

Generalizes the batched ZK BaseFold channel + MLE-check to a **mixed ZK / non-ZK** batch, per [BINIUS-69](https://linear.app/jimpo/issue/BINIUS-69/combine-non-zk-with-zk-basefold-compiler) and the design settled in the Linear thread (materialized combined buffer with lift/repeat placement; `log_lift` from `FRIParams`; full flexible non-ZK batch). Built on top of the merged foundation (#1539).

The all-ZK path remains **byte-identical** — the generalization doesn't disturb the existing protocol.

## Commits

1. **generalize batched ZK BaseFold to mixed ZK/non-ZK oracles** — conditional masking (`γ: Option`, σ/blinding only for ZK oracles); `max_n = max_i(log_msg_len_i)`; non-ZK messages/claims pass through unmasked and commit via `commit_interleaved` (`CommittedOracleData.mask` is now `Option`); the combined buffer places each oracle with zero-pad over `log_lift` and **repeat** over `log_repeat = max_n − n_i − log_lift`, with `s'` picking up `eq_ind_zero` over the lift dims only.
2. **minor refactors** (@jimpo) — review cleanups to taste.
3. **fix FRI challenge ordering for heterogeneous batch; enable mixed/zero-ZK tests** — see below.

## The FRI challenge-ordering fix (commit 3)

When a non-ZK oracle gets `log_batch_size > 0`, its batch-fold challenges come from the **leading `max_n − D` MLE rounds** (`D = rs_code().log_dim()`), which arrive *after* the outer (oracle-combine) challenges in the original feed order — so `FRIFolder`'s `[inner-batch | outer]` split mis-routed them. The fix feeds the outer challenges to the folder **after** those leading rounds, in both `prove_mlecheck_basefold_zk_batch` and `verify_mlecheck_basefold_zk_batch` (threading `reduced_log_dim = D` through). For an all-ZK batch `n_leading = max_n − D = 0`, so the outers still precede every MLE round and the transcript is unchanged.

## Tests

All 40 `binius-iop` / `binius-iop-prover` library tests pass, including the now-enabled heterogeneous cases:
- `test_basefold_zk_channel_mixed_zk_non_zk` — `[(8, non-ZK), (6, ZK)]`
- `test_basefold_zk_channel_zero_zk` — all non-ZK (γ never sampled)
- `test_basefold_zk_channel_mixed_invalid_proof` — tampered mixed batch is rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)