### PR TITLE
BINIUS-146: use hint_varsize for compute_public_value (derived public wire)

### DIFF
--- a/crates/ip/src/channel.rs
+++ b/crates/ip/src/channel.rs
@@ -88,9 +88,9 @@ pub trait IPVerifierChannel<F: Field> {
 	/// as a freshly allocated `Elem`.
 	///
 	/// In wrapper channels that build constraints (e.g. `IronSpartanBuilderChannel`), the result
-	/// is materialized as a single inout wire holding the closure's return value, replacing what
-	/// would otherwise be a sub-circuit's worth of constraints. In non-wrapper channels where
-	/// `Elem = F`, the impl is just `f(inputs)`.
+	/// is materialized as a single derived public wire (a one-output `hint_varsize`) holding the
+	/// closure's return value, replacing what would otherwise be a sub-circuit's worth of
+	/// constraints. In non-wrapper channels where `Elem = F`, the impl is just `f(inputs)`.
 	///
 	/// The caller MUST ensure each entry in `inputs` is either a `Constant` or a `Wire` whose
 	/// public-tag is true — i.e. produced by `sample_*` / `observe_*` / `compute_public_value`

--- a/crates/spartan-frontend/src/circuit_builder.rs
+++ b/crates/spartan-frontend/src/circuit_builder.rs
@@ -44,6 +44,18 @@ pub trait CircuitBuilder {
 		inputs: [Self::Wire; IN],
 		f: H,
 	) -> [Self::Wire; OUT];
+
+	/// Runtime-arity variant of [`hint`](Self::hint): takes a slice of input wires and an
+	/// `out_len`, with a closure mapping the input values to `out_len` output values. Emits no
+	/// constraints; the outputs are public-derivable (allocated in the derived segment) iff every
+	/// input is, matching [`hint`](Self::hint). The closure is invoked at most once —
+	/// value-generating builders run it, the symbolic builder skips it.
+	fn hint_varsize<H: FnOnce(&[Self::Field]) -> Vec<Self::Field>>(
+		&mut self,
+		inputs: &[Self::Wire],
+		out_len: usize,
+		f: H,
+	) -> Vec<Self::Wire>;
 }
 
 #[derive(Debug)]
@@ -329,6 +341,28 @@ impl<F: Field> CircuitBuilder for ConstraintBuilder<F> {
 			}
 		})
 	}
+
+	fn hint_varsize<H: FnOnce(&[F]) -> Vec<F>>(
+		&mut self,
+		inputs: &[Self::Wire],
+		out_len: usize,
+		_f: H,
+	) -> Vec<Self::Wire> {
+		// A hint over only public-derivable inputs is itself public-derivable. (Hints emit no
+		// constraints regardless; only the allocator choice changes.)
+		let derived = inputs.iter().all(|wire| wire.kind.is_public());
+		(0..out_len)
+			.map(|_| {
+				if derived {
+					self.ir.derived_alloc.alloc()
+				} else {
+					let wire = self.ir.private_alloc.alloc();
+					self.ir.private_wires_status.push(WireStatus::Unknown);
+					wire
+				}
+			})
+			.collect()
+	}
 }
 
 #[derive(Debug)]
@@ -486,6 +520,26 @@ impl<'a, F: Field> CircuitBuilder for WitnessGenerator<'a, F> {
 		let all_derivable = inputs.iter().all(|wire| wire.is_public());
 		f(inputs.map(WitnessWire::val)).map(|value| self.alloc_op_value(all_derivable, value))
 	}
+
+	fn hint_varsize<H: FnOnce(&[F]) -> Vec<F>>(
+		&mut self,
+		inputs: &[Self::Wire],
+		out_len: usize,
+		f: H,
+	) -> Vec<Self::Wire> {
+		let all_derivable = inputs.iter().all(|wire| wire.is_public());
+		let input_vals: Vec<F> = inputs.iter().map(|wire| wire.val()).collect();
+		let outputs = f(&input_vals);
+		debug_assert_eq!(
+			outputs.len(),
+			out_len,
+			"hint_varsize closure returned wrong output count"
+		);
+		outputs
+			.into_iter()
+			.map(|value| self.alloc_op_value(all_derivable, value))
+			.collect()
+	}
 }
 
 /// Wire type for [`InstanceGenerator`]: holds the field value of a public wire (a constant, inout,
@@ -619,6 +673,38 @@ impl<'a, F: Field> CircuitBuilder for InstanceGenerator<'a, F> {
 			})
 		} else {
 			[PublicWire(None); OUT]
+		}
+	}
+
+	fn hint_varsize<H: FnOnce(&[F]) -> Vec<F>>(
+		&mut self,
+		inputs: &[Self::Wire],
+		out_len: usize,
+		f: H,
+	) -> Vec<Self::Wire> {
+		// Only invoke `f` when every input is public (its value is known); otherwise the outputs
+		// are private (value-less to the verifier) and allocate no derived wires, matching the
+		// other builders' private branch.
+		if inputs.iter().all(|wire| wire.0.is_some()) {
+			let input_vals: Vec<F> = inputs
+				.iter()
+				.map(|wire| wire.0.expect("every input checked public above"))
+				.collect();
+			let outputs = f(&input_vals);
+			debug_assert_eq!(
+				outputs.len(),
+				out_len,
+				"hint_varsize closure returned wrong output count"
+			);
+			outputs
+				.into_iter()
+				.map(|value| {
+					let wire = self.derived_alloc.alloc();
+					self.write_public(wire, value)
+				})
+				.collect()
+		} else {
+			vec![PublicWire(None); out_len]
 		}
 	}
 }
@@ -918,5 +1004,52 @@ mod tests {
 		// The intermediate has no public slot; the alive one does.
 		assert!(layout.get(&x2).is_none(), "pruned derived intermediate must have no slot");
 		assert!(layout.get(&x3).is_some(), "referenced derived wire must have a slot");
+	}
+
+	#[test]
+	fn test_hint_varsize_syncs_with_witness() {
+		use crate::compiler::compile;
+
+		// From two public inouts `a`, `b`, a runtime-arity hint yields `[a + b, a * b]`; the first
+		// output (a derived wire) is asserted equal to an inout `expected`. The second output feeds
+		// nothing and is pruned. The instance generator must reproduce the witness public segment.
+		fn circuit<Builder: CircuitBuilder>(
+			builder: &mut Builder,
+			a: Builder::Wire,
+			b: Builder::Wire,
+			expected: Builder::Wire,
+		) {
+			let outs =
+				builder.hint_varsize(&[a, b], 2, |vals| vec![vals[0] + vals[1], vals[0] * vals[1]]);
+			builder.assert_eq(outs[0], expected);
+		}
+
+		let a_val = B128::new(3);
+		let b_val = B128::new(5);
+		let expected_val = a_val + b_val;
+
+		let mut cb = ConstraintBuilder::new();
+		let a = cb.alloc_inout();
+		let b = cb.alloc_inout();
+		let expected = cb.alloc_inout();
+		circuit(&mut cb, a, b, expected);
+		let (cs, layout) = compile(cb);
+
+		let mut wg = WitnessGenerator::new(&layout);
+		let a_w = wg.write_inout(a, a_val);
+		let b_w = wg.write_inout(b, b_val);
+		let expected_w = wg.write_inout(expected, expected_val);
+		circuit(&mut wg, a_w, b_w, expected_w);
+		let witness = wg.build().expect("witness generation should succeed");
+		cs.validate(&witness);
+
+		let mut ig = InstanceGenerator::new(&layout);
+		let a_i = ig.write_inout(a, a_val);
+		let b_i = ig.write_inout(b, b_val);
+		let expected_i = ig.write_inout(expected, expected_val);
+		circuit(&mut ig, a_i, b_i, expected_i);
+		let public = ig.build();
+
+		assert_eq!(public, witness.public());
 	}
 }

--- a/crates/spartan-prover/src/wrapper/replay_channel.rs
+++ b/crates/spartan-prover/src/wrapper/replay_channel.rs
@@ -126,27 +126,19 @@ impl<'a, F: Field> IPVerifierChannel<F> for ReplayChannel<'a, F> {
 		inputs: &[Self::Elem],
 		f: impl FnOnce(&[F]) -> F,
 	) -> Self::Elem {
-		// The closure's result enters as a single inout wire (matching the symbolic builder), whose
-		// value the prover computes natively from the public-derived inputs. See
-		// `IronSpartanBuilderChannel::compute_public_value`.
-		let value = f(&extract_public_values(inputs));
-		let wire = self.inout_alloc.alloc();
-		let witness_wire = self.witness_gen.borrow_mut().write_inout(wire, value);
-		CircuitElem::wire(&self.witness_gen, witness_wire)
+		// The closure's result enters as a single derived public wire (matching the symbolic
+		// builder's `hint_varsize`), whose value the prover computes natively from the
+		// public-derived inputs. See `IronSpartanBuilderChannel::compute_public_value`.
+		let out_wire = {
+			let mut witness_gen = self.witness_gen.borrow_mut();
+			let input_wires: Vec<_> = inputs
+				.iter()
+				.map(|elem| elem.to_wire(&mut witness_gen))
+				.collect();
+			witness_gen.hint_varsize(&input_wires, 1, move |vals| vec![f(vals)])[0]
+		};
+		CircuitElem::wire(&self.witness_gen, out_wire)
 	}
-}
-
-/// Extracts the concrete field value of each input. The prover knows every wire's value (public or
-/// not), so no public-tag check is needed here — the [`IPVerifierChannel::compute_public_value`]
-/// contract is enforced verifier-side, where non-public inputs are value-less.
-fn extract_public_values<F: Field>(inputs: &[CircuitElem<F, WitnessGenerator<'_, F>>]) -> Vec<F> {
-	inputs
-		.iter()
-		.map(|elem| match elem {
-			CircuitElem::Constant(c) => *c,
-			CircuitElem::Wire { wire, .. } => wire.val(),
-		})
-		.collect()
 }
 
 impl<'r, 'a, F: Field> IOPVerifierChannel<'r, F> for ReplayChannel<'a, F> {

--- a/crates/spartan-verifier/src/wrapper/builder_channel.rs
+++ b/crates/spartan-verifier/src/wrapper/builder_channel.rs
@@ -107,14 +107,24 @@ impl<F: Field> IPVerifierChannel<F> for IronSpartanBuilderChannel<F> {
 
 	fn compute_public_value(
 		&mut self,
-		_inputs: &[Self::Elem],
-		_f: impl FnOnce(&[F]) -> F,
+		inputs: &[Self::Elem],
+		f: impl FnOnce(&[F]) -> F,
 	) -> Self::Elem {
 		// The closure is an arbitrary native computation the constraint system cannot replay, so
-		// its result enters as a single inout wire (a public input the verifier supplies), rather
-		// than a sub-circuit's worth of constraints. The value is filled concretely by the
-		// instance/witness channels; symbolically we only allocate the wire.
-		self.alloc_inout_elem()
+		// its result enters as a single derived public wire (a one-output `hint_varsize`,
+		// computed from the public inputs, emitting no constraints) rather than a sub-circuit's
+		// worth of constraints. Symbolically we only allocate the wire; the value is filled
+		// concretely by the instance/witness channels, which recompute it via their own
+		// `hint_varsize`.
+		let out_wire = {
+			let mut builder = self.builder.borrow_mut();
+			let input_wires: Vec<_> = inputs
+				.iter()
+				.map(|elem| elem.to_wire(&mut builder))
+				.collect();
+			builder.hint_varsize(&input_wires, 1, move |vals| vec![f(vals)])[0]
+		};
+		CircuitElem::wire(&self.builder, out_wire)
 	}
 }
 

--- a/crates/spartan-verifier/src/wrapper/circuit_elem.rs
+++ b/crates/spartan-verifier/src/wrapper/circuit_elem.rs
@@ -91,6 +91,17 @@ where
 		}
 	}
 
+	/// Lowers this element to a wire on `builder`, materializing a `Constant` via
+	/// [`CircuitBuilder::constant`]. A `Wire`'s backing builder is assumed to be `builder`; callers
+	/// mixing elements from different channels must check that themselves (as [`Self::combine`]
+	/// does).
+	pub fn to_wire(&self, builder: &mut B) -> B::Wire {
+		match self {
+			Self::Constant(val) => builder.constant(*val),
+			Self::Wire { wire, .. } => *wire,
+		}
+	}
+
 	/// Combine `elems` under an operation. If every input is a `Constant`, fold at the `F` level
 	/// via `f_op` (no builder is touched). Otherwise convert constants to wires on the shared
 	/// builder and run `builder_op` over the wires.

--- a/crates/spartan-verifier/src/wrapper/zk_wrapped_channel.rs
+++ b/crates/spartan-verifier/src/wrapper/zk_wrapped_channel.rs
@@ -13,7 +13,7 @@
 
 use std::{cell::RefCell, rc::Rc};
 
-use binius_field::{BinaryField, Field};
+use binius_field::BinaryField;
 use binius_iop::{
 	basefold_zk_channel::{BaseFoldZKOracle, BaseFoldZKVerifierChannel},
 	channel::{IOPVerifierChannel, OracleLinearRelation, OracleSpec},
@@ -21,7 +21,7 @@ use binius_iop::{
 };
 use binius_ip::channel::IPVerifierChannel;
 use binius_spartan_frontend::{
-	circuit_builder::{InstanceGenerator, WireAllocator},
+	circuit_builder::{CircuitBuilder, InstanceGenerator, WireAllocator},
 	constraint_system::{WireKind, WitnessLayout},
 };
 use binius_transcript::fiat_shamir::Challenger;
@@ -218,11 +218,18 @@ where
 		inputs: &[Self::Elem],
 		f: impl FnOnce(&[F]) -> F,
 	) -> Self::Elem {
-		// The closure's result enters as a single inout wire (matching the symbolic builder), whose
-		// value the verifier computes natively from the public-derived inputs. See
-		// `IronSpartanBuilderChannel::compute_public_value`.
-		let value = f(&extract_public_values(inputs));
-		self.alloc_inout_elem(value)
+		// The closure's result enters as a single derived public wire (matching the symbolic
+		// builder's `hint_varsize`), whose value the verifier computes natively from the
+		// public-derived inputs. See `IronSpartanBuilderChannel::compute_public_value`.
+		let out_wire = {
+			let mut instance_gen = self.instance_gen.borrow_mut();
+			let input_wires: Vec<_> = inputs
+				.iter()
+				.map(|elem| elem.to_wire(&mut instance_gen))
+				.collect();
+			instance_gen.hint_varsize(&input_wires, 1, move |vals| vec![f(vals)])[0]
+		};
+		CircuitElem::wire(&self.instance_gen, out_wire)
 	}
 }
 
@@ -302,18 +309,4 @@ where
 		}
 		self.inner_channel.verify_oracle_relations(inner_relations)
 	}
-}
-
-/// Extracts the concrete field value of each public-derived input. Panics if any input is not
-/// public (value-less), enforcing the [`IPVerifierChannel::compute_public_value`] contract.
-fn extract_public_values<F: Field>(inputs: &[CircuitElem<F, InstanceGenerator<'_, F>>]) -> Vec<F> {
-	inputs
-		.iter()
-		.map(|elem| match elem {
-			CircuitElem::Constant(c) => *c,
-			CircuitElem::Wire { wire, .. } => wire
-				.value()
-				.expect("compute_public_value: input is not public"),
-		})
-		.collect()
 }


### PR DESCRIPTION
Closes [BINIUS-146](https://linear.app/jimpo/issue/BINIUS-146/use-hint-varsize-for-compute-public-value-derived-public-wire).

Salvaged from the cancelled BINIUS-43 / PR #1573 (the ReplayChannel → recorded-gate-sequence rewrite that wasn't a net win) — this is just the standalone-valuable piece.

## What

`compute_public_value` on the ZK wrapper's channels allocated its output as an **InOut** wire — a public input the verifier must supply — even though the value is *computed* from other public inputs. Make it a **derived** public wire instead: computed from the public inputs, emitting no constraint, sorted after the transcript inout wires.

## Commits (2)

1. **add `CircuitBuilder::hint_varsize`** — the runtime-arity sibling of `hint` (a `&[Wire]` input slice + runtime `out_len`, closure `&[F] -> Vec<F>`). Outputs are derived iff every input is public, else private; emits no constraints. Implemented on `ConstraintBuilder`, `WitnessGenerator`, and `InstanceGenerator`.
2. **use it for `compute_public_value`** — each of the three wrapper channels (symbolic `IronSpartanBuilderChannel`, prover `ReplayChannel`, verifier `ZKWrappedVerifierChannel`) now routes `compute_public_value` through its backend's `hint_varsize`, yielding a one-output derived wire instead of a channel-allocated inout. Because all three already allocate derived wires via the backend during the shared circuit traversal (exactly as `add`/`mul`/`hint` do), the wire ids stay aligned — `ReplayChannel` and the rest of the interaction path are untouched.

No `'static` bound is added to `hint` (per review): nothing records the closure for replay, so `compute_public_value`'s closure stays borrow-friendly.

## Validation (native)

- `spartan-frontend` lib (27, incl. a new `hint_varsize` sync test asserting `InstanceGenerator` matches the witness public segment),
- `spartan-verifier` lib (10), `wrapper_integration_test` (1),
- full `prove_verify` (7/7), incl. `test_zk_prove_verify_sha256_preimage` — the real path through `monster_eval` / `compute_public_value` — and the serialized round-trip,
- clippy `-D warnings` + rustdoc `-D warnings` clean on the tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)