### PR TITLE
BINIUS-218: fold gamma^j into the logUp* numerator's eq seed

### DIFF
--- a/crates/ip-prover/src/logup_star/witness.rs
+++ b/crates/ip-prover/src/logup_star/witness.rs
@@ -12,7 +12,7 @@
 use std::iter;
 
 use binius_field::{BinaryField, Divisible, Field, PackedField, util::powers};
-use binius_math::{FieldBuffer, multilinear::eq::eq_ind_partial_eval};
+use binius_math::{FieldBuffer, multilinear::eq::scaled_eq_ind_partial_eval};
 use binius_utils::rayon::prelude::*;
 use itertools::izip;
 
@@ -59,12 +59,10 @@ where
 				looker.index.len(),
 				1usize << n,
 			);
-			let eq_r = equality_indicator::<F, P>(looker.eval_point);
-			let scaled = eq_r
-				.iter_scalars()
-				.map(|eq_i| eq_i * power)
-				.collect::<Vec<_>>();
-			FieldBuffer::from_values(&scaled)
+			// Looker j's numerator is gamma^j * eq_{r_j}.
+			// Seeding the expansion with gamma^j folds the scale into the tensor product.
+			// That keeps it to one pass over one 2^n buffer.
+			scaled_eq_ind_partial_eval::<P>(looker.eval_point, power)
 		})
 		.collect::<Vec<_>>();
 
@@ -100,20 +98,6 @@ where
 	F: BinaryField<Underlier: Divisible<u64>>,
 {
 	F::from_underlier(F::Underlier::from_iter(iter::once(j as u64)))
-}
-
-/// Build the looker numerator `eq_r`, the equality indicator at the evaluation point.
-///
-/// `eq_r[i] = eq(eval_point, i)`, the multilinear `X = eq_r` of [Soukhanov25, Section 4].
-///
-/// [Soukhanov25]: <https://eprint.iacr.org/2025/946>
-pub fn equality_indicator<F, P>(eval_point: &[F]) -> FieldBuffer<P>
-where
-	F: Field,
-	P: PackedField<Scalar = F>,
-{
-	// The equality indicator's hypercube values are the Lagrange weights at the point.
-	eq_ind_partial_eval(eval_point)
 }
 
 /// Build the looker denominator `c - I` over the `n`-variable looker cube.

--- a/crates/math/src/multilinear/eq.rs
+++ b/crates/math/src/multilinear/eq.rs
@@ -120,11 +120,36 @@ pub fn tensor_prod_eq_ind_prepend<P: PackedField, Data: DerefMut<Target = [P]>>(
 ///
 /// [DP23]: <https://eprint.iacr.org/2023/1784>
 pub fn eq_ind_partial_eval<P: PackedField>(point: &[P::Scalar]) -> FieldBuffer<P> {
-	// The buffer needs to have the correct size: 2^max(point.len(), P::LOG_WIDTH) elements
-	// but since tensor_prod_eq_ind starts with log_n_values=0, we need the final size
+	// The unscaled indicator is the scaled indicator with a scale of one.
+	scaled_eq_ind_partial_eval(point, P::Scalar::ONE)
+}
+
+/// Computes the partial evaluation of the equality indicator polynomial, scaled by a constant.
+///
+/// Every hypercube value of the equality indicator is multiplied by `scale`:
+///
+/// $$
+/// scale \cdot (1 - r_0, r_0) \otimes ... \otimes (1 - r_{n-1}, r_{n-1}).
+/// $$
+///
+/// # Arguments
+///
+/// * `point` - The evaluation point whose length is the number of variables.
+/// * `scale` - The constant every returned value is multiplied by.
+///
+/// A scale of one reproduces the unscaled equality indicator.
+pub fn scaled_eq_ind_partial_eval<P: PackedField>(
+	point: &[P::Scalar],
+	scale: P::Scalar,
+) -> FieldBuffer<P> {
+	// The expansion starts from a single value and grows one variable at a time.
+	// Allocate at the final capacity 2^n now, so the growth never reallocates.
 	let log_size = point.len();
 	let mut buffer = FieldBuffer::zeros_truncated(0, log_size);
-	buffer.set(0, P::Scalar::ONE);
+
+	// Seed the starting value with the scale.
+	// The expansion multiplies it through, so every hypercube value ends up scaled.
+	buffer.set(0, scale);
 	tensor_prod_eq_ind(&mut buffer, point);
 	buffer
 }
@@ -242,6 +267,7 @@ pub fn eq_ind_partial_eval_scalars<F: FieldOps>(point: &[F]) -> Vec<F> {
 
 #[cfg(test)]
 mod tests {
+	use proptest::prelude::*;
 	use rand::prelude::*;
 
 	use super::*;
@@ -452,5 +478,67 @@ mod tests {
 		tensor_prod_eq_ind_prepend(&mut prepend, prefix);
 
 		assert_eq!(append, prepend);
+	}
+
+	#[test]
+	fn test_scaled_eq_ind_partial_eval_scale_one_matches_unscaled() {
+		let mut rng = StdRng::seed_from_u64(0);
+
+		// Invariant: a scale of one is the identity on the expansion.
+		// So the scaled and unscaled indicators must be the identical buffer.
+		//
+		// Sizes span the empty point (0 variables) up to a 256-value cube (8 variables).
+		for log_n in [0, 1, 2, 5, 8] {
+			let point = random_scalars::<F>(&mut rng, log_n);
+
+			// Equality is checked packed-word for packed-word, not just value by value.
+			assert_eq!(
+				scaled_eq_ind_partial_eval::<P>(&point, F::ONE),
+				eq_ind_partial_eval::<P>(&point),
+				"mismatch at log_n={log_n}"
+			);
+		}
+	}
+
+	#[test]
+	fn test_scaled_eq_ind_partial_eval_scale_zero_is_zero() {
+		let mut rng = StdRng::seed_from_u64(1);
+
+		// Invariant: the expansion is linear in its starting value.
+		// So a starting value of zero yields the all-zero polynomial.
+		for log_n in [0, 1, 2, 5] {
+			let point = random_scalars::<F>(&mut rng, log_n);
+
+			// Every one of the 2^log_n hypercube values must be zero.
+			let scaled = scaled_eq_ind_partial_eval::<P>(&point, F::ZERO);
+			assert!(scaled.iter_scalars().all(|v| v == F::ZERO), "nonzero at log_n={log_n}");
+		}
+	}
+
+	proptest! {
+		#![proptest_config(ProptestConfig::with_cases(16))]
+
+		// Invariant: scaling commutes with the expansion, value by value.
+		//
+		//     scaled_eq(point, s)[i] == s * eq(point)[i]   for every hypercube index i
+		#[test]
+		fn scaled_eq_ind_partial_eval_matches_scaled_reference(
+			seed in any::<u64>(),
+			log_n in 0usize..=8,
+		) {
+			// Draw the point and an independent scale from one seeded stream.
+			let mut rng = StdRng::seed_from_u64(seed);
+			let point = random_scalars::<F>(&mut rng, log_n);
+			let scale = random_scalars::<F>(&mut rng, 1)[0];
+
+			// Reference: the unscaled expansion, to be compared against the scaled one.
+			let scaled = scaled_eq_ind_partial_eval::<P>(&point, scale);
+			let reference = eq_ind_partial_eval::<P>(&point);
+
+			// The scaled value at each index must equal the scale times the reference value.
+			for (got, base) in scaled.iter_scalars().zip(reference.iter_scalars()) {
+				prop_assert_eq!(got, scale * base);
+			}
+		}
 	}
 }


### PR DESCRIPTION
Part of [BINIUS-218](https://linear.app/jimpo/issue/BINIUS-218). This is one of possibly several witness inefficiencies tracked there, so it should **not** close the ticket on merge.

Builds the logUp* looker numerator with one pass over one buffer instead of three. Output is bit-identical — no protocol change, the looked-up vector is still never committed.

### The problem

Each looker's numerator is $\gamma^j \cdot eq_{r_j}$, one value per row over the $2^n$ looker cube.
Building it took three full-size steps on the dominant $n$-axis:

- expand the equality indicator into a `$2^n$` buffer,
- walk every scalar to multiply it by $\gamma^j$, collecting a second buffer,
- repack that scalar vector into a third buffer.

So three `$2^n$` allocations and two passes, and the middle pass runs scalar-by-scalar, defeating the packed layout.

### The idea

The equality-indicator expansion is a tensor product built from a single seed value.
It is **linear in that seed**: every hypercube value is the seed times a product of $(1-r_i)$ / $r_i$ factors.

So seeding the expansion with $\gamma^j$ instead of $1$ scales the whole thing for free:

```
seed = gamma^j   ->   every output value already carries the gamma^j factor
```

No second pass, no rescale, no extra buffer.

### Per looker numerator

- **before:** expand ($2^n$), scalar rescale ($2^n$), repack ($2^n$) — 3 allocations, 2 passes
- **after:** one seeded expansion — 1 allocation, 1 pass

→ the scaling cost drops to zero.

### The change

New `scaled_eq_ind_partial_eval` in `binius-math` seeds the tensor expansion with the scale.
`eq_ind_partial_eval` becomes that function with a scale of one, so its result is unchanged.

At the logUp* call site:

```diff
- let eq_r = equality_indicator::<F, P>(looker.eval_point);
- let scaled = eq_r.iter_scalars().map(|eq_i| eq_i * power).collect::<Vec<_>>();
- FieldBuffer::from_values(&scaled)
+ scaled_eq_ind_partial_eval::<P>(looker.eval_point, power)
```

The now-dead `equality_indicator` helper (its only caller was this site) is removed.

### Soundness

- The numerator is bit-identical to before, value for value.
- Both consumers — the pushforward scatter and the fractional-addition leaf — read the same scaled numerator, exactly as they did.
- So the transcript matches today's protocol exactly; nothing about the challenge distribution changes.

### Scope

- **new:** `scaled_eq_ind_partial_eval` in `binius-math`
- **changed:** the numerator build in `crates/ip-prover/src/logup_star/witness.rs`; `eq_ind_partial_eval` now delegates
- **left untouched:** the pushforward, the fractional-addition circuits, the verifier — this only trims witness construction
- **not addressed here:** the other witness inefficiencies noted on BINIUS-218 (the denominator's scalar-vec-then-repack, and the fractional-addition layer footprint) — left for follow-ups under the same ticket

### Verification

- `cargo check --workspace --all-targets`, `clippy -p binius-math -p binius-ip-prover --all-targets`, nightly `fmt --all` — clean
- `binius-math` eq tests (14), `binius-ip-prover` + `binius-iop-prover` logUp* round-trips (10 + 5) — pass
- new proptest pins `scaled_eq(point, s)[i] == s * eq(point)[i]` over random points and scales, plus scale-zero and scale-one boundaries

### Benchmark

Building $\gamma^j \cdot eq$ over the $2^n$ cube:

| n_vars | baseline (expand + rescale + repack) | seeded expansion | speedup |
|---|---|---|---|
| 20 (1.0M elems) | 6.87 ms | 3.09 ms | 2.22× |
| 24 (16.8M elems) | 109.9 ms | 47.8 ms | 2.30× |

Throughput rises from ~152 Melem/s to ~345 Melem/s — consistent with dropping two of the three passes.

The bench is a throwaway used only to produce these numbers and is **not part of this PR**. To reproduce: drop the file below into `crates/math/benches/scaled_eq_ind_partial_eval.rs`, add a matching `[[bench]]` entry (`name = "scaled_eq_ind_partial_eval"`, `harness = false`) to `crates/math/Cargo.toml`, then run `cargo bench -p binius-math --bench scaled_eq_ind_partial_eval`.

<details>
<summary>bench source (reference only, not committed)</summary>

```rust
// Copyright 2026 The Binius Developers

//! Before/after benchmark for the logUp* looker numerator `gamma^j * eq_{r_j}`.
//!
//! The looker numerator is the equality indicator scaled by a per-looker constant.
//! Two ways to build it are compared over the `2^n` hypercube:
//!
//!     baseline: expand eq, then rescale every scalar and repack into a new buffer
//!     seeded  : seed the expansion with the scale, so it comes out scaled in one pass

use binius_field::arch::{OptimalB128, OptimalPackedB128};
use binius_math::{
    FieldBuffer,
    multilinear::eq::{eq_ind_partial_eval, scaled_eq_ind_partial_eval},
    test_utils::random_scalars,
};
use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
use rand::{SeedableRng, rngs::StdRng};

fn bench_scaled_eq_ind_partial_eval(c: &mut Criterion) {
    type F = OptimalB128;
    type P = OptimalPackedB128;

    let mut group = c.benchmark_group("logup_numerator");

    let mut rng = StdRng::seed_from_u64(0);

    // One fixed scale stands in for a looker's gamma^j.
    // A power of gamma is a general field element, so a random scalar models it faithfully.
    let scale = random_scalars::<F>(&mut rng, 1)[0];

    for n_vars in [16, 20, 24] {
        // Throughput is the number of hypercube values produced, one per looker row.
        let n_output_elems = 1u64 << n_vars;
        group.throughput(Throughput::Elements(n_output_elems));

        let point = random_scalars::<F>(&mut rng, n_vars);

        // Baseline: the three-allocation path.
        // Expand the indicator, unpack to scalars, multiply each by the scale, then repack.
        group.bench_function(BenchmarkId::new("baseline_expand_rescale_repack", n_vars), |b| {
            b.iter(|| {
                let eq = eq_ind_partial_eval::<P>(&point);
                let scaled = eq.iter_scalars().map(|v| v * scale).collect::<Vec<_>>();
                FieldBuffer::<P>::from_values(&scaled)
            });
        });

        // Seeded: the one-allocation path.
        // Fold the scale into the tensor seed, so the expansion emits scaled values directly.
        group.bench_function(BenchmarkId::new("seeded_scaled_expansion", n_vars), |b| {
            b.iter(|| scaled_eq_ind_partial_eval::<P>(&point, scale));
        });
    }

    group.finish();
}

criterion_group!(benches, bench_scaled_eq_ind_partial_eval);
criterion_main!(benches);
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
