### PR TITLE
[codex] Add independent hash primitive benchmarks

### DIFF
--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -64,6 +64,18 @@ name = "hashsign"
 harness = false
 
 [[bench]]
+name = "sha256_compressions"
+harness = false
+
+[[bench]]
+name = "blake3_compressions"
+harness = false
+
+[[bench]]
+name = "keccak_permutations"
+harness = false
+
+[[bench]]
 name = "sha256"
 harness = false
 

--- a/crates/examples/benches/blake3_compressions.rs
+++ b/crates/examples/benches/blake3_compressions.rs
@@ -1,0 +1,33 @@
+// Copyright 2026 The Binius Developers
+// Copyright 2025 Irreducible Inc.
+//! Independent BLAKE3 compression benchmark.
+
+#[path = "utils/config.rs"]
+mod config;
+#[path = "utils/independent_hashes.rs"]
+mod independent_hashes;
+#[path = "utils/reporting.rs"]
+mod reporting;
+#[path = "utils/runner.rs"]
+mod runner;
+
+use std::alloc::System;
+
+use binius_examples::circuits::independent_hashes::IndependentBlake3Compressions;
+use criterion::{Criterion, criterion_group, criterion_main};
+use independent_hashes::{IndependentPrimitive, run_independent_hash_benchmark};
+use peakmem_alloc::PeakMemAlloc;
+
+#[global_allocator]
+static BLAKE3_COMPRESSIONS_PEAK_ALLOC: PeakMemAlloc<System> = PeakMemAlloc::new(System);
+
+fn bench_blake3_compressions(c: &mut Criterion) {
+	run_independent_hash_benchmark::<IndependentBlake3Compressions>(
+		c,
+		IndependentPrimitive::Blake3,
+		&BLAKE3_COMPRESSIONS_PEAK_ALLOC,
+	);
+}
+
+criterion_group!(blake3_compressions, bench_blake3_compressions);
+criterion_main!(blake3_compressions);

--- a/crates/examples/benches/keccak_permutations.rs
+++ b/crates/examples/benches/keccak_permutations.rs
@@ -1,0 +1,33 @@
+// Copyright 2026 The Binius Developers
+// Copyright 2025 Irreducible Inc.
+//! Independent Keccak-f[1600] permutation benchmark.
+
+#[path = "utils/config.rs"]
+mod config;
+#[path = "utils/independent_hashes.rs"]
+mod independent_hashes;
+#[path = "utils/reporting.rs"]
+mod reporting;
+#[path = "utils/runner.rs"]
+mod runner;
+
+use std::alloc::System;
+
+use binius_examples::circuits::independent_hashes::IndependentKeccakPermutations;
+use criterion::{Criterion, criterion_group, criterion_main};
+use independent_hashes::{IndependentPrimitive, run_independent_hash_benchmark};
+use peakmem_alloc::PeakMemAlloc;
+
+#[global_allocator]
+static KECCAK_PERMUTATIONS_PEAK_ALLOC: PeakMemAlloc<System> = PeakMemAlloc::new(System);
+
+fn bench_keccak_permutations(c: &mut Criterion) {
+	run_independent_hash_benchmark::<IndependentKeccakPermutations>(
+		c,
+		IndependentPrimitive::Keccak,
+		&KECCAK_PERMUTATIONS_PEAK_ALLOC,
+	);
+}
+
+criterion_group!(keccak_permutations, bench_keccak_permutations);
+criterion_main!(keccak_permutations);

--- a/crates/examples/benches/sha256_compressions.rs
+++ b/crates/examples/benches/sha256_compressions.rs
@@ -1,0 +1,33 @@
+// Copyright 2026 The Binius Developers
+// Copyright 2025 Irreducible Inc.
+//! Independent SHA-256 compression benchmark.
+
+#[path = "utils/config.rs"]
+mod config;
+#[path = "utils/independent_hashes.rs"]
+mod independent_hashes;
+#[path = "utils/reporting.rs"]
+mod reporting;
+#[path = "utils/runner.rs"]
+mod runner;
+
+use std::alloc::System;
+
+use binius_examples::circuits::independent_hashes::IndependentSha256Compressions;
+use criterion::{Criterion, criterion_group, criterion_main};
+use independent_hashes::{IndependentPrimitive, run_independent_hash_benchmark};
+use peakmem_alloc::PeakMemAlloc;
+
+#[global_allocator]
+static SHA256_COMPRESSIONS_PEAK_ALLOC: PeakMemAlloc<System> = PeakMemAlloc::new(System);
+
+fn bench_sha256_compressions(c: &mut Criterion) {
+	run_independent_hash_benchmark::<IndependentSha256Compressions>(
+		c,
+		IndependentPrimitive::Sha256,
+		&SHA256_COMPRESSIONS_PEAK_ALLOC,
+	);
+}
+
+criterion_group!(sha256_compressions, bench_sha256_compressions);
+criterion_main!(sha256_compressions);

--- a/crates/examples/benches/utils/config.rs
+++ b/crates/examples/benches/utils/config.rs
@@ -12,6 +12,9 @@ pub const DEFAULT_HASH_LOG_INV_RATE: usize = 1;
 /// Default LOG_INV_RATE for signature benchmarks
 pub const DEFAULT_SIGN_LOG_INV_RATE: usize = 2;
 
+/// Default number of primitives for independent hash primitive benchmarks.
+pub const DEFAULT_INDEPENDENT_NUM_PRIMITIVES: usize = 4096;
+
 /// Common configuration for hash benchmarks
 #[derive(Debug, Clone)]
 #[allow(dead_code)]

--- a/crates/examples/benches/utils/independent_hashes.rs
+++ b/crates/examples/benches/utils/independent_hashes.rs
@@ -1,0 +1,173 @@
+// Copyright 2026 The Binius Developers
+// Copyright 2025 Irreducible Inc.
+//! Shared runner for independent hash primitive benchmarks.
+
+use std::{env, marker::PhantomData, time::Duration};
+
+use binius_examples::{
+	ExampleCircuit,
+	circuits::independent_hashes::{Instance, PrimitiveParams},
+};
+use binius_verifier::{config::StdChallenger, transcript::ProverTranscript};
+use criterion::{BenchmarkId, Criterion, Throughput};
+use peakmem_alloc::PeakMemAllocTrait;
+
+use super::{
+	config::{DEFAULT_HASH_LOG_INV_RATE, DEFAULT_INDEPENDENT_NUM_PRIMITIVES},
+	reporting::print_benchmark_header,
+	runner::{
+		ConstraintSystemBenchmarkContext, ExampleBenchmark, run_cs_benchmark_with_extra_groups,
+	},
+};
+
+#[derive(Clone, Copy)]
+#[allow(dead_code)]
+pub enum IndependentPrimitive {
+	Sha256,
+	Blake3,
+	Keccak,
+}
+
+impl IndependentPrimitive {
+	const fn label(self) -> &'static str {
+		match self {
+			Self::Sha256 => "SHA-256 compressions",
+			Self::Blake3 => "BLAKE3 compressions",
+			Self::Keccak => "Keccak-f[1600] permutations",
+		}
+	}
+
+	const fn group_prefix(self) -> &'static str {
+		match self {
+			Self::Sha256 => "sha256_compressions",
+			Self::Blake3 => "blake3_compressions",
+			Self::Keccak => "keccak_permutations",
+		}
+	}
+
+	const fn count_env_key(self) -> &'static str {
+		match self {
+			Self::Sha256 | Self::Blake3 => "N_COMPRESSIONS",
+			Self::Keccak => "N_PERMUTATIONS",
+		}
+	}
+}
+
+struct IndependentHashBenchmark<E> {
+	primitive: IndependentPrimitive,
+	num_primitives: usize,
+	log_inv_rate: usize,
+	_marker: PhantomData<E>,
+}
+
+impl<E> IndependentHashBenchmark<E> {
+	fn new(primitive: IndependentPrimitive) -> Self {
+		let num_primitives = env_usize(primitive.count_env_key())
+			.or_else(|| env_usize("N_PRIMITIVES"))
+			.unwrap_or(DEFAULT_INDEPENDENT_NUM_PRIMITIVES);
+		let log_inv_rate = env_usize("LOG_INV_RATE").unwrap_or(DEFAULT_HASH_LOG_INV_RATE);
+
+		Self {
+			primitive,
+			num_primitives,
+			log_inv_rate,
+			_marker: PhantomData,
+		}
+	}
+}
+
+impl<E> ExampleBenchmark for IndependentHashBenchmark<E>
+where
+	E: ExampleCircuit<Params = PrimitiveParams, Instance = Instance>,
+{
+	type Params = PrimitiveParams;
+	type Instance = Instance;
+	type Example = E;
+
+	fn create_params(&self) -> Self::Params {
+		PrimitiveParams {
+			num_primitives: self.num_primitives,
+		}
+	}
+
+	fn create_instance(&self) -> Self::Instance {
+		Instance { seed: None }
+	}
+
+	fn bench_name(&self) -> String {
+		format!("n_{}", self.num_primitives)
+	}
+
+	fn throughput(&self) -> Throughput {
+		Throughput::Elements(self.num_primitives as u64)
+	}
+
+	fn proof_description(&self) -> String {
+		format!("{} {}", self.num_primitives, self.primitive.label())
+	}
+
+	fn log_inv_rate(&self) -> usize {
+		self.log_inv_rate
+	}
+
+	fn print_params(&self) {
+		let params = vec![
+			("Primitive".to_string(), self.primitive.label().to_string()),
+			("Count".to_string(), self.num_primitives.to_string()),
+			("Log inverse rate".to_string(), self.log_inv_rate.to_string()),
+		];
+		print_benchmark_header("Independent hash primitives", &params);
+	}
+}
+
+pub fn run_independent_hash_benchmark<E>(
+	c: &mut Criterion,
+	primitive: IndependentPrimitive,
+	peak_alloc: &impl PeakMemAllocTrait,
+) where
+	E: ExampleCircuit<Params = PrimitiveParams, Instance = Instance>,
+{
+	let benchmark = IndependentHashBenchmark::<E>::new(primitive);
+	run_cs_benchmark_with_extra_groups(
+		c,
+		benchmark,
+		primitive.group_prefix(),
+		peak_alloc,
+		bench_witness_generation_and_proving,
+	);
+}
+
+fn bench_witness_generation_and_proving<B>(
+	c: &mut Criterion,
+	ctx: ConstraintSystemBenchmarkContext<'_, B>,
+) where
+	B: ExampleBenchmark,
+{
+	let mut group =
+		c.benchmark_group(format!("{}_witness_generation_and_proving", ctx.group_prefix));
+	group.throughput(ctx.benchmark.throughput());
+	group.sample_size(10);
+	group.warm_up_time(Duration::from_secs(2));
+
+	// Flock's headline proof path includes witness generation, so this group reports the same
+	// end-to-end unit of work for cross-prover comparisons.
+	group.bench_function(BenchmarkId::from_parameter(ctx.bench_name), |b| {
+		b.iter(|| {
+			let mut filler = ctx.circuit.new_witness_filler();
+			ctx.example
+				.populate_witness(ctx.instance.clone(), &mut filler)
+				.unwrap();
+			ctx.circuit.populate_wire_witness(&mut filler).unwrap();
+			let witness = filler.into_value_vec();
+			let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
+			ctx.prover.prove(witness, &mut prover_transcript).unwrap();
+			prover_transcript
+		})
+	});
+
+	group.finish();
+}
+
+fn env_usize(key: &str) -> Option<usize> {
+	env::var(key).ok().and_then(|s| s.parse::<usize>().ok())
+}

--- a/crates/examples/benches/utils/reporting.rs
+++ b/crates/examples/benches/utils/reporting.rs
@@ -3,7 +3,10 @@
 
 use std::env;
 
-use super::config::{DEFAULT_HASH_LOG_INV_RATE, DEFAULT_HASH_MAX_BYTES, DEFAULT_SIGN_LOG_INV_RATE};
+use super::config::{
+	DEFAULT_HASH_LOG_INV_RATE, DEFAULT_HASH_MAX_BYTES, DEFAULT_INDEPENDENT_NUM_PRIMITIVES,
+	DEFAULT_SIGN_LOG_INV_RATE,
+};
 
 /// Print benchmark header with consistent formatting
 pub fn print_benchmark_header(name: &str, params: &[(String, String)]) {
@@ -74,6 +77,16 @@ pub fn print_env_help() {
 			"  HASH_MAX_BYTES         - Maximum bytes for hash benchmarks (default: {})",
 			DEFAULT_HASH_MAX_BYTES
 		);
+		println!("\nIndependent primitive benchmarks:");
+		println!(
+			"  N_COMPRESSIONS         - Number of independent SHA-256/BLAKE3 compressions (default: {})",
+			DEFAULT_INDEPENDENT_NUM_PRIMITIVES
+		);
+		println!(
+			"  N_PERMUTATIONS         - Number of independent Keccak-f[1600] permutations (default: {})",
+			DEFAULT_INDEPENDENT_NUM_PRIMITIVES
+		);
+		println!("  N_PRIMITIVES           - Fallback count for either primitive type");
 		println!("\nSignature aggregation benchmarks:");
 		println!(
 			"  N_SIGNATURES           - Number of signatures (default: 1 for ethsign, 4 for hashsign)"

--- a/crates/examples/benches/utils/runner.rs
+++ b/crates/examples/benches/utils/runner.rs
@@ -4,8 +4,9 @@
 use std::error::Error;
 
 use binius_examples::{ExampleCircuit, setup};
-use binius_frontend::CircuitBuilder;
+use binius_frontend::{Circuit, CircuitBuilder};
 use binius_hash::StdHashSuite;
+use binius_prover::{OptimalPackedB128, Prover};
 use binius_utils::platform_diagnostics::PlatformDiagnostics;
 use binius_verifier::{
 	config::StdChallenger,
@@ -53,13 +54,43 @@ pub trait ExampleBenchmark {
 	fn print_params(&self);
 }
 
+/// Context passed to benchmark-specific extension groups.
+///
+/// Some benchmark binaries load this runner without registering extension groups, so these fields
+/// are only read in targets that use [`run_cs_benchmark_with_extra_groups`].
+#[allow(dead_code)]
+pub struct ConstraintSystemBenchmarkContext<'a, B: ExampleBenchmark> {
+	pub group_prefix: &'a str,
+	pub bench_name: &'a str,
+	pub benchmark: &'a B,
+	pub circuit: &'a Circuit,
+	pub example: &'a B::Example,
+	pub instance: &'a B::Instance,
+	pub prover: &'a Prover<OptimalPackedB128, StdHashSuite>,
+}
+
 /// Run a complete benchmark suite for a constraint system
+#[allow(dead_code)]
 pub fn run_cs_benchmark<B: ExampleBenchmark>(
 	c: &mut Criterion,
 	benchmark: B,
 	group_prefix: &str,
 	peak_alloc: &impl PeakMemAllocTrait,
 ) {
+	run_cs_benchmark_with_extra_groups(c, benchmark, group_prefix, peak_alloc, |_, _| {});
+}
+
+/// Run a complete benchmark suite for a constraint system, with benchmark-specific extra groups.
+pub fn run_cs_benchmark_with_extra_groups<B, F>(
+	c: &mut Criterion,
+	benchmark: B,
+	group_prefix: &str,
+	peak_alloc: &impl PeakMemAllocTrait,
+	extra_groups: F,
+) where
+	B: ExampleBenchmark,
+	F: FnOnce(&mut Criterion, ConstraintSystemBenchmarkContext<'_, B>),
+{
 	use super::reporting::{print_env_help, print_memory_stats, print_proof_size};
 
 	// Check for help
@@ -98,13 +129,13 @@ pub fn run_cs_benchmark<B: ExampleBenchmark>(
 	prover
 		.prove(witness.clone(), &mut prover_transcript_mem)
 		.unwrap();
-	let proof_bytes_mem = prover_transcript_mem.finalize();
+	let proof_bytes = prover_transcript_mem.finalize();
 	let proof_peak_bytes = peak_alloc.get_peak_memory();
 
 	// Track memory for verification
 	peak_alloc.reset_peak_memory();
 	let mut verifier_transcript_mem =
-		VerifierTranscript::new(StdChallenger::default(), proof_bytes_mem);
+		VerifierTranscript::new(StdChallenger::default(), proof_bytes.clone());
 	verifier
 		.verify(witness.public(), &mut verifier_transcript_mem)
 		.unwrap();
@@ -155,12 +186,19 @@ pub fn run_cs_benchmark<B: ExampleBenchmark>(
 		group.finish();
 	}
 
-	// Generate proof for verification and size measurement
-	let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
-	prover
-		.prove(witness.clone(), &mut prover_transcript)
-		.unwrap();
-	let proof_bytes = prover_transcript.finalize();
+	extra_groups(
+		c,
+		ConstraintSystemBenchmarkContext {
+			group_prefix,
+			bench_name: &bench_name,
+			benchmark: &benchmark,
+			circuit: &circuit,
+			example: &example,
+			instance: &instance,
+			prover: &prover,
+		},
+	);
+
 	let proof_size = proof_bytes.len();
 
 	// Benchmark proof verification

--- a/crates/examples/src/circuits/independent_hashes.rs
+++ b/crates/examples/src/circuits/independent_hashes.rs
@@ -1,0 +1,256 @@
+// Copyright 2026 The Binius Developers
+// Copyright 2025 Irreducible Inc.
+
+use anyhow::{Result, ensure};
+use binius_circuits::{
+	blake3::blake3_compress,
+	keccak::permutation::{Permutation, State as KeccakState},
+	sha256::{State as Sha256State, populate_message_block, sha256_compress},
+};
+use binius_core::word::Word;
+use binius_frontend::{CircuitBuilder, Wire, WitnessFiller};
+use clap::Args;
+use rand::prelude::*;
+
+use super::utils::DEFAULT_RANDOM_SEED;
+use crate::ExampleCircuit;
+
+/// Default number of logical compression/permutation primitives for CLI use.
+///
+/// Benchmark harnesses override this with environment variables.
+pub const DEFAULT_NUM_PRIMITIVES: usize = 16;
+
+#[derive(Debug, Clone, Args)]
+pub struct PrimitiveParams {
+	/// Number of independent primitive evaluations.
+	#[arg(short = 'n', long, default_value_t = DEFAULT_NUM_PRIMITIVES)]
+	pub num_primitives: usize,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct Instance {
+	/// RNG seed for deterministic witness values.
+	#[arg(long)]
+	pub seed: Option<u64>,
+}
+
+/// Independent SHA-256 compression evaluations.
+///
+/// Each circuit component runs `compress(IV, m_i)` for a fresh 64-byte message block.
+pub struct IndependentSha256Compressions {
+	blocks: Vec<[Wire; 16]>,
+}
+
+impl ExampleCircuit for IndependentSha256Compressions {
+	type Params = PrimitiveParams;
+	type Instance = Instance;
+
+	fn build(params: PrimitiveParams, builder: &mut CircuitBuilder) -> Result<Self> {
+		ensure!(params.num_primitives > 0, "num_primitives must be positive");
+
+		let blocks = (0..params.num_primitives)
+			.map(|_| {
+				let block = std::array::from_fn(|_| builder.add_witness());
+				let _out = sha256_compress(builder, Sha256State::iv(builder), block);
+				block
+			})
+			.collect();
+
+		Ok(Self { blocks })
+	}
+
+	fn populate_witness(&self, instance: Instance, w: &mut WitnessFiller) -> Result<()> {
+		let mut rng = StdRng::seed_from_u64(instance.seed.unwrap_or(DEFAULT_RANDOM_SEED));
+		for block in &self.blocks {
+			populate_message_block(w, block, next_block(&mut rng));
+		}
+		Ok(())
+	}
+
+	fn param_summary(params: &Self::Params) -> Option<String> {
+		Some(format!("{}c", params.num_primitives))
+	}
+}
+
+/// Independent BLAKE3 compression evaluations.
+///
+/// Each circuit component runs one independent BLAKE3 compression function.
+pub struct IndependentBlake3Compressions {
+	compressions: Vec<Blake3Compression>,
+}
+
+struct Blake3Compression {
+	cv: [Wire; 8],
+	block: [Wire; 16],
+	counter: Wire,
+	block_len: Wire,
+	flags: Wire,
+}
+
+impl ExampleCircuit for IndependentBlake3Compressions {
+	type Params = PrimitiveParams;
+	type Instance = Instance;
+
+	fn build(params: PrimitiveParams, builder: &mut CircuitBuilder) -> Result<Self> {
+		ensure!(params.num_primitives > 0, "num_primitives must be positive");
+
+		let compressions = (0..params.num_primitives)
+			.map(|_| {
+				let cv = std::array::from_fn(|_| builder.add_witness());
+				let block = std::array::from_fn(|_| builder.add_witness());
+				let counter = builder.add_witness();
+				let block_len = builder.add_witness();
+				let flags = builder.add_witness();
+				let _out = blake3_compress(builder, cv, block, counter, block_len, flags);
+				Blake3Compression {
+					cv,
+					block,
+					counter,
+					block_len,
+					flags,
+				}
+			})
+			.collect();
+
+		Ok(Self { compressions })
+	}
+
+	fn populate_witness(&self, instance: Instance, w: &mut WitnessFiller) -> Result<()> {
+		let mut rng = StdRng::seed_from_u64(instance.seed.unwrap_or(DEFAULT_RANDOM_SEED));
+		for compression in &self.compressions {
+			for wire in compression.cv {
+				w[wire] = next_u32_word(&mut rng);
+			}
+			for wire in compression.block {
+				w[wire] = next_u32_word(&mut rng);
+			}
+			w[compression.counter] = Word(rng.next_u64());
+			w[compression.block_len] = Word((rng.next_u32() % 65) as u64);
+			w[compression.flags] = next_u32_word(&mut rng);
+		}
+		Ok(())
+	}
+
+	fn param_summary(params: &Self::Params) -> Option<String> {
+		Some(format!("{}c", params.num_primitives))
+	}
+}
+
+/// Independent Keccak-f\[1600\] permutation evaluations.
+pub struct IndependentKeccakPermutations {
+	permutations: Vec<Permutation>,
+}
+
+impl ExampleCircuit for IndependentKeccakPermutations {
+	type Params = PrimitiveParams;
+	type Instance = Instance;
+
+	fn build(params: PrimitiveParams, builder: &mut CircuitBuilder) -> Result<Self> {
+		ensure!(params.num_primitives > 0, "num_primitives must be positive");
+
+		let permutations = (0..params.num_primitives)
+			.map(|_| {
+				let words = std::array::from_fn(|_| builder.add_witness());
+				Permutation::new(builder, KeccakState { words })
+			})
+			.collect();
+
+		Ok(Self { permutations })
+	}
+
+	fn populate_witness(&self, instance: Instance, w: &mut WitnessFiller) -> Result<()> {
+		let mut rng = StdRng::seed_from_u64(instance.seed.unwrap_or(DEFAULT_RANDOM_SEED));
+		for permutation in &self.permutations {
+			let state = std::array::from_fn(|_| rng.next_u64());
+			permutation.populate_state(w, state);
+		}
+		Ok(())
+	}
+
+	fn param_summary(params: &Self::Params) -> Option<String> {
+		Some(format!("{}p", params.num_primitives))
+	}
+}
+
+fn next_u32_word(rng: &mut StdRng) -> Word {
+	Word(rng.next_u32() as u64)
+}
+
+fn next_block(rng: &mut StdRng) -> [u8; 64] {
+	let mut block = [0; 64];
+	for chunk in block.chunks_exact_mut(8) {
+		chunk.copy_from_slice(&rng.next_u64().to_le_bytes());
+	}
+	block
+}
+
+#[cfg(test)]
+mod tests {
+	use binius_core::verify::verify_constraints;
+	use binius_frontend::CircuitBuilder;
+
+	use super::*;
+
+	fn assert_builds_and_populates<E>()
+	where
+		E: ExampleCircuit<Params = PrimitiveParams, Instance = Instance>,
+	{
+		let mut builder = CircuitBuilder::new();
+		let example = E::build(PrimitiveParams { num_primitives: 2 }, &mut builder).unwrap();
+		let circuit = builder.build();
+		let mut filler = circuit.new_witness_filler();
+
+		example
+			.populate_witness(Instance { seed: Some(7) }, &mut filler)
+			.unwrap();
+		circuit.populate_wire_witness(&mut filler).unwrap();
+		verify_constraints(circuit.constraint_system(), &filler.into_value_vec()).unwrap();
+	}
+
+	#[test]
+	fn independent_sha256_compressions_populate_valid_witness() {
+		assert_builds_and_populates::<IndependentSha256Compressions>();
+	}
+
+	#[test]
+	fn independent_blake3_compressions_populate_valid_witness() {
+		assert_builds_and_populates::<IndependentBlake3Compressions>();
+	}
+
+	#[test]
+	fn independent_keccak_permutations_populate_valid_witness() {
+		assert_builds_and_populates::<IndependentKeccakPermutations>();
+	}
+
+	#[test]
+	fn compression_benchmarks_accept_odd_counts() {
+		let mut builder = CircuitBuilder::new();
+		IndependentSha256Compressions::build(PrimitiveParams { num_primitives: 1 }, &mut builder)
+			.unwrap();
+
+		let mut builder = CircuitBuilder::new();
+		IndependentBlake3Compressions::build(PrimitiveParams { num_primitives: 1 }, &mut builder)
+			.unwrap();
+	}
+
+	#[test]
+	fn compression_benchmarks_reject_zero_counts() {
+		let mut builder = CircuitBuilder::new();
+		assert!(
+			IndependentSha256Compressions::build(
+				PrimitiveParams { num_primitives: 0 },
+				&mut builder
+			)
+			.is_err()
+		);
+
+		let mut builder = CircuitBuilder::new();
+		assert!(
+			IndependentBlake3Compressions::build(
+				PrimitiveParams { num_primitives: 0 },
+				&mut builder
+			)
+			.is_err()
+		);
+	}
+}

--- a/crates/examples/src/circuits/mod.rs
+++ b/crates/examples/src/circuits/mod.rs
@@ -10,6 +10,7 @@ pub mod blake3_compress;
 pub mod ec_msm;
 pub mod ethsign;
 pub mod hashsign;
+pub mod independent_hashes;
 pub mod keccak;
 pub mod sha256;
 pub mod sha512;


### PR DESCRIPTION
## Summary

Adds benchmark coverage for batches of independent hash primitives:

- `sha256_compressions`: independent `compress(IV, m_i)` SHA-256 compression calls
- `blake3_compressions`: independent BLAKE3 compression calls
- `keccak_permutations`: independent Keccak-f[1600] permutations

The benchmark runner reports witness generation, proof generation, combined witness-generation-plus-proving throughput, verification, proof size, and peak memory. The combined group is intended to make cross-prover comparisons easier for workloads like Flock's independent hash primitive benchmarks.

## Benchmark knobs

- `N_COMPRESSIONS`: SHA-256/BLAKE3 compression count, default `4096`
- `N_PERMUTATIONS`: Keccak-f[1600] permutation count, default `4096`
- `N_PRIMITIVES`: fallback count for either primitive type
- `LOG_INV_RATE`: inverse-rate parameter, default `1`

## Local 4096 results

Measured on Apple M4 Pro, generic ARM64 target, default features, `LOG_INV_RATE=1`.

| Primitive | Witness gen | Proof gen | Witness + prove | Verify | Proof | Peak mem |
|---|---:|---:|---:|---:|---:|---:|
| SHA-256 compressions | 91.47K/s | 6.87K/s | 6.43K/s | 39.70K/s | 14816 B / 14.47 KiB | 519.06 MB |
| BLAKE3 compressions | 275.80K/s | 8.51K/s | 8.20K/s | 58.51K/s | 14816 B / 14.47 KiB | 468.21 MB |
| Keccak-f[1600] permutations | 72.97K/s | 6.87K/s | 6.26K/s | 47.07K/s | 14816 B / 14.47 KiB | 519.09 MB |

The identical proof size is expected here: at `N=4096` and `LOG_INV_RATE=1`, all three circuits round into the same proof-size bucket.

## Methodology notes

- The `witness_generation_and_proving` group is the closest analog to Flock's headline prove path because it includes witness generation plus proving.
- The standalone `witness_generation` group includes `WitnessFiller` allocation, input population, circuit witness evaluation, and conversion into a `ValueVec`. Flock's competitor benches time only `populate_wire_witness` after pre-filling inputs, so this row is a Binius64-internal baseline rather than a strict cross-prover witness-generation comparison.
- The local numbers above are single-threaded, generic ARM64-target results. They are not a native CPU / pinned-performance-core comparison run.

## Test plan

- `cargo +nightly-2026-01-01 fmt --check`
- `cargo test -p binius-examples independent_hashes --lib`
- `cargo bench -p binius-examples --bench sha256_compressions --bench blake3_compressions --bench keccak_permutations --no-run`
- `cargo clippy --all --all-features --tests --benches --examples -- -D warnings`
- `N_COMPRESSIONS=4096 cargo bench -p binius-examples --bench sha256_compressions -- --noplot`
- `N_COMPRESSIONS=4096 cargo bench -p binius-examples --bench blake3_compressions -- --noplot`
- `N_PERMUTATIONS=4096 cargo bench -p binius-examples --bench keccak_permutations -- --noplot`