### PR TITLE
Clean up the AND-check NTT lookup and univariate round

### DIFF
--- a/crates/prover/benches/and_reduction.rs
+++ b/crates/prover/benches/and_reduction.rs
@@ -3,7 +3,7 @@ use std::{iter, iter::repeat_with};
 
 use binius_core::word::Word;
 use binius_field::{
-	Field, PackedAESBinaryField64x8b, Random,
+	Field, Random,
 	linear_transformation::{
 		BytewiseLookupTransformationFactory, LinearTransformationFactory,
 		OutputWrappingTransformationFactory,
@@ -53,13 +53,13 @@ fn bench(c: &mut Criterion) {
 
 	let mut group = c.benchmark_group("evaluate");
 	group.bench_function("NTT lookup precompute", |bench| {
-		bench.iter(|| NTTLookup::<PackedAESBinaryField64x8b>::new(&prover_message_domain));
+		bench.iter(|| NTTLookup::new(&prover_message_domain));
 	});
 
 	group.throughput(Throughput::Elements(1 << log_words));
 	group.bench_function(format!("univariate_round_message 2^{log_words}"), |bench| {
 		bench.iter(|| {
-			univariate_round_message_extension_domain::<B128, PackedAESBinaryField64x8b>(
+			univariate_round_message_extension_domain::<B128>(
 				log_words,
 				&a_words,
 				&b_words,
@@ -70,7 +70,7 @@ fn bench(c: &mut Criterion) {
 		});
 	});
 
-	let urm = univariate_round_message_extension_domain::<B128, PackedAESBinaryField64x8b>(
+	let urm = univariate_round_message_extension_domain::<B128>(
 		log_words,
 		&a_words,
 		&b_words,

--- a/crates/prover/benches/and_reduction.rs
+++ b/crates/prover/benches/and_reduction.rs
@@ -51,8 +51,6 @@ fn bench(c: &mut Criterion) {
 		.reduce_dim(prover_message_domain.dim() - 1)
 		.isomorphic();
 
-	let ntt_lookup = NTTLookup::<PackedAESBinaryField64x8b>::new(&prover_message_domain);
-
 	let mut group = c.benchmark_group("evaluate");
 	group.bench_function("NTT lookup precompute", |bench| {
 		bench.iter(|| NTTLookup::<PackedAESBinaryField64x8b>::new(&prover_message_domain));
@@ -61,26 +59,24 @@ fn bench(c: &mut Criterion) {
 	group.throughput(Throughput::Elements(1 << log_words));
 	group.bench_function(format!("univariate_round_message 2^{log_words}"), |bench| {
 		bench.iter(|| {
-			let urm: [B128; _] = univariate_round_message_extension_domain(
+			univariate_round_message_extension_domain::<B128, PackedAESBinaryField64x8b>(
 				log_words,
 				&a_words,
 				&b_words,
 				&c_words,
 				&big_field_zerocheck_challenges,
-				&ntt_lookup,
-			);
-
-			urm
+				&prover_message_domain,
+			)
 		});
 	});
 
-	let urm: [B128; _] = univariate_round_message_extension_domain(
+	let urm = univariate_round_message_extension_domain::<B128, PackedAESBinaryField64x8b>(
 		log_words,
 		&a_words,
 		&b_words,
 		&c_words,
 		&big_field_zerocheck_challenges,
-		&ntt_lookup,
+		&prover_message_domain,
 	);
 	let univariate_challenge = B128::random(&mut rng);
 

--- a/crates/prover/src/and_reduction/ntt_lookup.rs
+++ b/crates/prover/src/and_reduction/ntt_lookup.rs
@@ -1,4 +1,6 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
+
 //! # NTT Lookup Table Module
 //!
 //! This module provides a precomputed lookup table implementation for fast Number Theoretic
@@ -35,8 +37,9 @@
 
 use std::{array, marker::PhantomData};
 
+use binius_core::Word;
 use binius_field::{
-	AESTowerField8b as B8, BinaryField, BinaryField1b as B1, Divisible, FieldOps,
+	AESTowerField8b as B8, BinaryField, BinaryField1b as B1, FieldOps,
 	PackedAESBinaryField64x8b as Packed64xB8, PackedField, util::expand_subset_sums_array,
 };
 use binius_math::{
@@ -116,8 +119,10 @@ impl NTTLookup {
 	/// the NTT evaluations at all points in the output domain.
 	#[cfg(test)]
 	#[inline]
-	pub fn ntt<T: Divisible<u8>>(&self, input: T) -> Packed64xB8 {
-		Divisible::value_iter(input)
+	pub fn ntt(&self, input: Word) -> Packed64xB8 {
+		let input_bytes = input.as_u64().to_le_bytes();
+		input_bytes
+			.into_iter()
 			.enumerate()
 			.map(|(b, i)| self.0[b][i as usize])
 			.sum()
@@ -140,14 +145,13 @@ impl NTTLookup {
 	///
 	/// An array of `N` packed field elements containing the NTT evaluations of each input.
 	#[inline]
-	pub fn multi_ntt_array<T: Divisible<u8>, const N: usize>(
-		&self,
-		inputs: [T; N],
-	) -> [Packed64xB8; N] {
+	pub fn multi_ntt_array<const N: usize>(&self, inputs: [Word; N]) -> [Packed64xB8; N] {
+		let inputs_bytes = inputs.map(|input| input.as_u64().to_le_bytes());
+
 		let mut results = [Packed64xB8::zero(); N];
 		for (byte_index, lookup_byte) in self.0.iter().enumerate() {
-			for (result, input) in std::iter::zip(&mut results, &inputs) {
-				let byte = Divisible::<u8>::get(input, byte_index);
+			for (result, input_bytes) in std::iter::zip(&mut results, &inputs_bytes) {
+				let byte = input_bytes[byte_index];
 				*result += lookup_byte[byte as usize];
 			}
 		}
@@ -207,6 +211,7 @@ where
 
 #[cfg(test)]
 mod test {
+	use binius_field::Divisible;
 	use binius_math::BinarySubspace;
 	use rand::prelude::*;
 
@@ -224,7 +229,7 @@ mod test {
 			let input = rng.random::<u64>();
 
 			let lde_result = lde.transform(input);
-			let ntt_lookup_result = ntt_lookup.ntt(input);
+			let ntt_lookup_result = ntt_lookup.ntt(Word(input));
 			for i in 0..ROWS_PER_HYPERCUBE_VERTEX {
 				let lookup_result = ntt_lookup_result.get(i);
 				assert_eq!(lookup_result, lde_result.get(i + ROWS_PER_HYPERCUBE_VERTEX));

--- a/crates/prover/src/and_reduction/ntt_lookup.rs
+++ b/crates/prover/src/and_reduction/ntt_lookup.rs
@@ -36,7 +36,8 @@
 use std::{array, marker::PhantomData};
 
 use binius_field::{
-	BinaryField, BinaryField1b as B1, Divisible, PackedField, util::expand_subset_sums_array,
+	AESTowerField8b as B8, BinaryField, BinaryField1b as B1, Divisible, FieldOps,
+	PackedAESBinaryField64x8b as Packed64xB8, PackedField, util::expand_subset_sums_array,
 };
 use binius_math::{
 	BinarySubspace, FieldBuffer,
@@ -51,49 +52,32 @@ use binius_verifier::protocols::bitand::{ROWS_PER_HYPERCUBE_VERTEX, SKIPPED_VARS
 ///
 /// ## Structure
 ///
-/// The internal data structure is a boxed 3-dimensional array `Box<[[[P; 4]; 256]; 8]>` where:
+/// The internal data structure is a boxed 2-dimensional array `Box<[[Packed64xB8; 256]; 8]>` where:
 /// - **First dimension**: Index of the 8-bit chunk within the 64-bit input (0-7)
 /// - **Second dimension**: The 8-bit value (0-255) representing coefficient combinations
-/// - **Third dimension**: Packed field element index (0-3)
 ///
-/// ## Memory Layout
-///
-/// Packed field indices are placed on the innermost axis so that the 4 packed evaluations
-/// for a given (byte position, byte value) are contiguous in memory. This is the access
-/// pattern of the hot inner loop in `univariate_round_message_extension_domain`.
-///
-/// ## Type Parameters
-///
-/// - `P`: The packed field type used for storing precomputed values. Must implement `PackedField`
-///   with a scalar type that is a binary field.
+/// Each entry holds the `ROWS_PER_HYPERCUBE_VERTEX` NTT evaluations of that byte's coefficients at
+/// the corresponding byte position, packed into a single [`Packed64xB8`].
 #[derive(Debug, Clone)]
-pub struct NTTLookup<P>(Box<[[P; 256]; 8]>);
+pub struct NTTLookup(Box<[[Packed64xB8; 256]; 8]>);
 
-impl<F, PNTTDomain> NTTLookup<PNTTDomain>
-where
-	F: BinaryField,
-	PNTTDomain: PackedField<Scalar = F>,
-{
+impl NTTLookup {
 	/// Creates a new NTT lookup table by precomputing all possible NTT evaluations
 	/// for 8-bit input chunks across all byte positions in a 64-bit word.
 	///
 	/// ## Parameters
 	///
-	/// - `ntt_input_domain`: Binary subspace defining the input domain for the NTT. Must have
-	///   dimension `SKIPPED_VARS` (6 bits).
-	/// - `ntt_output_domain`: Array of field elements where the NTT will be evaluated. Must have
-	///   length `ROWS_PER_HYPERCUBE_VERTEX` (64 elements).
+	/// - `subspace`: Binary subspace of dimension `SKIPPED_VARS + 1`. Its lower half defines the
+	///   NTT input domain and its upper half the output domain at which evaluations are
+	///   precomputed.
 	///
 	/// ## Constraints
 	///
-	/// - `PNTTDomain::WIDTH` must equal 16 (packed field constraint)
-	/// - Input domain dimension must equal `SKIPPED_VARS` (6)
-	/// - Output domain length must equal `ROWS_PER_HYPERCUBE_VERTEX` (64)
-	pub fn new(subspace: &BinarySubspace<F>) -> Self {
-		assert_eq!(PNTTDomain::WIDTH, ROWS_PER_HYPERCUBE_VERTEX);
+	/// - Subspace dimension must equal `SKIPPED_VARS + 1`
+	pub fn new(subspace: &BinarySubspace<B8>) -> Self {
 		assert_eq!(subspace.dim(), SKIPPED_VARS + 1);
 
-		let lde = LowDegreeExtension::new(subspace);
+		let lde = LowDegreeExtension::<Packed64xB8>::new(subspace);
 		let lde_mat = array::from_fn::<_, { ROWS_PER_HYPERCUBE_VERTEX / 8 }, _>(|b| {
 			array::from_fn::<_, 8, _>(|i| {
 				let output = lde.transform(1 << (8 * b + i));
@@ -132,7 +116,7 @@ where
 	/// the NTT evaluations at all points in the output domain.
 	#[cfg(test)]
 	#[inline]
-	pub fn ntt<T: Divisible<u8>>(&self, input: T) -> PNTTDomain {
+	pub fn ntt<T: Divisible<u8>>(&self, input: T) -> Packed64xB8 {
 		Divisible::value_iter(input)
 			.enumerate()
 			.map(|(b, i)| self.0[b][i as usize])
@@ -159,8 +143,8 @@ where
 	pub fn multi_ntt_array<T: Divisible<u8>, const N: usize>(
 		&self,
 		inputs: [T; N],
-	) -> [PNTTDomain; N] {
-		let mut results = [PNTTDomain::zero(); N];
+	) -> [Packed64xB8; N] {
+		let mut results = [Packed64xB8::zero(); N];
 		for (byte_index, lookup_byte) in self.0.iter().enumerate() {
 			for (result, input) in std::iter::zip(&mut results, &inputs) {
 				let byte = Divisible::<u8>::get(input, byte_index);
@@ -223,7 +207,6 @@ where
 
 #[cfg(test)]
 mod test {
-	use binius_field::{AESTowerField8b, PackedAESBinaryField64x8b};
 	use binius_math::BinarySubspace;
 	use rand::prelude::*;
 
@@ -232,8 +215,8 @@ mod test {
 	#[test]
 	fn test_against_ntt() {
 		let subspace = BinarySubspace::with_dim(SKIPPED_VARS + 1);
-		let lde = LowDegreeExtension::<AESTowerField8b>::new(&subspace);
-		let ntt_lookup = NTTLookup::<PackedAESBinaryField64x8b>::new(&subspace);
+		let lde = LowDegreeExtension::<B8>::new(&subspace);
+		let ntt_lookup = NTTLookup::new(&subspace);
 
 		// Repeat for 10 random values
 		let mut rng = StdRng::seed_from_u64(0);

--- a/crates/prover/src/and_reduction/prover.rs
+++ b/crates/prover/src/and_reduction/prover.rs
@@ -21,7 +21,6 @@ use binius_verifier::{
 
 use super::sumcheck_round_messages;
 use crate::{
-	and_reduction::ntt_lookup::NTTLookup,
 	fold_word::fold_words_with_transform,
 	protocols::sumcheck::{
 		Error, ProveSingleOutput, common::MleCheckProver, prove_single_mlecheck,
@@ -86,18 +85,15 @@ where
 		big_field_zerocheck_challenges: Vec<F>,
 		prover_message_domain: BinarySubspace<AESTowerField8b>,
 	) -> Self {
-		let ntt_lookup = tracing::debug_span!("Compute univariate LDE table")
-			.in_scope(|| NTTLookup::<PNTTDomain>::new(&prover_message_domain));
-
 		let univariate_round_message = tracing::debug_span!("Compute univariate round message")
 			.in_scope(|| {
-				sumcheck_round_messages::univariate_round_message_extension_domain(
+				sumcheck_round_messages::univariate_round_message_extension_domain::<F, PNTTDomain>(
 					log_words,
 					&first_col,
 					&second_col,
 					&third_col,
 					&big_field_zerocheck_challenges,
-					&ntt_lookup,
+					&prover_message_domain,
 				)
 			});
 

--- a/crates/prover/src/and_reduction/prover.rs
+++ b/crates/prover/src/and_reduction/prover.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 
 use binius_core::word::Word;
 use binius_field::{
-	AESTowerField8b, BinaryField, PackedField,
+	AESTowerField8b as B8, BinaryField, PackedField,
 	linear_transformation::{
 		BytewiseLookupTransformationFactory, LinearTransformationFactory,
 		OutputWrappingTransformationFactory,
@@ -35,7 +35,7 @@ use crate::{
 /// The type parameter `PChallenge` is the packed field over the challenge field `FChallenge` used
 /// for the multilinear sumcheck rounds that follow the univariate round. Packing these rounds over
 /// a wide field provides SIMD acceleration.
-pub struct OblongZerocheckProver<FChallenge, PNTTDomain, PChallenge>
+pub struct OblongZerocheckProver<FChallenge, PChallenge>
 where
 	FChallenge: BinaryField,
 {
@@ -46,13 +46,12 @@ where
 	big_field_zerocheck_challenges: Vec<FChallenge>,
 	univariate_round_message: [FChallenge; ROWS_PER_HYPERCUBE_VERTEX],
 	univariate_round_message_domain: BinarySubspace<FChallenge>,
-	_marker: PhantomData<(PNTTDomain, PChallenge)>,
+	_marker: PhantomData<PChallenge>,
 }
 
-impl<F, PNTTDomain, PChallenge> OblongZerocheckProver<F, PNTTDomain, PChallenge>
+impl<F, PChallenge> OblongZerocheckProver<F, PChallenge>
 where
-	F: BinaryField + From<AESTowerField8b>,
-	PNTTDomain: PackedField<Scalar = AESTowerField8b>,
+	F: BinaryField + From<B8>,
 	PChallenge: PackedField<Scalar = F>,
 {
 	/// Creates a new oblong zerocheck prover for AND constraint reduction.
@@ -83,11 +82,11 @@ where
 		second_col: Vec<Word>,
 		third_col: Vec<Word>,
 		big_field_zerocheck_challenges: Vec<F>,
-		prover_message_domain: BinarySubspace<AESTowerField8b>,
+		prover_message_domain: BinarySubspace<B8>,
 	) -> Self {
 		let univariate_round_message = tracing::debug_span!("Compute univariate round message")
 			.in_scope(|| {
-				sumcheck_round_messages::univariate_round_message_extension_domain::<F, PNTTDomain>(
+				sumcheck_round_messages::univariate_round_message_extension_domain::<F>(
 					log_words,
 					&first_col,
 					&second_col,
@@ -271,7 +270,7 @@ mod test {
 
 	use binius_core::word::Word;
 	use binius_field::{
-		AESTowerField8b, PackedAESBinaryField64x8b,
+		AESTowerField8b,
 		arch::OptimalPackedB128,
 		linear_transformation::{
 			BytewiseLookupTransformationFactory, LinearTransformationFactory,
@@ -322,7 +321,7 @@ mod test {
 		// Prover is instantiated
 		let big_field_zerocheck_challenges = prover_challenger
 			.sample_vec(log_num_rows - PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES.len());
-		let prover = OblongZerocheckProver::<_, PackedAESBinaryField64x8b, OptimalPackedB128>::new(
+		let prover = OblongZerocheckProver::<_, OptimalPackedB128>::new(
 			log_num_rows,
 			first_mlv.clone(),
 			second_mlv.clone(),

--- a/crates/prover/src/and_reduction/sumcheck_round_messages.rs
+++ b/crates/prover/src/and_reduction/sumcheck_round_messages.rs
@@ -8,7 +8,7 @@ use binius_field::{
 	AESTowerField8b as B8, BinaryField, BinaryField1b as B1, ExtensionField, PackedField, WideMul,
 	util::expand_subset_sums_array,
 };
-use binius_math::multilinear::eq::eq_ind_partial_eval;
+use binius_math::{BinarySubspace, multilinear::eq::eq_ind_partial_eval};
 use binius_utils::rayon::prelude::*;
 use binius_verifier::{
 	config::PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES, protocols::bitand::ROWS_PER_HYPERCUBE_VERTEX,
@@ -48,7 +48,8 @@ use super::ntt_lookup::NTTLookup;
 /// * `b_words` - Second multiplicand (b) as a one-bit oblong multilinear polynomial
 /// * `c_words` - Product constraint (c) as a one-bit oblong multilinear polynomial
 /// * `eq_ind_big_field_challenges` - Partial equality indicator evaluations for big field variables
-/// * `ntt_lookup` - NTT lookup tables for efficient low-degree extension of each column
+/// * `prover_message_domain` - The NTT domain subspace (dimension `SKIPPED_VARS + 1`) from which
+///   the low-degree-extension lookup table is built internally
 ///
 /// # Returns
 ///
@@ -67,7 +68,7 @@ pub fn univariate_round_message_extension_domain<F, PNTTDomain>(
 	b_words: &[Word],
 	c_words: &[Word],
 	big_field_challenges: &[F],
-	ntt_lookup: &NTTLookup<PNTTDomain>,
+	prover_message_domain: &BinarySubspace<B8>,
 ) -> [F; ROWS_PER_HYPERCUBE_VERTEX]
 where
 	F: BinaryField + From<B8>,
@@ -88,6 +89,9 @@ where
 	for col in [a_words, b_words, c_words] {
 		assert_eq!(col.len(), 1 << log_words);
 	}
+
+	let ntt_lookup = tracing::debug_span!("Compute univariate LDE table")
+		.in_scope(|| NTTLookup::<PNTTDomain>::new(prover_message_domain));
 
 	let eq_ind_small: [_; 1 << N_FIXED_SMALL_CHALLENGES] =
 		eq_ind_partial_eval::<B8>(&PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES)
@@ -304,19 +308,19 @@ mod test {
 		// Agreed-upon proof parameter
 
 		let prover_message_domain = BinarySubspace::with_dim(SKIPPED_VARS + 1);
-		let ntt_lookup = NTTLookup::<PackedAESBinaryField64x8b>::new(&prover_message_domain);
 
 		let verifier_message_domain = prover_message_domain.isomorphic::<B128>();
 
 		// Prover generates first round message
-		let first_round_message_on_ext_domain = univariate_round_message_extension_domain::<B128, _>(
-			log_num_words,
-			&mlv_1,
-			&mlv_2,
-			&mlv_3,
-			&big_field_zerocheck_challenges,
-			&ntt_lookup,
-		);
+		let first_round_message_on_ext_domain =
+			univariate_round_message_extension_domain::<B128, PackedAESBinaryField64x8b>(
+				log_num_words,
+				&mlv_1,
+				&mlv_2,
+				&mlv_3,
+				&big_field_zerocheck_challenges,
+				&prover_message_domain,
+			);
 
 		let mut first_round_message_coeffs = vec![B128::ZERO; 2 * ROWS_PER_HYPERCUBE_VERTEX];
 

--- a/crates/prover/src/and_reduction/sumcheck_round_messages.rs
+++ b/crates/prover/src/and_reduction/sumcheck_round_messages.rs
@@ -142,12 +142,12 @@ where
 				izip!(a_subchunks, b_subchunks, &outer_weight_mul_maps)
 			{
 				let mut summed_ntt = <Packed64xB8 as WideMul>::Output::default();
-				for (a_i, b_i, inner_weight) in izip!(a_subchunk, b_subchunk, &eq_ind_small) {
-					let c_i = *a_i & *b_i;
+				for (&a_i, &b_i, inner_weight) in izip!(a_subchunk, b_subchunk, &eq_ind_small) {
+					let c_i = a_i & b_i;
 
 					// Compute the low-degree extension of each column via the lookup table.
 					let [first_col_ntt, second_col_ntt, third_col_ntt] =
-						ntt_lookup.multi_ntt_array([a_i.0, b_i.0, c_i.0]);
+						ntt_lookup.multi_ntt_array([a_i, b_i, c_i]);
 
 					// Compute the weighted composition of the LDE values.
 					summed_ntt += Packed64xB8::wide_mul(

--- a/crates/prover/src/and_reduction/sumcheck_round_messages.rs
+++ b/crates/prover/src/and_reduction/sumcheck_round_messages.rs
@@ -5,8 +5,8 @@ use std::{array, borrow::Cow, iter};
 
 use binius_core::word::Word;
 use binius_field::{
-	AESTowerField8b as B8, BinaryField, BinaryField1b as B1, ExtensionField, PackedField, WideMul,
-	util::expand_subset_sums_array,
+	AESTowerField8b as B8, BinaryField, BinaryField1b as B1, ExtensionField,
+	PackedAESBinaryField64x8b as Packed64xB8, PackedField, WideMul, util::expand_subset_sums_array,
 };
 use binius_math::{BinarySubspace, multilinear::eq::eq_ind_partial_eval};
 use binius_utils::rayon::prelude::*;
@@ -60,9 +60,7 @@ use super::ntt_lookup::NTTLookup;
 /// # Type Parameters
 ///
 /// * `F` - The challenge field type (must be a binary field)
-/// * `PNTTDomain` - The packed extension field type for NTT operations (width must equal
-///   `ROWS_PER_HYPERCUBE_VERTEX`)
-pub fn univariate_round_message_extension_domain<F, PNTTDomain>(
+pub fn univariate_round_message_extension_domain<F>(
 	log_words: usize,
 	a_words: &[Word],
 	b_words: &[Word],
@@ -72,14 +70,7 @@ pub fn univariate_round_message_extension_domain<F, PNTTDomain>(
 ) -> [F; ROWS_PER_HYPERCUBE_VERTEX]
 where
 	F: BinaryField + From<B8>,
-	PNTTDomain: PackedField<Scalar = B8>,
 {
-	// This assertion is used as a workaround for Rust's limited support for const-generics,
-	// ideally we would just use PNTTDomain::WIDTH everywhere instead, but since this function only
-	// supports 128b underliers, this is set to a constant. We would need to rethink for support of
-	// multiple underlier sizes
-	assert_eq!(PNTTDomain::WIDTH, ROWS_PER_HYPERCUBE_VERTEX);
-
 	const N_FIXED_SMALL_CHALLENGES: usize = PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES.len();
 	const N_FIXED_LARGE_CHALLENGES: usize = 4;
 
@@ -91,12 +82,12 @@ where
 	}
 
 	let ntt_lookup = tracing::debug_span!("Compute univariate LDE table")
-		.in_scope(|| NTTLookup::<PNTTDomain>::new(prover_message_domain));
+		.in_scope(|| NTTLookup::new(prover_message_domain));
 
 	let eq_ind_small: [_; 1 << N_FIXED_SMALL_CHALLENGES] =
 		eq_ind_partial_eval::<B8>(&PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES)
 			.iter_scalars()
-			.map(PNTTDomain::broadcast)
+			.map(Packed64xB8::broadcast)
 			.collect::<Vec<_>>()
 			.try_into()
 			.expect("PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES.len() == N_FIXED_SMALL_CHALLENGES");
@@ -150,7 +141,7 @@ where
 			for (a_subchunk, b_subchunk, outer_weight) in
 				izip!(a_subchunks, b_subchunks, &outer_weight_mul_maps)
 			{
-				let mut summed_ntt = <PNTTDomain as WideMul>::Output::default();
+				let mut summed_ntt = <Packed64xB8 as WideMul>::Output::default();
 				for (a_i, b_i, inner_weight) in izip!(a_subchunk, b_subchunk, &eq_ind_small) {
 					let c_i = *a_i & *b_i;
 
@@ -159,13 +150,13 @@ where
 						ntt_lookup.multi_ntt_array([a_i.0, b_i.0, c_i.0]);
 
 					// Compute the weighted composition of the LDE values.
-					summed_ntt += PNTTDomain::wide_mul(
+					summed_ntt += Packed64xB8::wide_mul(
 						first_col_ntt * second_col_ntt - third_col_ntt,
 						*inner_weight,
 					);
 				}
 
-				let summed_ntt_reduced = PNTTDomain::reduce(summed_ntt);
+				let summed_ntt_reduced = Packed64xB8::reduce(summed_ntt);
 				for (acc_i, summed_ntt_i) in iter::zip(&mut acc, summed_ntt_reduced.into_iter()) {
 					*acc_i += outer_weight.call(summed_ntt_i);
 				}
@@ -252,7 +243,7 @@ mod test {
 	use std::iter::repeat_with;
 
 	use binius_field::{
-		BinaryField128bGhash as B128, Field, PackedAESBinaryField64x8b, Random,
+		BinaryField128bGhash as B128, Field, Random,
 		linear_transformation::{
 			BytewiseLookupTransformationFactory, LinearTransformationFactory,
 			OutputWrappingTransformationFactory,
@@ -312,15 +303,14 @@ mod test {
 		let verifier_message_domain = prover_message_domain.isomorphic::<B128>();
 
 		// Prover generates first round message
-		let first_round_message_on_ext_domain =
-			univariate_round_message_extension_domain::<B128, PackedAESBinaryField64x8b>(
-				log_num_words,
-				&mlv_1,
-				&mlv_2,
-				&mlv_3,
-				&big_field_zerocheck_challenges,
-				&prover_message_domain,
-			);
+		let first_round_message_on_ext_domain = univariate_round_message_extension_domain::<B128>(
+			log_num_words,
+			&mlv_1,
+			&mlv_2,
+			&mlv_3,
+			&big_field_zerocheck_challenges,
+			&prover_message_domain,
+		);
 
 		let mut first_round_message_coeffs = vec![B128::ZERO; 2 * ROWS_PER_HYPERCUBE_VERTEX];
 

--- a/crates/prover/src/and_reduction/sumcheck_round_messages.rs
+++ b/crates/prover/src/and_reduction/sumcheck_round_messages.rs
@@ -129,29 +129,27 @@ where
 	// Process columns in fixed-length chunks of 8 to assist compiler in loop unrolling.
 	let a_col_chunks = duplicate_to_fixed_chunks::<{ 1 << LOG_CHUNK_SIZE }>(a_words);
 	let b_col_chunks = duplicate_to_fixed_chunks::<{ 1 << LOG_CHUNK_SIZE }>(b_words);
-	let c_col_chunks = duplicate_to_fixed_chunks::<{ 1 << LOG_CHUNK_SIZE }>(c_words);
 
 	// Accumulate resulting polynomial evals by iterating over each hypercube vertex.
-	(a_col_chunks.as_ref(), b_col_chunks.as_ref(), c_col_chunks.as_ref())
+	(a_col_chunks.as_ref(), b_col_chunks.as_ref())
 		.into_par_iter()
-		.map(|(a_chunk, b_chunk, c_chunk)| {
+		.map(|(a_chunk, b_chunk)| {
 			// Reshape the chunk arrays into arrays of arrays
-			let [a_subchunks, b_subchunks, c_subchunks] =
-				[a_chunk, b_chunk, c_chunk].map(|chunk| {
-					bytemuck::must_cast_ref::<
-						[Word; 1 << LOG_CHUNK_SIZE],
-						[[Word; 1 << N_FIXED_SMALL_CHALLENGES]; 1 << N_FIXED_LARGE_CHALLENGES],
-					>(chunk)
-				});
+			let [a_subchunks, b_subchunks] = [a_chunk, b_chunk].map(|chunk| {
+				bytemuck::must_cast_ref::<
+					[Word; 1 << LOG_CHUNK_SIZE],
+					[[Word; 1 << N_FIXED_SMALL_CHALLENGES]; 1 << N_FIXED_LARGE_CHALLENGES],
+				>(chunk)
+			});
 
 			let mut acc = [F::ZERO; ROWS_PER_HYPERCUBE_VERTEX];
-			for (a_subchunk, b_subchunk, c_subchunk, outer_weight) in
-				izip!(a_subchunks, b_subchunks, c_subchunks, &outer_weight_mul_maps)
+			for (a_subchunk, b_subchunk, outer_weight) in
+				izip!(a_subchunks, b_subchunks, &outer_weight_mul_maps)
 			{
 				let mut summed_ntt = <PNTTDomain as WideMul>::Output::default();
-				for (a_i, b_i, c_i, inner_weight) in
-					izip!(a_subchunk, b_subchunk, c_subchunk, &eq_ind_small)
-				{
+				for (a_i, b_i, inner_weight) in izip!(a_subchunk, b_subchunk, &eq_ind_small) {
+					let c_i = *a_i & *b_i;
+
 					// Compute the low-degree extension of each column via the lookup table.
 					let [first_col_ntt, second_col_ntt, third_col_ntt] =
 						ntt_lookup.multi_ntt_array([a_i.0, b_i.0, c_i.0]);

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -6,8 +6,7 @@ use binius_core::{
 	word::Word,
 };
 use binius_field::{
-	AESTowerField8b as B8, BinaryField, ExtensionField, PackedAESBinaryField64x8b, PackedExtension,
-	PackedField,
+	AESTowerField8b as B8, BinaryField, ExtensionField, PackedExtension, PackedField,
 };
 use binius_hash::binary_merkle_tree::HashSuite;
 use binius_iop_prover::{
@@ -446,7 +445,7 @@ where
 		log_constraint_count.saturating_sub(PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES.len());
 	let big_field_zerocheck_challenges = channel.sample_many(n_extra_zerocheck_challenges);
 
-	let prover = OblongZerocheckProver::<_, PackedAESBinaryField64x8b, PChallenge>::new(
+	let prover = OblongZerocheckProver::<_, PChallenge>::new(
 		log_constraint_count,
 		a,
 		b,


### PR DESCRIPTION
A cleanup series for the AND-check NTT lookup table and the univariate round
message that builds on it. No behavioral change to the protocol; this simplifies
the API surface and removes generics/parameters that were never exercised.

## Commits

**`[andcheck] Compute c_i words on the fly instead of loading`**
In `univariate_round_message_extension_domain`, stop materializing and threading
the `c` column through the parallel loop. Since `c = a & b`, compute
`c_i = a_i & b_i` inline in the inner loop instead, dropping the `c_col_chunks`
duplication and the third sub-chunk reshape.

**`Build the NTT lookup table inside univariate_round_message_extension_domain`**
The `NTTLookup` is purely an internal detail of the low-degree extension, but
callers had to construct it and pass it in. Replace the `&NTTLookup` parameter
with the `&BinarySubspace<B8>` it is built from, and construct the lookup inside
the function (under the existing "Compute univariate LDE table" tracing span).
`OblongZerocheckProver::new` and the bench/test call sites are updated; the
standalone "NTT lookup precompute" benchmark still builds the table directly.

**`and_reduction: make NTTLookup concrete, drop the PNTTDomain generic`**
The lookup was only ever instantiated with `PackedAESBinaryField64x8b`, so the
`NTTLookup<P>` type parameter added only turbofish noise. Make it concrete
(`Box<[[Packed64xB8; 256]; 8]>`) and drop `PNTTDomain` from
`univariate_round_message_extension_domain` and
`OblongZerocheckProver<FChallenge, PChallenge>`. Concrete types name the field
types under short aliases (`PackedAESBinaryField64x8b as Packed64xB8`,
`AESTowerField8b as B8`); `Divisible`/`FieldOps` are imported explicitly since
their methods no longer resolve via a `PackedField` bound.

**`Made NTTLookup Word-specific`**
`ntt`/`multi_ntt_array` took a generic `T: Divisible<u8>`, but the only caller
passes `Word`. Specialize to `Word` (splitting via `input.as_u64().to_le_bytes()`),
which drops the `Divisible` dependency from those methods and removes the
per-element `.0` unwrapping at the call site.

## Testing

`cargo build -p binius-prover --tests --benches` is clean on x86_64; the
`and_reduction` unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
