### PR TITLE
BINIUS-145: split KeyCollection into public and non-public segments

### DIFF
--- a/crates/core/src/constraint_system/layout.rs
+++ b/crates/core/src/constraint_system/layout.rs
@@ -1,4 +1,5 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 use binius_utils::serialization::{DeserializeBytes, SerializationError, SerializeBytes};
 use bytes::{Buf, BufMut};
 
@@ -51,6 +52,25 @@ impl ValueVecLayout {
 		}
 
 		Ok(())
+	}
+
+	/// Returns the number of words in the public segment: the constants and inout values,
+	/// including padding up to the power-of-two segment length.
+	pub const fn n_public_words(&self) -> usize {
+		self.offset_witness
+	}
+
+	/// Returns the base-2 logarithm of the public segment length in words.
+	///
+	/// [`Self::validate`] guarantees that the public segment length is a power of two.
+	pub const fn log_public_words(&self) -> usize {
+		self.offset_witness.trailing_zeros() as usize
+	}
+
+	/// Returns the number of non-public words: the witness and internal values, including
+	/// padding up to `committed_total_len`.
+	pub const fn n_non_public_words(&self) -> usize {
+		self.committed_total_len - self.offset_witness
 	}
 
 	/// Returns true if the given index points to an area that is considered to be padding.

--- a/crates/prover/src/protocols/shift/key_collection.rs
+++ b/crates/prover/src/protocols/shift/key_collection.rs
@@ -1,4 +1,5 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 use std::{iter, mem, ops::Range};
 
@@ -168,30 +169,64 @@ impl Key {
 	}
 }
 
-/// A collection of keys that organizes the prover's view of the constraint system.
+/// The keys for the words of one segment of the value vector.
 ///
-/// The prover operates in both phases by iterating through `key_ranges` (one range per witness
-/// word), then accessing the corresponding keys in the `keys` vector. Each key contains a range
-/// that indexes into `constraint_indices` to identify which constraints involve that
+/// The prover operates in both phases by iterating through `key_ranges` (one range per word of
+/// the segment), then accessing the corresponding keys in the `keys` vector. Each key contains a
+/// range that indexes into `constraint_indices` to identify which constraints involve that
 /// particular shifted operand.
 ///
 /// # Structure
 ///
-/// - **keys**: All keys flattened into a single vector
-/// - **key_ranges**: For every word there is a range of keys within the `keys` vector
+/// - **keys**: All keys of the segment flattened into a single vector
+/// - **key_ranges**: For every word of the segment there is a range of keys within the `keys`
+///   vector
 /// - **constraint_indices**: Flattened list of constraint indices referenced by the keys
 ///
 /// # Organization
 ///
-/// Keys are organized by word index for efficient batch processing. For word `w`,
-/// `key_ranges[w]` gives the range of keys in the `keys` vector that correspond to that word.
-/// Each key's range field then points into `constraint_indices` to specify which constraints
-/// involve that particular shifted operand.
+/// Keys are organized by word index for efficient batch processing. For the word at index `w`
+/// *within the segment*, `key_ranges[w]` gives the range of keys in the `keys` vector that
+/// correspond to that word. Each key's range field then points into `constraint_indices` to
+/// specify which constraints involve that particular shifted operand.
 #[derive(Debug, Clone)]
-pub struct KeyCollection {
+pub struct KeySegment {
 	pub keys: Vec<Key>,
 	pub key_ranges: Vec<Range<u32>>,
 	pub constraint_indices: Vec<ConstraintIndex>,
+}
+
+impl KeySegment {
+	/// The number of words the segment covers.
+	pub const fn n_words(&self) -> usize {
+		self.key_ranges.len()
+	}
+
+	/// The keys for the word at the given segment-relative index.
+	pub fn word_keys(&self, index: usize) -> &[Key] {
+		let Range { start, end } = self.key_ranges[index];
+		&self.keys[start as usize..end as usize]
+	}
+}
+
+/// A collection of keys that organizes the prover's view of the constraint system.
+///
+/// The keys are split by value-vector segment: one [`KeySegment`] for the public words
+/// (value-vector indices `[0, n_public_words)`) and one for the non-public committed words
+/// (indices `[n_public_words, committed_total_len)`). Word indices within each segment are
+/// segment-relative. The split prepares for committing the two segments separately
+/// (BINIUS-145); the phases still iterate both segments in absolute value-vector order.
+#[derive(Debug, Clone)]
+pub struct KeyCollection {
+	pub public: KeySegment,
+	pub non_public: KeySegment,
+}
+
+impl KeyCollection {
+	/// The total number of words covered by both segments.
+	pub const fn n_words(&self) -> usize {
+		self.public.n_words() + self.non_public.n_words()
+	}
 }
 
 /// A `BuilderKey` is a key that is being built up during `KeyCollection`
@@ -303,7 +338,17 @@ pub fn build_key_collection(cs: &ConstraintSystem) -> KeyCollection {
 			);
 		});
 
-	// Compute all three fields of the key collection from the builder keys lists
+	// Split the builder keys lists at the public segment boundary and build one `KeySegment`
+	// per half.
+	let non_public_lists = builder_key_lists.split_off(cs.value_vec_layout.n_public_words());
+	KeyCollection {
+		public: build_key_segment(builder_key_lists),
+		non_public: build_key_segment(non_public_lists),
+	}
+}
+
+/// Computes all three fields of a [`KeySegment`] from the builder keys lists of its words.
+fn build_key_segment(builder_key_lists: Vec<Vec<BuilderKey>>) -> KeySegment {
 	let key_ranges = builder_key_lists
 		.iter()
 		.scan(0u32, |offset, builder_keys| {
@@ -336,7 +381,7 @@ pub fn build_key_collection(cs: &ConstraintSystem) -> KeyCollection {
 		});
 	}
 
-	KeyCollection {
+	KeySegment {
 		keys,
 		key_ranges,
 		constraint_indices,
@@ -410,12 +455,8 @@ impl DeserializeBytes for ConstraintIndex {
 	}
 }
 
-impl SerializeBytes for KeyCollection {
+impl SerializeBytes for KeySegment {
 	fn serialize(&self, mut write_buf: impl BufMut) -> Result<(), SerializationError> {
-		// Version for forward compatibility
-		const VERSION: u32 = 1;
-		VERSION.serialize(&mut write_buf)?;
-
 		self.keys.serialize(&mut write_buf)?;
 
 		// Serialize key_ranges as pairs of start/end
@@ -429,16 +470,8 @@ impl SerializeBytes for KeyCollection {
 	}
 }
 
-impl DeserializeBytes for KeyCollection {
+impl DeserializeBytes for KeySegment {
 	fn deserialize(mut read_buf: impl Buf) -> Result<Self, SerializationError> {
-		const VERSION: u32 = 1;
-		let version = u32::deserialize(&mut read_buf)?;
-		if version != VERSION {
-			return Err(SerializationError::InvalidConstruction {
-				name: "KeyCollection::version",
-			});
-		}
-
 		let keys = Vec::<Key>::deserialize(&mut read_buf)?;
 
 		// Deserialize key_ranges
@@ -452,11 +485,39 @@ impl DeserializeBytes for KeyCollection {
 
 		let constraint_indices = Vec::<ConstraintIndex>::deserialize(&mut read_buf)?;
 
-		Ok(KeyCollection {
+		Ok(KeySegment {
 			keys,
 			key_ranges,
 			constraint_indices,
 		})
+	}
+}
+
+impl SerializeBytes for KeyCollection {
+	fn serialize(&self, mut write_buf: impl BufMut) -> Result<(), SerializationError> {
+		// Version for forward compatibility; version 2 introduced the public/non-public split.
+		const VERSION: u32 = 2;
+		VERSION.serialize(&mut write_buf)?;
+
+		self.public.serialize(&mut write_buf)?;
+		self.non_public.serialize(write_buf)
+	}
+}
+
+impl DeserializeBytes for KeyCollection {
+	fn deserialize(mut read_buf: impl Buf) -> Result<Self, SerializationError> {
+		const VERSION: u32 = 2;
+		let version = u32::deserialize(&mut read_buf)?;
+		if version != VERSION {
+			return Err(SerializationError::InvalidConstruction {
+				name: "KeyCollection::version",
+			});
+		}
+
+		let public = KeySegment::deserialize(&mut read_buf)?;
+		let non_public = KeySegment::deserialize(read_buf)?;
+
+		Ok(KeyCollection { public, non_public })
 	}
 }
 

--- a/crates/prover/src/protocols/shift/mod.rs
+++ b/crates/prover/src/protocols/shift/mod.rs
@@ -15,5 +15,5 @@ pub mod phase_1;
 pub mod phase_2;
 mod prove;
 
-pub use key_collection::{KeyCollection, build_key_collection};
+pub use key_collection::{KeyCollection, KeySegment, build_key_collection};
 pub use prove::{OperatorData, PreparedOperatorData, prove};

--- a/crates/prover/src/protocols/shift/monster.rs
+++ b/crates/prover/src/protocols/shift/monster.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-use std::{iter, ops::Range};
+use std::iter;
 
 use binius_field::{AESTowerField8b, BinaryField, Field, PackedField};
 use binius_math::{
@@ -17,7 +17,7 @@ use tracing::instrument;
 
 use super::{
 	SHIFT_VARIANT_COUNT,
-	key_collection::{KeyCollection, Operation},
+	key_collection::{KeyCollection, KeySegment, Operation},
 	prove::PreparedOperatorData,
 };
 
@@ -187,32 +187,45 @@ where
 		&intmul_h_ops,
 	);
 
-	let n_words = key_collection.key_ranges.len();
+	let n_words = key_collection.n_words();
 	let log_len = log2_ceil_usize(n_words).max(LOG_WORDS_PER_ELEM);
 	let capacity = 1 << log_len.saturating_sub(P::LOG_WIDTH);
 
-	let mut monster_multilinear = Vec::<P>::with_capacity(capacity);
-	key_collection
-		.key_ranges
-		.par_chunks(P::WIDTH)
-		.map(|chunk| {
-			P::from_scalars(chunk.iter().map(|&Range { start, end }| {
-				key_collection.keys[start as usize..end as usize]
-					.iter()
-					.map(|key| {
-						let (operator_data, scalars) = match key.operation {
-							Operation::BitwiseAnd => (bitand_operator_data, &bitand_scalars),
-							Operation::IntegerMul => (intmul_operator_data, &intmul_scalars),
-						};
-						key.accumulate_by_operand(&key_collection.constraint_indices, operator_data)
-							.map(|(operand_index, acc)| {
-								let index = key.id as usize
-									+ operand_index * SHIFT_VARIANT_COUNT * WORD_SIZE_BITS;
-								acc * scalars[index]
-							})
-							.sum::<F>()
+	// The scalar for one word of a segment: the accumulated contribution of all its keys.
+	let word_scalar = |segment: &KeySegment, index: usize| {
+		segment
+			.word_keys(index)
+			.iter()
+			.map(|key| {
+				let (operator_data, scalars) = match key.operation {
+					Operation::BitwiseAnd => (bitand_operator_data, &bitand_scalars),
+					Operation::IntegerMul => (intmul_operator_data, &intmul_scalars),
+				};
+				key.accumulate_by_operand(&segment.constraint_indices, operator_data)
+					.map(|(operand_index, acc)| {
+						let index =
+							key.id as usize + operand_index * SHIFT_VARIANT_COUNT * WORD_SIZE_BITS;
+						acc * scalars[index]
 					})
-					.sum()
+					.sum::<F>()
+			})
+			.sum::<F>()
+	};
+
+	// The multilinear is indexed by absolute word index: the public segment words followed by
+	// the non-public segment words.
+	let n_public_words = key_collection.public.n_words();
+	let mut monster_multilinear = Vec::<P>::with_capacity(capacity);
+	(0..n_words.div_ceil(P::WIDTH))
+		.into_par_iter()
+		.map(|chunk_index| {
+			let start = chunk_index * P::WIDTH;
+			P::from_scalars((start..(start + P::WIDTH).min(n_words)).map(|word_index| {
+				if word_index < n_public_words {
+					word_scalar(&key_collection.public, word_index)
+				} else {
+					word_scalar(&key_collection.non_public, word_index - n_public_words)
+				}
 			}))
 		})
 		.collect_into_vec(&mut monster_multilinear);

--- a/crates/prover/src/protocols/shift/phase_1.rs
+++ b/crates/prover/src/protocols/shift/phase_1.rs
@@ -185,13 +185,24 @@ pub fn build_g_parts<F: BinaryField, P: PackedField<Scalar = F>>(
 	// A mask for low `P::WIDTH` bits.
 	let low_bits_mask = (1u8 << P::WIDTH) - 1;
 
-	let multilinears = words
+	// Process the public and non-public segments in absolute value-vector order: the public
+	// words are the prefix of `words`, and each segment's key ranges are segment-relative.
+	let (public_words, non_public_words) = words.split_at(key_collection.public.n_words());
+	let public_iter = public_words
 		.par_iter()
-		.zip(key_collection.key_ranges.par_iter())
+		.zip(key_collection.public.key_ranges.par_iter())
+		.map(|(word, range)| (word, range, &key_collection.public));
+	let non_public_iter = non_public_words
+		.par_iter()
+		.zip(key_collection.non_public.key_ranges.par_iter())
+		.map(|(word, range)| (word, range, &key_collection.non_public));
+
+	let multilinears = public_iter
+		.chain(non_public_iter)
 		.fold(
 			|| zeroed_vec::<P>(acc_size).into_boxed_slice(),
-			|mut multilinears, (word, Range { start, end })| {
-				let keys = &key_collection.keys[*start as usize..*end as usize];
+			|mut multilinears, (word, Range { start, end }, segment)| {
+				let keys = &segment.keys[*start as usize..*end as usize];
 
 				for key in keys {
 					let operator_data = match key.operation {
@@ -199,7 +210,7 @@ pub fn build_g_parts<F: BinaryField, P: PackedField<Scalar = F>>(
 						Operation::IntegerMul => intmul_operator_data,
 					};
 
-					let acc = key.accumulate(&key_collection.constraint_indices, operator_data);
+					let acc = key.accumulate(&segment.constraint_indices, operator_data);
 					let acc_packed = P::broadcast(acc);
 
 					// The following loop is an optimized version of the following

--- a/crates/verifier/src/verify.rs
+++ b/crates/verifier/src/verify.rs
@@ -331,11 +331,9 @@ where
 	) -> Result<Self, Error> {
 		constraint_system.validate_and_prepare()?;
 
-		// Use offset_witness which is guaranteed to be power of two and be at least one full
+		// The validated layout guarantees a power-of-two public segment of at least one full
 		// element.
-		let n_public = constraint_system.value_vec_layout.offset_witness;
-		let log_public_words = log2_ceil_usize(n_public);
-		assert!(n_public.is_power_of_two());
+		let log_public_words = constraint_system.value_vec_layout.log_public_words();
 		assert!(log_public_words >= LOG_WORDS_PER_ELEM);
 
 		let iop_verifier = IOPVerifier::new(constraint_system, log_public_words);

--- a/crates/verifier/src/zk_config.rs
+++ b/crates/verifier/src/zk_config.rs
@@ -34,10 +34,7 @@ use binius_spartan_verifier::{
 	wrapper::{IronSpartanBuilderChannel, ZKWrappedVerifierChannel},
 };
 use binius_transcript::{VerifierTranscript, fiat_shamir::Challenger};
-use binius_utils::{
-	DeserializeBytes, SerializeBytes, checked_arithmetics::log2_ceil_usize,
-	serialization::SerializationError,
-};
+use binius_utils::{DeserializeBytes, SerializeBytes, serialization::SerializationError};
 use bytes::{Buf, BufMut};
 use digest::Output;
 
@@ -74,9 +71,9 @@ where
 
 		constraint_system.validate_and_prepare()?;
 
-		let n_public = constraint_system.value_vec_layout.offset_witness;
-		let log_public_words = log2_ceil_usize(n_public);
-		assert!(n_public.is_power_of_two());
+		// The validated layout guarantees a power-of-two public segment of at least one full
+		// element.
+		let log_public_words = constraint_system.value_vec_layout.log_public_words();
 		assert!(log_public_words >= LOG_WORDS_PER_ELEM);
 
 		let inner_iop_verifier = IOPVerifier::new(constraint_system, log_public_words);


### PR DESCRIPTION
Mechanical prep for splitting the public segment out of the committed trace ([BINIUS-145](https://linear.app/jimpo/issue/BINIUS-145/handling-constants), PR 1 of the sequence in the [plan](https://linear.app/jimpo/issue/BINIUS-145/handling-constants#comment-c759bc33)). Proofs are byte-identical: verified by comparing serialized transcripts (plain and ZK, fixed seeds) for the SHA-256 test circuit before and after the change.

**Commit 1 — segment word-count accessors on `ValueVecLayout`.** Adds `n_public_words` / `log_public_words` / `n_non_public_words` and replaces the hand-rolled `log2_ceil(offset_witness)` derivations in `Verifier::setup` and `ZKVerifier::setup`. (The virtual-address index translation lands with PR 2, where it is first used.)

**Commit 2 — `KeyCollection` becomes two `KeySegment`s.** One segment for the public words, one for the non-public committed words, each self-contained (`keys` / `key_ranges` / `constraint_indices`, segment-relative indices). The phases still iterate both segments in absolute value-vector order: `build_g_parts` chains the two per-segment zips into one fold, and `build_monster_multilinear` maps chunk indices over the concatenated word range so the packing is unchanged at every position. `KeyCollection` serialization version bumps to 2. Naming follows `ValueVec::public()` / `non_public()` rather than "committed", which would collide with `committed_total_len` still including the public prefix until the PR 3 layout reshape.

Both commits build and pass tests and clippy independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)