### PR TITLE
BINIUS-151: trim circuit-test CI cost (x86_64-only + collapse snapshot matrix)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,12 +49,18 @@ jobs:
           - name: x86_64-portable
             runner: ubuntu-24.04
             rustflags: # portable
+            # binius-circuits tests are architecture-independent (it depends only on
+            # binius-frontend + binius-core, which contain no arch-specific code), so they run
+            # only on the x86_64 leg below. See BINIUS-151.
+            test_args: "--exclude binius-circuits"
           - name: x86_64
             runner: ubuntu-24.04
             rustflags: "-Ctarget-cpu=native"
+            test_args: ""
           - name: arm64
             runner: ubuntu-24.04-arm
             rustflags: "-Ctarget-cpu=native"
+            test_args: "--exclude binius-circuits"
     name: rust-checks-${{ matrix.arch.name }}
     runs-on: ${{ matrix.arch.runner }}
     env:
@@ -93,7 +99,7 @@ jobs:
       - name: Run clippy
         run: cargo clippy --workspace --all-targets -- -D warnings
       - name: Run tests
-        run: cargo nextest run --workspace --no-fail-fast
+        run: cargo nextest run --workspace --no-fail-fast ${{ matrix.arch.test_args }}
       # Must run doctests separately, see https://github.com/nextest-rs/nextest/issues/16
       - name: Run doctests
         run: cargo test --doc --workspace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,19 +151,25 @@ jobs:
           RUSTDOCFLAGS: "-D warnings"
 
   circuits-snapshot:
-    name: circuits-snapshot (${{ matrix.example }})
+    name: circuits-snapshot
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        example: [ethsign, zklogin, sha256, sha512, keccak, blake2s, blake3_compress, hashsign, ec_msm]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
-      - name: Check ${{ matrix.example }} circuit statistics snapshot
-        run: cargo run --example ${{ matrix.example }} -- check-snapshot
+      # One job instead of a 9-way matrix: the examples share the same `binius-examples` crate, so
+      # a matrix recompiled that whole tree (which links the prover + verifier) nine times for a
+      # stats-only check. Building once and running each snapshot in turn keeps the work but cuts
+      # ~8 redundant compiles. See BINIUS-151.
+      - name: Check circuit statistics snapshots
+        run: |
+          set -e
+          for example in ethsign zklogin sha256 sha512 keccak blake2s blake3_compress hashsign ec_msm; do
+            echo "::group::${example}"
+            cargo run --example "${example}" -- check-snapshot
+            echo "::endgroup::"
+          done
 
   # This job ensures all CI checks pass
   ci-all-checks:


### PR DESCRIPTION
Closes [BINIUS-151](https://linear.app/jimpo/issue/BINIUS-151/reduce-the-ci-cost-of-circuit-tests) (PR 1 of 2 — the low-risk CI-only changes; path-filtering is the follow-up). Plan + measurements are on the issue.

## Commits (2)

1. **Run `binius-circuits` tests on x86_64 only.** They build a circuit + fill a witness + `verify_constraints` (no SNARK proving), and `binius-circuits` depends only on `binius-frontend` + `binius-core`, which contain **no** arch-conditional code — so the tests are architecture-independent. The `rust-checks` matrix now passes `--exclude binius-circuits` to `cargo nextest run` on the arm64 and x86_64-portable legs and runs the full suite on x86_64. (Build + clippy still run on all three arches; only the redundant *test execution* is dropped on two of them.)
2. **Collapse the 9-way `circuits-snapshot` matrix into one job.** The examples all live in the same `binius-examples` crate (which links the prover + verifier), so the matrix recompiled that whole tree nine times for a stats-only `check-snapshot`. One job builds it once and runs each snapshot in turn — same coverage, ~8 fewer redundant compiles. The job id is unchanged, so the `ci-all-checks` gate still covers it.

## Validation

This is CI config — it's validated by this PR's own run (watch that `rust-checks-arm64` / `-x86_64-portable` skip the circuit tests, `rust-checks-x86_64` still runs them, and `circuits-snapshot` runs all 9 checks in one job). Locally: `python -c "yaml.safe_load(...)"` parses, `prek run typos` passes.

Deliberately **not** here: `--release` (measured net-negative — see the issue) and path-filtering (PR 2, where the `ci-all-checks` gate question gets resolved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)