### PR TITLE
BINIUS-237: add ValueTable2, a wire-major M4 witness table

### DIFF
--- a/crates/frontend/Cargo.toml
+++ b/crates/frontend/Cargo.toml
@@ -9,6 +9,7 @@ workspace = true
 
 [dependencies]
 binius-core = { path = "../core" }
+binius-utils = { path = "../utils" }
 cranelift-entity = { workspace = true }
 hex-literal.workspace = true
 num-bigint = { workspace = true }

--- a/crates/frontend/src/compiler/circuit.rs
+++ b/crates/frontend/src/compiler/circuit.rs
@@ -1,14 +1,16 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 use std::{error, fmt};
 
 use binius_core::{
 	constraint_system::{ConstraintSystem, ValueIndex, ValueVec},
 	word::Word,
 };
+use binius_utils::strided_array::StridedArray2DViewMut;
 use cranelift_entity::SecondaryMap;
 
 use crate::compiler::{
-	eval_form::EvalForm,
+	eval_form::{BatchPopulateError, EvalForm},
 	gate_graph::{GateGraph, Wire},
 };
 
@@ -150,6 +152,39 @@ impl Circuit {
 			.evaluate(&mut w.value_vec, Some(&self.gate_graph.path_spec_tree))?;
 
 		Ok(())
+	}
+
+	/// Populates non-input values for a batch of instances at once.
+	///
+	/// This is the structure-of-arrays counterpart to [`Self::populate_wire_witness`]. `values` is
+	/// the transposed value array: rows are value-vector indices (in the same order a single
+	/// instance's [`ValueVec`] uses) and columns are instances. Its height must be the full
+	/// value-vector length (including scratch) and its width is the instance count.
+	///
+	/// The caller must fill each instance's input rows first — the witness wires and any inout
+	/// wires. This function fills the constant rows (broadcasting each constant across every
+	/// instance) and then evaluates the circuit gate-by-gate for all instances.
+	///
+	/// # Errors
+	///
+	/// If any instance is not satisfiable, returns an error naming the lowest-indexed failing
+	/// instance and its assertion failures.
+	pub fn populate_wire_witness_batched(
+		&self,
+		values: &mut StridedArray2DViewMut<'_, Word>,
+	) -> Result<(), BatchPopulateError> {
+		// Broadcast each constant into its row across every instance. The constants are the same
+		// for all instances, so this fills the constant rows uniformly.
+		let n_instances = values.width();
+		for (index, &constant) in self.constraint_system.constants.iter().enumerate() {
+			for instance in 0..n_instances {
+				values[(index, instance)] = constant;
+			}
+		}
+
+		// Evaluate the bytecode across all instances, symbolicating assertion failures.
+		self.eval_form
+			.evaluate_batched(values, Some(&self.gate_graph.path_spec_tree))
 	}
 
 	/// Returns the constraint system for this circuit.

--- a/crates/frontend/src/compiler/eval_form/batch_interpreter.rs
+++ b/crates/frontend/src/compiler/eval_form/batch_interpreter.rs
@@ -1,0 +1,755 @@
+// Copyright 2025-2026 The Binius Developers
+//! Batched bytecode interpreter for circuit evaluation.
+//!
+//! This is the structure-of-arrays counterpart to [`Interpreter`](super::interpreter::Interpreter).
+//! It evaluates the same bytecode over `n` independent instances of one circuit at once.
+//!
+//! The value vector is transposed into a 2D array whose rows are value-vector indices (wires) and
+//! whose columns are instances. A "register" is therefore a whole row, and executing an
+//! instruction applies its scalar operation across the entire row — every instance in one pass.
+//! This is the memory order the batch prover wants downstream.
+//!
+//! ```text
+//!                  instance 0   instance 1   ...   instance n-1
+//!   value index 0 [   w        |   w        | ... |   w        ]   <- one row = one register
+//!   value index 1 [   w        |   w        | ... |   w        ]
+//!         ...
+//! ```
+
+use binius_core::Word;
+use binius_utils::strided_array::StridedArray2DViewMut;
+
+use crate::compiler::{
+	circuit::PopulateError,
+	hints::HintRegistry,
+	pathspec::{PathSpec, PathSpecTree},
+};
+
+/// The cap on how many assertion failures are retained across the whole batch.
+///
+/// This mirrors the single-instance interpreter's cap. Failures past it are counted but not stored.
+const MAX_ASSERTION_FAILURES: usize = 100;
+
+/// A single assertion failure, tagged with the instance whose values violated it.
+struct InstanceAssertionFailure {
+	instance: usize,
+	path_spec: PathSpec,
+	message: String,
+}
+
+/// The failure of batch witness population, attributed to a single instance.
+///
+/// When several instances fail, this reports the one with the lowest index, matching what
+/// populating that instance on its own would produce.
+#[derive(Debug)]
+pub struct BatchPopulateError {
+	/// The index of the reported instance, the lowest-numbered failing instance.
+	pub instance: usize,
+	/// The assertion failures recorded for that instance.
+	pub source: PopulateError,
+}
+
+/// Execution context holding the transposed value array during batch evaluation.
+struct BatchExecutionContext<'a, 'v> {
+	/// Rows are value-vector indices; columns are instances.
+	values: &'a mut StridedArray2DViewMut<'v, Word>,
+	/// Assertion failures recorded during evaluation, capped by [`MAX_ASSERTION_FAILURES`].
+	failures: Vec<InstanceAssertionFailure>,
+	/// The total number of assertion violations recorded, across all instances.
+	total_count: usize,
+	/// The lowest-indexed instance that has failed an assertion, tracked even past the cap.
+	min_failing_instance: Option<usize>,
+}
+
+impl<'a, 'v> BatchExecutionContext<'a, 'v> {
+	const fn new(values: &'a mut StridedArray2DViewMut<'v, Word>) -> Self {
+		Self {
+			values,
+			failures: Vec::new(),
+			total_count: 0,
+			min_failing_instance: None,
+		}
+	}
+
+	/// The number of instances, i.e. the number of columns in the value array.
+	const fn n_instances(&self) -> usize {
+		self.values.width()
+	}
+
+	#[inline]
+	fn load(&self, reg: u32, instance: usize) -> Word {
+		self.values[(reg as usize, instance)]
+	}
+
+	#[inline]
+	fn store(&mut self, reg: u32, instance: usize, value: Word) {
+		self.values[(reg as usize, instance)] = value;
+	}
+
+	/// Record an assertion failure for `instance`.
+	///
+	/// The failure may be dropped from the stored list once the cap is reached, but it always
+	/// updates the count and the lowest-failing-instance tracker.
+	#[cold]
+	fn note_assertion_failure(&mut self, instance: usize, path_spec: PathSpec, message: String) {
+		self.total_count += 1;
+		self.min_failing_instance = Some(
+			self.min_failing_instance
+				.map_or(instance, |m| m.min(instance)),
+		);
+		if self.failures.len() < MAX_ASSERTION_FAILURES {
+			self.failures.push(InstanceAssertionFailure {
+				instance,
+				path_spec,
+				message,
+			});
+		}
+	}
+
+	/// Turn recorded failures into an error attributed to the lowest-failing instance.
+	fn check_assertions(
+		self,
+		path_spec_tree: Option<&PathSpecTree>,
+	) -> Result<(), BatchPopulateError> {
+		let Some(instance) = self.min_failing_instance else {
+			return Ok(());
+		};
+
+		// Collect and symbolicate just the reported instance's messages.
+		let mut messages = Vec::new();
+		let mut total_count = 0;
+		for failure in self.failures.into_iter().filter(|f| f.instance == instance) {
+			total_count += 1;
+			let message = if let Some(tree) = path_spec_tree {
+				let mut path = String::new();
+				tree.stringify(failure.path_spec, &mut path);
+				if path.is_empty() {
+					failure.message
+				} else {
+					format!("{}: {}", path, failure.message)
+				}
+			} else {
+				failure.message
+			};
+			messages.push(message);
+		}
+
+		Err(BatchPopulateError {
+			instance,
+			source: PopulateError {
+				messages,
+				total_count,
+			},
+		})
+	}
+}
+
+/// Bytecode interpreter that evaluates one circuit over many instances at once.
+pub struct BatchInterpreter<'a> {
+	bytecode: &'a [u8],
+	hints: &'a HintRegistry,
+	pc: usize,
+}
+
+impl<'a> BatchInterpreter<'a> {
+	pub const fn new(bytecode: &'a [u8], hints: &'a HintRegistry) -> Self {
+		Self {
+			bytecode,
+			hints,
+			pc: 0,
+		}
+	}
+
+	/// Evaluate the bytecode over the transposed value array, filling every instance's wires.
+	///
+	/// The constant and input rows must already be populated for every instance. Returns an error
+	/// naming the lowest-indexed instance whose assignment fails an assertion.
+	pub fn run(
+		&mut self,
+		values: &mut StridedArray2DViewMut<'_, Word>,
+		path_spec_tree: Option<&PathSpecTree>,
+	) -> Result<(), BatchPopulateError> {
+		let mut ctx = BatchExecutionContext::new(values);
+		while self.pc < self.bytecode.len() {
+			let opcode = self.read_u8();
+			match opcode {
+				// Bitwise operations
+				0x01 => self.exec_band(&mut ctx),
+				0x02 => self.exec_bor(&mut ctx),
+				0x03 => self.exec_bxor(&mut ctx),
+				0x05 => self.exec_select(&mut ctx),
+				0x06 => self.exec_bxor_multi(&mut ctx),
+				0x07 => self.exec_fax(&mut ctx),
+
+				// Shifts
+				0x10 => self.exec_sll(&mut ctx),
+				0x11 => self.exec_slr(&mut ctx),
+				0x12 => self.exec_sar(&mut ctx),
+
+				// Arithmetic
+				0x20 => self.exec_iadd_cout(&mut ctx),
+				0x21 => self.exec_iadd_cin_cout(&mut ctx),
+				0x23 => self.exec_isub_bin_bout(&mut ctx),
+				0x30 => self.exec_imul(&mut ctx),
+
+				// 32-bit operations
+				0x40 => self.exec_iadd32_cin_cout(&mut ctx),
+				0x41 => self.exec_rotr32(&mut ctx),
+				0x42 => self.exec_srl32(&mut ctx),
+				0x43 => self.exec_rotr(&mut ctx),
+				0x44 => self.exec_sll32(&mut ctx),
+				0x45 => self.exec_sra32(&mut ctx),
+				0x46 => self.exec_iadd32_cout(&mut ctx),
+
+				// Masks
+				0x50 => self.exec_mask_low(&mut ctx),
+				0x51 => self.exec_mask_high(&mut ctx),
+
+				// Assertions
+				0x60 => self.exec_assert_eq(&mut ctx),
+				0x61 => self.exec_assert_eq_cond(&mut ctx),
+				0x62 => self.exec_assert_zero(&mut ctx),
+				0x63 => self.exec_assert_non_zero(&mut ctx),
+				0x64 => self.exec_assert_false(&mut ctx),
+				0x65 => self.exec_assert_true(&mut ctx),
+
+				// Hint calls
+				0x80 => self.exec_hint(&mut ctx),
+
+				_ => panic!("Unknown opcode: {:#x} at pc={}", opcode, self.pc - 1),
+			}
+		}
+		ctx.check_assertions(path_spec_tree)
+	}
+
+	// Bitwise operations
+	fn exec_band(&mut self, ctx: &mut BatchExecutionContext<'_, '_>) {
+		let dst = self.read_reg();
+		let src1 = self.read_reg();
+		let src2 = self.read_reg();
+		for i in 0..ctx.n_instances() {
+			let val = ctx.load(src1, i) & ctx.load(src2, i);
+			ctx.store(dst, i, val);
+		}
+	}
+
+	fn exec_bor(&mut self, ctx: &mut BatchExecutionContext<'_, '_>) {
+		let dst = self.read_reg();
+		let src1 = self.read_reg();
+		let src2 = self.read_reg();
+		for i in 0..ctx.n_instances() {
+			let val = ctx.load(src1, i) | ctx.load(src2, i);
+			ctx.store(dst, i, val);
+		}
+	}
+
+	fn exec_bxor(&mut self, ctx: &mut BatchExecutionContext<'_, '_>) {
+		let dst = self.read_reg();
+		let src1 = self.read_reg();
+		let src2 = self.read_reg();
+		for i in 0..ctx.n_instances() {
+			let val = ctx.load(src1, i) ^ ctx.load(src2, i);
+			ctx.store(dst, i, val);
+		}
+	}
+
+	fn exec_select(&mut self, ctx: &mut BatchExecutionContext<'_, '_>) {
+		let dst = self.read_reg();
+		let cond = self.read_reg();
+		let t = self.read_reg();
+		let f = self.read_reg();
+		for i in 0..ctx.n_instances() {
+			// Select t if MSB(cond) is 1, otherwise select f
+			let val = if ctx.load(cond, i).is_msb_true() {
+				ctx.load(t, i)
+			} else {
+				ctx.load(f, i)
+			};
+			ctx.store(dst, i, val);
+		}
+	}
+
+	fn exec_bxor_multi(&mut self, ctx: &mut BatchExecutionContext<'_, '_>) {
+		let dst = self.read_reg();
+		let n = self.read_u32() as usize;
+		// Read the source registers once; they are shared across every instance.
+		let srcs = (0..n).map(|_| self.read_reg()).collect::<Vec<_>>();
+		for i in 0..ctx.n_instances() {
+			let mut val = Word::ZERO;
+			for &src in &srcs {
+				val = val ^ ctx.load(src, i);
+			}
+			ctx.store(dst, i, val);
+		}
+	}
+
+	fn exec_fax(&mut self, ctx: &mut BatchExecutionContext<'_, '_>) {
+		let dst = self.read_reg();
+		let src1 = self.read_reg();
+		let src2 = self.read_reg();
+		let src3 = self.read_reg();
+		for i in 0..ctx.n_instances() {
+			let val = (ctx.load(src1, i) & ctx.load(src2, i)) ^ ctx.load(src3, i);
+			ctx.store(dst, i, val);
+		}
+	}
+
+	// Shifts
+	fn exec_sll(&mut self, ctx: &mut BatchExecutionContext<'_, '_>) {
+		let dst = self.read_reg();
+		let src = self.read_reg();
+		let shift = self.read_u8() as u32;
+		for i in 0..ctx.n_instances() {
+			let val = ctx.load(src, i) << shift;
+			ctx.store(dst, i, val);
+		}
+	}
+
+	fn exec_slr(&mut self, ctx: &mut BatchExecutionContext<'_, '_>) {
+		let dst = self.read_reg();
+		let src = self.read_reg();
+		let shift = self.read_u8() as u32;
+		for i in 0..ctx.n_instances() {
+			let val = ctx.load(src, i) >> shift;
+			ctx.store(dst, i, val);
+		}
+	}
+
+	fn exec_sar(&mut self, ctx: &mut BatchExecutionContext<'_, '_>) {
+		let dst = self.read_reg();
+		let src = self.read_reg();
+		let shift = self.read_u8() as u32;
+		for i in 0..ctx.n_instances() {
+			let val = ctx.load(src, i).sar(shift);
+			ctx.store(dst, i, val);
+		}
+	}
+
+	// Arithmetic operations
+	fn exec_iadd_cout(&mut self, ctx: &mut BatchExecutionContext<'_, '_>) {
+		let dst_sum = self.read_reg();
+		let dst_cout = self.read_reg();
+		let src1 = self.read_reg();
+		let src2 = self.read_reg();
+		for i in 0..ctx.n_instances() {
+			let (sum, cout) = ctx
+				.load(src1, i)
+				.iadd_cin_cout(ctx.load(src2, i), Word::ZERO);
+			ctx.store(dst_sum, i, sum);
+			ctx.store(dst_cout, i, cout);
+		}
+	}
+
+	fn exec_iadd_cin_cout(&mut self, ctx: &mut BatchExecutionContext<'_, '_>) {
+		let dst_sum = self.read_reg();
+		let dst_cout = self.read_reg();
+		let src1 = self.read_reg();
+		let src2 = self.read_reg();
+		let cin = self.read_reg();
+		for i in 0..ctx.n_instances() {
+			let cin_bit = ctx.load(cin, i) >> 63; // Use MSB as carry bit
+			let (sum, cout) = ctx.load(src1, i).iadd_cin_cout(ctx.load(src2, i), cin_bit);
+			ctx.store(dst_sum, i, sum);
+			ctx.store(dst_cout, i, cout);
+		}
+	}
+
+	fn exec_isub_bin_bout(&mut self, ctx: &mut BatchExecutionContext<'_, '_>) {
+		let dst_diff = self.read_reg();
+		let dst_bout = self.read_reg();
+		let src1 = self.read_reg();
+		let src2 = self.read_reg();
+		let bin = self.read_reg();
+		for i in 0..ctx.n_instances() {
+			let bin_bit = ctx.load(bin, i) >> 63; // Use MSB as borrow bit
+			let (diff, bout) = ctx.load(src1, i).isub_bin_bout(ctx.load(src2, i), bin_bit);
+			ctx.store(dst_diff, i, diff);
+			ctx.store(dst_bout, i, bout);
+		}
+	}
+
+	fn exec_imul(&mut self, ctx: &mut BatchExecutionContext<'_, '_>) {
+		let dst_hi = self.read_reg();
+		let dst_lo = self.read_reg();
+		let src1 = self.read_reg();
+		let src2 = self.read_reg();
+		for i in 0..ctx.n_instances() {
+			let (hi, lo) = ctx.load(src1, i).imul(ctx.load(src2, i));
+			ctx.store(dst_hi, i, hi);
+			ctx.store(dst_lo, i, lo);
+		}
+	}
+
+	// 32-bit operations
+	fn exec_iadd32_cin_cout(&mut self, ctx: &mut BatchExecutionContext<'_, '_>) {
+		let dst_sum = self.read_reg();
+		let dst_cout = self.read_reg();
+		let src1 = self.read_reg();
+		let src2 = self.read_reg();
+		let cin = self.read_reg();
+		for i in 0..ctx.n_instances() {
+			let (sum, cout) = ctx
+				.load(src1, i)
+				.iadd32_cin_cout(ctx.load(src2, i), ctx.load(cin, i));
+			ctx.store(dst_sum, i, sum);
+			ctx.store(dst_cout, i, cout);
+		}
+	}
+
+	fn exec_iadd32_cout(&mut self, ctx: &mut BatchExecutionContext<'_, '_>) {
+		let dst_sum = self.read_reg();
+		let dst_cout = self.read_reg();
+		let src1 = self.read_reg();
+		let src2 = self.read_reg();
+		for i in 0..ctx.n_instances() {
+			let (sum, cout) = ctx.load(src1, i).iadd_cout_32(ctx.load(src2, i));
+			ctx.store(dst_sum, i, sum);
+			ctx.store(dst_cout, i, cout);
+		}
+	}
+
+	fn exec_rotr32(&mut self, ctx: &mut BatchExecutionContext<'_, '_>) {
+		let dst = self.read_reg();
+		let src = self.read_reg();
+		let rotate = self.read_u8() as u32;
+		for i in 0..ctx.n_instances() {
+			let val = ctx.load(src, i).rotr32(rotate);
+			ctx.store(dst, i, val);
+		}
+	}
+
+	fn exec_srl32(&mut self, ctx: &mut BatchExecutionContext<'_, '_>) {
+		let dst = self.read_reg();
+		let src = self.read_reg();
+		let shift = self.read_u8() as u32;
+		for i in 0..ctx.n_instances() {
+			let val = ctx.load(src, i).srl32(shift);
+			ctx.store(dst, i, val);
+		}
+	}
+
+	fn exec_sll32(&mut self, ctx: &mut BatchExecutionContext<'_, '_>) {
+		let dst = self.read_reg();
+		let src = self.read_reg();
+		let shift = self.read_u8() as u32;
+		for i in 0..ctx.n_instances() {
+			let val = ctx.load(src, i).sll32(shift);
+			ctx.store(dst, i, val);
+		}
+	}
+
+	fn exec_sra32(&mut self, ctx: &mut BatchExecutionContext<'_, '_>) {
+		let dst = self.read_reg();
+		let src = self.read_reg();
+		let shift = self.read_u8() as u32;
+		for i in 0..ctx.n_instances() {
+			let val = ctx.load(src, i).sra32(shift);
+			ctx.store(dst, i, val);
+		}
+	}
+
+	fn exec_rotr(&mut self, ctx: &mut BatchExecutionContext<'_, '_>) {
+		let dst = self.read_reg();
+		let src = self.read_reg();
+		let rotate = self.read_u8() as u32;
+		for i in 0..ctx.n_instances() {
+			let val = ctx.load(src, i).rotr(rotate);
+			ctx.store(dst, i, val);
+		}
+	}
+
+	// Mask operations
+	fn exec_mask_low(&mut self, ctx: &mut BatchExecutionContext<'_, '_>) {
+		let dst = self.read_reg();
+		let src = self.read_reg();
+		let n_bits = self.read_u8();
+		let mask = if n_bits >= 64 {
+			Word::ALL_ONE
+		} else {
+			Word::from_u64((1u64 << n_bits) - 1)
+		};
+		for i in 0..ctx.n_instances() {
+			let val = ctx.load(src, i) & mask;
+			ctx.store(dst, i, val);
+		}
+	}
+
+	fn exec_mask_high(&mut self, ctx: &mut BatchExecutionContext<'_, '_>) {
+		let dst = self.read_reg();
+		let src = self.read_reg();
+		let n_bits = self.read_u8();
+		let mask = if n_bits >= 64 {
+			Word::ALL_ONE
+		} else {
+			Word::from_u64(!((1u64 << (64 - n_bits)) - 1))
+		};
+		for i in 0..ctx.n_instances() {
+			let val = ctx.load(src, i) & mask;
+			ctx.store(dst, i, val);
+		}
+	}
+
+	// Assertions
+	fn exec_assert_eq(&mut self, ctx: &mut BatchExecutionContext<'_, '_>) {
+		let src1 = self.read_reg();
+		let src2 = self.read_reg();
+		let error_id = self.read_u32();
+		let path_spec = PathSpec::from_u32(error_id);
+
+		for i in 0..ctx.n_instances() {
+			let val1 = ctx.load(src1, i);
+			let val2 = ctx.load(src2, i);
+			if val1 != val2 {
+				ctx.note_assertion_failure(i, path_spec, format!("{val1:?} != {val2:?}"));
+			}
+		}
+	}
+
+	fn exec_assert_eq_cond(&mut self, ctx: &mut BatchExecutionContext<'_, '_>) {
+		let cond = self.read_reg();
+		let src1 = self.read_reg();
+		let src2 = self.read_reg();
+		let error_id = self.read_u32();
+		let path_spec = PathSpec::from_u32(error_id);
+
+		for i in 0..ctx.n_instances() {
+			if ctx.load(cond, i).is_msb_true() {
+				let val1 = ctx.load(src1, i);
+				let val2 = ctx.load(src2, i);
+				if val1 != val2 {
+					ctx.note_assertion_failure(
+						i,
+						path_spec,
+						format!("conditional assert: {val1:?} != {val2:?}"),
+					);
+				}
+			}
+		}
+	}
+
+	fn exec_assert_zero(&mut self, ctx: &mut BatchExecutionContext<'_, '_>) {
+		let src = self.read_reg();
+		let error_id = self.read_u32();
+		let path_spec = PathSpec::from_u32(error_id);
+
+		for i in 0..ctx.n_instances() {
+			let val = ctx.load(src, i);
+			if val != Word::ZERO {
+				ctx.note_assertion_failure(i, path_spec, format!("{val:?} != 0"));
+			}
+		}
+	}
+
+	fn exec_assert_non_zero(&mut self, ctx: &mut BatchExecutionContext<'_, '_>) {
+		let src = self.read_reg();
+		let error_id = self.read_u32();
+		let path_spec = PathSpec::from_u32(error_id);
+
+		for i in 0..ctx.n_instances() {
+			let val = ctx.load(src, i);
+			if val == Word::ZERO {
+				ctx.note_assertion_failure(i, path_spec, format!("{val:?} == 0"));
+			}
+		}
+	}
+
+	fn exec_assert_false(&mut self, ctx: &mut BatchExecutionContext<'_, '_>) {
+		let src = self.read_reg();
+		let error_id = self.read_u32();
+		let path_spec = PathSpec::from_u32(error_id);
+
+		for i in 0..ctx.n_instances() {
+			let val = ctx.load(src, i);
+			if val.is_msb_true() {
+				ctx.note_assertion_failure(i, path_spec, format!("{val:?} MSB is true"));
+			}
+		}
+	}
+
+	fn exec_assert_true(&mut self, ctx: &mut BatchExecutionContext<'_, '_>) {
+		let src = self.read_reg();
+		let error_id = self.read_u32();
+		let path_spec = PathSpec::from_u32(error_id);
+
+		for i in 0..ctx.n_instances() {
+			let val = ctx.load(src, i);
+			if val.is_msb_false() {
+				ctx.note_assertion_failure(i, path_spec, format!("{val:?} MSB is false"));
+			}
+		}
+	}
+
+	// Hint execution
+	fn exec_hint(&mut self, ctx: &mut BatchExecutionContext<'_, '_>) {
+		let hint_id = self.read_u32();
+
+		// Read dimensions
+		let n_dimensions = self.read_u16() as usize;
+		let mut dimensions = Vec::with_capacity(n_dimensions);
+		for _ in 0..n_dimensions {
+			dimensions.push(self.read_u32() as usize);
+		}
+
+		let n_inputs = self.read_u16() as usize;
+		let n_outputs = self.read_u16() as usize;
+
+		// Read the input and output registers once; they are shared across every instance.
+		let input_regs = (0..n_inputs).map(|_| self.read_reg()).collect::<Vec<_>>();
+		let output_regs = (0..n_outputs).map(|_| self.read_reg()).collect::<Vec<_>>();
+
+		let mut inputs = vec![Word::ZERO; n_inputs];
+		let mut outputs = vec![Word::ZERO; n_outputs];
+		for i in 0..ctx.n_instances() {
+			for (input, &reg) in inputs.iter_mut().zip(&input_regs) {
+				*input = ctx.load(reg, i);
+			}
+			self.hints
+				.execute(hint_id, &dimensions, &inputs, &mut outputs);
+			for (&reg, &output) in output_regs.iter().zip(&outputs) {
+				ctx.store(reg, i, output);
+			}
+		}
+	}
+
+	// Bytecode reading helpers
+	fn read_u8(&mut self) -> u8 {
+		let val = self.bytecode[self.pc];
+		self.pc += 1;
+		val
+	}
+
+	fn read_u16(&mut self) -> u16 {
+		let val = u16::from_le_bytes([self.bytecode[self.pc], self.bytecode[self.pc + 1]]);
+		self.pc += 2;
+		val
+	}
+
+	fn read_u32(&mut self) -> u32 {
+		let val = u32::from_le_bytes([
+			self.bytecode[self.pc],
+			self.bytecode[self.pc + 1],
+			self.bytecode[self.pc + 2],
+			self.bytecode[self.pc + 3],
+		]);
+		self.pc += 4;
+		val
+	}
+
+	fn read_reg(&mut self) -> u32 {
+		self.read_u32()
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use binius_core::Word;
+	use binius_utils::strided_array::StridedArray2DViewMut;
+
+	use crate::compiler::CircuitBuilder;
+
+	// The batched interpreter must reproduce, for every instance, exactly what the single-instance
+	// interpreter produces for the same inputs. This is the core equivalence guarantee.
+	#[test]
+	fn batched_matches_scalar_per_instance() {
+		// A circuit that exercises a spread of opcodes plus a constant, with only witness inputs
+		// and force-committed outputs (no inout wires — the M4 setting).
+		let builder = CircuitBuilder::new();
+		let a = builder.add_witness();
+		let b = builder.add_witness();
+		let k = builder.add_constant_64(0x0123_4567_89ab_cdef);
+		let c = builder.band(a, b);
+		let d = builder.bxor(a, k);
+		let (sum, _cout) = builder.iadd(a, b);
+		let e = builder.rotr(b, 7);
+		let f = builder.bor(c, e);
+		builder.force_commit(c);
+		builder.force_commit(d);
+		builder.force_commit(sum);
+		builder.force_commit(f);
+		let circuit = builder.build();
+
+		let layout = circuit.constraint_system().value_vec_layout.clone();
+		assert_eq!(layout.n_inout, 0, "fixture should have no inout wires");
+		let combined = layout.combined_len();
+		let full_len = combined + layout.n_scratch;
+		let n = 8usize;
+
+		// Distinct inputs per instance.
+		let inputs: Vec<(u64, u64)> = (0..n)
+			.map(|i| {
+				let i = i as u64;
+				(i.wrapping_mul(0x9e37_79b9_7f4a_7c15), i ^ 0x0000_0000_dead_beef)
+			})
+			.collect();
+
+		// Single-instance reference: populate each instance on its own.
+		let scalar: Vec<Vec<Word>> = inputs
+			.iter()
+			.map(|&(x, y)| {
+				let mut filler = circuit.new_witness_filler();
+				filler[a] = Word(x);
+				filler[b] = Word(y);
+				circuit.populate_wire_witness(&mut filler).unwrap();
+				filler.value_vec().combined_witness().to_vec()
+			})
+			.collect();
+
+		// Batched: fill the input rows for every instance, then evaluate all at once.
+		let a_row = circuit.witness_index(a).0 as usize;
+		let b_row = circuit.witness_index(b).0 as usize;
+		let mut data = vec![Word::ZERO; full_len * n];
+		let mut view = StridedArray2DViewMut::without_stride(&mut data, full_len, n).unwrap();
+		for (instance, &(x, y)) in inputs.iter().enumerate() {
+			view[(a_row, instance)] = Word(x);
+			view[(b_row, instance)] = Word(y);
+		}
+		circuit.populate_wire_witness_batched(&mut view).unwrap();
+
+		// Every instance's committed prefix must equal the single-instance witness.
+		for instance in 0..n {
+			for row in 0..combined {
+				assert_eq!(
+					view[(row, instance)],
+					scalar[instance][row],
+					"mismatch at row {row}, instance {instance}"
+				);
+			}
+		}
+	}
+
+	// A batched run must flag the lowest-indexed instance whose inputs violate an assertion.
+	#[test]
+	fn batched_reports_lowest_failing_instance() {
+		// Assert a == b; instances where a != b fail.
+		let builder = CircuitBuilder::new();
+		let a = builder.add_witness();
+		let b = builder.add_witness();
+		builder.assert_eq("a_eq_b", a, b);
+		let circuit = builder.build();
+
+		let layout = circuit.constraint_system().value_vec_layout.clone();
+		let full_len = layout.combined_len() + layout.n_scratch;
+		let n = 4usize;
+
+		// Instances 2 and 3 violate a == b; instance 2 is the lowest.
+		let inputs = [(1u64, 1u64), (7, 7), (4, 5), (9, 8)];
+		let a_row = circuit.witness_index(a).0 as usize;
+		let b_row = circuit.witness_index(b).0 as usize;
+		let mut data = vec![Word::ZERO; full_len * n];
+		let mut view = StridedArray2DViewMut::without_stride(&mut data, full_len, n).unwrap();
+		for (instance, &(x, y)) in inputs.iter().enumerate() {
+			view[(a_row, instance)] = Word(x);
+			view[(b_row, instance)] = Word(y);
+		}
+
+		let err = circuit
+			.populate_wire_witness_batched(&mut view)
+			.expect_err("instances 2 and 3 violate a == b");
+		assert_eq!(err.instance, 2);
+		assert_eq!(err.source.total_count, 1);
+		assert_eq!(
+			err.source.messages,
+			vec![".a_eq_b: Word(0x0000000000000004) != Word(0x0000000000000005)".to_string()]
+		);
+	}
+}

--- a/crates/frontend/src/compiler/eval_form/mod.rs
+++ b/crates/frontend/src/compiler/eval_form/mod.rs
@@ -1,16 +1,20 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 //! Circuit representation in the evaluation form.
 //!
 //! The main purpose of the evaluation form is to evaluate and assign the intermediate witness
 //! values. Those are also referred as internal wires.
 
+mod batch_interpreter;
 mod builder;
 mod const_eval;
 mod interpreter;
 #[cfg(test)]
 mod tests;
 
-use binius_core::{ValueIndex, ValueVec};
+pub use batch_interpreter::{BatchInterpreter, BatchPopulateError};
+use binius_core::{ValueIndex, ValueVec, Word};
+use binius_utils::strided_array::StridedArray2DViewMut;
 pub use builder::BytecodeBuilder;
 pub use const_eval::evaluate_gate_constants;
 use cranelift_entity::SecondaryMap;
@@ -84,6 +88,20 @@ impl EvalForm {
 		let mut interpreter = interpreter::Interpreter::new(&self.bytecode, &self.hint_registry);
 		interpreter.run_with_value_vec(value_vec, path_spec_tree)?;
 		Ok(())
+	}
+
+	/// Execute the evaluation form over a batch of instances at once.
+	///
+	/// `values` is the transposed value array: rows are value-vector indices and columns are
+	/// instances. The constant and input rows must already be populated for every instance. This
+	/// is the structure-of-arrays counterpart to [`Self::evaluate`].
+	pub fn evaluate_batched(
+		&self,
+		values: &mut StridedArray2DViewMut<'_, Word>,
+		path_spec_tree: Option<&PathSpecTree>,
+	) -> Result<(), BatchPopulateError> {
+		let mut interpreter = BatchInterpreter::new(&self.bytecode, &self.hint_registry);
+		interpreter.run(values, path_spec_tree)
 	}
 
 	/// Get the number of evaluation instructions

--- a/crates/frontend/src/compiler/gate_fusion/mod.rs
+++ b/crates/frontend/src/compiler/gate_fusion/mod.rs
@@ -1,4 +1,5 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 //! Gate fusion optimization.
 //!
 //! The main cost of our system is coming from the number of AND constraints. The less we have the
@@ -36,7 +37,15 @@ pub fn run_pass(cb: &mut ConstraintBuilder, pinned_wires: &EntitySet<Wire>, all_
 
 	let mut leg = LeGraph::new(cb, &mut stat);
 	commit_set::run_decide_commit_set(&mut leg, &mut stat);
-	leg.lin_committed.extend(pinned_wires.iter());
+	// Pin force-committed wires that are linear definitions so their values survive as committed
+	// AND constraints. Pinned wires that are not linear definitions (e.g. AND or MUL outputs) are
+	// already committed by their own constraints, so they must be excluded here: `patch::build`
+	// treats every wire in the commit set as a linear definition and would otherwise panic.
+	let pinned_lin_defs = pinned_wires
+		.iter()
+		.filter(|&wire| leg.is_lin_def(wire))
+		.collect::<Vec<_>>();
+	leg.lin_committed.extend(pinned_lin_defs);
 	let patches = patch::build(cb, &leg, all_one);
 	patch::apply_patches(cb, patches);
 }

--- a/crates/frontend/src/compiler/gate_fusion/tests/awhole.rs
+++ b/crates/frontend/src/compiler/gate_fusion/tests/awhole.rs
@@ -1,7 +1,29 @@
 // Copyright 2025 Irreducible Inc.
-use binius_core::ConstraintSystem;
+// Copyright 2026 The Binius Developers
+use binius_core::{ConstraintSystem, verify::verify_constraints, word::Word};
 
 use crate::compiler::{CircuitBuilder, Options, gate_fusion::commit_set::MAX_DEPTH};
+
+#[test]
+fn test_force_commit_non_linear_output_without_inout() {
+	// Regression: force-committing a non-linear (AND) output when the circuit has no inout wires
+	// must not panic in gate fusion. A committed AND output is not a linear definition, so it must
+	// stay out of the linear-commit set. This is the M4 accelerator pattern: witness inputs, no
+	// inout, output pinned with `force_commit` so dead-code elimination keeps the constraint.
+	let builder = CircuitBuilder::new();
+	let x = builder.add_witness();
+	let y = builder.add_witness();
+	let and_out = builder.band(x, y);
+	builder.force_commit(and_out);
+	let circuit = builder.build();
+
+	let mut w = circuit.new_witness_filler();
+	w[x] = Word(0xF0F0_F0F0_F0F0_F0F0);
+	w[y] = Word(0xFF00_FF00_FF00_FF00);
+	circuit.populate_wire_witness(&mut w).unwrap();
+	assert_eq!(w[and_out], Word(0xF0F0_F0F0_F0F0_F0F0 & 0xFF00_FF00_FF00_FF00));
+	verify_constraints(circuit.constraint_system(), &w.value_vec).unwrap();
+}
 
 /// Returns a string that represents the given constraint system in a textual form.
 fn stringify_constraint_system(cs: &ConstraintSystem) -> String {

--- a/crates/frontend/src/lib.rs
+++ b/crates/frontend/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 //! Circuit construction frontend for Binius64.
 //!
@@ -34,6 +35,7 @@ pub mod util;
 pub use compiler::{
 	CircuitBuilder, Wire,
 	circuit::{Circuit, PopulateError, WitnessFiller},
+	eval_form::BatchPopulateError,
 	hints::{self, Hint},
 };
 pub use stat::CircuitStat;

--- a/crates/m4-prover/Cargo.toml
+++ b/crates/m4-prover/Cargo.toml
@@ -24,11 +24,17 @@ binius-verifier = { path = "../verifier" }
 
 [dev-dependencies]
 assert_matches = { workspace = true }
+binius-circuits = { path = "../circuits" }
 binius-iop = { path = "../iop" }
 binius-math = { path = "../math", features = ["test-utils"] }
+criterion = { workspace = true }
 proptest = { workspace = true }
 rand = { workspace = true }
 
 [features]
 default = []
 rayon = ["binius-utils/rayon"]
+
+[[bench]]
+name = "keccak_witness_gen"
+harness = false

--- a/crates/m4-prover/benches/keccak_witness_gen.rs
+++ b/crates/m4-prover/benches/keccak_witness_gen.rs
@@ -1,0 +1,81 @@
+// Copyright 2026 The Binius Developers
+//! Witness-generation benchmark comparing [`ValueTable`] and [`ValueTable2`].
+//!
+//! The circuit applies one Keccak-f1600 permutation to a 25-word state. The state words are
+//! witness inputs and the permuted output words are force-committed, so the circuit has no inout
+//! wires and is accepted by both tables. Witness generation is timed for 8192 instances.
+
+use std::array;
+
+use binius_circuits::keccak::permutation::Permutation;
+use binius_core::word::Word;
+use binius_frontend::{Circuit, CircuitBuilder, Wire};
+use binius_m4_prover::{ValueTable, ValueTable2};
+use criterion::{Criterion, criterion_group, criterion_main};
+
+/// The base-2 logarithm of the instance count: 2^13 = 8192 instances.
+const LOG_INSTANCES: usize = 13;
+
+/// The number of 64-bit lanes in a Keccak-f1600 state.
+const STATE_LANES: usize = 25;
+
+/// Builds a circuit that applies one Keccak-f1600 permutation to a witness-input state and
+/// force-commits the permuted output words. Returns the circuit and the 25 input state wires.
+fn build_keccak_circuit() -> (Circuit, [Wire; STATE_LANES]) {
+	let builder = CircuitBuilder::new();
+	let input: [Wire; STATE_LANES] = array::from_fn(|_| builder.add_witness());
+
+	// Permute a copy of the input wires in place; `state` then holds the output wires.
+	let mut state = input;
+	Permutation::keccak_f1600(&builder, &mut state);
+
+	// Pin the outputs so dead-code elimination keeps the whole permutation.
+	for wire in state {
+		builder.force_commit(wire);
+	}
+
+	(builder.build(), input)
+}
+
+/// A deterministic, instance- and lane-dependent input word. Keccak's timing is data-independent,
+/// so the exact values only need to be non-degenerate.
+const fn input_word(instance: usize, lane: usize) -> Word {
+	let mixed = (instance as u64).wrapping_mul(0x9e37_79b9_7f4a_7c15)
+		^ (lane as u64).wrapping_mul(0x0100_0000_01b3);
+	Word(mixed)
+}
+
+fn bench_keccak_witness_gen(c: &mut Criterion) {
+	let (circuit, input) = build_keccak_circuit();
+
+	let mut group = c.benchmark_group("keccak_f1600_witness_gen_8k");
+	// Each iteration generates the witness for 8192 instances, so keep the sample count modest.
+	group.sample_size(10);
+
+	group.bench_function("value_table", |b| {
+		b.iter(|| {
+			ValueTable::populate(&circuit, LOG_INSTANCES, |instance, w| {
+				for lane in 0..STATE_LANES {
+					w[input[lane]] = input_word(instance, lane);
+				}
+			})
+			.unwrap()
+		});
+	});
+
+	group.bench_function("value_table2", |b| {
+		b.iter(|| {
+			ValueTable2::populate(&circuit, LOG_INSTANCES, |instance, w| {
+				for lane in 0..STATE_LANES {
+					w[input[lane]] = input_word(instance, lane);
+				}
+			})
+			.unwrap()
+		});
+	});
+
+	group.finish();
+}
+
+criterion_group!(benches, bench_keccak_witness_gen);
+criterion_main!(benches);

--- a/crates/m4-prover/src/lib.rs
+++ b/crates/m4-prover/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 //! Witness table and prover for the data-parallel Binius64 M4 proof system.
 
@@ -6,7 +7,9 @@ mod bitand;
 mod prove;
 mod shift;
 mod value_table;
+mod value_table2;
 
 pub use bitand::BatchAndCheckWitness;
 pub use prove::Prover;
 pub use value_table::{PopulateInstanceError, ValueTable};
+pub use value_table2::{Batch2WitnessFiller, ValueTable2};

--- a/crates/m4-prover/src/value_table2.rs
+++ b/crates/m4-prover/src/value_table2.rs
@@ -1,0 +1,385 @@
+// Copyright 2026 The Binius Developers
+
+use std::ops::{Index, IndexMut};
+
+use binius_core::{
+	constraint_system::{ValueVec, ValueVecLayout},
+	word::Word,
+};
+use binius_frontend::{BatchPopulateError, Circuit, Wire};
+use binius_utils::strided_array::StridedArray2DViewMut;
+
+/// The witness for a batch of `2^k` independent instances of one circuit, in wire-major order.
+///
+/// This is the transpose of [`ValueTable`](crate::ValueTable). Where `ValueTable` stores each
+/// instance's words back to back (instance-major), `ValueTable2` groups each wire's values across
+/// all instances (wire-major):
+///
+/// ```text
+///                 instance 0   instance 1   ...   instance K-1
+///   wire 0       [   w        |   w        | ... |   w        ]   <- one row
+///   wire 1       [   w        |   w        | ... |   w        ]
+///        ...
+/// ```
+///
+/// Each row is one wire and each column is one instance, so a batched interpreter can advance every
+/// instance of a wire in a single pass. Transposing the value table this way is expected to pay off
+/// throughout the rest of the M4 protocol.
+///
+/// # Differences from `ValueTable`
+///
+/// This table is specialized for the M4 accelerator setting, where a circuit plugs into a larger
+/// system rather than exposing public inputs and outputs:
+///
+/// 1. **No inout wires.** The circuit's [`ValueVecLayout`] must have `n_inout == 0`. Output wires
+///    are kept alive with
+///    [`CircuitBuilder::force_commit`](binius_frontend::CircuitBuilder::force_commit) so that
+///    dead-code elimination does not drop the circuit. Inout wires are inappropriate here, so
+///    [`Self::populate`] rejects them.
+/// 2. **Constants are not stored.** The constants live once on the constraint system as a
+///    `Vec<Word>`, not replicated per instance. Only the hidden segment — the witness and internal
+///    words — is stored here. Witness generation reads the constants from that separate bank.
+///
+/// So the stored data holds exactly the hidden segment of every instance: `n_hidden_words` rows by
+/// `2^log_instances` columns.
+#[derive(Clone, Debug)]
+pub struct ValueTable2 {
+	/// The per-instance value layout, shared by every instance in the batch.
+	layout: ValueVecLayout,
+	/// The base-2 logarithm of the instance count.
+	log_instances: usize,
+	/// The hidden words of every wire, in wire-major order.
+	///
+	/// Row `r` (for `r` in `0..n_hidden_words`) holds the `2^log_instances` values of hidden wire
+	/// `r` — value index `offset_witness + r` — one per instance. The rows are laid out
+	/// contiguously, so the length is `n_hidden_words << log_instances`.
+	data: Vec<Word>,
+}
+
+impl ValueTable2 {
+	/// Builds the batch witness in wire-major order, populating all `2^log_instances` instances.
+	///
+	/// The instances are independent. For each, `fill` sets the witness input wires; the batched
+	/// interpreter then derives every remaining wire, filling all instances of one wire at a time.
+	///
+	/// # Arguments
+	///
+	/// - `circuit`: the single-instance circuit. Its layout must have no inout wires.
+	/// - `log_instances`: base-2 logarithm of the instance count.
+	/// - `fill`: sets the witness input wires of instance `i`, for `i` in `0..2^log_instances`. It
+	///   must assign every witness input on each call.
+	///
+	/// # Panics
+	///
+	/// Panics if the circuit's layout has any inout wires (`n_inout != 0`).
+	///
+	/// # Errors
+	///
+	/// Returns an error naming the lowest-indexed instance whose inputs do not satisfy the circuit.
+	pub fn populate<F>(
+		circuit: &Circuit,
+		log_instances: usize,
+		fill: F,
+	) -> Result<Self, BatchPopulateError>
+	where
+		F: Fn(usize, &mut Batch2WitnessFiller<'_, '_>),
+	{
+		let layout = circuit.constraint_system().value_vec_layout.clone();
+		assert_eq!(
+			layout.n_inout, 0,
+			"ValueTable2 requires a constraint system with no inout wires; \
+			 use force_commit on output wires instead"
+		);
+
+		let n_instances = 1usize << log_instances;
+
+		// The transient working buffer spans the full value vector — constants, inputs, internal
+		// values, and scratch — for every instance, in wire-major order.
+		let full_len = layout.combined_len() + layout.n_scratch;
+		let mut working = vec![Word::ZERO; full_len << log_instances];
+
+		{
+			let mut values =
+				StridedArray2DViewMut::without_stride(&mut working, full_len, n_instances)
+					.expect("full_len * n_instances == working.len() by construction");
+
+			// The caller assigns each instance's witness input wires into that instance's column.
+			for instance in 0..n_instances {
+				let mut filler = Batch2WitnessFiller {
+					circuit,
+					values: &mut values,
+					instance,
+				};
+				fill(instance, &mut filler);
+			}
+
+			// Broadcast the constants and evaluate every instance's remaining wires.
+			circuit.populate_wire_witness_batched(&mut values)?;
+		}
+
+		// Keep only the hidden segment: rows `[offset_witness, combined_len)`. In the wire-major
+		// working buffer these rows are contiguous, so this is a single slice of the words. The
+		// constants and scratch are dropped.
+		let start = layout.offset_witness << log_instances;
+		let end = layout.combined_len() << log_instances;
+		let data = working[start..end].to_vec();
+
+		Ok(Self {
+			layout,
+			log_instances,
+			data,
+		})
+	}
+
+	/// The base-2 logarithm of the number of instances.
+	pub const fn log_instances(&self) -> usize {
+		self.log_instances
+	}
+
+	/// The number of instances in the batch.
+	pub const fn n_instances(&self) -> usize {
+		1usize << self.log_instances
+	}
+
+	/// The per-instance value layout shared by every instance.
+	pub const fn layout(&self) -> &ValueVecLayout {
+		&self.layout
+	}
+
+	/// The number of hidden words per instance: the witness and internal words stored in each row.
+	pub const fn n_hidden_words(&self) -> usize {
+		self.layout.n_hidden_words
+	}
+
+	/// The whole batch as one flat, wire-major word buffer.
+	///
+	/// Row `r` (hidden wire `r`) occupies `data[r << log_instances .. (r + 1) << log_instances]`,
+	/// holding that wire's value in every instance.
+	pub fn as_words(&self) -> &[Word] {
+		&self.data
+	}
+
+	/// Reconstructs one instance as a standalone single-instance value vector.
+	///
+	/// Because the constants are not stored in the table, the caller supplies them (they live on
+	/// the constraint system). The result is bit-for-bit what populating this instance on its own
+	/// would produce, so it can be fed directly to single-instance constraint checking.
+	///
+	/// # Panics
+	///
+	/// Panics if the index is not below the instance count, or if `constants` does not match the
+	/// layout's constant count.
+	pub fn instance_value_vec(&self, instance: usize, constants: &[Word]) -> ValueVec {
+		assert!(instance < self.n_instances(), "instance index out of range");
+		assert_eq!(
+			constants.len(),
+			self.layout.n_const,
+			"constants length must match the layout's constant count"
+		);
+
+		// The public segment holds the constants at the front, then zero padding up to its
+		// power-of-two length. There are no inout wires.
+		let mut public = vec![Word::ZERO; self.layout.offset_witness];
+		public[..constants.len()].copy_from_slice(constants);
+
+		// Gather this instance's column of hidden words across every row.
+		let private = (0..self.n_hidden_words())
+			.map(|row| self.data[(row << self.log_instances) + instance])
+			.collect::<Vec<_>>();
+
+		ValueVec::new_from_data(self.layout.clone(), public, private)
+			.expect("public and private lengths match the layout by construction")
+	}
+}
+
+/// Assigns witness input wires of one instance into a [`ValueTable2`] working buffer.
+///
+/// Indexing by [`Wire`] targets that wire's row in the instance's column, mirroring the
+/// single-instance [`WitnessFiller`](binius_frontend::WitnessFiller).
+pub struct Batch2WitnessFiller<'a, 'v> {
+	circuit: &'a Circuit,
+	values: &'a mut StridedArray2DViewMut<'v, Word>,
+	instance: usize,
+}
+
+impl Index<Wire> for Batch2WitnessFiller<'_, '_> {
+	type Output = Word;
+
+	fn index(&self, wire: Wire) -> &Self::Output {
+		&self.values[(self.circuit.witness_index(wire).0 as usize, self.instance)]
+	}
+}
+
+impl IndexMut<Wire> for Batch2WitnessFiller<'_, '_> {
+	fn index_mut(&mut self, wire: Wire) -> &mut Self::Output {
+		let row = self.circuit.witness_index(wire).0 as usize;
+		&mut self.values[(row, self.instance)]
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use binius_core::verify::verify_constraints;
+	use binius_frontend::{CircuitBuilder, Wire};
+	use proptest::prelude::*;
+
+	use super::*;
+
+	// A circuit that computes several derived words from two witness inputs and a constant, with no
+	// inout wires. Every observable output is force-committed so dead-code elimination keeps it.
+	struct MixCircuit {
+		circuit: Circuit,
+		a: Wire,
+		b: Wire,
+	}
+
+	fn mix_circuit() -> MixCircuit {
+		let builder = CircuitBuilder::new();
+		let a = builder.add_witness();
+		let b = builder.add_witness();
+		let k = builder.add_constant_64(0x0123_4567_89ab_cdef);
+
+		let and = builder.band(a, b);
+		let xor = builder.bxor(a, k);
+		let (sum, _cout) = builder.iadd(a, b);
+		let rot = builder.rotr(b, 7);
+		let or = builder.bor(and, rot);
+
+		builder.force_commit(and);
+		builder.force_commit(xor);
+		builder.force_commit(sum);
+		builder.force_commit(or);
+
+		MixCircuit {
+			circuit: builder.build(),
+			a,
+			b,
+		}
+	}
+
+	// Populate one instance on its own through the ordinary single-instance flow.
+	fn reference_value_vec(c: &MixCircuit, a: u64, b: u64) -> ValueVec {
+		let mut filler = c.circuit.new_witness_filler();
+		filler[c.a] = Word(a);
+		filler[c.b] = Word(b);
+		c.circuit.populate_wire_witness(&mut filler).unwrap();
+		filler.into_value_vec()
+	}
+
+	#[test]
+	fn shape_matches_layout() {
+		let c = mix_circuit();
+		let log_instances = 3;
+		let table = ValueTable2::populate(&c.circuit, log_instances, |i, w| {
+			w[c.a] = Word(i as u64);
+			w[c.b] = Word(i as u64 + 1);
+		})
+		.unwrap();
+
+		let layout = &c.circuit.constraint_system().value_vec_layout;
+		assert_eq!(table.log_instances(), log_instances);
+		assert_eq!(table.n_instances(), 8);
+		assert_eq!(table.n_hidden_words(), layout.n_hidden_words);
+		assert_eq!(table.as_words().len(), layout.n_hidden_words * 8);
+	}
+
+	#[test]
+	fn every_instance_satisfies_the_constraint_system() {
+		let c = mix_circuit();
+		let constants = &c.circuit.constraint_system().constants;
+
+		let table = ValueTable2::populate(&c.circuit, 2, |i, w| {
+			w[c.a] = Word(i as u64 * 0x9e37_79b9);
+			w[c.b] = Word(i as u64 ^ 0xdead);
+		})
+		.unwrap();
+
+		for i in 0..table.n_instances() {
+			let vv = table.instance_value_vec(i, constants);
+			verify_constraints(c.circuit.constraint_system(), &vv)
+				.unwrap_or_else(|e| panic!("instance {i} failed verification: {e}"));
+		}
+	}
+
+	#[test]
+	fn single_instance_batch_matches_reference() {
+		let c = mix_circuit();
+		let constants = &c.circuit.constraint_system().constants;
+
+		let table = ValueTable2::populate(&c.circuit, 0, |_, w| {
+			w[c.a] = Word(0xABCD);
+			w[c.b] = Word(0x0F0F);
+		})
+		.unwrap();
+
+		assert_eq!(table.n_instances(), 1);
+		let reference = reference_value_vec(&c, 0xABCD, 0x0F0F);
+		// The reconstructed instance equals the reference's committed witness, word for word.
+		let reconstructed = table.instance_value_vec(0, constants);
+		assert_eq!(reconstructed.combined_witness(), reference.combined_witness());
+	}
+
+	proptest! {
+		// Invariant: every batch instance equals the single-instance witness for the same inputs.
+		#[test]
+		fn batch_instances_match_single_instance_reference(
+			inputs in prop::collection::vec((any::<u64>(), any::<u64>()), 4),
+		) {
+			let c = mix_circuit();
+			let constants = c.circuit.constraint_system().constants.clone();
+
+			let table = ValueTable2::populate(&c.circuit, 2, |i, w| {
+				let (a, b) = inputs[i];
+				w[c.a] = Word(a);
+				w[c.b] = Word(b);
+			})
+			.unwrap();
+
+			for (i, &(a, b)) in inputs.iter().enumerate() {
+				let reference = reference_value_vec(&c, a, b);
+				let reconstructed = table.instance_value_vec(i, &constants);
+				prop_assert_eq!(reconstructed.combined_witness(), reference.combined_witness());
+			}
+		}
+	}
+
+	#[test]
+	fn unsatisfiable_instance_reports_its_index() {
+		// A circuit that asserts a == b; instances where they differ fail.
+		let builder = CircuitBuilder::new();
+		let a = builder.add_witness();
+		let b = builder.add_witness();
+		builder.assert_eq("a_eq_b", a, b);
+		let circuit = builder.build();
+
+		// Instance 2 violates a == b; the others satisfy it.
+		let result = ValueTable2::populate(&circuit, 2, |i, w| {
+			w[a] = Word(i as u64);
+			w[b] = Word(if i == 2 { 99 } else { i as u64 });
+		});
+
+		let err = result.expect_err("instance 2 violates a == b");
+		assert_eq!(err.instance, 2);
+		assert_eq!(err.source.total_count, 1);
+		assert_eq!(
+			err.source.messages,
+			vec![".a_eq_b: Word(0x0000000000000002) != Word(0x0000000000000063)".to_string()]
+		);
+	}
+
+	#[test]
+	#[should_panic(expected = "no inout wires")]
+	fn rejects_circuits_with_inout_wires() {
+		let builder = CircuitBuilder::new();
+		let a = builder.add_inout();
+		let b = builder.add_witness();
+		let and = builder.band(a, b);
+		builder.force_commit(and);
+		let circuit = builder.build();
+
+		let _ = ValueTable2::populate(&circuit, 1, |_, w| {
+			w[a] = Word(1);
+			w[b] = Word(1);
+		});
+	}
+}


### PR DESCRIPTION
Implements [BINIUS-237](https://linear.app/jimpo/issue/BINIUS-237/valuetable2-for-m4).

`ValueTable2` is an alternative to `ValueTable` that stores the batch witness in the **transposed** order — each wire's values across all instances (wire-major), rather than each instance's words back to back (instance-major). It exists alongside `ValueTable` for now; once both are evaluated we can drop one. Transposing the value table this way is expected to pay off throughout the rest of the M4 protocol.

It is specialized for the M4 accelerator setting, per the issue's two requirements:
1. **No inout wires.** `populate` rejects a constraint system with `n_inout != 0`. Circuits keep their output wires alive with `force_commit` instead.
2. **Constants are not stored in the table.** They stay as a `Vec<Word>` on the `ConstraintSystem`; the batched interpreter reads them from that bank (broadcast into the working buffer) and only the hidden segment (witness + internal words) is stored.

Witness generation is done by a new `BatchInterpreter` — a structure-of-arrays counterpart to `Interpreter` that evaluates the circuit bytecode over every instance at once, treating each "register" as a whole row (a `StridedArray2DViewMut` over the value data, rows = value indices, columns = instances).

### Commits
1. **Fix gate fusion panic on force-committed non-linear outputs.** Gate fusion added *every* force-committed wire to the linear-commit set and then treated each as a linear definition, panicking (`no entry found for key`) when the pinned wire was an AND/MUL output. It now filters pinned wires to linear definitions only — non-linear outputs are already committed by their own constraints. This is a prerequisite: the M4 pattern (witness inputs, no inout, `force_commit`ed outputs) hit this panic on any circuit whose output is an AND. **Flagging for review** since it changes a foundational optimizer path; includes a focused regression test.
2. **Add the batched circuit interpreter.** `BatchInterpreter` + `EvalForm::evaluate_batched` + `Circuit::populate_wire_witness_batched`. Validated by a test asserting the batched result matches the single-instance interpreter for every instance across a spread of opcodes.
3. **Add `ValueTable2`.** The wire-major table + `Batch2WitnessFiller`, with tests verifying each reconstructed instance against `verify_constraints`, batch-vs-single-instance equivalence, failing-instance reporting, and inout rejection.

### Scope
This PR covers the transposed storage and witness generation only. A commitment/packing scheme for the transposed layout (the actual downstream protocol perf win) is deliberately left as follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)