### PR TITLE
BINIUS-198: remove redundant c_root from intmul Witness

### DIFF
--- a/crates/prover/benches/intmul.rs
+++ b/crates/prover/benches/intmul.rs
@@ -126,9 +126,9 @@ fn bench_intmul_phases(c: &mut Criterion) {
 	// only clone the datastructures a phase consumes by value. The specific transcript challenges
 	// do not affect the work a phase performs, so a throwaway transcript (and a random initial
 	// evaluation point) is sufficient.
-	let n_vars = witness.c_root.log_len();
+	let n_vars = witness.b_root.log_len();
 	let initial_eval_point = random_scalars::<F>(&mut rand::rng(), n_vars);
-	let exp_eval = evaluate(&witness.c_root, &initial_eval_point);
+	let exp_eval = evaluate(&witness.b_root, &initial_eval_point);
 
 	let phase1 = {
 		let mut transcript = ProverTranscript::new(StdChallenger::default());
@@ -301,9 +301,9 @@ fn bench_intmul_components(c: &mut Criterion) {
 	// the per-iteration setup only clones what `SelectorMlecheckProver::new` consumes. `Word` is
 	// `repr(transparent)` over `u64`, so the exponent bitmasks reinterpret the slice in place.
 	let b_bitmasks: &[u64] = bytemuck::cast_slice(witness.b_exponents);
-	let n_vars = witness.c_root.log_len();
+	let n_vars = witness.b_root.log_len();
 	let initial_eval_point = random_scalars::<F>(&mut rand::rng(), n_vars);
-	let exp_eval = evaluate(&witness.c_root, &initial_eval_point);
+	let exp_eval = evaluate(&witness.b_root, &initial_eval_point);
 	let phase1 = {
 		let mut transcript = ProverTranscript::new(StdChallenger::default());
 		let mut prover = IntMulProver::<P, _>::new(0, &mut transcript);

--- a/crates/prover/src/protocols/intmul/prove.rs
+++ b/crates/prover/src/protocols/intmul/prove.rs
@@ -23,7 +23,7 @@ use binius_math::{
 	inner_product::inner_product_buffers,
 	multilinear::{
 		eq::{eq_ind_partial_eval, eq_ind_partial_eval_scalars},
-		evaluate::evaluate,
+		evaluate::{evaluate, evaluate_inplace},
 	},
 };
 use binius_utils::{checked_arithmetics::log2_ceil_usize, rayon::prelude::*};
@@ -97,21 +97,23 @@ where
 			b_exponents,
 			b_leaves,
 			b_prodcheck,
-			b_root: _,
+			b_root,
 			c_lo_exponents,
 			c_lo_prodcheck,
 			c_lo_root,
 			c_hi_prodcheck,
 			c_hi_root,
-			c_root,
 		} = witness;
 
-		let n_vars = c_root.log_len();
+		// `b_root` (the variable-base `b`-exponent tree root) equals the full product `c` root, so
+		// it serves as the MLE root that opens the protocol.
+		let n_vars = b_root.log_len();
 		assert!(log_bits >= 1);
 
 		let initial_eval_point = self.channel.sample_many(n_vars);
 
-		let exp_eval = evaluate(&c_root, &initial_eval_point);
+		// `b_root` is not needed after this, so fold it in place rather than allocating a copy.
+		let exp_eval = evaluate_inplace(b_root, &initial_eval_point);
 
 		self.channel.send_one(exp_eval);
 

--- a/crates/prover/src/protocols/intmul/witness.rs
+++ b/crates/prover/src/protocols/intmul/witness.rs
@@ -67,8 +67,6 @@ pub struct Witness<'a, P: PackedField> {
 	pub c_hi_prodcheck: ProdcheckProver<P>,
 	/// The root of the `c_hi` tree.
 	pub c_hi_root: FieldBuffer<P>,
-	/// The root of a `log_bits + 1` deep tree of the full product `c` (`c_lo_root * c_hi_root`).
-	pub c_root: FieldBuffer<P>,
 }
 
 impl<'a, F, P> Witness<'a, P>
@@ -122,9 +120,6 @@ where
 		// Create the prodcheck prover; its products layer becomes b_root
 		let (b_prodcheck, b_root) = ProdcheckProver::new(log_bits, b_leaves.clone());
 
-		// The root of a `log_bits + 1` deep tree of the full product `c`.
-		let c_root = buffer_bivariate_product(&c_lo_root, &c_hi_root);
-
 		Ok(Self {
 			log_bits,
 			a_exponents: a,
@@ -139,7 +134,6 @@ where
 			c_lo_root,
 			c_hi_prodcheck,
 			c_hi_root,
-			c_root,
 		})
 	}
 }
@@ -324,9 +318,11 @@ mod tests {
 	const LOG_BITS: usize = 6;
 
 	fn check_consistency<P: PackedField>(witness: &Witness<'_, P>) {
-		let b_root = witness.b_root();
-		let c_root = witness.c_root();
-		assert_eq!(b_root, c_root);
+		// The variable-base `b`-exponent tree root must equal the full product `c` root
+		// (`c_lo_root * c_hi_root`); this equality is what lets the prover reuse `b_root` in place
+		// of a separately stored `c_root`.
+		let c_root = buffer_bivariate_product(witness.c_lo_root(), witness.c_hi_root());
+		assert_eq!(witness.b_root(), &c_root);
 	}
 
 	#[test]


### PR DESCRIPTION
Closes [BINIUS-198](https://linear.app/jimpo/issue/BINIUS-198/remove-c-root-from-intmul-witness).

The intmul `Witness` stored a `c_root` field (the full product `c` root, computed as `c_lo_root * c_hi_root`). It was only used to open the protocol as the MLE root — but that value equals `b_root`, the root of the variable-base `b`-exponent tree (the protocol proves exactly `(G^a)^b = G^{c_lo} · (G^{2^{2^m}})^{c_hi}`, so the two roots coincide). So `c_root` is redundant.

This removes the field and its `buffer_bivariate_product(c_lo_root, c_hi_root)` computation in `Witness::new`, and switches `prove` (and the phase benchmarks) to use `b_root` — which was already destructured-and-discarded (`b_root: _`) — as the MLE root. Transcript-identical: `exp_eval` is computed from a buffer equal to the old `c_root`.

The `check_consistency` test previously asserted `b_root == c_root` by reading the field; it now recomputes `c_root` from `c_lo_root`/`c_hi_root` and asserts the same equality, so the invariant that justifies the removal is still checked.

Verified: `cargo test -p binius-core -p binius-prover -p binius-verifier` (incl. `prove_and_verify`), `cargo build --workspace --tests --benches`, clippy `-D warnings`, nightly fmt, and rust-doc all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)