### PR TITLE
BINIUS-255: bind the reduction claim to the committed trace oracle

### DIFF
--- a/crates/m4-prover/src/prove.rs
+++ b/crates/m4-prover/src/prove.rs
@@ -1,34 +1,39 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
+use binius_core::{constraint_system::ConstraintSystem, word::Word};
 use binius_field::PackedField;
 use binius_hash::StdHashSuite;
 use binius_iop_prover::{basefold_compiler::BaseFoldProverCompiler, channel::IOPProverChannel};
-use binius_ip_prover::channel::IPProverChannel;
-use binius_m4_verifier::{BatchCommitLayout, Verifier};
-use binius_math::{
-	inner_product::inner_product_buffers,
-	multilinear::eq::eq_ind_partial_eval,
-	ntt::{NeighborsLastMultiThread, domain_context::GenericPreExpanded},
+use binius_m4_verifier::Verifier;
+use binius_math::ntt::{NeighborsLastMultiThread, domain_context::GenericPreExpanded};
+use binius_prover::{
+	protocols::shift::{KeyCollection, build_key_collection},
+	ring_switch::{self, RingSwitchOutput},
 };
 use binius_transcript::{ProverTranscript, fiat_shamir::Challenger};
 use binius_verifier::config::B128;
 
-use crate::ValueTable;
+use crate::{
+	ValueTable,
+	reduction::{ReductionProverOutput, prove_reduction},
+};
 
 /// The multithreaded additive NTT used to encode the committed codeword.
 type ProverNtt = NeighborsLastMultiThread<GenericPreExpanded<B128>>;
 
-/// Proves a batch-witness commitment opened at a verifier-chosen random point.
+/// Proves the data-parallel M4 statement for a batch of `2^log_instances` circuit instances.
 ///
-/// Setup builds the BaseFold prover once, reusing the verifier's FRI parameters.
-/// A later call commits a witness table and opens it at a transcript-chosen point.
+/// One-time setup builds the shift keys and the BaseFold prover, reusing the verifier's parameters.
+/// A later proving call commits a witness table and proves it satisfies every AND constraint.
 pub struct Prover<P>
 where
 	P: PackedField<Scalar = B128>,
 {
-	/// The committed-multilinear shape of the batch, shared with the verifier.
-	layout: BatchCommitLayout,
+	/// The prepared single-instance constraint system shared by every instance.
+	cs: ConstraintSystem,
+	/// The shift keys for the constraint system, built once and reused across proofs.
+	key_collection: KeyCollection,
 	/// The precomputed BaseFold prover, holding the NTT and the FRI parameters.
 	basefold_compiler: BaseFoldProverCompiler<P, ProverNtt>,
 }
@@ -37,7 +42,7 @@ impl<P> Prover<P>
 where
 	P: PackedField<Scalar = B128>,
 {
-	/// Builds the prover from a verifier, inheriting its FRI parameters.
+	/// Builds the prover from a verifier, inheriting its constraint system and FRI parameters.
 	///
 	/// The prover encodes the codeword with the multithreaded NTT, spread across the cores.
 	/// Reusing the verifier's compiler keeps both sides on one set of FRI parameters.
@@ -54,37 +59,41 @@ where
 		let basefold_compiler =
 			BaseFoldProverCompiler::from_verifier_compiler(verifier.iop_compiler(), ntt);
 
+		// Build the shift keys once from the shared constraint system.
+		let key_collection = build_key_collection(verifier.constraint_system());
+
 		Self {
-			layout: *verifier.layout(),
+			cs: verifier.constraint_system().clone(),
+			key_collection,
 			basefold_compiler,
 		}
 	}
 
-	/// Commits the batch witness and proves its evaluation at a verifier-chosen random point.
+	/// Proves that every instance in the batch satisfies the constraint system.
 	///
-	/// The flow is the standard polynomial-commitment open:
+	/// The flow composes the commitment, the reduction, and the opening on one transcript:
 	/// - Pack the table into one B128 multilinear and commit it as the trace oracle.
-	/// - Draw a random point from the transcript.
-	/// - Open the commitment at that point.
+	/// - Run the AND-check and shift reduction to a claim about the instance-folded witness.
+	/// - Ring-switch that claim onto the committed trace and open it.
 	///
-	/// The point is drawn after the commitment.
-	/// So Fiat-Shamir binds it to the committed data.
+	/// The trace commits before the reduction draws its challenges.
+	/// So Fiat-Shamir binds every challenge to the committed data.
 	///
-	/// This opens the packed B128 multilinear directly.
-	/// It does not ring-switch down to the bit witness.
-	/// That step belongs with the later reductions.
+	/// The reduction ends with a claim about the witness folded over instances at `r_rho`.
+	/// The trace's bit index is `[bit | instance | wire]`.
+	/// Evaluating its instance coordinates at `r_rho` performs that fold.
+	/// So the ring-switch opens the trace at `r_j || r_rho || r_y`, matching the reduced claim.
 	///
 	/// The trace oracle is not ZK, so the channel masks nothing and needs no randomness.
 	///
-	/// # Returns
+	/// # Panics
 	///
-	/// The random point and the evaluation the prover commits to at it.
+	/// Panics if the constraint system has any MUL constraints.
 	pub fn prove<Challenger_>(
 		&self,
 		table: &ValueTable,
 		transcript: &mut ProverTranscript<Challenger_>,
-	) -> (Vec<B128>, B128)
-	where
+	) where
 		Challenger_: Challenger,
 	{
 		let mut channel = self
@@ -93,153 +102,130 @@ where
 
 		// Pack the 2-D table into one multilinear and commit it as the trace oracle.
 		let packed = table.pack::<P>();
-		let oracle = channel.send_oracle(packed.to_ref());
+		let trace_oracle = channel.send_oracle(packed.to_ref());
 
-		// Sample the evaluation point only now.
-		// This makes it depend on the commitment.
-		let point = channel.sample_many(self.layout.log_witness_elems);
+		// Reduce the AND constraints and shift to one folded-witness claim.
+		// Every challenge is drawn now, after the commitment.
+		let ReductionProverOutput {
+			r_rho,
+			witness_claim,
+		} = prove_reduction::<P, _>(&self.cs, &self.key_collection, table, &mut channel);
 
-		// The claimed evaluation is the inner product of the committed values with eq(point, .).
-		//
-		//     committed(point) = sum_w committed[w] * eq(point, w) = <committed, eq_ind(point)>
-		let eq = eq_ind_partial_eval::<P>(&point);
-		let eval = inner_product_buffers(&packed, &eq);
+		// Split the shift's final point `r_j || r_y || r_segment` into its three parts.
+		// The bit index `r_j` is the low coordinates addressing a bit within a 64-bit word.
+		// The segment selector `r_segment` is the last coordinate, choosing public or hidden words.
+		// The hidden-only trace drops it.
+		// The word index `r_y` is everything in between.
+		let challenges = &witness_claim.challenges;
+		let r_j = &challenges[..Word::LOG_BITS];
+		let r_y = &challenges[Word::LOG_BITS..challenges.len() - 1];
 
-		// Send the claim, then open the commitment to prove it.
-		// The verifier cannot recompute the claim, since the point depends on the commitment.
-		channel.send_one(eval);
+		// Ring-switch the reduced claim onto the committed trace.
+		// The point is `r_j || r_rho || r_y`.
+		// Its instance coordinates fold the trace at `r_rho`.
+		let trace_point = [r_j, r_rho.as_slice(), r_y].concat();
+		let RingSwitchOutput {
+			rs_eq_ind,
+			sumcheck_claim,
+		} = ring_switch::prove(&packed, &trace_point, &mut channel);
 
-		// The ZK channel only queues the relation here.
-		// `finish` runs the single combined FRI opening and writes it to the transcript.
-		channel.prove_oracle_relations([(oracle, packed, eq, eval)]);
+		// Queue the trace opening against the ring-switch's transparent multilinear.
+		// The final call runs the single combined FRI opening and writes it to the transcript.
+		channel.prove_oracle_relations([(trace_oracle, packed, rs_eq_ind, sumcheck_claim)]);
 		channel.finish();
-
-		(point, eval)
 	}
 }
 
 #[cfg(test)]
 mod tests {
+	use std::array;
+
 	use assert_matches::assert_matches;
-	use binius_core::word::Word;
 	use binius_field::PackedBinaryGhash1x128b;
-	use binius_frontend::{Circuit, CircuitBuilder, Wire};
 	use binius_iop::{
 		basefold::{Error as BaseFoldError, VerificationError as BaseFoldVerificationError},
+		channel::Error as IOPChannelError,
 		fri::VerificationError as FriVerificationError,
 		merkle_tree::VerificationError as MerkleVerificationError,
 	};
-	use binius_math::multilinear::evaluate::evaluate;
 	use binius_transcript::VerifierTranscript;
-	use binius_verifier::config::StdChallenger;
-	use proptest::prelude::*;
+	use binius_verifier::{Error, config::StdChallenger};
+	use rand::prelude::*;
 
 	use super::*;
+	use crate::test_utils::{N_INPUT_WORDS, crc64_circuit, populate_crc64_witness};
 
 	type P = PackedBinaryGhash1x128b;
 
-	// A circuit asserting `z == x & y` over three witness words (no inout — the M4 setting).
-	// Satisfiable for an instance exactly when it sets z = x & y.
-	struct AndCircuit {
-		circuit: Circuit,
-		x: Wire,
-		y: Wire,
-		z: Wire,
+	// Builds a batch of `2^log_instances` CRC-64 instances with random input words.
+	fn setup_batch(log_instances: usize, seed: u64) -> (ConstraintSystem, ValueTable) {
+		let c = crc64_circuit();
+		let n_instances = 1usize << log_instances;
+		let mut rng = StdRng::seed_from_u64(seed);
+		let inputs: Vec<[u64; N_INPUT_WORDS]> = (0..n_instances)
+			.map(|_| array::from_fn(|_| rng.random()))
+			.collect();
+		let table = populate_crc64_witness(&c, &inputs);
+
+		let mut cs = c.circuit.constraint_system().clone();
+		cs.validate_and_prepare().unwrap();
+		(cs, table)
 	}
 
-	fn and_circuit() -> AndCircuit {
-		let builder = CircuitBuilder::new();
-		let x = builder.add_witness();
-		let y = builder.add_witness();
-		let z = builder.add_witness();
-		let and = builder.band(x, y);
-		builder.assert_eq("z_eq_x_and_y", and, z);
-		AndCircuit {
-			circuit: builder.build(),
-			x,
-			y,
-			z,
-		}
-	}
-
-	// Populate one instance per `(x, y)` pair; the instance count is the pair count.
-	fn populate_table(c: &AndCircuit, inputs: &[(u64, u64)]) -> ValueTable {
-		let log_instances = inputs.len().ilog2() as usize;
-		ValueTable::populate(&c.circuit, log_instances, |i, w| {
-			let (x, y) = inputs[i];
-			w[c.x] = Word(x);
-			w[c.y] = Word(y);
-			w[c.z] = Word(x & y);
-		})
-		.unwrap()
-	}
-
-	proptest! {
-		// Round-trip: a commitment opened at the transcript point verifies, and the value the
-		// opening proves is the committed multilinear evaluated at that same point.
-		//
-		//     prover  : commit, draw point, open at point, claim e
-		//     verifier: commit', draw point' (== point), read e, check the opening
-		//
-		// The inputs vary the witness, so each case commits to different data.
-		#[test]
-		fn commit_open_round_trips(inputs in prop::collection::vec((any::<u64>(), any::<u64>()), 4)) {
-			let c = and_circuit();
-			let table = populate_table(&c, &inputs);
-
-			// Setup once: the verifier fixes the shape and FRI parameters; the prover inherits them.
-			let verifier = Verifier::setup(c.circuit.constraint_system(), 2, 1);
-			let prover = Prover::<P>::setup(&verifier);
-
-			// Prover: commit and open on a fresh transcript.
-			let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
-			let (point, eval) = prover.prove(&table, &mut prover_transcript);
-
-			// Verifier: replay the same transcript and check the opening.
-			let mut verifier_transcript = prover_transcript.into_verifier();
-			let (v_point, v_eval) = verifier
-				.verify(&mut verifier_transcript)
-				.expect("a faithful opening verifies");
-			verifier_transcript.finalize().expect("no trailing proof data");
-
-			// Both sides drew the same Fiat-Shamir point and agree on the opened value.
-			prop_assert_eq!(&v_point, &point);
-			prop_assert_eq!(v_eval, eval);
-
-			// The opened value is the committed multilinear evaluated at the point.
-			let direct = evaluate(&table.pack::<P>(), &point);
-			prop_assert_eq!(eval, direct);
-		}
-	}
-
+	// The prover and verifier run the whole protocol on one transcript.
+	// A faithful proof over 64 instances verifies and leaves no trailing data.
 	#[test]
-	fn tampered_proof_is_rejected() {
-		let c = and_circuit();
-		let table = populate_table(&c, &[(1, 2), (3, 4), (5, 6), (7, 8)]);
+	fn protocol_round_trips() {
+		let log_instances = 6;
+		let (cs, table) = setup_batch(log_instances, 0);
 
-		let verifier = Verifier::setup(c.circuit.constraint_system(), 2, 1);
+		// Setup once: the verifier fixes the shape and FRI parameters.
+		// The prover inherits them.
+		let verifier = Verifier::setup(&cs, log_instances, 1);
+		let prover = Prover::<P>::setup(&verifier);
+
+		// Prover: commit, reduce, and open on a fresh transcript.
+		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
+		prover.prove(&table, &mut prover_transcript);
+
+		// Verifier: replay the same transcript end to end.
+		let mut verifier_transcript = prover_transcript.into_verifier();
+		verifier
+			.verify(&mut verifier_transcript)
+			.expect("a faithful proof verifies");
+		verifier_transcript
+			.finalize()
+			.expect("no trailing proof data");
+	}
+
+	// Tampering with the trace opening breaks the final FRI check.
+	#[test]
+	fn tampered_opening_is_rejected() {
+		let log_instances = 6;
+		let (cs, table) = setup_batch(log_instances, 1);
+
+		let verifier = Verifier::setup(&cs, log_instances, 1);
 		let prover = Prover::<P>::setup(&verifier);
 
 		// Produce a faithful proof, then collect its bytes.
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
-		let _ = prover.prove(&table, &mut prover_transcript);
+		prover.prove(&table, &mut prover_transcript);
 		let mut proof = prover_transcript.finalize();
 
-		// Flip one bit deep in the proof; any change to the committed data must break the opening.
-		let mid = proof.len() / 2;
-		proof[mid] ^= 1;
-
-		// The flipped byte lands in a FRI query's Merkle opening.
+		// Flip one bit in the last byte, which lands in a FRI query's Merkle opening.
 		// The opening no longer matches the committed root, so BaseFold verification rejects it.
+		let last = proof.len() - 1;
+		proof[last] ^= 1;
+
 		let mut verifier_transcript = VerifierTranscript::new(StdChallenger::default(), proof);
 		let err = verifier.verify(&mut verifier_transcript).unwrap_err();
 		assert_matches!(
 			err,
-			binius_iop::channel::Error::BaseFold(BaseFoldError::Verification(
+			Error::IOPChannel(IOPChannelError::BaseFold(BaseFoldError::Verification(
 				BaseFoldVerificationError::FRI(FriVerificationError::MerkleError(
 					MerkleVerificationError::InvalidProof
 				))
-			))
+			)))
 		);
 	}
 }

--- a/crates/m4-prover/src/reduction.rs
+++ b/crates/m4-prover/src/reduction.rs
@@ -10,9 +10,9 @@
 //! 3. The witness is folded over the instance axis at `r_rho`.
 //! 4. The shift reduction reduces the operand claims to a single evaluation of the folded witness.
 //!
-//! The output is that witness claim.
-//! Binding it to the committed trace oracle is a later step, not done here.
-//! That tie binds `r_rho` and bridges the bit witness to the packed commitment.
+//! The output is that witness claim, together with `r_rho`.
+//! The caller binds it to the committed trace by ring-switching at `r_j || r_rho || r_y`.
+//! Evaluating the trace's instance coordinates at `r_rho` performs that instance fold.
 //!
 //! Only AND constraints are handled, so the circuit must have no MUL constraints.
 

--- a/crates/m4-verifier/src/reduction.rs
+++ b/crates/m4-verifier/src/reduction.rs
@@ -10,7 +10,8 @@
 //! 4. The public-input consistency check ties in the shared constants.
 //!
 //! The output is that witness claim together with `r_rho`.
-//! Binding the claim to the committed trace oracle is a later step, not done here.
+//! The caller binds it to the committed trace by ring-switching at `r_j || r_rho || r_y`.
+//! Evaluating the trace's instance coordinates at `r_rho` performs that instance fold.
 
 use binius_core::{constraint_system::ConstraintSystem, word::Word};
 use binius_field::{AESTowerField8b as B8, Field};

--- a/crates/m4-verifier/src/verify.rs
+++ b/crates/m4-verifier/src/verify.rs
@@ -2,6 +2,7 @@
 // Copyright 2026 The Binius Developers
 
 use binius_core::constraint_system::ConstraintSystem;
+use binius_field::ExtensionField;
 use binius_hash::StdHashSuite;
 use binius_iop::{
 	basefold_compiler::BaseFoldVerifierCompiler,
@@ -9,12 +10,17 @@ use binius_iop::{
 	fri::{ConstantArityStrategy, calculate_n_test_queries},
 	merkle_tree::BinaryMerkleTreeScheme,
 };
-use binius_ip::channel::IPVerifierChannel;
-use binius_math::multilinear::eq::eq_ind;
 use binius_transcript::{VerifierTranscript, fiat_shamir::Challenger};
-use binius_verifier::config::B128;
+use binius_verifier::{
+	Error,
+	config::{B1, B128},
+	ring_switch::{self, RingSwitchVerifyOutput},
+};
 
-use crate::commit::BatchCommitLayout;
+use crate::{
+	commit::BatchCommitLayout,
+	reduction::{ReductionVerifierOutput, verify_reduction},
+};
 
 /// The target soundness, in bits.
 ///
@@ -25,13 +31,16 @@ const SECURITY_BITS: usize = 96;
 /// The Merkle commitment scheme over the committed field.
 type Scheme = BinaryMerkleTreeScheme<B128, StdHashSuite>;
 
-/// Verifies a batch-witness commitment opened at a verifier-chosen random point.
+/// Verifies the data-parallel M4 proof for a batch of `2^log_instances` circuit instances.
 ///
-/// Setup fixes the committed-oracle shape and the BaseFold parameters once.
-/// A later opening proof is then checked against that fixed setup.
+/// The proof reduces the whole batch to one claim about the committed trace, then opens the trace.
+/// One-time setup fixes the constraint system, the committed-oracle shape, and the FRI parameters.
+/// A later verification checks one proof against that fixed setup.
 ///
 /// The prover is built from this verifier, so both sides share one set of FRI parameters.
 pub struct Verifier {
+	/// The prepared single-instance constraint system shared by every instance.
+	cs: ConstraintSystem,
 	/// The committed-multilinear shape of the batch.
 	layout: BatchCommitLayout,
 	/// The precomputed BaseFold verifier, holding the FRI parameters.
@@ -43,7 +52,7 @@ impl Verifier {
 	///
 	/// # Arguments
 	///
-	/// - `cs`: the single-instance constraint system shared by every instance.
+	/// - `cs`: the prepared single-instance constraint system shared by every instance.
 	/// - `log_instances`: base-2 logarithm of the instance count.
 	/// - `log_inv_rate`: base-2 logarithm of the inverse Reed-Solomon rate.
 	pub fn setup(cs: &ConstraintSystem, log_instances: usize, log_inv_rate: usize) -> Self {
@@ -73,9 +82,15 @@ impl Verifier {
 		);
 
 		Self {
+			cs: cs.clone(),
 			layout,
 			iop_compiler,
 		}
+	}
+
+	/// The prepared constraint system this verifier checks against.
+	pub const fn constraint_system(&self) -> &ConstraintSystem {
+		&self.cs
 	}
 
 	/// The committed-multilinear shape this verifier expects.
@@ -90,22 +105,27 @@ impl Verifier {
 		&self.iop_compiler
 	}
 
-	/// Verifies a batch-witness commitment opened at a verifier-chosen random point.
+	/// Verifies one M4 proof.
 	///
-	/// The verifier receives the commitment, redraws the same point, reads the claim, and checks
-	/// the opening.
+	/// The steps mirror the prover on the same transcript:
+	/// - Receive the trace commitment.
+	/// - Replay the AND-check and shift reduction to one folded-witness claim.
+	/// - Ring-switch that claim onto the committed trace.
+	/// - Check the trace opening.
 	///
-	/// # Returns
-	///
-	/// The random point and the evaluation the opening proves at it.
+	/// The reduction ends with a claim about the witness folded over instances at `r_rho`.
+	/// The trace's bit index is `[bit | instance | wire]`.
+	/// So evaluating its instance coordinates at `r_rho` performs that fold.
+	/// The ring-switch therefore opens the trace at `r_j || r_rho || r_y`.
+	/// That evaluation equals the folded-witness claim the reduction produced.
 	///
 	/// # Errors
 	///
-	/// Returns an error if the commitment opening does not verify.
+	/// Returns an error if the reduction, the ring-switch, or the trace opening fails.
 	pub fn verify<Challenger_>(
 		&self,
 		transcript: &mut VerifierTranscript<Challenger_>,
-	) -> Result<(Vec<B128>, B128), binius_iop::channel::Error>
+	) -> Result<(), Error>
 	where
 		Challenger_: Challenger,
 	{
@@ -113,28 +133,36 @@ impl Verifier {
 			.iop_compiler
 			.create_channel_from_transcript::<StdHashSuite, Challenger_, _>(transcript);
 
-		// Receive the commitment, redraw the same point, and read the claimed evaluation. The
-		// packed batch witness is witness-dependent (M4 commits it without ZK regardless).
-		let oracle = channel.recv_oracle(self.layout.log_witness_elems, true)?;
-		let point = channel.sample_many(self.layout.log_witness_elems);
-		let eval = channel.recv_one()?;
+		// Receive the trace commitment.
+		// The witness is committed without zero-knowledge.
+		let trace_oracle = channel.recv_oracle(self.layout.log_witness_elems, true)?;
 
-		// The committed multilinear opened at `point` must equal `eval`.
-		//
-		// The transparent multilinear is eq(point, .).
-		// BaseFold reduces to a challenge point `pt`, where this transparent evaluates to eq(point,
-		// pt).
-		let point_at_pt = point.clone();
+		// Replay the AND-check and shift reduction to a single folded-witness claim.
+		let ReductionVerifierOutput { r_rho, shift } =
+			verify_reduction(&self.cs, self.layout.log_instances, &mut channel)?;
 
-		// The channel only queues the relation here.
-		// `finish` runs the single combined FRI opening check.
+		// Ring-switch the reduced claim onto the committed trace.
+		// The point is `r_j || r_rho || r_y`.
+		// Its instance coordinates fold the trace at `r_rho`.
+		let trace_point = [shift.r_j(), r_rho.as_slice(), shift.r_y()].concat();
+		let RingSwitchVerifyOutput {
+			eq_r_double_prime,
+			sumcheck_claim,
+		} = ring_switch::verify(shift.witness_eval, &trace_point, &mut channel)?;
+
+		// Open the trace oracle against the ring-switch's transparent multilinear.
+		// BaseFold reduces to a challenge point where the transparent evaluates as below.
+		let log_packing = <B128 as ExtensionField<B1>>::LOG_DEGREE;
+		let eval_point_high = trace_point[log_packing..].to_vec();
 		channel.verify_oracle_relations([OracleLinearRelation {
-			oracle,
-			transparent: Box::new(move |pt: &[B128]| eq_ind(&point_at_pt, pt)),
-			claim: eval,
+			oracle: trace_oracle,
+			transparent: Box::new(move |pt: &[B128]| {
+				ring_switch::eval_rs_eq(&eval_point_high, pt, &eq_r_double_prime)
+			}),
+			claim: sumcheck_claim,
 		}])?;
 		channel.finish()?;
 
-		Ok((point, eval))
+		Ok(())
 	}
 }


### PR DESCRIPTION
Closes [BINIUS-255](https://linear.app/jimpo/issue/BINIUS-255).

Ties the AND-check + shift reduction to the committed trace, so the data-parallel M4 prover/verifier now run end to end.

### The problem

The reduction crunches the whole batch to one number: the witness, folded over instances at `r_rho`, evaluated at a random point.

But nothing linked that number to the data committed at the very start.

- A cheating prover could reduce one witness and commit a different one.
- The claim was floating free — about *some* witness, not *the committed* witness.
- Without the link, the proof proves nothing.

### The idea

The verifier must force: *the committed trace, read at the reduction's point, equals the reduced number.*

Two mismatches make that look hard:

- The number is **folded over instances**; the commitment still has every instance separately.
- The number is over **single bits**; the commitment is packed into $\mathbb{F}_{2^{128}}$ elements.

Both vanish with the right point. The trace's bit index is laid out as `[bit | instance | wire]`, and evaluating a multilinear at a coordinate is a weighted sum over it. So:

- Evaluating the trace's **instance** coordinates at `r_rho` performs the instance fold — for free.
- The bit-to-packed gap is exactly what the existing ring-switch handles.

So the single-instance ring-switch is reused verbatim, opening the trace at:

```
r_j  ||  r_rho  ||  r_y
(bit)   (instance)  (wire)
```

No new gadget, no new assumption — just the right point.

### The change

```diff
- Prover::prove / Verifier::verify: standalone commit-open at a random point
+ Prover::prove / Verifier::verify: commit trace -> reduction -> ring-switch -> open, on one transcript
```

- `crates/m4-prover/src/prove.rs` — `Prover::prove` runs the whole protocol; `setup` builds the shift keys once.
- `crates/m4-verifier/src/verify.rs` — `Verifier::verify` runs the whole protocol; the verifier now stores the constraint system.
- `crates/{m4-prover,m4-verifier}/src/reduction.rs` — module docs updated: the trace-oracle tie is done by the protocol layer, not "a later step".

### Soundness

- The instance fold **equals** evaluating the trace at `r_rho` on the instance axis — a multilinear evaluation is the `eq`-weighted sum, so this is exact, not an approximation.
- The point `r_j || r_rho || r_y` matches the trace layout `[bit | instance | wire]` coordinate for coordinate.
- Dimensions match exactly: the packed trace has `log_hidden + log_inst - 1` elements; the point has `6 + log_inst + log_hidden` coordinates, which is elements + 7 (the ring-switch packing width).
- The ring-switch is the same gadget the single-instance protocol uses — no new cryptographic assumption.
- The channel's `Elem` is `$\mathbb{F}_{2^{128}}$`, and M4 fixes its one oracle spec directly rather than deriving it against a symbolic channel — so the concrete `Elem` bound is correct and needs no generalization.

### Scope

- **new:** the full-protocol wiring and two end-to-end tests.
- **changed:** `Prover`/`Verifier` now run the whole protocol (were a standalone commit-open).
- **left untouched:** intmul / MUL constraints stay out of scope (asserted absent) — that is not part of "andcheck and shift".

### Verification

- `cargo check`, `clippy -p binius-m4-prover -p binius-m4-verifier`, nightly `fmt` — clean.
- 29 `binius-m4-prover` + 3 `binius-m4-verifier` tests pass, including:
  - `protocol_round_trips` — a full proof over 64 instances verifies end to end (this is what confirms the point is correct).
  - `tampered_opening_is_rejected` — flipping one bit of the opening fails with exactly `MerkleError(InvalidProof)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)