### PR TITLE
Drop ValueVec::get/set in favor of typed ValueIndex indexing

### DIFF
--- a/crates/core/src/constraint_system/system.rs
+++ b/crates/core/src/constraint_system/system.rs
@@ -672,7 +672,7 @@ mod tests {
 		for i in 0..full_len {
 			// Deterministic pattern
 			let val = Word::from_u64(0xA5A5_5A5A ^ (i as u64 * 0x9E37_79B9));
-			values.set(i, val);
+			values[ValueIndex(i as u32)] = val;
 		}
 
 		// Split into public and non-public witnesses and serialize all artifacts
@@ -705,7 +705,11 @@ mod tests {
 		let scratch_start = layout.committed_total_len;
 		let scratch_end = scratch_start + layout.n_scratch;
 		for i in scratch_start..scratch_end {
-			assert_eq!(reconstructed.get(i), Word::ZERO, "scratch index {i} should be zero");
+			assert_eq!(
+				reconstructed[ValueIndex(i as u32)],
+				Word::ZERO,
+				"scratch index {i} should be zero"
+			);
 		}
 	}
 }

--- a/crates/core/src/constraint_system/value_vec.rs
+++ b/crates/core/src/constraint_system/value_vec.rs
@@ -133,20 +133,6 @@ impl ValueVec {
 		self.layout.committed_total_len
 	}
 
-	/// Returns the value stored at the given index.
-	///
-	/// Panics if the index is out of bounds. Will happily return a value from the padding section.
-	pub fn get(&self, index: usize) -> Word {
-		self.data[index]
-	}
-
-	/// Sets the value at the given index.
-	///
-	/// Panics if the index is out of bounds. Will gladly assign a value to the padding section.
-	pub fn set(&mut self, index: usize, value: Word) {
-		self.data[index] = value;
-	}
-
 	/// Returns the public portion of the values vector.
 	pub fn public(&self) -> &[Word] {
 		&self.data[..self.layout.offset_witness]
@@ -313,7 +299,7 @@ mod tests {
 
 			// The scratch tail past the committed words is zeroed and addressable.
 			for i in committed_total_len..committed_total_len + n_scratch {
-				prop_assert_eq!(vv.get(i), Word::ZERO);
+				prop_assert_eq!(vv[ValueIndex(i as u32)], Word::ZERO);
 			}
 		}
 	}

--- a/crates/core/src/verify.rs
+++ b/crates/core/src/verify.rs
@@ -4,7 +4,7 @@
 //! [value vector][`ValueVec`].
 
 use crate::{
-	constraint_system::{AndConstraint, ConstraintSystem, MulConstraint, ValueVec},
+	constraint_system::{AndConstraint, ConstraintSystem, MulConstraint, ValueIndex, ValueVec},
 	word::Word,
 };
 
@@ -55,7 +55,7 @@ pub fn verify_constraints(cs: &ConstraintSystem, witness: &ValueVec) -> Result<(
 
 	// First check that the witness correctly populated the constants section.
 	for (index, constant) in cs.constants.iter().enumerate() {
-		if witness.get(index) != *constant {
+		if witness[ValueIndex(index as u32)] != *constant {
 			return Err(format!(
 				"Constant at index {index} does not match expected value {:016x} in value vec",
 				constant.as_u64()

--- a/crates/frontend/src/compiler/circuit.rs
+++ b/crates/frontend/src/compiler/circuit.rs
@@ -141,7 +141,7 @@ impl Circuit {
 	pub fn populate_wire_witness(&self, w: &mut WitnessFiller) -> Result<(), PopulateError> {
 		// Fill the constant part from the witness.
 		for (index, constant) in self.constraint_system.constants.iter().enumerate() {
-			w.value_vec.set(index, *constant);
+			w.value_vec[ValueIndex(index as u32)] = *constant;
 		}
 
 		// Execute the evaluation form - it modifies the ValueVec in place

--- a/crates/frontend/src/compiler/eval_form/const_eval.rs
+++ b/crates/frontend/src/compiler/eval_form/const_eval.rs
@@ -56,7 +56,7 @@ fn setup_value_vec(shape: &OpcodeShape, concrete_inputs: &[Word], wire_count: u3
 		.chain(concrete_inputs.iter())
 		.enumerate()
 	{
-		value_vec.set(i, const_val);
+		value_vec[ValueIndex(i as u32)] = const_val;
 	}
 
 	value_vec

--- a/crates/frontend/src/compiler/eval_form/interpreter.rs
+++ b/crates/frontend/src/compiler/eval_form/interpreter.rs
@@ -530,7 +530,7 @@ impl<'a> Interpreter<'a> {
 	}
 
 	fn store(&self, ctx: &mut ExecutionContext<'_>, reg: u32, value: Word) {
-		ctx.value_vec.set(reg as usize, value);
+		ctx.value_vec[ValueIndex(reg)] = value;
 	}
 
 	// Bytecode reading helpers


### PR DESCRIPTION
@jimpo This looks like a duplicate, feel free to close if you think that both the variants are useful :) 

Removes a redundant pair of accessors on the value vector. Pure refactor — no behavior change, no protocol change.

### The problem

`ValueVec` exposed two parallel ways to reach a word by position:

- `get(usize)` / `set(usize)` — take a raw `usize`, return/take `Word` by value.
- `Index<ValueIndex>` / `IndexMut<ValueIndex>` — key on the `ValueIndex` newtype, hand back `&Word` / `&mut Word`.

Both bottom out in the exact same buffer access with the same panic-on-out-of-bounds behavior, so the pair is redundant.

Worse, the two were used inconsistently — some code wrote a buffer through the `usize` path and read it back through the typed one:

```rust
value_vec.set(i, const_val);            // write: raw usize
... value_vec[ValueIndex(i as u32)]     // read:  typed index
```

### The idea

Keep one accessor, and make it the typed one.

The direction is not symmetric — it has to collapse onto `ValueIndex` indexing:

- **`Index<ValueIndex>` is load-bearing.** The constraint-evaluation hot path already reads through it (`witness[self.value_index]`), and it keys on the newtype that exists precisely to stop a value-vector position being confused with any other integer.
- **`IndexMut` subsumes `set`.** It hands out `&mut Word`, so it does everything `set`'s wholesale overwrite did and more.
- **`get` buys nothing over `Index`.** `Word` is `Copy`, so `let w = vv[idx];` copies out just the same.
- **The `usize` surface was a footgun.** A real value index is a `u32`; the `usize` accessors let you name positions a `ValueIndex` could not even represent.

### The change

```diff
-pub fn get(&self, index: usize) -> Word { self.data[index] }
-pub fn set(&mut self, index: usize, value: Word) { self.data[index] = value; }
```

Call sites holding a raw `usize` now wrap it explicitly, making "this integer indexes the value vector" visible at the point of use:

```diff
-value_vec.set(i, const_val);
+value_vec[ValueIndex(i as u32)] = const_val;
```

One nice side effect: the interpreter's `store` now mirrors its own `load` exactly — both go through `ctx.value_vec[ValueIndex(reg)]`.

### Scope

- **removed:** `ValueVec::get` and `ValueVec::set`.
- **migrated (6 sites):** `verify.rs` and `system.rs` (core), `circuit.rs`, `const_eval.rs`, `interpreter.rs` (frontend).
- **untouched:** the `Index` / `IndexMut` impls, the buffer, and every other accessor.

### Soundness

- Pure refactor: the migrated expressions compile to the same buffer access as before.
- Panic-on-out-of-bounds behavior is identical — both paths index the same underlying slice.
- No wire format, no protocol, no serialized artifact is affected.

### Verification

- `cargo check -p binius-core -p binius-frontend --all-targets`, `cargo clippy` on both, `cargo +nightly fmt --all --check` — clean
- `cargo test -p binius-core --lib` — **71 passed**; `cargo test -p binius-frontend` — **150 + 2 passed**

Note: `cargo check --workspace --all-targets` currently reports 4 pre-existing errors in `crates/verifier/` (lifetime and type-mismatch in `intmul/verify.rs`, `verify.rs`, `zk_config.rs`) under the feature-unified build. These reproduce identically on a clean `main` and are unrelated to this change — the crates touched here build and test clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
