### PR TITLE
Fix FieldBuffer::eq ignoring length in the sub-packed branch

### DIFF
--- a/crates/math/src/field_buffer.rs
+++ b/crates/math/src/field_buffer.rs
@@ -36,8 +36,17 @@ pub struct FieldBuffer<P: PackedField, Data: Deref<Target = [P]> = Box<[P]>> {
 
 impl<P: PackedField, Data: Deref<Target = [P]>> PartialEq for FieldBuffer<P, Data> {
 	fn eq(&self, other: &Self) -> bool {
-		// Custom equality impl is needed because values beyond length until capacity can be
-		// arbitrary.
+		// Lanes from the logical length up to the capacity hold arbitrary data.
+		// Equality compares only the live scalars, never the raw packed backing store.
+		//
+		// Invariant: buffers of different lengths are never equal.
+		//
+		// The length-below-width branch compares only a prefix of a single packed word.
+		//   - Shorter and longer buffers sharing that prefix would otherwise compare equal.
+		//   - The shorter buffer's out-of-range lanes are arbitrary and must not be read.
+		if self.log_len != other.log_len {
+			return false;
+		}
 		if self.log_len < P::LOG_WIDTH {
 			let iter_1 = self
 				.values
@@ -54,7 +63,7 @@ impl<P: PackedField, Data: Deref<Target = [P]>> PartialEq for FieldBuffer<P, Dat
 			iter_1.eq(iter_2)
 		} else {
 			let prefix = 1 << (self.log_len - P::LOG_WIDTH);
-			self.log_len == other.log_len && self.values[..prefix] == other.values[..prefix]
+			self.values[..prefix] == other.values[..prefix]
 		}
 	}
 }
@@ -773,6 +782,8 @@ impl<'a, P: PackedField> Drop for FieldBufferChunkMutInner<'a, P> {
 
 #[cfg(test)]
 mod tests {
+	use proptest::prelude::*;
+
 	use super::*;
 	use crate::test_utils::{B128, Packed128b};
 
@@ -1462,5 +1473,27 @@ mod tests {
 	fn test_split_half_mut_size_one() {
 		let mut buffer = FieldBuffer::<P>::zeros(0); // 1 element
 		let _ = buffer.split_half_mut();
+	}
+
+	proptest! {
+		#[test]
+		fn unequal_length_buffers_are_never_equal(
+			log_len_a in 0usize..=6,
+			log_len_b in 0usize..=6,
+			fill in any::<u128>(),
+		) {
+			// Invariant: buffers are equal iff same length and same scalars.
+			let value = F::new(fill);
+			let buf_a = FieldBuffer::<P>::from_values(&vec![value; 1 << log_len_a]);
+			let buf_b = FieldBuffer::<P>::from_values(&vec![value; 1 << log_len_b]);
+
+			// - Same length -> equal;
+			// - Different length -> unequal despite matching scalars.
+			if log_len_a == log_len_b {
+				prop_assert_eq!(buf_a, buf_b);
+			} else {
+				prop_assert_ne!(buf_a, buf_b);
+			}
+		}
 	}
 }


### PR DESCRIPTION
Makes `FieldBuffer` equality respect length in the small-buffer branch, so buffers of different lengths are never equal.
Fixes a real bug — the previous code could report two different-length buffers as equal and read out-of-range lanes.

### The problem

A `FieldBuffer` stores scalars in packed words, and the lanes between the logical length and the capacity hold **arbitrary** data.
So equality cannot compare the raw backing store — it must compare only the live scalars, keyed off length.

The wide branch (length $\geq$ packing width) checked `self.log_len == other.log_len`.
The small branch (length $<$ packing width) did **not**.
It compared only the first `1 << self.log_len` lanes of a single packed word, ignoring the other buffer's length entirely.

Two things went wrong as a result:

- A length-1 buffer and a length-2 buffer that agree on the first element compared **equal**.
- When the other buffer was the shorter one, the comparison read its **out-of-range lanes** — arbitrary capacity data — as if they were live scalars.

### The idea

Gate equality on length once, up front, before either branch:

```
if self.log_len != other.log_len {
    return false;
}
```

Different lengths are never equal.
The redundant length check in the wide branch then goes away.

### The change

```diff
 fn eq(&self, other: &Self) -> bool {
+    if self.log_len != other.log_len {
+        return false;
+    }
     if self.log_len < P::LOG_WIDTH {
         // compare 1 << self.log_len lanes of the single packed word
     } else {
-        self.log_len == other.log_len && self.values[..prefix] == other.values[..prefix]
+        self.values[..prefix] == other.values[..prefix]
     }
 }
```

### Scope

- **changed:** the `PartialEq` impl in `crates/math/src/field_buffer.rs` — one early-return guard, one redundant clause removed.
- **new:** a proptest that fills both buffers with the same scalar over `log_len` in `0..=6` (spanning both branches, since the packing width is 4).
- Same length must compare equal; different length must not — regardless of matching contents.
- No public API change, no behavior change for equal-length buffers.

### Verification

- `cargo +nightly fmt --all`, `cargo check --workspace --all-targets`, `cargo clippy -p binius-math --all-targets` — all clean.
- `cargo test -p binius-math field_buffer` — 32 passed.
- Confirmed the proptest is a real regression test: with the guard removed it fails and shrinks to the exact witness `log_len_a = 0`, `log_len_b = 1` (length 1 vs length 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)