### PR TITLE
Reject MUL constraints in M4 verifier reduction

### DIFF
--- a/crates/m4-prover/src/reduction.rs
+++ b/crates/m4-prover/src/reduction.rs
@@ -128,6 +128,7 @@ mod tests {
 	use std::array;
 
 	use binius_field::PackedBinaryGhash1x128b;
+	use binius_frontend::CircuitBuilder;
 	use binius_m4_verifier::verify_reduction;
 	use binius_math::{inner_product::inner_product, multilinear::eq::eq_ind_partial_eval};
 	use binius_prover::protocols::shift::build_key_collection;
@@ -250,5 +251,25 @@ mod tests {
 					.expect_err("a tampered proof must not verify and finalize cleanly");
 			}
 		}
+	}
+
+	#[test]
+	#[should_panic(
+		expected = "the M4 reduction handles only AND constraints; the circuit must have no MUL constraints"
+	)]
+	fn verifier_rejects_mul_constraints_before_reading_transcript() {
+		let builder = CircuitBuilder::new();
+		let x = builder.add_witness();
+		let y = builder.add_witness();
+		let (hi, lo) = builder.smul(x, y);
+		builder.force_commit(hi);
+		builder.force_commit(lo);
+		let circuit = builder.build();
+
+		let mut cs = circuit.constraint_system().clone();
+		cs.validate_and_prepare().unwrap();
+
+		let mut verifier_transcript = VerifierTranscript::new(StdChallenger::default(), Vec::new());
+		let _ = verify_reduction(&cs, 0, &mut verifier_transcript);
 	}
 }

--- a/crates/m4-verifier/src/reduction.rs
+++ b/crates/m4-verifier/src/reduction.rs
@@ -47,6 +47,10 @@ pub struct ReductionVerifierOutput {
 /// # Errors
 ///
 /// Returns an error if the AND-check, the shift reduction, or the public-input check fails.
+///
+/// # Panics
+///
+/// Panics if the constraint system has any MUL constraints, which this reduction does not handle.
 pub fn verify_reduction<Channel>(
 	cs: &ConstraintSystem,
 	log_instances: usize,
@@ -55,6 +59,11 @@ pub fn verify_reduction<Channel>(
 where
 	Channel: IPVerifierChannel<B128, Elem = B128>,
 {
+	assert!(
+		cs.mul_constraints.is_empty(),
+		"the M4 reduction handles only AND constraints; the circuit must have no MUL constraints"
+	);
+
 	// One base domain shared by the AND-check and the shift, consistent by construction.
 	// The AND-check's univariate-skip domain spans one dimension above the 64-bit word.
 	let andcheck_domain = BinarySubspace::<B8>::with_dim(Word::LOG_BITS + 1);


### PR DESCRIPTION
## Summary
Make the verifier-side M4 reduction reject constraint systems with MUL constraints up front.

The M4 reduction currently handles only AND constraints. The prover already asserts this before proving, but the verifier path still built a zero intmul claim and proceeded. This PR mirrors the prover's scope check on the verifier side, so unsupported circuits fail immediately with the same message instead of reaching the shift verifier indirectly.

## Test plan
- `cargo test -p binius-m4-prover --lib reduction::tests::verifier_rejects_mul_constraints_before_reading_transcript -- --exact`
- `cargo test -p binius-m4-prover --lib reduction::tests`
- `cargo test -p binius-m4-prover --lib`
- `cargo test -p binius-m4-verifier --lib`
- `cargo +nightly-2026-01-01 fmt --check`
- `cargo clippy -p binius-m4-prover -p binius-m4-verifier --all-features --tests --benches -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p binius-m4-prover -p binius-m4-verifier --all-features --document-private-items --no-deps`
