### PR TITLE
BINIUS-212: select the Blake3 hash suite from the example CLI, rename the --compression flag

### DIFF
--- a/crates/examples/src/cli.rs
+++ b/crates/examples/src/cli.rs
@@ -5,13 +5,13 @@ use std::{fs, path::Path};
 use anyhow::Result;
 use binius_core::constraint_system::{ConstraintSystem, Proof, ValueVec, ValuesData};
 use binius_frontend::{CircuitBuilder, CircuitStat};
-use binius_hash::{StdHashSuite, binary_merkle_tree::HashSuite};
+use binius_hash::{Blake3HashSuite, StdHashSuite, binary_merkle_tree::HashSuite};
 use binius_utils::serialization::{DeserializeBytes, SerializeBytes};
 use clap::{Arg, Args, Command, FromArgMatches, Subcommand};
 use digest::Output;
 
 use crate::{
-	CompressionType, ExampleCircuit, check_proof, check_proof_zk, create_proof, create_proof_zk,
+	ExampleCircuit, HashSuiteType, check_proof, check_proof_zk, create_proof, create_proof_zk,
 	prove_verify, setup, setup_verifier, setup_zk, setup_zk_verifier,
 };
 
@@ -139,9 +139,9 @@ enum Commands {
 		#[arg(short = 'l', long, default_value_t = 1, value_parser = clap::value_parser!(u32).range(1..))]
 		log_inv_rate: u32,
 
-		/// Compression function to use
-		#[arg(short = 'c', long, value_enum, default_value_t = CompressionType::Sha256)]
-		compression: CompressionType,
+		/// Merkle hash suite to use (leaf hash + inner-node compression)
+		#[arg(short = 'c', long = "hash-suite", alias = "compression", value_enum, default_value_t = HashSuiteType::Sha256)]
+		hash_suite: HashSuiteType,
 
 		#[command(flatten)]
 		params: CommandArgs,
@@ -282,12 +282,13 @@ where
 					.value_parser(clap::value_parser!(u32).range(1..)),
 			)
 			.arg(
-				Arg::new("compression")
+				Arg::new("hash_suite")
 					.short('c')
-					.long("compression")
-					.value_name("TYPE")
-					.help("Compression function to use")
-					.value_parser(clap::value_parser!(CompressionType))
+					.long("hash-suite")
+					.alias("compression")
+					.value_name("SUITE")
+					.help("Merkle hash suite to use (leaf hash + inner-node compression)")
+					.value_parser(clap::value_parser!(HashSuiteType))
 					.default_value("sha256"),
 			)
 			.arg(
@@ -338,12 +339,13 @@ where
 					.value_parser(clap::value_parser!(u32).range(1..)),
 			)
 			.arg(
-				Arg::new("compression")
+				Arg::new("hash_suite")
 					.short('c')
-					.long("compression")
-					.value_name("TYPE")
-					.help("Compression function to use")
-					.value_parser(clap::value_parser!(CompressionType))
+					.long("hash-suite")
+					.alias("compression")
+					.value_name("SUITE")
+					.help("Merkle hash suite to use (leaf hash + inner-node compression)")
+					.value_parser(clap::value_parser!(HashSuiteType))
 					.default_value("sha256"),
 			)
 			.arg(
@@ -470,12 +472,13 @@ where
 					.value_parser(clap::value_parser!(u32).range(1..)),
 			)
 			.arg(
-				Arg::new("compression")
+				Arg::new("hash_suite")
 					.short('c')
-					.long("compression")
-					.value_name("TYPE")
-					.help("Compression function to use")
-					.value_parser(clap::value_parser!(CompressionType))
+					.long("hash-suite")
+					.alias("compression")
+					.value_name("SUITE")
+					.help("Merkle hash suite to use (leaf hash + inner-node compression)")
+					.value_parser(clap::value_parser!(HashSuiteType))
 					.default_value("sha256"),
 			)
 	}
@@ -499,12 +502,13 @@ where
 					.value_parser(clap::value_parser!(u32).range(1..)),
 			)
 			.arg(
-				Arg::new("compression")
+				Arg::new("hash_suite")
 					.short('c')
-					.long("compression")
-					.value_name("TYPE")
-					.help("Compression function to use")
-					.value_parser(clap::value_parser!(CompressionType))
+					.long("hash-suite")
+					.alias("compression")
+					.value_name("SUITE")
+					.help("Merkle hash suite to use (leaf hash + inner-node compression)")
+					.value_parser(clap::value_parser!(HashSuiteType))
 					.default_value("sha256"),
 			)
 			.arg(
@@ -617,14 +621,14 @@ where
 		let log_inv_rate = *matches
 			.get_one::<u32>("log_inv_rate")
 			.expect("has default value");
-		let compression = matches
-			.get_one::<CompressionType>("compression")
+		let hash_suite = matches
+			.get_one::<HashSuiteType>("hash_suite")
 			.expect("has default value")
 			.clone();
 		let zk = matches.get_flag("zk");
 		let sign_message = matches.get_one::<String>("sign_message").cloned();
 		let output = matches.get_one::<String>("output").cloned();
-		tracing::info!("Parsed compression type: {compression:?}");
+		tracing::info!("Parsed hash suite: {hash_suite:?}");
 		if zk {
 			tracing::info!("Using zero-knowledge proving config");
 		}
@@ -663,10 +667,21 @@ where
 		drop(witness_population);
 
 		let output = output.as_deref();
-		match compression {
-			CompressionType::Sha256 => {
-				tracing::info!("Using SHA256 compression for Merkle tree");
+		match hash_suite {
+			HashSuiteType::Sha256 => {
+				tracing::info!("Using SHA-256 hash suite for Merkle tree");
 				prove_with_hash_suite::<StdHashSuite>(
+					cs,
+					log_inv_rate as usize,
+					zk,
+					message,
+					witness,
+					output,
+				)?;
+			}
+			HashSuiteType::Blake3 => {
+				tracing::info!("Using Blake3 hash suite for Merkle tree");
+				prove_with_hash_suite::<Blake3HashSuite>(
 					cs,
 					log_inv_rate as usize,
 					zk,
@@ -820,8 +835,8 @@ where
 		let log_inv_rate = *matches
 			.get_one::<u32>("log_inv_rate")
 			.expect("has default value");
-		let compression = matches
-			.get_one::<CompressionType>("compression")
+		let hash_suite = matches
+			.get_one::<HashSuiteType>("hash_suite")
 			.expect("has default value")
 			.clone();
 
@@ -861,11 +876,17 @@ where
 		)?;
 		drop(witness_load_scope);
 
-		match compression {
-			CompressionType::Sha256 => {
-				tracing::info!("Using SHA256 compression for Merkle tree");
+		match hash_suite {
+			HashSuiteType::Sha256 => {
+				tracing::info!("Using SHA-256 hash suite for Merkle tree");
 				let (verifier, prover) =
 					setup::<StdHashSuite>(cs, log_inv_rate as usize, maybe_key_collection)?;
+				prove_verify(&verifier, &prover, witness)?;
+			}
+			HashSuiteType::Blake3 => {
+				tracing::info!("Using Blake3 hash suite for Merkle tree");
+				let (verifier, prover) =
+					setup::<Blake3HashSuite>(cs, log_inv_rate as usize, maybe_key_collection)?;
 				prove_verify(&verifier, &prover, witness)?;
 			}
 		};
@@ -880,8 +901,8 @@ where
 		let log_inv_rate = *matches
 			.get_one::<u32>("log_inv_rate")
 			.expect("has default value");
-		let compression = matches
-			.get_one::<CompressionType>("compression")
+		let hash_suite = matches
+			.get_one::<HashSuiteType>("hash_suite")
 			.expect("has default value")
 			.clone();
 		let zk = matches.get_flag("zk");
@@ -912,10 +933,21 @@ where
 		circuit.populate_wire_witness(&mut filler)?;
 		let witness = filler.into_value_vec();
 
-		match compression {
-			CompressionType::Sha256 => {
-				tracing::info!("Using SHA256 compression for Merkle tree");
+		match hash_suite {
+			HashSuiteType::Sha256 => {
+				tracing::info!("Using SHA-256 hash suite for Merkle tree");
 				verify_with_hash_suite::<StdHashSuite>(
+					cs,
+					log_inv_rate as usize,
+					zk,
+					message,
+					witness,
+					proof_bytes,
+				)?;
+			}
+			HashSuiteType::Blake3 => {
+				tracing::info!("Using Blake3 hash suite for Merkle tree");
+				verify_with_hash_suite::<Blake3HashSuite>(
 					cs,
 					log_inv_rate as usize,
 					zk,

--- a/crates/examples/src/lib.rs
+++ b/crates/examples/src/lib.rs
@@ -46,10 +46,19 @@ pub fn init_tracing() {
 		.try_init();
 }
 
+/// Selects which Merkle [`HashSuite`] the prover and verifier use.
+///
+/// A hash suite fixes both halves of the Merkle tree at once:
+/// - the leaf hash applied to the committed values, and
+/// - the two-to-one compression that folds a pair of child nodes into their parent.
+///
+/// It does not select a compression function alone, which is why the flag is `--hash-suite`.
 #[derive(Debug, Clone, ValueEnum)]
-pub enum CompressionType {
-	/// SHA-256 compression function
+pub enum HashSuiteType {
+	/// SHA-256 leaves with a SHA-256 two-to-one compression.
 	Sha256,
+	/// Blake3 leaves with a Blake3 two-to-one compression.
+	Blake3,
 }
 
 /// Standard verifier using SHA256 compression


### PR DESCRIPTION
Closes [BINIUS-212](https://linear.app/jimpo/issue/BINIUS-212/select-the-blake3-hash-suite-from-the-example-cli-and-rename-the).

Makes the Blake3 `HashSuite` selectable from the example CLI, and renames the flag to say what it actually picks. No behavior change for existing invocations.

### The problem

The example CLI's `--compression` / `-c` flag had two things wrong.

First, it could only ever pick SHA-256.
The backing enum `CompressionType` had a single variant, `Sha256`.
[BINIUS-206](https://linear.app/jimpo/issue/BINIUS-206) landed a Blake3 `HashSuite`, but the CLI had no way to select it — so the fast path stayed unreachable from the examples.

Second, the flag was misnamed.
It does not select a compression function.
It selects the whole hash suite: the leaf hash **and** the two-to-one inner-node compression.
Calling it `--compression` misled the reader about what it controls.

### The idea

A hash suite fixes both halves of the Merkle tree at once:

- the leaf hash applied to the committed values, and
- the two-to-one compression that folds a pair of child nodes into their parent.

So the selector is renamed to name that unit, and gains a `Blake3` arm next to `Sha256`.

```
CompressionType { Sha256 }   ->   HashSuiteType { Sha256, Blake3 }
--compression <TYPE>         ->   --hash-suite <SUITE>
```

### The change

The enum and its dispatch sites, in `crates/examples`:

```diff
- pub enum CompressionType { Sha256 }
+ pub enum HashSuiteType  { Sha256, Blake3 }

  match hash_suite {
      HashSuiteType::Sha256 => prove_with_hash_suite::<StdHashSuite>(..),
+     HashSuiteType::Blake3 => prove_with_hash_suite::<Blake3HashSuite>(..),
  }
```

- `lib.rs` — `CompressionType` -> `HashSuiteType`, add the `Blake3` variant.
- `cli.rs` — rename the flag on the derived `Prove` command and the four `Arg` builders; add the `Blake3` arm at all three dispatch sites (`run_prove`, `run_load_prove`, `run_verify`).

### Back-compat

The change is user-visible, but existing invocations keep working:

- the short `-c` stays,
- `--compression` remains a **hidden** alias (`.alias("compression")`), so `-c sha256` and `--compression sha256` still parse,
- only `--hash-suite` shows in `--help`.

### Scope

- **changed:** `crates/examples/src/lib.rs`, `crates/examples/src/cli.rs`.
- **left untouched:** the hash crate — `Blake3HashSuite` already exists and already satisfies the `HashSuite + Clone` and `Output<LeafHash>: SerializeBytes + DeserializeBytes` bounds (its digest is the same 32-byte `GenericArray` as SHA-256's).

### Verification

- `cargo check --workspace --all-targets`, `clippy -p binius-examples --all-targets`, nightly `fmt`, `test -p binius-examples` — all clean.
- End-to-end via the `sha256` example:

| invocation | result |
|---|---|
| `prove --hash-suite blake3` | proves + verifies (95 KiB) |
| `prove -c blake3` (short) | works |
| `prove --compression sha256` (hidden alias) | works — back-compat |

🤖 Generated with [Claude Code](https://claude.com/claude-code)