### PR TITLE
BINIUS-247: deduplicate the circuit interpreters via a shared execution-context trait

### DIFF
--- a/crates/frontend/src/compiler/eval_form/batch_interpreter.rs
+++ b/crates/frontend/src/compiler/eval_form/batch_interpreter.rs
@@ -1,17 +1,20 @@
 // Copyright 2025-2026 The Binius Developers
 //! Batched bytecode interpreter for circuit evaluation.
 //!
-//! This is the structure-of-arrays counterpart to [`Interpreter`](super::interpreter::Interpreter).
-//! It evaluates the same bytecode over `n` independent instances of one circuit at once.
+//! This is the structure-of-arrays counterpart to the single-instance interpreter.
+//! It evaluates the same bytecode over many independent instances of one circuit at once.
+//! The opcode dispatch is shared through the executor and the execution-context trait.
 //!
-//! The value vector is transposed into a 2D array whose rows are value-vector indices (wires) and
-//! whose columns are instances. A "register" is therefore a whole row, and executing an
-//! instruction applies its scalar operation across the entire row — every instance in one pass.
+//! The value vector is transposed into a 2D array:
+//! - rows are value-vector indices (wires).
+//! - columns are instances.
+//!
+//! An instruction applies its scalar operation across a whole row: every instance in one pass.
 //! This is the memory order the batch prover wants downstream.
 //!
 //! ```text
 //!                  instance 0   instance 1   ...   instance n-1
-//!   value index 0 [   w        |   w        | ... |   w        ]   <- one row = one register
+//!   value index 0 [   w        |   w        | ... |   w        ]   <- one row
 //!   value index 1 [   w        |   w        | ... |   w        ]
 //!         ...
 //! ```
@@ -19,6 +22,7 @@
 use binius_core::Word;
 use binius_utils::strided_array::StridedArray2DViewMut;
 
+use super::exec::{EvalContext, Executor};
 use crate::compiler::{
 	circuit::PopulateError,
 	hints::HintRegistry,
@@ -74,42 +78,6 @@ impl<'a, 'v> BatchExecutionContext<'a, 'v> {
 		}
 	}
 
-	/// The number of instances, i.e. the number of columns in the value array.
-	const fn n_instances(&self) -> usize {
-		self.values.width()
-	}
-
-	#[inline]
-	fn load(&self, reg: u32, instance: usize) -> Word {
-		self.values[(reg as usize, instance)]
-	}
-
-	#[inline]
-	fn store(&mut self, reg: u32, instance: usize, value: Word) {
-		self.values[(reg as usize, instance)] = value;
-	}
-
-	/// Record an assertion failure for `instance`.
-	///
-	/// The failure may be dropped from the stored list once the cap is reached, but it always
-	/// updates the count and the lowest-failing-instance tracker.
-	#[cold]
-	fn note_assertion_failure(&mut self, instance: usize, path_spec: PathSpec, message: String) {
-		let instance = self.instance_offset + instance;
-		self.total_count += 1;
-		self.min_failing_instance = Some(
-			self.min_failing_instance
-				.map_or(instance, |m| m.min(instance)),
-		);
-		if self.failures.len() < MAX_ASSERTION_FAILURES {
-			self.failures.push(InstanceAssertionFailure {
-				instance,
-				path_spec,
-				message,
-			});
-		}
-	}
-
 	/// Turn recorded failures into an error attributed to the lowest-failing instance.
 	fn check_assertions(
 		self,
@@ -148,19 +116,53 @@ impl<'a, 'v> BatchExecutionContext<'a, 'v> {
 	}
 }
 
+impl EvalContext for BatchExecutionContext<'_, '_> {
+	fn n_instances(&self) -> usize {
+		self.values.width()
+	}
+
+	#[inline]
+	fn load(&self, reg: u32, instance: usize) -> Word {
+		self.values[(reg as usize, instance)]
+	}
+
+	#[inline]
+	fn store(&mut self, reg: u32, instance: usize, value: Word) {
+		self.values[(reg as usize, instance)] = value;
+	}
+
+	/// Record an assertion failure for one local instance.
+	///
+	/// The failure may be dropped from the stored list once the cap is reached.
+	/// It always updates the count and the lowest-failing-instance tracker.
+	/// The stripe offset remaps the local index to a global instance index.
+	#[cold]
+	fn note_assertion_failure(&mut self, instance: usize, path_spec: PathSpec, message: String) {
+		let instance = self.instance_offset + instance;
+		self.total_count += 1;
+		self.min_failing_instance = Some(
+			self.min_failing_instance
+				.map_or(instance, |m| m.min(instance)),
+		);
+		if self.failures.len() < MAX_ASSERTION_FAILURES {
+			self.failures.push(InstanceAssertionFailure {
+				instance,
+				path_spec,
+				message,
+			});
+		}
+	}
+}
+
 /// Bytecode interpreter that evaluates one circuit over many instances at once.
 pub struct BatchInterpreter<'a> {
-	bytecode: &'a [u8],
-	hints: &'a HintRegistry,
-	pc: usize,
+	executor: Executor<'a>,
 }
 
 impl<'a> BatchInterpreter<'a> {
 	pub const fn new(bytecode: &'a [u8], hints: &'a HintRegistry) -> Self {
 		Self {
-			bytecode,
-			hints,
-			pc: 0,
+			executor: Executor::new(bytecode, hints),
 		}
 	}
 
@@ -184,473 +186,8 @@ impl<'a> BatchInterpreter<'a> {
 		path_spec_tree: Option<&PathSpecTree>,
 	) -> Result<(), BatchPopulateError> {
 		let mut ctx = BatchExecutionContext::new(values, instance_offset);
-		while self.pc < self.bytecode.len() {
-			let opcode = self.read_u8();
-			match opcode {
-				// Bitwise operations
-				0x01 => self.exec_band(&mut ctx),
-				0x02 => self.exec_bor(&mut ctx),
-				0x03 => self.exec_bxor(&mut ctx),
-				0x05 => self.exec_select(&mut ctx),
-				0x06 => self.exec_bxor_multi(&mut ctx),
-				0x07 => self.exec_fax(&mut ctx),
-
-				// Shifts
-				0x10 => self.exec_sll(&mut ctx),
-				0x11 => self.exec_slr(&mut ctx),
-				0x12 => self.exec_sar(&mut ctx),
-
-				// Arithmetic
-				0x20 => self.exec_iadd_cout(&mut ctx),
-				0x21 => self.exec_iadd_cin_cout(&mut ctx),
-				0x23 => self.exec_isub_bin_bout(&mut ctx),
-				0x30 => self.exec_imul(&mut ctx),
-
-				// 32-bit operations
-				0x40 => self.exec_iadd32_cin_cout(&mut ctx),
-				0x41 => self.exec_rotr32(&mut ctx),
-				0x42 => self.exec_srl32(&mut ctx),
-				0x43 => self.exec_rotr(&mut ctx),
-				0x44 => self.exec_sll32(&mut ctx),
-				0x45 => self.exec_sra32(&mut ctx),
-				0x46 => self.exec_iadd32_cout(&mut ctx),
-
-				// Masks
-				0x50 => self.exec_mask_low(&mut ctx),
-				0x51 => self.exec_mask_high(&mut ctx),
-
-				// Assertions
-				0x60 => self.exec_assert_eq(&mut ctx),
-				0x61 => self.exec_assert_eq_cond(&mut ctx),
-				0x62 => self.exec_assert_zero(&mut ctx),
-				0x63 => self.exec_assert_non_zero(&mut ctx),
-				0x64 => self.exec_assert_false(&mut ctx),
-				0x65 => self.exec_assert_true(&mut ctx),
-
-				// Hint calls
-				0x80 => self.exec_hint(&mut ctx),
-
-				_ => panic!("Unknown opcode: {:#x} at pc={}", opcode, self.pc - 1),
-			}
-		}
+		self.executor.run(&mut ctx);
 		ctx.check_assertions(path_spec_tree)
-	}
-
-	// Bitwise operations
-	fn exec_band(&mut self, ctx: &mut BatchExecutionContext<'_, '_>) {
-		let dst = self.read_reg();
-		let src1 = self.read_reg();
-		let src2 = self.read_reg();
-		for i in 0..ctx.n_instances() {
-			let val = ctx.load(src1, i) & ctx.load(src2, i);
-			ctx.store(dst, i, val);
-		}
-	}
-
-	fn exec_bor(&mut self, ctx: &mut BatchExecutionContext<'_, '_>) {
-		let dst = self.read_reg();
-		let src1 = self.read_reg();
-		let src2 = self.read_reg();
-		for i in 0..ctx.n_instances() {
-			let val = ctx.load(src1, i) | ctx.load(src2, i);
-			ctx.store(dst, i, val);
-		}
-	}
-
-	fn exec_bxor(&mut self, ctx: &mut BatchExecutionContext<'_, '_>) {
-		let dst = self.read_reg();
-		let src1 = self.read_reg();
-		let src2 = self.read_reg();
-		for i in 0..ctx.n_instances() {
-			let val = ctx.load(src1, i) ^ ctx.load(src2, i);
-			ctx.store(dst, i, val);
-		}
-	}
-
-	fn exec_select(&mut self, ctx: &mut BatchExecutionContext<'_, '_>) {
-		let dst = self.read_reg();
-		let cond = self.read_reg();
-		let t = self.read_reg();
-		let f = self.read_reg();
-		for i in 0..ctx.n_instances() {
-			// Select t if MSB(cond) is 1, otherwise select f
-			let val = if ctx.load(cond, i).is_msb_true() {
-				ctx.load(t, i)
-			} else {
-				ctx.load(f, i)
-			};
-			ctx.store(dst, i, val);
-		}
-	}
-
-	fn exec_bxor_multi(&mut self, ctx: &mut BatchExecutionContext<'_, '_>) {
-		let dst = self.read_reg();
-		let n = self.read_u32() as usize;
-		// Read the source registers once; they are shared across every instance.
-		let srcs = (0..n).map(|_| self.read_reg()).collect::<Vec<_>>();
-		for i in 0..ctx.n_instances() {
-			let mut val = Word::ZERO;
-			for &src in &srcs {
-				val = val ^ ctx.load(src, i);
-			}
-			ctx.store(dst, i, val);
-		}
-	}
-
-	fn exec_fax(&mut self, ctx: &mut BatchExecutionContext<'_, '_>) {
-		let dst = self.read_reg();
-		let src1 = self.read_reg();
-		let src2 = self.read_reg();
-		let src3 = self.read_reg();
-		for i in 0..ctx.n_instances() {
-			let val = (ctx.load(src1, i) & ctx.load(src2, i)) ^ ctx.load(src3, i);
-			ctx.store(dst, i, val);
-		}
-	}
-
-	// Shifts
-	fn exec_sll(&mut self, ctx: &mut BatchExecutionContext<'_, '_>) {
-		let dst = self.read_reg();
-		let src = self.read_reg();
-		let shift = self.read_u8() as u32;
-		for i in 0..ctx.n_instances() {
-			let val = ctx.load(src, i) << shift;
-			ctx.store(dst, i, val);
-		}
-	}
-
-	fn exec_slr(&mut self, ctx: &mut BatchExecutionContext<'_, '_>) {
-		let dst = self.read_reg();
-		let src = self.read_reg();
-		let shift = self.read_u8() as u32;
-		for i in 0..ctx.n_instances() {
-			let val = ctx.load(src, i) >> shift;
-			ctx.store(dst, i, val);
-		}
-	}
-
-	fn exec_sar(&mut self, ctx: &mut BatchExecutionContext<'_, '_>) {
-		let dst = self.read_reg();
-		let src = self.read_reg();
-		let shift = self.read_u8() as u32;
-		for i in 0..ctx.n_instances() {
-			let val = ctx.load(src, i).sar(shift);
-			ctx.store(dst, i, val);
-		}
-	}
-
-	// Arithmetic operations
-	fn exec_iadd_cout(&mut self, ctx: &mut BatchExecutionContext<'_, '_>) {
-		let dst_sum = self.read_reg();
-		let dst_cout = self.read_reg();
-		let src1 = self.read_reg();
-		let src2 = self.read_reg();
-		for i in 0..ctx.n_instances() {
-			let (sum, cout) = ctx
-				.load(src1, i)
-				.iadd_cin_cout(ctx.load(src2, i), Word::ZERO);
-			ctx.store(dst_sum, i, sum);
-			ctx.store(dst_cout, i, cout);
-		}
-	}
-
-	fn exec_iadd_cin_cout(&mut self, ctx: &mut BatchExecutionContext<'_, '_>) {
-		let dst_sum = self.read_reg();
-		let dst_cout = self.read_reg();
-		let src1 = self.read_reg();
-		let src2 = self.read_reg();
-		let cin = self.read_reg();
-		for i in 0..ctx.n_instances() {
-			let cin_bit = ctx.load(cin, i) >> 63; // Use MSB as carry bit
-			let (sum, cout) = ctx.load(src1, i).iadd_cin_cout(ctx.load(src2, i), cin_bit);
-			ctx.store(dst_sum, i, sum);
-			ctx.store(dst_cout, i, cout);
-		}
-	}
-
-	fn exec_isub_bin_bout(&mut self, ctx: &mut BatchExecutionContext<'_, '_>) {
-		let dst_diff = self.read_reg();
-		let dst_bout = self.read_reg();
-		let src1 = self.read_reg();
-		let src2 = self.read_reg();
-		let bin = self.read_reg();
-		for i in 0..ctx.n_instances() {
-			let bin_bit = ctx.load(bin, i) >> 63; // Use MSB as borrow bit
-			let (diff, bout) = ctx.load(src1, i).isub_bin_bout(ctx.load(src2, i), bin_bit);
-			ctx.store(dst_diff, i, diff);
-			ctx.store(dst_bout, i, bout);
-		}
-	}
-
-	fn exec_imul(&mut self, ctx: &mut BatchExecutionContext<'_, '_>) {
-		let dst_hi = self.read_reg();
-		let dst_lo = self.read_reg();
-		let src1 = self.read_reg();
-		let src2 = self.read_reg();
-		for i in 0..ctx.n_instances() {
-			let (hi, lo) = ctx.load(src1, i).imul(ctx.load(src2, i));
-			ctx.store(dst_hi, i, hi);
-			ctx.store(dst_lo, i, lo);
-		}
-	}
-
-	// 32-bit operations
-	fn exec_iadd32_cin_cout(&mut self, ctx: &mut BatchExecutionContext<'_, '_>) {
-		let dst_sum = self.read_reg();
-		let dst_cout = self.read_reg();
-		let src1 = self.read_reg();
-		let src2 = self.read_reg();
-		let cin = self.read_reg();
-		for i in 0..ctx.n_instances() {
-			let (sum, cout) = ctx
-				.load(src1, i)
-				.iadd32_cin_cout(ctx.load(src2, i), ctx.load(cin, i));
-			ctx.store(dst_sum, i, sum);
-			ctx.store(dst_cout, i, cout);
-		}
-	}
-
-	fn exec_iadd32_cout(&mut self, ctx: &mut BatchExecutionContext<'_, '_>) {
-		let dst_sum = self.read_reg();
-		let dst_cout = self.read_reg();
-		let src1 = self.read_reg();
-		let src2 = self.read_reg();
-		for i in 0..ctx.n_instances() {
-			let (sum, cout) = ctx.load(src1, i).iadd_cout_32(ctx.load(src2, i));
-			ctx.store(dst_sum, i, sum);
-			ctx.store(dst_cout, i, cout);
-		}
-	}
-
-	fn exec_rotr32(&mut self, ctx: &mut BatchExecutionContext<'_, '_>) {
-		let dst = self.read_reg();
-		let src = self.read_reg();
-		let rotate = self.read_u8() as u32;
-		for i in 0..ctx.n_instances() {
-			let val = ctx.load(src, i).rotr32(rotate);
-			ctx.store(dst, i, val);
-		}
-	}
-
-	fn exec_srl32(&mut self, ctx: &mut BatchExecutionContext<'_, '_>) {
-		let dst = self.read_reg();
-		let src = self.read_reg();
-		let shift = self.read_u8() as u32;
-		for i in 0..ctx.n_instances() {
-			let val = ctx.load(src, i).srl32(shift);
-			ctx.store(dst, i, val);
-		}
-	}
-
-	fn exec_sll32(&mut self, ctx: &mut BatchExecutionContext<'_, '_>) {
-		let dst = self.read_reg();
-		let src = self.read_reg();
-		let shift = self.read_u8() as u32;
-		for i in 0..ctx.n_instances() {
-			let val = ctx.load(src, i).sll32(shift);
-			ctx.store(dst, i, val);
-		}
-	}
-
-	fn exec_sra32(&mut self, ctx: &mut BatchExecutionContext<'_, '_>) {
-		let dst = self.read_reg();
-		let src = self.read_reg();
-		let shift = self.read_u8() as u32;
-		for i in 0..ctx.n_instances() {
-			let val = ctx.load(src, i).sra32(shift);
-			ctx.store(dst, i, val);
-		}
-	}
-
-	fn exec_rotr(&mut self, ctx: &mut BatchExecutionContext<'_, '_>) {
-		let dst = self.read_reg();
-		let src = self.read_reg();
-		let rotate = self.read_u8() as u32;
-		for i in 0..ctx.n_instances() {
-			let val = ctx.load(src, i).rotr(rotate);
-			ctx.store(dst, i, val);
-		}
-	}
-
-	// Mask operations
-	fn exec_mask_low(&mut self, ctx: &mut BatchExecutionContext<'_, '_>) {
-		let dst = self.read_reg();
-		let src = self.read_reg();
-		let n_bits = self.read_u8();
-		let mask = if n_bits >= 64 {
-			Word::ALL_ONE
-		} else {
-			Word::from_u64((1u64 << n_bits) - 1)
-		};
-		for i in 0..ctx.n_instances() {
-			let val = ctx.load(src, i) & mask;
-			ctx.store(dst, i, val);
-		}
-	}
-
-	fn exec_mask_high(&mut self, ctx: &mut BatchExecutionContext<'_, '_>) {
-		let dst = self.read_reg();
-		let src = self.read_reg();
-		let n_bits = self.read_u8();
-		let mask = if n_bits >= 64 {
-			Word::ALL_ONE
-		} else {
-			Word::from_u64(!((1u64 << (64 - n_bits)) - 1))
-		};
-		for i in 0..ctx.n_instances() {
-			let val = ctx.load(src, i) & mask;
-			ctx.store(dst, i, val);
-		}
-	}
-
-	// Assertions
-	fn exec_assert_eq(&mut self, ctx: &mut BatchExecutionContext<'_, '_>) {
-		let src1 = self.read_reg();
-		let src2 = self.read_reg();
-		let error_id = self.read_u32();
-		let path_spec = PathSpec::from_u32(error_id);
-
-		for i in 0..ctx.n_instances() {
-			let val1 = ctx.load(src1, i);
-			let val2 = ctx.load(src2, i);
-			if val1 != val2 {
-				ctx.note_assertion_failure(i, path_spec, format!("{val1:?} != {val2:?}"));
-			}
-		}
-	}
-
-	fn exec_assert_eq_cond(&mut self, ctx: &mut BatchExecutionContext<'_, '_>) {
-		let cond = self.read_reg();
-		let src1 = self.read_reg();
-		let src2 = self.read_reg();
-		let error_id = self.read_u32();
-		let path_spec = PathSpec::from_u32(error_id);
-
-		for i in 0..ctx.n_instances() {
-			if ctx.load(cond, i).is_msb_true() {
-				let val1 = ctx.load(src1, i);
-				let val2 = ctx.load(src2, i);
-				if val1 != val2 {
-					ctx.note_assertion_failure(
-						i,
-						path_spec,
-						format!("conditional assert: {val1:?} != {val2:?}"),
-					);
-				}
-			}
-		}
-	}
-
-	fn exec_assert_zero(&mut self, ctx: &mut BatchExecutionContext<'_, '_>) {
-		let src = self.read_reg();
-		let error_id = self.read_u32();
-		let path_spec = PathSpec::from_u32(error_id);
-
-		for i in 0..ctx.n_instances() {
-			let val = ctx.load(src, i);
-			if val != Word::ZERO {
-				ctx.note_assertion_failure(i, path_spec, format!("{val:?} != 0"));
-			}
-		}
-	}
-
-	fn exec_assert_non_zero(&mut self, ctx: &mut BatchExecutionContext<'_, '_>) {
-		let src = self.read_reg();
-		let error_id = self.read_u32();
-		let path_spec = PathSpec::from_u32(error_id);
-
-		for i in 0..ctx.n_instances() {
-			let val = ctx.load(src, i);
-			if val == Word::ZERO {
-				ctx.note_assertion_failure(i, path_spec, format!("{val:?} == 0"));
-			}
-		}
-	}
-
-	fn exec_assert_false(&mut self, ctx: &mut BatchExecutionContext<'_, '_>) {
-		let src = self.read_reg();
-		let error_id = self.read_u32();
-		let path_spec = PathSpec::from_u32(error_id);
-
-		for i in 0..ctx.n_instances() {
-			let val = ctx.load(src, i);
-			if val.is_msb_true() {
-				ctx.note_assertion_failure(i, path_spec, format!("{val:?} MSB is true"));
-			}
-		}
-	}
-
-	fn exec_assert_true(&mut self, ctx: &mut BatchExecutionContext<'_, '_>) {
-		let src = self.read_reg();
-		let error_id = self.read_u32();
-		let path_spec = PathSpec::from_u32(error_id);
-
-		for i in 0..ctx.n_instances() {
-			let val = ctx.load(src, i);
-			if val.is_msb_false() {
-				ctx.note_assertion_failure(i, path_spec, format!("{val:?} MSB is false"));
-			}
-		}
-	}
-
-	// Hint execution
-	fn exec_hint(&mut self, ctx: &mut BatchExecutionContext<'_, '_>) {
-		let hint_id = self.read_u32();
-
-		// Read dimensions
-		let n_dimensions = self.read_u16() as usize;
-		let mut dimensions = Vec::with_capacity(n_dimensions);
-		for _ in 0..n_dimensions {
-			dimensions.push(self.read_u32() as usize);
-		}
-
-		let n_inputs = self.read_u16() as usize;
-		let n_outputs = self.read_u16() as usize;
-
-		// Read the input and output registers once; they are shared across every instance.
-		let input_regs = (0..n_inputs).map(|_| self.read_reg()).collect::<Vec<_>>();
-		let output_regs = (0..n_outputs).map(|_| self.read_reg()).collect::<Vec<_>>();
-
-		let mut inputs = vec![Word::ZERO; n_inputs];
-		let mut outputs = vec![Word::ZERO; n_outputs];
-		for i in 0..ctx.n_instances() {
-			for (input, &reg) in inputs.iter_mut().zip(&input_regs) {
-				*input = ctx.load(reg, i);
-			}
-			self.hints
-				.execute(hint_id, &dimensions, &inputs, &mut outputs);
-			for (&reg, &output) in output_regs.iter().zip(&outputs) {
-				ctx.store(reg, i, output);
-			}
-		}
-	}
-
-	// Bytecode reading helpers
-	fn read_u8(&mut self) -> u8 {
-		let val = self.bytecode[self.pc];
-		self.pc += 1;
-		val
-	}
-
-	fn read_u16(&mut self) -> u16 {
-		let val = u16::from_le_bytes([self.bytecode[self.pc], self.bytecode[self.pc + 1]]);
-		self.pc += 2;
-		val
-	}
-
-	fn read_u32(&mut self) -> u32 {
-		let val = u32::from_le_bytes([
-			self.bytecode[self.pc],
-			self.bytecode[self.pc + 1],
-			self.bytecode[self.pc + 2],
-			self.bytecode[self.pc + 3],
-		]);
-		self.pc += 4;
-		val
-	}
-
-	fn read_reg(&mut self) -> u32 {
-		self.read_u32()
 	}
 }
 

--- a/crates/frontend/src/compiler/eval_form/exec.rs
+++ b/crates/frontend/src/compiler/eval_form/exec.rs
@@ -1,0 +1,540 @@
+// Copyright 2025-2026 The Binius Developers
+//! Shared bytecode execution core for the circuit interpreters.
+//!
+//! Both interpreters run the same bytecode through the same opcode dispatch.
+//! They differ only in where a decoded instruction reads and writes:
+//! - single instance: one value vector.
+//! - batched: one column per instance.
+//!
+//! That difference is captured by one trait over the execution context.
+//! Every instruction is applied across all instances the context holds.
+//! The single-instance form is then the degenerate case of one instance.
+//! The dispatch loop, the opcode handlers, and the bytecode readers live here once.
+
+use binius_core::Word;
+
+use crate::compiler::{hints::HintRegistry, pathspec::PathSpec};
+
+/// The values one bytecode program evaluates against.
+///
+/// A context holds some number of independent instances of one circuit.
+/// A register names a value-vector index.
+/// Reading or writing a register targets that index within one chosen instance.
+/// So an instruction is applied once per instance.
+pub(crate) trait EvalContext {
+	/// The number of independent instances evaluated in lockstep.
+	fn n_instances(&self) -> usize;
+
+	/// Reads the register at index `reg` within instance `instance`.
+	fn load(&self, reg: u32, instance: usize) -> Word;
+
+	/// Writes `value` to the register at index `reg` within instance `instance`.
+	fn store(&mut self, reg: u32, instance: usize, value: Word);
+
+	/// Records an assertion violation for one instance.
+	///
+	/// The index is local to this context.
+	/// A context that covers a stripe of a larger batch remaps it to a global index.
+	fn note_assertion_failure(&mut self, instance: usize, path_spec: PathSpec, message: String);
+}
+
+/// A bytecode program together with a cursor into it.
+///
+/// The cursor advances as the dispatch loop consumes opcodes and operands.
+/// One executor drives one pass over the bytecode.
+/// The interpreters build a fresh executor per run, so the cursor starts at the first instruction.
+pub(crate) struct Executor<'a> {
+	bytecode: &'a [u8],
+	hints: &'a HintRegistry,
+	pc: usize,
+}
+
+impl<'a> Executor<'a> {
+	pub(crate) const fn new(bytecode: &'a [u8], hints: &'a HintRegistry) -> Self {
+		Self {
+			bytecode,
+			hints,
+			pc: 0,
+		}
+	}
+
+	/// Evaluates the whole program against the context, filling every instance's wires.
+	///
+	/// The constant and input registers must already be populated for every instance.
+	/// Assertion violations are recorded on the context, not raised here.
+	/// So the caller decides how to turn them into an error.
+	///
+	/// # Panics
+	///
+	/// Panics on an unknown opcode, which can only happen if the bytecode is malformed.
+	pub(crate) fn run<C: EvalContext>(&mut self, ctx: &mut C) {
+		while self.pc < self.bytecode.len() {
+			let opcode = self.read_u8();
+			match opcode {
+				// Bitwise operations
+				0x01 => self.exec_band(ctx),
+				0x02 => self.exec_bor(ctx),
+				0x03 => self.exec_bxor(ctx),
+				0x05 => self.exec_select(ctx),
+				0x06 => self.exec_bxor_multi(ctx),
+				0x07 => self.exec_fax(ctx),
+
+				// Shifts
+				0x10 => self.exec_sll(ctx),
+				0x11 => self.exec_slr(ctx),
+				0x12 => self.exec_sar(ctx),
+
+				// Arithmetic
+				0x20 => self.exec_iadd_cout(ctx),
+				0x21 => self.exec_iadd_cin_cout(ctx),
+				0x23 => self.exec_isub_bin_bout(ctx),
+				0x30 => self.exec_imul(ctx),
+
+				// 32-bit operations
+				0x40 => self.exec_iadd32_cin_cout(ctx),
+				0x41 => self.exec_rotr32(ctx),
+				0x42 => self.exec_srl32(ctx),
+				0x43 => self.exec_rotr(ctx),
+				0x44 => self.exec_sll32(ctx),
+				0x45 => self.exec_sra32(ctx),
+				0x46 => self.exec_iadd32_cout(ctx),
+
+				// Masks
+				0x50 => self.exec_mask_low(ctx),
+				0x51 => self.exec_mask_high(ctx),
+
+				// Assertions
+				0x60 => self.exec_assert_eq(ctx),
+				0x61 => self.exec_assert_eq_cond(ctx),
+				0x62 => self.exec_assert_zero(ctx),
+				0x63 => self.exec_assert_non_zero(ctx),
+				0x64 => self.exec_assert_false(ctx),
+				0x65 => self.exec_assert_true(ctx),
+
+				// Hint calls
+				0x80 => self.exec_hint(ctx),
+
+				_ => panic!("Unknown opcode: {:#x} at pc={}", opcode, self.pc - 1),
+			}
+		}
+	}
+
+	// Bitwise operations
+	fn exec_band<C: EvalContext>(&mut self, ctx: &mut C) {
+		let dst = self.read_reg();
+		let src1 = self.read_reg();
+		let src2 = self.read_reg();
+		for i in 0..ctx.n_instances() {
+			let val = ctx.load(src1, i) & ctx.load(src2, i);
+			ctx.store(dst, i, val);
+		}
+	}
+
+	fn exec_bor<C: EvalContext>(&mut self, ctx: &mut C) {
+		let dst = self.read_reg();
+		let src1 = self.read_reg();
+		let src2 = self.read_reg();
+		for i in 0..ctx.n_instances() {
+			let val = ctx.load(src1, i) | ctx.load(src2, i);
+			ctx.store(dst, i, val);
+		}
+	}
+
+	fn exec_bxor<C: EvalContext>(&mut self, ctx: &mut C) {
+		let dst = self.read_reg();
+		let src1 = self.read_reg();
+		let src2 = self.read_reg();
+		for i in 0..ctx.n_instances() {
+			let val = ctx.load(src1, i) ^ ctx.load(src2, i);
+			ctx.store(dst, i, val);
+		}
+	}
+
+	fn exec_select<C: EvalContext>(&mut self, ctx: &mut C) {
+		let dst = self.read_reg();
+		let cond = self.read_reg();
+		let t = self.read_reg();
+		let f = self.read_reg();
+		for i in 0..ctx.n_instances() {
+			// Select t if MSB(cond) is 1, otherwise select f.
+			let val = if ctx.load(cond, i).is_msb_true() {
+				ctx.load(t, i)
+			} else {
+				ctx.load(f, i)
+			};
+			ctx.store(dst, i, val);
+		}
+	}
+
+	fn exec_bxor_multi<C: EvalContext>(&mut self, ctx: &mut C) {
+		let dst = self.read_reg();
+		let n = self.read_u32() as usize;
+		// Read the source registers once; they are shared across every instance.
+		let srcs = (0..n).map(|_| self.read_reg()).collect::<Vec<_>>();
+		for i in 0..ctx.n_instances() {
+			let mut val = Word::ZERO;
+			for &src in &srcs {
+				val = val ^ ctx.load(src, i);
+			}
+			ctx.store(dst, i, val);
+		}
+	}
+
+	fn exec_fax<C: EvalContext>(&mut self, ctx: &mut C) {
+		let dst = self.read_reg();
+		let src1 = self.read_reg();
+		let src2 = self.read_reg();
+		let src3 = self.read_reg();
+		for i in 0..ctx.n_instances() {
+			let val = (ctx.load(src1, i) & ctx.load(src2, i)) ^ ctx.load(src3, i);
+			ctx.store(dst, i, val);
+		}
+	}
+
+	// Shifts
+	fn exec_sll<C: EvalContext>(&mut self, ctx: &mut C) {
+		let dst = self.read_reg();
+		let src = self.read_reg();
+		let shift = self.read_u8() as u32;
+		for i in 0..ctx.n_instances() {
+			let val = ctx.load(src, i) << shift;
+			ctx.store(dst, i, val);
+		}
+	}
+
+	fn exec_slr<C: EvalContext>(&mut self, ctx: &mut C) {
+		let dst = self.read_reg();
+		let src = self.read_reg();
+		let shift = self.read_u8() as u32;
+		for i in 0..ctx.n_instances() {
+			let val = ctx.load(src, i) >> shift;
+			ctx.store(dst, i, val);
+		}
+	}
+
+	fn exec_sar<C: EvalContext>(&mut self, ctx: &mut C) {
+		let dst = self.read_reg();
+		let src = self.read_reg();
+		let shift = self.read_u8() as u32;
+		for i in 0..ctx.n_instances() {
+			let val = ctx.load(src, i).sar(shift);
+			ctx.store(dst, i, val);
+		}
+	}
+
+	// Arithmetic operations
+	fn exec_iadd_cout<C: EvalContext>(&mut self, ctx: &mut C) {
+		let dst_sum = self.read_reg();
+		let dst_cout = self.read_reg();
+		let src1 = self.read_reg();
+		let src2 = self.read_reg();
+		for i in 0..ctx.n_instances() {
+			let (sum, cout) = ctx
+				.load(src1, i)
+				.iadd_cin_cout(ctx.load(src2, i), Word::ZERO);
+			ctx.store(dst_sum, i, sum);
+			ctx.store(dst_cout, i, cout);
+		}
+	}
+
+	fn exec_iadd_cin_cout<C: EvalContext>(&mut self, ctx: &mut C) {
+		let dst_sum = self.read_reg();
+		let dst_cout = self.read_reg();
+		let src1 = self.read_reg();
+		let src2 = self.read_reg();
+		let cin = self.read_reg();
+		for i in 0..ctx.n_instances() {
+			let cin_bit = ctx.load(cin, i) >> 63; // Use MSB as carry bit
+			let (sum, cout) = ctx.load(src1, i).iadd_cin_cout(ctx.load(src2, i), cin_bit);
+			ctx.store(dst_sum, i, sum);
+			ctx.store(dst_cout, i, cout);
+		}
+	}
+
+	fn exec_isub_bin_bout<C: EvalContext>(&mut self, ctx: &mut C) {
+		let dst_diff = self.read_reg();
+		let dst_bout = self.read_reg();
+		let src1 = self.read_reg();
+		let src2 = self.read_reg();
+		let bin = self.read_reg();
+		for i in 0..ctx.n_instances() {
+			let bin_bit = ctx.load(bin, i) >> 63; // Use MSB as borrow bit
+			let (diff, bout) = ctx.load(src1, i).isub_bin_bout(ctx.load(src2, i), bin_bit);
+			ctx.store(dst_diff, i, diff);
+			ctx.store(dst_bout, i, bout);
+		}
+	}
+
+	fn exec_imul<C: EvalContext>(&mut self, ctx: &mut C) {
+		let dst_hi = self.read_reg();
+		let dst_lo = self.read_reg();
+		let src1 = self.read_reg();
+		let src2 = self.read_reg();
+		for i in 0..ctx.n_instances() {
+			let (hi, lo) = ctx.load(src1, i).imul(ctx.load(src2, i));
+			ctx.store(dst_hi, i, hi);
+			ctx.store(dst_lo, i, lo);
+		}
+	}
+
+	// 32-bit operations
+	fn exec_iadd32_cin_cout<C: EvalContext>(&mut self, ctx: &mut C) {
+		let dst_sum = self.read_reg();
+		let dst_cout = self.read_reg();
+		let src1 = self.read_reg();
+		let src2 = self.read_reg();
+		let cin = self.read_reg();
+		for i in 0..ctx.n_instances() {
+			let (sum, cout) = ctx
+				.load(src1, i)
+				.iadd32_cin_cout(ctx.load(src2, i), ctx.load(cin, i));
+			ctx.store(dst_sum, i, sum);
+			ctx.store(dst_cout, i, cout);
+		}
+	}
+
+	fn exec_iadd32_cout<C: EvalContext>(&mut self, ctx: &mut C) {
+		let dst_sum = self.read_reg();
+		let dst_cout = self.read_reg();
+		let src1 = self.read_reg();
+		let src2 = self.read_reg();
+		for i in 0..ctx.n_instances() {
+			let (sum, cout) = ctx.load(src1, i).iadd_cout_32(ctx.load(src2, i));
+			ctx.store(dst_sum, i, sum);
+			ctx.store(dst_cout, i, cout);
+		}
+	}
+
+	fn exec_rotr32<C: EvalContext>(&mut self, ctx: &mut C) {
+		let dst = self.read_reg();
+		let src = self.read_reg();
+		let rotate = self.read_u8() as u32;
+		for i in 0..ctx.n_instances() {
+			let val = ctx.load(src, i).rotr32(rotate);
+			ctx.store(dst, i, val);
+		}
+	}
+
+	fn exec_srl32<C: EvalContext>(&mut self, ctx: &mut C) {
+		let dst = self.read_reg();
+		let src = self.read_reg();
+		let shift = self.read_u8() as u32;
+		for i in 0..ctx.n_instances() {
+			let val = ctx.load(src, i).srl32(shift);
+			ctx.store(dst, i, val);
+		}
+	}
+
+	fn exec_sll32<C: EvalContext>(&mut self, ctx: &mut C) {
+		let dst = self.read_reg();
+		let src = self.read_reg();
+		let shift = self.read_u8() as u32;
+		for i in 0..ctx.n_instances() {
+			let val = ctx.load(src, i).sll32(shift);
+			ctx.store(dst, i, val);
+		}
+	}
+
+	fn exec_sra32<C: EvalContext>(&mut self, ctx: &mut C) {
+		let dst = self.read_reg();
+		let src = self.read_reg();
+		let shift = self.read_u8() as u32;
+		for i in 0..ctx.n_instances() {
+			let val = ctx.load(src, i).sra32(shift);
+			ctx.store(dst, i, val);
+		}
+	}
+
+	fn exec_rotr<C: EvalContext>(&mut self, ctx: &mut C) {
+		let dst = self.read_reg();
+		let src = self.read_reg();
+		let rotate = self.read_u8() as u32;
+		for i in 0..ctx.n_instances() {
+			let val = ctx.load(src, i).rotr(rotate);
+			ctx.store(dst, i, val);
+		}
+	}
+
+	// Mask operations
+	fn exec_mask_low<C: EvalContext>(&mut self, ctx: &mut C) {
+		let dst = self.read_reg();
+		let src = self.read_reg();
+		let n_bits = self.read_u8();
+		// The mask depends only on the immediate, so build it once for the whole batch.
+		let mask = if n_bits >= 64 {
+			Word::ALL_ONE
+		} else {
+			Word::from_u64((1u64 << n_bits) - 1)
+		};
+		for i in 0..ctx.n_instances() {
+			let val = ctx.load(src, i) & mask;
+			ctx.store(dst, i, val);
+		}
+	}
+
+	fn exec_mask_high<C: EvalContext>(&mut self, ctx: &mut C) {
+		let dst = self.read_reg();
+		let src = self.read_reg();
+		let n_bits = self.read_u8();
+		// The mask depends only on the immediate, so build it once for the whole batch.
+		let mask = if n_bits >= 64 {
+			Word::ALL_ONE
+		} else {
+			Word::from_u64(!((1u64 << (64 - n_bits)) - 1))
+		};
+		for i in 0..ctx.n_instances() {
+			let val = ctx.load(src, i) & mask;
+			ctx.store(dst, i, val);
+		}
+	}
+
+	// Assertions
+	fn exec_assert_eq<C: EvalContext>(&mut self, ctx: &mut C) {
+		let src1 = self.read_reg();
+		let src2 = self.read_reg();
+		let error_id = self.read_u32();
+		let path_spec = PathSpec::from_u32(error_id);
+
+		for i in 0..ctx.n_instances() {
+			let val1 = ctx.load(src1, i);
+			let val2 = ctx.load(src2, i);
+			if val1 != val2 {
+				ctx.note_assertion_failure(i, path_spec, format!("{val1:?} != {val2:?}"));
+			}
+		}
+	}
+
+	fn exec_assert_eq_cond<C: EvalContext>(&mut self, ctx: &mut C) {
+		let cond = self.read_reg();
+		let src1 = self.read_reg();
+		let src2 = self.read_reg();
+		let error_id = self.read_u32();
+		let path_spec = PathSpec::from_u32(error_id);
+
+		for i in 0..ctx.n_instances() {
+			if ctx.load(cond, i).is_msb_true() {
+				let val1 = ctx.load(src1, i);
+				let val2 = ctx.load(src2, i);
+				if val1 != val2 {
+					ctx.note_assertion_failure(
+						i,
+						path_spec,
+						format!("conditional assert: {val1:?} != {val2:?}"),
+					);
+				}
+			}
+		}
+	}
+
+	fn exec_assert_zero<C: EvalContext>(&mut self, ctx: &mut C) {
+		let src = self.read_reg();
+		let error_id = self.read_u32();
+		let path_spec = PathSpec::from_u32(error_id);
+
+		for i in 0..ctx.n_instances() {
+			let val = ctx.load(src, i);
+			if val != Word::ZERO {
+				ctx.note_assertion_failure(i, path_spec, format!("{val:?} != 0"));
+			}
+		}
+	}
+
+	fn exec_assert_non_zero<C: EvalContext>(&mut self, ctx: &mut C) {
+		let src = self.read_reg();
+		let error_id = self.read_u32();
+		let path_spec = PathSpec::from_u32(error_id);
+
+		for i in 0..ctx.n_instances() {
+			let val = ctx.load(src, i);
+			if val == Word::ZERO {
+				ctx.note_assertion_failure(i, path_spec, format!("{val:?} == 0"));
+			}
+		}
+	}
+
+	fn exec_assert_false<C: EvalContext>(&mut self, ctx: &mut C) {
+		let src = self.read_reg();
+		let error_id = self.read_u32();
+		let path_spec = PathSpec::from_u32(error_id);
+
+		for i in 0..ctx.n_instances() {
+			let val = ctx.load(src, i);
+			if val.is_msb_true() {
+				ctx.note_assertion_failure(i, path_spec, format!("{val:?} MSB is true"));
+			}
+		}
+	}
+
+	fn exec_assert_true<C: EvalContext>(&mut self, ctx: &mut C) {
+		let src = self.read_reg();
+		let error_id = self.read_u32();
+		let path_spec = PathSpec::from_u32(error_id);
+
+		for i in 0..ctx.n_instances() {
+			let val = ctx.load(src, i);
+			if val.is_msb_false() {
+				ctx.note_assertion_failure(i, path_spec, format!("{val:?} MSB is false"));
+			}
+		}
+	}
+
+	// Hint execution
+	fn exec_hint<C: EvalContext>(&mut self, ctx: &mut C) {
+		let hint_id = self.read_u32();
+
+		// Read dimensions
+		let n_dimensions = self.read_u16() as usize;
+		let mut dimensions = Vec::with_capacity(n_dimensions);
+		for _ in 0..n_dimensions {
+			dimensions.push(self.read_u32() as usize);
+		}
+
+		let n_inputs = self.read_u16() as usize;
+		let n_outputs = self.read_u16() as usize;
+
+		// Read the input and output registers once; they are shared across every instance.
+		let input_regs = (0..n_inputs).map(|_| self.read_reg()).collect::<Vec<_>>();
+		let output_regs = (0..n_outputs).map(|_| self.read_reg()).collect::<Vec<_>>();
+
+		let mut inputs = vec![Word::ZERO; n_inputs];
+		let mut outputs = vec![Word::ZERO; n_outputs];
+		for i in 0..ctx.n_instances() {
+			for (input, &reg) in inputs.iter_mut().zip(&input_regs) {
+				*input = ctx.load(reg, i);
+			}
+			self.hints
+				.execute(hint_id, &dimensions, &inputs, &mut outputs);
+			for (&reg, &output) in output_regs.iter().zip(&outputs) {
+				ctx.store(reg, i, output);
+			}
+		}
+	}
+
+	// Bytecode reading helpers
+	fn read_u8(&mut self) -> u8 {
+		let val = self.bytecode[self.pc];
+		self.pc += 1;
+		val
+	}
+
+	fn read_u16(&mut self) -> u16 {
+		let val = u16::from_le_bytes([self.bytecode[self.pc], self.bytecode[self.pc + 1]]);
+		self.pc += 2;
+		val
+	}
+
+	fn read_u32(&mut self) -> u32 {
+		let val = u32::from_le_bytes([
+			self.bytecode[self.pc],
+			self.bytecode[self.pc + 1],
+			self.bytecode[self.pc + 2],
+			self.bytecode[self.pc + 3],
+		]);
+		self.pc += 4;
+		val
+	}
+
+	fn read_reg(&mut self) -> u32 {
+		self.read_u32()
+	}
+}

--- a/crates/frontend/src/compiler/eval_form/exec.rs
+++ b/crates/frontend/src/compiler/eval_form/exec.rs
@@ -21,7 +21,7 @@ use crate::compiler::{hints::HintRegistry, pathspec::PathSpec};
 /// A register names a value-vector index.
 /// Reading or writing a register targets that index within one chosen instance.
 /// So an instruction is applied once per instance.
-pub(crate) trait EvalContext {
+pub trait EvalContext {
 	/// The number of independent instances evaluated in lockstep.
 	fn n_instances(&self) -> usize;
 
@@ -43,14 +43,14 @@ pub(crate) trait EvalContext {
 /// The cursor advances as the dispatch loop consumes opcodes and operands.
 /// One executor drives one pass over the bytecode.
 /// The interpreters build a fresh executor per run, so the cursor starts at the first instruction.
-pub(crate) struct Executor<'a> {
+pub struct Executor<'a> {
 	bytecode: &'a [u8],
 	hints: &'a HintRegistry,
 	pc: usize,
 }
 
 impl<'a> Executor<'a> {
-	pub(crate) const fn new(bytecode: &'a [u8], hints: &'a HintRegistry) -> Self {
+	pub const fn new(bytecode: &'a [u8], hints: &'a HintRegistry) -> Self {
 		Self {
 			bytecode,
 			hints,
@@ -67,7 +67,7 @@ impl<'a> Executor<'a> {
 	/// # Panics
 	///
 	/// Panics on an unknown opcode, which can only happen if the bytecode is malformed.
-	pub(crate) fn run<C: EvalContext>(&mut self, ctx: &mut C) {
+	pub fn run<C: EvalContext>(&mut self, ctx: &mut C) {
 		while self.pc < self.bytecode.len() {
 			let opcode = self.read_u8();
 			match opcode {

--- a/crates/frontend/src/compiler/eval_form/interpreter.rs
+++ b/crates/frontend/src/compiler/eval_form/interpreter.rs
@@ -1,9 +1,14 @@
 // Copyright 2025-2026 The Binius Developers
 // Copyright 2025 Irreducible Inc.
-//! Bytecode interpreter for circuit evaluation
+//! Single-instance bytecode interpreter for circuit evaluation.
+//!
+//! This is the one-instance case of the shared executor.
+//! It evaluates the bytecode against a single value vector.
+//! The batched counterpart evaluates many instances at once.
 
 use binius_core::{ValueIndex, ValueVec, Word};
 
+use super::exec::{EvalContext, Executor};
 use crate::compiler::{
 	circuit::PopulateError,
 	hints::HintRegistry,
@@ -35,19 +40,6 @@ impl<'a> ExecutionContext<'a> {
 			value_vec,
 			assertion_failures: Vec::new(),
 			assertion_count: 0,
-		}
-	}
-
-	/// Record an assertion failure with the given path spec and message.
-	///
-	/// Note that this assertion might be discarded in case there is already too many recorded
-	/// assertions.
-	#[cold]
-	fn note_assertion_failure(&mut self, path_spec: PathSpec, message: String) {
-		self.assertion_count += 1;
-		if self.assertion_failures.len() < MAX_ASSERTION_FAILURES {
-			self.assertion_failures
-				.push(AssertionFailure { path_spec, message });
 		}
 	}
 
@@ -89,21 +81,42 @@ impl<'a> ExecutionContext<'a> {
 	}
 }
 
+impl EvalContext for ExecutionContext<'_> {
+	// One value vector: a single instance.
+	fn n_instances(&self) -> usize {
+		1
+	}
+
+	fn load(&self, reg: u32, _instance: usize) -> Word {
+		self.value_vec[ValueIndex(reg)]
+	}
+
+	fn store(&mut self, reg: u32, _instance: usize, value: Word) {
+		self.value_vec[ValueIndex(reg)] = value;
+	}
+
+	#[cold]
+	fn note_assertion_failure(&mut self, _instance: usize, path_spec: PathSpec, message: String) {
+		self.assertion_count += 1;
+		if self.assertion_failures.len() < MAX_ASSERTION_FAILURES {
+			self.assertion_failures
+				.push(AssertionFailure { path_spec, message });
+		}
+	}
+}
+
 pub struct Interpreter<'a> {
-	bytecode: &'a [u8],
-	hints: &'a HintRegistry,
-	pc: usize,
+	executor: Executor<'a>,
 }
 
 impl<'a> Interpreter<'a> {
 	pub const fn new(bytecode: &'a [u8], hints: &'a HintRegistry) -> Self {
 		Self {
-			bytecode,
-			hints,
-			pc: 0,
+			executor: Executor::new(bytecode, hints),
 		}
 	}
 
+	/// Evaluate the bytecode against `value_vec`, returning any assertion failures as an error.
 	pub fn run_with_value_vec(
 		&mut self,
 		value_vec: &mut ValueVec,
@@ -114,439 +127,12 @@ impl<'a> Interpreter<'a> {
 		ctx.check_assertions(path_spec_tree)
 	}
 
+	/// Evaluate the bytecode against a caller-owned context.
+	///
+	/// Assertion failures are recorded on the context.
+	/// Call the context's assertion check to turn them into an error.
 	pub fn run(&mut self, ctx: &mut ExecutionContext<'_>) -> Result<(), PopulateError> {
-		while self.pc < self.bytecode.len() {
-			let opcode = self.read_u8();
-
-			match opcode {
-				// Bitwise operations
-				0x01 => self.exec_band(ctx),
-				0x02 => self.exec_bor(ctx),
-				0x03 => self.exec_bxor(ctx),
-				0x05 => self.exec_select(ctx),
-				0x06 => self.exec_bxor_multi(ctx),
-				0x07 => self.exec_fax(ctx),
-
-				// Shifts
-				0x10 => self.exec_sll(ctx),
-				0x11 => self.exec_slr(ctx),
-				0x12 => self.exec_sar(ctx),
-
-				// Arithmetic
-				0x20 => self.exec_iadd_cout(ctx),
-				0x21 => self.exec_iadd_cin_cout(ctx),
-				0x23 => self.exec_isub_bin_bout(ctx),
-				0x30 => self.exec_imul(ctx),
-
-				// 32-bit operations
-				0x40 => self.exec_iadd32_cin_cout(ctx),
-				0x41 => self.exec_rotr32(ctx),
-				0x42 => self.exec_srl32(ctx),
-				0x43 => self.exec_rotr(ctx),
-				0x44 => self.exec_sll32(ctx),
-				0x45 => self.exec_sra32(ctx),
-				0x46 => self.exec_iadd32_cout(ctx),
-
-				// Masks
-				0x50 => self.exec_mask_low(ctx),
-				0x51 => self.exec_mask_high(ctx),
-
-				// Assertions
-				0x60 => self.exec_assert_eq(ctx),
-				0x61 => self.exec_assert_eq_cond(ctx),
-				0x62 => self.exec_assert_zero(ctx),
-				0x63 => self.exec_assert_non_zero(ctx),
-				0x64 => self.exec_assert_false(ctx),
-				0x65 => self.exec_assert_true(ctx),
-
-				// Hint calls
-				0x80 => self.exec_hint(ctx),
-
-				_ => panic!("Unknown opcode: {:#x} at pc={}", opcode, self.pc - 1),
-			}
-		}
+		self.executor.run(ctx);
 		Ok(())
-	}
-
-	// Bitwise operations
-	fn exec_band(&mut self, ctx: &mut ExecutionContext<'_>) {
-		let dst = self.read_reg();
-		let src1 = self.read_reg();
-		let src2 = self.read_reg();
-		let val = self.load(ctx, src1) & self.load(ctx, src2);
-		self.store(ctx, dst, val);
-	}
-
-	fn exec_bor(&mut self, ctx: &mut ExecutionContext<'_>) {
-		let dst = self.read_reg();
-		let src1 = self.read_reg();
-		let src2 = self.read_reg();
-		let val = self.load(ctx, src1) | self.load(ctx, src2);
-		self.store(ctx, dst, val);
-	}
-
-	fn exec_bxor(&mut self, ctx: &mut ExecutionContext<'_>) {
-		let dst = self.read_reg();
-		let src1 = self.read_reg();
-		let src2 = self.read_reg();
-		let val = self.load(ctx, src1) ^ self.load(ctx, src2);
-		self.store(ctx, dst, val);
-	}
-
-	fn exec_select(&mut self, ctx: &mut ExecutionContext<'_>) {
-		let dst = self.read_reg();
-		let cond = self.read_reg();
-		let t = self.read_reg();
-		let f = self.read_reg();
-		// Select t if MSB(cond) is 1, otherwise select f
-		let cond_val = self.load(ctx, cond);
-		let val = if cond_val.is_msb_true() {
-			self.load(ctx, t)
-		} else {
-			self.load(ctx, f)
-		};
-		self.store(ctx, dst, val);
-	}
-
-	fn exec_bxor_multi(&mut self, ctx: &mut ExecutionContext<'_>) {
-		let dst = self.read_reg();
-		let n = self.read_u32() as usize;
-		let mut val = Word::ZERO;
-		for _ in 0..n {
-			let src = self.read_reg();
-			val = val ^ self.load(ctx, src);
-		}
-		self.store(ctx, dst, val);
-	}
-
-	fn exec_fax(&mut self, ctx: &mut ExecutionContext<'_>) {
-		let dst = self.read_reg();
-		let src1 = self.read_reg();
-		let src2 = self.read_reg();
-		let src3 = self.read_reg();
-		let val = (self.load(ctx, src1) & self.load(ctx, src2)) ^ self.load(ctx, src3);
-		self.store(ctx, dst, val);
-	}
-
-	// Shifts
-	fn exec_sll(&mut self, ctx: &mut ExecutionContext<'_>) {
-		let dst = self.read_reg();
-		let src = self.read_reg();
-		let shift = self.read_u8() as u32;
-		let val = self.load(ctx, src) << shift;
-		self.store(ctx, dst, val);
-	}
-
-	fn exec_slr(&mut self, ctx: &mut ExecutionContext<'_>) {
-		let dst = self.read_reg();
-		let src = self.read_reg();
-		let shift = self.read_u8() as u32;
-		let val = self.load(ctx, src) >> shift;
-		self.store(ctx, dst, val);
-	}
-
-	fn exec_sar(&mut self, ctx: &mut ExecutionContext<'_>) {
-		let dst = self.read_reg();
-		let src = self.read_reg();
-		let shift = self.read_u8() as u32;
-		let val = self.load(ctx, src).sar(shift);
-		self.store(ctx, dst, val);
-	}
-
-	// Arithmetic operations
-	fn exec_iadd_cout(&mut self, ctx: &mut ExecutionContext<'_>) {
-		let dst_sum = self.read_reg();
-		let dst_cout = self.read_reg();
-		let src1 = self.read_reg();
-		let src2 = self.read_reg();
-		let (sum, cout) = self
-			.load(ctx, src1)
-			.iadd_cin_cout(self.load(ctx, src2), Word::ZERO);
-		self.store(ctx, dst_sum, sum);
-		self.store(ctx, dst_cout, cout);
-	}
-
-	fn exec_iadd_cin_cout(&mut self, ctx: &mut ExecutionContext<'_>) {
-		let dst_sum = self.read_reg();
-		let dst_cout = self.read_reg();
-		let src1 = self.read_reg();
-		let src2 = self.read_reg();
-		let cin = self.read_reg();
-		let cin_bit = self.load(ctx, cin) >> 63; // Use MSB as carry bit
-		let (sum, cout) = self
-			.load(ctx, src1)
-			.iadd_cin_cout(self.load(ctx, src2), cin_bit);
-		self.store(ctx, dst_sum, sum);
-		self.store(ctx, dst_cout, cout);
-	}
-
-	fn exec_isub_bin_bout(&mut self, ctx: &mut ExecutionContext<'_>) {
-		let dst_diff = self.read_reg();
-		let dst_bout = self.read_reg();
-		let src1 = self.read_reg();
-		let src2 = self.read_reg();
-		let bin = self.read_reg();
-		let bin_bit = self.load(ctx, bin) >> 63; // Use MSB as borrow bit
-		let (diff, bout) = self
-			.load(ctx, src1)
-			.isub_bin_bout(self.load(ctx, src2), bin_bit);
-		self.store(ctx, dst_diff, diff);
-		self.store(ctx, dst_bout, bout);
-	}
-
-	fn exec_imul(&mut self, ctx: &mut ExecutionContext<'_>) {
-		let dst_hi = self.read_reg();
-		let dst_lo = self.read_reg();
-		let src1 = self.read_reg();
-		let src2 = self.read_reg();
-		let (hi, lo) = self.load(ctx, src1).imul(self.load(ctx, src2));
-		self.store(ctx, dst_hi, hi);
-		self.store(ctx, dst_lo, lo);
-	}
-
-	// 32-bit operations
-	fn exec_iadd32_cin_cout(&mut self, ctx: &mut ExecutionContext<'_>) {
-		let dst_sum = self.read_reg();
-		let dst_cout = self.read_reg();
-		let src1 = self.read_reg();
-		let src2 = self.read_reg();
-		let cin = self.read_reg();
-		let (sum, cout) = self
-			.load(ctx, src1)
-			.iadd32_cin_cout(self.load(ctx, src2), self.load(ctx, cin));
-		self.store(ctx, dst_sum, sum);
-		self.store(ctx, dst_cout, cout);
-	}
-
-	fn exec_iadd32_cout(&mut self, ctx: &mut ExecutionContext<'_>) {
-		let dst_sum = self.read_reg();
-		let dst_cout = self.read_reg();
-		let src1 = self.read_reg();
-		let src2 = self.read_reg();
-		let (sum, cout) = self.load(ctx, src1).iadd_cout_32(self.load(ctx, src2));
-		self.store(ctx, dst_sum, sum);
-		self.store(ctx, dst_cout, cout);
-	}
-
-	fn exec_rotr32(&mut self, ctx: &mut ExecutionContext<'_>) {
-		let dst = self.read_reg();
-		let src = self.read_reg();
-		let rotate = self.read_u8() as u32;
-		let val = self.load(ctx, src).rotr32(rotate);
-		self.store(ctx, dst, val);
-	}
-
-	fn exec_srl32(&mut self, ctx: &mut ExecutionContext<'_>) {
-		let dst = self.read_reg();
-		let src = self.read_reg();
-		let shift = self.read_u8() as u32;
-		let val = self.load(ctx, src).srl32(shift);
-		self.store(ctx, dst, val);
-	}
-
-	fn exec_sll32(&mut self, ctx: &mut ExecutionContext<'_>) {
-		let dst = self.read_reg();
-		let src = self.read_reg();
-		let shift = self.read_u8() as u32;
-		let val = self.load(ctx, src).sll32(shift);
-		self.store(ctx, dst, val);
-	}
-
-	fn exec_sra32(&mut self, ctx: &mut ExecutionContext<'_>) {
-		let dst = self.read_reg();
-		let src = self.read_reg();
-		let shift = self.read_u8() as u32;
-		let val = self.load(ctx, src).sra32(shift);
-		self.store(ctx, dst, val);
-	}
-
-	fn exec_rotr(&mut self, ctx: &mut ExecutionContext<'_>) {
-		let dst = self.read_reg();
-		let src = self.read_reg();
-		let rotate = self.read_u8() as u32;
-		let val = self.load(ctx, src).rotr(rotate);
-		self.store(ctx, dst, val);
-	}
-
-	// Mask operations
-	fn exec_mask_low(&mut self, ctx: &mut ExecutionContext<'_>) {
-		let dst = self.read_reg();
-		let src = self.read_reg();
-		let n_bits = self.read_u8();
-		let mask = if n_bits >= 64 {
-			Word::ALL_ONE
-		} else {
-			Word::from_u64((1u64 << n_bits) - 1)
-		};
-		let val = self.load(ctx, src) & mask;
-		self.store(ctx, dst, val);
-	}
-
-	fn exec_mask_high(&mut self, ctx: &mut ExecutionContext<'_>) {
-		let dst = self.read_reg();
-		let src = self.read_reg();
-		let n_bits = self.read_u8();
-		let mask = if n_bits >= 64 {
-			Word::ALL_ONE
-		} else {
-			Word::from_u64(!((1u64 << (64 - n_bits)) - 1))
-		};
-		let val = self.load(ctx, src) & mask;
-		self.store(ctx, dst, val);
-	}
-
-	// Assertions
-	fn exec_assert_eq(&mut self, ctx: &mut ExecutionContext<'_>) {
-		let src1 = self.read_reg();
-		let src2 = self.read_reg();
-		let error_id = self.read_u32();
-		let path_spec = PathSpec::from_u32(error_id);
-
-		let val1 = self.load(ctx, src1);
-		let val2 = self.load(ctx, src2);
-
-		if val1 != val2 {
-			ctx.note_assertion_failure(path_spec, format!("{val1:?} != {val2:?}"));
-		}
-	}
-
-	fn exec_assert_eq_cond(&mut self, ctx: &mut ExecutionContext<'_>) {
-		let cond = self.read_reg();
-		let src1 = self.read_reg();
-		let src2 = self.read_reg();
-		let error_id = self.read_u32();
-		let path_spec = PathSpec::from_u32(error_id);
-
-		let cond_val = self.load(ctx, cond);
-
-		if cond_val.is_msb_true() {
-			let val1 = self.load(ctx, src1);
-			let val2 = self.load(ctx, src2);
-
-			if val1 != val2 {
-				ctx.note_assertion_failure(
-					path_spec,
-					format!("conditional assert: {val1:?} != {val2:?}"),
-				);
-			}
-		}
-	}
-
-	fn exec_assert_zero(&mut self, ctx: &mut ExecutionContext<'_>) {
-		let src = self.read_reg();
-		let error_id = self.read_u32();
-		let path_spec = PathSpec::from_u32(error_id);
-
-		let val = self.load(ctx, src);
-
-		if val != Word::ZERO {
-			ctx.note_assertion_failure(path_spec, format!("{val:?} != 0"));
-		}
-	}
-
-	fn exec_assert_non_zero(&mut self, ctx: &mut ExecutionContext<'_>) {
-		let src = self.read_reg();
-		let error_id = self.read_u32();
-		let path_spec = PathSpec::from_u32(error_id);
-
-		let val = self.load(ctx, src);
-
-		if val == Word::ZERO {
-			ctx.note_assertion_failure(path_spec, format!("{val:?} == 0"));
-		}
-	}
-
-	fn exec_assert_false(&mut self, ctx: &mut ExecutionContext<'_>) {
-		let src = self.read_reg();
-		let error_id = self.read_u32();
-		let path_spec = PathSpec::from_u32(error_id);
-
-		let val = self.load(ctx, src);
-
-		if val.is_msb_true() {
-			ctx.note_assertion_failure(path_spec, format!("{val:?} MSB is true"));
-		}
-	}
-
-	fn exec_assert_true(&mut self, ctx: &mut ExecutionContext<'_>) {
-		let src = self.read_reg();
-		let error_id = self.read_u32();
-		let path_spec = PathSpec::from_u32(error_id);
-
-		let val = self.load(ctx, src);
-
-		if val.is_msb_false() {
-			ctx.note_assertion_failure(path_spec, format!("{val:?} MSB is false"));
-		}
-	}
-
-	// Hint execution
-	fn exec_hint(&mut self, ctx: &mut ExecutionContext<'_>) {
-		let hint_id = self.read_u32();
-
-		// Read dimensions
-		let n_dimensions = self.read_u16() as usize;
-		let mut dimensions = Vec::with_capacity(n_dimensions);
-		for _ in 0..n_dimensions {
-			dimensions.push(self.read_u32() as usize);
-		}
-
-		let n_inputs = self.read_u16() as usize;
-		let n_outputs = self.read_u16() as usize;
-
-		// Collect input values
-		let mut inputs = Vec::with_capacity(n_inputs);
-		for _ in 0..n_inputs {
-			let reg = self.read_reg();
-			inputs.push(self.load(ctx, reg));
-		}
-
-		// Prepare output buffer
-		let mut outputs = vec![Word::ZERO; n_outputs];
-
-		self.hints
-			.execute(hint_id, &dimensions, &inputs, &mut outputs);
-
-		// Store outputs
-		for output_val in outputs {
-			let dst = self.read_reg();
-			self.store(ctx, dst, output_val);
-		}
-	}
-
-	fn load(&self, ctx: &ExecutionContext<'_>, reg: u32) -> Word {
-		ctx.value_vec[ValueIndex(reg)]
-	}
-
-	fn store(&self, ctx: &mut ExecutionContext<'_>, reg: u32, value: Word) {
-		ctx.value_vec[ValueIndex(reg)] = value;
-	}
-
-	// Bytecode reading helpers
-	fn read_u8(&mut self) -> u8 {
-		let val = self.bytecode[self.pc];
-		self.pc += 1;
-		val
-	}
-
-	fn read_u16(&mut self) -> u16 {
-		let val = u16::from_le_bytes([self.bytecode[self.pc], self.bytecode[self.pc + 1]]);
-		self.pc += 2;
-		val
-	}
-
-	fn read_u32(&mut self) -> u32 {
-		let val = u32::from_le_bytes([
-			self.bytecode[self.pc],
-			self.bytecode[self.pc + 1],
-			self.bytecode[self.pc + 2],
-			self.bytecode[self.pc + 3],
-		]);
-		self.pc += 4;
-		val
-	}
-
-	fn read_reg(&mut self) -> u32 {
-		self.read_u32()
 	}
 }

--- a/crates/frontend/src/compiler/eval_form/mod.rs
+++ b/crates/frontend/src/compiler/eval_form/mod.rs
@@ -8,6 +8,7 @@
 mod batch_interpreter;
 mod builder;
 mod const_eval;
+mod exec;
 mod interpreter;
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
Part of [BINIUS-247](https://linear.app/jimpo/issue/BINIUS-247/adopt-valuetable2-across-m4-and-remove-valuetable) — the second checklist item ("deduplicate `BatchInterpreter` and the single-instance `Interpreter` via a shared trait over the eval/execution context"). That issue has several bullet points; this is one of several PRs and does **not** close it.

Merges the two circuit interpreters into one shared executor. Pure refactor — no behavior change.

### The problem

A circuit is a little bytecode program: `AND` two words, shift one right by 7, assert two are equal. Something has to run it to fill in every wire value.

There were two runners doing exactly that:
- single-instance: runs the program once, on one value vector.
- batched: runs the same program on many instances at once (the data-parallel prover path).

They did the **same thing** opcode for opcode. The ~40-branch dispatch, every operation handler, and the bytecode readers all existed **twice** — differing only in *where* a decoded instruction reads and writes.

That is a maintenance trap: touch one opcode and you must edit both copies identically, or the batched prover silently disagrees with the single-instance one.

### The idea

Look at what actually differs between the two. It is tiny:

```
                read a value        write a value
single:         one value vector    one value vector
batched:        column i of a       column i of a
                wide table          wide table
```

The operation logic is identical. Only "where do I read/write" differs.

So put that one difference behind a small trait over the execution context:
- how many instances?
- read register `r` of instance `i`?
- write register `r` of instance `i`?
- note an assertion failure for instance `i`?

Then write the opcode logic **once**, as "for each instance `i`, apply the operation". The single-instance interpreter is just the case where there is **one** instance.

### Per opcode

Take `AND dst, src1, src2`.

```
// before — two hand-written copies
single:   dst        = src1 & src2
batched:  for i:  dst[i] = src1[i] & src2[i]

// after — one copy, parameterized by the context
for i in 0..ctx.n_instances():
    v = ctx.load(src1, i) & ctx.load(src2, i)
    ctx.store(dst, i, v)
```

- single context: `n_instances() == 1`, so the loop runs once and reads/writes the lone value vector. The `0..1` loop inlines away.
- batched context: `n_instances()` is the column count, so the loop covers every instance.

Same source line, both behaviors — chosen purely by which context is handed in.

### The change

```
- interpreter.rs:      own copy of the dispatch + all exec_* handlers + readers
- batch_interpreter.rs: own copy of the dispatch + all exec_* handlers + readers
+ exec.rs:             the dispatch + all exec_* handlers + readers, once, over a trait
```

- The single-instance interpreter and the batched interpreter are now thin wrappers that build a context and hand it to the shared executor.
- Net: +630 / -966 lines across the four files.

### Soundness / behavior preservation

This is a pure refactor; two details are load-bearing and were kept identical:
- **Assertion diagnostics.** The failure message text and the blamed instance index are byte-for-byte the same. The batched context adds its stripe's global offset; the single context ignores the index.
- **Hint reads.** The one opcode that calls out to external hint code now reads its output registers up front (the batched order) instead of interleaved. Same bytes consumed in the same order, so behavior is unchanged.

The batched-machine-code path is unchanged (same monomorphization). The single-instance path gains a `0..1` loop that the compiler elides.

### Scope

- **new:** `crates/frontend/src/compiler/eval_form/exec.rs` — the shared trait and executor.
- **changed:** `interpreter.rs` and `batch_interpreter.rs` reduced to wrappers; `mod.rs` registers the new module.
- **left untouched:** the public API of both interpreters, the bytecode format, and the equivalence tests.

### Verification

- `cargo check -p binius-frontend --all-targets` — clean
- `cargo clippy -p binius-frontend --all-targets` — clean
- `cargo +nightly fmt --all -- --check` — clean
- `cargo test -p binius-frontend` — 161 + 2 pass, including the batched-equals-single equivalence test and the assertion-path tests
- `cargo test -p binius-m4-prover value_table2` — 9 pass (real-circuit batch witness generation, parallel stripes, failure diagnostics)

Note: `cargo check --workspace --all-targets` fails on `evaluate_batched_parallel` (a rayon feature-unification quirk with `into_par_strides`). This reproduces on a clean `main` and is unrelated to this change, so it is left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)