### PR TITLE
BINIUS-151: fix the circuit-test recompile (run-layer -E filter, not --exclude)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,13 +46,15 @@ jobs:
       fail-fast: false
       matrix:
         arch:
+          # binius-circuits tests are architecture-independent (the crate depends only on
+          # binius-frontend + binius-core, which contain no arch-specific code), so they run only on
+          # the x86_64 leg. The other legs skip them with nextest's run-layer filter (`-E`) rather
+          # than `cargo --exclude`: keeping the build set at `--workspace` matches the Compile step's
+          # feature unification, so the dependency tree is not recompiled. See BINIUS-151.
           - name: x86_64-portable
             runner: ubuntu-24.04
             rustflags: # portable
-            # binius-circuits tests are architecture-independent (it depends only on
-            # binius-frontend + binius-core, which contain no arch-specific code), so they run
-            # only on the x86_64 leg below. See BINIUS-151.
-            test_args: "--exclude binius-circuits"
+            test_args: "-E 'not package(binius-circuits)'"
           - name: x86_64
             runner: ubuntu-24.04
             rustflags: "-Ctarget-cpu=native"
@@ -60,7 +62,7 @@ jobs:
           - name: arm64
             runner: ubuntu-24.04-arm
             rustflags: "-Ctarget-cpu=native"
-            test_args: "--exclude binius-circuits"
+            test_args: "-E 'not package(binius-circuits)'"
     name: rust-checks-${{ matrix.arch.name }}
     runs-on: ${{ matrix.arch.runner }}
     env:


### PR DESCRIPTION
Closes [BINIUS-151](https://linear.app/jimpo/issue/BINIUS-151/reduce-the-ci-cost-of-circuit-tests). Pure `ci.yml`, one commit.

Fixes a regression from #1598: skipping `binius-circuits` tests on the arm64/portable legs with `cargo nextest run --workspace --exclude binius-circuits` changed the workspace **package set**, so Cargo's v2 feature resolver unified features differently than the `Compile` step (`cargo build --workspace --all-targets`) and recompiled shared deps (`sha2`/`sha3`/`rand`/…) for several minutes — more than it saved.

Now the test step keeps `--workspace` (same build set → no recompile) and just skips *running* the circuit tests on the non-x86 legs via nextest's filterset `-E 'not package(binius-circuits)'`.

**Simplified per review:** dropped the path-filtering (the `changes` job + `ci-all-checks` skip-handling). Validated by `yaml.safe_load` + `prek run typos`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)