### PR TITLE
perf(circuits): use XOR for biguint_lt's mutually exclusive lt/eq merge

### DIFF
--- a/crates/circuits/src/bignum/cmp.rs
+++ b/crates/circuits/src/bignum/cmp.rs
@@ -1,3 +1,4 @@
+// Copyright 2026 The Binius Developers
 // Copyright 2025 Irreducible Inc.
 use std::iter;
 
@@ -30,7 +31,11 @@ pub fn biguint_lt(builder: &CircuitBuilder, a: &BigUint, b: &BigUint) -> Wire {
 	for (&a_limb, &b_limb) in iter::zip(&a.limbs, &b.limbs) {
 		let lt_flag = builder.icmp_ult(a_limb, b_limb);
 		let eq_flag = builder.icmp_eq(a_limb, b_limb);
-		result = builder.bor(lt_flag, builder.band(eq_flag, result));
+		// `lt_flag` and `eq_flag` are mutually exclusive (a limb cannot be both
+		// less than and equal to another), so their MSB-bools never share a set
+		// bit and OR agrees with XOR on the only bit these flags define. XOR is
+		// linear, saving one AND constraint per limb.
+		result = builder.bxor(lt_flag, builder.band(eq_flag, result));
 	}
 
 	result

--- a/crates/examples/snapshots/bitcoin_headers.snap
+++ b/crates/examples/snapshots/bitcoin_headers.snap
@@ -5,24 +5,24 @@ Gates & Instructions
 └─ Number of evaluation instructions: 52,708
 
 Constraints
-├─ AND constraints: 23,640 used (72.1% of 2^15)
-│  [▓▓▓▓▓▓▓░░░] spare: 9,128
-├─ MUL constraints: 0 used (0.0% of 2^0)
-│  [░░░░░░░░░░] spare: 1
-└─ Distinct value indices: 53,407
+├─ AND constraints: 23,600 used (72.0% of 2^15)
+│  [▓▓▓▓▓▓▓░░░] spare: 9,168
+├─ MUL constraints: 0 used (0.0% of 0)
+│  [░░░░░░░░░░] spare: 0
+└─ Distinct value indices: 53,367
    ├─ Distinct shifted value indices: 29,960
-   └─ Distinct unshifted value indices: 23,447
+   └─ Distinct unshifted value indices: 23,407
 
 Value Vector
 ├─ Public Section: 175 used (68.4% of 2^8)
 │  [▓▓▓▓▓▓░░░░] spare: 81
 │  ├─ Constants: 175
 │  └─ Inout: 0
-├─ Private Section: 23,274 used (71.6%)
-│  [▓▓▓▓▓▓▓░░░] spare: 9,238
+├─ Private Section: 23,234 used (71.5%)
+│  [▓▓▓▓▓▓▓░░░] spare: 9,278
 │  ├─ Witness: 804
-│  └─ Internal: 22,470
-├─ Total Committed: 23,449 used (71.6% of 2^15)
-│  [▓▓▓▓▓▓▓░░░] spare: 9,319
-└─ Scratch (uncommitted): 41,708
+│  └─ Internal: 22,430
+├─ Total Committed: 23,409 used (71.4% of 2^15)
+│  [▓▓▓▓▓▓▓░░░] spare: 9,359
+└─ Scratch (uncommitted): 41,748
 

--- a/crates/examples/snapshots/bitcoin_p2pkh.snap
+++ b/crates/examples/snapshots/bitcoin_p2pkh.snap
@@ -5,24 +5,24 @@ Gates & Instructions
 └─ Number of evaluation instructions: 201,906
 
 Constraints
-├─ AND constraints: 148,242 used (56.5% of 2^18)
-│  [▓▓▓▓▓░░░░░] spare: 113,902
+├─ AND constraints: 138,465 used (52.8% of 2^18)
+│  [▓▓▓▓▓░░░░░] spare: 123,679
 ├─ MUL constraints: 15,198 used (92.8% of 2^14)
 │  [▓▓▓▓▓▓▓▓▓░] spare: 1,186
-└─ Distinct value indices: 315,143
-   ├─ Distinct shifted value indices: 146,276
-   └─ Distinct unshifted value indices: 168,867
+└─ Distinct value indices: 306,723
+   ├─ Distinct shifted value indices: 147,633
+   └─ Distinct unshifted value indices: 159,090
 
 Value Vector
 ├─ Public Section: 123 used (96.1% of 2^7)
 │  [▓▓▓▓▓▓▓▓▓░] spare: 5
 │  ├─ Constants: 123
 │  └─ Inout: 0
-├─ Private Section: 168,748 used (64.4%)
-│  [▓▓▓▓▓▓░░░░] spare: 93,268
+├─ Private Section: 158,971 used (60.7%)
+│  [▓▓▓▓▓▓░░░░] spare: 103,045
 │  ├─ Witness: 9
-│  └─ Internal: 168,739
-├─ Total Committed: 168,871 used (64.4% of 2^18)
-│  [▓▓▓▓▓▓░░░░] spare: 93,273
-└─ Scratch (uncommitted): 137,142
+│  └─ Internal: 158,962
+├─ Total Committed: 159,094 used (60.7% of 2^18)
+│  [▓▓▓▓▓▓░░░░] spare: 103,050
+└─ Scratch (uncommitted): 146,919
 

--- a/crates/examples/snapshots/ec_msm.snap
+++ b/crates/examples/snapshots/ec_msm.snap
@@ -5,24 +5,24 @@ Gates & Instructions
 └─ Number of evaluation instructions: 278,916
 
 Constraints
-├─ AND constraints: 207,239 used (79.1% of 2^18)
-│  [▓▓▓▓▓▓▓░░░] spare: 54,905
+├─ AND constraints: 193,975 used (74.0% of 2^18)
+│  [▓▓▓▓▓▓▓░░░] spare: 68,169
 ├─ MUL constraints: 20,596 used (62.9% of 2^15)
 │  [▓▓▓▓▓▓░░░░] spare: 12,172
-└─ Distinct value indices: 432,596
-   ├─ Distinct shifted value indices: 197,668
-   └─ Distinct unshifted value indices: 234,928
+└─ Distinct value indices: 421,180
+   ├─ Distinct shifted value indices: 199,516
+   └─ Distinct unshifted value indices: 221,664
 
 Value Vector
 ├─ Public Section: 52 used (81.2% of 2^6)
 │  [▓▓▓▓▓▓▓▓░░] spare: 12
 │  ├─ Constants: 20
 │  └─ Inout: 32
-├─ Private Section: 234,881 used (89.6%)
-│  [▓▓▓▓▓▓▓▓░░] spare: 27,199
+├─ Private Section: 221,617 used (84.6%)
+│  [▓▓▓▓▓▓▓▓░░] spare: 40,463
 │  ├─ Witness: 0
-│  └─ Internal: 234,881
-├─ Total Committed: 234,933 used (89.6% of 2^18)
-│  [▓▓▓▓▓▓▓▓░░] spare: 27,211
-└─ Scratch (uncommitted): 183,965
+│  └─ Internal: 221,617
+├─ Total Committed: 221,669 used (84.6% of 2^18)
+│  [▓▓▓▓▓▓▓▓░░] spare: 40,475
+└─ Scratch (uncommitted): 197,229
 

--- a/crates/examples/snapshots/ethsign.snap
+++ b/crates/examples/snapshots/ethsign.snap
@@ -5,24 +5,24 @@ Gates & Instructions
 └─ Number of evaluation instructions: 285,349
 
 Constraints
-├─ AND constraints: 209,134 used (79.8% of 2^18)
-│  [▓▓▓▓▓▓▓░░░] spare: 53,010
+├─ AND constraints: 195,861 used (74.7% of 2^18)
+│  [▓▓▓▓▓▓▓░░░] spare: 66,283
 ├─ MUL constraints: 20,592 used (62.8% of 2^15)
 │  [▓▓▓▓▓▓░░░░] spare: 12,176
-└─ Distinct value indices: 438,227
-   ├─ Distinct shifted value indices: 201,362
-   └─ Distinct unshifted value indices: 236,865
+└─ Distinct value indices: 426,803
+   ├─ Distinct shifted value indices: 203,211
+   └─ Distinct unshifted value indices: 223,592
 
 Value Vector
 ├─ Public Section: 119 used (93.0% of 2^7)
 │  [▓▓▓▓▓▓▓▓▓░] spare: 9
 │  ├─ Constants: 90
 │  └─ Inout: 29
-├─ Private Section: 236,756 used (90.4%)
-│  [▓▓▓▓▓▓▓▓▓░] spare: 25,260
+├─ Private Section: 223,483 used (85.3%)
+│  [▓▓▓▓▓▓▓▓░░] spare: 38,533
 │  ├─ Witness: 42
-│  └─ Internal: 236,714
-├─ Total Committed: 236,875 used (90.4% of 2^18)
-│  [▓▓▓▓▓▓▓▓▓░] spare: 25,269
-└─ Scratch (uncommitted): 188,576
+│  └─ Internal: 223,441
+├─ Total Committed: 223,602 used (85.3% of 2^18)
+│  [▓▓▓▓▓▓▓▓░░] spare: 38,542
+└─ Scratch (uncommitted): 201,849
 


### PR DESCRIPTION
## What

`biguint_lt` merges each limb's "less than" and "equal" flags with an OR:

```rust
let lt_flag = builder.icmp_ult(a_limb, b_limb);
let eq_flag = builder.icmp_eq(a_limb, b_limb);
result = builder.bor(lt_flag, builder.band(eq_flag, result));
```

Root cause: `bor` costs one AND constraint per limb, but `lt_flag` and `eq_flag` are mutually exclusive. A limb cannot be both less than and equal to the same value, so the two operands never share a set bit, and OR agrees with XOR on the only bit these MSB-bool flags define.

Fix: replace the OR with XOR, which is linear and free.

```rust
result = builder.bxor(lt_flag, builder.band(eq_flag, result));
```

This is the same constraint-enforced-disjointness reasoning as the merged rs256 swap (#1661), applied to a much hotter gadget.

## Numbers

AND constraints from the example circuit snapshots (the four circuits that use `biguint_lt` transitively; every other snapshot is unchanged):

| circuit | before | this PR | reduction |
|---------|--------|---------|-----------|
| ethsign | 209,134 | 195,861 | -6.35% |
| ec_msm | 207,239 | 193,975 | -6.40% |
| bitcoin_p2pkh | 148,242 | 138,465 | -6.60% |
| bitcoin_header_chain | 23,640 | 23,600 | -0.17% |

`biguint_lt` sits on the hot path of every secp256k1 pseudo-Mersenne field reduction (`mul`, `square`, `add`, `div`, `inverse`), so a full ECDSA verify calls it thousands of times, which is why one line moves the ECDSA circuits by ~6%.

```
repro: cargo run --release --example ethsign -- check-snapshot
```

## Correctness

The change preserves the MSB of `biguint_lt`'s output bit-for-bit for every witness, and only the MSB is ever read:

- `lt_flag` and `eq_flag` come from `icmp_ult` / `icmp_eq`, whose non-MSB bits are undefined and whose MSBs are pinned to `(a < b)` and `(a == b)` by the gate constraints. `(a < b)` and `(a == b)` are mutually exclusive, so `MSB(lt_flag) & MSB(eq_flag) = 0` for every satisfying witness, adversarial included. Hence `bor` and `bxor` produce the same MSB.
- The recursion feeds `result` back through `band(eq_flag, result)`, whose MSB depends only on the (preserved) MSB of `result`, so the divergence in the low bits never propagates to any MSB.
- Every consumer reads the MSB only: `assert_true` masks it, and `select` / `zero_unless` / `pai_unless` / `div`'s conditional reduction broadcast it through `sar(cond, 63)`. No consumer reads a low bit, which the icmp contract already forbids.

All 336 `binius-circuits` tests pass (including the ECDSA prove/verify roundtrips), the four affected snapshots are re-blessed, and no other snapshot changes.

## Scope

Only `biguint_lt` is touched. `biguint_eq` right below it folds with `band`, a genuine conjunction that is not reducible, so it is left as is.
