### PR TITLE
BINIUS-157: rework FRI & BaseFold challenge order

### DIFF
--- a/crates/iop-prover/src/basefold.rs
+++ b/crates/iop-prover/src/basefold.rs
@@ -183,9 +183,6 @@ where
 ///   down to the codeword of `π_i'` in the FRI inner (unbatch) round
 /// * `outer_challenges` - the batching challenges `r'` (`len = log_n_oracles`); combine the `k`
 ///   lifted codewords in the FRI outer (oracle-combine) rounds
-/// * `reduced_log_dim` - the reduced (first-round) code dimension `D = rs_code().log_dim()`. The
-///   leading `max_n - D` standard rounds are the non-ZK oracles' batch folds, fed to the folder as
-///   inner challenges; only the trailing `D` rounds are genuine FRI fold rounds.
 /// * `fri_folder` - the combined FRI fold prover, with `n_rounds == 𝐧 + 1 + log_n_oracles`
 /// * `transcript` - the prover transcript
 ///
@@ -198,7 +195,6 @@ pub fn prove_mlecheck_basefold_zk_batch<'a, F, P, NTT, MerkleScheme, MerkleProve
 	eval_claim: F,
 	batch_challenge: Option<F>,
 	outer_challenges: &[F],
-	reduced_log_dim: usize,
 	mut fri_folder: FRIFoldProver<'a, F, P, NTT, MerkleProver>,
 	transcript: &mut ProverTranscript<Challenger_>,
 ) -> Result<(), Error>
@@ -216,37 +212,26 @@ where
 	assert_eq!(eval_point.len(), n_vars);
 	// The FRI folder has `n_inner` inner (unbatch) rounds — one for the shared mask challenge γ
 	// when any ZK oracle is present, none otherwise — `log_n_oracles` outer (oracle-combine)
-	// rounds, and `𝐧` standard fold rounds. The non-ZK oracles' batch-fold challenges are drawn
-	// from the leading standard rounds and routed to each oracle via its `skip_batch_challenges`
-	// window in the folder.
+	// rounds, and `𝐧` standard fold rounds.
 	let n_inner = usize::from(batch_challenge.is_some());
 	assert_eq!(n_vars + n_inner + outer_challenges.len(), fri_folder.n_rounds());
-
-	// The leading `max_n - D` standard rounds carry the non-ZK oracles' batch folds; only the
-	// trailing `D` are genuine FRI rounds. The folder's FirstFold consumes its accumulated
-	// challenges as `[inner-batch | outer]`, where the inner-batch challenges are γ (if any)
-	// followed by those `max_n - D` leading challenges, so the outer challenges must be fed only
-	// once the leading ones are in.
-	assert!(reduced_log_dim <= n_vars);
-	let n_leading = n_vars - reduced_log_dim;
 
 	// Inner (unbatch) round: fold every interleaved (π_i ‖ ω_i) ZK codeword at the masking
 	// challenge.
 	if let Some(gamma) = batch_challenge {
 		fri_folder.receive_challenge(gamma);
 	}
+	// Outer rounds: combine the k lifted codewords at the batching challenges r'. These carry no
+	// sumcheck round-polynomial; the folder applies them lazily at the first commit round. The
+	// FirstFold consumes its accumulated challenges as `[early ++ outer ++ later]`, so feeding the
+	// outer challenges here (right after γ, before any standard round) lands them in the outer
+	// window; the leading standard rounds then supply each non-ZK oracle's later batch fold.
+	for &outer_challenge in outer_challenges {
+		fri_folder.receive_challenge(outer_challenge);
+	}
 
 	let mut sumcheck = MultilinearEvalProver::new(witness, eval_point, eval_claim)?;
-	for round in 0..n_vars {
-		// Once the leading batch-fold challenges are accumulated, feed the outer (oracle-combine)
-		// challenges so they land in the FirstFold's outer window. For an all-ZK batch
-		// `n_leading == 0`, matching the original "feed γ then outers up front" order.
-		if round == n_leading {
-			for &outer_challenge in outer_challenges {
-				fri_folder.receive_challenge(outer_challenge);
-			}
-		}
-
+	for _ in 0..n_vars {
 		let mut round_coeffs_vec = sumcheck.execute()?;
 		let round_coeffs = round_coeffs_vec
 			.pop()
@@ -263,13 +248,6 @@ where
 		let challenge = transcript.sample();
 		sumcheck.fold(challenge)?;
 		fri_folder.receive_challenge(challenge);
-	}
-	// When `D == 0` the leading window spans every standard round, so the outer challenges follow
-	// them here, before the final fold.
-	if n_leading == n_vars {
-		for &outer_challenge in outer_challenges {
-			fri_folder.receive_challenge(outer_challenge);
-		}
 	}
 
 	let commitment = fri_folder.execute_fold_round();
@@ -545,7 +523,6 @@ mod test {
 			eval_claim,
 			Some(batch_challenge),
 			&[],
-			fri_params.rs_code().log_dim(),
 			fri_folder,
 			&mut prover_transcript,
 		)?;

--- a/crates/iop-prover/src/basefold_zk_channel.rs
+++ b/crates/iop-prover/src/basefold_zk_channel.rs
@@ -355,7 +355,6 @@ fn prove_batch_zk_basefold<F, P, NTT, MerkleScheme, MerkleProver_, Challenger_>(
 		s_prime,
 		gamma,
 		&outer_challenges,
-		fri_params.rs_code().log_dim(),
 		fri_folder,
 		channel,
 	)
@@ -902,10 +901,10 @@ mod tests {
 		assert!(run_zk_channel(&[5, 6, 8], false));
 	}
 
-	// Heterogeneous mixed/zero-ZK openings: the non-ZK oracles' batch-fold challenges come from the
-	// leading `max_n - D` MLE rounds, so prove/verify_mlecheck feed the FRI folder's outer
-	// (oracle-combine) challenges *after* those rounds, landing them in the FirstFold's outer
-	// window. All-ZK (`n_leading == 0`) is unaffected: the outers still precede every MLE round.
+	// Heterogeneous mixed/zero-ZK openings: each non-ZK oracle's batch fold is routed to the
+	// *later* window of the first-fold challenge slice `[early ++ outer ++ later]`, so the
+	// non-ZK oracles' batch-fold challenges come from the leading MLE rounds (which follow the
+	// outer challenges in feed order) and land correctly in the FirstFold's later window.
 	#[test]
 	fn test_basefold_zk_channel_mixed_zk_non_zk() {
 		// One non-ZK oracle (8 vars) and one ZK oracle (6 vars): exercises conditional masking,

--- a/crates/iop-prover/src/fri/commit.rs
+++ b/crates/iop-prover/src/fri/commit.rs
@@ -52,7 +52,7 @@ where
 	VCS: MerkleTreeScheme<F>,
 {
 	let oracle_spec = &params.input_oracles()[oracle_index];
-	let log_batch_size = oracle_spec.log_batch_size;
+	let log_batch_size = oracle_spec.log_batch_size();
 	// The oracle's own codeword dimension is the reduced dimension minus its lift; its committed
 	// (interleaved) message length is that plus the batch size.
 	let oracle_log_dim = params.rs_code().log_dim() - oracle_spec.log_lift;
@@ -137,7 +137,7 @@ where
 	VCS: MerkleTreeScheme<F>,
 {
 	let oracle_spec = &params.input_oracles()[oracle_index];
-	assert_eq!(oracle_spec.log_batch_size, 1, "commit_masked requires log_batch_size == 1");
+	assert_eq!(oracle_spec.log_batch_size(), 1, "commit_masked requires log_batch_size == 1");
 	// With batch size 1, the oracle's own codeword dimension (reduced dimension minus its lift) is
 	// exactly the bare message length; the mask is interleaved internally.
 	let oracle_log_dim = params.rs_code().log_dim() - oracle_spec.log_lift;

--- a/crates/iop-prover/src/fri/fold.rs
+++ b/crates/iop-prover/src/fri/fold.rs
@@ -127,7 +127,7 @@ where
 				// length is that plus the batch size plus the inverse rate. It is lifted to the
 				// common first-round length by duplicating each entry `2^log_lift` times.
 				let oracle_log_dim = log_dim - spec.log_lift;
-				let expected_log_len = oracle_log_dim + spec.log_batch_size + log_inv_rate;
+				let expected_log_len = oracle_log_dim + spec.log_batch_size() + log_inv_rate;
 				assert_eq!(
 					codeword.log_len(),
 					expected_log_len,
@@ -135,8 +135,8 @@ where
 					 Reed-Solomon code length plus its batch size"
 				);
 				ProxTestFolder {
-					log_batch_size: spec.log_batch_size,
-					skip_batch_challenges: spec.skip_batch_challenges,
+					log_early_batch_size: spec.log_early_batch_size,
+					log_later_batch_size: spec.log_later_batch_size,
 					log_lift: spec.log_lift,
 					codeword,
 					merkle_committed: committed,
@@ -402,11 +402,14 @@ where
 }
 
 pub struct ProxTestFolder<'a, P: PackedField, MTProver: MerkleTreeProver<P::Scalar>> {
-	log_batch_size: usize,
-	/// The number of leading inner challenges this oracle skips before its batch fold. The oracle
-	/// folds with the window `inner[skip_batch_challenges .. skip_batch_challenges +
-	/// log_batch_size]`.
-	skip_batch_challenges: usize,
+	/// log2 the number of *early* batch-fold challenges this oracle's interleaving folds with
+	/// (sampled before the outer oracle-combine challenges). The oracle folds with the
+	/// `log_early_batch_size`-length suffix of the early challenges.
+	log_early_batch_size: usize,
+	/// log2 the number of *later* batch-fold challenges this oracle's interleaving folds with
+	/// (sampled after the outer oracle-combine challenges). The oracle folds with the
+	/// `log_later_batch_size`-length suffix of the later challenges.
+	log_later_batch_size: usize,
 	/// log2 the lift factor (oracle padding): how many times each folded codeword entry is
 	/// duplicated to reach the common first-round length. Zero when no lifting is needed.
 	log_lift: usize,
@@ -418,8 +421,13 @@ impl<'a, F: Field, P: PackedField<Scalar = F>, MTProver> ProxTestFolder<'a, P, M
 where
 	MTProver: MerkleTreeProver<F>,
 {
+	/// The total interleave batch size, `log_early_batch_size + log_later_batch_size`.
+	fn log_batch_size(&self) -> usize {
+		self.log_early_batch_size + self.log_later_batch_size
+	}
+
 	pub fn log_folded_len(&self) -> usize {
-		self.codeword.log_len() - self.log_batch_size
+		self.codeword.log_len() - self.log_batch_size()
 	}
 }
 
@@ -471,14 +479,26 @@ where
 		merkle_prover: &'a MTProver,
 		challenges: &[F],
 	) -> (FieldBuffer<F>, BatchBrakedownOracleProver<'a, P, MTProver>) {
-		let max_inner_challenges = self
+		// The first-fold challenge slice is `[early ++ outer ++ later]`: `max_early` early
+		// within-oracle batch challenges, then `log_n_oracles` outer oracle-combine challenges,
+		// then `max_later` later within-oracle batch challenges.
+		let max_early = self
 			.folders
 			.iter()
-			.map(|folder| folder.skip_batch_challenges + folder.log_batch_size)
+			.map(|folder| folder.log_early_batch_size)
 			.max()
 			.expect("folders is not empty by struct invariant");
+		let max_later = self
+			.folders
+			.iter()
+			.map(|folder| folder.log_later_batch_size)
+			.max()
+			.expect("folders is not empty by struct invariant");
+		let log_n_oracles = log2_ceil_usize(self.folders.len());
 
-		let (inner_challenges, outer_challenges) = challenges.split_at(max_inner_challenges);
+		let early_challenges = &challenges[..max_early];
+		let outer_challenges = &challenges[max_early..max_early + log_n_oracles];
+		let later_challenges = &challenges[max_early + log_n_oracles..];
 		let outer_tensor = eq_ind_partial_eval::<F>(outer_challenges);
 
 		let mut combined_codeword = FieldBuffer::zeros(self.log_code_len);
@@ -487,19 +507,26 @@ where
 		// reduce # of scaling muls)
 		for (folder, &scalar) in iter::zip(self.folders, outer_tensor.as_ref()) {
 			let ProxTestFolder {
-				log_batch_size,
-				skip_batch_challenges,
+				log_early_batch_size,
+				log_later_batch_size,
 				log_lift,
 				codeword,
 				merkle_committed,
 			} = folder;
+			let log_batch_size = log_early_batch_size + log_later_batch_size;
+
+			// This oracle folds its interleaving with `early_window ++ later_window`, where each
+			// window is the suffix of its group. An oracle is purely early (ZK) or purely later
+			// (non-ZK), so in practice one window is empty, but the concatenation is general.
+			let early_window = &early_challenges[max_early - log_early_batch_size..];
+			let later_window = &later_challenges[max_later - log_later_batch_size..];
+			let fold_challenges: Vec<F> =
+				early_window.iter().chain(later_window).copied().collect();
 
 			// Fold the outer-challenge tensor value into the inner folding tensor so that every
 			// folded entry comes out already scaled by `scalar`. This replaces one scaling mul per
 			// (lifted) output entry with a single pass over the `2^log_batch_size`-element tensor.
-			let mut tensor = eq_ind_partial_eval::<P>(
-				&inner_challenges[skip_batch_challenges..skip_batch_challenges + log_batch_size],
-			);
+			let mut tensor = eq_ind_partial_eval::<P>(&fold_challenges);
 			let scalar_broadcast = P::broadcast(scalar);
 			for packed in tensor.as_mut() {
 				*packed *= scalar_broadcast;

--- a/crates/iop-prover/src/fri/tests.rs
+++ b/crates/iop-prover/src/fri/tests.rs
@@ -18,6 +18,7 @@ use binius_transcript::{
 	ProverTranscript,
 	fiat_shamir::{CanSample, HasherChallenger},
 };
+use binius_utils::checked_arithmetics::log2_ceil_usize;
 use rand::prelude::*;
 
 use super::{CommitOutput, FRIFoldProver, FoldRoundOutput, commit_interleaved};
@@ -237,15 +238,15 @@ fn test_commit_prove_verify_batched_multi_oracle() {
 	let ntt = NeighborsLastSingleThread::new(domain_context);
 
 	// Each oracle has RS dimension `log_dim` (no lifting), so every oracle sits at the reduced
-	// (first-round) dimension `log_dim`. The non-ZK batch folds are routed to a suffix of the inner
-	// challenges, so oracle `i` skips `max(log_batch_size) - log_batch_size_i` of them.
-	let max_log_batch_size = log_batch_sizes.iter().copied().max().unwrap();
+	// (first-round) dimension `log_dim`. These are all non-ZK oracles, so their batch folds are
+	// "later" challenges (sampled after the outer oracle-combine challenges); oracle `i` folds
+	// with the `log_batch_size_i`-length suffix of the later group.
 	let oracle_specs = log_batch_sizes
 		.iter()
 		.map(|&log_batch_size| CodewordSpec {
 			log_lift: 0,
-			log_batch_size,
-			skip_batch_challenges: max_log_batch_size - log_batch_size,
+			log_early_batch_size: 0,
+			log_later_batch_size: log_batch_size,
 		})
 		.collect::<Vec<_>>();
 	let rs_code =
@@ -327,39 +328,39 @@ fn test_commit_prove_verify_batched_multi_oracle() {
 	);
 	let final_value = verifier.verify(&mut verifier_challenger).unwrap();
 
-	// The first fold reduces oracle `i` by the inner challenges in its window
-	// `inner[skip_i .. skip_i + log_batch_size_i]` (the ZK-aware selection routes every non-ZK
-	// oracle's batch to a suffix, so `skip_i = n_inner - log_batch_size_i`) and combines the
-	// oracles with the outer-challenge tensor. The remaining (tail) challenges fold the shared
-	// reduced codeword. So the final value is   sum_i outer_tensor[i] * evaluate(msg_i,
-	// reversed(inner_i ++ tail)).
-	let max_log_batch_size = log_batch_sizes.iter().copied().max().unwrap();
+	// The first-fold challenge slice is `[early ++ outer ++ later]`. Here every oracle is non-ZK,
+	// so `max_early = 0` and the slice is `[outer ++ later]`. Oracle `i` folds with the
+	// `log_batch_size_i`-length suffix of the later group; the remaining (tail) challenges fold the
+	// shared reduced codeword. So the final value is
+	//   sum_i outer_tensor[i] * evaluate(msg_i, reversed(later_i ++ tail)).
+	let max_later = log_batch_sizes.iter().copied().max().unwrap();
+	let log_n_oracles = log2_ceil_usize(log_batch_sizes.len());
 	let first_fold_arity = params.log_batch_size();
-	let inner = &verifier_challenges[..max_log_batch_size];
-	let outer = &verifier_challenges[max_log_batch_size..first_fold_arity];
+	let outer = &verifier_challenges[..log_n_oracles];
+	let later = &verifier_challenges[log_n_oracles..log_n_oracles + max_later];
 	let tail = &verifier_challenges[first_fold_arity..];
 	let outer_tensor = eq_ind_partial_eval_scalars::<F>(outer);
 
 	let mut expected = F::ZERO;
 	for (i, (msg, &log_batch_size)) in iter::zip(&messages, &log_batch_sizes).enumerate() {
-		let skip = params.input_oracles()[i].skip_batch_challenges;
-		let inner_i = &inner[skip..skip + log_batch_size];
-		let mut eval_point = inner_i.iter().chain(tail).copied().collect::<Vec<_>>();
+		let later_i = &later[max_later - log_batch_size..];
+		let mut eval_point = later_i.iter().chain(tail).copied().collect::<Vec<_>>();
 		eval_point.reverse();
 		expected += outer_tensor[i] * evaluate(msg, &eval_point);
 	}
 	assert_eq!(final_value, expected);
 }
 
-/// Full FRI round trip that batches oracles consuming **disjoint inner-challenge windows** via
-/// per-oracle `skip_batch_challenges`.
+/// Full FRI round trip that batches a ZK oracle (early window) with a non-ZK oracle (later
+/// window), exercising the heterogeneous `[early ++ outer ++ later]` challenge layout.
 ///
-/// Oracle 0 has `skip_batch_challenges = 0`, `log_batch_size = 1`, so it folds with `inner[0]`
-/// alone — the position a ZK BaseFold oracle reserves for its shared masking challenge γ. Oracle 1
-/// has `skip_batch_challenges = 1`, `log_batch_size = 2`, so it skips `inner[0]` and folds with
-/// `inner[1..3]`. The first fold therefore draws `max(0 + 1, 1 + 2) = 3` inner challenges, and the
-/// two oracles overlap in none of them. This is the routing the homogeneous suffix convention could
-/// not express (it would hand Oracle 0 the *last* inner challenge instead of `inner[0]`).
+/// Oracle 0 is ZK with `log_batch_size = 1`, so it is purely *early* (`log_early_batch_size = 1`)
+/// and folds with the single early challenge — the shared masking challenge γ a ZK BaseFold oracle
+/// reserves. Oracle 1 is non-ZK with `log_batch_size = 2`, so it is purely *later*
+/// (`log_later_batch_size = 2`) and folds with the two later challenges, which are sampled after
+/// the `log_n_oracles = 1` outer (oracle-combine) challenge. The first fold therefore draws
+/// `max_early + log_n_oracles + max_later = 1 + 1 + 2 = 4` challenges, with the two oracles folding
+/// disjoint within-oracle windows on opposite sides of the outer challenge.
 #[test]
 fn test_commit_prove_verify_batched_mixed_skip() {
 	type F = B128;
@@ -369,9 +370,9 @@ fn test_commit_prove_verify_batched_mixed_skip() {
 
 	let log_dim = 8;
 	let log_inv_rate = 2;
-	// (log_batch_size, is_zk) per oracle. The ZK oracle (batch 1) takes the prefix masking slot
-	// `inner[0]` (skip 0); the non-ZK oracle (batch 2) is routed to the suffix `inner[1..3]` by the
-	// ZK-aware selection (`skip = n_batch_challenges - log_batch_size = 3 - 2 = 1`).
+	// (log_batch_size, is_zk) per oracle. The ZK oracle (batch 1) folds with the early window
+	// (before the outer challenge); the non-ZK oracle (batch 2) folds with the later window (after
+	// the outer challenge).
 	let oracle_params_spec = [(1usize, true), (2usize, false)];
 	let n_test_queries = 3;
 
@@ -384,33 +385,14 @@ fn test_commit_prove_verify_batched_mixed_skip() {
 	let ntt = NeighborsLastSingleThread::new(domain_context);
 
 	// Every oracle sits at the reduced dimension `log_dim` (no lifting). The ZK oracle (batch 1)
-	// takes the prefix masking slot `inner[0]` (skip 0); the non-ZK oracle (batch 2) is routed to
-	// the suffix `inner[1..3]`. With `n_inner = max non-ZK batch = 2` and `max_zk_batch = 1`, the
-	// first fold draws `n_batch_challenges = 3` inner challenges, so the non-ZK oracle skips
-	// `3 - 2 = 1`.
-	let n_inner = oracle_params_spec
-		.iter()
-		.filter(|&&(_, is_zk)| !is_zk)
-		.map(|&(log_batch_size, _)| log_batch_size)
-		.max()
-		.unwrap();
-	let max_zk_batch = oracle_params_spec
-		.iter()
-		.filter(|&&(_, is_zk)| is_zk)
-		.map(|&(log_batch_size, _)| log_batch_size)
-		.max()
-		.unwrap_or(0);
-	let n_batch_challenges = n_inner + max_zk_batch;
+	// is purely early; the non-ZK oracle (batch 2) is purely later. With `max_early = 1`,
+	// `max_later = 2`, and `log_n_oracles = 1`, the first fold draws `1 + 1 + 2 = 4` challenges.
 	let oracle_specs = oracle_params_spec
 		.iter()
 		.map(|&(log_batch_size, is_zk)| CodewordSpec {
 			log_lift: 0,
-			log_batch_size,
-			skip_batch_challenges: if is_zk {
-				0
-			} else {
-				n_batch_challenges - log_batch_size
-			},
+			log_early_batch_size: if is_zk { log_batch_size } else { 0 },
+			log_later_batch_size: if is_zk { 0 } else { log_batch_size },
 		})
 		.collect::<Vec<_>>();
 	let rs_code =
@@ -492,29 +474,44 @@ fn test_commit_prove_verify_batched_mixed_skip() {
 	);
 	let final_value = verifier.verify(&mut verifier_challenger).unwrap();
 
-	// Each oracle folds with the window `inner[skip .. skip + log_batch_size]`, so the inner
-	// segment spans `max(skip + log_batch_size)` challenges. The remaining (tail) challenges fold
+	// The first-fold challenge slice is `[early ++ outer ++ later]`. Oracle `i` folds with
+	// `early_window ++ later_window`, the suffixes of the early and later groups of lengths
+	// `log_early_batch_size_i` and `log_later_batch_size_i`. The remaining (tail) challenges fold
 	// the shared reduced codeword. So the final value is
-	//   sum_i outer_tensor[i] * evaluate(msg_i, reversed(inner_i ++ tail)).
-	let max_inner = params
+	//   sum_i outer_tensor[i] * evaluate(msg_i, reversed(early_i ++ later_i ++ tail)).
+	let max_early = params
 		.input_oracles()
 		.iter()
-		.map(|spec| spec.skip_batch_challenges + spec.log_batch_size)
+		.map(|spec| spec.log_early_batch_size)
 		.max()
 		.unwrap();
+	let max_later = params
+		.input_oracles()
+		.iter()
+		.map(|spec| spec.log_later_batch_size)
+		.max()
+		.unwrap();
+	let log_n_oracles = log2_ceil_usize(oracle_params_spec.len());
 	let first_fold_arity = params.log_batch_size();
-	let inner = &verifier_challenges[..max_inner];
-	let outer = &verifier_challenges[max_inner..first_fold_arity];
+	let early = &verifier_challenges[..max_early];
+	let outer = &verifier_challenges[max_early..max_early + log_n_oracles];
+	let later = &verifier_challenges[max_early + log_n_oracles..first_fold_arity];
 	let tail = &verifier_challenges[first_fold_arity..];
 	let outer_tensor = eq_ind_partial_eval_scalars::<F>(outer);
 
 	let mut expected = F::ZERO;
-	for (i, (msg, &(log_batch_size, _is_zk))) in
+	for (i, (msg, &(_log_batch_size, _is_zk))) in
 		iter::zip(&messages, &oracle_params_spec).enumerate()
 	{
-		let skip = params.input_oracles()[i].skip_batch_challenges;
-		let inner_i = &inner[skip..skip + log_batch_size];
-		let mut eval_point = inner_i.iter().chain(tail).copied().collect::<Vec<_>>();
+		let spec = &params.input_oracles()[i];
+		let early_i = &early[max_early - spec.log_early_batch_size..];
+		let later_i = &later[max_later - spec.log_later_batch_size..];
+		let mut eval_point = early_i
+			.iter()
+			.chain(later_i)
+			.chain(tail)
+			.copied()
+			.collect::<Vec<_>>();
 		eval_point.reverse();
 		expected += outer_tensor[i] * evaluate(msg, &eval_point);
 	}
@@ -554,13 +551,13 @@ fn test_commit_prove_verify_lifted_multi_oracle() {
 	let ntt = NeighborsLastSingleThread::new(domain_context);
 
 	// Each oracle is lifted from its own RS dimension up to `reduced_log_dim` (`log_lift` is the
-	// gap), and the non-ZK batch folds are routed to a suffix of the inner challenges.
-	let max_log_batch_size = log_batch_sizes.iter().copied().max().unwrap();
+	// gap). These are all non-ZK oracles, so their batch folds are "later" challenges; oracle `i`
+	// folds with the `log_batch_size_i`-length suffix of the later group.
 	let oracle_specs = iter::zip(oracle_log_dims, log_batch_sizes)
 		.map(|(oracle_log_dim, log_batch_size)| CodewordSpec {
 			log_lift: reduced_log_dim - oracle_log_dim,
-			log_batch_size,
-			skip_batch_challenges: max_log_batch_size - log_batch_size,
+			log_early_batch_size: 0,
+			log_later_batch_size: log_batch_size,
 		})
 		.collect::<Vec<_>>();
 	let rs_code = ReedSolomonCode::with_domain_context_subspace(
@@ -650,10 +647,10 @@ fn test_commit_prove_verify_lifted_multi_oracle() {
 	);
 	let final_value = verifier.verify(&mut verifier_challenger).unwrap();
 
-	// The first fold reduces oracle `i` by its inner challenges (with all skips zero here, the
-	// first `log_batch_size_i` of the `max_log_batch_size` inner challenges) and combines the
-	// oracles with the outer-challenge tensor. The remaining `reduced_log_dim` tail challenges
-	// fold the combined codeword.
+	// The first-fold challenge slice is `[early ++ outer ++ later]`. Every oracle is non-ZK here,
+	// so `max_early = 0` and the slice is `[outer ++ later]`. Oracle `i` folds with the
+	// `log_batch_size_i`-length suffix of the later group and combines with the outer-challenge
+	// tensor. The remaining `reduced_log_dim` tail challenges fold the combined codeword.
 	//
 	// Lifting oracle `i` embeds its codeword as `Enc_M(ZeroPadMSB_eta(m_i'))`, whose multilinear
 	// extension factors as `m_i'(low vars) * prod_j (1 - Y_j)` over the `eta_i = reduced_log_dim -
@@ -662,11 +659,12 @@ fn test_commit_prove_verify_lifted_multi_oracle() {
 	// (contributing the factor `prod (1 - tail_k)`), and the surviving `log_dim_i` tail challenges
 	// bind the real message. Hence the final value is
 	//   sum_i outer_tensor[i] * prod_{k<eta_i}(1 - tail_k)
-	//                          * evaluate(msg_i, reversed(inner_i ++ tail[eta_i..])).
-	let max_log_batch_size = log_batch_sizes.iter().copied().max().unwrap();
+	//                          * evaluate(msg_i, reversed(later_i ++ tail[eta_i..])).
+	let max_later = log_batch_sizes.iter().copied().max().unwrap();
+	let log_n_oracles = log2_ceil_usize(log_batch_sizes.len());
 	let first_fold_arity = params.log_batch_size();
-	let inner = &verifier_challenges[..max_log_batch_size];
-	let outer = &verifier_challenges[max_log_batch_size..first_fold_arity];
+	let outer = &verifier_challenges[..log_n_oracles];
+	let later = &verifier_challenges[log_n_oracles..log_n_oracles + max_later];
 	let tail = &verifier_challenges[first_fold_arity..];
 	let outer_tensor = eq_ind_partial_eval_scalars::<F>(outer);
 
@@ -675,11 +673,10 @@ fn test_commit_prove_verify_lifted_multi_oracle() {
 		iter::zip(iter::zip(&messages, &log_batch_sizes), &oracle_log_dims).enumerate()
 	{
 		let eta = reduced_log_dim - log_dim;
-		let skip = params.input_oracles()[i].skip_batch_challenges;
 		// The lift (oracle padding) factor from the zero-padded high message variables.
 		let pad_factor = tail[..eta].iter().map(|&t| F::ONE - t).product::<F>();
-		let inner_i = &inner[skip..skip + log_batch_size];
-		let mut eval_point = inner_i
+		let later_i = &later[max_later - log_batch_size..];
+		let mut eval_point = later_i
 			.iter()
 			.chain(&tail[eta..])
 			.copied()

--- a/crates/iop/src/basefold.rs
+++ b/crates/iop/src/basefold.rs
@@ -126,10 +126,7 @@ where
 /// * `outer_challenges` - the batching challenges `r'` (length `log_n_oracles`) used in the FRI
 ///   outer (oracle-combine) rounds.
 ///
-/// The leading `max_n - D` standard rounds (`D = fri_params.rs_code().log_dim()`, the reduced
-/// first-round code dimension) carry the non-ZK oracles' batch folds; only the trailing `D` are
-/// genuine FRI fold rounds. The returned `challenges` are the FRI fold challenges
-/// `[γ] ++ leading_X ++ r' ++ trailing_X`, matching the prover's feed order. Use
+/// The returned `challenges` are the FRI fold challenges `[γ] ++ r' ++ fresh_X`. Use
 /// [`mlecheck_fri_consistency`] to check the reduced values.
 #[allow(clippy::too_many_arguments)]
 pub fn verify_mlecheck_basefold_zk_batch<F, MTScheme, Challenger_>(
@@ -160,13 +157,8 @@ where
 	let n_vars = eval_point.len();
 
 	// `n_inner` inner (unbatch) rounds: one for the shared mask challenge γ when any ZK oracle is
-	// present, none otherwise. The leading `n_leading = max_n - D` standard rounds carry the non-ZK
-	// oracles' batch folds (inner challenges); the outer (oracle-combine) challenges follow them so
-	// they land in the FirstFold's outer window, exactly mirroring the prover's feed order.
+	// present, none otherwise.
 	let n_inner = usize::from(batch_challenge.is_some());
-	let reduced_log_dim = fri_params.rs_code().log_dim();
-	assert!(reduced_log_dim <= n_vars);
-	let n_leading = n_vars - reduced_log_dim;
 	let mut challenges = Vec::with_capacity(n_vars + n_inner + log_n_oracles);
 	let mut fri_fold_verifier = FRIFoldVerifier::new(fri_params);
 
@@ -177,19 +169,20 @@ where
 		challenges.push(gamma);
 	}
 
+	// Outer rounds: combine the `k` lifted codewords at the batching challenges `r'`. These carry
+	// no sumcheck round-polynomial (the oracle-index variables are collapsed deterministically).
+	// The first fold consumes its challenges as `[γ] ++ r' ++ fresh_X`, so the outer challenges are
+	// processed here (right after γ) to land in the outer window; the leading standard rounds then
+	// supply each non-ZK oracle's later batch fold.
+	for &outer_challenge in outer_challenges {
+		fri_fold_verifier.process_round(&mut transcript.message())?;
+		challenges.push(outer_challenge);
+	}
+
 	// Standard rounds: the only sumcheck (MLE-check) rounds, folding the combined codeword at the
-	// fresh challenges over the `𝐧` variables `X`. The outer (oracle-combine) challenges — which
-	// carry no sumcheck round-polynomial — are processed once the leading batch-fold challenges are
-	// in (all-ZK has `n_leading == 0`, so they precede every standard round as before).
+	// fresh challenges over the `𝐧` variables `X`.
 	let mut sum = eval_claim;
 	for round in 0..n_vars {
-		if round == n_leading {
-			for &outer_challenge in outer_challenges {
-				fri_fold_verifier.process_round(&mut transcript.message())?;
-				challenges.push(outer_challenge);
-			}
-		}
-
 		let round_proof = mlecheck::RoundProof(RoundCoeffs(transcript.message().read_vec(DEGREE)?));
 		fri_fold_verifier.process_round(&mut transcript.message())?;
 
@@ -199,14 +192,6 @@ where
 		let challenge = transcript.sample();
 		sum = round_coeffs.evaluate(challenge);
 		challenges.push(challenge);
-	}
-	// When `D == 0` the leading window spans every standard round, so the outer challenges follow
-	// them here, before the final fold.
-	if n_leading == n_vars {
-		for &outer_challenge in outer_challenges {
-			fri_fold_verifier.process_round(&mut transcript.message())?;
-			challenges.push(outer_challenge);
-		}
 	}
 
 	fri_fold_verifier.process_round(&mut transcript.message())?;

--- a/crates/iop/src/fri/common.rs
+++ b/crates/iop/src/fri/common.rs
@@ -28,8 +28,9 @@ pub struct FRIParams<F> {
 	/// Guaranteed to be non-empty.
 	input_oracles: Vec<CodewordSpec>,
 	/// log2 the maximum message length of all input oracles, after lifting each to the reduced
-	/// dimension. Equals `rs_code.log_dim() + max(skip_batch_challenges + log_batch_size)` over
-	/// the input oracles (the inner challenges the first fold must draw).
+	/// dimension. Equals `rs_code.log_dim() + max_early + max_later`, where `max_early` (resp.
+	/// `max_later`) is the maximum `log_early_batch_size` (resp. `log_later_batch_size`) over the
+	/// input oracles (the within-oracle batch challenges the first fold must draw).
 	max_log_msg_len: usize,
 	/// log2 ceiling of the number of input oracles.
 	log_n_oracles: usize,
@@ -59,19 +60,33 @@ pub struct CodewordSpec {
 	/// message length is `rs_code.log_dim() - log_lift + log_batch_size`. It is `0` when the
 	/// oracle already sits at the reduced dimension.
 	pub log_lift: usize,
-	/// log2 the interleaved batch size.
-	pub log_batch_size: usize,
-	/// The number of leading inner challenges this oracle skips before its batch fold.
+	/// log2 the number of *early* batch-fold challenges this oracle's interleaving folds with.
 	///
-	/// The first fold draws `max(skip_batch_challenges + log_batch_size)` inner challenges across
-	/// all oracles; oracle `i` folds its interleaved batch with the window
-	/// `inner_challenges[skip_batch_challenges .. skip_batch_challenges + log_batch_size]`. This
-	/// lets distinct oracles consume distinct (or overlapping) inner challenges — needed when a
-	/// leading inner challenge is reserved for one group of oracles (e.g. the shared masking
-	/// challenge of ZK BaseFold oracles) while others must skip it. It is `0` in the homogeneous
-	/// case, recovering the convention where every oracle folds with a prefix of the inner
-	/// challenges.
-	pub skip_batch_challenges: usize,
+	/// The first fold draws its within-oracle batch challenges in two groups: `max_early =
+	/// max(log_early_batch_size)` *early* challenges, sampled before the `log_n_oracles` outer
+	/// (oracle-combine) challenges, followed by `max_later = max(log_later_batch_size)` *later*
+	/// challenges, sampled after them. The full first-fold challenge slice is therefore
+	/// `[early (max_early)] ++ [outer (log_n_oracles)] ++ [later (max_later)]`.
+	///
+	/// Oracle `i` folds its interleaving with the concatenation `early_window ++ later_window`,
+	/// where `early_window` is the `log_early_batch_size`-length *suffix* of the early challenges
+	/// and `later_window` is the `log_later_batch_size`-length *suffix* of the later challenges.
+	/// The early group carries the shared masking challenge γ of ZK BaseFold oracles (each such
+	/// oracle is purely early, `log_later_batch_size == 0`); the later group carries the non-ZK
+	/// oracles' flexible batch folds (each such oracle is purely later, `log_early_batch_size ==
+	/// 0`). The total interleave batch size of an oracle is `log_early_batch_size +
+	/// log_later_batch_size` (see [`Self::log_batch_size`]).
+	pub log_early_batch_size: usize,
+	/// log2 the number of *later* batch-fold challenges this oracle's interleaving folds with,
+	/// sampled after the outer (oracle-combine) challenges. See [`Self::log_early_batch_size`].
+	pub log_later_batch_size: usize,
+}
+
+impl CodewordSpec {
+	/// log2 the interleaved batch size: the early plus the later batch challenges.
+	pub fn log_batch_size(&self) -> usize {
+		self.log_early_batch_size + self.log_later_batch_size
+	}
 }
 
 impl<F> FRIParams<F>
@@ -87,12 +102,13 @@ where
 		fold_arities: Vec<usize>,
 		n_test_queries: usize,
 	) -> Self {
-		// A single oracle already sits at the reduced dimension (no lifting) and folds with a
-		// prefix of the inner challenges (no skip).
+		// A single oracle already sits at the reduced dimension (no lifting) and is non-ZK /
+		// homogeneous: its whole batch is "later" (with `log_n_oracles == 0` there is no outer
+		// group between early and later, so this is identical to the old prefix convention).
 		let oracle_spec = CodewordSpec {
 			log_lift: 0,
-			log_batch_size,
-			skip_batch_challenges: 0,
+			log_early_batch_size: 0,
+			log_later_batch_size: log_batch_size,
 		};
 		Self::new_batch(rs_code, vec![oracle_spec], fold_arities, n_test_queries)
 	}
@@ -100,7 +116,7 @@ where
 	/// Create parameters for a batch of committed codewords with an explicit per-codeword layout.
 	///
 	/// This is the low-level constructor: the caller supplies the reduced Reed–Solomon code, each
-	/// codeword's lift / batch size / inner-challenge routing, and the fold arities. The
+	/// codeword's lift / early & later batch-fold routing, and the fold arities. The
 	/// proof-size-minimizing selection of those values from a batch of higher-level oracle
 	/// descriptions lives in [`Self::optimal_for_batch`].
 	///
@@ -125,15 +141,21 @@ where
 
 		let log_n_oracles = log2_ceil_usize(oracles.len());
 
-		// The first fold draws `max(skip_batch_challenges + log_batch_size)` inner challenges
-		// across all oracles (oracle `i` folds with `inner[skip_i .. skip_i + log_batch_size_i]`)
-		// before the `log_n_oracles` outer folds that batch the oracles together.
-		let max_inner_challenges = oracles
+		// The first fold draws its within-oracle batch challenges as `max_early` early challenges
+		// followed (after the `log_n_oracles` outer oracle-combine folds) by `max_later` later
+		// challenges, so the full first-fold slice is `[early ++ outer ++ later]`. The lifted
+		// message length each oracle reaches is `rs_code.log_dim() + max_early + max_later`.
+		let max_early = oracles
 			.iter()
-			.map(|spec| spec.skip_batch_challenges + spec.log_batch_size)
+			.map(|spec| spec.log_early_batch_size)
 			.max()
 			.expect("oracles is non-empty");
-		let max_log_msg_len = rs_code.log_dim() + max_inner_challenges;
+		let max_later = oracles
+			.iter()
+			.map(|spec| spec.log_later_batch_size)
+			.max()
+			.expect("oracles is non-empty");
+		let max_log_msg_len = rs_code.log_dim() + max_early + max_later;
 
 		Self {
 			rs_code,
@@ -490,41 +512,24 @@ where
 		})
 		.collect();
 
-	// ZK-aware `skip_batch_challenges` selection. The inner challenges are the (shared) masking
-	// challenge γ for the ZK oracles plus `n_inner` batch-fold challenges for the non-ZK oracles.
-	// Routing every non-ZK oracle's batch fold to a *suffix* of the inner challenges makes the
-	// inner challenges consistent across a heterogeneous batch (γ folds the ZK oracles' single
-	// mask round at the prefix; the non-ZK oracles share the suffix).
-	let n_inner = resolved
-		.iter()
-		.filter(|(_, _, is_zk)| !is_zk)
-		.map(|(_, log_batch_size, _)| *log_batch_size)
-		.max()
-		.unwrap_or(0);
-	let max_zk_batch = resolved
-		.iter()
-		.filter(|(_, _, is_zk)| *is_zk)
-		.map(|(_, log_batch_size, _)| *log_batch_size)
-		.max()
-		.unwrap_or(0);
-	let n_batch_challenges = n_inner + max_zk_batch;
-
+	// ZK-aware early/later batch-fold routing. A ZK oracle's batch is the shared masking challenge
+	// γ, sampled *before* the outer (oracle-combine) challenges, so it is entirely "early". A
+	// non-ZK oracle's flexible batch is sampled *after* the outer challenges, so it is entirely
+	// "later". The first-fold challenge slice is therefore `[early ++ outer ++ later]`, and each
+	// oracle folds its interleaving with a suffix of whichever group it belongs to.
 	let oracle_specs = resolved
 		.iter()
 		.map(|&(committed_log_msg_len, log_batch_size, is_zk)| {
-			let skip_batch_challenges = if is_zk {
-				0
-			} else {
-				n_batch_challenges - log_batch_size
-			};
+			let log_early_batch_size = if is_zk { log_batch_size } else { 0 };
+			let log_later_batch_size = if is_zk { 0 } else { log_batch_size };
 			// The committed codeword's own dimension is `committed_log_msg_len - log_batch_size`;
 			// it is lifted to the reduced dimension, so `log_lift` is the gap between the two.
 			let oracle_log_dim = committed_log_msg_len - log_batch_size;
 			let log_lift = reduced_log_dim - oracle_log_dim;
 			CodewordSpec {
 				log_lift,
-				log_batch_size,
-				skip_batch_challenges,
+				log_early_batch_size,
+				log_later_batch_size,
 			}
 		})
 		.collect();
@@ -967,19 +972,19 @@ mod tests {
 			// The committed codeword (dimension `committed_log_msg_len - log_batch_size`) is lifted
 			// to the reduced dimension, recovering the committed message length.
 			let oracle_log_dim = reduced_log_dim - spec.log_lift;
-			assert_eq!(oracle_log_dim + spec.log_batch_size, committed_log_msg_len);
+			assert_eq!(oracle_log_dim + spec.log_batch_size(), committed_log_msg_len);
 			if oracle.is_zk {
 				// ZK oracles keep their fixed batch size of 1.
-				assert_eq!(spec.log_batch_size, 1);
+				assert_eq!(spec.log_batch_size(), 1);
 			}
 			// log_batch_size <= committed message length
-			assert!(spec.log_batch_size <= committed_log_msg_len);
+			assert!(spec.log_batch_size() <= committed_log_msg_len);
 		}
 
 		// The largest input oracle is the non-ZK flexible one, so its batch size folds it down
 		// exactly to the reduced dimension (no lifting).
 		assert_eq!(fri_params.input_oracles[2].log_lift, 0);
-		assert_eq!(fri_params.input_oracles[2].log_batch_size, 16 - reduced_log_dim);
+		assert_eq!(fri_params.input_oracles[2].log_batch_size(), 16 - reduced_log_dim);
 
 		// Pin the estimated proof size to detect unintended changes in the optimizer.
 		assert_eq!(proof_size, 229376);

--- a/crates/iop/src/fri/verify.rs
+++ b/crates/iop/src/fri/verify.rs
@@ -9,7 +9,7 @@ use binius_transcript::{
 	TranscriptReader, VerifierTranscript,
 	fiat_shamir::{CanSampleBits, Challenger},
 };
-use binius_utils::DeserializeBytes;
+use binius_utils::{DeserializeBytes, checked_arithmetics::log2_ceil_usize};
 use bytes::Buf;
 
 use super::{
@@ -118,18 +118,28 @@ where
 		// The committed codeword's Merkle tree has one coset per leaf, so its depth is the number
 		// of index bits.
 		let index_bits = params.index_bits();
-		// The first fold consumes `log_batch_size()` challenges, split into the inner challenges
-		// (folding each input oracle's interleaving) and the outer challenges (batching the oracles
-		// together). Oracle `i` folds its interleaved batch with the inner-challenge window
-		// `inner[skip_batch_challenges_i .. skip_batch_challenges_i + log_batch_size_i]`.
-		let max_inner_challenges = params
+		// The first fold consumes `log_batch_size()` challenges, ordered `[early ++ outer ++
+		// later]`: `max_early` early within-oracle batch challenges, then `log_n_oracles` outer
+		// challenges (batching the oracles together), then `max_later` later within-oracle batch
+		// challenges. Oracle `i` folds its interleaving with `early_window ++ later_window`, the
+		// suffixes of the early and later groups of lengths `log_early_batch_size_i` and
+		// `log_later_batch_size_i`.
+		let max_early = params
 			.input_oracles()
 			.iter()
-			.map(|spec| spec.skip_batch_challenges + spec.log_batch_size)
+			.map(|spec| spec.log_early_batch_size)
 			.max()
 			.expect("input_oracles is non-empty as an invariant");
-		let inner_challenges = &challenges[..max_inner_challenges];
-		let outer_challenges = challenges[max_inner_challenges..params.log_batch_size()].to_vec();
+		let max_later = params
+			.input_oracles()
+			.iter()
+			.map(|spec| spec.log_later_batch_size)
+			.max()
+			.expect("input_oracles is non-empty as an invariant");
+		let log_n_oracles = log2_ceil_usize(params.input_oracles().len());
+		let early_challenges = &challenges[..max_early];
+		let outer_challenges = challenges[max_early..max_early + log_n_oracles].to_vec();
+		let later_challenges = &challenges[max_early + log_n_oracles..params.log_batch_size()];
 		let codeword_sub_oracles = iter::zip(codeword_commitments, params.input_oracles())
 			.map(|(commitment, spec)| {
 				// The oracle's own codeword has dimension `log_dim - log_lift`, so its Merkle tree
@@ -138,9 +148,12 @@ where
 				let oracle_log_dim = log_dim - spec.log_lift;
 				let depth = oracle_log_dim + log_inv_rate;
 				let log_lift = spec.log_lift;
-				let inner_start = spec.skip_batch_challenges;
+				let early_window = &early_challenges[max_early - spec.log_early_batch_size..];
+				let later_window = &later_challenges[max_later - spec.log_later_batch_size..];
+				let fold_challenges: Vec<F> =
+					early_window.iter().chain(later_window).copied().collect();
 				BrakedownOracle::new(
-					inner_challenges[inner_start..inner_start + spec.log_batch_size].to_vec(),
+					fold_challenges,
 					Commitment {
 						root: commitment.clone(),
 						depth,


### PR DESCRIPTION
Closes [BINIUS-157](https://linear.app/jimpo/issue/BINIUS-157/rework-fri-and-basefold-challenge-order).

Normalizes the FRI first-fold challenge order so the verifier samples challenges in the same order the FRI folder processes them, reverting the `c2e2aa4a` BaseFold reordering workaround from #1586. (Discussed the design on the Linear issue — option A: all folding stays in `BatchBrakedownFolder`, no query/decommit-path change.)

### What changes

The first-fold challenge slice goes from `[early ++ later ++ outer]` to the natural **`[early ++ outer ++ later]`** — only the `outer` (oracle-combine) block moves from the end to the middle; the total challenge count and `max_log_msg_len` are unchanged:

1. **Early** — the ZK masking batch challenge γ (0 or 1).
2. **Outer** — the oracle-combine challenges `r'` (`log_n_oracles`).
3. **Later** — the non-ZK oracles' within-oracle batch folds.
4. FRI reduction rounds.

- **`CodewordSpec`** (`iop/src/fri/common.rs`): replaces `skip_batch_challenges` with `log_early_batch_size` + `log_later_batch_size` (+ a `log_batch_size()` method = early+later). `choose_codeword_specs_for_oracles` routes each ZK oracle's fixed batch (=1) to **early** and each non-ZK oracle's flexible batch to **later**; an oracle whose `log_later_batch_size` is below `max_later` takes the **suffix** of the later challenges.
- **`BatchBrakedownFolder::fold`** (prover) and **`FRIQueryVerifier::new_batch`** (verifier) slice `[early, outer, later]` with identical logic and fold each oracle's interleaving with `early_window ++ later_window` (each the suffix of its group). All folding stays in the FRI folder — no change to the committed-codeword length or the query/decommit path.
- **BaseFold revert** (`iop-prover/src/basefold.rs`, `iop/src/basefold.rs`, `iop-prover/src/basefold_zk_channel.rs`): with FRI now processing the natural order, the prover/verifier feed `γ → outer → MLE rounds` straight through again — dropping the `reduced_log_dim` parameter and the `n_leading` delayed-outer-feed gymnastics `c2e2aa4a` added.

Pre-first-reduction reorder, so not a soundness change — purely normalizes the sampling/processing order.

### Verification

`cargo test -p binius-iop -p binius-iop-prover` — 40 passed, **0 ignored** (the three heterogeneous mixed/zero-ZK `basefold_zk_channel` tests now run in their natural form), clippy `-D warnings` clean, fmt clean, full `cargo build --workspace`. The `test_optimal_for_batch` proof-size pin is unchanged — only challenge *ordering* moved, confirming the lift/arity selection math is byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)