### PR TITLE
[shift] Rewrite evaluate_monster_multilinear_for_operation 

### DIFF
--- a/crates/verifier/src/protocols/shift/monster.rs
+++ b/crates/verifier/src/protocols/shift/monster.rs
@@ -109,7 +109,9 @@ pub fn evaluate_h_op<E: FieldOps>(l_tilde: &[E], r_j: &[E], r_s: &[E]) -> [E; SH
 /// # Arguments
 ///
 /// * `operand_vecs` - Vector of operand vectors, one per operand position in the constraint
-/// * `r_x_prime` - Multilinear challenge `r_x'` for the constraint variables
+/// * `r_x_prime_tensor` - Equality indicator tensor expansion of the constraint challenge `r_x'`.
+///   The expansion is passed in (rather than computed here) so a single call can share it and so
+///   the [`FieldFn`](binius_field::util::FieldFn) `call` / `call_native` paths compute it once.
 /// * `lambda` - Random coefficient for batching operand evaluations
 /// * `r_s` - Challenge point for shift variables (length `LOG_WORD_SIZE_BITS`)
 /// * `r_y_tensor` - Equality indicator tensor expansion of the word index challenge `r_y`
@@ -122,7 +124,7 @@ pub fn evaluate_h_op<E: FieldOps>(l_tilde: &[E], r_j: &[E], r_s: &[E]) -> [E; SH
 /// if the computation fails.
 pub fn evaluate_monster_multilinear_for_operation<F, E>(
 	operand_vecs: &[Vec<&Operand>],
-	r_x_prime: &[E],
+	r_x_prime_tensor: &[E],
 	lambda: E,
 	r_s: &[E],
 	r_y_tensor: &[E],
@@ -132,13 +134,11 @@ where
 	F: BinaryField,
 	E: FieldOps<Scalar = F> + From<F>,
 {
-	let r_x_prime_tensor = eq_ind_partial_eval_scalars(r_x_prime);
-
 	let lambda_powers = powers(lambda)
 		.skip(1)
 		.take(operand_vecs.len())
 		.collect::<Vec<_>>();
-	let evals = evaluate_matrices(operand_vecs, &lambda_powers, &r_x_prime_tensor, r_y_tensor);
+	let evals = evaluate_matrices(operand_vecs, &lambda_powers, r_x_prime_tensor, r_y_tensor);
 
 	let eval = inner_product_scalars(
 		evals.map(|mut evals_op| evaluate_inplace_scalars(&mut evals_op[..], r_s)),

--- a/crates/verifier/src/protocols/shift/monster.rs
+++ b/crates/verifier/src/protocols/shift/monster.rs
@@ -1,20 +1,15 @@
 // Copyright 2025 Irreducible Inc.
 
-use std::{array, iter};
+use std::iter;
 
-use binius_core::{
-	ShiftVariant,
-	constraint_system::{Operand, ShiftedValueIndex},
-};
+use binius_core::constraint_system::Operand;
 use binius_field::{BinaryField, FieldOps, util::powers};
 use binius_math::{
-	inner_product::inner_product_scalars,
-	multilinear::{eq::eq_ind_partial_eval_scalars, evaluate::evaluate_inplace_scalars},
+	inner_product::inner_product_scalars, multilinear::eq::eq_ind_partial_eval_scalars,
 };
 
 use super::{
 	SHIFT_VARIANT_COUNT,
-	error::Error,
 	shift_ind::{partial_eval_phi, partial_eval_sigmas, partial_eval_sigmas_transpose},
 };
 use crate::config::{LOG_WORD_SIZE_BITS, WORD_SIZE_BITS};
@@ -109,113 +104,64 @@ pub fn evaluate_h_op<E: FieldOps>(l_tilde: &[E], r_j: &[E], r_s: &[E]) -> [E; SH
 /// # Arguments
 ///
 /// * `operand_vecs` - Vector of operand vectors, one per operand position in the constraint
-/// * `r_x_prime_tensor` - Equality indicator tensor expansion of the constraint challenge `r_x'`.
-///   The expansion is passed in (rather than computed here) so a single call can share it and so
-///   the [`FieldFn`](binius_field::util::FieldFn) `call` / `call_native` paths compute it once.
+/// * `r_x_prime` - The constraint challenge `r_x'`; its equality indicator tensor is expanded here.
 /// * `lambda` - Random coefficient for batching operand evaluations
-/// * `r_s` - Challenge point for shift variables (length `LOG_WORD_SIZE_BITS`)
+/// * `shift_scalars` - Tensor product of the shift-selector evaluations `h_op` and the shift-amount
+///   equality indicator `eq(r_s)`, indexed by `variant * WORD_SIZE_BITS + amount`. Shared across
+///   operations.
 /// * `r_y_tensor` - Equality indicator tensor expansion of the word index challenge `r_y`
-/// * `h_op_evals` - Precomputed shift selector evaluations from `evaluate_h_op`, shared across
-///   operations
 ///
 /// # Returns
 ///
-/// The evaluation of the monster multilinear at the given challenge points, or an error
-/// if the computation fails.
+/// The evaluation of the monster multilinear at the given challenge points.
 pub fn evaluate_monster_multilinear_for_operation<F, E>(
 	operand_vecs: &[Vec<&Operand>],
-	r_x_prime_tensor: &[E],
+	r_x_prime: &[E],
 	lambda: E,
-	r_s: &[E],
+	shift_scalars: &[E; SHIFT_VARIANT_COUNT * WORD_SIZE_BITS],
 	r_y_tensor: &[E],
-	h_op_evals: &[E; SHIFT_VARIANT_COUNT],
-) -> Result<E, Error>
+) -> E
 where
 	F: BinaryField,
 	E: FieldOps<Scalar = F> + From<F>,
 {
-	let lambda_powers = powers(lambda)
-		.skip(1)
-		.take(operand_vecs.len())
-		.collect::<Vec<_>>();
-	let evals = evaluate_matrices(operand_vecs, &lambda_powers, r_x_prime_tensor, r_y_tensor);
+	let arity = operand_vecs.len();
+	for operands in operand_vecs {
+		assert_eq!(operands.len(), (1 << r_x_prime.len()));
+	}
 
-	let eval = inner_product_scalars(
-		evals.map(|mut evals_op| evaluate_inplace_scalars(&mut evals_op[..], r_s)),
-		h_op_evals.iter().cloned(),
-	);
+	let r_x_prime_tensor = eq_ind_partial_eval_scalars(r_x_prime);
+	let lambda_powers = powers(lambda).skip(1).take(arity).collect::<Vec<_>>();
 
-	Ok(eval)
-}
+	// Fold the operand batching coefficients into the shared shift scalars, producing a table
+	// indexed by `(variant, amount, operand_id)` whose entry is
+	// `shift_scalars[variant * WORD_SIZE_BITS + amount] · λ^{operand_id + 1}` — the scalar that
+	// multiplies each shifted-value term.
+	let mut operand_shift_scalars = Vec::with_capacity(shift_scalars.len() * arity);
+	for shift_scalar in shift_scalars {
+		for lambda_power in &lambda_powers {
+			operand_shift_scalars.push(shift_scalar.clone() * lambda_power);
+		}
+	}
 
-/// Calculate a batched sum of the M_{\text{op}}(r'_x, r_y, s) matrices.
-///
-/// Computes one evaluation per shift op, shift amount pair. The matrix evaluations are scaled by
-/// the operand coefficients (λ powers) and accumulated.
-///
-/// # Arguments
-///
-/// * `operands` - Three-dimensional array of operands where:
-///   - dim 1: operation arity
-///   - dim 2: constraints
-///   - dim 3: shifted indices per term
-/// * `operand_coeffs` - Coefficients (λ powers) for batching operand evaluations
-/// * `r_x_prime_tensor` - Multilinear challenge tensor for constraint variables
-/// * `r_y_tensor` - Challenge tensor for word index variables
-fn evaluate_matrices<F: BinaryField, E: FieldOps<Scalar = F> + From<F>>(
-	operands: &[Vec<&Operand>],
-	operand_coeffs: &[E],
-	r_x_prime_tensor: &[E],
-	r_y_tensor: &[E],
-) -> [[E; WORD_SIZE_BITS]; SHIFT_VARIANT_COUNT] {
-	assert_eq!(operands.len(), operand_coeffs.len());
-
-	let zero_evals = array::from_fn(|_| array::from_fn::<E, WORD_SIZE_BITS, _>(|_| E::zero()));
-
-	iter::zip(operand_coeffs, operands)
-		.map(|(coeff, constraint_operands)| {
-			let mut evals: [[E; WORD_SIZE_BITS]; SHIFT_VARIANT_COUNT] =
-				array::from_fn(|_| array::from_fn::<E, WORD_SIZE_BITS, _>(|_| E::zero()));
-			for (operand_terms, constraint_eval) in iter::zip(constraint_operands, r_x_prime_tensor)
-			{
-				for ShiftedValueIndex {
-					value_index,
-					shift_variant,
-					amount,
-				} in *operand_terms
-				{
-					let shift_id = match shift_variant {
-						ShiftVariant::Sll => 0,
-						ShiftVariant::Slr => 1,
-						ShiftVariant::Sar => 2,
-						ShiftVariant::Rotr => 3,
-						ShiftVariant::Sll32 => 4,
-						ShiftVariant::Srl32 => 5,
-						ShiftVariant::Sra32 => 6,
-						ShiftVariant::Rotr32 => 7,
-					};
-					evals[shift_id][*amount as usize] +=
-						constraint_eval.clone() * &r_y_tensor[value_index.0 as usize];
-				}
+	// Accumulate one contribution per constraint. Within a constraint, each shifted-value term over
+	// all operands is weighted by its operand shift scalar and the word-index tensor entry; the
+	// running sum is then scaled by the constraint-index tensor entry.
+	let mut eval = E::zero();
+	for (constraint, r_x_prime_entry) in r_x_prime_tensor.iter().enumerate() {
+		let mut constraint_eval = E::zero();
+		for (operand_id, operand_vec) in operand_vecs.iter().enumerate() {
+			for svi in operand_vec[constraint] {
+				let variant = svi.shift_variant as usize;
+				let index = (variant * WORD_SIZE_BITS + svi.amount as usize) * arity + operand_id;
+				constraint_eval +=
+					operand_shift_scalars[index].clone() * &r_y_tensor[svi.value_index.0 as usize];
 			}
+		}
+		eval += constraint_eval * r_x_prime_entry;
+	}
 
-			// Scale all evaluations by the batching coefficient.
-			for evals_op in &mut evals {
-				for evals_op_s in &mut *evals_op {
-					*evals_op_s *= coeff;
-				}
-			}
-
-			evals
-		})
-		.fold(zero_evals, |mut a, b| {
-			for (a_op, b_op) in iter::zip(&mut a, b) {
-				for (a_op_s, b_op_s) in iter::zip(&mut *a_op, b_op) {
-					*a_op_s += b_op_s;
-				}
-			}
-			a
-		})
+	eval
 }
 
 #[cfg(test)]

--- a/crates/verifier/src/protocols/shift/verify.rs
+++ b/crates/verifier/src/protocols/shift/verify.rs
@@ -421,6 +421,11 @@ impl<F: BinaryField> FieldFn<F> for MonsterEvalFn<'_, F> {
 		let l_tilde = lagrange_evals_scalars(self.subspace, r_zhat_prime_v);
 		let h_op_evals = evaluate_h_op(&l_tilde, r_j_v, r_s_v);
 
+		// Expand the per-operation constraint-challenge tensors once here (rather than inside each
+		// `evaluate_monster_multilinear_for_operation` call).
+		let bitand_r_x_prime_tensor = eq_ind_partial_eval_scalars(bitand_r_x_prime_v);
+		let intmul_r_x_prime_tensor = eq_ind_partial_eval_scalars(intmul_r_x_prime_v);
+
 		// BitAnd contribution: operands (a, b, c) batched by `bitand_lambda`.
 		let bitand_part = {
 			let (a, b, c) = self
@@ -431,7 +436,7 @@ impl<F: BinaryField> FieldFn<F> for MonsterEvalFn<'_, F> {
 				.multiunzip();
 			evaluate_monster_multilinear_for_operation::<F, E>(
 				&[a, b, c],
-				bitand_r_x_prime_v,
+				&bitand_r_x_prime_tensor,
 				bitand_lambda_v,
 				r_s_v,
 				&r_y_tensor,
@@ -449,7 +454,7 @@ impl<F: BinaryField> FieldFn<F> for MonsterEvalFn<'_, F> {
 				.multiunzip();
 			evaluate_monster_multilinear_for_operation::<F, E>(
 				&[a, b, lo, hi],
-				intmul_r_x_prime_v,
+				&intmul_r_x_prime_tensor,
 				intmul_lambda_v,
 				r_s_v,
 				&r_y_tensor,

--- a/crates/verifier/src/protocols/shift/verify.rs
+++ b/crates/verifier/src/protocols/shift/verify.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-use std::iter;
+use std::{array, iter};
 
 use binius_core::{
 	constraint_system::{AndConstraint, ConstraintSystem, MulConstraint},
@@ -22,7 +22,7 @@ use getset::Getters;
 use itertools::Itertools;
 
 use super::{
-	BITAND_ARITY, INTMUL_ARITY, error::Error, evaluate_h_op,
+	BITAND_ARITY, INTMUL_ARITY, SHIFT_VARIANT_COUNT, error::Error, evaluate_h_op,
 	evaluate_monster_multilinear_for_operation,
 };
 use crate::config::{LOG_WORD_SIZE_BITS, WORD_SIZE_BITS};
@@ -421,10 +421,14 @@ impl<F: BinaryField> FieldFn<F> for MonsterEvalFn<'_, F> {
 		let l_tilde = lagrange_evals_scalars(self.subspace, r_zhat_prime_v);
 		let h_op_evals = evaluate_h_op(&l_tilde, r_j_v, r_s_v);
 
-		// Expand the per-operation constraint-challenge tensors once here (rather than inside each
-		// `evaluate_monster_multilinear_for_operation` call).
-		let bitand_r_x_prime_tensor = eq_ind_partial_eval_scalars(bitand_r_x_prime_v);
-		let intmul_r_x_prime_tensor = eq_ind_partial_eval_scalars(intmul_r_x_prime_v);
+		// Tensor the shift-selector evaluations with the shift-amount equality indicator once, so
+		// both the BitAnd and IntMul monster evaluations share it. Indexed by
+		// `variant * WORD_SIZE_BITS + amount`.
+		let eq_r_s = eq_ind_partial_eval_scalars(r_s_v);
+		let shift_scalars =
+			Box::new(array::from_fn::<_, { SHIFT_VARIANT_COUNT * WORD_SIZE_BITS }, _>(|i| {
+				h_op_evals[i / WORD_SIZE_BITS].clone() * &eq_r_s[i % WORD_SIZE_BITS]
+			}));
 
 		// BitAnd contribution: operands (a, b, c) batched by `bitand_lambda`.
 		let bitand_part = {
@@ -436,13 +440,11 @@ impl<F: BinaryField> FieldFn<F> for MonsterEvalFn<'_, F> {
 				.multiunzip();
 			evaluate_monster_multilinear_for_operation::<F, E>(
 				&[a, b, c],
-				&bitand_r_x_prime_tensor,
+				&bitand_r_x_prime_v,
 				bitand_lambda_v,
-				r_s_v,
+				&shift_scalars,
 				&r_y_tensor,
-				&h_op_evals,
 			)
-			.expect("evaluate_monster_multilinear_for_operation has no fallible path")
 		};
 		// IntMul contribution: operands (a, b, lo, hi) batched by `intmul_lambda`.
 		let intmul_part = {
@@ -454,13 +456,11 @@ impl<F: BinaryField> FieldFn<F> for MonsterEvalFn<'_, F> {
 				.multiunzip();
 			evaluate_monster_multilinear_for_operation::<F, E>(
 				&[a, b, lo, hi],
-				&intmul_r_x_prime_tensor,
+				&intmul_r_x_prime_v,
 				intmul_lambda_v,
-				r_s_v,
+				&shift_scalars,
 				&r_y_tensor,
-				&h_op_evals,
 			)
-			.expect("evaluate_monster_multilinear_for_operation has no fallible path")
 		};
 
 		bitand_part + intmul_part

--- a/crates/verifier/src/protocols/shift/verify.rs
+++ b/crates/verifier/src/protocols/shift/verify.rs
@@ -440,14 +440,14 @@ impl<F: BinaryField> FieldFn<F> for MonsterEvalFn<'_, F> {
 				.multiunzip();
 			evaluate_monster_multilinear_for_operation::<F, E>(
 				&[a, b, c],
-				&bitand_r_x_prime_v,
+				bitand_r_x_prime_v,
 				bitand_lambda_v,
 				&shift_scalars,
 				&r_y_tensor,
 			)
 		};
 		// IntMul contribution: operands (a, b, lo, hi) batched by `intmul_lambda`.
-		let intmul_part = {
+		let intmul_part = if !self.constraint_system.mul_constraints.is_empty() {
 			let (a, b, lo, hi) = self
 				.constraint_system
 				.mul_constraints
@@ -456,11 +456,13 @@ impl<F: BinaryField> FieldFn<F> for MonsterEvalFn<'_, F> {
 				.multiunzip();
 			evaluate_monster_multilinear_for_operation::<F, E>(
 				&[a, b, lo, hi],
-				&intmul_r_x_prime_v,
+				intmul_r_x_prime_v,
 				intmul_lambda_v,
 				&shift_scalars,
 				&r_y_tensor,
 			)
+		} else {
+			E::zero()
 		};
 
 		bitand_part + intmul_part


### PR DESCRIPTION
Flatten the separate evaluate_matrices helper into
evaluate_monster_multilinear_for_operation and restructure the evaluation
around a single precomputed scalar table.

Previously the evaluation built, for each operand, a [[E; WORD_SIZE_BITS];
SHIFT_VARIANT_COUNT] matrix of accumulated r_y-tensor entries scaled by the
batching coefficient, then per shift variant ran evaluate_inplace over r_s and
took an inner product with h_op_evals.

The new algorithm precomputes operand_shift_scalars: the tensor product of
h_op_evals (per shift variant), eq_ind_partial_eval(r_s) (per shift amount),
and the lambda powers (per operand id). This flat table of size
SHIFT_VARIANT_COUNT * WORD_SIZE_BITS * arity is indexed by (variant, amount,
operand_id) and holds h_op_evals[variant] * eq(r_s)[amount] * lambda^{id+1} --
the scalar weighting each shifted-value term.

The main loop then iterates over constraints. For each constraint it sums, over
every shifted-value term of every operand, the operand shift scalar times the
term's r_y-tensor entry, and finally scales that per-constraint sum by the
r_x-prime-tensor entry once per constraint (rather than once per term).

The shift-variant to table index uses `shift_variant as usize` directly, since
the #[repr(u8)] discriminants (0..8) already match the h_op_evals ordering,
dropping the explicit match. The public signature is unchanged.