### PR TITLE
BINIUS-170: IntMul run the c_hi product tree at base g via the high-half Frobenius twist

### DIFF
--- a/crates/prover/src/protocols/intmul/prove.rs
+++ b/crates/prover/src/protocols/intmul/prove.rs
@@ -20,7 +20,7 @@ use binius_utils::rayon::prelude::*;
 use binius_verifier::protocols::{
 	intmul::common::{
 		IntMulOutput, Phase1Output, Phase2Output, Phase3Output, Phase4Output, frobenius_twist,
-		normalize_a_c_exponent_evals,
+		inv_frobenius, inv_frobenius_point, normalize_a_c_exponent_evals,
 	},
 	prodcheck::MultilinearEvalClaim,
 };
@@ -29,7 +29,7 @@ use itertools::{Itertools, chain, izip};
 
 use super::{
 	error::Error,
-	witness::{Witness, two_valued_field_buffer},
+	witness::{Witness, frobenius, two_valued_field_buffer},
 };
 use crate::{
 	fold_word::{fold_across_words, fold_words},
@@ -135,6 +135,10 @@ where
 		let (c_lo_exponents, c_lo_root, mut c_lo_layers) = c_lo.split();
 		let (_, c_hi_root, mut c_hi_layers) = c_hi.split();
 
+		// The c_hi tree runs at base g, so its root is C_hi; the LO * HI product check in Phase 3
+		// needs the base-g^{2^64} high-half root D_hi = φ^{2^log_bits}(C_hi).
+		let d_hi_root = frobenius(&c_hi_root, 1 << log_bits);
+
 		let a_last_layer = a_layers.pop().expect("log_bits >= 1");
 		let c_lo_last_layer = c_lo_layers.pop().expect("log_bits >= 1");
 		let c_hi_last_layer = c_hi_layers.pop().expect("log_bits >= 1");
@@ -147,13 +151,14 @@ where
 			gpow_a_eval,
 			gpow_c_lo_eval,
 			gpow_c_hi_eval,
+			c_hi_eval_point,
 		} = self.phase3(
 			log_bits,
 			&twisted_eval_points,
 			&twisted_evals,
 			a_root,
 			b_exponents.as_ref(),
-			[c_lo_root, c_hi_root],
+			[c_lo_root, d_hi_root],
 			&initial_eval_point,
 			exp_eval,
 		)?;
@@ -167,6 +172,7 @@ where
 		} = self.phase4(
 			log_bits,
 			&phase3_eval_point,
+			&c_hi_eval_point,
 			(gpow_a_eval, a_layers.into_iter()),
 			(gpow_c_lo_eval, c_lo_layers.into_iter()),
 			(gpow_c_hi_eval, c_hi_layers.into_iter()),
@@ -276,7 +282,7 @@ where
 			.pop()
 			.expect("selector_prover_evals.len() > 0");
 		let b_evals = selector_prover_evals;
-		let [gpow_c_lo_eval, gpow_c_hi_eval] = c_root_prover_evals
+		let [gpow_c_lo_eval, d_hi_eval] = c_root_prover_evals
 			.try_into()
 			.expect("c_root_prover with two multilinears returns two evals");
 
@@ -286,6 +292,12 @@ where
 		let r_ib = self.channel.sample_many(log_bits);
 		let b_recomb = evaluate(&FieldBuffer::<P>::from_values(&b_evals), &r_ib);
 
+		// High-half twist (mirror the verifier): convert the base-g^{2^64} claim D_hi(r) into the
+		// base-g claim C_hi(φ^{-64}(r)) = φ^{-64}(D_hi(r)) so the c_hi product tree runs at base g.
+		let twist = 1 << log_bits;
+		let gpow_c_hi_eval = inv_frobenius(d_hi_eval, twist);
+		let c_hi_eval_point = inv_frobenius_point(&challenges, twist);
+
 		Ok(Phase3Output {
 			eval_point: challenges,
 			r_ib,
@@ -293,13 +305,16 @@ where
 			gpow_a_eval,
 			gpow_c_lo_eval,
 			gpow_c_hi_eval,
+			c_hi_eval_point,
 		})
 	}
 
+	#[allow(clippy::too_many_arguments)]
 	fn phase4(
 		&mut self,
 		log_bits: usize,
 		eval_point: &[F],
+		c_hi_eval_point: &[F],
 		(a_root_eval, a_layers): (F, impl ExactSizeIterator<Item = Vec<FieldBuffer<P>>>),
 		(gpow_c_lo_eval, c_lo_layers): (F, impl ExactSizeIterator<Item = Vec<FieldBuffer<P>>>),
 		(gpow_c_hi_eval, c_hi_layers): (F, impl ExactSizeIterator<Item = Vec<FieldBuffer<P>>>),
@@ -309,6 +324,10 @@ where
 		assert_eq!(c_hi_layers.len(), log_bits - 1);
 
 		let mut eval_point = eval_point.to_vec();
+		// The c_hi product tree is rooted at the φ^{-64}-twisted point. It is only used at layer 0;
+		// after that all three trees fold by the same challenges, so subsequent layers run a single
+		// prover at the shared `eval_point`.
+		let c_hi_eval_point = c_hi_eval_point.to_vec();
 		let mut evals = vec![a_root_eval, gpow_c_lo_eval, gpow_c_hi_eval];
 
 		for (depth, (a_l, c_lo_l, c_hi_l)) in izip!(a_layers, c_lo_layers, c_hi_layers).enumerate()
@@ -318,25 +337,55 @@ where
 			assert_eq!(c_hi_l.len(), 2 << depth);
 			assert_eq!(evals.len(), 3 << depth);
 
-			let layer = a_l.into_iter().chain(c_lo_l).chain(c_hi_l);
-			let sumcheck_prover = BivariateProductMultiMlecheckProver::new(
-				make_pairs(layer),
-				&eval_point,
-				evals.clone(),
-			)?;
+			let challenges = if depth == 0 {
+				// c_hi is rooted at the twisted point: batch two provers — [a, c_lo] at
+				// `eval_point` and [c_hi] at the twisted point — into one sumcheck, so the c_hi
+				// tuples carry a distinct eq weight while sharing the fold challenges with a
+				// and c_lo.
+				let (a_root, c_lo_root, c_hi_root) = (evals[0], evals[1], evals[2]);
+				let a_c_prover =
+					MleToSumCheckDecorator::new(BivariateProductMultiMlecheckProver::new(
+						make_pairs(a_l.into_iter().chain(c_lo_l)),
+						&eval_point,
+						vec![a_root, c_lo_root],
+					)?);
+				let c_hi_prover =
+					MleToSumCheckDecorator::new(BivariateProductMultiMlecheckProver::new(
+						make_pairs(c_hi_l),
+						&c_hi_eval_point,
+						vec![c_hi_root],
+					)?);
+				let BatchSumcheckOutput {
+					challenges,
+					multilinear_evals,
+				} = batch_prove_and_write_evals(vec![a_c_prover, c_hi_prover], self.channel)?;
+				let [a_c_child_evals, c_hi_child_evals] =
+					<[Vec<F>; 2]>::try_from(multilinear_evals)
+						.expect("batch_prove with two provers returns two eval vecs");
+				evals = a_c_child_evals
+					.into_iter()
+					.chain(c_hi_child_evals)
+					.collect();
+				challenges
+			} else {
+				let layer = a_l.into_iter().chain(c_lo_l).chain(c_hi_l);
+				let prover = MleToSumCheckDecorator::new(BivariateProductMultiMlecheckProver::new(
+					make_pairs(layer),
+					&eval_point,
+					evals.clone(),
+				)?);
+				let BatchSumcheckOutput {
+					challenges,
+					mut multilinear_evals,
+				} = batch_prove_and_write_evals(vec![prover], self.channel)?;
+				assert_eq!(multilinear_evals.len(), 1);
+				evals = multilinear_evals
+					.pop()
+					.expect("multilinear_evals.len() == 1");
+				challenges
+			};
 
-			let prover = MleToSumCheckDecorator::new(sumcheck_prover);
-
-			let BatchSumcheckOutput {
-				challenges,
-				mut multilinear_evals,
-			} = batch_prove_and_write_evals(vec![prover], self.channel)?;
-
-			assert_eq!(multilinear_evals.len(), 1);
 			eval_point = challenges;
-			evals = multilinear_evals
-				.pop()
-				.expect("multilinear_evals.len() == 1");
 		}
 
 		debug_assert_eq!(evals.len(), 3 << (log_bits - 1));

--- a/crates/prover/src/protocols/intmul/witness.rs
+++ b/crates/prover/src/protocols/intmul/witness.rs
@@ -79,13 +79,12 @@ where
 		}
 
 		let g = F::MULTIPLICATIVE_GENERATOR;
-		let g_c_hi = iterate(g, |g| g.square())
-			.nth(1 << log_bits)
-			.expect("infinite iterator");
 
 		let a = BinaryTree::constant_base(log_bits, g, a);
 		let c_lo = BinaryTree::constant_base(log_bits, g, c_lo);
-		let c_hi = BinaryTree::constant_base(log_bits, g_c_hi, c_hi);
+		// The c_hi tree runs at base g (uniformly with a and c_lo); the high-half factor 2^64 is
+		// reintroduced by the Frobenius twist downstream (spec §IntMul high-half twist).
+		let c_hi = BinaryTree::constant_base(log_bits, g, c_hi);
 
 		// Compute b_leaves as concatenated leaves for prodcheck
 		let variable_base = a.root().clone();
@@ -94,8 +93,11 @@ where
 		// Create the prodcheck prover; its products layer becomes b_root
 		let (b_prodcheck, b_root) = ProdcheckProver::new(log_bits, b_leaves.clone());
 
-		// The root of a `log_bits + 1` deep tree of the full product `c`.
-		let c_root = buffer_bivariate_product(c_lo.root(), c_hi.root());
+		// The root of a `log_bits + 1` deep tree of the full product `c`. The high-half root is
+		// taken at base g^{2^64} = φ^{2^log_bits}(C_hi_root), so c_root = g^{int(c_lo) + 2^64
+		// int(c_hi)} = g^c.
+		let d_hi_root = frobenius(c_hi.root(), 1 << log_bits);
+		let c_root = buffer_bivariate_product(c_lo.root(), &d_hi_root);
 
 		Ok(Self {
 			a,
@@ -360,6 +362,18 @@ pub fn buffer_bivariate_product<P: PackedField, Data: Deref<Target = [P]>>(
 		.map(|(&a, &b)| a * b)
 		.collect::<Box<[P]>>();
 	FieldBuffer::new(a.log_len(), product)
+}
+
+/// Apply the Frobenius endomorphism `φ^exp` to a field buffer: raise every element to the `2^exp`
+/// power by squaring `exp` times. Used by the IntMul high-half twist to map between the base-`g`
+/// high-half root `C_hi` and the base-`g^{2^64}` root `D_hi = φ^{2^log_bits}(C_hi)`.
+pub fn frobenius<P: PackedField>(buffer: &FieldBuffer<P>, exp: usize) -> FieldBuffer<P> {
+	let values = buffer
+		.as_ref()
+		.iter()
+		.map(|&packed| (0..exp).fold(packed, |acc, _| acc.square()))
+		.collect::<Box<[P]>>();
+	FieldBuffer::new(buffer.log_len(), values)
 }
 
 /// Constructs a field buffer with values selected from `elements` based on the bit values

--- a/crates/verifier/src/protocols/intmul/common.rs
+++ b/crates/verifier/src/protocols/intmul/common.rs
@@ -44,8 +44,15 @@ pub struct Phase3Output<F> {
 	pub gpow_a_eval: F,
 	/// $C_{\textsf{lo}}(r)$.
 	pub gpow_c_lo_eval: F,
-	/// $C_{\textsf{hi}}(r)$.
+	/// The base-$g$ high-half claim $\widetilde{C}_{\textsf{hi}}(\varphi^{-64}(r)) =
+	/// \varphi^{-64}(\widetilde{D}_{\textsf{hi}}(r))$, obtained by twisting the base-$g^{2^{64}}$
+	/// high-half claim so the $c_{\textsf{hi}}$ product tree runs at base $g$ uniformly with $a$
+	/// and $c_{\textsf{lo}}$ (spec §IntMul high-half twist). Evaluated at `c_hi_eval_point`.
 	pub gpow_c_hi_eval: F,
+	/// The twisted constraint point $\varphi^{-64}(r)$ at which `gpow_c_hi_eval` is taken. Only
+	/// the $c_{\textsf{hi}}$ product tree uses it (at Phase-4 layer 0); $a$ and $c_{\textsf{lo}}$
+	/// use `eval_point`.
+	pub c_hi_eval_point: Vec<F>,
 }
 
 /// Output of Phase 4: all but last GKR layer for $\widetilde{a}$, $\widetilde{c}_{\textsf{lo}}$,
@@ -66,7 +73,7 @@ pub struct Phase4Output<F> {
 /// x^{2^i}$. Its order is $d$ (the extension degree), meaning $\varphi^d = \textsf{id}$.
 /// Therefore $\varphi^{-i} = \varphi^{d - i}$, and we compute $\varphi^{-i}(x) = x^{2^{d-i}}$
 /// by repeated squaring $d - i$ times.
-fn inv_frobenius<F>(x: F, i: usize) -> F
+pub fn inv_frobenius<F>(x: F, i: usize) -> F
 where
 	F: FieldOps,
 	F::Scalar: BinaryField,
@@ -75,6 +82,23 @@ where
 	iterate(x, |g| g.clone().square())
 		.nth(degree - i)
 		.expect("infinite iterator")
+}
+
+/// Apply the inverse Frobenius endomorphism $\varphi^{-i}$ coordinate-wise to an evaluation point.
+///
+/// Used by the high-half twist (spec §IntMul): a base-$g^{2^i}$ root claim $\widetilde{D}(r)$ is
+/// converted to the base-$g$ claim $\widetilde{C}(\varphi^{-i}(r)) =
+/// \varphi^{-i}(\widetilde{D}(r))$, which evaluates the same multilinear at the twisted point
+/// $\varphi^{-i}(r)$.
+pub fn inv_frobenius_point<F>(point: &[F], i: usize) -> Vec<F>
+where
+	F: FieldOps,
+	F::Scalar: BinaryField,
+{
+	point
+		.iter()
+		.map(|coord| inv_frobenius(coord.clone(), i))
+		.collect()
 }
 
 /// Compute the inverse Frobenius sequence $[\varphi^{0}(x), \varphi^{-1}(x), \ldots,
@@ -147,7 +171,7 @@ where
 ///
 /// * $\textsf{select}(a(i, r), g^{2^i})$,
 /// * $\textsf{select}(c_{\textsf{lo}}(i, r), g^{2^i})$,
-/// * $\textsf{select}(c_{\textsf{hi}}(i, r), g^{2^(i + k)}$,
+/// * $\textsf{select}(c_{\textsf{hi}}(i, r), g^{2^i})$,
 ///
 /// for all $i$ in $\{0, \ldots, 2^k - 1\}$, where
 ///
@@ -173,19 +197,19 @@ where
 	assert_eq!(selected_c_lo_evals.len(), 1 << k);
 	assert_eq!(selected_c_hi_evals.len(), 1 << k);
 
-	// Compute the normalization factors (conjugate - 1)^{-1} in F, then convert to E.
+	// Compute the normalization factors (conjugate - 1)^{-1} in F, then convert to E. All three
+	// trees run at base g (the c_hi high-half twist is applied upstream), so they share the same
+	// low generator powers g^{2^i} for i in 0..2^k.
 	let inv_factors: Vec<E> = iterate(F::MULTIPLICATIVE_GENERATOR, |g| g.square())
-		.take(2 << k)
+		.take(1 << k)
 		// Safety: `conjugate` ranges over powers of the multiplicative generator, which has odd
 		// order, so `conjugate - 1` is never zero.
 		.map(|conjugate| E::from(unsafe { (conjugate - F::ONE).invert() }))
 		.collect();
 
-	let (lo_inv_factors, hi_inv_factors) = inv_factors.split_at(1 << k);
-
-	let a_evals = recover_selectors(selected_a_evals, lo_inv_factors);
-	let c_lo_evals = recover_selectors(selected_c_lo_evals, lo_inv_factors);
-	let c_hi_evals = recover_selectors(selected_c_hi_evals, hi_inv_factors);
+	let a_evals = recover_selectors(selected_a_evals, &inv_factors);
+	let c_lo_evals = recover_selectors(selected_c_lo_evals, &inv_factors);
+	let c_hi_evals = recover_selectors(selected_c_hi_evals, &inv_factors);
 
 	[a_evals, c_lo_evals, c_hi_evals]
 }
@@ -211,7 +235,7 @@ fn recover_selectors<F: FieldOps>(selecteds: Vec<F>, inv_factors: &[F]) -> Vec<F
 ///
 /// * $\textsf{select}(a(i, r), g^{2^i})$,
 /// * $\textsf{select}(c_{\textsf{lo}}(i, r), g^{2^i})$,
-/// * $\textsf{select}(c_{\textsf{hi}}(i, r), g^{2^{i + k}})$,
+/// * $\textsf{select}(c_{\textsf{hi}}(i, r), g^{2^i})$,
 ///
 /// for $i \in \{0, \ldots, 2^k - 1\}$, where $\textsf{select}(S, V) = S \cdot (V - 1) + 1$.
 ///
@@ -232,17 +256,17 @@ where
 	assert_eq!(c_lo_evals.len(), 1 << k);
 	assert_eq!(c_hi_evals.len(), 1 << k);
 
-	// powers[j] = g^{2^j}, for j in 0..2^{k+1}.
+	// powers[j] = g^{2^j}, for j in 0..2^k. All three trees run at base g (the c_hi high-half twist
+	// is applied upstream), so c_hi reconstructs from the same low powers as a and c_lo.
 	let powers: Vec<E> = iterate(F::MULTIPLICATIVE_GENERATOR, |g| g.square())
-		.take(2 << k)
+		.take(1 << k)
 		.map(E::from)
 		.collect();
-	let (lo_powers, hi_powers) = powers.split_at(1 << k);
 
 	[
-		apply_selectors(a_evals, lo_powers),
-		apply_selectors(c_lo_evals, lo_powers),
-		apply_selectors(c_hi_evals, hi_powers),
+		apply_selectors(a_evals, &powers),
+		apply_selectors(c_lo_evals, &powers),
+		apply_selectors(c_hi_evals, &powers),
 	]
 }
 

--- a/crates/verifier/src/protocols/intmul/verify.rs
+++ b/crates/verifier/src/protocols/intmul/verify.rs
@@ -13,7 +13,7 @@ use itertools::{Itertools, chain};
 use super::{
 	common::{
 		IntMulOutput, Phase1Output, Phase2Output, Phase3Output, Phase4Output, frobenius_twist,
-		reconstruct_selecteds,
+		inv_frobenius, inv_frobenius_point, reconstruct_selecteds,
 	},
 	error::Error,
 };
@@ -29,7 +29,9 @@ use crate::protocols::{
 /// point (challenges) and the claimed factor evaluations.
 #[allow(clippy::type_complexity)]
 fn verify_multi_bivariate_product_mle_layer<F, C>(
-	eval_point: &[C::Elem],
+	a_c_eval_point: &[C::Elem],
+	c_hi_eval_point: &[C::Elem],
+	n_a_c_tuples: usize,
 	evals: &[C::Elem],
 	channel: &mut C,
 ) -> Result<(Vec<C::Elem>, Vec<C::Elem>), Error>
@@ -37,7 +39,7 @@ where
 	F: Field,
 	C: IPVerifierChannel<F>,
 {
-	let n_vars = eval_point.len();
+	let n_vars = a_c_eval_point.len();
 
 	let BatchSumcheckOutput {
 		batch_coeff,
@@ -49,11 +51,23 @@ where
 
 	let multilinear_evals = channel.recv_many(2 * evals.len())?;
 
-	let eq_ind_eval = eq_ind(eval_point, &challenges);
+	// The a and c_lo product tuples (the first `n_a_c_tuples`) are weighted by eq(a_c_eval_point),
+	// the c_hi tuples by eq(c_hi_eval_point). The two points differ (by the φ^{-64} high-half
+	// twist) only at Phase-4 layer 0; thereafter the caller passes the same shared point for both.
+	let a_c_eq_eval = eq_ind(a_c_eval_point, &challenges);
+	let c_hi_eq_eval = eq_ind(c_hi_eval_point, &challenges);
 	let expected_unbatched_terms = multilinear_evals
 		.iter()
 		.tuples()
-		.map(|(left, right)| eq_ind_eval.clone() * left * right)
+		.enumerate()
+		.map(|(i, (left, right))| {
+			let eq_ind_eval = if i < n_a_c_tuples {
+				&a_c_eq_eval
+			} else {
+				&c_hi_eq_eval
+			};
+			eq_ind_eval.clone() * left * right
+		})
 		.collect::<Vec<_>>();
 
 	let expected_eval = evaluate_univariate(&expected_unbatched_terms, batch_coeff);
@@ -119,6 +133,7 @@ fn verify_phase_3<F, C>(
 where
 	F: Field,
 	C: IPVerifierChannel<F>,
+	<C::Elem as FieldOps>::Scalar: BinaryField,
 {
 	let n_vars = c_eval_point.len();
 
@@ -150,8 +165,9 @@ where
 	// A(r)
 	let gpow_a_eval = channel.recv_one()?;
 
-	// C_lo(r), C_hi(r)
-	let [gpow_c_lo_eval, gpow_c_hi_eval] = channel.recv_array::<2>()?;
+	// C_lo(r), and the base-g^{2^64} high-half claim D_hi(r). The high-half product tree is run at
+	// base g^{2^64}, so the LO * HI product check below needs the base-g^{2^64} claim D_hi(r).
+	let [gpow_c_lo_eval, d_hi_eval] = channel.recv_array::<2>()?;
 
 	// Recombine the 2^k per-bit exponent claims b(i, r) into a single claim b(r_I^b, r) by
 	// sampling a recombination point r_I^b in K^k. This carries one exponent claim (rather than
@@ -168,9 +184,9 @@ where
 				* eq_ind(&twisted_eval_point, &eval_point)
 		});
 
-	// - c_lo(r) * c_hi(r) * eq(c_eval_point ; r)
+	// - c_lo(r) * D_hi(r) * eq(c_eval_point ; r)
 	let expected_c_prod_eval =
-		gpow_c_lo_eval.clone() * gpow_c_hi_eval.clone() * eq_ind(c_eval_point, &eval_point);
+		gpow_c_lo_eval.clone() * d_hi_eval.clone() * eq_ind(c_eval_point, &eval_point);
 
 	let expected_terms = expected_selected_terms
 		.chain([expected_c_prod_eval])
@@ -179,6 +195,14 @@ where
 
 	channel.assert_zero(expected_batched_eval - eval)?;
 
+	// High-half twist: convert the base-g^{2^64} claim D_hi(r) into the base-g claim
+	// C_hi(φ^{-64}(r)) = φ^{-64}(D_hi(r)), so the c_hi product tree runs at base g uniformly with a
+	// and c_lo (spec §IntMul). The shift is 2^{2^log_bits} = 2^64, i.e. inv_frobenius with
+	// i = 1 << log_bits applied to both the claim value and the evaluation point.
+	let twist = 1 << log_bits;
+	let gpow_c_hi_eval = inv_frobenius(d_hi_eval, twist);
+	let c_hi_eval_point = inv_frobenius_point(&eval_point, twist);
+
 	Ok(Phase3Output {
 		eval_point,
 		r_ib,
@@ -186,6 +210,7 @@ where
 		gpow_a_eval,
 		gpow_c_lo_eval,
 		gpow_c_hi_eval,
+		c_hi_eval_point,
 	})
 }
 
@@ -197,6 +222,7 @@ where
 fn verify_phase_4<F, C>(
 	log_bits: usize,
 	eval_point: &[C::Elem],
+	c_hi_eval_point: &[C::Elem],
 	a_root_eval: C::Elem,
 	gpow_c_lo_eval: C::Elem,
 	gpow_c_hi_eval: C::Elem,
@@ -209,15 +235,27 @@ where
 	assert!(log_bits >= 1);
 
 	let mut eval_point = eval_point.to_vec();
+	// The c_hi product tree is rooted at the φ^{-64}-twisted point; a and c_lo at `eval_point`.
+	let mut c_hi_eval_point = c_hi_eval_point.to_vec();
 	let mut evals = vec![a_root_eval, gpow_c_lo_eval, gpow_c_hi_eval];
 
 	for depth in 0..log_bits - 1 {
 		assert_eq!(evals.len(), 3 << depth);
 
-		let (challenges, multilinear_evals) =
-			verify_multi_bivariate_product_mle_layer(&eval_point, &evals, channel)?;
+		// a and c_lo occupy the first 2 << depth product tuples, c_hi the last 1 << depth.
+		let n_a_c_tuples = 2 << depth;
+		let (challenges, multilinear_evals) = verify_multi_bivariate_product_mle_layer(
+			&eval_point,
+			&c_hi_eval_point,
+			n_a_c_tuples,
+			&evals,
+			channel,
+		)?;
 
-		eval_point = challenges;
+		// After a layer all three trees fold by the same challenges, so the twisted c_hi point
+		// rejoins the shared point.
+		eval_point = challenges.clone();
+		c_hi_eval_point = challenges;
 		evals = multilinear_evals;
 	}
 
@@ -472,6 +510,7 @@ where
 		gpow_a_eval,
 		gpow_c_lo_eval,
 		gpow_c_hi_eval,
+		c_hi_eval_point,
 	} = verify_phase_3(
 		log_bits,
 		twisted_eval_points,
@@ -490,6 +529,7 @@ where
 	} = verify_phase_4(
 		log_bits,
 		&phase_3_eval_point,
+		&c_hi_eval_point,
 		gpow_a_eval,
 		gpow_c_lo_eval,
 		gpow_c_hi_eval,


### PR DESCRIPTION
Closes [BINIUS-170](https://linear.app/jimpo/issue/BINIUS-170) — audit divergence **D-V3** under [BINIUS-163](https://linear.app/jimpo/issue/BINIUS-163) (conform IntMul to `sec:intmul`). Second of the D-V3/4/5 trio.

## What

The spec rewrites the base-`g^{2^64}` high-half claim `D̃_hi(r)` as a base-`g` claim `C̃_hi(φ⁻⁶⁴(r))` so the `c_hi` product tree runs at base `g`, uniformly with `a` and `c_lo`. The code instead ran the whole `c_hi` tree at base `g^{2^64}` and reduced the "scaled" leaf evals locally (high generator powers). Soundness-equivalent, but not spec-literal.

Identity: `D_hi = φ⁶⁴(C_hi)` entrywise (φ(y)=y², so φ⁶⁴(y)=y^{2⁶⁴}), hence `C̃_hi(φ⁻⁶⁴(r)) = φ⁻⁶⁴(D̃_hi(r))`. φ⁶⁴ is an 𝔽₂-automorphism: it distributes over the multilinear sum and fixes the {0,1} eq weights, twisting only the evaluation point.

Two observations keep the change tight:
- **The twist only touches Phase-4 layer 0.** The GKR `eval_point` resets to the shared fold challenges after every layer, so from layer 1 on (and all of Phase 5) `c_hi` is already at the shared point — only its layer-0 root claim + eq weight differ.
- **No shared-primitive change.** `batch_prove` already composes provers with distinct eval points (Phase 5 does it), so Phase-4 layer 0 batches two provers — `[a, c_lo]` at `r` and `[c_hi]` at `φ⁻⁶⁴(r)` — into one sumcheck. The verifier mirrors with two eq weights in the batched-layer check.

Changes:
- **verifier** (`verify_phase_3`): keep the raw `D̃_hi(r)` for the LO·HI product check, then convert to `C̃_hi(φ⁻⁶⁴(r))` and thread the twisted point into `Phase3Output`. `verify_phase_4` / the batched-layer function weight the `c_hi` tuples by `eq(φ⁻⁶⁴(r))` at layer 0. `reconstruct_selecteds`: `c_hi` now uses the low generator powers `g^{2^i}` (base g).
- **prover** (`witness`): `c_hi` tree built at base `g`; the `c_root` product identity uses `D_hi = φ⁶⁴(C_hi_root)`. `phase3`/`phase4` mirror the verifier (convert the claim, two-prover layer 0). `inv_frobenius`/`inv_frobenius_point` exposed from `common`, plus a `frobenius` buffer helper.

No interface change; `IntMulOutput` unchanged.

## Test

`prove_and_verify` roundtrip + the witness tests pass (the roundtrip gates the prover↔verifier transcript through the new twist and the two-prover batching). `+ fmt + clippy -D warnings + rustdoc -D warnings` clean on `binius-verifier`/`binius-prover`.

Last in the trio: BINIUS-171 (D-V4, eq_6 Phase-1 batching).

🤖 Generated with [Claude Code](https://claude.com/claude-code)