### PR TITLE
BINIUS-238: optimize the batched instance fold with a shared Method-of-Four-Russians pass

### DIFF
--- a/crates/m4-prover/src/shift.rs
+++ b/crates/m4-prover/src/shift.rs
@@ -17,7 +17,7 @@ use binius_math::{
 	multilinear::eq::{eq_ind_partial_eval, eq_ind_partial_eval_scalars},
 };
 use binius_prover::{
-	fold_word::fold_words,
+	fold_word::{WordFolder, fold_words},
 	protocols::shift::{
 		KeyCollection, KeySegment, Operation, OperatorData, PreparedOperatorData,
 		monster::{build_h_parts, build_monster_segments},
@@ -25,7 +25,7 @@ use binius_prover::{
 		phase_2::run_sumcheck,
 	},
 };
-use binius_utils::checked_arithmetics::log2_strict_usize;
+use binius_utils::{checked_arithmetics::log2_strict_usize, rayon::prelude::*};
 use binius_verifier::protocols::shift::SHIFT_VARIANT_COUNT;
 
 use crate::ValueTable;
@@ -42,9 +42,13 @@ pub type FoldedWord<F> = [F; WORD_SIZE_BITS];
 
 /// Folds the committed witness of a batch value table along the instance axis.
 ///
-/// The batch value table is a three-axis object: the bits within each 64-bit word, the committed
-/// words within one instance, and the instances themselves. This collapses the instance axis by the
-/// equality-indicator weights of `r_rho`, leaving a multilinear over the other two axes.
+/// The batch value table has three axes:
+/// * the bits within each 64-bit word.
+/// * the committed words within one instance.
+/// * the instances themselves.
+///
+/// This collapses the instance axis by the equality-indicator weights of `r_rho`.
+/// What remains is a multilinear over the other two axes.
 ///
 /// For committed word `w` and bit `b`, the output element is
 ///
@@ -52,24 +56,27 @@ pub type FoldedWord<F> = [F; WORD_SIZE_BITS];
 /// out[w][b] = sum_rho eq(r_rho, rho) * bit_b(word[rho][w])
 /// ```
 ///
-/// so each message bit contributes its instance's equality weight to a full field element. The
-/// result is laid out with the bit axis in the low coordinates and the word axis in the high
-/// coordinates, making it a multilinear over `LOG_WORD_SIZE_BITS + log2(n_committed)` variables:
+/// so each set bit contributes its instance's equality weight to a full field element.
+///
+/// The result places the bit axis in the low coordinates and the word axis in the high coordinates.
+/// It is a multilinear over `LOG_WORD_SIZE_BITS + log2(n_committed)` variables:
 ///
 /// ```text
 /// index = w * WORD_SIZE_BITS + b     (b occupies the low LOG_WORD_SIZE_BITS coordinates)
 /// ```
 ///
-/// The public words at the front of each instance are excluded; only the committed witness words
-/// are folded, so the word axis has `combined_len - offset_witness` entries.
+/// The public words at the front of each instance are excluded.
+/// Only the committed witness words are folded.
+/// So the word axis has `combined_len - offset_witness` entries.
 ///
-/// This implementation is intentionally naive: it walks every committed word of every instance and
-/// scans its bits one at a time. A faster method-of-four-Russians version will replace it later.
+/// Every committed word position folds against the same instance point `r_rho`.
+/// So the lookup tables and per-chunk weights are built once and shared across all word positions.
+/// The word positions are independent, so the fold runs in parallel.
+/// Each task produces one output word.
 ///
 /// # Panics
 ///
-/// Panics if `r_rho.len()` does not equal the batch dimension, or if the committed word count is
-/// not a power of two.
+/// Panics if `r_rho.len()` does not equal the batch dimension.
 pub fn fold_instances<F, P>(table: &ValueTable, r_rho: &[F]) -> FieldBuffer<P>
 where
 	F: BinaryField,
@@ -82,23 +89,35 @@ where
 	let offset = layout.offset_witness;
 	let log_committed = layout.log_witness_words();
 
-	// One equality weight per instance: eq(r_rho, rho).
-	let eq = eq_ind_partial_eval_scalars::<F>(r_rho);
+	// The instance-major buffer and stride let each word position be read as a strided column.
+	let data = table.as_words();
+	let stride = table.instance_stride();
+	let n_instances = table.n_instances();
 
-	// Accumulate every committed word bit into its field element, weighted by its instance. Walking
-	// instances outermost lets each instance's slice and weight be read once.
+	// The committed word count is `combined_len - offset`.
+	// Word positions past it are the multilinear's zero padding up to `2^log_committed`.
+	let n_committed = layout.combined_len() - offset;
+
+	// Build the instance-fold tables once; the lookups and weights depend only on r_rho.
+	let folder = WordFolder::<F>::new(r_rho);
+
+	// Each output chunk holds one committed word position:
+	//     out[w * WORD_SIZE_BITS + b] = sum_rho eq(r_rho, rho) * bit_b(word[rho][w]).
+	// The word positions are independent, so fold them in parallel.
+	// Positions beyond the committed count keep their zero padding.
 	let mut out = vec![F::ZERO; 1 << (LOG_WORD_SIZE_BITS + log_committed)];
-	for (rho, &weight) in eq.iter().enumerate() {
-		let words = &table.instance(rho)[offset..];
-		for (w, word) in words.iter().enumerate() {
-			let base = w << LOG_WORD_SIZE_BITS;
-			for b in 0..WORD_SIZE_BITS {
-				if (word.0 >> b) & 1 == 1 {
-					out[base + b] += weight;
-				}
-			}
-		}
-	}
+	out.par_chunks_mut(WORD_SIZE_BITS)
+		.take(n_committed)
+		.enumerate()
+		.for_each(|(w, slot)| {
+			// Gather word position w across every instance.
+			// It is a stride-`stride` column of the instance-major buffer.
+			// Collecting it makes the column contiguous, so the fold can chunk it.
+			let column: Vec<Word> = (0..n_instances)
+				.map(|rho| data[rho * stride + offset + w])
+				.collect();
+			slot.copy_from_slice(&folder.fold(&column));
+		});
 
 	FieldBuffer::from_values(&out)
 }
@@ -510,50 +529,52 @@ mod tests {
 		type P = PackedBinaryGhash1x128b;
 
 		let c = crc64_circuit();
-
-		// A modest batch keeps the naive fold quick while still exercising a non-trivial rho axis.
-		let log_instances = 6;
-		let n_instances = 1usize << log_instances;
-
 		let mut rng = StdRng::seed_from_u64(0);
-		let inputs: Vec<[u64; N_INPUT_WORDS]> = (0..n_instances)
-			.map(|_| std::array::from_fn(|_| rng.random()))
-			.collect();
-		let table = populate_crc64_witness(&c, &inputs);
 
-		// The committed witness segment, whose word count fixes the word (x) axis.
-		let layout = table.layout();
-		let offset = layout.offset_witness;
-		let n_committed = layout.combined_len() - offset;
-		let log_committed = log2_strict_usize(n_committed);
+		// Cover every chunk regime of the per-column fold.
+		// A sub-chunk batch (< CHUNK_SIZE instances), exactly one chunk, and several chunks.
+		for log_instances in [3, LOG_WORD_SIZE_BITS, LOG_WORD_SIZE_BITS + 2] {
+			let n_instances = 1usize << log_instances;
 
-		// The instance-fold point, and a fresh point over the (bit, word) axes.
-		let r_rho = random_scalars::<B128>(&mut rng, log_instances);
-		let r = random_scalars::<B128>(&mut rng, LOG_WORD_SIZE_BITS + log_committed);
+			let inputs: Vec<[u64; N_INPUT_WORDS]> = (0..n_instances)
+				.map(|_| std::array::from_fn(|_| rng.random()))
+				.collect();
+			let table = populate_crc64_witness(&c, &inputs);
 
-		// Route A: fold the instance axis, then evaluate the resulting (bit, word) multilinear at
-		// r.
-		let folded = fold_instances::<B128, P>(&table, &r_rho);
-		let lhs = evaluate(&folded, &r);
+			// The committed witness segment, whose word count fixes the word (x) axis.
+			let layout = table.layout();
+			let offset = layout.offset_witness;
+			let n_committed = layout.combined_len() - offset;
+			let log_committed = log2_strict_usize(n_committed);
 
-		// Route B: fold each word's bits by the tensor expansion of the bit coordinates, then
-		// evaluate the resulting (word, instance) multilinear over the word and instance axes.
-		let (r_bit, r_wire) = r.split_at(LOG_WORD_SIZE_BITS);
-		let bit_tensor = eq_ind_partial_eval_scalars::<B128>(r_bit);
+			// The instance-fold point, and a fresh point over the (bit, word) axes.
+			let r_rho = random_scalars::<B128>(&mut rng, log_instances);
+			let r = random_scalars::<B128>(&mut rng, LOG_WORD_SIZE_BITS + log_committed);
 
-		// Gather the committed words of every instance, instance-major: index = rho * n_committed +
-		// w.
-		let mut committed = Vec::with_capacity(n_instances * n_committed);
-		for rho in 0..n_instances {
-			committed.extend_from_slice(&table.instance(rho)[offset..]);
+			// Route A: fold the instance axis, then evaluate the resulting (bit, word) multilinear
+			// at r.
+			let folded = fold_instances::<B128, P>(&table, &r_rho);
+			let lhs = evaluate(&folded, &r);
+
+			// Route B: fold each word's bits by the tensor expansion of the bit coordinates, then
+			// evaluate the resulting (word, instance) multilinear over the word and instance axes.
+			let (r_bit, r_wire) = r.split_at(LOG_WORD_SIZE_BITS);
+			let bit_tensor = eq_ind_partial_eval_scalars::<B128>(r_bit);
+
+			// Gather the committed words of every instance, instance-major: index = rho *
+			// n_committed + w.
+			let mut committed = Vec::with_capacity(n_instances * n_committed);
+			for rho in 0..n_instances {
+				committed.extend_from_slice(&table.instance(rho)[offset..]);
+			}
+			let folded_words = fold_words::<B128, P>(&committed, &bit_tensor);
+
+			let mut point = r_wire.to_vec();
+			point.extend_from_slice(&r_rho);
+			let rhs = evaluate(&folded_words, &point);
+
+			assert_eq!(lhs, rhs, "mismatch at log_instances = {log_instances}");
 		}
-		let folded_words = fold_words::<B128, P>(&committed, &bit_tensor);
-
-		let mut point = r_wire.to_vec();
-		point.extend_from_slice(&r_rho);
-		let rhs = evaluate(&folded_words, &point);
-
-		assert_eq!(lhs, rhs);
 	}
 
 	// The oblong evaluation of each bitand operand column A, B, C at the shift challenges.

--- a/crates/prover/src/fold_word.rs
+++ b/crates/prover/src/fold_word.rs
@@ -117,44 +117,23 @@ where
 {
 	assert_eq!(words.len(), 1 << point.len());
 
-	// Split the point into a prefix of at most LOG_CHUNK_SIZE coordinates and a suffix. The prefix
-	// is zero-padded up to LOG_CHUNK_SIZE coordinates. This padding leaves the result unchanged:
-	// when `words.len() < CHUNK_SIZE`, `duplicate_to_fixed_chunks` fills the chunk by repeating the
-	// words, and the padding pairs each repeated copy with a zero weight in the prefix expansion.
-	let prefix_len = point.len().min(LOG_CHUNK_SIZE);
-	let mut prefix = [F::ZERO; LOG_CHUNK_SIZE];
-	prefix[..prefix_len].copy_from_slice(&point[..prefix_len]);
-	let suffix = &point[prefix_len..];
-
-	// Build one 256-entry subset-sum lookup table per byte of the words. The prefix tensor
-	// expansion has CHUNK_SIZE entries (one per word in a chunk), split into WORD_SIZE_BYTES groups
-	// of BITS_PER_BYTE. Table `s` folds the words at positions `s * BITS_PER_BYTE + t` within a
-	// chunk, weighted by expansion entry `t` of the group.
-	let prefix_expansion = eq_ind_partial_eval_scalars::<F>(&prefix);
-	let lookups: [[F; 1 << BITS_PER_BYTE]; WORD_SIZE_BYTES] = array::from_fn(|byte| {
-		let group: [F; BITS_PER_BYTE] = prefix_expansion
-			[byte * BITS_PER_BYTE..(byte + 1) * BITS_PER_BYTE]
-			.try_into()
-			.expect("prefix_expansion has CHUNK_SIZE = WORD_SIZE_BYTES * BITS_PER_BYTE entries");
-		expand_subset_sums_array(group)
-	});
-
-	// The suffix tensor expansion provides one weight per chunk of CHUNK_SIZE words.
-	let suffix_weights = eq_ind_partial_eval::<F>(suffix);
-
+	// Build the point tables, then fold the one word-list over its chunks in parallel.
+	// A single list can span many chunks (up to 2^20 words in the benchmark).
+	// Parallelizing over the chunk axis is what keeps a lone fold fast.
+	let folder = WordFolder::<F>::new(point);
 	let chunks = duplicate_to_fixed_chunks::<CHUNK_SIZE>(words);
-	debug_assert_eq!(chunks.len(), suffix_weights.as_ref().len());
+	debug_assert_eq!(chunks.len(), folder.suffix_weights.as_ref().len());
 
-	// Each chunk folds into an accumulator that is transposed relative to bit position: the entry
-	// at `BITS_PER_BYTE * a + j` holds the result for bit position `BITS_PER_BYTE * j + a` (see
-	// `transpose_bits` and `fold_chunk`). The chunk accumulators are scaled by their suffix weight
-	// and summed, then transposed once at the end.
+	// Each chunk folds into an accumulator that is transposed relative to bit position.
+	// The entry at `BITS_PER_BYTE * a + j` holds the result for bit position `BITS_PER_BYTE * j +
+	// a`. Scale each chunk accumulator by its suffix weight and sum them.
+	// Transpose the total once at the end.
 	let folded = chunks
 		.as_ref()
 		.par_iter()
-		.zip(suffix_weights.as_ref().par_iter())
+		.zip(folder.suffix_weights.as_ref().par_iter())
 		.map(|(chunk, &suffix_weight)| {
-			let mut acc = fold_chunk(chunk, &lookups);
+			let mut acc = fold_chunk(chunk, &folder.lookups);
 			for acc_i in &mut acc {
 				*acc_i *= suffix_weight;
 			}
@@ -170,8 +149,112 @@ where
 			},
 		);
 
-	// Transpose the accumulator as a WORD_SIZE_BYTES × BITS_PER_BYTE matrix to index by bit
-	// position.
+	transpose_accumulator(folded)
+}
+
+/// A reusable [Method of Four Russians] folder over a fixed evaluation point.
+///
+/// [`fold_across_words`] folds one word-list per call and rebuilds its point tables each time.
+/// Many word-lists often share one point, and then those tables can be built once and reused.
+/// The batched instance fold is that case: every committed word folds against the same point.
+///
+/// The two tables it holds:
+/// * per-byte subset-sum lookups, built from the point's prefix.
+/// * one weight per chunk, built from the point's suffix.
+///
+/// [Method of Four Russians]: <https://en.wikipedia.org/wiki/Method_of_Four_Russians>
+pub struct WordFolder<F: BinaryField> {
+	/// One 256-entry subset-sum table per byte of a word, from the prefix expansion.
+	///
+	/// Table `s` folds the words at positions `s * BITS_PER_BYTE + t` within a chunk.
+	/// Each such word is weighted by prefix-expansion entry `t` of that group.
+	lookups: [[F; 1 << BITS_PER_BYTE]; WORD_SIZE_BYTES],
+	/// One weight per chunk of `CHUNK_SIZE` words, from the suffix expansion.
+	suffix_weights: FieldBuffer<F>,
+	/// The exact word-list length each [`fold`](Self::fold) consumes: `2^point.len()`.
+	n_words: usize,
+}
+
+impl<F: BinaryField> WordFolder<F> {
+	/// Builds the folding tables for `point`.
+	///
+	/// Each later [`fold`](Self::fold) call folds a `2^point.len()`-word list against this point.
+	pub fn new(point: &[F]) -> Self {
+		// Split the point into a prefix of at most LOG_CHUNK_SIZE coordinates and a suffix.
+		// Zero-pad the prefix up to LOG_CHUNK_SIZE coordinates.
+		// Why the padding is harmless:
+		//   - a list shorter than one chunk is filled by repeating its words.
+		//   - each repeated copy pairs with a zero prefix weight, so it adds nothing.
+		let prefix_len = point.len().min(LOG_CHUNK_SIZE);
+		let mut prefix = [F::ZERO; LOG_CHUNK_SIZE];
+		prefix[..prefix_len].copy_from_slice(&point[..prefix_len]);
+		let suffix = &point[prefix_len..];
+
+		// Build one 256-entry subset-sum lookup table per byte of the words.
+		// The prefix tensor expansion has CHUNK_SIZE entries, one per word in a chunk.
+		// Split those entries into WORD_SIZE_BYTES groups of BITS_PER_BYTE.
+		let prefix_expansion = eq_ind_partial_eval_scalars::<F>(&prefix);
+		let lookups: [[F; 1 << BITS_PER_BYTE]; WORD_SIZE_BYTES] = array::from_fn(|byte| {
+			let group: [F; BITS_PER_BYTE] = prefix_expansion
+				[byte * BITS_PER_BYTE..(byte + 1) * BITS_PER_BYTE]
+				.try_into()
+				.expect(
+					"prefix_expansion has CHUNK_SIZE = WORD_SIZE_BYTES * BITS_PER_BYTE entries",
+				);
+			expand_subset_sums_array(group)
+		});
+
+		// The suffix tensor expansion provides one weight per chunk of CHUNK_SIZE words.
+		let suffix_weights = eq_ind_partial_eval::<F>(suffix);
+
+		Self {
+			lookups,
+			suffix_weights,
+			n_words: 1 << point.len(),
+		}
+	}
+
+	/// Folds one word-list against the point.
+	///
+	/// Returns the array whose entry at bit position `b` is
+	///
+	/// ```text
+	/// out[b] = sum_i eq(point, i) * bit_b(words[i])
+	/// ```
+	///
+	/// with a clear bit read as zero and a set bit read as one.
+	///
+	/// This runs sequentially over the list's chunks.
+	/// A caller folding many lists against one point should parallelize across the lists instead.
+	///
+	/// ## Preconditions
+	///
+	/// * `words.len() == 1 << point.len()`
+	pub fn fold(&self, words: &[Word]) -> [F; WORD_SIZE_BITS] {
+		assert_eq!(words.len(), self.n_words, "words.len() must equal 2^point.len()");
+
+		let chunks = duplicate_to_fixed_chunks::<CHUNK_SIZE>(words);
+		debug_assert_eq!(chunks.len(), self.suffix_weights.as_ref().len());
+
+		// Accumulate each chunk's contribution, scaled by its suffix weight.
+		// The accumulator stays in the chunk kernel's transposed bit layout until the end.
+		let mut folded = [F::ZERO; WORD_SIZE_BITS];
+		for (chunk, &suffix_weight) in iter::zip(chunks.as_ref(), self.suffix_weights.as_ref()) {
+			let acc = fold_chunk(chunk, &self.lookups);
+			for (folded_i, acc_i) in iter::zip(&mut folded, acc) {
+				*folded_i += acc_i * suffix_weight;
+			}
+		}
+
+		transpose_accumulator(folded)
+	}
+}
+
+/// Transposes a reduced chunk accumulator back into bit-position order.
+///
+/// The chunk kernel stores bit `BITS_PER_BYTE * j + a`'s contribution at index `BITS_PER_BYTE * a +
+/// j`. Transposing that `WORD_SIZE_BYTES`-by-`BITS_PER_BYTE` layout restores bit-position order.
+fn transpose_accumulator<F: BinaryField>(folded: [F; WORD_SIZE_BITS]) -> [F; WORD_SIZE_BITS] {
 	let mut result = [F::ZERO; WORD_SIZE_BITS];
 	for a in 0..BITS_PER_BYTE {
 		for j in 0..WORD_SIZE_BYTES {
@@ -399,6 +482,35 @@ mod tests {
 			let result_naive = naive_fold_across_words(&words, &point);
 
 			assert_eq!(result_optimized, result_naive, "mismatch at log_n = {log_n}");
+		}
+	}
+
+	#[test]
+	fn test_word_folder_fold_matches_naive() {
+		let mut rng = StdRng::seed_from_u64(0);
+
+		// The sequential fold driver differs from the parallel one, so pin it to the naive
+		// reference. Cover every chunk regime: sub-chunk (log_n < 6), one chunk (log_n = 6), many
+		// chunks (> 6).
+		for log_n in [
+			0,
+			1,
+			3,
+			LOG_CHUNK_SIZE,
+			LOG_CHUNK_SIZE + 1,
+			LOG_CHUNK_SIZE + 4,
+		] {
+			let n_words = 1 << log_n;
+
+			let words = (0..n_words)
+				.map(|_| Word::from_u64(rng.random::<u64>()))
+				.collect::<Vec<_>>();
+			let point = random_scalars::<B128>(&mut rng, log_n);
+
+			let result_folder = WordFolder::new(&point).fold(&words);
+			let result_naive = naive_fold_across_words(&words, &point);
+
+			assert_eq!(result_folder, result_naive, "mismatch at log_n = {log_n}");
 		}
 	}
 }


### PR DESCRIPTION
Closes [BINIUS-238](https://linear.app/jimpo/issue/BINIUS-238).

Follow-up to #1735.

Replaces the batched instance fold's naive per-bit scan with a shared Method-of-Four-Russians pass.
Output is bit-identical — a prover-internal reassociation, no protocol change.

### The problem

The batched shift prover folds `2^k` circuit instances into one multilinear.
One step is the instance fold: for each committed witness word position, collapse the instance axis by the equality weights of the instance challenge `r_rho`.

The first cut from #1735 was deliberately naive.
For every instance, and every committed word, it scanned all 64 bits one at a time, adding the instance's weight into a field element per set bit.
That is `n_instances * n_committed * 64` iterations of a branch and one $\mathbb{F}_{2^{128}}$ add.
At `2^12` instances and a few thousand committed words that is a few hundred million bit-scans — it dominates the fold.

### The idea

The single-instance prover already has a fast fold on the Method of Four Russians:
group words into chunks, fold each chunk against a small precomputed lookup table, scale by a per-chunk weight, then sum.

The instance fold is the *same* operation, once per committed word position, all against the *same* point `r_rho`.
The lookup tables and the per-chunk weights depend only on the point.
So build them once and reuse them for every word position.

```
for each committed word position w:          # in parallel over word positions
    column = [ word[rho][w] for all rho ]     # gather across instances
    out[w] = folder.fold(column)              # shared M4R tables, built once
```

### Per word position

- **before:** 64 bit-scans per instance (one field add per set bit)
- **after:** the shared M4R fold — about 8 lookups plus 1 scaling multiply per instance

→ roughly an 8x cut in the dominant work.

### The change

- New `WordFolder` in `crates/prover/src/fold_word.rs`: `new(point)` builds the point tables once, `fold(words)` folds one word-list sequentially.
- `fold_across_words` now builds a `WordFolder` and keeps its parallel-over-chunks driver — behavior unchanged.
- `fold_instances` in `crates/m4-prover/src/shift.rs` builds one `WordFolder` from `r_rho` and folds every committed word position in parallel.

### Correctness

- The output is bit-identical to the naive fold, so the transcript is unchanged.
- Two parallelism strategies, one kernel: one list with many chunks folds over the chunk axis; many lists with few chunks each fold over the list axis.
- Pinned by tests: the new sequential fold against the naive reference across sub-chunk / one-chunk / multi-chunk regimes, and the instance-fold commutativity test parametrized over the same batch sizes.

### Scope

- **new:** `WordFolder` (public), plus a test pinning its fold to the naive reference.
- **changed:** `fold_across_words` (delegates to the shared kernel), `fold_instances` (M4R), the commutativity test (parametrized).
- **left untouched:** the M4R kernel (`fold_chunk` / `transpose_bits`), the protocol, and the transcript.

### Verification

- `cargo check -p binius-prover -p binius-m4-prover --all-targets` — clean
- `cargo clippy -p binius-prover -p binius-m4-prover --all-targets` — clean
- nightly `cargo fmt --all --check` — clean
- `cargo test -p binius-prover -p binius-m4-prover` — 24 + 22 pass

`cargo check --workspace --all-targets` fails on `main` today for unrelated reasons (a dependency-resolution quirk under all-targets feature unification), so verification is scoped to the touched crates.

### Benchmark

CRC-64/GO-ISO fixture (shift-heavy, a few thousand committed words per instance), `PackedBinaryGhash1x128b`, single machine:

| batch (`log_instances`) | naive | m4r | speedup |
|---|---|---|---|
| 8 (256 instances) | 18.13 ms | 2.086 ms | 8.7x |
| 10 (1024 instances) | 72.53 ms | 9.208 ms | 7.9x |
| 12 (4096 instances) | 290.6 ms | 37.97 ms | 7.7x |

Roughly 8x across the range, matching the per-word-position operation count.

<details>
<summary>Benchmark code (throwaway harness — not part of this PR)</summary>

To run it, temporarily make the `shift` module public (`pub mod shift;` in `crates/m4-prover/src/lib.rs`) and add to `crates/m4-prover/Cargo.toml`:

```toml
[dev-dependencies]
criterion.workspace = true

[lib]
bench = false

[[bench]]
name = "fold_instances"
harness = false
```

Then place this at `crates/m4-prover/benches/fold_instances.rs` and run `cargo bench -p binius-m4-prover --bench fold_instances`:

```rust
// Copyright 2026 The Binius Developers
//
// Before/after benchmark for `binius_m4_prover::shift::fold_instances`.
//
// The baseline `naive_fold_instances` below is the original implementation: it walks every
// committed word of every instance and scans its 64 bits one at a time. The optimized
// `fold_instances` replaces that per-bit scan with a shared Method-of-Four-Russians fold
// (`WordFolder`), built once from `r_rho` and applied to every committed word position in parallel.

use binius_core::{
	consts::{LOG_WORD_SIZE_BITS, WORD_SIZE_BITS},
	word::Word,
};
use binius_field::{BinaryField, PackedBinaryGhash1x128b, PackedField, Random};
use binius_frontend::{Circuit, CircuitBuilder, Wire};
use binius_m4_prover::{ValueTable, shift::fold_instances};
use binius_math::{FieldBuffer, multilinear::eq::eq_ind_partial_eval_scalars};
use binius_verifier::config::B128;
use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
use rand::prelude::*;

/// CRC-64/GO-ISO parameters, matching the shift-heavy test fixture.
const POLY_REFLECTED: u64 = 0xd800000000000000;
const INIT: u64 = 0xffffffffffffffff;
const XOR_OUT: u64 = 0xffffffffffffffff;
const N_INPUT_WORDS: usize = 4;

/// Builds a shift-heavy CRC-64/GO-ISO circuit over four private witness words.
///
/// A shift-heavy circuit gives a large committed witness (a few thousand words per instance), so
/// the instance fold does real work.
fn crc64_circuit() -> (Circuit, [Wire; N_INPUT_WORDS]) {
	let builder = CircuitBuilder::new();
	let input = std::array::from_fn(|_| builder.add_witness());

	let mut crc = builder.add_constant_64(INIT);
	let poly = builder.add_constant_64(POLY_REFLECTED);

	for word in input {
		for i in 0..64 {
			let bit = if i == 0 { word } else { builder.shr(word, i) };
			let mixed = builder.bxor(crc, bit);
			let to_msb = builder.shl(mixed, 63);
			let mask = builder.sar(to_msb, 63);
			let poly_term = builder.band(mask, poly);
			let shifted = builder.shr(crc, 1);
			crc = builder.bxor(shifted, poly_term);
		}
	}

	let output = builder.bxor(crc, builder.add_constant_64(XOR_OUT));
	builder.force_commit(output);

	(builder.build(), input)
}

/// Populates a batch value table with `2^log_instances` random instances.
fn populate(circuit: &Circuit, input: &[Wire; N_INPUT_WORDS], log_instances: usize) -> ValueTable {
	let n = 1usize << log_instances;
	let mut rng = StdRng::seed_from_u64(0);
	let inputs: Vec<[u64; N_INPUT_WORDS]> =
		(0..n).map(|_| std::array::from_fn(|_| rng.random())).collect();

	ValueTable::populate(circuit, log_instances, |i, filler| {
		for (wire, &w) in input.iter().zip(&inputs[i]) {
			filler[*wire] = Word(w);
		}
	})
	.unwrap()
}

/// The original per-word, per-bit instance fold, kept as the "before" baseline.
fn naive_fold_instances<F, P>(table: &ValueTable, r_rho: &[F]) -> FieldBuffer<P>
where
	F: BinaryField,
	P: PackedField<Scalar = F>,
{
	let layout = table.layout();
	let offset = layout.offset_witness;
	let log_committed = layout.log_witness_words();

	let eq = eq_ind_partial_eval_scalars::<F>(r_rho);

	let mut out = vec![F::ZERO; 1 << (LOG_WORD_SIZE_BITS + log_committed)];
	for (rho, &weight) in eq.iter().enumerate() {
		let words = &table.instance(rho)[offset..];
		for (w, word) in words.iter().enumerate() {
			let base = w << LOG_WORD_SIZE_BITS;
			for b in 0..WORD_SIZE_BITS {
				if (word.0 >> b) & 1 == 1 {
					out[base + b] += weight;
				}
			}
		}
	}

	FieldBuffer::from_values(&out)
}

fn bench_fold_instances(c: &mut Criterion) {
	type P = PackedBinaryGhash1x128b;

	let (circuit, input) = crc64_circuit();

	let mut group = c.benchmark_group("fold_instances");

	for log_instances in [8, 10, 12] {
		let table = populate(&circuit, &input, log_instances);
		let n_committed = table.layout().combined_len() - table.layout().offset_witness;

		// One committed field element is produced per (word, bit); use that as the throughput unit.
		let elements = (n_committed << LOG_WORD_SIZE_BITS) as u64;
		group.throughput(Throughput::Elements(elements));

		let mut rng = StdRng::seed_from_u64(1);
		let r_rho: Vec<B128> = (0..log_instances).map(|_| B128::random(&mut rng)).collect();

		// Sanity: the optimized fold agrees with the naive baseline before timing either.
		assert_eq!(
			fold_instances::<B128, P>(&table, &r_rho),
			naive_fold_instances::<B128, P>(&table, &r_rho),
		);

		group.bench_with_input(
			BenchmarkId::new("naive", log_instances),
			&log_instances,
			|b, _| b.iter(|| naive_fold_instances::<B128, P>(&table, &r_rho)),
		);
		group.bench_with_input(
			BenchmarkId::new("m4r", log_instances),
			&log_instances,
			|b, _| b.iter(|| fold_instances::<B128, P>(&table, &r_rho)),
		);
	}

	group.finish();
}

criterion_group!(benches, bench_fold_instances);
criterion_main!(benches);
```
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
