### PR TITLE
BINIUS-160: index gate-fusion per-edge state by edge id

### DIFF
--- a/crates/frontend/src/compiler/gate_fusion/commit_set.rs
+++ b/crates/frontend/src/compiler/gate_fusion/commit_set.rs
@@ -3,10 +3,8 @@ use std::iter;
 
 use petgraph::{
 	Direction,
-	graph::EdgeIndex,
 	visit::{DfsPostOrder, EdgeRef},
 };
-use rustc_hash::FxHashMap;
 
 use super::{LeGraph, Stat};
 use crate::compiler::constraint_builder::Shift;
@@ -80,8 +78,15 @@ impl CommitSetCx {
 /// Note that this is all-or-nothing decision: if at least one user cannot inline an expression
 /// then no users should inline it.
 pub fn run_decide_commit_set(leg: &mut LeGraph, stat: &mut Stat) {
-	let mut per_edge: FxHashMap<EdgeIndex, CommitSetCx> = FxHashMap::default();
-	per_edge.reserve(leg.pg.edge_count());
+	// Context carried for each graph edge during the commit-set decision.
+	//
+	// Edge identifiers are dense integers from zero up to the edge count.
+	// A slot in a vector therefore addresses each edge directly, without hashing.
+	//
+	// Invariant: no edge is added or removed during this pass.
+	// So an edge identifier stays a valid index for the whole traversal.
+	let mut per_edge: Vec<Option<CommitSetCx>> = Vec::new();
+	per_edge.resize_with(leg.pg.edge_count(), || None);
 
 	// Iterate the graph in the postorder. That is, we iterate the producers before their consumers.
 	// IOW, when visiting a node all of its children have been already visited.
@@ -112,7 +117,7 @@ pub fn run_decide_commit_set(leg: &mut LeGraph, stat: &mut Stat) {
 				// Just create a new context for each root node with the seed shift.
 				for in_edge in leg.pg.edges_directed(node, Direction::Incoming) {
 					let shift = in_edge.weight().shift;
-					per_edge.insert(in_edge.id(), CommitSetCx::new(shift));
+					per_edge[in_edge.id().index()] = Some(CommitSetCx::new(shift));
 				}
 				continue;
 			}
@@ -132,7 +137,9 @@ pub fn run_decide_commit_set(leg: &mut LeGraph, stat: &mut Stat) {
 			let mut depth = 0;
 
 			'out: for out_edge in outcoming.clone() {
-				let out_edge_cx = &per_edge[&out_edge.id()];
+				let out_edge_cx = per_edge[out_edge.id().index()]
+					.as_ref()
+					.expect("consumer edge context is set before the producer is visited");
 				depth = out_edge_cx.depth.max(depth);
 				for in_edge in incoming.clone() {
 					let in_shift = in_edge.weight().shift;
@@ -150,7 +157,7 @@ pub fn run_decide_commit_set(leg: &mut LeGraph, stat: &mut Stat) {
 				// current shift.
 				for in_edge in incoming {
 					let in_shift = in_edge.weight().shift;
-					per_edge.insert(in_edge.id(), CommitSetCx::new(in_shift));
+					per_edge[in_edge.id().index()] = Some(CommitSetCx::new(in_shift));
 				}
 
 				// Insert into the committed set verifying that this wire was not inserted before.
@@ -168,10 +175,14 @@ pub fn run_decide_commit_set(leg: &mut LeGraph, stat: &mut Stat) {
 				//
 				// TODO: note that we've already visited every child, so we could free up memory
 				// required for their context.
-				let join_cx = CommitSetCx::join(outcoming.map(|edge| &per_edge[&edge.id()]));
+				let join_cx = CommitSetCx::join(outcoming.map(|edge| {
+					per_edge[edge.id().index()]
+						.as_ref()
+						.expect("consumer edge context is set before the producer is visited")
+				}));
 				for in_edge in incoming {
 					let in_shift = in_edge.weight().shift;
-					per_edge.insert(in_edge.id(), join_cx.add(in_shift));
+					per_edge[in_edge.id().index()] = Some(join_cx.add(in_shift));
 				}
 			}
 


### PR DESCRIPTION
Closes [BINIUS-160](https://linear.app/jimpo/issue/BINIUS-160).

Replaces the per-edge hash map in gate fusion's commit-set decision with a vector indexed by the edge identifier.
Pure data-structure swap inside the optimizer — the emitted constraint system is bit-identical.

### The problem

Gate fusion is the most expensive pass in circuit `build()`.

Its commit-set decision carries one small context object per graph edge in a side table.

That side table was a hash map keyed by the edge identifier.

But edge identifiers are already dense integers from zero up to the edge count.

So every read and write hashed an integer that was already a perfect array index.

Edge count scales with the number of XOR terms — millions on a hash-heavy circuit — and this table is touched in the innermost loop of the pass.

### The idea

Address the per-edge context directly by edge identifier.

A vector sized to the edge count gives O(1) access with no hashing and better locality.

The table is only ever read and written by edge identifier, never iterated, so ordering never mattered and the decision logic is untouched.

### The change

```
- per_edge: hash map keyed by edge identifier
+ per_edge: vector indexed by edge identifier (sized to edge count)

- read:  per_edge[&edge.id()]
+ read:  per_edge[edge.id().index()] (checked; present by traversal order)
```

### Soundness

- The set of committed wires is unchanged, so the emitted AND/MUL constraints are identical.
- No protocol surface, no witness, no transcript is affected.
- Consumer-edge reads are guaranteed present: post-order visits every consumer before its producer.

### Scope

- **changed:** one function in `crates/frontend/src/compiler/gate_fusion/commit_set.rs`
- **removed:** two now-unused imports (the hash map type and the edge-index type)
- nothing else touched

### Verification

- `cargo check --workspace --all-targets`, `clippy -p binius-frontend --all-targets`, nightly `fmt --all` — clean
- `cargo test -p binius-frontend` — 150 tests pass, including the 80 gate-fusion decision tests that pin exact commit choices and operand expansions
- byte-identical output confirmed by a structural digest over every emitted constraint operand (see below)

### Benchmark

XMSS / hashsign, 4 validators, tree height 13 — ~1.8M AND constraints, 7 iterations timing `build()` only.

| metric | before (main) | after | result |
|---|---|---|---|
| and_constraints | 1,806,896 | 1,806,896 | identical |
| cs_digest | 0x07e2aaa8399e3886 | 0x07e2aaa8399e3886 | identical |
| build() min | 4.145 s | 3.067 s | 1.35x |
| build() median | 4.803 s | 3.388 s | 1.42x |

The digest match proves the constraint system is unchanged; build() median drops ~29%, and fusion is only part of build() so the pass itself sped up by more.

### Reproducing the benchmark

The harness is not committed. Drop it at `crates/examples/examples/bench_build_xmss.rs`, then run it on `main` and on this branch:

```
cargo run --release --example bench_build_xmss
```

It rebuilds the gate graph fresh each iteration and times `build()` only, then prints a structural digest of the resulting constraint system so the two runs can be checked byte-identical. Tunable via env vars: `XMSS_VALS`, `XMSS_TREE_HEIGHT`, `WOTS_SPEC`, `ITERS`.

```rust
// crates/examples/examples/bench_build_xmss.rs
use std::{
    collections::hash_map::DefaultHasher,
    hash::{Hash, Hasher},
    time::{Duration, Instant},
};

use binius_examples::{ExampleCircuit, circuits::hashsign::HashBasedSigExample};
use binius_frontend::CircuitBuilder;

fn main() {
    let params = binius_examples::circuits::hashsign::Params {
        num_validators: std::env::var("XMSS_VALS").ok().and_then(|s| s.parse().ok()).unwrap_or(4),
        tree_height: std::env::var("XMSS_TREE_HEIGHT").ok().and_then(|s| s.parse().ok()).unwrap_or(13),
        spec: std::env::var("WOTS_SPEC").ok().and_then(|s| s.parse().ok()).unwrap_or(2),
    };
    let iters: usize = std::env::var("ITERS").ok().and_then(|s| s.parse().ok()).unwrap_or(7);

    let mut times: Vec<Duration> = Vec::with_capacity(iters);
    let mut digest = 0u64;
    let mut n_and = 0usize;
    let mut n_mul = 0usize;
    let mut vv_len = 0usize;

    for _ in 0..iters {
        // Rebuild the gate graph fresh each iteration; only build() is timed.
        let mut builder = CircuitBuilder::new();
        HashBasedSigExample::build(params.clone(), &mut builder).unwrap();

        let t = Instant::now();
        let circuit = builder.build();
        times.push(t.elapsed());

        let cs = circuit.constraint_system();
        let mut h = DefaultHasher::new();
        for c in &cs.and_constraints {
            c.a.hash(&mut h);
            c.b.hash(&mut h);
            c.c.hash(&mut h);
        }
        for c in &cs.mul_constraints {
            c.a.hash(&mut h);
            c.b.hash(&mut h);
            c.hi.hash(&mut h);
            c.lo.hash(&mut h);
        }
        digest = h.finish();
        n_and = cs.and_constraints.len();
        n_mul = cs.mul_constraints.len();
        vv_len = cs.value_vec_len();
    }

    times.sort_unstable();
    let min = times[0];
    let median = times[times.len() / 2];
    let max = times[times.len() - 1];

    println!("\n==== build() benchmark (XMSS / hashsign) ====");
    println!(
        "params: num_validators={} tree_height={} spec={} | iters={}",
        params.num_validators, params.tree_height, params.spec, iters
    );
    println!("and_constraints = {n_and}");
    println!("mul_constraints = {n_mul}");
    println!("value_vec_len   = {vv_len}");
    println!("cs_digest       = {digest:#018x}");
    println!("build() min     = {min:?}");
    println!("build() median  = {median:?}");
    println!("build() max     = {max:?}");
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
