### PR TITLE
BINIUS-236: eliminate the per-layer witness copy in the fractional-addition prover

### DIFF
--- a/crates/ip-prover/src/fracaddcheck.rs
+++ b/crates/ip-prover/src/fracaddcheck.rs
@@ -116,14 +116,11 @@ where
 		};
 
 		let (num, den) = layer;
-		let (num_0, num_1) = num.split_half_ref();
-		let (den_0, den_1) = den.split_half_ref();
-		let num_0 = FieldBuffer::new(num_0.log_len(), num_0.as_ref().into());
-		let num_1 = FieldBuffer::new(num_1.log_len(), num_1.as_ref().into());
-		let den_0 = FieldBuffer::new(den_0.log_len(), den_0.as_ref().into());
-		let den_1 = FieldBuffer::new(den_1.log_len(), den_1.as_ref().into());
+		// The MLE-check reduces four multilinears.
+		// These are the low and high halves of the numerator buffer and of the denominator buffer.
+		// Splitting the owned buffers hands those halves over by borrow, so the fold runs in place.
 		let prover = frac_add_mle::new(
-			[num_0, num_1, den_0, den_1],
+			[num.split_half(), den.split_half()],
 			num_claim.point.clone(),
 			[num_claim.eval, den_claim.eval],
 		);

--- a/crates/ip-prover/src/sumcheck/frac_add_mle.rs
+++ b/crates/ip-prover/src/sumcheck/frac_add_mle.rs
@@ -1,7 +1,7 @@
 // Copyright 2025-2026 The Binius Developers
 
 use binius_field::{Field, PackedField};
-use binius_math::FieldBuffer;
+use binius_math::{AsSlicesMut, FieldBuffer};
 
 use crate::sumcheck::{batch_quadratic_mle::BatchQuadraticMleCheckProver, common::MleCheckProver};
 
@@ -10,7 +10,7 @@ pub type FractionalBuffer<P> = (FieldBuffer<P>, FieldBuffer<P>);
 // denominators to be added in a single buffer respectively, with the assumption that the 2
 // collections to be added are in either half.
 pub fn new<F, P>(
-	fraction: [FieldBuffer<P>; 4],
+	fraction: impl AsSlicesMut<P, 4> + Send + 'static,
 	eval_point: Vec<F>,
 	eval_claims: [F; 2],
 ) -> impl MleCheckProver<F>

--- a/crates/math/src/field_buffer.rs
+++ b/crates/math/src/field_buffer.rs
@@ -723,6 +723,20 @@ impl<P: PackedField, Data: DerefMut<Target = [P]>> AsSlicesMut<P, 2>
 	}
 }
 
+impl<P: PackedField, Data: DerefMut<Target = [P]>> AsSlicesMut<P, 4>
+	for [FieldBufferSplitMut<P, Data>; 2]
+{
+	fn as_slices_mut(&mut self) -> [FieldSliceMut<'_, P>; 4] {
+		// Borrow the two splits independently so both stay mutable at once.
+		let [first, second] = self;
+		// Each split yields its own low and high half.
+		let (lo_0, hi_0) = first.halves();
+		let (lo_1, hi_1) = second.halves();
+		// Order the four slices as first-low, first-high, second-low, second-high.
+		[lo_0, hi_0, lo_1, hi_1]
+	}
+}
+
 /// Return type of [`FieldBuffer::chunk_mut`] for small chunks.
 #[derive(Debug)]
 pub struct FieldBufferChunkMut<'a, P: PackedField>(FieldBufferChunkMutInner<'a, P>);
@@ -1473,6 +1487,41 @@ mod tests {
 	fn test_split_half_mut_size_one() {
 		let mut buffer = FieldBuffer::<P>::zeros(0); // 1 element
 		let _ = buffer.split_half_mut();
+	}
+
+	// Invariant: viewing two split buffers as four field slices yields exactly their four halves.
+	// The order is first-low, first-high, second-low, second-high.
+	// The reference halves come from a borrow-only split of each buffer.
+	#[test]
+	fn test_split_pair_as_slices_mut_matches_split_half_ref() {
+		// Cover log_len below, at, and above the packing width (P::LOG_WIDTH == 2).
+		for log_len in 1..=5 {
+			let n = 1 << log_len;
+			let mut buf_0 = FieldBuffer::<P>::zeros(log_len);
+			let mut buf_1 = FieldBuffer::<P>::zeros(log_len);
+			for i in 0..n {
+				buf_0.set(i, F::new(i as u128));
+				buf_1.set(i, F::new((i + 100) as u128));
+			}
+
+			// Reference halves: a borrow-only split of each buffer, read low then high.
+			let (ref_lo_0, ref_hi_0) = buf_0.split_half_ref();
+			let (ref_lo_1, ref_hi_1) = buf_1.split_half_ref();
+			let reference: [Vec<F>; 4] = [
+				ref_lo_0.iter_scalars().collect(),
+				ref_hi_0.iter_scalars().collect(),
+				ref_lo_1.iter_scalars().collect(),
+				ref_hi_1.iter_scalars().collect(),
+			];
+
+			// Consume the buffers into owning splits and view the pair as four slices.
+			let mut pair = [buf_0.split_half(), buf_1.split_half()];
+			let slices = pair.as_slices_mut();
+			let actual: [Vec<F>; 4] =
+				std::array::from_fn(|i| slices[i].iter_scalars().collect::<Vec<_>>());
+
+			assert_eq!(actual, reference, "half mismatch at log_len {log_len}");
+		}
 	}
 
 	proptest! {


### PR DESCRIPTION
Closes [BINIUS-236](https://linear.app/jimpo/issue/BINIUS-236).

Removes a full copy of the numerator+denominator layer that the fractional-addition prover made on every reduction layer. Proof output is bit-identical — no protocol change, no new soundness assumption.

### The problem

The fraction prover reduces a claim layer by layer, from the small summed layer back to the original witness.

At each layer it hands four multilinears to an MLE-check: the low and high halves of the numerator buffer and of the denominator buffer.

It built those four by **copying** — split each buffer by reference, then allocate four fresh owned buffers and memcpy the halves in.

That is one full copy of the num+den layer, allocated and freed, per layer per proof.

At lookup scale ($2^{20}$ to $2^{24}$ fractions) the widest layer is tens of megabytes, so the copy is real memory bandwidth and cache pressure.

### The idea

The MLE-check never needs to *own* those halves — it folds them in place.

A buffer split already exposes its two halves as borrowed mutable slices over the same backing store.

So hand the four borrowed halves straight to the prover instead of copying.

The sibling product-check prover already works this way; the fraction prover was the odd one out because its MLE-check constructor demanded four owned buffers.

### The change

```
layer_prover:
- split each buffer by ref, then allocate + memcpy four owned halves
+ split each owned buffer and hand the four borrowed halves over
```

### Soundness

- The reduction algorithm and all field arithmetic are unchanged.
- The prover folds the same values in the same order, so the proof output is bit-identical.
- The existing prove/verify round-trip tests (fraction, batched, logUp*) are the reference oracle and still pass.

### Scope

- **new:** a zero-copy adapter in `binius-math` presenting two split buffers as their four halves (first-low, first-high, second-low, second-high), plus a test pinning it to the borrow-only split.
- **changed:** the fraction MLE-check constructor now takes anything presenting four mutable slices; the per-layer step passes split halves directly.
- **untouched:** the other constructor call site (fresh padded buffers) — an owned array of buffers still presents as four slices.

### Verification

- `cargo check`/`clippy`/`test` on `binius-math` and `binius-ip-prover` (default and `rayon`) — clean, 0 clippy warnings.
- `binius-math` 33 + `binius-ip-prover` 58 tests pass, including all fraction/batched/logUp* prove-verify round-trips.
- nightly `fmt --check` — clean.
- Note: `cargo check --workspace --all-targets` is red on `main` for an unrelated reason (`FieldFn::call_native` feature gating in `binius-ip`); it reproduces on a clean checkout and is not touched here.

### Benchmark

End-to-end `prove` wall time, full reduction to a scalar, release build with rayon (median of repeated runs; speedup on min to filter noise):

| witness | before | after | speedup (min) |
|---|---|---|---|
| 2^18 fractions | 25.6 ms | 26.6 ms | ~0% (noise) |
| 2^20 fractions | 44.4 ms | 42.0 ms | ~9% |
| 2^22 fractions | 92.9 ms | 74 ms | ~23% |

The win scales with witness size: the copy cost is proportional to layer width, so it is lost in the arithmetic at small sizes and reaches ~20% at lookup scale. Measured with NEW running last (hottest) to rule out thermal-ordering bias.

🤖 Generated with [Claude Code](https://claude.com/claude-code)