### PR TITLE
Give the M4 prover a non-ZK channel and drop its dead RNG

### DIFF
--- a/crates/iop-prover/src/basefold_compiler.rs
+++ b/crates/iop-prover/src/basefold_compiler.rs
@@ -15,7 +15,7 @@ use binius_iop::{
 use binius_math::ntt::AdditiveNTT;
 use binius_transcript::{ProverTranscript, fiat_shamir::Challenger};
 use binius_utils::SerializeBytes;
-use rand::Rng;
+use rand::{Rng, SeedableRng, rngs::StdRng};
 
 use crate::{basefold_channel::BaseFoldProverChannel, merkle_tree::MerkleTreeProver};
 
@@ -128,5 +128,30 @@ where
 		rng: impl Rng,
 	) -> BaseFoldProverChannel<'a, F, P, NTT, MerkleProver_, Challenger_> {
 		BaseFoldProverChannel::from_compiler(self, transcript, rng)
+	}
+
+	/// Creates a prover channel for a compiler whose oracles are all non-ZK.
+	///
+	/// A mask is drawn from the channel's RNG only when committing a ZK oracle.
+	/// With no ZK oracle the RNG is never read, so its seed cannot affect the proof.
+	/// The seed is therefore fixed, and no randomness needs to be supplied by the caller.
+	///
+	/// # Panics
+	///
+	/// Panics if any configured oracle is ZK.
+	/// A ZK oracle would draw its mask from the fixed seed, which destroys the hiding property.
+	/// So this constructor refuses to build a channel that could mask deterministically.
+	pub fn create_channel_without_zk<'a, Challenger_: Challenger>(
+		&'a self,
+		transcript: &'a mut ProverTranscript<Challenger_>,
+	) -> BaseFoldProverChannel<'a, F, P, NTT, MerkleProver_, Challenger_> {
+		// A ZK oracle masks with the RNG, so a fixed seed here would silently break hiding.
+		assert!(
+			self.oracle_specs().iter().all(|spec| !spec.is_zk),
+			"create_channel_without_zk requires every oracle to be non-ZK"
+		);
+
+		// No mask is ever drawn, so the seed is arbitrary; reuse the seeded-RNG constructor.
+		self.create_channel(transcript, StdRng::seed_from_u64(0))
 	}
 }

--- a/crates/m4-prover/Cargo.toml
+++ b/crates/m4-prover/Cargo.toml
@@ -19,7 +19,6 @@ binius-math = { path = "../math" }
 binius-transcript = { path = "../transcript" }
 binius-utils = { path = "../utils" }
 binius-verifier = { path = "../verifier" }
-rand = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }

--- a/crates/m4-prover/src/prove.rs
+++ b/crates/m4-prover/src/prove.rs
@@ -15,7 +15,6 @@ use binius_math::{
 };
 use binius_transcript::{ProverTranscript, fiat_shamir::Challenger};
 use binius_verifier::config::B128;
-use rand::CryptoRng;
 
 use crate::ValueTable;
 
@@ -85,7 +84,7 @@ where
 	/// It does not ring-switch down to the bit witness.
 	/// That step belongs with the later reductions.
 	///
-	/// The `rng` seeds the ZK channel's internal mask generation.
+	/// The trace oracle is not ZK, so the channel masks nothing and needs no randomness.
 	///
 	/// # Returns
 	///
@@ -93,13 +92,12 @@ where
 	pub fn prove<Challenger_>(
 		&self,
 		table: &ValueTable,
-		rng: impl CryptoRng,
 		transcript: &mut ProverTranscript<Challenger_>,
 	) -> (Vec<B128>, B128)
 	where
 		Challenger_: Challenger,
 	{
-		let mut channel = self.basefold_compiler.create_channel(transcript, rng);
+		let mut channel = self.basefold_compiler.create_channel_without_zk(transcript);
 
 		// Pack the 2-D table into one multilinear and commit it as the trace oracle.
 		let packed = table.pack::<P>();
@@ -143,7 +141,6 @@ mod tests {
 	use binius_transcript::VerifierTranscript;
 	use binius_verifier::config::StdChallenger;
 	use proptest::prelude::*;
-	use rand::{SeedableRng, rngs::StdRng};
 
 	use super::*;
 
@@ -204,8 +201,7 @@ mod tests {
 
 			// Prover: commit and open on a fresh transcript.
 			let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
-			let rng = StdRng::seed_from_u64(0);
-			let (point, eval) = prover.prove(&table, rng, &mut prover_transcript);
+			let (point, eval) = prover.prove(&table, &mut prover_transcript);
 
 			// Verifier: replay the same transcript and check the opening.
 			let mut verifier_transcript = prover_transcript.into_verifier();
@@ -234,8 +230,7 @@ mod tests {
 
 		// Produce a faithful proof, then collect its bytes.
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
-		let rng = StdRng::seed_from_u64(0);
-		let _ = prover.prove(&table, rng, &mut prover_transcript);
+		let _ = prover.prove(&table, &mut prover_transcript);
 		let mut proof = prover_transcript.finalize();
 
 		// Flip one bit deep in the proof; any change to the committed data must break the opening.


### PR DESCRIPTION
@jimpo Let me know what you think about this one? I've tried this after what you proposed in your comment.

Addresses [jimpo's review on #1621](https://github.com/binius-zk/binius64/pull/1621#discussion_r3488672928).

Gives the M4 prover a channel constructor that needs no randomness, and drops the dead RNG from its public API.

### The problem

The M4 batch prover commits a single **non-ZK** trace oracle.

A mask is drawn from the channel's RNG only when committing a ZK oracle.
So in M4 the RNG is never read — yet `Prover::prove` still took `rng: impl CryptoRng` and forwarded it, and `rand` had to be promoted to a normal dependency just to name `CryptoRng` in the signature.

That is a `CryptoRng` in the public API that does nothing.

### The idea

Make the no-ZK case first-class instead of threading an unused RNG.

```rust
// prover compiler (iop-prover)
pub fn create_channel_without_zk(&self, transcript) -> BaseFoldProverChannel {
    // A ZK oracle masks with the RNG, so a fixed seed here would silently break hiding.
    assert!(self.oracle_specs().iter().all(|spec| !spec.is_zk),
            "create_channel_without_zk requires every oracle to be non-ZK");
    // No mask is ever drawn, so the seed is arbitrary; reuse the seeded constructor.
    self.create_channel(transcript, StdRng::seed_from_u64(0))
}
```

The seed is fixed because nothing reads it. The `assert!` guards the one case where a fixed seed would matter.

### Why not `Option<impl Rng>`

The review floated `create_channel(transcript, Option<impl Rng>)`. Two problems:

- `None` can't infer the type parameter, so callers write the `None::<StdRng>` turbofish.
- Worse, `None` **plus a ZK oracle present** silently masks from a default seed — a real loss of hiding, with nothing to catch it.

A named constructor with an assert keeps the RNG out of the no-ZK surface entirely and makes the dangerous case impossible to reach silently. This is the `new` / `with_hasher` split, not an optional argument.

### The change

```diff
  // m4-prover/src/prove.rs
- pub fn prove<Challenger_>(&self, table: &ValueTable, rng: impl CryptoRng, transcript: ..)
+ pub fn prove<Challenger_>(&self, table: &ValueTable, transcript: ..)
- let mut channel = self.basefold_compiler.create_channel(transcript, rng);
+ let mut channel = self.basefold_compiler.create_channel_without_zk(transcript);
```

### Soundness

- No behavior change for any existing caller — `create_channel(transcript, rng)` is untouched, and spartan / the main prover keep passing their real RNG.
- M4 produces the same proof: the trace oracle is non-ZK, so no mask was ever drawn from the old RNG either; the seed cannot affect the transcript.
- The new path is safe by construction, and the assert refuses to build a channel that could mask deterministically.

### Scope

- **new:** `BaseFoldProverCompiler::create_channel_without_zk` (`iop-prover`).
- **changed:** `Prover::prove` signature + body and two tests (`m4-prover`).
- **dependency:** `rand` moves from `[dependencies]` back to `[dev-dependencies]` in `m4-prover` (it was promoted only for `CryptoRng` in the public API).
- left every ZK caller of `create_channel` as-is.

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-iop-prover -p binius-m4-prover -p binius-m4-verifier --all-targets` — clean
- `cargo +nightly fmt --all` — clean
- `cargo test -p binius-m4-prover` (11, incl. `commit_open_round_trips` and `tampered_proof_is_rejected`), `-p binius-m4-verifier` (3), `-p binius-iop-prover` (29) — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
