### PR TITLE
BINIUS-164: IntMul Phase-5 forward leaf reconstruction

### DIFF
--- a/crates/prover/src/protocols/intmul/prove.rs
+++ b/crates/prover/src/protocols/intmul/prove.rs
@@ -430,17 +430,20 @@ where
 		let selected_c_lo_evals = bivariate_evals.split_off(1 << log_bits);
 		let selected_a_evals = bivariate_evals;
 
-		self.channel.send_many(&selected_a_evals);
-		self.channel.send_many(&selected_c_lo_evals);
-		self.channel.send_many(&selected_c_hi_evals);
-		self.channel.send_many(&b_evals);
-
+		// Recover the raw per-bit evaluations from the leaf selectors and send those (spec Phase
+		// 5). The verifier reconstructs the selectors forward rather than receiving them and
+		// inverting.
 		let [a_evals, c_lo_evals, c_hi_evals] = normalize_a_c_exponent_evals(
 			log_bits,
 			selected_a_evals,
 			selected_c_lo_evals,
 			selected_c_hi_evals,
 		);
+
+		self.channel.send_many(&a_evals);
+		self.channel.send_many(&c_lo_evals);
+		self.channel.send_many(&c_hi_evals);
+		self.channel.send_many(&b_evals);
 
 		let [a_0_eval, b_0_eval, c_lo_0_eval] =
 			lsb_evals.try_into().expect("c_lo_prover_evals.len() == 3");

--- a/crates/verifier/src/protocols/intmul/common.rs
+++ b/crates/verifier/src/protocols/intmul/common.rs
@@ -198,3 +198,56 @@ fn recover_selectors<F: FieldOps>(selecteds: Vec<F>, inv_factors: &[F]) -> Vec<F
 		})
 		.collect()
 }
+
+/// Reconstruct the "selected" leaf evaluations from the raw per-bit evaluations.
+///
+/// This is the forward direction of [`normalize_a_c_exponent_evals`]: given the raw bit
+/// evaluations $a(i, r), c_{\textsf{lo}}(i, r), c_{\textsf{hi}}(i, r)$, it returns the selected
+/// leaf values
+///
+/// * $\textsf{select}(a(i, r), g^{2^i})$,
+/// * $\textsf{select}(c_{\textsf{lo}}(i, r), g^{2^i})$,
+/// * $\textsf{select}(c_{\textsf{hi}}(i, r), g^{2^{i + k}})$,
+///
+/// for $i \in \{0, \ldots, 2^k - 1\}$, where $\textsf{select}(S, V) = S \cdot (V - 1) + 1$.
+///
+/// The verifier reconstructs these forward from the prover's raw evaluations and binds them to the
+/// GKR-verified leaf-product claims, rather than receiving them and inverting. $g$ is a constant
+/// multiplicative generator of the field $F$.
+pub fn reconstruct_selecteds<F, E>(
+	k: usize,
+	a_evals: &[E],
+	c_lo_evals: &[E],
+	c_hi_evals: &[E],
+) -> [Vec<E>; 3]
+where
+	F: Field,
+	E: FieldOps<Scalar = F> + From<F>,
+{
+	assert_eq!(a_evals.len(), 1 << k);
+	assert_eq!(c_lo_evals.len(), 1 << k);
+	assert_eq!(c_hi_evals.len(), 1 << k);
+
+	// powers[j] = g^{2^j}, for j in 0..2^{k+1}.
+	let powers: Vec<E> = iterate(F::MULTIPLICATIVE_GENERATOR, |g| g.square())
+		.take(2 << k)
+		.map(E::from)
+		.collect();
+	let (lo_powers, hi_powers) = powers.split_at(1 << k);
+
+	[
+		apply_selectors(a_evals, lo_powers),
+		apply_selectors(c_lo_evals, lo_powers),
+		apply_selectors(c_hi_evals, hi_powers),
+	]
+}
+
+/// Apply the affine selector `z * (V - 1) + 1` pointwise, given the generator powers `V_i`.
+fn apply_selectors<E: FieldOps>(raw_evals: &[E], powers: &[E]) -> Vec<E> {
+	assert_eq!(raw_evals.len(), powers.len());
+
+	let one = E::one();
+	iter::zip(raw_evals, powers)
+		.map(|(raw, power)| raw.clone() * (power.clone() - one.clone()) + one.clone())
+		.collect()
+}

--- a/crates/verifier/src/protocols/intmul/verify.rs
+++ b/crates/verifier/src/protocols/intmul/verify.rs
@@ -13,7 +13,7 @@ use itertools::{Itertools, chain};
 use super::{
 	common::{
 		IntMulOutput, Phase1Output, Phase2Output, Phase3Output, Phase4Output, frobenius_twist,
-		normalize_a_c_exponent_evals,
+		reconstruct_selecteds,
 	},
 	error::Error,
 };
@@ -276,29 +276,25 @@ where
 	} = batch_verify(n_vars, 3, &evals, channel)?;
 	challenges.reverse();
 
-	// Read the evals of all multilinears.
-	let a_selected_evals = channel.recv_many(1 << log_bits)?;
-	let c_lo_selected_evals = channel.recv_many(1 << log_bits)?;
-	let c_hi_selected_evals = channel.recv_many(1 << log_bits)?;
+	// The prover sends the raw per-bit evaluations of all multilinears; the verifier reconstructs
+	// the leaf selectors forward (rather than receiving selectors and inverting them).
+	let a_evals = channel.recv_many(1 << log_bits)?;
+	let c_lo_evals = channel.recv_many(1 << log_bits)?;
+	let c_hi_evals = channel.recv_many(1 << log_bits)?;
 	let b_evals = channel.recv_many(1 << log_bits)?;
 
-	// Compose the expected evaluation of the batched composition via
-	// the prover's claimed multilinear evals extracted above.
-	// For every pair (p,q) of multilinears, the verifier can be sure that
-	// the MLE of p*q at `a_c_eq_eval` equals the corresponding eval in `evals`.
+	let [a_selected_evals, c_lo_selected_evals, c_hi_selected_evals] =
+		reconstruct_selecteds(log_bits, &a_evals, &c_lo_evals, &c_hi_evals);
+
+	// Compose the expected evaluation of the batched composition via the reconstructed leaf
+	// selectors. For every pair (p,q) of leaf selectors, the verifier checks that the MLE of p*q
+	// at `a_c_eq_eval` equals the corresponding bivariate-product eval in `evals`.
 	let a_c_eq_eval = eq_ind(a_c_eval_point, &challenges);
 	let expected_bivariate_unbatched_evals =
 		chain!(&a_selected_evals, &c_lo_selected_evals, &c_hi_selected_evals)
 			.tuples()
 			.map(|(left, right)| a_c_eq_eval.clone() * left * right)
 			.collect::<Vec<_>>();
-
-	let [a_evals, c_lo_evals, c_hi_evals] = normalize_a_c_exponent_evals(
-		log_bits,
-		a_selected_evals,
-		c_lo_selected_evals,
-		c_hi_selected_evals,
-	);
 
 	// We must check that `a_0 * b_0 = c_lo_0` across all rows, where these represent the least
 	// significant bits of `a_exponents`, `b_exponents`, and `c_lo_exponents` respectively.


### PR DESCRIPTION
Closes [BINIUS-164](https://linear.app/jimpo/issue/BINIUS-164) — first conformance fix under [BINIUS-163](https://linear.app/jimpo/issue/BINIUS-163) (make IntMul match the overhauled `sec:intmul`).

## What

Spec **Phase 5** (leaf reconstruction): the prover sends the raw per-bit evals `a(i,r_x), c_lo(i,r_x), c_hi(i,r_x)` and the verifier **reconstructs the leaf selectors forward** — `sel(z, g^{2^i}) = z·(g^{2^i}−1)+1` — then binds those to the GKR-verified layer-0 product claims.

The code did the opposite: the prover sent the **selector** values and the verifier **inverted** them (`recover_selectors`/`normalize_a_c_exponent_evals`) to recover the raw bits. So the transcript carried selectors, not raw bits, and the binding direction was reversed.

This swaps to the spec direction:
- **verifier** (`verify_phase_5`): reads the raw per-bit evals, reconstructs the selectors via the new `reconstruct_selectors` (forward), binds the reconstructed selectors to the bivariate-product claims, uses the raw bit-0 evals for the wraparound-parity check, and returns the raw evals. No inversion on the verifier.
- **prover** (`phase5`): sends the raw per-bit evals instead of the selectors.
- **common.rs**: adds the forward `reconstruct_selectors`; `normalize_a_c_exponent_evals`/`recover_selectors` stay (now prover-only).

`IntMulOutput` (raw per-bit evals at the shared point) is **unchanged**, so the downstream shift reduction is unaffected — this is a transcript/binding-shape change, not an output change. For an honest prover the output values are identical to before.

Note: the prover still derives the raw evals by inverting its own selector evals (which the GKR already produced) — that's one cheap field inversion per bit, versus re-evaluating the witness bit-columns. The spec-relevant property (transcript carries raw bits; verifier reconstructs forward) is what changed.

## Test

`prove_and_verify` roundtrip passes (it checks both the per-bit output↔witness consistency and prover↔verifier agreement through the new path); `+ fmt + clippy -D warnings` clean on `binius-verifier`/`binius-prover`. No negative test added — none existed, the binding structure/soundness is unchanged, and a byte-level tamper test is awkward against the flat transcript; flagging as a possible follow-up.

This is the first of a sequence (next: BINIUS-165, recombine `b` via `r_I^b`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)