### PR TITLE
Optimize build_g_parts scatter for small words

### DIFF
--- a/crates/prover/src/protocols/shift/phase_1.rs
+++ b/crates/prover/src/protocols/shift/phase_1.rs
@@ -229,11 +229,14 @@ pub fn build_g_parts<F: BinaryField, P: PackedField<Scalar = F>>(
 					//     }
 					// }
 					let start = key.id as usize * (WORD_SIZE_BITS >> P::LOG_WIDTH);
-					let word_bytes = word.0.to_le_bytes();
-					for (&byte, values) in word_bytes.iter().zip(
-						multilinears[start..start + (WORD_SIZE_BITS >> P::LOG_WIDTH)]
-							.chunks_exact_mut(WORD_SIZE_BYTES >> P::LOG_WIDTH),
-					) {
+					let values = &mut multilinears[start..start + (WORD_SIZE_BITS >> P::LOG_WIDTH)];
+					let values_per_byte = WORD_SIZE_BYTES >> P::LOG_WIDTH;
+					let mut remaining_word = word.0;
+					let mut byte_index = 0;
+					while remaining_word != 0 {
+						let byte = remaining_word as u8;
+						let byte_values =
+							&mut values[byte_index * values_per_byte..][..values_per_byte];
 						for value_index in 0..(8 >> P::LOG_WIDTH) {
 							unsafe {
 								let packed_mask_index =
@@ -249,10 +252,12 @@ pub fn build_g_parts<F: BinaryField, P: PackedField<Scalar = F>>(
 								//   due to the chunking
 								// - `value_index` is always in bounds because we iterate over 0..(8
 								//   >> P::LOG_WIDTH)
-								*values.get_unchecked_mut(value_index) +=
+								*byte_values.get_unchecked_mut(value_index) +=
 									acc_packed.select(packed_mask);
 							}
 						}
+						remaining_word >>= 8;
+						byte_index += 1;
 					}
 				}
 


### PR DESCRIPTION

## Summary
In `build_g_parts` (shift protocol phase 1), each key's accumulated contribution is
scattered into the g multilinears byte-by-byte. The old loop materialized
`word.0.to_le_bytes()` and processed all 8 bytes, even when the remaining high bytes were
zero. On the optimized SHA256 `shift_reduction` benchmark, many witness words are small
values, so those high-byte iterations only add zero masks.

This keeps the existing byte-level masked-select scatter, but consumes the word directly:

- take the low byte with `remaining_word as u8`
- process that byte exactly as before
- shift with `remaining_word >>= 8`
- stop once the remaining high bytes are zero

This is a single code path for every word. It removes the previous popcount threshold and
the separate set-bit scatter path, so there is no microarchitecture-tuned popcount
constant and less semantic duplication to maintain.

Prover output is unchanged: skipped high zero bytes would only have selected zero masks in
the old loop, and nonzero low bytes are processed in the same low-to-high byte order with
the same lane masks.

## Benchmarks
Fresh local 3-way Criterion run on Apple M4 Pro against current `main` (`947e1377`, after
#1739). The previous sparse-popcount branch is included only as a comparison point; this
PR now uses the early-exit byte loop.

| Benchmark | main | previous sparse-popcount | this PR | Δ vs main |
|---|---:|---:|---:|---:|
| `shift_reduction_phases/phase1_build_g_parts` | 6.0089 ms | 5.7712 ms | 5.4169 ms | -9.85% |
| `shift_reduction_log2_12_bytes_4096/prove` | 2.6846 ms | 2.5875 ms | 2.5040 ms | -6.73% |

Relative to the previous sparse-popcount implementation, the early-exit byte loop is also
faster:

| Benchmark | Δ vs previous sparse-popcount |
|---|---:|
| `phase1_build_g_parts` | -6.14% |
| 4096-byte `prove` | -3.23% |

## Test plan
- `cargo +nightly-2026-01-01 fmt --check`
- `cargo test -p binius-prover --lib` (22/22)
- `cargo clippy -p binius-prover --lib --tests -- -D warnings`
- Fresh `shift_reduction` Criterion comparison above