### PR TITLE
BINIUS-264: drop three stale #[allow(dead_code)] attributes on live code

### DIFF
--- a/crates/ip-prover/src/sumcheck/gruen32.rs
+++ b/crates/ip-prover/src/sumcheck/gruen32.rs
@@ -85,7 +85,6 @@ impl<F: Field, P: PackedField<Scalar = F>> Gruen32<P> {
 
 	// An interpolation routine for degree-2 round polynomials. Takes P'(x) evals and sum claim on
 	// P(x).
-	#[allow(dead_code)]
 	pub fn interpolate2(
 		&self,
 		sum: F,

--- a/crates/ip-prover/src/sumcheck/selector_mle.rs
+++ b/crates/ip-prover/src/sumcheck/selector_mle.rs
@@ -1,8 +1,6 @@
 // Copyright 2023-2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-#![allow(dead_code)]
-
 use binius_field::{Field, PackedField, WideMul};
 use binius_ip::sumcheck::RoundCoeffs;
 use binius_math::{FieldBuffer, multilinear::fold::fold_highest_var_inplace};

--- a/crates/utils/src/strided_array.rs
+++ b/crates/utils/src/strided_array.rs
@@ -85,7 +85,6 @@ impl<'a, T> StridedArray2DViewMut<'a, T> {
 	}
 
 	/// Returns iterator over vertical slices of the data for the given stride.
-	#[allow(dead_code)]
 	pub fn into_strides(self, stride: usize) -> impl Iterator<Item = Self> + 'a {
 		let Self {
 			data,


### PR DESCRIPTION
Closes [BINIUS-264](https://linear.app/jimpo/issue/BINIUS-264).

Removes three `#[allow(dead_code)]` attributes whose code is used today. Pure cleanup — no behavior change.

### The problem

An `allow(dead_code)` is a promise: "this looks unused, ignore it." Once the code becomes live again, the attribute should come off — otherwise it silently masks the *next* thing that goes dead in the same scope.

A file-level `#![allow(dead_code)]` is the worst of these: it blankets a whole module, so any future dead helper in that file is invisible.

Three of them now sit on live code.

### The change

Remove the attribute in three places; the code stays.

- `crates/ip-prover/src/sumcheck/selector_mle.rs` — file-level `#![allow(dead_code)]`. The module is a `pub` export driven by `binius-prover` (`intmul/prove.rs` builds a `SelectorMlecheckProver`), and no dead internal helpers remain, so the blanket allow suppresses nothing.
- `crates/ip-prover/src/sumcheck/gruen32.rs` — `#[allow(dead_code)]` on `pub fn interpolate2`, which is actually called from `selector_mle.rs:225`.
- `crates/utils/src/strided_array.rs` — `#[allow(dead_code)]` on `pub fn into_strides`, a public-API method exercised by the crate's own tests; a plain lib build emits no `dead_code` warning once the allow is gone.

### Soundness

Nothing runtime changes — these are attributes, not code.

If any of these items truly goes unused later, the lint will now fire and `clippy -D warnings` will catch it, which is the point.

### Scope

- Three `.rs` files, four lines removed, no source logic touched.
- All three files are architecture-independent (no `cfg`, no SIMD), so the result holds across the portable / x86_64 / arm64 CI legs.

### Verification

- `cargo clippy --workspace --all-targets -- -D warnings` — clean, under `RUSTFLAGS="-Ctarget-cpu=native"`.

### Context

Same maintenance sweep as [BINIUS-263](https://linear.app/jimpo/issue/BINIUS-263) (unused-dependency removal); independent files, so the two can land in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)