### PR TITLE
BINIUS-209: allow 0 mul constraints and skip the intmul protocol

### DIFF
--- a/crates/core/src/constraint_system.rs
+++ b/crates/core/src/constraint_system.rs
@@ -603,9 +603,15 @@ impl ConstraintSystem {
 	pub fn validate_and_prepare(&mut self) -> Result<(), ConstraintSystemError> {
 		self.validate()?;
 
-		// Require all constraint types to have a power-of-two count.
+		// Require all constraint types to have a power-of-two count. An empty MUL constraint set is
+		// kept at zero (rather than padded to a single dummy constraint) so the prover and verifier
+		// can skip the IntMul reduction entirely — see `IOPProver::prove` / `IOPVerifier::verify`.
 		let and_target_size = self.and_constraints.len().next_power_of_two();
-		let mul_target_size = self.mul_constraints.len().next_power_of_two();
+		let mul_target_size = if self.mul_constraints.is_empty() {
+			0
+		} else {
+			self.mul_constraints.len().next_power_of_two()
+		};
 
 		self.and_constraints
 			.resize_with(and_target_size, AndConstraint::default);

--- a/crates/examples/snapshots/blake2b.snap
+++ b/crates/examples/snapshots/blake2b.snap
@@ -7,8 +7,8 @@ Gates & Instructions
 Constraints
 ├─ AND constraints: 8,163 used (99.6% of 2^13)
 │  [▓▓▓▓▓▓▓▓▓░] spare: 29
-├─ MUL constraints: 0 used (0.0% of 2^0)
-│  [░░░░░░░░░░] spare: 1
+├─ MUL constraints: 0 used (0.0% of 0)
+│  [░░░░░░░░░░] spare: 0
 └─ Distinct value indices: 21,675
    ├─ Distinct shifted value indices: 13,371
    └─ Distinct unshifted value indices: 8,304

--- a/crates/examples/snapshots/blake2s.snap
+++ b/crates/examples/snapshots/blake2s.snap
@@ -7,8 +7,8 @@ Gates & Instructions
 Constraints
 ├─ AND constraints: 13,656 used (83.3% of 2^14)
 │  [▓▓▓▓▓▓▓▓░░] spare: 2,728
-├─ MUL constraints: 0 used (0.0% of 2^0)
-│  [░░░░░░░░░░] spare: 1
+├─ MUL constraints: 0 used (0.0% of 0)
+│  [░░░░░░░░░░] spare: 0
 └─ Distinct value indices: 35,720
    ├─ Distinct shifted value indices: 21,918
    └─ Distinct unshifted value indices: 13,802

--- a/crates/examples/snapshots/blake3_compress.snap
+++ b/crates/examples/snapshots/blake3_compress.snap
@@ -7,8 +7,8 @@ Gates & Instructions
 Constraints
 ├─ AND constraints: 0 used (0.0% of 2^0)
 │  [░░░░░░░░░░] spare: 1
-├─ MUL constraints: 0 used (0.0% of 2^0)
-│  [░░░░░░░░░░] spare: 1
+├─ MUL constraints: 0 used (0.0% of 0)
+│  [░░░░░░░░░░] spare: 0
 └─ Distinct value indices: 0
    ├─ Distinct shifted value indices: 0
    └─ Distinct unshifted value indices: 0

--- a/crates/examples/snapshots/hashsign.snap
+++ b/crates/examples/snapshots/hashsign.snap
@@ -7,8 +7,8 @@ Gates & Instructions
 Constraints
 ├─ AND constraints: 301,536 used (57.5% of 2^19)
 │  [▓▓▓▓▓░░░░░] spare: 222,752
-├─ MUL constraints: 0 used (0.0% of 2^0)
-│  [░░░░░░░░░░] spare: 1
+├─ MUL constraints: 0 used (0.0% of 0)
+│  [░░░░░░░░░░] spare: 0
 └─ Distinct value indices: 767,638
    ├─ Distinct shifted value indices: 467,068
    └─ Distinct unshifted value indices: 300,570

--- a/crates/examples/snapshots/keccak.snap
+++ b/crates/examples/snapshots/keccak.snap
@@ -7,8 +7,8 @@ Gates & Instructions
 Constraints
 ├─ AND constraints: 6,675 used (81.5% of 2^13)
 │  [▓▓▓▓▓▓▓▓░░] spare: 1,517
-├─ MUL constraints: 0 used (0.0% of 2^0)
-│  [░░░░░░░░░░] spare: 1
+├─ MUL constraints: 0 used (0.0% of 0)
+│  [░░░░░░░░░░] spare: 0
 └─ Distinct value indices: 21,481
    ├─ Distinct shifted value indices: 14,621
    └─ Distinct unshifted value indices: 6,860

--- a/crates/examples/snapshots/sha256.snap
+++ b/crates/examples/snapshots/sha256.snap
@@ -7,8 +7,8 @@ Gates & Instructions
 Constraints
 ├─ AND constraints: 10,414 used (63.6% of 2^14)
 │  [▓▓▓▓▓▓░░░░] spare: 5,970
-├─ MUL constraints: 0 used (0.0% of 2^0)
-│  [░░░░░░░░░░] spare: 1
+├─ MUL constraints: 0 used (0.0% of 0)
+│  [░░░░░░░░░░] spare: 0
 └─ Distinct value indices: 23,921
    ├─ Distinct shifted value indices: 13,422
    └─ Distinct unshifted value indices: 10,499

--- a/crates/examples/snapshots/sha512.snap
+++ b/crates/examples/snapshots/sha512.snap
@@ -7,8 +7,8 @@ Gates & Instructions
 Constraints
 ├─ AND constraints: 11,946 used (72.9% of 2^14)
 │  [▓▓▓▓▓▓▓░░░] spare: 4,438
-├─ MUL constraints: 0 used (0.0% of 2^0)
-│  [░░░░░░░░░░] spare: 1
+├─ MUL constraints: 0 used (0.0% of 0)
+│  [░░░░░░░░░░] spare: 0
 └─ Distinct value indices: 28,490
    ├─ Distinct shifted value indices: 16,167
    └─ Distinct unshifted value indices: 12,323

--- a/crates/frontend/src/stat.rs
+++ b/crates/frontend/src/stat.rs
@@ -189,12 +189,20 @@ impl fmt::Display for CircuitStat {
 			0.0
 		};
 		let mul_spare = self.mul_allocated - self.n_mul_constraints;
+		// A circuit with no MUL constraints allocates nothing (the IntMul reduction is skipped),
+		// so there is no power-of-two allocation to report — unlike AND, which is always padded to
+		// at least one.
+		let mul_allocation = if self.mul_allocated == 0 {
+			"0".to_string()
+		} else {
+			format!("2^{}", log2(self.mul_allocated))
+		};
 		writeln!(
 			f,
-			"├─ MUL constraints: {} used ({:.1}% of 2^{})",
+			"├─ MUL constraints: {} used ({:.1}% of {})",
 			fmt_num(self.n_mul_constraints),
 			mul_percent,
-			log2(self.mul_allocated)
+			mul_allocation
 		)?;
 		writeln!(
 			f,

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -5,7 +5,7 @@ use binius_core::{
 	word::Word,
 };
 use binius_field::{
-	AESTowerField8b as B8, BinaryField, ExtensionField, PackedExtension, PackedField,
+	AESTowerField8b as B8, BinaryField, ExtensionField, Field, PackedExtension, PackedField,
 };
 use binius_hash::binary_merkle_tree::HashSuite;
 use binius_iop_prover::{
@@ -123,16 +123,26 @@ impl IOPProver {
 		drop(witness_commit_guard);
 
 		// [phase] IntMul Reduction - multiplication constraint reduction
-		let intmul_guard = tracing::info_span!(
-			"[phase] IntMul Reduction",
-			phase = "intmul_reduction",
-			perfetto_category = "phase",
-			n_constraints = cs.mul_constraints.len()
-		)
-		.entered();
-		let mul_witness = build_intmul_witness(&cs.mul_constraints, &witness);
-		let intmul_output = prove_intmul_reduction::<_, P, _>(mul_witness, &mut *channel)?;
-		drop(intmul_guard);
+		//
+		// Skipped entirely (no transcript messages) when the constraint system has no MUL
+		// constraints. The verifier applies the identical guard, so the transcript stays in sync;
+		// the zero `OperatorData` synthesized below then contributes nothing to the shift
+		// reduction.
+		let intmul_output = if cs.n_mul_constraints() > 0 {
+			let intmul_guard = tracing::info_span!(
+				"[phase] IntMul Reduction",
+				phase = "intmul_reduction",
+				perfetto_category = "phase",
+				n_constraints = cs.mul_constraints.len()
+			)
+			.entered();
+			let mul_witness = build_intmul_witness(&cs.mul_constraints, &witness);
+			let intmul_output = prove_intmul_reduction::<_, P, _>(mul_witness, &mut *channel)?;
+			drop(intmul_guard);
+			Some(intmul_output)
+		} else {
+			None
+		};
 
 		// [phase] BitAnd Reduction - AND constraint reduction
 		let bitand_guard = tracing::info_span!(
@@ -161,30 +171,37 @@ impl IOPProver {
 
 		// Build `OperatorData` for IntMul using the same `r_zhat_prime`
 		// challenge as in BitAnd. Sharing this univariate challenge
-		// improves ShiftReduction perf.
-		let intmul_claim = {
-			let IntMulOutput {
+		// improves ShiftReduction perf. When IntMul was skipped, synthesize a zero claim (four
+		// zero evals at an empty point): the shift reduction iterates the (empty) MUL constraints,
+		// so this claim contributes zero to its batched evaluation.
+		let intmul_claim = match intmul_output {
+			Some(IntMulOutput {
 				eval_point,
 				a_evals,
 				b_evals,
 				c_lo_evals,
 				c_hi_evals,
-			} = intmul_output;
-
-			let r_zhat_prime = bitand_claim.r_zhat_prime;
-			let subspace = BinarySubspace::<B8>::with_dim(LOG_WORD_SIZE_BITS).isomorphic();
-			let l_tilde = lagrange_evals(&subspace, r_zhat_prime);
-			let make_final_claim = |evals| inner_product(evals, l_tilde.iter_scalars());
-			OperatorData {
-				evals: vec![
-					make_final_claim(a_evals),
-					make_final_claim(b_evals),
-					make_final_claim(c_lo_evals),
-					make_final_claim(c_hi_evals),
-				],
-				r_zhat_prime,
-				r_x_prime: eval_point,
+			}) => {
+				let r_zhat_prime = bitand_claim.r_zhat_prime;
+				let subspace = BinarySubspace::<B8>::with_dim(LOG_WORD_SIZE_BITS).isomorphic();
+				let l_tilde = lagrange_evals(&subspace, r_zhat_prime);
+				let make_final_claim = |evals| inner_product(evals, l_tilde.iter_scalars());
+				OperatorData {
+					evals: vec![
+						make_final_claim(a_evals),
+						make_final_claim(b_evals),
+						make_final_claim(c_lo_evals),
+						make_final_claim(c_hi_evals),
+					],
+					r_zhat_prime,
+					r_x_prime: eval_point,
+				}
 			}
+			None => OperatorData {
+				evals: vec![B128::ZERO; 4],
+				r_zhat_prime: bitand_claim.r_zhat_prime,
+				r_x_prime: Vec::new(),
+			},
 		};
 
 		// [phase] Shift Reduction - shift operations

--- a/crates/prover/tests/prove_verify.rs
+++ b/crates/prover/tests/prove_verify.rs
@@ -132,6 +132,18 @@ fn test_prove_verify_sha256_preimage() {
 	prove_verify(cs, witness);
 }
 
+/// A SHA-256 circuit uses only AND constraints, so its constraint system has zero MUL
+/// constraints. This locks in that the prover and verifier skip the IntMul reduction entirely
+/// (rather than padding up to a dummy MUL constraint); see `IOPProver::prove` /
+/// `IOPVerifier::verify`.
+#[test]
+fn test_prove_verify_zero_mul_constraints() {
+	let (cs, witness) = sha256_preimage_circuit();
+	assert_eq!(cs.n_mul_constraints(), 0, "SHA-256 circuit should have no MUL constraints");
+	prove_verify(cs.clone(), witness.clone());
+	prove_verify_zk(cs, witness);
+}
+
 #[test]
 fn test_zk_prove_verify_sha256_preimage() {
 	let (cs, witness) = sha256_preimage_circuit();

--- a/crates/prover/tests/shift.rs
+++ b/crates/prover/tests/shift.rs
@@ -191,7 +191,7 @@ pub fn evaluate_witness<F: BinaryField>(words: &[Word], r_j: &[F], r_y: &[F]) ->
 
 #[test]
 fn test_shift_prove_and_verify() {
-	use binius_field::{BinaryField128bGhash, PackedBinaryGhash2x128b, Random};
+	use binius_field::{BinaryField128bGhash, Field, PackedBinaryGhash2x128b, Random};
 	type F = BinaryField128bGhash;
 	type P = PackedBinaryGhash2x128b;
 	let mut rng = StdRng::seed_from_u64(0);
@@ -218,7 +218,13 @@ fn test_shift_prove_and_verify() {
 				.map(F::new)
 				.collect::<Vec<_>>()
 		};
-		let r_x_prime_intmul = {
+		// A constraint system may have zero MUL constraints (e.g. a pure-AND circuit like SHA-256).
+		// The IntMul operator is then empty — an empty challenge point and a zero claim — mirroring
+		// the prover/verifier skip of the IntMul reduction in `binius_prover` / `binius_verifier`.
+		let intmul_is_empty = cs.mul_constraints.is_empty();
+		let r_x_prime_intmul = if intmul_is_empty {
+			Vec::new()
+		} else {
 			let log_intmul_constraint_count = strict_log_2(cs.mul_constraints.len()).unwrap();
 			(0..log_intmul_constraint_count as u128)
 				.map(F::new)
@@ -240,14 +246,18 @@ fn test_shift_prove_and_verify() {
 			)
 		});
 
-		let intmul_evals = compute_intmul_images(&cs.mul_constraints, &value_vec).map(|image| {
-			evaluate_image(
-				&subspace,
-				&image,
-				r_zhat_prime,
-				eq_ind_partial_eval(&r_x_prime_intmul).as_ref(),
-			)
-		});
+		let intmul_evals: [F; 4] = if intmul_is_empty {
+			[F::ZERO; 4]
+		} else {
+			compute_intmul_images(&cs.mul_constraints, &value_vec).map(|image| {
+				evaluate_image(
+					&subspace,
+					&image,
+					r_zhat_prime,
+					eq_ind_partial_eval(&r_x_prime_intmul).as_ref(),
+				)
+			})
+		};
 
 		// Build prover's constraint system
 		let key_collection = build_key_collection(&cs);

--- a/crates/verifier/src/verify.rs
+++ b/crates/verifier/src/verify.rs
@@ -155,17 +155,25 @@ impl IOPVerifier {
 		// `prover::prove`.
 		//
 		// [phase] Verify IntMul Reduction - multiplication constraint verification
-		let intmul_guard = tracing::info_span!(
-			"[phase] Verify IntMul Reduction",
-			phase = "verify_intmul_reduction",
-			perfetto_category = "phase",
-			n_constraints = self.constraint_system.n_mul_constraints()
-		)
-		.entered();
-		let log_n_constraints = checked_log_2(self.constraint_system.n_mul_constraints());
-		let intmul_output =
-			verify_intmul_reduction::<B128, _>(LOG_WORD_SIZE_BITS, log_n_constraints, channel)?;
-		drop(intmul_guard);
+		//
+		// Skipped (no transcript reads) when the constraint system has no MUL constraints,
+		// mirroring the prover's identical guard so the transcript stays in sync.
+		let intmul_output = if self.constraint_system.n_mul_constraints() > 0 {
+			let intmul_guard = tracing::info_span!(
+				"[phase] Verify IntMul Reduction",
+				phase = "verify_intmul_reduction",
+				perfetto_category = "phase",
+				n_constraints = self.constraint_system.n_mul_constraints()
+			)
+			.entered();
+			let log_n_constraints = checked_log_2(self.constraint_system.n_mul_constraints());
+			let intmul_output =
+				verify_intmul_reduction::<B128, _>(LOG_WORD_SIZE_BITS, log_n_constraints, channel)?;
+			drop(intmul_guard);
+			Some(intmul_output)
+		} else {
+			None
+		};
 
 		// [phase] Verify BitAnd Reduction - AND constraint verification
 		let bitand_guard = tracing::info_span!(
@@ -191,27 +199,31 @@ impl IOPVerifier {
 		// Build `OperatorData` for IntMul. The univariate challenge `r_zhat_prime` is
 		// shared with BitAnd (computed above) — sharing it improves prover
 		// ShiftReduction perf and lets the verifier compute `h_op_evals` once for both
-		// operations in `shift::check_eval`.
-		let intmul_claim = {
-			let IntMulOutput {
+		// operations in `shift::check_eval`. When IntMul was skipped, synthesize a zero claim
+		// (four zero evals at an empty point); it contributes zero to the shift reduction, whose
+		// monster evaluation iterates the (empty) MUL constraints.
+		let intmul_claim = match intmul_output {
+			Some(IntMulOutput {
 				a_evals,
 				b_evals,
 				c_lo_evals,
 				c_hi_evals,
 				eval_point,
-			} = intmul_output;
-
-			let l_tilde = lagrange_evals_scalars(&domain_subspace, r_zhat_prime.clone());
-			let make_final_claim = |evals| inner_product_scalars(evals, l_tilde.iter().cloned());
-			OperatorData::new(
-				eval_point,
-				[
-					make_final_claim(a_evals),
-					make_final_claim(b_evals),
-					make_final_claim(c_lo_evals),
-					make_final_claim(c_hi_evals),
-				],
-			)
+			}) => {
+				let l_tilde = lagrange_evals_scalars(&domain_subspace, r_zhat_prime.clone());
+				let make_final_claim =
+					|evals| inner_product_scalars(evals, l_tilde.iter().cloned());
+				OperatorData::new(
+					eval_point,
+					[
+						make_final_claim(a_evals),
+						make_final_claim(b_evals),
+						make_final_claim(c_lo_evals),
+						make_final_claim(c_hi_evals),
+					],
+				)
+			}
+			None => OperatorData::new(Vec::new(), std::array::from_fn(|_| Channel::Elem::zero())),
 		};
 
 		// [phase] Verify Shift Reduction - shift operations and constraint validation


### PR DESCRIPTION
Closes [BINIUS-209](https://linear.app/jimpo/issue/BINIUS-209/allow-0-mul-constraints-and-disable-intmul-protocol).

Lets a constraint system have **zero MUL constraints**, in which case both the prover and verifier skip the IntMul reduction entirely (no transcript messages on either side). This enables [BINIUS-208](https://linear.app/jimpo/issue/BINIUS-208) without imposing the IntMul cost on circuits that have no integer multiplication (e.g. pure-AND circuits like SHA-256).

## Changes
- **`ConstraintSystem::validate_and_prepare`**: an empty MUL constraint set is kept at zero rather than padded up to a single dummy constraint (so the "0 mul" state becomes reachable). The AND path is untouched — still padded to the next power of two.
- **`IOPProver::prove` / `IOPVerifier::verify`**: guard the IntMul reduction on `n_mul_constraints() > 0`. Both sides apply the **identical** guard, so the Fiat-Shamir transcript stays in lockstep.
- When skipped, each side synthesizes a **zero IntMul `OperatorData`** (four zero evals at an empty `r_x_prime`, sharing BitAnd's `r_zhat_prime`). The shift reduction's monster evaluation iterates the (now empty) MUL constraints and this claim contributes zero, so the shift/PCS phases are unchanged and still receive a (zero) claim rather than an `Option`.
- **Circuit-statistics display** (`stat.rs`): with zero MUL constraints nothing is allocated, so there's no power-of-two exponent to report — print `0 used (0.0% of 0)` instead of the wraparound `2^64` (`trailing_zeros(0)`). Regenerated the affected snapshots (the pure-AND hash circuits: sha256, sha512, keccak, blake2s, blake2b, blake3_compress, hashsign).

## Soundness
The existing "IntMul before BitAnd" ordering (IntMul evals must be bound before `r_zhat_prime` is drawn) only matters when IntMul runs; when it's skipped there are no evals to bind, and `r_zhat_prime` is drawn solely by BitAnd — consistent between prover and verifier because both skip identically.

## Validation
- `test_prove_verify_zero_mul_constraints` (new): asserts the SHA-256 circuit has `n_mul_constraints() == 0` and runs both plain and ZK prove→verify through the skip path.
- The existing `test_prove_verify_sha256_preimage` / `test_zk_prove_verify_sha256_preimage` now exercise the skip path too (SHA-256 has no muls, previously masked by the pad-to-1).
- Updated `tests/shift.rs::test_shift_prove_and_verify` to handle a zero-MUL constraint system (empty point + zero claim), matching the production skip.
- Full `binius-core` / `binius-prover` / `binius-verifier` / `binius-frontend` / `binius-spartan-*` / `binius-m4-prover` suites pass; all 9 circuit-snapshot examples pass `check-snapshot`; `clippy --all-targets -D warnings`, nightly `fmt --check`, and `typos` clean; portable-leg (`RUSTFLAGS=""`) build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)