### PR TITLE
BINIUS-250: sliced multiplication for the degree-2 Monbijou extension

### DIFF
--- a/crates/arith-bench/benches/field_mul.rs
+++ b/crates/arith-bench/benches/field_mul.rs
@@ -563,16 +563,18 @@ fn bench_monbijou(c: &mut Criterion) {
 	group.finish();
 }
 
-/// Benchmark GF(2^128) Monbijou 128-bit extension field multiplication using CLMUL instructions
+/// Benchmark GF(2^128) Monbijou 128-bit extension field multiplication using CLMUL instructions,
+/// comparing the packed representation (`mul_128b_clmul`) against the sliced representation
+/// (`mul_sliced_128b_clmul`).
 #[allow(unused_imports, unused_variables, unused_mut)]
 fn bench_monbijou_128b(c: &mut Criterion) {
-	use binius_arith_bench::monbijou::mul_128b_clmul;
+	use binius_arith_bench::monbijou::{mul_128b_clmul, mul_sliced_128b_clmul};
 
 	let mut rng = rand::rng();
 
 	let mut group = c.benchmark_group("monbijou_128b");
 
-	// Benchmark __m128i
+	// Packed __m128i
 	#[cfg(all(target_feature = "pclmulqdq", target_feature = "sse2"))]
 	{
 		run_mul_benchmark(
@@ -584,7 +586,7 @@ fn bench_monbijou_128b(c: &mut Criterion) {
 		);
 	}
 
-	// Benchmark __m256i
+	// Packed __m256i
 	#[cfg(all(
 		target_feature = "vpclmulqdq",
 		target_feature = "avx2",
@@ -600,7 +602,7 @@ fn bench_monbijou_128b(c: &mut Criterion) {
 		);
 	}
 
-	// Benchmark uint64x2_t (AARCH64 NEON)
+	// Packed uint64x2_t (AARCH64 NEON)
 	#[cfg(all(
 		target_arch = "aarch64",
 		target_feature = "neon",
@@ -611,6 +613,50 @@ fn bench_monbijou_128b(c: &mut Criterion) {
 			&mut group,
 			"mul_128b_clmul::uint64x2_t",
 			mul_128b_clmul::<uint64x2_t>,
+			&mut rng,
+			128,
+		);
+	}
+
+	// Sliced __m128i (a `[__m128i; 2]` holds two GF(2^128) elements)
+	#[cfg(all(target_feature = "pclmulqdq", target_feature = "sse2"))]
+	{
+		run_mul_benchmark(
+			&mut group,
+			"mul_sliced_128b_clmul::<__m128i>",
+			mul_sliced_128b_clmul::<__m128i>,
+			&mut rng,
+			128,
+		);
+	}
+
+	// Sliced __m256i (a `[__m256i; 2]` holds four GF(2^128) elements)
+	#[cfg(all(
+		target_feature = "vpclmulqdq",
+		target_feature = "avx2",
+		target_feature = "sse2"
+	))]
+	{
+		run_mul_benchmark(
+			&mut group,
+			"mul_sliced_128b_clmul::<__m256i>",
+			mul_sliced_128b_clmul::<__m256i>,
+			&mut rng,
+			128,
+		);
+	}
+
+	// Sliced uint64x2_t (AARCH64 NEON)
+	#[cfg(all(
+		target_arch = "aarch64",
+		target_feature = "neon",
+		target_feature = "aes"
+	))]
+	{
+		run_mul_benchmark(
+			&mut group,
+			"mul_sliced_128b_clmul::uint64x2_t",
+			mul_sliced_128b_clmul::<uint64x2_t>,
 			&mut rng,
 			128,
 		);

--- a/crates/arith-bench/src/monbijou.rs
+++ b/crates/arith-bench/src/monbijou.rs
@@ -1,4 +1,5 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 //! Arithmetic for the Monbijou field, GF(2)\[X\] / (X^64 + X^4 + X^3 + X + 1).
 //!
 //! This module implements arithmetic in the GF(2^64) binary field defined by the
@@ -69,6 +70,71 @@ pub fn mul_128b_clmul<U: Underlier + OpsClmul + PackedUnderlier<u64>>(x: U, y: U
 	reduce_pair(term0, term1)
 }
 
+/// Multiplies two elements of GF(2^128), the degree-2 extension of the Monbijou field, in
+/// *sliced* representation.
+///
+/// Each element is given as `[U; 2]`: index 0 holds coefficient 0 and index 1 holds
+/// coefficient 1, where each coefficient is an element (or SIMD pack of elements) of the base
+/// field GF(2^64). This transposed layout keeps the two coefficients in separate registers, so
+/// the multiplication is built from base-field carry-less multiplications and processes every
+/// packed lane in parallel. It computes the same field product as [`mul_128b_clmul`], which
+/// instead packs the two coefficients into the low and high halves of a single value.
+///
+/// The extension is GF(2)\[X, Y\] / (X^64 + X^4 + X^3 + X + 1) / (Y^2 + XY + 1), so `Y^2 = XY + 1`
+/// and, writing `a = a0 + a1·Y` and `b = b0 + b1·Y`,
+///
+/// ```text
+/// coeff 0 = a0·b0 + a1·b1
+/// coeff 1 = a0·b1 + a1·b0 + X·(a1·b1)
+/// ```
+///
+/// The base-field products are kept unreduced and combined into the two output coefficients, so
+/// only a single `reduce_pair` is spent per coefficient (one reduction per element), matching
+/// [`mul_128b_clmul`]. The cross term `a0·b1 + a1·b0` is recovered from Karatsuba as `t1 + t0 +
+/// t2`.
+#[inline]
+pub fn mul_sliced_128b_clmul<U: Underlier + OpsClmul + PackedUnderlier<u64>>(
+	x: [U; 2],
+	y: [U; 2],
+) -> [U; 2] {
+	// The low-degree terms of the base-field reduction polynomial (X^4 + X^3 + X + 1), used to
+	// multiply by X.
+	const POLY: u64 = 0x1B;
+	let poly = <U as PackedUnderlier<u64>>::broadcast(POLY);
+
+	let [x0, x1] = x;
+	let [y0, y1] = y;
+	// Karatsuba middle inputs: (a0 + a1) and (b0 + b1).
+	let xm = U::xor(x0, x1);
+	let ym = U::xor(y0, y1);
+
+	// Unreduced base-field products, one 128-bit product per lane (the `0x00`/`0x11` immediates
+	// select the low/high halves of each 128-bit lane, as in `mul_clmul`).
+	// t0 = a0·b0, t2 = a1·b1, t1 = (a0 + a1)·(b0 + b1).
+	let t0_lo = U::clmulepi64::<0x00>(x0, y0);
+	let t0_hi = U::clmulepi64::<0x11>(x0, y0);
+	let t2_lo = U::clmulepi64::<0x00>(x1, y1);
+	let t2_hi = U::clmulepi64::<0x11>(x1, y1);
+	let t1_lo = U::clmulepi64::<0x00>(xm, ym);
+	let t1_hi = U::clmulepi64::<0x11>(xm, ym);
+
+	// X·(a1·b1) on the unreduced product, per lane: shift left by one and fold the overflow bit
+	// (bit 63) back in with the reduction polynomial.
+	let t2x_lo = U::xor(U::slli_epi64::<1>(t2_lo), U::and(poly, U::movepi64_mask(t2_lo)));
+	let t2x_hi = U::xor(U::slli_epi64::<1>(t2_hi), U::and(poly, U::movepi64_mask(t2_hi)));
+
+	// Assemble the two output coefficients while still unreduced, then reduce each once.
+	let term0_lo = U::xor(t0_lo, t2_lo);
+	let term0_hi = U::xor(t0_hi, t2_hi);
+	let term1_lo = U::xor(U::xor(U::xor(t1_lo, t0_lo), t2_lo), t2x_lo);
+	let term1_hi = U::xor(U::xor(U::xor(t1_hi, t0_hi), t2_hi), t2x_hi);
+
+	let z0 = reduce_pair(term0_lo, term0_hi);
+	let z1 = reduce_pair(term1_lo, term1_hi);
+
+	[z0, z1]
+}
+
 #[inline]
 fn reduce_pair<U: Underlier + OpsClmul + PackedUnderlier<u64>>(prod_0: U, prod_1: U) -> U {
 	// The reduction polynomial X^64 + X^4 + X^3 + X + 1 is represented as 0x1B
@@ -96,4 +162,71 @@ fn reduce_pair<U: Underlier + OpsClmul + PackedUnderlier<u64>>(prod_0: U, prod_1
 
 	// Final result: XOR all three components together
 	U::xor(result, second_reduction_lo)
+}
+
+#[cfg(test)]
+#[cfg(all(
+	target_arch = "x86_64",
+	target_feature = "pclmulqdq",
+	target_feature = "sse2"
+))]
+mod tests {
+	use std::arch::x86_64::__m128i;
+
+	use proptest::prelude::*;
+
+	use super::{mul_128b_clmul, mul_sliced_128b_clmul};
+
+	// A packed GF(2^128) element is a `u128` with coefficient 0 in the low 64 bits and coefficient
+	// 1 in the high 64 bits, matching `__m128i`'s lane layout.
+	//
+	// Packs two packed elements into sliced form across the two `__m128i` lanes:
+	//   x[0] = [e0 coeff 0, e1 coeff 0], x[1] = [e0 coeff 1, e1 coeff 1].
+	fn to_sliced(e0: u128, e1: u128) -> [__m128i; 2] {
+		let coeff0 = (e0 as u64 as u128) | ((e1 as u64 as u128) << 64);
+		let coeff1 = ((e0 >> 64) as u64 as u128) | (((e1 >> 64) as u64 as u128) << 64);
+		unsafe {
+			[
+				std::mem::transmute::<u128, __m128i>(coeff0),
+				std::mem::transmute::<u128, __m128i>(coeff1),
+			]
+		}
+	}
+
+	// Recovers the two packed elements from sliced form.
+	fn from_sliced(z: [__m128i; 2]) -> (u128, u128) {
+		let coeff0 = unsafe { std::mem::transmute::<__m128i, u128>(z[0]) };
+		let coeff1 = unsafe { std::mem::transmute::<__m128i, u128>(z[1]) };
+		let e0 = (coeff0 as u64 as u128) | ((coeff1 as u64 as u128) << 64);
+		let e1 = ((coeff0 >> 64) as u64 as u128) | (((coeff1 >> 64) as u64 as u128) << 64);
+		(e0, e1)
+	}
+
+	fn packed_mul(a: u128, b: u128) -> u128 {
+		unsafe {
+			std::mem::transmute::<__m128i, u128>(mul_128b_clmul::<__m128i>(
+				std::mem::transmute::<u128, __m128i>(a),
+				std::mem::transmute::<u128, __m128i>(b),
+			))
+		}
+	}
+
+	proptest! {
+		// The sliced multiplication computes the same field product as the packed one, for both
+		// lanes packed into the `__m128i`.
+		#[test]
+		fn sliced_matches_packed_128b(
+			a0 in any::<u128>(),
+			a1 in any::<u128>(),
+			b0 in any::<u128>(),
+			b1 in any::<u128>(),
+		) {
+			// Lane 0 multiplies a0 by b0; lane 1 multiplies a1 by b1.
+			let z = mul_sliced_128b_clmul::<__m128i>(to_sliced(a0, a1), to_sliced(b0, b1));
+			let (z0, z1) = from_sliced(z);
+
+			prop_assert_eq!(z0, packed_mul(a0, b0));
+			prop_assert_eq!(z1, packed_mul(a1, b1));
+		}
+	}
 }


### PR DESCRIPTION
Implements [BINIUS-250](https://linear.app/jimpo/issue/BINIUS-250/arith-bench-slice-multiplication-algorithm-for-degree-2-monbijou) (experiment).

Adds `mul_sliced_128b_clmul` in `crates/arith-bench/src/monbijou.rs` — a degree-2 Monbijou extension multiply in **sliced** representation, alongside the existing packed `mul_128b_clmul`. Each element is `[U; 2]` with coeff 0 at index 0 and coeff 1 at index 1 (each `U` a SIMD pack of base-field GF(2^64) elements), so the two coefficients live in separate registers and the multiply is built from base-field muls, processing every lane in parallel.

For `Y² = XY + 1`, writing `a = a0 + a1·Y`, `b = b0 + b1·Y`:
```
coeff 0 = a0·b0 + a1·b1
coeff 1 = a0·b1 + a1·b0 + X·(a1·b1)
```
using Karatsuba for the cross term (3 base-field muls) and the same shift+`0x1B` trick for the multiply-by-X.

**Correctness:** a proptest verifies it produces the same field product as the trusted packed `mul_128b_clmul` for both `__m128i` lanes.

**Benchmark (`monbijou_128b` group)** added packed-vs-sliced entries for `__m128i`/`__m256i`/`uint64x2_t`.

Marking **draft** since this is an experiment with no fixed acceptance criterion — the numbers and the question of whether to pursue it are below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)