### PR TITLE
Enable clippy::missing_const_for_fn and mark eligible functions const

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,7 @@ ureq = "3.1"
 
 [workspace.lints.clippy]
 needless_range_loop = "allow"
+missing_const_for_fn = "warn"
 
 [workspace.metadata.typos]
 default.extend-words = { "typ" = "typ", "Toom" = "Toom", "inouts" = "inouts" }

--- a/crates/arith-bench/src/arch/portable64.rs
+++ b/crates/arith-bench/src/arch/portable64.rs
@@ -72,7 +72,7 @@ pub fn bmul64(x: u64, y: u64) -> u64 {
 }
 
 /// Bit-reverse a `u64` in constant time
-pub fn rev64(mut x: u64) -> u64 {
+pub const fn rev64(mut x: u64) -> u64 {
 	x = ((x & 0x5555_5555_5555_5555) << 1) | ((x >> 1) & 0x5555_5555_5555_5555);
 	x = ((x & 0x3333_3333_3333_3333) << 2) | ((x >> 2) & 0x3333_3333_3333_3333);
 	x = ((x & 0x0f0f_0f0f_0f0f_0f0f) << 4) | ((x >> 4) & 0x0f0f_0f0f_0f0f_0f0f);
@@ -84,7 +84,7 @@ pub fn rev64(mut x: u64) -> u64 {
 /// Squares a GF(2) polynomial, represented bitwise in a `u64`.
 ///
 /// The parameter `x` must have its top 32 bits clear (the polynomial has degree <32).
-pub fn bsqr64(mut x: u64) -> u64 {
+pub const fn bsqr64(mut x: u64) -> u64 {
 	// Algorithm adapted from https://graphics.stanford.edu/~seander/bithacks.html#InterleaveBMN
 	x = (x | (x << 16)) & 0x0000FFFF0000FFFF;
 	x = (x | (x << 8)) & 0x00FF00FF00FF00FF;

--- a/crates/arith-bench/src/ghash/soft64.rs
+++ b/crates/arith-bench/src/ghash/soft64.rs
@@ -116,7 +116,7 @@ pub fn square(x: u128) -> u128 {
 ///
 /// This is equivalent to `mul(x, INV_X)` but optimized: right-shift by 1 and conditionally XOR
 /// with X^{-1} if the LSB was set.
-pub fn mul_inv_x(x: u128) -> u128 {
+pub const fn mul_inv_x(x: u128) -> u128 {
 	let lsb = x & 1;
 	let shifted = x >> 1;
 	// If lsb is 1, XOR with INV_X; the mask is all-ones when lsb=1, all-zeros when lsb=0.

--- a/crates/circuits/src/bignum/prime_field.rs
+++ b/crates/circuits/src/bignum/prime_field.rs
@@ -37,12 +37,12 @@ impl PseudoMersennePrimeField {
 	}
 
 	/// Number of limbs in `BigUint`s representing field elements.
-	pub fn limbs_len(&self) -> usize {
+	pub const fn limbs_len(&self) -> usize {
 		self.modulus.limbs.len()
 	}
 
 	/// Field modulus.
-	pub fn modulus(&self) -> &BigUint {
+	pub const fn modulus(&self) -> &BigUint {
 		&self.modulus
 	}
 

--- a/crates/circuits/src/bitcoin/p2pkh_signature.rs
+++ b/crates/circuits/src/bitcoin/p2pkh_signature.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 
 /// Convert 20-byte address payload into five little-endian u32 words (circuit witness layout).
-pub fn addr_bytes_to_le_words(addr: &[u8; 20]) -> [u32; 5] {
+pub const fn addr_bytes_to_le_words(addr: &[u8; 20]) -> [u32; 5] {
 	[
 		u32::from_le_bytes([addr[0], addr[1], addr[2], addr[3]]),
 		u32::from_le_bytes([addr[4], addr[5], addr[6], addr[7]]),

--- a/crates/circuits/src/blake2b/reference.rs
+++ b/crates/circuits/src/blake2b/reference.rs
@@ -8,7 +8,7 @@ use super::constants::{BLOCK_BYTES, IV, MAX_OUTPUT_BYTES, R1, R2, R3, R4, ROUNDS
 
 /// Rotate right for 64-bit words
 #[inline(always)]
-fn rotr64(x: u64, n: u32) -> u64 {
+const fn rotr64(x: u64, n: u32) -> u64 {
 	x.rotate_right(n)
 }
 
@@ -16,7 +16,7 @@ fn rotr64(x: u64, n: u32) -> u64 {
 ///
 /// Performs 8 operations mixing two input words with the state
 #[inline(always)]
-pub fn g(v: &mut [u64; 16], a: usize, b: usize, c: usize, d: usize, x: u64, y: u64) {
+pub const fn g(v: &mut [u64; 16], a: usize, b: usize, c: usize, d: usize, x: u64, y: u64) {
 	v[a] = v[a].wrapping_add(v[b]).wrapping_add(x);
 	v[d] = rotr64(v[d] ^ v[a], R1);
 	v[c] = v[c].wrapping_add(v[d]);

--- a/crates/circuits/src/blake3/compress.rs
+++ b/crates/circuits/src/blake3/compress.rs
@@ -316,7 +316,7 @@ impl Hint for Blake3CompressHint {
 //
 // Shared by [`Blake3CompressHint`] (prover-side witness generation) and the tests.
 
-fn ref_g(v: &mut [u32; 16], a: usize, b: usize, c: usize, d: usize, mx: u32, my: u32) {
+const fn ref_g(v: &mut [u32; 16], a: usize, b: usize, c: usize, d: usize, mx: u32, my: u32) {
 	v[a] = v[a].wrapping_add(v[b]).wrapping_add(mx);
 	v[d] = (v[d] ^ v[a]).rotate_right(16);
 	v[c] = v[c].wrapping_add(v[d]);
@@ -327,7 +327,7 @@ fn ref_g(v: &mut [u32; 16], a: usize, b: usize, c: usize, d: usize, mx: u32, my:
 	v[b] = (v[b] ^ v[c]).rotate_right(7);
 }
 
-fn ref_round(state: &mut [u32; 16], msg: &[u32; 16], round: usize) {
+const fn ref_round(state: &mut [u32; 16], msg: &[u32; 16], round: usize) {
 	let schedule = MSG_SCHEDULE[round];
 
 	ref_g(state, 0, 4, 8, 12, msg[schedule[0]], msg[schedule[1]]);

--- a/crates/circuits/src/fixed_byte_vec.rs
+++ b/crates/circuits/src/fixed_byte_vec.rs
@@ -178,7 +178,7 @@ impl ByteVec {
 	}
 
 	/// Returns the maximum length of this vector in bytes.
-	pub fn max_len_bytes(&self) -> usize {
+	pub const fn max_len_bytes(&self) -> usize {
 		self.data.len() * 8
 	}
 

--- a/crates/circuits/src/hash_based_sig/hashing/chain_blake3.rs
+++ b/crates/circuits/src/hash_based_sig/hashing/chain_blake3.rs
@@ -51,7 +51,7 @@ const CV_WORDS: usize = 8;
 
 /// Tweak content length in bytes for a given parameter length:
 /// `param || 0x00 || epoch(4) || chain_index(1) || position(1)`.
-pub fn chain_tweak_len(param_len: usize) -> usize {
+pub const fn chain_tweak_len(param_len: usize) -> usize {
 	param_len + 1 + EPOCH_BYTES + CHAIN_INDEX_BYTES + POSITION_BYTES
 }
 

--- a/crates/circuits/src/hash_based_sig/winternitz_ots.rs
+++ b/crates/circuits/src/hash_based_sig/winternitz_ots.rs
@@ -247,12 +247,12 @@ impl WinternitzSpec {
 	}
 
 	/// Returns the number of coordinates/chains
-	pub fn dimension(&self) -> usize {
+	pub const fn dimension(&self) -> usize {
 		self.message_hash_len * 8 / self.coordinate_resolution_bits
 	}
 
 	/// Returns the chain length (2^coordinate_resolution_bits)
-	pub fn chain_len(&self) -> usize {
+	pub const fn chain_len(&self) -> usize {
 		1 << self.coordinate_resolution_bits
 	}
 

--- a/crates/circuits/src/hash_based_sig/xmss_aggregate.rs
+++ b/crates/circuits/src/hash_based_sig/xmss_aggregate.rs
@@ -68,7 +68,7 @@ pub struct MultiSigBuilder<'a> {
 }
 
 impl<'a> MultiSigBuilder<'a> {
-	pub fn new(builder: &'a CircuitBuilder, spec: &'a WinternitzSpec) -> Self {
+	pub const fn new(builder: &'a CircuitBuilder, spec: &'a WinternitzSpec) -> Self {
 		Self { builder, spec }
 	}
 

--- a/crates/circuits/src/keccak/mod.rs
+++ b/crates/circuits/src/keccak/mod.rs
@@ -201,7 +201,7 @@ impl Keccak256 {
 		}
 	}
 
-	pub fn max_len_bytes(&self) -> usize {
+	pub const fn max_len_bytes(&self) -> usize {
 		self.message.len() << 3
 	}
 

--- a/crates/circuits/src/multiplexer.rs
+++ b/crates/circuits/src/multiplexer.rs
@@ -116,7 +116,7 @@ pub fn single_wire_multiplex(b: &CircuitBuilder, inputs: &[Wire], sel: Wire) -> 
 }
 
 #[inline]
-fn log2_ceil_usize(n: usize) -> usize {
+const fn log2_ceil_usize(n: usize) -> usize {
 	if n <= 1 {
 		0
 	} else {

--- a/crates/circuits/src/secp256k1/curve.rs
+++ b/crates/circuits/src/secp256k1/curve.rs
@@ -28,12 +28,12 @@ impl Secp256k1 {
 	}
 
 	/// Coordinate field.
-	pub fn f_p(&self) -> &PseudoMersennePrimeField {
+	pub const fn f_p(&self) -> &PseudoMersennePrimeField {
 		&self.f_p
 	}
 
 	/// Scalar field.
-	pub fn f_scalar(&self) -> &PseudoMersennePrimeField {
+	pub const fn f_scalar(&self) -> &PseudoMersennePrimeField {
 		&self.f_scalar
 	}
 

--- a/crates/circuits/src/sha256/compress.rs
+++ b/crates/circuits/src/sha256/compress.rs
@@ -27,7 +27,7 @@ const K: [u32; 64] = [
 pub struct State(pub [Wire; 8]);
 
 impl State {
-	pub fn new(wires: [Wire; 8]) -> Self {
+	pub const fn new(wires: [Wire; 8]) -> Self {
 		State(wires)
 	}
 

--- a/crates/circuits/src/sha256/mod.rs
+++ b/crates/circuits/src/sha256/mod.rs
@@ -360,7 +360,7 @@ impl Sha256 {
 	}
 
 	/// Returns the maximum message length, in bytes.
-	pub fn max_len_bytes(&self) -> usize {
+	pub const fn max_len_bytes(&self) -> usize {
 		self.message.len() << (LOG_WORD_SIZE_BITS - LOG_BYTE_BITS)
 	}
 

--- a/crates/circuits/src/sha512/compress.rs
+++ b/crates/circuits/src/sha512/compress.rs
@@ -105,7 +105,7 @@ const K: [u64; 80] = [
 pub struct State(pub [Wire; 8]);
 
 impl State {
-	pub fn new(wires: [Wire; 8]) -> Self {
+	pub const fn new(wires: [Wire; 8]) -> Self {
 		State(wires)
 	}
 

--- a/crates/circuits/src/skein512/mod.rs
+++ b/crates/circuits/src/skein512/mod.rs
@@ -218,7 +218,7 @@ impl Skein512 {
 	}
 
 	/// Get the digest wires
-	pub fn digest_wires(&self) -> [Wire; 8] {
+	pub const fn digest_wires(&self) -> [Wire; 8] {
 		self.digest
 	}
 
@@ -264,7 +264,7 @@ fn mix(circuit: &CircuitBuilder, a: Wire, b: Wire, r: u32) -> (Wire, Wire) {
 /// This corresponds to the Threefish permutation from Table 3 of the Skein specification
 /// for Nw=8 (8 words). The permutation is applied after the MIX operations in each round
 /// to ensure proper diffusion across the state.
-fn permute_512(_circuit: &CircuitBuilder, x: [Wire; 8]) -> [Wire; 8] {
+const fn permute_512(_circuit: &CircuitBuilder, x: [Wire; 8]) -> [Wire; 8] {
 	[x[2], x[1], x[4], x[7], x[6], x[5], x[0], x[3]]
 }
 

--- a/crates/core/src/constraint_system.rs
+++ b/crates/core/src/constraint_system.rs
@@ -145,7 +145,7 @@ pub struct ShiftedValueIndex {
 impl ShiftedValueIndex {
 	/// Create a value index that just uses the specified value. Equivalent to [`Self::sll`] with
 	/// amount equals 0.
-	pub fn plain(value_index: ValueIndex) -> Self {
+	pub const fn plain(value_index: ValueIndex) -> Self {
 		Self {
 			value_index,
 			shift_variant: ShiftVariant::Sll,
@@ -583,17 +583,17 @@ impl ConstraintSystem {
 	}
 
 	/// Returns the number of AND constraints in the system.
-	pub fn n_and_constraints(&self) -> usize {
+	pub const fn n_and_constraints(&self) -> usize {
 		self.and_constraints.len()
 	}
 
 	/// Returns the number of MUL  constraints in the system.
-	pub fn n_mul_constraints(&self) -> usize {
+	pub const fn n_mul_constraints(&self) -> usize {
 		self.mul_constraints.len()
 	}
 
 	/// The total length of the [`ValueVec`] expected by this constraint system.
-	pub fn value_vec_len(&self) -> usize {
+	pub const fn value_vec_len(&self) -> usize {
 		self.value_vec_layout.committed_total_len
 	}
 
@@ -681,7 +681,7 @@ impl ValueVecLayout {
 	///
 	/// - the public segment (constants and inout values) is padded to the power of two.
 	/// - the public segment is not less than the minimum size.
-	pub fn validate(&self) -> Result<(), ConstraintSystemError> {
+	pub const fn validate(&self) -> Result<(), ConstraintSystemError> {
 		if !self.offset_witness.is_power_of_two() {
 			return Err(ConstraintSystemError::PublicInputPowerOfTwo);
 		}
@@ -695,7 +695,7 @@ impl ValueVecLayout {
 	}
 
 	/// Returns true if the given index points to an area that is considered to be padding.
-	fn is_padding(&self, index: ValueIndex) -> bool {
+	const fn is_padding(&self, index: ValueIndex) -> bool {
 		let idx = index.0 as usize;
 
 		// padding 1: between constants and inout section
@@ -719,7 +719,7 @@ impl ValueVecLayout {
 	}
 
 	/// Returns true if the given index is out-of-bounds for the committed part of this layout.
-	fn is_committed_oob(&self, index: ValueIndex) -> bool {
+	const fn is_committed_oob(&self, index: ValueIndex) -> bool {
 		index.0 as usize >= self.committed_total_len
 	}
 }
@@ -886,7 +886,7 @@ impl ValueVec {
 	}
 
 	/// The total size of the committed portion of the vector (excluding scratch).
-	pub fn size(&self) -> usize {
+	pub const fn size(&self) -> usize {
 		self.layout.committed_total_len
 	}
 
@@ -958,14 +958,14 @@ impl<'a> ValuesData<'a> {
 	pub const SERIALIZATION_VERSION: u32 = 1;
 
 	/// Create a new ValuesData from borrowed data
-	pub fn borrowed(data: &'a [Word]) -> Self {
+	pub const fn borrowed(data: &'a [Word]) -> Self {
 		Self {
 			data: Cow::Borrowed(data),
 		}
 	}
 
 	/// Create a new ValuesData from owned data
-	pub fn owned(data: Vec<Word>) -> Self {
+	pub const fn owned(data: Vec<Word>) -> Self {
 		Self {
 			data: Cow::Owned(data),
 		}
@@ -1084,7 +1084,7 @@ impl<'a> Proof<'a> {
 	pub const SERIALIZATION_VERSION: u32 = 1;
 
 	/// Create a new Proof from borrowed transcript data
-	pub fn borrowed(data: &'a [u8], challenger_type: String) -> Self {
+	pub const fn borrowed(data: &'a [u8], challenger_type: String) -> Self {
 		Self {
 			data: Cow::Borrowed(data),
 			challenger_type,
@@ -1092,7 +1092,7 @@ impl<'a> Proof<'a> {
 	}
 
 	/// Create a new Proof from owned transcript data
-	pub fn owned(data: Vec<u8>, challenger_type: String) -> Self {
+	pub const fn owned(data: Vec<u8>, challenger_type: String) -> Self {
 		Self {
 			data: Cow::Owned(data),
 			challenger_type,

--- a/crates/core/src/word.rs
+++ b/crates/core/src/word.rs
@@ -102,7 +102,7 @@ impl Word {
 	///
 	/// Returns (sum, carry_out) where the ith carry_out bit is set to one if there is a
 	/// carry out at that bit position.
-	pub fn iadd32_cin_cout(self, rhs: Word, cin: Word) -> (Word, Word) {
+	pub const fn iadd32_cin_cout(self, rhs: Word, cin: Word) -> (Word, Word) {
 		let Word(lhs) = self;
 		let Word(rhs) = rhs;
 		let Word(cin) = cin;
@@ -129,7 +129,7 @@ impl Word {
 	/// Performs parallel 32-bit additions on the upper and lower halves.
 	///
 	/// Equivalent to [`iadd32_cin_cout`](Word::iadd32_cin_cout) with zero carry-in.
-	pub fn iadd_cout_32(self, rhs: Word) -> (Word, Word) {
+	pub const fn iadd_cout_32(self, rhs: Word) -> (Word, Word) {
 		self.iadd32_cin_cout(rhs, Word::ZERO)
 	}
 
@@ -168,7 +168,7 @@ impl Word {
 	}
 
 	/// Performs shift right by a given number of bits followed by masking with a 32-bit mask.
-	pub fn shr_32(self, n: u32) -> Word {
+	pub const fn shr_32(self, n: u32) -> Word {
 		let Word(value) = self;
 		// Shift right logically by n bits and mask with 32-bit mask
 		let result = (value >> n) & Self::MASK_32.0;
@@ -178,7 +178,7 @@ impl Word {
 	/// Shift Arithmetic Right by a given number of bits.
 	///
 	/// This is similar to a logical shift right, but it shifts the sign bit to the right.
-	pub fn sar(self, n: u32) -> Word {
+	pub const fn sar(self, n: u32) -> Word {
 		let Word(value) = self;
 		let value = value as i64;
 		let result = value >> n;
@@ -186,7 +186,7 @@ impl Word {
 	}
 
 	/// Rotate Right by a given number of bits.
-	pub fn rotr(self, n: u32) -> Word {
+	pub const fn rotr(self, n: u32) -> Word {
 		let Word(value) = self;
 		Word(value.rotate_right(n))
 	}
@@ -195,7 +195,7 @@ impl Word {
 	///
 	/// Performs independent logical left shifts on the upper and lower 32-bit halves.
 	/// Only uses the lower 5 bits of the shift amount (0-31).
-	pub fn sll32(self, n: u32) -> Word {
+	pub const fn sll32(self, n: u32) -> Word {
 		let Word(value) = self;
 		let n = n & 0x1F; // Only use lower 5 bits
 
@@ -214,7 +214,7 @@ impl Word {
 	///
 	/// Performs independent logical right shifts on the upper and lower 32-bit halves.
 	/// Only uses the lower 5 bits of the shift amount (0-31).
-	pub fn srl32(self, n: u32) -> Word {
+	pub const fn srl32(self, n: u32) -> Word {
 		let Word(value) = self;
 		let n = n & 0x1F; // Only use lower 5 bits
 
@@ -234,7 +234,7 @@ impl Word {
 	/// Performs independent arithmetic right shifts on the upper and lower 32-bit halves.
 	/// Sign extends each 32-bit half independently. Only uses the lower 5 bits of the shift amount
 	/// (0-31).
-	pub fn sra32(self, n: u32) -> Word {
+	pub const fn sra32(self, n: u32) -> Word {
 		let Word(value) = self;
 		let n = n & 0x1F; // Only use lower 5 bits
 
@@ -254,7 +254,7 @@ impl Word {
 	/// Performs independent rotate right operations on the upper and lower 32-bit halves.
 	/// Bits shifted off the right end wrap around to the left within each 32-bit half.
 	/// Only uses the lower 5 bits of the shift amount (0-31).
-	pub fn rotr32(self, n: u32) -> Word {
+	pub const fn rotr32(self, n: u32) -> Word {
 		let Word(value) = self;
 		let n = n & 0x1F; // Only use lower 5 bits
 
@@ -273,7 +273,7 @@ impl Word {
 	///
 	/// Multiplies two 64-bit unsigned integers and returns the 128-bit result split into high and
 	/// low 64-bit words, respectively.
-	pub fn imul(self, rhs: Word) -> (Word, Word) {
+	pub const fn imul(self, rhs: Word) -> (Word, Word) {
 		let Word(lhs) = self;
 		let Word(rhs) = rhs;
 		let result = (lhs as u128) * (rhs as u128);
@@ -287,7 +287,7 @@ impl Word {
 	///
 	/// Multiplies two 64-bit signed integers and returns the 128-bit result split into high and
 	/// low 64-bit words, respectively.
-	pub fn smul(self, rhs: Word) -> (Word, Word) {
+	pub const fn smul(self, rhs: Word) -> (Word, Word) {
 		let Word(lhs) = self;
 		let Word(rhs) = rhs;
 		// Interpret as signed 64-bit integers
@@ -304,14 +304,14 @@ impl Word {
 	/// Integer addition.
 	///
 	/// Wraps around on overflow.
-	pub fn wrapping_add(self, rhs: Word) -> Word {
+	pub const fn wrapping_add(self, rhs: Word) -> Word {
 		Word(self.0.wrapping_add(rhs.0))
 	}
 
 	/// Integer subtraction.
 	///
 	/// Wraps around on overflow.
-	pub fn wrapping_sub(self, rhs: Word) -> Word {
+	pub const fn wrapping_sub(self, rhs: Word) -> Word {
 		Word(self.0.wrapping_sub(rhs.0))
 	}
 

--- a/crates/examples/src/circuits/bip32.rs
+++ b/crates/examples/src/circuits/bip32.rs
@@ -133,7 +133,7 @@ fn il_scalar(hash: &[Wire; 8]) -> BigUint {
 
 /// The last 32 bytes (`I_R`, the chain code) of a SHA-512 output, as four big-endian words ready to
 /// be used directly as an HMAC-SHA512 key.
-fn ir_words(hash: &[Wire; 8]) -> [Wire; 4] {
+const fn ir_words(hash: &[Wire; 8]) -> [Wire; 4] {
 	[hash[4], hash[5], hash[6], hash[7]]
 }
 

--- a/crates/examples/src/circuits/zklogin.rs
+++ b/crates/examples/src/circuits/zklogin.rs
@@ -56,15 +56,15 @@ impl Default for Config {
 }
 
 impl Config {
-	pub fn max_len_base64_jwt_header(&self) -> usize {
+	pub const fn max_len_base64_jwt_header(&self) -> usize {
 		self.max_len_json_jwt_header.div_ceil(3) * 4
 	}
 
-	pub fn max_len_base64_jwt_payload(&self) -> usize {
+	pub const fn max_len_base64_jwt_payload(&self) -> usize {
 		self.max_len_json_jwt_payload.div_ceil(3) * 4
 	}
 
-	pub fn max_len_base64_jwt_signature(&self) -> usize {
+	pub const fn max_len_base64_jwt_signature(&self) -> usize {
 		self.max_len_jwt_signature.div_ceil(3) * 4
 	}
 }

--- a/crates/field/src/arch/portable/univariate_mul_utils_128.rs
+++ b/crates/field/src/arch/portable/univariate_mul_utils_128.rs
@@ -142,7 +142,7 @@ pub fn bmul64<U: Underlier64bLanes>(x: U, y: U) -> U {
 
 /// Spread bits of a 64-bit value into a 128-bit value by interleaving zeroes.
 #[inline]
-pub fn spread_bits_64(val: u64) -> u128 {
+pub const fn spread_bits_64(val: u64) -> u128 {
 	let mut x = val as u128;
 	x = (x | (x << 32)) & 0x00000000FFFFFFFF00000000FFFFFFFF;
 	x = (x | (x << 16)) & 0x0000FFFF0000FFFF0000FFFF0000FFFF;

--- a/crates/field/src/linear_transformation.rs
+++ b/crates/field/src/linear_transformation.rs
@@ -207,7 +207,7 @@ where
 	Input: Sync,
 	Output: WithUnderlier,
 {
-	pub fn new(inner: Inner) -> Self {
+	pub const fn new(inner: Inner) -> Self {
 		Self {
 			inner,
 			_marker: PhantomData,
@@ -266,7 +266,7 @@ where
 	Input: WithUnderlier,
 	Output: Sync,
 {
-	pub fn new(inner: Inner) -> Self {
+	pub const fn new(inner: Inner) -> Self {
 		Self {
 			inner,
 			_marker: PhantomData,

--- a/crates/field/src/packed.rs
+++ b/crates/field/src/packed.rs
@@ -329,7 +329,7 @@ pub struct PackedSlice<'a, P: PackedField> {
 
 impl<'a, P: PackedField> PackedSlice<'a, P> {
 	#[inline(always)]
-	pub fn new(slice: &'a [P]) -> Self {
+	pub const fn new(slice: &'a [P]) -> Self {
 		Self {
 			slice,
 			len: len_packed_slice(slice),
@@ -364,7 +364,7 @@ pub struct PackedSliceMut<'a, P: PackedField> {
 
 impl<'a, P: PackedField> PackedSliceMut<'a, P> {
 	#[inline(always)]
-	pub fn new(slice: &'a mut [P]) -> Self {
+	pub const fn new(slice: &'a mut [P]) -> Self {
 		let len = len_packed_slice(slice);
 		Self { slice, len }
 	}

--- a/crates/frontend/src/compiler/circuit.rs
+++ b/crates/frontend/src/compiler/circuit.rs
@@ -49,12 +49,12 @@ impl<'a> WitnessFiller<'a> {
 	}
 
 	/// Returns a reference to the underlying value vector.
-	pub fn value_vec(&self) -> &ValueVec {
+	pub const fn value_vec(&self) -> &ValueVec {
 		&self.value_vec
 	}
 
 	/// Returns a mutable reference to the underlying value vector.
-	pub fn value_vec_mut(&mut self) -> &mut ValueVec {
+	pub const fn value_vec_mut(&mut self) -> &mut ValueVec {
 		&mut self.value_vec
 	}
 }
@@ -153,12 +153,12 @@ impl Circuit {
 	}
 
 	/// Returns the constraint system for this circuit.
-	pub fn constraint_system(&self) -> &ConstraintSystem {
+	pub const fn constraint_system(&self) -> &ConstraintSystem {
 		&self.constraint_system
 	}
 
 	/// Returns the evaluation form (witness-filling bytecode) for this circuit.
-	pub fn eval_form(&self) -> &EvalForm {
+	pub const fn eval_form(&self) -> &EvalForm {
 		&self.eval_form
 	}
 
@@ -171,7 +171,7 @@ impl Circuit {
 	}
 
 	/// Returns the number of evaluation instructions in this circuit.
-	pub fn n_eval_insn(&self) -> usize {
+	pub const fn n_eval_insn(&self) -> usize {
 		self.eval_form.n_eval_insn()
 	}
 

--- a/crates/frontend/src/compiler/constraint_builder.rs
+++ b/crates/frontend/src/compiler/constraint_builder.rs
@@ -13,7 +13,7 @@ pub struct ConstraintBuilder {
 }
 
 impl ConstraintBuilder {
-	pub fn new() -> Self {
+	pub const fn new() -> Self {
 		Self {
 			and_constraints: Vec::new(),
 			mul_constraints: Vec::new(),
@@ -22,19 +22,19 @@ impl ConstraintBuilder {
 	}
 
 	/// Build an AND constraint: A ' B = C
-	pub fn and(&mut self) -> AndConstraintBuilder<'_> {
+	pub const fn and(&mut self) -> AndConstraintBuilder<'_> {
 		AndConstraintBuilder::new(self)
 	}
 
 	/// Build a MUL constraint: A * B = (HI << 64) | LO
-	pub fn mul(&mut self) -> MulConstraintBuilder<'_> {
+	pub const fn mul(&mut self) -> MulConstraintBuilder<'_> {
 		MulConstraintBuilder::new(self)
 	}
 
 	/// Build a linear constraint: RHS = DST
 	/// (where RHS is XOR of shifted values and DST is a
 	/// single wire)
-	pub fn linear(&mut self) -> LinearConstraintBuilder<'_> {
+	pub const fn linear(&mut self) -> LinearConstraintBuilder<'_> {
 		LinearConstraintBuilder::new(self)
 	}
 
@@ -207,7 +207,7 @@ impl Shift {
 	/// Try to compose two shift operations.
 	///
 	/// Returns None if the shifts are incompatible.
-	pub fn compose(lhs: Shift, rhs: Shift) -> Option<Self> {
+	pub const fn compose(lhs: Shift, rhs: Shift) -> Option<Self> {
 		match (lhs, rhs) {
 			(Shift::None, shift) | (shift, Shift::None) => Some(shift),
 			(Shift::Sll(a), Shift::Sll(b)) => {
@@ -355,7 +355,7 @@ pub struct AndConstraintBuilder<'a> {
 }
 
 impl<'a> AndConstraintBuilder<'a> {
-	fn new(builder: &'a mut ConstraintBuilder) -> Self {
+	const fn new(builder: &'a mut ConstraintBuilder) -> Self {
 		Self {
 			builder,
 			a: Vec::new(),
@@ -407,7 +407,7 @@ pub struct LinearConstraintBuilder<'a> {
 }
 
 impl<'a> MulConstraintBuilder<'a> {
-	fn new(builder: &'a mut ConstraintBuilder) -> Self {
+	const fn new(builder: &'a mut ConstraintBuilder) -> Self {
 		Self {
 			builder,
 			a: Vec::new(),
@@ -448,7 +448,7 @@ impl<'a> MulConstraintBuilder<'a> {
 }
 
 impl<'a> LinearConstraintBuilder<'a> {
-	fn new(builder: &'a mut ConstraintBuilder) -> Self {
+	const fn new(builder: &'a mut ConstraintBuilder) -> Self {
 		Self {
 			builder,
 			rhs: Vec::new(),
@@ -463,7 +463,7 @@ impl<'a> LinearConstraintBuilder<'a> {
 	}
 
 	/// Set the DST operand (destination wire)
-	pub fn dst(mut self, wire: Wire) -> Self {
+	pub const fn dst(mut self, wire: Wire) -> Self {
 		self.dst = Some(wire);
 		self
 	}
@@ -513,7 +513,7 @@ impl WireExpr {
 }
 
 impl WireExprTerm {
-	fn to_shifted_wire(self) -> ShiftedWire {
+	const fn to_shifted_wire(self) -> ShiftedWire {
 		match self {
 			WireExprTerm::Wire(w) => ShiftedWire {
 				wire: w,
@@ -541,35 +541,35 @@ pub fn wire(w: Wire) -> WireExpr {
 	WireExpr(smallvec![w.into()])
 }
 
-pub fn sll(w: Wire, n: u32) -> WireExprTerm {
+pub const fn sll(w: Wire, n: u32) -> WireExprTerm {
 	WireExprTerm::Shifted(w, ShiftOp::Sll(n))
 }
 
-pub fn sll32(w: Wire, n: u32) -> WireExprTerm {
+pub const fn sll32(w: Wire, n: u32) -> WireExprTerm {
 	WireExprTerm::Shifted(w, ShiftOp::Sll32(n))
 }
 
-pub fn srl(w: Wire, n: u32) -> WireExprTerm {
+pub const fn srl(w: Wire, n: u32) -> WireExprTerm {
 	WireExprTerm::Shifted(w, ShiftOp::Srl(n))
 }
 
-pub fn srl32(w: Wire, n: u32) -> WireExprTerm {
+pub const fn srl32(w: Wire, n: u32) -> WireExprTerm {
 	WireExprTerm::Shifted(w, ShiftOp::Srl32(n))
 }
 
-pub fn sar(w: Wire, n: u32) -> WireExprTerm {
+pub const fn sar(w: Wire, n: u32) -> WireExprTerm {
 	WireExprTerm::Shifted(w, ShiftOp::Sar(n))
 }
 
-pub fn sra32(w: Wire, n: u32) -> WireExprTerm {
+pub const fn sra32(w: Wire, n: u32) -> WireExprTerm {
 	WireExprTerm::Shifted(w, ShiftOp::Sra32(n))
 }
 
-pub fn rotr(w: Wire, n: u32) -> WireExprTerm {
+pub const fn rotr(w: Wire, n: u32) -> WireExprTerm {
 	WireExprTerm::Shifted(w, ShiftOp::Rotr(n))
 }
 
-pub fn rotr32(w: Wire, n: u32) -> WireExprTerm {
+pub const fn rotr32(w: Wire, n: u32) -> WireExprTerm {
 	WireExprTerm::Shifted(w, ShiftOp::Rotr32(n))
 }
 

--- a/crates/frontend/src/compiler/dump.rs
+++ b/crates/frontend/src/compiler/dump.rs
@@ -16,7 +16,7 @@ struct PathSpecData {
 }
 
 impl PathSpecData {
-	fn new() -> Self {
+	const fn new() -> Self {
 		PathSpecData {
 			name: String::new(),
 			gates: Vec::new(),
@@ -60,7 +60,7 @@ struct Cx {
 }
 
 impl Cx {
-	fn new() -> Self {
+	const fn new() -> Self {
 		Self {
 			data: BTreeMap::new(),
 			post_order: Vec::new(),

--- a/crates/frontend/src/compiler/eval_form/builder.rs
+++ b/crates/frontend/src/compiler/eval_form/builder.rs
@@ -9,7 +9,7 @@ pub struct BytecodeBuilder {
 }
 
 impl BytecodeBuilder {
-	pub fn new() -> Self {
+	pub const fn new() -> Self {
 		Self {
 			bytecode: Vec::new(),
 			n_eval_insn: 0,

--- a/crates/frontend/src/compiler/eval_form/interpreter.rs
+++ b/crates/frontend/src/compiler/eval_form/interpreter.rs
@@ -30,7 +30,7 @@ pub struct ExecutionContext<'a> {
 }
 
 impl<'a> ExecutionContext<'a> {
-	pub fn new(value_vec: &'a mut ValueVec) -> Self {
+	pub const fn new(value_vec: &'a mut ValueVec) -> Self {
 		Self {
 			value_vec,
 			assertion_failures: Vec::new(),
@@ -96,7 +96,7 @@ pub struct Interpreter<'a> {
 }
 
 impl<'a> Interpreter<'a> {
-	pub fn new(bytecode: &'a [u8], hints: &'a HintRegistry) -> Self {
+	pub const fn new(bytecode: &'a [u8], hints: &'a HintRegistry) -> Self {
 		Self {
 			bytecode,
 			hints,

--- a/crates/frontend/src/compiler/eval_form/mod.rs
+++ b/crates/frontend/src/compiler/eval_form/mod.rs
@@ -87,7 +87,7 @@ impl EvalForm {
 	}
 
 	/// Get the number of evaluation instructions
-	pub fn n_eval_insn(&self) -> usize {
+	pub const fn n_eval_insn(&self) -> usize {
 		self.n_eval_insn
 	}
 

--- a/crates/frontend/src/compiler/gate/assert_eq.rs
+++ b/crates/frontend/src/compiler/gate/assert_eq.rs
@@ -21,7 +21,7 @@ use crate::compiler::{
 	pathspec::PathSpec,
 };
 
-pub fn shape() -> OpcodeShape {
+pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
 		const_in: &[Word::ALL_ONE],
 		n_in: 2,

--- a/crates/frontend/src/compiler/gate/assert_eq_cond.rs
+++ b/crates/frontend/src/compiler/gate/assert_eq_cond.rs
@@ -21,7 +21,7 @@ use crate::compiler::{
 	pathspec::PathSpec,
 };
 
-pub fn shape() -> OpcodeShape {
+pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
 		const_in: &[],
 		n_in: 3,

--- a/crates/frontend/src/compiler/gate/assert_false.rs
+++ b/crates/frontend/src/compiler/gate/assert_false.rs
@@ -22,7 +22,7 @@ use crate::compiler::{
 	pathspec::PathSpec,
 };
 
-pub fn shape() -> OpcodeShape {
+pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
 		const_in: &[Word::MSB_ONE],
 		n_in: 1,

--- a/crates/frontend/src/compiler/gate/assert_non_zero.rs
+++ b/crates/frontend/src/compiler/gate/assert_non_zero.rs
@@ -34,7 +34,7 @@ use crate::compiler::{
 	pathspec::PathSpec,
 };
 
-pub fn shape() -> OpcodeShape {
+pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
 		const_in: &[Word::ALL_ONE, Word::ZERO], // Need zero constant for cin
 		n_in: 1,

--- a/crates/frontend/src/compiler/gate/assert_true.rs
+++ b/crates/frontend/src/compiler/gate/assert_true.rs
@@ -22,7 +22,7 @@ use crate::compiler::{
 	pathspec::PathSpec,
 };
 
-pub fn shape() -> OpcodeShape {
+pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
 		const_in: &[Word::MSB_ONE],
 		n_in: 1,

--- a/crates/frontend/src/compiler/gate/assert_zero.rs
+++ b/crates/frontend/src/compiler/gate/assert_zero.rs
@@ -21,7 +21,7 @@ use crate::compiler::{
 	pathspec::PathSpec,
 };
 
-pub fn shape() -> OpcodeShape {
+pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
 		const_in: &[Word::ALL_ONE],
 		n_in: 1,

--- a/crates/frontend/src/compiler/gate/band.rs
+++ b/crates/frontend/src/compiler/gate/band.rs
@@ -18,7 +18,7 @@ use crate::compiler::{
 	gate_graph::{Gate, GateData, GateParam, Wire},
 };
 
-pub fn shape() -> OpcodeShape {
+pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
 		const_in: &[],
 		n_in: 2,

--- a/crates/frontend/src/compiler/gate/bor.rs
+++ b/crates/frontend/src/compiler/gate/bor.rs
@@ -19,7 +19,7 @@ use crate::compiler::{
 	gate_graph::{Gate, GateData, GateParam, Wire},
 };
 
-pub fn shape() -> OpcodeShape {
+pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
 		const_in: &[],
 		n_in: 2,

--- a/crates/frontend/src/compiler/gate/bxor.rs
+++ b/crates/frontend/src/compiler/gate/bxor.rs
@@ -20,7 +20,7 @@ use crate::compiler::{
 	gate_graph::{Gate, GateData, GateParam, Wire},
 };
 
-pub fn shape() -> OpcodeShape {
+pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
 		const_in: &[Word::ALL_ONE],
 		n_in: 2,

--- a/crates/frontend/src/compiler/gate/fax.rs
+++ b/crates/frontend/src/compiler/gate/fax.rs
@@ -19,7 +19,7 @@ use crate::compiler::{
 	gate_graph::{Gate, GateData, GateParam, Wire},
 };
 
-pub fn shape() -> OpcodeShape {
+pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
 		const_in: &[],
 		n_in: 3,

--- a/crates/frontend/src/compiler/gate/iadd.rs
+++ b/crates/frontend/src/compiler/gate/iadd.rs
@@ -23,7 +23,7 @@ use crate::compiler::{
 	gate_graph::{Gate, GateData, GateParam, Wire},
 };
 
-pub fn shape() -> OpcodeShape {
+pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
 		const_in: &[],
 		n_in: 2,

--- a/crates/frontend/src/compiler/gate/iadd32.rs
+++ b/crates/frontend/src/compiler/gate/iadd32.rs
@@ -26,7 +26,7 @@ use crate::compiler::{
 	gate_graph::{Gate, GateData, GateParam, Wire},
 };
 
-pub fn shape() -> OpcodeShape {
+pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
 		const_in: &[],
 		n_in: 2,

--- a/crates/frontend/src/compiler/gate/iadd32_cin_cout.rs
+++ b/crates/frontend/src/compiler/gate/iadd32_cin_cout.rs
@@ -29,7 +29,7 @@ use crate::compiler::{
 	gate_graph::{Gate, GateData, GateParam, Wire},
 };
 
-pub fn shape() -> OpcodeShape {
+pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
 		const_in: &[],
 		n_in: 3,

--- a/crates/frontend/src/compiler/gate/iadd_cin_cout.rs
+++ b/crates/frontend/src/compiler/gate/iadd_cin_cout.rs
@@ -35,7 +35,7 @@ use crate::compiler::{
 	gate_graph::{Gate, GateData, GateParam, Wire},
 };
 
-pub fn shape() -> OpcodeShape {
+pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
 		const_in: &[Word::ALL_ONE],
 		n_in: 3,

--- a/crates/frontend/src/compiler/gate/icmp_eq.rs
+++ b/crates/frontend/src/compiler/gate/icmp_eq.rs
@@ -41,7 +41,7 @@ use crate::compiler::{
 	gate_graph::{Gate, GateData, GateParam, Wire},
 };
 
-pub fn shape() -> OpcodeShape {
+pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
 		const_in: &[Word::ALL_ONE, Word::MSB_ONE, Word::ZERO], // Need zero constant for cin
 		n_in: 2,

--- a/crates/frontend/src/compiler/gate/icmp_ult.rs
+++ b/crates/frontend/src/compiler/gate/icmp_ult.rs
@@ -28,7 +28,7 @@ use crate::compiler::{
 	gate_graph::{Gate, GateData, GateParam, Wire},
 };
 
-pub fn shape() -> OpcodeShape {
+pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
 		const_in: &[Word::ALL_ONE, Word::ZERO], // Need all_one and zero constants
 		n_in: 2,

--- a/crates/frontend/src/compiler/gate/imul.rs
+++ b/crates/frontend/src/compiler/gate/imul.rs
@@ -8,7 +8,7 @@ use crate::compiler::{
 	gate_graph::{Gate, GateData, GateParam, Wire},
 };
 
-pub fn shape() -> OpcodeShape {
+pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
 		const_in: &[],
 		n_in: 2,

--- a/crates/frontend/src/compiler/gate/isub_bin_bout.rs
+++ b/crates/frontend/src/compiler/gate/isub_bin_bout.rs
@@ -7,7 +7,7 @@ use crate::compiler::{
 	gate_graph::{Gate, GateData, GateParam, Wire},
 };
 
-pub fn shape() -> OpcodeShape {
+pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
 		const_in: &[Word::ALL_ONE],
 		n_in: 3,

--- a/crates/frontend/src/compiler/gate/opcode.rs
+++ b/crates/frontend/src/compiler/gate/opcode.rs
@@ -143,7 +143,7 @@ impl Opcode {
 		}
 	}
 
-	pub fn is_const_shape(&self) -> bool {
+	pub const fn is_const_shape(&self) -> bool {
 		#[allow(clippy::match_like_matches_macro)]
 		match self {
 			Opcode::BxorMulti => false,

--- a/crates/frontend/src/compiler/gate/rotr.rs
+++ b/crates/frontend/src/compiler/gate/rotr.rs
@@ -27,7 +27,7 @@ use crate::compiler::{
 	gate_graph::{Gate, GateData, GateParam, Wire},
 };
 
-pub fn shape() -> OpcodeShape {
+pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
 		const_in: &[Word::ALL_ONE],
 		n_in: 1,

--- a/crates/frontend/src/compiler/gate/rotr32.rs
+++ b/crates/frontend/src/compiler/gate/rotr32.rs
@@ -20,7 +20,7 @@ use crate::compiler::{
 	gate_graph::{Gate, GateData, GateParam, Wire},
 };
 
-pub fn shape() -> OpcodeShape {
+pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
 		const_in: &[],
 		n_in: 1,

--- a/crates/frontend/src/compiler/gate/sar.rs
+++ b/crates/frontend/src/compiler/gate/sar.rs
@@ -21,7 +21,7 @@ use crate::compiler::{
 	gate_graph::{Gate, GateData, GateParam, Wire},
 };
 
-pub fn shape() -> OpcodeShape {
+pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
 		const_in: &[Word::ALL_ONE],
 		n_in: 1,

--- a/crates/frontend/src/compiler/gate/select.rs
+++ b/crates/frontend/src/compiler/gate/select.rs
@@ -23,7 +23,7 @@ use crate::compiler::{
 	gate_graph::{Gate, GateData, GateParam, Wire},
 };
 
-pub fn shape() -> OpcodeShape {
+pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
 		const_in: &[],
 		n_in: 3,

--- a/crates/frontend/src/compiler/gate/shl.rs
+++ b/crates/frontend/src/compiler/gate/shl.rs
@@ -21,7 +21,7 @@ use crate::compiler::{
 	gate_graph::{Gate, GateData, GateParam, Wire},
 };
 
-pub fn shape() -> OpcodeShape {
+pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
 		const_in: &[Word::ALL_ONE],
 		n_in: 1,

--- a/crates/frontend/src/compiler/gate/shr.rs
+++ b/crates/frontend/src/compiler/gate/shr.rs
@@ -21,7 +21,7 @@ use crate::compiler::{
 	gate_graph::{Gate, GateData, GateParam, Wire},
 };
 
-pub fn shape() -> OpcodeShape {
+pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
 		const_in: &[Word::ALL_ONE],
 		n_in: 1,

--- a/crates/frontend/src/compiler/gate/sll32.rs
+++ b/crates/frontend/src/compiler/gate/sll32.rs
@@ -22,7 +22,7 @@ use crate::compiler::{
 	gate_graph::{Gate, GateData, GateParam, Wire},
 };
 
-pub fn shape() -> OpcodeShape {
+pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
 		const_in: &[Word::ALL_ONE],
 		n_in: 1,

--- a/crates/frontend/src/compiler/gate/smul.rs
+++ b/crates/frontend/src/compiler/gate/smul.rs
@@ -54,7 +54,7 @@ fn constrain_modular_addition(
 		.build();
 }
 
-pub fn shape() -> OpcodeShape {
+pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
 		const_in: &[],
 		n_in: 2,

--- a/crates/frontend/src/compiler/gate/sra32.rs
+++ b/crates/frontend/src/compiler/gate/sra32.rs
@@ -22,7 +22,7 @@ use crate::compiler::{
 	gate_graph::{Gate, GateData, GateParam, Wire},
 };
 
-pub fn shape() -> OpcodeShape {
+pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
 		const_in: &[Word::ALL_ONE],
 		n_in: 1,

--- a/crates/frontend/src/compiler/gate/srl32.rs
+++ b/crates/frontend/src/compiler/gate/srl32.rs
@@ -21,7 +21,7 @@ use crate::compiler::{
 	gate_graph::{Gate, GateData, GateParam, Wire},
 };
 
-pub fn shape() -> OpcodeShape {
+pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
 		const_in: &[Word::ALL_ONE],
 		n_in: 1,

--- a/crates/frontend/src/compiler/gate_fusion/legraph.rs
+++ b/crates/frontend/src/compiler/gate_fusion/legraph.rs
@@ -76,11 +76,11 @@ pub enum NodeData {
 }
 
 impl NodeData {
-	fn is_root(&self) -> bool {
+	const fn is_root(&self) -> bool {
 		matches!(self, NodeData::Root { .. })
 	}
 
-	fn is_opaque(&self) -> bool {
+	const fn is_opaque(&self) -> bool {
 		matches!(self, NodeData::Opaque { .. })
 	}
 }
@@ -186,7 +186,7 @@ impl LeGraph {
 	/// Returns the set of wires that must be committed (converted to AND constraints).
 	///
 	/// This is populated only after running the commit_set decision pass.
-	pub fn commit_set(&self) -> &EntitySet<Wire> {
+	pub const fn commit_set(&self) -> &EntitySet<Wire> {
 		&self.lin_committed
 	}
 

--- a/crates/frontend/src/compiler/gate_fusion/stat.rs
+++ b/crates/frontend/src/compiler/gate_fusion/stat.rs
@@ -30,7 +30,7 @@ impl fmt::Debug for Stat {
 }
 
 impl Stat {
-	pub fn new(cb: &ConstraintBuilder) -> Self {
+	pub const fn new(cb: &ConstraintBuilder) -> Self {
 		Self {
 			pre_linear_def: cb.linear_constraints.len(),
 			pre_and_constraints: cb.and_constraints.len(),
@@ -40,15 +40,15 @@ impl Stat {
 		}
 	}
 
-	pub fn note_committed(&mut self) {
+	pub const fn note_committed(&mut self) {
 		self.committed_linear += 1;
 	}
 
-	pub fn note_visited(&mut self) {
+	pub const fn note_visited(&mut self) {
 		self.legraph_visited += 1;
 	}
 
-	pub fn note_committed_linear_depth(&mut self) {
+	pub const fn note_committed_linear_depth(&mut self) {
 		self.committed_linear_depth += 1;
 	}
 }

--- a/crates/frontend/src/compiler/gate_graph.rs
+++ b/crates/frontend/src/compiler/gate_graph.rs
@@ -52,7 +52,7 @@ pub enum WireKind {
 }
 impl WireKind {
 	/// Returns `true` if this is a constant wire.
-	pub fn is_const(&self) -> bool {
+	pub const fn is_const(&self) -> bool {
 		matches!(self, WireKind::Constant(_))
 	}
 }

--- a/crates/frontend/src/compiler/hints/big_uint_divide.rs
+++ b/crates/frontend/src/compiler/hints/big_uint_divide.rs
@@ -9,7 +9,7 @@ use crate::util::num_biguint_from_u64_limbs;
 pub struct BigUintDivideHint;
 
 impl BigUintDivideHint {
-	pub fn new() -> Self {
+	pub const fn new() -> Self {
 		Self
 	}
 }

--- a/crates/frontend/src/compiler/hints/big_uint_mod_pow.rs
+++ b/crates/frontend/src/compiler/hints/big_uint_mod_pow.rs
@@ -9,7 +9,7 @@ use crate::util::num_biguint_from_u64_limbs;
 pub struct BigUintModPowHint;
 
 impl BigUintModPowHint {
-	pub fn new() -> Self {
+	pub const fn new() -> Self {
 		Self
 	}
 }

--- a/crates/frontend/src/compiler/hints/byte_vec_concat.rs
+++ b/crates/frontend/src/compiler/hints/byte_vec_concat.rs
@@ -13,7 +13,7 @@ use super::Hint;
 pub struct ByteVecConcatHint;
 
 impl ByteVecConcatHint {
-	pub fn new() -> Self {
+	pub const fn new() -> Self {
 		Self
 	}
 }

--- a/crates/frontend/src/compiler/hints/mod_divide.rs
+++ b/crates/frontend/src/compiler/hints/mod_divide.rs
@@ -15,7 +15,7 @@ use crate::util::num_biguint_from_u64_limbs;
 pub struct ModDivideHint;
 
 impl ModDivideHint {
-	pub fn new() -> Self {
+	pub const fn new() -> Self {
 		Self
 	}
 }

--- a/crates/frontend/src/compiler/hints/mod_inverse.rs
+++ b/crates/frontend/src/compiler/hints/mod_inverse.rs
@@ -10,7 +10,7 @@ use crate::util::num_biguint_from_u64_limbs;
 pub struct ModInverseHint;
 
 impl ModInverseHint {
-	pub fn new() -> Self {
+	pub const fn new() -> Self {
 		Self
 	}
 }

--- a/crates/frontend/src/compiler/pathspec.rs
+++ b/crates/frontend/src/compiler/pathspec.rs
@@ -69,7 +69,7 @@ impl PathSpecTree {
 	}
 
 	/// Returns the root of the tree.
-	pub fn root(&self) -> PathSpec {
+	pub const fn root(&self) -> PathSpec {
 		self.root
 	}
 }

--- a/crates/frontend/src/compiler/value_vec_alloc.rs
+++ b/crates/frontend/src/compiler/value_vec_alloc.rs
@@ -22,7 +22,7 @@ pub struct Alloc {
 
 impl Alloc {
 	/// Creates a new [`Alloc`] instance.
-	pub fn new() -> Self {
+	pub const fn new() -> Self {
 		Self {
 			w_const: Vec::new(),
 			w_inout: Vec::new(),

--- a/crates/frontend/src/stat.rs
+++ b/crates/frontend/src/stat.rs
@@ -150,7 +150,7 @@ impl fmt::Display for CircuitStat {
 		}
 
 		// Helper to get log2 of a power of 2
-		fn log2(n: usize) -> u32 {
+		const fn log2(n: usize) -> u32 {
 			n.trailing_zeros()
 		}
 

--- a/crates/hash/src/parallel_compression.rs
+++ b/crates/hash/src/parallel_compression.rs
@@ -57,7 +57,7 @@ pub struct ParallelCompressionAdaptor<C> {
 
 impl<C> ParallelCompressionAdaptor<C> {
 	/// Creates a new adapter wrapping the given compression function.
-	pub fn new(compression: C) -> Self {
+	pub const fn new(compression: C) -> Self {
 		Self { compression }
 	}
 }

--- a/crates/iop-prover/src/basefold_channel.rs
+++ b/crates/iop-prover/src/basefold_channel.rs
@@ -125,7 +125,7 @@ where
 	}
 
 	/// Returns a reference to the underlying transcript.
-	pub fn transcript(&self) -> &ProverTranscript<Challenger_> {
+	pub const fn transcript(&self) -> &ProverTranscript<Challenger_> {
 		self.transcript
 	}
 

--- a/crates/iop-prover/src/basefold_compiler.rs
+++ b/crates/iop-prover/src/basefold_compiler.rs
@@ -100,12 +100,12 @@ where
 	}
 
 	/// Returns a reference to the NTT.
-	pub fn ntt(&self) -> &NTT {
+	pub const fn ntt(&self) -> &NTT {
 		&self.ntt
 	}
 
 	/// Returns a reference to the Merkle prover.
-	pub fn merkle_prover(&self) -> &MerkleProver_ {
+	pub const fn merkle_prover(&self) -> &MerkleProver_ {
 		&self.merkle_prover
 	}
 
@@ -115,7 +115,7 @@ where
 	}
 
 	/// Returns a reference to the precomputed combined FRI parameters.
-	pub fn fri_params(&self) -> &FRIParams<F> {
+	pub const fn fri_params(&self) -> &FRIParams<F> {
 		&self.fri_params
 	}
 

--- a/crates/iop-prover/src/fri/fold.rs
+++ b/crates/iop-prover/src/fri/fold.rs
@@ -158,12 +158,12 @@ where
 	}
 
 	/// Number of fold rounds, including the final fold.
-	pub fn n_rounds(&self) -> usize {
+	pub const fn n_rounds(&self) -> usize {
 		self.params.n_fold_rounds()
 	}
 
 	/// Number of times `execute_fold_round` has been called.
-	pub fn n_rounds_remaining(&self) -> usize {
+	pub const fn n_rounds_remaining(&self) -> usize {
 		self.n_rounds() - self.curr_round
 	}
 
@@ -422,11 +422,11 @@ where
 	MTProver: MerkleTreeProver<F>,
 {
 	/// The total interleave batch size, `log_early_batch_size + log_later_batch_size`.
-	fn log_batch_size(&self) -> usize {
+	const fn log_batch_size(&self) -> usize {
 		self.log_early_batch_size + self.log_later_batch_size
 	}
 
-	pub fn log_folded_len(&self) -> usize {
+	pub const fn log_folded_len(&self) -> usize {
 		self.codeword.log_len() - self.log_batch_size()
 	}
 }

--- a/crates/iop-prover/src/fri/query.rs
+++ b/crates/iop-prover/src/fri/query.rs
@@ -46,7 +46,7 @@ where
 	/// `log_lift` is the oracle-padding lift factor (the committed codeword is virtually duplicated
 	/// `2^log_lift` times to reach the common first-round length); pass `0` when no lifting is
 	/// needed.
-	pub fn new(
+	pub const fn new(
 		codeword: FieldBuffer<P>,
 		committed: &'a MerkleProver::Committed,
 		merkle_prover: &'a MerkleProver,
@@ -103,7 +103,7 @@ where
 	MerkleProver: MerkleTreeProver<P::Scalar>,
 {
 	/// Constructs a batch oracle prover from the per-commitment oracle provers.
-	pub fn new(oracles: Vec<BrakedownOracleProver<'a, P, MerkleProver>>) -> Self {
+	pub const fn new(oracles: Vec<BrakedownOracleProver<'a, P, MerkleProver>>) -> Self {
 		Self { oracles }
 	}
 }
@@ -141,7 +141,7 @@ where
 	MerkleProver: MerkleTreeProver<F>,
 {
 	/// Constructs a new oracle prover wrapping a committed fold-round codeword.
-	pub fn new(
+	pub const fn new(
 		codeword: FieldBuffer<F>,
 		committed: MerkleProver::Committed,
 		merkle_prover: &'a MerkleProver,
@@ -241,7 +241,7 @@ where
 	/// `codeword_oracle` is the [`BatchBrakedownOracleProver`] for the originally committed
 	/// interleaved codeword(s), and `fri_oracles` holds one [`FRIOracleProver`] per fold arity. The
 	/// terminal codeword is sent in full and therefore is not represented here.
-	pub fn new(
+	pub const fn new(
 		codeword_oracle: BatchBrakedownOracleProver<'a, P, MerkleProver>,
 		fri_oracles: Vec<FRIOracleProver<'a, F, MerkleProver>>,
 	) -> Self {
@@ -252,7 +252,7 @@ where
 	}
 
 	/// Number of oracles sent during the fold rounds.
-	pub fn n_oracles(&self) -> usize {
+	pub const fn n_oracles(&self) -> usize {
 		1 + self.fri_oracles.len()
 	}
 

--- a/crates/iop-prover/src/naive_channel.rs
+++ b/crates/iop-prover/src/naive_channel.rs
@@ -60,7 +60,7 @@ where
 	///
 	/// * `transcript` - The prover transcript for Fiat-Shamir (borrowed mutably)
 	/// * `oracle_specs` - Specifications for each oracle to be committed
-	pub fn new(
+	pub const fn new(
 		transcript: &'a mut ProverTranscript<Challenger_>,
 		oracle_specs: Vec<OracleSpec>,
 	) -> Self {
@@ -74,7 +74,7 @@ where
 	}
 
 	/// Returns a reference to the underlying transcript.
-	pub fn transcript(&self) -> &ProverTranscript<Challenger_> {
+	pub const fn transcript(&self) -> &ProverTranscript<Challenger_> {
 		self.transcript
 	}
 

--- a/crates/iop/src/basefold_channel.rs
+++ b/crates/iop/src/basefold_channel.rs
@@ -75,7 +75,7 @@ where
 	///
 	/// The FRI parameters should already account for ZK (log_batch_size = 1, doubled message
 	/// length).
-	pub fn from_precomputed(
+	pub const fn from_precomputed(
 		transcript: &'a mut VerifierTranscript<Challenger_>,
 		merkle_scheme: &'a MerkleScheme_,
 		oracle_specs: &'a [OracleSpec],
@@ -93,7 +93,7 @@ where
 	}
 
 	/// Returns a reference to the underlying transcript.
-	pub fn transcript(&self) -> &VerifierTranscript<Challenger_> {
+	pub const fn transcript(&self) -> &VerifierTranscript<Challenger_> {
 		self.transcript
 	}
 

--- a/crates/iop/src/basefold_compiler.rs
+++ b/crates/iop/src/basefold_compiler.rs
@@ -95,12 +95,12 @@ where
 	}
 
 	/// Returns a reference to the precomputed combined FRI parameters.
-	pub fn fri_params(&self) -> &FRIParams<F> {
+	pub const fn fri_params(&self) -> &FRIParams<F> {
 		&self.fri_params
 	}
 
 	/// Returns a reference to the Merkle scheme.
-	pub fn merkle_scheme(&self) -> &MerkleScheme_ {
+	pub const fn merkle_scheme(&self) -> &MerkleScheme_ {
 		&self.merkle_scheme
 	}
 

--- a/crates/iop/src/channel.rs
+++ b/crates/iop/src/channel.rs
@@ -46,7 +46,7 @@ pub struct OracleSpec {
 
 impl OracleSpec {
 	/// A non-ZK (unmasked) oracle of the given message length.
-	pub fn new(log_msg_len: usize) -> Self {
+	pub const fn new(log_msg_len: usize) -> Self {
 		Self {
 			log_msg_len,
 			is_zk: false,
@@ -54,7 +54,7 @@ impl OracleSpec {
 	}
 
 	/// A ZK (masked, hiding) oracle of the given message length.
-	pub fn new_zk(log_msg_len: usize) -> Self {
+	pub const fn new_zk(log_msg_len: usize) -> Self {
 		Self {
 			log_msg_len,
 			is_zk: true,

--- a/crates/iop/src/fri/batch.rs
+++ b/crates/iop/src/fri/batch.rs
@@ -63,7 +63,7 @@ impl<F: BinaryField, MTScheme: MerkleTreeScheme<F>> BrakedownOracle<F, MTScheme>
 	/// `log_lift` is the oracle-padding lift factor (the committed codeword is virtually duplicated
 	/// `2^log_lift` times to reach the common first-round length); pass `0` when no lifting is
 	/// needed.
-	pub fn new(
+	pub const fn new(
 		challenges: Vec<F>,
 		commitment: Commitment<MTScheme::Digest>,
 		merkle_scheme: MTScheme,
@@ -202,7 +202,7 @@ where
 {
 	/// Constructs a new oracle from a committed oracle, its folding challenges, and the domain
 	/// context providing the FRI fold twiddles.
-	pub fn new(
+	pub const fn new(
 		challenges: Vec<F>,
 		commitment: Commitment<MTScheme::Digest>,
 		merkle_scheme: MTScheme,
@@ -217,7 +217,7 @@ where
 	}
 
 	/// The base-2 log of the size of each coset opened from the committed oracle.
-	fn coset_log_size(&self) -> usize {
+	const fn coset_log_size(&self) -> usize {
 		self.challenges.len()
 	}
 

--- a/crates/iop/src/fri/common.rs
+++ b/crates/iop/src/fri/common.rs
@@ -84,7 +84,7 @@ pub struct CodewordSpec {
 
 impl CodewordSpec {
 	/// log2 the interleaved batch size: the early plus the later batch challenges.
-	pub fn log_batch_size(&self) -> usize {
+	pub const fn log_batch_size(&self) -> usize {
 		self.log_early_batch_size + self.log_later_batch_size
 	}
 }
@@ -272,23 +272,23 @@ where
 	///
 	/// This is the largest input message length, plus `log_n_oracles` extra rounds that fold the
 	/// distinct input oracles together into the batched codeword.
-	pub fn n_fold_rounds(&self) -> usize {
+	pub const fn n_fold_rounds(&self) -> usize {
 		self.max_log_msg_len + self.log_n_oracles
 	}
 
 	/// Number of oracles sent during the fold rounds.
-	pub fn n_oracles(&self) -> usize {
+	pub const fn n_oracles(&self) -> usize {
 		// One for the batched codeword commitment, and one for each subsequent one.
 		1 + self.fold_arities.len()
 	}
 
 	/// Number of bits in the query indices sampled during the query phase.
-	pub fn index_bits(&self) -> usize {
+	pub const fn index_bits(&self) -> usize {
 		self.rs_code.log_len()
 	}
 
 	/// Number of folding challenges the verifier sends after receiving the last oracle.
-	pub fn n_final_challenges(&self) -> usize {
+	pub const fn n_final_challenges(&self) -> usize {
 		self.log_terminal_dim
 	}
 
@@ -316,7 +316,7 @@ where
 	///
 	/// This includes the `log_n_oracles` extra rounds used to fold the distinct input oracles
 	/// together, so it equals [`Self::n_fold_rounds`].
-	pub fn log_msg_len(&self) -> usize {
+	pub const fn log_msg_len(&self) -> usize {
 		self.max_log_msg_len + self.log_n_oracles
 	}
 }
@@ -591,7 +591,7 @@ where
 	F: Field,
 	MTScheme: MerkleTreeScheme<F>,
 {
-	fn new(merkle_scheme: &'a MTScheme, n_test_queries: usize) -> Self {
+	const fn new(merkle_scheme: &'a MTScheme, n_test_queries: usize) -> Self {
 		Self {
 			merkle_scheme,
 			n_test_queries,
@@ -743,7 +743,7 @@ pub struct ConstantArityStrategy {
 
 impl ConstantArityStrategy {
 	/// Creates a new strategy with the given arity.
-	pub fn new(arity: usize) -> Self {
+	pub const fn new(arity: usize) -> Self {
 		Self { arity }
 	}
 

--- a/crates/iop/src/fri/fold.rs
+++ b/crates/iop/src/fri/fold.rs
@@ -212,7 +212,7 @@ where
 	}
 
 	/// Returns true if all rounds have been processed.
-	pub fn is_complete(&self) -> bool {
+	pub const fn is_complete(&self) -> bool {
 		self.curr_round == self.n_rounds()
 	}
 
@@ -235,12 +235,12 @@ where
 	}
 
 	/// Returns the current round number.
-	pub fn current_round(&self) -> usize {
+	pub const fn current_round(&self) -> usize {
 		self.curr_round
 	}
 
 	/// Returns the total number of rounds.
-	pub fn n_rounds(&self) -> usize {
+	pub const fn n_rounds(&self) -> usize {
 		self.commit_rounds.len()
 	}
 }

--- a/crates/iop/src/fri/verify.rs
+++ b/crates/iop/src/fri/verify.rs
@@ -201,7 +201,7 @@ where
 	}
 
 	/// Number of oracles sent during the fold rounds.
-	pub fn n_oracles(&self) -> usize {
+	pub const fn n_oracles(&self) -> usize {
 		self.params.n_oracles()
 	}
 

--- a/crates/iop/src/naive_channel.rs
+++ b/crates/iop/src/naive_channel.rs
@@ -60,7 +60,7 @@ where
 	///
 	/// * `transcript` - The verifier transcript for Fiat-Shamir (borrowed mutably)
 	/// * `oracle_specs` - Specifications for each oracle to be received (borrowed)
-	pub fn new(
+	pub const fn new(
 		transcript: &'a mut VerifierTranscript<Challenger_>,
 		oracle_specs: &'a [OracleSpec],
 	) -> Self {
@@ -73,7 +73,7 @@ where
 	}
 
 	/// Returns a reference to the underlying transcript.
-	pub fn transcript(&self) -> &VerifierTranscript<Challenger_> {
+	pub const fn transcript(&self) -> &VerifierTranscript<Challenger_> {
 		self.transcript
 	}
 

--- a/crates/iop/src/size_tracking_channel.rs
+++ b/crates/iop/src/size_tracking_channel.rs
@@ -41,7 +41,7 @@ impl<'a, F: BinaryField, MerkleScheme_: MerkleTreeScheme<F>>
 	SizeTrackingChannel<'a, F, MerkleScheme_>
 {
 	/// Creates a new size-tracking channel with default element (16) and oracle (32) sizes.
-	pub fn new(
+	pub const fn new(
 		oracle_specs: Vec<OracleSpec>,
 		fri_params: &'a [FRIParams<F>],
 		merkle_scheme: &'a MerkleScheme_,
@@ -56,7 +56,7 @@ impl<'a, F: BinaryField, MerkleScheme_: MerkleTreeScheme<F>>
 	}
 
 	/// Creates a new size-tracking channel with custom element and oracle sizes.
-	pub fn with_sizes(
+	pub const fn with_sizes(
 		oracle_specs: Vec<OracleSpec>,
 		fri_params: &'a [FRIParams<F>],
 		merkle_scheme: &'a MerkleScheme_,
@@ -75,7 +75,7 @@ impl<'a, F: BinaryField, MerkleScheme_: MerkleTreeScheme<F>>
 	}
 
 	/// Returns the accumulated proof size in bytes.
-	pub fn proof_size(&self) -> usize {
+	pub const fn proof_size(&self) -> usize {
 		self.proof_size
 	}
 }

--- a/crates/ip-prover/src/fracaddcheck.rs
+++ b/crates/ip-prover/src/fracaddcheck.rs
@@ -88,7 +88,7 @@ where
 	}
 
 	/// Returns the number of remaining layers to prove.
-	pub fn n_layers(&self) -> usize {
+	pub const fn n_layers(&self) -> usize {
 		self.layers.len()
 	}
 

--- a/crates/ip-prover/src/prodcheck.rs
+++ b/crates/ip-prover/src/prodcheck.rs
@@ -79,7 +79,7 @@ where
 	}
 
 	/// Returns the number of remaining layers to prove.
-	pub fn n_layers(&self) -> usize {
+	pub const fn n_layers(&self) -> usize {
 		self.layers.len()
 	}
 

--- a/crates/ip-prover/src/sumcheck/gruen32.rs
+++ b/crates/ip-prover/src/sumcheck/gruen32.rs
@@ -71,15 +71,15 @@ impl<F: Field, P: PackedField<Scalar = F>> Gruen32<P> {
 		&self.chunk_eq_expansion
 	}
 
-	pub fn chunk_eq_expansion(&self) -> &FieldBuffer<P> {
+	pub const fn chunk_eq_expansion(&self) -> &FieldBuffer<P> {
 		&self.chunk_eq_expansion
 	}
 
-	pub fn suffix_eq_expansion(&self) -> &FieldBuffer<P> {
+	pub const fn suffix_eq_expansion(&self) -> &FieldBuffer<P> {
 		&self.suffix_eq_expansion
 	}
 
-	pub fn n_vars_remaining(&self) -> usize {
+	pub const fn n_vars_remaining(&self) -> usize {
 		self.n_vars_remaining
 	}
 

--- a/crates/ip-prover/src/sumcheck/mle_to_sumcheck.rs
+++ b/crates/ip-prover/src/sumcheck/mle_to_sumcheck.rs
@@ -32,7 +32,7 @@ pub struct MleToSumCheckDecorator<F: Field, InnerProver> {
 }
 
 impl<F: Field, InnerProver: MleCheckProver<F>> MleToSumCheckDecorator<F, InnerProver> {
-	pub fn new(mlecheck_prover: InnerProver) -> Self {
+	pub const fn new(mlecheck_prover: InnerProver) -> Self {
 		Self {
 			mlecheck_prover,
 			eq_prefix_eval: F::ONE,

--- a/crates/ip-prover/src/sumcheck/padded.rs
+++ b/crates/ip-prover/src/sumcheck/padded.rs
@@ -42,7 +42,7 @@ pub struct PaddedSumcheckDecorator<F: Field, Inner> {
 
 impl<F: Field, Inner: SumcheckProver<F>> PaddedSumcheckDecorator<F, Inner> {
 	/// Wraps `inner`, padding its claim with `n_extra_vars` extra (highest-indexed) variables.
-	pub fn new(inner: Inner, n_extra_vars: usize) -> Self {
+	pub const fn new(inner: Inner, n_extra_vars: usize) -> Self {
 		Self {
 			inner,
 			n_extra_vars,
@@ -52,7 +52,7 @@ impl<F: Field, Inner: SumcheckProver<F>> PaddedSumcheckDecorator<F, Inner> {
 	}
 
 	/// Whether the current round binds one of the padding variables.
-	fn in_padding_phase(&self) -> bool {
+	const fn in_padding_phase(&self) -> bool {
 		self.round < self.n_extra_vars
 	}
 }

--- a/crates/ip-prover/src/sumcheck/switchover.rs
+++ b/crates/ip-prover/src/sumcheck/switchover.rs
@@ -71,7 +71,7 @@ where
 	}
 
 	// Number of variables in all 1-bit multilinears at start of sumcheck.
-	fn n_vars_transparent(&self) -> usize {
+	const fn n_vars_transparent(&self) -> usize {
 		checked_log_2(self.bitmasks.len())
 	}
 

--- a/crates/ip-prover/src/sumcheck/zk_mlecheck.rs
+++ b/crates/ip-prover/src/sumcheck/zk_mlecheck.rs
@@ -114,7 +114,7 @@ impl<F: Field, P: PackedField<Scalar = F>, Data: Deref<Target = [P]>> Mask<P, Da
 	/// * `n_vars` - Number of variables (n).
 	/// * `degree` - Degree of each univariate polynomial (d).
 	/// * `buffer` - Buffer with log_len = m_n + m_d.
-	pub fn new(n_vars: usize, degree: usize, buffer: FieldBuffer<P, Data>) -> Self {
+	pub const fn new(n_vars: usize, degree: usize, buffer: FieldBuffer<P, Data>) -> Self {
 		Self {
 			n_vars,
 			degree,
@@ -123,17 +123,17 @@ impl<F: Field, P: PackedField<Scalar = F>, Data: Deref<Target = [P]>> Mask<P, Da
 	}
 
 	/// Returns the number of variables.
-	pub fn n_vars(&self) -> usize {
+	pub const fn n_vars(&self) -> usize {
 		self.n_vars
 	}
 
 	/// Returns the degree of each univariate polynomial.
-	pub fn degree(&self) -> usize {
+	pub const fn degree(&self) -> usize {
 		self.degree
 	}
 
 	/// Returns m_d = ceil(log2(degree + 1)).
-	fn log_degree_plus_one(&self) -> usize {
+	const fn log_degree_plus_one(&self) -> usize {
 		(self.degree + 1).next_power_of_two().ilog2() as usize
 	}
 
@@ -257,7 +257,7 @@ impl<F: Field, P: PackedField<Scalar = F>, Data: Deref<Target = [P]>>
 
 	/// Returns the index of the current variable being processed.
 	/// Processing is high-to-low, so we start at n_vars-1 and decrease.
-	fn current_var_index(&self) -> usize {
+	const fn current_var_index(&self) -> usize {
 		self.n_vars_remaining - 1
 	}
 }

--- a/crates/m4-prover/src/value_table.rs
+++ b/crates/m4-prover/src/value_table.rs
@@ -132,22 +132,22 @@ impl ValueTable {
 	}
 
 	/// The base-2 logarithm of the number of instances.
-	pub fn log_instances(&self) -> usize {
+	pub const fn log_instances(&self) -> usize {
 		self.log_instances
 	}
 
 	/// The number of instances in the batch.
-	pub fn n_instances(&self) -> usize {
+	pub const fn n_instances(&self) -> usize {
 		1usize << self.log_instances
 	}
 
 	/// The per-instance value layout shared by every instance.
-	pub fn layout(&self) -> &ValueVecLayout {
+	pub const fn layout(&self) -> &ValueVecLayout {
 		&self.layout
 	}
 
 	/// The number of committed words occupied by a single instance.
-	pub fn instance_stride(&self) -> usize {
+	pub const fn instance_stride(&self) -> usize {
 		self.layout.committed_total_len
 	}
 

--- a/crates/m4-verifier/src/commit.rs
+++ b/crates/m4-verifier/src/commit.rs
@@ -84,7 +84,7 @@ impl BatchCommitLayout {
 	}
 
 	/// The number of words one instance occupies after power-of-two padding.
-	pub fn padded_instance_words(&self) -> usize {
+	pub const fn padded_instance_words(&self) -> usize {
 		1 << self.log_instance_words
 	}
 }

--- a/crates/m4-verifier/src/verify.rs
+++ b/crates/m4-verifier/src/verify.rs
@@ -78,14 +78,14 @@ impl Verifier {
 	}
 
 	/// The committed-multilinear shape this verifier expects.
-	pub fn layout(&self) -> &BatchCommitLayout {
+	pub const fn layout(&self) -> &BatchCommitLayout {
 		&self.layout
 	}
 
 	/// The precomputed BaseFold verifier compiler.
 	///
 	/// The prover reuses it so both sides share one set of FRI parameters.
-	pub fn iop_compiler(&self) -> &BaseFoldVerifierCompiler<B128, Scheme> {
+	pub const fn iop_compiler(&self) -> &BaseFoldVerifierCompiler<B128, Scheme> {
 		&self.iop_compiler
 	}
 

--- a/crates/math/benches/ntt.rs
+++ b/crates/math/benches/ntt.rs
@@ -219,7 +219,7 @@ fn bench_fields(c: &mut Criterion) {
 }
 
 /// Gives the number of raw field multiplications that are done for an NTT with specific parameters.
-fn num_muls(log_d: usize, skip_early: usize, skip_late: usize) -> u64 {
+const fn num_muls(log_d: usize, skip_early: usize, skip_late: usize) -> u64 {
 	let num_rounds = log_d - skip_late - skip_early;
 	let muls_per_round = 1u64 << (log_d - 1);
 

--- a/crates/math/src/bit_reverse.rs
+++ b/crates/math/src/bit_reverse.rs
@@ -16,7 +16,7 @@ use crate::field_buffer::FieldSliceMut;
 /// # Returns
 ///
 /// The value with its low `bits` bits reversed
-pub fn reverse_bits(x: usize, bits: u32) -> usize {
+pub const fn reverse_bits(x: usize, bits: u32) -> usize {
 	x.reverse_bits().unbounded_shr(usize::BITS - bits)
 }
 

--- a/crates/math/src/field_buffer.rs
+++ b/crates/math/src/field_buffer.rs
@@ -176,7 +176,7 @@ impl<P: PackedField, Data: Deref<Target = [P]>> FieldBuffer<P, Data> {
 	}
 
 	/// Returns the number of field elements.
-	pub fn len(&self) -> usize {
+	pub const fn len(&self) -> usize {
 		1 << self.log_len
 	}
 
@@ -719,7 +719,7 @@ impl<P: PackedField, Data: DerefMut<Target = [P]>> AsSlicesMut<P, 2>
 pub struct FieldBufferChunkMut<'a, P: PackedField>(FieldBufferChunkMutInner<'a, P>);
 
 impl<'a, P: PackedField> FieldBufferChunkMut<'a, P> {
-	pub fn get(&mut self) -> FieldSliceMut<'_, P> {
+	pub const fn get(&mut self) -> FieldSliceMut<'_, P> {
 		match &mut self.0 {
 			FieldBufferChunkMutInner::Single {
 				log_len,

--- a/crates/math/src/ntt/neighbors_last.rs
+++ b/crates/math/src/ntt/neighbors_last.rs
@@ -372,7 +372,7 @@ pub struct NeighborsLastSingleThread<DC> {
 
 impl<DC> NeighborsLastSingleThread<DC> {
 	/// Convenience constructor which sets `log_base_len` to a reasonable default.
-	pub fn new(domain_context: DC) -> Self {
+	pub const fn new(domain_context: DC) -> Self {
 		Self {
 			domain_context,
 			log_base_len: DEFAULT_LOG_BASE_LEN,
@@ -449,7 +449,7 @@ pub struct NeighborsLastMultiThread<DC> {
 
 impl<DC> NeighborsLastMultiThread<DC> {
 	/// Convenience constructor which sets `log_base_len` to a reasonable default.
-	pub fn new(domain_context: DC, log_num_shares: usize) -> Self {
+	pub const fn new(domain_context: DC, log_num_shares: usize) -> Self {
 		Self {
 			domain_context,
 			log_base_len: DEFAULT_LOG_BASE_LEN,

--- a/crates/math/src/univariate.rs
+++ b/crates/math/src/univariate.rs
@@ -161,11 +161,11 @@ impl<F: Field> EvaluationDomain<F> {
 		Self { points, weights }
 	}
 
-	pub fn size(&self) -> usize {
+	pub const fn size(&self) -> usize {
 		self.points.len()
 	}
 
-	pub fn points(&self) -> &[F] {
+	pub const fn points(&self) -> &[F] {
 		self.points.as_slice()
 	}
 

--- a/crates/prover/src/and_reduction/prover.rs
+++ b/crates/prover/src/and_reduction/prover.rs
@@ -125,7 +125,7 @@ where
 	///
 	/// The polynomial evaluations are precomputed in the constructor using the NTT lookup table
 	/// for efficiency. This method simply returns the cached result.
-	pub fn execute(&self) -> &[F; ROWS_PER_HYPERCUBE_VERTEX] {
+	pub const fn execute(&self) -> &[F; ROWS_PER_HYPERCUBE_VERTEX] {
 		&self.univariate_round_message
 	}
 

--- a/crates/prover/src/and_reduction/sumcheck_round_messages.rs
+++ b/crates/prover/src/and_reduction/sumcheck_round_messages.rs
@@ -201,7 +201,7 @@ impl<F: BinaryField + From<B8>> B8ToExtMulMap<F> {
 	}
 
 	#[inline]
-	fn call(&self, input: B8) -> F {
+	const fn call(&self, input: B8) -> F {
 		self.lookup[input.val() as usize]
 	}
 }

--- a/crates/prover/src/protocols/intmul/prove.rs
+++ b/crates/prover/src/protocols/intmul/prove.rs
@@ -57,7 +57,7 @@ pub struct IntMulProver<'a, P, S, Channel> {
 }
 
 impl<'a, P, S, Channel> IntMulProver<'a, P, S, Channel> {
-	pub fn new(switchover: usize, channel: &'a mut Channel) -> Self {
+	pub const fn new(switchover: usize, channel: &'a mut Channel) -> Self {
 		Self {
 			_p_marker: PhantomData,
 			_s_marker: PhantomData,

--- a/crates/prover/src/protocols/intmul/witness.rs
+++ b/crates/prover/src/protocols/intmul/witness.rs
@@ -301,7 +301,7 @@ where
 		}
 	}
 
-	pub fn log_bits(&self) -> usize {
+	pub const fn log_bits(&self) -> usize {
 		self.tree.len() - 1
 	}
 

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -79,14 +79,14 @@ impl IOPProver {
 	}
 
 	/// Returns the constraint system.
-	pub fn constraint_system(&self) -> &ConstraintSystem {
+	pub const fn constraint_system(&self) -> &ConstraintSystem {
 		&self.constraint_system
 	}
 
 	/// Returns a reference to the KeyCollection.
 	///
 	/// This can be used to serialize the KeyCollection for later use.
-	pub fn key_collection(&self) -> &KeyCollection {
+	pub const fn key_collection(&self) -> &KeyCollection {
 		&self.key_collection
 	}
 
@@ -314,14 +314,14 @@ where
 	}
 
 	/// Returns a reference to the IOP prover.
-	pub fn iop_prover(&self) -> &IOPProver {
+	pub const fn iop_prover(&self) -> &IOPProver {
 		&self.iop_prover
 	}
 
 	/// Returns a reference to the KeyCollection.
 	///
 	/// This can be used to serialize the KeyCollection for later use.
-	pub fn key_collection(&self) -> &KeyCollection {
+	pub const fn key_collection(&self) -> &KeyCollection {
 		self.iop_prover.key_collection()
 	}
 

--- a/crates/prover/src/zk_config.rs
+++ b/crates/prover/src/zk_config.rs
@@ -137,12 +137,12 @@ where
 	}
 
 	/// Returns a reference to the inner IOP prover.
-	pub fn inner_iop_prover(&self) -> &IOPProver {
+	pub const fn inner_iop_prover(&self) -> &IOPProver {
 		&self.inner_iop_prover
 	}
 
 	/// Returns a reference to the KeyCollection.
-	pub fn key_collection(&self) -> &crate::protocols::shift::KeyCollection {
+	pub const fn key_collection(&self) -> &crate::protocols::shift::KeyCollection {
 		self.inner_iop_prover.key_collection()
 	}
 

--- a/crates/spartan-frontend/src/circuit_builder.rs
+++ b/crates/spartan-frontend/src/circuit_builder.rs
@@ -65,11 +65,11 @@ pub struct WireAllocator {
 }
 
 impl WireAllocator {
-	pub fn new(kind: WireKind) -> Self {
+	pub const fn new(kind: WireKind) -> Self {
 		WireAllocator { n_wires: 0, kind }
 	}
 
-	pub fn alloc(&mut self) -> ConstraintWire {
+	pub const fn alloc(&mut self) -> ConstraintWire {
 		let wire = ConstraintWire {
 			kind: self.kind,
 			id: self.n_wires,
@@ -254,11 +254,11 @@ impl<F: Field> ConstraintBuilder<F> {
 		}
 	}
 
-	pub fn alloc_inout(&mut self) -> ConstraintWire {
+	pub const fn alloc_inout(&mut self) -> ConstraintWire {
 		self.ir.public_alloc.alloc()
 	}
 
-	pub fn alloc_precommit(&mut self) -> ConstraintWire {
+	pub const fn alloc_precommit(&mut self) -> ConstraintWire {
 		self.ir.precommit_alloc.alloc()
 	}
 
@@ -378,7 +378,7 @@ pub struct WitnessWire<F: Field> {
 
 impl<F: Field> WitnessWire<F> {
 	#[inline]
-	pub fn val(self) -> F {
+	pub const fn val(self) -> F {
 		self.val
 	}
 
@@ -468,7 +468,7 @@ impl<'a, F: Field> WitnessGenerator<'a, F> {
 		}
 	}
 
-	pub fn error(&self) -> Option<&Backtrace> {
+	pub const fn error(&self) -> Option<&Backtrace> {
 		self.first_error.as_ref()
 	}
 
@@ -553,7 +553,7 @@ impl<F: Field> PublicWire<F> {
 	/// The wire's value if it is public-derivable (constant, inout, or derived), else `None` for a
 	/// private/precommit wire whose value the verifier does not know.
 	#[inline]
-	pub fn value(self) -> Option<F> {
+	pub const fn value(self) -> Option<F> {
 		self.0
 	}
 }

--- a/crates/spartan-frontend/src/constraint_system.rs
+++ b/crates/spartan-frontend/src/constraint_system.rs
@@ -27,7 +27,7 @@ pub enum WireKind {
 impl WireKind {
 	/// The witness segment a wire of this kind lives in: constants, inout, and derived wires occupy
 	/// the public segment; precommit and private wires occupy their own segments.
-	pub fn segment(self) -> WitnessSegment {
+	pub const fn segment(self) -> WitnessSegment {
 		match self {
 			WireKind::Constant | WireKind::InOut | WireKind::Derived => WitnessSegment::Public,
 			WireKind::Precommit => WitnessSegment::Precommit,
@@ -57,7 +57,7 @@ impl ConstraintWire {
 	/// Creates a constraint wire referencing an inout wire by ID.
 	///
 	/// TODO: This is not ideal, and instead we should use some sort of allocator.
-	pub fn inout(id: u32) -> Self {
+	pub const fn inout(id: u32) -> Self {
 		Self {
 			kind: WireKind::InOut,
 			id,
@@ -65,7 +65,7 @@ impl ConstraintWire {
 	}
 
 	/// Creates a constraint wire referencing a precommit wire by ID.
-	pub fn precommit(id: u32) -> Self {
+	pub const fn precommit(id: u32) -> Self {
 		Self {
 			kind: WireKind::Precommit,
 			id,
@@ -191,21 +191,21 @@ pub struct WitnessIndex {
 }
 
 impl WitnessIndex {
-	pub fn public(index: u32) -> Self {
+	pub const fn public(index: u32) -> Self {
 		Self {
 			segment: WitnessSegment::Public,
 			index,
 		}
 	}
 
-	pub fn precommit(index: u32) -> Self {
+	pub const fn precommit(index: u32) -> Self {
 		Self {
 			segment: WitnessSegment::Precommit,
 			index,
 		}
 	}
 
-	pub fn private(index: u32) -> Self {
+	pub const fn private(index: u32) -> Self {
 		Self {
 			segment: WitnessSegment::Private,
 			index,
@@ -220,7 +220,7 @@ pub struct Witness<F> {
 }
 
 impl<F> Witness<F> {
-	pub fn new(public: Vec<F>, precommit: Vec<F>, private: Vec<F>) -> Self {
+	pub const fn new(public: Vec<F>, precommit: Vec<F>, private: Vec<F>) -> Self {
 		Self {
 			public,
 			precommit,
@@ -283,7 +283,7 @@ pub struct ConstraintSystem<F: Field> {
 
 impl<F: Field> ConstraintSystem<F> {
 	/// Create a new constraint system.
-	pub fn new(
+	pub const fn new(
 		constants: Vec<F>,
 		n_inout: u32,
 		n_precommit: u32,
@@ -307,23 +307,23 @@ impl<F: Field> ConstraintSystem<F> {
 		&self.constants
 	}
 
-	pub fn n_inout(&self) -> u32 {
+	pub const fn n_inout(&self) -> u32 {
 		self.n_inout
 	}
 
-	pub fn n_precommit(&self) -> u32 {
+	pub const fn n_precommit(&self) -> u32 {
 		self.n_precommit
 	}
 
-	pub fn n_private(&self) -> u32 {
+	pub const fn n_private(&self) -> u32 {
 		self.n_private
 	}
 
-	pub fn log_public(&self) -> u32 {
+	pub const fn log_public(&self) -> u32 {
 		self.log_public
 	}
 
-	pub fn n_public(&self) -> u32 {
+	pub const fn n_public(&self) -> u32 {
 		1 << self.log_public
 	}
 
@@ -331,7 +331,7 @@ impl<F: Field> ConstraintSystem<F> {
 		&self.mul_constraints
 	}
 
-	pub fn one_wire(&self) -> WitnessIndex {
+	pub const fn one_wire(&self) -> WitnessIndex {
 		WitnessIndex {
 			segment: WitnessSegment::Public,
 			index: self.one_wire_index,
@@ -443,52 +443,52 @@ impl<F: Field> WitnessLayout<F> {
 		}
 	}
 
-	pub fn public_size(&self) -> usize {
+	pub const fn public_size(&self) -> usize {
 		1 << self.log_public as usize
 	}
 
-	pub fn precommit_size(&self) -> usize {
+	pub const fn precommit_size(&self) -> usize {
 		1 << self.log_precommit as usize
 	}
 
-	pub fn private_size(&self) -> usize {
+	pub const fn private_size(&self) -> usize {
 		1 << self.log_private as usize
 	}
 
-	pub fn n_constants(&self) -> usize {
+	pub const fn n_constants(&self) -> usize {
 		self.constants.len()
 	}
 
-	pub fn n_inout(&self) -> usize {
+	pub const fn n_inout(&self) -> usize {
 		self.n_inout as usize
 	}
 
-	pub fn n_derived(&self) -> usize {
+	pub const fn n_derived(&self) -> usize {
 		self.n_derived as usize
 	}
 
-	pub fn n_precommit(&self) -> usize {
+	pub const fn n_precommit(&self) -> usize {
 		self.n_precommit as usize
 	}
 
-	pub fn n_private(&self) -> usize {
+	pub const fn n_private(&self) -> usize {
 		self.n_private as usize
 	}
 
-	pub fn log_public(&self) -> u32 {
+	pub const fn log_public(&self) -> u32 {
 		self.log_public
 	}
 
-	pub fn log_precommit(&self) -> u32 {
+	pub const fn log_precommit(&self) -> u32 {
 		self.log_precommit
 	}
 
-	pub fn log_private(&self) -> u32 {
+	pub const fn log_private(&self) -> u32 {
 		self.log_private
 	}
 
 	/// Returns the first index of the inout
-	pub fn inout_offset(&self) -> WitnessIndex {
+	pub const fn inout_offset(&self) -> WitnessIndex {
 		WitnessIndex::public(self.constants.len() as u32)
 	}
 

--- a/crates/spartan-prover/src/lib.rs
+++ b/crates/spartan-prover/src/lib.rs
@@ -123,7 +123,7 @@ impl<F: Field> IOPProver<F> {
 		}
 	}
 
-	pub fn constraint_system(&self) -> &ConstraintSystemPadded<F> {
+	pub const fn constraint_system(&self) -> &ConstraintSystemPadded<F> {
 		&self.constraint_system
 	}
 
@@ -357,12 +357,12 @@ where
 	}
 
 	/// Returns a reference to the IOP prover.
-	pub fn iop_prover(&self) -> &IOPProver<P::Scalar> {
+	pub const fn iop_prover(&self) -> &IOPProver<P::Scalar> {
 		&self.iop_prover
 	}
 
 	/// Returns a reference to the BaseFold ZK prover compiler.
-	pub fn iop_compiler(
+	pub const fn iop_compiler(
 		&self,
 	) -> &BaseFoldProverCompiler<P, ProverNTT<F>, ProverMerkleProver<F, H>> {
 		&self.basefold_compiler

--- a/crates/spartan-prover/src/wiring.rs
+++ b/crates/spartan-prover/src/wiring.rs
@@ -66,11 +66,11 @@ impl WiringTranspose {
 		}
 	}
 
-	pub fn log_size(&self) -> usize {
+	pub const fn log_size(&self) -> usize {
 		self.log_size
 	}
 
-	pub fn size(&self) -> usize {
+	pub const fn size(&self) -> usize {
 		1 << self.log_size
 	}
 
@@ -172,13 +172,13 @@ pub fn build_mulcheck_witness<F: Field, P: PackedField<Scalar = F>>(
 	precommit_packed: FieldSlice<P>,
 	private_packed: FieldSlice<P>,
 ) -> MulCheckWitness<P> {
-	fn get_a(c: &MulConstraint<WitnessIndex>) -> &Operand<WitnessIndex> {
+	const fn get_a(c: &MulConstraint<WitnessIndex>) -> &Operand<WitnessIndex> {
 		&c.a
 	}
-	fn get_b(c: &MulConstraint<WitnessIndex>) -> &Operand<WitnessIndex> {
+	const fn get_b(c: &MulConstraint<WitnessIndex>) -> &Operand<WitnessIndex> {
 		&c.b
 	}
-	fn get_c(c: &MulConstraint<WitnessIndex>) -> &Operand<WitnessIndex> {
+	const fn get_c(c: &MulConstraint<WitnessIndex>) -> &Operand<WitnessIndex> {
 		&c.c
 	}
 

--- a/crates/spartan-verifier/src/constraint_system.rs
+++ b/crates/spartan-verifier/src/constraint_system.rs
@@ -108,47 +108,47 @@ impl<F: Field> ConstraintSystemPadded<F> {
 		self.inner.constants()
 	}
 
-	pub fn n_inout(&self) -> u32 {
+	pub const fn n_inout(&self) -> u32 {
 		self.inner.n_inout()
 	}
 
-	pub fn n_precommit(&self) -> u32 {
+	pub const fn n_precommit(&self) -> u32 {
 		self.inner.n_precommit()
 	}
 
-	pub fn n_private(&self) -> u32 {
+	pub const fn n_private(&self) -> u32 {
 		self.inner.n_private()
 	}
 
-	pub fn log_public(&self) -> u32 {
+	pub const fn log_public(&self) -> u32 {
 		self.inner.log_public()
 	}
 
-	pub fn n_public(&self) -> u32 {
+	pub const fn n_public(&self) -> u32 {
 		self.inner.n_public()
 	}
 
-	pub fn one_wire(&self) -> WitnessIndex {
+	pub const fn one_wire(&self) -> WitnessIndex {
 		self.inner.one_wire()
 	}
 
-	pub fn log_precommit(&self) -> u32 {
+	pub const fn log_precommit(&self) -> u32 {
 		self.log_precommit
 	}
 
-	pub fn precommit_size(&self) -> usize {
+	pub const fn precommit_size(&self) -> usize {
 		1 << self.log_precommit as usize
 	}
 
-	pub fn log_private(&self) -> u32 {
+	pub const fn log_private(&self) -> u32 {
 		self.log_private
 	}
 
-	pub fn private_size(&self) -> usize {
+	pub const fn private_size(&self) -> usize {
 		1 << self.log_private as usize
 	}
 
-	pub fn blinding_info(&self) -> &BlindingInfo {
+	pub const fn blinding_info(&self) -> &BlindingInfo {
 		&self.blinding_info
 	}
 
@@ -157,7 +157,7 @@ impl<F: Field> ConstraintSystemPadded<F> {
 	}
 
 	/// Returns the mask buffer dimensions (m_n, m_d) for the ZK mulcheck mask polynomial.
-	pub fn mask_dims(&self) -> (usize, usize) {
+	pub const fn mask_dims(&self) -> (usize, usize) {
 		self.mask_dims
 	}
 

--- a/crates/spartan-verifier/src/lib.rs
+++ b/crates/spartan-verifier/src/lib.rs
@@ -97,11 +97,11 @@ where
 
 impl<F: Field> IOPVerifier<F> {
 	/// Constructs an IOP verifier for a constraint system.
-	pub fn new(constraint_system: ConstraintSystemPadded<F>) -> Self {
+	pub const fn new(constraint_system: ConstraintSystemPadded<F>) -> Self {
 		Self { constraint_system }
 	}
 
-	pub fn constraint_system(&self) -> &ConstraintSystemPadded<F> {
+	pub const fn constraint_system(&self) -> &ConstraintSystemPadded<F> {
 		&self.constraint_system
 	}
 
@@ -279,16 +279,16 @@ where
 	}
 
 	/// Returns a reference to the IOP verifier.
-	pub fn iop_verifier(&self) -> &IOPVerifier<F> {
+	pub const fn iop_verifier(&self) -> &IOPVerifier<F> {
 		&self.iop_verifier
 	}
 
-	pub fn constraint_system(&self) -> &ConstraintSystemPadded<F> {
+	pub const fn constraint_system(&self) -> &ConstraintSystemPadded<F> {
 		self.iop_verifier.constraint_system()
 	}
 
 	/// Returns a reference to the BaseFold ZK verifier compiler.
-	pub fn iop_compiler(&self) -> &BaseFoldVerifierCompiler<F, BinaryMerkleTreeScheme<F, H>> {
+	pub const fn iop_compiler(&self) -> &BaseFoldVerifierCompiler<F, BinaryMerkleTreeScheme<F, H>> {
 		&self.basefold_compiler
 	}
 

--- a/crates/spartan-verifier/src/wiring.rs
+++ b/crates/spartan-verifier/src/wiring.rs
@@ -113,7 +113,10 @@ pub struct PublicWiringEvalFn<'a> {
 
 impl<'a> PublicWiringEvalFn<'a> {
 	/// Builds the function from the constraints and the count of leading public inputs.
-	pub fn new(mul_constraints: &'a [MulConstraint<WitnessIndex>], public_len: usize) -> Self {
+	pub const fn new(
+		mul_constraints: &'a [MulConstraint<WitnessIndex>],
+		public_len: usize,
+	) -> Self {
 		Self {
 			mul_constraints,
 			public_len,

--- a/crates/utils/src/bitwise.rs
+++ b/crates/utils/src/bitwise.rs
@@ -33,7 +33,7 @@ pub struct BitSelector<B: Bitwise, S: AsRef<[B]>> {
 }
 
 impl<B: Bitwise, S: AsRef<[B]>> BitSelector<B, S> {
-	pub fn new(bit_offset: usize, slice: S) -> Self {
+	pub const fn new(bit_offset: usize, slice: S) -> Self {
 		Self {
 			bit_offset,
 			slice,

--- a/crates/utils/src/rayon/config.rs
+++ b/crates/utils/src/rayon/config.rs
@@ -42,6 +42,7 @@ pub fn adjust_thread_pool() -> &'static Result<(), ThreadPoolBuildError> {
 }
 
 /// Returns the base-2 logarithm of the number of threads that should be used for the task
+#[allow(clippy::missing_const_for_fn)]
 pub fn get_log_max_threads() -> usize {
 	(2 * current_num_threads() - 1).ilog2() as _
 }

--- a/crates/utils/src/strided_array.rs
+++ b/crates/utils/src/strided_array.rs
@@ -243,7 +243,7 @@ impl<T> IndexMut<(usize, usize)> for StridedArray2DViewMut<'_, T> {
 struct SendPtr<T>(*mut T);
 
 impl<T> SendPtr<T> {
-	fn as_ptr(self) -> *mut T {
+	const fn as_ptr(self) -> *mut T {
 		self.0
 	}
 }

--- a/crates/verifier/src/protocols/shift/verify.rs
+++ b/crates/verifier/src/protocols/shift/verify.rs
@@ -43,7 +43,7 @@ impl<F: FieldOps, const ARITY: usize> OperatorData<F, ARITY> {
 	// Constructs a new operator data instance encoding
 	// evaluation claim with multilinear challenge `r_x_prime` and evaluations `evals`
 	// (one eval for each operand of the operation).
-	pub fn new(r_x_prime: Vec<F>, evals: [F; ARITY]) -> Self {
+	pub const fn new(r_x_prime: Vec<F>, evals: [F; ARITY]) -> Self {
 		Self { r_x_prime, evals }
 	}
 

--- a/crates/verifier/src/verify.rs
+++ b/crates/verifier/src/verify.rs
@@ -55,7 +55,7 @@ impl IOPVerifier {
 	///
 	/// The constraint system must already be validated via
 	/// [`ConstraintSystem::validate_and_prepare`].
-	pub fn new(constraint_system: ConstraintSystem, log_public_words: usize) -> Self {
+	pub const fn new(constraint_system: ConstraintSystem, log_public_words: usize) -> Self {
 		Self {
 			constraint_system,
 			log_public_words,
@@ -63,7 +63,7 @@ impl IOPVerifier {
 	}
 
 	/// Returns the constraint system.
-	pub fn constraint_system(&self) -> &ConstraintSystem {
+	pub const fn constraint_system(&self) -> &ConstraintSystem {
 		&self.constraint_system
 	}
 
@@ -73,7 +73,7 @@ impl IOPVerifier {
 	}
 
 	/// Returns log2 of the number of public constants and input/output words.
-	pub fn log_public_words(&self) -> usize {
+	pub const fn log_public_words(&self) -> usize {
 		self.log_public_words
 	}
 
@@ -333,7 +333,7 @@ where
 	}
 
 	/// Returns a reference to the IOP verifier.
-	pub fn iop_verifier(&self) -> &IOPVerifier {
+	pub const fn iop_verifier(&self) -> &IOPVerifier {
 		&self.iop_verifier
 	}
 
@@ -353,27 +353,29 @@ where
 	}
 
 	/// Returns the constraint system.
-	pub fn constraint_system(&self) -> &ConstraintSystem {
+	pub const fn constraint_system(&self) -> &ConstraintSystem {
 		self.iop_verifier.constraint_system()
 	}
 
 	/// Returns the chosen FRI parameters.
-	pub fn fri_params(&self) -> &FRIParams<B128> {
+	pub const fn fri_params(&self) -> &FRIParams<B128> {
 		self.iop_compiler.fri_params()
 	}
 
 	/// Returns the [`crate::merkle_tree::MerkleTreeScheme`] instance used.
-	pub fn merkle_scheme(&self) -> &BinaryMerkleTreeScheme<B128, H> {
+	pub const fn merkle_scheme(&self) -> &BinaryMerkleTreeScheme<B128, H> {
 		self.iop_compiler.merkle_scheme()
 	}
 
 	/// Returns log2 of the number of public constants and input/output words.
-	pub fn log_public_words(&self) -> usize {
+	pub const fn log_public_words(&self) -> usize {
 		self.iop_verifier.log_public_words()
 	}
 
 	/// Returns the IOP compiler for creating verifier channels.
-	pub fn iop_compiler(&self) -> &BaseFoldVerifierCompiler<B128, BinaryMerkleTreeScheme<B128, H>> {
+	pub const fn iop_compiler(
+		&self,
+	) -> &BaseFoldVerifierCompiler<B128, BinaryMerkleTreeScheme<B128, H>> {
 		&self.iop_compiler
 	}
 

--- a/crates/verifier/src/zk_config.rs
+++ b/crates/verifier/src/zk_config.rs
@@ -140,29 +140,29 @@ where
 	}
 
 	/// Returns a reference to the inner IOP verifier.
-	pub fn inner_iop_verifier(&self) -> &IOPVerifier {
+	pub const fn inner_iop_verifier(&self) -> &IOPVerifier {
 		&self.inner_iop_verifier
 	}
 
 	/// Returns a reference to the outer spartan IOP verifier.
-	pub fn outer_iop_verifier(&self) -> &IronSpartanIOPVerifier<B128> {
+	pub const fn outer_iop_verifier(&self) -> &IronSpartanIOPVerifier<B128> {
 		&self.outer_iop_verifier
 	}
 
 	/// Returns the BaseFold ZK verifier compiler.
-	pub fn basefold_compiler(
+	pub const fn basefold_compiler(
 		&self,
 	) -> &BaseFoldVerifierCompiler<B128, BinaryMerkleTreeScheme<B128, H>> {
 		&self.basefold_compiler
 	}
 
 	/// Returns the constraint system.
-	pub fn constraint_system(&self) -> &ConstraintSystem {
+	pub const fn constraint_system(&self) -> &ConstraintSystem {
 		self.inner_iop_verifier.constraint_system()
 	}
 
 	/// Returns log2 of the number of public words.
-	pub fn log_public_words(&self) -> usize {
+	pub const fn log_public_words(&self) -> usize {
 		self.inner_iop_verifier.log_public_words()
 	}
 


### PR DESCRIPTION
One lint in isolation, split out from #1637 so its effect can be reviewed on its own.

Per the feedback on #1637 ("do them in separate commits so I can see the effects in isolation"), this PR enables a single lint and applies only its fixes.

### The lint

`clippy::missing_const_for_fn` (nursery): flags functions whose bodies are already const-evaluable but aren't declared `const fn`. Marking them `const` lets callers use them in const contexts (array lengths, `const`/`static` initializers, other const fns).

Enabled in the workspace config:

```toml
[workspace.lints.clippy]
needless_range_loop = "allow"
missing_const_for_fn = "warn"
```

All 21 crates already inherit it via `[lints] workspace = true`.

### The change

Almost entirely `pub fn` -> `pub const fn` one-liners, applied by `cargo clippy --fix`. No bodies changed; no behavior changed (a `const fn` compiles and runs identically when called at runtime).

### The one exception

`utils::rayon::config::get_log_max_threads` is deliberately left non-`const` with an explicit `#[allow(clippy::missing_const_for_fn)]`:

- without the `rayon` feature, `current_num_threads` is a `const fn` returning `1`, so the lint fires;
- with the `rayon` feature, `current_num_threads` is a non-const Rayon call, so `const fn` would not compile.

Marking it `const` (as the autofix did) breaks the `rayon` build, so it stays a regular `fn`.

### Scope

- **changed:** root `Cargo.toml` (one lint line) + `const` on eligible functions across the workspace
- **left untouched:** all logic and behavior

### Verification

- `cargo clippy --workspace --all-targets -- -D warnings` — exits 0
- `cargo clippy -p binius-utils --all-targets --features rayon -- -D warnings` — exits 0 (the `get_log_max_threads` allow holds)
- `cargo build --workspace --all-targets` — clean
- `cargo +nightly fmt --all --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)