### PR TITLE
Optimize AND-reduction univariate round message hot loop (1.31× faster)

### DIFF
--- a/crates/math/Cargo.toml
+++ b/crates/math/Cargo.toml
@@ -49,3 +49,7 @@ harness = false
 [[bench]]
 name = "multilinear_evaluate"
 harness = false
+
+[[bench]]
+name = "eq_ind_partial_eval"
+harness = false

--- a/crates/math/benches/eq_ind_partial_eval.rs
+++ b/crates/math/benches/eq_ind_partial_eval.rs
@@ -1,0 +1,32 @@
+// Copyright 2025 Irreducible Inc.
+
+use binius_field::arch::{OptimalB128, OptimalPackedB128};
+use binius_math::{multilinear::eq::eq_ind_partial_eval, test_utils::random_scalars};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use rand::{SeedableRng, rngs::StdRng};
+
+fn bench_eq_ind_partial_eval(c: &mut Criterion) {
+	type F = OptimalB128;
+	type P = OptimalPackedB128;
+
+	let mut group = c.benchmark_group("eq_ind_partial_eval");
+
+	let mut rng = StdRng::seed_from_u64(0);
+
+	for n_vars in [16, 20, 24] {
+		// Throughput is measured in the number of output elements, which is the size of the
+		// returned tensor over the n-dimensional hypercube.
+		let n_output_elems = 1u64 << n_vars;
+		group.throughput(Throughput::Elements(n_output_elems));
+
+		let point = random_scalars::<F>(&mut rng, n_vars);
+		group.bench_function(BenchmarkId::from_parameter(format!("n_vars={n_vars}")), |b| {
+			b.iter(|| eq_ind_partial_eval::<P>(&point));
+		});
+	}
+
+	group.finish();
+}
+
+criterion_group!(benches, bench_eq_ind_partial_eval);
+criterion_main!(benches);

--- a/crates/prover/benches/and_reduction.rs
+++ b/crates/prover/benches/and_reduction.rs
@@ -11,7 +11,6 @@ use binius_field::{
 };
 use binius_math::{
 	BinarySubspace,
-	multilinear::eq::eq_ind_partial_eval,
 	univariate::{extrapolate_over_subspace, lagrange_evals_scalars},
 };
 use binius_prover::{
@@ -62,14 +61,12 @@ fn bench(c: &mut Criterion) {
 	group.throughput(Throughput::Elements(1 << log_words));
 	group.bench_function(format!("univariate_round_message 2^{log_words}"), |bench| {
 		bench.iter(|| {
-			let eq_ind_mle = eq_ind_partial_eval(&big_field_zerocheck_challenges);
-
 			let urm: [B128; _] = univariate_round_message_extension_domain(
 				log_words,
 				&a_words,
 				&b_words,
 				&c_words,
-				&eq_ind_mle,
+				&big_field_zerocheck_challenges,
 				&ntt_lookup,
 			);
 
@@ -77,13 +74,12 @@ fn bench(c: &mut Criterion) {
 		});
 	});
 
-	let eq_ind_mle = eq_ind_partial_eval(&big_field_zerocheck_challenges);
 	let urm: [B128; _] = univariate_round_message_extension_domain(
 		log_words,
 		&a_words,
 		&b_words,
 		&c_words,
-		&eq_ind_mle,
+		&big_field_zerocheck_challenges,
 		&ntt_lookup,
 	);
 	let univariate_challenge = B128::random(&mut rng);

--- a/crates/prover/benches/and_reduction.rs
+++ b/crates/prover/benches/and_reduction.rs
@@ -3,18 +3,19 @@ use std::{iter, iter::repeat_with};
 
 use binius_core::word::Word;
 use binius_field::{
-	AESTowerField8b, Field, PackedAESBinaryField64x8b, Random,
+	Field, PackedAESBinaryField64x8b, Random,
 	linear_transformation::{
 		BytewiseLookupTransformationFactory, LinearTransformationFactory,
 		OutputWrappingTransformationFactory,
 	},
 };
 use binius_math::{
-	BinarySubspace, FieldBuffer,
+	BinarySubspace,
 	multilinear::eq::eq_ind_partial_eval,
 	univariate::{extrapolate_over_subspace, lagrange_evals_scalars},
 };
 use binius_prover::{
+	OptimalPackedB128,
 	and_reduction::{
 		NTTLookup, sumcheck_round_messages::univariate_round_message_extension_domain,
 	},
@@ -22,31 +23,26 @@ use binius_prover::{
 	protocols::sumcheck::{common::SumcheckProver, quadratic_mle::QuadraticMleCheckProver},
 };
 use binius_verifier::{
-	config::B128,
+	config::{B128, PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES},
 	protocols::bitand::{ROWS_PER_HYPERCUBE_VERTEX, SKIPPED_VARS},
 };
-use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
 use rand::prelude::*;
 
 fn bench(c: &mut Criterion) {
-	let log_num_rows = 27;
-	let mut rng = StdRng::seed_from_u64(0);
+	let mut rng = rand::rng();
+
+	let log_words = 21;
 	let big_field_zerocheck_challenges =
-		vec![B128::random(&mut rng); log_num_rows - SKIPPED_VARS - 3];
-	let small_field_zerocheck_challenges = [
-		AESTowerField8b::new(2),
-		AESTowerField8b::new(4),
-		AESTowerField8b::new(16),
-	];
-	let first_mlv: Vec<Word> = repeat_with(|| Word(rng.random()))
-		.take(1 << (log_num_rows - SKIPPED_VARS))
-		.collect();
+		vec![B128::random(&mut rng); log_words - PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES.len()];
 
-	let second_mlv: Vec<Word> = repeat_with(|| Word(rng.random()))
-		.take(1 << (log_num_rows - SKIPPED_VARS))
+	let a_words: Vec<Word> = repeat_with(|| Word(rng.random()))
+		.take(1 << log_words)
 		.collect();
-
-	let third_mlv: Vec<Word> = iter::zip(&first_mlv, &second_mlv)
+	let b_words: Vec<Word> = repeat_with(|| Word(rng.random()))
+		.take(1 << log_words)
+		.collect();
+	let c_words: Vec<Word> = iter::zip(&a_words, &b_words)
 		.map(|(&a, &b)| a & b)
 		.collect();
 
@@ -63,111 +59,92 @@ fn bench(c: &mut Criterion) {
 		bench.iter(|| NTTLookup::<PackedAESBinaryField64x8b>::new(&prover_message_domain));
 	});
 
-	group.throughput(Throughput::Elements(1 << (log_num_rows - SKIPPED_VARS)));
-	group.bench_function(format!("univariate_round_message 2^{log_num_rows}"), |bench| {
+	group.throughput(Throughput::Elements(1 << log_words));
+	group.bench_function(format!("univariate_round_message 2^{log_words}"), |bench| {
 		bench.iter(|| {
 			let eq_ind_mle = eq_ind_partial_eval(&big_field_zerocheck_challenges);
 
 			let urm: [B128; _] = univariate_round_message_extension_domain(
-				&first_mlv,
-				&second_mlv,
-				&third_mlv,
+				log_words,
+				&a_words,
+				&b_words,
+				&c_words,
 				&eq_ind_mle,
 				&ntt_lookup,
-				&small_field_zerocheck_challenges,
 			);
 
 			urm
 		});
 	});
 
-	group.bench_function(format!("full_univariate_round 2^{log_num_rows}"), |bench| {
+	let eq_ind_mle = eq_ind_partial_eval(&big_field_zerocheck_challenges);
+	let urm: [B128; _] = univariate_round_message_extension_domain(
+		log_words,
+		&a_words,
+		&b_words,
+		&c_words,
+		&eq_ind_mle,
+		&ntt_lookup,
+	);
+	let univariate_challenge = B128::random(&mut rng);
+
+	group.bench_function(format!("univariate fold 2^{log_words}"), |bench| {
 		bench.iter(|| {
-			let eq_ind_mle = eq_ind_partial_eval(&big_field_zerocheck_challenges);
-
-			let urm: [B128; _] = univariate_round_message_extension_domain(
-				&first_mlv,
-				&second_mlv,
-				&third_mlv,
-				&eq_ind_mle,
-				&ntt_lookup,
-				&small_field_zerocheck_challenges,
-			);
-
-			let lagrange_evals = lagrange_evals_scalars(&univariate_domain, B128::random(&mut rng));
+			let lagrange_evals = lagrange_evals_scalars(&univariate_domain, univariate_challenge);
 			let transform =
 				OutputWrappingTransformationFactory::new(BytewiseLookupTransformationFactory)
 					.create(&lagrange_evals);
 
-			let folded: [FieldBuffer<B128>; 3] = [&first_mlv, &second_mlv, &third_mlv]
-				.map(|mlv| fold_words_with_transform(&transform, mlv));
-
-			(urm, folded)
+			[&a_words, &b_words, &c_words]
+				.map(|mlv| fold_words_with_transform::<_, OptimalPackedB128, _>(&transform, mlv))
 		});
 	});
 
-	group.bench_function(format!("full zerocheck 2^{log_num_rows}"), |bench| {
-		bench.iter(|| {
-			let eq_ind_only_big = eq_ind_partial_eval(&big_field_zerocheck_challenges);
+	let lagrange_evals = lagrange_evals_scalars(&univariate_domain, univariate_challenge);
+	let transform = OutputWrappingTransformationFactory::new(BytewiseLookupTransformationFactory)
+		.create(&lagrange_evals);
+	let proving_polys = [&a_words, &b_words, &c_words]
+		.map(|mlv| fold_words_with_transform::<_, OptimalPackedB128, _>(&transform, mlv));
 
-			let urm = univariate_round_message_extension_domain(
-				&first_mlv,
-				&second_mlv,
-				&third_mlv,
-				&eq_ind_only_big,
-				&ntt_lookup,
-				&small_field_zerocheck_challenges,
-			);
+	let mut univariate_message_coeffs = vec![B128::ZERO; 2 * ROWS_PER_HYPERCUBE_VERTEX];
+	univariate_message_coeffs[ROWS_PER_HYPERCUBE_VERTEX..2 * ROWS_PER_HYPERCUBE_VERTEX]
+		.copy_from_slice(&urm);
 
-			let first_sumcheck_challenge = B128::random(&mut rng);
+	let next_round_claim = extrapolate_over_subspace(
+		&prover_message_domain.clone().isomorphic::<B128>(),
+		&univariate_message_coeffs,
+		univariate_challenge,
+	);
 
-			let lagrange_evals =
-				lagrange_evals_scalars(&univariate_domain, first_sumcheck_challenge);
-			let transform =
-				OutputWrappingTransformationFactory::new(BytewiseLookupTransformationFactory)
-					.create(&lagrange_evals);
+	group.bench_function(format!("remaining zerocheck 2^{log_words}"), |bench| {
+		bench.iter_batched(
+			|| proving_polys.clone(),
+			|proving_polys| {
+				let multilinear_zerocheck_challenges: Vec<_> =
+					PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES
+						.into_iter()
+						.map(B128::from)
+						.chain(big_field_zerocheck_challenges.iter().copied())
+						.collect();
 
-			let mut univariate_message_coeffs = vec![B128::ZERO; 2 * ROWS_PER_HYPERCUBE_VERTEX];
+				let mut prover = QuadraticMleCheckProver::new(
+					proving_polys,
+					|[a, b, c]| a * b - c,
+					|[a, b, _]| a * b,
+					multilinear_zerocheck_challenges,
+					next_round_claim,
+				)
+				.expect("multilinears should have consistent dimensions");
 
-			univariate_message_coeffs[ROWS_PER_HYPERCUBE_VERTEX..2 * ROWS_PER_HYPERCUBE_VERTEX]
-				.copy_from_slice(&urm);
+				for _ in 0..log_words {
+					let _ = prover.execute().unwrap();
+					prover.fold(B128::random(&mut rng)).unwrap();
+				}
 
-			let next_round_claim = extrapolate_over_subspace(
-				&prover_message_domain.clone().isomorphic::<B128>(),
-				&univariate_message_coeffs,
-				first_sumcheck_challenge,
-			);
-
-			let upcasted_small_field_challenges: Vec<_> = small_field_zerocheck_challenges
-				.into_iter()
-				.map(B128::from)
-				.collect();
-
-			let multilinear_zerocheck_challenges: Vec<_> = upcasted_small_field_challenges
-				.iter()
-				.chain(big_field_zerocheck_challenges.iter())
-				.copied()
-				.collect();
-
-			let proving_polys: [FieldBuffer<B128>; 3] = [&first_mlv, &second_mlv, &third_mlv]
-				.map(|mlv| fold_words_with_transform(&transform, mlv));
-
-			let mut prover = QuadraticMleCheckProver::new(
-				proving_polys,
-				|[a, b, c]| a * b - c,
-				|[a, b, _]| a * b,
-				multilinear_zerocheck_challenges.clone(),
-				next_round_claim,
-			)
-			.expect("multilinears should have consistent dimensions");
-
-			for _ in multilinear_zerocheck_challenges {
-				let _ = prover.execute().unwrap();
-				prover.fold(B128::random(&mut rng)).unwrap();
-			}
-
-			prover.finish().unwrap()
-		});
+				prover.finish().unwrap()
+			},
+			BatchSize::SmallInput,
+		);
 	});
 }
 

--- a/crates/prover/src/and_reduction/prover.rs
+++ b/crates/prover/src/and_reduction/prover.rs
@@ -15,7 +15,10 @@ use binius_math::{
 	multilinear::eq::eq_ind_partial_eval,
 	univariate::{extrapolate_over_subspace, lagrange_evals_scalars},
 };
-use binius_verifier::protocols::bitand::{AndCheckOutput, ROWS_PER_HYPERCUBE_VERTEX};
+use binius_verifier::{
+	config::PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES,
+	protocols::bitand::{AndCheckOutput, ROWS_PER_HYPERCUBE_VERTEX},
+};
 
 use super::sumcheck_round_messages;
 use crate::{
@@ -38,11 +41,11 @@ pub struct OblongZerocheckProver<FChallenge, PNTTDomain, PChallenge>
 where
 	FChallenge: BinaryField,
 {
+	log_words: usize,
 	first_col: Vec<Word>,
 	second_col: Vec<Word>,
 	third_col: Vec<Word>,
 	big_field_zerocheck_challenges: Vec<FChallenge>,
-	small_field_zerocheck_challenges: Vec<AESTowerField8b>,
 	univariate_round_message: [FChallenge; ROWS_PER_HYPERCUBE_VERTEX],
 	univariate_round_message_domain: BinarySubspace<FChallenge>,
 	_marker: PhantomData<(PNTTDomain, PChallenge)>,
@@ -62,15 +65,12 @@ where
 	///
 	/// # Arguments
 	///
+	/// * `log_words` - Base-2 logarithm of the number of words in each column
 	/// * `first_col` - The oblong multilinear polynomial A in the AND constraint A & B ^ C = 0
 	/// * `second_col` - The oblong multilinear polynomial B in the AND constraint
 	/// * `third_col` - The oblong multilinear polynomial C in the AND constraint
 	/// * `big_field_zerocheck_challenges` - Challenges Z_{k+1},...,Zₙ in the large field FChallenge
-	/// * `ntt_lookup` - Precomputed NTT lookup table for efficient polynomial evaluation
-	/// * `small_field_zerocheck_challenges` - Challenges Z₁,...,Zₖ in the small field (at most 3
-	///   challenges since we use an 8-bit subfield and require F₂-linear independence of all subset
-	///   products)
-	/// * `univariate_round_message_domain` - The domain for evaluating the univariate polynomial
+	/// * `prover_message_domain` - The domain for evaluating the univariate polynomial
 	///
 	/// # Implementation Details
 	///
@@ -80,11 +80,11 @@ where
 	/// 3. Caches these evaluations for later use in the execute() method
 	#[allow(clippy::too_many_arguments)]
 	pub fn new(
+		log_words: usize,
 		first_col: Vec<Word>,
 		second_col: Vec<Word>,
 		third_col: Vec<Word>,
 		big_field_zerocheck_challenges: Vec<F>,
-		small_field_zerocheck_challenges: Vec<AESTowerField8b>,
 		prover_message_domain: BinarySubspace<AESTowerField8b>,
 	) -> Self {
 		let ntt_lookup = tracing::debug_span!("Compute univariate LDE table")
@@ -94,20 +94,20 @@ where
 		let univariate_round_message = tracing::debug_span!("Compute univariate round message")
 			.in_scope(|| {
 				sumcheck_round_messages::univariate_round_message_extension_domain(
+					log_words,
 					&first_col,
 					&second_col,
 					&third_col,
 					&eq_ind_big_field_challenges,
 					&ntt_lookup,
-					&small_field_zerocheck_challenges,
 				)
 			});
 
 		Self {
+			log_words,
 			first_col,
 			second_col,
 			third_col,
-			small_field_zerocheck_challenges,
 			univariate_round_message,
 			big_field_zerocheck_challenges,
 			univariate_round_message_domain: prover_message_domain.isomorphic(),
@@ -176,17 +176,15 @@ where
 		let proving_polys = [&self.first_col, &self.second_col, &self.third_col]
 			.map(|col| fold_words_with_transform::<_, PChallenge, _>(&transform, col));
 
-		let upcasted_small_field_challenges: Vec<_> = self
-			.small_field_zerocheck_challenges
-			.into_iter()
-			.map(F::from)
-			.collect();
-
-		let verifier_field_zerocheck_challenges: Vec<_> = upcasted_small_field_challenges
+		let upcasted_small_field_challenges = PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES
 			.iter()
-			.chain(self.big_field_zerocheck_challenges.iter())
 			.copied()
-			.collect();
+			.take(self.log_words)
+			.map(F::from);
+
+		let verifier_field_zerocheck_challenges = upcasted_small_field_challenges
+			.chain(self.big_field_zerocheck_challenges)
+			.collect::<Vec<_>>();
 
 		let mut first_round_message_coeffs = vec![F::ZERO; 2 * ROWS_PER_HYPERCUBE_VERTEX];
 
@@ -292,7 +290,7 @@ mod test {
 	};
 	use binius_transcript::{ProverTranscript, fiat_shamir::CanSample};
 	use binius_verifier::{
-		config::{B128, StdChallenger},
+		config::{B128, PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES, StdChallenger},
 		protocols::bitand::{AndCheckOutput, SKIPPED_VARS, verify_with_channel},
 	};
 	use rand::prelude::*;
@@ -309,7 +307,7 @@ mod test {
 	#[test]
 	fn test_transcript_prover_verifies() {
 		let mut prover_challenger = ProverTranscript::new(StdChallenger::default());
-		let log_num_rows = 10;
+		let log_num_rows = 6;
 		let mut rng = StdRng::seed_from_u64(0);
 
 		let small_field_zerocheck_challenges = [
@@ -317,8 +315,8 @@ mod test {
 			AESTowerField8b::new(4),
 			AESTowerField8b::new(16),
 		];
-		let first_mlv = random_words(log_num_rows - SKIPPED_VARS, &mut rng);
-		let second_mlv = random_words(log_num_rows - SKIPPED_VARS, &mut rng);
+		let first_mlv = random_words(log_num_rows, &mut rng);
+		let second_mlv = random_words(log_num_rows, &mut rng);
 		let third_mlv: Vec<Word> = iter::zip(&first_mlv, &second_mlv)
 			.map(|(&a, &b)| a & b)
 			.collect();
@@ -328,14 +326,14 @@ mod test {
 		let verifier_message_domain = prover_message_domain.isomorphic();
 
 		// Prover is instantiated
-		let big_field_zerocheck_challenges =
-			prover_challenger.sample_vec(log_num_rows - SKIPPED_VARS - 3);
+		let big_field_zerocheck_challenges = prover_challenger
+			.sample_vec(log_num_rows - PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES.len());
 		let prover = OblongZerocheckProver::<_, PackedAESBinaryField64x8b, OptimalPackedB128>::new(
+			log_num_rows,
 			first_mlv.clone(),
 			second_mlv.clone(),
 			third_mlv.clone(),
 			big_field_zerocheck_challenges.to_vec(),
-			small_field_zerocheck_challenges.to_vec(),
 			prover_message_domain.clone(),
 		);
 
@@ -344,8 +342,7 @@ mod test {
 		// Verifier is instantiated
 		let mut verifier_challenger = prover_challenger.into_verifier();
 
-		let big_field_zerocheck_challenges =
-			verifier_challenger.sample_vec(log_num_rows - SKIPPED_VARS - 3);
+		let big_field_zerocheck_challenges = verifier_challenger.sample_vec(log_num_rows - 3);
 
 		let mut all_zerocheck_challenges = vec![];
 

--- a/crates/prover/src/and_reduction/prover.rs
+++ b/crates/prover/src/and_reduction/prover.rs
@@ -12,7 +12,6 @@ use binius_field::{
 use binius_ip_prover::channel::IPProverChannel;
 use binius_math::{
 	BinarySubspace,
-	multilinear::eq::eq_ind_partial_eval,
 	univariate::{extrapolate_over_subspace, lagrange_evals_scalars},
 };
 use binius_verifier::{
@@ -89,7 +88,6 @@ where
 	) -> Self {
 		let ntt_lookup = tracing::debug_span!("Compute univariate LDE table")
 			.in_scope(|| NTTLookup::<PNTTDomain>::new(&prover_message_domain));
-		let eq_ind_big_field_challenges = eq_ind_partial_eval(&big_field_zerocheck_challenges);
 
 		let univariate_round_message = tracing::debug_span!("Compute univariate round message")
 			.in_scope(|| {
@@ -98,7 +96,7 @@ where
 					&first_col,
 					&second_col,
 					&third_col,
-					&eq_ind_big_field_challenges,
+					&big_field_zerocheck_challenges,
 					&ntt_lookup,
 				)
 			});

--- a/crates/prover/src/and_reduction/sumcheck_round_messages.rs
+++ b/crates/prover/src/and_reduction/sumcheck_round_messages.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-use std::{array, borrow::Cow, iter, mem};
+use std::{array, borrow::Cow, iter};
 
 use binius_core::word::Word;
 use binius_field::{
@@ -80,7 +80,7 @@ where
 	assert_eq!(PNTTDomain::WIDTH, ROWS_PER_HYPERCUBE_VERTEX);
 
 	const N_FIXED_SMALL_CHALLENGES: usize = PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES.len();
-	const N_FIXED_LARGE_CHALLENGES: usize = 3;
+	const N_FIXED_LARGE_CHALLENGES: usize = 4;
 
 	const LOG_CHUNK_SIZE: usize = N_FIXED_SMALL_CHALLENGES + N_FIXED_LARGE_CHALLENGES;
 
@@ -137,33 +137,33 @@ where
 		.map(|(a_chunk, b_chunk, c_chunk)| {
 			// Reshape the chunk arrays into arrays of arrays
 			let [a_subchunks, b_subchunks, c_subchunks] =
-				[a_chunk, b_chunk, c_chunk].map(|chunk| unsafe {
-					mem::transmute::<
-						&[Word; 1 << LOG_CHUNK_SIZE],
-						&[[Word; 1 << N_FIXED_SMALL_CHALLENGES]; 1 << N_FIXED_SMALL_CHALLENGES],
+				[a_chunk, b_chunk, c_chunk].map(|chunk| {
+					bytemuck::must_cast_ref::<
+						[Word; 1 << LOG_CHUNK_SIZE],
+						[[Word; 1 << N_FIXED_SMALL_CHALLENGES]; 1 << N_FIXED_LARGE_CHALLENGES],
 					>(chunk)
 				});
 
-			izip!(a_subchunks, b_subchunks, c_subchunks, &outer_weight_mul_maps).fold(
-				[F::ZERO; ROWS_PER_HYPERCUBE_VERTEX],
-				|mut acc, (a_subchunk, b_subchunk, c_subchunk, outer_weight)| {
-					let summed_ntt = izip!(a_subchunk, b_subchunk, c_subchunk, &eq_ind_small)
-						.map(|(a_i, b_i, c_i, inner_weight)| {
-							// Compute the low-degree extension of each column via the lookup
-							// table.
-							let [first_col_ntt, second_col_ntt, third_col_ntt] =
-								ntt_lookup.multi_ntt_array([a_i.0, b_i.0, c_i.0]);
+			let mut acc = [F::ZERO; ROWS_PER_HYPERCUBE_VERTEX];
+			for (a_subchunk, b_subchunk, c_subchunk, outer_weight) in
+				izip!(a_subchunks, b_subchunks, c_subchunks, &outer_weight_mul_maps)
+			{
+				let mut summed_ntt = PNTTDomain::zero();
+				for (a_i, b_i, c_i, inner_weight) in
+					izip!(a_subchunk, b_subchunk, c_subchunk, &eq_ind_small)
+				{
+					// Compute the low-degree extension of each column via the lookup table.
+					let [first_col_ntt, second_col_ntt, third_col_ntt] =
+						ntt_lookup.multi_ntt_array([a_i.0, b_i.0, c_i.0]);
 
-							// Compute the weighted composition of the LDE values.
-							(first_col_ntt * second_col_ntt - third_col_ntt) * inner_weight
-						})
-						.sum::<PNTTDomain>();
-					for (acc_i, summed_ntt_i) in iter::zip(&mut acc, summed_ntt.into_iter()) {
-						*acc_i += outer_weight.call(summed_ntt_i);
-					}
-					acc
-				},
-			)
+					// Compute the weighted composition of the LDE values.
+					summed_ntt += (first_col_ntt * second_col_ntt - third_col_ntt) * inner_weight;
+				}
+				for (acc_i, summed_ntt_i) in iter::zip(&mut acc, summed_ntt.into_iter()) {
+					*acc_i += outer_weight.call(summed_ntt_i);
+				}
+			}
+			acc
 		})
 		.zip(eq_ind_extra.as_ref())
 		.map(|(mut acc, eq_weight)| {

--- a/crates/prover/src/and_reduction/sumcheck_round_messages.rs
+++ b/crates/prover/src/and_reduction/sumcheck_round_messages.rs
@@ -1,10 +1,13 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-use std::{borrow::Cow, iter, mem};
+use std::{array, borrow::Cow, iter, mem};
 
 use binius_core::word::Word;
-use binius_field::{AESTowerField8b, BinaryField, PackedField};
+use binius_field::{
+	AESTowerField8b as B8, BinaryField, BinaryField1b as B1, ExtensionField, PackedField,
+	util::expand_subset_sums_array,
+};
 use binius_math::multilinear::eq::eq_ind_partial_eval;
 use binius_utils::rayon::prelude::*;
 use binius_verifier::{
@@ -67,8 +70,8 @@ pub fn univariate_round_message_extension_domain<F, PNTTDomain>(
 	ntt_lookup: &NTTLookup<PNTTDomain>,
 ) -> [F; ROWS_PER_HYPERCUBE_VERTEX]
 where
-	F: BinaryField + From<AESTowerField8b>,
-	PNTTDomain: PackedField<Scalar = AESTowerField8b>,
+	F: BinaryField + From<B8>,
+	PNTTDomain: PackedField<Scalar = B8>,
 {
 	// This assertion is used as a workaround for Rust's limited support for const-generics,
 	// ideally we would just use PNTTDomain::WIDTH everywhere instead, but since this function only
@@ -87,7 +90,7 @@ where
 	}
 
 	let eq_ind_small: [_; 1 << N_FIXED_SMALL_CHALLENGES] =
-		eq_ind_partial_eval::<AESTowerField8b>(&PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES)
+		eq_ind_partial_eval::<B8>(&PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES)
 			.iter_scalars()
 			.map(PNTTDomain::broadcast)
 			.collect::<Vec<_>>()
@@ -96,6 +99,8 @@ where
 
 	// We don't actually use fixed large challenges yet, so just take a prefix of the big field
 	// challenges passed in.
+	//
+	// TODO: Use some fixed challenges instead throughout the protocol.
 	let (fixed_large_challenges, extra_challenges) = if big_field_challenges.len()
 		< N_FIXED_LARGE_CHALLENGES
 	{
@@ -117,6 +122,8 @@ where
 			.try_into()
 			.expect("fixed_large_challenges.len() == N_FIXED_LARGE_CHALLENGES");
 
+	let outer_weight_mul_maps = eq_ind_fixed_large.map(B8ToExtMulMap::new);
+
 	let eq_ind_extra = eq_ind_partial_eval::<F>(extra_challenges);
 
 	// Process columns in fixed-length chunks of 8 to assist compiler in loop unrolling.
@@ -137,23 +144,22 @@ where
 					>(chunk)
 				});
 
-			izip!(a_subchunks, b_subchunks, c_subchunks, &eq_ind_fixed_large).fold(
+			izip!(a_subchunks, b_subchunks, c_subchunks, &outer_weight_mul_maps).fold(
 				[F::ZERO; ROWS_PER_HYPERCUBE_VERTEX],
 				|mut acc, (a_subchunk, b_subchunk, c_subchunk, outer_weight)| {
-					let summed_ntt =
-						izip!(a_subchunk, b_subchunk, c_subchunk, &eq_ind_small)
-							.map(|(a_i, b_i, c_i, inner_weight)| {
-								// Compute the low-degree extension of each column via the lookup
-								// table.
-								let [first_col_ntt, second_col_ntt, third_col_ntt] =
-									ntt_lookup.multi_ntt_array([a_i.0, b_i.0, c_i.0]);
+					let summed_ntt = izip!(a_subchunk, b_subchunk, c_subchunk, &eq_ind_small)
+						.map(|(a_i, b_i, c_i, inner_weight)| {
+							// Compute the low-degree extension of each column via the lookup
+							// table.
+							let [first_col_ntt, second_col_ntt, third_col_ntt] =
+								ntt_lookup.multi_ntt_array([a_i.0, b_i.0, c_i.0]);
 
-								// Compute the weighted composition of the LDE values.
-								(first_col_ntt * second_col_ntt - third_col_ntt) * inner_weight
-							})
-							.sum::<PNTTDomain>();
+							// Compute the weighted composition of the LDE values.
+							(first_col_ntt * second_col_ntt - third_col_ntt) * inner_weight
+						})
+						.sum::<PNTTDomain>();
 					for (acc_i, summed_ntt_i) in iter::zip(&mut acc, summed_ntt.into_iter()) {
-						*acc_i += F::from(summed_ntt_i) * outer_weight;
+						*acc_i += outer_weight.call(summed_ntt_i);
 					}
 					acc
 				},
@@ -208,13 +214,38 @@ fn duplicate_to_fixed_chunks<const N: usize>(words: &[Word]) -> Cow<'_, [[Word; 
 	}
 }
 
+/// Represents a precomputed multiplication map by an extension field constant for
+/// [`B8`].`
+///
+/// Multiplication by a constant for a binary field is an $\mathbb{F}_2$-linear transform. For small
+/// inputs, such as $\mathbb{F}_{2^8}$ elements, this can be represented by a small lookup table.
+struct B8ToExtMulMap<F> {
+	lookup: [F; 256],
+}
+
+impl<F: BinaryField + From<B8>> B8ToExtMulMap<F> {
+	fn new(val: F) -> Self {
+		let basis_images: [F; 8] = array::from_fn(|i| {
+			let basis = <B8 as ExtensionField<B1>>::basis(i);
+			F::from(basis) * val
+		});
+		Self {
+			lookup: expand_subset_sums_array(basis_images),
+		}
+	}
+
+	#[inline]
+	fn call(&self, input: B8) -> F {
+		self.lookup[input.val() as usize]
+	}
+}
+
 #[cfg(test)]
 mod test {
-	use std::{iter, iter::repeat_with};
+	use std::iter::repeat_with;
 
-	use binius_core::word::Word;
 	use binius_field::{
-		AESTowerField8b, Field, PackedAESBinaryField64x8b, Random,
+		BinaryField128bGhash as B128, Field, PackedAESBinaryField64x8b, Random,
 		linear_transformation::{
 			BytewiseLookupTransformationFactory, LinearTransformationFactory,
 			OutputWrappingTransformationFactory,
@@ -222,18 +253,13 @@ mod test {
 	};
 	use binius_math::{
 		BinarySubspace, FieldBuffer,
-		multilinear::eq::eq_ind_partial_eval,
 		univariate::{extrapolate_over_subspace, lagrange_evals_scalars},
 	};
-	use binius_verifier::{
-		config::B128,
-		protocols::bitand::{ROWS_PER_HYPERCUBE_VERTEX, SKIPPED_VARS},
-	};
-	use itertools::izip;
+	use binius_verifier::protocols::bitand::SKIPPED_VARS;
 	use rand::prelude::*;
 
-	use super::univariate_round_message_extension_domain;
-	use crate::{and_reduction::ntt_lookup::NTTLookup, fold_word::fold_words_with_transform};
+	use super::*;
+	use crate::fold_word::fold_words_with_transform;
 
 	fn random_words(log_num_words: usize, mut rng: impl Rng) -> Vec<Word> {
 		repeat_with(|| Word(rng.random()))
@@ -259,11 +285,7 @@ mod test {
 		let log_num_rows = 10;
 		let mut rng = StdRng::from_seed([0; 32]);
 
-		let small_field_zerocheck_challenges = [
-			AESTowerField8b::new(2),
-			AESTowerField8b::new(4),
-			AESTowerField8b::new(16),
-		];
+		let small_field_zerocheck_challenges = PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES;
 
 		let big_field_zerocheck_challenges =
 			vec![

--- a/crates/prover/src/and_reduction/sumcheck_round_messages.rs
+++ b/crates/prover/src/and_reduction/sumcheck_round_messages.rs
@@ -1,11 +1,15 @@
 // Copyright 2025 Irreducible Inc.
-use std::iter;
+// Copyright 2026 The Binius Developers
+
+use std::{borrow::Cow, iter};
 
 use binius_core::word::Word;
 use binius_field::{AESTowerField8b, BinaryField, PackedField};
 use binius_math::{FieldBuffer, multilinear::eq::eq_ind_partial_eval};
 use binius_utils::rayon::prelude::*;
-use binius_verifier::protocols::bitand::ROWS_PER_HYPERCUBE_VERTEX;
+use binius_verifier::{
+	config::PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES, protocols::bitand::ROWS_PER_HYPERCUBE_VERTEX,
+};
 use itertools::izip;
 
 use super::ntt_lookup::NTTLookup;
@@ -36,16 +40,12 @@ use super::ntt_lookup::NTTLookup;
 ///
 /// # Arguments
 ///
-/// * `first_col` - First multiplicand (a) as a one-bit oblong multilinear polynomial
-/// * `second_col` - Second multiplicand (b) as a one-bit oblong multilinear polynomial
-/// * `third_col` - Product constraint (c) as a one-bit oblong multilinear polynomial
+/// * `log_words` - Base-2 logarithm of the number of words in each column
+/// * `a_words` - First multiplicand (a) as a one-bit oblong multilinear polynomial
+/// * `b_words` - Second multiplicand (b) as a one-bit oblong multilinear polynomial
+/// * `c_words` - Product constraint (c) as a one-bit oblong multilinear polynomial
 /// * `eq_ind_big_field_challenges` - Partial equality indicator evaluations for big field variables
-/// * `prover_message_domain_with_ntt_lookup` - Domain and NTT lookup tables for efficient
-///   computation
-/// * `small_field_zerocheck_challenges` - Zerocheck challenges for the small field variables (3
-///   vars). These are a parameter to the proof, agreed on ahead of time by prover and verifier.
-///   Their tensor product expansion must be an F2-basis of PNTTDomain::Scalar
-/// * `univariate_zerocheck_challenge` - Zerocheck challenge for the univariate variable
+/// * `ntt_lookup` - NTT lookup tables for efficient low-degree extension of each column
 ///
 /// # Returns
 ///
@@ -55,15 +55,16 @@ use super::ntt_lookup::NTTLookup;
 ///
 /// # Type Parameters
 ///
-/// * `FChallenge` - The challenge field type (must be a binary field)
-/// * `PNTTDomain` - The packed extension field type for NTT operations (width must be 16)
+/// * `F` - The challenge field type (must be a binary field)
+/// * `PNTTDomain` - The packed extension field type for NTT operations (width must equal
+///   `ROWS_PER_HYPERCUBE_VERTEX`)
 pub fn univariate_round_message_extension_domain<F, PNTTDomain>(
-	first_col: &[Word],
-	second_col: &[Word],
-	third_col: &[Word],
+	log_words: usize,
+	a_words: &[Word],
+	b_words: &[Word],
+	c_words: &[Word],
 	eq_ind_big_field_challenges: &FieldBuffer<F>,
 	ntt_lookup: &NTTLookup<PNTTDomain>,
-	small_field_zerocheck_challenges: &[AESTowerField8b],
 ) -> [F; ROWS_PER_HYPERCUBE_VERTEX]
 where
 	F: BinaryField + From<AESTowerField8b>,
@@ -75,29 +76,36 @@ where
 	// multiple underlier sizes
 	assert_eq!(PNTTDomain::WIDTH, ROWS_PER_HYPERCUBE_VERTEX);
 
-	let expected_log_words =
-		eq_ind_big_field_challenges.log_len() + small_field_zerocheck_challenges.len();
-	for col in [first_col, second_col, third_col] {
-		assert_eq!(col.len(), 1 << expected_log_words);
+	assert_eq!(
+		eq_ind_big_field_challenges.log_len(),
+		log_words.saturating_sub(PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES.len())
+	);
+	for col in [a_words, b_words, c_words] {
+		assert_eq!(col.len(), 1 << log_words);
 	}
 
-	let eq_ind_small = eq_ind_partial_eval::<AESTowerField8b>(small_field_zerocheck_challenges)
-		.iter_scalars()
-		.map(PNTTDomain::broadcast)
-		.collect::<Vec<_>>();
+	let eq_ind_small: [_; 8] =
+		eq_ind_partial_eval::<AESTowerField8b>(&PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES)
+			.iter_scalars()
+			.map(PNTTDomain::broadcast)
+			.collect::<Vec<_>>()
+			.try_into()
+			.expect("PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES.len() == 3; 2^3 == 8");
 
-	// Accumulate resulting polynomial evals by iterating over each hypercube vertex
-	let chunk_size = eq_ind_small.len();
-	(
-		first_col.par_chunks(chunk_size),
-		second_col.par_chunks(chunk_size),
-		third_col.par_chunks(chunk_size),
-	)
+	// Process columns in fixed-length chunks of 8 to assist compiler in loop unrolling.
+	let a_col_chunks = duplicate_to_fixed_chunks::<8>(a_words);
+	let b_col_chunks = duplicate_to_fixed_chunks::<8>(b_words);
+	let c_col_chunks = duplicate_to_fixed_chunks::<8>(c_words);
+
+	// Accumulate resulting polynomial evals by iterating over each hypercube vertex.
+	(a_col_chunks.as_ref(), b_col_chunks.as_ref(), c_col_chunks.as_ref())
 		.into_par_iter()
 		.map(|(a_chunk, b_chunk, c_chunk)| {
 			let mut summed_ntt = PNTTDomain::zero();
 
-			for (a_i, b_i, c_i, &weight) in izip!(a_chunk, b_chunk, c_chunk, &eq_ind_small) {
+			for (a_i, b_i, c_i, &weight) in
+				izip!(a_chunk, b_chunk, c_chunk, eq_ind_small.each_ref())
+			{
 				// Compute the low-degree extension of each column via the lookup table.
 				let [first_col_ntt, second_col_ntt, third_col_ntt] =
 					ntt_lookup.multi_ntt_array([a_i.0, b_i.0, c_i.0]);
@@ -124,6 +132,37 @@ where
 				lhs
 			},
 		)
+}
+
+/// View the words as a slice of fixed-length arrays.
+///
+/// If the number of words is less than N, then repeat it into an N-length array. Repeating
+/// corresponds to variable padding over the boolean hypercube.
+///
+/// ## Preconditions
+///
+/// * `words` must be a power of two
+/// * `N` must be a power of two
+fn duplicate_to_fixed_chunks<const N: usize>(words: &[Word]) -> Cow<'_, [[Word; N]]> {
+	assert!(words.len().is_power_of_two());
+	assert!(N.is_power_of_two());
+
+	let (chunks, leftover) = words.as_chunks::<N>();
+
+	assert!(
+		chunks.is_empty() || leftover.is_empty(),
+		"words.len() and N are both powers of two; either words.len() is divisible by N or less than it"
+	);
+
+	if chunks.is_empty() {
+		let mut repeated = [Word::ZERO; N];
+		for chunk in repeated.chunks_mut(words.len()) {
+			chunk.copy_from_slice(words);
+		}
+		Cow::Owned(vec![repeated])
+	} else {
+		Cow::Borrowed(chunks)
+	}
 }
 
 #[cfg(test)]
@@ -205,12 +244,12 @@ mod test {
 
 		// Prover generates first round message
 		let first_round_message_on_ext_domain = univariate_round_message_extension_domain::<B128, _>(
+			log_num_words,
 			&mlv_1,
 			&mlv_2,
 			&mlv_3,
 			&eq_ind_only_big,
 			&ntt_lookup,
-			&small_field_zerocheck_challenges,
 		);
 
 		let mut first_round_message_coeffs = vec![B128::ZERO; 2 * ROWS_PER_HYPERCUBE_VERTEX];

--- a/crates/prover/src/and_reduction/sumcheck_round_messages.rs
+++ b/crates/prover/src/and_reduction/sumcheck_round_messages.rs
@@ -1,11 +1,11 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-use std::{borrow::Cow, iter};
+use std::{borrow::Cow, iter, mem};
 
 use binius_core::word::Word;
 use binius_field::{AESTowerField8b, BinaryField, PackedField};
-use binius_math::{FieldBuffer, multilinear::eq::eq_ind_partial_eval};
+use binius_math::multilinear::eq::eq_ind_partial_eval;
 use binius_utils::rayon::prelude::*;
 use binius_verifier::{
 	config::PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES, protocols::bitand::ROWS_PER_HYPERCUBE_VERTEX,
@@ -63,7 +63,7 @@ pub fn univariate_round_message_extension_domain<F, PNTTDomain>(
 	a_words: &[Word],
 	b_words: &[Word],
 	c_words: &[Word],
-	eq_ind_big_field_challenges: &FieldBuffer<F>,
+	big_field_challenges: &[F],
 	ntt_lookup: &NTTLookup<PNTTDomain>,
 ) -> [F; ROWS_PER_HYPERCUBE_VERTEX]
 where
@@ -76,50 +76,93 @@ where
 	// multiple underlier sizes
 	assert_eq!(PNTTDomain::WIDTH, ROWS_PER_HYPERCUBE_VERTEX);
 
-	assert_eq!(
-		eq_ind_big_field_challenges.log_len(),
-		log_words.saturating_sub(PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES.len())
-	);
+	const N_FIXED_SMALL_CHALLENGES: usize = PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES.len();
+	const N_FIXED_LARGE_CHALLENGES: usize = 3;
+
+	const LOG_CHUNK_SIZE: usize = N_FIXED_SMALL_CHALLENGES + N_FIXED_LARGE_CHALLENGES;
+
+	assert_eq!(big_field_challenges.len(), log_words.saturating_sub(N_FIXED_SMALL_CHALLENGES));
 	for col in [a_words, b_words, c_words] {
 		assert_eq!(col.len(), 1 << log_words);
 	}
 
-	let eq_ind_small: [_; 8] =
+	let eq_ind_small: [_; 1 << N_FIXED_SMALL_CHALLENGES] =
 		eq_ind_partial_eval::<AESTowerField8b>(&PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES)
 			.iter_scalars()
 			.map(PNTTDomain::broadcast)
 			.collect::<Vec<_>>()
 			.try_into()
-			.expect("PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES.len() == 3; 2^3 == 8");
+			.expect("PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES.len() == N_FIXED_SMALL_CHALLENGES");
+
+	// We don't actually use fixed large challenges yet, so just take a prefix of the big field
+	// challenges passed in.
+	let (fixed_large_challenges, extra_challenges) = if big_field_challenges.len()
+		< N_FIXED_LARGE_CHALLENGES
+	{
+		let mut fixed_large_challenges = [F::ZERO; N_FIXED_LARGE_CHALLENGES];
+		fixed_large_challenges[..big_field_challenges.len()].copy_from_slice(big_field_challenges);
+		(fixed_large_challenges, &[][..])
+	} else {
+		let (fixed_large_challenges, extra_challenges) =
+			big_field_challenges.split_at(N_FIXED_LARGE_CHALLENGES);
+		let fixed_large_challenges: [_; N_FIXED_LARGE_CHALLENGES] = fixed_large_challenges
+			.try_into()
+			.expect("big_field_challenges.len() >= N_FIXED_LARGE_CHALLENGES");
+		(fixed_large_challenges, extra_challenges)
+	};
+
+	let eq_ind_fixed_large: [_; 1 << N_FIXED_LARGE_CHALLENGES] =
+		eq_ind_partial_eval::<F>(&fixed_large_challenges)
+			.as_ref()
+			.try_into()
+			.expect("fixed_large_challenges.len() == N_FIXED_LARGE_CHALLENGES");
+
+	let eq_ind_extra = eq_ind_partial_eval::<F>(extra_challenges);
 
 	// Process columns in fixed-length chunks of 8 to assist compiler in loop unrolling.
-	let a_col_chunks = duplicate_to_fixed_chunks::<8>(a_words);
-	let b_col_chunks = duplicate_to_fixed_chunks::<8>(b_words);
-	let c_col_chunks = duplicate_to_fixed_chunks::<8>(c_words);
+	let a_col_chunks = duplicate_to_fixed_chunks::<{ 1 << LOG_CHUNK_SIZE }>(a_words);
+	let b_col_chunks = duplicate_to_fixed_chunks::<{ 1 << LOG_CHUNK_SIZE }>(b_words);
+	let c_col_chunks = duplicate_to_fixed_chunks::<{ 1 << LOG_CHUNK_SIZE }>(c_words);
 
 	// Accumulate resulting polynomial evals by iterating over each hypercube vertex.
 	(a_col_chunks.as_ref(), b_col_chunks.as_ref(), c_col_chunks.as_ref())
 		.into_par_iter()
 		.map(|(a_chunk, b_chunk, c_chunk)| {
-			let mut summed_ntt = PNTTDomain::zero();
+			// Reshape the chunk arrays into arrays of arrays
+			let [a_subchunks, b_subchunks, c_subchunks] =
+				[a_chunk, b_chunk, c_chunk].map(|chunk| unsafe {
+					mem::transmute::<
+						&[Word; 1 << LOG_CHUNK_SIZE],
+						&[[Word; 1 << N_FIXED_SMALL_CHALLENGES]; 1 << N_FIXED_SMALL_CHALLENGES],
+					>(chunk)
+				});
 
-			for (a_i, b_i, c_i, &weight) in
-				izip!(a_chunk, b_chunk, c_chunk, eq_ind_small.each_ref())
-			{
-				// Compute the low-degree extension of each column via the lookup table.
-				let [first_col_ntt, second_col_ntt, third_col_ntt] =
-					ntt_lookup.multi_ntt_array([a_i.0, b_i.0, c_i.0]);
+			izip!(a_subchunks, b_subchunks, c_subchunks, &eq_ind_fixed_large).fold(
+				[F::ZERO; ROWS_PER_HYPERCUBE_VERTEX],
+				|mut acc, (a_subchunk, b_subchunk, c_subchunk, outer_weight)| {
+					let summed_ntt =
+						izip!(a_subchunk, b_subchunk, c_subchunk, &eq_ind_small)
+							.map(|(a_i, b_i, c_i, inner_weight)| {
+								// Compute the low-degree extension of each column via the lookup
+								// table.
+								let [first_col_ntt, second_col_ntt, third_col_ntt] =
+									ntt_lookup.multi_ntt_array([a_i.0, b_i.0, c_i.0]);
 
-				// Compute the weighted composition of the LDE values.
-				summed_ntt += (first_col_ntt * second_col_ntt - third_col_ntt) * weight;
-			}
-
-			summed_ntt
+								// Compute the weighted composition of the LDE values.
+								(first_col_ntt * second_col_ntt - third_col_ntt) * inner_weight
+							})
+							.sum::<PNTTDomain>();
+					for (acc_i, summed_ntt_i) in iter::zip(&mut acc, summed_ntt.into_iter()) {
+						*acc_i += F::from(summed_ntt_i) * outer_weight;
+					}
+					acc
+				},
+			)
 		})
-		.zip(eq_ind_big_field_challenges.as_ref())
-		.fold_with([F::ZERO; ROWS_PER_HYPERCUBE_VERTEX], |mut acc, (summed_ntt, &eq_weight)| {
-			for (acc_i, summed_ntt_i) in iter::zip(&mut acc, summed_ntt.into_iter()) {
-				*acc_i += eq_weight * F::from(summed_ntt_i);
+		.zip(eq_ind_extra.as_ref())
+		.map(|(mut acc, eq_weight)| {
+			for acc_i in &mut acc {
+				*acc_i *= eq_weight;
 			}
 			acc
 		})
@@ -233,8 +276,6 @@ mod test {
 		let mlv_2 = random_words(log_num_words, &mut rng);
 		let mlv_3: Vec<Word> = iter::zip(&mlv_1, &mlv_2).map(|(&a, &b)| a & b).collect();
 
-		let eq_ind_only_big = eq_ind_partial_eval(&big_field_zerocheck_challenges);
-
 		// Agreed-upon proof parameter
 
 		let prover_message_domain = BinarySubspace::with_dim(SKIPPED_VARS + 1);
@@ -248,7 +289,7 @@ mod test {
 			&mlv_1,
 			&mlv_2,
 			&mlv_3,
-			&eq_ind_only_big,
+			&big_field_zerocheck_challenges,
 			&ntt_lookup,
 		);
 

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -437,18 +437,16 @@ where
 
 	let log_constraint_count = checked_log_2(a.len());
 
-	let mut small_field_zerocheck_challenges = PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES.to_vec();
-	small_field_zerocheck_challenges.truncate(log_constraint_count);
-
-	let big_field_zerocheck_challenges =
-		channel.sample_many(log_constraint_count - small_field_zerocheck_challenges.len());
+	let n_extra_zerocheck_challenges =
+		log_constraint_count.saturating_sub(PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES.len());
+	let big_field_zerocheck_challenges = channel.sample_many(n_extra_zerocheck_challenges);
 
 	let prover = OblongZerocheckProver::<_, PackedAESBinaryField64x8b, PChallenge>::new(
+		log_constraint_count,
 		a,
 		b,
 		c,
 		big_field_zerocheck_challenges,
-		small_field_zerocheck_challenges,
 		prover_message_domain.isomorphic(),
 	);
 


### PR DESCRIPTION
## Summary

Optimizes the hot loop of `univariate_round_message_extension_domain` (the first-round message of the AND-constraint reduction / oblong univariate zerocheck). The algorithm is unchanged; this is a codegen-focused rewrite of how the hypercube accumulation loop is structured so the compiler keeps the inner NTT inlined and the accumulator in registers.

## Performance

Measured with the `univariate_round_message` benchmark (`crates/prover/benches/and_reduction.rs`), 2^21 words per column, throughput in output elements, `target-cpu=native`, back-to-back on the same machine:

| | time | throughput | |
|---|---|---|---|
| `main` (b25d1dbf) | 69.8 ms | 30.0 Melem/s | |
| this branch | 53.2 ms | 39.4 Melem/s | **1.31× faster** (−24% time, +31% throughput) |

## What changed

The work is split into reviewable commits:

1. **Remove inner-loop bounds checks via fixed-size word chunks** — replace `par_chunks(runtime_len)` with fixed-size `[[Word; N]]` chunks so the inner `izip!` loop has a compile-time-constant trip count (no per-chunk min-length bookkeeping). Also derives the small-field zerocheck challenges from the compile-time constant and threads `log_words` instead, dropping the `small_field_zerocheck_challenges` parameter.
2. **Process bigger chunks in the hot loop** — widen the chunk to a 2D subchunk layout (16 outer × 8 inner) so each outer weight is applied once per subchunk.
3. **Use preprocessed multiplication maps for outer weights** — replace the per-element B128 multiply in the extension step with a precomputed `B8 → ext` multiplication-map lookup.
4. **Convert folds to for loops and drop each_ref for better inlining** — rewrite `.map(...).sum()` / `izip!(...).fold([F; ROWS], …)` as explicit `for` loops mutating `summed_ntt` / `acc` in place. This inlines the inner NTT (no out-of-line `Map::fold` call) and stops copying the 1 KB accumulator by value, dropping per-chunk stack traffic from ~200 to ~2 `vmovaps`. Dropping `.each_ref()` removes per-iteration `[&T; N]` reference-array materialization.

Also included: a small `eq_ind_partial_eval` benchmark in `binius-math`, and rustdoc fixes for the changed signatures.

## Testing

- `cargo test -p binius-prover and_reduction` passes, including the full prover/verifier round-trip `test_transcript_prover_verifies`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
