### PR TITLE
BINIUS-232: pass the domain subspace into the shift reduction prover

### DIFF
--- a/crates/prover/benches/shift_reduction.rs
+++ b/crates/prover/benches/shift_reduction.rs
@@ -3,10 +3,10 @@
 
 use binius_circuits::sha256::sha256_fixed;
 use binius_core::{ValueVec, constraint_system::ConstraintSystem, word::Word};
-use binius_field::{BinaryField128bGhash, Field, Random, arch::OptimalPackedB128};
+use binius_field::{AESTowerField8b, BinaryField128bGhash, Field, Random, arch::OptimalPackedB128};
 use binius_frontend::{CircuitBuilder, Wire};
 use binius_ip::sumcheck::SumcheckOutput;
-use binius_math::multilinear::eq::eq_ind_partial_eval;
+use binius_math::{BinarySubspace, multilinear::eq::eq_ind_partial_eval};
 use binius_prover::{
 	fold_word::fold_words,
 	protocols::shift::{
@@ -111,6 +111,7 @@ fn bench_prove_and_verify(c: &mut Criterion) {
 		let bitand_evals = [F::random(&mut rng); 3];
 		let intmul_evals = [F::ZERO; 4];
 		let key_collection = build_key_collection(&cs);
+		let subspace = BinarySubspace::<AESTowerField8b>::with_dim(LOG_WORD_SIZE_BITS).isomorphic();
 
 		let mut group = c.benchmark_group(format!(
 			"shift_reduction_log2_{log_message_len_bytes}_bytes_{message_len_bytes}"
@@ -137,6 +138,7 @@ fn bench_prove_and_verify(c: &mut Criterion) {
 					value_vec.combined_witness(),
 					prover_bitand_data,
 					prover_intmul_data,
+					&subspace,
 					&mut prover_transcript,
 				)
 			})
@@ -161,6 +163,7 @@ fn bench_prove_and_verify(c: &mut Criterion) {
 			value_vec.combined_witness(),
 			prover_bitand_data,
 			prover_intmul_data,
+			&subspace,
 			&mut prover_transcript,
 		);
 
@@ -210,6 +213,7 @@ fn bench_shift_phases(c: &mut Criterion) {
 
 	let key_collection = build_key_collection(&cs);
 	let words = value_vec.combined_witness();
+	let subspace = BinarySubspace::<AESTowerField8b>::with_dim(LOG_WORD_SIZE_BITS).isomorphic();
 
 	// Prepare the operator data. Lambda sampling is cheap and not part of any benched phase, so a
 	// random lambda (rather than one drawn from a transcript) yields realistic-magnitude data.
@@ -236,7 +240,7 @@ fn bench_shift_phases(c: &mut Criterion) {
 	// then only clone what a phase consumes by value. The specific transcript challenges do not
 	// change the work a phase performs.
 	let g_parts = build_g_parts::<F, P>(words, &key_collection, &prepared_bitand, &prepared_intmul);
-	let h_parts = build_h_parts::<F, P>(prepared_bitand.r_zhat_prime);
+	let h_parts = build_h_parts::<F, P>(&subspace, prepared_bitand.r_zhat_prime);
 	let SumcheckOutput {
 		challenges: mut r_jr_s,
 		eval: gamma,
@@ -255,6 +259,7 @@ fn bench_shift_phases(c: &mut Criterion) {
 		&key_collection,
 		&prepared_bitand,
 		&prepared_intmul,
+		&subspace,
 		&r_j,
 		&r_s,
 	);
@@ -270,7 +275,7 @@ fn bench_shift_phases(c: &mut Criterion) {
 		});
 	});
 	group.bench_function("phase1_build_h_parts", |b| {
-		b.iter(|| build_h_parts::<F, P>(prepared_bitand.r_zhat_prime));
+		b.iter(|| build_h_parts::<F, P>(&subspace, prepared_bitand.r_zhat_prime));
 	});
 	group.bench_function("phase1_run_sumcheck", |b| {
 		b.iter_batched(
@@ -291,6 +296,7 @@ fn bench_shift_phases(c: &mut Criterion) {
 				&key_collection,
 				&prepared_bitand,
 				&prepared_intmul,
+				&subspace,
 				&r_j,
 				&r_s,
 			)

--- a/crates/prover/src/protocols/shift/monster.rs
+++ b/crates/prover/src/protocols/shift/monster.rs
@@ -3,13 +3,13 @@
 
 use std::iter;
 
-use binius_field::{AESTowerField8b, BinaryField, Field, PackedField, WideMul};
+use binius_field::{BinaryField, Field, PackedField, WideMul};
 use binius_math::{
 	BinarySubspace, FieldBuffer, multilinear::eq::eq_ind_partial_eval, univariate::lagrange_evals,
 };
 use binius_utils::{checked_arithmetics::checked_log_2, rayon::prelude::*};
 use binius_verifier::{
-	config::{LOG_WORD_SIZE_BITS, WORD_SIZE_BITS},
+	config::WORD_SIZE_BITS,
 	protocols::shift::{BITAND_ARITY, INTMUL_ARITY, evaluate_h_op},
 };
 use bytemuck::zeroed_vec;
@@ -32,13 +32,13 @@ use super::{
 /// Used in phase 1, thus returning an array of multilinear evaluations.
 #[instrument(skip_all, name = "build_h_parts")]
 pub fn build_h_parts<F, P: PackedField<Scalar = F>>(
+	domain_subspace: &BinarySubspace<F>,
 	r_zhat_prime: F,
 ) -> [FieldBuffer<P>; SHIFT_VARIANT_COUNT]
 where
-	F: BinaryField + From<AESTowerField8b>,
+	F: BinaryField,
 {
-	let subspace = BinarySubspace::<AESTowerField8b>::with_dim(LOG_WORD_SIZE_BITS).isomorphic();
-	let l_tilde = lagrange_evals(&subspace, r_zhat_prime);
+	let l_tilde = lagrange_evals(domain_subspace, r_zhat_prime);
 	let l_tilde = l_tilde.as_ref();
 
 	fn build_part<F: Field, P: PackedField<Scalar = F>>(
@@ -140,20 +140,20 @@ pub fn build_monster_segments<F, P: PackedField<Scalar = F>>(
 	key_collection: &KeyCollection,
 	bitand_operator_data: &PreparedOperatorData<F>,
 	intmul_operator_data: &PreparedOperatorData<F>,
+	domain_subspace: &BinarySubspace<F>,
 	r_j: &[F],
 	r_s: &[F],
 ) -> (FieldBuffer<P>, FieldBuffer<P>)
 where
-	F: BinaryField + From<AESTowerField8b>,
+	F: BinaryField,
 {
 	// Compute h evaluations
-	let subspace = BinarySubspace::<AESTowerField8b>::with_dim(LOG_WORD_SIZE_BITS).isomorphic();
 	let [bitand_h_ops, intmul_h_ops] = [
 		bitand_operator_data.r_zhat_prime,
 		intmul_operator_data.r_zhat_prime,
 	]
 	.map(|r_zhat_prime| {
-		let l_tilde = lagrange_evals(&subspace, r_zhat_prime);
+		let l_tilde = lagrange_evals(domain_subspace, r_zhat_prime);
 		evaluate_h_op(l_tilde.as_ref(), r_j, r_s)
 	});
 
@@ -248,9 +248,9 @@ where
 
 #[cfg(test)]
 mod tests {
-	use binius_field::{BinaryField128bGhash, PackedBinaryGhash2x128b, Random};
+	use binius_field::{AESTowerField8b, BinaryField128bGhash, PackedBinaryGhash2x128b, Random};
 	use binius_math::{inner_product::inner_product_buffers, multilinear::eq::eq_ind_partial_eval};
-	use binius_verifier::protocols::shift::evaluate_h_op;
+	use binius_verifier::{config::LOG_WORD_SIZE_BITS, protocols::shift::evaluate_h_op};
 	use rand::{SeedableRng, rngs::StdRng};
 
 	use super::*;
@@ -279,7 +279,7 @@ mod tests {
 			let succinct_evaluations = evaluate_h_op(l_tilde.as_ref(), &r_j, &r_s);
 
 			// Method 2: Direct evaluation via multilinear part
-			let h_parts = build_h_parts(r_zhat_prime);
+			let h_parts = build_h_parts(&subspace, r_zhat_prime);
 			let evaluation_point: Vec<F> = [r_j.clone(), r_s.clone()].concat();
 			let tensor = eq_ind_partial_eval::<P>(&evaluation_point);
 			let direct_evaluations = h_parts.map(|buf| inner_product_buffers(&buf, &tensor));

--- a/crates/prover/src/protocols/shift/phase_1.rs
+++ b/crates/prover/src/protocols/shift/phase_1.rs
@@ -4,13 +4,13 @@
 use std::{iter, ops::Range};
 
 use binius_core::word::Word;
-use binius_field::{AESTowerField8b, BinaryField, Field, PackedField};
+use binius_field::{BinaryField, Field, PackedField};
 use binius_ip::sumcheck::{SumcheckOutput, common::RoundCoeffs};
 use binius_ip_prover::{
 	channel::IPProverChannel,
 	sumcheck::{bivariate_product::BivariateProductSumcheckProver, common::SumcheckProver},
 };
-use binius_math::{FieldBuffer, inner_product::inner_product_buffers};
+use binius_math::{BinarySubspace, FieldBuffer, inner_product::inner_product_buffers};
 use binius_utils::rayon::prelude::*;
 use binius_verifier::{
 	config::{LOG_WORD_SIZE_BITS, WORD_SIZE_BITS, WORD_SIZE_BYTES},
@@ -38,17 +38,18 @@ pub fn prove_phase_1<F, P, Channel>(
 	words: &[Word],
 	bitand_data: &PreparedOperatorData<F>,
 	intmul_data: &PreparedOperatorData<F>,
+	domain_subspace: &BinarySubspace<F>,
 	channel: &mut Channel,
 ) -> SumcheckOutput<F>
 where
-	F: BinaryField + From<AESTowerField8b>,
+	F: BinaryField,
 	P: PackedField<Scalar = F>,
 	Channel: IPProverChannel<F>,
 {
 	let g_parts = build_g_parts::<_, P>(words, key_collection, bitand_data, intmul_data);
 
 	// BitAnd and IntMul share the same `r_zhat_prime`.
-	let h_parts = build_h_parts(bitand_data.r_zhat_prime);
+	let h_parts = build_h_parts(domain_subspace, bitand_data.r_zhat_prime);
 
 	run_phase_1_sumcheck(g_parts, h_parts, channel)
 }

--- a/crates/prover/src/protocols/shift/phase_2.rs
+++ b/crates/prover/src/protocols/shift/phase_2.rs
@@ -4,7 +4,7 @@
 use std::iter;
 
 use binius_core::word::Word;
-use binius_field::{AESTowerField8b, BinaryField, Field, PackedField, WideMul};
+use binius_field::{BinaryField, Field, PackedField, WideMul};
 use binius_ip::sumcheck::{RoundCoeffs, SumcheckOutput};
 use binius_ip_prover::{
 	channel::IPProverChannel,
@@ -14,7 +14,7 @@ use binius_ip_prover::{
 	},
 };
 use binius_math::{
-	FieldBuffer,
+	BinarySubspace, FieldBuffer,
 	multilinear::eq::{eq_ind_partial_eval, eq_ind_zero},
 };
 use binius_utils::{checked_arithmetics::checked_log_2, rayon::prelude::*};
@@ -57,11 +57,12 @@ pub fn prove_phase_2<F, P: PackedField<Scalar = F>, Channel>(
 	words: &[Word],
 	bitand_data: &PreparedOperatorData<F>,
 	intmul_data: &PreparedOperatorData<F>,
+	domain_subspace: &BinarySubspace<F>,
 	phase_1_output: SumcheckOutput<F>,
 	channel: &mut Channel,
 ) -> SumcheckOutput<F>
 where
-	F: BinaryField + From<AESTowerField8b>,
+	F: BinaryField,
 	Channel: IPProverChannel<F>,
 {
 	let SumcheckOutput {
@@ -83,8 +84,14 @@ where
 	let public_folded = fold_words::<_, P>(public_words, r_j_tensor.as_ref());
 	let hidden_folded = fold_words::<_, P>(hidden_words, r_j_tensor.as_ref());
 
-	let (public_monster, hidden_monster) =
-		build_monster_segments(key_collection, bitand_data, intmul_data, &r_j, &r_s);
+	let (public_monster, hidden_monster) = build_monster_segments(
+		key_collection,
+		bitand_data,
+		intmul_data,
+		domain_subspace,
+		&r_j,
+		&r_s,
+	);
 
 	run_sumcheck(
 		public_folded,
@@ -119,7 +126,7 @@ fn first_round_coeffs<F, P: PackedField<Scalar = F>>(
 	gamma: F,
 ) -> RoundCoeffs<F>
 where
-	F: BinaryField + From<AESTowerField8b>,
+	F: BinaryField,
 {
 	// The dense hidden-segment pass.
 	let wide_dense = (hidden_folded.as_ref(), hidden_monster.as_ref())
@@ -210,7 +217,7 @@ pub fn run_sumcheck<F, P: PackedField<Scalar = F>, Channel: IPProverChannel<F>>(
 	channel: &mut Channel,
 ) -> SumcheckOutput<F>
 where
-	F: BinaryField + From<AESTowerField8b>,
+	F: BinaryField,
 {
 	let log_hidden = hidden_folded.log_len();
 	assert_eq!(hidden_monster.log_len(), log_hidden);

--- a/crates/prover/src/protocols/shift/prove.rs
+++ b/crates/prover/src/protocols/shift/prove.rs
@@ -1,11 +1,11 @@
 // Copyright 2025 Irreducible Inc.
 
 use binius_core::word::Word;
-use binius_field::{AESTowerField8b, BinaryField, Field, PackedField, util::powers};
+use binius_field::{BinaryField, Field, PackedField, util::powers};
 use binius_ip::sumcheck::SumcheckOutput;
 use binius_ip_prover::channel::IPProverChannel;
 use binius_math::{
-	FieldBuffer, inner_product::inner_product, multilinear::eq::eq_ind_partial_eval,
+	BinarySubspace, FieldBuffer, inner_product::inner_product, multilinear::eq::eq_ind_partial_eval,
 };
 
 use super::{key_collection::KeyCollection, phase_1::prove_phase_1, phase_2::prove_phase_2};
@@ -97,10 +97,11 @@ pub fn prove<F, P, Channel>(
 	words: &[Word],
 	bitand_data: OperatorData<F>,
 	intmul_data: OperatorData<F>,
+	domain_subspace: &BinarySubspace<F>,
 	channel: &mut Channel,
 ) -> SumcheckOutput<F>
 where
-	F: BinaryField + From<AESTowerField8b>,
+	F: BinaryField,
 	P: PackedField<Scalar = F>,
 	Channel: IPProverChannel<F>,
 {
@@ -122,6 +123,7 @@ where
 		words,
 		&prepared_bitand_data,
 		&prepared_intmul_data,
+		domain_subspace,
 		channel,
 	);
 
@@ -134,6 +136,7 @@ where
 		words,
 		&prepared_bitand_data,
 		&prepared_intmul_data,
+		domain_subspace,
 		phase_1_output,
 		channel,
 	);

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -165,6 +165,11 @@ impl IOPProver {
 		// improves ShiftReduction perf. When IntMul was skipped, synthesize a zero claim (four
 		// zero evals at an empty point): the shift reduction iterates the (empty) MUL constraints,
 		// so this claim contributes zero to its batched evaluation.
+		//
+		// Build the oblong domain subspace once and pass it into the shift reduction, mirroring
+		// the verifier side (`shift::check_eval` takes the domain subspace). It is reused for the
+		// IntMul claim collapse below.
+		let subspace = BinarySubspace::<B8>::with_dim(LOG_WORD_SIZE_BITS).isomorphic();
 		let intmul_claim = match intmul_output {
 			Some(IntMulOutput {
 				eval_point,
@@ -174,7 +179,6 @@ impl IOPProver {
 				c_hi_evals,
 			}) => {
 				let r_zhat_prime = bitand_claim.r_zhat_prime;
-				let subspace = BinarySubspace::<B8>::with_dim(LOG_WORD_SIZE_BITS).isomorphic();
 				let l_tilde = lagrange_evals(&subspace, r_zhat_prime);
 				let make_final_claim = |evals| inner_product(evals, l_tilde.iter_scalars());
 				OperatorData {
@@ -210,6 +214,7 @@ impl IOPProver {
 			witness.combined_witness(),
 			bitand_claim,
 			intmul_claim,
+			&subspace,
 			&mut *channel,
 		);
 		drop(shift_guard);

--- a/crates/prover/tests/shift.rs
+++ b/crates/prover/tests/shift.rs
@@ -282,6 +282,7 @@ fn test_shift_prove_and_verify() {
 			value_vec.combined_witness(),
 			prover_bitand_data.clone(),
 			prover_intmul_data.clone(),
+			&subspace,
 			&mut prover_transcript,
 		);
 


### PR DESCRIPTION
Resolves [BINIUS-232](https://linear.app/jimpo/issue/BINIUS-232).

## What

The shift-reduction **prover** constructed the oblong-multilinearization binary subspace internally
(`BinarySubspace::<AESTowerField8b>::with_dim(LOG_WORD_SIZE_BITS).isomorphic()`), which forced a
`F: From<AESTowerField8b>` bound to propagate through seven functions. The **verifier** already
avoids this — `shift::check_eval` takes the domain subspace as a plain `&BinarySubspace<F>` and has
no such bound.

This mirrors the verifier on the prover side: the subspace is now **passed in**, and **all seven
`F: From<AESTowerField8b>` bounds in `shift` are removed**.

## How

- Added a `domain_subspace: &BinarySubspace<F>` parameter, threaded
  `prove` → `prove_phase_1` → `build_h_parts` and `prove` → `prove_phase_2` → `build_monster_segments`,
  placed after the operator data to match `check_eval`'s parameter shape.
- Deleted the two internal `with_dim(…).isomorphic()` constructions in `monster.rs`; the functions
  now `lagrange_evals` against the passed-in subspace.
- Dropped the `From<AESTowerField8b>` bound from `prove`, `prove_phase_1`, `prove_phase_2`,
  `first_round_coeffs`, `run_sumcheck`, `build_h_parts`, `build_monster_segments`.
- In the production caller (`prove.rs`) the identical subspace was already being built for the IntMul
  claim collapse — it is now built **once**, hoisted above the match, and reused for both that
  collapse and the shift reduction. (Net effect: the subspace is constructed once per proof instead
  of once here plus once each inside `build_h_parts`/`build_monster_segments`.)
- Updated the test and bench callers to construct and pass the subspace.

Pure refactor — no behavior change; identical proofs.

## Testing

- `cargo build -p binius-prover --all-targets` — clean.
- `cargo test -p binius-prover --test shift` (prover → verifier `check_eval` roundtrip) — passes,
  confirming behavior is preserved.
- `cargo test -p binius-prover --lib protocols::shift` (incl. `monster::tests::h_op_consistency`) — passes.
- `cargo clippy -p binius-prover --all-targets -- -D warnings` — clean.
- Nightly `cargo fmt --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)