### PR TITLE
BINIUS-227: sparse first round for shift phase-2 sumcheck (draft for review)

### DIFF
--- a/crates/prover/benches/shift_reduction.rs
+++ b/crates/prover/benches/shift_reduction.rs
@@ -13,7 +13,7 @@ use binius_prover::{
 		OperatorData, PreparedOperatorData, build_key_collection,
 		monster::{build_h_parts, build_monster_multilinear},
 		phase_1::{build_g_parts, run_phase_1_sumcheck},
-		phase_2::{assemble_witness, run_sumcheck},
+		phase_2::run_sumcheck,
 		prove,
 	},
 };
@@ -251,8 +251,6 @@ fn bench_shift_phases(c: &mut Criterion) {
 	let (public_words, hidden_words) = words.split_at(key_collection.public.n_words());
 	let public_folded = fold_words::<F, P>(public_words, r_j_tensor.as_ref());
 	let hidden_folded = fold_words::<F, P>(hidden_words, r_j_tensor.as_ref());
-	let witness_folded =
-		assemble_witness(&public_folded, &hidden_folded, key_collection.log_witness_words());
 	let monster_multilinear = build_monster_multilinear::<F, P>(
 		&key_collection,
 		&prepared_bitand,
@@ -286,7 +284,7 @@ fn bench_shift_phases(c: &mut Criterion) {
 	});
 
 	// Phase 2. `build_monster_multilinear` takes its inputs by reference; `run_sumcheck` consumes
-	// `r_j_witness`, `monster_multilinear`, and `r_j` by value.
+	// the two folded segments, `monster_multilinear`, and `r_j` by value.
 	group.bench_function("phase2_build_monster_multilinear", |b| {
 		b.iter(|| {
 			build_monster_multilinear::<F, P>(
@@ -300,11 +298,20 @@ fn bench_shift_phases(c: &mut Criterion) {
 	});
 	group.bench_function("phase2_run_sumcheck", |b| {
 		b.iter_batched(
-			|| (witness_folded.clone(), monster_multilinear.clone(), r_j.clone()),
-			|(witness_folded, monster_multilinear, r_j)| {
+			|| {
+				(
+					public_folded.clone(),
+					hidden_folded.clone(),
+					monster_multilinear.clone(),
+					r_j.clone(),
+				)
+			},
+			|(public_folded, hidden_folded, monster_multilinear, r_j)| {
 				let mut transcript = ProverTranscript::<StdChallenger>::default();
 				run_sumcheck::<F, P, _>(
-					witness_folded,
+					public_folded,
+					hidden_folded,
+					hidden_words.len(),
 					public_words,
 					monster_multilinear,
 					r_j,

--- a/crates/prover/src/protocols/shift/phase_2.rs
+++ b/crates/prover/src/protocols/shift/phase_2.rs
@@ -3,7 +3,7 @@
 
 use binius_core::word::Word;
 use binius_field::{AESTowerField8b, BinaryField, Field, PackedField};
-use binius_ip::sumcheck::SumcheckOutput;
+use binius_ip::sumcheck::{RoundCoeffs, SumcheckOutput};
 use binius_ip_prover::{
 	channel::IPProverChannel,
 	sumcheck::{
@@ -12,7 +12,10 @@ use binius_ip_prover::{
 };
 use binius_math::{
 	FieldBuffer,
-	multilinear::eq::{eq_ind_partial_eval, eq_ind_zero},
+	multilinear::{
+		eq::{eq_ind_partial_eval, eq_ind_zero},
+		fold::fold_highest_var_inplace,
+	},
 };
 use binius_utils::checked_arithmetics::checked_log_2;
 use binius_verifier::{config::LOG_WORD_SIZE_BITS, protocols::shift::evaluate_words_mle};
@@ -73,18 +76,27 @@ where
 
 	let r_j_tensor = eq_ind_partial_eval::<F>(&r_j);
 
-	// Fold each segment separately and assemble the witness: the public words at the base of
-	// the low half-cube, the hidden words at the base of the high half-cube.
+	// Fold each committed segment separately. The witness multilinear is, conceptually, the public
+	// folded segment at the base of the low half-cube and the hidden folded segment at the base of
+	// the high half-cube. Rather than materialize that mostly-zero combined buffer, the sumcheck's
+	// special first round consumes the two segments directly (see `run_sumcheck`).
 	let (public_words, hidden_words) = words.split_at(key_collection.public.n_words());
 	let public_folded = fold_words::<_, P>(public_words, r_j_tensor.as_ref());
 	let hidden_folded = fold_words::<_, P>(hidden_words, r_j_tensor.as_ref());
-	let witness_folded =
-		assemble_witness(&public_folded, &hidden_folded, key_collection.log_witness_words());
 
 	let monster_multilinear =
 		build_monster_multilinear(key_collection, bitand_data, intmul_data, &r_j, &r_s);
 
-	run_sumcheck(witness_folded, public_words, monster_multilinear, r_j, gamma, channel)
+	run_sumcheck(
+		public_folded,
+		hidden_folded,
+		hidden_words.len(),
+		public_words,
+		monster_multilinear,
+		r_j,
+		gamma,
+		channel,
+	)
 }
 
 /// Assembles the folded witness from its two folded segments.
@@ -107,15 +119,26 @@ pub fn assemble_witness<F: Field, P: PackedField<Scalar = F>>(
 	witness_folded
 }
 
-/// Executes the bivariate product sumcheck for the witness and monster multilinear
-/// relationship.
+/// Executes the bivariate product sumcheck for the witness and monster multilinear relationship,
+/// with a special first round over the two committed segments.
 ///
-/// This helper function runs the sumcheck protocol to prove the relationship between
-/// the witness and monster multilinear, then sends the hidden-segment evaluation: the
-/// verifier reconstructs the full witness evaluation from it and its own public words.
+/// The witness multilinear is, conceptually, the public folded segment at the base of the low
+/// half-cube and the hidden folded segment at the base of the high half-cube, zero-padded to
+/// `2^(log_half + 1)` scalars (see [`assemble_witness`]). Its first sumcheck round binds the
+/// most-significant "segment selector" variable that distinguishes the two halves. Instead of
+/// materializing that mostly-zero combined buffer and running a full-width first round, this round
+/// is computed directly from the two segments, doing work proportional to `n_public_words +
+/// n_hidden_words`. The remaining rounds run the generic bivariate product sumcheck over the
+/// half-size folded buffers. The transcript is identical to the dense formulation.
+///
+/// After the sumcheck, sends the hidden-segment evaluation: the verifier reconstructs the full
+/// witness evaluation from it and its own public words.
 ///
 /// # Parameters
-/// - `witness_folded`: The witness folded at challenges `r_j`
+/// - `public_folded`: The public segment folded at challenges `r_j` (`n_public_words` scalars)
+/// - `hidden_folded`: The hidden segment folded at challenges `r_j` (padded to `2^log_half`
+///   scalars)
+/// - `n_hidden_words`: The number of real hidden words; bounds the sparse first-round work
 /// - `public_words`: The public segment words, for the witness evaluation derivation
 /// - `monster_multilinear`: The monster multilinear polynomial constructed from constraints
 /// - `r_j`: Challenge vector from phase 1 (first `LOG_WORD_SIZE_BITS` challenges)
@@ -126,10 +149,13 @@ pub fn assemble_witness<F: Field, P: PackedField<Scalar = F>>(
 /// Returns `SumcheckOutput` with concatenated challenges `[r_j, r_y]` and the committed-half
 /// evaluation.
 #[instrument(skip_all, name = "run_sumcheck")]
+#[allow(clippy::too_many_arguments)]
 pub fn run_sumcheck<F, P: PackedField<Scalar = F>, Channel: IPProverChannel<F>>(
-	witness_folded: FieldBuffer<P>,
+	public_folded: FieldBuffer<P>,
+	hidden_folded: FieldBuffer<P>,
+	n_hidden_words: usize,
 	public_words: &[Word],
-	monster_multilinear: FieldBuffer<P>,
+	mut monster_multilinear: FieldBuffer<P>,
 	r_j: Vec<F>,
 	gamma: F,
 	channel: &mut Channel,
@@ -137,18 +163,67 @@ pub fn run_sumcheck<F, P: PackedField<Scalar = F>, Channel: IPProverChannel<F>>(
 where
 	F: BinaryField + From<AESTowerField8b>,
 {
+	let log_half = monster_multilinear.log_len() - 1;
+	let half = 1usize << log_half;
+	let n_public_words = public_words.len();
+
 	#[cfg(debug_assertions)]
-	let cloned_witness_folded_for_debugging = witness_folded.clone();
+	let debug_witness_folded = assemble_witness(&public_folded, &hidden_folded, log_half);
 
-	// Run sumcheck on bivariate product
-	let prover = BivariateProductSumcheckProver::new([witness_folded, monster_multilinear], gamma);
+	// Special first round (binds the segment selector). Over the combined witness `A` and monster
+	// `B`, with `A_0`/`B_0` the low (public) halves and `A_1`/`B_1` the high (hidden) halves, the
+	// round evaluations are `y_1 = Σ A_1·B_1` and `y_∞ = Σ (A_0+A_1)(B_0+B_1)`. The public folded
+	// segment occupies `[0, n_public_words)` of the low half; the hidden folded segment occupies
+	// `[0, n_hidden_words)` of the high half; everything else is zero. Since `n_hidden_words >=
+	// n_public_words`, iterating `[0, n_hidden_words)` covers every non-zero term, so the work is
+	// proportional to the two segment sizes rather than the full `2^(log_half + 1)` cube.
+	let (mut y_1, mut y_inf) = (F::ZERO, F::ZERO);
+	for i in 0..n_hidden_words {
+		let a_0 = if i < n_public_words {
+			public_folded.get(i)
+		} else {
+			F::ZERO
+		};
+		let a_1 = hidden_folded.get(i);
+		let b_0 = monster_multilinear.get(i);
+		let b_1 = monster_multilinear.get(half + i);
+		y_1 += a_1 * b_1;
+		y_inf += (a_0 + a_1) * (b_0 + b_1);
+	}
+	// Interpolate the degree-2 round polynomial from `(y_0 = gamma - y_1, y_1, y_∞)`.
+	let y_0 = gamma - y_1;
+	let round_coeffs = RoundCoeffs(vec![y_0, y_1 - y_0 - y_inf, y_inf]);
+	channel.send_many(round_coeffs.clone().truncate().coeffs());
+	let r_segment = channel.sample();
+	let round_sum = round_coeffs.evaluate(r_segment);
 
+	// Fold both multilinears on the selector. The witness fold is written sparsely into a
+	// half-size buffer; the monster is folded in place.
+	let mut witness_folded = FieldBuffer::<P>::zeros(log_half);
+	let one_minus_r = F::ONE - r_segment;
+	for i in 0..n_hidden_words {
+		let a_0 = if i < n_public_words {
+			public_folded.get(i)
+		} else {
+			F::ZERO
+		};
+		let a_1 = hidden_folded.get(i);
+		witness_folded.set(i, one_minus_r * a_0 + r_segment * a_1);
+	}
+	fold_highest_var_inplace(&mut monster_multilinear, r_segment);
+
+	// Run the remaining `log_half` rounds of the bivariate product sumcheck.
+	let prover =
+		BivariateProductSumcheckProver::new([witness_folded, monster_multilinear], round_sum);
 	let ProveSingleOutput {
 		multilinear_evals,
-		challenges: mut r_y,
+		challenges: r_rest,
 	} = prove_single(prover, channel);
 
-	// Reverse the challenges to get the evaluation point.
+	// The full round challenges are `[r_segment, r_rest...]`; reverse to get the evaluation point.
+	let mut r_y = Vec::with_capacity(log_half + 1);
+	r_y.push(r_segment);
+	r_y.extend(r_rest);
 	r_y.reverse();
 
 	let [trace_eval, _monster_eval] = multilinear_evals
@@ -158,10 +233,8 @@ where
 	#[cfg(debug_assertions)]
 	{
 		let r_y_tensor = eq_ind_partial_eval(&r_y);
-		let expected_trace_eval = binius_math::inner_product::inner_product_buffers(
-			&cloned_witness_folded_for_debugging,
-			&r_y_tensor,
-		);
+		let expected_trace_eval =
+			binius_math::inner_product::inner_product_buffers(&debug_witness_folded, &r_y_tensor);
 		debug_assert_eq!(trace_eval, expected_trace_eval);
 	}
 
@@ -169,8 +242,6 @@ where
 	// (cheap, like the verifier does), subtracting its padded contribution off and scaling.
 	// This makes the protocol incomplete with negligible probability, when the segment selector
 	// challenge is zero.
-	let log_half = r_y.len() - 1;
-	let r_segment = r_y[log_half];
 	let log_public_words = checked_log_2(public_words.len());
 	let public_eval = evaluate_words_mle::<F, F>(public_words, &r_j, &r_y[..log_public_words]);
 	let padded_public_eval = eq_ind_zero(&r_y[log_public_words..log_half]) * public_eval;


### PR DESCRIPTION
Draft PR for review, per your request on [BINIUS-227](https://linear.app/jimpo/issue/BINIUS-227). **Opening as draft because the microbenchmark shows no measurable speedup** at the size our fine-grained bench exercises — the value here is the removed allocation + arguably-cleaner structure, and I want your eyes on the code before deciding whether/how it lands.

## What changed
`phase_2::run_sumcheck` (`crates/prover/src/protocols/shift/phase_2.rs`) now consumes the two folded segments directly instead of the pre-assembled combined witness buffer:

- `prove_phase_2` no longer calls `assemble_witness`; it passes `public_folded`, `hidden_folded`, and `n_hidden_words` into `run_sumcheck`.
- `run_sumcheck` computes the first (selector-binding) round's `y_1 = Σ A₁·B₁` and `y_∞ = Σ (A₀+A₁)(B₀+B₁)` directly over the non-zero prefixes `[0, n_hidden_words)` (public in `[0, n_public_words)`), interpolates the degree-2 round poly, sends it, samples the selector, folds both multilinears on it (witness written sparsely into a half-size buffer), and delegates the remaining `log_half` rounds to `BivariateProductSumcheckProver` as before.
- **Transcript is identical to the dense formulation.** `assemble_witness` is kept (`pub`) for a debug-only `trace_eval` cross-check and the bench — flagging it as a candidate for your call in review.

## Correctness
- `cargo test -p binius-prover --test shift` (prover↔verifier round-trip, in-function debug asserts active) passes.
- `clippy -p binius-prover --all-targets -D warnings`, `RUSTDOCFLAGS=-D warnings cargo doc -p binius-prover`, nightly-2026-01-01 `fmt --check`, typos — all clean.

## Measurement (clean A/B, this machine, 4096-byte SHA-256, `shift_reduction_phases/phase2_run_sumcheck`)
```
old (assemble + dense round):  time [1.6255  1.6623  1.6880] ms
new (sparse first round):      change [-5.85%  -2.04%  +2.03%]  p=0.35  -> No change detected
```
**Why no win at this size:** the layout guarantees `n_hidden_words ≥ n_public_words`, and `2^log_half = 2^⌈log₂ n_hidden⌉ ∈ [n_hidden, 2·n_hidden)`. For SHA-256 the hidden segment dominates and the public segment is tiny, so `2^log_half ≈ n_hidden ≈ n_public + n_hidden` — the dense first round was already ~proportional to the segments, and its low-half padding entries are zero (cheap), not wasted compute. The one thing genuinely removed is the `assemble_witness` allocation of the `2^(log_half+1)` buffer, which lives outside `run_sumcheck` and is small next to the monster build / remaining rounds.

## Notes for review
- Orthogonal to & composes cleanly on top of #1718 (that speeds up the monster build; this removes the combined-buffer allocation). Rebased + re-validated on current main.
- The `#[allow(clippy::too_many_arguments)]` on `run_sumcheck` is the cost of passing the two segments + `n_hidden_words` instead of the assembled buffer — happy to bundle them into a small struct if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)