### PR TITLE
Relax parallel batch diagnostics ordering

### DIFF
--- a/crates/frontend/src/compiler/circuit.rs
+++ b/crates/frontend/src/compiler/circuit.rs
@@ -192,6 +192,12 @@ impl Circuit {
 	/// This is the parallel counterpart to [`Self::populate_wire_witness_batched`]. Constants are
 	/// broadcast once over the full value array, then the bytecode interpreter runs independently
 	/// on disjoint instance-column stripes of at most `stripe_width` columns.
+	///
+	/// # Errors
+	///
+	/// If any instance is not satisfiable, returns an error naming a failing instance and its
+	/// assertion failures. The reported instance is not guaranteed to be the lowest failing
+	/// instance across all stripes.
 	pub fn populate_wire_witness_batched_parallel(
 		&self,
 		mut values: StridedArray2DViewMut<'_, Word>,

--- a/crates/frontend/src/compiler/eval_form/batch_interpreter.rs
+++ b/crates/frontend/src/compiler/eval_form/batch_interpreter.rs
@@ -39,11 +39,11 @@ struct InstanceAssertionFailure {
 
 /// The failure of batch witness population, attributed to a single instance.
 ///
-/// When several instances fail, this reports the one with the lowest index, matching what
-/// populating that instance on its own would produce.
+/// Serial batched evaluation reports the lowest-indexed failing instance. Parallel batched
+/// evaluation runs over independent stripes, and may report the first failing stripe observed.
 #[derive(Debug)]
 pub struct BatchPopulateError {
-	/// The index of the reported instance, the lowest-numbered failing instance.
+	/// The index of the reported failing instance.
 	pub instance: usize,
 	/// The assertion failures recorded for that instance.
 	pub source: PopulateError,

--- a/crates/frontend/src/compiler/eval_form/mod.rs
+++ b/crates/frontend/src/compiler/eval_form/mod.rs
@@ -105,6 +105,10 @@ impl EvalForm {
 	}
 
 	/// Execute the evaluation form over disjoint vertical instance stripes in parallel.
+	///
+	/// Returns an error from one failing stripe if any instance is unsatisfiable. Unlike
+	/// [`Self::evaluate_batched`], this does not guarantee that the reported instance is the
+	/// lowest-indexed failing instance across the full batch.
 	pub fn evaluate_batched_parallel(
 		&self,
 		values: StridedArray2DViewMut<'_, Word>,

--- a/crates/m4-prover/src/value_table.rs
+++ b/crates/m4-prover/src/value_table.rs
@@ -94,6 +94,11 @@ impl ValueTable {
 	/// This is the parallel counterpart to [`Self::populate`]. Input filling is still performed
 	/// once up front, then circuit evaluation runs over disjoint vertical instance stripes.
 	///
+	/// # Errors
+	///
+	/// Returns an error naming a failing instance whose inputs do not satisfy the circuit. The
+	/// reported instance is not guaranteed to be the lowest failing instance across all stripes.
+	///
 	/// # Panics
 	///
 	/// Panics if the circuit's layout has any inout wires.
@@ -117,6 +122,11 @@ impl ValueTable {
 	///
 	/// This is exposed for benchmarking stripe widths. Production callers should use
 	/// [`Self::populate_parallel`].
+	///
+	/// # Errors
+	///
+	/// Returns an error naming a failing instance whose inputs do not satisfy the circuit. The
+	/// reported instance is not guaranteed to be the lowest failing instance across all stripes.
 	///
 	/// # Panics
 	///
@@ -522,7 +532,7 @@ mod tests {
 	}
 
 	#[test]
-	fn parallel_failure_diagnostics_match_serial_for_failures_in_different_stripes() {
+	fn parallel_failure_diagnostics_report_global_instance_across_stripes() {
 		// A circuit that asserts a == b; instances where they differ fail.
 		let builder = CircuitBuilder::new();
 		let a = builder.add_witness();
@@ -530,20 +540,25 @@ mod tests {
 		builder.assert_eq("a_eq_b", a, b);
 		let circuit = builder.build();
 
-		// Instances 5 and 7 fail in different two-column stripes. The batched interpreter reports
-		// the lowest failing instance's diagnostics, so the parallel path should match the serial
-		// path exactly rather than aggregating failures from unrelated later instances.
+		// Instances 5 and 7 fail in different two-column stripes. The parallel path may report
+		// either stripe depending on scheduling, but it must report a global instance index and
+		// diagnostics for that instance rather than aggregating unrelated stripes.
 		let fill = |i: usize, w: &mut BatchWitnessFiller<'_, '_>| {
 			w[a] = Word(i as u64);
 			w[b] = Word(if i == 5 || i == 7 { 99 } else { i as u64 });
 		};
-		let serial = ValueTable::populate(&circuit, 3, fill).expect_err("instances fail");
 		let parallel = ValueTable::populate_parallel_with_stripe_width(&circuit, 3, 2, fill)
 			.expect_err("instances fail");
 
-		assert_eq!(parallel.instance, serial.instance);
-		assert_eq!(parallel.source.total_count, serial.source.total_count);
-		assert_eq!(parallel.source.messages, serial.source.messages);
+		assert!(parallel.instance == 5 || parallel.instance == 7);
+		assert_eq!(parallel.source.total_count, 1);
+		assert_eq!(
+			parallel.source.messages,
+			vec![format!(
+				".a_eq_b: Word(0x{0:016x}) != Word(0x0000000000000063)",
+				parallel.instance
+			)]
+		);
 	}
 
 	#[test]


### PR DESCRIPTION
## Summary
Updates the parallel batched witness-generation diagnostics contract to match the current implementation: when failures occur in multiple independent stripes, the parallel path reports one failing stripe's global instance, not necessarily the lowest failing instance across the whole batch.

This is the lighter alternative to #1749. The previous PR preserved the serial-compatible lowest-instance diagnostic by collecting every stripe result and taking `min_by_key(instance)`. Since that deterministic ordering is not important for proof correctness, this PR keeps the existing `collect::<Result<Vec<_>, _>>()` short-circuit behavior and instead relaxes the docs/test to require only a valid failing global instance.

Serial batched evaluation still reports the lowest failing instance; the existing frontend test for that behavior remains unchanged.

## Why
The old cross-stripe test required the parallel path to match serial exactly. Under Rayon, `collect::<Result<_>>()` may observe either failing stripe first, so the test can intermittently report instance `7` instead of serial's `5`. That is fine for diagnostics as long as the reported instance is global and the messages belong to that instance.

## Test plan
- `RAYON_NUM_THREADS=8` repeated targeted test: 50/50 passes
- `cargo test -p binius-m4-prover --features rayon --lib`
- `cargo test -p binius-m4-prover --lib`
- `cargo test -p binius-frontend --lib`
- `cargo +nightly-2026-01-01 fmt --check`
- `cargo clippy -p binius-frontend -p binius-m4-prover --all-features --tests --benches -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p binius-frontend -p binius-m4-prover --all-features --document-private-items --no-deps`
