### PR TITLE
BINIUS-197: use CPU-feature cache key for Setup Rust in all CI jobs

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -1,0 +1,38 @@
+name: Setup Rust
+description: >-
+  Install the Rust toolchain and enable caching, with the cache key namespaced
+  by the runner's CPU feature set so heterogeneous GitHub-hosted runners never
+  share build artifacts.
+inputs:
+  components:
+    description: Comma-separated rustup components to install (e.g. clippy, rustfmt).
+    required: false
+    default: ""
+  target:
+    description: Additional Rust target triple to install (e.g. wasm32-wasip1).
+    required: false
+    default: ""
+runs:
+  using: composite
+  steps:
+    # GitHub-hosted x86_64 runners include both Intel (with AVX-512/GFNI) and AMD (without) SKUs.
+    # With `-Ctarget-cpu=native`, build artifacts cached on one SKU produce illegal instructions
+    # when restored on another. Hash the CPU feature set into the cache key so heterogeneous runners
+    # do not share artifacts. Jobs that build CPU-agnostic output are unaffected beyond landing in a
+    # stable per-SKU cache bucket.
+    - name: Compute CPU feature cache key
+      id: cpu
+      shell: bash
+      run: |
+        if [ -r /proc/cpuinfo ]; then
+          HASH=$(grep -m1 -E '^(flags|Features)[[:space:]]*:' /proc/cpuinfo | sha256sum | cut -c1-16)
+        else
+          HASH=portable
+        fi
+        echo "key=cpu-${HASH}" >> "$GITHUB_OUTPUT"
+    - name: Setup Rust toolchain
+      uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        components: ${{ inputs.components }}
+        target: ${{ inputs.target }}
+        cache-key: ${{ steps.cpu.outputs.key }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Check typos
         run: prek run typos --all-files
       - name: Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: ./.github/actions/setup-rust
         with:
           components: rustfmt
       - name: Install nightly toolchain for rustfmt
@@ -75,26 +75,10 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6
-      # GitHub-hosted x86_64 runners include both Intel (with AVX-512/GFNI) and
-      # AMD (without) SKUs. With `-Ctarget-cpu=native`, build artifacts cached
-      # on one SKU produce illegal instructions when restored on another.
-      # Hash the CPU feature set into the cache key so heterogeneous runners do
-      # not share artifacts. Skipped for portable builds (CPU-agnostic output).
-      - name: Compute CPU feature cache key
-        if: matrix.arch.rustflags != ''
-        id: cpu
-        run: |
-          if [ -r /proc/cpuinfo ]; then
-            HASH=$(grep -m1 -E '^(flags|Features)[[:space:]]*:' /proc/cpuinfo | sha256sum | cut -c1-16)
-          else
-            HASH=portable
-          fi
-          echo "key=cpu-${HASH}" >> "$GITHUB_OUTPUT"
       - name: Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: ./.github/actions/setup-rust
         with:
           components: clippy
-          cache-key: ${{ steps.cpu.outputs.key }}
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2
         with:
@@ -125,7 +109,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v6
       - name: Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: ./.github/actions/setup-rust
         with:
           target: wasm32-unknown-unknown
       - name: Compile vanilla wasm32
@@ -138,7 +122,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v6
       - name: Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: ./.github/actions/setup-rust
         with:
           target: wasm32-wasip1
       - name: Set up Wasmer
@@ -155,7 +139,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v6
       - name: Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: ./.github/actions/setup-rust
       - name: Build documentation (including private items for CI checks)
         run: cargo doc --document-private-items --no-deps
         env:
@@ -170,7 +154,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v6
       - name: Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: ./.github/actions/setup-rust
       # One job instead of a 9-way matrix: the examples share the same `binius-examples` crate, so
       # a matrix recompiled that whole tree (which links the prover + verifier) nine times for a
       # stats-only check. Building once and running each snapshot in turn keeps the work but cuts


### PR DESCRIPTION
Closes [BINIUS-197](https://linear.app/jimpo/issue/BINIUS-197/use-custom-cache-key-for-rust-setup-in-all-ci-jobs).

## What

Previously only the `rust-checks` job namespaced its cargo cache by the runner's CPU feature set (an inline "Compute CPU feature cache key" step feeding `cache-key` to `setup-rust-toolchain`). This extends that CPU-feature cache key to the **Setup Rust** step of *every* CI job, kept DRY.

## How

GitHub Actions has no YAML anchors, so the DRY mechanism is a **local composite action** — `.github/actions/setup-rust` — that:
1. computes the `cpu-<hash>` key from `/proc/cpuinfo` (the exact logic moved out of `rust-checks`), then
2. calls `actions-rust-lang/setup-rust-toolchain@v1` with that `cache-key`, plus pass-through `components` / `target` inputs.

Every job's `Setup Rust` step now `uses: ./.github/actions/setup-rust` (passing only its `components`/`target`), and the bespoke compute step + comment block are gone from `rust-checks`. The CPU-namespacing rationale now lives once, in the action.

## Behavior note for review

The old inline step **skipped** the CPU key for the `rust-checks` *portable* leg (`if: matrix.arch.rustflags != ''`), since portable output is CPU-agnostic and can be shared across heterogeneous SKUs. The composite action always computes the key, so the portable leg (and the wasm / doc / format / circuits-snapshot jobs) now also land in a per-SKU cache bucket. This matches the issue's "in all jobs" and keeps the action simple; the only cost is slightly reduced cache sharing for CPU-agnostic jobs (no correctness impact). Happy to reintroduce a skip input if you'd rather preserve the portable sharing.

## Validation

- Both YAML files parse; `typos` hook passes on the changed files.
- No Rust changed. The real exercise is CI running this workflow on the PR itself (all jobs now resolve the local composite action after checkout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)