### PR TITLE
BINIUS-169: IntMul bind the wraparound-parity zerocheck at r_2

### DIFF
--- a/crates/prover/src/protocols/intmul/prove.rs
+++ b/crates/prover/src/protocols/intmul/prove.rs
@@ -397,13 +397,15 @@ where
 		let b_0: FieldBuffer<P> = two_valued_field_buffer(0, &b_exponents, binary_elements);
 		let c_lo_0: FieldBuffer<P> = two_valued_field_buffer(0, &c_lo_exponents, binary_elements);
 
-		// Make the sumcheck prover for the overflow parity check.
+		// Make the sumcheck prover for the overflow parity check, binding it at the Phase-2
+		// constraint point `b_eval_point` (r_2) per the spec (reused for free from the `b`
+		// re-randomization) rather than the Phase-4 point.
 		let overflow_prover =
 			MleToSumCheckDecorator::new(QuadraticMleCheckProver::<P, _, _, 3>::new(
 				[a_0, b_0, c_lo_0],
 				|[a, b, c]| a * b - c,
 				|[a, b, _c]| a * b,
-				a_c_eval_point.to_vec(),
+				b_eval_point.to_vec(),
 				F::ZERO,
 			)?);
 

--- a/crates/verifier/src/protocols/intmul/verify.rs
+++ b/crates/verifier/src/protocols/intmul/verify.rs
@@ -314,15 +314,16 @@ where
 	// This check catches the attack: if `c = 2^128-1` then `c_lo_0 = 1` (since 2^128-1 is odd),
 	// but `a_0 * b_0 = 0` when `a=0` or `b=0`, so the check `a_0 * b_0 = c_lo_0` fails.
 	//
-	// Implementation: We must perform a zerocheck on `a_0 * b_0 - c_lo_0 = 0`. We can reuse
-	// `a_c_eval_point` as our zerocheck challenge.
+	// Implementation: We must perform a zerocheck on `a_0 * b_0 - c_lo_0 = 0`. We reuse the
+	// Phase-2 constraint point `b_eval_point` (r_2) as the zerocheck challenge — available for
+	// free because the `b` re-randomization already evaluates at r_2.
+	let b_eq_eval = eq_ind(b_eval_point, &challenges);
 	let expected_overflow_eval =
-		a_c_eq_eval.clone() * (a_evals[0].clone() * &b_evals[0] - &c_lo_evals[0]);
+		b_eq_eval.clone() * (a_evals[0].clone() * &b_evals[0] - &c_lo_evals[0]);
 
 	// Bind the prover's raw per-bit evals to the single recombined rerandomization claim:
 	// b(r_I^b, r_x) = sum_i eq(r_I^b, i) * b(i, r_x).
 	let b_at_rx = evaluate_inplace_scalars(b_evals.clone(), r_ib);
-	let b_eq_eval = eq_ind(b_eval_point, &challenges);
 	let expected_b_rerand_eval = b_eq_eval * &b_at_rx;
 
 	let expected_unbatched_evals = [


### PR DESCRIPTION
Closes [BINIUS-169](https://linear.app/jimpo/issue/BINIUS-169) — audit divergence **D-V5** under [BINIUS-163](https://linear.app/jimpo/issue/BINIUS-163) (conform IntMul to `sec:intmul`). First of the D-V3/4/5 trio jimpo greenlit.

## What

The spec's Phase-4 wraparound-parity zerocheck

> `Σ_x eq_{ℓmul}(r_2, x)·[ ã(0,x)·b̃(0,x) − c̃_lo(0,x) ] = 0`

binds at the **Phase-2 constraint point `r_2`**, "available for free because the `b` re-randomization already evaluates at constraint `r_2`." The code instead bound it at the Phase-4 point (`a_c_eval_point` = r_3). Soundness-equivalent (both are random zerocheck challenges), but not spec-literal, and it conceptually carries r_3 where r_2 suffices.

This switches the parity zerocheck's eq point from r_3 to `b_eval_point` (= r_2):
- **verifier** (`verify_phase_5`): the overflow term now weights by `b_eq_eval = eq(b_eval_point, challenges)` — the value already computed for the `b` re-randomization binding — instead of `a_c_eq_eval`.
- **prover** (`phase5`): the `QuadraticMleCheckProver` for the parity is constructed at `b_eval_point` instead of `a_c_eval_point`.

No interface change; `IntMulOutput` unchanged. The bivariate product layer still uses `a_c_eval_point` (r_3) and the `b` re-randomization still point-switches r_2 → r_x.

## Test

`prove_and_verify` roundtrip passes (gates prover↔verifier transcript agreement through the changed binding). `+ fmt + clippy -D warnings + rustdoc -D warnings` clean on `binius-verifier`/`binius-prover`.

Next in the trio: BINIUS-170 (D-V3, high-half twist), then BINIUS-171 (D-V4, eq_6 batching).

🤖 Generated with [Claude Code](https://claude.com/claude-code)