### PR TITLE
[field] Remove Shr and Shl parent traits from UnderlierType

### DIFF
--- a/crates/field/src/arch/portable/packed_arithmetic.rs
+++ b/crates/field/src/arch/portable/packed_arithmetic.rs
@@ -1,11 +1,14 @@
 // Copyright 2024-2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
+
+use std::ops::{Shl, Shr};
 
 use crate::underlier::UnderlierType;
 
 /// Interleave using the provided even mask slice.
 ///
 /// See [Hacker's Delight](https://dl.acm.org/doi/10.5555/2462741), Section 7-3.
-pub fn interleave_with_mask<U: UnderlierType>(
+pub fn interleave_with_mask<U: UnderlierType + Shr<usize, Output = U> + Shl<usize, Output = U>>(
 	a: U,
 	b: U,
 	log_block_len: usize,

--- a/crates/field/src/binary_field.rs
+++ b/crates/field/src/binary_field.rs
@@ -293,11 +293,14 @@ macro_rules! impl_field_extension {
 
 			#[inline]
 			fn try_from(elem: $name) -> Result<Self, Self::Error> {
-				use $crate::underlier::NumCast;
+				use $crate::underlier::{Divisible, NumCast, UnderlierType};
 
-				if elem.0 >> $subfield_name::N_BITS
-					== <$typ as $crate::underlier::UnderlierType>::ZERO
-				{
+				// `elem` lies in the subfield iff every subfield-underlier limb above the
+				// least-significant one is zero (equivalent to `elem >> N_BITS == 0`).
+				let in_subfield = Divisible::<$subfield_typ>::ref_iter(&elem.0)
+					.skip(1)
+					.all(|limb| limb == <$subfield_typ as UnderlierType>::ZERO);
+				if in_subfield {
 					Ok($subfield_name(<$subfield_typ>::num_cast_from(elem.val())))
 				} else {
 					Err(())
@@ -384,7 +387,7 @@ macro_rules! impl_field_extension {
 
 			#[inline]
 			fn basis(i: usize) -> Self {
-				use $crate::underlier::UnderlierType;
+				use $crate::underlier::{Divisible, UnderlierType};
 
 				assert!(
 					i < 1 << $log_degree,
@@ -392,7 +395,15 @@ macro_rules! impl_field_extension {
 					i,
 					1 << $log_degree
 				);
-				Self(<$typ>::ONE << (i * $subfield_name::N_BITS))
+				// The `i`-th basis element sets subfield-underlier limb `i` to one, i.e. bit
+				// `i * N_BITS` (equivalent to `ONE << (i * N_BITS)`).
+				let mut underlier = <$typ as UnderlierType>::ZERO;
+				Divisible::<$subfield_typ>::set(
+					&mut underlier,
+					i,
+					<$subfield_typ as UnderlierType>::ONE,
+				);
+				Self(underlier)
 			}
 
 			#[inline]
@@ -400,20 +411,24 @@ macro_rules! impl_field_extension {
 				base_elems: impl IntoIterator<Item = $subfield_name>,
 				log_stride: usize,
 			) -> Self {
-				use $crate::underlier::UnderlierType;
+				use $crate::underlier::{Divisible, UnderlierType};
 
 				debug_assert!($name::N_BITS.is_power_of_two());
 				let shift_step = ($subfield_name::N_BITS << log_stride) & ($name::N_BITS - 1);
-				let mut value = <$typ>::ZERO;
+				let mut underlier = <$typ as UnderlierType>::ZERO;
 				let mut shift = 0;
 
 				for elem in base_elems.into_iter() {
 					assert!(shift < $name::N_BITS, "too many base elements for extension degree");
-					value |= <$typ>::from(elem.val()) << shift;
+					// `shift` is a multiple of the subfield width, so it addresses limb
+					// `shift / N_BITS`; OR the element in (matching the previous `|= .. << shift`).
+					let limb = shift / $subfield_name::N_BITS;
+					let acc = Divisible::<$subfield_typ>::get(&underlier, limb) | elem.val();
+					Divisible::<$subfield_typ>::set(&mut underlier, limb, acc);
 					shift += shift_step;
 				}
 
-				Self(value)
+				Self(underlier)
 			}
 
 			#[inline]

--- a/crates/field/src/underlier/scaled.rs
+++ b/crates/field/src/underlier/scaled.rs
@@ -5,7 +5,7 @@ use std::{
 	array,
 	fmt::{self, LowerHex},
 	mem,
-	ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Not, Shl, Shr},
+	ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Not},
 };
 
 use binius_utils::{
@@ -106,46 +106,6 @@ impl<U: BitXorAssign + Copy, const N: usize> BitXorAssign for ScaledUnderlier<U,
 		for i in 0..N {
 			self.0[i] ^= rhs.0[i];
 		}
-	}
-}
-
-impl<U: UnderlierType, const N: usize> Shr<usize> for ScaledUnderlier<U, N> {
-	type Output = Self;
-
-	fn shr(self, rhs: usize) -> Self::Output {
-		let mut result = Self::default();
-
-		let shift_in_items = rhs / U::BITS;
-		for i in 0..N.saturating_sub(shift_in_items.saturating_sub(1)) {
-			if i + shift_in_items < N {
-				result.0[i] |= self.0[i + shift_in_items] >> (rhs % U::BITS);
-			}
-			if i + shift_in_items + 1 < N && !rhs.is_multiple_of(U::BITS) {
-				result.0[i] |= self.0[i + shift_in_items + 1] << (U::BITS - (rhs % U::BITS));
-			}
-		}
-
-		result
-	}
-}
-
-impl<U: UnderlierType, const N: usize> Shl<usize> for ScaledUnderlier<U, N> {
-	type Output = Self;
-
-	fn shl(self, rhs: usize) -> Self::Output {
-		let mut result = Self::default();
-
-		let shift_in_items = rhs / U::BITS;
-		for i in shift_in_items.saturating_sub(1)..N {
-			if i >= shift_in_items {
-				result.0[i] |= self.0[i - shift_in_items] << (rhs % U::BITS);
-			}
-			if i > shift_in_items && !rhs.is_multiple_of(U::BITS) {
-				result.0[i] |= self.0[i - shift_in_items - 1] >> (U::BITS - (rhs % U::BITS));
-			}
-		}
-
-		result
 	}
 }
 
@@ -335,36 +295,6 @@ impl<U: DeserializeBytes, const N: usize> DeserializeBytes for ScaledUnderlier<U
 #[cfg(test)]
 mod tests {
 	use super::*;
-
-	#[test]
-	fn test_shr() {
-		let val = ScaledUnderlier::<u8, 4>([0, 1, 2, 3]);
-		assert_eq!(
-			val >> 1,
-			ScaledUnderlier::<u8, 4>([0b10000000, 0b00000000, 0b10000001, 0b00000001])
-		);
-		assert_eq!(
-			val >> 2,
-			ScaledUnderlier::<u8, 4>([0b01000000, 0b10000000, 0b11000000, 0b00000000])
-		);
-		assert_eq!(
-			val >> 8,
-			ScaledUnderlier::<u8, 4>([0b00000001, 0b00000010, 0b00000011, 0b00000000])
-		);
-		assert_eq!(
-			val >> 9,
-			ScaledUnderlier::<u8, 4>([0b00000000, 0b10000001, 0b00000001, 0b00000000])
-		);
-	}
-
-	#[test]
-	fn test_shl() {
-		let val = ScaledUnderlier::<u8, 4>([0, 1, 2, 3]);
-		assert_eq!(val << 1, ScaledUnderlier::<u8, 4>([0, 2, 4, 6]));
-		assert_eq!(val << 2, ScaledUnderlier::<u8, 4>([0, 4, 8, 12]));
-		assert_eq!(val << 8, ScaledUnderlier::<u8, 4>([0, 0, 1, 2]));
-		assert_eq!(val << 9, ScaledUnderlier::<u8, 4>([0, 0, 2, 4]));
-	}
 
 	#[test]
 	fn test_interleave_within_element() {

--- a/crates/field/src/underlier/underlier_type.rs
+++ b/crates/field/src/underlier/underlier_type.rs
@@ -3,7 +3,7 @@
 
 use std::{
 	fmt::Debug,
-	ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Not, Shl, Shr},
+	ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Not},
 };
 
 use bytemuck::{NoUninit, TransparentWrapper, Zeroable};
@@ -32,8 +32,6 @@ pub trait UnderlierType:
 	+ BitOrAssign<Self>
 	+ BitXor<Self, Output = Self>
 	+ BitXorAssign<Self>
-	+ Shr<usize, Output = Self>
-	+ Shl<usize, Output = Self>
 	+ Not<Output = Self>
 	+ Divisible<U1>
 {

--- a/crates/field/src/underlier/underlier_with_bit_ops.rs
+++ b/crates/field/src/underlier/underlier_with_bit_ops.rs
@@ -2,13 +2,18 @@
 // Copyright 2026 The Binius Developers
 
 #[cfg(test)]
+use std::ops::Shl;
+
+#[cfg(test)]
 use super::underlier_type::UnderlierType;
 #[cfg(test)]
 use crate::Divisible;
 
 #[cfg(test)]
 #[allow(unused)]
-pub(crate) fn single_element_mask_bits<T: UnderlierType>(bits_count: usize) -> T {
+pub(crate) fn single_element_mask_bits<T: UnderlierType + Shl<usize, Output = T>>(
+	bits_count: usize,
+) -> T {
 	use binius_utils::checked_arithmetics::checked_log_2;
 
 	if bits_count == T::BITS {
@@ -16,7 +21,7 @@ pub(crate) fn single_element_mask_bits<T: UnderlierType>(bits_count: usize) -> T
 	} else {
 		let mut result = T::ONE;
 		for height in 0..checked_log_2(bits_count) {
-			result |= result << (1 << height)
+			result |= result << (1usize << height)
 		}
 
 		result


### PR DESCRIPTION
Closes BINIUS-225. Completes and supersedes #1705 (jimpo's starting point is folded in here, with a `Co-authored-by` trailer — #1705 can be closed).

`Shr<usize>` / `Shl<usize>` were supertraits of `UnderlierType`, forcing every underlier to implement general bit shifts. They're a pain to implement for composite underliers (`ScaledUnderlier`) and don't fit the abstraction, so this drops them and removes `ScaledUnderlier`'s hand-written shift impls (and their tests).

## Changes

- **`UnderlierType`**: remove the `Shr<usize>` / `Shl<usize>` supertraits.
- **`ScaledUnderlier`**: remove the `Shl`/`Shr` impls + tests.
- **Explicit bounds where shifts are genuinely needed**: `interleave_with_mask` and the test-only `single_element_mask_bits` now bound on `Shr`/`Shl` directly.
- **`impl_field_extension!` macro** (the part that was missing from #1705): its three shift sites — `TryFrom`, `basis`, and `from_bases_sparse` — shifted the *extension* underlier by multiples of the subfield width. That breaks for `ScaledUnderlier`-backed fields like `GhashSq256b` on targets without native 256-bit SIMD (portable / wasm). Rewrote them as subfield-lane accesses via `Divisible<subfield underlier>` — the **same** abstraction the macro already uses for `iter_bases` / `get_base_unchecked` — so they no longer require `Shl`/`Shr` on the underlier.

## Verification

- Native build + `cargo test -p binius-field` (217 passed).
- **Portable** (`M256 = ScaledUnderlier<M128, 2>`) `cargo test -p binius-field` (199 passed) — exercises the rewritten `GhashSq256b` `basis` / `from_bases_sparse` / `TryFrom` paths that were broken.
- Cross-compile `cargo check` for `aarch64` (`+neon,+aes`), `x86_64` (`+avx2,+vpclmulqdq`), and `wasm32` — all green (wasm was the target that surfaced the breakage).
- Workspace clippy (`--all --tests --benches --examples -D warnings`) and nightly fmt.

## Note for review

`basis` / `from_bases_sparse` now do `Divisible` lane get/set instead of a raw `<< shift`. This matches the macro's existing `iter_bases`/`get_base_unchecked` idiom and these aren't inner-multiply-loop paths, so I judged it behavior- and perf-neutral — flagging in case you'd rather keep an explicit-shift fast path for the primitive-underlier fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)