### PR TITLE
BINIUS-41: deduplicate the outer constraint-system build between ZK prover and verifier

### DIFF
--- a/crates/prover/src/zk_config.rs
+++ b/crates/prover/src/zk_config.rs
@@ -6,19 +6,13 @@
 //! Spartan-based zero-knowledge wrapper. The prover counterpart to
 //! [`binius_verifier::zk_config::ZKVerifier`].
 
-use binius_core::{
-	constraint_system::{ConstraintSystem, ValueVec},
-	word::Word,
-};
+use binius_core::constraint_system::{ConstraintSystem, ValueVec};
 use binius_field::{BinaryField128bGhash as B128, PackedExtension, PackedField};
 use binius_hash::binary_merkle_tree::HashSuite;
 use binius_iop_prover::basefold_compiler::BaseFoldProverCompiler;
 use binius_math::ntt::{NeighborsLastMultiThread, domain_context::GenericPreExpanded};
-use binius_spartan_frontend::{compiler::compile, constraint_system::WitnessLayout};
+use binius_spartan_frontend::constraint_system::WitnessLayout;
 use binius_spartan_prover::wrapper::{ReplayChannel, ZKWrappedProverChannel};
-use binius_spartan_verifier::{
-	constraint_system::ConstraintSystemPadded, wrapper::IronSpartanBuilderChannel,
-};
 use binius_transcript::{ProverTranscript, fiat_shamir::Challenger};
 use binius_utils::{DeserializeBytes, SerializeBytes, serialization::SerializationError};
 use binius_verifier::{IOPVerifier, zk_config::ZKVerifier};
@@ -79,37 +73,14 @@ where
 		let inner_iop_verifier = zk_verifier.inner_iop_verifier().clone();
 		let inner_iop_prover = IOPProver::new(inner_iop_verifier.clone(), key_collection);
 
-		// Re-derive the outer constraint system and layout via symbolic execution.
+		// Reuse the padded outer constraint system and layout the verifier already built.
 		//
-		// TODO: This duplicates code in ZKVerifier::setup. Prover needs to call it separately
-		// because the Verifier doesn't (and shouldn't) store the layout. However, the code can be
-		// refactored out for DRYness.
-		let outer_builder = {
-			let _guard = tracing::debug_span!("Build ZK wrapper circuit").entered();
-			let dummy_public_words =
-				vec![Word::from_u64(0); 1 << inner_iop_verifier.log_public_words()];
-			let mut builder_channel = IronSpartanBuilderChannel::new();
-			inner_iop_verifier
-				.verify(&dummy_public_words, &mut builder_channel)
-				.expect("symbolic verify should not fail");
-			builder_channel.finish()
-		};
-		let (outer_cs, outer_layout) = {
-			let _guard = tracing::debug_span!("Compile ZK wrapper circuit").entered();
-			compile(outer_builder)
-		};
-
-		// Pad the outer constraint system with the same blinding as the verifier.
-		let outer_cs = ConstraintSystemPadded::new(
-			outer_cs,
-			zk_verifier
-				.outer_iop_verifier()
-				.constraint_system()
-				.blinding_info()
-				.clone(),
-		);
-		let outer_layout = outer_layout.with_blinding(outer_cs.blinding_info().clone());
-
+		// Invariant: the verifier builds, pads, and lays out the wrapper circuit once.
+		// - It keeps that result for its own verification.
+		// - The prover's outer circuit is identical to it.
+		// - Cloning the result skips a redundant rebuild.
+		let outer_cs = zk_verifier.outer_iop_verifier().constraint_system().clone();
+		let outer_layout = zk_verifier.outer_layout().clone();
 		let outer_iop_prover = binius_spartan_prover::IOPProver::new(outer_cs);
 
 		// Build the BaseFold prover compiler from the verifier compiler.

--- a/crates/verifier/src/zk_config.rs
+++ b/crates/verifier/src/zk_config.rs
@@ -149,6 +149,13 @@ where
 		&self.outer_iop_verifier
 	}
 
+	/// Returns the witness layout of the outer Spartan constraint system.
+	///
+	/// The layout maps each logical wire to its position in the witness vector.
+	pub const fn outer_layout(&self) -> &WitnessLayout<B128> {
+		&self.outer_layout
+	}
+
 	/// Returns the BaseFold ZK verifier compiler.
 	pub const fn basefold_compiler(
 		&self,


### PR DESCRIPTION
Closes [BINIUS-41](https://linear.app/jimpo/issue/BINIUS-41/deduplicate-zkproversetup-and-zkverifiersetup).

Makes the ZK prover reuse the outer Spartan constraint system the ZK verifier already built, instead of re-deriving it.
Pure refactor — no behavior change.

### The problem

Setting up the ZK prover re-derived the *outer* Spartan constraint system from scratch:

- symbolically execute the inner verifier into a builder channel,
- compile the wrapper circuit,
- pad it for zero-knowledge,
- re-apply blinding to the layout.

That is exactly the sequence the ZK verifier's setup already runs.
An inline `TODO` called this out and asked for it to be refactored for DRYness.

The `TODO` also claimed the verifier "doesn't (and shouldn't) store the layout".
That is stale: the verifier stores the blinded layout and uses it itself during verification.

### The idea

The verifier already holds everything the prover recomputes:

- the **padded** outer constraint system, inside its outer IOP verifier,
- the **blinded** outer layout, as its own field.

The prover even fed the verifier's blinding info into its own recomputation, so the two results were byte-for-byte identical.

So the prover does not need to rebuild anything — it can clone what the verifier already has.

### The change

```
ZKProver::setup_with_key_collection:
- let dummy = vec![Word::from_u64(0); 1 << inner.log_public_words()];
- let mut builder = IronSpartanBuilderChannel::new();
- inner.verify(&dummy, &mut builder).expect(...);          // symbolic execution
- let (outer_cs, outer_layout) = compile(builder.finish());
- let outer_cs = ConstraintSystemPadded::new(outer_cs, verifier_blinding_info);
- let outer_layout = outer_layout.with_blinding(...);
+ let outer_cs = zk_verifier.outer_iop_verifier().constraint_system().clone();
+ let outer_layout = zk_verifier.outer_layout().clone();
let outer_iop_prover = binius_spartan_prover::IOPProver::new(outer_cs);
```

### Scope

- **new:** an `outer_layout()` accessor on the ZK verifier (the only piece the prover could not already reach).
- **changed:** the prover's setup now clones the padded constraint system and layout from the verifier; drops the now-unused `Word` / `compile` / `ConstraintSystemPadded` / builder-channel imports.
- **left untouched:** the verifier's setup, and the proof/transcript format.

### Soundness

- The prover's outer circuit was already constructed to equal the verifier's, using the verifier's own blinding info.
- Cloning it produces the identical padded constraint system and blinded layout.
- The transcript and proof are therefore bit-identical to before.

### Verification

- `cargo check --workspace --all-targets`, `clippy -p binius-prover -p binius-verifier --all-targets`, nightly `fmt --all` — clean.
- `cargo test -p binius-prover --test prove_verify` — 7/7 pass, including the full ZK roundtrip and the serialized-setup roundtrip, which exercise the reused constraint system end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)