### PR TITLE
BINIUS-196: replace tiny-keccak dependency with sha3/keccak

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ jwt-simple = { version = "0.12.16", default-features = false, features = [
     "pure-rust",
 ] }
 k256 = "0.13.4"
+keccak = "0.2.0"
 lazy_static = "1.5.0"
 num-bigint = "0.4.6"
 num-integer = "0.1.46"

--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -27,12 +27,12 @@ ethsign = "0.9.0"
 hex.workspace = true
 jwt-simple.workspace = true
 k256 = { workspace = true, features = ["arithmetic"] }
+keccak.workspace = true
 num-bigint = { workspace = true }
 peakmem-alloc = "0.3.0"
 rand = { workspace = true, features = ["thread_rng"] }
 sha2.workspace = true
 sha3.workspace = true
-tiny-keccak = { version = "2.0.2", features = ["keccak"] }
 tracing-forest.workspace = true
 tracing-profile.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/examples/src/circuits/ethsign.rs
+++ b/crates/examples/src/circuits/ethsign.rs
@@ -13,7 +13,7 @@ use binius_frontend::{
 use clap::Args;
 use ethsign::SecretKey;
 use rand::prelude::*;
-use tiny_keccak::{Hasher, Keccak as KeccakHasher};
+use sha3::{Digest, Keccak256 as Sha3Keccak256};
 
 use crate::ExampleCircuit;
 
@@ -205,11 +205,7 @@ fn assert_address_eq(b: &CircuitBuilder, digest: &[Wire], address: &[Wire]) {
 }
 
 fn keccak256(bytes: &[u8]) -> [u8; 32] {
-	let mut hasher = KeccakHasher::v256();
+	let mut hasher = Sha3Keccak256::new();
 	hasher.update(bytes);
-
-	let mut digest = [0u8; 32];
-	hasher.finalize(&mut digest);
-
-	digest
+	hasher.finalize().into()
 }

--- a/crates/examples/src/circuits/independent_hashes.rs
+++ b/crates/examples/src/circuits/independent_hashes.rs
@@ -231,7 +231,7 @@ impl ExampleCircuit for IndependentKeccakPermutations {
 			permutation.permutation.populate_state(w, state);
 
 			let mut expected = state;
-			tiny_keccak::keccakf(&mut expected);
+			keccak::Keccak::new().with_f1600(|f1600| f1600(&mut expected));
 			for (wire, value) in permutation.output.iter().zip(expected) {
 				w[*wire] = Word(value);
 			}


### PR DESCRIPTION
## Summary

Removes the direct `tiny-keccak` dependency from `binius-examples`. There were two usage sites (not just the one the ticket assumed):

- **`ethsign.rs`** — the `keccak256()` host helper (Keccak-256 hashing) now uses `sha3::Keccak256`, matching the idiom already used in `binius-circuits`.
- **`independent_hashes.rs`** — the raw Keccak-f[1600] permutation (added by #1663) now uses the `keccak` crate's `with_f1600` closure, since `sha3` does not expose the bare permutation.

This follows "Option A" as chosen on [BINIUS-196](https://linear.app/jimpo/issue/BINIUS-196/replace-tiny-keccak-dependency-with-sha3): sha3 for hashing, the `keccak` crate (sha3's own backing crate, already transitive in the lockfile) for the permutation.

## Verification

- `sha3::Keccak256` uses padding `0x01` (legacy Keccak / Ethereum), byte-for-byte matching `tiny_keccak::Keccak::v256()` — **not** the SHA3 `0x06` variant.
- `keccak::with_f1600` is exactly one 24-round Keccak-f[1600] over `[u64; 25]`, matching `tiny_keccak::keccakf`.
- Full `binius-examples` test suite (22 tests) passes, including `independent_keccak_permutations_populate_valid_witness` and an end-to-end ethsign prove/verify run.
- Single `keccak 0.2.0` in `Cargo.lock` (no duplicate version).

## Note

`tiny-keccak` remains as a **transitive** dependency via the third-party `ethsign` crate; removing that edge is out of scope. The direct dependency is fully gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)