### PR TITLE
BINIUS-229: optimize power_table with strided packed field muls

### DIFF
--- a/crates/prover/src/protocols/intmul/witness.rs
+++ b/crates/prover/src/protocols/intmul/witness.rs
@@ -163,19 +163,70 @@ where
 	}
 }
 
+/// Number of packed columns filled as one independent group before chaining to the next block.
+///
+/// The power chain `base^i` is inherently serial; striding the fill into blocks of
+/// `2^LOG_STRIDE` independent packed multiplies exposes instruction-level parallelism so the
+/// multiplier pipeline stays busy. `4` keeps a block (16 packed elements) comfortably in registers.
+const LOG_STRIDE: usize = 4;
+
+/// The first `count` powers of `base` (`base^0 .. base^(count-1)`) plus the next power
+/// `base^count`.
+fn sequential_powers<F: Field>(count: usize, base: F) -> (Vec<F>, F) {
+	let mut scalars = Vec::with_capacity(count);
+	let mut row = F::ONE;
+	for _ in 0..count {
+		scalars.push(row);
+		row *= base;
+	}
+	(scalars, row)
+}
+
 /// Build the power table of `base` with `2^log_size` rows: row `i` holds `base^i`.
 pub fn power_table<F, P>(log_size: usize, base: F) -> FieldBuffer<P>
 where
 	F: Field,
 	P: PackedField<Scalar = F>,
 {
-	let mut scalars = Vec::with_capacity(1 << log_size);
-	let mut row = F::ONE;
-	for _ in 0..1usize << log_size {
-		scalars.push(row);
-		row *= base;
+	// The first block spans `2^log_block` scalars = `2^LOG_STRIDE` packed elements.
+	let log_block = P::LOG_WIDTH + LOG_STRIDE;
+
+	// Small tables (at most one block) don't benefit from striding; build them sequentially. This
+	// also covers `log_size < P::LOG_WIDTH` (a single partially-filled packed element).
+	if log_size <= log_block {
+		let (scalars, _) = sequential_powers(1 << log_size, base);
+		return FieldBuffer::<P>::from_values(&scalars);
 	}
-	FieldBuffer::<P>::from_values(&scalars)
+
+	// Build the first block's `2^log_block` sequential powers, packed into `2^LOG_STRIDE` elements;
+	// `incr = base^(2^log_block)` is the per-block increment.
+	let (block_scalars, incr_scalar) = sequential_powers(1 << log_block, base);
+	let incr = P::broadcast(incr_scalar);
+
+	let block_len = 1 << LOG_STRIDE; // packed elements per block
+	let packed_len = 1 << (log_size - P::LOG_WIDTH);
+	let mut table = Vec::<P>::with_capacity(packed_len);
+	table.extend(
+		block_scalars
+			.chunks(P::WIDTH)
+			.map(|chunk| P::from_scalars(chunk.iter().copied())),
+	);
+	table.resize(packed_len, P::zero());
+
+	// Fill each block from the previous one; the `block_len` multiplies within a block are
+	// independent, so only the block-to-block step carries a dependency.
+	let mut blocks = table.chunks_mut(block_len);
+	let mut prev = blocks
+		.next()
+		.expect("log_size > log_block, so packed_len > block_len");
+	for cur in blocks {
+		for (dst, &src) in cur.iter_mut().zip(prev.iter()) {
+			*dst = src * incr;
+		}
+		prev = cur;
+	}
+
+	FieldBuffer::new(log_size, table.into_boxed_slice())
 }
 
 /// Extract limb `l` of an exponent word as a table row index.
@@ -406,7 +457,6 @@ mod tests {
 		let witness = Witness::<P>::new(&a, &b, &c_lo, &c_hi).unwrap();
 		check_consistency(&witness);
 	}
-
 	/// Directly checks `compute_b_leaves` against its specification — leaf `z` holds
 	/// `bases[i]^(2^z)` where bit `z` of `exponents[i]` is set, else `F::ONE` — over both the
 	/// parallel path (`n_vars >= P::LOG_WIDTH`) and the scalar fallback (`n_vars < P::LOG_WIDTH`).
@@ -447,6 +497,30 @@ mod tests {
 					);
 					base = base.square();
 				}
+			}
+		}
+	}
+
+	/// Checks `power_table` against a sequential reference (`row i == base^i`) across both the
+	/// small sequential fallback (`log_size <= P::LOG_WIDTH + LOG_STRIDE`) and the strided packed
+	/// path.
+	#[test]
+	fn power_table_matches_sequential() {
+		use binius_field::{BinaryField128bGhash, Random};
+		use rand::prelude::*;
+
+		type F = BinaryField128bGhash;
+
+		let mut rng = StdRng::seed_from_u64(2);
+		let base = F::random(&mut rng);
+		// `Packed128b` has `LOG_WIDTH == 2`, so `log_block == 6`: sizes up to 6 take the sequential
+		// fallback; 7 and 10 (multiple blocks) exercise the strided path.
+		for log_size in [0usize, 3, 6, 7, 10] {
+			let table = power_table::<F, P>(log_size, base);
+			let mut expected = F::ONE;
+			for i in 0..1usize << log_size {
+				assert_eq!(table.get(i), expected, "mismatch at log_size={log_size}, i={i}");
+				expected *= base;
 			}
 		}
 	}


### PR DESCRIPTION
Rewrites `power_table` (intmul witness) to fill the table with strided packed multiplies instead of a serial scalar power chain, exposing instruction-level parallelism.

Linear: https://linear.app/jimpo/issue/BINIUS-229

## Approach

The old version walked `base^i` one scalar at a time (`row *= base`) — a fully serial dependency chain through the multiplier. The new version:
1. builds the first **stride block** of `2^(P::LOG_WIDTH + LOG_STRIDE)` sequential powers, packed into `2^LOG_STRIDE` packed elements;
2. fills each subsequent block by multiplying the previous block, element-wise, by `incr = base^(2^(P::LOG_WIDTH + LOG_STRIDE))` broadcast.

The `2^LOG_STRIDE` multiplies **within** a block are independent, so the CPU pipelines them; only the block-to-block step carries a dependency. `LOG_STRIDE = 4` (16 packed elements per block). Small tables (≤ one block, incl. `log_size < P::LOG_WIDTH`) keep the simple sequential build. A small `sequential_powers` helper dedups the two sequential loops.

## Correctness

Behavior-preserving (row `i` is still exactly `base^i`). Added `power_table_matches_sequential`, a direct oracle test checking every row against a sequential reference across both the fallback and strided paths (sizes 0/3/6 fallback, 7/10 strided). Existing `test_forwards*` pass.

## Performance

`intmul/components/power_table` (criterion, `-C target-cpu=native`, `P = PackedBinaryGhash4x128b`, `log_size = LIMB_BITS = 16`), baseline = `main` via a throwaway sibling commit:

| | median |
|---|---|
| before (serial scalar chain) | ~766 µs |
| after (strided packed) | ~196 µs |
| criterion change | **−74.4%** (p = 0.00), ≈ 3.9× |

Numbers in a comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)