### PR TITLE
BINIUS-247: build the BitAnd columns without an up-front zero pass

### DIFF
--- a/crates/m4-prover/src/bitand.rs
+++ b/crates/m4-prover/src/bitand.rs
@@ -2,6 +2,8 @@
 
 //! The batched BitAnd-check witness built from a populated batch value table.
 
+use std::mem::MaybeUninit;
+
 use binius_core::{
 	constraint_system::{AndConstraint, ShiftedValueIndex},
 	word::Word,
@@ -112,9 +114,11 @@ impl BatchAndCheckWitness {
 		assert!(n_instances.is_power_of_two(), "instance count must be a power of two");
 
 		// One column each for the three operands, laid out instance-major.
-		let mut a = vec![Word::ZERO; total];
-		let mut b = vec![Word::ZERO; total];
-		let mut c = vec![Word::ZERO; total];
+		// The columns are left uninitialized here.
+		// Each task zeroes its own chunk, fusing the zero-fill into the write pass.
+		let mut a = Vec::<Word>::with_capacity(total);
+		let mut b = Vec::<Word>::with_capacity(total);
+		let mut c = Vec::<Word>::with_capacity(total);
 
 		// The witness offset splits public words (below) from hidden rows (at or above).
 		let offset = table.layout().offset_witness;
@@ -125,32 +129,53 @@ impl BatchAndCheckWitness {
 		// Its output blocks are those instances' rows of the three instance-major columns.
 		// Reads stay contiguous: within a stripe, one hidden row is a contiguous sub-slice.
 		let block = STRIPE_WIDTH.min(n_instances) * n_and;
-		a.par_chunks_mut(block)
-			.zip(b.par_chunks_mut(block))
-			.zip(c.par_chunks_mut(block))
-			.enumerate()
-			.for_each(|(stripe, ((a_block, b_block), c_block))| {
-				// The first global instance of this stripe.
-				// The instances in this stripe, derived from the block length.
-				let base = stripe * STRIPE_WIDTH;
-				let width = a_block.len() / n_and;
+		{
+			let a_spare = &mut a.spare_capacity_mut()[..total];
+			let b_spare = &mut b.spare_capacity_mut()[..total];
+			let c_spare = &mut c.spare_capacity_mut()[..total];
+			a_spare
+				.par_chunks_mut(block)
+				.zip(b_spare.par_chunks_mut(block))
+				.zip(c_spare.par_chunks_mut(block))
+				.enumerate()
+				.for_each(|(stripe, ((a_block, b_block), c_block))| {
+					// Zero this chunk, then view it as an initialized slice to accumulate into.
+					let a_block = init_zeroed(a_block);
+					let b_block = init_zeroed(b_block);
+					let c_block = init_zeroed(c_block);
 
-				for (j, constraint) in and_constraints.iter().enumerate() {
-					let ctx = OperandContext {
-						data,
-						constants,
-						offset,
-						log_instances,
-						base,
-						width,
-						n_and,
-						j,
-					};
-					ctx.accumulate(a_block, &constraint.a);
-					ctx.accumulate(b_block, &constraint.b);
-					ctx.accumulate(c_block, &constraint.c);
-				}
-			});
+					// The first global instance of this stripe.
+					// The instances in this stripe, derived from the block length.
+					let base = stripe * STRIPE_WIDTH;
+					let width = a_block.len() / n_and;
+
+					for (j, constraint) in and_constraints.iter().enumerate() {
+						let ctx = OperandContext {
+							data,
+							constants,
+							offset,
+							log_instances,
+							base,
+							width,
+							n_and,
+							j,
+						};
+						ctx.accumulate(a_block, &constraint.a);
+						ctx.accumulate(b_block, &constraint.b);
+						ctx.accumulate(c_block, &constraint.c);
+					}
+				});
+		}
+
+		// The stripes partition `[0, total)` and each zeroed its whole range.
+		// So all `total` elements of every column are initialized.
+		//
+		// SAFETY: every element in `0..total` was written above.
+		unsafe {
+			a.set_len(total);
+			b.set_len(total);
+			c.set_len(total);
+		}
 
 		Self { a, b, c }
 	}
@@ -254,6 +279,21 @@ impl BatchAndCheckWitness {
 
 		prover.prove_with_channel(channel)
 	}
+}
+
+/// Zeroes an uninitialized word chunk and returns it as an initialized slice.
+///
+/// Every element is set to `Word::ZERO`, so the caller can XOR operand terms into it.
+/// Chunks whose constraints have empty operands then stay zero, as the reduction expects.
+fn init_zeroed(chunk: &mut [MaybeUninit<Word>]) -> &mut [Word] {
+	for slot in chunk.iter_mut() {
+		slot.write(Word::ZERO);
+	}
+	// Every element was just written.
+	// `MaybeUninit<Word>` shares the layout of `Word`.
+	//
+	// SAFETY: the whole chunk is initialized, so reinterpreting it as `Word` is sound.
+	unsafe { &mut *(chunk as *mut [MaybeUninit<Word>] as *mut [Word]) }
 }
 
 /// The placement of one operand column for one constraint over one instance stripe.


### PR DESCRIPTION
Part of [BINIUS-247](https://linear.app/jimpo/issue/BINIUS-247/adopt-valuetable2-across-m4-and-remove-valuetable). Follow-up to the review on #1759; does **not** close the issue.

Drops the separate zero-initialization of the three BitAnd operand columns. Same output, one pass instead of two.

### The problem

`BatchAndCheckWitness::build` allocated its three columns with a full zero fill:

```rust
let mut a = vec![Word::ZERO; total];   // pass 1: single-threaded zero fill
// ...
a.par_chunks_mut(block).for_each(|chunk| { /* pass 2: write every slot */ });
```

That is **two passes over the same memory**. The parallel pass already visits every slot, and `vec![Word::ZERO; total]` for a wrapper type is an ordinary single-threaded fill (not `alloc_zeroed`).

### The idea

Allocate capacity only and leave the columns uninitialized. Each parallel task zeroes **its own** chunk right before accumulating into it, so:
- the zero-fill is **fused** into the pass that already touches the chunk (one traversal, cache-hot),
- and it is **parallelized** across the stripes instead of a serial memset.

Zeroing stays necessary: a padding constraint (empty operands) contributes nothing, so its slots must already be zero — the fused zeroing provides that.

### The change

```rust
let mut a = Vec::<Word>::with_capacity(total);   // no init
// ...
let a_spare = &mut a.spare_capacity_mut()[..total];
a_spare.par_chunks_mut(block).zip(...).for_each(|(stripe, (a_block, ...))| {
    let a_block = init_zeroed(a_block);   // zero this chunk, view as &mut [Word]
    // ... accumulate as before ...
});
// SAFETY: the stripes partition 0..total and each zeroed its whole range.
unsafe { a.set_len(total); /* b, c */ }
```

`init_zeroed` writes `Word::ZERO` across an uninitialized chunk and returns it as an initialized slice:

```rust
fn init_zeroed(chunk: &mut [MaybeUninit<Word>]) -> &mut [Word] {
    for slot in chunk.iter_mut() { slot.write(Word::ZERO); }
    // SAFETY: fully written above; MaybeUninit<Word> shares Word's layout.
    unsafe { &mut *(chunk as *mut [MaybeUninit<Word>] as *mut [Word]) }
}
```

(`MaybeUninit::slice_assume_init_mut` is still unstable on the pinned 1.95 toolchain, so this uses the equivalent pointer cast.)

### Safety

- The three stripe iterators partition `[0, total)` exactly (rayon `par_chunks_mut` covers the whole slice).
- Every task zeroes **all** elements of its chunk before returning the initialized view.
- So all `total` elements of each column are initialized before `set_len(total)` — no uninitialized read, no out-of-bounds length.

### Scope

- **changed:** `BatchAndCheckWitness::build` allocation + the new `init_zeroed` helper in `bitand.rs`.
- output columns are byte-identical to before; no API or layout change.

### Verification

- `cargo build -p binius-m4-prover`, `clippy --all-targets`, `+nightly fmt -- --check` — clean
- `cargo test -p binius-m4-prover` — 34 pass. The per-instance-reference proptest and `build_spans_multiple_instance_stripes` would surface any slot left unwritten (garbage) or any padding slot not zeroed; both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)