### PR TITLE
BINIUS-150: use FxHashMap/FxHashSet for small-integer-keyed maps in the frontend

### DIFF
--- a/crates/frontend/src/compiler/const_prop.rs
+++ b/crates/frontend/src/compiler/const_prop.rs
@@ -5,7 +5,9 @@
 //! with all-constant inputs, evaluating them at compile time, and replacing their
 //! outputs with constant wires.
 
-use std::collections::{HashSet, VecDeque};
+use std::collections::VecDeque;
+
+use rustc_hash::FxHashSet;
 
 use super::{
 	eval_form::evaluate_gate_constants,
@@ -26,7 +28,8 @@ pub fn constant_propagation(graph: &mut GateGraph, hint_registry: &HintRegistry)
 
 	// Initialize worklist with all gates that might be evaluable
 	let mut worklist: VecDeque<Gate> = VecDeque::new();
-	let mut in_worklist: HashSet<Gate> = HashSet::new();
+	// Gate ids are small integers, so a fast integer hasher beats the default SipHash here.
+	let mut in_worklist: FxHashSet<Gate> = FxHashSet::default();
 
 	// Add all gates that use constant wires to the initial worklist.
 	//

--- a/crates/frontend/src/compiler/eval_form/const_eval.rs
+++ b/crates/frontend/src/compiler/eval_form/const_eval.rs
@@ -2,6 +2,7 @@
 //! Constant evaluation support for gates.
 
 use binius_core::{ValueIndex, ValueVec, ValueVecLayout, Word};
+use rustc_hash::FxHashMap;
 
 use super::{BytecodeBuilder, interpreter::Interpreter};
 use crate::compiler::{
@@ -12,8 +13,9 @@ use crate::compiler::{
 
 /// Creates a wire mapping from gate wires to sequential register indices.
 /// Returns the mapping and the total number of registers used.
-fn create_wire_mapping(gate_param: &GateParam) -> (std::collections::HashMap<Wire, u32>, u32) {
-	let mut wire_mapping = std::collections::HashMap::new();
+fn create_wire_mapping(gate_param: &GateParam) -> (FxHashMap<Wire, u32>, u32) {
+	// Wire ids are small integers, so a fast integer hasher beats the default SipHash here.
+	let mut wire_mapping = FxHashMap::default();
 	let mut wire_index = 0u32;
 
 	// Helper to map a slice of wires sequentially

--- a/crates/frontend/src/compiler/gate_graph.rs
+++ b/crates/frontend/src/compiler/gate_graph.rs
@@ -1,8 +1,7 @@
 // Copyright 2025 Irreducible Inc.
-use std::collections::{HashMap, HashSet};
-
 use binius_core::word::Word;
 use cranelift_entity::{PrimaryMap, SecondaryMap, entity_impl};
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::compiler::{
 	gate::opcode::{Opcode, OpcodeShape},
@@ -12,7 +11,10 @@ use crate::compiler::{
 
 #[derive(Default)]
 pub struct ConstPool {
-	pub pool: HashMap<Word, Wire>,
+	/// Interning table mapping each constant value to the wire that holds it.
+	///
+	/// Keyed by a 64-bit word, so a fast integer hasher beats the default SipHash here.
+	pub pool: FxHashMap<Word, Wire>,
 }
 
 impl ConstPool {
@@ -197,8 +199,10 @@ pub struct GateGraph {
 	// Use-def analysis
 	/// Maps each wire to the gate that defines it (if any)
 	pub wire_def: SecondaryMap<Wire, Option<Gate>>,
-	/// Maps each wire to the set of gates that use it
-	wire_uses: SecondaryMap<Wire, HashSet<Gate>>,
+	/// Maps each wire to the set of gates that use it.
+	///
+	/// Gate ids are small integers, so a fast integer hasher beats the default SipHash here.
+	wire_uses: SecondaryMap<Wire, FxHashSet<Gate>>,
 }
 
 impl GateGraph {
@@ -410,7 +414,7 @@ impl GateGraph {
 	}
 
 	/// Returns all gates that use the given wire
-	pub fn get_wire_uses(&self, wire: Wire) -> &HashSet<Gate> {
+	pub fn get_wire_uses(&self, wire: Wire) -> &FxHashSet<Gate> {
 		&self.wire_uses[wire]
 	}
 

--- a/crates/frontend/src/stat.rs
+++ b/crates/frontend/src/stat.rs
@@ -287,10 +287,10 @@ impl fmt::Display for CircuitStat {
 /// Traverses the constraint system and returns the number of distinct value indices that
 /// are shifted and unshifted, respectively.
 fn traverse_constraint_system(cs: &ConstraintSystem) -> (usize, usize) {
-	use std::collections::HashSet;
+	use rustc_hash::FxHashSet;
 	let mut cx = Cx {
-		shifted_terms: HashSet::new(),
-		unshifted_terms: HashSet::new(),
+		shifted_terms: FxHashSet::default(),
+		unshifted_terms: FxHashSet::default(),
 	};
 	for and in &cs.and_constraints {
 		visit_operand(&and.a, &mut cx);
@@ -306,8 +306,8 @@ fn traverse_constraint_system(cs: &ConstraintSystem) -> (usize, usize) {
 	return (cx.shifted_terms.len(), cx.unshifted_terms.len());
 
 	struct Cx {
-		shifted_terms: HashSet<ShiftedValueIndex>,
-		unshifted_terms: HashSet<ShiftedValueIndex>,
+		shifted_terms: FxHashSet<ShiftedValueIndex>,
+		unshifted_terms: FxHashSet<ShiftedValueIndex>,
 	}
 
 	fn visit_operand(operand: &Operand, cx: &mut Cx) {


### PR DESCRIPTION
Closes [BINIUS-150](https://linear.app/jimpo/issue/BINIUS-150).

Swaps std's SipHash for `rustc_hash`'s FxHash on the frontend's small-integer-keyed maps. Internal-only — no behavior change, compiled circuits are byte-identical.

### The problem

Several hot maps in the frontend key on small integers but use std's default hasher.
SipHash is designed to resist hash-flooding on untrusted string keys.
For `Word`/`Wire`/`Gate` keys (32/64-bit integers) it is pure overhead.

The constant pool is the clearest case: it is probed on every `add_constant`, and every bitwise gate re-interns the all-ones constant — so the lookup is on the hot path of circuit construction.

### The idea

Use FxHash on these maps. No new dependency — `rustc-hash` is already used in `gate_fusion`.

### The change

```diff
-use std::collections::{HashMap, HashSet};
+use rustc_hash::{FxHashMap, FxHashSet};

-pub pool: HashMap<Word, Wire>,
+pub pool: FxHashMap<Word, Wire>,

-wire_uses: SecondaryMap<Wire, HashSet<Gate>>,
+wire_uses: SecondaryMap<Wire, FxHashSet<Gate>>,
```

Same shape in `const_prop.rs` (worklist set), `const_eval.rs` (per-gate wire map), and `stat.rs` (distinct-term sets).

### Scope

- **changed:** `gate_graph.rs`, `const_prop.rs`, `eval_form/const_eval.rs`, `stat.rs`
- **left untouched:** the maps in `gate_fusion` already use FxHash; the hint registry map is keyed once per hint type and not hot
- **not included:** the benchmark used for the numbers below is kept local, not pushed (its code is in the collapsed section)

### Soundness

- These maps never feed the constraint system or witness values, so output circuits are byte-identical.
- Determinism holds: the one order-sensitive consumer (constant propagation) already sorts gate ids before use.

### Verification

- `cargo check -p binius-frontend --all-targets`, `clippy --all-targets`, nightly `fmt` — clean
- `cargo test -p binius-frontend` — 148 pass

### Benchmark

Construct-and-compile a synthetic wide circuit; criterion, before = SipHash, after = FxHash (all p < 0.05):

```
                        before     after     change
default   /  5000       14.54 ms   14.07 ms   -3.3%
default   / 20000       77.77 ms   75.26 ms   -3.2%
constprop /  5000       22.48 ms   19.17 ms  -14.7%
constprop / 20000      112.6  ms   94.9  ms  -15.7%
```

The default compile path only touches the constant pool, so it gains ~3%.
The constant-propagation path additionally hammers the per-wire use-def sets, the worklist, and the per-gate wire map, so it gains ~15%.

<details>
<summary>Benchmark code and how to reproduce (kept local, not in this PR)</summary>

Reproduce by dropping this file at `crates/frontend/benches/circuit_build.rs`, adding `criterion = { workspace = true }` to `[dev-dependencies]` and a `[[bench]]` entry (`name = "circuit_build"`, `harness = false`), then:

```sh
# baseline: stash the source changes, capture "before"
git stash push -- crates/frontend/src/compiler/gate_graph.rs \
  crates/frontend/src/compiler/const_prop.rs \
  crates/frontend/src/compiler/eval_form/const_eval.rs \
  crates/frontend/src/stat.rs
cargo bench -p binius-frontend --bench circuit_build -- --save-baseline before

# restore the source changes, capture "after" against the baseline
git stash pop
cargo bench -p binius-frontend --bench circuit_build -- --baseline before
```

```rust
// Copyright 2026 The Binius Developers

//! Build-time benchmark for the circuit frontend.
//!
//! Measures the cost of turning gate-graph construction into a compiled circuit, the path that
//! hammers the internal hash maps (constant pool, use-def chains, constant-propagation worklist).

use std::hint::black_box;

use binius_core::Word;
use binius_frontend::{Circuit, CircuitBuilder, Wire};
use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};

/// Odd 64-bit constant with good avalanche, used to spread distinct constant values apart.
///
/// Multiplying the loop index by this value before interning it keeps the constant pool
/// populated with many distinct keys rather than a handful of repeats.
const SPREAD: u64 = 0x9E37_79B9_7F4A_7C15;

/// Construct a wide circuit that interns many constants and emits many gates.
///
/// # Overview
///
/// Each iteration touches the paths the fast-hasher change cares about:
/// - One fresh interned constant per step keeps inserting into the constant pool.
/// - Every bitwise gate re-interns the all-ones constant, exercising the dedup lookup.
/// - A purely constant sub-expression per step gives constant propagation something to fold.
///
/// # Arguments
///
/// - `n_ops` is the number of operation groups to emit.
///
/// # Returns
///
/// The fully compiled circuit.
fn build_wide_circuit(n_ops: usize) -> Circuit {
	// One private input anchors the equality target the chain must reproduce.
	let b = CircuitBuilder::new();
	let init = b.add_witness();
	// Seed the data-dependent chain from a second witness so the gates below never fold.
	let mut acc = acc_seed(&b);

	// Track the previous interned constant to form a foldable constant-only sub-expression.
	let mut prev_c = b.add_constant_64(1);

	for i in 0..n_ops {
		// Distinct constant per step: forces a constant-pool insert with a new key.
		let c = b.add_constant_64((i as u64).wrapping_mul(SPREAD).wrapping_add(1));

		// Data-dependent gates: inputs trace back to a witness, so these do not fold.
		//
		//     acc ─xor─> x ─and─> y ─rotr─> z ─iadd─> acc'
		let x = b.bxor(acc, c);
		let y = b.band(x, init);
		let z = b.rotr(y, (i % 63 + 1) as u32);
		let (s, _) = b.iadd(z, c);
		acc = s;

		// Constant-only sub-expression: both inputs are interned constants.
		//
		// With constant propagation enabled this collapses to a single constant,
		// driving the use-def rebuild and the constant-evaluation interpreter.
		prev_c = b.bxor(c, prev_c);
	}

	// Mix the folded constant chain back into the data-dependent result so it is not pruned.
	let mixed = b.bxor(acc, prev_c);
	b.assert_eq("final", mixed, init);

	b.build()
}

/// Allocate the witness wire that seeds the data-dependent chain.
fn acc_seed(b: &CircuitBuilder) -> Wire {
	// A second witness, distinct from the equality target, anchors the chain in non-constant data.
	let seed = b.add_witness();
	// XOR with a constant so the very first gate already pulls from the constant pool.
	b.bxor(seed, b.add_constant(Word::ONE))
}

/// Benchmark the default compile path (gate fusion on, constant propagation off).
///
/// This is the configuration production uses, so it is the headline number.
fn bench_build_default(c: &mut Criterion) {
	let mut group = c.benchmark_group("circuit_build_default");
	// Sweep a couple of sizes to show the cost scales linearly with the gate count.
	for &n_ops in &[5_000usize, 20_000] {
		group.bench_with_input(BenchmarkId::from_parameter(n_ops), &n_ops, |b, &n_ops| {
			// Time the full construct-and-compile so constant-pool traffic is included.
			b.iter(|| build_wide_circuit(black_box(n_ops)));
		});
	}
	group.finish();
}

/// Benchmark the compile path with constant propagation enabled.
///
/// Constant propagation rebuilds the use-def chains (one set per wire) and runs the
/// constant-evaluation interpreter, exercising the maps the default path leaves untouched.
fn bench_build_constprop(c: &mut Criterion) {
	// The compiler reads this environment variable when a builder is created.
	//
	// SAFETY: the benchmark harness is single-threaded at this point; no other thread
	// observes the environment while it is being mutated.
	unsafe {
		std::env::set_var("MONBIJOU_CONSTPROP", "1");
	}

	let mut group = c.benchmark_group("circuit_build_constprop");
	for &n_ops in &[5_000usize, 20_000] {
		group.bench_with_input(BenchmarkId::from_parameter(n_ops), &n_ops, |b, &n_ops| {
			// Time the full construct-and-compile so the use-def rebuild is included.
			b.iter(|| build_wide_circuit(black_box(n_ops)));
		});
	}
	group.finish();

	// Restore the environment so it cannot leak into any later benchmark in the same process.
	//
	// SAFETY: same single-threaded justification as the set above.
	unsafe {
		std::env::remove_var("MONBIJOU_CONSTPROP");
	}
}

criterion_group!(benches, bench_build_default, bench_build_constprop);
criterion_main!(benches);
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
