### PR TITLE
Add parallel witness evaluation for independent components

### DIFF
--- a/crates/core/src/constraint_system/value_vec.rs
+++ b/crates/core/src/constraint_system/value_vec.rs
@@ -143,6 +143,11 @@ impl ValueVec {
 		&self.data[self.layout.offset_witness..self.layout.committed_total_len]
 	}
 
+	/// Returns the full mutable backing store, including scratch space.
+	pub fn as_mut_slice(&mut self) -> &mut [Word] {
+		&mut self.data
+	}
+
 	/// Returns the witness portion of the values vector.
 	pub fn witness(&self) -> &[Word] {
 		let start = self.layout.offset_witness;

--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -86,7 +86,7 @@ harness = false
 [features]
 default = []
 perfetto = ["tracing-profile/perfetto"]
-rayon = ["binius-utils/rayon"]
+rayon = ["binius-frontend/rayon", "binius-utils/rayon"]
 
 # Tutorial examples
 [[example]]

--- a/crates/examples/benches/utils/independent_hashes.rs
+++ b/crates/examples/benches/utils/independent_hashes.rs
@@ -133,13 +133,24 @@ pub fn run_independent_hash_benchmark<E>(
 		benchmark,
 		primitive.group_prefix(),
 		peak_alloc,
-		bench_witness_generation_and_proving,
+		bench_independent_hash_extra_groups,
 	);
+}
+
+fn bench_independent_hash_extra_groups<B>(
+	c: &mut Criterion,
+	ctx: ConstraintSystemBenchmarkContext<'_, B>,
+) where
+	B: ExampleBenchmark,
+{
+	bench_witness_generation_and_proving(c, &ctx);
+	#[cfg(feature = "rayon")]
+	bench_parallel_witness_generation_and_proving(c, &ctx);
 }
 
 fn bench_witness_generation_and_proving<B>(
 	c: &mut Criterion,
-	ctx: ConstraintSystemBenchmarkContext<'_, B>,
+	ctx: &ConstraintSystemBenchmarkContext<'_, B>,
 ) where
 	B: ExampleBenchmark,
 {
@@ -158,6 +169,38 @@ fn bench_witness_generation_and_proving<B>(
 				.populate_witness(ctx.instance.clone(), &mut filler)
 				.unwrap();
 			ctx.circuit.populate_wire_witness(&mut filler).unwrap();
+			let witness = filler.into_value_vec();
+			let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
+			ctx.prover.prove(witness, &mut prover_transcript).unwrap();
+			prover_transcript
+		})
+	});
+
+	group.finish();
+}
+
+#[cfg(feature = "rayon")]
+fn bench_parallel_witness_generation_and_proving<B>(
+	c: &mut Criterion,
+	ctx: &ConstraintSystemBenchmarkContext<'_, B>,
+) where
+	B: ExampleBenchmark,
+{
+	let mut group =
+		c.benchmark_group(format!("{}_parallel_witness_generation_and_proving", ctx.group_prefix));
+	group.throughput(ctx.benchmark.throughput());
+	group.sample_size(10);
+	group.warm_up_time(Duration::from_secs(2));
+
+	group.bench_function(BenchmarkId::from_parameter(ctx.bench_name), |b| {
+		b.iter(|| {
+			let mut filler = ctx.circuit.new_witness_filler();
+			ctx.example
+				.populate_witness(ctx.instance.clone(), &mut filler)
+				.unwrap();
+			ctx.circuit
+				.populate_wire_witness_parallel(&mut filler)
+				.unwrap();
 			let witness = filler.into_value_vec();
 			let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 			ctx.prover.prove(witness, &mut prover_transcript).unwrap();

--- a/crates/frontend/Cargo.toml
+++ b/crates/frontend/Cargo.toml
@@ -9,6 +9,7 @@ workspace = true
 
 [dependencies]
 binius-core = { path = "../core" }
+binius-utils = { path = "../utils" }
 cranelift-entity = { workspace = true }
 hex-literal.workspace = true
 num-bigint = { workspace = true }
@@ -24,3 +25,7 @@ rand = { workspace = true, features = ["thread_rng"] }
 hex-literal = { workspace = true }
 proptest = { workspace = true }
 insta = { workspace = true }
+
+[features]
+default = []
+rayon = ["binius-utils/rayon"]

--- a/crates/frontend/src/compiler/circuit.rs
+++ b/crates/frontend/src/compiler/circuit.rs
@@ -152,6 +152,24 @@ impl Circuit {
 		Ok(())
 	}
 
+	/// Populates non-input values by evaluating independent components in parallel.
+	///
+	/// When the `rayon` feature is disabled, this uses the same sequential fallback as the rest of
+	/// the repo's rayon compatibility layer.
+	pub fn populate_wire_witness_parallel(
+		&self,
+		w: &mut WitnessFiller,
+	) -> Result<(), PopulateError> {
+		for (index, constant) in self.constraint_system.constants.iter().enumerate() {
+			w.value_vec[ValueIndex(index as u32)] = *constant;
+		}
+
+		self.eval_form
+			.evaluate_parallel(&mut w.value_vec, Some(&self.gate_graph.path_spec_tree))?;
+
+		Ok(())
+	}
+
 	/// Returns the constraint system for this circuit.
 	pub const fn constraint_system(&self) -> &ConstraintSystem {
 		&self.constraint_system

--- a/crates/frontend/src/compiler/eval_form/builder.rs
+++ b/crates/frontend/src/compiler/eval_form/builder.rs
@@ -16,6 +16,10 @@ impl BytecodeBuilder {
 		}
 	}
 
+	pub(crate) const fn byte_len(&self) -> usize {
+		self.bytecode.len()
+	}
+
 	// Bitwise operations
 	pub fn emit_band(&mut self, dst: u32, src1: u32, src2: u32) {
 		self.n_eval_insn += 1;

--- a/crates/frontend/src/compiler/eval_form/interpreter.rs
+++ b/crates/frontend/src/compiler/eval_form/interpreter.rs
@@ -2,7 +2,7 @@
 // Copyright 2025 Irreducible Inc.
 //! Bytecode interpreter for circuit evaluation
 
-use binius_core::{ValueIndex, ValueVec, Word};
+use binius_core::{ValueVec, Word};
 
 use crate::compiler::{
 	circuit::PopulateError,
@@ -18,9 +18,56 @@ pub struct AssertionFailure {
 	pub message: String,
 }
 
-/// Execution context holds a reference to ValueVec during execution
-pub struct ExecutionContext<'a> {
-	value_vec: &'a mut ValueVec,
+/// Raw shareable view over a [`ValueVec`]'s backing words.
+///
+/// Safety contract: parallel executions may share a store only when each task writes a disjoint set
+/// of value indices, and any concurrently shared reads are from already-populated input or constant
+/// values.
+#[derive(Clone, Copy)]
+pub(super) struct ValueStore {
+	ptr: *mut Word,
+	len: usize,
+}
+
+// SAFETY: `ValueStore` only becomes `Send`/`Sync` under the disjoint-writer contract documented on
+// the type. The parallel evaluator derives those disjoint sets from gate-graph connected
+// components while holding an exclusive `&mut ValueVec` for the entire run.
+unsafe impl Send for ValueStore {}
+unsafe impl Sync for ValueStore {}
+
+impl ValueStore {
+	pub(super) fn new(value_vec: &mut ValueVec) -> Self {
+		let values = value_vec.as_mut_slice();
+		Self {
+			ptr: values.as_mut_ptr(),
+			len: values.len(),
+		}
+	}
+
+	#[inline]
+	fn get(self, index: u32) -> Word {
+		let index = index as usize;
+		assert!(index < self.len, "value index {index} out of bounds");
+		// SAFETY: The index is bounds-checked above. The caller must uphold the store's aliasing
+		// contract.
+		unsafe { *self.ptr.add(index) }
+	}
+
+	#[inline]
+	fn set(self, index: u32, value: Word) {
+		let index = index as usize;
+		assert!(index < self.len, "value index {index} out of bounds");
+		// SAFETY: The index is bounds-checked above. The caller must uphold the store's aliasing
+		// contract.
+		unsafe {
+			*self.ptr.add(index) = value;
+		}
+	}
+}
+
+/// Execution context holds access to witness values during execution.
+pub struct ExecutionContext {
+	store: ValueStore,
 	/// Assertion failures recorded during the evaluation of the circuit.
 	///
 	/// This list is capped by [`MAX_ASSERTION_FAILURES`].
@@ -29,13 +76,17 @@ pub struct ExecutionContext<'a> {
 	assertion_count: usize,
 }
 
-impl<'a> ExecutionContext<'a> {
-	pub const fn new(value_vec: &'a mut ValueVec) -> Self {
+impl ExecutionContext {
+	pub const fn new(store: ValueStore) -> Self {
 		Self {
-			value_vec,
+			store,
 			assertion_failures: Vec::new(),
 			assertion_count: 0,
 		}
+	}
+
+	pub fn into_failures(self) -> (Vec<AssertionFailure>, usize) {
+		(self.assertion_failures, self.assertion_count)
 	}
 
 	/// Record an assertion failure with the given path spec and message.
@@ -89,6 +140,39 @@ impl<'a> ExecutionContext<'a> {
 	}
 }
 
+pub(super) fn report_failures(
+	mut failures: Vec<AssertionFailure>,
+	total_count: usize,
+	path_spec_tree: Option<&PathSpecTree>,
+) -> Result<(), PopulateError> {
+	if failures.is_empty() {
+		return Ok(());
+	}
+
+	failures.truncate(MAX_ASSERTION_FAILURES);
+	let messages = if let Some(tree) = path_spec_tree {
+		failures
+			.into_iter()
+			.map(|f| {
+				let mut path = String::new();
+				tree.stringify(f.path_spec, &mut path);
+				if path.is_empty() {
+					f.message
+				} else {
+					format!("{}: {}", path, f.message)
+				}
+			})
+			.collect()
+	} else {
+		failures.into_iter().map(|f| f.message).collect()
+	};
+
+	Err(PopulateError {
+		messages,
+		total_count,
+	})
+}
+
 pub struct Interpreter<'a> {
 	bytecode: &'a [u8],
 	hints: &'a HintRegistry,
@@ -109,12 +193,21 @@ impl<'a> Interpreter<'a> {
 		value_vec: &mut ValueVec,
 		path_spec_tree: Option<&PathSpecTree>,
 	) -> Result<(), PopulateError> {
-		let mut ctx = ExecutionContext::new(value_vec);
+		let mut ctx = ExecutionContext::new(ValueStore::new(value_vec));
 		self.run(&mut ctx)?;
 		ctx.check_assertions(path_spec_tree)
 	}
 
-	pub fn run(&mut self, ctx: &mut ExecutionContext<'_>) -> Result<(), PopulateError> {
+	pub fn run_with_store(
+		&mut self,
+		store: ValueStore,
+	) -> Result<(Vec<AssertionFailure>, usize), PopulateError> {
+		let mut ctx = ExecutionContext::new(store);
+		self.run(&mut ctx)?;
+		Ok(ctx.into_failures())
+	}
+
+	pub fn run(&mut self, ctx: &mut ExecutionContext) -> Result<(), PopulateError> {
 		while self.pc < self.bytecode.len() {
 			let opcode = self.read_u8();
 
@@ -170,7 +263,7 @@ impl<'a> Interpreter<'a> {
 	}
 
 	// Bitwise operations
-	fn exec_band(&mut self, ctx: &mut ExecutionContext<'_>) {
+	fn exec_band(&mut self, ctx: &mut ExecutionContext) {
 		let dst = self.read_reg();
 		let src1 = self.read_reg();
 		let src2 = self.read_reg();
@@ -178,7 +271,7 @@ impl<'a> Interpreter<'a> {
 		self.store(ctx, dst, val);
 	}
 
-	fn exec_bor(&mut self, ctx: &mut ExecutionContext<'_>) {
+	fn exec_bor(&mut self, ctx: &mut ExecutionContext) {
 		let dst = self.read_reg();
 		let src1 = self.read_reg();
 		let src2 = self.read_reg();
@@ -186,7 +279,7 @@ impl<'a> Interpreter<'a> {
 		self.store(ctx, dst, val);
 	}
 
-	fn exec_bxor(&mut self, ctx: &mut ExecutionContext<'_>) {
+	fn exec_bxor(&mut self, ctx: &mut ExecutionContext) {
 		let dst = self.read_reg();
 		let src1 = self.read_reg();
 		let src2 = self.read_reg();
@@ -194,7 +287,7 @@ impl<'a> Interpreter<'a> {
 		self.store(ctx, dst, val);
 	}
 
-	fn exec_select(&mut self, ctx: &mut ExecutionContext<'_>) {
+	fn exec_select(&mut self, ctx: &mut ExecutionContext) {
 		let dst = self.read_reg();
 		let cond = self.read_reg();
 		let t = self.read_reg();
@@ -209,7 +302,7 @@ impl<'a> Interpreter<'a> {
 		self.store(ctx, dst, val);
 	}
 
-	fn exec_bxor_multi(&mut self, ctx: &mut ExecutionContext<'_>) {
+	fn exec_bxor_multi(&mut self, ctx: &mut ExecutionContext) {
 		let dst = self.read_reg();
 		let n = self.read_u32() as usize;
 		let mut val = Word::ZERO;
@@ -220,7 +313,7 @@ impl<'a> Interpreter<'a> {
 		self.store(ctx, dst, val);
 	}
 
-	fn exec_fax(&mut self, ctx: &mut ExecutionContext<'_>) {
+	fn exec_fax(&mut self, ctx: &mut ExecutionContext) {
 		let dst = self.read_reg();
 		let src1 = self.read_reg();
 		let src2 = self.read_reg();
@@ -230,7 +323,7 @@ impl<'a> Interpreter<'a> {
 	}
 
 	// Shifts
-	fn exec_sll(&mut self, ctx: &mut ExecutionContext<'_>) {
+	fn exec_sll(&mut self, ctx: &mut ExecutionContext) {
 		let dst = self.read_reg();
 		let src = self.read_reg();
 		let shift = self.read_u8() as u32;
@@ -238,7 +331,7 @@ impl<'a> Interpreter<'a> {
 		self.store(ctx, dst, val);
 	}
 
-	fn exec_slr(&mut self, ctx: &mut ExecutionContext<'_>) {
+	fn exec_slr(&mut self, ctx: &mut ExecutionContext) {
 		let dst = self.read_reg();
 		let src = self.read_reg();
 		let shift = self.read_u8() as u32;
@@ -246,7 +339,7 @@ impl<'a> Interpreter<'a> {
 		self.store(ctx, dst, val);
 	}
 
-	fn exec_sar(&mut self, ctx: &mut ExecutionContext<'_>) {
+	fn exec_sar(&mut self, ctx: &mut ExecutionContext) {
 		let dst = self.read_reg();
 		let src = self.read_reg();
 		let shift = self.read_u8() as u32;
@@ -255,7 +348,7 @@ impl<'a> Interpreter<'a> {
 	}
 
 	// Arithmetic operations
-	fn exec_iadd_cout(&mut self, ctx: &mut ExecutionContext<'_>) {
+	fn exec_iadd_cout(&mut self, ctx: &mut ExecutionContext) {
 		let dst_sum = self.read_reg();
 		let dst_cout = self.read_reg();
 		let src1 = self.read_reg();
@@ -267,7 +360,7 @@ impl<'a> Interpreter<'a> {
 		self.store(ctx, dst_cout, cout);
 	}
 
-	fn exec_iadd_cin_cout(&mut self, ctx: &mut ExecutionContext<'_>) {
+	fn exec_iadd_cin_cout(&mut self, ctx: &mut ExecutionContext) {
 		let dst_sum = self.read_reg();
 		let dst_cout = self.read_reg();
 		let src1 = self.read_reg();
@@ -281,7 +374,7 @@ impl<'a> Interpreter<'a> {
 		self.store(ctx, dst_cout, cout);
 	}
 
-	fn exec_isub_bin_bout(&mut self, ctx: &mut ExecutionContext<'_>) {
+	fn exec_isub_bin_bout(&mut self, ctx: &mut ExecutionContext) {
 		let dst_diff = self.read_reg();
 		let dst_bout = self.read_reg();
 		let src1 = self.read_reg();
@@ -295,7 +388,7 @@ impl<'a> Interpreter<'a> {
 		self.store(ctx, dst_bout, bout);
 	}
 
-	fn exec_imul(&mut self, ctx: &mut ExecutionContext<'_>) {
+	fn exec_imul(&mut self, ctx: &mut ExecutionContext) {
 		let dst_hi = self.read_reg();
 		let dst_lo = self.read_reg();
 		let src1 = self.read_reg();
@@ -305,7 +398,7 @@ impl<'a> Interpreter<'a> {
 		self.store(ctx, dst_lo, lo);
 	}
 
-	fn exec_smul(&mut self, ctx: &mut ExecutionContext<'_>) {
+	fn exec_smul(&mut self, ctx: &mut ExecutionContext) {
 		let dst_hi = self.read_reg();
 		let dst_lo = self.read_reg();
 		let src1 = self.read_reg();
@@ -316,7 +409,7 @@ impl<'a> Interpreter<'a> {
 	}
 
 	// 32-bit operations
-	fn exec_iadd32_cin_cout(&mut self, ctx: &mut ExecutionContext<'_>) {
+	fn exec_iadd32_cin_cout(&mut self, ctx: &mut ExecutionContext) {
 		let dst_sum = self.read_reg();
 		let dst_cout = self.read_reg();
 		let src1 = self.read_reg();
@@ -329,7 +422,7 @@ impl<'a> Interpreter<'a> {
 		self.store(ctx, dst_cout, cout);
 	}
 
-	fn exec_iadd32_cout(&mut self, ctx: &mut ExecutionContext<'_>) {
+	fn exec_iadd32_cout(&mut self, ctx: &mut ExecutionContext) {
 		let dst_sum = self.read_reg();
 		let dst_cout = self.read_reg();
 		let src1 = self.read_reg();
@@ -339,7 +432,7 @@ impl<'a> Interpreter<'a> {
 		self.store(ctx, dst_cout, cout);
 	}
 
-	fn exec_rotr32(&mut self, ctx: &mut ExecutionContext<'_>) {
+	fn exec_rotr32(&mut self, ctx: &mut ExecutionContext) {
 		let dst = self.read_reg();
 		let src = self.read_reg();
 		let rotate = self.read_u8() as u32;
@@ -347,7 +440,7 @@ impl<'a> Interpreter<'a> {
 		self.store(ctx, dst, val);
 	}
 
-	fn exec_srl32(&mut self, ctx: &mut ExecutionContext<'_>) {
+	fn exec_srl32(&mut self, ctx: &mut ExecutionContext) {
 		let dst = self.read_reg();
 		let src = self.read_reg();
 		let shift = self.read_u8() as u32;
@@ -355,7 +448,7 @@ impl<'a> Interpreter<'a> {
 		self.store(ctx, dst, val);
 	}
 
-	fn exec_sll32(&mut self, ctx: &mut ExecutionContext<'_>) {
+	fn exec_sll32(&mut self, ctx: &mut ExecutionContext) {
 		let dst = self.read_reg();
 		let src = self.read_reg();
 		let shift = self.read_u8() as u32;
@@ -363,7 +456,7 @@ impl<'a> Interpreter<'a> {
 		self.store(ctx, dst, val);
 	}
 
-	fn exec_sra32(&mut self, ctx: &mut ExecutionContext<'_>) {
+	fn exec_sra32(&mut self, ctx: &mut ExecutionContext) {
 		let dst = self.read_reg();
 		let src = self.read_reg();
 		let shift = self.read_u8() as u32;
@@ -371,7 +464,7 @@ impl<'a> Interpreter<'a> {
 		self.store(ctx, dst, val);
 	}
 
-	fn exec_rotr(&mut self, ctx: &mut ExecutionContext<'_>) {
+	fn exec_rotr(&mut self, ctx: &mut ExecutionContext) {
 		let dst = self.read_reg();
 		let src = self.read_reg();
 		let rotate = self.read_u8() as u32;
@@ -380,7 +473,7 @@ impl<'a> Interpreter<'a> {
 	}
 
 	// Mask operations
-	fn exec_mask_low(&mut self, ctx: &mut ExecutionContext<'_>) {
+	fn exec_mask_low(&mut self, ctx: &mut ExecutionContext) {
 		let dst = self.read_reg();
 		let src = self.read_reg();
 		let n_bits = self.read_u8();
@@ -393,7 +486,7 @@ impl<'a> Interpreter<'a> {
 		self.store(ctx, dst, val);
 	}
 
-	fn exec_mask_high(&mut self, ctx: &mut ExecutionContext<'_>) {
+	fn exec_mask_high(&mut self, ctx: &mut ExecutionContext) {
 		let dst = self.read_reg();
 		let src = self.read_reg();
 		let n_bits = self.read_u8();
@@ -407,7 +500,7 @@ impl<'a> Interpreter<'a> {
 	}
 
 	// Assertions
-	fn exec_assert_eq(&mut self, ctx: &mut ExecutionContext<'_>) {
+	fn exec_assert_eq(&mut self, ctx: &mut ExecutionContext) {
 		let src1 = self.read_reg();
 		let src2 = self.read_reg();
 		let error_id = self.read_u32();
@@ -421,7 +514,7 @@ impl<'a> Interpreter<'a> {
 		}
 	}
 
-	fn exec_assert_eq_cond(&mut self, ctx: &mut ExecutionContext<'_>) {
+	fn exec_assert_eq_cond(&mut self, ctx: &mut ExecutionContext) {
 		let cond = self.read_reg();
 		let src1 = self.read_reg();
 		let src2 = self.read_reg();
@@ -443,7 +536,7 @@ impl<'a> Interpreter<'a> {
 		}
 	}
 
-	fn exec_assert_zero(&mut self, ctx: &mut ExecutionContext<'_>) {
+	fn exec_assert_zero(&mut self, ctx: &mut ExecutionContext) {
 		let src = self.read_reg();
 		let error_id = self.read_u32();
 		let path_spec = PathSpec::from_u32(error_id);
@@ -455,7 +548,7 @@ impl<'a> Interpreter<'a> {
 		}
 	}
 
-	fn exec_assert_non_zero(&mut self, ctx: &mut ExecutionContext<'_>) {
+	fn exec_assert_non_zero(&mut self, ctx: &mut ExecutionContext) {
 		let src = self.read_reg();
 		let error_id = self.read_u32();
 		let path_spec = PathSpec::from_u32(error_id);
@@ -467,7 +560,7 @@ impl<'a> Interpreter<'a> {
 		}
 	}
 
-	fn exec_assert_false(&mut self, ctx: &mut ExecutionContext<'_>) {
+	fn exec_assert_false(&mut self, ctx: &mut ExecutionContext) {
 		let src = self.read_reg();
 		let error_id = self.read_u32();
 		let path_spec = PathSpec::from_u32(error_id);
@@ -479,7 +572,7 @@ impl<'a> Interpreter<'a> {
 		}
 	}
 
-	fn exec_assert_true(&mut self, ctx: &mut ExecutionContext<'_>) {
+	fn exec_assert_true(&mut self, ctx: &mut ExecutionContext) {
 		let src = self.read_reg();
 		let error_id = self.read_u32();
 		let path_spec = PathSpec::from_u32(error_id);
@@ -492,7 +585,7 @@ impl<'a> Interpreter<'a> {
 	}
 
 	// Hint execution
-	fn exec_hint(&mut self, ctx: &mut ExecutionContext<'_>) {
+	fn exec_hint(&mut self, ctx: &mut ExecutionContext) {
 		let hint_id = self.read_u32();
 
 		// Read dimensions
@@ -525,12 +618,12 @@ impl<'a> Interpreter<'a> {
 		}
 	}
 
-	fn load(&self, ctx: &ExecutionContext<'_>, reg: u32) -> Word {
-		ctx.value_vec[ValueIndex(reg)]
+	fn load(&self, ctx: &ExecutionContext, reg: u32) -> Word {
+		ctx.store.get(reg)
 	}
 
-	fn store(&self, ctx: &mut ExecutionContext<'_>, reg: u32, value: Word) {
-		ctx.value_vec[ValueIndex(reg)] = value;
+	fn store(&self, ctx: &mut ExecutionContext, reg: u32, value: Word) {
+		ctx.store.set(reg, value);
 	}
 
 	// Bytecode reading helpers

--- a/crates/frontend/src/compiler/eval_form/mod.rs
+++ b/crates/frontend/src/compiler/eval_form/mod.rs
@@ -10,10 +10,13 @@ mod interpreter;
 #[cfg(test)]
 mod tests;
 
+use std::{collections::BTreeMap, ops::Range};
+
 use binius_core::{ValueIndex, ValueVec};
+use binius_utils::rayon::prelude::*;
 pub use builder::BytecodeBuilder;
 pub use const_eval::evaluate_gate_constants;
-use cranelift_entity::SecondaryMap;
+use cranelift_entity::{EntityRef, SecondaryMap};
 
 use crate::compiler::{
 	circuit::PopulateError,
@@ -31,6 +34,51 @@ pub struct EvalForm {
 	n_eval_insn: usize,
 	/// Registered hint handlers
 	hint_registry: HintRegistry,
+	/// Bytecode ranges for independent connected components.
+	parallel_components: Vec<EvalComponent>,
+}
+
+#[derive(Debug, Clone)]
+struct EvalComponent {
+	byte_ranges: Vec<Range<usize>>,
+}
+
+struct UnionFind {
+	parent: Vec<usize>,
+	rank: Vec<u8>,
+}
+
+impl UnionFind {
+	fn new(len: usize) -> Self {
+		Self {
+			parent: (0..len).collect(),
+			rank: vec![0; len],
+		}
+	}
+
+	fn find(&mut self, index: usize) -> usize {
+		let parent = self.parent[index];
+		if parent != index {
+			let root = self.find(parent);
+			self.parent[index] = root;
+		}
+		self.parent[index]
+	}
+
+	fn union(&mut self, a: usize, b: usize) {
+		let mut root_a = self.find(a);
+		let mut root_b = self.find(b);
+		if root_a == root_b {
+			return;
+		}
+		if self.rank[root_a] < self.rank[root_b] {
+			std::mem::swap(&mut root_a, &mut root_b);
+		}
+		self.parent[root_b] = root_a;
+		if self.rank[root_a] == self.rank[root_b] {
+			self.rank[root_a] += 1;
+		}
+	}
 }
 
 impl EvalForm {
@@ -45,6 +93,14 @@ impl EvalForm {
 		hint_registry: HintRegistry,
 	) -> Self {
 		let mut builder = BytecodeBuilder::new();
+		let capture_parallel_components = cfg!(feature = "rayon");
+		let gate_components = if capture_parallel_components {
+			gate_component_roots(gate_graph, &hint_registry)
+		} else {
+			Vec::new()
+		};
+		let mut component_ranges = BTreeMap::<usize, Vec<Range<usize>>>::new();
+		let mut component_writes = BTreeMap::<usize, Vec<usize>>::new();
 
 		// Combined wire to register mapping
 		let wire_to_reg = |wire: Wire| -> u32 {
@@ -57,6 +113,8 @@ impl EvalForm {
 
 		// Build bytecode for each gate
 		for (gate_id, data) in gate_graph.gates.iter() {
+			let component = capture_parallel_components.then(|| gate_components[gate_id.index()]);
+			let start = component.map(|_| builder.byte_len());
 			gate::emit_gate_bytecode(
 				gate_id,
 				data,
@@ -65,13 +123,51 @@ impl EvalForm {
 				wire_to_reg,
 				&hint_registry,
 			);
+			if let (Some(component), Some(start)) = (component, start) {
+				let end = builder.byte_len();
+				if start != end {
+					let ranges = component_ranges.entry(component).or_default();
+					if let Some(last) = ranges.last_mut() {
+						if last.end == start {
+							last.end = end;
+						} else {
+							ranges.push(start..end);
+						}
+					} else {
+						ranges.push(start..end);
+					}
+				}
+
+				let gate_param = data.gate_param_with_registry(&hint_registry);
+				let writes = component_writes.entry(component).or_default();
+				for &wire in gate_param
+					.outputs
+					.iter()
+					.chain(gate_param.aux)
+					.chain(gate_param.scratch)
+				{
+					if let Some(&ValueIndex(index)) = wire_mapping.get(wire) {
+						writes.push(index as usize);
+					}
+				}
+			}
 		}
 
 		let (bytecode, n_eval_insn) = builder.finalize();
+		let parallel_components =
+			if capture_parallel_components && component_writes_are_disjoint(&component_writes) {
+				component_ranges
+					.into_values()
+					.map(|byte_ranges| EvalComponent { byte_ranges })
+					.collect()
+			} else {
+				Vec::new()
+			};
 		EvalForm {
 			bytecode,
 			n_eval_insn,
 			hint_registry,
+			parallel_components,
 		}
 	}
 
@@ -86,6 +182,47 @@ impl EvalForm {
 		Ok(())
 	}
 
+	/// Execute independent evaluation components in parallel.
+	pub(crate) fn evaluate_parallel(
+		&self,
+		value_vec: &mut ValueVec,
+		path_spec_tree: Option<&PathSpecTree>,
+	) -> Result<(), PopulateError> {
+		if self.parallel_components.len() <= 1 {
+			return self.evaluate(value_vec, path_spec_tree);
+		}
+
+		let store = interpreter::ValueStore::new(value_vec);
+		let component_results = self
+			.parallel_components
+			.par_iter()
+			.map(|component| {
+				let mut failures = Vec::new();
+				let mut total_count = 0;
+				for range in &component.byte_ranges {
+					let mut interpreter = interpreter::Interpreter::new(
+						&self.bytecode[range.clone()],
+						&self.hint_registry,
+					);
+					let (mut range_failures, range_count) = interpreter.run_with_store(store)?;
+					failures.append(&mut range_failures);
+					total_count += range_count;
+				}
+				Ok::<_, PopulateError>((failures, total_count))
+			})
+			.collect::<Vec<_>>();
+
+		let mut failures = Vec::new();
+		let mut total_count = 0;
+		for result in component_results {
+			let (mut component_failures, component_count) = result?;
+			failures.append(&mut component_failures);
+			total_count += component_count;
+		}
+
+		interpreter::report_failures(failures, total_count, path_spec_tree)
+	}
+
 	/// Get the number of evaluation instructions
 	pub const fn n_eval_insn(&self) -> usize {
 		self.n_eval_insn
@@ -95,4 +232,59 @@ impl EvalForm {
 	pub fn bytecode(&self) -> &[u8] {
 		&self.bytecode
 	}
+}
+
+fn gate_component_roots(gate_graph: &GateGraph, hint_registry: &HintRegistry) -> Vec<usize> {
+	let gate_count = gate_graph.gates.len();
+	let mut union_find = UnionFind::new(gate_count);
+	let mut wire_defs = SecondaryMap::<Wire, Option<_>>::new();
+
+	// Build local use-def data instead of relying on `GateGraph::wire_def`. The graph-level map is
+	// only rebuilt by optional optimization passes, while eval-form component splitting must stay
+	// correct even when those passes are disabled.
+	for (gate, gate_data) in gate_graph.gates.iter() {
+		let gate_param = gate_data.gate_param_with_registry(hint_registry);
+		// Gate bytecode reads cross-gate values only through constants/inputs. Outputs, aux, and
+		// scratch wires are the values written by this gate; tracking all of them here keeps the
+		// partition conservative if a future opcode exposes scratch as an input.
+		for &wire in gate_param
+			.outputs
+			.iter()
+			.chain(gate_param.aux)
+			.chain(gate_param.scratch)
+		{
+			if let Some(previous) = wire_defs[wire].replace(gate) {
+				debug_assert_eq!(previous, gate, "wire {wire:?} is defined by multiple gates");
+			}
+		}
+	}
+
+	for (gate, gate_data) in gate_graph.gates.iter() {
+		let gate_param = gate_data.gate_param_with_registry(hint_registry);
+		for &wire in gate_param.constants.iter().chain(gate_param.inputs) {
+			if let Some(def_gate) = wire_defs[wire] {
+				union_find.union(gate.index(), def_gate.index());
+			}
+		}
+	}
+
+	let mut roots = vec![0; gate_count];
+	for gate in gate_graph.gates.keys() {
+		roots[gate.index()] = union_find.find(gate.index());
+	}
+	roots
+}
+
+fn component_writes_are_disjoint(component_writes: &BTreeMap<usize, Vec<usize>>) -> bool {
+	let mut owners = BTreeMap::new();
+	for (&component, writes) in component_writes {
+		for &index in writes {
+			if let Some(owner) = owners.insert(index, component)
+				&& owner != component
+			{
+				return false;
+			}
+		}
+	}
+	true
 }

--- a/crates/frontend/src/compiler/eval_form/tests.rs
+++ b/crates/frontend/src/compiler/eval_form/tests.rs
@@ -2,14 +2,38 @@
 
 use binius_core::{ValueIndex, ValueVec, ValueVecLayout, word::Word};
 
+#[cfg(feature = "rayon")]
+use crate::compiler::{CircuitBuilder, Options};
 use crate::compiler::{
 	circuit::PopulateError,
 	eval_form::{
 		BytecodeBuilder,
-		interpreter::{ExecutionContext, Interpreter},
+		interpreter::{ExecutionContext, Interpreter, ValueStore},
 	},
 	hints::HintRegistry,
 };
+
+#[cfg(feature = "rayon")]
+#[test]
+fn parallel_components_do_not_depend_on_rebuilt_use_def_chains() {
+	let builder = CircuitBuilder::with_opts(Options {
+		enable_gate_fusion: false,
+		enable_constant_propagation: false,
+		enable_dead_code_elimination: false,
+	});
+
+	let a = builder.add_inout();
+	let b = builder.add_inout();
+	let c = builder.add_inout();
+	let first = builder.band(a, b);
+	let dependent = builder.bxor(first, c);
+	let expected = builder.add_inout();
+	builder.assert_eq("dependent", dependent, expected);
+
+	let circuit = builder.build();
+
+	assert_eq!(circuit.eval_form().parallel_components.len(), 1);
+}
 
 /// Test harness for interpreter tests that makes them much more concise
 struct InterpreterTest {
@@ -45,16 +69,16 @@ impl InterpreterTest {
 
 	/// Run the test and expect success (no assertion failures)
 	fn expect_success(self) {
-		let (result, ctx) = self.execute();
+		let (result, assertions) = self.execute();
 		assert!(result.is_ok(), "Interpreter should execute successfully");
-		assert!(ctx.check_assertions(None).is_ok(), "Should have no assertion failures");
+		assert!(assertions.is_ok(), "Should have no assertion failures");
 	}
 
 	/// Run the test and expect assertion failure
 	fn expect_assertion_failure(self) {
-		let (result, ctx) = self.execute();
+		let (result, assertions) = self.execute();
 		assert!(result.is_ok(), "Interpreter should execute successfully");
-		assert!(ctx.check_assertions(None).is_err(), "Should have assertion failures");
+		assert!(assertions.is_err(), "Should have assertion failures");
 	}
 
 	/// Run the test and check that specific values match expectations
@@ -81,7 +105,7 @@ impl InterpreterTest {
 
 		let hint_registry = HintRegistry::new();
 		let mut interpreter = Interpreter::new(&bytecode, &hint_registry);
-		let mut ctx = ExecutionContext::new(&mut value_vec);
+		let mut ctx = ExecutionContext::new(ValueStore::new(&mut value_vec));
 
 		let result = interpreter.run(&mut ctx);
 		assert!(result.is_ok(), "Interpreter should execute successfully");
@@ -97,8 +121,8 @@ impl InterpreterTest {
 		}
 	}
 
-	/// Execute the bytecode and return the result and context
-	fn execute(self) -> (Result<(), PopulateError>, ExecutionContext<'static>) {
+	/// Execute the bytecode and return the interpreter and assertion results.
+	fn execute(self) -> (Result<(), PopulateError>, Result<(), PopulateError>) {
 		let (bytecode, _) = self.builder.finalize();
 
 		// Create value vec with the right size
@@ -122,12 +146,11 @@ impl InterpreterTest {
 		let hint_registry = HintRegistry::new();
 		let mut interpreter = Interpreter::new(&bytecode, &hint_registry);
 
-		// Leak the value_vec to get 'static lifetime - this is ok in tests
-		let value_vec = Box::leak(Box::new(value_vec));
-		let mut ctx = ExecutionContext::new(value_vec);
+		let mut ctx = ExecutionContext::new(ValueStore::new(&mut value_vec));
 
 		let result = interpreter.run(&mut ctx);
-		(result, ctx)
+		let assertions = ctx.check_assertions(None);
+		(result, assertions)
 	}
 }
 

--- a/crates/frontend/src/compiler/tests.rs
+++ b/crates/frontend/src/compiler/tests.rs
@@ -770,3 +770,157 @@ fn test_zero_constant_not_in_binius64_operands() {
 		}
 	}
 }
+
+#[test]
+fn populate_wire_witness_parallel_matches_sequential_for_independent_components() {
+	let builder = CircuitBuilder::new();
+
+	let a = builder.add_inout();
+	let b = builder.add_inout();
+	let and = builder.band(a, b);
+	let rotate = builder.rotr(a, 13);
+	let first = builder.bxor(and, rotate);
+	let first_expected = builder.add_inout();
+	builder.assert_eq("first", first, first_expected);
+
+	let c = builder.add_inout();
+	let d = builder.add_inout();
+	let zero = builder.add_constant(Word::ZERO);
+	let (sum, carry) = builder.iadd_cin_cout(c, d, zero);
+	let second = builder.bxor(sum, carry);
+	let second_expected = builder.add_inout();
+	builder.assert_eq("second", second, second_expected);
+
+	let e = builder.add_inout();
+	let f = builder.add_inout();
+	let third = builder.icmp_eq(e, f);
+	let third_expected = builder.add_inout();
+	builder.assert_eq("third", third, third_expected);
+
+	let circuit = builder.build();
+
+	let a_value = Word(0xf0f0_f0f0_f0f0_f0f0);
+	let b_value = Word(0x1234_5678_9abc_def0);
+	let c_value = Word(0xffff_ffff_ffff_fff0);
+	let d_value = Word(0x25);
+	let e_value = Word(0xfeed_face_cafe_beef);
+	let (sum_value, carry_value) = c_value.iadd_cin_cout(d_value, Word::ZERO);
+
+	let mut sequential = circuit.new_witness_filler();
+	sequential[a] = a_value;
+	sequential[b] = b_value;
+	sequential[first_expected] = (a_value & b_value) ^ a_value.rotr(13);
+	sequential[c] = c_value;
+	sequential[d] = d_value;
+	sequential[second_expected] = sum_value ^ carry_value;
+	sequential[e] = e_value;
+	sequential[f] = e_value;
+	sequential[third_expected] = Word::MSB_ONE;
+	circuit.populate_wire_witness(&mut sequential).unwrap();
+
+	let mut parallel = circuit.new_witness_filler();
+	parallel[a] = a_value;
+	parallel[b] = b_value;
+	parallel[first_expected] = (a_value & b_value) ^ a_value.rotr(13);
+	parallel[c] = c_value;
+	parallel[d] = d_value;
+	parallel[second_expected] = sum_value ^ carry_value;
+	parallel[e] = e_value;
+	parallel[f] = e_value;
+	parallel[third_expected] = Word::MSB_ONE;
+	circuit
+		.populate_wire_witness_parallel(&mut parallel)
+		.unwrap();
+
+	let mut sequential_values = sequential.into_value_vec();
+	let mut parallel_values = parallel.into_value_vec();
+	assert_eq!(sequential_values.as_mut_slice(), parallel_values.as_mut_slice());
+	verify_constraints(circuit.constraint_system(), &parallel_values).unwrap();
+}
+
+#[cfg(feature = "rayon")]
+#[test]
+fn populate_wire_witness_parallel_matches_sequential_when_dce_is_disabled() {
+	let builder = CircuitBuilder::with_opts(Options {
+		enable_gate_fusion: false,
+		enable_constant_propagation: false,
+		enable_dead_code_elimination: false,
+	});
+
+	let a = builder.add_inout();
+	let b = builder.add_inout();
+	let c = builder.add_inout();
+	let first = builder.band(a, b);
+	let second = builder.rotr(first, 17);
+	let third = builder.bxor(second, c);
+	let expected = builder.add_inout();
+	builder.assert_eq("dce_disabled", third, expected);
+
+	let circuit = builder.build();
+
+	let a_value = Word(0x0f0f_f0f0_3333_cccc);
+	let b_value = Word(0xffff_0000_5555_aaaa);
+	let c_value = Word(0x1234_5678_9abc_def0);
+	let expected_value = (a_value & b_value).rotr(17) ^ c_value;
+
+	let mut sequential = circuit.new_witness_filler();
+	sequential[a] = a_value;
+	sequential[b] = b_value;
+	sequential[c] = c_value;
+	sequential[expected] = expected_value;
+	circuit.populate_wire_witness(&mut sequential).unwrap();
+
+	let mut parallel = circuit.new_witness_filler();
+	parallel[a] = a_value;
+	parallel[b] = b_value;
+	parallel[c] = c_value;
+	parallel[expected] = expected_value;
+	circuit
+		.populate_wire_witness_parallel(&mut parallel)
+		.unwrap();
+
+	let mut sequential_values = sequential.into_value_vec();
+	let mut parallel_values = parallel.into_value_vec();
+	assert_eq!(sequential_values.as_mut_slice(), parallel_values.as_mut_slice());
+	verify_constraints(circuit.constraint_system(), &parallel_values).unwrap();
+}
+
+#[test]
+fn populate_wire_witness_parallel_reports_independent_assertion_failures() {
+	let builder = CircuitBuilder::new();
+
+	let a = builder.add_inout();
+	let b = builder.add_inout();
+	builder.assert_eq("first", a, b);
+
+	let c = builder.add_inout();
+	let d = builder.add_inout();
+	builder.assert_eq("second", c, d);
+
+	let circuit = builder.build();
+
+	let mut sequential = circuit.new_witness_filler();
+	sequential[a] = Word(1);
+	sequential[b] = Word(2);
+	sequential[c] = Word(3);
+	sequential[d] = Word(4);
+	let sequential_err = circuit.populate_wire_witness(&mut sequential).unwrap_err();
+
+	let mut parallel = circuit.new_witness_filler();
+	parallel[a] = Word(1);
+	parallel[b] = Word(2);
+	parallel[c] = Word(3);
+	parallel[d] = Word(4);
+	let parallel_err = circuit
+		.populate_wire_witness_parallel(&mut parallel)
+		.unwrap_err();
+
+	assert_eq!(parallel_err.total_count, sequential_err.total_count);
+	assert_eq!(parallel_err.total_count, 2);
+
+	let mut sequential_messages = sequential_err.messages;
+	let mut parallel_messages = parallel_err.messages;
+	sequential_messages.sort();
+	parallel_messages.sort();
+	assert_eq!(parallel_messages, sequential_messages);
+}


### PR DESCRIPTION
## Summary

Adds an explicit `Circuit::populate_wire_witness_parallel` path that evaluates independent eval-form bytecode components in parallel. The default `populate_wire_witness` path remains sequential and unchanged at the API level.

The parallel path builds connected components over eval bytecode, checks that component writes are disjoint, and then runs those components with a shared raw `ValueStore`. The `unsafe` boundary is intentionally contained to the interpreter store. Soundness depends on two invariants:

- write-disjointness: checked at eval-form build time over outputs, aux wires, and scratch wires
- read-closure: established by a local def-map inside `gate_component_roots`, not by pass-populated `GateGraph::wire_def`, so this remains correct even when optional passes such as DCE are disabled

This also adds a Criterion benchmark group for independent hash circuits that measures `populate_witness + populate_wire_witness_parallel + prove`.

## Benchmarks

Fresh Criterion sweep on Apple M4 Pro, `RAYON_NUM_THREADS=8`, `N_PRIMITIVES=4096`, `LOG_INV_RATE=1`, `--features rayon`, generic `aarch64-apple-darwin` target.

| Primitive | Witness + prove | Parallel witness + prove | Delta |
|---|---:|---:|---:|
| SHA-256 compressions | 218.43 ms | 192.27 ms | -12.0% |
| BLAKE3 compressions | 140.99 ms | 134.25 ms | -4.8% |
| Keccak-f[1600] permutations | 264.15 ms | 228.14 ms | -13.6% |

BLAKE3 was rerun because the first pass was noisy; two follow-up runs clustered around a smaller ~5% win. Proof size at these settings is unchanged by this PR: 352992 bytes (344.72 KiB) for all three independent hash benches.

## Safety / Correctness Notes

- The default sequential witness path is still available and used unless callers opt into `populate_wire_witness_parallel`.
- If the eval form has <=1 component or component writes are not disjoint, the parallel path falls back to sequential evaluation.
- The local def-map avoids relying on `GateGraph::wire_def`, which is only populated by optional compiler passes.
- Tests compare sequential and parallel full `ValueVec` backing storage, including scratch space.
- A DCE-disabled regression covers the original failure mode under `BINIUS_DISABLE_DCE=1`.

## Test Plan

- `cargo test -p binius-frontend`
- `cargo test -p binius-frontend --features rayon`
- `BINIUS_DISABLE_DCE=1 RAYON_NUM_THREADS=8 cargo test -p binius-frontend --features rayon populate_wire_witness_parallel_matches_sequential_when_dce_is_disabled -- --nocapture`
- `cargo check --workspace`
- `cargo clippy --all --all-features --tests --benches --examples -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p binius-frontend --features rayon --document-private-items --no-deps`
- `cargo test -p binius-examples --features rayon independent_hashes --lib`
- `cargo bench -p binius-examples --features rayon --bench sha256_compressions --no-run`
- `cargo bench -p binius-examples --features rayon --bench blake3_compressions --no-run`
- `cargo bench -p binius-examples --features rayon --bench keccak_permutations --no-run`
- `cargo +nightly-2026-01-01 fmt --check`
- Scale smoke under `BINIUS_DISABLE_DCE=1 RAYON_NUM_THREADS=8 N_PRIMITIVES=4096 RUNS=10`: SHA-256 and Keccak both passed 10/10 sequential-vs-parallel full-store equality plus constraint verification.
