### PR TITLE
BINIUS-220: optimize embed_position in logup*

### DIFF
--- a/crates/iop-prover/src/logup_star.rs
+++ b/crates/iop-prover/src/logup_star.rs
@@ -12,7 +12,7 @@
 //!
 //! [Soukhanov25]: <https://eprint.iacr.org/2025/946>
 
-use binius_field::{BinaryField1b, ExtensionField, Field, PackedField};
+use binius_field::{BinaryField, Divisible, PackedField};
 use binius_ip_prover::logup_star::{self as reduction, witness};
 use binius_math::{FieldBuffer, multilinear::eq::eq_ind_partial_eval};
 
@@ -79,7 +79,7 @@ pub fn prove<F, P, Channel>(
 	channel: &mut Channel,
 ) -> LogupProof<P, Channel::Oracle>
 where
-	F: Field + ExtensionField<BinaryField1b>,
+	F: BinaryField<Underlier: Divisible<u64>>,
 	P: PackedField<Scalar = F>,
 	Channel: IOPProverChannel<P>,
 {

--- a/crates/ip-prover/src/logup_star/prove.rs
+++ b/crates/ip-prover/src/logup_star/prove.rs
@@ -2,7 +2,7 @@
 
 //! The top-level logUp* proving routine.
 
-use binius_field::{BinaryField1b, ExtensionField, Field, PackedField};
+use binius_field::{BinaryField, Divisible, Field, PackedField};
 use binius_ip::{MultilinearEvalClaim, logup_star::LogupOutput};
 use binius_math::FieldBuffer;
 
@@ -57,7 +57,7 @@ pub fn prove<F, P>(
 	channel: &mut impl IPProverChannel<F>,
 ) -> LogupOutput<F>
 where
-	F: Field + ExtensionField<BinaryField1b>,
+	F: BinaryField<Underlier: Divisible<u64>>,
 	P: PackedField<Scalar = F>,
 {
 	let m = table.log_len();
@@ -123,7 +123,7 @@ pub fn prove_reduction<F, P>(
 	channel: &mut impl IPProverChannel<F>,
 ) -> LogupOutput<F>
 where
-	F: Field + ExtensionField<BinaryField1b>,
+	F: BinaryField<Underlier: Divisible<u64>>,
 	P: PackedField<Scalar = F>,
 {
 	let m = table.log_len();

--- a/crates/ip-prover/src/logup_star/witness.rs
+++ b/crates/ip-prover/src/logup_star/witness.rs
@@ -9,7 +9,9 @@
 //! - the table denominator `c - J`, with `J` the embedded table positions,
 //! - the pushforward `Y = I_* eq_r`, the looker numerator scattered onto table positions.
 
-use binius_field::{BinaryField1b, ExtensionField, Field, PackedField};
+use std::iter;
+
+use binius_field::{BinaryField, Divisible, Field, PackedField};
 use binius_math::{FieldBuffer, multilinear::eq::eq_ind_partial_eval};
 use binius_utils::rayon::prelude::*;
 
@@ -21,15 +23,16 @@ use binius_utils::rayon::prelude::*;
 ///
 /// This is the same embedding the verifier uses for the table-side denominator `J`.
 /// It makes a position and an index value that point to it embed to the same field element.
+///
+/// The `GF(2)`-linear basis of a binary tower field is its underlier's bit basis: basis element
+/// `t` is the field element whose underlier has only bit `t` set. So `iota(j)` is just the field
+/// element whose underlier is `j`, which we build directly instead of summing basis elements.
+#[inline]
 pub fn embed_position<F>(j: usize) -> F
 where
-	F: Field + ExtensionField<BinaryField1b>,
+	F: BinaryField<Underlier: Divisible<u64>>,
 {
-	// usize::BITS bounds the loop; positions with a set bit at t contribute basis(t).
-	(0..usize::BITS as usize)
-		.filter(|&t| (j >> t) & 1 == 1)
-		.map(<F as ExtensionField<BinaryField1b>>::basis)
-		.fold(F::ZERO, |acc, b| acc + b)
+	F::from_underlier(F::Underlier::from_iter(iter::once(j as u64)))
 }
 
 /// Build the looker numerator `eq_r`, the equality indicator at the evaluation point.
@@ -51,7 +54,7 @@ where
 /// Entry `i` is `c - iota(index[i])`, the logUp denominator for looker row `i`.
 pub fn looker_denominator<F, P>(c: F, index: &[usize]) -> FieldBuffer<P>
 where
-	F: Field + ExtensionField<BinaryField1b>,
+	F: BinaryField<Underlier: Divisible<u64>>,
 	P: PackedField<Scalar = F>,
 {
 	// One denominator per looker row: shift the challenge by the row's embedded index value.
@@ -67,7 +70,7 @@ where
 /// Entry `j` is `c - iota(j)`, the logUp denominator for table position `j`.
 pub fn table_denominator<F, P>(c: F, table_n_vars: usize) -> FieldBuffer<P>
 where
-	F: Field + ExtensionField<BinaryField1b>,
+	F: BinaryField<Underlier: Divisible<u64>>,
 	P: PackedField<Scalar = F>,
 {
 	// One denominator per table position: shift the challenge by the position's embedding.


### PR DESCRIPTION
Implements [BINIUS-220](https://linear.app/jimpo/issue/BINIUS-220/optimize-embed-position-in-logup).

## Summary

`embed_position(j)` maps a table position `j` to the field element `iota(j) = Σ_{bit t of j set} basis(t)`. The old implementation summed up to 64 `GF(2)`-basis elements per call. Since the `GF(2)`-linear basis of a binary tower field **is** its underlier's bit basis (basis element `t` = the field element whose underlier has only bit `t` set), `iota(j)` is just the field element whose underlier equals `j`. So we build it directly:

```
#[inline]
pub fn embed_position<F>(j: usize) -> F
where
    F: BinaryField<Underlier: Divisible<u64>>,
{
    F::from_underlier(F::Underlier::from_iter(iter::once(j as u64)))
}
```

Per the issue, this threads the `BinaryField<Underlier: Divisible<u64>>` bound through the callers (`looker_denominator`, `table_denominator`, `logup_star::prove`, `prove_reduction`, and the committing wrapper), replacing the previous `Field + ExtensionField<BinaryField1b>` — which `BinaryField` subsumes.

## Behavior-preserving

The embedding is unchanged, so the transcript is identical and the existing logUp* prove→verify roundtrip tests pass without modification (13 tests across `binius-ip-prover` + `binius-iop-prover`). Each test's independent `iota` reference (the fold) is left in place and cross-checks the new path.

## Performance

Micro-benchmarked both implementations in one binary over 2²² calls (`OptimalB128`, `target-cpu=native`, release), 3 runs:

| | old (fold) | new (underlier) | speedup |
|---|---|---|---|
| 2²² embeds | ~540–564 ms | ~1.4–1.6 ms | **~350–410×** |

The embedding is now effectively free. It's called `2^m + 2^n` times per logUp* proof (one per table position and looker row), so it removes a per-row cost from denominator construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)