### PR TITLE
BINIUS-247: rename ValueTable2 to ValueTable now that the original is gone

### DIFF
--- a/crates/m4-prover/benches/keccak_witness_gen.rs
+++ b/crates/m4-prover/benches/keccak_witness_gen.rs
@@ -1,5 +1,5 @@
 // Copyright 2026 The Binius Developers
-//! Witness-generation benchmark for [`ValueTable2`], serial and parallel.
+//! Witness-generation benchmark for [`ValueTable`], serial and parallel.
 //!
 //! The circuit applies one Keccak-f1600 permutation to a 25-word state. The state words are
 //! witness inputs and the permuted output words are force-committed, so the circuit has no inout
@@ -10,7 +10,7 @@ use std::array;
 use binius_circuits::keccak::permutation::Permutation;
 use binius_core::word::Word;
 use binius_frontend::{Circuit, CircuitBuilder, Wire};
-use binius_m4_prover::ValueTable2;
+use binius_m4_prover::ValueTable;
 use criterion::{Criterion, criterion_group, criterion_main};
 
 /// The base-2 logarithm of the instance count: 2^13 = 8192 instances.
@@ -19,7 +19,7 @@ const LOG_INSTANCES: usize = 13;
 /// The number of 64-bit lanes in a Keccak-f1600 state.
 const STATE_LANES: usize = 25;
 
-/// Candidate instance-stripe widths for parallel [`ValueTable2`] witness generation.
+/// Candidate instance-stripe widths for parallel [`ValueTable`] witness generation.
 const STRIPE_WIDTHS: [usize; 3] = [256, 512, 1024];
 
 /// Builds a circuit that applies one Keccak-f1600 permutation to a witness-input state and
@@ -55,9 +55,9 @@ fn bench_keccak_witness_gen(c: &mut Criterion) {
 	// Each iteration generates the witness for 8192 instances, so keep the sample count modest.
 	group.sample_size(10);
 
-	group.bench_function("value_table2", |b| {
+	group.bench_function("value_table", |b| {
 		b.iter(|| {
-			ValueTable2::populate(&circuit, LOG_INSTANCES, |instance, w| {
+			ValueTable::populate(&circuit, LOG_INSTANCES, |instance, w| {
 				for lane in 0..STATE_LANES {
 					w[input[lane]] = input_word(instance, lane);
 				}
@@ -67,9 +67,9 @@ fn bench_keccak_witness_gen(c: &mut Criterion) {
 	});
 
 	for stripe_width in STRIPE_WIDTHS {
-		group.bench_function(format!("value_table2_parallel_{stripe_width}"), |b| {
+		group.bench_function(format!("value_table_parallel_{stripe_width}"), |b| {
 			b.iter(|| {
-				ValueTable2::populate_parallel_with_stripe_width(
+				ValueTable::populate_parallel_with_stripe_width(
 					&circuit,
 					LOG_INSTANCES,
 					stripe_width,

--- a/crates/m4-prover/src/bitand.rs
+++ b/crates/m4-prover/src/bitand.rs
@@ -18,7 +18,7 @@ use binius_verifier::{
 	protocols::bitand::AndCheckOutput,
 };
 
-use crate::ValueTable2;
+use crate::ValueTable;
 
 /// Instance columns processed by one parallel witness-assembly task.
 ///
@@ -33,7 +33,7 @@ const STRIPE_WIDTH: usize = 256;
 /// It enforces the bitwise relation `A & B == C` on every row.
 ///
 /// This holds those three columns for a batch of `K = 2^log_instances` instances at once.
-/// The rows are stacked in instance-major order, the same layout the batch witness uses:
+/// The rows are stacked in instance-major order, with the instance index on the high coordinates:
 ///
 /// ```text
 ///         instance 0         instance 1            instance K-1
@@ -98,7 +98,7 @@ impl BatchAndCheckWitness {
 	///
 	/// Panics if the constraint count or the instance count is not a power of two.
 	pub fn build(
-		table: &ValueTable2,
+		table: &ValueTable,
 		constants: &[Word],
 		and_constraints: &[AndConstraint],
 	) -> Self {
@@ -460,9 +460,9 @@ mod tests {
 	//
 	// `w` is an arbitrary mask that only feeds the XOR, never the AND.
 	// So a tuple like `(1, 3, 7)` means `x=1, y=3, w=7`, not `1 & 3 = 7`.
-	fn populate_table(c: &AndCircuit, inputs: &[(u64, u64, u64)]) -> ValueTable2 {
+	fn populate_table(c: &AndCircuit, inputs: &[(u64, u64, u64)]) -> ValueTable {
 		let log_instances = inputs.len().ilog2() as usize;
-		ValueTable2::populate(&c.circuit, log_instances, |i, filler| {
+		ValueTable::populate(&c.circuit, log_instances, |i, filler| {
 			let (x, y, w) = inputs[i];
 			filler[c.x] = Word(x);
 			filler[c.y] = Word(y);

--- a/crates/m4-prover/src/lib.rs
+++ b/crates/m4-prover/src/lib.rs
@@ -6,8 +6,8 @@
 mod bitand;
 mod prove;
 mod shift;
-mod value_table2;
+mod value_table;
 
 pub use bitand::BatchAndCheckWitness;
 pub use prove::Prover;
-pub use value_table2::{Batch2WitnessFiller, ValueTable2};
+pub use value_table::{BatchWitnessFiller, ValueTable};

--- a/crates/m4-prover/src/prove.rs
+++ b/crates/m4-prover/src/prove.rs
@@ -14,7 +14,7 @@ use binius_math::{
 use binius_transcript::{ProverTranscript, fiat_shamir::Challenger};
 use binius_verifier::config::B128;
 
-use crate::ValueTable2;
+use crate::ValueTable;
 
 /// The multithreaded additive NTT used to encode the committed codeword.
 type ProverNtt = NeighborsLastMultiThread<GenericPreExpanded<B128>>;
@@ -81,7 +81,7 @@ where
 	/// The random point and the evaluation the prover commits to at it.
 	pub fn prove<Challenger_>(
 		&self,
-		table: &ValueTable2,
+		table: &ValueTable,
 		transcript: &mut ProverTranscript<Challenger_>,
 	) -> (Vec<B128>, B128)
 	where
@@ -163,9 +163,9 @@ mod tests {
 	}
 
 	// Populate one instance per `(x, y)` pair; the instance count is the pair count.
-	fn populate_table(c: &AndCircuit, inputs: &[(u64, u64)]) -> ValueTable2 {
+	fn populate_table(c: &AndCircuit, inputs: &[(u64, u64)]) -> ValueTable {
 		let log_instances = inputs.len().ilog2() as usize;
-		ValueTable2::populate(&c.circuit, log_instances, |i, w| {
+		ValueTable::populate(&c.circuit, log_instances, |i, w| {
 			let (x, y) = inputs[i];
 			w[c.x] = Word(x);
 			w[c.y] = Word(y);

--- a/crates/m4-prover/src/shift.rs
+++ b/crates/m4-prover/src/shift.rs
@@ -28,7 +28,7 @@ use binius_prover::{
 use binius_utils::{checked_arithmetics::log2_strict_usize, rayon::prelude::*};
 use binius_verifier::protocols::shift::SHIFT_VARIANT_COUNT;
 
-use crate::ValueTable2;
+use crate::ValueTable;
 
 /// The number of variables in each "g" (and "h") multilinear of phase 1: one 6-bit shift-amount
 /// axis and one 6-bit bit-position axis.
@@ -78,7 +78,7 @@ pub type FoldedWord<F> = [F; WORD_SIZE_BITS];
 /// # Panics
 ///
 /// Panics if `r_rho.len()` does not equal the batch dimension.
-pub fn fold_instances<F, P>(table: &ValueTable2, r_rho: &[F]) -> FieldBuffer<P>
+pub fn fold_instances<F, P>(table: &ValueTable, r_rho: &[F]) -> FieldBuffer<P>
 where
 	F: BinaryField,
 	P: PackedField<Scalar = F>,
@@ -299,7 +299,7 @@ mod crc64 {
 	use binius_core::word::Word;
 	use binius_frontend::{Circuit, CircuitBuilder, Wire};
 
-	use crate::ValueTable2;
+	use crate::ValueTable;
 
 	/// CRC-64/GO-ISO parameters.
 	///
@@ -398,12 +398,9 @@ mod crc64 {
 	/// Each instance's four message words are the corresponding tuple.
 	/// Circuit evaluation derives the rest.
 	/// The circuit has no inout wires, so it is admissible in the wire-major table.
-	pub fn populate_crc64_witness(
-		c: &Crc64Circuit,
-		inputs: &[[u64; N_INPUT_WORDS]],
-	) -> ValueTable2 {
+	pub fn populate_crc64_witness(c: &Crc64Circuit, inputs: &[[u64; N_INPUT_WORDS]]) -> ValueTable {
 		let log_instances = inputs.len().ilog2() as usize;
-		ValueTable2::populate(&c.circuit, log_instances, |i, filler| {
+		ValueTable::populate(&c.circuit, log_instances, |i, filler| {
 			for (wire, &w) in c.input.iter().zip(&inputs[i]) {
 				filler[*wire] = Word(w);
 			}
@@ -574,7 +571,7 @@ mod tests {
 	// r_x || r_rho. The columns are instance-major, so r_x (low) indexes the constraint within an
 	// instance and r_rho (high) indexes the instance.
 	fn evaluate_and_witness<P: PackedField<Scalar = B128>>(
-		table: &ValueTable2,
+		table: &ValueTable,
 		constants: &[Word],
 		and_constraints: &[AndConstraint],
 		domain_subspace: &BinarySubspace<B128>,
@@ -600,7 +597,7 @@ mod tests {
 	// This lets the public and hidden segments be folded separately, matching how `build_g_parts`
 	// consumes one segment at a time.
 	fn fold_words_over_instances(
-		table: &ValueTable2,
+		table: &ValueTable,
 		constants: &[Word],
 		r_rho: &[B128],
 		words: std::ops::Range<usize>,

--- a/crates/m4-prover/src/value_table.rs
+++ b/crates/m4-prover/src/value_table.rs
@@ -45,7 +45,7 @@ const DEFAULT_PARALLEL_STRIPE_WIDTH: usize = 1024;
 /// So the stored data holds exactly the hidden segment of every instance: `n_hidden_words` rows by
 /// `2^log_instances` columns.
 #[derive(Clone, Debug)]
-pub struct ValueTable2 {
+pub struct ValueTable {
 	/// The per-instance value layout, shared by every instance in the batch.
 	layout: ValueVecLayout,
 	/// The base-2 logarithm of the instance count.
@@ -58,7 +58,7 @@ pub struct ValueTable2 {
 	data: Vec<Word>,
 }
 
-impl ValueTable2 {
+impl ValueTable {
 	/// Builds the batch witness in wire-major order, populating all `2^log_instances` instances.
 	///
 	/// The instances are independent. For each, `fill` sets the witness input wires; the batched
@@ -84,7 +84,7 @@ impl ValueTable2 {
 		fill: F,
 	) -> Result<Self, BatchPopulateError>
 	where
-		F: Fn(usize, &mut Batch2WitnessFiller<'_, '_>),
+		F: Fn(usize, &mut BatchWitnessFiller<'_, '_>),
 	{
 		Self::populate_with(circuit, log_instances, None, fill)
 	}
@@ -103,7 +103,7 @@ impl ValueTable2 {
 		fill: F,
 	) -> Result<Self, BatchPopulateError>
 	where
-		F: Fn(usize, &mut Batch2WitnessFiller<'_, '_>),
+		F: Fn(usize, &mut BatchWitnessFiller<'_, '_>),
 	{
 		Self::populate_parallel_with_stripe_width(
 			circuit,
@@ -128,7 +128,7 @@ impl ValueTable2 {
 		fill: F,
 	) -> Result<Self, BatchPopulateError>
 	where
-		F: Fn(usize, &mut Batch2WitnessFiller<'_, '_>),
+		F: Fn(usize, &mut BatchWitnessFiller<'_, '_>),
 	{
 		assert!(stripe_width > 0, "stripe width must be positive");
 		Self::populate_with(circuit, log_instances, Some(stripe_width), fill)
@@ -141,12 +141,12 @@ impl ValueTable2 {
 		fill: F,
 	) -> Result<Self, BatchPopulateError>
 	where
-		F: Fn(usize, &mut Batch2WitnessFiller<'_, '_>),
+		F: Fn(usize, &mut BatchWitnessFiller<'_, '_>),
 	{
 		let layout = circuit.constraint_system().value_vec_layout.clone();
 		assert_eq!(
 			layout.n_inout, 0,
-			"ValueTable2 requires a constraint system with no inout wires; \
+			"ValueTable requires a constraint system with no inout wires; \
 			 use force_commit on output wires instead"
 		);
 
@@ -164,7 +164,7 @@ impl ValueTable2 {
 
 			// The caller assigns each instance's witness input wires into that instance's column.
 			for instance in 0..n_instances {
-				let mut filler = Batch2WitnessFiller {
+				let mut filler = BatchWitnessFiller {
 					circuit,
 					values: &mut values,
 					instance,
@@ -282,17 +282,17 @@ impl ValueTable2 {
 	}
 }
 
-/// Assigns witness input wires of one instance into a [`ValueTable2`] working buffer.
+/// Assigns witness input wires of one instance into a [`ValueTable`] working buffer.
 ///
 /// Indexing by [`Wire`] targets that wire's row in the instance's column, mirroring the
 /// single-instance [`WitnessFiller`](binius_frontend::WitnessFiller).
-pub struct Batch2WitnessFiller<'a, 'v> {
+pub struct BatchWitnessFiller<'a, 'v> {
 	circuit: &'a Circuit,
 	values: &'a mut StridedArray2DViewMut<'v, Word>,
 	instance: usize,
 }
 
-impl Index<Wire> for Batch2WitnessFiller<'_, '_> {
+impl Index<Wire> for BatchWitnessFiller<'_, '_> {
 	type Output = Word;
 
 	fn index(&self, wire: Wire) -> &Self::Output {
@@ -300,7 +300,7 @@ impl Index<Wire> for Batch2WitnessFiller<'_, '_> {
 	}
 }
 
-impl IndexMut<Wire> for Batch2WitnessFiller<'_, '_> {
+impl IndexMut<Wire> for BatchWitnessFiller<'_, '_> {
 	fn index_mut(&mut self, wire: Wire) -> &mut Self::Output {
 		let row = self.circuit.witness_index(wire).0 as usize;
 		&mut self.values[(row, self.instance)]
@@ -361,7 +361,7 @@ mod tests {
 	fn shape_matches_layout() {
 		let c = mix_circuit();
 		let log_instances = 3;
-		let table = ValueTable2::populate(&c.circuit, log_instances, |i, w| {
+		let table = ValueTable::populate(&c.circuit, log_instances, |i, w| {
 			w[c.a] = Word(i as u64);
 			w[c.b] = Word(i as u64 + 1);
 		})
@@ -379,7 +379,7 @@ mod tests {
 		let c = mix_circuit();
 		let constants = &c.circuit.constraint_system().constants;
 
-		let table = ValueTable2::populate(&c.circuit, 2, |i, w| {
+		let table = ValueTable::populate(&c.circuit, 2, |i, w| {
 			w[c.a] = Word(i as u64 * 0x9e37_79b9);
 			w[c.b] = Word(i as u64 ^ 0xdead);
 		})
@@ -397,7 +397,7 @@ mod tests {
 		let c = mix_circuit();
 		let constants = &c.circuit.constraint_system().constants;
 
-		let table = ValueTable2::populate(&c.circuit, 0, |_, w| {
+		let table = ValueTable::populate(&c.circuit, 0, |_, w| {
 			w[c.a] = Word(0xABCD);
 			w[c.b] = Word(0x0F0F);
 		})
@@ -419,7 +419,7 @@ mod tests {
 			let c = mix_circuit();
 			let constants = c.circuit.constraint_system().constants.clone();
 
-			let table = ValueTable2::populate(&c.circuit, 2, |i, w| {
+			let table = ValueTable::populate(&c.circuit, 2, |i, w| {
 				let (a, b) = inputs[i];
 				w[c.a] = Word(a);
 				w[c.b] = Word(b);
@@ -439,13 +439,13 @@ mod tests {
 		let c = mix_circuit();
 		let log_instances = 3;
 
-		let serial = ValueTable2::populate(&c.circuit, log_instances, |i, w| {
+		let serial = ValueTable::populate(&c.circuit, log_instances, |i, w| {
 			w[c.a] = Word((i as u64).wrapping_mul(0x9e37_79b9));
 			w[c.b] = Word((i as u64).rotate_left(17) ^ 0xdead_beef);
 		})
 		.unwrap();
 
-		let default_parallel = ValueTable2::populate_parallel(&c.circuit, log_instances, |i, w| {
+		let default_parallel = ValueTable::populate_parallel(&c.circuit, log_instances, |i, w| {
 			w[c.a] = Word((i as u64).wrapping_mul(0x9e37_79b9));
 			w[c.b] = Word((i as u64).rotate_left(17) ^ 0xdead_beef);
 		})
@@ -453,7 +453,7 @@ mod tests {
 		assert_eq!(default_parallel.as_words(), serial.as_words());
 
 		for stripe_width in [1, 2, 3, 8, 64] {
-			let parallel = ValueTable2::populate_parallel_with_stripe_width(
+			let parallel = ValueTable::populate_parallel_with_stripe_width(
 				&c.circuit,
 				log_instances,
 				stripe_width,
@@ -482,7 +482,7 @@ mod tests {
 		let circuit = builder.build();
 
 		// Instance 2 violates a == b; the others satisfy it.
-		let result = ValueTable2::populate(&circuit, 2, |i, w| {
+		let result = ValueTable::populate(&circuit, 2, |i, w| {
 			w[a] = Word(i as u64);
 			w[b] = Word(if i == 2 { 99 } else { i as u64 });
 		});
@@ -507,7 +507,7 @@ mod tests {
 
 		// Instance 5 is in the third two-column stripe. Reporting a local stripe index would
 		// incorrectly return 1 instead of the global instance index 5.
-		let result = ValueTable2::populate_parallel_with_stripe_width(&circuit, 3, 2, |i, w| {
+		let result = ValueTable::populate_parallel_with_stripe_width(&circuit, 3, 2, |i, w| {
 			w[a] = Word(i as u64);
 			w[b] = Word(if i == 5 { 99 } else { i as u64 });
 		});
@@ -533,12 +533,12 @@ mod tests {
 		// Instances 5 and 7 fail in different two-column stripes. The batched interpreter reports
 		// the lowest failing instance's diagnostics, so the parallel path should match the serial
 		// path exactly rather than aggregating failures from unrelated later instances.
-		let fill = |i: usize, w: &mut Batch2WitnessFiller<'_, '_>| {
+		let fill = |i: usize, w: &mut BatchWitnessFiller<'_, '_>| {
 			w[a] = Word(i as u64);
 			w[b] = Word(if i == 5 || i == 7 { 99 } else { i as u64 });
 		};
-		let serial = ValueTable2::populate(&circuit, 3, fill).expect_err("instances fail");
-		let parallel = ValueTable2::populate_parallel_with_stripe_width(&circuit, 3, 2, fill)
+		let serial = ValueTable::populate(&circuit, 3, fill).expect_err("instances fail");
+		let parallel = ValueTable::populate_parallel_with_stripe_width(&circuit, 3, 2, fill)
 			.expect_err("instances fail");
 
 		assert_eq!(parallel.instance, serial.instance);
@@ -556,7 +556,7 @@ mod tests {
 		builder.force_commit(and);
 		let circuit = builder.build();
 
-		let _ = ValueTable2::populate(&circuit, 1, |_, w| {
+		let _ = ValueTable::populate(&circuit, 1, |_, w| {
 			w[a] = Word(1);
 			w[b] = Word(1);
 		});
@@ -568,7 +568,7 @@ mod tests {
 		let c = mix_circuit();
 
 		// Fixture state: 4 instances with distinct witness inputs.
-		let table = ValueTable2::populate(&c.circuit, 2, |i, w| {
+		let table = ValueTable::populate(&c.circuit, 2, |i, w| {
 			w[c.a] = Word((i as u64).wrapping_mul(0x9e37_79b9));
 			w[c.b] = Word(i as u64 ^ 0xdead);
 		})


### PR DESCRIPTION
Part of [BINIUS-247](https://linear.app/jimpo/issue/BINIUS-247/adopt-valuetable2-across-m4-and-remove-valuetable). The optional cleanup I flagged when the prover migration landed (#1767).

Pure rename — no behavior change.

### The idea

`#1767` deleted the instance-major `ValueTable`, so the `2` suffix on the wire-major table and its filler is now just noise. With the original name free, drop it:

- `ValueTable2` → `ValueTable`
- `Batch2WitnessFiller` → `BatchWitnessFiller`
- `value_table2.rs` → `value_table.rs` (module + file)
- the comments, doc links, and Criterion benchmark ids that carried the old name

### Scope

- Mechanical rename across `m4-prover` (`value_table.rs`, `lib.rs`, `prove.rs`, `bitand.rs`, `shift.rs`, and the witness-gen bench). No external users to update.
- `m4-verifier` is untouched (it never referenced the table type).
- One stale doc line corrected in passing: the BitAnd witness rows are instance-major, which is no longer "the same layout the batch witness uses" now that the witness is wire-major — reworded to state the instance index sits on the high coordinates.

### Verification

- `cargo build -p binius-m4-prover --all-targets`, `clippy --all-targets`, `+nightly fmt -- --check` — clean
- `RUSTDOCFLAGS=-D rustdoc::broken_intra_doc_links cargo doc` — clean
- `cargo test -p binius-m4-prover` — 26 pass (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)