### PR TITLE
BINIUS-265: delete the render_graphviz dumper and unmask the m4 shift path

### DIFF
--- a/crates/frontend/src/compiler/gate_fusion/legraph.rs
+++ b/crates/frontend/src/compiler/gate_fusion/legraph.rs
@@ -2,10 +2,7 @@
 //! linear expression graph.
 
 use cranelift_entity::EntitySet;
-use petgraph::{
-	dot::Dot,
-	graph::{DiGraph, NodeIndex},
-};
+use petgraph::graph::{DiGraph, NodeIndex};
 use rustc_hash::FxHashMap;
 
 use super::Stat;
@@ -69,10 +66,7 @@ pub enum NodeData {
 	/// x = input()     // Creates an Opaque node for x
 	/// y = a * b       // Creates Opaque nodes for y (MUL output)
 	/// ```
-	Opaque {
-		/// The opaque wire that cannot be inlined.
-		wire: Wire,
-	},
+	Opaque,
 }
 
 impl NodeData {
@@ -81,7 +75,7 @@ impl NodeData {
 	}
 
 	const fn is_opaque(&self) -> bool {
-		matches!(self, NodeData::Opaque { .. })
+		matches!(self, NodeData::Opaque)
 	}
 }
 
@@ -265,7 +259,7 @@ impl LeGraph {
 		} else {
 			// This is a use of a wire that is not defined by a linear. That means it's opaque!
 			let opaque_node = *self.wire_to_node.entry(producer).or_insert_with(|| {
-				let t = self.pg.add_node(NodeData::Opaque { wire: producer });
+				let t = self.pg.add_node(NodeData::Opaque);
 				self.opaque.push(t);
 				t
 			});
@@ -279,63 +273,6 @@ impl LeGraph {
 		let root_node = self.pg.add_node(NodeData::Root { constraint });
 		self.roots.push(root_node);
 		self.pg.add_edge(node_p, root_node, EdgeData { shift });
-	}
-
-	/// A pure diagnostic tool which can come in handy if you are in trouble.
-	#[doc(hidden)]
-	#[allow(dead_code)]
-	pub fn render_graphviz(&self) -> String {
-		let fmt_edge =
-			|_g: &petgraph::Graph<NodeData, EdgeData>,
-			 _edge: petgraph::graph::EdgeReference<'_, EdgeData>| { String::new() };
-		let fmt_node = |_g: &petgraph::Graph<NodeData, EdgeData>,
-		                (_node, data): (NodeIndex, &NodeData)| {
-			match data {
-				NodeData::Root { .. } => {
-					let label = "root".to_string();
-					format!("shape=box color=red label=\"{label}\"")
-				}
-				NodeData::LinDef { dst, operand, .. } => {
-					let fmt_operand = if operand.len() == 1 {
-						format_shifted_wire(&operand[0])
-					} else {
-						operand
-							.iter()
-							.map(format_shifted_wire)
-							.collect::<Vec<String>>()
-							.join("^")
-					};
-
-					let label = format!("{:?} = {fmt_operand}", dst);
-					let shape = if self.lin_committed.contains(*dst) {
-						"shape=octogon"
-					} else {
-						"shape=box"
-					};
-					format!("{shape} label=\"{label}\"")
-				}
-				NodeData::Opaque { wire } => {
-					let label = format!("opaque: {:?}", wire);
-					format!("shape=box color=blue label=\"{label}\"")
-				}
-			}
-		};
-		let dot = Dot::with_attr_getters(&self.pg, &[], &fmt_edge, &fmt_node);
-		return format!("{:?}", dot);
-
-		fn format_shifted_wire(t: &crate::compiler::constraint_builder::ShiftedWire) -> String {
-			match t.shift {
-				Shift::None => format!("{:?}", t.wire),
-				Shift::Sll(amount) => format!("{:?} << {:?}", t.wire, amount),
-				Shift::Sll32(amount) => format!("{:?} <<32 {:?}", t.wire, amount),
-				Shift::Srl(amount) => format!("{:?} >> {:?}", t.wire, amount),
-				Shift::Srl32(amount) => format!("{:?} >>32 {:?}", t.wire, amount),
-				Shift::Sar(amount) => format!("{:?} sar {:?}", t.wire, amount),
-				Shift::Sra32(amount) => format!("{:?} sar32 {:?}", t.wire, amount),
-				Shift::Rotr(amount) => format!("{:?} rotr {:?}", t.wire, amount),
-				Shift::Rotr32(amount) => format!("{:?} rotr32 {:?}", t.wire, amount),
-			}
-		}
 	}
 }
 

--- a/crates/m4-prover/src/shift.rs
+++ b/crates/m4-prover/src/shift.rs
@@ -2,16 +2,12 @@
 
 //! The batched shift-reduction prover for the data-parallel Binius64 M4 proof system.
 
-#![allow(unused)]
-
 use binius_core::word::Word;
 use binius_field::{BinaryField, PackedField};
 use binius_ip::sumcheck::SumcheckOutput;
 use binius_ip_prover::channel::IPProverChannel;
 use binius_math::{
-	BinarySubspace, FieldBuffer,
-	inner_product::inner_product,
-	multilinear::eq::{eq_ind_partial_eval, eq_ind_partial_eval_scalars},
+	BinarySubspace, FieldBuffer, inner_product::inner_product, multilinear::eq::eq_ind_partial_eval,
 };
 use binius_prover::{
 	fold_word::{WordFolder, fold_words},
@@ -22,7 +18,7 @@ use binius_prover::{
 		phase_2::run_sumcheck,
 	},
 };
-use binius_utils::{checked_arithmetics::log2_strict_usize, rayon::prelude::*};
+use binius_utils::rayon::prelude::*;
 use binius_verifier::protocols::shift::SHIFT_VARIANT_COUNT;
 
 use crate::ValueTable;
@@ -293,15 +289,17 @@ mod tests {
 	use binius_core::{constraint_system::AndConstraint, verify::verify_constraints, word::Word};
 	use binius_field::{AESTowerField8b, Field, PackedBinaryGhash1x128b, Random};
 	use binius_math::{
-		inner_product::inner_product_buffers, multilinear::evaluate::evaluate,
-		test_utils::random_scalars, univariate::lagrange_evals_scalars,
+		inner_product::inner_product_buffers,
+		multilinear::{eq::eq_ind_partial_eval_scalars, evaluate::evaluate},
+		test_utils::random_scalars,
+		univariate::lagrange_evals_scalars,
 	};
 	use binius_prover::{
 		fold_word::fold_words,
 		protocols::shift::{build_key_collection, monster::build_h_parts},
 	};
 	use binius_transcript::ProverTranscript;
-	use binius_utils::checked_arithmetics::log2_ceil_usize;
+	use binius_utils::checked_arithmetics::{log2_ceil_usize, log2_strict_usize};
 	use binius_verifier::{
 		config::{B128, StdChallenger},
 		protocols::shift::{OperatorData as VerifierOperatorData, check_eval, verify},
@@ -548,7 +546,7 @@ mod tests {
 			.chunks_exact(Word::BITS)
 			.map(|chunk| chunk.try_into().unwrap())
 			.collect();
-		let offset = table.layout().offset_witness;
+		let _offset = table.layout().offset_witness;
 		let public_words = &cs.constants;
 
 		// The bitand operand evals at (r_z, r_x, r_rho); the circuit has no MUL constraints, so the


### PR DESCRIPTION
Closes [BINIUS-265](https://linear.app/jimpo/issue/BINIUS-265).

Removes genuinely dead code from two `src/` files. Pure cleanup — no behavior change.

### The problem

Two files carried dead code kept alive only by an `#[allow]`.

Unlike [BINIUS-264](https://linear.app/jimpo/issue/BINIUS-264) (where the allow sat on *live* code), here the code really is unused — the allow was hiding it, not marking a false positive.

### The change

**1. `crates/frontend/src/compiler/gate_fusion/legraph.rs` — remove the GraphViz dumper.**

`render_graphviz()` is a `#[doc(hidden)] #[allow(dead_code)]` diagnostic that renders the linear-expression graph to DOT. It is never called anywhere.

Removing it has a small ripple, because it was the *only* reader of one field:

- the `petgraph` `dot::Dot` import becomes unused → removed;
- `NodeData::Opaque`'s `wire` field was read only inside the dumper → the field is now dead, so `Opaque` becomes a unit variant;
- its single constructor in `note_lin_use` (`NodeData::Opaque { wire: producer }`) and the `is_opaque` `matches!` pattern are updated to match.

Worth being explicit: this was a *deliberately kept* debug aid, correctly annotated — not accidental rot. Deleting it removes that capability. It restores trivially from history, and I'm happy to keep it instead if you'd rather.

**2. `crates/m4-prover/src/shift.rs` — drop the file-level `#![allow(unused)]`.**

That blanket allow masked a real issue: two imports are used *only* by the in-file `#[cfg(test)]` module (which pulls them in via `use super::*`), so they are dead in the `lib` target.

- `eq_ind_partial_eval_scalars` and `checked_arithmetics::log2_strict_usize` moved into the test module's own `use` block.
- `eq_ind_partial_eval` stays at module scope — the library itself uses it.
- One unused `offset` binding in a test is underscore-prefixed.

The rest of the module is live (driven by `reduction.rs`), so only the allow and the misplaced imports change.

### Soundness

No runtime logic changes.

The `Opaque` node still marks "a wire not defined by a linear constraint"; only the unused `wire` payload is dropped, and `is_opaque` still distinguishes the variant.

### Scope

- Two `.rs` files, `+12 −77`.
- Both are architecture-independent, so the result holds across the portable / x86_64 / arm64 CI legs.

### Verification

All under `RUSTFLAGS="-Ctarget-cpu=native"`:

- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo test -p binius-m4-prover --lib` — 29 pass.
- `cargo test -p binius-frontend gate_fusion` — 81 pass.
- `cargo +nightly fmt` — clean.

### Context

Same maintenance sweep as [BINIUS-263](https://linear.app/jimpo/issue/BINIUS-263) (unused deps) and [BINIUS-264](https://linear.app/jimpo/issue/BINIUS-264) (stale allows); independent files, so they land in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)