### PR TITLE
Shrink ShiftedValueIndex from 16 bytes to 8

### DIFF
--- a/crates/core/src/constraint_system/shift.rs
+++ b/crates/core/src/constraint_system/shift.rs
@@ -130,10 +130,11 @@ pub struct ShiftedValueIndex {
 	pub value_index: ValueIndex,
 	/// The flavour of the shift that the value must be shifted by.
 	pub shift_variant: ShiftVariant,
-	/// The number of bits by which the value must be shifted by.
+	/// The number of bits to shift by.
 	///
+	/// Stored as a byte to keep the struct small: constraint systems hold millions of these.
 	/// Must be less than 64.
-	pub amount: usize,
+	pub amount: u8,
 }
 
 impl ShiftedValueIndex {
@@ -156,7 +157,7 @@ impl ShiftedValueIndex {
 		Self {
 			value_index,
 			shift_variant: ShiftVariant::Sll,
-			amount,
+			amount: amount as u8,
 		}
 	}
 
@@ -169,7 +170,7 @@ impl ShiftedValueIndex {
 		Self {
 			value_index,
 			shift_variant: ShiftVariant::Slr,
-			amount,
+			amount: amount as u8,
 		}
 	}
 
@@ -185,7 +186,7 @@ impl ShiftedValueIndex {
 		Self {
 			value_index,
 			shift_variant: ShiftVariant::Sar,
-			amount,
+			amount: amount as u8,
 		}
 	}
 
@@ -200,7 +201,7 @@ impl ShiftedValueIndex {
 		Self {
 			value_index,
 			shift_variant: ShiftVariant::Rotr,
-			amount,
+			amount: amount as u8,
 		}
 	}
 
@@ -216,7 +217,7 @@ impl ShiftedValueIndex {
 		Self {
 			value_index,
 			shift_variant: ShiftVariant::Sll32,
-			amount,
+			amount: amount as u8,
 		}
 	}
 
@@ -232,7 +233,7 @@ impl ShiftedValueIndex {
 		Self {
 			value_index,
 			shift_variant: ShiftVariant::Srl32,
-			amount,
+			amount: amount as u8,
 		}
 	}
 
@@ -249,7 +250,7 @@ impl ShiftedValueIndex {
 		Self {
 			value_index,
 			shift_variant: ShiftVariant::Sra32,
-			amount,
+			amount: amount as u8,
 		}
 	}
 
@@ -266,7 +267,7 @@ impl ShiftedValueIndex {
 		Self {
 			value_index,
 			shift_variant: ShiftVariant::Rotr32,
-			amount,
+			amount: amount as u8,
 		}
 	}
 
@@ -278,7 +279,7 @@ impl ShiftedValueIndex {
 	pub fn eval(&self, witness: &ValueVec) -> Word {
 		// Look up the referenced word, then apply this term's shift.
 		self.shift_variant
-			.apply(witness[self.value_index], self.amount)
+			.apply(witness[self.value_index], self.amount as usize)
 	}
 }
 
@@ -286,7 +287,8 @@ impl SerializeBytes for ShiftedValueIndex {
 	fn serialize(&self, mut write_buf: impl BufMut) -> Result<(), SerializationError> {
 		self.value_index.serialize(&mut write_buf)?;
 		self.shift_variant.serialize(&mut write_buf)?;
-		self.amount.serialize(write_buf)
+		// Keep the wire format a u32 so serialized systems stay byte-compatible.
+		(self.amount as usize).serialize(write_buf)
 	}
 }
 
@@ -299,7 +301,8 @@ impl DeserializeBytes for ShiftedValueIndex {
 		let shift_variant = ShiftVariant::deserialize(&mut read_buf)?;
 		let amount = usize::deserialize(read_buf)?;
 
-		// Validate that amount is within valid range
+		// Validate the range before narrowing to the byte-sized field.
+		// A value below 64 always fits in a u8.
 		if amount >= 64 {
 			return Err(SerializationError::InvalidConstruction {
 				name: "ShiftedValueIndex::amount",
@@ -309,7 +312,7 @@ impl DeserializeBytes for ShiftedValueIndex {
 		Ok(ShiftedValueIndex {
 			value_index,
 			shift_variant,
-			amount,
+			amount: amount as u8,
 		})
 	}
 }
@@ -391,5 +394,13 @@ mod tests {
 			}
 			_ => panic!("Expected InvalidConstruction error"),
 		}
+	}
+
+	#[test]
+	fn shifted_value_index_fits_in_a_word() {
+		// Layout: value_index (u32, 4 bytes) + shift_variant (1 byte) + amount (u8, 1 byte).
+		// Padded to the u32 alignment, that is 8 bytes.
+		// Holding this at one word matters: systems carry millions of these on the prover hot path.
+		assert_eq!(size_of::<ShiftedValueIndex>(), 8);
 	}
 }

--- a/crates/core/src/constraint_system/system.rs
+++ b/crates/core/src/constraint_system/system.rs
@@ -100,7 +100,7 @@ impl ConstraintSystem {
 						constraint_type,
 						constraint_index,
 						operand_name,
-						shift_amount: term.amount,
+						shift_amount: term.amount as usize,
 					});
 				}
 				// Check if the value index is out of bounds.

--- a/crates/m4-prover/src/bitand.rs
+++ b/crates/m4-prover/src/bitand.rs
@@ -233,7 +233,7 @@ impl BatchAndCheckWitness {
 fn eval_operand_words(words: &[Word], operand: &[ShiftedValueIndex]) -> Word {
 	operand.iter().fold(Word::ZERO, |acc, sv| {
 		let word = words[sv.value_index.0 as usize];
-		acc ^ sv.shift_variant.apply(word, sv.amount)
+		acc ^ sv.shift_variant.apply(word, sv.amount as usize)
 	})
 }
 

--- a/crates/verifier/src/protocols/shift/monster.rs
+++ b/crates/verifier/src/protocols/shift/monster.rs
@@ -194,7 +194,7 @@ fn evaluate_matrices<F: BinaryField, E: FieldOps<Scalar = F> + From<F>>(
 						ShiftVariant::Sra32 => 6,
 						ShiftVariant::Rotr32 => 7,
 					};
-					evals[shift_id][*amount] +=
+					evals[shift_id][*amount as usize] +=
 						constraint_eval.clone() * &r_y_tensor[value_index.0 as usize];
 				}
 			}


### PR DESCRIPTION
Halves the size of the value type the prover reads while evaluating operands. Pure in-memory change — the serialized wire format is unchanged, so there is no protocol change and no soundness assumption.

### The problem

A shifted operand term is a value index, a shift variant, and a shift amount:

```
value_index: u32 | shift_variant | amount: usize
```

The amount is always `< 64`, so it needs 6 bits.
But it was stored as a `usize` — 8 bytes — and with alignment padding that made the whole struct **16 bytes**.

Constraint systems hold **millions** of these terms.
The prover walks them on its hot path, evaluating each operand as a XOR of shifted words.
So the struct's size directly sets how much memory that traversal touches and how many terms fit in cache.

### The idea

The amount fits in a byte, so store it in one:

```
before:  value_index: u32 | shift_variant | amount: usize   -> 16 bytes
after:   value_index: u32 | shift_variant | amount: u8       ->  8 bytes
```

A single 8-byte word instead of two.
Half the memory for the same data, and twice as many terms per cache line.

### Keeping the API and the wire format stable

Two things stay exactly as they were, so the change stays contained:

- **Constructors.** `sll`, `srl`, `sar`, `rotr`, and the `*32` variants still take `amount: usize` and still range-check it.
  They narrow to `u8` internally, so **no call site changes**.
- **Wire format.** A `usize` serializes as a `u32` in this repo.
  Serialization still writes the amount as a `u32` and narrows it on read after the range check.
  So serialized systems stay byte-for-byte identical — **no `SERIALIZATION_VERSION` bump, no reference-binary regeneration**.

Field reads that feed a `usize`-typed sink (the shift kernel, the verifier's per-amount table index, the error's reported amount) gain a single `as usize`.

### Scope

- **changed:** `amount` field type in `crates/core/src/constraint_system/shift.rs`; constructors narrow to `u8`; serialize/deserialize keep the `u32` wire encoding
- **cast sites:** one `as usize` each in `system.rs` (error field), `verifier/.../shift/monster.rs` (table index), `m4-prover/src/bitand.rs` (shift kernel)
- **left untouched:** constructor signatures, the serialized format, and every construction call site across `frontend` / `circuits` / `examples`

### Soundness

- No protocol change: the serialized transcript and constraint-system bytes are identical to before.
- No behavior change: the amount range (`< 64`) is unchanged and still enforced on construction and deserialization.
- Purely a storage-width change on an in-memory struct.

### Verification

- `cargo check --workspace --all-targets`, `cargo +nightly fmt --all`, `cargo clippy -p binius-core -p binius-verifier -p binius-m4-prover --all-targets` — clean
- core lib **71 passed** (incl. a new `size_of::<ShiftedValueIndex>() == 8` guard so the win cannot silently regress)
- verifier shift **6**, m4-prover **19**, prover `shift` **8** + `prove_verify` **1** — the full prove/verify pipeline exercises the amount encoding through the shift argument end-to-end
- all serialization round-trip and reference-binary tests pass unchanged, confirming the wire format is stable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
