### PR TITLE
Remove redundant CI trigger on push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:


### PR DESCRIPTION
## Summary

- Removes `push: branches: [main]` from the CI workflow triggers

## Rationale

All PRs are merged via the merge queue, which runs CI against the tip of main before merging (`merge_group` trigger). The resulting commit on main has therefore already passed CI. Re-running CI on push to main is pure duplicate work — same code, same result, wasted runner time.

The only scenario where the push trigger would catch something is if a commit landed on main without going through the queue (e.g. an admin bypass), but that's better prevented by branch protection than detected after the fact.