### PR TITLE
Replace Underlier::zero() with a ZERO associated constant

### DIFF
--- a/crates/arith-bench/benches/field_mul.rs
+++ b/crates/arith-bench/benches/field_mul.rs
@@ -34,7 +34,7 @@ fn run_google_mul_benchmark<U, R>(
 	const N: usize = 64;
 
 	let x = U::random(rng);
-	let mut y = [U::zero(); N];
+	let mut y = [U::ZERO; N];
 
 	// Calculate throughput based on elements per underlier
 	let elements_per_underlier = U::BITS / element_bits;

--- a/crates/arith-bench/src/arch/aarch64.rs
+++ b/crates/arith-bench/src/arch/aarch64.rs
@@ -9,6 +9,8 @@ use crate::underlier::{PackedUnderlier, Underlier};
 
 impl Underlier for uint64x2_t {
 	const BITS: usize = 128;
+	// Safety: all-zero bytes are a valid bit pattern for every 128-bit SIMD register.
+	const ZERO: Self = unsafe { std::mem::transmute(0u128) };
 
 	#[inline]
 	fn and(a: Self, b: Self) -> Self {
@@ -18,11 +20,6 @@ impl Underlier for uint64x2_t {
 	#[inline]
 	fn xor(a: Self, b: Self) -> Self {
 		unsafe { veorq_u64(a, b) }
-	}
-
-	#[inline]
-	fn zero() -> Self {
-		unsafe { vdupq_n_u64(0) }
 	}
 
 	#[inline]
@@ -138,6 +135,8 @@ impl PackedUnderlier<u128> for uint64x2_t {
 
 impl Underlier for poly64x2_t {
 	const BITS: usize = 128;
+	// Safety: all-zero bytes are a valid bit pattern for every 128-bit SIMD register.
+	const ZERO: Self = unsafe { std::mem::transmute(0u128) };
 
 	#[inline]
 	fn and(a: Self, b: Self) -> Self {
@@ -151,11 +150,6 @@ impl Underlier for poly64x2_t {
 		unsafe {
 			vreinterpretq_p64_u64(veorq_u64(vreinterpretq_u64_p64(a), vreinterpretq_u64_p64(b)))
 		}
-	}
-
-	#[inline]
-	fn zero() -> Self {
-		unsafe { vreinterpretq_p64_p128(0u128) }
 	}
 
 	#[inline]
@@ -552,7 +546,7 @@ mod tests {
 			assert_eq!(vgetq_lane_u64(xor_result, 1), expected_xor_high);
 
 			// Test zero
-			let zero_result = <uint64x2_t as Underlier>::zero();
+			let zero_result = <uint64x2_t as Underlier>::ZERO;
 			assert_eq!(vgetq_lane_u64(zero_result, 0), 0);
 			assert_eq!(vgetq_lane_u64(zero_result, 1), 0);
 

--- a/crates/arith-bench/src/arch/x86_64.rs
+++ b/crates/arith-bench/src/arch/x86_64.rs
@@ -9,6 +9,8 @@ use crate::underlier::{PackedUnderlier, Underlier};
 #[cfg(target_feature = "sse2")]
 impl Underlier for __m128i {
 	const BITS: usize = 128;
+	// Safety: all-zero bytes are a valid bit pattern for every 128-bit SIMD register.
+	const ZERO: Self = unsafe { std::mem::transmute(0u128) };
 
 	#[inline]
 	fn and(a: Self, b: Self) -> Self {
@@ -18,11 +20,6 @@ impl Underlier for __m128i {
 	#[inline]
 	fn xor(a: Self, b: Self) -> Self {
 		unsafe { _mm_xor_si128(a, b) }
-	}
-
-	#[inline]
-	fn zero() -> Self {
-		unsafe { _mm_setzero_si128() }
 	}
 
 	#[inline]
@@ -216,6 +213,8 @@ impl crate::underlier::OpsClmul for __m128i {
 #[cfg(target_feature = "avx2")]
 impl Underlier for __m256i {
 	const BITS: usize = 256;
+	// Safety: all-zero bytes are a valid bit pattern for every 256-bit SIMD register.
+	const ZERO: Self = unsafe { std::mem::transmute([0u128; 2]) };
 
 	#[inline]
 	fn and(a: Self, b: Self) -> Self {
@@ -225,11 +224,6 @@ impl Underlier for __m256i {
 	#[inline]
 	fn xor(a: Self, b: Self) -> Self {
 		unsafe { _mm256_xor_si256(a, b) }
-	}
-
-	#[inline]
-	fn zero() -> Self {
-		unsafe { _mm256_setzero_si256() }
 	}
 
 	#[inline]
@@ -483,6 +477,8 @@ impl crate::underlier::OpsClmul for __m256i {
 #[cfg(target_feature = "avx512bw")]
 impl Underlier for __m512i {
 	const BITS: usize = 512;
+	// Safety: all-zero bytes are a valid bit pattern for every 512-bit SIMD register.
+	const ZERO: Self = unsafe { std::mem::transmute([0u128; 4]) };
 
 	#[inline]
 	fn and(a: Self, b: Self) -> Self {
@@ -492,11 +488,6 @@ impl Underlier for __m512i {
 	#[inline]
 	fn xor(a: Self, b: Self) -> Self {
 		unsafe { _mm512_xor_si512(a, b) }
-	}
-
-	#[inline]
-	fn zero() -> Self {
-		unsafe { _mm512_setzero_si512() }
 	}
 
 	#[inline]

--- a/crates/arith-bench/src/ghash/bit_sliced.rs
+++ b/crates/arith-bench/src/ghash/bit_sliced.rs
@@ -9,7 +9,7 @@ pub fn mul_naive<U>(x: [U; 128], y: [U; 128]) -> [U; 128]
 where
 	U: Underlier,
 {
-	let mut result = [U::zero(); 256];
+	let mut result = [U::ZERO; 256];
 	cmul_naive::<U, Level256>(&x, &y, &mut result);
 
 	reduce_bit_sliced(&mut result);
@@ -24,7 +24,7 @@ pub fn mul_katatsuba<U>(x: [U; 128], y: [U; 128]) -> [U; 128]
 where
 	U: Underlier,
 {
-	let mut result = [U::zero(); 256];
+	let mut result = [U::ZERO; 256];
 	cmul_karatsuba_impl::<U, Level256>(&x, &y, &mut result);
 
 	reduce_bit_sliced(&mut result);
@@ -108,7 +108,7 @@ impl Level for Level1 {
 	where
 		U: Underlier,
 	{
-		[U::zero(); Self::N]
+		[U::ZERO; Self::N]
 	}
 
 	#[inline]
@@ -158,7 +158,7 @@ macro_rules! define_level {
 			where
 				U: Underlier,
 			{
-				[U::zero(); Self::N]
+				[U::ZERO; Self::N]
 			}
 
 			#[inline]

--- a/crates/arith-bench/src/ghash/clmul.rs
+++ b/crates/arith-bench/src/ghash/clmul.rs
@@ -39,7 +39,7 @@ pub fn mul_inv_x<U: Underlier + OpsClmul + PackedUnderlier<u128>>(x: U) -> U {
 	// Carry bit 0 of the high qword into bit 63 of the low qword within each 128-bit lane.
 	// unpackhi gives us [hi_a, hi_b] from two inputs; with zero as second arg, this moves
 	// the high qword to the low position and zeros the high.
-	let carry = U::unpackhi_epi64(lsb_at_top, U::zero());
+	let carry = U::unpackhi_epi64(lsb_at_top, U::ZERO);
 	let shifted = U::xor(shifted, carry);
 
 	// Build a mask from the original LSB of each 128-bit element (bit 0 of the low qword).

--- a/crates/arith-bench/src/rijndael/russian_peasant.rs
+++ b/crates/arith-bench/src/rijndael/russian_peasant.rs
@@ -49,7 +49,7 @@ pub fn mul<U: RijndaelBytewise>(a: U, b: U) -> U {
 	// carries out of bit 7.
 	let poly = <U as PackedUnderlier<u8>>::broadcast(0x1b);
 
-	let mut r = U::zero();
+	let mut r = U::ZERO;
 	// MSB-first double-and-add. On step `k` we test bit `i = 7 - k` of `b`: shifting `b` left by
 	// `k` moves that bit into each byte's sign bit, so `sign_mask_epi8` broadcasts it to a
 	// full-byte mask.
@@ -158,8 +158,8 @@ mod tests {
 	/// oracle.
 	#[allow(dead_code)]
 	fn check<U: RijndaelBytewise>(a: &[u8], b: &[u8]) -> Result<(), TestCaseError> {
-		let mut pa = U::zero();
-		let mut pb = U::zero();
+		let mut pa = U::ZERO;
+		let mut pb = U::ZERO;
 		for (i, (&x, &y)) in a.iter().zip(b).enumerate() {
 			pa = pa.set(i, x);
 			pb = pb.set(i, y);

--- a/crates/arith-bench/src/test_utils.rs
+++ b/crates/arith-bench/src/test_utils.rs
@@ -19,8 +19,8 @@ where
 	U: PackedUnderlier<Inner>,
 	Inner: Underlier + std::fmt::Debug,
 {
-	let mut subject = U::zero();
-	let mut reference = vec![Inner::zero(); 1 << U::LOG_WIDTH];
+	let mut subject = U::ZERO;
+	let mut reference = vec![Inner::ZERO; 1 << U::LOG_WIDTH];
 	for op in ops {
 		match op {
 			GetSetOp::Get { index } => {

--- a/crates/arith-bench/src/underlier.rs
+++ b/crates/arith-bench/src/underlier.rs
@@ -15,6 +15,9 @@ pub trait Underlier: Sized + Clone + Copy + Debug {
 	/// The number of bits in this underlier type.
 	const BITS: usize;
 
+	/// The all-bits-zero value for this underlier type.
+	const ZERO: Self;
+
 	/// Performs bitwise AND operation.
 	fn and(a: Self, b: Self) -> Self;
 
@@ -33,9 +36,6 @@ pub trait Underlier: Sized + Clone + Copy + Debug {
 		*self = Self::xor(*self, other);
 	}
 
-	/// Returns the zero value for this underlier type.
-	fn zero() -> Self;
-
 	/// Checks if two underlier values are equal.
 	fn is_equal(a: Self, b: Self) -> bool;
 
@@ -45,6 +45,7 @@ pub trait Underlier: Sized + Clone + Copy + Debug {
 
 impl<U: Underlier, const N: usize> Underlier for [U; N] {
 	const BITS: usize = U::BITS * N;
+	const ZERO: Self = [U::ZERO; N];
 
 	#[inline]
 	fn and(a: Self, b: Self) -> Self {
@@ -62,11 +63,6 @@ impl<U: Underlier, const N: usize> Underlier for [U; N] {
 			result[i] = U::xor(a[i], b[i]);
 		}
 		result
-	}
-
-	#[inline]
-	fn zero() -> Self {
-		std::array::from_fn(|_| U::zero())
 	}
 
 	#[inline]
@@ -193,6 +189,7 @@ macro_rules! impl_underlier_for_native_uint {
 	($type:ty) => {
 		impl Underlier for $type {
 			const BITS: usize = <$type>::BITS as usize;
+			const ZERO: Self = 0;
 
 			#[inline]
 			fn and(a: Self, b: Self) -> Self {
@@ -202,11 +199,6 @@ macro_rules! impl_underlier_for_native_uint {
 			#[inline]
 			fn xor(a: Self, b: Self) -> Self {
 				a ^ b
-			}
-
-			#[inline]
-			fn zero() -> Self {
-				0
 			}
 
 			#[inline]


### PR DESCRIPTION
Turns `Underlier::zero()` in `binius-arith-bench` into a `const ZERO: Self`.
Pure API cleanup — no behavior change, codegen is identical.

### The problem

The `Underlier` trait in `binius-arith-bench` exposed zero as a method:

```rust
fn zero() -> Self;
```

But the core `UnderlierType` trait in `binius-field` already exposes it as a constant (`const ZERO: Self`).
So arith-bench was the odd one out, and zero — which is a compile-time constant for every underlier — was hiding behind a function call.

### The idea

Make it a `const`, matching `binius-field` and `std` (`i32::MAX`, `f32::INFINITY`):

```rust
const ZERO: Self;
```

This reads better, sits right next to the existing `const BITS`, and — unlike a method — is usable in const contexts like `[T::ZERO; N]` and `static` initializers.

### The change

The scalar and generic impls are trivial constants:

```diff
- fn zero() -> Self { 0 }                          // native uints
+ const ZERO: Self = 0;

- fn zero() -> Self { std::array::from_fn(|_| U::zero()) }   // [U; N]
+ const ZERO: Self = [U::ZERO; N];
```

The SIMD impls needed a little care.
`_mm*_setzero_*` and `vdupq_n_u64` are `unsafe` and **not** `const fn`, so they cannot seed a constant.
Following the pattern already used in `binius-field`, the SIMD constants are built by const-transmuting zeroed bytes, which *is* const-stable:

```diff
- fn zero() -> Self { unsafe { _mm256_setzero_si256() } }
+ const ZERO: Self = unsafe { std::mem::transmute([0u128; 2]) };
```

All-zero bytes are a valid bit pattern for every SIMD register, and lane order is irrelevant for zero, so this is correct for `__m128i` / `__m256i` / `__m512i` (x86_64) and `uint64x2_t` / `poly64x2_t` (NEON).

### Scope

- **changed:** the `Underlier` trait and all its impls — native uints, `[U; N]`, x86_64 SIMD, NEON SIMD.
- **updated call sites:** `U::zero()` → `U::ZERO` in `test_utils.rs`, `ghash/{clmul,bit_sliced}.rs`, `rijndael/russian_peasant.rs`, `benches/field_mul.rs`, and the aarch64 test.
- 8 files, +27 / −50.

### Verification

- `cargo check --workspace --all-targets` — clean.
- `cargo clippy -p binius-arith-bench --all-targets` — clean.
- `cargo +nightly fmt --all` — clean.
- `cargo test -p binius-arith-bench` (native aarch64 / NEON) — 63 tests + 1 doctest pass.
- The x86_64 SIMD const-transmutes were cross-checked with `--target x86_64-apple-darwin` under `+avx2,+avx512f,+avx512bw` (those impls are feature-gated off on the host) — `check` and `clippy` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)