### PR TITLE
docs: fix broken link to CLI framework in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ lto = "thin"
 
 ### Running Examples
 
-The `prover/examples/` directory contains example circuits, which you can run using the [CLI framework](https://www.binius.xyz/building/getting-started/cli).
+The `prover/examples/` directory contains example circuits, which you can run using the [CLI framework](https://www.binius.xyz/building/tutorials).
 
 For example, to run an example proving a SHA-512 preimage of a fixed-length 65536-byte message:
 


### PR DESCRIPTION
The linked page (/building/getting-started/cli) returns a 404 since the docs site was restructured. Point to the current Tutorials page, 
<img width="1280" height="800" alt="Знімок екрана 2026-07-10 о 19 09 11" src="https://github.com/user-attachments/assets/478503e2-9035-48db-a7a5-697c188485f9" />
which covers running the repository's example circuits.