### PR TITLE
[field] Remove Shr and Shl parent traits from UnderlierType

### DIFF
--- a/crates/field/src/arch/portable/packed_arithmetic.rs
+++ b/crates/field/src/arch/portable/packed_arithmetic.rs
@@ -1,11 +1,12 @@
 // Copyright 2024-2025 Irreducible Inc.
 
 use crate::underlier::UnderlierType;
+use std::ops::{Shl, Shr};
 
 /// Interleave using the provided even mask slice.
 ///
 /// See [Hacker's Delight](https://dl.acm.org/doi/10.5555/2462741), Section 7-3.
-pub fn interleave_with_mask<U: UnderlierType>(
+pub fn interleave_with_mask<U: UnderlierType + Shr<usize, Output=U> + Shl<usize, Output=U>>(
 	a: U,
 	b: U,
 	log_block_len: usize,

--- a/crates/field/src/underlier/scaled.rs
+++ b/crates/field/src/underlier/scaled.rs
@@ -5,7 +5,7 @@ use std::{
 	array,
 	fmt::{self, LowerHex},
 	mem,
-	ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Not, Shl, Shr},
+	ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Not},
 };
 
 use binius_utils::{
@@ -106,46 +106,6 @@ impl<U: BitXorAssign + Copy, const N: usize> BitXorAssign for ScaledUnderlier<U,
 		for i in 0..N {
 			self.0[i] ^= rhs.0[i];
 		}
-	}
-}
-
-impl<U: UnderlierType, const N: usize> Shr<usize> for ScaledUnderlier<U, N> {
-	type Output = Self;
-
-	fn shr(self, rhs: usize) -> Self::Output {
-		let mut result = Self::default();
-
-		let shift_in_items = rhs / U::BITS;
-		for i in 0..N.saturating_sub(shift_in_items.saturating_sub(1)) {
-			if i + shift_in_items < N {
-				result.0[i] |= self.0[i + shift_in_items] >> (rhs % U::BITS);
-			}
-			if i + shift_in_items + 1 < N && !rhs.is_multiple_of(U::BITS) {
-				result.0[i] |= self.0[i + shift_in_items + 1] << (U::BITS - (rhs % U::BITS));
-			}
-		}
-
-		result
-	}
-}
-
-impl<U: UnderlierType, const N: usize> Shl<usize> for ScaledUnderlier<U, N> {
-	type Output = Self;
-
-	fn shl(self, rhs: usize) -> Self::Output {
-		let mut result = Self::default();
-
-		let shift_in_items = rhs / U::BITS;
-		for i in shift_in_items.saturating_sub(1)..N {
-			if i >= shift_in_items {
-				result.0[i] |= self.0[i - shift_in_items] << (rhs % U::BITS);
-			}
-			if i > shift_in_items && !rhs.is_multiple_of(U::BITS) {
-				result.0[i] |= self.0[i - shift_in_items - 1] >> (U::BITS - (rhs % U::BITS));
-			}
-		}
-
-		result
 	}
 }
 
@@ -335,36 +295,6 @@ impl<U: DeserializeBytes, const N: usize> DeserializeBytes for ScaledUnderlier<U
 #[cfg(test)]
 mod tests {
 	use super::*;
-
-	#[test]
-	fn test_shr() {
-		let val = ScaledUnderlier::<u8, 4>([0, 1, 2, 3]);
-		assert_eq!(
-			val >> 1,
-			ScaledUnderlier::<u8, 4>([0b10000000, 0b00000000, 0b10000001, 0b00000001])
-		);
-		assert_eq!(
-			val >> 2,
-			ScaledUnderlier::<u8, 4>([0b01000000, 0b10000000, 0b11000000, 0b00000000])
-		);
-		assert_eq!(
-			val >> 8,
-			ScaledUnderlier::<u8, 4>([0b00000001, 0b00000010, 0b00000011, 0b00000000])
-		);
-		assert_eq!(
-			val >> 9,
-			ScaledUnderlier::<u8, 4>([0b00000000, 0b10000001, 0b00000001, 0b00000000])
-		);
-	}
-
-	#[test]
-	fn test_shl() {
-		let val = ScaledUnderlier::<u8, 4>([0, 1, 2, 3]);
-		assert_eq!(val << 1, ScaledUnderlier::<u8, 4>([0, 2, 4, 6]));
-		assert_eq!(val << 2, ScaledUnderlier::<u8, 4>([0, 4, 8, 12]));
-		assert_eq!(val << 8, ScaledUnderlier::<u8, 4>([0, 0, 1, 2]));
-		assert_eq!(val << 9, ScaledUnderlier::<u8, 4>([0, 0, 2, 4]));
-	}
 
 	#[test]
 	fn test_interleave_within_element() {

--- a/crates/field/src/underlier/underlier_type.rs
+++ b/crates/field/src/underlier/underlier_type.rs
@@ -3,7 +3,7 @@
 
 use std::{
 	fmt::Debug,
-	ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Not, Shl, Shr},
+	ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Not},
 };
 
 use bytemuck::{NoUninit, TransparentWrapper, Zeroable};
@@ -32,8 +32,6 @@ pub trait UnderlierType:
 	+ BitOrAssign<Self>
 	+ BitXor<Self, Output = Self>
 	+ BitXorAssign<Self>
-	+ Shr<usize, Output = Self>
-	+ Shl<usize, Output = Self>
 	+ Not<Output = Self>
 	+ Divisible<U1>
 {

--- a/crates/field/src/underlier/underlier_with_bit_ops.rs
+++ b/crates/field/src/underlier/underlier_with_bit_ops.rs
@@ -5,10 +5,14 @@
 use super::underlier_type::UnderlierType;
 #[cfg(test)]
 use crate::Divisible;
+#[cfg(test)]
+use std::ops::Shl;
 
 #[cfg(test)]
 #[allow(unused)]
-pub(crate) fn single_element_mask_bits<T: UnderlierType>(bits_count: usize) -> T {
+pub(crate) fn single_element_mask_bits<T: UnderlierType + Shl<usize, Output = T>>(
+	bits_count: usize,
+) -> T {
 	use binius_utils::checked_arithmetics::checked_log_2;
 
 	if bits_count == T::BITS {
@@ -16,7 +20,7 @@ pub(crate) fn single_element_mask_bits<T: UnderlierType>(bits_count: usize) -> T
 	} else {
 		let mut result = T::ONE;
 		for height in 0..checked_log_2(bits_count) {
-			result |= result << (1 << height)
+			result |= result << (1usize << height)
 		}
 
 		result


### PR DESCRIPTION
They're a pain to implement in general and don't fit the abstraction.