### PR TITLE
BINIUS-145: prove the shift phase-2 first round sparsely over the segment selector

### DIFF
--- a/crates/ip-prover/src/sumcheck/mod.rs
+++ b/crates/ip-prover/src/sumcheck/mod.rs
@@ -1,4 +1,5 @@
 // Copyright 2023-2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 pub mod batch;
 pub mod batch_quadratic_mle;
@@ -13,7 +14,11 @@ mod padded;
 mod prove;
 pub mod quadratic_mle;
 pub mod rerand_mle;
-mod round_evals;
+// `round_evals` is internal implementation, exposed (via `#[doc(hidden)]` `pub mod`) only so
+// `binius-prover` can compute the shift reduction's sparse first sumcheck round with the exact
+// interpolation the in-crate provers use. Not a stable API.
+#[doc(hidden)]
+pub mod round_evals;
 pub mod selector_mle;
 mod switchover;
 pub use mle_to_sumcheck::*;

--- a/crates/prover/benches/shift_reduction.rs
+++ b/crates/prover/benches/shift_reduction.rs
@@ -11,9 +11,9 @@ use binius_prover::{
 	fold_word::fold_words,
 	protocols::shift::{
 		OperatorData, PreparedOperatorData, build_key_collection,
-		monster::{build_h_parts, build_monster_multilinear},
+		monster::{build_h_parts, build_monster_segments},
 		phase_1::{build_g_parts, run_phase_1_sumcheck},
-		phase_2::{assemble_witness, run_sumcheck},
+		phase_2::run_sumcheck,
 		prove,
 	},
 };
@@ -251,9 +251,7 @@ fn bench_shift_phases(c: &mut Criterion) {
 	let (public_words, hidden_words) = words.split_at(key_collection.public.n_words());
 	let public_folded = fold_words::<F, P>(public_words, r_j_tensor.as_ref());
 	let hidden_folded = fold_words::<F, P>(hidden_words, r_j_tensor.as_ref());
-	let witness_folded =
-		assemble_witness(&public_folded, &hidden_folded, key_collection.log_witness_words());
-	let monster_multilinear = build_monster_multilinear::<F, P>(
+	let (public_monster, hidden_monster) = build_monster_segments::<F, P>(
 		&key_collection,
 		&prepared_bitand,
 		&prepared_intmul,
@@ -285,11 +283,11 @@ fn bench_shift_phases(c: &mut Criterion) {
 		);
 	});
 
-	// Phase 2. `build_monster_multilinear` takes its inputs by reference; `run_sumcheck` consumes
-	// `r_j_witness`, `monster_multilinear`, and `r_j` by value.
-	group.bench_function("phase2_build_monster_multilinear", |b| {
+	// Phase 2. `build_monster_segments` takes its inputs by reference; `run_sumcheck` consumes
+	// its buffers and `r_j` by value.
+	group.bench_function("phase2_build_monster_segments", |b| {
 		b.iter(|| {
-			build_monster_multilinear::<F, P>(
+			build_monster_segments::<F, P>(
 				&key_collection,
 				&prepared_bitand,
 				&prepared_intmul,
@@ -300,13 +298,23 @@ fn bench_shift_phases(c: &mut Criterion) {
 	});
 	group.bench_function("phase2_run_sumcheck", |b| {
 		b.iter_batched(
-			|| (witness_folded.clone(), monster_multilinear.clone(), r_j.clone()),
-			|(witness_folded, monster_multilinear, r_j)| {
+			|| {
+				(
+					public_folded.clone(),
+					hidden_folded.clone(),
+					public_monster.clone(),
+					hidden_monster.clone(),
+					r_j.clone(),
+				)
+			},
+			|(public_folded, hidden_folded, public_monster, hidden_monster, r_j)| {
 				let mut transcript = ProverTranscript::<StdChallenger>::default();
 				run_sumcheck::<F, P, _>(
-					witness_folded,
+					public_folded,
+					hidden_folded,
+					public_monster,
+					hidden_monster,
 					public_words,
-					monster_multilinear,
 					r_j,
 					gamma,
 					&mut transcript,

--- a/crates/prover/src/protocols/shift/monster.rs
+++ b/crates/prover/src/protocols/shift/monster.rs
@@ -7,7 +7,7 @@ use binius_field::{AESTowerField8b, BinaryField, Field, PackedField, WideMul};
 use binius_math::{
 	BinarySubspace, FieldBuffer, multilinear::eq::eq_ind_partial_eval, univariate::lagrange_evals,
 };
-use binius_utils::rayon::prelude::*;
+use binius_utils::{checked_arithmetics::checked_log_2, rayon::prelude::*};
 use binius_verifier::{
 	config::{LOG_WORD_SIZE_BITS, WORD_SIZE_BITS},
 	protocols::shift::{BITAND_ARITY, INTMUL_ARITY, evaluate_h_op},
@@ -131,16 +131,18 @@ where
 ///
 /// # Usage
 ///
-/// Used in phase 2 of the shift protocol where the prover needs a single multilinear combining
-/// all shift-related constraints for efficient sumcheck computation.
-#[instrument(skip_all, name = "build_monster_multilinear")]
-pub fn build_monster_multilinear<F, P: PackedField<Scalar = F>>(
+/// Used in phase 2 of the shift protocol. The two returned buffers are the segments of the
+/// witness's monster multilinear: the public piece over `log_public_words` variables and the
+/// hidden piece over `log_witness_words` variables (the hidden words at the base, zeros above).
+/// The sparse first sumcheck round consumes them without materializing the combined buffer.
+#[instrument(skip_all, name = "build_monster_segments")]
+pub fn build_monster_segments<F, P: PackedField<Scalar = F>>(
 	key_collection: &KeyCollection,
 	bitand_operator_data: &PreparedOperatorData<F>,
 	intmul_operator_data: &PreparedOperatorData<F>,
 	r_j: &[F],
 	r_s: &[F],
-) -> FieldBuffer<P>
+) -> (FieldBuffer<P>, FieldBuffer<P>)
 where
 	F: BinaryField + From<AESTowerField8b>,
 {
@@ -189,10 +191,6 @@ where
 		&intmul_h_ops,
 	);
 
-	let log_half = key_collection.log_witness_words();
-	let log_len = log_half + 1;
-	let capacity = 1 << log_len.saturating_sub(P::LOG_WIDTH);
-
 	// The scalar for one word of a segment: the accumulated contribution of all its keys. The
 	// per-key wide accumulations are summed unreduced and reduced once at the end.
 	let word_scalar = |segment: &KeySegment, index: usize| {
@@ -215,31 +213,37 @@ where
 		F::reduce(wide)
 	};
 
-	// The multilinear is indexed over the witness address space: the public segment at the
-	// base of the low half-cube, the hidden segment at the base of the high half-cube, zeros
-	// elsewhere.
-	let half = 1 << log_half;
-	let n_public_words = key_collection.public.n_words();
-	let n_words = half + key_collection.hidden.n_words();
-	let mut monster_multilinear = Vec::<P>::with_capacity(capacity);
-	(0..n_words.div_ceil(P::WIDTH))
-		.into_par_iter()
-		.map(|chunk_index| {
-			let start = chunk_index * P::WIDTH;
-			P::from_scalars((start..(start + P::WIDTH).min(n_words)).map(|word_index| {
-				if word_index < n_public_words {
-					word_scalar(&key_collection.public, word_index)
-				} else if word_index >= half {
-					word_scalar(&key_collection.hidden, word_index - half)
-				} else {
-					F::ZERO
-				}
-			}))
-		})
-		.collect_into_vec(&mut monster_multilinear);
-	monster_multilinear.resize(capacity, P::default());
+	// Each segment sits at the base of its buffer: the public piece fills its power-of-two
+	// length exactly, the hidden piece is zero-padded up to the hidden segment length.
+	let build_segment = |segment: &KeySegment, log_len: usize| {
+		let capacity = 1 << log_len.saturating_sub(P::LOG_WIDTH);
+		let n_words = segment.n_words();
+		// Full packed elements: each maps exactly `P::WIDTH` words, so `from_scalars` sees a
+		// statically-sized iterator. The trailing partial element is filled separately below.
+		let n_full = n_words / P::WIDTH;
+		let mut values = Vec::<P>::with_capacity(capacity);
+		(0..n_full)
+			.into_par_iter()
+			.map(|chunk_index| {
+				let start = chunk_index * P::WIDTH;
+				P::from_scalars((0..P::WIDTH).map(|i| word_scalar(segment, start + i)))
+			})
+			.collect_into_vec(&mut values);
+		if !n_words.is_multiple_of(P::WIDTH) {
+			let start = n_full * P::WIDTH;
+			values.push(P::from_scalars(
+				(start..n_words).map(|word_index| word_scalar(segment, word_index)),
+			));
+		}
+		values.resize(capacity, P::default());
+		FieldBuffer::new(log_len, values.into_boxed_slice())
+	};
 
-	FieldBuffer::new(log_len, monster_multilinear.into_boxed_slice())
+	let log_public_words = checked_log_2(key_collection.public.n_words());
+	let public_monster = build_segment(&key_collection.public, log_public_words);
+	let hidden_monster = build_segment(&key_collection.hidden, key_collection.log_witness_words());
+
+	(public_monster, hidden_monster)
 }
 
 #[cfg(test)]

--- a/crates/prover/src/protocols/shift/phase_2.rs
+++ b/crates/prover/src/protocols/shift/phase_2.rs
@@ -1,25 +1,28 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
+use std::iter;
+
 use binius_core::word::Word;
-use binius_field::{AESTowerField8b, BinaryField, Field, PackedField};
-use binius_ip::sumcheck::SumcheckOutput;
+use binius_field::{AESTowerField8b, BinaryField, Field, PackedField, WideMul};
+use binius_ip::sumcheck::{RoundCoeffs, SumcheckOutput};
 use binius_ip_prover::{
 	channel::IPProverChannel,
 	sumcheck::{
 		ProveSingleOutput, bivariate_product::BivariateProductSumcheckProver, prove_single,
+		round_evals::RoundEvals2,
 	},
 };
 use binius_math::{
 	FieldBuffer,
 	multilinear::eq::{eq_ind_partial_eval, eq_ind_zero},
 };
-use binius_utils::checked_arithmetics::checked_log_2;
+use binius_utils::{checked_arithmetics::checked_log_2, rayon::prelude::*};
 use binius_verifier::{config::LOG_WORD_SIZE_BITS, protocols::shift::evaluate_words_mle};
 use tracing::instrument;
 
 use super::{
-	key_collection::KeyCollection, monster::build_monster_multilinear, prove::PreparedOperatorData,
+	key_collection::KeyCollection, monster::build_monster_segments, prove::PreparedOperatorData,
 };
 use crate::fold_word::fold_words;
 
@@ -32,22 +35,22 @@ use crate::fold_word::fold_words;
 /// # Protocol Steps
 /// 1. **Challenge Splitting**: Splits phase 1 challenges into `r_j` and `r_s` components
 /// 2. **Segment Folding**: Folds the public and hidden words using the `r_j` challenges
-/// 3. **Monster Multilinear Construction**: Builds the monster multilinear from key collection and
+/// 3. **Monster Multilinear Construction**: Builds the monster segments from the key collection and
 ///    operator data
-/// 4. **Sumcheck Execution**: Runs bivariate product sumcheck to prove witness ×
-///    monster_multilinear relationship
+/// 4. **Sumcheck Execution**: Runs the bivariate product sumcheck with a sparse first round over
+///    the segment selector
 ///
 /// # Parameters
 /// - `key_collection`: Prover's key collection representing the constraint system
-/// - `words`: The witness words
+/// - `words`: The value vector words
 /// - `bitand_data`: Operator data for bit multiplication constraints
 /// - `intmul_data`: Operator data for integer multiplication constraints
 /// - `phase_1_output`: Challenges and evaluation from the first phase
-/// - `transcript`: The prover's transcript
+/// - `channel`: The prover's channel
 ///
 /// # Returns
-/// Returns `SumcheckOutput` containing the combined challenges `[r_j, r_y]` and witness evaluation,
-/// or an error if the protocol fails.
+/// Returns `SumcheckOutput` containing the combined challenges `[r_j, r_y]` and the witness
+/// evaluation, or an error if the protocol fails.
 #[instrument(skip_all, name = "prove_phase_2")]
 pub fn prove_phase_2<F, P: PackedField<Scalar = F>, Channel>(
 	key_collection: &KeyCollection,
@@ -73,63 +76,135 @@ where
 
 	let r_j_tensor = eq_ind_partial_eval::<F>(&r_j);
 
-	// Fold each segment separately and assemble the witness: the public words at the base of
-	// the low half-cube, the hidden words at the base of the high half-cube.
+	// Fold each segment separately; the combined witness is never materialized. `fold_words`
+	// zero-pads each fold to `log2_ceil(len)` variables, so the hidden fold already has
+	// `log_witness_words` variables (its word count is the hidden segment length).
 	let (public_words, hidden_words) = words.split_at(key_collection.public.n_words());
 	let public_folded = fold_words::<_, P>(public_words, r_j_tensor.as_ref());
 	let hidden_folded = fold_words::<_, P>(hidden_words, r_j_tensor.as_ref());
-	let witness_folded =
-		assemble_witness(&public_folded, &hidden_folded, key_collection.log_witness_words());
 
-	let monster_multilinear =
-		build_monster_multilinear(key_collection, bitand_data, intmul_data, &r_j, &r_s);
+	let (public_monster, hidden_monster) =
+		build_monster_segments(key_collection, bitand_data, intmul_data, &r_j, &r_s);
 
-	run_sumcheck(witness_folded, public_words, monster_multilinear, r_j, gamma, channel)
+	run_sumcheck(
+		public_folded,
+		hidden_folded,
+		public_monster,
+		hidden_monster,
+		public_words,
+		r_j,
+		gamma,
+		channel,
+	)
 }
 
-/// Assembles the folded witness from its two folded segments.
+/// Computes the phase-2 first-round message: the degree-2 round polynomial that binds the segment
+/// selector, evaluated sparsely without materializing the combined witness.
 ///
-/// Each segment sits at the base of its half-cube, zero-padded up to `2^log_half` entries. The
-/// interim dense representation materializes the mostly-zero low half; a sparse special first
-/// sumcheck round can remove this cost without changing the transcript.
-pub fn assemble_witness<F: Field, P: PackedField<Scalar = F>>(
+/// With `W(X, y) = (1 - X) * P_pad(y) + X * H(y)` and `M` likewise,
+///
+/// ```text
+/// y_1 = sum_y H * M_h    y_inf = sum_y (P_pad + H) * (M_p_pad + M_h)
+/// ```
+///
+/// The dense `H * M_h` pass dominates; the `y_inf` corrections have support on the public prefix
+/// only. Both corrections run over whole packed elements: past the public length the `P`/`M_p`
+/// entries are zero, so the stray `H * M_h` lane terms cancel between the two sums. The per-point
+/// products accumulate in unreduced (wide) form and reduce once at the end.
+fn first_round_coeffs<F, P: PackedField<Scalar = F>>(
 	public_folded: &FieldBuffer<P>,
 	hidden_folded: &FieldBuffer<P>,
-	log_half: usize,
-) -> FieldBuffer<P> {
-	let mut witness_folded = FieldBuffer::zeros(log_half + 1);
-	{
-		let mut split = witness_folded.split_half_mut();
-		let (mut lo_half, mut hi_half) = split.halves();
-		lo_half.as_mut()[..public_folded.as_ref().len()].copy_from_slice(public_folded.as_ref());
-		hi_half.as_mut()[..hidden_folded.as_ref().len()].copy_from_slice(hidden_folded.as_ref());
-	}
-	witness_folded
+	public_monster: &FieldBuffer<P>,
+	hidden_monster: &FieldBuffer<P>,
+	gamma: F,
+) -> RoundCoeffs<F>
+where
+	F: BinaryField + From<AESTowerField8b>,
+{
+	// The dense hidden-segment pass.
+	let wide_dense = (hidden_folded.as_ref(), hidden_monster.as_ref())
+		.into_par_iter()
+		.map(|(&hidden_i, &monster_i)| P::wide_mul(hidden_i, monster_i))
+		.reduce(<P as WideMul>::Output::default, |lhs, rhs| lhs + rhs);
+
+	// The public-prefix corrections.
+	let n_public_packed = public_folded.as_ref().len();
+	let (wide_low_hidden, wide_low_cross) = iter::zip(
+		iter::zip(public_folded.as_ref(), &hidden_folded.as_ref()[..n_public_packed]),
+		iter::zip(public_monster.as_ref(), &hidden_monster.as_ref()[..n_public_packed]),
+	)
+	.map(|((&public_i, &hidden_i), (&public_monster_i, &hidden_monster_i))| {
+		(
+			P::wide_mul(hidden_i, hidden_monster_i),
+			P::wide_mul(public_i + hidden_i, public_monster_i + hidden_monster_i),
+		)
+	})
+	.fold(
+		(<P as WideMul>::Output::default(), <P as WideMul>::Output::default()),
+		|(acc_hidden, acc_cross), (hidden_term, cross_term)| {
+			(acc_hidden + hidden_term, acc_cross + cross_term)
+		},
+	);
+
+	let sum_lanes = |wide: <P as WideMul>::Output| P::reduce(wide).iter().sum::<F>();
+	let y_1 = sum_lanes(wide_dense);
+	let y_inf = y_1 + sum_lanes(wide_low_hidden) + sum_lanes(wide_low_cross);
+
+	RoundEvals2 { y_1, y_inf }.interpolate(gamma)
 }
 
-/// Executes the bivariate product sumcheck for the witness and monster multilinear
-/// relationship.
+/// Folds the two segment buffers of the witness at the selector challenge.
 ///
-/// This helper function runs the sumcheck protocol to prove the relationship between
-/// the witness and monster multilinear, then sends the hidden-segment evaluation: the
-/// verifier reconstructs the full witness evaluation from it and its own public words.
+/// Consumes and overwrites `hidden` for memory efficiency, returning
+/// `(1 - alpha) * public_padded + alpha * hidden` — exactly the result of
+/// `fold_highest_var_inplace` on the materialized witness buffer.
+fn fold_segments<F: Field, P: PackedField<Scalar = F>>(
+	public: &FieldBuffer<P>,
+	mut hidden: FieldBuffer<P>,
+	alpha: F,
+) -> FieldBuffer<P> {
+	// Scale the dominant hidden segment in place, in parallel.
+	let alpha_broadcast = P::broadcast(alpha);
+	hidden
+		.as_mut()
+		.par_iter_mut()
+		.for_each(|hidden_i| *hidden_i *= alpha_broadcast);
+
+	// Add the small public prefix sequentially. Its trailing partial packed element carries zero
+	// high lanes, so whole-element updates are correct.
+	let one_minus_alpha = P::broadcast(F::ONE - alpha);
+	let n_public_packed = public.as_ref().len();
+	for (value, &public_i) in iter::zip(&mut hidden.as_mut()[..n_public_packed], public.as_ref()) {
+		*value += public_i * one_minus_alpha;
+	}
+
+	hidden
+}
+
+/// Executes the phase-2 sumcheck over the witness, with a sparse first round.
 ///
-/// # Parameters
-/// - `witness_folded`: The witness folded at challenges `r_j`
-/// - `public_words`: The public segment words, for the witness evaluation derivation
-/// - `monster_multilinear`: The monster multilinear polynomial constructed from constraints
-/// - `r_j`: Challenge vector from phase 1 (first `LOG_WORD_SIZE_BITS` challenges)
-/// - `gamma`: The claimed evaluation from phase 1
-/// - `channel`: The prover's channel
+/// The witness `W` and monster `M` are each given as a (public, hidden) segment pair; the top
+/// word-index variable selects the segment. The first round (`first_round_coeffs`) binds that
+/// selector without materializing the mostly-zero combined buffers. After the selector challenge
+/// the segment pairs fold into single dense buffers (`fold_segments`) and the standard
+/// [`BivariateProductSumcheckProver`] proves the remaining rounds, so every round message is
+/// identical to the dense prover's.
+///
+/// After the sumcheck this derives the witness evaluation from the combined evaluation by
+/// evaluating the public segment (cheap, like the verifier does), subtracting its padded
+/// contribution off and scaling.
 ///
 /// # Returns
-/// Returns `SumcheckOutput` with concatenated challenges `[r_j, r_y]` and the committed-half
+/// Returns `SumcheckOutput` with concatenated challenges `[r_j, r_y]` and the witness
 /// evaluation.
+#[allow(clippy::too_many_arguments)]
 #[instrument(skip_all, name = "run_sumcheck")]
 pub fn run_sumcheck<F, P: PackedField<Scalar = F>, Channel: IPProverChannel<F>>(
-	witness_folded: FieldBuffer<P>,
+	public_folded: FieldBuffer<P>,
+	hidden_folded: FieldBuffer<P>,
+	public_monster: FieldBuffer<P>,
+	hidden_monster: FieldBuffer<P>,
 	public_words: &[Word],
-	monster_multilinear: FieldBuffer<P>,
 	r_j: Vec<F>,
 	gamma: F,
 	channel: &mut Channel,
@@ -137,17 +212,30 @@ pub fn run_sumcheck<F, P: PackedField<Scalar = F>, Channel: IPProverChannel<F>>(
 where
 	F: BinaryField + From<AESTowerField8b>,
 {
-	#[cfg(debug_assertions)]
-	let cloned_witness_folded_for_debugging = witness_folded.clone();
+	let log_hidden = hidden_folded.log_len();
+	assert_eq!(hidden_monster.log_len(), log_hidden);
+	assert_eq!(public_monster.log_len(), public_folded.log_len());
+	assert!(public_folded.log_len() <= log_hidden);
 
-	// Run sumcheck on bivariate product
-	let prover = BivariateProductSumcheckProver::new([witness_folded, monster_multilinear], gamma);
+	// Round 1: bind the segment selector.
+	let round_coeffs =
+		first_round_coeffs(&public_folded, &hidden_folded, &public_monster, &hidden_monster, gamma);
+	channel.send_many(round_coeffs.clone().truncate().coeffs());
+	let alpha = channel.sample();
+	let round_sum = round_coeffs.evaluate(alpha);
+
+	// Fold the segment pairs at the selector challenge and run the remaining rounds with the
+	// standard prover.
+	let folded_witness = fold_segments(&public_folded, hidden_folded, alpha);
+	let folded_monster = fold_segments(&public_monster, hidden_monster, alpha);
+	let prover = BivariateProductSumcheckProver::new([folded_witness, folded_monster], round_sum);
 
 	let ProveSingleOutput {
 		multilinear_evals,
-		challenges: mut r_y,
+		challenges,
 	} = prove_single(prover, channel);
 
+	let mut r_y = iter::once(alpha).chain(challenges).collect::<Vec<_>>();
 	// Reverse the challenges to get the evaluation point.
 	r_y.reverse();
 
@@ -155,20 +243,10 @@ where
 		.try_into()
 		.expect("prover has 2 multilinear polynomials");
 
-	#[cfg(debug_assertions)]
-	{
-		let r_y_tensor = eq_ind_partial_eval(&r_y);
-		let expected_trace_eval = binius_math::inner_product::inner_product_buffers(
-			&cloned_witness_folded_for_debugging,
-			&r_y_tensor,
-		);
-		debug_assert_eq!(trace_eval, expected_trace_eval);
-	}
-
-	// Derive the witness evaluation from the trace evaluation by evaluating the public segment
-	// (cheap, like the verifier does), subtracting its padded contribution off and scaling.
-	// This makes the protocol incomplete with negligible probability, when the segment selector
-	// challenge is zero.
+	// Derive the witness evaluation from the combined evaluation by evaluating the public
+	// segment (cheap, like the verifier does), subtracting its padded contribution off and
+	// scaling. This makes the protocol incomplete with negligible probability, when the segment
+	// selector challenge is zero.
 	let log_half = r_y.len() - 1;
 	let r_segment = r_y[log_half];
 	let log_public_words = checked_log_2(public_words.len());


### PR DESCRIPTION
Final PR of [BINIUS-145](https://linear.app/jimpo/issue/BINIUS-145/handling-constants) (the [plan](https://linear.app/jimpo/issue/BINIUS-145/handling-constants#comment-c759bc33); follows #1707, #1708, #1724). Prover-only optimization — the proof transcript is **byte-identical** to a build without it (verified plain + ZK on the SHA-256 test circuit), so no verifier or proof-format change.

**Context.** #1708 committed only the hidden segment and moved the public segment out of the trace oracle, but its phase-2 sumcheck materialized the full witness as a dense buffer over `log_witness_words + 1` variables — the low half (the zero-padded public segment) is mostly zeros. This PR removes that interim cost.

**The sparse first round.** The witness's top word-index variable is the segment selector, bound in round 1. Instead of building the combined `2^(log_witness_words + 1)` buffer, the prover keeps the two segments separate (`build_monster_segments` returns the public and hidden monster pieces; the folded witness stays split too) and computes round 1 directly:

* the dense `Σ hidden · monster_hidden` pass — the same `O(2^log_witness_words)` dominant term as before;
* two `O(2^log_public_words)` public-prefix corrections for `y_inf`, exploiting that the public/`M_p` buffers vanish past the public length so the stray hidden-lane terms cancel between the two sums.

After the selector challenge `α`, the segment pairs fold into single dense buffers (`fold_segments`) and the remaining rounds run through the standard `BivariateProductSumcheckProver` — so every round message is identical to the dense prover's. The witness evaluation is derived from the final combined evaluation by the same public-segment subtract-and-scale the verifier uses.

The first commit exposes `binius-ip-prover`'s `round_evals` as a `#[doc(hidden)] pub` module so the shift prover can reuse the exact `RoundEvals2` interpolation the in-crate provers use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)