### PR TITLE
Adapt the M4 batch prover/verifier to the unified ZK channel

### DIFF
--- a/crates/m4-prover/Cargo.toml
+++ b/crates/m4-prover/Cargo.toml
@@ -19,6 +19,7 @@ binius-math = { path = "../math" }
 binius-transcript = { path = "../transcript" }
 binius-utils = { path = "../utils" }
 binius-verifier = { path = "../verifier" }
+rand = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }

--- a/crates/m4-prover/src/prove.rs
+++ b/crates/m4-prover/src/prove.rs
@@ -15,6 +15,7 @@ use binius_math::{
 };
 use binius_transcript::{ProverTranscript, fiat_shamir::Challenger};
 use binius_verifier::config::B128;
+use rand::CryptoRng;
 
 use crate::ValueTable;
 
@@ -84,18 +85,21 @@ where
 	/// It does not ring-switch down to the bit witness.
 	/// That step belongs with the later reductions.
 	///
+	/// The `rng` seeds the ZK channel's internal mask generation.
+	///
 	/// # Returns
 	///
 	/// The random point and the evaluation the prover commits to at it.
 	pub fn prove<Challenger_>(
 		&self,
 		table: &ValueTable,
+		rng: impl CryptoRng,
 		transcript: &mut ProverTranscript<Challenger_>,
 	) -> (Vec<B128>, B128)
 	where
 		Challenger_: Challenger,
 	{
-		let mut channel = self.basefold_compiler.create_channel(transcript);
+		let mut channel = self.basefold_compiler.create_channel(transcript, rng);
 
 		// Pack the 2-D table into one multilinear and commit it as the trace oracle.
 		let packed = table.pack::<P>();
@@ -114,7 +118,11 @@ where
 		// Send the claim, then open the commitment to prove it.
 		// The verifier cannot recompute the claim, since the point depends on the commitment.
 		channel.send_one(eval);
+
+		// The ZK channel only queues the relation here.
+		// `finish` runs the single combined FRI opening and writes it to the transcript.
 		channel.prove_oracle_relations([(oracle, packed, eq, eval)]);
+		channel.finish();
 
 		(point, eval)
 	}
@@ -135,6 +143,7 @@ mod tests {
 	use binius_transcript::VerifierTranscript;
 	use binius_verifier::config::StdChallenger;
 	use proptest::prelude::*;
+	use rand::{SeedableRng, rngs::StdRng};
 
 	use super::*;
 
@@ -195,7 +204,8 @@ mod tests {
 
 			// Prover: commit and open on a fresh transcript.
 			let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
-			let (point, eval) = prover.prove(&table, &mut prover_transcript);
+			let rng = StdRng::seed_from_u64(0);
+			let (point, eval) = prover.prove(&table, rng, &mut prover_transcript);
 
 			// Verifier: replay the same transcript and check the opening.
 			let mut verifier_transcript = prover_transcript.into_verifier();
@@ -224,7 +234,8 @@ mod tests {
 
 		// Produce a faithful proof, then collect its bytes.
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
-		let _ = prover.prove(&table, &mut prover_transcript);
+		let rng = StdRng::seed_from_u64(0);
+		let _ = prover.prove(&table, rng, &mut prover_transcript);
 		let mut proof = prover_transcript.finalize();
 
 		// Flip one bit deep in the proof; any change to the committed data must break the opening.

--- a/crates/m4-verifier/src/verify.rs
+++ b/crates/m4-verifier/src/verify.rs
@@ -121,11 +121,15 @@ impl Verifier {
 		// BaseFold reduces to a challenge point `pt`, where this transparent evaluates to eq(point,
 		// pt).
 		let point_at_pt = point.clone();
+
+		// The channel only queues the relation here.
+		// `finish` runs the single combined FRI opening check.
 		channel.verify_oracle_relations([OracleLinearRelation {
 			oracle,
 			transparent: Box::new(move |pt: &[B128]| eq_ind(&point_at_pt, pt)),
 			claim: eval,
 		}])?;
+		channel.finish()?;
 
 		Ok((point, eval))
 	}


### PR DESCRIPTION
Re-wires the M4 batch prover and verifier onto the unified ZK channel API.
Restores a real FRI opening that the previous code silently dropped — no protocol change.

### The problem

The M4 scaffold ([#1593](https://github.com/binius-zk/binius64/pull/1593)) was written against the old BaseFold channel, but it merged on top of the unified ZK channel ([#1612](https://github.com/binius-zk/binius64/pull/1612)).
The channel API changed underneath it in two ways, and the merge did not reconcile them.

1. `create_channel` now takes an `rng` to seed the ZK channel's internal mask generation — this broke compilation.
2. `prove_oracle_relations` / `verify_oracle_relations` now only **queue** the relation; the single combined FRI opening is deferred to a new `finish()` call.

The first is a compile error. The second is worse: it compiled fine after the `rng` fix, the round-trip test passed, yet the opening was never produced or checked.

### Why the missing `finish()` mattered

Without `finish()`, the prover wrote only the Merkle root and the claimed eval — **48 bytes, zero FRI opening data** — and the verifier checked nothing.
Flipping any byte of the proof still verified.

```
before fix:  proof = root (32) + eval (16) = 48 bytes, tamper-proof in the wrong sense
after fix:   proof = ~5.5 KB with the real FRI opening, tampering rejected
```

### The change

```diff
  // prover (m4-prover/src/prove.rs)
- let mut channel = self.basefold_compiler.create_channel(transcript);
+ let mut channel = self.basefold_compiler.create_channel(transcript, rng);
  ...
  channel.prove_oracle_relations([(oracle, packed, eq, eval)]);
+ channel.finish();
```

```diff
  // verifier (m4-verifier/src/verify.rs)
  channel.verify_oracle_relations([ /* ... */ ])?;
+ channel.finish()?;
```

`Prover::prove` now takes `rng: impl CryptoRng` and forwards it, matching the spartan and outer provers.

### Soundness

- The fix restores the intended check; it does not relax one.
- The prover now actually runs the combined FRI opening and writes it to the transcript.
- The verifier now actually checks it via `finish()`.
- Without these calls the opening was vacuous — this closes that gap rather than introducing any new assumption.

### Scope

- **changed:** `Prover::prove` signature + body (`m4-prover`), `Verifier::verify` body (`m4-verifier`).
- **added:** `rand` as a normal dependency of `m4-prover` (it was dev-only; `CryptoRng` is now in the public API).
- left the verifier's non-ZK channel pairing as-is — the round-trip and tamper tests confirm it pairs correctly with the ZK prover channel.

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-m4-prover -p binius-m4-verifier --all-targets` — clean
- `cargo +nightly fmt --all` — clean
- `cargo test -p binius-m4-prover -p binius-m4-verifier` — 14 tests pass, including the round-trip and the `tampered_proof_is_rejected` test (now back to catching `MerkleError(InvalidProof)`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)