### PR TITLE
BINIUS-258: wide_mul (deferred-reduction) variants for the GHASH modules

### DIFF
--- a/crates/arith-bench/benches/field_mul.rs
+++ b/crates/arith-bench/benches/field_mul.rs
@@ -11,7 +11,6 @@ use std::{array, hint::black_box};
 
 use binius_arith_bench::{Underlier, ghash, ghash_sq, polyval};
 use criterion::{BenchmarkGroup, Criterion, Throughput, criterion_group, criterion_main};
-use proptest::num::u128;
 use rand::{
 	Rng,
 	distr::{Distribution, StandardUniform},
@@ -139,6 +138,45 @@ fn run_unary_op_benchmark<T, R>(
 					batch[i] = op_fn(batch[i]);
 				}
 			}
+		})
+	});
+}
+
+/// Benchmark helper for an inner product of two fixed-size buffers.
+///
+/// This is the setting where a widening multiply pays off: the per-term products are
+/// XOR-accumulated in their unreduced form and the single final reduction is skipped entirely (an
+/// inner product needs only one reduction at the very end, negligible against the `2^log_len`
+/// terms). The gap between a `wide_mul` variant and the corresponding reduce-every-term `mul`
+/// isolates the cost of the amortized reduction.
+///
+/// `T` is the underlier of the operands (`u128` for the software path, a SIMD type for the packed
+/// paths) and `W` the unreduced product accumulator — either a field element (reduce-every-term) or
+/// a multi-limb product like `[u64; 4]` / `[__m128i; 3]`, all [`Underlier`]s (arrays via the
+/// blanket impl), so accumulation is `W::xor`. Each GHASH element is 128 bits, so a `T`-wide
+/// underlier carries `T::BITS / 128` inner-product terms.
+fn run_inner_product_benchmark<T, W, R>(
+	group: &mut BenchmarkGroup<'_, criterion::measurement::WallTime>,
+	name: &str,
+	wide_mul: impl Fn(T, T) -> W,
+	mut rng: R,
+	log_len: usize,
+) where
+	T: Underlier,
+	W: Underlier,
+	R: Rng,
+{
+	let len = 1usize << log_len;
+	let a: Vec<T> = (0..len).map(|_| T::random(&mut rng)).collect();
+	let b: Vec<T> = (0..len).map(|_| T::random(&mut rng)).collect();
+
+	let elements_per_underlier = T::BITS / 128;
+	group.throughput(Throughput::Elements((len * elements_per_underlier) as u64));
+	group.bench_function(name, |bencher| {
+		bencher.iter(|| {
+			black_box(std::iter::zip(&a, &b).fold(W::ZERO, |acc, (&ai, &bi)| {
+				W::xor(acc, wide_mul(black_box(ai), black_box(bi)))
+			}))
 		})
 	});
 }
@@ -790,6 +828,33 @@ fn bench_ghash_sq(c: &mut Criterion) {
 	group.finish();
 }
 
+/// Benchmark inner products over the GHASH field, contrasting the widening multiply (accumulate
+/// unreduced, reduce once) against the reduce-every-term multiply.
+#[allow(unused_imports, unused_variables, unused_mut)]
+fn bench_ghash_inner_product(c: &mut Criterion) {
+	/// Length of the inner product. Long enough that the single skipped final reduction is
+	/// negligible.
+	const LOG_LEN: usize = 10;
+
+	let mut rng = rand::rng();
+
+	let mut group = c.benchmark_group("ghash_inner_product");
+
+	// Baseline: reduce each product, accumulate the reduced GHASH elements.
+	run_inner_product_benchmark(&mut group, "soft64::mul", ghash::soft64::mul, &mut rng, LOG_LEN);
+
+	// Widening: accumulate the unreduced four-limb products by XOR, skip the final reduction.
+	run_inner_product_benchmark(
+		&mut group,
+		"soft64::mul_wide",
+		ghash::soft64::mul_wide,
+		&mut rng,
+		LOG_LEN,
+	);
+
+	group.finish();
+}
+
 criterion_group!(
 	benches,
 	bench_rijndael,
@@ -798,5 +863,6 @@ criterion_group!(
 	bench_ghash_sq,
 	bench_monbijou,
 	bench_monbijou_128b,
+	bench_ghash_inner_product,
 );
 criterion_main!(benches);

--- a/crates/arith-bench/benches/field_mul.rs
+++ b/crates/arith-bench/benches/field_mul.rs
@@ -852,6 +852,29 @@ fn bench_ghash_inner_product(c: &mut Criterion) {
 		LOG_LEN,
 	);
 
+	// CLMUL path (__m128i): the reduction is a larger fraction of a single fast pclmulqdq multiply,
+	// so amortizing it across the inner product should help more than in the software path.
+	#[cfg(all(target_feature = "pclmulqdq", target_feature = "sse2"))]
+	{
+		use binius_arith_bench::ghash::clmul;
+
+		run_inner_product_benchmark(
+			&mut group,
+			"clmul::mul::<__m128i>",
+			clmul::mul::<__m128i>,
+			&mut rng,
+			LOG_LEN,
+		);
+
+		run_inner_product_benchmark(
+			&mut group,
+			"clmul::mul_wide::<__m128i>",
+			clmul::mul_wide::<__m128i>,
+			&mut rng,
+			LOG_LEN,
+		);
+	}
+
 	group.finish();
 }
 

--- a/crates/arith-bench/src/ghash/clmul.rs
+++ b/crates/arith-bench/src/ghash/clmul.rs
@@ -14,6 +14,8 @@
 //
 // Modified by Irreducible Inc. (2025): Translated from C++ to Rust
 // Original: lib/gf2k/sysdep.h from google/longfellow-zk
+//
+// Copyright 2026 The Binius Developers
 
 //! Hardware-accelerated GHASH multiplication using CLMUL instructions.
 //!
@@ -50,28 +52,43 @@ pub fn mul_inv_x<U: Underlier + OpsClmul + PackedUnderlier<u128>>(x: U) -> U {
 	U::xor(shifted, U::and(inv_x, lsb_mask))
 }
 
-/// Multiply two GHASH field elements using CLMUL instructions.
+/// Widening (unreduced) CLMUL GHASH multiply: the schoolbook product as three 128-bit limbs
+/// `[t0, t1, t2]`, without the modular reduction.
+///
+/// Per 128-bit lane, `t0 = x.lo·y.lo` (low), `t1 = x.lo·y.hi ⊕ x.hi·y.lo` (middle, at offset
+/// `X^64`), and `t2 = x.hi·y.hi` (high, at offset `X^128`), so the product is
+/// `t0 + t1·X^64 + t2·X^128`. Because the reduction ([`reduce`]) is F2-linear, these limbs can be
+/// XOR-accumulated across many products and reduced only once — an inner product of `n` terms
+/// costs one reduction instead of `n`.
 #[inline]
-pub fn mul<U: Underlier + OpsClmul + PackedUnderlier<u128>>(x: U, y: U) -> U {
-	// Based on the C++ reference implementation
-	// The algorithm performs polynomial multiplication followed by reduction
-
-	// t1a = x.lo * y.hi
-	let t1a = U::clmulepi64::<0x01>(x, y);
-	// t1b = x.hi * y.lo
-	let t1b = U::clmulepi64::<0x10>(x, y);
-	// t1 = t1a + t1b (XOR in binary field)
-	let mut t1 = U::xor(t1a, t1b);
+pub fn mul_wide<U: Underlier + OpsClmul + PackedUnderlier<u128>>(x: U, y: U) -> [U; 3] {
+	// t0 = x.lo * y.lo
+	let t0 = U::clmulepi64::<0x00>(x, y);
+	// t1 = x.lo * y.hi + x.hi * y.lo (XOR in binary field)
+	let t1 = U::xor(U::clmulepi64::<0x01>(x, y), U::clmulepi64::<0x10>(x, y));
 	// t2 = x.hi * y.hi
 	let t2 = U::clmulepi64::<0x11>(x, y);
-	// Reduce t1 and t2
-	t1 = gf2_128_reduce(t1, t2);
-	// t0 = x.lo * y.lo
-	let mut t0 = U::clmulepi64::<0x00>(x, y);
-	// Final reduction
-	t0 = gf2_128_reduce(t0, t1);
 
-	t0
+	[t0, t1, t2]
+}
+
+/// Reduce the wide product `[t0, t1, t2]` to a single GHASH field element.
+///
+/// Folds the high limb into the middle, then the middle into the low, via `gf2_128_reduce`. Each
+/// fold is F2-linear, so `reduce` is F2-linear in the limbs: unreduced products may be summed by
+/// XOR and reduced once at the end.
+#[inline]
+pub fn reduce<U: Underlier + OpsClmul + PackedUnderlier<u128>>([t0, t1, t2]: [U; 3]) -> U {
+	let t1 = gf2_128_reduce(t1, t2);
+	gf2_128_reduce(t0, t1)
+}
+
+/// Multiply two GHASH field elements using CLMUL instructions.
+///
+/// Composes the widening multiply [`mul_wide`] with the modular [`reduce`]; both are inlined.
+#[inline]
+pub fn mul<U: Underlier + OpsClmul + PackedUnderlier<u128>>(x: U, y: U) -> U {
+	reduce(mul_wide(x, y))
 }
 
 /// Multiply two GHASH field elements using CLMUL instructions.
@@ -123,4 +140,52 @@ fn gf2_128_shift_reduce<U: Underlier + OpsClmul + PackedUnderlier<u128>>(t1: U) 
 	t0 = U::xor(t0, U::clmulepi64::<0x01>(t1, poly));
 
 	t0
+}
+
+#[cfg(all(
+	test,
+	target_arch = "x86_64",
+	target_feature = "pclmulqdq",
+	target_feature = "sse2"
+))]
+mod tests {
+	use std::arch::x86_64::__m128i;
+
+	use proptest::prelude::*;
+
+	use super::*;
+	use crate::ghash::soft64;
+
+	fn to_u(x: u128) -> __m128i {
+		<__m128i as PackedUnderlier<u128>>::broadcast(x)
+	}
+
+	fn from_u(x: __m128i) -> u128 {
+		<__m128i as PackedUnderlier<u128>>::get(x, 0)
+	}
+
+	proptest! {
+		// The widening multiply followed by reduction agrees with the reference software multiply.
+		#[test]
+		fn test_clmul_mul_matches_soft64(a in any::<u128>(), b in any::<u128>()) {
+			prop_assert_eq!(from_u(mul(to_u(a), to_u(b))), soft64::mul(a, b));
+		}
+
+		// The reduction is F2-linear, so accumulating two unreduced products by XOR and reducing
+		// once equals reducing each and summing.
+		#[test]
+		fn test_clmul_wide_mul_deferred_reduction(
+			a1 in any::<u128>(), b1 in any::<u128>(),
+			a2 in any::<u128>(), b2 in any::<u128>(),
+		) {
+			let [p0, p1, p2] = mul_wide(to_u(a1), to_u(b1));
+			let [q0, q1, q2] = mul_wide(to_u(a2), to_u(b2));
+			let acc = reduce([
+				Underlier::xor(p0, q0),
+				Underlier::xor(p1, q1),
+				Underlier::xor(p2, q2),
+			]);
+			prop_assert_eq!(from_u(acc), soft64::mul(a1, b1) ^ soft64::mul(a2, b2));
+		}
+	}
 }

--- a/crates/arith-bench/src/ghash/soft64.rs
+++ b/crates/arith-bench/src/ghash/soft64.rs
@@ -14,6 +14,8 @@
 // shall be included in all copies or substantial portions
 // of the Software.
 
+// Copyright 2026 The Binius Developers
+
 //! Constant-time software implementation of GHASH for 64-bit architectures.
 //!
 //! This implementation is adapted from the RustCrypto/universal-hashes repository:
@@ -29,7 +31,13 @@
 
 use crate::arch::portable64::{U64x2, bmul64, bsqr64, rev64};
 
-/// Multiply two GHASH field elements using software implementation.
+/// Widening (unreduced) GHASH multiply: the 256-bit schoolbook polynomial product of two GHASH
+/// field elements, without the modular reduction.
+///
+/// Returns the four 64-bit limbs `[v0, v1, v2, v3]` of the product `v0 + v1·X^64 + v2·X^128 +
+/// v3·X^192`. Because the reduction ([`reduce`]) is F2-linear, these limbs can be XOR-accumulated
+/// across many products and reduced only once — an inner product of `n` terms costs one reduction
+/// instead of `n`.
 ///
 /// Method described at:
 /// * <https://www.bearssl.org/constanttime.html#ghash-for-gcm>
@@ -37,7 +45,8 @@ use crate::arch::portable64::{U64x2, bmul64, bsqr64, rev64};
 ///
 /// This code does not conform to the bit-endianness requirements of the GCM specification, but is
 /// a valid GHASH field multiplication with the modified representation.
-pub fn mul(x: u128, y: u128) -> u128 {
+#[inline]
+pub fn mul_wide(x: u128, y: u128) -> [u64; 4] {
 	// Convert to U64x2 representation
 	let U64x2(x0, x1) = U64x2::from(x);
 	let U64x2(y0, y1) = U64x2::from(y);
@@ -67,12 +76,16 @@ pub fn mul(x: u128, y: u128) -> u128 {
 	z1h = rev64(z1h) >> 1;
 	z2h = rev64(z2h) >> 1;
 
-	let mut v0 = z0;
-	let mut v1 = z0h ^ z2;
-	let mut v2 = z1 ^ z2h;
-	let v3 = z1h;
+	[z0, z0h ^ z2, z1 ^ z2h, z1h]
+}
 
-	// Reduce modulo X^128 + X^7 + X^2 + X + 1.
+/// Reduce a 256-bit widening product, given as its four 64-bit limbs `[v0, v1, v2, v3]`, to a
+/// single GHASH field element modulo `X^128 + X^7 + X^2 + X + 1`.
+///
+/// This is an F2-linear map, so `reduce(a) ^ reduce(b) == reduce([a0 ^ b0, ..])`: unreduced
+/// products may be summed by XOR and reduced once at the end.
+#[inline]
+pub fn reduce([mut v0, mut v1, mut v2, v3]: [u64; 4]) -> u128 {
 	v1 ^= v3 ^ (v3 << 1) ^ (v3 << 2) ^ (v3 << 7);
 	v2 ^= (v3 >> 63) ^ (v3 >> 62) ^ (v3 >> 57);
 	v0 ^= v2 ^ (v2 << 1) ^ (v2 << 2) ^ (v2 << 7);
@@ -80,6 +93,14 @@ pub fn mul(x: u128, y: u128) -> u128 {
 
 	// Convert back to u128
 	U64x2(v0, v1).into()
+}
+
+/// Multiply two GHASH field elements using software implementation.
+///
+/// Composes the widening multiply [`mul_wide`] with the modular [`reduce`]; both are inlined.
+#[inline]
+pub fn mul(x: u128, y: u128) -> u128 {
+	reduce(mul_wide(x, y))
 }
 
 /// Square a GHASH field element using software implementation.
@@ -97,19 +118,7 @@ pub fn square(x: u128) -> u128 {
 	let x1l = x1 & 0x00000000FFFFFFFF;
 	let x1h = x1 >> 32;
 
-	let mut v0 = bsqr64(x0l);
-	let mut v1 = bsqr64(x0h);
-	let mut v2 = bsqr64(x1l);
-	let v3 = bsqr64(x1h);
-
-	// Reduce modulo X^128 + X^7 + X^2 + X + 1.
-	v1 ^= v3 ^ (v3 << 1) ^ (v3 << 2) ^ (v3 << 7);
-	v2 ^= (v3 >> 63) ^ (v3 >> 62) ^ (v3 >> 57);
-	v0 ^= v2 ^ (v2 << 1) ^ (v2 << 2) ^ (v2 << 7);
-	v1 ^= (v2 >> 63) ^ (v2 >> 62) ^ (v2 >> 57);
-
-	// Convert back to u128
-	U64x2(v0, v1).into()
+	reduce([bsqr64(x0l), bsqr64(x0h), bsqr64(x1l), bsqr64(x1h)])
 }
 
 /// Multiply a GHASH field element by X^{-1}.
@@ -182,6 +191,19 @@ mod tests {
 			a in any::<u128>(),
 		) {
 			test_square_equals_mul(a, mul, square, "GHASH");
+		}
+
+		// The reduction is F2-linear, so accumulating two unreduced products by XOR and reducing
+		// once equals reducing each and summing.
+		#[test]
+		fn test_ghash_soft64_wide_mul_deferred_reduction(
+			a1 in any::<u128>(), b1 in any::<u128>(),
+			a2 in any::<u128>(), b2 in any::<u128>(),
+		) {
+			let [p0, p1, p2, p3] = mul_wide(a1, b1);
+			let [q0, q1, q2, q3] = mul_wide(a2, b2);
+			let acc = reduce([p0 ^ q0, p1 ^ q1, p2 ^ q2, p3 ^ q3]);
+			prop_assert_eq!(acc, mul(a1, b1) ^ mul(a2, b2));
 		}
 	}
 }


### PR DESCRIPTION
Implements [BINIUS-258](https://linear.app/jimpo/issue/BINIUS-258) in `binius-arith-bench`: splits GHASH multiplication into an unreduced widening multiply (`wide_mul`) plus a separate F2-linear `reduce`, so the reduction can be amortized across an inner product. `mul` becomes `reduce(wide_mul(x, y))`, both inlined — no behavior change.

Since the reduction is F2-linear on the wide product, unreduced products accumulate by XOR and only the final result is reduced. An inner product of `n` terms therefore pays one reduction instead of `n`.

### Commits
1. **soft64** — extract the four-limb schoolbook product into `mul_wide`, the shared modular reduction into `reduce`; `mul`/`square` compose them. Adds a deferred-reduction proptest.
2. **soft64 inner-product benchmark** — new `ghash_inner_product` criterion group: a length-2¹⁰ inner product of two random buffers, contrasting reduce-every-term `mul` against accumulate-unreduced `mul_wide` (final reduction skipped). Ad-hoc output types, no trait — benchmark-only.
3. **clmul** — `mul_wide` returns the three 128-bit limbs `[t0, t1, t2]`; `reduce` folds high→middle→low. Adds a clmul test module (the file had none) cross-checking against `soft64` and verifying deferred reduction, plus the `__m128i` inner-product benchmarks.

Bit-sliced and aarch64 are out of scope here (the aarch64 module already has this split).

### Benchmark (length-2¹⁰ inner product, `-C target-cpu=native`, x86_64 pclmulqdq)
| variant | time | vs. reduce-every-term |
|---|---|---|
| `soft64::mul` | 63.6 µs | — |
| `soft64::mul_wide` | 60.8 µs | ~1.04× |
| `clmul::mul::<__m128i>` | 2.93 µs | — |
| `clmul::mul_wide::<__m128i>` | **1.58 µs** | **~1.85×** |

The deferred reduction is a large win on CLMUL (a single fast `pclmulqdq` product, so the reduction is a big fraction of per-term cost — amortizing it nearly halves the inner product), and marginal in software (the carry-less `bmul64`s dominate). This is the measurement that motivates carrying the approach into the field crate (BINIUS-257 → BINIUS-256).

🤖 Generated with [Claude Code](https://claude.com/claude-code)