### PR TITLE
Fix binius-hash build: migrate Blake3Compression off removed PseudoCompressionFunction

### DIFF
--- a/crates/hash/src/blake3.rs
+++ b/crates/hash/src/blake3.rs
@@ -5,17 +5,15 @@
 use digest::Output;
 
 use super::{
-	binary_merkle_tree::HashSuite,
-	compress::{CompressionFunction, PseudoCompressionFunction},
-	parallel_compression::ParallelCompressionAdaptor,
-	parallel_digest::ParallelDigestAdapter,
+	binary_merkle_tree::HashSuite, compress::CompressionFunction,
+	parallel_compression::ParallelCompressionAdaptor, parallel_digest::ParallelDigestAdapter,
 };
 
 /// A two-to-one compression function that hashes the concatenation of its inputs with Blake3.
 #[derive(Debug, Clone, Default)]
 pub struct Blake3Compression;
 
-impl PseudoCompressionFunction<Output<blake3::Hasher>, 2> for Blake3Compression {
+impl CompressionFunction<Output<blake3::Hasher>, 2> for Blake3Compression {
 	fn compress(&self, input: [Output<blake3::Hasher>; 2]) -> Output<blake3::Hasher> {
 		let mut hasher = blake3::Hasher::new();
 		hasher.update(input[0].as_slice());
@@ -23,8 +21,6 @@ impl PseudoCompressionFunction<Output<blake3::Hasher>, 2> for Blake3Compression 
 		(*hasher.finalize().as_bytes()).into()
 	}
 }
-
-impl CompressionFunction<Output<blake3::Hasher>, 2> for Blake3Compression {}
 
 /// Blake3 [`HashSuite`]: Blake3 leaves and a Blake3 compression function for inner nodes.
 #[derive(Debug, Clone, Default)]


### PR DESCRIPTION
`binius-hash` does not compile on `main` right now. This is a one-line-shaped fix for a bad interaction between two already-merged PRs.

### The problem

#1630 ("Remove dead abstractions from binius-hash") deleted the `PseudoCompressionFunction` trait and folded its `compress` method into `CompressionFunction`.

#1632 ("add Blake3 hash suite") landed around the same time and still implements the now-removed `PseudoCompressionFunction`.

The two merged into an inconsistent state, so `crates/hash/src/blake3.rs` fails to compile on `main`:

```
error[E0432]: unresolved import `super::compress::PseudoCompressionFunction`
error[E0046]: not all trait items implemented, missing: `compress`
```

`blake3` is an unconditional `pub mod`, so this breaks the entire `binius-hash` build — and every crate that depends on it.

### The fix

Implement `CompressionFunction` directly, carrying the `compress` method, exactly matching the post-#1630 shape of `Sha256Compression`:

```diff
-use super::compress::{CompressionFunction, PseudoCompressionFunction};
+use super::compress::CompressionFunction;

-impl PseudoCompressionFunction<Output<blake3::Hasher>, 2> for Blake3Compression {
-    fn compress(&self, input: [Output<blake3::Hasher>; 2]) -> Output<blake3::Hasher> { ... }
-}
-impl CompressionFunction<Output<blake3::Hasher>, 2> for Blake3Compression {}
+impl CompressionFunction<Output<blake3::Hasher>, 2> for Blake3Compression {
+    fn compress(&self, input: [Output<blake3::Hasher>; 2]) -> Output<blake3::Hasher> { ... }
+}
```

No behavior change — the compression body is identical.

### Scope

- **changed:** `crates/hash/src/blake3.rs` only
- the existing Blake3 tests are unchanged and still pass

### Verification

- `cargo build --workspace --all-targets` — clean (was failing before)
- `cargo clippy -p binius-hash --all-targets -- -D warnings` — exits 0
- `cargo +nightly fmt --all --check` — clean
- `cargo test -p binius-hash blake3` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)