### PR TITLE
Move word-size constants onto the Word type as associated constants

### DIFF
--- a/crates/circuits/src/bignum/biguint.rs
+++ b/crates/circuits/src/bignum/biguint.rs
@@ -81,14 +81,14 @@ impl BigUint {
 	}
 
 	/// Splits the `BigUint` at a given limb position into `(lo, hi)`. The result
-	/// satisfies `lo + 2^(WORD_SIZE_BITS * lo.limbs.len()) * hi`.
+	/// satisfies `lo + 2^(Word::BITS * lo.limbs.len()) * hi`.
 	pub fn split_at_limbs(mut self, at_limbs: usize) -> (Self, Self) {
 		let hi_limbs = self.limbs.split_off(at_limbs);
 		(self, Self { limbs: hi_limbs })
 	}
 
 	/// Concatenate the limbs of another `BigUint` on top. The resulting value
-	/// equals `self + 2^(WORD_SIZE_BITS * self.limbs.len()) * hi`.
+	/// equals `self + 2^(Word::BITS * self.limbs.len()) * hi`.
 	pub fn concat_limbs(&self, hi: &Self) -> Self {
 		let mut limbs = self.limbs.clone();
 		limbs.extend(&hi.limbs);

--- a/crates/circuits/src/bignum/mul.rs
+++ b/crates/circuits/src/bignum/mul.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 Irreducible Inc.
 use std::iter;
 
-use binius_core::consts::WORD_SIZE_BITS;
+use binius_core::word::Word;
 use binius_frontend::{CircuitBuilder, Wire};
 
 use super::{
@@ -150,7 +150,7 @@ pub fn karatsuba_mul(builder: &CircuitBuilder, a: &BigUint, b: &BigUint) -> BigU
 
 	// a(t) = a_0 + t * a_∞
 	// b(t) = b_0 + t * b_∞
-	// for t = 2^(WORD_SIZE_BITS*n/2), a = a(t), b = b(t)
+	// for t = 2^(Word::BITS*n/2), a = a(t), b = b(t)
 	let n_half = n >> 1;
 	let (a_0, a_inf) = a.clone().split_at_limbs(n_half);
 	let (b_0, b_inf) = b.clone().split_at_limbs(n_half);
@@ -168,7 +168,7 @@ pub fn karatsuba_mul(builder: &CircuitBuilder, a: &BigUint, b: &BigUint) -> BigU
 
 	// Multiply a(1) and b(1) carry out bits only
 	let ab_1_carry_out =
-		builder.shr(builder.band(a_1_carry_out, b_1_carry_out), (WORD_SIZE_BITS - 1) as u32);
+		builder.shr(builder.band(a_1_carry_out, b_1_carry_out), (Word::BITS - 1) as u32);
 
 	// Addition chain for overflow_sum = ab_0 + ab_inf * 2^n + ab_1 * 2^n/2
 	let mut product_stacks = vec![Vec::new(); 2 * n];
@@ -200,7 +200,7 @@ pub fn karatsuba_mul(builder: &CircuitBuilder, a: &BigUint, b: &BigUint) -> BigU
 		.expect("at least one carry out");
 	overflow_sum
 		.limbs
-		.push(builder.shr(carry_out, (WORD_SIZE_BITS - 1) as u32));
+		.push(builder.shr(carry_out, (Word::BITS - 1) as u32));
 
 	// now we need to subtract (ab_0 + ab_inf) * 2^n/2, separate the lower limbs that won't get
 	// affected

--- a/crates/circuits/src/bignum/prime_field.rs
+++ b/crates/circuits/src/bignum/prime_field.rs
@@ -1,6 +1,6 @@
 // Copyright 2026 The Binius Developers
 // Copyright 2025 Irreducible Inc.
-use binius_core::{consts::WORD_SIZE_BITS, word::Word};
+use binius_core::word::Word;
 use binius_frontend::{CircuitBuilder, Wire, util::num_biguint_from_u64_limbs};
 
 use super::{
@@ -57,7 +57,7 @@ impl PseudoMersennePrimeField {
 		let zero = b.add_constant(Word::ZERO);
 
 		// May need an extra limb to accommodate overflow.
-		let extra_limbs = if self.modulus_po2 + 1 > l * WORD_SIZE_BITS {
+		let extra_limbs = if self.modulus_po2 + 1 > l * Word::BITS {
 			1
 		} else {
 			0

--- a/crates/circuits/src/bignum/reduce.rs
+++ b/crates/circuits/src/bignum/reduce.rs
@@ -1,5 +1,5 @@
 // Copyright 2025 Irreducible Inc.
-use binius_core::{consts::WORD_SIZE_BITS, word::Word};
+use binius_core::word::Word;
 use binius_frontend::{CircuitBuilder, Wire};
 
 use super::{
@@ -85,8 +85,7 @@ impl PseudoMersenneModReduce {
 	/// # Arguments
 	/// * `builder` - Circuit builder for constraint generation
 	/// * `a` - The dividend
-	/// * `modulus_po2` - the power of two modulus minuend (has to be a multiple of
-	///   `WORD_SIZE_BITS`)
+	/// * `modulus_po2` - the power of two modulus minuend (has to be a multiple of `Word::BITS`)
 	/// * `modulus_subtrahend` - the value subtracted form `2^modulus_po2` to obtain modulus
 	/// * `quotient` - The quotient
 	/// * `remainder` - The remainder
@@ -115,13 +114,13 @@ impl PseudoMersenneModReduce {
 		// max(lo, remainder) < 2^modulus_po2
 		// quotient < |a/(2^modulus_po2 - modulus_subtrahend)|
 		// quotient >= hi
-		assert!(modulus_po2.is_multiple_of(WORD_SIZE_BITS));
-		assert!(modulus_subtrahend.limbs.len() * WORD_SIZE_BITS <= modulus_po2);
-		assert!(remainder.limbs.len() * WORD_SIZE_BITS <= modulus_po2);
+		assert!(modulus_po2.is_multiple_of(Word::BITS));
+		assert!(modulus_subtrahend.limbs.len() * Word::BITS <= modulus_po2);
+		assert!(remainder.limbs.len() * Word::BITS <= modulus_po2);
 
 		let zero = builder.add_constant(Word::ZERO);
 
-		let n_lo_limbs = modulus_po2 / WORD_SIZE_BITS;
+		let n_lo_limbs = modulus_po2 / Word::BITS;
 
 		let (a_lo, a_hi) = a.pad_limbs_to(n_lo_limbs, zero).split_at_limbs(n_lo_limbs);
 

--- a/crates/circuits/src/concat.rs
+++ b/crates/circuits/src/concat.rs
@@ -1,5 +1,5 @@
 // Copyright 2025 Irreducible Inc.
-use binius_core::{consts::WORD_SIZE_BYTES, word::Word};
+use binius_core::word::Word;
 use binius_frontend::{CircuitBuilder, Wire, hints::Hint};
 
 use crate::{
@@ -130,11 +130,8 @@ pub fn concat(b: &CircuitBuilder, inputs: &[ByteVec]) -> ByteVec {
 			} else {
 				// Constant offset, dynamic length: extract the term's (capacity-sized) region with
 				// constant shifts, then mask the comparison to the runtime length.
-				let region = extract_const_range(
-					b,
-					&output_data,
-					off..off + input.data.len() * WORD_SIZE_BYTES,
-				);
+				let region =
+					extract_const_range(b, &output_data, off..off + input.data.len() * Word::BYTES);
 				assert_slice_eq(b, &name, input.len_bytes, &region, &input.data);
 			}
 		} else {
@@ -177,7 +174,7 @@ fn assert_const_slice_eq(
 	// bytes before comparing.
 	let extracted = extract_const_range(b, output, offset..offset + len);
 	let n_words = extracted.len();
-	let final_bytes = len % WORD_SIZE_BYTES;
+	let final_bytes = len % Word::BYTES;
 	for (k, &a) in extracted.iter().enumerate() {
 		let e = input[k];
 		if k + 1 == n_words && final_bytes != 0 {

--- a/crates/circuits/src/ecdsa/scalar_mul.rs
+++ b/crates/circuits/src/ecdsa/scalar_mul.rs
@@ -1,6 +1,6 @@
 // Copyright 2026 The Binius Developers
 // Copyright 2025 Irreducible Inc.
-use binius_core::{consts::WORD_SIZE_BITS, word::Word};
+use binius_core::word::Word;
 use binius_frontend::{CircuitBuilder, Wire};
 
 use crate::{
@@ -103,7 +103,7 @@ fn check_endomorphism_split(
 /// # Panics
 ///
 /// Panics if `scalars.len() != points.len()`, if `n == 0`, if `window` is not in
-/// `1..WORD_SIZE_BITS`, or if any scalar does not have exactly `N_LIMBS` limbs.
+/// `1..Word::BITS`, or if any scalar does not have exactly `N_LIMBS` limbs.
 pub fn msm_strauss_endo(
 	b: &CircuitBuilder,
 	curve: &Secp256k1,
@@ -114,7 +114,7 @@ pub fn msm_strauss_endo(
 	let n = points.len();
 	assert_eq!(scalars.len(), n, "scalars and points must have the same length");
 	assert!(n >= 1, "MSM requires at least one point");
-	assert!(0 < window && window < WORD_SIZE_BITS, "window must be in 1..WORD_SIZE_BITS");
+	assert!(0 < window && window < Word::BITS, "window must be in 1..Word::BITS");
 
 	// Split each scalar via the endomorphism into two base points (`±P`, `±φ(P)`) with 128-bit
 	// subscalars. Build `±P`'s table with point additions, then derive `±φ(P)`'s table by applying
@@ -233,8 +233,8 @@ fn strauss_accumulate(
 				if bit_index >= exponent_bits {
 					continue; // past the top of the exponent — contributes a zero bit
 				}
-				let limb = bit_index / WORD_SIZE_BITS;
-				let bit = bit_index % WORD_SIZE_BITS;
+				let limb = bit_index / Word::BITS;
+				let bit = bit_index % Word::BITS;
 				let bit_val = b.band(b.shr(subscalar[limb], bit as u32), one);
 				sel = b.bor(sel, b.shl(bit_val, j as u32));
 			}

--- a/crates/circuits/src/fixed_byte_vec.rs
+++ b/crates/circuits/src/fixed_byte_vec.rs
@@ -3,7 +3,7 @@
 
 use std::ops::{Range, RangeInclusive};
 
-use binius_core::{consts::WORD_SIZE_BYTES, word::Word};
+use binius_core::word::Word;
 use binius_frontend::{CircuitBuilder, Wire, WitnessFiller, util::pack_bytes_into_wires_le};
 
 /// A variable-length byte vector with fixed capacity determined at circuit construction time.
@@ -60,7 +60,7 @@ impl ByteVec {
 	///
 	/// The length range defaults to the full `0..capacity`, preserving the fully-dynamic behavior.
 	pub fn new(data: Vec<Wire>, len_bytes: Wire) -> Self {
-		let capacity = data.len() * WORD_SIZE_BYTES;
+		let capacity = data.len() * Word::BYTES;
 		Self::new_with_len_range(data, len_bytes, 0..=capacity)
 	}
 
@@ -77,7 +77,7 @@ impl ByteVec {
 		len_bytes: Wire,
 		len_range: RangeInclusive<usize>,
 	) -> Self {
-		let capacity = data.len() * WORD_SIZE_BYTES;
+		let capacity = data.len() * Word::BYTES;
 		assert!(len_range.start() <= len_range.end(), "invalid len_range: start > end");
 		assert!(
 			*len_range.end() <= capacity,
@@ -277,10 +277,10 @@ pub(crate) fn extract_const_range(
 ) -> Vec<Wire> {
 	assert!(range.start <= range.end, "invalid range: start > end");
 	assert!(
-		range.end <= data.len() * WORD_SIZE_BYTES,
+		range.end <= data.len() * Word::BYTES,
 		"range.end {} exceeds capacity {}",
 		range.end,
-		data.len() * WORD_SIZE_BYTES
+		data.len() * Word::BYTES
 	);
 
 	let slice_len = range.len();
@@ -288,11 +288,11 @@ pub(crate) fn extract_const_range(
 		return Vec::new();
 	}
 
-	let start_word_idx = range.start / WORD_SIZE_BYTES;
+	let start_word_idx = range.start / Word::BYTES;
 	// Word index containing the last byte of the sliced data.
-	let last_word_index = (range.end - 1) / WORD_SIZE_BYTES;
-	let byte_offset = range.start % WORD_SIZE_BYTES;
-	let num_output_words = slice_len.div_ceil(WORD_SIZE_BYTES);
+	let last_word_index = (range.end - 1) / Word::BYTES;
+	let byte_offset = range.start % Word::BYTES;
+	let num_output_words = slice_len.div_ceil(Word::BYTES);
 
 	// Extract words with shifting if needed. Bytes of the final word beyond the slice length are
 	// left as-is (a `ByteVec` makes no guarantee about byte values past its length).
@@ -312,8 +312,7 @@ pub(crate) fn extract_const_range(
 				if source_idx < last_word_index {
 					let next_word = data[source_idx + 1];
 					// Shift next word left to fill in the high bytes.
-					let shifted_next =
-						b.shl(next_word, ((WORD_SIZE_BYTES - byte_offset) * 8) as u32);
+					let shifted_next = b.shl(next_word, ((Word::BYTES - byte_offset) * 8) as u32);
 					// Combine the two parts (XOR is cheaper than OR).
 					b.bxor(shifted_current, shifted_next)
 				} else {

--- a/crates/circuits/src/multiplexer.rs
+++ b/crates/circuits/src/multiplexer.rs
@@ -1,5 +1,5 @@
 // Copyright 2025 Irreducible Inc.
-use binius_core::{consts::WORD_SIZE_BITS, word::Word};
+use binius_core::word::Word;
 use binius_frontend::{CircuitBuilder, Wire};
 
 /// Creates a multiplexer circuit that selects a group of wires from multiple groups based on a
@@ -91,7 +91,7 @@ pub fn single_wire_multiplex(b: &CircuitBuilder, inputs: &[Wire], sel: Wire) -> 
 
 	// Process level by level until we have a single output
 	for bit_level in 0..num_sel_bits {
-		let sel_bit = b.shl(sel, (WORD_SIZE_BITS - 1 - bit_level) as u32);
+		let sel_bit = b.shl(sel, (Word::BITS - 1 - bit_level) as u32);
 
 		// Process pairs of wires at the current level
 		let next_level = current_level

--- a/crates/circuits/src/secp256k1/curve.rs
+++ b/crates/circuits/src/secp256k1/curve.rs
@@ -1,6 +1,6 @@
 // Copyright 2026 The Binius Developers
 // Copyright 2025 Irreducible Inc.
-use binius_core::consts::WORD_SIZE_BITS;
+use binius_core::word::Word;
 use binius_frontend::{CircuitBuilder, Wire};
 
 use super::{
@@ -73,7 +73,7 @@ impl Secp256k1 {
 
 		// both residues differ in parity
 		let res_1_low_limb = *res_1.limbs.first().expect("N_LIMBS > 0");
-		let odd_1 = b.shl(res_1_low_limb, (WORD_SIZE_BITS - 1) as u32);
+		let odd_1 = b.shl(res_1_low_limb, (Word::BITS - 1) as u32);
 		let is_res_2 = b.bxor(odd_1, recid_odd);
 
 		let y = select(b, is_res_2, &res_2, &res_1);

--- a/crates/circuits/src/sha256/mod.rs
+++ b/crates/circuits/src/sha256/mod.rs
@@ -1,10 +1,7 @@
 // Copyright 2025 Irreducible Inc.
 pub mod compress;
 
-use binius_core::{
-	consts::{LOG_BYTE_BITS, LOG_WORD_SIZE_BITS},
-	word::Word,
-};
+use binius_core::{consts::LOG_BYTE_BITS, word::Word};
 use binius_frontend::{CircuitBuilder, Wire, WitnessFiller};
 pub use compress::{
 	State, populate_message_block, ref_compress, sha256_compress, sha256_compress_2x,
@@ -71,7 +68,7 @@ impl Sha256 {
 	/// * `message` - Input message as packed 64-bit words (8 bytes per wire)
 	///
 	/// # Panics If the total number of bits of content contained in `message` cannot be represented in 32
-	///   bits; i.e., if `message.len() << LOG_WORD_SIZE_BITS > u32::MAX`
+	///   bits; i.e., if `message.len() << Word::LOG_BITS > u32::MAX`
 	///
 	/// # Circuit Structure
 	/// The circuit performs the following validations:
@@ -117,11 +114,11 @@ impl Sha256 {
 		//
 		// We also verify that the actual input length len is within bounds.
 		assert!(
-			message.len() << LOG_WORD_SIZE_BITS <= u32::MAX as usize,
+			message.len() << Word::LOG_BITS <= u32::MAX as usize,
 			"length of message in bits must fit within 32 bits"
 		);
 
-		let max_len_bytes = message.len() << (LOG_WORD_SIZE_BITS - LOG_BYTE_BITS);
+		let max_len_bytes = message.len() << (Word::LOG_BITS - LOG_BYTE_BITS);
 		let n_blocks = (message.len() + 2).div_ceil(8);
 		let n_words = n_blocks << 3; // 8 message words per compression gadget block
 
@@ -395,7 +392,7 @@ impl Sha256 {
 
 	/// Returns the maximum message length, in bytes.
 	pub const fn max_len_bytes(&self) -> usize {
-		self.message.len() << (LOG_WORD_SIZE_BITS - LOG_BYTE_BITS)
+		self.message.len() << (Word::LOG_BITS - LOG_BYTE_BITS)
 	}
 
 	/// Populates the length wire with the actual message size in bytes.

--- a/crates/circuits/src/sha512/mod.rs
+++ b/crates/circuits/src/sha512/mod.rs
@@ -1,10 +1,7 @@
 // Copyright 2025 Irreducible Inc.
 pub mod compress;
 
-use binius_core::{
-	consts::{LOG_BYTE_BITS, LOG_WORD_SIZE_BITS},
-	word::Word,
-};
+use binius_core::{consts::LOG_BYTE_BITS, word::Word};
 use binius_frontend::{CircuitBuilder, Wire};
 pub use compress::{State, compress, pack_message_block};
 
@@ -161,11 +158,11 @@ pub fn sha512_varlen(builder: &CircuitBuilder, message: &ByteVec) -> [Wire; 8] {
 	// the actual length is within bounds.
 	let len_bytes = message.len_bytes;
 	assert!(
-		message.data.len() << LOG_WORD_SIZE_BITS <= u64::MAX as usize,
+		message.data.len() << Word::LOG_BITS <= u64::MAX as usize,
 		"length of message in bits must fit in 64-bit wire"
 	);
 
-	let max_len_bytes = message.data.len() << (LOG_WORD_SIZE_BITS - LOG_BYTE_BITS);
+	let max_len_bytes = message.data.len() << (Word::LOG_BITS - LOG_BYTE_BITS);
 	let n_blocks = (message.data.len() + 3).div_ceil(16);
 	let n_words: usize = n_blocks << 4; // 16 words per block
 

--- a/crates/core/src/consts.rs
+++ b/crates/core/src/consts.rs
@@ -3,15 +3,6 @@
 
 use binius_utils::checked_arithmetics::checked_log_2;
 
-/// The protocol proves constraint systems over 64-bit words.
-pub const WORD_SIZE_BYTES: usize = 8;
-
-/// The protocol proves constraint systems over 64-bit words.
-pub const WORD_SIZE_BITS: usize = WORD_SIZE_BYTES * 8;
-
-/// log2 of [`WORD_SIZE_BITS`].
-pub const LOG_WORD_SIZE_BITS: usize = checked_log_2(WORD_SIZE_BITS);
-
 /// The minimum number of words per segment.
 ///
 /// This is the minimum size requirement for public input segments in the constraint system.

--- a/crates/core/src/word.rs
+++ b/crates/core/src/word.rs
@@ -6,7 +6,10 @@ use std::{
 	ops::{BitAnd, BitOr, BitXor, Not, Shl, Shr},
 };
 
-use binius_utils::serialization::{DeserializeBytes, SerializationError, SerializeBytes};
+use binius_utils::{
+	checked_arithmetics::checked_log_2,
+	serialization::{DeserializeBytes, SerializationError, SerializeBytes},
+};
 use bytemuck::{Pod, Zeroable};
 use bytes::{Buf, BufMut};
 
@@ -20,6 +23,13 @@ use bytes::{Buf, BufMut};
 pub struct Word(pub u64);
 
 impl Word {
+	/// The size of a [`Word`] in bytes; the protocol proves constraint systems over 64-bit words.
+	pub const BYTES: usize = size_of::<Word>();
+	/// The size of a [`Word`] in bits (mirrors [`u64::BITS`]).
+	pub const BITS: usize = Self::BYTES * 8;
+	/// log2 of [`Word::BITS`].
+	pub const LOG_BITS: usize = checked_log_2(Self::BITS);
+
 	/// All zero bit pattern, zero, nil, null.
 	pub const ZERO: Word = Word(0);
 	/// 1.

--- a/crates/frontend/src/util.rs
+++ b/crates/frontend/src/util.rs
@@ -4,7 +4,7 @@
 
 use std::iter;
 
-use binius_core::{Word, consts::WORD_SIZE_BITS};
+use binius_core::Word;
 
 use crate::compiler::{CircuitBuilder, Wire, circuit::WitnessFiller};
 
@@ -96,7 +96,7 @@ pub fn all_true(b: &CircuitBuilder, booleans: impl IntoIterator<Item = Wire>) ->
 
 /// Convert MSB-bool into an all-1/all-0 mask.
 pub fn bool_to_mask(b: &CircuitBuilder, boolean: Wire) -> Wire {
-	b.sar(boolean, (WORD_SIZE_BITS - 1) as u32)
+	b.sar(boolean, (Word::BITS - 1) as u32)
 }
 
 /// Swap the byte order of the word.
@@ -109,7 +109,7 @@ pub fn byteswap(b: &CircuitBuilder, word: Wire) -> Wire {
 	});
 	bytes
 		.reduce(|lhs, rhs| b.bxor(lhs, rhs))
-		.expect("WORD_SIZE_BITS > 0")
+		.expect("Word::BITS > 0")
 }
 
 #[cfg(test)]

--- a/crates/m4-prover/src/bitand.rs
+++ b/crates/m4-prover/src/bitand.rs
@@ -14,7 +14,7 @@ use binius_math::BinarySubspace;
 use binius_prover::and_reduction::prover::OblongZerocheckProver;
 use binius_utils::{checked_arithmetics::checked_log_2, rayon::prelude::*};
 use binius_verifier::{
-	config::{B128, LOG_WORD_SIZE_BITS, PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES},
+	config::{B128, PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES},
 	protocols::bitand::AndCheckOutput,
 };
 
@@ -250,7 +250,7 @@ impl BatchAndCheckWitness {
 	{
 		// The univariate-skip domain spans one extra dimension above the 64-bit word.
 		// This is the same skip parameter the single-instance check uses.
-		let prover_message_domain = BinarySubspace::<B8>::with_dim(LOG_WORD_SIZE_BITS + 1);
+		let prover_message_domain = BinarySubspace::<B8>::with_dim(Word::LOG_BITS + 1);
 
 		let (a, b, c) = self.into_columns();
 
@@ -397,7 +397,7 @@ mod tests {
 	/// The result must equal the eval the reduction claimed for that column.
 	fn fold_eval_column(col: &[Word], z_challenge: B128, eval_point: &[B128]) -> B128 {
 		// The univariate domain is the skip domain with the extension dimension dropped.
-		let univariate_domain = BinarySubspace::<B8>::with_dim(LOG_WORD_SIZE_BITS + 1)
+		let univariate_domain = BinarySubspace::<B8>::with_dim(Word::LOG_BITS + 1)
 			.isomorphic::<B128>()
 			.reduce_dim(SKIPPED_VARS);
 		let lagrange = lagrange_evals_scalars(&univariate_domain, z_challenge);

--- a/crates/m4-prover/src/shift.rs
+++ b/crates/m4-prover/src/shift.rs
@@ -4,10 +4,7 @@
 
 #![allow(unused)]
 
-use binius_core::{
-	consts::{LOG_WORD_SIZE_BITS, WORD_SIZE_BITS},
-	word::Word,
-};
+use binius_core::word::Word;
 use binius_field::{BinaryField, PackedField};
 use binius_ip::sumcheck::SumcheckOutput;
 use binius_ip_prover::channel::IPProverChannel;
@@ -32,13 +29,13 @@ use crate::ValueTable2;
 
 /// The number of variables in each "g" (and "h") multilinear of phase 1: one 6-bit shift-amount
 /// axis and one 6-bit bit-position axis.
-const LOG_LEN: usize = LOG_WORD_SIZE_BITS + LOG_WORD_SIZE_BITS;
+const LOG_LEN: usize = Word::LOG_BITS + Word::LOG_BITS;
 
 /// A committed witness word after folding its bits into the field.
 ///
 /// Each 64-bit word contributes one field element per bit position, so a folded word is the oblong
 /// representation of that word: its bit axis expanded to full field elements.
-pub type FoldedWord<F> = [F; WORD_SIZE_BITS];
+pub type FoldedWord<F> = [F; Word::BITS];
 
 /// Folds the committed witness of a batch value table along the instance axis.
 ///
@@ -59,10 +56,10 @@ pub type FoldedWord<F> = [F; WORD_SIZE_BITS];
 /// so each set bit contributes its instance's equality weight to a full field element.
 ///
 /// The bit axis occupies the low coordinates and the word axis the high coordinates.
-/// The result is a multilinear over `LOG_WORD_SIZE_BITS + log2(n_committed)` variables:
+/// The result is a multilinear over `Word::LOG_BITS + log2(n_committed)` variables:
 ///
 /// ```text
-/// index = w * WORD_SIZE_BITS + b     (b occupies the low LOG_WORD_SIZE_BITS coordinates)
+/// index = w * Word::BITS + b     (b occupies the low Word::LOG_BITS coordinates)
 /// ```
 ///
 /// The table stores exactly the committed (hidden) words, so nothing here is excluded.
@@ -98,11 +95,11 @@ where
 	let folder = WordFolder::<F>::new(r_rho);
 
 	// Each output chunk holds one committed word position:
-	//     out[w * WORD_SIZE_BITS + b] = sum_rho eq(r_rho, rho) * bit_b(word[rho][w]).
+	//     out[w * Word::BITS + b] = sum_rho eq(r_rho, rho) * bit_b(word[rho][w]).
 	// The word positions are independent, so fold them in parallel.
 	// Positions beyond the committed count keep their zero padding.
-	let mut out = vec![F::ZERO; 1 << (LOG_WORD_SIZE_BITS + log_committed)];
-	out.par_chunks_mut(WORD_SIZE_BITS)
+	let mut out = vec![F::ZERO; 1 << (Word::LOG_BITS + log_committed)];
+	out.par_chunks_mut(Word::BITS)
 		.take(n_committed)
 		.enumerate()
 		.for_each(|(w, slot)| {
@@ -190,7 +187,7 @@ where
 		challenges: mut r_jr_s,
 		eval: gamma,
 	} = phase_1_output;
-	let r_s = r_jr_s.split_off(LOG_WORD_SIZE_BITS);
+	let r_s = r_jr_s.split_off(Word::LOG_BITS);
 	let r_j = r_jr_s;
 	let r_j_tensor = eq_ind_partial_eval::<F>(&r_j);
 
@@ -241,7 +238,7 @@ where
 ///
 /// The result is a flat accumulator split into `SHIFT_VARIANT_COUNT` multilinears of [`LOG_LEN`]
 /// variables each. Each multilinear is indexed by `(shift amount, bit position)`: for shift key
-/// `id = (variant << LOG_WORD_SIZE_BITS) | amount`, the slot at `id * WORD_SIZE_BITS + bit`
+/// `id = (variant << Word::LOG_BITS) | amount`, the slot at `id * Word::BITS + bit`
 /// accumulates, over every word carrying that key, the word's folded bit times the key's
 /// lambda-weighted partial evaluation tensor.
 ///
@@ -275,7 +272,7 @@ pub fn build_g_parts_from_folded_words<F: BinaryField>(
 			);
 
 			// Scatter the accumulator across this key's bit slots, scaling each by the folded bit.
-			let bit_base = key.id as usize * WORD_SIZE_BITS;
+			let bit_base = key.id as usize * Word::BITS;
 			for (bit, &folded_bit) in word.iter().enumerate() {
 				multilinears[bit_base + bit] += acc * folded_bit;
 			}
@@ -510,7 +507,7 @@ mod tests {
 	//     sum_{rho, w, b} eq(r_rho, rho) * eq(r_wire, w) * eq(r_bit, b) * bit_b(word[rho][w])
 	//
 	// The evaluation point `r` is fresh and unrelated to the reduction's own r_z / r_x challenges;
-	// its low LOG_WORD_SIZE_BITS coordinates are the bit axis and its high coordinates are the word
+	// its low Word::LOG_BITS coordinates are the bit axis and its high coordinates are the word
 	// axis, matching the layout `fold_instances` produces.
 	#[test]
 	fn fold_instances_commutes_with_evaluation() {
@@ -521,7 +518,7 @@ mod tests {
 
 		// Cover every chunk regime of the per-column fold.
 		// A sub-chunk batch (< CHUNK_SIZE instances), exactly one chunk, and several chunks.
-		for log_instances in [3, LOG_WORD_SIZE_BITS, LOG_WORD_SIZE_BITS + 2] {
+		for log_instances in [3, Word::LOG_BITS, Word::LOG_BITS + 2] {
 			let n_instances = 1usize << log_instances;
 
 			let inputs: Vec<[u64; N_INPUT_WORDS]> = (0..n_instances)
@@ -538,7 +535,7 @@ mod tests {
 
 			// The instance-fold point, and a fresh point over the (bit, word) axes.
 			let r_rho = random_scalars::<B128>(&mut rng, log_instances);
-			let r = random_scalars::<B128>(&mut rng, LOG_WORD_SIZE_BITS + log_committed);
+			let r = random_scalars::<B128>(&mut rng, Word::LOG_BITS + log_committed);
 
 			// Route A: fold the instance axis, then evaluate the resulting (bit, word) multilinear
 			// at r.
@@ -547,7 +544,7 @@ mod tests {
 
 			// Route B: fold each word's bits by the tensor expansion of the bit coordinates, then
 			// evaluate the resulting (word, instance) multilinear over the word and instance axes.
-			let (r_bit, r_wire) = r.split_at(LOG_WORD_SIZE_BITS);
+			let (r_bit, r_wire) = r.split_at(Word::LOG_BITS);
 			let bit_tensor = eq_ind_partial_eval_scalars::<B128>(r_bit);
 
 			// Gather the committed words of every instance, instance-major: index = rho *
@@ -606,7 +603,7 @@ mod tests {
 		words: std::ops::Range<usize>,
 	) -> Vec<FoldedWord<B128>> {
 		let eq = eq_ind_partial_eval_scalars::<B128>(r_rho);
-		let mut folded = vec![[B128::ZERO; WORD_SIZE_BITS]; words.len()];
+		let mut folded = vec![[B128::ZERO; Word::BITS]; words.len()];
 		for (rho, &weight) in eq.iter().enumerate() {
 			// Reconstruct this instance independently of the fold, then fold its chosen word range.
 			let vv = table.instance_value_vec(rho, constants);
@@ -659,7 +656,7 @@ mod tests {
 
 		// The univariate bit challenge, the constraint challenge, and the instance challenge.
 		let domain_subspace =
-			BinarySubspace::<AESTowerField8b>::with_dim(LOG_WORD_SIZE_BITS).isomorphic();
+			BinarySubspace::<AESTowerField8b>::with_dim(Word::LOG_BITS).isomorphic();
 		let r_z = B128::random(&mut rng);
 		let r_x = random_scalars::<B128>(&mut rng, log2_strict_usize(cs.n_and_constraints()));
 		let r_rho = random_scalars::<B128>(&mut rng, log_instances);
@@ -669,7 +666,7 @@ mod tests {
 		let folded = fold_instances::<B128, P>(&table, &r_rho);
 		let scalars: Vec<B128> = folded.iter_scalars().collect();
 		let folded_witness: Vec<FoldedWord<B128>> = scalars
-			.chunks_exact(WORD_SIZE_BITS)
+			.chunks_exact(Word::BITS)
 			.map(|chunk| chunk.try_into().unwrap())
 			.collect();
 		let offset = table.layout().offset_witness;
@@ -778,7 +775,7 @@ mod tests {
 
 		// The univariate bit challenge, the constraint challenge, and the instance challenge.
 		let domain_subspace =
-			BinarySubspace::<AESTowerField8b>::with_dim(LOG_WORD_SIZE_BITS).isomorphic();
+			BinarySubspace::<AESTowerField8b>::with_dim(Word::LOG_BITS).isomorphic();
 		let r_z = B128::random(&mut rng);
 		let r_x = random_scalars::<B128>(&mut rng, log2_strict_usize(cs.n_and_constraints()));
 		let r_rho = random_scalars::<B128>(&mut rng, log_instances);

--- a/crates/m4-verifier/src/bitand.rs
+++ b/crates/m4-verifier/src/bitand.rs
@@ -2,12 +2,13 @@
 
 //! Verifier for the batched BitAnd reduction of the data-parallel M4 proof system.
 
+use binius_core::word::Word;
 use binius_field::AESTowerField8b as B8;
 use binius_ip::channel::IPVerifierChannel;
 use binius_math::BinarySubspace;
 use binius_verifier::{
 	Error,
-	config::{B128, LOG_WORD_SIZE_BITS, PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES},
+	config::{B128, PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES},
 	protocols::bitand::{AndCheckOutput, verify_with_channel},
 };
 
@@ -56,7 +57,7 @@ where
 	// The prover sends round-message evaluations over exactly this domain.
 	let eval_domain = BinarySubspace::<B8>::default()
 		.isomorphic::<B128>()
-		.reduce_dim(LOG_WORD_SIZE_BITS + 1);
+		.reduce_dim(Word::LOG_BITS + 1);
 
 	// The first few zerocheck coordinates are pinned to fixed small-field elements.
 	// The prover pins the same prefix, so both sides agree on this split.

--- a/crates/prover/benches/fold_words.rs
+++ b/crates/prover/benches/fold_words.rs
@@ -3,7 +3,7 @@ use binius_core::word::Word;
 use binius_field::arch::OptimalPackedB128;
 use binius_math::test_utils::random_scalars;
 use binius_prover::fold_word::fold_words;
-use binius_verifier::config::{B128, WORD_SIZE_BITS};
+use binius_verifier::config::B128;
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use rand::prelude::*;
 
@@ -21,7 +21,7 @@ fn bench_fold_words(c: &mut Criterion) {
 			let words = (0..n_words)
 				.map(|_| Word::from_u64(rng.random::<u64>()))
 				.collect::<Vec<_>>();
-			let vec = random_scalars::<B128>(&mut rng, WORD_SIZE_BITS);
+			let vec = random_scalars::<B128>(&mut rng, Word::BITS);
 
 			b.iter(|| fold_words::<_, OptimalPackedB128>(&words, &vec));
 		});

--- a/crates/prover/benches/intmul.rs
+++ b/crates/prover/benches/intmul.rs
@@ -26,7 +26,7 @@ use binius_prover::protocols::intmul::{
 use binius_transcript::ProverTranscript;
 use binius_utils::rayon::ThreadPoolBuilder;
 use binius_verifier::{
-	config::{LOG_WORD_SIZE_BITS, StdChallenger},
+	config::StdChallenger,
 	protocols::intmul::common::{LIMB_BITS, frobenius_twist},
 };
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
@@ -181,7 +181,7 @@ fn bench_intmul_phases(c: &mut Criterion) {
 		let mut prover = IntMulProver::<P, _>::new(0, &mut transcript);
 		prover.phase1(&initial_eval_point, witness.b_prodcheck.clone(), &witness.b_leaves, exp_eval)
 	};
-	let phase2 = frobenius_twist(LOG_WORD_SIZE_BITS, &phase1.eval_point, &phase1.b_leaves_evals);
+	let phase2 = frobenius_twist(Word::LOG_BITS, &phase1.eval_point, &phase1.b_leaves_evals);
 	let phase3 = {
 		let mut transcript = ProverTranscript::new(StdChallenger::default());
 		let mut prover = IntMulProver::<P, _>::new(0, &mut transcript);
@@ -226,9 +226,8 @@ fn bench_intmul_phases(c: &mut Criterion) {
 
 	// The Frobenius twist consumes nothing by value, so no per-iteration clone is needed.
 	group.bench_function("phase2_frobenius_twist", |bencher| {
-		bencher.iter(|| {
-			frobenius_twist(LOG_WORD_SIZE_BITS, &phase1.eval_point, &phase1.b_leaves_evals)
-		});
+		bencher
+			.iter(|| frobenius_twist(Word::LOG_BITS, &phase1.eval_point, &phase1.b_leaves_evals));
 	});
 
 	group.bench_function("phase3", |bencher| {
@@ -335,7 +334,7 @@ fn bench_intmul_components(c: &mut Criterion) {
 	group.bench_function("product_tree", |bencher| {
 		bencher.iter_batched(
 			|| witness.b_leaves.clone(),
-			|b_leaves| ProdcheckProver::<P>::new(LOG_WORD_SIZE_BITS, b_leaves),
+			|b_leaves| ProdcheckProver::<P>::new(Word::LOG_BITS, b_leaves),
 			BatchSize::SmallInput,
 		);
 	});
@@ -353,7 +352,7 @@ fn bench_intmul_components(c: &mut Criterion) {
 		let mut prover = IntMulProver::<P, _>::new(0, &mut transcript);
 		prover.phase1(&initial_eval_point, witness.b_prodcheck.clone(), &witness.b_leaves, exp_eval)
 	};
-	let phase2 = frobenius_twist(LOG_WORD_SIZE_BITS, &phase1.eval_point, &phase1.b_leaves_evals);
+	let phase2 = frobenius_twist(Word::LOG_BITS, &phase1.eval_point, &phase1.b_leaves_evals);
 
 	group.bench_function("selector_sumcheck", |bencher| {
 		let mut rng = rand::rng();
@@ -368,7 +367,7 @@ fn bench_intmul_components(c: &mut Criterion) {
 						value,
 					})
 					.collect();
-				let gamma = random_scalars::<F>(&mut rng, LOG_WORD_SIZE_BITS);
+				let gamma = random_scalars::<F>(&mut rng, Word::LOG_BITS);
 				let eq_weights = eq_ind_partial_eval_scalars::<F>(&gamma);
 				(witness.a_root.clone(), claims, eq_weights)
 			},

--- a/crates/prover/benches/shift_reduction.rs
+++ b/crates/prover/benches/shift_reduction.rs
@@ -20,7 +20,7 @@ use binius_prover::{
 use binius_transcript::ProverTranscript;
 use binius_utils::checked_arithmetics::strict_log_2;
 use binius_verifier::{
-	config::{LOG_WORD_SIZE_BITS, StdChallenger},
+	config::StdChallenger,
 	protocols::shift::{OperatorData as VerifierOperatorData, verify},
 };
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
@@ -111,7 +111,7 @@ fn bench_prove_and_verify(c: &mut Criterion) {
 		let bitand_evals = [F::random(&mut rng); 3];
 		let intmul_evals = [F::ZERO; 4];
 		let key_collection = build_key_collection(&cs);
-		let subspace = BinarySubspace::<AESTowerField8b>::with_dim(LOG_WORD_SIZE_BITS).isomorphic();
+		let subspace = BinarySubspace::<AESTowerField8b>::with_dim(Word::LOG_BITS).isomorphic();
 
 		let mut group = c.benchmark_group(format!(
 			"shift_reduction_log2_{log_message_len_bytes}_bytes_{message_len_bytes}"
@@ -213,7 +213,7 @@ fn bench_shift_phases(c: &mut Criterion) {
 
 	let key_collection = build_key_collection(&cs);
 	let words = value_vec.combined_witness();
-	let subspace = BinarySubspace::<AESTowerField8b>::with_dim(LOG_WORD_SIZE_BITS).isomorphic();
+	let subspace = BinarySubspace::<AESTowerField8b>::with_dim(Word::LOG_BITS).isomorphic();
 
 	// Prepare the operator data. Lambda sampling is cheap and not part of any benched phase, so a
 	// random lambda (rather than one drawn from a transcript) yields realistic-magnitude data.
@@ -273,7 +273,7 @@ fn bench_shift_phases(c: &mut Criterion) {
 		run_phase_1_sumcheck::<F, P, _>(g_parts.clone(), h_parts.clone(), &mut transcript)
 	};
 	// Split phase-1 challenges into `r_j` (low) and `r_s` (high) halves.
-	let r_s = r_jr_s.split_off(LOG_WORD_SIZE_BITS);
+	let r_s = r_jr_s.split_off(Word::LOG_BITS);
 	let r_j = r_jr_s;
 	let r_j_tensor = eq_ind_partial_eval::<F>(&r_j);
 	let (public_words, hidden_words) = words.split_at(key_collection.public.n_words());

--- a/crates/prover/src/fold_word.rs
+++ b/crates/prover/src/fold_word.rs
@@ -3,10 +3,7 @@
 
 use std::{array, borrow::Cow, iter};
 
-use binius_core::{
-	consts::{LOG_WORD_SIZE_BITS, WORD_SIZE_BITS, WORD_SIZE_BYTES},
-	word::Word,
-};
+use binius_core::word::Word;
 use binius_field::{
 	BinaryField, Field, PackedField,
 	linear_transformation::{
@@ -22,12 +19,12 @@ use binius_math::{
 use binius_utils::{checked_arithmetics::log2_ceil_usize, rayon::prelude::*};
 
 /// Base-2 logarithm of the number of words folded together within a single chunk.
-const LOG_CHUNK_SIZE: usize = LOG_WORD_SIZE_BITS;
+const LOG_CHUNK_SIZE: usize = Word::LOG_BITS;
 /// Number of words folded together within a single chunk.
 const CHUNK_SIZE: usize = 1 << LOG_CHUNK_SIZE;
 /// Number of bits in a byte; [`fold_across_words`] processes each chunk in groups of this many
 /// words, one per byte of the words.
-const BITS_PER_BYTE: usize = WORD_SIZE_BITS / WORD_SIZE_BYTES;
+const BITS_PER_BYTE: usize = Word::BITS / Word::BYTES;
 
 /// Computes a [`FieldBuffer`] where each element is the inner product of the bits of a word and a
 /// vector of field elements.
@@ -42,7 +39,7 @@ const BITS_PER_BYTE: usize = WORD_SIZE_BITS / WORD_SIZE_BYTES;
 /// length; the high words up to that rounded-up length are treated as zero.
 ///
 /// ## Preconditions
-/// * `vec` contains exactly [`binius_core::consts::WORD_SIZE_BITS`] elements
+/// * `vec` contains exactly [`Word::BITS`] elements
 ///
 /// [Method of Four Russians]: <https://en.wikipedia.org/wiki/Method_of_Four_Russians>
 pub fn fold_words<F, P>(words: &[Word], vec: &[F]) -> FieldBuffer<P>
@@ -110,7 +107,7 @@ where
 /// * `words.len() == 1 << point.len()`
 ///
 /// [Method of Four Russians]: <https://en.wikipedia.org/wiki/Method_of_Four_Russians>
-pub fn fold_across_words<F, P>(words: &[Word], point: &[F]) -> [F; WORD_SIZE_BITS]
+pub fn fold_across_words<F, P>(words: &[Word], point: &[F]) -> [F; Word::BITS]
 where
 	F: BinaryField,
 	P: PackedField<Scalar = F>,
@@ -140,7 +137,7 @@ where
 			acc
 		})
 		.reduce(
-			|| [F::ZERO; WORD_SIZE_BITS],
+			|| [F::ZERO; Word::BITS],
 			|mut lhs, rhs| {
 				for (lhs_i, rhs_i) in iter::zip(&mut lhs, rhs) {
 					*lhs_i += rhs_i;
@@ -168,7 +165,7 @@ pub struct WordFolder<F: BinaryField> {
 	///
 	/// Table `s` folds the words at positions `s * BITS_PER_BYTE + t` within a chunk.
 	/// Each such word is weighted by prefix-expansion entry `t` of that group.
-	lookups: [[F; 1 << BITS_PER_BYTE]; WORD_SIZE_BYTES],
+	lookups: [[F; 1 << BITS_PER_BYTE]; Word::BYTES],
 	/// One weight per chunk of `CHUNK_SIZE` words, from the suffix expansion.
 	suffix_weights: FieldBuffer<F>,
 	/// The exact word-list length each [`fold`](Self::fold) consumes: `2^point.len()`.
@@ -192,15 +189,13 @@ impl<F: BinaryField> WordFolder<F> {
 
 		// Build one 256-entry subset-sum lookup table per byte of the words.
 		// The prefix tensor expansion has CHUNK_SIZE entries, one per word in a chunk.
-		// Split those entries into WORD_SIZE_BYTES groups of BITS_PER_BYTE.
+		// Split those entries into Word::BYTES groups of BITS_PER_BYTE.
 		let prefix_expansion = eq_ind_partial_eval_scalars::<F>(&prefix);
-		let lookups: [[F; 1 << BITS_PER_BYTE]; WORD_SIZE_BYTES] = array::from_fn(|byte| {
+		let lookups: [[F; 1 << BITS_PER_BYTE]; Word::BYTES] = array::from_fn(|byte| {
 			let group: [F; BITS_PER_BYTE] = prefix_expansion
 				[byte * BITS_PER_BYTE..(byte + 1) * BITS_PER_BYTE]
 				.try_into()
-				.expect(
-					"prefix_expansion has CHUNK_SIZE = WORD_SIZE_BYTES * BITS_PER_BYTE entries",
-				);
+				.expect("prefix_expansion has CHUNK_SIZE = Word::BYTES * BITS_PER_BYTE entries");
 			expand_subset_sums_array(group)
 		});
 
@@ -230,7 +225,7 @@ impl<F: BinaryField> WordFolder<F> {
 	/// ## Preconditions
 	///
 	/// * `words.len() == 1 << point.len()`
-	pub fn fold(&self, words: &[Word]) -> [F; WORD_SIZE_BITS] {
+	pub fn fold(&self, words: &[Word]) -> [F; Word::BITS] {
 		assert_eq!(words.len(), self.n_words, "words.len() must equal 2^point.len()");
 
 		let chunks = duplicate_to_fixed_chunks::<CHUNK_SIZE>(words);
@@ -238,7 +233,7 @@ impl<F: BinaryField> WordFolder<F> {
 
 		// Accumulate each chunk's contribution, scaled by its suffix weight.
 		// The accumulator stays in the chunk kernel's transposed bit layout until the end.
-		let mut folded = [F::ZERO; WORD_SIZE_BITS];
+		let mut folded = [F::ZERO; Word::BITS];
 		for (chunk, &suffix_weight) in iter::zip(chunks.as_ref(), self.suffix_weights.as_ref()) {
 			let acc = fold_chunk(chunk, &self.lookups);
 			for (folded_i, acc_i) in iter::zip(&mut folded, acc) {
@@ -253,11 +248,11 @@ impl<F: BinaryField> WordFolder<F> {
 /// Transposes a reduced chunk accumulator back into bit-position order.
 ///
 /// The chunk kernel stores bit `BITS_PER_BYTE * j + a`'s contribution at index `BITS_PER_BYTE * a +
-/// j`. Transposing that `WORD_SIZE_BYTES`-by-`BITS_PER_BYTE` layout restores bit-position order.
-fn transpose_accumulator<F: BinaryField>(folded: [F; WORD_SIZE_BITS]) -> [F; WORD_SIZE_BITS] {
-	let mut result = [F::ZERO; WORD_SIZE_BITS];
+/// j`. Transposing that `Word::BYTES`-by-`BITS_PER_BYTE` layout restores bit-position order.
+fn transpose_accumulator<F: BinaryField>(folded: [F; Word::BITS]) -> [F; Word::BITS] {
+	let mut result = [F::ZERO; Word::BITS];
 	for a in 0..BITS_PER_BYTE {
-		for j in 0..WORD_SIZE_BYTES {
+		for j in 0..Word::BYTES {
 			result[BITS_PER_BYTE * j + a] = folded[BITS_PER_BYTE * a + j];
 		}
 	}
@@ -272,15 +267,13 @@ fn transpose_accumulator<F: BinaryField>(folded: [F; WORD_SIZE_BITS]) -> [F; WOR
 /// transposes the reduced accumulator back into bit-position order.
 fn fold_chunk<F: BinaryField>(
 	chunk: &[Word; CHUNK_SIZE],
-	lookups: &[[F; 1 << BITS_PER_BYTE]; WORD_SIZE_BYTES],
-) -> [F; WORD_SIZE_BITS] {
+	lookups: &[[F; 1 << BITS_PER_BYTE]; Word::BYTES],
+) -> [F; Word::BITS] {
 	// Reshape the chunk into one sub-array per lookup table, each holding BITS_PER_BYTE words.
-	let subchunks = bytemuck::must_cast_ref::<
-		[Word; CHUNK_SIZE],
-		[[Word; BITS_PER_BYTE]; WORD_SIZE_BYTES],
-	>(chunk);
+	let subchunks =
+		bytemuck::must_cast_ref::<[Word; CHUNK_SIZE], [[Word; BITS_PER_BYTE]; Word::BYTES]>(chunk);
 
-	let mut acc = [F::ZERO; WORD_SIZE_BITS];
+	let mut acc = [F::ZERO; Word::BITS];
 	for (subchunk, lookup) in iter::zip(subchunks, lookups) {
 		// After the transpose, byte `j` of output word `a` collects bit `BITS_PER_BYTE * j + a`
 		// across the BITS_PER_BYTE words of this sub-chunk. Looking it up sums the prefix weights
@@ -298,7 +291,7 @@ fn fold_chunk<F: BinaryField>(
 
 /// Bit-transposes the within-byte bit axis and the word axis of [`BITS_PER_BYTE`] words in place.
 ///
-/// Viewing the input and output as `BITS_PER_BYTE`×`WORD_SIZE_BYTES`×`BITS_PER_BYTE` bit matrices
+/// Viewing the input and output as `BITS_PER_BYTE`×`Word::BYTES`×`BITS_PER_BYTE` bit matrices
 /// where the axes are (bit within a byte, byte within a word, word), this permutes
 /// `out[i][j][k] = in[k][j][i]`, leaving the byte-within-word axis `j` unchanged. After the call,
 /// byte `j` of word `i` holds, in bit `k`, the value of bit `BITS_PER_BYTE * j + i` of input word
@@ -361,7 +354,6 @@ pub(crate) fn duplicate_to_fixed_chunks<const N: usize>(words: &[Word]) -> Cow<'
 
 #[cfg(test)]
 mod tests {
-	use binius_core::consts::WORD_SIZE_BITS;
 	use binius_field::arch::OptimalPackedB128;
 	use binius_math::test_utils::random_scalars;
 	use binius_utils::checked_arithmetics::log2_strict_usize;
@@ -375,7 +367,7 @@ mod tests {
 		F: Field,
 		P: PackedField<Scalar = F>,
 	{
-		assert_eq!(vec.len(), WORD_SIZE_BITS);
+		assert_eq!(vec.len(), Word::BITS);
 		assert!(words.len().is_power_of_two());
 
 		let log_n = log2_strict_usize(words.len());
@@ -386,7 +378,7 @@ mod tests {
 				P::from_scalars(word_chunk.iter().map(|&word| {
 					// Decompose word into bits and compute inner product
 					let mut sum = F::ZERO;
-					for bit_idx in 0..WORD_SIZE_BITS {
+					for bit_idx in 0..Word::BITS {
 						if (word.as_u64() >> bit_idx) & 1 == 1 {
 							sum += vec[bit_idx];
 						}
@@ -410,7 +402,7 @@ mod tests {
 			.map(|_| Word::from_u64(rng.random::<u64>()))
 			.collect::<Vec<_>>();
 
-		let vec = random_scalars(&mut rng, WORD_SIZE_BITS);
+		let vec = random_scalars(&mut rng, Word::BITS);
 
 		// Compute using both methods
 		let result_optimized = fold_words::<B128, B128>(&words, &vec);
@@ -420,11 +412,11 @@ mod tests {
 		assert_eq!(result_optimized, result_naive);
 	}
 
-	fn naive_fold_across_words<F: BinaryField>(words: &[Word], point: &[F]) -> [F; WORD_SIZE_BITS] {
+	fn naive_fold_across_words<F: BinaryField>(words: &[Word], point: &[F]) -> [F; Word::BITS] {
 		assert_eq!(words.len(), 1 << point.len());
 
 		let eq = eq_ind_partial_eval_scalars(point);
-		let mut out = [F::ZERO; WORD_SIZE_BITS];
+		let mut out = [F::ZERO; Word::BITS];
 		for (word, &weight) in iter::zip(words, &eq) {
 			for (bit_idx, out_i) in out.iter_mut().enumerate() {
 				if (word.as_u64() >> bit_idx) & 1 == 1 {
@@ -447,7 +439,7 @@ mod tests {
 			// out[i][j][k] = in[k][j][i]: bit `BITS_PER_BYTE * j + k` of output word `i` equals bit
 			// `BITS_PER_BYTE * j + i` of input word `k`.
 			for i in 0..BITS_PER_BYTE {
-				for j in 0..WORD_SIZE_BYTES {
+				for j in 0..Word::BYTES {
 					for k in 0..BITS_PER_BYTE {
 						let out_bit = (output[i].as_u64() >> (BITS_PER_BYTE * j + k)) & 1;
 						let in_bit = (input[k].as_u64() >> (BITS_PER_BYTE * j + i)) & 1;

--- a/crates/prover/src/protocols/intmul/prove.rs
+++ b/crates/prover/src/protocols/intmul/prove.rs
@@ -31,12 +31,9 @@ use binius_math::{
 	},
 };
 use binius_utils::{checked_arithmetics::log2_ceil_usize, rayon::prelude::*};
-use binius_verifier::{
-	config::{LOG_WORD_SIZE_BITS, WORD_SIZE_BITS},
-	protocols::intmul::common::{
-		IntMulOutput, LIMB_BITS, LOG_N_LIMBS, N_LIMB_COLUMNS, N_LIMBS, Phase1Output, Phase2Output,
-		Phase3Output, Phase4Output, frobenius_twist, limb_column_twists, twist_limb_claim,
-	},
+use binius_verifier::protocols::intmul::common::{
+	IntMulOutput, LIMB_BITS, LOG_N_LIMBS, N_LIMB_COLUMNS, N_LIMBS, Phase1Output, Phase2Output,
+	Phase3Output, Phase4Output, frobenius_twist, limb_column_twists, twist_limb_claim,
 };
 use either::Either;
 use itertools::izip;
@@ -74,7 +71,7 @@ where
 	/// This method consumes a `Witness` in order to reduce integer multiplication statement to
 	/// evaluation claims on 1-bit multilinears. More formally:
 	///  * `witness` contains po2-sized integer arrays  `a`, `b`, `c_lo` and `c_hi` that satisfy `a
-	///    * b = c_lo | c_hi << WORD_SIZE_BITS`, as well as the layers of the constant- and
+	///    * b = c_lo | c_hi << Word::BITS`, as well as the layers of the constant- and
 	///      variable-base GKR product check circuits
 	///  * The proving consists of five phases:
 	///    - Phase 1: GKR tree roots for B & C are evaluated at a sampled point, after which
@@ -135,7 +132,7 @@ where
 			twisted_eval_points,
 			twisted_evals,
 		} = tracing::debug_span!("IntMul phase2 (Frobenius twist)")
-			.in_scope(|| frobenius_twist(LOG_WORD_SIZE_BITS, &phase1_eval_point, &b_leaves_evals));
+			.in_scope(|| frobenius_twist(Word::LOG_BITS, &phase1_eval_point, &b_leaves_evals));
 
 		// Phase 3
 		let Phase3Output {
@@ -441,7 +438,7 @@ where
 		// 2^k claims with a multilinear one; the verifier mirrors it by weighting the corresponding
 		// terms by eq_k(γ, ·). γ is sampled before the batched sumcheck so the round polynomials
 		// are fixed against it.
-		let gamma = self.channel.sample_many(LOG_WORD_SIZE_BITS);
+		let gamma = self.channel.sample_many(Word::LOG_BITS);
 		let eq_weights = eq_ind_partial_eval_scalars::<F>(&gamma);
 		// `SelectorMlecheckProver` reads the exponent bits through the `Bitwise` bitmask
 		// abstraction, which is implemented for the primitive integer types. `Word` is
@@ -472,7 +469,7 @@ where
 			.try_into()
 			.expect("batch_prove with two provers returns length-2 multilinear_evals");
 
-		assert_eq!(selector_prover_evals.len(), 1 + WORD_SIZE_BITS);
+		assert_eq!(selector_prover_evals.len(), 1 + Word::BITS);
 
 		let gpow_a_eval = selector_prover_evals
 			.pop()
@@ -485,7 +482,7 @@ where
 		// Recombine the 2^k per-bit b(i, r) claims into a single claim b(r_I^b, r) by sampling a
 		// recombination point r_I^b in K^k, matching the verifier. This carries one exponent claim
 		// (rather than 2^k) into Phases 4 and 5.
-		let r_ib = self.channel.sample_many(LOG_WORD_SIZE_BITS);
+		let r_ib = self.channel.sample_many(Word::LOG_BITS);
 		let b_recomb = evaluate(&FieldBuffer::<P>::from_values(&b_evals), &r_ib);
 
 		Phase3Output {

--- a/crates/prover/src/protocols/intmul/tests.rs
+++ b/crates/prover/src/protocols/intmul/tests.rs
@@ -8,7 +8,7 @@ use binius_iop_prover::naive_channel::NaiveProverChannel;
 use binius_math::{inner_product::inner_product_buffers, multilinear::eq::eq_ind_partial_eval};
 use binius_transcript::ProverTranscript;
 use binius_verifier::{
-	config::{LOG_WORD_SIZE_BITS, StdChallenger},
+	config::StdChallenger,
 	protocols::intmul::{
 		common::{IntMulOutput, LIMB_BITS},
 		verify,
@@ -24,7 +24,7 @@ type F = BinaryField128bGhash;
 type P = PackedBinaryGhash2x128b;
 
 pub fn evaluate_witness(words: &[Word], eval_point: &[F]) -> F {
-	let (prefix, suffix) = eval_point.split_at(LOG_WORD_SIZE_BITS);
+	let (prefix, suffix) = eval_point.split_at(Word::LOG_BITS);
 	let prefix_tensor = eq_ind_partial_eval::<F>(prefix);
 	let suffix_tensor = eq_ind_partial_eval::<F>(suffix);
 
@@ -83,9 +83,7 @@ fn prove_and_verify() {
 	// Instead of evaluating each exponent bit column
 	// separately, we batch them together with a `z_challenge`
 	// and check consistency by evaluating at a single point `consistency_check_eval_point`.
-	let z_challenge: Vec<F> = (0..LOG_WORD_SIZE_BITS)
-		.map(|_| F::random(&mut rng))
-		.collect();
+	let z_challenge: Vec<F> = (0..Word::LOG_BITS).map(|_| F::random(&mut rng)).collect();
 	let z_tensor = eq_ind_partial_eval::<F>(&z_challenge);
 	let consistency_check_eval_point = [z_challenge, eval_point].concat();
 	let get_consistency_check_eval =

--- a/crates/prover/src/protocols/intmul/witness.rs
+++ b/crates/prover/src/protocols/intmul/witness.rs
@@ -12,10 +12,7 @@ use binius_utils::{
 	rayon::prelude::*,
 	strided_array::StridedArray2DViewMut,
 };
-use binius_verifier::{
-	config::{LOG_WORD_SIZE_BITS, WORD_SIZE_BITS},
-	protocols::intmul::common::{LIMB_BITS, LOG_N_LIMBS, N_LIMBS},
-};
+use binius_verifier::protocols::intmul::common::{LIMB_BITS, LOG_N_LIMBS, N_LIMBS};
 use getset::Getters;
 use itertools::iterate;
 
@@ -25,7 +22,7 @@ use super::error::Error;
 /// proving.
 ///
 /// The statement being proven is `a * b = c`, where `c` is represented as a pair `(c_lo, c_hi)`:
-/// `WORD_SIZE_BITS`-wide multiplicands with a double-wide product.
+/// `Word::BITS`-wide multiplicands with a double-wide product.
 ///
 /// For each of `a`, `c_lo`, `c_hi` the exponent words split into `N_LIMBS` limbs, and the
 /// constant-base exponentiation factors as a product of `N_LIMBS` limb columns — column `l` reads
@@ -34,8 +31,8 @@ use super::error::Error;
 /// limb index in the high bits, and a [`ProdcheckProver`] is constructed over each:
 ///  1) `a` and `c_lo` exponentiate the multiplicative group generator $G$
 ///  2) `c_hi` exponentiates $G^{2^{2^m}}$
-///  3) `b` selects a variable base (the root of the `a` tree) per bit, over `WORD_SIZE_BITS`
-///     per-bit leaves as before
+///  3) `b` selects a variable base (the root of the `a` tree) per bit, over `Word::BITS` per-bit
+///     leaves as before
 ///
 /// The shared power table $T\colon i \mapsto G^i$ over $2^w$ rows is retained for the Phase 5
 /// logup* lookup.
@@ -58,7 +55,7 @@ pub struct Witness<'a, P: PackedField> {
 	#[getset(skip)]
 	pub b_exponents: &'a [Word],
 	/// Concatenated b leaves for prodcheck: [L_0, L_1, ..., L_{2^k-1}].
-	/// Has log_len = n_vars + LOG_WORD_SIZE_BITS.
+	/// Has log_len = n_vars + Word::LOG_BITS.
 	pub b_leaves: FieldBuffer<P>,
 	/// The prover for the prodcheck reduction on b_leaves.
 	pub b_prodcheck: ProdcheckProver<P>,
@@ -98,7 +95,7 @@ where
 		c_lo: &'a [Word],
 		c_hi: &'a [Word],
 	) -> Result<Self, Error> {
-		assert!(2 * WORD_SIZE_BITS <= F::N_BITS);
+		assert!(2 * Word::BITS <= F::N_BITS);
 
 		// Statement should be of pow-2 length.
 		let Some(n_vars) = strict_log_2(a.len()) else {
@@ -115,7 +112,7 @@ where
 
 		// The 2·N_LIMBS twisted power tables: tables[s][i] = (G^{2^{ws}})^i. The `a` and `c_lo`
 		// limb columns read tables 0..N_LIMBS; the `c_hi` limb columns (base
-		// G^{2^{WORD_SIZE_BITS}}) read tables N_LIMBS..2·N_LIMBS. Table 0 is the shared logup*
+		// G^{2^{Word::BITS}}) read tables N_LIMBS..2·N_LIMBS. Table 0 is the shared logup*
 		// table.
 		let power_table_scope = tracing::debug_span!("Build power tables").entered();
 		let g = F::MULTIPLICATIVE_GENERATOR;
@@ -147,7 +144,7 @@ where
 		let variable_base_tree_scope =
 			tracing::debug_span!("Compute variable-base prodcheck layers").entered();
 		let b_leaves = compute_b_leaves(&a_root, b);
-		let (b_prodcheck, b_root) = ProdcheckProver::new(LOG_WORD_SIZE_BITS, b_leaves.clone());
+		let (b_prodcheck, b_root) = ProdcheckProver::new(Word::LOG_BITS, b_leaves.clone());
 		drop(variable_base_tree_scope);
 
 		Ok(Self {
@@ -285,11 +282,11 @@ where
 	}
 
 	// Fallback: bases is too small to parallelize (n_vars < P::LOG_WIDTH)
-	let mut out = FieldBuffer::zeros(n_vars + LOG_WORD_SIZE_BITS);
+	let mut out = FieldBuffer::zeros(n_vars + Word::LOG_BITS);
 	let n_elems = 1 << n_vars;
 
 	for (i, (mut base, &exp)) in iter::zip(bases.iter_scalars(), exponents).enumerate() {
-		for z in 0..WORD_SIZE_BITS {
+		for z in 0..Word::BITS {
 			// Branchless select of `base` when bit `z` is set, else `F::ONE`: on the selected lane
 			// `mask` is all-ones so `select` keeps `base - 1` and the `+ 1` restores `base`; on the
 			// unselected lane `select` yields `0` and the `+ 1` gives `F::ONE`.
@@ -311,7 +308,7 @@ where
 {
 	let n_vars = bases.log_len();
 	let n_packed = bases.as_ref().len();
-	let height = WORD_SIZE_BITS;
+	let height = Word::BITS;
 	let total = n_packed * height;
 
 	let mut out_vec: Vec<P> = Vec::with_capacity(total);
@@ -346,7 +343,7 @@ where
 	// SAFETY: All elements initialized in the parallel loop above
 	unsafe { out_vec.set_len(total) };
 
-	FieldBuffer::new(n_vars + LOG_WORD_SIZE_BITS, out_vec.into_boxed_slice())
+	FieldBuffer::new(n_vars + Word::LOG_BITS, out_vec.into_boxed_slice())
 }
 
 /// Compute the per-vertex bivariate product of two equally sized field buffers.
@@ -490,7 +487,7 @@ mod tests {
 
 			for (i, &base0) in base_scalars.iter().enumerate() {
 				let mut base = base0;
-				for z in 0..WORD_SIZE_BITS {
+				for z in 0..Word::BITS {
 					let expected = if exponents[i].extract_bit(z) {
 						base
 					} else {

--- a/crates/prover/src/protocols/shift/key_collection.rs
+++ b/crates/prover/src/protocols/shift/key_collection.rs
@@ -8,7 +8,7 @@ use binius_core::{
 	constraint_system::{
 		AndConstraint, ConstraintSystem, MulConstraint, Operand, ShiftedValueIndex,
 	},
-	consts::LOG_WORD_SIZE_BITS,
+	word::Word,
 };
 use binius_field::{Field, WideMul};
 use binius_utils::{
@@ -52,7 +52,7 @@ pub enum Operation {
 /// # Relationship to Formal Specification
 ///
 /// The paper defines one `M` multilinear polynomial for each (operation, operand, shift variant)
-/// tuple. Each `M` multilinear forms a 3D matrix that decomposes into `WORD_SIZE_BITS`
+/// tuple. Each `M` multilinear forms a 3D matrix that decomposes into `Word::BITS`
 /// 2D matrices. Each `Key` corresponds to one such 2D matrix. We operate at 2D granularity
 /// because the prover performs field operations on 2D matrices during both protocol phases.
 ///
@@ -67,7 +67,7 @@ pub enum Operation {
 /// The `id` packs three values:
 /// - Operand index (which operand in the constraint)
 /// - Shift variant (logical left, logical right, arithmetic right)
-/// - Shift amount (0 to `WORD_SIZE_BITS-1` bits)
+/// - Shift amount (0 to `Word::BITS-1` bits)
 ///
 /// This ordering places shift information (fundamental to Binius64) in lower bits,
 /// with operation and operand data in higher bits. Future operations can simply extend
@@ -297,7 +297,7 @@ fn update_with_operand(
 				ShiftVariant::Sra32 => 6,
 				ShiftVariant::Rotr32 => 7,
 			};
-			let id = (shift_variant_val << LOG_WORD_SIZE_BITS) + *amount as u16;
+			let id = (shift_variant_val << Word::LOG_BITS) + *amount as u16;
 
 			// Find existing builder key or create a new one for this (operation, id) pair
 			let constraint_index = ConstraintIndex {

--- a/crates/prover/src/protocols/shift/monster.rs
+++ b/crates/prover/src/protocols/shift/monster.rs
@@ -3,15 +3,13 @@
 
 use std::iter;
 
+use binius_core::word::Word;
 use binius_field::{BinaryField, Field, PackedField, WideMul};
 use binius_math::{
 	BinarySubspace, FieldBuffer, multilinear::eq::eq_ind_partial_eval, univariate::lagrange_evals,
 };
 use binius_utils::{checked_arithmetics::checked_log_2, rayon::prelude::*};
-use binius_verifier::{
-	config::WORD_SIZE_BITS,
-	protocols::shift::{BITAND_ARITY, INTMUL_ARITY, evaluate_h_op},
-};
+use binius_verifier::protocols::shift::{BITAND_ARITY, INTMUL_ARITY, evaluate_h_op};
 use bytemuck::zeroed_vec;
 use tracing::instrument;
 
@@ -42,9 +40,9 @@ where
 	let l_tilde = l_tilde.as_ref();
 
 	fn build_part<F: Field, P: PackedField<Scalar = F>>(
-		fill: impl Fn(usize, &mut [F; WORD_SIZE_BITS]),
+		fill: impl Fn(usize, &mut [F; Word::BITS]),
 	) -> FieldBuffer<P> {
-		let mut data = zeroed_vec::<[F; WORD_SIZE_BITS]>(WORD_SIZE_BITS);
+		let mut data = zeroed_vec::<[F; Word::BITS]>(Word::BITS);
 		for (s, chunk) in data.iter_mut().enumerate() {
 			fill(s, chunk);
 		}
@@ -52,21 +50,21 @@ where
 	}
 
 	let sll = build_part(|s, sll_s| {
-		sll_s[..WORD_SIZE_BITS - s].copy_from_slice(&l_tilde[s..]);
+		sll_s[..Word::BITS - s].copy_from_slice(&l_tilde[s..]);
 	});
 
 	let srl = build_part(|s, srl_s| {
-		srl_s[s..].copy_from_slice(&l_tilde[..WORD_SIZE_BITS - s]);
+		srl_s[s..].copy_from_slice(&l_tilde[..Word::BITS - s]);
 	});
 
 	let sra = build_part(|s, sra_s| {
-		sra_s[s..].copy_from_slice(&l_tilde[..WORD_SIZE_BITS - s]);
-		sra_s[WORD_SIZE_BITS - 1] += l_tilde[WORD_SIZE_BITS - s..].iter().sum::<F>();
+		sra_s[s..].copy_from_slice(&l_tilde[..Word::BITS - s]);
+		sra_s[Word::BITS - 1] += l_tilde[Word::BITS - s..].iter().sum::<F>();
 	});
 
 	let rotr = build_part(|s, rotr_s| {
-		rotr_s[..s].copy_from_slice(&l_tilde[WORD_SIZE_BITS - s..]);
-		rotr_s[s..].copy_from_slice(&l_tilde[..WORD_SIZE_BITS - s]);
+		rotr_s[..s].copy_from_slice(&l_tilde[Word::BITS - s..]);
+		rotr_s[s..].copy_from_slice(&l_tilde[..Word::BITS - s]);
 	});
 
 	let sll32 = build_part(|s, sll32_s| {
@@ -127,7 +125,7 @@ where
 /// ```
 /// where `scalars[key.id]` is the contiguous per-operand chunk encoding
 /// `λ^(operand_idx+1) × h_op[shift_variant] × r_s_tensor[shift_amount]` for operand index
-/// `operand_idx` and `shift_variant` in {SLL, SRL, SRA} and `shift_amount` in [0, WORD_SIZE_BITS).
+/// `operand_idx` and `shift_variant` in {SLL, SRL, SRA} and `shift_amount` in [0, Word::BITS).
 ///
 /// # Usage
 ///
@@ -160,15 +158,15 @@ where
 	let r_s_tensor = eq_ind_partial_eval::<F>(r_s);
 
 	// Allocate and populate the scalars, laid out with the operand index innermost so that the
-	// `arity` weights for one `key.id` (= `op * WORD_SIZE_BITS + s`) form a contiguous chunk that
+	// `arity` weights for one `key.id` (= `op * Word::BITS + s`) form a contiguous chunk that
 	// [`Key::accumulate`] can index directly by operand index.
-	let mut bitand_scalars = vec![F::ZERO; BITAND_ARITY * SHIFT_VARIANT_COUNT * WORD_SIZE_BITS];
-	let mut intmul_scalars = vec![F::ZERO; INTMUL_ARITY * SHIFT_VARIANT_COUNT * WORD_SIZE_BITS];
+	let mut bitand_scalars = vec![F::ZERO; BITAND_ARITY * SHIFT_VARIANT_COUNT * Word::BITS];
+	let mut intmul_scalars = vec![F::ZERO; INTMUL_ARITY * SHIFT_VARIANT_COUNT * Word::BITS];
 
 	let populate_scalars = |scalars: &mut [F], arity: usize, lambda_powers: &[F], h_ops: &[F]| {
 		for op in 0..SHIFT_VARIANT_COUNT {
-			for s in 0..WORD_SIZE_BITS {
-				let key_id = op * WORD_SIZE_BITS + s;
+			for s in 0..Word::BITS {
+				let key_id = op * Word::BITS + s;
 				let op_s_scalar = h_ops[op] * r_s_tensor.as_ref()[s];
 				for operand_idx in 0..arity {
 					scalars[key_id * arity + operand_idx] =
@@ -250,7 +248,7 @@ where
 mod tests {
 	use binius_field::{AESTowerField8b, BinaryField128bGhash, PackedBinaryGhash2x128b, Random};
 	use binius_math::{inner_product::inner_product_buffers, multilinear::eq::eq_ind_partial_eval};
-	use binius_verifier::{config::LOG_WORD_SIZE_BITS, protocols::shift::evaluate_h_op};
+	use binius_verifier::protocols::shift::evaluate_h_op;
 	use rand::{SeedableRng, rngs::StdRng};
 
 	use super::*;
@@ -273,8 +271,7 @@ mod tests {
 			let r_s: Vec<F> = (0..6).map(|_| F::random(&mut rng)).collect();
 
 			// Method 1: Succinct evaluation using `evaluate_h_op`
-			let subspace =
-				BinarySubspace::<AESTowerField8b>::with_dim(LOG_WORD_SIZE_BITS).isomorphic();
+			let subspace = BinarySubspace::<AESTowerField8b>::with_dim(Word::LOG_BITS).isomorphic();
 			let l_tilde = lagrange_evals(&subspace, r_zhat_prime);
 			let succinct_evaluations = evaluate_h_op(l_tilde.as_ref(), &r_j, &r_s);
 

--- a/crates/prover/src/protocols/shift/phase_1.rs
+++ b/crates/prover/src/protocols/shift/phase_1.rs
@@ -12,10 +12,7 @@ use binius_ip_prover::{
 };
 use binius_math::{BinarySubspace, FieldBuffer, inner_product::inner_product_buffers};
 use binius_utils::rayon::prelude::*;
-use binius_verifier::{
-	config::{LOG_WORD_SIZE_BITS, WORD_SIZE_BITS, WORD_SIZE_BYTES},
-	protocols::shift::SHIFT_VARIANT_COUNT,
-};
+use binius_verifier::protocols::shift::SHIFT_VARIANT_COUNT;
 use bytemuck::zeroed_vec;
 use itertools::izip;
 use tracing::instrument;
@@ -27,7 +24,7 @@ use super::{
 };
 
 // This is the number of variables in the g (and h) multilinears of phase 1.
-const LOG_LEN: usize = LOG_WORD_SIZE_BITS + LOG_WORD_SIZE_BITS;
+const LOG_LEN: usize = Word::LOG_BITS + Word::LOG_BITS;
 
 /// Constructs the "g" multilinear parts for both BITAND and INTMUL operations.
 /// Proves the first phase of the shift reduction.
@@ -105,7 +102,7 @@ pub fn run_phase_1_sumcheck<F: Field, P: PackedField<Scalar = F>, Channel: IPPro
 		.collect::<Vec<_>>();
 
 	// Perform the sumcheck rounds, collecting challenges.
-	let n_vars = 2 * LOG_WORD_SIZE_BITS;
+	let n_vars = 2 * Word::LOG_BITS;
 	let mut challenges = Vec::with_capacity(n_vars);
 	for _ in 0..n_vars {
 		let mut all_round_coeffs = Vec::new();
@@ -223,14 +220,14 @@ pub fn build_g_parts<F: BinaryField, P: PackedField<Scalar = F>>(
 					let acc_packed = P::broadcast(acc);
 
 					// The following loop is an optimized version of the following
-					// for i in 0..WORD_SIZE_BITS {
+					// for i in 0..Word::BITS {
 					//     if get_bit(word, i) {
 					//         values[start + i] += acc;
 					//     }
 					// }
-					let start = key.id as usize * (WORD_SIZE_BITS >> P::LOG_WIDTH);
-					let values = &mut multilinears[start..start + (WORD_SIZE_BITS >> P::LOG_WIDTH)];
-					let values_per_byte = WORD_SIZE_BYTES >> P::LOG_WIDTH;
+					let start = key.id as usize * (Word::BITS >> P::LOG_WIDTH);
+					let values = &mut multilinears[start..start + (Word::BITS >> P::LOG_WIDTH)];
+					let values_per_byte = Word::BYTES >> P::LOG_WIDTH;
 					let mut remaining_word = word.0;
 					let mut byte_index = 0;
 					while remaining_word != 0 {

--- a/crates/prover/src/protocols/shift/phase_2.rs
+++ b/crates/prover/src/protocols/shift/phase_2.rs
@@ -18,7 +18,7 @@ use binius_math::{
 	multilinear::eq::{eq_ind_partial_eval, eq_ind_zero},
 };
 use binius_utils::{checked_arithmetics::checked_log_2, rayon::prelude::*};
-use binius_verifier::{config::LOG_WORD_SIZE_BITS, protocols::shift::evaluate_words_mle};
+use binius_verifier::protocols::shift::evaluate_words_mle;
 use tracing::instrument;
 
 use super::{
@@ -69,10 +69,10 @@ where
 		challenges: mut r_jr_s,
 		eval: gamma,
 	} = phase_1_output;
-	// Split challenges as r_j,r_s where r_j is the first LOG_WORD_SIZE_BITS
-	// variables and r_s is the last LOG_WORD_SIZE_BITS variables
+	// Split challenges as r_j,r_s where r_j is the first Word::LOG_BITS
+	// variables and r_s is the last Word::LOG_BITS variables
 	// Thus r_s are the more significant variables.
-	let r_s = r_jr_s.split_off(LOG_WORD_SIZE_BITS);
+	let r_s = r_jr_s.split_off(Word::LOG_BITS);
 	let r_j = r_jr_s;
 
 	let r_j_tensor = eq_ind_partial_eval::<F>(&r_j);

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -21,9 +21,7 @@ use binius_transcript::{ProverTranscript, fiat_shamir::Challenger};
 use binius_utils::{SerializeBytes, checked_arithmetics::checked_log_2, rayon::prelude::*};
 use binius_verifier::{
 	IOPVerifier, Verifier,
-	config::{
-		B128, LOG_WORD_SIZE_BITS, LOG_WORDS_PER_ELEM, PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES,
-	},
+	config::{B128, LOG_WORDS_PER_ELEM, PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES},
 	protocols::{bitand::AndCheckOutput, intmul::IntMulOutput},
 };
 use digest::Output;
@@ -169,7 +167,7 @@ impl IOPProver {
 		// Build the oblong domain subspace once and pass it into the shift reduction, mirroring
 		// the verifier side (`shift::check_eval` takes the domain subspace). It is reused for the
 		// IntMul claim collapse below.
-		let subspace = BinarySubspace::<B8>::with_dim(LOG_WORD_SIZE_BITS).isomorphic();
+		let subspace = BinarySubspace::<B8>::with_dim(Word::LOG_BITS).isomorphic();
 		let intmul_claim = match intmul_output {
 			Some(IntMulOutput {
 				eval_point,
@@ -422,7 +420,7 @@ where
 	PChallenge: PackedField<Scalar = F>,
 	Channel: binius_ip_prover::channel::IPProverChannel<F>,
 {
-	let prover_message_domain = BinarySubspace::<B8>::with_dim(LOG_WORD_SIZE_BITS + 1);
+	let prover_message_domain = BinarySubspace::<B8>::with_dim(Word::LOG_BITS + 1);
 	let AndCheckWitness { a, b, c } = witness;
 
 	let log_constraint_count = checked_log_2(a.len());

--- a/crates/prover/tests/shift.rs
+++ b/crates/prover/tests/shift.rs
@@ -22,7 +22,7 @@ use binius_prover::{
 use binius_transcript::ProverTranscript;
 use binius_utils::checked_arithmetics::{log2_ceil_usize, strict_log_2};
 use binius_verifier::{
-	config::{LOG_WORD_SIZE_BITS, StdChallenger},
+	config::StdChallenger,
 	protocols::shift::{OperatorData as VerifierOperatorData, check_eval, verify},
 };
 use itertools::Itertools;
@@ -236,7 +236,7 @@ fn test_shift_prove_and_verify() {
 		// `r_zhat_prime` so the verifier can compute `h_op_evals` once for both.
 		let r_zhat_prime = F::random(&mut rng);
 
-		let subspace = BinarySubspace::<AESTowerField8b>::with_dim(LOG_WORD_SIZE_BITS).isomorphic();
+		let subspace = BinarySubspace::<AESTowerField8b>::with_dim(Word::LOG_BITS).isomorphic();
 
 		let bitand_evals = compute_bitand_images(&cs.and_constraints, &value_vec).map(|image| {
 			evaluate_image(

--- a/crates/verifier/src/config.rs
+++ b/crates/verifier/src/config.rs
@@ -1,10 +1,11 @@
 // Copyright 2025 Irreducible Inc.
 //! Specifies standard trait implementations and parameters.
 
+use binius_core::word::Word;
 use binius_field::{AESTowerField8b, BinaryField, BinaryField1b, BinaryField128bGhash};
 use binius_hash::StdDigest;
 use binius_transcript::fiat_shamir::{Challenger, HasherChallenger};
-use binius_utils::checked_arithmetics::{checked_int_div, checked_log_2};
+use binius_utils::checked_arithmetics::checked_log_2;
 
 // Exports the binary fields that this system uses
 pub type B1 = BinaryField1b;
@@ -22,13 +23,8 @@ impl ChallengerWithName for HasherChallenger<StdDigest> {
 /// The default [`binius_transcript::fiat_shamir::Challenger`] implementation.
 pub type StdChallenger = HasherChallenger<StdDigest>;
 
-/// The protocol proves constraint systems over 64-bit words.
-pub const WORD_SIZE_BITS: usize = 64;
-pub const WORD_SIZE_BYTES: usize = checked_int_div(WORD_SIZE_BITS, 8);
-
-/// log2 of [`WORD_SIZE_BITS`].
-pub const LOG_WORD_SIZE_BITS: usize = checked_log_2(WORD_SIZE_BITS);
-pub const LOG_WORDS_PER_ELEM: usize = checked_log_2(B128::N_BITS) - LOG_WORD_SIZE_BITS;
+/// log2 of the number of [`Word`]s packed into one field element.
+pub const LOG_WORDS_PER_ELEM: usize = checked_log_2(B128::N_BITS) - Word::LOG_BITS;
 
 pub const PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES: [AESTowerField8b; 3] = [
 	AESTowerField8b::new(0x2),

--- a/crates/verifier/src/protocols/bitand.rs
+++ b/crates/verifier/src/protocols/bitand.rs
@@ -9,7 +9,7 @@ use binius_math::{BinarySubspace, univariate::extrapolate_over_subspace};
 use crate::Error;
 
 /// log2 size of the univariate domain
-pub const SKIPPED_VARS: usize = binius_core::consts::LOG_WORD_SIZE_BITS;
+pub const SKIPPED_VARS: usize = binius_core::Word::LOG_BITS;
 
 /// Size of the univariate domain
 pub const ROWS_PER_HYPERCUBE_VERTEX: usize = 1 << SKIPPED_VARS;

--- a/crates/verifier/src/protocols/intmul/common.rs
+++ b/crates/verifier/src/protocols/intmul/common.rs
@@ -3,10 +3,9 @@
 
 use std::iter;
 
+use binius_core::word::Word;
 use binius_field::{BinaryField, field::FieldOps};
 use itertools::iterate;
-
-use crate::config::LOG_WORD_SIZE_BITS;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct IntMulOutput<F> {
@@ -59,7 +58,7 @@ pub const LOG_N_LIMBS: usize = 2;
 pub const N_LIMBS: usize = 1 << LOG_N_LIMBS;
 
 /// The bit width of one exponent limb; the lookup table has `2^LIMB_BITS` rows.
-pub const LIMB_BITS: usize = 1 << (LOG_WORD_SIZE_BITS - LOG_N_LIMBS);
+pub const LIMB_BITS: usize = 1 << (Word::LOG_BITS - LOG_N_LIMBS);
 
 /// The number of looked-up limb columns: one per limb of $\widetilde{a}$,
 /// $\widetilde{c}_{\textsf{lo}}$, and $\widetilde{c}_{\textsf{hi}}$.

--- a/crates/verifier/src/protocols/intmul/verify.rs
+++ b/crates/verifier/src/protocols/intmul/verify.rs
@@ -3,6 +3,7 @@
 
 use std::iter;
 
+use binius_core::word::Word;
 use binius_field::{BinaryField, BinaryField1b, ExtensionField, Field, field::FieldOps};
 use binius_iop::{channel::IOPVerifierChannel, logup_star};
 use binius_ip::{
@@ -25,7 +26,6 @@ use super::{
 	},
 	error::Error,
 };
-use crate::config::{LOG_WORD_SIZE_BITS, WORD_SIZE_BITS};
 
 /// Verify Phase 1: GKR step on the exponentiation product tree.
 ///
@@ -47,16 +47,16 @@ where
 		eval: initial_b_eval,
 		point: initial_eval_point.to_vec(),
 	};
-	let output_claim = prodcheck::verify(LOG_WORD_SIZE_BITS, claim, channel)?;
+	let output_claim = prodcheck::verify(Word::LOG_BITS, claim, channel)?;
 
 	// Split output point: first n are x-point, last k are z-challenges
 	let (eval_point, z_suffix) = output_claim.point.split_at(n_vars);
 
 	// Read 2^k leaf evaluations from channel
-	let b_leaves_evals = channel.recv_many(WORD_SIZE_BITS)?;
+	let b_leaves_evals = channel.recv_many(Word::BITS)?;
 
 	// Verify: output_claim.eval = multilinear_eval(b_leaves_evals, z_suffix)
-	// The leaf evals form a multilinear over LOG_WORD_SIZE_BITS variables; evaluate at z_suffix
+	// The leaf evals form a multilinear over Word::LOG_BITS variables; evaluate at z_suffix
 	let expected_eval = evaluate_inplace_scalars(b_leaves_evals.clone(), z_suffix);
 
 	channel.assert_zero(expected_eval - output_claim.eval)?;
@@ -85,7 +85,7 @@ where
 {
 	let n_vars = c_eval_point.len();
 
-	assert_eq!(twisted_eval_points.len(), WORD_SIZE_BITS);
+	assert_eq!(twisted_eval_points.len(), Word::BITS);
 
 	for twisted_eval_point in &twisted_eval_points {
 		assert_eq!(twisted_eval_point.len(), c_eval_point.len());
@@ -100,7 +100,7 @@ where
 	// The two batched terms (each degree 3) are:
 	// - the 2^k aggregate: Σ_i eq_k(γ, i) * (b(i, X) * (A(X) - 1) + 1) * eq(φ⁻ⁱ(x) ; X)
 	// - LO(X) * HI(X) * eq(c_eval_point ; X)
-	let gamma = channel.sample_many(LOG_WORD_SIZE_BITS);
+	let gamma = channel.sample_many(Word::LOG_BITS);
 	let selector_agg_eval = evaluate_inplace_scalars(twisted_evals, &gamma);
 	let evals = [selector_agg_eval, c_eval];
 
@@ -112,7 +112,7 @@ where
 	challenges.reverse();
 
 	// b(i, r) for i in 0..2^k
-	let b_evals = channel.recv_many(WORD_SIZE_BITS)?;
+	let b_evals = channel.recv_many(Word::BITS)?;
 
 	// A(r)
 	let gpow_a_eval = channel.recv_one()?;
@@ -123,7 +123,7 @@ where
 	// Recombine the 2^k per-bit exponent claims b(i, r) into a single claim b(r_I^b, r) by
 	// sampling a recombination point r_I^b in K^k. This carries one exponent claim (rather than
 	// 2^k) into Phases 4 and 5.
-	let r_ib = channel.sample_many(LOG_WORD_SIZE_BITS);
+	let r_ib = channel.sample_many(Word::LOG_BITS);
 	let b_recomb = evaluate_inplace_scalars(b_evals.clone(), &r_ib);
 
 	let eval_point = challenges;
@@ -312,10 +312,10 @@ where
 	let r_out = challenges.as_slice();
 
 	// The prover sends the raw per-bit evaluations at r_out.
-	let a_evals = channel.recv_many(WORD_SIZE_BITS)?;
-	let c_lo_evals = channel.recv_many(WORD_SIZE_BITS)?;
-	let c_hi_evals = channel.recv_many(WORD_SIZE_BITS)?;
-	let b_evals = channel.recv_many(WORD_SIZE_BITS)?;
+	let a_evals = channel.recv_many(Word::BITS)?;
+	let c_lo_evals = channel.recv_many(Word::BITS)?;
+	let c_hi_evals = channel.recv_many(Word::BITS)?;
+	let b_evals = channel.recv_many(Word::BITS)?;
 
 	// Bind the per-bit evals to the folded index claim. The index entries are the GF(2)-linear
 	// embeddings iota(e_{t,l}) = Σ_u basis(u) · bit_u(e_{t,l}), and bit u of limb l is bit
@@ -469,14 +469,14 @@ where
 /// - `n_vars`: Number of variables in the row dimension (i.e., $\log_2$ of the number of
 ///   multiplication constraints).
 ///
-/// The integer operands are fixed at the `WORD_SIZE_BITS` bit width.
+/// The integer operands are fixed at the `Word::BITS` bit width.
 pub fn verify<F, C>(n_vars: usize, channel: &mut C) -> Result<IntMulOutput<C::Elem>, Error>
 where
 	F: BinaryField,
 	C: IOPVerifierChannel<F>,
 	C::Elem: FieldOps<Scalar = F> + From<F>,
 {
-	assert!(2 * WORD_SIZE_BITS <= F::N_BITS);
+	assert!(2 * Word::BITS <= F::N_BITS);
 
 	let initial_eval_point = channel.sample_many(n_vars);
 
@@ -490,13 +490,13 @@ where
 	} = verify_phase_1(&initial_eval_point, exp_eval.clone(), channel)?;
 
 	assert_eq!(phase_1_eval_point.len(), n_vars);
-	assert_eq!(b_leaves_evals.len(), WORD_SIZE_BITS);
+	assert_eq!(b_leaves_evals.len(), Word::BITS);
 
 	// Phase 2
 	let Phase2Output {
 		twisted_eval_points,
 		twisted_evals,
-	} = frobenius_twist(LOG_WORD_SIZE_BITS, &phase_1_eval_point, &b_leaves_evals);
+	} = frobenius_twist(Word::LOG_BITS, &phase_1_eval_point, &b_leaves_evals);
 
 	// Phase 3
 	let Phase3Output {

--- a/crates/verifier/src/protocols/shift/monster.rs
+++ b/crates/verifier/src/protocols/shift/monster.rs
@@ -2,7 +2,7 @@
 
 use std::iter;
 
-use binius_core::constraint_system::Operand;
+use binius_core::{constraint_system::Operand, word::Word};
 use binius_field::{BinaryField, FieldOps, WideMul, util::powers};
 use binius_math::{
 	inner_product::inner_product_scalars, multilinear::eq::eq_ind_partial_eval_scalars,
@@ -13,7 +13,6 @@ use super::{
 	SHIFT_VARIANT_COUNT,
 	shift_ind::{partial_eval_phi, partial_eval_sigmas, partial_eval_sigmas_transpose},
 };
-use crate::config::{LOG_WORD_SIZE_BITS, WORD_SIZE_BITS};
 
 /// Evaluates the three h multilinear polynomials (corresponding to SLL, SRL, SRA) at challenge
 /// points.
@@ -21,9 +20,9 @@ use crate::config::{LOG_WORD_SIZE_BITS, WORD_SIZE_BITS};
 /// This is the verifier's version of the h-parts evaluation - instead of building
 /// full multilinear polynomials, it directly computes their evaluations.
 pub fn evaluate_h_op<E: FieldOps>(l_tilde: &[E], r_j: &[E], r_s: &[E]) -> [E; SHIFT_VARIANT_COUNT] {
-	assert_eq!(l_tilde.len(), WORD_SIZE_BITS);
-	assert_eq!(r_j.len(), LOG_WORD_SIZE_BITS);
-	assert_eq!(r_s.len(), LOG_WORD_SIZE_BITS);
+	assert_eq!(l_tilde.len(), Word::BITS);
+	assert_eq!(r_j.len(), Word::LOG_BITS);
+	assert_eq!(r_s.len(), Word::LOG_BITS);
 
 	// Use helper functions to compute shift indicator helpers for 64-bit shifts
 	let (sigma, sigma_prime) = partial_eval_sigmas(r_j, r_s);
@@ -108,7 +107,7 @@ pub fn evaluate_h_op<E: FieldOps>(l_tilde: &[E], r_j: &[E], r_s: &[E]) -> [E; SH
 /// * `r_x_prime` - The constraint challenge `r_x'`; its equality indicator tensor is expanded here.
 /// * `lambda` - Random coefficient for batching operand evaluations
 /// * `shift_scalars` - Tensor product of the shift-selector evaluations `h_op` and the shift-amount
-///   equality indicator `eq(r_s)`, indexed by `variant * WORD_SIZE_BITS + amount`. Shared across
+///   equality indicator `eq(r_s)`, indexed by `variant * Word::BITS + amount`. Shared across
 ///   operations.
 /// * `r_y_tensor` - Equality indicator tensor expansion of the word index challenge `r_y`
 ///
@@ -119,7 +118,7 @@ pub fn evaluate_monster_multilinear_for_operation<F, E>(
 	operand_vecs: &[Vec<&Operand>],
 	r_x_prime: &[E],
 	lambda: E,
-	shift_scalars: &[E; SHIFT_VARIANT_COUNT * WORD_SIZE_BITS],
+	shift_scalars: &[E; SHIFT_VARIANT_COUNT * Word::BITS],
 	r_y_tensor: &[E],
 ) -> E
 where
@@ -143,7 +142,7 @@ where
 		for (operand_id, operand_vec) in operand_vecs.iter().enumerate() {
 			for svi in operand_vec[constraint] {
 				let variant = svi.shift_variant as usize;
-				let index = (variant * WORD_SIZE_BITS + svi.amount as usize) * arity + operand_id;
+				let index = (variant * Word::BITS + svi.amount as usize) * arity + operand_id;
 				constraint_eval +=
 					operand_shift_scalars[index].clone() * &r_y_tensor[svi.value_index.0 as usize];
 			}
@@ -156,10 +155,10 @@ where
 
 /// Folds the operand batching coefficients (λ powers) into the shared shift scalars, producing a
 /// table indexed by `(variant, amount, operand_id)` whose entry is
-/// `shift_scalars[variant * WORD_SIZE_BITS + amount] · λ^{operand_id + 1}` — the scalar that
+/// `shift_scalars[variant * Word::BITS + amount] · λ^{operand_id + 1}` — the scalar that
 /// multiplies each shifted-value term.
 fn operand_shift_scalar_table<E: FieldOps>(
-	shift_scalars: &[E; SHIFT_VARIANT_COUNT * WORD_SIZE_BITS],
+	shift_scalars: &[E; SHIFT_VARIANT_COUNT * Word::BITS],
 	lambda: E,
 	arity: usize,
 ) -> Vec<E> {
@@ -184,7 +183,7 @@ pub(crate) fn evaluate_monster_multilinear_for_operation_native<F: BinaryField>(
 	operand_vecs: &[Vec<&Operand>],
 	r_x_prime: &[F],
 	lambda: F,
-	shift_scalars: &[F; SHIFT_VARIANT_COUNT * WORD_SIZE_BITS],
+	shift_scalars: &[F; SHIFT_VARIANT_COUNT * Word::BITS],
 	r_y_tensor: &[F],
 ) -> F {
 	let arity = operand_vecs.len();
@@ -206,8 +205,7 @@ pub(crate) fn evaluate_monster_multilinear_for_operation_native<F: BinaryField>(
 			for (operand_id, operand_vec) in operand_vecs.iter().enumerate() {
 				for svi in operand_vec[constraint] {
 					let variant = svi.shift_variant as usize;
-					let index =
-						(variant * WORD_SIZE_BITS + svi.amount as usize) * arity + operand_id;
+					let index = (variant * Word::BITS + svi.amount as usize) * arity + operand_id;
 					constraint_eval +=
 						operand_shift_scalars[index] * r_y_tensor[svi.value_index.0 as usize];
 				}
@@ -266,7 +264,7 @@ mod tests {
 								value_index: ValueIndex(rng.random_range(0..n_words) as u32),
 								shift_variant: shift_variants
 									[rng.random_range(0..SHIFT_VARIANT_COUNT)],
-								amount: rng.random_range(0..WORD_SIZE_BITS) as u8,
+								amount: rng.random_range(0..Word::BITS) as u8,
 							})
 							.collect()
 					})
@@ -277,7 +275,7 @@ mod tests {
 
 		let r_x_prime = random_scalars::<F>(&mut rng, log_constraints);
 		let lambda = F::random(&mut rng);
-		let shift_scalars: [F; SHIFT_VARIANT_COUNT * WORD_SIZE_BITS] =
+		let shift_scalars: [F; SHIFT_VARIANT_COUNT * Word::BITS] =
 			std::array::from_fn(|_| F::random(&mut rng));
 		let r_y_tensor = random_scalars::<F>(&mut rng, n_words);
 
@@ -308,7 +306,7 @@ mod tests {
 		// - sra == 1 iff i + s == j || i + s >= 64 && j == 63
 		// - rotr == 1 iff (i + s) % 64 == j
 		let mut rng = StdRng::seed_from_u64(0);
-		let subspace = BinarySubspace::<BinaryField128bGhash>::with_dim(LOG_WORD_SIZE_BITS);
+		let subspace = BinarySubspace::<BinaryField128bGhash>::with_dim(Word::LOG_BITS);
 
 		// Run a reasonable number of random trials
 		for _trial in 0..1024 {
@@ -319,8 +317,8 @@ mod tests {
 			let challenge = subspace.get(i);
 			let l_tilde = lagrange_evals_scalars(&subspace, challenge);
 
-			let r_j = index_to_hypercube_point::<BinaryField128bGhash>(LOG_WORD_SIZE_BITS, j);
-			let r_s = index_to_hypercube_point::<BinaryField128bGhash>(LOG_WORD_SIZE_BITS, s);
+			let r_j = index_to_hypercube_point::<BinaryField128bGhash>(Word::LOG_BITS, j);
+			let r_s = index_to_hypercube_point::<BinaryField128bGhash>(Word::LOG_BITS, s);
 
 			let [sll, srl, sra, rotr, sll32, srl32, sra32, rotr32] =
 				evaluate_h_op(&l_tilde, &r_j, &r_s);
@@ -367,13 +365,13 @@ mod tests {
 
 		// Generate random evaluation points
 		let challenge = BinaryField128bGhash::random(&mut rng);
-		let subspace = BinarySubspace::<BinaryField128bGhash>::with_dim(LOG_WORD_SIZE_BITS);
+		let subspace = BinarySubspace::<BinaryField128bGhash>::with_dim(Word::LOG_BITS);
 		let l_tilde = lagrange_evals_scalars(&subspace, challenge);
-		let r_j = random_scalars::<BinaryField128bGhash>(&mut rng, LOG_WORD_SIZE_BITS);
-		let r_s = random_scalars::<BinaryField128bGhash>(&mut rng, LOG_WORD_SIZE_BITS);
+		let r_j = random_scalars::<BinaryField128bGhash>(&mut rng, Word::LOG_BITS);
+		let r_s = random_scalars::<BinaryField128bGhash>(&mut rng, Word::LOG_BITS);
 
 		// Check linearity in each variable
-		for i in 0..LOG_WORD_SIZE_BITS {
+		for i in 0..Word::LOG_BITS {
 			// Check r_j[i]
 			let mut r_j_at_0 = r_j.clone();
 			r_j_at_0[i] = BinaryField128bGhash::ZERO;

--- a/crates/verifier/src/protocols/shift/verify.rs
+++ b/crates/verifier/src/protocols/shift/verify.rs
@@ -28,31 +28,30 @@ use super::{
 	evaluate_monster_multilinear_for_operation,
 	monster::evaluate_monster_multilinear_for_operation_native,
 };
-use crate::config::{LOG_WORD_SIZE_BITS, WORD_SIZE_BITS};
 
 /// Evaluates the bit-level multilinear extension of a word slice at the point `r_j ++ r_y`.
 ///
-/// The multilinear has `LOG_WORD_SIZE_BITS + r_y.len()` variables: the low variables index the
+/// The multilinear has `Word::LOG_BITS + r_y.len()` variables: the low variables index the
 /// bit within a word and the high variables index the word. Words past `words.len()` (up to
 /// `2^r_y.len()`) are treated as zero.
 ///
 /// ## Preconditions
 ///
-/// * `r_j` has exactly `LOG_WORD_SIZE_BITS` entries
+/// * `r_j` has exactly `Word::LOG_BITS` entries
 /// * `words` has at most `2^r_y.len()` entries
 pub fn evaluate_words_mle<F, E>(words: &[Word], r_j: &[E], r_y: &[E]) -> E
 where
 	F: BinaryField,
 	E: FieldOps<Scalar = F> + From<F>,
 {
-	assert_eq!(r_j.len(), LOG_WORD_SIZE_BITS); // precondition
+	assert_eq!(r_j.len(), Word::LOG_BITS); // precondition
 	assert!(words.len() <= 1 << r_y.len()); // precondition
 
 	let r_j_tensor = eq_ind_partial_eval_scalars(r_j);
 	let r_y_tensor = eq_ind_partial_eval_scalars(r_y);
 	iter::zip(words, r_y_tensor)
 		.map(|(word, weight)| {
-			let word_eval = (0..WORD_SIZE_BITS)
+			let word_eval = (0..Word::BITS)
 				.filter(|bit| (word.as_u64() >> bit) & 1 == 1)
 				.map(|bit| &r_j_tensor[bit])
 				.sum::<E>();
@@ -105,9 +104,9 @@ pub struct VerifyOutput<F> {
 	bitand_lambda: F,
 	/// Random coefficient for batching MUL constraint evaluations.
 	intmul_lambda: F,
-	/// Challenge point for the bit index variables (length `LOG_WORD_SIZE_BITS`).
+	/// Challenge point for the bit index variables (length `Word::LOG_BITS`).
 	pub r_j: Vec<F>,
-	/// Challenge point for the shift variables (length `LOG_WORD_SIZE_BITS`).
+	/// Challenge point for the shift variables (length `Word::LOG_BITS`).
 	pub r_s: Vec<F>,
 	/// Challenge point for the word index variables (length `log_witness_words`).
 	pub r_y: Vec<F>,
@@ -123,7 +122,7 @@ pub struct VerifyOutput<F> {
 impl<F> VerifyOutput<F> {
 	/// Returns the challenge point for bit index variables.
 	///
-	/// This corresponds to the first `LOG_WORD_SIZE_BITS` variables
+	/// This corresponds to the first `Word::LOG_BITS` variables
 	/// in the witness encoding, indexing individual bits within words.
 	pub fn r_j(&self) -> &[F] {
 		&self.r_j
@@ -131,7 +130,7 @@ impl<F> VerifyOutput<F> {
 
 	/// Returns the challenge point for shift variables.
 	///
-	/// This corresponds to `LOG_WORD_SIZE_BITS` variables encoding
+	/// This corresponds to `Word::LOG_BITS` variables encoding
 	/// the shift operations in the constraint system.
 	pub fn r_s(&self) -> &[F] {
 		&self.r_s
@@ -151,8 +150,7 @@ impl<F> VerifyOutput<F> {
 /// # Protocol Overview
 /// 1. **Sampling Phase**: Samples random lambda coefficients for batching bitand and intmul
 ///    evaluation claims across operands.
-/// 2. **First Sumcheck**: Verifies the batched evaluation claim over `LOG_WORD_SIZE_BITS * 2`
-///    variables
+/// 2. **First Sumcheck**: Verifies the batched evaluation claim over `Word::LOG_BITS * 2` variables
 /// 3. **Challenge Splitting**: Splits sumcheck challenges into `r_j` and `r_s` components
 /// 4. **Second Sumcheck**: Verifies the gamma claim over `log_word_count` variables
 /// 5. **Monster Multilinear Verification**: Checks that the claimed evaluations match expected
@@ -192,13 +190,13 @@ where
 	let SumcheckOutput {
 		eval: gamma,
 		challenges: mut r_jr_s,
-	} = verify_sumcheck(LOG_WORD_SIZE_BITS * 2, 2, eval, channel)?;
+	} = verify_sumcheck(Word::LOG_BITS * 2, 2, eval, channel)?;
 
 	r_jr_s.reverse();
-	// Split challenges as `r_j,r_s` where `r_j` is the first `LOG_WORD_SIZE_BITS`
-	// variables and `r_s` is the last `LOG_WORD_SIZE_BITS` variables
+	// Split challenges as `r_j,r_s` where `r_j` is the first `Word::LOG_BITS`
+	// variables and `r_s` is the last `Word::LOG_BITS` variables
 	// Thus `r_s` are the more significant variables.
-	let r_s = r_jr_s.split_off(LOG_WORD_SIZE_BITS);
+	let r_s = r_jr_s.split_off(Word::LOG_BITS);
 	let r_j = r_jr_s;
 
 	// The second sumcheck runs over the witness: the public segment in the low half-cube and
@@ -356,7 +354,7 @@ struct PublicWordsEvalFn<'a> {
 
 impl<F: BinaryField> FieldFn<F> for PublicWordsEvalFn<'_> {
 	fn call<E: FieldOps<Scalar = F> + From<F>>(&self, vals: &[E]) -> E {
-		let (r_j, r_y_low) = vals.split_at(LOG_WORD_SIZE_BITS);
+		let (r_j, r_y_low) = vals.split_at(Word::LOG_BITS);
 		evaluate_words_mle(self.public, r_j, r_y_low)
 	}
 }
@@ -398,7 +396,7 @@ impl<F: BinaryField> MonsterEvalFn<'_, F> {
 	fn evaluate<E, G>(&self, vals: &[E], eval_op: G) -> E
 	where
 		E: FieldOps<Scalar = F> + From<F>,
-		G: Fn(&[Vec<&Operand>], &[E], E, &[E; SHIFT_VARIANT_COUNT * WORD_SIZE_BITS], &[E]) -> E,
+		G: Fn(&[Vec<&Operand>], &[E], E, &[E; SHIFT_VARIANT_COUNT * Word::BITS], &[E]) -> E,
 	{
 		// Split the flat input back into its sections, in the order they were concatenated.
 		let r_zhat_prime_v = vals[0].clone();
@@ -450,11 +448,11 @@ impl<F: BinaryField> MonsterEvalFn<'_, F> {
 
 		// Tensor the shift-selector evaluations with the shift-amount equality indicator once, so
 		// both the BitAnd and IntMul monster evaluations share it. Indexed by
-		// `variant * WORD_SIZE_BITS + amount`.
+		// `variant * Word::BITS + amount`.
 		let eq_r_s = eq_ind_partial_eval_scalars(r_s_v);
 		let shift_scalars =
-			Box::new(array::from_fn::<_, { SHIFT_VARIANT_COUNT * WORD_SIZE_BITS }, _>(|i| {
-				h_op_evals[i / WORD_SIZE_BITS].clone() * &eq_r_s[i % WORD_SIZE_BITS]
+			Box::new(array::from_fn::<_, { SHIFT_VARIANT_COUNT * Word::BITS }, _>(|i| {
+				h_op_evals[i / Word::BITS].clone() * &eq_r_s[i % Word::BITS]
 			}));
 
 		// BitAnd contribution: operands (a, b, c) batched by `bitand_lambda`.
@@ -519,7 +517,7 @@ mod tests {
 		let words = (0..(1 << log_words) - 3)
 			.map(|_| Word::from_u64(rng.random::<u64>()))
 			.collect::<Vec<_>>();
-		let r_j = random_scalars::<B128>(&mut rng, LOG_WORD_SIZE_BITS);
+		let r_j = random_scalars::<B128>(&mut rng, Word::LOG_BITS);
 		let r_y = random_scalars::<B128>(&mut rng, log_words);
 
 		// Naive reference: sum the full bit-level eq tensor over every set bit.
@@ -527,9 +525,9 @@ mod tests {
 		let full_tensor = eq_ind_partial_eval_scalars::<B128>(&full_point);
 		let mut expected = B128::ZERO;
 		for (word_index, word) in words.iter().enumerate() {
-			for bit in 0..WORD_SIZE_BITS {
+			for bit in 0..Word::BITS {
 				if (word.as_u64() >> bit) & 1 == 1 {
-					expected += full_tensor[(word_index << LOG_WORD_SIZE_BITS) | bit];
+					expected += full_tensor[(word_index << Word::LOG_BITS) | bit];
 				}
 			}
 		}

--- a/crates/verifier/src/verify.rs
+++ b/crates/verifier/src/verify.rs
@@ -22,9 +22,7 @@ use itertools::chain;
 
 use super::error::Error;
 use crate::{
-	config::{
-		B1, B128, LOG_WORD_SIZE_BITS, LOG_WORDS_PER_ELEM, PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES,
-	},
+	config::{B1, B128, LOG_WORDS_PER_ELEM, PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES},
 	fri::{ConstantArityStrategy, FRIParams, calculate_n_test_queries},
 	merkle_tree::BinaryMerkleTreeScheme,
 	protocols::{
@@ -135,8 +133,8 @@ impl IOPVerifier {
 				.entered();
 
 		let subfield_subspace = BinarySubspace::<B8>::default().isomorphic();
-		let extended_subspace = subfield_subspace.reduce_dim(LOG_WORD_SIZE_BITS + 1);
-		let domain_subspace = extended_subspace.reduce_dim(LOG_WORD_SIZE_BITS);
+		let extended_subspace = subfield_subspace.reduce_dim(Word::LOG_BITS + 1);
+		let domain_subspace = extended_subspace.reduce_dim(Word::LOG_BITS);
 
 		// Receive the trace oracle commitment via channel. The trace is the witness, so it is
 		// witness-dependent (masked in a ZK proof).


### PR DESCRIPTION
Pure refactor — no behavior change. Turns the free `WORD_SIZE_*` constants into associated constants on `Word`, derived from the type itself.

### The problem

The word-size facts lived as free constants, hardcoded in **two** places:

- `binius_core::consts` — `WORD_SIZE_BYTES = 8`, `WORD_SIZE_BITS`, `LOG_WORD_SIZE_BITS`
- `binius_verifier::config` — its own `WORD_SIZE_BITS = 64` (a second, independent literal)

Two hardcoded copies of the same fact that can silently drift apart.
And a `Word` is a `#[repr(transparent)]` newtype over `u64` — so the literal `8` restates something the type already knows.

### The idea

Put the constants on `Word` as associated constants, derived from the type, mirroring std's `u64::BITS`:

```
impl Word {
    pub const BYTES: usize = size_of::<Word>();            // 8
    pub const BITS: usize = Self::BYTES * 8;               // 64
    pub const LOG_BITS: usize = checked_log_2(Self::BITS);  // 6
}
```

`size_of::<Word>()` ties the value to the actual layout, so it cannot drift from the inner `u64`. All three are `const`, so this is a compile-time value with zero runtime cost.

### The change

```
- use binius_core::consts::WORD_SIZE_BITS;
- ...  WORD_SIZE_BITS ...
+ use binius_core::Word;
+ ...  Word::BITS ...
```

- removed the free `WORD_SIZE_BYTES` / `WORD_SIZE_BITS` / `LOG_WORD_SIZE_BITS` from `core/consts.rs`
- removed the duplicate literal definitions from `verifier/config.rs`; `LOG_WORDS_PER_ELEM` now reads `Word::LOG_BITS`
- rewrote the ~354 call sites across six crates to `Word::*`, dropping every `use …::WORD_SIZE_*` import in favor of importing the `Word` type

### Naming

Chose `Word::BITS` / `Word::BYTES` / `Word::LOG_BITS` to mirror std's `u64::BITS` exactly — `Word` already hosts associated constants (`ZERO`, `ONE`, `ALL_ONE`, `MASK_32`, `MSB_ONE`), so this is its natural home.

### Scope

- **changed:** `core` (`word.rs`, `consts.rs`), `verifier`, `prover`, `circuits`, `frontend`, `m4-prover`, `m4-verifier` — 37 files, +254 / -302
- **left untouched:** `BYTE_BITS`, `LOG_BYTE_BITS`, `MIN_WORDS_PER_SEGMENT` stay as free constants in `core/consts.rs` (not word-size facts)

### Verification

- `cargo build --workspace --all-targets` — clean
- `cargo clippy --workspace --all-targets` — clean
- nightly `cargo fmt --all` — clean
- `cargo test` across the seven touched crates — all pass (342 core, 155 circuits, 76 verifier, 34 prover, …)
- note: `cargo check --workspace --all-targets` is red on `main` **independent of this change** — a pre-existing metadata-only error in `binius-ip` (`channel::call_native`) under the pinned `rustc 1.95.0`, reproduced with this branch's changes stashed. Full `cargo build --all-targets` (codegen) resolves it and is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)