### PR TITLE
BINIUS-119: share build_g_parts between single-instance and batched shift provers

### DIFF
--- a/crates/m4-prover/src/shift.rs
+++ b/crates/m4-prover/src/shift.rs
@@ -646,7 +646,7 @@ mod tests {
 			.map(|chunk| chunk.try_into().unwrap())
 			.collect();
 		let offset = table.layout().offset_witness;
-		let public_words = table.instance(0)[..offset].to_vec();
+		let public_words = &cs.constants;
 
 		// The bitand operand evals at (r_z, r_x, r_rho); the circuit has no MUL constraints, so the
 		// intmul claim is the zero claim over an empty point.
@@ -664,7 +664,7 @@ mod tests {
 		let mut prover_transcript = ProverTranscript::<StdChallenger>::default();
 		let prover_output = prove::<B128, P, _>(
 			&key_collection,
-			&public_words,
+			public_words,
 			&folded_witness,
 			OperatorData {
 				evals: bitand_evals.to_vec(),
@@ -688,7 +688,7 @@ mod tests {
 			verify(&cs, &verifier_bitand, &verifier_intmul, &mut verifier_transcript).unwrap();
 		check_eval(
 			&cs,
-			&public_words,
+			public_words,
 			&verifier_bitand,
 			&verifier_intmul,
 			&domain_subspace,
@@ -766,7 +766,7 @@ mod tests {
 		);
 		let offset = table.layout().offset_witness;
 		let stride = table.instance_stride();
-		let public_words = table.instance(0)[..offset].to_vec();
+		let public_words = &cs.constants;
 		let hidden_folded = fold_words_over_instances(&table, &r_rho, offset..stride);
 
 		// Prepare the operator data: lambda batches the three operand claims. The circuit has no
@@ -792,7 +792,7 @@ mod tests {
 		// builder, the hidden segment from the instance-folded words. Add them. The h parts come
 		// from the single-instance prover.
 		let mut g_parts = build_g_parts::<B128, B128>(
-			&public_words,
+			public_words,
 			&key_collection.public,
 			&prepared_bitand,
 			&prepared_intmul,

--- a/crates/m4-prover/src/shift.rs
+++ b/crates/m4-prover/src/shift.rs
@@ -21,7 +21,7 @@ use binius_prover::{
 	protocols::shift::{
 		KeyCollection, KeySegment, Operation, OperatorData, PreparedOperatorData,
 		monster::{build_h_parts, build_monster_segments},
-		phase_1::run_phase_1_sumcheck,
+		phase_1::{build_g_parts, run_phase_1_sumcheck},
 		phase_2::run_sumcheck,
 	},
 };
@@ -103,39 +103,19 @@ where
 	FieldBuffer::from_values(&out)
 }
 
-/// Embeds each word's bits into the field, one [`FoldedWord`] per word.
-///
-/// Bit `b` of word `w` becomes `F::ONE` when set and `F::ZERO` otherwise. This is the fold of a
-/// word that is constant across instances: its instance fold is `bit * sum_rho eq(r_rho, rho) =
-/// bit`, so no `r_rho` weighting is needed. The public words are such constants.
-fn expand_words<F: BinaryField>(words: &[Word]) -> Vec<FoldedWord<F>> {
-	words
-		.iter()
-		.map(|word| {
-			std::array::from_fn(|b| {
-				if (word.0 >> b) & 1 == 1 {
-					F::ONE
-				} else {
-					F::ZERO
-				}
-			})
-		})
-		.collect()
-}
-
 /// Proves the batched shift-reduction, reducing the bitand and intmul evaluation claims to a single
 /// multilinear claim on the batched witness.
 ///
 /// This mirrors the single-instance shift reduction, but the hidden witness enters already folded
 /// over the instance axis: `folded_witness` holds one [`FoldedWord`] per hidden (committed) word,
 /// the oblong representation produced by [`fold_instances`]. The public words are constants shared
-/// by every instance, so they are passed unfolded and expanded on the fly.
+/// by every instance, so they are passed unfolded as raw words.
 ///
-/// The two phases call the single-instance prover's own subroutines. Phase 1 replaces the raw-word
-/// g-parts builder with the batched [`build_g_parts`], run once per key segment (public and hidden)
-/// and summed. Phase 2 derives the hidden folded segment as a partial evaluation of
-/// `folded_witness` along the bit (`r_j`) axis, folds the public segment the same way, and reuses
-/// `build_monster_ segments` and `run_sumcheck` unchanged.
+/// The two phases call the single-instance prover's own subroutines. Phase 1 builds the hidden g
+/// parts with [`build_g_parts_from_folded_words`] and the public g parts with the single-instance
+/// `build_g_parts`, then sums them. Phase 2 derives the hidden folded segment as a partial
+/// evaluation of `folded_witness` along the bit (`r_j`) axis, folds the public segment the same
+/// way, and reuses `build_monster_segments` and `run_sumcheck` unchanged.
 ///
 /// # Parameters
 /// - `key_collection`: the prover's key collection for the constraint system.
@@ -169,14 +149,22 @@ where
 	let prepared_bitand = PreparedOperatorData::new(bitand_data, bitand_lambda);
 	let prepared_intmul = PreparedOperatorData::new(intmul_data, intmul_lambda);
 
-	// Phase 1: build the g parts from the folded witness, once per key segment, then add them. The
-	// public words are constants, so their fold is just their bits. This scalar path drives the
+	// Phase 1: build the g parts once per key segment, then add them. The public words are
+	// constants shared by every instance, so the single-instance builder folds them directly from
+	// their bits; the hidden words are already folded over instances. This scalar path drives the
 	// single-instance phase-1 sumcheck.
-	let public_expanded = expand_words::<F>(public_words);
-	let mut g_parts =
-		build_g_parts(&public_expanded, &key_collection.public, &prepared_bitand, &prepared_intmul);
-	let hidden_g_parts =
-		build_g_parts(folded_witness, &key_collection.hidden, &prepared_bitand, &prepared_intmul);
+	let mut g_parts = build_g_parts::<F, F>(
+		public_words,
+		&key_collection.public,
+		&prepared_bitand,
+		&prepared_intmul,
+	);
+	let hidden_g_parts = build_g_parts_from_folded_words(
+		folded_witness,
+		&key_collection.hidden,
+		&prepared_bitand,
+		&prepared_intmul,
+	);
 	for (g, hidden_g) in g_parts.iter_mut().zip(&hidden_g_parts) {
 		for (slot, add) in g.as_mut().iter_mut().zip(hidden_g.as_ref()) {
 			*slot += *add;
@@ -225,19 +213,19 @@ where
 	)
 }
 
-/// Constructs the phase-1 "g" multilinear parts, one per shift variant, for a single key segment.
+/// Constructs the phase-1 "g" multilinear parts, one per shift variant, from instance-folded words.
 ///
-/// This is the batched analogue of the single-instance `build_g_parts`: it consumes the segment's
-/// words already folded over the instance axis, so each word is a [`FoldedWord`] whose bits are
-/// full field elements rather than a packed `u64`. Where the single-instance builder scatters an
-/// accumulator onto a word's set bits by masking, this scales the accumulator by each folded bit
-/// with a field multiplication, which coincides with masking when the folded bit is 0 or 1.
+/// This is the batched analogue of the single-instance [`build_g_parts`]: it consumes a key
+/// segment's words already folded over the instance axis, so each word is a [`FoldedWord`] whose
+/// bits are full field elements rather than a packed `u64`. Where the single-instance builder
+/// scatters an accumulator onto a word's set bits by masking, this scales the accumulator by each
+/// folded bit with a field multiplication, which coincides with masking when the folded bit is 0 or
+/// 1.
 ///
-/// Because the value vector's public and hidden words are folded by different means, the collection
-/// splits into a public and a hidden [`KeySegment`]. Call this once per segment with that segment's
-/// folded words, then add the two results to obtain the complete g parts. `folded_words` is paired
-/// with `segment.key_ranges` in order, so any power-of-two padding beyond the segment's word count
-/// is ignored.
+/// Use this for the hidden (committed) segment, whose words are folded over instances, and the
+/// single-instance [`build_g_parts`] for the public segment, whose words are constants; add the two
+/// results to obtain the complete g parts. `folded_words` is paired with `segment.key_ranges` in
+/// order, so any power-of-two padding beyond the segment's word count is ignored.
 ///
 /// The result is a flat accumulator split into `SHIFT_VARIANT_COUNT` multilinears of [`LOG_LEN`]
 /// variables each. Each multilinear is indexed by `(shift amount, bit position)`: for shift key
@@ -247,7 +235,7 @@ where
 ///
 /// This scalar implementation ignores the packed-field and parallelism optimizations of the
 /// single-instance builder.
-pub fn build_g_parts<F: BinaryField>(
+pub fn build_g_parts_from_folded_words<F: BinaryField>(
 	folded_words: &[FoldedWord<F>],
 	segment: &KeySegment,
 	bitand_operator_data: &PreparedOperatorData<F>,
@@ -606,37 +594,6 @@ mod tests {
 		folded
 	}
 
-	// Expands the public words into FoldedWords without folding over the instance axis.
-	//
-	// The public words are constants, identical across every instance, so their instance fold is
-	// `bit * sum_rho eq(r_rho, rho) = bit` (the equality weights sum to one). Folding is therefore
-	// unnecessary: take the first instance's public words and embed each bit as F::ONE or F::ZERO.
-	// The assertion pins the "identical across instances" premise this relies on.
-	fn expand_public_words(table: &ValueTable) -> Vec<FoldedWord<B128>> {
-		let offset = table.layout().offset_witness;
-		let public = &table.instance(0)[..offset];
-		for rho in 1..table.n_instances() {
-			assert_eq!(
-				&table.instance(rho)[..offset],
-				public,
-				"public words differ across instances"
-			);
-		}
-
-		public
-			.iter()
-			.map(|word| {
-				std::array::from_fn(|b| {
-					if (word.0 >> b) & 1 == 1 {
-						B128::ONE
-					} else {
-						B128::ZERO
-					}
-				})
-			})
-			.collect()
-	}
-
 	// Evaluates the instance-folded witness at the oblong point `(r_j, r_y)`: fold each word's
 	// folded bits against the `r_j` tensor, then contract the resulting per-word multilinear at
 	// `r_y`.
@@ -809,7 +766,7 @@ mod tests {
 		);
 		let offset = table.layout().offset_witness;
 		let stride = table.instance_stride();
-		let public_folded = expand_public_words(&table);
+		let public_words = table.instance(0)[..offset].to_vec();
 		let hidden_folded = fold_words_over_instances(&table, &r_rho, offset..stride);
 
 		// Prepare the operator data: lambda batches the three operand claims. The circuit has no
@@ -831,15 +788,16 @@ mod tests {
 			B128::random(&mut rng),
 		);
 
-		// The g parts: build each segment's contribution separately and add them. The h parts come
+		// The g parts: the public segment folds from raw constant words via the single-instance
+		// builder, the hidden segment from the instance-folded words. Add them. The h parts come
 		// from the single-instance prover.
-		let mut g_parts = build_g_parts(
-			&public_folded,
+		let mut g_parts = build_g_parts::<B128, B128>(
+			&public_words,
 			&key_collection.public,
 			&prepared_bitand,
 			&prepared_intmul,
 		);
-		let hidden_g_parts = build_g_parts(
+		let hidden_g_parts = build_g_parts_from_folded_words(
 			&hidden_folded,
 			&key_collection.hidden,
 			&prepared_bitand,

--- a/crates/prover/benches/shift_reduction.rs
+++ b/crates/prover/benches/shift_reduction.rs
@@ -239,7 +239,31 @@ fn bench_shift_phases(c: &mut Criterion) {
 	// here (with a throwaway transcript) to capture each phase's inputs; the setup closures below
 	// then only clone what a phase consumes by value. The specific transcript challenges do not
 	// change the work a phase performs.
-	let g_parts = build_g_parts::<F, P>(words, &key_collection, &prepared_bitand, &prepared_intmul);
+	// `build_g_parts` runs per key segment; the full g parts are the sum of the public and hidden
+	// segment parts.
+	let build_combined_g_parts = || {
+		let (public_words, hidden_words) = words.split_at(key_collection.public.n_words());
+		let mut g_parts = build_g_parts::<F, P>(
+			public_words,
+			&key_collection.public,
+			&prepared_bitand,
+			&prepared_intmul,
+		);
+		let hidden_g_parts = build_g_parts::<F, P>(
+			hidden_words,
+			&key_collection.hidden,
+			&prepared_bitand,
+			&prepared_intmul,
+		);
+		for (g, hidden_g) in g_parts.iter_mut().zip(&hidden_g_parts) {
+			for (slot, add) in g.as_mut().iter_mut().zip(hidden_g.as_ref()) {
+				*slot += *add;
+			}
+		}
+		g_parts
+	};
+
+	let g_parts = build_combined_g_parts();
 	let h_parts = build_h_parts::<F, P>(&subspace, prepared_bitand.r_zhat_prime);
 	let SumcheckOutput {
 		challenges: mut r_jr_s,
@@ -270,9 +294,7 @@ fn bench_shift_phases(c: &mut Criterion) {
 	// Phase 1. `build_g_parts` / `build_h_parts` take their inputs by reference, so no
 	// per-iteration clone is needed; `run_phase_1_sumcheck` consumes `g_parts`/`h_parts` by value.
 	group.bench_function("phase1_build_g_parts", |b| {
-		b.iter(|| {
-			build_g_parts::<F, P>(words, &key_collection, &prepared_bitand, &prepared_intmul)
-		});
+		b.iter(&build_combined_g_parts);
 	});
 	group.bench_function("phase1_build_h_parts", |b| {
 		b.iter(|| build_h_parts::<F, P>(&subspace, prepared_bitand.r_zhat_prime));

--- a/crates/prover/src/protocols/shift/phase_1.rs
+++ b/crates/prover/src/protocols/shift/phase_1.rs
@@ -21,7 +21,7 @@ use itertools::izip;
 use tracing::instrument;
 
 use super::{
-	key_collection::{KeyCollection, Operation},
+	key_collection::{KeyCollection, KeySegment, Operation},
 	monster::build_h_parts,
 	prove::PreparedOperatorData,
 };
@@ -46,7 +46,18 @@ where
 	P: PackedField<Scalar = F>,
 	Channel: IPProverChannel<F>,
 {
-	let g_parts = build_g_parts::<_, P>(words, key_collection, bitand_data, intmul_data);
+	// Build the g parts for the public and hidden segments separately, then sum them. The public
+	// words are the prefix of `words`, and each segment's key ranges are segment-relative.
+	let (public_words, hidden_words) = words.split_at(key_collection.public.n_words());
+	let mut g_parts =
+		build_g_parts::<_, P>(public_words, &key_collection.public, bitand_data, intmul_data);
+	let hidden_g_parts =
+		build_g_parts::<_, P>(hidden_words, &key_collection.hidden, bitand_data, intmul_data);
+	for (g, hidden_g) in g_parts.iter_mut().zip(&hidden_g_parts) {
+		for (slot, add) in g.as_mut().iter_mut().zip(hidden_g.as_ref()) {
+			*slot += *add;
+		}
+	}
 
 	// BitAnd and IntMul share the same `r_zhat_prime`.
 	let h_parts = build_h_parts(domain_subspace, bitand_data.r_zhat_prime);
@@ -141,17 +152,20 @@ pub fn run_phase_1_sumcheck<F: Field, P: PackedField<Scalar = F>, Channel: IPPro
 	}
 }
 
-/// Constructs the "g" multilinear parts for both BITAND and INTMUL operations.
+/// Constructs the "g" multilinear parts for both BITAND and INTMUL operations, for one key segment.
 ///
-/// This function builds the g multilinear polynomials used in phase 1 of the shift protocol.
-/// For each operation (BITAND and INTMUL), it constructs three multilinear polynomials
-/// corresponding to the three shift variants (SLL, SRL, SRA).
+/// This builds the g multilinear polynomials used in phase 1 of the shift protocol, over the words
+/// of a single value-vector segment (public or hidden). For each operation (BITAND and INTMUL) it
+/// constructs three multilinear polynomials corresponding to the three shift variants (SLL, SRL,
+/// SRA).
+///
+/// The value vector's public and hidden words participate through their own [`KeySegment`], so a
+/// caller builds each segment's parts with the matching words and sums the two results.
 ///
 /// # Construction Process
 ///
 /// 1. **Parallel Processing**: Words are processed in parallel chunks for efficiency
-/// 2. **Key Processing**: For each word, iterate through its associated keys from the key
-///    collection
+/// 2. **Key Processing**: For each word, iterate through its associated keys in the segment
 /// 3. **Accumulation**: For each key, accumulate its contribution weighted by the r_x' tensor
 /// 4. **Word Expansion**: Expand each witness word bitwise to populate the g multilinears
 /// 5. **Lambda Weighting**: Apply lambda powers to weight different operand positions
@@ -167,7 +181,7 @@ pub fn run_phase_1_sumcheck<F: Field, P: PackedField<Scalar = F>, Channel: IPPro
 #[instrument(skip_all, name = "build_g_parts")]
 pub fn build_g_parts<F: BinaryField, P: PackedField<Scalar = F>>(
 	words: &[Word],
-	key_collection: &KeyCollection,
+	segment: &KeySegment,
 	bitand_operator_data: &PreparedOperatorData<F>,
 	intmul_operator_data: &PreparedOperatorData<F>,
 ) -> [FieldBuffer<P>; SHIFT_VARIANT_COUNT] {
@@ -186,23 +200,13 @@ pub fn build_g_parts<F: BinaryField, P: PackedField<Scalar = F>>(
 	// A mask for low `P::WIDTH` bits.
 	let low_bits_mask = (1u8 << P::WIDTH) - 1;
 
-	// Process the public and hidden segments in absolute value-vector order: the public
-	// words are the prefix of `words`, and each segment's key ranges are segment-relative.
-	let (public_words, hidden_words) = words.split_at(key_collection.public.n_words());
-	let public_iter = public_words
+	// Each word carries the keys named by the segment-relative range at its position.
+	let multilinears = words
 		.par_iter()
-		.zip(key_collection.public.key_ranges.par_iter())
-		.map(|(word, range)| (word, range, &key_collection.public));
-	let hidden_iter = hidden_words
-		.par_iter()
-		.zip(key_collection.hidden.key_ranges.par_iter())
-		.map(|(word, range)| (word, range, &key_collection.hidden));
-
-	let multilinears = public_iter
-		.chain(hidden_iter)
+		.zip(segment.key_ranges.par_iter())
 		.fold(
 			|| zeroed_vec::<P>(acc_size).into_boxed_slice(),
-			|mut multilinears, (word, Range { start, end }, segment)| {
+			|mut multilinears, (word, Range { start, end })| {
 				let keys = &segment.keys[*start as usize..*end as usize];
 
 				for key in keys {


### PR DESCRIPTION
## Summary

Follows #1735 (merged into main).

Reworks `build_g_parts` so the single-instance and batched (M4) shift provers share it, one key segment at a time.

- **Split single-instance `build_g_parts` to accept a `KeySegment`** (in `binius-prover`): it now takes one segment plus that segment's words instead of the whole `KeyCollection` and combined word slice, and iterates the segment's words against `segment.key_ranges`. `prove_phase_1` splits the combined witness at the public boundary, builds each segment's g parts, and sums them element-wise across shift variants. The `shift_reduction` benchmark's two call sites use a local `build_combined_g_parts` helper. Behavior is unchanged — the accumulation is additive per word, so summing the per-segment parts equals the previous single combined pass.

- **Reuse it for public words in the batched prover** (in `binius-m4-prover`): the batched `build_g_parts` (which consumes instance-folded `FoldedWord`s) is renamed to `build_g_parts_from_folded_words` and kept for the hidden segment. The public segment now folds directly from its raw constant `Word`s via the single-instance `build_g_parts`, dropping the `expand_words` / `expand_public_words` bit-expansion shims (masking on raw words gives the identical result).

## Testing

- `cargo test -p binius-prover --test shift` — `test_shift_prove_and_verify` passes (single-instance behavior preserved).
- `cargo test -p binius-m4-prover` — all pass, including `phase_1_g_h_inner_product_matches_batched_evals` and `prove_and_verify_round_trip`.
- `cargo clippy` and `cargo fmt` clean on both crates (benches included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
