### PR TITLE
BINIUS-222: extend blake3_fixed to handle multiple chunks

### DIFF
--- a/crates/circuits/src/blake3/mod.rs
+++ b/crates/circuits/src/blake3/mod.rs
@@ -10,8 +10,9 @@
 //! The entry points are:
 //! - [`blake3_compress`] — single-block compression primitive.
 //! - [`blake3_compress_2x_seq`] — two sequential compressions sharing one parallel core.
-//! - [`blake3_fixed`] — single-chunk hash gadget for messages of compile-time-known length up to
-//!   1024 bytes.
+//! - [`blake3_chunk`] — single-chunk (up to 16 blocks) chaining-value gadget.
+//! - [`blake3_fixed`] — full hash gadget for messages of compile-time-known length, spanning any
+//!   number of chunks via BLAKE3's parent tree.
 
 use binius_core::word::Word;
 use binius_frontend::{CircuitBuilder, Wire};
@@ -84,10 +85,7 @@ pub fn blake3_chunk(
 	last_flags_extra: u32,
 ) -> [Wire; 8] {
 	let n_blocks = blocks.len();
-	assert!(
-		(1..=16).contains(&n_blocks),
-		"blake3_chunk: n_blocks ({n_blocks}) must be in 1..=16",
-	);
+	assert!((1..=16).contains(&n_blocks), "blake3_chunk: n_blocks ({n_blocks}) must be in 1..=16",);
 	assert_eq!(
 		block_lens.len(),
 		n_blocks,
@@ -152,36 +150,139 @@ pub fn blake3_chunk(
 	cv
 }
 
+/// One BLAKE3 parent-node compression: combines two child chaining values into one.
+///
+/// The parent block is the two children concatenated (16 words); the chaining value is the
+/// [`IV`], the counter is 0, the block length is [`BLOCK_BYTES`], and the flags are [`PARENT`]
+/// (plus [`ROOT`] for the tree root).
+fn blake3_parent(
+	builder: &CircuitBuilder,
+	left: [Wire; 8],
+	right: [Wire; 8],
+	is_root: bool,
+) -> [Wire; 8] {
+	let cv: [Wire; 8] = std::array::from_fn(|i| builder.add_constant(Word(IV[i] as u64)));
+	let block: [Wire; 16] = std::array::from_fn(|i| if i < 8 { left[i] } else { right[i - 8] });
+	let counter = builder.add_constant(Word::ZERO);
+	let block_len = builder.add_constant(Word(BLOCK_BYTES as u64));
+	let flags = builder.add_constant(Word((PARENT | if is_root { ROOT } else { 0 }) as u64));
+	blake3_compress(builder, cv, block, counter, block_len, flags)
+}
+
+/// Two independent BLAKE3 parent-node compressions evaluated in the two lanes of
+/// [`blake3_compress_2x`].
+///
+/// Lane 0 combines the pair `a`, lane 1 combines the pair `b`. Each child holds a 32-bit value in
+/// its low bits, so a pair is packed into a 64-bit wire by placing lane 0 in bits `[0:32]` and
+/// lane 1 in bits `[32:64]`. Returns the two parent chaining values, unpacked back into the
+/// low-32 layout.
+fn blake3_parent_2x(
+	builder: &CircuitBuilder,
+	a: ([Wire; 8], [Wire; 8]),
+	b: ([Wire; 8], [Wire; 8]),
+) -> ([Wire; 8], [Wire; 8]) {
+	// lane 0 in the low 32 bits, lane 1 in the high 32 bits; both children have zero high bits,
+	// so shifting lane 1 up and XOR-ing is a clean merge.
+	let pack = |lo: Wire, hi: Wire| builder.bxor(lo, builder.shl(hi, 32));
+	let cv: [Wire; 8] = std::array::from_fn(|i| {
+		let w = IV[i] as u64;
+		builder.add_constant(Word(w | (w << 32)))
+	});
+	let block: [Wire; 16] = std::array::from_fn(|i| {
+		if i < 8 {
+			pack(a.0[i], b.0[i])
+		} else {
+			pack(a.1[i - 8], b.1[i - 8])
+		}
+	});
+	let zero = builder.add_constant(Word::ZERO);
+	let block_len = builder.add_constant(Word((BLOCK_BYTES as u64) | ((BLOCK_BYTES as u64) << 32)));
+	let flags = builder.add_constant(Word((PARENT as u64) | ((PARENT as u64) << 32)));
+	let out = blake3_compress_2x(builder, cv, block, zero, zero, block_len, flags);
+	let cv_a: [Wire; 8] = std::array::from_fn(|i| clear_high_bits(builder, out[i], 32));
+	let cv_b: [Wire; 8] = std::array::from_fn(|i| builder.shr(out[i], 32));
+	(cv_a, cv_b)
+}
+
+/// Folds chunk chaining values into the root digest through BLAKE3's binary parent tree.
+///
+/// The tree is built bottom-up: at each level, adjacent chaining values are paired and combined by
+/// a parent compression, and a lone trailing value is promoted unchanged to the next level. This
+/// bottom-up pairing reproduces BLAKE3's canonical left-full tree exactly. Parent compressions are
+/// batched two at a time through [`blake3_parent_2x`]; the final root — the last level's single
+/// 2->1 compression — carries [`ROOT`].
+///
+/// Requires at least two chunk chaining values (a single chunk needs no tree).
+fn blake3_tree_root(builder: &CircuitBuilder, chunk_cvs: Vec<[Wire; 8]>) -> [Wire; 8] {
+	assert!(chunk_cvs.len() >= 2, "blake3_tree_root: needs at least two chunks");
+
+	let mut level = chunk_cvs;
+	let mut depth = 0;
+	loop {
+		// The root is the compression that reduces the final two subtree CVs to one.
+		if level.len() == 2 {
+			return blake3_parent(
+				&builder.subcircuit("blake3_tree_root"),
+				level[0],
+				level[1],
+				true,
+			);
+		}
+
+		let sub = builder.subcircuit(format!("blake3_tree_level[{depth}]"));
+		let n = level.len();
+		let n_pairs = n / 2;
+		let mut next: Vec<[Wire; 8]> = Vec::with_capacity(n.div_ceil(2));
+
+		// Combine two independent parents per `blake3_compress_2x` call.
+		let mut p = 0;
+		while p + 1 < n_pairs {
+			let (cv_a, cv_b) = blake3_parent_2x(
+				&sub,
+				(level[2 * p], level[2 * p + 1]),
+				(level[2 * p + 2], level[2 * p + 3]),
+			);
+			next.push(cv_a);
+			next.push(cv_b);
+			p += 2;
+		}
+		// A leftover unpaired parent (odd number of pairs) is done single-lane.
+		if p < n_pairs {
+			next.push(blake3_parent(&sub, level[2 * p], level[2 * p + 1], false));
+		}
+		// A lone trailing chaining value with no sibling is promoted unchanged.
+		if n % 2 == 1 {
+			next.push(level[n - 1]);
+		}
+
+		level = next;
+		depth += 1;
+	}
+}
+
 /// Computes the BLAKE3 hash of a compile-time fixed-length message.
 ///
-/// This is the BLAKE3 analog of
-/// [`sha256_fixed`](crate::sha256::sha256_fixed) — the message length is known at
-/// circuit construction time, which eliminates runtime padding logic.
+/// The BLAKE3 analog of [`sha256_fixed`](crate::sha256::sha256_fixed): the message length is known
+/// at circuit construction time, which fixes the chunk/tree shape and eliminates runtime padding
+/// logic.
 ///
-/// # Scope
-///
-/// Currently restricted to single-chunk inputs (`len_bytes <= 1024`). Multi-chunk
-/// hashing requires BLAKE3's tree construction with parent nodes and chunk counters,
-/// which is out of scope for this gadget. The underlying [`blake3_compress`] is
-/// fully general and can be wrapped to support multi-chunk in a follow-up.
+/// The message is split into 1024-byte chunks ([`blake3_chunk`]); each chunk's chaining value is
+/// folded into the digest by BLAKE3's binary parent tree, two independent parent compressions at a
+/// time via [`blake3_compress_2x`]. The single [`ROOT`] flag lands on the final compression: the
+/// lone chunk when the message fits in one chunk, otherwise the tree's root parent.
 ///
 /// # Arguments
 ///
 /// - `builder`: Circuit builder.
 /// - `message`: Input message as 32-bit little-endian words (4 bytes per wire). The high 32 bits of
 ///   each wire must be zero. Length must equal `len_bytes.div_ceil(4)`.
-/// - `len_bytes`: The compile-time-known length of the message in bytes. Must be at most
-///   [`CHUNK_BYTES`] (1024).
+/// - `len_bytes`: The compile-time-known length of the message in bytes.
 ///
 /// # Returns
 ///
 /// The BLAKE3 digest as 8 wires, each holding a 32-bit little-endian word in its
 /// low 32 bits.
 pub fn blake3_fixed(builder: &CircuitBuilder, message: &[Wire], len_bytes: usize) -> [Wire; 8] {
-	assert!(
-		len_bytes <= CHUNK_BYTES,
-		"blake3_fixed: len_bytes ({len_bytes}) exceeds single-chunk limit of {CHUNK_BYTES}",
-	);
 	assert_eq!(
 		message.len(),
 		len_bytes.div_ceil(4),
@@ -192,9 +293,9 @@ pub fn blake3_fixed(builder: &CircuitBuilder, message: &[Wire], len_bytes: usize
 
 	let zero = builder.add_constant(Word::ZERO);
 
-	// Build the padded message as a flat list of 32-bit LE words. BLAKE3 does not
-	// append a length field; the trailing partial block is simply zero-filled and
-	// its `block_len` parameter records the actual byte count.
+	// Build the padded message as a flat list of 32-bit LE words. BLAKE3 does not append a length
+	// field; the trailing partial block is simply zero-filled and its `block_len` parameter records
+	// the actual byte count.
 	let n_blocks = len_bytes.div_ceil(BLOCK_BYTES).max(1);
 	let n_padded_words = n_blocks * 16;
 
@@ -204,31 +305,52 @@ pub fn blake3_fixed(builder: &CircuitBuilder, message: &[Wire], len_bytes: usize
 	let mut padded: Vec<Wire> = Vec::with_capacity(n_padded_words);
 	padded.extend_from_slice(&message[..n_message_words]);
 	if boundary_bytes > 0 {
-		// Partial trailing word: mask the high bytes to zero (BLAKE3 words are
-		// little-endian, so the valid message bytes occupy the low bytes).
+		// Partial trailing word: mask the high bytes to zero (BLAKE3 words are little-endian, so
+		// the valid message bytes occupy the low bytes).
 		let mask_value = (1u64 << (boundary_bytes * 8)) - 1;
 		let mask = builder.add_constant(Word(mask_value));
 		padded.push(builder.band(message[n_message_words], mask));
 	}
 	padded.resize(n_padded_words, zero);
 
-	// Split the padded words into blocks, and record each block's byte length.
-	let blocks: Vec<[Wire; 16]> = (0..n_blocks)
-		.map(|j| std::array::from_fn(|i| padded[j * 16 + i]))
-		.collect();
-	let block_lens: Vec<Wire> = (0..n_blocks)
-		.map(|j| {
-			let len = if j + 1 == n_blocks {
-				len_bytes - j * BLOCK_BYTES
-			} else {
-				BLOCK_BYTES
-			};
-			builder.add_constant(Word(len as u64))
+	let block = |j: usize| -> [Wire; 16] { std::array::from_fn(|i| padded[j * 16 + i]) };
+	let block_len = |j: usize| -> Wire {
+		let len = if j + 1 == n_blocks {
+			len_bytes - j * BLOCK_BYTES
+		} else {
+			BLOCK_BYTES
+		};
+		builder.add_constant(Word(len as u64))
+	};
+
+	// One chaining value per chunk. Every chunk but the last is a full 16 blocks (1024 bytes).
+	let n_chunks = len_bytes.div_ceil(CHUNK_BYTES).max(1);
+	let blocks_per_chunk = CHUNK_BYTES / BLOCK_BYTES;
+	let chunk_cvs: Vec<[Wire; 8]> = (0..n_chunks)
+		.map(|c| {
+			let block_start = c * blocks_per_chunk;
+			let block_end = ((c + 1) * blocks_per_chunk).min(n_blocks);
+			let blocks: Vec<[Wire; 16]> = (block_start..block_end).map(block).collect();
+			let block_lens: Vec<Wire> = (block_start..block_end).map(block_len).collect();
+			// ROOT lands on the lone chunk directly; with multiple chunks it moves to the tree
+			// root.
+			let last_flags_extra = if n_chunks == 1 { ROOT } else { 0 };
+			blake3_chunk(
+				&builder.subcircuit(format!("blake3_chunk[{c}]")),
+				&blocks,
+				&block_lens,
+				c as u64,
+				last_flags_extra,
+			)
 		})
 		.collect();
 
-	// A single chunk: its chaining value is the digest, so ROOT lands on its final block.
-	blake3_chunk(builder, &blocks, &block_lens, 0, ROOT)
+	// A single chunk is its own digest; otherwise fold the chunk chaining values through the tree.
+	if n_chunks == 1 {
+		chunk_cvs[0]
+	} else {
+		blake3_tree_root(builder, chunk_cvs)
+	}
 }
 
 #[cfg(test)]
@@ -309,10 +431,24 @@ mod tests {
 	}
 
 	#[test]
-	#[should_panic(expected = "exceeds single-chunk limit")]
-	fn rejects_oversize() {
-		let builder = CircuitBuilder::new();
-		let message: Vec<Wire> = (0..257).map(|_| builder.add_witness()).collect();
-		blake3_fixed(&builder, &message, CHUNK_BYTES + 1);
+	fn multi_chunk() {
+		// Lengths spanning 2..=10 chunks, including odd chunk counts (3, 5, 7, 9) and a partial
+		// final chunk, to exercise the parent tree: the 2x-batched parents, the single-lane
+		// leftover parent, the lone-chaining-value promotion, and the ROOT node.
+		for &len in &[
+			1025usize, // 2 chunks: 16 blocks + 1 block
+			2048,      // 2 full chunks
+			2049,      // 3 chunks
+			3072,      // 3 full chunks
+			4096,      // 4 full chunks
+			5121,      // 5 chunks (odd), partial final chunk
+			7168,      // 7 full chunks
+			8192,      // 8 full chunks (balanced tree)
+			9217,      // 9 chunks (odd), partial final chunk
+			10240,     // 10 full chunks
+		] {
+			let input: Vec<u8> = (0..len).map(|i| (i * 37 + 1) as u8).collect();
+			check(&input);
+		}
 	}
 }

--- a/crates/circuits/src/blake3/mod.rs
+++ b/crates/circuits/src/blake3/mod.rs
@@ -57,6 +57,101 @@ pub const BLOCK_BYTES: usize = 64;
 /// Byte length of a BLAKE3 chunk.
 pub const CHUNK_BYTES: usize = 1024;
 
+/// Computes the BLAKE3 chaining value of a single chunk.
+///
+/// A BLAKE3 chunk is up to 16 blocks (1024 bytes) compressed in a chain: the chaining value is
+/// threaded block-to-block starting from the [`IV`]. The first block carries [`CHUNK_START`] and
+/// the last carries [`CHUNK_END`]; every block carries the chunk's `counter` (its chunk index).
+/// `last_flags_extra` is OR'd into the last block's flags — pass [`ROOT`] when this chunk is the
+/// entire message (no parent tree), otherwise `0`.
+///
+/// # Arguments
+///
+/// - `builder`: Circuit builder.
+/// - `blocks`: the chunk's message blocks (1..=16), each 16 little-endian 32-bit words.
+/// - `block_lens`: the byte length (0..=64) of each block; the trailing block may be partial.
+/// - `counter`: the chunk index, used as the 64-bit block counter for every block.
+/// - `last_flags_extra`: extra flags OR'd into the last block (e.g. [`ROOT`] for a lone chunk).
+///
+/// # Returns
+///
+/// The chunk's 8-word chaining value, each word a 32-bit value in its low 32 bits.
+pub fn blake3_chunk(
+	builder: &CircuitBuilder,
+	blocks: &[[Wire; 16]],
+	block_lens: &[Wire],
+	counter: u64,
+	last_flags_extra: u32,
+) -> [Wire; 8] {
+	let n_blocks = blocks.len();
+	assert!(
+		(1..=16).contains(&n_blocks),
+		"blake3_chunk: n_blocks ({n_blocks}) must be in 1..=16",
+	);
+	assert_eq!(
+		block_lens.len(),
+		n_blocks,
+		"blake3_chunk: block_lens.len() ({}) must equal blocks.len() ({n_blocks})",
+		block_lens.len(),
+	);
+
+	let zero = builder.add_constant(Word::ZERO);
+	let counter = builder.add_constant_64(counter);
+
+	let mut blocks = blocks.to_vec();
+	let mut block_lens = block_lens.to_vec();
+	let mut flags: Vec<Wire> = (0..n_blocks)
+		.map(|j| {
+			let start = if j == 0 { CHUNK_START } else { 0 };
+			let end = if j + 1 == n_blocks {
+				CHUNK_END | last_flags_extra
+			} else {
+				0
+			};
+			builder.add_constant(Word((start | end) as u64))
+		})
+		.collect();
+
+	// Pad to an even block count with one unused dummy block so the blocks pair up uniformly.
+	let odd = n_blocks % 2 == 1;
+	if odd {
+		blocks.push([zero; 16]);
+		block_lens.push(zero);
+		flags.push(zero);
+	}
+
+	// Initial chaining value = IV.
+	let mut cv: [Wire; 8] = std::array::from_fn(|i| builder.add_constant(Word(IV[i] as u64)));
+
+	// Compress two blocks at a time: `blake3_compress_2x_seq` chains two sequential block
+	// compressions through a single parallel core, roughly halving the per-block cost.
+	let n_pairs = blocks.len() / 2;
+	for pair in 0..n_pairs {
+		let (lo, hi) = (2 * pair, 2 * pair + 1);
+		let out = blake3_compress_2x_seq(
+			&builder.subcircuit(format!("blake3_chunk_compress[{pair}]")),
+			cv,
+			[blocks[lo], blocks[hi]],
+			counter,
+			[block_lens[lo], block_lens[hi]],
+			[flags[lo], flags[hi]],
+		);
+		// The chaining value after the pair is the second compression's output, in the low 32 bits
+		// of each word. On a trailing odd block the second lane is the unused dummy, so the chunk's
+		// chaining value is instead the first compression's output, in the high 32 bits.
+		let last_odd = odd && pair + 1 == n_pairs;
+		cv = std::array::from_fn(|i| {
+			if last_odd {
+				builder.shr(out[i], 32)
+			} else {
+				clear_high_bits(builder, out[i], 32)
+			}
+		});
+	}
+
+	cv
+}
+
 /// Computes the BLAKE3 hash of a compile-time fixed-length message.
 ///
 /// This is the BLAKE3 analog of
@@ -117,14 +212,11 @@ pub fn blake3_fixed(builder: &CircuitBuilder, message: &[Wire], len_bytes: usize
 	}
 	padded.resize(n_padded_words, zero);
 
-	// All blocks of a single chunk share the chunk counter (0).
-	let counter = zero;
-
-	// Per-block message words, byte lengths, and domain-separation flags.
-	let mut blocks: Vec<[Wire; 16]> = (0..n_blocks)
+	// Split the padded words into blocks, and record each block's byte length.
+	let blocks: Vec<[Wire; 16]> = (0..n_blocks)
 		.map(|j| std::array::from_fn(|i| padded[j * 16 + i]))
 		.collect();
-	let mut block_lens: Vec<Wire> = (0..n_blocks)
+	let block_lens: Vec<Wire> = (0..n_blocks)
 		.map(|j| {
 			let len = if j + 1 == n_blocks {
 				len_bytes - j * BLOCK_BYTES
@@ -134,56 +226,9 @@ pub fn blake3_fixed(builder: &CircuitBuilder, message: &[Wire], len_bytes: usize
 			builder.add_constant(Word(len as u64))
 		})
 		.collect();
-	let mut flags: Vec<Wire> = (0..n_blocks)
-		.map(|j| {
-			let start = if j == 0 { CHUNK_START } else { 0 };
-			let end = if j + 1 == n_blocks {
-				CHUNK_END | ROOT
-			} else {
-				0
-			};
-			builder.add_constant(Word((start | end) as u64))
-		})
-		.collect();
 
-	// Pad to an even block count with one unused dummy block so the blocks pair up uniformly.
-	let odd = n_blocks % 2 == 1;
-	if odd {
-		blocks.push([zero; 16]);
-		block_lens.push(zero);
-		flags.push(zero);
-	}
-
-	// Initial chaining value = IV.
-	let mut cv: [Wire; 8] = std::array::from_fn(|i| builder.add_constant(Word(IV[i] as u64)));
-
-	// Compress two blocks at a time: `blake3_compress_2x_seq` chains two sequential block
-	// compressions through a single parallel core, roughly halving the per-block cost.
-	let n_pairs = blocks.len() / 2;
-	for pair in 0..n_pairs {
-		let (lo, hi) = (2 * pair, 2 * pair + 1);
-		let out = blake3_compress_2x_seq(
-			&builder.subcircuit(format!("blake3_fixed_compress[{pair}]")),
-			cv,
-			[blocks[lo], blocks[hi]],
-			counter,
-			[block_lens[lo], block_lens[hi]],
-			[flags[lo], flags[hi]],
-		);
-		// The chaining value after the pair is the second compression's output, in the low 32 bits
-		// of each word. On a trailing odd block the second lane is the unused dummy, so the chunk's
-		// chaining value is instead the first compression's output, in the high 32 bits.
-		let last_odd = odd && pair + 1 == n_pairs;
-		cv = std::array::from_fn(|i| {
-			if last_odd {
-				builder.shr(out[i], 32)
-			} else {
-				clear_high_bits(builder, out[i], 32)
-			}
-		});
-	}
-
-	cv
+	// A single chunk: its chaining value is the digest, so ROOT lands on its final block.
+	blake3_chunk(builder, &blocks, &block_lens, 0, ROOT)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Implements [BINIUS-222](https://linear.app/jimpo/issue/BINIUS-222/extend-blake3-fixed-circuit-gadget-to-handle-multiple-chunks).

Extends `blake3_fixed` (in `binius-circuits`) from single-chunk (≤1024 bytes) to arbitrary compile-time-fixed lengths, using BLAKE3's parent tree with 2x-parallel compression for the tree layers.

Two commits:

## 1. Extract `blake3_chunk` sub-gadget

Factors the single-chunk compression chain out of `blake3_fixed` into a reusable `pub fn blake3_chunk` (1..=16 blocks, `CHUNK_START`/`CHUNK_END` flags, chunk counter, `ROOT` via a `last_flags_extra` arg). Behavior-preserving — `blake3_fixed` delegates to it for the single chunk.

## 2. Multi-chunk tree compression

- `blake3_fixed` now splits the message into 1024-byte chunks, hashes each with `blake3_chunk` (chunk `c` gets counter `c`), and folds the chunk chaining values into the digest through BLAKE3's binary parent tree.
- New private helpers: `blake3_parent` (one parent node via `blake3_compress`) and `blake3_parent_2x` (**two independent parent compressions in the two lanes of `blake3_compress_2x`** — the "2x parallel compress for the tree layers" the issue asks for), and `blake3_tree_root` which drives the level-by-level fold.
- The `ROOT` flag moves from the last chunk block to the final tree compression (single chunk stays as before, `ROOT` on its `CHUNK_END` block).

### Why the bottom-up pairing is correct

`blake3_tree_root` builds the tree bottom-up: pair adjacent CVs, promote a lone trailing CV unchanged, repeat. This reproduces BLAKE3's canonical **left-full** tree exactly — I verified the equivalence by hand for n = 3, 5, 6, 7, 9, 10, 11 chunks, and the tests confirm it against the `blake3` crate oracle for chunk counts up to 10 (including the odd counts 3/5/7/9 that exercise the single-lane leftover parent and the lone-CV promotion). Two independent parents are batched per `blake3_compress_2x` call; the final 2→1 root is a single `blake3_compress` carrying `PARENT | ROOT`.

## Validation

- `cargo test -p binius-circuits blake3` — 18 pass, including a new `multi_chunk` test (lengths 1025…10240, i.e. 2–10 chunks incl. odd counts and partial final chunks), all checked against `blake3::hash`. Existing single-chunk tests pass unchanged.
- `cargo clippy -p binius-circuits --all-targets -- -D warnings`, nightly `fmt --check`, `typos`, `RUSTDOCFLAGS='-D warnings' cargo doc` — clean.
- `binius-circuits` is architecture-independent (no cross-arch matrix). `blake3_fixed` has no callers outside `src/blake3/`, so no snapshot/example circuits are affected.

## Note on the sub-gadget split

The issue suggested `blake3_full_chunk` / `blake3_partial_chunk`. A full chunk and a partial (last) chunk differ only in block count and the last block's length, so I consolidated them into one `blake3_chunk(blocks, block_lens, counter, last_flags_extra)` rather than two near-identical gadgets. Happy to split them if you'd prefer the explicit pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)