### PR TITLE
Enable clippy::use_self and replace type-name repetition with Self

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,7 @@ ureq = "3.1"
 needless_range_loop = "allow"
 missing_const_for_fn = "warn"
 redundant_clone = "warn"
+use_self = "warn"
 
 [workspace.metadata.typos]
 default.extend-words = { "typ" = "typ", "Toom" = "Toom", "inouts" = "inouts" }

--- a/crates/arith-bench/src/arch/aarch64.rs
+++ b/crates/arith-bench/src/arch/aarch64.rs
@@ -35,7 +35,7 @@ impl Underlier for uint64x2_t {
 
 	fn random(mut rng: impl Rng) -> Self {
 		let value: u128 = rng.random();
-		unsafe { std::mem::transmute::<_, uint64x2_t>(value) }
+		unsafe { std::mem::transmute::<_, Self>(value) }
 	}
 }
 
@@ -223,7 +223,7 @@ impl crate::underlier::OpsClmul for uint64x2_t {
 					let a_bytes: uint8x16_t = std::mem::transmute(a);
 					let zero: uint8x16_t = vdupq_n_u8(0);
 					let shifted: uint8x16_t = vextq_u8::<IMM8>(zero, a_bytes);
-					std::mem::transmute::<uint8x16_t, uint64x2_t>(shifted)
+					std::mem::transmute::<uint8x16_t, Self>(shifted)
 				}
 				16.. => vdupq_n_u64(0),
 				_ => {
@@ -248,7 +248,7 @@ impl crate::underlier::OpsClmul for uint64x2_t {
 	#[inline]
 	fn movepi64_mask(a: Self) -> Self {
 		unsafe {
-			let a = std::mem::transmute::<uint64x2_t, uint32x4_t>(a);
+			let a = std::mem::transmute::<Self, uint32x4_t>(a);
 			// Get the odd lanes (upper 32 bits of each 64-bit element)
 			let odd_lanes = vtrn2q_u32(a, a);
 			// Arithmetic shift right to broadcast the sign bit

--- a/crates/arith-bench/src/arch/portable64.rs
+++ b/crates/arith-bench/src/arch/portable64.rs
@@ -32,14 +32,14 @@ pub struct U64x2(pub u64, pub u64);
 impl From<u128> for U64x2 {
 	fn from(x: u128) -> Self {
 		// Little-endian: low 64 bits first, then high 64 bits
-		U64x2(x as u64, (x >> 64) as u64)
+		Self(x as u64, (x >> 64) as u64)
 	}
 }
 
 impl From<U64x2> for u128 {
 	fn from(x: U64x2) -> Self {
 		// Little-endian: x.0 is low 64 bits, x.1 is high 64 bits
-		(x.0 as u128) | ((x.1 as u128) << 64)
+		(x.0 as Self) | ((x.1 as Self) << 64)
 	}
 }
 

--- a/crates/arith-bench/src/arch/x86_64.rs
+++ b/crates/arith-bench/src/arch/x86_64.rs
@@ -36,7 +36,7 @@ impl Underlier for __m128i {
 	fn random(mut rng: impl Rng) -> Self {
 		let mut bytes = [0u8; 16];
 		rng.fill_bytes(&mut bytes);
-		unsafe { _mm_loadu_si128(bytes.as_ptr() as *const __m128i) }
+		unsafe { _mm_loadu_si128(bytes.as_ptr() as *const Self) }
 	}
 }
 
@@ -243,7 +243,7 @@ impl Underlier for __m256i {
 	fn random(mut rng: impl Rng) -> Self {
 		let mut bytes = [0u8; 32];
 		rng.fill_bytes(&mut bytes);
-		unsafe { _mm256_loadu_si256(bytes.as_ptr() as *const __m256i) }
+		unsafe { _mm256_loadu_si256(bytes.as_ptr() as *const Self) }
 	}
 }
 

--- a/crates/circuits/src/bignum/biguint.rs
+++ b/crates/circuits/src/bignum/biguint.rs
@@ -18,13 +18,13 @@ impl BigUint {
 	/// Creates a new BigUint with the given number of limbs as inout wires.
 	pub fn new_inout(b: &CircuitBuilder, num_limbs: usize) -> Self {
 		let limbs = (0..num_limbs).map(|_| b.add_inout()).collect();
-		BigUint { limbs }
+		Self { limbs }
 	}
 
 	/// Creates a new BigUint with the given number of limbs as witness wires.
 	pub fn new_witness(b: &CircuitBuilder, num_limbs: usize) -> Self {
 		let limbs = (0..num_limbs).map(|_| b.add_witness()).collect();
-		BigUint { limbs }
+		Self { limbs }
 	}
 
 	/// Creates a constant BigUint from num_bigint::BigUint.
@@ -33,7 +33,7 @@ impl BigUint {
 			.iter_u64_digits()
 			.map(|limb| b.add_constant_64(limb))
 			.collect();
-		BigUint { limbs }
+		Self { limbs }
 	}
 
 	/// Returns zero unless the MSB-boolean `cond` is true, then passes the value unchanged.

--- a/crates/circuits/src/bignum/reduce.rs
+++ b/crates/circuits/src/bignum/reduce.rs
@@ -54,7 +54,7 @@ impl ModReduce {
 			&a.pad_limbs_to(n_limbs, zero),
 		);
 
-		ModReduce {
+		Self {
 			a,
 			modulus,
 			quotient,

--- a/crates/circuits/src/fixed_byte_vec.rs
+++ b/crates/circuits/src/fixed_byte_vec.rs
@@ -186,11 +186,11 @@ impl ByteVec {
 	///
 	/// # Panics
 	/// * If num_wires exceeds self.data.len()
-	pub fn truncate(&self, b: &CircuitBuilder, num_wires: usize) -> ByteVec {
+	pub fn truncate(&self, b: &CircuitBuilder, num_wires: usize) -> Self {
 		assert!(num_wires <= self.data.len(), "num_wires must be less than self.data.len()");
 
 		let trimmed_wires = self.data[0..num_wires].to_vec();
-		ByteVec::new_const_len(b, trimmed_wires, num_wires << 3)
+		Self::new_const_len(b, trimmed_wires, num_wires << 3)
 	}
 
 	/// Extracts a slice at a compile-time constant range.
@@ -225,7 +225,7 @@ impl ByteVec {
 	/// let slice = byte_vec.slice_const_range(&builder, 3..11);
 	/// // slice will have capacity of 16 bytes (2 words) but length of 8 bytes
 	/// ```
-	pub fn slice_const_range(&self, b: &CircuitBuilder, range: Range<usize>) -> ByteVec {
+	pub fn slice_const_range(&self, b: &CircuitBuilder, range: Range<usize>) -> Self {
 		assert!(range.start <= range.end, "Invalid range: start > end");
 		assert!(
 			range.end <= *self.len_range.end(),
@@ -238,7 +238,7 @@ impl ByteVec {
 
 		// Return early if slice is empty
 		if slice_len == 0 {
-			return ByteVec::new_const_len(b, Vec::new(), 0);
+			return Self::new_const_len(b, Vec::new(), 0);
 		}
 
 		// Validate that `range.end <= self.len_bytes` at runtime. For a const-length vec
@@ -252,7 +252,7 @@ impl ByteVec {
 		}
 
 		let output_words = extract_const_range(b, &self.data, range);
-		ByteVec::new_const_len(b, output_words, slice_len)
+		Self::new_const_len(b, output_words, slice_len)
 	}
 }
 

--- a/crates/circuits/src/hash_based_sig/witness_utils.rs
+++ b/crates/circuits/src/hash_based_sig/witness_utils.rs
@@ -175,7 +175,7 @@ impl ValidatorSignatureData {
 		let (tree_levels, root) = build_merkle_tree(param_bytes, &leaves);
 		let auth_path = extract_auth_path(&tree_levels, epoch as usize);
 
-		ValidatorSignatureData {
+		Self {
 			root,
 			nonce,
 			signature_hashes,

--- a/crates/circuits/src/hash_based_sig/xmss.rs
+++ b/crates/circuits/src/hash_based_sig/xmss.rs
@@ -186,7 +186,7 @@ mod tests {
 			let (tree_levels, root_hash) = build_merkle_tree(&param_bytes, &leaves);
 			let auth_path = extract_auth_path(&tree_levels, signing_epoch as usize);
 
-			XmssTestData {
+			Self {
 				param_bytes,
 				message_bytes,
 				nonce_bytes: grind_result.nonce,
@@ -296,7 +296,7 @@ mod tests {
 			let mut rng = StdRng::seed_from_u64(42);
 
 			match self {
-				TestCase::Valid {
+				Self::Valid {
 					tree_size,
 					signing_epoch,
 				} => {
@@ -309,7 +309,7 @@ mod tests {
 						panic!("Test expected to pass but failed: {}", e);
 					});
 				}
-				TestCase::Invalid {
+				Self::Invalid {
 					tree_size,
 					signing_epoch,
 					corrupt_fn,

--- a/crates/circuits/src/hash_based_sig/xmss_aggregate.rs
+++ b/crates/circuits/src/hash_based_sig/xmss_aggregate.rs
@@ -162,7 +162,7 @@ mod tests {
 			let mut rng = StdRng::seed_from_u64(42);
 
 			match self {
-				MultisigTestCase::Valid {
+				Self::Valid {
 					num_validators,
 					tree_height,
 					epoch,
@@ -176,7 +176,7 @@ mod tests {
 					);
 					test_data.run(&spec, *tree_height).unwrap();
 				}
-				MultisigTestCase::Invalid {
+				Self::Invalid {
 					num_validators,
 					tree_height,
 					epoch,
@@ -234,7 +234,7 @@ mod tests {
 				validator_param_bytes.push(param_bytes);
 			}
 
-			MultisigTestData {
+			Self {
 				validator_param_bytes,
 				message_bytes,
 				epoch,

--- a/crates/circuits/src/jwt_claims.rs
+++ b/crates/circuits/src/jwt_claims.rs
@@ -190,7 +190,7 @@ impl JwtClaims {
 			slice::assert_slice_eq(&b, "attr_value", value_length, &extracted, &attr.value);
 		}
 
-		JwtClaims {
+		Self {
 			len_bytes,
 			json,
 			attributes,

--- a/crates/circuits/src/rs256.rs
+++ b/crates/circuits/src/rs256.rs
@@ -320,7 +320,7 @@ impl RsaIntermediates {
 		let mul_quotient = BigUint::new_witness(builder, 32);
 		let mul_remainder = BigUint::new_witness(builder, 32);
 
-		RsaIntermediates {
+		Self {
 			square_quotients,
 			square_remainders,
 			mul_quotient,

--- a/crates/circuits/src/secp256k1/point.rs
+++ b/crates/circuits/src/secp256k1/point.rs
@@ -37,10 +37,10 @@ impl Secp256k1Affine {
 
 	/// Return point-at-infinity unless the MSB-boolean `cond` is true, then pass the point
 	/// unchanged.
-	pub fn pai_unless(&self, b: &CircuitBuilder, cond: Wire) -> Secp256k1Affine {
+	pub fn pai_unless(&self, b: &CircuitBuilder, cond: Wire) -> Self {
 		let is_point_at_infinity =
 			b.select(cond, self.is_point_at_infinity, b.add_constant(Word::ALL_ONE));
-		Secp256k1Affine {
+		Self {
 			x: self.x.clone(),
 			y: self.y.clone(),
 			is_point_at_infinity,

--- a/crates/circuits/src/sha256/compress.rs
+++ b/crates/circuits/src/sha256/compress.rs
@@ -28,19 +28,19 @@ pub struct State(pub [Wire; 8]);
 
 impl State {
 	pub const fn new(wires: [Wire; 8]) -> Self {
-		State(wires)
+		Self(wires)
 	}
 
 	pub fn public(builder: &CircuitBuilder) -> Self {
-		State(std::array::from_fn(|_| builder.add_inout()))
+		Self(std::array::from_fn(|_| builder.add_inout()))
 	}
 
 	pub fn private(builder: &CircuitBuilder) -> Self {
-		State(std::array::from_fn(|_| builder.add_witness()))
+		Self(std::array::from_fn(|_| builder.add_witness()))
 	}
 
 	pub fn iv(builder: &CircuitBuilder) -> Self {
-		State(std::array::from_fn(|i| builder.add_constant(Word(IV[i] as u64))))
+		Self(std::array::from_fn(|i| builder.add_constant(Word(IV[i] as u64))))
 	}
 
 	/// Packs the state into 4 x 64-bit words.

--- a/crates/circuits/src/sha512/compress.rs
+++ b/crates/circuits/src/sha512/compress.rs
@@ -106,19 +106,19 @@ pub struct State(pub [Wire; 8]);
 
 impl State {
 	pub const fn new(wires: [Wire; 8]) -> Self {
-		State(wires)
+		Self(wires)
 	}
 
 	pub fn public(builder: &CircuitBuilder) -> Self {
-		State(std::array::from_fn(|_| builder.add_inout()))
+		Self(std::array::from_fn(|_| builder.add_inout()))
 	}
 
 	pub fn private(builder: &CircuitBuilder) -> Self {
-		State(std::array::from_fn(|_| builder.add_witness()))
+		Self(std::array::from_fn(|_| builder.add_witness()))
 	}
 
 	pub fn iv(builder: &CircuitBuilder) -> Self {
-		State(std::array::from_fn(|i| builder.add_constant(Word(IV[i]))))
+		Self(std::array::from_fn(|i| builder.add_constant(Word(IV[i]))))
 	}
 }
 

--- a/crates/core/src/constraint_system.rs
+++ b/crates/core/src/constraint_system.rs
@@ -18,7 +18,7 @@ pub struct ValueIndex(pub u32);
 
 impl ValueIndex {
 	/// The value index that is not considered to be valid.
-	pub const INVALID: ValueIndex = ValueIndex(u32::MAX);
+	pub const INVALID: Self = Self(u32::MAX);
 }
 
 /// The most sensible default for a value index is invalid.
@@ -39,7 +39,7 @@ impl DeserializeBytes for ValueIndex {
 	where
 		Self: Sized,
 	{
-		Ok(ValueIndex(u32::deserialize(read_buf)?))
+		Ok(Self(u32::deserialize(read_buf)?))
 	}
 }
 
@@ -88,14 +88,14 @@ pub enum ShiftVariant {
 impl SerializeBytes for ShiftVariant {
 	fn serialize(&self, write_buf: impl BufMut) -> Result<(), SerializationError> {
 		let index = match self {
-			ShiftVariant::Sll => 0u8,
-			ShiftVariant::Slr => 1u8,
-			ShiftVariant::Sar => 2u8,
-			ShiftVariant::Rotr => 3u8,
-			ShiftVariant::Sll32 => 4u8,
-			ShiftVariant::Srl32 => 5u8,
-			ShiftVariant::Sra32 => 6u8,
-			ShiftVariant::Rotr32 => 7u8,
+			Self::Sll => 0u8,
+			Self::Slr => 1u8,
+			Self::Sar => 2u8,
+			Self::Rotr => 3u8,
+			Self::Sll32 => 4u8,
+			Self::Srl32 => 5u8,
+			Self::Sra32 => 6u8,
+			Self::Rotr32 => 7u8,
 		};
 		index.serialize(write_buf)
 	}
@@ -108,14 +108,14 @@ impl DeserializeBytes for ShiftVariant {
 	{
 		let index = u8::deserialize(read_buf)?;
 		match index {
-			0 => Ok(ShiftVariant::Sll),
-			1 => Ok(ShiftVariant::Slr),
-			2 => Ok(ShiftVariant::Sar),
-			3 => Ok(ShiftVariant::Rotr),
-			4 => Ok(ShiftVariant::Sll32),
-			5 => Ok(ShiftVariant::Srl32),
-			6 => Ok(ShiftVariant::Sra32),
-			7 => Ok(ShiftVariant::Rotr32),
+			0 => Ok(Self::Sll),
+			1 => Ok(Self::Slr),
+			2 => Ok(Self::Sar),
+			3 => Ok(Self::Rotr),
+			4 => Ok(Self::Sll32),
+			5 => Ok(Self::Srl32),
+			6 => Ok(Self::Sra32),
+			7 => Ok(Self::Rotr32),
 			_ => Err(SerializationError::UnknownEnumVariant {
 				name: "ShiftVariant",
 				index,
@@ -301,7 +301,7 @@ impl DeserializeBytes for ShiftedValueIndex {
 			});
 		}
 
-		Ok(ShiftedValueIndex {
+		Ok(Self {
 			value_index,
 			shift_variant,
 			amount,
@@ -344,8 +344,8 @@ impl AndConstraint {
 		a: impl IntoIterator<Item = ValueIndex>,
 		b: impl IntoIterator<Item = ValueIndex>,
 		c: impl IntoIterator<Item = ValueIndex>,
-	) -> AndConstraint {
-		AndConstraint {
+	) -> Self {
+		Self {
 			a: a.into_iter().map(ShiftedValueIndex::plain).collect(),
 			b: b.into_iter().map(ShiftedValueIndex::plain).collect(),
 			c: c.into_iter().map(ShiftedValueIndex::plain).collect(),
@@ -357,8 +357,8 @@ impl AndConstraint {
 		a: impl IntoIterator<Item = ShiftedValueIndex>,
 		b: impl IntoIterator<Item = ShiftedValueIndex>,
 		c: impl IntoIterator<Item = ShiftedValueIndex>,
-	) -> AndConstraint {
-		AndConstraint {
+	) -> Self {
+		Self {
 			a: a.into_iter().collect(),
 			b: b.into_iter().collect(),
 			c: c.into_iter().collect(),
@@ -383,7 +383,7 @@ impl DeserializeBytes for AndConstraint {
 		let b = Vec::<ShiftedValueIndex>::deserialize(&mut read_buf)?;
 		let c = Vec::<ShiftedValueIndex>::deserialize(read_buf)?;
 
-		Ok(AndConstraint { a, b, c })
+		Ok(Self { a, b, c })
 	}
 }
 
@@ -426,7 +426,7 @@ impl DeserializeBytes for MulConstraint {
 		let hi = Vec::<ShiftedValueIndex>::deserialize(&mut read_buf)?;
 		let lo = Vec::<ShiftedValueIndex>::deserialize(read_buf)?;
 
-		Ok(MulConstraint { a, b, hi, lo })
+		Ok(Self { a, b, hi, lo })
 	}
 }
 
@@ -467,7 +467,7 @@ impl ConstraintSystem {
 		mul_constraints: Vec<MulConstraint>,
 	) -> Self {
 		assert_eq!(constants.len(), value_vec_layout.n_const);
-		ConstraintSystem {
+		Self {
 			constants,
 			value_vec_layout,
 			and_constraints,
@@ -637,7 +637,7 @@ impl DeserializeBytes for ConstraintSystem {
 			});
 		}
 
-		Ok(ConstraintSystem {
+		Ok(Self {
 			value_vec_layout,
 			constants,
 			and_constraints,
@@ -751,7 +751,7 @@ impl DeserializeBytes for ValueVecLayout {
 		let committed_total_len = usize::deserialize(&mut read_buf)?;
 		let n_scratch = usize::deserialize(read_buf)?;
 
-		Ok(ValueVecLayout {
+		Ok(Self {
 			n_const,
 			n_inout,
 			n_witness,
@@ -849,9 +849,9 @@ impl ValueVec {
 	/// Creates a new value vector with the given layout.
 	///
 	/// The values are filled with zeros.
-	pub fn new(layout: ValueVecLayout) -> ValueVec {
+	pub fn new(layout: ValueVecLayout) -> Self {
 		let size = layout.committed_total_len + layout.n_scratch;
-		ValueVec {
+		Self {
 			layout,
 			data: AlignedWords::zeroed(size),
 		}
@@ -864,7 +864,7 @@ impl ValueVec {
 		layout: ValueVecLayout,
 		public: Vec<Word>,
 		private: Vec<Word>,
-	) -> Result<ValueVec, ConstraintSystemError> {
+	) -> Result<Self, ConstraintSystemError> {
 		let committed_len = public.len() + private.len();
 		if committed_len != layout.committed_total_len {
 			return Err(ConstraintSystemError::ValueVecLenMismatch {
@@ -882,7 +882,7 @@ impl ValueVec {
 		// Private words follow, filling the rest of the committed region.
 		data[public.len()..committed_len].copy_from_slice(&private);
 
-		Ok(ValueVec { layout, data })
+		Ok(Self { layout, data })
 	}
 
 	/// The total size of the committed portion of the vector (excluding scratch).

--- a/crates/core/src/word.rs
+++ b/crates/core/src/word.rs
@@ -21,17 +21,17 @@ pub struct Word(pub u64);
 
 impl Word {
 	/// All zero bit pattern, zero, nil, null.
-	pub const ZERO: Word = Word(0);
+	pub const ZERO: Self = Self(0);
 	/// 1.
-	pub const ONE: Word = Word(1);
+	pub const ONE: Self = Self(1);
 	/// All bits set to one.
-	pub const ALL_ONE: Word = Word(u64::MAX);
+	pub const ALL_ONE: Self = Self(u64::MAX);
 	/// 32 lower bits are set to one, all other bits are zero.
-	pub const MASK_32: Word = Word(0x00000000FFFFFFFF);
+	pub const MASK_32: Self = Self(0x00000000FFFFFFFF);
 	/// Most Significant Bit is set to one, all other bits are zero.
 	///
 	/// This is a canonical representation of true.
-	pub const MSB_ONE: Word = Word(0x8000000000000000);
+	pub const MSB_ONE: Self = Self(0x8000000000000000);
 }
 
 impl fmt::Debug for Word {
@@ -44,7 +44,7 @@ impl BitAnd for Word {
 	type Output = Self;
 
 	fn bitand(self, rhs: Self) -> Self::Output {
-		Word(self.0 & rhs.0)
+		Self(self.0 & rhs.0)
 	}
 }
 
@@ -52,7 +52,7 @@ impl BitOr for Word {
 	type Output = Self;
 
 	fn bitor(self, rhs: Self) -> Self::Output {
-		Word(self.0 | rhs.0)
+		Self(self.0 | rhs.0)
 	}
 }
 
@@ -60,7 +60,7 @@ impl BitXor for Word {
 	type Output = Self;
 
 	fn bitxor(self, rhs: Self) -> Self::Output {
-		Word(self.0 ^ rhs.0)
+		Self(self.0 ^ rhs.0)
 	}
 }
 
@@ -68,7 +68,7 @@ impl Shl<u32> for Word {
 	type Output = Self;
 
 	fn shl(self, rhs: u32) -> Self::Output {
-		Word(self.0 << rhs)
+		Self(self.0 << rhs)
 	}
 }
 
@@ -76,7 +76,7 @@ impl Shr<u32> for Word {
 	type Output = Self;
 
 	fn shr(self, rhs: u32) -> Self::Output {
-		Word(self.0 >> rhs)
+		Self(self.0 >> rhs)
 	}
 }
 
@@ -84,14 +84,14 @@ impl Not for Word {
 	type Output = Self;
 
 	fn not(self) -> Self::Output {
-		Word(!self.0)
+		Self(!self.0)
 	}
 }
 
 impl Word {
 	/// Creates a new `Word` from a 64-bit unsigned integer.
-	pub const fn from_u64(value: u64) -> Word {
-		Word(value)
+	pub const fn from_u64(value: u64) -> Self {
+		Self(value)
 	}
 
 	/// Performs parallel 32-bit additions on the upper and lower halves with carry-in.
@@ -102,10 +102,10 @@ impl Word {
 	///
 	/// Returns (sum, carry_out) where the ith carry_out bit is set to one if there is a
 	/// carry out at that bit position.
-	pub const fn iadd32_cin_cout(self, rhs: Word, cin: Word) -> (Word, Word) {
-		let Word(lhs) = self;
-		let Word(rhs) = rhs;
-		let Word(cin) = cin;
+	pub const fn iadd32_cin_cout(self, rhs: Self, cin: Self) -> (Self, Self) {
+		let Self(lhs) = self;
+		let Self(rhs) = rhs;
+		let Self(cin) = cin;
 
 		// Extract carry-in bits from MSBs of each 32-bit half
 		let cin_lo = (cin >> 31) & 1;
@@ -123,14 +123,14 @@ impl Word {
 		let sum = (lo_sum as u32 as u64) | ((hi_sum as u32 as u64) << 32);
 
 		let cout = (lhs & rhs) | ((lhs ^ rhs) & !sum);
-		(Word(sum), Word(cout))
+		(Self(sum), Self(cout))
 	}
 
 	/// Performs parallel 32-bit additions on the upper and lower halves.
 	///
 	/// Equivalent to [`iadd32_cin_cout`](Word::iadd32_cin_cout) with zero carry-in.
-	pub const fn iadd_cout_32(self, rhs: Word) -> (Word, Word) {
-		self.iadd32_cin_cout(rhs, Word::ZERO)
+	pub const fn iadd_cout_32(self, rhs: Self) -> (Self, Self) {
+		self.iadd32_cin_cout(rhs, Self::ZERO)
 	}
 
 	/// Performs 64-bit addition with carry input bit.
@@ -140,14 +140,14 @@ impl Word {
 	///
 	/// Returns (sum, carry_out) where ith carry_out bit is set to one if there is a carry out at
 	/// that bit position.
-	pub fn iadd_cin_cout(self, rhs: Word, cin: Word) -> (Word, Word) {
-		debug_assert!(cin == Word::ZERO || cin == Word::ONE, "cin must be 0 or 1");
-		let Word(lhs) = self;
-		let Word(rhs) = rhs;
-		let Word(cin) = cin;
+	pub fn iadd_cin_cout(self, rhs: Self, cin: Self) -> (Self, Self) {
+		debug_assert!(cin == Self::ZERO || cin == Self::ONE, "cin must be 0 or 1");
+		let Self(lhs) = self;
+		let Self(rhs) = rhs;
+		let Self(cin) = cin;
 		let sum = lhs.wrapping_add(rhs).wrapping_add(cin);
 		let cout = (lhs & rhs) | ((lhs ^ rhs) & !sum);
-		(Word(sum), Word(cout))
+		(Self(sum), Self(cout))
 	}
 
 	/// Performs 64-bit subtraction with borrow input bit.
@@ -157,46 +157,46 @@ impl Word {
 	///
 	/// Returns (diff, borrow_out) where ith borrow_out bit is set to one if there is a borrow out
 	/// at that bit position.
-	pub fn isub_bin_bout(self, rhs: Word, bin: Word) -> (Word, Word) {
-		debug_assert!(bin == Word::ZERO || bin == Word::ONE, "bin must be 0 or 1");
-		let Word(lhs) = self;
-		let Word(rhs) = rhs;
-		let Word(bin) = bin;
+	pub fn isub_bin_bout(self, rhs: Self, bin: Self) -> (Self, Self) {
+		debug_assert!(bin == Self::ZERO || bin == Self::ONE, "bin must be 0 or 1");
+		let Self(lhs) = self;
+		let Self(rhs) = rhs;
+		let Self(bin) = bin;
 		let diff = lhs.wrapping_sub(rhs).wrapping_sub(bin);
 		let bout = (!lhs & rhs) | (!(lhs ^ rhs) & diff);
-		(Word(diff), Word(bout))
+		(Self(diff), Self(bout))
 	}
 
 	/// Performs shift right by a given number of bits followed by masking with a 32-bit mask.
-	pub const fn shr_32(self, n: u32) -> Word {
-		let Word(value) = self;
+	pub const fn shr_32(self, n: u32) -> Self {
+		let Self(value) = self;
 		// Shift right logically by n bits and mask with 32-bit mask
 		let result = (value >> n) & Self::MASK_32.0;
-		Word(result)
+		Self(result)
 	}
 
 	/// Shift Arithmetic Right by a given number of bits.
 	///
 	/// This is similar to a logical shift right, but it shifts the sign bit to the right.
-	pub const fn sar(self, n: u32) -> Word {
-		let Word(value) = self;
+	pub const fn sar(self, n: u32) -> Self {
+		let Self(value) = self;
 		let value = value as i64;
 		let result = value >> n;
-		Word(result as u64)
+		Self(result as u64)
 	}
 
 	/// Rotate Right by a given number of bits.
-	pub const fn rotr(self, n: u32) -> Word {
-		let Word(value) = self;
-		Word(value.rotate_right(n))
+	pub const fn rotr(self, n: u32) -> Self {
+		let Self(value) = self;
+		Self(value.rotate_right(n))
 	}
 
 	/// Shift Left Logical on 32-bit halves.
 	///
 	/// Performs independent logical left shifts on the upper and lower 32-bit halves.
 	/// Only uses the lower 5 bits of the shift amount (0-31).
-	pub const fn sll32(self, n: u32) -> Word {
-		let Word(value) = self;
+	pub const fn sll32(self, n: u32) -> Self {
+		let Self(value) = self;
 		let n = n & 0x1F; // Only use lower 5 bits
 
 		// Extract 32-bit halves
@@ -207,15 +207,15 @@ impl Word {
 		let lo_shifted = (lo << n) as u64;
 		let hi_shifted = ((hi << n) as u64) << 32;
 
-		Word(lo_shifted | hi_shifted)
+		Self(lo_shifted | hi_shifted)
 	}
 
 	/// Shift Right Logical on 32-bit halves.
 	///
 	/// Performs independent logical right shifts on the upper and lower 32-bit halves.
 	/// Only uses the lower 5 bits of the shift amount (0-31).
-	pub const fn srl32(self, n: u32) -> Word {
-		let Word(value) = self;
+	pub const fn srl32(self, n: u32) -> Self {
+		let Self(value) = self;
 		let n = n & 0x1F; // Only use lower 5 bits
 
 		// Extract 32-bit halves
@@ -226,7 +226,7 @@ impl Word {
 		let lo_shifted = (lo >> n) as u64;
 		let hi_shifted = ((hi >> n) as u64) << 32;
 
-		Word(lo_shifted | hi_shifted)
+		Self(lo_shifted | hi_shifted)
 	}
 
 	/// Shift Right Arithmetic on 32-bit halves.
@@ -234,8 +234,8 @@ impl Word {
 	/// Performs independent arithmetic right shifts on the upper and lower 32-bit halves.
 	/// Sign extends each 32-bit half independently. Only uses the lower 5 bits of the shift amount
 	/// (0-31).
-	pub const fn sra32(self, n: u32) -> Word {
-		let Word(value) = self;
+	pub const fn sra32(self, n: u32) -> Self {
+		let Self(value) = self;
 		let n = n & 0x1F; // Only use lower 5 bits
 
 		// Extract 32-bit halves as signed integers
@@ -246,7 +246,7 @@ impl Word {
 		let lo_shifted = ((lo >> n) as u32) as u64;
 		let hi_shifted = (((hi >> n) as u32) as u64) << 32;
 
-		Word(lo_shifted | hi_shifted)
+		Self(lo_shifted | hi_shifted)
 	}
 
 	/// Rotate Right on 32-bit halves.
@@ -254,8 +254,8 @@ impl Word {
 	/// Performs independent rotate right operations on the upper and lower 32-bit halves.
 	/// Bits shifted off the right end wrap around to the left within each 32-bit half.
 	/// Only uses the lower 5 bits of the shift amount (0-31).
-	pub const fn rotr32(self, n: u32) -> Word {
-		let Word(value) = self;
+	pub const fn rotr32(self, n: u32) -> Self {
+		let Self(value) = self;
 		let n = n & 0x1F; // Only use lower 5 bits
 
 		// Extract 32-bit halves
@@ -266,30 +266,30 @@ impl Word {
 		let lo_rotated = lo.rotate_right(n) as u64;
 		let hi_rotated = (hi.rotate_right(n) as u64) << 32;
 
-		Word(lo_rotated | hi_rotated)
+		Self(lo_rotated | hi_rotated)
 	}
 
 	/// Unsigned integer multiplication.
 	///
 	/// Multiplies two 64-bit unsigned integers and returns the 128-bit result split into high and
 	/// low 64-bit words, respectively.
-	pub const fn imul(self, rhs: Word) -> (Word, Word) {
-		let Word(lhs) = self;
-		let Word(rhs) = rhs;
+	pub const fn imul(self, rhs: Self) -> (Self, Self) {
+		let Self(lhs) = self;
+		let Self(rhs) = rhs;
 		let result = (lhs as u128) * (rhs as u128);
 
 		let hi = (result >> 64) as u64;
 		let lo = result as u64;
-		(Word(hi), Word(lo))
+		(Self(hi), Self(lo))
 	}
 
 	/// Signed integer multiplication.
 	///
 	/// Multiplies two 64-bit signed integers and returns the 128-bit result split into high and
 	/// low 64-bit words, respectively.
-	pub const fn smul(self, rhs: Word) -> (Word, Word) {
-		let Word(lhs) = self;
-		let Word(rhs) = rhs;
+	pub const fn smul(self, rhs: Self) -> (Self, Self) {
+		let Self(lhs) = self;
+		let Self(rhs) = rhs;
 		// Interpret as signed 64-bit integers
 		let a = lhs as i64;
 		let b = rhs as i64;
@@ -298,21 +298,21 @@ impl Word {
 		// Extract high and low 64-bit words
 		let hi = (result >> 64) as u64;
 		let lo = result as u64;
-		(Word(hi), Word(lo))
+		(Self(hi), Self(lo))
 	}
 
 	/// Integer addition.
 	///
 	/// Wraps around on overflow.
-	pub const fn wrapping_add(self, rhs: Word) -> Word {
-		Word(self.0.wrapping_add(rhs.0))
+	pub const fn wrapping_add(self, rhs: Self) -> Self {
+		Self(self.0.wrapping_add(rhs.0))
 	}
 
 	/// Integer subtraction.
 	///
 	/// Wraps around on overflow.
-	pub const fn wrapping_sub(self, rhs: Word) -> Word {
-		Word(self.0.wrapping_sub(rhs.0))
+	pub const fn wrapping_sub(self, rhs: Self) -> Self {
+		Self(self.0.wrapping_sub(rhs.0))
 	}
 
 	/// Returns the integer value as a 64-bit unsigned integer.
@@ -352,7 +352,7 @@ impl DeserializeBytes for Word {
 	where
 		Self: Sized,
 	{
-		Ok(Word(u64::deserialize(read_buf)?))
+		Ok(Self(u64::deserialize(read_buf)?))
 	}
 }
 

--- a/crates/field/src/arch/portable/univariate_mul_utils_128.rs
+++ b/crates/field/src/arch/portable/univariate_mul_utils_128.rs
@@ -95,12 +95,12 @@ impl Underlier128bLanes for u128 {
 
 	#[inline(always)]
 	fn join_u64s(high: Self::U64, low: Self::U64) -> Self {
-		((high as u128) << 64) | (low as u128)
+		((high as Self) << 64) | (low as Self)
 	}
 
 	#[inline(always)]
 	fn broadcast_64(val: u64) -> Self {
-		val as u128
+		val as Self
 	}
 
 	#[inline(always)]

--- a/crates/field/src/arch/x86_64/m128.rs
+++ b/crates/field/src/arch/x86_64/m128.rs
@@ -94,7 +94,7 @@ impl From<M128> for u128 {
 		let mut result = 0u128;
 		unsafe {
 			// Safety: u128 is 16-byte aligned
-			assert_eq!(align_of::<u128>(), 16);
+			assert_eq!(align_of::<Self>(), 16);
 			_mm_store_si128(&raw mut result as *mut __m128i, value.0)
 		};
 		result

--- a/crates/field/src/binary_field_arithmetic.rs
+++ b/crates/field/src/binary_field_arithmetic.rs
@@ -58,7 +58,7 @@ impl InvertOrZero for BinaryField1b {
 }
 
 #[allow(clippy::suspicious_arithmetic_impl)]
-impl Mul<BinaryField1b> for BinaryField1b {
+impl Mul<Self> for BinaryField1b {
 	type Output = Self;
 
 	#[inline]

--- a/crates/field/src/ghash.rs
+++ b/crates/field/src/ghash.rs
@@ -121,7 +121,7 @@ impl BinaryField128bGhash {
 // Multiplication is `reduce(wide_mul)`, deferring to the scalar's own `WideMul` impl above (which
 // routes through the optimal `GhashWideMul` packing). This keeps the widening multiply as the
 // single source of truth for both `Mul` and `WideMul`.
-impl Mul<BinaryField128bGhash> for BinaryField128bGhash {
+impl Mul<Self> for BinaryField128bGhash {
 	type Output = Self;
 
 	#[inline]
@@ -432,7 +432,7 @@ impl From<AESTowerField8b> for BinaryField128bGhash {
 			0x71af641f08dbd1a0990483806bffbe0d,
 		];
 
-		BinaryField128bGhash::new(LOOKUP_TABLE[value.0 as usize])
+		Self::new(LOOKUP_TABLE[value.0 as usize])
 	}
 }
 

--- a/crates/field/src/ghash_sq.rs
+++ b/crates/field/src/ghash_sq.rs
@@ -188,7 +188,7 @@ fn square(x: [BinaryField128bGhash; 2]) -> [BinaryField128bGhash; 2] {
 	[t0 + t2.mul_inv_x(), t2]
 }
 
-impl Mul<GhashSq256b> for GhashSq256b {
+impl Mul<Self> for GhashSq256b {
 	type Output = Self;
 
 	#[inline]

--- a/crates/field/src/underlier/divisible.rs
+++ b/crates/field/src/underlier/divisible.rs
@@ -694,14 +694,14 @@ impl Divisible<SmallU<1>> for SmallU<2> {
 	#[inline]
 	unsafe fn set_unchecked(&mut self, index: usize, val: SmallU<1>) {
 		let mask = 1u8 << index;
-		*self = SmallU::<2>::new((self.val() & !mask) | (val.val() << index));
+		*self = Self::new((self.val() & !mask) | (val.val() << index));
 	}
 
 	#[inline]
 	fn broadcast(val: SmallU<1>) -> Self {
 		// 0b0 -> 0b00, 0b1 -> 0b11
 		let v = val.val();
-		SmallU::<2>::new(v | (v << 1))
+		Self::new(v | (v << 1))
 	}
 
 	#[inline]
@@ -709,7 +709,7 @@ impl Divisible<SmallU<1>> for SmallU<2> {
 		iter.chain(std::iter::repeat(SmallU::<1>::new(0)))
 			.take(2)
 			.enumerate()
-			.fold(SmallU::<2>::new(0), |mut acc, (i, val)| {
+			.fold(Self::new(0), |mut acc, (i, val)| {
 				acc.set(i, val);
 				acc
 			})
@@ -742,7 +742,7 @@ impl Divisible<SmallU<1>> for SmallU<4> {
 	#[inline]
 	unsafe fn set_unchecked(&mut self, index: usize, val: SmallU<1>) {
 		let mask = 1u8 << index;
-		*self = SmallU::<4>::new((self.val() & !mask) | (val.val() << index));
+		*self = Self::new((self.val() & !mask) | (val.val() << index));
 	}
 
 	#[inline]
@@ -751,7 +751,7 @@ impl Divisible<SmallU<1>> for SmallU<4> {
 		let mut v = val.val();
 		v |= v << 1;
 		v |= v << 2;
-		SmallU::<4>::new(v)
+		Self::new(v)
 	}
 
 	#[inline]
@@ -759,7 +759,7 @@ impl Divisible<SmallU<1>> for SmallU<4> {
 		iter.chain(std::iter::repeat(SmallU::<1>::new(0)))
 			.take(4)
 			.enumerate()
-			.fold(SmallU::<4>::new(0), |mut acc, (i, val)| {
+			.fold(Self::new(0), |mut acc, (i, val)| {
 				acc.set(i, val);
 				acc
 			})
@@ -793,14 +793,14 @@ impl Divisible<SmallU<2>> for SmallU<4> {
 	unsafe fn set_unchecked(&mut self, index: usize, val: SmallU<2>) {
 		let shift = index * 2;
 		let mask = 0b11u8 << shift;
-		*self = SmallU::<4>::new((self.val() & !mask) | (val.val() << shift));
+		*self = Self::new((self.val() & !mask) | (val.val() << shift));
 	}
 
 	#[inline]
 	fn broadcast(val: SmallU<2>) -> Self {
 		// 0bXX -> 0bXXXX
 		let v = val.val();
-		SmallU::<4>::new(v | (v << 2))
+		Self::new(v | (v << 2))
 	}
 
 	#[inline]
@@ -808,7 +808,7 @@ impl Divisible<SmallU<2>> for SmallU<4> {
 		iter.chain(std::iter::repeat(SmallU::<2>::new(0)))
 			.take(2)
 			.enumerate()
-			.fold(SmallU::<4>::new(0), |mut acc, (i, val)| {
+			.fold(Self::new(0), |mut acc, (i, val)| {
 				acc.set(i, val);
 				acc
 			})

--- a/crates/frontend/src/compiler/constraint_builder.rs
+++ b/crates/frontend/src/compiler/constraint_builder.rs
@@ -207,72 +207,72 @@ impl Shift {
 	/// Try to compose two shift operations.
 	///
 	/// Returns None if the shifts are incompatible.
-	pub const fn compose(lhs: Shift, rhs: Shift) -> Option<Self> {
+	pub const fn compose(lhs: Self, rhs: Self) -> Option<Self> {
 		match (lhs, rhs) {
-			(Shift::None, shift) | (shift, Shift::None) => Some(shift),
-			(Shift::Sll(a), Shift::Sll(b)) => {
+			(Self::None, shift) | (shift, Self::None) => Some(shift),
+			(Self::Sll(a), Self::Sll(b)) => {
 				// Left shift composition: shl(shl(x, a), b) = shl(x, a + b)
 				let combined = a + b;
 				if combined < 64 {
-					Some(Shift::Sll(combined))
+					Some(Self::Sll(combined))
 				} else {
 					None
 				}
 			}
-			(Shift::Sll32(a), Shift::Sll32(b)) => {
+			(Self::Sll32(a), Self::Sll32(b)) => {
 				// 32-bit half-wise left shift composition
 				let combined = a + b;
 				if combined < 32 {
-					Some(Shift::Sll32(combined))
+					Some(Self::Sll32(combined))
 				} else {
 					None
 				}
 			}
-			(Shift::Srl(a), Shift::Srl(b)) => {
+			(Self::Srl(a), Self::Srl(b)) => {
 				// Logical right shift composition: shr(shr(x, a), b) = shr(x, a + b)
 				let combined = a + b;
 				if combined < 64 {
-					Some(Shift::Srl(combined))
+					Some(Self::Srl(combined))
 				} else {
 					None
 				}
 			}
-			(Shift::Srl32(a), Shift::Srl32(b)) => {
+			(Self::Srl32(a), Self::Srl32(b)) => {
 				// 32-bit half-wise logical right shift composition
 				let combined = a + b;
 				if combined < 32 {
-					Some(Shift::Srl32(combined))
+					Some(Self::Srl32(combined))
 				} else {
 					None
 				}
 			}
-			(Shift::Sar(a), Shift::Sar(b)) => {
+			(Self::Sar(a), Self::Sar(b)) => {
 				// Arithmetic right shift composition
 				let combined = a + b;
 				if combined < 64 {
-					Some(Shift::Sar(combined))
+					Some(Self::Sar(combined))
 				} else {
 					None
 				}
 			}
-			(Shift::Sra32(a), Shift::Sra32(b)) => {
+			(Self::Sra32(a), Self::Sra32(b)) => {
 				// 32-bit half-wise arithmetic right shift composition
 				let combined = a + b;
 				if combined < 32 {
-					Some(Shift::Sra32(combined))
+					Some(Self::Sra32(combined))
 				} else {
 					None
 				}
 			}
-			(Shift::Rotr(a), Shift::Rotr(b)) => {
+			(Self::Rotr(a), Self::Rotr(b)) => {
 				// Rotate right composition: rotr(rotr(x, a), b) = rotr(x, (a + b) % 64)
 				let combined = (a + b) % 64;
-				Some(Shift::Rotr(combined))
+				Some(Self::Rotr(combined))
 			}
-			(Shift::Rotr32(a), Shift::Rotr32(b)) => {
+			(Self::Rotr32(a), Self::Rotr32(b)) => {
 				// 32-bit half-wise rotate right composition
 				let combined = (a + b) % 32;
-				Some(Shift::Rotr32(combined))
+				Some(Self::Rotr32(combined))
 			}
 			_ => None, // Different shift types are not composable
 		}
@@ -515,11 +515,11 @@ impl WireExpr {
 impl WireExprTerm {
 	const fn to_shifted_wire(self) -> ShiftedWire {
 		match self {
-			WireExprTerm::Wire(w) => ShiftedWire {
+			Self::Wire(w) => ShiftedWire {
 				wire: w,
 				shift: Shift::None,
 			},
-			WireExprTerm::Shifted(w, op) => ShiftedWire {
+			Self::Shifted(w, op) => ShiftedWire {
 				wire: w,
 				shift: match op {
 					ShiftOp::Sll(n) => Shift::Sll(n),
@@ -613,13 +613,13 @@ impl From<Wire> for WireExpr {
 
 impl From<Wire> for WireExprTerm {
 	fn from(w: Wire) -> Self {
-		WireExprTerm::Wire(w)
+		Self::Wire(w)
 	}
 }
 
 impl From<WireExprTerm> for WireExpr {
 	fn from(expr: WireExprTerm) -> Self {
-		WireExpr(smallvec![expr])
+		Self(smallvec![expr])
 	}
 }
 

--- a/crates/frontend/src/compiler/dump.rs
+++ b/crates/frontend/src/compiler/dump.rs
@@ -17,7 +17,7 @@ struct PathSpecData {
 
 impl PathSpecData {
 	const fn new() -> Self {
-		PathSpecData {
+		Self {
 			name: String::new(),
 			gates: Vec::new(),
 			parent: None,
@@ -35,8 +35,8 @@ struct GateBreakdown {
 }
 
 impl GateBreakdown {
-	fn count(gg: &GateGraph, gates: &[Gate]) -> GateBreakdown {
-		let mut breakdown = GateBreakdown {
+	fn count(gg: &GateGraph, gates: &[Gate]) -> Self {
+		let mut breakdown = Self {
 			by_opcode: BTreeMap::new(),
 		};
 		for gate in gates {
@@ -46,7 +46,7 @@ impl GateBreakdown {
 		breakdown
 	}
 
-	fn merge(mut self, other: &GateBreakdown) -> GateBreakdown {
+	fn merge(mut self, other: &Self) -> Self {
 		for (opcode, count) in &other.by_opcode {
 			*self.by_opcode.entry(opcode.clone()).or_insert(0) += count;
 		}
@@ -213,7 +213,7 @@ impl Cx {
 struct SubcircuitInfo {
 	name: String,
 	n_gates: usize,
-	children: Vec<SubcircuitInfo>,
+	children: Vec<Self>,
 	breakdown: GateBreakdown,
 }
 

--- a/crates/frontend/src/compiler/eval_form/mod.rs
+++ b/crates/frontend/src/compiler/eval_form/mod.rs
@@ -68,7 +68,7 @@ impl EvalForm {
 		}
 
 		let (bytecode, n_eval_insn) = builder.finalize();
-		EvalForm {
+		Self {
 			bytecode,
 			n_eval_insn,
 			hint_registry,

--- a/crates/frontend/src/compiler/gate/opcode.rs
+++ b/crates/frontend/src/compiler/gate/opcode.rs
@@ -95,49 +95,49 @@ impl Opcode {
 
 		match self {
 			// Bitwise operations
-			Opcode::Band => gate::band::shape(),
-			Opcode::Bxor => gate::bxor::shape(),
+			Self::Band => gate::band::shape(),
+			Self::Bxor => gate::bxor::shape(),
 			// TODO: Can we get rid of this gate? This is the only non-hint one with dimensions
-			Opcode::BxorMulti => gate::bxor_multi::shape(dimensions),
-			Opcode::Bor => gate::bor::shape(),
-			Opcode::Fax => gate::fax::shape(),
+			Self::BxorMulti => gate::bxor_multi::shape(dimensions),
+			Self::Bor => gate::bor::shape(),
+			Self::Fax => gate::fax::shape(),
 
 			// Selection
-			Opcode::Select => gate::select::shape(),
+			Self::Select => gate::select::shape(),
 
 			// Arithmetic
-			Opcode::Iadd => gate::iadd::shape(),
-			Opcode::IaddCinCout => gate::iadd_cin_cout::shape(),
-			Opcode::Iadd32 => gate::iadd32::shape(),
-			Opcode::Iadd32CinCout => gate::iadd32_cin_cout::shape(),
-			Opcode::IsubBinBout => gate::isub_bin_bout::shape(),
-			Opcode::Imul => gate::imul::shape(),
-			Opcode::Smul => gate::smul::shape(),
+			Self::Iadd => gate::iadd::shape(),
+			Self::IaddCinCout => gate::iadd_cin_cout::shape(),
+			Self::Iadd32 => gate::iadd32::shape(),
+			Self::Iadd32CinCout => gate::iadd32_cin_cout::shape(),
+			Self::IsubBinBout => gate::isub_bin_bout::shape(),
+			Self::Imul => gate::imul::shape(),
+			Self::Smul => gate::smul::shape(),
 
 			// Shifts
-			Opcode::Shr => gate::shr::shape(),
-			Opcode::Shl => gate::shl::shape(),
-			Opcode::Sll32 => gate::sll32::shape(),
-			Opcode::Sar => gate::sar::shape(),
-			Opcode::Srl32 => gate::srl32::shape(),
-			Opcode::Sra32 => gate::sra32::shape(),
-			Opcode::Rotr => gate::rotr::shape(),
-			Opcode::Rotr32 => gate::rotr32::shape(),
+			Self::Shr => gate::shr::shape(),
+			Self::Shl => gate::shl::shape(),
+			Self::Sll32 => gate::sll32::shape(),
+			Self::Sar => gate::sar::shape(),
+			Self::Srl32 => gate::srl32::shape(),
+			Self::Sra32 => gate::sra32::shape(),
+			Self::Rotr => gate::rotr::shape(),
+			Self::Rotr32 => gate::rotr32::shape(),
 
 			// Comparisons
-			Opcode::IcmpUlt => gate::icmp_ult::shape(),
-			Opcode::IcmpEq => gate::icmp_eq::shape(),
+			Self::IcmpUlt => gate::icmp_ult::shape(),
+			Self::IcmpEq => gate::icmp_eq::shape(),
 
 			// Assertions (no outputs)
-			Opcode::AssertEq => gate::assert_eq::shape(),
-			Opcode::AssertZero => gate::assert_zero::shape(),
-			Opcode::AssertNonZero => gate::assert_non_zero::shape(),
-			Opcode::AssertFalse => gate::assert_false::shape(),
-			Opcode::AssertTrue => gate::assert_true::shape(),
-			Opcode::AssertEqCond => gate::assert_eq_cond::shape(),
+			Self::AssertEq => gate::assert_eq::shape(),
+			Self::AssertZero => gate::assert_zero::shape(),
+			Self::AssertNonZero => gate::assert_non_zero::shape(),
+			Self::AssertFalse => gate::assert_false::shape(),
+			Self::AssertTrue => gate::assert_true::shape(),
+			Self::AssertEqCond => gate::assert_eq_cond::shape(),
 
 			// Hints (no constraints)
-			Opcode::Hint => {
+			Self::Hint => {
 				panic!("Opcode::Hint shape requires the HintRegistry; use GateData::shape instead")
 			}
 		}
@@ -146,8 +146,8 @@ impl Opcode {
 	pub const fn is_const_shape(&self) -> bool {
 		#[allow(clippy::match_like_matches_macro)]
 		match self {
-			Opcode::BxorMulti => false,
-			Opcode::Hint => false,
+			Self::BxorMulti => false,
+			Self::Hint => false,
 			_ => true,
 		}
 	}

--- a/crates/frontend/src/compiler/gate_fusion/commit_set.rs
+++ b/crates/frontend/src/compiler/gate_fusion/commit_set.rs
@@ -35,7 +35,7 @@ impl CommitSetCx {
 	}
 
 	/// Merge multiple contexts into a single one.
-	fn join<'a>(iter: impl Iterator<Item = &'a CommitSetCx>) -> Self {
+	fn join<'a>(iter: impl Iterator<Item = &'a Self>) -> Self {
 		let mut set = Vec::with_capacity(8);
 		let mut depth = 0;
 		for cx in iter {
@@ -48,7 +48,7 @@ impl CommitSetCx {
 	}
 
 	/// Create a new context by adding a new shift and incrementing depth.
-	fn add(&self, out_shift: Shift) -> CommitSetCx {
+	fn add(&self, out_shift: Shift) -> Self {
 		let mut set = self
 			.set
 			.iter()

--- a/crates/frontend/src/compiler/gate_fusion/legraph.rs
+++ b/crates/frontend/src/compiler/gate_fusion/legraph.rs
@@ -77,11 +77,11 @@ pub enum NodeData {
 
 impl NodeData {
 	const fn is_root(&self) -> bool {
-		matches!(self, NodeData::Root { .. })
+		matches!(self, Self::Root { .. })
 	}
 
 	const fn is_opaque(&self) -> bool {
-		matches!(self, NodeData::Opaque { .. })
+		matches!(self, Self::Opaque { .. })
 	}
 }
 

--- a/crates/frontend/src/compiler/gate_graph.rs
+++ b/crates/frontend/src/compiler/gate_graph.rs
@@ -19,7 +19,7 @@ pub struct ConstPool {
 
 impl ConstPool {
 	pub fn new() -> Self {
-		ConstPool::default()
+		Self::default()
 	}
 
 	pub fn get(&self, value: Word) -> Option<Wire> {
@@ -53,7 +53,7 @@ pub enum WireKind {
 impl WireKind {
 	/// Returns `true` if this is a constant wire.
 	pub const fn is_const(&self) -> bool {
-		matches!(self, WireKind::Constant(_))
+		matches!(self, Self::Constant(_))
 	}
 }
 

--- a/crates/frontend/src/compiler/mod.rs
+++ b/crates/frontend/src/compiler/mod.rs
@@ -164,7 +164,7 @@ pub struct CircuitBuilder {
 
 impl Default for CircuitBuilder {
 	fn default() -> Self {
-		CircuitBuilder::new()
+		Self::new()
 	}
 }
 
@@ -179,7 +179,7 @@ impl CircuitBuilder {
 	pub(crate) fn with_opts(opts: Options) -> Self {
 		let graph = GateGraph::new();
 		let root = graph.path_spec_tree.root();
-		CircuitBuilder {
+		Self {
 			current_path: root,
 			shared: Rc::new(RefCell::new(Some(Shared {
 				graph,
@@ -313,12 +313,12 @@ impl CircuitBuilder {
 	///
 	/// Note that this is the same builder instance, but with a different namespace, and that means
 	/// calling [`Self::build`] on the returned builder is going to build the whole circuit.
-	pub fn subcircuit(&self, name: impl Into<String>) -> CircuitBuilder {
+	pub fn subcircuit(&self, name: impl Into<String>) -> Self {
 		let nested_path = self
 			.graph_mut()
 			.path_spec_tree
 			.extend(self.current_path, name);
-		CircuitBuilder {
+		Self {
 			current_path: nested_path,
 			shared: self.shared.clone(),
 		}

--- a/crates/iop/src/basefold.rs
+++ b/crates/iop/src/basefold.rs
@@ -178,8 +178,8 @@ pub enum VerificationError {
 impl From<fri::Error> for Error {
 	fn from(err: fri::Error) -> Self {
 		match err {
-			fri::Error::Verification(err) => Error::Verification(err.into()),
-			_ => Error::FRI(err),
+			fri::Error::Verification(err) => Self::Verification(err.into()),
+			_ => Self::FRI(err),
 		}
 	}
 }

--- a/crates/ip/src/fracaddcheck.rs
+++ b/crates/ip/src/fracaddcheck.rs
@@ -97,7 +97,7 @@ impl From<sumcheck::Error> for Error {
 	fn from(err: sumcheck::Error) -> Self {
 		match err {
 			sumcheck::Error::Verification(err) => VerificationError::Sumcheck(err).into(),
-			_ => Error::Sumcheck(err),
+			_ => Self::Sumcheck(err),
 		}
 	}
 }
@@ -106,7 +106,7 @@ impl From<TranscriptError> for Error {
 	fn from(err: TranscriptError) -> Self {
 		match err {
 			TranscriptError::NotEnoughBytes => VerificationError::TranscriptIsEmpty.into(),
-			_ => Error::Transcript(err),
+			_ => Self::Transcript(err),
 		}
 	}
 }

--- a/crates/ip/src/prodcheck.rs
+++ b/crates/ip/src/prodcheck.rs
@@ -85,7 +85,7 @@ impl From<sumcheck::Error> for Error {
 	fn from(err: sumcheck::Error) -> Self {
 		match err {
 			sumcheck::Error::Verification(err) => VerificationError::Sumcheck(err).into(),
-			_ => Error::Sumcheck(err),
+			_ => Self::Sumcheck(err),
 		}
 	}
 }
@@ -94,7 +94,7 @@ impl From<TranscriptError> for Error {
 	fn from(err: TranscriptError) -> Self {
 		match err {
 			TranscriptError::NotEnoughBytes => VerificationError::TranscriptIsEmpty.into(),
-			_ => Error::Transcript(err),
+			_ => Self::Transcript(err),
 		}
 	}
 }

--- a/crates/ip/src/sumcheck/error.rs
+++ b/crates/ip/src/sumcheck/error.rs
@@ -24,7 +24,7 @@ impl From<TranscriptError> for Error {
 	fn from(err: TranscriptError) -> Self {
 		match err {
 			TranscriptError::NotEnoughBytes => VerificationError::TranscriptIsEmpty.into(),
-			_ => Error::Transcript(err),
+			_ => Self::Transcript(err),
 		}
 	}
 }

--- a/crates/math/src/ntt/tests_evaluation.rs
+++ b/crates/math/src/ntt/tests_evaluation.rs
@@ -147,8 +147,8 @@ impl<F: Field> Mul<&Polynomial<F>> for &Polynomial<F> {
 }
 
 // Polynomial *= &Polynomial
-impl<F: Field> MulAssign<&Polynomial<F>> for Polynomial<F> {
-	fn mul_assign(&mut self, other: &Polynomial<F>) {
+impl<F: Field> MulAssign<&Self> for Polynomial<F> {
+	fn mul_assign(&mut self, other: &Self) {
 		*self = &*self * other;
 	}
 }

--- a/crates/prover/src/and_reduction/ntt_lookup.rs
+++ b/crates/prover/src/and_reduction/ntt_lookup.rs
@@ -107,7 +107,7 @@ impl NTTLookup {
 		});
 
 		let lookup = lde_mat.map(expand_subset_sums_array::<_, 8, 256>);
-		NTTLookup(Box::new(lookup))
+		Self(Box::new(lookup))
 	}
 
 	/// Computes the LDE of 64 1-bit coefficients using the precomputed lookup tables.

--- a/crates/prover/src/protocols/shift/key_collection.rs
+++ b/crates/prover/src/protocols/shift/key_collection.rs
@@ -316,8 +316,8 @@ pub fn build_key_collection(cs: &ConstraintSystem) -> KeyCollection {
 impl SerializeBytes for Operation {
 	fn serialize(&self, write_buf: impl BufMut) -> Result<(), SerializationError> {
 		let val = match self {
-			Operation::BitwiseAnd => 0u8,
-			Operation::IntegerMul => 1u8,
+			Self::BitwiseAnd => 0u8,
+			Self::IntegerMul => 1u8,
 		};
 		val.serialize(write_buf)
 	}
@@ -327,8 +327,8 @@ impl DeserializeBytes for Operation {
 	fn deserialize(mut read_buf: impl Buf) -> Result<Self, SerializationError> {
 		let val = u8::deserialize(&mut read_buf)?;
 		match val {
-			0 => Ok(Operation::BitwiseAnd),
-			1 => Ok(Operation::IntegerMul),
+			0 => Ok(Self::BitwiseAnd),
+			1 => Ok(Self::IntegerMul),
 			_ => Err(SerializationError::UnknownEnumVariant {
 				name: "Operation",
 				index: val,
@@ -352,7 +352,7 @@ impl DeserializeBytes for Key {
 		let id = u16::deserialize(&mut read_buf)?;
 		let start = u32::deserialize(&mut read_buf)?;
 		let end = u32::deserialize(&mut read_buf)?;
-		Ok(Key {
+		Ok(Self {
 			operation,
 			id,
 			range: start..end,
@@ -371,7 +371,7 @@ impl DeserializeBytes for ConstraintIndex {
 	fn deserialize(mut read_buf: impl Buf) -> Result<Self, SerializationError> {
 		let operand_index = u8::deserialize(&mut read_buf)?;
 		let constraint_index = u32::deserialize(&mut read_buf)?;
-		Ok(ConstraintIndex {
+		Ok(Self {
 			operand_index,
 			constraint_index,
 		})
@@ -420,7 +420,7 @@ impl DeserializeBytes for KeyCollection {
 
 		let constraint_indices = Vec::<ConstraintIndex>::deserialize(&mut read_buf)?;
 
-		Ok(KeyCollection {
+		Ok(Self {
 			keys,
 			key_ranges,
 			constraint_indices,

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -307,7 +307,7 @@ where
 
 		let iop_prover = IOPProver::new(verifier.into_iop_verifier(), key_collection);
 
-		Ok(Prover {
+		Ok(Self {
 			iop_prover,
 			basefold_compiler,
 		})

--- a/crates/spartan-frontend/src/circuit_builder.rs
+++ b/crates/spartan-frontend/src/circuit_builder.rs
@@ -66,7 +66,7 @@ pub struct WireAllocator {
 
 impl WireAllocator {
 	pub const fn new(kind: WireKind) -> Self {
-		WireAllocator { n_wires: 0, kind }
+		Self { n_wires: 0, kind }
 	}
 
 	pub const fn alloc(&mut self) -> ConstraintWire {
@@ -239,7 +239,7 @@ pub struct ConstraintBuilder<F: Field> {
 impl<F: Field> ConstraintBuilder<F> {
 	#[allow(clippy::new_without_default)]
 	pub fn new() -> Self {
-		ConstraintBuilder {
+		Self {
 			ir: ConstraintSystemIR {
 				constant_alloc: WireAllocator::new(WireKind::Constant),
 				public_alloc: WireAllocator::new(WireKind::InOut),

--- a/crates/spartan-frontend/src/constraint_system.rs
+++ b/crates/spartan-frontend/src/constraint_system.rs
@@ -29,9 +29,9 @@ impl WireKind {
 	/// the public segment; precommit and private wires occupy their own segments.
 	pub const fn segment(self) -> WitnessSegment {
 		match self {
-			WireKind::Constant | WireKind::InOut | WireKind::Derived => WitnessSegment::Public,
-			WireKind::Precommit => WitnessSegment::Precommit,
-			WireKind::Private => WitnessSegment::Private,
+			Self::Constant | Self::InOut | Self::Derived => WitnessSegment::Public,
+			Self::Precommit => WitnessSegment::Precommit,
+			Self::Private => WitnessSegment::Private,
 		}
 	}
 
@@ -78,7 +78,7 @@ pub struct Operand<W>(SmallVec<[W; 4]>);
 
 impl<W> Default for Operand<W> {
 	fn default() -> Self {
-		Operand(SmallVec::new())
+		Self(SmallVec::new())
 	}
 }
 
@@ -115,7 +115,7 @@ impl<W: Copy + Ord> Operand<W> {
 		&self.0
 	}
 
-	pub fn merge(&mut self, rhs: &Self) -> (Operand<W>, Operand<W>) {
+	pub fn merge(&mut self, rhs: &Self) -> (Self, Self) {
 		// Classic merge algorithm for sorted vectors, but where duplicate items cancel out.
 		let lhs = mem::take(&mut self.0);
 		let dst = &mut self.0;
@@ -123,8 +123,8 @@ impl<W: Copy + Ord> Operand<W> {
 		let mut lhs_iter = lhs.into_iter().peekable();
 		let mut rhs_iter = rhs.0.iter().copied().peekable();
 
-		let mut additions = Operand::default();
-		let mut removals = Operand::default();
+		let mut additions = Self::default();
+		let mut removals = Self::default();
 
 		loop {
 			match (lhs_iter.peek(), rhs_iter.peek()) {
@@ -161,7 +161,7 @@ impl<W: Copy + Ord> Operand<W> {
 
 impl<W> From<W> for Operand<W> {
 	fn from(value: W) -> Self {
-		Operand(smallvec![value])
+		Self(smallvec![value])
 	}
 }
 

--- a/crates/spartan-frontend/src/wire_elimination.rs
+++ b/crates/spartan-frontend/src/wire_elimination.rs
@@ -40,7 +40,7 @@ pub struct CostModel {
 impl Default for CostModel {
 	fn default() -> Self {
 		// This is just a guess, can be tuned later.
-		CostModel {
+		Self {
 			wire_cost: 16,
 			mul_cost: 2,
 			ref_cost: 1,

--- a/crates/spartan-prover/src/lib.rs
+++ b/crates/spartan-prover/src/lib.rs
@@ -350,7 +350,7 @@ where
 
 		let iop_prover = IOPProver::new(verifier.constraint_system().clone());
 
-		Ok(Prover {
+		Ok(Self {
 			iop_prover,
 			basefold_compiler,
 		})

--- a/crates/spartan-verifier/src/wrapper/circuit_elem.rs
+++ b/crates/spartan-verifier/src/wrapper/circuit_elem.rs
@@ -388,7 +388,7 @@ impl<F: Field, B: CircuitBuilder<Field = F>> MulAssign<&Self> for CircuitElem<F,
 
 impl<F: Field, B: CircuitBuilder<Field = F>> Sum for CircuitElem<F, B> {
 	fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
-		iter.fold(CircuitElem::Constant(F::ZERO), |acc, x| acc + x)
+		iter.fold(Self::Constant(F::ZERO), |acc, x| acc + x)
 	}
 }
 

--- a/crates/utils/src/rayon/iter/parallel_iterator.rs
+++ b/crates/utils/src/rayon/iter/parallel_iterator.rs
@@ -1165,8 +1165,8 @@ where
 	#[inline(always)]
 	fn into_inner(self) -> Self::Inner {
 		match self {
-			Either::Left(left) => Either::Left(left.into_inner()),
-			Either::Right(right) => Either::Right(right.into_inner()),
+			Self::Left(left) => Either::Left(left.into_inner()),
+			Self::Right(right) => Either::Right(right.into_inner()),
 		}
 	}
 

--- a/crates/utils/src/rayon/mod.rs
+++ b/crates/utils/src/rayon/mod.rs
@@ -97,7 +97,7 @@ cfg_if::cfg_if! {
 
 		pub struct Scope<'scope> {
 			#[allow(clippy::type_complexity)]
-			marker: PhantomData<Box<dyn FnOnce(&Scope<'scope>) + Send + Sync + 'scope>>,
+			marker: PhantomData<Box<dyn FnOnce(&Self) + Send + Sync + 'scope>>,
 		}
 
 		impl<'scope> Scope<'scope> {


### PR DESCRIPTION
One lint in isolation, in its own commit, so its effect can be reviewed on its own (same approach as the const-fn and redundant-clone PRs).

### The lint

`clippy::use_self` (nursery): inside an `impl` block, flags references to the implementing type written with its full name where `Self` would do — `MyType::new()` -> `Self::new()`, `-> MyType` -> `-> Self`, `x as *const MyType` -> `x as *const Self`. Using `Self` keeps impls robust to renames and makes the "this is the impl's own type" relationship explicit.

Enabled in the workspace config:

```toml
[workspace.lints.clippy]
needless_range_loop = "allow"
missing_const_for_fn = "warn"
redundant_clone = "warn"
use_self = "warn"
```

### The change

46 files, all from `cargo clippy --fix`. Purely syntactic — no behavior change.

### Checked every arch/feature config

`use_self` fires in the feature-gated SIMD code under `arch/x86_64` and `arch/aarch64`, which a plain build on one host never fully compiles. So I ran the fix and `-D warnings` check across every config the CI matrix (`-Ctarget-cpu=native` per leg) can hit:

| config | result |
|---|---|
| native aarch64 (default) | clean |
| aarch64 `+neon,+aes,+sha3` | clean |
| x86_64 default (sse2 / portable leg) | clean |
| x86_64 `+avx,+avx2,+pclmulqdq` (AMD-like, no AVX-512) | clean |
| x86_64 `+avx2,+avx512f,+gfni,+vpclmulqdq,...` (Intel native) | clean |

### Scope

- **changed:** root `Cargo.toml` (one lint line) + `Self` substitutions across the workspace, including the x86_64/aarch64 arch modules

### Verification

- `cargo clippy --workspace --all-targets -- -D warnings` — exits 0 (all five configs above)
- `cargo build --workspace --all-targets` — clean
- `cargo +nightly fmt --all --check` — clean
- `cargo test --workspace` — all pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)