### PR TITLE
BINIUS-119: batched shift prover reusing the single-instance verifier

### DIFF
--- a/crates/prover/src/protocols/shift/batch.rs
+++ b/crates/prover/src/protocols/shift/batch.rs
@@ -1,0 +1,181 @@
+// Copyright 2025 Irreducible Inc.
+
+//! Batched shift reduction prover for the M4 data-parallel proof system.
+//!
+//! M4 proves `K = 2^k` instances of one circuit at once, stacked instance-major.
+//! The batched BitAnd/IntMul reductions leave operand claims at a local constraint point.
+//! Their evaluation point also carries an instance part `r_kappa`.
+//!
+//! The instance index enters an operand claim only through the committed witness bit.
+//! The shift structure is shared by every instance, so the instance factor folds onto the witness.
+//! Every witness-derived buffer of the single-instance reduction then becomes an eq-weighted sum:
+//!
+//! ```text
+//!   g_batch    = sum_kappa eq(r_kappa, kappa) * g(instance_kappa)
+//!   fold_batch = sum_kappa eq(r_kappa, kappa) * fold(instance_kappa)
+//! ```
+//!
+//! The g parts and the phase-2 folds are linear in the witness, so these combinations are exact.
+//! The shift kernels and the monster are instance-independent, so they are reused verbatim.
+//!
+//! So this is the single-instance reduction run on the instance-folded witness.
+//! Its transcript matches the single-instance prover, so `verify` and `check_eval` accept it as is.
+//! Their witness evaluation is the committed batch witness partially evaluated at `r_kappa`.
+
+use binius_core::word::Word;
+use binius_field::{BinaryField, PackedField};
+use binius_ip::sumcheck::SumcheckOutput;
+use binius_ip_prover::channel::IPProverChannel;
+use binius_math::{
+	BinarySubspace, FieldBuffer,
+	multilinear::eq::{eq_ind_partial_eval, eq_ind_partial_eval_scalars},
+};
+use binius_verifier::config::LOG_WORD_SIZE_BITS;
+
+use super::{
+	key_collection::KeyCollection,
+	monster::{build_h_parts, build_monster_segments},
+	phase_1::{build_g_parts, run_phase_1_sumcheck},
+	phase_2::run_sumcheck,
+	prove::{OperatorData, PreparedOperatorData},
+};
+use crate::fold_word::fold_words;
+
+/// Proves the batched shift reduction over `K = 2^k` instances of one circuit.
+///
+/// It runs the single-instance two-phase reduction on the instance-folded witness.
+/// The transcript matches the single-instance prover, so the single-instance verifier accepts it.
+///
+/// # Arguments
+///
+/// - `key_collection`: the per-instance shift structure, shared by every instance.
+/// - `instances`: one committed-word slice per instance, in instance order.
+/// - `r_kappa`: the instance challenge of length `k`, the instance coordinates of the claim point.
+/// - `bitand_data`: the BitAnd operand claim at the local constraint point.
+/// - `intmul_data`: the IntMul operand claim at the local constraint point.
+/// - `domain_subspace`: the Lagrange basis subspace over the word bits.
+/// - `channel`: the prover channel.
+///
+/// # Returns
+///
+/// The challenges `[r_j, r_y]` and the witness evaluation.
+/// That evaluation is the committed batch witness partially evaluated at `r_kappa`.
+///
+/// # Panics
+///
+/// Panics if the instance count is not `2^{r_kappa.len()}`.
+pub fn prove_batch<F, P, Channel>(
+	key_collection: &KeyCollection,
+	instances: &[&[Word]],
+	r_kappa: &[F],
+	bitand_data: OperatorData<F>,
+	intmul_data: OperatorData<F>,
+	domain_subspace: &BinarySubspace<F>,
+	channel: &mut Channel,
+) -> SumcheckOutput<F>
+where
+	F: BinaryField,
+	P: PackedField<Scalar = F>,
+	Channel: IPProverChannel<F>,
+{
+	// The batch is a clean hypercube of instances: exactly 2^k of them.
+	assert_eq!(instances.len(), 1usize << r_kappa.len(), "instance count must be 2^r_kappa.len()");
+
+	// Sample the operand-batching coefficients, matching the single-instance prover's order.
+	let bitand_lambda = channel.sample();
+	let intmul_lambda = channel.sample();
+	let bitand_prep = PreparedOperatorData::new(bitand_data, bitand_lambda);
+	let intmul_prep = PreparedOperatorData::new(intmul_data, intmul_lambda);
+
+	// eq(r_kappa, .) expanded over the 2^k instances: one weight per instance.
+	let eps = eq_ind_partial_eval_scalars(r_kappa);
+
+	// Phase 1: g parts are the eq(r_kappa, .)-weighted sum of the per-instance g parts.
+	let mut g_parts =
+		build_g_parts::<F, P>(instances[0], key_collection, &bitand_prep, &intmul_prep);
+	for part in &mut g_parts {
+		scale(part, eps[0]);
+	}
+	for (kappa, &eps_k) in eps.iter().enumerate().skip(1) {
+		let g_kappa =
+			build_g_parts::<F, P>(instances[kappa], key_collection, &bitand_prep, &intmul_prep);
+		for (acc, src) in g_parts.iter_mut().zip(&g_kappa) {
+			add_scaled(acc, src, eps_k);
+		}
+	}
+	let h_parts = build_h_parts::<F, P>(domain_subspace, bitand_prep.r_zhat_prime);
+
+	let SumcheckOutput {
+		challenges: mut r_jr_s,
+		eval: gamma,
+	} = run_phase_1_sumcheck(g_parts, h_parts, channel);
+
+	// Split the phase-1 challenges: r_j is the low bit-index half, r_s the high shift-amount half.
+	let r_s = r_jr_s.split_off(LOG_WORD_SIZE_BITS);
+	let r_j = r_jr_s;
+	let r_j_tensor = eq_ind_partial_eval::<F>(&r_j);
+
+	// Phase 2: fold each instance's segments at r_j.
+	// Combine the per-instance folds over instances with the eq weights.
+	let n_public = key_collection.public.n_words();
+	let (public_0, hidden_0) = instances[0].split_at(n_public);
+	let mut public_folded = fold_words::<F, P>(public_0, r_j_tensor.as_ref());
+	let mut hidden_folded = fold_words::<F, P>(hidden_0, r_j_tensor.as_ref());
+	scale(&mut public_folded, eps[0]);
+	scale(&mut hidden_folded, eps[0]);
+	for (kappa, &eps_k) in eps.iter().enumerate().skip(1) {
+		let (public_words, hidden_words) = instances[kappa].split_at(n_public);
+		add_scaled(
+			&mut public_folded,
+			&fold_words::<F, P>(public_words, r_j_tensor.as_ref()),
+			eps_k,
+		);
+		add_scaled(
+			&mut hidden_folded,
+			&fold_words::<F, P>(hidden_words, r_j_tensor.as_ref()),
+			eps_k,
+		);
+	}
+
+	// The monster is instance-independent: the single-instance segments verbatim.
+	let (public_monster, hidden_monster) = build_monster_segments::<F, P>(
+		key_collection,
+		&bitand_prep,
+		&intmul_prep,
+		domain_subspace,
+		&r_j,
+		&r_s,
+	);
+
+	// The public reconstruction words: the shared public segment.
+	// This initial batch targets instances whose public inputs agree.
+	let public_words = &instances[0][..n_public];
+
+	run_sumcheck(
+		public_folded,
+		hidden_folded,
+		public_monster,
+		hidden_monster,
+		public_words,
+		r_j,
+		gamma,
+		channel,
+	)
+}
+
+/// Scales every packed element of a buffer by a scalar, in place.
+fn scale<P: PackedField>(buf: &mut FieldBuffer<P>, scalar: P::Scalar) {
+	let broadcast = P::broadcast(scalar);
+	for elem in buf.as_mut() {
+		*elem *= broadcast;
+	}
+}
+
+/// Adds `scalar * src` into `acc`, element-wise.
+/// The two buffers have equal length.
+fn add_scaled<P: PackedField>(acc: &mut FieldBuffer<P>, src: &FieldBuffer<P>, scalar: P::Scalar) {
+	let broadcast = P::broadcast(scalar);
+	for (acc_elem, &src_elem) in acc.as_mut().iter_mut().zip(src.as_ref()) {
+		*acc_elem += broadcast * src_elem;
+	}
+}

--- a/crates/prover/src/protocols/shift/mod.rs
+++ b/crates/prover/src/protocols/shift/mod.rs
@@ -3,6 +3,7 @@
 
 use binius_verifier::protocols::shift::{BITAND_ARITY, INTMUL_ARITY, SHIFT_VARIANT_COUNT};
 
+mod batch;
 mod key_collection;
 // `monster`, `phase_1`, and `phase_2` are internal implementation, exposed (via `#[doc(hidden)]`
 // `pub mod`) only so the `shift_reduction` benchmark can time individual phase functions (see
@@ -15,5 +16,6 @@ pub mod phase_1;
 pub mod phase_2;
 mod prove;
 
+pub use batch::prove_batch;
 pub use key_collection::{KeyCollection, KeySegment, build_key_collection};
 pub use prove::{OperatorData, PreparedOperatorData, prove};

--- a/crates/prover/tests/shift.rs
+++ b/crates/prover/tests/shift.rs
@@ -17,7 +17,7 @@ use binius_math::{
 };
 use binius_prover::{
 	fold_word::fold_words,
-	protocols::shift::{OperatorData, build_key_collection, prove},
+	protocols::shift::{OperatorData, build_key_collection, prove, prove_batch},
 };
 use binius_transcript::ProverTranscript;
 use binius_utils::checked_arithmetics::{log2_ceil_usize, strict_log_2};
@@ -332,4 +332,144 @@ fn test_shift_prove_and_verify() {
 		assert_eq!(prover_output.challenges, eval_point);
 		assert_eq!(prover_output.eval, verifier_output.witness_eval);
 	}
+}
+
+// Builds `K = 2^log_instances` value vectors of one circuit with shifted AND operands.
+// Each instance is populated with distinct inputs.
+// Returns the prepared constraint system and the per-instance value vectors.
+//
+// The circuit asserts, over public words x, y, z0, z1:
+//     shl(x, 5) & rotr(y, 13) == z0     (Sll amount 5, Rotr amount 13)
+//     shr(x, 7) & sar(y, 3)   == z1     (Slr amount 7, Sar amount 3)
+// Four shift variants at non-zero amounts flow through the batched g-build and monster.
+fn build_shifted_batch(log_instances: usize) -> (ConstraintSystem, Vec<ValueVec>) {
+	let builder = CircuitBuilder::new();
+	let x = builder.add_inout();
+	let y = builder.add_inout();
+	let z0 = builder.add_inout();
+	let z1 = builder.add_inout();
+	let and0 = builder.band(builder.shl(x, 5), builder.rotr(y, 13));
+	builder.assert_eq("z0", and0, z0);
+	let and1 = builder.band(builder.shr(x, 7), builder.sar(y, 3));
+	builder.assert_eq("z1", and1, z1);
+	let circuit = builder.build();
+
+	let value_vecs = (0..(1usize << log_instances))
+		.map(|i| {
+			// Distinct inputs per instance, so the public and hidden segments both differ.
+			let xv = 0x0123_4567_89ab_cdefu64.wrapping_mul(i as u64 + 1) ^ 0xdead_beef;
+			let yv = 0xfedc_ba98_7654_3210u64.wrapping_add(i as u64 * 0x9e37) ^ 0x1234;
+			let mut filler = circuit.new_witness_filler();
+			filler[x] = Word(xv);
+			filler[y] = Word(yv);
+			filler[z0] = Word((xv << 5) & yv.rotate_right(13));
+			filler[z1] = Word((xv >> 7) & (((yv as i64) >> 3) as u64));
+			circuit.populate_wire_witness(&mut filler).unwrap();
+			filler.into_value_vec()
+		})
+		.collect();
+
+	let mut cs = circuit.constraint_system().clone();
+	cs.validate_and_prepare().unwrap();
+	(cs, value_vecs)
+}
+
+#[test]
+fn test_batch_shift_prove_with_unmodified_verifier() {
+	use binius_field::{BinaryField128bGhash, Field, PackedBinaryGhash2x128b, Random};
+	use binius_math::multilinear::eq::eq_ind_partial_eval_scalars;
+	type F = BinaryField128bGhash;
+	type P = PackedBinaryGhash2x128b;
+	let mut rng = StdRng::seed_from_u64(0);
+
+	// Fixture state: K = 4 instances of one circuit, distinct inputs, four shift variants.
+	let log_instances = 2;
+	let (cs, value_vecs) = build_shifted_batch(log_instances);
+	for vv in &value_vecs {
+		verify_constraints(&cs, vv).unwrap();
+	}
+	let instances = value_vecs
+		.iter()
+		.map(|v| v.combined_witness())
+		.collect::<Vec<_>>();
+
+	// Challenges: the local constraint point, the univariate bit point, and the instance point.
+	let r_x_prime_bitand = (0..strict_log_2(cs.and_constraints.len()).unwrap())
+		.map(|_| F::random(&mut rng))
+		.collect::<Vec<_>>();
+	let r_zhat_prime = F::random(&mut rng);
+	let r_kappa = (0..log_instances)
+		.map(|_| F::random(&mut rng))
+		.collect::<Vec<_>>();
+	let subspace = BinarySubspace::<AESTowerField8b>::with_dim(LOG_WORD_SIZE_BITS).isomorphic();
+
+	// The batched operand claim: the eq(r_kappa, .)-weighted sum of the per-instance operand evals.
+	// This is exactly what the folded witness produces, so the reduction chains.
+	let eps = eq_ind_partial_eval_scalars(&r_kappa);
+	let r_x_tensor = eq_ind_partial_eval(&r_x_prime_bitand);
+	let mut bitand_evals = [F::ZERO; 3];
+	for (kappa, vv) in value_vecs.iter().enumerate() {
+		let images = compute_bitand_images(&cs.and_constraints, vv);
+		for (eval, image) in bitand_evals.iter_mut().zip(&images) {
+			*eval +=
+				eps[kappa] * evaluate_image(&subspace, image, r_zhat_prime, r_x_tensor.as_ref());
+		}
+	}
+
+	// This circuit is pure-AND, so the IntMul operator is empty (mirrors the single-instance skip).
+	let intmul_evals = [F::ZERO; 4];
+	let r_x_prime_intmul: Vec<F> = Vec::new();
+
+	let key_collection = build_key_collection(&cs);
+	let mut prover_transcript = ProverTranscript::<StdChallenger>::default();
+	let bitand_data = OperatorData {
+		evals: bitand_evals.to_vec(),
+		r_zhat_prime,
+		r_x_prime: r_x_prime_bitand.clone(),
+	};
+	let intmul_data = OperatorData {
+		evals: intmul_evals.to_vec(),
+		r_zhat_prime,
+		r_x_prime: r_x_prime_intmul.clone(),
+	};
+	let prover_output = prove_batch::<F, P, _>(
+		&key_collection,
+		&instances,
+		&r_kappa,
+		bitand_data,
+		intmul_data,
+		&subspace,
+		&mut prover_transcript,
+	);
+
+	// Verify with the UNMODIFIED single-instance verifier and its evaluation check.
+	// The public words are the shared reconstruction set (instance 0's public segment).
+	let mut verifier_transcript = prover_transcript.into_verifier();
+	let verifier_bitand_data = VerifierOperatorData::new(r_x_prime_bitand, bitand_evals);
+	let verifier_intmul_data = VerifierOperatorData::new(r_x_prime_intmul, intmul_evals);
+	let verifier_output =
+		verify(&cs, &verifier_bitand_data, &verifier_intmul_data, &mut verifier_transcript)
+			.unwrap();
+	check_eval(
+		&cs,
+		value_vecs[0].public(),
+		&verifier_bitand_data,
+		&verifier_intmul_data,
+		&subspace,
+		r_zhat_prime,
+		&verifier_output,
+		&mut verifier_transcript,
+	)
+	.unwrap();
+	verifier_transcript.finalize().unwrap();
+
+	// The prover and verifier agree on the reduced claim.
+	let eval_point = [
+		verifier_output.r_j(),
+		verifier_output.r_y(),
+		std::slice::from_ref(&verifier_output.r_segment),
+	]
+	.concat();
+	assert_eq!(prover_output.challenges, eval_point);
+	assert_eq!(prover_output.eval, verifier_output.witness_eval);
 }

--- a/crates/prover/tests/shift.rs
+++ b/crates/prover/tests/shift.rs
@@ -358,7 +358,7 @@ fn build_shifted_batch(log_instances: usize) -> (ConstraintSystem, Vec<ValueVec>
 		.map(|i| {
 			// Distinct inputs per instance, so the public and hidden segments both differ.
 			let xv = 0x0123_4567_89ab_cdefu64.wrapping_mul(i as u64 + 1) ^ 0xdead_beef;
-			let yv = 0xfedc_ba98_7654_3210u64.wrapping_add(i as u64 * 0x9e37) ^ 0x1234;
+			let yv = 0xfedc_9b98_7654_3210u64.wrapping_add(i as u64 * 0x9e37) ^ 0x1234;
 			let mut filler = circuit.new_witness_filler();
 			filler[x] = Word(xv);
 			filler[y] = Word(yv);


### PR DESCRIPTION
Part of [BINIUS-119](https://linear.app/jimpo/issue/BINIUS-119).
Prover-only split of #1722, following the review there: reuse the existing single-instance shift verifier and change only the prover.

Adds a batched shift-reduction prover for M4. The single-instance `verify` and `check_eval` are untouched.

### The problem

M4 proves $K = 2^k$ instances of one circuit at once, stacked instance-major.
The batched BitAnd/IntMul reductions leave operand claims whose evaluation point carries an extra instance part `r_kappa`.
The single-instance shift prover has no notion of that instance axis.

### The idea

The instance index enters an operand claim *only* through the committed witness bit — the shift structure is shared by every instance.
So the instance factor folds onto the witness, and every witness-derived buffer of the single-instance reduction becomes an `eq(r_kappa, .)`-weighted sum of the per-instance buffers:

```
g_batch    = sum_kappa eq(r_kappa, kappa) * g(instance_kappa)
fold_batch = sum_kappa eq(r_kappa, kappa) * fold(instance_kappa)
```

These combinations are exact: the `g` parts and the phase-2 folds are linear in the witness, and the shift kernels and monster are instance-independent.
So the batch prover is the single-instance reduction run on the instance-folded witness.

### The change

`prove_batch` reuses the single-instance building blocks verbatim, eps-combining their per-instance outputs:

- `build_g_parts` and `fold_words` per instance, combined with the `eq(r_kappa, .)` weights.
- `build_h_parts`, `build_monster_segments`, `run_phase_1_sumcheck`, `run_sumcheck` — used as-is (instance-independent).

The transcript is byte-identical in shape to a single-instance proof.
So the existing `verify` and `check_eval` accept it with no modification.
Their `witness_eval` output is the committed batch witness partially evaluated at `r_kappa` along the instance axis — exactly the review's framing.

### Why the verifier needs no change

`run_sumcheck` derives the committed-half evaluation by subtracting the public-segment contribution, and `check_eval` adds it back.
Prover and verifier use the same public words, so that term cancels and the verifier reconstructs the true folded trace.
The final identity `trace * monster == eval` then holds for the batch.

### Soundness

- The instance fold is an exact algebraic identity, not a probabilistic step.
- Both sumchecks and the closing monster identity are the single-instance reduction, run on the folded witness.
- The public reconstruction uses one shared public set (instance 0's). This binds correctly when the batch's public inputs agree, or when the full witness is committed (M4's current `ValueTable`), so the public is bound by the commitment and the cancellation is harmless. A hidden-only commitment with differing per-instance public would need the public folded across instances — a downstream commit/ring-switch point, not part of this reduction.

### Scope

- **new:** `crates/prover/src/protocols/shift/batch.rs` (`prove_batch`) and its `pub use`.
- **new:** a round-trip test in `crates/prover/tests/shift.rs`.
- **untouched:** the single-instance prover and the verifier (`verify`, `check_eval`).

### Verification

- `cargo check --workspace --all-targets`, `cargo clippy -p binius-prover --all-targets`, nightly `fmt` — clean.
- `cargo test -p binius-prover --test shift` — the new `test_batch_shift_prove_with_unmodified_verifier` (K=4 instances, distinct inputs, four shift variants at non-zero amounts) round-trips through the unmodified `verify` + `check_eval`, and the single-instance test still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)