### PR TITLE
BINIUS-259: parallelize the logUp* numerator build across lookers

### DIFF
--- a/crates/ip-prover/src/logup_star/witness.rs
+++ b/crates/ip-prover/src/logup_star/witness.rs
@@ -14,7 +14,6 @@ use std::iter;
 use binius_field::{BinaryField, Divisible, Field, PackedField, util::powers};
 use binius_math::{FieldBuffer, multilinear::eq::scaled_eq_ind_partial_eval};
 use binius_utils::rayon::prelude::*;
-use itertools::izip;
 
 use super::prove::Looker;
 
@@ -51,8 +50,21 @@ where
 	assert!(!lookers.is_empty(), "at least one looker is required");
 	let n = lookers[0].eval_point.len();
 
-	let numerators = izip!(lookers, powers(gamma))
-		.map(|(looker, power)| {
+	// The scale for looker j is gamma^j.
+	// The powers chain is sequential: each power depends on the last.
+	// So the scales are materialized once here, ahead of the parallel region.
+	let scales = powers(gamma).take(lookers.len()).collect::<Vec<_>>();
+
+	// Build one numerator per looker, fanned out across lookers.
+	// Why fan out: the per-looker expansion is itself parallel.
+	//   But it under-saturates the machine at moderate n.
+	//   Spreading the lookers over the cores fills them.
+	// Invariant: the parallel build writes results back in looker order.
+	//   So numerator j stays gamma^j * eq_{r_j}.
+	let numerators = (0..lookers.len())
+		.into_par_iter()
+		.map(|j| {
+			let looker = &lookers[j];
 			assert_eq!(
 				looker.eval_point.len(),
 				n,
@@ -68,7 +80,7 @@ where
 			// Looker j's numerator is gamma^j * eq_{r_j}.
 			// Seeding the expansion with gamma^j folds the scale into the tensor product.
 			// That keeps it to one pass over one 2^n buffer.
-			scaled_eq_ind_partial_eval::<P>(looker.eval_point, power)
+			scaled_eq_ind_partial_eval::<P>(looker.eval_point, scales[j])
 		})
 		.collect::<Vec<_>>();
 


### PR DESCRIPTION
Closes [BINIUS-259](https://linear.app/jimpo/issue/BINIUS-259).

Follow-up to a review comment on #1748. Builds the per-looker numerators in parallel across lookers instead of one at a time. Output is bit-identical — no protocol change.

### The problem

The logUp* witness builder makes one numerator per looker: looker $j$'s numerator is `gamma^j * eq_{r_j}`.

It builds them one looker at a time, in a serial `map`.

Each build calls `scaled_eq_ind_partial_eval`, which is itself rayonized.

But that inner parallelism does not saturate the machine at moderate `n`.

So the serial outer loop leaves cores idle between lookers.

The intmul caller has 12 lookers, so a whole axis of parallelism goes unused.

### The idea

Fan out across lookers instead of building them one at a time.

The one obstacle is the scale $\gamma^j$: the powers chain is sequential, each power depends on the last.

So materialize the per-looker scales once, then let every numerator build in parallel.

```
scales = [gamma^0, gamma^1, ..., gamma^(L-1)]   // sequential, once
numerators[j] = scaled_eq_ind_partial_eval(eval_point_j, scales[j])   // in parallel over j
```

### The change

```
combined_lookers, one call site in witness.rs:
- izip!(lookers, powers(gamma)).map(|(looker, power)| ...).collect()   // serial across lookers
+ let scales = powers(gamma).take(lookers.len()).collect();            // sequential once
+ (0..lookers.len()).into_par_iter().map(|j| ...).collect()            // parallel across lookers
```

### Soundness

Output is bit-identical, so the transcript matches today's protocol exactly.

The powers chain is unchanged; only where each scale is consumed moves.

The indexed `collect` preserves looker order, so numerator $j$ stays `gamma^j * eq_{r_j}`.

### Scope

- **changed:** the numerator build in `crates/ip-prover/src/logup_star/witness.rs`; the `itertools::izip` import is now unused and dropped.
- **left untouched:** the combined-pushforward scatter, the denominators, the fractional-addition circuits, the verifier.

### Verification

- `cargo check --workspace --all-targets`, `clippy -p binius-ip-prover --all-targets` (with and without `rayon`), nightly `fmt --all --check` — clean.
- `binius-ip-prover` (13) + `binius-iop-prover` (5) logUp* tests pass with `--features rayon`, so the end-to-end proof still verifies and the reference proptests still pin the output.

### Benchmark

Building the 12 numerators at the intmul regime, medians over 100 samples. Throughput is total hypercube volume built, $12 \cdot 2^n$.

| n | baseline (serial) | fused (parallel) | speedup |
|---|---|---|---|
| 16 | 9.67 ms (81 Melem/s) | 1.70 ms (463 Melem/s) | 5.7× |
| 18 | 15.19 ms (207 Melem/s) | 3.31 ms (952 Melem/s) | 4.6× |
| 20 | 26.13 ms (482 Melem/s) | 8.07 ms (1.56 Gelem/s) | 3.2× |

The speedup shrinks as `n` grows because the inner `scaled_eq_ind_partial_eval` parallelism saturates more at large `n` — exactly why the outer fan-out matters most at the moderate `n` where it does not.

The throwaway bench used for these numbers is not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)