### PR TITLE
Implement WideMul for the Scaled strategy; use it for portable AES

### DIFF
--- a/crates/field/src/arch/portable/packed_aes_256.rs
+++ b/crates/field/src/arch/portable/packed_aes_256.rs
@@ -1,6 +1,6 @@
 // Copyright 2024-2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-pub type AesWideMul32x<T> = crate::arch::Divide<u8, T, 32>;
+pub type AesWideMul32x<T> = crate::arch::Scaled<T>;
 pub type AesSquare32x<T> = crate::arch::Scaled<T>;
 pub type AesInvert32x<T> = crate::arch::Scaled<T>;

--- a/crates/field/src/arch/portable/packed_aes_512.rs
+++ b/crates/field/src/arch/portable/packed_aes_512.rs
@@ -1,6 +1,6 @@
 // Copyright 2024-2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-pub type AesWideMul64x<T> = crate::arch::Divide<u8, T, 64>;
+pub type AesWideMul64x<T> = crate::arch::Scaled<T>;
 pub type AesSquare64x<T> = crate::arch::Scaled<T>;
 pub type AesInvert64x<T> = crate::arch::Scaled<T>;

--- a/crates/field/src/arch/portable/scaled_arithmetic.rs
+++ b/crates/field/src/arch/portable/scaled_arithmetic.rs
@@ -7,7 +7,8 @@ use bytemuck::{Pod, TransparentWrapper};
 use super::packed::PackedPrimitiveType;
 use crate::{
 	BinaryField,
-	arithmetic_traits::{InvertOrZero, Square},
+	arch::LaneWideProduct,
+	arithmetic_traits::{InvertOrZero, Square, WideMul},
 	underlier::{ScaledUnderlier, UnderlierType},
 };
 
@@ -60,5 +61,85 @@ where
 				sub_underlier,
 			)))
 		}))))
+	}
+}
+
+/// Widening multiply for a `ScaledUnderlier` packing: apply the sub-underlier packing's [`WideMul`]
+/// to each of the `N` lanes independently, deferring reduction per lane via [`LaneWideProduct`].
+/// The `Scaled` analogue of [`Divide`](crate::arch::Divide)'s `WideMul`, but addressing the inner
+/// sub-underliers of `ScaledUnderlier` directly instead of splitting an underlier with `Divisible`.
+impl<U: UnderlierType + Pod, Scalar: BinaryField, const N: usize> WideMul
+	for Scaled<PackedPrimitiveType<ScaledUnderlier<U, N>, Scalar>>
+where
+	PackedPrimitiveType<U, Scalar>: WideMul,
+	<PackedPrimitiveType<U, Scalar> as WideMul>::Output: Copy + Default,
+{
+	type Output = LaneWideProduct<<PackedPrimitiveType<U, Scalar> as WideMul>::Output, N>;
+
+	#[inline]
+	fn wide_mul(a: Self, b: Self) -> Self::Output {
+		let (a, b) = (Self::peel(a), Self::peel(b));
+		LaneWideProduct(array::from_fn(|i| {
+			<PackedPrimitiveType<U, Scalar> as WideMul>::wide_mul(
+				PackedPrimitiveType::wrap(a.0.0[i]),
+				PackedPrimitiveType::wrap(b.0.0[i]),
+			)
+		}))
+	}
+
+	#[inline]
+	fn reduce(wide: Self::Output) -> Self {
+		Self::wrap(PackedPrimitiveType::wrap(ScaledUnderlier(array::from_fn(|i| {
+			PackedPrimitiveType::peel(<PackedPrimitiveType<U, Scalar> as WideMul>::reduce(
+				wide.0[i],
+			))
+		}))))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use proptest::prelude::*;
+
+	use super::*;
+	use crate::{aes_field::AESTowerField8b, arch::M128};
+
+	// A two-lane `ScaledUnderlier` AES packing whose `M128` lanes carry their own `WideMul`.
+	type Inner = PackedPrimitiveType<ScaledUnderlier<M128, 2>, AESTowerField8b>;
+	type P = Scaled<Inner>;
+
+	fn packing(lo: u128, hi: u128) -> P {
+		P::wrap(Inner::from_underlier(ScaledUnderlier([M128::from_u128(lo), M128::from_u128(hi)])))
+	}
+
+	proptest! {
+		// `reduce(wide_mul(a, b))` must agree with the `Scaled` multiply.
+		#[test]
+		fn wide_mul_reduce_matches_mul(
+			a_lo in any::<u128>(), a_hi in any::<u128>(),
+			b_lo in any::<u128>(), b_hi in any::<u128>(),
+		) {
+			let (a, b) = (packing(a_lo, a_hi), packing(b_lo, b_hi));
+			let via_wide = P::peel(P::reduce(P::wide_mul(a, b)));
+			let via_mul = P::peel(packing(a_lo, a_hi) * packing(b_lo, b_hi));
+			prop_assert_eq!(via_wide, via_mul);
+		}
+
+		// Deferred per-lane accumulation: summing two wide products then reducing once must equal
+		// the sum of the two reduced products.
+		#[test]
+		fn wide_mul_accumulates(
+			a_lo in any::<u128>(), a_hi in any::<u128>(),
+			b_lo in any::<u128>(), b_hi in any::<u128>(),
+			c_lo in any::<u128>(), c_hi in any::<u128>(),
+			d_lo in any::<u128>(), d_hi in any::<u128>(),
+		) {
+			let acc = P::wide_mul(packing(a_lo, a_hi), packing(b_lo, b_hi))
+				+ P::wide_mul(packing(c_lo, c_hi), packing(d_lo, d_hi));
+			let via_wide = P::peel(P::reduce(acc));
+			let via_mul = P::peel(packing(a_lo, a_hi) * packing(b_lo, b_hi))
+				+ P::peel(packing(c_lo, c_hi) * packing(d_lo, d_hi));
+			prop_assert_eq!(via_wide, via_mul);
+		}
 	}
 }

--- a/crates/field/src/arch/strategies.rs
+++ b/crates/field/src/arch/strategies.rs
@@ -79,7 +79,7 @@ where
 /// accumulate (`Add`/`Sub`/`Sum`) and reduce independently, mirroring the packing structure, so a
 /// sum of products is reduced only once per lane. `N` is the lane count.
 #[derive(Clone, Copy, Debug)]
-pub struct LaneWideProduct<O, const N: usize>([O; N]);
+pub struct LaneWideProduct<O, const N: usize>(pub [O; N]);
 
 impl<O: Copy + Default, const N: usize> Default for LaneWideProduct<O, N> {
 	#[inline]


### PR DESCRIPTION
## Summary

Adds a `WideMul` implementation for the `Scaled` strategy, completing the set of
arithmetic strategies (`Mul`/`Square`/`InvertOrZero`/`WideMul`) defined for
`Scaled<PackedPrimitiveType<ScaledUnderlier<U, N>, Scalar>>`.

It is the `Scaled` analogue of `Divide`'s `WideMul` (added in #1605): each of the
`N` lanes applies the sub-underlier packing's own `WideMul` and defers reduction
per lane via the shared `LaneWideProduct<O, N>`, so a sum of products is reduced
only once per lane. The difference from `Divide` is how lanes are addressed —
`Scaled` indexes the inner sub-underliers of `ScaledUnderlier` directly
(`a.0.0[i]`), matching the existing `Scaled` impls, rather than splitting an
underlier with `Divisible`.

## Changes

- **`scaled_arithmetic.rs`**: new `WideMul` impl for `Scaled`.
- **`portable/packed_aes_256.rs` / `packed_aes_512.rs`**: `AesWideMul32x` /
  `AesWideMul64x` now use `Scaled<T>` instead of `Divide<u8, T, 32/64>`, matching
  the `Scaled` square/invert these packings already use. Because portable
  `M256 = ScaledUnderlier<M128, 2>` and `M512 = ScaledUnderlier<M256, 2>`, the
  widening multiply now recurses lane-by-lane the same way the x86_64 `Divide`
  fallback does (512 → 256 → 128 → base).
- **`strategies.rs`**: `LaneWideProduct`'s tuple field made `pub` so `Scaled`'s
  impl (in a different module) can construct/destructure the wide product;
  `Divide` already accesses it directly within `strategies`.

## Testing

`cargo test -p binius-field`, clippy, and fmt are clean.

Added a proptest that exercises the new impl directly. On x86_64 the arch selects
the SIMD AES modules rather than the portable `ScaledUnderlier` packings, so the
existing packed-field proptests do not monomorphize this generic impl on this
target. The test instantiates
`Scaled<PackedPrimitiveType<ScaledUnderlier<M128, 2>, AESTowerField8b>>`
explicitly and checks that `reduce(wide_mul(a, b))` matches the `Scaled` multiply
and that summing two wide products before a single `reduce` equals the sum of the
separately reduced products.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
