### PR TITLE
[shift] Optimize key accumulation and defer reductions in monster multilinear

### DIFF
--- a/crates/prover/benches/shift_reduction.rs
+++ b/crates/prover/benches/shift_reduction.rs
@@ -7,25 +7,23 @@ use binius_field::{BinaryField128bGhash, Field, Random, arch::OptimalPackedB128}
 use binius_frontend::{CircuitBuilder, Wire};
 use binius_ip::sumcheck::SumcheckOutput;
 use binius_math::multilinear::eq::eq_ind_partial_eval;
-use binius_prover::protocols::shift::{OperatorData, build_key_collection, prove};
 use binius_prover::{
 	fold_word::fold_words,
 	protocols::shift::{
-		PreparedOperatorData,
+		OperatorData, PreparedOperatorData, build_key_collection,
 		monster::{build_h_parts, build_monster_multilinear},
 		phase_1::{build_g_parts, run_phase_1_sumcheck},
 		phase_2::{assemble_witness, run_sumcheck},
+		prove,
 	},
 };
 use binius_transcript::ProverTranscript;
 use binius_utils::checked_arithmetics::strict_log_2;
-use binius_verifier::config::LOG_WORD_SIZE_BITS;
 use binius_verifier::{
-	config::StdChallenger,
+	config::{LOG_WORD_SIZE_BITS, StdChallenger},
 	protocols::shift::{OperatorData as VerifierOperatorData, verify},
 };
-use criterion::BatchSize;
-use criterion::{Criterion, criterion_group, criterion_main};
+use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use sha2::{Digest, Sha256 as Sha256Hasher};
 
 pub fn create_sha256_cs_with_witness(
@@ -192,8 +190,8 @@ fn bench_shift_phases(c: &mut Criterion) {
 	type P = OptimalPackedB128;
 	let mut rng = rand::rng();
 
-	// A single fixed size (16384-byte SHA256 message), rather than a sweep, so the per-phase benches
-	// share one setup and stay quick.
+	// A single fixed size (16384-byte SHA256 message), rather than a sweep, so the per-phase
+	// benches share one setup and stay quick.
 	const LOG_MESSAGE_LEN_BYTES: usize = 14;
 
 	let (mut cs, value_vec) = create_sha256_cs_with_witness(LOG_MESSAGE_LEN_BYTES, &mut rng);

--- a/crates/prover/benches/shift_reduction.rs
+++ b/crates/prover/benches/shift_reduction.rs
@@ -1,16 +1,30 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-use binius_circuits::sha256::Sha256;
-use binius_core::{ValueVec, constraint_system::ConstraintSystem};
-use binius_frontend::CircuitBuilder;
+use binius_circuits::sha256::sha256_fixed;
+use binius_core::{ValueVec, constraint_system::ConstraintSystem, word::Word};
+use binius_field::{BinaryField128bGhash, Field, Random, arch::OptimalPackedB128};
+use binius_frontend::{CircuitBuilder, Wire};
+use binius_ip::sumcheck::SumcheckOutput;
+use binius_math::multilinear::eq::eq_ind_partial_eval;
 use binius_prover::protocols::shift::{OperatorData, build_key_collection, prove};
+use binius_prover::{
+	fold_word::fold_words,
+	protocols::shift::{
+		PreparedOperatorData,
+		monster::{build_h_parts, build_monster_multilinear},
+		phase_1::{build_g_parts, run_phase_1_sumcheck},
+		phase_2::{assemble_witness, run_sumcheck},
+	},
+};
 use binius_transcript::ProverTranscript;
 use binius_utils::checked_arithmetics::strict_log_2;
+use binius_verifier::config::LOG_WORD_SIZE_BITS;
 use binius_verifier::{
 	config::StdChallenger,
 	protocols::shift::{OperatorData as VerifierOperatorData, verify},
 };
+use criterion::BatchSize;
 use criterion::{Criterion, criterion_group, criterion_main};
 use sha2::{Digest, Sha256 as Sha256Hasher};
 
@@ -21,34 +35,46 @@ pub fn create_sha256_cs_with_witness(
 	let builder = CircuitBuilder::new();
 	let message_len_bytes: usize = 1 << log_message_len_bytes; // 2^log_message_len
 
-	// Create wires for the SHA256 circuit
-	let len = builder.add_witness(); // Actual message length
-	let digest = [
-		builder.add_inout(), // Expected digest as 4x64-bit words
-		builder.add_inout(),
-		builder.add_inout(),
-		builder.add_inout(),
-	];
-	let message: Vec<binius_frontend::Wire> = (0..message_len_bytes.div_ceil(8usize))
+	// Message wires: one 32-bit word per 4 message bytes (`message_len_bytes` is a power of two,
+	// so this divides evenly).
+	let n_message_words = message_len_bytes.div_ceil(4);
+	let message: Vec<Wire> = (0..n_message_words)
 		.map(|_| builder.add_witness())
 		.collect();
 
-	// Create the SHA256 circuit
-	let sha256 = Sha256::new(&builder, len, digest, message);
+	// Expected digest as 8 big-endian 32-bit words.
+	let expected_digest: [Wire; 8] = std::array::from_fn(|_| builder.add_inout());
+
+	// Compute the SHA256 digest of the fixed-length message and constrain it to the expected wires.
+	let computed_digest = sha256_fixed(&builder, &message, message_len_bytes);
+	for i in 0..8 {
+		builder.assert_eq(format!("digest[{i}]"), computed_digest[i], expected_digest[i]);
+	}
 
 	let circuit = builder.build();
 	let mut witness_filler = circuit.new_witness_filler();
 
-	// Generate random message bytes of specified length
+	// Generate random message bytes of specified length and pack them into big-endian 32-bit words.
 	let mut message_bytes = vec![0u8; message_len_bytes];
 	rng.fill_bytes(&mut message_bytes);
-	sha256.populate_len_bytes(&mut witness_filler, message_bytes.len());
-	sha256.populate_message(&mut witness_filler, &message_bytes);
+	for (word_idx, wire) in message.iter().enumerate() {
+		let mut packed = 0u32;
+		for i in 0..4 {
+			packed |= (message_bytes[word_idx * 4 + i] as u32) << (24 - i * 8);
+		}
+		witness_filler[*wire] = Word(packed as u64);
+	}
 
-	// Calculate SHA256 digest of the message dynamically
+	// Calculate SHA256 digest of the message dynamically and populate the expected digest wires.
 	let hash = Sha256Hasher::digest(&message_bytes);
-	let expected_digest: [u8; 32] = hash.into();
-	sha256.populate_digest(&mut witness_filler, expected_digest);
+	let expected_bytes: [u8; 32] = hash.into();
+	for (i, wire) in expected_digest.iter().enumerate() {
+		let mut word = 0u32;
+		for j in 0..4 {
+			word |= (expected_bytes[i * 4 + j] as u32) << (24 - j * 8);
+		}
+		witness_filler[*wire] = Word(word as u64);
+	}
 
 	// Get the witness vector
 	circuit.populate_wire_witness(&mut witness_filler).unwrap();
@@ -57,9 +83,8 @@ pub fn create_sha256_cs_with_witness(
 }
 
 fn bench_prove_and_verify(c: &mut Criterion) {
-	use binius_field::{BinaryField128bGhash, Field, PackedBinaryGhash1x128b, Random};
 	type F = BinaryField128bGhash;
-	type P = PackedBinaryGhash1x128b;
+	type P = OptimalPackedB128;
 	let mut rng = rand::rng();
 
 	// Configurable log message lengths to benchmark (actual lengths will be 2^log_len)
@@ -163,28 +188,13 @@ fn bench_prove_and_verify(c: &mut Criterion) {
 /// `intmul/phases` breakdown. Each of the five phase functions is timed on its own, sharing one
 /// expensive circuit / witness / key-collection setup.
 fn bench_shift_phases(c: &mut Criterion) {
-	use binius_field::{BinaryField128bGhash, Field, PackedBinaryGhash1x128b, Random};
-	use binius_ip::sumcheck::SumcheckOutput;
-	use binius_math::multilinear::eq::eq_ind_partial_eval;
-	use binius_prover::{
-		fold_word::fold_words,
-		protocols::shift::{
-			PreparedOperatorData,
-			monster::{build_h_parts, build_monster_multilinear},
-			phase_1::{build_g_parts, run_phase_1_sumcheck},
-			phase_2::{assemble_witness, run_sumcheck},
-		},
-	};
-	use binius_verifier::config::LOG_WORD_SIZE_BITS;
-	use criterion::BatchSize;
-
 	type F = BinaryField128bGhash;
-	type P = PackedBinaryGhash1x128b;
+	type P = OptimalPackedB128;
 	let mut rng = rand::rng();
 
-	// A single fixed size (4096-byte SHA256 message), rather than a sweep, so the per-phase benches
+	// A single fixed size (16384-byte SHA256 message), rather than a sweep, so the per-phase benches
 	// share one setup and stay quick.
-	const LOG_MESSAGE_LEN_BYTES: usize = 12;
+	const LOG_MESSAGE_LEN_BYTES: usize = 14;
 
 	let (mut cs, value_vec) = create_sha256_cs_with_witness(LOG_MESSAGE_LEN_BYTES, &mut rng);
 	cs.validate_and_prepare().unwrap();

--- a/crates/prover/src/protocols/shift/key_collection.rs
+++ b/crates/prover/src/protocols/shift/key_collection.rs
@@ -124,10 +124,13 @@ impl Key {
 		})
 	}
 
-	/// Accumulates the same weighted sum as [`Self::accumulate_by_operand`], but fuses the
+	/// Accumulates the partial evaluation of an operation matrix for the key.
+	///
+	/// A [`Key`] references the operation constraints where one witness word is an operand. This
+	/// accumulates the partial evaluation of the operation matrix for this key, fusing the
 	/// `lambda_powers[operand_index]` weighting into the consecutive-operand scan.
 	#[inline]
-	fn accumulate_weighted<F: Field>(
+	pub fn accumulate<F: Field>(
 		&self,
 		constraint_indices: &[ConstraintIndex],
 		operator_data: &PreparedOperatorData<F>,
@@ -156,19 +159,6 @@ impl Key {
 		}
 
 		result + acc * operator_data.lambda_powers[operand_index]
-	}
-
-	/// Accumulates the partial evaluation of an operation matrix for the key.
-	///
-	/// A [`Key`] references the operation constraints where one witness word is an operand. This
-	/// accumulates the partial evaluation of the operation matrix for this key.
-	#[inline]
-	pub fn accumulate<F: Field>(
-		&self,
-		constraint_indices: &[ConstraintIndex],
-		operator_data: &PreparedOperatorData<F>,
-	) -> F {
-		self.accumulate_weighted(constraint_indices, operator_data)
 	}
 }
 
@@ -548,7 +538,7 @@ mod tests {
 	}
 
 	#[test]
-	fn accumulate_weighted_matches_grouped_operand_accumulation() {
+	fn accumulate_matches_grouped_operand_accumulation() {
 		let constraint_indices = vec![
 			ConstraintIndex {
 				operand_index: 0,
@@ -597,7 +587,7 @@ mod tests {
 			.map(|(operand_index, acc)| acc * operator_data.lambda_powers[operand_index])
 			.sum::<F>();
 
-		assert_eq!(key.accumulate_weighted(&constraint_indices, &operator_data), expected);
+		assert_eq!(key.accumulate(&constraint_indices, &operator_data), expected);
 
 		let non_contiguous_constraint_indices = vec![
 			ConstraintIndex {
@@ -632,8 +622,7 @@ mod tests {
 			.sum::<F>();
 
 		assert_eq!(
-			non_contiguous_key
-				.accumulate_weighted(&non_contiguous_constraint_indices, &operator_data),
+			non_contiguous_key.accumulate(&non_contiguous_constraint_indices, &operator_data),
 			non_contiguous_expected
 		);
 
@@ -642,6 +631,6 @@ mod tests {
 			id: 0,
 			range: 0..0,
 		};
-		assert_eq!(empty_key.accumulate_weighted(&constraint_indices, &operator_data), F::ZERO);
+		assert_eq!(empty_key.accumulate(&constraint_indices, &operator_data), F::ZERO);
 	}
 }

--- a/crates/prover/src/protocols/shift/key_collection.rs
+++ b/crates/prover/src/protocols/shift/key_collection.rs
@@ -124,29 +124,31 @@ impl Key {
 		})
 	}
 
-	/// Accumulates the partial evaluation of an operation matrix for the key.
+	/// Accumulates the partial evaluation of an operation matrix for the key, in unreduced (wide)
+	/// form.
 	///
 	/// A [`Key`] references the operation constraints where one witness word is an operand. This
 	/// accumulates the partial evaluation of the operation matrix for this key, weighting each
 	/// operand's contribution by `scalars[operand_index]` and fusing that weighting into the
-	/// consecutive-operand scan.
+	/// consecutive-operand scan. The caller reduces the result via [`WideMul::reduce`], and may
+	/// sum several wide accumulations before that single reduction.
 	#[inline]
-	pub fn accumulate<F: Field>(
+	pub fn accumulate_wide<F: Field>(
 		&self,
 		constraint_indices: &[ConstraintIndex],
 		r_x_prime_tensor: &[F],
 		scalars: &[F],
-	) -> F {
+	) -> <F as WideMul>::Output {
 		let Range { start, end } = self.range;
 		let mut constraint_indices = constraint_indices[start as usize..end as usize].iter();
 
+		let mut result = <F as WideMul>::Output::default();
 		let Some(first) = constraint_indices.next() else {
-			return F::ZERO;
+			return result;
 		};
 
 		let mut operand_index = first.operand_index as usize;
 		let mut acc = F::ZERO;
-		let mut result = <F as WideMul>::Output::default();
 		acc += r_x_prime_tensor[first.constraint_index as usize];
 
 		for current in constraint_indices {
@@ -159,7 +161,20 @@ impl Key {
 			acc += r_x_prime_tensor[current.constraint_index as usize];
 		}
 
-		F::reduce(result + F::wide_mul(acc, scalars[operand_index]))
+		result + F::wide_mul(acc, scalars[operand_index])
+	}
+
+	/// Accumulates the partial evaluation of an operation matrix for the key.
+	///
+	/// This is [`Self::accumulate_wide`] followed by a single reduction.
+	#[inline]
+	pub fn accumulate<F: Field>(
+		&self,
+		constraint_indices: &[ConstraintIndex],
+		r_x_prime_tensor: &[F],
+		scalars: &[F],
+	) -> F {
+		F::reduce(self.accumulate_wide(constraint_indices, r_x_prime_tensor, scalars))
 	}
 }
 

--- a/crates/prover/src/protocols/shift/key_collection.rs
+++ b/crates/prover/src/protocols/shift/key_collection.rs
@@ -127,13 +127,15 @@ impl Key {
 	/// Accumulates the partial evaluation of an operation matrix for the key.
 	///
 	/// A [`Key`] references the operation constraints where one witness word is an operand. This
-	/// accumulates the partial evaluation of the operation matrix for this key, fusing the
-	/// `lambda_powers[operand_index]` weighting into the consecutive-operand scan.
+	/// accumulates the partial evaluation of the operation matrix for this key, weighting each
+	/// operand's contribution by `scalars[operand_index]` and fusing that weighting into the
+	/// consecutive-operand scan.
 	#[inline]
 	pub fn accumulate<F: Field>(
 		&self,
 		constraint_indices: &[ConstraintIndex],
-		operator_data: &PreparedOperatorData<F>,
+		r_x_prime_tensor: &[F],
+		scalars: &[F],
 	) -> F {
 		let Range { start, end } = self.range;
 		let mut constraint_indices = constraint_indices[start as usize..end as usize].iter();
@@ -145,20 +147,19 @@ impl Key {
 		let mut operand_index = first.operand_index as usize;
 		let mut acc = F::ZERO;
 		let mut result = <F as WideMul>::Output::default();
-		let tensor = operator_data.r_x_prime_tensor.as_ref();
-		acc += tensor[first.constraint_index as usize];
+		acc += r_x_prime_tensor[first.constraint_index as usize];
 
 		for current in constraint_indices {
 			let current_operand_index = current.operand_index as usize;
 			if current_operand_index != operand_index {
-				result += F::wide_mul(acc, operator_data.lambda_powers[operand_index]);
+				result += F::wide_mul(acc, scalars[operand_index]);
 				operand_index = current_operand_index;
 				acc = F::ZERO;
 			}
-			acc += tensor[current.constraint_index as usize];
+			acc += r_x_prime_tensor[current.constraint_index as usize];
 		}
 
-		F::reduce(result + F::wide_mul(acc, operator_data.lambda_powers[operand_index]))
+		F::reduce(result + F::wide_mul(acc, scalars[operand_index]))
 	}
 }
 
@@ -587,7 +588,14 @@ mod tests {
 			.map(|(operand_index, acc)| acc * operator_data.lambda_powers[operand_index])
 			.sum::<F>();
 
-		assert_eq!(key.accumulate(&constraint_indices, &operator_data), expected);
+		assert_eq!(
+			key.accumulate(
+				&constraint_indices,
+				operator_data.r_x_prime_tensor.as_ref(),
+				&operator_data.lambda_powers
+			),
+			expected
+		);
 
 		let non_contiguous_constraint_indices = vec![
 			ConstraintIndex {
@@ -622,7 +630,11 @@ mod tests {
 			.sum::<F>();
 
 		assert_eq!(
-			non_contiguous_key.accumulate(&non_contiguous_constraint_indices, &operator_data),
+			non_contiguous_key.accumulate(
+				&non_contiguous_constraint_indices,
+				operator_data.r_x_prime_tensor.as_ref(),
+				&operator_data.lambda_powers
+			),
 			non_contiguous_expected
 		);
 
@@ -631,6 +643,13 @@ mod tests {
 			id: 0,
 			range: 0..0,
 		};
-		assert_eq!(empty_key.accumulate(&constraint_indices, &operator_data), F::ZERO);
+		assert_eq!(
+			empty_key.accumulate(
+				&constraint_indices,
+				operator_data.r_x_prime_tensor.as_ref(),
+				&operator_data.lambda_powers
+			),
+			F::ZERO
+		);
 	}
 }

--- a/crates/prover/src/protocols/shift/key_collection.rs
+++ b/crates/prover/src/protocols/shift/key_collection.rs
@@ -10,7 +10,7 @@ use binius_core::{
 	},
 	consts::LOG_WORD_SIZE_BITS,
 };
-use binius_field::Field;
+use binius_field::{Field, WideMul};
 use binius_utils::{
 	checked_arithmetics::log2_ceil_usize,
 	serialization::{DeserializeBytes, SerializationError, SerializeBytes},
@@ -144,21 +144,21 @@ impl Key {
 
 		let mut operand_index = first.operand_index as usize;
 		let mut acc = F::ZERO;
-		let mut result = F::ZERO;
+		let mut result = <F as WideMul>::Output::default();
 		let tensor = operator_data.r_x_prime_tensor.as_ref();
 		acc += tensor[first.constraint_index as usize];
 
 		for current in constraint_indices {
 			let current_operand_index = current.operand_index as usize;
 			if current_operand_index != operand_index {
-				result += acc * operator_data.lambda_powers[operand_index];
+				result += F::wide_mul(acc, operator_data.lambda_powers[operand_index]);
 				operand_index = current_operand_index;
 				acc = F::ZERO;
 			}
 			acc += tensor[current.constraint_index as usize];
 		}
 
-		result + acc * operator_data.lambda_powers[operand_index]
+		F::reduce(result + F::wide_mul(acc, operator_data.lambda_powers[operand_index]))
 	}
 }
 

--- a/crates/prover/src/protocols/shift/monster.rs
+++ b/crates/prover/src/protocols/shift/monster.rs
@@ -3,7 +3,7 @@
 
 use std::iter;
 
-use binius_field::{AESTowerField8b, BinaryField, Field, PackedField};
+use binius_field::{AESTowerField8b, BinaryField, Field, PackedField, WideMul};
 use binius_math::{
 	BinarySubspace, FieldBuffer, multilinear::eq::eq_ind_partial_eval, univariate::lagrange_evals,
 };
@@ -192,9 +192,10 @@ where
 	let log_len = log_half + 1;
 	let capacity = 1 << log_len.saturating_sub(P::LOG_WIDTH);
 
-	// The scalar for one word of a segment: the accumulated contribution of all its keys.
+	// The scalar for one word of a segment: the accumulated contribution of all its keys. The
+	// per-key wide accumulations are summed unreduced and reduced once at the end.
 	let word_scalar = |segment: &KeySegment, index: usize| {
-		segment
+		let wide = segment
 			.word_keys(index)
 			.iter()
 			.map(|key| {
@@ -203,13 +204,14 @@ where
 					Operation::IntegerMul => (intmul_operator_data, &intmul_scalars, INTMUL_ARITY),
 				};
 				let base = key.id as usize * arity;
-				key.accumulate(
+				key.accumulate_wide(
 					&segment.constraint_indices,
 					operator_data.r_x_prime_tensor.as_ref(),
 					&scalars[base..base + arity],
 				)
 			})
-			.sum::<F>()
+			.sum::<<F as WideMul>::Output>();
+		F::reduce(wide)
 	};
 
 	// The multilinear is indexed over the witness address space: the public segment at the

--- a/crates/prover/src/protocols/shift/monster.rs
+++ b/crates/prover/src/protocols/shift/monster.rs
@@ -123,11 +123,11 @@ where
 ///
 /// For each word w, computes:
 /// ```text
-/// ∑_{key ∈ keys[w]} key.accumulate(constraint_indices, tensor) × scalars[key.id]
+/// ∑_{key ∈ keys[w]} key.accumulate(constraint_indices, tensor, scalars[key.id])
 /// ```
-/// where the scalars encode `λ^(operand_idx+1) × h_op[shift_variant] × r_s_tensor[shift_amount]`
-/// for operand index `operand_idx` and `shift_variant` in {SLL, SRL, SRA} and `shift_amount` in
-/// [0, WORD_SIZE_BITS).
+/// where `scalars[key.id]` is the contiguous per-operand chunk encoding
+/// `λ^(operand_idx+1) × h_op[shift_variant] × r_s_tensor[shift_amount]` for operand index
+/// `operand_idx` and `shift_variant` in {SLL, SRL, SRA} and `shift_amount` in [0, WORD_SIZE_BITS).
 ///
 /// # Usage
 ///
@@ -157,18 +157,19 @@ where
 
 	let r_s_tensor = eq_ind_partial_eval::<F>(r_s);
 
-	// Allocate and populate the scalars
+	// Allocate and populate the scalars, laid out with the operand index innermost so that the
+	// `arity` weights for one `key.id` (= `op * WORD_SIZE_BITS + s`) form a contiguous chunk that
+	// [`Key::accumulate`] can index directly by operand index.
 	let mut bitand_scalars = vec![F::ZERO; BITAND_ARITY * SHIFT_VARIANT_COUNT * WORD_SIZE_BITS];
 	let mut intmul_scalars = vec![F::ZERO; INTMUL_ARITY * SHIFT_VARIANT_COUNT * WORD_SIZE_BITS];
 
 	let populate_scalars = |scalars: &mut [F], arity: usize, lambda_powers: &[F], h_ops: &[F]| {
-		for operand_idx in 0..arity {
-			for op in 0..SHIFT_VARIANT_COUNT {
-				let operand_op_idx = operand_idx * SHIFT_VARIANT_COUNT + op;
-				let operand_op_scalar = lambda_powers[operand_idx] * h_ops[op];
-				for s in 0..WORD_SIZE_BITS {
-					let operand_op_s_idx = operand_op_idx * WORD_SIZE_BITS + s;
-					scalars[operand_op_s_idx] = operand_op_scalar * r_s_tensor.as_ref()[s];
+		for op in 0..SHIFT_VARIANT_COUNT {
+			for s in 0..WORD_SIZE_BITS {
+				let key_id = op * WORD_SIZE_BITS + s;
+				let op_s_scalar = h_ops[op] * r_s_tensor.as_ref()[s];
+				for operand_idx in 0..arity {
+					scalars[key_id * arity + operand_idx] = lambda_powers[operand_idx] * op_s_scalar;
 				}
 			}
 		}
@@ -197,17 +198,16 @@ where
 			.word_keys(index)
 			.iter()
 			.map(|key| {
-				let (operator_data, scalars) = match key.operation {
-					Operation::BitwiseAnd => (bitand_operator_data, &bitand_scalars),
-					Operation::IntegerMul => (intmul_operator_data, &intmul_scalars),
+				let (operator_data, scalars, arity) = match key.operation {
+					Operation::BitwiseAnd => (bitand_operator_data, &bitand_scalars, BITAND_ARITY),
+					Operation::IntegerMul => (intmul_operator_data, &intmul_scalars, INTMUL_ARITY),
 				};
-				key.accumulate_by_operand(&segment.constraint_indices, operator_data)
-					.map(|(operand_index, acc)| {
-						let index =
-							key.id as usize + operand_index * SHIFT_VARIANT_COUNT * WORD_SIZE_BITS;
-						acc * scalars[index]
-					})
-					.sum::<F>()
+				let base = key.id as usize * arity;
+				key.accumulate(
+					&segment.constraint_indices,
+					operator_data.r_x_prime_tensor.as_ref(),
+					&scalars[base..base + arity],
+				)
 			})
 			.sum::<F>()
 	};

--- a/crates/prover/src/protocols/shift/monster.rs
+++ b/crates/prover/src/protocols/shift/monster.rs
@@ -169,7 +169,8 @@ where
 				let key_id = op * WORD_SIZE_BITS + s;
 				let op_s_scalar = h_ops[op] * r_s_tensor.as_ref()[s];
 				for operand_idx in 0..arity {
-					scalars[key_id * arity + operand_idx] = lambda_powers[operand_idx] * op_s_scalar;
+					scalars[key_id * arity + operand_idx] =
+						lambda_powers[operand_idx] * op_s_scalar;
 				}
 			}
 		}

--- a/crates/prover/src/protocols/shift/phase_1.rs
+++ b/crates/prover/src/protocols/shift/phase_1.rs
@@ -210,7 +210,11 @@ pub fn build_g_parts<F: BinaryField, P: PackedField<Scalar = F>>(
 						Operation::IntegerMul => intmul_operator_data,
 					};
 
-					let acc = key.accumulate(&segment.constraint_indices, operator_data);
+					let acc = key.accumulate(
+						&segment.constraint_indices,
+						operator_data.r_x_prime_tensor.as_ref(),
+						&operator_data.lambda_powers,
+					);
 					let acc_packed = P::broadcast(acc);
 
 					// The following loop is an optimized version of the following


### PR DESCRIPTION
## Summary

A series of optimizations and cleanups to the shift-protocol key accumulation (`Key::accumulate`) and the phase-2 `build_monster_multilinear`, plus a benchmark refresh.

## Changes

- **`[shift_reduction] Improve benchmark`** — switch the benchmark circuit to the dense fixed-length SHA-256 gadget (`sha256_fixed`) so `build_g_parts` / `build_monster_multilinear` are exercised on a realistic, dense witness.
- **`[key_collection] Cleanup redundant method`** — fold the redundant `accumulate_weighted` into `accumulate` and delete it.
- **`[key_collection] Use delayed reduction in accumulate`** — accumulate the per-operand products in unreduced (wide) form via `WideMul::wide_mul` and reduce once at the end, amortizing the GF(2¹²⁸) reduction.
- **`[shift] Use Key::accumulate in build_monster_multilinear`** — generalize `Key::accumulate` to take the `r_x_prime_tensor` and a `scalars` slice directly (instead of `PreparedOperatorData`), weighting each operand by `scalars[operand_index]`. `build_monster_multilinear` now calls `accumulate` instead of `accumulate_by_operand`, with the bitand/intmul scalar arrays transposed to operand-innermost layout so each `key.id` maps to a contiguous per-operand chunk.
- **`[shift] Add Key::accumulate_wide and defer reduction in monster`** — split out `Key::accumulate_wide` returning the unreduced `<F as WideMul>::Output`; `accumulate` is now `F::reduce(accumulate_wide(...))`. `word_scalar` sums the per-key wide accumulations and reduces once per word instead of once per key.

## Testing

- `cargo test -p binius-prover` (shift unit tests + `test_shift_prove_and_verify` roundtrip) pass.
- Benchmark (`shift_reduction`) builds and runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
