### PR TITLE
BINIUS-255: share one skip domain between the AND-check and shift reduction

### DIFF
--- a/crates/m4-prover/src/bitand.rs
+++ b/crates/m4-prover/src/bitand.rs
@@ -235,6 +235,8 @@ impl BatchAndCheckWitness {
 	///
 	/// # Arguments
 	///
+	/// - `prover_message_domain`: the univariate-skip domain, one dimension above the 64-bit word.
+	///   The caller passes it so it matches the shift reduction's domain by construction.
 	/// - `channel`: the prover channel that records messages and draws Fiat-Shamir challenges.
 	///
 	/// # Returns
@@ -243,15 +245,15 @@ impl BatchAndCheckWitness {
 	/// - The claimed `A`, `B`, `C` evaluations.
 	/// - The univariate (bit-index) challenge.
 	/// - The multilinear evaluation point reached by the sumcheck.
-	pub fn prove<P, Channel>(self, channel: &mut Channel) -> AndCheckOutput<B128>
+	pub fn prove<P, Channel>(
+		self,
+		prover_message_domain: &BinarySubspace<B8>,
+		channel: &mut Channel,
+	) -> AndCheckOutput<B128>
 	where
 		P: PackedField<Scalar = B128>,
 		Channel: IPProverChannel<B128>,
 	{
-		// The univariate-skip domain spans one extra dimension above the 64-bit word.
-		// This is the same skip parameter the single-instance check uses.
-		let prover_message_domain = BinarySubspace::<B8>::with_dim(Word::LOG_BITS + 1);
-
 		let (a, b, c) = self.into_columns();
 
 		// X has `log_instances + log(n_and)` coordinates: the row count is a power of two.
@@ -398,6 +400,11 @@ mod tests {
 	/// A width-1 packed field keeps one scalar per element, so the SIMD sumcheck rounds stay
 	/// simple.
 	type P = PackedBinaryGhash1x128b;
+
+	// The univariate-skip domain the AND-check runs over: one dimension above the 64-bit word.
+	fn message_domain() -> BinarySubspace<B8> {
+		BinarySubspace::<B8>::with_dim(Word::LOG_BITS + 1)
+	}
 
 	/// Recomputes the true multilinear evaluation of one bit-column at the reduction's point.
 	///
@@ -716,10 +723,12 @@ mod tests {
 
 		// Prover and verifier agree on the reduced claim over the batched columns.
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
-		let prove_output = witness.prove::<P, _>(&mut prover_transcript);
+		let prove_output = witness.prove::<P, _>(&message_domain(), &mut prover_transcript);
 
 		let mut verifier_transcript = prover_transcript.into_verifier();
-		let verify_output = verify_bitand_reduction(log_total, &mut verifier_transcript).unwrap();
+		let verify_output =
+			verify_bitand_reduction(log_total, &message_domain(), &mut verifier_transcript)
+				.unwrap();
 		verifier_transcript
 			.finalize()
 			.expect("no trailing proof data");
@@ -742,7 +751,7 @@ mod tests {
 
 		// Produce a faithful proof.
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
-		let _ = witness.prove::<P, _>(&mut prover_transcript);
+		let _ = witness.prove::<P, _>(&message_domain(), &mut prover_transcript);
 		let mut proof = prover_transcript.finalize();
 
 		// Mutation: flip a bit in the prover's first message, the univariate round evaluations.
@@ -752,7 +761,8 @@ mod tests {
 		// The final consistency check then no longer holds.
 		// So verification fails.
 		let mut verifier_transcript = VerifierTranscript::new(StdChallenger::default(), proof);
-		let err = verify_bitand_reduction(log_total, &mut verifier_transcript).unwrap_err();
+		let err = verify_bitand_reduction(log_total, &message_domain(), &mut verifier_transcript)
+			.unwrap_err();
 
 		// The closing check is `A_eval * B_eval - C_eval == sumcheck_eval`.
 		// The tampered message moves the claim, so this equality no longer holds.
@@ -786,11 +796,11 @@ mod tests {
 			let log_total = checked_log_2(witness.a().len());
 
 			let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
-			let prove_output = witness.prove::<P, _>(&mut prover_transcript);
+			let prove_output = witness.prove::<P, _>(&message_domain(), &mut prover_transcript);
 
 			let mut verifier_transcript = prover_transcript.into_verifier();
 			let verify_output =
-				verify_bitand_reduction(log_total, &mut verifier_transcript).unwrap();
+				verify_bitand_reduction(log_total, &message_domain(), &mut verifier_transcript).unwrap();
 			verifier_transcript.finalize().expect("no trailing proof data");
 
 			// Both sides reach the same reduced claim.

--- a/crates/m4-prover/src/reduction.rs
+++ b/crates/m4-prover/src/reduction.rs
@@ -65,6 +65,14 @@ where
 		"the M4 reduction handles only AND constraints; the circuit must have no MUL constraints"
 	);
 
+	// One base domain shared by the AND-check and the shift, consistent by construction.
+	// The AND-check's univariate-skip domain spans one dimension above the 64-bit word.
+	let andcheck_domain = BinarySubspace::<B8>::with_dim(Word::LOG_BITS + 1);
+	// The shift domain drops that extra dimension.
+	let shift_domain = andcheck_domain
+		.reduce_dim(Word::LOG_BITS)
+		.isomorphic::<B128>();
+
 	// AND-check the `A & B == C` relation over all `K * n_and` rows.
 	let and_witness = BatchAndCheckWitness::build(table, &cs.constants, &cs.and_constraints);
 	let AndCheckOutput {
@@ -73,7 +81,7 @@ where
 		c_eval,
 		z_challenge,
 		eval_point,
-	} = and_witness.prove::<P, _>(channel);
+	} = and_witness.prove::<P, _>(&andcheck_domain, channel);
 
 	// The row point is `r_x || r_rho`: the constraint index on the low coordinates, the instance
 	// index on the high coordinates.
@@ -91,7 +99,6 @@ where
 
 	// Reduce the operand claims to one witness evaluation.
 	// No MUL constraints here, so the intmul claim is a zero claim at an empty point.
-	let domain = BinarySubspace::<B8>::with_dim(Word::LOG_BITS).isomorphic::<B128>();
 	let witness_claim = prove_shift::<B128, P, _>(
 		key_collection,
 		&cs.constants,
@@ -106,7 +113,7 @@ where
 			r_zhat_prime: z_challenge,
 			r_x_prime: Vec::new(),
 		},
-		&domain,
+		&shift_domain,
 		channel,
 	);
 

--- a/crates/m4-verifier/src/bitand.rs
+++ b/crates/m4-verifier/src/bitand.rs
@@ -2,7 +2,6 @@
 
 //! Verifier for the batched BitAnd reduction of the data-parallel M4 proof system.
 
-use binius_core::word::Word;
 use binius_field::AESTowerField8b as B8;
 use binius_ip::channel::IPVerifierChannel;
 use binius_math::BinarySubspace;
@@ -30,6 +29,8 @@ use binius_verifier::{
 /// # Arguments
 ///
 /// - `log_total_constraints`: base-2 logarithm of the total row count `K * n_and`.
+/// - `eval_domain`: the univariate-skip domain, one dimension above the 64-bit word. The caller
+///   passes it so it matches the shift reduction's domain by construction.
 /// - `channel`: the verifier channel that reads messages and redraws Fiat-Shamir challenges.
 ///
 /// The total row count is the instance count times the per-instance constraint count.
@@ -47,17 +48,15 @@ use binius_verifier::{
 /// Returns an error if any sumcheck round message or the final consistency check fails.
 pub fn verify_bitand_reduction<C>(
 	log_total_constraints: usize,
+	eval_domain: &BinarySubspace<B8>,
 	channel: &mut C,
 ) -> Result<AndCheckOutput<B128>, Error>
 where
 	C: IPVerifierChannel<B128, Elem = B128>,
 {
-	// The univariate-skip domain: the full B8 subspace, lifted to B128.
-	// It is then cut to one dimension above the 64-bit word.
+	// Lift the caller's univariate-skip domain to B128.
 	// The prover sends round-message evaluations over exactly this domain.
-	let eval_domain = BinarySubspace::<B8>::default()
-		.isomorphic::<B128>()
-		.reduce_dim(Word::LOG_BITS + 1);
+	let eval_domain = eval_domain.isomorphic::<B128>();
 
 	// The first few zerocheck coordinates are pinned to fixed small-field elements.
 	// The prover pins the same prefix, so both sides agree on this split.

--- a/crates/m4-verifier/src/reduction.rs
+++ b/crates/m4-verifier/src/reduction.rs
@@ -55,6 +55,14 @@ pub fn verify_reduction<Channel>(
 where
 	Channel: IPVerifierChannel<B128, Elem = B128>,
 {
+	// One base domain shared by the AND-check and the shift, consistent by construction.
+	// The AND-check's univariate-skip domain spans one dimension above the 64-bit word.
+	let andcheck_domain = BinarySubspace::<B8>::with_dim(Word::LOG_BITS + 1);
+	// The shift domain drops that extra dimension.
+	let shift_domain = andcheck_domain
+		.reduce_dim(Word::LOG_BITS)
+		.isomorphic::<B128>();
+
 	// AND-check over all `K * n_and` rows.
 	let log_n_and = checked_log_2(cs.and_constraints.len());
 	let AndCheckOutput {
@@ -63,7 +71,7 @@ where
 		c_eval,
 		z_challenge,
 		eval_point,
-	} = verify_bitand_reduction(log_instances + log_n_and, channel)?;
+	} = verify_bitand_reduction(log_instances + log_n_and, &andcheck_domain, channel)?;
 
 	// The row point is `r_x || r_rho`: the constraint index low, the instance index high.
 	let (r_x, r_rho) = eval_point.split_at(log_n_and);
@@ -75,13 +83,12 @@ where
 	let shift = shift::verify::<B128, _>(cs, &bitand, &intmul, channel)?;
 
 	// Tie in the shared constants through the public-input consistency check.
-	let domain = BinarySubspace::<B8>::with_dim(Word::LOG_BITS).isomorphic::<B128>();
 	shift::check_eval::<B128, _>(
 		cs,
 		&cs.constants,
 		&bitand,
 		&intmul,
-		&domain,
+		&shift_domain,
 		z_challenge,
 		&shift,
 		channel,


### PR DESCRIPTION
Part of [BINIUS-255](https://linear.app/jimpo/issue/BINIUS-255/integrate-andcheck-and-shift-reduction-into-m4-protocol). Follow-up to jimpo's review comment on #1771 (https://github.com/binius-zk/binius64/pull/1771#discussion_r3563886686); does **not** close the issue.

Pure refactor — the domains are identical, only their provenance changes.

### The problem

The AND-check and the shift reduction each built their univariate-skip evaluation domain **independently**:

- AND-check (prover): `BinarySubspace::<B8>::with_dim(Word::LOG_BITS + 1)`
- AND-check (verifier): `default().isomorphic().reduce_dim(Word::LOG_BITS + 1)`
- shift (both sides): `with_dim(Word::LOG_BITS).isomorphic()`

They agree only because the three constructions happen to match. If one drifted, the two reductions would silently disagree on the domain — a latent soundness footgun.

### The idea

Build **one** base domain per reduction and derive the shift's from it, so they are consistent by construction (mirroring the single-instance verifier, which already passes its domain into its bitand check):

```rust
// in both prove_reduction and verify_reduction
let andcheck_domain = BinarySubspace::<B8>::with_dim(Word::LOG_BITS + 1);   // pre-isomorphism
let shift_domain    = andcheck_domain.reduce_dim(Word::LOG_BITS).isomorphic::<B128>();
```

The shift domain is literally the AND-check domain with the skip dimension dropped. The base is threaded into the AND-check on both sides:

- `BatchAndCheckWitness::prove` now takes `prover_message_domain: &BinarySubspace<B8>`.
- `verify_bitand_reduction` now takes `eval_domain: &BinarySubspace<B8>` (the pre-isomorphism version, as jimpo asked) and lifts it to B128 internally.

### Correctness

Behavior-preserving:
- `with_dim(7).isomorphic()` equals the old verifier's `default().isomorphic().reduce_dim(7)` — same basis.
- `with_dim(7).reduce_dim(6).isomorphic()` equals the old shift's `with_dim(6).isomorphic()`.

So the domains are byte-for-byte the same; only where they come from changed. The `reduction_round_trips` test still passes, confirming the AND-check and shift agree end to end.

### Scope

- **changed:** `BatchAndCheckWitness::prove` and `verify_bitand_reduction` signatures (take the domain); `prove_reduction` and `verify_reduction` build the base and derive the shift domain.
- the 6 AND-check test call sites use a small `message_domain()` helper; a now-unused `Word` import was dropped in the verifier's `bitand.rs`.
- no external users of either function outside the two M4 crates.

### Verification

- `cargo test` — m4-prover 29, m4-verifier 3
- `clippy --all-targets`, `+nightly fmt -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)