### PR TITLE
BINIUS-215: construct BaseFold channels outside the compilers

### DIFF
--- a/crates/iop-prover/src/basefold_channel.rs
+++ b/crates/iop-prover/src/basefold_channel.rs
@@ -547,11 +547,15 @@ mod tests {
 		// === PROVER SIDE ===
 		let ntt = make_ntt(verifier_compiler.max_subspace());
 		let prover_compiler =
-			BaseFoldProverCompiler::<P, _, _>::from_verifier_compiler(&verifier_compiler, ntt);
+			BaseFoldProverCompiler::<P, _>::from_verifier_compiler(&verifier_compiler, ntt);
 
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 		let prover_rng = StdRng::seed_from_u64(1);
-		let mut prover_channel = prover_compiler.create_channel(&mut prover_transcript, prover_rng);
+		let mut prover_channel = prover_compiler
+			.create_channel_from_transcript::<StdHashSuite, StdChallenger, _>(
+				&mut prover_transcript,
+				prover_rng,
+			);
 
 		let oracle = prover_channel.send_oracle(buffer.to_ref());
 		assert_eq!(oracle.index, 0);
@@ -566,7 +570,10 @@ mod tests {
 
 		// === VERIFIER SIDE ===
 		let mut verifier_transcript = prover_transcript.into_verifier();
-		let mut verifier_channel = verifier_compiler.create_channel(&mut verifier_transcript);
+		let mut verifier_channel = verifier_compiler
+			.create_channel_from_transcript::<StdHashSuite, StdChallenger, _>(
+				&mut verifier_transcript,
+			);
 
 		let v_oracle = verifier_channel.recv_oracle(n_vars, true).unwrap();
 
@@ -612,11 +619,15 @@ mod tests {
 		// === PROVER SIDE ===
 		let ntt = make_ntt(verifier_compiler.max_subspace());
 		let prover_compiler =
-			BaseFoldProverCompiler::<P, _, _>::from_verifier_compiler(&verifier_compiler, ntt);
+			BaseFoldProverCompiler::<P, _>::from_verifier_compiler(&verifier_compiler, ntt);
 
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 		let prover_rng = StdRng::seed_from_u64(1);
-		let mut prover_channel = prover_compiler.create_channel(&mut prover_transcript, prover_rng);
+		let mut prover_channel = prover_compiler
+			.create_channel_from_transcript::<StdHashSuite, StdChallenger, _>(
+				&mut prover_transcript,
+				prover_rng,
+			);
 
 		let oracle_1 = prover_channel.send_oracle(buffer_1.to_ref());
 		let oracle_2 = prover_channel.send_oracle(buffer_2.to_ref());
@@ -629,7 +640,10 @@ mod tests {
 
 		// === VERIFIER SIDE ===
 		let mut verifier_transcript = prover_transcript.into_verifier();
-		let mut verifier_channel = verifier_compiler.create_channel(&mut verifier_transcript);
+		let mut verifier_channel = verifier_compiler
+			.create_channel_from_transcript::<StdHashSuite, StdChallenger, _>(
+				&mut verifier_transcript,
+			);
 
 		let v_oracle_1 = verifier_channel.recv_oracle(n_vars_1, true).unwrap();
 		let v_oracle_2 = verifier_channel.recv_oracle(n_vars_2, true).unwrap();
@@ -688,11 +702,15 @@ mod tests {
 		// === PROVER SIDE ===
 		let ntt = make_ntt(verifier_compiler.max_subspace());
 		let prover_compiler =
-			BaseFoldProverCompiler::<P, _, _>::from_verifier_compiler(&verifier_compiler, ntt);
+			BaseFoldProverCompiler::<P, _>::from_verifier_compiler(&verifier_compiler, ntt);
 
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 		let prover_rng = StdRng::seed_from_u64(1);
-		let mut prover_channel = prover_compiler.create_channel(&mut prover_transcript, prover_rng);
+		let mut prover_channel = prover_compiler
+			.create_channel_from_transcript::<StdHashSuite, StdChallenger, _>(
+				&mut prover_transcript,
+				prover_rng,
+			);
 
 		let oracles: Vec<_> = data
 			.iter()
@@ -710,7 +728,10 @@ mod tests {
 
 		// === VERIFIER SIDE ===
 		let mut verifier_transcript = prover_transcript.into_verifier();
-		let mut verifier_channel = verifier_compiler.create_channel(&mut verifier_transcript);
+		let mut verifier_channel = verifier_compiler
+			.create_channel_from_transcript::<StdHashSuite, StdChallenger, _>(
+				&mut verifier_transcript,
+			);
 
 		let v_oracles: Vec<_> = n_vars_list
 			.iter()
@@ -777,11 +798,15 @@ mod tests {
 
 		let ntt = make_ntt(verifier_compiler.max_subspace());
 		let prover_compiler =
-			BaseFoldProverCompiler::<P, _, _>::from_verifier_compiler(&verifier_compiler, ntt);
+			BaseFoldProverCompiler::<P, _>::from_verifier_compiler(&verifier_compiler, ntt);
 
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 		let prover_rng = StdRng::seed_from_u64(1);
-		let mut prover_channel = prover_compiler.create_channel(&mut prover_transcript, prover_rng);
+		let mut prover_channel = prover_compiler
+			.create_channel_from_transcript::<StdHashSuite, StdChallenger, _>(
+				&mut prover_transcript,
+				prover_rng,
+			);
 
 		let oracles: Vec<_> = data
 			.iter()
@@ -798,7 +823,10 @@ mod tests {
 		prover_channel.finish();
 
 		let mut verifier_transcript = prover_transcript.into_verifier();
-		let mut verifier_channel = verifier_compiler.create_channel(&mut verifier_transcript);
+		let mut verifier_channel = verifier_compiler
+			.create_channel_from_transcript::<StdHashSuite, StdChallenger, _>(
+				&mut verifier_transcript,
+			);
 
 		let v_oracles: Vec<_> = specs
 			.iter()

--- a/crates/iop-prover/src/basefold_compiler.rs
+++ b/crates/iop-prover/src/basefold_compiler.rs
@@ -5,7 +5,7 @@
 //! This module provides [`BaseFoldProverCompiler`], which precomputes FRI parameters and can
 //! create prover channel instances.
 
-use std::marker::PhantomData;
+use std::{borrow::BorrowMut, marker::PhantomData};
 
 use binius_field::{BinaryField, PackedField};
 use binius_hash::binary_merkle_tree::HashSuite;
@@ -20,7 +20,8 @@ use digest::Output;
 use rand::{Rng, SeedableRng, rngs::StdRng};
 
 use crate::{
-	basefold_channel::BaseFoldProverChannel, merkle_channel::ProverMerkleTranscriptChannel,
+	basefold_channel::BaseFoldProverChannel,
+	merkle_channel::{MerkleIPProverChannel, ProverMerkleTranscriptChannel},
 };
 
 /// A compiler that creates BaseFold ZK prover channels with precomputed parameters.
@@ -28,37 +29,40 @@ use crate::{
 /// This compiler builds a single combined FRI over all oracles, with ZK oracles configured for
 /// zero-knowledge mode.
 #[derive(Debug)]
-pub struct BaseFoldProverCompiler<P, NTT, H>
+pub struct BaseFoldProverCompiler<P, NTT>
 where
 	P: PackedField<Scalar: BinaryField>,
 	NTT: AdditiveNTT<Field = P::Scalar> + Sync,
-	H: HashSuite,
 {
 	ntt: NTT,
 	oracle_specs: Vec<OracleSpec>,
 	/// The combined FRI parameters over **all** oracles.
 	fri_params: FRIParams<P::Scalar>,
-	_marker: PhantomData<(P, H)>,
+	_marker: PhantomData<P>,
 }
 
-impl<F, P, NTT, H> BaseFoldProverCompiler<P, NTT, H>
+impl<F, P, NTT> BaseFoldProverCompiler<P, NTT>
 where
 	F: BinaryField,
 	P: PackedField<Scalar = F>,
 	NTT: AdditiveNTT<Field = F> + Sync,
-	H: HashSuite,
-	Output<H::LeafHash>: SerializeBytes,
 {
 	/// Creates a new compiler with precomputed combined FRI parameters.
 	///
-	/// Each oracle's batch size is derived from its ZK flag: a ZK oracle fixes `log_batch_size = 1`
-	/// (message ‖ equal-length mask), a non-ZK oracle takes a flexible batch size.
-	pub fn new(
+	/// The `merkle_scheme` is consulted only for proof-size estimation while choosing the FRI
+	/// parameters; it is not stored. Each oracle's batch size is derived from its ZK flag: a ZK
+	/// oracle fixes `log_batch_size = 1` (message ‖ equal-length mask), a non-ZK oracle takes a
+	/// flexible batch size.
+	pub fn new<H>(
 		ntt: NTT,
+		merkle_scheme: BinaryMerkleTreeScheme<F, H>,
 		oracle_specs: Vec<OracleSpec>,
 		log_inv_rate: usize,
 		n_test_queries: usize,
-	) -> Self {
+	) -> Self
+	where
+		H: HashSuite,
+	{
 		assert!(
 			!oracle_specs.is_empty(),
 			"BaseFoldProverCompiler requires at least one oracle spec"
@@ -69,7 +73,7 @@ where
 		// equal-length mask); non-ZK oracles take a flexible batch size.
 		let (fri_params, _) = FRIParams::optimal_for_batch(
 			ntt.domain_context(),
-			&BinaryMerkleTreeScheme::<F, H>::new(),
+			&merkle_scheme,
 			&oracle_specs,
 			log_inv_rate,
 			n_test_queries,
@@ -87,7 +91,7 @@ where
 	///
 	/// This reuses the precomputed FRI parameters and oracle specifications.
 	pub fn from_verifier_compiler(
-		verifier_compiler: &BaseFoldVerifierCompiler<F, H>,
+		verifier_compiler: &BaseFoldVerifierCompiler<F>,
 		ntt: NTT,
 	) -> Self {
 		Self {
@@ -113,17 +117,20 @@ where
 		&self.fri_params
 	}
 
-	/// Creates a ZK prover channel from this compiler, a transcript, and an RNG.
+	/// Creates a ZK prover channel over the given Merkle channel and an RNG.
 	///
-	/// The returned channel drives all prover interaction through a
-	/// [`ProverMerkleTranscriptChannel`] over the transcript, constructed here with a non-hiding
-	/// Merkle tree prover. The `rng` is used to seed an internal `StdRng` for mask generation.
-	pub fn create_channel<'a, Challenger_: Challenger>(
-		&'a self,
-		transcript: &'a mut ProverTranscript<Challenger_>,
+	/// The returned channel drives all prover interaction through `channel`, committing and opening
+	/// oracles with this compiler's NTT, oracle specs, and combined FRI parameters. The caller
+	/// constructs the Merkle channel, so it decides how commitments are produced. The `rng` is used
+	/// to seed an internal `StdRng` for mask generation.
+	pub fn create_channel<Channel>(
+		&self,
+		channel: Channel,
 		rng: impl Rng,
-	) -> BaseFoldTranscriptProverChannel<'a, F, P, NTT, H, Challenger_> {
-		let channel = ProverMerkleTranscriptChannel::new(transcript);
+	) -> BaseFoldProverChannel<'_, F, P, NTT, Channel>
+	where
+		Channel: MerkleIPProverChannel<F>,
+	{
 		BaseFoldProverChannel::new(
 			channel,
 			&self.ntt,
@@ -144,10 +151,13 @@ where
 	/// Panics if any configured oracle is ZK.
 	/// A ZK oracle would draw its mask from the fixed seed, which destroys the hiding property.
 	/// So this constructor refuses to build a channel that could mask deterministically.
-	pub fn create_channel_without_zk<'a, Challenger_: Challenger>(
-		&'a self,
-		transcript: &'a mut ProverTranscript<Challenger_>,
-	) -> BaseFoldTranscriptProverChannel<'a, F, P, NTT, H, Challenger_> {
+	pub fn create_channel_without_zk<Channel>(
+		&self,
+		channel: Channel,
+	) -> BaseFoldProverChannel<'_, F, P, NTT, Channel>
+	where
+		Channel: MerkleIPProverChannel<F>,
+	{
 		// A ZK oracle masks with the RNG, so a fixed seed here would silently break hiding.
 		assert!(
 			self.oracle_specs().iter().all(|spec| !spec.is_zk),
@@ -155,16 +165,42 @@ where
 		);
 
 		// No mask is ever drawn, so the seed is arbitrary; reuse the seeded-RNG constructor.
-		self.create_channel(transcript, StdRng::seed_from_u64(0))
+		self.create_channel(channel, StdRng::seed_from_u64(0))
+	}
+
+	/// Creates a ZK prover channel over a transcript, for the common case.
+	///
+	/// The transcript (owned or mutably borrowed) is wrapped in a
+	/// [`ProverMerkleTranscriptChannel`] with a non-hiding Merkle tree prover for the given hash
+	/// suite, then passed to [`Self::create_channel`].
+	pub fn create_channel_from_transcript<H, Challenger_, T>(
+		&self,
+		transcript: T,
+		rng: impl Rng,
+	) -> BaseFoldProverChannel<'_, F, P, NTT, ProverMerkleTranscriptChannel<T, Challenger_, F, H>>
+	where
+		H: HashSuite,
+		Challenger_: Challenger,
+		T: BorrowMut<ProverTranscript<Challenger_>>,
+		Output<H::LeafHash>: SerializeBytes,
+	{
+		self.create_channel(ProverMerkleTranscriptChannel::new(transcript), rng)
+	}
+
+	/// Creates a non-ZK prover channel over a transcript, for the common case.
+	///
+	/// The transcript handling matches [`Self::create_channel_from_transcript`]; the channel is
+	/// built with [`Self::create_channel_without_zk`] and panics under the same conditions.
+	pub fn create_channel_without_zk_from_transcript<H, Challenger_, T>(
+		&self,
+		transcript: T,
+	) -> BaseFoldProverChannel<'_, F, P, NTT, ProverMerkleTranscriptChannel<T, Challenger_, F, H>>
+	where
+		H: HashSuite,
+		Challenger_: Challenger,
+		T: BorrowMut<ProverTranscript<Challenger_>>,
+		Output<H::LeafHash>: SerializeBytes,
+	{
+		self.create_channel_without_zk(ProverMerkleTranscriptChannel::new(transcript))
 	}
 }
-
-/// The [`BaseFoldProverChannel`] type produced by [`BaseFoldProverCompiler::create_channel`]: a
-/// BaseFold channel over a [`ProverMerkleTranscriptChannel`] borrowing the transcript.
-pub type BaseFoldTranscriptProverChannel<'a, F, P, NTT, H, Challenger_> = BaseFoldProverChannel<
-	'a,
-	F,
-	P,
-	NTT,
-	ProverMerkleTranscriptChannel<&'a mut ProverTranscript<Challenger_>, Challenger_, F, H>,
->;

--- a/crates/iop-prover/src/logup_star.rs
+++ b/crates/iop-prover/src/logup_star.rs
@@ -335,12 +335,15 @@ mod tests {
 			GenericOnTheFly::generate_from_subspace(verifier_compiler.max_subspace());
 		let ntt = NeighborsLastSingleThread::new(domain_context);
 		let prover_compiler =
-			BaseFoldProverCompiler::<BP, _, _>::from_verifier_compiler(&verifier_compiler, ntt);
+			BaseFoldProverCompiler::<BP, _>::from_verifier_compiler(&verifier_compiler, ntt);
 
 		let mut prover_transcript = ProverTranscript::new(Chal::default());
 		let prover_channel_rng = StdRng::seed_from_u64(8);
-		let mut prover_channel =
-			prover_compiler.create_channel(&mut prover_transcript, prover_channel_rng);
+		let mut prover_channel = prover_compiler
+			.create_channel_from_transcript::<StdHashSuite, Chal, _>(
+				&mut prover_transcript,
+				prover_channel_rng,
+			);
 
 		let prover_proof =
 			prove::<F, BP, _>(&table, &index, &eval_point, eval_claim, &mut prover_channel);
@@ -355,7 +358,8 @@ mod tests {
 
 		// Verify: receive Y, run the reduction, open the pushforward through the real FRI check.
 		let mut verifier_transcript = prover_transcript.into_verifier();
-		let mut verifier_channel = verifier_compiler.create_channel(&mut verifier_transcript);
+		let mut verifier_channel = verifier_compiler
+			.create_channel_from_transcript::<StdHashSuite, Chal, _>(&mut verifier_transcript);
 		let verifier_proof =
 			verify_logup::verify(m, eval_claim, &eval_point, &mut verifier_channel)
 				.expect("verification succeeds");

--- a/crates/iop/src/basefold_channel.rs
+++ b/crates/iop/src/basefold_channel.rs
@@ -318,6 +318,18 @@ where
 		let fri_oracle = &self.fri_params.input_oracles()[index];
 		let depth = (self.fri_params.rs_code().log_dim() - fri_oracle.log_lift)
 			+ self.fri_params.rs_code().log_inv_rate();
+
+		// The committed message length implied by this shape is `log_batch_size + depth -
+		// log_inv_rate`; it must cover the spec's message plus, for a ZK oracle, the equal-length
+		// interleaved mask.
+		let spec = &self.oracle_specs[index];
+		assert_eq!(
+			fri_oracle.log_batch_size() + depth - self.fri_params.rs_code().log_inv_rate(),
+			spec.log_msg_len + usize::from(spec.is_zk),
+			"invariant: the FRI commitment shape must be consistent with the oracle spec's \
+			 log_msg_len"
+		);
+
 		let commitment = self
 			.channel
 			.recv_merkle_commitment(1 << fri_oracle.log_batch_size(), depth)

--- a/crates/iop/src/basefold_compiler.rs
+++ b/crates/iop/src/basefold_compiler.rs
@@ -5,6 +5,8 @@
 //! This module provides [`BaseFoldVerifierCompiler`], which precomputes FRI parameters and can
 //! create verifier channel instances.
 
+use std::borrow::BorrowMut;
+
 use binius_field::BinaryField;
 use binius_hash::binary_merkle_tree::HashSuite;
 use binius_math::{BinarySubspace, ntt::domain_context::GenericOnTheFly};
@@ -16,9 +18,8 @@ use crate::{
 	basefold_channel::BaseFoldVerifierChannel,
 	channel::OracleSpec,
 	fri::{AritySelectionStrategy, FRIParams},
-	merkle_channel::VerifierMerkleTranscriptChannel,
+	merkle_channel::{MerkleIPVerifierChannel, VerifierMerkleTranscriptChannel},
 	merkle_tree::BinaryMerkleTreeScheme,
-	size_tracking_channel::SizeTrackingChannel,
 };
 
 /// A compiler that creates BaseFold ZK verifier channels with precomputed parameters.
@@ -27,27 +28,25 @@ use crate::{
 /// parameters for zero-knowledge mode (`log_msg_len + 1` as the message length and
 /// `log_batch_size = 1`); non-ZK oracles take a flexible batch size with no mask.
 #[derive(Clone)]
-pub struct BaseFoldVerifierCompiler<F, H>
+pub struct BaseFoldVerifierCompiler<F>
 where
 	F: BinaryField,
-	H: HashSuite,
 {
-	merkle_scheme: BinaryMerkleTreeScheme<F, H>,
 	oracle_specs: Vec<OracleSpec>,
 	fri_params: FRIParams<F>,
 }
 
-impl<F, H> BaseFoldVerifierCompiler<F, H>
+impl<F> BaseFoldVerifierCompiler<F>
 where
 	F: BinaryField,
-	H: HashSuite,
 {
 	/// Creates a new compiler with precomputed combined FRI parameters.
 	///
-	/// Each oracle's batch size is derived from its ZK flag: a ZK oracle fixes `log_batch_size = 1`
-	/// (message ‖ equal-length mask), a non-ZK oracle takes a flexible batch size. Requires at
-	/// least one oracle spec.
-	pub fn new<Strategy>(
+	/// The `merkle_scheme` is consulted only for proof-size estimation while choosing the FRI
+	/// parameters; it is not stored. Each oracle's batch size is derived from its ZK flag: a ZK
+	/// oracle fixes `log_batch_size = 1` (message ‖ equal-length mask), a non-ZK oracle takes a
+	/// flexible batch size. Requires at least one oracle spec.
+	pub fn new<H, Strategy>(
 		merkle_scheme: BinaryMerkleTreeScheme<F, H>,
 		oracle_specs: Vec<OracleSpec>,
 		log_inv_rate: usize,
@@ -55,6 +54,7 @@ where
 		_arity_strategy: &Strategy,
 	) -> Self
 	where
+		H: HashSuite,
 		Strategy: AritySelectionStrategy,
 	{
 		assert!(
@@ -86,7 +86,6 @@ where
 		);
 
 		Self {
-			merkle_scheme,
 			oracle_specs,
 			fri_params,
 		}
@@ -102,54 +101,42 @@ where
 		&self.fri_params
 	}
 
-	/// Returns a reference to the Merkle scheme.
-	pub const fn merkle_scheme(&self) -> &BinaryMerkleTreeScheme<F, H> {
-		&self.merkle_scheme
-	}
-
 	/// Returns the Reed-Solomon code subspace of the combined FRI parameters (the largest needed).
 	pub fn max_subspace(&self) -> &BinarySubspace<F> {
 		self.fri_params.rs_code().subspace()
 	}
 
-	/// Creates a [`SizeTrackingChannel`] from this compiler's oracle specs.
-	pub fn create_size_tracking_channel(
-		&self,
-	) -> SizeTrackingChannel<'_, F, BinaryMerkleTreeScheme<F, H>> {
-		SizeTrackingChannel::new(
-			self.oracle_specs.clone(),
-			std::slice::from_ref(&self.fri_params),
-			&self.merkle_scheme,
-		)
-	}
-
-	/// Creates a ZK verifier channel from this compiler and a transcript.
+	/// Creates a ZK verifier channel over the given Merkle channel.
 	///
-	/// The returned channel drives all prover interaction through a
-	/// [`VerifierMerkleTranscriptChannel`] over the transcript, constructed here with a scheme
-	/// matching this compiler's Merkle scheme.
-	pub fn create_channel<'a, Challenger_>(
-		&'a self,
-		transcript: &'a mut VerifierTranscript<Challenger_>,
-	) -> BaseFoldTranscriptVerifierChannel<'a, F, H, Challenger_>
+	/// The returned channel drives all prover interaction through `channel`, opening oracles with
+	/// this compiler's oracle specs and combined FRI parameters. The caller constructs the Merkle
+	/// channel, so it decides how commitments are received and verified.
+	pub fn create_channel<Channel>(
+		&self,
+		channel: Channel,
+	) -> BaseFoldVerifierChannel<'_, F, Channel>
 	where
-		F: FixedSizeSerializeBytes,
-		Output<H::LeafHash>: DeserializeBytes,
-		Challenger_: Challenger,
+		Channel: MerkleIPVerifierChannel<F, Elem = F>,
 	{
-		// `BinaryMerkleTreeScheme` is fully determined by its salt length, so reconstructing with
-		// the compiler's salt length reproduces the scheme.
-		let scheme = BinaryMerkleTreeScheme::hiding(self.merkle_scheme.salt_len());
-		let channel = VerifierMerkleTranscriptChannel::with_scheme(transcript, scheme);
 		BaseFoldVerifierChannel::new(channel, &self.oracle_specs, &self.fri_params)
 	}
-}
 
-/// The [`BaseFoldVerifierChannel`] type produced by
-/// [`BaseFoldVerifierCompiler::create_channel`]: a BaseFold channel over a
-/// [`VerifierMerkleTranscriptChannel`] borrowing the transcript.
-pub type BaseFoldTranscriptVerifierChannel<'a, F, H, Challenger_> = BaseFoldVerifierChannel<
-	'a,
-	F,
-	VerifierMerkleTranscriptChannel<&'a mut VerifierTranscript<Challenger_>, Challenger_, F, H>,
->;
+	/// Creates a ZK verifier channel over a transcript, for the common case.
+	///
+	/// The transcript (owned or mutably borrowed) is wrapped in a
+	/// [`VerifierMerkleTranscriptChannel`] with a non-hiding [`BinaryMerkleTreeScheme`] for the
+	/// given hash suite, then passed to [`Self::create_channel`].
+	pub fn create_channel_from_transcript<H, Challenger_, T>(
+		&self,
+		transcript: T,
+	) -> BaseFoldVerifierChannel<'_, F, VerifierMerkleTranscriptChannel<T, Challenger_, F, H>>
+	where
+		F: FixedSizeSerializeBytes,
+		H: HashSuite,
+		Challenger_: Challenger,
+		T: BorrowMut<VerifierTranscript<Challenger_>>,
+		Output<H::LeafHash>: DeserializeBytes,
+	{
+		self.create_channel(VerifierMerkleTranscriptChannel::new(transcript))
+	}
+}

--- a/crates/m4-prover/src/prove.rs
+++ b/crates/m4-prover/src/prove.rs
@@ -29,8 +29,8 @@ where
 {
 	/// The committed-multilinear shape of the batch, shared with the verifier.
 	layout: BatchCommitLayout,
-	/// The precomputed BaseFold prover, holding the NTT and the Merkle prover.
-	basefold_compiler: BaseFoldProverCompiler<P, ProverNtt, StdHashSuite>,
+	/// The precomputed BaseFold prover, holding the NTT and the FRI parameters.
+	basefold_compiler: BaseFoldProverCompiler<P, ProverNtt>,
 }
 
 impl<P> Prover<P>
@@ -87,7 +87,9 @@ where
 	where
 		Challenger_: Challenger,
 	{
-		let mut channel = self.basefold_compiler.create_channel_without_zk(transcript);
+		let mut channel = self
+			.basefold_compiler
+			.create_channel_without_zk_from_transcript::<StdHashSuite, Challenger_, _>(transcript);
 
 		// Pack the 2-D table into one multilinear and commit it as the trace oracle.
 		let packed = table.pack::<P>();

--- a/crates/m4-verifier/src/verify.rs
+++ b/crates/m4-verifier/src/verify.rs
@@ -34,8 +34,8 @@ type Scheme = BinaryMerkleTreeScheme<B128, StdHashSuite>;
 pub struct Verifier {
 	/// The committed-multilinear shape of the batch.
 	layout: BatchCommitLayout,
-	/// The precomputed BaseFold verifier, holding the Merkle scheme and FRI parameters.
-	iop_compiler: BaseFoldVerifierCompiler<B128, StdHashSuite>,
+	/// The precomputed BaseFold verifier, holding the FRI parameters.
+	iop_compiler: BaseFoldVerifierCompiler<B128>,
 }
 
 impl Verifier {
@@ -86,7 +86,7 @@ impl Verifier {
 	/// The precomputed BaseFold verifier compiler.
 	///
 	/// The prover reuses it so both sides share one set of FRI parameters.
-	pub const fn iop_compiler(&self) -> &BaseFoldVerifierCompiler<B128, StdHashSuite> {
+	pub const fn iop_compiler(&self) -> &BaseFoldVerifierCompiler<B128> {
 		&self.iop_compiler
 	}
 
@@ -109,7 +109,9 @@ impl Verifier {
 	where
 		Challenger_: Challenger,
 	{
-		let mut channel = self.iop_compiler.create_channel(transcript);
+		let mut channel = self
+			.iop_compiler
+			.create_channel_from_transcript::<StdHashSuite, Challenger_, _>(transcript);
 
 		// Receive the commitment, redraw the same point, and read the claimed evaluation. The
 		// packed batch witness is witness-dependent (M4 commits it without ZK regardless).

--- a/crates/prover/benches/intmul.rs
+++ b/crates/prover/benches/intmul.rs
@@ -53,8 +53,8 @@ const LOG_ORACLE_LEN: usize = 16;
 /// encoding and Merkle tree construction) is measured; a naive channel would serialize
 /// oracles for free. The final batched opening in `finish` is not measured, since the full
 /// system amortizes it into the single opening shared with the witness trace.
-fn basefold_compiler()
--> BaseFoldProverCompiler<P, NeighborsLastSingleThread<GenericPreExpanded<F>>, StdHashSuite> {
+fn basefold_compiler() -> BaseFoldProverCompiler<P, NeighborsLastSingleThread<GenericPreExpanded<F>>>
+{
 	let verifier_compiler = BaseFoldVerifierCompiler::new(
 		BinaryMerkleTreeScheme::<F, StdHashSuite>::new(),
 		vec![OracleSpec::new(LOG_ORACLE_LEN)],
@@ -115,18 +115,17 @@ fn bench_intmul_prove(c: &mut Criterion) {
 	let witness = Witness::<P>::new(LOG_BITS, &a, &b, &c_lo, &c_hi).unwrap();
 	let compiler = basefold_compiler();
 
-	// The channel is created in the setup closures. It borrows its transcript, and a closure
-	// cannot return a borrow of captured state, so each setup leaks one small transcript; the
-	// leak is bounded by the iteration count.
 	group.bench_with_input(
 		BenchmarkId::new("prove", num_exponents),
 		&witness,
 		|bencher, witness| {
 			bencher.iter_batched_ref(
 				|| {
-					let transcript =
-						Box::leak(Box::new(ProverTranscript::<StdChallenger>::default()));
-					(Some(witness.clone()), compiler.create_channel_without_zk(transcript))
+					let channel = compiler
+						.create_channel_without_zk_from_transcript::<StdHashSuite, StdChallenger, _>(
+							ProverTranscript::default(),
+						);
+					(Some(witness.clone()), channel)
 				},
 				|(witness, channel)| {
 					let mut intmul_prover = IntMulProver::new(0, channel);
@@ -144,9 +143,10 @@ fn bench_intmul_prove(c: &mut Criterion) {
 		|bencher, _| {
 			bencher.iter_batched_ref(
 				|| {
-					let transcript =
-						Box::leak(Box::new(ProverTranscript::<StdChallenger>::default()));
-					compiler.create_channel_without_zk(transcript)
+					compiler
+						.create_channel_without_zk_from_transcript::<StdHashSuite, StdChallenger, _>(
+							ProverTranscript::default(),
+						)
 				},
 				|channel| {
 					let mut intmul_prover = IntMulProver::new(0, channel);

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -1,6 +1,8 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
+use std::marker::PhantomData;
+
 use binius_core::{
 	constraint_system::{AndConstraint, ConstraintSystem, MulConstraint, ValueVec},
 	word::Word,
@@ -272,7 +274,9 @@ where
 	H: HashSuite,
 {
 	iop_prover: IOPProver,
-	basefold_compiler: BaseFoldProverCompiler<P, ProverNTT<B128>, H>,
+	basefold_compiler: BaseFoldProverCompiler<P, ProverNTT<B128>>,
+	/// The prover creates its Merkle transcript channels with the hash suite `H`.
+	_hash_marker: PhantomData<H>,
 }
 
 impl<P, H> Prover<P, H>
@@ -315,6 +319,7 @@ where
 		Ok(Prover {
 			iop_prover,
 			basefold_compiler,
+			_hash_marker: PhantomData,
 		})
 	}
 
@@ -348,7 +353,9 @@ where
 		// Create channel, delegate to IOPProver::prove, then finish it. The unified channel takes
 		// an rng to mask ZK oracles, but a plain `Prover` produces a transparent proof whose only
 		// oracle is non-ZK, so no masks are drawn and the rng is never consumed.
-		let mut channel = self.basefold_compiler.create_channel_without_zk(transcript);
+		let mut channel = self
+			.basefold_compiler
+			.create_channel_without_zk_from_transcript::<H, Challenger_, _>(transcript);
 		self.iop_prover.prove::<P, _>(witness, &mut channel)?;
 		channel.finish();
 		Ok(())

--- a/crates/prover/src/zk_config.rs
+++ b/crates/prover/src/zk_config.rs
@@ -6,6 +6,8 @@
 //! Spartan-based zero-knowledge wrapper. The prover counterpart to
 //! [`binius_verifier::zk_config::ZKVerifier`].
 
+use std::marker::PhantomData;
+
 use binius_core::constraint_system::{ConstraintSystem, ValueVec};
 use binius_field::{BinaryField128bGhash as B128, PackedExtension, PackedField};
 use binius_hash::binary_merkle_tree::HashSuite;
@@ -40,7 +42,9 @@ where
 	inner_iop_verifier: IOPVerifier,
 	outer_iop_prover: binius_spartan_prover::IOPProver<B128>,
 	outer_layout: WitnessLayout<B128>,
-	basefold_compiler: BaseFoldProverCompiler<P, ProverNTT<B128>, H>,
+	basefold_compiler: BaseFoldProverCompiler<P, ProverNTT<B128>>,
+	/// The prover creates its Merkle transcript channels with the hash suite `H`.
+	_hash_marker: PhantomData<H>,
 }
 
 impl<P, H> ZKProver<P, H>
@@ -98,6 +102,7 @@ where
 			outer_iop_prover,
 			outer_layout,
 			basefold_compiler,
+			_hash_marker: PhantomData,
 		})
 	}
 
@@ -122,7 +127,9 @@ where
 		let public_words = witness.public().to_vec();
 
 		// Create BaseFold prover channel and wrap with outer prover.
-		let basefold_channel = self.basefold_compiler.create_channel(transcript, &mut rng);
+		let basefold_channel = self
+			.basefold_compiler
+			.create_channel_from_transcript::<H, Challenger_, _>(transcript, &mut rng);
 		let mut wrapped_channel = ZKWrappedProverChannel::new(
 			basefold_channel,
 			&self.outer_iop_prover,

--- a/crates/spartan-prover/src/lib.rs
+++ b/crates/spartan-prover/src/lib.rs
@@ -33,6 +33,7 @@ pub mod wrapper;
 
 use std::{
 	iter::{repeat_n, repeat_with},
+	marker::PhantomData,
 	ops::Deref,
 };
 
@@ -95,7 +96,9 @@ where
 	H: HashSuite,
 {
 	iop_prover: IOPProver<P::Scalar>,
-	basefold_compiler: BaseFoldProverCompiler<P, ProverNTT<P::Scalar>, H>,
+	basefold_compiler: BaseFoldProverCompiler<P, ProverNTT<P::Scalar>>,
+	/// The prover creates its Merkle transcript channels with the hash suite `H`.
+	_hash_marker: PhantomData<H>,
 }
 
 impl<F: Field> IOPProver<F> {
@@ -343,6 +346,7 @@ where
 		Ok(Prover {
 			iop_prover,
 			basefold_compiler,
+			_hash_marker: PhantomData,
 		})
 	}
 
@@ -352,7 +356,7 @@ where
 	}
 
 	/// Returns a reference to the BaseFold ZK prover compiler.
-	pub const fn iop_compiler(&self) -> &BaseFoldProverCompiler<P, ProverNTT<F>, H> {
+	pub const fn iop_compiler(&self) -> &BaseFoldProverCompiler<P, ProverNTT<F>> {
 		&self.basefold_compiler
 	}
 
@@ -379,7 +383,9 @@ where
 
 		// Create ZK channel (owns the RNG for mask generation), commit the precommit oracle,
 		// and delegate to the IOP prover.
-		let mut channel = self.basefold_compiler.create_channel(transcript, &mut rng);
+		let mut channel = self
+			.basefold_compiler
+			.create_channel_from_transcript::<H, Challenger_, _>(transcript, &mut rng);
 		let (precommit_oracle, precommit_packed) =
 			self.iop_prover
 				.commit_precommit::<P, _>(&witness, &mut rng, &mut channel);

--- a/crates/spartan-prover/tests/wrapper_integration_test.rs
+++ b/crates/spartan-prover/tests/wrapper_integration_test.rs
@@ -114,7 +114,7 @@ fn test_zk_wrapped_prove_verify() {
 	let subspace = zk_basefold_compiler.max_subspace();
 	let domain_context = GenericOnTheFly::generate_from_subspace(subspace);
 	let ntt = NeighborsLastSingleThread::new(domain_context);
-	let zk_basefold_prover: BaseFoldProverCompiler<OptimalPackedB128, _, _> =
+	let zk_basefold_prover: BaseFoldProverCompiler<OptimalPackedB128, _> =
 		BaseFoldProverCompiler::from_verifier_compiler(&zk_basefold_compiler, ntt);
 
 	// === Step 6: Generate inner witness ===
@@ -138,7 +138,11 @@ fn test_zk_wrapped_prove_verify() {
 	// Observe inner public input on the transcript (Fiat-Shamir).
 	prover_transcript.observe().write_slice(&public);
 
-	let basefold_channel = zk_basefold_prover.create_channel(&mut prover_transcript, &mut rng);
+	let basefold_channel = zk_basefold_prover
+		.create_channel_from_transcript::<StdHashSuite, StdChallenger, _>(
+			&mut prover_transcript,
+			&mut rng,
+		);
 	let mut wrapped_prover_channel = ZKWrappedProverChannel::new(
 		basefold_channel,
 		&outer_iop_prover,
@@ -188,7 +192,8 @@ fn test_zk_wrapped_prove_verify() {
 	// Verifier observes the public input on the transcript (Fiat-Shamir).
 	verifier_transcript.observe().write_slice(&public);
 
-	let verifier_channel = zk_basefold_compiler.create_channel(&mut verifier_transcript);
+	let verifier_channel = zk_basefold_compiler
+		.create_channel_from_transcript::<StdHashSuite, StdChallenger, _>(&mut verifier_transcript);
 	let mut wrapped_verifier_channel =
 		ZKWrappedVerifierChannel::new(verifier_channel, &outer_iop_verifier, &outer_layout)
 			.expect("ZKWrappedVerifierChannel::new should succeed");

--- a/crates/spartan-verifier/src/lib.rs
+++ b/crates/spartan-verifier/src/lib.rs
@@ -33,7 +33,7 @@ pub mod constraint_system;
 pub mod wiring;
 pub mod wrapper;
 
-use std::{rc::Rc, slice};
+use std::{marker::PhantomData, rc::Rc, slice};
 
 use binius_field::{BinaryField, Field, field::FieldOps};
 use binius_hash::binary_merkle_tree::HashSuite;
@@ -93,7 +93,9 @@ where
 {
 	iop_verifier: IOPVerifier<F>,
 	/// BaseFold ZK compiler for creating verifier channels.
-	basefold_compiler: BaseFoldVerifierCompiler<F, H>,
+	basefold_compiler: BaseFoldVerifierCompiler<F>,
+	/// The verifier creates its Merkle transcript channels with the hash suite `H`.
+	_hash_marker: PhantomData<H>,
 }
 
 impl<F: Field> IOPVerifier<F> {
@@ -296,6 +298,7 @@ where
 		Ok(Self {
 			iop_verifier,
 			basefold_compiler,
+			_hash_marker: PhantomData,
 		})
 	}
 
@@ -309,7 +312,7 @@ where
 	}
 
 	/// Returns a reference to the BaseFold ZK verifier compiler.
-	pub const fn iop_compiler(&self) -> &BaseFoldVerifierCompiler<F, H> {
+	pub const fn iop_compiler(&self) -> &BaseFoldVerifierCompiler<F> {
 		&self.basefold_compiler
 	}
 
@@ -333,7 +336,9 @@ where
 
 		// Create channel, receive the precommit oracle, and delegate to IOPVerifier::verify. The
 		// IOP verifier only queues the oracle relations; `finish` runs the single combined opening.
-		let mut channel = self.basefold_compiler.create_channel(transcript);
+		let mut channel = self
+			.basefold_compiler
+			.create_channel_from_transcript::<H, Challenger_, _>(transcript);
 		let precommit_oracle =
 			channel.recv_oracle(self.constraint_system().log_precommit() as usize, true)?;
 		self.iop_verifier

--- a/crates/spartan-verifier/tests/proof_size_test.rs
+++ b/crates/spartan-verifier/tests/proof_size_test.rs
@@ -2,7 +2,10 @@
 
 use binius_field::BinaryField128bGhash as B128;
 use binius_hash::StdHashSuite;
-use binius_iop::channel::IOPVerifierChannel;
+use binius_iop::{
+	channel::IOPVerifierChannel, merkle_tree::BinaryMerkleTreeScheme,
+	size_tracking_channel::SizeTrackingChannel,
+};
 use binius_ip::channel::IPVerifierChannel;
 use binius_spartan_frontend::{
 	circuit_builder::{CircuitBuilder, ConstraintBuilder},
@@ -40,8 +43,15 @@ fn test_ip_proof_size() {
 	let cs = verifier.constraint_system();
 
 	// Create size tracking channel and run verify with dummy public inputs
-	// (SizeTrackingChannel ignores values).
-	let mut channel = verifier.iop_compiler().create_size_tracking_channel();
+	// (SizeTrackingChannel ignores values). The Merkle scheme matches the one the verifier
+	// estimates proof sizes with at setup.
+	let iop_compiler = verifier.iop_compiler();
+	let merkle_scheme = BinaryMerkleTreeScheme::<B128, StdHashSuite>::new();
+	let mut channel = SizeTrackingChannel::new(
+		iop_compiler.oracle_specs().to_vec(),
+		std::slice::from_ref(iop_compiler.fri_params()),
+		&merkle_scheme,
+	);
 	let public = vec![B128::default(); 1 << cs.log_public()];
 	let public_elems = channel.observe_many(&public);
 	// SizeTrackingChannel::Oracle = (), but we still bind to exercise the real call pattern.

--- a/crates/verifier/src/verify.rs
+++ b/crates/verifier/src/verify.rs
@@ -1,6 +1,8 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
+use std::marker::PhantomData;
+
 use binius_core::{constraint_system::ConstraintSystem, word::Word};
 use binius_field::{AESTowerField8b as B8, BinaryField, ExtensionField, FieldOps};
 use binius_hash::binary_merkle_tree::HashSuite;
@@ -309,7 +311,9 @@ impl IOPVerifier {
 #[derive(Clone)]
 pub struct Verifier<H: HashSuite> {
 	iop_verifier: IOPVerifier,
-	iop_compiler: BaseFoldVerifierCompiler<B128, H>,
+	iop_compiler: BaseFoldVerifierCompiler<B128>,
+	/// The verifier creates its Merkle transcript channels with the hash suite `H`.
+	_hash_marker: PhantomData<H>,
 }
 
 impl<H> Verifier<H>
@@ -359,6 +363,7 @@ where
 		Ok(Self {
 			iop_verifier,
 			iop_compiler,
+			_hash_marker: PhantomData,
 		})
 	}
 
@@ -392,18 +397,13 @@ where
 		self.iop_compiler.fri_params()
 	}
 
-	/// Returns the [`crate::merkle_tree::MerkleTreeScheme`] instance used.
-	pub const fn merkle_scheme(&self) -> &BinaryMerkleTreeScheme<B128, H> {
-		self.iop_compiler.merkle_scheme()
-	}
-
 	/// Returns log2 of the number of public constants and input/output words.
 	pub const fn log_public_words(&self) -> usize {
 		self.iop_verifier.log_public_words()
 	}
 
 	/// Returns the IOP compiler for creating verifier channels.
-	pub const fn iop_compiler(&self) -> &BaseFoldVerifierCompiler<B128, H> {
+	pub const fn iop_compiler(&self) -> &BaseFoldVerifierCompiler<B128> {
 		&self.iop_compiler
 	}
 
@@ -423,7 +423,9 @@ where
 		.entered();
 
 		// Create channel, delegate to IOPVerifier::verify, then finish it.
-		let mut channel = self.iop_compiler.create_channel(transcript);
+		let mut channel = self
+			.iop_compiler
+			.create_channel_from_transcript::<H, Challenger_, _>(transcript);
 		self.iop_verifier.verify(public, &mut channel)?;
 		channel.finish()?;
 		Ok(())

--- a/crates/verifier/src/zk_config.rs
+++ b/crates/verifier/src/zk_config.rs
@@ -13,6 +13,8 @@
 //!
 //! [`ZKWrappedVerifierChannel`]: binius_spartan_verifier::wrapper::ZKWrappedVerifierChannel
 
+use std::marker::PhantomData;
+
 use binius_core::{constraint_system::ConstraintSystem, word::Word};
 use binius_field::BinaryField128bGhash as B128;
 use binius_hash::binary_merkle_tree::HashSuite;
@@ -53,7 +55,9 @@ pub struct ZKVerifier<H: HashSuite> {
 	inner_iop_verifier: IOPVerifier,
 	outer_iop_verifier: IronSpartanIOPVerifier<B128>,
 	outer_layout: WitnessLayout<B128>,
-	basefold_compiler: BaseFoldVerifierCompiler<B128, H>,
+	basefold_compiler: BaseFoldVerifierCompiler<B128>,
+	/// The verifier creates its Merkle transcript channels with the hash suite `H`.
+	_hash_marker: PhantomData<H>,
 }
 
 impl<H> ZKVerifier<H>
@@ -136,6 +140,7 @@ where
 			outer_iop_verifier,
 			outer_layout,
 			basefold_compiler,
+			_hash_marker: PhantomData,
 		})
 	}
 
@@ -157,7 +162,7 @@ where
 	}
 
 	/// Returns the BaseFold ZK verifier compiler.
-	pub const fn basefold_compiler(&self) -> &BaseFoldVerifierCompiler<B128, H> {
+	pub const fn basefold_compiler(&self) -> &BaseFoldVerifierCompiler<B128> {
 		&self.basefold_compiler
 	}
 
@@ -183,7 +188,9 @@ where
 		transcript: &mut VerifierTranscript<Challenger_>,
 	) -> Result<(), Error> {
 		// Create BaseFold channel and wrap with outer verifier.
-		let channel = self.basefold_compiler.create_channel(transcript);
+		let channel = self
+			.basefold_compiler
+			.create_channel_from_transcript::<H, Challenger_, _>(transcript);
 		let mut wrapped_channel =
 			ZKWrappedVerifierChannel::new(channel, &self.outer_iop_verifier, &self.outer_layout)?;
 


### PR DESCRIPTION
Follow-up to #1693, addressing the four review comments left with the approval ([BINIUS-215](https://linear.app/jimpo/issue/BINIUS-215/abstract-merkle-ip-channels-over-transcript)):

- **`BaseFoldVerifierCompiler::create_channel` takes an `impl MerkleIPVerifierChannel<F>` by value** and just wraps it; the `merkle_scheme` field is removed. The struct collapses to `BaseFoldVerifierCompiler<F> { oracle_specs, fri_params }` — the `H: HashSuite` parameter is gone too (`new` still takes a scheme transiently for the `FRIParams::optimal_for_batch` proof-size estimation, with `H` demoted to a method generic). The now-pointless `merkle_scheme()` accessors and `BaseFoldTranscript*Channel` aliases are deleted.
- **`create_size_tracking_channel` removed**; its one caller (`spartan-verifier/tests/proof_size_test.rs`) constructs the `SizeTrackingChannel` directly. The hardcoded proof-size assertion is unmodified and passes.
- **`recv_oracle` asserts commitment-shape consistency with `log_msg_len`**: the committed message length implied by `(leaf_size, depth)` must equal the spec's `log_msg_len` (plus one variable for a ZK oracle's interleaved mask).
- **`BaseFoldProverCompiler::create_channel`/`create_channel_without_zk` take the channel by value** as well; the struct collapses to `BaseFoldProverCompiler<P, NTT>`.

For the common case, the compilers gain **`create_channel_from_transcript`** (and the prover's `create_channel_without_zk_from_transcript`), which wrap an owned-or-borrowed transcript in the concrete non-hiding Merkle channel. All compiler-paired construction sites — the main paths in `crates/{prover,verifier}` (incl. both zk_configs), spartan, m4, and the basefold/logup*/wrapper tests — use these helpers; the intmul bench setup passes an owned `ProverTranscript::default()` through the helper, eliminating the previous `Box::leak`.

Transcripts are byte-identical (round-trip tests and the unmodified proof-size assertions pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)