### PR TITLE
BINIUS-226: remove special hint methods from CircuitBuilder

### DIFF
--- a/crates/circuits/src/bignum/prime_field.rs
+++ b/crates/circuits/src/bignum/prime_field.rs
@@ -1,7 +1,11 @@
 // Copyright 2026 The Binius Developers
 // Copyright 2025 Irreducible Inc.
 use binius_core::{consts::WORD_SIZE_BITS, word::Word};
-use binius_frontend::{CircuitBuilder, Wire, util::num_biguint_from_u64_limbs};
+use binius_frontend::{
+	CircuitBuilder, Wire,
+	hints::{BigUintDivideHint, ModDivideHint, ModInverseHint},
+	util::num_biguint_from_u64_limbs,
+};
 
 use super::{
 	BigUint, PseudoMersenneModReduce, add, biguint_lt, sub, textbook_mul, textbook_square,
@@ -104,7 +108,7 @@ impl PseudoMersennePrimeField {
 	}
 
 	fn reduce_product(&self, b: &CircuitBuilder, product: BigUint) -> BigUint {
-		let (quotient, remainder) = b.biguint_divide_hint(&product.limbs, &self.modulus.limbs);
+		let (quotient, remainder) = BigUintDivideHint::call(b, &product.limbs, &self.modulus.limbs);
 
 		let zero = b.add_constant(Word::ZERO);
 
@@ -135,7 +139,7 @@ impl PseudoMersennePrimeField {
 	/// for avoiding overconstraining in skipped parts of larger circuits.
 	pub fn inverse(&self, b: &CircuitBuilder, fe: &BigUint, exists: Wire) -> BigUint {
 		assert!(fe.limbs.len() == self.limbs_len());
-		let (quotient, inverse) = b.mod_inverse_hint(&fe.limbs, &self.modulus.limbs);
+		let (quotient, inverse) = ModInverseHint::call(b, &fe.limbs, &self.modulus.limbs);
 
 		let zero = b.add_constant(Word::ZERO);
 
@@ -200,7 +204,7 @@ impl PseudoMersennePrimeField {
 			dividend.limbs.len() == self.limbs_len() && divisor.limbs.len() == self.limbs_len()
 		);
 		let (quotient, slope) =
-			b.mod_divide_hint(&dividend.limbs, &divisor.limbs, &self.modulus.limbs);
+			ModDivideHint::call(b, &dividend.limbs, &divisor.limbs, &self.modulus.limbs);
 
 		let zero = b.add_constant(Word::ZERO);
 

--- a/crates/circuits/src/ecdsa/scalar_mul.rs
+++ b/crates/circuits/src/ecdsa/scalar_mul.rs
@@ -1,7 +1,7 @@
 // Copyright 2026 The Binius Developers
 // Copyright 2025 Irreducible Inc.
 use binius_core::{consts::WORD_SIZE_BITS, word::Word};
-use binius_frontend::{CircuitBuilder, Wire};
+use binius_frontend::{CircuitBuilder, Wire, hints::Secp256k1EndosplitHint};
 
 use crate::{
 	bignum::{BigUint, assert_eq, select as select_biguint},
@@ -36,7 +36,7 @@ pub fn scalar_mul(
 	msm_strauss_endo(b, curve, MSM_WINDOW, std::slice::from_ref(scalar), &[point])
 }
 
-// Constrain the return value of `CircuitBuilder::secp256k1_endomorphism_split_hint`.
+// Constrain the return value of `Secp256k1EndosplitHint::call`.
 // Verifies that `k1 + λ k2 = k (mod n)` where `n` is scalar field modulus.
 fn check_endomorphism_split(
 	b: &CircuitBuilder,
@@ -122,7 +122,7 @@ pub fn msm_strauss_endo(
 	for (scalar, point) in scalars.iter().zip(points) {
 		assert_eq!(scalar.limbs.len(), N_LIMBS);
 
-		let (k1_neg, k2_neg, k1_abs, k2_abs) = b.secp256k1_endomorphism_split_hint(&scalar.limbs);
+		let (k1_neg, k2_neg, k1_abs, k2_abs) = Secp256k1EndosplitHint::call(b, &scalar.limbs);
 		check_endomorphism_split(b, curve, k1_neg, k2_neg, k1_abs, k2_abs, scalar);
 
 		// Table for the (possibly negated) base point `±P`, built with point additions.

--- a/crates/circuits/src/secp256k1/curve.rs
+++ b/crates/circuits/src/secp256k1/curve.rs
@@ -1,7 +1,7 @@
 // Copyright 2026 The Binius Developers
 // Copyright 2025 Irreducible Inc.
 use binius_core::consts::WORD_SIZE_BITS;
-use binius_frontend::{CircuitBuilder, Wire};
+use binius_frontend::{CircuitBuilder, Wire, hints::BigUintModPowHint};
 
 use super::{
 	common::{coord_b, coord_beta, coord_field, coord_zero, pow_sqrt, scalar_field},
@@ -65,7 +65,7 @@ impl Secp256k1 {
 
 		// p = 2^256 - 2^32 - 977 = 3 (mod 4), compute the quadratic residue by raising to (p+1)/4
 		let res_1_limbs =
-			b.biguint_mod_pow_hint(&y_squared.limbs, &pow_sqrt(b).limbs, &f_p.modulus().limbs);
+			BigUintModPowHint::call(b, &y_squared.limbs, &pow_sqrt(b).limbs, &f_p.modulus().limbs);
 		let res_1 = BigUint { limbs: res_1_limbs };
 		let res_2 = f_p.sub(b, &coord_zero(b), &res_1);
 

--- a/crates/examples/examples/tutorials/basics_nondeterministic.rs
+++ b/crates/examples/examples/tutorials/basics_nondeterministic.rs
@@ -7,7 +7,7 @@
 //! Guide: https://www.binius.xyz/building/
 
 use binius_core::verify::verify_constraints;
-use binius_frontend::CircuitBuilder;
+use binius_frontend::{CircuitBuilder, hints::BigUintDivideHint};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
 	let builder = CircuitBuilder::new();
@@ -19,7 +19,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 	let divisor = vec![builder.add_constant_64(83)];
 
 	// Hint computes quotient and remainder externally
-	let (quotient, remainder) = builder.biguint_divide_hint(&dividend, &divisor);
+	let (quotient, remainder) = BigUintDivideHint::call(&builder, &dividend, &divisor);
 
 	// Verify: dividend = divisor × quotient + remainder
 	let (_hi, lo) = builder.imul(divisor[0], quotient[0]);

--- a/crates/frontend/src/compiler/hints/big_uint_divide.rs
+++ b/crates/frontend/src/compiler/hints/big_uint_divide.rs
@@ -4,13 +4,34 @@
 use binius_core::Word;
 
 use super::Hint;
-use crate::util::num_biguint_from_u64_limbs;
+use crate::{
+	compiler::{CircuitBuilder, Wire},
+	util::num_biguint_from_u64_limbs,
+};
 
 pub struct BigUintDivideHint;
 
 impl BigUintDivideHint {
 	pub const fn new() -> Self {
 		Self
+	}
+
+	/// BigUint division.
+	///
+	/// Returns `(quotient, remainder)` of the division of `dividend` by `divisor`.
+	///
+	/// This is a hint - a deterministic computation that happens only on the prover side.
+	/// The result should be additionally constrained by using bignum circuits to check that
+	/// `remainder + divisor * quotient == dividend`.
+	pub fn call(
+		builder: &CircuitBuilder,
+		dividend: &[Wire],
+		divisor: &[Wire],
+	) -> (Vec<Wire>, Vec<Wire>) {
+		let inputs: Vec<Wire> = dividend.iter().chain(divisor).copied().collect();
+		let mut out = builder.call_hint(Self::new(), &[dividend.len(), divisor.len()], &inputs);
+		let remainder = out.split_off(dividend.len());
+		(out, remainder)
 	}
 }
 

--- a/crates/frontend/src/compiler/hints/big_uint_mod_pow.rs
+++ b/crates/frontend/src/compiler/hints/big_uint_mod_pow.rs
@@ -4,13 +4,31 @@
 use binius_core::Word;
 
 use super::Hint;
-use crate::util::num_biguint_from_u64_limbs;
+use crate::{
+	compiler::{CircuitBuilder, Wire},
+	util::num_biguint_from_u64_limbs,
+};
 
 pub struct BigUintModPowHint;
 
 impl BigUintModPowHint {
 	pub const fn new() -> Self {
 		Self
+	}
+
+	/// Modular exponentiation.
+	///
+	/// Computes `(base^exp) % modulus`.
+	/// This is a hint - a deterministic computation that happens only on the prover side.
+	/// The result should be additionally constrained using bignum circuits.
+	pub fn call(
+		builder: &CircuitBuilder,
+		base: &[Wire],
+		exp: &[Wire],
+		modulus: &[Wire],
+	) -> Vec<Wire> {
+		let inputs: Vec<Wire> = base.iter().chain(exp).chain(modulus).copied().collect();
+		builder.call_hint(Self::new(), &[base.len(), exp.len(), modulus.len()], &inputs)
 	}
 }
 

--- a/crates/frontend/src/compiler/hints/mod_divide.rs
+++ b/crates/frontend/src/compiler/hints/mod_divide.rs
@@ -4,7 +4,10 @@
 use binius_core::Word;
 
 use super::Hint;
-use crate::util::num_biguint_from_u64_limbs;
+use crate::{
+	compiler::{CircuitBuilder, Wire},
+	util::num_biguint_from_u64_limbs,
+};
 
 /// ModDivide hint implementation.
 ///
@@ -17,6 +20,38 @@ pub struct ModDivideHint;
 impl ModDivideHint {
 	pub const fn new() -> Self {
 		Self
+	}
+
+	/// Modular division.
+	///
+	/// Computes `dividend / divisor (mod modulus) = dividend * divisor^{-1} (mod modulus)`.
+	/// Returns a pair `(quotient, slope)` where `slope` is the modular quotient and `quotient`
+	/// is the non-negative integer satisfying `slope * divisor = dividend + quotient * modulus`.
+	/// Both are set to zero when `divisor` is not invertible modulo `modulus` (e.g. `divisor ==
+	/// 0`).
+	///
+	/// This is a hint - a deterministic computation that happens only on the prover side.
+	/// The result should be additionally constrained by using bignum circuits to check that
+	/// `slope * divisor = dividend + quotient * modulus`.
+	pub fn call(
+		builder: &CircuitBuilder,
+		dividend: &[Wire],
+		divisor: &[Wire],
+		modulus: &[Wire],
+	) -> (Vec<Wire>, Vec<Wire>) {
+		let inputs: Vec<Wire> = dividend
+			.iter()
+			.chain(divisor)
+			.chain(modulus)
+			.copied()
+			.collect();
+		let mut out = builder.call_hint(
+			Self::new(),
+			&[dividend.len(), divisor.len(), modulus.len()],
+			&inputs,
+		);
+		let slope = out.split_off(modulus.len());
+		(out, slope)
 	}
 }
 

--- a/crates/frontend/src/compiler/hints/mod_inverse.rs
+++ b/crates/frontend/src/compiler/hints/mod_inverse.rs
@@ -4,7 +4,10 @@
 use binius_core::Word;
 
 use super::Hint;
-use crate::util::num_biguint_from_u64_limbs;
+use crate::{
+	compiler::{CircuitBuilder, Wire},
+	util::num_biguint_from_u64_limbs,
+};
 
 /// ModInverse hint implementation
 pub struct ModInverseHint;
@@ -12,6 +15,26 @@ pub struct ModInverseHint;
 impl ModInverseHint {
 	pub const fn new() -> Self {
 		Self
+	}
+
+	/// Modular inverse.
+	///
+	/// Computes the modular inverse of `base` modulo `modulus`.
+	/// Returns a pair `(quotient, inverse)` where both numbers are Bézout coefficients when
+	/// `base` and `modulus` are coprime. Both numbers are set to zero if `gcd(base, modulus) > 1`.
+	///
+	/// This is a hint - a deterministic computation that happens only on the prover side.
+	/// The result should be additionally constrained by using bignum circuits to check that
+	/// `base * inverse = 1 + quotient * modulus`.
+	pub fn call(
+		builder: &CircuitBuilder,
+		base: &[Wire],
+		modulus: &[Wire],
+	) -> (Vec<Wire>, Vec<Wire>) {
+		let inputs: Vec<Wire> = base.iter().chain(modulus).copied().collect();
+		let mut out = builder.call_hint(Self::new(), &[base.len(), modulus.len()], &inputs);
+		let inverse = out.split_off(modulus.len());
+		(out, inverse)
 	}
 }
 

--- a/crates/frontend/src/compiler/hints/secp256k1_endosplit.rs
+++ b/crates/frontend/src/compiler/hints/secp256k1_endosplit.rs
@@ -26,7 +26,10 @@ use hex_literal::hex;
 use num_bigint::BigUint;
 
 use super::Hint;
-use crate::util::num_biguint_from_u64_limbs;
+use crate::{
+	compiler::{CircuitBuilder, Wire},
+	util::num_biguint_from_u64_limbs,
+};
 
 pub struct Secp256k1EndosplitHint {
 	minus_b1: BigUint,
@@ -76,6 +79,33 @@ impl Secp256k1EndosplitHint {
 			k1_tight_bound,
 			k2_tight_bound,
 		}
+	}
+
+	/// Secp256k1 endomorphism split.
+	///
+	/// The curve has an endomorphism `λ (x, y) = (βx, y)` where `λ³=1 (mod n)`
+	/// and `β³=1 (mod p)` (`n` being the scalar field modulus and `p` coordinate field one).
+	///
+	/// For a 256-bit scalar `k` it is possible to split it into `k1` and `k2` such that
+	/// `k1 + λ k2 = k (mod n)` and both `k1` and `k2` are no farther than `2^128` from zero.
+	///
+	/// The `k` scalar is represented by four 64-bit limbs in little endian order. The return value
+	/// is quadruple of `(k1_neg, k2_neg, k1_abs, k2_abs)` where `k1_neg` and `k2_neg` are
+	/// MSB-bools indicating whether `k1_abs` or `k2_abs`, respectively, should be negated.
+	/// `k1_abs` and `k2_abs` are at most 128 bits and are represented with two 64-bit limbs.
+	/// When `k` cannot be represented in this way (any valid scalar can, so it has to be modulus
+	/// or above), both `k1_abs` and `k2_abs` are assigned zero values.
+	///
+	/// This is a hint - a deterministic computation that happens only on the prover side.
+	/// The result should be additionally constrained by using bignum circuits to check that
+	/// `k1 + λ k2 = k (mod n)`.
+	pub fn call(builder: &CircuitBuilder, k: &[Wire]) -> (Wire, Wire, [Wire; 2], [Wire; 2]) {
+		assert_eq!(k.len(), 4);
+		let out = builder.call_hint(Self::new(), &[], k);
+		let [k1_neg, k2_neg, k1_abs0, k1_abs1, k2_abs0, k2_abs1] = out.as_slice() else {
+			panic!("Secp256k1EndosplitHint must return 6 wires");
+		};
+		(*k1_neg, *k2_neg, [*k1_abs0, *k1_abs1], [*k2_abs0, *k2_abs1])
 	}
 
 	fn scalar_abs(&self, scalar: BigUint) -> (Word, BigUint) {

--- a/crates/frontend/src/compiler/mod.rs
+++ b/crates/frontend/src/compiler/mod.rs
@@ -12,10 +12,7 @@ use crate::compiler::{
 	circuit::Circuit,
 	constraint_builder::ConstraintBuilder,
 	gate_graph::{GateGraph, WireKind},
-	hints::{
-		BigUintDivideHint, BigUintModPowHint, Hint, HintRegistry, ModDivideHint, ModInverseHint,
-		Secp256k1EndosplitHint,
-	},
+	hints::{Hint, HintRegistry},
 	pathspec::PathSpec,
 };
 
@@ -1213,112 +1210,5 @@ impl CircuitBuilder {
 		);
 
 		outputs
-	}
-
-	/// BigUint division.
-	///
-	/// Returns `(quotient, remainder)` of the division of `dividend` by `divisor`.
-	///
-	/// This is a hint - a deterministic computation that happens only on the prover side.
-	/// The result should be additionally constrained by using bignum circuits to check that
-	/// `remainder + divisor * quotient == dividend`.
-	pub fn biguint_divide_hint(
-		&self,
-		dividend: &[Wire],
-		divisor: &[Wire],
-	) -> (Vec<Wire>, Vec<Wire>) {
-		let inputs: Vec<Wire> = dividend.iter().chain(divisor).copied().collect();
-		let mut out =
-			self.call_hint(BigUintDivideHint::new(), &[dividend.len(), divisor.len()], &inputs);
-		let remainder = out.split_off(dividend.len());
-		(out, remainder)
-	}
-
-	/// Modular exponentiation.
-	///
-	/// Computes `(base^exp) % modulus`.
-	/// This is a hint - a deterministic computation that happens only on the prover side.
-	/// The result should be additionally constrained using bignum circuits.
-	pub fn biguint_mod_pow_hint(&self, base: &[Wire], exp: &[Wire], modulus: &[Wire]) -> Vec<Wire> {
-		let inputs: Vec<Wire> = base.iter().chain(exp).chain(modulus).copied().collect();
-		self.call_hint(BigUintModPowHint::new(), &[base.len(), exp.len(), modulus.len()], &inputs)
-	}
-
-	/// Modular inverse.
-	///
-	/// Computes the modular inverse of `base` modulo `modulus`.
-	/// Returns a pair `(quotient, inverse)` where both numbers are Bézout coefficients when
-	/// `base` and `modulus` are coprime. Both numbers are set to zero if `gcd(base, modulus) > 1`.
-	///
-	/// This is a hint - a deterministic computation that happens only on the prover side.
-	/// The result should be additionally constrained by using bignum circuits to check that
-	/// `base * inverse = 1 + quotient * modulus`.
-	pub fn mod_inverse_hint(&self, base: &[Wire], modulus: &[Wire]) -> (Vec<Wire>, Vec<Wire>) {
-		let inputs: Vec<Wire> = base.iter().chain(modulus).copied().collect();
-		let mut out = self.call_hint(ModInverseHint::new(), &[base.len(), modulus.len()], &inputs);
-		let inverse = out.split_off(modulus.len());
-		(out, inverse)
-	}
-
-	/// Modular division.
-	///
-	/// Computes `dividend / divisor (mod modulus) = dividend * divisor^{-1} (mod modulus)`.
-	/// Returns a pair `(quotient, slope)` where `slope` is the modular quotient and `quotient`
-	/// is the non-negative integer satisfying `slope * divisor = dividend + quotient * modulus`.
-	/// Both are set to zero when `divisor` is not invertible modulo `modulus` (e.g. `divisor ==
-	/// 0`).
-	///
-	/// This is a hint - a deterministic computation that happens only on the prover side.
-	/// The result should be additionally constrained by using bignum circuits to check that
-	/// `slope * divisor = dividend + quotient * modulus`.
-	pub fn mod_divide_hint(
-		&self,
-		dividend: &[Wire],
-		divisor: &[Wire],
-		modulus: &[Wire],
-	) -> (Vec<Wire>, Vec<Wire>) {
-		let inputs: Vec<Wire> = dividend
-			.iter()
-			.chain(divisor)
-			.chain(modulus)
-			.copied()
-			.collect();
-		let mut out = self.call_hint(
-			ModDivideHint::new(),
-			&[dividend.len(), divisor.len(), modulus.len()],
-			&inputs,
-		);
-		let slope = out.split_off(modulus.len());
-		(out, slope)
-	}
-
-	/// Secp256k1 endomorphism split
-	///
-	/// The curve has an endomorphism `λ (x, y) = (βx, y)` where `λ³=1 (mod n)`
-	/// and `β³=1 (mod p)` (`n` being the scalar field modulus and `p` coordinate field one).
-	///
-	/// For a 256-bit scalar `k` it is possible to split it into `k1` and `k2` such that
-	/// `k1 + λ k2 = k (mod n)` and both `k1` and `k2` are no farther than `2^128` from zero.
-	///
-	/// The `k` scalar is represented by four 64-bit limbs in little endian order. The return value
-	/// is quadruple of `(k1_neg, k2_neg, k1_abs, k2_abs)` where `k1_neg` and `k2_neg` are
-	/// MSB-bools indicating whether `k1_abs` or `k2_abs`, respectively, should be negated.
-	/// `k1_abs` and `k2_abs` are at most 128 bits and are represented with two 64-bit limbs.
-	/// When `k` cannot be represented in this way (any valid scalar can, so it has to be modulus
-	/// or above), both `k1_abs` and `k2_abs` are assigned zero values.
-	///
-	/// This is a hint - a deterministic computation that happens only on the prover side.
-	/// The result should be additionally constrained by using bignum circuits to check that
-	/// `k1 + λ k2 = k (mod n)`.
-	pub fn secp256k1_endomorphism_split_hint(
-		&self,
-		k: &[Wire],
-	) -> (Wire, Wire, [Wire; 2], [Wire; 2]) {
-		assert_eq!(k.len(), 4);
-		let out = self.call_hint(Secp256k1EndosplitHint::new(), &[], k);
-		let [k1_neg, k2_neg, k1_abs0, k1_abs1, k2_abs0, k2_abs1] = out.as_slice() else {
-			panic!("Secp256k1EndosplitHint must return 6 wires");
-		};
-		(*k1_neg, *k2_neg, [*k1_abs0, *k1_abs1], [*k2_abs0, *k2_abs1])
 	}
 }

--- a/crates/frontend/src/compiler/tests.rs
+++ b/crates/frontend/src/compiler/tests.rs
@@ -4,7 +4,12 @@ use proptest::prelude::*;
 use rand::{RngExt, SeedableRng, rngs::StdRng};
 
 use super::*;
-use crate::util::num_biguint_from_u64_limbs;
+use crate::{
+	compiler::hints::{
+		BigUintDivideHint, BigUintModPowHint, ModInverseHint, Secp256k1EndosplitHint,
+	},
+	util::num_biguint_from_u64_limbs,
+};
 
 #[test]
 fn test_icmp_ult() {
@@ -111,7 +116,7 @@ fn test_biguint_divide_hint() {
 
 	let m = builder.add_constant_64(u64::MAX - 4);
 
-	let (q, r) = builder.biguint_divide_hint(&[d0, d1], &[m]);
+	let (q, r) = BigUintDivideHint::call(&builder, &[d0, d1], &[m]);
 
 	let circuit = builder.build();
 	let mut w = circuit.new_witness_filler();
@@ -135,7 +140,7 @@ fn test_biguint_divide_hint_div_by_zero() {
 	let m0 = builder.add_constant_64(0);
 	let m1 = builder.add_constant_64(0);
 
-	let (q, r) = builder.biguint_divide_hint(&[d0, d1], &[m0, m1]);
+	let (q, r) = BigUintDivideHint::call(&builder, &[d0, d1], &[m0, m1]);
 
 	let circuit = builder.build();
 	let mut w = circuit.new_witness_filler();
@@ -155,7 +160,7 @@ fn test_mod_pow_hint() {
 	let builder = CircuitBuilder::new();
 
 	let c = builder.add_constant_64(0x123456789abcdef0);
-	let modpow = builder.biguint_mod_pow_hint(&[c], &[c, c], &[c, c, c]);
+	let modpow = BigUintModPowHint::call(&builder, &[c], &[c, c], &[c, c, c]);
 
 	let circuit = builder.build();
 	let mut w = circuit.new_witness_filler();
@@ -177,7 +182,7 @@ fn test_mod_inverse_hint() {
 	let m0 = builder.add_constant_64(u64::MAX);
 	let m1 = builder.add_constant_64((1u64 << 63) - 1);
 
-	let (quotient, inverse) = builder.mod_inverse_hint(&[b], &[m0, m1]);
+	let (quotient, inverse) = ModInverseHint::call(&builder, &[b], &[m0, m1]);
 
 	let circuit = builder.build();
 	let mut w = circuit.new_witness_filler();
@@ -202,7 +207,7 @@ fn test_mod_inverse_hint_non_coprime() {
 	let m0 = builder.add_constant_64(0xfffffffffff80001);
 	let m1 = builder.add_constant_64(0x3ffff7ffffffffff);
 
-	let (quotient, inverse) = builder.mod_inverse_hint(&[b], &[m0, m1]);
+	let (quotient, inverse) = ModInverseHint::call(&builder, &[b], &[m0, m1]);
 
 	let circuit = builder.build();
 	let mut w = circuit.new_witness_filler();
@@ -397,7 +402,7 @@ proptest! {
 		let builder = CircuitBuilder::new();
 		let k = k.map(|limb| builder.add_constant_64(limb));
 		let (k1_neg, k2_neg, k1_abs, k2_abs) =
-			builder.secp256k1_endomorphism_split_hint(&k);
+			Secp256k1EndosplitHint::call(&builder, &k);
 
 		let circuit = builder.build();
 		let mut w = circuit.new_witness_filler();


### PR DESCRIPTION
Implements [BINIUS-226](https://linear.app/jimpo/issue/BINIUS-226/remove-special-hint-methods-from-circuitbuilder).

`CircuitBuilder` carried five special hint-calling convenience methods. Each was a thin wrapper that flattened its `&[Wire]` arguments, invoked the generic `CircuitBuilder::call_hint`, and reshaped the result. This moves that logic onto the `Hint` impl structs themselves (per the issue), so `CircuitBuilder`'s surface shrinks to the single low-level `call_hint` entry point.

Two commits:

## 1. Add `call` associated functions to hint structs

Each hint struct gains a `pub fn call(builder: &CircuitBuilder, ..) -> ..` associated function holding the exact wrap/reshape logic the old method had (matching the issue's `BigUintModPowHint::call` sketch):

| struct | signature |
|---|---|
| `BigUintDivideHint` | `call(builder, dividend, divisor) -> (Vec<Wire>, Vec<Wire>)` |
| `BigUintModPowHint` | `call(builder, base, exp, modulus) -> Vec<Wire>` |
| `ModInverseHint` | `call(builder, base, modulus) -> (Vec<Wire>, Vec<Wire>)` |
| `ModDivideHint` | `call(builder, dividend, divisor, modulus) -> (Vec<Wire>, Vec<Wire>)` |
| `Secp256k1EndosplitHint` | `call(builder, k) -> (Wire, Wire, [Wire; 2], [Wire; 2])` |

Additive only — no callers yet. Each hint's rich doc comment moves onto its `call`.

## 2. Remove the wrapper methods from CircuitBuilder, migrate callers

Deletes the five `*_hint` methods (`biguint_divide_hint`, `biguint_mod_pow_hint`, `mod_inverse_hint`, `mod_divide_hint`, `secp256k1_endomorphism_split_hint`) and repoints all callers from `builder.foo_hint(..)` to `FooHint::call(builder, ..)` — 6 production/example sites (in `binius-circuits`/`binius-examples`) and 6 frontend tests, plus one doc-comment reference.

## Notes

- **Behavior-preserving relocation.** Return shapes and reshaping are unchanged, so every call site is a mechanical rewrite. `CircuitBuilder::call_hint` was already `pub`, so **no visibility changes were needed**.
- `ByteVecConcatHint` / `Sha256CompressHint` / `Blake3CompressHint` never had wrapper methods (already invoked via `call_hint` directly), so they're untouched.

## Validation

- `cargo test -p binius-frontend` (150 + 2, incl. the migrated hint tests) and `cargo test -p binius-circuits --lib` for the affected modules (`bignum` 16 incl. `test_prime_field`/`test_prime_field_div`, `secp256k1` 3, `ecdsa` 6) — all pass.
- `cargo clippy -p binius-frontend -p binius-circuits -p binius-examples --all-targets -- -D warnings`, nightly `fmt --check`, `typos` — clean. The `basics_nondeterministic` tutorial example builds.
- Both commits are independently green and fmt-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)