### PR TITLE
Remove the backward-compatibility protocol re-export facades

### DIFF
--- a/crates/prover/Cargo.toml
+++ b/crates/prover/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 binius-core = { path = "../core" }
 binius-field = { path = "../field" }
 binius-hash = { path = "../hash" }
+binius-ip = { path = "../ip" }
 binius-iop = { path = "../iop" }
 binius-iop-prover = { path = "../iop-prover", default-features = false }
 binius-ip-prover = { path = "../ip-prover", default-features = false }

--- a/crates/prover/benches/and_reduction.rs
+++ b/crates/prover/benches/and_reduction.rs
@@ -9,6 +9,7 @@ use binius_field::{
 		OutputWrappingTransformationFactory,
 	},
 };
+use binius_ip_prover::sumcheck::{common::SumcheckProver, quadratic_mle::QuadraticMleCheckProver};
 use binius_math::{
 	BinarySubspace,
 	univariate::{extrapolate_over_subspace, lagrange_evals_scalars},
@@ -19,7 +20,6 @@ use binius_prover::{
 		NTTLookup, sumcheck_round_messages::univariate_round_message_extension_domain,
 	},
 	fold_word::fold_words_with_transform,
-	protocols::sumcheck::{common::SumcheckProver, quadratic_mle::QuadraticMleCheckProver},
 };
 use binius_verifier::{
 	config::{B128, PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES},

--- a/crates/prover/benches/batch_quadratic_mle.rs
+++ b/crates/prover/benches/batch_quadratic_mle.rs
@@ -3,19 +3,20 @@
 use std::array;
 
 use binius_field::{Field, FieldOps, PackedField, arch::OptimalPackedB128};
+use binius_ip::mlecheck;
+use binius_ip_prover::sumcheck::{
+	Error, batch_quadratic_mle::BatchQuadraticMleCheckProver, common::MleCheckProver,
+};
 use binius_math::{
 	FieldBuffer,
 	multilinear::evaluate::evaluate_inplace,
 	test_utils::{random_field_buffer, random_scalars},
 };
-use binius_prover::protocols::sumcheck::{
-	Error, batch_quadratic_mle::BatchQuadraticMleCheckProver, common::MleCheckProver,
-};
 use binius_transcript::{
 	ProverTranscript,
 	fiat_shamir::{CanSample, Challenger},
 };
-use binius_verifier::{config::StdChallenger, protocols::mlecheck};
+use binius_verifier::config::StdChallenger;
 use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
 use rand::{SeedableRng, rngs::StdRng};
 

--- a/crates/prover/benches/fracaddcheck.rs
+++ b/crates/prover/benches/fracaddcheck.rs
@@ -1,10 +1,11 @@
 // Copyright 2025-2026 The Binius Developers
 
 use binius_field::arch::OptimalPackedB128;
+use binius_ip::prodcheck::MultilinearEvalClaim;
+use binius_ip_prover::fracaddcheck::FracAddCheckProver;
 use binius_math::{multilinear::evaluate::evaluate, test_utils::random_field_buffer};
-use binius_prover::protocols::fracaddcheck::FracAddCheckProver;
 use binius_transcript::ProverTranscript;
-use binius_verifier::{config::StdChallenger, protocols::prodcheck::MultilinearEvalClaim};
+use binius_verifier::config::StdChallenger;
 use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
 
 type P = OptimalPackedB128;

--- a/crates/prover/benches/prodcheck.rs
+++ b/crates/prover/benches/prodcheck.rs
@@ -1,10 +1,11 @@
 // Copyright 2025-2026 The Binius Developers
 
 use binius_field::arch::OptimalPackedB128;
+use binius_ip::prodcheck::MultilinearEvalClaim;
+use binius_ip_prover::prodcheck::ProdcheckProver;
 use binius_math::{multilinear::evaluate::evaluate, test_utils::random_field_buffer};
-use binius_prover::protocols::prodcheck::ProdcheckProver;
 use binius_transcript::ProverTranscript;
-use binius_verifier::{config::StdChallenger, protocols::prodcheck::MultilinearEvalClaim};
+use binius_verifier::config::StdChallenger;
 use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
 
 type P = OptimalPackedB128;

--- a/crates/prover/benches/sumcheck.rs
+++ b/crates/prover/benches/sumcheck.rs
@@ -1,13 +1,13 @@
 // Copyright 2025 Irreducible Inc.
 
 use binius_field::{arch::OptimalPackedB128, packed::PackedField};
+use binius_ip_prover::sumcheck::{
+	bivariate_product::BivariateProductSumcheckProver, prove_single, prove_single_mlecheck,
+	quadratic_mle::QuadraticMleCheckProver,
+};
 use binius_math::{
 	inner_product::inner_product_par,
 	test_utils::{random_field_buffer, random_scalars},
-};
-use binius_prover::protocols::sumcheck::{
-	bivariate_product::BivariateProductSumcheckProver, prove_single, prove_single_mlecheck,
-	quadratic_mle::QuadraticMleCheckProver,
 };
 use binius_transcript::ProverTranscript;
 use binius_utils::rayon::prelude::*;

--- a/crates/prover/src/and_reduction/prover.rs
+++ b/crates/prover/src/and_reduction/prover.rs
@@ -9,7 +9,13 @@ use binius_field::{
 		OutputWrappingTransformationFactory,
 	},
 };
-use binius_ip_prover::channel::IPProverChannel;
+use binius_ip_prover::{
+	channel::IPProverChannel,
+	sumcheck::{
+		Error, ProveSingleOutput, common::MleCheckProver, prove_single_mlecheck,
+		quadratic_mle::QuadraticMleCheckProver,
+	},
+};
 use binius_math::{
 	BinarySubspace,
 	univariate::{extrapolate_over_subspace, lagrange_evals_scalars},
@@ -20,13 +26,7 @@ use binius_verifier::{
 };
 
 use super::sumcheck_round_messages;
-use crate::{
-	fold_word::fold_words_with_transform,
-	protocols::sumcheck::{
-		Error, ProveSingleOutput, common::MleCheckProver, prove_single_mlecheck,
-		quadratic_mle::QuadraticMleCheckProver,
-	},
-};
+use crate::fold_word::fold_words_with_transform;
 
 /// Prover for the AND constraint reduction protocol via oblong univariate zerocheck.
 ///

--- a/crates/prover/src/error.rs
+++ b/crates/prover/src/error.rs
@@ -1,6 +1,9 @@
 // Copyright 2025 Irreducible Inc.
 
-use crate::protocols::{basefold, intmul, shift, sumcheck};
+use binius_iop_prover::basefold;
+use binius_ip_prover::sumcheck;
+
+use crate::protocols::{intmul, shift};
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {

--- a/crates/prover/src/protocols/inout_check.rs
+++ b/crates/prover/src/protocols/inout_check.rs
@@ -1,16 +1,15 @@
 // Copyright 2025 Irreducible Inc.
 
 use binius_field::{Field, PackedField};
-use binius_math::{
-	FieldBuffer, FieldSlice, inner_product::inner_product_buffers, line::extrapolate_line_packed,
-	multilinear::fold::fold_highest_var_inplace,
-};
-use binius_verifier::protocols::sumcheck::RoundCoeffs;
-
-use crate::protocols::sumcheck::{
+use binius_ip::sumcheck::RoundCoeffs;
+use binius_ip_prover::sumcheck::{
 	Error,
 	common::{MleCheckProver, SumcheckProver},
 	gruen32::Gruen32,
+};
+use binius_math::{
+	FieldBuffer, FieldSlice, inner_product::inner_product_buffers, line::extrapolate_line_packed,
+	multilinear::fold::fold_highest_var_inplace,
 };
 
 /// An MLE-check prover instance for the argument of public input/witness consistency.
@@ -241,6 +240,7 @@ mod tests {
 		PackedField,
 		arch::{OptimalB128, OptimalPackedB128},
 	};
+	use binius_ip_prover::sumcheck::prove_single_mlecheck;
 	use binius_math::{
 		FieldBuffer, FieldSlice,
 		multilinear::evaluate::evaluate,
@@ -251,7 +251,6 @@ mod tests {
 	use rand::{SeedableRng, prelude::StdRng};
 
 	use super::*;
-	use crate::protocols::sumcheck::prove_single_mlecheck;
 
 	#[test]
 	fn test_pubcheck_prove_verify() {

--- a/crates/prover/src/protocols/intmul/error.rs
+++ b/crates/prover/src/protocols/intmul/error.rs
@@ -1,6 +1,6 @@
 // Copyright 2025 Irreducible Inc.
 
-use crate::protocols::{prodcheck::Error as ProdcheckError, sumcheck::Error as SumcheckError};
+use binius_ip_prover::{prodcheck::Error as ProdcheckError, sumcheck::Error as SumcheckError};
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {

--- a/crates/prover/src/protocols/intmul/prove.rs
+++ b/crates/prover/src/protocols/intmul/prove.rs
@@ -4,9 +4,19 @@ use std::{iter, marker::PhantomData};
 
 use binius_core::word::Word;
 use binius_field::{BinaryField, FieldOps, PackedField};
+use binius_ip::prodcheck::MultilinearEvalClaim;
 use binius_ip_prover::{
 	channel::IPProverChannel,
-	sumcheck::{batch::batch_prove, quadratic_mle::QuadraticMleCheckProver},
+	prodcheck::{self, ProdcheckProver},
+	sumcheck::{
+		MleToSumCheckDecorator,
+		batch::{BatchSumcheckOutput, batch_prove, batch_prove_and_write_evals},
+		bivariate_product_mle,
+		bivariate_product_multi_mle::BivariateProductMultiMlecheckProver,
+		multilinear_eval::MultilinearEvalProver,
+		quadratic_mle::QuadraticMleCheckProver,
+		selector_mle::{Claim, SelectorMlecheckProver},
+	},
 };
 use binius_math::{
 	field_buffer::FieldBuffer,
@@ -17,12 +27,9 @@ use binius_math::{
 	},
 };
 use binius_utils::{checked_arithmetics::log2_ceil_usize, rayon::prelude::*};
-use binius_verifier::protocols::{
-	intmul::common::{
-		IntMulOutput, Phase1Output, Phase2Output, Phase3Output, Phase4Output, frobenius_twist,
-		normalize_a_c_exponent_evals,
-	},
-	prodcheck::MultilinearEvalClaim,
+use binius_verifier::protocols::intmul::common::{
+	IntMulOutput, Phase1Output, Phase2Output, Phase3Output, Phase4Output, frobenius_twist,
+	normalize_a_c_exponent_evals,
 };
 use either::Either;
 use itertools::{chain, izip};
@@ -31,20 +38,7 @@ use super::{
 	error::Error,
 	witness::{Witness, buffer_bivariate_product, two_valued_field_buffer},
 };
-use crate::{
-	fold_word::{fold_across_words, fold_words},
-	protocols::{
-		prodcheck::{self, ProdcheckProver},
-		sumcheck::{
-			MleToSumCheckDecorator,
-			batch::{BatchSumcheckOutput, batch_prove_and_write_evals},
-			bivariate_product_mle,
-			bivariate_product_multi_mle::BivariateProductMultiMlecheckProver,
-			multilinear_eval::MultilinearEvalProver,
-			selector_mle::{Claim, SelectorMlecheckProver},
-		},
-	},
-};
+use crate::fold_word::{fold_across_words, fold_words};
 
 /// A helper structure that encapsulates switchover settings and the prover channel for
 /// the integer multiplication protocol.

--- a/crates/prover/src/protocols/intmul/witness.rs
+++ b/crates/prover/src/protocols/intmul/witness.rs
@@ -3,6 +3,7 @@
 use std::{iter, marker::PhantomData, mem::MaybeUninit, ops::Deref};
 
 use binius_field::{BinaryField, Field, PackedField};
+use binius_ip_prover::prodcheck::ProdcheckProver;
 use binius_math::field_buffer::FieldBuffer;
 use binius_utils::{
 	bitwise::{BitSelector, Bitwise},
@@ -15,7 +16,6 @@ use getset::Getters;
 use itertools::iterate;
 
 use super::error::Error;
-use crate::protocols::prodcheck::ProdcheckProver;
 
 /// An integer multiplication protocol witness. Created from integer slices, consumed during
 /// proving.

--- a/crates/prover/src/protocols/mod.rs
+++ b/crates/prover/src/protocols/mod.rs
@@ -4,8 +4,4 @@ mod inout_check;
 pub mod intmul;
 pub mod shift;
 
-// Re-export from binius-iop-prover for backward compatibility
-pub use binius_iop_prover::basefold;
-// Re-export from binius-ip-prover for backward compatibility
-pub use binius_ip_prover::{fracaddcheck, prodcheck, sumcheck};
 pub use inout_check::InOutCheckProver;

--- a/crates/prover/src/protocols/shift/error.rs
+++ b/crates/prover/src/protocols/shift/error.rs
@@ -1,6 +1,6 @@
 // Copyright 2025 Irreducible Inc.
 
-use crate::protocols::sumcheck::Error as SumcheckError;
+use binius_ip_prover::sumcheck::Error as SumcheckError;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {

--- a/crates/prover/src/protocols/shift/phase_1.rs
+++ b/crates/prover/src/protocols/shift/phase_1.rs
@@ -4,15 +4,16 @@ use std::{iter, ops::Range};
 
 use binius_core::word::Word;
 use binius_field::{AESTowerField8b, BinaryField, Field, PackedField};
-use binius_ip_prover::channel::IPProverChannel;
+use binius_ip::sumcheck::{SumcheckOutput, common::RoundCoeffs};
+use binius_ip_prover::{
+	channel::IPProverChannel,
+	sumcheck::{bivariate_product::BivariateProductSumcheckProver, common::SumcheckProver},
+};
 use binius_math::{FieldBuffer, inner_product::inner_product_buffers};
 use binius_utils::rayon::prelude::*;
 use binius_verifier::{
 	config::{LOG_WORD_SIZE_BITS, WORD_SIZE_BITS, WORD_SIZE_BYTES},
-	protocols::{
-		shift::SHIFT_VARIANT_COUNT,
-		sumcheck::{SumcheckOutput, common::RoundCoeffs},
-	},
+	protocols::shift::SHIFT_VARIANT_COUNT,
 };
 use bytemuck::zeroed_vec;
 use itertools::izip;
@@ -23,9 +24,6 @@ use super::{
 	key_collection::{KeyCollection, Operation},
 	monster::build_h_parts,
 	prove::PreparedOperatorData,
-};
-use crate::protocols::sumcheck::{
-	bivariate_product::BivariateProductSumcheckProver, common::SumcheckProver,
 };
 
 // This is the number of variables in the g (and h) multilinears of phase 1.

--- a/crates/prover/src/protocols/shift/phase_2.rs
+++ b/crates/prover/src/protocols/shift/phase_2.rs
@@ -2,21 +2,22 @@
 
 use binius_core::word::Word;
 use binius_field::{AESTowerField8b, BinaryField, Field, PackedField};
-use binius_ip_prover::channel::IPProverChannel;
+use binius_ip::sumcheck::SumcheckOutput;
+use binius_ip_prover::{
+	channel::IPProverChannel,
+	sumcheck::{
+		ProveSingleOutput, bivariate_product::BivariateProductSumcheckProver, prove_single,
+	},
+};
 use binius_math::{FieldBuffer, multilinear::eq::eq_ind_partial_eval};
-use binius_verifier::{config::LOG_WORD_SIZE_BITS, protocols::sumcheck::SumcheckOutput};
+use binius_verifier::config::LOG_WORD_SIZE_BITS;
 use tracing::instrument;
 
 use super::{
 	error::Error, key_collection::KeyCollection, monster::build_monster_multilinear,
 	prove::PreparedOperatorData,
 };
-use crate::{
-	fold_word::fold_words,
-	protocols::sumcheck::{
-		ProveSingleOutput, bivariate_product::BivariateProductSumcheckProver, prove_single,
-	},
-};
+use crate::fold_word::fold_words;
 
 /// Proves the second phase of the shift protocol reduction.
 ///

--- a/crates/prover/src/protocols/shift/prove.rs
+++ b/crates/prover/src/protocols/shift/prove.rs
@@ -2,11 +2,11 @@
 
 use binius_core::word::Word;
 use binius_field::{AESTowerField8b, BinaryField, Field, PackedField, util::powers};
+use binius_ip::sumcheck::SumcheckOutput;
 use binius_ip_prover::channel::IPProverChannel;
 use binius_math::{
 	FieldBuffer, inner_product::inner_product, multilinear::eq::eq_ind_partial_eval,
 };
-use binius_verifier::protocols::sumcheck::SumcheckOutput;
 
 use super::{
 	error::Error, key_collection::KeyCollection, phase_1::prove_phase_1, phase_2::prove_phase_2,

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -13,6 +13,7 @@ use binius_iop_prover::{
 	basefold_channel::BaseFoldProverChannel, basefold_compiler::BaseFoldProverCompiler,
 	channel::IOPProverChannel,
 };
+use binius_ip::sumcheck::SumcheckOutput;
 use binius_math::{
 	BinarySubspace, FieldBuffer, FieldSlice,
 	inner_product::inner_product,
@@ -27,7 +28,7 @@ use binius_verifier::{
 	config::{
 		B1, B128, LOG_WORD_SIZE_BITS, LOG_WORDS_PER_ELEM, PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES,
 	},
-	protocols::{bitand::AndCheckOutput, intmul::IntMulOutput, sumcheck::SumcheckOutput},
+	protocols::{bitand::AndCheckOutput, intmul::IntMulOutput},
 };
 use digest::Output;
 use rand::{SeedableRng, rngs::StdRng};

--- a/crates/verifier/src/error.rs
+++ b/crates/verifier/src/error.rs
@@ -2,11 +2,11 @@
 
 use binius_core::ConstraintSystemError;
 use binius_iop::channel::Error as IOPChannelError;
-use binius_ip::channel::Error as ChannelError;
+use binius_ip::{channel::Error as ChannelError, sumcheck};
 
 use crate::{
 	fri,
-	protocols::{intmul, shift, sumcheck},
+	protocols::{intmul, shift},
 	ring_switch,
 };
 

--- a/crates/verifier/src/protocols/bitand.rs
+++ b/crates/verifier/src/protocols/bitand.rs
@@ -3,13 +3,10 @@
 use std::iter::{self};
 
 use binius_field::{BinaryField, field::FieldOps};
-use binius_ip::channel::IPVerifierChannel;
+use binius_ip::{channel::IPVerifierChannel, mlecheck::verify, sumcheck::SumcheckOutput};
 use binius_math::{BinarySubspace, univariate::extrapolate_over_subspace};
 
-use crate::{
-	Error,
-	protocols::{mlecheck::verify, sumcheck::SumcheckOutput},
-};
+use crate::Error;
 
 /// log2 size of the univariate domain
 pub const SKIPPED_VARS: usize = binius_core::consts::LOG_WORD_SIZE_BITS;

--- a/crates/verifier/src/protocols/intmul/error.rs
+++ b/crates/verifier/src/protocols/intmul/error.rs
@@ -1,8 +1,9 @@
 // Copyright 2025 Irreducible Inc.
 
-use binius_ip::channel::Error as ChannelError;
-
-use crate::protocols::{prodcheck::Error as ProdcheckError, sumcheck::Error as SumcheckError};
+use binius_ip::{
+	channel::Error as ChannelError, prodcheck::Error as ProdcheckError,
+	sumcheck::Error as SumcheckError,
+};
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {

--- a/crates/verifier/src/protocols/intmul/verify.rs
+++ b/crates/verifier/src/protocols/intmul/verify.rs
@@ -3,7 +3,11 @@
 use std::{iter, slice};
 
 use binius_field::{BinaryField, Field, field::FieldOps};
-use binius_ip::channel::IPVerifierChannel;
+use binius_ip::{
+	channel::IPVerifierChannel,
+	prodcheck::{self, MultilinearEvalClaim},
+	sumcheck::{BatchSumcheckOutput, batch_verify},
+};
 use binius_math::{
 	multilinear::{eq::eq_ind, evaluate::evaluate_inplace_scalars},
 	univariate::evaluate_univariate,
@@ -17,10 +21,6 @@ use super::{
 		reconstruct_selecteds,
 	},
 	error::Error,
-};
-use crate::protocols::{
-	prodcheck::{self, MultilinearEvalClaim},
-	sumcheck::{BatchSumcheckOutput, batch_verify},
 };
 
 /// Verify Phase 1: GKR step on the exponentiation product tree.

--- a/crates/verifier/src/protocols/mod.rs
+++ b/crates/verifier/src/protocols/mod.rs
@@ -4,8 +4,3 @@ pub mod bitand;
 pub mod intmul;
 pub mod pubcheck;
 pub mod shift;
-
-// Re-export from binius-iop for backward compatibility
-pub use binius_iop::basefold;
-// Re-export from binius-ip for backward compatibility
-pub use binius_ip::{fracaddcheck, mlecheck, prodcheck, sumcheck};

--- a/crates/verifier/src/protocols/pubcheck.rs
+++ b/crates/verifier/src/protocols/pubcheck.rs
@@ -2,12 +2,10 @@
 use std::iter;
 
 use binius_field::Field;
+use binius_ip::{mlecheck, sumcheck::SumcheckOutput};
 use binius_transcript::{VerifierTranscript, fiat_shamir::Challenger};
 
-use crate::{
-	error::Error,
-	protocols::{mlecheck, sumcheck::SumcheckOutput},
-};
+use crate::error::Error;
 
 /// Output of [`verify`].
 #[derive(Debug)]

--- a/crates/verifier/src/protocols/shift/error.rs
+++ b/crates/verifier/src/protocols/shift/error.rs
@@ -9,7 +9,7 @@ pub enum Error {
 	#[error("channel error")]
 	Channel(#[from] ChannelError),
 	#[error("sumcheck error")]
-	Sumcheck(#[from] crate::protocols::sumcheck::Error),
+	Sumcheck(#[from] binius_ip::sumcheck::Error),
 	#[error("verification failure")]
 	VerificationFailure,
 }

--- a/crates/verifier/src/protocols/shift/verify.rs
+++ b/crates/verifier/src/protocols/shift/verify.rs
@@ -4,7 +4,10 @@ use std::iter;
 
 use binius_core::constraint_system::{AndConstraint, ConstraintSystem, MulConstraint};
 use binius_field::{BinaryField, field::FieldOps, util::FieldFn};
-use binius_ip::channel::IPVerifierChannel;
+use binius_ip::{
+	channel::IPVerifierChannel,
+	sumcheck::{SumcheckOutput, verify as verify_sumcheck},
+};
 use binius_math::{
 	BinarySubspace,
 	multilinear::eq::eq_ind_partial_eval_scalars,
@@ -18,10 +21,7 @@ use super::{
 	BITAND_ARITY, INTMUL_ARITY, error::Error, evaluate_h_op,
 	evaluate_monster_multilinear_for_operation,
 };
-use crate::{
-	config::{LOG_WORD_SIZE_BITS, LOG_WORDS_PER_ELEM},
-	protocols::sumcheck::{SumcheckOutput, verify as verify_sumcheck},
-};
+use crate::config::{LOG_WORD_SIZE_BITS, LOG_WORDS_PER_ELEM};
 
 /// Verifier data for an operation with the specified arity.
 ///


### PR DESCRIPTION
I don't know if we wanted to keep this but this looked confusing and I've seen that the comment for backward compatibility was like 6 months old, that's why I've tried to remove the facades. If you don't like, feel free to close.


Deletes the `// backward compatibility` re-export blocks from `binius-prover` and `binius-verifier`, and points every call site at the crate the code actually lives in.

Pure refactor — imports only, no behavior change.

### The problem

The protocol implementations were split out of `binius-prover` / `binius-verifier` into dedicated crates: `binius-ip` and `binius-ip-prover` (sumcheck, prodcheck, fracaddcheck, mlecheck), `binius-iop` and `binius-iop-prover` (basefold).

But each crate's `protocols/mod.rs` kept re-export lines to preserve the old paths:

```rust
// crates/prover/src/protocols/mod.rs
// Re-export from binius-iop-prover for backward compatibility
pub use binius_iop_prover::basefold;
// Re-export from binius-ip-prover for backward compatibility
pub use binius_ip_prover::{fracaddcheck, prodcheck, sumcheck};
```

Two things made this confusing:

- These were **not** dead shims. They were the path everything used, including the crates' own `src`. So `crate::protocols::sumcheck` silently resolved into a *different* crate.
- The `for backward compatibility` label implied external callers depended on them, when in practice they were just an indirection layer over the real modules.

### The idea

Delete both facades, and at every use site name the source crate directly — exactly what the facade resolved to:

| what | prover | verifier |
|---|---|---|
| `sumcheck` / `prodcheck` / `fracaddcheck` | `binius_ip_prover` | `binius_ip` |
| `mlecheck` | — | `binius_ip` |
| `basefold` | `binius_iop_prover` | `binius_iop` |

Verifier-side data structures used *inside* the prover — `SumcheckOutput`, `RoundCoeffs`, `MultilinearEvalClaim`, `mlecheck` — come from `binius_ip` (they were previously reached via `binius_verifier::protocols::…`, which was itself the verifier's facade).

### The change

```diff
- use crate::protocols::sumcheck::{
+ use binius_ip_prover::sumcheck::{
      Error, common::{MleCheckProver, SumcheckProver}, gruen32::Gruen32,
  };
```

Several sites were nested `use crate::{ protocols::{ … } }` blocks mixing facade modules (`sumcheck`) with genuine local ones (`bitand`, `intmul`, `shift`). Those were split so the local modules stay on `crate::protocols` and only the moved ones repoint.

### Scope

- **removed:** the two `pub use … // backward compatibility` blocks in `crates/prover/src/protocols/mod.rs` and `crates/verifier/src/protocols/mod.rs`.
- **changed:** 24 call sites across both crates' `src` and `benches` (imports only).
- **added:** `binius-ip` to `binius-prover`'s `[dependencies]` — its `src` now names `binius_ip::sumcheck` directly, where before it went through the verifier's facade.
- **left untouched:** all protocol logic; the modules themselves already live in the split crates.

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-prover -p binius-verifier --all-targets` — clean
- `cargo +nightly fmt --all` — clean
- `cargo test -p binius-prover -p binius-verifier` — 32 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)