### PR TITLE
BINIUS-216: share round-chunk preparation across sumcheck evaluators

### DIFF
--- a/crates/ip-prover/src/sumcheck/bivariate_product_evaluator.rs
+++ b/crates/ip-prover/src/sumcheck/bivariate_product_evaluator.rs
@@ -5,9 +5,9 @@ use binius_ip::sumcheck::RoundCoeffs;
 use itertools::izip;
 
 use super::{
-	mle_store::{ColId, MleStore},
+	mle_store::{ColId, EvaluationChunk, MleStore},
 	round_evals::WideRoundEvals2,
-	round_evaluator::{EvaluationChunk, RoundEvaluator},
+	round_evaluator::RoundEvaluator,
 };
 
 /// Sumcheck round evaluator for a composite defined as the product of two store columns.

--- a/crates/ip-prover/src/sumcheck/bivariate_product_evaluator.rs
+++ b/crates/ip-prover/src/sumcheck/bivariate_product_evaluator.rs
@@ -2,13 +2,12 @@
 
 use binius_field::{Field, PackedField, WideMul};
 use binius_ip::sumcheck::RoundCoeffs;
-use binius_math::FieldSlice;
 use itertools::izip;
 
 use super::{
 	mle_store::{ColId, MleStore},
 	round_evals::WideRoundEvals2,
-	round_evaluator::{RoundContext, RoundEvaluator},
+	round_evaluator::{EvaluationChunk, RoundEvaluator},
 };
 
 /// Sumcheck round evaluator for a composite defined as the product of two store columns.
@@ -47,29 +46,18 @@ impl<F: Field, P: PackedField<Scalar = F>> RoundEvaluator<F, P> for BivariatePro
 		}
 	}
 
-	fn accumulate(
-		&self,
-		ctx: &RoundContext<'_, '_, P>,
-		chunk_index: usize,
-		accum: &mut [<P as WideMul>::Output],
-	) {
-		let chunk_vars = ctx.chunk_vars();
+	fn accumulate(&self, chunk: &EvaluationChunk<'_, P>, accum: &mut [<P as WideMul>::Output]) {
+		let a = chunk.col(self.cols[0]);
+		let b = chunk.col(self.cols[1]);
 
-		let [a, b]: [&FieldSlice<'_, P>; 2] = self.cols.map(|id| ctx.col(id));
-		let (a_0, a_1) = a.split_half_ref();
-		let (b_0, b_1) = b.split_half_ref();
-		let a_0 = a_0.chunk(chunk_vars, chunk_index);
-		let a_1 = a_1.chunk(chunk_vars, chunk_index);
-		let b_0 = b_0.chunk(chunk_vars, chunk_index);
-		let b_1 = b_1.chunk(chunk_vars, chunk_index);
-
-		// Accumulate F(1) and F(∞) where F = ∑_{v ∈ B} A(v || X) B(v || X).
+		// Accumulate F(1) and F(∞) where F = ∑_{v ∈ B} A(v || X) B(v || X). The low half is the
+		// v-prefix at x=0, the high half at x=1.
 		//
 		// The per-point products are accumulated in unreduced (wide) form and reduced a single
 		// time in interpolate, amortizing the GF(2^128) reduction over the whole sum.
 		let mut evals = WideRoundEvals2::<<P as WideMul>::Output>::default();
 		for (&a_0_i, &a_1_i, &b_0_i, &b_1_i) in
-			izip!(a_0.as_ref(), a_1.as_ref(), b_0.as_ref(), b_1.as_ref())
+			izip!(a.lo.as_ref(), a.hi.as_ref(), b.lo.as_ref(), b.hi.as_ref())
 		{
 			// Evaluate M(∞) = M(0) + M(1)
 			let a_inf_i = a_0_i + a_1_i;

--- a/crates/ip-prover/src/sumcheck/mle_store.rs
+++ b/crates/ip-prover/src/sumcheck/mle_store.rs
@@ -44,6 +44,13 @@ impl ColId {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct EqId(usize);
 
+impl EqId {
+	/// Returns the registration position of the tracker in the store.
+	pub const fn index(self) -> usize {
+		self.0
+	}
+}
+
 /// One physical entry in the store, holding one or two logical columns.
 ///
 /// A `Borrowed` or `Owned` entry is a single column. A `SplitHalf` entry holds two adjacent
@@ -176,6 +183,18 @@ impl<'a, F: Field, P: PackedField<Scalar = F>> MleStore<'a, P> {
 	/// variable currently being bound.
 	pub fn eq_expansion(&self, id: EqId) -> &FieldBuffer<P> {
 		self.eq_trackers[id.0].eq_expansion()
+	}
+
+	/// Returns the equality-indicator expansion of every registered tracker, in [`EqId`] order.
+	///
+	/// The driving prover slices each expansion per chunk once per round; the returned order
+	/// matches [`EqId::index`], so an evaluator's tracker id indexes the resulting per-chunk
+	/// slices.
+	pub fn eq_expansions(&self) -> Vec<&FieldBuffer<P>> {
+		self.eq_trackers
+			.iter()
+			.map(|tracker| tracker.eq_expansion())
+			.collect()
 	}
 
 	/// Returns the full evaluation point of a registered eq tracker.

--- a/crates/ip-prover/src/sumcheck/mle_store.rs
+++ b/crates/ip-prover/src/sumcheck/mle_store.rs
@@ -307,6 +307,116 @@ impl<'a, F: Field, P: PackedField<Scalar = F>> MleStore<'a, P> {
 			.map(|slice| slice.get(0))
 			.collect()
 	}
+
+	/// Prepares one round's accumulation pass over the columns and eq trackers.
+	///
+	/// The returned [`ExecuteContext`] borrows the store's expanded column slices and eq-indicator
+	/// expansions and hands each parallel chunk to the round evaluators (see
+	/// [`ExecuteContext::par_chunks`]).
+	pub fn execute_context(&self) -> ExecuteContext<'_, P> {
+		ExecuteContext {
+			n_vars: self.n_vars,
+			cols: self.column_slices(),
+			eqs: self.eq_expansions(),
+		}
+	}
+}
+
+/// One store column's low and high halves at a single chunk of the halved hypercube.
+///
+/// The column is split on the round's highest variable: `lo` fixes that variable to 0, `hi` to 1.
+/// Both range over the chunk's `2^chunk_vars` scalars.
+pub struct ColumnChunk<'c, P: PackedField> {
+	pub lo: FieldSlice<'c, P>,
+	pub hi: FieldSlice<'c, P>,
+}
+
+/// One chunk of the halved hypercube, prepared for the round evaluators.
+///
+/// With `n` variables remaining, each column splits on the highest variable into two halves of
+/// `n - 1` variables, and both halves divide into chunks of `2^chunk_vars` scalars. This holds one
+/// such chunk: the split halves of every logical column and the same chunk of every eq-indicator
+/// expansion. A column read by several evaluators is chunked a single time. Evaluators read their
+/// columns by [`ColId`] and their eq trackers by [`EqId`].
+pub struct EvaluationChunk<'c, P: PackedField> {
+	cols: Vec<ColumnChunk<'c, P>>,
+	eqs: Vec<FieldSlice<'c, P>>,
+}
+
+impl<'c, P: PackedField> EvaluationChunk<'c, P> {
+	/// Returns the low and high halves of a column at this chunk.
+	pub fn col(&self, id: ColId) -> &ColumnChunk<'c, P> {
+		&self.cols[id.index()]
+	}
+
+	/// Returns the equality-indicator expansion of a registered tracker at this chunk.
+	///
+	/// The expansion ranges over the halved hypercube, so it is chunked with the same chunk index
+	/// as the column halves.
+	pub fn eq(&self, id: EqId) -> &FieldSlice<'c, P> {
+		&self.eqs[id.index()]
+	}
+}
+
+/// A round's expanded columns and eq-indicator expansions, borrowed from an [`MleStore`].
+///
+/// Produced by [`MleStore::execute_context`]. It expands the store's columns once — a split-half
+/// column becomes its two halves — and drives the parallel round pass through
+/// [`Self::par_chunks`], which slices each column and eq expansion per chunk into an
+/// [`EvaluationChunk`].
+pub struct ExecuteContext<'b, P: PackedField> {
+	// The store's remaining variable count; the halved hypercube has `n_vars - 1` variables.
+	n_vars: usize,
+	// One slice per logical column, over all `n_vars` remaining variables, in `ColId` order.
+	cols: Vec<FieldSlice<'b, P>>,
+	// One eq-indicator expansion per registered tracker, over `n_vars - 1` variables, in `EqId`
+	// order.
+	eqs: Vec<&'b FieldBuffer<P>>,
+}
+
+impl<'b, P: PackedField> ExecuteContext<'b, P> {
+	/// Returns a parallel iterator over the chunks of the halved hypercube.
+	///
+	/// Each item is one [`EvaluationChunk`]: the split low/high halves of every column and the
+	/// matching chunk of every eq-indicator expansion, at `2^chunk_vars` scalars per chunk. A
+	/// column's low half is the front chunk `chunk_index` of the full column; its high half is
+	/// chunk `chunk_count + chunk_index`, the corresponding chunk of the back half — so the column
+	/// is sliced without materializing its halves separately.
+	///
+	/// ## Preconditions
+	///
+	/// * `chunk_vars` must be at most `n_vars - 1`.
+	pub fn par_chunks(
+		&self,
+		chunk_vars: usize,
+	) -> impl IndexedParallelIterator<Item = EvaluationChunk<'_, P>> {
+		// precondition
+		assert!(
+			chunk_vars < self.n_vars,
+			"chunk_vars must be at most the halved hypercube's variable count"
+		);
+
+		let chunk_count = 1usize << (self.n_vars - 1 - chunk_vars);
+		(0..chunk_count).into_par_iter().map(move |chunk_index| {
+			// The full column at `chunk_vars` holds the low half in its first `chunk_count` chunks
+			// and the high half in the next `chunk_count`, so the two halves of this chunk are the
+			// full column's chunks `chunk_index` and `chunk_count + chunk_index`.
+			let cols = self
+				.cols
+				.iter()
+				.map(|col| ColumnChunk {
+					lo: col.chunk(chunk_vars, chunk_index),
+					hi: col.chunk(chunk_vars, chunk_count + chunk_index),
+				})
+				.collect();
+			let eqs = self
+				.eqs
+				.iter()
+				.map(|eq| eq.chunk(chunk_vars, chunk_index))
+				.collect();
+			EvaluationChunk { cols, eqs }
+		})
+	}
 }
 
 /// Computes the partial evaluation of a multilinear on its highest variable, out of place.

--- a/crates/ip-prover/src/sumcheck/mle_to_sumcheck.rs
+++ b/crates/ip-prover/src/sumcheck/mle_to_sumcheck.rs
@@ -7,9 +7,9 @@ use binius_math::multilinear::eq::eq_one_var;
 
 use crate::sumcheck::{
 	common::{MleCheckProver, SumcheckProver},
-	mle_store::{EqId, MleStore},
+	mle_store::{EqId, EvaluationChunk, MleStore},
 	round_evals::round_coeffs_by_eq,
-	round_evaluator::{EvaluationChunk, RoundEvaluator},
+	round_evaluator::RoundEvaluator,
 };
 
 /// Adaptor that exposes a `SumcheckProver` interface for an internal `MleCheckProver`.

--- a/crates/ip-prover/src/sumcheck/mle_to_sumcheck.rs
+++ b/crates/ip-prover/src/sumcheck/mle_to_sumcheck.rs
@@ -9,7 +9,7 @@ use crate::sumcheck::{
 	common::{MleCheckProver, SumcheckProver},
 	mle_store::{EqId, MleStore},
 	round_evals::round_coeffs_by_eq,
-	round_evaluator::{RoundContext, RoundEvaluator},
+	round_evaluator::{EvaluationChunk, RoundEvaluator},
 };
 
 /// Adaptor that exposes a `SumcheckProver` interface for an internal `MleCheckProver`.
@@ -138,13 +138,8 @@ where
 		self.inner.round_claim(store) * store.eq_prefix(self.eq_tracker)
 	}
 
-	fn accumulate(
-		&self,
-		ctx: &RoundContext<'_, '_, P>,
-		chunk_index: usize,
-		accum: &mut [<P as WideMul>::Output],
-	) {
-		self.inner.accumulate(ctx, chunk_index, accum)
+	fn accumulate(&self, chunk: &EvaluationChunk<'_, P>, accum: &mut [<P as WideMul>::Output]) {
+		self.inner.accumulate(chunk, accum)
 	}
 
 	fn interpolate(

--- a/crates/ip-prover/src/sumcheck/quadratic_mle_evaluator.rs
+++ b/crates/ip-prover/src/sumcheck/quadratic_mle_evaluator.rs
@@ -1,15 +1,12 @@
 // Copyright 2026 The Binius Developers
 
-use std::array;
-
 use binius_field::{Field, PackedField, WideMul};
 use binius_ip::sumcheck::RoundCoeffs;
-use binius_math::FieldSlice;
 
 use super::{
 	mle_store::{ColId, EqId, MleStore},
 	round_evals::RoundEvals2,
-	round_evaluator::{RoundContext, RoundEvaluator},
+	round_evaluator::{ColumnChunk, EvaluationChunk, RoundEvaluator},
 };
 
 /// MLE-check round evaluator for one quadratic composition over N store columns.
@@ -102,24 +99,12 @@ where
 		}
 	}
 
-	fn accumulate(
-		&self,
-		ctx: &RoundContext<'_, '_, P>,
-		chunk_index: usize,
-		accum: &mut [<P as WideMul>::Output],
-	) {
-		let chunk_vars = ctx.chunk_vars();
+	fn accumulate(&self, chunk: &EvaluationChunk<'_, P>, accum: &mut [<P as WideMul>::Output]) {
+		let eq_chunk = chunk.eq(self.eq_tracker);
 
-		let eq_chunk = ctx
-			.eq_expansion(self.eq_tracker)
-			.chunk(chunk_vars, chunk_index);
-
-		// Split each column into low/high halves for the top variable and take this pass's chunk:
-		// the low half corresponds to x=0, the high half to x=1.
-		let cols: [&FieldSlice<'_, P>; N] = self.cols.map(|id| ctx.col(id));
-		let halves: [_; N] = array::from_fn(|i| cols[i].split_half_ref());
-		let lo_chunks: [_; N] = array::from_fn(|i| halves[i].0.chunk(chunk_vars, chunk_index));
-		let hi_chunks: [_; N] = array::from_fn(|i| halves[i].1.chunk(chunk_vars, chunk_index));
+		// Each column arrives split into low/high halves for the top variable: the low half
+		// corresponds to x=0, the high half to x=1.
+		let cols: [&ColumnChunk<'_, P>; N] = self.cols.map(|id| chunk.col(id));
 
 		// The evaluator's run holds `y_1` in slot 0 and `y_inf` in slot 1.
 		let mut y_1 = <P as WideMul>::Output::default();
@@ -130,8 +115,8 @@ where
 			let mut evals_inf = [P::default(); N];
 
 			for i in 0..N {
-				let lo_i = lo_chunks[i].as_ref()[idx];
-				let hi_i = hi_chunks[i].as_ref()[idx];
+				let lo_i = cols[i].lo.as_ref()[idx];
+				let hi_i = cols[i].hi.as_ref()[idx];
 
 				// Compose once with the high half and once with the lo+hi combination.
 				// The lo+hi branch corresponds to evaluation at infinity for multilinears.

--- a/crates/ip-prover/src/sumcheck/quadratic_mle_evaluator.rs
+++ b/crates/ip-prover/src/sumcheck/quadratic_mle_evaluator.rs
@@ -4,9 +4,9 @@ use binius_field::{Field, PackedField, WideMul};
 use binius_ip::sumcheck::RoundCoeffs;
 
 use super::{
-	mle_store::{ColId, EqId, MleStore},
+	mle_store::{ColId, ColumnChunk, EqId, EvaluationChunk, MleStore},
 	round_evals::RoundEvals2,
-	round_evaluator::{ColumnChunk, EvaluationChunk, RoundEvaluator},
+	round_evaluator::RoundEvaluator,
 };
 
 /// MLE-check round evaluator for one quadratic composition over N store columns.

--- a/crates/ip-prover/src/sumcheck/round_evaluator.rs
+++ b/crates/ip-prover/src/sumcheck/round_evaluator.rs
@@ -25,37 +25,42 @@ use super::{
 	mle_store::{ColId, EqId, MleStore},
 };
 
-/// Read-only view of the store during one round's accumulation pass.
+/// One store column's low and high halves at a single chunk of the halved hypercube.
+///
+/// The column is split on the round's highest variable: `lo` fixes that variable to 0, `hi` to 1.
+/// Both range over the chunk's `2^chunk_vars` scalars.
+pub struct ColumnChunk<'c, P: PackedField> {
+	pub lo: FieldSlice<'c, P>,
+	pub hi: FieldSlice<'c, P>,
+}
+
+/// One chunk of the halved hypercube, prepared by the driving prover for the round evaluators.
 ///
 /// The pass runs over the halved hypercube: with `n` variables remaining, each column splits on
 /// the highest variable into two halves of `n - 1` variables, and both halves divide into chunks
-/// of `2^chunk_vars` scalars addressed by a shared chunk index.
+/// of `2^chunk_vars` scalars.
 ///
-/// The store's columns are expanded once, at the start of the round, into one slice per logical
-/// column (a split-half column becomes its two halves), so [`Self::col`] is a plain index.
-pub struct RoundContext<'b, 'a, P: PackedField> {
-	store: &'b MleStore<'a, P>,
-	cols: Vec<FieldSlice<'b, P>>,
-	chunk_vars: usize,
+/// The driver splits every store column on the round's highest variable and slices this chunk out
+/// of each half, and slices the same chunk out of each eq-indicator expansion — once per chunk, so
+/// a column read by several evaluators is split and chunked a single time. Evaluators read their
+/// columns by [`ColId`] and their eq trackers by [`EqId`].
+pub struct EvaluationChunk<'c, P: PackedField> {
+	cols: Vec<ColumnChunk<'c, P>>,
+	eqs: Vec<FieldSlice<'c, P>>,
 }
 
-impl<'b, P: PackedField> RoundContext<'b, '_, P> {
-	/// Returns log2 the number of scalars in one chunk of the halved hypercube.
-	pub const fn chunk_vars(&self) -> usize {
-		self.chunk_vars
-	}
-
-	/// Returns a borrowed view of a column, over all remaining variables.
-	pub fn col(&self, id: ColId) -> &FieldSlice<'b, P> {
+impl<'c, P: PackedField> EvaluationChunk<'c, P> {
+	/// Returns the low and high halves of a column at this chunk.
+	pub fn col(&self, id: ColId) -> &ColumnChunk<'c, P> {
 		&self.cols[id.index()]
 	}
 
-	/// Returns the equality-indicator expansion of a registered tracker.
+	/// Returns the equality-indicator expansion of a registered tracker at this chunk.
 	///
-	/// The expansion ranges over the halved hypercube, so it chunks with the same chunk index as
-	/// the column halves.
-	pub fn eq_expansion(&self, id: EqId) -> &'b FieldBuffer<P> {
-		self.store.eq_expansion(id)
+	/// The expansion ranges over the halved hypercube, so it is chunked with the same chunk index
+	/// as the column halves.
+	pub fn eq(&self, id: EqId) -> &FieldSlice<'c, P> {
+		&self.eqs[id.index()]
 	}
 }
 
@@ -96,14 +101,11 @@ pub trait RoundEvaluator<F: Field, P: PackedField<Scalar = F>>: Send + Sync {
 
 	/// Accumulates one chunk of the halved hypercube into `accum`.
 	///
-	/// `accum` is this evaluator's run of [`Self::degree`] wide slots, zero-initialized on the
-	/// first chunk and carried across the worker's chunks.
-	fn accumulate(
-		&self,
-		ctx: &RoundContext<'_, '_, P>,
-		chunk_index: usize,
-		accum: &mut [<P as WideMul>::Output],
-	);
+	/// The driving prover prepares `chunk` — the split, per-chunk column halves and eq-indicator
+	/// expansions — so the evaluator only reads its columns by [`ColId`] and eq trackers by
+	/// [`EqId`]. `accum` is this evaluator's run of [`Self::degree`] wide slots, zero-initialized
+	/// on the first chunk and carried across the worker's chunks.
+	fn accumulate(&self, chunk: &EvaluationChunk<'_, P>, accum: &mut [<P as WideMul>::Output]);
 
 	/// Interpolates this round's polynomial from the slot-wise summed accumulator slice.
 	///
@@ -225,18 +227,37 @@ where
 			.last()
 			.expect("offsets has one entry per evaluator, plus one");
 
-		let ctx = RoundContext {
-			cols: self.store.column_slices(),
-			store: &self.store,
-			chunk_vars,
-		};
+		// Split every column on the round's highest variable once; the halves are re-sliced per
+		// chunk below into the `EvaluationChunk` each evaluator reads. The eq-indicator expansions
+		// already range over the halved hypercube, so they are chunked directly.
+		let col_slices = self.store.column_slices();
+		let col_halves = col_slices
+			.iter()
+			.map(|col| col.split_half_ref())
+			.collect::<Vec<_>>();
+		let eq_expansions = self.store.eq_expansions();
+
 		let evaluators = &self.evaluators;
 		let new_accum = || -> Vec<<P as WideMul>::Output> { vec![Default::default(); total_slots] };
 		let accum = (0..chunk_count)
 			.into_par_iter()
 			.fold(new_accum, |mut accum, chunk_index| {
+				// Prepare this chunk's column halves and eq expansions once for every evaluator.
+				let chunk = EvaluationChunk {
+					cols: col_halves
+						.iter()
+						.map(|(lo, hi)| ColumnChunk {
+							lo: lo.chunk(chunk_vars, chunk_index),
+							hi: hi.chunk(chunk_vars, chunk_index),
+						})
+						.collect(),
+					eqs: eq_expansions
+						.iter()
+						.map(|eq| eq.chunk(chunk_vars, chunk_index))
+						.collect(),
+				};
 				for (evaluator, window) in iter::zip(evaluators, offsets.windows(2)) {
-					evaluator.accumulate(&ctx, chunk_index, &mut accum[window[0]..window[1]]);
+					evaluator.accumulate(&chunk, &mut accum[window[0]..window[1]]);
 				}
 				accum
 			})

--- a/crates/ip-prover/src/sumcheck/round_evaluator.rs
+++ b/crates/ip-prover/src/sumcheck/round_evaluator.rs
@@ -127,7 +127,7 @@ pub trait RoundEvaluator<F: Field, P: PackedField<Scalar = F>>: Send + Sync {
 ///
 /// Chunked accumulation keeps the equality-indicator chunk resident in L1 cache while all
 /// evaluators read it, mirroring the chunking of the pre-store quadratic prover.
-const MAX_CHUNK_VARS: usize = 8;
+const MAX_CHUNK_VARS: usize = 12;
 
 /// A [`SumcheckProver`] over a shared [`MleStore`] and a list of [`RoundEvaluator`]s, one per
 /// claim.

--- a/crates/ip-prover/src/sumcheck/round_evaluator.rs
+++ b/crates/ip-prover/src/sumcheck/round_evaluator.rs
@@ -11,58 +11,19 @@
 //! existing [`SumcheckProver`] interface, and [`SharedMleCheckProver`] to the [`MleCheckProver`]
 //! interface, so they batch alongside standalone provers unchanged.
 
-use std::{cmp::max, iter};
+use std::iter;
 
 use auto_impl::auto_impl;
 use binius_field::{Field, PackedField, WideMul};
 use binius_ip::sumcheck::RoundCoeffs;
-use binius_math::{FieldBuffer, FieldSlice};
+use binius_math::FieldBuffer;
 use binius_utils::rayon::prelude::*;
 
 use super::{
 	MleToSumCheckEvaluator,
 	common::{MleCheckProver, SumcheckProver},
-	mle_store::{ColId, EqId, MleStore},
+	mle_store::{ColId, EvaluationChunk, MleStore},
 };
-
-/// One store column's low and high halves at a single chunk of the halved hypercube.
-///
-/// The column is split on the round's highest variable: `lo` fixes that variable to 0, `hi` to 1.
-/// Both range over the chunk's `2^chunk_vars` scalars.
-pub struct ColumnChunk<'c, P: PackedField> {
-	pub lo: FieldSlice<'c, P>,
-	pub hi: FieldSlice<'c, P>,
-}
-
-/// One chunk of the halved hypercube, prepared by the driving prover for the round evaluators.
-///
-/// The pass runs over the halved hypercube: with `n` variables remaining, each column splits on
-/// the highest variable into two halves of `n - 1` variables, and both halves divide into chunks
-/// of `2^chunk_vars` scalars.
-///
-/// The driver splits every store column on the round's highest variable and slices this chunk out
-/// of each half, and slices the same chunk out of each eq-indicator expansion — once per chunk, so
-/// a column read by several evaluators is split and chunked a single time. Evaluators read their
-/// columns by [`ColId`] and their eq trackers by [`EqId`].
-pub struct EvaluationChunk<'c, P: PackedField> {
-	cols: Vec<ColumnChunk<'c, P>>,
-	eqs: Vec<FieldSlice<'c, P>>,
-}
-
-impl<'c, P: PackedField> EvaluationChunk<'c, P> {
-	/// Returns the low and high halves of a column at this chunk.
-	pub fn col(&self, id: ColId) -> &ColumnChunk<'c, P> {
-		&self.cols[id.index()]
-	}
-
-	/// Returns the equality-indicator expansion of a registered tracker at this chunk.
-	///
-	/// The expansion ranges over the halved hypercube, so it is chunked with the same chunk index
-	/// as the column halves.
-	pub fn eq(&self, id: EqId) -> &FieldSlice<'c, P> {
-		&self.eqs[id.index()]
-	}
-}
 
 /// Per-round-polynomial logic for one composite claim over store columns.
 ///
@@ -103,8 +64,8 @@ pub trait RoundEvaluator<F: Field, P: PackedField<Scalar = F>>: Send + Sync {
 	///
 	/// The driving prover prepares `chunk` — the split, per-chunk column halves and eq-indicator
 	/// expansions — so the evaluator only reads its columns by [`ColId`] and eq trackers by
-	/// [`EqId`]. `accum` is this evaluator's run of [`Self::degree`] wide slots, zero-initialized
-	/// on the first chunk and carried across the worker's chunks.
+	/// [`EqId`](super::mle_store::EqId). `accum` is this evaluator's run of [`Self::degree`] wide
+	/// slots, zero-initialized on the first chunk and carried across the worker's chunks.
 	fn accumulate(&self, chunk: &EvaluationChunk<'_, P>, accum: &mut [<P as WideMul>::Output]);
 
 	/// Interpolates this round's polynomial from the slot-wise summed accumulator slice.
@@ -216,8 +177,10 @@ where
 
 		// One parallel pass over the halved hypercube feeds every evaluator, so shared columns
 		// and eq-indicator chunks are read once per round while they are cache-resident.
-		let chunk_vars = max(MAX_CHUNK_VARS, P::LOG_WIDTH).min(n_vars_remaining - 1);
-		let chunk_count = 1usize << (n_vars_remaining - 1 - chunk_vars);
+		//
+		// TODO: dynamically choose chunk size based on the number of columns and P byte-size,
+		// based on estimated L1 cache size.
+		let chunk_vars = (n_vars_remaining - 1).min(MAX_CHUNK_VARS.max(P::LOG_WIDTH));
 
 		// Each evaluator owns a contiguous run of `degree` wide slots in one flat per-worker
 		// buffer; `offsets` holds the run boundaries as a prefix sum, so `offsets[i]..offsets[i +
@@ -227,35 +190,14 @@ where
 			.last()
 			.expect("offsets has one entry per evaluator, plus one");
 
-		// Split every column on the round's highest variable once; the halves are re-sliced per
-		// chunk below into the `EvaluationChunk` each evaluator reads. The eq-indicator expansions
-		// already range over the halved hypercube, so they are chunked directly.
-		let col_slices = self.store.column_slices();
-		let col_halves = col_slices
-			.iter()
-			.map(|col| col.split_half_ref())
-			.collect::<Vec<_>>();
-		let eq_expansions = self.store.eq_expansions();
-
+		// The store prepares one `EvaluationChunk` per chunk of the halved hypercube — the split
+		// column halves and eq-indicator expansions each evaluator reads.
+		let ctx = self.store.execute_context();
 		let evaluators = &self.evaluators;
 		let new_accum = || -> Vec<<P as WideMul>::Output> { vec![Default::default(); total_slots] };
-		let accum = (0..chunk_count)
-			.into_par_iter()
-			.fold(new_accum, |mut accum, chunk_index| {
-				// Prepare this chunk's column halves and eq expansions once for every evaluator.
-				let chunk = EvaluationChunk {
-					cols: col_halves
-						.iter()
-						.map(|(lo, hi)| ColumnChunk {
-							lo: lo.chunk(chunk_vars, chunk_index),
-							hi: hi.chunk(chunk_vars, chunk_index),
-						})
-						.collect(),
-					eqs: eq_expansions
-						.iter()
-						.map(|eq| eq.chunk(chunk_vars, chunk_index))
-						.collect(),
-				};
+		let accum = ctx
+			.par_chunks(chunk_vars)
+			.fold(new_accum, |mut accum, chunk| {
 				for (evaluator, window) in iter::zip(evaluators, offsets.windows(2)) {
 					evaluator.accumulate(&chunk, &mut accum[window[0]..window[1]]);
 				}

--- a/crates/math/src/field_buffer.rs
+++ b/crates/math/src/field_buffer.rs
@@ -226,6 +226,7 @@ impl<P: PackedField, Data: Deref<Target = [P]>> FieldBuffer<P, Data> {
 	///
 	/// * `log_chunk_size` must be at most `log_len`.
 	/// * `chunk_index` must be less than the chunk count.
+	#[inline]
 	pub fn chunk(&self, log_chunk_size: usize, chunk_index: usize) -> FieldSlice<'_, P> {
 		assert!(
 			log_chunk_size <= self.log_len,


### PR DESCRIPTION
## Summary

Restructures sumcheck round-chunk preparation so that shared multilinear columns are split and chunked **once per round** by the driver / store, rather than once per evaluator. A column shared by K evaluators was previously split and chunked K times per chunk; this collapses that to a single shared `EvaluationChunk`.

This continues the BINIUS-216 shared-multilinear-store work (follows #1755).

## Changes

**Bump default chunk size.**

**Hand round evaluators a prepared `EvaluationChunk`.**
`SharedSumcheckProver::execute` now splits every column once per round and, inside the parallel fold, builds one `EvaluationChunk` per chunk index that every evaluator shares. `accumulate` drops its `RoundContext` and `chunk_index` arguments and only reads its prepared columns by `ColId` and eq trackers by `EqId`.
- Delete `RoundContext`; add `ColumnChunk { lo, hi }` and `EvaluationChunk` with `col(ColId)` / `eq(EqId)` accessors.
- New signature: `accumulate(&self, chunk: &EvaluationChunk, accum)`.
- Add `EqId::index()` (mirroring `ColId::index()`) and `MleStore::eq_expansions()`.
- Update `BivariateProductEvaluator`, `QuadraticMleEvaluator`, and the `MleToSumCheckEvaluator` passthrough.

**Move round-chunk preparation onto `MleStore`.**
Push chunk preparation off the driver and onto the store so the driver only picks the chunk size and runs the accumulation.
- `MleStore::execute_context()` returns an `ExecuteContext` borrowing the expanded column slices and eq-indicator expansions.
- `ExecuteContext::par_chunks(chunk_vars)` yields an `IndexedParallelIterator` of `EvaluationChunk`s, one per chunk of the halved hypercube. Rather than materialize each column's halves, it slices the full column directly (low half = front chunk `chunk_index`, high half = chunk `chunk_count + chunk_index`), so every produced slice stays borrowed from the context — no half buffers stored, no binius-math change needed.
- `ColumnChunk` / `EvaluationChunk` move from `round_evaluator` to `mle_store`.

## Testing

No behavior change: the existing byte-identical-transcript differential tests against the pre-store provers still pass.
