### PR TITLE
Adopt Plonky3-style workspace clippy lints and fix all findings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,8 +98,27 @@ trait-set = "0.3.0"
 uninit = "0.6.2"
 ureq = "3.1"
 
+[workspace.lints]
+rust.rust_2018_idioms = { level = "deny", priority = -1 }
+rust.unused_must_use = "deny"
+rust.rust_2024_incompatible_pat = "warn"
+rustdoc.all = "warn"
+
 [workspace.lints.clippy]
-needless_range_loop = "allow"
+all = { level = "warn", priority = -1 }
+nursery = { level = "warn", priority = -1 }
+
+# Some pedantic lints
+semicolon_if_nothing_returned = "warn"
+match_bool = "warn"
+needless_pass_by_value = "warn"
+
+redundant_pub_crate = "allow"
+too_long_first_doc_paragraph = "allow"
+unused_peekable = "allow"
+tuple_array_conversions = "allow"
+transmute_undefined_repr = "allow"
+cognitive_complexity = "allow"
 
 [workspace.metadata.typos]
 default.extend-words = { "typ" = "typ", "Toom" = "Toom", "inouts" = "inouts" }

--- a/crates/arith-bench/benches/field_mul.rs
+++ b/crates/arith-bench/benches/field_mul.rs
@@ -45,21 +45,21 @@ fn run_google_mul_benchmark<U, R>(
 	group.bench_function(name, |b| {
 		b.iter(|| {
 			let mut x = black_box(x);
-			for j in 0..N {
-				y[j] = x;
+			for slot in y.iter_mut().take(N) {
+				*slot = x;
 				x = mul_fn(x, x);
 			}
 			for _i in 0..N * N {
-				for j in 0..N {
-					y[j] = mul_fn(y[j], x);
+				for slot in y.iter_mut().take(N) {
+					*slot = mul_fn(*slot, x);
 				}
 				x = mul_fn(x, x);
 			}
-			for j in 0..N {
-				x = mul_fn(y[j], x);
+			for &elem in y.iter().take(N) {
+				x = mul_fn(elem, x);
 			}
 			x
-		})
+		});
 	});
 }
 
@@ -101,7 +101,7 @@ fn run_mul_benchmark<T, R>(
 					batch[i] = mul_fn(batch[i], batch[(i + BATCH_SIZE / 2) % BATCH_SIZE]);
 				}
 			}
-		})
+		});
 	});
 }
 
@@ -135,11 +135,11 @@ fn run_unary_op_benchmark<T, R>(
 	group.bench_function(name, |b| {
 		b.iter(|| {
 			for _ in 0..N_PASSES {
-				for i in 0..BATCH_SIZE {
-					batch[i] = op_fn(batch[i]);
+				for slot in batch.iter_mut().take(BATCH_SIZE) {
+					*slot = op_fn(*slot);
 				}
 			}
-		})
+		});
 	});
 }
 
@@ -221,7 +221,12 @@ fn bench_polyval(c: &mut Criterion) {
 }
 
 /// Benchmark GF(2^128) GHASH multiplication using CLMUL instructions
-#[allow(unused_imports, unused_variables, unused_mut)]
+#[allow(
+	unused_imports,
+	unused_variables,
+	unused_mut,
+	clippy::significant_drop_tightening
+)]
 fn bench_ghash(c: &mut Criterion) {
 	use binius_arith_bench::ghash::{mul_clmul, square_clmul};
 

--- a/crates/arith-bench/src/arch/aarch64.rs
+++ b/crates/arith-bench/src/arch/aarch64.rs
@@ -35,7 +35,7 @@ impl Underlier for uint64x2_t {
 
 	fn random(mut rng: impl Rng) -> Self {
 		let value: u128 = rng.random();
-		unsafe { std::mem::transmute::<_, uint64x2_t>(value) }
+		unsafe { std::mem::transmute::<_, Self>(value) }
 	}
 }
 
@@ -223,7 +223,7 @@ impl crate::underlier::OpsClmul for uint64x2_t {
 					let a_bytes: uint8x16_t = std::mem::transmute(a);
 					let zero: uint8x16_t = vdupq_n_u8(0);
 					let shifted: uint8x16_t = vextq_u8::<IMM8>(zero, a_bytes);
-					std::mem::transmute::<uint8x16_t, uint64x2_t>(shifted)
+					std::mem::transmute::<uint8x16_t, Self>(shifted)
 				}
 				16.. => vdupq_n_u64(0),
 				_ => {
@@ -248,7 +248,7 @@ impl crate::underlier::OpsClmul for uint64x2_t {
 	#[inline]
 	fn movepi64_mask(a: Self) -> Self {
 		unsafe {
-			let a = std::mem::transmute::<uint64x2_t, uint32x4_t>(a);
+			let a = std::mem::transmute::<Self, uint32x4_t>(a);
 			// Get the odd lanes (upper 32 bits of each 64-bit element)
 			let odd_lanes = vtrn2q_u32(a, a);
 			// Arithmetic shift right to broadcast the sign bit

--- a/crates/arith-bench/src/arch/portable64.rs
+++ b/crates/arith-bench/src/arch/portable64.rs
@@ -32,14 +32,14 @@ pub struct U64x2(pub u64, pub u64);
 impl From<u128> for U64x2 {
 	fn from(x: u128) -> Self {
 		// Little-endian: low 64 bits first, then high 64 bits
-		U64x2(x as u64, (x >> 64) as u64)
+		Self(x as u64, (x >> 64) as u64)
 	}
 }
 
 impl From<U64x2> for u128 {
 	fn from(x: U64x2) -> Self {
 		// Little-endian: x.0 is low 64 bits, x.1 is high 64 bits
-		(x.0 as u128) | ((x.1 as u128) << 64)
+		(x.0 as Self) | ((x.1 as Self) << 64)
 	}
 }
 
@@ -72,7 +72,7 @@ pub fn bmul64(x: u64, y: u64) -> u64 {
 }
 
 /// Bit-reverse a `u64` in constant time
-pub fn rev64(mut x: u64) -> u64 {
+pub const fn rev64(mut x: u64) -> u64 {
 	x = ((x & 0x5555_5555_5555_5555) << 1) | ((x >> 1) & 0x5555_5555_5555_5555);
 	x = ((x & 0x3333_3333_3333_3333) << 2) | ((x >> 2) & 0x3333_3333_3333_3333);
 	x = ((x & 0x0f0f_0f0f_0f0f_0f0f) << 4) | ((x >> 4) & 0x0f0f_0f0f_0f0f_0f0f);
@@ -84,7 +84,7 @@ pub fn rev64(mut x: u64) -> u64 {
 /// Squares a GF(2) polynomial, represented bitwise in a `u64`.
 ///
 /// The parameter `x` must have its top 32 bits clear (the polynomial has degree <32).
-pub fn bsqr64(mut x: u64) -> u64 {
+pub const fn bsqr64(mut x: u64) -> u64 {
 	// Algorithm adapted from https://graphics.stanford.edu/~seander/bithacks.html#InterleaveBMN
 	x = (x | (x << 16)) & 0x0000FFFF0000FFFF;
 	x = (x | (x << 8)) & 0x00FF00FF00FF00FF;

--- a/crates/arith-bench/src/arch/x86_64.rs
+++ b/crates/arith-bench/src/arch/x86_64.rs
@@ -36,7 +36,7 @@ impl Underlier for __m128i {
 	fn random(mut rng: impl Rng) -> Self {
 		let mut bytes = [0u8; 16];
 		rng.fill_bytes(&mut bytes);
-		unsafe { _mm_loadu_si128(bytes.as_ptr() as *const __m128i) }
+		unsafe { _mm_loadu_si128(bytes.as_ptr() as *const Self) }
 	}
 }
 
@@ -243,7 +243,7 @@ impl Underlier for __m256i {
 	fn random(mut rng: impl Rng) -> Self {
 		let mut bytes = [0u8; 32];
 		rng.fill_bytes(&mut bytes);
-		unsafe { _mm256_loadu_si256(bytes.as_ptr() as *const __m256i) }
+		unsafe { _mm256_loadu_si256(bytes.as_ptr() as *const Self) }
 	}
 }
 

--- a/crates/arith-bench/src/ghash/aarch64.rs
+++ b/crates/arith-bench/src/ghash/aarch64.rs
@@ -4,7 +4,7 @@
 //! GHASH elements are represented as `poly64x2_t` (a SIMD vector type, so the multiply stays in
 //! NEON registers across call boundaries). The `PMULL` / `PMULL2` instructions (`vmull_p64` /
 //! `vmull_high_p64`) drive the carryless multiplies, pairwise 128-bit XORs use `vaddq_p128`, and
-//! three-way XORs go through [`xor3`] (`EOR3` when the `SHA3` extension is available). The
+//! three-way XORs go through `xor3` (`EOR3` when the `SHA3` extension is available). The
 //! multiply is split into two phases:
 //!
 //! * `mul_wide`, which produces the unreduced product as three 128-bit limbs `[t0, t1, t2]`: `t0 =

--- a/crates/arith-bench/src/ghash/soft64.rs
+++ b/crates/arith-bench/src/ghash/soft64.rs
@@ -116,7 +116,7 @@ pub fn square(x: u128) -> u128 {
 ///
 /// This is equivalent to `mul(x, INV_X)` but optimized: right-shift by 1 and conditionally XOR
 /// with X^{-1} if the LSB was set.
-pub fn mul_inv_x(x: u128) -> u128 {
+pub const fn mul_inv_x(x: u128) -> u128 {
 	let lsb = x & 1;
 	let shifted = x >> 1;
 	// If lsb is 1, XOR with INV_X; the mask is all-ones when lsb=1, all-zeros when lsb=0.

--- a/crates/circuits/src/base64.rs
+++ b/crates/circuits/src/base64.rs
@@ -89,7 +89,7 @@ impl Base64UrlSafe {
 	///
 	/// * `w` - Witness filler to populate
 	/// * `length` - Actual length of decoded data in bytes
-	pub fn populate_len_bytes(&self, w: &mut WitnessFiller, len_bytes: usize) {
+	pub fn populate_len_bytes(&self, w: &mut WitnessFiller<'_>, len_bytes: usize) {
 		w[self.len_bytes] = Word(len_bytes as u64);
 	}
 
@@ -103,7 +103,7 @@ impl Base64UrlSafe {
 	/// # Panics
 	///
 	/// Panics if `data.len()` exceeds the maximum size specified during construction.
-	pub fn populate_decoded(&self, w: &mut WitnessFiller, data: &[u8]) {
+	pub fn populate_decoded(&self, w: &mut WitnessFiller<'_>, data: &[u8]) {
 		pack_bytes_into_wires_le(w, &self.decoded, data);
 	}
 
@@ -117,7 +117,7 @@ impl Base64UrlSafe {
 	/// # Panics
 	///
 	/// Panics if `data.len()` exceeds the maximum size specified during construction.
-	pub fn populate_encoded(&self, w: &mut WitnessFiller, data: &[u8]) {
+	pub fn populate_encoded(&self, w: &mut WitnessFiller<'_>, data: &[u8]) {
 		pack_bytes_into_wires_le(w, &self.encoded, data);
 	}
 }

--- a/crates/circuits/src/bignum/addsub.rs
+++ b/crates/circuits/src/bignum/addsub.rs
@@ -38,9 +38,9 @@ pub fn add_with_carry_out(builder: &CircuitBuilder, a: &BigUint, b: &BigUint) ->
 	);
 
 	let mut accumulator = vec![vec![]; a.limbs.len()];
-	for i in 0..a.limbs.len() {
-		accumulator[i].push(a.limbs[i]);
-		accumulator[i].push(b.limbs[i]);
+	for (acc, (a_limb, b_limb)) in accumulator.iter_mut().zip(a.limbs.iter().zip(&b.limbs)) {
+		acc.push(*a_limb);
+		acc.push(*b_limb);
 	}
 
 	let (sum, carry_out) = compute_stack_adds_with_carry_outs(builder, &accumulator);
@@ -50,7 +50,7 @@ pub fn add_with_carry_out(builder: &CircuitBuilder, a: &BigUint, b: &BigUint) ->
 		carry_out
 			.first()
 			.copied()
-			.unwrap_or(builder.add_constant(Word::ZERO)),
+			.unwrap_or_else(|| builder.add_constant(Word::ZERO)),
 	)
 }
 

--- a/crates/circuits/src/bignum/biguint.rs
+++ b/crates/circuits/src/bignum/biguint.rs
@@ -18,13 +18,13 @@ impl BigUint {
 	/// Creates a new BigUint with the given number of limbs as inout wires.
 	pub fn new_inout(b: &CircuitBuilder, num_limbs: usize) -> Self {
 		let limbs = (0..num_limbs).map(|_| b.add_inout()).collect();
-		BigUint { limbs }
+		Self { limbs }
 	}
 
 	/// Creates a new BigUint with the given number of limbs as witness wires.
 	pub fn new_witness(b: &CircuitBuilder, num_limbs: usize) -> Self {
 		let limbs = (0..num_limbs).map(|_| b.add_witness()).collect();
-		BigUint { limbs }
+		Self { limbs }
 	}
 
 	/// Creates a constant BigUint from num_bigint::BigUint.
@@ -33,7 +33,7 @@ impl BigUint {
 			.iter_u64_digits()
 			.map(|limb| b.add_constant_64(limb))
 			.collect();
-		BigUint { limbs }
+		Self { limbs }
 	}
 
 	/// Returns zero unless the MSB-boolean `cond` is true, then passes the value unchanged.
@@ -98,7 +98,7 @@ impl BigUint {
 	/// Populate the BigUint with the expected limb_values
 	///
 	/// Panics if limb_values.len() != self.limbs.len()
-	pub fn populate_limbs(&self, w: &mut WitnessFiller, limb_values: &[u64]) {
+	pub fn populate_limbs(&self, w: &mut WitnessFiller<'_>, limb_values: &[u64]) {
 		assert!(limb_values.len() == self.limbs.len());
 		for (&wire, &v) in iter::zip(&self.limbs, limb_values) {
 			w[wire] = Word::from_u64(v);

--- a/crates/circuits/src/bignum/prime_field.rs
+++ b/crates/circuits/src/bignum/prime_field.rs
@@ -37,12 +37,12 @@ impl PseudoMersennePrimeField {
 	}
 
 	/// Number of limbs in `BigUint`s representing field elements.
-	pub fn limbs_len(&self) -> usize {
+	pub const fn limbs_len(&self) -> usize {
 		self.modulus.limbs.len()
 	}
 
 	/// Field modulus.
-	pub fn modulus(&self) -> &BigUint {
+	pub const fn modulus(&self) -> &BigUint {
 		&self.modulus
 	}
 
@@ -91,7 +91,7 @@ impl PseudoMersennePrimeField {
 	/// Equivalent formula: `(fe ** 2) % modulus`
 	pub fn square(&self, b: &CircuitBuilder, fe: &BigUint) -> BigUint {
 		assert!(fe.limbs.len() == self.limbs_len());
-		self.reduce_product(b, textbook_square(b, fe))
+		self.reduce_product(b, &textbook_square(b, fe))
 	}
 
 	/// Field multiplication.
@@ -100,10 +100,10 @@ impl PseudoMersennePrimeField {
 	/// Note: Both fe1 and fe2 may be greater or equal to modulus.
 	pub fn mul(&self, b: &CircuitBuilder, fe1: &BigUint, fe2: &BigUint) -> BigUint {
 		assert!(fe1.limbs.len() == self.limbs_len() && fe2.limbs.len() == self.limbs_len());
-		self.reduce_product(b, textbook_mul(b, fe1, fe2))
+		self.reduce_product(b, &textbook_mul(b, fe1, fe2))
 	}
 
-	fn reduce_product(&self, b: &CircuitBuilder, product: BigUint) -> BigUint {
+	fn reduce_product(&self, b: &CircuitBuilder, product: &BigUint) -> BigUint {
 		let (quotient, remainder) = b.biguint_divide_hint(&product.limbs, &self.modulus.limbs);
 
 		let zero = b.add_constant(Word::ZERO);
@@ -116,7 +116,7 @@ impl PseudoMersennePrimeField {
 		// constraint: product == remainder + quotient * modulus
 		PseudoMersenneModReduce::new(
 			b,
-			&product,
+			product,
 			self.modulus_po2,
 			&self.modulus_subtrahend,
 			&quotient,

--- a/crates/circuits/src/bignum/reduce.rs
+++ b/crates/circuits/src/bignum/reduce.rs
@@ -54,7 +54,7 @@ impl ModReduce {
 			&a.pad_limbs_to(n_limbs, zero),
 		);
 
-		ModReduce {
+		Self {
 			a,
 			modulus,
 			quotient,
@@ -158,6 +158,6 @@ impl PseudoMersenneModReduce {
 
 	/// Apply the reduction constraint conditionally based on the value of boolean `mask` wire.
 	pub fn constrain_cond(self, builder: &CircuitBuilder, cond: Wire) {
-		assert_eq_cond(builder, "modred_pseudo_mersenne", &self.lhs, &self.rhs, cond)
+		assert_eq_cond(builder, "modred_pseudo_mersenne", &self.lhs, &self.rhs, cond);
 	}
 }

--- a/crates/circuits/src/bignum/tests.rs
+++ b/crates/circuits/src/bignum/tests.rs
@@ -23,7 +23,7 @@ use super::*;
 ///
 /// # Returns
 /// The `BigUint` value as a `num_biguint::BigUint`
-pub fn biguint_to_num_biguint(w: &WitnessFiller, biguint: &BigUint) -> num_bigint::BigUint {
+pub fn biguint_to_num_biguint(w: &WitnessFiller<'_>, biguint: &BigUint) -> num_bigint::BigUint {
 	let limb_vals: Vec<_> = biguint.limbs.iter().map(|&l| w[l].as_u64()).collect();
 	from_u64_limbs(&limb_vals)
 }

--- a/crates/circuits/src/bitcoin/double_sha256.rs
+++ b/crates/circuits/src/bitcoin/double_sha256.rs
@@ -25,7 +25,7 @@ impl DoubleSha256 {
 	/// - `message.len() * 8 == message_len`
 	pub fn construct_circuit(
 		builder: &CircuitBuilder,
-		message: Vec<Wire>,
+		message: &[Wire],
 		digest: [Wire; 4],
 	) -> Self {
 		// first SHA256 circuit
@@ -79,7 +79,7 @@ impl DoubleSha256 {
 	/// Return the digest.
 	///
 	/// (Hopefully this method is not needed in the future.)
-	pub fn populate_inner(&self, filler: &mut WitnessFiller, message: &[u8]) -> [u8; 32] {
+	pub fn populate_inner(&self, filler: &mut WitnessFiller<'_>, message: &[u8]) -> [u8; 32] {
 		// don't need to `populate_len(...)` because we passed a constant to the length wires
 		self.sha256_0.populate_message(filler, message);
 		let digest_0: [u8; 32] = sha2::Sha256::digest(message).into();
@@ -110,8 +110,7 @@ mod tests {
 		let builder = CircuitBuilder::new();
 		let block_header: [Wire; 10] = array::from_fn(|_| builder.add_witness());
 		let block_hash: [Wire; 4] = array::from_fn(|_| builder.add_witness());
-		let double_sha_256 =
-			DoubleSha256::construct_circuit(&builder, block_header.to_vec(), block_hash);
+		let double_sha_256 = DoubleSha256::construct_circuit(&builder, &block_header, block_hash);
 		let circuit = builder.build();
 
 		// populate_witness
@@ -137,8 +136,7 @@ mod tests {
 		let builder = CircuitBuilder::new();
 		let block_header: [Wire; 10] = array::from_fn(|_| builder.add_witness());
 		let block_hash: [Wire; 4] = array::from_fn(|_| builder.add_witness());
-		let double_sha_256 =
-			DoubleSha256::construct_circuit(&builder, block_header.to_vec(), block_hash);
+		let double_sha_256 = DoubleSha256::construct_circuit(&builder, &block_header, block_hash);
 		let circuit = builder.build();
 
 		// populate_witness

--- a/crates/circuits/src/bitcoin/header_chain.rs
+++ b/crates/circuits/src/bitcoin/header_chain.rs
@@ -43,7 +43,7 @@ impl HeaderChain {
 			// hash equals `latest_digest`
 			header_digests.push(DoubleSha256::construct_circuit(
 				builder,
-				headers[0].to_vec(),
+				&headers[0],
 				latest_digest,
 			));
 
@@ -60,11 +60,7 @@ impl HeaderChain {
 		for i in 1..headers.len() {
 			// hash equals the "previous block hash" in the newer block
 			let digest = previous_block_hash(builder, &headers[i - 1]);
-			header_digests.push(DoubleSha256::construct_circuit(
-				builder,
-				headers[i].to_vec(),
-				digest,
-			));
+			header_digests.push(DoubleSha256::construct_circuit(builder, &headers[i], digest));
 
 			// hash is smaller than target (proof of work)
 			// NOTE: One could save constraints by noting that the target only changes every 2016
@@ -83,7 +79,7 @@ impl HeaderChain {
 		Self { header_digests }
 	}
 
-	pub fn populate_inner(&self, filler: &mut WitnessFiller, headers: &[&[u8]]) {
+	pub fn populate_inner(&self, filler: &mut WitnessFiller<'_>, headers: &[&[u8]]) {
 		for (header_digest, header) in self.header_digests.iter().zip(headers) {
 			header_digest.populate_inner(filler, header);
 		}

--- a/crates/circuits/src/bitcoin/merkle_path.rs
+++ b/crates/circuits/src/bitcoin/merkle_path.rs
@@ -45,7 +45,7 @@ impl MerklePath {
 				builder.select(sib.1, sib.0[2], leaf[2]),
 				builder.select(sib.1, sib.0[3], leaf[3]),
 			];
-			pairs.push((DoubleSha256::construct_circuit(builder, message, digest), digest));
+			pairs.push((DoubleSha256::construct_circuit(builder, &message, digest), digest));
 
 			let current_length = builder.add_constant_64(i as u64);
 			let past_length = builder.icmp_ult(current_length, length);
@@ -64,7 +64,7 @@ impl MerklePath {
 
 	pub fn populate_inner(
 		&self,
-		filler: &mut WitnessFiller,
+		filler: &mut WitnessFiller<'_>,
 		mut leaf: [u8; 32],
 		siblings: &[([u8; 32], SiblingSide)],
 	) {

--- a/crates/circuits/src/bitcoin/p2pkh_signature.rs
+++ b/crates/circuits/src/bitcoin/p2pkh_signature.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 
 /// Convert 20-byte address payload into five little-endian u32 words (circuit witness layout).
-pub fn addr_bytes_to_le_words(addr: &[u8; 20]) -> [u32; 5] {
+pub const fn addr_bytes_to_le_words(addr: &[u8; 20]) -> [u32; 5] {
 	[
 		u32::from_le_bytes([addr[0], addr[1], addr[2], addr[3]]),
 		u32::from_le_bytes([addr[4], addr[5], addr[6], addr[7]]),
@@ -264,7 +264,7 @@ mod tests {
 
 		// Pack expected compressed bytes into 9 big-endian u32 words (low 32 bits used)
 		let mut expected_word_values = [0u32; 9];
-		for i in 0..9 {
+		for (i, word_value) in expected_word_values.iter_mut().enumerate() {
 			let start = i * 4;
 			let mut word = 0u32;
 			for j in 0..4 {
@@ -272,7 +272,7 @@ mod tests {
 					word |= (expected_compressed_sec1[start + j] as u32) << (24 - j * 8);
 				}
 			}
-			expected_word_values[i] = word;
+			*word_value = word;
 		}
 		for i in 0..9 {
 			w[expected_words[i]] = Word::from_u64(expected_word_values[i] as u64);
@@ -390,7 +390,7 @@ mod tests {
 
 		// Pack expected compressed bytes into 32-bit words for comparison
 		let mut expected_word_values = [0u32; 9];
-		for i in 0..9 {
+		for (i, word_value) in expected_word_values.iter_mut().enumerate() {
 			let word_start = i * 4;
 			if word_start < 33 {
 				let bytes_in_word = std::cmp::min(4, 33 - word_start);
@@ -398,7 +398,7 @@ mod tests {
 				for j in 0..bytes_in_word {
 					word |= (expected_compressed[word_start + j] as u32) << (24 - j * 8);
 				}
-				expected_word_values[i] = word;
+				*word_value = word;
 			}
 		}
 

--- a/crates/circuits/src/blake2b/circuit.rs
+++ b/crates/circuits/src/blake2b/circuit.rs
@@ -63,7 +63,7 @@ impl Blake2bCircuit {
 	}
 
 	/// Populate the message data into the witness
-	pub fn populate_message(&self, w: &mut WitnessFiller, message: &[u8]) {
+	pub fn populate_message(&self, w: &mut WitnessFiller<'_>, message: &[u8]) {
 		assert!(message.len() <= self.length, "Message exceeds circuit capacity");
 
 		// Pack message bytes into 64-bit words (little-endian)
@@ -82,7 +82,7 @@ impl Blake2bCircuit {
 	}
 
 	/// Populate the expected digest output for verification
-	pub fn populate_digest(&self, w: &mut WitnessFiller, digest: &[u8; 64]) {
+	pub fn populate_digest(&self, w: &mut WitnessFiller<'_>, digest: &[u8; 64]) {
 		// Pack digest bytes into 64-bit words (little-endian)
 		for i in 0..8 {
 			let mut word_value = 0u64;
@@ -141,7 +141,7 @@ impl Blake2bCircuit {
 			let mut m = [zero; 16];
 
 			// Fill message words from input
-			for word_idx in 0..16 {
+			for (word_idx, m_word) in m.iter_mut().enumerate() {
 				let byte_start = block_idx * BLOCK_BYTES + word_idx * 8;
 
 				if byte_start < length {
@@ -156,9 +156,9 @@ impl Blake2bCircuit {
 							// Need to mask off bytes beyond message length
 							let valid_bytes = length - byte_start;
 							let mask = builder.add_constant(Word((1u64 << (valid_bytes * 8)) - 1));
-							m[word_idx] = builder.band(msg_word, mask);
+							*m_word = builder.band(msg_word, mask);
 						} else {
-							m[word_idx] = msg_word;
+							*m_word = msg_word;
 						}
 					}
 				}

--- a/crates/circuits/src/blake2b/reference.rs
+++ b/crates/circuits/src/blake2b/reference.rs
@@ -8,7 +8,7 @@ use super::constants::{BLOCK_BYTES, IV, MAX_OUTPUT_BYTES, R1, R2, R3, R4, ROUNDS
 
 /// Rotate right for 64-bit words
 #[inline(always)]
-fn rotr64(x: u64, n: u32) -> u64 {
+const fn rotr64(x: u64, n: u32) -> u64 {
 	x.rotate_right(n)
 }
 
@@ -16,7 +16,7 @@ fn rotr64(x: u64, n: u32) -> u64 {
 ///
 /// Performs 8 operations mixing two input words with the state
 #[inline(always)]
-pub fn g(v: &mut [u64; 16], a: usize, b: usize, c: usize, d: usize, x: u64, y: u64) {
+pub const fn g(v: &mut [u64; 16], a: usize, b: usize, c: usize, d: usize, x: u64, y: u64) {
 	v[a] = v[a].wrapping_add(v[b]).wrapping_add(x);
 	v[d] = rotr64(v[d] ^ v[a], R1);
 	v[c] = v[c].wrapping_add(v[d]);
@@ -62,9 +62,7 @@ pub fn compress(h: &mut [u64; 8], block: &[u8; 128], t: u128, last: bool) {
 	let m = bytes_to_words(block);
 
 	// 12 rounds of mixing
-	for round in 0..ROUNDS {
-		let s = &SIGMA[round];
-
+	for s in SIGMA.iter().take(ROUNDS) {
 		// Column step (mix columns of the 4x4 matrix)
 		g(&mut v, 0, 4, 8, 12, m[s[0]], m[s[1]]);
 		g(&mut v, 1, 5, 9, 13, m[s[2]], m[s[3]]);

--- a/crates/circuits/src/blake2s/mod.rs
+++ b/crates/circuits/src/blake2s/mod.rs
@@ -340,7 +340,7 @@ impl Blake2s {
 			let mut m = [builder.add_constant(Word(0)); 16];
 
 			// Fill message words from input qwords
-			for word_idx in 0..16 {
+			for (word_idx, m_word) in m.iter_mut().enumerate() {
 				let message_qword = *message.get(block_idx << 3 | word_idx >> 1).unwrap_or(&zero);
 
 				// Select low or high dword from the qword
@@ -366,7 +366,7 @@ impl Blake2s {
 					message_dword
 				};
 
-				m[word_idx] = padded_message_dword;
+				*m_word = padded_message_dword;
 			}
 
 			// Determine if this block is in the valid range and if it's the final block
@@ -409,7 +409,7 @@ impl Blake2s {
 	///
 	/// * `witness` - Witness filler to populate
 	/// * `message` - The message bytes to hash
-	pub fn populate_message(&self, witness: &mut WitnessFiller, message: &[u8]) {
+	pub fn populate_message(&self, witness: &mut WitnessFiller<'_>, message: &[u8]) {
 		assert!(
 			message.len() == self.length,
 			"Only messages of length {} supported while given {} bytes",
@@ -421,7 +421,7 @@ impl Blake2s {
 		for (i, bytes) in message.chunks(8).enumerate() {
 			let mut le_bytes = [0; 8];
 			le_bytes[..bytes.len()].copy_from_slice(bytes);
-			witness[self.message[i]] = Word(u64::from_le_bytes(le_bytes))
+			witness[self.message[i]] = Word(u64::from_le_bytes(le_bytes));
 		}
 	}
 
@@ -431,7 +431,7 @@ impl Blake2s {
 	///
 	/// * `witness` - Witness filler to populate
 	/// * `digest` - The expected 32-byte Blake2s digest
-	pub fn populate_digest(&self, witness: &mut WitnessFiller, digest: &[u8; 32]) {
+	pub fn populate_digest(&self, witness: &mut WitnessFiller<'_>, digest: &[u8; 32]) {
 		// Convert digest bytes to 8 × 32-bit words (little-endian)
 		for i in 0..8 {
 			let word_bytes = &digest[i * 4..(i + 1) * 4];

--- a/crates/circuits/src/blake3/compress.rs
+++ b/crates/circuits/src/blake3/compress.rs
@@ -316,7 +316,7 @@ impl Hint for Blake3CompressHint {
 //
 // Shared by [`Blake3CompressHint`] (prover-side witness generation) and the tests.
 
-fn ref_g(v: &mut [u32; 16], a: usize, b: usize, c: usize, d: usize, mx: u32, my: u32) {
+const fn ref_g(v: &mut [u32; 16], a: usize, b: usize, c: usize, d: usize, mx: u32, my: u32) {
 	v[a] = v[a].wrapping_add(v[b]).wrapping_add(mx);
 	v[d] = (v[d] ^ v[a]).rotate_right(16);
 	v[c] = v[c].wrapping_add(v[d]);
@@ -327,7 +327,7 @@ fn ref_g(v: &mut [u32; 16], a: usize, b: usize, c: usize, d: usize, mx: u32, my:
 	v[b] = (v[b] ^ v[c]).rotate_right(7);
 }
 
-fn ref_round(state: &mut [u32; 16], msg: &[u32; 16], round: usize) {
+const fn ref_round(state: &mut [u32; 16], msg: &[u32; 16], round: usize) {
 	let schedule = MSG_SCHEDULE[round];
 
 	ref_g(state, 0, 4, 8, 12, msg[schedule[0]], msg[schedule[1]]);

--- a/crates/circuits/src/concat.rs
+++ b/crates/circuits/src/concat.rs
@@ -314,7 +314,7 @@ mod tests {
 	/// Build a concat over a mix of constant- and dynamic-length terms, populate, verify
 	/// constraints, and return the concatenated bytes. Lets tests drive the constant-offset /
 	/// constant-length branches that the `new_inout`-based `run_concat` never reaches.
-	fn run_concat_mixed(terms: &[Term]) -> Result<Vec<u8>> {
+	fn run_concat_mixed(terms: &[Term<'_>]) -> Result<Vec<u8>> {
 		let b = CircuitBuilder::new();
 		let inputs: Vec<ByteVec> = terms
 			.iter()
@@ -513,7 +513,7 @@ mod tests {
 					.enumerate()
 					.map(|(i, &n)| random_bytes(n, seed.wrapping_add(i as u64)))
 					.collect();
-				let terms: Vec<Term> = term_bytes.iter().map(|d| Term::Const(d.as_slice())).collect();
+				let terms: Vec<Term<'_>> = term_bytes.iter().map(|d| Term::Const(d.as_slice())).collect();
 				let expected: Vec<u8> = term_bytes.iter().flatten().copied().collect();
 				let bytes = run_concat_mixed(&terms).unwrap();
 				prop_assert_eq!(bytes, expected);

--- a/crates/circuits/src/fixed_byte_vec.rs
+++ b/crates/circuits/src/fixed_byte_vec.rs
@@ -119,7 +119,7 @@ impl ByteVec {
 	///
 	/// # Panics
 	/// * If `len_bytes` lies outside `self.len_range`.
-	pub fn populate_len_bytes(&self, w: &mut WitnessFiller, len_bytes: usize) {
+	pub fn populate_len_bytes(&self, w: &mut WitnessFiller<'_>, len_bytes: usize) {
 		self.assert_len_in_range(len_bytes);
 		w[self.len_bytes] = Word(len_bytes as u64);
 	}
@@ -139,7 +139,7 @@ impl ByteVec {
 	///
 	/// # Panics
 	/// * If bytes.len() exceeds self.max_len
-	pub fn populate_bytes_le(&self, w: &mut WitnessFiller, bytes: &[u8]) {
+	pub fn populate_bytes_le(&self, w: &mut WitnessFiller<'_>, bytes: &[u8]) {
 		self.assert_len_in_range(bytes.len());
 		pack_bytes_into_wires_le(w, &self.data, bytes);
 		w[self.len_bytes] = Word(bytes.len() as u64);
@@ -152,7 +152,7 @@ impl ByteVec {
 	///
 	/// # Panics
 	/// Panics if `data_bytes.len()` > `self.max_len_bytes()`
-	pub fn populate_data(&self, w: &mut WitnessFiller, data_bytes: &[u8]) {
+	pub fn populate_data(&self, w: &mut WitnessFiller<'_>, data_bytes: &[u8]) {
 		assert!(
 			data_bytes.len() <= self.max_len_bytes(),
 			"vector data length {} exceeds maximum {}",
@@ -178,7 +178,7 @@ impl ByteVec {
 	}
 
 	/// Returns the maximum length of this vector in bytes.
-	pub fn max_len_bytes(&self) -> usize {
+	pub const fn max_len_bytes(&self) -> usize {
 		self.data.len() * 8
 	}
 
@@ -186,11 +186,11 @@ impl ByteVec {
 	///
 	/// # Panics
 	/// * If num_wires exceeds self.data.len()
-	pub fn truncate(&self, b: &CircuitBuilder, num_wires: usize) -> ByteVec {
+	pub fn truncate(&self, b: &CircuitBuilder, num_wires: usize) -> Self {
 		assert!(num_wires <= self.data.len(), "num_wires must be less than self.data.len()");
 
 		let trimmed_wires = self.data[0..num_wires].to_vec();
-		ByteVec::new_const_len(b, trimmed_wires, num_wires << 3)
+		Self::new_const_len(b, trimmed_wires, num_wires << 3)
 	}
 
 	/// Extracts a slice at a compile-time constant range.
@@ -225,7 +225,7 @@ impl ByteVec {
 	/// let slice = byte_vec.slice_const_range(&builder, 3..11);
 	/// // slice will have capacity of 16 bytes (2 words) but length of 8 bytes
 	/// ```
-	pub fn slice_const_range(&self, b: &CircuitBuilder, range: Range<usize>) -> ByteVec {
+	pub fn slice_const_range(&self, b: &CircuitBuilder, range: Range<usize>) -> Self {
 		assert!(range.start <= range.end, "Invalid range: start > end");
 		assert!(
 			range.end <= *self.len_range.end(),
@@ -238,7 +238,7 @@ impl ByteVec {
 
 		// Return early if slice is empty
 		if slice_len == 0 {
-			return ByteVec::new_const_len(b, Vec::new(), 0);
+			return Self::new_const_len(b, Vec::new(), 0);
 		}
 
 		// Validate that `range.end <= self.len_bytes` at runtime. For a const-length vec
@@ -252,7 +252,7 @@ impl ByteVec {
 		}
 
 		let output_words = extract_const_range(b, &self.data, range);
-		ByteVec::new_const_len(b, output_words, slice_len)
+		Self::new_const_len(b, output_words, slice_len)
 	}
 }
 

--- a/crates/circuits/src/hash_based_sig/hashing/chain_blake3.rs
+++ b/crates/circuits/src/hash_based_sig/hashing/chain_blake3.rs
@@ -51,7 +51,7 @@ const CV_WORDS: usize = 8;
 
 /// Tweak content length in bytes for a given parameter length:
 /// `param || 0x00 || epoch(4) || chain_index(1) || position(1)`.
-pub fn chain_tweak_len(param_len: usize) -> usize {
+pub const fn chain_tweak_len(param_len: usize) -> usize {
 	param_len + 1 + EPOCH_BYTES + CHAIN_INDEX_BYTES + POSITION_BYTES
 }
 

--- a/crates/circuits/src/hash_based_sig/merkle_tree.rs
+++ b/crates/circuits/src/hash_based_sig/merkle_tree.rs
@@ -40,15 +40,12 @@ pub fn circuit_merkle_path(
 		domain_param.len() * 8
 	);
 
-	let tree_height = auth_path.len();
 	let mut current_hash = *leaf_hash;
 	let mut current_index = leaf_index;
 	let one = builder.add_constant_64(1);
 
 	// Climb one tree level per authentication-path sibling.
-	for level in 0..tree_height {
-		let sibling_hash = auth_path[level];
-
+	for (level, &sibling_hash) in auth_path.iter().enumerate() {
 		// The current node is the left child when its index is even (low bit clear).
 		let is_left = builder.bnot(builder.band(current_index, one));
 

--- a/crates/circuits/src/hash_based_sig/winternitz_ots.rs
+++ b/crates/circuits/src/hash_based_sig/winternitz_ots.rs
@@ -247,12 +247,12 @@ impl WinternitzSpec {
 	}
 
 	/// Returns the number of coordinates/chains
-	pub fn dimension(&self) -> usize {
+	pub const fn dimension(&self) -> usize {
 		self.message_hash_len * 8 / self.coordinate_resolution_bits
 	}
 
 	/// Returns the chain length (2^coordinate_resolution_bits)
-	pub fn chain_len(&self) -> usize {
+	pub const fn chain_len(&self) -> usize {
 		1 << self.coordinate_resolution_bits
 	}
 
@@ -390,13 +390,11 @@ mod tests {
 
 		// Prepare signatures and derive each public key as the endpoint after
 		// (chain_len - 1 - x_i) steps starting from sig_i, at positions x_i+1..chain_len-1.
-		let mut sig_hashes = Vec::with_capacity(spec.dimension());
 		let mut pk_hashes = Vec::with_capacity(spec.dimension());
 
 		for chain_idx in 0..spec.dimension() {
 			let mut sig = [0u8; MESSAGE_LENGTH_BYTES];
 			rng.fill_bytes(&mut sig);
-			sig_hashes.push(sig);
 
 			let xi = grind.coords[chain_idx] as usize;
 			let pk_hash = hash_chain_blake3(

--- a/crates/circuits/src/hash_based_sig/witness_utils.rs
+++ b/crates/circuits/src/hash_based_sig/witness_utils.rs
@@ -65,9 +65,9 @@ pub fn extract_auth_path(tree_levels: &[Vec<[u8; 32]>], leaf_index: usize) -> Ve
 	let mut idx = leaf_index;
 	let tree_height = tree_levels.len() - 1;
 
-	for level in 0..tree_height {
+	for level in tree_levels.iter().take(tree_height) {
 		let sibling_idx = idx ^ 1;
-		auth_path.push(tree_levels[level][sibling_idx]);
+		auth_path.push(level[sibling_idx]);
 		idx /= 2;
 	}
 
@@ -175,7 +175,7 @@ impl ValidatorSignatureData {
 		let (tree_levels, root) = build_merkle_tree(param_bytes, &leaves);
 		let auth_path = extract_auth_path(&tree_levels, epoch as usize);
 
-		ValidatorSignatureData {
+		Self {
 			root,
 			nonce,
 			signature_hashes,

--- a/crates/circuits/src/hash_based_sig/xmss.rs
+++ b/crates/circuits/src/hash_based_sig/xmss.rs
@@ -186,7 +186,7 @@ mod tests {
 			let (tree_levels, root_hash) = build_merkle_tree(&param_bytes, &leaves);
 			let auth_path = extract_auth_path(&tree_levels, signing_epoch as usize);
 
-			XmssTestData {
+			Self {
 				param_bytes,
 				message_bytes,
 				nonce_bytes: grind_result.nonce,
@@ -292,36 +292,36 @@ mod tests {
 	}
 
 	impl TestCase {
-		fn run(&self, spec: WinternitzSpec) {
+		fn run(&self, spec: &WinternitzSpec) {
 			let mut rng = StdRng::seed_from_u64(42);
 
 			match self {
-				TestCase::Valid {
+				Self::Valid {
 					tree_size,
 					signing_epoch,
 				} => {
 					// Generate test data
 					let test_data =
-						XmssTestData::generate(&spec, *tree_size, *signing_epoch, &mut rng);
+						XmssTestData::generate(spec, *tree_size, *signing_epoch, &mut rng);
 
-					let result = test_data.run(&spec);
+					let result = test_data.run(spec);
 					result.unwrap_or_else(|e| {
 						panic!("Test expected to pass but failed: {}", e);
 					});
 				}
-				TestCase::Invalid {
+				Self::Invalid {
 					tree_size,
 					signing_epoch,
 					corrupt_fn,
 				} => {
 					// Generate test data
 					let mut test_data =
-						XmssTestData::generate(&spec, *tree_size, *signing_epoch, &mut rng);
+						XmssTestData::generate(spec, *tree_size, *signing_epoch, &mut rng);
 
 					// Apply corruption
 					corrupt_fn(&mut test_data);
 
-					let result = test_data.run(&spec);
+					let result = test_data.run(spec);
 					assert!(result.is_err(), "Test expected to fail but passed");
 				}
 			}
@@ -392,7 +392,7 @@ mod tests {
 			tree_size,
 			signing_epoch,
 		}
-		.run(spec);
+		.run(&spec);
 	}
 
 	/// Invalid test cases with various corruption scenarios
@@ -409,6 +409,6 @@ mod tests {
 			signing_epoch: 1,
 			corrupt_fn,
 		}
-		.run(test_spec_small());
+		.run(&test_spec_small());
 	}
 }

--- a/crates/circuits/src/hash_based_sig/xmss_aggregate.rs
+++ b/crates/circuits/src/hash_based_sig/xmss_aggregate.rs
@@ -68,7 +68,7 @@ pub struct MultiSigBuilder<'a> {
 }
 
 impl<'a> MultiSigBuilder<'a> {
-	pub fn new(builder: &'a CircuitBuilder, spec: &'a WinternitzSpec) -> Self {
+	pub const fn new(builder: &'a CircuitBuilder, spec: &'a WinternitzSpec) -> Self {
 		Self { builder, spec }
 	}
 
@@ -158,11 +158,11 @@ mod tests {
 	}
 
 	impl MultisigTestCase {
-		fn run(&self, spec: WinternitzSpec) {
+		fn run(&self, spec: &WinternitzSpec) {
 			let mut rng = StdRng::seed_from_u64(42);
 
 			match self {
-				MultisigTestCase::Valid {
+				Self::Valid {
 					num_validators,
 					tree_height,
 					epoch,
@@ -171,12 +171,12 @@ mod tests {
 						*num_validators,
 						*tree_height,
 						*epoch,
-						&spec,
+						spec,
 						&mut rng,
 					);
-					test_data.run(&spec, *tree_height).unwrap();
+					test_data.run(spec, *tree_height).unwrap();
 				}
-				MultisigTestCase::Invalid {
+				Self::Invalid {
 					num_validators,
 					tree_height,
 					epoch,
@@ -186,11 +186,11 @@ mod tests {
 						*num_validators,
 						*tree_height,
 						*epoch,
-						&spec,
+						spec,
 						&mut rng,
 					);
 					corrupt_fn(&mut test_data);
-					let result = test_data.run(&spec, *tree_height);
+					let result = test_data.run(spec, *tree_height);
 					assert!(result.is_err(), "Test expected to fail but passed");
 				}
 			}
@@ -234,7 +234,7 @@ mod tests {
 				validator_param_bytes.push(param_bytes);
 			}
 
-			MultisigTestData {
+			Self {
 				validator_param_bytes,
 				message_bytes,
 				epoch,
@@ -345,7 +345,7 @@ mod tests {
 			tree_height,
 			epoch,
 		}
-		.run(spec);
+		.run(&spec);
 	}
 
 	fn corrupt_one_validator_signature(test_data: &mut MultisigTestData) {
@@ -460,6 +460,6 @@ mod tests {
 			epoch: 2, // All validators sign at epoch 2
 			corrupt_fn,
 		}
-		.run(test_spec_small());
+		.run(&test_spec_small());
 	}
 }

--- a/crates/circuits/src/jwt_claims.rs
+++ b/crates/circuits/src/jwt_claims.rs
@@ -14,7 +14,7 @@ pub struct Attribute {
 
 impl Attribute {
 	/// Populate the actual value length
-	pub fn populate_len_bytes(&self, w: &mut WitnessFiller, len_bytes: usize) {
+	pub fn populate_len_bytes(&self, w: &mut WitnessFiller<'_>, len_bytes: usize) {
 		w[self.len_bytes] = Word(len_bytes as u64);
 	}
 
@@ -22,7 +22,7 @@ impl Attribute {
 	///
 	/// # Panics
 	/// Panics if value.len() > max_value_size (determined by self.value.len() * 8)
-	pub fn populate_value(&self, w: &mut WitnessFiller, value: &[u8]) {
+	pub fn populate_value(&self, w: &mut WitnessFiller<'_>, value: &[u8]) {
 		pack_bytes_into_wires_le(w, &self.value, value);
 	}
 }
@@ -190,7 +190,7 @@ impl JwtClaims {
 			slice::assert_slice_eq(&b, "attr_value", value_length, &extracted, &attr.value);
 		}
 
-		JwtClaims {
+		Self {
 			len_bytes,
 			json,
 			attributes,
@@ -198,7 +198,7 @@ impl JwtClaims {
 	}
 
 	/// Populate the len_bytes wire with the actual JSON size in bytes
-	pub fn populate_len_bytes(&self, w: &mut WitnessFiller, len_bytes: usize) {
+	pub fn populate_len_bytes(&self, w: &mut WitnessFiller<'_>, len_bytes: usize) {
 		w[self.len_bytes] = Word(len_bytes as u64);
 	}
 
@@ -206,7 +206,7 @@ impl JwtClaims {
 	///
 	/// # Panics
 	/// Panics if json.len() > max_len_json (the maximum size specified during construction)
-	pub fn populate_json(&self, w: &mut WitnessFiller, json: &[u8]) {
+	pub fn populate_json(&self, w: &mut WitnessFiller<'_>, json: &[u8]) {
 		pack_bytes_into_wires_le(w, &self.json, json);
 	}
 }

--- a/crates/circuits/src/keccak/mod.rs
+++ b/crates/circuits/src/keccak/mod.rs
@@ -201,7 +201,7 @@ impl Keccak256 {
 		}
 	}
 
-	pub fn max_len_bytes(&self) -> usize {
+	pub const fn max_len_bytes(&self) -> usize {
 		self.message.len() << 3
 	}
 

--- a/crates/circuits/src/keccak/permutation.rs
+++ b/crates/circuits/src/keccak/permutation.rs
@@ -80,7 +80,7 @@ impl Permutation {
 	///
 	/// * `w` - The witness to populate the state with.
 	/// * `state` - The state to populate the witness with.
-	pub fn populate_state(&self, w: &mut WitnessFiller, state: [u64; 25]) {
+	pub fn populate_state(&self, w: &mut WitnessFiller<'_>, state: [u64; 25]) {
 		for i in 0..25 {
 			w[self.input_state.words[i]] = Word(state[i]);
 		}

--- a/crates/circuits/src/multiplexer.rs
+++ b/crates/circuits/src/multiplexer.rs
@@ -116,7 +116,7 @@ pub fn single_wire_multiplex(b: &CircuitBuilder, inputs: &[Wire], sel: Wire) -> 
 }
 
 #[inline]
-fn log2_ceil_usize(n: usize) -> usize {
+const fn log2_ceil_usize(n: usize) -> usize {
 	if n <= 1 {
 		0
 	} else {

--- a/crates/circuits/src/rs256.rs
+++ b/crates/circuits/src/rs256.rs
@@ -12,7 +12,7 @@ use crate::{
 ///
 /// This function converts a FixedByteVec with little-endian packed wires
 /// to a BigUint representing a big-endian number.
-fn fixedbytevec_le_to_biguint(builder: &mut CircuitBuilder, byte_vec: &ByteVec) -> BigUint {
+fn fixedbytevec_le_to_biguint(builder: &CircuitBuilder, byte_vec: &ByteVec) -> BigUint {
 	// With LE packing, each wire contains 8 bytes as: byte0 | byte1<<8 | ... | byte7<<56
 	// For a BE number, we need to both reverse wire order AND byte-swap within each wire
 	let mut limbs = Vec::new();
@@ -102,7 +102,7 @@ impl Rs256Verify {
 		let signature = if signature.data.len() > 32 {
 			signature.truncate(builder, 32)
 		} else {
-			signature.clone()
+			signature
 		};
 
 		let signature_bignum = fixedbytevec_le_to_biguint(builder, &signature);
@@ -213,19 +213,24 @@ impl Rs256Verify {
 	}
 
 	/// Populate the message length
-	pub fn populate_len_bytes(&self, w: &mut WitnessFiller, len_bytes: usize) {
+	pub fn populate_len_bytes(&self, w: &mut WitnessFiller<'_>, len_bytes: usize) {
 		self.sha256.populate_len_bytes(w, len_bytes);
 	}
 
 	/// Populate the RSA signature, modulus and intermediate computations
-	pub fn populate_rsa(&self, w: &mut WitnessFiller, signature: &[u8], modulus: &[u8]) {
+	pub fn populate_rsa(&self, w: &mut WitnessFiller<'_>, signature: &[u8], modulus: &[u8]) {
 		self.populate_signature(w, signature);
 		self.populate_modulus(w, modulus);
 		self.rsa_intermediates
 			.populate_witness(w, signature, modulus);
 	}
 
-	pub fn populate_intermediates(&self, w: &mut WitnessFiller, signature: &[u8], modulus: &[u8]) {
+	pub fn populate_intermediates(
+		&self,
+		w: &mut WitnessFiller<'_>,
+		signature: &[u8],
+		modulus: &[u8],
+	) {
 		self.rsa_intermediates
 			.populate_witness(w, signature, modulus);
 	}
@@ -234,7 +239,7 @@ impl Rs256Verify {
 	///
 	/// # Panics
 	/// Panics if message.len() > self.message.len() * 8
-	pub fn populate_message(&self, w: &mut WitnessFiller, message: &[u8]) {
+	pub fn populate_message(&self, w: &mut WitnessFiller<'_>, message: &[u8]) {
 		self.sha256.populate_message(w, message);
 	}
 
@@ -242,7 +247,7 @@ impl Rs256Verify {
 	///
 	/// # Panics
 	/// Panics if modulus_bytes.len() != 256
-	pub fn populate_modulus(&self, w: &mut WitnessFiller, modulus_bytes: &[u8]) {
+	pub fn populate_modulus(&self, w: &mut WitnessFiller<'_>, modulus_bytes: &[u8]) {
 		assert_eq!(modulus_bytes.len(), 256, "modulus must be exactly 256 bytes");
 		self.modulus.populate_bytes_le(w, modulus_bytes);
 	}
@@ -255,7 +260,7 @@ impl Rs256Verify {
 	///
 	/// # Panics
 	/// Panics if signature_bytes.len() != 256
-	pub fn populate_signature(&self, w: &mut WitnessFiller, signature_bytes: &[u8]) {
+	pub fn populate_signature(&self, w: &mut WitnessFiller<'_>, signature_bytes: &[u8]) {
 		assert_eq!(signature_bytes.len(), 256, "signature must be exactly 256 bytes");
 		self.signature.populate_bytes_le(w, signature_bytes);
 	}
@@ -320,7 +325,7 @@ impl RsaIntermediates {
 		let mul_quotient = BigUint::new_witness(builder, 32);
 		let mul_remainder = BigUint::new_witness(builder, 32);
 
-		RsaIntermediates {
+		Self {
 			square_quotients,
 			square_remainders,
 			mul_quotient,
@@ -336,7 +341,7 @@ impl RsaIntermediates {
 	/// # Arguments
 	/// * `signature` - The bytes of a RSA signature
 	/// * `modulus_limbs` - The bytes of a RSA modulus
-	pub fn populate_witness(&self, w: &mut WitnessFiller, signature: &[u8], modulus: &[u8]) {
+	pub fn populate_witness(&self, w: &mut WitnessFiller<'_>, signature: &[u8], modulus: &[u8]) {
 		assert_eq!(signature.len(), 256, "signature must be exactly 256 bytes");
 		assert_eq!(modulus.len(), 256, "modulus must be exactly 256 bytes");
 
@@ -382,7 +387,11 @@ impl RsaIntermediates {
 	///
 	/// # Panics
 	/// Panics if square_quotient_limbs.len() != 16 or if any quotient doesn't have 32 limbs.
-	fn populate_square_quotients(&self, w: &mut WitnessFiller, square_quotient_limbs: &[Vec<u64>]) {
+	fn populate_square_quotients(
+		&self,
+		w: &mut WitnessFiller<'_>,
+		square_quotient_limbs: &[Vec<u64>],
+	) {
 		assert_eq!(square_quotient_limbs.len(), 16, "must provide 16 square quotients");
 		for (i, q_limbs) in square_quotient_limbs.iter().enumerate() {
 			assert_eq!(
@@ -401,7 +410,7 @@ impl RsaIntermediates {
 	/// Panics if square_remainder_limbs.len() != 16 or if any remainder doesn't have 32 limbs
 	fn populate_square_remainders(
 		&self,
-		w: &mut WitnessFiller,
+		w: &mut WitnessFiller<'_>,
 		square_remainder_limbs: &[Vec<u64>],
 	) {
 		assert_eq!(square_remainder_limbs.len(), 16, "must provide 16 square remainders");
@@ -415,7 +424,7 @@ impl RsaIntermediates {
 	///
 	/// # Panics
 	/// Panics if mul_quotient_limbs.len() != 32
-	fn populate_mul_quotient(&self, w: &mut WitnessFiller, mul_quotient_limbs: &[u64]) {
+	fn populate_mul_quotient(&self, w: &mut WitnessFiller<'_>, mul_quotient_limbs: &[u64]) {
 		assert_eq!(
 			mul_quotient_limbs.len(),
 			self.mul_quotient.limbs.len(),
@@ -429,7 +438,7 @@ impl RsaIntermediates {
 	///
 	/// # Panics
 	/// Panics if mul_remainder_limbs.len() != 32
-	fn populate_mul_remainder(&self, w: &mut WitnessFiller, mul_remainder_limbs: &[u64]) {
+	fn populate_mul_remainder(&self, w: &mut WitnessFiller<'_>, mul_remainder_limbs: &[u64]) {
 		assert_eq!(mul_remainder_limbs.len(), 32, "mul_remainder must have 32 limbs");
 		self.mul_remainder.populate_limbs(w, mul_remainder_limbs);
 	}
@@ -470,7 +479,7 @@ mod tests {
 
 	fn populate_circuit(
 		circuit: &Rs256Verify,
-		w: &mut WitnessFiller,
+		w: &mut WitnessFiller<'_>,
 		signature_bytes: &[u8],
 		message_bytes: &[u8],
 		modulus_bytes: &[u8],

--- a/crates/circuits/src/secp256k1/curve.rs
+++ b/crates/circuits/src/secp256k1/curve.rs
@@ -28,12 +28,12 @@ impl Secp256k1 {
 	}
 
 	/// Coordinate field.
-	pub fn f_p(&self) -> &PseudoMersennePrimeField {
+	pub const fn f_p(&self) -> &PseudoMersennePrimeField {
 		&self.f_p
 	}
 
 	/// Scalar field.
-	pub fn f_scalar(&self) -> &PseudoMersennePrimeField {
+	pub const fn f_scalar(&self) -> &PseudoMersennePrimeField {
 		&self.f_scalar
 	}
 

--- a/crates/circuits/src/secp256k1/point.rs
+++ b/crates/circuits/src/secp256k1/point.rs
@@ -37,10 +37,10 @@ impl Secp256k1Affine {
 
 	/// Return point-at-infinity unless the MSB-boolean `cond` is true, then pass the point
 	/// unchanged.
-	pub fn pai_unless(&self, b: &CircuitBuilder, cond: Wire) -> Secp256k1Affine {
+	pub fn pai_unless(&self, b: &CircuitBuilder, cond: Wire) -> Self {
 		let is_point_at_infinity =
 			b.select(cond, self.is_point_at_infinity, b.add_constant(Word::ALL_ONE));
-		Secp256k1Affine {
+		Self {
 			x: self.x.clone(),
 			y: self.y.clone(),
 			is_point_at_infinity,

--- a/crates/circuits/src/sha256/compress.rs
+++ b/crates/circuits/src/sha256/compress.rs
@@ -23,24 +23,24 @@ const K: [u32; 64] = [
 /// 4 x 64-bit words.
 ///
 /// The elements are referred to as a–h or H0–H7.
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct State(pub [Wire; 8]);
 
 impl State {
-	pub fn new(wires: [Wire; 8]) -> Self {
-		State(wires)
+	pub const fn new(wires: [Wire; 8]) -> Self {
+		Self(wires)
 	}
 
 	pub fn public(builder: &CircuitBuilder) -> Self {
-		State(std::array::from_fn(|_| builder.add_inout()))
+		Self(std::array::from_fn(|_| builder.add_inout()))
 	}
 
 	pub fn private(builder: &CircuitBuilder) -> Self {
-		State(std::array::from_fn(|_| builder.add_witness()))
+		Self(std::array::from_fn(|_| builder.add_witness()))
 	}
 
 	pub fn iv(builder: &CircuitBuilder) -> Self {
-		State(std::array::from_fn(|i| builder.add_constant(Word(IV[i] as u64))))
+		Self(std::array::from_fn(|i| builder.add_constant(Word(IV[i] as u64))))
 	}
 
 	/// Packs the state into 4 x 64-bit words.
@@ -148,7 +148,7 @@ fn compress_inner(
 	}
 
 	let w: &[Wire; 64] = (&*w).try_into().unwrap();
-	let mut state = state_in.clone();
+	let mut state = state_in;
 	for t in 0..64 {
 		state = round(builder, k[t], w[t], state);
 	}
@@ -170,7 +170,7 @@ fn compress_inner(
 ///
 /// The bytes are packed big-endian into 16 32-bit words, one per wire, with the high 32 bits left
 /// zero — matching the precondition on `m` documented in [`sha256_compress`].
-pub fn populate_message_block(w: &mut WitnessFiller, m: &[Wire; 16], bytes: [u8; 64]) {
+pub fn populate_message_block(w: &mut WitnessFiller<'_>, m: &[Wire; 16], bytes: [u8; 64]) {
 	for (wire, chunk) in m.iter().zip(bytes.chunks_exact(4)) {
 		let word = u32::from_be_bytes(chunk.try_into().unwrap());
 		w[*wire] = Word(word as u64);
@@ -443,8 +443,8 @@ mod tests {
 		let m: [Wire; 16] = std::array::from_fn(|_| circuit.add_witness());
 		let out = sha256_compress_2x(&circuit, State::new(state_in), m);
 		let out_inout: [Wire; 8] = std::array::from_fn(|_| circuit.add_inout());
-		for i in 0..8 {
-			circuit.assert_eq(format!("out[{i}]"), out.0[i], out_inout[i]);
+		for (i, &out_inout_wire) in out_inout.iter().enumerate() {
+			circuit.assert_eq(format!("out[{i}]"), out.0[i], out_inout_wire);
 		}
 
 		let circuit = circuit.build();

--- a/crates/circuits/src/sha256/mod.rs
+++ b/crates/circuits/src/sha256/mod.rs
@@ -163,7 +163,7 @@ impl Sha256 {
 			});
 			let state_out = sha256_compress(
 				&builder.subcircuit(format!("compress[{block_no}]")),
-				states[block_no].clone(),
+				states[block_no],
 				m,
 			);
 			states.push(state_out);
@@ -360,7 +360,7 @@ impl Sha256 {
 	}
 
 	/// Returns the maximum message length, in bytes.
-	pub fn max_len_bytes(&self) -> usize {
+	pub const fn max_len_bytes(&self) -> usize {
 		self.message.len() << (LOG_WORD_SIZE_BITS - LOG_BYTE_BITS)
 	}
 
@@ -592,7 +592,7 @@ pub fn sha256_fixed(builder: &CircuitBuilder, message: &[Wire], len_bytes: usize
 
 			sha256_compress(
 				&builder.subcircuit(format!("sha256_fixed_compress[{}]", block_idx)),
-				state.clone(),
+				state,
 				block_message,
 			)
 		},
@@ -613,7 +613,7 @@ mod tests {
 
 	use super::*;
 
-	fn mk_circuit(b: &mut CircuitBuilder, max_len: usize) -> Sha256 {
+	fn mk_circuit(b: &CircuitBuilder, max_len: usize) -> Sha256 {
 		let len = b.add_witness();
 		let digest: [Wire; 4] = std::array::from_fn(|_| b.add_inout());
 		let message = (0..max_len).map(|_| b.add_inout()).collect();
@@ -622,8 +622,8 @@ mod tests {
 
 	#[test]
 	fn full_sha256() {
-		let mut b = CircuitBuilder::new();
-		let c = mk_circuit(&mut b, 256);
+		let b = CircuitBuilder::new();
+		let c = mk_circuit(&b, 256);
 		let circuit = b.build();
 		let mut w = circuit.new_witness_filler();
 		c.populate_len_bytes(&mut w, 3);
@@ -637,8 +637,8 @@ mod tests {
 
 	#[test]
 	fn full_sha256_multi_block() {
-		let mut b = CircuitBuilder::new();
-		let c = mk_circuit(&mut b, 256);
+		let b = CircuitBuilder::new();
+		let c = mk_circuit(&b, 256);
 		let circuit = b.build();
 		let mut w = circuit.new_witness_filler();
 
@@ -654,8 +654,8 @@ mod tests {
 
 	// Helper function to run SHA-256 test with given input and expected digest
 	fn test_sha256_with_input(message_bytes: &[u8], expected_digest: [u8; 32]) {
-		let mut b = CircuitBuilder::new();
-		let c = mk_circuit(&mut b, 256);
+		let b = CircuitBuilder::new();
+		let c = mk_circuit(&b, 256);
 		let circuit = b.build();
 		let cs = circuit.constraint_system();
 		let mut w = circuit.new_witness_filler();
@@ -831,8 +831,8 @@ mod tests {
 	#[test]
 	fn test_bogus_length_rejection() {
 		// Test that providing wrong length causes circuit to reject
-		let mut b = CircuitBuilder::new();
-		let c = mk_circuit(&mut b, 256);
+		let b = CircuitBuilder::new();
+		let c = mk_circuit(&b, 256);
 		let circuit = b.build();
 		let mut w = circuit.new_witness_filler();
 
@@ -854,8 +854,8 @@ mod tests {
 	fn test_length_exceeds_max_rejection() {
 		// Test that providing a length > max_len_bytes causes circuit to reject
 		let max_len = 3;
-		let mut b = CircuitBuilder::new();
-		let c = mk_circuit(&mut b, max_len);
+		let b = CircuitBuilder::new();
+		let c = mk_circuit(&b, max_len);
 		let circuit = b.build();
 		let mut w = circuit.new_witness_filler();
 
@@ -876,8 +876,8 @@ mod tests {
 	#[test]
 	fn test_invalid_digest_rejection() {
 		// Test that providing wrong digest causes circuit to reject
-		let mut b = CircuitBuilder::new();
-		let c = mk_circuit(&mut b, 256);
+		let b = CircuitBuilder::new();
+		let c = mk_circuit(&b, 256);
 		let circuit = b.build();
 		let mut w = circuit.new_witness_filler();
 
@@ -895,8 +895,8 @@ mod tests {
 	#[test]
 	fn test_wrong_message_content() {
 		// Test that providing wrong message content causes circuit to reject
-		let mut b = CircuitBuilder::new();
-		let c = mk_circuit(&mut b, 256);
+		let b = CircuitBuilder::new();
+		let c = mk_circuit(&b, 256);
 		let circuit = b.build();
 		let mut w = circuit.new_witness_filler();
 
@@ -934,8 +934,8 @@ mod tests {
 		];
 
 		for (max_len, description) in test_cases {
-			let mut b = CircuitBuilder::new();
-			let c = mk_circuit(&mut b, max_len);
+			let b = CircuitBuilder::new();
+			let c = mk_circuit(&b, max_len);
 			let circuit = b.build();
 
 			assert_eq!(
@@ -964,8 +964,8 @@ mod tests {
 
 	#[test]
 	fn test_sha256_to_le_wires() {
-		let mut b = CircuitBuilder::new();
-		let c = mk_circuit(&mut b, 64);
+		let b = CircuitBuilder::new();
+		let c = mk_circuit(&b, 64);
 
 		// Obtain LE-packed wires for the digest wires
 		let le_wires = c.digest_to_le_wires(&b);
@@ -995,8 +995,8 @@ mod tests {
 
 	#[test]
 	fn test_message_to_le_wires() {
-		let mut b = CircuitBuilder::new();
-		let c = mk_circuit(&mut b, 16); // Small circuit for simple test
+		let b = CircuitBuilder::new();
+		let c = mk_circuit(&b, 16); // Small circuit for simple test
 
 		// Obtain LE-packed wires for the message
 		let le_message_wires = c.message_to_le_wires(&b);

--- a/crates/circuits/src/sha512/compress.rs
+++ b/crates/circuits/src/sha512/compress.rs
@@ -101,24 +101,24 @@ const K: [u64; 80] = [
 /// The state size is 512 bits.
 ///
 /// The elements are referred to as a–h or H0–H7.
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct State(pub [Wire; 8]);
 
 impl State {
-	pub fn new(wires: [Wire; 8]) -> Self {
-		State(wires)
+	pub const fn new(wires: [Wire; 8]) -> Self {
+		Self(wires)
 	}
 
 	pub fn public(builder: &CircuitBuilder) -> Self {
-		State(std::array::from_fn(|_| builder.add_inout()))
+		Self(std::array::from_fn(|_| builder.add_inout()))
 	}
 
 	pub fn private(builder: &CircuitBuilder) -> Self {
-		State(std::array::from_fn(|_| builder.add_witness()))
+		Self(std::array::from_fn(|_| builder.add_witness()))
 	}
 
 	pub fn iv(builder: &CircuitBuilder) -> Self {
-		State(std::array::from_fn(|i| builder.add_constant(Word(IV[i]))))
+		Self(std::array::from_fn(|i| builder.add_constant(Word(IV[i]))))
 	}
 }
 
@@ -151,7 +151,7 @@ pub fn compress(builder: &CircuitBuilder, state_in: State, m: [Wire; 16]) -> Sta
 	}
 
 	let w: &[Wire; 80] = (&*w).try_into().unwrap();
-	let mut state = state_in.clone();
+	let mut state = state_in;
 	for t in 0..80 {
 		state = round(builder, t, state, w);
 	}

--- a/crates/circuits/src/sha512/mod.rs
+++ b/crates/circuits/src/sha512/mod.rs
@@ -118,7 +118,7 @@ pub fn sha512_fixed(builder: &CircuitBuilder, message: &[Wire], len_bytes: usize
 				.expect("padded_message.len() must be divisible by 16");
 			compress(
 				&builder.subcircuit(format!("sha512_fixed_compress[{}]", block_idx)),
-				state.clone(),
+				state,
 				block_message,
 			)
 		},
@@ -258,11 +258,8 @@ pub fn sha512_varlen(builder: &CircuitBuilder, message: &ByteVec) -> [Wire; 8] {
 		let m: [Wire; 16] = padded_message[block_no << 4..(block_no + 1) << 4]
 			.try_into()
 			.unwrap();
-		let state_out = compress(
-			&builder.subcircuit(format!("compress[{block_no}]")),
-			states[block_no].clone(),
-			m,
-		);
+		let state_out =
+			compress(&builder.subcircuit(format!("compress[{block_no}]")), states[block_no], m);
 		states.push(state_out);
 	}
 
@@ -315,8 +312,8 @@ mod tests {
 			let byte_end = ((i + 1) * 8).min(message_bytes.len());
 
 			let mut word = 0u64;
-			for j in byte_start..byte_end {
-				word |= (message_bytes[j] as u64) << (56 - (j - byte_start) * 8);
+			for (k, byte) in message_bytes[byte_start..byte_end].iter().enumerate() {
+				word |= (*byte as u64) << (56 - k * 8);
 			}
 			w[*wire] = Word(word);
 		}

--- a/crates/circuits/src/skein512/mod.rs
+++ b/crates/circuits/src/skein512/mod.rs
@@ -106,7 +106,7 @@ impl Skein512 {
 		let mut current_cv = config_ubi_out;
 
 		// Process each message block
-		for block_idx in 0..n_blocks {
+		for (block_idx, &message_block) in message.iter().enumerate().take(n_blocks) {
 			// Calculate position: number of bytes processed so far INCLUDING this block
 			let pos_end = ((block_idx + 1) * 64) as u64;
 
@@ -123,7 +123,7 @@ impl Skein512 {
 			let t_msg_wires = [t_low, t_high];
 
 			// Message UBI: CV_{i+1} = UBI(CV_i, T_msg, message_block_i)
-			current_cv = ubi_block(builder, current_cv, t_msg_wires, message[block_idx]);
+			current_cv = ubi_block(builder, current_cv, t_msg_wires, message_block);
 		}
 
 		// ---- Final Message Block (Empty) ----
@@ -218,7 +218,7 @@ impl Skein512 {
 	}
 
 	/// Get the digest wires
-	pub fn digest_wires(&self) -> [Wire; 8] {
+	pub const fn digest_wires(&self) -> [Wire; 8] {
 		self.digest
 	}
 
@@ -264,7 +264,7 @@ fn mix(circuit: &CircuitBuilder, a: Wire, b: Wire, r: u32) -> (Wire, Wire) {
 /// This corresponds to the Threefish permutation from Table 3 of the Skein specification
 /// for Nw=8 (8 words). The permutation is applied after the MIX operations in each round
 /// to ensure proper diffusion across the state.
-fn permute_512(_circuit: &CircuitBuilder, x: [Wire; 8]) -> [Wire; 8] {
+const fn permute_512(_circuit: &CircuitBuilder, x: [Wire; 8]) -> [Wire; 8] {
 	[x[2], x[1], x[4], x[7], x[6], x[5], x[0], x[3]]
 }
 
@@ -468,9 +468,9 @@ impl Threefish512Block {
 		let mut k_vec = Vec::with_capacity(9);
 		let mut sum = key[0];
 		k_vec.push(key[0]);
-		for i in 1..8 {
-			k_vec.push(key[i]);
-			sum = circuit.bxor(sum, key[i]);
+		for &key_word in key.iter().skip(1) {
+			k_vec.push(key_word);
+			sum = circuit.bxor(sum, key_word);
 		}
 		k_vec.push(circuit.bxor(c240, sum));
 		let k: [Wire; 9] = k_vec.try_into().expect("Vec to array conversion");
@@ -1110,8 +1110,8 @@ mod tests {
 				&circuit, v_in_wires, k_wires, t_wires, group_idx,
 			);
 
-			for i in 0..8 {
-				let expected_wire = circuit.add_constant(Word(expected[i]));
+			for (i, &expected_val) in expected.iter().enumerate() {
+				let expected_wire = circuit.add_constant(Word(expected_val));
 				circuit.assert_eq(format!("{}[{}]", description, i), comp.v_out[i], expected_wire);
 			}
 
@@ -1182,8 +1182,8 @@ mod tests {
 
 			let comp = Threefish512Block::new(&circuit, key_wires, tweak_wires, block_wires);
 
-			for i in 0..8 {
-				let expected_wire = circuit.add_constant(Word(expected[i]));
+			for (i, &expected_val) in expected.iter().enumerate() {
+				let expected_wire = circuit.add_constant(Word(expected_val));
 				circuit.assert_eq(format!("{}[{}]", description, i), comp.v_out[i], expected_wire);
 			}
 

--- a/crates/circuits/src/slice.rs
+++ b/crates/circuits/src/slice.rs
@@ -198,7 +198,7 @@ mod tests {
 	/// Run a success-case test: pack `input_data` and `expected_slice_data` into the test setup,
 	/// run the circuit, and verify constraints.
 	fn run_slice_success(
-		setup: SliceTestSetup,
+		setup: &SliceTestSetup,
 		len_input_val: u64,
 		len_slice_val: u64,
 		offset_val: u64,
@@ -220,7 +220,7 @@ mod tests {
 
 	/// Run a failure-case test: expect `populate_wire_witness` to error.
 	fn run_slice_failure(
-		setup: SliceTestSetup,
+		setup: &SliceTestSetup,
 		len_input_val: u64,
 		len_slice_val: u64,
 		offset_val: u64,
@@ -246,7 +246,7 @@ mod tests {
 			0x0e, 0x0f,
 		];
 		let slice_data = [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07];
-		run_slice_success(setup, 16, 8, 0, &input_data, &slice_data);
+		run_slice_success(&setup, 16, 8, 0, &input_data, &slice_data);
 	}
 
 	#[test]
@@ -258,7 +258,7 @@ mod tests {
 			0x0e, 0x0f,
 		];
 		let slice_data = [0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a];
-		run_slice_success(setup, 16, 8, 3, &input_data, &slice_data);
+		run_slice_success(&setup, 16, 8, 3, &input_data, &slice_data);
 	}
 
 	#[test]
@@ -267,7 +267,7 @@ mod tests {
 		let setup = build_slice_check(2, 1);
 		let dummy_input = vec![0u8; 10];
 		let dummy_slice = vec![0u8; 8];
-		run_slice_failure(setup, 10, 8, 5, &dummy_input, &dummy_slice);
+		run_slice_failure(&setup, 10, 8, 5, &dummy_input, &dummy_slice);
 	}
 
 	#[test]
@@ -276,7 +276,7 @@ mod tests {
 		let setup = build_slice_check(2, 1);
 		let input_data = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
 		let slice_data = vec![5, 6, 7, 8, 9];
-		run_slice_success(setup, 10, 5, 5, &input_data, &slice_data);
+		run_slice_success(&setup, 10, 5, 5, &input_data, &slice_data);
 	}
 
 	#[test]
@@ -284,7 +284,7 @@ mod tests {
 		// len_slice = 0 — output is all zeros.
 		let setup = build_slice_check(2, 1);
 		let input_data = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
-		run_slice_success(setup, 10, 0, 5, &input_data, &[]);
+		run_slice_success(&setup, 10, 0, 5, &input_data, &[]);
 	}
 
 	#[test]
@@ -295,7 +295,7 @@ mod tests {
 		let input_data = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
 		// Actual extracted slice at offset 2 with len 5 is [2,3,4,5,6]; we claim [0,1,2,3,4].
 		let wrong_slice_data = vec![0, 1, 2, 3, 4];
-		run_slice_failure(setup, 10, 5, 2, &input_data, &wrong_slice_data);
+		run_slice_failure(&setup, 10, 5, 2, &input_data, &wrong_slice_data);
 	}
 
 	#[test]
@@ -303,7 +303,7 @@ mod tests {
 		// Empty slice at offset 10, where len_input = 10.
 		let setup = build_slice_check(2, 1);
 		let input_data = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
-		run_slice_success(setup, 10, 0, 10, &input_data, &[]);
+		run_slice_success(&setup, 10, 0, 10, &input_data, &[]);
 	}
 
 	#[test]
@@ -319,7 +319,7 @@ mod tests {
 				let setup = build_slice_check(3, 1);
 				let input_data: Vec<u8> = (0..24).map(|i| i as u8).collect();
 				let slice_data: Vec<u8> = input_data[offset_val..offset_val + 8].to_vec();
-				run_slice_success(setup, 24, 8, offset_val as u64, &input_data, &slice_data);
+				run_slice_success(&setup, 24, 8, offset_val as u64, &input_data, &slice_data);
 			}
 		}
 	}
@@ -339,7 +339,7 @@ mod tests {
 			0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, // word 0
 			0x08, 0x09, 0x0a, 0x0b, 0x00, 0x00, 0x00, 0x00, // word 1 padded to 16 bytes
 		];
-		run_slice_success(setup, 20, 12, 0, &input_data, &correct_slice);
+		run_slice_success(&setup, 20, 12, 0, &input_data, &correct_slice);
 	}
 
 	#[test]
@@ -417,14 +417,14 @@ mod tests {
 	fn test_edge_case_len_input_zero() {
 		// Empty input + empty slice at offset 0.
 		let setup = build_slice_check(2, 1);
-		run_slice_success(setup, 0, 0, 0, &[], &[]);
+		run_slice_success(&setup, 0, 0, 0, &[], &[]);
 	}
 
 	#[test]
 	fn test_edge_case_len_input_zero_with_nonzero_slice() {
 		// Empty input + non-empty slice → bounds check fails.
 		let setup = build_slice_check(2, 1);
-		run_slice_failure(setup, 0, 5, 0, &[], &[1, 2, 3, 4, 5]);
+		run_slice_failure(&setup, 0, 5, 0, &[], &[1, 2, 3, 4, 5]);
 	}
 
 	#[test]
@@ -434,7 +434,7 @@ mod tests {
 		let input_data = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
 		// Slice is 8 bytes, so word 1 is fully zero-padded.
 		let slice_data = vec![2, 3, 4, 5, 6, 7, 8, 9];
-		run_slice_success(setup, 12, 8, 2, &input_data, &slice_data);
+		run_slice_success(&setup, 12, 8, 2, &input_data, &slice_data);
 	}
 
 	#[test]

--- a/crates/core/src/constraint_system.rs
+++ b/crates/core/src/constraint_system.rs
@@ -18,7 +18,7 @@ pub struct ValueIndex(pub u32);
 
 impl ValueIndex {
 	/// The value index that is not considered to be valid.
-	pub const INVALID: ValueIndex = ValueIndex(u32::MAX);
+	pub const INVALID: Self = Self(u32::MAX);
 }
 
 /// The most sensible default for a value index is invalid.
@@ -39,7 +39,7 @@ impl DeserializeBytes for ValueIndex {
 	where
 		Self: Sized,
 	{
-		Ok(ValueIndex(u32::deserialize(read_buf)?))
+		Ok(Self(u32::deserialize(read_buf)?))
 	}
 }
 
@@ -88,14 +88,14 @@ pub enum ShiftVariant {
 impl SerializeBytes for ShiftVariant {
 	fn serialize(&self, write_buf: impl BufMut) -> Result<(), SerializationError> {
 		let index = match self {
-			ShiftVariant::Sll => 0u8,
-			ShiftVariant::Slr => 1u8,
-			ShiftVariant::Sar => 2u8,
-			ShiftVariant::Rotr => 3u8,
-			ShiftVariant::Sll32 => 4u8,
-			ShiftVariant::Srl32 => 5u8,
-			ShiftVariant::Sra32 => 6u8,
-			ShiftVariant::Rotr32 => 7u8,
+			Self::Sll => 0u8,
+			Self::Slr => 1u8,
+			Self::Sar => 2u8,
+			Self::Rotr => 3u8,
+			Self::Sll32 => 4u8,
+			Self::Srl32 => 5u8,
+			Self::Sra32 => 6u8,
+			Self::Rotr32 => 7u8,
 		};
 		index.serialize(write_buf)
 	}
@@ -108,14 +108,14 @@ impl DeserializeBytes for ShiftVariant {
 	{
 		let index = u8::deserialize(read_buf)?;
 		match index {
-			0 => Ok(ShiftVariant::Sll),
-			1 => Ok(ShiftVariant::Slr),
-			2 => Ok(ShiftVariant::Sar),
-			3 => Ok(ShiftVariant::Rotr),
-			4 => Ok(ShiftVariant::Sll32),
-			5 => Ok(ShiftVariant::Srl32),
-			6 => Ok(ShiftVariant::Sra32),
-			7 => Ok(ShiftVariant::Rotr32),
+			0 => Ok(Self::Sll),
+			1 => Ok(Self::Slr),
+			2 => Ok(Self::Sar),
+			3 => Ok(Self::Rotr),
+			4 => Ok(Self::Sll32),
+			5 => Ok(Self::Srl32),
+			6 => Ok(Self::Sra32),
+			7 => Ok(Self::Rotr32),
 			_ => Err(SerializationError::UnknownEnumVariant {
 				name: "ShiftVariant",
 				index,
@@ -145,7 +145,7 @@ pub struct ShiftedValueIndex {
 impl ShiftedValueIndex {
 	/// Create a value index that just uses the specified value. Equivalent to [`Self::sll`] with
 	/// amount equals 0.
-	pub fn plain(value_index: ValueIndex) -> Self {
+	pub const fn plain(value_index: ValueIndex) -> Self {
 		Self {
 			value_index,
 			shift_variant: ShiftVariant::Sll,
@@ -301,7 +301,7 @@ impl DeserializeBytes for ShiftedValueIndex {
 			});
 		}
 
-		Ok(ShiftedValueIndex {
+		Ok(Self {
 			value_index,
 			shift_variant,
 			amount,
@@ -344,8 +344,8 @@ impl AndConstraint {
 		a: impl IntoIterator<Item = ValueIndex>,
 		b: impl IntoIterator<Item = ValueIndex>,
 		c: impl IntoIterator<Item = ValueIndex>,
-	) -> AndConstraint {
-		AndConstraint {
+	) -> Self {
+		Self {
 			a: a.into_iter().map(ShiftedValueIndex::plain).collect(),
 			b: b.into_iter().map(ShiftedValueIndex::plain).collect(),
 			c: c.into_iter().map(ShiftedValueIndex::plain).collect(),
@@ -357,8 +357,8 @@ impl AndConstraint {
 		a: impl IntoIterator<Item = ShiftedValueIndex>,
 		b: impl IntoIterator<Item = ShiftedValueIndex>,
 		c: impl IntoIterator<Item = ShiftedValueIndex>,
-	) -> AndConstraint {
-		AndConstraint {
+	) -> Self {
+		Self {
 			a: a.into_iter().collect(),
 			b: b.into_iter().collect(),
 			c: c.into_iter().collect(),
@@ -383,7 +383,7 @@ impl DeserializeBytes for AndConstraint {
 		let b = Vec::<ShiftedValueIndex>::deserialize(&mut read_buf)?;
 		let c = Vec::<ShiftedValueIndex>::deserialize(read_buf)?;
 
-		Ok(AndConstraint { a, b, c })
+		Ok(Self { a, b, c })
 	}
 }
 
@@ -426,7 +426,7 @@ impl DeserializeBytes for MulConstraint {
 		let hi = Vec::<ShiftedValueIndex>::deserialize(&mut read_buf)?;
 		let lo = Vec::<ShiftedValueIndex>::deserialize(read_buf)?;
 
-		Ok(MulConstraint { a, b, hi, lo })
+		Ok(Self { a, b, hi, lo })
 	}
 }
 
@@ -467,7 +467,7 @@ impl ConstraintSystem {
 		mul_constraints: Vec<MulConstraint>,
 	) -> Self {
 		assert_eq!(constants.len(), value_vec_layout.n_const);
-		ConstraintSystem {
+		Self {
 			constants,
 			value_vec_layout,
 			and_constraints,
@@ -583,17 +583,17 @@ impl ConstraintSystem {
 	}
 
 	/// Returns the number of AND constraints in the system.
-	pub fn n_and_constraints(&self) -> usize {
+	pub const fn n_and_constraints(&self) -> usize {
 		self.and_constraints.len()
 	}
 
 	/// Returns the number of MUL  constraints in the system.
-	pub fn n_mul_constraints(&self) -> usize {
+	pub const fn n_mul_constraints(&self) -> usize {
 		self.mul_constraints.len()
 	}
 
 	/// The total length of the [`ValueVec`] expected by this constraint system.
-	pub fn value_vec_len(&self) -> usize {
+	pub const fn value_vec_len(&self) -> usize {
 		self.value_vec_layout.committed_total_len
 	}
 
@@ -637,7 +637,7 @@ impl DeserializeBytes for ConstraintSystem {
 			});
 		}
 
-		Ok(ConstraintSystem {
+		Ok(Self {
 			value_vec_layout,
 			constants,
 			and_constraints,
@@ -681,7 +681,7 @@ impl ValueVecLayout {
 	///
 	/// - the public segment (constants and inout values) is padded to the power of two.
 	/// - the public segment is not less than the minimum size.
-	pub fn validate(&self) -> Result<(), ConstraintSystemError> {
+	pub const fn validate(&self) -> Result<(), ConstraintSystemError> {
 		if !self.offset_witness.is_power_of_two() {
 			return Err(ConstraintSystemError::PublicInputPowerOfTwo);
 		}
@@ -695,7 +695,7 @@ impl ValueVecLayout {
 	}
 
 	/// Returns true if the given index points to an area that is considered to be padding.
-	fn is_padding(&self, index: ValueIndex) -> bool {
+	const fn is_padding(&self, index: ValueIndex) -> bool {
 		let idx = index.0 as usize;
 
 		// padding 1: between constants and inout section
@@ -719,7 +719,7 @@ impl ValueVecLayout {
 	}
 
 	/// Returns true if the given index is out-of-bounds for the committed part of this layout.
-	fn is_committed_oob(&self, index: ValueIndex) -> bool {
+	const fn is_committed_oob(&self, index: ValueIndex) -> bool {
 		index.0 as usize >= self.committed_total_len
 	}
 }
@@ -751,7 +751,7 @@ impl DeserializeBytes for ValueVecLayout {
 		let committed_total_len = usize::deserialize(&mut read_buf)?;
 		let n_scratch = usize::deserialize(read_buf)?;
 
-		Ok(ValueVecLayout {
+		Ok(Self {
 			n_const,
 			n_inout,
 			n_witness,
@@ -849,9 +849,9 @@ impl ValueVec {
 	/// Creates a new value vector with the given layout.
 	///
 	/// The values are filled with zeros.
-	pub fn new(layout: ValueVecLayout) -> ValueVec {
+	pub fn new(layout: ValueVecLayout) -> Self {
 		let size = layout.committed_total_len + layout.n_scratch;
-		ValueVec {
+		Self {
 			layout,
 			data: AlignedWords::zeroed(size),
 		}
@@ -862,9 +862,9 @@ impl ValueVec {
 	/// The data is checked to have the correct length.
 	pub fn new_from_data(
 		layout: ValueVecLayout,
-		public: Vec<Word>,
-		private: Vec<Word>,
-	) -> Result<ValueVec, ConstraintSystemError> {
+		public: &[Word],
+		private: &[Word],
+	) -> Result<Self, ConstraintSystemError> {
 		let committed_len = public.len() + private.len();
 		if committed_len != layout.committed_total_len {
 			return Err(ConstraintSystemError::ValueVecLenMismatch {
@@ -878,15 +878,15 @@ impl ValueVec {
 		// Fresh 16-byte-aligned buffer; the scratch tail past the committed words stays zeroed.
 		let mut data = AlignedWords::zeroed(full_len);
 		// Public words occupy the front of the committed region.
-		data[..public.len()].copy_from_slice(&public);
+		data[..public.len()].copy_from_slice(public);
 		// Private words follow, filling the rest of the committed region.
-		data[public.len()..committed_len].copy_from_slice(&private);
+		data[public.len()..committed_len].copy_from_slice(private);
 
-		Ok(ValueVec { layout, data })
+		Ok(Self { layout, data })
 	}
 
 	/// The total size of the committed portion of the vector (excluding scratch).
-	pub fn size(&self) -> usize {
+	pub const fn size(&self) -> usize {
 		self.layout.committed_total_len
 	}
 
@@ -958,14 +958,14 @@ impl<'a> ValuesData<'a> {
 	pub const SERIALIZATION_VERSION: u32 = 1;
 
 	/// Create a new ValuesData from borrowed data
-	pub fn borrowed(data: &'a [Word]) -> Self {
+	pub const fn borrowed(data: &'a [Word]) -> Self {
 		Self {
 			data: Cow::Borrowed(data),
 		}
 	}
 
 	/// Create a new ValuesData from owned data
-	pub fn owned(data: Vec<Word>) -> Self {
+	pub const fn owned(data: Vec<Word>) -> Self {
 		Self {
 			data: Cow::Owned(data),
 		}
@@ -1084,7 +1084,7 @@ impl<'a> Proof<'a> {
 	pub const SERIALIZATION_VERSION: u32 = 1;
 
 	/// Create a new Proof from borrowed transcript data
-	pub fn borrowed(data: &'a [u8], challenger_type: String) -> Self {
+	pub const fn borrowed(data: &'a [u8], challenger_type: String) -> Self {
 		Self {
 			data: Cow::Borrowed(data),
 			challenger_type,
@@ -1092,7 +1092,7 @@ impl<'a> Proof<'a> {
 	}
 
 	/// Create a new Proof from owned transcript data
-	pub fn owned(data: Vec<u8>, challenger_type: String) -> Self {
+	pub const fn owned(data: Vec<u8>, challenger_type: String) -> Self {
 		Self {
 			data: Cow::Owned(data),
 			challenger_type,
@@ -1876,9 +1876,7 @@ mod serialization_tests {
 
 		let public = values.public();
 		let non_public = values.non_public();
-		let combined =
-			ValueVec::new_from_data(values.layout.clone(), public.to_vec(), non_public.to_vec())
-				.unwrap();
+		let combined = ValueVec::new_from_data(values.layout.clone(), public, non_public).unwrap();
 		assert_eq!(combined.combined_witness(), values.combined_witness());
 	}
 
@@ -1927,12 +1925,8 @@ mod serialization_tests {
 		let non_pub2 = ValuesData::deserialize(&mut buf_non_pub.as_slice()).unwrap();
 
 		// Reconstruct ValueVec from deserialized pieces
-		let reconstructed = ValueVec::new_from_data(
-			cs2.value_vec_layout.clone(),
-			pub2.into_owned(),
-			non_pub2.into_owned(),
-		)
-		.unwrap();
+		let reconstructed =
+			ValueVec::new_from_data(cs2.value_vec_layout, &pub2, &non_pub2).unwrap();
 
 		// Ensure committed part matches exactly
 		assert_eq!(reconstructed.combined_witness(), values.combined_witness());
@@ -2521,10 +2515,10 @@ mod serialization_tests {
 			};
 
 			// The public input must fill its whole power-of-two section, so zero-pad it.
-			let mut public_padded = public.clone();
+			let mut public_padded = public;
 			public_padded.resize(offset_witness, Word::ZERO);
 
-			let vv = ValueVec::new_from_data(layout, public_padded.clone(), private.clone()).unwrap();
+			let vv = ValueVec::new_from_data(layout, &public_padded, &private).unwrap();
 
 			// Alignment survives construction for any word count.
 			assert_16_byte_aligned(vv.combined_witness());

--- a/crates/core/src/word.rs
+++ b/crates/core/src/word.rs
@@ -21,17 +21,17 @@ pub struct Word(pub u64);
 
 impl Word {
 	/// All zero bit pattern, zero, nil, null.
-	pub const ZERO: Word = Word(0);
+	pub const ZERO: Self = Self(0);
 	/// 1.
-	pub const ONE: Word = Word(1);
+	pub const ONE: Self = Self(1);
 	/// All bits set to one.
-	pub const ALL_ONE: Word = Word(u64::MAX);
+	pub const ALL_ONE: Self = Self(u64::MAX);
 	/// 32 lower bits are set to one, all other bits are zero.
-	pub const MASK_32: Word = Word(0x00000000FFFFFFFF);
+	pub const MASK_32: Self = Self(0x00000000FFFFFFFF);
 	/// Most Significant Bit is set to one, all other bits are zero.
 	///
 	/// This is a canonical representation of true.
-	pub const MSB_ONE: Word = Word(0x8000000000000000);
+	pub const MSB_ONE: Self = Self(0x8000000000000000);
 }
 
 impl fmt::Debug for Word {
@@ -44,7 +44,7 @@ impl BitAnd for Word {
 	type Output = Self;
 
 	fn bitand(self, rhs: Self) -> Self::Output {
-		Word(self.0 & rhs.0)
+		Self(self.0 & rhs.0)
 	}
 }
 
@@ -52,7 +52,7 @@ impl BitOr for Word {
 	type Output = Self;
 
 	fn bitor(self, rhs: Self) -> Self::Output {
-		Word(self.0 | rhs.0)
+		Self(self.0 | rhs.0)
 	}
 }
 
@@ -60,7 +60,7 @@ impl BitXor for Word {
 	type Output = Self;
 
 	fn bitxor(self, rhs: Self) -> Self::Output {
-		Word(self.0 ^ rhs.0)
+		Self(self.0 ^ rhs.0)
 	}
 }
 
@@ -68,7 +68,7 @@ impl Shl<u32> for Word {
 	type Output = Self;
 
 	fn shl(self, rhs: u32) -> Self::Output {
-		Word(self.0 << rhs)
+		Self(self.0 << rhs)
 	}
 }
 
@@ -76,7 +76,7 @@ impl Shr<u32> for Word {
 	type Output = Self;
 
 	fn shr(self, rhs: u32) -> Self::Output {
-		Word(self.0 >> rhs)
+		Self(self.0 >> rhs)
 	}
 }
 
@@ -84,14 +84,14 @@ impl Not for Word {
 	type Output = Self;
 
 	fn not(self) -> Self::Output {
-		Word(!self.0)
+		Self(!self.0)
 	}
 }
 
 impl Word {
 	/// Creates a new `Word` from a 64-bit unsigned integer.
-	pub const fn from_u64(value: u64) -> Word {
-		Word(value)
+	pub const fn from_u64(value: u64) -> Self {
+		Self(value)
 	}
 
 	/// Performs parallel 32-bit additions on the upper and lower halves with carry-in.
@@ -102,10 +102,10 @@ impl Word {
 	///
 	/// Returns (sum, carry_out) where the ith carry_out bit is set to one if there is a
 	/// carry out at that bit position.
-	pub fn iadd32_cin_cout(self, rhs: Word, cin: Word) -> (Word, Word) {
-		let Word(lhs) = self;
-		let Word(rhs) = rhs;
-		let Word(cin) = cin;
+	pub const fn iadd32_cin_cout(self, rhs: Self, cin: Self) -> (Self, Self) {
+		let Self(lhs) = self;
+		let Self(rhs) = rhs;
+		let Self(cin) = cin;
 
 		// Extract carry-in bits from MSBs of each 32-bit half
 		let cin_lo = (cin >> 31) & 1;
@@ -123,14 +123,14 @@ impl Word {
 		let sum = (lo_sum as u32 as u64) | ((hi_sum as u32 as u64) << 32);
 
 		let cout = (lhs & rhs) | ((lhs ^ rhs) & !sum);
-		(Word(sum), Word(cout))
+		(Self(sum), Self(cout))
 	}
 
 	/// Performs parallel 32-bit additions on the upper and lower halves.
 	///
 	/// Equivalent to [`iadd32_cin_cout`](Word::iadd32_cin_cout) with zero carry-in.
-	pub fn iadd_cout_32(self, rhs: Word) -> (Word, Word) {
-		self.iadd32_cin_cout(rhs, Word::ZERO)
+	pub const fn iadd_cout_32(self, rhs: Self) -> (Self, Self) {
+		self.iadd32_cin_cout(rhs, Self::ZERO)
 	}
 
 	/// Performs 64-bit addition with carry input bit.
@@ -140,14 +140,14 @@ impl Word {
 	///
 	/// Returns (sum, carry_out) where ith carry_out bit is set to one if there is a carry out at
 	/// that bit position.
-	pub fn iadd_cin_cout(self, rhs: Word, cin: Word) -> (Word, Word) {
-		debug_assert!(cin == Word::ZERO || cin == Word::ONE, "cin must be 0 or 1");
-		let Word(lhs) = self;
-		let Word(rhs) = rhs;
-		let Word(cin) = cin;
+	pub fn iadd_cin_cout(self, rhs: Self, cin: Self) -> (Self, Self) {
+		debug_assert!(cin == Self::ZERO || cin == Self::ONE, "cin must be 0 or 1");
+		let Self(lhs) = self;
+		let Self(rhs) = rhs;
+		let Self(cin) = cin;
 		let sum = lhs.wrapping_add(rhs).wrapping_add(cin);
 		let cout = (lhs & rhs) | ((lhs ^ rhs) & !sum);
-		(Word(sum), Word(cout))
+		(Self(sum), Self(cout))
 	}
 
 	/// Performs 64-bit subtraction with borrow input bit.
@@ -157,46 +157,46 @@ impl Word {
 	///
 	/// Returns (diff, borrow_out) where ith borrow_out bit is set to one if there is a borrow out
 	/// at that bit position.
-	pub fn isub_bin_bout(self, rhs: Word, bin: Word) -> (Word, Word) {
-		debug_assert!(bin == Word::ZERO || bin == Word::ONE, "bin must be 0 or 1");
-		let Word(lhs) = self;
-		let Word(rhs) = rhs;
-		let Word(bin) = bin;
+	pub fn isub_bin_bout(self, rhs: Self, bin: Self) -> (Self, Self) {
+		debug_assert!(bin == Self::ZERO || bin == Self::ONE, "bin must be 0 or 1");
+		let Self(lhs) = self;
+		let Self(rhs) = rhs;
+		let Self(bin) = bin;
 		let diff = lhs.wrapping_sub(rhs).wrapping_sub(bin);
 		let bout = (!lhs & rhs) | (!(lhs ^ rhs) & diff);
-		(Word(diff), Word(bout))
+		(Self(diff), Self(bout))
 	}
 
 	/// Performs shift right by a given number of bits followed by masking with a 32-bit mask.
-	pub fn shr_32(self, n: u32) -> Word {
-		let Word(value) = self;
+	pub const fn shr_32(self, n: u32) -> Self {
+		let Self(value) = self;
 		// Shift right logically by n bits and mask with 32-bit mask
 		let result = (value >> n) & Self::MASK_32.0;
-		Word(result)
+		Self(result)
 	}
 
 	/// Shift Arithmetic Right by a given number of bits.
 	///
 	/// This is similar to a logical shift right, but it shifts the sign bit to the right.
-	pub fn sar(self, n: u32) -> Word {
-		let Word(value) = self;
+	pub const fn sar(self, n: u32) -> Self {
+		let Self(value) = self;
 		let value = value as i64;
 		let result = value >> n;
-		Word(result as u64)
+		Self(result as u64)
 	}
 
 	/// Rotate Right by a given number of bits.
-	pub fn rotr(self, n: u32) -> Word {
-		let Word(value) = self;
-		Word(value.rotate_right(n))
+	pub const fn rotr(self, n: u32) -> Self {
+		let Self(value) = self;
+		Self(value.rotate_right(n))
 	}
 
 	/// Shift Left Logical on 32-bit halves.
 	///
 	/// Performs independent logical left shifts on the upper and lower 32-bit halves.
 	/// Only uses the lower 5 bits of the shift amount (0-31).
-	pub fn sll32(self, n: u32) -> Word {
-		let Word(value) = self;
+	pub const fn sll32(self, n: u32) -> Self {
+		let Self(value) = self;
 		let n = n & 0x1F; // Only use lower 5 bits
 
 		// Extract 32-bit halves
@@ -207,15 +207,15 @@ impl Word {
 		let lo_shifted = (lo << n) as u64;
 		let hi_shifted = ((hi << n) as u64) << 32;
 
-		Word(lo_shifted | hi_shifted)
+		Self(lo_shifted | hi_shifted)
 	}
 
 	/// Shift Right Logical on 32-bit halves.
 	///
 	/// Performs independent logical right shifts on the upper and lower 32-bit halves.
 	/// Only uses the lower 5 bits of the shift amount (0-31).
-	pub fn srl32(self, n: u32) -> Word {
-		let Word(value) = self;
+	pub const fn srl32(self, n: u32) -> Self {
+		let Self(value) = self;
 		let n = n & 0x1F; // Only use lower 5 bits
 
 		// Extract 32-bit halves
@@ -226,7 +226,7 @@ impl Word {
 		let lo_shifted = (lo >> n) as u64;
 		let hi_shifted = ((hi >> n) as u64) << 32;
 
-		Word(lo_shifted | hi_shifted)
+		Self(lo_shifted | hi_shifted)
 	}
 
 	/// Shift Right Arithmetic on 32-bit halves.
@@ -234,8 +234,8 @@ impl Word {
 	/// Performs independent arithmetic right shifts on the upper and lower 32-bit halves.
 	/// Sign extends each 32-bit half independently. Only uses the lower 5 bits of the shift amount
 	/// (0-31).
-	pub fn sra32(self, n: u32) -> Word {
-		let Word(value) = self;
+	pub const fn sra32(self, n: u32) -> Self {
+		let Self(value) = self;
 		let n = n & 0x1F; // Only use lower 5 bits
 
 		// Extract 32-bit halves as signed integers
@@ -246,7 +246,7 @@ impl Word {
 		let lo_shifted = ((lo >> n) as u32) as u64;
 		let hi_shifted = (((hi >> n) as u32) as u64) << 32;
 
-		Word(lo_shifted | hi_shifted)
+		Self(lo_shifted | hi_shifted)
 	}
 
 	/// Rotate Right on 32-bit halves.
@@ -254,8 +254,8 @@ impl Word {
 	/// Performs independent rotate right operations on the upper and lower 32-bit halves.
 	/// Bits shifted off the right end wrap around to the left within each 32-bit half.
 	/// Only uses the lower 5 bits of the shift amount (0-31).
-	pub fn rotr32(self, n: u32) -> Word {
-		let Word(value) = self;
+	pub const fn rotr32(self, n: u32) -> Self {
+		let Self(value) = self;
 		let n = n & 0x1F; // Only use lower 5 bits
 
 		// Extract 32-bit halves
@@ -266,30 +266,30 @@ impl Word {
 		let lo_rotated = lo.rotate_right(n) as u64;
 		let hi_rotated = (hi.rotate_right(n) as u64) << 32;
 
-		Word(lo_rotated | hi_rotated)
+		Self(lo_rotated | hi_rotated)
 	}
 
 	/// Unsigned integer multiplication.
 	///
 	/// Multiplies two 64-bit unsigned integers and returns the 128-bit result split into high and
 	/// low 64-bit words, respectively.
-	pub fn imul(self, rhs: Word) -> (Word, Word) {
-		let Word(lhs) = self;
-		let Word(rhs) = rhs;
+	pub const fn imul(self, rhs: Self) -> (Self, Self) {
+		let Self(lhs) = self;
+		let Self(rhs) = rhs;
 		let result = (lhs as u128) * (rhs as u128);
 
 		let hi = (result >> 64) as u64;
 		let lo = result as u64;
-		(Word(hi), Word(lo))
+		(Self(hi), Self(lo))
 	}
 
 	/// Signed integer multiplication.
 	///
 	/// Multiplies two 64-bit signed integers and returns the 128-bit result split into high and
 	/// low 64-bit words, respectively.
-	pub fn smul(self, rhs: Word) -> (Word, Word) {
-		let Word(lhs) = self;
-		let Word(rhs) = rhs;
+	pub const fn smul(self, rhs: Self) -> (Self, Self) {
+		let Self(lhs) = self;
+		let Self(rhs) = rhs;
 		// Interpret as signed 64-bit integers
 		let a = lhs as i64;
 		let b = rhs as i64;
@@ -298,21 +298,21 @@ impl Word {
 		// Extract high and low 64-bit words
 		let hi = (result >> 64) as u64;
 		let lo = result as u64;
-		(Word(hi), Word(lo))
+		(Self(hi), Self(lo))
 	}
 
 	/// Integer addition.
 	///
 	/// Wraps around on overflow.
-	pub fn wrapping_add(self, rhs: Word) -> Word {
-		Word(self.0.wrapping_add(rhs.0))
+	pub const fn wrapping_add(self, rhs: Self) -> Self {
+		Self(self.0.wrapping_add(rhs.0))
 	}
 
 	/// Integer subtraction.
 	///
 	/// Wraps around on overflow.
-	pub fn wrapping_sub(self, rhs: Word) -> Word {
-		Word(self.0.wrapping_sub(rhs.0))
+	pub const fn wrapping_sub(self, rhs: Self) -> Self {
+		Self(self.0.wrapping_sub(rhs.0))
 	}
 
 	/// Returns the integer value as a 64-bit unsigned integer.
@@ -352,7 +352,7 @@ impl DeserializeBytes for Word {
 	where
 		Self: Sized,
 	{
-		Ok(Word(u64::deserialize(read_buf)?))
+		Ok(Self(u64::deserialize(read_buf)?))
 	}
 }
 
@@ -553,13 +553,12 @@ mod tests {
 
 			// Check sign bit is extended
 			let is_negative = (val as i64) < 0;
+			let mask = !((1u64 << (64 - shift)) - 1);
 			if is_negative {
 				// High bits should all be 1
-				let mask = !((1u64 << (64 - shift)) - 1);
 				assert_eq!(result.0 & mask, mask);
 			} else {
 				// High bits should all be 0
-				let mask = !((1u64 << (64 - shift)) - 1);
 				assert_eq!(result.0 & mask, 0);
 			}
 		}

--- a/crates/examples/benches/blake2b.rs
+++ b/crates/examples/benches/blake2b.rs
@@ -78,7 +78,7 @@ impl ExampleBenchmark for Blake2bBenchmark {
 
 fn bench_blake2b_hash(c: &mut Criterion) {
 	let benchmark = Blake2bBenchmark::new();
-	run_cs_benchmark(c, benchmark, "blake2b", &BLAKE2B_PEAK_ALLOC);
+	run_cs_benchmark(c, &benchmark, "blake2b", &BLAKE2B_PEAK_ALLOC);
 }
 
 criterion_group!(benches, bench_blake2b_hash);

--- a/crates/examples/benches/blake2s.rs
+++ b/crates/examples/benches/blake2s.rs
@@ -78,7 +78,7 @@ impl ExampleBenchmark for Blake2sBenchmark {
 
 fn bench_blake2s_hash(c: &mut Criterion) {
 	let benchmark = Blake2sBenchmark::new();
-	run_cs_benchmark(c, benchmark, "blake2s", &BLAKE2S_PEAK_ALLOC);
+	run_cs_benchmark(c, &benchmark, "blake2s", &BLAKE2S_PEAK_ALLOC);
 }
 
 criterion_group!(benches, bench_blake2s_hash);

--- a/crates/examples/benches/ethsign.rs
+++ b/crates/examples/benches/ethsign.rs
@@ -79,7 +79,7 @@ impl ExampleBenchmark for EthSignBenchmark {
 
 fn bench_ethsign_signatures(c: &mut Criterion) {
 	let benchmark = EthSignBenchmark::new();
-	run_cs_benchmark(c, benchmark, "ethsign", &ETHSIGN_PEAK_ALLOC);
+	run_cs_benchmark(c, &benchmark, "ethsign", &ETHSIGN_PEAK_ALLOC);
 }
 
 criterion_group!(ethsign, bench_ethsign_signatures);

--- a/crates/examples/benches/hashsign.rs
+++ b/crates/examples/benches/hashsign.rs
@@ -97,7 +97,7 @@ impl ExampleBenchmark for HashSignBenchmark {
 
 fn bench_hashsign(c: &mut Criterion) {
 	let benchmark = HashSignBenchmark::new();
-	run_cs_benchmark(c, benchmark, "hashsign", &HASHSIGN_PEAK_ALLOC);
+	run_cs_benchmark(c, &benchmark, "hashsign", &HASHSIGN_PEAK_ALLOC);
 }
 
 criterion_group!(hashsign, bench_hashsign);

--- a/crates/examples/benches/keccak.rs
+++ b/crates/examples/benches/keccak.rs
@@ -78,7 +78,7 @@ impl ExampleBenchmark for KeccakBenchmark {
 
 fn bench_keccak(c: &mut Criterion) {
 	let benchmark = KeccakBenchmark::new();
-	run_cs_benchmark(c, benchmark, "keccak", &KECCAK_PEAK_ALLOC);
+	run_cs_benchmark(c, &benchmark, "keccak", &KECCAK_PEAK_ALLOC);
 }
 
 criterion_group!(keccak, bench_keccak);

--- a/crates/examples/benches/sha256.rs
+++ b/crates/examples/benches/sha256.rs
@@ -79,7 +79,7 @@ impl ExampleBenchmark for Sha256Benchmark {
 
 fn bench_sha256_hash(c: &mut Criterion) {
 	let benchmark = Sha256Benchmark::new();
-	run_cs_benchmark(c, benchmark, "sha256", &SHA256_PEAK_ALLOC);
+	run_cs_benchmark(c, &benchmark, "sha256", &SHA256_PEAK_ALLOC);
 }
 
 criterion_group!(benches, bench_sha256_hash);

--- a/crates/examples/benches/sha512.rs
+++ b/crates/examples/benches/sha512.rs
@@ -79,7 +79,7 @@ impl ExampleBenchmark for Sha512Benchmark {
 
 fn bench_sha512_hash(c: &mut Criterion) {
 	let benchmark = Sha512Benchmark::new();
-	run_cs_benchmark(c, benchmark, "sha512", &SHA512_PEAK_ALLOC);
+	run_cs_benchmark(c, &benchmark, "sha512", &SHA512_PEAK_ALLOC);
 }
 
 criterion_group!(benches, bench_sha512_hash);

--- a/crates/examples/benches/utils/runner.rs
+++ b/crates/examples/benches/utils/runner.rs
@@ -56,7 +56,7 @@ pub trait ExampleBenchmark {
 /// Run a complete benchmark suite for a constraint system
 pub fn run_cs_benchmark<B: ExampleBenchmark>(
 	c: &mut Criterion,
-	benchmark: B,
+	benchmark: &B,
 	group_prefix: &str,
 	peak_alloc: &impl PeakMemAllocTrait,
 ) {
@@ -77,7 +77,7 @@ pub fn run_cs_benchmark<B: ExampleBenchmark>(
 	let instance = benchmark.create_instance();
 
 	let mut builder = CircuitBuilder::new();
-	let example = B::build_example_circuit(params.clone(), &mut builder).unwrap();
+	let example = B::build_example_circuit(params, &mut builder).unwrap();
 	let circuit = builder.build();
 	let cs = circuit.constraint_system().clone();
 	let (verifier, prover) = setup::<StdHashSuite>(cs, benchmark.log_inv_rate(), None).unwrap();
@@ -95,16 +95,14 @@ pub fn run_cs_benchmark<B: ExampleBenchmark>(
 	// Track memory for proof generation
 	peak_alloc.reset_peak_memory();
 	let mut prover_transcript_mem = ProverTranscript::new(StdChallenger::default());
-	prover
-		.prove(witness.clone(), &mut prover_transcript_mem)
-		.unwrap();
+	prover.prove(&witness, &mut prover_transcript_mem).unwrap();
 	let proof_bytes_mem = prover_transcript_mem.finalize();
 	let proof_peak_bytes = peak_alloc.get_peak_memory();
 
 	// Track memory for verification
 	peak_alloc.reset_peak_memory();
 	let mut verifier_transcript_mem =
-		VerifierTranscript::new(StdChallenger::default(), proof_bytes_mem.clone());
+		VerifierTranscript::new(StdChallenger::default(), proof_bytes_mem);
 	verifier
 		.verify(witness.public(), &mut verifier_transcript_mem)
 		.unwrap();
@@ -129,7 +127,7 @@ pub fn run_cs_benchmark<B: ExampleBenchmark>(
 					.unwrap();
 				circuit.populate_wire_witness(&mut filler).unwrap();
 				filler.into_value_vec()
-			})
+			});
 		});
 
 		group.finish();
@@ -145,11 +143,9 @@ pub fn run_cs_benchmark<B: ExampleBenchmark>(
 		group.bench_function(BenchmarkId::from_parameter(&bench_name), |b| {
 			b.iter(|| {
 				let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
-				prover
-					.prove(witness.clone(), &mut prover_transcript)
-					.unwrap();
+				prover.prove(&witness, &mut prover_transcript).unwrap();
 				prover_transcript
-			})
+			});
 		});
 
 		group.finish();
@@ -157,9 +153,7 @@ pub fn run_cs_benchmark<B: ExampleBenchmark>(
 
 	// Generate proof for verification and size measurement
 	let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
-	prover
-		.prove(witness.clone(), &mut prover_transcript)
-		.unwrap();
+	prover.prove(&witness, &mut prover_transcript).unwrap();
 	let proof_bytes = prover_transcript.finalize();
 	let proof_size = proof_bytes.len();
 
@@ -177,8 +171,8 @@ pub fn run_cs_benchmark<B: ExampleBenchmark>(
 				verifier
 					.verify(witness.public(), &mut verifier_transcript)
 					.unwrap();
-				verifier_transcript.finalize().unwrap()
-			})
+				verifier_transcript.finalize().unwrap();
+			});
 		});
 
 		group.finish();

--- a/crates/examples/examples/tutorials/end_to_end_example.rs
+++ b/crates/examples/examples/tutorials/end_to_end_example.rs
@@ -19,11 +19,11 @@ use sha2::{Digest, Sha256 as StdSha256};
 fn main() -> Result<(), Box<dyn std::error::Error>> {
 	let builder = CircuitBuilder::new();
 
-	let content: Vec<_> = (0..4).map(|_| builder.add_witness()).collect();
-	let nonce: Vec<_> = (0..4).map(|_| builder.add_witness()).collect();
+	let content = (0..4).map(|_| builder.add_witness());
+	let nonce = (0..4).map(|_| builder.add_witness());
 	let commitment: [_; 4] = core::array::from_fn(|_| builder.add_inout());
 
-	let message: Vec<_> = content.clone().into_iter().chain(nonce.clone()).collect();
+	let message: Vec<_> = content.chain(nonce).collect();
 	let len_bytes = builder.add_witness();
 	let sha256 = Sha256::new(&builder, len_bytes, commitment, message);
 	let circuit = builder.build();
@@ -57,12 +57,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 	let challenger = StdChallenger::default();
 	let mut prover_transcript = ProverTranscript::new(challenger.clone());
-	let public_words = witness_vec.public().to_vec();
-	prover.prove(witness_vec, &mut prover_transcript)?;
+	prover.prove(&witness_vec, &mut prover_transcript)?;
 	let proof = prover_transcript.finalize();
 
 	let mut verifier_transcript = VerifierTranscript::new(challenger, proof);
-	verifier.verify(&public_words, &mut verifier_transcript)?;
+	verifier.verify(witness_vec.public(), &mut verifier_transcript)?;
 	verifier_transcript.finalize()?;
 
 	println!("✓ proof successfully verified");

--- a/crates/examples/src/bin/prover.rs
+++ b/crates/examples/src/bin/prover.rs
@@ -1,4 +1,5 @@
 // Copyright 2025 Irreducible Inc.
+//! Standalone prover binary: loads a constraint system and witness from disk and writes a proof.
 use std::{fs, path::PathBuf};
 
 use anyhow::{Context, Result};
@@ -66,10 +67,7 @@ fn main() -> Result<()> {
 		.context("Failed to deserialize non-public ValuesData")?;
 
 	// Reconstruct the full ValueVec
-	// Take ownership of the underlying vectors without extra copies
-	let public: Vec<_> = public.into();
-	let non_public: Vec<_> = non_public.into();
-	let witness = ValueVec::new_from_data(cs.value_vec_layout.clone(), public, non_public)
+	let witness = ValueVec::new_from_data(cs.value_vec_layout.clone(), &public, &non_public)
 		.context("Failed to reconstruct ValueVec from provided values")?;
 
 	// Setup prover (verifier is not used here)
@@ -78,7 +76,7 @@ fn main() -> Result<()> {
 	// Prove
 	let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 	prover
-		.prove(witness, &mut prover_transcript)
+		.prove(&witness, &mut prover_transcript)
 		.context("Proving failed")?;
 	let transcript = prover_transcript.finalize();
 

--- a/crates/examples/src/bin/verifier.rs
+++ b/crates/examples/src/bin/verifier.rs
@@ -1,4 +1,6 @@
 // Copyright 2025 Irreducible Inc.
+//! Standalone verifier binary: loads a constraint system, public input, and proof from disk and
+//! checks the proof.
 use std::{fs, path::PathBuf};
 
 use anyhow::{Context, Result, bail};

--- a/crates/examples/src/circuits/bip32.rs
+++ b/crates/examples/src/circuits/bip32.rs
@@ -84,13 +84,13 @@ pub fn bip32_derive_compressed(
 	// non-hardened step, and as the candidates for the depth multiplexer.
 	let mut serp_levels: Vec<Vec<Wire>> = Vec::with_capacity(max_depth + 1);
 
-	for level in 0..max_depth {
+	for &child in path {
 		// Parent public key P = k * G.
 		let point = scalar_mul(b, &curve, &k, Secp256k1Affine::generator(b));
 		serp_levels.push(compress_pubkey(b, &point.x, &point.y));
 
 		// Hardened iff bit 31 of the index is set (moved to the MSB for `select`).
-		let is_hardened = b.shl(path[level], 32);
+		let is_hardened = b.shl(child, 32);
 
 		// CKD data is `prefix || value[32] || ser32(index)` either way (37 bytes):
 		// hardened => 0x00 || ser256(k_par); normal => (0x02|0x03) || x_be.
@@ -106,7 +106,7 @@ pub fn bip32_derive_compressed(
 			value_field.limbs[0],
 		];
 
-		let message = assemble_message(b, prefix, &value, path[level]);
+		let message = assemble_message(b, prefix, &value, child);
 		let i = hmac_sha512_fixed(b, &c, &message, 37);
 
 		// k_child = (parse256(I_L) + k_par) mod n ; c_child = I_R.
@@ -133,7 +133,7 @@ fn il_scalar(hash: &[Wire; 8]) -> BigUint {
 
 /// The last 32 bytes (`I_R`, the chain code) of a SHA-512 output, as four big-endian words ready to
 /// be used directly as an HMAC-SHA512 key.
-fn ir_words(hash: &[Wire; 8]) -> [Wire; 4] {
+const fn ir_words(hash: &[Wire; 8]) -> [Wire; 4] {
 	[hash[4], hash[5], hash[6], hash[7]]
 }
 
@@ -226,7 +226,7 @@ impl ExampleCircuit for Bip32Example {
 		})
 	}
 
-	fn populate_witness(&self, instance: Instance, w: &mut WitnessFiller) -> Result<()> {
+	fn populate_witness(&self, instance: Instance, w: &mut WitnessFiller<'_>) -> Result<()> {
 		if instance.path.len() > self.max_depth {
 			bail!("path depth {} exceeds max_depth {}", instance.path.len(), self.max_depth);
 		}
@@ -277,10 +277,9 @@ impl ExampleCircuit for Bip32Example {
 /// Parse a single derivation-path child like "0", "44'", or "5h" into a 32-bit index with the
 /// hardened bit set when suffixed.
 fn parse_child(s: &str) -> Result<u32, String> {
-	let (digits, hardened) = match s.strip_suffix(['\'', 'h', 'H']) {
-		Some(rest) => (rest, true),
-		None => (s, false),
-	};
+	let (digits, hardened) = s
+		.strip_suffix(['\'', 'h', 'H'])
+		.map_or((s, false), |rest| (rest, true));
 	let idx: u32 = digits
 		.parse()
 		.map_err(|e| format!("invalid child index '{s}': {e}"))?;

--- a/crates/examples/src/circuits/bitcoin_block_contains_transaction.rs
+++ b/crates/examples/src/circuits/bitcoin_block_contains_transaction.rs
@@ -47,8 +47,7 @@ impl BlockContainsTransaction {
 		);
 
 		// `block_header` hashes to `block_hash`
-		let block_header =
-			DoubleSha256::construct_circuit(builder, block_header.to_vec(), block_hash);
+		let block_header = DoubleSha256::construct_circuit(builder, &block_header, block_hash);
 
 		Self {
 			merkle_path,
@@ -58,7 +57,7 @@ impl BlockContainsTransaction {
 
 	pub fn populate_inner(
 		&self,
-		filler: &mut WitnessFiller,
+		filler: &mut WitnessFiller<'_>,
 		transaction_hash: [u8; 32],
 		merkle_path: &[([u8; 32], SiblingSide)],
 		block_header: &[u8],

--- a/crates/examples/src/circuits/bitcoin_header_chain.rs
+++ b/crates/examples/src/circuits/bitcoin_header_chain.rs
@@ -59,7 +59,7 @@ impl ExampleCircuit for BitcoinHeaderChainExample {
 	fn populate_witness(
 		&self,
 		instance: Self::Instance,
-		filler: &mut WitnessFiller,
+		filler: &mut WitnessFiller<'_>,
 	) -> anyhow::Result<()> {
 		let (headers_value, latest_digest_value) =
 			pull_headers(self.headers.len(), instance.to_block)?;
@@ -115,8 +115,6 @@ fn pull_headers(
 			.call()?
 			.body_mut()
 			.read_to_string()?;
-		let mut hash = hex::decode(hash)?;
-		hash.reverse();
 		let header = hex::decode(header)?;
 		headers.push(header);
 	}

--- a/crates/examples/src/circuits/bitcoin_p2pkh.rs
+++ b/crates/examples/src/circuits/bitcoin_p2pkh.rs
@@ -71,14 +71,10 @@ impl ExampleCircuit for BitcoinP2PKHExample {
 		})
 	}
 
-	fn populate_witness(&self, instance: Instance, w: &mut WitnessFiller) -> Result<()> {
+	fn populate_witness(&self, instance: Instance, w: &mut WitnessFiller<'_>) -> Result<()> {
 		// Generate or use provided private key
-		let private_key_bytes = match instance.private_key {
-			Some(key) => {
-				tracing::info!("Using provided private key");
-				key
-			}
-			None => {
+		let private_key_bytes = instance.private_key.map_or_else(
+			|| {
 				let mut rng = StdRng::seed_from_u64(instance.seed);
 				let mut key = [0u8; 32];
 
@@ -100,8 +96,12 @@ impl ExampleCircuit for BitcoinP2PKHExample {
 					hex::encode(key)
 				);
 				key
-			}
-		};
+			},
+			|key| {
+				tracing::info!("Using provided private key");
+				key
+			},
+		);
 
 		// Get expected Bitcoin address (hash160). If not provided, compute from the private key
 		let expected_address_bytes = match instance.expected_address {
@@ -178,8 +178,8 @@ fn is_valid_secp256k1_key(bytes: &[u8; 32]) -> bool {
 	// secp256k1 group order starts with 0xFFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFE
 	// So any key starting with 0xFFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF is definitely too large
 	// Return false if the first 12 bytes are all 0xFF
-	for i in 0..12 {
-		if bytes[i] != 0xFF {
+	for &byte in &bytes[0..12] {
+		if byte != 0xFF {
 			return true;
 		}
 	}

--- a/crates/examples/src/circuits/blake2b.rs
+++ b/crates/examples/src/circuits/blake2b.rs
@@ -47,7 +47,7 @@ impl ExampleCircuit for Blake2bExample {
 		Ok(Self { blake2b_circuit })
 	}
 
-	fn populate_witness(&self, instance: Instance, w: &mut WitnessFiller) -> Result<()> {
+	fn populate_witness(&self, instance: Instance, w: &mut WitnessFiller<'_>) -> Result<()> {
 		// Step 1: Get raw message bytes
 		let message = utils::generate_message_bytes(instance.message_string, instance.message_len);
 

--- a/crates/examples/src/circuits/blake2s.rs
+++ b/crates/examples/src/circuits/blake2s.rs
@@ -48,7 +48,7 @@ impl ExampleCircuit for Blake2sExample {
 		Ok(Self { blake2s_gadget })
 	}
 
-	fn populate_witness(&self, instance: Instance, w: &mut WitnessFiller) -> Result<()> {
+	fn populate_witness(&self, instance: Instance, w: &mut WitnessFiller<'_>) -> Result<()> {
 		// Step 1: Get raw message bytes
 		let message = utils::generate_message_bytes(instance.message_string, instance.message_len);
 

--- a/crates/examples/src/circuits/blake3_compress.rs
+++ b/crates/examples/src/circuits/blake3_compress.rs
@@ -77,7 +77,7 @@ impl ExampleCircuit for Blake3CompressExample {
 		Ok(Self { initial_cv, pairs })
 	}
 
-	fn populate_witness(&self, instance: Instance, w: &mut WitnessFiller) -> Result<()> {
+	fn populate_witness(&self, instance: Instance, w: &mut WitnessFiller<'_>) -> Result<()> {
 		let mut rng = StdRng::seed_from_u64(instance.seed.unwrap_or(DEFAULT_RANDOM_SEED));
 		let mut next = || Word(rng.next_u64());
 

--- a/crates/examples/src/circuits/ec_msm.rs
+++ b/crates/examples/src/circuits/ec_msm.rs
@@ -37,7 +37,7 @@ struct AffinePoint {
 }
 
 impl AffinePoint {
-	fn new_inout(builder: &mut CircuitBuilder) -> Self {
+	fn new_inout(builder: &CircuitBuilder) -> Self {
 		Self {
 			x: BigUint::new_inout(builder, N_LIMBS),
 			y: BigUint::new_inout(builder, N_LIMBS),
@@ -101,7 +101,7 @@ impl ExampleCircuit for EcMsmExample {
 		})
 	}
 
-	fn populate_witness(&self, _instance: Instance, w: &mut WitnessFiller) -> Result<()> {
+	fn populate_witness(&self, _instance: Instance, w: &mut WitnessFiller<'_>) -> Result<()> {
 		let mut rng = StdRng::seed_from_u64(42);
 		let mut expected = ProjectivePoint::IDENTITY;
 
@@ -133,7 +133,7 @@ impl ExampleCircuit for EcMsmExample {
 }
 
 /// Populate the `x` and `y` limb wires from a k256 projective point's affine coordinates.
-fn populate_point(w: &mut WitnessFiller, p: &ProjectivePoint, x: &BigUint, y: &BigUint) {
+fn populate_point(w: &mut WitnessFiller<'_>, p: &ProjectivePoint, x: &BigUint, y: &BigUint) {
 	let bytes = p.to_affine().to_encoded_point(false).to_bytes();
 	// Uncompressed SEC1 encoding: `0x04 || x (32 bytes) || y (32 bytes)`.
 	x.populate_limbs(w, &le_limbs(&num_bigint::BigUint::from_bytes_be(&bytes[1..33])));

--- a/crates/examples/src/circuits/ethsign.rs
+++ b/crates/examples/src/circuits/ethsign.rs
@@ -63,7 +63,7 @@ impl ExampleCircuit for EthSignExample {
 				let address = array::from_fn(|_| builder.add_inout());
 
 				let msg_final_state = array::from_fn(|_| builder.add_witness());
-				let msg_keccak = Keccak256::new(builder, msg_len, msg_final_state, message.clone());
+				let msg_keccak = Keccak256::new(builder, msg_len, msg_final_state, message);
 
 				// The Keccak digest is little endian encoded into 4 words, while Ethereum expects
 				// big endian
@@ -127,7 +127,7 @@ impl ExampleCircuit for EthSignExample {
 		})
 	}
 
-	fn populate_witness(&self, _instance: Instance, w: &mut WitnessFiller) -> Result<()> {
+	fn populate_witness(&self, _instance: Instance, w: &mut WitnessFiller<'_>) -> Result<()> {
 		// Generate random initial state with fixed seed for reproducibility
 		let mut rng = StdRng::seed_from_u64(42);
 

--- a/crates/examples/src/circuits/hashsign.rs
+++ b/crates/examples/src/circuits/hashsign.rs
@@ -100,7 +100,7 @@ impl ExampleCircuit for HashBasedSigExample {
 		})
 	}
 
-	fn populate_witness(&self, _instance: Instance, w: &mut WitnessFiller) -> Result<()> {
+	fn populate_witness(&self, _instance: Instance, w: &mut WitnessFiller<'_>) -> Result<()> {
 		let mut rng = StdRng::seed_from_u64(42); // Fixed seed for benchmarking consistency
 
 		// Fixed 32-byte message

--- a/crates/examples/src/circuits/keccak.rs
+++ b/crates/examples/src/circuits/keccak.rs
@@ -52,7 +52,7 @@ impl ExampleCircuit for KeccakExample {
 		})
 	}
 
-	fn populate_witness(&self, instance: Instance, w: &mut WitnessFiller) -> Result<()> {
+	fn populate_witness(&self, instance: Instance, w: &mut WitnessFiller<'_>) -> Result<()> {
 		// Step 1: Get raw message bytes
 		let message = utils::generate_message_bytes(instance.message_string, instance.message_len);
 

--- a/crates/examples/src/circuits/sha256.rs
+++ b/crates/examples/src/circuits/sha256.rs
@@ -55,7 +55,7 @@ impl ExampleCircuit for Sha256Example {
 		Ok(Self { sha256_gadget })
 	}
 
-	fn populate_witness(&self, instance: Instance, w: &mut WitnessFiller) -> Result<()> {
+	fn populate_witness(&self, instance: Instance, w: &mut WitnessFiller<'_>) -> Result<()> {
 		// Step 1: Get raw message bytes
 		let message = utils::generate_message_bytes(instance.message_string, instance.message_len);
 
@@ -85,7 +85,7 @@ impl ExampleCircuit for Sha256Example {
 	}
 }
 
-fn mk_circuit(b: &mut CircuitBuilder, max_len: usize, len_bytes: Wire) -> Sha256 {
+fn mk_circuit(b: &CircuitBuilder, max_len: usize, len_bytes: Wire) -> Sha256 {
 	let digest: [Wire; 4] = array::from_fn(|_| b.add_inout());
 	let message = (0..max_len).map(|_| b.add_inout()).collect();
 	Sha256::new(b, len_bytes, digest, message)

--- a/crates/examples/src/circuits/sha512.rs
+++ b/crates/examples/src/circuits/sha512.rs
@@ -65,7 +65,7 @@ impl ExampleCircuit for Sha512Example {
 		Ok(Self { message, digest })
 	}
 
-	fn populate_witness(&self, instance: Instance, w: &mut WitnessFiller) -> Result<()> {
+	fn populate_witness(&self, instance: Instance, w: &mut WitnessFiller<'_>) -> Result<()> {
 		// Step 1: Get raw message bytes
 		let message = utils::generate_message_bytes(instance.message_string, instance.message_len);
 

--- a/crates/examples/src/circuits/subset_sum.rs
+++ b/crates/examples/src/circuits/subset_sum.rs
@@ -56,8 +56,8 @@ impl SubsetSum {
 		// compute sum of `values_masked`
 		let mut sum = builder.add_constant(Word::ZERO);
 		let mut carry = builder.add_constant(Word::ZERO);
-		for i in 0..len {
-			(sum, carry) = builder.iadd_cin_cout(sum, values_masked[i], carry);
+		for &value_masked in &values_masked {
+			(sum, carry) = builder.iadd_cin_cout(sum, value_masked, carry);
 			// check that no overflow occurred
 			builder.assert_false("no overflow", carry);
 		}
@@ -77,7 +77,7 @@ impl SubsetSum {
 	///
 	/// - `values` is the list of integers available
 	/// - `target` is the target value that a sublist should sum to
-	pub fn populate_problem(&self, filler: &mut WitnessFiller<'_>, values: Vec<u64>, target: u64) {
+	pub fn populate_problem(&self, filler: &mut WitnessFiller<'_>, values: &[u64], target: u64) {
 		assert_eq!(values.len(), self.len);
 
 		for i in 0..self.len {
@@ -92,7 +92,7 @@ impl SubsetSum {
 	///
 	/// - `selection` should have the same length as the original list, and should contain `true`
 	///   for every number that should be included in the sublist
-	pub fn populate_solution(&self, filler: &mut WitnessFiller<'_>, selection: Vec<bool>) {
+	pub fn populate_solution(&self, filler: &mut WitnessFiller<'_>, selection: &[bool]) {
 		assert_eq!(selection.len(), self.len);
 
 		for i in 0..self.len {
@@ -122,8 +122,8 @@ mod tests {
 
 		// populate witness
 		let mut filler = circuit.new_witness_filler();
-		subset_sum.populate_problem(&mut filler, vec![2, 5, 5, 3, 7], 17);
-		subset_sum.populate_solution(&mut filler, vec![false, true, true, false, true]);
+		subset_sum.populate_problem(&mut filler, &[2, 5, 5, 3, 7], 17);
+		subset_sum.populate_solution(&mut filler, &[false, true, true, false, true]);
 		circuit.populate_wire_witness(&mut filler).unwrap();
 
 		// check
@@ -141,8 +141,8 @@ mod tests {
 
 		// populate witness
 		let mut filler = circuit.new_witness_filler();
-		subset_sum.populate_problem(&mut filler, vec![2, 5, 5, 3, 7], 17);
-		subset_sum.populate_solution(&mut filler, vec![false, true, true, false, false]);
+		subset_sum.populate_problem(&mut filler, &[2, 5, 5, 3, 7], 17);
+		subset_sum.populate_solution(&mut filler, &[false, true, true, false, false]);
 		circuit.populate_wire_witness(&mut filler).unwrap_err();
 	}
 
@@ -157,7 +157,7 @@ mod tests {
 
 		// populate witness
 		let mut filler = circuit.new_witness_filler();
-		subset_sum.populate_problem(&mut filler, vec![3], 1);
+		subset_sum.populate_problem(&mut filler, &[3], 1);
 		// This is trying to be a malicious prover: If the constraints are not assembled
 		// carefully, this could pass because `values ^ selection` sums to target.
 		// In other words, we carefully selected the bits of `selection` so that they
@@ -176,10 +176,10 @@ mod tests {
 
 		// populate witness
 		let mut filler = circuit.new_witness_filler();
-		subset_sum.populate_problem(&mut filler, vec![2 << 62, 3 << 62], 1 << 62);
+		subset_sum.populate_problem(&mut filler, &[2 << 62, 3 << 62], 1 << 62);
 		// This is a valid solution modulo 2^64, so if the constraints are not assembled
 		// carefully, this could pass.
-		subset_sum.populate_solution(&mut filler, vec![true, true]);
+		subset_sum.populate_solution(&mut filler, &[true, true]);
 		circuit.populate_wire_witness(&mut filler).unwrap_err();
 	}
 }

--- a/crates/examples/src/circuits/utils.rs
+++ b/crates/examples/src/circuits/utils.rs
@@ -46,11 +46,10 @@ pub fn determine_hash_max_bytes_from_args(max_bytes_param: Option<usize>) -> Res
 			}
 		}
 
-		if let Some(msg_string) = message_string {
-			msg_string.len()
-		} else {
-			message_len.unwrap_or(DEFAULT_HASH_MESSAGE_BYTES)
-		}
+		message_string.map_or_else(
+			|| message_len.unwrap_or(DEFAULT_HASH_MESSAGE_BYTES),
+			|msg_string| msg_string.len(),
+		)
 	});
 
 	ensure!(max_bytes > 0, "Message length must be positive");
@@ -68,13 +67,14 @@ pub fn generate_message_bytes(
 	message_string: Option<String>,
 	message_len: Option<usize>,
 ) -> Vec<u8> {
-	if let Some(message_string) = message_string {
-		message_string.as_bytes().to_vec()
-	} else {
-		let mut rng = StdRng::seed_from_u64(DEFAULT_RANDOM_SEED);
-		let len = message_len.unwrap_or(DEFAULT_HASH_MESSAGE_BYTES);
-		let mut message_bytes = vec![0u8; len];
-		rng.fill_bytes(&mut message_bytes);
-		message_bytes
-	}
+	message_string.map_or_else(
+		|| {
+			let mut rng = StdRng::seed_from_u64(DEFAULT_RANDOM_SEED);
+			let len = message_len.unwrap_or(DEFAULT_HASH_MESSAGE_BYTES);
+			let mut message_bytes = vec![0u8; len];
+			rng.fill_bytes(&mut message_bytes);
+			message_bytes
+		},
+		|message_string| message_string.as_bytes().to_vec(),
+	)
 }

--- a/crates/examples/src/circuits/zklogin.rs
+++ b/crates/examples/src/circuits/zklogin.rs
@@ -56,15 +56,15 @@ impl Default for Config {
 }
 
 impl Config {
-	pub fn max_len_base64_jwt_header(&self) -> usize {
+	pub const fn max_len_base64_jwt_header(&self) -> usize {
 		self.max_len_json_jwt_header.div_ceil(3) * 4
 	}
 
-	pub fn max_len_base64_jwt_payload(&self) -> usize {
+	pub const fn max_len_base64_jwt_payload(&self) -> usize {
 		self.max_len_json_jwt_payload.div_ceil(3) * 4
 	}
 
-	pub fn max_len_base64_jwt_signature(&self) -> usize {
+	pub const fn max_len_base64_jwt_signature(&self) -> usize {
 		self.max_len_jwt_signature.div_ceil(3) * 4
 	}
 }
@@ -116,7 +116,7 @@ pub struct ZkLogin {
 }
 
 impl ZkLogin {
-	pub fn new(b: &mut CircuitBuilder, config: Config) -> Self {
+	pub fn new(b: &mut CircuitBuilder, config: &Config) -> Self {
 		let sub = ByteVec::new_inout(b, config.max_len_jwt_sub);
 		let aud = ByteVec::new_inout(b, config.max_len_jwt_aud);
 		let iss = ByteVec::new_inout(b, config.max_len_jwt_iss);
@@ -251,7 +251,7 @@ impl ZkLogin {
 		let base64_check_nonce_builder = b.subcircuit("base64_check_nonce");
 		let _base64decode_check_nonce = Base64UrlSafe::new(
 			&base64_check_nonce_builder,
-			nonce_le_for_base64.clone(),
+			nonce_le_for_base64,
 			base64_jwt_payload_nonce.to_vec(),
 			base64_check_nonce_builder.add_constant_64(32),
 		);
@@ -277,7 +277,7 @@ impl ZkLogin {
 			.collect();
 
 		let jwt_signing_payload =
-			ByteVec::new(jwt_signing_payload_sha256_message.clone(), signing_payload.len_bytes);
+			ByteVec::new(jwt_signing_payload_sha256_message, signing_payload.len_bytes);
 
 		let jwt_signature_verify =
 			Rs256Verify::new(b, jwt_signing_payload, jwt_signature.clone(), rsa_modulus);
@@ -320,92 +320,96 @@ impl ZkLogin {
 		}
 	}
 
-	pub fn populate_sub(&self, w: &mut WitnessFiller, sub_bytes: &[u8]) {
+	pub fn populate_sub(&self, w: &mut WitnessFiller<'_>, sub_bytes: &[u8]) {
 		self.sub.populate_bytes_le(w, sub_bytes);
 	}
 
-	pub fn populate_aud(&self, w: &mut WitnessFiller, aud_bytes: &[u8]) {
+	pub fn populate_aud(&self, w: &mut WitnessFiller<'_>, aud_bytes: &[u8]) {
 		self.aud.populate_bytes_le(w, aud_bytes);
 	}
 
-	pub fn populate_iss(&self, w: &mut WitnessFiller, iss_bytes: &[u8]) {
+	pub fn populate_iss(&self, w: &mut WitnessFiller<'_>, iss_bytes: &[u8]) {
 		self.iss.populate_bytes_le(w, iss_bytes);
 	}
 
-	pub fn populate_salt(&self, w: &mut WitnessFiller, salt_bytes: &[u8]) {
+	pub fn populate_salt(&self, w: &mut WitnessFiller<'_>, salt_bytes: &[u8]) {
 		self.salt.populate_bytes_le(w, salt_bytes);
 	}
 
-	pub fn populate_zkaddr(&self, w: &mut WitnessFiller, zkaddr_hash: &[u8; 32]) {
+	pub fn populate_zkaddr(&self, w: &mut WitnessFiller<'_>, zkaddr_hash: &[u8; 32]) {
 		self.zkaddr_sha256.populate_digest(w, *zkaddr_hash);
 	}
 
-	pub fn populate_zkaddr_preimage(&self, w: &mut WitnessFiller, zkaddr_preimage: &[u8]) {
+	pub fn populate_zkaddr_preimage(&self, w: &mut WitnessFiller<'_>, zkaddr_preimage: &[u8]) {
 		self.zkaddr_sha256
 			.populate_len_bytes(w, zkaddr_preimage.len());
 		self.zkaddr_sha256.populate_message(w, zkaddr_preimage);
 	}
 
-	pub fn populate_jwt_header(&self, w: &mut WitnessFiller, header_bytes: &[u8]) {
+	pub fn populate_jwt_header(&self, w: &mut WitnessFiller<'_>, header_bytes: &[u8]) {
 		self.jwt_header.populate_bytes_le(w, header_bytes);
 	}
 
-	pub fn populate_jwt_payload(&self, w: &mut WitnessFiller, payload_bytes: &[u8]) {
+	pub fn populate_jwt_payload(&self, w: &mut WitnessFiller<'_>, payload_bytes: &[u8]) {
 		self.jwt_payload.populate_bytes_le(w, payload_bytes);
 	}
 
-	pub fn populate_jwt_signature(&self, w: &mut WitnessFiller, signature_bytes: &[u8]) {
+	pub fn populate_jwt_signature(&self, w: &mut WitnessFiller<'_>, signature_bytes: &[u8]) {
 		assert_eq!(signature_bytes.len(), 256, "RSA signature must be 256 bytes");
 		self.jwt_signature.populate_bytes_le(w, signature_bytes);
 	}
 
-	pub fn populate_base64_jwt_header(&self, w: &mut WitnessFiller, bytes: &[u8]) {
+	pub fn populate_base64_jwt_header(&self, w: &mut WitnessFiller<'_>, bytes: &[u8]) {
 		self.base64_jwt_header.populate_bytes_le(w, bytes);
 	}
 
-	pub fn populate_base64_jwt_payload(&self, w: &mut WitnessFiller, bytes: &[u8]) {
+	pub fn populate_base64_jwt_payload(&self, w: &mut WitnessFiller<'_>, bytes: &[u8]) {
 		self.base64_jwt_payload.populate_bytes_le(w, bytes);
 	}
 
-	pub fn populate_base64_jwt_signature(&self, w: &mut WitnessFiller, bytes: &[u8]) {
+	pub fn populate_base64_jwt_signature(&self, w: &mut WitnessFiller<'_>, bytes: &[u8]) {
 		self.base64_jwt_signature.populate_bytes_le(w, bytes);
 	}
 
-	pub fn populate_rsa_modulus(&self, w: &mut WitnessFiller, modulus_bytes: &[u8]) {
+	pub fn populate_rsa_modulus(&self, w: &mut WitnessFiller<'_>, modulus_bytes: &[u8]) {
 		self.jwt_signature_verify
 			.modulus
 			.populate_bytes_le(w, modulus_bytes);
 	}
 
-	pub fn populate_jwt_header_attributes(&self, w: &mut WitnessFiller) {
+	pub fn populate_jwt_header_attributes(&self, w: &mut WitnessFiller<'_>) {
 		// Populate the expected lengths for "alg" and "typ" attributes
 		self.jwt_claims_header.attributes[0].populate_len_bytes(w, 5); // "RS256" is 5 bytes
 		self.jwt_claims_header.attributes[1].populate_len_bytes(w, 3); // "JWT" is 3 bytes
 	}
 
-	pub fn populate_nonce(&self, w: &mut WitnessFiller, nonce_hash: &[u8; 32]) {
+	pub fn populate_nonce(&self, w: &mut WitnessFiller<'_>, nonce_hash: &[u8; 32]) {
 		self.nonce_sha256.populate_digest(w, *nonce_hash);
 	}
 
-	pub fn populate_nonce_preimage(&self, w: &mut WitnessFiller, nonce_preimage: &[u8]) {
+	pub fn populate_nonce_preimage(&self, w: &mut WitnessFiller<'_>, nonce_preimage: &[u8]) {
 		self.nonce_sha256
 			.populate_len_bytes(w, nonce_preimage.len());
 		self.nonce_sha256.populate_message(w, nonce_preimage);
 	}
 
-	pub fn populate_vk_u(&self, w: &mut WitnessFiller, vk_u_bytes: &[u8; 32]) {
+	pub fn populate_vk_u(&self, w: &mut WitnessFiller<'_>, vk_u_bytes: &[u8; 32]) {
 		pack_bytes_into_wires_le(w, &self.vk_u, vk_u_bytes);
 	}
 
-	pub fn populate_t_max(&self, w: &mut WitnessFiller, t_max_bytes: &[u8]) {
+	pub fn populate_t_max(&self, w: &mut WitnessFiller<'_>, t_max_bytes: &[u8]) {
 		self.t_max.populate_bytes_le(w, t_max_bytes);
 	}
 
-	pub fn populate_nonce_r(&self, w: &mut WitnessFiller, nonce_r_bytes: &[u8]) {
+	pub fn populate_nonce_r(&self, w: &mut WitnessFiller<'_>, nonce_r_bytes: &[u8]) {
 		self.nonce_r.populate_bytes_le(w, nonce_r_bytes);
 	}
 
-	pub fn populate_base64_jwt_payload_nonce(&self, w: &mut WitnessFiller, base64_nonce: &[u8]) {
+	pub fn populate_base64_jwt_payload_nonce(
+		&self,
+		w: &mut WitnessFiller<'_>,
+		base64_nonce: &[u8],
+	) {
 		// The base64 nonce is 43 characters, but we need to pad to 48 bytes (6 wires)
 		let mut padded = vec![0u8; 48];
 		padded[..base64_nonce.len()].copy_from_slice(&base64_nonce[..base64_nonce.len()]);
@@ -569,12 +573,12 @@ impl ExampleCircuit for ZkLoginExample {
 
 	fn build(params: Params, builder: &mut CircuitBuilder) -> Result<Self> {
 		let config = params.config.unwrap_or_default();
-		let zklogin = ZkLogin::new(builder, config);
+		let zklogin = ZkLogin::new(builder, &config);
 
 		Ok(Self { zklogin })
 	}
 
-	fn populate_witness(&self, instance: Instance, w: &mut WitnessFiller) -> Result<()> {
+	fn populate_witness(&self, instance: Instance, w: &mut WitnessFiller<'_>) -> Result<()> {
 		let mut rng = StdRng::seed_from_u64(42);
 
 		// Generate JWT and related data

--- a/crates/examples/src/cli.rs
+++ b/crates/examples/src/cli.rs
@@ -57,7 +57,7 @@ fn prove_with_hash_suite<H>(
 	log_inv_rate: usize,
 	zk: bool,
 	message: Option<&[u8]>,
-	witness: ValueVec,
+	witness: &ValueVec,
 	output: Option<&str>,
 ) -> Result<()>
 where
@@ -66,14 +66,14 @@ where
 {
 	if zk {
 		let (verifier, prover) = setup_zk::<H>(cs, log_inv_rate)?;
-		let proof_bytes = create_proof_zk(&prover, witness.clone(), message)?;
+		let proof_bytes = create_proof_zk(&prover, witness, message)?;
 		maybe_write_proof(&proof_bytes, output)?;
-		check_proof_zk(&verifier, &witness, proof_bytes, message)?;
+		check_proof_zk(&verifier, witness, proof_bytes, message)?;
 	} else {
 		let (verifier, prover) = setup::<H>(cs, log_inv_rate, None)?;
-		let proof_bytes = create_proof(&prover, witness.clone())?;
+		let proof_bytes = create_proof(&prover, witness)?;
 		maybe_write_proof(&proof_bytes, output)?;
-		check_proof(&verifier, &witness, proof_bytes)?;
+		check_proof(&verifier, witness, proof_bytes)?;
 	}
 	Ok(())
 }
@@ -84,7 +84,7 @@ fn verify_with_hash_suite<H>(
 	log_inv_rate: usize,
 	zk: bool,
 	message: Option<&[u8]>,
-	witness: ValueVec,
+	witness: &ValueVec,
 	proof_bytes: Vec<u8>,
 ) -> Result<()>
 where
@@ -93,10 +93,10 @@ where
 {
 	if zk {
 		let verifier = setup_zk_verifier::<H>(cs, log_inv_rate)?;
-		check_proof_zk(&verifier, &witness, proof_bytes, message)?;
+		check_proof_zk(&verifier, witness, proof_bytes, message)?;
 	} else {
 		let verifier = setup_verifier::<H>(cs, log_inv_rate)?;
-		check_proof(&verifier, &witness, proof_bytes)?;
+		check_proof(&verifier, witness, proof_bytes)?;
 	}
 	Ok(())
 }
@@ -558,7 +558,7 @@ where
 
 	/// Run the circuit with parsed ArgMatches (implementation).
 	#[allow(unused_variables)]
-	fn run_with_matches_impl(matches: clap::ArgMatches, circuit_name: &str) -> Result<()> {
+	fn run_with_matches_impl(matches: &clap::ArgMatches, circuit_name: &str) -> Result<()> {
 		// Initialize tracing once at the beginning for all commands. In perfetto mode the
 		// returned guard must be held for the duration of the program to flush the trace.
 		#[cfg(feature = "perfetto")]
@@ -577,7 +577,7 @@ where
 			// Try to extract params from the appropriate matches for richer context
 			// This will succeed for most commands (prove, stat, save, etc.)
 			// and fail gracefully for commands without params (like load-prove)
-			let matches_for_params = matches.subcommand().map(|(_, sub)| sub).unwrap_or(&matches);
+			let matches_for_params = matches.subcommand().map(|(_, sub)| sub).unwrap_or(matches);
 
 			if let Ok(params) = E::Params::from_arg_matches(matches_for_params)
 				&& let Some(param_summary) = E::param_summary(&params)
@@ -592,18 +592,18 @@ where
 
 		// Check if a subcommand was used
 		match matches.subcommand() {
-			Some(("prove", sub_matches)) => Self::run_prove(sub_matches.clone()),
-			Some(("stat", sub_matches)) => Self::run_stat(sub_matches.clone()),
-			Some(("composition", sub_matches)) => Self::run_composition(sub_matches.clone()),
+			Some(("prove", sub_matches)) => Self::run_prove(sub_matches),
+			Some(("stat", sub_matches)) => Self::run_stat(sub_matches),
+			Some(("composition", sub_matches)) => Self::run_composition(sub_matches),
 			Some(("check-snapshot", sub_matches)) => {
-				Self::run_check_snapshot_impl(sub_matches.clone(), circuit_name)
+				Self::run_check_snapshot_impl(sub_matches, circuit_name)
 			}
 			Some(("bless-snapshot", sub_matches)) => {
-				Self::run_bless_snapshot_impl(sub_matches.clone(), circuit_name)
+				Self::run_bless_snapshot_impl(sub_matches, circuit_name)
 			}
-			Some(("save", sub_matches)) => Self::run_save(sub_matches.clone()),
-			Some(("load-prove", sub_matches)) => Self::run_load_prove(sub_matches.clone()),
-			Some(("verify", sub_matches)) => Self::run_verify(sub_matches.clone()),
+			Some(("save", sub_matches)) => Self::run_save(sub_matches),
+			Some(("load-prove", sub_matches)) => Self::run_load_prove(sub_matches),
+			Some(("verify", sub_matches)) => Self::run_verify(sub_matches),
 			Some((cmd, _)) => anyhow::bail!("Unknown subcommand: {}", cmd),
 			None => {
 				// No subcommand - default to prove behavior for backward compatibility
@@ -612,7 +612,7 @@ where
 		}
 	}
 
-	fn run_prove(matches: clap::ArgMatches) -> Result<()> {
+	fn run_prove(matches: &clap::ArgMatches) -> Result<()> {
 		// Extract common arguments
 		let log_inv_rate = *matches
 			.get_one::<u32>("log_inv_rate")
@@ -634,8 +634,8 @@ where
 		let message = sign_message.as_deref().map(str::as_bytes);
 
 		// Parse Params and Instance from matches
-		let params = E::Params::from_arg_matches(&matches)?;
-		let instance = E::Instance::from_arg_matches(&matches)?;
+		let params = E::Params::from_arg_matches(matches)?;
+		let instance = E::Instance::from_arg_matches(matches)?;
 
 		// Build the circuit
 		let build_scope = tracing::info_span!("Building circuit").entered();
@@ -671,7 +671,7 @@ where
 					log_inv_rate as usize,
 					zk,
 					message,
-					witness,
+					&witness,
 					output,
 				)?;
 			}
@@ -680,9 +680,9 @@ where
 		Ok(())
 	}
 
-	fn run_stat(matches: clap::ArgMatches) -> Result<()> {
+	fn run_stat(matches: &clap::ArgMatches) -> Result<()> {
 		// Parse Params from matches
-		let params = E::Params::from_arg_matches(&matches)?;
+		let params = E::Params::from_arg_matches(matches)?;
 
 		// Build the circuit
 		let mut builder = CircuitBuilder::new();
@@ -696,9 +696,9 @@ where
 		Ok(())
 	}
 
-	fn run_composition(matches: clap::ArgMatches) -> Result<()> {
+	fn run_composition(matches: &clap::ArgMatches) -> Result<()> {
 		// Parse Params from matches
-		let params = E::Params::from_arg_matches(&matches)?;
+		let params = E::Params::from_arg_matches(matches)?;
 
 		// Build the circuit
 		let mut builder = CircuitBuilder::new();
@@ -712,9 +712,9 @@ where
 		Ok(())
 	}
 
-	fn run_check_snapshot_impl(matches: clap::ArgMatches, circuit_name: &str) -> Result<()> {
+	fn run_check_snapshot_impl(matches: &clap::ArgMatches, circuit_name: &str) -> Result<()> {
 		// Parse Params from matches
-		let params = E::Params::from_arg_matches(&matches)?;
+		let params = E::Params::from_arg_matches(matches)?;
 
 		// Build the circuit
 		let mut builder = CircuitBuilder::new();
@@ -727,9 +727,9 @@ where
 		Ok(())
 	}
 
-	fn run_bless_snapshot_impl(matches: clap::ArgMatches, circuit_name: &str) -> Result<()> {
+	fn run_bless_snapshot_impl(matches: &clap::ArgMatches, circuit_name: &str) -> Result<()> {
 		// Parse Params from matches
-		let params = E::Params::from_arg_matches(&matches)?;
+		let params = E::Params::from_arg_matches(matches)?;
 
 		// Build the circuit
 		let mut builder = CircuitBuilder::new();
@@ -742,7 +742,7 @@ where
 		Ok(())
 	}
 
-	fn run_save(matches: clap::ArgMatches) -> Result<()> {
+	fn run_save(matches: &clap::ArgMatches) -> Result<()> {
 		// Extract optional output paths
 		let cs_path = matches.get_one::<String>("cs_path").cloned();
 		let pub_witness_path = matches.get_one::<String>("pub_witness_path").cloned();
@@ -760,8 +760,8 @@ where
 		}
 
 		// Parse Params and Instance
-		let params = E::Params::from_arg_matches(&matches)?;
-		let instance = E::Instance::from_arg_matches(&matches)?;
+		let params = E::Params::from_arg_matches(matches)?;
+		let instance = E::Instance::from_arg_matches(matches)?;
 
 		// Build circuit
 		let mut builder = CircuitBuilder::new();
@@ -805,7 +805,7 @@ where
 		Ok(())
 	}
 
-	fn run_load_prove(matches: clap::ArgMatches) -> Result<()> {
+	fn run_load_prove(matches: &clap::ArgMatches) -> Result<()> {
 		// Extract file paths and parameters
 		let cs_path = matches
 			.get_one::<String>("cs_path")
@@ -847,18 +847,14 @@ where
 
 		// Load witness data
 		let witness_load_scope = tracing::info_span!("Loading witness data").entered();
-		let pub_witness_data: ValuesData = read_deserialized(pub_witness_path)?;
+		let pub_witness_data: ValuesData<'_> = read_deserialized(pub_witness_path)?;
 		tracing::info!("Public witness loaded from '{}'", pub_witness_path);
 
-		let non_pub_data: ValuesData = read_deserialized(non_pub_data_path)?;
+		let non_pub_data: ValuesData<'_> = read_deserialized(non_pub_data_path)?;
 		tracing::info!("Non-public data loaded from '{}'", non_pub_data_path);
 
 		// Reconstruct the full witness using the layout
-		let witness = ValueVec::new_from_data(
-			layout,
-			pub_witness_data.into_owned(),
-			non_pub_data.into_owned(),
-		)?;
+		let witness = ValueVec::new_from_data(layout, &pub_witness_data, &non_pub_data)?;
 		drop(witness_load_scope);
 
 		match compression {
@@ -866,14 +862,14 @@ where
 				tracing::info!("Using SHA256 compression for Merkle tree");
 				let (verifier, prover) =
 					setup::<StdHashSuite>(cs, log_inv_rate as usize, maybe_key_collection)?;
-				prove_verify(&verifier, &prover, witness)?;
+				prove_verify(&verifier, &prover, &witness)?;
 			}
 		};
 
 		Ok(())
 	}
 
-	fn run_verify(matches: clap::ArgMatches) -> Result<()> {
+	fn run_verify(matches: &clap::ArgMatches) -> Result<()> {
 		let proof_file = matches
 			.get_one::<String>("proof_file")
 			.expect("proof_file is required");
@@ -893,8 +889,8 @@ where
 		let (proof_bytes, _) = proof.into_owned();
 
 		// Parse Params and Instance from matches
-		let params = E::Params::from_arg_matches(&matches)?;
-		let instance = E::Instance::from_arg_matches(&matches)?;
+		let params = E::Params::from_arg_matches(matches)?;
+		let instance = E::Instance::from_arg_matches(matches)?;
 
 		// Build the circuit
 		let build_scope = tracing::info_span!("Building circuit").entered();
@@ -920,7 +916,7 @@ where
 					log_inv_rate as usize,
 					zk,
 					message,
-					witness,
+					&witness,
 					proof_bytes,
 				)?;
 			}
@@ -941,7 +937,7 @@ where
 	pub fn run(self) -> Result<()> {
 		let name = self.name.clone();
 		let matches = self.command.get_matches();
-		Self::run_with_matches_impl(matches, &name)
+		Self::run_with_matches_impl(&matches, &name)
 	}
 
 	/// Parse arguments and run with custom argument strings (useful for testing).
@@ -955,6 +951,6 @@ where
 	{
 		let name = self.name.clone();
 		let matches = self.command.try_get_matches_from(args)?;
-		Self::run_with_matches_impl(matches, &name)
+		Self::run_with_matches_impl(&matches, &name)
 	}
 }

--- a/crates/examples/src/lib.rs
+++ b/crates/examples/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
+//! Example Binius64 circuits and a CLI harness for building, proving, and verifying them.
+
 pub mod circuits;
 pub mod cli;
 pub mod snapshot;
@@ -97,7 +99,7 @@ where
 {
 	let _setup_guard = tracing::info_span!("ZK setup", log_inv_rate).entered();
 	let verifier = ZKVerifier::<H>::setup(cs, log_inv_rate)?;
-	let prover = ZKProver::setup(verifier.clone())?;
+	let prover = ZKProver::setup(&verifier)?;
 	Ok((verifier, prover))
 }
 
@@ -124,7 +126,7 @@ where
 }
 
 /// Run the prover and return the raw proof transcript bytes.
-pub fn create_proof<H>(prover: &Prover<OptimalPackedB128, H>, witness: ValueVec) -> Result<Vec<u8>>
+pub fn create_proof<H>(prover: &Prover<OptimalPackedB128, H>, witness: &ValueVec) -> Result<Vec<u8>>
 where
 	H: HashSuite,
 	Output<H::LeafHash>: SerializeBytes + DeserializeBytes,
@@ -138,7 +140,7 @@ where
 /// Run the ZK prover and return the raw proof transcript bytes.
 pub fn create_proof_zk<H>(
 	prover: &ZKProver<OptimalPackedB128, H>,
-	witness: ValueVec,
+	witness: &ValueVec,
 	message: Option<&[u8]>,
 ) -> Result<Vec<u8>>
 where
@@ -189,7 +191,7 @@ where
 	let mut verifier_transcript = VerifierTranscript::new(challenger, proof_bytes);
 	match message {
 		Some(message) => {
-			verifier.verify_sig(witness.public(), message, &mut verifier_transcript)?
+			verifier.verify_sig(witness.public(), message, &mut verifier_transcript)?;
 		}
 		None => verifier.verify(witness.public(), &mut verifier_transcript)?,
 	}
@@ -200,31 +202,31 @@ where
 pub fn prove_verify<H>(
 	verifier: &Verifier<H>,
 	prover: &Prover<OptimalPackedB128, H>,
-	witness: ValueVec,
+	witness: &ValueVec,
 ) -> Result<()>
 where
 	H: HashSuite,
 	Output<H::LeafHash>: SerializeBytes + DeserializeBytes,
 {
-	let proof_bytes = create_proof(prover, witness.clone())?;
+	let proof_bytes = create_proof(prover, witness)?;
 	tracing::info!("Proof size: {} KiB", proof_bytes.len() / 1024);
-	check_proof(verifier, &witness, proof_bytes)?;
+	check_proof(verifier, witness, proof_bytes)?;
 	Ok(())
 }
 
 pub fn prove_verify_zk<H>(
 	verifier: &ZKVerifier<H>,
 	prover: &ZKProver<OptimalPackedB128, H>,
-	witness: ValueVec,
+	witness: &ValueVec,
 	message: Option<&[u8]>,
 ) -> Result<()>
 where
 	H: HashSuite,
 	Output<H::LeafHash>: SerializeBytes + DeserializeBytes,
 {
-	let proof_bytes = create_proof_zk(prover, witness.clone(), message)?;
+	let proof_bytes = create_proof_zk(prover, witness, message)?;
 	tracing::info!("Proof size: {} KiB", proof_bytes.len() / 1024);
-	check_proof_zk(verifier, &witness, proof_bytes, message)?;
+	check_proof_zk(verifier, witness, proof_bytes, message)?;
 	Ok(())
 }
 
@@ -303,7 +305,11 @@ pub trait ExampleCircuit: Sized {
 	/// - Process the instance data (e.g., parse inputs, compute hashes)
 	/// - Fill all witness values using the provided filler
 	/// - Validate that instance data is compatible with circuit parameters
-	fn populate_witness(&self, instance: Self::Instance, filler: &mut WitnessFiller) -> Result<()>;
+	fn populate_witness(
+		&self,
+		instance: Self::Instance,
+		filler: &mut WitnessFiller<'_>,
+	) -> Result<()>;
 
 	/// Generate a concise parameter summary for perfetto trace filenames.
 	///

--- a/crates/field/benches/binary_field.rs
+++ b/crates/field/benches/binary_field.rs
@@ -18,7 +18,7 @@ fn bench_function<F: Field, M: Measurement, R>(
 	let a: [F; BATCH_SIZE] = array::from_fn(|_| F::random(&mut rng));
 	let b: [F; BATCH_SIZE] = array::from_fn(|_| F::random(&mut rng));
 	c.bench_function(id, |bench| {
-		bench.iter(|| array::from_fn::<_, BATCH_SIZE, _>(|i| func(a[i], b[i])))
+		bench.iter(|| array::from_fn::<_, BATCH_SIZE, _>(|i| func(a[i], b[i])));
 	});
 }
 

--- a/crates/field/benches/ghash_invert.rs
+++ b/crates/field/benches/ghash_invert.rs
@@ -29,7 +29,7 @@ fn bench_width<P: PackedField>(group: &mut BenchmarkGroup<'_, WallTime>, label: 
 				acc += black_box(x).invert_or_zero();
 			}
 			black_box(acc)
-		})
+		});
 	});
 }
 

--- a/crates/field/benches/ghash_widening.rs
+++ b/crates/field/benches/ghash_widening.rs
@@ -27,7 +27,7 @@ fn bench_at_n<P: PackedField>(group: &mut BenchmarkGroup<'_, WallTime>, label: &
 				acc += black_box(a_vals[i]) * black_box(b_vals[i]);
 			}
 			black_box(acc)
-		})
+		});
 	});
 
 	group.bench_function(format!("wide_mul/{label}/n={n}"), |b| {
@@ -37,7 +37,7 @@ fn bench_at_n<P: PackedField>(group: &mut BenchmarkGroup<'_, WallTime>, label: &
 				acc += P::wide_mul(black_box(a_vals[i]), black_box(b_vals[i]));
 			}
 			black_box(P::reduce(acc))
-		})
+		});
 	});
 }
 

--- a/crates/field/benches/packed_field_element_access.rs
+++ b/crates/field/benches/packed_field_element_access.rs
@@ -38,7 +38,7 @@ fn benchmark_set_impl<P: PackedField>(group: &mut BenchmarkGroup<'_, WallTime>, 
 			}
 
 			value
-		})
+		});
 	});
 }
 

--- a/crates/field/benches/packed_field_init.rs
+++ b/crates/field/benches/packed_field_init.rs
@@ -26,7 +26,7 @@ fn benchmark_get_impl<P: PackedField>(group: &mut BenchmarkGroup<'_, WallTime>, 
 				let values = &values[j];
 				P::from_fn(|i| values[i])
 			})
-		})
+		});
 	});
 }
 

--- a/crates/field/benches/packed_field_slice_iter.rs
+++ b/crates/field/benches/packed_field_slice_iter.rs
@@ -25,7 +25,7 @@ fn benchmark_iter_impl<P: PackedField>(
 
 	if let Some(skip) = skip {
 		group.bench_function(id, |b| {
-			b.iter(|| iter_packed_slice_with_offset(&values, skip * P::WIDTH).sum::<P::Scalar>())
+			b.iter(|| iter_packed_slice_with_offset(&values, skip * P::WIDTH).sum::<P::Scalar>());
 		});
 	} else {
 		group

--- a/crates/field/benches/packed_field_spread.rs
+++ b/crates/field/benches/packed_field_spread.rs
@@ -28,7 +28,7 @@ fn benchmark_get_impl<P: PackedField>(
 			array::from_fn::<_, BATCH_SIZE, _>(|j| {
 				values[j].spread(log_block_len, (j % 1) << (P::LOG_WIDTH - log_block_len))
 			})
-		})
+		});
 	});
 }
 

--- a/crates/field/benches/packed_field_utils.rs
+++ b/crates/field/benches/packed_field_utils.rs
@@ -3,7 +3,7 @@
 use criterion::{BenchmarkGroup, measurement::WallTime};
 
 pub fn run_benchmark<R>(
-	group: &mut BenchmarkGroup<WallTime>,
+	group: &mut BenchmarkGroup<'_, WallTime>,
 	name: &str,
 	func: impl Fn() -> Batch<R>,
 ) {
@@ -22,7 +22,7 @@ macro_rules! benchmark_packed_operation {
 		paste::paste! {
             #[allow(non_snake_case)]
 			#[inline(never)]
-			fn [<$op_name $packed_field $strategy_name>](group: &mut criterion::BenchmarkGroup<criterion::measurement::WallTime>,
+			fn [<$op_name $packed_field $strategy_name>](group: &mut criterion::BenchmarkGroup<'_, criterion::measurement::WallTime>,
                 a: &$crate::packed_field_utils::Batch<$packed_field>,
                 b: &$crate::packed_field_utils::Batch<$packed_field>) {
 				#[allow(unused)]
@@ -60,7 +60,7 @@ macro_rules! benchmark_packed_operation {
 		paste::paste! {
             #[allow(non_snake_case)]
 			#[inline(never)]
-			fn [<$op_name $packed_field $strategy_name>](group: &mut criterion::BenchmarkGroup<criterion::measurement::WallTime>,
+			fn [<$op_name $packed_field $strategy_name>](group: &mut criterion::BenchmarkGroup<'_, criterion::measurement::WallTime>,
                 a: &$crate::packed_field_utils::Batch<$packed_field>,
                 _b: &$crate::packed_field_utils::Batch<$packed_field>) {
 				#[allow(unused)]

--- a/crates/field/src/aes_field.rs
+++ b/crates/field/src/aes_field.rs
@@ -185,7 +185,7 @@ mod tests {
 	proptest! {
 		#[test]
 		fn test_square_8(a in any::<u8>()) {
-			check_square(AESTowerField8b::from(a))
+			check_square(AESTowerField8b::from(a));
 		}
 	}
 
@@ -201,7 +201,7 @@ mod tests {
 	proptest! {
 		#[test]
 		fn test_invert_8(a in any::<u8>()) {
-			check_invert(AESTowerField8b::from(a))
+			check_invert(AESTowerField8b::from(a));
 		}
 	}
 
@@ -239,7 +239,7 @@ mod tests {
 	proptest! {
 		#[test]
 		fn test_mul_8(a in any::<u8>(), b in any::<u8>(), c in any::<u8>()) {
-			check_mul(AESTowerField8b::from(a), AESTowerField8b::from(b), AESTowerField8b::from(c))
+			check_mul(AESTowerField8b::from(a), AESTowerField8b::from(b), AESTowerField8b::from(c));
 		}
 	}
 

--- a/crates/field/src/arch/portable/arithmetic/itoh_tsujii.rs
+++ b/crates/field/src/arch/portable/arithmetic/itoh_tsujii.rs
@@ -172,9 +172,9 @@ mod tests {
 	fn test_compute_power_map_matrix_is_squaring() {
 		// The 2^1 power map is just squaring; column i must equal basis(i)^2.
 		let matrix = compute_power_map_matrix(1);
-		for i in 0..FIELD_BITS {
+		for (i, col) in matrix.iter().enumerate().take(FIELD_BITS) {
 			let basis = <GhashB128 as ExtensionField<BinaryField1b>>::basis(i);
-			assert_eq!(matrix[i], basis.square());
+			assert_eq!(*col, basis.square());
 		}
 	}
 

--- a/crates/field/src/arch/portable/packed.rs
+++ b/crates/field/src/arch/portable/packed.rs
@@ -490,7 +490,7 @@ where
 				&mut self.0,
 				index,
 				val.to_underlier(),
-			)
+			);
 		};
 	}
 

--- a/crates/field/src/arch/portable/univariate_mul_utils_128.rs
+++ b/crates/field/src/arch/portable/univariate_mul_utils_128.rs
@@ -95,12 +95,12 @@ impl Underlier128bLanes for u128 {
 
 	#[inline(always)]
 	fn join_u64s(high: Self::U64, low: Self::U64) -> Self {
-		((high as u128) << 64) | (low as u128)
+		((high as Self) << 64) | (low as Self)
 	}
 
 	#[inline(always)]
 	fn broadcast_64(val: u64) -> Self {
-		val as u128
+		val as Self
 	}
 
 	#[inline(always)]
@@ -142,7 +142,7 @@ pub fn bmul64<U: Underlier64bLanes>(x: U, y: U) -> U {
 
 /// Spread bits of a 64-bit value into a 128-bit value by interleaving zeroes.
 #[inline]
-pub fn spread_bits_64(val: u64) -> u128 {
+pub const fn spread_bits_64(val: u64) -> u128 {
 	let mut x = val as u128;
 	x = (x | (x << 32)) & 0x00000000FFFFFFFF00000000FFFFFFFF;
 	x = (x | (x << 16)) & 0x0000FFFF0000FFFF0000FFFF0000FFFF;

--- a/crates/field/src/arch/x86_64/m128.rs
+++ b/crates/field/src/arch/x86_64/m128.rs
@@ -94,8 +94,8 @@ impl From<M128> for u128 {
 		let mut result = 0u128;
 		unsafe {
 			// Safety: u128 is 16-byte aligned
-			assert_eq!(align_of::<u128>(), 16);
-			_mm_store_si128(&raw mut result as *mut __m128i, value.0)
+			assert_eq!(align_of::<Self>(), 16);
+			_mm_store_si128(&raw mut result as *mut __m128i, value.0);
 		};
 		result
 	}
@@ -160,7 +160,7 @@ impl BitAnd for M128 {
 impl BitAndAssign for M128 {
 	#[inline(always)]
 	fn bitand_assign(&mut self, rhs: Self) {
-		*self = *self & rhs
+		*self = *self & rhs;
 	}
 }
 
@@ -176,7 +176,7 @@ impl BitOr for M128 {
 impl BitOrAssign for M128 {
 	#[inline(always)]
 	fn bitor_assign(&mut self, rhs: Self) {
-		*self = *self | rhs
+		*self = *self | rhs;
 	}
 }
 
@@ -1033,7 +1033,7 @@ mod tests {
 
 		#[test]
 		fn test_negate(a in any::<u128>()) {
-			assert_eq!(M128::from(!a), !M128::from(a))
+			assert_eq!(M128::from(!a), !M128::from(a));
 		}
 
 		#[test]

--- a/crates/field/src/arch/x86_64/m256.rs
+++ b/crates/field/src/arch/x86_64/m256.rs
@@ -213,7 +213,7 @@ impl BitAnd for M256 {
 impl BitAndAssign for M256 {
 	#[inline(always)]
 	fn bitand_assign(&mut self, rhs: Self) {
-		*self = *self & rhs
+		*self = *self & rhs;
 	}
 }
 
@@ -229,7 +229,7 @@ impl BitOr for M256 {
 impl BitOrAssign for M256 {
 	#[inline(always)]
 	fn bitor_assign(&mut self, rhs: Self) {
-		*self = *self | rhs
+		*self = *self | rhs;
 	}
 }
 
@@ -276,7 +276,7 @@ impl Shr<usize> for M256 {
 					high = 0;
 				} else {
 					low = (low >> rhs) + (high << (128usize - rhs));
-					high >>= rhs
+					high >>= rhs;
 				}
 				[low, high].into()
 			}
@@ -299,7 +299,7 @@ impl Shl<usize> for M256 {
 					low = 0;
 				} else {
 					high = (high << rhs) + (low >> (128usize - rhs));
-					low <<= rhs
+					low <<= rhs;
 				}
 				[low, high].into()
 			}
@@ -1438,7 +1438,7 @@ mod tests {
 		#[test]
 		#[allow(clippy::tuple_array_conversions)] // false positive
 		fn test_negate(a in any::<u128>(), b in any::<u128>()) {
-			assert_eq!(M256::from([!a, ! b]), !M256::from([a, b]))
+			assert_eq!(M256::from([!a, ! b]), !M256::from([a, b]));
 		}
 
 		#[test]

--- a/crates/field/src/arch/x86_64/m512.rs
+++ b/crates/field/src/arch/x86_64/m512.rs
@@ -166,7 +166,7 @@ impl BitAnd for M512 {
 impl BitAndAssign for M512 {
 	#[inline(always)]
 	fn bitand_assign(&mut self, rhs: Self) {
-		*self = *self & rhs
+		*self = *self & rhs;
 	}
 }
 
@@ -182,7 +182,7 @@ impl BitOr for M512 {
 impl BitOrAssign for M512 {
 	#[inline(always)]
 	fn bitor_assign(&mut self, rhs: Self) {
-		*self = *self | rhs
+		*self = *self | rhs;
 	}
 }
 
@@ -1369,7 +1369,7 @@ mod tests {
 
 		#[test]
 		fn test_negate(a in any::<[u128; 4]>()) {
-			assert_eq!(M512::from([!a[0], !a[1], !a[2], !a[3]]), !M512::from(a))
+			assert_eq!(M512::from([!a[0], !a[1], !a[2], !a[3]]), !M512::from(a));
 		}
 
 		#[test]

--- a/crates/field/src/binary_field_arithmetic.rs
+++ b/crates/field/src/binary_field_arithmetic.rs
@@ -58,7 +58,7 @@ impl InvertOrZero for BinaryField1b {
 }
 
 #[allow(clippy::suspicious_arithmetic_impl)]
-impl Mul<BinaryField1b> for BinaryField1b {
+impl Mul<Self> for BinaryField1b {
 	type Output = Self;
 
 	#[inline]

--- a/crates/field/src/field.rs
+++ b/crates/field/src/field.rs
@@ -185,6 +185,6 @@ impl<F: Field> FieldOps for F {
 	where
 		F: ExtensionField<FSub>,
 	{
-		<F as ExtensionField<FSub>>::square_transpose(elems)
+		<F as ExtensionField<FSub>>::square_transpose(elems);
 	}
 }

--- a/crates/field/src/ghash.rs
+++ b/crates/field/src/ghash.rs
@@ -121,7 +121,7 @@ impl BinaryField128bGhash {
 // Multiplication is `reduce(wide_mul)`, deferring to the scalar's own `WideMul` impl above (which
 // routes through the optimal `GhashWideMul` packing). This keeps the widening multiply as the
 // single source of truth for both `Mul` and `WideMul`.
-impl Mul<BinaryField128bGhash> for BinaryField128bGhash {
+impl Mul<Self> for BinaryField128bGhash {
 	type Output = Self;
 
 	#[inline]
@@ -432,7 +432,7 @@ impl From<AESTowerField8b> for BinaryField128bGhash {
 			0x71af641f08dbd1a0990483806bffbe0d,
 		];
 
-		BinaryField128bGhash::new(LOOKUP_TABLE[value.0 as usize])
+		Self::new(LOOKUP_TABLE[value.0 as usize])
 	}
 }
 

--- a/crates/field/src/ghash_sq.rs
+++ b/crates/field/src/ghash_sq.rs
@@ -188,7 +188,7 @@ fn square(x: [BinaryField128bGhash; 2]) -> [BinaryField128bGhash; 2] {
 	[t0 + t2.mul_inv_x(), t2]
 }
 
-impl Mul<GhashSq256b> for GhashSq256b {
+impl Mul<Self> for GhashSq256b {
 	type Output = Self;
 
 	#[inline]

--- a/crates/field/src/linear_transformation.rs
+++ b/crates/field/src/linear_transformation.rs
@@ -207,7 +207,7 @@ where
 	Input: Sync,
 	Output: WithUnderlier,
 {
-	pub fn new(inner: Inner) -> Self {
+	pub const fn new(inner: Inner) -> Self {
 		Self {
 			inner,
 			_marker: PhantomData,
@@ -266,7 +266,7 @@ where
 	Input: WithUnderlier,
 	Output: Sync,
 {
-	pub fn new(inner: Inner) -> Self {
+	pub const fn new(inner: Inner) -> Self {
 		Self {
 			inner,
 			_marker: PhantomData,

--- a/crates/field/src/packed.rs
+++ b/crates/field/src/packed.rs
@@ -124,7 +124,7 @@ pub trait PackedField:
 		for i in (0..64).rev() {
 			res = Square::square(res);
 			if ((exp >> i) & 1) == 1 {
-				res.mul_assign(self)
+				res.mul_assign(self);
 			}
 		}
 		res
@@ -280,7 +280,7 @@ pub unsafe fn set_packed_slice_unchecked<P: PackedField>(
 	unsafe {
 		packed
 			.get_unchecked_mut(i >> P::LOG_WIDTH)
-			.set_unchecked(i % P::WIDTH, scalar)
+			.set_unchecked(i % P::WIDTH, scalar);
 	}
 }
 
@@ -329,7 +329,7 @@ pub struct PackedSlice<'a, P: PackedField> {
 
 impl<'a, P: PackedField> PackedSlice<'a, P> {
 	#[inline(always)]
-	pub fn new(slice: &'a [P]) -> Self {
+	pub const fn new(slice: &'a [P]) -> Self {
 		Self {
 			slice,
 			len: len_packed_slice(slice),
@@ -364,7 +364,7 @@ pub struct PackedSliceMut<'a, P: PackedField> {
 
 impl<'a, P: PackedField> PackedSliceMut<'a, P> {
 	#[inline(always)]
-	pub fn new(slice: &'a mut [P]) -> Self {
+	pub const fn new(slice: &'a mut [P]) -> Self {
 		let len = len_packed_slice(slice);
 		Self { slice, len }
 	}

--- a/crates/field/src/packed_binary_field.rs
+++ b/crates/field/src/packed_binary_field.rs
@@ -592,7 +592,7 @@ mod tests {
 
 	fn test_mul_packed_random<P: PackedField>() {
 		let mut rng = StdRng::seed_from_u64(0);
-		test_mul_packed(P::random(&mut rng), P::random(&mut rng))
+		test_mul_packed(P::random(&mut rng), P::random(&mut rng));
 	}
 
 	fn test_set_then_get<P: PackedField>() {
@@ -662,33 +662,33 @@ mod tests {
 	proptest! {
 		#[test]
 		fn test_add_packed_128x1b(a_val in any::<u128>(), b_val in any::<u128>()) {
-			test_add_packed::<PackedBinaryField128x1b>(a_val, b_val)
+			test_add_packed::<PackedBinaryField128x1b>(a_val, b_val);
 		}
 
 		#[test]
 		fn test_add_packed_16x8b(a_val in any::<u128>(), b_val in any::<u128>()) {
-			test_add_packed::<PackedAESBinaryField16x8b>(a_val, b_val)
+			test_add_packed::<PackedAESBinaryField16x8b>(a_val, b_val);
 		}
 
 		#[test]
 		fn test_add_packed_1x128b(a_val in any::<u128>(), b_val in any::<u128>()) {
-			test_add_packed::<PackedBinaryGhash1x128b>(a_val, b_val)
+			test_add_packed::<PackedBinaryGhash1x128b>(a_val, b_val);
 		}
 	}
 
 	#[test]
 	fn test_mul_packed_256x1b() {
-		test_mul_packed_random::<PackedBinaryField256x1b>()
+		test_mul_packed_random::<PackedBinaryField256x1b>();
 	}
 
 	#[test]
 	fn test_mul_packed_32x8b() {
-		test_mul_packed_random::<PackedAESBinaryField32x8b>()
+		test_mul_packed_random::<PackedAESBinaryField32x8b>();
 	}
 
 	#[test]
 	fn test_mul_packed_2x128b() {
-		test_mul_packed_random::<PackedBinaryGhash2x128b>()
+		test_mul_packed_random::<PackedBinaryGhash2x128b>();
 	}
 
 	#[test]

--- a/crates/field/src/packed_extension_ops.rs
+++ b/crates/field/src/packed_extension_ops.rs
@@ -7,7 +7,9 @@ use binius_utils::rayon::prelude::{
 use crate::{ExtensionField, Field, PackedExtension, PackedField};
 
 pub fn ext_base_mul<PE: PackedExtension<F>, F: Field>(lhs: &mut [PE], rhs: &[PE::PackedSubfield]) {
-	ext_base_op(lhs, rhs, |_, lhs, broadcasted_rhs| PE::cast_ext(lhs.cast_base() * broadcasted_rhs))
+	ext_base_op(lhs, rhs, |_, lhs, broadcasted_rhs| {
+		PE::cast_ext(lhs.cast_base() * broadcasted_rhs)
+	});
 }
 
 pub fn ext_base_mul_par<PE: PackedExtension<F>, F: Field>(
@@ -16,7 +18,7 @@ pub fn ext_base_mul_par<PE: PackedExtension<F>, F: Field>(
 ) {
 	ext_base_op_par(lhs, rhs, |_, lhs, broadcasted_rhs| {
 		PE::cast_ext(lhs.cast_base() * broadcasted_rhs)
-	})
+	});
 }
 
 /// # Safety

--- a/crates/field/src/tests.rs
+++ b/crates/field/src/tests.rs
@@ -31,7 +31,7 @@ fn test_field_text_debug() {
 	assert_eq!(
 		format!("{:?}", PackedAESBinaryField16x8b::broadcast(AESTowerField8b::new(123))),
 		"Packed16x8([0x7b,0x7b,0x7b,0x7b,0x7b,0x7b,0x7b,0x7b,0x7b,0x7b,0x7b,0x7b,0x7b,0x7b,0x7b,0x7b])"
-	)
+	);
 }
 
 fn basic_spread<P>(packed: P, log_block_len: usize, block_idx: usize) -> P
@@ -129,13 +129,9 @@ where
 	let mut elems_transposed = elems.clone();
 	<F as FieldOps>::square_transpose::<FSub>(&mut elems_transposed);
 
-	for i in 0..degree {
-		for j in 0..degree {
-			assert_eq!(
-				elems_transposed[i].get_base(j),
-				elems[j].get_base(i),
-				"mismatch at ({i}, {j})"
-			);
+	for (i, transposed) in elems_transposed.iter().enumerate().take(degree) {
+		for (j, elem) in elems.iter().enumerate().take(degree) {
+			assert_eq!(transposed.get_base(j), elem.get_base(i), "mismatch at ({i}, {j})");
 		}
 	}
 }
@@ -160,12 +156,12 @@ where
 	let mut elems_transposed = elems.clone();
 	<P as FieldOps>::square_transpose::<FSub>(&mut elems_transposed);
 
-	for i in 0..degree {
+	for (i, transposed) in elems_transposed.iter().enumerate().take(degree) {
 		for k in 0..P::WIDTH {
-			for j in 0..degree {
+			for (j, elem) in elems.iter().enumerate().take(degree) {
 				assert_eq!(
-					elems_transposed[i].get(k).get_base(j),
-					elems[j].get(k).get_base(i),
+					transposed.get(k).get_base(j),
+					elem.get(k).get_base(i),
 					"mismatch at slice_idx={i}, lane={k}, base={j}"
 				);
 			}

--- a/crates/field/src/transpose.rs
+++ b/crates/field/src/transpose.rs
@@ -56,7 +56,7 @@ pub fn square_transpose<P: PackedField>(log_n: usize, elems: &mut [P]) {
 pub fn square_transforms_extension_field<F: Field, FE: ExtensionField<F> + PackedExtension<F>>(
 	values: &mut [FE],
 ) {
-	square_transpose(FE::LOG_DEGREE, FE::cast_bases_mut(values))
+	square_transpose(FE::LOG_DEGREE, FE::cast_bases_mut(values));
 }
 
 #[cfg(test)]

--- a/crates/field/src/underlier/divisible.rs
+++ b/crates/field/src/underlier/divisible.rs
@@ -316,7 +316,7 @@ pub mod bitmask {
 	///
 	/// The caller must ensure that `index < Big::N` (over `SmallU<BITS>` elements).
 	#[inline]
-	pub unsafe fn get<Big, const BITS: usize>(value: Big, index: usize) -> SmallU<BITS>
+	pub unsafe fn get<Big, const BITS: usize>(value: &Big, index: usize) -> SmallU<BITS>
 	where
 		Big: Divisible<u8>,
 	{
@@ -324,7 +324,7 @@ pub mod bitmask {
 		let byte_index = index / elems_per_byte;
 		let sub_index = index % elems_per_byte;
 		// Safety: `index < Big::N` over `SmallU<BITS>` implies `byte_index < Big::N` over `u8`.
-		let byte = unsafe { Divisible::<u8>::get_unchecked(&value, byte_index) };
+		let byte = unsafe { Divisible::<u8>::get_unchecked(value, byte_index) };
 		let shift = sub_index * BITS;
 		SmallU::<BITS>::new(byte >> shift)
 	}
@@ -619,7 +619,7 @@ macro_rules! impl_divisible_bitmask {
 				#[inline]
 				unsafe fn get_unchecked(&self, index: usize) -> $crate::underlier::SmallU<$bits> {
 					// Safety: the caller guarantees `index < Self::N`.
-					unsafe { $crate::underlier::bitmask::get::<Self, $bits>(*self, index) }
+					unsafe { $crate::underlier::bitmask::get::<Self, $bits>(self, index) }
 				}
 
 				#[inline]
@@ -694,14 +694,14 @@ impl Divisible<SmallU<1>> for SmallU<2> {
 	#[inline]
 	unsafe fn set_unchecked(&mut self, index: usize, val: SmallU<1>) {
 		let mask = 1u8 << index;
-		*self = SmallU::<2>::new((self.val() & !mask) | (val.val() << index));
+		*self = Self::new((self.val() & !mask) | (val.val() << index));
 	}
 
 	#[inline]
 	fn broadcast(val: SmallU<1>) -> Self {
 		// 0b0 -> 0b00, 0b1 -> 0b11
 		let v = val.val();
-		SmallU::<2>::new(v | (v << 1))
+		Self::new(v | (v << 1))
 	}
 
 	#[inline]
@@ -709,7 +709,7 @@ impl Divisible<SmallU<1>> for SmallU<2> {
 		iter.chain(std::iter::repeat(SmallU::<1>::new(0)))
 			.take(2)
 			.enumerate()
-			.fold(SmallU::<2>::new(0), |mut acc, (i, val)| {
+			.fold(Self::new(0), |mut acc, (i, val)| {
 				acc.set(i, val);
 				acc
 			})
@@ -742,7 +742,7 @@ impl Divisible<SmallU<1>> for SmallU<4> {
 	#[inline]
 	unsafe fn set_unchecked(&mut self, index: usize, val: SmallU<1>) {
 		let mask = 1u8 << index;
-		*self = SmallU::<4>::new((self.val() & !mask) | (val.val() << index));
+		*self = Self::new((self.val() & !mask) | (val.val() << index));
 	}
 
 	#[inline]
@@ -751,7 +751,7 @@ impl Divisible<SmallU<1>> for SmallU<4> {
 		let mut v = val.val();
 		v |= v << 1;
 		v |= v << 2;
-		SmallU::<4>::new(v)
+		Self::new(v)
 	}
 
 	#[inline]
@@ -759,7 +759,7 @@ impl Divisible<SmallU<1>> for SmallU<4> {
 		iter.chain(std::iter::repeat(SmallU::<1>::new(0)))
 			.take(4)
 			.enumerate()
-			.fold(SmallU::<4>::new(0), |mut acc, (i, val)| {
+			.fold(Self::new(0), |mut acc, (i, val)| {
 				acc.set(i, val);
 				acc
 			})
@@ -793,14 +793,14 @@ impl Divisible<SmallU<2>> for SmallU<4> {
 	unsafe fn set_unchecked(&mut self, index: usize, val: SmallU<2>) {
 		let shift = index * 2;
 		let mask = 0b11u8 << shift;
-		*self = SmallU::<4>::new((self.val() & !mask) | (val.val() << shift));
+		*self = Self::new((self.val() & !mask) | (val.val() << shift));
 	}
 
 	#[inline]
 	fn broadcast(val: SmallU<2>) -> Self {
 		// 0bXX -> 0bXXXX
 		let v = val.val();
-		SmallU::<4>::new(v | (v << 2))
+		Self::new(v | (v << 2))
 	}
 
 	#[inline]
@@ -808,7 +808,7 @@ impl Divisible<SmallU<2>> for SmallU<4> {
 		iter.chain(std::iter::repeat(SmallU::<2>::new(0)))
 			.take(2)
 			.enumerate()
-			.fold(SmallU::<4>::new(0), |mut acc, (i, val)| {
+			.fold(Self::new(0), |mut acc, (i, val)| {
 				acc.set(i, val);
 				acc
 			})
@@ -980,8 +980,7 @@ mod tests {
 		assert_eq!(Divisible::<U4>::get(&val, 15), U4::new(0x1));
 
 		// Test ref_iter
-		let parts: Vec<U4> = Divisible::<U4>::ref_iter(&val).collect();
-		assert_eq!(parts.len(), 16);
+		assert_eq!(Divisible::<U4>::ref_iter(&val).count(), 16);
 	}
 
 	#[test]

--- a/crates/field/src/underlier/underlier_with_bit_ops.rs
+++ b/crates/field/src/underlier/underlier_with_bit_ops.rs
@@ -64,7 +64,7 @@ pub(crate) fn single_element_mask_bits<T: UnderlierType>(bits_count: usize) -> T
 	} else {
 		let mut result = T::ONE;
 		for height in 0..checked_log_2(bits_count) {
-			result |= result << (1 << height)
+			result |= result << (1 << height);
 		}
 
 		result

--- a/crates/field/src/util.rs
+++ b/crates/field/src/util.rs
@@ -111,8 +111,8 @@ mod tests {
 		let generator = BinaryField128bGhash::MULTIPLICATIVE_GENERATOR;
 		let power_values: Vec<_> = powers(generator).take(10).collect();
 
-		for i in 0..10 {
-			assert_eq!(power_values[i], generator.pow(i as u64));
+		for (i, value) in power_values.iter().enumerate().take(10) {
+			assert_eq!(*value, generator.pow(i as u64));
 		}
 	}
 

--- a/crates/frontend/src/compiler/circuit.rs
+++ b/crates/frontend/src/compiler/circuit.rs
@@ -49,12 +49,12 @@ impl<'a> WitnessFiller<'a> {
 	}
 
 	/// Returns a reference to the underlying value vector.
-	pub fn value_vec(&self) -> &ValueVec {
+	pub const fn value_vec(&self) -> &ValueVec {
 		&self.value_vec
 	}
 
 	/// Returns a mutable reference to the underlying value vector.
-	pub fn value_vec_mut(&mut self) -> &mut ValueVec {
+	pub const fn value_vec_mut(&mut self) -> &mut ValueVec {
 		&mut self.value_vec
 	}
 }
@@ -138,7 +138,7 @@ impl Circuit {
 	/// [`CircuitBuilder::add_constant`]: super::CircuitBuilder::add_constant
 	/// [`CircuitBuilder::add_inout`]: super::CircuitBuilder::add_inout
 	/// [`CircuitBuilder::add_witness`]: super::CircuitBuilder::add_witness
-	pub fn populate_wire_witness(&self, w: &mut WitnessFiller) -> Result<(), PopulateError> {
+	pub fn populate_wire_witness(&self, w: &mut WitnessFiller<'_>) -> Result<(), PopulateError> {
 		// Fill the constant part from the witness.
 		for (index, constant) in self.constraint_system.constants.iter().enumerate() {
 			w.value_vec.set(index, *constant);
@@ -153,12 +153,12 @@ impl Circuit {
 	}
 
 	/// Returns the constraint system for this circuit.
-	pub fn constraint_system(&self) -> &ConstraintSystem {
+	pub const fn constraint_system(&self) -> &ConstraintSystem {
 		&self.constraint_system
 	}
 
 	/// Returns the evaluation form (witness-filling bytecode) for this circuit.
-	pub fn eval_form(&self) -> &EvalForm {
+	pub const fn eval_form(&self) -> &EvalForm {
 		&self.eval_form
 	}
 
@@ -171,7 +171,7 @@ impl Circuit {
 	}
 
 	/// Returns the number of evaluation instructions in this circuit.
-	pub fn n_eval_insn(&self) -> usize {
+	pub const fn n_eval_insn(&self) -> usize {
 		self.eval_form.n_eval_insn()
 	}
 

--- a/crates/frontend/src/compiler/constraint_builder.rs
+++ b/crates/frontend/src/compiler/constraint_builder.rs
@@ -13,7 +13,7 @@ pub struct ConstraintBuilder {
 }
 
 impl ConstraintBuilder {
-	pub fn new() -> Self {
+	pub const fn new() -> Self {
 		Self {
 			and_constraints: Vec::new(),
 			mul_constraints: Vec::new(),
@@ -22,19 +22,19 @@ impl ConstraintBuilder {
 	}
 
 	/// Build an AND constraint: A ' B = C
-	pub fn and(&mut self) -> AndConstraintBuilder<'_> {
+	pub const fn and(&mut self) -> AndConstraintBuilder<'_> {
 		AndConstraintBuilder::new(self)
 	}
 
 	/// Build a MUL constraint: A * B = (HI << 64) | LO
-	pub fn mul(&mut self) -> MulConstraintBuilder<'_> {
+	pub const fn mul(&mut self) -> MulConstraintBuilder<'_> {
 		MulConstraintBuilder::new(self)
 	}
 
 	/// Build a linear constraint: RHS = DST
 	/// (where RHS is XOR of shifted values and DST is a
 	/// single wire)
-	pub fn linear(&mut self) -> LinearConstraintBuilder<'_> {
+	pub const fn linear(&mut self) -> LinearConstraintBuilder<'_> {
 		LinearConstraintBuilder::new(self)
 	}
 
@@ -207,72 +207,72 @@ impl Shift {
 	/// Try to compose two shift operations.
 	///
 	/// Returns None if the shifts are incompatible.
-	pub fn compose(lhs: Shift, rhs: Shift) -> Option<Self> {
+	pub const fn compose(lhs: Self, rhs: Self) -> Option<Self> {
 		match (lhs, rhs) {
-			(Shift::None, shift) | (shift, Shift::None) => Some(shift),
-			(Shift::Sll(a), Shift::Sll(b)) => {
+			(Self::None, shift) | (shift, Self::None) => Some(shift),
+			(Self::Sll(a), Self::Sll(b)) => {
 				// Left shift composition: shl(shl(x, a), b) = shl(x, a + b)
 				let combined = a + b;
 				if combined < 64 {
-					Some(Shift::Sll(combined))
+					Some(Self::Sll(combined))
 				} else {
 					None
 				}
 			}
-			(Shift::Sll32(a), Shift::Sll32(b)) => {
+			(Self::Sll32(a), Self::Sll32(b)) => {
 				// 32-bit half-wise left shift composition
 				let combined = a + b;
 				if combined < 32 {
-					Some(Shift::Sll32(combined))
+					Some(Self::Sll32(combined))
 				} else {
 					None
 				}
 			}
-			(Shift::Srl(a), Shift::Srl(b)) => {
+			(Self::Srl(a), Self::Srl(b)) => {
 				// Logical right shift composition: shr(shr(x, a), b) = shr(x, a + b)
 				let combined = a + b;
 				if combined < 64 {
-					Some(Shift::Srl(combined))
+					Some(Self::Srl(combined))
 				} else {
 					None
 				}
 			}
-			(Shift::Srl32(a), Shift::Srl32(b)) => {
+			(Self::Srl32(a), Self::Srl32(b)) => {
 				// 32-bit half-wise logical right shift composition
 				let combined = a + b;
 				if combined < 32 {
-					Some(Shift::Srl32(combined))
+					Some(Self::Srl32(combined))
 				} else {
 					None
 				}
 			}
-			(Shift::Sar(a), Shift::Sar(b)) => {
+			(Self::Sar(a), Self::Sar(b)) => {
 				// Arithmetic right shift composition
 				let combined = a + b;
 				if combined < 64 {
-					Some(Shift::Sar(combined))
+					Some(Self::Sar(combined))
 				} else {
 					None
 				}
 			}
-			(Shift::Sra32(a), Shift::Sra32(b)) => {
+			(Self::Sra32(a), Self::Sra32(b)) => {
 				// 32-bit half-wise arithmetic right shift composition
 				let combined = a + b;
 				if combined < 32 {
-					Some(Shift::Sra32(combined))
+					Some(Self::Sra32(combined))
 				} else {
 					None
 				}
 			}
-			(Shift::Rotr(a), Shift::Rotr(b)) => {
+			(Self::Rotr(a), Self::Rotr(b)) => {
 				// Rotate right composition: rotr(rotr(x, a), b) = rotr(x, (a + b) % 64)
 				let combined = (a + b) % 64;
-				Some(Shift::Rotr(combined))
+				Some(Self::Rotr(combined))
 			}
-			(Shift::Rotr32(a), Shift::Rotr32(b)) => {
+			(Self::Rotr32(a), Self::Rotr32(b)) => {
 				// 32-bit half-wise rotate right composition
 				let combined = (a + b) % 32;
-				Some(Shift::Rotr32(combined))
+				Some(Self::Rotr32(combined))
 			}
 			_ => None, // Different shift types are not composable
 		}
@@ -355,7 +355,7 @@ pub struct AndConstraintBuilder<'a> {
 }
 
 impl<'a> AndConstraintBuilder<'a> {
-	fn new(builder: &'a mut ConstraintBuilder) -> Self {
+	const fn new(builder: &'a mut ConstraintBuilder) -> Self {
 		Self {
 			builder,
 			a: Vec::new(),
@@ -407,7 +407,7 @@ pub struct LinearConstraintBuilder<'a> {
 }
 
 impl<'a> MulConstraintBuilder<'a> {
-	fn new(builder: &'a mut ConstraintBuilder) -> Self {
+	const fn new(builder: &'a mut ConstraintBuilder) -> Self {
 		Self {
 			builder,
 			a: Vec::new(),
@@ -448,7 +448,7 @@ impl<'a> MulConstraintBuilder<'a> {
 }
 
 impl<'a> LinearConstraintBuilder<'a> {
-	fn new(builder: &'a mut ConstraintBuilder) -> Self {
+	const fn new(builder: &'a mut ConstraintBuilder) -> Self {
 		Self {
 			builder,
 			rhs: Vec::new(),
@@ -463,7 +463,7 @@ impl<'a> LinearConstraintBuilder<'a> {
 	}
 
 	/// Set the DST operand (destination wire)
-	pub fn dst(mut self, wire: Wire) -> Self {
+	pub const fn dst(mut self, wire: Wire) -> Self {
 		self.dst = Some(wire);
 		self
 	}
@@ -513,13 +513,13 @@ impl WireExpr {
 }
 
 impl WireExprTerm {
-	fn to_shifted_wire(self) -> ShiftedWire {
+	const fn to_shifted_wire(self) -> ShiftedWire {
 		match self {
-			WireExprTerm::Wire(w) => ShiftedWire {
+			Self::Wire(w) => ShiftedWire {
 				wire: w,
 				shift: Shift::None,
 			},
-			WireExprTerm::Shifted(w, op) => ShiftedWire {
+			Self::Shifted(w, op) => ShiftedWire {
 				wire: w,
 				shift: match op {
 					ShiftOp::Sll(n) => Shift::Sll(n),
@@ -541,35 +541,35 @@ pub fn wire(w: Wire) -> WireExpr {
 	WireExpr(smallvec![w.into()])
 }
 
-pub fn sll(w: Wire, n: u32) -> WireExprTerm {
+pub const fn sll(w: Wire, n: u32) -> WireExprTerm {
 	WireExprTerm::Shifted(w, ShiftOp::Sll(n))
 }
 
-pub fn sll32(w: Wire, n: u32) -> WireExprTerm {
+pub const fn sll32(w: Wire, n: u32) -> WireExprTerm {
 	WireExprTerm::Shifted(w, ShiftOp::Sll32(n))
 }
 
-pub fn srl(w: Wire, n: u32) -> WireExprTerm {
+pub const fn srl(w: Wire, n: u32) -> WireExprTerm {
 	WireExprTerm::Shifted(w, ShiftOp::Srl(n))
 }
 
-pub fn srl32(w: Wire, n: u32) -> WireExprTerm {
+pub const fn srl32(w: Wire, n: u32) -> WireExprTerm {
 	WireExprTerm::Shifted(w, ShiftOp::Srl32(n))
 }
 
-pub fn sar(w: Wire, n: u32) -> WireExprTerm {
+pub const fn sar(w: Wire, n: u32) -> WireExprTerm {
 	WireExprTerm::Shifted(w, ShiftOp::Sar(n))
 }
 
-pub fn sra32(w: Wire, n: u32) -> WireExprTerm {
+pub const fn sra32(w: Wire, n: u32) -> WireExprTerm {
 	WireExprTerm::Shifted(w, ShiftOp::Sra32(n))
 }
 
-pub fn rotr(w: Wire, n: u32) -> WireExprTerm {
+pub const fn rotr(w: Wire, n: u32) -> WireExprTerm {
 	WireExprTerm::Shifted(w, ShiftOp::Rotr(n))
 }
 
-pub fn rotr32(w: Wire, n: u32) -> WireExprTerm {
+pub const fn rotr32(w: Wire, n: u32) -> WireExprTerm {
 	WireExprTerm::Shifted(w, ShiftOp::Rotr32(n))
 }
 
@@ -613,13 +613,13 @@ impl From<Wire> for WireExpr {
 
 impl From<Wire> for WireExprTerm {
 	fn from(w: Wire) -> Self {
-		WireExprTerm::Wire(w)
+		Self::Wire(w)
 	}
 }
 
 impl From<WireExprTerm> for WireExpr {
 	fn from(expr: WireExprTerm) -> Self {
-		WireExpr(smallvec![expr])
+		Self(smallvec![expr])
 	}
 }
 

--- a/crates/frontend/src/compiler/dump.rs
+++ b/crates/frontend/src/compiler/dump.rs
@@ -16,8 +16,8 @@ struct PathSpecData {
 }
 
 impl PathSpecData {
-	fn new() -> Self {
-		PathSpecData {
+	const fn new() -> Self {
+		Self {
 			name: String::new(),
 			gates: Vec::new(),
 			parent: None,
@@ -35,8 +35,8 @@ struct GateBreakdown {
 }
 
 impl GateBreakdown {
-	fn count(gg: &GateGraph, gates: &[Gate]) -> GateBreakdown {
-		let mut breakdown = GateBreakdown {
+	fn count(gg: &GateGraph, gates: &[Gate]) -> Self {
+		let mut breakdown = Self {
 			by_opcode: BTreeMap::new(),
 		};
 		for gate in gates {
@@ -46,7 +46,7 @@ impl GateBreakdown {
 		breakdown
 	}
 
-	fn merge(mut self, other: &GateBreakdown) -> GateBreakdown {
+	fn merge(mut self, other: &Self) -> Self {
 		for (opcode, count) in &other.by_opcode {
 			*self.by_opcode.entry(opcode.clone()).or_insert(0) += count;
 		}
@@ -60,7 +60,7 @@ struct Cx {
 }
 
 impl Cx {
-	fn new() -> Self {
+	const fn new() -> Self {
 		Self {
 			data: BTreeMap::new(),
 			post_order: Vec::new(),
@@ -213,7 +213,7 @@ impl Cx {
 struct SubcircuitInfo {
 	name: String,
 	n_gates: usize,
-	children: Vec<SubcircuitInfo>,
+	children: Vec<Self>,
 	breakdown: GateBreakdown,
 }
 

--- a/crates/frontend/src/compiler/eval_form/builder.rs
+++ b/crates/frontend/src/compiler/eval_form/builder.rs
@@ -9,7 +9,7 @@ pub struct BytecodeBuilder {
 }
 
 impl BytecodeBuilder {
-	pub fn new() -> Self {
+	pub const fn new() -> Self {
 		Self {
 			bytecode: Vec::new(),
 			n_eval_insn: 0,

--- a/crates/frontend/src/compiler/eval_form/const_eval.rs
+++ b/crates/frontend/src/compiler/eval_form/const_eval.rs
@@ -13,7 +13,7 @@ use crate::compiler::{
 
 /// Creates a wire mapping from gate wires to sequential register indices.
 /// Returns the mapping and the total number of registers used.
-fn create_wire_mapping(gate_param: &GateParam) -> (FxHashMap<Wire, u32>, u32) {
+fn create_wire_mapping(gate_param: &GateParam<'_>) -> (FxHashMap<Wire, u32>, u32) {
 	// Wire ids are small integers, so a fast integer hasher beats the default SipHash here.
 	let mut wire_mapping = FxHashMap::default();
 	let mut wire_index = 0u32;

--- a/crates/frontend/src/compiler/eval_form/interpreter.rs
+++ b/crates/frontend/src/compiler/eval_form/interpreter.rs
@@ -30,7 +30,7 @@ pub struct ExecutionContext<'a> {
 }
 
 impl<'a> ExecutionContext<'a> {
-	pub fn new(value_vec: &'a mut ValueVec) -> Self {
+	pub const fn new(value_vec: &'a mut ValueVec) -> Self {
 		Self {
 			value_vec,
 			assertion_failures: Vec::new(),
@@ -96,7 +96,7 @@ pub struct Interpreter<'a> {
 }
 
 impl<'a> Interpreter<'a> {
-	pub fn new(bytecode: &'a [u8], hints: &'a HintRegistry) -> Self {
+	pub const fn new(bytecode: &'a [u8], hints: &'a HintRegistry) -> Self {
 		Self {
 			bytecode,
 			hints,

--- a/crates/frontend/src/compiler/eval_form/mod.rs
+++ b/crates/frontend/src/compiler/eval_form/mod.rs
@@ -68,7 +68,7 @@ impl EvalForm {
 		}
 
 		let (bytecode, n_eval_insn) = builder.finalize();
-		EvalForm {
+		Self {
 			bytecode,
 			n_eval_insn,
 			hint_registry,
@@ -87,7 +87,7 @@ impl EvalForm {
 	}
 
 	/// Get the number of evaluation instructions
-	pub fn n_eval_insn(&self) -> usize {
+	pub const fn n_eval_insn(&self) -> usize {
 		self.n_eval_insn
 	}
 

--- a/crates/frontend/src/compiler/gate/assert_eq.rs
+++ b/crates/frontend/src/compiler/gate/assert_eq.rs
@@ -21,7 +21,7 @@ use crate::compiler::{
 	pathspec::PathSpec,
 };
 
-pub fn shape() -> OpcodeShape {
+pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
 		const_in: &[Word::ALL_ONE],
 		n_in: 2,

--- a/crates/frontend/src/compiler/gate/assert_eq_cond.rs
+++ b/crates/frontend/src/compiler/gate/assert_eq_cond.rs
@@ -21,7 +21,7 @@ use crate::compiler::{
 	pathspec::PathSpec,
 };
 
-pub fn shape() -> OpcodeShape {
+pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
 		const_in: &[],
 		n_in: 3,

--- a/crates/frontend/src/compiler/gate/assert_false.rs
+++ b/crates/frontend/src/compiler/gate/assert_false.rs
@@ -22,7 +22,7 @@ use crate::compiler::{
 	pathspec::PathSpec,
 };
 
-pub fn shape() -> OpcodeShape {
+pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
 		const_in: &[Word::MSB_ONE],
 		n_in: 1,

--- a/crates/frontend/src/compiler/gate/assert_non_zero.rs
+++ b/crates/frontend/src/compiler/gate/assert_non_zero.rs
@@ -34,7 +34,7 @@ use crate::compiler::{
 	pathspec::PathSpec,
 };
 
-pub fn shape() -> OpcodeShape {
+pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
 		const_in: &[Word::ALL_ONE, Word::ZERO], // Need zero constant for cin
 		n_in: 1,

--- a/crates/frontend/src/compiler/gate/assert_true.rs
+++ b/crates/frontend/src/compiler/gate/assert_true.rs
@@ -22,7 +22,7 @@ use crate::compiler::{
 	pathspec::PathSpec,
 };
 
-pub fn shape() -> OpcodeShape {
+pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
 		const_in: &[Word::MSB_ONE],
 		n_in: 1,

--- a/crates/frontend/src/compiler/gate/assert_zero.rs
+++ b/crates/frontend/src/compiler/gate/assert_zero.rs
@@ -21,7 +21,7 @@ use crate::compiler::{
 	pathspec::PathSpec,
 };
 
-pub fn shape() -> OpcodeShape {
+pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
 		const_in: &[Word::ALL_ONE],
 		n_in: 1,

--- a/crates/frontend/src/compiler/gate/band.rs
+++ b/crates/frontend/src/compiler/gate/band.rs
@@ -18,7 +18,7 @@ use crate::compiler::{
 	gate_graph::{Gate, GateData, GateParam, Wire},
 };
 
-pub fn shape() -> OpcodeShape {
+pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
 		const_in: &[],
 		n_in: 2,

--- a/crates/frontend/src/compiler/gate/bor.rs
+++ b/crates/frontend/src/compiler/gate/bor.rs
@@ -19,7 +19,7 @@ use crate::compiler::{
 	gate_graph::{Gate, GateData, GateParam, Wire},
 };
 
-pub fn shape() -> OpcodeShape {
+pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
 		const_in: &[],
 		n_in: 2,

--- a/crates/frontend/src/compiler/gate/bxor.rs
+++ b/crates/frontend/src/compiler/gate/bxor.rs
@@ -20,7 +20,7 @@ use crate::compiler::{
 	gate_graph::{Gate, GateData, GateParam, Wire},
 };
 
-pub fn shape() -> OpcodeShape {
+pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
 		const_in: &[Word::ALL_ONE],
 		n_in: 2,

--- a/crates/frontend/src/compiler/gate/fax.rs
+++ b/crates/frontend/src/compiler/gate/fax.rs
@@ -19,7 +19,7 @@ use crate::compiler::{
 	gate_graph::{Gate, GateData, GateParam, Wire},
 };
 
-pub fn shape() -> OpcodeShape {
+pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
 		const_in: &[],
 		n_in: 3,

--- a/crates/frontend/src/compiler/gate/iadd.rs
+++ b/crates/frontend/src/compiler/gate/iadd.rs
@@ -23,7 +23,7 @@ use crate::compiler::{
 	gate_graph::{Gate, GateData, GateParam, Wire},
 };
 
-pub fn shape() -> OpcodeShape {
+pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
 		const_in: &[],
 		n_in: 2,

--- a/crates/frontend/src/compiler/gate/iadd32.rs
+++ b/crates/frontend/src/compiler/gate/iadd32.rs
@@ -26,7 +26,7 @@ use crate::compiler::{
 	gate_graph::{Gate, GateData, GateParam, Wire},
 };
 
-pub fn shape() -> OpcodeShape {
+pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
 		const_in: &[],
 		n_in: 2,

--- a/crates/frontend/src/compiler/gate/iadd32_cin_cout.rs
+++ b/crates/frontend/src/compiler/gate/iadd32_cin_cout.rs
@@ -29,7 +29,7 @@ use crate::compiler::{
 	gate_graph::{Gate, GateData, GateParam, Wire},
 };
 
-pub fn shape() -> OpcodeShape {
+pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
 		const_in: &[],
 		n_in: 3,

--- a/crates/frontend/src/compiler/gate/iadd_cin_cout.rs
+++ b/crates/frontend/src/compiler/gate/iadd_cin_cout.rs
@@ -35,7 +35,7 @@ use crate::compiler::{
 	gate_graph::{Gate, GateData, GateParam, Wire},
 };
 
-pub fn shape() -> OpcodeShape {
+pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
 		const_in: &[Word::ALL_ONE],
 		n_in: 3,

--- a/crates/frontend/src/compiler/gate/icmp_eq.rs
+++ b/crates/frontend/src/compiler/gate/icmp_eq.rs
@@ -41,7 +41,7 @@ use crate::compiler::{
 	gate_graph::{Gate, GateData, GateParam, Wire},
 };
 
-pub fn shape() -> OpcodeShape {
+pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
 		const_in: &[Word::ALL_ONE, Word::MSB_ONE, Word::ZERO], // Need zero constant for cin
 		n_in: 2,

--- a/crates/frontend/src/compiler/gate/icmp_ult.rs
+++ b/crates/frontend/src/compiler/gate/icmp_ult.rs
@@ -28,7 +28,7 @@ use crate::compiler::{
 	gate_graph::{Gate, GateData, GateParam, Wire},
 };
 
-pub fn shape() -> OpcodeShape {
+pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
 		const_in: &[Word::ALL_ONE, Word::ZERO], // Need all_one and zero constants
 		n_in: 2,

--- a/crates/frontend/src/compiler/gate/imul.rs
+++ b/crates/frontend/src/compiler/gate/imul.rs
@@ -8,7 +8,7 @@ use crate::compiler::{
 	gate_graph::{Gate, GateData, GateParam, Wire},
 };
 
-pub fn shape() -> OpcodeShape {
+pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
 		const_in: &[],
 		n_in: 2,

--- a/crates/frontend/src/compiler/gate/isub_bin_bout.rs
+++ b/crates/frontend/src/compiler/gate/isub_bin_bout.rs
@@ -7,7 +7,7 @@ use crate::compiler::{
 	gate_graph::{Gate, GateData, GateParam, Wire},
 };
 
-pub fn shape() -> OpcodeShape {
+pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
 		const_in: &[Word::ALL_ONE],
 		n_in: 3,

--- a/crates/frontend/src/compiler/gate/mod.rs
+++ b/crates/frontend/src/compiler/gate/mod.rs
@@ -97,7 +97,7 @@ pub fn emit_gate_bytecode(
 		Opcode::IaddCinCout => iadd_cin_cout::emit_eval_bytecode(gate, data, builder, wire_to_reg),
 		Opcode::Iadd32 => iadd32::emit_eval_bytecode(gate, data, builder, wire_to_reg),
 		Opcode::Iadd32CinCout => {
-			iadd32_cin_cout::emit_eval_bytecode(gate, data, builder, wire_to_reg)
+			iadd32_cin_cout::emit_eval_bytecode(gate, data, builder, wire_to_reg);
 		}
 		Opcode::IsubBinBout => isub_bin_bout::emit_eval_bytecode(gate, data, builder, wire_to_reg),
 		Opcode::Sll32 => sll32::emit_eval_bytecode(gate, data, builder, wire_to_reg),
@@ -107,27 +107,27 @@ pub fn emit_gate_bytecode(
 		Opcode::Rotr => rotr::emit_eval_bytecode(gate, data, builder, wire_to_reg),
 		Opcode::AssertEq => {
 			let assertion_path = graph.assertion_names[gate];
-			assert_eq::emit_eval_bytecode(gate, data, assertion_path, builder, wire_to_reg)
+			assert_eq::emit_eval_bytecode(gate, data, assertion_path, builder, wire_to_reg);
 		}
 		Opcode::AssertZero => {
 			let assertion_path = graph.assertion_names[gate];
-			assert_zero::emit_eval_bytecode(gate, data, assertion_path, builder, wire_to_reg)
+			assert_zero::emit_eval_bytecode(gate, data, assertion_path, builder, wire_to_reg);
 		}
 		Opcode::AssertNonZero => {
 			let assertion_path = graph.assertion_names[gate];
-			assert_non_zero::emit_eval_bytecode(gate, data, assertion_path, builder, wire_to_reg)
+			assert_non_zero::emit_eval_bytecode(gate, data, assertion_path, builder, wire_to_reg);
 		}
 		Opcode::AssertEqCond => {
 			let assertion_path = graph.assertion_names[gate];
-			assert_eq_cond::emit_eval_bytecode(gate, data, assertion_path, builder, wire_to_reg)
+			assert_eq_cond::emit_eval_bytecode(gate, data, assertion_path, builder, wire_to_reg);
 		}
 		Opcode::AssertFalse => {
 			let assertion_path = graph.assertion_names[gate];
-			assert_false::emit_eval_bytecode(gate, data, assertion_path, builder, wire_to_reg)
+			assert_false::emit_eval_bytecode(gate, data, assertion_path, builder, wire_to_reg);
 		}
 		Opcode::AssertTrue => {
 			let assertion_path = graph.assertion_names[gate];
-			assert_true::emit_eval_bytecode(gate, data, assertion_path, builder, wire_to_reg)
+			assert_true::emit_eval_bytecode(gate, data, assertion_path, builder, wire_to_reg);
 		}
 		Opcode::Imul => imul::emit_eval_bytecode(gate, data, builder, wire_to_reg),
 		Opcode::Smul => smul::emit_eval_bytecode(gate, data, builder, wire_to_reg),

--- a/crates/frontend/src/compiler/gate/opcode.rs
+++ b/crates/frontend/src/compiler/gate/opcode.rs
@@ -95,59 +95,59 @@ impl Opcode {
 
 		match self {
 			// Bitwise operations
-			Opcode::Band => gate::band::shape(),
-			Opcode::Bxor => gate::bxor::shape(),
+			Self::Band => gate::band::shape(),
+			Self::Bxor => gate::bxor::shape(),
 			// TODO: Can we get rid of this gate? This is the only non-hint one with dimensions
-			Opcode::BxorMulti => gate::bxor_multi::shape(dimensions),
-			Opcode::Bor => gate::bor::shape(),
-			Opcode::Fax => gate::fax::shape(),
+			Self::BxorMulti => gate::bxor_multi::shape(dimensions),
+			Self::Bor => gate::bor::shape(),
+			Self::Fax => gate::fax::shape(),
 
 			// Selection
-			Opcode::Select => gate::select::shape(),
+			Self::Select => gate::select::shape(),
 
 			// Arithmetic
-			Opcode::Iadd => gate::iadd::shape(),
-			Opcode::IaddCinCout => gate::iadd_cin_cout::shape(),
-			Opcode::Iadd32 => gate::iadd32::shape(),
-			Opcode::Iadd32CinCout => gate::iadd32_cin_cout::shape(),
-			Opcode::IsubBinBout => gate::isub_bin_bout::shape(),
-			Opcode::Imul => gate::imul::shape(),
-			Opcode::Smul => gate::smul::shape(),
+			Self::Iadd => gate::iadd::shape(),
+			Self::IaddCinCout => gate::iadd_cin_cout::shape(),
+			Self::Iadd32 => gate::iadd32::shape(),
+			Self::Iadd32CinCout => gate::iadd32_cin_cout::shape(),
+			Self::IsubBinBout => gate::isub_bin_bout::shape(),
+			Self::Imul => gate::imul::shape(),
+			Self::Smul => gate::smul::shape(),
 
 			// Shifts
-			Opcode::Shr => gate::shr::shape(),
-			Opcode::Shl => gate::shl::shape(),
-			Opcode::Sll32 => gate::sll32::shape(),
-			Opcode::Sar => gate::sar::shape(),
-			Opcode::Srl32 => gate::srl32::shape(),
-			Opcode::Sra32 => gate::sra32::shape(),
-			Opcode::Rotr => gate::rotr::shape(),
-			Opcode::Rotr32 => gate::rotr32::shape(),
+			Self::Shr => gate::shr::shape(),
+			Self::Shl => gate::shl::shape(),
+			Self::Sll32 => gate::sll32::shape(),
+			Self::Sar => gate::sar::shape(),
+			Self::Srl32 => gate::srl32::shape(),
+			Self::Sra32 => gate::sra32::shape(),
+			Self::Rotr => gate::rotr::shape(),
+			Self::Rotr32 => gate::rotr32::shape(),
 
 			// Comparisons
-			Opcode::IcmpUlt => gate::icmp_ult::shape(),
-			Opcode::IcmpEq => gate::icmp_eq::shape(),
+			Self::IcmpUlt => gate::icmp_ult::shape(),
+			Self::IcmpEq => gate::icmp_eq::shape(),
 
 			// Assertions (no outputs)
-			Opcode::AssertEq => gate::assert_eq::shape(),
-			Opcode::AssertZero => gate::assert_zero::shape(),
-			Opcode::AssertNonZero => gate::assert_non_zero::shape(),
-			Opcode::AssertFalse => gate::assert_false::shape(),
-			Opcode::AssertTrue => gate::assert_true::shape(),
-			Opcode::AssertEqCond => gate::assert_eq_cond::shape(),
+			Self::AssertEq => gate::assert_eq::shape(),
+			Self::AssertZero => gate::assert_zero::shape(),
+			Self::AssertNonZero => gate::assert_non_zero::shape(),
+			Self::AssertFalse => gate::assert_false::shape(),
+			Self::AssertTrue => gate::assert_true::shape(),
+			Self::AssertEqCond => gate::assert_eq_cond::shape(),
 
 			// Hints (no constraints)
-			Opcode::Hint => {
+			Self::Hint => {
 				panic!("Opcode::Hint shape requires the HintRegistry; use GateData::shape instead")
 			}
 		}
 	}
 
-	pub fn is_const_shape(&self) -> bool {
+	pub const fn is_const_shape(&self) -> bool {
 		#[allow(clippy::match_like_matches_macro)]
 		match self {
-			Opcode::BxorMulti => false,
-			Opcode::Hint => false,
+			Self::BxorMulti => false,
+			Self::Hint => false,
 			_ => true,
 		}
 	}

--- a/crates/frontend/src/compiler/gate/rotr.rs
+++ b/crates/frontend/src/compiler/gate/rotr.rs
@@ -27,7 +27,7 @@ use crate::compiler::{
 	gate_graph::{Gate, GateData, GateParam, Wire},
 };
 
-pub fn shape() -> OpcodeShape {
+pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
 		const_in: &[Word::ALL_ONE],
 		n_in: 1,

--- a/crates/frontend/src/compiler/gate/rotr32.rs
+++ b/crates/frontend/src/compiler/gate/rotr32.rs
@@ -20,7 +20,7 @@ use crate::compiler::{
 	gate_graph::{Gate, GateData, GateParam, Wire},
 };
 
-pub fn shape() -> OpcodeShape {
+pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
 		const_in: &[],
 		n_in: 1,

--- a/crates/frontend/src/compiler/gate/sar.rs
+++ b/crates/frontend/src/compiler/gate/sar.rs
@@ -21,7 +21,7 @@ use crate::compiler::{
 	gate_graph::{Gate, GateData, GateParam, Wire},
 };
 
-pub fn shape() -> OpcodeShape {
+pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
 		const_in: &[Word::ALL_ONE],
 		n_in: 1,

--- a/crates/frontend/src/compiler/gate/select.rs
+++ b/crates/frontend/src/compiler/gate/select.rs
@@ -23,7 +23,7 @@ use crate::compiler::{
 	gate_graph::{Gate, GateData, GateParam, Wire},
 };
 
-pub fn shape() -> OpcodeShape {
+pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
 		const_in: &[],
 		n_in: 3,

--- a/crates/frontend/src/compiler/gate/shl.rs
+++ b/crates/frontend/src/compiler/gate/shl.rs
@@ -21,7 +21,7 @@ use crate::compiler::{
 	gate_graph::{Gate, GateData, GateParam, Wire},
 };
 
-pub fn shape() -> OpcodeShape {
+pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
 		const_in: &[Word::ALL_ONE],
 		n_in: 1,

--- a/crates/frontend/src/compiler/gate/shr.rs
+++ b/crates/frontend/src/compiler/gate/shr.rs
@@ -21,7 +21,7 @@ use crate::compiler::{
 	gate_graph::{Gate, GateData, GateParam, Wire},
 };
 
-pub fn shape() -> OpcodeShape {
+pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
 		const_in: &[Word::ALL_ONE],
 		n_in: 1,

--- a/crates/frontend/src/compiler/gate/sll32.rs
+++ b/crates/frontend/src/compiler/gate/sll32.rs
@@ -22,7 +22,7 @@ use crate::compiler::{
 	gate_graph::{Gate, GateData, GateParam, Wire},
 };
 
-pub fn shape() -> OpcodeShape {
+pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
 		const_in: &[Word::ALL_ONE],
 		n_in: 1,

--- a/crates/frontend/src/compiler/gate/smul.rs
+++ b/crates/frontend/src/compiler/gate/smul.rs
@@ -54,7 +54,7 @@ fn constrain_modular_addition(
 		.build();
 }
 
-pub fn shape() -> OpcodeShape {
+pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
 		const_in: &[],
 		n_in: 2,

--- a/crates/frontend/src/compiler/gate/sra32.rs
+++ b/crates/frontend/src/compiler/gate/sra32.rs
@@ -22,7 +22,7 @@ use crate::compiler::{
 	gate_graph::{Gate, GateData, GateParam, Wire},
 };
 
-pub fn shape() -> OpcodeShape {
+pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
 		const_in: &[Word::ALL_ONE],
 		n_in: 1,

--- a/crates/frontend/src/compiler/gate/srl32.rs
+++ b/crates/frontend/src/compiler/gate/srl32.rs
@@ -21,7 +21,7 @@ use crate::compiler::{
 	gate_graph::{Gate, GateData, GateParam, Wire},
 };
 
-pub fn shape() -> OpcodeShape {
+pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
 		const_in: &[Word::ALL_ONE],
 		n_in: 1,

--- a/crates/frontend/src/compiler/gate_fusion/commit_set.rs
+++ b/crates/frontend/src/compiler/gate_fusion/commit_set.rs
@@ -35,7 +35,7 @@ impl CommitSetCx {
 	}
 
 	/// Merge multiple contexts into a single one.
-	fn join<'a>(iter: impl Iterator<Item = &'a CommitSetCx>) -> Self {
+	fn join<'a>(iter: impl Iterator<Item = &'a Self>) -> Self {
 		let mut set = Vec::with_capacity(8);
 		let mut depth = 0;
 		for cx in iter {
@@ -48,7 +48,7 @@ impl CommitSetCx {
 	}
 
 	/// Create a new context by adding a new shift and incrementing depth.
-	fn add(&self, out_shift: Shift) -> CommitSetCx {
+	fn add(&self, out_shift: Shift) -> Self {
 		let mut set = self
 			.set
 			.iter()

--- a/crates/frontend/src/compiler/gate_fusion/legraph.rs
+++ b/crates/frontend/src/compiler/gate_fusion/legraph.rs
@@ -76,12 +76,12 @@ pub enum NodeData {
 }
 
 impl NodeData {
-	fn is_root(&self) -> bool {
-		matches!(self, NodeData::Root { .. })
+	const fn is_root(&self) -> bool {
+		matches!(self, Self::Root { .. })
 	}
 
-	fn is_opaque(&self) -> bool {
-		matches!(self, NodeData::Opaque { .. })
+	const fn is_opaque(&self) -> bool {
+		matches!(self, Self::Opaque { .. })
 	}
 }
 
@@ -186,7 +186,7 @@ impl LeGraph {
 	/// Returns the set of wires that must be committed (converted to AND constraints).
 	///
 	/// This is populated only after running the commit_set decision pass.
-	pub fn commit_set(&self) -> &EntitySet<Wire> {
+	pub const fn commit_set(&self) -> &EntitySet<Wire> {
 		&self.lin_committed
 	}
 

--- a/crates/frontend/src/compiler/gate_fusion/patch.rs
+++ b/crates/frontend/src/compiler/gate_fusion/patch.rs
@@ -524,9 +524,9 @@ mod tests {
 		map
 	}
 
-	fn assert_operand_eq(actual: &[ShiftedWire], expected: Vec<ShiftedWire>, ctx: &str) {
+	fn assert_operand_eq(actual: &[ShiftedWire], expected: &[ShiftedWire], ctx: &str) {
 		let am = operand_count_map(actual);
-		let em = operand_count_map(&expected);
+		let em = operand_count_map(expected);
 		assert_eq!(
 			am, em,
 			"operand mismatch for {}\nexpected: {:?}\nactual:   {:?}",
@@ -918,7 +918,7 @@ mod tests {
 		let a = &cb2.mul_constraints[0].a;
 		assert_operand_eq(
 			a,
-			vec![
+			&[
 				ShiftedWire {
 					wire: w(0),
 					shift: Shift::None,
@@ -974,7 +974,7 @@ mod tests {
 		let m = &cb2.mul_constraints[0];
 		assert_operand_eq(
 			&m.a,
-			vec![ShiftedWire {
+			&[ShiftedWire {
 				wire: w(1),
 				shift: Shift::Sll(30),
 			}],
@@ -982,7 +982,7 @@ mod tests {
 		);
 		assert_operand_eq(
 			&m.b,
-			vec![
+			&[
 				ShiftedWire {
 					wire: w(3),
 					shift: Shift::None,
@@ -1025,7 +1025,7 @@ mod tests {
 		let m = &cb2.mul_constraints[0];
 		assert_operand_eq(
 			&m.hi,
-			vec![ShiftedWire {
+			&[ShiftedWire {
 				wire: w(1),
 				shift: Shift::Sll(20),
 			}],
@@ -1033,7 +1033,7 @@ mod tests {
 		);
 		assert_operand_eq(
 			&m.lo,
-			vec![
+			&[
 				ShiftedWire {
 					wire: w(3),
 					shift: Shift::None,

--- a/crates/frontend/src/compiler/gate_fusion/stat.rs
+++ b/crates/frontend/src/compiler/gate_fusion/stat.rs
@@ -30,7 +30,7 @@ impl fmt::Debug for Stat {
 }
 
 impl Stat {
-	pub fn new(cb: &ConstraintBuilder) -> Self {
+	pub const fn new(cb: &ConstraintBuilder) -> Self {
 		Self {
 			pre_linear_def: cb.linear_constraints.len(),
 			pre_and_constraints: cb.and_constraints.len(),
@@ -40,15 +40,15 @@ impl Stat {
 		}
 	}
 
-	pub fn note_committed(&mut self) {
+	pub const fn note_committed(&mut self) {
 		self.committed_linear += 1;
 	}
 
-	pub fn note_visited(&mut self) {
+	pub const fn note_visited(&mut self) {
 		self.legraph_visited += 1;
 	}
 
-	pub fn note_committed_linear_depth(&mut self) {
+	pub const fn note_committed_linear_depth(&mut self) {
 		self.committed_linear_depth += 1;
 	}
 }

--- a/crates/frontend/src/compiler/gate_fusion/tests/awhole.rs
+++ b/crates/frontend/src/compiler/gate_fusion/tests/awhole.rs
@@ -103,7 +103,7 @@ fn mk_circuit_builder() -> CircuitBuilder {
 	CircuitBuilder::with_opts(opts)
 }
 
-fn compile(circuit_builder: CircuitBuilder) -> ConstraintSystem {
+fn compile(circuit_builder: &CircuitBuilder) -> ConstraintSystem {
 	let circuit = circuit_builder.build();
 	circuit.constraint_system().clone()
 }
@@ -123,7 +123,7 @@ fn test_mul_inlining_duplicate_linear_in_mul() {
 
 	let (_hi, _lo) = b.imul(y, y);
 
-	let cs = compile(b);
+	let cs = compile(&b);
 
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"MUL[0]: (v[2] ⊕ v[3]) * (v[2] ⊕ v[3]) = (HI: v[4], LO: v[5])");
 }
@@ -146,7 +146,7 @@ fn test_mul_and_and_shared_linear_uses() {
 	let z = b.add_witness();
 	let (_hi, _lo) = b.imul(y, z);
 
-	let cs = compile(b);
+	let cs = compile(&b);
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @r"
 	AND[0]: (v[2] ⊕ v[3]) ∧ (v[4]) = (v[6])
 	MUL[0]: (v[2] ⊕ v[3]) * (v[5]) = (HI: v[7], LO: v[8])
@@ -175,7 +175,7 @@ fn test_mul_inlining_into_hi_lo() {
 	// We cannot directly modify outputs, but using them later in ANDs will keep them alive
 	// The important check is that MUL constraint references should inline hi_src and lo_src
 
-	let cs = compile(b);
+	let cs = compile(&b);
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @r"
 	AND[0]: (v[2] ⊕ v[3]) ∧ (all-1) = (v[8])
 	AND[1]: (v[4] ⊕ v[5]) ∧ (all-1) = (v[9])
@@ -202,7 +202,7 @@ fn test_mul_inlining_distinct_linears() {
 
 	let (_hi, _lo) = b.imul(y1, y2);
 
-	let cs = compile(b);
+	let cs = compile(&b);
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"MUL[0]: (v[2] ⊕ v[3]) * (v[4]≪3 ⊕ v[5]) = (HI: v[6], LO: v[7])");
 }
 
@@ -213,7 +213,7 @@ fn test_xor_unused_preserved() {
 	let v0 = b.add_constant_64(0xe4);
 	let v1 = b.add_witness();
 	let _v2 = b.bxor(v0, v1);
-	let cs = compile(b);
+	let cs = compile(&b);
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (0xe4 ⊕ v[2]) ∧ (all-1) = (v[3])");
 }
 
@@ -224,7 +224,7 @@ fn test_xor_into_assert() {
 	let v1 = b.add_witness();
 	let v2 = b.bxor(v0, v1);
 	b.assert_zero("derp", v2);
-	let cs = compile(b);
+	let cs = compile(&b);
 	insta::assert_snapshot!(
 		stringify_constraint_system(&cs),
 		@"AND[0]: (0xe4 ⊕ v[2]) ∧ (all-1) = (0)",
@@ -245,7 +245,7 @@ fn test_xor_into_and_single_use() {
 	let v3 = b.add_witness();
 	let _v4 = b.band(v3, v2);
 
-	let cs = compile(b);
+	let cs = compile(&b);
 	insta::assert_snapshot!(
 		stringify_constraint_system(&cs),
 		@"AND[0]: (v[4]) ∧ (v[2] ⊕ v[3]) = (v[5])",
@@ -269,7 +269,7 @@ fn test_xor_used_on_both_sides() {
 	let rhs = b.bxor(v4, v2); // v4 ^ v2
 	let _v6 = b.band(lhs, rhs);
 
-	let cs = compile(b);
+	let cs = compile(&b);
 	// v2 is preserved since it's still referenced after lhs and rhs are inlined
 	// Expected: v[6] (which is v2 = v0^v1) should be fully inlined as (v[2] ⊕ v[3])
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (v[2] ⊕ v[3] ⊕ v[4]) ∧ (v[5] ⊕ v[2] ⊕ v[3]) = (v[6])");
@@ -288,7 +288,7 @@ fn test_shifted_base_into_and() {
 	let v2 = b.add_witness();
 	let _v3 = b.band(v2, v1);
 
-	let cs = compile(b);
+	let cs = compile(&b);
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (v[3]) ∧ (v[2]≪33) = (v[4])");
 }
 
@@ -308,7 +308,7 @@ fn test_mixed_xor_of_shifts_into_and() {
 	let v3 = b.add_witness();
 	let _v4 = b.band(v3, v2);
 
-	let cs = compile(b);
+	let cs = compile(&b);
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (v[4]) ∧ (v[2]≫7 ⊕ v[3]≪3) = (v[5])");
 }
 
@@ -331,7 +331,7 @@ fn test_deep_xor_in_both_a_and_c() {
 	let all_one = b.add_constant_64(u64::MAX);
 	let _v7 = b.band(lhs, all_one);
 
-	let cs = compile(b);
+	let cs = compile(&b);
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (v[2] ⊕ v[3] ⊕ v[4]a≫1 ⊕ v[5]) ∧ (all-1) = (v[6])");
 }
 
@@ -354,7 +354,7 @@ fn test_fuse_across_parens() {
 	let v5 = b.add_witness();
 	let _v6 = b.band(lhs, v5);
 
-	let cs = compile(b);
+	let cs = compile(&b);
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (v[2]≪33 ⊕ v[3] ⊕ v[4] ⊕ v[5]) ∧ (v[6]) = (v[7])");
 }
 
@@ -382,7 +382,7 @@ fn test_multiple_producers_into_one_consumer() {
 	let v4 = b.add_witness();
 	let _v5 = b.band(lhs, v4);
 
-	let cs = compile(b);
+	let cs = compile(&b);
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (v[2] ⊕ v[3] ⊕ v[4]≫5) ∧ (v[5]) = (v[6])");
 }
 
@@ -403,7 +403,7 @@ fn test_xor_producer_used_twice_inside_one_side() {
 	let v4 = b.add_witness();
 	let _v5 = b.band(lhs, v4);
 
-	let cs = compile(b);
+	let cs = compile(&b);
 	// When used twice, the XOR terms should be inlined twice
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (v[2] ⊕ v[3] ⊕ v[2] ⊕ v[3] ⊕ v[4]) ∧ (v[5]) = (v[6])");
 }
@@ -426,7 +426,7 @@ fn test_chain_two_level_fusion() {
 	let v5 = b.add_witness();
 	let _v6 = b.band(v5, v4);
 
-	let cs = compile(b);
+	let cs = compile(&b);
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (v[5]) ∧ (v[2] ⊕ v[3] ⊕ v[4]) = (v[6])");
 }
 
@@ -451,7 +451,7 @@ fn test_chain_with_shifts_inside_producers() {
 	let v5 = b.add_witness();
 	let _v6 = b.band(v5, v4);
 
-	let cs = compile(b);
+	let cs = compile(&b);
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (v[5]) ∧ (v[2]≫2 ⊕ v[3]a≫7 ⊕ v[4]≪11) = (v[6])");
 }
 
@@ -477,7 +477,7 @@ fn test_fuse_into_both_a_and_b() {
 
 	let _v6 = b.band(lhs, rhs);
 
-	let cs = compile(b);
+	let cs = compile(&b);
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (v[2] ⊕ v[3]≫3 ⊕ v[4]) ∧ (v[5] ⊕ v[2] ⊕ v[3]≫3 ⊕ v[6]) = (v[7])");
 }
 
@@ -500,7 +500,7 @@ fn test_xor_feeding_xor_via_all_one() {
 	let all_one = b.add_constant_64(u64::MAX);
 	let _v5 = b.band(lhs, all_one);
 
-	let cs = compile(b);
+	let cs = compile(&b);
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (v[2] ⊕ v[3]≪2 ⊕ v[4] ⊕ v[5]) ∧ (all-1) = (v[6])");
 }
 
@@ -518,7 +518,7 @@ fn test_not_pattern_via_xor_with_all_one() {
 	let v2 = b.add_witness();
 	let _v3 = b.band(v2, v1);
 
-	let cs = compile(b);
+	let cs = compile(&b);
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (v[3]) ∧ (v[2] ⊕ all-1) = (v[4])");
 }
 
@@ -537,7 +537,7 @@ fn test_dont_inline_xor_into_shifted_use() {
 	let v3 = b.add_witness();
 	let _v4 = b.band(v2_sll, v3);
 
-	let cs = compile(b);
+	let cs = compile(&b);
 	// The optimization successfully inlines despite the shift at the use site
 	// This shows gate fusion can handle shifts in the consuming constraint
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (v[2]≪5 ⊕ v[3]≪5) ∧ (v[4]) = (v[5])");
@@ -557,7 +557,7 @@ fn test_dont_inline_shifted_producer_into_shifted_use() {
 	let v2 = b.add_witness();
 	let _v3 = b.band(v1_sll, v2);
 
-	let cs = compile(b);
+	let cs = compile(&b);
 	// Cannot compose different shift types (srl then sll), so it commits the intermediate
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @r"
 	AND[0]: (v[4]≪3) ∧ (v[3]) = (v[5])
@@ -583,7 +583,7 @@ fn test_dont_inline_xor_into_shifted_xor_use() {
 	let v4 = b.add_witness();
 	let _v5 = b.band(lhs, v4);
 
-	let cs = compile(b);
+	let cs = compile(&b);
 	// The optimization can actually compose shifts of the same type (shr)
 	// So it inlines despite the shift at use site
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (v[2]≫9 ⊕ v[3]≫11 ⊕ v[4]) ∧ (v[5]) = (v[6])");
@@ -608,7 +608,7 @@ fn test_mixed_one_unshifted_use_one_shifted_use() {
 	let v5 = b.add_witness();
 	let _v6 = b.band(v2_srl, v5);
 
-	let cs = compile(b);
+	let cs = compile(&b);
 	// The optimization can inline into both uses since shifts distribute over XOR
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @r"
 	AND[0]: (v[4]) ∧ (v[2] ⊕ v[3]) = (v[6])
@@ -632,7 +632,7 @@ fn test_rotr_overflow_to_zero() {
 	let v3 = b.add_witness();
 	let _v4 = b.band(v3, v2);
 
-	let cs = compile(b);
+	let cs = compile(&b);
 	// rotr(v0, 64) should be simplified to v0 (no rotation)
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (v[3]) ∧ (v[2]) = (v[4])");
 }
@@ -653,7 +653,7 @@ fn test_rotr_wrap_around() {
 	let v3 = b.add_witness();
 	let _v4 = b.band(v3, v2);
 
-	let cs = compile(b);
+	let cs = compile(&b);
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (v[3]) ∧ (v[2]≫≫16) = (v[4])");
 }
 
@@ -677,7 +677,7 @@ fn test_rotr_in_xor_overflow() {
 	let v5 = b.add_witness();
 	let _v6 = b.band(v5, v4);
 
-	let cs = compile(b);
+	let cs = compile(&b);
 	// rotr(v0 ^ v1, 64) should be just v0 ^ v1
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (v[4]) ∧ (v[2] ⊕ v[3]) = (v[5])");
 }
@@ -699,7 +699,7 @@ fn test_rotr_chain_with_wrap() {
 	let v4 = b.add_witness();
 	let _v5 = b.band(v4, v3);
 
-	let cs = compile(b);
+	let cs = compile(&b);
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (v[3]) ∧ (v[2]≫≫11) = (v[4])");
 }
 
@@ -720,7 +720,7 @@ fn test_rotr_distributes_over_xor_expanded() {
 	let v4 = b.add_witness();
 	let _v5 = b.band(v4, v3);
 
-	let cs = compile(b);
+	let cs = compile(&b);
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (v[4]) ∧ (v[2]≫≫6 ⊕ v[3]≫≫6) = (v[5])");
 }
 
@@ -770,7 +770,7 @@ fn test_depth_limit_deep_chain() {
 	let w9 = b.add_witness();
 	let _result = b.band(v8, w9);
 
-	let cs = compile(b);
+	let cs = compile(&b);
 
 	// The deep chain should cause intermediate commitments due to depth limit
 	// We expect the optimizer to commit some intermediate value and create multiple AND constraints
@@ -824,7 +824,7 @@ fn test_depth_limit_with_shifts() {
 	let w9 = b.add_witness();
 	let _result = b.band(v8, w9);
 
-	let cs = compile(b);
+	let cs = compile(&b);
 
 	// With shifts in the chain, the depth limit should still apply
 	// The optimizer should handle the complexity and commit when needed

--- a/crates/frontend/src/compiler/gate_graph.rs
+++ b/crates/frontend/src/compiler/gate_graph.rs
@@ -19,7 +19,7 @@ pub struct ConstPool {
 
 impl ConstPool {
 	pub fn new() -> Self {
-		ConstPool::default()
+		Self::default()
 	}
 
 	pub fn get(&self, value: Word) -> Option<Wire> {
@@ -52,8 +52,8 @@ pub enum WireKind {
 }
 impl WireKind {
 	/// Returns `true` if this is a constant wire.
-	pub fn is_const(&self) -> bool {
-		matches!(self, WireKind::Constant(_))
+	pub const fn is_const(&self) -> bool {
+		matches!(self, Self::Constant(_))
 	}
 }
 
@@ -120,16 +120,16 @@ impl GateData {
 	/// and must use [`gate_param_with_registry`](Self::gate_param_with_registry) instead.
 	/// The ~25 per-gate-module callers never see `Opcode::Hint`, so they use this method.
 	pub fn gate_param(&self) -> GateParam<'_> {
-		self.gate_param_for_shape(self.opcode.shape(&self.dimensions))
+		self.gate_param_for_shape(&self.opcode.shape(&self.dimensions))
 	}
 
 	/// Like [`gate_param`](Self::gate_param) but works for [`Opcode::Hint`] gates by looking
 	/// up the shape in the provided registry.
 	pub fn gate_param_with_registry(&self, registry: &HintRegistry) -> GateParam<'_> {
-		self.gate_param_for_shape(self.shape(registry))
+		self.gate_param_for_shape(&self.shape(registry))
 	}
 
-	fn gate_param_for_shape(&self, shape: OpcodeShape) -> GateParam<'_> {
+	fn gate_param_for_shape(&self, shape: &OpcodeShape) -> GateParam<'_> {
 		let start_const = 0;
 		let end_const = shape.const_in.len();
 		let start_input = end_const;

--- a/crates/frontend/src/compiler/hints/big_uint_divide.rs
+++ b/crates/frontend/src/compiler/hints/big_uint_divide.rs
@@ -9,7 +9,7 @@ use crate::util::num_biguint_from_u64_limbs;
 pub struct BigUintDivideHint;
 
 impl BigUintDivideHint {
-	pub fn new() -> Self {
+	pub const fn new() -> Self {
 		Self
 	}
 }
@@ -47,7 +47,7 @@ impl Hint for BigUintDivideHint {
 		let (quotient, remainder) = if divisor != zero {
 			(dividend.clone() / divisor.clone(), dividend % divisor)
 		} else {
-			(zero.clone(), zero.clone())
+			(zero.clone(), zero)
 		};
 
 		// Fill quotient limbs (first part of output)
@@ -57,8 +57,12 @@ impl Hint for BigUintDivideHint {
 			}
 		}
 		// Zero remaining quotient outputs
-		for i in quotient.iter_u64_digits().len()..n_quotient {
-			outputs[i] = Word::ZERO;
+		for word in outputs
+			.iter_mut()
+			.take(n_quotient)
+			.skip(quotient.iter_u64_digits().len())
+		{
+			*word = Word::ZERO;
 		}
 
 		// Fill remainder limbs (second part of output)

--- a/crates/frontend/src/compiler/hints/big_uint_mod_pow.rs
+++ b/crates/frontend/src/compiler/hints/big_uint_mod_pow.rs
@@ -9,7 +9,7 @@ use crate::util::num_biguint_from_u64_limbs;
 pub struct BigUintModPowHint;
 
 impl BigUintModPowHint {
-	pub fn new() -> Self {
+	pub const fn new() -> Self {
 		Self
 	}
 }
@@ -52,8 +52,12 @@ impl Hint for BigUintModPowHint {
 			outputs[i] = Word::from_u64(limb);
 		}
 
-		for i in modpow.iter_u64_digits().len()..*n_modulus_limbs {
-			outputs[i] = Word::ZERO;
+		for word in outputs
+			.iter_mut()
+			.take(*n_modulus_limbs)
+			.skip(modpow.iter_u64_digits().len())
+		{
+			*word = Word::ZERO;
 		}
 	}
 }

--- a/crates/frontend/src/compiler/hints/byte_vec_concat.rs
+++ b/crates/frontend/src/compiler/hints/byte_vec_concat.rs
@@ -13,7 +13,7 @@ use super::Hint;
 pub struct ByteVecConcatHint;
 
 impl ByteVecConcatHint {
-	pub fn new() -> Self {
+	pub const fn new() -> Self {
 		Self
 	}
 }

--- a/crates/frontend/src/compiler/hints/mod.rs
+++ b/crates/frontend/src/compiler/hints/mod.rs
@@ -102,7 +102,7 @@ impl<T: Hint> ErasedHint for T {
 	}
 
 	fn execute(&self, dimensions: &[usize], inputs: &[Word], outputs: &mut [Word]) {
-		<T as Hint>::execute(self, dimensions, inputs, outputs)
+		<T as Hint>::execute(self, dimensions, inputs, outputs);
 	}
 }
 

--- a/crates/frontend/src/compiler/hints/mod_divide.rs
+++ b/crates/frontend/src/compiler/hints/mod_divide.rs
@@ -15,7 +15,7 @@ use crate::util::num_biguint_from_u64_limbs;
 pub struct ModDivideHint;
 
 impl ModDivideHint {
-	pub fn new() -> Self {
+	pub const fn new() -> Self {
 		Self
 	}
 }
@@ -61,7 +61,7 @@ impl Hint for ModDivideHint {
 			let quotient = if numerator >= dividend {
 				(numerator - &dividend) / &modulus
 			} else {
-				zero.clone()
+				zero
 			};
 			(quotient, slope)
 		} else {
@@ -78,8 +78,12 @@ impl Hint for ModDivideHint {
 				quotient_words[i] = Word::from_u64(limb);
 			}
 		}
-		for i in quotient.iter_u64_digits().len()..*n_mod {
-			quotient_words[i] = Word::ZERO;
+		for word in quotient_words
+			.iter_mut()
+			.take(*n_mod)
+			.skip(quotient.iter_u64_digits().len())
+		{
+			*word = Word::ZERO;
 		}
 
 		// Fill slope limbs and zero the remainder.
@@ -88,8 +92,12 @@ impl Hint for ModDivideHint {
 				slope_words[i] = Word::from_u64(limb);
 			}
 		}
-		for i in slope.iter_u64_digits().len()..*n_mod {
-			slope_words[i] = Word::ZERO;
+		for word in slope_words
+			.iter_mut()
+			.take(*n_mod)
+			.skip(slope.iter_u64_digits().len())
+		{
+			*word = Word::ZERO;
 		}
 	}
 }

--- a/crates/frontend/src/compiler/hints/mod_inverse.rs
+++ b/crates/frontend/src/compiler/hints/mod_inverse.rs
@@ -10,7 +10,7 @@ use crate::util::num_biguint_from_u64_limbs;
 pub struct ModInverseHint;
 
 impl ModInverseHint {
-	pub fn new() -> Self {
+	pub const fn new() -> Self {
 		Self
 	}
 }
@@ -43,12 +43,13 @@ impl Hint for ModInverseHint {
 		let modulus = num_biguint_from_u64_limbs(mod_limbs.iter().map(|w| w.as_u64()));
 
 		let zero = num_bigint::BigUint::ZERO;
-		let (quotient, inverse) = if let Some(inverse) = base.modinv(&modulus) {
-			let quotient = (base * &inverse - num_bigint::BigUint::from(1usize)) / &modulus;
-			(quotient, inverse)
-		} else {
-			(zero.clone(), zero)
-		};
+		let (quotient, inverse) = base.modinv(&modulus).map_or_else(
+			|| (zero.clone(), zero),
+			|inverse| {
+				let quotient = (base * &inverse - num_bigint::BigUint::from(1usize)) / &modulus;
+				(quotient, inverse)
+			},
+		);
 
 		assert_eq!(outputs.len(), 2 * *n_mod);
 		let (quotient_words, inverse_words) = outputs.split_at_mut(*n_mod);
@@ -59,8 +60,12 @@ impl Hint for ModInverseHint {
 		}
 
 		// Zero remaining outputs if quotient has fewer limbs
-		for i in quotient.iter_u64_digits().len()..*n_mod {
-			quotient_words[i] = Word::ZERO;
+		for word in quotient_words
+			.iter_mut()
+			.take(*n_mod)
+			.skip(quotient.iter_u64_digits().len())
+		{
+			*word = Word::ZERO;
 		}
 
 		// Fill output inverse limbs
@@ -68,8 +73,12 @@ impl Hint for ModInverseHint {
 			inverse_words[i] = Word::from_u64(limb);
 		}
 		// Zero remaining outputs if inverse has fewer limbs
-		for i in inverse.iter_u64_digits().len()..*n_mod {
-			inverse_words[i] = Word::ZERO;
+		for word in inverse_words
+			.iter_mut()
+			.take(*n_mod)
+			.skip(inverse.iter_u64_digits().len())
+		{
+			*word = Word::ZERO;
 		}
 	}
 }

--- a/crates/frontend/src/compiler/mod.rs
+++ b/crates/frontend/src/compiler/mod.rs
@@ -164,7 +164,7 @@ pub struct CircuitBuilder {
 
 impl Default for CircuitBuilder {
 	fn default() -> Self {
-		CircuitBuilder::new()
+		Self::new()
 	}
 }
 
@@ -179,7 +179,7 @@ impl CircuitBuilder {
 	pub(crate) fn with_opts(opts: Options) -> Self {
 		let graph = GateGraph::new();
 		let root = graph.path_spec_tree.root();
-		CircuitBuilder {
+		Self {
 			current_path: root,
 			shared: Rc::new(RefCell::new(Some(Shared {
 				graph,
@@ -313,12 +313,12 @@ impl CircuitBuilder {
 	///
 	/// Note that this is the same builder instance, but with a different namespace, and that means
 	/// calling [`Self::build`] on the returned builder is going to build the whole circuit.
-	pub fn subcircuit(&self, name: impl Into<String>) -> CircuitBuilder {
+	pub fn subcircuit(&self, name: impl Into<String>) -> Self {
 		let nested_path = self
 			.graph_mut()
 			.path_spec_tree
 			.extend(self.current_path, name);
-		CircuitBuilder {
+		Self {
 			current_path: nested_path,
 			shared: self.shared.clone(),
 		}

--- a/crates/frontend/src/compiler/pathspec.rs
+++ b/crates/frontend/src/compiler/pathspec.rs
@@ -69,7 +69,7 @@ impl PathSpecTree {
 	}
 
 	/// Returns the root of the tree.
-	pub fn root(&self) -> PathSpec {
+	pub const fn root(&self) -> PathSpec {
 		self.root
 	}
 }

--- a/crates/frontend/src/compiler/value_vec_alloc.rs
+++ b/crates/frontend/src/compiler/value_vec_alloc.rs
@@ -22,7 +22,7 @@ pub struct Alloc {
 
 impl Alloc {
 	/// Creates a new [`Alloc`] instance.
-	pub fn new() -> Self {
+	pub const fn new() -> Self {
 		Self {
 			w_const: Vec::new(),
 			w_inout: Vec::new(),

--- a/crates/frontend/src/stat.rs
+++ b/crates/frontend/src/stat.rs
@@ -119,7 +119,7 @@ impl CircuitStat {
 }
 
 impl fmt::Display for CircuitStat {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		// Helper to format numbers with commas
 		fn fmt_num(n: usize) -> String {
 			let s = n.to_string();
@@ -150,7 +150,7 @@ impl fmt::Display for CircuitStat {
 		}
 
 		// Helper to get log2 of a power of 2
-		fn log2(n: usize) -> u32 {
+		const fn log2(n: usize) -> u32 {
 			n.trailing_zeros()
 		}
 

--- a/crates/frontend/src/util.rs
+++ b/crates/frontend/src/util.rs
@@ -17,7 +17,7 @@ use crate::compiler::{CircuitBuilder, Wire, circuit::WitnessFiller};
 ///
 /// # Panics
 /// * If bytes.len() exceeds wires.len() * 8
-pub fn pack_bytes_into_wires_le(w: &mut WitnessFiller, wires: &[Wire], bytes: &[u8]) {
+pub fn pack_bytes_into_wires_le(w: &mut WitnessFiller<'_>, wires: &[Wire], bytes: &[u8]) {
 	let max_value_size = wires.len() * 8;
 	assert!(
 		bytes.len() <= max_value_size,

--- a/crates/hash/src/parallel_compression.rs
+++ b/crates/hash/src/parallel_compression.rs
@@ -57,12 +57,12 @@ pub struct ParallelCompressionAdaptor<C> {
 
 impl<C> ParallelCompressionAdaptor<C> {
 	/// Creates a new adapter wrapping the given compression function.
-	pub fn new(compression: C) -> Self {
+	pub const fn new(compression: C) -> Self {
 		Self { compression }
 	}
 
 	/// Returns a reference to the underlying compression function.
-	pub fn compression(&self) -> &C {
+	pub const fn compression(&self) -> &C {
 		&self.compression
 	}
 }

--- a/crates/hash/src/parallel_digest.rs
+++ b/crates/hash/src/parallel_digest.rs
@@ -143,7 +143,7 @@ impl<D: MultiDigest<N, Digest: Send> + Send + Sync, const N: usize> ParallelDige
 					buf.clear();
 					for item in chunk {
 						item.serialize(&mut buf)
-							.expect("pre-condition: items must serialize without error")
+							.expect("pre-condition: items must serialize without error");
 					}
 				}
 				let data = array::from_fn(|i| buffers[i].as_ref());
@@ -200,7 +200,7 @@ where
 					let mut buffer = HashBuffer::new(hasher);
 					for item in items {
 						item.serialize(&mut buffer)
-							.expect("pre-condition: items must serialize without error")
+							.expect("pre-condition: items must serialize without error");
 					}
 				}
 				out.write(hasher.finalize_reset());
@@ -323,7 +323,7 @@ mod tests {
 	fn check_parallel_digest_consistency<
 		D: ParallelDigest<Digest: BlockSizeUser + Send + Sync + Clone>,
 	>(
-		data: Vec<Vec<u8>>,
+		data: &[Vec<u8>],
 	) {
 		let parallel_digest = D::new();
 		let mut parallel_results = repeat_with(MaybeUninit::<Output<D::Digest>>::uninit)
@@ -341,14 +341,14 @@ mod tests {
 	#[test]
 	fn test_empty_data() {
 		let data = generate_mock_data(0, 16);
-		check_parallel_digest_consistency::<ParallelMultidigestImpl<MockMultiDigest, 4>>(data);
+		check_parallel_digest_consistency::<ParallelMultidigestImpl<MockMultiDigest, 4>>(&data);
 	}
 
 	#[test]
 	fn test_non_empty_data() {
 		for n_hashes in [1, 2, 4, 8, 9] {
 			let data = generate_mock_data(n_hashes, 16);
-			check_parallel_digest_consistency::<ParallelMultidigestImpl<MockMultiDigest, 4>>(data);
+			check_parallel_digest_consistency::<ParallelMultidigestImpl<MockMultiDigest, 4>>(&data);
 		}
 	}
 

--- a/crates/hash/src/serialization.rs
+++ b/crates/hash/src/serialization.rs
@@ -61,7 +61,7 @@ unsafe impl<D: Digest + BlockSizeUser> BufMut for HashBuffer<'_, D> {
 
 impl<D: Digest + BlockSizeUser> Drop for HashBuffer<'_, D> {
 	fn drop(&mut self) {
-		self.flush()
+		self.flush();
 	}
 }
 

--- a/crates/iop-prover/benches/binary_merkle_tree.rs
+++ b/crates/iop-prover/benches/binary_merkle_tree.rs
@@ -42,10 +42,10 @@ where
 			packing_name.as_ref()
 		),
 		|b| {
-			b.iter(|| commit_field_buffer(&merkle_prover, buffer.to_ref(), LOG_ELEMS_IN_LEAF));
+			b.iter(|| commit_field_buffer(&merkle_prover, &buffer.to_ref(), LOG_ELEMS_IN_LEAF));
 		},
 	);
-	group.finish()
+	group.finish();
 }
 
 fn bench_sha256_merkle_tree(c: &mut Criterion) {

--- a/crates/iop-prover/src/basefold.rs
+++ b/crates/iop-prover/src/basefold.rs
@@ -159,8 +159,8 @@ mod test {
 	/// combined FRI path. If `tamper`, the claim is corrupted and verification must fail. (The
 	/// multi-oracle path is exercised end-to-end by the channel tests.)
 	fn run_mlecheck_basefold_zk_prove_and_verify<F, P>(
-		witness: FieldBuffer<P>,
-		evaluation_point: Vec<F>,
+		witness: &FieldBuffer<P>,
+		evaluation_point: &[F],
 		tamper: bool,
 	) -> Result<()>
 	where
@@ -199,7 +199,7 @@ mod test {
 			0,
 			&ntt,
 			&merkle_prover,
-			witness.to_ref(),
+			&witness.to_ref(),
 			&mut commit_rng,
 		);
 
@@ -216,7 +216,7 @@ mod test {
 				*w = extrapolate_line_packed(*w, m, gamma_broadcast);
 			});
 
-		let eval_point_eq = eq_ind_partial_eval::<P>(&evaluation_point);
+		let eval_point_eq = eq_ind_partial_eval::<P>(evaluation_point);
 		let mut eval_claim = inner_product_buffers(&witness_prime, &eval_point_eq);
 		if tamper {
 			eval_claim += F::ONE;
@@ -230,7 +230,7 @@ mod test {
 		);
 		prove_mlecheck_basefold(
 			witness_prime,
-			&evaluation_point,
+			evaluation_point,
 			eval_claim,
 			Some(batch_challenge),
 			&[],
@@ -251,7 +251,7 @@ mod test {
 			merkle_prover.scheme(),
 			&[retrieved_commitment],
 			eval_claim,
-			&evaluation_point,
+			evaluation_point,
 			Some(batch_challenge_v),
 			&[],
 			&mut verifier_transcript,
@@ -273,7 +273,7 @@ mod test {
 		let witness = random_field_buffer::<P>(&mut rng, n_vars);
 		let evaluation_point = random_scalars(&mut rng, n_vars);
 
-		run_mlecheck_basefold_zk_prove_and_verify::<_, P>(witness, evaluation_point, false)
+		run_mlecheck_basefold_zk_prove_and_verify::<_, P>(&witness, &evaluation_point, false)
 			.unwrap();
 	}
 
@@ -287,7 +287,7 @@ mod test {
 		let evaluation_point = random_scalars(&mut rng, n_vars);
 
 		let result =
-			run_mlecheck_basefold_zk_prove_and_verify::<_, P>(witness, evaluation_point, true);
+			run_mlecheck_basefold_zk_prove_and_verify::<_, P>(&witness, &evaluation_point, true);
 		assert!(result.is_err());
 	}
 }

--- a/crates/iop-prover/src/basefold_channel.rs
+++ b/crates/iop-prover/src/basefold_channel.rs
@@ -125,7 +125,7 @@ where
 	}
 
 	/// Returns a reference to the underlying transcript.
-	pub fn transcript(&self) -> &ProverTranscript<Challenger_> {
+	pub const fn transcript(&self) -> &ProverTranscript<Challenger_> {
 		self.transcript
 	}
 
@@ -332,7 +332,7 @@ fn prove_batch_zk_basefold<F, P, NTT, MerkleScheme, MerkleProver_, Challenger_>(
 			.par_chunks_mut(chunk_packed)
 			.for_each(|chunk| {
 				let chunk_buf = FieldSliceMut::from_slice(n_i + log_lift, chunk);
-				accumulate_scaled_buffer(chunk_buf, witness_prime.to_ref(), scalar_broadcast);
+				accumulate_scaled_buffer(chunk_buf, &witness_prime.to_ref(), scalar_broadcast);
 			});
 
 		// Repeat dims contribute 1; only the lift dims contribute an eq-to-zero factor.
@@ -362,8 +362,8 @@ fn prove_batch_zk_basefold<F, P, NTT, MerkleScheme, MerkleProver_, Challenger_>(
 }
 
 fn accumulate_scaled_buffer<P: PackedField>(
-	mut dst: FieldSliceMut<P>,
-	src: FieldSlice<P>,
+	mut dst: FieldSliceMut<'_, P>,
+	src: &FieldSlice<'_, P>,
 	scalar_broadcast: P,
 ) {
 	if src.log_len() >= P::LOG_WIDTH {
@@ -427,7 +427,7 @@ where
 		&self.oracle_specs[self.next_oracle_index..]
 	}
 
-	fn send_oracle(&mut self, buffer: FieldSlice<P>) -> Self::Oracle {
+	fn send_oracle(&mut self, buffer: FieldSlice<'_, P>) -> Self::Oracle {
 		let remaining = self.remaining_oracle_specs();
 		assert!(!remaining.is_empty(), "send_oracle called but no remaining oracle specs");
 
@@ -456,7 +456,7 @@ where
 				index,
 				self.ntt,
 				self.merkle_prover,
-				buffer.to_ref(),
+				&buffer.to_ref(),
 				&mut self.rng,
 			);
 			(commitment, committed, codeword, Some(mask))
@@ -470,7 +470,7 @@ where
 				index,
 				self.ntt,
 				self.merkle_prover,
-				buffer.to_ref(),
+				&buffer.to_ref(),
 			);
 			(commitment, committed, codeword, None)
 		};
@@ -691,8 +691,8 @@ mod tests {
 		let v_oracle_1 = verifier_channel.recv_oracle().unwrap();
 		let v_oracle_2 = verifier_channel.recv_oracle().unwrap();
 
-		let tp1 = transparent_poly_1.clone();
-		let tp2 = transparent_poly_2.clone();
+		let tp1 = transparent_poly_1;
+		let tp2 = transparent_poly_2;
 
 		verifier_channel
 			.verify_oracle_relations([

--- a/crates/iop-prover/src/basefold_compiler.rs
+++ b/crates/iop-prover/src/basefold_compiler.rs
@@ -100,12 +100,12 @@ where
 	}
 
 	/// Returns a reference to the NTT.
-	pub fn ntt(&self) -> &NTT {
+	pub const fn ntt(&self) -> &NTT {
 		&self.ntt
 	}
 
 	/// Returns a reference to the Merkle prover.
-	pub fn merkle_prover(&self) -> &MerkleProver_ {
+	pub const fn merkle_prover(&self) -> &MerkleProver_ {
 		&self.merkle_prover
 	}
 
@@ -115,7 +115,7 @@ where
 	}
 
 	/// Returns a reference to the precomputed combined FRI parameters.
-	pub fn fri_params(&self) -> &FRIParams<F> {
+	pub const fn fri_params(&self) -> &FRIParams<F> {
 		&self.fri_params
 	}
 

--- a/crates/iop-prover/src/channel.rs
+++ b/crates/iop-prover/src/channel.rs
@@ -46,7 +46,7 @@ pub trait IOPProverChannel<P: PackedField>: IPProverChannel<P::Scalar> {
 	///
 	/// * `remaining_oracle_specs()` must be non-empty.
 	/// * `buffer.log_len()` must match the expected length from the next oracle spec.
-	fn send_oracle(&mut self, buffer: FieldSlice<P>) -> Self::Oracle;
+	fn send_oracle(&mut self, buffer: FieldSlice<'_, P>) -> Self::Oracle;
 
 	/// Generates opening proofs for all oracle linear relations.
 	///

--- a/crates/iop-prover/src/fri/commit.rs
+++ b/crates/iop-prover/src/fri/commit.rs
@@ -42,7 +42,7 @@ pub fn commit_interleaved<F, P, NTT, MerkleProver, VCS>(
 	oracle_index: usize,
 	ntt: &NTT,
 	merkle_prover: &MerkleProver,
-	message: FieldSlice<P>,
+	message: &FieldSlice<'_, P>,
 ) -> CommitOutput<P, VCS::Digest, MerkleProver::Committed>
 where
 	F: BinaryField,
@@ -79,11 +79,11 @@ where
 	.entered();
 
 	let encoded = tracing::debug_span!("Reed-Solomon Encode")
-		.in_scope(|| rs_code.encode_batch(ntt, message.to_ref(), log_batch_size));
+		.in_scope(|| rs_code.encode_batch(ntt, &message.to_ref(), log_batch_size));
 
 	let merkle_tree_span = tracing::debug_span!("Merkle Tree").entered();
 	let (commitment, vcs_committed) =
-		merkle_tree::commit_field_buffer(merkle_prover, encoded.to_ref(), log_batch_size);
+		merkle_tree::commit_field_buffer(merkle_prover, &encoded.to_ref(), log_batch_size);
 	drop(merkle_tree_span);
 
 	CommitOutput {
@@ -126,7 +126,7 @@ pub fn commit_masked<F, P, NTT, MerkleProver, VCS>(
 	oracle_index: usize,
 	ntt: &NTT,
 	merkle_prover: &MerkleProver,
-	message: FieldSlice<P>,
+	message: &FieldSlice<'_, P>,
 	mut rng: impl CryptoRng,
 ) -> CommitMaskedOutput<P, VCS::Digest, MerkleProver::Committed>
 where
@@ -172,7 +172,7 @@ where
 		commitment,
 		committed,
 		codeword,
-	} = commit_interleaved(params, oracle_index, ntt, merkle_prover, combined.to_ref());
+	} = commit_interleaved(params, oracle_index, ntt, merkle_prover, &combined.to_ref());
 
 	CommitMaskedOutput {
 		commitment,
@@ -231,7 +231,7 @@ mod tests {
 		let message = random_field_buffer::<P>(&mut rng, log_dim);
 
 		let output: CommitMaskedOutput<P, _, _> =
-			commit_masked(&params, 0, &ntt, &merkle_prover, message.to_ref(), &mut rng);
+			commit_masked(&params, 0, &ntt, &merkle_prover, &message.to_ref(), &mut rng);
 
 		// Verify mask has correct dimensions.
 		assert_eq!(output.mask.log_len(), log_dim);

--- a/crates/iop-prover/src/fri/fold.rs
+++ b/crates/iop-prover/src/fri/fold.rs
@@ -158,12 +158,12 @@ where
 	}
 
 	/// Number of fold rounds, including the final fold.
-	pub fn n_rounds(&self) -> usize {
+	pub const fn n_rounds(&self) -> usize {
 		self.params.n_fold_rounds()
 	}
 
 	/// Number of times `execute_fold_round` has been called.
-	pub fn n_rounds_remaining(&self) -> usize {
+	pub const fn n_rounds_remaining(&self) -> usize {
 		self.n_rounds() - self.curr_round
 	}
 
@@ -235,7 +235,7 @@ where
 				// reduced dimension and rate.
 				let challenges = mem::take(&mut self.unprocessed_challenges);
 				let fri_fold_span = tracing::debug_span!("FRI Fold").entered();
-				let folded_codeword = fold_codeword(self.ntt, last_codeword.to_ref(), &challenges);
+				let folded_codeword = fold_codeword(self.ntt, &last_codeword.to_ref(), &challenges);
 				drop(fri_fold_span);
 				let oracle = FRIOracleProver::new(
 					last_codeword,
@@ -375,7 +375,11 @@ where
 ///
 /// [DP24]: <https://eprint.iacr.org/2024/504>
 #[instrument(skip_all, level = "debug")]
-fn fold_codeword<F, NTT>(ntt: &NTT, codeword: FieldSlice<F>, challenges: &[F]) -> FieldBuffer<F>
+fn fold_codeword<F, NTT>(
+	ntt: &NTT,
+	codeword: &FieldSlice<'_, F>,
+	challenges: &[F],
+) -> FieldBuffer<F>
 where
 	F: BinaryField,
 	NTT: AdditiveNTT<Field = F> + Sync,
@@ -422,11 +426,11 @@ where
 	MTProver: MerkleTreeProver<F>,
 {
 	/// The total interleave batch size, `log_early_batch_size + log_later_batch_size`.
-	fn log_batch_size(&self) -> usize {
+	const fn log_batch_size(&self) -> usize {
 		self.log_early_batch_size + self.log_later_batch_size
 	}
 
-	pub fn log_folded_len(&self) -> usize {
+	pub const fn log_folded_len(&self) -> usize {
 		self.codeword.log_len() - self.log_batch_size()
 	}
 }
@@ -602,7 +606,7 @@ mod tests {
 		ntt.forward_transform(codeword.to_mut(), 0, 0);
 
 		// Fold the encoded message using FRI folding.
-		let folded_codeword = fold_codeword(&ntt, codeword.to_ref(), &challenges);
+		let folded_codeword = fold_codeword(&ntt, &codeword.to_ref(), &challenges);
 
 		// Encode the folded message.
 		ntt.forward_transform(folded_msg.to_mut(), 0, 0);

--- a/crates/iop-prover/src/fri/query.rs
+++ b/crates/iop-prover/src/fri/query.rs
@@ -15,7 +15,7 @@ use crate::merkle_tree::MerkleTreeProver;
 pub trait ProxTestOracleProver<F> {
 	/// Writes the per-oracle batched query openings: the oracle's optimal Merkle layer once,
 	/// followed by each queried coset's values and Merkle opening proof.
-	fn open_queries<B: BufMut>(&self, indices: &[usize], advice: &mut TranscriptWriter<B>);
+	fn open_queries<B: BufMut>(&self, indices: &[usize], advice: &mut TranscriptWriter<'_, B>);
 }
 
 /// The [`ProxTestOracleProver`] for a [Brakedown]-style interleaved code proximity check.
@@ -46,7 +46,7 @@ where
 	/// `log_lift` is the oracle-padding lift factor (the committed codeword is virtually duplicated
 	/// `2^log_lift` times to reach the common first-round length); pass `0` when no lifting is
 	/// needed.
-	pub fn new(
+	pub const fn new(
 		codeword: FieldBuffer<P>,
 		committed: &'a MerkleProver::Committed,
 		merkle_prover: &'a MerkleProver,
@@ -70,7 +70,7 @@ where
 	MerkleProver: MerkleTreeProver<F, Scheme = VCS>,
 	VCS: MerkleTreeScheme<F, Digest: SerializeBytes>,
 {
-	fn open_queries<B: BufMut>(&self, indices: &[usize], advice: &mut TranscriptWriter<B>) {
+	fn open_queries<B: BufMut>(&self, indices: &[usize], advice: &mut TranscriptWriter<'_, B>) {
 		open_oracle_queries(
 			self.merkle_prover,
 			&self.codeword,
@@ -79,7 +79,7 @@ where
 			self.log_lift,
 			indices,
 			advice,
-		)
+		);
 	}
 }
 
@@ -103,7 +103,7 @@ where
 	MerkleProver: MerkleTreeProver<P::Scalar>,
 {
 	/// Constructs a batch oracle prover from the per-commitment oracle provers.
-	pub fn new(oracles: Vec<BrakedownOracleProver<'a, P, MerkleProver>>) -> Self {
+	pub const fn new(oracles: Vec<BrakedownOracleProver<'a, P, MerkleProver>>) -> Self {
 		Self { oracles }
 	}
 }
@@ -116,7 +116,7 @@ where
 	MerkleProver: MerkleTreeProver<F, Scheme = VCS>,
 	VCS: MerkleTreeScheme<F, Digest: SerializeBytes>,
 {
-	fn open_queries<B: BufMut>(&self, indices: &[usize], advice: &mut TranscriptWriter<B>) {
+	fn open_queries<B: BufMut>(&self, indices: &[usize], advice: &mut TranscriptWriter<'_, B>) {
 		for oracle in &self.oracles {
 			oracle.open_queries(indices, advice);
 		}
@@ -141,7 +141,7 @@ where
 	MerkleProver: MerkleTreeProver<F>,
 {
 	/// Constructs a new oracle prover wrapping a committed fold-round codeword.
-	pub fn new(
+	pub const fn new(
 		codeword: FieldBuffer<F>,
 		committed: MerkleProver::Committed,
 		merkle_prover: &'a MerkleProver,
@@ -162,7 +162,7 @@ where
 	MerkleProver: MerkleTreeProver<F, Scheme = VCS>,
 	VCS: MerkleTreeScheme<F, Digest: SerializeBytes>,
 {
-	fn open_queries<B: BufMut>(&self, indices: &[usize], advice: &mut TranscriptWriter<B>) {
+	fn open_queries<B: BufMut>(&self, indices: &[usize], advice: &mut TranscriptWriter<'_, B>) {
 		open_oracle_queries(
 			self.merkle_prover,
 			&self.codeword,
@@ -171,7 +171,7 @@ where
 			0,
 			indices,
 			advice,
-		)
+		);
 	}
 }
 
@@ -187,7 +187,7 @@ fn open_oracle_queries<F, P, MerkleProver, B>(
 	coset_log_size: usize,
 	log_lift: usize,
 	indices: &[usize],
-	advice: &mut TranscriptWriter<B>,
+	advice: &mut TranscriptWriter<'_, B>,
 ) where
 	F: BinaryField,
 	P: PackedField<Scalar = F>,
@@ -203,7 +203,7 @@ fn open_oracle_queries<F, P, MerkleProver, B>(
 	for &index in indices {
 		prove_coset_opening(
 			merkle_prover,
-			codeword.to_ref(),
+			&codeword.to_ref(),
 			committed,
 			index >> log_lift,
 			coset_log_size,
@@ -241,7 +241,7 @@ where
 	/// `codeword_oracle` is the [`BatchBrakedownOracleProver`] for the originally committed
 	/// interleaved codeword(s), and `fri_oracles` holds one [`FRIOracleProver`] per fold arity. The
 	/// terminal codeword is sent in full and therefore is not represented here.
-	pub fn new(
+	pub const fn new(
 		codeword_oracle: BatchBrakedownOracleProver<'a, P, MerkleProver>,
 		fri_oracles: Vec<FRIOracleProver<'a, F, MerkleProver>>,
 	) -> Self {
@@ -252,7 +252,7 @@ where
 	}
 
 	/// Number of oracles sent during the fold rounds.
-	pub fn n_oracles(&self) -> usize {
+	pub const fn n_oracles(&self) -> usize {
 		1 + self.fri_oracles.len()
 	}
 
@@ -267,7 +267,7 @@ where
 	///
 	/// * `indices` - the sampled query indices into the original codeword domain
 	#[instrument(skip_all, name = "fri::FRIQueryProver::prove_queries", level = "debug")]
-	pub fn prove_queries<B>(&self, indices: &[usize], advice: &mut TranscriptWriter<B>)
+	pub fn prove_queries<B>(&self, indices: &[usize], advice: &mut TranscriptWriter<'_, B>)
 	where
 		B: BufMut,
 		VCS::Digest: SerializeBytes,
@@ -288,12 +288,12 @@ where
 
 fn prove_coset_opening<F, P, MTProver, B>(
 	merkle_prover: &MTProver,
-	codeword: FieldSlice<P>,
+	codeword: &FieldSlice<'_, P>,
 	committed: &MTProver::Committed,
 	coset_index: usize,
 	log_coset_size: usize,
 	optimal_layer_depth: usize,
-	advice: &mut TranscriptWriter<B>,
+	advice: &mut TranscriptWriter<'_, B>,
 ) where
 	F: BinaryField,
 	P: PackedField<Scalar = F>,

--- a/crates/iop-prover/src/fri/tests.rs
+++ b/crates/iop-prover/src/fri/tests.rs
@@ -59,7 +59,7 @@ fn test_commit_prove_verify_success<F, P>(
 		commitment: mut codeword_commitment,
 		committed: codeword_committed,
 		codeword,
-	} = commit_interleaved(&params, 0, &ntt, &merkle_prover, msg.to_ref());
+	} = commit_interleaved(&params, 0, &ntt, &merkle_prover, &msg.to_ref());
 
 	// Run the prover to generate the proximity proof
 	let mut round_prover =
@@ -267,7 +267,7 @@ fn test_commit_prove_verify_batched_multi_oracle() {
 			commitment,
 			committed,
 			codeword,
-		} = commit_interleaved(&oracle_params, 0, &ntt, &merkle_prover, msg.to_ref());
+		} = commit_interleaved(&oracle_params, 0, &ntt, &merkle_prover, &msg.to_ref());
 		messages.push(msg);
 		commitments.push(commitment);
 		committeds.push(committed);
@@ -413,7 +413,7 @@ fn test_commit_prove_verify_batched_mixed_skip() {
 			commitment,
 			committed,
 			codeword,
-		} = commit_interleaved(&oracle_params, 0, &ntt, &merkle_prover, msg.to_ref());
+		} = commit_interleaved(&oracle_params, 0, &ntt, &merkle_prover, &msg.to_ref());
 		messages.push(msg);
 		commitments.push(commitment);
 		committeds.push(committed);
@@ -586,7 +586,7 @@ fn test_commit_prove_verify_lifted_multi_oracle() {
 			commitment,
 			committed,
 			codeword,
-		} = commit_interleaved(&oracle_params, 0, &ntt, &merkle_prover, msg.to_ref());
+		} = commit_interleaved(&oracle_params, 0, &ntt, &merkle_prover, &msg.to_ref());
 		messages.push(msg);
 		commitments.push(commitment);
 		committeds.push(committed);
@@ -719,7 +719,7 @@ where
 		commitment: codeword_commitment,
 		committed: codeword_committed,
 		codeword,
-	} = commit_interleaved(&params, 0, &ntt, &merkle_prover, msg.to_ref());
+	} = commit_interleaved(&params, 0, &ntt, &merkle_prover, &msg.to_ref());
 
 	let mut round_prover =
 		FRIFoldProver::new(&params, &ntt, &merkle_prover, codeword, &codeword_committed);

--- a/crates/iop-prover/src/merkle_tree/mod.rs
+++ b/crates/iop-prover/src/merkle_tree/mod.rs
@@ -89,7 +89,7 @@ pub trait MerkleTreeProver<T: FixedSizeSerializeBytes> {
 		committed: &Self::Committed,
 		layer_depth: usize,
 		index: usize,
-		proof: &mut TranscriptWriter<B>,
+		proof: &mut TranscriptWriter<'_, B>,
 	);
 }
 
@@ -106,7 +106,7 @@ pub trait MerkleTreeProver<T: FixedSizeSerializeBytes> {
 #[allow(clippy::type_complexity)]
 pub fn commit_field_buffer<F, P, MerkleProver>(
 	merkle_prover: &MerkleProver,
-	buffer: FieldSlice<P>,
+	buffer: &FieldSlice<'_, P>,
 	log_batch_size: usize,
 ) -> (
 	Commitment<<MerkleProver::Scheme as MerkleTreeScheme<F>>::Digest>,

--- a/crates/iop-prover/src/merkle_tree/prover.rs
+++ b/crates/iop-prover/src/merkle_tree/prover.rs
@@ -67,7 +67,7 @@ where
 		committed: &Self::Committed,
 		layer_depth: usize,
 		index: usize,
-		proof: &mut TranscriptWriter<B>,
+		proof: &mut TranscriptWriter<'_, B>,
 	) {
 		let salt = committed.get_salt(index >> layer_depth);
 		proof.write_slice(salt);

--- a/crates/iop-prover/src/naive_channel.rs
+++ b/crates/iop-prover/src/naive_channel.rs
@@ -60,7 +60,7 @@ where
 	///
 	/// * `transcript` - The prover transcript for Fiat-Shamir (borrowed mutably)
 	/// * `oracle_specs` - Specifications for each oracle to be committed
-	pub fn new(
+	pub const fn new(
 		transcript: &'a mut ProverTranscript<Challenger_>,
 		oracle_specs: Vec<OracleSpec>,
 	) -> Self {
@@ -74,7 +74,7 @@ where
 	}
 
 	/// Returns a reference to the underlying transcript.
-	pub fn transcript(&self) -> &ProverTranscript<Challenger_> {
+	pub const fn transcript(&self) -> &ProverTranscript<Challenger_> {
 		self.transcript
 	}
 
@@ -123,7 +123,7 @@ where
 		&self.oracle_specs[self.next_oracle_index..]
 	}
 
-	fn send_oracle(&mut self, buffer: FieldSlice<P>) -> Self::Oracle {
+	fn send_oracle(&mut self, buffer: FieldSlice<'_, P>) -> Self::Oracle {
 		let index = self.next_oracle_index;
 		assert!(
 			index < self.oracle_specs.len(),

--- a/crates/iop/src/basefold.rs
+++ b/crates/iop/src/basefold.rs
@@ -118,7 +118,7 @@ where
 		let alpha = eval_point[n_vars - 1 - round];
 		let round_coeffs = round_proof.recover(sum, alpha);
 		let challenge = transcript.sample();
-		sum = round_coeffs.evaluate(challenge);
+		sum = round_coeffs.evaluate(&challenge);
 		challenges.push(challenge);
 	}
 
@@ -178,8 +178,8 @@ pub enum VerificationError {
 impl From<fri::Error> for Error {
 	fn from(err: fri::Error) -> Self {
 		match err {
-			fri::Error::Verification(err) => Error::Verification(err.into()),
-			_ => Error::FRI(err),
+			fri::Error::Verification(err) => Self::Verification(err.into()),
+			_ => Self::FRI(err),
 		}
 	}
 }

--- a/crates/iop/src/basefold_channel.rs
+++ b/crates/iop/src/basefold_channel.rs
@@ -75,7 +75,7 @@ where
 	///
 	/// The FRI parameters should already account for ZK (log_batch_size = 1, doubled message
 	/// length).
-	pub fn from_precomputed(
+	pub const fn from_precomputed(
 		transcript: &'a mut VerifierTranscript<Challenger_>,
 		merkle_scheme: &'a MerkleScheme_,
 		oracle_specs: &'a [OracleSpec],
@@ -93,7 +93,7 @@ where
 	}
 
 	/// Returns a reference to the underlying transcript.
-	pub fn transcript(&self) -> &VerifierTranscript<Challenger_> {
+	pub const fn transcript(&self) -> &VerifierTranscript<Challenger_> {
 		self.transcript
 	}
 
@@ -130,7 +130,7 @@ where
 			merkle_scheme,
 			oracle_specs,
 			fri_params,
-			oracle_commitments,
+			&oracle_commitments,
 			queue,
 		)
 	}
@@ -162,7 +162,7 @@ fn verify_batch_zk_basefold<F, MerkleScheme_, Challenger_>(
 	merkle_scheme: &MerkleScheme_,
 	oracle_specs: &[OracleSpec],
 	fri_params: &FRIParams<F>,
-	oracle_commitments: Vec<MerkleScheme_::Digest>,
+	oracle_commitments: &[MerkleScheme_::Digest],
 	relations: Vec<OracleLinearRelation<'_, BaseFoldOracle, F>>,
 ) -> Result<(), Error>
 where
@@ -231,7 +231,7 @@ where
 			alpha_i * transparent_eval * pad_eq
 		})
 		.collect::<Vec<_>>();
-	let expected = evaluate_univariate(&contributions, sumcheck_batch_coeff);
+	let expected = evaluate_univariate(&contributions, &sumcheck_batch_coeff);
 	channel.assert_zero(sumcheck_reduced_eval - expected)?;
 
 	// === Phase B: single combined-FRI MLE-check over the piecewise-concatenated oracle ===
@@ -260,7 +260,7 @@ where
 	} = basefold::verify_mlecheck_basefold(
 		fri_params,
 		merkle_scheme,
-		&oracle_commitments,
+		oracle_commitments,
 		s_prime,
 		&point,
 		gamma,

--- a/crates/iop/src/basefold_compiler.rs
+++ b/crates/iop/src/basefold_compiler.rs
@@ -95,12 +95,12 @@ where
 	}
 
 	/// Returns a reference to the precomputed combined FRI parameters.
-	pub fn fri_params(&self) -> &FRIParams<F> {
+	pub const fn fri_params(&self) -> &FRIParams<F> {
 		&self.fri_params
 	}
 
 	/// Returns a reference to the Merkle scheme.
-	pub fn merkle_scheme(&self) -> &MerkleScheme_ {
+	pub const fn merkle_scheme(&self) -> &MerkleScheme_ {
 		&self.merkle_scheme
 	}
 

--- a/crates/iop/src/channel.rs
+++ b/crates/iop/src/channel.rs
@@ -46,7 +46,7 @@ pub struct OracleSpec {
 
 impl OracleSpec {
 	/// A non-ZK (unmasked) oracle of the given message length.
-	pub fn new(log_msg_len: usize) -> Self {
+	pub const fn new(log_msg_len: usize) -> Self {
 		Self {
 			log_msg_len,
 			is_zk: false,
@@ -54,7 +54,7 @@ impl OracleSpec {
 	}
 
 	/// A ZK (masked, hiding) oracle of the given message length.
-	pub fn new_zk(log_msg_len: usize) -> Self {
+	pub const fn new_zk(log_msg_len: usize) -> Self {
 		Self {
 			log_msg_len,
 			is_zk: true,

--- a/crates/iop/src/fri/batch.rs
+++ b/crates/iop/src/fri/batch.rs
@@ -36,7 +36,7 @@ pub trait ProxTestOracle<F: BinaryField> {
 	fn open_queries<B: Buf>(
 		&self,
 		indices: &[usize],
-		advice: &mut TranscriptReader<B>,
+		advice: &mut TranscriptReader<'_, B>,
 	) -> Result<Vec<F>, Error>;
 }
 
@@ -63,7 +63,7 @@ impl<F: BinaryField, MTScheme: MerkleTreeScheme<F>> BrakedownOracle<F, MTScheme>
 	/// `log_lift` is the oracle-padding lift factor (the committed codeword is virtually duplicated
 	/// `2^log_lift` times to reach the common first-round length); pass `0` when no lifting is
 	/// needed.
-	pub fn new(
+	pub const fn new(
 		challenges: Vec<F>,
 		commitment: Commitment<MTScheme::Digest>,
 		merkle_scheme: MTScheme,
@@ -90,7 +90,7 @@ impl<F: BinaryField, MTScheme: MerkleTreeScheme<F, Digest: DeserializeBytes>> Pr
 	fn open_queries<B: Buf>(
 		&self,
 		indices: &[usize],
-		advice: &mut TranscriptReader<B>,
+		advice: &mut TranscriptReader<'_, B>,
 	) -> Result<Vec<F>, Error> {
 		assert!(indices.iter().all(|&index| index < 1 << self.log_len())); // precondition
 		// Translate each query on the virtual lifted oracle into a query on the committed codeword
@@ -160,7 +160,7 @@ impl<F: BinaryField, MTScheme: MerkleTreeScheme<F, Digest: DeserializeBytes>> Pr
 	fn open_queries<B: Buf>(
 		&self,
 		indices: &[usize],
-		advice: &mut TranscriptReader<B>,
+		advice: &mut TranscriptReader<'_, B>,
 	) -> Result<Vec<F>, Error> {
 		// Read each bundled oracle's openings in commit order (matching the prover), then combine
 		// across oracles by the outer-challenge tensor expansion:
@@ -202,7 +202,7 @@ where
 {
 	/// Constructs a new oracle from a committed oracle, its folding challenges, and the domain
 	/// context providing the FRI fold twiddles.
-	pub fn new(
+	pub const fn new(
 		challenges: Vec<F>,
 		commitment: Commitment<MTScheme::Digest>,
 		merkle_scheme: MTScheme,
@@ -217,7 +217,7 @@ where
 	}
 
 	/// The base-2 log of the size of each coset opened from the committed oracle.
-	fn coset_log_size(&self) -> usize {
+	const fn coset_log_size(&self) -> usize {
 		self.challenges.len()
 	}
 
@@ -302,7 +302,7 @@ where
 		&self,
 		indices: &[usize],
 		claims: &[F],
-		advice: &mut TranscriptReader<B>,
+		advice: &mut TranscriptReader<'_, B>,
 	) -> Result<Vec<F>, Error> {
 		assert_eq!(indices.len(), claims.len()); // precondition
 		assert!(
@@ -351,7 +351,7 @@ where
 	fn open_queries<B: Buf>(
 		&self,
 		indices: &[usize],
-		advice: &mut TranscriptReader<B>,
+		advice: &mut TranscriptReader<'_, B>,
 	) -> Result<Vec<F>, Error> {
 		assert!(indices.iter().all(|&index| index < 1 << self.log_len())); // precondition
 		verify_query_openings(
@@ -380,7 +380,7 @@ fn verify_query_openings<'a, F, MTScheme, B>(
 	commitment: &'a Commitment<MTScheme::Digest>,
 	coset_log_size: usize,
 	indices: &'a [usize],
-	advice: &'a mut TranscriptReader<B>,
+	advice: &'a mut TranscriptReader<'_, B>,
 ) -> Result<impl Iterator<Item = Result<(usize, Vec<F>), Error>> + 'a, Error>
 where
 	F: BinaryField,

--- a/crates/iop/src/fri/common.rs
+++ b/crates/iop/src/fri/common.rs
@@ -84,7 +84,7 @@ pub struct CodewordSpec {
 
 impl CodewordSpec {
 	/// log2 the interleaved batch size: the early plus the later batch challenges.
-	pub fn log_batch_size(&self) -> usize {
+	pub const fn log_batch_size(&self) -> usize {
 		self.log_early_batch_size + self.log_later_batch_size
 	}
 }
@@ -272,23 +272,23 @@ where
 	///
 	/// This is the largest input message length, plus `log_n_oracles` extra rounds that fold the
 	/// distinct input oracles together into the batched codeword.
-	pub fn n_fold_rounds(&self) -> usize {
+	pub const fn n_fold_rounds(&self) -> usize {
 		self.max_log_msg_len + self.log_n_oracles
 	}
 
 	/// Number of oracles sent during the fold rounds.
-	pub fn n_oracles(&self) -> usize {
+	pub const fn n_oracles(&self) -> usize {
 		// One for the batched codeword commitment, and one for each subsequent one.
 		1 + self.fold_arities.len()
 	}
 
 	/// Number of bits in the query indices sampled during the query phase.
-	pub fn index_bits(&self) -> usize {
+	pub const fn index_bits(&self) -> usize {
 		self.rs_code.log_len()
 	}
 
 	/// Number of folding challenges the verifier sends after receiving the last oracle.
-	pub fn n_final_challenges(&self) -> usize {
+	pub const fn n_final_challenges(&self) -> usize {
 		self.log_terminal_dim
 	}
 
@@ -316,7 +316,7 @@ where
 	///
 	/// This includes the `log_n_oracles` extra rounds used to fold the distinct input oracles
 	/// together, so it equals [`Self::n_fold_rounds`].
-	pub fn log_msg_len(&self) -> usize {
+	pub const fn log_msg_len(&self) -> usize {
 		self.max_log_msg_len + self.log_n_oracles
 	}
 }
@@ -334,8 +334,23 @@ where
 	MerkleScheme: MerkleTreeScheme<F>,
 	Strategy: AritySelectionStrategy,
 {
-	match log_batch_size {
-		Some(log_batch_size) => {
+	log_batch_size.map_or_else(
+		|| {
+			let mut fold_arities = strategy.choose_arities::<F, _>(
+				merkle_scheme,
+				log_msg_len,
+				log_inv_rate,
+				n_test_queries,
+			);
+			let log_batch_size = if fold_arities.is_empty() {
+				// Edge case: fold to log_dim = 0 code.
+				log_msg_len
+			} else {
+				fold_arities.remove(0)
+			};
+			(log_batch_size, fold_arities)
+		},
+		|log_batch_size| {
 			assert!(log_batch_size <= log_msg_len); // precondition
 			let fold_arities = strategy.choose_arities::<F, _>(
 				merkle_scheme,
@@ -344,23 +359,8 @@ where
 				n_test_queries,
 			);
 			(log_batch_size, fold_arities)
-		}
-		None => {
-			let mut fold_arities = strategy.choose_arities::<F, _>(
-				merkle_scheme,
-				log_msg_len,
-				log_inv_rate,
-				n_test_queries,
-			);
-			let log_batch_size = if !fold_arities.is_empty() {
-				fold_arities.remove(0)
-			} else {
-				// Edge case: fold to log_dim = 0 code.
-				log_msg_len
-			};
-			(log_batch_size, fold_arities)
-		}
-	}
+		},
+	)
 }
 
 struct ChooseBatchSizeAndAritiesOutput {
@@ -591,7 +591,7 @@ where
 	F: Field,
 	MTScheme: MerkleTreeScheme<F>,
 {
-	fn new(merkle_scheme: &'a MTScheme, n_test_queries: usize) -> Self {
+	const fn new(merkle_scheme: &'a MTScheme, n_test_queries: usize) -> Self {
 		Self {
 			merkle_scheme,
 			n_test_queries,
@@ -743,7 +743,7 @@ pub struct ConstantArityStrategy {
 
 impl ConstantArityStrategy {
 	/// Creates a new strategy with the given arity.
-	pub fn new(arity: usize) -> Self {
+	pub const fn new(arity: usize) -> Self {
 		Self { arity }
 	}
 

--- a/crates/iop/src/fri/fold.rs
+++ b/crates/iop/src/fri/fold.rs
@@ -88,7 +88,7 @@ where
 				(chunk_index << (log_size - 1)) | index_offset,
 				pair,
 				challenge,
-			)
+			);
 		}
 
 		log_len -= 1;
@@ -186,7 +186,7 @@ where
 	/// * `Ok(None)` if no commitment was needed in this round
 	pub fn process_round<B: Buf>(
 		&mut self,
-		transcript: &mut TranscriptReader<B>,
+		transcript: &mut TranscriptReader<'_, B>,
 	) -> Result<Option<Digest>, Error> {
 		assert!(
 			self.curr_round < self.n_rounds(),
@@ -212,7 +212,7 @@ where
 	}
 
 	/// Returns true if all rounds have been processed.
-	pub fn is_complete(&self) -> bool {
+	pub const fn is_complete(&self) -> bool {
 		self.curr_round == self.n_rounds()
 	}
 
@@ -235,12 +235,12 @@ where
 	}
 
 	/// Returns the current round number.
-	pub fn current_round(&self) -> usize {
+	pub const fn current_round(&self) -> usize {
 		self.curr_round
 	}
 
 	/// Returns the total number of rounds.
-	pub fn n_rounds(&self) -> usize {
+	pub const fn n_rounds(&self) -> usize {
 		self.commit_rounds.len()
 	}
 }

--- a/crates/iop/src/fri/verify.rs
+++ b/crates/iop/src/fri/verify.rs
@@ -201,7 +201,7 @@ where
 	}
 
 	/// Number of oracles sent during the fold rounds.
-	pub fn n_oracles(&self) -> usize {
+	pub const fn n_oracles(&self) -> usize {
 		self.params.n_oracles()
 	}
 
@@ -254,7 +254,7 @@ where
 		&self,
 		claims: &[F],
 		indices: &[usize],
-		advice: &mut TranscriptReader<B>,
+		advice: &mut TranscriptReader<'_, B>,
 	) -> Result<F, Error> {
 		let n_final_challenges = self.params.n_final_challenges();
 		let log_inv_rate = self.params.rs_code().log_inv_rate();

--- a/crates/iop/src/merkle_tree/merkle_tree_vcs.rs
+++ b/crates/iop/src/merkle_tree/merkle_tree_vcs.rs
@@ -51,7 +51,7 @@ pub trait MerkleTreeScheme<T: FixedSizeSerializeBytes> {
 		root: &Self::Digest,
 		data: &[T],
 		batch_size: usize,
-		proof: &mut TranscriptReader<B>,
+		proof: &mut TranscriptReader<'_, B>,
 	) -> Result<(), Error>;
 
 	/// Verify a given layer of the Merkle tree.
@@ -83,6 +83,6 @@ pub trait MerkleTreeScheme<T: FixedSizeSerializeBytes> {
 		layer_depth: usize,
 		tree_depth: usize,
 		layer_digests: &[Self::Digest],
-		proof: &mut TranscriptReader<B>,
+		proof: &mut TranscriptReader<'_, B>,
 	) -> Result<(), Error>;
 }

--- a/crates/iop/src/merkle_tree/scheme.rs
+++ b/crates/iop/src/merkle_tree/scheme.rs
@@ -56,7 +56,7 @@ where
 	fn compute_leaf_digest<B: Buf>(
 		&self,
 		values: &[T],
-		proof: &mut TranscriptReader<B>,
+		proof: &mut TranscriptReader<'_, B>,
 	) -> Result<Output<H::LeafHash>, Error> {
 		let salt = proof.read_vec::<T>(self.salt_len)?;
 		hash_serialize::<T, H::LeafHash>(values.iter().chain(&salt)).map_err(Error::Serialization)
@@ -94,7 +94,7 @@ where
 		root: &Self::Digest,
 		data: &[T],
 		batch_size: usize,
-		proof: &mut TranscriptReader<B>,
+		proof: &mut TranscriptReader<'_, B>,
 	) -> Result<(), Error> {
 		assert!(
 			data.len().is_multiple_of(batch_size),
@@ -138,7 +138,7 @@ where
 		layer_depth: usize,
 		tree_depth: usize,
 		layer_digests: &[Self::Digest],
-		proof: &mut TranscriptReader<B>,
+		proof: &mut TranscriptReader<'_, B>,
 	) -> Result<(), Error> {
 		assert_eq!(
 			layer_digests.len(),

--- a/crates/iop/src/naive_channel.rs
+++ b/crates/iop/src/naive_channel.rs
@@ -60,7 +60,7 @@ where
 	///
 	/// * `transcript` - The verifier transcript for Fiat-Shamir (borrowed mutably)
 	/// * `oracle_specs` - Specifications for each oracle to be received (borrowed)
-	pub fn new(
+	pub const fn new(
 		transcript: &'a mut VerifierTranscript<Challenger_>,
 		oracle_specs: &'a [OracleSpec],
 	) -> Self {
@@ -73,7 +73,7 @@ where
 	}
 
 	/// Returns a reference to the underlying transcript.
-	pub fn transcript(&self) -> &VerifierTranscript<Challenger_> {
+	pub const fn transcript(&self) -> &VerifierTranscript<Challenger_> {
 		self.transcript
 	}
 

--- a/crates/iop/src/size_tracking_channel.rs
+++ b/crates/iop/src/size_tracking_channel.rs
@@ -41,7 +41,7 @@ impl<'a, F: BinaryField, MerkleScheme_: MerkleTreeScheme<F>>
 	SizeTrackingChannel<'a, F, MerkleScheme_>
 {
 	/// Creates a new size-tracking channel with default element (16) and oracle (32) sizes.
-	pub fn new(
+	pub const fn new(
 		oracle_specs: Vec<OracleSpec>,
 		fri_params: &'a [FRIParams<F>],
 		merkle_scheme: &'a MerkleScheme_,
@@ -56,7 +56,7 @@ impl<'a, F: BinaryField, MerkleScheme_: MerkleTreeScheme<F>>
 	}
 
 	/// Creates a new size-tracking channel with custom element and oracle sizes.
-	pub fn with_sizes(
+	pub const fn with_sizes(
 		oracle_specs: Vec<OracleSpec>,
 		fri_params: &'a [FRIParams<F>],
 		merkle_scheme: &'a MerkleScheme_,
@@ -75,7 +75,7 @@ impl<'a, F: BinaryField, MerkleScheme_: MerkleTreeScheme<F>>
 	}
 
 	/// Returns the accumulated proof size in bytes.
-	pub fn proof_size(&self) -> usize {
+	pub const fn proof_size(&self) -> usize {
 		self.proof_size
 	}
 }

--- a/crates/ip-prover/src/fracaddcheck.rs
+++ b/crates/ip-prover/src/fracaddcheck.rs
@@ -88,7 +88,7 @@ where
 	}
 
 	/// Returns the number of remaining layers to prove.
-	pub fn n_layers(&self) -> usize {
+	pub const fn n_layers(&self) -> usize {
 		self.layers.len()
 	}
 
@@ -124,7 +124,7 @@ where
 		let den_1 = FieldBuffer::new(den_1.log_len(), den_1.as_ref().into());
 		let prover = frac_add_mle::new(
 			[num_0, num_1, den_0, den_1],
-			num_claim.point.clone(),
+			&num_claim.point,
 			[num_claim.eval, den_claim.eval],
 		)?;
 
@@ -236,9 +236,7 @@ mod tests {
 
 		// 5. Run prover
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
-		let prover_output = prover
-			.prove(prover_claim.clone(), &mut prover_transcript)
-			.unwrap();
+		let prover_output = prover.prove(prover_claim, &mut prover_transcript).unwrap();
 
 		// 6. Run verifier
 		let mut verifier_transcript = prover_transcript.into_verifier();

--- a/crates/ip-prover/src/prodcheck.rs
+++ b/crates/ip-prover/src/prodcheck.rs
@@ -79,7 +79,7 @@ where
 	}
 
 	/// Returns the number of remaining layers to prove.
-	pub fn n_layers(&self) -> usize {
+	pub const fn n_layers(&self) -> usize {
 		self.layers.len()
 	}
 
@@ -101,7 +101,8 @@ where
 			Some(self)
 		};
 
-		let prover = bivariate_product_mle::new(split, claim.point, claim.eval)?;
+		let MultilinearEvalClaim { point, eval } = claim;
+		let prover = bivariate_product_mle::new(split, &point, eval)?;
 
 		Ok((prover, remaining))
 	}
@@ -215,7 +216,7 @@ pub fn batch_prove<F: Field, P: PackedField<Scalar = F>>(
 	let (_, claimed_products, eval_point) = (0..n_layers).try_fold(
 		(provers, claimed_products, eval_point),
 		|(provers, claimed_products, eval_point), _| {
-			batch_prove_layer(provers, claimed_products, eval_point, k, channel)
+			batch_prove_layer(provers, claimed_products, &eval_point, k, channel)
 		},
 	)?;
 
@@ -233,7 +234,7 @@ pub fn batch_prove<F: Field, P: PackedField<Scalar = F>>(
 fn batch_prove_layer<F: Field, P: PackedField<Scalar = F>>(
 	provers: Vec<ProdcheckProver<P>>,
 	claimed_products: Vec<F>,
-	eval_point: Vec<F>,
+	eval_point: &[F],
 	k: usize,
 	channel: &mut impl IPProverChannel<F>,
 ) -> Result<(Vec<ProdcheckProver<P>>, Vec<F>, Vec<F>), Error> {
@@ -312,8 +313,7 @@ fn batch_prove_layer<F: Field, P: PackedField<Scalar = F>>(
 	let buffer_0 = FieldBuffer::<P>::from_values(&vals_0);
 	let buffer_1 = FieldBuffer::<P>::from_values(&vals_1);
 
-	let outer_prover =
-		bivariate_product_mle::new([buffer_0, buffer_1], outer_coords.to_vec(), eval)?;
+	let outer_prover = bivariate_product_mle::new([buffer_0, buffer_1], outer_coords, eval)?;
 
 	let ProveSingleOutput {
 		multilinear_evals: outer_evals,
@@ -453,13 +453,10 @@ mod tests {
 			.collect();
 
 		// Create ProdcheckProver for each
-		let provers_and_products: Vec<(ProdcheckProver<P>, FieldBuffer<P>)> = witnesses
+		let (provers, individual_products): (Vec<_>, Vec<_>) = witnesses
 			.iter()
 			.map(|witness| ProdcheckProver::new(n_layers, witness.clone()))
-			.collect();
-
-		let (provers, individual_products): (Vec<_>, Vec<_>) =
-			provers_and_products.into_iter().unzip();
+			.unzip();
 
 		// Products are 0-variate (scalars): just get the single value
 		let claimed_products: Vec<P::Scalar> = individual_products
@@ -488,13 +485,9 @@ mod tests {
 
 		// Run batch_prove
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
-		let prover_output = batch_prove(
-			provers,
-			claimed_products,
-			selector_challenge.clone(),
-			&mut prover_transcript,
-		)
-		.unwrap();
+		let prover_output =
+			batch_prove(provers, claimed_products, selector_challenge, &mut prover_transcript)
+				.unwrap();
 
 		// Run verifier with n_layers layers
 		let mut verifier_transcript = prover_transcript.into_verifier();

--- a/crates/ip-prover/src/sumcheck/batch.rs
+++ b/crates/ip-prover/src/sumcheck/batch.rs
@@ -299,13 +299,13 @@ mod tests {
 
 		let prover_0 = bivariate_product_mle::new(
 			[multilinear_a_0.clone(), multilinear_b_0.clone()],
-			eval_point.clone(),
+			&eval_point,
 			eval_claim_0,
 		)
 		.unwrap();
 		let prover_1 = bivariate_product_mle::new(
 			[multilinear_a_1.clone(), multilinear_b_1.clone()],
-			eval_point.clone(),
+			&eval_point,
 			eval_claim_1,
 		)
 		.unwrap();
@@ -353,7 +353,7 @@ mod tests {
 
 		let composed_evals = vec![eval_a_0 * eval_b_0, eval_a_1 * eval_b_1];
 		let expected_batched_eval =
-			evaluate_univariate(&composed_evals, sumcheck_output.batch_coeff);
+			evaluate_univariate(&composed_evals, &sumcheck_output.batch_coeff);
 
 		assert_eq!(
 			expected_batched_eval, sumcheck_output.eval,
@@ -390,13 +390,13 @@ mod tests {
 
 		let prover_0 = bivariate_product_mle::new(
 			[multilinear_a_0, multilinear_b_0],
-			eval_point,
+			&eval_point,
 			eval_claim_0,
 		)
 		.unwrap();
 		let prover_1 = bivariate_product_mle::new(
 			[multilinear_a_1, multilinear_b_1],
-			other_point,
+			&other_point,
 			eval_claim_1,
 		)
 		.unwrap();
@@ -429,13 +429,13 @@ mod tests {
 
 		let prover_0 = bivariate_product_mle::new(
 			[multilinear_a_0, multilinear_b_0],
-			eval_point_a,
+			&eval_point_a,
 			eval_claim_0,
 		)
 		.unwrap();
 		let prover_1 = bivariate_product_mle::new(
 			[multilinear_a_1, multilinear_b_1],
-			eval_point_b,
+			&eval_point_b,
 			eval_claim_1,
 		)
 		.unwrap();

--- a/crates/ip-prover/src/sumcheck/batch_quadratic_mle.rs
+++ b/crates/ip-prover/src/sumcheck/batch_quadratic_mle.rs
@@ -54,7 +54,7 @@ where
 		mut multilinears: impl AsSlicesMut<P, N> + Send + 'static,
 		composition: Composition,
 		infinity_composition: InfinityComposition,
-		eval_point: Vec<F>,
+		eval_point: &[F],
 		eval_claims: [F; M],
 	) -> Result<Self, Error> {
 		let n_vars = eval_point.len();
@@ -69,7 +69,7 @@ where
 		// The first execute round consumes the claimed composite evaluations at eval_point.
 		let last_coeffs_or_eval = RoundCoeffsOrEvals::Evals(eval_claims);
 		// Gruen32 owns the eq-indicator expansion tied to eval_point and drives per-round folding.
-		let gruen32 = Gruen32::new(&eval_point);
+		let gruen32 = Gruen32::new(eval_point);
 
 		Ok(Self {
 			multilinears: Box::new(multilinears),
@@ -273,7 +273,7 @@ where
 		// Evaluate each round polynomial at the verifier's challenge to form the next sum claim.
 		let evals = prime_coeffs
 			.iter()
-			.map(|coeffs| coeffs.evaluate(challenge))
+			.map(|coeffs| coeffs.evaluate(&challenge))
 			.collect_array()
 			.expect("Will have size M");
 
@@ -425,7 +425,7 @@ mod tests {
 				multilinears.clone(),
 				comp_0::<P> as CompFn<P>,
 				inf_comp_0::<P> as CompFn<P>,
-				eval_point.clone(),
+				&eval_point,
 				eval_claims[0],
 			)
 			.unwrap(),
@@ -433,17 +433,17 @@ mod tests {
 				multilinears.clone(),
 				comp_1::<P> as CompFn<P>,
 				inf_comp_1::<P> as CompFn<P>,
-				eval_point.clone(),
+				&eval_point,
 				eval_claims[1],
 			)
 			.unwrap(),
 		];
 
 		let mut batch_prover = BatchQuadraticMleCheckProver::new(
-			multilinears.clone(),
+			multilinears,
 			batch_comp::<P>,
 			batch_inf_comp::<P>,
-			eval_point,
+			&eval_point,
 			eval_claims,
 		)
 		.unwrap();
@@ -492,7 +492,7 @@ mod tests {
 			multilinears.clone(),
 			batch_comp::<P>,
 			batch_inf_comp::<P>,
-			eval_point.clone(),
+			&eval_point,
 			eval_claims,
 		)
 		.unwrap();
@@ -535,7 +535,7 @@ mod tests {
 						.sum::<P>();
 
 					let eval = packed_eval.iter().take(1 << n_vars_remaining).sum::<F>();
-					assert_eq!(eval, round_coeffs.evaluate(sample));
+					assert_eq!(eval, round_coeffs.evaluate(&sample));
 				}
 			}
 

--- a/crates/ip-prover/src/sumcheck/bivariate_product.rs
+++ b/crates/ip-prover/src/sumcheck/bivariate_product.rs
@@ -103,7 +103,7 @@ impl<F: Field, P: PackedField<Scalar = F>> SumcheckProver<F> for BivariateProduc
 			fold_highest_var_inplace(multilin, challenge);
 		}
 
-		let round_sum = last_coeffs.evaluate(challenge);
+		let round_sum = last_coeffs.evaluate(&challenge);
 		self.last_coeffs_or_sum = RoundCoeffsOrSum::Sum(round_sum);
 		Ok(())
 	}

--- a/crates/ip-prover/src/sumcheck/bivariate_product_mle.rs
+++ b/crates/ip-prover/src/sumcheck/bivariate_product_mle.rs
@@ -49,14 +49,15 @@ use crate::sumcheck::common::MleCheckProver;
 /// Note 2: evaluation points are 0 (implicit), 1 and Karatsuba infinity.
 ///
 /// [Gruen24]: <https://eprint.iacr.org/2024/108>
-pub fn new<F, P>(
-	multilinears: impl AsSlicesMut<P, 2> + Send + 'static,
-	eval_point: Vec<F>,
+pub fn new<F, P, M>(
+	multilinears: M,
+	eval_point: &[F],
 	eval_claim: F,
-) -> Result<impl MleCheckProver<F>, Error>
+) -> Result<impl MleCheckProver<F> + use<F, P, M>, Error>
 where
 	F: Field,
 	P: PackedField<Scalar = F>,
+	M: AsSlicesMut<P, 2> + Send + 'static,
 {
 	QuadraticMleCheckProver::new(
 		multilinears,
@@ -89,8 +90,8 @@ mod tests {
 		prover: impl MleCheckProver<F>,
 		eval_claim: F,
 		eval_point: &[F],
-		multilinear_a: FieldBuffer<P>,
-		multilinear_b: FieldBuffer<P>,
+		multilinear_a: &FieldBuffer<P>,
+		multilinear_b: &FieldBuffer<P>,
 	) where
 		F: Field,
 		P: PackedField<Scalar = F>,
@@ -130,8 +131,8 @@ mod tests {
 		// Check that the original multilinears evaluate to the claimed values at the challenge
 		// point The prover binds variables from high to low, but evaluate expects them from low
 		// to high
-		let eval_a = evaluate(&multilinear_a, &reduced_eval_point);
-		let eval_b = evaluate(&multilinear_b, &reduced_eval_point);
+		let eval_a = evaluate(multilinear_a, &reduced_eval_point);
+		let eval_b = evaluate(multilinear_b, &reduced_eval_point);
 
 		assert_eq!(
 			eval_a, multilinear_evals[0],
@@ -153,8 +154,8 @@ mod tests {
 		mlecheck_prover: impl MleCheckProver<F>,
 		eval_claim: F,
 		eval_point: &[F],
-		multilinear_a: FieldBuffer<P>,
-		multilinear_b: FieldBuffer<P>,
+		multilinear_a: &FieldBuffer<P>,
+		multilinear_b: &FieldBuffer<P>,
 	) where
 		F: Field,
 		P: PackedField<Scalar = F>,
@@ -201,8 +202,8 @@ mod tests {
 
 		// Check that the original multilinears evaluate to the claimed values at the challenge
 		// point
-		let eval_a = evaluate(&multilinear_a, &reduced_eval_point);
-		let eval_b = evaluate(&multilinear_b, &reduced_eval_point);
+		let eval_a = evaluate(multilinear_a, &reduced_eval_point);
+		let eval_b = evaluate(multilinear_b, &reduced_eval_point);
 
 		assert_eq!(
 			eval_a, multilinear_evals[0],
@@ -243,28 +244,26 @@ mod tests {
 
 		// Create the prover
 		let mlecheck_prover =
-			new([multilinear_a.clone(), multilinear_b.clone()], eval_point.clone(), eval_claim)
-				.unwrap();
+			new([multilinear_a.clone(), multilinear_b.clone()], &eval_point, eval_claim).unwrap();
 
 		test_mlecheck_prove_verify(
 			mlecheck_prover,
 			eval_claim,
 			&eval_point,
-			multilinear_a.clone(),
-			multilinear_b.clone(),
+			&multilinear_a,
+			&multilinear_b,
 		);
 
 		// Create another prover for the wrapped test
 		let mlecheck_prover =
-			new([multilinear_a.clone(), multilinear_b.clone()], eval_point.clone(), eval_claim)
-				.unwrap();
+			new([multilinear_a.clone(), multilinear_b.clone()], &eval_point, eval_claim).unwrap();
 
 		test_wrapped_sumcheck_prove_verify(
 			mlecheck_prover,
 			eval_claim,
 			&eval_point,
-			multilinear_a.clone(),
-			multilinear_b.clone(),
+			&multilinear_a,
+			&multilinear_b,
 		);
 	}
 }

--- a/crates/ip-prover/src/sumcheck/bivariate_product_multi_mle.rs
+++ b/crates/ip-prover/src/sumcheck/bivariate_product_multi_mle.rs
@@ -165,7 +165,7 @@ where
 
 		let sums = prime_coeffs
 			.iter()
-			.map(|coeffs| coeffs.evaluate(challenge))
+			.map(|coeffs| coeffs.evaluate(&challenge))
 			.collect();
 
 		self.multilinears
@@ -251,8 +251,7 @@ mod tests {
 		let multilinears = [multilinear_a, multilinear_b];
 
 		let mut single_prover =
-			bivariate_product_mle::new(multilinears.clone(), eval_point.clone(), eval_claim)
-				.unwrap();
+			bivariate_product_mle::new(multilinears.clone(), &eval_point, eval_claim).unwrap();
 
 		let mut multi_prover = BivariateProductMultiMlecheckProver::new(
 			[multilinears].to_vec(),
@@ -358,7 +357,7 @@ mod tests {
 						.sum::<F>();
 
 					// Test conformance to the mlecheck round polynomial
-					assert_eq!(eval, coeffs.evaluate(sample));
+					assert_eq!(eval, coeffs.evaluate(&sample));
 				}
 			}
 

--- a/crates/ip-prover/src/sumcheck/frac_add_mle.rs
+++ b/crates/ip-prover/src/sumcheck/frac_add_mle.rs
@@ -12,9 +12,9 @@ pub type FractionalBuffer<P> = (FieldBuffer<P>, FieldBuffer<P>);
 // collections to be added are in either half.
 pub fn new<F, P>(
 	fraction: [FieldBuffer<P>; 4],
-	eval_point: Vec<F>,
+	eval_point: &[F],
 	eval_claims: [F; 2],
-) -> Result<impl MleCheckProver<F>, Error>
+) -> Result<impl MleCheckProver<F> + use<F, P>, Error>
 where
 	F: Field,
 	P: PackedField<Scalar = F>,
@@ -58,10 +58,10 @@ mod tests {
 		prover: impl SumcheckProver<F>,
 		eval_claims: [F; 2],
 		eval_point: &[F],
-		num_a: FieldBuffer<P>,
-		num_b: FieldBuffer<P>,
-		den_a: FieldBuffer<P>,
-		den_b: FieldBuffer<P>,
+		num_a: &FieldBuffer<P>,
+		num_b: &FieldBuffer<P>,
+		den_a: &FieldBuffer<P>,
+		den_b: &FieldBuffer<P>,
 	) where
 		F: Field,
 		P: PackedField<Scalar = F>,
@@ -97,10 +97,10 @@ mod tests {
 
 		// Check that the original multilinears evaluate to the claimed values at the challenge
 		// point
-		let eval_num_a = evaluate(&num_a, &reduced_eval_point);
-		let eval_den_a = evaluate(&den_a, &reduced_eval_point);
-		let eval_num_b = evaluate(&num_b, &reduced_eval_point);
-		let eval_den_b = evaluate(&den_b, &reduced_eval_point);
+		let eval_num_a = evaluate(num_a, &reduced_eval_point);
+		let eval_den_a = evaluate(den_a, &reduced_eval_point);
+		let eval_num_b = evaluate(num_b, &reduced_eval_point);
+		let eval_den_b = evaluate(den_b, &reduced_eval_point);
 
 		assert_eq!(
 			eval_num_a, multilinear_evals[0],
@@ -133,7 +133,7 @@ mod tests {
 		);
 
 		// Also verify the challenges match what the prover saw
-		let mut prover_challenges = output.challenges.clone();
+		let mut prover_challenges = output.challenges;
 		prover_challenges.reverse();
 		assert_eq!(
 			prover_challenges, sumcheck_output.challenges,
@@ -175,7 +175,7 @@ mod tests {
 
 		let frac_prover = new(
 			[num_a.clone(), num_b.clone(), den_a.clone(), den_b.clone()],
-			eval_point.clone(),
+			&eval_point,
 			eval_claims,
 		)
 		.unwrap();
@@ -187,10 +187,10 @@ mod tests {
 			prover,
 			eval_claims,
 			&eval_point,
-			num_a,
-			num_b,
-			den_a,
-			den_b,
+			&num_a,
+			&num_b,
+			&den_a,
+			&den_b,
 		);
 	}
 }

--- a/crates/ip-prover/src/sumcheck/gruen32.rs
+++ b/crates/ip-prover/src/sumcheck/gruen32.rs
@@ -71,15 +71,15 @@ impl<F: Field, P: PackedField<Scalar = F>> Gruen32<P> {
 		&self.chunk_eq_expansion
 	}
 
-	pub fn chunk_eq_expansion(&self) -> &FieldBuffer<P> {
+	pub const fn chunk_eq_expansion(&self) -> &FieldBuffer<P> {
 		&self.chunk_eq_expansion
 	}
 
-	pub fn suffix_eq_expansion(&self) -> &FieldBuffer<P> {
+	pub const fn suffix_eq_expansion(&self) -> &FieldBuffer<P> {
 		&self.suffix_eq_expansion
 	}
 
-	pub fn n_vars_remaining(&self) -> usize {
+	pub const fn n_vars_remaining(&self) -> usize {
 		self.n_vars_remaining
 	}
 

--- a/crates/ip-prover/src/sumcheck/mle_to_sumcheck.rs
+++ b/crates/ip-prover/src/sumcheck/mle_to_sumcheck.rs
@@ -32,7 +32,7 @@ pub struct MleToSumCheckDecorator<F: Field, InnerProver> {
 }
 
 impl<F: Field, InnerProver: MleCheckProver<F>> MleToSumCheckDecorator<F, InnerProver> {
-	pub fn new(mlecheck_prover: InnerProver) -> Self {
+	pub const fn new(mlecheck_prover: InnerProver) -> Self {
 		Self {
 			mlecheck_prover,
 			eq_prefix_eval: F::ONE,

--- a/crates/ip-prover/src/sumcheck/multilinear_eval.rs
+++ b/crates/ip-prover/src/sumcheck/multilinear_eval.rs
@@ -113,7 +113,7 @@ impl<F: Field, P: PackedField<Scalar = F>> SumcheckProver<F> for MultilinearEval
 
 		assert!(self.n_vars() > 0);
 
-		let sum = coeffs.evaluate(challenge);
+		let sum = coeffs.evaluate(&challenge);
 
 		fold_highest_var_inplace(&mut self.witness, challenge);
 		self.gruen32.fold(challenge);
@@ -188,7 +188,7 @@ mod tests {
 			[witness],
 			|[a]: [P; 1]| a,
 			|[_a]: [P; 1]| P::zero(),
-			eval_point.clone(),
+			&eval_point,
 			eval_claim,
 		)
 		.unwrap();
@@ -243,7 +243,7 @@ mod tests {
 		// The reduced MLE-check evaluation is the witness multilinear at the challenge point.
 		assert_eq!(multilinear_evals[0], sumcheck_output.eval);
 
-		let mut reduced_point = sumcheck_output.challenges.clone();
+		let mut reduced_point = sumcheck_output.challenges;
 		reduced_point.reverse();
 		assert_eq!(evaluate(&witness, &reduced_point), multilinear_evals[0]);
 	}
@@ -267,7 +267,7 @@ mod tests {
 			let round = prover.execute().unwrap();
 			assert_eq!(prover.round_claim(), before);
 			let challenge = F::random(&mut rng);
-			let expected_next = round[0].evaluate(challenge);
+			let expected_next = round[0].evaluate(&challenge);
 			prover.fold(challenge).unwrap();
 			assert_eq!(prover.round_claim(), vec![expected_next]);
 		}

--- a/crates/ip-prover/src/sumcheck/padded.rs
+++ b/crates/ip-prover/src/sumcheck/padded.rs
@@ -42,7 +42,7 @@ pub struct PaddedSumcheckDecorator<F: Field, Inner> {
 
 impl<F: Field, Inner: SumcheckProver<F>> PaddedSumcheckDecorator<F, Inner> {
 	/// Wraps `inner`, padding its claim with `n_extra_vars` extra (highest-indexed) variables.
-	pub fn new(inner: Inner, n_extra_vars: usize) -> Self {
+	pub const fn new(inner: Inner, n_extra_vars: usize) -> Self {
 		Self {
 			inner,
 			n_extra_vars,
@@ -52,7 +52,7 @@ impl<F: Field, Inner: SumcheckProver<F>> PaddedSumcheckDecorator<F, Inner> {
 	}
 
 	/// Whether the current round binds one of the padding variables.
-	fn in_padding_phase(&self) -> bool {
+	const fn in_padding_phase(&self) -> bool {
 		self.round < self.n_extra_vars
 	}
 }
@@ -248,7 +248,7 @@ mod tests {
 				RoundProof(RoundCoeffs(verifier_transcript.recv_many(degree).unwrap()));
 			let challenge = verifier_transcript.sample();
 			let round_coeffs = round_proof.recover(running_sum);
-			running_sum = round_coeffs.evaluate(challenge);
+			running_sum = round_coeffs.evaluate(&challenge);
 			challenges.push(challenge);
 		}
 		let reduced_eval = running_sum;

--- a/crates/ip-prover/src/sumcheck/quadratic_mle.rs
+++ b/crates/ip-prover/src/sumcheck/quadratic_mle.rs
@@ -73,7 +73,7 @@ where
 		mut multilinears: impl AsSlicesMut<P, N> + Send + 'static,
 		composition: Composition,
 		infinity_composition: InfinityComposition,
-		eval_point: Vec<F>,
+		eval_point: &[F],
 		eval_claim: F,
 	) -> Result<Self, Error> {
 		let n_vars = eval_point.len();
@@ -85,7 +85,7 @@ where
 		}
 
 		let last_coeffs_or_eval = RoundCoeffsOrEval::Eval(eval_claim);
-		let gruen32 = Gruen32::new(&eval_point);
+		let gruen32 = Gruen32::new(eval_point);
 
 		Ok(Self {
 			multilinears: Box::new(multilinears),
@@ -211,7 +211,7 @@ where
 			thus, n_vars should be > 0"
 		);
 
-		let eval = coeffs.evaluate(challenge);
+		let eval = coeffs.evaluate(&challenge);
 
 		for multilinear in &mut self.multilinears_mut() {
 			fold_highest_var_inplace(multilinear, challenge);
@@ -286,7 +286,7 @@ mod tests {
 		composition: Composition,
 		eval_claim: F,
 		eval_point: &[F],
-		multilinears: Vec<FieldBuffer<P>>,
+		multilinears: &[FieldBuffer<P>],
 	) where
 		F: Field,
 		P: PackedField<Scalar = F>,
@@ -329,7 +329,7 @@ mod tests {
 
 		// Check that the original multilinears evaluate to the claimed values at the challenge
 		// point
-		for (multilinear, claimed_eval) in iter::zip(&multilinears, multilinear_evals) {
+		for (multilinear, claimed_eval) in iter::zip(multilinears, multilinear_evals) {
 			let actual_eval = evaluate(multilinear, &reduced_eval_point);
 			assert_eq!(actual_eval, claimed_eval);
 		}
@@ -371,7 +371,7 @@ mod tests {
 			multilinears.clone(),
 			composition.clone(),
 			infinity_composition,
-			eval_point.clone(),
+			&eval_point,
 			eval_claim,
 		)
 		.unwrap();
@@ -381,7 +381,7 @@ mod tests {
 			composition,
 			eval_claim,
 			&eval_point,
-			multilinears.to_vec(),
+			&multilinears,
 		);
 	}
 
@@ -443,7 +443,7 @@ mod tests {
 			multilinears,
 			composition,
 			composition,
-			eval_point,
+			&eval_point,
 			eval_claim,
 		)
 		.unwrap();
@@ -454,7 +454,7 @@ mod tests {
 			let round = prover.execute().unwrap();
 			assert_eq!(prover.round_claim(), expected, "claim recovered from coeffs");
 			let challenge = F::random(&mut rng);
-			expected = round.iter().map(|r| r.evaluate(challenge)).collect();
+			expected = round.iter().map(|r| r.evaluate(&challenge)).collect();
 			prover.fold(challenge).unwrap();
 		}
 	}

--- a/crates/ip-prover/src/sumcheck/rerand_mle.rs
+++ b/crates/ip-prover/src/sumcheck/rerand_mle.rs
@@ -175,7 +175,7 @@ where
 
 		let sums = round_coeffs
 			.iter()
-			.map(|coeffs| coeffs.evaluate(challenge))
+			.map(|coeffs| coeffs.evaluate(&challenge))
 			.collect::<Vec<F>>();
 
 		self.switchover.fold(challenge);

--- a/crates/ip-prover/src/sumcheck/selector_mle.rs
+++ b/crates/ip-prover/src/sumcheck/selector_mle.rs
@@ -226,7 +226,7 @@ where
 
 		let sums = prime_coeffs
 			.iter()
-			.map(|coeffs| coeffs.evaluate(challenge))
+			.map(|coeffs| coeffs.evaluate(&challenge))
 			.collect();
 
 		self.gruen32s

--- a/crates/ip-prover/src/sumcheck/switchover.rs
+++ b/crates/ip-prover/src/sumcheck/switchover.rs
@@ -71,7 +71,7 @@ where
 	}
 
 	// Number of variables in all 1-bit multilinears at start of sumcheck.
-	fn n_vars_transparent(&self) -> usize {
+	const fn n_vars_transparent(&self) -> usize {
 		checked_log_2(self.bitmasks.len())
 	}
 
@@ -91,18 +91,19 @@ where
 		assert!(bit_offset < self.n_multilinears);
 		assert_eq!(scratchpad.len(), 1 << chunk_vars);
 
-		if let Some(folded) = &self.folded {
-			folded[bit_offset].chunk(chunk_vars, chunk_index)
-		} else {
-			get_binary_chunk(
-				scratchpad,
-				&self.tensor,
-				&BitSelector::new(bit_offset, self.bitmasks),
-				chunk_vars,
-				chunk_index,
-			);
-			scratchpad.to_ref()
-		}
+		self.folded.as_ref().map_or_else(
+			|| {
+				get_binary_chunk(
+					scratchpad,
+					&self.tensor,
+					&BitSelector::new(bit_offset, self.bitmasks),
+					chunk_vars,
+					chunk_index,
+				);
+				scratchpad.to_ref()
+			},
+			|folded| folded[bit_offset].chunk(chunk_vars, chunk_index),
+		)
 	}
 
 	pub fn fold(&mut self, challenge: F) {
@@ -186,5 +187,5 @@ fn get_binary_chunk<P, DataOut, DataIn>(
 		chunk_vars,
 		chunk_index,
 	);
-	binary_fold_high(dest, tensor, matrix_vert_slice);
+	binary_fold_high(dest, tensor, &matrix_vert_slice);
 }

--- a/crates/ip-prover/src/sumcheck/zk_mlecheck.rs
+++ b/crates/ip-prover/src/sumcheck/zk_mlecheck.rs
@@ -114,7 +114,7 @@ impl<F: Field, P: PackedField<Scalar = F>, Data: Deref<Target = [P]>> Mask<P, Da
 	/// * `n_vars` - Number of variables (n).
 	/// * `degree` - Degree of each univariate polynomial (d).
 	/// * `buffer` - Buffer with log_len = m_n + m_d.
-	pub fn new(n_vars: usize, degree: usize, buffer: FieldBuffer<P, Data>) -> Self {
+	pub const fn new(n_vars: usize, degree: usize, buffer: FieldBuffer<P, Data>) -> Self {
 		Self {
 			n_vars,
 			degree,
@@ -123,17 +123,17 @@ impl<F: Field, P: PackedField<Scalar = F>, Data: Deref<Target = [P]>> Mask<P, Da
 	}
 
 	/// Returns the number of variables.
-	pub fn n_vars(&self) -> usize {
+	pub const fn n_vars(&self) -> usize {
 		self.n_vars
 	}
 
 	/// Returns the degree of each univariate polynomial.
-	pub fn degree(&self) -> usize {
+	pub const fn degree(&self) -> usize {
 		self.degree
 	}
 
 	/// Returns m_d = ceil(log2(degree + 1)).
-	fn log_degree_plus_one(&self) -> usize {
+	const fn log_degree_plus_one(&self) -> usize {
 		(self.degree + 1).next_power_of_two().ilog2() as usize
 	}
 
@@ -157,7 +157,7 @@ impl<F: Field, P: PackedField<Scalar = F>, Data: Deref<Target = [P]>> Mask<P, Da
 	/// Evaluates g_i(x) for a specific variable using Horner's method.
 	pub fn evaluate_univariate(&self, var_index: usize, x: F) -> F {
 		let coeffs: Vec<_> = self.coeffs_for_var(var_index).collect();
-		evaluate_univariate(&coeffs, x)
+		evaluate_univariate(&coeffs, &x)
 	}
 
 	/// Computes the MLE of the mask polynomial at a point.
@@ -257,7 +257,7 @@ impl<F: Field, P: PackedField<Scalar = F>, Data: Deref<Target = [P]>>
 
 	/// Returns the index of the current variable being processed.
 	/// Processing is high-to-low, so we start at n_vars-1 and decrease.
-	fn current_var_index(&self) -> usize {
+	const fn current_var_index(&self) -> usize {
 		self.n_vars_remaining - 1
 	}
 }
@@ -324,7 +324,7 @@ impl<F: Field, P: PackedField<Scalar = F>, Data: Deref<Target = [P]>> SumcheckPr
 		};
 
 		// Evaluate round polynomial at challenge to get new claim
-		let new_claim = coeffs.evaluate(challenge);
+		let new_claim = coeffs.evaluate(&challenge);
 
 		let var_idx = self.current_var_index();
 
@@ -523,7 +523,7 @@ mod tests {
 		assert_eq!(mask_eval_out, sumcheck_output.eval);
 
 		// Compute the challenge point (reverse for high-to-low order)
-		let mut challenge_point = sumcheck_output.challenges.clone();
+		let mut challenge_point = sumcheck_output.challenges;
 		challenge_point.reverse();
 
 		// Check that the final evaluation matches direct computation
@@ -572,7 +572,7 @@ mod tests {
 		let sumcheck_output =
 			mlecheck::verify(&eval_point, 2, eval_claim, &mut verifier_transcript).unwrap();
 
-		let mut challenge_point = sumcheck_output.challenges.clone();
+		let mut challenge_point = sumcheck_output.challenges;
 		challenge_point.reverse();
 
 		let mask = Mask::new(1, 2, buffer.to_ref());
@@ -710,7 +710,7 @@ mod tests {
 
 		// Create the bivariate product sumcheck prover
 		let prover = BivariateProductSumcheckProver::new(
-			[mask_buffer.clone(), libra_eval_tensor.clone()],
+			[mask_buffer.clone(), libra_eval_tensor],
 			claimed_sum,
 		)
 		.unwrap();

--- a/crates/ip/src/fracaddcheck.rs
+++ b/crates/ip/src/fracaddcheck.rs
@@ -97,7 +97,7 @@ impl From<sumcheck::Error> for Error {
 	fn from(err: sumcheck::Error) -> Self {
 		match err {
 			sumcheck::Error::Verification(err) => VerificationError::Sumcheck(err).into(),
-			_ => Error::Sumcheck(err),
+			_ => Self::Sumcheck(err),
 		}
 	}
 }
@@ -106,7 +106,7 @@ impl From<TranscriptError> for Error {
 	fn from(err: TranscriptError) -> Self {
 		match err {
 			TranscriptError::NotEnoughBytes => VerificationError::TranscriptIsEmpty.into(),
-			_ => Error::Transcript(err),
+			_ => Self::Transcript(err),
 		}
 	}
 }

--- a/crates/ip/src/logup_star/final_layer.rs
+++ b/crates/ip/src/logup_star/final_layer.rs
@@ -60,7 +60,7 @@ pub struct FinalLayer<F> {
 /// * `channel` - The verifier channel.
 pub fn verify_final_layer<F, C>(
 	m: usize,
-	c: C::Elem,
+	c: &C::Elem,
 	eval_claim: C::Elem,
 	layer1_num: C::Elem,
 	layer1_den: C::Elem,
@@ -98,7 +98,7 @@ where
 
 	// Table-side denominator halves D_0, D_1 are public: D = c - J with J(x) = sum_t basis(t) *
 	// x_t.
-	let (d_0, d_1) = denominator_halves::<F, C::Elem>(&c, &rho, m);
+	let (d_0, d_1) = denominator_halves::<F, C::Elem>(c, &rho, m);
 
 	// Reconstruct the batched summand at the challenge point and check it equals the reduced eval.
 	//

--- a/crates/ip/src/logup_star/verify.rs
+++ b/crates/ip/src/logup_star/verify.rs
@@ -154,7 +154,7 @@ where
 		table_eval_point,
 		table_eval_claim,
 		pushforward_eval_claim,
-	} = verify_final_layer::<F, C>(m, c, eval_claim, layer1_num, layer1_den, &layer1_point, channel)?;
+	} = verify_final_layer::<F, C>(m, &c, eval_claim, layer1_num, layer1_den, &layer1_point, channel)?;
 
 	Ok(LogupOutput {
 		table_eval_point,

--- a/crates/ip/src/mlecheck.rs
+++ b/crates/ip/src/mlecheck.rs
@@ -96,7 +96,7 @@ where
 		let challenge = channel.sample();
 
 		let round_coeffs = round_proof.recover(eval, z_i.clone());
-		eval = round_coeffs.evaluate(challenge.clone());
+		eval = round_coeffs.evaluate(&challenge);
 		challenges.push(challenge);
 	}
 
@@ -126,7 +126,7 @@ where
 
 	// Randomly mix the evaluation claim with the mask evaluation claim.
 	let batch_challenge = channel.sample();
-	let batch_eval = eval + batch_challenge.clone() * mask_eval.clone();
+	let batch_eval = eval + batch_challenge.clone() * mask_eval;
 
 	let SumcheckOutput {
 		eval: batch_eval_out,
@@ -261,8 +261,8 @@ mod tests {
 	fn test_recover_with_degree<F: Field>(mut rng: impl Rng, alpha: F, degree: usize) {
 		let coeffs = RoundCoeffs(random_scalars(&mut rng, degree + 1));
 
-		let v0 = coeffs.evaluate(F::ZERO);
-		let v1 = coeffs.evaluate(F::ONE);
+		let v0 = coeffs.evaluate(&F::ZERO);
+		let v1 = coeffs.evaluate(&F::ONE);
 		let eval = extrapolate_line_packed(v0, v1, alpha);
 
 		let proof = RoundProof::truncate(coeffs.clone());

--- a/crates/ip/src/prodcheck.rs
+++ b/crates/ip/src/prodcheck.rs
@@ -85,7 +85,7 @@ impl From<sumcheck::Error> for Error {
 	fn from(err: sumcheck::Error) -> Self {
 		match err {
 			sumcheck::Error::Verification(err) => VerificationError::Sumcheck(err).into(),
-			_ => Error::Sumcheck(err),
+			_ => Self::Sumcheck(err),
 		}
 	}
 }
@@ -94,7 +94,7 @@ impl From<TranscriptError> for Error {
 	fn from(err: TranscriptError) -> Self {
 		match err {
 			TranscriptError::NotEnoughBytes => VerificationError::TranscriptIsEmpty.into(),
-			_ => Error::Transcript(err),
+			_ => Self::Transcript(err),
 		}
 	}
 }

--- a/crates/ip/src/sumcheck/batch.rs
+++ b/crates/ip/src/sumcheck/batch.rs
@@ -47,7 +47,7 @@ where
 	// Random linear-combination coefficient that binds all sum claims together.
 	let batch_coeff = channel.sample();
 	// Combine the individual sum claims into a single scalar for sumcheck verification.
-	let sum = evaluate_univariate(sums, batch_coeff.clone());
+	let sum = evaluate_univariate(sums, &batch_coeff);
 
 	let SumcheckOutput { eval, challenges } =
 		sumcheck::verify::<F, C>(n_vars, degree, sum, channel)?;
@@ -77,7 +77,7 @@ where
 	// Random linear-combination coefficient that binds all eval claims together.
 	let batch_coeff = channel.sample();
 	// Combine the individual eval claims into a single scalar for MLE-check verification.
-	let eval = evaluate_univariate(evals, batch_coeff.clone());
+	let eval = evaluate_univariate(evals, &batch_coeff);
 
 	let SumcheckOutput { eval, challenges } =
 		mlecheck::verify::<F, C>(point, degree, eval, channel)?;

--- a/crates/ip/src/sumcheck/common.rs
+++ b/crates/ip/src/sumcheck/common.rs
@@ -21,7 +21,7 @@ impl<F> RoundCoeffs<F> {
 
 impl<F: FieldOps> RoundCoeffs<F> {
 	/// Evaluate the polynomial at a point.
-	pub fn evaluate(&self, x: F) -> F {
+	pub fn evaluate(&self, x: &F) -> F {
 		evaluate_univariate(&self.0, x)
 	}
 }

--- a/crates/ip/src/sumcheck/error.rs
+++ b/crates/ip/src/sumcheck/error.rs
@@ -24,7 +24,7 @@ impl From<TranscriptError> for Error {
 	fn from(err: TranscriptError) -> Self {
 		match err {
 			TranscriptError::NotEnoughBytes => VerificationError::TranscriptIsEmpty.into(),
-			_ => Error::Transcript(err),
+			_ => Self::Transcript(err),
 		}
 	}
 }

--- a/crates/ip/src/sumcheck/verify.rs
+++ b/crates/ip/src/sumcheck/verify.rs
@@ -12,7 +12,7 @@ use crate::{
 ///
 /// The [`verify`] function reduces a claim about the sum of a multivariate polynomial over the
 /// boolean hypercube to its evaluation at a challenge point.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SumcheckOutput<F> {
 	/// The evaluation of the sumcheck multivariate at the challenge point.
 	pub eval: F,
@@ -52,7 +52,7 @@ where
 		let challenge = channel.sample();
 
 		let round_coeffs = round_proof.recover(sum);
-		sum = round_coeffs.evaluate(challenge.clone());
+		sum = round_coeffs.evaluate(&challenge);
 		challenges.push(challenge);
 	}
 

--- a/crates/m4-prover/src/value_table.rs
+++ b/crates/m4-prover/src/value_table.rs
@@ -132,22 +132,22 @@ impl ValueTable {
 	}
 
 	/// The base-2 logarithm of the number of instances.
-	pub fn log_instances(&self) -> usize {
+	pub const fn log_instances(&self) -> usize {
 		self.log_instances
 	}
 
 	/// The number of instances in the batch.
-	pub fn n_instances(&self) -> usize {
+	pub const fn n_instances(&self) -> usize {
 		1usize << self.log_instances
 	}
 
 	/// The per-instance value layout shared by every instance.
-	pub fn layout(&self) -> &ValueVecLayout {
+	pub const fn layout(&self) -> &ValueVecLayout {
 		&self.layout
 	}
 
 	/// The number of committed words occupied by a single instance.
-	pub fn instance_stride(&self) -> usize {
+	pub const fn instance_stride(&self) -> usize {
 		self.layout.committed_total_len
 	}
 
@@ -201,7 +201,7 @@ impl ValueTable {
 		// Their lengths sum to one instance's committed length by construction.
 		// So reconstruction never fails here.
 		// The constructor only rejects a mismatched total length.
-		ValueVec::new_from_data(self.layout.clone(), public.to_vec(), private.to_vec())
+		ValueVec::new_from_data(self.layout.clone(), public, private)
 			.expect("public and private lengths sum to the committed layout length")
 	}
 

--- a/crates/m4-verifier/src/commit.rs
+++ b/crates/m4-verifier/src/commit.rs
@@ -84,7 +84,7 @@ impl BatchCommitLayout {
 	}
 
 	/// The number of words one instance occupies after power-of-two padding.
-	pub fn padded_instance_words(&self) -> usize {
+	pub const fn padded_instance_words(&self) -> usize {
 		1 << self.log_instance_words
 	}
 }

--- a/crates/m4-verifier/src/verify.rs
+++ b/crates/m4-verifier/src/verify.rs
@@ -78,14 +78,14 @@ impl Verifier {
 	}
 
 	/// The committed-multilinear shape this verifier expects.
-	pub fn layout(&self) -> &BatchCommitLayout {
+	pub const fn layout(&self) -> &BatchCommitLayout {
 		&self.layout
 	}
 
 	/// The precomputed BaseFold verifier compiler.
 	///
 	/// The prover reuses it so both sides share one set of FRI parameters.
-	pub fn iop_compiler(&self) -> &BaseFoldVerifierCompiler<B128, Scheme> {
+	pub const fn iop_compiler(&self) -> &BaseFoldVerifierCompiler<B128, Scheme> {
 		&self.iop_compiler
 	}
 

--- a/crates/math/benches/batch_invert.rs
+++ b/crates/math/benches/batch_invert.rs
@@ -18,7 +18,7 @@ fn bench_batch_inversion_scalar(c: &mut Criterion) {
 		group.bench_function(format!("{n}"), |b| {
 			b.iter(|| {
 				inverter.invert_or_zero(&mut elements);
-			})
+			});
 		});
 	}
 
@@ -38,7 +38,7 @@ fn bench_batch_inversion_packed(c: &mut Criterion) {
 			.collect();
 		let mut inverter = BatchInversion::<OptimalPackedB128>::new(n);
 		group.bench_function(format!("{n}x{}", OptimalPackedB128::WIDTH), |b| {
-			b.iter(|| inverter.invert_nonzero(&mut elements))
+			b.iter(|| inverter.invert_nonzero(&mut elements));
 		});
 	}
 

--- a/crates/math/benches/bit_reverse.rs
+++ b/crates/math/benches/bit_reverse.rs
@@ -22,7 +22,7 @@ fn bench_bit_reverse_helper<F: BinaryField, P: PackedField<Scalar = F>>(
 
 		group.bench_function(BenchmarkId::new("bit_reverse_packed", &parameter), |b| {
 			let mut data = random_field_buffer::<P>(&mut rng, log_d);
-			b.iter(|| bit_reverse_packed(data.to_mut()))
+			b.iter(|| bit_reverse_packed(data.to_mut()));
 		});
 	}
 

--- a/crates/math/benches/ntt.rs
+++ b/crates/math/benches/ntt.rs
@@ -36,7 +36,7 @@ enum ThroughputVariant {
 #[allow(clippy::too_many_arguments)]
 #[allow(clippy::single_element_loop)]
 fn bench_ntts<F: BinaryField, P: PackedField<Scalar = F>>(
-	group: &mut BenchmarkGroup<WallTime>,
+	group: &mut BenchmarkGroup<'_, WallTime>,
 	throughput_var: ThroughputVariant,
 	log_d: usize,
 	domain_context: &(impl DomainContext<Field = P::Scalar> + Sync),
@@ -65,7 +65,7 @@ fn bench_ntts<F: BinaryField, P: PackedField<Scalar = F>>(
 			};
 
 			let mut data = random_field_buffer::<P>(&mut rng, log_d);
-			b.iter(|| ntt.forward_transform(data.to_mut(), skip_early, skip_late))
+			b.iter(|| ntt.forward_transform(data.to_mut(), skip_early, skip_late));
 		});
 	}
 
@@ -74,7 +74,7 @@ fn bench_ntts<F: BinaryField, P: PackedField<Scalar = F>>(
 		let ntt = NeighborsLastBreadthFirst { domain_context };
 
 		let mut data = random_field_buffer::<P>(&mut rng, log_d);
-		b.iter(|| ntt.forward_transform(data.to_mut(), skip_early, skip_late))
+		b.iter(|| ntt.forward_transform(data.to_mut(), skip_early, skip_late));
 	});
 
 	for log_num_shares in [0, 3] {
@@ -97,8 +97,8 @@ fn bench_ntts<F: BinaryField, P: PackedField<Scalar = F>>(
 					.build()
 					.unwrap();
 				thread_pool.install(|| {
-					b.iter(|| ntt.forward_transform(data.to_mut(), skip_early, skip_late))
-				})
+					b.iter(|| ntt.forward_transform(data.to_mut(), skip_early, skip_late));
+				});
 			});
 		}
 	}
@@ -219,7 +219,7 @@ fn bench_fields(c: &mut Criterion) {
 }
 
 /// Gives the number of raw field multiplications that are done for an NTT with specific parameters.
-fn num_muls(log_d: usize, skip_early: usize, skip_late: usize) -> u64 {
+const fn num_muls(log_d: usize, skip_early: usize, skip_late: usize) -> u64 {
 	let num_rounds = log_d - skip_late - skip_early;
 	let muls_per_round = 1u64 << (log_d - 1);
 

--- a/crates/math/src/bit_reverse.rs
+++ b/crates/math/src/bit_reverse.rs
@@ -16,7 +16,7 @@ use crate::field_buffer::FieldSliceMut;
 /// # Returns
 ///
 /// The value with its low `bits` bits reversed
-pub fn reverse_bits(x: usize, bits: u32) -> usize {
+pub const fn reverse_bits(x: usize, bits: u32) -> usize {
 	x.reverse_bits().unbounded_shr(usize::BITS - bits)
 }
 
@@ -29,7 +29,7 @@ pub fn reverse_bits(x: usize, bits: u32) -> usize {
 /// # Arguments
 ///
 /// * `buffer` - Mutable slice of packed field elements to permute
-pub fn bit_reverse_packed<P: PackedField>(mut buffer: FieldSliceMut<P>) {
+pub fn bit_reverse_packed<P: PackedField>(mut buffer: FieldSliceMut<'_, P>) {
 	// The algorithm has two parallelized phases:
 	// 1. Process P::WIDTH x P::WIDTH submatrices in parallel
 	// 2. Apply bit-reversal to independent chunks in parallel
@@ -57,15 +57,15 @@ pub fn bit_reverse_packed<P: PackedField>(mut buffer: FieldSliceMut<P>) {
 				// Therefore, different i values access completely disjoint index sets.
 				unsafe {
 					let data = data_ptr as *mut P;
-					for j in 0..P::WIDTH {
-						tmp[j] = *data.add(reverse_bits(j, bits) | i);
+					for (j, tmp_j) in tmp.iter_mut().enumerate().take(P::WIDTH) {
+						*tmp_j = *data.add(reverse_bits(j, bits) | i);
 					}
 				}
 				square_transpose(P::LOG_WIDTH, tmp);
 				unsafe {
 					let data = data_ptr as *mut P;
-					for j in 0..P::WIDTH {
-						*data.add(reverse_bits(j, bits) | i) = tmp[j];
+					for (j, tmp_j) in tmp.iter().enumerate().take(P::WIDTH) {
+						*data.add(reverse_bits(j, bits) | i) = *tmp_j;
 					}
 				}
 			},
@@ -88,7 +88,7 @@ pub fn bit_reverse_packed<P: PackedField>(mut buffer: FieldSliceMut<P>) {
 /// # Arguments
 ///
 /// * `buffer` - Mutable slice of packed field elements to permute
-fn bit_reverse_packed_naive<P: PackedField>(mut buffer: FieldSliceMut<P>) {
+fn bit_reverse_packed_naive<P: PackedField>(mut buffer: FieldSliceMut<'_, P>) {
 	let bits = buffer.log_len() as u32;
 	for i in 0..buffer.len() {
 		let i_rev = reverse_bits(i, bits);
@@ -159,7 +159,7 @@ mod tests {
 		let data_orig = random_field_buffer::<Packed128b>(&mut rng, log_d);
 
 		let mut data_optimized = data_orig.clone();
-		let mut data_naive = data_orig.clone();
+		let mut data_naive = data_orig;
 
 		bit_reverse_packed(data_optimized.to_mut());
 		bit_reverse_packed_naive(data_naive.to_mut());

--- a/crates/math/src/field_buffer.rs
+++ b/crates/math/src/field_buffer.rs
@@ -176,7 +176,7 @@ impl<P: PackedField, Data: Deref<Target = [P]>> FieldBuffer<P, Data> {
 	}
 
 	/// Returns the number of field elements.
-	pub fn len(&self) -> usize {
+	pub const fn len(&self) -> usize {
 		1 << self.log_len
 	}
 
@@ -719,7 +719,7 @@ impl<P: PackedField, Data: DerefMut<Target = [P]>> AsSlicesMut<P, 2>
 pub struct FieldBufferChunkMut<'a, P: PackedField>(FieldBufferChunkMutInner<'a, P>);
 
 impl<'a, P: PackedField> FieldBufferChunkMut<'a, P> {
-	pub fn get(&mut self) -> FieldSliceMut<'_, P> {
+	pub const fn get(&mut self) -> FieldSliceMut<'_, P> {
 		match &mut self.0 {
 			FieldBufferChunkMutInner::Single {
 				log_len,

--- a/crates/math/src/multilinear/eq.rs
+++ b/crates/math/src/multilinear/eq.rs
@@ -179,7 +179,7 @@ pub fn eq_ind_truncate_low_inplace<P: PackedField, Data: DerefMut<Target = [P]>>
 #[inline(always)]
 pub fn eq_one_var<F: FieldOps>(x: F, y: F) -> F {
 	let one = F::one();
-	x.clone() * y.clone() + (one.clone() - x) * (one.clone() - y)
+	x.clone() * y.clone() + (one.clone() - x) * (one - y)
 }
 
 /// Evaluates the equality indicator multilinear at a pair of coordinates.

--- a/crates/math/src/multilinear/fold.rs
+++ b/crates/math/src/multilinear/fold.rs
@@ -49,7 +49,7 @@ pub fn fold_highest_var_inplace<P: PackedField, Data: DerefMut<Target = [P]>>(
 pub fn binary_fold_high<P, DataOut, DataIn>(
 	values: &mut FieldBuffer<P, DataOut>,
 	tensor: &FieldBuffer<P, DataIn>,
-	bits: impl RandomAccessSequence<bool> + Sync,
+	bits: &(impl RandomAccessSequence<bool> + Sync),
 ) where
 	P: PackedField,
 	DataOut: DerefMut<Target = [P]>,
@@ -144,7 +144,7 @@ mod tests {
 		let mut bits_buffer = FieldBuffer::<P>::from_values(&bits_scalars);
 
 		let mut binary_fold_result = FieldBuffer::<P>::zeros(n_vars - tensor_n_vars);
-		binary_fold_high(&mut binary_fold_result, &tensor, bits.as_slice());
+		binary_fold_high(&mut binary_fold_result, &tensor, &bits.as_slice());
 
 		for &scalar in point.iter().rev() {
 			fold_highest_var_inplace(&mut bits_buffer, scalar);
@@ -156,7 +156,7 @@ mod tests {
 	#[test]
 	fn test_binary_fold_high_conforms_to_regular_fold_high() {
 		for (n_vars, tensor_n_vars) in [(2, 0), (2, 1), (4, 4), (10, 3)] {
-			test_binary_fold_high_conforms_to_regular_fold_high_helper(n_vars, tensor_n_vars)
+			test_binary_fold_high_conforms_to_regular_fold_high_helper(n_vars, tensor_n_vars);
 		}
 	}
 }

--- a/crates/math/src/ntt/domain_context.rs
+++ b/crates/math/src/ntt/domain_context.rs
@@ -120,13 +120,13 @@ impl<F: BinaryField> GenericPreExpanded<F> {
 		for basis in evals.iter().rev() {
 			let mut expanded_i = Vec::with_capacity(1 << (basis.len() - 1));
 			expanded_i.push(F::ZERO);
-			for i in 1..basis.len() {
+			for basis_i in basis.iter().skip(1) {
 				for j in 0..expanded_i.len() {
-					expanded_i.push(expanded_i[j] + basis[i]);
+					expanded_i.push(expanded_i[j] + *basis_i);
 				}
 			}
 			assert_eq!(expanded_i.len(), 1 << (basis.len() - 1));
-			expanded.push(expanded_i)
+			expanded.push(expanded_i);
 		}
 		assert_eq!(expanded.len(), evals.len());
 
@@ -305,9 +305,9 @@ impl<F: BinaryField + TraceOneElement> GaoMateerPreExpanded<F> {
 
 		let mut expanded = Vec::with_capacity(1 << log_domain_size);
 		expanded.push(F::ZERO);
-		for i in 1..log_domain_size {
+		for basis_i in basis.iter().take(log_domain_size).skip(1) {
 			for j in 0..expanded.len() {
-				expanded.push(expanded[j] + basis[i]);
+				expanded.push(expanded[j] + *basis_i);
 			}
 		}
 		assert_eq!(expanded.len(), 1usize << (log_domain_size - 1));
@@ -359,7 +359,7 @@ mod tests {
 				assert_eq!(dc_1.twiddle(i, block), dc_2.twiddle(i, block));
 			}
 		}
-		assert_eq!(dc_1.subspace(log_domain_size), dc_2.subspace(log_domain_size))
+		assert_eq!(dc_1.subspace(log_domain_size), dc_2.subspace(log_domain_size));
 	}
 
 	#[test]

--- a/crates/math/src/ntt/mod.rs
+++ b/crates/math/src/ntt/mod.rs
@@ -73,7 +73,7 @@ pub trait AdditiveNTT {
 	/// [DP24]: <https://eprint.iacr.org/2024/504>
 	fn forward_transform<P: PackedField<Scalar = Self::Field>>(
 		&self,
-		data: FieldSliceMut<P>,
+		data: FieldSliceMut<'_, P>,
 		skip_early: usize,
 		skip_late: usize,
 	);
@@ -88,7 +88,7 @@ pub trait AdditiveNTT {
 	/// - same as [`Self::forward_transform`]
 	fn inverse_transform<P: PackedField<Scalar = Self::Field>>(
 		&self,
-		data: FieldSliceMut<P>,
+		data: FieldSliceMut<'_, P>,
 		skip_early: usize,
 		skip_late: usize,
 	);

--- a/crates/math/src/ntt/neighbors_last.rs
+++ b/crates/math/src/ntt/neighbors_last.rs
@@ -314,7 +314,7 @@ where
 
 	fn forward_transform<P: PackedField<Scalar = F>>(
 		&self,
-		mut data: FieldSliceMut<P>,
+		mut data: FieldSliceMut<'_, P>,
 		skip_early: usize,
 		skip_late: usize,
 	) {
@@ -340,7 +340,7 @@ where
 
 	fn inverse_transform<P: PackedField<Scalar = F>>(
 		&self,
-		_data: FieldSliceMut<P>,
+		_data: FieldSliceMut<'_, P>,
 		_skip_early: usize,
 		_skip_late: usize,
 	) {
@@ -372,7 +372,7 @@ pub struct NeighborsLastSingleThread<DC> {
 
 impl<DC> NeighborsLastSingleThread<DC> {
 	/// Convenience constructor which sets `log_base_len` to a reasonable default.
-	pub fn new(domain_context: DC) -> Self {
+	pub const fn new(domain_context: DC) -> Self {
 		Self {
 			domain_context,
 			log_base_len: DEFAULT_LOG_BASE_LEN,
@@ -385,7 +385,7 @@ impl<DC: DomainContext> AdditiveNTT for NeighborsLastSingleThread<DC> {
 
 	fn forward_transform<P: PackedField<Scalar = Self::Field>>(
 		&self,
-		mut data: FieldSliceMut<P>,
+		mut data: FieldSliceMut<'_, P>,
 		skip_early: usize,
 		skip_late: usize,
 	) {
@@ -413,7 +413,7 @@ impl<DC: DomainContext> AdditiveNTT for NeighborsLastSingleThread<DC> {
 
 	fn inverse_transform<P: PackedField<Scalar = Self::Field>>(
 		&self,
-		_data_orig: FieldSliceMut<P>,
+		_data_orig: FieldSliceMut<'_, P>,
 		_skip_early: usize,
 		_skip_late: usize,
 	) {
@@ -449,7 +449,7 @@ pub struct NeighborsLastMultiThread<DC> {
 
 impl<DC> NeighborsLastMultiThread<DC> {
 	/// Convenience constructor which sets `log_base_len` to a reasonable default.
-	pub fn new(domain_context: DC, log_num_shares: usize) -> Self {
+	pub const fn new(domain_context: DC, log_num_shares: usize) -> Self {
 		Self {
 			domain_context,
 			log_base_len: DEFAULT_LOG_BASE_LEN,
@@ -463,7 +463,7 @@ impl<DC: DomainContext + Sync> AdditiveNTT for NeighborsLastMultiThread<DC> {
 
 	fn forward_transform<P: PackedField<Scalar = Self::Field>>(
 		&self,
-		mut data: FieldSliceMut<P>,
+		mut data: FieldSliceMut<'_, P>,
 		skip_early: usize,
 		skip_late: usize,
 	) {
@@ -527,7 +527,7 @@ impl<DC: DomainContext + Sync> AdditiveNTT for NeighborsLastMultiThread<DC> {
 
 	fn inverse_transform<P: PackedField<Scalar = Self::Field>>(
 		&self,
-		_data_orig: FieldSliceMut<P>,
+		_data_orig: FieldSliceMut<'_, P>,
 		_skip_early: usize,
 		_skip_late: usize,
 	) {

--- a/crates/math/src/ntt/reference.rs
+++ b/crates/math/src/ntt/reference.rs
@@ -19,7 +19,7 @@ impl<DC: DomainContext> AdditiveNTT for NeighborsLastReference<DC> {
 
 	fn forward_transform<P: PackedField<Scalar = Self::Field>>(
 		&self,
-		mut data: FieldSliceMut<P>,
+		mut data: FieldSliceMut<'_, P>,
 		skip_early: usize,
 		skip_late: usize,
 	) {
@@ -48,7 +48,7 @@ impl<DC: DomainContext> AdditiveNTT for NeighborsLastReference<DC> {
 
 	fn inverse_transform<P: PackedField<Scalar = Self::Field>>(
 		&self,
-		mut data: FieldSliceMut<P>,
+		mut data: FieldSliceMut<'_, P>,
 		skip_early: usize,
 		skip_late: usize,
 	) {

--- a/crates/math/src/ntt/tests_evaluation.rs
+++ b/crates/math/src/ntt/tests_evaluation.rs
@@ -147,8 +147,8 @@ impl<F: Field> Mul<&Polynomial<F>> for &Polynomial<F> {
 }
 
 // Polynomial *= &Polynomial
-impl<F: Field> MulAssign<&Polynomial<F>> for Polynomial<F> {
-	fn mul_assign(&mut self, other: &Polynomial<F>) {
+impl<F: Field> MulAssign<&Self> for Polynomial<F> {
+	fn mul_assign(&mut self, other: &Self) {
 		*self = &*self * other;
 	}
 }
@@ -188,7 +188,7 @@ impl<F: Field> MulAssign<F> for Polynomial<F> {
 /// Computes the subspace polynomial of a given binary field subspace $V$.
 ///
 /// That is, it computes $\prod_{a \in V} (X - a)$.
-fn subspace_polynomial<F: BinaryField>(subspace: BinarySubspace<F>) -> Polynomial<F> {
+fn subspace_polynomial<F: BinaryField>(subspace: &BinarySubspace<F>) -> Polynomial<F> {
 	let mut poly = Polynomial::one();
 
 	for elem in subspace.iter() {
@@ -220,22 +220,22 @@ fn novel_basis<DC: DomainContext>(domain_context: &DC) -> Vec<Polynomial<DC::Fie
 	// collect subspace polynomials $W_i$ (this is *not* yet $\hat{W}_i$)
 	let mut w_hat: Vec<_> = (0..log_d)
 		.map(|i| domain.reduce_dim(i))
-		.map(subspace_polynomial)
+		.map(|s| subspace_polynomial(&s))
 		.collect();
 	// and normalize them to get $\hat{W}_i$
-	for i in 0..log_d {
+	for (i, w_hat_i) in w_hat.iter_mut().enumerate().take(log_d) {
 		let beta_i = domain.basis()[i];
-		let eval = w_hat[i].evaluate(beta_i);
+		let eval = w_hat_i.evaluate(beta_i);
 		// Safety: `eval` is the normalization value $\hat{W}_i(\beta_i)$, non-zero by construction.
-		w_hat[i] *= unsafe { eval.invert() };
+		*w_hat_i *= unsafe { eval.invert() };
 	}
 
 	// construct novel polynomial basis
 	let mut novel_basis = Vec::with_capacity(1 << log_d);
 	novel_basis.push(Polynomial::one());
-	for i in 0..log_d {
+	for w_hat_i in w_hat.iter().take(log_d) {
 		for j in 0..novel_basis.len() {
-			novel_basis.push(&novel_basis[j] * &w_hat[i])
+			novel_basis.push(&novel_basis[j] * w_hat_i);
 		}
 	}
 
@@ -264,7 +264,7 @@ fn test_equivalence<F: BinaryField, NTT: AdditiveNTT<Field = F>>(ntt: &NTT) {
 		.collect();
 
 	// way 2 to compute evaluations: use NTT
-	let mut ntt_data = novel_coeffs.clone();
+	let mut ntt_data = novel_coeffs;
 	ntt.forward_transform(ntt_data.to_mut(), 0, 0);
 
 	// check equivalence

--- a/crates/math/src/ntt/tests_reference.rs
+++ b/crates/math/src/ntt/tests_reference.rs
@@ -23,8 +23,8 @@ use crate::{
 
 fn test_transform_equivalence<P: PackedField>(
 	mut rng: impl Rng,
-	reference: impl Fn(FieldSliceMut<P>, usize, usize),
-	transform: impl Fn(FieldSliceMut<P>, usize, usize),
+	reference: impl Fn(FieldSliceMut<'_, P>, usize, usize),
+	transform: impl Fn(FieldSliceMut<'_, P>, usize, usize),
 	log_n: usize,
 ) {
 	let half_rounds = log_n / 2;
@@ -185,7 +185,7 @@ impl<F: BinaryField> NTTFactory<F> for NeighborsLastMultiThreadFactory {
 	NeighborsLastMultiThreadFactory { log_base_len: 3, log_num_shares: 1000 }
 )]
 fn test_forward_transform_is_identity(#[case] ntt_factory: impl NTTFactory<B128>) {
-	fn test_forward_transform_is_identity_helper<F, P>(ntt_factory: impl NTTFactory<F>)
+	fn test_forward_transform_is_identity_helper<F, P>(ntt_factory: &impl NTTFactory<F>)
 	where
 		F: BinaryField,
 		P: PackedField<Scalar = F>,
@@ -204,7 +204,7 @@ fn test_forward_transform_is_identity(#[case] ntt_factory: impl NTTFactory<B128>
 		assert_eq!(data, data_clone);
 	}
 
-	test_forward_transform_is_identity_helper::<_, Packed128b>(ntt_factory);
+	test_forward_transform_is_identity_helper::<_, Packed128b>(&ntt_factory);
 }
 
 fn test_equivalence_ntts_domain_contexts<P: PackedField>()

--- a/crates/math/src/reed_solomon.rs
+++ b/crates/math/src/reed_solomon.rs
@@ -126,7 +126,7 @@ impl<F: BinaryField> ReedSolomonCode<F> {
 	pub fn encode_batch<P, NTT>(
 		&self,
 		ntt: &NTT,
-		data: FieldSlice<P>,
+		data: &FieldSlice<'_, P>,
 		log_batch_size: usize,
 	) -> FieldBuffer<P>
 	where
@@ -240,7 +240,7 @@ mod tests {
 		let message = random_field_buffer::<P>(&mut rng, log_dim + log_batch_size);
 
 		// Test the new encode_batch interface
-		let encoded_buffer = rs_code.encode_batch(&ntt, message.to_ref(), log_batch_size);
+		let encoded_buffer = rs_code.encode_batch(&ntt, &message.to_ref(), log_batch_size);
 
 		// Method 2: Reference implementation - apply NTT with zero-padded coefficients to the
 		// bit-reversal permuted message.
@@ -329,8 +329,8 @@ mod tests {
 			msg_large.set(i, val);
 		}
 
-		let enc_small = rs_small.encode_batch(&ntt, msg_small.to_ref(), 0);
-		let enc_large = rs_large.encode_batch(&ntt, msg_large.to_ref(), 0);
+		let enc_small = rs_small.encode_batch(&ntt, &msg_small.to_ref(), 0);
+		let enc_large = rs_large.encode_batch(&ntt, &msg_large.to_ref(), 0);
 
 		let small_scalars = enc_small.iter_scalars().collect::<Vec<_>>();
 		let large_scalars = enc_large.iter_scalars().collect::<Vec<_>>();

--- a/crates/math/src/tensor_algebra.rs
+++ b/crates/math/src/tensor_algebra.rs
@@ -76,7 +76,7 @@ where
 	}
 
 	/// Multiply by an element from the vertical subring.
-	pub fn scale_vertical(mut self, scalar: FE) -> Self {
+	pub fn scale_vertical(mut self, scalar: &FE) -> Self {
 		for elem_i in &mut self.elems {
 			*elem_i *= scalar.clone();
 		}
@@ -88,7 +88,7 @@ where
 	/// Internally, this performs a transpose, vertical scaling, then transpose sequence. If
 	/// multiple horizontal scaling operations are required and performance is a concern, it may be
 	/// better for the caller to do the transposes directly and amortize their cost.
-	pub fn scale_horizontal(self, scalar: FE) -> Self {
+	pub fn scale_horizontal(self, scalar: &FE) -> Self {
 		self.transpose().scale_vertical(scalar).transpose()
 	}
 
@@ -233,7 +233,7 @@ mod tests {
 		let vert = FE::random(&mut rng);
 		let hztl = FE::random(&mut rng);
 
-		let expected = TensorAlgebra::<F, _>::from_vertical(vert).scale_horizontal(hztl);
+		let expected = TensorAlgebra::<F, _>::from_vertical(vert).scale_horizontal(&hztl);
 		assert_eq!(TensorAlgebra::tensor(vert, hztl), expected);
 	}
 
@@ -250,18 +250,18 @@ mod tests {
 
 		// Scale horizontally by an extension element, and we should no longer be vertical.
 		let hztl = FE::new(1111);
-		let elem = elem.scale_horizontal(hztl);
+		let elem = elem.scale_horizontal(&hztl);
 		assert_eq!(elem.try_extract_vertical(), None);
 
 		// Scale back by the inverse to get back to the vertical subring.
 		// Safety: `hztl` is the non-zero constant 1111.
 		let hztl_inv = unsafe { hztl.invert() };
-		let elem = elem.scale_horizontal(hztl_inv);
+		let elem = elem.scale_horizontal(&hztl_inv);
 		assert_eq!(elem.try_extract_vertical(), Some(vert));
 
 		// If we scale horizontally by an F element, we should remain in the vertical subring.
 		let hztl_subfield = FE::from(F::ONE);
-		let elem = elem.scale_horizontal(hztl_subfield);
+		let elem = elem.scale_horizontal(&hztl_subfield);
 		assert_eq!(elem.try_extract_vertical(), Some(vert * hztl_subfield));
 	}
 }

--- a/crates/math/src/univariate.rs
+++ b/crates/math/src/univariate.rs
@@ -10,7 +10,7 @@ use super::{BinarySubspace, FieldBuffer};
 /// # Arguments
 /// * `coeffs` - Slice of coefficients ordered from low-degree terms to high-degree terms
 /// * `x` - Point at which to evaluate the polynomial
-pub fn evaluate_univariate<F: FieldOps>(coeffs: &[F], x: F) -> F {
+pub fn evaluate_univariate<F: FieldOps>(coeffs: &[F], x: &F) -> F {
 	let Some((highest_degree, rest)) = coeffs.split_last() else {
 		return F::zero();
 	};
@@ -18,7 +18,7 @@ pub fn evaluate_univariate<F: FieldOps>(coeffs: &[F], x: F) -> F {
 	// Evaluate using Horner's method
 	rest.iter()
 		.rev()
-		.fold(highest_degree.clone(), |acc, coeff| acc * &x + coeff)
+		.fold(highest_degree.clone(), |acc, coeff| acc * x + coeff)
 }
 
 /// Optimized Lagrange evaluation for power-of-2 domains in binary fields.
@@ -44,7 +44,7 @@ pub fn evaluate_univariate<F: FieldOps>(coeffs: &[F], x: F) -> F {
 ///
 /// # Returns
 /// A vector of Lagrange polynomial evaluations, one for each domain element
-pub fn lagrange_evals<F: BinaryField>(subspace: &BinarySubspace<F>, z: F) -> FieldBuffer<F> {
+pub fn lagrange_evals<F: BinaryField>(subspace: &BinarySubspace<F>, z: &F) -> FieldBuffer<F> {
 	let result = lagrange_evals_scalars(subspace, z);
 	FieldBuffer::new(subspace.dim(), result.into_boxed_slice())
 }
@@ -62,7 +62,7 @@ pub fn lagrange_evals<F: BinaryField>(subspace: &BinarySubspace<F>, z: F) -> Fie
 /// A vector of Lagrange polynomial evaluations, one for each domain element
 pub fn lagrange_evals_scalars<F: BinaryField, E: FieldOps + From<F>>(
 	subspace: &BinarySubspace<F>,
-	z: E,
+	z: &E,
 ) -> Vec<E> {
 	let domain: Vec<E> = subspace.iter().map(E::from).collect();
 	let n = domain.len();
@@ -112,7 +112,7 @@ pub fn lagrange_evals_scalars<F: BinaryField, E: FieldOps + From<F>>(
 pub fn extrapolate_over_subspace<F: BinaryField, E: FieldOps + From<F>>(
 	subspace: &BinarySubspace<F>,
 	values: &[E],
-	z: E,
+	z: &E,
 ) -> E {
 	let n = 1 << subspace.dim();
 	assert_eq!(values.len(), n);
@@ -161,11 +161,11 @@ impl<F: Field> EvaluationDomain<F> {
 		Self { points, weights }
 	}
 
-	pub fn size(&self) -> usize {
+	pub const fn size(&self) -> usize {
 		self.points.len()
 	}
 
-	pub fn points(&self) -> &[F] {
+	pub const fn points(&self) -> &[F] {
 		self.points.as_slice()
 	}
 
@@ -270,7 +270,7 @@ mod tests {
 			let coeffs = random_scalars(&mut rng, n_coeffs);
 			let x = F::random(&mut rng);
 			assert_eq!(
-				evaluate_univariate(&coeffs, x),
+				evaluate_univariate(&coeffs, &x),
 				evaluate_univariate_with_powers(&coeffs, x)
 			);
 		}
@@ -288,7 +288,7 @@ mod tests {
 
 			// Test 1: Partition of Unity - Lagrange polynomials sum to 1
 			let eval_point = F::random(&mut rng);
-			let lagrange_coeffs = lagrange_evals(&subspace, eval_point);
+			let lagrange_coeffs = lagrange_evals(&subspace, &eval_point);
 			let sum: F = lagrange_coeffs.as_ref().iter().copied().sum();
 			assert_eq!(
 				sum,
@@ -299,7 +299,7 @@ mod tests {
 
 			// Test 2: Interpolation Property - L_i(x_j) = δ_ij
 			for (j, &domain_point) in domain.iter().enumerate() {
-				let lagrange_at_domain = lagrange_evals(&subspace, domain_point);
+				let lagrange_at_domain = lagrange_evals(&subspace, &domain_point);
 				for (i, &coeff) in lagrange_at_domain.as_ref().iter().enumerate() {
 					let expected = if i == j { F::ONE } else { F::ZERO };
 					assert_eq!(
@@ -319,15 +319,15 @@ mod tests {
 		// Evaluate polynomial at domain points
 		let domain_evals: Vec<F> = domain
 			.iter()
-			.map(|&point| evaluate_univariate(&coeffs, point))
+			.map(|&point| evaluate_univariate(&coeffs, &point))
 			.collect();
 
 		// Test interpolation at random point
 		let test_point = F::random(&mut rng);
-		let lagrange_coeffs = lagrange_evals(&subspace, test_point);
+		let lagrange_coeffs = lagrange_evals(&subspace, &test_point);
 		let interpolated =
 			inner_product(domain_evals.iter().copied(), lagrange_coeffs.iter_scalars());
-		let direct = evaluate_univariate(&coeffs, test_point);
+		let direct = evaluate_univariate(&coeffs, &test_point);
 
 		assert_eq!(interpolated, direct, "Polynomial interpolation accuracy failed");
 	}
@@ -344,11 +344,11 @@ mod tests {
 		let values = domain
 			.points()
 			.iter()
-			.map(|&x| evaluate_univariate(&coeffs, x))
+			.map(|&x| evaluate_univariate(&coeffs, &x))
 			.collect::<Vec<_>>();
 
 		let x = B128::random(&mut rng);
-		let expected_y = evaluate_univariate(&coeffs, x);
+		let expected_y = evaluate_univariate(&coeffs, &x);
 		assert_eq!(domain.extrapolate(&values, x), expected_y);
 	}
 
@@ -378,13 +378,13 @@ mod tests {
 			// Evaluate at all domain points
 			let values: Vec<F> = subspace
 				.iter()
-				.map(|point| evaluate_univariate(&coeffs, point))
+				.map(|point| evaluate_univariate(&coeffs, &point))
 				.collect();
 
 			// Extrapolate at a random point
 			let z = F::random(&mut rng);
-			let extrapolated = extrapolate_over_subspace(&subspace, &values, z);
-			let expected = evaluate_univariate(&coeffs, z);
+			let extrapolated = extrapolate_over_subspace(&subspace, &values, &z);
+			let expected = evaluate_univariate(&coeffs, &z);
 
 			assert_eq!(extrapolated, expected, "Mismatch for log_domain_size={log_domain_size}");
 		}
@@ -402,8 +402,8 @@ mod tests {
 			let values: Vec<F> = random_scalars(&mut rng, n);
 
 			let z = F::random(&mut rng);
-			let extrapolated = extrapolate_over_subspace(&subspace, &values, z);
-			let lagrange = lagrange_evals_scalars(&subspace, z);
+			let extrapolated = extrapolate_over_subspace(&subspace, &values, &z);
+			let lagrange = lagrange_evals_scalars(&subspace, &z);
 			let expected = inner_product(values.iter().copied(), lagrange);
 
 			assert_eq!(extrapolated, expected, "Mismatch for log_domain_size={log_domain_size}");
@@ -416,7 +416,7 @@ mod tests {
 
 		// Create a small domain
 		let domain_points: Vec<B128> = (0..10).map(|_| B128::random(&mut rng)).collect();
-		let evaluation_domain = EvaluationDomain::from_points(domain_points.clone());
+		let evaluation_domain = EvaluationDomain::from_points(domain_points);
 
 		// Create random values for interpolation
 		let values: Vec<B128> = (0..10).map(|_| B128::random(&mut rng)).collect();

--- a/crates/prover/benches/and_reduction.rs
+++ b/crates/prover/benches/and_reduction.rs
@@ -82,7 +82,7 @@ fn bench(c: &mut Criterion) {
 
 	group.bench_function(format!("univariate fold 2^{log_words}"), |bench| {
 		bench.iter(|| {
-			let lagrange_evals = lagrange_evals_scalars(&univariate_domain, univariate_challenge);
+			let lagrange_evals = lagrange_evals_scalars(&univariate_domain, &univariate_challenge);
 			let transform =
 				OutputWrappingTransformationFactory::new(BytewiseLookupTransformationFactory)
 					.create(&lagrange_evals);
@@ -92,7 +92,7 @@ fn bench(c: &mut Criterion) {
 		});
 	});
 
-	let lagrange_evals = lagrange_evals_scalars(&univariate_domain, univariate_challenge);
+	let lagrange_evals = lagrange_evals_scalars(&univariate_domain, &univariate_challenge);
 	let transform = OutputWrappingTransformationFactory::new(BytewiseLookupTransformationFactory)
 		.create(&lagrange_evals);
 	let proving_polys = [&a_words, &b_words, &c_words]
@@ -105,7 +105,7 @@ fn bench(c: &mut Criterion) {
 	let next_round_claim = extrapolate_over_subspace(
 		&prover_message_domain.clone().isomorphic::<B128>(),
 		&univariate_message_coeffs,
-		univariate_challenge,
+		&univariate_challenge,
 	);
 
 	group.bench_function(format!("remaining zerocheck 2^{log_words}"), |bench| {
@@ -123,7 +123,7 @@ fn bench(c: &mut Criterion) {
 					proving_polys,
 					|[a, b, c]| a * b - c,
 					|[a, b, _]| a * b,
-					multilinear_zerocheck_challenges,
+					&multilinear_zerocheck_challenges,
 					next_round_claim,
 				)
 				.expect("multilinears should have consistent dimensions");

--- a/crates/prover/benches/batch_quadratic_mle.rs
+++ b/crates/prover/benches/batch_quadratic_mle.rs
@@ -115,7 +115,7 @@ fn bench_batch_quadratic_mlecheck_prove(c: &mut Criterion) {
 						multilinears,
 						batch_comp::<P>,
 						batch_inf_comp::<P>,
-						eval_point,
+						&eval_point,
 						eval_claims,
 					)
 					.unwrap();

--- a/crates/prover/benches/intmul.rs
+++ b/crates/prover/benches/intmul.rs
@@ -53,7 +53,7 @@ fn bench_intmul_prove(c: &mut Criterion) {
 		BenchmarkId::new("witness", num_exponents),
 		&num_exponents,
 		|bencher, _| {
-			bencher.iter(|| Witness::<P, _, _>::new(LOG_BITS, &a, &b, &c_lo, &c_hi).unwrap())
+			bencher.iter(|| Witness::<P, _, _>::new(LOG_BITS, &a, &b, &c_lo, &c_hi).unwrap());
 		},
 	);
 
@@ -73,7 +73,7 @@ fn bench_intmul_prove(c: &mut Criterion) {
 					let mut intmul_prover = IntMulProver::new(0, &mut prover_transcript);
 					intmul_prover.prove(witness).unwrap();
 				},
-			)
+			);
 		},
 	);
 
@@ -88,7 +88,7 @@ fn bench_intmul_prove(c: &mut Criterion) {
 				let mut prover_transcript = ProverTranscript::<StdChallenger>::default();
 				let mut intmul_prover = IntMulProver::new(0, &mut prover_transcript);
 				intmul_prover.prove(witness).unwrap();
-			})
+			});
 		},
 	);
 

--- a/crates/prover/benches/shift_reduction.rs
+++ b/crates/prover/benches/shift_reduction.rs
@@ -118,7 +118,7 @@ fn bench_prove_and_verify(c: &mut Criterion) {
 					&mut prover_transcript,
 				)
 				.unwrap()
-			})
+			});
 		});
 
 		// Pre-run the prover to get the transcript for verifier benchmarking
@@ -157,7 +157,7 @@ fn bench_prove_and_verify(c: &mut Criterion) {
 
 				verify(&cs, &verifier_bitand_data, &verifier_intmul_data, &mut verifier_transcript)
 					.unwrap();
-			})
+			});
 		});
 	}
 }

--- a/crates/prover/benches/sumcheck.rs
+++ b/crates/prover/benches/sumcheck.rs
@@ -74,7 +74,7 @@ fn bench_mlecheck_prove(c: &mut Criterion) {
 						multilinears,
 						|[a, b]| a * b,
 						|[a, b]| a * b,
-						eval_point.clone(),
+						&eval_point,
 						eval_claim,
 					)
 					.unwrap();
@@ -117,7 +117,7 @@ fn bench_mlecheck_prove(c: &mut Criterion) {
 						multilinears,
 						|[a, b, c]| a * b - c,
 						|[a, b, _c]| a * b,
-						eval_point.clone(),
+						&eval_point,
 						eval_claim,
 					)
 					.unwrap();

--- a/crates/prover/src/and_reduction/ntt_lookup.rs
+++ b/crates/prover/src/and_reduction/ntt_lookup.rs
@@ -107,7 +107,7 @@ impl NTTLookup {
 		});
 
 		let lookup = lde_mat.map(expand_subset_sums_array::<_, 8, 256>);
-		NTTLookup(Box::new(lookup))
+		Self(Box::new(lookup))
 	}
 
 	/// Computes the LDE of 64 1-bit coefficients using the precomputed lookup tables.
@@ -135,8 +135,8 @@ impl NTTLookup {
 
 		let mut out = Packed64xB8::default();
 		// This will get unrolled, so indexing arithmetic washes away.
-		for b in 0..8 {
-			let packed = &self.0[b % 2][input_bytes[b] as usize];
+		for (b, &input_byte) in input_bytes.iter().enumerate() {
+			let packed = &self.0[b % 2][input_byte as usize];
 			let bitvec = packed.to_underlier_ref();
 			let dst_bitvec = Divisible::<M128>::from_iter(
 				(0..4).map(|i| Divisible::<M128>::get(bitvec, i ^ (b / 2))),

--- a/crates/prover/src/and_reduction/prover.rs
+++ b/crates/prover/src/and_reduction/prover.rs
@@ -82,7 +82,7 @@ where
 		second_col: Vec<Word>,
 		third_col: Vec<Word>,
 		big_field_zerocheck_challenges: Vec<F>,
-		prover_message_domain: BinarySubspace<B8>,
+		prover_message_domain: &BinarySubspace<B8>,
 	) -> Self {
 		let univariate_round_message = tracing::debug_span!("Compute univariate round message")
 			.in_scope(|| {
@@ -92,7 +92,7 @@ where
 					&second_col,
 					&third_col,
 					&big_field_zerocheck_challenges,
-					&prover_message_domain,
+					prover_message_domain,
 				)
 			});
 
@@ -125,7 +125,7 @@ where
 	///
 	/// The polynomial evaluations are precomputed in the constructor using the NTT lookup table
 	/// for efficiency. This method simply returns the cached result.
-	pub fn execute(&self) -> &[F; ROWS_PER_HYPERCUBE_VERTEX] {
+	pub const fn execute(&self) -> &[F; ROWS_PER_HYPERCUBE_VERTEX] {
 		&self.univariate_round_message
 	}
 
@@ -157,8 +157,8 @@ where
 	/// 5. Constructs the AND reduction sumcheck prover with the folded multilinears
 	pub fn fold_and_send_reduced_prover(
 		self,
-		round_message_domain: BinarySubspace<F>,
-		challenge: F,
+		round_message_domain: &BinarySubspace<F>,
+		challenge: &F,
 	) -> impl MleCheckProver<F> {
 		let univariate_domain = round_message_domain.reduce_dim(round_message_domain.dim() - 1);
 		let lagrange_evals = lagrange_evals_scalars(&univariate_domain, challenge);
@@ -188,12 +188,8 @@ where
 			proving_polys,
 			|[a, b, c]| a * b - c,
 			|[a, b, _]| a * b,
-			verifier_field_zerocheck_challenges,
-			extrapolate_over_subspace(
-				&round_message_domain,
-				&first_round_message_coeffs,
-				challenge,
-			),
+			&verifier_field_zerocheck_challenges,
+			extrapolate_over_subspace(round_message_domain, &first_round_message_coeffs, challenge),
 		)
 		.expect("multilinears should have consistent dimensions")
 	}
@@ -238,8 +234,8 @@ where
 		let univariate_round_message_domain = self.univariate_round_message_domain.clone();
 		let sumcheck_prover = tracing::debug_span!("Fold univariate round").in_scope(|| {
 			self.fold_and_send_reduced_prover(
-				univariate_round_message_domain,
-				univariate_sumcheck_challenge,
+				&univariate_round_message_domain,
+				&univariate_sumcheck_challenge,
 			)
 		});
 
@@ -327,7 +323,7 @@ mod test {
 			second_mlv.clone(),
 			third_mlv.clone(),
 			big_field_zerocheck_challenges.to_vec(),
-			prover_message_domain.clone(),
+			&prover_message_domain,
 		);
 
 		let prove_output = prover.prove_with_channel(&mut prover_challenger).unwrap();
@@ -369,7 +365,7 @@ mod test {
 		let one_bit_mlvs = [first_mlv, second_mlv, third_mlv];
 
 		let verifier_lagrange_evals =
-			lagrange_evals_scalars(&verifier_univariate_domain, z_challenge);
+			lagrange_evals_scalars(&verifier_univariate_domain, &z_challenge);
 		let verifier_transparent_transform =
 			OutputWrappingTransformationFactory::new(BytewiseLookupTransformationFactory)
 				.create(&verifier_lagrange_evals);

--- a/crates/prover/src/and_reduction/sumcheck_round_messages.rs
+++ b/crates/prover/src/and_reduction/sumcheck_round_messages.rs
@@ -181,7 +181,7 @@ where
 }
 
 /// Represents a precomputed multiplication map by an extension field constant for
-/// [`B8`].`
+/// [`B8`].
 ///
 /// Multiplication by a constant for a binary field is an $\mathbb{F}_2$-linear transform. For small
 /// inputs, such as $\mathbb{F}_{2^8}$ elements, this can be represented by a small lookup table.
@@ -201,7 +201,7 @@ impl<F: BinaryField + From<B8>> B8ToExtMulMap<F> {
 	}
 
 	#[inline]
-	fn call(&self, input: B8) -> F {
+	const fn call(&self, input: B8) -> F {
 		self.lookup[input.val() as usize]
 	}
 }
@@ -295,11 +295,11 @@ mod test {
 		let expected_next_round_sum = extrapolate_over_subspace(
 			&verifier_message_domain,
 			&first_round_message_coeffs,
-			first_sumcheck_challenge,
+			&first_sumcheck_challenge,
 		);
 
 		let lagrange_evals =
-			lagrange_evals_scalars(&verifier_input_domain, first_sumcheck_challenge);
+			lagrange_evals_scalars(&verifier_input_domain, &first_sumcheck_challenge);
 		let transform =
 			OutputWrappingTransformationFactory::new(BytewiseLookupTransformationFactory)
 				.create(&lagrange_evals);

--- a/crates/prover/src/fold_word.rs
+++ b/crates/prover/src/fold_word.rs
@@ -303,9 +303,9 @@ mod tests {
 				P::from_scalars(word_chunk.iter().map(|&word| {
 					// Decompose word into bits and compute inner product
 					let mut sum = F::ZERO;
-					for bit_idx in 0..WORD_SIZE_BITS {
+					for (bit_idx, &vec_bit) in vec.iter().enumerate() {
 						if (word.as_u64() >> bit_idx) & 1 == 1 {
-							sum += vec[bit_idx];
+							sum += vec_bit;
 						}
 					}
 					sum
@@ -363,11 +363,11 @@ mod tests {
 
 			// out[i][j][k] = in[k][j][i]: bit `BITS_PER_BYTE * j + k` of output word `i` equals bit
 			// `BITS_PER_BYTE * j + i` of input word `k`.
-			for i in 0..BITS_PER_BYTE {
+			for (i, output_i) in output.iter().enumerate() {
 				for j in 0..WORD_SIZE_BYTES {
-					for k in 0..BITS_PER_BYTE {
-						let out_bit = (output[i].as_u64() >> (BITS_PER_BYTE * j + k)) & 1;
-						let in_bit = (input[k].as_u64() >> (BITS_PER_BYTE * j + i)) & 1;
+					for (k, input_k) in input.iter().enumerate() {
+						let out_bit = (output_i.as_u64() >> (BITS_PER_BYTE * j + k)) & 1;
+						let in_bit = (input_k.as_u64() >> (BITS_PER_BYTE * j + i)) & 1;
 						assert_eq!(out_bit, in_bit, "mismatch at i={i}, j={j}, k={k}");
 					}
 				}

--- a/crates/prover/src/protocols/inout_check.rs
+++ b/crates/prover/src/protocols/inout_check.rs
@@ -47,7 +47,7 @@ impl<F: Field, P: PackedField<Scalar = F>> InOutCheckProver<P> {
 
 		let gruen32 = Gruen32::new(eval_point);
 		let public = witness.chunk(log_public, 0);
-		let public_eval = Self::evaluate_multilinear_with_gruen32(&gruen32, public);
+		let public_eval = Self::evaluate_multilinear_with_gruen32(&gruen32, &public);
 
 		Self {
 			log_public,
@@ -75,7 +75,7 @@ impl<F: Field, P: PackedField<Scalar = F>> InOutCheckProver<P> {
 			.witness
 			.chunk(n_vars, 1 << (self.witness.log_len() - n_vars - 1));
 
-		Self::evaluate_multilinear_with_gruen32(&self.gruen32, truncated_witness)
+		Self::evaluate_multilinear_with_gruen32(&self.gruen32, &truncated_witness)
 	}
 
 	/// Computes the round evaluation for the last m rounds.
@@ -95,7 +95,7 @@ impl<F: Field, P: PackedField<Scalar = F>> InOutCheckProver<P> {
 		inner_product_buffers(&witness_1, eq_expansion)
 	}
 
-	fn evaluate_multilinear_with_gruen32(gruen32: &Gruen32<P>, multilin: FieldSlice<P>) -> F {
+	fn evaluate_multilinear_with_gruen32(gruen32: &Gruen32<P>, multilin: &FieldSlice<'_, P>) -> F {
 		assert_eq!(gruen32.n_vars_remaining(), multilin.log_len());
 
 		if multilin.log_len() == 0 {
@@ -189,7 +189,7 @@ where
 		let n_vars = self.n_vars();
 		assert!(n_vars > 0);
 
-		let eval = coeffs.evaluate(challenge);
+		let eval = coeffs.evaluate(&challenge);
 
 		// Always fold the witness
 		fold_highest_var_inplace(&mut self.witness, challenge);

--- a/crates/prover/src/protocols/intmul/prove.rs
+++ b/crates/prover/src/protocols/intmul/prove.rs
@@ -57,7 +57,7 @@ pub struct IntMulProver<'a, P, S, Channel> {
 }
 
 impl<'a, P, S, Channel> IntMulProver<'a, P, S, Channel> {
-	pub fn new(switchover: usize, channel: &'a mut Channel) -> Self {
+	pub const fn new(switchover: usize, channel: &'a mut Channel) -> Self {
 		Self {
 			_p_marker: PhantomData,
 			_s_marker: PhantomData,
@@ -78,9 +78,9 @@ where
 	///
 	/// This method consumes a `Witness` in order to reduce integer multiplication statement to
 	/// evaluation claims on 1-bit multilinears. More formally:
-	///  * `witness` contains po2-sized integer arrays  `a`, `b`, `c_lo` and `c_hi` that satisfy `a
-	///    * b = c_lo | c_hi << (1 << log_bits)`, as well as the layers of the constant- and
-	///      variable-base GKR product check circuits
+	///  * `witness` contains po2-sized integer arrays `a`, `b`, `c_lo` and `c_hi` that satisfy `a *
+	///    b = c_lo | c_hi << (1 << log_bits)`, as well as the layers of the constant- and
+	///    variable-base GKR product check circuits
 	///  * The proving consists of five phases:
 	///    - Phase 1: GKR tree roots for B & C are evaluated at a sampled point, after which
 	///      reductions are performed to obtain evaluation claims on $(b * (G^{a_i} - 1) + 1)^{2^i}$
@@ -256,7 +256,7 @@ where
 			SelectorMlecheckProver::new(selector, selector_claims, b_exponents, self.switchover)?;
 
 		let c_root_sumcheck_prover =
-			bivariate_product_mle::new(c_lo_hi_roots, c_eval_point.to_vec(), c_root_eval)?;
+			bivariate_product_mle::new(c_lo_hi_roots, c_eval_point, c_root_eval)?;
 
 		let c_root_prover = MleToSumCheckDecorator::new(c_root_sumcheck_prover);
 
@@ -405,7 +405,7 @@ where
 				[a_0, b_0, c_lo_0],
 				|[a, b, c]| a * b - c,
 				|[a, b, _c]| a * b,
-				b_eval_point.to_vec(),
+				b_eval_point,
 				F::ZERO,
 			)?);
 

--- a/crates/prover/src/protocols/intmul/witness.rs
+++ b/crates/prover/src/protocols/intmul/witness.rs
@@ -89,7 +89,7 @@ where
 
 		// Compute b_leaves as concatenated leaves for prodcheck
 		let variable_base = a.root().clone();
-		let b_leaves = compute_b_leaves(log_bits, variable_base, &b);
+		let b_leaves = compute_b_leaves(log_bits, &variable_base, &b);
 
 		// Create the prodcheck prover; its products layer becomes b_root
 		let (b_prodcheck, b_root) = ProdcheckProver::new(log_bits, b_leaves.clone());
@@ -116,7 +116,7 @@ where
 /// The leaves are concatenated: `[L_0, L_1, ..., L_{2^k-1}]`
 fn compute_b_leaves<F, P, B, S>(
 	log_bits: usize,
-	bases: FieldBuffer<P>,
+	bases: &FieldBuffer<P>,
 	exponents: &S,
 ) -> FieldBuffer<P>
 where
@@ -129,7 +129,7 @@ where
 
 	if P::LOG_WIDTH <= n_vars {
 		// Parallel optimized path
-		return compute_b_leaves_parallel(log_bits, &bases, exponents);
+		return compute_b_leaves_parallel(log_bits, bases, exponents);
 	}
 
 	// Fallback: bases is too small to parallelize (n_vars < P::LOG_WIDTH)
@@ -301,7 +301,7 @@ where
 		}
 	}
 
-	pub fn log_bits(&self) -> usize {
+	pub const fn log_bits(&self) -> usize {
 		self.tree.len() - 1
 	}
 

--- a/crates/prover/src/protocols/shift/key_collection.rs
+++ b/crates/prover/src/protocols/shift/key_collection.rs
@@ -27,7 +27,7 @@ use super::{BITAND_ARITY, INTMUL_ARITY, PreparedOperatorData};
 ///
 /// These operations work with shifted value indices to efficiently encode
 /// computations on 64-bit words without requiring separate shift constraints.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u16)]
 pub enum Operation {
 	BitwiseAnd,
@@ -316,8 +316,8 @@ pub fn build_key_collection(cs: &ConstraintSystem) -> KeyCollection {
 impl SerializeBytes for Operation {
 	fn serialize(&self, write_buf: impl BufMut) -> Result<(), SerializationError> {
 		let val = match self {
-			Operation::BitwiseAnd => 0u8,
-			Operation::IntegerMul => 1u8,
+			Self::BitwiseAnd => 0u8,
+			Self::IntegerMul => 1u8,
 		};
 		val.serialize(write_buf)
 	}
@@ -327,8 +327,8 @@ impl DeserializeBytes for Operation {
 	fn deserialize(mut read_buf: impl Buf) -> Result<Self, SerializationError> {
 		let val = u8::deserialize(&mut read_buf)?;
 		match val {
-			0 => Ok(Operation::BitwiseAnd),
-			1 => Ok(Operation::IntegerMul),
+			0 => Ok(Self::BitwiseAnd),
+			1 => Ok(Self::IntegerMul),
 			_ => Err(SerializationError::UnknownEnumVariant {
 				name: "Operation",
 				index: val,
@@ -352,7 +352,7 @@ impl DeserializeBytes for Key {
 		let id = u16::deserialize(&mut read_buf)?;
 		let start = u32::deserialize(&mut read_buf)?;
 		let end = u32::deserialize(&mut read_buf)?;
-		Ok(Key {
+		Ok(Self {
 			operation,
 			id,
 			range: start..end,
@@ -371,7 +371,7 @@ impl DeserializeBytes for ConstraintIndex {
 	fn deserialize(mut read_buf: impl Buf) -> Result<Self, SerializationError> {
 		let operand_index = u8::deserialize(&mut read_buf)?;
 		let constraint_index = u32::deserialize(&mut read_buf)?;
-		Ok(ConstraintIndex {
+		Ok(Self {
 			operand_index,
 			constraint_index,
 		})
@@ -420,7 +420,7 @@ impl DeserializeBytes for KeyCollection {
 
 		let constraint_indices = Vec::<ConstraintIndex>::deserialize(&mut read_buf)?;
 
-		Ok(KeyCollection {
+		Ok(Self {
 			keys,
 			key_ranges,
 			constraint_indices,

--- a/crates/prover/src/protocols/shift/monster.rs
+++ b/crates/prover/src/protocols/shift/monster.rs
@@ -32,7 +32,7 @@ use super::{
 /// Used in phase 1, thus returning an array of multilinear evaluations.
 #[instrument(skip_all, name = "build_h_parts")]
 pub fn build_h_parts<F, P: PackedField<Scalar = F>>(
-	r_zhat_prime: F,
+	r_zhat_prime: &F,
 ) -> [FieldBuffer<P>; SHIFT_VARIANT_COUNT]
 where
 	F: BinaryField + From<AESTowerField8b>,
@@ -151,7 +151,7 @@ where
 		intmul_operator_data.r_zhat_prime,
 	]
 	.map(|r_zhat_prime| {
-		let l_tilde = lagrange_evals(&subspace, r_zhat_prime);
+		let l_tilde = lagrange_evals(&subspace, &r_zhat_prime);
 		evaluate_h_op(l_tilde.as_ref(), r_j, r_s)
 	});
 
@@ -162,10 +162,10 @@ where
 	let mut intmul_scalars = vec![F::ZERO; INTMUL_ARITY * SHIFT_VARIANT_COUNT * WORD_SIZE_BITS];
 
 	let populate_scalars = |scalars: &mut [F], arity: usize, lambda_powers: &[F], h_ops: &[F]| {
-		for operand_idx in 0..arity {
-			for op in 0..SHIFT_VARIANT_COUNT {
+		for (operand_idx, &lambda_power) in lambda_powers[..arity].iter().enumerate() {
+			for (op, &h_op) in h_ops[..SHIFT_VARIANT_COUNT].iter().enumerate() {
 				let operand_op_idx = operand_idx * SHIFT_VARIANT_COUNT + op;
-				let operand_op_scalar = lambda_powers[operand_idx] * h_ops[op];
+				let operand_op_scalar = lambda_power * h_op;
 				for s in 0..WORD_SIZE_BITS {
 					let operand_op_s_idx = operand_op_idx * WORD_SIZE_BITS + s;
 					scalars[operand_op_s_idx] = operand_op_scalar * r_s_tensor.as_ref()[s];
@@ -250,11 +250,11 @@ mod tests {
 			// Method 1: Succinct evaluation using `evaluate_h_op`
 			let subspace =
 				BinarySubspace::<AESTowerField8b>::with_dim(LOG_WORD_SIZE_BITS).isomorphic();
-			let l_tilde = lagrange_evals(&subspace, r_zhat_prime);
+			let l_tilde = lagrange_evals(&subspace, &r_zhat_prime);
 			let succinct_evaluations = evaluate_h_op(l_tilde.as_ref(), &r_j, &r_s);
 
 			// Method 2: Direct evaluation via multilinear part
-			let h_parts = build_h_parts(r_zhat_prime);
+			let h_parts = build_h_parts(&r_zhat_prime);
 			let evaluation_point: Vec<F> = [r_j.clone(), r_s.clone()].concat();
 			let tensor = eq_ind_partial_eval::<P>(&evaluation_point);
 			let direct_evaluations = h_parts.map(|buf| inner_product_buffers(&buf, &tensor));

--- a/crates/prover/src/protocols/shift/phase_1.rs
+++ b/crates/prover/src/protocols/shift/phase_1.rs
@@ -50,7 +50,7 @@ where
 	let g_parts = build_g_parts::<_, P>(words, key_collection, bitand_data, intmul_data)?;
 
 	// BitAnd and IntMul share the same `r_zhat_prime`.
-	let h_parts = build_h_parts(bitand_data.r_zhat_prime);
+	let h_parts = build_h_parts(&bitand_data.r_zhat_prime);
 
 	run_phase_1_sumcheck(g_parts, h_parts, channel)
 }

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -79,14 +79,14 @@ impl IOPProver {
 	}
 
 	/// Returns the constraint system.
-	pub fn constraint_system(&self) -> &ConstraintSystem {
+	pub const fn constraint_system(&self) -> &ConstraintSystem {
 		&self.constraint_system
 	}
 
 	/// Returns a reference to the KeyCollection.
 	///
 	/// This can be used to serialize the KeyCollection for later use.
-	pub fn key_collection(&self) -> &KeyCollection {
+	pub const fn key_collection(&self) -> &KeyCollection {
 		&self.key_collection
 	}
 
@@ -94,7 +94,7 @@ impl IOPProver {
 	///
 	/// This is the core proving logic, independent of the specific IOP compilation strategy.
 	/// For most users, [`Prover::prove`] is the simpler interface.
-	pub fn prove<P, Channel>(&self, witness: ValueVec, mut channel: Channel) -> Result<(), Error>
+	pub fn prove<P, Channel>(&self, witness: &ValueVec, mut channel: Channel) -> Result<(), Error>
 	where
 		P: PackedField<Scalar = B128> + PackedExtension<B128> + PackedExtension<B1>,
 		Channel: IOPProverChannel<P>,
@@ -130,7 +130,7 @@ impl IOPProver {
 			n_constraints = cs.mul_constraints.len()
 		)
 		.entered();
-		let mul_witness = build_intmul_witness(&cs.mul_constraints, &witness);
+		let mul_witness = build_intmul_witness(&cs.mul_constraints, witness);
 		let intmul_output = prove_intmul_reduction::<_, P, _>(mul_witness, &mut channel)?;
 		drop(intmul_guard);
 
@@ -143,7 +143,7 @@ impl IOPProver {
 		)
 		.entered();
 		let bitand_claim = {
-			let bitand_witness = build_bitand_witness(&cs.and_constraints, &witness);
+			let bitand_witness = build_bitand_witness(&cs.and_constraints, witness);
 			let AndCheckOutput {
 				a_eval,
 				b_eval,
@@ -173,7 +173,7 @@ impl IOPProver {
 
 			let r_zhat_prime = bitand_claim.r_zhat_prime;
 			let subspace = BinarySubspace::<B8>::with_dim(LOG_WORD_SIZE_BITS).isomorphic();
-			let l_tilde = lagrange_evals(&subspace, r_zhat_prime);
+			let l_tilde = lagrange_evals(&subspace, &r_zhat_prime);
 			let make_final_claim = |evals| inner_product(evals, l_tilde.iter_scalars());
 			OperatorData {
 				evals: vec![
@@ -307,27 +307,27 @@ where
 
 		let iop_prover = IOPProver::new(verifier.into_iop_verifier(), key_collection);
 
-		Ok(Prover {
+		Ok(Self {
 			iop_prover,
 			basefold_compiler,
 		})
 	}
 
 	/// Returns a reference to the IOP prover.
-	pub fn iop_prover(&self) -> &IOPProver {
+	pub const fn iop_prover(&self) -> &IOPProver {
 		&self.iop_prover
 	}
 
 	/// Returns a reference to the KeyCollection.
 	///
 	/// This can be used to serialize the KeyCollection for later use.
-	pub fn key_collection(&self) -> &KeyCollection {
+	pub const fn key_collection(&self) -> &KeyCollection {
 		self.iop_prover.key_collection()
 	}
 
 	pub fn prove<Challenger_: Challenger>(
 		&self,
-		witness: ValueVec,
+		witness: &ValueVec,
 		transcript: &mut ProverTranscript<Challenger_>,
 	) -> Result<(), Error> {
 		let cs = self.iop_prover.constraint_system();
@@ -451,7 +451,7 @@ where
 		b,
 		c,
 		big_field_zerocheck_challenges,
-		prover_message_domain.isomorphic(),
+		&prover_message_domain.isomorphic(),
 	);
 
 	Ok(prover.prove_with_channel(channel)?)

--- a/crates/prover/src/ring_switch.rs
+++ b/crates/prover/src/ring_switch.rs
@@ -226,7 +226,7 @@ where
 						expand_subset_sums_array::<_, CHUNK_BITS, { 1 << CHUNK_BITS }>(vec_scalars);
 
 					square_transpose_const_size::<_, LOG_CHUNK_BITS, CHUNK_BITS>(
-						mat_scalars
+						&mut mat_scalars
 							.each_mut()
 							.map(<B128 as PackedExtension<B1>>::cast_base_mut),
 					);
@@ -279,7 +279,7 @@ where
 /// * `LOG_N` must be less than or equal to `P::LOG_WIDTH`
 /// * `LOG_N` must be less than or equal to `log2(S)`
 fn square_transpose_const_size<P: PackedField, const LOG_N: usize, const S: usize>(
-	elems: [&mut P; S],
+	elems: &mut [&mut P; S],
 ) {
 	let log_size = checked_log_2(S);
 
@@ -491,7 +491,7 @@ mod test {
 				.map(|&bits_packed| P::cast_ext(bits_packed))
 				.collect(),
 		);
-		let folded_method2 = fold_elems_inplace(bit_matrix_packed.clone(), &prefix_tensor);
+		let folded_method2 = fold_elems_inplace(bit_matrix_packed, &prefix_tensor);
 		let method2_result = evaluate_inplace(folded_method2, suffix);
 
 		// Compare all three results

--- a/crates/prover/src/zk_config.rs
+++ b/crates/prover/src/zk_config.rs
@@ -60,7 +60,7 @@ where
 	Output<H::LeafHash>: SerializeBytes,
 {
 	/// Constructs a ZK prover from a [`ZKVerifier`].
-	pub fn setup(zk_verifier: ZKVerifier<H>) -> Result<Self, Error> {
+	pub fn setup(zk_verifier: &ZKVerifier<H>) -> Result<Self, Error> {
 		let key_collection = {
 			let _guard = tracing::debug_span!("Build key collection").entered();
 			build_key_collection(zk_verifier.inner_iop_verifier().constraint_system())
@@ -72,7 +72,7 @@ where
 	/// dominant key-collection build. Private: external callers use [`Self::setup`], or
 	/// [`DeserializeBytes::deserialize`] to reuse a serialized prover.
 	fn setup_with_key_collection(
-		zk_verifier: ZKVerifier<H>,
+		zk_verifier: &ZKVerifier<H>,
 		key_collection: KeyCollection,
 	) -> Result<Self, Error> {
 		// Build the inner IOPProver.
@@ -108,7 +108,7 @@ where
 				.blinding_info()
 				.clone(),
 		);
-		let outer_layout = outer_layout.with_blinding(outer_cs.blinding_info().clone());
+		let outer_layout = outer_layout.with_blinding(outer_cs.blinding_info());
 
 		let outer_iop_prover = binius_spartan_prover::IOPProver::new(outer_cs);
 
@@ -137,25 +137,22 @@ where
 	}
 
 	/// Returns a reference to the inner IOP prover.
-	pub fn inner_iop_prover(&self) -> &IOPProver {
+	pub const fn inner_iop_prover(&self) -> &IOPProver {
 		&self.inner_iop_prover
 	}
 
 	/// Returns a reference to the KeyCollection.
-	pub fn key_collection(&self) -> &crate::protocols::shift::KeyCollection {
+	pub const fn key_collection(&self) -> &crate::protocols::shift::KeyCollection {
 		self.inner_iop_prover.key_collection()
 	}
 
 	/// Generates a ZK proof for a witness.
 	pub fn prove<Challenger_: Challenger>(
 		&self,
-		witness: ValueVec,
+		witness: &ValueVec,
 		mut rng: impl CryptoRng,
 		transcript: &mut ProverTranscript<Challenger_>,
 	) -> Result<(), Error> {
-		// Clone public words before moving witness into prove().
-		let public_words = witness.public().to_vec();
-
 		// Create BaseFold prover channel and wrap with outer prover.
 		let basefold_channel = self.basefold_compiler.create_channel(transcript, &mut rng);
 		let mut wrapped_channel = ZKWrappedProverChannel::new(
@@ -167,7 +164,7 @@ where
 				let inner_iop_verifier = &self.inner_iop_verifier;
 				move |replay_channel: &mut ReplayChannel<'_, B128>| {
 					inner_iop_verifier
-						.verify(&public_words, replay_channel)
+						.verify(witness.public(), replay_channel)
 						.expect("replay verification should not fail");
 				}
 			},
@@ -210,7 +207,7 @@ where
 	/// [`Self::prove`] logic. See [`binius_verifier::signature`] for details.
 	pub fn prove_sig<Challenger_: Challenger>(
 		&self,
-		witness: ValueVec,
+		witness: &ValueVec,
 		message: &[u8],
 		rng: impl CryptoRng,
 		transcript: &mut ProverTranscript<Challenger_>,
@@ -267,7 +264,7 @@ where
 		let key_collection = KeyCollection::deserialize(&mut read_buf)?;
 		let zk_verifier = ZKVerifier::setup(constraint_system, log_inv_rate)
 			.map_err(|_| SerializationError::InvalidConstruction { name: "ZKProver" })?;
-		Self::setup_with_key_collection(zk_verifier, key_collection)
+		Self::setup_with_key_collection(&zk_verifier, key_collection)
 			.map_err(|_| SerializationError::InvalidConstruction { name: "ZKProver" })
 	}
 }

--- a/crates/prover/tests/prove_verify.rs
+++ b/crates/prover/tests/prove_verify.rs
@@ -15,7 +15,7 @@ use binius_utils::{DeserializeBytes, SerializeBytes};
 use binius_verifier::{Verifier, config::StdChallenger, zk_config::ZKVerifier};
 use rand::{SeedableRng, rngs::StdRng};
 
-fn prove_verify(cs: ConstraintSystem, witness: ValueVec) {
+fn prove_verify(cs: ConstraintSystem, witness: &ValueVec) {
 	const LOG_INV_RATE: usize = 1;
 
 	let verifier = Verifier::<StdHashSuite>::setup(cs, LOG_INV_RATE).unwrap();
@@ -23,9 +23,7 @@ fn prove_verify(cs: ConstraintSystem, witness: ValueVec) {
 	let prover = Prover::<OptimalPackedB128, StdHashSuite>::setup(verifier.clone()).unwrap();
 
 	let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
-	prover
-		.prove(witness.clone(), &mut prover_transcript)
-		.unwrap();
+	prover.prove(witness, &mut prover_transcript).unwrap();
 
 	let mut verifier_transcript = prover_transcript.into_verifier();
 	verifier
@@ -34,18 +32,17 @@ fn prove_verify(cs: ConstraintSystem, witness: ValueVec) {
 	verifier_transcript.finalize().unwrap();
 }
 
-fn prove_verify_zk(cs: ConstraintSystem, witness: ValueVec) {
+fn prove_verify_zk(cs: ConstraintSystem, witness: &ValueVec) {
 	const LOG_INV_RATE: usize = 1;
 
 	let zk_verifier = ZKVerifier::<StdHashSuite>::setup(cs, LOG_INV_RATE).unwrap();
 
-	let zk_prover =
-		ZKProver::<OptimalPackedB128, StdHashSuite>::setup(zk_verifier.clone()).unwrap();
+	let zk_prover = ZKProver::<OptimalPackedB128, StdHashSuite>::setup(&zk_verifier).unwrap();
 
 	let mut rng = StdRng::seed_from_u64(0);
 	let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 	zk_prover
-		.prove(witness.clone(), &mut rng, &mut prover_transcript)
+		.prove(witness, &mut rng, &mut prover_transcript)
 		.unwrap();
 
 	let mut verifier_transcript = prover_transcript.into_verifier();
@@ -55,12 +52,11 @@ fn prove_verify_zk(cs: ConstraintSystem, witness: ValueVec) {
 	verifier_transcript.finalize().unwrap();
 }
 
-fn prove_verify_zk_serialized(cs: ConstraintSystem, witness: ValueVec) {
+fn prove_verify_zk_serialized(cs: ConstraintSystem, witness: &ValueVec) {
 	const LOG_INV_RATE: usize = 1;
 
 	let zk_verifier = ZKVerifier::<StdHashSuite>::setup(cs, LOG_INV_RATE).unwrap();
-	let zk_prover =
-		ZKProver::<OptimalPackedB128, StdHashSuite>::setup(zk_verifier.clone()).unwrap();
+	let zk_prover = ZKProver::<OptimalPackedB128, StdHashSuite>::setup(&zk_verifier).unwrap();
 
 	// Round-trip both through serialization, mimicking save-to-disk / reload-in-a-fresh-process.
 	// The reloaded prover (which reuses the deserialized KeyCollection and recomputes the cheaper
@@ -77,7 +73,7 @@ fn prove_verify_zk_serialized(cs: ConstraintSystem, witness: ValueVec) {
 	let mut rng = StdRng::seed_from_u64(0);
 	let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 	zk_prover
-		.prove(witness.clone(), &mut rng, &mut prover_transcript)
+		.prove(witness, &mut rng, &mut prover_transcript)
 		.unwrap();
 
 	let mut verifier_transcript = prover_transcript.into_verifier();
@@ -129,19 +125,19 @@ fn sha256_preimage_circuit() -> (ConstraintSystem, ValueVec) {
 #[test]
 fn test_prove_verify_sha256_preimage() {
 	let (cs, witness) = sha256_preimage_circuit();
-	prove_verify(cs, witness);
+	prove_verify(cs, &witness);
 }
 
 #[test]
 fn test_zk_prove_verify_sha256_preimage() {
 	let (cs, witness) = sha256_preimage_circuit();
-	prove_verify_zk(cs, witness);
+	prove_verify_zk(cs, &witness);
 }
 
 #[test]
 fn test_zk_prove_verify_serialized() {
 	let (cs, witness) = sha256_preimage_circuit();
-	prove_verify_zk_serialized(cs, witness);
+	prove_verify_zk_serialized(cs, &witness);
 }
 
 /// Produces a ZK signature-of-knowledge proof over `sign_message`, then verifies it against
@@ -150,24 +146,23 @@ fn test_zk_prove_verify_serialized() {
 /// Signatures of knowledge are only supported by the ZK prover/verifier.
 fn sign_verify(
 	cs: ConstraintSystem,
-	witness: ValueVec,
+	witness: &ValueVec,
 	sign_message: Option<&[u8]>,
 	verify_message: Option<&[u8]>,
 ) -> bool {
 	const LOG_INV_RATE: usize = 1;
 
 	let zk_verifier = ZKVerifier::<StdHashSuite>::setup(cs, LOG_INV_RATE).unwrap();
-	let zk_prover =
-		ZKProver::<OptimalPackedB128, StdHashSuite>::setup(zk_verifier.clone()).unwrap();
+	let zk_prover = ZKProver::<OptimalPackedB128, StdHashSuite>::setup(&zk_verifier).unwrap();
 
 	let mut rng = StdRng::seed_from_u64(0);
 	let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 	match sign_message {
 		Some(message) => zk_prover
-			.prove_sig(witness.clone(), message, &mut rng, &mut prover_transcript)
+			.prove_sig(witness, message, &mut rng, &mut prover_transcript)
 			.unwrap(),
 		None => zk_prover
-			.prove(witness.clone(), &mut rng, &mut prover_transcript)
+			.prove(witness, &mut rng, &mut prover_transcript)
 			.unwrap(),
 	}
 
@@ -187,26 +182,26 @@ fn sign_verify(
 fn test_signature_of_knowledge_roundtrip() {
 	let (cs, witness) = sha256_preimage_circuit();
 	// Signing and verifying with the same message succeeds.
-	assert!(sign_verify(cs, witness, Some(b"hello world"), Some(b"hello world")));
+	assert!(sign_verify(cs, &witness, Some(b"hello world"), Some(b"hello world")));
 }
 
 #[test]
 fn test_signature_of_knowledge_wrong_message_fails() {
 	let (cs, witness) = sha256_preimage_circuit();
 	// A proof signed over one message must not verify against a different message.
-	assert!(!sign_verify(cs, witness, Some(b"hello world"), Some(b"goodbye world")));
+	assert!(!sign_verify(cs, &witness, Some(b"hello world"), Some(b"goodbye world")));
 }
 
 #[test]
 fn test_signature_of_knowledge_missing_message_fails() {
 	let (cs, witness) = sha256_preimage_circuit();
 	// A signature of knowledge must not verify as a plain proof of knowledge (no message).
-	assert!(!sign_verify(cs, witness, Some(b"hello world"), None));
+	assert!(!sign_verify(cs, &witness, Some(b"hello world"), None));
 }
 
 #[test]
 fn test_plain_proof_rejects_message() {
 	let (cs, witness) = sha256_preimage_circuit();
 	// A plain proof of knowledge must not verify when a message is supplied.
-	assert!(!sign_verify(cs, witness, None, Some(b"hello world")));
+	assert!(!sign_verify(cs, &witness, None, Some(b"hello world")));
 }

--- a/crates/prover/tests/shift.rs
+++ b/crates/prover/tests/shift.rs
@@ -163,7 +163,7 @@ fn compute_intmul_images(constraints: &[MulConstraint], witness: &ValueVec) -> [
 fn evaluate_image<F: BinaryField>(
 	subspace: &BinarySubspace<F>,
 	image: &[Word],
-	r_zhat_prime: F,
+	r_zhat_prime: &F,
 	r_x_prime_tensor: &[F],
 ) -> F {
 	let l_tilde = lagrange_evals(subspace, r_zhat_prime);
@@ -235,7 +235,7 @@ fn test_shift_prove_and_verify() {
 			evaluate_image(
 				&subspace,
 				&image,
-				r_zhat_prime,
+				&r_zhat_prime,
 				eq_ind_partial_eval(&r_x_prime_bitand).as_ref(),
 			)
 		});
@@ -244,7 +244,7 @@ fn test_shift_prove_and_verify() {
 			evaluate_image(
 				&subspace,
 				&image,
-				r_zhat_prime,
+				&r_zhat_prime,
 				eq_ind_partial_eval(&r_x_prime_intmul).as_ref(),
 			)
 		});

--- a/crates/spartan-frontend/src/circuit_builder.rs
+++ b/crates/spartan-frontend/src/circuit_builder.rs
@@ -65,11 +65,11 @@ pub struct WireAllocator {
 }
 
 impl WireAllocator {
-	pub fn new(kind: WireKind) -> Self {
-		WireAllocator { n_wires: 0, kind }
+	pub const fn new(kind: WireKind) -> Self {
+		Self { n_wires: 0, kind }
 	}
 
-	pub fn alloc(&mut self) -> ConstraintWire {
+	pub const fn alloc(&mut self) -> ConstraintWire {
 		let wire = ConstraintWire {
 			kind: self.kind,
 			id: self.n_wires,
@@ -239,7 +239,7 @@ pub struct ConstraintBuilder<F: Field> {
 impl<F: Field> ConstraintBuilder<F> {
 	#[allow(clippy::new_without_default)]
 	pub fn new() -> Self {
-		ConstraintBuilder {
+		Self {
 			ir: ConstraintSystemIR {
 				constant_alloc: WireAllocator::new(WireKind::Constant),
 				public_alloc: WireAllocator::new(WireKind::InOut),
@@ -254,11 +254,11 @@ impl<F: Field> ConstraintBuilder<F> {
 		}
 	}
 
-	pub fn alloc_inout(&mut self) -> ConstraintWire {
+	pub const fn alloc_inout(&mut self) -> ConstraintWire {
 		self.ir.public_alloc.alloc()
 	}
 
-	pub fn alloc_precommit(&mut self) -> ConstraintWire {
+	pub const fn alloc_precommit(&mut self) -> ConstraintWire {
 		self.ir.precommit_alloc.alloc()
 	}
 
@@ -272,7 +272,7 @@ impl<F: Field> CircuitBuilder for ConstraintBuilder<F> {
 	type Field = F;
 
 	fn assert_zero(&mut self, wire: Self::Wire) {
-		self.ir.zero_constraints.push(wire.into())
+		self.ir.zero_constraints.push(wire.into());
 	}
 
 	fn assert_eq(&mut self, lhs: Self::Wire, rhs: Self::Wire) {
@@ -378,7 +378,7 @@ pub struct WitnessWire<F: Field> {
 
 impl<F: Field> WitnessWire<F> {
 	#[inline]
-	pub fn val(self) -> F {
+	pub const fn val(self) -> F {
 		self.val
 	}
 
@@ -468,7 +468,7 @@ impl<'a, F: Field> WitnessGenerator<'a, F> {
 		}
 	}
 
-	pub fn error(&self) -> Option<&Backtrace> {
+	pub const fn error(&self) -> Option<&Backtrace> {
 		self.first_error.as_ref()
 	}
 
@@ -553,7 +553,7 @@ impl<F: Field> PublicWire<F> {
 	/// The wire's value if it is public-derivable (constant, inout, or derived), else `None` for a
 	/// private/precommit wire whose value the verifier does not know.
 	#[inline]
-	pub fn value(self) -> Option<F> {
+	pub const fn value(self) -> Option<F> {
 		self.0
 	}
 }

--- a/crates/spartan-frontend/src/circuits.rs
+++ b/crates/spartan-frontend/src/circuits.rs
@@ -242,7 +242,7 @@ mod tests {
 			B128::random(&mut rng),
 		];
 		let z_val = B128::random(&mut rng);
-		let expected = univariate::evaluate_univariate(&coeffs_vals, z_val);
+		let expected = univariate::evaluate_univariate(&coeffs_vals, &z_val);
 
 		test_helper::<UnivariateCircuit, 5>([
 			coeffs_vals[0],

--- a/crates/spartan-frontend/src/constraint_system.rs
+++ b/crates/spartan-frontend/src/constraint_system.rs
@@ -27,11 +27,11 @@ pub enum WireKind {
 impl WireKind {
 	/// The witness segment a wire of this kind lives in: constants, inout, and derived wires occupy
 	/// the public segment; precommit and private wires occupy their own segments.
-	pub fn segment(self) -> WitnessSegment {
+	pub const fn segment(self) -> WitnessSegment {
 		match self {
-			WireKind::Constant | WireKind::InOut | WireKind::Derived => WitnessSegment::Public,
-			WireKind::Precommit => WitnessSegment::Precommit,
-			WireKind::Private => WitnessSegment::Private,
+			Self::Constant | Self::InOut | Self::Derived => WitnessSegment::Public,
+			Self::Precommit => WitnessSegment::Precommit,
+			Self::Private => WitnessSegment::Private,
 		}
 	}
 
@@ -57,7 +57,7 @@ impl ConstraintWire {
 	/// Creates a constraint wire referencing an inout wire by ID.
 	///
 	/// TODO: This is not ideal, and instead we should use some sort of allocator.
-	pub fn inout(id: u32) -> Self {
+	pub const fn inout(id: u32) -> Self {
 		Self {
 			kind: WireKind::InOut,
 			id,
@@ -65,7 +65,7 @@ impl ConstraintWire {
 	}
 
 	/// Creates a constraint wire referencing a precommit wire by ID.
-	pub fn precommit(id: u32) -> Self {
+	pub const fn precommit(id: u32) -> Self {
 		Self {
 			kind: WireKind::Precommit,
 			id,
@@ -78,7 +78,7 @@ pub struct Operand<W>(SmallVec<[W; 4]>);
 
 impl<W> Default for Operand<W> {
 	fn default() -> Self {
-		Operand(SmallVec::new())
+		Self(SmallVec::new())
 	}
 }
 
@@ -115,7 +115,7 @@ impl<W: Copy + Ord> Operand<W> {
 		&self.0
 	}
 
-	pub fn merge(&mut self, rhs: &Self) -> (Operand<W>, Operand<W>) {
+	pub fn merge(&mut self, rhs: &Self) -> (Self, Self) {
 		// Classic merge algorithm for sorted vectors, but where duplicate items cancel out.
 		let lhs = mem::take(&mut self.0);
 		let dst = &mut self.0;
@@ -123,8 +123,8 @@ impl<W: Copy + Ord> Operand<W> {
 		let mut lhs_iter = lhs.into_iter().peekable();
 		let mut rhs_iter = rhs.0.iter().copied().peekable();
 
-		let mut additions = Operand::default();
-		let mut removals = Operand::default();
+		let mut additions = Self::default();
+		let mut removals = Self::default();
 
 		loop {
 			match (lhs_iter.peek(), rhs_iter.peek()) {
@@ -161,7 +161,7 @@ impl<W: Copy + Ord> Operand<W> {
 
 impl<W> From<W> for Operand<W> {
 	fn from(value: W) -> Self {
-		Operand(smallvec![value])
+		Self(smallvec![value])
 	}
 }
 
@@ -191,21 +191,21 @@ pub struct WitnessIndex {
 }
 
 impl WitnessIndex {
-	pub fn public(index: u32) -> Self {
+	pub const fn public(index: u32) -> Self {
 		Self {
 			segment: WitnessSegment::Public,
 			index,
 		}
 	}
 
-	pub fn precommit(index: u32) -> Self {
+	pub const fn precommit(index: u32) -> Self {
 		Self {
 			segment: WitnessSegment::Precommit,
 			index,
 		}
 	}
 
-	pub fn private(index: u32) -> Self {
+	pub const fn private(index: u32) -> Self {
 		Self {
 			segment: WitnessSegment::Private,
 			index,
@@ -220,7 +220,7 @@ pub struct Witness<F> {
 }
 
 impl<F> Witness<F> {
-	pub fn new(public: Vec<F>, precommit: Vec<F>, private: Vec<F>) -> Self {
+	pub const fn new(public: Vec<F>, precommit: Vec<F>, private: Vec<F>) -> Self {
 		Self {
 			public,
 			precommit,
@@ -283,7 +283,7 @@ pub struct ConstraintSystem<F: Field> {
 
 impl<F: Field> ConstraintSystem<F> {
 	/// Create a new constraint system.
-	pub fn new(
+	pub const fn new(
 		constants: Vec<F>,
 		n_inout: u32,
 		n_precommit: u32,
@@ -307,23 +307,23 @@ impl<F: Field> ConstraintSystem<F> {
 		&self.constants
 	}
 
-	pub fn n_inout(&self) -> u32 {
+	pub const fn n_inout(&self) -> u32 {
 		self.n_inout
 	}
 
-	pub fn n_precommit(&self) -> u32 {
+	pub const fn n_precommit(&self) -> u32 {
 		self.n_precommit
 	}
 
-	pub fn n_private(&self) -> u32 {
+	pub const fn n_private(&self) -> u32 {
 		self.n_private
 	}
 
-	pub fn log_public(&self) -> u32 {
+	pub const fn log_public(&self) -> u32 {
 		self.log_public
 	}
 
-	pub fn n_public(&self) -> u32 {
+	pub const fn n_public(&self) -> u32 {
 		1 << self.log_public
 	}
 
@@ -331,7 +331,7 @@ impl<F: Field> ConstraintSystem<F> {
 		&self.mul_constraints
 	}
 
-	pub fn one_wire(&self) -> WitnessIndex {
+	pub const fn one_wire(&self) -> WitnessIndex {
 		WitnessIndex {
 			segment: WitnessSegment::Public,
 			index: self.one_wire_index,
@@ -423,7 +423,7 @@ impl<F: Field> WitnessLayout<F> {
 		}
 	}
 
-	pub fn with_blinding(self, info: BlindingInfo) -> Self {
+	pub fn with_blinding(self, info: &BlindingInfo) -> Self {
 		// Precommit is a ZK-hidden oracle that only needs dummy wires; no dummy mul constraints
 		// are added to it. Private gets both. Keep this in sync with
 		// `ConstraintSystemPadded::new` in the verifier crate.
@@ -443,52 +443,52 @@ impl<F: Field> WitnessLayout<F> {
 		}
 	}
 
-	pub fn public_size(&self) -> usize {
+	pub const fn public_size(&self) -> usize {
 		1 << self.log_public as usize
 	}
 
-	pub fn precommit_size(&self) -> usize {
+	pub const fn precommit_size(&self) -> usize {
 		1 << self.log_precommit as usize
 	}
 
-	pub fn private_size(&self) -> usize {
+	pub const fn private_size(&self) -> usize {
 		1 << self.log_private as usize
 	}
 
-	pub fn n_constants(&self) -> usize {
+	pub const fn n_constants(&self) -> usize {
 		self.constants.len()
 	}
 
-	pub fn n_inout(&self) -> usize {
+	pub const fn n_inout(&self) -> usize {
 		self.n_inout as usize
 	}
 
-	pub fn n_derived(&self) -> usize {
+	pub const fn n_derived(&self) -> usize {
 		self.n_derived as usize
 	}
 
-	pub fn n_precommit(&self) -> usize {
+	pub const fn n_precommit(&self) -> usize {
 		self.n_precommit as usize
 	}
 
-	pub fn n_private(&self) -> usize {
+	pub const fn n_private(&self) -> usize {
 		self.n_private as usize
 	}
 
-	pub fn log_public(&self) -> u32 {
+	pub const fn log_public(&self) -> u32 {
 		self.log_public
 	}
 
-	pub fn log_precommit(&self) -> u32 {
+	pub const fn log_precommit(&self) -> u32 {
 		self.log_precommit
 	}
 
-	pub fn log_private(&self) -> u32 {
+	pub const fn log_private(&self) -> u32 {
 		self.log_private
 	}
 
 	/// Returns the first index of the inout
-	pub fn inout_offset(&self) -> WitnessIndex {
+	pub const fn inout_offset(&self) -> WitnessIndex {
 		WitnessIndex::public(self.constants.len() as u32)
 	}
 

--- a/crates/spartan-frontend/src/wire_elimination.rs
+++ b/crates/spartan-frontend/src/wire_elimination.rs
@@ -40,7 +40,7 @@ pub struct CostModel {
 impl Default for CostModel {
 	fn default() -> Self {
 		// This is just a guess, can be tuned later.
-		CostModel {
+		Self {
 			wire_cost: 16,
 			mul_cost: 2,
 			ref_cost: 1,

--- a/crates/spartan-prover/src/lib.rs
+++ b/crates/spartan-prover/src/lib.rs
@@ -123,7 +123,7 @@ impl<F: Field> IOPProver<F> {
 		}
 	}
 
-	pub fn constraint_system(&self) -> &ConstraintSystemPadded<F> {
+	pub const fn constraint_system(&self) -> &ConstraintSystemPadded<F> {
 		&self.constraint_system
 	}
 
@@ -177,7 +177,7 @@ impl<F: Field> IOPProver<F> {
 	///   [`Self::commit_precommit`])
 	pub fn prove<P, Channel>(
 		&self,
-		witness: Witness<F>,
+		witness: &Witness<F>,
 		precommit_oracle: Channel::Oracle,
 		precommit_packed: FieldBuffer<P>,
 		mut rng: impl CryptoRng,
@@ -265,8 +265,8 @@ impl<F: Field> IOPProver<F> {
 		let (mulcheck_evals, mask_eval, r_x) = prove_mulcheck::<F, P, _>(
 			cs.mul_constraints(),
 			witness.public(),
-			precommit_packed.to_ref(),
-			private_packed.to_ref(),
+			&precommit_packed.to_ref(),
+			&private_packed.to_ref(),
 			mulcheck_mask,
 			&mut *channel,
 		)?;
@@ -275,7 +275,7 @@ impl<F: Field> IOPProver<F> {
 		let lambda = channel.sample();
 
 		// Batch together the constraint operand evaluation claims.
-		let batched_sum = evaluate_univariate(&mulcheck_evals, lambda);
+		let batched_sum = evaluate_univariate(&mulcheck_evals, &lambda);
 
 		// Compute eq indicator tensor for r_x (shared across all segment evaluations)
 		let r_x_tensor = eq_ind_partial_eval::<F>(&r_x);
@@ -284,7 +284,7 @@ impl<F: Field> IOPProver<F> {
 		let public_eval = evaluate_wiring_mle_public(
 			cs.mul_constraints(),
 			witness.public(),
-			lambda,
+			&lambda,
 			r_x_tensor.as_ref(),
 		);
 
@@ -330,7 +330,7 @@ where
 	/// Constructs a prover corresponding to a constraint system verifier.
 	///
 	/// See [`Prover`] struct documentation for details.
-	pub fn setup(verifier: Verifier<F, H>) -> Result<Self, Error> {
+	pub fn setup(verifier: &Verifier<F, H>) -> Result<Self, Error> {
 		let log_num_shares = binius_utils::rayon::current_num_threads().ilog2() as usize;
 
 		// Get the largest subspace from the verifier compiler for NTT creation
@@ -350,19 +350,19 @@ where
 
 		let iop_prover = IOPProver::new(verifier.constraint_system().clone());
 
-		Ok(Prover {
+		Ok(Self {
 			iop_prover,
 			basefold_compiler,
 		})
 	}
 
 	/// Returns a reference to the IOP prover.
-	pub fn iop_prover(&self) -> &IOPProver<P::Scalar> {
+	pub const fn iop_prover(&self) -> &IOPProver<P::Scalar> {
 		&self.iop_prover
 	}
 
 	/// Returns a reference to the BaseFold ZK prover compiler.
-	pub fn iop_compiler(
+	pub const fn iop_compiler(
 		&self,
 	) -> &BaseFoldProverCompiler<P, ProverNTT<F>, ProverMerkleProver<F, H>> {
 		&self.basefold_compiler
@@ -381,7 +381,7 @@ where
 	/// * The witness length must match the constraint system size
 	pub fn prove<Challenger_: Challenger>(
 		&self,
-		witness: Witness<F>,
+		witness: &Witness<F>,
 		mut rng: impl CryptoRng,
 		transcript: &mut ProverTranscript<Challenger_>,
 	) -> Result<(), Error> {
@@ -394,7 +394,7 @@ where
 		let mut channel = self.basefold_compiler.create_channel(transcript, &mut rng);
 		let (precommit_oracle, precommit_packed) =
 			self.iop_prover
-				.commit_precommit::<P, _>(&witness, &mut rng, &mut channel);
+				.commit_precommit::<P, _>(witness, &mut rng, &mut channel);
 		// The IOP prover only queues the oracle relations; `finish` runs the single combined
 		// opening.
 		self.iop_prover.prove::<P, _>(
@@ -412,8 +412,8 @@ where
 fn prove_mulcheck<F, P, Channel>(
 	mul_constraints: &[MulConstraint<WitnessIndex>],
 	public: &[F],
-	precommit_packed: FieldSlice<P>,
-	private_packed: FieldSlice<P>,
+	precommit_packed: &FieldSlice<'_, P>,
+	private_packed: &FieldSlice<'_, P>,
 	mask: zk_mlecheck::Mask<P, impl Deref<Target = [P]>>,
 	channel: &mut Channel,
 ) -> Result<([F; 3], F, Vec<F>), Error>
@@ -433,7 +433,7 @@ where
 		[mulcheck_witness.a, mulcheck_witness.b, mulcheck_witness.c],
 		|[a, b, c]| a * b - c, // composition
 		|[a, b, _c]| a * b,    // infinity_composition (quadratic term only)
-		r_mulcheck,
+		&r_mulcheck,
 		F::ZERO, // eval_claim: zerocheck
 	)?;
 

--- a/crates/spartan-prover/src/wiring.rs
+++ b/crates/spartan-prover/src/wiring.rs
@@ -66,11 +66,11 @@ impl WiringTranspose {
 		}
 	}
 
-	pub fn log_size(&self) -> usize {
+	pub const fn log_size(&self) -> usize {
 		self.log_size
 	}
 
-	pub fn size(&self) -> usize {
+	pub const fn size(&self) -> usize {
 		1 << self.log_size
 	}
 
@@ -145,8 +145,8 @@ pub struct MulCheckWitness<P: PackedField> {
 /// Evaluates an operand by XORing witness values at the specified indices.
 fn eval_operand<F: Field, P: PackedField<Scalar = F>>(
 	public: &[F],
-	precommit_packed: &FieldSlice<P>,
-	private_packed: &FieldSlice<P>,
+	precommit_packed: &FieldSlice<'_, P>,
+	private_packed: &FieldSlice<'_, P>,
 	operand: &Operand<WitnessIndex>,
 ) -> F {
 	operand
@@ -169,16 +169,16 @@ fn eval_operand<F: Field, P: PackedField<Scalar = F>>(
 pub fn build_mulcheck_witness<F: Field, P: PackedField<Scalar = F>>(
 	mul_constraints: &[MulConstraint<WitnessIndex>],
 	public: &[F],
-	precommit_packed: FieldSlice<P>,
-	private_packed: FieldSlice<P>,
+	precommit_packed: &FieldSlice<'_, P>,
+	private_packed: &FieldSlice<'_, P>,
 ) -> MulCheckWitness<P> {
-	fn get_a(c: &MulConstraint<WitnessIndex>) -> &Operand<WitnessIndex> {
+	const fn get_a(c: &MulConstraint<WitnessIndex>) -> &Operand<WitnessIndex> {
 		&c.a
 	}
-	fn get_b(c: &MulConstraint<WitnessIndex>) -> &Operand<WitnessIndex> {
+	const fn get_b(c: &MulConstraint<WitnessIndex>) -> &Operand<WitnessIndex> {
 		&c.b
 	}
-	fn get_c(c: &MulConstraint<WitnessIndex>) -> &Operand<WitnessIndex> {
+	const fn get_c(c: &MulConstraint<WitnessIndex>) -> &Operand<WitnessIndex> {
 		&c.c
 	}
 
@@ -208,8 +208,8 @@ pub fn build_mulcheck_witness<F: Field, P: PackedField<Scalar = F>>(
 					if constraint_idx < n_constraints {
 						eval_operand(
 							public,
-							&precommit_packed,
-							&private_packed,
+							precommit_packed,
+							private_packed,
 							get_operand(&mul_constraints[constraint_idx]),
 						)
 					} else {
@@ -292,14 +292,13 @@ mod tests {
 	/// Evaluate the wiring MLE using the transposed representation.
 	fn evaluate_wiring_mle_transposed<F: Field>(
 		transposed: &WiringTranspose,
-		lambda: F,
+		lambda: &F,
 		r_x_tensor: &[F],
 		r_y_tensor: &[F],
 	) -> F {
 		let mut acc = [F::ZERO; 3];
 
-		for idx in 0..transposed.size() {
-			let r_y_weight = r_y_tensor[idx];
+		for (idx, &r_y_weight) in r_y_tensor.iter().enumerate().take(transposed.size()) {
 			for key in transposed.keys_for(idx) {
 				let r_x_weight = r_x_tensor[key.constraint_idx as usize];
 				acc[key.operand_idx as usize] += r_x_weight * r_y_weight;
@@ -337,7 +336,7 @@ mod tests {
 		let expected = evaluate_segment_wiring_mle(
 			&constraints,
 			WitnessSegment::Private,
-			lambda,
+			&lambda,
 			r_x_tensor.as_ref(),
 			&r_y,
 		);
@@ -347,7 +346,7 @@ mod tests {
 			WiringTranspose::transpose(WitnessSegment::Private, private_size, &constraints);
 		let actual = evaluate_wiring_mle_transposed(
 			&transposed,
-			lambda,
+			&lambda,
 			r_x_tensor.as_ref(),
 			r_y_tensor.as_ref(),
 		);
@@ -381,7 +380,7 @@ mod tests {
 		let expected = evaluate_segment_wiring_mle(
 			&constraints,
 			WitnessSegment::Private,
-			lambda,
+			&lambda,
 			r_x_tensor.as_ref(),
 			&r_y,
 		);
@@ -438,8 +437,8 @@ mod tests {
 		let mulcheck_witness = build_mulcheck_witness(
 			&constraints,
 			&public,
-			precommit_buf.to_ref(),
-			private_buf.to_ref(),
+			&precommit_buf.to_ref(),
+			&private_buf.to_ref(),
 		);
 
 		// Sample r_x (sumcheck evaluation point for constraint axis)
@@ -474,9 +473,9 @@ mod tests {
 		let r_x_tensor = eq_ind_partial_eval::<B128>(&r_x);
 
 		// Compute the batched sum and public contribution
-		let batched_sum = evaluate_univariate(&mulcheck_evals, lambda);
+		let batched_sum = evaluate_univariate(&mulcheck_evals, &lambda);
 		let public_eval =
-			evaluate_wiring_mle_public(&constraints, &public, lambda, r_x_tensor.as_ref());
+			evaluate_wiring_mle_public(&constraints, &public, &lambda, r_x_tensor.as_ref());
 		let trace_claim = batched_sum - public_eval;
 
 		// Fold constraints to get the private wiring polynomial
@@ -505,12 +504,12 @@ mod tests {
 		let verifier_lambda: B128 = verifier_channel.sample();
 
 		// Compute the same claim on the verifier side
-		let verifier_batched_sum = evaluate_univariate(&mulcheck_evals, verifier_lambda);
+		let verifier_batched_sum = evaluate_univariate(&mulcheck_evals, &verifier_lambda);
 		let verifier_r_x_tensor = eq_ind_partial_eval::<B128>(&r_x);
 		let verifier_public_eval = evaluate_wiring_mle_public(
 			&constraints,
 			&public,
-			verifier_lambda,
+			&verifier_lambda,
 			verifier_r_x_tensor.as_ref(),
 		);
 		let verifier_trace_claim = verifier_batched_sum - verifier_public_eval;

--- a/crates/spartan-prover/src/wrapper/replay_channel.rs
+++ b/crates/spartan-prover/src/wrapper/replay_channel.rs
@@ -224,12 +224,12 @@ mod tests {
 			.collect();
 
 		let witness_rc = Rc::new(RefCell::new(witness_gen));
-		let mut witness_elems: Vec<WitnessElem> = witness_wires
+		let mut witness_elems: Vec<WitnessElem<'_>> = witness_wires
 			.iter()
 			.map(|&w| WitnessElem::wire(&witness_rc, w))
 			.collect();
 
-		<WitnessElem as FieldOps>::square_transpose::<FSub>(&mut witness_elems);
+		<WitnessElem<'_> as FieldOps>::square_transpose::<FSub>(&mut witness_elems);
 
 		drop(witness_elems);
 		let witness_gen = Rc::try_unwrap(witness_rc).unwrap().into_inner();

--- a/crates/spartan-prover/src/wrapper/zk_wrapped_prover_channel.rs
+++ b/crates/spartan-prover/src/wrapper/zk_wrapped_prover_channel.rs
@@ -212,7 +212,7 @@ where
 
 		// Validate and generate the outer proof.
 		outer_prover.prove::<P, _>(
-			witness,
+			&witness,
 			precommit_oracle,
 			precommit_packed,
 			rng,
@@ -275,7 +275,7 @@ where
 		&remaining[..n_inner_remaining]
 	}
 
-	fn send_oracle(&mut self, buffer: FieldSlice<P>) -> Self::Oracle {
+	fn send_oracle(&mut self, buffer: FieldSlice<'_, P>) -> Self::Oracle {
 		assert!(
 			!self.remaining_oracle_specs().is_empty(),
 			"send_oracle called but no inner oracle specs remaining"
@@ -299,6 +299,6 @@ where
 			self.interaction.push(*claim);
 		}
 
-		self.inner_channel.prove_oracle_relations(oracle_relations)
+		self.inner_channel.prove_oracle_relations(oracle_relations);
 	}
 }

--- a/crates/spartan-prover/tests/integration_test.rs
+++ b/crates/spartan-prover/tests/integration_test.rs
@@ -43,11 +43,11 @@ fn test_power7_circuit_prover_verifier() {
 	let log_inv_rate = 1;
 	let verifier =
 		Verifier::<_, StdHashSuite>::setup(cs, log_inv_rate).expect("verifier setup failed");
-	let prover = Prover::<OptimalPackedB128, StdHashSuite>::setup(verifier.clone())
-		.expect("prover setup failed");
+	let prover =
+		Prover::<OptimalPackedB128, StdHashSuite>::setup(&verifier).expect("prover setup failed");
 
 	let cs = verifier.constraint_system();
-	let layout = layout.with_blinding(cs.blinding_info().clone());
+	let layout = layout.with_blinding(cs.blinding_info());
 
 	// Choose test values: x = random, y = x^7
 	let mut rng = StdRng::seed_from_u64(0);
@@ -78,7 +78,7 @@ fn test_power7_circuit_prover_verifier() {
 	// Generate proof
 	let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 	prover
-		.prove(witness, &mut rng, &mut prover_transcript)
+		.prove(&witness, &mut rng, &mut prover_transcript)
 		.expect("prove failed");
 
 	// Verify proof
@@ -103,11 +103,11 @@ fn test_tampered_derived_value_fails_verification() {
 	let log_inv_rate = 1;
 	let verifier =
 		Verifier::<_, StdHashSuite>::setup(cs, log_inv_rate).expect("verifier setup failed");
-	let prover = Prover::<OptimalPackedB128, StdHashSuite>::setup(verifier.clone())
-		.expect("prover setup failed");
+	let prover =
+		Prover::<OptimalPackedB128, StdHashSuite>::setup(&verifier).expect("prover setup failed");
 
 	let cs = verifier.constraint_system();
-	let layout = layout.with_blinding(cs.blinding_info().clone());
+	let layout = layout.with_blinding(cs.blinding_info());
 
 	let mut rng = StdRng::seed_from_u64(0);
 	let x_val = B128::random(&mut rng);
@@ -138,7 +138,7 @@ fn test_tampered_derived_value_fails_verification() {
 	// The prover observes its tampered public into the transcript while proving.
 	let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 	prover
-		.prove(tampered_witness, &mut rng, &mut prover_transcript)
+		.prove(&tampered_witness, &mut rng, &mut prover_transcript)
 		.expect("prove failed");
 
 	// The verifier verifies against the recomputed (correct) public and must reject the proof.

--- a/crates/spartan-prover/tests/wrapper_integration_test.rs
+++ b/crates/spartan-prover/tests/wrapper_integration_test.rs
@@ -61,7 +61,7 @@ fn test_zk_wrapped_prove_verify() {
 			n_dummy_constraints: 0,
 		},
 	);
-	let inner_layout = inner_layout.with_blinding(inner_cs.blinding_info().clone());
+	let inner_layout = inner_layout.with_blinding(inner_cs.blinding_info());
 
 	let inner_iop_verifier = IOPVerifier::new(inner_cs.clone());
 	let inner_iop_prover = IOPProver::new(inner_cs.clone());
@@ -74,7 +74,7 @@ fn test_zk_wrapped_prove_verify() {
 	let dummy_public_elems = builder_channel.observe_many(&dummy_public);
 	// IronSpartanBuilderChannel::Oracle = () and recv_oracle is a no-op, so pass () directly.
 	inner_iop_verifier
-		.verify((), dummy_public_elems, &mut builder_channel)
+		.verify((), &dummy_public_elems, &mut builder_channel)
 		.expect("symbolic verify failed");
 	let outer_builder = builder_channel.finish();
 	let (outer_cs, outer_layout) = compile(outer_builder);
@@ -87,7 +87,7 @@ fn test_zk_wrapped_prove_verify() {
 		n_dummy_constraints: 2,
 	};
 	let outer_cs = ConstraintSystemPadded::new(outer_cs, blinding_info);
-	let outer_layout = outer_layout.with_blinding(outer_cs.blinding_info().clone());
+	let outer_layout = outer_layout.with_blinding(outer_cs.blinding_info());
 
 	// === Step 5: Make combined proof compiler (inner + outer oracle specs) ===
 	let outer_iop_verifier = IOPVerifier::new(outer_cs.clone());
@@ -154,7 +154,7 @@ fn test_zk_wrapped_prove_verify() {
 				let inner_public_elems = replay_channel.observe_many(public);
 				// ReplayChannel::Oracle = () and recv_oracle is a no-op, so pass ().
 				inner_iop_verifier
-					.verify((), inner_public_elems, replay_channel)
+					.verify((), &inner_public_elems, replay_channel)
 					.expect("replay verification should not fail");
 			}
 		},
@@ -171,7 +171,7 @@ fn test_zk_wrapped_prove_verify() {
 		.commit_precommit::<OptimalPackedB128, _>(&inner_witness, &mut rng, &mut channel_ref);
 	inner_iop_prover
 		.prove::<OptimalPackedB128, _>(
-			inner_witness,
+			&inner_witness,
 			inner_precommit_oracle,
 			inner_precommit_packed,
 			&mut rng,
@@ -201,7 +201,7 @@ fn test_zk_wrapped_prove_verify() {
 	// Run the inner IOP verify through the wrapped channel.
 	let inner_precommit_oracle = wrapped_verifier_channel.recv_oracle().unwrap();
 	inner_iop_verifier
-		.verify(inner_precommit_oracle, inner_public_elems, &mut wrapped_verifier_channel)
+		.verify(inner_precommit_oracle, &inner_public_elems, &mut wrapped_verifier_channel)
 		.expect("inner IOP verify failed");
 
 	// Finish verifies the outer proof.

--- a/crates/spartan-verifier/src/constraint_system.rs
+++ b/crates/spartan-verifier/src/constraint_system.rs
@@ -84,7 +84,7 @@ impl<F: Field> ConstraintSystemPadded<F> {
 			MulConstraint {
 				a: one_operand.clone(),
 				b: one_operand.clone(),
-				c: one_operand.clone(),
+				c: one_operand,
 			},
 		);
 
@@ -108,47 +108,47 @@ impl<F: Field> ConstraintSystemPadded<F> {
 		self.inner.constants()
 	}
 
-	pub fn n_inout(&self) -> u32 {
+	pub const fn n_inout(&self) -> u32 {
 		self.inner.n_inout()
 	}
 
-	pub fn n_precommit(&self) -> u32 {
+	pub const fn n_precommit(&self) -> u32 {
 		self.inner.n_precommit()
 	}
 
-	pub fn n_private(&self) -> u32 {
+	pub const fn n_private(&self) -> u32 {
 		self.inner.n_private()
 	}
 
-	pub fn log_public(&self) -> u32 {
+	pub const fn log_public(&self) -> u32 {
 		self.inner.log_public()
 	}
 
-	pub fn n_public(&self) -> u32 {
+	pub const fn n_public(&self) -> u32 {
 		self.inner.n_public()
 	}
 
-	pub fn one_wire(&self) -> WitnessIndex {
+	pub const fn one_wire(&self) -> WitnessIndex {
 		self.inner.one_wire()
 	}
 
-	pub fn log_precommit(&self) -> u32 {
+	pub const fn log_precommit(&self) -> u32 {
 		self.log_precommit
 	}
 
-	pub fn precommit_size(&self) -> usize {
+	pub const fn precommit_size(&self) -> usize {
 		1 << self.log_precommit as usize
 	}
 
-	pub fn log_private(&self) -> u32 {
+	pub const fn log_private(&self) -> u32 {
 		self.log_private
 	}
 
-	pub fn private_size(&self) -> usize {
+	pub const fn private_size(&self) -> usize {
 		1 << self.log_private as usize
 	}
 
-	pub fn blinding_info(&self) -> &BlindingInfo {
+	pub const fn blinding_info(&self) -> &BlindingInfo {
 		&self.blinding_info
 	}
 
@@ -157,7 +157,7 @@ impl<F: Field> ConstraintSystemPadded<F> {
 	}
 
 	/// Returns the mask buffer dimensions (m_n, m_d) for the ZK mulcheck mask polynomial.
-	pub fn mask_dims(&self) -> (usize, usize) {
+	pub const fn mask_dims(&self) -> (usize, usize) {
 		self.mask_dims
 	}
 

--- a/crates/spartan-verifier/src/lib.rs
+++ b/crates/spartan-verifier/src/lib.rs
@@ -100,11 +100,11 @@ where
 
 impl<F: Field> IOPVerifier<F> {
 	/// Constructs an IOP verifier for a constraint system.
-	pub fn new(constraint_system: ConstraintSystemPadded<F>) -> Self {
+	pub const fn new(constraint_system: ConstraintSystemPadded<F>) -> Self {
 		Self { constraint_system }
 	}
 
-	pub fn constraint_system(&self) -> &ConstraintSystemPadded<F> {
+	pub const fn constraint_system(&self) -> &ConstraintSystemPadded<F> {
 		&self.constraint_system
 	}
 
@@ -141,7 +141,7 @@ impl<F: Field> IOPVerifier<F> {
 	pub fn verify<'r, Channel>(
 		&'r self,
 		precommit_oracle: Channel::Oracle,
-		public: Vec<Channel::Elem>,
+		public: &[Channel::Elem],
 		channel: &mut Channel,
 	) -> Result<(), Error>
 	where
@@ -176,7 +176,7 @@ impl<F: Field> IOPVerifier<F> {
 		let lambda = channel.sample();
 
 		// Batch together the constraint operand evaluation claims.
-		let batched_sum = evaluate_univariate(&[a_eval, b_eval, c_eval], lambda.clone());
+		let batched_sum = evaluate_univariate(&[a_eval, b_eval, c_eval], &lambda);
 
 		// Compute rₓ^⊤ (M_A + λ M_B + λ² M_C) x. Shared via `Rc` so the transparent closures can
 		// own it and outlive this call (the opening is deferred to the channel's `finish()`). `Rc`
@@ -190,12 +190,7 @@ impl<F: Field> IOPVerifier<F> {
 		// single inout wire instead of building the entire sub-circuit.
 		let public_eval = {
 			let public_len = public.len();
-			let inputs = [
-				public.as_slice(),
-				slice::from_ref(&lambda),
-				r_x_tensor.as_ref(),
-			]
-			.concat();
+			let inputs = [public, slice::from_ref(&lambda), r_x_tensor.as_ref()].concat();
 
 			let mul_constraints = cs.mul_constraints();
 			channel.compute_public_value(&inputs, move |vals| {
@@ -205,7 +200,7 @@ impl<F: Field> IOPVerifier<F> {
 				evaluate_wiring_mle_public(
 					mul_constraints,
 					public_vals,
-					lambda_val,
+					&lambda_val,
 					r_x_tensor_vals,
 				)
 			})
@@ -224,7 +219,7 @@ impl<F: Field> IOPVerifier<F> {
 			lambda.clone(),
 		);
 		let private_transparent =
-			wiring::eval_transparent(cs, WitnessSegment::Private, r_x_tensor.clone(), lambda);
+			wiring::eval_transparent(cs, WitnessSegment::Private, r_x_tensor, lambda);
 		let mask_transparent = mask_transparent(cs, &r_x);
 
 		// Verify all oracle relations
@@ -293,16 +288,16 @@ where
 	}
 
 	/// Returns a reference to the IOP verifier.
-	pub fn iop_verifier(&self) -> &IOPVerifier<F> {
+	pub const fn iop_verifier(&self) -> &IOPVerifier<F> {
 		&self.iop_verifier
 	}
 
-	pub fn constraint_system(&self) -> &ConstraintSystemPadded<F> {
+	pub const fn constraint_system(&self) -> &ConstraintSystemPadded<F> {
 		self.iop_verifier.constraint_system()
 	}
 
 	/// Returns a reference to the BaseFold ZK verifier compiler.
-	pub fn iop_compiler(&self) -> &BaseFoldVerifierCompiler<F, BinaryMerkleTreeScheme<F, H>> {
+	pub const fn iop_compiler(&self) -> &BaseFoldVerifierCompiler<F, BinaryMerkleTreeScheme<F, H>> {
 		&self.basefold_compiler
 	}
 
@@ -329,7 +324,7 @@ where
 		let mut channel = self.basefold_compiler.create_channel(transcript);
 		let precommit_oracle = channel.recv_oracle()?;
 		self.iop_verifier
-			.verify(precommit_oracle, public.to_vec(), &mut channel)?;
+			.verify(precommit_oracle, public, &mut channel)?;
 		Ok(channel.finish()?)
 	}
 }

--- a/crates/spartan-verifier/src/wiring.rs
+++ b/crates/spartan-verifier/src/wiring.rs
@@ -26,7 +26,7 @@ pub fn eval_transparent<'a, G: Field, F: FieldOps + 'a>(
 		evaluate_segment_wiring_mle(
 			constraint_system.mul_constraints(),
 			segment,
-			lambda.clone(),
+			&lambda,
 			&r_x_tensor,
 			r_y,
 		)
@@ -41,7 +41,7 @@ pub fn eval_transparent<'a, G: Field, F: FieldOps + 'a>(
 pub fn evaluate_segment_wiring_mle<F: FieldOps>(
 	mul_constraints: &[MulConstraint<WitnessIndex>],
 	segment: WitnessSegment,
-	lambda: F,
+	lambda: &F,
 	r_x_tensor: &[F],
 	r_y: &[F],
 ) -> F {
@@ -74,7 +74,7 @@ pub fn evaluate_segment_wiring_mle<F: FieldOps>(
 pub fn evaluate_wiring_mle_public<F: FieldOps>(
 	mul_constraints: &[MulConstraint<WitnessIndex>],
 	public: &[F],
-	lambda: F,
+	lambda: &F,
 	r_x_tensor: &[F],
 ) -> F {
 	let mut acc = [F::zero(), F::zero(), F::zero()];
@@ -84,7 +84,7 @@ pub fn evaluate_wiring_mle_public<F: FieldOps>(
 				.wires()
 				.iter()
 				.flat_map(|index| {
-					if let WitnessSegment::Public = index.segment {
+					if index.segment == WitnessSegment::Public {
 						Some(public[index.index as usize].clone())
 					} else {
 						None

--- a/crates/spartan-verifier/src/wrapper/circuit_elem.rs
+++ b/crates/spartan-verifier/src/wrapper/circuit_elem.rs
@@ -115,39 +115,42 @@ where
 			_ => None,
 		});
 
-		if let Some(builder_ptr) = builder {
-			let Some(builder) = builder_ptr.upgrade() else {
-				panic!("combine cannot be called on a CircuitElem after the channel is closed");
-			};
-			let mut builder = builder.borrow_mut();
-			let inner_wires = elems.map(|elem| match elem {
-				Self::Constant(val) => builder.constant(*val),
-				Self::Wire {
-					builder: other_builder_ptr,
-					wire,
-				} => {
-					assert!(
-						Weak::ptr_eq(builder_ptr, other_builder_ptr),
-						"all combined CircuitElems must come from the same channel"
-					);
-					*wire
-				}
-			});
-			builder_op(&mut builder, inner_wires).map(|wire| Self::Wire {
-				builder: builder_ptr.clone(),
-				wire,
-			})
-		} else {
-			let inner_constants = elems.map(|elem| {
-				let Self::Constant(val) = elem else {
-					unreachable!(
-						"the enum has only two variants; none of them are Wire; thus all must be Constant"
-					);
+		builder.map_or_else(
+			|| {
+				let inner_constants = elems.map(|elem| {
+					let Self::Constant(val) = elem else {
+						unreachable!(
+							"the enum has only two variants; none of them are Wire; thus all must be Constant"
+						);
+					};
+					*val
+				});
+				f_op(inner_constants).map(Self::Constant)
+			},
+			|builder_ptr| {
+				let Some(builder) = builder_ptr.upgrade() else {
+					panic!("combine cannot be called on a CircuitElem after the channel is closed");
 				};
-				*val
-			});
-			f_op(inner_constants).map(Self::Constant)
-		}
+				let mut builder = builder.borrow_mut();
+				let inner_wires = elems.map(|elem| match elem {
+					Self::Constant(val) => builder.constant(*val),
+					Self::Wire {
+						builder: other_builder_ptr,
+						wire,
+					} => {
+						assert!(
+							Weak::ptr_eq(builder_ptr, other_builder_ptr),
+							"all combined CircuitElems must come from the same channel"
+						);
+						*wire
+					}
+				});
+				builder_op(&mut builder, inner_wires).map(|wire| Self::Wire {
+					builder: builder_ptr.clone(),
+					wire,
+				})
+			},
+		)
 	}
 
 	/// Variable-arity sibling of [`Self::combine`].
@@ -165,54 +168,57 @@ where
 			_ => None,
 		});
 
-		if let Some(builder_ptr) = builder {
-			let Some(builder) = builder_ptr.upgrade() else {
-				panic!(
-					"combine_varlen cannot be called on a CircuitElem after the channel is closed"
-				);
-			};
-			let mut builder = builder.borrow_mut();
-			let inner_wires = elems
-				.iter()
-				.map(|elem| match elem {
-					Self::Constant(val) => builder.constant(*val),
-					Self::Wire {
-						builder: other_builder_ptr,
+		builder.map_or_else(
+			|| {
+				let inner_constants = elems
+					.iter()
+					.map(|elem| {
+						let Self::Constant(val) = elem else {
+							unreachable!(
+								"no Wire variant exists in elems; all entries must be Constant"
+							);
+						};
+						*val
+					})
+					.collect::<Vec<_>>();
+				let result = f_op(&inner_constants);
+				debug_assert_eq!(result.len(), n_out);
+				result.into_iter().map(Self::Constant).collect()
+			},
+			|builder_ptr| {
+				let Some(builder) = builder_ptr.upgrade() else {
+					panic!(
+						"combine_varlen cannot be called on a CircuitElem after the channel is closed"
+					);
+				};
+				let mut builder = builder.borrow_mut();
+				let inner_wires = elems
+					.iter()
+					.map(|elem| match elem {
+						Self::Constant(val) => builder.constant(*val),
+						Self::Wire {
+							builder: other_builder_ptr,
+							wire,
+						} => {
+							assert!(
+								Weak::ptr_eq(builder_ptr, other_builder_ptr),
+								"all combined CircuitElems must come from the same channel"
+							);
+							*wire
+						}
+					})
+					.collect::<Vec<_>>();
+				let result = builder_op(&mut builder, &inner_wires);
+				debug_assert_eq!(result.len(), n_out);
+				result
+					.into_iter()
+					.map(|wire| Self::Wire {
+						builder: builder_ptr.clone(),
 						wire,
-					} => {
-						assert!(
-							Weak::ptr_eq(builder_ptr, other_builder_ptr),
-							"all combined CircuitElems must come from the same channel"
-						);
-						*wire
-					}
-				})
-				.collect::<Vec<_>>();
-			let result = builder_op(&mut builder, &inner_wires);
-			debug_assert_eq!(result.len(), n_out);
-			result
-				.into_iter()
-				.map(|wire| Self::Wire {
-					builder: builder_ptr.clone(),
-					wire,
-				})
-				.collect()
-		} else {
-			let inner_constants = elems
-				.iter()
-				.map(|elem| {
-					let Self::Constant(val) = elem else {
-						unreachable!(
-							"no Wire variant exists in elems; all entries must be Constant"
-						);
-					};
-					*val
-				})
-				.collect::<Vec<_>>();
-			let result = f_op(&inner_constants);
-			debug_assert_eq!(result.len(), n_out);
-			result.into_iter().map(Self::Constant).collect()
-		}
+					})
+					.collect()
+			},
+		)
 	}
 }
 
@@ -388,7 +394,7 @@ impl<F: Field, B: CircuitBuilder<Field = F>> MulAssign<&Self> for CircuitElem<F,
 
 impl<F: Field, B: CircuitBuilder<Field = F>> Sum for CircuitElem<F, B> {
 	fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
-		iter.fold(CircuitElem::Constant(F::ZERO), |acc, x| acc + x)
+		iter.fold(Self::Constant(F::ZERO), |acc, x| acc + x)
 	}
 }
 

--- a/crates/spartan-verifier/src/wrapper/mod.rs
+++ b/crates/spartan-verifier/src/wrapper/mod.rs
@@ -194,7 +194,7 @@ mod tests {
 		let public_elems = channel.observe_many(&public);
 		// IronSpartanBuilderChannel::Oracle = () and recv_oracle is a no-op, so pass () directly.
 		iop_verifier
-			.verify((), public_elems, &mut channel)
+			.verify((), &public_elems, &mut channel)
 			.expect("symbolic verify failed");
 
 		let builder = channel.finish();

--- a/crates/spartan-verifier/src/wrapper/zk_wrapped_channel.rs
+++ b/crates/spartan-verifier/src/wrapper/zk_wrapped_channel.rs
@@ -156,7 +156,7 @@ where
 
 		let mut inner_channel = self.inner_channel;
 		self.outer_verifier
-			.verify(self.precommit_oracle, public, &mut inner_channel)?;
+			.verify(self.precommit_oracle, &public, &mut inner_channel)?;
 		// Both the inner and outer proofs queued their oracle relations onto `inner_channel`; run
 		// the single combined opening over all committed oracles now. `instance_gen` stays alive in
 		// `self` for the duration, so the transparent closures' `Weak` upgrades succeed.

--- a/crates/spartan-verifier/tests/proof_size_test.rs
+++ b/crates/spartan-verifier/tests/proof_size_test.rs
@@ -51,7 +51,7 @@ fn test_ip_proof_size() {
 		.expect("recv_oracle on size-tracking channel should succeed");
 	verifier
 		.iop_verifier()
-		.verify(precommit_oracle, public_elems, &mut channel)
+		.verify(precommit_oracle, &public_elems, &mut channel)
 		.expect("verify with size tracking channel should succeed");
 	let proof_size = channel.proof_size();
 

--- a/crates/transcript/src/fiat_shamir/hasher_challenger.rs
+++ b/crates/transcript/src/fiat_shamir/hasher_challenger.rs
@@ -116,7 +116,7 @@ where
 		Digest::update(&mut self.hasher, &digest);
 
 		self.buffer = digest;
-		self.index = 0
+		self.index = 0;
 	}
 }
 
@@ -140,7 +140,7 @@ where
 {
 	fn flush(&mut self) {
 		self.hasher.update(&self.buffer[..self.index]);
-		self.index = 0
+		self.index = 0;
 	}
 }
 

--- a/crates/transcript/src/fiat_shamir/sampling.rs
+++ b/crates/transcript/src/fiat_shamir/sampling.rs
@@ -42,9 +42,6 @@ pub fn sample_bits_reader<Reader: Buf>(mut reader: Reader, bits: usize) -> u32 {
 
 	let unmasked = u32::from_le_bytes(bytes);
 	let mask = 1u32.checked_shl(bits as u32);
-	let mask = match mask {
-		Some(x) => x - 1,
-		None => u32::MAX,
-	};
+	let mask = mask.map_or(u32::MAX, |x| x - 1);
 	mask & unmasked
 }

--- a/crates/transcript/src/transcript.rs
+++ b/crates/transcript/src/transcript.rs
@@ -111,7 +111,7 @@ impl<Challenger> Drop for VerifierTranscript<Challenger> {
 			tracing::warn!(
 				"Transcript reader is not fully read out: {:?} bytes left",
 				self.combined.buffer.remaining()
-			)
+			);
 		}
 	}
 }
@@ -263,11 +263,9 @@ impl<Challenger_: Challenger> ProverTranscript<Challenger_> {
 				let test_name = current_thread.name().unwrap_or("unknown");
 				// Adjust "./" to "../../" to ensure files are saved in the project root rather than
 				// the package root.
-				let path = if let Some(stripped) = path.strip_prefix("./") {
-					format!("../../{stripped}",)
-				} else {
-					path
-				};
+				let path = path
+					.strip_prefix("./")
+					.map_or_else(|| path.clone(), |stripped| format!("../../{stripped}",));
 				std::fs::create_dir_all(&path)
 					.unwrap_or_else(|_| panic!("Failed to create directories for path: {path}",));
 				format!("{path}/{test_name}.bin")
@@ -376,7 +374,7 @@ impl<B: BufMut> TranscriptWriter<'_, B> {
 
 	pub fn write_debug(&mut self, msg: &str) {
 		if self.options.debug_assertions {
-			self.write_bytes(msg.as_bytes())
+			self.write_bytes(msg.as_bytes());
 		}
 	}
 

--- a/crates/utils/build.rs
+++ b/crates/utils/build.rs
@@ -15,15 +15,16 @@ fn main() {
 	println!("cargo:rustc-env=BUILD_RUSTFLAGS={rustflags}");
 
 	// Collect target features
-	let target_features = if let Ok(features) = env::var("CARGO_CFG_TARGET_FEATURE") {
-		if features.is_empty() {
-			Vec::new()
-		} else {
-			features.split(',').map(|s| s.to_string()).collect()
-		}
-	} else {
-		Vec::new()
-	};
+	let target_features = env::var("CARGO_CFG_TARGET_FEATURE")
+		.ok()
+		.filter(|features| !features.is_empty())
+		.map(|features| {
+			features
+				.split(',')
+				.map(|s| s.to_string())
+				.collect::<Vec<_>>()
+		})
+		.unwrap_or_default();
 
 	// Pass target features as comma-separated list
 	println!("cargo:rustc-env=COMPILE_TIME_FEATURES={}", target_features.join(","));

--- a/crates/utils/src/bitwise.rs
+++ b/crates/utils/src/bitwise.rs
@@ -33,7 +33,7 @@ pub struct BitSelector<B: Bitwise, S: AsRef<[B]>> {
 }
 
 impl<B: Bitwise, S: AsRef<[B]>> BitSelector<B, S> {
-	pub fn new(bit_offset: usize, slice: S) -> Self {
+	pub const fn new(bit_offset: usize, slice: S) -> Self {
 		Self {
 			bit_offset,
 			slice,

--- a/crates/utils/src/checked_arithmetics.rs
+++ b/crates/utils/src/checked_arithmetics.rs
@@ -1,7 +1,7 @@
 // Copyright 2024-2025 Irreducible Inc.
 // Copyright (c) 2024 The Plonky3 Authors
 
-/// Division implementation that fails in case when `a`` isn't divisible by `b`
+/// Division implementation that fails in case when `a` isn't divisible by `b`
 pub const fn checked_int_div(a: usize, b: usize) -> usize {
 	let result = a / b;
 	assert!(b * result == a);
@@ -89,6 +89,6 @@ mod tests {
 	#[test]
 	#[should_panic]
 	const fn test_checked_log2_fail() {
-		_ = checked_log_2(6)
+		_ = checked_log_2(6);
 	}
 }

--- a/crates/utils/src/env.rs
+++ b/crates/utils/src/env.rs
@@ -2,8 +2,6 @@
 
 /// Read boolean flag from the environment variable.
 pub fn boolean_env_flag_set(flag: &str) -> bool {
-	match std::env::var(flag) {
-		Ok(val) => ["1", "on", "ON", "true", "TRUE", "yes", "YES"].contains(&val.as_str()),
-		Err(_) => false,
-	}
+	std::env::var(flag)
+		.is_ok_and(|val| ["1", "on", "ON", "true", "TRUE", "yes", "YES"].contains(&val.as_str()))
 }

--- a/crates/utils/src/rayon/config.rs
+++ b/crates/utils/src/rayon/config.rs
@@ -42,6 +42,7 @@ pub fn adjust_thread_pool() -> &'static Result<(), ThreadPoolBuildError> {
 }
 
 /// Returns the base-2 logarithm of the number of threads that should be used for the task
+#[allow(clippy::missing_const_for_fn)]
 pub fn get_log_max_threads() -> usize {
 	(2 * current_num_threads() - 1).ilog2() as _
 }

--- a/crates/utils/src/rayon/iter/indexed_parallel_iterator.rs
+++ b/crates/utils/src/rayon/iter/indexed_parallel_iterator.rs
@@ -228,7 +228,7 @@ pub trait IndexedParallelIterator:
 
 	#[inline]
 	fn collect_into_vec(self, target: &mut Vec<Self::Item>) {
-		ParallelIterator::into_inner(self).collect_into_vec(target)
+		ParallelIterator::into_inner(self).collect_into_vec(target);
 	}
 
 	#[inline]

--- a/crates/utils/src/rayon/iter/parallel_iterator.rs
+++ b/crates/utils/src/rayon/iter/parallel_iterator.rs
@@ -30,7 +30,7 @@ pub(crate) trait ParallelIteratorInner: Sized + Iterator {
 	where
 		OP: Fn(Self::Item),
 	{
-		Iterator::for_each(self, op)
+		Iterator::for_each(self, op);
 	}
 
 	#[inline]
@@ -259,25 +259,20 @@ pub(crate) trait ParallelIteratorInner: Sized + Iterator {
 		Self::Item: Try<Output = T>,
 	{
 		let mut iterator = self.into_iter();
-		match iterator.next() {
-			None => None,
-			Some(first) => {
-				let mut accum = first;
+		let mut accum = iterator.next()?;
 
-				loop {
-					match accum.branch() {
+		loop {
+			match accum.branch() {
+				ControlFlow::Break(r) => break Some(Self::Item::from_residual(r)),
+				ControlFlow::Continue(acc) => match iterator.next() {
+					None => break Some(Self::Item::from_output(acc)),
+					Some(next) => match next.branch() {
 						ControlFlow::Break(r) => break Some(Self::Item::from_residual(r)),
-						ControlFlow::Continue(acc) => match iterator.next() {
-							None => break Some(Self::Item::from_output(acc)),
-							Some(next) => match next.branch() {
-								ControlFlow::Break(r) => break Some(Self::Item::from_residual(r)),
-								ControlFlow::Continue(c) => {
-									accum = op(acc, c);
-								}
-							},
-						},
-					}
-				}
+						ControlFlow::Continue(c) => {
+							accum = op(acc, c);
+						}
+					},
+				},
 			}
 		}
 	}
@@ -632,7 +627,7 @@ pub trait ParallelIterator: Sized {
 	where
 		OP: Fn(Self::Item),
 	{
-		ParallelIteratorInner::for_each(self.into_inner(), op)
+		ParallelIteratorInner::for_each(self.into_inner(), op);
 	}
 
 	#[inline]
@@ -640,7 +635,7 @@ pub trait ParallelIterator: Sized {
 	where
 		OP: Fn(&mut T, Self::Item),
 	{
-		ParallelIteratorInner::for_each_with(self.into_inner(), init, op)
+		ParallelIteratorInner::for_each_with(self.into_inner(), init, op);
 	}
 
 	#[inline]
@@ -649,7 +644,7 @@ pub trait ParallelIterator: Sized {
 		OP: Fn(&mut T, Self::Item),
 		INIT: Fn() -> T,
 	{
-		ParallelIteratorInner::for_each_init(self.into_inner(), init, op)
+		ParallelIteratorInner::for_each_init(self.into_inner(), init, op);
 	}
 
 	#[inline]
@@ -1165,8 +1160,8 @@ where
 	#[inline(always)]
 	fn into_inner(self) -> Self::Inner {
 		match self {
-			Either::Left(left) => Either::Left(left.into_inner()),
-			Either::Right(right) => Either::Right(right.into_inner()),
+			Self::Left(left) => Either::Left(left.into_inner()),
+			Self::Right(right) => Either::Right(right.into_inner()),
 		}
 	}
 
@@ -1241,10 +1236,7 @@ mod private {
 		}
 
 		fn branch(self) -> ControlFlow<Self::Residual, Self::Output> {
-			match self {
-				Some(c) => Continue(c),
-				None => Break(None),
-			}
+			self.map_or(Break(None), Continue)
 		}
 	}
 

--- a/crates/utils/src/rayon/mod.rs
+++ b/crates/utils/src/rayon/mod.rs
@@ -97,7 +97,7 @@ cfg_if::cfg_if! {
 
 		pub struct Scope<'scope> {
 			#[allow(clippy::type_complexity)]
-			marker: PhantomData<Box<dyn FnOnce(&Scope<'scope>) + Send + Sync + 'scope>>,
+			marker: PhantomData<Box<dyn FnOnce(&Self) + Send + Sync + 'scope>>,
 		}
 
 		impl<'scope> Scope<'scope> {
@@ -106,7 +106,7 @@ cfg_if::cfg_if! {
 			where
 				BODY: FnOnce(&Self) + Send + 'scope,
 			{
-				body(self)
+				body(self);
 			}
 		}
 

--- a/crates/utils/src/rayon/slice/parallel_slice_mut.rs
+++ b/crates/utils/src/rayon/slice/parallel_slice_mut.rs
@@ -64,7 +64,7 @@ pub trait ParallelSliceMut<T: Sync> {
 	where
 		T: Ord,
 	{
-		self.as_parallel_slice_mut().sort()
+		self.as_parallel_slice_mut().sort();
 	}
 
 	#[inline(always)]
@@ -72,7 +72,7 @@ pub trait ParallelSliceMut<T: Sync> {
 	where
 		F: Fn(&T, &T) -> std::cmp::Ordering + Sync,
 	{
-		self.as_parallel_slice_mut().sort_by(compare)
+		self.as_parallel_slice_mut().sort_by(compare);
 	}
 
 	#[inline(always)]
@@ -81,7 +81,7 @@ pub trait ParallelSliceMut<T: Sync> {
 		K: Ord,
 		F: Fn(&T) -> K + Sync,
 	{
-		self.as_parallel_slice_mut().sort_by_key(f)
+		self.as_parallel_slice_mut().sort_by_key(f);
 	}
 
 	#[inline(always)]
@@ -90,7 +90,7 @@ pub trait ParallelSliceMut<T: Sync> {
 		F: Fn(&T) -> K + Sync,
 		K: Ord + Send,
 	{
-		self.as_parallel_slice_mut().sort_by_cached_key(f)
+		self.as_parallel_slice_mut().sort_by_cached_key(f);
 	}
 
 	#[inline(always)]
@@ -98,7 +98,7 @@ pub trait ParallelSliceMut<T: Sync> {
 	where
 		T: Ord,
 	{
-		self.as_parallel_slice_mut().sort_unstable()
+		self.as_parallel_slice_mut().sort_unstable();
 	}
 
 	#[inline(always)]
@@ -106,7 +106,7 @@ pub trait ParallelSliceMut<T: Sync> {
 	where
 		F: Fn(&T, &T) -> std::cmp::Ordering + Sync,
 	{
-		self.as_parallel_slice_mut().sort_unstable_by(compare)
+		self.as_parallel_slice_mut().sort_unstable_by(compare);
 	}
 
 	#[inline(always)]
@@ -115,7 +115,7 @@ pub trait ParallelSliceMut<T: Sync> {
 		K: Ord,
 		F: Fn(&T) -> K + Sync,
 	{
-		self.as_parallel_slice_mut().sort_unstable_by_key(f)
+		self.as_parallel_slice_mut().sort_unstable_by_key(f);
 	}
 
 	#[inline(always)]

--- a/crates/utils/src/serialization.rs
+++ b/crates/utils/src/serialization.rs
@@ -281,9 +281,10 @@ impl<T: DeserializeBytes> DeserializeBytes for Option<T> {
 	where
 		Self: Sized,
 	{
-		Ok(match bool::deserialize(&mut read_buf)? {
-			true => Some(T::deserialize(&mut read_buf)?),
-			false => None,
+		Ok(if bool::deserialize(&mut read_buf)? {
+			Some(T::deserialize(&mut read_buf)?)
+		} else {
+			None
 		})
 	}
 }

--- a/crates/utils/src/strided_array.rs
+++ b/crates/utils/src/strided_array.rs
@@ -123,7 +123,7 @@ impl<'a, T> StridedArray2DViewMut<'a, T> {
 					// Safety: different instances of StridedArray2DViewMut created with the same
 					// data slice do not access overlapping indices.
 					data: unsafe {
-						slice::from_raw_parts_mut(self.data.as_ptr() as *mut T, self.data.len())
+						slice::from_raw_parts_mut(self.data.as_ptr().cast_mut(), self.data.len())
 					},
 					data_width: self.data_width,
 					height: self.height,
@@ -243,7 +243,7 @@ impl<T> IndexMut<(usize, usize)> for StridedArray2DViewMut<'_, T> {
 struct SendPtr<T>(*mut T);
 
 impl<T> SendPtr<T> {
-	fn as_ptr(self) -> *mut T {
+	const fn as_ptr(self) -> *mut T {
 		self.0
 	}
 }

--- a/crates/verifier/src/protocols/bitand.rs
+++ b/crates/verifier/src/protocols/bitand.rs
@@ -18,7 +18,7 @@ pub const SKIPPED_VARS: usize = binius_core::consts::LOG_WORD_SIZE_BITS;
 pub const ROWS_PER_HYPERCUBE_VERTEX: usize = 1 << SKIPPED_VARS;
 
 /// Output from the AND constraint reduction protocol verification.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct AndCheckOutput<F> {
 	pub a_eval: F,
 	pub b_eval: F,
@@ -117,7 +117,7 @@ where
 	let sumcheck_claim = extrapolate_over_subspace(
 		round_message_univariate_domain,
 		&univariate_message_coeffs,
-		univariate_sumcheck_challenge.clone(),
+		&univariate_sumcheck_challenge,
 	);
 
 	let SumcheckOutput {

--- a/crates/verifier/src/protocols/intmul/common.rs
+++ b/crates/verifier/src/protocols/intmul/common.rs
@@ -5,7 +5,7 @@ use std::iter;
 use binius_field::{BinaryField, Field, field::FieldOps};
 use itertools::iterate;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IntMulOutput<F> {
 	pub eval_point: Vec<F>,
 	pub a_evals: Vec<F>,

--- a/crates/verifier/src/protocols/intmul/verify.rs
+++ b/crates/verifier/src/protocols/intmul/verify.rs
@@ -56,7 +56,7 @@ where
 		.map(|(left, right)| eq_ind_eval.clone() * left * right)
 		.collect::<Vec<_>>();
 
-	let expected_eval = evaluate_univariate(&expected_unbatched_terms, batch_coeff);
+	let expected_eval = evaluate_univariate(&expected_unbatched_terms, &batch_coeff);
 	channel.assert_zero(expected_eval - eval)?;
 
 	Ok((challenges, multilinear_evals))
@@ -175,7 +175,7 @@ where
 	let expected_terms = expected_selected_terms
 		.chain([expected_c_prod_eval])
 		.collect::<Vec<_>>();
-	let expected_batched_eval = evaluate_univariate(&expected_terms, batch_coeff);
+	let expected_batched_eval = evaluate_univariate(&expected_terms, &batch_coeff);
 
 	channel.assert_zero(expected_batched_eval - eval)?;
 
@@ -249,7 +249,7 @@ fn verify_phase_5<F, C>(
 	c_hi_prod_evals: &[C::Elem],
 	b_eval_point: &[C::Elem],
 	r_ib: &[C::Elem],
-	b_recomb: C::Elem,
+	b_recomb: &C::Elem,
 	channel: &mut C,
 ) -> Result<IntMulOutput<C::Elem>, Error>
 where
@@ -273,7 +273,7 @@ where
 		c_lo_prod_evals,
 		c_hi_prod_evals,
 		&[C::Elem::zero()], // overflow parity zerocheck
-		slice::from_ref(&b_recomb),
+		slice::from_ref(b_recomb),
 	]
 	.concat();
 
@@ -332,7 +332,7 @@ where
 		slice::from_ref(&expected_b_rerand_eval),
 	]
 	.concat();
-	let expected_batched_eval = evaluate_univariate(&expected_unbatched_evals, batch_coeff);
+	let expected_batched_eval = evaluate_univariate(&expected_unbatched_evals, &batch_coeff);
 
 	// Compare expected evaluation against given evaluation `eval`.
 	channel.assert_zero(expected_batched_eval - eval)?;
@@ -505,7 +505,7 @@ where
 		&c_hi_evals,
 		&phase_3_eval_point,
 		&r_ib,
-		b_recomb,
+		&b_recomb,
 		channel,
 	)
 }

--- a/crates/verifier/src/protocols/shift/monster.rs
+++ b/crates/verifier/src/protocols/shift/monster.rs
@@ -249,7 +249,7 @@ mod tests {
 			let s = rng.random_range(0..64);
 
 			let challenge = subspace.get(i);
-			let l_tilde = lagrange_evals_scalars(&subspace, challenge);
+			let l_tilde = lagrange_evals_scalars(&subspace, &challenge);
 
 			let r_j = index_to_hypercube_point::<BinaryField128bGhash>(LOG_WORD_SIZE_BITS, j);
 			let r_s = index_to_hypercube_point::<BinaryField128bGhash>(LOG_WORD_SIZE_BITS, s);
@@ -300,7 +300,7 @@ mod tests {
 		// Generate random evaluation points
 		let challenge = BinaryField128bGhash::random(&mut rng);
 		let subspace = BinarySubspace::<BinaryField128bGhash>::with_dim(LOG_WORD_SIZE_BITS);
-		let l_tilde = lagrange_evals_scalars(&subspace, challenge);
+		let l_tilde = lagrange_evals_scalars(&subspace, &challenge);
 		let r_j = random_scalars::<BinaryField128bGhash>(&mut rng, LOG_WORD_SIZE_BITS);
 		let r_s = random_scalars::<BinaryField128bGhash>(&mut rng, LOG_WORD_SIZE_BITS);
 

--- a/crates/verifier/src/protocols/shift/shift_ind.rs
+++ b/crates/verifier/src/protocols/shift/shift_ind.rs
@@ -173,10 +173,9 @@ mod tests {
 
 		assert_eq!(partial_eval.len(), 1 << n);
 
-		for i_idx in 0..(1 << n) {
+		for (i_idx, &actual) in partial_eval.iter().enumerate() {
 			let i = index_to_hypercube_point::<F>(n, i_idx);
 			let expected = direct_fn(&i, j, s);
-			let actual = partial_eval[i_idx];
 			assert_eq!(
 				actual, expected,
 				"Mismatch at i_idx={}, i={:?}, j={:?}, s={:?}",

--- a/crates/verifier/src/protocols/shift/verify.rs
+++ b/crates/verifier/src/protocols/shift/verify.rs
@@ -43,14 +43,14 @@ impl<F: FieldOps, const ARITY: usize> OperatorData<F, ARITY> {
 	// Constructs a new operator data instance encoding
 	// evaluation claim with multilinear challenge `r_x_prime` and evaluations `evals`
 	// (one eval for each operand of the operation).
-	pub fn new(r_x_prime: Vec<F>, evals: [F; ARITY]) -> Self {
+	pub const fn new(r_x_prime: Vec<F>, evals: [F; ARITY]) -> Self {
 		Self { r_x_prime, evals }
 	}
 
 	// Batching is scaled by random lambda and therefore this batched
 	// evaluation claim can be added to other batched evaluation claims
 	// without further random scaling.
-	fn batched_eval(&self, lambda: F) -> F {
+	fn batched_eval(&self, lambda: &F) -> F {
 		let lambda_clone = lambda.clone();
 		lambda_clone * evaluate_univariate(&self.evals, lambda)
 	}
@@ -146,8 +146,7 @@ where
 	let bitand_lambda = channel.sample();
 	let intmul_lambda = channel.sample();
 
-	let eval = bitand_data.batched_eval(bitand_lambda.clone())
-		+ intmul_data.batched_eval(intmul_lambda.clone());
+	let eval = bitand_data.batched_eval(&bitand_lambda) + intmul_data.batched_eval(&intmul_lambda);
 
 	let SumcheckOutput {
 		eval: gamma,
@@ -244,7 +243,7 @@ where
 		let r_s_len = r_s.len();
 		let r_y_len = r_y.len();
 
-		let inputs: Vec<C::Elem> = iter::once(r_zhat_prime.clone())
+		let inputs: Vec<C::Elem> = iter::once(r_zhat_prime)
 			.chain(iter::once(bitand_lambda.clone()))
 			.chain(iter::once(intmul_lambda.clone()))
 			.chain(bitand_data.r_x_prime.iter().cloned())
@@ -270,7 +269,7 @@ where
 			let r_y_v = &vals[off..off + r_y_len];
 
 			let r_y_tensor = eq_ind_partial_eval_scalars(r_y_v);
-			let l_tilde = lagrange_evals_scalars(subspace, r_zhat_prime_v);
+			let l_tilde = lagrange_evals_scalars(subspace, &r_zhat_prime_v);
 			let h_op_evals = evaluate_h_op(&l_tilde, r_j_v, r_s_v);
 
 			let bitand_part = {

--- a/crates/verifier/src/ring_switch.rs
+++ b/crates/verifier/src/ring_switch.rs
@@ -113,8 +113,8 @@ where
 		|eval, (vert_i, hztl_i)| {
 			// This formula is specific to characteristic 2 fields
 			// Here we know that $h v + (1 - h) (1 - v) = 1 + h + v$.
-			let vert_scaled = eval.clone().scale_vertical(vert_i.clone());
-			let hztl_scaled = eval.clone().scale_horizontal(hztl_i.clone());
+			let vert_scaled = eval.clone().scale_vertical(vert_i);
+			let hztl_scaled = eval.clone().scale_horizontal(hztl_i);
 
 			eval + &vert_scaled + &hztl_scaled
 		},

--- a/crates/verifier/src/signature.rs
+++ b/crates/verifier/src/signature.rs
@@ -73,7 +73,7 @@ use digest::Digest;
 ///
 /// The `writer` must be an *observing* writer (obtained from `transcript.observe()`), so the
 /// digest is mixed into the Fiat-Shamir state without being written to the proof tape.
-pub fn observe_message<H, B>(writer: &mut TranscriptWriter<B>, message: &[u8])
+pub fn observe_message<H, B>(writer: &mut TranscriptWriter<'_, B>, message: &[u8])
 where
 	H: HashSuite,
 	B: BufMut,

--- a/crates/verifier/src/verify.rs
+++ b/crates/verifier/src/verify.rs
@@ -55,7 +55,7 @@ impl IOPVerifier {
 	///
 	/// The constraint system must already be validated via
 	/// [`ConstraintSystem::validate_and_prepare`].
-	pub fn new(constraint_system: ConstraintSystem, log_public_words: usize) -> Self {
+	pub const fn new(constraint_system: ConstraintSystem, log_public_words: usize) -> Self {
 		Self {
 			constraint_system,
 			log_public_words,
@@ -63,7 +63,7 @@ impl IOPVerifier {
 	}
 
 	/// Returns the constraint system.
-	pub fn constraint_system(&self) -> &ConstraintSystem {
+	pub const fn constraint_system(&self) -> &ConstraintSystem {
 		&self.constraint_system
 	}
 
@@ -73,7 +73,7 @@ impl IOPVerifier {
 	}
 
 	/// Returns log2 of the number of public constants and input/output words.
-	pub fn log_public_words(&self) -> usize {
+	pub const fn log_public_words(&self) -> usize {
 		self.log_public_words
 	}
 
@@ -183,7 +183,7 @@ impl IOPVerifier {
 				eval_point,
 			} = intmul_output;
 
-			let l_tilde = lagrange_evals_scalars(&domain_subspace, r_zhat_prime.clone());
+			let l_tilde = lagrange_evals_scalars(&domain_subspace, &r_zhat_prime);
 			let make_final_claim = |evals| inner_product_scalars(evals, l_tilde.iter().cloned());
 			OperatorData::new(
 				eval_point,
@@ -333,7 +333,7 @@ where
 	}
 
 	/// Returns a reference to the IOP verifier.
-	pub fn iop_verifier(&self) -> &IOPVerifier {
+	pub const fn iop_verifier(&self) -> &IOPVerifier {
 		&self.iop_verifier
 	}
 
@@ -353,27 +353,29 @@ where
 	}
 
 	/// Returns the constraint system.
-	pub fn constraint_system(&self) -> &ConstraintSystem {
+	pub const fn constraint_system(&self) -> &ConstraintSystem {
 		self.iop_verifier.constraint_system()
 	}
 
 	/// Returns the chosen FRI parameters.
-	pub fn fri_params(&self) -> &FRIParams<B128> {
+	pub const fn fri_params(&self) -> &FRIParams<B128> {
 		self.iop_compiler.fri_params()
 	}
 
 	/// Returns the [`crate::merkle_tree::MerkleTreeScheme`] instance used.
-	pub fn merkle_scheme(&self) -> &BinaryMerkleTreeScheme<B128, H> {
+	pub const fn merkle_scheme(&self) -> &BinaryMerkleTreeScheme<B128, H> {
 		self.iop_compiler.merkle_scheme()
 	}
 
 	/// Returns log2 of the number of public constants and input/output words.
-	pub fn log_public_words(&self) -> usize {
+	pub const fn log_public_words(&self) -> usize {
 		self.iop_verifier.log_public_words()
 	}
 
 	/// Returns the IOP compiler for creating verifier channels.
-	pub fn iop_compiler(&self) -> &BaseFoldVerifierCompiler<B128, BinaryMerkleTreeScheme<B128, H>> {
+	pub const fn iop_compiler(
+		&self,
+	) -> &BaseFoldVerifierCompiler<B128, BinaryMerkleTreeScheme<B128, H>> {
 		&self.iop_compiler
 	}
 

--- a/crates/verifier/src/zk_config.rs
+++ b/crates/verifier/src/zk_config.rs
@@ -109,7 +109,7 @@ where
 			n_dummy_constraints: 2,
 		};
 		let outer_cs = ConstraintSystemPadded::new(outer_cs, blinding_info);
-		let outer_layout = outer_layout.with_blinding(outer_cs.blinding_info().clone());
+		let outer_layout = outer_layout.with_blinding(outer_cs.blinding_info());
 		let outer_iop_verifier = IronSpartanIOPVerifier::new(outer_cs);
 
 		// Transcript layout: outer precommit oracle first (committed at wrapper construction),
@@ -140,29 +140,29 @@ where
 	}
 
 	/// Returns a reference to the inner IOP verifier.
-	pub fn inner_iop_verifier(&self) -> &IOPVerifier {
+	pub const fn inner_iop_verifier(&self) -> &IOPVerifier {
 		&self.inner_iop_verifier
 	}
 
 	/// Returns a reference to the outer spartan IOP verifier.
-	pub fn outer_iop_verifier(&self) -> &IronSpartanIOPVerifier<B128> {
+	pub const fn outer_iop_verifier(&self) -> &IronSpartanIOPVerifier<B128> {
 		&self.outer_iop_verifier
 	}
 
 	/// Returns the BaseFold ZK verifier compiler.
-	pub fn basefold_compiler(
+	pub const fn basefold_compiler(
 		&self,
 	) -> &BaseFoldVerifierCompiler<B128, BinaryMerkleTreeScheme<B128, H>> {
 		&self.basefold_compiler
 	}
 
 	/// Returns the constraint system.
-	pub fn constraint_system(&self) -> &ConstraintSystem {
+	pub const fn constraint_system(&self) -> &ConstraintSystem {
 		self.inner_iop_verifier.constraint_system()
 	}
 
 	/// Returns log2 of the number of public words.
-	pub fn log_public_words(&self) -> usize {
+	pub const fn log_public_words(&self) -> usize {
 		self.inner_iop_verifier.log_public_words()
 	}
 


### PR DESCRIPTION
@jimpo Feel free to close if you feel this is useless (this is an automatic PR made with automatic fixing). I've just replicated here the setup we are using in Plonky3 which helps us a lot to clean the codebase and adopt the strongest constraints.

Pure cleanup — no behavior change. Brings the workspace's clippy configuration in line with Plonky3 and fixes every finding so the repo passes `cargo clippy --workspace --all-targets -- -D warnings` (the CI command).

### The idea

Plonky3 lints its whole workspace with a strict, shared config. This ports that same config here and clears the resulting backlog.

Root `Cargo.toml` `[workspace.lints]` now mirrors Plonky3 exactly:

```
[workspace.lints]
rust.rust_2018_idioms = { level = "deny", priority = -1 }
rust.unused_must_use = "deny"
rust.rust_2024_incompatible_pat = "warn"
rustdoc.all = "warn"

[workspace.lints.clippy]
all = { level = "warn", priority = -1 }
nursery = { level = "warn", priority = -1 }
semicolon_if_nothing_returned = "warn"
match_bool = "warn"
needless_pass_by_value = "warn"
redundant_pub_crate = "allow"
too_long_first_doc_paragraph = "allow"
unused_peekable = "allow"
tuple_array_conversions = "allow"
transmute_undefined_repr = "allow"
cognitive_complexity = "allow"
```

All 21 crates already opt in with `[lints] workspace = true`, so no per-crate change was needed.
The previous `needless_range_loop = "allow"` is dropped (Plonky3 doesn't allow it either).

### The change

Two buckets of fixes.

Mechanical (largely `clippy --fix`):

- `use_self`, `missing_const_for_fn`, `semicolon_if_nothing_returned`, `redundant_clone`
- elided lifetimes in paths (`<'_>`), required by the now-`deny` `rust_2018_idioms`

By hand:

- `needless_range_loop` → iterators (`iter()/iter_mut().enumerate()/.take()/.skip()`)
- `option_if_let_else`, `needless_pass_by_ref_mut`, `collection_is_never_read`, `or_fun_call`, `branches_sharing_code`
- the `needless_pass_by_value` cascade: `T` / `Vec<T>` → `&T` / `&[T]`, propagated through every call site

The largest cascade is the prove chain and the MLE-check constructors:

```diff
- pub fn prove(&self, witness: ValueVec, ...) -> ...
+ pub fn prove(&self, witness: &ValueVec, ...) -> ...

- pub fn new(..., eval_point: Vec<F>, ...) -> Result<Self, Error>
+ pub fn new(..., eval_point: &[F], ...) -> Result<Self, Error>
```

### Soundness

Pure cleanup. Every change is type-level (passing `&x` where `x` was passed before) or a mechanical lint fix; no computation, challenge, or transcript behavior changes.

One subtlety worth calling out: a few wrapper constructors return `impl MleCheckProver<F>`. Under edition 2024, switching their `eval_point` to `&[F]` would make the returned `impl Trait` capture that lifetime and break callers that pass temporaries. Since the point is copied into an owned `Gruen32` (the prover never borrows it), those returns use precise capturing — `+ use<F, P, M>` — to exclude the lifetime.

A few redundant `.to_vec()` snapshots that only existed to copy data before a now-removed move were dropped. The genuinely load-bearing ones were kept: one releases a `RefCell` borrow before a later `borrow_mut` (would panic otherwise), one feeds a tampering test that mutates the copy.

### Scope

- **changed:** root `Cargo.toml` lint config + clippy fixes across all 21 crates (282 files, mostly one- or two-line edits)
- **left untouched:** all logic, all public behavior; the old reference oracles in tests

### Verification

- `cargo build --workspace --all-targets` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — exits 0
- `cargo +nightly fmt --all --check` — clean
- `cargo test --workspace` — all pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)