### PR TITLE
BINIUS-263: remove unused dependencies across the workspace

### DIFF
--- a/crates/field/Cargo.toml
+++ b/crates/field/Cargo.toml
@@ -14,7 +14,6 @@ cfg-if.workspace = true
 derive_more.workspace = true
 rand.workspace = true
 seq-macro.workspace = true
-thiserror.workspace = true
 tracing = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/crates/frontend/Cargo.toml
+++ b/crates/frontend/Cargo.toml
@@ -11,7 +11,6 @@ workspace = true
 binius-core = { path = "../core" }
 binius-utils = { path = "../utils" }
 cranelift-entity = { workspace = true }
-hex-literal.workspace = true
 num-bigint = { workspace = true }
 rand.workspace = true
 petgraph.workspace = true
@@ -22,6 +21,5 @@ rustc-hash.workspace = true
 
 [dev-dependencies]
 rand = { workspace = true, features = ["thread_rng"] }
-hex-literal = { workspace = true }
 proptest = { workspace = true }
 insta = { workspace = true }

--- a/crates/hash/Cargo.toml
+++ b/crates/hash/Cargo.toml
@@ -11,7 +11,6 @@ workspace = true
 
 [dependencies]
 binius-field = { path = "../field" }
-binius-math = { path = "../math" }
 binius-transcript = { path = "../transcript" }
 binius-utils = { path = "../utils" }
 blake3 = { workspace = true, features = ["traits-preview"] }

--- a/crates/iop-prover/Cargo.toml
+++ b/crates/iop-prover/Cargo.toml
@@ -16,13 +16,10 @@ binius-ip-prover = { path = "../ip-prover" }
 binius-math = { path = "../math" }
 binius-transcript = { path = "../transcript" }
 binius-utils = { path = "../utils" }
-bytes.workspace = true
-derive_more.workspace = true
 digest.workspace = true
 getset.workspace = true
 itertools.workspace = true
 rand.workspace = true
-thiserror.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]

--- a/crates/iop/Cargo.toml
+++ b/crates/iop/Cargo.toml
@@ -14,12 +14,10 @@ binius-ip = { path = "../ip" }
 binius-math = { path = "../math" }
 binius-transcript = { path = "../transcript" }
 binius-utils = { path = "../utils" }
-bytes.workspace = true
 digest.workspace = true
 getset.workspace = true
 itertools.workspace = true
 thiserror.workspace = true
-tracing.workspace = true
 
 [dev-dependencies]
 binius-math = { path = "../math", features = ["test-utils"] }

--- a/crates/ip-prover/Cargo.toml
+++ b/crates/ip-prover/Cargo.toml
@@ -15,7 +15,6 @@ binius-transcript = { path = "../transcript" }
 binius-utils = { path = "../utils" }
 either.workspace = true
 itertools.workspace = true
-thiserror.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]

--- a/crates/math/Cargo.toml
+++ b/crates/math/Cargo.toml
@@ -10,13 +10,11 @@ workspace = true
 [dependencies]
 binius-field = { path = "../field", default-features = false }
 binius-utils = { path = "../utils", default-features = false }
-bytemuck.workspace = true
+bytemuck = { workspace = true, features = ["extern_crate_alloc"] }
 getset.workspace = true
 itertools.workspace = true
 rand.workspace = true
-thiserror.workspace = true
 tracing.workspace = true
-uninit.workspace = true
 
 [dev-dependencies]
 assert_matches.workspace = true

--- a/crates/prover/Cargo.toml
+++ b/crates/prover/Cargo.toml
@@ -18,13 +18,11 @@ binius-ip-prover = { path = "../ip-prover", default-features = false }
 binius-math = { path = "../math" }
 binius-spartan-frontend = { path = "../spartan-frontend" }
 binius-spartan-prover = { path = "../spartan-prover", default-features = false }
-binius-spartan-verifier = { path = "../spartan-verifier" }
 binius-transcript = { path = "../transcript" }
 binius-verifier = { path = "../verifier" }
 binius-utils = { path = "../utils" }
-bytemuck.workspace = true
+bytemuck = { workspace = true, features = ["extern_crate_alloc"] }
 bytes.workspace = true
-derive_more.workspace = true
 digest.workspace = true
 either.workspace = true
 getset.workspace = true

--- a/crates/spartan-frontend/Cargo.toml
+++ b/crates/spartan-frontend/Cargo.toml
@@ -7,9 +7,7 @@ authors.workspace = true
 [dependencies]
 binius-field = { path = "../field" }
 binius-utils = { path = "../utils" }
-bytemuck.workspace = true
-getset.workspace = true
-itertools.workspace = true
+bytemuck = { workspace = true, features = ["extern_crate_alloc"] }
 smallvec.workspace = true
 
 [dev-dependencies]

--- a/crates/spartan-prover/Cargo.toml
+++ b/crates/spartan-prover/Cargo.toml
@@ -8,7 +8,6 @@ authors.workspace = true
 workspace = true
 
 [dependencies]
-array-util.workspace = true
 binius-field = { path = "../field" }
 binius-hash = { path = "../hash" }
 binius-iop = { path = "../iop" }

--- a/crates/spartan-verifier/Cargo.toml
+++ b/crates/spartan-verifier/Cargo.toml
@@ -8,7 +8,6 @@ authors.workspace = true
 workspace = true
 
 [dependencies]
-array-util.workspace = true
 binius-field = { path = "../field" }
 binius-hash = { path = "../hash", default-features = false }
 binius-iop = { path = "../iop" }
@@ -19,7 +18,6 @@ binius-spartan-frontend = { path = "../spartan-frontend" }
 binius-utils = { path = "../utils" }
 digest.workspace = true
 thiserror.workspace = true
-tracing.workspace = true
 
 [dev-dependencies]
 binius-spartan-frontend = { path = "../spartan-frontend" }

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -10,7 +10,6 @@ workspace = true
 
 [dependencies]
 array-util.workspace = true
-bytemuck = { workspace = true, features = ["extern_crate_alloc"] }
 bytes.workspace = true
 cfg-if.workspace = true
 hybrid-array.workspace = true

--- a/crates/verifier/Cargo.toml
+++ b/crates/verifier/Cargo.toml
@@ -18,7 +18,6 @@ binius-transcript = { path = "../transcript" }
 binius-spartan-frontend = { path = "../spartan-frontend", default-features = false }
 binius-spartan-verifier = { path = "../spartan-verifier", default-features = false }
 binius-utils = { path = "../utils" }
-bytemuck.workspace = true
 bytes.workspace = true
 digest.workspace = true
 getset.workspace = true


### PR DESCRIPTION
Closes [BINIUS-263](https://linear.app/jimpo/issue/BINIUS-263).

Removes fourteen dependencies that are declared but never used. Only `Cargo.toml` files change — no source changes, no behavior change.

### The problem

Fourteen crate dependencies are declared but never used.

They cost compile time and linking, and mislead a reader about what a crate actually depends on.

Nothing in CI catches this today: `cargo build -D warnings` flags an unused `use`, but never an unused `Cargo.toml` entry.

`cargo machete` finds them; each was then grep-confirmed to have zero references, including behind derive macros (`thiserror`, `derive_more`) and `#[error]` attributes.

### The change

Drop the unused dependency from each crate:

- `binius-iop-prover`: `bytes`, `derive_more`, `thiserror`
- `binius-iop`: `bytes`, `tracing`
- `binius-ip-prover`: `thiserror`
- `binius-spartan-verifier`: `array-util`, `tracing`
- `binius-spartan-frontend`: `getset`, `itertools`
- `binius-math`: `thiserror`, `uninit`
- `binius-prover`: `binius-spartan-verifier`, `derive_more`
- `binius-field`: `thiserror`
- `binius-hash`: `binius-math`
- `binius-utils`: `bytemuck`
- `binius-verifier`: `bytemuck`
- `binius-spartan-prover`: `array-util`
- `binius-frontend`: `hex-literal` (in both `[dependencies]` and `[dev-dependencies]`)

The `binius-prover` → `binius-spartan-verifier` one is a whole crate that was linked for nothing.

### A hidden coupling this surfaced

Removing `bytemuck` from `binius-utils` broke the build — the interesting part.

`binius-utils` had no code using `bytemuck`; its entry existed only to turn on `bytemuck`'s `extern_crate_alloc` feature.

Three crates — `binius-math`, `binius-prover`, `binius-spartan-frontend` — call the alloc-gated APIs (`zeroed_vec`, `zeroed_slice_box`) but declared plain `bytemuck`, and only compiled because Cargo's feature unification turned the feature on for the whole graph.

The fix makes each of those three declare `features = ["extern_crate_alloc"]` itself, so the dependency is correct in isolation (standalone builds, wasm) rather than by accident of unification.

### Scope

- Only `Cargo.toml` files change — no source changes, no behavior change.
- `Cargo.lock` is unchanged: every removed dependency is still used by some other crate in the workspace.
- Feature-gated and derive-macro deps were checked by hand, not just by the tool.

### Verification

All under `RUSTFLAGS="-Ctarget-cpu=native"`:

- `cargo machete` — clean.
- `cargo build --workspace --lib --bins --tests --examples` — clean.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.

### Follow-up

Worth adding a `cargo machete` step to CI so this cannot regress — it needs no compile, so it is nearly free. Plonky3's CI has no such guard either, so there is no prior art to copy; this would be a small net-new addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)