### PR TITLE
BINIUS-199: parallelize the pushforward scatter-add in the logUp* prover

### DIFF
--- a/crates/ip-prover/src/logup_star/witness.rs
+++ b/crates/ip-prover/src/logup_star/witness.rs
@@ -11,6 +11,7 @@
 
 use binius_field::{BinaryField1b, ExtensionField, Field, PackedField};
 use binius_math::{FieldBuffer, multilinear::eq::eq_ind_partial_eval};
+use binius_utils::rayon::prelude::*;
 
 /// Embed a table position `j` into the field through the `GF(2)`-linear basis.
 ///
@@ -97,10 +98,101 @@ where
 	F: Field,
 	P: PackedField<Scalar = F>,
 {
-	// Scatter-add the looker numerator onto its table position, summing collisions.
-	let mut values = vec![F::ZERO; 1usize << table_n_vars];
-	for (eq_i, &j) in eq_r.iter_scalars().zip(index) {
-		values[j] += eq_i;
-	}
+	// Row count at or above which parallel scatter beats the single-threaded scan.
+	//
+	// Obtained by experimentation, can be tuned in the future.
+	const PARALLEL_THRESHOLD: usize = 1 << 18;
+
+	let table_size = 1usize << table_n_vars;
+
+	let values = if index.len() < PARALLEL_THRESHOLD {
+		// One thread scatters every row into a single bucket array.
+		let mut buckets = vec![F::ZERO; table_size];
+		for (eq_i, &j) in eq_r.iter_scalars().zip(index) {
+			buckets[j] += eq_i;
+		}
+		buckets
+	} else {
+		// Each job folds a contiguous run of rows into its own bucket array, reading eq_r in order.
+		//
+		// The per-job arrays are then summed position by position.
+		index
+			.par_iter()
+			.enumerate()
+			.fold(
+				|| vec![F::ZERO; table_size],
+				|mut buckets, (i, &j)| {
+					buckets[j] += eq_r.get(i);
+					buckets
+				},
+			)
+			.reduce(
+				|| vec![F::ZERO; table_size],
+				|mut acc, partial| {
+					for (slot, add) in acc.iter_mut().zip(partial) {
+						*slot += add;
+					}
+					acc
+				},
+			)
+	};
 	FieldBuffer::from_values(&values)
+}
+
+#[cfg(test)]
+mod tests {
+	use binius_field::{
+		Field,
+		arch::{OptimalB128, OptimalPackedB128},
+	};
+	use binius_math::{FieldBuffer, test_utils::random_field_buffer};
+	use proptest::prelude::*;
+	use rand::prelude::*;
+
+	use super::pushforward;
+
+	type F = OptimalB128;
+	type P = OptimalPackedB128;
+
+	// An independent single-threaded scatter, the reference the dispatched result must match.
+	fn reference(eq_r: &FieldBuffer<P>, index: &[usize], m: usize) -> Vec<F> {
+		let mut values = vec![F::ZERO; 1usize << m];
+		for (i, &j) in index.iter().enumerate() {
+			values[j] += eq_r.get(i);
+		}
+		values
+	}
+
+	// Assert pushforward equals the reference on a random instance of shape (n, m).
+	fn check(n: usize, m: usize, seed: u64) {
+		let mut rng = StdRng::seed_from_u64(seed);
+		let eq_r = random_field_buffer::<P>(&mut rng, n);
+		let index = (0..(1usize << n))
+			.map(|_| rng.random_range(0..(1usize << m)))
+			.collect::<Vec<_>>();
+
+		let got = pushforward::<F, P>(&eq_r, &index, m)
+			.iter_scalars()
+			.collect::<Vec<_>>();
+		assert_eq!(got, reference(&eq_r, &index, m));
+	}
+
+	proptest! {
+		#![proptest_config(ProptestConfig::with_cases(8))]
+
+		// 2^18 rows crosses the threshold, so this fuzzes the parallel scatter.
+		// Small m forces heavy collisions into few buckets.
+		#[test]
+		fn parallel_scatter_matches_reference(seed in any::<u64>(), m in 1usize..=6) {
+			check(18, m, seed);
+		}
+	}
+
+	#[test]
+	fn sequential_scatter_matches_reference() {
+		// Below the threshold the single-threaded path runs.
+		// n = 0 is the one-row edge; (10, 1) packs 2^10 rows into 2 buckets.
+		check(0, 3, 7);
+		check(10, 1, 42);
+	}
 }


### PR DESCRIPTION
Closes [BINIUS-199](https://linear.app/jimpo/issue/BINIUS-199/parallelize-the-pushforward-scatter-add-in-the-logup-prover).

Parallelizes the pushforward scatter-add, the one witness step that scales with the large dimension. The result is identical to the single-threaded version — no protocol change.

### The problem

The pushforward `Y = I_* eq_r` is built by scattering each of the $2^n$ looker rows onto its table position:

```
Y[j] = sum over { i : index[i] == j } of eq_r[i]
```

There are $2^n$ looker rows against only $2^m$ table entries, with $m \ll n$, so this scan scales with the large dimension. It ran single-threaded.

### The idea

Rows collide — several can map to the same table position — so this is a histogram, not a map. A naive parallel loop would race on the shared buckets.

Instead each rayon job scatters its contiguous run of rows into its **own** private $2^m$ bucket array, and the per-job arrays are then summed position by position. The bucket arrays are tiny ($m \ll n$), so the copies and the final reduction are cheap next to the scatter.

### The threshold

The parallel path has a fixed floor: the rayon dispatch plus one $2^m$ bucket array per job. Below a certain size that floor costs more than the scatter it saves, so `pushforward` falls back to the single-threaded scan.

A sweep (`GF(2^128)`, 10 threads, `m = 6`) puts the crossover near $2^{18}$ rows, which is the chosen threshold:

| n | rows | sequential | parallel | speedup |
|---|---|---|---|---|
| 8  | 256  | 274 ns  | 77.7 µs | 0.00× |
| 12 | 4 K  | 3.73 µs | 128 µs  | 0.03× |
| 16 | 64 K | 64.1 µs | 170 µs  | 0.38× |
| 18 | 256 K | 265 µs | 241 µs  | 1.10× |
| 20 | 1 M  | 1.06 ms | 422 µs  | 2.51× |
| 22 | 4 M  | 4.20 ms | 1.20 ms | 3.51× |

Below $2^{18}$ the single-threaded scan wins; at and above it the parallel scatter pulls ahead, reaching ~3.5× by $2^{22}$.

### Benchmark code

Self-contained timer (drop into `mod tests`, run with `cargo test -p binius-ip-prover --release --features rayon -- --ignored --nocapture scatter_bench`):

```rust
#[test]
#[ignore]
fn scatter_bench() {
    use std::{hint::black_box, time::Instant};
    use binius_utils::rayon::prelude::*;

    fn scatter_sequential(eq_r: &FieldBuffer<P>, index: &[usize], m: usize) -> Vec<F> {
        let mut b = vec![F::ZERO; 1 << m];
        for (eq_i, &j) in eq_r.iter_scalars().zip(index) {
            b[j] += eq_i;
        }
        b
    }

    fn scatter_parallel(eq_r: &FieldBuffer<P>, index: &[usize], m: usize) -> Vec<F> {
        let size = 1usize << m;
        index
            .par_iter()
            .enumerate()
            .fold(|| vec![F::ZERO; size], |mut b, (i, &j)| { b[j] += eq_r.get(i); b })
            .reduce(|| vec![F::ZERO; size], |mut a, p| {
                for (x, y) in a.iter_mut().zip(p) { *x += y; }
                a
            })
    }

    let m = 6;
    let threads = std::thread::available_parallelism().map_or(1, |t| t.get());
    println!("scatter-add (m={m}, threads={threads})");
    for n in [8usize, 10, 12, 14, 16, 18, 20, 22] {
        let mut rng = StdRng::seed_from_u64(0);
        let eq_r = random_field_buffer::<P>(&mut rng, n);
        let index = (0..(1usize << n))
            .map(|_| rng.random_range(0..(1usize << m)))
            .collect::<Vec<_>>();
        let iters = (1usize << 26 >> n).max(10) as u32;

        black_box(scatter_parallel(&eq_r, &index, m)); // warm the pool
        let t = Instant::now();
        for _ in 0..iters { black_box(scatter_sequential(black_box(&eq_r), black_box(&index), m)); }
        let seq = t.elapsed() / iters;
        let t = Instant::now();
        for _ in 0..iters { black_box(scatter_parallel(black_box(&eq_r), black_box(&index), m)); }
        let par = t.elapsed() / iters;
        println!("n={n}: sequential {seq:?}, parallel {par:?}, {:.2}x",
                 seq.as_secs_f64() / par.as_secs_f64());
    }
}
```

### Scope

- **changed:** `pushforward` in `crates/ip-prover/src/logup_star/witness.rs` — the scatter now branches on the threshold.
- This speeds the scatter **step**. It is a small fraction of the whole prove, whose dominant cost is elsewhere (`looker_denominator`), so end-to-end prove time is roughly unchanged; that hotspot is a separate follow-up.
- The parallel path only engages when the crate is built with the `rayon` feature.

### Verification

- `cargo check --workspace --all-targets`, `clippy -p binius-ip-prover --all-targets -- -D warnings` (rayon on and off), nightly `fmt --all` — all clean.
- proptest: the parallel scatter equals the single-threaded reference at $2^{18}$ rows across a range of `m` (heavy to light collisions); a separate test covers the below-threshold path at the one-row edge and a 2-bucket case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)