### PR TITLE
BINIUS-215: convert FRI and BaseFold to the Merkle IP channels

### DIFF
--- a/crates/iop-prover/src/basefold.rs
+++ b/crates/iop-prover/src/basefold.rs
@@ -2,20 +2,11 @@
 // Copyright 2026 The Binius Developers
 
 use binius_field::{BinaryField, PackedField};
-use binius_iop::merkle_tree::MerkleTreeScheme;
 use binius_ip::mlecheck;
 use binius_ip_prover::sumcheck::{common::SumcheckProver, multilinear_eval::MultilinearEvalProver};
 use binius_math::{FieldBuffer, ntt::AdditiveNTT};
-use binius_transcript::{
-	ProverTranscript,
-	fiat_shamir::{CanSample, Challenger},
-};
-use binius_utils::SerializeBytes;
 
-use crate::{
-	fri::{FRIFoldProver, FoldRoundOutput},
-	merkle_tree::MerkleTreeProver,
-};
+use crate::{fri::FRIFoldProver, merkle_channel::MerkleIPProverChannel};
 
 /// Proves a *combined* multilinear evaluation claim `𝛑(eval_point) = eval_claim` by interleaving a
 /// single [`MultilinearEvalProver`] MLE-check with a single combined FRI over the
@@ -40,26 +31,24 @@ use crate::{
 /// * `outer_challenges` - the batching challenges `r'` (`len = log_n_oracles`); combine the `k`
 ///   lifted codewords in the FRI outer (oracle-combine) rounds
 /// * `fri_folder` - the combined FRI fold prover, with `n_rounds == 𝐧 + 1 + log_n_oracles`
-/// * `transcript` - the prover transcript
+/// * `channel` - the Merkle channel carrying all prover interaction: round coefficients,
+///   challenges, commitments, and query openings
 ///
 /// The final FRI value equals the final MLE-check value `𝛑(r)` (see
 /// [`binius_iop::basefold::mlecheck_fri_consistency`]).
-#[allow(clippy::too_many_arguments)]
-pub fn prove_mlecheck_basefold<'a, F, P, NTT, MerkleScheme, MerkleProver, Challenger_>(
+pub fn prove_mlecheck_basefold<F, P, NTT, Channel>(
 	witness: FieldBuffer<P>,
 	eval_point: &[F],
 	eval_claim: F,
 	batch_challenge: Option<F>,
 	outer_challenges: &[F],
-	mut fri_folder: FRIFoldProver<'a, F, P, NTT, MerkleProver>,
-	transcript: &mut ProverTranscript<Challenger_>,
+	mut fri_folder: FRIFoldProver<'_, F, P, NTT, Channel::Commitment>,
+	channel: &mut Channel,
 ) where
 	F: BinaryField,
 	P: PackedField<Scalar = F>,
 	NTT: AdditiveNTT<Field = F> + Sync,
-	MerkleScheme: MerkleTreeScheme<F, Digest: SerializeBytes>,
-	MerkleProver: MerkleTreeProver<F, Scheme = MerkleScheme>,
-	Challenger_: Challenger,
+	Channel: MerkleIPProverChannel<F>,
 {
 	let _scope = tracing::debug_span!("Basefold MLE-check ZK (batched)").entered();
 
@@ -91,25 +80,19 @@ pub fn prove_mlecheck_basefold<'a, F, P, NTT, MerkleScheme, MerkleProver, Challe
 		let round_coeffs = round_coeffs_vec
 			.pop()
 			.expect("MultilinearEvalProver proves exactly one claim");
-		let commitment = fri_folder.execute_fold_round();
 
-		transcript
-			.message()
-			.write_scalar_slice(mlecheck::RoundProof::truncate(round_coeffs).coeffs());
-		if let FoldRoundOutput::Commitment(commitment) = commitment {
-			transcript.message().write(&commitment);
-		}
+		// Send the round coefficients first: on a commitment round, `execute_fold_round` commits
+		// the folded codeword and writes its root, which must land after the coefficients.
+		channel.send_many(mlecheck::RoundProof::truncate(round_coeffs).coeffs());
+		fri_folder.execute_fold_round(channel);
 
-		let challenge = transcript.sample();
+		let challenge = channel.sample();
 		sumcheck.fold(challenge);
 		fri_folder.receive_challenge(challenge);
 	}
 
-	let commitment = fri_folder.execute_fold_round();
-	if let FoldRoundOutput::Commitment(commitment) = commitment {
-		transcript.message().write(&commitment);
-	}
-	fri_folder.finish_proof(transcript);
+	fri_folder.execute_fold_round(channel);
+	fri_folder.finish_proof(channel);
 }
 
 #[cfg(test)]
@@ -117,7 +100,13 @@ mod test {
 	use anyhow::{Result, bail};
 	use binius_field::{BinaryField, PackedBinaryGhash1x128b, PackedExtension, PackedField};
 	use binius_hash::{StdDigest, StdHashSuite};
-	use binius_iop::{basefold as verifier_basefold, channel::OracleSpec};
+	use binius_iop::{
+		basefold as verifier_basefold,
+		channel::OracleSpec,
+		merkle_channel::{MerkleIPVerifierChannel, VerifierMerkleTranscriptChannel},
+	};
+	use binius_ip::channel::IPVerifierChannel;
+	use binius_ip_prover::channel::IPProverChannel;
 	use binius_math::{
 		BinarySubspace, FieldBuffer,
 		inner_product::inner_product_buffers,
@@ -126,16 +115,14 @@ mod test {
 		ntt::{AdditiveNTT, NeighborsLastSingleThread, domain_context::GenericOnTheFly},
 		test_utils::{random_field_buffer, random_scalars},
 	};
-	use binius_transcript::{
-		ProverTranscript,
-		fiat_shamir::{CanSample, HasherChallenger},
-	};
+	use binius_transcript::{ProverTranscript, fiat_shamir::HasherChallenger};
 	use binius_utils::rayon::prelude::*;
 	use rand::{SeedableRng, rngs::StdRng};
 
 	use super::prove_mlecheck_basefold;
 	use crate::{
-		fri::{self, CommitMaskedOutput, FRIFoldProver},
+		fri::{self, FRIFoldProver, MaskedCodeword},
+		merkle_channel::{MerkleIPProverChannel, ProverMerkleTranscriptChannel},
 		merkle_tree::prover::BinaryMerkleTreeProver,
 	};
 
@@ -168,7 +155,7 @@ mod test {
 		let ntt = NeighborsLastSingleThread::new(domain_context);
 
 		// For a single oracle the combined opening params (`optimal_for_batch`) also satisfy
-		// `commit_masked`'s preconditions (`log_batch_size() == 1`, `rs_code().log_dim() ==
+		// `encode_masked`'s preconditions (`log_batch_size() == 1`, `rs_code().log_dim() ==
 		// n_vars`).
 		let (fri_params, _) = binius_iop::fri::FRIParams::optimal_for_batch(
 			ntt.domain_context(),
@@ -178,27 +165,22 @@ mod test {
 			32,
 		);
 
-		// Commit the interleaved (witness ‖ mask), generating the mask internally.
+		// Encode the interleaved (witness ‖ mask), generating the mask internally, and commit the
+		// codeword over the Merkle channel.
 		let mut commit_rng = StdRng::seed_from_u64(7);
-		let CommitMaskedOutput {
-			commitment: codeword_commitment,
-			committed: codeword_committed,
-			codeword,
-			mask,
-		} = fri::commit_masked(
-			&fri_params,
-			0,
-			&ntt,
-			&merkle_prover,
-			witness.to_ref(),
-			&mut commit_rng,
-		);
+		let MaskedCodeword { codeword, mask } =
+			fri::encode_masked(&fri_params, 0, &ntt, witness.to_ref(), &mut commit_rng);
 
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
-		prover_transcript.message().write(&codeword_commitment);
+		let mut prover_channel =
+			ProverMerkleTranscriptChannel::<_, StdChallenger, _, StdHashSuite>::with_merkle_prover(
+				&mut prover_transcript,
+				merkle_prover,
+			);
+		let codeword_commitment = prover_channel.send_merkle_commitment(codeword.to_ref(), 2);
 
 		// Sample the masking challenge γ and form π' = (1-γ)·witness + γ·mask.
-		let batch_challenge: F = prover_transcript.sample();
+		let batch_challenge: F = IPProverChannel::sample(&mut prover_channel);
 		let mut witness_prime = witness.clone();
 		let gamma_broadcast = P::broadcast(batch_challenge);
 		(witness_prime.as_mut(), mask.as_ref())
@@ -213,12 +195,8 @@ mod test {
 			eval_claim += F::ONE;
 		}
 
-		let fri_folder = FRIFoldProver::new_batch(
-			&fri_params,
-			&ntt,
-			&merkle_prover,
-			vec![(codeword, &codeword_committed)],
-		);
+		let fri_folder =
+			FRIFoldProver::new_batch(&fri_params, &ntt, vec![(codeword, codeword_commitment)]);
 		prove_mlecheck_basefold(
 			witness_prime,
 			&evaluation_point,
@@ -226,12 +204,19 @@ mod test {
 			Some(batch_challenge),
 			&[],
 			fri_folder,
-			&mut prover_transcript,
+			&mut prover_channel,
 		);
+		drop(prover_channel);
 
 		let mut verifier_transcript = prover_transcript.into_verifier();
-		let retrieved_commitment = verifier_transcript.message().read()?;
-		let batch_challenge_v: F = verifier_transcript.sample();
+		let mut verifier_channel =
+			VerifierMerkleTranscriptChannel::<_, StdChallenger, _, StdHashSuite>::new(
+				&mut verifier_transcript,
+			);
+		// The committed codeword has one interleaved (π ‖ ω) coset of 2 scalars per leaf.
+		let retrieved_commitment =
+			verifier_channel.recv_merkle_commitment(2, n_vars + LOG_INV_RATE)?;
+		let batch_challenge_v: F = IPVerifierChannel::sample(&mut verifier_channel);
 
 		let verifier_basefold::ReducedOutput {
 			final_fri_value,
@@ -239,13 +224,12 @@ mod test {
 			..
 		} = verifier_basefold::verify_mlecheck_basefold(
 			&fri_params,
-			merkle_prover.scheme(),
 			&[retrieved_commitment],
 			eval_claim,
 			&evaluation_point,
 			Some(batch_challenge_v),
 			&[],
-			&mut verifier_transcript,
+			&mut verifier_channel,
 		)?;
 
 		if !verifier_basefold::mlecheck_fri_consistency(final_fri_value, final_sumcheck_value) {

--- a/crates/iop-prover/src/basefold_channel.rs
+++ b/crates/iop-prover/src/basefold_channel.rs
@@ -7,10 +7,8 @@
 //! mask generated internally; non-ZK oracles are committed without a mask. All committed oracles
 //! are opened with a single combined FRI.
 
-use std::iter;
-
 use binius_field::{BinaryField, PackedField};
-use binius_iop::{channel::OracleSpec, fri::FRIParams, merkle_tree::MerkleTreeScheme};
+use binius_iop::{channel::OracleSpec, fri::FRIParams};
 use binius_ip_prover::{
 	channel::IPProverChannel,
 	sumcheck::{self, PaddedSumcheckDecorator, bivariate_product::BivariateProductSumcheckProver},
@@ -22,20 +20,15 @@ use binius_math::{
 	multilinear::eq::{eq_ind_partial_eval_scalars, eq_ind_zero},
 	ntt::AdditiveNTT,
 };
-use binius_transcript::{
-	ProverTranscript,
-	fiat_shamir::{CanSample, Challenger},
-};
-use binius_utils::{SerializeBytes, checked_arithmetics::log2_ceil_usize, rayon::prelude::*};
+use binius_utils::{checked_arithmetics::log2_ceil_usize, rayon::prelude::*};
 use itertools::izip;
 use rand::{Rng, SeedableRng, rngs::StdRng};
 
 use crate::{
 	basefold::prove_mlecheck_basefold,
-	basefold_compiler::BaseFoldProverCompiler,
 	channel::IOPProverChannel,
-	fri::{self, CommitMaskedOutput, CommitOutput, FRIFoldProver},
-	merkle_tree::MerkleTreeProver,
+	fri::{self, FRIFoldProver, MaskedCodeword},
+	merkle_channel::MerkleIPProverChannel,
 };
 
 /// Oracle handle returned by [`BaseFoldProverChannel::send_oracle`].
@@ -45,14 +38,14 @@ pub struct BaseFoldOracle {
 }
 
 /// Committed oracle data stored internally.
-struct CommittedOracleData<P: PackedField, Committed> {
-	/// The mask buffer generated during [`fri::commit_masked`] for a ZK oracle, held by the
+struct CommittedOracleData<P: PackedField, C> {
+	/// The mask buffer generated during [`fri::encode_masked`] for a ZK oracle, held by the
 	/// channel because it is the only party that knows it. `None` for a non-ZK (unmasked) oracle.
 	mask: Option<FieldBuffer<P>>,
 	/// RS-encoded codeword.
 	codeword: FieldBuffer<P>,
-	/// Merkle commitment data for query proofs.
-	committed: Committed,
+	/// The Merkle commitment handle for query proofs, owning the committed tree.
+	commitment: C,
 }
 
 /// A prover channel that uses ZK BaseFold for all oracle commitments and openings.
@@ -69,23 +62,22 @@ struct CommittedOracleData<P: PackedField, Committed> {
 /// - `F`: The binary field type
 /// - `P`: The packed field type with `Scalar = F`
 /// - `NTT`: The additive NTT for Reed-Solomon encoding
-/// - `MerkleProver_`: The Merkle tree prover for commitments
-/// - `Challenger_`: The Fiat-Shamir challenger
-pub struct BaseFoldProverChannel<'a, F, P, NTT, MerkleProver_, Challenger_>
+/// - `Channel`: The Merkle channel carrying all prover interaction
+pub struct BaseFoldProverChannel<'a, F, P, NTT, Channel>
 where
 	F: BinaryField,
 	P: PackedField<Scalar = F>,
 	NTT: AdditiveNTT<Field = F> + Sync,
-	MerkleProver_: MerkleTreeProver<F>,
-	Challenger_: Challenger,
+	Channel: MerkleIPProverChannel<F>,
 {
-	transcript: &'a mut ProverTranscript<Challenger_>,
+	/// The Merkle channel carrying all prover interaction: field elements, challenges,
+	/// commitments, and openings.
+	channel: Channel,
 	ntt: &'a NTT,
-	merkle_prover: &'a MerkleProver_,
 	oracle_specs: Vec<OracleSpec>,
 	/// The combined FRI parameters over all committed oracles.
 	fri_params: FRIParams<F>,
-	committed_oracles: Vec<CommittedOracleData<P, MerkleProver_::Committed>>,
+	committed_oracles: Vec<CommittedOracleData<P, Channel::Commitment>>,
 	/// Oracle relations queued by [`Self::prove_oracle_relations`], opened together in
 	/// [`Self::finish`]. Each entry is `(oracle_index, message π_i, transparent t_i, claim s_i)`.
 	queue: Vec<(usize, FieldBuffer<P>, FieldBuffer<P>, F)>,
@@ -93,40 +85,35 @@ where
 	rng: StdRng,
 }
 
-impl<'a, F, P, NTT, MerkleScheme, MerkleProver_, Challenger_>
-	BaseFoldProverChannel<'a, F, P, NTT, MerkleProver_, Challenger_>
+impl<'a, F, P, NTT, Channel> BaseFoldProverChannel<'a, F, P, NTT, Channel>
 where
 	F: BinaryField,
 	P: PackedField<Scalar = F>,
 	NTT: AdditiveNTT<Field = F> + Sync,
-	MerkleScheme: MerkleTreeScheme<F, Digest: SerializeBytes>,
-	MerkleProver_: MerkleTreeProver<F, Scheme = MerkleScheme>,
-	Challenger_: Challenger,
+	Channel: MerkleIPProverChannel<F>,
 {
-	/// Creates a new BaseFold ZK prover channel from a compiler with precomputed FRI parameters.
+	/// Creates a new BaseFold ZK prover channel over a Merkle channel from precomputed FRI
+	/// parameters.
 	///
-	/// The `rng` is used to seed an internal `StdRng` for mask generation.
-	pub fn from_compiler(
-		compiler: &'a BaseFoldProverCompiler<P, NTT, MerkleProver_>,
-		transcript: &'a mut ProverTranscript<Challenger_>,
+	/// The FRI parameters should already account for ZK (log_batch_size = 1, doubled message
+	/// length). The `rng` is used to seed an internal `StdRng` for mask generation.
+	pub fn new(
+		channel: Channel,
+		ntt: &'a NTT,
+		oracle_specs: Vec<OracleSpec>,
+		fri_params: FRIParams<F>,
 		mut rng: impl Rng,
 	) -> Self {
 		Self {
-			transcript,
-			ntt: compiler.ntt(),
-			merkle_prover: compiler.merkle_prover(),
-			oracle_specs: compiler.oracle_specs().to_vec(),
-			fri_params: compiler.fri_params().clone(),
+			channel,
+			ntt,
+			oracle_specs,
+			fri_params,
 			committed_oracles: Vec::new(),
 			queue: Vec::new(),
 			next_oracle_index: 0,
 			rng: StdRng::from_rng(&mut rng),
 		}
-	}
-
-	/// Returns a reference to the underlying transcript.
-	pub const fn transcript(&self) -> &ProverTranscript<Challenger_> {
-		self.transcript
 	}
 
 	/// Consumes the channel and proves the single combined opening over **all** committed oracles.
@@ -140,9 +127,8 @@ where
 	/// [`BaseFoldVerifierChannel::finish`]: binius_iop::basefold_channel::BaseFoldVerifierChannel::finish
 	pub fn finish(self) {
 		let Self {
-			transcript,
+			mut channel,
 			ntt,
-			merkle_prover,
 			oracle_specs,
 			fri_params,
 			committed_oracles,
@@ -159,9 +145,8 @@ where
 		}
 
 		prove_batch_zk_basefold(
-			transcript,
+			&mut channel,
 			ntt,
-			merkle_prover,
 			&oracle_specs,
 			&fri_params,
 			committed_oracles,
@@ -172,10 +157,10 @@ where
 
 /// Proves the combined ZK BaseFold opening over all committed oracles.
 ///
-/// This drives `channel` — the [`ProverTranscript`] taken from the destructured
-/// [`BaseFoldProverChannel`] — through its [`IPProverChannel`] interface: it sends the masked
-/// inner products σ_i, runs one batched sumcheck reducing the masked claims to a shared point `r`,
-/// then opens each committed oracle with its own FRI parameters. Mirrors
+/// This drives `channel` — the Merkle channel taken from the destructured
+/// [`BaseFoldProverChannel`] — through its [`MerkleIPProverChannel`] interface: it sends the
+/// masked inner products σ_i, runs one batched sumcheck reducing the masked claims to a shared
+/// point `r`, then opens all committed oracles together with a single combined FRI. Mirrors
 /// [`binius_iop::basefold_channel::BaseFoldVerifierChannel::finish`].
 ///
 /// The masking inner products and the batched sumcheck process the `relations` in arrival order (so
@@ -184,25 +169,18 @@ where
 /// index, so the two orders are reconciled by indexing rather than by sorting the relations; the
 /// per-oracle data (`oracle_specs`, `fri_params`, `committed_oracles`) is all indexed by oracle
 /// index.
-///
-/// `channel` is the concrete [`ProverTranscript`] rather than an arbitrary [`IPProverChannel`]
-/// because the Phase-B FRI openings write Merkle query proofs, which fall outside that interface.
-#[allow(clippy::too_many_arguments)]
-fn prove_batch_zk_basefold<F, P, NTT, MerkleScheme, MerkleProver_, Challenger_>(
-	channel: &mut ProverTranscript<Challenger_>,
+fn prove_batch_zk_basefold<F, P, NTT, Channel>(
+	channel: &mut Channel,
 	ntt: &NTT,
-	merkle_prover: &MerkleProver_,
 	oracle_specs: &[OracleSpec],
 	fri_params: &FRIParams<F>,
-	committed_oracles: Vec<CommittedOracleData<P, MerkleProver_::Committed>>,
+	committed_oracles: Vec<CommittedOracleData<P, Channel::Commitment>>,
 	relations: Vec<(usize, FieldBuffer<P>, FieldBuffer<P>, F)>,
 ) where
 	F: BinaryField,
 	P: PackedField<Scalar = F>,
 	NTT: AdditiveNTT<Field = F> + Sync,
-	MerkleScheme: MerkleTreeScheme<F, Digest: SerializeBytes>,
-	MerkleProver_: MerkleTreeProver<F, Scheme = MerkleScheme>,
-	Challenger_: Challenger,
+	Channel: MerkleIPProverChannel<F>,
 {
 	let n_committed = committed_oracles.len();
 	assert_eq!(oracle_specs.len(), n_committed);
@@ -235,7 +213,7 @@ fn prove_batch_zk_basefold<F, P, NTT, MerkleScheme, MerkleProver_, Challenger_>(
 		.collect::<Vec<_>>();
 	channel.send_many(&sigmas);
 
-	let gamma = (!sigmas.is_empty()).then(|| IPProverChannel::<F>::sample(channel));
+	let gamma = (!sigmas.is_empty()).then(|| channel.sample());
 
 	// === Phase A: batched sumcheck on the masked claims ⟨π_i', t_i⟩ = s_i' ===
 	// Register provers in arrival order; form π_i' = (1-γ)π_i + γω_i, storing each clone for Phase
@@ -338,15 +316,12 @@ fn prove_batch_zk_basefold<F, P, NTT, MerkleScheme, MerkleProver_, Challenger_>(
 	}
 
 	// Codeword commitments in oracle-index order, matching `open_fri_params.input_oracles()`.
-	let (committed_codewords, committeds) = committed_oracles
+	let committed_codewords = committed_oracles
 		.into_iter()
-		.map(|committed| (committed.codeword, committed.committed))
-		.unzip::<_, _, Vec<_>, Vec<_>>();
-	// TODO: Annoying that we need to pass references for committeds. Maybe we can change the
-	// FRIFoldProver constructor.
-	let committed_codewords = iter::zip(committed_codewords, &committeds).collect();
+		.map(|committed| (committed.codeword, committed.commitment))
+		.collect();
 
-	let fri_folder = FRIFoldProver::new_batch(fri_params, ntt, merkle_prover, committed_codewords);
+	let fri_folder = FRIFoldProver::new_batch(fri_params, ntt, committed_codewords);
 	prove_mlecheck_basefold(
 		combined,
 		point,
@@ -377,46 +352,40 @@ fn accumulate_scaled_buffer<P: PackedField>(
 	}
 }
 
-impl<'a, F, P, NTT, MerkleScheme, MerkleProver_, Challenger_> IPProverChannel<F>
-	for BaseFoldProverChannel<'a, F, P, NTT, MerkleProver_, Challenger_>
+impl<'a, F, P, NTT, Channel> IPProverChannel<F> for BaseFoldProverChannel<'a, F, P, NTT, Channel>
 where
 	F: BinaryField,
 	P: PackedField<Scalar = F>,
 	NTT: AdditiveNTT<Field = F> + Sync,
-	MerkleScheme: MerkleTreeScheme<F, Digest: SerializeBytes>,
-	MerkleProver_: MerkleTreeProver<F, Scheme = MerkleScheme>,
-	Challenger_: Challenger,
+	Channel: MerkleIPProverChannel<F>,
 {
 	fn send_one(&mut self, elem: F) {
-		self.transcript.message().write_scalar(elem);
+		self.channel.send_one(elem);
 	}
 
 	fn send_many(&mut self, elems: &[F]) {
-		self.transcript.message().write_scalar_slice(elems);
+		self.channel.send_many(elems);
 	}
 
 	fn observe_one(&mut self, val: F) {
-		self.transcript.observe().write_scalar(val);
+		self.channel.observe_one(val);
 	}
 
 	fn observe_many(&mut self, vals: &[F]) {
-		self.transcript.observe().write_scalar_slice(vals);
+		self.channel.observe_many(vals);
 	}
 
 	fn sample(&mut self) -> F {
-		CanSample::sample(&mut self.transcript)
+		self.channel.sample()
 	}
 }
 
-impl<'a, F, P, NTT, MerkleScheme, MerkleProver_, Challenger_> IOPProverChannel<P>
-	for BaseFoldProverChannel<'a, F, P, NTT, MerkleProver_, Challenger_>
+impl<'a, F, P, NTT, Channel> IOPProverChannel<P> for BaseFoldProverChannel<'a, F, P, NTT, Channel>
 where
 	F: BinaryField,
 	P: PackedField<Scalar = F>,
 	NTT: AdditiveNTT<Field = F> + Sync,
-	MerkleScheme: MerkleTreeScheme<F, Digest: SerializeBytes>,
-	MerkleProver_: MerkleTreeProver<F, Scheme = MerkleScheme>,
-	Challenger_: Challenger,
+	Channel: MerkleIPProverChannel<F>,
 {
 	type Oracle = BaseFoldOracle;
 
@@ -440,45 +409,31 @@ where
 			buffer.log_len()
 		);
 
-		// Commit oracle `index` of the combined FRI parameters. ZK oracles interleave a fresh mask
-		// (`commit_masked`); non-ZK oracles commit the message alone (`commit_interleaved`).
-		let (commitment, committed, codeword, mask) = if spec.is_zk {
-			let CommitMaskedOutput {
-				commitment,
-				committed,
-				codeword,
-				mask,
-			} = fri::commit_masked(
+		// Encode oracle `index` of the combined FRI parameters. ZK oracles interleave a fresh mask
+		// (`encode_masked`); non-ZK oracles encode the message alone (`encode_interleaved`).
+		let (codeword, mask) = if spec.is_zk {
+			let MaskedCodeword { codeword, mask } = fri::encode_masked(
 				&self.fri_params,
 				index,
 				self.ntt,
-				self.merkle_prover,
 				buffer.to_ref(),
 				&mut self.rng,
 			);
-			(commitment, committed, codeword, Some(mask))
+			(codeword, Some(mask))
 		} else {
-			let CommitOutput {
-				commitment,
-				committed,
-				codeword,
-			} = fri::commit_interleaved(
-				&self.fri_params,
-				index,
-				self.ntt,
-				self.merkle_prover,
-				buffer.to_ref(),
-			);
-			(commitment, committed, codeword, None)
+			(fri::encode_interleaved(&self.fri_params, index, self.ntt, buffer.to_ref()), None)
 		};
 
-		// Send commitment via transcript.
-		self.transcript.message().write(&commitment);
+		// Commit the codeword over the Merkle channel, with one interleaved coset per leaf.
+		let leaf_size = 1 << self.fri_params.input_oracles()[index].log_batch_size();
+		let commitment = self
+			.channel
+			.send_merkle_commitment(codeword.to_ref(), leaf_size);
 
 		self.committed_oracles.push(CommittedOracleData {
 			mask,
 			codeword,
-			committed,
+			commitment,
 		});
 
 		self.next_oracle_index += 1;
@@ -516,6 +471,7 @@ mod tests {
 		basefold_compiler::BaseFoldVerifierCompiler,
 		channel::{IOPVerifierChannel, OracleLinearRelation, OracleSpec},
 		fri::MinProofSizeStrategy,
+		merkle_tree::BinaryMerkleTreeScheme,
 	};
 	use binius_math::{
 		BinarySubspace, FieldBuffer,
@@ -528,9 +484,7 @@ mod tests {
 	use rand::{Rng, SeedableRng, rngs::StdRng};
 
 	use super::IOPProverChannel;
-	use crate::{
-		basefold_compiler::BaseFoldProverCompiler, merkle_tree::prover::BinaryMerkleTreeProver,
-	};
+	use crate::basefold_compiler::BaseFoldProverCompiler;
 
 	type StdChallenger = HasherChallenger<StdDigest>;
 
@@ -548,8 +502,8 @@ mod tests {
 		NeighborsLastSingleThread::new(domain_context)
 	}
 
-	fn make_merkle_prover() -> BinaryMerkleTreeProver<BinaryField128bGhash, StdHashSuite> {
-		BinaryMerkleTreeProver::new()
+	fn make_merkle_scheme() -> BinaryMerkleTreeScheme<BinaryField128bGhash, StdHashSuite> {
+		BinaryMerkleTreeScheme::new()
 	}
 
 	fn generate_zk_oracle_data<F, P, R: Rng>(
@@ -582,9 +536,8 @@ mod tests {
 
 		let oracle_specs = vec![OracleSpec::new_zk(n_vars)];
 
-		let merkle_prover = make_merkle_prover();
 		let verifier_compiler = BaseFoldVerifierCompiler::new(
-			merkle_prover.scheme().clone(),
+			make_merkle_scheme(),
 			oracle_specs,
 			LOG_INV_RATE,
 			n_test_queries,
@@ -593,11 +546,8 @@ mod tests {
 
 		// === PROVER SIDE ===
 		let ntt = make_ntt(verifier_compiler.max_subspace());
-		let prover_compiler = BaseFoldProverCompiler::<P, _, _>::from_verifier_compiler(
-			&verifier_compiler,
-			ntt,
-			merkle_prover,
-		);
+		let prover_compiler =
+			BaseFoldProverCompiler::<P, _, _>::from_verifier_compiler(&verifier_compiler, ntt);
 
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 		let prover_rng = StdRng::seed_from_u64(1);
@@ -651,9 +601,8 @@ mod tests {
 
 		let oracle_specs = vec![OracleSpec::new_zk(n_vars_1), OracleSpec::new_zk(n_vars_2)];
 
-		let merkle_prover = make_merkle_prover();
 		let verifier_compiler = BaseFoldVerifierCompiler::new(
-			merkle_prover.scheme().clone(),
+			make_merkle_scheme(),
 			oracle_specs,
 			LOG_INV_RATE,
 			n_test_queries,
@@ -662,11 +611,8 @@ mod tests {
 
 		// === PROVER SIDE ===
 		let ntt = make_ntt(verifier_compiler.max_subspace());
-		let prover_compiler = BaseFoldProverCompiler::<P, _, _>::from_verifier_compiler(
-			&verifier_compiler,
-			ntt,
-			merkle_prover,
-		);
+		let prover_compiler =
+			BaseFoldProverCompiler::<P, _, _>::from_verifier_compiler(&verifier_compiler, ntt);
 
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 		let prover_rng = StdRng::seed_from_u64(1);
@@ -731,9 +677,8 @@ mod tests {
 		let oracle_specs: Vec<OracleSpec> =
 			n_vars_list.iter().map(|&n| OracleSpec::new_zk(n)).collect();
 
-		let merkle_prover = make_merkle_prover();
 		let verifier_compiler = BaseFoldVerifierCompiler::new(
-			merkle_prover.scheme().clone(),
+			make_merkle_scheme(),
 			oracle_specs,
 			LOG_INV_RATE,
 			n_test_queries,
@@ -742,11 +687,8 @@ mod tests {
 
 		// === PROVER SIDE ===
 		let ntt = make_ntt(verifier_compiler.max_subspace());
-		let prover_compiler = BaseFoldProverCompiler::<P, _, _>::from_verifier_compiler(
-			&verifier_compiler,
-			ntt,
-			merkle_prover,
-		);
+		let prover_compiler =
+			BaseFoldProverCompiler::<P, _, _>::from_verifier_compiler(&verifier_compiler, ntt);
 
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 		let prover_rng = StdRng::seed_from_u64(1);
@@ -825,9 +767,8 @@ mod tests {
 			})
 			.collect();
 
-		let merkle_prover = make_merkle_prover();
 		let verifier_compiler = BaseFoldVerifierCompiler::new(
-			merkle_prover.scheme().clone(),
+			make_merkle_scheme(),
 			oracle_specs,
 			LOG_INV_RATE,
 			n_test_queries,
@@ -835,11 +776,8 @@ mod tests {
 		);
 
 		let ntt = make_ntt(verifier_compiler.max_subspace());
-		let prover_compiler = BaseFoldProverCompiler::<P, _, _>::from_verifier_compiler(
-			&verifier_compiler,
-			ntt,
-			merkle_prover,
-		);
+		let prover_compiler =
+			BaseFoldProverCompiler::<P, _, _>::from_verifier_compiler(&verifier_compiler, ntt);
 
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 		let prover_rng = StdRng::seed_from_u64(1);

--- a/crates/iop-prover/src/basefold_compiler.rs
+++ b/crates/iop-prover/src/basefold_compiler.rs
@@ -8,43 +8,46 @@
 use std::marker::PhantomData;
 
 use binius_field::{BinaryField, PackedField};
+use binius_hash::binary_merkle_tree::HashSuite;
 use binius_iop::{
 	basefold_compiler::BaseFoldVerifierCompiler, channel::OracleSpec, fri::FRIParams,
-	merkle_tree::MerkleTreeScheme,
+	merkle_tree::BinaryMerkleTreeScheme,
 };
 use binius_math::ntt::AdditiveNTT;
 use binius_transcript::{ProverTranscript, fiat_shamir::Challenger};
 use binius_utils::SerializeBytes;
+use digest::Output;
 use rand::{Rng, SeedableRng, rngs::StdRng};
 
-use crate::{basefold_channel::BaseFoldProverChannel, merkle_tree::MerkleTreeProver};
+use crate::{
+	basefold_channel::BaseFoldProverChannel, merkle_channel::ProverMerkleTranscriptChannel,
+};
 
 /// A compiler that creates BaseFold ZK prover channels with precomputed parameters.
 ///
 /// This compiler builds a single combined FRI over all oracles, with ZK oracles configured for
 /// zero-knowledge mode.
 #[derive(Debug)]
-pub struct BaseFoldProverCompiler<P, NTT, MerkleProver_>
+pub struct BaseFoldProverCompiler<P, NTT, H>
 where
 	P: PackedField<Scalar: BinaryField>,
 	NTT: AdditiveNTT<Field = P::Scalar> + Sync,
-	MerkleProver_: MerkleTreeProver<P::Scalar>,
+	H: HashSuite,
 {
 	ntt: NTT,
-	merkle_prover: MerkleProver_,
 	oracle_specs: Vec<OracleSpec>,
 	/// The combined FRI parameters over **all** oracles.
 	fri_params: FRIParams<P::Scalar>,
-	_p_marker: PhantomData<P>,
+	_marker: PhantomData<(P, H)>,
 }
 
-impl<F, P, NTT, MerkleScheme, MerkleProver_> BaseFoldProverCompiler<P, NTT, MerkleProver_>
+impl<F, P, NTT, H> BaseFoldProverCompiler<P, NTT, H>
 where
 	F: BinaryField,
 	P: PackedField<Scalar = F>,
 	NTT: AdditiveNTT<Field = F> + Sync,
-	MerkleScheme: MerkleTreeScheme<F, Digest: SerializeBytes>,
-	MerkleProver_: MerkleTreeProver<F, Scheme = MerkleScheme>,
+	H: HashSuite,
+	Output<H::LeafHash>: SerializeBytes,
 {
 	/// Creates a new compiler with precomputed combined FRI parameters.
 	///
@@ -52,7 +55,6 @@ where
 	/// (message ‖ equal-length mask), a non-ZK oracle takes a flexible batch size.
 	pub fn new(
 		ntt: NTT,
-		merkle_prover: MerkleProver_,
 		oracle_specs: Vec<OracleSpec>,
 		log_inv_rate: usize,
 		n_test_queries: usize,
@@ -67,7 +69,7 @@ where
 		// equal-length mask); non-ZK oracles take a flexible batch size.
 		let (fri_params, _) = FRIParams::optimal_for_batch(
 			ntt.domain_context(),
-			merkle_prover.scheme(),
+			&BinaryMerkleTreeScheme::<F, H>::new(),
 			&oracle_specs,
 			log_inv_rate,
 			n_test_queries,
@@ -75,10 +77,9 @@ where
 
 		Self {
 			ntt,
-			merkle_prover,
 			oracle_specs,
 			fri_params,
-			_p_marker: PhantomData,
+			_marker: PhantomData,
 		}
 	}
 
@@ -86,27 +87,20 @@ where
 	///
 	/// This reuses the precomputed FRI parameters and oracle specifications.
 	pub fn from_verifier_compiler(
-		verifier_compiler: &BaseFoldVerifierCompiler<F, MerkleScheme>,
+		verifier_compiler: &BaseFoldVerifierCompiler<F, H>,
 		ntt: NTT,
-		merkle_prover: MerkleProver_,
 	) -> Self {
 		Self {
 			ntt,
-			merkle_prover,
 			oracle_specs: verifier_compiler.oracle_specs().to_vec(),
 			fri_params: verifier_compiler.fri_params().clone(),
-			_p_marker: PhantomData,
+			_marker: PhantomData,
 		}
 	}
 
 	/// Returns a reference to the NTT.
 	pub const fn ntt(&self) -> &NTT {
 		&self.ntt
-	}
-
-	/// Returns a reference to the Merkle prover.
-	pub const fn merkle_prover(&self) -> &MerkleProver_ {
-		&self.merkle_prover
 	}
 
 	/// Returns a reference to the oracle specifications.
@@ -121,13 +115,22 @@ where
 
 	/// Creates a ZK prover channel from this compiler, a transcript, and an RNG.
 	///
-	/// The `rng` is used to seed an internal `StdRng` for mask generation.
+	/// The returned channel drives all prover interaction through a
+	/// [`ProverMerkleTranscriptChannel`] over the transcript, constructed here with a non-hiding
+	/// Merkle tree prover. The `rng` is used to seed an internal `StdRng` for mask generation.
 	pub fn create_channel<'a, Challenger_: Challenger>(
 		&'a self,
 		transcript: &'a mut ProverTranscript<Challenger_>,
 		rng: impl Rng,
-	) -> BaseFoldProverChannel<'a, F, P, NTT, MerkleProver_, Challenger_> {
-		BaseFoldProverChannel::from_compiler(self, transcript, rng)
+	) -> BaseFoldTranscriptProverChannel<'a, F, P, NTT, H, Challenger_> {
+		let channel = ProverMerkleTranscriptChannel::new(transcript);
+		BaseFoldProverChannel::new(
+			channel,
+			&self.ntt,
+			self.oracle_specs.clone(),
+			self.fri_params.clone(),
+			rng,
+		)
 	}
 
 	/// Creates a prover channel for a compiler whose oracles are all non-ZK.
@@ -144,7 +147,7 @@ where
 	pub fn create_channel_without_zk<'a, Challenger_: Challenger>(
 		&'a self,
 		transcript: &'a mut ProverTranscript<Challenger_>,
-	) -> BaseFoldProverChannel<'a, F, P, NTT, MerkleProver_, Challenger_> {
+	) -> BaseFoldTranscriptProverChannel<'a, F, P, NTT, H, Challenger_> {
 		// A ZK oracle masks with the RNG, so a fixed seed here would silently break hiding.
 		assert!(
 			self.oracle_specs().iter().all(|spec| !spec.is_zk),
@@ -155,3 +158,13 @@ where
 		self.create_channel(transcript, StdRng::seed_from_u64(0))
 	}
 }
+
+/// The [`BaseFoldProverChannel`] type produced by [`BaseFoldProverCompiler::create_channel`]: a
+/// BaseFold channel over a [`ProverMerkleTranscriptChannel`] borrowing the transcript.
+pub type BaseFoldTranscriptProverChannel<'a, F, P, NTT, H, Challenger_> = BaseFoldProverChannel<
+	'a,
+	F,
+	P,
+	NTT,
+	ProverMerkleTranscriptChannel<&'a mut ProverTranscript<Challenger_>, Challenger_, F, H>,
+>;

--- a/crates/iop-prover/src/fri/encode.rs
+++ b/crates/iop-prover/src/fri/encode.rs
@@ -4,52 +4,43 @@
 use std::iter;
 
 use binius_field::{BinaryField, PackedField};
-use binius_iop::{fri::FRIParams, merkle_tree::MerkleTreeScheme};
+use binius_iop::fri::FRIParams;
 use binius_math::{FieldBuffer, FieldSlice, ntt::AdditiveNTT, reed_solomon::ReedSolomonCode};
 use binius_utils::{rand::par_rand, rayon::prelude::*};
 use rand::{CryptoRng, rngs::StdRng};
 
-use crate::merkle_tree::{self, MerkleTreeProver};
-
-#[derive(Debug)]
-pub struct CommitOutput<P: PackedField, VCSCommitment, VCSCommitted> {
-	pub commitment: VCSCommitment,
-	pub committed: VCSCommitted,
-	pub codeword: FieldBuffer<P>,
-}
-
-/// Encodes and commits one input oracle's interleaved message.
+/// Reed-Solomon encodes one input oracle's interleaved message.
 ///
 /// `params` are the (possibly batched) FRI parameters and `oracle_index` selects which oracle of
-/// [`FRIParams::input_oracles`] is committed. The oracle is Reed–Solomon encoded at its own
+/// [`FRIParams::input_oracles`] is encoded. The oracle is Reed–Solomon encoded at its own
 /// dimension — which may be smaller than the batched code's reduced dimension — over the same
 /// subspace and rate; the lift to the reduced dimension is applied later during the combined fold.
+///
+/// The returned codeword is committed by sending it over a Merkle channel (via
+/// `MerkleIPProverChannel::send_merkle_commitment`) with one interleaved coset of
+/// `2^log_batch_size` scalars per leaf.
 ///
 /// ## Arguments
 ///
 /// * `params` - the (possibly batched) FRI protocol parameters.
-/// * `oracle_index` - the index into [`FRIParams::input_oracles`] of the oracle being committed.
+/// * `oracle_index` - the index into [`FRIParams::input_oracles`] of the oracle being encoded.
 /// * `ntt` - the additive NTT for Reed-Solomon encoding.
-/// * `merkle_prover` - the merkle tree prover to use for committing.
-/// * `message` - the interleaved message to encode and commit.
+/// * `message` - the interleaved message to encode.
 ///
 /// ## Preconditions
 ///
 /// * `message.log_len()` must equal the oracle's committed message length,
 ///   `params.rs_code().log_dim() - log_lift + log_batch_size`.
-pub fn commit_interleaved<F, P, NTT, MerkleProver, VCS>(
+pub fn encode_interleaved<F, P, NTT>(
 	params: &FRIParams<F>,
 	oracle_index: usize,
 	ntt: &NTT,
-	merkle_prover: &MerkleProver,
 	message: FieldSlice<P>,
-) -> CommitOutput<P, VCS::Digest, MerkleProver::Committed>
+) -> FieldBuffer<P>
 where
 	F: BinaryField,
 	P: PackedField<Scalar = F>,
 	NTT: AdditiveNTT<Field = F> + Sync,
-	MerkleProver: MerkleTreeProver<F, Scheme = VCS>,
-	VCS: MerkleTreeScheme<F>,
 {
 	let oracle_spec = &params.input_oracles()[oracle_index];
 	let log_batch_size = oracle_spec.log_batch_size();
@@ -70,7 +61,7 @@ where
 		ReedSolomonCode::with_ntt_subspace(ntt, oracle_log_dim, params.rs_code().log_inv_rate());
 
 	let _scope = tracing::debug_span!(
-		"FRI Commit",
+		"FRI Encode",
 		log_batch_size,
 		log_dim = rs_code.log_dim(),
 		log_inv_rate = rs_code.log_inv_rate(),
@@ -78,73 +69,55 @@ where
 	)
 	.entered();
 
-	let encoded = tracing::debug_span!("Reed-Solomon Encode")
-		.in_scope(|| rs_code.encode_batch(ntt, message.to_ref(), log_batch_size));
-
-	let merkle_tree_span = tracing::debug_span!("Merkle Tree").entered();
-	let (commitment, vcs_committed) =
-		merkle_tree::commit_field_buffer(merkle_prover, encoded.to_ref(), log_batch_size);
-	drop(merkle_tree_span);
-
-	CommitOutput {
-		commitment: commitment.root,
-		committed: vcs_committed,
-		codeword: encoded,
-	}
+	tracing::debug_span!("Reed-Solomon Encode")
+		.in_scope(|| rs_code.encode_batch(ntt, message.to_ref(), log_batch_size))
 }
 
+/// Output of [`encode_masked`]: the interleaved (message ‖ mask) codeword and the generated mask.
 #[derive(Debug)]
-pub struct CommitMaskedOutput<P: PackedField, VCSCommitment, VCSCommitted> {
-	pub commitment: VCSCommitment,
-	pub committed: VCSCommitted,
+pub struct MaskedCodeword<P: PackedField> {
+	/// The Reed-Solomon encoding of the interleaved (message ‖ mask) buffer.
 	pub codeword: FieldBuffer<P>,
+	/// The generated random mask, of equal length to the message.
 	pub mask: FieldBuffer<P>,
 }
 
-/// Generates a random mask, interleaves it with the message, and commits.
+/// Generates a random mask, interleaves it with the message, and Reed-Solomon encodes.
 ///
 /// This is used for zero-knowledge FRI commitments. The function generates a random mask of
 /// equal length to the input message, concatenates `message || mask` as the interleaved message
-/// (with `log_batch_size = 1`), performs Reed-Solomon encoding, and commits via Merkle tree.
+/// (with `log_batch_size = 1`), and performs Reed-Solomon encoding. The returned codeword is
+/// committed by sending it over a Merkle channel, like [`encode_interleaved`]'s.
 ///
 /// ## Arguments
 ///
 /// * `params` - the (possibly batched) FRI parameters.
-/// * `oracle_index` - the index into [`FRIParams::input_oracles`] of the oracle being committed;
-///   its spec must have `log_batch_size == 1` and `log_msg_len - 1 == message.log_len()`.
+/// * `oracle_index` - the index into [`FRIParams::input_oracles`] of the oracle being encoded; its
+///   spec must have `log_batch_size == 1` and `log_msg_len - 1 == message.log_len()`.
 /// * `ntt` - the additive NTT for Reed-Solomon encoding
-/// * `merkle_prover` - the Merkle tree prover for commitments
-/// * `message` - the raw message to commit (not doubled)
+/// * `message` - the raw message to encode (not doubled)
 /// * `rng` - cryptographic RNG for mask generation
-///
-/// ## Returns
-///
-/// A [`CommitMaskedOutput`] containing the commitment, Merkle tree data, encoded codeword, and
-/// the generated mask buffer.
-pub fn commit_masked<F, P, NTT, MerkleProver, VCS>(
+pub fn encode_masked<F, P, NTT>(
 	params: &FRIParams<F>,
 	oracle_index: usize,
 	ntt: &NTT,
-	merkle_prover: &MerkleProver,
 	message: FieldSlice<P>,
 	mut rng: impl CryptoRng,
-) -> CommitMaskedOutput<P, VCS::Digest, MerkleProver::Committed>
+) -> MaskedCodeword<P>
 where
 	F: BinaryField,
 	P: PackedField<Scalar = F>,
 	NTT: AdditiveNTT<Field = F> + Sync,
-	MerkleProver: MerkleTreeProver<F, Scheme = VCS>,
-	VCS: MerkleTreeScheme<F>,
 {
 	let oracle_spec = &params.input_oracles()[oracle_index];
-	assert_eq!(oracle_spec.log_batch_size(), 1, "commit_masked requires log_batch_size == 1");
+	assert_eq!(oracle_spec.log_batch_size(), 1, "encode_masked requires log_batch_size == 1");
 	// With batch size 1, the oracle's own codeword dimension (reduced dimension minus its lift) is
 	// exactly the bare message length; the mask is interleaved internally.
 	let oracle_log_dim = params.rs_code().log_dim() - oracle_spec.log_lift;
 	assert_eq!(
 		oracle_log_dim,
 		message.log_len(),
-		"commit_masked requires the oracle's message dimension to match the message length"
+		"encode_masked requires the oracle's message dimension to match the message length"
 	);
 
 	// Generate random mask of equal length to message.
@@ -160,7 +133,7 @@ where
 			P::from_scalars(iter::chain(message.iter_scalars(), mask.iter_scalars()));
 		vec![combined_value]
 	} else {
-		// TODO: Ideally, commit should not allocate and copy the memory into a temp buffer.
+		// TODO: Ideally, encoding should not allocate and copy the memory into a temp buffer.
 		let mut combined_values: Vec<P> = Vec::with_capacity(2 * packed_len);
 		combined_values.extend_from_slice(message.as_ref());
 		combined_values.extend_from_slice(mask.as_ref());
@@ -168,18 +141,9 @@ where
 	};
 	let combined = FieldBuffer::new(log_len + 1, combined_values.into_boxed_slice());
 
-	let CommitOutput {
-		commitment,
-		committed,
-		codeword,
-	} = commit_interleaved(params, oracle_index, ntt, merkle_prover, combined.to_ref());
+	let codeword = encode_interleaved(params, oracle_index, ntt, combined.to_ref());
 
-	CommitMaskedOutput {
-		commitment,
-		committed,
-		codeword,
-		mask,
-	}
+	MaskedCodeword { codeword, mask }
 }
 
 #[cfg(test)]
@@ -198,7 +162,7 @@ mod tests {
 	use crate::merkle_tree::prover::BinaryMerkleTreeProver;
 
 	#[test]
-	fn test_commit_masked() {
+	fn test_encode_masked() {
 		type F = B128;
 		type P = PackedBinaryGhash1x128b;
 
@@ -230,8 +194,7 @@ mod tests {
 
 		let message = random_field_buffer::<P>(&mut rng, log_dim);
 
-		let output: CommitMaskedOutput<P, _, _> =
-			commit_masked(&params, 0, &ntt, &merkle_prover, message.to_ref(), &mut rng);
+		let output: MaskedCodeword<P> = encode_masked(&params, 0, &ntt, message.to_ref(), &mut rng);
 
 		// Verify mask has correct dimensions.
 		assert_eq!(output.mask.log_len(), log_dim);

--- a/crates/iop-prover/src/fri/fold.rs
+++ b/crates/iop-prover/src/fri/fold.rs
@@ -4,89 +4,74 @@
 use std::{iter, mem};
 
 use binius_field::{BinaryField, Field, PackedField};
-use binius_iop::{
-	fri::{FRIParams, fold::fold_chunk},
-	merkle_tree::MerkleTreeScheme,
-};
+use binius_iop::fri::{FRIParams, fold::fold_chunk};
 use binius_math::{
 	FieldBuffer, FieldSlice, inner_product::inner_product_buffers,
 	multilinear::eq::eq_ind_partial_eval, ntt::AdditiveNTT,
 };
-use binius_transcript::{
-	ProverTranscript,
-	fiat_shamir::{CanSampleBits, Challenger},
-};
-use binius_utils::{SerializeBytes, checked_arithmetics::log2_ceil_usize, rayon::prelude::*};
+use binius_utils::{checked_arithmetics::log2_ceil_usize, rayon::prelude::*};
 use tracing::instrument;
 
 use super::query::FRIQueryProver;
 use crate::{
 	fri::{BatchBrakedownOracleProver, BrakedownOracleProver, FRIOracleProver},
-	merkle_tree::MerkleTreeProver,
+	merkle_channel::MerkleIPProverChannel,
 };
 
 /// The type of the termination round codeword in the FRI protocol.
 pub type TerminateCodeword<F> = FieldBuffer<F>;
 
-pub enum FoldRoundOutput<VCSCommitment> {
-	NoCommitment,
-	Commitment(VCSCommitment),
-}
-
-enum FRIFolderState<'a, P, MTProver>
+enum FRIFolderState<P, C>
 where
 	P: PackedField,
-	MTProver: MerkleTreeProver<P::Scalar>,
 {
-	FirstFold(BatchBrakedownFolder<'a, P, MTProver>),
+	FirstFold(BatchBrakedownFolder<P, C>),
 	LaterFolds {
-		first_oracle: BatchBrakedownOracleProver<'a, P, MTProver>,
+		first_oracle: BatchBrakedownOracleProver<P, C>,
 		last_codeword: FieldBuffer<P::Scalar>,
-		last_committed: MTProver::Committed,
-		round_oracles: Vec<FRIOracleProver<'a, P::Scalar, MTProver>>,
+		last_commitment: C,
+		round_oracles: Vec<FRIOracleProver<P::Scalar, C>>,
 	},
 }
 /// A stateful prover for the FRI fold phase.
-pub struct FRIFoldProver<'a, F, P, NTT, MerkleProver>
+///
+/// Fold-round codewords are committed by sending them over a Merkle channel with commitment
+/// handle type `C`, matching the channel's `Commitment` associated type.
+pub struct FRIFoldProver<'a, F, P, NTT, C>
 where
 	F: BinaryField,
 	P: PackedField<Scalar = F>,
-	MerkleProver: MerkleTreeProver<F>,
 {
 	params: &'a FRIParams<F>,
 	ntt: &'a NTT,
-	merkle_prover: &'a MerkleProver,
-	state: Option<FRIFolderState<'a, P, MerkleProver>>,
+	state: Option<FRIFolderState<P, C>>,
 	curr_round: usize,
 	next_commit_round: Option<usize>,
 	unprocessed_challenges: Vec<F>,
 }
 
-impl<'a, F, P, NTT, MerkleScheme, MerkleProver> FRIFoldProver<'a, F, P, NTT, MerkleProver>
+impl<'a, F, P, NTT, C> FRIFoldProver<'a, F, P, NTT, C>
 where
 	F: BinaryField,
 	P: PackedField<Scalar = F>,
 	NTT: AdditiveNTT<Field = F> + Sync,
-	MerkleScheme: MerkleTreeScheme<F, Digest: SerializeBytes>,
-	MerkleProver: MerkleTreeProver<F, Scheme = MerkleScheme>,
 {
 	/// Constructs a new folder for a single committed input oracle.
 	pub fn new(
 		params: &'a FRIParams<F>,
 		ntt: &'a NTT,
-		merkle_prover: &'a MerkleProver,
 		committed_codeword: FieldBuffer<P>,
-		committed: &'a MerkleProver::Committed,
+		commitment: C,
 	) -> Self {
-		Self::new_batch(params, ntt, merkle_prover, vec![(committed_codeword, committed)])
+		Self::new_batch(params, ntt, vec![(committed_codeword, commitment)])
 	}
 
 	/// Constructs a new folder for a batch of committed input oracles.
 	///
 	/// The input oracles share the Reed-Solomon code but may have differing batch sizes; they are
 	/// folded and combined into a single first-round codeword. The codewords must be supplied in
-	/// the same order as [`FRIParams::input_oracles`], and each must match its oracle's batch
-	/// size.
+	/// the same order as [`FRIParams::input_oracles`], each with the commitment handle produced
+	/// when it was sent over the Merkle channel.
 	///
 	/// ## Preconditions
 	///
@@ -94,12 +79,12 @@ where
 	/// * Each input oracle's dimension (`rs_code().log_dim() - log_lift`) must be at most
 	///   `params.rs_code().log_dim()`.
 	/// * Each codeword's length must equal its oracle's Reed-Solomon code length plus its batch
-	///   size (`rs_code().log_dim() - log_lift + log_batch_size + log_inv_rate`).
+	///   size (`rs_code().log_dim() - log_lift + log_batch_size + log_inv_rate`), and its
+	///   commitment's leaf size must be one interleaved coset (`2^log_batch_size` scalars).
 	pub fn new_batch(
 		params: &'a FRIParams<F>,
 		ntt: &'a NTT,
-		merkle_prover: &'a MerkleProver,
-		committed_codewords: Vec<(FieldBuffer<P>, &'a MerkleProver::Committed)>,
+		committed_codewords: Vec<(FieldBuffer<P>, C)>,
 	) -> Self {
 		let input_oracles = params.input_oracles();
 		assert_eq!(
@@ -122,7 +107,7 @@ where
 		}
 
 		let folders = iter::zip(committed_codewords, input_oracles)
-			.map(|((codeword, committed), spec)| {
+			.map(|((codeword, commitment), spec)| {
 				// The oracle's own codeword has dimension `log_dim - log_lift`, so its interleaved
 				// length is that plus the batch size plus the inverse rate. It is lifted to the
 				// common first-round length by duplicating each entry `2^log_lift` times.
@@ -139,7 +124,7 @@ where
 					log_later_batch_size: spec.log_later_batch_size,
 					log_lift: spec.log_lift,
 					codeword,
-					merkle_committed: committed,
+					commitment,
 				}
 			})
 			.collect::<Vec<_>>();
@@ -149,7 +134,6 @@ where
 		Self {
 			params,
 			ntt,
-			merkle_prover,
 			state: Some(FRIFolderState::FirstFold(batch_folder)),
 			curr_round: 0,
 			next_commit_round,
@@ -177,14 +161,23 @@ where
 		self.curr_round += 1;
 	}
 
-	/// Executes the next fold round and returns the folded codeword commitment.
+	/// Executes the next fold round, committing the folded codeword over the channel if this is a
+	/// commitment round.
+	///
+	/// On a commitment round, the folded codeword's Merkle commitment is computed and its root is
+	/// written to the channel as an observed message. Call this *after* writing any other messages
+	/// belonging to the same round (e.g. sumcheck round coefficients), so the root lands after them
+	/// in the transcript.
 	///
 	/// As a memory efficient optimization, this method may not actually do the folding, but instead
 	/// accumulate the folding challenge for processing at a later time. This saves us from storing
 	/// intermediate folded codewords.
-	pub fn execute_fold_round(&mut self) -> FoldRoundOutput<MerkleScheme::Digest> {
+	pub fn execute_fold_round<Channel>(&mut self, channel: &mut Channel)
+	where
+		Channel: MerkleIPProverChannel<F, Commitment = C>,
+	{
 		if !self.is_commitment_round() {
-			return FoldRoundOutput::NoCommitment;
+			return;
 		}
 
 		let state = self
@@ -192,7 +185,7 @@ where
 			.take()
 			.expect("state is always Some by struct invariant");
 
-		let (root, new_state) = match state {
+		let new_state = match state {
 			FRIFolderState::FirstFold(folder) => {
 				let _scope = tracing::debug_span!(
 					"FRI Initial Fold",
@@ -205,23 +198,22 @@ where
 				// single codeword with the same block length, and turn them into a batched
 				// Brakedown query oracle.
 				let challenges = mem::take(&mut self.unprocessed_challenges);
-				let (folded_codeword, first_oracle) = folder.fold(self.merkle_prover, &challenges);
+				let (folded_codeword, first_oracle) = folder.fold(&challenges);
 
 				let next_arity = self.params.fold_arities().first().copied();
-				let (root, last_committed) = self.commit_round(&folded_codeword, next_arity);
+				let last_commitment = self.commit_round(channel, &folded_codeword, next_arity);
 
-				let new_state = FRIFolderState::LaterFolds {
+				FRIFolderState::LaterFolds {
 					first_oracle,
 					last_codeword: folded_codeword,
-					last_committed,
+					last_commitment,
 					round_oracles: Vec::with_capacity(self.params.fold_arities().len()),
-				};
-				(root, new_state)
+				}
 			}
 			FRIFolderState::LaterFolds {
 				first_oracle,
 				last_codeword,
-				last_committed,
+				last_commitment,
 				mut round_oracles,
 			} => {
 				let _fri_round_scope = tracing::debug_span!(
@@ -237,75 +229,74 @@ where
 				let fri_fold_span = tracing::debug_span!("FRI Fold").entered();
 				let folded_codeword = fold_codeword(self.ntt, last_codeword.to_ref(), &challenges);
 				drop(fri_fold_span);
-				let oracle = FRIOracleProver::new(
-					last_codeword,
-					last_committed,
-					self.merkle_prover,
-					challenges.len(),
-				);
+				// The fold consuming `last_codeword` has arity `challenges.len()`, which is the
+				// coset size its commitment was built with.
+				let oracle = FRIOracleProver::new(last_codeword, last_commitment, challenges.len());
 
 				let next_arity = self
 					.params
 					.fold_arities()
 					.get(round_oracles.len() + 1)
 					.copied();
-				let (root, last_committed) = self.commit_round(&folded_codeword, next_arity);
+				let last_commitment = self.commit_round(channel, &folded_codeword, next_arity);
 
 				round_oracles.push(oracle);
-				let new_state = FRIFolderState::LaterFolds {
+				FRIFolderState::LaterFolds {
 					first_oracle,
 					last_codeword: folded_codeword,
-					last_committed,
+					last_commitment,
 					round_oracles,
-				};
-				(root, new_state)
+				}
 			}
 		};
 
 		self.state = Some(new_state);
-		FoldRoundOutput::Commitment(root)
 	}
 
-	/// Commits to a folded codeword, advancing `next_commit_round` for the next fold.
+	/// Commits a folded codeword over the channel, advancing `next_commit_round` for the next
+	/// fold.
 	///
-	/// The coset size is determined by the arity of the *next* fold round, or by the number of
-	/// final challenges once there are no more committed rounds (the terminal codeword).
-	fn commit_round(
+	/// The coset (leaf) size is determined by the arity of the *next* fold round, or by the number
+	/// of final challenges once there are no more committed rounds (the terminal codeword). The
+	/// returned commitment handle owns the committed tree, so the query phase can open it over the
+	/// channel later.
+	fn commit_round<Channel>(
 		&mut self,
+		channel: &mut Channel,
 		folded_codeword: &FieldBuffer<F>,
 		next_arity: Option<usize>,
-	) -> (MerkleScheme::Digest, MerkleProver::Committed) {
+	) -> C
+	where
+		Channel: MerkleIPProverChannel<F, Commitment = C>,
+	{
 		let log_coset_size = next_arity.unwrap_or_else(|| self.params.n_final_challenges());
-		let coset_size = 1 << log_coset_size;
 
 		let _merkle_tree_span = tracing::debug_span!("Merkle Tree").entered();
-		let (commitment, committed) = self
-			.merkle_prover
-			.commit(folded_codeword.as_ref(), coset_size);
+		let commitment =
+			channel.send_merkle_commitment(folded_codeword.to_ref(), 1 << log_coset_size);
 
 		// The next commitment lands `next_arity` rounds after the current one. Once there is no
 		// next arity, this is the terminal codeword and no further commitments are made.
 		self.next_commit_round = next_arity.map(|arity| self.curr_round + arity);
 
-		(commitment.root, committed)
+		commitment
 	}
 
 	/// Finalizes the FRI folding process.
 	///
 	/// This step will process any unprocessed folding challenges to produce the
 	/// final folded codeword. Then it will decode this final folded codeword
-	/// to get the final message. The result is the final message and a query prover instance.
+	/// to get the final message.
 	///
-	/// This returns the final message and a query prover instance.
+	/// This returns the terminal codeword, its commitment handle (for sending it in full over a
+	/// Merkle channel), and a query prover instance.
 	///
 	/// ## Preconditions
 	///
 	/// * All fold rounds must have been executed (`curr_round == n_rounds()`).
 	#[instrument(skip_all, name = "fri::FRIFolder::finalize", level = "debug")]
 	#[allow(clippy::type_complexity)]
-	pub fn finalize(
-		mut self,
-	) -> (TerminateCodeword<F>, FRIQueryProver<'a, F, P, MerkleProver, MerkleScheme>) {
+	pub fn finalize(mut self) -> (TerminateCodeword<F>, C, FRIQueryProver<F, P, C>) {
 		assert_eq!(
 			self.curr_round,
 			self.n_rounds(),
@@ -325,11 +316,11 @@ where
 			FRIFolderState::LaterFolds {
 				first_oracle,
 				last_codeword,
+				last_commitment,
 				round_oracles,
-				..
 			} => {
 				let query_prover = FRIQueryProver::new(first_oracle, round_oracles);
-				(last_codeword, query_prover)
+				(last_codeword, last_commitment, query_prover)
 			}
 			// The first fold fires at `curr_round == log_batch_size <= n_rounds` and
 			// `execute_fold_round` runs every round, so the first fold always precedes `finalize`.
@@ -339,26 +330,32 @@ where
 		}
 	}
 
-	pub fn finish_proof<Challenger_>(self, transcript: &mut ProverTranscript<Challenger_>)
+	/// Runs the FRI query phase over the channel.
+	///
+	/// Samples the query indices, sends the per-oracle batched query openings, and sends the
+	/// terminal codeword in full.
+	///
+	/// ## Preconditions
+	///
+	/// * All fold rounds must have been executed (`curr_round == n_rounds()`).
+	pub fn finish_proof<Channel>(self, channel: &mut Channel)
 	where
-		Challenger_: Challenger,
+		Channel: MerkleIPProverChannel<F, Commitment = C>,
 	{
 		let n_test_queries = self.params.n_test_queries();
 		let index_bits = self.params.index_bits();
-		let (terminate_codeword, query_prover) = self.finalize();
+		let (terminate_codeword, terminal_commitment, query_prover) = self.finalize();
 
-		// Sample all query indices before writing the (per-oracle batched) query openings. The
+		// Sample all query indices before sending the (per-oracle batched) query openings. The
 		// decommitment advice is not absorbed by the challenger, so this matches the verifier
 		// sampling all indices up front.
 		let indices = (0..n_test_queries)
-			.map(|_| transcript.sample_bits(index_bits) as usize)
+			.map(|_| channel.sample_bits(index_bits))
 			.collect::<Vec<_>>();
 
-		// Write the per-oracle batched query openings, then the terminal codeword in full.
-		query_prover.prove_queries(&indices, &mut transcript.decommitment());
-		transcript
-			.decommitment()
-			.write_scalar_slice(terminate_codeword.as_ref());
+		// Send the per-oracle batched query openings, then the terminal codeword in full.
+		query_prover.prove_queries(&indices, channel);
+		channel.send_committed_vector(&terminal_commitment, terminate_codeword.to_ref());
 	}
 }
 
@@ -401,7 +398,7 @@ where
 	FieldBuffer::new(folded_log_len, values.into_boxed_slice())
 }
 
-pub struct ProxTestFolder<'a, P: PackedField, MTProver: MerkleTreeProver<P::Scalar>> {
+pub struct ProxTestFolder<P: PackedField, C> {
 	/// log2 the number of *early* batch-fold challenges this oracle's interleaving folds with
 	/// (sampled before the outer oracle-combine challenges). The oracle folds with the
 	/// `log_early_batch_size`-length suffix of the early challenges.
@@ -414,13 +411,10 @@ pub struct ProxTestFolder<'a, P: PackedField, MTProver: MerkleTreeProver<P::Scal
 	/// duplicated to reach the common first-round length. Zero when no lifting is needed.
 	log_lift: usize,
 	codeword: FieldBuffer<P>,
-	merkle_committed: &'a MTProver::Committed,
+	commitment: C,
 }
 
-impl<'a, F: Field, P: PackedField<Scalar = F>, MTProver> ProxTestFolder<'a, P, MTProver>
-where
-	MTProver: MerkleTreeProver<F>,
-{
+impl<P: PackedField, C> ProxTestFolder<P, C> {
 	/// The total interleave batch size, `log_early_batch_size + log_later_batch_size`.
 	const fn log_batch_size(&self) -> usize {
 		self.log_early_batch_size + self.log_later_batch_size
@@ -437,21 +431,18 @@ where
 /// of the common length `codeword.log_len() - log_batch_size`. The folded codewords are summed into
 /// a single codeword that continues through the FRI rounds, and the per-commitment
 /// [`BrakedownOracleProver`]s are bundled into a [`BatchBrakedownOracleProver`].
-pub struct BatchBrakedownFolder<'a, P: PackedField, MTProver: MerkleTreeProver<P::Scalar>> {
+pub struct BatchBrakedownFolder<P: PackedField, C> {
 	log_code_len: usize,
-	folders: Vec<ProxTestFolder<'a, P, MTProver>>,
+	folders: Vec<ProxTestFolder<P, C>>,
 }
 
-impl<'a, F: Field, P: PackedField<Scalar = F>, MTProver> BatchBrakedownFolder<'a, P, MTProver>
-where
-	MTProver: MerkleTreeProver<F>,
-{
+impl<F: Field, P: PackedField<Scalar = F>, C> BatchBrakedownFolder<P, C> {
 	/// Constructs a batch folder from one or more interleaved-codeword folders.
 	///
 	/// `log_code_len` is the common (first-round) codeword length the folders combine into. Each
 	/// folder's own folded length must not exceed it; folders that fall short are lifted (their
 	/// folded codewords duplicated) up to `log_code_len` during [`Self::fold`].
-	pub fn new(folders: Vec<ProxTestFolder<'a, P, MTProver>>, log_code_len: usize) -> Self {
+	pub fn new(folders: Vec<ProxTestFolder<P, C>>, log_code_len: usize) -> Self {
 		assert!(!folders.is_empty()); // precondition
 		for folder in &folders {
 			assert!(folder.log_folded_len() <= log_code_len);
@@ -474,11 +465,7 @@ where
 		max_folder_log_len + log_folders
 	}
 
-	pub fn fold(
-		self,
-		merkle_prover: &'a MTProver,
-		challenges: &[F],
-	) -> (FieldBuffer<F>, BatchBrakedownOracleProver<'a, P, MTProver>) {
+	pub fn fold(self, challenges: &[F]) -> (FieldBuffer<F>, BatchBrakedownOracleProver<P, C>) {
 		// The first-fold challenge slice is `[early ++ outer ++ later]`: `max_early` early
 		// within-oracle batch challenges, then `log_n_oracles` outer oracle-combine challenges,
 		// then `max_later` later within-oracle batch challenges.
@@ -511,7 +498,7 @@ where
 				log_later_batch_size,
 				log_lift,
 				codeword,
-				merkle_committed,
+				commitment,
 			} = folder;
 			let log_batch_size = log_early_batch_size + log_later_batch_size;
 
@@ -548,13 +535,7 @@ where
 					}
 				});
 
-			oracles.push(BrakedownOracleProver::new(
-				codeword,
-				merkle_committed,
-				merkle_prover,
-				log_batch_size,
-				log_lift,
-			));
+			oracles.push(BrakedownOracleProver::new(codeword, commitment, log_lift));
 		}
 
 		(combined_codeword, BatchBrakedownOracleProver::new(oracles))

--- a/crates/iop-prover/src/fri/mod.rs
+++ b/crates/iop-prover/src/fri/mod.rs
@@ -1,11 +1,12 @@
 // Copyright 2024-2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
-mod commit;
+mod encode;
 mod fold;
 mod query;
 #[cfg(test)]
 mod tests;
 
-pub use commit::*;
+pub use encode::*;
 pub use fold::*;
 pub use query::*;

--- a/crates/iop-prover/src/fri/query.rs
+++ b/crates/iop-prover/src/fri/query.rs
@@ -1,85 +1,77 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
-use binius_field::{BinaryField, Field, PackedField};
-use binius_iop::merkle_tree::MerkleTreeScheme;
-use binius_math::{FieldBuffer, FieldSlice};
-use binius_transcript::TranscriptWriter;
-use binius_utils::SerializeBytes;
-use bytes::BufMut;
+use binius_field::{Field, PackedField};
+use binius_math::FieldBuffer;
 use tracing::instrument;
 
-use crate::merkle_tree::MerkleTreeProver;
+use crate::merkle_channel::MerkleIPProverChannel;
 
 /// The prover counterpart of a `ProxTestOracle` (verifier side), producing the per-oracle query
 /// openings.
-pub trait ProxTestOracleProver<F> {
-	/// Writes the per-oracle batched query openings: the oracle's optimal Merkle layer once,
+pub trait ProxTestOracleProver<F: Field> {
+	/// The Merkle commitment handle for the committed oracle.
+	type Commitment;
+
+	/// Sends the per-oracle batched query openings: the oracle's optimal Merkle layer once,
 	/// followed by each queried coset's values and Merkle opening proof.
-	fn open_queries<B: BufMut>(&self, indices: &[usize], advice: &mut TranscriptWriter<B>);
+	fn open_queries<Channel>(&self, indices: &[usize], channel: &mut Channel)
+	where
+		Channel: MerkleIPProverChannel<F, Commitment = Self::Commitment>;
 }
 
 /// The [`ProxTestOracleProver`] for a [Brakedown]-style interleaved code proximity check.
 ///
 /// [Brakedown]: <https://dl.acm.org/doi/10.1007/978-3-031-38545-2_7>
-pub struct BrakedownOracleProver<'a, P, MerkleProver>
+pub struct BrakedownOracleProver<P, C>
 where
 	P: PackedField,
-	MerkleProver: MerkleTreeProver<P::Scalar>,
 {
 	codeword: FieldBuffer<P>,
-	committed: &'a MerkleProver::Committed,
-	merkle_prover: &'a MerkleProver,
-	log_batch_size: usize,
+	commitment: C,
 	/// log2 the lift factor (oracle padding). The committed codeword is virtually duplicated
 	/// `2^log_lift` times to reach the common first-round length; a query at global index `k`
 	/// opens the committed codeword at `k >> log_lift`. Zero when no lifting is needed.
 	log_lift: usize,
 }
 
-impl<'a, P, MerkleProver> BrakedownOracleProver<'a, P, MerkleProver>
+impl<P, C> BrakedownOracleProver<P, C>
 where
 	P: PackedField,
-	MerkleProver: MerkleTreeProver<P::Scalar>,
 {
 	/// Constructs a new oracle prover wrapping a committed interleaved codeword.
 	///
 	/// `log_lift` is the oracle-padding lift factor (the committed codeword is virtually duplicated
 	/// `2^log_lift` times to reach the common first-round length); pass `0` when no lifting is
 	/// needed.
-	pub const fn new(
-		codeword: FieldBuffer<P>,
-		committed: &'a MerkleProver::Committed,
-		merkle_prover: &'a MerkleProver,
-		log_batch_size: usize,
-		log_lift: usize,
-	) -> Self {
+	pub const fn new(codeword: FieldBuffer<P>, commitment: C, log_lift: usize) -> Self {
 		Self {
 			codeword,
-			committed,
-			merkle_prover,
-			log_batch_size,
+			commitment,
 			log_lift,
 		}
 	}
 }
 
-impl<F, P, MerkleProver, VCS> ProxTestOracleProver<F> for BrakedownOracleProver<'_, P, MerkleProver>
+impl<F, P, C> ProxTestOracleProver<F> for BrakedownOracleProver<P, C>
 where
-	F: BinaryField,
+	F: Field,
 	P: PackedField<Scalar = F>,
-	MerkleProver: MerkleTreeProver<F, Scheme = VCS>,
-	VCS: MerkleTreeScheme<F, Digest: SerializeBytes>,
 {
-	fn open_queries<B: BufMut>(&self, indices: &[usize], advice: &mut TranscriptWriter<B>) {
-		open_oracle_queries(
-			self.merkle_prover,
-			&self.codeword,
-			self.committed,
-			self.log_batch_size,
-			self.log_lift,
-			indices,
-			advice,
-		)
+	type Commitment = C;
+
+	fn open_queries<Channel>(&self, indices: &[usize], channel: &mut Channel)
+	where
+		Channel: MerkleIPProverChannel<F, Commitment = Self::Commitment>,
+	{
+		// When the oracle is lifted (`log_lift > 0`), each global query index is translated to the
+		// committed codeword by dropping its low `log_lift` bits (the duplicated copies), mirroring
+		// the verifier.
+		let lifted_indices = indices
+			.iter()
+			.map(|&index| index >> self.log_lift)
+			.collect::<Vec<_>>();
+		channel.send_openings(&self.commitment, self.codeword.to_ref(), &lifted_indices);
 	}
 }
 
@@ -89,127 +81,85 @@ where
 /// single folded codeword during the first FRI fold. Their query openings are written sequentially,
 /// one oracle's full decommitment after another, so the verifier reads each committed oracle's
 /// advice in turn.
-pub struct BatchBrakedownOracleProver<'a, P, MerkleProver>
+pub struct BatchBrakedownOracleProver<P, C>
 where
 	P: PackedField,
-	MerkleProver: MerkleTreeProver<P::Scalar>,
 {
-	oracles: Vec<BrakedownOracleProver<'a, P, MerkleProver>>,
+	oracles: Vec<BrakedownOracleProver<P, C>>,
 }
 
-impl<'a, P, MerkleProver> BatchBrakedownOracleProver<'a, P, MerkleProver>
+impl<P, C> BatchBrakedownOracleProver<P, C>
 where
 	P: PackedField,
-	MerkleProver: MerkleTreeProver<P::Scalar>,
 {
 	/// Constructs a batch oracle prover from the per-commitment oracle provers.
-	pub const fn new(oracles: Vec<BrakedownOracleProver<'a, P, MerkleProver>>) -> Self {
+	pub const fn new(oracles: Vec<BrakedownOracleProver<P, C>>) -> Self {
 		Self { oracles }
 	}
 }
 
-impl<F, P, MerkleProver, VCS> ProxTestOracleProver<F>
-	for BatchBrakedownOracleProver<'_, P, MerkleProver>
+impl<F, P, C> ProxTestOracleProver<F> for BatchBrakedownOracleProver<P, C>
 where
-	F: BinaryField,
+	F: Field,
 	P: PackedField<Scalar = F>,
-	MerkleProver: MerkleTreeProver<F, Scheme = VCS>,
-	VCS: MerkleTreeScheme<F, Digest: SerializeBytes>,
 {
-	fn open_queries<B: BufMut>(&self, indices: &[usize], advice: &mut TranscriptWriter<B>) {
+	type Commitment = C;
+
+	fn open_queries<Channel>(&self, indices: &[usize], channel: &mut Channel)
+	where
+		Channel: MerkleIPProverChannel<F, Commitment = Self::Commitment>,
+	{
 		for oracle in &self.oracles {
-			oracle.open_queries(indices, advice);
+			oracle.open_queries(indices, channel);
 		}
 	}
 }
 
 /// The [`ProxTestOracleProver`] for a FRI-style code proximity check.
-pub struct FRIOracleProver<'a, F, MerkleProver>
+pub struct FRIOracleProver<F, C>
 where
 	F: Field,
-	MerkleProver: MerkleTreeProver<F>,
 {
 	codeword: FieldBuffer<F>,
-	committed: MerkleProver::Committed,
-	merkle_prover: &'a MerkleProver,
+	commitment: C,
+	/// The base-2 log of the size of each coset opened from the committed oracle: the arity of
+	/// the fold that consumes this codeword, which is also the commitment's leaf size.
 	coset_log_size: usize,
 }
 
-impl<'a, F, MerkleProver> FRIOracleProver<'a, F, MerkleProver>
+impl<F, C> FRIOracleProver<F, C>
 where
-	F: BinaryField,
-	MerkleProver: MerkleTreeProver<F>,
+	F: Field,
 {
 	/// Constructs a new oracle prover wrapping a committed fold-round codeword.
-	pub const fn new(
-		codeword: FieldBuffer<F>,
-		committed: MerkleProver::Committed,
-		merkle_prover: &'a MerkleProver,
-		coset_log_size: usize,
-	) -> Self {
+	///
+	/// `coset_log_size` is the base-2 log of the coset size of the fold that consumes this
+	/// codeword, which must equal the commitment's leaf size.
+	pub const fn new(codeword: FieldBuffer<F>, commitment: C, coset_log_size: usize) -> Self {
 		Self {
 			codeword,
-			committed,
-			merkle_prover,
+			commitment,
 			coset_log_size,
 		}
 	}
-}
 
-impl<F, MerkleProver, VCS> ProxTestOracleProver<F> for FRIOracleProver<'_, F, MerkleProver>
-where
-	F: BinaryField,
-	MerkleProver: MerkleTreeProver<F, Scheme = VCS>,
-	VCS: MerkleTreeScheme<F, Digest: SerializeBytes>,
-{
-	fn open_queries<B: BufMut>(&self, indices: &[usize], advice: &mut TranscriptWriter<B>) {
-		open_oracle_queries(
-			self.merkle_prover,
-			&self.codeword,
-			&self.committed,
-			self.coset_log_size,
-			0,
-			indices,
-			advice,
-		)
+	/// The base-2 log of the size of each coset opened from the committed oracle.
+	const fn coset_log_size(&self) -> usize {
+		self.coset_log_size
 	}
 }
 
-/// Writes the optimal Merkle layer once, then a coset opening for each queried index.
-///
-/// The coset is opened at the index directly, mirroring the verifier's `open_queries`. When the
-/// oracle is lifted (`log_lift > 0`), each global query index is translated to the committed
-/// codeword by dropping its low `log_lift` bits (the duplicated copies), mirroring the verifier.
-fn open_oracle_queries<F, P, MerkleProver, B>(
-	merkle_prover: &MerkleProver,
-	codeword: &FieldBuffer<P>,
-	committed: &MerkleProver::Committed,
-	coset_log_size: usize,
-	log_lift: usize,
-	indices: &[usize],
-	advice: &mut TranscriptWriter<B>,
-) where
-	F: BinaryField,
-	P: PackedField<Scalar = F>,
-	MerkleProver: MerkleTreeProver<F>,
-	<MerkleProver::Scheme as MerkleTreeScheme<F>>::Digest: SerializeBytes,
-	B: BufMut,
+impl<F, C> ProxTestOracleProver<F> for FRIOracleProver<F, C>
+where
+	F: Field,
 {
-	let scheme = merkle_prover.scheme();
-	// The Merkle tree has one coset per leaf, so its depth is the codeword length minus the coset.
-	let tree_depth = codeword.log_len() - coset_log_size;
-	let layer_depth = scheme.optimal_verify_layer(indices.len(), tree_depth);
-	advice.write_slice(merkle_prover.layer(committed, layer_depth));
-	for &index in indices {
-		prove_coset_opening(
-			merkle_prover,
-			codeword.to_ref(),
-			committed,
-			index >> log_lift,
-			coset_log_size,
-			layer_depth,
-			advice,
-		);
+	type Commitment = C;
+
+	fn open_queries<Channel>(&self, indices: &[usize], channel: &mut Channel)
+	where
+		Channel: MerkleIPProverChannel<F, Commitment = Self::Commitment>,
+	{
+		channel.send_openings(&self.commitment, self.codeword.to_ref(), indices);
 	}
 }
 
@@ -218,23 +168,19 @@ fn open_oracle_queries<F, P, MerkleProver, B>(
 /// This is a composition of [`ProxTestOracleProver`]s mirroring the verifier's `FRIQueryVerifier`:
 /// a [`BatchBrakedownOracleProver`] for the codeword's interleaved reduction, then one
 /// [`FRIOracleProver`] per fold arity for the subsequent reductions.
-pub struct FRIQueryProver<'a, F, P, MerkleProver, VCS>
+pub struct FRIQueryProver<F, P, C>
 where
-	F: BinaryField,
+	F: Field,
 	P: PackedField<Scalar = F>,
-	MerkleProver: MerkleTreeProver<F, Scheme = VCS>,
-	VCS: MerkleTreeScheme<F>,
 {
-	codeword_oracle: BatchBrakedownOracleProver<'a, P, MerkleProver>,
-	fri_oracles: Vec<FRIOracleProver<'a, F, MerkleProver>>,
+	codeword_oracle: BatchBrakedownOracleProver<P, C>,
+	fri_oracles: Vec<FRIOracleProver<F, C>>,
 }
 
-impl<'a, F, P, MerkleProver, VCS> FRIQueryProver<'a, F, P, MerkleProver, VCS>
+impl<F, P, C> FRIQueryProver<F, P, C>
 where
-	F: BinaryField,
+	F: Field,
 	P: PackedField<Scalar = F>,
-	MerkleProver: MerkleTreeProver<F, Scheme = VCS>,
-	VCS: MerkleTreeScheme<F>,
 {
 	/// Constructs a query prover from the per-oracle provers built during the fold phase.
 	///
@@ -242,8 +188,8 @@ where
 	/// interleaved codeword(s), and `fri_oracles` holds one [`FRIOracleProver`] per fold arity. The
 	/// terminal codeword is sent in full and therefore is not represented here.
 	pub const fn new(
-		codeword_oracle: BatchBrakedownOracleProver<'a, P, MerkleProver>,
-		fri_oracles: Vec<FRIOracleProver<'a, F, MerkleProver>>,
+		codeword_oracle: BatchBrakedownOracleProver<P, C>,
+		fri_oracles: Vec<FRIOracleProver<F, C>>,
 	) -> Self {
 		Self {
 			codeword_oracle,
@@ -259,51 +205,28 @@ where
 	/// Proves the FRI challenge queries, batched per oracle.
 	///
 	/// For each committed oracle (the codeword first, then each fold-round oracle excluding the
-	/// terminal codeword) this writes the oracle's optimal Merkle layer once, followed by the coset
+	/// terminal codeword) this sends the oracle's optimal Merkle layer once, followed by the coset
 	/// opening for each query index. This per-oracle batched layout matches the verifier, which
-	/// reads each oracle's layer and then all of its query openings together.
+	/// receives each oracle's layer and then all of its query openings together.
 	///
 	/// ## Arguments
 	///
 	/// * `indices` - the sampled query indices into the original codeword domain
 	#[instrument(skip_all, name = "fri::FRIQueryProver::prove_queries", level = "debug")]
-	pub fn prove_queries<B>(&self, indices: &[usize], advice: &mut TranscriptWriter<B>)
+	pub fn prove_queries<Channel>(&self, indices: &[usize], channel: &mut Channel)
 	where
-		B: BufMut,
-		VCS::Digest: SerializeBytes,
+		Channel: MerkleIPProverChannel<F, Commitment = C>,
 	{
-		self.codeword_oracle.open_queries(indices, advice);
+		self.codeword_oracle.open_queries(indices, channel);
 
 		// Each subsequent oracle indexes the previous virtual oracle, so shift the query indices
 		// right by the round's arity before opening it.
 		let mut indices = indices.to_vec();
 		for fri_oracle in &self.fri_oracles {
 			for index in &mut indices {
-				*index >>= fri_oracle.coset_log_size;
+				*index >>= fri_oracle.coset_log_size();
 			}
-			fri_oracle.open_queries(&indices, advice);
+			fri_oracle.open_queries(&indices, channel);
 		}
 	}
-}
-
-fn prove_coset_opening<F, P, MTProver, B>(
-	merkle_prover: &MTProver,
-	codeword: FieldSlice<P>,
-	committed: &MTProver::Committed,
-	coset_index: usize,
-	log_coset_size: usize,
-	optimal_layer_depth: usize,
-	advice: &mut TranscriptWriter<B>,
-) where
-	F: BinaryField,
-	P: PackedField<Scalar = F>,
-	MTProver: MerkleTreeProver<F>,
-	B: BufMut,
-{
-	assert!(coset_index < (1 << (codeword.log_len() - log_coset_size))); // precondition
-
-	let values = codeword.chunk(log_coset_size, coset_index);
-	advice.write_scalar_iter(values.iter_scalars());
-
-	merkle_prover.prove_opening(committed, optimal_layer_depth, coset_index, advice);
 }

--- a/crates/iop-prover/src/fri/tests.rs
+++ b/crates/iop-prover/src/fri/tests.rs
@@ -7,22 +7,24 @@ use binius_field::{
 	BinaryField, BinaryField128bGhash as B128, Field, PackedBinaryGhash1x128b, PackedField,
 };
 use binius_hash::{StdDigest, StdHashSuite};
-use binius_iop::fri::{self, CodewordSpec, FRIFoldVerifier, FRIParams, verify::FRIQueryVerifier};
+use binius_iop::{
+	fri::{self, CodewordSpec, FRIFoldVerifier, FRIParams, verify::FRIQueryVerifier},
+	merkle_channel::{MerkleIPVerifierChannel, VerifierMerkleTranscriptChannel},
+};
+use binius_ip::channel::IPVerifierChannel;
+use binius_ip_prover::channel::IPProverChannel;
 use binius_math::{
 	BinarySubspace, ReedSolomonCode,
 	multilinear::{eq::eq_ind_partial_eval_scalars, evaluate::evaluate},
 	ntt::{AdditiveNTT, NeighborsLastSingleThread, domain_context::GenericOnTheFly},
 	test_utils::{Packed128b, random_field_buffer},
 };
-use binius_transcript::{
-	ProverTranscript,
-	fiat_shamir::{CanSample, HasherChallenger},
-};
+use binius_transcript::{ProverTranscript, fiat_shamir::HasherChallenger};
 use binius_utils::checked_arithmetics::log2_ceil_usize;
 use rand::prelude::*;
 
-use super::{CommitOutput, FRIFoldProver, FoldRoundOutput, commit_interleaved};
-use crate::merkle_tree::prover::BinaryMerkleTreeProver;
+use super::{FRIFoldProver, encode_interleaved};
+use crate::merkle_channel::{MerkleIPProverChannel, ProverMerkleTranscriptChannel};
 
 type StdChallenger = HasherChallenger<StdDigest>;
 
@@ -36,8 +38,6 @@ fn test_commit_prove_verify_success<F, P>(
 	P: PackedField<Scalar = F>,
 {
 	let mut rng = StdRng::seed_from_u64(0);
-
-	let merkle_prover = BinaryMerkleTreeProver::<_, StdHashSuite>::new();
 
 	let committed_rs_code = ReedSolomonCode::<F>::new(log_dimension, log_inv_rate);
 
@@ -54,41 +54,41 @@ fn test_commit_prove_verify_success<F, P>(
 	// Generate a random message
 	let msg = random_field_buffer::<P>(&mut rng, params.log_msg_len());
 
-	// Prover commits the message
-	let CommitOutput {
-		commitment: mut codeword_commitment,
-		committed: codeword_committed,
-		codeword,
-	} = commit_interleaved(&params, 0, &ntt, &merkle_prover, msg.to_ref());
-
-	// Run the prover to generate the proximity proof
-	let mut round_prover =
-		FRIFoldProver::new(&params, &ntt, &merkle_prover, codeword, &codeword_committed);
+	// Prover encodes the message and commits the codeword over a Merkle channel.
+	let codeword = encode_interleaved(&params, 0, &ntt, msg.to_ref());
 
 	let mut prover_challenger = ProverTranscript::new(StdChallenger::default());
-	prover_challenger.message().write(&codeword_commitment);
+	let mut prover_channel =
+		ProverMerkleTranscriptChannel::<_, StdChallenger, _, StdHashSuite>::new(
+			&mut prover_challenger,
+		);
+	let codeword_commitment =
+		prover_channel.send_merkle_commitment(codeword.to_ref(), 1 << log_batch_size);
+
+	// Run the prover to generate the proximity proof
+	let mut round_prover = FRIFoldProver::new(&params, &ntt, codeword, codeword_commitment);
 
 	// Note: The prover does an initial fold round before receiving any challenges
 	// This is round 0, which won't produce a commitment when log_batch_size > 0
-	let fold_round_output = round_prover.execute_fold_round();
-	if let FoldRoundOutput::Commitment(round_commitment) = fold_round_output {
-		prover_challenger.message().write(&round_commitment);
-	}
+	round_prover.execute_fold_round(&mut prover_channel);
 
 	for _i in 0..params.n_fold_rounds() {
-		let challenge = prover_challenger.sample();
+		let challenge: F = IPProverChannel::sample(&mut prover_channel);
 		round_prover.receive_challenge(challenge);
-
-		let fold_round_output = round_prover.execute_fold_round();
-		if let FoldRoundOutput::Commitment(round_commitment) = fold_round_output {
-			prover_challenger.message().write(&round_commitment);
-		}
+		round_prover.execute_fold_round(&mut prover_channel);
 	}
 
-	round_prover.finish_proof(&mut prover_challenger);
-	// Now run the verifier
+	round_prover.finish_proof(&mut prover_channel);
+	drop(prover_channel);
+	// Now run the verifier, receiving commitments and openings over a Merkle channel.
 	let mut verifier_challenger = prover_challenger.into_verifier();
-	codeword_commitment = verifier_challenger.message().read().unwrap();
+	let mut channel = VerifierMerkleTranscriptChannel::<_, StdChallenger, _, StdHashSuite>::new(
+		&mut verifier_challenger,
+	);
+	// The committed codeword's Merkle tree has one interleaved coset per leaf.
+	let codeword_commitment = channel
+		.recv_merkle_commitment(1 << log_batch_size, log_dimension + log_inv_rate)
+		.unwrap();
 	let mut verifier_challenges = Vec::with_capacity(params.n_fold_rounds());
 
 	assert_eq!(params.fold_arities().len(), n_round_commitments);
@@ -98,16 +98,12 @@ fn test_commit_prove_verify_success<F, P>(
 	let mut fri_fold_verifier = FRIFoldVerifier::new(&params);
 
 	// Process initial round (before any challenges) - round 0
-	fri_fold_verifier
-		.process_round(&mut verifier_challenger.message())
-		.unwrap();
+	fri_fold_verifier.process_round(&mut channel).unwrap();
 
 	// Process remaining rounds with challenges
 	for _ in 0..params.n_fold_rounds() {
-		verifier_challenges.push(verifier_challenger.sample());
-		fri_fold_verifier
-			.process_round(&mut verifier_challenger.message())
-			.unwrap();
+		verifier_challenges.push(IPVerifierChannel::<F>::sample(&mut channel));
+		fri_fold_verifier.process_round(&mut channel).unwrap();
 	}
 
 	let round_commitments = fri_fold_verifier.finalize();
@@ -116,7 +112,6 @@ fn test_commit_prove_verify_success<F, P>(
 
 	let verifier = FRIQueryVerifier::new(
 		&params,
-		merkle_prover.scheme(),
 		&codeword_commitment,
 		&round_commitments,
 		&verifier_challenges,
@@ -131,7 +126,7 @@ fn test_commit_prove_verify_success<F, P>(
 	eval_point.reverse();
 	let computed_eval = evaluate(&msg, &eval_point);
 
-	let final_fri_value = verifier.verify(&mut verifier_challenger).unwrap();
+	let final_fri_value = verifier.verify(&mut channel).unwrap();
 	assert_eq!(computed_eval, final_fri_value);
 }
 
@@ -229,8 +224,6 @@ fn test_commit_prove_verify_batched_multi_oracle() {
 	let log_batch_sizes = [1usize, 1, 2];
 	let n_test_queries = 3;
 
-	let merkle_prover = BinaryMerkleTreeProver::<F, StdHashSuite>::new();
-
 	// The reduced Reed-Solomon code is shared by every input oracle, so the domain only needs to
 	// cover its length.
 	let subspace = BinarySubspace::with_dim(log_dim + log_inv_rate);
@@ -254,79 +247,71 @@ fn test_commit_prove_verify_batched_multi_oracle() {
 	let params = FRIParams::<F>::new_batch(rs_code, oracle_specs, vec![], n_test_queries);
 	assert_eq!(params.rs_code().log_dim(), log_dim);
 
-	// Commit each input oracle's interleaved codeword separately.
+	// Encode each input oracle's interleaved codeword separately and commit it over the channel.
+	let mut prover_challenger = ProverTranscript::new(StdChallenger::default());
+	let mut prover_channel =
+		ProverMerkleTranscriptChannel::<_, StdChallenger, _, StdHashSuite>::new(
+			&mut prover_challenger,
+		);
 	let mut messages = Vec::new();
-	let mut commitments = Vec::new();
-	let mut committeds = Vec::new();
-	let mut codewords = Vec::new();
+	let mut committed_codewords = Vec::new();
 	for &log_batch_size in &log_batch_sizes {
 		let oracle_params =
 			FRIParams::new(params.rs_code().clone(), log_batch_size, vec![], n_test_queries);
 		let msg = random_field_buffer::<P>(&mut rng, log_dim + log_batch_size);
-		let CommitOutput {
-			commitment,
-			committed,
-			codeword,
-		} = commit_interleaved(&oracle_params, 0, &ntt, &merkle_prover, msg.to_ref());
+		let codeword = encode_interleaved(&oracle_params, 0, &ntt, msg.to_ref());
+		let commitment =
+			prover_channel.send_merkle_commitment(codeword.to_ref(), 1 << log_batch_size);
 		messages.push(msg);
-		commitments.push(commitment);
-		committeds.push(committed);
-		codewords.push(codeword);
+		committed_codewords.push((codeword, commitment));
 	}
 
-	// Run the prover: write the per-oracle codeword commitments, then fold.
-	let committed_codewords = iter::zip(codewords, &committeds).collect::<Vec<_>>();
-	let mut round_prover =
-		FRIFoldProver::new_batch(&params, &ntt, &merkle_prover, committed_codewords);
+	// Run the prover to fold the committed codewords.
+	let mut round_prover = FRIFoldProver::new_batch(&params, &ntt, committed_codewords);
 
-	let mut prover_challenger = ProverTranscript::new(StdChallenger::default());
-	for commitment in &commitments {
-		prover_challenger.message().write(commitment);
-	}
-
-	let fold_round_output = round_prover.execute_fold_round();
-	if let FoldRoundOutput::Commitment(round_commitment) = fold_round_output {
-		prover_challenger.message().write(&round_commitment);
-	}
+	round_prover.execute_fold_round(&mut prover_channel);
 	for _ in 0..params.n_fold_rounds() {
-		let challenge = prover_challenger.sample();
+		let challenge: F = IPProverChannel::sample(&mut prover_channel);
 		round_prover.receive_challenge(challenge);
-
-		let fold_round_output = round_prover.execute_fold_round();
-		if let FoldRoundOutput::Commitment(round_commitment) = fold_round_output {
-			prover_challenger.message().write(&round_commitment);
-		}
+		round_prover.execute_fold_round(&mut prover_channel);
 	}
-	round_prover.finish_proof(&mut prover_challenger);
+	round_prover.finish_proof(&mut prover_channel);
+	drop(prover_channel);
 
-	// Run the verifier.
+	// Run the verifier, receiving commitments and openings over a Merkle channel.
 	let mut verifier_challenger = prover_challenger.into_verifier();
-	let read_commitments = commitments
+	let mut channel = VerifierMerkleTranscriptChannel::<_, StdChallenger, _, StdHashSuite>::new(
+		&mut verifier_challenger,
+	);
+	// Each input oracle's Merkle tree has one interleaved coset per leaf and depth equal to its
+	// own (possibly lifted) codeword dimension plus the inverse rate.
+	let read_commitments = params
+		.input_oracles()
 		.iter()
-		.map(|_| verifier_challenger.message().read().unwrap())
+		.map(|spec| {
+			let depth = (params.rs_code().log_dim() - spec.log_lift) + log_inv_rate;
+			channel
+				.recv_merkle_commitment(1 << spec.log_batch_size(), depth)
+				.unwrap()
+		})
 		.collect::<Vec<_>>();
 
 	let mut verifier_challenges = Vec::with_capacity(params.n_fold_rounds());
 	let mut fri_fold_verifier = FRIFoldVerifier::new(&params);
-	fri_fold_verifier
-		.process_round(&mut verifier_challenger.message())
-		.unwrap();
+	fri_fold_verifier.process_round(&mut channel).unwrap();
 	for _ in 0..params.n_fold_rounds() {
-		verifier_challenges.push(verifier_challenger.sample());
-		fri_fold_verifier
-			.process_round(&mut verifier_challenger.message())
-			.unwrap();
+		verifier_challenges.push(IPVerifierChannel::<F>::sample(&mut channel));
+		fri_fold_verifier.process_round(&mut channel).unwrap();
 	}
 	let round_commitments = fri_fold_verifier.finalize();
 
 	let verifier = FRIQueryVerifier::new_batch(
 		&params,
-		merkle_prover.scheme(),
 		&read_commitments,
 		&round_commitments,
 		&verifier_challenges,
 	);
-	let final_value = verifier.verify(&mut verifier_challenger).unwrap();
+	let final_value = verifier.verify(&mut channel).unwrap();
 
 	// The first-fold challenge slice is `[early ++ outer ++ later]`. Here every oracle is non-ZK,
 	// so `max_early = 0` and the slice is `[outer ++ later]`. Oracle `i` folds with the
@@ -376,8 +361,6 @@ fn test_commit_prove_verify_batched_mixed_skip() {
 	let oracle_params_spec = [(1usize, true), (2usize, false)];
 	let n_test_queries = 3;
 
-	let merkle_prover = BinaryMerkleTreeProver::<F, StdHashSuite>::new();
-
 	// Every oracle reduces to the shared dimension `log_dim`, so no lifting is exercised here — the
 	// focus is the inner-challenge windowing.
 	let subspace = BinarySubspace::with_dim(log_dim + log_inv_rate);
@@ -400,79 +383,71 @@ fn test_commit_prove_verify_batched_mixed_skip() {
 	let params = FRIParams::<F>::new_batch(rs_code, oracle_specs, vec![], n_test_queries);
 	assert_eq!(params.rs_code().log_dim(), log_dim);
 
-	// Commit each input oracle's interleaved codeword separately.
+	// Encode each input oracle's interleaved codeword separately and commit it over the channel.
+	let mut prover_challenger = ProverTranscript::new(StdChallenger::default());
+	let mut prover_channel =
+		ProverMerkleTranscriptChannel::<_, StdChallenger, _, StdHashSuite>::new(
+			&mut prover_challenger,
+		);
 	let mut messages = Vec::new();
-	let mut commitments = Vec::new();
-	let mut committeds = Vec::new();
-	let mut codewords = Vec::new();
+	let mut committed_codewords = Vec::new();
 	for &(log_batch_size, _) in &oracle_params_spec {
 		let oracle_params =
 			FRIParams::new(params.rs_code().clone(), log_batch_size, vec![], n_test_queries);
 		let msg = random_field_buffer::<P>(&mut rng, log_dim + log_batch_size);
-		let CommitOutput {
-			commitment,
-			committed,
-			codeword,
-		} = commit_interleaved(&oracle_params, 0, &ntt, &merkle_prover, msg.to_ref());
+		let codeword = encode_interleaved(&oracle_params, 0, &ntt, msg.to_ref());
+		let commitment =
+			prover_channel.send_merkle_commitment(codeword.to_ref(), 1 << log_batch_size);
 		messages.push(msg);
-		commitments.push(commitment);
-		committeds.push(committed);
-		codewords.push(codeword);
+		committed_codewords.push((codeword, commitment));
 	}
 
-	// Run the prover: write the per-oracle codeword commitments, then fold.
-	let committed_codewords = iter::zip(codewords, &committeds).collect::<Vec<_>>();
-	let mut round_prover =
-		FRIFoldProver::new_batch(&params, &ntt, &merkle_prover, committed_codewords);
+	// Run the prover to fold the committed codewords.
+	let mut round_prover = FRIFoldProver::new_batch(&params, &ntt, committed_codewords);
 
-	let mut prover_challenger = ProverTranscript::new(StdChallenger::default());
-	for commitment in &commitments {
-		prover_challenger.message().write(commitment);
-	}
-
-	let fold_round_output = round_prover.execute_fold_round();
-	if let FoldRoundOutput::Commitment(round_commitment) = fold_round_output {
-		prover_challenger.message().write(&round_commitment);
-	}
+	round_prover.execute_fold_round(&mut prover_channel);
 	for _ in 0..params.n_fold_rounds() {
-		let challenge = prover_challenger.sample();
+		let challenge: F = IPProverChannel::sample(&mut prover_channel);
 		round_prover.receive_challenge(challenge);
-
-		let fold_round_output = round_prover.execute_fold_round();
-		if let FoldRoundOutput::Commitment(round_commitment) = fold_round_output {
-			prover_challenger.message().write(&round_commitment);
-		}
+		round_prover.execute_fold_round(&mut prover_channel);
 	}
-	round_prover.finish_proof(&mut prover_challenger);
+	round_prover.finish_proof(&mut prover_channel);
+	drop(prover_channel);
 
-	// Run the verifier.
+	// Run the verifier, receiving commitments and openings over a Merkle channel.
 	let mut verifier_challenger = prover_challenger.into_verifier();
-	let read_commitments = commitments
+	let mut channel = VerifierMerkleTranscriptChannel::<_, StdChallenger, _, StdHashSuite>::new(
+		&mut verifier_challenger,
+	);
+	// Each input oracle's Merkle tree has one interleaved coset per leaf and depth equal to its
+	// own (possibly lifted) codeword dimension plus the inverse rate.
+	let read_commitments = params
+		.input_oracles()
 		.iter()
-		.map(|_| verifier_challenger.message().read().unwrap())
+		.map(|spec| {
+			let depth = (params.rs_code().log_dim() - spec.log_lift) + log_inv_rate;
+			channel
+				.recv_merkle_commitment(1 << spec.log_batch_size(), depth)
+				.unwrap()
+		})
 		.collect::<Vec<_>>();
 
 	let mut verifier_challenges = Vec::with_capacity(params.n_fold_rounds());
 	let mut fri_fold_verifier = FRIFoldVerifier::new(&params);
-	fri_fold_verifier
-		.process_round(&mut verifier_challenger.message())
-		.unwrap();
+	fri_fold_verifier.process_round(&mut channel).unwrap();
 	for _ in 0..params.n_fold_rounds() {
-		verifier_challenges.push(verifier_challenger.sample());
-		fri_fold_verifier
-			.process_round(&mut verifier_challenger.message())
-			.unwrap();
+		verifier_challenges.push(IPVerifierChannel::<F>::sample(&mut channel));
+		fri_fold_verifier.process_round(&mut channel).unwrap();
 	}
 	let round_commitments = fri_fold_verifier.finalize();
 
 	let verifier = FRIQueryVerifier::new_batch(
 		&params,
-		merkle_prover.scheme(),
 		&read_commitments,
 		&round_commitments,
 		&verifier_challenges,
 	);
-	let final_value = verifier.verify(&mut verifier_challenger).unwrap();
+	let final_value = verifier.verify(&mut channel).unwrap();
 
 	// The first-fold challenge slice is `[early ++ outer ++ later]`. Oracle `i` folds with
 	// `early_window ++ later_window`, the suffixes of the early and later groups of lengths
@@ -542,8 +517,6 @@ fn test_commit_prove_verify_lifted_multi_oracle() {
 	// The reduced (first-round) code dimension is the largest oracle dimension.
 	let reduced_log_dim = oracle_log_dims.iter().copied().max().unwrap();
 
-	let merkle_prover = BinaryMerkleTreeProver::<F, StdHashSuite>::new();
-
 	// A single shared domain context covers the reduced code; every per-oracle (smaller) code is
 	// derived from it so their subspaces are nested prefixes of the reduced subspace.
 	let subspace = BinarySubspace::with_dim(reduced_log_dim + log_inv_rate);
@@ -568,12 +541,15 @@ fn test_commit_prove_verify_lifted_multi_oracle() {
 	let params = FRIParams::<F>::new_batch(rs_code, oracle_specs, vec![], n_test_queries);
 	assert_eq!(params.rs_code().log_dim(), reduced_log_dim);
 
-	// Commit each input oracle's interleaved codeword separately, using its own smaller code built
-	// from the shared domain context.
+	// Encode each input oracle's interleaved codeword separately, using its own smaller code built
+	// from the shared domain context, and commit it over the channel.
+	let mut prover_challenger = ProverTranscript::new(StdChallenger::default());
+	let mut prover_channel =
+		ProverMerkleTranscriptChannel::<_, StdChallenger, _, StdHashSuite>::new(
+			&mut prover_challenger,
+		);
 	let mut messages = Vec::new();
-	let mut commitments = Vec::new();
-	let mut committeds = Vec::new();
-	let mut codewords = Vec::new();
+	let mut committed_codewords = Vec::new();
 	for (&log_dim, &log_batch_size) in iter::zip(&oracle_log_dims, &log_batch_sizes) {
 		let rs_code = ReedSolomonCode::with_domain_context_subspace(
 			ntt.domain_context(),
@@ -582,70 +558,59 @@ fn test_commit_prove_verify_lifted_multi_oracle() {
 		);
 		let oracle_params = FRIParams::new(rs_code, log_batch_size, vec![], n_test_queries);
 		let msg = random_field_buffer::<P>(&mut rng, log_dim + log_batch_size);
-		let CommitOutput {
-			commitment,
-			committed,
-			codeword,
-		} = commit_interleaved(&oracle_params, 0, &ntt, &merkle_prover, msg.to_ref());
+		let codeword = encode_interleaved(&oracle_params, 0, &ntt, msg.to_ref());
+		let commitment =
+			prover_channel.send_merkle_commitment(codeword.to_ref(), 1 << log_batch_size);
 		messages.push(msg);
-		commitments.push(commitment);
-		committeds.push(committed);
-		codewords.push(codeword);
+		committed_codewords.push((codeword, commitment));
 	}
 
-	// Run the prover: write the per-oracle codeword commitments, then fold.
-	let committed_codewords = iter::zip(codewords, &committeds).collect::<Vec<_>>();
-	let mut round_prover =
-		FRIFoldProver::new_batch(&params, &ntt, &merkle_prover, committed_codewords);
+	// Run the prover to fold the committed codewords.
+	let mut round_prover = FRIFoldProver::new_batch(&params, &ntt, committed_codewords);
 
-	let mut prover_challenger = ProverTranscript::new(StdChallenger::default());
-	for commitment in &commitments {
-		prover_challenger.message().write(commitment);
-	}
-
-	let fold_round_output = round_prover.execute_fold_round();
-	if let FoldRoundOutput::Commitment(round_commitment) = fold_round_output {
-		prover_challenger.message().write(&round_commitment);
-	}
+	round_prover.execute_fold_round(&mut prover_channel);
 	for _ in 0..params.n_fold_rounds() {
-		let challenge = prover_challenger.sample();
+		let challenge: F = IPProverChannel::sample(&mut prover_channel);
 		round_prover.receive_challenge(challenge);
-
-		let fold_round_output = round_prover.execute_fold_round();
-		if let FoldRoundOutput::Commitment(round_commitment) = fold_round_output {
-			prover_challenger.message().write(&round_commitment);
-		}
+		round_prover.execute_fold_round(&mut prover_channel);
 	}
-	round_prover.finish_proof(&mut prover_challenger);
+	round_prover.finish_proof(&mut prover_channel);
+	drop(prover_channel);
 
-	// Run the verifier.
+	// Run the verifier, receiving commitments and openings over a Merkle channel.
 	let mut verifier_challenger = prover_challenger.into_verifier();
-	let read_commitments = commitments
+	let mut channel = VerifierMerkleTranscriptChannel::<_, StdChallenger, _, StdHashSuite>::new(
+		&mut verifier_challenger,
+	);
+	// Each input oracle's Merkle tree has one interleaved coset per leaf and depth equal to its
+	// own (possibly lifted) codeword dimension plus the inverse rate.
+	let read_commitments = params
+		.input_oracles()
 		.iter()
-		.map(|_| verifier_challenger.message().read().unwrap())
+		.map(|spec| {
+			let depth = (params.rs_code().log_dim() - spec.log_lift) + log_inv_rate;
+			channel
+				.recv_merkle_commitment(1 << spec.log_batch_size(), depth)
+				.unwrap()
+		})
 		.collect::<Vec<_>>();
 
 	let mut verifier_challenges = Vec::with_capacity(params.n_fold_rounds());
 	let mut fri_fold_verifier = FRIFoldVerifier::new(&params);
-	fri_fold_verifier
-		.process_round(&mut verifier_challenger.message())
-		.unwrap();
+	fri_fold_verifier.process_round(&mut channel).unwrap();
 	for _ in 0..params.n_fold_rounds() {
-		verifier_challenges.push(verifier_challenger.sample());
-		fri_fold_verifier
-			.process_round(&mut verifier_challenger.message())
-			.unwrap();
+		verifier_challenges.push(IPVerifierChannel::<F>::sample(&mut channel));
+		fri_fold_verifier.process_round(&mut channel).unwrap();
 	}
 	let round_commitments = fri_fold_verifier.finalize();
 
 	let verifier = FRIQueryVerifier::new_batch(
 		&params,
-		merkle_prover.scheme(),
 		&read_commitments,
 		&round_commitments,
 		&verifier_challenges,
 	);
-	let final_value = verifier.verify(&mut verifier_challenger).unwrap();
+	let final_value = verifier.verify(&mut channel).unwrap();
 
 	// The first-fold challenge slice is `[early ++ outer ++ later]`. Every oracle is non-ZK here,
 	// so `max_early = 0` and the slice is `[outer ++ later]`. Oracle `i` folds with the
@@ -701,8 +666,6 @@ where
 {
 	let mut rng = StdRng::seed_from_u64(0);
 
-	let merkle_prover = BinaryMerkleTreeProver::<_, StdHashSuite>::new();
-
 	let committed_rs_code = ReedSolomonCode::<F>::new(log_dimension, log_inv_rate);
 
 	let n_test_queries = 3;
@@ -715,36 +678,30 @@ where
 
 	let msg = random_field_buffer::<P>(&mut rng, params.log_msg_len());
 
-	let CommitOutput {
-		commitment: codeword_commitment,
-		committed: codeword_committed,
-		codeword,
-	} = commit_interleaved(&params, 0, &ntt, &merkle_prover, msg.to_ref());
-
-	let mut round_prover =
-		FRIFoldProver::new(&params, &ntt, &merkle_prover, codeword, &codeword_committed);
+	let codeword = encode_interleaved(&params, 0, &ntt, msg.to_ref());
 
 	let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
-	prover_transcript.message().write(&codeword_commitment);
+	let mut prover_channel =
+		ProverMerkleTranscriptChannel::<_, StdChallenger, _, StdHashSuite>::new(
+			&mut prover_transcript,
+		);
+	let codeword_commitment =
+		prover_channel.send_merkle_commitment(codeword.to_ref(), 1 << log_batch_size);
 
-	let fold_round_output = round_prover.execute_fold_round();
-	if let FoldRoundOutput::Commitment(round_commitment) = fold_round_output {
-		prover_transcript.message().write(&round_commitment);
-	}
+	let mut round_prover = FRIFoldProver::new(&params, &ntt, codeword, codeword_commitment);
+
+	round_prover.execute_fold_round(&mut prover_channel);
 
 	for _ in 0..params.n_fold_rounds() {
-		let challenge = prover_transcript.sample();
+		let challenge: F = IPProverChannel::sample(&mut prover_channel);
 		round_prover.receive_challenge(challenge);
-
-		let fold_round_output = round_prover.execute_fold_round();
-		if let FoldRoundOutput::Commitment(round_commitment) = fold_round_output {
-			prover_transcript.message().write(&round_commitment);
-		}
+		round_prover.execute_fold_round(&mut prover_channel);
 	}
 
-	round_prover.finish_proof(&mut prover_transcript);
+	round_prover.finish_proof(&mut prover_channel);
+	drop(prover_channel);
 
-	let scheme = merkle_prover.scheme().clone();
+	let scheme = binius_iop::merkle_tree::BinaryMerkleTreeScheme::new();
 	let proof_bytes = prover_transcript.finalize();
 	(proof_bytes, params, scheme)
 }

--- a/crates/iop-prover/src/logup_star.rs
+++ b/crates/iop-prover/src/logup_star.rs
@@ -300,12 +300,13 @@ mod tests {
 	fn test_basefold_round_trip() {
 		use binius_field::PackedBinaryGhash1x128b;
 		use binius_hash::{StdDigest, StdHashSuite};
-		use binius_iop::{basefold_compiler::BaseFoldVerifierCompiler, fri::MinProofSizeStrategy};
+		use binius_iop::{
+			basefold_compiler::BaseFoldVerifierCompiler, fri::MinProofSizeStrategy,
+			merkle_tree::BinaryMerkleTreeScheme,
+		};
 		use binius_math::ntt::{NeighborsLastSingleThread, domain_context::GenericOnTheFly};
 
-		use crate::{
-			basefold_compiler::BaseFoldProverCompiler, merkle_tree::prover::BinaryMerkleTreeProver,
-		};
+		use crate::basefold_compiler::BaseFoldProverCompiler;
 
 		// The commitment field is the GHASH 128-bit field; use a single-lane packing for BaseFold.
 		type BP = PackedBinaryGhash1x128b;
@@ -321,9 +322,8 @@ mod tests {
 		let n_test_queries = SECURITY_BITS.div_ceil(LOG_INV_RATE);
 		let oracle_specs = vec![OracleSpec::new_zk(m)];
 
-		let merkle_prover = BinaryMerkleTreeProver::<F, StdHashSuite>::new();
 		let verifier_compiler = BaseFoldVerifierCompiler::new(
-			merkle_prover.scheme().clone(),
+			BinaryMerkleTreeScheme::<F, StdHashSuite>::new(),
 			oracle_specs,
 			LOG_INV_RATE,
 			n_test_queries,
@@ -334,11 +334,8 @@ mod tests {
 		let domain_context =
 			GenericOnTheFly::generate_from_subspace(verifier_compiler.max_subspace());
 		let ntt = NeighborsLastSingleThread::new(domain_context);
-		let prover_compiler = BaseFoldProverCompiler::<BP, _, _>::from_verifier_compiler(
-			&verifier_compiler,
-			ntt,
-			merkle_prover,
-		);
+		let prover_compiler =
+			BaseFoldProverCompiler::<BP, _, _>::from_verifier_compiler(&verifier_compiler, ntt);
 
 		let mut prover_transcript = ProverTranscript::new(Chal::default());
 		let prover_channel_rng = StdRng::seed_from_u64(8);

--- a/crates/iop-prover/src/merkle_tree/mod.rs
+++ b/crates/iop-prover/src/merkle_tree/mod.rs
@@ -1,4 +1,5 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 use binius_field::{Field, PackedField};
 use binius_iop::merkle_tree::{Commitment, MerkleTreeScheme};

--- a/crates/iop/Cargo.toml
+++ b/crates/iop/Cargo.toml
@@ -14,7 +14,6 @@ binius-ip = { path = "../ip" }
 binius-math = { path = "../math" }
 binius-transcript = { path = "../transcript" }
 binius-utils = { path = "../utils" }
-auto_impl.workspace = true
 bytes.workspace = true
 digest.workspace = true
 getset.workspace = true

--- a/crates/iop/src/basefold.rs
+++ b/crates/iop/src/basefold.rs
@@ -22,15 +22,11 @@
 
 use binius_field::{BinaryField, Field};
 use binius_ip::{mlecheck, sumcheck::RoundCoeffs};
-use binius_transcript::{
-	self as transcript, VerifierTranscript,
-	fiat_shamir::{CanSample, Challenger},
-};
-use binius_utils::{DeserializeBytes, checked_arithmetics::log2_ceil_usize};
+use binius_utils::checked_arithmetics::log2_ceil_usize;
 
 use crate::{
 	fri::{self, FRIFoldVerifier, FRIParams, verify::FRIQueryVerifier},
-	merkle_tree::MerkleTreeScheme,
+	merkle_channel::MerkleIPVerifierChannel,
 };
 
 /// Verifies a *combined* multilinear-evaluation BaseFold opening: a single degree-1 MLE-check
@@ -47,30 +43,31 @@ use crate::{
 ///
 /// ## Arguments
 ///
-/// * `codeword_commitments` - one per oracle, in the same order as [`FRIParams::input_oracles`].
+/// * `codeword_commitments` - one per oracle, in the same order as [`FRIParams::input_oracles`], as
+///   commitment handles previously received over `channel` (via
+///   [`MerkleIPVerifierChannel::recv_merkle_commitment`]).
 /// * `eval_claim` - the combined target `s'`.
 /// * `eval_point` - the point `r` (length `𝐧 = fri_params.rs_code().log_dim()`), low-to-high order.
 /// * `batch_challenge` - the masking challenge `γ` used in the FRI inner (unbatch) round.
 /// * `outer_challenges` - the batching challenges `r'` (length `log_n_oracles`) used in the FRI
 ///   outer (oracle-combine) rounds.
+/// * `channel` - the Merkle channel carrying all prover interaction: round coefficients,
+///   challenges, commitments, and query openings.
 ///
 /// The returned `challenges` are the FRI fold challenges `[γ] ++ r' ++ fresh_X`. Use
 /// [`mlecheck_fri_consistency`] to check the reduced values.
-#[allow(clippy::too_many_arguments)]
-pub fn verify_mlecheck_basefold<F, MTScheme, Challenger_>(
+pub fn verify_mlecheck_basefold<F, Channel>(
 	fri_params: &FRIParams<F>,
-	merkle_scheme: &MTScheme,
-	codeword_commitments: &[MTScheme::Digest],
+	codeword_commitments: &[Channel::Commitment],
 	eval_claim: F,
 	eval_point: &[F],
 	batch_challenge: Option<F>,
 	outer_challenges: &[F],
-	transcript: &mut VerifierTranscript<Challenger_>,
+	channel: &mut Channel,
 ) -> Result<ReducedOutput<F>, Error>
 where
 	F: BinaryField,
-	Challenger_: Challenger,
-	MTScheme: MerkleTreeScheme<F, Digest: DeserializeBytes>,
+	Channel: MerkleIPVerifierChannel<F, Elem = F>,
 {
 	// The MLE-check round polynomial is degree 1 (the composite is the multilinear itself).
 	const DEGREE: usize = 1;
@@ -93,7 +90,7 @@ where
 	// Inner (unbatch) round: fold every interleaved (π_i ‖ ω_i) ZK codeword at the masking
 	// challenge.
 	if let Some(gamma) = batch_challenge {
-		fri_fold_verifier.process_round(&mut transcript.message())?;
+		fri_fold_verifier.process_round(channel)?;
 		challenges.push(gamma);
 	}
 
@@ -103,7 +100,7 @@ where
 	// processed here (right after γ) to land in the outer window; the leading standard rounds then
 	// supply each non-ZK oracle's later batch fold.
 	for &outer_challenge in outer_challenges {
-		fri_fold_verifier.process_round(&mut transcript.message())?;
+		fri_fold_verifier.process_round(channel)?;
 		challenges.push(outer_challenge);
 	}
 
@@ -111,29 +108,28 @@ where
 	// fresh challenges over the `𝐧` variables `X`.
 	let mut sum = eval_claim;
 	for round in 0..n_vars {
-		let round_proof = mlecheck::RoundProof(RoundCoeffs(transcript.message().read_vec(DEGREE)?));
-		fri_fold_verifier.process_round(&mut transcript.message())?;
+		let round_proof = mlecheck::RoundProof(RoundCoeffs(channel.recv_many(DEGREE)?));
+		fri_fold_verifier.process_round(channel)?;
 
 		// MLE-check binds variables high-to-low, so round `i` uses coordinate `eval_point[n-1-i]`.
 		let alpha = eval_point[n_vars - 1 - round];
 		let round_coeffs = round_proof.recover(sum, alpha);
-		let challenge = transcript.sample();
+		let challenge = channel.sample();
 		sum = round_coeffs.evaluate(challenge);
 		challenges.push(challenge);
 	}
 
-	fri_fold_verifier.process_round(&mut transcript.message())?;
+	fri_fold_verifier.process_round(channel)?;
 	let round_commitments = fri_fold_verifier.finalize();
 
 	let fri_verifier = FRIQueryVerifier::new_batch(
 		fri_params,
-		merkle_scheme,
 		codeword_commitments,
 		&round_commitments,
 		&challenges,
 	);
 
-	let final_fri_value = fri_verifier.verify(transcript)?;
+	let final_fri_value = fri_verifier.verify(channel)?;
 
 	Ok(ReducedOutput {
 		final_fri_value,
@@ -163,8 +159,8 @@ pub fn mlecheck_fri_consistency<F: Field>(fri_final_oracle: F, sumcheck_final_cl
 pub enum Error {
 	#[error("FRI: {0}")]
 	FRI(#[source] fri::Error),
-	#[error("transcript: {0}")]
-	Transcript(#[from] transcript::Error),
+	#[error("IP channel: {0}")]
+	IPChannel(#[from] binius_ip::channel::Error),
 	#[error("verification error: {0}")]
 	Verification(#[from] VerificationError),
 }

--- a/crates/iop/src/basefold_channel.rs
+++ b/crates/iop/src/basefold_channel.rs
@@ -17,18 +17,14 @@ use binius_math::{
 	multilinear::eq::{eq_ind_partial_eval_scalars, eq_ind_zero},
 	univariate::evaluate_univariate,
 };
-use binius_transcript::{
-	VerifierTranscript,
-	fiat_shamir::{CanSample, Challenger},
-};
-use binius_utils::{DeserializeBytes, checked_arithmetics::log2_ceil_usize};
+use binius_utils::checked_arithmetics::log2_ceil_usize;
 use itertools::izip;
 
 use crate::{
 	basefold,
 	channel::{Error, IOPVerifierChannel, OracleLinearRelation, OracleSpec},
 	fri::FRIParams,
-	merkle_tree::MerkleTreeScheme,
+	merkle_channel::MerkleIPVerifierChannel,
 };
 
 /// Oracle handle returned by [`BaseFoldVerifierChannel::recv_oracle`].
@@ -46,55 +42,47 @@ pub struct BaseFoldOracle {
 ///
 /// - `'a`: Lifetime for borrowed references
 /// - `F`: The binary field type
-/// - `MerkleScheme_`: The Merkle tree scheme for commitments
-/// - `Challenger_`: The Fiat-Shamir challenger
-pub struct BaseFoldVerifierChannel<'a, F, MerkleScheme_, Challenger_>
+/// - `Channel`: The Merkle channel carrying all prover interaction
+pub struct BaseFoldVerifierChannel<'a, F, Channel>
 where
 	F: BinaryField,
-	MerkleScheme_: MerkleTreeScheme<F>,
-	Challenger_: Challenger,
+	Channel: MerkleIPVerifierChannel<F, Elem = F>,
 {
-	transcript: &'a mut VerifierTranscript<Challenger_>,
-	merkle_scheme: &'a MerkleScheme_,
+	/// The Merkle channel carrying all prover interaction: field elements, challenges,
+	/// commitments, and openings.
+	channel: Channel,
 	oracle_specs: &'a [OracleSpec],
 	fri_params: &'a FRIParams<F>,
-	oracle_commitments: Vec<MerkleScheme_::Digest>,
+	oracle_commitments: Vec<Channel::Commitment>,
 	/// Oracle relations queued by [`Self::verify_oracle_relations`], opened together in
 	/// [`Self::finish`].
 	queue: Vec<OracleLinearRelation<'a, BaseFoldOracle, F>>,
 	next_oracle_index: usize,
 }
 
-impl<'a, F, MerkleScheme_, Challenger_> BaseFoldVerifierChannel<'a, F, MerkleScheme_, Challenger_>
+impl<'a, F, Channel> BaseFoldVerifierChannel<'a, F, Channel>
 where
 	F: BinaryField,
-	MerkleScheme_: MerkleTreeScheme<F, Digest: DeserializeBytes>,
-	Challenger_: Challenger,
+	Channel: MerkleIPVerifierChannel<F, Elem = F>,
 {
-	/// Creates a new BaseFold ZK verifier channel from precomputed FRI parameters.
+	/// Creates a new BaseFold ZK verifier channel over a Merkle channel from precomputed FRI
+	/// parameters.
 	///
 	/// The FRI parameters should already account for ZK (log_batch_size = 1, doubled message
 	/// length).
-	pub const fn from_precomputed(
-		transcript: &'a mut VerifierTranscript<Challenger_>,
-		merkle_scheme: &'a MerkleScheme_,
+	pub const fn new(
+		channel: Channel,
 		oracle_specs: &'a [OracleSpec],
 		fri_params: &'a FRIParams<F>,
 	) -> Self {
 		Self {
-			transcript,
-			merkle_scheme,
+			channel,
 			oracle_specs,
 			fri_params,
 			oracle_commitments: Vec::new(),
 			queue: Vec::new(),
 			next_oracle_index: 0,
 		}
-	}
-
-	/// Returns a reference to the underlying transcript.
-	pub const fn transcript(&self) -> &VerifierTranscript<Challenger_> {
-		self.transcript
 	}
 
 	/// Consumes the channel and verifies the single combined opening over **all** committed
@@ -109,8 +97,7 @@ where
 	/// (`optimal_for_batch` over all oracle specs) serves the opening.
 	pub fn finish(self) -> Result<(), Error> {
 		let Self {
-			transcript,
-			merkle_scheme,
+			mut channel,
 			oracle_specs,
 			fri_params,
 			oracle_commitments,
@@ -125,23 +112,16 @@ where
 			return Ok(());
 		}
 
-		verify_batch_zk_basefold(
-			transcript,
-			merkle_scheme,
-			oracle_specs,
-			fri_params,
-			oracle_commitments,
-			queue,
-		)
+		verify_batch_zk_basefold(&mut channel, oracle_specs, fri_params, oracle_commitments, queue)
 	}
 }
 
 /// Verifies the combined ZK BaseFold opening over all committed oracles.
 ///
-/// This drives `channel` — the [`VerifierTranscript`] taken from the destructured
-/// [`BaseFoldVerifierChannel`] — through its [`IPVerifierChannel`] interface: it reads the masked
-/// inner products σ_i, runs one batched sumcheck reducing the masked claims to a shared point `r`,
-/// then opens all committed oracles together with a single combined FRI over the
+/// This drives `channel` — the Merkle channel taken from the destructured
+/// [`BaseFoldVerifierChannel`] — through its [`MerkleIPVerifierChannel`] interface: it reads the
+/// masked inner products σ_i, runs one batched sumcheck reducing the masked claims to a shared
+/// point `r`, then opens all committed oracles together with a single combined FRI over the
 /// piecewise-concatenated oracle.
 ///
 /// The masking inner products and the batched sumcheck process the `relations` in arrival order (so
@@ -153,22 +133,16 @@ where
 /// Phase B collapses the oracle-index variables up front at sampled batching challenges `r'`: the
 /// combined target is `s' = Σ_i e[i]·α_i·∏_{j≥n_i}(1 - r_j)` with `e = eq_ind_partial_eval(r')`,
 /// and the single combined FRI (`fri_params`) opens all `k` committed `[π_i ‖ ω_i]` codewords.
-///
-/// `channel` is the concrete [`VerifierTranscript`] rather than an arbitrary [`IPVerifierChannel`]
-/// because the Phase-B FRI openings read Merkle query proofs, which fall outside that interface.
-#[allow(clippy::too_many_arguments)]
-fn verify_batch_zk_basefold<F, MerkleScheme_, Challenger_>(
-	channel: &mut VerifierTranscript<Challenger_>,
-	merkle_scheme: &MerkleScheme_,
+fn verify_batch_zk_basefold<F, Channel>(
+	channel: &mut Channel,
 	oracle_specs: &[OracleSpec],
 	fri_params: &FRIParams<F>,
-	oracle_commitments: Vec<MerkleScheme_::Digest>,
+	oracle_commitments: Vec<Channel::Commitment>,
 	relations: Vec<OracleLinearRelation<'_, BaseFoldOracle, F>>,
 ) -> Result<(), Error>
 where
 	F: BinaryField,
-	MerkleScheme_: MerkleTreeScheme<F, Digest: DeserializeBytes>,
-	Challenger_: Challenger,
+	Channel: MerkleIPVerifierChannel<F, Elem = F>,
 {
 	let n_committed = oracle_commitments.len();
 
@@ -184,7 +158,7 @@ where
 	// the single shared γ. With no ZK oracle, γ is never sampled.
 	let n_zk = oracle_specs.iter().filter(|s| s.is_zk).count();
 	let sigmas = channel.recv_many(n_zk)?;
-	let gamma = (!sigmas.is_empty()).then(|| IPVerifierChannel::<F>::sample(channel));
+	let gamma = (!sigmas.is_empty()).then(|| channel.sample());
 
 	// Masked claim per relation: ZK → s_i' = extrapolate_line(claim, σ_i, γ); non-ZK → s_i' =
 	// claim.
@@ -259,7 +233,6 @@ where
 		..
 	} = basefold::verify_mlecheck_basefold(
 		fri_params,
-		merkle_scheme,
 		&oracle_commitments,
 		s_prime,
 		&point,
@@ -274,69 +247,50 @@ where
 	Ok(())
 }
 
-impl<F, MerkleScheme_, Challenger_> IPVerifierChannel<F>
-	for BaseFoldVerifierChannel<'_, F, MerkleScheme_, Challenger_>
+impl<F, Channel> IPVerifierChannel<F> for BaseFoldVerifierChannel<'_, F, Channel>
 where
 	F: BinaryField,
-	MerkleScheme_: MerkleTreeScheme<F, Digest: DeserializeBytes>,
-	Challenger_: Challenger,
+	Channel: MerkleIPVerifierChannel<F, Elem = F>,
 {
 	type Elem = F;
 
 	fn recv_one(&mut self) -> Result<F, binius_ip::channel::Error> {
-		self.transcript
-			.message()
-			.read_scalar()
-			.map_err(|_| binius_ip::channel::Error::ProofEmpty)
+		self.channel.recv_one()
 	}
 
 	fn recv_many(&mut self, n: usize) -> Result<Vec<F>, binius_ip::channel::Error> {
-		self.transcript
-			.message()
-			.read_scalar_slice(n)
-			.map_err(|_| binius_ip::channel::Error::ProofEmpty)
+		self.channel.recv_many(n)
 	}
 
 	fn recv_array<const N: usize>(&mut self) -> Result<[F; N], binius_ip::channel::Error> {
-		self.transcript
-			.message()
-			.read()
-			.map_err(|_| binius_ip::channel::Error::ProofEmpty)
+		self.channel.recv_array()
 	}
 
 	fn sample(&mut self) -> F {
-		CanSample::sample(&mut self.transcript)
+		self.channel.sample()
 	}
 
 	fn observe_one(&mut self, val: F) -> F {
-		self.transcript.observe().write_scalar(val);
-		val
+		self.channel.observe_one(val)
 	}
 
 	fn observe_many(&mut self, vals: &[F]) -> Vec<F> {
-		self.transcript.observe().write_scalar_slice(vals);
-		vals.to_vec()
+		self.channel.observe_many(vals)
 	}
 
 	fn assert_zero(&mut self, val: F) -> Result<(), binius_ip::channel::Error> {
-		if val == F::ZERO {
-			Ok(())
-		} else {
-			Err(binius_ip::channel::Error::InvalidAssert)
-		}
+		self.channel.assert_zero(val)
 	}
 
 	fn compute_public_value(&mut self, inputs: &[F], f: impl FieldFn<F>) -> F {
-		f.call::<F>(inputs)
+		self.channel.compute_public_value(inputs, f)
 	}
 }
 
-impl<'a, F, MerkleScheme_, Challenger_> IOPVerifierChannel<'a, F>
-	for BaseFoldVerifierChannel<'a, F, MerkleScheme_, Challenger_>
+impl<'a, F, Channel> IOPVerifierChannel<'a, F> for BaseFoldVerifierChannel<'a, F, Channel>
 where
 	F: BinaryField,
-	MerkleScheme_: MerkleTreeScheme<F, Digest: DeserializeBytes>,
-	Challenger_: Challenger,
+	Channel: MerkleIPVerifierChannel<F, Elem = F>,
 {
 	type Oracle = BaseFoldOracle;
 
@@ -358,10 +312,15 @@ where
 
 		let index = self.next_oracle_index;
 
+		// Receive the commitment with its Merkle tree shape, matching the prover-side commit: the
+		// oracle's codeword has dimension `log_dim - log_lift` and one interleaved coset of
+		// `2^log_batch_size` scalars per leaf.
+		let fri_oracle = &self.fri_params.input_oracles()[index];
+		let depth = (self.fri_params.rs_code().log_dim() - fri_oracle.log_lift)
+			+ self.fri_params.rs_code().log_inv_rate();
 		let commitment = self
-			.transcript
-			.message()
-			.read::<MerkleScheme_::Digest>()
+			.channel
+			.recv_merkle_commitment(1 << fri_oracle.log_batch_size(), depth)
 			.map_err(|_| Error::ProofEmpty)?;
 
 		self.oracle_commitments.push(commitment);

--- a/crates/iop/src/basefold_compiler.rs
+++ b/crates/iop/src/basefold_compiler.rs
@@ -6,15 +6,18 @@
 //! create verifier channel instances.
 
 use binius_field::BinaryField;
+use binius_hash::binary_merkle_tree::HashSuite;
 use binius_math::{BinarySubspace, ntt::domain_context::GenericOnTheFly};
 use binius_transcript::{VerifierTranscript, fiat_shamir::Challenger};
-use binius_utils::DeserializeBytes;
+use binius_utils::{DeserializeBytes, FixedSizeSerializeBytes};
+use digest::Output;
 
 use crate::{
 	basefold_channel::BaseFoldVerifierChannel,
 	channel::OracleSpec,
 	fri::{AritySelectionStrategy, FRIParams},
-	merkle_tree::MerkleTreeScheme,
+	merkle_channel::VerifierMerkleTranscriptChannel,
+	merkle_tree::BinaryMerkleTreeScheme,
 	size_tracking_channel::SizeTrackingChannel,
 };
 
@@ -23,21 +26,21 @@ use crate::{
 /// This compiler builds a single combined FRI over all oracles. ZK oracles configure FRI
 /// parameters for zero-knowledge mode (`log_msg_len + 1` as the message length and
 /// `log_batch_size = 1`); non-ZK oracles take a flexible batch size with no mask.
-#[derive(Debug, Clone)]
-pub struct BaseFoldVerifierCompiler<F, MerkleScheme_>
+#[derive(Clone)]
+pub struct BaseFoldVerifierCompiler<F, H>
 where
 	F: BinaryField,
-	MerkleScheme_: MerkleTreeScheme<F>,
+	H: HashSuite,
 {
-	merkle_scheme: MerkleScheme_,
+	merkle_scheme: BinaryMerkleTreeScheme<F, H>,
 	oracle_specs: Vec<OracleSpec>,
 	fri_params: FRIParams<F>,
 }
 
-impl<F, MerkleScheme_> BaseFoldVerifierCompiler<F, MerkleScheme_>
+impl<F, H> BaseFoldVerifierCompiler<F, H>
 where
 	F: BinaryField,
-	MerkleScheme_: MerkleTreeScheme<F>,
+	H: HashSuite,
 {
 	/// Creates a new compiler with precomputed combined FRI parameters.
 	///
@@ -45,7 +48,7 @@ where
 	/// (message ‖ equal-length mask), a non-ZK oracle takes a flexible batch size. Requires at
 	/// least one oracle spec.
 	pub fn new<Strategy>(
-		merkle_scheme: MerkleScheme_,
+		merkle_scheme: BinaryMerkleTreeScheme<F, H>,
 		oracle_specs: Vec<OracleSpec>,
 		log_inv_rate: usize,
 		n_test_queries: usize,
@@ -100,7 +103,7 @@ where
 	}
 
 	/// Returns a reference to the Merkle scheme.
-	pub const fn merkle_scheme(&self) -> &MerkleScheme_ {
+	pub const fn merkle_scheme(&self) -> &BinaryMerkleTreeScheme<F, H> {
 		&self.merkle_scheme
 	}
 
@@ -110,7 +113,9 @@ where
 	}
 
 	/// Creates a [`SizeTrackingChannel`] from this compiler's oracle specs.
-	pub fn create_size_tracking_channel(&self) -> SizeTrackingChannel<'_, F, MerkleScheme_> {
+	pub fn create_size_tracking_channel(
+		&self,
+	) -> SizeTrackingChannel<'_, F, BinaryMerkleTreeScheme<F, H>> {
 		SizeTrackingChannel::new(
 			self.oracle_specs.clone(),
 			std::slice::from_ref(&self.fri_params),
@@ -119,19 +124,32 @@ where
 	}
 
 	/// Creates a ZK verifier channel from this compiler and a transcript.
+	///
+	/// The returned channel drives all prover interaction through a
+	/// [`VerifierMerkleTranscriptChannel`] over the transcript, constructed here with a scheme
+	/// matching this compiler's Merkle scheme.
 	pub fn create_channel<'a, Challenger_>(
 		&'a self,
 		transcript: &'a mut VerifierTranscript<Challenger_>,
-	) -> BaseFoldVerifierChannel<'a, F, MerkleScheme_, Challenger_>
+	) -> BaseFoldTranscriptVerifierChannel<'a, F, H, Challenger_>
 	where
-		MerkleScheme_::Digest: DeserializeBytes,
+		F: FixedSizeSerializeBytes,
+		Output<H::LeafHash>: DeserializeBytes,
 		Challenger_: Challenger,
 	{
-		BaseFoldVerifierChannel::from_precomputed(
-			transcript,
-			&self.merkle_scheme,
-			&self.oracle_specs,
-			&self.fri_params,
-		)
+		// `BinaryMerkleTreeScheme` is fully determined by its salt length, so reconstructing with
+		// the compiler's salt length reproduces the scheme.
+		let scheme = BinaryMerkleTreeScheme::hiding(self.merkle_scheme.salt_len());
+		let channel = VerifierMerkleTranscriptChannel::with_scheme(transcript, scheme);
+		BaseFoldVerifierChannel::new(channel, &self.oracle_specs, &self.fri_params)
 	}
 }
+
+/// The [`BaseFoldVerifierChannel`] type produced by
+/// [`BaseFoldVerifierCompiler::create_channel`]: a BaseFold channel over a
+/// [`VerifierMerkleTranscriptChannel`] borrowing the transcript.
+pub type BaseFoldTranscriptVerifierChannel<'a, F, H, Challenger_> = BaseFoldVerifierChannel<
+	'a,
+	F,
+	VerifierMerkleTranscriptChannel<&'a mut VerifierTranscript<Challenger_>, Challenger_, F, H>,
+>;

--- a/crates/iop/src/fri/batch.rs
+++ b/crates/iop/src/fri/batch.rs
@@ -1,21 +1,24 @@
 // Copyright 2026 The Binius Developers
 
+use std::iter;
+
 use binius_field::BinaryField;
 use binius_math::{line::extrapolate_line, multilinear, ntt::DomainContext};
-use binius_transcript::TranscriptReader;
-use binius_utils::{DeserializeBytes, FixedSizeSerializeBytes};
-use bytes::Buf;
 
-use crate::merkle_tree::{Commitment, MerkleTreeScheme};
+use crate::merkle_channel::MerkleIPVerifierChannel;
 /// A virtual oracle for a code proximity test.
 ///
 /// The interactive code proximity tests used in this project (eg. FRI) commit to a codeword and
 /// then interactively fold it with random challenges. This trait represents the resulting *virtual
 /// oracle*: the folded codeword, whose values are not committed directly but are instead recovered
 /// on demand by opening the committed oracle at the queried indices and applying the folding. An
-/// implementation therefore holds the committed oracle along with the folding challenges, and
-/// verifies decommitted prover advice in order to evaluate the virtual oracle at queried locations.
+/// implementation therefore holds a handle to the committed oracle along with the folding
+/// challenges, and receives openings over a Merkle channel in order to evaluate the virtual oracle
+/// at queried locations.
 pub trait ProxTestOracle<F: BinaryField> {
+	/// The Merkle commitment handle for the committed oracle.
+	type Commitment;
+
 	/// The base-2 logarithm of the length of the virtual oracle.
 	///
 	/// The virtual oracle is defined by the committed oracle and the folding challenges. Indices
@@ -33,65 +36,62 @@ pub trait ProxTestOracle<F: BinaryField> {
 	/// ## Returns
 	/// The values of the virtual oracle at the queried indices. The virtual oracle is defined by
 	/// the committed oracle and the folding challenges.
-	fn open_queries<B: Buf>(
+	fn open_queries<Channel>(
 		&self,
 		indices: &[usize],
-		advice: &mut TranscriptReader<B>,
-	) -> Result<Vec<F>, Error>;
+		channel: &mut Channel,
+	) -> Result<Vec<F>, Error>
+	where
+		Channel: MerkleIPVerifierChannel<F, Commitment = Self::Commitment>;
 }
 
 /// A [ProxTestOracle] implementation for a [Brakedown]-style interleaved code proximity check.
 ///
 /// [Brakedown]: <https://dl.acm.org/doi/10.1007/978-3-031-38545-2_7>
-pub struct BrakedownOracle<F, MTScheme>
-where
-	F: FixedSizeSerializeBytes,
-	MTScheme: MerkleTreeScheme<F>,
-{
+pub struct BrakedownOracle<F, C> {
 	challenges: Vec<F>,
-	commitment: Commitment<MTScheme::Digest>,
-	merkle_scheme: MTScheme,
+	commitment: C,
+	/// The depth of the committed Merkle tree.
+	depth: usize,
 	/// log2 the lift factor (oracle padding). The committed codeword is virtually duplicated
 	/// `2^log_lift` times to reach the common first-round length; a query at global index `k`
 	/// reads the committed codeword at `k >> log_lift`. Zero when no lifting is needed.
 	log_lift: usize,
 }
 
-impl<F: BinaryField, MTScheme: MerkleTreeScheme<F>> BrakedownOracle<F, MTScheme> {
+impl<F: BinaryField, C> BrakedownOracle<F, C> {
 	/// Constructs a new oracle from the committed interleaved codeword and the folding challenges.
 	///
-	/// `log_lift` is the oracle-padding lift factor (the committed codeword is virtually duplicated
-	/// `2^log_lift` times to reach the common first-round length); pass `0` when no lifting is
-	/// needed.
-	pub const fn new(
-		challenges: Vec<F>,
-		commitment: Commitment<MTScheme::Digest>,
-		merkle_scheme: MTScheme,
-		log_lift: usize,
-	) -> Self {
+	/// `depth` is the depth of the committed Merkle tree. `log_lift` is the oracle-padding lift
+	/// factor (the committed codeword is virtually duplicated `2^log_lift` times to reach the
+	/// common first-round length); pass `0` when no lifting is needed.
+	pub const fn new(challenges: Vec<F>, commitment: C, depth: usize, log_lift: usize) -> Self {
 		Self {
 			challenges,
 			commitment,
-			merkle_scheme,
+			depth,
 			log_lift,
 		}
 	}
 }
 
-impl<F: BinaryField, MTScheme: MerkleTreeScheme<F, Digest: DeserializeBytes>> ProxTestOracle<F>
-	for BrakedownOracle<F, MTScheme>
-{
+impl<F: BinaryField, C> ProxTestOracle<F> for BrakedownOracle<F, C> {
+	type Commitment = C;
+
 	fn log_len(&self) -> usize {
 		// The virtual (lifted) oracle length: the committed tree depth duplicated `2^log_lift`
 		// times.
-		self.commitment.depth + self.log_lift
+		self.depth + self.log_lift
 	}
 
-	fn open_queries<B: Buf>(
+	fn open_queries<Channel>(
 		&self,
 		indices: &[usize],
-		advice: &mut TranscriptReader<B>,
-	) -> Result<Vec<F>, Error> {
+		channel: &mut Channel,
+	) -> Result<Vec<F>, Error>
+	where
+		Channel: MerkleIPVerifierChannel<F, Commitment = C>,
+	{
 		assert!(indices.iter().all(|&index| index < 1 << self.log_len())); // precondition
 		// Translate each query on the virtual lifted oracle into a query on the committed codeword
 		// by dropping the low `log_lift` bits (the duplicated copies).
@@ -99,19 +99,14 @@ impl<F: BinaryField, MTScheme: MerkleTreeScheme<F, Digest: DeserializeBytes>> Pr
 			.iter()
 			.map(|&index| index >> self.log_lift)
 			.collect::<Vec<_>>();
-		verify_query_openings(
-			&self.merkle_scheme,
-			&self.commitment,
-			self.challenges.len(),
-			&lifted_indices,
-			advice,
-		)?
-		.map(|opening| {
-			let (_index, values) = opening?;
-			// Fold the coset using a multilinear tensor fold over the challenges.
-			Ok(multilinear::evaluate::evaluate_inplace_scalars(values, &self.challenges))
-		})
-		.collect()
+		let values = channel.recv_openings(&self.commitment, &lifted_indices)?;
+		Ok(values
+			.chunks(1 << self.challenges.len())
+			.map(|coset| {
+				// Fold the coset using a multilinear tensor fold over the challenges.
+				multilinear::evaluate::evaluate_inplace_scalars(coset.to_vec(), &self.challenges)
+			})
+			.collect())
 	}
 }
 
@@ -123,18 +118,14 @@ impl<F: BinaryField, MTScheme: MerkleTreeScheme<F, Digest: DeserializeBytes>> Pr
 /// are combined as `\sum_i values_i[q] * outer_tensor[i]`, where
 /// `outer_tensor = eq_ind_partial_eval(outer_challenges)`. This mirrors the prover's
 /// `BatchBrakedownFolder::fold`.
-pub struct BatchBrakedownOracle<F, MTScheme>
-where
-	F: FixedSizeSerializeBytes,
-	MTScheme: MerkleTreeScheme<F>,
-{
-	oracles: Vec<BrakedownOracle<F, MTScheme>>,
+pub struct BatchBrakedownOracle<F, C> {
+	oracles: Vec<BrakedownOracle<F, C>>,
 	outer_challenges: Vec<F>,
 }
 
-impl<F: BinaryField, MTScheme: MerkleTreeScheme<F>> BatchBrakedownOracle<F, MTScheme> {
+impl<F: BinaryField, C> BatchBrakedownOracle<F, C> {
 	/// Constructs a batch oracle from the per-commitment oracles and the batching challenges.
-	pub fn new(oracles: Vec<BrakedownOracle<F, MTScheme>>, outer_challenges: Vec<F>) -> Self {
+	pub fn new(oracles: Vec<BrakedownOracle<F, C>>, outer_challenges: Vec<F>) -> Self {
 		assert!(!oracles.is_empty()); // precondition
 		Self {
 			oracles,
@@ -143,9 +134,9 @@ impl<F: BinaryField, MTScheme: MerkleTreeScheme<F>> BatchBrakedownOracle<F, MTSc
 	}
 }
 
-impl<F: BinaryField, MTScheme: MerkleTreeScheme<F, Digest: DeserializeBytes>> ProxTestOracle<F>
-	for BatchBrakedownOracle<F, MTScheme>
-{
+impl<F: BinaryField, C> ProxTestOracle<F> for BatchBrakedownOracle<F, C> {
+	type Commitment = C;
+
 	fn log_len(&self) -> usize {
 		// Every bundled oracle reports the same virtual (lifted) length: the common first-round
 		// codeword length they are batched into.
@@ -157,18 +148,21 @@ impl<F: BinaryField, MTScheme: MerkleTreeScheme<F, Digest: DeserializeBytes>> Pr
 		self.oracles[0].log_len()
 	}
 
-	fn open_queries<B: Buf>(
+	fn open_queries<Channel>(
 		&self,
 		indices: &[usize],
-		advice: &mut TranscriptReader<B>,
-	) -> Result<Vec<F>, Error> {
-		// Read each bundled oracle's openings in commit order (matching the prover), then combine
-		// across oracles by the outer-challenge tensor expansion:
+		channel: &mut Channel,
+	) -> Result<Vec<F>, Error>
+	where
+		Channel: MerkleIPVerifierChannel<F, Commitment = C>,
+	{
+		// Receive each bundled oracle's openings in commit order (matching the prover), then
+		// combine across oracles by the outer-challenge tensor expansion:
 		// combined[q] = \sum_i values_i[q] * outer_tensor[i].
 		let outer_tensor = multilinear::eq::eq_ind_partial_eval::<F>(&self.outer_challenges);
 		let mut combined = vec![F::ZERO; indices.len()];
 		for (oracle, &scalar) in self.oracles.iter().zip(outer_tensor.as_ref()) {
-			let values = oracle.open_queries(indices, advice)?;
+			let values = oracle.open_queries(indices, channel)?;
 			for (acc, value) in combined.iter_mut().zip(values) {
 				*acc += value * scalar;
 			}
@@ -182,36 +176,31 @@ impl<F: BinaryField, MTScheme: MerkleTreeScheme<F, Digest: DeserializeBytes>> Pr
 /// Note that this is distinct from the full FRI query-phase verifier in the `verify` module. This
 /// one only verifies the openings of a single committed oracle and folds each opened coset into a
 /// single value using FRI folding.
-pub struct FRIOracle<F, MTScheme, DC>
+pub struct FRIOracle<F, C, DC>
 where
-	F: FixedSizeSerializeBytes,
-	MTScheme: MerkleTreeScheme<F>,
 	DC: DomainContext<Field = F>,
 {
 	challenges: Vec<F>,
-	commitment: Commitment<MTScheme::Digest>,
-	merkle_scheme: MTScheme,
+	commitment: C,
+	/// The depth of the committed Merkle tree.
+	depth: usize,
 	domain_context: DC,
 }
 
-impl<F, MTScheme, DC> FRIOracle<F, MTScheme, DC>
+impl<F, C, DC> FRIOracle<F, C, DC>
 where
 	F: BinaryField,
-	MTScheme: MerkleTreeScheme<F>,
 	DC: DomainContext<Field = F>,
 {
 	/// Constructs a new oracle from a committed oracle, its folding challenges, and the domain
 	/// context providing the FRI fold twiddles.
-	pub const fn new(
-		challenges: Vec<F>,
-		commitment: Commitment<MTScheme::Digest>,
-		merkle_scheme: MTScheme,
-		domain_context: DC,
-	) -> Self {
+	///
+	/// `depth` is the depth of the committed Merkle tree.
+	pub const fn new(challenges: Vec<F>, commitment: C, depth: usize, domain_context: DC) -> Self {
 		Self {
 			challenges,
 			commitment,
-			merkle_scheme,
+			depth,
 			domain_context,
 		}
 	}
@@ -229,7 +218,7 @@ where
 	fn fold_coset(&self, chunk_index: usize, values: Vec<F>) -> F {
 		fold_coset(
 			&self.domain_context,
-			self.commitment.depth + self.challenges.len(),
+			self.depth + self.challenges.len(),
 			chunk_index,
 			&self.challenges,
 			values,
@@ -276,10 +265,9 @@ where
 	values[0]
 }
 
-impl<F, MTScheme, DC> FRIOracle<F, MTScheme, DC>
+impl<F, C, DC> FRIOracle<F, C, DC>
 where
 	F: BinaryField,
-	MTScheme: MerkleTreeScheme<F, Digest: DeserializeBytes>,
 	DC: DomainContext<Field = F>,
 {
 	/// Opens queried locations on the base codeword, reducing claims about it to the virtual
@@ -298,12 +286,15 @@ where
 	///
 	/// ## Returns
 	/// The values of the virtual oracle at the queried coset indices.
-	pub fn reduce_queries<B: Buf>(
+	pub fn reduce_queries<Channel>(
 		&self,
 		indices: &[usize],
 		claims: &[F],
-		advice: &mut TranscriptReader<B>,
-	) -> Result<Vec<F>, Error> {
+		channel: &mut Channel,
+	) -> Result<Vec<F>, Error>
+	where
+		Channel: MerkleIPVerifierChannel<F, Commitment = C>,
+	{
 		assert_eq!(indices.len(), claims.len()); // precondition
 		assert!(
 			indices
@@ -318,103 +309,51 @@ where
 			.map(|&index| index >> coset_log_size)
 			.collect::<Vec<_>>();
 
-		verify_query_openings(
-			&self.merkle_scheme,
-			&self.commitment,
-			coset_log_size,
-			&coset_indices,
-			advice,
-		)?
-		.zip(indices.iter().zip(claims))
-		.map(|(opening, (&index, &claim))| {
-			let (coset_index, values) = opening?;
-			// Verify the claimed base-codeword value against the opened coset.
-			if values[index & coset_mask] != claim {
-				return Err(Error::ClaimMismatch { index });
-			}
-			Ok(self.fold_coset(coset_index, values))
-		})
-		.collect()
+		let values = channel.recv_openings(&self.commitment, &coset_indices)?;
+		iter::zip(values.chunks(1 << coset_log_size), iter::zip(&coset_indices, indices))
+			.zip(claims)
+			.map(|((coset, (&coset_index, &index)), &claim)| {
+				// Verify the claimed base-codeword value against the opened coset.
+				if coset[index & coset_mask] != claim {
+					return Err(Error::ClaimMismatch { index });
+				}
+				Ok(self.fold_coset(coset_index, coset.to_vec()))
+			})
+			.collect()
 	}
 }
 
-impl<F, MTScheme, DC> ProxTestOracle<F> for FRIOracle<F, MTScheme, DC>
+impl<F, C, DC> ProxTestOracle<F> for FRIOracle<F, C, DC>
 where
 	F: BinaryField,
-	MTScheme: MerkleTreeScheme<F, Digest: DeserializeBytes>,
 	DC: DomainContext<Field = F>,
 {
+	type Commitment = C;
+
 	fn log_len(&self) -> usize {
-		self.commitment.depth
+		self.depth
 	}
 
-	fn open_queries<B: Buf>(
+	fn open_queries<Channel>(
 		&self,
 		indices: &[usize],
-		advice: &mut TranscriptReader<B>,
-	) -> Result<Vec<F>, Error> {
+		channel: &mut Channel,
+	) -> Result<Vec<F>, Error>
+	where
+		Channel: MerkleIPVerifierChannel<F, Commitment = C>,
+	{
 		assert!(indices.iter().all(|&index| index < 1 << self.log_len())); // precondition
-		verify_query_openings(
-			&self.merkle_scheme,
-			&self.commitment,
-			self.challenges.len(),
-			indices,
-			advice,
-		)?
-		.map(|opening| {
-			let (index, values) = opening?;
-			Ok(self.fold_coset(index, values))
-		})
-		.collect()
+		let values = channel.recv_openings(&self.commitment, indices)?;
+		Ok(iter::zip(values.chunks(1 << self.coset_log_size()), indices)
+			.map(|(coset, &index)| self.fold_coset(index, coset.to_vec()))
+			.collect())
 	}
-}
-
-/// Verifies the Merkle openings shared by the [ProxTestOracle] implementations.
-///
-/// First decommits and verifies the optimal internal layer of the Merkle tree, then returns a lazy
-/// iterator that, for each queried index, reads the opened coset of `1 << coset_log_size` values
-/// from the advice and verifies its opening against that layer. Each item is the queried index
-/// paired with the verified coset values.
-fn verify_query_openings<'a, F, MTScheme, B>(
-	merkle_scheme: &'a MTScheme,
-	commitment: &'a Commitment<MTScheme::Digest>,
-	coset_log_size: usize,
-	indices: &'a [usize],
-	advice: &'a mut TranscriptReader<B>,
-) -> Result<impl Iterator<Item = Result<(usize, Vec<F>), Error>> + 'a, Error>
-where
-	F: BinaryField,
-	MTScheme: MerkleTreeScheme<F, Digest: DeserializeBytes>,
-	B: Buf,
-{
-	let tree_depth = commitment.depth;
-	let layer_depth = merkle_scheme.optimal_verify_layer(indices.len(), tree_depth);
-	let layer_digests = advice.read_vec(1 << layer_depth)?;
-	merkle_scheme.verify_layer(&commitment.root, layer_depth, &layer_digests)?;
-
-	let openings = indices.iter().map(move |&index| {
-		// Receive the codeword symbols of the coset at the index and verify their consistency with
-		// the commitment.
-		let values = advice.read_scalar_slice::<F>(1 << coset_log_size)?;
-		merkle_scheme.verify_opening(
-			index,
-			&values,
-			layer_depth,
-			tree_depth,
-			&layer_digests,
-			advice,
-		)?;
-		Ok((index, values))
-	});
-	Ok(openings)
 }
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
 	#[error("claimed value at index {index} does not match the committed codeword")]
 	ClaimMismatch { index: usize },
-	#[error("Merkle tree error: {0}")]
-	Merkle(#[from] crate::merkle_tree::Error),
-	#[error("transcript error: {0}")]
-	Transcript(#[from] binius_transcript::Error),
+	#[error("Merkle channel error: {0}")]
+	Channel(#[from] crate::merkle_channel::Error),
 }

--- a/crates/iop/src/fri/error.rs
+++ b/crates/iop/src/fri/error.rs
@@ -1,23 +1,24 @@
 // Copyright 2024-2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 use super::batch;
-use crate::merkle_tree;
+use crate::{merkle_channel, merkle_tree};
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-	#[error("Merkle tree error: {0}")]
-	MerkleError(merkle_tree::Error),
+	#[error("Merkle channel error: {0}")]
+	Channel(merkle_channel::Error),
 	#[error("Reed-Solomon encoding error: {0}")]
 	Verification(#[from] VerificationError),
-	#[error("transcript error: {0}")]
-	TranscriptError(#[from] binius_transcript::Error),
 }
 
-impl From<merkle_tree::Error> for Error {
-	fn from(err: merkle_tree::Error) -> Self {
+impl From<merkle_channel::Error> for Error {
+	fn from(err: merkle_channel::Error) -> Self {
 		match err {
-			merkle_tree::Error::Verification(err) => Self::Verification(err.into()),
-			_ => Self::MerkleError(err),
+			merkle_channel::Error::MerkleTree(merkle_tree::Error::Verification(err)) => {
+				Self::Verification(err.into())
+			}
+			_ => Self::Channel(err),
 		}
 	}
 }
@@ -25,8 +26,7 @@ impl From<merkle_tree::Error> for Error {
 impl From<batch::Error> for Error {
 	fn from(err: batch::Error) -> Self {
 		match err {
-			batch::Error::Merkle(err) => err.into(),
-			batch::Error::Transcript(err) => Self::TranscriptError(err),
+			batch::Error::Channel(err) => err.into(),
 			batch::Error::ClaimMismatch { index } => VerificationError::IncorrectFold {
 				query_round: 0,
 				index,

--- a/crates/iop/src/fri/fold.rs
+++ b/crates/iop/src/fri/fold.rs
@@ -1,4 +1,5 @@
 // Copyright 2024-2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 use std::iter;
 
@@ -6,11 +7,9 @@ use binius_field::{BinaryField, ExtensionField, Field, PackedField};
 use binius_math::{
 	inner_product::inner_product_packed, line::extrapolate_line_packed, ntt::AdditiveNTT,
 };
-use binius_transcript::TranscriptReader;
-use binius_utils::DeserializeBytes;
-use bytes::Buf;
 
 use super::{FRIParams, error::Error};
+use crate::merkle_channel::MerkleIPVerifierChannel;
 
 /// Calculate fold of `values` at `index` with `r` random coefficient.
 ///
@@ -129,34 +128,37 @@ where
 	inner_product_packed(log_batch_size, values.iter().copied(), tensor.iter().copied())
 }
 
-/// A stateful verifier for the FRI fold phase that tracks when to read commitments.
+/// A stateful verifier for the FRI fold phase that tracks when to receive commitments.
 ///
 /// This verifier encapsulates the logic of determining which FRI rounds require
-/// commitments and handles reading them from the transcript at the appropriate times.
-pub struct FRIFoldVerifier<'a, F, Digest>
+/// commitments and handles receiving them over the Merkle channel at the appropriate times. It is
+/// parameterized by the channel's Merkle commitment handle type `C`.
+pub struct FRIFoldVerifier<'a, F, C>
 where
 	F: BinaryField,
 {
-	/// Indicates which rounds require reading a commitment
+	/// Indicates which rounds require receiving a commitment
 	commit_rounds: Vec<bool>,
-	/// The round commitments read from the transcript
-	round_commitments: Vec<Digest>,
+	/// The `(leaf_size, depth)` Merkle tree shape of each expected commitment, matching the
+	/// prover's fold-phase commits.
+	commitment_shapes: Vec<(usize, usize)>,
+	/// The round commitments received over the channel
+	round_commitments: Vec<C>,
 	/// Current round number
 	curr_round: usize,
 	_phantom: std::marker::PhantomData<&'a F>,
 }
 
-impl<'a, F, Digest> FRIFoldVerifier<'a, F, Digest>
+impl<'a, F, C> FRIFoldVerifier<'a, F, C>
 where
 	F: BinaryField,
-	Digest: DeserializeBytes + Clone,
+	C: Clone,
 {
 	/// Creates a new FRI fold verifier.
 	///
 	/// ## Arguments
 	///
 	/// * `params` - The FRI parameters
-	/// * `n_rounds` - The total number of folding rounds (typically equals n_vars for sumcheck)
 	pub fn new(params: &'a FRIParams<F>) -> Self {
 		let commit_rounds = calculate_fri_commit_rounds(
 			params.log_batch_size(),
@@ -166,28 +168,42 @@ where
 
 		let expected_oracles = params.n_oracles();
 
+		// The prover commits each folded codeword with one coset of the *next* fold's arity per
+		// leaf, so commitment `j` has `2^arity_j` scalars per leaf and depth `index_bits` minus the
+		// arities folded so far. The last commitment is the terminal codeword, with one coset of
+		// `2^n_final_challenges` scalars per leaf and one leaf per codeword symbol position, i.e.
+		// depth `log_inv_rate`.
+		let mut commitment_shapes = Vec::with_capacity(expected_oracles);
+		let mut depth = params.index_bits();
+		for &arity in params.fold_arities() {
+			depth -= arity;
+			commitment_shapes.push((1 << arity, depth));
+		}
+		commitment_shapes.push((1 << params.n_final_challenges(), params.rs_code().log_inv_rate()));
+
 		Self {
 			commit_rounds,
+			commitment_shapes,
 			round_commitments: Vec::with_capacity(expected_oracles),
 			curr_round: 0,
 			_phantom: std::marker::PhantomData,
 		}
 	}
 
-	/// Processes the next round, reading a commitment from the transcript if needed.
+	/// Processes the next round, receiving a commitment over the channel if needed.
 	///
 	/// ## Arguments
 	///
-	/// * `transcript` - The transcript to read the commitment from (if needed)
+	/// * `channel` - The channel to receive the commitment from (if needed)
 	///
 	/// ## Returns
 	///
-	/// * `Ok(Some(commitment))` if a commitment was read in this round
+	/// * `Ok(Some(commitment))` if a commitment was received in this round
 	/// * `Ok(None)` if no commitment was needed in this round
-	pub fn process_round<B: Buf>(
-		&mut self,
-		transcript: &mut TranscriptReader<B>,
-	) -> Result<Option<Digest>, Error> {
+	pub fn process_round<Channel>(&mut self, channel: &mut Channel) -> Result<Option<C>, Error>
+	where
+		Channel: MerkleIPVerifierChannel<F, Commitment = C>,
+	{
 		assert!(
 			self.curr_round < self.n_rounds(),
 			"precondition: process_round must not be called more than n_rounds() times"
@@ -195,7 +211,8 @@ where
 
 		let needs_commitment = self.commit_rounds[self.curr_round];
 		let commitment = if needs_commitment {
-			let commitment: Digest = transcript.read()?;
+			let (leaf_size, depth) = self.commitment_shapes[self.round_commitments.len()];
+			let commitment = channel.recv_merkle_commitment(leaf_size, depth)?;
 			self.round_commitments.push(commitment.clone());
 			Some(commitment)
 		} else {
@@ -225,7 +242,7 @@ where
 	/// ## Returns
 	///
 	/// The collected round commitments
-	pub fn finalize(self) -> Vec<Digest> {
+	pub fn finalize(self) -> Vec<C> {
 		assert!(
 			self.is_complete(),
 			"precondition: all fold rounds must be processed before finalize"

--- a/crates/iop/src/fri/verify.rs
+++ b/crates/iop/src/fri/verify.rs
@@ -5,19 +5,14 @@ use std::iter::{self, repeat_with};
 
 use binius_field::BinaryField;
 use binius_math::ntt::domain_context::GenericOnTheFly;
-use binius_transcript::{
-	TranscriptReader, VerifierTranscript,
-	fiat_shamir::{CanSampleBits, Challenger},
-};
-use binius_utils::{DeserializeBytes, checked_arithmetics::log2_ceil_usize};
-use bytes::Buf;
+use binius_utils::checked_arithmetics::log2_ceil_usize;
 
 use super::{
 	batch::{BatchBrakedownOracle, BrakedownOracle, FRIOracle, ProxTestOracle, fold_coset},
 	common::FRIParams,
 	error::{Error, VerificationError},
 };
-use crate::merkle_tree::{Commitment, MerkleTreeScheme};
+use crate::merkle_channel::MerkleIPVerifierChannel;
 
 /// A verifier for the FRI query phase.
 ///
@@ -27,39 +22,37 @@ use crate::merkle_tree::{Commitment, MerkleTreeScheme};
 /// Internally, this is a composition of `ProxTestOracle`s: a `BatchBrakedownOracle` performs
 /// the first, interleaved reduction of the committed codeword(s), then one `FRIOracle` per fold
 /// arity performs each subsequent FRI reduction. The verifier orchestrates the consistency checks
-/// between these oracles and the final, fully-folded terminal codeword.
-pub struct FRIQueryVerifier<'a, F, VCS>
+/// between these oracles and the final, fully-folded terminal codeword. The oracles are
+/// parameterized by the Merkle commitment handle type `C` of the channel that receives the query
+/// openings.
+pub struct FRIQueryVerifier<'a, F, C>
 where
 	F: BinaryField,
-	VCS: MerkleTreeScheme<F>,
 {
 	params: &'a FRIParams<F>,
-	vcs: &'a VCS,
 	/// Commitment to the fully-folded terminal codeword, sent in full by the prover.
-	terminal_commitment: &'a VCS::Digest,
+	terminal_commitment: C,
 	/// The folding challenges applied after the last committed oracle.
 	final_challenges: &'a [F],
 	/// Performs the first, interleaved reduction of the committed codeword(s).
-	codeword_oracle: BatchBrakedownOracle<F, &'a VCS>,
+	codeword_oracle: BatchBrakedownOracle<F, C>,
 	/// Performs each subsequent FRI reduction, one per fold arity.
-	fri_oracles: Vec<FRIOracle<F, &'a VCS, GenericOnTheFly<F>>>,
+	fri_oracles: Vec<FRIOracle<F, C, GenericOnTheFly<F>>>,
 }
 
-impl<'a, F, VCS> FRIQueryVerifier<'a, F, VCS>
+impl<'a, F, C> FRIQueryVerifier<'a, F, C>
 where
 	F: BinaryField,
-	VCS: MerkleTreeScheme<F, Digest: DeserializeBytes>,
+	C: Clone,
 {
 	pub fn new(
 		params: &'a FRIParams<F>,
-		vcs: &'a VCS,
-		codeword_commitment: &'a VCS::Digest,
-		round_commitments: &'a [VCS::Digest],
+		codeword_commitment: &C,
+		round_commitments: &[C],
 		challenges: &'a [F],
 	) -> Self {
 		Self::new_batch(
 			params,
-			vcs,
 			std::slice::from_ref(codeword_commitment),
 			round_commitments,
 			challenges,
@@ -81,9 +74,8 @@ where
 	///   `params.rs_code().log_dim()`.
 	pub fn new_batch(
 		params: &'a FRIParams<F>,
-		vcs: &'a VCS,
-		codeword_commitments: &'a [VCS::Digest],
-		round_commitments: &'a [VCS::Digest],
+		codeword_commitments: &[C],
+		round_commitments: &[C],
 		challenges: &'a [F],
 	) -> Self {
 		assert_eq!(
@@ -152,15 +144,7 @@ where
 				let later_window = &later_challenges[max_later - spec.log_later_batch_size..];
 				let fold_challenges: Vec<F> =
 					early_window.iter().chain(later_window).copied().collect();
-				BrakedownOracle::new(
-					fold_challenges,
-					Commitment {
-						root: commitment.clone(),
-						depth,
-					},
-					vcs,
-					log_lift,
-				)
+				BrakedownOracle::new(fold_challenges, commitment.clone(), depth, log_lift)
 			})
 			.collect();
 		let codeword_oracle = BatchBrakedownOracle::new(codeword_sub_oracles, outer_challenges);
@@ -175,11 +159,8 @@ where
 			depth -= arity;
 			fri_oracles.push(FRIOracle::new(
 				challenges[fold_round..fold_round + arity].to_vec(),
-				Commitment {
-					root: round_commitment.clone(),
-					depth,
-				},
-				vcs,
+				round_commitment.clone(),
+				depth,
 				domain_context.clone(),
 			));
 			fold_round += arity;
@@ -188,11 +169,11 @@ where
 		let final_challenges = &challenges[fold_round..];
 		let terminal_commitment = round_commitments
 			.last()
-			.expect("round_commitments is non-empty as an invariant");
+			.expect("round_commitments is non-empty as an invariant")
+			.clone();
 
 		Self {
 			params,
-			vcs,
 			terminal_commitment,
 			final_challenges,
 			codeword_oracle,
@@ -205,70 +186,61 @@ where
 		self.params.n_oracles()
 	}
 
-	pub fn verify<Challenger_>(
-		&self,
-		transcript: &mut VerifierTranscript<Challenger_>,
-	) -> Result<F, Error>
+	pub fn verify<Channel>(&self, channel: &mut Channel) -> Result<F, Error>
 	where
-		Challenger_: Challenger,
+		Channel: MerkleIPVerifierChannel<F, Commitment = C>,
 	{
 		// Sample all query indices up front to facilitate batched Merkle openings.
-		let mut indices = repeat_with(|| transcript.sample_bits(self.params.index_bits()) as usize)
+		let mut indices = repeat_with(|| channel.sample_bits(self.params.index_bits()))
 			.take(self.params.n_test_queries())
 			.collect::<Vec<_>>();
 
-		// Open and reduce the queries through each oracle in turn, reading the per-oracle batched
-		// openings from a single continuous decommitment stream.
-		let mut advice = transcript.decommitment();
-		let mut claims = self.codeword_oracle.open_queries(&indices, &mut advice)?;
+		// Open and reduce the queries through each oracle in turn, receiving the per-oracle
+		// batched openings over the channel.
+		let mut claims = self.codeword_oracle.open_queries(&indices, channel)?;
 		for (query_round, (oracle, &arity)) in self
 			.fri_oracles
 			.iter()
 			.zip(self.params.fold_arities())
 			.enumerate()
 		{
-			claims = oracle
-				.reduce_queries(&indices, &claims, &mut advice)
-				.map_err(|err| match err {
-					super::batch::Error::ClaimMismatch { index } => {
-						VerificationError::IncorrectFold { query_round, index }.into()
-					}
-					err => Error::from(err),
-				})?;
+			claims =
+				oracle
+					.reduce_queries(&indices, &claims, channel)
+					.map_err(|err| match err {
+						super::batch::Error::ClaimMismatch { index } => {
+							VerificationError::IncorrectFold { query_round, index }.into()
+						}
+						err => Error::from(err),
+					})?;
 			for index in &mut indices {
 				*index >>= arity;
 			}
 		}
 
 		// Check the fully-reduced queries against the terminal codeword sent in full.
-		self.verify_terminal_queries(&claims, &indices, &mut advice)
+		self.verify_terminal_queries(&claims, &indices, channel)
 	}
 
 	/// Verifies the terminal codeword the prover sends in full at the end of the query phase.
 	///
-	/// Reads the terminal codeword from the transcript and checks it against its commitment, then
+	/// Receives the terminal codeword over the channel, checked against its commitment, then
 	/// checks that the fully-reduced query `claims` match it at the queried `indices`. Finally it
 	/// folds each coset of the terminal codeword and checks they are equal, i.e. that it is a
 	/// repetition codeword of the claimed low degree, and returns the fully-folded message value.
-	fn verify_terminal_queries<B: Buf>(
+	fn verify_terminal_queries<Channel>(
 		&self,
 		claims: &[F],
 		indices: &[usize],
-		advice: &mut TranscriptReader<B>,
-	) -> Result<F, Error> {
+		channel: &mut Channel,
+	) -> Result<F, Error>
+	where
+		Channel: MerkleIPVerifierChannel<F, Commitment = C>,
+	{
 		let n_final_challenges = self.params.n_final_challenges();
 		let log_inv_rate = self.params.rs_code().log_inv_rate();
-		let terminate_codeword_len = 1 << (n_final_challenges + log_inv_rate);
 
-		let terminate_codeword = advice
-			.read_scalar_slice::<F>(terminate_codeword_len)
-			.map_err(Error::TranscriptError)?;
-		self.vcs.verify_vector(
-			self.terminal_commitment,
-			&terminate_codeword,
-			1 << n_final_challenges,
-			advice,
-		)?;
+		let terminate_codeword = channel.recv_committed_vector(&self.terminal_commitment)?;
 
 		// Check the fully-reduced claims against the terminal codeword the verifier holds in full.
 		for (&claim, &index) in iter::zip(claims, indices) {

--- a/crates/iop/src/merkle_tree/merkle_tree_vcs.rs
+++ b/crates/iop/src/merkle_tree/merkle_tree_vcs.rs
@@ -1,6 +1,6 @@
 // Copyright 2024-2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
-use auto_impl::auto_impl;
 use binius_transcript::{Buf, TranscriptReader};
 use binius_utils::FixedSizeSerializeBytes;
 
@@ -19,7 +19,6 @@ pub struct Commitment<Digest> {
 }
 
 /// A Merkle tree scheme.
-#[auto_impl(&)]
 pub trait MerkleTreeScheme<T: FixedSizeSerializeBytes> {
 	type Digest: Clone + PartialEq + Eq;
 

--- a/crates/m4-prover/src/prove.rs
+++ b/crates/m4-prover/src/prove.rs
@@ -1,11 +1,9 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 use binius_field::PackedField;
 use binius_hash::StdHashSuite;
-use binius_iop_prover::{
-	basefold_compiler::BaseFoldProverCompiler, channel::IOPProverChannel,
-	merkle_tree::prover::BinaryMerkleTreeProver,
-};
+use binius_iop_prover::{basefold_compiler::BaseFoldProverCompiler, channel::IOPProverChannel};
 use binius_ip_prover::channel::IPProverChannel;
 use binius_m4_verifier::{BatchCommitLayout, Verifier};
 use binius_math::{
@@ -21,9 +19,6 @@ use crate::ValueTable;
 /// The multithreaded additive NTT used to encode the committed codeword.
 type ProverNtt = NeighborsLastMultiThread<GenericPreExpanded<B128>>;
 
-/// The Merkle prover used to commit the codeword.
-type ProverMerkle = BinaryMerkleTreeProver<B128, StdHashSuite>;
-
 /// Proves a batch-witness commitment opened at a verifier-chosen random point.
 ///
 /// Setup builds the BaseFold prover once, reusing the verifier's FRI parameters.
@@ -35,7 +30,7 @@ where
 	/// The committed-multilinear shape of the batch, shared with the verifier.
 	layout: BatchCommitLayout,
 	/// The precomputed BaseFold prover, holding the NTT and the Merkle prover.
-	basefold_compiler: BaseFoldProverCompiler<P, ProverNtt, ProverMerkle>,
+	basefold_compiler: BaseFoldProverCompiler<P, ProverNtt, StdHashSuite>,
 }
 
 impl<P> Prover<P>
@@ -55,14 +50,9 @@ where
 		let log_num_shares = binius_utils::rayon::current_num_threads().ilog2() as usize;
 		let ntt = NeighborsLastMultiThread::new(domain_context, log_num_shares);
 
-		let merkle_prover = ProverMerkle::new();
-
 		// Inherit the verifier's oracle specs and FRI parameters verbatim.
-		let basefold_compiler = BaseFoldProverCompiler::from_verifier_compiler(
-			verifier.iop_compiler(),
-			ntt,
-			merkle_prover,
-		);
+		let basefold_compiler =
+			BaseFoldProverCompiler::from_verifier_compiler(verifier.iop_compiler(), ntt);
 
 		Self {
 			layout: *verifier.layout(),

--- a/crates/m4-verifier/src/verify.rs
+++ b/crates/m4-verifier/src/verify.rs
@@ -1,4 +1,5 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 use binius_core::constraint_system::ConstraintSystem;
 use binius_hash::StdHashSuite;
@@ -34,7 +35,7 @@ pub struct Verifier {
 	/// The committed-multilinear shape of the batch.
 	layout: BatchCommitLayout,
 	/// The precomputed BaseFold verifier, holding the Merkle scheme and FRI parameters.
-	iop_compiler: BaseFoldVerifierCompiler<B128, Scheme>,
+	iop_compiler: BaseFoldVerifierCompiler<B128, StdHashSuite>,
 }
 
 impl Verifier {
@@ -85,7 +86,7 @@ impl Verifier {
 	/// The precomputed BaseFold verifier compiler.
 	///
 	/// The prover reuses it so both sides share one set of FRI parameters.
-	pub const fn iop_compiler(&self) -> &BaseFoldVerifierCompiler<B128, Scheme> {
+	pub const fn iop_compiler(&self) -> &BaseFoldVerifierCompiler<B128, StdHashSuite> {
 		&self.iop_compiler
 	}
 

--- a/crates/prover/benches/intmul.rs
+++ b/crates/prover/benches/intmul.rs
@@ -4,10 +4,9 @@ use binius_field::{BinaryField128bGhash, Field, PackedBinaryGhash1x128b};
 use binius_hash::StdHashSuite;
 use binius_iop::{
 	basefold_compiler::BaseFoldVerifierCompiler, channel::OracleSpec, fri::MinProofSizeStrategy,
+	merkle_tree::BinaryMerkleTreeScheme,
 };
-use binius_iop_prover::{
-	basefold_compiler::BaseFoldProverCompiler, merkle_tree::prover::BinaryMerkleTreeProver,
-};
+use binius_iop_prover::basefold_compiler::BaseFoldProverCompiler;
 use binius_ip_prover::{
 	prodcheck::ProdcheckProver,
 	sumcheck::{
@@ -54,14 +53,10 @@ const LOG_ORACLE_LEN: usize = 16;
 /// encoding and Merkle tree construction) is measured; a naive channel would serialize
 /// oracles for free. The final batched opening in `finish` is not measured, since the full
 /// system amortizes it into the single opening shared with the witness trace.
-fn basefold_compiler() -> BaseFoldProverCompiler<
-	P,
-	NeighborsLastSingleThread<GenericPreExpanded<F>>,
-	BinaryMerkleTreeProver<F, StdHashSuite>,
-> {
-	let merkle_prover = BinaryMerkleTreeProver::<F, StdHashSuite>::new();
+fn basefold_compiler()
+-> BaseFoldProverCompiler<P, NeighborsLastSingleThread<GenericPreExpanded<F>>, StdHashSuite> {
 	let verifier_compiler = BaseFoldVerifierCompiler::new(
-		merkle_prover.scheme().clone(),
+		BinaryMerkleTreeScheme::<F, StdHashSuite>::new(),
 		vec![OracleSpec::new(LOG_ORACLE_LEN)],
 		LOG_INV_RATE,
 		N_TEST_QUERIES,
@@ -70,7 +65,7 @@ fn basefold_compiler() -> BaseFoldProverCompiler<
 	let domain_context =
 		GenericPreExpanded::generate_from_subspace(verifier_compiler.max_subspace());
 	let ntt = NeighborsLastSingleThread::new(domain_context);
-	BaseFoldProverCompiler::from_verifier_compiler(&verifier_compiler, ntt, merkle_prover)
+	BaseFoldProverCompiler::from_verifier_compiler(&verifier_compiler, ntt)
 }
 
 fn generate_test_data(log_num: usize) -> (Vec<Word>, Vec<Word>, Vec<Word>, Vec<Word>) {

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -9,10 +9,7 @@ use binius_field::{
 	AESTowerField8b as B8, BinaryField, ExtensionField, Field, PackedExtension, PackedField,
 };
 use binius_hash::binary_merkle_tree::HashSuite;
-use binius_iop_prover::{
-	basefold_channel::BaseFoldProverChannel, basefold_compiler::BaseFoldProverCompiler,
-	channel::IOPProverChannel,
-};
+use binius_iop_prover::{basefold_compiler::BaseFoldProverCompiler, channel::IOPProverChannel};
 use binius_ip::sumcheck::SumcheckOutput;
 use binius_math::{
 	BinarySubspace, FieldBuffer, FieldSlice,
@@ -31,12 +28,10 @@ use binius_verifier::{
 	protocols::{bitand::AndCheckOutput, intmul::IntMulOutput},
 };
 use digest::Output;
-use rand::{SeedableRng, rngs::StdRng};
 
 use super::error::Error;
 use crate::{
 	and_reduction::prover::OblongZerocheckProver,
-	merkle_tree::prover::BinaryMerkleTreeProver,
 	protocols::{
 		intmul::{prove::IntMulProver, witness::Witness as IntMulWitness},
 		shift::{
@@ -48,9 +43,6 @@ use crate::{
 
 /// Type alias for the prover NTT parameterized by field.
 type ProverNTT<F> = NeighborsLastMultiThread<GenericPreExpanded<F>>;
-
-/// Type alias for the prover Merkle tree prover parameterized by field.
-type ProverMerkleProver<F, H> = BinaryMerkleTreeProver<F, H>;
 
 /// IOP prover for a particular constraint system.
 ///
@@ -280,7 +272,7 @@ where
 	H: HashSuite,
 {
 	iop_prover: IOPProver,
-	basefold_compiler: BaseFoldProverCompiler<P, ProverNTT<B128>, ProverMerkleProver<B128, H>>,
+	basefold_compiler: BaseFoldProverCompiler<P, ProverNTT<B128>, H>,
 }
 
 impl<P, H> Prover<P, H>
@@ -314,14 +306,9 @@ where
 		let log_num_shares = binius_utils::rayon::current_num_threads().ilog2() as usize;
 		let ntt = NeighborsLastMultiThread::new(domain_context, log_num_shares);
 
-		let merkle_prover = BinaryMerkleTreeProver::<_, H>::new();
-
 		// Create prover compiler from verifier compiler (reuses FRI params and oracle specs)
-		let basefold_compiler = BaseFoldProverCompiler::from_verifier_compiler(
-			verifier.iop_compiler(),
-			ntt,
-			merkle_prover,
-		);
+		let basefold_compiler =
+			BaseFoldProverCompiler::from_verifier_compiler(verifier.iop_compiler(), ntt);
 
 		let iop_prover = IOPProver::new(verifier.into_iop_verifier(), key_collection);
 
@@ -361,9 +348,7 @@ where
 		// Create channel, delegate to IOPProver::prove, then finish it. The unified channel takes
 		// an rng to mask ZK oracles, but a plain `Prover` produces a transparent proof whose only
 		// oracle is non-ZK, so no masks are drawn and the rng is never consumed.
-		let rng = StdRng::seed_from_u64(0);
-		let mut channel =
-			BaseFoldProverChannel::from_compiler(&self.basefold_compiler, transcript, rng);
+		let mut channel = self.basefold_compiler.create_channel_without_zk(transcript);
 		self.iop_prover.prove::<P, _>(witness, &mut channel)?;
 		channel.finish();
 		Ok(())

--- a/crates/prover/src/zk_config.rs
+++ b/crates/prover/src/zk_config.rs
@@ -22,12 +22,10 @@ use rand::CryptoRng;
 
 use crate::{
 	IOPProver,
-	merkle_tree::prover::BinaryMerkleTreeProver,
 	protocols::shift::{KeyCollection, build_key_collection},
 };
 
 type ProverNTT<F> = NeighborsLastMultiThread<GenericPreExpanded<F>>;
-type ProverMerkleProver<F, H> = BinaryMerkleTreeProver<F, H>;
 
 /// Zero-knowledge prover for Binius64 constraint systems.
 ///
@@ -42,7 +40,7 @@ where
 	inner_iop_verifier: IOPVerifier,
 	outer_iop_prover: binius_spartan_prover::IOPProver<B128>,
 	outer_layout: WitnessLayout<B128>,
-	basefold_compiler: BaseFoldProverCompiler<P, ProverNTT<B128>, ProverMerkleProver<B128, H>>,
+	basefold_compiler: BaseFoldProverCompiler<P, ProverNTT<B128>, H>,
 }
 
 impl<P, H> ZKProver<P, H>
@@ -91,12 +89,8 @@ where
 		};
 		let log_num_shares = binius_utils::rayon::current_num_threads().ilog2() as usize;
 		let ntt = NeighborsLastMultiThread::new(domain_context, log_num_shares);
-		let merkle_prover = BinaryMerkleTreeProver::<_, H>::new();
-		let basefold_compiler = BaseFoldProverCompiler::from_verifier_compiler(
-			zk_verifier.basefold_compiler(),
-			ntt,
-			merkle_prover,
-		);
+		let basefold_compiler =
+			BaseFoldProverCompiler::from_verifier_compiler(zk_verifier.basefold_compiler(), ntt);
 
 		Ok(Self {
 			inner_iop_prover,

--- a/crates/spartan-prover/src/lib.rs
+++ b/crates/spartan-prover/src/lib.rs
@@ -38,10 +38,7 @@ use std::{
 
 use binius_field::{BinaryField, Field, PackedExtension, PackedField};
 use binius_hash::binary_merkle_tree::HashSuite;
-use binius_iop_prover::{
-	basefold_compiler::BaseFoldProverCompiler, channel::IOPProverChannel,
-	merkle_tree::prover::BinaryMerkleTreeProver,
-};
+use binius_iop_prover::{basefold_compiler::BaseFoldProverCompiler, channel::IOPProverChannel};
 use binius_ip_prover::{
 	channel::IPProverChannel,
 	sumcheck::{quadratic_mle::QuadraticMleCheckProver, zk_mlecheck},
@@ -74,7 +71,6 @@ use rand::CryptoRng;
 use crate::wiring::{WiringTranspose, fold_constraints};
 
 type ProverNTT<F> = NeighborsLastMultiThread<GenericPreExpanded<F>>;
-type ProverMerkleProver<F, H> = BinaryMerkleTreeProver<F, H>;
 
 /// IOP prover for a particular constraint system.
 ///
@@ -99,8 +95,7 @@ where
 	H: HashSuite,
 {
 	iop_prover: IOPProver<P::Scalar>,
-	basefold_compiler:
-		BaseFoldProverCompiler<P, ProverNTT<P::Scalar>, ProverMerkleProver<P::Scalar, H>>,
+	basefold_compiler: BaseFoldProverCompiler<P, ProverNTT<P::Scalar>, H>,
 }
 
 impl<F: Field> IOPProver<F> {
@@ -338,15 +333,10 @@ where
 		let domain_context = GenericPreExpanded::generate_from_subspace(subspace);
 		let ntt = NeighborsLastMultiThread::new(domain_context, log_num_shares);
 
-		let merkle_prover = BinaryMerkleTreeProver::<_, H>::new();
-
 		// Create the BaseFold ZK compiler from verifier compiler (reuses oracle_specs and
 		// fri_params)
-		let basefold_compiler = BaseFoldProverCompiler::from_verifier_compiler(
-			verifier.iop_compiler(),
-			ntt,
-			merkle_prover,
-		);
+		let basefold_compiler =
+			BaseFoldProverCompiler::from_verifier_compiler(verifier.iop_compiler(), ntt);
 
 		let iop_prover = IOPProver::new(verifier.constraint_system().clone());
 
@@ -362,9 +352,7 @@ where
 	}
 
 	/// Returns a reference to the BaseFold ZK prover compiler.
-	pub const fn iop_compiler(
-		&self,
-	) -> &BaseFoldProverCompiler<P, ProverNTT<F>, ProverMerkleProver<F, H>> {
+	pub const fn iop_compiler(&self) -> &BaseFoldProverCompiler<P, ProverNTT<F>, H> {
 		&self.basefold_compiler
 	}
 

--- a/crates/spartan-prover/src/wrapper/zk_wrapped_prover_channel.rs
+++ b/crates/spartan-prover/src/wrapper/zk_wrapped_prover_channel.rs
@@ -14,18 +14,16 @@
 use std::iter::repeat_with;
 
 use binius_field::{BinaryField, PackedExtension, PackedField};
-use binius_iop::{channel::OracleSpec, merkle_tree::MerkleTreeScheme};
+use binius_iop::channel::OracleSpec;
 use binius_iop_prover::{
 	basefold_channel::{BaseFoldOracle, BaseFoldProverChannel},
 	channel::IOPProverChannel,
-	merkle_tree::MerkleTreeProver,
+	merkle_channel::MerkleIPProverChannel,
 };
 use binius_ip_prover::channel::IPProverChannel;
 use binius_math::{FieldBuffer, FieldSlice, ntt::AdditiveNTT};
 use binius_spartan_frontend::constraint_system::{BlindingInfo, WitnessLayout};
 use binius_spartan_verifier::IOPVerifier;
-use binius_transcript::fiat_shamir::Challenger;
-use binius_utils::SerializeBytes;
 use rand::CryptoRng;
 
 use crate::{Error, IOPProver, pack_and_blind_witness, wrapper::ReplayChannel};
@@ -41,14 +39,13 @@ use crate::{Error, IOPProver, pack_and_blind_witness, wrapper::ReplayChannel};
 /// The `ReplayFn` closure is called during [`finish`](Self::finish) with a [`ReplayChannel`] to
 /// replay the inner verification and fill the outer witness. This allows the channel to be generic
 /// over different inner verification protocols.
-pub struct ZKWrappedProverChannel<'a, P, NTT, MTProver, Challenger_, ReplayFn>
+pub struct ZKWrappedProverChannel<'a, P, NTT, Channel, ReplayFn>
 where
 	P: PackedField<Scalar: BinaryField>,
 	NTT: AdditiveNTT<Field = P::Scalar> + Sync,
-	MTProver: MerkleTreeProver<P::Scalar>,
-	Challenger_: Challenger,
+	Channel: MerkleIPProverChannel<P::Scalar>,
 {
-	inner_channel: BaseFoldProverChannel<'a, P::Scalar, P, NTT, MTProver, Challenger_>,
+	inner_channel: BaseFoldProverChannel<'a, P::Scalar, P, NTT, Channel>,
 	outer_prover: &'a IOPProver<P::Scalar>,
 	outer_layout: &'a WitnessLayout<P::Scalar>,
 	replay_fn: ReplayFn,
@@ -66,15 +63,12 @@ where
 	n_outer_suffix_oracles: usize,
 }
 
-impl<'a, F, P, NTT, MTScheme, MTProver, Challenger_, ReplayFn>
-	ZKWrappedProverChannel<'a, P, NTT, MTProver, Challenger_, ReplayFn>
+impl<'a, F, P, NTT, Channel, ReplayFn> ZKWrappedProverChannel<'a, P, NTT, Channel, ReplayFn>
 where
 	F: BinaryField,
 	P: PackedField<Scalar = F> + PackedExtension<F>,
 	NTT: AdditiveNTT<Field = F> + Sync,
-	MTScheme: MerkleTreeScheme<F, Digest: SerializeBytes>,
-	MTProver: MerkleTreeProver<F, Scheme = MTScheme>,
-	Challenger_: Challenger,
+	Channel: MerkleIPProverChannel<F>,
 {
 	/// Creates a new ZK-wrapped prover channel.
 	///
@@ -96,7 +90,7 @@ where
 	/// * `replay_fn` - Closure called during [`finish`](Self::finish) with a [`ReplayChannel`] to
 	///   replay the inner verification and fill the outer witness
 	pub fn new(
-		mut inner_channel: BaseFoldProverChannel<'a, F, P, NTT, MTProver, Challenger_>,
+		mut inner_channel: BaseFoldProverChannel<'a, F, P, NTT, Channel>,
 		outer_prover: &'a IOPProver<F>,
 		outer_layout: &'a WitnessLayout<F>,
 		rng: impl CryptoRng,
@@ -146,7 +140,7 @@ where
 	/// inner verifier) contains a matching precommit wire per key that the outer proof uses to
 	/// decrypt.
 	fn commit_transcript_mask(
-		inner_channel: &mut BaseFoldProverChannel<'a, F, P, NTT, MTProver, Challenger_>,
+		inner_channel: &mut BaseFoldProverChannel<'a, F, P, NTT, Channel>,
 		outer_prover: &IOPProver<F>,
 		mut rng: impl CryptoRng,
 	) -> (Vec<F>, BaseFoldOracle, FieldBuffer<P>) {
@@ -225,15 +219,13 @@ where
 	}
 }
 
-impl<F, P, NTT, MTScheme, MTProver, Challenger_, ReplayFn> IPProverChannel<F>
-	for ZKWrappedProverChannel<'_, P, NTT, MTProver, Challenger_, ReplayFn>
+impl<F, P, NTT, Channel, ReplayFn> IPProverChannel<F>
+	for ZKWrappedProverChannel<'_, P, NTT, Channel, ReplayFn>
 where
 	F: BinaryField,
 	P: PackedField<Scalar = F> + PackedExtension<F>,
 	NTT: AdditiveNTT<Field = F> + Sync,
-	MTScheme: MerkleTreeScheme<F, Digest: SerializeBytes>,
-	MTProver: MerkleTreeProver<F, Scheme = MTScheme>,
-	Challenger_: Challenger,
+	Channel: MerkleIPProverChannel<F>,
 {
 	fn send_one(&mut self, elem: F) {
 		let key = self.next_key();
@@ -257,15 +249,13 @@ where
 	}
 }
 
-impl<F, P, NTT, MTScheme, MTProver, Challenger_, ReplayFn> IOPProverChannel<P>
-	for ZKWrappedProverChannel<'_, P, NTT, MTProver, Challenger_, ReplayFn>
+impl<F, P, NTT, Channel, ReplayFn> IOPProverChannel<P>
+	for ZKWrappedProverChannel<'_, P, NTT, Channel, ReplayFn>
 where
 	F: BinaryField,
 	P: PackedField<Scalar = F> + PackedExtension<F>,
 	NTT: AdditiveNTT<Field = F> + Sync,
-	MTScheme: MerkleTreeScheme<F, Digest: SerializeBytes>,
-	MTProver: MerkleTreeProver<F, Scheme = MTScheme>,
-	Challenger_: Challenger,
+	Channel: MerkleIPProverChannel<F>,
 {
 	type Oracle = BaseFoldOracle;
 

--- a/crates/spartan-prover/tests/wrapper_integration_test.rs
+++ b/crates/spartan-prover/tests/wrapper_integration_test.rs
@@ -8,9 +8,7 @@ use binius_iop::{
 	fri::{self, MinProofSizeStrategy},
 	merkle_tree::BinaryMerkleTreeScheme,
 };
-use binius_iop_prover::{
-	basefold_compiler::BaseFoldProverCompiler, merkle_tree::prover::BinaryMerkleTreeProver,
-};
+use binius_iop_prover::basefold_compiler::BaseFoldProverCompiler;
 use binius_ip::channel::IPVerifierChannel;
 use binius_ip_prover::channel::IPProverChannel;
 use binius_math::ntt::{NeighborsLastSingleThread, domain_context::GenericOnTheFly};
@@ -116,9 +114,8 @@ fn test_zk_wrapped_prove_verify() {
 	let subspace = zk_basefold_compiler.max_subspace();
 	let domain_context = GenericOnTheFly::generate_from_subspace(subspace);
 	let ntt = NeighborsLastSingleThread::new(domain_context);
-	let merkle_prover = BinaryMerkleTreeProver::<_, StdHashSuite>::new();
 	let zk_basefold_prover: BaseFoldProverCompiler<OptimalPackedB128, _, _> =
-		BaseFoldProverCompiler::from_verifier_compiler(&zk_basefold_compiler, ntt, merkle_prover);
+		BaseFoldProverCompiler::from_verifier_compiler(&zk_basefold_compiler, ntt);
 
 	// === Step 6: Generate inner witness ===
 	let mut rng = StdRng::seed_from_u64(0);

--- a/crates/spartan-verifier/src/lib.rs
+++ b/crates/spartan-verifier/src/lib.rs
@@ -93,7 +93,7 @@ where
 {
 	iop_verifier: IOPVerifier<F>,
 	/// BaseFold ZK compiler for creating verifier channels.
-	basefold_compiler: BaseFoldVerifierCompiler<F, BinaryMerkleTreeScheme<F, H>>,
+	basefold_compiler: BaseFoldVerifierCompiler<F, H>,
 }
 
 impl<F: Field> IOPVerifier<F> {
@@ -309,7 +309,7 @@ where
 	}
 
 	/// Returns a reference to the BaseFold ZK verifier compiler.
-	pub const fn iop_compiler(&self) -> &BaseFoldVerifierCompiler<F, BinaryMerkleTreeScheme<F, H>> {
+	pub const fn iop_compiler(&self) -> &BaseFoldVerifierCompiler<F, H> {
 		&self.basefold_compiler
 	}
 

--- a/crates/spartan-verifier/src/wrapper/zk_wrapped_channel.rs
+++ b/crates/spartan-verifier/src/wrapper/zk_wrapped_channel.rs
@@ -17,15 +17,13 @@ use binius_field::{BinaryField, util::FieldFn};
 use binius_iop::{
 	basefold_channel::{BaseFoldOracle, BaseFoldVerifierChannel},
 	channel::{IOPVerifierChannel, OracleLinearRelation, OracleSpec},
-	merkle_tree::MerkleTreeScheme,
+	merkle_channel::MerkleIPVerifierChannel,
 };
 use binius_ip::channel::IPVerifierChannel;
 use binius_spartan_frontend::{
 	circuit_builder::{CircuitBuilder, InstanceGenerator, WireAllocator},
 	constraint_system::{WireKind, WitnessLayout},
 };
-use binius_transcript::fiat_shamir::Challenger;
-use binius_utils::DeserializeBytes;
 
 use crate::{Error, IOPVerifier, wrapper::circuit_elem::CircuitElem};
 
@@ -41,13 +39,12 @@ use crate::{Error, IOPVerifier, wrapper::circuit_elem::CircuitElem};
 /// `transparent` closures supplied via [`OracleLinearRelation`] must depend only on public inputs
 /// (constants and sampled challenges), never on private ones — `verify_oracle_relations` panics
 /// otherwise.
-pub struct ZKWrappedVerifierChannel<'a, F, MTScheme, Challenger_>
+pub struct ZKWrappedVerifierChannel<'a, F, Channel>
 where
 	F: BinaryField,
-	MTScheme: MerkleTreeScheme<F>,
-	Challenger_: Challenger,
+	Channel: MerkleIPVerifierChannel<F, Elem = F>,
 {
-	inner_channel: BaseFoldVerifierChannel<'a, F, MTScheme, Challenger_>,
+	inner_channel: BaseFoldVerifierChannel<'a, F, Channel>,
 	outer_verifier: &'a IOPVerifier<F>,
 	precommit_oracle: BaseFoldOracle,
 	/// Reconstructs the outer public-input vector as the channel replays the inner verifier;
@@ -65,11 +62,10 @@ where
 	n_outer_suffix_oracles: usize,
 }
 
-impl<'a, F, MTScheme, Challenger_> ZKWrappedVerifierChannel<'a, F, MTScheme, Challenger_>
+impl<'a, F, Channel> ZKWrappedVerifierChannel<'a, F, Channel>
 where
 	F: BinaryField,
-	MTScheme: MerkleTreeScheme<F, Digest: DeserializeBytes>,
-	Challenger_: Challenger,
+	Channel: MerkleIPVerifierChannel<F, Elem = F>,
 {
 	/// Creates a new ZK-wrapped verifier channel.
 	///
@@ -87,7 +83,7 @@ where
 	/// Panics if the channel's oracle specs do not match the expected layout
 	/// `[outer_precommit, inner..., outer_private, outer_mask]`.
 	pub fn new(
-		mut inner_channel: BaseFoldVerifierChannel<'a, F, MTScheme, Challenger_>,
+		mut inner_channel: BaseFoldVerifierChannel<'a, F, Channel>,
 		outer_verifier: &'a IOPVerifier<F>,
 		outer_layout: &'a WitnessLayout<F>,
 	) -> Result<Self, Error> {
@@ -166,12 +162,10 @@ where
 	}
 }
 
-impl<'a, F, MTScheme, Challenger_> IPVerifierChannel<F>
-	for ZKWrappedVerifierChannel<'a, F, MTScheme, Challenger_>
+impl<'a, F, Channel> IPVerifierChannel<F> for ZKWrappedVerifierChannel<'a, F, Channel>
 where
 	F: BinaryField,
-	MTScheme: MerkleTreeScheme<F, Digest: DeserializeBytes>,
-	Challenger_: Challenger,
+	Channel: MerkleIPVerifierChannel<F, Elem = F>,
 {
 	type Elem = CircuitElem<F, InstanceGenerator<'a, F>>;
 
@@ -230,12 +224,10 @@ where
 	}
 }
 
-impl<'a, F, MTScheme, Challenger_> IOPVerifierChannel<'a, F>
-	for ZKWrappedVerifierChannel<'a, F, MTScheme, Challenger_>
+impl<'a, F, Channel> IOPVerifierChannel<'a, F> for ZKWrappedVerifierChannel<'a, F, Channel>
 where
 	F: BinaryField,
-	MTScheme: MerkleTreeScheme<F, Digest: DeserializeBytes>,
-	Challenger_: Challenger,
+	Channel: MerkleIPVerifierChannel<F, Elem = F>,
 {
 	type Oracle = BaseFoldOracle;
 

--- a/crates/verifier/src/verify.rs
+++ b/crates/verifier/src/verify.rs
@@ -309,7 +309,7 @@ impl IOPVerifier {
 #[derive(Clone)]
 pub struct Verifier<H: HashSuite> {
 	iop_verifier: IOPVerifier,
-	iop_compiler: BaseFoldVerifierCompiler<B128, BinaryMerkleTreeScheme<B128, H>>,
+	iop_compiler: BaseFoldVerifierCompiler<B128, H>,
 }
 
 impl<H> Verifier<H>
@@ -403,9 +403,7 @@ where
 	}
 
 	/// Returns the IOP compiler for creating verifier channels.
-	pub const fn iop_compiler(
-		&self,
-	) -> &BaseFoldVerifierCompiler<B128, BinaryMerkleTreeScheme<B128, H>> {
+	pub const fn iop_compiler(&self) -> &BaseFoldVerifierCompiler<B128, H> {
 		&self.iop_compiler
 	}
 

--- a/crates/verifier/src/zk_config.rs
+++ b/crates/verifier/src/zk_config.rs
@@ -53,7 +53,7 @@ pub struct ZKVerifier<H: HashSuite> {
 	inner_iop_verifier: IOPVerifier,
 	outer_iop_verifier: IronSpartanIOPVerifier<B128>,
 	outer_layout: WitnessLayout<B128>,
-	basefold_compiler: BaseFoldVerifierCompiler<B128, BinaryMerkleTreeScheme<B128, H>>,
+	basefold_compiler: BaseFoldVerifierCompiler<B128, H>,
 }
 
 impl<H> ZKVerifier<H>
@@ -157,9 +157,7 @@ where
 	}
 
 	/// Returns the BaseFold ZK verifier compiler.
-	pub const fn basefold_compiler(
-		&self,
-	) -> &BaseFoldVerifierCompiler<B128, BinaryMerkleTreeScheme<B128, H>> {
+	pub const fn basefold_compiler(&self) -> &BaseFoldVerifierCompiler<B128, H> {
 		&self.basefold_compiler
 	}
 


### PR DESCRIPTION
Second and final PR for [BINIUS-215](https://linear.app/jimpo/issue/BINIUS-215/abstract-merkle-ip-channels-over-transcript), on top of #1689. FRI and BaseFold now interact with the transcript and Merkle trees exclusively through `MerkleIPProverChannel` / `MerkleIPVerifierChannel` — no protocol code touches a transcript or a Merkle scheme/prover directly, and the "must take the concrete transcript" escape hatches in the BaseFold channels are gone.

**Transcripts are byte-identical.** All round-trip tests and the three `test_proof_size_*` byte-count tests pass with unmodified assertions.

## What moved where

- **Verifier**: `verify_mlecheck_basefold` / `verify_batch_zk_basefold` / `BaseFoldVerifierChannel` take `&mut impl MerkleIPVerifierChannel<F>`; roots are received as commitment handles via `recv_merkle_commitment(leaf_size, depth)` (same observed digest read as before), query openings via `recv_openings` (same optimal-layer batched Merkle verification), the terminal codeword via `recv_committed_vector`. The FRI oracles (`BrakedownOracle`/`FRIOracle`/`BatchBrakedownOracle`) are generic over an opaque commitment handle and no longer hold a scheme reference.
- **Prover**: the FRI fold/query stack and `prove_mlecheck_basefold` / `BaseFoldProverChannel` are generic over `MerkleIPProverChannel<F>`. `fri::commit_interleaved`/`commit_masked` split into `encode_*` (pure encoding, `fri/encode.rs`) + one `channel.send_merkle_commitment(...)` at the call site. `FRIFoldProver::execute_fold_round(channel)` commits through the channel; the BaseFold round loop is reordered to coeffs-write → fold+commit (root write) → sample. The *computation* of the commit moves after the coeffs write, but since folding/committing does no transcript I/O the byte stream is unchanged (coeffs, then observed root, then sample — exactly as before).
- **Construction sites**: the concrete `{Verifier,Prover}MerkleTranscriptChannel` wrappers are built only in the BaseFold compilers (`create_channel`); `crates/verifier`, `crates/prover`, spartan, and m4 all go through them. All `merkle_prover` plumbing in prover-side setup paths is deleted, along with `ProverMerkleCommitment::new` (handles are only minted by `send_merkle_commitment`) and the now-unneeded `#[auto_impl(&)]` on the Merkle tree traits.

## Size note

This is one large PR rather than separate FRI/BaseFold steps: routing the fold-phase roots through the channels (BaseFold) required restructuring the same fold-prover state machine the query-phase conversion (FRI) introduces, so an FRI-only intermediate would not have survived review intact. The change is mechanical — signatures and plumbing — with the proof-size tests pinning behavior; net −415 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)