### PR TITLE
BINIUS-208: replace intmul phase 4/5 with a logup* fixed-base exponentiation lookup

### DIFF
--- a/crates/iop-prover/src/logup_star.rs
+++ b/crates/iop-prover/src/logup_star.rs
@@ -21,36 +21,19 @@ use binius_math::{
 
 use crate::channel::IOPProverChannel;
 
-/// The pushforward oracle relation produced by the prover.
-///
-/// The four fields match the oracle-relation tuple the prover channel opens.
-/// The caller batches this with the table and index openings into one channel open.
-pub struct PushforwardRelation<P: PackedField, Oracle> {
-	/// The handle of the committed pushforward oracle.
-	pub oracle: Oracle,
-	/// The committed message, the pushforward `Y` over the `m`-variable cube.
-	pub message: FieldBuffer<P>,
-	/// The transparent polynomial, the equality indicator at the reduced table point.
-	pub transparent: FieldBuffer<P>,
-	/// The inner-product claim, the pushforward evaluation `Y(table_eval_point)`.
-	pub claim: P::Scalar,
-}
-
 /// The reduced claims of a committed logUp* proof.
 ///
 /// The table and index claims are left for the caller to open against its own commitments.
-/// The pushforward claim is packaged as an oracle relation against the commitment sent here.
-pub struct LogupProof<P: PackedField, Oracle> {
+/// The pushforward claim is opened against the commitment sent here, through the channel.
+pub struct LogupProof<F> {
 	/// The `m`-coordinate point shared by the table and pushforward claims.
-	pub table_eval_point: Vec<P::Scalar>,
+	pub table_eval_point: Vec<F>,
 	/// The claimed evaluation of the table `T` at the point.
-	pub table_eval_claim: P::Scalar,
+	pub table_eval_claim: F,
 	/// The `n`-coordinate point shared by the index claims.
-	pub index_eval_point: Vec<P::Scalar>,
+	pub index_eval_point: Vec<F>,
 	/// The claimed evaluations of the per-looker embedded index columns at the point.
-	pub index_eval_claims: Vec<P::Scalar>,
-	/// The oracle relation that opens the pushforward at the reduced point.
-	pub pushforward: PushforwardRelation<P, Oracle>,
+	pub index_eval_claims: Vec<F>,
 }
 
 /// Prove a logUp* reduction whose pushforward is committed as an oracle.
@@ -59,8 +42,8 @@ pub struct LogupProof<P: PackedField, Oracle> {
 /// It builds the pushforward `Y` once, commits it, then runs the reduction over that same buffer.
 /// Committing before the reduction binds `Y` into the logUp challenge.
 ///
-/// The returned relation asserts `<Y, eq_r'> = Y(r')` at the reduced table point `r'`.
-/// The caller batches this relation with the table and index openings into one channel open.
+/// The relation `<Y, eq_r'> = Y(r')` at the reduced table point `r'` is opened through the
+/// channel, which may defer the actual opening to `finish()`.
 ///
 /// # Arguments
 ///
@@ -77,7 +60,7 @@ pub fn prove<F, P, Channel>(
 	table: &FieldBuffer<P>,
 	lookers: &[Looker<'_, F>],
 	channel: &mut Channel,
-) -> LogupProof<P, Channel::Oracle>
+) -> LogupProof<F>
 where
 	F: BinaryField<Underlier: Divisible<u64>>,
 	P: PackedField<Scalar = F>,
@@ -113,22 +96,23 @@ where
 		channel,
 	);
 
-	// The pushforward relation opens Y at the reduced point.
+	// Open the pushforward relation through the channel; a deferring channel (e.g. BaseFold)
+	// batches it with every other queued relation in `finish()`.
 	//
 	//     <Y, eq_r'> = Y(r') = pushforward_eval_claim
 	let transparent = eq_ind_partial_eval::<P>(&output.table_eval_point);
+	channel.prove_oracle_relations([(
+		oracle,
+		pushforward,
+		transparent,
+		output.pushforward_eval_claim,
+	)]);
 
 	LogupProof {
 		table_eval_point: output.table_eval_point,
 		table_eval_claim: output.table_eval_claim,
 		index_eval_point: output.index_eval_point,
 		index_eval_claims: output.index_eval_claims,
-		pushforward: PushforwardRelation {
-			oracle,
-			message: pushforward,
-			transparent,
-			claim: output.pushforward_eval_claim,
-		},
 	}
 }
 
@@ -139,9 +123,7 @@ mod tests {
 		arch::{OptimalB128, OptimalPackedB128},
 	};
 	use binius_iop::{
-		channel::{IOPVerifierChannel, OracleSpec},
-		logup_star as verify_logup,
-		naive_channel::NaiveVerifierChannel,
+		channel::OracleSpec, logup_star as verify_logup, naive_channel::NaiveVerifierChannel,
 	};
 	use binius_ip::logup_star::LookerClaim;
 	use binius_math::{
@@ -153,7 +135,7 @@ mod tests {
 	use rand::prelude::*;
 
 	use super::*;
-	use crate::{channel::IOPProverChannel, naive_channel::NaiveProverChannel};
+	use crate::naive_channel::NaiveProverChannel;
 
 	type F = OptimalB128;
 	type P = OptimalPackedB128;
@@ -214,13 +196,6 @@ mod tests {
 		};
 		let prover_proof = prove::<F, P, _>(&table, &[looker], &mut prover_channel);
 
-		let PushforwardRelation {
-			oracle,
-			message,
-			transparent,
-			claim: pushforward_claim,
-		} = prover_proof.pushforward;
-		prover_channel.prove_oracle_relations([(oracle, message, transparent, pushforward_claim)]);
 		prover_channel.finish();
 
 		// Verify: receive Y, run the reduction, then open the pushforward relation.
@@ -233,10 +208,6 @@ mod tests {
 		};
 		let verifier_proof = verify_logup::verify(m, &[looker_claim], &mut verifier_channel)
 			.expect("verification succeeds");
-		let verifier_pushforward_claim = verifier_proof.pushforward.claim;
-		verifier_channel
-			.verify_oracle_relations([verifier_proof.pushforward])
-			.expect("the pushforward opening verifies");
 		verifier_channel.finish();
 
 		// The prover and verifier must derive identical reduced claims from the same transcript.
@@ -247,7 +218,6 @@ mod tests {
 			prover_proof.index_eval_claims, verifier_proof.index_eval_claims,
 			"index claims"
 		);
-		assert_eq!(pushforward_claim, verifier_pushforward_claim, "pushforward claim");
 
 		// The reduced table claim is the honest evaluation of T at the reduced point.
 		assert_eq!(
@@ -256,17 +226,8 @@ mod tests {
 			"table claim wrong (n={n}, m={m})"
 		);
 
-		// The pushforward claim is the honest evaluation of Y = I_* eq_r at the same point.
-		let mut pushforward = vec![F::ZERO; 1usize << m];
-		for (&j, &eq) in index.iter().zip(&eq_r) {
-			pushforward[j] += eq;
-		}
-		let pushforward = FieldBuffer::<P>::from_values(&pushforward);
-		assert_eq!(
-			pushforward_claim,
-			evaluate(&pushforward, &prover_proof.table_eval_point),
-			"pushforward claim wrong (n={n}, m={m})"
-		);
+		// The pushforward opening is checked inside the channel; nothing further to assert here.
+		let _ = eq_r;
 
 		// The index claim is the honest evaluation of the embedded index column.
 		let index_embedded = index.iter().map(|&j| iota::<F>(j, m)).collect::<Vec<_>>();
@@ -319,13 +280,6 @@ mod tests {
 			},
 		];
 		let prover_proof = prove::<F, P, _>(&table, &lookers, &mut prover_channel);
-		let PushforwardRelation {
-			oracle,
-			message,
-			transparent,
-			claim,
-		} = prover_proof.pushforward;
-		prover_channel.prove_oracle_relations([(oracle, message, transparent, claim)]);
 		prover_channel.finish();
 
 		let mut verifier_transcript = prover_transcript.into_verifier();
@@ -343,9 +297,6 @@ mod tests {
 		];
 		let verifier_proof = verify_logup::verify(m, &looker_claims, &mut verifier_channel)
 			.expect("verification succeeds");
-		verifier_channel
-			.verify_oracle_relations([verifier_proof.pushforward])
-			.expect("the pushforward opening verifies");
 		verifier_channel.finish();
 
 		assert_eq!(prover_proof.table_eval_point, verifier_proof.table_eval_point);
@@ -379,14 +330,7 @@ mod tests {
 			eval_point: &eval_point,
 			eval_claim: wrong_claim,
 		};
-		let prover_proof = prove::<F, P, _>(&table, &[looker], &mut prover_channel);
-		let PushforwardRelation {
-			oracle,
-			message,
-			transparent,
-			claim,
-		} = prover_proof.pushforward;
-		prover_channel.prove_oracle_relations([(oracle, message, transparent, claim)]);
+		let _prover_proof = prove::<F, P, _>(&table, &[looker], &mut prover_channel);
 		prover_channel.finish();
 
 		// The reduction's product check must surface the inconsistency as a verification failure.
@@ -456,13 +400,6 @@ mod tests {
 			eval_claim,
 		};
 		let prover_proof = prove::<F, BP, _>(&table, &[looker], &mut prover_channel);
-		let PushforwardRelation {
-			oracle,
-			message,
-			transparent,
-			claim,
-		} = prover_proof.pushforward;
-		prover_channel.prove_oracle_relations([(oracle, message, transparent, claim)]);
 		prover_channel.finish();
 
 		// Verify: receive Y, run the reduction, open the pushforward through the real FRI check.
@@ -475,9 +412,6 @@ mod tests {
 		};
 		let verifier_proof = verify_logup::verify(m, &[looker_claim], &mut verifier_channel)
 			.expect("verification succeeds");
-		verifier_channel
-			.verify_oracle_relations([verifier_proof.pushforward])
-			.expect("the FRI pushforward opening verifies");
 		verifier_channel
 			.finish()
 			.expect("the batched FRI opening verifies");
@@ -493,12 +427,7 @@ mod tests {
 			"table claim must be the honest table evaluation"
 		);
 
-		// The pushforward claim is the honest evaluation of Y = I_* eq_r at the reduced point.
-		let mut pushforward = vec![F::ZERO; 1usize << m];
-		for (&j, &eq) in index.iter().zip(&eq_r) {
-			pushforward[j] += eq;
-		}
-		let pushforward = FieldBuffer::<BP>::from_values(&pushforward);
-		assert_eq!(claim, evaluate(&pushforward, &prover_proof.table_eval_point));
+		// The FRI opening already bound the pushforward claim inside the channel.
+		let _ = eq_r;
 	}
 }

--- a/crates/iop/src/logup_star.rs
+++ b/crates/iop/src/logup_star.rs
@@ -32,8 +32,8 @@ pub enum Error {
 /// The reduced claims of a committed logUp* verification.
 ///
 /// The table and index claims are left for the caller to open against its own commitments.
-/// The pushforward claim is packaged as an oracle relation against the commitment received here.
-pub struct LogupProof<'a, Oracle, Elem> {
+/// The pushforward claim is opened against the commitment received here, through the channel.
+pub struct LogupProof<Elem> {
 	/// The `m`-coordinate point shared by the table and pushforward claims.
 	pub table_eval_point: Vec<Elem>,
 	/// The claimed evaluation of the table `T` at the point.
@@ -42,8 +42,6 @@ pub struct LogupProof<'a, Oracle, Elem> {
 	pub index_eval_point: Vec<Elem>,
 	/// The claimed evaluations of the per-looker embedded index columns at the point.
 	pub index_eval_claims: Vec<Elem>,
-	/// The oracle relation `<Y, eq_{table_eval_point}> = Y(table_eval_point)` for the pushforward.
-	pub pushforward: OracleLinearRelation<'a, Oracle, Elem>,
 }
 
 /// Verify a logUp* reduction whose pushforward is committed as an oracle.
@@ -51,11 +49,8 @@ pub struct LogupProof<'a, Oracle, Elem> {
 /// This wraps [`binius_ip::logup_star::verify_reduction`] with the pushforward commitment: the
 /// looker batching challenge is sampled first (the prover builds the combined pushforward from
 /// it), then the `Y` oracle is received before the reduction, so the logUp challenge binds the
-/// commitment. It then returns the relation that opens `Y` at the reduced point.
-///
-/// The returned relation asserts `<Y, eq_r'> = Y(r')` at the reduced table point `r'`.
-/// Its transparent polynomial is the equality indicator at `r'`.
-/// The caller batches this relation with the table and index openings into one channel open.
+/// commitment. The relation `<Y, eq_r'> = Y(r')` at the reduced table point `r'` is opened
+/// through the channel, which may defer the actual opening to `finish()`.
 ///
 /// # Arguments
 ///
@@ -70,7 +65,7 @@ pub fn verify<'a, F, C>(
 	table_n_vars: usize,
 	lookers: &[reduction::LookerClaim<'_, C::Elem>],
 	channel: &mut C,
-) -> Result<LogupProof<'a, C::Oracle, C::Elem>, Error>
+) -> Result<LogupProof<C::Elem>, Error>
 where
 	F: Field + ExtensionField<BinaryField1b>,
 	C: IOPVerifierChannel<'a, F>,
@@ -90,23 +85,23 @@ where
 	// Run the bare reduction over the same channel, viewed as an IP channel.
 	let output = reduction::verify_reduction::<F, C>(gamma, table_n_vars, lookers, channel)?;
 
-	// The pushforward relation opens Y at the reduced point.
+	// Open the pushforward relation through the channel; a deferring channel (e.g. BaseFold)
+	// batches it with every other queued relation in `finish()`.
 	//
 	//     <Y, eq_r'> = Y(r') = pushforward_eval_claim
 	//
 	// BaseFold reduces this inner product to a challenge point, where the transparent is eq(r', .).
 	let point = output.table_eval_point.clone();
-	let pushforward = OracleLinearRelation {
+	channel.verify_oracle_relations([OracleLinearRelation {
 		oracle,
 		transparent: Box::new(move |challenge: &[C::Elem]| eq_ind(&point, challenge)),
 		claim: output.pushforward_eval_claim,
-	};
+	}])?;
 
 	Ok(LogupProof {
 		table_eval_point: output.table_eval_point,
 		table_eval_claim: output.table_eval_claim,
 		index_eval_point: output.index_eval_point,
 		index_eval_claims: output.index_eval_claims,
-		pushforward,
 	})
 }

--- a/crates/ip-prover/src/prodcheck.rs
+++ b/crates/ip-prover/src/prodcheck.rs
@@ -161,9 +161,21 @@ where
 
 /// Output of [`batch_prove`].
 ///
+/// After the full `n_layers` reduction, `evals` holds each input prover's reduced evaluation at
+/// `eval_point`. The batched claim the verifier checks is the eq(selector)-weighted combination
+/// of these evaluations.
+pub struct BatchProveOutput<F> {
+	/// The reduced evaluation point (`selector ++ content ++ node`) shared by all input provers.
+	pub eval_point: Vec<F>,
+	/// Each input prover's reduced evaluation at `eval_point`, in input order.
+	pub evals: Vec<F>,
+}
+
+/// Output of [`batch_prove_until_final_layer`].
+///
 /// After running `n_layers - 1` reduction layers, each prover retains its final (widest) layer.
 /// `provers` pairs each remaining prover with its reduced evaluation at `eval_point`.
-pub struct BatchProveOutput<P: PackedField> {
+pub struct BatchProveUntilFinalLayerOutput<P: PackedField> {
 	/// The reduced evaluation point shared by all remaining provers.
 	pub eval_point: Vec<P::Scalar>,
 	/// Each remaining prover (with its final layer) paired with its reduced eval at `eval_point`.
@@ -198,14 +210,14 @@ pub struct BatchProveOutput<P: PackedField> {
 /// * `claimed_products.len() == provers.len()`.
 /// * `content_point.len() == witness.log_len() - n_layers` for each prover.
 ///
-/// This runs `n_layers - 1` of the per-layer reductions, stopping one layer short so that each
-/// prover retains its final (widest) layer. The remaining provers are returned (each paired with
-/// its reduced eval at the shared reduced `eval_point`) rather than combined into a single claim,
-/// so the caller can finish the final layer itself.
+/// This delegates to [`batch_prove_until_final_layer`] and then runs the final retained layer,
+/// returning the reduced per-input-prover evaluations at the reduced evaluation point. The
+/// batched claim is checked by the ordinary `binius_ip::prodcheck::verify` recursion over
+/// `n_layers` layers (the eq(selector)-weighted combination of the returned evaluations), with
+/// the selector coordinates forming the first `k` coordinates of the claim point.
 ///
 /// # Returns
-/// A [`BatchProveOutput`] with the reduced `eval_point` and the remaining (single-layer) provers,
-/// each paired with its reduced eval at that point.
+/// A [`BatchProveOutput`] with the reduced `eval_point` and each input prover's reduced eval.
 ///
 /// # Mathematical Description
 ///
@@ -230,7 +242,49 @@ pub fn batch_prove<F: Field, P: PackedField<Scalar = F>>(
 	selector_point: Vec<F>,
 	content_point: Vec<F>,
 	channel: &mut impl IPProverChannel<F>,
-) -> BatchProveOutput<P> {
+) -> BatchProveOutput<F> {
+	let n = provers.len();
+	let k = selector_point.len();
+
+	let BatchProveUntilFinalLayerOutput {
+		eval_point,
+		provers,
+	} = batch_prove_until_final_layer(
+		provers,
+		claimed_products,
+		selector_point,
+		content_point,
+		channel,
+	);
+
+	// Finish the retained final layer: run it exactly as an interior reduction layer does.
+	let (claimed_products, provers): (Vec<_>, Vec<_>) = provers.into_iter().unzip();
+	let (provers, mut evals, eval_point) =
+		batch_prove_layer(provers, claimed_products, eval_point, k, channel);
+	debug_assert!(provers.is_empty(), "the final layer leaves no provers");
+
+	// Drop the padded (2^k) selector slots, keeping one reduced eval per input prover.
+	evals.truncate(n);
+
+	BatchProveOutput { eval_point, evals }
+}
+
+/// Runs a batched product check up to (but not finishing) the final layer.
+///
+/// Runs `n_layers - 1` of the per-layer reductions, stopping one layer short so that each prover
+/// retains its final (widest) layer. The remaining provers are returned (each paired with its
+/// reduced eval at the shared reduced `eval_point`) rather than combined into a single claim, so
+/// the caller can finish the final layer itself — e.g. [`batch_prove`] runs it directly, or a
+/// caller splices the retained layers into another reduction.
+///
+/// Arguments and preconditions are as for [`batch_prove`].
+pub fn batch_prove_until_final_layer<F: Field, P: PackedField<Scalar = F>>(
+	provers: Vec<ProdcheckProver<P>>,
+	claimed_products: Vec<F>,
+	selector_point: Vec<F>,
+	content_point: Vec<F>,
+	channel: &mut impl IPProverChannel<F>,
+) -> BatchProveUntilFinalLayerOutput<P> {
 	assert!(!provers.is_empty()); // precondition
 	assert_eq!(claimed_products.len(), provers.len()); // precondition
 
@@ -258,7 +312,7 @@ pub fn batch_prove<F: Field, P: PackedField<Scalar = F>>(
 	// Pair each remaining (single-layer) prover with its reduced eval at `eval_point`.
 	let provers = iter::zip(claimed_products, provers).collect();
 
-	BatchProveOutput {
+	BatchProveUntilFinalLayerOutput {
 		eval_point,
 		provers,
 	}
@@ -391,25 +445,17 @@ mod tests {
 
 	use super::*;
 
-	/// Finishes a [`batch_prove`] output by running the final retained layer and combining the
-	/// per-prover reduced evals into a single [`MultilinearEvalClaim`], matching the full-reduction
-	/// claim the verifier produces.
-	fn finish_batch_prove<F: Field, P: PackedField<Scalar = F>>(
-		output: BatchProveOutput<P>,
+	/// Combines the per-input-prover evals returned by [`batch_prove`] into the single
+	/// [`MultilinearEvalClaim`] the verifier produces: the eq(selector)-weighted sum over the
+	/// first `k` (selector) coordinates of the reduced evaluation point.
+	fn combine_batch_prove<F: Field, P: PackedField<Scalar = F>>(
+		output: BatchProveOutput<F>,
 		k: usize,
-		channel: &mut impl IPProverChannel<F>,
 	) -> MultilinearEvalClaim<F> {
-		let BatchProveOutput {
-			eval_point,
-			provers,
-		} = output;
-		let (claimed_products, provers): (Vec<_>, Vec<_>) = provers.into_iter().unzip();
-
-		let (_provers, claimed_products, eval_point) =
-			batch_prove_layer(provers, claimed_products, eval_point, k, channel);
-
-		let eq_weights = eq_ind_partial_eval::<F>(&eval_point[..k]);
-		let final_eval = inner_product(claimed_products.iter().copied(), eq_weights.iter_scalars());
+		let BatchProveOutput { eval_point, evals } = output;
+		let eq_weights = eq_ind_partial_eval::<P>(&eval_point[..k]);
+		let final_eval =
+			inner_product(evals.iter().copied(), (0..evals.len()).map(|i| eq_weights.get(i)));
 
 		MultilinearEvalClaim {
 			eval: final_eval,
@@ -553,8 +599,8 @@ mod tests {
 			&mut prover_transcript,
 		);
 		// Each remaining prover has exactly one layer.
-		assert!(batch_output.provers.iter().all(|(_, p)| p.n_layers() == 1));
-		let prover_output = finish_batch_prove(batch_output, log_n_provers, &mut prover_transcript);
+		assert_eq!(batch_output.evals.len(), n_provers);
+		let prover_output = combine_batch_prove::<_, P>(batch_output, log_n_provers);
 
 		// Run verifier with n_layers layers
 		let mut verifier_transcript = prover_transcript.into_verifier();
@@ -671,8 +717,8 @@ mod tests {
 			content_point,
 			&mut prover_transcript,
 		);
-		assert!(batch_output.provers.iter().all(|(_, p)| p.n_layers() == 1));
-		let prover_output = finish_batch_prove(batch_output, log_n_provers, &mut prover_transcript);
+		assert_eq!(batch_output.evals.len(), n_provers);
+		let prover_output = combine_batch_prove::<_, P>(batch_output, log_n_provers);
 
 		// Run verifier with n_layers layers.
 		let mut verifier_transcript = prover_transcript.into_verifier();

--- a/crates/prover/benches/intmul.rs
+++ b/crates/prover/benches/intmul.rs
@@ -21,11 +21,14 @@ use binius_math::{
 };
 use binius_prover::protocols::intmul::{
 	prove::IntMulProver,
-	witness::{Witness, compute_b_leaves, constant_base_leaves},
+	witness::{Witness, compute_b_leaves, power_table},
 };
 use binius_transcript::ProverTranscript;
 use binius_utils::rayon::ThreadPoolBuilder;
-use binius_verifier::{config::StdChallenger, protocols::intmul::common::frobenius_twist};
+use binius_verifier::{
+	config::{LOG_WORD_SIZE_BITS, StdChallenger},
+	protocols::intmul::common::{LIMB_BITS, frobenius_twist},
+};
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use rand::prelude::*;
 
@@ -34,18 +37,12 @@ type F = BinaryField128bGhash;
 
 /// Number of exponents is `2^LOG_NUM`.
 const LOG_NUM: usize = 14;
-/// Log of the integer bit width; the exponentiation tree has `2^LOG_BITS` leaves per node.
-const LOG_BITS: usize = 6;
 
 /// The Reed-Solomon rate of the standard prover configuration.
 const LOG_INV_RATE: usize = 1;
 /// One FRI test query keeps the parameters cheap; the benchmarks measure commitment cost, not
 /// opening soundness.
 const N_TEST_QUERIES: usize = 1;
-/// Log-length of the oracle budget the channel declares. intmul commits no oracle yet; this
-/// matches the 2^16-entry exponentiation-table pushforward its logup*-based phase 5 commits,
-/// so the harness measures that cost as soon as it lands.
-const LOG_ORACLE_LEN: usize = 16;
 
 /// Builds a BaseFold prover compiler for the prove benchmarks.
 ///
@@ -57,7 +54,7 @@ fn basefold_compiler() -> BaseFoldProverCompiler<P, NeighborsLastSingleThread<Ge
 {
 	let verifier_compiler = BaseFoldVerifierCompiler::new(
 		BinaryMerkleTreeScheme::<F, StdHashSuite>::new(),
-		vec![OracleSpec::new(LOG_ORACLE_LEN)],
+		vec![OracleSpec::new(LIMB_BITS)],
 		LOG_INV_RATE,
 		N_TEST_QUERIES,
 		&MinProofSizeStrategy,
@@ -108,11 +105,11 @@ fn bench_intmul_prove(c: &mut Criterion) {
 	group.bench_with_input(
 		BenchmarkId::new("witness", num_exponents),
 		&num_exponents,
-		|bencher, _| bencher.iter(|| Witness::<P>::new(LOG_BITS, &a, &b, &c_lo, &c_hi).unwrap()),
+		|bencher, _| bencher.iter(|| Witness::<P>::new(&a, &b, &c_lo, &c_hi).unwrap()),
 	);
 
 	// prove
-	let witness = Witness::<P>::new(LOG_BITS, &a, &b, &c_lo, &c_hi).unwrap();
+	let witness = Witness::<P>::new(&a, &b, &c_lo, &c_hi).unwrap();
 	let compiler = basefold_compiler();
 
 	group.bench_with_input(
@@ -150,7 +147,7 @@ fn bench_intmul_prove(c: &mut Criterion) {
 				},
 				|channel| {
 					let mut intmul_prover = IntMulProver::new(0, channel);
-					let witness = Witness::<P>::new(LOG_BITS, &a, &b, &c_lo, &c_hi).unwrap();
+					let witness = Witness::<P>::new(&a, &b, &c_lo, &c_hi).unwrap();
 					intmul_prover.prove(witness);
 				},
 				BatchSize::SmallInput,
@@ -167,8 +164,7 @@ fn bench_intmul_phases(c: &mut Criterion) {
 	group.throughput(Throughput::Elements(1 << LOG_NUM));
 
 	let (a, b, c_lo, c_hi) = generate_test_data(LOG_NUM);
-	let witness = Witness::<P>::new(LOG_BITS, &a, &b, &c_lo, &c_hi).unwrap();
-	let log_bits = witness.log_bits;
+	let witness = Witness::<P>::new(&a, &b, &c_lo, &c_hi).unwrap();
 
 	// The proving phases are sequential and stateful: each consumes the outputs of the previous
 	// one. Rather than re-deriving every predecessor inside each phase's per-iteration setup, we
@@ -185,12 +181,11 @@ fn bench_intmul_phases(c: &mut Criterion) {
 		let mut prover = IntMulProver::<P, _>::new(0, &mut transcript);
 		prover.phase1(&initial_eval_point, witness.b_prodcheck.clone(), &witness.b_leaves, exp_eval)
 	};
-	let phase2 = frobenius_twist(log_bits, &phase1.eval_point, &phase1.b_leaves_evals);
+	let phase2 = frobenius_twist(LOG_WORD_SIZE_BITS, &phase1.eval_point, &phase1.b_leaves_evals);
 	let phase3 = {
 		let mut transcript = ProverTranscript::new(StdChallenger::default());
 		let mut prover = IntMulProver::<P, _>::new(0, &mut transcript);
 		prover.phase3(
-			log_bits,
 			&phase2.twisted_eval_points,
 			&phase2.twisted_evals,
 			witness.a_root.clone(),
@@ -200,15 +195,20 @@ fn bench_intmul_phases(c: &mut Criterion) {
 			exp_eval,
 		)
 	};
-	let (phase4_claims, phase4_eval_point) = {
+	let phase4 = {
 		let mut transcript = ProverTranscript::new(StdChallenger::default());
 		let mut prover = IntMulProver::<P, _>::new(0, &mut transcript);
 		prover.phase4(
-			log_bits,
 			&phase3.eval_point,
 			(phase3.gpow_a_eval, witness.a_prodcheck.clone()),
 			(phase3.gpow_c_lo_eval, witness.c_lo_prodcheck.clone()),
 			(phase3.gpow_c_hi_eval, witness.c_hi_prodcheck.clone()),
+			[
+				witness.a_exponents,
+				witness.c_lo_exponents,
+				witness.c_hi_exponents,
+			],
+			&witness.tables,
 		)
 	};
 
@@ -226,7 +226,9 @@ fn bench_intmul_phases(c: &mut Criterion) {
 
 	// The Frobenius twist consumes nothing by value, so no per-iteration clone is needed.
 	group.bench_function("phase2_frobenius_twist", |bencher| {
-		bencher.iter(|| frobenius_twist(log_bits, &phase1.eval_point, &phase1.b_leaves_evals));
+		bencher.iter(|| {
+			frobenius_twist(LOG_WORD_SIZE_BITS, &phase1.eval_point, &phase1.b_leaves_evals)
+		});
 	});
 
 	group.bench_function("phase3", |bencher| {
@@ -236,7 +238,6 @@ fn bench_intmul_phases(c: &mut Criterion) {
 				let mut transcript = ProverTranscript::new(StdChallenger::default());
 				let mut prover = IntMulProver::<P, _>::new(0, &mut transcript);
 				prover.phase3(
-					log_bits,
 					&phase2.twisted_eval_points,
 					&phase2.twisted_evals,
 					a_root,
@@ -263,29 +264,35 @@ fn bench_intmul_phases(c: &mut Criterion) {
 				let mut transcript = ProverTranscript::new(StdChallenger::default());
 				let mut prover = IntMulProver::<P, _>::new(0, &mut transcript);
 				prover.phase4(
-					log_bits,
 					&phase3.eval_point,
 					(phase3.gpow_a_eval, a_prodcheck),
 					(phase3.gpow_c_lo_eval, c_lo_prodcheck),
 					(phase3.gpow_c_hi_eval, c_hi_prodcheck),
+					[
+						witness.a_exponents,
+						witness.c_lo_exponents,
+						witness.c_hi_exponents,
+					],
+					&witness.tables,
 				)
 			},
 			BatchSize::SmallInput,
 		);
 	});
 
+	let compiler = basefold_compiler();
 	group.bench_function("phase5", |bencher| {
-		bencher.iter_batched(
-			|| phase4_claims.clone(),
-			|[a_claim, c_lo_claim, c_hi_claim]| {
-				let mut transcript = ProverTranscript::new(StdChallenger::default());
-				let mut prover = IntMulProver::<P, _>::new(0, &mut transcript);
+		bencher.iter_batched_ref(
+			|| {
+				compiler
+					.create_channel_without_zk_from_transcript::<StdHashSuite, StdChallenger, _>(
+						ProverTranscript::default(),
+					)
+			},
+			|channel| {
+				let mut prover = IntMulProver::<P, _>::new(0, channel);
 				prover.phase5(
-					log_bits,
-					&phase4_eval_point,
-					a_claim,
-					c_lo_claim,
-					c_hi_claim,
+					&phase4,
 					witness.b_exponents,
 					&phase3.eval_point,
 					&phase3.r_ib,
@@ -293,6 +300,7 @@ fn bench_intmul_phases(c: &mut Criterion) {
 					witness.a_exponents,
 					witness.c_lo_exponents,
 					witness.c_hi_exponents,
+					&witness.tables[0],
 				)
 			},
 			BatchSize::SmallInput,
@@ -308,27 +316,26 @@ fn bench_intmul_components(c: &mut Criterion) {
 	group.throughput(Throughput::Elements(1 << LOG_NUM));
 
 	let (a, b, c_lo, c_hi) = generate_test_data(LOG_NUM);
-	let witness = Witness::<P>::new(LOG_BITS, &a, &b, &c_lo, &c_hi).unwrap();
-	let log_bits = witness.log_bits;
+	let witness = Witness::<P>::new(&a, &b, &c_lo, &c_hi).unwrap();
 
-	// Computing the leaves of a constant-base exponentiation tree (fixed generator as base, the `a`
-	// integers as exponents) — the `a` / `c_lo` / `c_hi` trees are built this way.
+	// Building one twisted power table (the `a` / `c_lo` / `c_hi` limb columns read 2·N_LIMBS of
+	// these).
 	let g = F::MULTIPLICATIVE_GENERATOR;
-	group.bench_function("constant_base_leaves", |bencher| {
-		bencher.iter(|| constant_base_leaves::<F, P>(log_bits, g, witness.a_exponents));
+	group.bench_function("power_table", |bencher| {
+		bencher.iter(|| power_table::<F, P>(LIMB_BITS, g));
 	});
 
 	// Computing the leaves of the variable-base exponentiation tree (`a` root as base, `b` as
 	// exponents).
 	group.bench_function("b_leaves", |bencher| {
-		bencher.iter(|| compute_b_leaves::<F, P>(log_bits, &witness.a_root, witness.b_exponents));
+		bencher.iter(|| compute_b_leaves::<F, P>(&witness.a_root, witness.b_exponents));
 	});
 
 	// Computing a product tree over the leaves.
 	group.bench_function("product_tree", |bencher| {
 		bencher.iter_batched(
 			|| witness.b_leaves.clone(),
-			|b_leaves| ProdcheckProver::<P>::new(log_bits, b_leaves),
+			|b_leaves| ProdcheckProver::<P>::new(LOG_WORD_SIZE_BITS, b_leaves),
 			BatchSize::SmallInput,
 		);
 	});
@@ -346,7 +353,7 @@ fn bench_intmul_components(c: &mut Criterion) {
 		let mut prover = IntMulProver::<P, _>::new(0, &mut transcript);
 		prover.phase1(&initial_eval_point, witness.b_prodcheck.clone(), &witness.b_leaves, exp_eval)
 	};
-	let phase2 = frobenius_twist(log_bits, &phase1.eval_point, &phase1.b_leaves_evals);
+	let phase2 = frobenius_twist(LOG_WORD_SIZE_BITS, &phase1.eval_point, &phase1.b_leaves_evals);
 
 	group.bench_function("selector_sumcheck", |bencher| {
 		let mut rng = rand::rng();
@@ -361,7 +368,7 @@ fn bench_intmul_components(c: &mut Criterion) {
 						value,
 					})
 					.collect();
-				let gamma = random_scalars::<F>(&mut rng, log_bits);
+				let gamma = random_scalars::<F>(&mut rng, LOG_WORD_SIZE_BITS);
 				let eq_weights = eq_ind_partial_eval_scalars::<F>(&gamma);
 				(witness.a_root.clone(), claims, eq_weights)
 			},

--- a/crates/prover/src/protocols/intmul/prove.rs
+++ b/crates/prover/src/protocols/intmul/prove.rs
@@ -4,14 +4,17 @@
 use std::marker::PhantomData;
 
 use binius_core::word::Word;
-use binius_field::{BinaryField, FieldOps, PackedField};
-use binius_iop_prover::channel::IOPProverChannel;
+use binius_field::{BinaryField, BinaryField1b, Divisible, ExtensionField, FieldOps, PackedField};
+use binius_iop_prover::{
+	channel::IOPProverChannel,
+	logup_star::{self, Looker},
+};
 use binius_ip::prodcheck::MultilinearEvalClaim;
 use binius_ip_prover::{
 	channel::IPProverChannel,
 	prodcheck::{self, ProdcheckProver},
 	sumcheck::{
-		MleToSumCheckDecorator, PaddedSumcheckDecorator,
+		MleToSumCheckDecorator,
 		batch::{BatchSumcheckOutput, batch_prove, batch_prove_and_write_evals},
 		bivariate_product_mle,
 		multilinear_eval::MultilinearEvalProver,
@@ -28,13 +31,17 @@ use binius_math::{
 	},
 };
 use binius_utils::{checked_arithmetics::log2_ceil_usize, rayon::prelude::*};
-use binius_verifier::protocols::intmul::common::{
-	IntMulOutput, Phase1Output, Phase2Output, Phase3Output, frobenius_twist,
+use binius_verifier::{
+	config::{LOG_WORD_SIZE_BITS, WORD_SIZE_BITS},
+	protocols::intmul::common::{
+		IntMulOutput, LIMB_BITS, LOG_N_LIMBS, N_LIMB_COLUMNS, N_LIMBS, Phase1Output, Phase2Output,
+		Phase3Output, Phase4Output, frobenius_twist, limb_column_twists, twist_limb_claim,
+	},
 };
 use either::Either;
 use itertools::izip;
 
-use super::witness::{Witness, two_valued_field_buffer};
+use super::witness::{Witness, limb_index, two_valued_field_buffer};
 use crate::fold_word::{fold_across_words, fold_words};
 
 /// A helper structure that encapsulates switchover settings and the prover channel for
@@ -58,7 +65,7 @@ impl<'a, P, Channel> IntMulProver<'a, P, Channel> {
 
 impl<F, P, Channel> IntMulProver<'_, P, Channel>
 where
-	F: BinaryField,
+	F: BinaryField<Underlier: Divisible<u64>>,
 	P: PackedField<Scalar = F>,
 	Channel: IOPProverChannel<P>,
 {
@@ -67,7 +74,7 @@ where
 	/// This method consumes a `Witness` in order to reduce integer multiplication statement to
 	/// evaluation claims on 1-bit multilinears. More formally:
 	///  * `witness` contains po2-sized integer arrays  `a`, `b`, `c_lo` and `c_hi` that satisfy `a
-	///    * b = c_lo | c_hi << (1 << log_bits)`, as well as the layers of the constant- and
+	///    * b = c_lo | c_hi << WORD_SIZE_BITS`, as well as the layers of the constant- and
 	///      variable-base GKR product check circuits
 	///  * The proving consists of five phases:
 	///    - Phase 1: GKR tree roots for B & C are evaluated at a sampled point, after which
@@ -77,17 +84,18 @@ where
 	///      - Selector mlecheck to reduce claims on $b * (G^{a_i} - 1) + 1$ to claims on $G^{a_i}$
 	///        and $b$, then recombine the $2^k$ per-bit `b` claims into one via a sampled $r_I^b$
 	///      - First layer of GPA reduction for the `c_lo || c_hi` combined `c` tree
-	///    - Phase 4: Batching all but last layers and `a`, `c_lo` and `c_hi`
-	///    - Phase 5: Proving the last (widest) layers of `a`, `c_lo` and `c_hi` batched with a
-	///      single-claim rerandomization (MLE-eval) of the recombined `b` exponent claim from phase
-	///      3
+	///    - Phase 4: Batched product check over the three depth-`LOG_N_LIMBS` constant-base trees
+	///      (`a`, `c_lo`, `c_hi`), reducing the roots to per-limb evaluation claims
+	///    - Phase 5: The per-limb claims are Frobenius-twisted onto the shared power table `i ↦
+	///      G^i` and read from it via a committed logup* lookup; a final batched sumcheck brings
+	///      the reduced index claim, a single-claim rerandomization (MLE-eval) of the recombined
+	///      `b` exponent claim from phase 3, and the overflow parity zerocheck to one shared point
 	///
 	/// The output of this protocol is a set of evaluation claims on the `b` selectors representing
 	/// all of `a`, `b`, `c_lo` and `c_hi` as column-major bit matrices, at a common evaluation
-	/// point.
+	/// point. The logup* pushforward commitment is opened through the channel inside phase 5.
 	pub fn prove(&mut self, witness: Witness<'_, P>) -> IntMulOutput<F> {
 		let Witness {
-			log_bits,
 			a_exponents,
 			a_prodcheck,
 			a_root,
@@ -101,12 +109,12 @@ where
 			c_hi_exponents,
 			c_hi_prodcheck,
 			c_hi_root,
+			tables,
 		} = witness;
 
 		// `b_root` (the variable-base `b`-exponent tree root) equals the full product `c` root, so
 		// it serves as the MLE root that opens the protocol.
 		let n_vars = b_root.log_len();
-		assert!(log_bits >= 1);
 
 		let initial_eval_point = self.channel.sample_many(n_vars);
 
@@ -125,7 +133,7 @@ where
 		let Phase2Output {
 			twisted_eval_points,
 			twisted_evals,
-		} = frobenius_twist(log_bits, &phase1_eval_point, &b_leaves_evals);
+		} = frobenius_twist(LOG_WORD_SIZE_BITS, &phase1_eval_point, &b_leaves_evals);
 
 		// Phase 3
 		let Phase3Output {
@@ -136,7 +144,6 @@ where
 			gpow_c_lo_eval,
 			gpow_c_hi_eval,
 		} = self.phase3(
-			log_bits,
 			&twisted_eval_points,
 			&twisted_evals,
 			a_root,
@@ -147,21 +154,18 @@ where
 		);
 
 		// Phase 4
-		let ([a_claim, c_lo_claim, c_hi_claim], phase4_eval_point) = self.phase4(
-			log_bits,
+		let phase_4_output = self.phase4(
 			&phase3_eval_point,
 			(gpow_a_eval, a_prodcheck),
 			(gpow_c_lo_eval, c_lo_prodcheck),
 			(gpow_c_hi_eval, c_hi_prodcheck),
+			[a_exponents, c_lo_exponents, c_hi_exponents],
+			&tables,
 		);
 
 		// Phase 5
 		self.phase5(
-			log_bits,
-			&phase4_eval_point,
-			a_claim,
-			c_lo_claim,
-			c_hi_claim,
+			&phase_4_output,
 			b_exponents,
 			&phase3_eval_point,
 			&r_ib,
@@ -169,7 +173,176 @@ where
 			a_exponents,
 			c_lo_exponents,
 			c_hi_exponents,
+			&tables[0],
 		)
+	}
+
+	#[doc(hidden)] // exposed for benchmarking (`benches/intmul.rs`), not a stable API
+	#[allow(clippy::too_many_arguments)]
+	pub fn phase5(
+		&mut self,
+		phase_4_output: &Phase4Output<F>,
+		b_exponents: &[Word],
+		b_eval_point: &[F],
+		r_ib: &[F],
+		b_recomb: F,
+		// The exponents supply the lookup indices, the overflow zerocheck bits (`a_0`, `c_lo_0`),
+		// and the raw per-bit output evaluations.
+		a_exponents: &[Word],
+		c_lo_exponents: &[Word],
+		c_hi_exponents: &[Word],
+		table: &FieldBuffer<P>,
+	) -> IntMulOutput<F> {
+		let n_vars = b_eval_point.len();
+		assert_eq!(phase_4_output.eval_point.len(), n_vars);
+
+		// Twist each per-limb claim onto the shared table: column (t, l) is the Frobenius power
+		// φ^{twist} of the looked-up column U_{t,l}(x) = T[e_{t,l}(x)], so its claim becomes a
+		// claim on U_{t,l} at the twisted point.
+		let twists = limb_column_twists();
+		let exponents = [a_exponents, c_lo_exponents, c_hi_exponents];
+		let limb_evals = [
+			&phase_4_output.a_limb_evals,
+			&phase_4_output.c_lo_limb_evals,
+			&phase_4_output.c_hi_limb_evals,
+		];
+
+		let index_columns = (0..N_LIMB_COLUMNS)
+			.map(|j| {
+				let (tree, limb) = (j / N_LIMBS, j % N_LIMBS);
+				exponents[tree]
+					.iter()
+					.map(|&word| limb_index(word, limb))
+					.collect::<Vec<_>>()
+			})
+			.collect::<Vec<_>>();
+		let twisted_claims = (0..N_LIMB_COLUMNS)
+			.map(|j| {
+				let (tree, limb) = (j / N_LIMBS, j % N_LIMBS);
+				twist_limb_claim(twists[j], &phase_4_output.eval_point, limb_evals[tree][limb])
+			})
+			.collect::<Vec<_>>();
+
+		// Read the N_LIMB_COLUMNS looked-up columns from the shared table via the committed multi-
+		// looker logup* reduction. The pushforward oracle is committed inside; its opening relation
+		// is returned to the caller. The reduction returns one index claim per column, all at the
+		// shared content point.
+		let lookers = izip!(&index_columns, &twisted_claims)
+			.map(|(index, (twisted_point, twisted_eval))| Looker {
+				index,
+				eval_point: twisted_point,
+				eval_claim: *twisted_eval,
+			})
+			.collect::<Vec<_>>();
+		let log_cols = log2_ceil_usize(N_LIMB_COLUMNS);
+		let logup_proof = logup_star::prove(table, &lookers, self.channel);
+
+		// The index entries are the GF(2)-linear embeddings iota(e) = Σ_u basis(u) · bit_u(e),
+		// materialized by a table of all 2^LIMB_BITS embeddings.
+		let mut iota_table = Vec::with_capacity(1usize << LIMB_BITS);
+		iota_table.push(F::ZERO);
+		for row in 1..1usize << LIMB_BITS {
+			let low_bit_basis =
+				<F as ExtensionField<BinaryField1b>>::basis(row.trailing_zeros() as usize);
+			iota_table.push(iota_table[row & (row - 1)] + low_bit_basis);
+		}
+
+		let index_content_point = logup_proof.index_eval_point.as_slice();
+		let embedded_columns = index_columns
+			.iter()
+			.map(|rows| rows.iter().map(|&row| iota_table[row]).collect::<Vec<_>>())
+			.collect::<Vec<_>>();
+
+		// Collapse the per-column claims into a single claim on the eq(ρ)-folded column V by
+		// sampling ρ, so the final unification runs over the content variables only.
+		let rho = self.channel.sample_many(log_cols);
+		let mut padded_column_evals = logup_proof.index_eval_claims.clone();
+		padded_column_evals.resize(1 << log_cols, F::ZERO);
+		let folded_index_claim =
+			evaluate(&FieldBuffer::<P>::from_values(&padded_column_evals), &rho);
+		let rho_tensor = eq_ind_partial_eval_scalars::<F>(&rho);
+		let folded_column_scalars = (0..1usize << n_vars)
+			.map(|i| {
+				izip!(&embedded_columns, &rho_tensor)
+					.map(|(column, &weight)| column[i] * weight)
+					.sum::<F>()
+			})
+			.collect::<Vec<_>>();
+		let folded_column = FieldBuffer::<P>::from_values(&folded_column_scalars);
+		let index_prover = MleToSumCheckDecorator::new(MultilinearEvalProver::new(
+			folded_column,
+			index_content_point,
+			folded_index_claim,
+		));
+
+		// Embed `a_0`, `b_0`, `c_lo_0` bits into field buffers for the overflow zerocheck.
+		let binary_elements = [F::zero(), F::one()];
+
+		// TODO: Use a special 1-bit-optimized MLE-check with switchover to save memory.
+		let a_0: FieldBuffer<P> = two_valued_field_buffer(0, a_exponents, binary_elements);
+		let b_0: FieldBuffer<P> = two_valued_field_buffer(0, b_exponents, binary_elements);
+		let c_lo_0: FieldBuffer<P> = two_valued_field_buffer(0, c_lo_exponents, binary_elements);
+
+		// The overflow parity check binds at the Phase-2 constraint point `b_eval_point` (r_2) —
+		// reused for free from the `b` re-randomization.
+		let overflow_prover =
+			MleToSumCheckDecorator::new(QuadraticMleCheckProver::<P, _, _, 3>::new(
+				[a_0, b_0, c_lo_0],
+				|[a, b, c]| a * b - c,
+				|[a, b, _c]| a * b,
+				b_eval_point.to_vec(),
+				F::ZERO,
+			));
+
+		// Fold the 2^k b bit-columns by the recombination tensor into a single field multilinear
+		// B(x) = sum_i eq(r_I^b, i) * b(i, x), then re-randomize its claim B(r_2) = b_recomb from
+		// `b_eval_point` (r_2) to the shared point via a single-claim MLE-eval check.
+		assert_eq!(b_exponents.len(), 1 << n_vars);
+		let b_tensor = eq_ind_partial_eval_scalars::<F>(r_ib);
+		let b_folded = fold_words::<_, P>(b_exponents, &b_tensor);
+		let b_sumcheck_prover = MleToSumCheckDecorator::new(MultilinearEvalProver::new(
+			b_folded,
+			b_eval_point,
+			b_recomb,
+		));
+
+		let BatchSumcheckOutput {
+			challenges,
+			multilinear_evals: _,
+		} = batch_prove(
+			vec![
+				Either::Left(index_prover),
+				Either::Right(Either::Left(overflow_prover)),
+				Either::Right(Either::Right(b_sumcheck_prover)),
+			],
+			self.channel,
+		);
+
+		// `challenges` (reversed) is the shared output point for all output claims.
+		let r_out = challenges.as_slice();
+
+		// Send the raw per-bit output evals at `r_out`, computed directly from the exponents. The
+		// verifier binds the stacked-index claim via the GF(2)-linearity of the embedding, the `b`
+		// evals via sum_i eq(r_I^b, i) * b(i, r_out) = B(r_out), and the parity bits directly.
+		let per_bit_evals =
+			|exponents: &[Word]| fold_across_words::<_, P>(exponents, r_out).to_vec();
+		let a_evals = per_bit_evals(a_exponents);
+		let c_lo_evals = per_bit_evals(c_lo_exponents);
+		let c_hi_evals = per_bit_evals(c_hi_exponents);
+		let b_evals = per_bit_evals(b_exponents);
+
+		self.channel.send_many(&a_evals);
+		self.channel.send_many(&c_lo_evals);
+		self.channel.send_many(&c_hi_evals);
+		self.channel.send_many(&b_evals);
+
+		IntMulOutput {
+			eval_point: r_out.to_vec(),
+			a_evals,
+			b_evals,
+			c_lo_evals,
+			c_hi_evals,
+		}
 	}
 }
 
@@ -221,7 +394,6 @@ where
 	#[allow(clippy::too_many_arguments)]
 	pub fn phase3(
 		&mut self,
-		log_bits: usize,
 		twisted_eval_points: &[Vec<F>],
 		twisted_evals: &[F],
 		selector: FieldBuffer<P>,
@@ -251,7 +423,7 @@ where
 		// 2^k claims with a multilinear one; the verifier mirrors it by weighting the corresponding
 		// terms by eq_k(γ, ·). γ is sampled before the batched sumcheck so the round polynomials
 		// are fixed against it.
-		let gamma = self.channel.sample_many(log_bits);
+		let gamma = self.channel.sample_many(LOG_WORD_SIZE_BITS);
 		let eq_weights = eq_ind_partial_eval_scalars::<F>(&gamma);
 		// `SelectorMlecheckProver` reads the exponent bits through the `Bitwise` bitmask
 		// abstraction, which is implemented for the primitive integer types. `Word` is
@@ -280,7 +452,7 @@ where
 			.try_into()
 			.expect("batch_prove with two provers returns length-2 multilinear_evals");
 
-		assert_eq!(selector_prover_evals.len(), 1 + (1 << log_bits));
+		assert_eq!(selector_prover_evals.len(), 1 + WORD_SIZE_BITS);
 
 		let gpow_a_eval = selector_prover_evals
 			.pop()
@@ -293,7 +465,7 @@ where
 		// Recombine the 2^k per-bit b(i, r) claims into a single claim b(r_I^b, r) by sampling a
 		// recombination point r_I^b in K^k, matching the verifier. This carries one exponent claim
 		// (rather than 2^k) into Phases 4 and 5.
-		let r_ib = self.channel.sample_many(log_bits);
+		let r_ib = self.channel.sample_many(LOG_WORD_SIZE_BITS);
 		let b_recomb = evaluate(&FieldBuffer::<P>::from_values(&b_evals), &r_ib);
 
 		Phase3Output {
@@ -307,31 +479,32 @@ where
 	}
 
 	#[doc(hidden)] // exposed for benchmarking (`benches/intmul.rs`), not a stable API
-	#[allow(clippy::type_complexity)]
+	#[allow(clippy::too_many_arguments)]
 	pub fn phase4(
 		&mut self,
-		log_bits: usize,
 		eval_point: &[F],
 		(a_root_eval, a_prover): (F, ProdcheckProver<P>),
 		(gpow_c_lo_eval, c_lo_prover): (F, ProdcheckProver<P>),
 		(gpow_c_hi_eval, c_hi_prover): (F, ProdcheckProver<P>),
-	) -> ([(F, ProdcheckProver<P>); 3], Vec<F>) {
-		// Each prover is over the full (widest) leaf layer of `2^log_bits` node multilinears.
-		assert_eq!(a_prover.n_layers(), log_bits);
-		assert_eq!(c_lo_prover.n_layers(), log_bits);
-		assert_eq!(c_hi_prover.n_layers(), log_bits);
+		exponents: [&[Word]; 3],
+		tables: &[FieldBuffer<P>],
+	) -> Phase4Output<F> {
+		let n_vars = eval_point.len();
+
+		// Each prover is over the full (widest) leaf layer of `N_LIMBS` limb columns.
+		assert_eq!(a_prover.n_layers(), LOG_N_LIMBS);
+		assert_eq!(c_lo_prover.n_layers(), LOG_N_LIMBS);
+		assert_eq!(c_hi_prover.n_layers(), LOG_N_LIMBS);
 
 		// Sample the selector challenges that batch the 3 trees (padded to 4).
 		let selector = self.channel.sample_many(log2_ceil_usize(3));
 
-		// Run the batched prodcheck: content point is the Phase-3 evaluation point at which the
-		// three roots are claimed. This runs `log_bits - 1` reduction layers, reducing the three
-		// trees down to (but not including) their final (widest) leaf layer, which it returns
-		// inside the remaining provers. Each remaining prover is paired with its reduced eval at
-		// the shared reduced point.
+		// Run the batched prodcheck over all LOG_N_LIMBS layers: content point is the Phase-3
+		// evaluation point at which the three roots are claimed. The output pairs each tree with
+		// its reduced leaf evaluation at the shared reduced point.
 		let prodcheck::BatchProveOutput {
 			eval_point: reduced_point,
-			provers,
+			evals: _tree_evals,
 		} = prodcheck::batch_prove(
 			vec![a_prover, c_lo_prover, c_hi_prover],
 			vec![a_root_eval, gpow_c_lo_eval, gpow_c_hi_eval],
@@ -340,175 +513,42 @@ where
 			self.channel,
 		);
 
-		// The reduced point is [selector (2), suffix (n_vars), bit_index (log_bits - 1)]. Drop the
-		// selector coordinates: `[suffix, bit_index]` is the point at which each retained
-		// all-but-last-layer node multilinear is now claimed, and is the content+node point the
-		// Phase-5 final-layer sumchecks bind. Hand the three per-tree reduced claims (eval +
-		// retained final layer) straight through to Phase 5 — no all-but-last-layer evals are
-		// recomputed or sent here.
+		// The reduced point is [selector (2), r_content (n_vars), r_limb (LOG_N_LIMBS)]:
+		// `r_content` is the shared point at which the limb columns are claimed; `r_limb`
+		// collapses the limb dimension.
 		let selector_len = log2_ceil_usize(3);
-		let a_c_eval_point = reduced_point[selector_len..].to_vec();
+		let (r_content, _r_limb) = reduced_point[selector_len..].split_at(n_vars);
 
-		let claims: [(F, ProdcheckProver<P>); 3] = provers
-			.try_into()
-			.ok()
-			.expect("batch_prove returns three provers");
-
-		(claims, a_c_eval_point)
-	}
-
-	#[doc(hidden)] // exposed for benchmarking (`benches/intmul.rs`), not a stable API
-	#[allow(clippy::too_many_arguments)]
-	pub fn phase5(
-		&mut self,
-		log_bits: usize,
-		a_c_eval_point: &[F],
-		a_claim: (F, ProdcheckProver<P>),
-		c_lo_claim: (F, ProdcheckProver<P>),
-		c_hi_claim: (F, ProdcheckProver<P>),
-		b_exponents: &[Word],
-		b_eval_point: &[F],
-		r_ib: &[F],
-		b_recomb: F,
-		// The exponents supply the overflow zerocheck bits (`a_0`, `c_lo_0`) and the raw per-bit
-		// output evaluations.
-		a_exponents: &[Word],
-		c_lo_exponents: &[Word],
-		c_hi_exponents: &[Word],
-	) -> IntMulOutput<F> {
-		assert!(log_bits >= 1);
-		let n_vars = b_eval_point.len();
-		// `a_c_eval_point = [suffix (n_vars), bit_index (log_bits - 1)]` — the content point plus
-		// the all-but-last-layer node coordinates. The final-layer sumchecks bind all of it; the
-		// overflow and `b` checks span only the `n_vars` content coordinates and are padded up.
-		let n_extra = log_bits - 1;
-		assert_eq!(a_c_eval_point.len(), n_vars + n_extra);
-
-		// Send the three per-tree reduced claims. The verifier checks they combine, weighted by
-		// eq(selector), to the batched prodcheck output claim, then uses each as the seed for that
-		// tree's final-layer sumcheck.
-		let (a_eval, a_prover) = a_claim;
-		let (c_lo_eval, c_lo_prover) = c_lo_claim;
-		let (c_hi_eval, c_hi_prover) = c_hi_claim;
-		self.channel.send_many(&[a_eval, c_lo_eval, c_hi_eval]);
-
-		// Prove the final (widest) GKR layer of each tree as a regular prodcheck-layer bivariate
-		// product MLE-check, seeded by the tree's reduced claim, wrapped as a sumcheck.
-		let make_tree_prover = |eval: F, prover: ProdcheckProver<P>| {
-			let (mle_prover, remaining) = prover.layer_prover(MultilinearEvalClaim {
-				eval,
-				point: a_c_eval_point.to_vec(),
-			});
-			debug_assert!(remaining.is_none(), "one retained layer per tree");
-			MleToSumCheckDecorator::new(mle_prover)
+		// Send the per-limb evaluations at `r_content`, computed by re-gathering each limb column
+		// from its twisted power table. The verifier recombines each tree's two leaf halves via
+		// eq(r_limb) to bind them to the final-layer sumchecks.
+		let twists = limb_column_twists();
+		let x_tensor = eq_ind_partial_eval(r_content);
+		let limb_evals = |tree: usize| {
+			(0..N_LIMBS)
+				.map(|limb| {
+					let table = &tables[twists[tree * N_LIMBS + limb] / LIMB_BITS];
+					let column_scalars = exponents[tree]
+						.iter()
+						.map(|&word| table.get(limb_index(word, limb)))
+						.collect::<Vec<_>>();
+					let column = FieldBuffer::<P>::from_values(&column_scalars);
+					inner_product_buffers(&column, &x_tensor)
+				})
+				.collect::<Vec<_>>()
 		};
-		let a_tree = make_tree_prover(a_eval, a_prover);
-		let c_lo_tree = make_tree_prover(c_lo_eval, c_lo_prover);
-		let c_hi_tree = make_tree_prover(c_hi_eval, c_hi_prover);
+		let a_limb_evals = limb_evals(0);
+		let c_lo_limb_evals = limb_evals(1);
+		let c_hi_limb_evals = limb_evals(2);
+		self.channel.send_many(&a_limb_evals);
+		self.channel.send_many(&c_lo_limb_evals);
+		self.channel.send_many(&c_hi_limb_evals);
 
-		// Embed `a_0`, `b_0`, `c_lo_0` bits into field buffers for the overflow zerocheck.
-		let binary_elements = [F::zero(), F::one()];
-
-		// TODO: Use a special 1-bit-optimized MLE-check with switchover to save memory.
-		let a_0: FieldBuffer<P> = two_valued_field_buffer(0, a_exponents, binary_elements);
-		let b_0: FieldBuffer<P> = two_valued_field_buffer(0, b_exponents, binary_elements);
-		let c_lo_0: FieldBuffer<P> = two_valued_field_buffer(0, c_lo_exponents, binary_elements);
-
-		// The overflow parity check binds at the Phase-2 constraint point `b_eval_point` (r_2) —
-		// reused for free from the `b` re-randomization. It spans only the `n_vars` content
-		// coordinates, so pad it up by `n_extra` variables to batch with the final-layer sumchecks.
-		let overflow_prover = PaddedSumcheckDecorator::new(
-			MleToSumCheckDecorator::new(QuadraticMleCheckProver::<P, _, _, 3>::new(
-				[a_0, b_0, c_lo_0],
-				|[a, b, c]| a * b - c,
-				|[a, b, _c]| a * b,
-				b_eval_point.to_vec(),
-				F::ZERO,
-			)),
-			n_extra,
-		);
-
-		// Fold the 2^k b bit-columns by the recombination tensor into a single field multilinear
-		// B(x) = sum_i eq(r_I^b, i) * b(i, x), then re-randomize its claim B(r_2) = b_recomb from
-		// `b_eval_point` (r_2) to the shared point via a single-claim MLE-eval check, padded up.
-		assert_eq!(b_exponents.len(), 1 << n_vars);
-		let b_tensor = eq_ind_partial_eval_scalars::<F>(r_ib);
-		let b_folded = fold_words::<_, P>(b_exponents, &b_tensor);
-		let b_sumcheck_prover = PaddedSumcheckDecorator::new(
-			MleToSumCheckDecorator::new(MultilinearEvalProver::new(
-				b_folded,
-				b_eval_point,
-				b_recomb,
-			)),
-			n_extra,
-		);
-
-		// Batch prove all five provers — the three final-layer sumchecks, the overflow zerocheck,
-		// and the `b` re-randomization — all over `n_vars + n_extra` variables.
-		let BatchSumcheckOutput {
-			challenges,
-			multilinear_evals,
-		} = batch_prove(
-			vec![
-				Either::Left(a_tree),
-				Either::Left(c_lo_tree),
-				Either::Left(c_hi_tree),
-				Either::Right(Either::Left(overflow_prover)),
-				Either::Right(Either::Right(b_sumcheck_prover)),
-			],
-			self.channel,
-		);
-
-		// The reduced point is [r_content (n_vars), r_bit (n_extra)]: `r_content` is the shared
-		// evaluation point for the output claims; `r_bit` collapses the node dimension (and is the
-		// padding point for the overflow / `b` checks).
-		let (r_content, _r_bit) = challenges.split_at(n_vars);
-
-		// Send the raw per-bit output evals at `r_content`, computed directly from the exponents.
-		// The verifier reconstructs the selected leaf values from these and recombines them via
-		// eq(r_bit) to bind the final-layer sumchecks; it binds the `b` evals via
-		// sum_i eq(r_I^b, i) * b(i, r_content) = B(r_content).
-		let per_bit_evals =
-			|exponents: &[Word]| fold_across_words::<_, P>(exponents, r_content).to_vec();
-		let a_evals = per_bit_evals(a_exponents);
-		let c_lo_evals = per_bit_evals(c_lo_exponents);
-		let c_hi_evals = per_bit_evals(c_hi_exponents);
-		let b_evals = per_bit_evals(b_exponents);
-
-		self.channel.send_many(&a_evals);
-		self.channel.send_many(&c_lo_evals);
-		self.channel.send_many(&c_hi_evals);
-		self.channel.send_many(&b_evals);
-
-		// Sanity: the overflow zerocheck's finished per-bit evals and the `b` recombined eval match
-		// the sent raw evals. The padded provers' `finish` returns the inner multilinear evals.
-		let [
-			_a_evals2,
-			_c_lo_evals2,
-			_c_hi_evals2,
-			lsb_evals,
-			b_recomb_evals,
-		] = multilinear_evals
-			.try_into()
-			.expect("batch_prove with 5 provers returns 5 multilinear_evals vecs");
-		let [a_0_eval, b_0_eval, c_lo_0_eval] = lsb_evals
-			.try_into()
-			.expect("overflow prover has 3 multilinears");
-		debug_assert_eq!(a_0_eval, a_evals[0]);
-		debug_assert_eq!(b_0_eval, b_evals[0]);
-		debug_assert_eq!(c_lo_0_eval, c_lo_evals[0]);
-		debug_assert_eq!(b_recomb_evals.len(), 1);
-		debug_assert_eq!(
-			b_recomb_evals[0],
-			evaluate(&FieldBuffer::<P>::from_values(&b_evals), r_ib)
-		);
-
-		IntMulOutput {
+		Phase4Output {
 			eval_point: r_content.to_vec(),
-			a_evals,
-			b_evals,
-			c_lo_evals,
-			c_hi_evals,
+			a_limb_evals,
+			c_lo_limb_evals,
+			c_hi_limb_evals,
 		}
 	}
 }

--- a/crates/prover/src/protocols/intmul/tests.rs
+++ b/crates/prover/src/protocols/intmul/tests.rs
@@ -3,13 +3,16 @@
 
 use binius_core::word::Word;
 use binius_field::{BinaryField128bGhash, PackedBinaryGhash2x128b, Random};
-use binius_iop::naive_channel::NaiveVerifierChannel;
+use binius_iop::{channel::OracleSpec, naive_channel::NaiveVerifierChannel};
 use binius_iop_prover::naive_channel::NaiveProverChannel;
 use binius_math::{inner_product::inner_product_buffers, multilinear::eq::eq_ind_partial_eval};
 use binius_transcript::ProverTranscript;
 use binius_verifier::{
 	config::{LOG_WORD_SIZE_BITS, StdChallenger},
-	protocols::intmul::{common::IntMulOutput, verify},
+	protocols::intmul::{
+		common::{IntMulOutput, LIMB_BITS},
+		verify,
+	},
 };
 use itertools::izip;
 use rand::prelude::*;
@@ -56,10 +59,15 @@ fn prove_and_verify() {
 		c_hi.push(Word::from_u64(c_hi_i));
 	}
 
-	let witness = Witness::<P>::new(LOG_WORD_SIZE_BITS, &a, &b, &c_lo, &c_hi).unwrap();
+	let witness = Witness::<P>::new(&a, &b, &c_lo, &c_hi).unwrap();
+
+	// The one oracle in the protocol is the logup* pushforward, over the table variables.
+	let oracle_specs = [OracleSpec::new(LIMB_BITS)];
+
 	// Run prover
 	let mut prover_transcript = ProverTranscript::<StdChallenger>::default();
-	let mut prover_channel = NaiveProverChannel::<F, _>::new(&mut prover_transcript, vec![]);
+	let mut prover_channel =
+		NaiveProverChannel::<F, _>::new(&mut prover_transcript, oracle_specs.to_vec());
 	let mut prover = IntMulProver::new(0, &mut prover_channel);
 	let prove_output = prover.prove(witness);
 	prover_channel.finish();
@@ -97,8 +105,8 @@ fn prove_and_verify() {
 	}
 	// Run verifier
 	let mut verifier_transcript = prover_transcript.into_verifier();
-	let mut verifier_channel = NaiveVerifierChannel::new(&mut verifier_transcript, &[]);
-	let verify_output = verify(LOG_WORD_SIZE_BITS, LOG_EXPONENTS, &mut verifier_channel).unwrap();
+	let mut verifier_channel = NaiveVerifierChannel::new(&mut verifier_transcript, &oracle_specs);
+	let verify_output = verify(LOG_EXPONENTS, &mut verifier_channel).unwrap();
 	verifier_channel.finish();
 
 	// Check verifier output is consistent with prover output

--- a/crates/prover/src/protocols/intmul/witness.rs
+++ b/crates/prover/src/protocols/intmul/witness.rs
@@ -1,4 +1,5 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 use std::{iter, mem::MaybeUninit, ops::Deref};
 
@@ -11,6 +12,10 @@ use binius_utils::{
 	rayon::prelude::*,
 	strided_array::StridedArray2DViewMut,
 };
+use binius_verifier::{
+	config::{LOG_WORD_SIZE_BITS, WORD_SIZE_BITS},
+	protocols::intmul::common::{LIMB_BITS, LOG_N_LIMBS, N_LIMBS},
+};
 use getset::Getters;
 use itertools::iterate;
 
@@ -19,17 +24,21 @@ use super::error::Error;
 /// An integer multiplication protocol witness. Created from integer slices, consumed during
 /// proving.
 ///
-/// The statement being proven is `a * b = c`, where `c` is represented as a pair `(c_lo, c_hi)`.
-/// All four values are of the same bit width that is passed to the prover via `log_bits` parameter
-/// (also denoted $m$). In Binius64, `log_bits = 6` for 64-bit multiplicands and 128-bit product.
+/// The statement being proven is `a * b = c`, where `c` is represented as a pair `(c_lo, c_hi)`:
+/// `WORD_SIZE_BITS`-wide multiplicands with a double-wide product.
 ///
-/// For each of `a`, `c_lo`, `c_hi`, `b` we build the `2^log_bits` "selected" leaf multilinears of
-/// the bivariate-product GKR tree (the widest layer), concatenated into one `(n_vars + log_bits)`
-/// variate buffer with the node index in the high bits. We then construct a [`ProdcheckProver`]
-/// over each, retaining the leaf layer for the final (Phase 5) GKR step:
-///  1) `a` and `c_lo` select a multiplicative group generator $G$
-///  2) `c_hi` selects $G^{2^{2^m}}$
-///  3) `b` selects variable base which is equal to the root of the `a` tree
+/// For each of `a`, `c_lo`, `c_hi` the exponent words split into `N_LIMBS` limbs, and the
+/// constant-base exponentiation factors as a product of `N_LIMBS` limb columns — column `l` reads
+/// the row `limb_l(e)` of the power table of the base $G^{2^{wl}}$ (where $w$ is the limb bit
+/// width). The columns are concatenated into one `(n_vars + LOG_N_LIMBS)`-variate buffer with the
+/// limb index in the high bits, and a [`ProdcheckProver`] is constructed over each:
+///  1) `a` and `c_lo` exponentiate the multiplicative group generator $G$
+///  2) `c_hi` exponentiates $G^{2^{2^m}}$
+///  3) `b` selects a variable base (the root of the `a` tree) per bit, over `WORD_SIZE_BITS`
+///     per-bit leaves as before
+///
+/// The shared power table $T\colon i \mapsto G^i$ over $2^w$ rows is retained for the Phase 5
+/// logup* lookup.
 ///
 /// Protocol proves that ${(G^a)}^b = G^{c\\_lo} \times (G^{2^{2^m}})^{c\\_hi}$, which is equivalent
 /// to $a \times b = c$ modulo $2^{2^{m+1}} - 1$. The special case of `0 * 0 = 1` is handled
@@ -37,9 +46,8 @@ use super::error::Error;
 #[derive(Clone, Getters)]
 #[getset(get = "pub")]
 pub struct Witness<'a, P: PackedField> {
-	/// The log of the bit width ($m$): the tree leaf layer has `2^log_bits` selected multilinears.
-	pub log_bits: usize,
-	/// The exponents for `a` (needed for the phase 5 parity zerocheck on `a_0`).
+	/// The exponents for `a` (needed for the phase 5 lookup indices and parity zerocheck on
+	/// `a_0`).
 	#[getset(skip)]
 	pub a_exponents: &'a [Word],
 	/// Prodcheck prover for the `a` exponentiation tree (leaf layer retained).
@@ -50,27 +58,32 @@ pub struct Witness<'a, P: PackedField> {
 	#[getset(skip)]
 	pub b_exponents: &'a [Word],
 	/// Concatenated b leaves for prodcheck: [L_0, L_1, ..., L_{2^k-1}].
-	/// Has log_len = n_vars + log_bits.
+	/// Has log_len = n_vars + LOG_WORD_SIZE_BITS.
 	pub b_leaves: FieldBuffer<P>,
 	/// The prover for the prodcheck reduction on b_leaves.
 	pub b_prodcheck: ProdcheckProver<P>,
 	/// The root of the b tree (product of all leaves element-wise).
 	pub b_root: FieldBuffer<P>,
-	/// The exponents for `c_lo` (needed for the phase 5 parity zerocheck on `c_lo_0` and the raw
-	/// per-bit output evaluations).
+	/// The exponents for `c_lo` (needed for the phase 5 lookup indices, parity zerocheck on
+	/// `c_lo_0`, and the raw per-bit output evaluations).
 	#[getset(skip)]
 	pub c_lo_exponents: &'a [Word],
 	/// Prodcheck prover for the `c_lo` exponentiation tree (leaf layer retained).
 	pub c_lo_prodcheck: ProdcheckProver<P>,
 	/// The root of the `c_lo` tree.
 	pub c_lo_root: FieldBuffer<P>,
-	/// The exponents for `c_hi` (needed for the phase 5 raw per-bit output evaluations).
+	/// The exponents for `c_hi` (needed for the phase 5 lookup indices and raw per-bit output
+	/// evaluations).
 	#[getset(skip)]
 	pub c_hi_exponents: &'a [Word],
 	/// Prodcheck prover for the `c_hi` exponentiation tree (leaf layer retained).
 	pub c_hi_prodcheck: ProdcheckProver<P>,
 	/// The root of the `c_hi` tree.
 	pub c_hi_root: FieldBuffer<P>,
+	/// The 2·N_LIMBS twisted power tables: `tables[s][i] = (G^{2^{ws}})^i`. Limb column `(t, l)`
+	/// is a gather from table `s(t, l)`; `tables[0]` is the shared table read by the Phase 5
+	/// logup* lookup.
+	pub tables: Vec<FieldBuffer<P>>,
 }
 
 impl<'a, F, P> Witness<'a, P>
@@ -79,16 +92,14 @@ where
 	P: PackedField<Scalar = F>,
 {
 	/// Constructs a new integer multiplication witness from the statement.
-	///
-	/// For statement of size $2^\ell$ using $2^m$-wide integers, the upper bound on the
-	/// witness size is $8^{\ell+m}$ large field elements.
 	pub fn new(
-		log_bits: usize,
 		a: &'a [Word],
 		b: &'a [Word],
 		c_lo: &'a [Word],
 		c_hi: &'a [Word],
 	) -> Result<Self, Error> {
+		assert!(2 * WORD_SIZE_BITS <= F::N_BITS);
+
 		// Statement should be of pow-2 length.
 		let Some(n_vars) = strict_log_2(a.len()) else {
 			return Err(Error::ExponentsPowerOfTwoLengthRequired);
@@ -102,30 +113,38 @@ where
 			return Err(Error::ExponentLengthMismatch);
 		}
 
+		// The 2·N_LIMBS twisted power tables: tables[s][i] = (G^{2^{ws}})^i. The `a` and `c_lo`
+		// limb columns read tables 0..N_LIMBS; the `c_hi` limb columns (base
+		// G^{2^{WORD_SIZE_BITS}}) read tables N_LIMBS..2·N_LIMBS. Table 0 is the shared logup*
+		// table.
 		let g = F::MULTIPLICATIVE_GENERATOR;
-		let g_c_hi = iterate(g, |g| g.square())
-			.nth(1 << log_bits)
-			.expect("infinite iterator");
+		let bases = iterate(g, |g| g.square())
+			.step_by(LIMB_BITS)
+			.take(2 * N_LIMBS)
+			.collect::<Vec<_>>();
+		let tables = bases
+			.into_par_iter()
+			.map(|base| power_table::<F, P>(LIMB_BITS, base))
+			.collect::<Vec<_>>();
 
-		// Build the constant-base leaf layers and their prodcheck provers. Each prover's products
+		// Build the per-limb leaf layers and their prodcheck provers. Each prover's products
 		// layer is the corresponding tree root.
-		let a_leaves = constant_base_leaves(log_bits, g, a);
-		let (a_prodcheck, a_root) = ProdcheckProver::new(log_bits, a_leaves);
+		let a_leaves = limb_leaves(&tables[..N_LIMBS], a);
+		let (a_prodcheck, a_root) = ProdcheckProver::new(LOG_N_LIMBS, a_leaves);
 
-		let c_lo_leaves = constant_base_leaves(log_bits, g, c_lo);
-		let (c_lo_prodcheck, c_lo_root) = ProdcheckProver::new(log_bits, c_lo_leaves);
+		let c_lo_leaves = limb_leaves(&tables[..N_LIMBS], c_lo);
+		let (c_lo_prodcheck, c_lo_root) = ProdcheckProver::new(LOG_N_LIMBS, c_lo_leaves);
 
-		let c_hi_leaves = constant_base_leaves(log_bits, g_c_hi, c_hi);
-		let (c_hi_prodcheck, c_hi_root) = ProdcheckProver::new(log_bits, c_hi_leaves);
+		let c_hi_leaves = limb_leaves(&tables[N_LIMBS..], c_hi);
+		let (c_hi_prodcheck, c_hi_root) = ProdcheckProver::new(LOG_N_LIMBS, c_hi_leaves);
 
 		// Compute b_leaves as concatenated leaves for prodcheck; the variable base is the `a` root.
-		let b_leaves = compute_b_leaves(log_bits, &a_root, b);
+		let b_leaves = compute_b_leaves(&a_root, b);
 
 		// Create the prodcheck prover; its products layer becomes b_root
-		let (b_prodcheck, b_root) = ProdcheckProver::new(log_bits, b_leaves.clone());
+		let (b_prodcheck, b_root) = ProdcheckProver::new(LOG_WORD_SIZE_BITS, b_leaves.clone());
 
 		Ok(Self {
-			log_bits,
 			a_exponents: a,
 			a_prodcheck,
 			a_root,
@@ -139,40 +158,55 @@ where
 			c_hi_exponents: c_hi,
 			c_hi_prodcheck,
 			c_hi_root,
+			tables,
 		})
 	}
 }
 
-/// Build the concatenated constant-base leaf layer for a GKR exponentiation tree.
-///
-/// The widest layer of the tree contains `2^log_bits` selected multilinears: the leaf for bit `b`
-/// has value `base^{2^b}` where the `b`-th bit of the corresponding exponent is set, and `1`
-/// otherwise.
-///
-/// The leaves are concatenated into one `(n_vars + log_bits)`-variate buffer with the node index in
-/// the high bits, in natural bit order: node position `p` carries the leaf for bit `p`. This
-/// matches the `b`-tree layout ([`compute_b_leaves`]). The prodcheck reduces on the highest node
-/// bit, so its first reduction (and the verifier's final GKR layer) pairs leaf `z` with leaf
-/// `z + 2^{log_bits-1}` — a strided pairing of bits `z` and `z + 2^{log_bits-1}`.
-#[doc(hidden)] // exposed for benchmarking (`benches/intmul.rs`), not a stable API
-pub fn constant_base_leaves<F, P>(log_bits: usize, base: F, exponents: &[Word]) -> FieldBuffer<P>
+/// Build the power table of `base` with `2^log_size` rows: row `i` holds `base^i`.
+pub fn power_table<F, P>(log_size: usize, base: F) -> FieldBuffer<P>
 where
 	F: Field,
 	P: PackedField<Scalar = F>,
 {
-	let bases = iterate(base, |g| g.square())
-		.take(1 << log_bits)
-		.collect::<Vec<_>>();
+	let mut scalars = Vec::with_capacity(1 << log_size);
+	let mut row = F::ONE;
+	for _ in 0..1usize << log_size {
+		scalars.push(row);
+		row *= base;
+	}
+	FieldBuffer::<P>::from_values(&scalars)
+}
+
+/// Extract limb `l` of an exponent word as a table row index.
+pub(super) const fn limb_index(word: Word, limb: usize) -> usize {
+	((word.0 >> (limb * LIMB_BITS)) & ((1 << LIMB_BITS) - 1)) as usize
+}
+
+/// Build the concatenated per-limb leaf columns for a constant-base GKR exponentiation tree.
+///
+/// Column `l` has entries `tables[l][limb_l(e)]` — the limb-`l` exponentiation of the
+/// corresponding word. The columns are concatenated into one `(n_vars + LOG_N_LIMBS)`-variate
+/// buffer with the limb index in the high bits, so the prodcheck's node reductions pair column `z`
+/// with column `z + N_LIMBS/2`.
+fn limb_leaves<F, P>(tables: &[FieldBuffer<P>], exponents: &[Word]) -> FieldBuffer<P>
+where
+	F: Field,
+	P: PackedField<Scalar = F>,
+{
+	assert_eq!(tables.len(), N_LIMBS);
 
 	let n_vars = checked_log_2(exponents.len());
-	let scalars = (0..1 << log_bits)
-		.flat_map(|bit| {
-			let leaf = two_valued_field_buffer::<F, P>(bit, exponents, [F::ONE, bases[bit]]);
-			leaf.iter_scalars().collect::<Vec<_>>()
+	let scalars = (0..N_LIMBS)
+		.flat_map(|limb| {
+			let table = &tables[limb];
+			exponents
+				.iter()
+				.map(move |&word| table.get(limb_index(word, limb)))
 		})
 		.collect::<Vec<_>>();
 
-	debug_assert_eq!(scalars.len(), 1 << (n_vars + log_bits));
+	debug_assert_eq!(scalars.len(), 1 << (n_vars + LOG_N_LIMBS));
 	FieldBuffer::<P>::from_values(&scalars)
 }
 
@@ -181,11 +215,7 @@ where
 /// Each leaf `L_z` contains: if bit z of `exponents[i]` is set then `bases[i]^{2^z}` else 1
 /// The leaves are concatenated: `[L_0, L_1, ..., L_{2^k-1}]`
 #[doc(hidden)] // exposed for benchmarking (`benches/intmul.rs`), not a stable API
-pub fn compute_b_leaves<F, P>(
-	log_bits: usize,
-	bases: &FieldBuffer<P>,
-	exponents: &[Word],
-) -> FieldBuffer<P>
+pub fn compute_b_leaves<F, P>(bases: &FieldBuffer<P>, exponents: &[Word]) -> FieldBuffer<P>
 where
 	F: Field,
 	P: PackedField<Scalar = F>,
@@ -194,15 +224,15 @@ where
 
 	if P::LOG_WIDTH <= n_vars {
 		// Parallel optimized path
-		return compute_b_leaves_parallel(log_bits, bases, exponents);
+		return compute_b_leaves_parallel(bases, exponents);
 	}
 
 	// Fallback: bases is too small to parallelize (n_vars < P::LOG_WIDTH)
-	let mut out = FieldBuffer::zeros(n_vars + log_bits);
+	let mut out = FieldBuffer::zeros(n_vars + LOG_WORD_SIZE_BITS);
 	let n_elems = 1 << n_vars;
 
 	for (i, (mut base, &exp)) in iter::zip(bases.iter_scalars(), exponents).enumerate() {
-		for z in 0..1 << log_bits {
+		for z in 0..WORD_SIZE_BITS {
 			let bit = exp.extract_bit(z);
 
 			out.set(z * n_elems + i, if bit { base } else { F::ONE });
@@ -215,18 +245,14 @@ where
 }
 
 /// Parallel implementation of compute_b_leaves for when bases is large enough to parallelize.
-fn compute_b_leaves_parallel<F, P>(
-	log_bits: usize,
-	bases: &FieldBuffer<P>,
-	exponents: &[Word],
-) -> FieldBuffer<P>
+fn compute_b_leaves_parallel<F, P>(bases: &FieldBuffer<P>, exponents: &[Word]) -> FieldBuffer<P>
 where
 	F: Field,
 	P: PackedField<Scalar = F>,
 {
 	let n_vars = bases.log_len();
 	let n_packed = bases.as_ref().len();
-	let height = 1 << log_bits;
+	let height = WORD_SIZE_BITS;
 	let total = n_packed * height;
 
 	let mut out_vec: Vec<P> = Vec::with_capacity(total);
@@ -262,7 +288,7 @@ where
 	// SAFETY: All elements initialized in the parallel loop above
 	unsafe { out_vec.set_len(total) };
 
-	FieldBuffer::new(n_vars + log_bits, out_vec.into_boxed_slice())
+	FieldBuffer::new(n_vars + LOG_WORD_SIZE_BITS, out_vec.into_boxed_slice())
 }
 
 /// Compute the per-vertex bivariate product of two equally sized field buffers.
@@ -320,8 +346,6 @@ mod tests {
 
 	type P = Packed128b;
 
-	const LOG_BITS: usize = 6;
-
 	fn check_consistency<P: PackedField>(witness: &Witness<'_, P>) {
 		// The variable-base `b`-exponent tree root must equal the full product `c` root
 		// (`c_lo_root * c_hi_root`); this equality is what lets the prover reuse `b_root` in place
@@ -337,7 +361,7 @@ mod tests {
 		let c_lo = [Word::from_u64(6)]; // 2*3 = 6
 		let c_hi = [Word::from_u64(0)]; // no high bits
 
-		let witness = Witness::<P>::new(LOG_BITS, &a, &b, &c_lo, &c_hi).unwrap();
+		let witness = Witness::<P>::new(&a, &b, &c_lo, &c_hi).unwrap();
 		check_consistency(&witness);
 	}
 
@@ -348,7 +372,7 @@ mod tests {
 		let c_lo = [Word::from_u64(0)];
 		let c_hi = [Word::from_u64(2)]; // 2^32 * 2^33 = 2^65, which is 2 in the high 64 bits
 
-		let witness = Witness::<P>::new(LOG_BITS, &a, &b, &c_lo, &c_hi).unwrap();
+		let witness = Witness::<P>::new(&a, &b, &c_lo, &c_hi).unwrap();
 		check_consistency(&witness);
 	}
 
@@ -378,7 +402,7 @@ mod tests {
 			c_hi.push(Word::from_u64(c_hi_i));
 		}
 
-		let witness = Witness::<P>::new(LOG_BITS, &a, &b, &c_lo, &c_hi).unwrap();
+		let witness = Witness::<P>::new(&a, &b, &c_lo, &c_hi).unwrap();
 		check_consistency(&witness);
 	}
 }

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -7,7 +7,9 @@ use binius_core::{
 	constraint_system::{AndConstraint, ConstraintSystem, MulConstraint, ValueVec},
 	word::Word,
 };
-use binius_field::{AESTowerField8b as B8, BinaryField, ExtensionField, Field, PackedField};
+use binius_field::{
+	AESTowerField8b as B8, BinaryField, Divisible, ExtensionField, Field, PackedField,
+};
 use binius_hash::binary_merkle_tree::HashSuite;
 use binius_iop_prover::{basefold_compiler::BaseFoldProverCompiler, channel::IOPProverChannel};
 use binius_ip::sumcheck::SumcheckOutput;
@@ -247,7 +249,8 @@ impl IOPProver {
 		let batched_transparent =
 			compute_batched_transparent(rs_eq_ind, pubcheck_point, batch_coeff);
 
-		// Prove oracle relations via channel (runs BaseFold internally)
+		// Prove oracle relations via channel (runs BaseFold internally). The intmul pushforward
+		// relation, when the IntMul reduction ran, was already queued inside phase 5.
 		channel.prove_oracle_relations([(
 			trace_oracle,
 			witness_packed,
@@ -484,7 +487,7 @@ fn prove_intmul_reduction<F, P, Channel>(
 	channel: &mut Channel,
 ) -> Result<IntMulOutput<F>, Error>
 where
-	F: BinaryField,
+	F: BinaryField<Underlier: Divisible<u64>>,
 	P: PackedField<Scalar = F>,
 	Channel: IOPProverChannel<P>,
 {
@@ -492,7 +495,7 @@ where
 
 	let mut mulcheck_prover = IntMulProver::new(0, channel);
 
-	let intmul_witness = IntMulWitness::<P>::new(LOG_WORD_SIZE_BITS, &a, &b, &lo, &hi)?;
+	let intmul_witness = IntMulWitness::<P>::new(&a, &b, &lo, &hi)?;
 
 	Ok(mulcheck_prover.prove(intmul_witness))
 }

--- a/crates/verifier/src/protocols/intmul/common.rs
+++ b/crates/verifier/src/protocols/intmul/common.rs
@@ -1,9 +1,12 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 use std::iter;
 
-use binius_field::{BinaryField, Field, field::FieldOps};
+use binius_field::{BinaryField, field::FieldOps};
 use itertools::iterate;
+
+use crate::config::LOG_WORD_SIZE_BITS;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct IntMulOutput<F> {
@@ -48,22 +51,34 @@ pub struct Phase3Output<F> {
 	pub gpow_c_hi_eval: F,
 }
 
-/// Output of Phase 4: all but last GKR layer for $\widetilde{a}$, $\widetilde{c}_{\textsf{lo}}$,
-/// $\widetilde{c}_{\textsf{hi}}$.
+/// The log2 of the number of limbs each exponent word is split into for the Phase 4/5 fixed-base
+/// lookup.
+pub const LOG_N_LIMBS: usize = 2;
+
+/// The number of exponent limbs per word.
+pub const N_LIMBS: usize = 1 << LOG_N_LIMBS;
+
+/// The bit width of one exponent limb; the lookup table has `2^LIMB_BITS` rows.
+pub const LIMB_BITS: usize = 1 << (LOG_WORD_SIZE_BITS - LOG_N_LIMBS);
+
+/// The number of looked-up limb columns: one per limb of $\widetilde{a}$,
+/// $\widetilde{c}_{\textsf{lo}}$, and $\widetilde{c}_{\textsf{hi}}$.
+pub const N_LIMB_COLUMNS: usize = 3 * N_LIMBS;
+
+/// Output of Phase 4: the three constant-base GKR product trees reduced to per-limb evaluation
+/// claims.
 ///
-/// Rather than binding the all-but-last-layer evaluations here, Phase 4 hands the reduced prodcheck
-/// claim straight to Phase 5: the content-and-node point at which the three trees' all-but-last
-/// layers are claimed, the reduced selector coordinates that batch them, and the combined claimed
-/// evaluation. Phase 5 receives one reduced eval per tree and checks they recombine, weighted by
-/// `eq(selector)`, to `combined_eval`.
+/// Each tree's leaf layer is the concatenation of its `N_LIMBS` limb columns; Phase 4 reduces the
+/// three roots to one evaluation claim per limb column at the shared content point `eval_point`.
 pub struct Phase4Output<F> {
-	/// The point `[suffix, bit_index]` (content coordinates followed by all-but-last-layer node
-	/// coordinates) at which each tree's all-but-last-layer multilinear is claimed.
+	/// The shared content point at which the limb columns are claimed.
 	pub eval_point: Vec<F>,
-	/// The reduced selector coordinates that batch the three trees (padded to four).
-	pub selector: Vec<F>,
-	/// The batched prodcheck output evaluation: `Σ_t eq(selector, t) · eval_t`.
-	pub combined_eval: F,
+	/// The `N_LIMBS` per-limb evaluations of the $\widetilde{a}$ tree leaf columns.
+	pub a_limb_evals: Vec<F>,
+	/// The `N_LIMBS` per-limb evaluations of the $\widetilde{c}_{\textsf{lo}}$ tree leaf columns.
+	pub c_lo_limb_evals: Vec<F>,
+	/// The `N_LIMBS` per-limb evaluations of the $\widetilde{c}_{\textsf{hi}}$ tree leaf columns.
+	pub c_hi_limb_evals: Vec<F>,
 }
 
 /// Compute the inverse Frobenius endomorphism $\varphi^{-i}(x)$.
@@ -145,56 +160,55 @@ where
 	}
 }
 
-/// Reconstruct the "selected" leaf evaluations from the raw per-bit evaluations.
+/// The Frobenius twist amounts (numbers of squarings) mapping each looked-up limb column onto the
+/// shared generator table, ordered `[a limbs, c_lo limbs, c_hi limbs]`.
 ///
-/// The product checks for the exponentiations reduce to multilinear evaluations of affine
-/// translations of the $a, c_{\textsf{lo}}, c_{\textsf{hi}}$ polynomials. Given the raw bit
-/// evaluations $a(i, r), c_{\textsf{lo}}(i, r), c_{\textsf{hi}}(i, r)$, this returns the selected
-/// leaf values
-///
-/// * $\textsf{select}(a(i, r), g^{2^i})$,
-/// * $\textsf{select}(c_{\textsf{lo}}(i, r), g^{2^i})$,
-/// * $\textsf{select}(c_{\textsf{hi}}(i, r), g^{2^{i + k}})$,
-///
-/// for $i \in \{0, \ldots, 2^k - 1\}$, where $\textsf{select}(S, V) = S \cdot (V - 1) + 1$.
-///
-/// The verifier reconstructs these forward from the prover's raw evaluations and binds them to the
-/// GKR-verified leaf-product claims, rather than receiving them and inverting. $g$ is a constant
-/// multiplicative generator of the field $F$.
-pub fn reconstruct_selecteds<F, E>(
-	k: usize,
-	a_evals: &[E],
-	c_lo_evals: &[E],
-	c_hi_evals: &[E],
-) -> [Vec<E>; 3]
-where
-	F: Field,
-	E: FieldOps<Scalar = F> + From<F>,
-{
-	assert_eq!(a_evals.len(), 1 << k);
-	assert_eq!(c_lo_evals.len(), 1 << k);
-	assert_eq!(c_hi_evals.len(), 1 << k);
-
-	// powers[j] = g^{2^j}, for j in 0..2^{k+1}.
-	let powers: Vec<E> = iterate(F::MULTIPLICATIVE_GENERATOR, |g| g.square())
-		.take(2 << k)
-		.map(E::from)
-		.collect();
-	let (lo_powers, hi_powers) = powers.split_at(1 << k);
-
-	[
-		apply_selectors(a_evals, lo_powers),
-		apply_selectors(c_lo_evals, lo_powers),
-		apply_selectors(c_hi_evals, hi_powers),
-	]
+/// Limb $l$ of $\widetilde{a}$ and $\widetilde{c}_{\textsf{lo}}$ has base $g^{2^{wl}}$ (where $w$
+/// is the limb bit width); limb $l$ of $\widetilde{c}_{\textsf{hi}}$ has base
+/// $g^{2^{w(\textsf{N\_LIMBS} + l)}}$ because the $\widetilde{c}_{\textsf{hi}}$ tree exponentiates
+/// $g^{2^{2^k}}$. So column $(t, l)$ is the Frobenius power $\varphi^{ws}$ of the shared table
+/// column $g^{(\cdot)}$, with $s = l$ for $t \in \{a, c_{\textsf{lo}}\}$ and $s = \textsf{N\_LIMBS}
+/// + l$ for $t = c_{\textsf{hi}}$.
+pub fn limb_column_twists() -> [usize; N_LIMB_COLUMNS] {
+	std::array::from_fn(|j| {
+		let (tree, limb) = (j / N_LIMBS, j % N_LIMBS);
+		let s = if tree == 2 { N_LIMBS + limb } else { limb };
+		LIMB_BITS * s
+	})
 }
 
-/// Apply the affine selector `z * (V - 1) + 1` pointwise, given the generator powers `V_i`.
-fn apply_selectors<E: FieldOps>(raw_evals: &[E], powers: &[E]) -> Vec<E> {
-	assert_eq!(raw_evals.len(), powers.len());
+/// Twist a limb-column evaluation claim onto the shared generator table.
+///
+/// The limb column satisfies $L = \varphi^{a} \circ U$ pointwise on the cube, where $U$ is the
+/// looked-up column of the shared table and $a$ is the twist amount. Since $\varphi$ is
+/// $\mathbb{F}_2$-linear and fixes the cube, the MLE claim twists as $\widetilde{U}
+/// (\varphi^{-a}(r)) = \varphi^{-a}(\widetilde{L}(r))$, applying $\varphi^{-a}$ to the value and
+/// every point coordinate.
+pub fn twist_limb_claim<F>(twist: usize, eval_point: &[F], eval: F) -> (Vec<F>, F)
+where
+	F: FieldOps,
+	F::Scalar: BinaryField,
+{
+	let twisted_point = eval_point
+		.iter()
+		.map(|coord| inv_frobenius(coord.clone(), twist))
+		.collect();
+	(twisted_point, inv_frobenius(eval, twist))
+}
 
+/// Evaluate the MLE of the fixed-base power table `i ↦ g^i` at a point.
+///
+/// Row $i$ is the product over the set bits $j$ of $i$ of $g^{2^j}$, so the MLE factors as
+/// $\prod_j \textsf{select}(y_j, g^{2^j})$ with $\textsf{select}(S, V) = S \cdot (V - 1) + 1$ —
+/// the same select formulation as the exponentiation tree leaves. The verifier evaluates this
+/// directly in `point.len()` multiplications, so the table needs no commitment.
+pub fn eval_power_table_mle<F, E>(point: &[E]) -> E
+where
+	F: BinaryField,
+	E: FieldOps<Scalar = F> + From<F>,
+{
 	let one = E::one();
-	iter::zip(raw_evals, powers)
-		.map(|(raw, power)| raw.clone() * (power.clone() - one.clone()) + one.clone())
-		.collect()
+	iter::zip(iterate(F::MULTIPLICATIVE_GENERATOR, |g| g.square()), point)
+		.map(|(power, coord)| coord.clone() * (E::from(power) - one.clone()) + one.clone())
+		.fold(E::one(), |acc, factor| acc * factor)
 }

--- a/crates/verifier/src/protocols/intmul/error.rs
+++ b/crates/verifier/src/protocols/intmul/error.rs
@@ -1,5 +1,7 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
+use binius_iop::logup_star::Error as LogupError;
 use binius_ip::{
 	channel::Error as ChannelError, prodcheck::Error as ProdcheckError,
 	sumcheck::Error as SumcheckError,
@@ -15,4 +17,6 @@ pub enum Error {
 	SumcheckVerify(#[from] SumcheckError),
 	#[error("prodcheck verify error")]
 	ProdcheckVerify(#[from] ProdcheckError),
+	#[error("logup* verify error")]
+	LogupVerify(#[from] LogupError),
 }

--- a/crates/verifier/src/protocols/intmul/verify.rs
+++ b/crates/verifier/src/protocols/intmul/verify.rs
@@ -3,36 +3,35 @@
 
 use std::iter;
 
-use binius_field::{BinaryField, Field, field::FieldOps};
-use binius_iop::channel::IOPVerifierChannel;
+use binius_field::{BinaryField, BinaryField1b, ExtensionField, Field, field::FieldOps};
+use binius_iop::{channel::IOPVerifierChannel, logup_star};
 use binius_ip::{
 	channel::IPVerifierChannel,
+	logup_star::LookerClaim,
 	prodcheck::{self, MultilinearEvalClaim},
 	sumcheck::{BatchSumcheckOutput, batch_verify},
 };
 use binius_math::{
-	multilinear::{
-		eq::{eq_ind, eq_ind_zero},
-		evaluate::evaluate_inplace_scalars,
-	},
+	multilinear::{eq::eq_ind, evaluate::evaluate_inplace_scalars},
 	univariate::evaluate_univariate,
 };
 use binius_utils::checked_arithmetics::log2_ceil_usize;
 
 use super::{
 	common::{
-		IntMulOutput, Phase1Output, Phase2Output, Phase3Output, Phase4Output, frobenius_twist,
-		reconstruct_selecteds,
+		IntMulOutput, LIMB_BITS, LOG_N_LIMBS, N_LIMB_COLUMNS, N_LIMBS, Phase1Output, Phase2Output,
+		Phase3Output, Phase4Output, eval_power_table_mle, frobenius_twist, limb_column_twists,
+		twist_limb_claim,
 	},
 	error::Error,
 };
+use crate::config::{LOG_WORD_SIZE_BITS, WORD_SIZE_BITS};
 
 /// Verify Phase 1: GKR step on the exponentiation product tree.
 ///
 /// Runs prodcheck verification to reduce the root claim on $\widetilde{Q}$ to $2^k$ leaf
 /// evaluation claims, then verifies the leaf evaluations against the prover's claimed values.
 fn verify_phase_1<F, C>(
-	log_bits: usize,
 	initial_eval_point: &[C::Elem],
 	initial_b_eval: C::Elem,
 	channel: &mut C,
@@ -48,16 +47,16 @@ where
 		eval: initial_b_eval,
 		point: initial_eval_point.to_vec(),
 	};
-	let output_claim = prodcheck::verify(log_bits, claim, channel)?;
+	let output_claim = prodcheck::verify(LOG_WORD_SIZE_BITS, claim, channel)?;
 
 	// Split output point: first n are x-point, last k are z-challenges
 	let (eval_point, z_suffix) = output_claim.point.split_at(n_vars);
 
 	// Read 2^k leaf evaluations from channel
-	let b_leaves_evals = channel.recv_many(1 << log_bits)?;
+	let b_leaves_evals = channel.recv_many(WORD_SIZE_BITS)?;
 
 	// Verify: output_claim.eval = multilinear_eval(b_leaves_evals, z_suffix)
-	// The leaf evals form a multilinear over log_bits variables; evaluate at z_suffix
+	// The leaf evals form a multilinear over LOG_WORD_SIZE_BITS variables; evaluate at z_suffix
 	let expected_eval = evaluate_inplace_scalars(b_leaves_evals.clone(), z_suffix);
 
 	channel.assert_zero(expected_eval - output_claim.eval)?;
@@ -74,7 +73,6 @@ where
 /// claims to exponent evaluations on $\widetilde{b}$ and a selector on $\widetilde{P}$, and
 /// (b) the product claim $\widetilde{\textsf{LO}} \cdot \widetilde{\textsf{HI}}$.
 fn verify_phase_3<F, C>(
-	log_bits: usize,
 	twisted_eval_points: Vec<Vec<C::Elem>>,
 	twisted_evals: Vec<C::Elem>,
 	c_eval_point: &[C::Elem],
@@ -87,7 +85,7 @@ where
 {
 	let n_vars = c_eval_point.len();
 
-	assert_eq!(twisted_eval_points.len(), 1 << log_bits);
+	assert_eq!(twisted_eval_points.len(), WORD_SIZE_BITS);
 
 	for twisted_eval_point in &twisted_eval_points {
 		assert_eq!(twisted_eval_point.len(), c_eval_point.len());
@@ -102,7 +100,7 @@ where
 	// The two batched terms (each degree 3) are:
 	// - the 2^k aggregate: Σ_i eq_k(γ, i) * (b(i, X) * (A(X) - 1) + 1) * eq(φ⁻ⁱ(x) ; X)
 	// - LO(X) * HI(X) * eq(c_eval_point ; X)
-	let gamma = channel.sample_many(log_bits);
+	let gamma = channel.sample_many(LOG_WORD_SIZE_BITS);
 	let selector_agg_eval = evaluate_inplace_scalars(twisted_evals, &gamma);
 	let evals = [selector_agg_eval, c_eval];
 
@@ -114,7 +112,7 @@ where
 	challenges.reverse();
 
 	// b(i, r) for i in 0..2^k
-	let b_evals = channel.recv_many(1 << log_bits)?;
+	let b_evals = channel.recv_many(WORD_SIZE_BITS)?;
 
 	// A(r)
 	let gpow_a_eval = channel.recv_one()?;
@@ -125,7 +123,7 @@ where
 	// Recombine the 2^k per-bit exponent claims b(i, r) into a single claim b(r_I^b, r) by
 	// sampling a recombination point r_I^b in K^k. This carries one exponent claim (rather than
 	// 2^k) into Phases 4 and 5.
-	let r_ib = channel.sample_many(log_bits);
+	let r_ib = channel.sample_many(LOG_WORD_SIZE_BITS);
 	let b_recomb = evaluate_inplace_scalars(b_evals.clone(), &r_ib);
 
 	let eval_point = challenges;
@@ -160,16 +158,16 @@ where
 	})
 }
 
-/// Verify Phase 4: all but last layer of the GKR product trees for $\widetilde{a}$,
-/// $\widetilde{c}_{\textsf{lo}}$, and $\widetilde{c}_{\textsf{hi}}$.
+/// Verify Phase 4: the GKR product trees for $\widetilde{a}$, $\widetilde{c}_{\textsf{lo}}$, and
+/// $\widetilde{c}_{\textsf{hi}}$, reduced to per-limb evaluation claims.
 ///
-/// Reduces the three tree roots (claimed at the Phase-3 point) to the all-but-last (depth
-/// `log_bits - 1`) layer claim via a single batched prodcheck over the three trees, batched with
-/// $\lceil \log_2 3 \rceil = 2$ selector variables. Rather than binding the all-but-last-layer
-/// evaluations here, the reduced claim (content-and-node point, reduced selector coordinates, and
-/// combined evaluation) is handed straight to Phase 5.
+/// Each tree's leaf layer is the concatenation of its `N_LIMBS` limb columns. A single batched
+/// prodcheck over the three trees (batched with $\lceil \log_2 3 \rceil = 2$ selector variables)
+/// runs the all-but-last reduction layer; the final (widest) layer of each tree is then proven by
+/// a batched bivariate-product sumcheck seeded by the three per-tree reduced claims. The prover
+/// sends the per-limb evaluations at the shared content point, which the verifier binds to the
+/// final-layer sumcheck by recombining each tree's two leaf halves via `eq(r_limb)`.
 fn verify_phase_4<F, C>(
-	log_bits: usize,
 	eval_point: &[C::Elem],
 	a_root_eval: C::Elem,
 	gpow_c_lo_eval: C::Elem,
@@ -180,10 +178,7 @@ where
 	F: Field,
 	C: IPVerifierChannel<F>,
 {
-	assert!(log_bits >= 1);
-
 	let n_vars = eval_point.len();
-	let n_layers = log_bits - 1;
 
 	let log_n_trees = log2_ceil_usize(3); // = 2 selector variables
 
@@ -200,116 +195,149 @@ where
 		point: [selector, eval_point.to_vec()].concat(),
 	};
 
-	// Run the batched prodcheck verification (n_layers = log_bits - 1 reduction layers).
-	let output_claim = prodcheck::verify(n_layers, claim, channel)?;
+	// Run the batched prodcheck verification over all LOG_N_LIMBS layers.
+	let output_claim = prodcheck::verify(LOG_N_LIMBS, claim, channel)?;
 
-	// The reduced point is [selector (log_n_trees), suffix (n_vars), bit_index (n_layers)]:
+	// The reduced point is [selector (log_n_trees), r_content (n_vars), r_limb (LOG_N_LIMBS)]:
 	//  - selector: the batching coordinates for the three trees, reduced through the selector
 	//    rounds,
-	//  - suffix ++ bit_index: the content-and-node point at which each tree's all-but-last-layer
-	//    multilinear is now claimed.
-	assert_eq!(output_claim.point.len(), log_n_trees + n_layers + n_vars);
-	let (selector_point, a_c_eval_point) = output_claim.point.split_at(log_n_trees);
+	//  - r_content: the shared point at which the limb columns are claimed,
+	//  - r_limb: the limb-index coordinates of each tree's leaf layer.
+	assert_eq!(output_claim.point.len(), log_n_trees + n_vars + LOG_N_LIMBS);
+	let (selector_point, rest) = output_claim.point.split_at(log_n_trees);
+	let (r_content, r_limb) = rest.split_at(n_vars);
+
+	// The prover sends the per-limb evaluations at r_content for each tree. Each tree's leaf
+	// multilinear stacks its limb columns over the limb coordinates, so its evaluation is the
+	// eq(r_limb)-fold of the per-limb evals; the batched output claim is the eq(selector)-weighted
+	// combination of the tree evaluations (the padding tree slot is zero).
+	let a_limb_evals = channel.recv_many(N_LIMBS)?;
+	let c_lo_limb_evals = channel.recv_many(N_LIMBS)?;
+	let c_hi_limb_evals = channel.recv_many(N_LIMBS)?;
+
+	let tree_eval = |limb_evals: &[C::Elem]| evaluate_inplace_scalars(limb_evals.to_vec(), r_limb);
+	let per_tree = vec![
+		tree_eval(&a_limb_evals),
+		tree_eval(&c_lo_limb_evals),
+		tree_eval(&c_hi_limb_evals),
+		C::Elem::zero(),
+	];
+	let combined = evaluate_inplace_scalars(per_tree, selector_point);
+	channel.assert_zero(combined - output_claim.eval)?;
 
 	Ok(Phase4Output {
-		eval_point: a_c_eval_point.to_vec(),
-		selector: selector_point.to_vec(),
-		combined_eval: output_claim.eval,
+		eval_point: r_content.to_vec(),
+		a_limb_evals,
+		c_lo_limb_evals,
+		c_hi_limb_evals,
 	})
 }
 
-/// Verify Phase 5: final GKR layer, $\widetilde{b}$ rerandomization, and parity zerocheck.
+/// Verify Phase 5: the logup* fixed-base exponentiation lookup, $\widetilde{b}$ rerandomization,
+/// and parity zerocheck.
 ///
-/// First receives one reduced eval per tree ($\widetilde{a}$, $\widetilde{c}_{\textsf{lo}}$,
-/// $\widetilde{c}_{\textsf{hi}}$) and checks they recombine, weighted by
-/// $\textsf{eq}(\text{selector})$, to the Phase-4 prodcheck output claim. Then batches five
-/// sumchecks: the final (widest) GKR layer of each of the three trees (each a regular
-/// prodcheck-layer bivariate product MLE-check seeded by its reduced eval), the parity zerocheck
-/// $a_0 \cdot b_0 = c_{\textsf{lo},0}$, and a single-claim rerandomization of the recombined
-/// $\widetilde{b}(r_I^b, \cdot)$ exponent claim. The latter two span only the content variables and
-/// are padded up to the trees' variable count.
-#[allow(clippy::too_many_arguments)]
-fn verify_phase_5<F, C>(
-	log_bits: usize,
-	a_c_eval_point: &[C::Elem],
-	selector: &[C::Elem],
-	combined_eval: C::Elem,
+/// The per-limb claims from Phase 4 are Frobenius-twisted onto the shared table of generator
+/// powers `i ↦ g^i`, batched to a single stacked lookup claim, and read from the table via a
+/// committed logup* reduction. The reduced table claim is checked against the table's succinct
+/// MLE; the pushforward claim is opened through the channel inside the reduction;
+/// the reduced index claims are carried into a final batched sumcheck — together with the
+/// $\widetilde{b}(r_I^b, \cdot)$ rerandomization and the parity zerocheck $a_0 \cdot b_0 =
+/// c_{\textsf{lo},0}$ — that brings every output claim to one shared point.
+fn verify_phase_5<'r, F, C>(
+	phase_4_output: &Phase4Output<C::Elem>,
 	b_eval_point: &[C::Elem],
 	r_ib: &[C::Elem],
 	b_recomb: C::Elem,
 	channel: &mut C,
 ) -> Result<IntMulOutput<C::Elem>, Error>
 where
-	F: Field,
-	C: IPVerifierChannel<F>,
-	C::Elem: FieldOps<Scalar = F> + From<F>,
+	F: BinaryField,
+	C: IOPVerifierChannel<'r, F>,
+	C::Elem: FieldOps<Scalar = F> + From<F> + 'r,
 {
-	assert!(log_bits >= 1);
 	let n_vars = b_eval_point.len();
-	let n_extra = log_bits - 1;
-	assert_eq!(a_c_eval_point.len(), n_vars + n_extra);
+	assert_eq!(phase_4_output.eval_point.len(), n_vars);
 
-	// Receive the three per-tree reduced claims and check they recombine, weighted by eq(selector)
-	// (padded to four), to the batched prodcheck output claim.
-	let [a_eval, c_lo_eval, c_hi_eval] = channel.recv_array::<3>()?;
-	let per_tree = vec![
-		a_eval.clone(),
-		c_lo_eval.clone(),
-		c_hi_eval.clone(),
-		C::Elem::zero(),
+	// Twist the per-limb claims onto the shared table: column (t, l) is the Frobenius power
+	// φ^{twist} of the looked-up column U_{t,l}(x) = T[e_{t,l}(x)], so its claim becomes a claim on
+	// U_{t,l} at the twisted point.
+	let twists = limb_column_twists();
+	let limb_evals = [
+		&phase_4_output.a_limb_evals,
+		&phase_4_output.c_lo_limb_evals,
+		&phase_4_output.c_hi_limb_evals,
 	];
-	let combined = evaluate_inplace_scalars(per_tree, selector);
-	channel.assert_zero(combined - combined_eval)?;
+	let twisted_claims = iter::zip(&twists, limb_evals.into_iter().flatten())
+		.map(|(&twist, eval)| twist_limb_claim(twist, &phase_4_output.eval_point, eval.clone()))
+		.collect::<Vec<_>>();
 
-	// The batched sumcheck's five per-prover sum claims: the three tree final-layer sumchecks
-	// (seeded by the reduced evals), the overflow parity zerocheck (0), and the single recombined
-	// b exponent eval for the rerandomization.
-	let evals = [a_eval, c_lo_eval, c_hi_eval, C::Elem::zero(), b_recomb];
+	// Read the N_LIMB_COLUMNS looked-up columns from the shared table via the committed multi-
+	// looker logup* reduction. The pushforward oracle is received inside; its opening relation is
+	// returned to the caller. The reduction returns one index claim per column, all at the shared
+	// content point.
+	let looker_claims = twisted_claims
+		.iter()
+		.map(|(twisted_point, twisted_eval)| LookerClaim {
+			eval_point: twisted_point,
+			eval_claim: twisted_eval.clone(),
+		})
+		.collect::<Vec<_>>();
+	let log_cols = log2_ceil_usize(N_LIMB_COLUMNS);
+	let logup_proof = logup_star::verify::<F, C>(LIMB_BITS, &looker_claims, channel)?;
 
+	// The table is succinct: the verifier evaluates its MLE directly.
+	let expected_table_eval = eval_power_table_mle::<F, C::Elem>(&logup_proof.table_eval_point);
+	channel.assert_zero(expected_table_eval - logup_proof.table_eval_claim)?;
+
+	// The reduction hands back the per-column embedded-index claims directly, all at the shared
+	// content point (padding columns read row 0, whose embedding is zero).
+	let index_content_point = logup_proof.index_eval_point.as_slice();
+	let mut padded_column_evals = logup_proof.index_eval_claims.clone();
+	padded_column_evals.resize(1 << log_cols, C::Elem::zero());
+
+	// Collapse the per-column claims into a single claim on the eq(ρ)-folded column V by sampling
+	// ρ, so the final unification runs over the content variables only.
+	let rho = channel.sample_many(log_cols);
+	let folded_index_claim = evaluate_inplace_scalars(padded_column_evals, &rho);
+
+	// Final unification: one batched sumcheck brings the folded index claim, the recombined b
+	// exponent claim, and the parity zerocheck to a shared output point.
+	let evals = [folded_index_claim, C::Elem::zero(), b_recomb];
 	let BatchSumcheckOutput {
 		batch_coeff,
 		mut challenges,
 		eval,
-	} = batch_verify(n_vars + n_extra, 3, &evals, channel)?;
+	} = batch_verify(n_vars, 3, &evals, channel)?;
 	challenges.reverse();
+	let r_out = challenges.as_slice();
 
-	// challenges = [r_content (n_vars), r_bit (n_extra)]: r_content is the shared output point;
-	// r_bit collapses the node dimension (and is the padding point for the overflow / b checks).
-	let (r_content, r_bit) = challenges.split_at(n_vars);
+	// The prover sends the raw per-bit evaluations at r_out.
+	let a_evals = channel.recv_many(WORD_SIZE_BITS)?;
+	let c_lo_evals = channel.recv_many(WORD_SIZE_BITS)?;
+	let c_hi_evals = channel.recv_many(WORD_SIZE_BITS)?;
+	let b_evals = channel.recv_many(WORD_SIZE_BITS)?;
 
-	// The prover sends the raw per-bit evaluations at r_content; the verifier reconstructs the leaf
-	// selectors forward (rather than receiving selectors and inverting them).
-	let a_evals = channel.recv_many(1 << log_bits)?;
-	let c_lo_evals = channel.recv_many(1 << log_bits)?;
-	let c_hi_evals = channel.recv_many(1 << log_bits)?;
-	let b_evals = channel.recv_many(1 << log_bits)?;
+	// Bind the per-bit evals to the folded index claim. The index entries are the GF(2)-linear
+	// embeddings iota(e_{t,l}) = Σ_u basis(u) · bit_u(e_{t,l}), and bit u of limb l is bit
+	// (LIMB_BITS·l + u) of the word, so each column's MLE is a fixed basis-weighted combination of
+	// the word's per-bit column MLEs.
+	let per_word_evals = [&a_evals, &c_lo_evals, &c_hi_evals];
+	let mut column_evals = (0..N_LIMB_COLUMNS)
+		.map(|j| {
+			let (tree, limb) = (j / N_LIMBS, j % N_LIMBS);
+			(0..LIMB_BITS)
+				.map(|u| {
+					let basis = <F as ExtensionField<BinaryField1b>>::basis(u);
+					per_word_evals[tree][limb * LIMB_BITS + u].clone() * C::Elem::from(basis)
+				})
+				.fold(C::Elem::zero(), |acc, term| acc + term)
+		})
+		.collect::<Vec<_>>();
+	column_evals.resize(1 << log_cols, C::Elem::zero());
+	let folded_index_eval = evaluate_inplace_scalars(column_evals, &rho);
+	let expected_index_eval = eq_ind(index_content_point, r_out) * folded_index_eval;
 
-	let [a_selected_evals, c_lo_selected_evals, c_hi_selected_evals] =
-		reconstruct_selecteds(log_bits, &a_evals, &c_lo_evals, &c_hi_evals);
-
-	// eq(a_c_eval_point ; challenges) is the MLE-check equality factor shared by the three
-	// final-layer sumchecks.
-	let a_c_eq_eval = eq_ind(a_c_eval_point, &challenges);
-
-	// Each tree's final-layer product reduces the all-but-last claim to the two halves of its leaf
-	// layer (split on the highest node bit). The verifier recombines the selected leaf evals into
-	// each half via eq(r_bit): half_lo = Σ_{z<half} eq(r_bit, z) · selected[z] and half_hi over
-	// selected[z + half]. The bivariate product is eq_ac · half_lo · half_hi.
-	let tree_product = |selecteds: &[C::Elem]| {
-		let half = selecteds.len() / 2;
-		let lo = evaluate_inplace_scalars(selecteds[..half].to_vec(), r_bit);
-		let hi = evaluate_inplace_scalars(selecteds[half..].to_vec(), r_bit);
-		a_c_eq_eval.clone() * lo * hi
-	};
-	let expected_a = tree_product(&a_selected_evals);
-	let expected_c_lo = tree_product(&c_lo_selected_evals);
-	let expected_c_hi = tree_product(&c_hi_selected_evals);
-
-	// The overflow and b checks span only the content variables, so their padded contribution
-	// carries the factor eq(0^{n_extra} ; r_bit).
-	let eq_pad = eq_ind_zero(r_bit);
-
-	let b_eq_eval = eq_ind(b_eval_point, r_content);
+	let b_eq_eval = eq_ind(b_eval_point, r_out);
 
 	// We must check that `a_0 * b_0 = c_lo_0` across all rows, where these represent the least
 	// significant bits of `a_exponents`, `b_exponents`, and `c_lo_exponents` respectively.
@@ -325,17 +353,15 @@ where
 	// `b_eval_point` (r_2) as the zerocheck challenge — available for free because the `b`
 	// re-randomization already evaluates at r_2.
 	let expected_overflow_eval =
-		eq_pad.clone() * &b_eq_eval * (a_evals[0].clone() * &b_evals[0] - &c_lo_evals[0]);
+		b_eq_eval.clone() * (a_evals[0].clone() * &b_evals[0] - &c_lo_evals[0]);
 
 	// Bind the prover's raw per-bit evals to the single recombined rerandomization claim:
-	// b(r_I^b, r_content) = sum_i eq(r_I^b, i) * b(i, r_content).
+	// b(r_I^b, r_out) = sum_i eq(r_I^b, i) * b(i, r_out).
 	let b_at_rx = evaluate_inplace_scalars(b_evals.clone(), r_ib);
-	let expected_b_rerand_eval = eq_pad * &b_eq_eval * &b_at_rx;
+	let expected_b_rerand_eval = b_eq_eval * &b_at_rx;
 
 	let expected_unbatched_evals = [
-		expected_a,
-		expected_c_lo,
-		expected_c_hi,
+		expected_index_eval,
 		expected_overflow_eval,
 		expected_b_rerand_eval,
 	];
@@ -345,7 +371,7 @@ where
 	channel.assert_zero(expected_batched_eval - eval)?;
 
 	Ok(IntMulOutput {
-		eval_point: r_content.to_vec(),
+		eval_point: r_out.to_vec(),
 		a_evals,
 		b_evals,
 		c_lo_evals,
@@ -412,44 +438,45 @@ where
 ///   \sum_i \textsf{eq}(r_I^b, i) \cdot \widetilde{b}(i, r)$, carried into Phases 4 and 5.
 ///
 /// - **Phase 4 — GKR on $\widetilde{a}$, $\widetilde{c}_{\textsf{lo}}$,
-///   $\widetilde{c}_{\textsf{hi}}$ (all but last layer):** Batched GKR layers for the three
-///   remaining exponentiation product trees. Each layer is a batched bivariate product sumcheck.
-///   Since the bases ($g$ and $g^{2^k}$) are fixed, the Frobenius steps can be skipped — the
-///   verifier locally reduces "scaled" evaluations to plain exponent evaluations.
+///   $\widetilde{c}_{\textsf{hi}}$, down to per-limb claims:** Each exponent word splits into
+///   `N_LIMBS` limbs, so each of the three constant-base exponentiations factors as a product of
+///   `N_LIMBS` limb columns. A batched GKR product check over the three (depth-`LOG_N_LIMBS`) trees
+///   reduces the root claims to one evaluation claim per limb column at a shared content point.
 ///
-/// - **Phase 5 — Final GKR layer + $\widetilde{b}$ rerandomization + parity check:** The final
-///   (widest) GKR layer for $\widetilde{a}$, $\widetilde{c}_{\textsf{lo}}$,
-///   $\widetilde{c}_{\textsf{hi}}$ is batched with: (a) A single-claim rerandomization sumcheck on
-///   the recombined $\widetilde{b}(r_I^b, \cdot)$ exponent claim from Phase 3, bringing it to the
-///   same evaluation point as $\widetilde{a}$ and $\widetilde{c}$. The prover sends the $2^k$ raw
-///   per-bit evals $\widetilde{b}(i, r_x)$, which the verifier binds via $\sum_i \textsf{eq}(r_I^b,
-///   i) \cdot \widetilde{b}(i, r_x) = \widetilde{b}(r_I^b, r_x)$. (b) A zerocheck verifying $a_0
-///   \cdot b_0 = c_{\textsf{lo},0}$ (least significant bits), ruling out the wraparound edge case.
+/// - **Phase 5 — logup* lookup + $\widetilde{b}$ rerandomization + parity check:** Limb column $(t,
+///   l)$ is the Frobenius power $\varphi^{ws}$ of the looked-up column $T[e_{t,l}(\cdot)]$ over the
+///   shared table $T\colon i \mapsto g^i$ of $2^w$ generator powers (where $w$ is the limb bit
+///   width). The per-limb claims are Frobenius-twisted onto $T$, batched to one stacked lookup
+///   claim, and reduced via committed logup* ([Soukhanov25]): the pushforward oracle is committed
+///   mid-protocol and its opening relation returned to the caller; the table claim is checked
+///   against the table's succinct product-of-selects MLE; the index claim is bound to the per-bit
+///   output evals in a final batched sumcheck, together with (a) a single-claim rerandomization of
+///   the recombined $\widetilde{b}(r_I^b, \cdot)$ exponent claim from Phase 3 and (b) a zerocheck
+///   verifying $a_0 \cdot b_0 = c_{\textsf{lo},0}$ (least significant bits), ruling out the
+///   wraparound edge case.
+///
+/// [Soukhanov25]: <https://eprint.iacr.org/2025/946>
 ///
 /// ### Output
 ///
 /// The protocol outputs evaluation claims on $\widetilde{a}_i$, $\widetilde{b}_i$,
 /// $\widetilde{c}_{\textsf{lo},i}$, $\widetilde{c}_{\textsf{hi},i}$ (for $i \in \{0, \ldots,
-/// 2^k - 1\}$) at a common $n$-dimensional evaluation point. These are passed to the shift
-/// reduction.
+/// 2^k - 1\}$) at a common $n$-dimensional evaluation point. The claims are passed to the shift
+/// reduction; the logup* pushforward commitment is opened through the channel inside phase 5.
 ///
 /// ### Parameters
 ///
-/// - `log_bits`: $k$, where $2^k$ is the bit-width of the integer operands.
 /// - `n_vars`: Number of variables in the row dimension (i.e., $\log_2$ of the number of
 ///   multiplication constraints).
-pub fn verify<'r, F, C>(
-	log_bits: usize,
-	n_vars: usize,
-	channel: &mut C,
-) -> Result<IntMulOutput<C::Elem>, Error>
+///
+/// The integer operands are fixed at the `WORD_SIZE_BITS` bit width.
+pub fn verify<'r, F, C>(n_vars: usize, channel: &mut C) -> Result<IntMulOutput<C::Elem>, Error>
 where
 	F: BinaryField,
 	C: IOPVerifierChannel<'r, F>,
-	C::Elem: FieldOps<Scalar = F> + From<F>,
+	C::Elem: FieldOps<Scalar = F> + From<F> + 'r,
 {
-	assert!(log_bits >= 1);
-	assert!((1 << (log_bits + 1)) <= F::N_BITS);
+	assert!(2 * WORD_SIZE_BITS <= F::N_BITS);
 
 	let initial_eval_point = channel.sample_many(n_vars);
 
@@ -460,16 +487,16 @@ where
 	let Phase1Output {
 		eval_point: phase_1_eval_point,
 		b_leaves_evals,
-	} = verify_phase_1(log_bits, &initial_eval_point, exp_eval.clone(), channel)?;
+	} = verify_phase_1(&initial_eval_point, exp_eval.clone(), channel)?;
 
 	assert_eq!(phase_1_eval_point.len(), n_vars);
-	assert_eq!(b_leaves_evals.len(), 1 << log_bits);
+	assert_eq!(b_leaves_evals.len(), WORD_SIZE_BITS);
 
 	// Phase 2
 	let Phase2Output {
 		twisted_eval_points,
 		twisted_evals,
-	} = frobenius_twist(log_bits, &phase_1_eval_point, &b_leaves_evals);
+	} = frobenius_twist(LOG_WORD_SIZE_BITS, &phase_1_eval_point, &b_leaves_evals);
 
 	// Phase 3
 	let Phase3Output {
@@ -479,38 +506,12 @@ where
 		gpow_a_eval,
 		gpow_c_lo_eval,
 		gpow_c_hi_eval,
-	} = verify_phase_3(
-		log_bits,
-		twisted_eval_points,
-		twisted_evals,
-		&initial_eval_point,
-		exp_eval,
-		channel,
-	)?;
+	} = verify_phase_3(twisted_eval_points, twisted_evals, &initial_eval_point, exp_eval, channel)?;
 
 	// Phase 4
-	let Phase4Output {
-		eval_point: phase_4_eval_point,
-		selector,
-		combined_eval,
-	} = verify_phase_4(
-		log_bits,
-		&phase_3_eval_point,
-		gpow_a_eval,
-		gpow_c_lo_eval,
-		gpow_c_hi_eval,
-		channel,
-	)?;
+	let phase_4_output =
+		verify_phase_4(&phase_3_eval_point, gpow_a_eval, gpow_c_lo_eval, gpow_c_hi_eval, channel)?;
 
 	// Phase 5
-	verify_phase_5(
-		log_bits,
-		&phase_4_eval_point,
-		&selector,
-		combined_eval,
-		&phase_3_eval_point,
-		&r_ib,
-		b_recomb,
-		channel,
-	)
+	verify_phase_5(&phase_4_output, &phase_3_eval_point, &r_ib, b_recomb, channel)
 }

--- a/crates/verifier/src/verify.rs
+++ b/crates/verifier/src/verify.rs
@@ -169,8 +169,7 @@ impl IOPVerifier {
 			)
 			.entered();
 			let log_n_constraints = checked_log_2(self.constraint_system.n_mul_constraints());
-			let intmul_output =
-				verify_intmul_reduction::<B128, _>(LOG_WORD_SIZE_BITS, log_n_constraints, channel)?;
+			let intmul_output = verify_intmul_reduction::<B128, _>(log_n_constraints, channel)?;
 			drop(intmul_guard);
 			Some(intmul_output)
 		} else {
@@ -291,7 +290,9 @@ impl IOPVerifier {
 			rs_eq_eval + batch_coeff.clone() * pubcheck_eq_eval
 		});
 
-		// Verify oracle relations (runs BaseFold internally and verifies the product check)
+		// Verify oracle relations (runs BaseFold internally and verifies the product check). The
+		// intmul pushforward relation, when the IntMul reduction ran, was already queued inside
+		// phase 5.
 		channel.verify_oracle_relations([OracleLinearRelation {
 			oracle: trace_oracle,
 			transparent,


### PR DESCRIPTION
Implements [BINIUS-208](https://linear.app/jimpo/issue/BINIUS-208/use-logup-for-fixed-base-exponentiation-in-intmul): intmul phases 4 and 5 now read the twisted per-limb exponentiation claims from a shared table of generator powers `i ↦ Gⁱ` via the committed multi-looker logup* reduction (#1691), instead of materializing the looked-up columns and batching them with an MLE-eval sumcheck. Final PR of the BINIUS-208 stack (follows #1682, #1685, #1691).

- Phase 4 is a single full-depth batched prodcheck: `prodcheck::batch_prove` now runs all layers (with the all-but-last body split out as `prodcheck::batch_prove_until_final_layer`), so the verifier is one `prodcheck::verify(LOG_N_LIMBS)` call plus one recombination check of the received per-limb evals.
- Phase 5 builds the `N_LIMB_COLUMNS = 12` per-limb index columns (limb slices of the `a`, `c_lo`, `c_hi` exponent words), Frobenius-twists the phase-4 claims onto the shared table, and reads them from the table via the committed logup* reduction. The pushforward oracle is committed inside and its opening relation is queued on the channel there (deferred to `finish()` for BaseFold).
- The reduction returns one embedded-index claim per column at a shared content point; phase 5 folds them by a sampled ρ and runs a separate rerandomization sumcheck bringing the folded index claim, the `b̃` rerandomization, and the parity zerocheck to one shared output point.
- The table is succinct: the verifier checks the reduced table claim against the power-table MLE directly. The pre-existing phase-4/5 machinery for materialized lookup columns is removed.
- intmul is now fixed to `WORD_SIZE_BITS`/`LOG_WORD_SIZE_BITS` constants: the `log_bits` runtime parameter is gone from the witness, prover, verifier, and bench surfaces.

Benchmark numbers (BaseFold channel, production params, main vs branch at LOG_NUM 14 and 17) are in the comments below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)