### PR TITLE
ci: drop most debuginfo to cut compile + link time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  # CI never debugs interactively, so drop most debuginfo to cut compile + link time. Keep line
+  # tables so panic / test-failure backtraces still report file:line.
+  CARGO_PROFILE_DEV_DEBUG: line-tables-only
+  CARGO_PROFILE_TEST_DEBUG: line-tables-only
 
 concurrency:
   group: ${{ github.event_name }}-${{ github.ref }}


### PR DESCRIPTION
First of three independent CI compile-time PRs (work order: this → skip-bench-compilation → lld linker).

`[profile.dev]` sets `opt-level = 1` but leaves `debug` at the default (full), so every CI compile generates and links full debuginfo it never uses. This sets `CARGO_PROFILE_DEV_DEBUG` / `CARGO_PROFILE_TEST_DEBUG` to `line-tables-only` at the workflow `env` level (applies to all jobs — `rust-checks` ×3, `wasm-tests`, `circuits-snapshot`, `rust-doc`), trimming the bulk of debuginfo generation + link cost while keeping `file:line` in panic / test-failure backtraces.

CI-only (env vars, not `Cargo.toml`), so local dev builds and debugging are unchanged. Verified cargo accepts the override locally. If we want to go further at the cost of backtrace line numbers, `0` (none) saves a little more — easy follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)