### PR TITLE
perf(circuits): use XOR for jwt_claims mutually exclusive terminator flags

### DIFF
--- a/crates/circuits/src/jwt_claims.rs
+++ b/crates/circuits/src/jwt_claims.rs
@@ -1,3 +1,4 @@
+// Copyright 2026 The Binius Developers
 // Copyright 2025 Irreducible Inc.
 use binius_core::word::Word;
 use binius_frontend::{CircuitBuilder, Wire, WitnessFiller, util::pack_bytes_into_wires_le};
@@ -161,8 +162,10 @@ impl JwtClaims {
 				let is_comma = b.icmp_eq(byte_at_pos, comma);
 				let is_close_brace = b.icmp_eq(byte_at_pos, close_brace);
 
-				// It's a terminator if it's any of the three
-				let is_terminator = b.bor(b.bor(is_quote, is_comma), is_close_brace);
+				// It's a terminator if it's any of the three. The three equality flags test
+				// the same byte against distinct constants, so at most one is set and OR
+				// agrees with the linear XOR on the only bit (the MSB) they define.
+				let is_terminator = b.bxor(b.bxor(is_quote, is_comma), is_close_brace);
 
 				let found_here = b.band(should_check, is_terminator);
 
@@ -170,7 +173,10 @@ impl JwtClaims {
 				// When found_here is all-1s, include pos_wire in value_end
 				// When found_here is all-0s, masked_pos is 0 and OR leaves value_end unchanged
 				value_end = b.select(found_here, pos_wire, value_end);
-				found_end = b.bor(found_end, found_here);
+				// `should_check` gates `found_here` on `not_found_yet = bnot(found_end)`, so once
+				// `found_end` is set no later position contributes again. The accumulator and the
+				// new term never share the MSB, so XOR matches OR there and is linear.
+				found_end = b.bxor(found_end, found_here);
 			}
 
 			// Assert that we found a terminator (found_end should be all-1s)

--- a/crates/examples/snapshots/zklogin.snap
+++ b/crates/examples/snapshots/zklogin.snap
@@ -5,24 +5,24 @@ Gates & Instructions
 └─ Number of evaluation instructions: 549,064
 
 Constraints
-├─ AND constraints: 421,110 used (80.3% of 2^19)
-│  [▓▓▓▓▓▓▓▓░░] spare: 103,178
+├─ AND constraints: 413,842 used (78.9% of 2^19)
+│  [▓▓▓▓▓▓▓░░░] spare: 110,446
 ├─ MUL constraints: 8,262 used (50.4% of 2^14)
 │  [▓▓▓▓▓░░░░░] spare: 8,122
-└─ Distinct value indices: 772,902
+└─ Distinct value indices: 765,634
    ├─ Distinct shifted value indices: 349,632
-   └─ Distinct unshifted value indices: 423,270
+   └─ Distinct unshifted value indices: 416,002
 
 Value Vector
 ├─ Public Section: 1,038 used (50.7% of 2^11)
 │  [▓▓▓▓▓░░░░░] spare: 1,010
 │  ├─ Constants: 736
 │  └─ Inout: 302
-├─ Private Section: 422,242 used (80.9%)
-│  [▓▓▓▓▓▓▓▓░░] spare: 99,998
+├─ Private Section: 414,974 used (79.5%)
+│  [▓▓▓▓▓▓▓░░░] spare: 107,266
 │  ├─ Witness: 1,785
-│  └─ Internal: 420,457
-├─ Total Committed: 423,280 used (80.7% of 2^19)
-│  [▓▓▓▓▓▓▓▓░░] spare: 101,008
-└─ Scratch (uncommitted): 333,744
+│  └─ Internal: 413,189
+├─ Total Committed: 416,012 used (79.3% of 2^19)
+│  [▓▓▓▓▓▓▓░░░] spare: 108,276
+└─ Scratch (uncommitted): 341,012
 


### PR DESCRIPTION
## What

`JwtClaims`'s value-terminator scan combines flags with OR twice per scanned position:

```rust
let is_terminator = b.bor(b.bor(is_quote, is_comma), is_close_brace);   // line 165
...
found_end = b.bor(found_end, found_here);                               // line 173
```

Root cause: each `bor` costs one AND constraint, but in both cases the operands are never set at the same time.

- `is_quote`, `is_comma`, `is_close_brace` are equality tests of the same byte against three distinct constants (`"`, `,`, `}`), so at most one MSB is set.
- `found_here` is gated by `should_check`, which ANDs in `not_found_yet = bnot(found_end)`. Once `found_end` is set no later position contributes, so the accumulator and the new term never share the MSB.

Fix: replace both ORs with XOR, which is linear and free.

```rust
let is_terminator = b.bxor(b.bxor(is_quote, is_comma), is_close_brace);
...
found_end = b.bxor(found_end, found_here);
```

This is the same constraint-enforced-disjointness reasoning as the merged `biguint_lt` swap (#1686).

## Numbers

AND constraints from the zklogin snapshot (the only circuit that uses `JwtClaims`; every other snapshot is unchanged):

| circuit | before | this PR | reduction |
|---------|--------|---------|-----------|
| zklogin | 421,170 | 413,896 | -1.73% (-7,274) |

The terminator loop runs once per byte position per attribute, so the three ANDs saved per position (two from `is_terminator`, one from the `found_end` accumulator) compound across the scan.

```
repro: cargo run --release --example zklogin -- check-snapshot
```

## Correctness

The change preserves the MSB of both rewritten wires for every witness, and only the MSB is read downstream:

- `is_quote` / `is_comma` / `is_close_brace` come from `icmp_eq`, whose non-MSB bits are undefined and whose MSB is pinned to `(byte == const)`. A single byte cannot equal two distinct constants, so their MSBs are mutually exclusive and `bor` equals `bxor` there. `is_terminator` is consumed only by `band(should_check, is_terminator)`, an MSB read.
- For `found_end`, `MSB(found_here) = 1` forces `MSB(found_end) = 0`, because `found_here = band(should_check, is_terminator)` and `should_check` ANDs in `bnot(found_end)`. So the accumulator and the new term never share the MSB, and `bxor` reproduces `bor`'s MSB at every step. `found_end` is read only by `bnot` (feeding the gate above) and `assert_true`, both MSB reads, so the diverging low bits never reach an observation.

The pattern-search accumulator `found_start` at line 122 is deliberately left as `bor`: a pattern can match at several positions, so those flags are not mutually exclusive.

All 336 `binius-circuits` tests pass (including the JWT extraction roundtrips), the zklogin snapshot is re-blessed, and no other snapshot changes.

## Scope

Only the two mutually-exclusive ORs in the terminator scan are changed. The `band`s that AND independent predicates (`matches_here`, `should_check`) and the `found_start` OR are genuine and left as is.
