### PR TITLE
BINIUS-249: degree-3 Monbijou extension multiplication

### DIFF
--- a/crates/arith-bench/benches/field_mul.rs
+++ b/crates/arith-bench/benches/field_mul.rs
@@ -712,6 +712,66 @@ fn bench_monbijou_128b(c: &mut Criterion) {
 	group.finish();
 }
 
+/// Benchmark GF(2^192) Monbijou degree-3 extension field multiplication in the sliced
+/// representation, comparing portable soft64 against the CLMUL implementation.
+#[allow(unused_imports, unused_variables, unused_mut)]
+fn bench_monbijou_192b(c: &mut Criterion) {
+	use binius_arith_bench::monbijou::{mul_sliced_192b_clmul, soft64};
+
+	let mut rng = rand::rng();
+
+	let mut group = c.benchmark_group("monbijou_192b");
+
+	// Portable soft64 (no CLMUL/SIMD)
+	run_mul_benchmark(&mut group, "soft64::mul_192b", soft64::mul_192b, &mut rng, 192);
+
+	// Sliced __m128i (a `[__m128i; 3]` holds two GF(2^192) elements)
+	#[cfg(all(target_feature = "pclmulqdq", target_feature = "sse2"))]
+	{
+		run_mul_benchmark(
+			&mut group,
+			"mul_sliced_192b_clmul::<__m128i>",
+			mul_sliced_192b_clmul::<__m128i>,
+			&mut rng,
+			192,
+		);
+	}
+
+	// Sliced __m256i (a `[__m256i; 3]` holds four GF(2^192) elements)
+	#[cfg(all(
+		target_feature = "vpclmulqdq",
+		target_feature = "avx2",
+		target_feature = "sse2"
+	))]
+	{
+		run_mul_benchmark(
+			&mut group,
+			"mul_sliced_192b_clmul::<__m256i>",
+			mul_sliced_192b_clmul::<__m256i>,
+			&mut rng,
+			192,
+		);
+	}
+
+	// Sliced uint64x2_t (AARCH64 NEON)
+	#[cfg(all(
+		target_arch = "aarch64",
+		target_feature = "neon",
+		target_feature = "aes"
+	))]
+	{
+		run_mul_benchmark(
+			&mut group,
+			"mul_sliced_192b_clmul::uint64x2_t",
+			mul_sliced_192b_clmul::<uint64x2_t>,
+			&mut rng,
+			192,
+		);
+	}
+
+	group.finish();
+}
+
 /// Benchmark GHASH² (degree-2 extension of GHASH) sliced multiplication
 #[allow(unused_variables, unused_mut)]
 fn bench_ghash_sq(c: &mut Criterion) {
@@ -1000,6 +1060,62 @@ fn bench_monbijou_inner_product(c: &mut Criterion) {
 	group.finish();
 }
 
+/// Benchmark inner products over the degree-3 Monbijou extension GF(2^192), contrasting the
+/// delayed-reduction widening multiply (accumulate the six raw products, reduce once) against the
+/// reduce-every-term sliced multiply.
+#[allow(unused_imports, unused_variables, unused_mut)]
+fn bench_monbijou_192b_inner_product(c: &mut Criterion) {
+	use binius_arith_bench::monbijou::{clmul, soft64};
+
+	/// Length of the inner product.
+	const LOG_LEN: usize = 10;
+
+	let mut rng = rand::rng();
+
+	let mut group = c.benchmark_group("monbijou_192b_inner_product");
+
+	// Baseline: reduce each product; widening: accumulate the six raw products, reduce once.
+	run_inner_product_benchmark(
+		&mut group,
+		"soft64::mul_192b",
+		soft64::mul_192b,
+		&mut rng,
+		LOG_LEN,
+		192,
+	);
+	run_inner_product_benchmark(
+		&mut group,
+		"soft64::mul_wide_192b",
+		soft64::mul_wide_192b,
+		&mut rng,
+		LOG_LEN,
+		192,
+	);
+
+	#[cfg(all(target_feature = "pclmulqdq", target_feature = "sse2"))]
+	{
+		run_inner_product_benchmark(
+			&mut group,
+			"clmul::mul_sliced_192b::<__m128i>",
+			clmul::mul_sliced_192b::<__m128i>,
+			&mut rng,
+			LOG_LEN,
+			192,
+		);
+
+		run_inner_product_benchmark(
+			&mut group,
+			"clmul::mul_wide_sliced_192b::<__m128i>",
+			clmul::mul_wide_sliced_192b::<__m128i>,
+			&mut rng,
+			LOG_LEN,
+			192,
+		);
+	}
+
+	group.finish();
+}
+
 criterion_group!(
 	benches,
 	bench_rijndael,
@@ -1008,8 +1124,10 @@ criterion_group!(
 	bench_ghash_sq,
 	bench_monbijou,
 	bench_monbijou_128b,
+	bench_monbijou_192b,
 	bench_ghash_inner_product,
 	bench_ghash_sq_inner_product,
 	bench_monbijou_inner_product,
+	bench_monbijou_192b_inner_product,
 );
 criterion_main!(benches);

--- a/crates/arith-bench/src/monbijou/clmul.rs
+++ b/crates/arith-bench/src/monbijou/clmul.rs
@@ -131,6 +131,83 @@ pub fn mul_sliced_128b<U: Underlier + OpsClmul + PackedUnderlier<u64>>(
 	[z0, z1]
 }
 
+/// Widening (unreduced) degree-3 Monbijou multiply in *sliced* representation: the six raw
+/// base-field Karatsuba products `[m0, m1, m2, m01, m02, m12]` (each a `[U; 2]` lane pair, as from
+/// [`mul_wide`]) of two GF(2^192) elements `[U; 3]`.
+///
+/// Each element is `[U; 3]`: index i holds coefficient i (a base-field element or SIMD pack), so
+/// the three coefficients live in separate registers. No combination, scaling, or reduction happens
+/// here — all F2-linear and deferred to [`reduce_sliced_192b`], so an inner product
+/// XOR-accumulates the six products and reduces once.
+#[inline]
+pub fn mul_wide_sliced_192b<U: Underlier + OpsClmul + PackedUnderlier<u64>>(
+	x: [U; 3],
+	y: [U; 3],
+) -> [[U; 2]; 6] {
+	let [x0, x1, x2] = x;
+	let [y0, y1, y2] = y;
+	[
+		mul_wide(x0, y0),
+		mul_wide(x1, y1),
+		mul_wide(x2, y2),
+		mul_wide(U::xor(x0, x1), U::xor(y0, y1)),
+		mul_wide(U::xor(x0, x2), U::xor(y0, y2)),
+		mul_wide(U::xor(x1, x2), U::xor(y1, y2)),
+	]
+}
+
+/// Reduce the six raw products from [`mul_wide_sliced_192b`] into a GF(2^192) element `[U; 3]`.
+///
+/// The tower is GF(2)\[X, Y\] / (X^64 + X^4 + X^3 + X + 1) / (Y^3 + X), so `Y^3 = X`; see
+/// [`super::soft64::mul_192b`] for the algebra. Karatsuba gives the degree-≤4 coefficients
+/// `c0..c4`; folding `Y^3 = X`, `Y^4 = X·Y` gives `z0 = c0 + X·c3`, `z1 = c1 + X·c4`, `z2 = c2`.
+/// The combinations and the multiply-by-X (per lane: shift the unreduced product left by one and
+/// fold the overflow bit back in with the polynomial) happen here, so each output coefficient is
+/// reduced once by [`reduce`].
+#[inline]
+pub fn reduce_sliced_192b<U: Underlier + OpsClmul + PackedUnderlier<u64>>(
+	[m0, m1, m2, m01, m02, m12]: [[U; 2]; 6],
+) -> [U; 3] {
+	// Product coefficients (unreduced): c0 = m0, c4 = m2, and the Karatsuba cross terms
+	//   c1 = m01 + m0 + m1,  c2 = m02 + m0 + m1 + m2,  c3 = m12 + m1 + m2.
+	// `[U; 2]` is itself an `Underlier` (blanket array impl), so `Underlier::xor` adds the
+	// unreduced product pairs lane-wise.
+	let c0 = m0;
+	let c1 = Underlier::xor(Underlier::xor(m01, m0), m1);
+	let c2 = Underlier::xor(Underlier::xor(Underlier::xor(m02, m0), m1), m2);
+	let c3 = Underlier::xor(Underlier::xor(m12, m1), m2);
+	let c4 = m2;
+
+	let z0 = reduce(Underlier::xor(c0, mul_x_wide(c3)));
+	let z1 = reduce(Underlier::xor(c1, mul_x_wide(c4)));
+	let z2 = reduce(c2);
+	[z0, z1, z2]
+}
+
+/// Multiply an unreduced base-field product pair `[lo, hi]` by X, lane-wise.
+///
+/// Each 64-bit lane holds one unreduced product; shift it left by one and fold the overflow bit
+/// back in with the low terms of the reduction polynomial (X^4 + X^3 + X + 1).
+#[inline]
+fn mul_x_wide<U: Underlier + OpsClmul + PackedUnderlier<u64>>([lo, hi]: [U; 2]) -> [U; 2] {
+	const POLY: u64 = 0x1B;
+	let poly = <U as PackedUnderlier<u64>>::broadcast(POLY);
+	[
+		U::xor(U::slli_epi64::<1>(lo), U::and(poly, U::movepi64_mask(lo))),
+		U::xor(U::slli_epi64::<1>(hi), U::and(poly, U::movepi64_mask(hi))),
+	]
+}
+
+/// Multiplies two elements of GF(2^192), the degree-3 extension of the Monbijou field, in *sliced*
+/// representation. Composes [`mul_wide_sliced_192b`] with [`reduce_sliced_192b`].
+#[inline]
+pub fn mul_sliced_192b<U: Underlier + OpsClmul + PackedUnderlier<u64>>(
+	x: [U; 3],
+	y: [U; 3],
+) -> [U; 3] {
+	reduce_sliced_192b(mul_wide_sliced_192b(x, y))
+}
+
 /// Reduce a Monbijou widening product `[prod_0, prod_1]` (two 128-bit carry-less products) to a
 /// single packed base-field element, modulo X^64 + X^4 + X^3 + X + 1.
 ///
@@ -177,7 +254,7 @@ mod tests {
 
 	use proptest::prelude::*;
 
-	use super::{mul, mul_128b, mul_sliced_128b, mul_wide, reduce};
+	use super::{mul, mul_128b, mul_sliced_128b, mul_sliced_192b, mul_wide, reduce};
 	use crate::{Underlier, monbijou::soft64};
 
 	// A packed GF(2^128) element is a `u128` with coefficient 0 in the low 64 bits and coefficient
@@ -253,6 +330,30 @@ mod tests {
 			let [q0, q1] = mul_wide::<__m128i>(to(x2), to(y2));
 			let acc = reduce([Underlier::xor(p0, q0), Underlier::xor(p1, q1)]);
 			prop_assert_eq!(from(acc), soft64::mul(x1, y1) ^ soft64::mul(x2, y2));
+		}
+
+		// The degree-3 sliced multiply agrees with the soft64 reference in both packed lanes.
+		#[test]
+		fn sliced_matches_soft64_192b(
+			xa in any::<[u64; 3]>(), xb in any::<[u64; 3]>(),
+			ya in any::<[u64; 3]>(), yb in any::<[u64; 3]>(),
+		) {
+			// Coefficient i is [lane0 = e0[i], lane1 = e1[i]] packed into an __m128i.
+			let to_sliced = |e0: [u64; 3], e1: [u64; 3]| -> [__m128i; 3] {
+				std::array::from_fn(|i| unsafe {
+					std::mem::transmute::<u128, __m128i>((e0[i] as u128) | ((e1[i] as u128) << 64))
+				})
+			};
+			let lane = |z: [__m128i; 3], lane: u32| -> [u64; 3] {
+				std::array::from_fn(|i| {
+					let c = unsafe { std::mem::transmute::<__m128i, u128>(z[i]) };
+					(c >> (64 * lane)) as u64
+				})
+			};
+
+			let z = mul_sliced_192b::<__m128i>(to_sliced(xa, xb), to_sliced(ya, yb));
+			prop_assert_eq!(lane(z, 0), soft64::mul_192b(xa, ya));
+			prop_assert_eq!(lane(z, 1), soft64::mul_192b(xb, yb));
 		}
 	}
 }

--- a/crates/arith-bench/src/monbijou/mod.rs
+++ b/crates/arith-bench/src/monbijou/mod.rs
@@ -15,6 +15,7 @@ pub mod soft64;
 
 pub use clmul::{
 	mul as mul_clmul, mul_128b as mul_128b_clmul, mul_sliced_128b as mul_sliced_128b_clmul,
+	mul_sliced_192b as mul_sliced_192b_clmul,
 };
 
 /// The multiplicative identity in the Monbijou field

--- a/crates/arith-bench/src/monbijou/soft64.rs
+++ b/crates/arith-bench/src/monbijou/soft64.rs
@@ -5,7 +5,10 @@
 //! the portable carry-less multiply primitives in `crate::arch::portable64` rather than on CLMUL or
 //! SIMD intrinsics. They operate on scalar `u64`/`u128` values, one field element at a time.
 
-use crate::arch::portable64::{bmul64, rev64};
+use crate::{
+	Underlier,
+	arch::portable64::{bmul64, rev64},
+};
 
 /// Widening (unreduced) Monbijou multiply: the 128-bit carry-less product of two 64-bit polynomials
 /// as `[low, high]` 64-bit limbs, without the modular reduction.
@@ -88,11 +91,71 @@ pub fn mul_128b(x: u128, y: u128) -> u128 {
 	(z0 as u128) | ((z1 as u128) << 64)
 }
 
+/// Widening (unreduced) degree-3 Monbijou multiply: the six raw base-field Karatsuba products
+/// `[m0, m1, m2, m01, m02, m12]` of two GF(2^192) elements `[a0, a1, a2]`, `[b0, b1, b2]`, where
+/// `m0 = a0·b0`, `m1 = a1·b1`, `m2 = a2·b2`, and the sum products `m01 = (a0+a1)(b0+b1)`,
+/// `m02 = (a0+a2)(b0+b2)`, `m12 = (a1+a2)(b1+b2)`.
+///
+/// No combination, scaling, or reduction is done here — those are all F2-linear and deferred to
+/// [`reduce_192b`], so an inner product XOR-accumulates the six products and reduces once.
+#[inline]
+pub fn mul_wide_192b(a: [u64; 3], b: [u64; 3]) -> [[u64; 2]; 6] {
+	let [a0, a1, a2] = a;
+	let [b0, b1, b2] = b;
+	[
+		mul_wide(a0, b0),
+		mul_wide(a1, b1),
+		mul_wide(a2, b2),
+		mul_wide(a0 ^ a1, b0 ^ b1),
+		mul_wide(a0 ^ a2, b0 ^ b2),
+		mul_wide(a1 ^ a2, b1 ^ b2),
+	]
+}
+
+/// Reduce the six raw products from [`mul_wide_192b`] into a GF(2^192) element.
+///
+/// The tower is GF(2)\[X, Y\] / (X^64 + X^4 + X^3 + X + 1) / (Y^3 + X), so `Y^3 = X`. Karatsuba
+/// gives the degree-≤4 product coefficients `c0..c4` (`c0 = m0`, `c1 = m01+m0+m1`, `c2 =
+/// m02+m0+m1+m2`, `c3 = m12+m1+m2`, `c4 = m2`); folding `Y^3 = X`, `Y^4 = X·Y` gives `z0 = c0 +
+/// X·c3`, `z1 = c1 + X·c4`, `z2 = c2`. The multiply-by-X (a 1-bit left shift of the unreduced
+/// `[low, high]` product, whose degree ≤ 126 leaves room) is done here, on the unreduced values, so
+/// only the three output coefficients are reduced.
+#[inline]
+pub fn reduce_192b([m0, m1, m2, m01, m02, m12]: [[u64; 2]; 6]) -> [u64; 3] {
+	// `[u64; 2]` is itself an `Underlier` (blanket array impl), so `Underlier::xor` adds the
+	// unreduced product pairs component-wise.
+	let c0 = m0;
+	let c1 = Underlier::xor(Underlier::xor(m01, m0), m1);
+	let c2 = Underlier::xor(Underlier::xor(Underlier::xor(m02, m0), m1), m2);
+	let c3 = Underlier::xor(Underlier::xor(m12, m1), m2);
+	let c4 = m2;
+
+	let z0 = reduce(Underlier::xor(c0, mul_x_wide(c3)));
+	let z1 = reduce(Underlier::xor(c1, mul_x_wide(c4)));
+	let z2 = reduce(c2);
+	[z0, z1, z2]
+}
+
+/// Multiply an unreduced base-field product pair `[low, high]` by X: a one-bit left shift of the
+/// 128-bit value (whose degree ≤ 126 leaves room, so no reduction is needed here).
+#[inline]
+const fn mul_x_wide([lo, hi]: [u64; 2]) -> [u64; 2] {
+	[lo << 1, (hi << 1) | (lo >> 63)]
+}
+
+/// Multiplies two elements of GF(2^192), the degree-3 extension of the Monbijou field.
+///
+/// Composes [`mul_wide_192b`] with [`reduce_192b`]; both are inlined.
+#[inline]
+pub fn mul_192b(a: [u64; 3], b: [u64; 3]) -> [u64; 3] {
+	reduce_192b(mul_wide_192b(a, b))
+}
+
 #[cfg(test)]
 mod tests {
 	use proptest::prelude::*;
 
-	use super::{mul, mul_128b, mul_wide, reduce};
+	use super::{mul, mul_128b, mul_192b, mul_wide, reduce};
 	use crate::{
 		monbijou::MONBIJOU_128B_ONE,
 		test_utils::multiplication_tests::{
@@ -148,6 +211,32 @@ mod tests {
 		#[test]
 		fn ext_mul_identity(a in any::<u128>()) {
 			prop_assert_eq!(mul_128b(a, MONBIJOU_128B_ONE), a);
+		}
+
+		// The degree-3 extension GF(2^192): field axioms ([u64; 3] is an Underlier via the blanket
+		// array impl, so the generic helpers apply).
+		#[test]
+		fn ext192_mul_commutative(a in any::<[u64; 3]>(), b in any::<[u64; 3]>()) {
+			test_mul_commutative(a, b, mul_192b, "Monbijou 192b");
+		}
+
+		#[test]
+		fn ext192_mul_associative(
+			a in any::<[u64; 3]>(), b in any::<[u64; 3]>(), c in any::<[u64; 3]>(),
+		) {
+			test_mul_associative(a, b, c, mul_192b, "Monbijou 192b");
+		}
+
+		#[test]
+		fn ext192_mul_distributive(
+			a in any::<[u64; 3]>(), b in any::<[u64; 3]>(), c in any::<[u64; 3]>(),
+		) {
+			test_mul_distributive(a, b, c, mul_192b, "Monbijou 192b");
+		}
+
+		#[test]
+		fn ext192_mul_identity(a in any::<[u64; 3]>()) {
+			prop_assert_eq!(mul_192b(a, [0x01, 0, 0]), a);
 		}
 	}
 


### PR DESCRIPTION
Implements [BINIUS-249](https://linear.app/jimpo/issue/BINIUS-249): packed multiplication for GF(2¹⁹²), the degree-3 extension of the base Monbijou field with irreducible `Y³ + X` — the full tower `GF(2)[X, Y] / (X⁶⁴+X⁴+X³+X+1) / (Y³+X)`.

**Stacked on #1756 (BINIUS-260)** — reuses the base-field `mul_wide`/`reduce` split from that PR. Review/merge #1756 first.

### Algorithm
An element `a0 + a1·Y + a2·Y²` is `[a0, a1, a2]` with base-field coefficients. Karatsuba over the three coefficients uses **six base-field products** (`m0=a0b0`, `m1=a1b1`, `m2=a2b2`, and the sum products `m01`, `m02`, `m12`), giving the degree-≤4 product coefficients `c0..c4`. Folding `Y³ = X`, `Y⁴ = X·Y` back down:

```text
z0 = c0 + X·c3,   z1 = c1 + X·c4,   z2 = c2
```

The six products are kept unreduced (`mul_wide`); the Karatsuba combinations and the multiply-by-X (a shift of the unreduced product) are done on the unreduced values, so only the three output coefficients are reduced.

### Commit
- **soft64** `mul_192b([u64; 3])` — the scalar reference, verified against the field axioms (commutativity, **associativity**, distributivity, identity — associativity is a strong check that the field is well-formed).
- **clmul** `mul_sliced_192b<U>([U; 3])` — *sliced* representation (each 64-bit lane holds one coefficient of a different element), cross-checked against the soft64 reference in both packed lanes.

Full x86_64 + aarch64 matrix verified (fmt/clippy/test/doc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)