### PR TITLE
Rename per-protocol error enums to distinct, self-describing names

### DIFF
--- a/crates/iop-prover/src/basefold.rs
+++ b/crates/iop-prover/src/basefold.rs
@@ -4,7 +4,9 @@
 use binius_field::{BinaryField, PackedField};
 use binius_iop::merkle_tree::MerkleTreeScheme;
 use binius_ip::mlecheck;
-use binius_ip_prover::sumcheck::{common::SumcheckProver, multilinear_eval::MultilinearEvalProver};
+use binius_ip_prover::sumcheck::{
+	SumcheckError, common::SumcheckProver, multilinear_eval::MultilinearEvalProver,
+};
 use binius_math::{FieldBuffer, ntt::AdditiveNTT};
 use binius_transcript::{
 	ProverTranscript,
@@ -18,9 +20,9 @@ use crate::{
 };
 
 #[derive(Debug, thiserror::Error)]
-pub enum Error {
+pub enum BaseFoldError {
 	#[error("sumcheck error: {0}")]
-	Sumcheck(#[from] binius_ip_prover::sumcheck::Error),
+	Sumcheck(#[from] SumcheckError),
 }
 
 /// Proves a *combined* multilinear evaluation claim `𝛑(eval_point) = eval_claim` by interleaving a
@@ -59,7 +61,7 @@ pub fn prove_mlecheck_basefold<'a, F, P, NTT, MerkleScheme, MerkleProver, Challe
 	outer_challenges: &[F],
 	mut fri_folder: FRIFoldProver<'a, F, P, NTT, MerkleProver>,
 	transcript: &mut ProverTranscript<Challenger_>,
-) -> Result<(), Error>
+) -> Result<(), BaseFoldError>
 where
 	F: BinaryField,
 	P: PackedField<Scalar = F>,

--- a/crates/iop/src/basefold.rs
+++ b/crates/iop/src/basefold.rs
@@ -23,13 +23,13 @@
 use binius_field::{BinaryField, Field};
 use binius_ip::{mlecheck, sumcheck::RoundCoeffs};
 use binius_transcript::{
-	self as transcript, VerifierTranscript,
+	TranscriptError, VerifierTranscript,
 	fiat_shamir::{CanSample, Challenger},
 };
 use binius_utils::{DeserializeBytes, checked_arithmetics::log2_ceil_usize};
 
 use crate::{
-	fri::{self, FRIFoldVerifier, FRIParams, verify::FRIQueryVerifier},
+	fri::{FRIFoldVerifier, FRIParams, FriError, FriVerificationError, verify::FRIQueryVerifier},
 	merkle_tree::MerkleTreeScheme,
 };
 
@@ -66,7 +66,7 @@ pub fn verify_mlecheck_basefold<F, MTScheme, Challenger_>(
 	batch_challenge: Option<F>,
 	outer_challenges: &[F],
 	transcript: &mut VerifierTranscript<Challenger_>,
-) -> Result<ReducedOutput<F>, Error>
+) -> Result<ReducedOutput<F>, BaseFoldError>
 where
 	F: BinaryField,
 	Challenger_: Challenger,
@@ -160,26 +160,26 @@ pub fn mlecheck_fri_consistency<F: Field>(fri_final_oracle: F, sumcheck_final_cl
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum Error {
+pub enum BaseFoldError {
 	#[error("FRI: {0}")]
-	FRI(#[source] fri::Error),
+	FRI(#[source] FriError),
 	#[error("transcript: {0}")]
-	Transcript(#[from] transcript::Error),
+	Transcript(#[from] TranscriptError),
 	#[error("verification error: {0}")]
-	Verification(#[from] VerificationError),
+	Verification(#[from] BaseFoldVerificationError),
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum VerificationError {
+pub enum BaseFoldVerificationError {
 	#[error("FRI: {0}")]
-	FRI(#[from] fri::VerificationError),
+	FRI(#[from] FriVerificationError),
 }
 
-impl From<fri::Error> for Error {
-	fn from(err: fri::Error) -> Self {
+impl From<FriError> for BaseFoldError {
+	fn from(err: FriError) -> Self {
 		match err {
-			fri::Error::Verification(err) => Error::Verification(err.into()),
-			_ => Error::FRI(err),
+			FriError::Verification(err) => BaseFoldError::Verification(err.into()),
+			_ => BaseFoldError::FRI(err),
 		}
 	}
 }

--- a/crates/iop/src/basefold_channel.rs
+++ b/crates/iop/src/basefold_channel.rs
@@ -26,7 +26,7 @@ use itertools::izip;
 
 use crate::{
 	basefold,
-	channel::{Error, IOPVerifierChannel, OracleLinearRelation, OracleSpec},
+	channel::{IOPChannelError, IOPVerifierChannel, OracleLinearRelation, OracleSpec},
 	fri::FRIParams,
 	merkle_tree::MerkleTreeScheme,
 };
@@ -107,7 +107,7 @@ where
 	/// (in oracle-index order). Because the whole opening is deferred to this point, every oracle
 	/// is committed and there is a single sumcheck point, so the precomputed combined `FRIParams`
 	/// (`optimal_for_batch` over all oracle specs) serves the opening.
-	pub fn finish(self) -> Result<(), Error> {
+	pub fn finish(self) -> Result<(), IOPChannelError> {
 		let Self {
 			transcript,
 			merkle_scheme,
@@ -164,7 +164,7 @@ fn verify_batch_zk_basefold<F, MerkleScheme_, Challenger_>(
 	fri_params: &FRIParams<F>,
 	oracle_commitments: Vec<MerkleScheme_::Digest>,
 	relations: Vec<OracleLinearRelation<'_, BaseFoldOracle, F>>,
-) -> Result<(), Error>
+) -> Result<(), IOPChannelError>
 where
 	F: BinaryField,
 	MerkleScheme_: MerkleTreeScheme<F, Digest: DeserializeBytes>,
@@ -283,25 +283,25 @@ where
 {
 	type Elem = F;
 
-	fn recv_one(&mut self) -> Result<F, binius_ip::channel::Error> {
+	fn recv_one(&mut self) -> Result<F, binius_ip::channel::IPChannelError> {
 		self.transcript
 			.message()
 			.read_scalar()
-			.map_err(|_| binius_ip::channel::Error::ProofEmpty)
+			.map_err(|_| binius_ip::channel::IPChannelError::ProofEmpty)
 	}
 
-	fn recv_many(&mut self, n: usize) -> Result<Vec<F>, binius_ip::channel::Error> {
+	fn recv_many(&mut self, n: usize) -> Result<Vec<F>, binius_ip::channel::IPChannelError> {
 		self.transcript
 			.message()
 			.read_scalar_slice(n)
-			.map_err(|_| binius_ip::channel::Error::ProofEmpty)
+			.map_err(|_| binius_ip::channel::IPChannelError::ProofEmpty)
 	}
 
-	fn recv_array<const N: usize>(&mut self) -> Result<[F; N], binius_ip::channel::Error> {
+	fn recv_array<const N: usize>(&mut self) -> Result<[F; N], binius_ip::channel::IPChannelError> {
 		self.transcript
 			.message()
 			.read()
-			.map_err(|_| binius_ip::channel::Error::ProofEmpty)
+			.map_err(|_| binius_ip::channel::IPChannelError::ProofEmpty)
 	}
 
 	fn sample(&mut self) -> F {
@@ -318,11 +318,11 @@ where
 		vals.to_vec()
 	}
 
-	fn assert_zero(&mut self, val: F) -> Result<(), binius_ip::channel::Error> {
+	fn assert_zero(&mut self, val: F) -> Result<(), binius_ip::channel::IPChannelError> {
 		if val == F::ZERO {
 			Ok(())
 		} else {
-			Err(binius_ip::channel::Error::InvalidAssert)
+			Err(binius_ip::channel::IPChannelError::InvalidAssert)
 		}
 	}
 
@@ -348,7 +348,7 @@ where
 		&mut self,
 		_log_msg_len: usize,
 		_is_witness_dependent: bool,
-	) -> Result<Self::Oracle, Error> {
+	) -> Result<Self::Oracle, IOPChannelError> {
 		// A BaseFold commitment is a fixed-size Merkle digest, so `log_msg_len` is not needed here;
 		// the per-oracle specs (used for the FRI opening) are supplied at channel construction.
 		assert!(
@@ -362,7 +362,7 @@ where
 			.transcript
 			.message()
 			.read::<MerkleScheme_::Digest>()
-			.map_err(|_| Error::ProofEmpty)?;
+			.map_err(|_| IOPChannelError::ProofEmpty)?;
 
 		self.oracle_commitments.push(commitment);
 		self.next_oracle_index += 1;
@@ -373,7 +373,7 @@ where
 	fn verify_oracle_relations(
 		&mut self,
 		oracle_relations: impl IntoIterator<Item = OracleLinearRelation<'a, Self::Oracle, Self::Elem>>,
-	) -> Result<(), Error> {
+	) -> Result<(), IOPChannelError> {
 		// Queue the relations; the actual opening (masking + sumcheck + combined FRI) happens once,
 		// over all committed oracles, in [`Self::finish`].
 		for relation in oracle_relations {

--- a/crates/iop/src/channel.rs
+++ b/crates/iop/src/channel.rs
@@ -15,21 +15,24 @@
 //! communication and commitment mechanisms.
 
 use binius_field::Field;
-use binius_ip::channel::IPVerifierChannel;
+use binius_ip::{
+	channel::{IPChannelError, IPVerifierChannel},
+	sumcheck::SumcheckError,
+};
 
-use crate::basefold;
+use crate::basefold::BaseFoldError;
 
-/// Error type for IOP verifier channel operations.
+/// IOPChannelError type for IOP verifier channel operations.
 #[derive(Debug, thiserror::Error)]
-pub enum Error {
+pub enum IOPChannelError {
 	#[error("proof is empty")]
 	ProofEmpty,
 	#[error("BaseFold verification failed: {0}")]
-	BaseFold(#[from] basefold::Error),
+	BaseFold(#[from] BaseFoldError),
 	#[error("IP channel error: {0}")]
-	IPChannel(#[from] binius_ip::channel::Error),
+	IPChannel(#[from] IPChannelError),
 	#[error("sumcheck error: {0}")]
-	Sumcheck(#[from] binius_ip::sumcheck::Error),
+	Sumcheck(#[from] SumcheckError),
 }
 
 /// Specification for an oracle to be committed in the IOP.
@@ -117,7 +120,7 @@ pub trait IOPVerifierChannel<'r, F: Field>: IPVerifierChannel<F> {
 		&mut self,
 		log_msg_len: usize,
 		is_witness_dependent: bool,
-	) -> Result<Self::Oracle, Error>;
+	) -> Result<Self::Oracle, IOPChannelError>;
 
 	/// Queues oracle linear relations to be opened.
 	///
@@ -135,5 +138,5 @@ pub trait IOPVerifierChannel<'r, F: Field>: IPVerifierChannel<F> {
 	fn verify_oracle_relations(
 		&mut self,
 		oracle_relations: impl IntoIterator<Item = OracleLinearRelation<'r, Self::Oracle, Self::Elem>>,
-	) -> Result<(), Error>;
+	) -> Result<(), IOPChannelError>;
 }

--- a/crates/iop/src/fri/batch.rs
+++ b/crates/iop/src/fri/batch.rs
@@ -2,11 +2,11 @@
 
 use binius_field::BinaryField;
 use binius_math::{line::extrapolate_line, multilinear, ntt::DomainContext};
-use binius_transcript::TranscriptReader;
+use binius_transcript::{TranscriptError, TranscriptReader};
 use binius_utils::{DeserializeBytes, FixedSizeSerializeBytes};
 use bytes::Buf;
 
-use crate::merkle_tree::{Commitment, MerkleTreeScheme};
+use crate::merkle_tree::{Commitment, MerkleTreeError, MerkleTreeScheme};
 /// A virtual oracle for a code proximity test.
 ///
 /// The interactive code proximity tests used in this project (eg. FRI) commit to a codeword and
@@ -37,7 +37,7 @@ pub trait ProxTestOracle<F: BinaryField> {
 		&self,
 		indices: &[usize],
 		advice: &mut TranscriptReader<B>,
-	) -> Result<Vec<F>, Error>;
+	) -> Result<Vec<F>, BatchFriError>;
 }
 
 /// A [ProxTestOracle] implementation for a [Brakedown]-style interleaved code proximity check.
@@ -91,7 +91,7 @@ impl<F: BinaryField, MTScheme: MerkleTreeScheme<F, Digest: DeserializeBytes>> Pr
 		&self,
 		indices: &[usize],
 		advice: &mut TranscriptReader<B>,
-	) -> Result<Vec<F>, Error> {
+	) -> Result<Vec<F>, BatchFriError> {
 		assert!(indices.iter().all(|&index| index < 1 << self.log_len())); // precondition
 		// Translate each query on the virtual lifted oracle into a query on the committed codeword
 		// by dropping the low `log_lift` bits (the duplicated copies).
@@ -161,7 +161,7 @@ impl<F: BinaryField, MTScheme: MerkleTreeScheme<F, Digest: DeserializeBytes>> Pr
 		&self,
 		indices: &[usize],
 		advice: &mut TranscriptReader<B>,
-	) -> Result<Vec<F>, Error> {
+	) -> Result<Vec<F>, BatchFriError> {
 		// Read each bundled oracle's openings in commit order (matching the prover), then combine
 		// across oracles by the outer-challenge tensor expansion:
 		// combined[q] = \sum_i values_i[q] * outer_tensor[i].
@@ -303,7 +303,7 @@ where
 		indices: &[usize],
 		claims: &[F],
 		advice: &mut TranscriptReader<B>,
-	) -> Result<Vec<F>, Error> {
+	) -> Result<Vec<F>, BatchFriError> {
 		assert_eq!(indices.len(), claims.len()); // precondition
 		assert!(
 			indices
@@ -330,7 +330,7 @@ where
 			let (coset_index, values) = opening?;
 			// Verify the claimed base-codeword value against the opened coset.
 			if values[index & coset_mask] != claim {
-				return Err(Error::ClaimMismatch { index });
+				return Err(BatchFriError::ClaimMismatch { index });
 			}
 			Ok(self.fold_coset(coset_index, values))
 		})
@@ -352,7 +352,7 @@ where
 		&self,
 		indices: &[usize],
 		advice: &mut TranscriptReader<B>,
-	) -> Result<Vec<F>, Error> {
+	) -> Result<Vec<F>, BatchFriError> {
 		assert!(indices.iter().all(|&index| index < 1 << self.log_len())); // precondition
 		verify_query_openings(
 			&self.merkle_scheme,
@@ -381,7 +381,7 @@ fn verify_query_openings<'a, F, MTScheme, B>(
 	coset_log_size: usize,
 	indices: &'a [usize],
 	advice: &'a mut TranscriptReader<B>,
-) -> Result<impl Iterator<Item = Result<(usize, Vec<F>), Error>> + 'a, Error>
+) -> Result<impl Iterator<Item = Result<(usize, Vec<F>), BatchFriError>> + 'a, BatchFriError>
 where
 	F: BinaryField,
 	MTScheme: MerkleTreeScheme<F, Digest: DeserializeBytes>,
@@ -410,11 +410,11 @@ where
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum Error {
+pub enum BatchFriError {
 	#[error("claimed value at index {index} does not match the committed codeword")]
 	ClaimMismatch { index: usize },
 	#[error("Merkle tree error: {0}")]
-	Merkle(#[from] crate::merkle_tree::Error),
+	Merkle(#[from] MerkleTreeError),
 	#[error("transcript error: {0}")]
-	Transcript(#[from] binius_transcript::Error),
+	Transcript(#[from] TranscriptError),
 }

--- a/crates/iop/src/fri/error.rs
+++ b/crates/iop/src/fri/error.rs
@@ -1,33 +1,35 @@
 // Copyright 2024-2025 Irreducible Inc.
 
-use super::batch;
-use crate::merkle_tree;
+use binius_transcript::TranscriptError;
+
+use super::batch::BatchFriError;
+use crate::merkle_tree::{MerkleTreeError, MerkleTreeVerificationError};
 
 #[derive(Debug, thiserror::Error)]
-pub enum Error {
+pub enum FriError {
 	#[error("Merkle tree error: {0}")]
-	MerkleError(merkle_tree::Error),
+	MerkleError(MerkleTreeError),
 	#[error("Reed-Solomon encoding error: {0}")]
-	Verification(#[from] VerificationError),
+	Verification(#[from] FriVerificationError),
 	#[error("transcript error: {0}")]
-	TranscriptError(#[from] binius_transcript::Error),
+	TranscriptError(#[from] TranscriptError),
 }
 
-impl From<merkle_tree::Error> for Error {
-	fn from(err: merkle_tree::Error) -> Self {
+impl From<MerkleTreeError> for FriError {
+	fn from(err: MerkleTreeError) -> Self {
 		match err {
-			merkle_tree::Error::Verification(err) => Self::Verification(err.into()),
+			MerkleTreeError::Verification(err) => Self::Verification(err.into()),
 			_ => Self::MerkleError(err),
 		}
 	}
 }
 
-impl From<batch::Error> for Error {
-	fn from(err: batch::Error) -> Self {
+impl From<BatchFriError> for FriError {
+	fn from(err: BatchFriError) -> Self {
 		match err {
-			batch::Error::Merkle(err) => err.into(),
-			batch::Error::Transcript(err) => Self::TranscriptError(err),
-			batch::Error::ClaimMismatch { index } => VerificationError::IncorrectFold {
+			BatchFriError::Merkle(err) => err.into(),
+			BatchFriError::Transcript(err) => Self::TranscriptError(err),
+			BatchFriError::ClaimMismatch { index } => FriVerificationError::IncorrectFold {
 				query_round: 0,
 				index,
 			}
@@ -37,7 +39,7 @@ impl From<batch::Error> for Error {
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum VerificationError {
+pub enum FriVerificationError {
 	#[error("incorrect codeword folding in query round {query_round} at index {index}")]
 	IncorrectFold { query_round: usize, index: usize },
 	#[error("the size of the query proof is incorrect, expected {expected}")]
@@ -49,5 +51,5 @@ pub enum VerificationError {
 	#[error("The dimension-1 codeword must contain the same values")]
 	IncorrectDegree,
 	#[error("Merkle tree error: {0}")]
-	MerkleError(#[from] merkle_tree::VerificationError),
+	MerkleError(#[from] MerkleTreeVerificationError),
 }

--- a/crates/iop/src/fri/fold.rs
+++ b/crates/iop/src/fri/fold.rs
@@ -10,7 +10,7 @@ use binius_transcript::TranscriptReader;
 use binius_utils::DeserializeBytes;
 use bytes::Buf;
 
-use super::{FRIParams, error::Error};
+use super::{FRIParams, error::FriError};
 
 /// Calculate fold of `values` at `index` with `r` random coefficient.
 ///
@@ -187,7 +187,7 @@ where
 	pub fn process_round<B: Buf>(
 		&mut self,
 		transcript: &mut TranscriptReader<B>,
-	) -> Result<Option<Digest>, Error> {
+	) -> Result<Option<Digest>, FriError> {
 		assert!(
 			self.curr_round < self.n_rounds(),
 			"precondition: process_round must not be called more than n_rounds() times"

--- a/crates/iop/src/fri/verify.rs
+++ b/crates/iop/src/fri/verify.rs
@@ -15,7 +15,7 @@ use bytes::Buf;
 use super::{
 	batch::{BatchBrakedownOracle, BrakedownOracle, FRIOracle, ProxTestOracle, fold_coset},
 	common::FRIParams,
-	error::{Error, VerificationError},
+	error::{FriError, FriVerificationError},
 };
 use crate::merkle_tree::{Commitment, MerkleTreeScheme};
 
@@ -208,7 +208,7 @@ where
 	pub fn verify<Challenger_>(
 		&self,
 		transcript: &mut VerifierTranscript<Challenger_>,
-	) -> Result<F, Error>
+	) -> Result<F, FriError>
 	where
 		Challenger_: Challenger,
 	{
@@ -230,10 +230,10 @@ where
 			claims = oracle
 				.reduce_queries(&indices, &claims, &mut advice)
 				.map_err(|err| match err {
-					super::batch::Error::ClaimMismatch { index } => {
-						VerificationError::IncorrectFold { query_round, index }.into()
+					super::batch::BatchFriError::ClaimMismatch { index } => {
+						FriVerificationError::IncorrectFold { query_round, index }.into()
 					}
-					err => Error::from(err),
+					err => FriError::from(err),
 				})?;
 			for index in &mut indices {
 				*index >>= arity;
@@ -255,14 +255,14 @@ where
 		claims: &[F],
 		indices: &[usize],
 		advice: &mut TranscriptReader<B>,
-	) -> Result<F, Error> {
+	) -> Result<F, FriError> {
 		let n_final_challenges = self.params.n_final_challenges();
 		let log_inv_rate = self.params.rs_code().log_inv_rate();
 		let terminate_codeword_len = 1 << (n_final_challenges + log_inv_rate);
 
 		let terminate_codeword = advice
 			.read_scalar_slice::<F>(terminate_codeword_len)
-			.map_err(Error::TranscriptError)?;
+			.map_err(FriError::TranscriptError)?;
 		self.vcs.verify_vector(
 			self.terminal_commitment,
 			&terminate_codeword,
@@ -273,7 +273,7 @@ where
 		// Check the fully-reduced claims against the terminal codeword the verifier holds in full.
 		for (&claim, &index) in iter::zip(claims, indices) {
 			if claim != terminate_codeword[index] {
-				return Err(VerificationError::IncorrectFold {
+				return Err(FriVerificationError::IncorrectFold {
 					query_round: self.n_oracles() - 1,
 					index,
 				}
@@ -307,7 +307,7 @@ where
 			.iter()
 			.any(|&entry| entry != final_value)
 		{
-			return Err(VerificationError::IncorrectDegree.into());
+			return Err(FriVerificationError::IncorrectDegree.into());
 		}
 
 		Ok(final_value)

--- a/crates/iop/src/merkle_tree/error.rs
+++ b/crates/iop/src/merkle_tree/error.rs
@@ -1,20 +1,21 @@
 // Copyright 2024-2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
+use binius_transcript::TranscriptError;
 use binius_utils::SerializationError;
 
 #[derive(Debug, thiserror::Error)]
-pub enum Error {
+pub enum MerkleTreeError {
 	#[error("Failed to serialize leaf element: {0}")]
 	Serialization(SerializationError),
 	#[error("transcript error: {0}")]
-	Transcript(#[from] binius_transcript::Error),
+	Transcript(#[from] TranscriptError),
 	#[error("verification failure: {0}")]
-	Verification(#[from] VerificationError),
+	Verification(#[from] MerkleTreeVerificationError),
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum VerificationError {
+pub enum MerkleTreeVerificationError {
 	#[error("the proof is invalid")]
 	InvalidProof,
 }

--- a/crates/iop/src/merkle_tree/merkle_tree_vcs.rs
+++ b/crates/iop/src/merkle_tree/merkle_tree_vcs.rs
@@ -4,7 +4,7 @@ use auto_impl::auto_impl;
 use binius_transcript::{Buf, TranscriptReader};
 use binius_utils::FixedSizeSerializeBytes;
 
-use super::error::Error;
+use super::error::MerkleTreeError;
 
 /// A Merkle tree commitment.
 ///
@@ -52,7 +52,7 @@ pub trait MerkleTreeScheme<T: FixedSizeSerializeBytes> {
 		data: &[T],
 		batch_size: usize,
 		proof: &mut TranscriptReader<B>,
-	) -> Result<(), Error>;
+	) -> Result<(), MerkleTreeError>;
 
 	/// Verify a given layer of the Merkle tree.
 	///
@@ -68,7 +68,7 @@ pub trait MerkleTreeScheme<T: FixedSizeSerializeBytes> {
 		root: &Self::Digest,
 		layer_depth: usize,
 		layer_digests: &[Self::Digest],
-	) -> Result<(), Error>;
+	) -> Result<(), MerkleTreeError>;
 
 	/// Verify an opening proof for an entry in a committed vector at the given index.
 	///
@@ -84,5 +84,5 @@ pub trait MerkleTreeScheme<T: FixedSizeSerializeBytes> {
 		tree_depth: usize,
 		layer_digests: &[Self::Digest],
 		proof: &mut TranscriptReader<B>,
-	) -> Result<(), Error>;
+	) -> Result<(), MerkleTreeError>;
 }

--- a/crates/iop/src/merkle_tree/scheme.rs
+++ b/crates/iop/src/merkle_tree/scheme.rs
@@ -13,7 +13,7 @@ use digest::{Digest, Output};
 use getset::CopyGetters;
 
 use super::{
-	error::{Error, VerificationError},
+	error::{MerkleTreeError, MerkleTreeVerificationError},
 	merkle_tree_vcs::MerkleTreeScheme,
 };
 
@@ -57,9 +57,10 @@ where
 		&self,
 		values: &[T],
 		proof: &mut TranscriptReader<B>,
-	) -> Result<Output<H::LeafHash>, Error> {
+	) -> Result<Output<H::LeafHash>, MerkleTreeError> {
 		let salt = proof.read_vec::<T>(self.salt_len)?;
-		hash_serialize::<T, H::LeafHash>(values.iter().chain(&salt)).map_err(Error::Serialization)
+		hash_serialize::<T, H::LeafHash>(values.iter().chain(&salt))
+			.map_err(MerkleTreeError::Serialization)
 	}
 }
 
@@ -95,7 +96,7 @@ where
 		data: &[T],
 		batch_size: usize,
 		proof: &mut TranscriptReader<B>,
-	) -> Result<(), Error> {
+	) -> Result<(), MerkleTreeError> {
 		assert!(
 			data.len().is_multiple_of(batch_size),
 			"precondition: data length must be a multiple of batch_size"
@@ -107,7 +108,7 @@ where
 			.collect::<Result<Vec<_>, _>>()?;
 
 		if fold_digests_vector_inplace(&self.compression, digests) != *root {
-			return Err(VerificationError::InvalidProof.into());
+			return Err(MerkleTreeVerificationError::InvalidProof.into());
 		}
 		Ok(())
 	}
@@ -117,7 +118,7 @@ where
 		root: &Self::Digest,
 		layer_depth: usize,
 		layer_digests: &[Self::Digest],
-	) -> Result<(), Error> {
+	) -> Result<(), MerkleTreeError> {
 		assert_eq!(
 			layer_digests.len(),
 			1 << layer_depth,
@@ -126,7 +127,7 @@ where
 
 		let computed_root = fold_digests_vector_inplace(&self.compression, layer_digests.to_vec());
 		if computed_root != *root {
-			return Err(VerificationError::InvalidProof.into());
+			return Err(MerkleTreeVerificationError::InvalidProof.into());
 		}
 		Ok(())
 	}
@@ -139,7 +140,7 @@ where
 		tree_depth: usize,
 		layer_digests: &[Self::Digest],
 		proof: &mut TranscriptReader<B>,
-	) -> Result<(), Error> {
+	) -> Result<(), MerkleTreeError> {
 		assert_eq!(
 			layer_digests.len(),
 			1 << layer_depth,
@@ -159,7 +160,7 @@ where
 
 		(leaf_digest == layer_digests[index])
 			.then_some(())
-			.ok_or_else(|| VerificationError::InvalidProof.into())
+			.ok_or_else(|| MerkleTreeVerificationError::InvalidProof.into())
 	}
 }
 

--- a/crates/iop/src/naive_channel.rs
+++ b/crates/iop/src/naive_channel.rs
@@ -14,7 +14,7 @@ use binius_transcript::{
 	fiat_shamir::{CanSample, Challenger},
 };
 
-use crate::channel::{Error, IOPVerifierChannel, OracleLinearRelation, OracleSpec};
+use crate::channel::{IOPChannelError, IOPVerifierChannel, OracleLinearRelation, OracleSpec};
 
 /// Oracle handle returned by [`NaiveVerifierChannel::recv_oracle`].
 #[derive(Debug, Clone, Copy)]
@@ -91,25 +91,25 @@ where
 {
 	type Elem = F;
 
-	fn recv_one(&mut self) -> Result<F, binius_ip::channel::Error> {
+	fn recv_one(&mut self) -> Result<F, binius_ip::channel::IPChannelError> {
 		self.transcript
 			.message()
 			.read_scalar()
-			.map_err(|_| binius_ip::channel::Error::ProofEmpty)
+			.map_err(|_| binius_ip::channel::IPChannelError::ProofEmpty)
 	}
 
-	fn recv_many(&mut self, n: usize) -> Result<Vec<F>, binius_ip::channel::Error> {
+	fn recv_many(&mut self, n: usize) -> Result<Vec<F>, binius_ip::channel::IPChannelError> {
 		self.transcript
 			.message()
 			.read_scalar_slice(n)
-			.map_err(|_| binius_ip::channel::Error::ProofEmpty)
+			.map_err(|_| binius_ip::channel::IPChannelError::ProofEmpty)
 	}
 
-	fn recv_array<const N: usize>(&mut self) -> Result<[F; N], binius_ip::channel::Error> {
+	fn recv_array<const N: usize>(&mut self) -> Result<[F; N], binius_ip::channel::IPChannelError> {
 		self.transcript
 			.message()
 			.read()
-			.map_err(|_| binius_ip::channel::Error::ProofEmpty)
+			.map_err(|_| binius_ip::channel::IPChannelError::ProofEmpty)
 	}
 
 	fn sample(&mut self) -> F {
@@ -126,11 +126,11 @@ where
 		vals.to_vec()
 	}
 
-	fn assert_zero(&mut self, val: F) -> Result<(), binius_ip::channel::Error> {
+	fn assert_zero(&mut self, val: F) -> Result<(), binius_ip::channel::IPChannelError> {
 		if val == F::ZERO {
 			Ok(())
 		} else {
-			Err(binius_ip::channel::Error::InvalidAssert)
+			Err(binius_ip::channel::IPChannelError::InvalidAssert)
 		}
 	}
 
@@ -154,7 +154,7 @@ where
 		&mut self,
 		log_msg_len: usize,
 		_is_witness_dependent: bool,
-	) -> Result<Self::Oracle, Error> {
+	) -> Result<Self::Oracle, IOPChannelError> {
 		assert!(
 			!self.remaining_oracle_specs().is_empty(),
 			"recv_oracle called but no remaining oracle specs"
@@ -170,7 +170,7 @@ where
 			.transcript
 			.message()
 			.read_scalar_slice(buffer_len)
-			.map_err(|_| Error::ProofEmpty)?;
+			.map_err(|_| IOPChannelError::ProofEmpty)?;
 
 		self.stored_polynomials
 			.push(FieldBuffer::from_values(&values));
@@ -182,7 +182,7 @@ where
 	fn verify_oracle_relations(
 		&mut self,
 		oracle_relations: impl IntoIterator<Item = OracleLinearRelation<'r, Self::Oracle, F>>,
-	) -> Result<(), Error> {
+	) -> Result<(), IOPChannelError> {
 		for relation in oracle_relations {
 			let index = relation.oracle.index;
 			assert!(index < self.stored_polynomials.len(), "oracle index {index} out of bounds");
@@ -197,7 +197,7 @@ where
 				.transcript
 				.message()
 				.read_scalar_slice(transparent_len)
-				.map_err(|_| Error::ProofEmpty)?;
+				.map_err(|_| IOPChannelError::ProofEmpty)?;
 			let transparent_poly = FieldBuffer::from_values(&transparent_values);
 
 			// Verify the inner product claim directly

--- a/crates/iop/src/oracle_setup_channel.rs
+++ b/crates/iop/src/oracle_setup_channel.rs
@@ -22,7 +22,7 @@ use binius_field::{
 };
 use binius_ip::channel::IPVerifierChannel;
 
-use crate::channel::{Error, IOPVerifierChannel, OracleLinearRelation, OracleSpec};
+use crate::channel::{IOPChannelError, IOPVerifierChannel, OracleLinearRelation, OracleSpec};
 
 /// A zero-sized dummy field element for [`OracleSetupChannel`].
 ///
@@ -170,15 +170,20 @@ impl OracleSetupChannel {
 impl<F: Field> IPVerifierChannel<F> for OracleSetupChannel {
 	type Elem = DummyElem;
 
-	fn recv_one(&mut self) -> Result<DummyElem, binius_ip::channel::Error> {
+	fn recv_one(&mut self) -> Result<DummyElem, binius_ip::channel::IPChannelError> {
 		Ok(DummyElem)
 	}
 
-	fn recv_many(&mut self, n: usize) -> Result<Vec<DummyElem>, binius_ip::channel::Error> {
+	fn recv_many(
+		&mut self,
+		n: usize,
+	) -> Result<Vec<DummyElem>, binius_ip::channel::IPChannelError> {
 		Ok(vec![DummyElem; n])
 	}
 
-	fn recv_array<const N: usize>(&mut self) -> Result<[DummyElem; N], binius_ip::channel::Error> {
+	fn recv_array<const N: usize>(
+		&mut self,
+	) -> Result<[DummyElem; N], binius_ip::channel::IPChannelError> {
 		Ok([DummyElem; N])
 	}
 
@@ -194,7 +199,7 @@ impl<F: Field> IPVerifierChannel<F> for OracleSetupChannel {
 		vec![DummyElem; vals.len()]
 	}
 
-	fn assert_zero(&mut self, _val: DummyElem) -> Result<(), binius_ip::channel::Error> {
+	fn assert_zero(&mut self, _val: DummyElem) -> Result<(), binius_ip::channel::IPChannelError> {
 		Ok(())
 	}
 
@@ -217,7 +222,7 @@ impl<'r, F: Field> IOPVerifierChannel<'r, F> for OracleSetupChannel {
 		&mut self,
 		log_msg_len: usize,
 		is_witness_dependent: bool,
-	) -> Result<Self::Oracle, Error> {
+	) -> Result<Self::Oracle, IOPChannelError> {
 		self.oracle_specs.push(OracleSpec {
 			log_msg_len,
 			is_zk: self.is_zk && is_witness_dependent,
@@ -228,7 +233,7 @@ impl<'r, F: Field> IOPVerifierChannel<'r, F> for OracleSetupChannel {
 	fn verify_oracle_relations(
 		&mut self,
 		_oracle_relations: impl IntoIterator<Item = OracleLinearRelation<'r, Self::Oracle, Self::Elem>>,
-	) -> Result<(), Error> {
+	) -> Result<(), IOPChannelError> {
 		Ok(())
 	}
 }

--- a/crates/iop/src/size_tracking_channel.rs
+++ b/crates/iop/src/size_tracking_channel.rs
@@ -9,7 +9,7 @@ use binius_field::{BinaryField, util::FieldFn};
 use binius_ip::channel::IPVerifierChannel;
 
 use crate::{
-	channel::{Error, IOPVerifierChannel, OracleLinearRelation, OracleSpec},
+	channel::{IOPChannelError, IOPVerifierChannel, OracleLinearRelation, OracleSpec},
 	fri::{self, FRIParams},
 	merkle_tree::MerkleTreeScheme,
 };
@@ -85,17 +85,17 @@ impl<F: BinaryField, MerkleScheme_: MerkleTreeScheme<F>> IPVerifierChannel<F>
 {
 	type Elem = F;
 
-	fn recv_one(&mut self) -> Result<F, binius_ip::channel::Error> {
+	fn recv_one(&mut self) -> Result<F, binius_ip::channel::IPChannelError> {
 		self.proof_size += self.element_size;
 		Ok(F::ZERO)
 	}
 
-	fn recv_many(&mut self, n: usize) -> Result<Vec<F>, binius_ip::channel::Error> {
+	fn recv_many(&mut self, n: usize) -> Result<Vec<F>, binius_ip::channel::IPChannelError> {
 		self.proof_size += n * self.element_size;
 		Ok(vec![F::ZERO; n])
 	}
 
-	fn recv_array<const N: usize>(&mut self) -> Result<[F; N], binius_ip::channel::Error> {
+	fn recv_array<const N: usize>(&mut self) -> Result<[F; N], binius_ip::channel::IPChannelError> {
 		self.proof_size += N * self.element_size;
 		Ok([F::ZERO; N])
 	}
@@ -112,7 +112,7 @@ impl<F: BinaryField, MerkleScheme_: MerkleTreeScheme<F>> IPVerifierChannel<F>
 		vec![F::ZERO; vals.len()]
 	}
 
-	fn assert_zero(&mut self, _val: F) -> Result<(), binius_ip::channel::Error> {
+	fn assert_zero(&mut self, _val: F) -> Result<(), binius_ip::channel::IPChannelError> {
 		Ok(())
 	}
 
@@ -134,7 +134,7 @@ impl<'r, F: BinaryField, MerkleScheme_: MerkleTreeScheme<F>> IOPVerifierChannel<
 		&mut self,
 		_log_msg_len: usize,
 		_is_witness_dependent: bool,
-	) -> Result<Self::Oracle, Error> {
+	) -> Result<Self::Oracle, IOPChannelError> {
 		self.proof_size += self.oracle_size;
 		self.next_oracle_index += 1;
 		Ok(())
@@ -143,7 +143,7 @@ impl<'r, F: BinaryField, MerkleScheme_: MerkleTreeScheme<F>> IOPVerifierChannel<
 	fn verify_oracle_relations(
 		&mut self,
 		_oracle_relations: impl IntoIterator<Item = OracleLinearRelation<'r, Self::Oracle, Self::Elem>>,
-	) -> Result<(), Error> {
+	) -> Result<(), IOPChannelError> {
 		// Add FRI proof sizes for all oracles. This accounts for the dominant component of
 		// BaseFold proofs (FRI decommitments) but is missing smaller elements (e.g. sumcheck
 		// coefficients within BaseFold, blinding elements for ZK), so it's a slight

--- a/crates/ip-prover/src/fracaddcheck.rs
+++ b/crates/ip-prover/src/fracaddcheck.rs
@@ -8,7 +8,7 @@ use binius_utils::rayon::iter::{IntoParallelIterator, ParallelIterator};
 use crate::{
 	channel::IPProverChannel,
 	sumcheck::{
-		Error as SumcheckError,
+		SumcheckError,
 		batch::batch_prove_mle_and_write_evals,
 		common::MleCheckProver,
 		frac_add_mle::{self, FractionalBuffer},
@@ -25,7 +25,7 @@ pub struct FracAddCheckProver<P: PackedField> {
 }
 
 #[derive(thiserror::Error, Debug)]
-pub enum Error {
+pub enum FracAddCheckError {
 	#[error(
 		"mismatched numerator/denominator lengths: numerator log_len {num_log_len}, denominator log_len {den_log_len}"
 	)]
@@ -100,7 +100,7 @@ where
 	pub fn layer_prover(
 		mut self,
 		claim: (MultilinearEvalClaim<F>, MultilinearEvalClaim<F>),
-	) -> Result<(impl MleCheckProver<F>, Option<Self>), Error> {
+	) -> Result<(impl MleCheckProver<F>, Option<Self>), FracAddCheckError> {
 		let (num_claim, den_claim) = claim;
 		assert_eq!(
 			num_claim.point, den_claim.point,
@@ -146,7 +146,7 @@ where
 		self,
 		claim: (MultilinearEvalClaim<F>, MultilinearEvalClaim<F>),
 		channel: &mut impl IPProverChannel<F>,
-	) -> Result<(MultilinearEvalClaim<F>, MultilinearEvalClaim<F>), Error> {
+	) -> Result<(MultilinearEvalClaim<F>, MultilinearEvalClaim<F>), FracAddCheckError> {
 		let mut prover_opt = Some(self);
 		let mut claim = claim;
 

--- a/crates/ip-prover/src/prodcheck.rs
+++ b/crates/ip-prover/src/prodcheck.rs
@@ -13,14 +13,14 @@ use itertools::izip;
 use crate::{
 	channel::IPProverChannel,
 	sumcheck::{
-		Error as SumcheckError, ProveSingleOutput, bivariate_product_mle,
+		ProveSingleOutput, SumcheckError, bivariate_product_mle,
 		common::{MleCheckProver, SumcheckProver},
 		prove_single_mlecheck,
 	},
 };
 
 #[derive(thiserror::Error, Debug)]
-pub enum Error {
+pub enum ProdcheckError {
 	#[error("sumcheck error: {0}")]
 	Sumcheck(#[from] SumcheckError),
 }
@@ -99,7 +99,7 @@ where
 	pub fn layer_prover(
 		mut self,
 		claim: MultilinearEvalClaim<F>,
-	) -> Result<(impl MleCheckProver<F>, Option<Self>), Error> {
+	) -> Result<(impl MleCheckProver<F>, Option<Self>), ProdcheckError> {
 		let layer = self.layers.pop().expect("layers is non-empty");
 		let split = layer.split_half();
 
@@ -129,7 +129,7 @@ where
 		self,
 		claim: MultilinearEvalClaim<F>,
 		channel: &mut impl IPProverChannel<F>,
-	) -> Result<MultilinearEvalClaim<F>, Error> {
+	) -> Result<MultilinearEvalClaim<F>, ProdcheckError> {
 		let mut prover_opt = Some(self);
 		let mut claim = claim;
 
@@ -236,7 +236,7 @@ pub fn batch_prove<F: Field, P: PackedField<Scalar = F>>(
 	selector_point: Vec<F>,
 	content_point: Vec<F>,
 	channel: &mut impl IPProverChannel<F>,
-) -> Result<BatchProveOutput<P>, Error> {
+) -> Result<BatchProveOutput<P>, ProdcheckError> {
 	assert!(!provers.is_empty()); // precondition
 	assert_eq!(claimed_products.len(), provers.len()); // precondition
 
@@ -277,7 +277,7 @@ fn batch_prove_layer<F: Field, P: PackedField<Scalar = F>>(
 	eval_point: Vec<F>,
 	k: usize,
 	channel: &mut impl IPProverChannel<F>,
-) -> Result<(Vec<ProdcheckProver<P>>, Vec<F>, Vec<F>), Error> {
+) -> Result<(Vec<ProdcheckProver<P>>, Vec<F>, Vec<F>), ProdcheckError> {
 	// Split eval_point into outer (selector) and inner (content) coordinates.
 	let (outer_coords, inner_coords) = eval_point.split_at(k);
 

--- a/crates/ip-prover/src/sumcheck/batch.rs
+++ b/crates/ip-prover/src/sumcheck/batch.rs
@@ -7,7 +7,7 @@ use crate::{
 	channel::IPProverChannel,
 	sumcheck::{
 		common::{MleCheckProver, SumcheckProver},
-		error::Error,
+		error::SumcheckError,
 	},
 };
 
@@ -43,7 +43,7 @@ pub struct BatchSumcheckOutput<F: Field> {
 pub fn batch_prove<F, Prover>(
 	mut provers: Vec<Prover>,
 	channel: &mut impl IPProverChannel<F>,
-) -> Result<BatchSumcheckOutput<F>, Error>
+) -> Result<BatchSumcheckOutput<F>, SumcheckError>
 where
 	F: Field,
 	Prover: SumcheckProver<F>,
@@ -58,7 +58,7 @@ where
 	let n_vars = first_prover.n_vars();
 
 	if provers.iter().any(|prover| prover.n_vars() != n_vars) {
-		return Err(Error::ProverRoundCountMismatch);
+		return Err(SumcheckError::ProverRoundCountMismatch);
 	}
 
 	// Random linear-combination coefficient for batching multiple sum claims.
@@ -126,7 +126,7 @@ where
 pub fn batch_prove_and_write_evals<F, Prover>(
 	provers: Vec<Prover>,
 	channel: &mut impl IPProverChannel<F>,
-) -> Result<BatchSumcheckOutput<F>, Error>
+) -> Result<BatchSumcheckOutput<F>, SumcheckError>
 where
 	F: Field,
 	Prover: SumcheckProver<F>,
@@ -148,7 +148,7 @@ where
 pub fn batch_prove_mle<F, MleCheckProver_>(
 	mut provers: Vec<MleCheckProver_>,
 	channel: &mut impl IPProverChannel<F>,
-) -> Result<BatchSumcheckOutput<F>, Error>
+) -> Result<BatchSumcheckOutput<F>, SumcheckError>
 where
 	F: Field,
 	MleCheckProver_: MleCheckProver<F>,
@@ -164,7 +164,7 @@ where
 	let eval_point = first_prover.eval_point();
 
 	if provers.iter().any(|prover| prover.n_vars() != n_vars) {
-		return Err(Error::ProverRoundCountMismatch);
+		return Err(SumcheckError::ProverRoundCountMismatch);
 	}
 
 	if provers
@@ -172,7 +172,7 @@ where
 		.any(|prover| prover.eval_point() != eval_point)
 	{
 		// All MLE-check provers must share the same evaluation point to batch safely.
-		return Err(Error::EvalPointLengthMismatch);
+		return Err(SumcheckError::EvalPointLengthMismatch);
 	}
 	// Random linear-combination coefficient for batching multiple eval claims.
 	let batch_coeff = channel.sample();
@@ -224,7 +224,7 @@ where
 pub fn batch_prove_mle_and_write_evals<F, MleCheckProver_>(
 	provers: Vec<MleCheckProver_>,
 	channel: &mut impl IPProverChannel<F>,
-) -> Result<BatchSumcheckOutput<F>, Error>
+) -> Result<BatchSumcheckOutput<F>, SumcheckError>
 where
 	F: Field,
 	MleCheckProver_: MleCheckProver<F>,
@@ -256,7 +256,7 @@ mod tests {
 	type StdChallenger = HasherChallenger<sha2::Sha256>;
 	use rand::prelude::*;
 
-	use super::{Error, batch_prove_mle};
+	use super::{SumcheckError, batch_prove_mle};
 	use crate::sumcheck::bivariate_product_mle;
 
 	fn product_eval_claim<F, P>(
@@ -404,7 +404,7 @@ mod tests {
 		let mut transcript = ProverTranscript::new(StdChallenger::default());
 		let err = batch_prove_mle(vec![prover_0, prover_1], &mut transcript).unwrap_err();
 		assert!(
-			matches!(err, Error::EvalPointLengthMismatch),
+			matches!(err, SumcheckError::EvalPointLengthMismatch),
 			"Expected eval point mismatch error"
 		);
 	}
@@ -443,7 +443,7 @@ mod tests {
 		let mut transcript = ProverTranscript::new(StdChallenger::default());
 		let err = batch_prove_mle(vec![prover_0, prover_1], &mut transcript).unwrap_err();
 		assert!(
-			matches!(err, Error::ProverRoundCountMismatch),
+			matches!(err, SumcheckError::ProverRoundCountMismatch),
 			"Expected prover round count mismatch error"
 		);
 	}

--- a/crates/ip-prover/src/sumcheck/batch_quadratic_mle.rs
+++ b/crates/ip-prover/src/sumcheck/batch_quadratic_mle.rs
@@ -11,7 +11,7 @@ use binius_utils::rayon::prelude::*;
 use itertools::{Itertools, izip};
 
 use crate::sumcheck::{
-	Error,
+	SumcheckError,
 	common::{MleCheckProver, SumcheckProver},
 	gruen32::Gruen32,
 	round_evals::RoundEvals2,
@@ -56,13 +56,13 @@ where
 		infinity_composition: InfinityComposition,
 		eval_point: Vec<F>,
 		eval_claims: [F; M],
-	) -> Result<Self, Error> {
+	) -> Result<Self, SumcheckError> {
 		let n_vars = eval_point.len();
 		assert!(N > 0 && M > 0);
 		for multilinear in &multilinears.as_slices_mut() {
 			// All multilinears must agree on the number of variables for consistent folding.
 			if multilinear.log_len() != n_vars {
-				return Err(Error::MultilinearSizeMismatch);
+				return Err(SumcheckError::MultilinearSizeMismatch);
 			}
 		}
 
@@ -123,11 +123,11 @@ where
 		}
 	}
 
-	fn execute(&mut self) -> Result<Vec<RoundCoeffs<F>>, Error> {
+	fn execute(&mut self) -> Result<Vec<RoundCoeffs<F>>, SumcheckError> {
 		// State machine: execute consumes evals from the previous round and produces new coeffs.
 		let last_eval = match &self.last_coeffs_or_eval {
 			RoundCoeffsOrEvals::Evals(evals) => *evals,
-			RoundCoeffsOrEvals::Coeffs(_) => return Err(Error::ExpectedFold),
+			RoundCoeffsOrEvals::Coeffs(_) => return Err(SumcheckError::ExpectedFold),
 		};
 
 		// There must be at least one variable left to sum over in this round.
@@ -175,53 +175,56 @@ where
 		};
 		let packed_prime_evals = (0..chunk_count)
 			.into_par_iter()
-			.try_fold(zero_wide_acc, |mut packed_prime_evals, chunk_index| -> Result<_, Error> {
-				let eq_chunk = eq_expansion.chunk(chunk_vars, chunk_index);
+			.try_fold(
+				zero_wide_acc,
+				|mut packed_prime_evals, chunk_index| -> Result<_, SumcheckError> {
+					let eq_chunk = eq_expansion.chunk(chunk_vars, chunk_index);
 
-				// Scratch buffers are reused per row to avoid allocations in the hot loop.
-				let [mut y_1_scratch, mut y_inf_scratch] = [[P::default(); M]; 2];
-				let splits_0_chunk = splits_0
-					.iter()
-					.map(|slice| slice.chunk(chunk_vars, chunk_index))
-					.collect::<Vec<_>>();
-				let splits_1_chunk = splits_1
-					.iter()
-					.map(|slice| slice.chunk(chunk_vars, chunk_index))
-					.collect::<Vec<_>>();
+					// Scratch buffers are reused per row to avoid allocations in the hot loop.
+					let [mut y_1_scratch, mut y_inf_scratch] = [[P::default(); M]; 2];
+					let splits_0_chunk = splits_0
+						.iter()
+						.map(|slice| slice.chunk(chunk_vars, chunk_index))
+						.collect::<Vec<_>>();
+					let splits_1_chunk = splits_1
+						.iter()
+						.map(|slice| slice.chunk(chunk_vars, chunk_index))
+						.collect::<Vec<_>>();
 
-				// Accumulate packed evals for this chunk; first index is y_1/y_inf.
-				let [y_1, y_inf] = &mut packed_prime_evals;
-				for (idx, &eq_i) in eq_chunk.as_ref().iter().enumerate() {
-					// Gather the idx-th evaluations of every multilinear at both halves.
-					let mut evals_1 = [P::default(); N];
-					let mut evals_inf = [P::default(); N];
+					// Accumulate packed evals for this chunk; first index is y_1/y_inf.
+					let [y_1, y_inf] = &mut packed_prime_evals;
+					for (idx, &eq_i) in eq_chunk.as_ref().iter().enumerate() {
+						// Gather the idx-th evaluations of every multilinear at both halves.
+						let mut evals_1 = [P::default(); N];
+						let mut evals_inf = [P::default(); N];
 
-					for i in 0..N {
-						let lo_i = splits_0_chunk[i].as_ref()[idx];
-						let hi_i = splits_1_chunk[i].as_ref()[idx];
+						for i in 0..N {
+							let lo_i = splits_0_chunk[i].as_ref()[idx];
+							let hi_i = splits_1_chunk[i].as_ref()[idx];
 
-						// Compose once with the high half and once with the lo+hi combination.
-						// The lo+hi branch corresponds to evaluation at infinity for
-						// multilinears.
-						evals_1[i] = hi_i;
-						evals_inf[i] = lo_i + hi_i;
+							// Compose once with the high half and once with the lo+hi combination.
+							// The lo+hi branch corresponds to evaluation at infinity for
+							// multilinears.
+							evals_1[i] = hi_i;
+							evals_inf[i] = lo_i + hi_i;
+						}
+
+						// Apply the compositions for this equality term.
+						comp(evals_1, &mut y_1_scratch);
+						inf_comp(evals_inf, &mut y_inf_scratch);
+
+						for i in 0..M {
+							// Weight by eq indicator to keep the sumcheck claim aligned to
+							// eval_point. Only this final multiply is widened; the composition
+							// products in the scratch buffers are already reduced.
+							y_1[i] += P::wide_mul(y_1_scratch[i], eq_i);
+							y_inf[i] += P::wide_mul(y_inf_scratch[i], eq_i);
+						}
 					}
 
-					// Apply the compositions for this equality term.
-					comp(evals_1, &mut y_1_scratch);
-					inf_comp(evals_inf, &mut y_inf_scratch);
-
-					for i in 0..M {
-						// Weight by eq indicator to keep the sumcheck claim aligned to
-						// eval_point. Only this final multiply is widened; the composition
-						// products in the scratch buffers are already reduced.
-						y_1[i] += P::wide_mul(y_1_scratch[i], eq_i);
-						y_inf[i] += P::wide_mul(y_inf_scratch[i], eq_i);
-					}
-				}
-
-				Ok(packed_prime_evals)
-			})
+					Ok(packed_prime_evals)
+				},
+			)
 			.try_reduce(zero_wide_acc, |mut lhs, mut rhs| {
 				for claim_idx in 0..M {
 					lhs[0][claim_idx] += std::mem::take(&mut rhs[0][claim_idx]);
@@ -255,10 +258,10 @@ where
 		Ok(round_coeffs)
 	}
 
-	fn fold(&mut self, challenge: F) -> Result<(), Error> {
+	fn fold(&mut self, challenge: F) -> Result<(), SumcheckError> {
 		// State machine: fold consumes coeffs and produces evals at the verifier challenge.
 		let RoundCoeffsOrEvals::Coeffs(prime_coeffs) = &self.last_coeffs_or_eval else {
-			return Err(Error::ExpectedExecute);
+			return Err(SumcheckError::ExpectedExecute);
 		};
 
 		// n_vars is decremented in fold, so we must have at least one variable left here.
@@ -290,12 +293,12 @@ where
 		Ok(())
 	}
 
-	fn finish(mut self) -> Result<Vec<F>, Error> {
+	fn finish(mut self) -> Result<Vec<F>, SumcheckError> {
 		// Finish is only valid after all folds complete (i.e., zero variables remain).
 		if self.n_vars() > 0 {
 			let error = match self.last_coeffs_or_eval {
-				RoundCoeffsOrEvals::Coeffs(_) => Error::ExpectedFold,
-				RoundCoeffsOrEvals::Evals(_) => Error::ExpectedExecute,
+				RoundCoeffsOrEvals::Coeffs(_) => SumcheckError::ExpectedFold,
+				RoundCoeffsOrEvals::Evals(_) => SumcheckError::ExpectedExecute,
 			};
 
 			return Err(error);

--- a/crates/ip-prover/src/sumcheck/bivariate_product.rs
+++ b/crates/ip-prover/src/sumcheck/bivariate_product.rs
@@ -6,7 +6,7 @@ use binius_ip::sumcheck::RoundCoeffs;
 use binius_math::{FieldBuffer, multilinear::fold::fold_highest_var_inplace};
 use binius_utils::rayon::prelude::*;
 
-use crate::sumcheck::{common::SumcheckProver, error::Error, round_evals::WideRoundEvals2};
+use crate::sumcheck::{common::SumcheckProver, error::SumcheckError, round_evals::WideRoundEvals2};
 
 /// A [`SumcheckProver`] implementation for a composite defined as the product of two multilinears.
 ///
@@ -24,9 +24,9 @@ pub struct BivariateProductSumcheckProver<P: PackedField> {
 impl<F: Field, P: PackedField<Scalar = F>> BivariateProductSumcheckProver<P> {
 	/// Constructs a prover, given the multilinear polynomial evaluations and the sum over the
 	/// boolean hypercube of their product.
-	pub fn new(multilinears: [FieldBuffer<P>; 2], sum: F) -> Result<Self, Error> {
+	pub fn new(multilinears: [FieldBuffer<P>; 2], sum: F) -> Result<Self, SumcheckError> {
 		if multilinears[0].log_len() != multilinears[1].log_len() {
-			return Err(Error::MultilinearSizeMismatch);
+			return Err(SumcheckError::MultilinearSizeMismatch);
 		}
 
 		Ok(Self {
@@ -53,9 +53,9 @@ impl<F: Field, P: PackedField<Scalar = F>> SumcheckProver<F> for BivariateProduc
 		vec![claim]
 	}
 
-	fn execute(&mut self) -> Result<Vec<RoundCoeffs<F>>, Error> {
+	fn execute(&mut self) -> Result<Vec<RoundCoeffs<F>>, SumcheckError> {
 		let RoundCoeffsOrSum::Sum(last_sum) = &self.last_coeffs_or_sum else {
-			return Err(Error::ExpectedFold);
+			return Err(SumcheckError::ExpectedFold);
 		};
 
 		// Multilinear inputs are the same length by invariant
@@ -94,9 +94,9 @@ impl<F: Field, P: PackedField<Scalar = F>> SumcheckProver<F> for BivariateProduc
 		Ok(vec![round_coeffs])
 	}
 
-	fn fold(&mut self, challenge: F) -> Result<(), Error> {
+	fn fold(&mut self, challenge: F) -> Result<(), SumcheckError> {
 		let RoundCoeffsOrSum::Coeffs(last_coeffs) = self.last_coeffs_or_sum.clone() else {
-			return Err(Error::ExpectedExecute);
+			return Err(SumcheckError::ExpectedExecute);
 		};
 
 		for multilin in &mut self.multilinears {
@@ -108,11 +108,11 @@ impl<F: Field, P: PackedField<Scalar = F>> SumcheckProver<F> for BivariateProduc
 		Ok(())
 	}
 
-	fn finish(self) -> Result<Vec<F>, Error> {
+	fn finish(self) -> Result<Vec<F>, SumcheckError> {
 		if self.n_vars() > 0 {
 			let error = match self.last_coeffs_or_sum {
-				RoundCoeffsOrSum::Coeffs(_) => Error::ExpectedFold,
-				RoundCoeffsOrSum::Sum(_) => Error::ExpectedExecute,
+				RoundCoeffsOrSum::Coeffs(_) => SumcheckError::ExpectedFold,
+				RoundCoeffsOrSum::Sum(_) => SumcheckError::ExpectedExecute,
 			};
 			return Err(error);
 		}

--- a/crates/ip-prover/src/sumcheck/bivariate_product_mle.rs
+++ b/crates/ip-prover/src/sumcheck/bivariate_product_mle.rs
@@ -3,7 +3,7 @@
 use binius_field::{Field, PackedField};
 use binius_math::AsSlicesMut;
 
-use super::{error::Error, quadratic_mle::QuadraticMleCheckProver};
+use super::{error::SumcheckError, quadratic_mle::QuadraticMleCheckProver};
 use crate::sumcheck::common::MleCheckProver;
 
 /// Creates an [`MleCheckProver`] that reduces an evaluation claim on a multilinear extension
@@ -53,7 +53,7 @@ pub fn new<F, P>(
 	multilinears: impl AsSlicesMut<P, 2> + Send + 'static,
 	eval_point: Vec<F>,
 	eval_claim: F,
-) -> Result<impl MleCheckProver<F>, Error>
+) -> Result<impl MleCheckProver<F>, SumcheckError>
 where
 	F: Field,
 	P: PackedField<Scalar = F>,

--- a/crates/ip-prover/src/sumcheck/bivariate_product_multi_mle.rs
+++ b/crates/ip-prover/src/sumcheck/bivariate_product_multi_mle.rs
@@ -9,7 +9,9 @@ use binius_math::{FieldBuffer, multilinear::fold::fold_highest_var_inplace};
 use binius_utils::rayon::prelude::*;
 use itertools::{Itertools, izip};
 
-use super::{common::SumcheckProver, error::Error, gruen32::Gruen32, round_evals::WideRoundEvals2};
+use super::{
+	common::SumcheckProver, error::SumcheckError, gruen32::Gruen32, round_evals::WideRoundEvals2,
+};
 use crate::sumcheck::common::MleCheckProver;
 
 /// Multiple claim version of `BivariateProductMlecheckProver` that can prove mlechecks
@@ -27,7 +29,7 @@ impl<F: Field, P: PackedField<Scalar = F>> BivariateProductMultiMlecheckProver<P
 		multilinears: Vec<[FieldBuffer<P>; 2]>,
 		eval_point: &[F],
 		eval_claims: Vec<F>,
-	) -> Result<Self, Error> {
+	) -> Result<Self, SumcheckError> {
 		let n_vars = eval_point.len();
 
 		if multilinears
@@ -35,11 +37,11 @@ impl<F: Field, P: PackedField<Scalar = F>> BivariateProductMultiMlecheckProver<P
 			.flatten()
 			.any(|multilinear| multilinear.log_len() != n_vars)
 		{
-			return Err(Error::MultilinearSizeMismatch);
+			return Err(SumcheckError::MultilinearSizeMismatch);
 		}
 
 		if multilinears.len() != eval_claims.len() {
-			return Err(Error::EvalClaimsNumberMismatch);
+			return Err(SumcheckError::EvalClaimsNumberMismatch);
 		}
 
 		let multilinears = multilinears.into_iter().flatten().collect_vec();
@@ -84,9 +86,9 @@ where
 		}
 	}
 
-	fn execute(&mut self) -> Result<Vec<RoundCoeffs<F>>, Error> {
+	fn execute(&mut self) -> Result<Vec<RoundCoeffs<F>>, SumcheckError> {
 		let RoundCoeffsOrSums::Sums(sums) = &self.last_coeffs_or_sums else {
-			return Err(Error::ExpectedFold);
+			return Err(SumcheckError::ExpectedFold);
 		};
 
 		assert!(self.n_vars() > 0);
@@ -156,9 +158,9 @@ where
 		Ok(round_coeffs)
 	}
 
-	fn fold(&mut self, challenge: F) -> Result<(), Error> {
+	fn fold(&mut self, challenge: F) -> Result<(), SumcheckError> {
 		let RoundCoeffsOrSums::Coeffs(prime_coeffs) = &self.last_coeffs_or_sums else {
-			return Err(Error::ExpectedExecute);
+			return Err(SumcheckError::ExpectedExecute);
 		};
 
 		assert!(self.n_vars() > 0);
@@ -177,11 +179,11 @@ where
 		Ok(())
 	}
 
-	fn finish(self) -> Result<Vec<F>, Error> {
+	fn finish(self) -> Result<Vec<F>, SumcheckError> {
 		if self.n_vars() > 0 {
 			let error = match self.last_coeffs_or_sums {
-				RoundCoeffsOrSums::Coeffs(_) => Error::ExpectedFold,
-				RoundCoeffsOrSums::Sums(_) => Error::ExpectedExecute,
+				RoundCoeffsOrSums::Coeffs(_) => SumcheckError::ExpectedFold,
+				RoundCoeffsOrSums::Sums(_) => SumcheckError::ExpectedExecute,
 			};
 
 			return Err(error);

--- a/crates/ip-prover/src/sumcheck/common.rs
+++ b/crates/ip-prover/src/sumcheck/common.rs
@@ -4,7 +4,7 @@ use binius_field::Field;
 use binius_ip::sumcheck::RoundCoeffs;
 use either::Either;
 
-use super::error::Error;
+use super::error::SumcheckError;
 
 /// A sumcheck prover with a round-by-round execution interface.
 ///
@@ -52,7 +52,7 @@ pub trait SumcheckProver<F: Field> {
 	/// the highest indexed one) and hypercube sums are performed over the lower indexed variables.
 	///
 	/// The returned Vec must have length equal to [`Self::n_claims`].
-	fn execute(&mut self) -> Result<Vec<RoundCoeffs<F>>, Error>;
+	fn execute(&mut self) -> Result<Vec<RoundCoeffs<F>>, SumcheckError>;
 
 	/// Returns the claimed sums for the current round, one per claim.
 	///
@@ -69,11 +69,11 @@ pub trait SumcheckProver<F: Field> {
 	fn round_claim(&self) -> Vec<F>;
 
 	/// Folds the sumcheck multilinears with a new verifier challenge.
-	fn fold(&mut self, challenge: F) -> Result<(), Error>;
+	fn fold(&mut self, challenge: F) -> Result<(), SumcheckError>;
 
 	/// Finishes the sumcheck proving protocol and returns the evaluations of all multilinears at
 	/// the challenge point.
-	fn finish(self) -> Result<Vec<F>, Error>;
+	fn finish(self) -> Result<Vec<F>, SumcheckError>;
 }
 
 impl<F, L, R> SumcheckProver<F> for Either<L, R>
@@ -90,7 +90,7 @@ where
 		either::for_both!(self, inner => inner.n_claims())
 	}
 
-	fn execute(&mut self) -> Result<Vec<RoundCoeffs<F>>, Error> {
+	fn execute(&mut self) -> Result<Vec<RoundCoeffs<F>>, SumcheckError> {
 		either::for_both!(self, inner => inner.execute())
 	}
 
@@ -98,11 +98,11 @@ where
 		either::for_both!(self, inner => inner.round_claim())
 	}
 
-	fn fold(&mut self, challenge: F) -> Result<(), Error> {
+	fn fold(&mut self, challenge: F) -> Result<(), SumcheckError> {
 		either::for_both!(self, inner => inner.fold(challenge))
 	}
 
-	fn finish(self) -> Result<Vec<F>, Error> {
+	fn finish(self) -> Result<Vec<F>, SumcheckError> {
 		either::for_both!(self, inner => inner.finish())
 	}
 }

--- a/crates/ip-prover/src/sumcheck/error.rs
+++ b/crates/ip-prover/src/sumcheck/error.rs
@@ -1,8 +1,8 @@
 // Copyright 2025 Irreducible Inc.
 
 #[derive(thiserror::Error, Debug)]
-pub enum Error {
-	/// Error indicating invalid arguments were passed to a sumcheck function.
+pub enum SumcheckError {
+	/// SumcheckError indicating invalid arguments were passed to a sumcheck function.
 	#[error("invalid arguments: {0}")]
 	ArgumentError(String),
 	#[error("multilinears do not have equal number of variables")]

--- a/crates/ip-prover/src/sumcheck/frac_add_mle.rs
+++ b/crates/ip-prover/src/sumcheck/frac_add_mle.rs
@@ -3,7 +3,7 @@
 use binius_field::{Field, PackedField};
 use binius_math::FieldBuffer;
 
-use super::error::Error;
+use super::error::SumcheckError;
 use crate::sumcheck::{batch_quadratic_mle::BatchQuadraticMleCheckProver, common::MleCheckProver};
 
 pub type FractionalBuffer<P> = (FieldBuffer<P>, FieldBuffer<P>);
@@ -14,7 +14,7 @@ pub fn new<F, P>(
 	fraction: [FieldBuffer<P>; 4],
 	eval_point: Vec<F>,
 	eval_claims: [F; 2],
-) -> Result<impl MleCheckProver<F>, Error>
+) -> Result<impl MleCheckProver<F>, SumcheckError>
 where
 	F: Field,
 	P: PackedField<Scalar = F>,

--- a/crates/ip-prover/src/sumcheck/mle_to_sumcheck.rs
+++ b/crates/ip-prover/src/sumcheck/mle_to_sumcheck.rs
@@ -4,7 +4,7 @@ use binius_ip::sumcheck::RoundCoeffs;
 use binius_math::multilinear::eq::eq_one_var;
 
 use crate::sumcheck::{
-	Error,
+	SumcheckError,
 	common::{MleCheckProver, SumcheckProver},
 	round_evals::round_coeffs_by_eq,
 };
@@ -62,7 +62,7 @@ impl<F: Field, InnerProver: MleCheckProver<F>> SumcheckProver<F>
 			.collect()
 	}
 
-	fn execute(&mut self) -> Result<Vec<RoundCoeffs<F>>, Error> {
+	fn execute(&mut self) -> Result<Vec<RoundCoeffs<F>>, SumcheckError> {
 		let round_coeffs_multi = self.mlecheck_prover.execute()?;
 
 		// Multiply the round polynomials from the inner MLE-check prover by (X - α).
@@ -75,9 +75,9 @@ impl<F: Field, InnerProver: MleCheckProver<F>> SumcheckProver<F>
 		Ok(wrapped_round_coeffs)
 	}
 
-	fn fold(&mut self, challenge: F) -> Result<(), Error> {
+	fn fold(&mut self, challenge: F) -> Result<(), SumcheckError> {
 		if self.n_vars() == 0 {
-			return Err(Error::ExpectedFinish);
+			return Err(SumcheckError::ExpectedFinish);
 		}
 
 		let alpha = self.mlecheck_prover.eval_point()[self.n_vars() - 1];
@@ -86,7 +86,7 @@ impl<F: Field, InnerProver: MleCheckProver<F>> SumcheckProver<F>
 		self.mlecheck_prover.fold(challenge)
 	}
 
-	fn finish(self) -> Result<Vec<F>, Error> {
+	fn finish(self) -> Result<Vec<F>, SumcheckError> {
 		self.mlecheck_prover.finish()
 	}
 }

--- a/crates/ip-prover/src/sumcheck/multilinear_eval.rs
+++ b/crates/ip-prover/src/sumcheck/multilinear_eval.rs
@@ -8,7 +8,7 @@ use binius_utils::rayon::prelude::*;
 
 use super::{
 	common::{MleCheckProver, SumcheckProver},
-	error::Error,
+	error::SumcheckError,
 	gruen32::Gruen32,
 	round_evals::RoundEvals1,
 };
@@ -38,11 +38,15 @@ impl<F: Field, P: PackedField<Scalar = F>> MultilinearEvalProver<P> {
 	/// Constructs a prover for the multilinear `witness`, given the evaluation point `eval_point`
 	/// and the claimed evaluation `eval_claim` of the multilinear extension at that point.
 	///
-	/// Returns [`Error::MultilinearSizeMismatch`] if the witness length does not match the
+	/// Returns [`SumcheckError::MultilinearSizeMismatch`] if the witness length does not match the
 	/// evaluation point length.
-	pub fn new(witness: FieldBuffer<P>, eval_point: &[F], eval_claim: F) -> Result<Self, Error> {
+	pub fn new(
+		witness: FieldBuffer<P>,
+		eval_point: &[F],
+		eval_claim: F,
+	) -> Result<Self, SumcheckError> {
 		if witness.log_len() != eval_point.len() {
-			return Err(Error::MultilinearSizeMismatch);
+			return Err(SumcheckError::MultilinearSizeMismatch);
 		}
 
 		Ok(Self {
@@ -72,9 +76,9 @@ impl<F: Field, P: PackedField<Scalar = F>> SumcheckProver<F> for MultilinearEval
 		vec![claim]
 	}
 
-	fn execute(&mut self) -> Result<Vec<RoundCoeffs<F>>, Error> {
+	fn execute(&mut self) -> Result<Vec<RoundCoeffs<F>>, SumcheckError> {
 		let RoundCoeffsOrSum::Sum(sum) = &self.last_coeffs_or_sum else {
-			return Err(Error::ExpectedFold);
+			return Err(SumcheckError::ExpectedFold);
 		};
 		let sum = *sum;
 
@@ -106,9 +110,9 @@ impl<F: Field, P: PackedField<Scalar = F>> SumcheckProver<F> for MultilinearEval
 		Ok(vec![round_coeffs])
 	}
 
-	fn fold(&mut self, challenge: F) -> Result<(), Error> {
+	fn fold(&mut self, challenge: F) -> Result<(), SumcheckError> {
 		let RoundCoeffsOrSum::Coeffs(coeffs) = &self.last_coeffs_or_sum else {
-			return Err(Error::ExpectedExecute);
+			return Err(SumcheckError::ExpectedExecute);
 		};
 
 		assert!(self.n_vars() > 0);
@@ -122,11 +126,11 @@ impl<F: Field, P: PackedField<Scalar = F>> SumcheckProver<F> for MultilinearEval
 		Ok(())
 	}
 
-	fn finish(self) -> Result<Vec<F>, Error> {
+	fn finish(self) -> Result<Vec<F>, SumcheckError> {
 		if self.n_vars() > 0 {
 			let error = match self.last_coeffs_or_sum {
-				RoundCoeffsOrSum::Coeffs(_) => Error::ExpectedFold,
-				RoundCoeffsOrSum::Sum(_) => Error::ExpectedExecute,
+				RoundCoeffsOrSum::Coeffs(_) => SumcheckError::ExpectedFold,
+				RoundCoeffsOrSum::Sum(_) => SumcheckError::ExpectedExecute,
 			};
 			return Err(error);
 		}

--- a/crates/ip-prover/src/sumcheck/padded.rs
+++ b/crates/ip-prover/src/sumcheck/padded.rs
@@ -3,7 +3,7 @@ use binius_field::Field;
 use binius_ip::sumcheck::RoundCoeffs;
 use binius_math::multilinear::eq::eq_one_var;
 
-use crate::sumcheck::{Error, common::SumcheckProver};
+use crate::sumcheck::{SumcheckError, common::SumcheckProver};
 
 /// Decorator that pads the number of variables of an inner [`SumcheckProver`].
 ///
@@ -77,7 +77,7 @@ impl<F: Field, Inner: SumcheckProver<F>> SumcheckProver<F> for PaddedSumcheckDec
 			.collect()
 	}
 
-	fn execute(&mut self) -> Result<Vec<RoundCoeffs<F>>, Error> {
+	fn execute(&mut self) -> Result<Vec<RoundCoeffs<F>>, SumcheckError> {
 		if self.in_padding_phase() {
 			// R_i(X) = (s * eq_prefix) * eq(0, X), with eq(0, X) = 1 - X. The inner prover is not
 			// touched during padding rounds.
@@ -98,7 +98,7 @@ impl<F: Field, Inner: SumcheckProver<F>> SumcheckProver<F> for PaddedSumcheckDec
 		}
 	}
 
-	fn fold(&mut self, challenge: F) -> Result<(), Error> {
+	fn fold(&mut self, challenge: F) -> Result<(), SumcheckError> {
 		if self.in_padding_phase() {
 			// eq(0, challenge) = 1 - challenge.
 			self.eq_prefix *= eq_one_var(F::ZERO, challenge);
@@ -109,7 +109,7 @@ impl<F: Field, Inner: SumcheckProver<F>> SumcheckProver<F> for PaddedSumcheckDec
 		Ok(())
 	}
 
-	fn finish(self) -> Result<Vec<F>, Error> {
+	fn finish(self) -> Result<Vec<F>, SumcheckError> {
 		// The final multilinear evaluations are those of the inner prover; padding does not add
 		// multilinears.
 		self.inner.finish()

--- a/crates/ip-prover/src/sumcheck/prove.rs
+++ b/crates/ip-prover/src/sumcheck/prove.rs
@@ -8,7 +8,7 @@
 use binius_field::Field;
 use binius_ip::mlecheck;
 
-use super::{common::SumcheckProver, error::Error};
+use super::{common::SumcheckProver, error::SumcheckError};
 use crate::{channel::IPProverChannel, sumcheck::common::MleCheckProver};
 
 /// Executes the sumcheck proving protocol for a single multivariate polynomial.
@@ -31,8 +31,8 @@ use crate::{channel::IPProverChannel, sumcheck::common::MleCheckProver};
 ///
 /// # Errors
 ///
-/// - [`Error::ArgumentError`] if the prover returns more than one composition polynomial from its
-///   `execute()` method
+/// - [`SumcheckError::ArgumentError`] if the prover returns more than one composition polynomial
+///   from its `execute()` method
 /// - Any error propagated from the underlying prover implementation
 ///
 /// # Protocol Flow
@@ -47,14 +47,14 @@ use crate::{channel::IPProverChannel, sumcheck::common::MleCheckProver};
 pub fn prove_single<F: Field>(
 	mut prover: impl SumcheckProver<F>,
 	channel: &mut impl IPProverChannel<F>,
-) -> Result<ProveSingleOutput<F>, Error> {
+) -> Result<ProveSingleOutput<F>, SumcheckError> {
 	let n_vars = prover.n_vars();
 	let mut challenges = Vec::with_capacity(n_vars);
 
 	for _ in 0..n_vars {
 		let mut round_coeffs_vec = prover.execute()?;
 		if round_coeffs_vec.len() != 1 {
-			return Err(Error::ArgumentError(format!(
+			return Err(SumcheckError::ArgumentError(format!(
 				"function expects prover to evaluate one composition, but it returned {} from \
 				execute()",
 				round_coeffs_vec.len()
@@ -82,14 +82,14 @@ pub fn prove_single<F: Field>(
 pub fn prove_single_mlecheck<F: Field>(
 	mut prover: impl MleCheckProver<F>,
 	channel: &mut impl IPProverChannel<F>,
-) -> Result<ProveSingleOutput<F>, Error> {
+) -> Result<ProveSingleOutput<F>, SumcheckError> {
 	let n_vars = prover.n_vars();
 	let mut challenges = Vec::with_capacity(n_vars);
 
 	for _ in 0..n_vars {
 		let mut round_coeffs_vec = prover.execute()?;
 		if round_coeffs_vec.len() != 1 {
-			return Err(Error::ArgumentError(format!(
+			return Err(SumcheckError::ArgumentError(format!(
 				"function expects prover to evaluate one composition, but it returned {} from \
 				execute()",
 				round_coeffs_vec.len()

--- a/crates/ip-prover/src/sumcheck/quadratic_mle.rs
+++ b/crates/ip-prover/src/sumcheck/quadratic_mle.rs
@@ -6,7 +6,9 @@ use binius_ip::sumcheck::RoundCoeffs;
 use binius_math::{AsSlicesMut, FieldSliceMut, multilinear::fold::fold_highest_var_inplace};
 use binius_utils::rayon::prelude::*;
 
-use super::{common::SumcheckProver, error::Error, gruen32::Gruen32, round_evals::WideRoundEvals2};
+use super::{
+	common::SumcheckProver, error::SumcheckError, gruen32::Gruen32, round_evals::WideRoundEvals2,
+};
 use crate::sumcheck::common::MleCheckProver;
 
 /// MLE-check prover for polynomials defined as quadratic compositions of N multilinear polynomials.
@@ -67,20 +69,20 @@ where
 	///
 	/// # Errors
 	///
-	/// Returns `Error::MultilinearSizeMismatch` if any multilinear has a different number of
-	/// variables than the length of `eval_point`.
+	/// Returns `SumcheckError::MultilinearSizeMismatch` if any multilinear has a different number
+	/// of variables than the length of `eval_point`.
 	pub fn new(
 		mut multilinears: impl AsSlicesMut<P, N> + Send + 'static,
 		composition: Composition,
 		infinity_composition: InfinityComposition,
 		eval_point: Vec<F>,
 		eval_claim: F,
-	) -> Result<Self, Error> {
+	) -> Result<Self, SumcheckError> {
 		let n_vars = eval_point.len();
 
 		for multilinear in &multilinears.as_slices_mut() {
 			if multilinear.log_len() != n_vars {
-				return Err(Error::MultilinearSizeMismatch);
+				return Err(SumcheckError::MultilinearSizeMismatch);
 			}
 		}
 
@@ -133,10 +135,10 @@ where
 		vec![claim]
 	}
 
-	fn execute(&mut self) -> Result<Vec<RoundCoeffs<F>>, Error> {
+	fn execute(&mut self) -> Result<Vec<RoundCoeffs<F>>, SumcheckError> {
 		let last_eval = match &self.last_coeffs_or_eval {
 			RoundCoeffsOrEval::Eval(eval) => *eval,
-			RoundCoeffsOrEval::Coeffs(_) => return Err(Error::ExpectedFold),
+			RoundCoeffsOrEval::Coeffs(_) => return Err(SumcheckError::ExpectedFold),
 		};
 
 		let n_vars_remaining = self.gruen32.n_vars_remaining();
@@ -198,9 +200,9 @@ where
 		Ok(vec![round_coeffs])
 	}
 
-	fn fold(&mut self, challenge: F) -> Result<(), Error> {
+	fn fold(&mut self, challenge: F) -> Result<(), SumcheckError> {
 		let RoundCoeffsOrEval::Coeffs(coeffs) = &self.last_coeffs_or_eval else {
-			return Err(Error::ExpectedExecute);
+			return Err(SumcheckError::ExpectedExecute);
 		};
 
 		assert!(
@@ -222,11 +224,11 @@ where
 		Ok(())
 	}
 
-	fn finish(mut self) -> Result<Vec<F>, Error> {
+	fn finish(mut self) -> Result<Vec<F>, SumcheckError> {
 		if self.n_vars() > 0 {
 			let error = match self.last_coeffs_or_eval {
-				RoundCoeffsOrEval::Coeffs(_) => Error::ExpectedFold,
-				RoundCoeffsOrEval::Eval(_) => Error::ExpectedExecute,
+				RoundCoeffsOrEval::Coeffs(_) => SumcheckError::ExpectedFold,
+				RoundCoeffsOrEval::Eval(_) => SumcheckError::ExpectedExecute,
 			};
 
 			return Err(error);

--- a/crates/ip-prover/src/sumcheck/rerand_mle.rs
+++ b/crates/ip-prover/src/sumcheck/rerand_mle.rs
@@ -11,7 +11,7 @@ use itertools::izip;
 
 use super::{
 	common::{MleCheckProver, SumcheckProver},
-	error::Error,
+	error::SumcheckError,
 	gruen32::Gruen32,
 	round_evals::RoundEvals1,
 	switchover::BinarySwitchover,
@@ -47,11 +47,11 @@ where
 		eval_claims: &[F],
 		bitmasks: &'b [B],
 		switchover: usize,
-	) -> Result<Self, Error> {
+	) -> Result<Self, SumcheckError> {
 		let n_vars = eval_point.len();
 
 		if bitmasks.len() != 1 << n_vars {
-			return Err(Error::BitmasksSizeMismatch);
+			return Err(SumcheckError::BitmasksSizeMismatch);
 		}
 
 		let gruen32 = Gruen32::new(eval_point);
@@ -96,9 +96,9 @@ where
 		}
 	}
 
-	fn execute(&mut self) -> Result<Vec<RoundCoeffs<F>>, Error> {
+	fn execute(&mut self) -> Result<Vec<RoundCoeffs<F>>, SumcheckError> {
 		let RoundCoeffsOrSums::Sums(sums) = &self.last_coeffs_or_sums else {
-			return Err(Error::ExpectedFold);
+			return Err(SumcheckError::ExpectedFold);
 		};
 
 		assert!(self.n_vars() > 0);
@@ -166,9 +166,9 @@ where
 		Ok(round_coeffs)
 	}
 
-	fn fold(&mut self, challenge: F) -> Result<(), Error> {
+	fn fold(&mut self, challenge: F) -> Result<(), SumcheckError> {
 		let RoundCoeffsOrSums::Coeffs(round_coeffs) = &self.last_coeffs_or_sums else {
-			return Err(Error::ExpectedExecute);
+			return Err(SumcheckError::ExpectedExecute);
 		};
 
 		assert!(self.n_vars() > 0);
@@ -185,11 +185,11 @@ where
 		Ok(())
 	}
 
-	fn finish(self) -> Result<Vec<F>, Error> {
+	fn finish(self) -> Result<Vec<F>, SumcheckError> {
 		if self.n_vars() > 0 {
 			let error = match self.last_coeffs_or_sums {
-				RoundCoeffsOrSums::Coeffs(_) => Error::ExpectedFold,
-				RoundCoeffsOrSums::Sums(_) => Error::ExpectedExecute,
+				RoundCoeffsOrSums::Coeffs(_) => SumcheckError::ExpectedFold,
+				RoundCoeffsOrSums::Sums(_) => SumcheckError::ExpectedExecute,
 			};
 
 			return Err(error);

--- a/crates/ip-prover/src/sumcheck/selector_mle.rs
+++ b/crates/ip-prover/src/sumcheck/selector_mle.rs
@@ -11,7 +11,7 @@ use itertools::izip;
 
 use super::{
 	common::SumcheckProver,
-	error::Error,
+	error::SumcheckError,
 	gruen32::Gruen32,
 	round_evals::{RoundEvals2, WideRoundEvals2},
 	switchover::BinarySwitchover,
@@ -58,19 +58,19 @@ impl<'b, F: Field, P: PackedField<Scalar = F>, B: Bitwise> SelectorMlecheckProve
 		bitmasks: &'b [B],
 		weights: Vec<F>,
 		switchover: usize,
-	) -> Result<Self, Error> {
+	) -> Result<Self, SumcheckError> {
 		let n_vars = selected.log_len();
 
 		if claims.iter().any(|claim| claim.point.len() != n_vars) {
-			return Err(Error::MultilinearSizeMismatch);
+			return Err(SumcheckError::MultilinearSizeMismatch);
 		}
 
 		if weights.len() != claims.len() {
-			return Err(Error::EvalClaimsNumberMismatch);
+			return Err(SumcheckError::EvalClaimsNumberMismatch);
 		}
 
 		if bitmasks.len() != selected.len() {
-			return Err(Error::BitmasksSizeMismatch);
+			return Err(SumcheckError::BitmasksSizeMismatch);
 		}
 
 		const MAX_CHUNK_VARS: usize = 8;
@@ -120,9 +120,9 @@ where
 		vec![izip!(per_claim, &self.weights).map(|(m, &w)| m * w).sum()]
 	}
 
-	fn execute(&mut self) -> Result<Vec<RoundCoeffs<F>>, Error> {
+	fn execute(&mut self) -> Result<Vec<RoundCoeffs<F>>, SumcheckError> {
 		let RoundCoeffsOrSums::Sums(sums) = &self.last_coeffs_or_sums else {
-			return Err(Error::ExpectedFold);
+			return Err(SumcheckError::ExpectedFold);
 		};
 
 		assert!(self.n_vars() > 0);
@@ -235,9 +235,9 @@ where
 		Ok(vec![combined])
 	}
 
-	fn fold(&mut self, challenge: F) -> Result<(), Error> {
+	fn fold(&mut self, challenge: F) -> Result<(), SumcheckError> {
 		let RoundCoeffsOrSums::Coeffs(prime_coeffs) = &self.last_coeffs_or_sums else {
-			return Err(Error::ExpectedExecute);
+			return Err(SumcheckError::ExpectedExecute);
 		};
 
 		assert!(self.n_vars() > 0);
@@ -258,11 +258,11 @@ where
 		Ok(())
 	}
 
-	fn finish(self) -> Result<Vec<F>, Error> {
+	fn finish(self) -> Result<Vec<F>, SumcheckError> {
 		if self.n_vars() > 0 {
 			let error = match self.last_coeffs_or_sums {
-				RoundCoeffsOrSums::Coeffs(_) => Error::ExpectedFold,
-				RoundCoeffsOrSums::Sums(_) => Error::ExpectedExecute,
+				RoundCoeffsOrSums::Coeffs(_) => SumcheckError::ExpectedFold,
+				RoundCoeffsOrSums::Sums(_) => SumcheckError::ExpectedExecute,
 			};
 
 			return Err(error);

--- a/crates/ip-prover/src/sumcheck/zk_mlecheck.rs
+++ b/crates/ip-prover/src/sumcheck/zk_mlecheck.rs
@@ -17,7 +17,7 @@ use binius_math::{
 };
 
 use super::{
-	Error,
+	SumcheckError,
 	common::{MleCheckProver, SumcheckProver},
 };
 use crate::channel::IPProverChannel;
@@ -284,13 +284,13 @@ impl<F: Field, P: PackedField<Scalar = F>, Data: Deref<Target = [P]>> SumcheckPr
 		vec![claim]
 	}
 
-	fn execute(&mut self) -> Result<Vec<RoundCoeffs<F>>, Error> {
+	fn execute(&mut self) -> Result<Vec<RoundCoeffs<F>>, SumcheckError> {
 		let RoundCoeffsOrClaim::Claim(_claim) = &self.last_coeffs_or_claim else {
-			return Err(Error::ExpectedFold);
+			return Err(SumcheckError::ExpectedFold);
 		};
 
 		if self.n_vars_remaining == 0 {
-			return Err(Error::ExpectedFinish);
+			return Err(SumcheckError::ExpectedFinish);
 		}
 
 		let var_idx = self.current_var_index();
@@ -318,9 +318,9 @@ impl<F: Field, P: PackedField<Scalar = F>, Data: Deref<Target = [P]>> SumcheckPr
 		Ok(vec![round_coeffs])
 	}
 
-	fn fold(&mut self, challenge: F) -> Result<(), Error> {
+	fn fold(&mut self, challenge: F) -> Result<(), SumcheckError> {
 		let RoundCoeffsOrClaim::Coeffs(coeffs) = &self.last_coeffs_or_claim else {
-			return Err(Error::ExpectedExecute);
+			return Err(SumcheckError::ExpectedExecute);
 		};
 
 		// Evaluate round polynomial at challenge to get new claim
@@ -337,11 +337,11 @@ impl<F: Field, P: PackedField<Scalar = F>, Data: Deref<Target = [P]>> SumcheckPr
 		Ok(())
 	}
 
-	fn finish(self) -> Result<Vec<F>, Error> {
+	fn finish(self) -> Result<Vec<F>, SumcheckError> {
 		if self.n_vars_remaining > 0 {
 			return match self.last_coeffs_or_claim {
-				RoundCoeffsOrClaim::Coeffs(_) => Err(Error::ExpectedFold),
-				RoundCoeffsOrClaim::Claim(_) => Err(Error::ExpectedExecute),
+				RoundCoeffsOrClaim::Coeffs(_) => Err(SumcheckError::ExpectedFold),
+				RoundCoeffsOrClaim::Claim(_) => Err(SumcheckError::ExpectedExecute),
 			};
 		}
 
@@ -393,7 +393,7 @@ pub fn prove<F: Field, P: PackedField<Scalar = F>, Data: Deref<Target = [P]>>(
 	mut main_prover: impl MleCheckProver<F>,
 	mask: Mask<P, Data>,
 	channel: &mut impl IPProverChannel<F>,
-) -> Result<ProveZKOutput<F>, Error> {
+) -> Result<ProveZKOutput<F>, SumcheckError> {
 	assert_eq!(
 		main_prover.n_claims(),
 		1,

--- a/crates/ip/src/channel.rs
+++ b/crates/ip/src/channel.rs
@@ -39,15 +39,15 @@ pub trait IPVerifierChannel<F: Field> {
 	type Elem: FieldOps;
 
 	/// Receives a single field element from the prover.
-	fn recv_one(&mut self) -> Result<Self::Elem, Error>;
+	fn recv_one(&mut self) -> Result<Self::Elem, IPChannelError>;
 
 	/// Receives `n` field elements from the prover.
-	fn recv_many(&mut self, n: usize) -> Result<Vec<Self::Elem>, Error> {
+	fn recv_many(&mut self, n: usize) -> Result<Vec<Self::Elem>, IPChannelError> {
 		repeat_with(|| self.recv_one()).take(n).collect()
 	}
 
 	/// Receives a fixed-size array of field elements from the prover.
-	fn recv_array<const N: usize>(&mut self) -> Result<[Self::Elem; N], Error> {
+	fn recv_array<const N: usize>(&mut self) -> Result<[Self::Elem; N], IPChannelError> {
 		array_util::try_from_fn(|_| self.recv_one())
 	}
 
@@ -81,8 +81,8 @@ pub trait IPVerifierChannel<F: Field> {
 
 	/// Asserts that a value is zero.
 	///
-	/// Returns [`Error::InvalidAssert`] if the value is not zero.
-	fn assert_zero(&mut self, val: Self::Elem) -> Result<(), Error>;
+	/// Returns [`IPChannelError::InvalidAssert`] if the value is not zero.
+	fn assert_zero(&mut self, val: Self::Elem) -> Result<(), IPChannelError>;
 
 	/// Computes a value that is a function of public-channel-derived elements and returns it
 	/// as a freshly allocated `Elem`.
@@ -117,18 +117,22 @@ where
 {
 	type Elem = F;
 
-	fn recv_one(&mut self) -> Result<F, Error> {
-		self.message().read_scalar().map_err(|_| Error::ProofEmpty)
+	fn recv_one(&mut self) -> Result<F, IPChannelError> {
+		self.message()
+			.read_scalar()
+			.map_err(|_| IPChannelError::ProofEmpty)
 	}
 
-	fn recv_many(&mut self, n: usize) -> Result<Vec<F>, Error> {
+	fn recv_many(&mut self, n: usize) -> Result<Vec<F>, IPChannelError> {
 		self.message()
 			.read_scalar_slice(n)
-			.map_err(|_| Error::ProofEmpty)
+			.map_err(|_| IPChannelError::ProofEmpty)
 	}
 
-	fn recv_array<const N: usize>(&mut self) -> Result<[F; N], Error> {
-		self.message().read().map_err(|_| Error::ProofEmpty)
+	fn recv_array<const N: usize>(&mut self) -> Result<[F; N], IPChannelError> {
+		self.message()
+			.read()
+			.map_err(|_| IPChannelError::ProofEmpty)
 	}
 
 	fn sample(&mut self) -> F {
@@ -145,11 +149,11 @@ where
 		vals.to_vec()
 	}
 
-	fn assert_zero(&mut self, val: F) -> Result<(), Error> {
+	fn assert_zero(&mut self, val: F) -> Result<(), IPChannelError> {
 		if val == F::ZERO {
 			Ok(())
 		} else {
-			Err(Error::InvalidAssert)
+			Err(IPChannelError::InvalidAssert)
 		}
 	}
 
@@ -159,7 +163,7 @@ where
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum Error {
+pub enum IPChannelError {
 	#[error("proof is empty")]
 	ProofEmpty,
 	#[error("invalid assertion: value is not zero")]

--- a/crates/ip/src/fracaddcheck.rs
+++ b/crates/ip/src/fracaddcheck.rs
@@ -7,11 +7,11 @@
 
 use binius_field::Field;
 use binius_math::line::extrapolate_line;
-use binius_transcript::Error as TranscriptError;
+use binius_transcript::TranscriptError;
 
 use crate::{
-	channel::IPVerifierChannel,
-	sumcheck::{self, BatchSumcheckOutput},
+	channel::{IPChannelError, IPVerifierChannel},
+	sumcheck::{self, BatchSumcheckOutput, SumcheckError, SumcheckVerificationError},
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -27,7 +27,7 @@ pub fn verify<F, C>(
 	k: usize,
 	claim: FracAddEvalClaim<C::Elem>,
 	channel: &mut C,
-) -> Result<FracAddEvalClaim<C::Elem>, Error>
+) -> Result<FracAddEvalClaim<C::Elem>, FracAddCheckError>
 where
 	F: Field,
 	C: IPVerifierChannel<F>,
@@ -84,46 +84,48 @@ where
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum Error {
+pub enum FracAddCheckError {
 	#[error("sumcheck error: {0}")]
-	Sumcheck(#[source] sumcheck::Error),
+	Sumcheck(#[source] SumcheckError),
 	#[error("transcript error: {0}")]
 	Transcript(#[source] TranscriptError),
 	#[error("verification error: {0}")]
-	Verification(#[from] VerificationError),
+	Verification(#[from] FracAddCheckVerificationError),
 }
 
-impl From<sumcheck::Error> for Error {
-	fn from(err: sumcheck::Error) -> Self {
+impl From<SumcheckError> for FracAddCheckError {
+	fn from(err: SumcheckError) -> Self {
 		match err {
-			sumcheck::Error::Verification(err) => VerificationError::Sumcheck(err).into(),
-			_ => Error::Sumcheck(err),
+			SumcheckError::Verification(err) => FracAddCheckVerificationError::Sumcheck(err).into(),
+			_ => FracAddCheckError::Sumcheck(err),
 		}
 	}
 }
 
-impl From<TranscriptError> for Error {
+impl From<TranscriptError> for FracAddCheckError {
 	fn from(err: TranscriptError) -> Self {
 		match err {
-			TranscriptError::NotEnoughBytes => VerificationError::TranscriptIsEmpty.into(),
-			_ => Error::Transcript(err),
+			TranscriptError::NotEnoughBytes => {
+				FracAddCheckVerificationError::TranscriptIsEmpty.into()
+			}
+			_ => FracAddCheckError::Transcript(err),
 		}
 	}
 }
 
-impl From<crate::channel::Error> for Error {
-	fn from(err: crate::channel::Error) -> Self {
+impl From<IPChannelError> for FracAddCheckError {
+	fn from(err: IPChannelError) -> Self {
 		match err {
-			crate::channel::Error::ProofEmpty => VerificationError::TranscriptIsEmpty.into(),
-			crate::channel::Error::InvalidAssert => VerificationError::InvalidAssert.into(),
+			IPChannelError::ProofEmpty => FracAddCheckVerificationError::TranscriptIsEmpty.into(),
+			IPChannelError::InvalidAssert => FracAddCheckVerificationError::InvalidAssert.into(),
 		}
 	}
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum VerificationError {
+pub enum FracAddCheckVerificationError {
 	#[error("sumcheck: {0}")]
-	Sumcheck(#[from] sumcheck::VerificationError),
+	Sumcheck(#[from] SumcheckVerificationError),
 	#[error("incorrect layer fraction sum evaluation: {round}")]
 	IncorrectLayerFractionSumEvaluation { round: usize },
 	#[error("incorrect round evaluation: {round}")]

--- a/crates/ip/src/logup_star/error.rs
+++ b/crates/ip/src/logup_star/error.rs
@@ -1,21 +1,21 @@
 // Copyright 2026 The Binius Developers
 
-//! Error types for logUp* verification.
+//! LogupStarError types for logUp* verification.
 
-use crate::{fracaddcheck, sumcheck};
+use crate::{fracaddcheck::FracAddCheckError, sumcheck::SumcheckError};
 
 #[derive(Debug, thiserror::Error)]
-pub enum Error {
+pub enum LogupStarError {
 	#[error("fractional-addition check error: {0}")]
-	FracAddCheck(#[from] fracaddcheck::Error),
+	FracAddCheck(#[from] FracAddCheckError),
 	#[error("sumcheck error: {0}")]
-	Sumcheck(#[from] sumcheck::Error),
+	Sumcheck(#[from] SumcheckError),
 	#[error("verification error: {0}")]
-	Verification(#[from] VerificationError),
+	Verification(#[from] LogupStarVerificationError),
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum VerificationError {
+pub enum LogupStarVerificationError {
 	#[error("the two lookup fractional sums are not equal")]
 	LookupSumMismatch,
 	#[error("the eq_r multilinear evaluation is incorrect")]

--- a/crates/ip/src/logup_star/final_layer.rs
+++ b/crates/ip/src/logup_star/final_layer.rs
@@ -12,7 +12,7 @@ use binius_field::{
 };
 use binius_math::{line::extrapolate_line, multilinear::eq::eq_ind};
 
-use super::error::{Error, VerificationError};
+use super::error::{LogupStarError, LogupStarVerificationError};
 use crate::{
 	channel::IPVerifierChannel,
 	sumcheck::{self, BatchSumcheckOutput},
@@ -66,7 +66,7 @@ pub fn verify_final_layer<F, C>(
 	layer1_den: C::Elem,
 	layer1_point: &[C::Elem],
 	channel: &mut C,
-) -> Result<FinalLayer<C::Elem>, Error>
+) -> Result<FinalLayer<C::Elem>, LogupStarError>
 where
 	F: Field + ExtensionField<BinaryField1b>,
 	C: IPVerifierChannel<F>,
@@ -87,7 +87,7 @@ where
 	//     T_0 = T(rho, 0),  T_1 = T(rho, 1)
 	let [y_0, y_1, t_0, t_1] = channel
 		.recv_array()
-		.map_err(|_| VerificationError::TranscriptIsEmpty)?;
+		.map_err(|_| LogupStarVerificationError::TranscriptIsEmpty)?;
 
 	// Sumcheck binds variables highest-to-lowest; reverse to align with the low-to-high point Z.
 	challenges.reverse();
@@ -117,7 +117,7 @@ where
 		eq_eval * (num_relation + batch_coeff * den_relation) + batch_coeff_sq * prod_relation;
 	channel
 		.assert_zero(eval - expected)
-		.map_err(|_| VerificationError::FinalLayerMismatch)?;
+		.map_err(|_| LogupStarVerificationError::FinalLayerMismatch)?;
 
 	// Fold the highest variable once to collapse the halves into single evaluations.
 	let r = channel.sample();

--- a/crates/ip/src/logup_star/mod.rs
+++ b/crates/ip/src/logup_star/mod.rs
@@ -104,7 +104,7 @@ mod output;
 mod verify;
 
 pub use self::{
-	error::{Error, VerificationError},
+	error::{LogupStarError, LogupStarVerificationError},
 	output::LogupOutput,
 	verify::verify,
 };

--- a/crates/ip/src/logup_star/verify.rs
+++ b/crates/ip/src/logup_star/verify.rs
@@ -6,7 +6,7 @@ use binius_field::{BinaryField1b, ExtensionField, Field};
 use binius_math::multilinear::eq::eq_ind;
 
 use super::{
-	error::{Error, VerificationError},
+	error::{LogupStarError, LogupStarVerificationError},
 	final_layer::{FinalLayer, verify_final_layer},
 	output::LogupOutput,
 };
@@ -68,7 +68,7 @@ pub fn verify<F, C>(
 	eval_claim: C::Elem,
 	eval_point: &[C::Elem],
 	channel: &mut C,
-) -> Result<LogupOutput<C::Elem>, Error>
+) -> Result<LogupOutput<C::Elem>, LogupStarError>
 where
 	F: Field + ExtensionField<BinaryField1b>,
 	C: IPVerifierChannel<F>,
@@ -89,7 +89,7 @@ where
 	//     table  side: num_r / den_r = sum_{j in B_m} Y(j)    / (c - j)
 	let [num_l, den_l, num_r, den_r] = channel
 		.recv_array()
-		.map_err(|_| VerificationError::TranscriptIsEmpty)?;
+		.map_err(|_| LogupStarVerificationError::TranscriptIsEmpty)?;
 
 	// The lookup identity is the equality of the two fractional sums.
 	//
@@ -97,7 +97,7 @@ where
 	let sum_diff = num_l.clone() * den_r.clone() - num_r.clone() * den_l.clone();
 	channel
 		.assert_zero(sum_diff)
-		.map_err(|_| VerificationError::LookupSumMismatch)?;
+		.map_err(|_| LogupStarVerificationError::LookupSumMismatch)?;
 
 	// Looker side: run the full n-layer GKR to reach the leaf claim.
 	//
@@ -123,7 +123,7 @@ where
 	let expected_eq = eq_ind::<C::Elem>(eval_point, &index_eval_point);
 	channel
 		.assert_zero(looker_num - expected_eq)
-		.map_err(|_| VerificationError::IncorrectXEvaluation)?;
+		.map_err(|_| LogupStarVerificationError::IncorrectXEvaluation)?;
 
 	// The looker denominator is c - I(point_l), so the index claim is I(point_l) = c - den.
 	let index_eval_claim = c.clone() - looker_den;

--- a/crates/ip/src/mlecheck.rs
+++ b/crates/ip/src/mlecheck.rs
@@ -83,7 +83,7 @@ pub fn verify<F, C>(
 	degree: usize,
 	mut eval: C::Elem,
 	channel: &mut C,
-) -> Result<SumcheckOutput<C::Elem>, sumcheck::Error>
+) -> Result<SumcheckOutput<C::Elem>, sumcheck::SumcheckError>
 where
 	F: Field,
 	C: IPVerifierChannel<F>,
@@ -116,7 +116,7 @@ pub fn verify_zk<F, C>(
 	degree: usize,
 	eval: C::Elem,
 	channel: &mut C,
-) -> Result<VerifyZKOutput<C::Elem>, sumcheck::Error>
+) -> Result<VerifyZKOutput<C::Elem>, sumcheck::SumcheckError>
 where
 	F: Field,
 	C: IPVerifierChannel<F>,

--- a/crates/ip/src/prodcheck.rs
+++ b/crates/ip/src/prodcheck.rs
@@ -18,21 +18,21 @@
 
 use binius_field::Field;
 use binius_math::line::extrapolate_line;
-use binius_transcript::Error as TranscriptError;
+use binius_transcript::TranscriptError;
 
 // Re-export MultilinearEvalClaim from crate root for backward compatibility
 pub use crate::MultilinearEvalClaim;
 use crate::{
-	channel::IPVerifierChannel,
+	channel::{IPChannelError, IPVerifierChannel},
 	mlecheck,
-	sumcheck::{self, SumcheckOutput},
+	sumcheck::{SumcheckError, SumcheckOutput, SumcheckVerificationError},
 };
 
 pub fn verify<F, C>(
 	k: usize,
 	claim: MultilinearEvalClaim<C::Elem>,
 	channel: &mut C,
-) -> Result<MultilinearEvalClaim<C::Elem>, Error>
+) -> Result<MultilinearEvalClaim<C::Elem>, ProdcheckError>
 where
 	F: Field,
 	C: IPVerifierChannel<F>,
@@ -72,46 +72,46 @@ where
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum Error {
+pub enum ProdcheckError {
 	#[error("sumcheck error: {0}")]
-	Sumcheck(#[source] sumcheck::Error),
+	Sumcheck(#[source] SumcheckError),
 	#[error("transcript error: {0}")]
 	Transcript(#[source] TranscriptError),
 	#[error("verification error: {0}")]
-	Verification(#[from] VerificationError),
+	Verification(#[from] ProdcheckVerificationError),
 }
 
-impl From<sumcheck::Error> for Error {
-	fn from(err: sumcheck::Error) -> Self {
+impl From<SumcheckError> for ProdcheckError {
+	fn from(err: SumcheckError) -> Self {
 		match err {
-			sumcheck::Error::Verification(err) => VerificationError::Sumcheck(err).into(),
-			_ => Error::Sumcheck(err),
+			SumcheckError::Verification(err) => ProdcheckVerificationError::Sumcheck(err).into(),
+			_ => ProdcheckError::Sumcheck(err),
 		}
 	}
 }
 
-impl From<TranscriptError> for Error {
+impl From<TranscriptError> for ProdcheckError {
 	fn from(err: TranscriptError) -> Self {
 		match err {
-			TranscriptError::NotEnoughBytes => VerificationError::TranscriptIsEmpty.into(),
-			_ => Error::Transcript(err),
+			TranscriptError::NotEnoughBytes => ProdcheckVerificationError::TranscriptIsEmpty.into(),
+			_ => ProdcheckError::Transcript(err),
 		}
 	}
 }
 
-impl From<crate::channel::Error> for Error {
-	fn from(err: crate::channel::Error) -> Self {
+impl From<IPChannelError> for ProdcheckError {
+	fn from(err: IPChannelError) -> Self {
 		match err {
-			crate::channel::Error::ProofEmpty => VerificationError::TranscriptIsEmpty.into(),
-			crate::channel::Error::InvalidAssert => VerificationError::InvalidAssert.into(),
+			IPChannelError::ProofEmpty => ProdcheckVerificationError::TranscriptIsEmpty.into(),
+			IPChannelError::InvalidAssert => ProdcheckVerificationError::InvalidAssert.into(),
 		}
 	}
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum VerificationError {
+pub enum ProdcheckVerificationError {
 	#[error("sumcheck: {0}")]
-	Sumcheck(#[from] sumcheck::VerificationError),
+	Sumcheck(#[from] SumcheckVerificationError),
 	#[error("incorrect round evaluation: {round}")]
 	IncorrectRoundEvaluation { round: usize },
 	#[error("transcript is empty")]

--- a/crates/ip/src/sumcheck/batch.rs
+++ b/crates/ip/src/sumcheck/batch.rs
@@ -6,7 +6,7 @@ use binius_math::univariate::evaluate_univariate;
 use crate::{
 	channel::IPVerifierChannel,
 	mlecheck,
-	sumcheck::{self, Error, SumcheckOutput},
+	sumcheck::{self, SumcheckError, SumcheckOutput},
 };
 
 /// The reduced output of a sumcheck verification.
@@ -39,7 +39,7 @@ pub fn batch_verify<F, C>(
 	degree: usize,
 	sums: &[C::Elem],
 	channel: &mut C,
-) -> Result<BatchSumcheckOutput<C::Elem>, Error>
+) -> Result<BatchSumcheckOutput<C::Elem>, SumcheckError>
 where
 	F: Field,
 	C: IPVerifierChannel<F>,
@@ -69,7 +69,7 @@ pub fn batch_verify_mle<F, C>(
 	degree: usize,
 	evals: &[C::Elem],
 	channel: &mut C,
-) -> Result<BatchSumcheckOutput<C::Elem>, Error>
+) -> Result<BatchSumcheckOutput<C::Elem>, SumcheckError>
 where
 	F: Field,
 	C: IPVerifierChannel<F>,

--- a/crates/ip/src/sumcheck/error.rs
+++ b/crates/ip/src/sumcheck/error.rs
@@ -1,39 +1,43 @@
 // Copyright 2025 Irreducible Inc.
 
-use binius_transcript::Error as TranscriptError;
+use binius_transcript::TranscriptError;
 
 use crate::channel;
 
 #[derive(Debug, thiserror::Error)]
-pub enum Error {
+pub enum SumcheckError {
 	#[error("transcript error: {0}")]
 	Transcript(#[source] TranscriptError),
 	#[error("verification error: {0}")]
-	Verification(#[from] VerificationError),
+	Verification(#[from] SumcheckVerificationError),
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum VerificationError {
+pub enum SumcheckVerificationError {
 	#[error("transcript is empty")]
 	TranscriptIsEmpty,
 	#[error("invalid assertion: value is not zero")]
 	InvalidAssert,
 }
 
-impl From<TranscriptError> for Error {
+impl From<TranscriptError> for SumcheckError {
 	fn from(err: TranscriptError) -> Self {
 		match err {
-			TranscriptError::NotEnoughBytes => VerificationError::TranscriptIsEmpty.into(),
-			_ => Error::Transcript(err),
+			TranscriptError::NotEnoughBytes => SumcheckVerificationError::TranscriptIsEmpty.into(),
+			_ => SumcheckError::Transcript(err),
 		}
 	}
 }
 
-impl From<channel::Error> for Error {
-	fn from(err: channel::Error) -> Self {
+impl From<channel::IPChannelError> for SumcheckError {
+	fn from(err: channel::IPChannelError) -> Self {
 		match err {
-			channel::Error::ProofEmpty => VerificationError::TranscriptIsEmpty.into(),
-			channel::Error::InvalidAssert => VerificationError::InvalidAssert.into(),
+			channel::IPChannelError::ProofEmpty => {
+				SumcheckVerificationError::TranscriptIsEmpty.into()
+			}
+			channel::IPChannelError::InvalidAssert => {
+				SumcheckVerificationError::InvalidAssert.into()
+			}
 		}
 	}
 }

--- a/crates/ip/src/sumcheck/verify.rs
+++ b/crates/ip/src/sumcheck/verify.rs
@@ -2,7 +2,7 @@
 
 use binius_field::Field;
 
-use super::error::Error;
+use super::error::SumcheckError;
 use crate::{
 	channel::IPVerifierChannel,
 	sumcheck::{RoundCoeffs, RoundProof},
@@ -41,7 +41,7 @@ pub fn verify<F, C>(
 	degree: usize,
 	mut sum: C::Elem,
 	channel: &mut C,
-) -> Result<SumcheckOutput<C::Elem>, Error>
+) -> Result<SumcheckOutput<C::Elem>, SumcheckError>
 where
 	F: Field,
 	C: IPVerifierChannel<F>,

--- a/crates/m4-prover/src/bitand.rs
+++ b/crates/m4-prover/src/bitand.rs
@@ -8,7 +8,7 @@ use binius_core::{
 	word::Word,
 };
 use binius_field::{AESTowerField8b as B8, PackedField};
-use binius_ip_prover::{channel::IPProverChannel, sumcheck::Error};
+use binius_ip_prover::{channel::IPProverChannel, sumcheck::SumcheckError};
 use binius_math::BinarySubspace;
 use binius_prover::and_reduction::prover::OblongZerocheckProver;
 use binius_utils::{checked_arithmetics::checked_log_2, rayon::prelude::*};
@@ -185,7 +185,10 @@ impl BatchAndCheckWitness {
 	/// # Errors
 	///
 	/// Returns an error if the underlying sumcheck fails.
-	pub fn prove<P, Channel>(self, channel: &mut Channel) -> Result<AndCheckOutput<B128>, Error>
+	pub fn prove<P, Channel>(
+		self,
+		channel: &mut Channel,
+	) -> Result<AndCheckOutput<B128>, SumcheckError>
 	where
 		P: PackedField<Scalar = B128>,
 		Channel: IPProverChannel<B128>,
@@ -254,7 +257,7 @@ mod tests {
 		},
 	};
 	use binius_frontend::{Circuit, CircuitBuilder, Wire};
-	use binius_ip::channel::Error as ChannelError;
+	use binius_ip::channel::IPChannelError;
 	use binius_m4_verifier::verify_bitand_reduction;
 	use binius_math::{
 		FieldBuffer, multilinear::evaluate::evaluate, univariate::lagrange_evals_scalars,
@@ -546,7 +549,7 @@ mod tests {
 		// The closing check is `A_eval * B_eval - C_eval == sumcheck_eval`.
 		// The tampered message moves the claim, so this equality no longer holds.
 		// The channel rejects the non-zero assertion, the protocol's terminal check.
-		assert_matches!(err, VerifierError::Channel(ChannelError::InvalidAssert));
+		assert_matches!(err, VerifierError::Channel(IPChannelError::InvalidAssert));
 	}
 
 	proptest! {

--- a/crates/m4-prover/src/prove.rs
+++ b/crates/m4-prover/src/prove.rs
@@ -133,9 +133,9 @@ mod tests {
 	use binius_field::PackedBinaryGhash1x128b;
 	use binius_frontend::{Circuit, CircuitBuilder, Wire};
 	use binius_iop::{
-		basefold::{Error as BaseFoldError, VerificationError as BaseFoldVerificationError},
-		fri::VerificationError as FriVerificationError,
-		merkle_tree::VerificationError as MerkleVerificationError,
+		basefold::{BaseFoldError, BaseFoldVerificationError},
+		fri::FriVerificationError,
+		merkle_tree::MerkleTreeVerificationError,
 	};
 	use binius_math::multilinear::evaluate::evaluate;
 	use binius_transcript::VerifierTranscript;
@@ -243,9 +243,9 @@ mod tests {
 		let err = verifier.verify(&mut verifier_transcript).unwrap_err();
 		assert_matches!(
 			err,
-			binius_iop::channel::Error::BaseFold(BaseFoldError::Verification(
+			binius_iop::channel::IOPChannelError::BaseFold(BaseFoldError::Verification(
 				BaseFoldVerificationError::FRI(FriVerificationError::MerkleError(
-					MerkleVerificationError::InvalidProof
+					MerkleTreeVerificationError::InvalidProof
 				))
 			))
 		);

--- a/crates/m4-verifier/src/verify.rs
+++ b/crates/m4-verifier/src/verify.rs
@@ -104,7 +104,7 @@ impl Verifier {
 	pub fn verify<Challenger_>(
 		&self,
 		transcript: &mut VerifierTranscript<Challenger_>,
-	) -> Result<(Vec<B128>, B128), binius_iop::channel::Error>
+	) -> Result<(Vec<B128>, B128), binius_iop::channel::IOPChannelError>
 	where
 		Challenger_: Challenger,
 	{

--- a/crates/prover/benches/batch_quadratic_mle.rs
+++ b/crates/prover/benches/batch_quadratic_mle.rs
@@ -9,7 +9,7 @@ use binius_math::{
 	test_utils::{random_field_buffer, random_scalars},
 };
 use binius_prover::protocols::sumcheck::{
-	Error, batch_quadratic_mle::BatchQuadraticMleCheckProver, common::MleCheckProver,
+	SumcheckError, batch_quadratic_mle::BatchQuadraticMleCheckProver, common::MleCheckProver,
 };
 use binius_transcript::{
 	ProverTranscript,
@@ -71,7 +71,7 @@ where
 fn prove_batch_mlecheck<Ff, Challenger_, Prover>(
 	mut prover: Prover,
 	transcript: &mut ProverTranscript<Challenger_>,
-) -> Result<Vec<Ff>, Error>
+) -> Result<Vec<Ff>, SumcheckError>
 where
 	Ff: Field,
 	Challenger_: Challenger,

--- a/crates/prover/src/and_reduction/prover.rs
+++ b/crates/prover/src/and_reduction/prover.rs
@@ -23,7 +23,7 @@ use super::sumcheck_round_messages;
 use crate::{
 	fold_word::fold_words_with_transform,
 	protocols::sumcheck::{
-		Error, ProveSingleOutput, common::MleCheckProver, prove_single_mlecheck,
+		ProveSingleOutput, SumcheckError, common::MleCheckProver, prove_single_mlecheck,
 		quadratic_mle::QuadraticMleCheckProver,
 	},
 };
@@ -229,7 +229,7 @@ where
 	pub fn prove_with_channel(
 		self,
 		channel: &mut impl IPProverChannel<F>,
-	) -> Result<AndCheckOutput<F>, Error> {
+	) -> Result<AndCheckOutput<F>, SumcheckError> {
 		let univariate_message_coeffs = self.execute();
 
 		channel.send_many(univariate_message_coeffs);

--- a/crates/prover/src/error.rs
+++ b/crates/prover/src/error.rs
@@ -1,19 +1,23 @@
 // Copyright 2025 Irreducible Inc.
 
-use crate::protocols::{basefold, intmul, shift, sumcheck};
+use binius_transcript::TranscriptError;
+
+use crate::protocols::{
+	basefold::BaseFoldError, intmul::IntMulError, shift::ShiftError, sumcheck::SumcheckError,
+};
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
 	#[error("invalid argument {arg}: {msg}")]
 	ArgumentError { arg: String, msg: String },
 	#[error("sumcheck error: {0}")]
-	Sumcheck(#[from] sumcheck::Error),
+	Sumcheck(#[from] SumcheckError),
 	#[error("basefold error: {0}")]
-	Basefold(#[from] basefold::Error),
+	Basefold(#[from] BaseFoldError),
 	#[error("transcript error: {0}")]
-	Transcript(#[from] binius_transcript::Error),
+	Transcript(#[from] TranscriptError),
 	#[error("integer multiplication error: {0}")]
-	IntMul(#[from] intmul::Error),
+	IntMul(#[from] IntMulError),
 	#[error("shift reduction error: {0}")]
-	ShiftReduction(#[from] shift::Error),
+	ShiftReduction(#[from] ShiftError),
 }

--- a/crates/prover/src/protocols/inout_check.rs
+++ b/crates/prover/src/protocols/inout_check.rs
@@ -8,7 +8,7 @@ use binius_math::{
 use binius_verifier::protocols::sumcheck::RoundCoeffs;
 
 use crate::protocols::sumcheck::{
-	Error,
+	SumcheckError,
 	common::{MleCheckProver, SumcheckProver},
 	gruen32::Gruen32,
 };
@@ -144,9 +144,9 @@ where
 		vec![claim]
 	}
 
-	fn execute(&mut self) -> Result<Vec<RoundCoeffs<F>>, Error> {
+	fn execute(&mut self) -> Result<Vec<RoundCoeffs<F>>, SumcheckError> {
 		let RoundCoeffsOrEval::Eval(last_eval) = &self.last_coeffs_or_eval else {
-			return Err(Error::ExpectedFold);
+			return Err(SumcheckError::ExpectedFold);
 		};
 
 		let n_vars_remaining = self.n_vars();
@@ -181,9 +181,9 @@ where
 		Ok(vec![round_coeffs])
 	}
 
-	fn fold(&mut self, challenge: F) -> Result<(), Error> {
+	fn fold(&mut self, challenge: F) -> Result<(), SumcheckError> {
 		let RoundCoeffsOrEval::Coeffs(coeffs) = &self.last_coeffs_or_eval else {
-			return Err(Error::ExpectedExecute);
+			return Err(SumcheckError::ExpectedExecute);
 		};
 
 		let n_vars = self.n_vars();
@@ -203,11 +203,11 @@ where
 		Ok(())
 	}
 
-	fn finish(self) -> Result<Vec<F>, Error> {
+	fn finish(self) -> Result<Vec<F>, SumcheckError> {
 		if self.n_vars() > 0 {
 			let error = match self.last_coeffs_or_eval {
-				RoundCoeffsOrEval::Coeffs(_) => Error::ExpectedFold,
-				RoundCoeffsOrEval::Eval(_) => Error::ExpectedExecute,
+				RoundCoeffsOrEval::Coeffs(_) => SumcheckError::ExpectedFold,
+				RoundCoeffsOrEval::Eval(_) => SumcheckError::ExpectedExecute,
 			};
 
 			return Err(error);

--- a/crates/prover/src/protocols/intmul/error.rs
+++ b/crates/prover/src/protocols/intmul/error.rs
@@ -1,15 +1,17 @@
 // Copyright 2025 Irreducible Inc.
 
-use crate::protocols::{prodcheck::Error as ProdcheckError, sumcheck::Error as SumcheckError};
+use binius_transcript::TranscriptError;
+
+use crate::protocols::{prodcheck::ProdcheckError, sumcheck::SumcheckError};
 
 #[derive(thiserror::Error, Debug)]
-pub enum Error {
+pub enum IntMulError {
 	#[error("Exponent length should be a power of two")]
 	ExponentsPowerOfTwoLengthRequired,
 	#[error("All exponent slices must have the same length")]
 	ExponentLengthMismatch,
 	#[error("transcript error")]
-	Transcript(#[from] binius_transcript::Error),
+	Transcript(#[from] TranscriptError),
 	#[error("sumcheck error: {0}")]
 	Sumcheck(#[from] SumcheckError),
 	#[error("prodcheck error: {0}")]

--- a/crates/prover/src/protocols/intmul/mod.rs
+++ b/crates/prover/src/protocols/intmul/mod.rs
@@ -4,7 +4,7 @@ mod error;
 pub mod prove;
 pub mod witness;
 
-pub use error::Error;
+pub use error::IntMulError;
 
 #[cfg(test)]
 mod tests;

--- a/crates/prover/src/protocols/intmul/prove.rs
+++ b/crates/prover/src/protocols/intmul/prove.rs
@@ -28,7 +28,7 @@ use either::Either;
 use itertools::{chain, izip};
 
 use super::{
-	error::Error,
+	error::IntMulError,
 	witness::{Witness, buffer_bivariate_product, two_valued_field_buffer},
 };
 use crate::{
@@ -97,7 +97,7 @@ where
 	/// The output of this protocol is a set of evaluation claims on the `b` selectors representing
 	/// all of `a`, `b`, `c_lo` and `c_hi` as column-major bit matrices, at a common evaluation
 	/// point.
-	pub fn prove(&mut self, witness: Witness<P, u64, S>) -> Result<IntMulOutput<F>, Error> {
+	pub fn prove(&mut self, witness: Witness<P, u64, S>) -> Result<IntMulOutput<F>, IntMulError> {
 		let Witness {
 			log_bits,
 			a_exponents,
@@ -195,7 +195,7 @@ where
 		b_prover: ProdcheckProver<P>,
 		b_leaves: &FieldBuffer<P>,
 		b_root_eval: F,
-	) -> Result<Phase1Output<F>, Error> {
+	) -> Result<Phase1Output<F>, IntMulError> {
 		let n_vars = eval_point.len();
 
 		// Create initial claim
@@ -237,7 +237,7 @@ where
 		c_lo_hi_roots: [FieldBuffer<P>; 2],
 		c_eval_point: &[F],
 		c_root_eval: F,
-	) -> Result<Phase3Output<F>, Error> {
+	) -> Result<Phase3Output<F>, IntMulError> {
 		let n_vars = selector.log_len();
 		assert!(
 			twisted_eval_points
@@ -318,7 +318,7 @@ where
 		(a_root_eval, a_prover): (F, ProdcheckProver<P>),
 		(gpow_c_lo_eval, c_lo_prover): (F, ProdcheckProver<P>),
 		(gpow_c_hi_eval, c_hi_prover): (F, ProdcheckProver<P>),
-	) -> Result<(Phase4Output<F>, [Vec<FieldBuffer<P>>; 3]), Error> {
+	) -> Result<(Phase4Output<F>, [Vec<FieldBuffer<P>>; 3]), IntMulError> {
 		let n_vars = eval_point.len();
 		// Each prover is over the full (widest) leaf layer of `2^log_bits` node multilinears.
 		assert_eq!(a_prover.n_layers(), log_bits);
@@ -409,7 +409,7 @@ where
 		// Needed for the zerocheck on `a_0 * b_0 = c_lo_0`.
 		a_exponents: &[u64],
 		c_lo_exponents: &[u64],
-	) -> Result<IntMulOutput<F>, Error> {
+	) -> Result<IntMulOutput<F>, IntMulError> {
 		assert!(log_bits >= 1);
 		assert_eq!(1 << log_bits, a_layer.len());
 		assert_eq!(2 * a_evals.len(), a_layer.len());

--- a/crates/prover/src/protocols/intmul/witness.rs
+++ b/crates/prover/src/protocols/intmul/witness.rs
@@ -14,7 +14,7 @@ use binius_utils::{
 use getset::Getters;
 use itertools::iterate;
 
-use super::error::Error;
+use super::error::IntMulError;
 use crate::protocols::prodcheck::ProdcheckProver;
 
 /// An integer multiplication protocol witness. Created from integer slices, consumed during
@@ -82,10 +82,10 @@ where
 	///
 	/// For statement of size $2^\ell$ using $2^m$-wide integers, the upper bound on the
 	/// witness size is $8^{\ell+m}$ large field elements.
-	pub fn new(log_bits: usize, a: S, b: S, c_lo: S, c_hi: S) -> Result<Self, Error> {
+	pub fn new(log_bits: usize, a: S, b: S, c_lo: S, c_hi: S) -> Result<Self, IntMulError> {
 		// Statement should be of pow-2 length.
 		let Some(n_vars) = strict_log_2(a.as_ref().len()) else {
-			return Err(Error::ExponentsPowerOfTwoLengthRequired);
+			return Err(IntMulError::ExponentsPowerOfTwoLengthRequired);
 		};
 
 		// All statement slices should be of same length.
@@ -93,7 +93,7 @@ where
 			.iter()
 			.any(|exponents| exponents.as_ref().len() != 1 << n_vars)
 		{
-			return Err(Error::ExponentLengthMismatch);
+			return Err(IntMulError::ExponentLengthMismatch);
 		}
 
 		let g = F::MULTIPLICATIVE_GENERATOR;

--- a/crates/prover/src/protocols/shift/error.rs
+++ b/crates/prover/src/protocols/shift/error.rs
@@ -1,9 +1,9 @@
 // Copyright 2025 Irreducible Inc.
 
-use crate::protocols::sumcheck::Error as SumcheckError;
+use crate::protocols::sumcheck::SumcheckError;
 
 #[derive(thiserror::Error, Debug)]
-pub enum Error {
+pub enum ShiftError {
 	#[error("sumcheck error: {0}")]
 	SumcheckError(#[from] SumcheckError),
 }

--- a/crates/prover/src/protocols/shift/mod.rs
+++ b/crates/prover/src/protocols/shift/mod.rs
@@ -9,6 +9,6 @@ mod phase_1;
 mod phase_2;
 mod prove;
 
-pub use error::Error;
+pub use error::ShiftError;
 pub use key_collection::{KeyCollection, build_key_collection};
 pub use prove::{OperatorData, PreparedOperatorData, prove};

--- a/crates/prover/src/protocols/shift/monster.rs
+++ b/crates/prover/src/protocols/shift/monster.rs
@@ -16,7 +16,7 @@ use tracing::instrument;
 
 use super::{
 	SHIFT_VARIANT_COUNT,
-	error::Error,
+	error::ShiftError,
 	key_collection::{KeyCollection, Operation},
 	prove::PreparedOperatorData,
 };
@@ -140,7 +140,7 @@ pub fn build_monster_multilinear<F, P: PackedField<Scalar = F>>(
 	intmul_operator_data: &PreparedOperatorData<F>,
 	r_j: &[F],
 	r_s: &[F],
-) -> Result<FieldBuffer<P>, Error>
+) -> Result<FieldBuffer<P>, ShiftError>
 where
 	F: BinaryField + From<AESTowerField8b>,
 {

--- a/crates/prover/src/protocols/shift/phase_1.rs
+++ b/crates/prover/src/protocols/shift/phase_1.rs
@@ -19,7 +19,7 @@ use itertools::izip;
 use tracing::instrument;
 
 use super::{
-	error::Error,
+	error::ShiftError,
 	key_collection::{KeyCollection, Operation},
 	monster::build_h_parts,
 	prove::PreparedOperatorData,
@@ -41,7 +41,7 @@ pub fn prove_phase_1<F, P, Channel>(
 	bitand_data: &PreparedOperatorData<F>,
 	intmul_data: &PreparedOperatorData<F>,
 	channel: &mut Channel,
-) -> Result<SumcheckOutput<F>, Error>
+) -> Result<SumcheckOutput<F>, ShiftError>
 where
 	F: BinaryField + From<AESTowerField8b>,
 	P: PackedField<Scalar = F>,
@@ -85,7 +85,7 @@ fn run_phase_1_sumcheck<F: Field, P: PackedField<Scalar = F>, Channel: IPProverC
 	g_parts: [FieldBuffer<P>; SHIFT_VARIANT_COUNT],
 	h_parts: [FieldBuffer<P>; SHIFT_VARIANT_COUNT],
 	channel: &mut Channel,
-) -> Result<SumcheckOutput<F>, Error> {
+) -> Result<SumcheckOutput<F>, ShiftError> {
 	// Build `BivariateProductSumcheckProver` provers.
 	let mut provers = iter::zip(g_parts, h_parts)
 		.map(|(g_part, h_part)| {
@@ -171,7 +171,7 @@ fn build_g_parts<F: BinaryField, P: PackedField<Scalar = F>>(
 	key_collection: &KeyCollection,
 	bitand_operator_data: &PreparedOperatorData<F>,
 	intmul_operator_data: &PreparedOperatorData<F>,
-) -> Result<[FieldBuffer<P>; SHIFT_VARIANT_COUNT], Error> {
+) -> Result<[FieldBuffer<P>; SHIFT_VARIANT_COUNT], ShiftError> {
 	let acc_size: usize = SHIFT_VARIANT_COUNT << (LOG_LEN.saturating_sub(P::LOG_WIDTH));
 
 	assert!(
@@ -263,7 +263,7 @@ fn build_g_parts<F: BinaryField, P: PackedField<Scalar = F>>(
 #[instrument(skip_all, name = "build_multilinear_parts")]
 fn build_multilinear_parts<P: PackedField>(
 	multilinears: &[P],
-) -> Result<[FieldBuffer<P>; SHIFT_VARIANT_COUNT], Error> {
+) -> Result<[FieldBuffer<P>; SHIFT_VARIANT_COUNT], ShiftError> {
 	assert!(
 		P::LOG_WIDTH < LOG_LEN,
 		"P::WIDTH is not supposed to exceed 8, so this statement must hold"

--- a/crates/prover/src/protocols/shift/phase_2.rs
+++ b/crates/prover/src/protocols/shift/phase_2.rs
@@ -8,7 +8,7 @@ use binius_verifier::{config::LOG_WORD_SIZE_BITS, protocols::sumcheck::SumcheckO
 use tracing::instrument;
 
 use super::{
-	error::Error, key_collection::KeyCollection, monster::build_monster_multilinear,
+	error::ShiftError, key_collection::KeyCollection, monster::build_monster_multilinear,
 	prove::PreparedOperatorData,
 };
 use crate::{
@@ -51,7 +51,7 @@ pub fn prove_phase_2<F, P: PackedField<Scalar = F>, Channel>(
 	intmul_data: &PreparedOperatorData<F>,
 	phase_1_output: SumcheckOutput<F>,
 	channel: &mut Channel,
-) -> Result<SumcheckOutput<F>, Error>
+) -> Result<SumcheckOutput<F>, ShiftError>
 where
 	F: BinaryField + From<AESTowerField8b>,
 	Channel: IPProverChannel<F>,
@@ -96,7 +96,7 @@ fn run_sumcheck<F: Field, P: PackedField<Scalar = F>, Channel: IPProverChannel<F
 	r_j: Vec<F>,
 	gamma: F,
 	channel: &mut Channel,
-) -> Result<SumcheckOutput<F>, Error> {
+) -> Result<SumcheckOutput<F>, ShiftError> {
 	#[cfg(debug_assertions)]
 	let cloned_r_j_witness_for_debugging = r_j_witness.clone();
 

--- a/crates/prover/src/protocols/shift/prove.rs
+++ b/crates/prover/src/protocols/shift/prove.rs
@@ -9,7 +9,8 @@ use binius_math::{
 use binius_verifier::protocols::sumcheck::SumcheckOutput;
 
 use super::{
-	error::Error, key_collection::KeyCollection, phase_1::prove_phase_1, phase_2::prove_phase_2,
+	error::ShiftError, key_collection::KeyCollection, phase_1::prove_phase_1,
+	phase_2::prove_phase_2,
 };
 
 /// Holds the prover data for an operator.
@@ -100,7 +101,7 @@ pub fn prove<F, P, Channel>(
 	bitand_data: OperatorData<F>,
 	intmul_data: OperatorData<F>,
 	channel: &mut Channel,
-) -> Result<SumcheckOutput<F>, Error>
+) -> Result<SumcheckOutput<F>, ShiftError>
 where
 	F: BinaryField + From<AESTowerField8b>,
 	P: PackedField<Scalar = F>,

--- a/crates/spartan-prover/src/error.rs
+++ b/crates/spartan-prover/src/error.rs
@@ -1,13 +1,17 @@
 // Copyright 2025 Irreducible Inc.
 
+use binius_iop_prover::basefold::BaseFoldError;
+use binius_ip_prover::sumcheck::SumcheckError;
+use binius_transcript::TranscriptError;
+
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
 	#[error("invalid argument {arg}: {msg}")]
 	ArgumentError { arg: String, msg: String },
 	#[error("basefold error: {0}")]
-	Basefold(#[from] binius_iop_prover::basefold::Error),
+	Basefold(#[from] BaseFoldError),
 	#[error("transcript error: {0}")]
-	Transcript(#[from] binius_transcript::Error),
+	Transcript(#[from] TranscriptError),
 	#[error("sumcheck error: {0}")]
-	Sumcheck(#[from] binius_ip_prover::sumcheck::Error),
+	Sumcheck(#[from] SumcheckError),
 }

--- a/crates/spartan-prover/src/wrapper/replay_channel.rs
+++ b/crates/spartan-prover/src/wrapper/replay_channel.rs
@@ -88,7 +88,7 @@ impl<'a, F: Field> ReplayChannel<'a, F> {
 impl<'a, F: Field> IPVerifierChannel<F> for ReplayChannel<'a, F> {
 	type Elem = CircuitElem<F, WitnessGenerator<'a, F>>;
 
-	fn recv_one(&mut self) -> Result<Self::Elem, binius_ip::channel::Error> {
+	fn recv_one(&mut self) -> Result<Self::Elem, binius_ip::channel::IPChannelError> {
 		let encrypted_elem = self.next_inout_elem();
 		let key = self.next_precommit_elem();
 		Ok(encrypted_elem + key)
@@ -102,7 +102,7 @@ impl<'a, F: Field> IPVerifierChannel<F> for ReplayChannel<'a, F> {
 		self.next_inout_elem()
 	}
 
-	fn assert_zero(&mut self, val: Self::Elem) -> Result<(), binius_ip::channel::Error> {
+	fn assert_zero(&mut self, val: Self::Elem) -> Result<(), binius_ip::channel::IPChannelError> {
 		match val {
 			// A compile-time constant is checked here; any other wire's value is checked by the
 			// witness generator, which records a constraint violation as a build error.
@@ -110,7 +110,7 @@ impl<'a, F: Field> IPVerifierChannel<F> for ReplayChannel<'a, F> {
 				if c == F::ZERO {
 					Ok(())
 				} else {
-					Err(binius_ip::channel::Error::InvalidAssert)
+					Err(binius_ip::channel::IPChannelError::InvalidAssert)
 				}
 			}
 			CircuitElem::Wire { builder, wire } => {
@@ -148,14 +148,14 @@ impl<'r, 'a, F: Field> IOPVerifierChannel<'r, F> for ReplayChannel<'a, F> {
 		&mut self,
 		_log_msg_len: usize,
 		_is_witness_dependent: bool,
-	) -> Result<Self::Oracle, binius_iop::channel::Error> {
+	) -> Result<Self::Oracle, binius_iop::channel::IOPChannelError> {
 		Ok(())
 	}
 
 	fn verify_oracle_relations(
 		&mut self,
 		oracle_relations: impl IntoIterator<Item = OracleLinearRelation<'r, Self::Oracle, Self::Elem>>,
-	) -> Result<(), binius_iop::channel::Error> {
+	) -> Result<(), binius_iop::channel::IOPChannelError> {
 		// For each oracle opening, the prover sends the decrypted evaluation. The outer verifier
 		// checks in the circuit equality of this value with the expected expression over encrypted
 		// values.

--- a/crates/spartan-verifier/src/lib.rs
+++ b/crates/spartan-verifier/src/lib.rs
@@ -38,17 +38,21 @@ use std::{rc::Rc, slice};
 use binius_field::{BinaryField, Field, field::FieldOps};
 use binius_hash::binary_merkle_tree::HashSuite;
 use binius_iop::{
-	basefold,
+	basefold::BaseFoldError,
 	basefold_compiler::BaseFoldVerifierCompiler,
-	channel::{IOPVerifierChannel, OracleLinearRelation, OracleSpec},
-	fri::{self, MinProofSizeStrategy},
+	channel::{IOPChannelError, IOPVerifierChannel, OracleLinearRelation, OracleSpec},
+	fri::{self, FriError, MinProofSizeStrategy},
 	merkle_tree::BinaryMerkleTreeScheme,
 	oracle_setup_channel::{DummyElem, OracleSetupChannel},
 };
-use binius_ip::{channel::IPVerifierChannel, mlecheck, sumcheck};
+use binius_ip::{
+	channel::{IPChannelError, IPVerifierChannel},
+	mlecheck,
+	sumcheck::SumcheckError,
+};
 use binius_math::{multilinear::eq::eq_ind_partial_eval_scalars, univariate::evaluate_univariate};
 use binius_spartan_frontend::constraint_system::{ConstraintSystem, WitnessSegment};
-use binius_transcript::{VerifierTranscript, fiat_shamir::Challenger};
+use binius_transcript::{TranscriptError, VerifierTranscript, fiat_shamir::Challenger};
 use binius_utils::{DeserializeBytes, checked_arithmetics::checked_log_2};
 use digest::Output;
 
@@ -400,17 +404,17 @@ fn mask_transparent<'a, F: Field, E: FieldOps + 'a>(
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
 	#[error("FRI error: {0}")]
-	FRI(#[from] fri::Error),
+	FRI(#[from] FriError),
 	#[error("Sumcheck error: {0}")]
-	Sumcheck(#[from] sumcheck::Error),
+	Sumcheck(#[from] SumcheckError),
 	#[error("BaseFold error: {0}")]
-	BaseFold(#[from] basefold::Error),
+	BaseFold(#[from] BaseFoldError),
 	#[error("Transcript error: {0}")]
-	Transcript(#[from] binius_transcript::Error),
+	Transcript(#[from] TranscriptError),
 	#[error("IOP channel error: {0}")]
-	IOPChannel(#[from] binius_iop::channel::Error),
+	IOPChannel(#[from] IOPChannelError),
 	#[error("IP channel error: {0}")]
-	IPChannel(#[from] binius_ip::channel::Error),
+	IPChannel(#[from] IPChannelError),
 	#[error("incorrect public inputs length: expected {expected}, got {actual}")]
 	IncorrectPublicInputLength { expected: usize, actual: usize },
 	#[error("incorrect reduction output of the multiplication check")]

--- a/crates/spartan-verifier/src/wrapper/builder_channel.rs
+++ b/crates/spartan-verifier/src/wrapper/builder_channel.rs
@@ -66,7 +66,7 @@ impl<F: Field> IronSpartanBuilderChannel<F> {
 impl<F: Field> IPVerifierChannel<F> for IronSpartanBuilderChannel<F> {
 	type Elem = CircuitElem<F, ConstraintBuilder<F>>;
 
-	fn recv_one(&mut self) -> Result<Self::Elem, binius_ip::channel::Error> {
+	fn recv_one(&mut self) -> Result<Self::Elem, binius_ip::channel::IPChannelError> {
 		// For each element that the inner prover sends, the wrapped prover allocates a one-time-pad
 		// encryption key in the precommit segment and encrypts the underlying value before sending.
 		// Here the verifier gets the encryption key from the precommit segment and decrypts.
@@ -83,7 +83,7 @@ impl<F: Field> IPVerifierChannel<F> for IronSpartanBuilderChannel<F> {
 		self.alloc_inout_elem()
 	}
 
-	fn assert_zero(&mut self, val: Self::Elem) -> Result<(), binius_ip::channel::Error> {
+	fn assert_zero(&mut self, val: Self::Elem) -> Result<(), binius_ip::channel::IPChannelError> {
 		match val {
 			// A compile-time constant is checked here; a non-zero one is an unsatisfiable
 			// assertion.
@@ -91,7 +91,7 @@ impl<F: Field> IPVerifierChannel<F> for IronSpartanBuilderChannel<F> {
 				if c == F::ZERO {
 					Ok(())
 				} else {
-					Err(binius_ip::channel::Error::InvalidAssert)
+					Err(binius_ip::channel::IPChannelError::InvalidAssert)
 				}
 			}
 			// Record the assertion as a constraint over the wire (whether public-derivable or
@@ -135,14 +135,14 @@ impl<'r, F: Field> IOPVerifierChannel<'r, F> for IronSpartanBuilderChannel<F> {
 		&mut self,
 		_log_msg_len: usize,
 		_is_witness_dependent: bool,
-	) -> Result<Self::Oracle, binius_iop::channel::Error> {
+	) -> Result<Self::Oracle, binius_iop::channel::IOPChannelError> {
 		Ok(())
 	}
 
 	fn verify_oracle_relations(
 		&mut self,
 		oracle_relations: impl IntoIterator<Item = OracleLinearRelation<'r, Self::Oracle, Self::Elem>>,
-	) -> Result<(), binius_iop::channel::Error> {
+	) -> Result<(), binius_iop::channel::IOPChannelError> {
 		// For each oracle opening, the prover sends the decrypted evaluation. The outer verifier
 		// checks in the circuit equality of this value with the expected expression over encrypted
 		// values.

--- a/crates/spartan-verifier/src/wrapper/zk_wrapped_channel.rs
+++ b/crates/spartan-verifier/src/wrapper/zk_wrapped_channel.rs
@@ -175,7 +175,7 @@ where
 {
 	type Elem = CircuitElem<F, InstanceGenerator<'a, F>>;
 
-	fn recv_one(&mut self) -> Result<Self::Elem, binius_ip::channel::Error> {
+	fn recv_one(&mut self) -> Result<Self::Elem, binius_ip::channel::IPChannelError> {
 		// Mirror `IronSpartanBuilderChannel::recv_one`'s shape: `inout - key`. The inout carries
 		// the encrypted F received from the inner channel (written into the public segment); the
 		// key is a precommit wire whose value the verifier does not know (`PublicWire(None)`).
@@ -197,7 +197,7 @@ where
 		self.alloc_inout_elem(elem)
 	}
 
-	fn assert_zero(&mut self, val: Self::Elem) -> Result<(), binius_ip::channel::Error> {
+	fn assert_zero(&mut self, val: Self::Elem) -> Result<(), binius_ip::channel::IPChannelError> {
 		match val {
 			// A compile-time constant is checked here; a non-zero one is an unsatisfiable
 			// assertion.
@@ -205,7 +205,7 @@ where
 				if c == F::ZERO {
 					Ok(())
 				} else {
-					Err(binius_ip::channel::Error::InvalidAssert)
+					Err(binius_ip::channel::IPChannelError::InvalidAssert)
 				}
 			}
 			// No-op for wires: the corresponding constraint was recorded symbolically and is
@@ -249,7 +249,7 @@ where
 		&mut self,
 		log_msg_len: usize,
 		is_witness_dependent: bool,
-	) -> Result<Self::Oracle, binius_iop::channel::Error> {
+	) -> Result<Self::Oracle, binius_iop::channel::IOPChannelError> {
 		assert!(
 			!self.remaining_oracle_specs().is_empty(),
 			"recv_oracle called but no remaining inner oracle specs"
@@ -261,7 +261,7 @@ where
 	fn verify_oracle_relations(
 		&mut self,
 		oracle_relations: impl IntoIterator<Item = OracleLinearRelation<'a, Self::Oracle, Self::Elem>>,
-	) -> Result<(), binius_iop::channel::Error> {
+	) -> Result<(), binius_iop::channel::IOPChannelError> {
 		let mut inner_relations = Vec::new();
 		for OracleLinearRelation {
 			oracle,

--- a/crates/transcript/src/error.rs
+++ b/crates/transcript/src/error.rs
@@ -1,7 +1,7 @@
 // Copyright 2024-2025 Irreducible Inc.
 
 #[derive(Debug, thiserror::Error)]
-pub enum Error {
+pub enum TranscriptError {
 	#[error("Transcript is not empty, {remaining} bytes")]
 	TranscriptNotEmpty { remaining: usize },
 	#[error("Not enough bytes in the buffer")]

--- a/crates/transcript/src/transcript.rs
+++ b/crates/transcript/src/transcript.rs
@@ -7,7 +7,7 @@ use binius_utils::{DeserializeBytes, SerializeBytes};
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 
 use super::{
-	error::Error,
+	error::TranscriptError,
 	fiat_shamir::{Challenger, FiatShamirBuf},
 };
 use crate::fiat_shamir::{CanSample, CanSampleBits, sample_bits_reader};
@@ -55,9 +55,9 @@ impl<Challenger_: Challenger> VerifierTranscript<Challenger_> {
 }
 
 impl<Challenger_: Challenger> VerifierTranscript<Challenger_> {
-	pub fn finalize(self) -> Result<(), Error> {
+	pub fn finalize(self) -> Result<(), TranscriptError> {
 		if self.combined.buffer.has_remaining() {
-			return Err(Error::TranscriptNotEmpty {
+			return Err(TranscriptError::TranscriptNotEmpty {
 				remaining: self.combined.buffer.remaining(),
 			});
 		}
@@ -146,33 +146,36 @@ impl<B: Buf> TranscriptReader<'_, B> {
 		self.buffer
 	}
 
-	pub fn read<T: DeserializeBytes>(&mut self) -> Result<T, Error> {
+	pub fn read<T: DeserializeBytes>(&mut self) -> Result<T, TranscriptError> {
 		T::deserialize(self.buffer()).map_err(Into::into)
 	}
 
-	pub fn read_vec<T: DeserializeBytes>(&mut self, n: usize) -> Result<Vec<T>, Error> {
+	pub fn read_vec<T: DeserializeBytes>(&mut self, n: usize) -> Result<Vec<T>, TranscriptError> {
 		let mut buffer = self.buffer();
 		repeat_with(move || T::deserialize(&mut buffer).map_err(Into::into))
 			.take(n)
 			.collect()
 	}
 
-	pub fn read_bytes(&mut self, buf: &mut [u8]) -> Result<(), Error> {
+	pub fn read_bytes(&mut self, buf: &mut [u8]) -> Result<(), TranscriptError> {
 		let buffer = self.buffer();
 		if buffer.remaining() < buf.len() {
-			return Err(Error::NotEnoughBytes);
+			return Err(TranscriptError::NotEnoughBytes);
 		}
 		buffer.copy_to_slice(buf);
 		Ok(())
 	}
 
-	pub fn read_scalar<F: Field>(&mut self) -> Result<F, Error> {
+	pub fn read_scalar<F: Field>(&mut self) -> Result<F, TranscriptError> {
 		let mut out = F::default();
 		self.read_scalar_slice_into(slice::from_mut(&mut out))?;
 		Ok(out)
 	}
 
-	pub fn read_scalar_slice_into<F: Field>(&mut self, buf: &mut [F]) -> Result<(), Error> {
+	pub fn read_scalar_slice_into<F: Field>(
+		&mut self,
+		buf: &mut [F],
+	) -> Result<(), TranscriptError> {
 		let mut buffer = self.buffer();
 		for elem in buf {
 			*elem = DeserializeBytes::deserialize(&mut buffer)?;
@@ -180,7 +183,7 @@ impl<B: Buf> TranscriptReader<'_, B> {
 		Ok(())
 	}
 
-	pub fn read_scalar_slice<F: Field>(&mut self, len: usize) -> Result<Vec<F>, Error> {
+	pub fn read_scalar_slice<F: Field>(&mut self, len: usize) -> Result<Vec<F>, TranscriptError> {
 		let mut elems = vec![F::default(); len];
 		self.read_scalar_slice_into(&mut elems)?;
 		Ok(elems)

--- a/crates/verifier/src/error.rs
+++ b/crates/verifier/src/error.rs
@@ -1,31 +1,31 @@
 // Copyright 2025 Irreducible Inc.
 
 use binius_core::ConstraintSystemError;
-use binius_iop::channel::Error as IOPChannelError;
-use binius_ip::channel::Error as ChannelError;
+use binius_iop::{channel::IOPChannelError, fri::FriError};
+use binius_ip::{channel::IPChannelError, sumcheck::SumcheckError};
+use binius_transcript::TranscriptError;
 
 use crate::{
-	fri,
-	protocols::{intmul, shift, sumcheck},
-	ring_switch,
+	protocols::{intmul::IntMulError, shift::ShiftError},
+	ring_switch::RingSwitchError,
 };
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
 	#[error("transcript error: {0}")]
-	Transcript(#[from] binius_transcript::Error),
+	Transcript(#[from] TranscriptError),
 	#[error("channel error: {0}")]
-	Channel(#[from] ChannelError),
+	Channel(#[from] IPChannelError),
 	#[error("IOP channel error: {0}")]
 	IOPChannel(#[from] IOPChannelError),
 	#[error("FRI error: {0}")]
-	FRI(#[from] fri::Error),
+	FRI(#[from] FriError),
 	#[error("ring switch error: {0}")]
-	RingSwitch(#[from] ring_switch::Error),
+	RingSwitch(#[from] RingSwitchError),
 	#[error("IntMul error: {0}")]
-	IntMul(#[from] intmul::Error),
+	IntMul(#[from] IntMulError),
 	#[error("sumcheck error: {0}")]
-	Sumcheck(#[from] sumcheck::Error),
+	Sumcheck(#[from] SumcheckError),
 	#[error("incorrect public inputs length: expected {expected}, got {actual}")]
 	IncorrectPublicInputLength { expected: usize, actual: usize },
 	#[error("constraint system error: {0}")]
@@ -33,7 +33,7 @@ pub enum Error {
 	#[error("invalid proof: {0}")]
 	Verification(#[from] VerificationError),
 	#[error("shift reduction error: {0}")]
-	ShiftReduction(#[from] shift::Error),
+	ShiftReduction(#[from] ShiftError),
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/verifier/src/protocols/intmul/error.rs
+++ b/crates/verifier/src/protocols/intmul/error.rs
@@ -1,15 +1,16 @@
 // Copyright 2025 Irreducible Inc.
 
-use binius_ip::channel::Error as ChannelError;
+use binius_ip::{channel::IPChannelError, sumcheck::SumcheckError};
+use binius_transcript::TranscriptError;
 
-use crate::protocols::{prodcheck::Error as ProdcheckError, sumcheck::Error as SumcheckError};
+use crate::protocols::prodcheck::ProdcheckError;
 
 #[derive(thiserror::Error, Debug)]
-pub enum Error {
+pub enum IntMulError {
 	#[error("transcript error")]
-	Transcript(#[from] binius_transcript::Error),
+	Transcript(#[from] TranscriptError),
 	#[error("channel error")]
-	Channel(#[from] ChannelError),
+	Channel(#[from] IPChannelError),
 	#[error("sumcheck verify error")]
 	SumcheckVerify(#[from] SumcheckError),
 	#[error("prodcheck verify error")]

--- a/crates/verifier/src/protocols/intmul/verify.rs
+++ b/crates/verifier/src/protocols/intmul/verify.rs
@@ -16,7 +16,7 @@ use super::{
 		IntMulOutput, Phase1Output, Phase2Output, Phase3Output, Phase4Output, frobenius_twist,
 		reconstruct_selecteds,
 	},
-	error::Error,
+	error::IntMulError,
 };
 use crate::protocols::{
 	prodcheck::{self, MultilinearEvalClaim},
@@ -32,7 +32,7 @@ fn verify_phase_1<F, C>(
 	initial_eval_point: &[C::Elem],
 	initial_b_eval: C::Elem,
 	channel: &mut C,
-) -> Result<Phase1Output<C::Elem>, Error>
+) -> Result<Phase1Output<C::Elem>, IntMulError>
 where
 	F: Field,
 	C: IPVerifierChannel<F>,
@@ -76,7 +76,7 @@ fn verify_phase_3<F, C>(
 	c_eval_point: &[C::Elem],
 	c_eval: C::Elem,
 	channel: &mut C,
-) -> Result<Phase3Output<C::Elem>, Error>
+) -> Result<Phase3Output<C::Elem>, IntMulError>
 where
 	F: Field,
 	C: IPVerifierChannel<F>,
@@ -170,7 +170,7 @@ fn verify_phase_4<F, C>(
 	gpow_c_lo_eval: C::Elem,
 	gpow_c_hi_eval: C::Elem,
 	channel: &mut C,
-) -> Result<Phase4Output<C::Elem>, Error>
+) -> Result<Phase4Output<C::Elem>, IntMulError>
 where
 	F: Field,
 	C: IPVerifierChannel<F>,
@@ -255,7 +255,7 @@ fn verify_phase_5<F, C>(
 	r_ib: &[C::Elem],
 	b_recomb: C::Elem,
 	channel: &mut C,
-) -> Result<IntMulOutput<C::Elem>, Error>
+) -> Result<IntMulOutput<C::Elem>, IntMulError>
 where
 	F: Field,
 	C: IPVerifierChannel<F>,
@@ -449,7 +449,7 @@ pub fn verify<F, C>(
 	log_bits: usize,
 	n_vars: usize,
 	channel: &mut C,
-) -> Result<IntMulOutput<C::Elem>, Error>
+) -> Result<IntMulOutput<C::Elem>, IntMulError>
 where
 	F: BinaryField,
 	C: IPVerifierChannel<F>,

--- a/crates/verifier/src/protocols/shift/error.rs
+++ b/crates/verifier/src/protocols/shift/error.rs
@@ -1,15 +1,16 @@
 // Copyright 2025 Irreducible Inc.
 
-use binius_ip::channel::Error as ChannelError;
+use binius_ip::{channel::IPChannelError, sumcheck::SumcheckError};
+use binius_transcript::TranscriptError;
 
 #[derive(thiserror::Error, Debug)]
-pub enum Error {
+pub enum ShiftError {
 	#[error("transcript error")]
-	Transcript(#[from] binius_transcript::Error),
+	Transcript(#[from] TranscriptError),
 	#[error("channel error")]
-	Channel(#[from] ChannelError),
+	Channel(#[from] IPChannelError),
 	#[error("sumcheck error")]
-	Sumcheck(#[from] crate::protocols::sumcheck::Error),
+	Sumcheck(#[from] SumcheckError),
 	#[error("verification failure")]
 	VerificationFailure,
 }

--- a/crates/verifier/src/protocols/shift/mod.rs
+++ b/crates/verifier/src/protocols/shift/mod.rs
@@ -11,5 +11,5 @@ pub use monster::*;
 mod error;
 mod verify;
 
-pub use error::Error;
+pub use error::ShiftError;
 pub use verify::{OperatorData, VerifyOutput, check_eval, verify};

--- a/crates/verifier/src/protocols/shift/monster.rs
+++ b/crates/verifier/src/protocols/shift/monster.rs
@@ -14,7 +14,7 @@ use binius_math::{
 
 use super::{
 	SHIFT_VARIANT_COUNT,
-	error::Error,
+	error::ShiftError,
 	shift_ind::{partial_eval_phi, partial_eval_sigmas, partial_eval_sigmas_transpose},
 };
 use crate::config::{LOG_WORD_SIZE_BITS, WORD_SIZE_BITS};
@@ -127,7 +127,7 @@ pub fn evaluate_monster_multilinear_for_operation<F, E>(
 	r_s: &[E],
 	r_y_tensor: &[E],
 	h_op_evals: &[E; SHIFT_VARIANT_COUNT],
-) -> Result<E, Error>
+) -> Result<E, ShiftError>
 where
 	F: BinaryField,
 	E: FieldOps<Scalar = F> + From<F>,

--- a/crates/verifier/src/protocols/shift/verify.rs
+++ b/crates/verifier/src/protocols/shift/verify.rs
@@ -15,7 +15,7 @@ use getset::Getters;
 use itertools::Itertools;
 
 use super::{
-	BITAND_ARITY, INTMUL_ARITY, error::Error, evaluate_h_op,
+	BITAND_ARITY, INTMUL_ARITY, error::ShiftError, evaluate_h_op,
 	evaluate_monster_multilinear_for_operation,
 };
 use crate::{
@@ -130,15 +130,15 @@ impl<F> VerifyOutput<F> {
 /// or an error if verification fails.
 ///
 /// # Errors
-/// - Returns `Error::VerificationFailure` if monster multilinear evaluations don't match expected
-///   values
+/// - Returns `ShiftError::VerificationFailure` if monster multilinear evaluations don't match
+///   expected values
 /// - Propagates sumcheck verification errors
 pub fn verify<F, C>(
 	constraint_system: &ConstraintSystem,
 	bitand_data: &OperatorData<C::Elem, BITAND_ARITY>,
 	intmul_data: &OperatorData<C::Elem, INTMUL_ARITY>,
 	channel: &mut C,
-) -> Result<VerifyOutput<C::Elem>, Error>
+) -> Result<VerifyOutput<C::Elem>, ShiftError>
 where
 	F: BinaryField,
 	C: IPVerifierChannel<F>,
@@ -205,7 +205,7 @@ where
 ///
 /// # Errors
 ///
-/// - `Error::VerificationFailure` if the evaluation equation doesn't hold
+/// - `ShiftError::VerificationFailure` if the evaluation equation doesn't hold
 /// - Propagates errors from monster multilinear evaluation
 pub fn check_eval<F, C>(
 	constraint_system: &ConstraintSystem,
@@ -215,7 +215,7 @@ pub fn check_eval<F, C>(
 	r_zhat_prime: C::Elem,
 	output: &VerifyOutput<C::Elem>,
 	channel: &mut C,
-) -> Result<(), Error>
+) -> Result<(), ShiftError>
 where
 	F: BinaryField,
 	C: IPVerifierChannel<F>,

--- a/crates/verifier/src/ring_switch.rs
+++ b/crates/verifier/src/ring_switch.rs
@@ -3,7 +3,7 @@
 use std::iter;
 
 use binius_field::{BinaryField, ExtensionField, FieldOps, PackedField};
-use binius_ip::channel::IPVerifierChannel;
+use binius_ip::channel::{IPChannelError, IPVerifierChannel};
 use binius_math::{
 	multilinear::{eq::eq_ind_partial_eval_scalars, evaluate::evaluate_inplace_scalars},
 	tensor_algebra::TensorAlgebra,
@@ -12,9 +12,9 @@ use binius_math::{
 use crate::config::B1;
 
 #[derive(Debug, thiserror::Error)]
-pub enum Error {
+pub enum RingSwitchError {
 	#[error("channel: {0}")]
-	Channel(#[from] binius_ip::channel::Error),
+	Channel(#[from] IPChannelError),
 }
 
 /// Output of ring-switching verification.
@@ -49,7 +49,7 @@ pub fn verify<F, C>(
 	evaluation_claim: C::Elem,
 	eval_point: &[C::Elem],
 	channel: &mut C,
-) -> Result<RingSwitchVerifyOutput<C::Elem>, Error>
+) -> Result<RingSwitchVerifyOutput<C::Elem>, RingSwitchError>
 where
 	F: BinaryField + PackedField<Scalar = F>,
 	C: IPVerifierChannel<F>,


### PR DESCRIPTION
@jimpo Just a proposal to try to remove the import aliases and be a bit more descriptive in error namings! Don't hesitate to close if you don't like!

Gives every protocol module's error type a unique name, so call sites stop aliasing them on import.

Pure refactor — names and imports only, no behavior change.

### The problem

Every protocol module named its error type plain `Error`.

So any file that touched two of them had to alias on import:

```rust
use crate::protocols::{
    prodcheck::Error as ProdcheckError,
    sumcheck::Error as SumcheckError,
};
```

Two costs:

- The `as XxxError` aliases were noise, repeated everywhere two errors met.
- Inline paths in variants — `Sumcheck(#[from] sumcheck::Error)` — hid where a type actually lived.

### The idea

Give each module's error (and its `VerificationError` sibling, where it has one) a name that stands on its own.

Then no alias is ever needed, and every reference imports the bare type at the top of the file.

| module | error | verification error |
|---|---|---|
| `sumcheck` | `SumcheckError` | `SumcheckVerificationError` |
| `prodcheck` | `ProdcheckError` | `ProdcheckVerificationError` |
| `fracaddcheck` | `FracAddCheckError` | `FracAddCheckVerificationError` |
| `logup_star` | `LogupStarError` | `LogupStarVerificationError` |
| `basefold` | `BaseFoldError` | `BaseFoldVerificationError` |
| `fri` | `FriError` | `FriVerificationError` |
| `fri::batch` | `BatchFriError` | — |
| `merkle_tree` | `MerkleTreeError` | `MerkleTreeVerificationError` |
| `channel` (ip / iop) | `IPChannelError` / `IOPChannelError` | — |
| `transcript` | `TranscriptError` | — |
| `intmul` / `shift` | `IntMulError` / `ShiftError` | — |
| `ring_switch` | `RingSwitchError` | — |

### The change

```diff
- use crate::protocols::{prodcheck::Error as ProdcheckError, sumcheck::Error as SumcheckError};
+ use crate::protocols::{prodcheck::ProdcheckError, sumcheck::SumcheckError};
```

Inline module-qualified paths in variants are hoisted to a top import and used bare:

```diff
- Sumcheck(#[from] sumcheck::SumcheckError),
+ Sumcheck(#[from] SumcheckError),   // with `use ...::sumcheck::SumcheckError;` at the top
```

### Scope

- **renamed:** the error enums listed above, in `binius-ip`, `binius-iop`, `binius-ip-prover`, `binius-iop-prover`, `binius-transcript`, and the `intmul` / `shift` / `ring_switch` modules of `binius-prover` and `binius-verifier`.
- **updated:** every reference across the workspace — imports hoisted to the top, aliases dropped, bare names in variants.
- **left as `Error`:** the crate-root errors (`binius_prover::Error`, `binius_verifier::Error`, the spartan crate errors, `zk_config`). Each is its crate's single top-level error and is never imported next to a sibling, so it needs no disambiguating name.

### Verification

- `cargo build --workspace --all-targets` — clean
- `cargo clippy --workspace --all-targets` — clean (no unused imports)
- `cargo +nightly fmt --all` — clean
- `cargo test` across the touched crates (ip, iop, ip-prover, iop-prover, prover, verifier, spartan-prover, spartan-verifier, m4-prover, m4-verifier) — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)