### PR TITLE
BINIUS-179: automatically determine oracle specs via OracleSetupChannel

### DIFF
--- a/crates/iop-prover/src/basefold_channel.rs
+++ b/crates/iop-prover/src/basefold_channel.rs
@@ -621,7 +621,7 @@ mod tests {
 		let mut verifier_transcript = prover_transcript.into_verifier();
 		let mut verifier_channel = verifier_compiler.create_channel(&mut verifier_transcript);
 
-		let v_oracle = verifier_channel.recv_oracle().unwrap();
+		let v_oracle = verifier_channel.recv_oracle(n_vars, true).unwrap();
 
 		verifier_channel
 			.verify_oracle_relations([OracleLinearRelation {
@@ -688,8 +688,8 @@ mod tests {
 		let mut verifier_transcript = prover_transcript.into_verifier();
 		let mut verifier_channel = verifier_compiler.create_channel(&mut verifier_transcript);
 
-		let v_oracle_1 = verifier_channel.recv_oracle().unwrap();
-		let v_oracle_2 = verifier_channel.recv_oracle().unwrap();
+		let v_oracle_1 = verifier_channel.recv_oracle(n_vars_1, true).unwrap();
+		let v_oracle_2 = verifier_channel.recv_oracle(n_vars_2, true).unwrap();
 
 		let tp1 = transparent_poly_1;
 		let tp2 = transparent_poly_2;
@@ -773,8 +773,9 @@ mod tests {
 		let mut verifier_transcript = prover_transcript.into_verifier();
 		let mut verifier_channel = verifier_compiler.create_channel(&mut verifier_transcript);
 
-		let v_oracles: Vec<_> = (0..n_vars_list.len())
-			.map(|_| verifier_channel.recv_oracle().unwrap())
+		let v_oracles: Vec<_> = n_vars_list
+			.iter()
+			.map(|&n| verifier_channel.recv_oracle(n, true).unwrap())
 			.collect();
 		let relations: Vec<_> = v_oracles
 			.into_iter()
@@ -864,8 +865,9 @@ mod tests {
 		let mut verifier_transcript = prover_transcript.into_verifier();
 		let mut verifier_channel = verifier_compiler.create_channel(&mut verifier_transcript);
 
-		let v_oracles: Vec<_> = (0..specs.len())
-			.map(|_| verifier_channel.recv_oracle().unwrap())
+		let v_oracles: Vec<_> = specs
+			.iter()
+			.map(|&(n, _)| verifier_channel.recv_oracle(n, true).unwrap())
 			.collect();
 		let relations: Vec<_> = v_oracles
 			.into_iter()

--- a/crates/iop/src/basefold_channel.rs
+++ b/crates/iop/src/basefold_channel.rs
@@ -344,7 +344,13 @@ where
 		&self.oracle_specs[self.next_oracle_index..]
 	}
 
-	fn recv_oracle(&mut self) -> Result<Self::Oracle, Error> {
+	fn recv_oracle(
+		&mut self,
+		_log_msg_len: usize,
+		_is_witness_dependent: bool,
+	) -> Result<Self::Oracle, Error> {
+		// A BaseFold commitment is a fixed-size Merkle digest, so `log_msg_len` is not needed here;
+		// the per-oracle specs (used for the FRI opening) are supplied at channel construction.
 		assert!(
 			!self.remaining_oracle_specs().is_empty(),
 			"recv_oracle called but no remaining oracle specs"

--- a/crates/iop/src/channel.rs
+++ b/crates/iop/src/channel.rs
@@ -106,10 +106,18 @@ pub trait IOPVerifierChannel<'r, F: Field>: IPVerifierChannel<F> {
 
 	/// Receives an oracle commitment from the prover.
 	///
-	/// # Preconditions
-	///
-	/// `remaining_oracle_specs()` must be non-empty.
-	fn recv_oracle(&mut self) -> Result<Self::Oracle, Error>;
+	/// The caller describes the oracle being received: `log_msg_len` is the log2 of the message
+	/// length, and `is_witness_dependent` is whether the oracle's contents depend on the witness.
+	/// These let a channel record the oracle's [`OracleSpec`] rather than requiring the specs to be
+	/// supplied up front. The resulting oracle is zero-knowledge iff the channel is configured for
+	/// ZK *and* the oracle is witness-dependent — a non-witness-dependent oracle (e.g. a
+	/// pre-indexed commitment to the wiring matrix for succinctness, a planned feature) is never
+	/// masked.
+	fn recv_oracle(
+		&mut self,
+		log_msg_len: usize,
+		is_witness_dependent: bool,
+	) -> Result<Self::Oracle, Error>;
 
 	/// Queues oracle linear relations to be opened.
 	///

--- a/crates/iop/src/lib.rs
+++ b/crates/iop/src/lib.rs
@@ -32,4 +32,5 @@ pub mod channel;
 pub mod fri;
 pub mod merkle_tree;
 pub mod naive_channel;
+pub mod oracle_setup_channel;
 pub mod size_tracking_channel;

--- a/crates/iop/src/naive_channel.rs
+++ b/crates/iop/src/naive_channel.rs
@@ -150,16 +150,20 @@ where
 		&self.oracle_specs[self.next_oracle_index..]
 	}
 
-	fn recv_oracle(&mut self) -> Result<Self::Oracle, Error> {
+	fn recv_oracle(
+		&mut self,
+		log_msg_len: usize,
+		_is_witness_dependent: bool,
+	) -> Result<Self::Oracle, Error> {
 		assert!(
 			!self.remaining_oracle_specs().is_empty(),
 			"recv_oracle called but no remaining oracle specs"
 		);
 
 		let index = self.next_oracle_index;
-		let spec = &self.oracle_specs[index];
+		debug_assert_eq!(log_msg_len, self.oracle_specs[index].log_msg_len);
 
-		let buffer_len = 1 << spec.log_msg_len;
+		let buffer_len = 1 << log_msg_len;
 
 		// Read all polynomial coefficients from the transcript
 		let values = self

--- a/crates/iop/src/oracle_setup_channel.rs
+++ b/crates/iop/src/oracle_setup_channel.rs
@@ -1,0 +1,234 @@
+// Copyright 2026 The Binius Developers
+
+//! An [`IOPVerifierChannel`] that records the sequence of oracle specifications an IOP uses,
+//! without performing any actual verification.
+//!
+//! Running an IOP verifier against an `OracleSetupChannel` (a dry run: all `recv_*` methods return
+//! dummy values and `assert_zero` is a no-op, like [`SizeTrackingChannel`]) discovers the
+//! [`OracleSpec`] sequence directly from the `recv_oracle` calls, so the specs need not be
+//! hardcoded and kept in sync with the verification logic by hand.
+//!
+//! [`SizeTrackingChannel`]: crate::size_tracking_channel::SizeTrackingChannel
+
+use std::{
+	iter::{Product, Sum},
+	ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
+};
+
+use binius_field::{
+	BinaryField128bGhash, ExtensionField, Field, FieldOps,
+	arithmetic_traits::{InvertOrZero, Square},
+	util::FieldFn,
+};
+use binius_ip::channel::IPVerifierChannel;
+
+use crate::channel::{Error, IOPVerifierChannel, OracleLinearRelation, OracleSpec};
+
+/// A zero-sized dummy field element for [`OracleSetupChannel`].
+///
+/// The setup channel performs no real verification, so the field values flowing through it are
+/// never inspected. `DummyElem` is a stand-in whose arithmetic is all no-ops; it lets the setup
+/// channel be a single non-generic type and avoids doing (pointless) real field arithmetic during
+/// the structural dry run.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct DummyElem;
+
+macro_rules! dummy_binop {
+	($trait:ident, $method:ident) => {
+		impl $trait for DummyElem {
+			type Output = Self;
+			fn $method(self, _rhs: Self) -> Self {
+				self
+			}
+		}
+		impl $trait<&DummyElem> for DummyElem {
+			type Output = Self;
+			fn $method(self, _rhs: &Self) -> Self {
+				self
+			}
+		}
+	};
+}
+dummy_binop!(Add, add);
+dummy_binop!(Sub, sub);
+dummy_binop!(Mul, mul);
+
+macro_rules! dummy_assign {
+	($trait:ident, $method:ident) => {
+		impl $trait for DummyElem {
+			fn $method(&mut self, _rhs: Self) {}
+		}
+		impl $trait<&DummyElem> for DummyElem {
+			fn $method(&mut self, _rhs: &Self) {}
+		}
+	};
+}
+dummy_assign!(AddAssign, add_assign);
+dummy_assign!(SubAssign, sub_assign);
+dummy_assign!(MulAssign, mul_assign);
+
+impl Neg for DummyElem {
+	type Output = Self;
+	fn neg(self) -> Self {
+		self
+	}
+}
+
+impl Sum for DummyElem {
+	fn sum<I: Iterator<Item = Self>>(_iter: I) -> Self {
+		Self
+	}
+}
+impl<'a> Sum<&'a DummyElem> for DummyElem {
+	fn sum<I: Iterator<Item = &'a Self>>(_iter: I) -> Self {
+		Self
+	}
+}
+impl Product for DummyElem {
+	fn product<I: Iterator<Item = Self>>(_iter: I) -> Self {
+		Self
+	}
+}
+impl<'a> Product<&'a DummyElem> for DummyElem {
+	fn product<I: Iterator<Item = &'a Self>>(_iter: I) -> Self {
+		Self
+	}
+}
+
+impl Square for DummyElem {
+	fn square(self) -> Self {
+		self
+	}
+}
+impl InvertOrZero for DummyElem {
+	fn invert_or_zero(self) -> Self {
+		self
+	}
+}
+
+impl From<BinaryField128bGhash> for DummyElem {
+	fn from(_value: BinaryField128bGhash) -> Self {
+		Self
+	}
+}
+
+impl FieldOps for DummyElem {
+	// The scalar is arbitrary; nothing reads it. `BinaryField128bGhash` satisfies the
+	// `FieldOps<Scalar = B128>` bound that `binius_verifier`'s IOP verify requires.
+	type Scalar = BinaryField128bGhash;
+
+	fn zero() -> Self {
+		Self
+	}
+
+	fn one() -> Self {
+		Self
+	}
+
+	fn square_transpose<FSub: Field>(_elems: &mut [Self])
+	where
+		BinaryField128bGhash: ExtensionField<FSub>,
+	{
+	}
+}
+
+/// An [`IOPVerifierChannel`] that records the [`OracleSpec`] of each received oracle.
+///
+/// This performs no verification: `recv_*` methods return dummy values, and sampling, observation,
+/// and `assert_zero` are no-ops. Drive an IOP verifier with this channel and then read the
+/// recorded specs via [`into_oracle_specs`](Self::into_oracle_specs).
+///
+/// The channel is configured with a single `is_zk` flag (the protocol-level zero-knowledge
+/// choice). Each `recv_oracle(log_msg_len, is_witness_dependent)` records
+/// `OracleSpec { log_msg_len, is_zk: self.is_zk && is_witness_dependent }`.
+#[derive(Debug, Default, Clone)]
+pub struct OracleSetupChannel {
+	is_zk: bool,
+	oracle_specs: Vec<OracleSpec>,
+}
+
+impl OracleSetupChannel {
+	/// Creates a new setup channel with the given protocol-level zero-knowledge flag.
+	pub const fn new(is_zk: bool) -> Self {
+		Self {
+			is_zk,
+			oracle_specs: Vec::new(),
+		}
+	}
+
+	/// Returns the oracle specs recorded so far.
+	pub fn oracle_specs(&self) -> &[OracleSpec] {
+		&self.oracle_specs
+	}
+
+	/// Consumes the channel and returns the recorded oracle specs, in the order received.
+	pub fn into_oracle_specs(self) -> Vec<OracleSpec> {
+		self.oracle_specs
+	}
+}
+
+impl<F: Field> IPVerifierChannel<F> for OracleSetupChannel {
+	type Elem = DummyElem;
+
+	fn recv_one(&mut self) -> Result<DummyElem, binius_ip::channel::Error> {
+		Ok(DummyElem)
+	}
+
+	fn recv_many(&mut self, n: usize) -> Result<Vec<DummyElem>, binius_ip::channel::Error> {
+		Ok(vec![DummyElem; n])
+	}
+
+	fn recv_array<const N: usize>(&mut self) -> Result<[DummyElem; N], binius_ip::channel::Error> {
+		Ok([DummyElem; N])
+	}
+
+	fn sample(&mut self) -> DummyElem {
+		DummyElem
+	}
+
+	fn observe_one(&mut self, _val: F) -> DummyElem {
+		DummyElem
+	}
+
+	fn observe_many(&mut self, vals: &[F]) -> Vec<DummyElem> {
+		vec![DummyElem; vals.len()]
+	}
+
+	fn assert_zero(&mut self, _val: DummyElem) -> Result<(), binius_ip::channel::Error> {
+		Ok(())
+	}
+
+	fn compute_public_value(&mut self, _inputs: &[DummyElem], _f: impl FieldFn<F>) -> DummyElem {
+		// The setup channel performs no real computation; skipping `f` is permitted (see the
+		// `IPVerifierChannel::compute_public_value` contract).
+		DummyElem
+	}
+}
+
+impl<'r, F: Field> IOPVerifierChannel<'r, F> for OracleSetupChannel {
+	type Oracle = ();
+
+	fn remaining_oracle_specs(&self) -> &[OracleSpec] {
+		// A setup channel has no pre-supplied specs; it records them as they are received.
+		&[]
+	}
+
+	fn recv_oracle(
+		&mut self,
+		log_msg_len: usize,
+		is_witness_dependent: bool,
+	) -> Result<Self::Oracle, Error> {
+		self.oracle_specs.push(OracleSpec {
+			log_msg_len,
+			is_zk: self.is_zk && is_witness_dependent,
+		});
+		Ok(())
+	}
+
+	fn verify_oracle_relations(
+		&mut self,
+		_oracle_relations: impl IntoIterator<Item = OracleLinearRelation<'r, Self::Oracle, Self::Elem>>,
+	) -> Result<(), Error> {
+		Ok(())
+	}
+}

--- a/crates/iop/src/size_tracking_channel.rs
+++ b/crates/iop/src/size_tracking_channel.rs
@@ -130,7 +130,11 @@ impl<'r, F: BinaryField, MerkleScheme_: MerkleTreeScheme<F>> IOPVerifierChannel<
 		&self.oracle_specs[self.next_oracle_index..]
 	}
 
-	fn recv_oracle(&mut self) -> Result<Self::Oracle, Error> {
+	fn recv_oracle(
+		&mut self,
+		_log_msg_len: usize,
+		_is_witness_dependent: bool,
+	) -> Result<Self::Oracle, Error> {
 		self.proof_size += self.oracle_size;
 		self.next_oracle_index += 1;
 		Ok(())

--- a/crates/m4-verifier/src/verify.rs
+++ b/crates/m4-verifier/src/verify.rs
@@ -110,8 +110,9 @@ impl Verifier {
 	{
 		let mut channel = self.iop_compiler.create_channel(transcript);
 
-		// Receive the commitment, redraw the same point, and read the claimed evaluation.
-		let oracle = channel.recv_oracle()?;
+		// Receive the commitment, redraw the same point, and read the claimed evaluation. The
+		// packed batch witness is witness-dependent (M4 commits it without ZK regardless).
+		let oracle = channel.recv_oracle(self.layout.log_witness_elems, true)?;
 		let point = channel.sample_many(self.layout.log_witness_elems);
 		let eval = channel.recv_one()?;
 

--- a/crates/spartan-prover/src/wiring.rs
+++ b/crates/spartan-prover/src/wiring.rs
@@ -498,7 +498,7 @@ mod tests {
 
 		// Receive witness oracle
 		let witness_oracle = verifier_channel
-			.recv_oracle()
+			.recv_oracle(log_private, true)
 			.expect("recv_oracle should succeed");
 
 		// Sample the same lambda as prover

--- a/crates/spartan-prover/src/wrapper/replay_channel.rs
+++ b/crates/spartan-prover/src/wrapper/replay_channel.rs
@@ -144,7 +144,11 @@ impl<'r, 'a, F: Field> IOPVerifierChannel<'r, F> for ReplayChannel<'a, F> {
 		&[]
 	}
 
-	fn recv_oracle(&mut self) -> Result<Self::Oracle, binius_iop::channel::Error> {
+	fn recv_oracle(
+		&mut self,
+		_log_msg_len: usize,
+		_is_witness_dependent: bool,
+	) -> Result<Self::Oracle, binius_iop::channel::Error> {
 		Ok(())
 	}
 

--- a/crates/spartan-prover/tests/wrapper_integration_test.rs
+++ b/crates/spartan-prover/tests/wrapper_integration_test.rs
@@ -200,7 +200,9 @@ fn test_zk_wrapped_prove_verify() {
 	let inner_public_elems = wrapped_verifier_channel.observe_many(&public);
 
 	// Run the inner IOP verify through the wrapped channel.
-	let inner_precommit_oracle = wrapped_verifier_channel.recv_oracle().unwrap();
+	let inner_precommit_oracle = wrapped_verifier_channel
+		.recv_oracle(outer_oracle_specs[0].log_msg_len, true)
+		.unwrap();
 	inner_iop_verifier
 		.verify(inner_precommit_oracle, inner_public_elems, &mut wrapped_verifier_channel)
 		.expect("inner IOP verify failed");

--- a/crates/spartan-verifier/src/lib.rs
+++ b/crates/spartan-verifier/src/lib.rs
@@ -43,6 +43,7 @@ use binius_iop::{
 	channel::{IOPVerifierChannel, OracleLinearRelation, OracleSpec},
 	fri::{self, MinProofSizeStrategy},
 	merkle_tree::BinaryMerkleTreeScheme,
+	oracle_setup_channel::{DummyElem, OracleSetupChannel},
 };
 use binius_ip::{channel::IPVerifierChannel, mlecheck, sumcheck};
 use binius_math::{multilinear::eq::eq_ind_partial_eval_scalars, univariate::evaluate_univariate};
@@ -108,16 +109,32 @@ impl<F: Field> IOPVerifier<F> {
 	/// Returns the oracle specs for the IOP channel.
 	///
 	/// These describe the oracles (witness and mask) that the prover commits to.
-	pub fn oracle_specs(&self) -> Vec<OracleSpec> {
+	///
+	/// The specs are derived by replaying the oracle-receiving sequence against an
+	/// [`OracleSetupChannel`] (which records each `recv_oracle` without doing real verification),
+	/// rather than hardcoding it. IronSpartan proofs are always zero-knowledge. The precommit
+	/// oracle is received by the outer [`Verifier::verify`] before it delegates to
+	/// [`Self::verify`], so it is recorded here first to match that order.
+	pub fn oracle_specs(&self) -> Vec<OracleSpec>
+	where
+		F: BinaryField,
+	{
 		let cs = &self.constraint_system;
-		let (m_n, m_d) = cs.mask_dims();
-		let log_mask_dim = m_n + m_d;
-
-		vec![
-			OracleSpec::new_zk(cs.log_precommit() as usize),
-			OracleSpec::new_zk(cs.log_private() as usize),
-			OracleSpec::new_zk(log_mask_dim),
-		]
+		let mut channel = OracleSetupChannel::new(true);
+		// Record the precommit oracle first (`OracleSetupChannel` implements the channel trait for
+		// every `F`, so the trait is named explicitly to fix `F`); the `verify` call below fixes it
+		// for the rest of the sequence.
+		<OracleSetupChannel as IOPVerifierChannel<'_, F>>::recv_oracle(
+			&mut channel,
+			cs.log_precommit() as usize,
+			true,
+		)
+		.expect("OracleSetupChannel::recv_oracle is infallible");
+		let public = vec![DummyElem; 1 << cs.log_public()];
+		// Discarded: the setup channel performs no real verification; we only read back the
+		// recorded oracle specs.
+		let _ = self.verify((), public, &mut channel);
+		channel.into_oracle_specs()
 	}
 
 	/// Verifies a proof using an IOP channel.
@@ -156,9 +173,13 @@ impl<F: Field> IOPVerifier<F> {
 			});
 		}
 
-		// Receive the private and mask oracle commitments.
-		let private_oracle = channel.recv_oracle()?;
-		let mask_oracle = channel.recv_oracle()?;
+		// Receive the private and mask oracle commitments. The private witness is
+		// witness-dependent. The mask is passed `is_witness_dependent = true` to preserve its ZK
+		// masking (it is a fresh random mask rather than witness data, but is committed with
+		// hiding in the ZK protocol).
+		let private_oracle = channel.recv_oracle(cs.log_private() as usize, true)?;
+		let (m_n, m_d) = cs.mask_dims();
+		let mask_oracle = channel.recv_oracle(m_n + m_d, true)?;
 
 		// Verify the multiplication constraints.
 		let MulcheckOutput {
@@ -313,7 +334,8 @@ where
 		// Create channel, receive the precommit oracle, and delegate to IOPVerifier::verify. The
 		// IOP verifier only queues the oracle relations; `finish` runs the single combined opening.
 		let mut channel = self.basefold_compiler.create_channel(transcript);
-		let precommit_oracle = channel.recv_oracle()?;
+		let precommit_oracle =
+			channel.recv_oracle(self.constraint_system().log_precommit() as usize, true)?;
 		self.iop_verifier
 			.verify(precommit_oracle, public.to_vec(), &mut channel)?;
 		Ok(channel.finish()?)

--- a/crates/spartan-verifier/src/wrapper/builder_channel.rs
+++ b/crates/spartan-verifier/src/wrapper/builder_channel.rs
@@ -131,7 +131,11 @@ impl<'r, F: Field> IOPVerifierChannel<'r, F> for IronSpartanBuilderChannel<F> {
 		&[]
 	}
 
-	fn recv_oracle(&mut self) -> Result<Self::Oracle, binius_iop::channel::Error> {
+	fn recv_oracle(
+		&mut self,
+		_log_msg_len: usize,
+		_is_witness_dependent: bool,
+	) -> Result<Self::Oracle, binius_iop::channel::Error> {
 		Ok(())
 	}
 

--- a/crates/spartan-verifier/src/wrapper/zk_wrapped_channel.rs
+++ b/crates/spartan-verifier/src/wrapper/zk_wrapped_channel.rs
@@ -111,7 +111,8 @@ where
 			"outer private/mask oracle specs must be the final suffix of channel specs"
 		);
 
-		let precommit_oracle = inner_channel.recv_oracle()?;
+		let precommit_oracle =
+			inner_channel.recv_oracle(outer_oracle_specs[0].log_msg_len, true)?;
 
 		Ok(Self {
 			inner_channel,
@@ -244,12 +245,17 @@ where
 		&all[..n_remaining_inner]
 	}
 
-	fn recv_oracle(&mut self) -> Result<Self::Oracle, binius_iop::channel::Error> {
+	fn recv_oracle(
+		&mut self,
+		log_msg_len: usize,
+		is_witness_dependent: bool,
+	) -> Result<Self::Oracle, binius_iop::channel::Error> {
 		assert!(
 			!self.remaining_oracle_specs().is_empty(),
 			"recv_oracle called but no remaining inner oracle specs"
 		);
-		self.inner_channel.recv_oracle()
+		self.inner_channel
+			.recv_oracle(log_msg_len, is_witness_dependent)
 	}
 
 	fn verify_oracle_relations(

--- a/crates/spartan-verifier/tests/proof_size_test.rs
+++ b/crates/spartan-verifier/tests/proof_size_test.rs
@@ -47,7 +47,7 @@ fn test_ip_proof_size() {
 	// SizeTrackingChannel::Oracle = (), but we still bind to exercise the real call pattern.
 	#[allow(clippy::let_unit_value)]
 	let precommit_oracle = channel
-		.recv_oracle()
+		.recv_oracle(cs.log_precommit() as usize, true)
 		.expect("recv_oracle on size-tracking channel should succeed");
 	verifier
 		.iop_verifier()

--- a/crates/verifier/src/verify.rs
+++ b/crates/verifier/src/verify.rs
@@ -7,6 +7,7 @@ use binius_hash::binary_merkle_tree::HashSuite;
 use binius_iop::{
 	basefold_compiler::BaseFoldVerifierCompiler,
 	channel::{IOPVerifierChannel, OracleLinearRelation, OracleSpec},
+	oracle_setup_channel::OracleSetupChannel,
 };
 use binius_ip::channel::IPVerifierChannel;
 use binius_math::{
@@ -97,13 +98,18 @@ impl IOPVerifier {
 	/// `is_zk` is the protocol-level zero-knowledge flag: in a ZK proof the witness oracle is
 	/// masked, in a transparent proof it is not. The flag is taken per call so that a non-ZK
 	/// oracle can still participate in a ZK protocol (e.g. indexed relation openings).
+	///
+	/// The specs are derived by running [`Self::verify`] against an [`OracleSetupChannel`], which
+	/// records each oracle received (via `recv_oracle`) without performing any real verification.
+	/// This keeps the spec sequence automatically in lockstep with the `recv_oracle` calls in
+	/// `verify`, rather than duplicating it here.
 	pub fn oracle_specs(&self, is_zk: bool) -> Vec<OracleSpec> {
-		let log_msg_len = self.log_witness_elems();
-		vec![if is_zk {
-			OracleSpec::new_zk(log_msg_len)
-		} else {
-			OracleSpec::new(log_msg_len)
-		}]
+		let mut channel = OracleSetupChannel::new(is_zk);
+		let public = vec![Word::ZERO; 1 << self.log_public_words()];
+		// The result is discarded: the setup channel performs no real verification (all `recv_*`
+		// return zero, `assert_zero` is a no-op), so we only read back the recorded oracle specs.
+		let _ = self.verify(&public, &mut channel);
+		channel.into_oracle_specs()
 	}
 
 	/// Verifies a proof using an IOP channel.
@@ -134,8 +140,9 @@ impl IOPVerifier {
 		let extended_subspace = subfield_subspace.reduce_dim(LOG_WORD_SIZE_BITS + 1);
 		let domain_subspace = extended_subspace.reduce_dim(LOG_WORD_SIZE_BITS);
 
-		// Receive the trace oracle commitment via channel.
-		let trace_oracle = channel.recv_oracle()?;
+		// Receive the trace oracle commitment via channel. The trace is the witness, so it is
+		// witness-dependent (masked in a ZK proof).
+		let trace_oracle = channel.recv_oracle(self.log_witness_elems(), true)?;
 
 		// SOUNDNESS: the IntMul reduction must run *before* the BitAnd reduction. The BitAnd
 		// reduction samples the univariate challenge `r_zhat_prime` (the `channel.sample()` in


### PR DESCRIPTION
Closes [BINIUS-179](https://linear.app/jimpo/issue/BINIUS-179).

## What

`IOPVerifier::oracle_specs` (in both Binius64 `binius-verifier` and IronSpartan `binius-spartan-verifier`) previously returned a **hardcoded** oracle-spec sequence that had to be kept in sync by hand with the actual `recv_oracle` calls in `verify`. This derives it automatically instead.

## How

- **`IOPVerifierChannel::recv_oracle`** now takes the oracle's description:
  ```rust
  fn recv_oracle(&mut self, log_msg_len: usize, is_witness_dependent: bool) -> Result<Self::Oracle, Error>;
  ```
- **New `OracleSetupChannel`** (`crates/iop/src/oracle_setup_channel.rs`) — an `IOPVerifierChannel` that performs no real verification (all `recv_*` return zero, `assert_zero` is a no-op — the same dry-run shape as the existing `SizeTrackingChannel`) and simply records an `OracleSpec { log_msg_len, is_zk: self.is_zk && is_witness_dependent }` on each `recv_oracle`.
- **`oracle_specs()`** is reimplemented to run `verify` against an `OracleSetupChannel` and read back the recorded specs. Because the oracle sequence is data-independent, the dry-run recovers it exactly, and it now stays in lockstep with `verify` automatically. (Binius64: one witness oracle. IronSpartan: the precommit oracle is received by the outer `Verifier::verify` before delegating, so `oracle_specs()` records it first, then dry-runs `verify` for the private + mask oracles.)
- The concrete channels take the new signature: `NaiveVerifierChannel` uses `log_msg_len` for its transcript read; `BaseFold`/`SizeTracking`/wrapper channels read fixed-size data and keep their pre-supplied specs (which are now the auto-derived ones), so they ignore `log_msg_len`.

The `SizeTrackingChannel` precedent (used in `proof_size_test`) already proves `verify` runs cleanly on an all-zero dry-run channel, so this reuses a known-safe pattern.

## Notes / judgment calls

- **IronSpartan mask oracle** (`lib.rs`): it's a fresh random mask rather than witness data, but it's currently committed with ZK hiding (`new_zk`). I pass `is_witness_dependent = true` to **preserve that behavior** (keeping it ZK) — flagging in case you'd prefer the mask be treated as *not* witness-dependent (which would drop its masking and change the proof). Easy to flip.
- **`binius-m4-verifier`** has its own separate `oracle_specs` (a single non-ZK oracle); the issue scopes this to Binius64 + IronSpartan, so I only updated M4's `recv_oracle` **call** to the new signature and left its `oracle_specs` hardcoded. Happy to convert it too as a follow-up if you'd like the consistency.

## Test

Build + full test suite green across `binius-iop`, `binius-iop-prover`, `binius-verifier`, `binius-spartan-verifier`, `binius-spartan-prover`, `binius-m4-verifier` — the prove/verify roundtrip tests are the real gate here (they exercise `oracle_specs()` during setup and would fail if the derived specs didn't match, since the BaseFold compiler indexes FRI params by spec). `fmt --check`, `clippy --all-targets -D warnings`, and `rustdoc -D warnings` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)