### PR TITLE
Drop binius-core's duplicate checked_log_2 helper

### DIFF
--- a/crates/core/src/consts.rs
+++ b/crates/core/src/consts.rs
@@ -1,14 +1,7 @@
 // Copyright 2025 Irreducible Inc.
 //! Protocol-level constants for the Binius64 constraint system.
 
-/// Computes the base-2 logarithm of a value, panicking if it's not a power of 2.
-///
-/// We redefine this function here instead of using the one from binius-utils
-/// to avoid bringing in unnecessary dependencies and cruft.
-const fn checked_log_2(val: usize) -> usize {
-	assert!(val.is_power_of_two(), "Value is not a power of 2");
-	val.ilog2() as usize
-}
+use binius_utils::checked_arithmetics::checked_log_2;
 
 /// The protocol proves constraint systems over 64-bit words.
 pub const WORD_SIZE_BYTES: usize = 8;


### PR DESCRIPTION
Pure refactor — no behavior change. Removes a redundant local copy of `checked_log_2` and uses the canonical one from `binius-utils`.

### The problem

`binius-core` defines its own `const fn checked_log_2`, with a comment defending it:

> We redefine this function here instead of using the one from binius-utils to avoid bringing in unnecessary dependencies and cruft.

That justification is false.

- `binius-core` already depends on `binius-utils` (`crates/core/Cargo.toml`).
- It already imports from it — `word.rs` and `constraint_system.rs` both use `binius_utils::serialization::*`.

So there is no dependency being avoided, and the local copy is just a worse duplicate of a function every other crate in the repo (verifier, prover, math, field, spartan-*) already imports from `binius-utils`.

### The change

```diff
-/// Computes the base-2 logarithm of a value, panicking if it's not a power of 2.
-///
-/// We redefine this function here instead of using the one from binius-utils
-/// to avoid bringing in unnecessary dependencies and cruft.
-const fn checked_log_2(val: usize) -> usize {
-	assert!(val.is_power_of_two(), "Value is not a power of 2");
-	val.ilog2() as usize
-}
+use binius_utils::checked_arithmetics::checked_log_2;
```

The canonical version is also slightly better: it is `#[inline]`, `#[must_use]`, and rejects `0` up front (via `strict_log_2`) rather than relying on `0.ilog2()` to panic.

### Soundness

Both `const` evaluations that consume it are unchanged in value:

- `LOG_WORD_SIZE_BITS = checked_log_2(64) = 6`
- `LOG_BYTE_BITS = checked_log_2(8) = 3`

Both functions panic on non-powers-of-two, so the contract at every call site is identical.

### Scope

- **changed:** `crates/core/src/consts.rs` — remove the 8-line local fn, add one `use`.
- nothing else touched; no public API change (the local fn was private).

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-core --all-targets` — clean
- `cargo +nightly fmt --all` — clean
- `cargo test -p binius-core` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)