### PR TITLE
ci: link rust-checks with lld

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,10 @@ jobs:
     name: rust-checks-${{ matrix.arch.name }}
     runs-on: ${{ matrix.arch.runner }}
     env:
-      RUSTFLAGS: ${{ matrix.arch.rustflags }}
+      # Link with lld instead of the default ld.bfd: the rust-checks build links many test and
+      # example binaries, where bfd is a serial bottleneck. Appended to the per-arch flags
+      # (target-cpu). lld is installed below.
+      RUSTFLAGS: "${{ matrix.arch.rustflags }} -Clink-arg=-fuse-ld=lld"
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6
@@ -94,6 +97,8 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-nextest
+      - name: Install lld
+        run: sudo apt-get update -qq && sudo apt-get install -y lld
       - name: Compile
         run: cargo build --workspace --all-targets
       - name: Run platform diagnostics


### PR DESCRIPTION
Third of three independent CI compile-time PRs (work order: disable-debuginfo → skip-bench-compilation → this).

The `rust-checks` build links many test/example binaries, and the default `ld.bfd` is a serial bottleneck on link-heavy builds. This installs `lld` and appends `-Clink-arg=-fuse-ld=lld` to the per-arch `RUSTFLAGS` (so it composes with the existing `-Ctarget-cpu=native`). Scoped to `rust-checks`, where linking dominates; the `CARGO_PROFILE_*_DEBUG` PR also helps here by shrinking what gets linked.

Notes:
- The portable leg's matrix `rustflags` field stays empty, so the `Compute CPU feature cache key` guard (`if: matrix.arch.rustflags != ''`) is unaffected — only the composed `RUSTFLAGS` env gains the link arg.
- Couldn't exercise lld in the sandbox (not installed locally), so this leans on CI; `-fuse-ld=lld` via the gcc driver is the standard mechanism and works on both the x86_64 and arm64 runners once `lld` is installed.

Validated `yaml.safe_load` + `prek typos`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)