### PR TITLE
BINIUS-224: fine-grained shift_reduction phase benchmarks

### DIFF
--- a/crates/prover/benches/shift_reduction.rs
+++ b/crates/prover/benches/shift_reduction.rs
@@ -1,4 +1,5 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 use binius_circuits::sha256::Sha256;
 use binius_core::{ValueVec, constraint_system::ConstraintSystem};
@@ -56,7 +57,7 @@ pub fn create_sha256_cs_with_witness(
 }
 
 fn bench_prove_and_verify(c: &mut Criterion) {
-	use binius_field::{BinaryField128bGhash, PackedBinaryGhash1x128b, Random};
+	use binius_field::{BinaryField128bGhash, Field, PackedBinaryGhash1x128b, Random};
 	type F = BinaryField128bGhash;
 	type P = PackedBinaryGhash1x128b;
 	let mut rng = rand::rng();
@@ -76,18 +77,16 @@ fn bench_prove_and_verify(c: &mut Criterion) {
 				.map(F::new)
 				.collect::<Vec<_>>()
 		};
-		let r_x_prime_intmul = {
-			let log_intmul_constraint_count = strict_log_2(cs.mul_constraints.len()).unwrap();
-			(0..log_intmul_constraint_count as u128)
-				.map(F::new)
-				.collect::<Vec<_>>()
-		};
+		// SHA256 has no MUL constraints, so the IntMul operator is the zero claim (four zero evals
+		// at an empty point), exactly as the real prover/verifier synthesize it (`prove.rs` /
+		// `verify.rs` `None` branch). Its `r_x_prime` is therefore empty.
+		let r_x_prime_intmul: Vec<F> = Vec::new();
 
 		// Sample univariate eval point — shared across bitand and intmul operators.
 		let r_zhat_prime = F::random(&mut rng);
 
 		let bitand_evals = [F::random(&mut rng); 3];
-		let intmul_evals = [F::random(&mut rng); 4];
+		let intmul_evals = [F::ZERO; 4];
 		let key_collection = build_key_collection(&cs);
 
 		let mut group = c.benchmark_group(format!(
@@ -160,5 +159,151 @@ fn bench_prove_and_verify(c: &mut Criterion) {
 	}
 }
 
-criterion_group!(benches, bench_prove_and_verify);
+/// Fine-grained benchmarks for the individual phases of the shift-reduction prover, mirroring the
+/// `intmul/phases` breakdown. Each of the five phase functions is timed on its own, sharing one
+/// expensive circuit / witness / key-collection setup.
+fn bench_shift_phases(c: &mut Criterion) {
+	use binius_field::{BinaryField128bGhash, Field, PackedBinaryGhash1x128b, Random};
+	use binius_ip::sumcheck::SumcheckOutput;
+	use binius_math::multilinear::eq::eq_ind_partial_eval;
+	use binius_prover::{
+		fold_word::fold_words,
+		protocols::shift::{
+			PreparedOperatorData,
+			monster::{build_h_parts, build_monster_multilinear},
+			phase_1::{build_g_parts, run_phase_1_sumcheck},
+			phase_2::run_sumcheck,
+		},
+	};
+	use binius_verifier::config::LOG_WORD_SIZE_BITS;
+	use criterion::BatchSize;
+
+	type F = BinaryField128bGhash;
+	type P = PackedBinaryGhash1x128b;
+	let mut rng = rand::rng();
+
+	// A single fixed size (4096-byte SHA256 message), rather than a sweep, so the per-phase benches
+	// share one setup and stay quick.
+	const LOG_MESSAGE_LEN_BYTES: usize = 12;
+
+	let (mut cs, value_vec) = create_sha256_cs_with_witness(LOG_MESSAGE_LEN_BYTES, &mut rng);
+	cs.validate_and_prepare().unwrap();
+
+	let r_x_prime_bitand = (0..strict_log_2(cs.and_constraints.len()).unwrap() as u128)
+		.map(F::new)
+		.collect::<Vec<_>>();
+	// SHA256 has no MUL constraints, so the IntMul operator is the zero claim at an empty point,
+	// matching the real prover (`prove.rs` `None` branch).
+	let r_x_prime_intmul: Vec<F> = Vec::new();
+	// `r_zhat_prime` is shared across the bitand and intmul operators.
+	let r_zhat_prime = F::random(&mut rng);
+	let bitand_evals = [F::random(&mut rng); 3];
+	let intmul_evals = [F::ZERO; 4];
+
+	let key_collection = build_key_collection(&cs);
+	let words = value_vec.combined_witness();
+
+	// Prepare the operator data. Lambda sampling is cheap and not part of any benched phase, so a
+	// random lambda (rather than one drawn from a transcript) yields realistic-magnitude data.
+	let prepared_bitand = PreparedOperatorData::new(
+		OperatorData {
+			evals: bitand_evals.to_vec(),
+			r_zhat_prime,
+			r_x_prime: r_x_prime_bitand,
+		},
+		F::random(&mut rng),
+	);
+	let prepared_intmul = PreparedOperatorData::new(
+		OperatorData {
+			evals: intmul_evals.to_vec(),
+			r_zhat_prime,
+			r_x_prime: r_x_prime_intmul,
+		},
+		F::random(&mut rng),
+	);
+
+	// The phases are sequential and stateful: each consumes the previous one's outputs. Rather than
+	// re-deriving predecessors inside each phase's per-iteration setup, advance the protocol once
+	// here (with a throwaway transcript) to capture each phase's inputs; the setup closures below
+	// then only clone what a phase consumes by value. The specific transcript challenges do not
+	// change the work a phase performs.
+	let g_parts = build_g_parts::<F, P>(words, &key_collection, &prepared_bitand, &prepared_intmul);
+	let h_parts = build_h_parts::<F, P>(prepared_bitand.r_zhat_prime);
+	let SumcheckOutput {
+		challenges: mut r_jr_s,
+		eval: gamma,
+	} = {
+		let mut transcript = ProverTranscript::<StdChallenger>::default();
+		run_phase_1_sumcheck::<F, P, _>(g_parts.clone(), h_parts.clone(), &mut transcript)
+	};
+	// Split phase-1 challenges into `r_j` (low) and `r_s` (high) halves.
+	let r_s = r_jr_s.split_off(LOG_WORD_SIZE_BITS);
+	let r_j = r_jr_s;
+	let r_j_witness = fold_words::<F, P>(words, eq_ind_partial_eval::<F>(&r_j).as_ref());
+	let monster_multilinear = build_monster_multilinear::<F, P>(
+		&key_collection,
+		&prepared_bitand,
+		&prepared_intmul,
+		&r_j,
+		&r_s,
+	);
+
+	let mut group = c.benchmark_group("shift_reduction_phases");
+	group.sample_size(10);
+
+	// Phase 1. `build_g_parts` / `build_h_parts` take their inputs by reference, so no
+	// per-iteration clone is needed; `run_phase_1_sumcheck` consumes `g_parts`/`h_parts` by value.
+	group.bench_function("phase1_build_g_parts", |b| {
+		b.iter(|| {
+			build_g_parts::<F, P>(words, &key_collection, &prepared_bitand, &prepared_intmul)
+		});
+	});
+	group.bench_function("phase1_build_h_parts", |b| {
+		b.iter(|| build_h_parts::<F, P>(prepared_bitand.r_zhat_prime));
+	});
+	group.bench_function("phase1_run_sumcheck", |b| {
+		b.iter_batched(
+			|| (g_parts.clone(), h_parts.clone()),
+			|(g, h)| {
+				let mut transcript = ProverTranscript::<StdChallenger>::default();
+				run_phase_1_sumcheck::<F, P, _>(g, h, &mut transcript)
+			},
+			BatchSize::SmallInput,
+		);
+	});
+
+	// Phase 2. `build_monster_multilinear` takes its inputs by reference; `run_sumcheck` consumes
+	// `r_j_witness`, `monster_multilinear`, and `r_j` by value.
+	group.bench_function("phase2_build_monster_multilinear", |b| {
+		b.iter(|| {
+			build_monster_multilinear::<F, P>(
+				&key_collection,
+				&prepared_bitand,
+				&prepared_intmul,
+				&r_j,
+				&r_s,
+			)
+		});
+	});
+	group.bench_function("phase2_run_sumcheck", |b| {
+		b.iter_batched(
+			|| (r_j_witness.clone(), monster_multilinear.clone(), r_j.clone()),
+			|(r_j_witness, monster_multilinear, r_j)| {
+				let mut transcript = ProverTranscript::<StdChallenger>::default();
+				run_sumcheck::<F, P, _>(
+					r_j_witness,
+					monster_multilinear,
+					r_j,
+					gamma,
+					&mut transcript,
+				)
+			},
+			BatchSize::SmallInput,
+		);
+	});
+
+	group.finish();
+}
+
+criterion_group!(benches, bench_prove_and_verify, bench_shift_phases);
 criterion_main!(benches);

--- a/crates/prover/src/protocols/shift/mod.rs
+++ b/crates/prover/src/protocols/shift/mod.rs
@@ -1,11 +1,18 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 use binius_verifier::protocols::shift::{BITAND_ARITY, INTMUL_ARITY, SHIFT_VARIANT_COUNT};
 
 mod key_collection;
-mod monster;
-mod phase_1;
-mod phase_2;
+// `monster`, `phase_1`, and `phase_2` are internal implementation, exposed (via `#[doc(hidden)]`
+// `pub mod`) only so the `shift_reduction` benchmark can time individual phase functions (see
+// `benches/shift_reduction.rs`). Not a stable API.
+#[doc(hidden)]
+pub mod monster;
+#[doc(hidden)]
+pub mod phase_1;
+#[doc(hidden)]
+pub mod phase_2;
 mod prove;
 
 pub use key_collection::{KeyCollection, build_key_collection};

--- a/crates/prover/src/protocols/shift/monster.rs
+++ b/crates/prover/src/protocols/shift/monster.rs
@@ -1,4 +1,5 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 use std::{iter, ops::Range};
 

--- a/crates/prover/src/protocols/shift/phase_1.rs
+++ b/crates/prover/src/protocols/shift/phase_1.rs
@@ -1,4 +1,5 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 use std::{iter, ops::Range};
 
@@ -78,7 +79,7 @@ where
 ///
 /// `SumcheckOutput` containing the challenge vector and final evaluation `gamma`
 #[instrument(skip_all, name = "run_sumcheck")]
-fn run_phase_1_sumcheck<F: Field, P: PackedField<Scalar = F>, Channel: IPProverChannel<F>>(
+pub fn run_phase_1_sumcheck<F: Field, P: PackedField<Scalar = F>, Channel: IPProverChannel<F>>(
 	g_parts: [FieldBuffer<P>; SHIFT_VARIANT_COUNT],
 	h_parts: [FieldBuffer<P>; SHIFT_VARIANT_COUNT],
 	channel: &mut Channel,
@@ -163,7 +164,7 @@ fn run_phase_1_sumcheck<F: Field, P: PackedField<Scalar = F>, Channel: IPProverC
 /// Used in phase 1 to construct the constant size g multilinears
 /// that will participate in the phase 1 sumcheck protocol.
 #[instrument(skip_all, name = "build_g_parts")]
-fn build_g_parts<F: BinaryField, P: PackedField<Scalar = F>>(
+pub fn build_g_parts<F: BinaryField, P: PackedField<Scalar = F>>(
 	words: &[Word],
 	key_collection: &KeyCollection,
 	bitand_operator_data: &PreparedOperatorData<F>,

--- a/crates/prover/src/protocols/shift/phase_2.rs
+++ b/crates/prover/src/protocols/shift/phase_2.rs
@@ -1,4 +1,5 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 use binius_core::word::Word;
 use binius_field::{AESTowerField8b, BinaryField, Field, PackedField};
@@ -90,7 +91,7 @@ where
 /// # Returns
 /// Returns `SumcheckOutput` with concatenated challenges `[r_j, r_y]` and witness evaluation.
 #[instrument(skip_all, name = "run_sumcheck")]
-fn run_sumcheck<F: Field, P: PackedField<Scalar = F>, Channel: IPProverChannel<F>>(
+pub fn run_sumcheck<F: Field, P: PackedField<Scalar = F>, Channel: IPProverChannel<F>>(
 	r_j_witness: FieldBuffer<P>,
 	monster_multilinear: FieldBuffer<P>,
 	r_j: Vec<F>,


### PR DESCRIPTION
Implements [BINIUS-224](https://linear.app/jimpo/issue/BINIUS-224/fine-grained-benchmarks-for-shift-reduction-proving).

Breaks the `shift_reduction` benchmark down into per-phase benchmarks, mirroring the `intmul/phases` breakdown, timing each of the five shift-reduction prover phase functions individually:

- **phase 1:** `build_g_parts`, `build_h_parts`, `run_phase_1_sumcheck`
- **phase 2:** `build_monster_multilinear`, `run_sumcheck`

## Benchmark structure

New `bench_shift_phases` in `benches/shift_reduction.rs` (added to the `criterion_group!`). The five phases are sequential and stateful, so — as `bench_intmul_phases` does — it builds the expensive circuit / witness / key-collection **once**, runs phase 1 once (throwaway transcript) to capture each phase's inputs (`g_parts`/`h_parts`, and phase 1's `r_j`/`r_s`/`gamma` → `r_j_witness`/`monster_multilinear`), then times each phase in its own `bench_function`, using `iter_batched` to clone only the by-value inputs (`run_phase_1_sumcheck`, `run_sumcheck`) and plain `iter` for the by-reference builders. One fixed size (4096-byte SHA256 message), `sample_size(10)`.

Sample run (`RUSTFLAGS="-C target-cpu=native" cargo bench -p binius-prover --bench shift_reduction`), one machine, indicative only:

| phase | time |
|---|---|
| phase1_build_g_parts | ~5.1 ms |
| phase1_build_h_parts | ~64 µs |
| phase1_run_sumcheck | ~450 µs |
| phase2_build_monster_multilinear | ~1.6 ms |
| phase2_run_sumcheck | ~0.5 ms |

(`build_g_parts` dominates phase 1; `build_monster_multilinear` dominates phase 2.)

## Visibility

To reach the phase functions from an integration bench (which sees only the public API), the `phase_1`/`phase_2`/`monster` modules are made `pub mod` and the exposed functions marked `#[doc(hidden)] pub` — **mirroring exactly the `#[doc(hidden)] pub` mechanism `intmul` already uses** for its phase methods (`protocols/intmul/prove.rs`). `#[doc(hidden)]` keeps them out of the docs and signals "not a stable API."

## Drive-by fix: the existing bench was broken

`bench_prove_and_verify` panicked on run: it computed the IntMul operator's `r_x_prime` via `strict_log_2(cs.mul_constraints.len()).unwrap()`, but SHA256 has **zero** MUL constraints, so `strict_log_2(0)` is `None`. (Benches aren't in CI, so this went unnoticed.) Fixed by synthesizing the IntMul operator as the **zero claim at an empty point** — four zero evals, empty `r_x_prime`, sharing BitAnd's `r_zhat_prime` — exactly as the real prover/verifier do in their `None` branch (`prove.rs` / `verify.rs`). The complete-run `prove`/`verify` benchmarks now run.

## Validation

- `cargo bench -p binius-prover --bench shift_reduction` — all benchmarks run and produce numbers (verified with a short criterion config); the previously-panicking `prove`/`verify` benches now work.
- `cargo clippy -p binius-prover --all-targets -- -D warnings`, nightly `fmt --check`, `typos` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)