### PR TITLE
perf(circuits): use the swap_bytes gadget in rs256 byte swapping

### DIFF
--- a/crates/circuits/src/rs256.rs
+++ b/crates/circuits/src/rs256.rs
@@ -1,3 +1,4 @@
+// Copyright 2026 The Binius Developers
 // Copyright 2025 Irreducible Inc.
 use binius_frontend::{CircuitBuilder, Wire, WitnessFiller};
 use num_integer::Integer;
@@ -5,6 +6,7 @@ use num_integer::Integer;
 use super::fixed_byte_vec::ByteVec;
 use crate::{
 	bignum::{BigUint, ModReduce, assert_eq, optimal_mul, optimal_sqr},
+	bytes::swap_bytes,
 	sha256::Sha256,
 };
 
@@ -15,25 +17,12 @@ use crate::{
 fn fixedbytevec_le_to_biguint(builder: &mut CircuitBuilder, byte_vec: &ByteVec) -> BigUint {
 	// With LE packing, each wire contains 8 bytes as: byte0 | byte1<<8 | ... | byte7<<56
 	// For a BE number, we need to both reverse wire order AND byte-swap within each wire
-	let mut limbs = Vec::new();
-	// Process wires in reverse order (big-endian to little-endian conversion)
-	for packed_wire in byte_vec.data.clone().into_iter().rev() {
-		// Extract bytes from LE-packed wire and repack in reverse order
-		let mut bytes = Vec::with_capacity(8);
-		for i in 0..8 {
-			let shift_amount = i * 8;
-			let byte = builder.shr(packed_wire, shift_amount as u32);
-			let byte_masked = builder.band(byte, builder.add_constant_64(0xFF));
-			bytes.push(byte_masked);
-		}
-		// Repack bytes in reverse order (byte-swap)
-		let mut swapped_limb = bytes[7];
-		for i in 1..8 {
-			let shifted = builder.shl(bytes[7 - i], (i * 8) as u32);
-			swapped_limb = builder.bor(swapped_limb, shifted);
-		}
-		limbs.push(swapped_limb);
-	}
+	let limbs = byte_vec
+		.data
+		.iter()
+		.rev()
+		.map(|&packed_wire| swap_bytes(builder, packed_wire))
+		.collect();
 	BigUint { limbs }
 }
 

--- a/crates/examples/snapshots/zklogin.snap
+++ b/crates/examples/snapshots/zklogin.snap
@@ -1,28 +1,28 @@
 zklogin circuit
 --
 Gates & Instructions
-├─ Number of gates: 486,290
-└─ Number of evaluation instructions: 550,349
+├─ Number of gates: 485,074
+└─ Number of evaluation instructions: 549,133
 
 Constraints
-├─ AND constraints: 421,746 used (80.4% of 2^19)
-│  [▓▓▓▓▓▓▓▓░░] spare: 102,542
+├─ AND constraints: 421,170 used (80.3% of 2^19)
+│  [▓▓▓▓▓▓▓▓░░] spare: 103,118
 ├─ MUL constraints: 8,262 used (50.4% of 2^14)
 │  [▓▓▓▓▓░░░░░] spare: 8,122
-└─ Distinct value indices: 774,039
-   ├─ Distinct shifted value indices: 350,133
-   └─ Distinct unshifted value indices: 423,906
+└─ Distinct value indices: 773,015
+   ├─ Distinct shifted value indices: 349,685
+   └─ Distinct unshifted value indices: 423,330
 
 Value Vector
 ├─ Public Section: 1,038 used (50.7% of 2^11)
 │  [▓▓▓▓▓░░░░░] spare: 1,010
 │  ├─ Constants: 736
 │  └─ Inout: 302
-├─ Private Section: 422,878 used (81.0%)
-│  [▓▓▓▓▓▓▓▓░░] spare: 99,362
+├─ Private Section: 422,302 used (80.9%)
+│  [▓▓▓▓▓▓▓▓░░] spare: 99,938
 │  ├─ Witness: 1,785
-│  └─ Internal: 421,093
-├─ Total Committed: 423,916 used (80.9% of 2^19)
-│  [▓▓▓▓▓▓▓▓░░] spare: 100,372
-└─ Scratch (uncommitted): 334,393
+│  └─ Internal: 420,517
+├─ Total Committed: 423,340 used (80.7% of 2^19)
+│  [▓▓▓▓▓▓▓▓░░] spare: 100,948
+└─ Scratch (uncommitted): 333,753
 


### PR DESCRIPTION
## What

`fixedbytevec_le_to_biguint` converts a little-endian byte vector to a big-endian `BigUint`. It byte-swapped each 64-bit limb by hand: mask out one byte per lane (`band(_, 0xFF)`, 8 AND constraints per limb), shift each byte into place, and combine the lanes with `bor` (one AND constraint and one committed word each).

## Fix

Reuse the existing `binius_circuits::bytes::swap_bytes` gadget, which reverses the byte order Hacker's Delight style: 4 AND constraints per word, fewer committed intermediate words, and the lane combines are already the linear `bxor`.

## Numbers

Measured on the full RS256-2048 circuit (`test_real_rsa_signature_verification_with_message`):

| version | AND constraints | committed words |
| --- | --- | --- |
| main (manual masks + bor) | 175523 | 180115 |
| this PR (swap_bytes) | 174947 | 179539 |

576 fewer AND constraints and 576 fewer committed words per verification. The byte-swap runs once per signature limb and once per modulus limb (32 limbs each for 2048-bit RSA). The zklogin snapshot drops the same amounts.

repro: print `cs.constraint_system().and_constraints.len()` and `cs.constraint_system().value_vec_layout.committed_total_len` after `builder.build()` in the rs256 test.

## Correctness

`swap_bytes` computes the same byte reversal (property-tested in `bytes.rs` against `u64::swap_bytes`). The `rs256` tests pass, including the negative cases (a wrong message and an invalid PKCS#1 prefix are still rejected). All other example snapshots are unchanged.

## Scope

Only `fixedbytevec_le_to_biguint` and the zklogin snapshot it feeds.
