### PR TITLE
BINIUS-260: split Monbijou multiplications into wide_mul and reduce

### DIFF
--- a/crates/arith-bench/benches/field_mul.rs
+++ b/crates/arith-bench/benches/field_mul.rs
@@ -153,14 +153,16 @@ fn run_unary_op_benchmark<T, R>(
 /// `T` is the underlier of the operands (`u128` for the software path, a SIMD type for the packed
 /// paths) and `W` the unreduced product accumulator — either a field element (reduce-every-term) or
 /// a multi-limb product like `[u64; 4]` / `[__m128i; 3]`, all [`Underlier`]s (arrays via the
-/// blanket impl), so accumulation is `W::xor`. Each GHASH element is 128 bits, so a `T`-wide
-/// underlier carries `T::BITS / 128` inner-product terms.
+/// blanket impl), so accumulation is `W::xor`. `element_bits` is the field element size (e.g. 128
+/// for GHASH, 64 for the base Monbijou field), so a `T`-wide underlier carries `T::BITS /
+/// element_bits` inner-product terms.
 fn run_inner_product_benchmark<T, W, R>(
 	group: &mut BenchmarkGroup<'_, criterion::measurement::WallTime>,
 	name: &str,
 	wide_mul: impl Fn(T, T) -> W,
 	mut rng: R,
 	log_len: usize,
+	element_bits: usize,
 ) where
 	T: Underlier,
 	W: Underlier,
@@ -170,7 +172,7 @@ fn run_inner_product_benchmark<T, W, R>(
 	let a: Vec<T> = (0..len).map(|_| T::random(&mut rng)).collect();
 	let b: Vec<T> = (0..len).map(|_| T::random(&mut rng)).collect();
 
-	let elements_per_underlier = T::BITS / 128;
+	let elements_per_underlier = T::BITS / element_bits;
 	group.throughput(Throughput::Elements((len * elements_per_underlier) as u64));
 	group.bench_function(name, |bencher| {
 		bencher.iter(|| {
@@ -841,7 +843,14 @@ fn bench_ghash_inner_product(c: &mut Criterion) {
 	let mut group = c.benchmark_group("ghash_inner_product");
 
 	// Baseline: reduce each product, accumulate the reduced GHASH elements.
-	run_inner_product_benchmark(&mut group, "soft64::mul", ghash::soft64::mul, &mut rng, LOG_LEN);
+	run_inner_product_benchmark(
+		&mut group,
+		"soft64::mul",
+		ghash::soft64::mul,
+		&mut rng,
+		LOG_LEN,
+		128,
+	);
 
 	// Widening: accumulate the unreduced four-limb products by XOR, skip the final reduction.
 	run_inner_product_benchmark(
@@ -850,6 +859,7 @@ fn bench_ghash_inner_product(c: &mut Criterion) {
 		ghash::soft64::mul_wide,
 		&mut rng,
 		LOG_LEN,
+		128,
 	);
 
 	// CLMUL path (__m128i): the reduction is a larger fraction of a single fast pclmulqdq multiply,
@@ -864,6 +874,7 @@ fn bench_ghash_inner_product(c: &mut Criterion) {
 			clmul::mul::<__m128i>,
 			&mut rng,
 			LOG_LEN,
+			128,
 		);
 
 		run_inner_product_benchmark(
@@ -872,6 +883,7 @@ fn bench_ghash_inner_product(c: &mut Criterion) {
 			clmul::mul_wide::<__m128i>,
 			&mut rng,
 			LOG_LEN,
+			128,
 		);
 	}
 
@@ -899,6 +911,7 @@ fn bench_ghash_sq_inner_product(c: &mut Criterion) {
 		ghash_sq::soft64::mul_sliced,
 		&mut rng,
 		LOG_LEN,
+		128,
 	);
 
 	// Widening: accumulate the unreduced coefficients by XOR, reduce once at the very end.
@@ -908,6 +921,7 @@ fn bench_ghash_sq_inner_product(c: &mut Criterion) {
 		ghash_sq::soft64::mul_wide_sliced,
 		&mut rng,
 		LOG_LEN,
+		128,
 	);
 
 	#[cfg(all(target_feature = "pclmulqdq", target_feature = "sse2"))]
@@ -918,6 +932,7 @@ fn bench_ghash_sq_inner_product(c: &mut Criterion) {
 			ghash_sq::x86_64::mul_sliced::<__m128i>,
 			&mut rng,
 			LOG_LEN,
+			128,
 		);
 
 		run_inner_product_benchmark(
@@ -926,6 +941,59 @@ fn bench_ghash_sq_inner_product(c: &mut Criterion) {
 			ghash_sq::x86_64::mul_wide_sliced::<__m128i>,
 			&mut rng,
 			LOG_LEN,
+			128,
+		);
+	}
+
+	group.finish();
+}
+
+/// Benchmark inner products over the base Monbijou field GF(2^64), contrasting the widening
+/// multiply (accumulate the unreduced products, reduce once) against the reduce-every-term
+/// multiply.
+#[allow(unused_imports, unused_variables, unused_mut)]
+fn bench_monbijou_inner_product(c: &mut Criterion) {
+	use binius_arith_bench::monbijou::{clmul, soft64};
+
+	/// Length of the inner product. Long enough that the single skipped final reduction is
+	/// negligible.
+	const LOG_LEN: usize = 10;
+
+	let mut rng = rand::rng();
+
+	let mut group = c.benchmark_group("monbijou_inner_product");
+
+	// Baseline: reduce each product, accumulate the reduced base-field elements.
+	run_inner_product_benchmark(&mut group, "soft64::mul", soft64::mul, &mut rng, LOG_LEN, 64);
+
+	// Widening: accumulate the unreduced [low, high] products by XOR, skip the final reduction.
+	run_inner_product_benchmark(
+		&mut group,
+		"soft64::mul_wide",
+		soft64::mul_wide,
+		&mut rng,
+		LOG_LEN,
+		64,
+	);
+
+	#[cfg(all(target_feature = "pclmulqdq", target_feature = "sse2"))]
+	{
+		run_inner_product_benchmark(
+			&mut group,
+			"clmul::mul::<__m128i>",
+			clmul::mul::<__m128i>,
+			&mut rng,
+			LOG_LEN,
+			64,
+		);
+
+		run_inner_product_benchmark(
+			&mut group,
+			"clmul::mul_wide::<__m128i>",
+			clmul::mul_wide::<__m128i>,
+			&mut rng,
+			LOG_LEN,
+			64,
 		);
 	}
 
@@ -942,5 +1010,6 @@ criterion_group!(
 	bench_monbijou_128b,
 	bench_ghash_inner_product,
 	bench_ghash_sq_inner_product,
+	bench_monbijou_inner_product,
 );
 criterion_main!(benches);

--- a/crates/arith-bench/src/monbijou/clmul.rs
+++ b/crates/arith-bench/src/monbijou/clmul.rs
@@ -9,19 +9,29 @@
 
 use crate::{PackedUnderlier, Underlier, underlier::OpsClmul};
 
+/// Widening (unreduced) Monbijou multiply: the two 128-bit carry-less products `[prod_0, prod_1]`,
+/// without the modular reduction.
+///
+/// The `0x00`/`0x11` immediates select the low·low and high·high halves of each 128-bit SIMD lane,
+/// i.e. the two independent base elements packed per lane. Because [`reduce`] is F2-linear, these
+/// products can be XOR-accumulated across many products and reduced only once — an inner product of
+/// `n` terms costs one reduction instead of `n`.
+#[inline]
+pub fn mul_wide<U: Underlier + OpsClmul + PackedUnderlier<u64>>(a: U, b: U) -> [U; 2] {
+	let prod_0 = U::clmulepi64::<0x00>(a, b); // 128-bit pre-reduction product elements 0
+	let prod_1 = U::clmulepi64::<0x11>(a, b); // 128-bit pre-reduction product elements 1
+	[prod_0, prod_1]
+}
+
 /// Multiplies two elements in GF(2^64) using SIMD carry-less multiplication.
 ///
 /// This function performs multiplication in the Monbijou field GF(2^64) defined by
-/// the reduction polynomial X^64 + X^4 + X^3 + X + 1. The algorithm uses a two-stage
-/// reduction process to efficiently handle the polynomial reduction after multiplication.
+/// the reduction polynomial X^64 + X^4 + X^3 + X + 1. Composes the widening multiply [`mul_wide`]
+/// with the two-stage [`reduce`]; both are inlined.
 #[inline]
 #[allow(dead_code)]
 pub fn mul<U: Underlier + OpsClmul + PackedUnderlier<u64>>(a: U, b: U) -> U {
-	// Step 1: Carry-less multiplication of 64-bit operands produces 128-bit results
-	// For SIMD types, this processes multiple pairs in parallel
-	let prod_0 = U::clmulepi64::<0x00>(a, b); // 128-bit pre-reduction product elements 0
-	let prod_1 = U::clmulepi64::<0x11>(a, b); // 128-bit pre-reduction product elements 1
-	reduce_pair(prod_0, prod_1)
+	reduce(mul_wide(a, b))
 }
 
 /// Multiplies two elements in GF(2^128), represented as a degree-2 extension of GF(2^64).
@@ -53,7 +63,7 @@ pub fn mul_128b<U: Underlier + OpsClmul + PackedUnderlier<u64>>(x: U, y: U) -> U
 	let term0 = U::xor(t0, t2);
 	let term1 = U::xor(t1, t2_times_x);
 
-	reduce_pair(term0, term1)
+	reduce([term0, term1])
 }
 
 /// Multiplies two elements of GF(2^128), the degree-2 extension of the Monbijou field, in
@@ -75,7 +85,7 @@ pub fn mul_128b<U: Underlier + OpsClmul + PackedUnderlier<u64>>(x: U, y: U) -> U
 /// ```
 ///
 /// The base-field products are kept unreduced and combined into the two output coefficients, so
-/// only a single `reduce_pair` is spent per coefficient (one reduction per element), matching
+/// only a single [`reduce`] is spent per coefficient (one reduction per element), matching
 /// [`mul_128b`]. The cross term `a0·b1 + a1·b0` is recovered from Karatsuba as `t1 + t0 +
 /// t2`.
 #[inline]
@@ -115,14 +125,20 @@ pub fn mul_sliced_128b<U: Underlier + OpsClmul + PackedUnderlier<u64>>(
 	let term1_lo = U::xor(U::xor(U::xor(t1_lo, t0_lo), t2_lo), t2x_lo);
 	let term1_hi = U::xor(U::xor(U::xor(t1_hi, t0_hi), t2_hi), t2x_hi);
 
-	let z0 = reduce_pair(term0_lo, term0_hi);
-	let z1 = reduce_pair(term1_lo, term1_hi);
+	let z0 = reduce([term0_lo, term0_hi]);
+	let z1 = reduce([term1_lo, term1_hi]);
 
 	[z0, z1]
 }
 
+/// Reduce a Monbijou widening product `[prod_0, prod_1]` (two 128-bit carry-less products) to a
+/// single packed base-field element, modulo X^64 + X^4 + X^3 + X + 1.
+///
+/// Two CLMUL folds by the low-degree terms `0x1B`; each lane's low 64 bits are packed into the
+/// output via `unpacklo_epi64`. This is an F2-linear map, so unreduced products may be summed by
+/// XOR and reduced once at the end.
 #[inline]
-fn reduce_pair<U: Underlier + OpsClmul + PackedUnderlier<u64>>(prod_0: U, prod_1: U) -> U {
+pub fn reduce<U: Underlier + OpsClmul + PackedUnderlier<u64>>([prod_0, prod_1]: [U; 2]) -> U {
 	// The reduction polynomial X^64 + X^4 + X^3 + X + 1 is represented as 0x1B
 	// This is the bit representation of the lower-degree terms (X^4 + X^3 + X + 1)
 	const POLY: u64 = 0x1B;
@@ -161,7 +177,8 @@ mod tests {
 
 	use proptest::prelude::*;
 
-	use super::{mul_128b, mul_sliced_128b};
+	use super::{mul, mul_128b, mul_sliced_128b, mul_wide, reduce};
+	use crate::{Underlier, monbijou::soft64};
 
 	// A packed GF(2^128) element is a `u128` with coefficient 0 in the low 64 bits and coefficient
 	// 1 in the high 64 bits, matching `__m128i`'s lane layout.
@@ -213,6 +230,29 @@ mod tests {
 
 			prop_assert_eq!(z0, packed_mul(a0, b0));
 			prop_assert_eq!(z1, packed_mul(a1, b1));
+		}
+
+		// The CLMUL base-field mul agrees with the soft64 reference (compared in lane 0).
+		#[test]
+		fn base_mul_matches_soft64(x in any::<u64>(), y in any::<u64>()) {
+			let to = |v: u64| unsafe { std::mem::transmute::<u128, __m128i>(v as u128) };
+			let got = unsafe { std::mem::transmute::<__m128i, u128>(mul::<__m128i>(to(x), to(y))) };
+			prop_assert_eq!(got as u64, soft64::mul(x, y));
+		}
+
+		// The reduction is F2-linear: accumulating two unreduced products by XOR and reducing once
+		// equals reducing each and summing (lane 0).
+		#[test]
+		fn base_wide_mul_deferred_reduction(
+			x1 in any::<u64>(), y1 in any::<u64>(),
+			x2 in any::<u64>(), y2 in any::<u64>(),
+		) {
+			let to = |v: u64| unsafe { std::mem::transmute::<u128, __m128i>(v as u128) };
+			let from = |v: __m128i| unsafe { std::mem::transmute::<__m128i, u128>(v) } as u64;
+			let [p0, p1] = mul_wide::<__m128i>(to(x1), to(y1));
+			let [q0, q1] = mul_wide::<__m128i>(to(x2), to(y2));
+			let acc = reduce([Underlier::xor(p0, q0), Underlier::xor(p1, q1)]);
+			prop_assert_eq!(from(acc), soft64::mul(x1, y1) ^ soft64::mul(x2, y2));
 		}
 	}
 }

--- a/crates/arith-bench/src/monbijou/soft64.rs
+++ b/crates/arith-bench/src/monbijou/soft64.rs
@@ -10,7 +10,7 @@ use crate::arch::portable64::{bmul64, rev64};
 /// Widening (unreduced) Monbijou multiply: the 128-bit carry-less product of two 64-bit polynomials
 /// as `[low, high]` 64-bit limbs, without the modular reduction.
 ///
-/// [`bmul64`] gives the low limb directly. The high limb comes from multiplying the bit-reversed
+/// `bmul64` gives the low limb directly. The high limb comes from multiplying the bit-reversed
 /// operands and reversing the result: reversing a product of two degree-`<64` polynomials leaves it
 /// shifted by one bit, which the final shift removes. Because [`reduce`] is F2-linear, these limbs
 /// can be XOR-accumulated across many products and reduced only once — an inner product of `n`

--- a/crates/arith-bench/src/monbijou/soft64.rs
+++ b/crates/arith-bench/src/monbijou/soft64.rs
@@ -7,26 +7,31 @@
 
 use crate::arch::portable64::{bmul64, rev64};
 
-/// The 128-bit carry-less product of two 64-bit polynomials, as `(low, high)` 64-bit limbs.
+/// Widening (unreduced) Monbijou multiply: the 128-bit carry-less product of two 64-bit polynomials
+/// as `[low, high]` 64-bit limbs, without the modular reduction.
 ///
 /// [`bmul64`] gives the low limb directly. The high limb comes from multiplying the bit-reversed
 /// operands and reversing the result: reversing a product of two degree-`<64` polynomials leaves it
-/// shifted by one bit, which the final shift removes.
+/// shifted by one bit, which the final shift removes. Because [`reduce`] is F2-linear, these limbs
+/// can be XOR-accumulated across many products and reduced only once — an inner product of `n`
+/// terms costs one reduction instead of `n`.
 #[inline]
-fn clmul64(x: u64, y: u64) -> (u64, u64) {
+pub fn mul_wide(x: u64, y: u64) -> [u64; 2] {
 	let lo = bmul64(x, y);
 	let hi = rev64(bmul64(rev64(x), rev64(y))) >> 1;
-	(lo, hi)
+	[lo, hi]
 }
 
-/// Reduces a 128-bit carry-less product, given as `(low, high)` limbs, modulo the Monbijou
+/// Reduces a 128-bit carry-less product, given as `[low, high]` limbs, modulo the Monbijou
 /// polynomial X^64 + X^4 + X^3 + X + 1.
 ///
 /// The high limb holds the coefficients of X^64..X^127. Folding it down is a carry-less multiply by
 /// X^64 ≡ `0x1B` (`= 1 + X + X^3 + X^4`). The left shifts drop the bits that spill past X^63; the
 /// matching right shifts collect those as the coefficients of X^64..X^67, which fold in once more.
+/// This is an F2-linear map, so unreduced products may be summed by XOR and reduced once at the
+/// end.
 #[inline]
-const fn reduce64(lo: u64, hi: u64) -> u64 {
+pub const fn reduce([lo, hi]: [u64; 2]) -> u64 {
 	// The bits of hi·0x1B that spill past X^63 (from the <<1, <<3, <<4 terms): coefficients
 	// X^64..X^67.
 	let spill = (hi >> 63) ^ (hi >> 61) ^ (hi >> 60);
@@ -36,10 +41,11 @@ const fn reduce64(lo: u64, hi: u64) -> u64 {
 }
 
 /// Multiplies two elements of the base field GF(2^64), the Monbijou field.
+///
+/// Composes the widening multiply [`mul_wide`] with the modular [`reduce`]; both are inlined.
 #[inline]
 pub fn mul(x: u64, y: u64) -> u64 {
-	let (lo, hi) = clmul64(x, y);
-	reduce64(lo, hi)
+	reduce(mul_wide(x, y))
 }
 
 /// Multiplies two elements of GF(2^128), the degree-2 extension of the Monbijou field.
@@ -62,13 +68,13 @@ pub fn mul_128b(x: u128, y: u128) -> u128 {
 	let (x0, x1) = (x as u64, (x >> 64) as u64);
 	let (y0, y1) = (y as u64, (y >> 64) as u64);
 
-	// Unreduced 128-bit carry-less products, as (low, high) limbs.
-	let (t0l, t0h) = clmul64(x0, y0); // a0·b0
-	let (t2l, t2h) = clmul64(x1, y1); // a1·b1
-	let (t1l, t1h) = clmul64(x0 ^ x1, y0 ^ y1); // (a0 + a1)·(b0 + b1)
+	// Unreduced 128-bit carry-less products, as [low, high] limbs.
+	let [t0l, t0h] = mul_wide(x0, y0); // a0·b0
+	let [t2l, t2h] = mul_wide(x1, y1); // a1·b1
+	let [t1l, t1h] = mul_wide(x0 ^ x1, y0 ^ y1); // (a0 + a1)·(b0 + b1)
 
 	// coeff 0 = a0·b0 + a1·b1; reduction is linear, so summing before reducing gives one reduction.
-	let z0 = reduce64(t0l ^ t2l, t0h ^ t2h);
+	let z0 = reduce([t0l ^ t2l, t0h ^ t2h]);
 
 	// coeff 1 = (a0·b1 + a1·b0) + X·(a1·b1). Karatsuba gives the cross term as t1 + t0 + t2;
 	// X·(a1·b1) is the unreduced a1·b1 shifted up one bit (its degree is ≤ 126, so the shift stays
@@ -77,7 +83,7 @@ pub fn mul_128b(x: u128, y: u128) -> u128 {
 	let cross_hi = t1h ^ t0h ^ t2h;
 	let xt2_lo = t2l << 1;
 	let xt2_hi = (t2h << 1) | (t2l >> 63);
-	let z1 = reduce64(cross_lo ^ xt2_lo, cross_hi ^ xt2_hi);
+	let z1 = reduce([cross_lo ^ xt2_lo, cross_hi ^ xt2_hi]);
 
 	(z0 as u128) | ((z1 as u128) << 64)
 }
@@ -86,7 +92,7 @@ pub fn mul_128b(x: u128, y: u128) -> u128 {
 mod tests {
 	use proptest::prelude::*;
 
-	use super::{mul, mul_128b};
+	use super::{mul, mul_128b, mul_wide, reduce};
 	use crate::{
 		monbijou::MONBIJOU_128B_ONE,
 		test_utils::multiplication_tests::{
@@ -109,6 +115,18 @@ mod tests {
 		#[test]
 		fn base_mul_distributive(a in any::<u64>(), b in any::<u64>(), c in any::<u64>()) {
 			prop_assert_eq!(mul(a, b ^ c), mul(a, b) ^ mul(a, c));
+		}
+
+		// The reduction is F2-linear, so accumulating two unreduced products by XOR and reducing
+		// once equals reducing each and summing.
+		#[test]
+		fn base_wide_mul_deferred_reduction(
+			a1 in any::<u64>(), b1 in any::<u64>(),
+			a2 in any::<u64>(), b2 in any::<u64>(),
+		) {
+			let [p0, p1] = mul_wide(a1, b1);
+			let [q0, q1] = mul_wide(a2, b2);
+			prop_assert_eq!(reduce([p0 ^ q0, p1 ^ q1]), mul(a1, b1) ^ mul(a2, b2));
 		}
 
 		// The 128-bit extension field: reuse the generic field-axiom helpers (u128 is an Underlier).


### PR DESCRIPTION
Implements [BINIUS-260](https://linear.app/jimpo/issue/BINIUS-260): the same widening-multiply / deferred-reduction split done for GHASH in #1750, now for the base Monbijou field GF(2⁶⁴) = GF(2)[X]/(X⁶⁴+X⁴+X³+X+1). Exposes `wide_mul` (unreduced) and `reduce` as separate public functions; since the reduction is F2-linear, a sum of products is reduced once.

### Commits
1. **Split the base-field mul** (soft64 + clmul) — `mul = reduce(mul_wide(..))`, both inlined:
   - **soft64**: `mul_wide(x,y) -> [u64; 2]` (the `[low, high]` carry-less limbs) + `reduce([u64;2]) -> u64`; `mul_128b` rewired to use them.
   - **clmul**: `mul_wide<U>(a,b) -> [U; 2]` (the two 128-bit lane products) + `reduce<U>([U;2]) -> U` (renamed from `reduce_pair`); `mul_128b` / `mul_sliced_128b` rewired.
   - deferred-reduction proptests on both paths + a clmul↔soft64 base-field cross-check.
2. **Monbijou inner-product benchmark** — new `monbijou_inner_product` group (length-2¹⁰) contrasting reduce-every-term `mul` against accumulate-unreduced `mul_wide`. Also generalizes `run_inner_product_benchmark` with an `element_bits` parameter (the base Monbijou field is 64-bit, so the previous hard-coded 128 gave the wrong term count — `u64` even hit `64/128 = 0`); the 8 existing GHASH/GHASH² call sites pass `128`.

### Performance (length-2¹⁰ inner product, native, x86_64 pclmulqdq)
| variant | reduce-every-term `mul` | deferred `mul_wide` | speedup |
|---|---|---|---|
| `clmul::<__m128i>` | 3.12 µs | **1.40 µs** | **~2.23×** |
| `soft64` | 24.0 µs | 19.5 µs | ~1.23× |

The reduction is a large fraction of a fast CLMUL multiply, so deferring it across the inner product is a solid win; software is more multiply-bound. Full x86_64 + aarch64 matrix verified (fmt/clippy/test/doc).

Unblocks the degree-3 Monbijou extension (BINIUS-249), which will stack on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)