### PR TITLE
BINIUS-233: reduce r_y tensor expansion work in MonsterEvalFn

### DIFF
--- a/crates/math/src/multilinear/eq.rs
+++ b/crates/math/src/multilinear/eq.rs
@@ -203,8 +203,14 @@ pub fn eq_ind_truncate_low_inplace<P: PackedField, Data: DerefMut<Target = [P]>>
 /// $$
 #[inline(always)]
 pub fn eq_one_var<F: FieldOps>(x: F, y: F) -> F {
-	let one = F::one();
-	x.clone() * y.clone() + (one.clone() - x) * (one - y)
+	// Over characteristic 2, `X·Y + (1−X)(1−Y)` simplifies to `X + Y + 1` (the `2·X·Y` term
+	// vanishes). The condition is a compile-time constant, so only one arm is generated.
+	if F::Scalar::CHARACTERISTIC == 2 {
+		x + y + F::one()
+	} else {
+		let one = F::one();
+		x.clone() * y.clone() + (one.clone() - x) * (one - y)
+	}
 }
 
 /// Evaluates the equality indicator multilinear at a pair of coordinates.

--- a/crates/math/src/multilinear/eq.rs
+++ b/crates/math/src/multilinear/eq.rs
@@ -248,8 +248,25 @@ pub fn eq_ind_zero<F: FieldOps>(point: &[F]) -> F {
 /// (1 - r_0, r_0) \otimes ... \otimes (1 - r_{n-1}, r_{n-1}).
 /// $$
 pub fn eq_ind_partial_eval_scalars<F: FieldOps>(point: &[F]) -> Vec<F> {
+	// The unscaled indicator is the scaled indicator with a scale of one.
+	scaled_eq_ind_partial_eval_scalars(point, F::one())
+}
+
+/// Computes the partial evaluation of the equality indicator polynomial scaled by a constant,
+/// returning scalars.
+///
+/// This is a scalar-only variant of [`scaled_eq_ind_partial_eval`] that returns a `Vec<F>` instead
+/// of a [`FieldBuffer`]. Every hypercube value of the tensor product
+///
+/// $$
+/// (1 - r_0, r_0) \otimes ... \otimes (1 - r_{n-1}, r_{n-1})
+/// $$
+///
+/// is multiplied by `scale`. A scale of one reproduces [`eq_ind_partial_eval_scalars`].
+pub fn scaled_eq_ind_partial_eval_scalars<F: FieldOps>(point: &[F], scale: F) -> Vec<F> {
 	let mut result = Vec::with_capacity(1 << point.len());
-	result.push(F::one());
+	// Seed with the scale; the expansion multiplies it through every hypercube value.
+	result.push(scale);
 
 	for r_i in point {
 		// Double the buffer size. For each existing value in 0..size,
@@ -267,6 +284,7 @@ pub fn eq_ind_partial_eval_scalars<F: FieldOps>(point: &[F]) -> Vec<F> {
 
 #[cfg(test)]
 mod tests {
+	use binius_field::Random;
 	use proptest::prelude::*;
 	use rand::prelude::*;
 
@@ -457,6 +475,23 @@ mod tests {
 
 			let packed_scalars: Vec<F> = packed_result.iter_scalars().collect();
 			assert_eq!(packed_scalars, scalar_result, "mismatch at log_n={log_n}");
+		}
+	}
+
+	#[test]
+	fn test_scaled_eq_ind_partial_eval_scalars_is_unscaled_times_scale() {
+		let mut rng = StdRng::seed_from_u64(0);
+
+		for log_n in [0, 1, 2, 5, 8] {
+			let point = random_scalars::<F>(&mut rng, log_n);
+			let scale = F::random(&mut rng);
+
+			let scaled = scaled_eq_ind_partial_eval_scalars(&point, scale);
+			let expected: Vec<F> = eq_ind_partial_eval_scalars(&point)
+				.into_iter()
+				.map(|x| x * scale)
+				.collect();
+			assert_eq!(scaled, expected, "mismatch at log_n={log_n}");
 		}
 	}
 

--- a/crates/verifier/src/protocols/shift/verify.rs
+++ b/crates/verifier/src/protocols/shift/verify.rs
@@ -15,7 +15,9 @@ use binius_ip::{
 use binius_math::{
 	BinarySubspace,
 	line::extrapolate_line,
-	multilinear::eq::{eq_ind_partial_eval_scalars, eq_ind_zero},
+	multilinear::eq::{
+		eq_ind_partial_eval_scalars, eq_ind_zero, eq_one_var, scaled_eq_ind_partial_eval_scalars,
+	},
 	univariate::{evaluate_univariate, lagrange_evals_scalars},
 };
 use getset::Getters;
@@ -291,7 +293,7 @@ where
 		let intmul_r_x_prime_len = intmul_data.r_x_prime.len();
 		let r_j_len = r_j.len();
 		let r_s_len = r_s.len();
-		let r_y_len = r_y.len() + 1;
+		let r_y_len = r_y.len();
 
 		let inputs: Vec<C::Elem> = iter::once(r_zhat_prime)
 			.chain(iter::once(bitand_lambda.clone()))
@@ -412,24 +414,37 @@ impl<F: BinaryField> MonsterEvalFn<'_, F> {
 		let r_s_v = &vals[off..off + self.r_s_len];
 		off += self.r_s_len;
 		let r_y_v = &vals[off..off + self.r_y_len];
+		off += self.r_y_len;
+		// `r_segment` is the top word-index coordinate, appended after `r_y`; it selects the public
+		// (0) vs hidden (1) segment.
+		let r_segment = vals[off].clone();
 
-		// Expand the column challenge and the per-bit Lagrange / shift-operator evaluations.
-		// The tensor is expanded over the witness address space, then rearranged into a lookup
-		// by absolute value-vector index: public words keep their index in the low half, and
-		// hidden words move to the base of the high half.
-		let witness_tensor = eq_ind_partial_eval_scalars(r_y_v);
+		// Build the word-index equality tensor over the value vector: public words in the low
+		// segment, hidden words in the high segment.
+		//
+		// Rather than expand the full `(r_y, r_segment)` tensor (which doubles the multiplications
+		// and then gets re-indexed), build each segment's portion directly from the shared `r_y`
+		// indicator:
+		//   * hidden — the `r_y` indicator scaled by `r_segment` (the high-half weight);
+		//   * public — the `log_public_words`-length prefix indicator (the public segment occupies
+		//     that prefix of the address space) scaled by `(1 - r_segment)` and the eq-zero padding
+		//     over the unused `r_y` coordinates — the same `padded_public_eval` factor that
+		//     `check_eval` reconstructs the witness evaluation with.
 		let layout = &self.constraint_system.value_vec_layout;
-		let half = 1 << (self.r_y_len - 1);
 		let n_public_words = layout.n_public_words();
-		let r_y_tensor = (0..layout.combined_len())
-			.map(|word_index| {
-				if word_index < n_public_words {
-					witness_tensor[word_index].clone()
-				} else {
-					witness_tensor[half + word_index - n_public_words].clone()
-				}
-			})
-			.collect::<Vec<_>>();
+		let log_public_words = layout.log_public_words();
+
+		let public_scale =
+			eq_one_var(r_segment.clone(), E::zero()) * eq_ind_zero(&r_y_v[log_public_words..]);
+		let public_tensor =
+			scaled_eq_ind_partial_eval_scalars(&r_y_v[..log_public_words], public_scale);
+		let hidden_tensor = scaled_eq_ind_partial_eval_scalars(r_y_v, r_segment);
+
+		// `n_public_words` is a power of two, so the public prefix indicator has exactly that many
+		// entries; the hidden portion fills the remainder of the value vector.
+		let mut r_y_tensor = Vec::with_capacity(layout.combined_len());
+		r_y_tensor.extend_from_slice(&public_tensor);
+		r_y_tensor.extend_from_slice(&hidden_tensor[..layout.combined_len() - n_public_words]);
 		let l_tilde = lagrange_evals_scalars(self.subspace, r_zhat_prime_v);
 		let h_op_evals = evaluate_h_op(&l_tilde, r_j_v, r_s_v);
 


### PR DESCRIPTION
Halves the `r_y` word-index tensor expansion in the verifier's `MonsterEvalFn`, and replaces the re-indexing map with a direct two-segment build.

Linear: https://linear.app/jimpo/issue/BINIUS-233

**Stacked on #1727** (base is that branch, not `main`) — it edits the `MonsterEvalFn::evaluate` helper introduced there. GitHub will retarget to `main` once #1727 merges.

### The problem

`MonsterEvalFn` receives `r_y` extended with the top `r_segment` coordinate (public vs hidden segment). The old code expanded the full extended point — `eq_ind_partial_eval_scalars(r_y_v)`, `2^r_y_len` entries — then re-indexed it into per-word weights, throwing away roughly half the work (the extension doubles the multiplications).

### Commit 1 — `scaled_eq_ind_partial_eval_scalars`

A scalar (`FieldOps`) analogue of the packed `scaled_eq_ind_partial_eval`, seeding the expansion with `scale` so it's folded in for free. `eq_ind_partial_eval_scalars` now delegates to it with `scale = 1` (mirroring how `eq_ind_partial_eval` calls the packed scaled version).

### Commit 2 — per-segment `r_y` tensor

Build each segment's portion directly from the shared `r_y` indicator instead of expanding the extended point:
- **hidden** = `scaled_eq_ind_partial_eval_scalars(r_y, r_segment)` — the high-half weight;
- **public** = `scaled_eq_ind_partial_eval_scalars(r_y[..log_public_words], (1 - r_segment) * eq_ind_zero(r_y[log_public_words..]))` — the public segment occupies a `log_public_words`-length prefix, scaled by the same `padded_public_eval` factor `check_eval` reconstructs with. `n_public_words` is a power of two, so this prefix indicator is exactly `n_public_words` entries.

Then the "garbage" re-indexing map becomes a `Vec::with_capacity(combined_len)` + two `extend_from_slice`s (public, then hidden).

## Correctness

New `scaled_eq_ind_partial_eval_scalars` unit test (equals unscaled × scale). The full prove→verify round-trip and all 8 `prove_verify` end-to-end tests (real public + hidden segments through `check_eval`) pass unchanged. Both commits independently green (build/clippy/doc/fmt).

## Performance

The `r_y` expansion drops from `2^r_y_len` to `2^(r_y_len-1) + 2^log_public_words` multiplications — ~2×. Micro-measured on the expansion alone at `r_y_len = 21`, `log_public = 10`, `F = BinaryField128bGhash`, `-C target-cpu=native`: **~27 ms → ~14 ms**. This is one component of `MonsterEvalFn` (which is dominated by the per-constraint loop), so the top-line verify impact is smaller, but the expansion itself is halved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)