### PR TITLE
ci: don't compile benchmarks in rust-checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,8 +99,12 @@ jobs:
           tool: cargo-nextest
       - name: Install lld
         run: sudo apt-get update -qq && sudo apt-get install -y lld
+      # Don't *build* benchmarks: each criterion bench is a separate binary linking the whole crate,
+      # and CI never runs them (`cargo bench`), so codegen + linking them is pure overhead. Clippy
+      # below still checks them via `--all-targets` — that's front-end only (no codegen/link), so it
+      # guards against bench bitrot (API drift) for a fraction of a full build.
       - name: Compile
-        run: cargo build --workspace --all-targets
+        run: cargo build --workspace --lib --bins --tests --examples
       - name: Run platform diagnostics
         run: cargo test -p binius-utils --features platform-diagnostics test_platform_diagnostics -- --nocapture
       - name: Run clippy


### PR DESCRIPTION
Second of three independent CI compile-time PRs (work order: disable-debuginfo → this → lld linker).

`rust-checks` builds with `--all-targets`, which includes benchmarks. CI never *runs* benches, and each criterion bench is a separate binary that links the whole crate under test — so codegen + linking them is pure overhead, paid on all three arch legs.

This drops benches from the **Compile** step only (`--lib --bins --tests --examples`), while keeping **clippy** at `--all-targets`. Clippy is front-end only (no codegen/link), so it still type-checks the benches — guarding against bench bitrot (API drift) for a small fraction of a full build. The only gap is codegen-/link-only failures in benches (rare, and benches aren't shipped).

Validated `yaml.safe_load` + `prek typos`; confirmed `cargo build -p binius-field --lib --bins --tests --examples` is valid locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)