### PR TITLE
BINIUS-127: define GhashSq256b multiplication in terms of WideMul

### DIFF
--- a/crates/field/benches/ghash_widening.rs
+++ b/crates/field/benches/ghash_widening.rs
@@ -8,7 +8,7 @@
 
 use std::hint::black_box;
 
-use binius_field::{PackedField, WideMul, arch::OptimalPackedB128};
+use binius_field::{GhashSq256b, PackedField, WideMul, arch::OptimalPackedB128};
 use criterion::{
 	BenchmarkGroup, Criterion, Throughput, criterion_group, criterion_main, measurement::WallTime,
 };
@@ -47,6 +47,12 @@ fn bench_ghash_widening(c: &mut Criterion) {
 	let label = format!("OptimalPacked_{}x128b", OptimalPackedB128::WIDTH);
 	for &n in &[16, 256, 4096] {
 		bench_at_n::<OptimalPackedB128>(&mut group, &label, n);
+	}
+
+	// GF(2^256) is a degree-two extension of GHASH, so one multiply is three GHASH products.
+	// Deferring their reduction across an inner product is where the widening multiply pays off.
+	for &n in &[16, 256, 4096] {
+		bench_at_n::<GhashSq256b>(&mut group, "GhashSq256b", n);
 	}
 
 	group.finish();

--- a/crates/field/src/ghash_sq.rs
+++ b/crates/field/src/ghash_sq.rs
@@ -34,7 +34,7 @@ use super::{
 use crate::{
 	BinaryField128bGhash, Divisible, Field, PackedBinaryGhash2x128b, PackedField,
 	arch::{M128, M256, m256_from_u128s},
-	arithmetic_traits::{InvertOrZero, Square, impl_trivial_wide_mul},
+	arithmetic_traits::{InvertOrZero, Square, WideMul},
 	mul_by_binary_field_1b,
 	underlier::U1,
 };
@@ -63,27 +63,116 @@ impl GhashSq256b {
 	}
 }
 
-/// Multiplies two GHASH² elements via Karatsuba over GHASH.
-///
-/// For `x = x₀ + x₁·Y` and `y = y₀ + y₁·Y`, with `Y² = Y + X⁻¹`:
-/// `z₀ = x₀·y₀ + (x₁·y₁)·X⁻¹`, `z₁ = (x₀+x₁)·(y₀+y₁) + x₀·y₀`.
-///
-/// The products `t₀ = x₀·y₀` and `t₂ = x₁·y₁` are computed together as a single packed
-/// [`PackedBinaryGhash2x128b`] multiply. On AVX2 this lowers to one `vpclmulqdq` over both
-/// 128-bit lanes — the `mul_m256i_hybrid` algorithm — while remaining portable on other targets.
-/// The third product `t₁` is a scalar GHASH multiply.
-#[inline]
-fn mul(x: [BinaryField128bGhash; 2], y: [BinaryField128bGhash; 2]) -> [BinaryField128bGhash; 2] {
-	let [x0, x1] = x;
-	let [y0, y1] = y;
+/// The two unreduced GHASH products `[x_0·y_0, x_1·y_1]` batched into one packed widening multiply.
+type DiagWide = <PackedBinaryGhash2x128b as WideMul>::Output;
 
-	let t0_t2 = PackedBinaryGhash2x128b::from_scalars([x0, x1])
-		* PackedBinaryGhash2x128b::from_scalars([y0, y1]);
-	let t0 = t0_t2.get(0);
-	let t2 = t0_t2.get(1);
-	let t1 = (x0 + x1) * (y0 + y1);
+/// The single unreduced GHASH product `(x_0+x_1)·(y_0+y_1)` from a scalar widening multiply.
+type CrossWide = <BinaryField128bGhash as WideMul>::Output;
 
-	[t0 + t2.mul_inv_x(), t1 + t0]
+/// The unreduced product of two GHASH^2 elements.
+///
+/// Holds the three GHASH widening products of the Karatsuba decomposition, before any reduction.
+///
+/// Take `x = x_0 + x_1·Y` and `y = y_0 + y_1·Y` over GHASH, with `Y^2 = Y + X^-1`.
+/// Then `z = x·y` has coordinates:
+/// - `z_0 = x_0·y_0 + (x_1·y_1)·X^-1`
+/// - `z_1 = (x_0+x_1)·(y_0+y_1) + x_0·y_0`
+///
+/// The three scalar products it defers are:
+/// - `x_0·y_0` and `x_1·y_1`, computed together as one packed [`PackedBinaryGhash2x128b`] multiply.
+/// - `(x_0+x_1)·(y_0+y_1)`, the Karatsuba cross term, a scalar GHASH multiply.
+///
+/// Both the GHASH reduction and the `X^-1` scaling are GF(2)-linear.
+/// So a sum of products reduces to the reduction of the XOR of their unreduced forms.
+/// An inner product over GHASH^2 then accumulates by XOR and reduces only once at the end.
+#[derive(Clone, Copy, Default, Debug)]
+pub struct WideGhashSqProduct {
+	/// Unreduced `[x_0·y_0, x_1·y_1]`, the diagonal Karatsuba products in their two packed lanes.
+	diag: DiagWide,
+	/// Unreduced `(x_0+x_1)·(y_0+y_1)`, the Karatsuba cross product.
+	cross: CrossWide,
+}
+
+impl Add for WideGhashSqProduct {
+	type Output = Self;
+
+	#[inline]
+	fn add(self, rhs: Self) -> Self {
+		Self {
+			diag: self.diag + rhs.diag,
+			cross: self.cross + rhs.cross,
+		}
+	}
+}
+
+impl AddAssign for WideGhashSqProduct {
+	#[inline]
+	fn add_assign(&mut self, rhs: Self) {
+		self.diag += rhs.diag;
+		self.cross += rhs.cross;
+	}
+}
+
+impl Sub for WideGhashSqProduct {
+	type Output = Self;
+
+	#[inline]
+	fn sub(self, rhs: Self) -> Self {
+		Self {
+			diag: self.diag - rhs.diag,
+			cross: self.cross - rhs.cross,
+		}
+	}
+}
+
+impl SubAssign for WideGhashSqProduct {
+	#[inline]
+	fn sub_assign(&mut self, rhs: Self) {
+		self.diag -= rhs.diag;
+		self.cross -= rhs.cross;
+	}
+}
+
+impl Sum for WideGhashSqProduct {
+	#[inline]
+	fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+		iter.fold(Self::default(), |acc, x| acc + x)
+	}
+}
+
+impl WideMul for GhashSq256b {
+	type Output = WideGhashSqProduct;
+
+	#[inline]
+	fn wide_mul(a: Self, b: Self) -> Self::Output {
+		let [x0, x1] = a.to_coeffs();
+		let [y0, y1] = b.to_coeffs();
+
+		// Diagonal `[x_0·y_0, x_1·y_1]` as one two-lane packed widening multiply.
+		// On AVX2 this is a single `vpclmulqdq` over both lanes — the `mul_m256i_hybrid` algorithm.
+		let diag = <PackedBinaryGhash2x128b as WideMul>::wide_mul(
+			PackedBinaryGhash2x128b::from_scalars([x0, x1]),
+			PackedBinaryGhash2x128b::from_scalars([y0, y1]),
+		);
+		// Karatsuba cross product `(x_0+x_1)·(y_0+y_1)` as a scalar widening multiply.
+		let cross = <BinaryField128bGhash as WideMul>::wide_mul(x0 + x1, y0 + y1);
+
+		WideGhashSqProduct { diag, cross }
+	}
+
+	#[inline]
+	fn reduce(wide: Self::Output) -> Self {
+		// Reduce the batched diagonal back to its two GHASH lanes: `t_0 = x_0·y_0`, `t_2 =
+		// x_1·y_1`.
+		let diag = <PackedBinaryGhash2x128b as WideMul>::reduce(wide.diag);
+		let t0 = diag.get(0);
+		let t2 = diag.get(1);
+		// Reduce the cross product: `t_1 = (x_0+x_1)·(y_0+y_1)`.
+		let t1 = <BinaryField128bGhash as WideMul>::reduce(wide.cross);
+
+		// Fold `Y^2 = Y + X^-1` into the basis: `z_0 = t_0 + t_2·X^-1`, `z_1 = t_1 + t_0`.
+		Self::from_coeffs([t0 + t2.mul_inv_x(), t1 + t0])
+	}
 }
 
 /// Squares a GHASH² element.
@@ -105,7 +194,7 @@ impl Mul<GhashSq256b> for GhashSq256b {
 	#[inline]
 	fn mul(self, rhs: Self) -> Self {
 		crate::tracing::trace_multiplication!(GhashSq256b);
-		Self::from_coeffs(mul(self.to_coeffs(), rhs.to_coeffs()))
+		Self::reduce(Self::wide_mul(self, rhs))
 	}
 }
 
@@ -132,8 +221,6 @@ impl InvertOrZero for GhashSq256b {
 		Self::from_coeffs([inv_a, inv_b])
 	}
 }
-
-impl_trivial_wide_mul!(GhashSq256b);
 
 // Degree-two extension over GHASH: the low 128 bits are the coefficient of `1`, the high 128 bits
 // the coefficient of `Y`. `square_transpose` uses the packed fast path via
@@ -324,6 +411,24 @@ mod tests {
 		#[test]
 		fn test_square_equals_mul(a in arb_elem()) {
 			prop_assert_eq!(Square::square(a), a * a);
+		}
+
+		#[test]
+		fn test_wide_mul_deferred_reduction(
+			pairs in prop::collection::vec((arb_elem(), arb_elem()), 1..16),
+		) {
+			// Inner product over GHASH^2: the deferred form must equal the eager form.
+			//
+			//     eager:    sum_i reduce(wide_mul(a_i, b_i))  =  sum_i a_i * b_i
+			//     deferred: reduce( sum_i wide_mul(a_i, b_i) )
+			//
+			// This holds because the GHASH reduction and the `X^-1` scaling are both GF(2)-linear.
+			// So a sum of products costs one reduction, not one per term.
+			let eager: GhashSq256b = pairs.iter().map(|&(a, b)| a * b).sum();
+			let deferred = GhashSq256b::reduce(
+				pairs.iter().map(|&(a, b)| GhashSq256b::wide_mul(a, b)).sum(),
+			);
+			prop_assert_eq!(deferred, eager);
 		}
 
 		#[test]


### PR DESCRIPTION
Closes [BINIUS-127](https://linear.app/jimpo/issue/BINIUS-127/define-mul-in-terms-of-widemul-across-all-fields).

Makes the widening multiply the single source of truth for `GhashSq256b` — the last field still doing it the other way round. `Mul` becomes `reduce(wide_mul)`: bit-identical results, plus a real deferred-reduction path for inner products.

### The problem

A binary-field multiply is two steps: a raw product, then a reduction back to size. The reduction is the expensive part.

GHASH and AES fields already define `Mul = reduce(wide_mul)`, so a sum of products can accumulate raw and reduce once (BINIUS-128, BINIUS-137). $\mathbb{F}_{2^{256}}$ was the exception: it used the trivial widening multiply, so it reduced on **every** term of an inner product.

### The idea

$\mathbb{F}_{2^{256}}$ here is a degree-two extension of GHASH, with $Y^2 = Y + X^{-1}$:

```
z0 = x0*y0 + (x1*y1)*X^-1
z1 = (x0+x1)*(y0+y1) + x0*y0
```

That is three GHASH products (a Karatsuba split: the diagonal pair `[x0*y0, x1*y1]` batched into one packed multiply, plus the cross term).

The reduction and the `X^-1` scaling are both $\mathbb{F}_2$-linear, so:

$$\mathrm{reduce}(A) + \mathrm{reduce}(B) = \mathrm{reduce}(A + B)$$

So an inner product can keep the three products **unreduced**, XOR-accumulate them, and reduce once at the end.

### Per inner product term

- **before:** 3 GHASH reductions per term (trivial widening = a full multiply each)
- **after:** XOR-accumulate raw; 3 GHASH reductions total, once

→ reductions drop from $3N$ to $3$ for an $N$-term sum.

### The change

```
- impl_trivial_wide_mul!(GhashSq256b);              // WideMul defined via Mul
- fn mul(..) { Karatsuba, reduces every product }
- impl Mul { from_coeffs(mul(..)) }

+ struct WideGhashSqProduct { diag, cross }          // the three unreduced products
+ impl WideMul for GhashSq256b { wide_mul; reduce }  // single source of truth
+ impl Mul { reduce(wide_mul(self, rhs)) }
```

### Soundness — preserved

- The math is the existing Karatsuba identity, unchanged.
- Deferring is exact because reduction and `X^-1` scaling are $\mathbb{F}_2$-linear.
- A standalone multiply does the same work as before (no regression); the win is only in sums.

### Scope

- **changed:** `crates/field/src/ghash_sq.rs` — the widening multiply, `Mul`, and a proptest for the deferred-reduction identity.
- **bench:** added `GhashSq256b` to `crates/field/benches/ghash_widening.rs`.
- **untouched:** `square` keeps its own optimized path; `B1` stays the trivial leaf (its multiply is a single AND — nothing to defer).
- This is the final field, so every non-trivial field now defines `Mul = reduce(wide_mul)`.

### Verification

- nightly `fmt --all`, `clippy -p binius-field --all-targets`, `check --workspace --all-targets` — clean
- `cargo test -p binius-field ghash_sq` — 15 pass, including a proptest that `reduce(sum_i wide_mul) == sum_i a_i*b_i`

### Benchmark

Inner product `sum_i a_i*b_i` over $\mathbb{F}_{2^{256}}$, deferred path (`ghash_widening`):

| n (terms) | before (trivial) | after (real WideMul) | speedup |
|---|---|---|---|
| 16 | 86.6 ns | 63.7 ns | 1.36× |
| 256 | 1.371 µs | 0.987 µs | 1.39× |
| 4096 | 23.42 µs | 16.34 µs | 1.43× |

A standalone multiply is unchanged — the gain is purely in batched sums, exactly where the deferred reduction applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
