### PR TITLE
BINIUS-200: commit the logUp* pushforward via an IOP channel

### DIFF
--- a/crates/iop-prover/src/lib.rs
+++ b/crates/iop-prover/src/lib.rs
@@ -30,5 +30,6 @@ pub mod basefold_channel;
 pub mod basefold_compiler;
 pub mod channel;
 pub mod fri;
+pub mod logup_star;
 pub mod merkle_tree;
 pub mod naive_channel;

--- a/crates/iop-prover/src/logup_star.rs
+++ b/crates/iop-prover/src/logup_star.rs
@@ -1,0 +1,402 @@
+// Copyright 2026 The Binius Developers
+
+//! logUp* proving with the pushforward committed as an oracle.
+//!
+//! The bare reduction returns a claimed evaluation of the pushforward `Y = I_* eq_r`.
+//! It commits nothing, so that claim cannot be checked on its own.
+//! This layer commits `Y` over the IOP channel and returns the relation that opens it.
+//!
+//! The commit precedes the reduction, so the logUp challenge binds the committed `Y`.
+//! The table `T` and index `I` stay the caller's oracles, so their claims are returned unchanged.
+//! `Y` is the only oracle this protocol introduces, per [Soukhanov25, Section 3].
+//!
+//! [Soukhanov25]: <https://eprint.iacr.org/2025/946>
+
+use binius_field::{BinaryField1b, ExtensionField, Field, PackedField};
+use binius_ip_prover::logup_star::{self as reduction, witness};
+use binius_math::{FieldBuffer, multilinear::eq::eq_ind_partial_eval};
+
+use crate::channel::IOPProverChannel;
+
+/// An error raised while proving a committed logUp* reduction.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+	/// The underlying logUp* reduction failed.
+	#[error("logUp* reduction error: {0}")]
+	Reduction(#[from] reduction::Error),
+}
+
+/// The pushforward oracle relation produced by the prover.
+///
+/// The four fields match the oracle-relation tuple the prover channel opens.
+/// The caller batches this with the table and index openings into one channel open.
+pub struct PushforwardRelation<P: PackedField, Oracle> {
+	/// The handle of the committed pushforward oracle.
+	pub oracle: Oracle,
+	/// The committed message, the pushforward `Y` over the `m`-variable cube.
+	pub message: FieldBuffer<P>,
+	/// The transparent polynomial, the equality indicator at the reduced table point.
+	pub transparent: FieldBuffer<P>,
+	/// The inner-product claim, the pushforward evaluation `Y(table_eval_point)`.
+	pub claim: P::Scalar,
+}
+
+/// The reduced claims of a committed logUp* proof.
+///
+/// The table and index claims are left for the caller to open against its own commitments.
+/// The pushforward claim is packaged as an oracle relation against the commitment sent here.
+pub struct LogupProof<P: PackedField, Oracle> {
+	/// The `m`-coordinate point shared by the table and pushforward claims.
+	pub table_eval_point: Vec<P::Scalar>,
+	/// The claimed evaluation of the table `T` at the point.
+	pub table_eval_claim: P::Scalar,
+	/// The `n`-coordinate point of the index claim.
+	pub index_eval_point: Vec<P::Scalar>,
+	/// The claimed evaluation of the embedded index column at its point.
+	pub index_eval_claim: P::Scalar,
+	/// The oracle relation that opens the pushforward at the reduced point.
+	pub pushforward: PushforwardRelation<P, Oracle>,
+}
+
+/// Prove a logUp* reduction whose pushforward is committed as an oracle.
+///
+/// This wraps [`binius_ip_prover::logup_star::prove`] with the pushforward commitment.
+/// It builds the pushforward `Y` once, commits it, then runs the reduction over that same buffer.
+/// Committing before the reduction binds `Y` into the logUp challenge.
+///
+/// The returned relation asserts `<Y, eq_r'> = Y(r')` at the reduced table point `r'`.
+/// The caller batches this relation with the table and index openings into one channel open.
+///
+/// # Arguments
+///
+/// * `table` - The table multilinear `T` over `m` variables (`2^m` entries).
+/// * `index` - The index column, one table position per looker row, of length `2^n`.
+/// * `eval_point` - The `n`-coordinate evaluation point `r`.
+/// * `eval_claim` - The claimed evaluation `e = (I^* T)(eval_point)`.
+/// * `channel` - The IOP prover channel, whose next oracle has message length `2^m`.
+///
+/// # Preconditions
+///
+/// - The table has at least one variable.
+/// - Every index entry is less than `2^m`.
+pub fn prove<F, P, Channel>(
+	table: &FieldBuffer<P>,
+	index: &[usize],
+	eval_point: &[F],
+	eval_claim: F,
+	channel: &mut Channel,
+) -> Result<LogupProof<P, Channel::Oracle>, Error>
+where
+	F: Field + ExtensionField<BinaryField1b>,
+	P: PackedField<Scalar = F>,
+	Channel: IOPProverChannel<P>,
+{
+	let m = table.log_len();
+
+	// Build the two witnesses that do not depend on the logUp challenge c.
+	//
+	//     eq_r = eq(eval_point, .)     the looker numerator
+	//     Y    = I_* eq_r              the pushforward, scattered onto table positions
+	let eq_r = witness::equality_indicator::<F, P>(eval_point);
+	let pushforward = witness::pushforward::<F, P>(&eq_r, index, m);
+
+	// Commit Y before the reduction, so the logUp challenge binds the commitment.
+	let oracle = channel.send_oracle(pushforward.to_ref());
+
+	// Run the reduction over the committed Y and the shared eq_r, viewing the channel as IP.
+	let output = reduction::prove_reduction(table, index, eval_claim, eq_r, &pushforward, channel)?;
+
+	// The pushforward relation opens Y at the reduced point.
+	//
+	//     <Y, eq_r'> = Y(r') = pushforward_eval_claim
+	let transparent = eq_ind_partial_eval::<P>(&output.table_eval_point);
+
+	Ok(LogupProof {
+		table_eval_point: output.table_eval_point,
+		table_eval_claim: output.table_eval_claim,
+		index_eval_point: output.index_eval_point,
+		index_eval_claim: output.index_eval_claim,
+		pushforward: PushforwardRelation {
+			oracle,
+			message: pushforward,
+			transparent,
+			claim: output.pushforward_eval_claim,
+		},
+	})
+}
+
+#[cfg(test)]
+mod tests {
+	use binius_field::{
+		BinaryField1b, ExtensionField, Field,
+		arch::{OptimalB128, OptimalPackedB128},
+	};
+	use binius_iop::{
+		channel::{IOPVerifierChannel, OracleSpec},
+		logup_star as verify_logup,
+		naive_channel::NaiveVerifierChannel,
+	};
+	use binius_math::{
+		FieldBuffer,
+		multilinear::{eq::eq_ind_partial_eval_scalars, evaluate::evaluate},
+		test_utils::{random_field_buffer, random_scalars},
+	};
+	use binius_transcript::{ProverTranscript, fiat_shamir::HasherChallenger};
+	use rand::prelude::*;
+
+	use super::*;
+	use crate::{channel::IOPProverChannel, naive_channel::NaiveProverChannel};
+
+	type F = OptimalB128;
+	type P = OptimalPackedB128;
+	type StdChallenger = HasherChallenger<sha2::Sha256>;
+
+	// Embed a table position j into the field through the GF(2)-linear basis, as the protocol does.
+	//
+	//     iota(j) = sum_{t : bit t of j is set} basis(t)
+	fn iota<E: Field + ExtensionField<BinaryField1b>>(j: usize, m: usize) -> E {
+		(0..m)
+			.filter(|t| (j >> t) & 1 == 1)
+			.map(<E as ExtensionField<BinaryField1b>>::basis)
+			.fold(E::ZERO, |acc, b| acc + b)
+	}
+
+	// Build a random instance and return (table, index, eval_point, eq_r scalars, true eval claim).
+	fn random_instance<E, Q>(
+		rng: &mut StdRng,
+		n: usize,
+		m: usize,
+	) -> (FieldBuffer<Q>, Vec<usize>, Vec<E>, Vec<E>, E)
+	where
+		E: Field,
+		Q: PackedField<Scalar = E>,
+	{
+		let table = random_field_buffer::<Q>(&mut *rng, m);
+		let index = (0..(1usize << n))
+			.map(|_| rng.random_range(0..(1usize << m)))
+			.collect::<Vec<_>>();
+		let eval_point = random_scalars::<E>(&mut *rng, n);
+
+		// The looked-up evaluation: e = (I^* T)(r) = sum_i eq_r(i) * T[index[i]].
+		let eq_r = eq_ind_partial_eval_scalars::<E>(&eval_point);
+		let eval_claim = index
+			.iter()
+			.zip(&eq_r)
+			.map(|(&j, &eq)| eq * table.get(j))
+			.fold(E::ZERO, |acc, t| acc + t);
+
+		(table, index, eval_point, eq_r, eval_claim)
+	}
+
+	fn check_prove_verify(n: usize, m: usize, seed: u64) {
+		let mut rng = StdRng::seed_from_u64(seed);
+		let (table, index, eval_point, eq_r, eval_claim) = random_instance::<F, P>(&mut rng, n, m);
+
+		// The one oracle is the pushforward Y, of message length 2^m.
+		let specs = vec![OracleSpec::new(m)];
+
+		// Prove: commit Y, run the reduction, then open Y as the caller would.
+		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
+		let mut prover_channel =
+			NaiveProverChannel::<F, _>::new(&mut prover_transcript, specs.clone());
+		let prover_proof =
+			prove::<F, P, _>(&table, &index, &eval_point, eval_claim, &mut prover_channel)
+				.expect("proving succeeds");
+
+		let PushforwardRelation {
+			oracle,
+			message,
+			transparent,
+			claim: pushforward_claim,
+		} = prover_proof.pushforward;
+		prover_channel.prove_oracle_relations([(oracle, message, transparent, pushforward_claim)]);
+		prover_channel.finish();
+
+		// Verify: receive Y, run the reduction, then open the pushforward relation.
+		let mut verifier_transcript = prover_transcript.into_verifier();
+		let mut verifier_channel =
+			NaiveVerifierChannel::<F, _>::new(&mut verifier_transcript, &specs);
+		let verifier_proof =
+			verify_logup::verify(m, eval_claim, &eval_point, &mut verifier_channel)
+				.expect("verification succeeds");
+		let verifier_pushforward_claim = verifier_proof.pushforward.claim;
+		verifier_channel
+			.verify_oracle_relations([verifier_proof.pushforward])
+			.expect("the pushforward opening verifies");
+		verifier_channel.finish();
+
+		// The prover and verifier must derive identical reduced claims from the same transcript.
+		assert_eq!(prover_proof.table_eval_point, verifier_proof.table_eval_point, "table point");
+		assert_eq!(prover_proof.table_eval_claim, verifier_proof.table_eval_claim, "table claim");
+		assert_eq!(prover_proof.index_eval_point, verifier_proof.index_eval_point, "index point");
+		assert_eq!(prover_proof.index_eval_claim, verifier_proof.index_eval_claim, "index claim");
+		assert_eq!(pushforward_claim, verifier_pushforward_claim, "pushforward claim");
+
+		// The reduced table claim is the honest evaluation of T at the reduced point.
+		assert_eq!(
+			prover_proof.table_eval_claim,
+			evaluate(&table, &prover_proof.table_eval_point),
+			"table claim wrong (n={n}, m={m})"
+		);
+
+		// The pushforward claim is the honest evaluation of Y = I_* eq_r at the same point.
+		let mut pushforward = vec![F::ZERO; 1usize << m];
+		for (&j, &eq) in index.iter().zip(&eq_r) {
+			pushforward[j] += eq;
+		}
+		let pushforward = FieldBuffer::<P>::from_values(&pushforward);
+		assert_eq!(
+			pushforward_claim,
+			evaluate(&pushforward, &prover_proof.table_eval_point),
+			"pushforward claim wrong (n={n}, m={m})"
+		);
+
+		// The index claim is the honest evaluation of the embedded index column.
+		let index_embedded = index.iter().map(|&j| iota::<F>(j, m)).collect::<Vec<_>>();
+		let index_embedded = FieldBuffer::<P>::from_values(&index_embedded);
+		assert_eq!(
+			prover_proof.index_eval_claim,
+			evaluate(&index_embedded, &prover_proof.index_eval_point),
+			"index claim wrong (n={n}, m={m})"
+		);
+	}
+
+	#[test]
+	fn test_prove_verify_round_trip() {
+		// A spread of shapes: m << n (the target regime), m == n, and a wide table.
+		for (n, m) in [(6, 2), (5, 3), (4, 4), (3, 5), (7, 1)] {
+			check_prove_verify(n, m, 0);
+		}
+	}
+
+	#[test]
+	fn test_prove_verify_single_table_variable() {
+		// m = 1 exercises the batched final layer with an empty layer-1 point.
+		check_prove_verify(4, 1, 1);
+	}
+
+	#[test]
+	fn test_verifier_rejects_wrong_eval_claim() {
+		let mut rng = StdRng::seed_from_u64(3);
+		let (table, index, eval_point, _eq_r, eval_claim) = random_instance::<F, P>(&mut rng, 5, 3);
+		let specs = vec![OracleSpec::new(3)];
+
+		// Prove a false statement by perturbing the looked-up evaluation.
+		let wrong_claim = eval_claim + F::ONE;
+		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
+		let mut prover_channel =
+			NaiveProverChannel::<F, _>::new(&mut prover_transcript, specs.clone());
+		let prover_proof =
+			prove::<F, P, _>(&table, &index, &eval_point, wrong_claim, &mut prover_channel)
+				.expect("proving a false claim still produces a transcript");
+		let PushforwardRelation {
+			oracle,
+			message,
+			transparent,
+			claim,
+		} = prover_proof.pushforward;
+		prover_channel.prove_oracle_relations([(oracle, message, transparent, claim)]);
+		prover_channel.finish();
+
+		// The reduction's product check must surface the inconsistency as a verification failure.
+		let mut verifier_transcript = prover_transcript.into_verifier();
+		let mut verifier_channel =
+			NaiveVerifierChannel::<F, _>::new(&mut verifier_transcript, &specs);
+		let result = verify_logup::verify(3, wrong_claim, &eval_point, &mut verifier_channel);
+		assert!(result.is_err(), "verifier must reject a wrong eval claim");
+	}
+
+	#[test]
+	fn test_basefold_round_trip() {
+		use binius_field::PackedBinaryGhash1x128b;
+		use binius_hash::{StdDigest, StdHashSuite};
+		use binius_iop::{basefold_compiler::BaseFoldVerifierCompiler, fri::MinProofSizeStrategy};
+		use binius_math::ntt::{NeighborsLastSingleThread, domain_context::GenericOnTheFly};
+
+		use crate::{
+			basefold_compiler::BaseFoldProverCompiler, merkle_tree::prover::BinaryMerkleTreeProver,
+		};
+
+		// The commitment field is the GHASH 128-bit field; use a single-lane packing for BaseFold.
+		type BP = PackedBinaryGhash1x128b;
+		type Chal = HasherChallenger<StdDigest>;
+
+		let (n, m) = (6, 2);
+		let mut rng = StdRng::seed_from_u64(7);
+		let (table, index, eval_point, eq_r, eval_claim) = random_instance::<F, BP>(&mut rng, n, m);
+
+		// One witness-dependent (ZK) oracle: the pushforward Y, with 2^m entries.
+		const LOG_INV_RATE: usize = 1;
+		const SECURITY_BITS: usize = 32;
+		let n_test_queries = SECURITY_BITS.div_ceil(LOG_INV_RATE);
+		let oracle_specs = vec![OracleSpec::new_zk(m)];
+
+		let merkle_prover = BinaryMerkleTreeProver::<F, StdHashSuite>::new();
+		let verifier_compiler = BaseFoldVerifierCompiler::new(
+			merkle_prover.scheme().clone(),
+			oracle_specs,
+			LOG_INV_RATE,
+			n_test_queries,
+			&MinProofSizeStrategy,
+		);
+
+		// Prove: commit Y with real FRI, run the reduction, open the pushforward.
+		let domain_context =
+			GenericOnTheFly::generate_from_subspace(verifier_compiler.max_subspace());
+		let ntt = NeighborsLastSingleThread::new(domain_context);
+		let prover_compiler = BaseFoldProverCompiler::<BP, _, _>::from_verifier_compiler(
+			&verifier_compiler,
+			ntt,
+			merkle_prover,
+		);
+
+		let mut prover_transcript = ProverTranscript::new(Chal::default());
+		let prover_channel_rng = StdRng::seed_from_u64(8);
+		let mut prover_channel =
+			prover_compiler.create_channel(&mut prover_transcript, prover_channel_rng);
+
+		let prover_proof =
+			prove::<F, BP, _>(&table, &index, &eval_point, eval_claim, &mut prover_channel)
+				.expect("proving succeeds");
+		let PushforwardRelation {
+			oracle,
+			message,
+			transparent,
+			claim,
+		} = prover_proof.pushforward;
+		prover_channel.prove_oracle_relations([(oracle, message, transparent, claim)]);
+		prover_channel.finish();
+
+		// Verify: receive Y, run the reduction, open the pushforward through the real FRI check.
+		let mut verifier_transcript = prover_transcript.into_verifier();
+		let mut verifier_channel = verifier_compiler.create_channel(&mut verifier_transcript);
+		let verifier_proof =
+			verify_logup::verify(m, eval_claim, &eval_point, &mut verifier_channel)
+				.expect("verification succeeds");
+		verifier_channel
+			.verify_oracle_relations([verifier_proof.pushforward])
+			.expect("the FRI pushforward opening verifies");
+		verifier_channel
+			.finish()
+			.expect("the batched FRI opening verifies");
+
+		// The FRI opening already bound Y to its claim.
+		// Cross-check the table and index claims against honest values.
+		assert_eq!(prover_proof.table_eval_point, verifier_proof.table_eval_point);
+		assert_eq!(prover_proof.table_eval_claim, verifier_proof.table_eval_claim);
+		assert_eq!(prover_proof.index_eval_claim, verifier_proof.index_eval_claim);
+		assert_eq!(
+			prover_proof.table_eval_claim,
+			evaluate(&table, &prover_proof.table_eval_point),
+			"table claim must be the honest table evaluation"
+		);
+
+		// The pushforward claim is the honest evaluation of Y = I_* eq_r at the reduced point.
+		let mut pushforward = vec![F::ZERO; 1usize << m];
+		for (&j, &eq) in index.iter().zip(&eq_r) {
+			pushforward[j] += eq;
+		}
+		let pushforward = FieldBuffer::<BP>::from_values(&pushforward);
+		assert_eq!(claim, evaluate(&pushforward, &prover_proof.table_eval_point));
+	}
+}

--- a/crates/iop/src/lib.rs
+++ b/crates/iop/src/lib.rs
@@ -30,6 +30,7 @@ pub mod basefold_channel;
 pub mod basefold_compiler;
 pub mod channel;
 pub mod fri;
+pub mod logup_star;
 pub mod merkle_tree;
 pub mod naive_channel;
 pub mod oracle_setup_channel;

--- a/crates/iop/src/logup_star.rs
+++ b/crates/iop/src/logup_star.rs
@@ -1,0 +1,107 @@
+// Copyright 2026 The Binius Developers
+
+//! logUp* verification with the pushforward committed as an oracle.
+//!
+//! The bare reduction returns a claimed evaluation of the pushforward `Y = I_* eq_r`.
+//! It never binds `Y` to a commitment, so that claim cannot be checked on its own.
+//! This layer receives the `Y` oracle over the IOP channel and returns the relation that opens it.
+//!
+//! The receive precedes the reduction, so the logUp challenge binds the received `Y`.
+//! The table `T` and index `I` stay the caller's oracles, so their claims are returned unchanged.
+//! `Y` is the only oracle this protocol introduces, per [Soukhanov25, Section 3].
+//!
+//! [Soukhanov25]: <https://eprint.iacr.org/2025/946>
+
+use binius_field::{BinaryField1b, ExtensionField, Field};
+use binius_ip::logup_star as reduction;
+use binius_math::multilinear::eq::eq_ind;
+
+use crate::channel::{Error as ChannelError, IOPVerifierChannel, OracleLinearRelation};
+
+/// An error raised while verifying a committed logUp* reduction.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+	/// The underlying logUp* reduction failed.
+	#[error("logUp* reduction error: {0}")]
+	Reduction(#[from] reduction::Error),
+	/// Receiving the pushforward oracle commitment failed.
+	#[error("IOP channel error: {0}")]
+	Channel(#[from] ChannelError),
+}
+
+/// The reduced claims of a committed logUp* verification.
+///
+/// The table and index claims are left for the caller to open against its own commitments.
+/// The pushforward claim is packaged as an oracle relation against the commitment received here.
+pub struct LogupProof<'a, Oracle, F> {
+	/// The `m`-coordinate point shared by the table and pushforward claims.
+	pub table_eval_point: Vec<F>,
+	/// The claimed evaluation of the table `T` at the point.
+	pub table_eval_claim: F,
+	/// The `n`-coordinate point of the index claim.
+	pub index_eval_point: Vec<F>,
+	/// The claimed evaluation of the embedded index column at its point.
+	pub index_eval_claim: F,
+	/// The oracle relation `<Y, eq_{table_eval_point}> = Y(table_eval_point)` for the pushforward.
+	pub pushforward: OracleLinearRelation<'a, Oracle, F>,
+}
+
+/// Verify a logUp* reduction whose pushforward is committed as an oracle.
+///
+/// This wraps [`binius_ip::logup_star::verify`] with the pushforward commitment.
+/// It receives the `Y` oracle before the reduction, so the logUp challenge binds the commitment.
+/// It then returns the relation that opens `Y` at the reduced point.
+///
+/// The returned relation asserts `<Y, eq_r'> = Y(r')` at the reduced table point `r'`.
+/// Its transparent polynomial is the equality indicator at `r'`.
+/// The caller batches this relation with the table and index openings into one channel open.
+///
+/// # Arguments
+///
+/// * `table_n_vars` - The number of table variables `m` (`2^m` entries).
+/// * `eval_claim` - The claimed evaluation `e` of the looked-up vector.
+/// * `eval_point` - The `n`-coordinate evaluation point, whose length defines `n`.
+/// * `channel` - The IOP verifier channel carrying the `Y` commitment.
+///
+/// # Errors
+///
+/// Returns an error when the pushforward commitment is missing or the reduction identity fails.
+pub fn verify<'a, F, C>(
+	table_n_vars: usize,
+	eval_claim: F,
+	eval_point: &[F],
+	channel: &mut C,
+) -> Result<LogupProof<'a, C::Oracle, F>, Error>
+where
+	F: Field + ExtensionField<BinaryField1b>,
+	C: IOPVerifierChannel<'a, F, Elem = F>,
+{
+	// Receive the pushforward Y commitment first, so the reduction's logUp challenge binds it.
+	//
+	//     Y has 2^m entries, so its message length is table_n_vars.
+	//     Y is witness-dependent (it scatters eq_r by the secret index), so it may be masked.
+	let oracle = channel.recv_oracle(table_n_vars, true)?;
+
+	// Run the bare reduction over the same channel, viewed as an IP channel.
+	let output = reduction::verify::<F, C>(table_n_vars, eval_claim, eval_point, channel)?;
+
+	// The pushforward relation opens Y at the reduced point.
+	//
+	//     <Y, eq_r'> = Y(r') = pushforward_eval_claim
+	//
+	// BaseFold reduces this inner product to a challenge point, where the transparent is eq(r', .).
+	let point = output.table_eval_point.clone();
+	let pushforward = OracleLinearRelation {
+		oracle,
+		transparent: Box::new(move |challenge: &[F]| eq_ind(&point, challenge)),
+		claim: output.pushforward_eval_claim,
+	};
+
+	Ok(LogupProof {
+		table_eval_point: output.table_eval_point,
+		table_eval_claim: output.table_eval_claim,
+		index_eval_point: output.index_eval_point,
+		index_eval_claim: output.index_eval_claim,
+		pushforward,
+	})
+}

--- a/crates/ip-prover/src/logup_star/mod.rs
+++ b/crates/ip-prover/src/logup_star/mod.rs
@@ -27,8 +27,11 @@
 mod error;
 mod final_layer;
 mod prove;
-mod witness;
+pub mod witness;
 
 pub use binius_ip::logup_star::LogupOutput;
 
-pub use self::{error::Error, prove::prove};
+pub use self::{
+	error::Error,
+	prove::{prove, prove_reduction},
+};

--- a/crates/ip-prover/src/logup_star/prove.rs
+++ b/crates/ip-prover/src/logup_star/prove.rs
@@ -84,26 +84,70 @@ where
 		"every index entry must be less than the table size 2^m"
 	);
 
-	// The looker numerator eq_r depends only on the evaluation point, so build it before sampling
-	// c.
+	// Build the two witnesses that do not depend on the logUp challenge c.
+	//
+	//     eq_r = eq(eval_point, .)     the looker numerator
+	//     Y    = I_* eq_r              the pushforward, scattered onto table positions
 	let eq_r = witness::equality_indicator::<F, P>(eval_point);
+	let pushforward = witness::pushforward::<F, P>(&eq_r, index, m);
+
+	// The self-contained prover commits nothing.
+	// It runs the reduction over the witnesses directly.
+	prove_reduction(table, index, eval_claim, eq_r, &pushforward, channel)
+}
+
+/// Run the logUp* reduction over the pre-built witnesses `eq_r` and pushforward `Y`.
+///
+/// This is the reduction core of [`prove`], split out so a caller can build `Y` once and commit it.
+/// The committing prover builds `eq_r` and `Y`, commits `Y`, then hands both here.
+/// That way the scatter-add that forms `Y` runs only once.
+///
+/// # Arguments
+///
+/// * `table` - The table multilinear `T` over `m` variables.
+/// * `index` - The index column, one table position per looker row.
+/// * `eval_claim` - The claimed evaluation `e = (I^* T)(eval_point)`.
+/// * `eq_r` - The looker numerator `eq(eval_point, .)` over `n` variables.
+/// * `pushforward` - The pushforward `Y = I_* eq_r` over `m` variables.
+/// * `channel` - The prover channel.
+///
+/// # Preconditions
+///
+/// - `table.log_len()` is at least 1.
+/// - `index.len()` equals `2^{eq_r.log_len()}`, with every entry less than the table size.
+/// - `pushforward` equals `I_* eq_r`.
+pub fn prove_reduction<F, P>(
+	table: &FieldBuffer<P>,
+	index: &[usize],
+	eval_claim: F,
+	eq_r: FieldBuffer<P>,
+	pushforward: &FieldBuffer<P>,
+	channel: &mut impl IPProverChannel<F>,
+) -> Result<LogupOutput<F>, Error>
+where
+	F: Field + ExtensionField<BinaryField1b>,
+	P: PackedField<Scalar = F>,
+{
+	let m = table.log_len();
+	let n = eq_r.log_len();
 
 	// Sample the logUp challenge c that randomizes the logarithmic-derivative denominators.
 	// This is the prover's first transcript action, mirroring the verifier.
+	// A committing caller must absorb the I, T, and Y commitments into the transcript before this.
 	let c = channel.sample();
 
-	// Build the remaining witnesses, which all depend on c.
+	// Build the denominators, which depend on c.
 	//
 	//     looker side: eq_r(i) / (c - I(i))   over n variables
-	//     table  side: Y(j)    / (c - j)       over m variables, with Y = I_* eq_r
+	//     table  side: Y(j)    / (c - j)       over m variables
 	let looker_den = witness::looker_denominator::<F, P>(c, index);
 	let table_den = witness::table_denominator::<F, P>(c, m);
-	let pushforward = witness::pushforward::<F, P>(&eq_r, index, m);
 
 	// Build both fractional-addition circuits.
 	// Constructing a circuit computes every layer and returns its single root fraction.
 	let (looker_prover, looker_root) = FracAddCheckProver::new(n, (eq_r, looker_den));
-	let (table_prover, table_root) = FracAddCheckProver::new(m, (pushforward.clone(), table_den));
+	let (table_prover, table_root) =
+		FracAddCheckProver::new(m, (FieldBuffer::clone(pushforward), table_den));
 
 	// The two root fractions; their equality is the logUp identity the verifier checks.
 	//
@@ -141,7 +185,7 @@ where
 		table_eval_point,
 		table_eval_claim,
 		pushforward_eval_claim,
-	} = prove_final_layer(eval_claim, table_leaf_prover, layer1, &pushforward, table, channel)?;
+	} = prove_final_layer(eval_claim, table_leaf_prover, layer1, pushforward, table, channel)?;
 
 	Ok(LogupOutput {
 		table_eval_point,


### PR DESCRIPTION
Closes [BINIUS-200](https://linear.app/jimpo/issue/BINIUS-200).

Makes the logUp* protocol commit its pushforward `Y` and prove it opens correctly, instead of returning an unbound evaluation claim. The reduction math is unchanged — this only adds the commitment and its opening.

### The problem

logUp* proves an indexed lookup by committing a small pushforward `Y = I_* eq_r` instead of the full looked-up vector.
The reduction ends with a claim: "`Y` at point `r'` equals `v`".
But `Y` was never committed — nothing bound it.
So a cheating prover could invent a fake `Y` that fits a false lookup and just assert its evaluation.
The verifier had no fingerprint of `Y` to check against, so the claim floated unanchored.

### The idea

Commit `Y` before the challenge is drawn, then open that commitment at the reduced point.
- Committing first (Fiat-Shamir) locks `Y` in, so it cannot be chosen after seeing the challenge.
- Opening at the end proves the claimed value is the real committed `Y`'s value.

Sending a commitment needs the IOP channel, which carries oracle commitments.
The bare IP channel only carries field elements, so it cannot express this.

### A concrete example

Table `T = [5, 9, 2, 7]`, indices `[2, 0, 2, 3]`, weights `[3, 1, 4, 2]`.

```
lookup   e = 3*T[2] + 1*T[0] + 4*T[2] + 2*T[3] = 33
scatter  Y = [1, 0, 7, 2]              (each weight added onto the slot its row hits)
duality  <T, Y> = 5*1 + 2*7 + 7*2 = 33 = e
```

The proof runs on the 4-entry `Y`, not the looked-up list — and in the real regime the table is tiny while the index list is huge, so `Y` is the whole saving.
Before this change the "`Y(r') = v`" claim was unanchored; now `Y` is committed and opened.

### The change

The crate layering is `ip` (commitment-free reductions) then `iop` (adds oracle commitments) on top.
So the reduction stays low and a thin committing wrapper sits above it.

- **`ip-prover`**: split the reduction body into `prove_reduction`, which takes a pre-built `eq_r` and `Y`. The self-contained `prove` builds both and delegates, so the committing layer builds `Y` once, commits it, and reuses it with no second scatter-add.
- **`iop-prover`**: `logup_star::prove` builds `eq_r` and `Y`, commits `Y` before the reduction, runs the reduction, and returns the table and index claims plus the pushforward oracle relation `<Y, eq_r'> = Y(r')`.
- **`iop`**: `logup_star::verify` receives the `Y` commitment and returns the matching relation.

`Y` is the only oracle this protocol introduces (Soukhanov25, Section 3).
The table `T` and index `I` stay the caller's oracles, so their claims are returned for the caller to open.
The caller batches all the openings into one channel open.

### Soundness

- The reduction transcript is unchanged; only the `Y` commitment is added, and it precedes the logUp challenge.
- The opening binds the claimed `Y(r')` to the committed `Y`, closing the gap where the claim was unchecked.

### Scope

- **new:** `crates/iop-prover/src/logup_star.rs`, `crates/iop/src/logup_star.rs`
- **changed:** `crates/ip-prover/src/logup_star/{prove.rs, mod.rs}` — extract `prove_reduction`, expose the witness builders
- **untouched:** the reduction transcript and the bare `binius-ip` verifier

### Verification

- `cargo check --workspace --all-targets`, `cargo clippy -p binius-ip-prover -p binius-iop -p binius-iop-prover --all-targets -- -D warnings`, nightly `cargo fmt --all` — all clean
- `RUSTDOCFLAGS=-D warnings cargo doc --no-deps` — intra-doc links resolve
- round-trip tests over the naive channel (shapes with $m \ll n$, $m = n$, $m = 1$) and over the real BaseFold/FRI channel, which commits `Y` and verifies its opening end-to-end
- a negative test: a wrong evaluation claim is rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)