### PR TITLE
Make Word::sar take self, and mark value methods const

### DIFF
--- a/crates/core/src/word.rs
+++ b/crates/core/src/word.rs
@@ -90,7 +90,7 @@ impl Not for Word {
 
 impl Word {
 	/// Creates a new `Word` from a 64-bit unsigned integer.
-	pub fn from_u64(value: u64) -> Word {
+	pub const fn from_u64(value: u64) -> Word {
 		Word(value)
 	}
 
@@ -178,9 +178,9 @@ impl Word {
 	/// Shift Arithmetic Right by a given number of bits.
 	///
 	/// This is similar to a logical shift right, but it shifts the sign bit to the right.
-	pub fn sar(&self, n: u32) -> Word {
+	pub fn sar(self, n: u32) -> Word {
 		let Word(value) = self;
-		let value = *value as i64;
+		let value = value as i64;
 		let result = value >> n;
 		Word(result as u64)
 	}
@@ -316,7 +316,7 @@ impl Word {
 	}
 
 	/// Returns the integer value as a 64-bit unsigned integer.
-	pub fn as_u64(self) -> u64 {
+	pub const fn as_u64(self) -> u64 {
 		self.0
 	}
 
@@ -326,7 +326,7 @@ impl Word {
 	/// 1. All other bits are ignored for the boolean value.
 	///
 	/// Returns true if the MSB is 1, false otherwise.
-	pub fn is_msb_true(self) -> bool {
+	pub const fn is_msb_true(self) -> bool {
 		(self.0 & 0x8000000000000000) != 0
 	}
 
@@ -336,7 +336,7 @@ impl Word {
 	/// All other bits are ignored for the boolean value.
 	///
 	/// Returns true if the MSB is 0, false otherwise.
-	pub fn is_msb_false(self) -> bool {
+	pub const fn is_msb_false(self) -> bool {
 		(self.0 & 0x8000000000000000) == 0
 	}
 }


### PR DESCRIPTION
Pure refactor — no behavior change. Two small consistency fixes to the `Word` API surface.

### The problem

Two inconsistencies in `Word`'s method surface:

- `sar` takes `&self`, while every sibling (`sll32`, `srl32`, `sra32`, `rotr`, `rotr32`, `shr_32`, ...) takes `self`. `Word` is `Copy` and 8 bytes, so a reference buys nothing — it's just the odd one out.
- `from_u64`, `as_u64`, `is_msb_true`, `is_msb_false` are pure functions of their input with const-capable bodies, but aren't marked `const`, so they can't be used in const contexts (array lengths, other `const` definitions, etc.).

### The change

```diff
-pub fn sar(&self, n: u32) -> Word {
-    let Word(value) = self;
-    let value = *value as i64;
+pub fn sar(self, n: u32) -> Word {
+    let Word(value) = self;
+    let value = value as i64;

-pub fn from_u64(value: u64) -> Word
+pub const fn from_u64(value: u64) -> Word
-pub fn as_u64(self) -> u64
+pub const fn as_u64(self) -> u64
-pub fn is_msb_true(self) -> bool
+pub const fn is_msb_true(self) -> bool
-pub fn is_msb_false(self) -> bool
+pub const fn is_msb_false(self) -> bool
```

### What this is not

- The operator trait impls (`BitAnd`, `BitOr`, `BitXor`, `Shl`, `Shr`, `Not`) are left as-is. A `const fn` inside a *trait impl* still requires the unstable `const_trait_impl` feature, so they cannot be `const` on stable Rust.
- No method renames. The `iadd_cout_32` vs `iadd32_cin_cout` / `shr_32` naming wart is a separate, opinionated call and is deliberately untouched here.

### Soundness

- `sar`: switching `&self` to `self` on a `Copy` type produces the identical value; the body change is just `*value` to `value` (no deref needed once `self` is owned). The sole `Word::sar` caller (`verify.rs`) passes a value, and auto-ref makes the call site identical, so nothing downstream changes.
- `const fn`: marking a function `const` only widens where it may be called; the runtime code path is unchanged.

### Scope

- **changed:** `crates/core/src/word.rs` — one receiver, four `const` markers.
- **call sites:** none touched; `binius-frontend` (the crate that exercises `Word::sar`) still compiles unchanged.
- public API stays source-compatible.

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-core --all-targets` — clean
- `cargo check -p binius-frontend --all-targets` — clean (downstream `sar` user)
- `cargo +nightly fmt --all` — clean
- `cargo test -p binius-core word` — 29 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)