### PR TITLE
Tidy frontend operand construction and constant-pool lookup

### DIFF
--- a/crates/frontend/src/compiler/constraint_builder.rs
+++ b/crates/frontend/src/compiler/constraint_builder.rs
@@ -505,13 +505,10 @@ pub enum ShiftOp {
 impl WireExpr {
 	#[allow(clippy::wrong_self_convention)]
 	fn to_operand(self) -> WireOperand {
-		let mut result = Vec::new();
-		for term in self.0 {
-			let shifted_wire = term.to_shifted_wire();
-
-			result.push(shifted_wire);
-		}
-		result
+		self.0
+			.into_iter()
+			.map(WireExprTerm::to_shifted_wire)
+			.collect()
 	}
 }
 

--- a/crates/frontend/src/compiler/gate_graph.rs
+++ b/crates/frontend/src/compiler/gate_graph.rs
@@ -21,7 +21,7 @@ impl ConstPool {
 	}
 
 	pub fn get(&self, value: Word) -> Option<Wire> {
-		self.pool.get(&value).cloned()
+		self.pool.get(&value).copied()
 	}
 
 	pub fn insert(&mut self, word: Word, wire: Wire) {


### PR DESCRIPTION
Two small, behavior-preserving cleanups in the circuit frontend. No functional change.

### The change

- **Operand construction** (`constraint_builder.rs`): build the operand by collecting the backing iterator instead of a `Vec::new()` + push loop. The source is a `SmallVec<[_; 4]>`, so its length is known up front and the collect preallocates rather than reallocating as the operand grows.
- **Constant-pool lookup** (`gate_graph.rs`): `.copied()` instead of `.cloned()`, since the wire handle is `Copy`.

### Scope

- **changed:** `constraint_builder.rs`, `gate_graph.rs` (2 files, +5 / -8)
- no public API change, no constraint-system or witness change

### Verification

- `cargo clippy -p binius-frontend --all-targets` — clean
- `cargo test -p binius-frontend` — 148 pass
- `cargo +nightly fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)