### PR TITLE
BINIUS-203: collapse the single-claim quadratic MLE-check prover onto the batch prover

### DIFF
--- a/crates/ip-prover/src/sumcheck/batch_quadratic_mle.rs
+++ b/crates/ip-prover/src/sumcheck/batch_quadratic_mle.rs
@@ -18,6 +18,26 @@ use crate::sumcheck::{
 	round_state::RoundState,
 };
 
+/// Produces the composite value of each of the `M` claims for one packed row of `N` inputs.
+///
+/// Evaluating all claims together lets those that share sub-expressions reuse the work.
+/// A closure of type `Fn([P; N], &mut [P; M])` implements this directly.
+pub trait QuadraticComposition<P: PackedField, const N: usize, const M: usize> {
+	/// Writes the `M` composite values for the given inputs into `outputs`.
+	fn evaluate(&self, inputs: [P; N], outputs: &mut [P; M]);
+}
+
+impl<P, T, const N: usize, const M: usize> QuadraticComposition<P, N, M> for T
+where
+	P: PackedField,
+	T: Fn([P; N], &mut [P; M]),
+{
+	fn evaluate(&self, inputs: [P; N], outputs: &mut [P; M]) {
+		// A closure that already has the right shape is its own evaluator.
+		self(inputs, outputs)
+	}
+}
+
 /// Batch MLE-check prover for M quadratic compositions over N multilinears.
 ///
 /// This prover runs a single sumcheck instance that amortizes the work of M independent
@@ -48,8 +68,8 @@ impl<F, P, Composition, InfinityComposition, const N: usize, const M: usize>
 where
 	F: Field,
 	P: PackedField<Scalar = F>,
-	Composition: Fn([P; N], &mut [P; M]) + Sync,
-	InfinityComposition: Fn([P; N], &mut [P; M]) + Sync,
+	Composition: QuadraticComposition<P, N, M> + Sync,
+	InfinityComposition: QuadraticComposition<P, N, M> + Sync,
 {
 	pub fn new(
 		mut multilinears: impl AsSlicesMut<P, N> + Send + 'static,
@@ -100,8 +120,8 @@ impl<F, P, Composition, InfinityComposition, const N: usize, const M: usize> Sum
 where
 	F: Field,
 	P: PackedField<Scalar = F>,
-	Composition: Fn([P; N], &mut [P; M]) + Sync,
-	InfinityComposition: Fn([P; N], &mut [P; M]) + Sync,
+	Composition: QuadraticComposition<P, N, M> + Sync,
+	InfinityComposition: QuadraticComposition<P, N, M> + Sync,
 {
 	fn n_vars(&self) -> usize {
 		self.gruen32.n_vars_remaining()
@@ -206,8 +226,8 @@ where
 					}
 
 					// Apply the compositions for this equality term.
-					comp(evals_1, &mut y_1_scratch);
-					inf_comp(evals_inf, &mut y_inf_scratch);
+					comp.evaluate(evals_1, &mut y_1_scratch);
+					inf_comp.evaluate(evals_inf, &mut y_inf_scratch);
 
 					for i in 0..M {
 						// Weight by eq indicator to keep the sumcheck claim aligned to
@@ -309,8 +329,8 @@ impl<F, P, Composition, InfinityComposition, const N: usize, const M: usize> Mle
 where
 	F: Field,
 	P: PackedField<Scalar = F>,
-	Composition: Fn([P; N], &mut [P; M]) + Sync,
-	InfinityComposition: Fn([P; N], &mut [P; M]) + Sync,
+	Composition: QuadraticComposition<P, N, M> + Sync,
+	InfinityComposition: QuadraticComposition<P, N, M> + Sync,
 {
 	fn eval_point(&self) -> &[F] {
 		&self.gruen32.eval_point()[..self.n_vars()]

--- a/crates/ip-prover/src/sumcheck/batch_quadratic_mle.rs
+++ b/crates/ip-prover/src/sumcheck/batch_quadratic_mle.rs
@@ -15,6 +15,7 @@ use crate::sumcheck::{
 	common::{MleCheckProver, SumcheckProver},
 	gruen32::Gruen32,
 	round_evals::RoundEvals2,
+	round_state::RoundState,
 };
 
 /// Batch MLE-check prover for M quadratic compositions over N multilinears.
@@ -37,7 +38,7 @@ pub struct BatchQuadraticMleCheckProver<
 	// Composition restricted to highest-degree terms for the "x = ∞" evaluation (Karatsuba).
 	infinity_composition: InfinityComposition,
 	// State machine storage: last round's evals (execute input) or current coeffs (fold input).
-	last_coeffs_or_eval: RoundCoeffsOrEvals<P::Scalar, M>,
+	last_coeffs_or_eval: RoundState<[RoundCoeffs<P::Scalar>; M], [P::Scalar; M]>,
 	// Tracks the eq-indicator expansion and evaluation-point folding across rounds.
 	gruen32: Gruen32<P>,
 }
@@ -67,7 +68,7 @@ where
 		}
 
 		// The first execute round consumes the claimed composite evaluations at eval_point.
-		let last_coeffs_or_eval = RoundCoeffsOrEvals::Evals(eval_claims);
+		let last_coeffs_or_eval = RoundState::Claim(eval_claims);
 		// Gruen32 owns the eq-indicator expansion tied to eval_point and drives per-round folding.
 		let gruen32 = Gruen32::new(&eval_point);
 
@@ -112,8 +113,8 @@ where
 
 	fn round_claim(&self) -> Vec<F> {
 		match &self.last_coeffs_or_eval {
-			RoundCoeffsOrEvals::Evals(evals) => evals.to_vec(),
-			RoundCoeffsOrEvals::Coeffs(coeffs) => {
+			RoundState::Claim(evals) => evals.to_vec(),
+			RoundState::Coeffs(coeffs) => {
 				let alpha = self.gruen32.next_coordinate();
 				coeffs
 					.iter()
@@ -125,10 +126,7 @@ where
 
 	fn execute(&mut self) -> Result<Vec<RoundCoeffs<F>>, Error> {
 		// State machine: execute consumes evals from the previous round and produces new coeffs.
-		let last_eval = match &self.last_coeffs_or_eval {
-			RoundCoeffsOrEvals::Evals(evals) => *evals,
-			RoundCoeffsOrEvals::Coeffs(_) => return Err(Error::ExpectedFold),
-		};
+		let last_eval = *self.last_coeffs_or_eval.claim()?;
 
 		// There must be at least one variable left to sum over in this round.
 		let n_vars_remaining = self.gruen32.n_vars_remaining();
@@ -246,7 +244,7 @@ where
 			})
 			.collect::<Vec<_>>();
 		// State transition: execute produces coeffs for fold to consume.
-		self.last_coeffs_or_eval = RoundCoeffsOrEvals::Coeffs(
+		self.last_coeffs_or_eval = RoundState::Coeffs(
 			round_coeffs
 				.clone()
 				.try_into()
@@ -257,9 +255,7 @@ where
 
 	fn fold(&mut self, challenge: F) -> Result<(), Error> {
 		// State machine: fold consumes coeffs and produces evals at the verifier challenge.
-		let RoundCoeffsOrEvals::Coeffs(prime_coeffs) = &self.last_coeffs_or_eval else {
-			return Err(Error::ExpectedExecute);
-		};
+		let prime_coeffs = self.last_coeffs_or_eval.coeffs()?;
 
 		// n_vars is decremented in fold, so we must have at least one variable left here.
 		assert!(
@@ -286,19 +282,14 @@ where
 		// Keep the equality polynomial in sync with the folding of multilinears.
 		self.gruen32.fold(challenge);
 		// State transition: fold produces evals for the next execute.
-		self.last_coeffs_or_eval = RoundCoeffsOrEvals::Evals(evals);
+		self.last_coeffs_or_eval = RoundState::Claim(evals);
 		Ok(())
 	}
 
 	fn finish(mut self) -> Result<Vec<F>, Error> {
 		// Finish is only valid after all folds complete (i.e., zero variables remain).
 		if self.n_vars() > 0 {
-			let error = match self.last_coeffs_or_eval {
-				RoundCoeffsOrEvals::Coeffs(_) => Error::ExpectedFold,
-				RoundCoeffsOrEvals::Evals(_) => Error::ExpectedExecute,
-			};
-
-			return Err(error);
+			return Err(self.last_coeffs_or_eval.unfinished_err());
 		}
 
 		// With no variables remaining, each multilinear has length 1 and can be read directly.
@@ -324,12 +315,6 @@ where
 	fn eval_point(&self) -> &[F] {
 		&self.gruen32.eval_point()[..self.n_vars()]
 	}
-}
-
-#[derive(Debug, Clone)]
-enum RoundCoeffsOrEvals<F: Field, const M: usize> {
-	Coeffs([RoundCoeffs<F>; M]),
-	Evals([F; M]),
 }
 
 #[cfg(test)]

--- a/crates/ip-prover/src/sumcheck/bivariate_product.rs
+++ b/crates/ip-prover/src/sumcheck/bivariate_product.rs
@@ -6,7 +6,9 @@ use binius_ip::sumcheck::RoundCoeffs;
 use binius_math::{FieldBuffer, multilinear::fold::fold_highest_var_inplace};
 use binius_utils::rayon::prelude::*;
 
-use crate::sumcheck::{common::SumcheckProver, error::Error, round_evals::WideRoundEvals2};
+use crate::sumcheck::{
+	common::SumcheckProver, error::Error, round_evals::WideRoundEvals2, round_state::RoundState,
+};
 
 /// A [`SumcheckProver`] implementation for a composite defined as the product of two multilinears.
 ///
@@ -18,7 +20,7 @@ use crate::sumcheck::{common::SumcheckProver, error::Error, round_evals::WideRou
 #[derive(Debug)]
 pub struct BivariateProductSumcheckProver<P: PackedField> {
 	multilinears: [FieldBuffer<P>; 2],
-	last_coeffs_or_sum: RoundCoeffsOrSum<P::Scalar>,
+	last_coeffs_or_sum: RoundState<RoundCoeffs<P::Scalar>, P::Scalar>,
 }
 
 impl<F: Field, P: PackedField<Scalar = F>> BivariateProductSumcheckProver<P> {
@@ -31,7 +33,7 @@ impl<F: Field, P: PackedField<Scalar = F>> BivariateProductSumcheckProver<P> {
 
 		Ok(Self {
 			multilinears,
-			last_coeffs_or_sum: RoundCoeffsOrSum::Sum(sum),
+			last_coeffs_or_sum: RoundState::Claim(sum),
 		})
 	}
 }
@@ -47,16 +49,14 @@ impl<F: Field, P: PackedField<Scalar = F>> SumcheckProver<F> for BivariateProduc
 
 	fn round_claim(&self) -> Vec<F> {
 		let claim = match &self.last_coeffs_or_sum {
-			RoundCoeffsOrSum::Sum(sum) => *sum,
-			RoundCoeffsOrSum::Coeffs(coeffs) => coeffs.sum_over_endpoints(),
+			RoundState::Claim(sum) => *sum,
+			RoundState::Coeffs(coeffs) => coeffs.sum_over_endpoints(),
 		};
 		vec![claim]
 	}
 
 	fn execute(&mut self) -> Result<Vec<RoundCoeffs<F>>, Error> {
-		let RoundCoeffsOrSum::Sum(last_sum) = &self.last_coeffs_or_sum else {
-			return Err(Error::ExpectedFold);
-		};
+		let last_sum = self.last_coeffs_or_sum.claim()?;
 
 		// Multilinear inputs are the same length by invariant
 		debug_assert_eq!(self.multilinears[0].len(), self.multilinears[1].len());
@@ -90,31 +90,25 @@ impl<F: Field, P: PackedField<Scalar = F>> SumcheckProver<F> for BivariateProduc
 			.reduce::<P>()
 			.sum_scalars(n_vars_remaining)
 			.interpolate(*last_sum);
-		self.last_coeffs_or_sum = RoundCoeffsOrSum::Coeffs(round_coeffs.clone());
+		self.last_coeffs_or_sum = RoundState::Coeffs(round_coeffs.clone());
 		Ok(vec![round_coeffs])
 	}
 
 	fn fold(&mut self, challenge: F) -> Result<(), Error> {
-		let RoundCoeffsOrSum::Coeffs(last_coeffs) = self.last_coeffs_or_sum.clone() else {
-			return Err(Error::ExpectedExecute);
-		};
+		let last_coeffs = self.last_coeffs_or_sum.coeffs()?.clone();
 
 		for multilin in &mut self.multilinears {
 			fold_highest_var_inplace(multilin, challenge);
 		}
 
 		let round_sum = last_coeffs.evaluate(challenge);
-		self.last_coeffs_or_sum = RoundCoeffsOrSum::Sum(round_sum);
+		self.last_coeffs_or_sum = RoundState::Claim(round_sum);
 		Ok(())
 	}
 
 	fn finish(self) -> Result<Vec<F>, Error> {
 		if self.n_vars() > 0 {
-			let error = match self.last_coeffs_or_sum {
-				RoundCoeffsOrSum::Coeffs(_) => Error::ExpectedFold,
-				RoundCoeffsOrSum::Sum(_) => Error::ExpectedExecute,
-			};
-			return Err(error);
+			return Err(self.last_coeffs_or_sum.unfinished_err());
 		}
 
 		let multilinear_evals = self
@@ -124,12 +118,6 @@ impl<F: Field, P: PackedField<Scalar = F>> SumcheckProver<F> for BivariateProduc
 			.collect();
 		Ok(multilinear_evals)
 	}
-}
-
-#[derive(Debug, Clone)]
-enum RoundCoeffsOrSum<F: Field> {
-	Coeffs(RoundCoeffs<F>),
-	Sum(F),
 }
 
 #[cfg(test)]

--- a/crates/ip-prover/src/sumcheck/bivariate_product_multi_mle.rs
+++ b/crates/ip-prover/src/sumcheck/bivariate_product_multi_mle.rs
@@ -9,14 +9,17 @@ use binius_math::{FieldBuffer, multilinear::fold::fold_highest_var_inplace};
 use binius_utils::rayon::prelude::*;
 use itertools::{Itertools, izip};
 
-use super::{common::SumcheckProver, error::Error, gruen32::Gruen32, round_evals::WideRoundEvals2};
+use super::{
+	common::SumcheckProver, error::Error, gruen32::Gruen32, round_evals::WideRoundEvals2,
+	round_state::RoundState,
+};
 use crate::sumcheck::common::MleCheckProver;
 
 /// Multiple claim version of `BivariateProductMlecheckProver` that can prove mlechecks
 /// that share the evaluation point. This allows deduplicating folding and evaluation work.
 pub struct BivariateProductMultiMlecheckProver<P: PackedField> {
 	multilinears: Vec<FieldBuffer<P>>,
-	last_coeffs_or_sums: RoundCoeffsOrSums<P::Scalar>,
+	last_coeffs_or_sums: RoundState<Vec<RoundCoeffs<P::Scalar>>, Vec<P::Scalar>>,
 	gruen32: Gruen32<P>,
 }
 
@@ -43,7 +46,7 @@ impl<F: Field, P: PackedField<Scalar = F>> BivariateProductMultiMlecheckProver<P
 		}
 
 		let multilinears = multilinears.into_iter().flatten().collect_vec();
-		let last_coeffs_or_sums = RoundCoeffsOrSums::Sums(eval_claims);
+		let last_coeffs_or_sums = RoundState::Claim(eval_claims);
 
 		let gruen32 = Gruen32::new(eval_point);
 
@@ -66,15 +69,15 @@ where
 
 	fn n_claims(&self) -> usize {
 		match &self.last_coeffs_or_sums {
-			RoundCoeffsOrSums::Coeffs(v) => v.len(),
-			RoundCoeffsOrSums::Sums(v) => v.len(),
+			RoundState::Coeffs(v) => v.len(),
+			RoundState::Claim(v) => v.len(),
 		}
 	}
 
 	fn round_claim(&self) -> Vec<F> {
 		match &self.last_coeffs_or_sums {
-			RoundCoeffsOrSums::Sums(sums) => sums.clone(),
-			RoundCoeffsOrSums::Coeffs(coeffs) => {
+			RoundState::Claim(sums) => sums.clone(),
+			RoundState::Coeffs(coeffs) => {
 				let alpha = self.gruen32.next_coordinate();
 				coeffs
 					.iter()
@@ -85,9 +88,7 @@ where
 	}
 
 	fn execute(&mut self) -> Result<Vec<RoundCoeffs<F>>, Error> {
-		let RoundCoeffsOrSums::Sums(sums) = &self.last_coeffs_or_sums else {
-			return Err(Error::ExpectedFold);
-		};
+		let sums = self.last_coeffs_or_sums.claim()?;
 
 		assert!(self.n_vars() > 0);
 
@@ -152,14 +153,12 @@ where
 			})
 			.collect::<Vec<_>>();
 
-		self.last_coeffs_or_sums = RoundCoeffsOrSums::Coeffs(round_coeffs.clone());
+		self.last_coeffs_or_sums = RoundState::Coeffs(round_coeffs.clone());
 		Ok(round_coeffs)
 	}
 
 	fn fold(&mut self, challenge: F) -> Result<(), Error> {
-		let RoundCoeffsOrSums::Coeffs(prime_coeffs) = &self.last_coeffs_or_sums else {
-			return Err(Error::ExpectedExecute);
-		};
+		let prime_coeffs = self.last_coeffs_or_sums.coeffs()?;
 
 		assert!(self.n_vars() > 0);
 
@@ -173,18 +172,13 @@ where
 			.for_each(|multilinear| fold_highest_var_inplace(multilinear, challenge));
 
 		self.gruen32.fold(challenge);
-		self.last_coeffs_or_sums = RoundCoeffsOrSums::Sums(sums);
+		self.last_coeffs_or_sums = RoundState::Claim(sums);
 		Ok(())
 	}
 
 	fn finish(self) -> Result<Vec<F>, Error> {
 		if self.n_vars() > 0 {
-			let error = match self.last_coeffs_or_sums {
-				RoundCoeffsOrSums::Coeffs(_) => Error::ExpectedFold,
-				RoundCoeffsOrSums::Sums(_) => Error::ExpectedExecute,
-			};
-
-			return Err(error);
+			return Err(self.last_coeffs_or_sums.unfinished_err());
 		}
 
 		let multilinear_evals = self
@@ -205,11 +199,6 @@ where
 	fn eval_point(&self) -> &[F] {
 		self.gruen32.eval_point()
 	}
-}
-
-enum RoundCoeffsOrSums<F: Field> {
-	Coeffs(Vec<RoundCoeffs<F>>),
-	Sums(Vec<F>),
 }
 
 #[cfg(test)]

--- a/crates/ip-prover/src/sumcheck/frac_add_mle.rs
+++ b/crates/ip-prover/src/sumcheck/frac_add_mle.rs
@@ -21,11 +21,11 @@ where
 {
 	BatchQuadraticMleCheckProver::new(
 		fraction,
-		|[num_a, num_b, den_a, den_b], out| {
+		|[num_a, num_b, den_a, den_b]: [P; 4], out: &mut [P; 2]| {
 			out[0] = num_a * den_b + num_b * den_a;
 			out[1] = den_a * den_b;
 		},
-		|[num_a, num_b, den_a, den_b], out| {
+		|[num_a, num_b, den_a, den_b]: [P; 4], out: &mut [P; 2]| {
 			// The fractional addition formulas are purely quadratic, so the infinity composition
 			// matches the regular composition.
 			out[0] = num_a * den_b + num_b * den_a;

--- a/crates/ip-prover/src/sumcheck/mod.rs
+++ b/crates/ip-prover/src/sumcheck/mod.rs
@@ -15,6 +15,7 @@ mod prove;
 pub mod quadratic_mle;
 pub mod rerand_mle;
 mod round_evals;
+mod round_state;
 pub mod selector_mle;
 mod switchover;
 pub use error::*;

--- a/crates/ip-prover/src/sumcheck/multilinear_eval.rs
+++ b/crates/ip-prover/src/sumcheck/multilinear_eval.rs
@@ -11,6 +11,7 @@ use super::{
 	error::Error,
 	gruen32::Gruen32,
 	round_evals::RoundEvals1,
+	round_state::RoundState,
 };
 
 /// An [`MleCheckProver`] for the multilinear extension evaluation of a single multilinear
@@ -31,7 +32,7 @@ use super::{
 pub struct MultilinearEvalProver<P: PackedField> {
 	witness: FieldBuffer<P>,
 	gruen32: Gruen32<P>,
-	last_coeffs_or_sum: RoundCoeffsOrSum<P::Scalar>,
+	last_coeffs_or_sum: RoundState<RoundCoeffs<P::Scalar>, P::Scalar>,
 }
 
 impl<F: Field, P: PackedField<Scalar = F>> MultilinearEvalProver<P> {
@@ -48,7 +49,7 @@ impl<F: Field, P: PackedField<Scalar = F>> MultilinearEvalProver<P> {
 		Ok(Self {
 			witness,
 			gruen32: Gruen32::new(eval_point),
-			last_coeffs_or_sum: RoundCoeffsOrSum::Sum(eval_claim),
+			last_coeffs_or_sum: RoundState::Claim(eval_claim),
 		})
 	}
 }
@@ -64,8 +65,8 @@ impl<F: Field, P: PackedField<Scalar = F>> SumcheckProver<F> for MultilinearEval
 
 	fn round_claim(&self) -> Vec<F> {
 		let claim = match &self.last_coeffs_or_sum {
-			RoundCoeffsOrSum::Sum(sum) => *sum,
-			RoundCoeffsOrSum::Coeffs(coeffs) => {
+			RoundState::Claim(sum) => *sum,
+			RoundState::Coeffs(coeffs) => {
 				coeffs.lerp_over_endpoints(self.gruen32.next_coordinate())
 			}
 		};
@@ -73,10 +74,7 @@ impl<F: Field, P: PackedField<Scalar = F>> SumcheckProver<F> for MultilinearEval
 	}
 
 	fn execute(&mut self) -> Result<Vec<RoundCoeffs<F>>, Error> {
-		let RoundCoeffsOrSum::Sum(sum) = &self.last_coeffs_or_sum else {
-			return Err(Error::ExpectedFold);
-		};
-		let sum = *sum;
+		let sum = *self.last_coeffs_or_sum.claim()?;
 
 		let n_vars_remaining = self.n_vars();
 		assert!(n_vars_remaining > 0);
@@ -102,14 +100,12 @@ impl<F: Field, P: PackedField<Scalar = F>> SumcheckProver<F> for MultilinearEval
 			.sum_scalars(n_vars_remaining)
 			.interpolate_eq(sum, alpha);
 
-		self.last_coeffs_or_sum = RoundCoeffsOrSum::Coeffs(round_coeffs.clone());
+		self.last_coeffs_or_sum = RoundState::Coeffs(round_coeffs.clone());
 		Ok(vec![round_coeffs])
 	}
 
 	fn fold(&mut self, challenge: F) -> Result<(), Error> {
-		let RoundCoeffsOrSum::Coeffs(coeffs) = &self.last_coeffs_or_sum else {
-			return Err(Error::ExpectedExecute);
-		};
+		let coeffs = self.last_coeffs_or_sum.coeffs()?;
 
 		assert!(self.n_vars() > 0);
 
@@ -118,17 +114,13 @@ impl<F: Field, P: PackedField<Scalar = F>> SumcheckProver<F> for MultilinearEval
 		fold_highest_var_inplace(&mut self.witness, challenge);
 		self.gruen32.fold(challenge);
 
-		self.last_coeffs_or_sum = RoundCoeffsOrSum::Sum(sum);
+		self.last_coeffs_or_sum = RoundState::Claim(sum);
 		Ok(())
 	}
 
 	fn finish(self) -> Result<Vec<F>, Error> {
 		if self.n_vars() > 0 {
-			let error = match self.last_coeffs_or_sum {
-				RoundCoeffsOrSum::Coeffs(_) => Error::ExpectedFold,
-				RoundCoeffsOrSum::Sum(_) => Error::ExpectedExecute,
-			};
-			return Err(error);
+			return Err(self.last_coeffs_or_sum.unfinished_err());
 		}
 
 		debug_assert_eq!(self.witness.log_len(), 0);
@@ -140,12 +132,6 @@ impl<F: Field, P: PackedField<Scalar = F>> MleCheckProver<F> for MultilinearEval
 	fn eval_point(&self) -> &[F] {
 		self.gruen32.eval_point()
 	}
-}
-
-#[derive(Debug, Clone)]
-enum RoundCoeffsOrSum<F: Field> {
-	Coeffs(RoundCoeffs<F>),
-	Sum(F),
 }
 
 #[cfg(test)]

--- a/crates/ip-prover/src/sumcheck/quadratic_mle.rs
+++ b/crates/ip-prover/src/sumcheck/quadratic_mle.rs
@@ -3,32 +3,31 @@
 
 use binius_field::{Field, PackedField};
 use binius_ip::sumcheck::RoundCoeffs;
-use binius_math::{AsSlicesMut, FieldSliceMut, multilinear::fold::fold_highest_var_inplace};
-use binius_utils::rayon::prelude::*;
+use binius_math::AsSlicesMut;
 
 use super::{
-	common::SumcheckProver, error::Error, gruen32::Gruen32, round_evals::WideRoundEvals2,
-	round_state::RoundState,
+	batch_quadratic_mle::{BatchQuadraticMleCheckProver, QuadraticComposition},
+	common::{MleCheckProver, SumcheckProver},
+	error::Error,
 };
-use crate::sumcheck::common::MleCheckProver;
 
-/// MLE-check prover for polynomials defined as quadratic compositions of N multilinear polynomials.
+/// MLE-check prover for a quadratic composition of `N` multilinear polynomials.
 ///
-/// This prover implements the MLE (multilinear extension) check protocol. Given N multilinear
-/// polynomials M₁, M₂, ..., Mₙ and a quadratic composition function C, it proves claims about
-/// the multilinear extension of the composite polynomial C(M₁, M₂, ..., Mₙ).
+/// It proves a claim about the multilinear extension of the composite `C(M_1, ..., M_N)`.
+/// The claim is reduced to a claim on each multilinear's evaluation at the challenge point.
+/// Round polynomials are degree 2, interpolated with the Karatsuba optimization.
 ///
-/// The prover uses the sumcheck protocol to reduce claims about this multilinear extension
-/// to claims about the individual multilinear evaluations, employing the Karatsuba optimization
-/// for efficient degree-2 polynomial interpolation.
-pub struct QuadraticMleCheckProver<P: PackedField, Composition, InfinityComposition, const N: usize>
-{
-	multilinears: Box<dyn AsSlicesMut<P, N> + Send>,
-	composition: Composition,
-	infinity_composition: InfinityComposition,
-	last_coeffs_or_eval: RoundState<RoundCoeffs<P::Scalar>, P::Scalar>,
-	gruen32: Gruen32<P>,
-}
+/// This is the single-claim specialization of [`BatchQuadraticMleCheckProver`].
+/// It runs one claim through the same chunked, wide-accumulated round evaluation.
+pub struct QuadraticMleCheckProver<P: PackedField, Composition, InfinityComposition, const N: usize>(
+	BatchQuadraticMleCheckProver<
+		P,
+		SingleComposition<Composition>,
+		SingleComposition<InfinityComposition>,
+		N,
+		1,
+	>,
+);
 
 impl<F, P, Composition, InfinityComposition, const N: usize>
 	QuadraticMleCheckProver<P, Composition, InfinityComposition, N>
@@ -38,75 +37,36 @@ where
 	Composition: Fn([P; N]) -> P + Sync,
 	InfinityComposition: Fn([P; N]) -> P + Sync,
 {
-	/// Creates a new prover for verifying quadratic composite polynomial evaluations.
+	/// Creates a new prover for verifying a quadratic composite polynomial evaluation.
 	///
 	/// # Arguments
 	///
-	/// * `multilinears` - Array of N multilinear polynomials that serve as inputs to the
-	///   composition. Each multilinear must have the same number of variables.
-	///
-	/// * `composition` - Function for evaluating the N-variate quadratic composition over packed
-	///   field elements. Takes an array of N packed field elements (one from each multilinear) and
-	///   returns their composition value. For example, for a product of two multilinears, this
-	///   would compute `M₁(X) * M₂(X)`.
-	///
-	/// * `infinity_composition` - Polynomial evaluator that computes only the highest-degree terms
-	///   of the composition. This is used for evaluation at the "infinity point" in the Karatsuba
-	///   optimization, where we take the limit of P(X)/X^d as X approaches infinity. This limit
-	///   equals the coefficient of the highest-degree term, effectively ignoring lower-degree
-	///   terms. For example, if composition is `a*b - c`, the infinity_composition would be just
-	///   `a*b`.
-	///
-	/// * `eval_point` - The point at which the multilinear extension is being evaluated. Must have
-	///   length equal to the number of variables in the multilinears.
-	///
-	/// * `eval_claim` - The claimed value of the multilinear extension of the composite polynomial
-	///   at the evaluation point. This is the multilinear extension of the function that maps v ∈
-	///   {0,1}ⁿ to C(M₁(v), M₂(v), ..., Mₙ(v)), evaluated at eval_point.
-	///
-	/// # Returns
-	///
-	/// A configured prover instance ready to execute the sumcheck protocol.
+	/// * `multilinears` - the `N` input multilinears, all with the same number of variables.
+	/// * `composition` - evaluates `C` on one packed row of the inputs, e.g. `|[a, b]| a * b`.
+	/// * `infinity_composition` - the highest-degree part of `C`, e.g. `a * b` for `a * b - c`.
+	/// * `eval_point` - the point at which the composite's multilinear extension is claimed.
+	/// * `eval_claim` - the claimed value of that extension at `eval_point`.
 	///
 	/// # Errors
 	///
-	/// Returns `Error::MultilinearSizeMismatch` if any multilinear has a different number of
-	/// variables than the length of `eval_point`.
+	/// Returns [`Error::MultilinearSizeMismatch`] if a multilinear's variable count differs from
+	/// the length of `eval_point`.
 	pub fn new(
-		mut multilinears: impl AsSlicesMut<P, N> + Send + 'static,
+		multilinears: impl AsSlicesMut<P, N> + Send + 'static,
 		composition: Composition,
 		infinity_composition: InfinityComposition,
 		eval_point: Vec<F>,
 		eval_claim: F,
 	) -> Result<Self, Error> {
-		let n_vars = eval_point.len();
-
-		for multilinear in &multilinears.as_slices_mut() {
-			if multilinear.log_len() != n_vars {
-				return Err(Error::MultilinearSizeMismatch);
-			}
-		}
-
-		let last_coeffs_or_eval = RoundState::Claim(eval_claim);
-		let gruen32 = Gruen32::new(&eval_point);
-
-		Ok(Self {
-			multilinears: Box::new(multilinears),
-			composition,
-			infinity_composition,
-			last_coeffs_or_eval,
-			gruen32,
-		})
-	}
-
-	/// Gets mutable slices of the multilinears, truncated to the current number of variables.
-	fn multilinears_mut(&mut self) -> [FieldSliceMut<'_, P>; N] {
-		let n_vars = self.gruen32.n_vars_remaining();
-		let mut slices = self.multilinears.as_slices_mut();
-		for slice in &mut slices {
-			slice.truncate(n_vars);
-		}
-		slices
+		// Reuse the batch prover with a single claim.
+		let inner = BatchQuadraticMleCheckProver::new(
+			multilinears,
+			SingleComposition(composition),
+			SingleComposition(infinity_composition),
+			eval_point,
+			[eval_claim],
+		)?;
+		Ok(Self(inner))
 	}
 }
 
@@ -119,119 +79,33 @@ where
 	InfinityComposition: Fn([P; N]) -> P + Sync,
 {
 	fn n_vars(&self) -> usize {
-		self.gruen32.n_vars_remaining()
+		// Variables left to bind, tracked by the underlying batch prover.
+		self.0.n_vars()
 	}
 
 	fn n_claims(&self) -> usize {
-		1
+		// A single claim.
+		self.0.n_claims()
 	}
 
 	fn round_claim(&self) -> Vec<F> {
-		let claim = match &self.last_coeffs_or_eval {
-			RoundState::Claim(eval) => *eval,
-			RoundState::Coeffs(coeffs) => {
-				coeffs.lerp_over_endpoints(self.gruen32.next_coordinate())
-			}
-		};
-		vec![claim]
+		// The one claim carried into this round.
+		self.0.round_claim()
 	}
 
 	fn execute(&mut self) -> Result<Vec<RoundCoeffs<F>>, Error> {
-		let last_eval = *self.last_coeffs_or_eval.claim()?;
-
-		let n_vars_remaining = self.gruen32.n_vars_remaining();
-		assert!(n_vars_remaining > 0);
-
-		let eq_expansion = self.gruen32.eq_expansion();
-		assert_eq!(eq_expansion.log_len(), n_vars_remaining - 1);
-
-		// Get references to compositions - these don't conflict with multilinears borrow
-		let composition = &self.composition;
-		let infinity_composition = &self.infinity_composition;
-
-		// Get multilinear slices and truncate to current n_vars
-		let mut multilinears = self.multilinears.as_slices_mut();
-		for slice in &mut multilinears {
-			slice.truncate(n_vars_remaining);
-		}
-
-		// Split each multilinear in half
-		let (splits_0, splits_1) = multilinears
-			.iter()
-			.map(|multilinear| multilinear.split_half_ref())
-			.unzip::<_, _, Vec<_>, Vec<_>>();
-
-		// Compute F(1) and F(∞) where F = ∑_{v ∈ B} C(M_1(v || X), ..., M_N(v || X)) eq(v, z).
-		// We need to iterate over all positions in parallel.
-		//
-		// The per-position products `C(..) * eq_i` are accumulated in unreduced (wide) form and
-		// reduced a single time at the end, which amortizes the GF(2^128) reduction across all
-		// hypercube points.
-		let round_evals = eq_expansion
-			.as_ref()
-			.into_par_iter()
-			.enumerate()
-			.map(|(i, &eq_i)| {
-				// Collect evaluations at 1 and ∞ for each multilinear
-				let mut evals_1 = [P::default(); N];
-				let mut evals_inf = [P::default(); N];
-				for j in 0..N {
-					evals_1[j] = splits_1[j].as_ref()[i];
-					evals_inf[j] = splits_0[j].as_ref()[i] + splits_1[j].as_ref()[i];
-				}
-
-				WideRoundEvals2 {
-					// Evaluate composition at X=1
-					y_1: P::wide_mul(composition(evals_1), eq_i),
-					// Evaluate composition at X=∞ (where M(∞) = M(0) + M(1))
-					y_inf: P::wide_mul(infinity_composition(evals_inf), eq_i),
-				}
-			})
-			.reduce(WideRoundEvals2::default, |lhs, rhs| lhs + rhs)
-			.reduce::<P>()
-			.sum_scalars(n_vars_remaining - 1);
-
-		let alpha = self.gruen32.next_coordinate();
-		let round_coeffs = round_evals.interpolate_eq(last_eval, alpha);
-
-		self.last_coeffs_or_eval = RoundState::Coeffs(round_coeffs.clone());
-		Ok(vec![round_coeffs])
+		// The single round polynomial for the variable being bound.
+		self.0.execute()
 	}
 
 	fn fold(&mut self, challenge: F) -> Result<(), Error> {
-		let coeffs = self.last_coeffs_or_eval.coeffs()?;
-
-		assert!(
-			self.n_vars() > 0,
-			"n_vars is decremented in fold; \
-			fold changes last_coeffs_or_eval to Eval variant; \
-			fold only executes with Coeffs variant; \
-			thus, n_vars should be > 0"
-		);
-
-		let eval = coeffs.evaluate(challenge);
-
-		for multilinear in &mut self.multilinears_mut() {
-			fold_highest_var_inplace(multilinear, challenge);
-		}
-
-		self.gruen32.fold(challenge);
-		self.last_coeffs_or_eval = RoundState::Claim(eval);
-		Ok(())
+		// Bind the current variable to the verifier challenge.
+		self.0.fold(challenge)
 	}
 
-	fn finish(mut self) -> Result<Vec<F>, Error> {
-		if self.n_vars() > 0 {
-			return Err(self.last_coeffs_or_eval.unfinished_err());
-		}
-
-		let multilinear_evals = self
-			.multilinears_mut()
-			.into_iter()
-			.map(|multilinear| multilinear.get(0))
-			.collect();
-
-		Ok(multilinear_evals)
+	fn finish(self) -> Result<Vec<F>, Error> {
+		// The N multilinear evaluations at the challenge point.
+		self.0.finish()
 	}
 }
 
@@ -244,7 +118,22 @@ where
 	InfinityComposition: Fn([P; N]) -> P + Sync,
 {
 	fn eval_point(&self) -> &[F] {
-		&self.gruen32.eval_point()[..self.n_vars()]
+		// The remaining coordinates of the evaluation point.
+		self.0.eval_point()
+	}
+}
+
+/// Adapts a single-output composition into the [`QuadraticComposition`] shape with `M = 1`.
+struct SingleComposition<C>(C);
+
+impl<P, C, const N: usize> QuadraticComposition<P, N, 1> for SingleComposition<C>
+where
+	P: PackedField,
+	C: Fn([P; N]) -> P,
+{
+	fn evaluate(&self, inputs: [P; N], outputs: &mut [P; 1]) {
+		// The single composite value is the only output.
+		outputs[0] = (self.0)(inputs);
 	}
 }
 

--- a/crates/ip-prover/src/sumcheck/quadratic_mle.rs
+++ b/crates/ip-prover/src/sumcheck/quadratic_mle.rs
@@ -6,7 +6,10 @@ use binius_ip::sumcheck::RoundCoeffs;
 use binius_math::{AsSlicesMut, FieldSliceMut, multilinear::fold::fold_highest_var_inplace};
 use binius_utils::rayon::prelude::*;
 
-use super::{common::SumcheckProver, error::Error, gruen32::Gruen32, round_evals::WideRoundEvals2};
+use super::{
+	common::SumcheckProver, error::Error, gruen32::Gruen32, round_evals::WideRoundEvals2,
+	round_state::RoundState,
+};
 use crate::sumcheck::common::MleCheckProver;
 
 /// MLE-check prover for polynomials defined as quadratic compositions of N multilinear polynomials.
@@ -23,7 +26,7 @@ pub struct QuadraticMleCheckProver<P: PackedField, Composition, InfinityComposit
 	multilinears: Box<dyn AsSlicesMut<P, N> + Send>,
 	composition: Composition,
 	infinity_composition: InfinityComposition,
-	last_coeffs_or_eval: RoundCoeffsOrEval<P::Scalar>,
+	last_coeffs_or_eval: RoundState<RoundCoeffs<P::Scalar>, P::Scalar>,
 	gruen32: Gruen32<P>,
 }
 
@@ -84,7 +87,7 @@ where
 			}
 		}
 
-		let last_coeffs_or_eval = RoundCoeffsOrEval::Eval(eval_claim);
+		let last_coeffs_or_eval = RoundState::Claim(eval_claim);
 		let gruen32 = Gruen32::new(&eval_point);
 
 		Ok(Self {
@@ -125,8 +128,8 @@ where
 
 	fn round_claim(&self) -> Vec<F> {
 		let claim = match &self.last_coeffs_or_eval {
-			RoundCoeffsOrEval::Eval(eval) => *eval,
-			RoundCoeffsOrEval::Coeffs(coeffs) => {
+			RoundState::Claim(eval) => *eval,
+			RoundState::Coeffs(coeffs) => {
 				coeffs.lerp_over_endpoints(self.gruen32.next_coordinate())
 			}
 		};
@@ -134,10 +137,7 @@ where
 	}
 
 	fn execute(&mut self) -> Result<Vec<RoundCoeffs<F>>, Error> {
-		let last_eval = match &self.last_coeffs_or_eval {
-			RoundCoeffsOrEval::Eval(eval) => *eval,
-			RoundCoeffsOrEval::Coeffs(_) => return Err(Error::ExpectedFold),
-		};
+		let last_eval = *self.last_coeffs_or_eval.claim()?;
 
 		let n_vars_remaining = self.gruen32.n_vars_remaining();
 		assert!(n_vars_remaining > 0);
@@ -194,14 +194,12 @@ where
 		let alpha = self.gruen32.next_coordinate();
 		let round_coeffs = round_evals.interpolate_eq(last_eval, alpha);
 
-		self.last_coeffs_or_eval = RoundCoeffsOrEval::Coeffs(round_coeffs.clone());
+		self.last_coeffs_or_eval = RoundState::Coeffs(round_coeffs.clone());
 		Ok(vec![round_coeffs])
 	}
 
 	fn fold(&mut self, challenge: F) -> Result<(), Error> {
-		let RoundCoeffsOrEval::Coeffs(coeffs) = &self.last_coeffs_or_eval else {
-			return Err(Error::ExpectedExecute);
-		};
+		let coeffs = self.last_coeffs_or_eval.coeffs()?;
 
 		assert!(
 			self.n_vars() > 0,
@@ -218,18 +216,13 @@ where
 		}
 
 		self.gruen32.fold(challenge);
-		self.last_coeffs_or_eval = RoundCoeffsOrEval::Eval(eval);
+		self.last_coeffs_or_eval = RoundState::Claim(eval);
 		Ok(())
 	}
 
 	fn finish(mut self) -> Result<Vec<F>, Error> {
 		if self.n_vars() > 0 {
-			let error = match self.last_coeffs_or_eval {
-				RoundCoeffsOrEval::Coeffs(_) => Error::ExpectedFold,
-				RoundCoeffsOrEval::Eval(_) => Error::ExpectedExecute,
-			};
-
-			return Err(error);
+			return Err(self.last_coeffs_or_eval.unfinished_err());
 		}
 
 		let multilinear_evals = self
@@ -253,12 +246,6 @@ where
 	fn eval_point(&self) -> &[F] {
 		&self.gruen32.eval_point()[..self.n_vars()]
 	}
-}
-
-#[derive(Debug, Clone)]
-enum RoundCoeffsOrEval<F: Field> {
-	Coeffs(RoundCoeffs<F>),
-	Eval(F),
 }
 
 #[cfg(test)]

--- a/crates/ip-prover/src/sumcheck/rerand_mle.rs
+++ b/crates/ip-prover/src/sumcheck/rerand_mle.rs
@@ -14,6 +14,7 @@ use super::{
 	error::Error,
 	gruen32::Gruen32,
 	round_evals::RoundEvals1,
+	round_state::RoundState,
 	switchover::BinarySwitchover,
 };
 
@@ -28,7 +29,7 @@ use super::{
 /// To combat memory blowup issues arising from folding 1-bit multilinears, this prover introduces
 /// switchover. See `BinarySwitchover` for more in-depth explanation of the mechanism.
 pub struct RerandMlecheckProver<'b, P: PackedField, B: Bitwise> {
-	last_coeffs_or_sums: RoundCoeffsOrSums<P::Scalar>,
+	last_coeffs_or_sums: RoundState<Vec<RoundCoeffs<P::Scalar>>, Vec<P::Scalar>>,
 	gruen32: Gruen32<P>,
 	switchover: BinarySwitchover<'b, P, B>,
 }
@@ -56,7 +57,7 @@ where
 
 		let gruen32 = Gruen32::new(eval_point);
 		let switchover = BinarySwitchover::new(eval_claims.len(), switchover.min(n_vars), bitmasks);
-		let last_coeffs_or_sums = RoundCoeffsOrSums::Sums(eval_claims.to_vec());
+		let last_coeffs_or_sums = RoundState::Claim(eval_claims.to_vec());
 
 		Ok(Self {
 			last_coeffs_or_sums,
@@ -78,15 +79,15 @@ where
 
 	fn n_claims(&self) -> usize {
 		match &self.last_coeffs_or_sums {
-			RoundCoeffsOrSums::Coeffs(v) => v.len(),
-			RoundCoeffsOrSums::Sums(v) => v.len(),
+			RoundState::Coeffs(v) => v.len(),
+			RoundState::Claim(v) => v.len(),
 		}
 	}
 
 	fn round_claim(&self) -> Vec<F> {
 		match &self.last_coeffs_or_sums {
-			RoundCoeffsOrSums::Sums(sums) => sums.clone(),
-			RoundCoeffsOrSums::Coeffs(coeffs) => {
+			RoundState::Claim(sums) => sums.clone(),
+			RoundState::Coeffs(coeffs) => {
 				let alpha = self.gruen32.next_coordinate();
 				coeffs
 					.iter()
@@ -97,9 +98,7 @@ where
 	}
 
 	fn execute(&mut self) -> Result<Vec<RoundCoeffs<F>>, Error> {
-		let RoundCoeffsOrSums::Sums(sums) = &self.last_coeffs_or_sums else {
-			return Err(Error::ExpectedFold);
-		};
+		let sums = self.last_coeffs_or_sums.claim()?;
 
 		assert!(self.n_vars() > 0);
 
@@ -162,14 +161,12 @@ where
 			})
 			.collect::<Vec<_>>();
 
-		self.last_coeffs_or_sums = RoundCoeffsOrSums::Coeffs(round_coeffs.clone());
+		self.last_coeffs_or_sums = RoundState::Coeffs(round_coeffs.clone());
 		Ok(round_coeffs)
 	}
 
 	fn fold(&mut self, challenge: F) -> Result<(), Error> {
-		let RoundCoeffsOrSums::Coeffs(round_coeffs) = &self.last_coeffs_or_sums else {
-			return Err(Error::ExpectedExecute);
-		};
+		let round_coeffs = self.last_coeffs_or_sums.coeffs()?;
 
 		assert!(self.n_vars() > 0);
 
@@ -181,18 +178,13 @@ where
 		self.switchover.fold(challenge);
 		self.gruen32.fold(challenge);
 
-		self.last_coeffs_or_sums = RoundCoeffsOrSums::Sums(sums);
+		self.last_coeffs_or_sums = RoundState::Claim(sums);
 		Ok(())
 	}
 
 	fn finish(self) -> Result<Vec<F>, Error> {
 		if self.n_vars() > 0 {
-			let error = match self.last_coeffs_or_sums {
-				RoundCoeffsOrSums::Coeffs(_) => Error::ExpectedFold,
-				RoundCoeffsOrSums::Sums(_) => Error::ExpectedExecute,
-			};
-
-			return Err(error);
+			return Err(self.last_coeffs_or_sums.unfinished_err());
 		}
 
 		let multilinear_evals = self
@@ -218,11 +210,6 @@ where
 	fn eval_point(&self) -> &[F] {
 		self.gruen32.eval_point()
 	}
-}
-
-enum RoundCoeffsOrSums<F: Field> {
-	Coeffs(Vec<RoundCoeffs<F>>),
-	Sums(Vec<F>),
 }
 
 #[cfg(test)]

--- a/crates/ip-prover/src/sumcheck/round_state.rs
+++ b/crates/ip-prover/src/sumcheck/round_state.rs
@@ -1,0 +1,65 @@
+// Copyright 2026 The Binius Developers
+
+use super::error::Error;
+
+/// The value a sumcheck-style prover carries between two consecutive protocol phases.
+///
+/// A prover alternates between two phases, once per variable:
+/// - producing the round polynomial(s) for the variable being bound,
+/// - reducing them with the verifier challenge to the claim(s) for the next variable.
+///
+/// A prover holds exactly one of the two at any time.
+/// Tracking which one lets the mandated call order be validated in a single place.
+#[derive(Debug, Clone)]
+pub enum RoundState<Coeffs, Claim> {
+	/// Round polynomial(s) already produced for this variable, awaiting the reduction step.
+	Coeffs(Coeffs),
+	/// Claim(s) awaiting the next round polynomial(s): the initial claim, or a reduction result.
+	Claim(Claim),
+}
+
+impl<Coeffs, Claim> RoundState<Coeffs, Claim> {
+	/// Borrows the carried claim, needed to start producing this round's polynomial(s).
+	///
+	/// # Errors
+	///
+	/// Fails when the prover still holds an unreduced round polynomial.
+	/// That means two round polynomials were requested with no reduction step between them.
+	pub const fn claim(&self) -> Result<&Claim, Error> {
+		match self {
+			// A carried claim is the expected input to the round-polynomial phase.
+			Self::Claim(claim) => Ok(claim),
+			// Holding coefficients means the reduction step is still owed.
+			Self::Coeffs(_) => Err(Error::ExpectedFold),
+		}
+	}
+
+	/// Borrows this round's polynomial(s), needed to start the reduction step.
+	///
+	/// # Errors
+	///
+	/// Fails when the prover instead holds a claim.
+	/// That means a reduction was requested before its round polynomial was produced.
+	pub const fn coeffs(&self) -> Result<&Coeffs, Error> {
+		match self {
+			// The round polynomial is the expected input to the reduction phase.
+			Self::Coeffs(coeffs) => Ok(coeffs),
+			// Holding a claim means the round polynomial is still owed.
+			Self::Claim(_) => Err(Error::ExpectedExecute),
+		}
+	}
+
+	/// The error to raise when the protocol is told to finish while variables still remain.
+	///
+	/// # Returns
+	///
+	/// The call the prover is still waiting for, encoded as an error:
+	/// - holding a round polynomial, the reduction step is owed,
+	/// - holding a claim, the next round polynomial is owed.
+	pub const fn unfinished_err(&self) -> Error {
+		match self {
+			Self::Coeffs(_) => Error::ExpectedFold,
+			Self::Claim(_) => Error::ExpectedExecute,
+		}
+	}
+}

--- a/crates/ip-prover/src/sumcheck/selector_mle.rs
+++ b/crates/ip-prover/src/sumcheck/selector_mle.rs
@@ -14,6 +14,7 @@ use super::{
 	error::Error,
 	gruen32::Gruen32,
 	round_evals::{RoundEvals2, WideRoundEvals2},
+	round_state::RoundState,
 	switchover::BinarySwitchover,
 };
 
@@ -36,7 +37,7 @@ pub struct Claim<F: Field> {
 /// that the need to expand the equality indicator for each multilinear still results in some
 /// blowup.
 pub struct SelectorMlecheckProver<'b, P: PackedField, B: Bitwise> {
-	last_coeffs_or_sums: RoundCoeffsOrSums<P::Scalar>,
+	last_coeffs_or_sums: RoundState<Vec<RoundCoeffs<P::Scalar>>, Vec<P::Scalar>>,
 	selected: FieldBuffer<P>,
 	gruen32s: Vec<Gruen32<P>>,
 	weights: Vec<P::Scalar>,
@@ -80,7 +81,7 @@ impl<'b, F: Field, P: PackedField<Scalar = F>, B: Bitwise> SelectorMlecheckProve
 			.collect::<(Vec<_>, Vec<_>)>();
 
 		let switchover = BinarySwitchover::new(sums.len(), switchover.min(n_vars), bitmasks);
-		let last_coeffs_or_sums = RoundCoeffsOrSums::Sums(sums);
+		let last_coeffs_or_sums = RoundState::Claim(sums);
 
 		Ok(Self {
 			last_coeffs_or_sums,
@@ -109,10 +110,10 @@ where
 
 	fn round_claim(&self) -> Vec<F> {
 		let per_claim: Vec<F> = match &self.last_coeffs_or_sums {
-			RoundCoeffsOrSums::Sums(sums) => sums.clone(),
+			RoundState::Claim(sums) => sums.clone(),
 			// This prover has a separate evaluation point per claim, so each round polynomial is
 			// interpolated against its own coordinate.
-			RoundCoeffsOrSums::Coeffs(coeffs) => izip!(coeffs, &self.gruen32s)
+			RoundState::Coeffs(coeffs) => izip!(coeffs, &self.gruen32s)
 				.map(|(coeffs, gruen32)| coeffs.lerp_over_endpoints(gruen32.next_coordinate()))
 				.collect(),
 		};
@@ -121,9 +122,7 @@ where
 	}
 
 	fn execute(&mut self) -> Result<Vec<RoundCoeffs<F>>, Error> {
-		let RoundCoeffsOrSums::Sums(sums) = &self.last_coeffs_or_sums else {
-			return Err(Error::ExpectedFold);
-		};
+		let sums = self.last_coeffs_or_sums.claim()?;
 
 		assert!(self.n_vars() > 0);
 
@@ -225,7 +224,7 @@ where
 			})
 			.unzip::<_, _, Vec<_>, Vec<_>>();
 
-		self.last_coeffs_or_sums = RoundCoeffsOrSums::Coeffs(prime_coeffs);
+		self.last_coeffs_or_sums = RoundState::Coeffs(prime_coeffs);
 
 		// Combine the per-claim round polynomials into the single weighted round polynomial
 		// `Σ_i weights[i] · R_i`.
@@ -236,9 +235,7 @@ where
 	}
 
 	fn fold(&mut self, challenge: F) -> Result<(), Error> {
-		let RoundCoeffsOrSums::Coeffs(prime_coeffs) = &self.last_coeffs_or_sums else {
-			return Err(Error::ExpectedExecute);
-		};
+		let prime_coeffs = self.last_coeffs_or_sums.coeffs()?;
 
 		assert!(self.n_vars() > 0);
 
@@ -254,18 +251,13 @@ where
 		self.switchover.fold(challenge);
 		fold_highest_var_inplace(&mut self.selected, challenge);
 
-		self.last_coeffs_or_sums = RoundCoeffsOrSums::Sums(sums);
+		self.last_coeffs_or_sums = RoundState::Claim(sums);
 		Ok(())
 	}
 
 	fn finish(self) -> Result<Vec<F>, Error> {
 		if self.n_vars() > 0 {
-			let error = match self.last_coeffs_or_sums {
-				RoundCoeffsOrSums::Coeffs(_) => Error::ExpectedFold,
-				RoundCoeffsOrSums::Sums(_) => Error::ExpectedExecute,
-			};
-
-			return Err(error);
+			return Err(self.last_coeffs_or_sums.unfinished_err());
 		}
 
 		let mut multilinear_evals = Vec::with_capacity(self.gruen32s.len() + 1);
@@ -281,11 +273,6 @@ where
 
 		Ok(multilinear_evals)
 	}
-}
-
-enum RoundCoeffsOrSums<F: Field> {
-	Coeffs(Vec<RoundCoeffs<F>>),
-	Sums(Vec<F>),
 }
 
 #[cfg(test)]

--- a/crates/ip-prover/src/sumcheck/zk_mlecheck.rs
+++ b/crates/ip-prover/src/sumcheck/zk_mlecheck.rs
@@ -19,6 +19,7 @@ use binius_math::{
 use super::{
 	Error,
 	common::{MleCheckProver, SumcheckProver},
+	round_state::RoundState,
 };
 use crate::channel::IPProverChannel;
 
@@ -207,13 +208,7 @@ pub struct MleCheckMaskProver<F: Field, P: PackedField<Scalar = F>, Data: Deref<
 	/// Precomputed (1-z_j)*g_j(0) + z_j*g_j(1) for each variable
 	suffix_sums: Vec<F>,
 	/// State: either last round coefficients (after execute) or current claim (after fold)
-	last_coeffs_or_claim: RoundCoeffsOrClaim<F>,
-}
-
-#[derive(Debug, Clone)]
-enum RoundCoeffsOrClaim<F: Field> {
-	Coeffs(RoundCoeffs<F>),
-	Claim(F),
+	last_coeffs_or_claim: RoundState<RoundCoeffs<F>, F>,
 }
 
 impl<F: Field, P: PackedField<Scalar = F>, Data: Deref<Target = [P]>>
@@ -251,7 +246,7 @@ impl<F: Field, P: PackedField<Scalar = F>, Data: Deref<Target = [P]>>
 			n_vars_remaining: n_vars,
 			prefix_sum: F::ZERO,
 			suffix_sums,
-			last_coeffs_or_claim: RoundCoeffsOrClaim::Claim(eval_claim),
+			last_coeffs_or_claim: RoundState::Claim(eval_claim),
 		}
 	}
 
@@ -275,8 +270,8 @@ impl<F: Field, P: PackedField<Scalar = F>, Data: Deref<Target = [P]>> SumcheckPr
 
 	fn round_claim(&self) -> Vec<F> {
 		let claim = match &self.last_coeffs_or_claim {
-			RoundCoeffsOrClaim::Claim(claim) => *claim,
-			RoundCoeffsOrClaim::Coeffs(coeffs) => {
+			RoundState::Claim(claim) => *claim,
+			RoundState::Coeffs(coeffs) => {
 				let alpha = self.eval_point[self.n_vars_remaining - 1];
 				coeffs.lerp_over_endpoints(alpha)
 			}
@@ -285,9 +280,7 @@ impl<F: Field, P: PackedField<Scalar = F>, Data: Deref<Target = [P]>> SumcheckPr
 	}
 
 	fn execute(&mut self) -> Result<Vec<RoundCoeffs<F>>, Error> {
-		let RoundCoeffsOrClaim::Claim(_claim) = &self.last_coeffs_or_claim else {
-			return Err(Error::ExpectedFold);
-		};
+		self.last_coeffs_or_claim.claim()?;
 
 		if self.n_vars_remaining == 0 {
 			return Err(Error::ExpectedFinish);
@@ -314,14 +307,12 @@ impl<F: Field, P: PackedField<Scalar = F>, Data: Deref<Target = [P]>> SumcheckPr
 		}
 
 		let round_coeffs = RoundCoeffs(round_coeffs_vec);
-		self.last_coeffs_or_claim = RoundCoeffsOrClaim::Coeffs(round_coeffs.clone());
+		self.last_coeffs_or_claim = RoundState::Coeffs(round_coeffs.clone());
 		Ok(vec![round_coeffs])
 	}
 
 	fn fold(&mut self, challenge: F) -> Result<(), Error> {
-		let RoundCoeffsOrClaim::Coeffs(coeffs) = &self.last_coeffs_or_claim else {
-			return Err(Error::ExpectedExecute);
-		};
+		let coeffs = self.last_coeffs_or_claim.coeffs()?;
 
 		// Evaluate round polynomial at challenge to get new claim
 		let new_claim = coeffs.evaluate(challenge);
@@ -332,17 +323,14 @@ impl<F: Field, P: PackedField<Scalar = F>, Data: Deref<Target = [P]>> SumcheckPr
 		self.prefix_sum += self.mask.evaluate_univariate(var_idx, challenge);
 
 		self.n_vars_remaining -= 1;
-		self.last_coeffs_or_claim = RoundCoeffsOrClaim::Claim(new_claim);
+		self.last_coeffs_or_claim = RoundState::Claim(new_claim);
 
 		Ok(())
 	}
 
 	fn finish(self) -> Result<Vec<F>, Error> {
 		if self.n_vars_remaining > 0 {
-			return match self.last_coeffs_or_claim {
-				RoundCoeffsOrClaim::Coeffs(_) => Err(Error::ExpectedFold),
-				RoundCoeffsOrClaim::Claim(_) => Err(Error::ExpectedExecute),
-			};
+			return Err(self.last_coeffs_or_claim.unfinished_err());
 		}
 
 		// Final evaluation of g at the challenge point is prefix_sum


### PR DESCRIPTION
Closes [BINIUS-203](https://linear.app/jimpo/issue/BINIUS-203).

> **Stacked on #1670** (BINIUS-201). Until that merges, the diff here also shows its commit — review the top commit (`BINIUS-203`) only, and merge after #1670.

Makes the single-claim quadratic MLE-check prover a thin wrapper over the batch prover, deleting the duplicated round loop. Pure refactor — no behavior change.

### The problem

Two provers implement the same degree-2 MLE-check algorithm.
`QuadraticMleCheckProver` proves one composition; `BatchQuadraticMleCheckProver` proves `M` at once.

The batch prover's per-round loop is chunked, so the equality-indicator chunk stays in L1, and it accumulates in unreduced (wide) form.
The single-claim prover carried its own copy of that loop, and it was the worse copy:
- it was not chunked,
- its hot loop did bounds-checked random indexing into a `Vec` of split halves, one index per input per row.

So there were two round loops for one algorithm, and the hot single-claim path was the slower one.

### The idea

The single-claim prover is just the batch prover with `M = 1`.

A small trait captures "evaluate the `M` compositions on one packed row":

```rust
pub trait QuadraticComposition<P, const N: usize, const M: usize> {
    fn evaluate(&self, inputs: [P; N], outputs: &mut [P; M]);
}
```

- Every `Fn([P; N], &mut [P; M])` closure implements it via a blanket impl, so existing batch call sites are unaffected.
- A single-output `Fn([P; N]) -> P` is adapted to `M = 1` by a wrapper that writes its one value into the length-1 output.

`BatchQuadraticMleCheckProver` switches its bound to this trait.
`QuadraticMleCheckProver` becomes a newtype over `BatchQuadraticMleCheckProver<..., 1>` that adapts the composition and delegates.

### The change

```
- for j in 0..N {
-     evals_1[j]   = splits_1[j].as_ref()[i];        // bounds-checked, per input per row
-     evals_inf[j] = splits_0[j].as_ref()[i] + splits_1[j].as_ref()[i];
- }
- // ...its own non-chunked round loop...
+ // QuadraticMleCheckProver::new wraps each Fn([P; N]) -> P and defers to the batch prover,
+ // which runs the chunked, wide-accumulated loop.
```

### Soundness

Pure refactor — no protocol, transcript, or arithmetic change.
The chunked loop only reorders a sum of field elements, and field addition is commutative, so the round polynomials are bit-identical.
The existing conformance test (a batch of two vs. two single-claim provers) passes unchanged and guards this.

### Scope

- **new:** the `QuadraticComposition` trait, its blanket impl, and a single-output adapter.
- **removed:** the single-claim prover's hand-rolled round loop and state machine (~150 lines).
- **unchanged:** the public type `QuadraticMleCheckProver` and its `new` — every call site (`spartan-prover`, `and_reduction`, `intmul`, benches) is untouched.
- the fractional-addition prover annotates its closure arguments, since the blanket impl does not back-propagate the expected closure signature to untyped parameters.

### Verification

- `cargo check --workspace --all-targets`, `clippy -p binius-ip-prover -p binius-prover -p binius-spartan-prover --all-targets`, nightly `fmt` — clean
- `binius-ip-prover` — 50 tests pass, incl. `test_batch_quadratic_mlecheck_conforms_to_single_quadratic_mlecheck`
- `binius-prover` and `binius-spartan-prover` — tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)