### PR TITLE
BINIUS-100: rename NumCast to CastFrom and drop its dead bounds

### DIFF
--- a/crates/field/src/arch/aarch64/m128.rs
+++ b/crates/field/src/arch/aarch64/m128.rs
@@ -21,7 +21,7 @@ use super::super::portable::{
 use crate::{
 	BinaryField,
 	underlier::{
-		NumCast, SmallU, UnderlierType,
+		CastFrom, SmallU, UnderlierType,
 		divisible::{Divisible, mapget},
 		impl_divisible_bitmask, impl_divisible_self,
 	},
@@ -735,9 +735,9 @@ impl<Scalar: BinaryField> From<PackedPrimitiveType<M128, Scalar>> for u128 {
 	}
 }
 
-impl<U: NumCast<u128>> NumCast<M128> for U {
-	fn num_cast_from(val: M128) -> Self {
-		Self::num_cast_from(val.into())
+impl<U: CastFrom<u128>> CastFrom<M128> for U {
+	fn cast_from(val: M128) -> Self {
+		Self::cast_from(val.into())
 	}
 }
 

--- a/crates/field/src/arch/portable/m128.rs
+++ b/crates/field/src/arch/portable/m128.rs
@@ -18,7 +18,7 @@ use crate::{
 	BinaryField,
 	arch::portable::packed::PackedPrimitiveType,
 	underlier::{
-		Divisible, NumCast, SmallU, UnderlierType, impl_divisible_bitmask, impl_divisible_memcast,
+		CastFrom, Divisible, SmallU, UnderlierType, impl_divisible_bitmask, impl_divisible_memcast,
 		impl_divisible_self,
 	},
 };
@@ -72,10 +72,10 @@ impl<const N: usize> From<SmallU<N>> for M128 {
 	}
 }
 
-impl<U: NumCast<u128>> NumCast<M128> for U {
+impl<U: CastFrom<u128>> CastFrom<M128> for U {
 	#[inline(always)]
-	fn num_cast_from(val: M128) -> Self {
-		Self::num_cast_from(val.0)
+	fn cast_from(val: M128) -> Self {
+		Self::cast_from(val.0)
 	}
 }
 

--- a/crates/field/src/arch/portable/packed.rs
+++ b/crates/field/src/arch/portable/packed.rs
@@ -30,7 +30,7 @@ use crate::{
 	BinaryField, Divisible, ExtensionField, Field, Maskable, PackedField, WideMul,
 	arithmetic_traits::{InvertOrZero, Square},
 	field::FieldOps,
-	underlier::{NumCast, UnderlierType, WithUnderlier},
+	underlier::{CastFrom, UnderlierType, WithUnderlier},
 };
 
 #[derive(PartialEq, Eq, Clone, Copy, Default, bytemuck::TransparentWrapper)]
@@ -618,14 +618,14 @@ where
 	PT1: PackedField + WithUnderlier,
 	PT2: PackedField<Scalar = PT1::Scalar> + WithUnderlier,
 	PT2::Underlier: From<PT1::Underlier>,
-	PT1::Underlier: NumCast<PT2::Underlier>,
+	PT1::Underlier: CastFrom<PT2::Underlier>,
 {
 	let bigger_lhs = PT2::from_underlier(lhs.to_underlier().into());
 	let bigger_rhs = PT2::from_underlier(rhs.to_underlier().into());
 
 	let bigger_result = bigger_lhs * bigger_rhs;
 
-	PT1::from_underlier(PT1::Underlier::num_cast_from(bigger_result.to_underlier()))
+	PT1::from_underlier(PT1::Underlier::cast_from(bigger_result.to_underlier()))
 }
 
 /// Square `PT1` values by upcasting to wider `PT2` type with the same scalar.
@@ -636,13 +636,13 @@ where
 	PT1: PackedField + WithUnderlier,
 	PT2: PackedField<Scalar = PT1::Scalar> + WithUnderlier,
 	PT2::Underlier: From<PT1::Underlier>,
-	PT1::Underlier: NumCast<PT2::Underlier>,
+	PT1::Underlier: CastFrom<PT2::Underlier>,
 {
 	let bigger_val = PT2::from_underlier(val.to_underlier().into());
 
 	let bigger_result = bigger_val.square();
 
-	PT1::from_underlier(PT1::Underlier::num_cast_from(bigger_result.to_underlier()))
+	PT1::from_underlier(PT1::Underlier::cast_from(bigger_result.to_underlier()))
 }
 
 /// Invert `PT1` values by upcasting to wider `PT2` type with the same scalar.
@@ -653,11 +653,11 @@ where
 	PT1: PackedField + WithUnderlier,
 	PT2: PackedField<Scalar = PT1::Scalar> + WithUnderlier,
 	PT2::Underlier: From<PT1::Underlier>,
-	PT1::Underlier: NumCast<PT2::Underlier>,
+	PT1::Underlier: CastFrom<PT2::Underlier>,
 {
 	let bigger_val = PT2::from_underlier(val.to_underlier().into());
 
 	let bigger_result = bigger_val.invert_or_zero();
 
-	PT1::from_underlier(PT1::Underlier::num_cast_from(bigger_result.to_underlier()))
+	PT1::from_underlier(PT1::Underlier::cast_from(bigger_result.to_underlier()))
 }

--- a/crates/field/src/arch/wasm32/m128.rs
+++ b/crates/field/src/arch/wasm32/m128.rs
@@ -18,7 +18,7 @@ use crate::{
 	BinaryField, Random,
 	arch::portable::{packed::PackedPrimitiveType, packed_arithmetic::interleave_mask_even},
 	underlier::{
-		NumCast, SmallU, U1, U2, U4, UnderlierType, WithUnderlier, impl_divisible_bitmask,
+		CastFrom, SmallU, U1, U2, U4, UnderlierType, WithUnderlier, impl_divisible_bitmask,
 		impl_divisible_memcast,
 	},
 };
@@ -137,10 +137,10 @@ impl<const N: usize> From<SmallU<N>> for M128 {
 	}
 }
 
-impl<U: NumCast<u128>> NumCast<M128> for U {
+impl<U: CastFrom<u128>> CastFrom<M128> for U {
 	#[inline]
-	fn num_cast_from(val: M128) -> Self {
-		Self::num_cast_from(val.into())
+	fn cast_from(val: M128) -> Self {
+		Self::cast_from(val.into())
 	}
 }
 

--- a/crates/field/src/arch/x86_64/m128.rs
+++ b/crates/field/src/arch/x86_64/m128.rs
@@ -23,7 +23,7 @@ use crate::{
 	BinaryField,
 	arch::portable::packed::PackedPrimitiveType,
 	underlier::{
-		Divisible, NumCast, SmallU, SpreadToByte, U2, U4, UnderlierType, impl_divisible_bitmask,
+		CastFrom, Divisible, SmallU, SpreadToByte, U2, U4, UnderlierType, impl_divisible_bitmask,
 		impl_divisible_self, mapget, spread_fallback,
 	},
 };
@@ -134,10 +134,10 @@ impl DeserializeBytes for M128 {
 
 impl_divisible_bitmask!(M128, 1, 2, 4);
 
-impl<U: NumCast<u128>> NumCast<M128> for U {
+impl<U: CastFrom<u128>> CastFrom<M128> for U {
 	#[inline(always)]
-	fn num_cast_from(val: M128) -> Self {
-		Self::num_cast_from(u128::from(val))
+	fn cast_from(val: M128) -> Self {
+		Self::cast_from(u128::from(val))
 	}
 }
 

--- a/crates/field/src/arch/x86_64/m256.rs
+++ b/crates/field/src/arch/x86_64/m256.rs
@@ -21,7 +21,7 @@ use crate::{
 	BinaryField,
 	arch::portable::packed::PackedPrimitiveType,
 	underlier::{
-		Divisible, NumCast, SmallU, U1, U2, U4, UnderlierType, get_block_values, get_spread_bytes,
+		CastFrom, Divisible, SmallU, U1, U2, U4, UnderlierType, get_block_values, get_spread_bytes,
 		impl_divisible_bitmask, mapget, spread_fallback,
 	},
 };
@@ -176,19 +176,19 @@ impl DeserializeBytes for M256 {
 
 impl_divisible_bitmask!(M256, 1, 2, 4);
 
-impl<U: NumCast<u128>> NumCast<M256> for U {
+impl<U: CastFrom<u128>> CastFrom<M256> for U {
 	#[inline(always)]
-	fn num_cast_from(val: M256) -> Self {
+	fn cast_from(val: M256) -> Self {
 		let [low, _high] = val.into();
-		Self::num_cast_from(low)
+		Self::cast_from(low)
 	}
 }
 
-// `M128` is not a `NumCast<u128>` type (so it is not covered by the blanket above), but the GHASH
+// `M128` is not a `CastFrom<u128>` type (so it is not covered by the blanket above), but the GHASH
 // subfield extraction for `GhashSq256b` needs to pull the low 128-bit half out as an `M128`.
-impl NumCast<M256> for M128 {
+impl CastFrom<M256> for M128 {
 	#[inline(always)]
-	fn num_cast_from(val: M256) -> Self {
+	fn cast_from(val: M256) -> Self {
 		let [low, _high]: [u128; 2] = val.into();
 		Self::from(low)
 	}

--- a/crates/field/src/arch/x86_64/m512.rs
+++ b/crates/field/src/arch/x86_64/m512.rs
@@ -21,7 +21,7 @@ use crate::{
 		x86_64::{m128::M128, m256::M256},
 	},
 	underlier::{
-		Divisible, NumCast, SmallU, U1, U2, U4, UnderlierType, get_block_values, get_spread_bytes,
+		CastFrom, Divisible, SmallU, U1, U2, U4, UnderlierType, get_block_values, get_spread_bytes,
 		impl_divisible_bitmask, mapget, spread_fallback,
 	},
 };
@@ -111,10 +111,10 @@ impl From<M512> for __m512i {
 		value.0
 	}
 }
-impl<U: NumCast<u128>> NumCast<M512> for U {
-	fn num_cast_from(val: M512) -> Self {
+impl<U: CastFrom<u128>> CastFrom<M512> for U {
+	fn cast_from(val: M512) -> Self {
 		let [low, _, _, _] = val.into();
-		Self::num_cast_from(low)
+		Self::cast_from(low)
 	}
 }
 

--- a/crates/field/src/binary_field.rs
+++ b/crates/field/src/binary_field.rs
@@ -293,12 +293,12 @@ macro_rules! impl_field_extension {
 
 			#[inline]
 			fn try_from(elem: $name) -> Result<Self, Self::Error> {
-				use $crate::underlier::NumCast;
+				use $crate::underlier::CastFrom;
 
 				if elem.0 >> $subfield_name::N_BITS
 					== <$typ as $crate::underlier::UnderlierType>::ZERO
 				{
-					Ok($subfield_name(<$subfield_typ>::num_cast_from(elem.val())))
+					Ok($subfield_name(<$subfield_typ>::cast_from(elem.val())))
 				} else {
 					Err(())
 				}

--- a/crates/field/src/underlier/scaled.rs
+++ b/crates/field/src/underlier/scaled.rs
@@ -19,7 +19,7 @@ use rand::{
 	distr::{Distribution, StandardUniform},
 };
 
-use super::{Divisible, NumCast, U1, UnderlierType, mapget};
+use super::{CastFrom, Divisible, U1, UnderlierType, mapget};
 use crate::Random;
 
 /// A type that represents N elements of the same underlier type.
@@ -193,32 +193,32 @@ impl<U: UnderlierType + Pod, const N: usize> UnderlierType for ScaledUnderlier<U
 	}
 }
 
-impl<U: UnderlierType, const N: usize> NumCast<ScaledUnderlier<U, N>> for u8
+impl<U: UnderlierType, const N: usize> CastFrom<ScaledUnderlier<U, N>> for u8
 where
-	Self: NumCast<U>,
+	Self: CastFrom<U>,
 {
-	fn num_cast_from(val: ScaledUnderlier<U, N>) -> Self {
-		Self::num_cast_from(val.0[0])
+	fn cast_from(val: ScaledUnderlier<U, N>) -> Self {
+		Self::cast_from(val.0[0])
 	}
 }
 
-impl<U: UnderlierType, const N: usize> NumCast<ScaledUnderlier<U, N>> for U1
+impl<U: UnderlierType, const N: usize> CastFrom<ScaledUnderlier<U, N>> for U1
 where
-	Self: NumCast<U>,
+	Self: CastFrom<U>,
 {
-	fn num_cast_from(val: ScaledUnderlier<U, N>) -> Self {
-		Self::num_cast_from(val.0[0])
+	fn cast_from(val: ScaledUnderlier<U, N>) -> Self {
+		Self::cast_from(val.0[0])
 	}
 }
 
 // `M128` is the `BinaryField128bGhash` subfield underlier; this extracts it from the low limb of a
 // `ScaledUnderlier<M128, _>`-backed extension field (`GhashSq256b` off the AVX2 path).
-impl<U: UnderlierType, const N: usize> NumCast<ScaledUnderlier<U, N>> for crate::arch::M128
+impl<U: UnderlierType, const N: usize> CastFrom<ScaledUnderlier<U, N>> for crate::arch::M128
 where
-	Self: NumCast<U>,
+	Self: CastFrom<U>,
 {
-	fn num_cast_from(val: ScaledUnderlier<U, N>) -> Self {
-		Self::num_cast_from(val.0[0])
+	fn cast_from(val: ScaledUnderlier<U, N>) -> Self {
+		Self::cast_from(val.0[0])
 	}
 }
 

--- a/crates/field/src/underlier/underlier_impls.rs
+++ b/crates/field/src/underlier/underlier_impls.rs
@@ -2,7 +2,7 @@
 
 use super::{
 	small_uint::{U1, U2, U4},
-	underlier_type::{NumCast, UnderlierType},
+	underlier_type::{CastFrom, UnderlierType},
 };
 use crate::arch::{interleave_mask_even, interleave_with_mask};
 
@@ -40,46 +40,46 @@ macro_rules! impl_num_cast {
 	(@pair U2, $bigger:ty) => {impl_num_cast!(@small_u_from_u U2, $bigger);};
 	(@pair U4, $bigger:ty) => {impl_num_cast!(@small_u_from_u U4, $bigger);};
 	(@pair $smaller:ident, $bigger:ident) => {
-		impl NumCast<$bigger> for $smaller {
+		impl CastFrom<$bigger> for $smaller {
 			#[inline(always)]
-			fn num_cast_from(val: $bigger) -> Self {
+			fn cast_from(val: $bigger) -> Self {
 				val as _
 			}
 		}
 
-		impl NumCast<$smaller> for $bigger {
+		impl CastFrom<$smaller> for $bigger {
 			#[inline(always)]
-			fn num_cast_from(val: $smaller) -> Self {
+			fn cast_from(val: $smaller) -> Self {
 				val as _
 			}
 		}
 	};
 	(@small_u_from_small_u $smaller:ty, $bigger:ty) => {
-		impl NumCast<$bigger> for $smaller {
+		impl CastFrom<$bigger> for $smaller {
 			#[inline(always)]
-			fn num_cast_from(val: $bigger) -> Self {
+			fn cast_from(val: $bigger) -> Self {
 				Self::new(val.val()) & Self::ONES
 			}
 		}
 
-		impl NumCast<$smaller> for $bigger {
+		impl CastFrom<$smaller> for $bigger {
 			#[inline(always)]
-			fn num_cast_from(val: $smaller) -> Self {
+			fn cast_from(val: $smaller) -> Self {
 				Self::new(val.val())
 			}
 		}
 	};
 	(@small_u_from_u $smaller:ty, $bigger:ty) => {
-		impl NumCast<$bigger> for $smaller {
+		impl CastFrom<$bigger> for $smaller {
 			#[inline(always)]
-			fn num_cast_from(val: $bigger) -> Self {
+			fn cast_from(val: $bigger) -> Self {
 				Self::new(val as u8) & Self::ONES
 			}
 		}
 
-		impl NumCast<$smaller> for $bigger {
+		impl CastFrom<$smaller> for $bigger {
 			#[inline(always)]
-			fn num_cast_from(val: $smaller) -> Self {
+			fn cast_from(val: $smaller) -> Self {
 				val.val() as _
 			}
 		}

--- a/crates/field/src/underlier/underlier_type.rs
+++ b/crates/field/src/underlier/underlier_type.rs
@@ -215,15 +215,25 @@ pub unsafe trait WithUnderlier:
 	}
 }
 
-/// A trait that represents potentially lossy numeric cast.
-/// Is a drop-in replacement of `as _` in a generic code.
-pub trait NumCast<From> {
-	fn num_cast_from(val: From) -> Self;
+/// A potentially lossy numeric cast, for generic code where the `as _` operator cannot appear.
+///
+/// The low bits of the input are kept.
+/// The remaining high bits are discarded.
+///
+/// [`From`] cannot serve this purpose.
+/// - It is contractually lossless, so it must not express a narrowing cast.
+/// - Its narrowing targets are foreign primitives (`u8` through `u128`).
+/// - The orphan rule forbids adding a `From` impl to a foreign type from this crate.
+///
+/// Hence a crate-local trait.
+pub trait CastFrom<T> {
+	/// Casts the input to this type, keeping its low bits when this type is narrower.
+	fn cast_from(val: T) -> Self;
 }
 
-impl<U: UnderlierType> NumCast<U> for U {
+impl<U: UnderlierType> CastFrom<U> for U {
 	#[inline(always)]
-	fn num_cast_from(val: U) -> Self {
+	fn cast_from(val: U) -> Self {
 		val
 	}
 }

--- a/crates/field/src/underlier/underlier_with_bit_ops.rs
+++ b/crates/field/src/underlier/underlier_with_bit_ops.rs
@@ -1,9 +1,6 @@
 // Copyright 2024-2025 Irreducible Inc.
 
-use super::{
-	U1, U2, U4,
-	underlier_type::{NumCast, UnderlierType},
-};
+use super::{U1, U2, U4, underlier_type::UnderlierType};
 use crate::Divisible;
 
 /// Fallback implementation of `spread` method.
@@ -116,7 +113,7 @@ pub(crate) unsafe fn get_block_values<U, T, const BLOCK_LEN: usize>(
 ) -> [T; BLOCK_LEN]
 where
 	U: UnderlierType + From<T> + Divisible<T>,
-	T: UnderlierType + NumCast<U>,
+	T: UnderlierType,
 {
 	// Safety: `block_idx * BLOCK_LEN + i < U::BITS / T::BITS` by the function preconditions.
 	std::array::from_fn(|i| unsafe {
@@ -136,7 +133,7 @@ pub(crate) unsafe fn get_spread_bytes<U, T, const BLOCK_LEN: usize>(
 ) -> [u8; BLOCK_LEN]
 where
 	U: UnderlierType + From<T> + Divisible<T>,
-	T: UnderlierType + SpreadToByte + NumCast<U>,
+	T: UnderlierType + SpreadToByte,
 {
 	unsafe { get_block_values::<U, T, BLOCK_LEN>(value, block_idx) }
 		.map(SpreadToByte::spread_to_byte)


### PR DESCRIPTION
Closes [BINIUS-100](https://linear.app/jimpo/issue/BINIUS-100).

Resolves the investigation: the lossy-cast trait is load-bearing and stays, but it is cleaned up.
Pure refactor, entirely inside the private `underlier` module — no behavior change.

### The problem

`NumCast<From>` is the field crate's "`as _` for generic code": a deliberately lossy numeric cast.
The investigation asked whether it can be deleted. It cannot — but three things around it were wrong.

- It shared its name with `num_traits::NumCast`, an unrelated trait with `Option`-returning semantics (and `num-traits` is a workspace dependency, so the clash is real, not hypothetical).
- Its type parameter was literally named `From`, shadowing `std::convert::From`.
- Two spread helpers carried a `T: NumCast<U>` bound their bodies never use.

### Why it can't just be removed

The narrowing casts target foreign primitives (`u8` through `u128`).

- `From` is contractually lossless, so it must not model a narrowing cast.
- The orphan rule forbids `impl From<...> for u8` from this crate (both `From` and the target are foreign).

So a crate-local trait is genuinely required — the fix is to make it a *good* local trait.

### The change

Rename the trait and its method, and free the shadowed `From` parameter name:

```diff
-pub trait NumCast<From> {
-    fn num_cast_from(val: From) -> Self;
+pub trait CastFrom<T> {
+    fn cast_from(val: T) -> Self;
 }
```

Drop the dead bounds in the two spread helpers:

```diff
 fn get_block_values<U, T, const BLOCK_LEN: usize>(...)
 where
     U: UnderlierType + From<T> + Divisible<T>,
-    T: UnderlierType + NumCast<U>,
+    T: UnderlierType,
```

The rename is mechanical across the crate: every impl, the `impl_field_extension!` macro, and the `NumCast` bounds in `mul`/`square`/`invert_as_bigger_type`.

### Scope

- **changed:** 12 files, all under `crates/field/src/...` — the trait def, the primitive/scaled impls, the four arch SIMD paths, and the binary-field `TryFrom` macro.
- **removed:** the two dead `NumCast<U>` bounds in the spread helpers and their now-unused import.
- **left untouched:** every conversion's behavior — `cast_from` keeps the low bits and discards the high bits exactly as `num_cast_from` did.
- the trait is unused outside `binius-field` (the `underlier` module is private), so nothing downstream changes.

### Soundness

Not a soundness-bearing change — it is a rename plus a dead-bound removal.
The cast semantics are identical, so every field and packed-field conversion produces the same bits as before.

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-field --all-targets` — clean
- `cargo +nightly fmt --all -- --check` — clean
- `cargo test -p binius-field --lib` — 193 passed
- `cargo check -p binius-field --target x86_64-apple-darwin` — clean (validates the AVX `m256`/`m512` paths not built on the arm host)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
