### PR TITLE
BINIUS-213: parallel Blake3 compression for batched Merkle inner-node folding

### DIFF
--- a/crates/hash/Cargo.toml
+++ b/crates/hash/Cargo.toml
@@ -26,6 +26,7 @@ tracing.workspace = true
 
 [dev-dependencies]
 criterion.workspace = true
+proptest.workspace = true
 rand = { workspace = true, features = ["thread_rng"] }
 
 [features]

--- a/crates/hash/src/blake3.rs
+++ b/crates/hash/src/blake3.rs
@@ -5,8 +5,9 @@
 use digest::Output;
 
 use super::{
-	binary_merkle_tree::HashSuite, blake3_portable::PortableBlake3ParallelDigest,
-	compress::CompressionFunction, parallel_compression::ParallelCompressionAdaptor,
+	binary_merkle_tree::HashSuite,
+	blake3_portable::{PortableBlake3ParallelCompression, PortableBlake3ParallelDigest},
+	compress::CompressionFunction,
 };
 
 /// A two-to-one compression function that hashes the concatenation of its inputs with Blake3.
@@ -24,13 +25,12 @@ impl CompressionFunction<Output<blake3::Hasher>, 2> for Blake3Compression {
 
 /// Blake3 [`HashSuite`]: Blake3 leaves and a Blake3 compression function for inner nodes.
 ///
-/// Every leaf digest is a standard Blake3 hash; only the parallel compute path is specialized.
-/// - Leaves within one 1024-byte chunk are hashed by the portable auto-vectorized batch kernel.
+/// Both parallel compute paths use the portable auto-vectorized kernel, not the scalar loop:
+/// - Leaves within one 1024-byte chunk are hashed by the batch kernel.
 /// - Larger leaves fall back to the scalar adapter that walks the tree.
+/// - Every inner-node level folds its node pairs through the batched two-to-one compression.
 ///
-/// The speedup is confined to the sub-chunk regime the ZK leaf-hashing path exercises.
-///
-/// The batch width is fixed at 16 lanes:
+/// The batch width is fixed at 16 lanes for both paths:
 /// - The throughput sweet spot on NEON in the portable-kernel benchmark.
 /// - The width the AVX2 / AVX-512 vectorizer fills.
 /// - 4 and 8 lanes both measure slower.
@@ -41,7 +41,7 @@ impl HashSuite for Blake3HashSuite {
 	type LeafHash = blake3::Hasher;
 	type Compression = Blake3Compression;
 	type ParLeafHash = PortableBlake3ParallelDigest<16>;
-	type ParCompression = ParallelCompressionAdaptor<Blake3Compression>;
+	type ParCompression = PortableBlake3ParallelCompression<16>;
 }
 
 #[cfg(test)]

--- a/crates/hash/src/blake3_portable.rs
+++ b/crates/hash/src/blake3_portable.rs
@@ -1,6 +1,10 @@
 // Copyright 2026 The Binius Developers
 
-//! Experimental portable, auto-vectorized Blake3 multi-lane leaf hasher.
+//! Experimental portable, auto-vectorized Blake3 multi-lane kernel.
+//!
+//! Two batched entry points share one block-compression core:
+//! - Leaf hashing, for any message up to one 1024-byte chunk.
+//! - Two-to-one inner-node compression, `blake3(left || right)` over a 64-byte pair.
 //!
 //! An alternative to driving the `blake3` crate's hand-written SIMD kernel.
 //! The bet: LLVM auto-vectorizes plain lane loops into whatever the target has.
@@ -19,12 +23,22 @@
 
 use std::{array, mem::MaybeUninit};
 
-use binius_utils::{FixedSizeSerializeBytes, SerializeBytes, rayon::iter::IndexedParallelIterator};
+use binius_utils::{
+	FixedSizeSerializeBytes, SerializeBytes,
+	rayon::{
+		iter::{IndexedParallelIterator, ParallelIterator},
+		slice::{ParallelSlice, ParallelSliceMut},
+	},
+};
 use blake3::{BLOCK_LEN, CHUNK_LEN, OUT_LEN};
 use digest::Output;
 
-use super::parallel_digest::{
-	MultiDigest, ParallelDigest, ParallelDigestAdapter, ParallelMultidigestImpl,
+use super::{
+	blake3::Blake3Compression,
+	parallel_compression::ParallelPseudoCompression,
+	parallel_digest::{
+		MultiDigest, ParallelDigest, ParallelDigestAdapter, ParallelMultidigestImpl,
+	},
 };
 
 /// Blake3 domain-separation flag marking the first block of a chunk.
@@ -178,6 +192,16 @@ fn broadcast_iv<const N: usize>() -> [[u32; N]; 8] {
 	array::from_fn(|w| [IV[w]; N])
 }
 
+/// Serializes one lane's eight-word chaining value into its 32-byte little-endian digest.
+#[inline(always)]
+fn serialize_cv_lane<const N: usize>(cv: &[[u32; N]; 8], lane: usize) -> [u8; OUT_LEN] {
+	let mut digest = [0u8; OUT_LEN];
+	for (w, chunk) in digest.chunks_exact_mut(4).enumerate() {
+		chunk.copy_from_slice(&cv[w][lane].to_le_bytes());
+	}
+	digest
+}
+
 /// Portable multi-lane Blake3 leaf digest over `N` messages, hashed a block at a time.
 ///
 /// One chunk, so the chaining value stays at counter 0 and needs no CV stack.
@@ -245,11 +269,7 @@ impl<const N: usize> PortableBlake3MultiDigest<N> {
 
 		// Serialize each lane's eight-word chaining value into its 32-byte digest.
 		for lane in 0..N {
-			let mut digest = [0u8; OUT_LEN];
-			for (w, chunk) in digest.chunks_exact_mut(4).enumerate() {
-				chunk.copy_from_slice(&cv[w][lane].to_le_bytes());
-			}
-			out[lane].write(digest.into());
+			out[lane].write(serialize_cv_lane(&cv, lane).into());
 		}
 	}
 }
@@ -360,14 +380,148 @@ impl<const LANES: usize> ParallelDigest for PortableBlake3ParallelDigest<LANES> 
 	}
 }
 
+/// Folds up to `N` node pairs with a single batched Blake3 block compression.
+///
+/// Each pair is a 64-byte concatenation `left || right` of two 32-byte digests.
+/// That 64-byte message is exactly one Blake3 block.
+/// A one-block message makes its single block the first, last, and root block at once:
+/// - counter   = 0       (a single chunk).
+/// - block_len = 64      (a full block).
+/// - flags     = CHUNK_START | CHUNK_END | ROOT.
+///
+/// Folds `out.len()` pairs, which must be at most `N`.
+/// `inputs.len()` must be `2 * out.len()`.
+/// A partial batch leaves the unused high lanes zero.
+/// Their output is never read.
+#[inline]
+fn compress_node_pairs<const N: usize>(
+	inputs: &[Output<blake3::Hasher>],
+	out: &mut [MaybeUninit<Output<blake3::Hasher>>],
+) {
+	// Pack each pair into one 64-byte block: bytes 0..32 = left child, 32..64 = right child.
+	let mut blocks = [[0u8; BLOCK_LEN]; N];
+	for (lane, block) in blocks.iter_mut().enumerate().take(out.len()) {
+		block[..OUT_LEN].copy_from_slice(inputs[2 * lane].as_slice());
+		block[OUT_LEN..].copy_from_slice(inputs[2 * lane + 1].as_slice());
+	}
+
+	// One block compression seeded from the IV yields each pair's two-to-one digest.
+	let m = load_block_words(&blocks);
+	let mut cv = broadcast_iv::<N>();
+	compress_block(&mut cv, &m, 0, BLOCK_LEN as u32, CHUNK_START | CHUNK_END | ROOT);
+
+	for (lane, slot) in out.iter_mut().enumerate() {
+		slot.write(serialize_cv_lane(&cv, lane).into());
+	}
+}
+
+/// Parallel Blake3 two-to-one compression backed by the portable auto-vectorized kernel.
+///
+/// The Merkle inner-node counterpart to the leaf digest [`PortableBlake3ParallelDigest`].
+/// Every parent folds a pair of 32-byte child digests as `blake3(left || right)`.
+/// A batch of `LANES` node pairs is a fixed-length batched Blake3 over 64-byte messages.
+/// Each batch runs through the shared block-compression core in one pass.
+///
+/// Output is bit-identical to the scalar [`Blake3Compression`], pinned to it in tests.
+#[derive(Debug, Clone, Default)]
+pub struct PortableBlake3ParallelCompression<const LANES: usize> {
+	/// The scalar two-to-one function this batched path reproduces, exposed via `compression()`.
+	compression: Blake3Compression,
+}
+
+impl<const LANES: usize> ParallelPseudoCompression<Output<blake3::Hasher>, 2>
+	for PortableBlake3ParallelCompression<LANES>
+{
+	type Compression = Blake3Compression;
+
+	fn compression(&self) -> &Self::Compression {
+		&self.compression
+	}
+
+	fn parallel_compress(
+		&self,
+		inputs: &[Output<blake3::Hasher>],
+		out: &mut [MaybeUninit<Output<blake3::Hasher>>],
+	) {
+		assert_eq!(inputs.len(), 2 * out.len(), "Input length must be 2 * output length");
+
+		// Fold `LANES` pairs per batch.
+		// A shorter trailing batch is fine: the kernel only reads its valid lanes.
+		inputs
+			.par_chunks(2 * LANES)
+			.zip(out.par_chunks_mut(LANES))
+			.for_each(|(in_batch, out_batch)| compress_node_pairs::<LANES>(in_batch, out_batch));
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use std::iter::repeat_with;
 
 	use binius_utils::rayon::iter::{IntoParallelRefIterator, ParallelIterator};
+	use proptest::prelude::*;
 	use rand::{Rng, SeedableRng, rngs::StdRng};
 
-	use super::*;
+	use super::{super::compress::CompressionFunction, *};
+
+	/// Folds `pairs` through the `N`-lane portable compression.
+	/// Pins every output bit-identical to the scalar [`Blake3Compression`].
+	fn check_parallel_compression<const N: usize>(pairs: &[[[u8; OUT_LEN]; 2]]) {
+		// Flatten pairs to the `[left_0, right_0, left_1, ...]` layout the compressor reads.
+		let inputs: Vec<Output<blake3::Hasher>> = pairs
+			.iter()
+			.flat_map(|[l, r]| [(*l).into(), (*r).into()])
+			.collect();
+		let mut out = repeat_with(MaybeUninit::<Output<blake3::Hasher>>::uninit)
+			.take(pairs.len())
+			.collect::<Vec<_>>();
+
+		PortableBlake3ParallelCompression::<N>::default().parallel_compress(&inputs, &mut out);
+
+		// Invariant: each batched lane equals the scalar two-to-one of the same pair.
+		for (slot, [l, r]) in out.into_iter().zip(pairs) {
+			let expected = Blake3Compression.compress([(*l).into(), (*r).into()]);
+			assert_eq!(unsafe { slot.assume_init() }.as_slice(), expected.as_slice());
+		}
+	}
+
+	#[test]
+	fn test_parallel_compression_boundaries() {
+		// Extreme digests exercise all-zero and all-ones message blocks in every left/right slot.
+		let zero = [0u8; OUT_LEN];
+		let ones = [0xffu8; OUT_LEN];
+		check_parallel_compression::<16>(&[[zero, zero], [ones, ones], [zero, ones], [ones, zero]]);
+
+		// Counts straddling the 16-lane batch boundary: empty, single, full, full+1, multi+partial.
+		let mut rng = StdRng::seed_from_u64(7);
+		for count in [0usize, 1, 15, 16, 17, 33] {
+			let pairs: Vec<[[u8; OUT_LEN]; 2]> = (0..count)
+				.map(|_| {
+					let mut pair = [[0u8; OUT_LEN]; 2];
+					rng.fill_bytes(&mut pair[0]);
+					rng.fill_bytes(&mut pair[1]);
+					pair
+				})
+				.collect();
+			check_parallel_compression::<16>(&pairs);
+		}
+	}
+
+	proptest! {
+		#[test]
+		fn parallel_compression_matches_scalar(
+			pairs in prop::collection::vec(
+				(prop::array::uniform32(any::<u8>()), prop::array::uniform32(any::<u8>())),
+				0..40usize,
+			),
+		) {
+			// The batch path is bit-identical to the scalar reference, at every vectorizer width.
+			let pairs: Vec<[[u8; OUT_LEN]; 2]> = pairs.into_iter().map(|(l, r)| [l, r]).collect();
+			check_parallel_compression::<4>(&pairs);
+			check_parallel_compression::<8>(&pairs);
+			check_parallel_compression::<16>(&pairs);
+		}
+	}
 
 	/// Runs `N` equal-length messages of `len` bytes through the portable batch and pins each lane
 	/// to the scalar reference.


### PR DESCRIPTION
Closes [BINIUS-213](https://linear.app/jimpo/issue/BINIUS-213).

Folds many Merkle inner nodes at once through the portable auto-vectorized Blake3 kernel, instead of hashing one node pair at a time.
Output is bit-identical to the scalar compression — no protocol change.

### The problem

[BINIUS-206](https://linear.app/jimpo/issue/BINIUS-206) gave the Blake3 *leaf* path a real vectorized kernel.
The *inner-node* path did not get the same treatment.

The suite folded every tree level above the leaves with a scalar loop:

```rust
type ParCompression = ParallelCompressionAdaptor<Blake3Compression>;
```

`ParallelCompressionAdaptor` calls the one-node-at-a-time `Blake3Compression` once per node pair.
So every level above the leaves was hashed serially per node, even though the leaves below were batched.

### The idea

Each inner node is a two-to-one Blake3 of a 64-byte concatenation `left || right`.
A 64-byte message is *exactly one Blake3 block*, and that single block is the whole chunk.
So a batch of node pairs is a fixed-length batched Blake3 — the same shape the leaf kernel already handles.

Fold `LANES` pairs at once through the shared block-compression core, with the flags a single-block chunk carries:

```
counter   = 0
block_len = 64
flags     = CHUNK_START | CHUNK_END | ROOT
```

### Per tree level

- **before:** one scalar Blake3 compression per node pair.
- **after:** one batched block compression per `LANES` node pairs, the lane loops auto-vectorized to NEON / AVX2 / AVX-512.

→ ~2.8× on the folding step at 16 lanes (see Benchmark).

### The change

```
Blake3HashSuite:
- type ParCompression = ParallelCompressionAdaptor<Blake3Compression>;   // scalar loop, one node at a time
+ type ParCompression = PortableBlake3ParallelCompression<16>;           // batched, auto-vectorized
```

The new `PortableBlake3ParallelCompression<LANES>` reuses the leaf kernel's private block-compression core (message load, block compression, IV broadcast).
No new hashing code, no intrinsics, no `unsafe`.

### Soundness

- The digest is bit-identical to the scalar `Blake3Compression`, byte for byte.
- A proptest pins the batched path equal to the scalar reference at lane widths 4, 8, and 16, over random pairs.
- A boundary test covers all-zero and all-ones digests, and batch counts straddling the 16-lane edge (0, 1, 15, 16, 17, 33), including partial trailing batches.

### Scope

- **new:** `PortableBlake3ParallelCompression<LANES>` and its batched fold, in `crates/hash/src/blake3_portable.rs`.
- **changed:** the suite's `ParCompression` in `crates/hash/src/blake3.rs`; factored a shared chaining-value serializer used by both the leaf and inner-node paths.
- **left untouched:** the scalar `Blake3Compression` (still the reference), the leaf path, and the SHA-256 suite.

### Verification

- nightly `cargo fmt`, `cargo clippy -p binius-hash --all-targets` — clean.
- `cargo test -p binius-hash` — 15 pass, including the new proptest and boundary test.

### Benchmark

One Merkle level, $2^{16}$ parents folded from $2^{17}$ child digests, same machine and input pool in one run.

| path | time | throughput | vs. scalar |
|---|---|---|---|
| `adapter` (scalar loop, baseline) | 7.91 ms | 505 MiB/s | 1.00× |
| `portable_4` | 6.62 ms | 605 MiB/s | 1.20× |
| `portable_8` | 7.92 ms | 505 MiB/s | 1.00× |
| **`portable_16` (wired in)** | **2.86 ms** | **1.36 GiB/s** | **2.77×** |

16 lanes is the clear winner — the same sweet spot the leaf kernel found, which is why the suite uses width 16.
`portable_8` happens to land right at the scalar baseline on this machine, but 16 wins decisively.

<details>
<summary>Benchmark code — not committed (this run's numbers are above); drop into <code>crates/hash/benches/</code> to reproduce</summary>

Add to `crates/hash/Cargo.toml`:

```toml
[[bench]]
name = "blake3_compression"
harness = false
```

`crates/hash/benches/blake3_compression.rs`:

```rust
// Copyright 2026 The Binius Developers

//! Compares Blake3 two-to-one inner-node compression over one Merkle level:
//! - the scalar per-node `ParallelCompressionAdaptor<Blake3Compression>` (the baseline on `main`),
//! - the portable auto-vectorized batched compression at several lane widths.
//!
//! Each fold is `blake3(left || right)` over a 64-byte pair of child digests.

use std::{hint::black_box, mem::MaybeUninit};

use binius_hash::{
    Blake3Compression, ParallelCompressionAdaptor, ParallelPseudoCompression,
    blake3_portable::PortableBlake3ParallelCompression,
};
use criterion::{Criterion, Throughput, criterion_group, criterion_main};
use digest::Output;
use rand::{Rng, rng};

/// Inner nodes folded per iteration: one Merkle level of 2^16 parents from 2^17 children.
const N_NODES: usize = 1 << 16;

/// Builds `n` random 32-byte child digests to fold.
fn random_digests(n: usize) -> Vec<Output<blake3::Hasher>> {
    let mut rng = rng();
    (0..n)
        .map(|_| {
            let mut digest = [0u8; 32];
            rng.fill_bytes(&mut digest);
            digest.into()
        })
        .collect()
}

/// Folds `inputs` (`2 * out.len()` children) into `out.len()` parents with `compression`.
fn run<C: ParallelPseudoCompression<Output<blake3::Hasher>, 2>>(
    compression: &C,
    inputs: &[Output<blake3::Hasher>],
    out: &mut [MaybeUninit<Output<blake3::Hasher>>],
) {
    compression.parallel_compress(black_box(inputs), out);
}

fn bench_compression(c: &mut Criterion) {
    // One fixed pool of children, reused for every path: 2 * N_NODES digests -> N_NODES parents.
    let inputs = random_digests(2 * N_NODES);

    // The candidate compressions: the scalar baseline and the portable kernel at three widths.
    let adapter = ParallelCompressionAdaptor::new(Blake3Compression);
    let portable4 = PortableBlake3ParallelCompression::<4>::default();
    let portable8 = PortableBlake3ParallelCompression::<8>::default();
    let portable16 = PortableBlake3ParallelCompression::<16>::default();

    // Output buffer allocated once, so the measurement excludes allocation.
    let mut out: Vec<Output<blake3::Hasher>> = Vec::with_capacity(N_NODES);

    let mut group = c.benchmark_group("blake3_compression");
    // Each parent reads 64 bytes.
    // Account throughput against the folded child bytes.
    group.throughput(Throughput::Bytes((2 * N_NODES * 32) as u64));

    group.bench_function("adapter", |b| {
        b.iter(|| run(&adapter, &inputs, &mut out.spare_capacity_mut()[..N_NODES]));
    });
    group.bench_function("portable_4", |b| {
        b.iter(|| run(&portable4, &inputs, &mut out.spare_capacity_mut()[..N_NODES]));
    });
    group.bench_function("portable_8", |b| {
        b.iter(|| run(&portable8, &inputs, &mut out.spare_capacity_mut()[..N_NODES]));
    });
    group.bench_function("portable_16", |b| {
        b.iter(|| run(&portable16, &inputs, &mut out.spare_capacity_mut()[..N_NODES]));
    });
    group.finish();
}

criterion_group!(benches, bench_compression);
criterion_main!(benches);
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)