### PR TITLE
BINIUS-171: IntMul batch Phase-1 Frobenius leaf claims with eq_6(γ,i) (D-V4)

### DIFF
--- a/crates/ip-prover/src/sumcheck/selector_mle.rs
+++ b/crates/ip-prover/src/sumcheck/selector_mle.rs
@@ -39,23 +39,34 @@ pub struct SelectorMlecheckProver<'b, P: PackedField, B: Bitwise> {
 	last_coeffs_or_sums: RoundCoeffsOrSums<P::Scalar>,
 	selected: FieldBuffer<P>,
 	gruen32s: Vec<Gruen32<P>>,
+	weights: Vec<P::Scalar>,
 	switchover: BinarySwitchover<'b, P, B>,
 }
 
 impl<'b, F: Field, P: PackedField<Scalar = F>, B: Bitwise> SelectorMlecheckProver<'b, P, B> {
 	/// Constructs a prover, given `bitmasks` as representation of 1-bit columns, `selected` being
-	/// the shared large field multilinear, individual `claims` per selector and `switchover` as
-	/// the round at which 1-bit columns should be folded.
+	/// the shared large field multilinear, individual `claims` per selector, `weights` to combine
+	/// the per-selector round polynomials into one (one weight per claim), and `switchover` as the
+	/// round at which 1-bit columns should be folded.
+	///
+	/// The prover exposes a single claim — the `weights`-combination `Σ_i weights[i] · C_i` of the
+	/// per-selector claims. Supplying the equality-indicator tensor `eq_k(γ, ·)` as the weights
+	/// batches the claims with `eq_k(γ, i)`.
 	pub fn new(
 		selected: FieldBuffer<P>,
 		claims: Vec<Claim<F>>,
 		bitmasks: &'b [B],
+		weights: Vec<F>,
 		switchover: usize,
 	) -> Result<Self, Error> {
 		let n_vars = selected.log_len();
 
 		if claims.iter().any(|claim| claim.point.len() != n_vars) {
 			return Err(Error::MultilinearSizeMismatch);
+		}
+
+		if weights.len() != claims.len() {
+			return Err(Error::EvalClaimsNumberMismatch);
 		}
 
 		if bitmasks.len() != selected.len() {
@@ -75,6 +86,7 @@ impl<'b, F: Field, P: PackedField<Scalar = F>, B: Bitwise> SelectorMlecheckProve
 			last_coeffs_or_sums,
 			selected,
 			gruen32s,
+			weights,
 			switchover,
 		})
 	}
@@ -91,21 +103,21 @@ where
 	}
 
 	fn n_claims(&self) -> usize {
-		match &self.last_coeffs_or_sums {
-			RoundCoeffsOrSums::Coeffs(v) => v.len(),
-			RoundCoeffsOrSums::Sums(v) => v.len(),
-		}
+		// The per-selector claims are combined into a single weighted claim.
+		1
 	}
 
 	fn round_claim(&self) -> Vec<F> {
-		match &self.last_coeffs_or_sums {
+		let per_claim: Vec<F> = match &self.last_coeffs_or_sums {
 			RoundCoeffsOrSums::Sums(sums) => sums.clone(),
 			// This prover has a separate evaluation point per claim, so each round polynomial is
 			// interpolated against its own coordinate.
 			RoundCoeffsOrSums::Coeffs(coeffs) => izip!(coeffs, &self.gruen32s)
 				.map(|(coeffs, gruen32)| coeffs.lerp_over_endpoints(gruen32.next_coordinate()))
 				.collect(),
-		}
+		};
+		// Combine the per-claim values into the single weighted claim `Σ_i weights[i] · m_i`.
+		vec![izip!(per_claim, &self.weights).map(|(m, &w)| m * w).sum()]
 	}
 
 	fn execute(&mut self) -> Result<Vec<RoundCoeffs<F>>, Error> {
@@ -214,7 +226,13 @@ where
 			.unzip::<_, _, Vec<_>, Vec<_>>();
 
 		self.last_coeffs_or_sums = RoundCoeffsOrSums::Coeffs(prime_coeffs);
-		Ok(round_coeffs)
+
+		// Combine the per-claim round polynomials into the single weighted round polynomial
+		// `Σ_i weights[i] · R_i`.
+		let combined = izip!(round_coeffs, &self.weights)
+			.map(|(coeffs, &w)| coeffs * w)
+			.sum();
+		Ok(vec![combined])
 	}
 
 	fn fold(&mut self, challenge: F) -> Result<(), Error> {
@@ -370,8 +388,10 @@ mod tests {
 			.unzip::<_, _, Vec<_>, Vec<_>>();
 
 		let switchover = 0;
+		let weights = random_scalars::<F>(&mut rng, selector_count);
 		let mut selector_prover =
-			SelectorMlecheckProver::new(selected, claims, &bitmasks, switchover).unwrap();
+			SelectorMlecheckProver::new(selected, claims, &bitmasks, weights.clone(), switchover)
+				.unwrap();
 
 		for _n_rounds_remaining in (1..=n_vars).rev() {
 			// NB: this is unsound, for test usage only!
@@ -380,8 +400,12 @@ mod tests {
 			let all_selector_coeffs = selector_prover.execute().unwrap();
 			selector_prover.fold(challenge).unwrap();
 
-			for (selector_coeffs, (direct_prover, inverted_prover)) in
-				izip!(all_selector_coeffs, &mut bivariate_provers)
+			// The prover combines its per-selector round polynomials into the single weighted
+			// polynomial `Σ_i weights[i] · (direct_i + inverted_i)`.
+			assert_eq!(all_selector_coeffs.len(), 1);
+			let mut expected = RoundCoeffs::<F>::default();
+			for (&weight, (direct_prover, inverted_prover)) in
+				izip!(&weights, &mut bivariate_provers)
 			{
 				let direct_coeffs = direct_prover.execute().unwrap();
 				let inverted_coeffs = inverted_prover.execute().unwrap();
@@ -391,8 +415,9 @@ mod tests {
 
 				assert_eq!(direct_coeffs.len(), 1);
 				assert_eq!(inverted_coeffs.len(), 1);
-				assert_eq!(selector_coeffs, direct_coeffs[0].clone() + &inverted_coeffs[0]);
+				expected += &((direct_coeffs[0].clone() + &inverted_coeffs[0]) * weight);
 			}
+			assert_eq!(all_selector_coeffs[0], expected);
 		}
 	}
 
@@ -428,7 +453,9 @@ mod tests {
 			})
 			.collect_vec();
 
-		let mut prover = SelectorMlecheckProver::new(selected, claims, &bitmasks, 0).unwrap();
+		let weights = random_scalars::<F>(&mut rng, selector_count);
+		let mut prover =
+			SelectorMlecheckProver::new(selected, claims, &bitmasks, weights, 0).unwrap();
 
 		for _ in 0..n_vars {
 			// The claim recovered from the round coefficients (post-execute, via lerp against each

--- a/crates/prover/src/protocols/intmul/prove.rs
+++ b/crates/prover/src/protocols/intmul/prove.rs
@@ -252,8 +252,21 @@ where
 			})
 			.collect();
 
-		let selector_prover =
-			SelectorMlecheckProver::new(selector, selector_claims, b_exponents, self.switchover)?;
+		// Batch the 2^k Frobenius-twisted leaf claims with eq_k(γ, i): sample γ in K^k and pass the
+		// eq_k(γ, ·) weights to the selector prover, which combines its 2^k per-claim round
+		// polynomials into a single weighted one. This replaces a univariate-power batch over the
+		// 2^k claims with a multilinear one; the verifier mirrors it by weighting the corresponding
+		// terms by eq_k(γ, ·). γ is sampled before the batched sumcheck so the round polynomials
+		// are fixed against it.
+		let gamma = self.channel.sample_many(log_bits);
+		let eq_weights = eq_ind_partial_eval_scalars::<F>(&gamma);
+		let selector_prover = SelectorMlecheckProver::new(
+			selector,
+			selector_claims,
+			b_exponents,
+			eq_weights,
+			self.switchover,
+		)?;
 
 		let c_root_sumcheck_prover =
 			bivariate_product_mle::new(c_lo_hi_roots, c_eval_point.to_vec(), c_root_eval)?;

--- a/crates/verifier/src/protocols/intmul/verify.rs
+++ b/crates/verifier/src/protocols/intmul/verify.rs
@@ -128,15 +128,19 @@ where
 		assert_eq!(twisted_eval_point.len(), c_eval_point.len());
 	}
 
-	let evals = iter::chain(twisted_evals, [c_eval]).collect::<Vec<_>>();
-
-	// Polynomial is a univariate random combination of 2^k + 1 quartic terms:
+	// Batch the 2^k Frobenius-twisted leaf claims with eq_k(γ, i): sample γ in K^k and take the
+	// multilinear evaluation of the 2^k claims at γ, matching the prover's CombineClaimsDecorator.
+	// The aggregate and the LO·HI claim are then combined into the same sumcheck by the univariate
+	// batch coefficient. γ is sampled before the sumcheck so its round polynomials are fixed
+	// against it.
 	//
-	// First 2^k:
-	// - (b(i, X) * (A(X) - 1) + 1) * eq(φ⁻ⁱ(x) ; X)
-	//
-	// Last one:
+	// The two batched terms (each degree 3) are:
+	// - the 2^k aggregate: Σ_i eq_k(γ, i) * (b(i, X) * (A(X) - 1) + 1) * eq(φ⁻ⁱ(x) ; X)
 	// - LO(X) * HI(X) * eq(c_eval_point ; X)
+	let gamma = channel.sample_many(log_bits);
+	let selector_agg_eval = evaluate_inplace_scalars(twisted_evals, &gamma);
+	let evals = [selector_agg_eval, c_eval];
+
 	let BatchSumcheckOutput {
 		batch_coeff,
 		mut challenges,
@@ -161,20 +165,22 @@ where
 
 	let eval_point = challenges;
 
-	let expected_selected_terms =
-		iter::zip(twisted_eval_points, &b_evals).map(|(twisted_eval_point, b_eval)| {
+	let expected_selected_terms = iter::zip(twisted_eval_points, &b_evals)
+		.map(|(twisted_eval_point, b_eval)| {
 			let one = C::Elem::one();
 			(b_eval.clone() * (gpow_a_eval.clone() - one.clone()) + one)
 				* eq_ind(&twisted_eval_point, &eval_point)
-		});
+		})
+		.collect::<Vec<_>>();
+	// Combine the 2^k selector terms with eq_k(γ, i) — the multilinear evaluation at γ — mirroring
+	// the prover's CombineClaimsDecorator.
+	let expected_selected_agg = evaluate_inplace_scalars(expected_selected_terms, &gamma);
 
 	// - c_lo(r) * c_hi(r) * eq(c_eval_point ; r)
 	let expected_c_prod_eval =
 		gpow_c_lo_eval.clone() * gpow_c_hi_eval.clone() * eq_ind(c_eval_point, &eval_point);
 
-	let expected_terms = expected_selected_terms
-		.chain([expected_c_prod_eval])
-		.collect::<Vec<_>>();
+	let expected_terms = [expected_selected_agg, expected_c_prod_eval];
 	let expected_batched_eval = evaluate_univariate(&expected_terms, batch_coeff);
 
 	channel.assert_zero(expected_batched_eval - eval)?;


### PR DESCRIPTION
Closes [BINIUS-171](https://linear.app/jimpo/issue/BINIUS-171) — audit divergence **D-V4** under [BINIUS-163](https://linear.app/jimpo/issue/BINIUS-163) (conform IntMul to `sec:intmul`). Last of the D-V3/4/5 trio (D-V5 merged in #1633; D-V3 scrapped per the [BINIUS-170 discussion](https://linear.app/jimpo/issue/BINIUS-170)).

## What

The spec's variable-base Frobenius subprotocol batches the `2^k` Frobenius-twisted Phase-1 leaf claims with the multilinear `eq_k(γ, i)`, `γ ∈ K^k` (a single verifier challenge), giving soundness `2^k/|K|`. The code instead batched them with **powers of a single univariate challenge** (`batch_coeff^i`). Soundness-equivalent, but not spec-literal.

This switches the 64 selector claims to `eq_6(γ, i)` weights. The LO·HI (`c_root`) claim still rides the same sumcheck, now combined with the 64-way aggregate by a 2-way univariate `batch_coeff` instead of being the 65th univariate term.

## How — batching inside `SelectorMlecheckProver`

The eq-batching lives in `SelectorMlecheckProver` (its only consumer), rather than in a separate adapter:

- **`SelectorMlecheckProver`** now takes a `weights` vector (one per selector) and exposes a **single** claim (`n_claims() == 1`): `execute()` and `round_claim()` combine its per-selector round polynomials / claims into `Σ_i weights[i] · R_i`, while folding and the final multilinear evaluations stay per-selector internally. Passing `eq_ind_partial_eval_scalars(γ)` as the weights gives the `eq_k(γ, i)` batching.
- **prover `phase3`**: sample `γ = channel.sample_many(k)` before the batched sumcheck, pass the `eq_k(γ, ·)` weights to `SelectorMlecheckProver::new`, then `batch_prove` 2-way `[selector-agg, LO·HI]` (was 65-way).
- **verifier `verify_phase_3`**: sample `γ` first, form the aggregate claim `evaluate_inplace_scalars(twisted_evals, γ)` — the same multilinear-eval convention the D-V2 `b_recomb` already uses, so there's no bit-order risk — and reconstruct the two batched terms 2-way.

No interface change beyond the new `weights` argument; `IntMulOutput` unchanged. (An earlier revision routed the combination through a standalone `CombineClaimsDecorator`; per review it was folded into `SelectorMlecheckProver` directly, since that prover is the sole user.)

## Test

`prove_and_verify` roundtrip + the 3 witness tests pass (the roundtrip gates the full prover↔verifier transcript through the new `γ` sampling and the in-prover batching), and the two `selector_mle` unit tests now check the weighted combination. `fmt --check`, `clippy -p binius-ip-prover -p binius-prover -p binius-verifier --all-targets -D warnings`, and `rustdoc -D warnings` all clean.

This is the final divergence; with it, IntMul matches `sec:intmul` (modulo the D-V3 high-half twist, which is being handled in the spec instead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)