### PR TITLE
BINIUS-205: rework the intmul phase 4/5 handoff

### DIFF
--- a/crates/prover/benches/intmul.rs
+++ b/crates/prover/benches/intmul.rs
@@ -150,7 +150,7 @@ fn bench_intmul_phases(c: &mut Criterion) {
 			exp_eval,
 		)
 	};
-	let (phase4, leaves) = {
+	let (phase4_claims, phase4_eval_point) = {
 		let mut transcript = ProverTranscript::new(StdChallenger::default());
 		let mut prover = IntMulProver::<P, _>::new(0, &mut transcript);
 		prover.phase4(
@@ -226,22 +226,23 @@ fn bench_intmul_phases(c: &mut Criterion) {
 
 	group.bench_function("phase5", |bencher| {
 		bencher.iter_batched(
-			|| leaves.clone(),
-			|[a_leaves, c_lo_leaves, c_hi_leaves]| {
+			|| phase4_claims.clone(),
+			|[a_claim, c_lo_claim, c_hi_claim]| {
 				let mut transcript = ProverTranscript::new(StdChallenger::default());
 				let mut prover = IntMulProver::<P, _>::new(0, &mut transcript);
 				prover.phase5(
 					log_bits,
-					&phase4.eval_point,
-					(&phase4.a_evals, a_leaves),
-					(&phase4.c_lo_evals, c_lo_leaves),
-					(&phase4.c_hi_evals, c_hi_leaves),
+					&phase4_eval_point,
+					a_claim,
+					c_lo_claim,
+					c_hi_claim,
 					witness.b_exponents,
 					&phase3.eval_point,
 					&phase3.r_ib,
 					phase3.b_recomb,
 					witness.a_exponents,
 					witness.c_lo_exponents,
+					witness.c_hi_exponents,
 				)
 			},
 			BatchSize::SmallInput,

--- a/crates/prover/src/protocols/intmul/prove.rs
+++ b/crates/prover/src/protocols/intmul/prove.rs
@@ -1,6 +1,6 @@
 // Copyright 2025 Irreducible Inc.
 
-use std::{iter, marker::PhantomData};
+use std::marker::PhantomData;
 
 use binius_core::word::Word;
 use binius_field::{BinaryField, FieldOps, PackedField};
@@ -9,10 +9,9 @@ use binius_ip_prover::{
 	channel::IPProverChannel,
 	prodcheck::{self, ProdcheckProver},
 	sumcheck::{
-		MleToSumCheckDecorator,
+		MleToSumCheckDecorator, PaddedSumcheckDecorator,
 		batch::{BatchSumcheckOutput, batch_prove, batch_prove_and_write_evals},
 		bivariate_product_mle,
-		bivariate_product_multi_mle::BivariateProductMultiMlecheckProver,
 		multilinear_eval::MultilinearEvalProver,
 		quadratic_mle::QuadraticMleCheckProver,
 		selector_mle::{Claim, SelectorMlecheckProver},
@@ -28,13 +27,12 @@ use binius_math::{
 };
 use binius_utils::{checked_arithmetics::log2_ceil_usize, rayon::prelude::*};
 use binius_verifier::protocols::intmul::common::{
-	IntMulOutput, Phase1Output, Phase2Output, Phase3Output, Phase4Output, frobenius_twist,
-	normalize_a_c_exponent_evals,
+	IntMulOutput, Phase1Output, Phase2Output, Phase3Output, frobenius_twist,
 };
 use either::Either;
-use itertools::{chain, izip};
+use itertools::izip;
 
-use super::witness::{Witness, buffer_bivariate_product, two_valued_field_buffer};
+use super::witness::{Witness, two_valued_field_buffer};
 use crate::fold_word::{fold_across_words, fold_words};
 
 /// A helper structure that encapsulates switchover settings and the prover channel for
@@ -98,6 +96,7 @@ where
 			c_lo_exponents,
 			c_lo_prodcheck,
 			c_lo_root,
+			c_hi_exponents,
 			c_hi_prodcheck,
 			c_hi_root,
 		} = witness;
@@ -146,15 +145,7 @@ where
 		);
 
 		// Phase 4
-		let (
-			Phase4Output {
-				eval_point: phase4_eval_point,
-				a_evals,
-				c_lo_evals,
-				c_hi_evals,
-			},
-			[a_leaves, c_lo_leaves, c_hi_leaves],
-		) = self.phase4(
+		let ([a_claim, c_lo_claim, c_hi_claim], phase4_eval_point) = self.phase4(
 			log_bits,
 			&phase3_eval_point,
 			(gpow_a_eval, a_prodcheck),
@@ -166,15 +157,16 @@ where
 		self.phase5(
 			log_bits,
 			&phase4_eval_point,
-			(&a_evals, a_leaves),
-			(&c_lo_evals, c_lo_leaves),
-			(&c_hi_evals, c_hi_leaves),
+			a_claim,
+			c_lo_claim,
+			c_hi_claim,
 			b_exponents,
 			&phase3_eval_point,
 			&r_ib,
 			b_recomb,
 			a_exponents,
 			c_lo_exponents,
+			c_hi_exponents,
 		)
 	}
 
@@ -314,8 +306,7 @@ where
 		(a_root_eval, a_prover): (F, ProdcheckProver<P>),
 		(gpow_c_lo_eval, c_lo_prover): (F, ProdcheckProver<P>),
 		(gpow_c_hi_eval, c_hi_prover): (F, ProdcheckProver<P>),
-	) -> (Phase4Output<F>, [Vec<FieldBuffer<P>>; 3]) {
-		let n_vars = eval_point.len();
+	) -> ([(F, ProdcheckProver<P>); 3], Vec<F>) {
 		// Each prover is over the full (widest) leaf layer of `2^log_bits` node multilinears.
 		assert_eq!(a_prover.n_layers(), log_bits);
 		assert_eq!(c_lo_prover.n_layers(), log_bits);
@@ -327,7 +318,8 @@ where
 		// Run the batched prodcheck: content point is the Phase-3 evaluation point at which the
 		// three roots are claimed. This runs `log_bits - 1` reduction layers, reducing the three
 		// trees down to (but not including) their final (widest) leaf layer, which it returns
-		// inside the remaining provers.
+		// inside the remaining provers. Each remaining prover is paired with its reduced eval at
+		// the shared reduced point.
 		let prodcheck::BatchProveOutput {
 			eval_point: reduced_point,
 			provers,
@@ -339,55 +331,21 @@ where
 			self.channel,
 		);
 
-		// The reduced point is [selector (2), suffix (n_vars), bit_index (log_bits - 1)]. The
-		// suffix is the content point at which the all-but-last node multilinears are now
-		// claimed.
+		// The reduced point is [selector (2), suffix (n_vars), bit_index (log_bits - 1)]. Drop the
+		// selector coordinates: `[suffix, bit_index]` is the point at which each retained
+		// all-but-last-layer node multilinear is now claimed, and is the content+node point the
+		// Phase-5 final-layer sumchecks bind. Hand the three per-tree reduced claims (eval +
+		// retained final layer) straight through to Phase 5 — no all-but-last-layer evals are
+		// recomputed or sent here.
 		let selector_len = log2_ceil_usize(3);
-		let suffix = reduced_point[selector_len..selector_len + n_vars].to_vec();
+		let a_c_eval_point = reduced_point[selector_len..].to_vec();
 
-		// Extract each tree's retained leaf layer as `2^log_bits` per-node n_vars-variate buffers,
-		// in the natural node order produced by `constant_base_leaves` (node `z` carries bit `z`).
-		// The prodcheck reduces on the highest node bit, so the all-but-last-layer node `z` is the
-		// product of leaves `z` and `z + half` (a strided pairing of bits `z` and `z + half`).
-		let [a_leaves, c_lo_leaves, c_hi_leaves] = provers
-			.into_iter()
-			.map(|(_eval, prover)| split_leaf_layer(prover.into_final_layer(), n_vars))
-			.collect::<Vec<_>>()
+		let claims: [(F, ProdcheckProver<P>); 3] = provers
 			.try_into()
+			.ok()
 			.expect("batch_prove returns three provers");
 
-		// Compute the all-but-last-layer (`2^(log_bits - 1)` node) evals at `suffix` by folding the
-		// pairwise leaf products. Node `z` = leaf[z] * leaf[z + half].
-		// TODO: these leaf evals should later be pulled directly out of the sumcheck folding in the
-		// last prodcheck layer rather than recomputed.
-		let suffix_tensor = eq_ind_partial_eval(&suffix);
-		let half = 1 << (log_bits - 1);
-		let leaf_evals = |leaves: &[FieldBuffer<P>]| {
-			(0..half)
-				.map(|z| {
-					let node = buffer_bivariate_product(&leaves[z], &leaves[z + half]);
-					inner_product_buffers(&node, &suffix_tensor)
-				})
-				.collect::<Vec<_>>()
-		};
-
-		let a_evals = leaf_evals(&a_leaves);
-		let c_lo_evals = leaf_evals(&c_lo_leaves);
-		let c_hi_evals = leaf_evals(&c_hi_leaves);
-
-		self.channel.send_many(&a_evals);
-		self.channel.send_many(&c_lo_evals);
-		self.channel.send_many(&c_hi_evals);
-
-		(
-			Phase4Output {
-				eval_point: suffix,
-				a_evals,
-				c_lo_evals,
-				c_hi_evals,
-			},
-			[a_leaves, c_lo_leaves, c_hi_leaves],
-		)
+		(claims, a_c_eval_point)
 	}
 
 	#[doc(hidden)] // exposed for benchmarking (`benches/intmul.rs`), not a stable API
@@ -396,39 +354,50 @@ where
 		&mut self,
 		log_bits: usize,
 		a_c_eval_point: &[F],
-		(a_evals, a_layer): (&[F], Vec<FieldBuffer<P>>),
-		(c_lo_evals, c_lo_layer): (&[F], Vec<FieldBuffer<P>>),
-		(c_hi_evals, c_hi_layer): (&[F], Vec<FieldBuffer<P>>),
+		a_claim: (F, ProdcheckProver<P>),
+		c_lo_claim: (F, ProdcheckProver<P>),
+		c_hi_claim: (F, ProdcheckProver<P>),
 		b_exponents: &[Word],
 		b_eval_point: &[F],
 		r_ib: &[F],
 		b_recomb: F,
-		// Needed for the zerocheck on `a_0 * b_0 = c_lo_0`.
+		// The exponents supply the overflow zerocheck bits (`a_0`, `c_lo_0`) and the raw per-bit
+		// output evaluations.
 		a_exponents: &[Word],
 		c_lo_exponents: &[Word],
+		c_hi_exponents: &[Word],
 	) -> IntMulOutput<F> {
 		assert!(log_bits >= 1);
-		assert_eq!(1 << log_bits, a_layer.len());
-		assert_eq!(2 * a_evals.len(), a_layer.len());
-		assert_eq!(2 * c_lo_evals.len(), c_lo_layer.len());
-		assert_eq!(2 * c_hi_evals.len(), c_hi_layer.len());
-		assert_eq!(b_eval_point.len(), a_layer.first().expect("log_bits >= 1").log_len());
-		assert_eq!(a_c_eval_point.len(), b_eval_point.len());
+		let n_vars = b_eval_point.len();
+		// `a_c_eval_point = [suffix (n_vars), bit_index (log_bits - 1)]` — the content point plus
+		// the all-but-last-layer node coordinates. The final-layer sumchecks bind all of it; the
+		// overflow and `b` checks span only the `n_vars` content coordinates and are padded up.
+		let n_extra = log_bits - 1;
+		assert_eq!(a_c_eval_point.len(), n_vars + n_extra);
 
-		// Make the `BivariateProductMultiMlecheckProver` prover.
-		// The prover proves an MLE eval claim on each pair of the retained leaf layer. The leaf
-		// layer is in natural node order (node `z` carries bit `z`), so pairing node `z` with node
-		// `z + half` reproduces the bivariate-product layer the verifier expects (with pair `z`
-		// being the strided bits `z` and `z + half`).
-		let pairs = chain!(split_pairs(a_layer), split_pairs(c_lo_layer), split_pairs(c_hi_layer))
-			.collect::<Vec<_>>();
-		let evals = [a_evals, c_lo_evals, c_hi_evals].concat();
+		// Send the three per-tree reduced claims. The verifier checks they combine, weighted by
+		// eq(selector), to the batched prodcheck output claim, then uses each as the seed for that
+		// tree's final-layer sumcheck.
+		let (a_eval, a_prover) = a_claim;
+		let (c_lo_eval, c_lo_prover) = c_lo_claim;
+		let (c_hi_eval, c_hi_prover) = c_hi_claim;
+		self.channel.send_many(&[a_eval, c_lo_eval, c_hi_eval]);
 
-		let bivariate_mle_prover =
-			BivariateProductMultiMlecheckProver::new(pairs, a_c_eval_point, evals);
-		let bivariate_sumcheck_prover = MleToSumCheckDecorator::new(bivariate_mle_prover);
+		// Prove the final (widest) GKR layer of each tree as a regular prodcheck-layer bivariate
+		// product MLE-check, seeded by the tree's reduced claim, wrapped as a sumcheck.
+		let make_tree_prover = |eval: F, prover: ProdcheckProver<P>| {
+			let (mle_prover, remaining) = prover.layer_prover(MultilinearEvalClaim {
+				eval,
+				point: a_c_eval_point.to_vec(),
+			});
+			debug_assert!(remaining.is_none(), "one retained layer per tree");
+			MleToSumCheckDecorator::new(mle_prover)
+		};
+		let a_tree = make_tree_prover(a_eval, a_prover);
+		let c_lo_tree = make_tree_prover(c_lo_eval, c_lo_prover);
+		let c_hi_tree = make_tree_prover(c_hi_eval, c_hi_prover);
 
-		// Embed `a_0` and `b_0` bits into field buffers for `BivariateProductMultiMlecheckProver`.
+		// Embed `a_0`, `b_0`, `c_lo_0` bits into field buffers for the overflow zerocheck.
 		let binary_elements = [F::zero(), F::one()];
 
 		// TODO: Use a special 1-bit-optimized MLE-check with switchover to save memory.
@@ -436,135 +405,101 @@ where
 		let b_0: FieldBuffer<P> = two_valued_field_buffer(0, b_exponents, binary_elements);
 		let c_lo_0: FieldBuffer<P> = two_valued_field_buffer(0, c_lo_exponents, binary_elements);
 
-		// Make the sumcheck prover for the overflow parity check, binding it at the Phase-2
-		// constraint point `b_eval_point` (r_2) per the spec (reused for free from the `b`
-		// re-randomization) rather than the Phase-4 point.
-		let overflow_prover =
+		// The overflow parity check binds at the Phase-2 constraint point `b_eval_point` (r_2) —
+		// reused for free from the `b` re-randomization. It spans only the `n_vars` content
+		// coordinates, so pad it up by `n_extra` variables to batch with the final-layer sumchecks.
+		let overflow_prover = PaddedSumcheckDecorator::new(
 			MleToSumCheckDecorator::new(QuadraticMleCheckProver::<P, _, _, 3>::new(
 				[a_0, b_0, c_lo_0],
 				|[a, b, c]| a * b - c,
 				|[a, b, _c]| a * b,
 				b_eval_point.to_vec(),
 				F::ZERO,
-			));
+			)),
+			n_extra,
+		);
 
 		// Fold the 2^k b bit-columns by the recombination tensor into a single field multilinear
 		// B(x) = sum_i eq(r_I^b, i) * b(i, x), then re-randomize its claim B(r_2) = b_recomb from
-		// `b_eval_point` (r_2) to the shared point via a single-claim MLE-eval check. This
-		// replaces the 2^k separate b rerandomizations with the spec's single recombined claim.
-		assert_eq!(b_exponents.len(), 1 << b_eval_point.len());
-
+		// `b_eval_point` (r_2) to the shared point via a single-claim MLE-eval check, padded up.
+		assert_eq!(b_exponents.len(), 1 << n_vars);
 		let b_tensor = eq_ind_partial_eval_scalars::<F>(r_ib);
 		let b_folded = fold_words::<_, P>(b_exponents, &b_tensor);
+		let b_sumcheck_prover = PaddedSumcheckDecorator::new(
+			MleToSumCheckDecorator::new(MultilinearEvalProver::new(
+				b_folded,
+				b_eval_point,
+				b_recomb,
+			)),
+			n_extra,
+		);
 
-		let b_eval_prover = MultilinearEvalProver::new(b_folded, b_eval_point, b_recomb);
-		let b_sumcheck_prover = MleToSumCheckDecorator::new(b_eval_prover);
-
-		// Batch prove all three provers.
+		// Batch prove all five provers — the three final-layer sumchecks, the overflow zerocheck,
+		// and the `b` re-randomization — all over `n_vars + n_extra` variables.
 		let BatchSumcheckOutput {
 			challenges,
 			multilinear_evals,
 		} = batch_prove(
 			vec![
-				Either::Left(bivariate_sumcheck_prover),
+				Either::Left(a_tree),
+				Either::Left(c_lo_tree),
+				Either::Left(c_hi_tree),
 				Either::Right(Either::Left(overflow_prover)),
 				Either::Right(Either::Right(b_sumcheck_prover)),
 			],
 			self.channel,
 		);
 
-		// Pull out the evals of all three provers. The b prover is now a single-claim MLE-eval
-		// check, so it yields one recombined eval B(r_x) rather than 2^k per-bit evals.
-		let [mut bivariate_evals, lsb_evals, b_recomb_evals] = multilinear_evals
-			.try_into()
-			.expect("batch_prove with 3 provers returns 3 multilinear_evals vecs");
+		// The reduced point is [r_content (n_vars), r_bit (n_extra)]: `r_content` is the shared
+		// evaluation point for the output claims; `r_bit` collapses the node dimension (and is the
+		// padding point for the overflow / `b` checks).
+		let (r_content, _r_bit) = challenges.split_at(n_vars);
 
-		assert_eq!(bivariate_evals.len(), 3 << log_bits);
-		assert_eq!(lsb_evals.len(), 3);
-		assert_eq!(b_recomb_evals.len(), 1);
-
-		// The prover still sends the 2^k raw per-bit evals b(i, r_x) for Phase-5 leaf
-		// reconstruction; the verifier binds them via sum_i eq(r_I^b, i) * b(i, r_x) = B(r_x).
-		let b_evals = fold_across_words::<_, P>(b_exponents, &challenges).to_vec();
-
-		// Sanity: the single recombined rerandomization eval B(r_x) equals the recombination of
-		// the raw per-bit evals.
-		debug_assert_eq!(
-			b_recomb_evals[0],
-			evaluate(&FieldBuffer::<P>::from_values(&b_evals), r_ib)
-		);
-
-		// The bivariate prover flattens its `(leaf[z], leaf[z + half])` pairs pair-major, so each
-		// tree's leaf evals come out interleaved as `[bit 0, bit half, bit 1, bit half+1, ...]`.
-		// De-interleave them back into bit order for `normalize_a_c_exponent_evals`.
-		let selected_c_hi_evals = deinterleave_pairs(bivariate_evals.split_off(2 << log_bits));
-		let selected_c_lo_evals = deinterleave_pairs(bivariate_evals.split_off(1 << log_bits));
-		let selected_a_evals = deinterleave_pairs(bivariate_evals);
-
-		// Recover the raw per-bit evaluations from the leaf selectors and send those (spec Phase
-		// 5). The verifier reconstructs the selectors forward rather than receiving them and
-		// inverting.
-		let [a_evals, c_lo_evals, c_hi_evals] = normalize_a_c_exponent_evals(
-			log_bits,
-			selected_a_evals,
-			selected_c_lo_evals,
-			selected_c_hi_evals,
-		);
+		// Send the raw per-bit output evals at `r_content`, computed directly from the exponents.
+		// The verifier reconstructs the selected leaf values from these and recombines them via
+		// eq(r_bit) to bind the final-layer sumchecks; it binds the `b` evals via
+		// sum_i eq(r_I^b, i) * b(i, r_content) = B(r_content).
+		let per_bit_evals =
+			|exponents: &[Word]| fold_across_words::<_, P>(exponents, r_content).to_vec();
+		let a_evals = per_bit_evals(a_exponents);
+		let c_lo_evals = per_bit_evals(c_lo_exponents);
+		let c_hi_evals = per_bit_evals(c_hi_exponents);
+		let b_evals = per_bit_evals(b_exponents);
 
 		self.channel.send_many(&a_evals);
 		self.channel.send_many(&c_lo_evals);
 		self.channel.send_many(&c_hi_evals);
 		self.channel.send_many(&b_evals);
 
-		let [a_0_eval, b_0_eval, c_lo_0_eval] =
-			lsb_evals.try_into().expect("c_lo_prover_evals.len() == 3");
-
+		// Sanity: the overflow zerocheck's finished per-bit evals and the `b` recombined eval match
+		// the sent raw evals. The padded provers' `finish` returns the inner multilinear evals.
+		let [
+			_a_evals2,
+			_c_lo_evals2,
+			_c_hi_evals2,
+			lsb_evals,
+			b_recomb_evals,
+		] = multilinear_evals
+			.try_into()
+			.expect("batch_prove with 5 provers returns 5 multilinear_evals vecs");
+		let [a_0_eval, b_0_eval, c_lo_0_eval] = lsb_evals
+			.try_into()
+			.expect("overflow prover has 3 multilinears");
 		debug_assert_eq!(a_0_eval, a_evals[0]);
 		debug_assert_eq!(b_0_eval, b_evals[0]);
 		debug_assert_eq!(c_lo_0_eval, c_lo_evals[0]);
+		debug_assert_eq!(b_recomb_evals.len(), 1);
+		debug_assert_eq!(
+			b_recomb_evals[0],
+			evaluate(&FieldBuffer::<P>::from_values(&b_evals), r_ib)
+		);
 
 		IntMulOutput {
-			eval_point: challenges,
+			eval_point: r_content.to_vec(),
 			a_evals,
 			b_evals,
 			c_lo_evals,
 			c_hi_evals,
 		}
 	}
-}
-
-/// Splits a prodcheck prover's retained leaf layer — one `(n_vars + log_bits)`-variate buffer with
-/// the node index in the high bits — into its `2^log_bits` per-node `n_vars`-variate buffers, in
-/// node order.
-fn split_leaf_layer<P: PackedField>(layer: FieldBuffer<P>, n_vars: usize) -> Vec<FieldBuffer<P>> {
-	let scalars = layer.iter_scalars().collect::<Vec<_>>();
-	let n_nodes = scalars.len() >> n_vars;
-	(0..n_nodes)
-		.map(|z| FieldBuffer::<P>::from_values(&scalars[z << n_vars..(z + 1) << n_vars]))
-		.collect()
-}
-
-/// Pairs the leaf layer's node `z` with node `z + half` (the highest-bit split), reproducing the
-/// bivariate-product pairing of the GKR tree's final layer. The layer is in natural node order, so
-/// this pairs bits `z` and `z + half` (a strided pairing).
-fn split_pairs<P: PackedField>(layer: Vec<FieldBuffer<P>>) -> Vec<[FieldBuffer<P>; 2]> {
-	let half = layer.len() / 2;
-	let (lo, hi) = layer.split_at(half);
-	iter::zip(lo.to_vec(), hi.to_vec())
-		.map(|(a, b)| [a, b])
-		.collect()
-}
-
-/// De-interleave a tree's leaf evals from the bivariate prover's pair-major order back into bit
-/// order.
-///
-/// The bivariate prover pairs leaf `z` with leaf `z + half` (the strided pairing of
-/// [`split_pairs`]) and flattens the pairs, so its leaf evals come out interleaved as
-/// `[bit 0, bit half, bit 1, bit half+1, ...]`: the even slots hold bits `0..half` and the odd
-/// slots hold bits `half..2·half`. Splitting the evens from the odds restores bit order
-/// `[bit 0, bit 1, ..., bit (2·half - 1)]`.
-fn deinterleave_pairs<F: Clone>(evals: Vec<F>) -> Vec<F> {
-	let evens = evals.iter().step_by(2);
-	let odds = evals.iter().skip(1).step_by(2);
-	evens.chain(odds).cloned().collect()
 }

--- a/crates/prover/src/protocols/intmul/witness.rs
+++ b/crates/prover/src/protocols/intmul/witness.rs
@@ -56,13 +56,17 @@ pub struct Witness<'a, P: PackedField> {
 	pub b_prodcheck: ProdcheckProver<P>,
 	/// The root of the b tree (product of all leaves element-wise).
 	pub b_root: FieldBuffer<P>,
-	/// The exponents for `c_lo` (needed for the phase 5 parity zerocheck on `c_lo_0`).
+	/// The exponents for `c_lo` (needed for the phase 5 parity zerocheck on `c_lo_0` and the raw
+	/// per-bit output evaluations).
 	#[getset(skip)]
 	pub c_lo_exponents: &'a [Word],
 	/// Prodcheck prover for the `c_lo` exponentiation tree (leaf layer retained).
 	pub c_lo_prodcheck: ProdcheckProver<P>,
 	/// The root of the `c_lo` tree.
 	pub c_lo_root: FieldBuffer<P>,
+	/// The exponents for `c_hi` (needed for the phase 5 raw per-bit output evaluations).
+	#[getset(skip)]
+	pub c_hi_exponents: &'a [Word],
 	/// Prodcheck prover for the `c_hi` exponentiation tree (leaf layer retained).
 	pub c_hi_prodcheck: ProdcheckProver<P>,
 	/// The root of the `c_hi` tree.
@@ -132,6 +136,7 @@ where
 			c_lo_exponents: c_lo,
 			c_lo_prodcheck,
 			c_lo_root,
+			c_hi_exponents: c_hi,
 			c_hi_prodcheck,
 			c_hi_root,
 		})

--- a/crates/verifier/src/protocols/intmul/common.rs
+++ b/crates/verifier/src/protocols/intmul/common.rs
@@ -51,13 +51,19 @@ pub struct Phase3Output<F> {
 /// Output of Phase 4: all but last GKR layer for $\widetilde{a}$, $\widetilde{c}_{\textsf{lo}}$,
 /// $\widetilde{c}_{\textsf{hi}}$.
 ///
-/// Contains the evaluation point and leaf evaluations for each of the three product trees at
-/// depth `log_bits - 1`.
+/// Rather than binding the all-but-last-layer evaluations here, Phase 4 hands the reduced prodcheck
+/// claim straight to Phase 5: the content-and-node point at which the three trees' all-but-last
+/// layers are claimed, the reduced selector coordinates that batch them, and the combined claimed
+/// evaluation. Phase 5 receives one reduced eval per tree and checks they recombine, weighted by
+/// `eq(selector)`, to `combined_eval`.
 pub struct Phase4Output<F> {
+	/// The point `[suffix, bit_index]` (content coordinates followed by all-but-last-layer node
+	/// coordinates) at which each tree's all-but-last-layer multilinear is claimed.
 	pub eval_point: Vec<F>,
-	pub a_evals: Vec<F>,
-	pub c_lo_evals: Vec<F>,
-	pub c_hi_evals: Vec<F>,
+	/// The reduced selector coordinates that batch the three trees (padded to four).
+	pub selector: Vec<F>,
+	/// The batched prodcheck output evaluation: `Σ_t eq(selector, t) · eval_t`.
+	pub combined_eval: F,
 }
 
 /// Compute the inverse Frobenius endomorphism $\varphi^{-i}(x)$.
@@ -139,74 +145,11 @@ where
 	}
 }
 
-/// Recovers the multilinear evaluations of the $a, c_{\textsf{lo}}, c_{\textsf{hi}}$ polynomials.
-///
-/// The product checks for the exponentiations reduce to multilinear evaluations of affine
-/// translations of the $a, c_{\textsf{lo}}, c_{\textsf{hi}}$ polynomials. Specifically, the
-/// sumcheck reduces to evaluations of
-///
-/// * $\textsf{select}(a(i, r), g^{2^i})$,
-/// * $\textsf{select}(c_{\textsf{lo}}(i, r), g^{2^i})$,
-/// * $\textsf{select}(c_{\textsf{hi}}(i, r), g^{2^(i + k)}$,
-///
-/// for all $i$ in $\{0, \ldots, 2^k - 1\}$, where
-///
-/// $$
-/// \textsf{select}(S, V) = S * (V - 1) + 1.
-/// $$
-///
-/// $g$ is a constant multiplicative generator of the field $F$.
-///
-/// Given, these evaluations, this function computes and returns $a(i, r), c_{\textsf{lo}}(i, r),
-/// c_{\textsf{hi}}(i, r)$.
-pub fn normalize_a_c_exponent_evals<F, E>(
-	k: usize,
-	selected_a_evals: Vec<E>,
-	selected_c_lo_evals: Vec<E>,
-	selected_c_hi_evals: Vec<E>,
-) -> [Vec<E>; 3]
-where
-	F: Field,
-	E: FieldOps<Scalar = F> + From<F>,
-{
-	assert_eq!(selected_a_evals.len(), 1 << k);
-	assert_eq!(selected_c_lo_evals.len(), 1 << k);
-	assert_eq!(selected_c_hi_evals.len(), 1 << k);
-
-	// Compute the normalization factors (conjugate - 1)^{-1} in F, then convert to E.
-	let inv_factors: Vec<E> = iterate(F::MULTIPLICATIVE_GENERATOR, |g| g.square())
-		.take(2 << k)
-		// Safety: `conjugate` ranges over powers of the multiplicative generator, which has odd
-		// order, so `conjugate - 1` is never zero.
-		.map(|conjugate| E::from(unsafe { (conjugate - F::ONE).invert() }))
-		.collect();
-
-	let (lo_inv_factors, hi_inv_factors) = inv_factors.split_at(1 << k);
-
-	let a_evals = recover_selectors(selected_a_evals, lo_inv_factors);
-	let c_lo_evals = recover_selectors(selected_c_lo_evals, lo_inv_factors);
-	let c_hi_evals = recover_selectors(selected_c_hi_evals, hi_inv_factors);
-
-	[a_evals, c_lo_evals, c_hi_evals]
-}
-
-fn recover_selectors<F: FieldOps>(selecteds: Vec<F>, inv_factors: &[F]) -> Vec<F> {
-	assert_eq!(selecteds.len(), inv_factors.len());
-
-	let one = F::one();
-	iter::zip(selecteds, inv_factors)
-		.map(|(selected, inv_factor)| {
-			// z_i = s_i * (v_i - 1) + 1
-			// Recover s_i = (z_i - 1) * (v_i - 1)^{-1}
-			(selected - one.clone()) * inv_factor
-		})
-		.collect()
-}
-
 /// Reconstruct the "selected" leaf evaluations from the raw per-bit evaluations.
 ///
-/// This is the forward direction of [`normalize_a_c_exponent_evals`]: given the raw bit
-/// evaluations $a(i, r), c_{\textsf{lo}}(i, r), c_{\textsf{hi}}(i, r)$, it returns the selected
+/// The product checks for the exponentiations reduce to multilinear evaluations of affine
+/// translations of the $a, c_{\textsf{lo}}, c_{\textsf{hi}}$ polynomials. Given the raw bit
+/// evaluations $a(i, r), c_{\textsf{lo}}(i, r), c_{\textsf{hi}}(i, r)$, this returns the selected
 /// leaf values
 ///
 /// * $\textsf{select}(a(i, r), g^{2^i})$,

--- a/crates/verifier/src/protocols/intmul/verify.rs
+++ b/crates/verifier/src/protocols/intmul/verify.rs
@@ -1,6 +1,6 @@
 // Copyright 2025 Irreducible Inc.
 
-use std::{iter, slice};
+use std::iter;
 
 use binius_field::{BinaryField, Field, field::FieldOps};
 use binius_ip::{
@@ -9,11 +9,13 @@ use binius_ip::{
 	sumcheck::{BatchSumcheckOutput, batch_verify},
 };
 use binius_math::{
-	multilinear::{eq::eq_ind, evaluate::evaluate_inplace_scalars},
+	multilinear::{
+		eq::{eq_ind, eq_ind_zero},
+		evaluate::evaluate_inplace_scalars,
+	},
 	univariate::evaluate_univariate,
 };
 use binius_utils::checked_arithmetics::log2_ceil_usize;
-use itertools::chain;
 
 use super::{
 	common::{
@@ -160,9 +162,10 @@ where
 /// $\widetilde{c}_{\textsf{lo}}$, and $\widetilde{c}_{\textsf{hi}}$.
 ///
 /// Reduces the three tree roots (claimed at the Phase-3 point) to the all-but-last (depth
-/// `log_bits - 1`) layer leaf claims via a single batched prodcheck over the three trees, batched
-/// with $\lceil \log_2 3 \rceil = 2$ selector variables. The prover sends the $3 \cdot 2^{k-1}$
-/// all-but-last-layer evaluations, which the verifier binds to the prodcheck output claim.
+/// `log_bits - 1`) layer claim via a single batched prodcheck over the three trees, batched with
+/// $\lceil \log_2 3 \rceil = 2$ selector variables. Rather than binding the all-but-last-layer
+/// evaluations here, the reduced claim (content-and-node point, reduced selector coordinates, and
+/// combined evaluation) is handed straight to Phase 5.
 fn verify_phase_4<F, C>(
 	log_bits: usize,
 	eval_point: &[C::Elem],
@@ -179,7 +182,6 @@ where
 
 	let n_vars = eval_point.len();
 	let n_layers = log_bits - 1;
-	let width = 1 << n_layers; // = 2^(log_bits - 1) all-but-last-layer node multilinears per tree
 
 	let log_n_trees = log2_ceil_usize(3); // = 2 selector variables
 
@@ -200,57 +202,36 @@ where
 	let output_claim = prodcheck::verify(n_layers, claim, channel)?;
 
 	// The reduced point is [selector (log_n_trees), suffix (n_vars), bit_index (n_layers)]:
-	//  - selector: the batching coordinates for the three trees (the content batching coordinates,
-	//    reduced through the selector rounds),
-	//  - suffix: the content point at which the node multilinears are now claimed,
-	//  - bit_index: the node-index coordinates of the all-but-last layer (high bits in the prover's
-	//    concatenated buffer, reduced through the layer rounds).
+	//  - selector: the batching coordinates for the three trees, reduced through the selector
+	//    rounds,
+	//  - suffix ++ bit_index: the content-and-node point at which each tree's all-but-last-layer
+	//    multilinear is now claimed.
 	assert_eq!(output_claim.point.len(), log_n_trees + n_layers + n_vars);
-	let (selector_point, rest) = output_claim.point.split_at(log_n_trees);
-	let (suffix, bit_index) = rest.split_at(n_vars);
-
-	// Receive the 3 * 2^(log_bits - 1) all-but-last-layer leaf evals (a, then c_lo, then c_hi),
-	// matching the prover's send order.
-	let a_evals = channel.recv_many(width)?;
-	let c_lo_evals = channel.recv_many(width)?;
-	let c_hi_evals = channel.recv_many(width)?;
-
-	// Soundness check: bind the received leaf evals to the prodcheck output. The reduced
-	// multilinear is the eq(selector)-interpolation over trees of the eq(bit_index)-interpolation
-	// over nodes of the leaf evals, evaluated at the suffix point (which the leaf evals already
-	// embed). Concretely:
-	//   output_claim.eval == Σ_t eq(selector, t) · Σ_z eq(bit_index, z) · leaf_eval[t][z],
-	// with the 4th tree slot zero. We fold each tree's 2^(n_layers) leaf evals at bit_index, then
-	// fold the three (padded to 4) per-tree results at selector.
-	let a_folded = evaluate_inplace_scalars(a_evals.clone(), bit_index);
-	let c_lo_folded = evaluate_inplace_scalars(c_lo_evals.clone(), bit_index);
-	let c_hi_folded = evaluate_inplace_scalars(c_hi_evals.clone(), bit_index);
-	let per_tree = vec![a_folded, c_lo_folded, c_hi_folded, C::Elem::zero()];
-	let expected_eval = evaluate_inplace_scalars(per_tree, selector_point);
-
-	channel.assert_zero(expected_eval - output_claim.eval)?;
+	let (selector_point, a_c_eval_point) = output_claim.point.split_at(log_n_trees);
 
 	Ok(Phase4Output {
-		eval_point: suffix.to_vec(),
-		a_evals,
-		c_lo_evals,
-		c_hi_evals,
+		eval_point: a_c_eval_point.to_vec(),
+		selector: selector_point.to_vec(),
+		combined_eval: output_claim.eval,
 	})
 }
 
 /// Verify Phase 5: final GKR layer, $\widetilde{b}$ rerandomization, and parity zerocheck.
 ///
-/// Batches three sumchecks: (a) the final (widest) bivariate product layer for $\widetilde{a}$,
-/// $\widetilde{c}_{\textsf{lo}}$, $\widetilde{c}_{\textsf{hi}}$, (b) a single-claim
-/// rerandomization (MLE-eval) of the recombined $\widetilde{b}(r_I^b, \cdot)$ exponent claim, and
-/// (c) a zerocheck verifying $a_0 \cdot b_0 = c_{\textsf{lo},0}$.
+/// First receives one reduced eval per tree ($\widetilde{a}$, $\widetilde{c}_{\textsf{lo}}$,
+/// $\widetilde{c}_{\textsf{hi}}$) and checks they recombine, weighted by
+/// $\textsf{eq}(\text{selector})$, to the Phase-4 prodcheck output claim. Then batches five
+/// sumchecks: the final (widest) GKR layer of each of the three trees (each a regular
+/// prodcheck-layer bivariate product MLE-check seeded by its reduced eval), the parity zerocheck
+/// $a_0 \cdot b_0 = c_{\textsf{lo},0}$, and a single-claim rerandomization of the recombined
+/// $\widetilde{b}(r_I^b, \cdot)$ exponent claim. The latter two span only the content variables and
+/// are padded up to the trees' variable count.
 #[allow(clippy::too_many_arguments)]
 fn verify_phase_5<F, C>(
 	log_bits: usize,
 	a_c_eval_point: &[C::Elem],
-	a_prod_evals: &[C::Elem],
-	c_lo_prod_evals: &[C::Elem],
-	c_hi_prod_evals: &[C::Elem],
+	selector: &[C::Elem],
+	combined_eval: C::Elem,
 	b_eval_point: &[C::Elem],
 	r_ib: &[C::Elem],
 	b_recomb: C::Elem,
@@ -262,34 +243,40 @@ where
 	C::Elem: FieldOps<Scalar = F> + From<F>,
 {
 	assert!(log_bits >= 1);
-	assert_eq!(2 * a_prod_evals.len(), 1 << log_bits);
-	assert_eq!(2 * c_lo_prod_evals.len(), 1 << log_bits);
-	assert_eq!(2 * c_hi_prod_evals.len(), 1 << log_bits);
+	let n_vars = b_eval_point.len();
+	let n_extra = log_bits - 1;
+	assert_eq!(a_c_eval_point.len(), n_vars + n_extra);
 
-	let n_vars = a_c_eval_point.len();
-	assert_eq!(b_eval_point.len(), n_vars);
+	// Receive the three per-tree reduced claims and check they recombine, weighted by eq(selector)
+	// (padded to four), to the batched prodcheck output claim.
+	let [a_eval, c_lo_eval, c_hi_eval] = channel.recv_array::<3>()?;
+	let per_tree = vec![
+		a_eval.clone(),
+		c_lo_eval.clone(),
+		c_hi_eval.clone(),
+		C::Elem::zero(),
+	];
+	let combined = evaluate_inplace_scalars(per_tree, selector);
+	channel.assert_zero(combined - combined_eval)?;
 
-	// Evals for the batched sumcheck: a (2^(k-1)), c_lo (2^(k-1)), c_hi (2^(k-1)) from the
-	// bivariate product layer, then a_0*b_0 and c_lo_0 for the parity zerocheck, then the single
-	// recombined b exponent eval for the rerandomization sumcheck.
-	let evals = [
-		a_prod_evals,
-		c_lo_prod_evals,
-		c_hi_prod_evals,
-		&[C::Elem::zero()], // overflow parity zerocheck
-		slice::from_ref(&b_recomb),
-	]
-	.concat();
+	// The batched sumcheck's five per-prover sum claims: the three tree final-layer sumchecks
+	// (seeded by the reduced evals), the overflow parity zerocheck (0), and the single recombined
+	// b exponent eval for the rerandomization.
+	let evals = [a_eval, c_lo_eval, c_hi_eval, C::Elem::zero(), b_recomb];
 
 	let BatchSumcheckOutput {
 		batch_coeff,
 		mut challenges,
 		eval,
-	} = batch_verify(n_vars, 3, &evals, channel)?;
+	} = batch_verify(n_vars + n_extra, 3, &evals, channel)?;
 	challenges.reverse();
 
-	// The prover sends the raw per-bit evaluations of all multilinears; the verifier reconstructs
-	// the leaf selectors forward (rather than receiving selectors and inverting them).
+	// challenges = [r_content (n_vars), r_bit (n_extra)]: r_content is the shared output point;
+	// r_bit collapses the node dimension (and is the padding point for the overflow / b checks).
+	let (r_content, r_bit) = challenges.split_at(n_vars);
+
+	// The prover sends the raw per-bit evaluations at r_content; the verifier reconstructs the leaf
+	// selectors forward (rather than receiving selectors and inverting them).
 	let a_evals = channel.recv_many(1 << log_bits)?;
 	let c_lo_evals = channel.recv_many(1 << log_bits)?;
 	let c_hi_evals = channel.recv_many(1 << log_bits)?;
@@ -298,25 +285,29 @@ where
 	let [a_selected_evals, c_lo_selected_evals, c_hi_selected_evals] =
 		reconstruct_selecteds(log_bits, &a_evals, &c_lo_evals, &c_hi_evals);
 
-	// Compose the expected evaluation of the batched composition via the reconstructed leaf
-	// selectors. The prodcheck reduces on the highest node bit, so the final GKR layer pairs leaf
-	// `z` with leaf `z + 2^(log_bits - 1)` (a strided pairing of bits `z` and `z + half`), matching
-	// the natural bit-order leaf layout. For each tree the verifier checks that the MLE of each
-	// strided pair's product at `a_c_eq_eval` equals the corresponding bivariate-product eval in
-	// `evals`, keeping the (a, c_lo, c_hi) order of the batched sumcheck claims.
+	// eq(a_c_eval_point ; challenges) is the MLE-check equality factor shared by the three
+	// final-layer sumchecks.
 	let a_c_eq_eval = eq_ind(a_c_eval_point, &challenges);
-	let strided_products = |selecteds: &[C::Elem]| {
+
+	// Each tree's final-layer product reduces the all-but-last claim to the two halves of its leaf
+	// layer (split on the highest node bit). The verifier recombines the selected leaf evals into
+	// each half via eq(r_bit): half_lo = Σ_{z<half} eq(r_bit, z) · selected[z] and half_hi over
+	// selected[z + half]. The bivariate product is eq_ac · half_lo · half_hi.
+	let tree_product = |selecteds: &[C::Elem]| {
 		let half = selecteds.len() / 2;
-		(0..half)
-			.map(|z| a_c_eq_eval.clone() * &selecteds[z] * &selecteds[z + half])
-			.collect::<Vec<_>>()
+		let lo = evaluate_inplace_scalars(selecteds[..half].to_vec(), r_bit);
+		let hi = evaluate_inplace_scalars(selecteds[half..].to_vec(), r_bit);
+		a_c_eq_eval.clone() * lo * hi
 	};
-	let expected_bivariate_unbatched_evals = chain!(
-		strided_products(&a_selected_evals),
-		strided_products(&c_lo_selected_evals),
-		strided_products(&c_hi_selected_evals),
-	)
-	.collect::<Vec<_>>();
+	let expected_a = tree_product(&a_selected_evals);
+	let expected_c_lo = tree_product(&c_lo_selected_evals);
+	let expected_c_hi = tree_product(&c_hi_selected_evals);
+
+	// The overflow and b checks span only the content variables, so their padded contribution
+	// carries the factor eq(0^{n_extra} ; r_bit).
+	let eq_pad = eq_ind_zero(r_bit);
+
+	let b_eq_eval = eq_ind(b_eval_point, r_content);
 
 	// We must check that `a_0 * b_0 = c_lo_0` across all rows, where these represent the least
 	// significant bits of `a_exponents`, `b_exponents`, and `c_lo_exponents` respectively.
@@ -328,31 +319,31 @@ where
 	// This check catches the attack: if `c = 2^128-1` then `c_lo_0 = 1` (since 2^128-1 is odd),
 	// but `a_0 * b_0 = 0` when `a=0` or `b=0`, so the check `a_0 * b_0 = c_lo_0` fails.
 	//
-	// Implementation: We must perform a zerocheck on `a_0 * b_0 - c_lo_0 = 0`. We reuse the
-	// Phase-2 constraint point `b_eval_point` (r_2) as the zerocheck challenge — available for
-	// free because the `b` re-randomization already evaluates at r_2.
-	let b_eq_eval = eq_ind(b_eval_point, &challenges);
+	// Implementation: A zerocheck on `a_0 * b_0 - c_lo_0 = 0`, reusing the Phase-2 constraint point
+	// `b_eval_point` (r_2) as the zerocheck challenge — available for free because the `b`
+	// re-randomization already evaluates at r_2.
 	let expected_overflow_eval =
-		b_eq_eval.clone() * (a_evals[0].clone() * &b_evals[0] - &c_lo_evals[0]);
+		eq_pad.clone() * &b_eq_eval * (a_evals[0].clone() * &b_evals[0] - &c_lo_evals[0]);
 
 	// Bind the prover's raw per-bit evals to the single recombined rerandomization claim:
-	// b(r_I^b, r_x) = sum_i eq(r_I^b, i) * b(i, r_x).
+	// b(r_I^b, r_content) = sum_i eq(r_I^b, i) * b(i, r_content).
 	let b_at_rx = evaluate_inplace_scalars(b_evals.clone(), r_ib);
-	let expected_b_rerand_eval = b_eq_eval * &b_at_rx;
+	let expected_b_rerand_eval = eq_pad * &b_eq_eval * &b_at_rx;
 
 	let expected_unbatched_evals = [
-		&expected_bivariate_unbatched_evals,
-		slice::from_ref(&expected_overflow_eval),
-		slice::from_ref(&expected_b_rerand_eval),
-	]
-	.concat();
+		expected_a,
+		expected_c_lo,
+		expected_c_hi,
+		expected_overflow_eval,
+		expected_b_rerand_eval,
+	];
 	let expected_batched_eval = evaluate_univariate(&expected_unbatched_evals, batch_coeff);
 
 	// Compare expected evaluation against given evaluation `eval`.
 	channel.assert_zero(expected_batched_eval - eval)?;
 
 	Ok(IntMulOutput {
-		eval_point: challenges,
+		eval_point: r_content.to_vec(),
 		a_evals,
 		b_evals,
 		c_lo_evals,
@@ -498,9 +489,8 @@ where
 	// Phase 4
 	let Phase4Output {
 		eval_point: phase_4_eval_point,
-		a_evals,
-		c_lo_evals,
-		c_hi_evals,
+		selector,
+		combined_eval,
 	} = verify_phase_4(
 		log_bits,
 		&phase_3_eval_point,
@@ -514,9 +504,8 @@ where
 	verify_phase_5(
 		log_bits,
 		&phase_4_eval_point,
-		&a_evals,
-		&c_lo_evals,
-		&c_hi_evals,
+		&selector,
+		combined_eval,
 		&phase_3_eval_point,
 		&r_ib,
 		b_recomb,


### PR DESCRIPTION
Closes [BINIUS-205](https://linear.app/jimpo/issue/BINIUS-205/rework-the-intmul-phase-4phase-5-handoff).

Reworks the phase 4 → phase 5 handoff of the integer-multiplication protocol so phase 4 stops binding the all-but-last-layer evaluations and instead passes the reduced prodcheck claims straight to phase 5, and phase 5 finishes each tree with a regular prodcheck-layer MLE-check rather than a single `3·2^k`-claim multi-MLE.

## Phase 4
The batched prodcheck already stops one layer short and returns each tree's reduced claim (eval + retained final layer). Phase 4 now just hands those three claims and the reduced content-and-node point straight to phase 5 — it no longer recomputes or sends the `3·2^{k-1}` all-but-last-layer evals, and the verifier no longer receives/binds them.

## Phase 5
- **Before the sumcheck**, the prover sends one reduced eval per tree (`a`, `c_lo`, `c_hi`); the verifier checks they recombine, weighted by `eq(selector)`, to the phase-4 prodcheck output claim.
- The final sumcheck **batches five** provers: the final (widest) GKR layer of each of the three trees — each a regular prodcheck-layer bivariate-product MLE-check (`ProdcheckProver::layer_prover`) seeded by its reduced eval and wrapped in `MleToSumCheck` — plus the overflow parity zerocheck and the `b` re-randomization. The latter two span only the `n_vars` content variables, so they're padded up to the trees' `n_vars + (k-1)` variables via the (previously unused) `PaddedSumcheckDecorator`.
- **After the sumcheck**, the prover sends the raw per-bit output evals (computed directly from the exponents, as `b` already did); the verifier reconstructs the selected leaf values and recombines them via `eq(r_bit)` to bind the three final-layer sumchecks, and applies the `eq(0; r_bit)` padding factor to the overflow / `b` terms.

The protocol output (per-bit evals at a common `n_vars` point) is unchanged, so the downstream shift reduction is unaffected.

## Notes
- Adds `Witness::c_hi_exponents` (already passed to `Witness::new`, now retained) so phase 5 can compute the raw `c_hi` output evals from the exponents.
- Removes the now-dead multi-MLE path and its `split_pairs` / `deinterleave_pairs` / `split_leaf_layer` helpers, plus the orphaned `normalize_a_c_exponent_evals` / `recover_selectors` (the verifier's forward `reconstruct_selecteds` remains). Net −128 lines.

## Validation
- `prove_and_verify` (full 5-phase intmul) and `test_shift_prove_and_verify` (downstream consumer) green; full `binius-prover` + `binius-verifier` suites pass.
- `clippy --all-targets -D warnings`, nightly `fmt --check`, and `typos` clean; portable-leg (`RUSTFLAGS=""`) build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)