### PR TITLE
Remove MaybeUninit slice helpers now stabilized in std

### DIFF
--- a/crates/hash/src/binary_merkle_tree.rs
+++ b/crates/hash/src/binary_merkle_tree.rs
@@ -6,7 +6,6 @@ use std::{fmt::Debug, mem::MaybeUninit};
 use binius_field::Field;
 use binius_utils::{
 	checked_arithmetics::log2_strict_usize,
-	mem::slice_assume_init_mut,
 	rand::par_rand,
 	rayon::{prelude::*, slice::ParallelSlice},
 };
@@ -126,7 +125,7 @@ where
 
 	let mut prev_layer = unsafe {
 		// SAFETY: prev-layer was initialized by hash_leaves
-		slice_assume_init_mut(prev_layer)
+		prev_layer.assume_init_mut()
 	};
 	let parallel_compression = H::ParCompression::default();
 	for i in 1..(log_len + 1) {
@@ -137,7 +136,7 @@ where
 
 		prev_layer = unsafe {
 			// SAFETY: next_layer was just initialized by compress_layer
-			slice_assume_init_mut(next_layer)
+			next_layer.assume_init_mut()
 		};
 	}
 

--- a/crates/utils/src/mem.rs
+++ b/crates/utils/src/mem.rs
@@ -30,35 +30,3 @@ pub fn slice_uninit_mut<T>(slice: &mut [T]) -> &mut [MaybeUninit<T>] {
 		std::slice::from_raw_parts_mut(slice.as_mut_ptr() as *mut MaybeUninit<T>, slice.len())
 	}
 }
-
-/// This can be removed when MaybeUninit::slice_assume_init_mut is stabilized
-/// <https://github.com/rust-lang/rust/issues/63569>
-///
-/// # Safety
-///
-/// It is up to the caller to guarantee that the `MaybeUninit<T>` elements
-/// really are in an initialized state.
-/// Calling this when the content is not yet fully initialized causes undefined behavior.
-///
-/// See [`assume_init_mut`] for more details and examples.
-///
-/// [`assume_init_mut`]: MaybeUninit::assume_init_mut
-pub const unsafe fn slice_assume_init_mut<T>(slice: &mut [MaybeUninit<T>]) -> &mut [T] {
-	unsafe { std::mem::transmute(slice) }
-}
-
-/// This can be removed when MaybeUninit::slice_assume_init_ref is stabilized
-/// <https://github.com/rust-lang/rust/issues/63569>
-///
-/// # Safety
-///
-/// It is up to the caller to guarantee that the `MaybeUninit<T>` elements
-/// really are in an initialized state.
-/// Calling this when the content is not yet fully initialized causes undefined behavior.
-///
-/// See [`assume_init_ref`] for more details and examples.
-///
-/// [`assume_init_ref`]: MaybeUninit::assume_init_ref
-pub const unsafe fn slice_assume_init_ref<T>(slice: &[MaybeUninit<T>]) -> &[T] {
-	unsafe { std::mem::transmute(slice) }
-}


### PR DESCRIPTION
Removes two `MaybeUninit` slice helpers from `binius-utils` and switches the one caller to the standard-library method. Pure refactor — no behavior change.

### The problem

`crates/utils/src/mem.rs` carried two hand-rolled helpers, each with a comment saying "this can be removed when [rust-lang/rust#63569](https://github.com/rust-lang/rust/issues/63569) is stabilized":

- `slice_assume_init_mut(&mut [MaybeUninit<T>]) -> &mut [T]`
- `slice_assume_init_ref(&[MaybeUninit<T>]) -> &[T]`

That issue has since stabilized. The methods now live on the slice type itself as `<[MaybeUninit<T>]>::assume_init_mut()` and `assume_init_ref()`, available on stable from edition 2024 — which is what this repo builds on (Rust 1.95.0).

### The change

One caller used `slice_assume_init_mut`, in `crates/hash/src/binary_merkle_tree.rs`:

```diff
- slice_assume_init_mut(prev_layer)
+ prev_layer.assume_init_mut()

- slice_assume_init_mut(next_layer)
+ next_layer.assume_init_mut()
```

The two operations are identical — both reinterpret an initialized `[MaybeUninit<T>]` as `[T]` — so the `unsafe` safety argument at each call site is unchanged.

### Scope

- **removed:** `slice_assume_init_mut` and `slice_assume_init_ref` from `mem.rs`. The latter had zero call sites — it was dead code.
- **kept:** `slice_uninit_mut` (`&mut [T] -> &mut [MaybeUninit<T>]`) — std still has no stable equivalent for that direction.
- **changed:** two call sites + one import in `binary_merkle_tree.rs`.

### Verification

- `cargo check --workspace --all-targets`, `cargo clippy -p binius-utils -p binius-hash`, nightly `cargo fmt --all` — clean
- `cargo test -p binius-hash` — 7 passed
- Confirmed the std methods compile with no `#![feature(...)]` gate against the repo's 1.95.0 toolchain

🤖 Generated with [Claude Code](https://claude.com/claude-code)