### PR TITLE
Pin ShiftVariant to a one-byte repr(u8) discriminant

### DIFF
--- a/crates/core/src/constraint_system/shift.rs
+++ b/crates/core/src/constraint_system/shift.rs
@@ -8,43 +8,46 @@ use crate::word::Word;
 /// A different variants of shifting a value.
 ///
 /// Note that there is no shift left arithmetic because it is redundant.
+///
+/// The discriminant is stored in a single byte.
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(u8)]
 pub enum ShiftVariant {
 	/// Shift logical left.
-	Sll,
+	Sll = 0,
 	/// Shift logical right.
-	Slr,
+	Slr = 1,
 	/// Shift arithmetic right.
 	///
 	/// This is similar to the logical shift right but instead of shifting in 0 bits it will
 	/// replicate the sign bit.
-	Sar,
+	Sar = 2,
 	/// Rotate right.
 	///
 	/// Rotates bits to the right, with bits shifted off the right end wrapping around to the left.
-	Rotr,
+	Rotr = 3,
 	/// Shift logical left on 32-bit halves.
 	///
 	/// Performs independent logical left shifts on the upper and lower 32-bit halves of the word.
 	/// Only uses the lower 5 bits of the shift amount (0-31).
-	Sll32,
+	Sll32 = 4,
 	/// Shift logical right on 32-bit halves.
 	///
 	/// Performs independent logical right shifts on the upper and lower 32-bit halves of the word.
 	/// Only uses the lower 5 bits of the shift amount (0-31).
-	Srl32,
+	Srl32 = 5,
 	/// Shift arithmetic right on 32-bit halves.
 	///
 	/// Performs independent arithmetic right shifts on the upper and lower 32-bit halves of the
 	/// word. Sign extends each 32-bit half independently. Only uses the lower 5 bits of the shift
 	/// amount (0-31).
-	Sra32,
+	Sra32 = 6,
 	/// Rotate right on 32-bit halves.
 	///
 	/// Performs independent rotate right operations on the upper and lower 32-bit halves of the
 	/// word. Bits shifted off the right end wrap around to the left within each 32-bit half.
 	/// Only uses the lower 5 bits of the shift amount (0-31).
-	Rotr32,
+	Rotr32 = 7,
 }
 
 impl ShiftVariant {
@@ -81,17 +84,7 @@ impl ShiftVariant {
 
 impl SerializeBytes for ShiftVariant {
 	fn serialize(&self, write_buf: impl BufMut) -> Result<(), SerializationError> {
-		let index = match self {
-			ShiftVariant::Sll => 0u8,
-			ShiftVariant::Slr => 1u8,
-			ShiftVariant::Sar => 2u8,
-			ShiftVariant::Rotr => 3u8,
-			ShiftVariant::Sll32 => 4u8,
-			ShiftVariant::Srl32 => 5u8,
-			ShiftVariant::Sra32 => 6u8,
-			ShiftVariant::Rotr32 => 7u8,
-		};
-		index.serialize(write_buf)
+		(*self as u8).serialize(write_buf)
 	}
 }
 


### PR DESCRIPTION
Follow-up to a review comment on #1690: https://github.com/binius-zk/binius64/pull/1690#discussion_r3523133103

Pins the shift-variant enum's discriminant to one byte and folds the serialize path down to a single cast. No API change, no wire-format change — the serialized bytes are identical to today.

### The problem

#1690 shrank the shifted-operand term to 8 bytes by storing the shift amount in a single byte.

That 8-byte layout leans on the compiler *choosing* a one-byte discriminant for the shift-variant enum.

For a fieldless enum with 8 variants that is today's default — but it is not a layout guarantee, so the size win could silently regress on a future compiler.

### The idea

Make the one-byte discriminant a guarantee, not a default:

```
#[repr(u8)]
enum ShiftVariant { Sll = 0, Slr = 1, ..., Rotr32 = 7 }
```

- `#[repr(u8)]` fixes the discriminant width at one byte.
- The explicit `0..=7` values are exactly the existing wire encoding, so nothing about the serialized format moves.

With the discriminant pinned, the numeric value of each variant *is* its serialized byte, so the write path no longer needs a hand-written table:

```diff
-let index = match self {
-    ShiftVariant::Sll => 0u8,
-    ...
-    ShiftVariant::Rotr32 => 7u8,
-};
-index.serialize(write_buf)
+(*self as u8).serialize(write_buf)
```

The read path keeps its explicit match: it must validate an untrusted byte and reject anything outside `0..=7`, which a cast cannot do.

### Soundness

- Wire format is byte-for-byte identical: the discriminants equal the values the old match wrote, so `$0$` through `$7$` serialize exactly as before.
- No `SERIALIZATION_VERSION` bump and no reference-binary regeneration — the encoding did not change.
- Purely a layout annotation plus a mechanical rewrite of the write path; behavior is unchanged.

### Scope

- **changed:** the shift-variant enum gains `#[repr(u8)]` and explicit `0..=7` discriminants; the serialize impl collapses to one cast.
- **left untouched:** the deserialize match, the wire format, every construction and match site across the workspace.

### Verification

- `cargo check -p binius-core --all-targets`, `cargo clippy -p binius-core --all-targets`, `cargo +nightly fmt --check` — clean
- `cargo test -p binius-core --lib constraint_system::shift` — **5 passed**, including the round-trip test (which transitively pins the new cast against the deserialize match), the unknown-variant rejection, and the `size_of == 8` guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)
