### PR TITLE
BINIUS-145: commit only the hidden segment, splitting the witness claim

### DIFF
--- a/crates/core/src/constraint_system/layout.rs
+++ b/crates/core/src/constraint_system/layout.rs
@@ -1,6 +1,9 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
-use binius_utils::serialization::{DeserializeBytes, SerializationError, SerializeBytes};
+use binius_utils::{
+	checked_arithmetics::log2_ceil_usize,
+	serialization::{DeserializeBytes, SerializationError, SerializeBytes},
+};
 use bytes::{Buf, BufMut};
 
 use super::ValueIndex;
@@ -41,6 +44,8 @@ impl ValueVecLayout {
 	///
 	/// - the public segment (constants and inout values) is padded to the power of two.
 	/// - the public segment is not less than the minimum size.
+	/// - the hidden segment is at least as long as the public segment, so
+	///   [`Self::log_witness_words`] is at least [`Self::log_public_words`].
 	pub const fn validate(&self) -> Result<(), ConstraintSystemError> {
 		if !self.offset_witness.is_power_of_two() {
 			return Err(ConstraintSystemError::PublicInputPowerOfTwo);
@@ -49,6 +54,13 @@ impl ValueVecLayout {
 		let pub_input_size = self.offset_witness;
 		if pub_input_size < consts::MIN_WORDS_PER_SEGMENT {
 			return Err(ConstraintSystemError::PublicInputTooShort { pub_input_size });
+		}
+
+		if self.n_hidden_words() < self.n_public_words() {
+			return Err(ConstraintSystemError::HiddenSegmentTooShort {
+				public_len: self.n_public_words(),
+				hidden_len: self.n_hidden_words(),
+			});
 		}
 
 		Ok(())
@@ -67,10 +79,18 @@ impl ValueVecLayout {
 		self.offset_witness.trailing_zeros() as usize
 	}
 
-	/// Returns the number of non-public words: the witness and internal values, including
-	/// padding up to `committed_total_len`.
-	pub const fn n_non_public_words(&self) -> usize {
+	/// Returns the number of words in the hidden segment: the witness and internal values,
+	/// including padding up to `committed_total_len`.
+	pub const fn n_hidden_words(&self) -> usize {
 		self.committed_total_len - self.offset_witness
+	}
+
+	/// Returns the base-2 logarithm of the hidden segment length in words, rounded up to a
+	/// power of two.
+	///
+	/// [`Self::validate`] guarantees this is at least [`Self::log_public_words`].
+	pub const fn log_witness_words(&self) -> usize {
+		log2_ceil_usize(self.n_hidden_words())
 	}
 
 	/// Returns true if the given index points to an area that is considered to be padding.
@@ -165,6 +185,43 @@ mod tests {
 
 		let deserialized = ValueVecLayout::deserialize(&mut buf.as_slice()).unwrap();
 		assert_eq!(layout, deserialized);
+	}
+
+	#[test]
+	fn test_log_witness_words() {
+		let layout = |offset_witness: usize, committed_total_len: usize| ValueVecLayout {
+			n_const: 0,
+			n_inout: 0,
+			n_witness: 0,
+			n_internal: 0,
+			offset_inout: 0,
+			offset_witness,
+			committed_total_len,
+			n_scratch: 0,
+		};
+		// Typical: more witness words than public words.
+		assert_eq!(layout(4, 68).log_witness_words(), 6);
+		// Exact power-of-two witness count.
+		assert_eq!(layout(4, 36).log_witness_words(), 5);
+	}
+
+	#[test]
+	fn test_validate_rejects_short_hidden_segment() {
+		// The hidden segment (4 words) is shorter than the public segment (16 words).
+		let layout = ValueVecLayout {
+			n_const: 1,
+			n_inout: 8,
+			n_witness: 4,
+			n_internal: 0,
+			offset_inout: 1,
+			offset_witness: 16,
+			committed_total_len: 20,
+			n_scratch: 0,
+		};
+		assert!(matches!(
+			layout.validate(),
+			Err(ConstraintSystemError::HiddenSegmentTooShort { .. })
+		));
 	}
 
 	#[test]

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -13,6 +13,13 @@ pub enum ConstraintSystemError {
 		"the public input segment must be at least {MIN_WORDS_PER_SEGMENT} words, got: {pub_input_size}"
 	)]
 	PublicInputTooShort { pub_input_size: usize },
+	#[error(
+		"the hidden segment must be at least as long as the public segment (public: {public_len}, hidden: {hidden_len})"
+	)]
+	HiddenSegmentTooShort {
+		public_len: usize,
+		hidden_len: usize,
+	},
 	#[error("the data length doesn't match layout. Expected: {expected}, Actual: {actual}")]
 	ValueVecLenMismatch { expected: usize, actual: usize },
 	#[error(

--- a/crates/frontend/src/compiler/value_vec_alloc.rs
+++ b/crates/frontend/src/compiler/value_vec_alloc.rs
@@ -105,6 +105,10 @@ impl Alloc {
 			cur_index += 1;
 		}
 
+		// Pad the hidden segment to at least the public segment length, so
+		// `log_witness_words >= log_public_words` (see `ValueVecLayout::validate`).
+		cur_index = cur_index.max(2 * offset_witness as u32);
+
 		let committed_total_len = cur_index as usize;
 
 		for wire in self.w_scratch {
@@ -219,14 +223,9 @@ mod tests {
 		assert_eq!(assignment.value_vec_layout.n_internal, 1);
 		assert_eq!(assignment.value_vec_layout.offset_inout, 3);
 		assert_eq!(assignment.value_vec_layout.offset_witness, witness1_idx.0 as usize);
-		// The committed length is exactly the public section (padded) plus the witness and
-		// internal values.
-		assert_eq!(
-			assignment.value_vec_layout.committed_total_len,
-			assignment.value_vec_layout.offset_witness
-				+ assignment.value_vec_layout.n_witness
-				+ assignment.value_vec_layout.n_internal
-		);
+		// The committed length is the public section (8 words after padding) plus the witness
+		// segment, itself padded from 4 up to the public segment length.
+		assert_eq!(assignment.value_vec_layout.committed_total_len, 16);
 	}
 
 	#[test]

--- a/crates/prover/benches/shift_reduction.rs
+++ b/crates/prover/benches/shift_reduction.rs
@@ -172,7 +172,7 @@ fn bench_shift_phases(c: &mut Criterion) {
 			PreparedOperatorData,
 			monster::{build_h_parts, build_monster_multilinear},
 			phase_1::{build_g_parts, run_phase_1_sumcheck},
-			phase_2::run_sumcheck,
+			phase_2::{assemble_witness, run_sumcheck},
 		},
 	};
 	use binius_verifier::config::LOG_WORD_SIZE_BITS;
@@ -239,7 +239,12 @@ fn bench_shift_phases(c: &mut Criterion) {
 	// Split phase-1 challenges into `r_j` (low) and `r_s` (high) halves.
 	let r_s = r_jr_s.split_off(LOG_WORD_SIZE_BITS);
 	let r_j = r_jr_s;
-	let r_j_witness = fold_words::<F, P>(words, eq_ind_partial_eval::<F>(&r_j).as_ref());
+	let r_j_tensor = eq_ind_partial_eval::<F>(&r_j);
+	let (public_words, hidden_words) = words.split_at(key_collection.public.n_words());
+	let public_folded = fold_words::<F, P>(public_words, r_j_tensor.as_ref());
+	let hidden_folded = fold_words::<F, P>(hidden_words, r_j_tensor.as_ref());
+	let witness_folded =
+		assemble_witness(&public_folded, &hidden_folded, key_collection.log_witness_words());
 	let monster_multilinear = build_monster_multilinear::<F, P>(
 		&key_collection,
 		&prepared_bitand,
@@ -287,11 +292,12 @@ fn bench_shift_phases(c: &mut Criterion) {
 	});
 	group.bench_function("phase2_run_sumcheck", |b| {
 		b.iter_batched(
-			|| (r_j_witness.clone(), monster_multilinear.clone(), r_j.clone()),
-			|(r_j_witness, monster_multilinear, r_j)| {
+			|| (witness_folded.clone(), monster_multilinear.clone(), r_j.clone()),
+			|(witness_folded, monster_multilinear, r_j)| {
 				let mut transcript = ProverTranscript::<StdChallenger>::default();
 				run_sumcheck::<F, P, _>(
-					r_j_witness,
+					witness_folded,
+					public_words,
 					monster_multilinear,
 					r_j,
 					gamma,

--- a/crates/prover/src/protocols/shift/key_collection.rs
+++ b/crates/prover/src/protocols/shift/key_collection.rs
@@ -11,7 +11,10 @@ use binius_core::{
 	consts::LOG_WORD_SIZE_BITS,
 };
 use binius_field::Field;
-use binius_utils::serialization::{DeserializeBytes, SerializationError, SerializeBytes};
+use binius_utils::{
+	checked_arithmetics::log2_ceil_usize,
+	serialization::{DeserializeBytes, SerializationError, SerializeBytes},
+};
 use bytes::{Buf, BufMut};
 
 use super::{BITAND_ARITY, INTMUL_ARITY, PreparedOperatorData};
@@ -212,20 +215,30 @@ impl KeySegment {
 /// A collection of keys that organizes the prover's view of the constraint system.
 ///
 /// The keys are split by value-vector segment: one [`KeySegment`] for the public words
-/// (value-vector indices `[0, n_public_words)`) and one for the non-public committed words
-/// (indices `[n_public_words, committed_total_len)`). Word indices within each segment are
-/// segment-relative. The split prepares for committing the two segments separately
-/// (BINIUS-145); the phases still iterate both segments in absolute value-vector order.
+/// (value-vector indices `[0, n_public_words)`) and one for the hidden words (indices
+/// `[n_public_words, committed_total_len)`). Word indices within each segment are
+/// segment-relative. The phases iterate both segments in absolute value-vector order.
 #[derive(Debug, Clone)]
 pub struct KeyCollection {
 	pub public: KeySegment,
-	pub non_public: KeySegment,
+	pub hidden: KeySegment,
 }
 
 impl KeyCollection {
 	/// The total number of words covered by both segments.
 	pub const fn n_words(&self) -> usize {
-		self.public.n_words() + self.non_public.n_words()
+		self.public.n_words() + self.hidden.n_words()
+	}
+
+	/// The base-2 logarithm of the hidden segment length in words, rounded up to a power of
+	/// two.
+	///
+	/// Matches [`ValueVecLayout::log_witness_words`] for the layout the collection was built
+	/// from; the layout guarantees this is at least the public segment's logarithm.
+	///
+	/// [`ValueVecLayout::log_witness_words`]: binius_core::constraint_system::ValueVecLayout::log_witness_words
+	pub const fn log_witness_words(&self) -> usize {
+		log2_ceil_usize(self.hidden.n_words())
 	}
 }
 
@@ -340,10 +353,10 @@ pub fn build_key_collection(cs: &ConstraintSystem) -> KeyCollection {
 
 	// Split the builder keys lists at the public segment boundary and build one `KeySegment`
 	// per half.
-	let non_public_lists = builder_key_lists.split_off(cs.value_vec_layout.n_public_words());
+	let hidden_lists = builder_key_lists.split_off(cs.value_vec_layout.n_public_words());
 	KeyCollection {
 		public: build_key_segment(builder_key_lists),
-		non_public: build_key_segment(non_public_lists),
+		hidden: build_key_segment(hidden_lists),
 	}
 }
 
@@ -500,7 +513,7 @@ impl SerializeBytes for KeyCollection {
 		VERSION.serialize(&mut write_buf)?;
 
 		self.public.serialize(&mut write_buf)?;
-		self.non_public.serialize(write_buf)
+		self.hidden.serialize(write_buf)
 	}
 }
 
@@ -515,9 +528,9 @@ impl DeserializeBytes for KeyCollection {
 		}
 
 		let public = KeySegment::deserialize(&mut read_buf)?;
-		let non_public = KeySegment::deserialize(read_buf)?;
+		let hidden = KeySegment::deserialize(read_buf)?;
 
-		Ok(KeyCollection { public, non_public })
+		Ok(KeyCollection { public, hidden })
 	}
 }
 

--- a/crates/prover/src/protocols/shift/monster.rs
+++ b/crates/prover/src/protocols/shift/monster.rs
@@ -7,9 +7,9 @@ use binius_field::{AESTowerField8b, BinaryField, Field, PackedField};
 use binius_math::{
 	BinarySubspace, FieldBuffer, multilinear::eq::eq_ind_partial_eval, univariate::lagrange_evals,
 };
-use binius_utils::{checked_arithmetics::log2_ceil_usize, rayon::prelude::*};
+use binius_utils::rayon::prelude::*;
 use binius_verifier::{
-	config::{LOG_WORD_SIZE_BITS, LOG_WORDS_PER_ELEM, WORD_SIZE_BITS},
+	config::{LOG_WORD_SIZE_BITS, WORD_SIZE_BITS},
 	protocols::shift::{BITAND_ARITY, INTMUL_ARITY, evaluate_h_op},
 };
 use bytemuck::zeroed_vec;
@@ -187,8 +187,8 @@ where
 		&intmul_h_ops,
 	);
 
-	let n_words = key_collection.n_words();
-	let log_len = log2_ceil_usize(n_words).max(LOG_WORDS_PER_ELEM);
+	let log_half = key_collection.log_witness_words();
+	let log_len = log_half + 1;
 	let capacity = 1 << log_len.saturating_sub(P::LOG_WIDTH);
 
 	// The scalar for one word of a segment: the accumulated contribution of all its keys.
@@ -212,9 +212,12 @@ where
 			.sum::<F>()
 	};
 
-	// The multilinear is indexed by absolute word index: the public segment words followed by
-	// the non-public segment words.
+	// The multilinear is indexed over the witness address space: the public segment at the
+	// base of the low half-cube, the hidden segment at the base of the high half-cube, zeros
+	// elsewhere.
+	let half = 1 << log_half;
 	let n_public_words = key_collection.public.n_words();
+	let n_words = half + key_collection.hidden.n_words();
 	let mut monster_multilinear = Vec::<P>::with_capacity(capacity);
 	(0..n_words.div_ceil(P::WIDTH))
 		.into_par_iter()
@@ -223,8 +226,10 @@ where
 			P::from_scalars((start..(start + P::WIDTH).min(n_words)).map(|word_index| {
 				if word_index < n_public_words {
 					word_scalar(&key_collection.public, word_index)
+				} else if word_index >= half {
+					word_scalar(&key_collection.hidden, word_index - half)
 				} else {
-					word_scalar(&key_collection.non_public, word_index - n_public_words)
+					F::ZERO
 				}
 			}))
 		})

--- a/crates/prover/src/protocols/shift/phase_1.rs
+++ b/crates/prover/src/protocols/shift/phase_1.rs
@@ -185,20 +185,20 @@ pub fn build_g_parts<F: BinaryField, P: PackedField<Scalar = F>>(
 	// A mask for low `P::WIDTH` bits.
 	let low_bits_mask = (1u8 << P::WIDTH) - 1;
 
-	// Process the public and non-public segments in absolute value-vector order: the public
+	// Process the public and hidden segments in absolute value-vector order: the public
 	// words are the prefix of `words`, and each segment's key ranges are segment-relative.
-	let (public_words, non_public_words) = words.split_at(key_collection.public.n_words());
+	let (public_words, hidden_words) = words.split_at(key_collection.public.n_words());
 	let public_iter = public_words
 		.par_iter()
 		.zip(key_collection.public.key_ranges.par_iter())
 		.map(|(word, range)| (word, range, &key_collection.public));
-	let non_public_iter = non_public_words
+	let hidden_iter = hidden_words
 		.par_iter()
-		.zip(key_collection.non_public.key_ranges.par_iter())
-		.map(|(word, range)| (word, range, &key_collection.non_public));
+		.zip(key_collection.hidden.key_ranges.par_iter())
+		.map(|(word, range)| (word, range, &key_collection.hidden));
 
 	let multilinears = public_iter
-		.chain(non_public_iter)
+		.chain(hidden_iter)
 		.fold(
 			|| zeroed_vec::<P>(acc_size).into_boxed_slice(),
 			|mut multilinears, (word, Range { start, end }, segment)| {

--- a/crates/prover/src/protocols/shift/phase_2.rs
+++ b/crates/prover/src/protocols/shift/phase_2.rs
@@ -10,8 +10,12 @@ use binius_ip_prover::{
 		ProveSingleOutput, bivariate_product::BivariateProductSumcheckProver, prove_single,
 	},
 };
-use binius_math::{FieldBuffer, multilinear::eq::eq_ind_partial_eval};
-use binius_verifier::config::LOG_WORD_SIZE_BITS;
+use binius_math::{
+	FieldBuffer,
+	multilinear::eq::{eq_ind_partial_eval, eq_ind_zero},
+};
+use binius_utils::checked_arithmetics::checked_log_2;
+use binius_verifier::{config::LOG_WORD_SIZE_BITS, protocols::shift::evaluate_words_mle};
 use tracing::instrument;
 
 use super::{
@@ -27,7 +31,7 @@ use crate::fold_word::fold_words;
 ///
 /// # Protocol Steps
 /// 1. **Challenge Splitting**: Splits phase 1 challenges into `r_j` and `r_s` components
-/// 2. **Witness Folding**: Folds the witness words using the `r_j` challenges
+/// 2. **Segment Folding**: Folds the public and hidden words using the `r_j` challenges
 /// 3. **Monster Multilinear Construction**: Builds the monster multilinear from key collection and
 ///    operator data
 /// 4. **Sumcheck Execution**: Runs bivariate product sumcheck to prove witness ×
@@ -68,41 +72,76 @@ where
 	let r_j = r_jr_s;
 
 	let r_j_tensor = eq_ind_partial_eval::<F>(&r_j);
-	let r_j_witness = fold_words::<_, P>(words, r_j_tensor.as_ref());
+
+	// Fold each segment separately and assemble the witness: the public words at the base of
+	// the low half-cube, the hidden words at the base of the high half-cube.
+	let (public_words, hidden_words) = words.split_at(key_collection.public.n_words());
+	let public_folded = fold_words::<_, P>(public_words, r_j_tensor.as_ref());
+	let hidden_folded = fold_words::<_, P>(hidden_words, r_j_tensor.as_ref());
+	let witness_folded =
+		assemble_witness(&public_folded, &hidden_folded, key_collection.log_witness_words());
 
 	let monster_multilinear =
 		build_monster_multilinear(key_collection, bitand_data, intmul_data, &r_j, &r_s);
 
-	run_sumcheck(r_j_witness, monster_multilinear, r_j, gamma, channel)
+	run_sumcheck(witness_folded, public_words, monster_multilinear, r_j, gamma, channel)
 }
 
-/// Executes the bivariate product sumcheck for the witness and monster multilinear relationship.
+/// Assembles the folded witness from its two folded segments.
+///
+/// Each segment sits at the base of its half-cube, zero-padded up to `2^log_half` entries. The
+/// interim dense representation materializes the mostly-zero low half; a sparse special first
+/// sumcheck round can remove this cost without changing the transcript.
+pub fn assemble_witness<F: Field, P: PackedField<Scalar = F>>(
+	public_folded: &FieldBuffer<P>,
+	hidden_folded: &FieldBuffer<P>,
+	log_half: usize,
+) -> FieldBuffer<P> {
+	let mut witness_folded = FieldBuffer::zeros(log_half + 1);
+	{
+		let mut split = witness_folded.split_half_mut();
+		let (mut lo_half, mut hi_half) = split.halves();
+		lo_half.as_mut()[..public_folded.as_ref().len()].copy_from_slice(public_folded.as_ref());
+		hi_half.as_mut()[..hidden_folded.as_ref().len()].copy_from_slice(hidden_folded.as_ref());
+	}
+	witness_folded
+}
+
+/// Executes the bivariate product sumcheck for the witness and monster multilinear
+/// relationship.
 ///
 /// This helper function runs the sumcheck protocol to prove the relationship between
-/// the witness and monster multilinear.
+/// the witness and monster multilinear, then sends the hidden-segment evaluation: the
+/// verifier reconstructs the full witness evaluation from it and its own public words.
 ///
 /// # Parameters
-/// - `r_j_witness`: The witness folded at challenges `r_j`
+/// - `witness_folded`: The witness folded at challenges `r_j`
+/// - `public_words`: The public segment words, for the witness evaluation derivation
 /// - `monster_multilinear`: The monster multilinear polynomial constructed from constraints
 /// - `r_j`: Challenge vector from phase 1 (first `LOG_WORD_SIZE_BITS` challenges)
 /// - `gamma`: The claimed evaluation from phase 1
-/// - `transcript`: The prover's transcript
+/// - `channel`: The prover's channel
 ///
 /// # Returns
-/// Returns `SumcheckOutput` with concatenated challenges `[r_j, r_y]` and witness evaluation.
+/// Returns `SumcheckOutput` with concatenated challenges `[r_j, r_y]` and the committed-half
+/// evaluation.
 #[instrument(skip_all, name = "run_sumcheck")]
-pub fn run_sumcheck<F: Field, P: PackedField<Scalar = F>, Channel: IPProverChannel<F>>(
-	r_j_witness: FieldBuffer<P>,
+pub fn run_sumcheck<F, P: PackedField<Scalar = F>, Channel: IPProverChannel<F>>(
+	witness_folded: FieldBuffer<P>,
+	public_words: &[Word],
 	monster_multilinear: FieldBuffer<P>,
 	r_j: Vec<F>,
 	gamma: F,
 	channel: &mut Channel,
-) -> SumcheckOutput<F> {
+) -> SumcheckOutput<F>
+where
+	F: BinaryField + From<AESTowerField8b>,
+{
 	#[cfg(debug_assertions)]
-	let cloned_r_j_witness_for_debugging = r_j_witness.clone();
+	let cloned_witness_folded_for_debugging = witness_folded.clone();
 
 	// Run sumcheck on bivariate product
-	let prover = BivariateProductSumcheckProver::new([r_j_witness, monster_multilinear], gamma);
+	let prover = BivariateProductSumcheckProver::new([witness_folded, monster_multilinear], gamma);
 
 	let ProveSingleOutput {
 		multilinear_evals,
@@ -112,22 +151,32 @@ pub fn run_sumcheck<F: Field, P: PackedField<Scalar = F>, Channel: IPProverChann
 	// Reverse the challenges to get the evaluation point.
 	r_y.reverse();
 
-	// Extract witness evaluation
-	let [witness_eval, _monster_eval] = multilinear_evals
+	let [trace_eval, _monster_eval] = multilinear_evals
 		.try_into()
 		.expect("prover has 2 multilinear polynomials");
-
-	channel.send_one(witness_eval);
 
 	#[cfg(debug_assertions)]
 	{
 		let r_y_tensor = eq_ind_partial_eval(&r_y);
-		let expected_witness_eval = binius_math::inner_product::inner_product_buffers(
-			&cloned_r_j_witness_for_debugging,
+		let expected_trace_eval = binius_math::inner_product::inner_product_buffers(
+			&cloned_witness_folded_for_debugging,
 			&r_y_tensor,
 		);
-		debug_assert_eq!(witness_eval, expected_witness_eval);
+		debug_assert_eq!(trace_eval, expected_trace_eval);
 	}
+
+	// Derive the witness evaluation from the trace evaluation by evaluating the public segment
+	// (cheap, like the verifier does), subtracting its padded contribution off and scaling.
+	// This makes the protocol incomplete with negligible probability, when the segment selector
+	// challenge is zero.
+	let log_half = r_y.len() - 1;
+	let r_segment = r_y[log_half];
+	let log_public_words = checked_log_2(public_words.len());
+	let public_eval = evaluate_words_mle::<F, F>(public_words, &r_j, &r_y[..log_public_words]);
+	let padded_public_eval = eq_ind_zero(&r_y[log_public_words..log_half]) * public_eval;
+	let witness_eval =
+		(trace_eval - (F::ONE - r_segment) * padded_public_eval) * r_segment.invert_or_zero();
+	channel.send_one(witness_eval);
 
 	SumcheckOutput {
 		challenges: [r_j, r_y].concat(),

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -7,16 +7,13 @@ use binius_core::{
 	constraint_system::{AndConstraint, ConstraintSystem, MulConstraint, ValueVec},
 	word::Word,
 };
-use binius_field::{
-	AESTowerField8b as B8, BinaryField, Divisible, ExtensionField, Field, PackedField,
-};
+use binius_field::{AESTowerField8b as B8, BinaryField, Divisible, Field, PackedField};
 use binius_hash::binary_merkle_tree::HashSuite;
 use binius_iop_prover::{basefold_compiler::BaseFoldProverCompiler, channel::IOPProverChannel};
 use binius_ip::sumcheck::SumcheckOutput;
 use binius_math::{
-	BinarySubspace, FieldBuffer, FieldSlice,
+	BinarySubspace, FieldBuffer,
 	inner_product::inner_product,
-	multilinear::{eq::eq_ind_partial_eval, evaluate::evaluate},
 	ntt::{NeighborsLastMultiThread, domain_context::GenericPreExpanded},
 	univariate::lagrange_evals,
 };
@@ -25,7 +22,7 @@ use binius_utils::{SerializeBytes, checked_arithmetics::checked_log_2, rayon::pr
 use binius_verifier::{
 	IOPVerifier, Verifier,
 	config::{
-		B1, B128, LOG_WORD_SIZE_BITS, LOG_WORDS_PER_ELEM, PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES,
+		B128, LOG_WORD_SIZE_BITS, LOG_WORDS_PER_ELEM, PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES,
 	},
 	protocols::{bitand::AndCheckOutput, intmul::IntMulOutput},
 };
@@ -97,16 +94,17 @@ impl IOPProver {
 		let cs = &self.constraint_system;
 
 		// [phase] Setup - initialization and constraint system setup
+		//
+		// Only the non-public words are committed as the trace oracle; the public segment is a
+		// verifier-known polynomial.
 		let setup_guard = tracing::debug_span!("Prepare Witness").entered();
-		let witness_packed = pack_witness::<P>(self.log_witness_elems, witness.combined_witness())?;
+		let witness_packed = pack_witness::<P>(self.log_witness_elems, witness.non_public())?;
 		drop(setup_guard);
 
 		// Observe the public input as B128 elements (includes it in Fiat-Shamir).
-		let n_public_elems = 1 << (self.log_public_words - LOG_WORDS_PER_ELEM);
-		let public_elems = witness_packed
-			.iter_scalars()
-			.take(n_public_elems)
-			.collect::<Vec<_>>();
+		let public_packed =
+			pack_witness::<P>(self.log_public_words - LOG_WORDS_PER_ELEM, witness.public())?;
+		let public_elems = public_packed.iter_scalars().collect::<Vec<_>>();
 		channel.observe_many(&public_elems);
 
 		// [phase] Witness Commit - witness generation and commitment
@@ -226,37 +224,18 @@ impl IOPProver {
 		)
 		.entered();
 
-		// Ring-switching reduction
+		// Ring-switching reduction of the witness claim. The top challenge is the witness's
+		// segment selector, which the verifier consumes when reconstructing the full witness
+		// evaluation.
+		let witness_point = &eval_point[..eval_point.len() - 1];
 		let ring_switch::RingSwitchOutput {
 			rs_eq_ind,
 			sumcheck_claim,
-		} = ring_switch::prove(&witness_packed, &eval_point, &mut *channel);
-
-		// Public input check batched with ring-switch
-		let log_packing = <B128 as ExtensionField<B1>>::LOG_DEGREE;
-
-		let log_public_elems = self.log_public_words - LOG_WORDS_PER_ELEM;
-		let pubcheck_point = &eval_point[log_packing..][..log_public_elems];
-		let pubcheck_claim = {
-			let public_elems_buf = FieldSlice::from_slice(log_public_elems, &public_elems);
-			evaluate(&public_elems_buf, pubcheck_point)
-		};
-
-		let batch_coeff: B128 = channel.sample();
-		let batched_claim = sumcheck_claim + batch_coeff * pubcheck_claim;
-
-		// Batch the pubcheck transparent with the ring-switch transparent
-		let batched_transparent =
-			compute_batched_transparent(rs_eq_ind, pubcheck_point, batch_coeff);
+		} = ring_switch::prove(&witness_packed, witness_point, &mut *channel);
 
 		// Prove oracle relations via channel (runs BaseFold internally). The intmul pushforward
 		// relation, when the IntMul reduction ran, was already queued inside phase 5.
-		channel.prove_oracle_relations([(
-			trace_oracle,
-			witness_packed,
-			batched_transparent,
-			batched_claim,
-		)]);
+		channel.prove_oracle_relations([(trace_oracle, witness_packed, rs_eq_ind, sumcheck_claim)]);
 
 		drop(pcs_guard);
 
@@ -361,27 +340,6 @@ where
 		channel.finish();
 		Ok(())
 	}
-}
-
-/// Batches the pubcheck transparent polynomial with the ring-switch equality indicator.
-///
-/// Computes `rs_eq_ind + batch_coeff * eq(pubcheck_point || 0, ·)`, adding the scaled
-/// pubcheck equality indicator to the first `2^log_public_elems` entries of `rs_eq_ind`.
-fn compute_batched_transparent<P: PackedField<Scalar = B128>>(
-	mut rs_eq_ind: FieldBuffer<P>,
-	pubcheck_point: &[B128],
-	batch_coeff: B128,
-) -> FieldBuffer<P> {
-	let log_public_elems = pubcheck_point.len();
-	let pubcheck_eq = eq_ind_partial_eval::<P>(pubcheck_point);
-	let mut chunk = rs_eq_ind.chunk_mut(log_public_elems, 0);
-	let mut chunk_data = chunk.get();
-	let batch = P::broadcast(batch_coeff);
-	for (dst, src) in std::iter::zip(chunk_data.as_mut(), pubcheck_eq.as_ref()) {
-		*dst += *src * batch;
-	}
-	drop(chunk);
-	rs_eq_ind
 }
 
 /// Packs committed witness words into the field buffer committed as the trace oracle.

--- a/crates/prover/tests/shift.rs
+++ b/crates/prover/tests/shift.rs
@@ -1,4 +1,5 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 use binius_circuits::sha256::Sha256;
 use binius_core::{
@@ -19,7 +20,7 @@ use binius_prover::{
 	protocols::shift::{OperatorData, build_key_collection, prove},
 };
 use binius_transcript::ProverTranscript;
-use binius_utils::checked_arithmetics::strict_log_2;
+use binius_utils::checked_arithmetics::{log2_ceil_usize, strict_log_2};
 use binius_verifier::{
 	config::{LOG_WORD_SIZE_BITS, StdChallenger},
 	protocols::shift::{OperatorData as VerifierOperatorData, check_eval, verify},
@@ -297,6 +298,7 @@ fn test_shift_prove_and_verify() {
 		// Check consistency with verifier output
 		check_eval(
 			&cs,
+			value_vec.public(),
 			&verifier_bitand_data,
 			&verifier_intmul_data,
 			&subspace,
@@ -307,16 +309,25 @@ fn test_shift_prove_and_verify() {
 		.unwrap();
 		verifier_transcript.finalize().unwrap();
 
-		// Check the claimed eval matches the computed eval
-		let expected_eval = evaluate_witness(
-			value_vec.combined_witness(),
-			verifier_output.r_j(),
-			verifier_output.r_y(),
+		// Check the claimed witness eval matches the direct evaluation of the non-public words.
+		// The witness segment is zero-padded from the folded length up to the segment length,
+		// contributing the `(1 - r)` factors.
+		let r_y = verifier_output.r_y();
+		let non_public = value_vec.non_public();
+		let log_folded = log2_ceil_usize(non_public.len());
+		let expected_eval = r_y[log_folded..].iter().fold(
+			evaluate_witness(non_public, verifier_output.r_j(), &r_y[..log_folded]),
+			|acc, &r_y_i| acc * (F::ONE - r_y_i),
 		);
 		assert_eq!(expected_eval, verifier_output.witness_eval);
 
 		// Check consistency of prover and verifier outputs
-		let eval_point = [verifier_output.r_j(), verifier_output.r_y()].concat();
+		let eval_point = [
+			verifier_output.r_j(),
+			r_y,
+			std::slice::from_ref(&verifier_output.r_segment),
+		]
+		.concat();
 		assert_eq!(prover_output.challenges, eval_point);
 		assert_eq!(prover_output.eval, verifier_output.witness_eval);
 	}

--- a/crates/verifier/src/protocols/shift/mod.rs
+++ b/crates/verifier/src/protocols/shift/mod.rs
@@ -1,4 +1,5 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 pub const SHIFT_VARIANT_COUNT: usize = 8;
 pub const BITAND_ARITY: usize = 3;
@@ -12,4 +13,4 @@ mod error;
 mod verify;
 
 pub use error::Error;
-pub use verify::{OperatorData, VerifyOutput, check_eval, verify};
+pub use verify::{OperatorData, VerifyOutput, check_eval, evaluate_words_mle, verify};

--- a/crates/verifier/src/protocols/shift/verify.rs
+++ b/crates/verifier/src/protocols/shift/verify.rs
@@ -4,7 +4,7 @@
 use std::iter;
 
 use binius_core::{
-	constraint_system::{AndConstraint, ConstraintSystem, MulConstraint, ValueVecLayout},
+	constraint_system::{AndConstraint, ConstraintSystem, MulConstraint},
 	word::Word,
 };
 use binius_field::{BinaryField, field::FieldOps, util::FieldFn};
@@ -14,10 +14,10 @@ use binius_ip::{
 };
 use binius_math::{
 	BinarySubspace,
-	multilinear::eq::eq_ind_partial_eval_scalars,
+	line::extrapolate_line,
+	multilinear::eq::{eq_ind_partial_eval_scalars, eq_ind_zero},
 	univariate::{evaluate_univariate, lagrange_evals_scalars},
 };
-use binius_utils::checked_arithmetics::log2_ceil_usize;
 use getset::Getters;
 use itertools::Itertools;
 
@@ -25,7 +25,7 @@ use super::{
 	BITAND_ARITY, INTMUL_ARITY, error::Error, evaluate_h_op,
 	evaluate_monster_multilinear_for_operation,
 };
-use crate::config::{LOG_WORD_SIZE_BITS, LOG_WORDS_PER_ELEM, WORD_SIZE_BITS};
+use crate::config::{LOG_WORD_SIZE_BITS, WORD_SIZE_BITS};
 
 /// Evaluates the bit-level multilinear extension of a word slice at the point `r_j ++ r_y`.
 ///
@@ -106,8 +106,10 @@ pub struct VerifyOutput<F> {
 	pub r_j: Vec<F>,
 	/// Challenge point for the shift variables (length `LOG_WORD_SIZE_BITS`).
 	pub r_s: Vec<F>,
-	/// Challenge point for the word index variables (length `log_word_count`).
+	/// Challenge point for the word index variables (length `log_witness_words`).
 	pub r_y: Vec<F>,
+	/// Challenge for the witness's segment selector variable.
+	pub r_segment: F,
 	/// Final evaluation claim from the second sumcheck.
 	eval: F,
 	/// The claimed witness evaluation at the challenge point.
@@ -196,11 +198,10 @@ where
 	let r_s = r_jr_s.split_off(LOG_WORD_SIZE_BITS);
 	let r_j = r_jr_s;
 
-	// The committed witness is folded as a power-of-two-length multilinear, so its number of
-	// variables rounds the (possibly non-power-of-two) committed value count up to the next power
-	// of two. This matches the prover, which zero-pads the witness to the same length.
-	let log_word_count = log2_ceil_usize(constraint_system.value_vec_layout.committed_total_len)
-		.max(LOG_WORDS_PER_ELEM);
+	// The second sumcheck runs over the witness: the public segment in the low half-cube and
+	// the hidden segment in the high half-cube, selected by the top word-index variable. This
+	// matches the prover, which zero-pads each segment to the half size.
+	let log_word_count = constraint_system.value_vec_layout.log_witness_words() + 1;
 
 	let SumcheckOutput {
 		eval,
@@ -208,6 +209,7 @@ where
 	} = verify_sumcheck(log_word_count, 2, gamma, channel)?;
 
 	r_y.reverse();
+	let r_segment = r_y.pop().expect("log_word_count >= 1");
 
 	let witness_eval = channel.recv_one()?;
 
@@ -216,6 +218,7 @@ where
 		intmul_lambda,
 		r_j,
 		r_y,
+		r_segment,
 		r_s,
 		eval,
 		witness_eval,
@@ -233,17 +236,26 @@ where
 ///
 /// The function verifies that:
 /// ```text
-/// eval = witness_eval * monster_eval
+/// eval = trace_eval * monster_eval
 /// ```
 ///
-/// Where `monster_eval` is the sum of evaluations for AND and MUL constraint polynomials.
+/// where `monster_eval` is the sum of evaluations for AND and MUL constraint polynomials, and
+/// `trace_eval` is the witness evaluation reconstructed from its two segments:
+/// ```text
+/// trace_eval = (1 - r_segment) * prod_{k <= i} (1 - r_y_i) * public_eval + r_segment * witness_eval
+/// ```
+/// The public half is evaluated over the *verifier's* public words, so a prover that used
+/// different public values fails this check with high probability; this subsumes the former
+/// standalone public input check.
 ///
 /// # Errors
 ///
 /// - `Error::VerificationFailure` if the evaluation equation doesn't hold
 /// - Propagates errors from monster multilinear evaluation
+#[allow(clippy::too_many_arguments)]
 pub fn check_eval<F, C>(
 	constraint_system: &ConstraintSystem,
+	public: &[Word],
 	bitand_data: &OperatorData<C::Elem, BITAND_ARITY>,
 	intmul_data: &OperatorData<C::Elem, INTMUL_ARITY>,
 	subspace: &BinarySubspace<F>,
@@ -263,6 +275,7 @@ where
 		r_j,
 		r_s,
 		r_y,
+		r_segment,
 		witness_eval,
 	} = output;
 
@@ -277,7 +290,7 @@ where
 		let intmul_r_x_prime_len = intmul_data.r_x_prime.len();
 		let r_j_len = r_j.len();
 		let r_s_len = r_s.len();
-		let r_y_len = r_y.len();
+		let r_y_len = r_y.len() + 1;
 
 		let inputs: Vec<C::Elem> = iter::once(r_zhat_prime)
 			.chain(iter::once(bitand_lambda.clone()))
@@ -287,6 +300,7 @@ where
 			.chain(r_j.iter().cloned())
 			.chain(r_s.iter().cloned())
 			.chain(r_y.iter().cloned())
+			.chain(iter::once(r_segment.clone()))
 			.collect();
 
 		let eval_fn = MonsterEvalFn {
@@ -301,15 +315,47 @@ where
 		channel.compute_public_value(&inputs, eval_fn)
 	};
 
-	// Check if the prover-provided witness value is satisfying.
+	// The public-half evaluation is a function of the verifier's public words (plaintext) and
+	// public-channel-derived challenges, so it is computed the same way as `monster_eval`.
+	let log_public_words = constraint_system.value_vec_layout.log_public_words();
+	let public_eval = {
+		let inputs: Vec<C::Elem> = r_j
+			.iter()
+			.chain(&r_y[..log_public_words])
+			.cloned()
+			.collect();
+		channel.compute_public_value(&inputs, PublicWordsEvalFn { public })
+	};
+
+	// Reconstruct the witness evaluation from its two segments. The public segment is
+	// zero-padded up to the hidden segment length, contributing the eq-zero padding factor.
+	let padded_public_eval = eq_ind_zero(&r_y[log_public_words..]) * public_eval;
+	let trace_eval = extrapolate_line(padded_public_eval, witness_eval.clone(), r_segment.clone());
+
+	// Check if the reconstructed trace value is satisfying.
 	//
-	// The protocol could compute this witness value instead of reading it from the prover. This
-	// would require inverting a random element, however, making the protocol incomplete with
-	// negligible probability. As a matter of taste, we read the witness value from the prover.
-	let expected_eval = witness_eval.clone() * monster_eval;
+	// The protocol could compute the committed-half value instead of reading it from the prover.
+	// This would require inverting a random element, however, making the protocol incomplete
+	// with negligible probability. As a matter of taste, we read the value from the prover.
+	let expected_eval = trace_eval * monster_eval;
 	channel.assert_zero(expected_eval - eval)?;
 
 	Ok(())
+}
+
+/// The bit-level MLE evaluation of the public words, as a [`FieldFn`] over the inputs
+/// `r_j.. | r_y_low..`: the word-bit challenges followed by the low `log_public_words`
+/// word-index challenges. Computed via the same public-value mechanism as [`MonsterEvalFn`].
+struct PublicWordsEvalFn<'a> {
+	/// The public words of the value vector.
+	public: &'a [Word],
+}
+
+impl<F: BinaryField> FieldFn<F> for PublicWordsEvalFn<'_> {
+	fn call<E: FieldOps<Scalar = F> + From<F>>(&self, vals: &[E]) -> E {
+		let (r_j, r_y_low) = vals.split_at(LOG_WORD_SIZE_BITS);
+		evaluate_words_mle(self.public, r_j, r_y_low)
+	}
 }
 
 /// The monster multilinear evaluation, as a [`FieldFn`] over public-channel-derived inputs.
@@ -356,7 +402,22 @@ impl<F: BinaryField> FieldFn<F> for MonsterEvalFn<'_, F> {
 		let r_y_v = &vals[off..off + self.r_y_len];
 
 		// Expand the column challenge and the per-bit Lagrange / shift-operator evaluations.
-		let r_y_tensor = eq_ind_partial_eval_scalars(r_y_v);
+		// The tensor is expanded over the witness address space, then rearranged into a lookup
+		// by absolute value-vector index: public words keep their index in the low half, and
+		// hidden words move to the base of the high half.
+		let witness_tensor = eq_ind_partial_eval_scalars(r_y_v);
+		let layout = &self.constraint_system.value_vec_layout;
+		let half = 1 << (self.r_y_len - 1);
+		let n_public_words = layout.n_public_words();
+		let r_y_tensor = (0..layout.committed_total_len)
+			.map(|word_index| {
+				if word_index < n_public_words {
+					witness_tensor[word_index].clone()
+				} else {
+					witness_tensor[half + word_index - n_public_words].clone()
+				}
+			})
+			.collect::<Vec<_>>();
 		let l_tilde = lagrange_evals_scalars(self.subspace, r_zhat_prime_v);
 		let h_op_evals = evaluate_h_op(&l_tilde, r_j_v, r_s_v);
 
@@ -403,7 +464,6 @@ impl<F: BinaryField> FieldFn<F> for MonsterEvalFn<'_, F> {
 
 #[cfg(test)]
 mod tests {
-	use binius_core::constraint_system::ValueVecLayout;
 	use binius_field::Field;
 	use binius_math::test_utils::random_scalars;
 	use rand::{RngExt, SeedableRng, rngs::StdRng};

--- a/crates/verifier/src/protocols/shift/verify.rs
+++ b/crates/verifier/src/protocols/shift/verify.rs
@@ -1,8 +1,12 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 use std::iter;
 
-use binius_core::constraint_system::{AndConstraint, ConstraintSystem, MulConstraint};
+use binius_core::{
+	constraint_system::{AndConstraint, ConstraintSystem, MulConstraint, ValueVecLayout},
+	word::Word,
+};
 use binius_field::{BinaryField, field::FieldOps, util::FieldFn};
 use binius_ip::{
 	channel::IPVerifierChannel,
@@ -21,7 +25,38 @@ use super::{
 	BITAND_ARITY, INTMUL_ARITY, error::Error, evaluate_h_op,
 	evaluate_monster_multilinear_for_operation,
 };
-use crate::config::{LOG_WORD_SIZE_BITS, LOG_WORDS_PER_ELEM};
+use crate::config::{LOG_WORD_SIZE_BITS, LOG_WORDS_PER_ELEM, WORD_SIZE_BITS};
+
+/// Evaluates the bit-level multilinear extension of a word slice at the point `r_j ++ r_y`.
+///
+/// The multilinear has `LOG_WORD_SIZE_BITS + r_y.len()` variables: the low variables index the
+/// bit within a word and the high variables index the word. Words past `words.len()` (up to
+/// `2^r_y.len()`) are treated as zero.
+///
+/// ## Preconditions
+///
+/// * `r_j` has exactly `LOG_WORD_SIZE_BITS` entries
+/// * `words` has at most `2^r_y.len()` entries
+pub fn evaluate_words_mle<F, E>(words: &[Word], r_j: &[E], r_y: &[E]) -> E
+where
+	F: BinaryField,
+	E: FieldOps<Scalar = F> + From<F>,
+{
+	assert_eq!(r_j.len(), LOG_WORD_SIZE_BITS); // precondition
+	assert!(words.len() <= 1 << r_y.len()); // precondition
+
+	let r_j_tensor = eq_ind_partial_eval_scalars(r_j);
+	let r_y_tensor = eq_ind_partial_eval_scalars(r_y);
+	iter::zip(words, r_y_tensor)
+		.map(|(word, weight)| {
+			let word_eval = (0..WORD_SIZE_BITS)
+				.filter(|bit| (word.as_u64() >> bit) & 1 == 1)
+				.map(|bit| &r_j_tensor[bit])
+				.sum::<E>();
+			weight * word_eval
+		})
+		.sum()
+}
 
 /// Verifier data for an operation with the specified arity.
 ///
@@ -363,5 +398,42 @@ impl<F: BinaryField> FieldFn<F> for MonsterEvalFn<'_, F> {
 		};
 
 		bitand_part + intmul_part
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use binius_core::constraint_system::ValueVecLayout;
+	use binius_field::Field;
+	use binius_math::test_utils::random_scalars;
+	use rand::{RngExt, SeedableRng, rngs::StdRng};
+
+	use super::*;
+	use crate::config::B128;
+
+	#[test]
+	fn test_evaluate_words_mle_matches_naive() {
+		let mut rng = StdRng::seed_from_u64(0);
+		let log_words = 3;
+		// A non-power-of-two word count exercises the implicit zero padding.
+		let words = (0..(1 << log_words) - 3)
+			.map(|_| Word::from_u64(rng.random::<u64>()))
+			.collect::<Vec<_>>();
+		let r_j = random_scalars::<B128>(&mut rng, LOG_WORD_SIZE_BITS);
+		let r_y = random_scalars::<B128>(&mut rng, log_words);
+
+		// Naive reference: sum the full bit-level eq tensor over every set bit.
+		let full_point = [r_j.clone(), r_y.clone()].concat();
+		let full_tensor = eq_ind_partial_eval_scalars::<B128>(&full_point);
+		let mut expected = B128::ZERO;
+		for (word_index, word) in words.iter().enumerate() {
+			for bit in 0..WORD_SIZE_BITS {
+				if (word.as_u64() >> bit) & 1 == 1 {
+					expected += full_tensor[(word_index << LOG_WORD_SIZE_BITS) | bit];
+				}
+			}
+		}
+
+		assert_eq!(evaluate_words_mle::<B128, B128>(&words, &r_j, &r_y), expected);
 	}
 }

--- a/crates/verifier/src/verify.rs
+++ b/crates/verifier/src/verify.rs
@@ -13,16 +13,10 @@ use binius_iop::{
 };
 use binius_ip::channel::IPVerifierChannel;
 use binius_math::{
-	BinarySubspace,
-	inner_product::inner_product_scalars,
-	multilinear::{eq::eq_ind, evaluate::evaluate_inplace_scalars},
-	univariate::lagrange_evals_scalars,
+	BinarySubspace, inner_product::inner_product_scalars, univariate::lagrange_evals_scalars,
 };
 use binius_transcript::{VerifierTranscript, fiat_shamir::Challenger};
-use binius_utils::{
-	DeserializeBytes,
-	checked_arithmetics::{checked_log_2, log2_ceil_usize},
-};
+use binius_utils::{DeserializeBytes, checked_arithmetics::checked_log_2};
 use digest::Output;
 use itertools::chain;
 
@@ -82,14 +76,16 @@ impl IOPVerifier {
 	}
 
 	/// Returns log2 of the number of field elements in the packed trace.
-	pub fn log_witness_elems(&self) -> usize {
-		let log_witness_words =
-			log2_ceil_usize(self.constraint_system.value_vec_len()).max(LOG_WORDS_PER_ELEM);
+	///
+	/// The trace oracle commits only the witness's hidden segment, padded to the segment
+	/// length; the public segment is a verifier-known polynomial.
+	pub const fn log_witness_elems(&self) -> usize {
+		let log_witness_words = self.constraint_system.value_vec_layout.log_witness_words();
 		log_witness_words - LOG_WORDS_PER_ELEM
 	}
 
-	/// Returns log2 of the number of words in the witness.
-	pub fn log_witness_words(&self) -> usize {
+	/// Returns log2 of the number of words in the committed trace.
+	pub const fn log_witness_words(&self) -> usize {
 		self.log_witness_elems() + LOG_WORDS_PER_ELEM
 	}
 
@@ -132,7 +128,7 @@ impl IOPVerifier {
 		}
 
 		// Verifier observes the public input (includes it in Fiat-Shamir).
-		let public_elems = channel.observe_many(&encode_public(public));
+		channel.observe_many(&encode_public(public));
 
 		let _verify_guard =
 			tracing::info_span!("Verify", operation = "verify", perfetto_category = "operation")
@@ -247,6 +243,7 @@ impl IOPVerifier {
 		.entered();
 		shift::check_eval(
 			self.constraint_system(),
+			public,
 			&bitand_claim,
 			&intmul_claim,
 			&domain_subspace,
@@ -264,30 +261,18 @@ impl IOPVerifier {
 		)
 		.entered();
 
-		// Ring-switching verification
+		// Ring-switching verification of the witness claim.
 		let eval_point = [shift_output.r_j(), shift_output.r_y()].concat();
 		let ring_switch::RingSwitchVerifyOutput {
 			eq_r_double_prime,
 			sumcheck_claim,
 		} = ring_switch::verify(shift_output.witness_eval().clone(), &eval_point, channel)?;
 
-		// Public input check batched with ring-switch
 		let log_packing = <B128 as ExtensionField<B1>>::LOG_DEGREE;
 		let eval_point_high = eval_point[log_packing..].to_vec();
 
-		let log_public_elems = self.log_public_words() - LOG_WORDS_PER_ELEM;
-		let pubcheck_point = eval_point_high[..log_public_elems].to_vec();
-		let pubcheck_claim = evaluate_inplace_scalars(public_elems, &pubcheck_point);
-
-		let batch_coeff = channel.sample();
-		let batched_claim = sumcheck_claim + batch_coeff.clone() * pubcheck_claim;
-
-		// Build the transparent closure combining ring-switch and public input check
 		let transparent = Box::new(move |point: &[Channel::Elem]| {
-			let rs_eq_eval =
-				ring_switch::eval_rs_eq(&eval_point_high, point, eq_r_double_prime.as_ref());
-			let pubcheck_eq_eval = eval_pubcheck_eq(&pubcheck_point, point);
-			rs_eq_eval + batch_coeff.clone() * pubcheck_eq_eval
+			ring_switch::eval_rs_eq(&eval_point_high, point, eq_r_double_prime.as_ref())
 		});
 
 		// Verify oracle relations (runs BaseFold internally and verifies the product check). The
@@ -296,7 +281,7 @@ impl IOPVerifier {
 		channel.verify_oracle_relations([OracleLinearRelation {
 			oracle: trace_oracle,
 			transparent,
-			claim: batched_claim,
+			claim: sumcheck_claim,
 		}])?;
 
 		drop(pcs_guard);
@@ -377,12 +362,12 @@ where
 	}
 
 	/// Returns log2 of the number of words in the witness.
-	pub fn log_witness_words(&self) -> usize {
+	pub const fn log_witness_words(&self) -> usize {
 		self.iop_verifier.log_witness_words()
 	}
 
 	/// Returns log2 of the number of field elements in the packed trace.
-	pub fn log_witness_elems(&self) -> usize {
+	pub const fn log_witness_elems(&self) -> usize {
 		self.iop_verifier.log_witness_elems()
 	}
 
@@ -455,21 +440,6 @@ where
 		chain!(small_field_zerocheck_challenges, big_field_zerocheck_challenges)
 			.collect::<Vec<_>>();
 	verify_with_channel(&zerocheck_challenges, channel, eval_domain)
-}
-
-/// Evaluate the public input equality indicator at a query point.
-///
-/// Computes `eq(pubcheck_point || 0, query)`, which selects the first `2^k` entries of the
-/// committed polynomial (the public inputs). In characteristic 2:
-/// `eq(a || 0, x) = eq(a, x[..k]) * prod_{i >= k} (1 - x_i)`
-fn eval_pubcheck_eq<F: FieldOps>(pubcheck_point: &[F], query: &[F]) -> F {
-	let one = F::one();
-	let (query_prefix, query_suffix) = query.split_at(pubcheck_point.len());
-	let prefix_eq = eq_ind(pubcheck_point, query_prefix);
-	let suffix_prod = query_suffix
-		.iter()
-		.fold(one.clone(), |acc, x| acc * (one.clone() - x));
-	prefix_eq * suffix_prod
 }
 
 /// Encode public input words as B128 elements, for compliance with the IOP interface.


### PR DESCRIPTION
The protocol change for [BINIUS-145](https://linear.app/jimpo/issue/BINIUS-145/handling-constants) (PR 2 of the [plan](https://linear.app/jimpo/issue/BINIUS-145/handling-constants#comment-c759bc33), stacked on #1707): the trace oracle commits only the witness's **hidden segment**; the **public segment** (constants and inout values) enters the protocol as a verifier-known polynomial. `IOPProver::prove` / `IOPVerifier::verify` signatures are unchanged.

**Protocol.** The witness spans `log_witness_words + 1` word-index variables: the public segment at the base of the low half-cube, the hidden segment at the base of the high half-cube, selected by the top variable (`r_segment`) — which the existing sumcheck binds in round 1, so the planned sparse special first round (PR 4) needs no transcript change. The layout now guarantees the hidden segment is at least as long as the public segment (the frontend allocator pads), so `layout.log_witness_words() >= log_public_words()` with no `max`. As discussed on the issue, the claim splits **before** ring-switch: the prover derives and sends the hidden-segment (`witness_eval`) value, and the verifier reconstructs the full witness evaluation via `extrapolate_line(eq_ind_zero(..) * public_eval, witness_eval, r_segment)`, computing `public_eval` from its **own** public words via the same `compute_public_value` mechanism as the monster evaluation. Ring-switch and BaseFold then run unchanged on the witness claim.

**The standalone public input check is deleted, not moved** — `eval_pubcheck_eq`, the batching in `verify.rs`, and `compute_batched_transparent` on the prover side. Its binding role is subsumed: a prover using different public values fails the reconstructed final check w.h.p. ZK masks now cover only the committed oracle (specs track automatically via `OracleSetupChannel`).

**Commit 1** adds `ValueVecLayout::log_witness_words` with the validate/allocator guarantee and the bit-level public-words MLE evaluation (`evaluate_words_mle`) with unit tests. **Commit 2** is the protocol change across prover and verifier, plus bench and test updates.

**Proof sizes** (SHA-256 compress test circuit, `log_inv_rate=1`, verification round-tripped): plain 43,408 → 35,936 bytes (−17.2%); ZK 362,544 → 355,120 bytes (−2.0%). The phase-2 prover domain temporarily grows to `2^(log_witness_words + 1)` (dense buffers); PR 4 removes that cost transcript-identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)