### PR TITLE
Parallelize ValueTable2 witness generation

### DIFF
--- a/crates/frontend/src/compiler/circuit.rs
+++ b/crates/frontend/src/compiler/circuit.rs
@@ -187,6 +187,35 @@ impl Circuit {
 			.evaluate_batched(values, Some(&self.gate_graph.path_spec_tree))
 	}
 
+	/// Populates non-input values for a batch of instances split into vertical stripes.
+	///
+	/// This is the parallel counterpart to [`Self::populate_wire_witness_batched`]. Constants are
+	/// broadcast once over the full value array, then the bytecode interpreter runs independently
+	/// on disjoint instance-column stripes of at most `stripe_width` columns.
+	pub fn populate_wire_witness_batched_parallel(
+		&self,
+		mut values: StridedArray2DViewMut<'_, Word>,
+		stripe_width: usize,
+	) -> Result<(), BatchPopulateError> {
+		assert!(stripe_width > 0, "stripe width must be positive");
+
+		// Broadcast each constant into its row across every instance. The constants are the same
+		// for all instances, so this fills the constant rows uniformly before the stripes split.
+		let n_instances = values.width();
+		for (index, &constant) in self.constraint_system.constants.iter().enumerate() {
+			for instance in 0..n_instances {
+				values[(index, instance)] = constant;
+			}
+		}
+
+		// Evaluate independent instance stripes in parallel, symbolicating assertion failures.
+		self.eval_form.evaluate_batched_parallel(
+			values,
+			stripe_width,
+			Some(&self.gate_graph.path_spec_tree),
+		)
+	}
+
 	/// Returns the constraint system for this circuit.
 	pub const fn constraint_system(&self) -> &ConstraintSystem {
 		&self.constraint_system

--- a/crates/frontend/src/compiler/eval_form/batch_interpreter.rs
+++ b/crates/frontend/src/compiler/eval_form/batch_interpreter.rs
@@ -53,6 +53,8 @@ pub struct BatchPopulateError {
 struct BatchExecutionContext<'a, 'v> {
 	/// Rows are value-vector indices; columns are instances.
 	values: &'a mut StridedArray2DViewMut<'v, Word>,
+	/// The global instance index represented by local column 0.
+	instance_offset: usize,
 	/// Assertion failures recorded during evaluation, capped by [`MAX_ASSERTION_FAILURES`].
 	failures: Vec<InstanceAssertionFailure>,
 	/// The total number of assertion violations recorded, across all instances.
@@ -62,9 +64,10 @@ struct BatchExecutionContext<'a, 'v> {
 }
 
 impl<'a, 'v> BatchExecutionContext<'a, 'v> {
-	const fn new(values: &'a mut StridedArray2DViewMut<'v, Word>) -> Self {
+	const fn new(values: &'a mut StridedArray2DViewMut<'v, Word>, instance_offset: usize) -> Self {
 		Self {
 			values,
+			instance_offset,
 			failures: Vec::new(),
 			total_count: 0,
 			min_failing_instance: None,
@@ -92,6 +95,7 @@ impl<'a, 'v> BatchExecutionContext<'a, 'v> {
 	/// updates the count and the lowest-failing-instance tracker.
 	#[cold]
 	fn note_assertion_failure(&mut self, instance: usize, path_spec: PathSpec, message: String) {
+		let instance = self.instance_offset + instance;
 		self.total_count += 1;
 		self.min_failing_instance = Some(
 			self.min_failing_instance
@@ -169,7 +173,17 @@ impl<'a> BatchInterpreter<'a> {
 		values: &mut StridedArray2DViewMut<'_, Word>,
 		path_spec_tree: Option<&PathSpecTree>,
 	) -> Result<(), BatchPopulateError> {
-		let mut ctx = BatchExecutionContext::new(values);
+		self.run_with_instance_offset(values, 0, path_spec_tree)
+	}
+
+	/// Evaluate the bytecode over a view whose local column 0 corresponds to `instance_offset`.
+	pub(crate) fn run_with_instance_offset(
+		&mut self,
+		values: &mut StridedArray2DViewMut<'_, Word>,
+		instance_offset: usize,
+		path_spec_tree: Option<&PathSpecTree>,
+	) -> Result<(), BatchPopulateError> {
+		let mut ctx = BatchExecutionContext::new(values, instance_offset);
 		while self.pc < self.bytecode.len() {
 			let opcode = self.read_u8();
 			match opcode {

--- a/crates/frontend/src/compiler/eval_form/mod.rs
+++ b/crates/frontend/src/compiler/eval_form/mod.rs
@@ -14,7 +14,7 @@ mod tests;
 
 pub use batch_interpreter::{BatchInterpreter, BatchPopulateError};
 use binius_core::{ValueIndex, ValueVec, Word};
-use binius_utils::strided_array::StridedArray2DViewMut;
+use binius_utils::{rayon::prelude::*, strided_array::StridedArray2DViewMut};
 pub use builder::BytecodeBuilder;
 pub use const_eval::evaluate_gate_constants;
 use cranelift_entity::SecondaryMap;
@@ -102,6 +102,31 @@ impl EvalForm {
 	) -> Result<(), BatchPopulateError> {
 		let mut interpreter = BatchInterpreter::new(&self.bytecode, &self.hint_registry);
 		interpreter.run(values, path_spec_tree)
+	}
+
+	/// Execute the evaluation form over disjoint vertical instance stripes in parallel.
+	pub fn evaluate_batched_parallel(
+		&self,
+		values: StridedArray2DViewMut<'_, Word>,
+		stripe_width: usize,
+		path_spec_tree: Option<&PathSpecTree>,
+	) -> Result<(), BatchPopulateError> {
+		assert!(stripe_width > 0, "stripe width must be positive");
+
+		values
+			.into_par_strides(stripe_width)
+			.enumerate()
+			.map(|(stripe_index, mut stripe)| {
+				let mut interpreter = BatchInterpreter::new(&self.bytecode, &self.hint_registry);
+				interpreter.run_with_instance_offset(
+					&mut stripe,
+					stripe_index * stripe_width,
+					path_spec_tree,
+				)
+			})
+			.collect::<Result<Vec<_>, _>>()?;
+
+		Ok(())
 	}
 
 	/// Get the number of evaluation instructions

--- a/crates/m4-prover/benches/keccak_witness_gen.rs
+++ b/crates/m4-prover/benches/keccak_witness_gen.rs
@@ -19,6 +19,9 @@ const LOG_INSTANCES: usize = 13;
 /// The number of 64-bit lanes in a Keccak-f1600 state.
 const STATE_LANES: usize = 25;
 
+/// Candidate instance-stripe widths for parallel [`ValueTable2`] witness generation.
+const STRIPE_WIDTHS: [usize; 3] = [256, 512, 1024];
+
 /// Builds a circuit that applies one Keccak-f1600 permutation to a witness-input state and
 /// force-commits the permuted output words. Returns the circuit and the 25 input state wires.
 fn build_keccak_circuit() -> (Circuit, [Wire; STATE_LANES]) {
@@ -73,6 +76,24 @@ fn bench_keccak_witness_gen(c: &mut Criterion) {
 			.unwrap()
 		});
 	});
+
+	for stripe_width in STRIPE_WIDTHS {
+		group.bench_function(format!("value_table2_parallel_{stripe_width}"), |b| {
+			b.iter(|| {
+				ValueTable2::populate_parallel_with_stripe_width(
+					&circuit,
+					LOG_INSTANCES,
+					stripe_width,
+					|instance, w| {
+						for lane in 0..STATE_LANES {
+							w[input[lane]] = input_word(instance, lane);
+						}
+					},
+				)
+				.unwrap()
+			});
+		});
+	}
 
 	group.finish();
 }

--- a/crates/m4-prover/src/value_table2.rs
+++ b/crates/m4-prover/src/value_table2.rs
@@ -9,6 +9,9 @@ use binius_core::{
 use binius_frontend::{BatchPopulateError, Circuit, Wire};
 use binius_utils::strided_array::StridedArray2DViewMut;
 
+/// Default number of instance columns evaluated by one parallel witness-generation task.
+const DEFAULT_PARALLEL_STRIPE_WIDTH: usize = 1024;
+
 /// The witness for a batch of `2^k` independent instances of one circuit, in wire-major order.
 ///
 /// This is the transpose of [`ValueTable`](crate::ValueTable). Where `ValueTable` stores each
@@ -84,6 +87,63 @@ impl ValueTable2 {
 	where
 		F: Fn(usize, &mut Batch2WitnessFiller<'_, '_>),
 	{
+		Self::populate_with(circuit, log_instances, None, fill)
+	}
+
+	/// Builds the batch witness in wire-major order, evaluating instance stripes in parallel.
+	///
+	/// This is the parallel counterpart to [`Self::populate`]. Input filling is still performed
+	/// once up front, then circuit evaluation runs over disjoint vertical instance stripes.
+	///
+	/// # Panics
+	///
+	/// Panics if the circuit's layout has any inout wires.
+	pub fn populate_parallel<F>(
+		circuit: &Circuit,
+		log_instances: usize,
+		fill: F,
+	) -> Result<Self, BatchPopulateError>
+	where
+		F: Fn(usize, &mut Batch2WitnessFiller<'_, '_>),
+	{
+		Self::populate_parallel_with_stripe_width(
+			circuit,
+			log_instances,
+			DEFAULT_PARALLEL_STRIPE_WIDTH,
+			fill,
+		)
+	}
+
+	/// Builds the batch witness in parallel using a caller-provided stripe width.
+	///
+	/// This is exposed for benchmarking stripe widths. Production callers should use
+	/// [`Self::populate_parallel`].
+	///
+	/// # Panics
+	///
+	/// Panics if `stripe_width == 0` or if the circuit's layout has any inout wires.
+	pub fn populate_parallel_with_stripe_width<F>(
+		circuit: &Circuit,
+		log_instances: usize,
+		stripe_width: usize,
+		fill: F,
+	) -> Result<Self, BatchPopulateError>
+	where
+		F: Fn(usize, &mut Batch2WitnessFiller<'_, '_>),
+	{
+		assert!(stripe_width > 0, "stripe width must be positive");
+		Self::populate_with(circuit, log_instances, Some(stripe_width), fill)
+	}
+
+	fn populate_with<F>(
+		circuit: &Circuit,
+		log_instances: usize,
+		parallel_stripe_width: Option<usize>,
+		fill: F,
+	) -> Result<Self, BatchPopulateError>
+	where
+		F: Fn(usize, &mut Batch2WitnessFiller<'_, '_>),
+	{
 		let layout = circuit.constraint_system().value_vec_layout.clone();
 		assert_eq!(
 			layout.n_inout, 0,
@@ -113,8 +173,14 @@ impl ValueTable2 {
 				fill(instance, &mut filler);
 			}
 
-			// Broadcast the constants and evaluate every instance's remaining wires.
-			circuit.populate_wire_witness_batched(&mut values)?;
+			if let Some(stripe_width) = parallel_stripe_width {
+				// Broadcast the constants once, then evaluate disjoint instance stripes in
+				// parallel.
+				circuit.populate_wire_witness_batched_parallel(values, stripe_width)?;
+			} else {
+				// Broadcast the constants and evaluate every instance's remaining wires.
+				circuit.populate_wire_witness_batched(&mut values)?;
+			}
 		}
 
 		// Keep only the hidden segment: rows `[offset_witness, combined_len)`. In the wire-major
@@ -344,6 +410,44 @@ mod tests {
 	}
 
 	#[test]
+	fn parallel_population_matches_serial_for_varied_stripe_widths() {
+		let c = mix_circuit();
+		let log_instances = 3;
+
+		let serial = ValueTable2::populate(&c.circuit, log_instances, |i, w| {
+			w[c.a] = Word((i as u64).wrapping_mul(0x9e37_79b9));
+			w[c.b] = Word((i as u64).rotate_left(17) ^ 0xdead_beef);
+		})
+		.unwrap();
+
+		let default_parallel = ValueTable2::populate_parallel(&c.circuit, log_instances, |i, w| {
+			w[c.a] = Word((i as u64).wrapping_mul(0x9e37_79b9));
+			w[c.b] = Word((i as u64).rotate_left(17) ^ 0xdead_beef);
+		})
+		.unwrap();
+		assert_eq!(default_parallel.as_words(), serial.as_words());
+
+		for stripe_width in [1, 2, 3, 8, 64] {
+			let parallel = ValueTable2::populate_parallel_with_stripe_width(
+				&c.circuit,
+				log_instances,
+				stripe_width,
+				|i, w| {
+					w[c.a] = Word((i as u64).wrapping_mul(0x9e37_79b9));
+					w[c.b] = Word((i as u64).rotate_left(17) ^ 0xdead_beef);
+				},
+			)
+			.unwrap();
+
+			assert_eq!(
+				parallel.as_words(),
+				serial.as_words(),
+				"stripe width {stripe_width} changed the populated table"
+			);
+		}
+	}
+
+	#[test]
 	fn unsatisfiable_instance_reports_its_index() {
 		// A circuit that asserts a == b; instances where they differ fail.
 		let builder = CircuitBuilder::new();
@@ -365,6 +469,56 @@ mod tests {
 			err.source.messages,
 			vec![".a_eq_b: Word(0x0000000000000002) != Word(0x0000000000000063)".to_string()]
 		);
+	}
+
+	#[test]
+	fn parallel_unsatisfiable_instance_reports_global_index_across_stripes() {
+		// A circuit that asserts a == b; instances where they differ fail.
+		let builder = CircuitBuilder::new();
+		let a = builder.add_witness();
+		let b = builder.add_witness();
+		builder.assert_eq("a_eq_b", a, b);
+		let circuit = builder.build();
+
+		// Instance 5 is in the third two-column stripe. Reporting a local stripe index would
+		// incorrectly return 1 instead of the global instance index 5.
+		let result = ValueTable2::populate_parallel_with_stripe_width(&circuit, 3, 2, |i, w| {
+			w[a] = Word(i as u64);
+			w[b] = Word(if i == 5 { 99 } else { i as u64 });
+		});
+
+		let err = result.expect_err("instance 5 violates a == b");
+		assert_eq!(err.instance, 5);
+		assert_eq!(err.source.total_count, 1);
+		assert_eq!(
+			err.source.messages,
+			vec![".a_eq_b: Word(0x0000000000000005) != Word(0x0000000000000063)".to_string()]
+		);
+	}
+
+	#[test]
+	fn parallel_failure_diagnostics_match_serial_for_failures_in_different_stripes() {
+		// A circuit that asserts a == b; instances where they differ fail.
+		let builder = CircuitBuilder::new();
+		let a = builder.add_witness();
+		let b = builder.add_witness();
+		builder.assert_eq("a_eq_b", a, b);
+		let circuit = builder.build();
+
+		// Instances 5 and 7 fail in different two-column stripes. The batched interpreter reports
+		// the lowest failing instance's diagnostics, so the parallel path should match the serial
+		// path exactly rather than aggregating failures from unrelated later instances.
+		let fill = |i: usize, w: &mut Batch2WitnessFiller<'_, '_>| {
+			w[a] = Word(i as u64);
+			w[b] = Word(if i == 5 || i == 7 { 99 } else { i as u64 });
+		};
+		let serial = ValueTable2::populate(&circuit, 3, fill).expect_err("instances fail");
+		let parallel = ValueTable2::populate_parallel_with_stripe_width(&circuit, 3, 2, fill)
+			.expect_err("instances fail");
+
+		assert_eq!(parallel.instance, serial.instance);
+		assert_eq!(parallel.source.total_count, serial.source.total_count);
+		assert_eq!(parallel.source.messages, serial.source.messages);
 	}
 
 	#[test]

--- a/crates/utils/src/strided_array.rs
+++ b/crates/utils/src/strided_array.rs
@@ -108,7 +108,7 @@ impl<'a, T> StridedArray2DViewMut<'a, T> {
 	}
 
 	/// Returns parallel iterator over vertical slices of the data for the given stride.
-	pub fn into_par_strides(self, stride: usize) -> impl ParallelIterator<Item = Self> + 'a
+	pub fn into_par_strides(self, stride: usize) -> impl IndexedParallelIterator<Item = Self> + 'a
 	where
 		T: Send + Sync,
 	{


### PR DESCRIPTION
## Summary
Follow-up to the ValueTable2 direction from #1716 and #1739: this implements the stripe-parallel witness-generation path Jimpo sketched for the wire-major M4 witness table.

Adds a stripe-based parallel path for batched witness evaluation over `ValueTable2`'s wire-major table.

`ValueTable2::populate_parallel` fills inputs once, broadcasts constants once, then evaluates disjoint vertical instance stripes concurrently using the measured 1024-column default. The benchmark-only `populate_parallel_with_stripe_width` exposes the stripe width for the sweep below. Each stripe runs the existing batch interpreter over its own `StridedArray2DViewMut` columns via `into_par_strides`; `Circuit::populate_wire_witness_batched_parallel` provides the lower-level frontend hook.

This introduces no new `unsafe`; it reuses the existing strided-array splitter. Output is identical to serial `ValueTable2::populate`, and assertion diagnostics preserve serial behavior: the lowest-indexed failing instance and its messages are reported, even when failures land in different stripes.

`ValueTable2` is the wire-major table intended to underpin the M4 prover migration, but today's full M4 prover still consumes `ValueTable`. So this PR lands the parallel witness-generation capability ahead of that migration rather than claiming an end-to-end prover speedup.

## Benchmark
Apple M4 Pro, `RAYON_NUM_THREADS=8`, `--features rayon`, 8192 Keccak-f1600 instances:

| path | time | vs current `ValueTable` |
|---|---:|---:|
| `ValueTable` (current, already rayon-parallel) | 15.9523 ms | baseline |
| `ValueTable2` serial | 22.4140 ms | +40.5% |
| `ValueTable2` parallel, stripe 256 | 7.3865 ms | -53.7% |
| `ValueTable2` parallel, stripe 512 | 6.6785 ms | -58.1% |
| `ValueTable2` parallel, stripe 1024 | **6.2891 ms** | **-60.6%** |

Headline: **-60.6% vs the current already-parallel `ValueTable` witness-generation path**. The serial `ValueTable2` row is included as context only.

The stripe-width sweep answers the sizing question directly: on this M4 Pro run, 1024 was fastest, with no diminishing returns yet across 256 -> 512 -> 1024. The likely explanation is that reduced rayon/task overhead outweighed any L1-locality pressure at these widths.

## Test plan
- `cargo +nightly-2026-01-01 fmt --check`
- `cargo test -p binius-m4-prover --lib` (33/33)
- `cargo test -p binius-m4-prover --features rayon --lib` (33/33)
- `cargo test -p binius-frontend --lib` (161/161)
- `cargo test -p binius-utils --lib` (30/30)
- `cargo test -p binius-utils --features rayon --lib` (18/18)
- `cargo clippy -p binius-utils -p binius-frontend -p binius-m4-prover --all-features --tests --benches -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p binius-m4-prover --features rayon --document-private-items --no-deps`
- `cargo bench -p binius-m4-prover --features rayon --bench keccak_witness_gen -- --noplot`
