### PR TITLE
BINIUS-215: add Merkle IP channel traits over transcript

### DIFF
--- a/crates/iop-prover/src/lib.rs
+++ b/crates/iop-prover/src/lib.rs
@@ -31,5 +31,6 @@ pub mod basefold_compiler;
 pub mod channel;
 pub mod fri;
 pub mod logup_star;
+pub mod merkle_channel;
 pub mod merkle_tree;
 pub mod naive_channel;

--- a/crates/iop-prover/src/merkle_channel.rs
+++ b/crates/iop-prover/src/merkle_channel.rs
@@ -1,0 +1,242 @@
+// Copyright 2026 The Binius Developers
+
+//! Channel abstraction for provers of protocols using Merkle commitments.
+//!
+//! This module provides the [`MerkleIPProverChannel`] trait, the prover-side counterpart of
+//! `binius_iop::merkle_channel::MerkleIPVerifierChannel`. It extends [`IPProverChannel`] with the
+//! ability to send Merkle commitments and openings of the committed leaves.
+//!
+//! The [`ProverMerkleTranscriptChannel`] implementation wraps a [`ProverTranscript`] and commits
+//! with a [`BinaryMerkleTreeProver`]: commitment roots are written as observed messages, while
+//! opening proofs are written as unobserved decommitment advice bound to the already-observed
+//! roots.
+
+use std::{borrow::BorrowMut, marker::PhantomData};
+
+use binius_field::{Field, PackedField};
+use binius_hash::binary_merkle_tree::{BinaryMerkleTree, HashSuite};
+use binius_iop::merkle_tree::MerkleTreeScheme;
+use binius_ip_prover::channel::IPProverChannel;
+use binius_math::FieldSlice;
+use binius_transcript::{
+	ProverTranscript,
+	fiat_shamir::{CanSampleBits, Challenger},
+};
+use binius_utils::{SerializeBytes, checked_arithmetics::log2_strict_usize};
+use digest::Output;
+use rand::CryptoRng;
+
+use crate::merkle_tree::{MerkleTreeProver, commit_field_buffer, prover::BinaryMerkleTreeProver};
+
+/// An extension of [`IPProverChannel`] that can send and open Merkle commitments.
+pub trait MerkleIPProverChannel<F: Field>: IPProverChannel<F> {
+	/// A Merkle commitment, carrying the data required to open it later.
+	type Commitment;
+
+	/// Commits `data` as a Merkle tree with leaves of exactly `leaf_size` scalars each and sends
+	/// the commitment.
+	///
+	/// The tree depth is `log2(data.len() / leaf_size)`.
+	///
+	/// ## Preconditions
+	///
+	/// * `data.len()` must be a multiple of `leaf_size`, and the resulting leaf count must be a
+	///   power of two.
+	fn send_merkle_commitment<P: PackedField<Scalar = F>>(
+		&mut self,
+		data: FieldSlice<P>,
+		leaf_size: usize,
+	) -> Self::Commitment;
+
+	/// Sends a multi-opening of committed leaves, bound by a Merkle commitment.
+	///
+	/// All indices must be less than `2^depth` for the commitment's tree depth. The verifier
+	/// receives `indices.len() * leaf_size` field elements via its matching `recv_openings` call.
+	///
+	/// ## Preconditions
+	///
+	/// * `data` must be the buffer passed to [`Self::send_merkle_commitment`] for this commitment.
+	fn send_openings<P: PackedField<Scalar = F>>(
+		&mut self,
+		commitment: &Self::Commitment,
+		data: FieldSlice<P>,
+		indices: &[usize],
+	);
+
+	/// Sends the full committed vector, bound by a Merkle commitment.
+	///
+	/// ## Preconditions
+	///
+	/// * `data` must be the buffer passed to [`Self::send_merkle_commitment`] for this commitment.
+	fn send_committed_vector<P: PackedField<Scalar = F>>(
+		&mut self,
+		commitment: &Self::Commitment,
+		data: FieldSlice<P>,
+	);
+
+	/// Samples a uniform integer with the given number of bits.
+	///
+	/// Protocols use this to sample query indices for [`Self::send_openings`], matching the
+	/// verifier's samples.
+	fn sample_bits(&mut self, bits: usize) -> usize;
+}
+
+/// A [`MerkleIPProverChannel`] over a [`ProverTranscript`], committing with a
+/// [`BinaryMerkleTreeProver`].
+///
+/// The transcript is held through a [`BorrowMut`] bound, so the channel can own the transcript or
+/// mutably borrow one.
+pub struct ProverMerkleTranscriptChannel<T, Challenger_, F, H: HashSuite> {
+	transcript: T,
+	merkle_prover: BinaryMerkleTreeProver<F, H>,
+	_challenger_marker: PhantomData<Challenger_>,
+}
+
+impl<T, Challenger_, F, H: HashSuite> ProverMerkleTranscriptChannel<T, Challenger_, F, H> {
+	/// Constructs a channel over the transcript with a non-hiding Merkle tree prover.
+	pub fn new(transcript: T) -> Self {
+		Self::with_merkle_prover(transcript, BinaryMerkleTreeProver::new())
+	}
+
+	/// Constructs a channel over the transcript with a hiding Merkle tree prover, salting each
+	/// leaf with `salt_len` random field elements drawn from `rng`.
+	pub fn hiding(transcript: T, rng: impl CryptoRng, salt_len: usize) -> Self {
+		Self::with_merkle_prover(transcript, BinaryMerkleTreeProver::hiding(rng, salt_len))
+	}
+
+	/// Constructs a channel over the transcript with the given Merkle tree prover.
+	pub const fn with_merkle_prover(
+		transcript: T,
+		merkle_prover: BinaryMerkleTreeProver<F, H>,
+	) -> Self {
+		Self {
+			transcript,
+			merkle_prover,
+			_challenger_marker: PhantomData,
+		}
+	}
+
+	/// Returns the wrapped transcript.
+	pub fn into_transcript(self) -> T {
+		self.transcript
+	}
+}
+
+/// A Merkle commitment produced by [`ProverMerkleTranscriptChannel`], carrying the committed tree
+/// required to open it.
+pub struct ProverMerkleCommitment<Committed> {
+	committed: Committed,
+	depth: usize,
+	log_leaf_size: usize,
+}
+
+impl<F, T, Challenger_, H> IPProverChannel<F>
+	for ProverMerkleTranscriptChannel<T, Challenger_, F, H>
+where
+	F: Field,
+	T: BorrowMut<ProverTranscript<Challenger_>>,
+	Challenger_: Challenger,
+	H: HashSuite,
+{
+	fn send_one(&mut self, elem: F) {
+		self.transcript.borrow_mut().send_one(elem)
+	}
+
+	fn send_many(&mut self, elems: &[F]) {
+		self.transcript.borrow_mut().send_many(elems)
+	}
+
+	fn observe_one(&mut self, val: F) {
+		self.transcript.borrow_mut().observe_one(val)
+	}
+
+	fn observe_many(&mut self, vals: &[F]) {
+		self.transcript.borrow_mut().observe_many(vals)
+	}
+
+	fn sample(&mut self) -> F {
+		IPProverChannel::sample(self.transcript.borrow_mut())
+	}
+}
+
+impl<F, T, Challenger_, H> MerkleIPProverChannel<F>
+	for ProverMerkleTranscriptChannel<T, Challenger_, F, H>
+where
+	F: Field,
+	T: BorrowMut<ProverTranscript<Challenger_>>,
+	Challenger_: Challenger,
+	H: HashSuite,
+	Output<H::LeafHash>: SerializeBytes,
+{
+	type Commitment = ProverMerkleCommitment<BinaryMerkleTree<Output<H::LeafHash>, F>>;
+
+	fn send_merkle_commitment<P: PackedField<Scalar = F>>(
+		&mut self,
+		data: FieldSlice<P>,
+		leaf_size: usize,
+	) -> Self::Commitment {
+		assert!(leaf_size.is_power_of_two(), "precondition: leaf_size must be a power of two");
+		let log_leaf_size = log2_strict_usize(leaf_size);
+		let (commitment, committed) = commit_field_buffer(&self.merkle_prover, data, log_leaf_size);
+		self.transcript
+			.borrow_mut()
+			.message()
+			.write(&commitment.root);
+		ProverMerkleCommitment {
+			committed,
+			depth: commitment.depth,
+			log_leaf_size,
+		}
+	}
+
+	fn send_openings<P: PackedField<Scalar = F>>(
+		&mut self,
+		commitment: &Self::Commitment,
+		data: FieldSlice<P>,
+		indices: &[usize],
+	) {
+		let tree_depth = commitment.depth;
+		debug_assert_eq!(tree_depth, data.log_len() - commitment.log_leaf_size);
+		assert!(indices.iter().all(|&index| index < 1 << tree_depth)); // precondition
+
+		// Write the optimal internal layer once, then the leaf values and opening proof for each
+		// queried index, mirroring the verifier's `recv_openings`.
+		let scheme = self.merkle_prover.scheme();
+		let layer_depth = scheme.optimal_verify_layer(indices.len(), tree_depth);
+		let layer = self.merkle_prover.layer(&commitment.committed, layer_depth);
+		let mut advice = self.transcript.borrow_mut().decommitment();
+		advice.write_slice(layer);
+		for &index in indices {
+			let leaf = data.chunk(commitment.log_leaf_size, index);
+			advice.write_scalar_iter(leaf.iter_scalars());
+			self.merkle_prover.prove_opening(
+				&commitment.committed,
+				layer_depth,
+				index,
+				&mut advice,
+			);
+		}
+	}
+
+	fn send_committed_vector<P: PackedField<Scalar = F>>(
+		&mut self,
+		commitment: &Self::Commitment,
+		data: FieldSlice<P>,
+	) {
+		debug_assert_eq!(commitment.depth, data.log_len() - commitment.log_leaf_size);
+
+		// Write the data in full, then whatever binding data the verifier's `verify_vector` reads
+		// while recomputing the root (the per-leaf salts, empty for non-hiding trees).
+		let mut advice = self.transcript.borrow_mut().decommitment();
+		advice.write_scalar_iter(data.iter_scalars());
+		self.merkle_prover
+			.prove_vector(&commitment.committed, &mut advice);
+	}
+
+	fn sample_bits(&mut self, bits: usize) -> usize {
+		CanSampleBits::sample_bits(self.transcript.borrow_mut(), bits) as usize
+	}
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/iop-prover/src/merkle_channel/tests.rs
+++ b/crates/iop-prover/src/merkle_channel/tests.rs
@@ -1,0 +1,213 @@
+// Copyright 2026 The Binius Developers
+
+use binius_field::{BinaryField128bGhash as B128, PackedBinaryGhash2x128b};
+use binius_hash::{StdDigest, StdHashSuite};
+use binius_iop::{
+	merkle_channel::{MerkleIPVerifierChannel, VerifierMerkleTranscriptChannel},
+	merkle_tree::BinaryMerkleTreeScheme,
+};
+use binius_math::{FieldBuffer, test_utils::random_scalars};
+use binius_transcript::{ProverTranscript, fiat_shamir::HasherChallenger};
+use rand::prelude::*;
+
+use super::{MerkleIPProverChannel, ProverMerkleTranscriptChannel};
+
+type StdChallenger = HasherChallenger<StdDigest>;
+type P = PackedBinaryGhash2x128b;
+type VerifierChannel<T> = VerifierMerkleTranscriptChannel<T, StdChallenger, B128, StdHashSuite>;
+type ProverChannel<T> = ProverMerkleTranscriptChannel<T, StdChallenger, B128, StdHashSuite>;
+
+const LOG_LEN: usize = 8;
+const LOG_LEAF_SIZE: usize = 2;
+const LEAF_SIZE: usize = 1 << LOG_LEAF_SIZE;
+const DEPTH: usize = LOG_LEN - LOG_LEAF_SIZE;
+const N_QUERIES: usize = 5;
+
+fn sample_indices(channel: &mut impl MerkleIPProverChannel<B128>) -> Vec<usize> {
+	(0..N_QUERIES).map(|_| channel.sample_bits(DEPTH)).collect()
+}
+
+#[test]
+fn test_merkle_channel_roundtrip() {
+	let mut rng = StdRng::seed_from_u64(0);
+
+	let scalars = random_scalars::<B128>(&mut rng, 1 << LOG_LEN);
+	let data = FieldBuffer::<P, _>::from_values(&scalars);
+
+	// Prover side: commit, sample query indices, open them, then send the vector in full.
+	let mut prover_channel = ProverChannel::new(ProverTranscript::new(StdChallenger::default()));
+	let commitment = prover_channel.send_merkle_commitment(data.to_ref(), LEAF_SIZE);
+	let indices = sample_indices(&mut prover_channel);
+	prover_channel.send_openings(&commitment, data.to_ref(), &indices);
+	prover_channel.send_committed_vector(&commitment, data.to_ref());
+
+	// Verifier side: mirror the interaction and check the opened values against the data.
+	let transcript = prover_channel.into_transcript().into_verifier();
+	let mut verifier_channel = VerifierChannel::new(transcript);
+	let commitment = verifier_channel
+		.recv_merkle_commitment(LEAF_SIZE, DEPTH)
+		.unwrap();
+	let verifier_indices = (0..N_QUERIES)
+		.map(|_| verifier_channel.sample_bits(DEPTH))
+		.collect::<Vec<_>>();
+	assert_eq!(verifier_indices, indices);
+
+	let values = verifier_channel
+		.recv_openings(&commitment, &indices)
+		.unwrap();
+	assert_eq!(values.len(), N_QUERIES * LEAF_SIZE);
+	for (chunk, &index) in values.chunks(LEAF_SIZE).zip(&indices) {
+		assert_eq!(chunk, &scalars[index * LEAF_SIZE..(index + 1) * LEAF_SIZE]);
+	}
+
+	let vector = verifier_channel.recv_committed_vector(&commitment).unwrap();
+	assert_eq!(vector, scalars);
+
+	verifier_channel.into_transcript().finalize().unwrap();
+}
+
+#[test]
+fn test_merkle_channel_roundtrip_hiding() {
+	let mut rng = StdRng::seed_from_u64(0);
+	let salt_len = 2;
+
+	let scalars = random_scalars::<B128>(&mut rng, 1 << LOG_LEN);
+	let data = FieldBuffer::<P, _>::from_values(&scalars);
+
+	let mut prover_channel =
+		ProverChannel::hiding(ProverTranscript::new(StdChallenger::default()), &mut rng, salt_len);
+	let commitment = prover_channel.send_merkle_commitment(data.to_ref(), LEAF_SIZE);
+	let indices = sample_indices(&mut prover_channel);
+	prover_channel.send_openings(&commitment, data.to_ref(), &indices);
+	prover_channel.send_committed_vector(&commitment, data.to_ref());
+
+	let transcript = prover_channel.into_transcript().into_verifier();
+	let mut verifier_channel =
+		VerifierChannel::with_scheme(transcript, BinaryMerkleTreeScheme::hiding(salt_len));
+	let commitment = verifier_channel
+		.recv_merkle_commitment(LEAF_SIZE, DEPTH)
+		.unwrap();
+	let verifier_indices = (0..N_QUERIES)
+		.map(|_| verifier_channel.sample_bits(DEPTH))
+		.collect::<Vec<_>>();
+	assert_eq!(verifier_indices, indices);
+
+	let values = verifier_channel
+		.recv_openings(&commitment, &indices)
+		.unwrap();
+	for (chunk, &index) in values.chunks(LEAF_SIZE).zip(&indices) {
+		assert_eq!(chunk, &scalars[index * LEAF_SIZE..(index + 1) * LEAF_SIZE]);
+	}
+
+	let vector = verifier_channel.recv_committed_vector(&commitment).unwrap();
+	assert_eq!(vector, scalars);
+
+	verifier_channel.into_transcript().finalize().unwrap();
+}
+
+#[test]
+fn test_merkle_channel_borrowed_transcript() {
+	let mut rng = StdRng::seed_from_u64(0);
+
+	let scalars = random_scalars::<B128>(&mut rng, 1 << LOG_LEN);
+	let data = FieldBuffer::<P, _>::from_values(&scalars);
+
+	let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
+	{
+		let mut prover_channel = ProverChannel::new(&mut prover_transcript);
+		let commitment = prover_channel.send_merkle_commitment(data.to_ref(), LEAF_SIZE);
+		let indices = sample_indices(&mut prover_channel);
+		prover_channel.send_openings(&commitment, data.to_ref(), &indices);
+	}
+
+	let mut verifier_transcript = prover_transcript.into_verifier();
+	{
+		let mut verifier_channel = VerifierChannel::new(&mut verifier_transcript);
+		let commitment = verifier_channel
+			.recv_merkle_commitment(LEAF_SIZE, DEPTH)
+			.unwrap();
+		let indices = (0..N_QUERIES)
+			.map(|_| verifier_channel.sample_bits(DEPTH))
+			.collect::<Vec<_>>();
+		let values = verifier_channel
+			.recv_openings(&commitment, &indices)
+			.unwrap();
+		for (chunk, &index) in values.chunks(LEAF_SIZE).zip(&indices) {
+			assert_eq!(chunk, &scalars[index * LEAF_SIZE..(index + 1) * LEAF_SIZE]);
+		}
+	}
+	verifier_transcript.finalize().unwrap();
+}
+
+#[test]
+fn test_merkle_channel_rejects_openings_at_wrong_index() {
+	let mut rng = StdRng::seed_from_u64(0);
+
+	let scalars = random_scalars::<B128>(&mut rng, 1 << LOG_LEN);
+	let data = FieldBuffer::<P, _>::from_values(&scalars);
+
+	let mut prover_channel = ProverChannel::new(ProverTranscript::new(StdChallenger::default()));
+	let commitment = prover_channel.send_merkle_commitment(data.to_ref(), LEAF_SIZE);
+	let indices = sample_indices(&mut prover_channel);
+	prover_channel.send_openings(&commitment, data.to_ref(), &indices);
+
+	let transcript = prover_channel.into_transcript().into_verifier();
+	let mut verifier_channel = VerifierChannel::new(transcript);
+	let commitment = verifier_channel
+		.recv_merkle_commitment(LEAF_SIZE, DEPTH)
+		.unwrap();
+	let _ = (0..N_QUERIES)
+		.map(|_| verifier_channel.sample_bits(DEPTH))
+		.collect::<Vec<_>>();
+
+	// Requesting openings at indices other than the ones the prover opened must fail.
+	let wrong_indices = indices.iter().map(|&index| index ^ 1).collect::<Vec<_>>();
+	assert!(
+		verifier_channel
+			.recv_openings(&commitment, &wrong_indices)
+			.is_err()
+	);
+
+	// Drop the transcript without finalizing; the tampered read left it misaligned.
+	let _ = verifier_channel.into_transcript();
+}
+
+#[test]
+fn test_merkle_channel_rejects_wrong_root() {
+	let mut rng = StdRng::seed_from_u64(0);
+
+	let scalars = random_scalars::<B128>(&mut rng, 1 << LOG_LEN);
+	let data = FieldBuffer::<P, _>::from_values(&scalars);
+	let other_scalars = random_scalars::<B128>(&mut rng, 1 << LOG_LEN);
+	let other_data = FieldBuffer::<P, _>::from_values(&other_scalars);
+
+	// Commit one buffer but open the other, so the openings do not match the commitment.
+	let mut prover_channel = ProverChannel::new(ProverTranscript::new(StdChallenger::default()));
+	let commitment = prover_channel.send_merkle_commitment(data.to_ref(), LEAF_SIZE);
+	let other_commitment = prover_channel.send_merkle_commitment(other_data.to_ref(), LEAF_SIZE);
+	let indices = sample_indices(&mut prover_channel);
+	prover_channel.send_openings(&other_commitment, other_data.to_ref(), &indices);
+	let _ = commitment;
+
+	let transcript = prover_channel.into_transcript().into_verifier();
+	let mut verifier_channel = VerifierChannel::new(transcript);
+	let commitment = verifier_channel
+		.recv_merkle_commitment(LEAF_SIZE, DEPTH)
+		.unwrap();
+	let _other_commitment = verifier_channel
+		.recv_merkle_commitment(LEAF_SIZE, DEPTH)
+		.unwrap();
+	let indices = (0..N_QUERIES)
+		.map(|_| verifier_channel.sample_bits(DEPTH))
+		.collect::<Vec<_>>();
+
+	// The openings on the tape are bound to `other_commitment`, so verifying them against
+	// `commitment` must fail.
+	assert!(
+		verifier_channel
+			.recv_openings(&commitment, &indices)
+			.is_err()
+	);
+
+	let _ = verifier_channel.into_transcript();
+}

--- a/crates/iop-prover/src/merkle_tree/mod.rs
+++ b/crates/iop-prover/src/merkle_tree/mod.rs
@@ -91,6 +91,12 @@ pub trait MerkleTreeProver<T: FixedSizeSerializeBytes> {
 		index: usize,
 		proof: &mut TranscriptWriter<B>,
 	);
+
+	/// Generate an opening proof for the full committed vector.
+	///
+	/// This writes the binding data that [`MerkleTreeScheme::verify_vector`] reads alongside the
+	/// data itself while recomputing the root — the per-leaf salts, empty for non-hiding trees.
+	fn prove_vector<B: BufMut>(&self, committed: &Self::Committed, proof: &mut TranscriptWriter<B>);
 }
 
 /// Commits a field buffer to a Merkle tree, packing `1 << log_batch_size` scalars into each leaf.

--- a/crates/iop-prover/src/merkle_tree/prover.rs
+++ b/crates/iop-prover/src/merkle_tree/prover.rs
@@ -69,7 +69,7 @@ where
 		index: usize,
 		proof: &mut TranscriptWriter<B>,
 	) {
-		let salt = committed.get_salt(index >> layer_depth);
+		let salt = committed.get_salt(index);
 		proof.write_slice(salt);
 
 		let branch = committed

--- a/crates/iop-prover/src/merkle_tree/prover.rs
+++ b/crates/iop-prover/src/merkle_tree/prover.rs
@@ -78,6 +78,16 @@ where
 		proof.write_slice(&branch);
 	}
 
+	fn prove_vector<B: BufMut>(
+		&self,
+		committed: &Self::Committed,
+		proof: &mut TranscriptWriter<B>,
+	) {
+		for leaf_index in 0..1 << committed.log_len {
+			proof.write_slice(committed.get_salt(leaf_index));
+		}
+	}
+
 	#[allow(clippy::type_complexity)]
 	fn commit_iterated<ParIter>(
 		&self,

--- a/crates/iop-prover/src/merkle_tree/tests.rs
+++ b/crates/iop-prover/src/merkle_tree/tests.rs
@@ -160,6 +160,40 @@ fn test_binary_merkle_vcs_hiding_verify_vector() {
 }
 
 #[test]
+fn test_binary_merkle_vcs_hiding_prove_open_against_layer() {
+	let mut rng = StdRng::seed_from_u64(0);
+
+	let salt_len = 2;
+	let mt_prover = BinaryMerkleTreeProver::<_, StdHashSuite>::hiding(&mut rng, salt_len);
+
+	let data = random_scalars::<B128>(&mut rng, 32);
+	let (_, tree) = mt_prover.commit(&data, 1);
+
+	// Openings against an internal layer must write the salt of the opened leaf, not of the
+	// layer-relative index.
+	for layer_depth in 1..5 {
+		let layer = mt_prover.layer(&tree, layer_depth);
+		for (i, value) in data.iter().enumerate() {
+			let mut proof_writer = ProverTranscript::new(StdChallenger::default());
+			mt_prover.prove_opening(&tree, layer_depth, i, &mut proof_writer.message());
+
+			let mut proof_reader = proof_writer.into_verifier();
+			mt_prover
+				.scheme()
+				.verify_opening(
+					i,
+					slice::from_ref(value),
+					layer_depth,
+					5,
+					layer,
+					&mut proof_reader.message(),
+				)
+				.unwrap();
+		}
+	}
+}
+
+#[test]
 fn test_binary_merkle_vcs_hiding_batch_size() {
 	let mut rng = StdRng::seed_from_u64(0);
 

--- a/crates/iop/src/lib.rs
+++ b/crates/iop/src/lib.rs
@@ -31,6 +31,7 @@ pub mod basefold_compiler;
 pub mod channel;
 pub mod fri;
 pub mod logup_star;
+pub mod merkle_channel;
 pub mod merkle_tree;
 pub mod naive_channel;
 pub mod oracle_setup_channel;

--- a/crates/iop/src/merkle_channel.rs
+++ b/crates/iop/src/merkle_channel.rs
@@ -1,0 +1,232 @@
+// Copyright 2026 The Binius Developers
+
+//! Channel abstraction for verifiers of protocols using Merkle commitments.
+//!
+//! This module provides the [`MerkleIPVerifierChannel`] trait, which extends
+//! [`IPVerifierChannel`] with the ability to receive Merkle commitments and openings of the
+//! committed leaves. Protocols like FRI and BaseFold interact with the prover through these
+//! operations instead of reading commitments and opening proofs from a transcript directly.
+//!
+//! The [`VerifierMerkleTranscriptChannel`] implementation wraps a [`VerifierTranscript`] and
+//! verifies openings with a [`BinaryMerkleTreeScheme`]: commitment roots are read as observed
+//! messages, while opening proofs are read as unobserved decommitment advice bound to the
+//! already-observed roots.
+
+use std::{borrow::BorrowMut, marker::PhantomData};
+
+use binius_field::{Field, util::FieldFn};
+use binius_hash::binary_merkle_tree::HashSuite;
+use binius_ip::channel::IPVerifierChannel;
+use binius_transcript::{
+	VerifierTranscript,
+	fiat_shamir::{CanSampleBits, Challenger},
+};
+use binius_utils::{DeserializeBytes, FixedSizeSerializeBytes};
+use digest::Output;
+
+use crate::merkle_tree::{BinaryMerkleTreeScheme, Commitment, MerkleTreeScheme};
+
+/// An extension of [`IPVerifierChannel`] that can receive and open Merkle commitments.
+pub trait MerkleIPVerifierChannel<F: Field>: IPVerifierChannel<F> {
+	/// A Merkle commitment.
+	type Commitment: Clone;
+
+	/// Receives a Merkle commitment for a tree with the given depth and leaf size.
+	///
+	/// The leaves of the Merkle tree each contain exactly `leaf_size` `F` elements.
+	fn recv_merkle_commitment(
+		&mut self,
+		leaf_size: usize,
+		depth: usize,
+	) -> Result<Self::Commitment, Error>;
+
+	/// Receives a multi-opening of leaves, bound by a Merkle commitment.
+	///
+	/// Each commitment is associated with the `leaf_size` and `depth` requested when received with
+	/// [`Self::recv_merkle_commitment`]. All indices must be less than `2^depth`.
+	///
+	/// Returns `indices.len() * leaf_size` field elements, where each chunk of `leaf_size`
+	/// contiguous elements corresponds to one provided index.
+	fn recv_openings(
+		&mut self,
+		commitment: &Self::Commitment,
+		indices: &[usize],
+	) -> Result<Vec<F>, Error>;
+
+	/// Receives the full committed vector, bound by a Merkle commitment.
+	///
+	/// Returns `leaf_size << depth` field elements, in leaf order.
+	fn recv_committed_vector(&mut self, commitment: &Self::Commitment) -> Result<Vec<F>, Error>;
+
+	/// Samples a uniform integer with the given number of bits.
+	///
+	/// Protocols use this to sample query indices for [`Self::recv_openings`].
+	fn sample_bits(&mut self, bits: usize) -> usize;
+}
+
+/// A [`MerkleIPVerifierChannel`] over a [`VerifierTranscript`], verifying openings with a
+/// [`BinaryMerkleTreeScheme`].
+///
+/// The transcript is held through a [`BorrowMut`] bound, so the channel can own the transcript or
+/// mutably borrow one.
+pub struct VerifierMerkleTranscriptChannel<T, Challenger_, F, H: HashSuite> {
+	transcript: T,
+	scheme: BinaryMerkleTreeScheme<F, H>,
+	_challenger_marker: PhantomData<Challenger_>,
+}
+
+impl<T, Challenger_, F, H: HashSuite> VerifierMerkleTranscriptChannel<T, Challenger_, F, H> {
+	/// Constructs a channel over the transcript with a non-hiding Merkle tree scheme.
+	pub fn new(transcript: T) -> Self {
+		Self::with_scheme(transcript, BinaryMerkleTreeScheme::new())
+	}
+
+	/// Constructs a channel over the transcript with the given Merkle tree scheme.
+	pub const fn with_scheme(transcript: T, scheme: BinaryMerkleTreeScheme<F, H>) -> Self {
+		Self {
+			transcript,
+			scheme,
+			_challenger_marker: PhantomData,
+		}
+	}
+
+	/// Returns the wrapped transcript.
+	pub fn into_transcript(self) -> T {
+		self.transcript
+	}
+}
+
+/// A Merkle commitment received over a transcript channel.
+#[derive(Debug, Clone)]
+pub struct TranscriptMerkleCommitment<Digest> {
+	/// The commitment root and tree depth.
+	pub commitment: Commitment<Digest>,
+	/// The number of `F` elements in each leaf.
+	pub leaf_size: usize,
+}
+
+impl<F, T, Challenger_, H> IPVerifierChannel<F>
+	for VerifierMerkleTranscriptChannel<T, Challenger_, F, H>
+where
+	F: Field,
+	T: BorrowMut<VerifierTranscript<Challenger_>>,
+	Challenger_: Challenger,
+	H: HashSuite,
+{
+	type Elem = F;
+
+	fn recv_one(&mut self) -> Result<F, binius_ip::channel::Error> {
+		self.transcript.borrow_mut().recv_one()
+	}
+
+	fn recv_many(&mut self, n: usize) -> Result<Vec<F>, binius_ip::channel::Error> {
+		self.transcript.borrow_mut().recv_many(n)
+	}
+
+	fn recv_array<const N: usize>(&mut self) -> Result<[F; N], binius_ip::channel::Error> {
+		self.transcript.borrow_mut().recv_array()
+	}
+
+	fn sample(&mut self) -> F {
+		IPVerifierChannel::sample(self.transcript.borrow_mut())
+	}
+
+	fn observe_one(&mut self, val: F) -> F {
+		self.transcript.borrow_mut().observe_one(val)
+	}
+
+	fn observe_many(&mut self, vals: &[F]) -> Vec<F> {
+		self.transcript.borrow_mut().observe_many(vals)
+	}
+
+	fn assert_zero(&mut self, val: F) -> Result<(), binius_ip::channel::Error> {
+		self.transcript.borrow_mut().assert_zero(val)
+	}
+
+	fn compute_public_value(&mut self, inputs: &[F], f: impl FieldFn<F>) -> F {
+		self.transcript.borrow_mut().compute_public_value(inputs, f)
+	}
+}
+
+impl<F, T, Challenger_, H> MerkleIPVerifierChannel<F>
+	for VerifierMerkleTranscriptChannel<T, Challenger_, F, H>
+where
+	F: Field + FixedSizeSerializeBytes,
+	T: BorrowMut<VerifierTranscript<Challenger_>>,
+	Challenger_: Challenger,
+	H: HashSuite,
+	Output<H::LeafHash>: DeserializeBytes,
+{
+	type Commitment = TranscriptMerkleCommitment<Output<H::LeafHash>>;
+
+	fn recv_merkle_commitment(
+		&mut self,
+		leaf_size: usize,
+		depth: usize,
+	) -> Result<Self::Commitment, Error> {
+		let root = self.transcript.borrow_mut().message().read()?;
+		Ok(TranscriptMerkleCommitment {
+			commitment: Commitment { root, depth },
+			leaf_size,
+		})
+	}
+
+	fn recv_openings(
+		&mut self,
+		commitment: &Self::Commitment,
+		indices: &[usize],
+	) -> Result<Vec<F>, Error> {
+		let tree_depth = commitment.commitment.depth;
+		assert!(indices.iter().all(|&index| index < 1 << tree_depth)); // precondition
+
+		// Read and verify the optimal internal layer once, then verify every opening against it.
+		let layer_depth = self.scheme.optimal_verify_layer(indices.len(), tree_depth);
+		let mut advice = self.transcript.borrow_mut().decommitment();
+		let layer_digests = advice.read_vec(1 << layer_depth)?;
+		self.scheme
+			.verify_layer(&commitment.commitment.root, layer_depth, &layer_digests)?;
+
+		let mut values = Vec::with_capacity(indices.len() * commitment.leaf_size);
+		for &index in indices {
+			let leaf = advice.read_scalar_slice::<F>(commitment.leaf_size)?;
+			self.scheme.verify_opening(
+				index,
+				&leaf,
+				layer_depth,
+				tree_depth,
+				&layer_digests,
+				&mut advice,
+			)?;
+			values.extend_from_slice(&leaf);
+		}
+		Ok(values)
+	}
+
+	fn recv_committed_vector(&mut self, commitment: &Self::Commitment) -> Result<Vec<F>, Error> {
+		let len = commitment.leaf_size << commitment.commitment.depth;
+		let mut advice = self.transcript.borrow_mut().decommitment();
+		let data = advice.read_scalar_slice::<F>(len)?;
+		self.scheme.verify_vector(
+			&commitment.commitment.root,
+			&data,
+			commitment.leaf_size,
+			&mut advice,
+		)?;
+		Ok(data)
+	}
+
+	fn sample_bits(&mut self, bits: usize) -> usize {
+		CanSampleBits::sample_bits(self.transcript.borrow_mut(), bits) as usize
+	}
+}
+
+/// Error type for Merkle channel operations.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+	#[error("IP channel error: {0}")]
+	IPChannel(#[from] binius_ip::channel::Error),
+	#[error("Merkle tree error: {0}")]
+	MerkleTree(#[from] crate::merkle_tree::Error),
+	#[error("transcript error: {0}")]
+	Transcript(#[from] binius_transcript::Error),
+}


### PR DESCRIPTION
Introduces the Merkle IP channel abstraction from [BINIUS-215](https://linear.app/jimpo/issue/BINIUS-215/abstract-merkle-ip-channels-over-transcript). This is the first PR of the stack; the follow-up converts FRI and BaseFold to use it.

## Commits

1. **Fix salt index in hiding Merkle opening proofs** — `BinaryMerkleTreeProver::prove_opening` wrote `get_salt(index >> layer_depth)`, i.e. the salt of the wrong leaf whenever `layer_depth > 0`. Invisible in-tree because production trees are non-hiding and the existing hiding tests only exercise `layer_depth = 0`; caught by the new channel round-trip test. Includes a regression test opening hiding commitments against internal layers.
2. **Add the Merkle IP channel traits + transcript-backed impls** — `MerkleIPVerifierChannel<F>: IPVerifierChannel<F>` in `binius_iop::merkle_channel` and `MerkleIPProverChannel<F>: IPProverChannel<F>` (with `P: PackedField<Scalar = F>` on the data-carrying methods) in `binius_iop_prover::merkle_channel`, implemented by `VerifierMerkleTranscriptChannel<T, Challenger_, F, H: HashSuite>` / `ProverMerkleTranscriptChannel<T, Challenger_, F, H>` wrapping a transcript (owned or `&mut`, via `BorrowMut`) together with a `BinaryMerkleTreeScheme<F, H>` / `BinaryMerkleTreeProver<F, H>`. Roots travel as observed messages; openings as unobserved decommitment advice, using the optimal-layer batching FRI uses today. Also adds `MerkleTreeProver::prove_vector`, the prover mirror of `MerkleTreeScheme::verify_vector` (writes the per-leaf salts for hiding trees; today that side is open-coded saltless in the FRI fold prover). Round-trip, hiding, borrowed-transcript, and negative tests included.

## Design decisions beyond the issue sketch

- **`Result`-returning receive methods.** `recv_merkle_commitment`/`recv_openings` return `Result<_, merkle_channel::Error>` rather than bare values, matching `IPVerifierChannel::recv_one` — reads can hit an empty tape and openings can fail verification.
- **`recv_committed_vector` / `send_committed_vector`.** FRI's terminal codeword is sent in full and checked with `MerkleTreeScheme::verify_vector`; that receive is Merkle-bound, so it belongs on the channel. Without it the FRI conversion would still need a raw transcript escape hatch.
- **`sample_bits`.** FRI samples query indices via `CanSampleBits`, which the IP channel traits don't expose. Putting index sampling on the Merkle channel traits lets the query phase go fully behind the abstraction.
- **Prover `send_openings(commitment, data, indices)` re-takes the data.** The commitment handle owns the Merkle tree (`Committed`) but borrows the committed values at open time, so FRI keeps owning its codewords across fold rounds unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)