### PR TITLE
BINIUS-167: add Blake3 hash suite

### DIFF
--- a/crates/hash/Cargo.toml
+++ b/crates/hash/Cargo.toml
@@ -14,6 +14,7 @@ binius-field = { path = "../field" }
 binius-math = { path = "../math" }
 binius-transcript = { path = "../transcript" }
 binius-utils = { path = "../utils" }
+blake3 = { workspace = true, features = ["traits-preview"] }
 bytemuck.workspace = true
 bytes.workspace = true
 digest.workspace = true

--- a/crates/hash/src/blake3.rs
+++ b/crates/hash/src/blake3.rs
@@ -1,0 +1,92 @@
+// Copyright 2026 The Binius Developers
+
+//! Blake3 hash and compression functions for use in Merkle tree constructions.
+
+use digest::Output;
+
+use super::{
+	binary_merkle_tree::HashSuite,
+	compress::{CompressionFunction, PseudoCompressionFunction},
+	parallel_compression::ParallelCompressionAdaptor,
+	parallel_digest::ParallelDigestAdapter,
+};
+
+/// A two-to-one compression function that hashes the concatenation of its inputs with Blake3.
+#[derive(Debug, Clone, Default)]
+pub struct Blake3Compression;
+
+impl PseudoCompressionFunction<Output<blake3::Hasher>, 2> for Blake3Compression {
+	fn compress(&self, input: [Output<blake3::Hasher>; 2]) -> Output<blake3::Hasher> {
+		let mut hasher = blake3::Hasher::new();
+		hasher.update(input[0].as_slice());
+		hasher.update(input[1].as_slice());
+		(*hasher.finalize().as_bytes()).into()
+	}
+}
+
+impl CompressionFunction<Output<blake3::Hasher>, 2> for Blake3Compression {}
+
+/// Blake3 [`HashSuite`]: Blake3 leaves and a Blake3 compression function for inner nodes.
+#[derive(Debug, Clone, Default)]
+pub struct Blake3HashSuite;
+
+impl HashSuite for Blake3HashSuite {
+	type LeafHash = blake3::Hasher;
+	type Compression = Blake3Compression;
+	type ParLeafHash = ParallelDigestAdapter<blake3::Hasher>;
+	type ParCompression = ParallelCompressionAdaptor<Blake3Compression>;
+}
+
+#[cfg(test)]
+mod tests {
+	use std::{iter::repeat_with, mem::MaybeUninit};
+
+	use binius_utils::rayon::iter::{IntoParallelRefIterator, ParallelIterator};
+	use rand::{RngExt, SeedableRng, rngs::StdRng};
+
+	use super::*;
+	use crate::ParallelDigest;
+
+	/// Checks that the compression function matches `blake3::hash` of the concatenated inputs.
+	#[test]
+	fn test_blake3_compression_matches_reference() {
+		let mut rng = StdRng::seed_from_u64(0);
+		let left: [u8; 32] = rng.random();
+		let right: [u8; 32] = rng.random();
+
+		let compressed = Blake3Compression.compress([left.into(), right.into()]);
+
+		let mut concatenated = [0u8; 64];
+		concatenated[..32].copy_from_slice(&left);
+		concatenated[32..].copy_from_slice(&right);
+		let expected = blake3::hash(&concatenated);
+
+		assert_eq!(compressed.as_slice(), expected.as_bytes());
+	}
+
+	/// Checks that the parallel leaf digest matches `blake3::hash` over the serialized leaf bytes.
+	#[test]
+	fn test_parallel_blake3_matches_serial() {
+		let mut rng = StdRng::seed_from_u64(0);
+		let n_leaves = 50;
+		// `u128` serializes to 16 little-endian bytes.
+		let leaves: Vec<Vec<u128>> = (0..n_leaves)
+			.map(|_| (0..4).map(|_| rng.random::<u128>()).collect())
+			.collect();
+
+		let digest = <ParallelDigestAdapter<blake3::Hasher> as ParallelDigest>::new();
+		let mut results = repeat_with(MaybeUninit::<Output<blake3::Hasher>>::uninit)
+			.take(n_leaves)
+			.collect::<Vec<_>>();
+		digest.digest(leaves.par_iter().map(|leaf| leaf.iter().copied()), &mut results);
+
+		for (result, leaf) in results.into_iter().zip(&leaves) {
+			let mut bytes = Vec::new();
+			for &item in leaf {
+				bytes.extend_from_slice(&item.to_le_bytes());
+			}
+			let expected = blake3::hash(&bytes);
+			assert_eq!(unsafe { result.assume_init() }.as_slice(), expected.as_bytes());
+		}
+	}
+}

--- a/crates/hash/src/lib.rs
+++ b/crates/hash/src/lib.rs
@@ -8,6 +8,7 @@
 //! such as standard hash functions (SHA-256).
 
 pub mod binary_merkle_tree;
+pub mod blake3;
 pub mod compress;
 pub mod parallel_compression;
 pub mod parallel_digest;


### PR DESCRIPTION
Implements [BINIUS-167](https://linear.app/jimpo/issue/BINIUS-167/blake3-hash-suite-in-binius-hash).

## Summary

Adds `Blake3HashSuite` to `binius-hash`, mirroring `Sha256HashSuite`:

```rust
impl HashSuite for Blake3HashSuite {
    type LeafHash = blake3::Hasher;
    type Compression = Blake3Compression;
    type ParLeafHash = ParallelDigestAdapter<blake3::Hasher>;
    type ParCompression = ParallelCompressionAdaptor<Blake3Compression>;
}
```

- `Blake3Compression` is the Blake3 hash of the two inputs' concatenation (the issue's spec).
- The parallel leaf hash and compression use the generic `ParallelDigestAdapter` / `ParallelCompressionAdaptor`, per the issue.
- `blake3` is a plain (non-optional) dependency of `binius-hash`.

## On the digest wiring

`HashSuite::LeafHash` requires `digest` **0.11**'s `Digest + BlockSizeUser + FixedOutputReset + Send`. The `blake3` crate's RustCrypto integration lives behind its **`traits-preview`** feature, and in blake3 1.8.5 that feature targets `digest` 0.11.2 — the same major version `binius-hash` already uses. So `blake3::Hasher` satisfies the `LeafHash` (and `ParallelDigestAdapter`) bounds directly, and **no newtype wrapper is needed**. The PR enables that feature:

```toml
blake3 = { workspace = true, features = ["traits-preview"] }
```

Flagging the `traits-preview` dependency explicitly in case you'd prefer a hand-written `digest` 0.11 wrapper around `blake3::Hasher` instead — happy to switch, but the feature is the minimal path and keeps us on the upstream impl.

## Testing

- `test_blake3_compression_matches_reference` — the compression function equals `blake3::hash` of the 64-byte concatenation.
- `test_parallel_blake3_matches_serial` — `ParallelDigestAdapter<blake3::Hasher>` matches serial `blake3::hash` over serialized leaf bytes (mirrors the SHA-256 suite test).

`cargo test -p binius-hash`, fmt, clippy, and `cargo doc` are green; `cargo build --locked` confirms no Cargo.lock churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)