### PR TITLE
BINIUS-172: document intmul-before-bitand ordering requirement

### DIFF
--- a/crates/verifier/src/verify.rs
+++ b/crates/verifier/src/verify.rs
@@ -1,4 +1,5 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 use binius_core::{constraint_system::ConstraintSystem, word::Word};
 use binius_field::{AESTowerField8b as B8, BinaryField, ExtensionField, FieldOps};
@@ -136,6 +137,16 @@ impl IOPVerifier {
 		// Receive the trace oracle commitment via channel.
 		let trace_oracle = channel.recv_oracle()?;
 
+		// SOUNDNESS: the IntMul reduction must run *before* the BitAnd reduction. The BitAnd
+		// reduction samples the univariate challenge `r_zhat_prime` (the `channel.sample()` in
+		// `bitand::verify_with_channel`), and the IntMul per-bit `a`/`b`/`c_lo`/`c_hi` evaluations
+		// are collapsed at that point via the Lagrange weights `l_tilde(r_zhat_prime)` below. Those
+		// evaluations are bound to the transcript while the IntMul reduction runs, so they must be
+		// committed *before* `r_zhat_prime` is drawn; otherwise a malicious prover could choose
+		// them adaptively as a function of `r_zhat_prime` and satisfy the collapsed claim without
+		// a valid witness. Do not reorder these two reductions, and keep the same order in
+		// `prover::prove`.
+		//
 		// [phase] Verify IntMul Reduction - multiplication constraint verification
 		let intmul_guard = tracing::info_span!(
 			"[phase] Verify IntMul Reduction",


### PR DESCRIPTION
Implements [BINIUS-172](https://linear.app/jimpo/issue/BINIUS-172/move-intmul-reduction-before-bitand-reduction).

## Context

The issue flags a soundness ordering: `r_zhat_prime` must be sampled *after* the IntMul reduction commits its a/b/c_lo/c_hi per-bit evaluations. On a scope check ([Linear thread](https://linear.app/jimpo/issue/BINIUS-172)), the **reduction order is already correct on `main`** — the IntMul reduction runs before the BitAnd reduction (which samples `r_zhat_prime`) in both `verifier::verify` and `prover::prove`, and has since the #1428/#1443-era. Per jimpo's confirmation ("Go with (1)"), this PR adds the missing **documentation** of *why* the order matters, so a future refactor doesn't silently reorder it.

## Change

Documentation only (no behavior change):

- `crates/verifier/src/verify.rs` — a `SOUNDNESS:` comment at the IntMul/BitAnd phase boundary explaining that the IntMul reduction must precede the BitAnd reduction: BitAnd samples the shared univariate challenge `r_zhat_prime`, at which IntMul's per-bit evals are collapsed via `l_tilde(r_zhat_prime)`. Those evals must be bound to the transcript *before* `r_zhat_prime` is drawn, or a malicious prover could choose them adaptively and satisfy the collapsed claim without a valid witness.
- `crates/prover/src/prove.rs` — the mirror note, since the prover must keep the same order in lockstep (Fiat–Shamir).

## Testing

No behavior change, so existing coverage applies. Verified `cargo build`, fmt, clippy, and `cargo doc -D warnings` are green, and ran `test_prove_verify_sha256_preimage` (the prove→verify roundtrip that would catch any Fiat–Shamir desync) — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)