### PR TITLE
BINIUS-274: enable IntMul constraints for M4

### DIFF
--- a/crates/m4-prover/src/prove.rs
+++ b/crates/m4-prover/src/prove.rs
@@ -86,9 +86,9 @@ where
 	///
 	/// The trace oracle is not ZK, so the channel masks nothing and needs no randomness.
 	///
-	/// # Panics
-	///
-	/// Panics if the constraint system has any MUL constraints.
+	/// With MUL constraints the reduction commits one further oracle: the IntMul logup*
+	/// pushforward. The IntMul check queues that oracle's opening itself.
+	/// The final combined FRI opening covers it alongside the trace, so it needs no handling here.
 	pub fn prove<Challenger_>(
 		&self,
 		table: &ValueTable,
@@ -154,6 +154,7 @@ mod tests {
 
 	use assert_matches::assert_matches;
 	use binius_field::PackedBinaryGhash1x128b;
+	use binius_frontend::CircuitBuilder;
 	use binius_iop::{
 		basefold::{Error as BaseFoldError, VerificationError as BaseFoldVerificationError},
 		channel::Error as IOPChannelError,
@@ -197,6 +198,64 @@ mod tests {
 		let prover = Prover::<P>::setup(&verifier);
 
 		// Prover: commit, reduce, and open on a fresh transcript.
+		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
+		prover.prove(&table, &mut prover_transcript);
+
+		// Verifier: replay the same transcript end to end.
+		let mut verifier_transcript = prover_transcript.into_verifier();
+		verifier
+			.verify(&mut verifier_transcript)
+			.expect("a faithful proof verifies");
+		verifier_transcript
+			.finalize()
+			.expect("no trailing proof data");
+	}
+
+	// A circuit carrying MUL constraints round-trips through the whole protocol.
+	//
+	// With MUL constraints the proof commits two oracles rather than one:
+	//
+	//     trace oracle    : the packed batch witness
+	//     logup* oracle   : the IntMul check's pushforward
+	//
+	// The IntMul and AND checks reduce to different instance points, which the re-randomization
+	// unifies before the witness is folded.
+	//
+	// Fixture: one unsigned 64x64 -> 128 product per instance over 2^6 instances, both product
+	// words force-committed. The `imul` gate emits one MUL constraint and one AND security check.
+	//
+	// A faithful proof verifies, both oracles open, and no trailing data is left.
+	#[test]
+	fn protocol_round_trips_with_mul() {
+		// One product per instance, with both result words committed as hidden words.
+		let builder = CircuitBuilder::new();
+		let x = builder.add_witness();
+		let y = builder.add_witness();
+		let (hi, lo) = builder.imul(x, y);
+		builder.force_commit(hi);
+		builder.force_commit(lo);
+		let circuit = builder.build();
+
+		let mut cs = circuit.constraint_system().clone();
+		cs.validate_and_prepare().unwrap();
+		// Confirm the fixture genuinely exercises the IntMul path.
+		assert!(!cs.mul_constraints.is_empty(), "the fixture must emit a MUL constraint");
+
+		// Fill each instance's two multiplicands from a per-instance seed; the circuit derives the
+		// two product words.
+		let log_instances = 6;
+		let table = ValueTable::populate(&circuit, log_instances, |i, w| {
+			let mut rng = StdRng::seed_from_u64(i as u64);
+			w[x] = Word(rng.next_u64());
+			w[y] = Word(rng.next_u64());
+		})
+		.unwrap();
+
+		// Setup once: the verifier fixes the shape and FRI parameters, the prover inherits them.
+		let verifier = Verifier::setup(&cs, log_instances, 1);
+		let prover = Prover::<P>::setup(&verifier);
+
+		// Prover: commit both oracles, reduce, and open on a fresh transcript.
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 		prover.prove(&table, &mut prover_transcript);
 

--- a/crates/m4-prover/src/reduction.rs
+++ b/crates/m4-prover/src/reduction.rs
@@ -14,16 +14,43 @@
 //! The caller binds it to the committed trace by ring-switching at `r_j || r_rho || r_y`.
 //! Evaluating the trace's instance coordinates at `r_rho` performs that instance fold.
 //!
-//! Only the AND-check is reduced so far. When the circuit has MUL constraints the IntMul operand
-//! columns are also built, but they are not yet consumed by the reduction.
+//! When the circuit has MUL constraints the IntMul check runs too.
+//! It reduces the multiplication relation to per-bit operand claims at its own instance point.
+//! The AND-check reduces to a different instance point.
+//! A batched multilinear-evaluation sumcheck re-randomizes both to one shared `r_rho`.
+//! The witness is then folded once at that shared point and both operand claims feed the shift.
 
 use binius_core::{constraint_system::ConstraintSystem, word::Word};
 use binius_field::{AESTowerField8b as B8, Field, PackedField};
+use binius_iop_prover::channel::IOPProverChannel;
 use binius_ip::sumcheck::SumcheckOutput;
-use binius_ip_prover::channel::IPProverChannel;
-use binius_math::BinarySubspace;
-use binius_prover::protocols::shift::{KeyCollection, OperatorData};
-use binius_verifier::{config::B128, protocols::bitand::AndCheckOutput};
+use binius_ip_prover::sumcheck::{
+	MleToSumCheckEvaluator,
+	batch::batch_prove_and_write_evals,
+	mle_store::MleStore,
+	quadratic_mle_evaluator::QuadraticMleEvaluator,
+	round_evaluator::{RoundEvaluator, SharedSumcheckProver},
+};
+use binius_math::{
+	BinarySubspace, FieldBuffer, inner_product::inner_product,
+	multilinear::eq::eq_ind_partial_eval_scalars, univariate::lagrange_evals_scalars,
+};
+use binius_prover::{
+	fold_word::fold_words,
+	protocols::{
+		intmul::{prove::IntMulProver, witness::Witness as IntMulWitness},
+		shift::{KeyCollection, OperatorData},
+	},
+};
+use binius_utils::{checked_arithmetics::checked_log_2, rayon::prelude::*};
+use binius_verifier::{
+	config::B128,
+	protocols::{
+		bitand::AndCheckOutput,
+		intmul::IntMulOutput,
+		shift::{BITAND_ARITY, INTMUL_ARITY},
+	},
+};
 
 use crate::{
 	BatchAndCheckWitness, ValueTable,
@@ -33,7 +60,10 @@ use crate::{
 
 /// The prover's output of the M4 constraint reduction.
 pub struct ReductionProverOutput {
-	/// The instance-fold challenge: the low coordinates of the AND-check row point.
+	/// The shared instance-fold challenge the witness is folded at.
+	///
+	/// Without MUL constraints this is the low half of the AND-check row point.
+	/// With MUL constraints the re-randomization sumcheck produces it fresh.
 	pub r_rho: Vec<B128>,
 	/// The reduced claim: the instance-folded witness evaluated at the shift's final point.
 	pub witness_claim: SumcheckOutput<B128>,
@@ -55,97 +85,432 @@ pub fn prove_reduction<P, Channel>(
 ) -> ReductionProverOutput
 where
 	P: PackedField<Scalar = B128>,
-	Channel: IPProverChannel<B128>,
+	Channel: IOPProverChannel<P>,
 {
-	// Build the IntMul operand witness whenever the circuit has MUL constraints. The reduction
-	// does not consume these yet; wiring them into the IntMul check is future work, so for now
-	// they are built and dropped.
-	let _mul_witness = (!cs.mul_constraints.is_empty()).then(|| {
-		let _scope = tracing::debug_span!("Assemble IntMul witness").entered();
-		build_intmul_witness(table, &cs.constants, &cs.mul_constraints)
-	});
-
 	// One base domain shared by the AND-check and the shift, consistent by construction.
 	// The AND-check's univariate-skip domain spans one dimension above the 64-bit word.
 	let andcheck_domain = BinarySubspace::<B8>::with_dim(Word::LOG_BITS + 1);
 	// The shift domain drops that extra dimension.
+	// This is exactly the domain the AND-check folds its bit axis over.
+	// So the operand claims rebuilt below at the shared univariate challenge match the AND-check's.
 	let shift_domain = andcheck_domain
 		.reduce_dim(Word::LOG_BITS)
 		.isomorphic::<B128>();
 
+	// Build the IntMul operand columns and run the IntMul check, only when the circuit has MUL
+	// constraints.
+	//
+	// SOUNDNESS: the IntMul check runs before the BitAnd check below.
+	// Its per-bit operand evaluations are bound to the transcript here.
+	// BitAnd then draws the univariate challenge that collapses them.
+	// Committing them first stops a malicious prover choosing them as a function of that challenge.
+	// Do not reorder these, and keep the same order in the verifier.
+	//
+	// The columns are the four operands of every constraint over every instance, laid out
+	// constraint-major.
+	// They are kept alongside the check output.
+	// The re-randomization re-reads them to build the instance-axis multilinears it transports.
+	let mul = (!cs.mul_constraints.is_empty()).then(|| {
+		let columns = {
+			let _scope = tracing::debug_span!("Assemble IntMul witness").entered();
+			// `build_intmul_witness` yields `[A, B, HI, LO]`; reorder to the `[A, B, LO, HI]`
+			// operand order the IntMul witness and the shift both expect.
+			let [a, b, hi, lo] = build_intmul_witness(table, &cs.constants, &cs.mul_constraints);
+			[a, b, lo, hi]
+		};
+		let output = prove_intmul::<P, _>(&columns, channel);
+		(columns, output)
+	});
+
 	// AND-check the `A & B == C` relation over all `K * n_and` rows.
-	let AndCheckOutput {
-		a_eval,
-		b_eval,
-		c_eval,
-		z_challenge,
-		eval_point,
-	} = {
+	// Retain the operand columns when IntMul ran, since the re-randomization re-reads them.
+	let (
+		and_columns,
+		AndCheckOutput {
+			a_eval,
+			b_eval,
+			c_eval,
+			z_challenge,
+			eval_point,
+		},
+	) = {
 		let _scope = tracing::debug_span!("BitAnd check").entered();
 
 		let and_witness = {
 			let _scope = tracing::debug_span!("Assemble BitAnd witness").entered();
 			BatchAndCheckWitness::build(table, &cs.constants, &cs.and_constraints)
 		};
-		and_witness.prove::<P, _>(&andcheck_domain, channel)
+		let and_columns = mul.is_some().then(|| {
+			[
+				and_witness.a().to_vec(),
+				and_witness.b().to_vec(),
+				and_witness.c().to_vec(),
+			]
+		});
+		(and_columns, and_witness.prove::<P, _>(&andcheck_domain, channel))
 	};
 
-	// The row point is `r_rho || r_x`: the instance index on the low coordinates, the constraint
-	// index on the high coordinates.
-	let (r_rho, r_x) = eval_point.split_at(table.log_instances());
+	// The AND-check row point is `r_rho_and || r_x_and`: the instance index on the low coordinates,
+	// the constraint index on the high coordinates.
+	let (r_rho_and, r_x_and) = eval_point.split_at(table.log_instances());
 
-	// Fold the committed witness over the instance axis, then reshape into one folded word per
-	// committed word.
-	let folded_witness = {
-		let _scope = tracing::debug_span!("Fold instances").entered();
-		fold_instances(table, r_rho)
-	};
-
-	// Reduce the operand claims to one witness evaluation.
-	// The shift evaluates the constants over the layout's power-of-two word count.
-	// Their count need not be a power of two, so they are passed unpadded.
-	// The IntMul witness is not fed in yet, so the intmul claim stays a zero claim at an empty
-	// point.
-	let witness_claim = {
-		let _scope = tracing::debug_span!("Prove shift reduction").entered();
-		prove_shift::<B128, P, _>(
-			key_collection,
-			&cs.constants,
-			&folded_witness,
+	// Reduce to one shared instance point `r_rho` and the operand claims at that point.
+	let (r_rho, bitand_data, intmul_data) = match mul {
+		Some((mul_columns, intmul_output)) => {
+			// Both operations enter the re-randomization as operand columns with their oblong
+			// claims at their own instance point.
+			// BitAnd is already oblong.
+			// IntMul is collapsed from its per-bit form.
+			let lagrange = lagrange_evals_scalars::<B128, B128>(&shift_domain, z_challenge);
+			let and_columns =
+				and_columns.expect("AND columns are retained whenever there are MUL constraints");
+			RerandomizedOperations {
+				bitand: Operation::new(&and_columns, [a_eval, b_eval, c_eval], r_x_and, r_rho_and),
+				intmul: Operation::from_intmul(
+					&mul_columns,
+					intmul_output,
+					&lagrange,
+					table.log_instances(),
+				),
+			}
+			.prove::<P, _>(&lagrange, z_challenge, channel)
+		}
+		// No MUL constraints: the AND-check instance point is used directly.
+		// The IntMul claim is a zero claim at an empty point, contributing nothing to the shift.
+		None => (
+			r_rho_and.to_vec(),
 			OperatorData {
 				evals: vec![a_eval, b_eval, c_eval],
 				r_zhat_prime: z_challenge,
-				r_x_prime: r_x.to_vec(),
+				r_x_prime: r_x_and.to_vec(),
 			},
 			OperatorData {
 				evals: vec![B128::ZERO; 4],
 				r_zhat_prime: z_challenge,
 				r_x_prime: Vec::new(),
 			},
+		),
+	};
+
+	// Fold the committed witness over the instance axis at the shared point.
+	let folded_witness = {
+		let _scope = tracing::debug_span!("Fold instances").entered();
+		fold_instances::<B128>(table, &r_rho)
+	};
+
+	// The public segment is the shared constants, padded with zeros to the layout's power-of-two
+	// word count.
+	// The shift folds it against the monster's public part, which is sized to that padded count.
+	// The padding makes the two lengths agree, and matches the zeros the verifier assumes.
+	let mut public_words = cs.constants.clone();
+	public_words.resize(cs.value_vec_layout.n_public_words(), Word::ZERO);
+
+	// Reduce the operand claims to one witness evaluation.
+	let witness_claim = {
+		let _scope = tracing::debug_span!("Prove shift reduction").entered();
+		prove_shift::<B128, P, _>(
+			key_collection,
+			&public_words,
+			&folded_witness,
+			bitand_data,
+			intmul_data,
 			&shift_domain,
 			channel,
 		)
 	};
 
 	ReductionProverOutput {
-		r_rho: r_rho.to_vec(),
+		r_rho,
 		witness_claim,
 	}
+}
+
+/// Runs the IntMul check over the batched operand columns.
+///
+/// The four columns are the multiplicands and the low and high product words, in the order
+/// `[A, B, LO, HI]`.
+/// Each is `K * n_mul` rows, laid out constraint-major.
+/// The check reduces the multiplication relation to per-bit evaluation claims on the four columns.
+/// Those claims share a common row point.
+fn prove_intmul<P, Channel>(columns: &[Vec<Word>; 4], channel: &mut Channel) -> IntMulOutput<B128>
+where
+	P: PackedField<Scalar = B128>,
+	Channel: IOPProverChannel<P>,
+{
+	let _scope = tracing::debug_span!("IntMul check").entered();
+
+	// The columns are the multiplicand `a`, the multiplicand `b`, and the product's low and high
+	// words, in the order the IntMul witness expects.
+	let [a, b, lo, hi] = columns;
+
+	// A prepared constraint system pads its constraint and instance counts to powers of two, so the
+	// columns always have a power-of-two length as the witness requires.
+	let witness = IntMulWitness::<P>::new(a, b, lo, hi)
+		.expect("a prepared constraint system yields power-of-two operand columns");
+
+	// Switchover 0 keeps the exponentiation trees in the small field for every round.
+	let mut prover = IntMulProver::<P, _>::new(0, channel);
+	prover.prove(witness)
+}
+
+/// One operation's operand columns, oblong claims, and the points they are claimed at.
+///
+/// The AND-check and the IntMul check both reduce to this shape.
+/// The re-randomization folds each column into its instance-axis multilinear.
+/// It then transports the claims to the instance point shared by both operations.
+struct Operation<'a, const ARITY: usize> {
+	/// The operand columns, constraint-major, one per operand.
+	columns: &'a [Vec<Word>; ARITY],
+	/// The oblong operand claim per operand: its multilinear-eval claim at the instance point.
+	operand_claims: [B128; ARITY],
+	/// The constraint-index point the operands are claimed at.
+	r_x: Vec<B128>,
+	/// The instance-index point the operands are claimed at.
+	r_rho: Vec<B128>,
+}
+
+impl<'a, const ARITY: usize> Operation<'a, ARITY> {
+	/// The operand columns with their claims at the constraint point `r_x` and instance point
+	/// `r_rho`.
+	fn new(
+		columns: &'a [Vec<Word>; ARITY],
+		operand_claims: [B128; ARITY],
+		r_x: &[B128],
+		r_rho: &[B128],
+	) -> Self {
+		Self {
+			columns,
+			operand_claims,
+			r_x: r_x.to_vec(),
+			r_rho: r_rho.to_vec(),
+		}
+	}
+
+	/// Adds this operation's operand evaluators to a shared store.
+	///
+	/// The operation's instance-point indicator is registered once, and every operand reads it.
+	/// So the store expands that indicator once, not once per operand.
+	/// Each operand's instance-axis multilinear becomes a store column.
+	/// Its evaluator is an identity-composition quadratic MLE-check: a multilinear evaluation.
+	fn push_to<P>(
+		&self,
+		lagrange: &[B128],
+		store: &mut MleStore<P>,
+		evaluators: &mut Vec<Box<dyn RoundEvaluator<B128, P>>>,
+	) where
+		P: PackedField<Scalar = B128>,
+	{
+		let eq_tracker = store.register_eq_tracker(&self.r_rho);
+		// The constraint tensor is the same for every operand of this operation, so expand it once.
+		let r_x_tensor = eq_ind_partial_eval_scalars::<B128>(&self.r_x);
+		for (column, &claim) in self.columns.iter().zip(&self.operand_claims) {
+			let col = store.push_owned(operand_rho_multilinear::<P>(column, lagrange, &r_x_tensor));
+			let evaluator = QuadraticMleEvaluator::new(
+				[col],
+				eq_tracker,
+				|[operand]: [P; 1]| operand,
+				|[_operand]: [P; 1]| P::zero(),
+				claim,
+			);
+			evaluators.push(Box::new(MleToSumCheckEvaluator::new(evaluator, eq_tracker)));
+		}
+	}
+}
+
+impl<'a> Operation<'a, INTMUL_ARITY> {
+	/// Builds the IntMul operation by collapsing its per-bit operand claims to oblong claims.
+	///
+	/// The Lagrange weights fold the per-bit claims at the univariate challenge.
+	/// This gives the oblong form the BitAnd claims already have.
+	/// The IntMul row point splits into an instance part (low) and a constraint part (high).
+	fn from_intmul(
+		columns: &'a [Vec<Word>; INTMUL_ARITY],
+		intmul_output: IntMulOutput<B128>,
+		lagrange: &[B128],
+		log_instances: usize,
+	) -> Self {
+		let IntMulOutput {
+			eval_point: r_out_mul,
+			a_evals,
+			b_evals,
+			c_lo_evals,
+			c_hi_evals,
+		} = intmul_output;
+		let oblong =
+			|evals: &[B128]| inner_product(evals.iter().copied(), lagrange.iter().copied());
+		let (r_rho, r_x) = r_out_mul.split_at(log_instances);
+		Self::new(
+			columns,
+			[
+				oblong(&a_evals),
+				oblong(&b_evals),
+				oblong(&c_lo_evals),
+				oblong(&c_hi_evals),
+			],
+			r_x,
+			r_rho,
+		)
+	}
+}
+
+/// The two operations entering the batched instance re-randomization.
+struct RerandomizedOperations<'a> {
+	/// The BitAnd operation, at the AND-check instance point.
+	bitand: Operation<'a, BITAND_ARITY>,
+	/// The IntMul operation, at the IntMul instance point.
+	intmul: Operation<'a, INTMUL_ARITY>,
+}
+
+impl RerandomizedOperations<'_> {
+	/// Re-randomizes both operations' instance points to one shared point.
+	///
+	/// Each operation reduces to operand claims at its own instance point.
+	/// The witness folds over the instance axis only once, so the points must be unified first.
+	///
+	/// - Push both operations' operand multilinears onto one store.
+	/// - Register one equality tracker per operation, so each indicator is expanded once.
+	/// - A batched sumcheck transports every claim to one shared instance point.
+	/// - The reduced evaluations there are the operand claims the shift consumes.
+	///
+	/// # Returns
+	///
+	/// The shared instance point, the BitAnd operand data, and the IntMul operand data.
+	fn prove<P, Channel>(
+		self,
+		lagrange: &[B128],
+		z_challenge: B128,
+		channel: &mut Channel,
+	) -> (Vec<B128>, OperatorData<B128>, OperatorData<B128>)
+	where
+		P: PackedField<Scalar = B128>,
+		Channel: IOPProverChannel<P>,
+	{
+		let _scope = tracing::debug_span!("Re-randomize instances").entered();
+
+		// Both operations reduce over the same instance axis.
+		// Recover its width from either point.
+		let log_instances = self.bitand.r_rho.len();
+
+		// One shared store over the instance axis holds every operation's operand multilinears.
+		// The evaluators list the operands in order [BitAnd a, b, c | IntMul a, b, lo, hi].
+		// The verifier reads the reduced evaluations back in the same order.
+		let mut store = MleStore::<P>::new(log_instances);
+		let mut evaluators: Vec<Box<dyn RoundEvaluator<B128, P>>> =
+			Vec::with_capacity(BITAND_ARITY + INTMUL_ARITY);
+		self.bitand.push_to(lagrange, &mut store, &mut evaluators);
+		self.intmul.push_to(lagrange, &mut store, &mut evaluators);
+
+		// One shared prover drives all claims over the store in a single round pass.
+		// Its evaluations are the store's per-column values at the shared instance point, in push
+		// order.
+		let shared = SharedSumcheckProver::new(store, evaluators);
+		let output = batch_prove_and_write_evals(vec![shared], channel);
+		let reduced = &output.multilinear_evals[0];
+
+		// The reduced evaluations split back into the two operations at the operand-count boundary.
+		let split = self.bitand.operand_claims.len();
+		let bitand_data = OperatorData {
+			evals: reduced[..split].to_vec(),
+			r_zhat_prime: z_challenge,
+			r_x_prime: self.bitand.r_x,
+		};
+		let intmul_data = OperatorData {
+			evals: reduced[split..].to_vec(),
+			r_zhat_prime: z_challenge,
+			r_x_prime: self.intmul.r_x,
+		};
+		(output.challenges, bitand_data, intmul_data)
+	}
+}
+
+/// Builds the instance-axis multilinear of one operand column, folded over its bit and constraint
+/// axes.
+///
+/// The operand column is constraint-major: `row = local_constraint * n_instances + instance`.
+/// Folding collapses the two other axes and leaves one field element per instance:
+///
+/// ```text
+/// M[rho] = sum_{local, j} lagrange[j] * r_x_tensor[local] * bit_j(column[local * K + rho])
+/// ```
+///
+/// - The Lagrange weights fold each 64-bit word over its bit axis at the shared univariate
+///   challenge.
+/// - The constraint tensor `r_x_tensor` folds the constraint axis; the caller expands it once per
+///   operation and shares it across the operands.
+///
+/// Its evaluation at the operation's instance point equals that operation's oblong operand claim.
+/// So the re-randomization sumcheck can transport that claim to a shared instance point.
+fn operand_rho_multilinear<P>(
+	column: &[Word],
+	lagrange: &[B128],
+	r_x_tensor: &[B128],
+) -> FieldBuffer<P>
+where
+	P: PackedField<Scalar = B128>,
+{
+	// Fold each word's bits at the univariate challenge: one scalar per row, laid out
+	// constraint-major.
+	// Folding into scalars keeps the row indexing flat for the constraint fold.
+	let folded_rows = fold_words::<B128, B128>(column, lagrange);
+	let folded_rows = folded_rows.as_ref();
+
+	// Produce the packed instance-axis multilinear directly, one packed element per parallel task.
+	// Each element's lanes are the constraint folds of consecutive instances.
+	// Lanes past the instance count are the multilinear's zero padding.
+	//
+	// The constraint axis is the high, strided axis: constraint `local` of instance `rho` sits at
+	// row `local * n_instances + rho`.
+	let n_constraints = r_x_tensor.len();
+	let n_instances = folded_rows.len() / n_constraints;
+	let log_instances = checked_log_2(n_instances);
+	let log_packed = log_instances.saturating_sub(P::LOG_WIDTH);
+	let packed = (0..1usize << log_packed)
+		.into_par_iter()
+		.map(|packed_index| {
+			P::from_scalars((0..P::WIDTH).map(|lane| {
+				let instance = (packed_index << P::LOG_WIDTH) | lane;
+				if instance < n_instances {
+					r_x_tensor
+						.iter()
+						.enumerate()
+						.map(|(local, &weight)| {
+							weight * folded_rows[local * n_instances + instance]
+						})
+						.sum()
+				} else {
+					B128::ZERO
+				}
+			}))
+		})
+		.collect::<Vec<P>>();
+
+	FieldBuffer::new(log_instances, packed.into_boxed_slice())
 }
 
 #[cfg(test)]
 mod tests {
 	use std::array;
 
+	use assert_matches::assert_matches;
 	use binius_circuits::blake3::blake3_compress;
-	use binius_field::PackedBinaryGhash1x128b;
+	use binius_field::{PackedBinaryGhash1x128b, PackedBinaryGhash2x128b};
 	use binius_frontend::{CircuitBuilder, Wire};
-	use binius_m4_verifier::verify_reduction;
+	use binius_iop::{channel::OracleSpec, naive_channel::NaiveVerifierChannel};
+	use binius_iop_prover::naive_channel::NaiveProverChannel;
+	use binius_ip::{
+		channel::Error as ChannelError,
+		prodcheck::{Error as ProdcheckError, VerificationError as ProdcheckVerificationError},
+	};
+	use binius_m4_verifier::{ReductionVerifierOutput, verify_reduction};
 	use binius_math::{inner_product::inner_product, multilinear::eq::eq_ind_partial_eval};
 	use binius_prover::protocols::shift::build_key_collection;
 	use binius_transcript::{ProverTranscript, VerifierTranscript};
 	use binius_utils::checked_arithmetics::log2_ceil_usize;
-	use binius_verifier::config::StdChallenger;
+	use binius_verifier::{
+		Error,
+		config::StdChallenger,
+		protocols::intmul::{Error as IntMulError, common::LIMB_BITS},
+	};
 	use rand::prelude::*;
 
 	use super::*;
@@ -155,6 +520,52 @@ mod tests {
 	};
 
 	type P = PackedBinaryGhash1x128b;
+
+	// The oracle specs the reduction commits against, in commit order.
+	// The trace oracle lives outside the reduction, so it is not listed here.
+	// Only a circuit with MUL constraints commits an oracle inside the reduction.
+	// That oracle is the IntMul check's logup* pushforward over the table variables.
+	fn oracle_specs(cs: &ConstraintSystem) -> Vec<OracleSpec> {
+		if cs.mul_constraints.is_empty() {
+			Vec::new()
+		} else {
+			vec![OracleSpec::new(LIMB_BITS)]
+		}
+	}
+
+	// Proves the reduction over a naive IOP channel, generic over the packing width `PP`.
+	// The naive channel carries the oracle specs the IntMul check commits against.
+	// Returns the reduction output and the finished transcript to replay.
+	fn prove_via_channel<PP: PackedField<Scalar = B128>>(
+		cs: &ConstraintSystem,
+		key_collection: &KeyCollection,
+		table: &ValueTable,
+	) -> (ReductionProverOutput, ProverTranscript<StdChallenger>) {
+		let specs = oracle_specs(cs);
+		let mut transcript = ProverTranscript::<StdChallenger>::default();
+		// Scope the channel so it releases its borrow of the transcript before it is returned.
+		let output = {
+			let mut channel = NaiveProverChannel::<B128, _>::new(&mut transcript, specs);
+			let output = prove_reduction::<PP, _>(cs, key_collection, table, &mut channel);
+			channel.finish();
+			output
+		};
+		(output, transcript)
+	}
+
+	// Verifies the reduction over a naive IOP channel replaying the prover's transcript.
+	fn verify_via_channel(
+		cs: &ConstraintSystem,
+		log_instances: usize,
+		transcript: &mut VerifierTranscript<StdChallenger>,
+	) -> Result<ReductionVerifierOutput, Error> {
+		// The specs must match the prover's, in the same order.
+		let specs = oracle_specs(cs);
+		let mut channel = NaiveVerifierChannel::new(transcript, &specs);
+		let output = verify_reduction(cs, log_instances, &mut channel)?;
+		channel.finish();
+		Ok(output)
+	}
 
 	// Evaluates the instance-folded witness directly at the shift's final point.
 	// This is the independent reference the reduced claim is checked against.
@@ -174,13 +585,14 @@ mod tests {
 			.fold(base, |acc, &r_y_i| acc * (B128::ONE - r_y_i))
 	}
 
-	// The prover and verifier compose the AND-check and shift reduction on one transcript.
-	// They agree on the reduced claim.
-	// That claim is the true instance-folded witness evaluated at the reduction's point.
 	#[test]
 	fn reduction_round_trips() {
+		// The prover and verifier compose the AND-check and shift reduction on one transcript,
+		// agree on the reduced claim, and that claim is the true instance-folded witness at the
+		// point.
 		let c = crc64_circuit();
 
+		// A batch of 2^6 instances, each with an independent random message.
 		let log_instances = 6;
 		let n_instances = 1usize << log_instances;
 		let mut rng = StdRng::seed_from_u64(0);
@@ -196,13 +608,12 @@ mod tests {
 		let key_collection = build_key_collection(&cs);
 
 		// Prove the reduction on a fresh transcript.
-		let mut prover_transcript = ProverTranscript::<StdChallenger>::default();
-		let prover_out =
-			prove_reduction::<P, _>(&cs, &key_collection, &table, &mut prover_transcript);
+		let (prover_out, prover_transcript) = prove_via_channel::<P>(&cs, &key_collection, &table);
 
 		// Verify by replaying the same transcript.
 		let mut verifier_transcript = prover_transcript.into_verifier();
-		let verifier_out = verify_reduction(&cs, log_instances, &mut verifier_transcript).unwrap();
+		let verifier_out =
+			verify_via_channel(&cs, log_instances, &mut verifier_transcript).unwrap();
 		verifier_transcript.finalize().unwrap();
 
 		// Both sides drew the same instance challenge and reached the same reduced claim.
@@ -226,9 +637,10 @@ mod tests {
 		assert_eq!(expected, verifier_out.shift.witness_eval);
 	}
 
-	// A tampered transcript must be rejected somewhere in the composed reduction.
 	#[test]
 	fn tampered_transcript_is_rejected() {
+		// A single flipped bit in the AND-check's first message must be rejected somewhere in the
+		// composed reduction.
 		let c = crc64_circuit();
 
 		let log_instances = 6;
@@ -243,40 +655,37 @@ mod tests {
 		cs.validate_and_prepare().unwrap();
 		let key_collection = build_key_collection(&cs);
 
-		let mut prover_transcript = ProverTranscript::<StdChallenger>::default();
-		let _ = prove_reduction::<P, _>(&cs, &key_collection, &table, &mut prover_transcript);
+		let (_, prover_transcript) = prove_via_channel::<P>(&cs, &key_collection, &table);
 		let mut proof = prover_transcript.finalize();
 
 		// Flip a bit in the AND-check's first message.
 		// The verifier then redraws a diverging challenge and the reduction no longer checks out.
 		proof[0] ^= 1;
 
+		// The reduction rejects the tampered proof with a channel assertion failure.
 		let mut verifier_transcript = VerifierTranscript::new(StdChallenger::default(), proof);
-		match verify_reduction(&cs, log_instances, &mut verifier_transcript) {
-			Err(_) => {}
-			Ok(_) => {
-				verifier_transcript
-					.finalize()
-					.expect_err("a tampered proof must not verify and finalize cleanly");
-			}
-		}
+		let err = match verify_via_channel(&cs, log_instances, &mut verifier_transcript) {
+			Ok(_) => panic!("a tampered proof must not verify"),
+			Err(err) => err,
+		};
+		assert_matches!(err, Error::Channel(ChannelError::InvalidAssert));
 	}
 
-	// Invariant: a circuit whose constant count is not a power of two proves and verifies.
-	// The shift evaluates the constants over the layout's power-of-two word count.
-	// It treats the words past the constant count as zero, so no caller padding is needed.
-	//
-	// Fixture: one BLAKE3 compression per instance, over 2^6 instances.
-	// A BLAKE3 compression is a real circuit with a non-power-of-two constant count.
 	#[test]
 	fn reduction_round_trips_with_non_power_of_two_constants() {
-		// One BLAKE3 compression; the output is force-committed so the circuit has no inout wires.
+		// A circuit whose constant count is not a power of two proves and verifies: the shift
+		// evaluates the constants over the layout's power-of-two word count, treating the words
+		// past the constant count as zero, so no caller padding is needed.
+		//
+		// A single BLAKE3 compression per instance is a real circuit with a non-power-of-two
+		// constant count, so it exercises exactly that padding path.
 		let builder = CircuitBuilder::new();
 		let cv: [Wire; 8] = array::from_fn(|_| builder.add_witness());
 		let block: [Wire; 16] = array::from_fn(|_| builder.add_witness());
 		let counter = builder.add_witness();
 		let block_len = builder.add_witness();
 		let flags = builder.add_witness();
+		// Force-commit the output so the circuit has no inout wires.
 		let out = blake3_compress(&builder, cv, block, counter, block_len, flags);
 		for wire in out {
 			builder.force_commit(wire);
@@ -313,13 +722,12 @@ mod tests {
 		let key_collection = build_key_collection(&cs);
 
 		// Prove the reduction on a fresh transcript.
-		let mut prover_transcript = ProverTranscript::<StdChallenger>::default();
-		let prover_out =
-			prove_reduction::<P, _>(&cs, &key_collection, &table, &mut prover_transcript);
+		let (prover_out, prover_transcript) = prove_via_channel::<P>(&cs, &key_collection, &table);
 
 		// Verify by replaying the same transcript, leaving no trailing data.
 		let mut verifier_transcript = prover_transcript.into_verifier();
-		let verifier_out = verify_reduction(&cs, log_instances, &mut verifier_transcript).unwrap();
+		let verifier_out =
+			verify_via_channel(&cs, log_instances, &mut verifier_transcript).unwrap();
 		verifier_transcript.finalize().unwrap();
 
 		// Both sides agree on the instance challenge and the reduced claim.
@@ -328,14 +736,77 @@ mod tests {
 	}
 
 	#[test]
-	#[should_panic(
-		expected = "the M4 reduction handles only AND constraints; the circuit must have no MUL constraints"
-	)]
-	fn verifier_rejects_mul_constraints_before_reading_transcript() {
+	fn reduction_round_trips_with_mul_constraints() {
+		// The reduction handles a circuit with both AND and MUL constraints: the IntMul check
+		// reduces to its own instance point, distinct from the AND-check's, and the
+		// re-randomization sumcheck unifies the two before the witness is folded.
+		//
+		// Four products over eight witness inputs give a multi-coordinate constraint index, so the
+		// IntMul claims sit at a non-trivial constraint point and the re-randomization exercises
+		// its constraint fold. Every result word is committed, and each `imul` gate also emits
+		// one AND security check, so both operations are present.
+		let builder = CircuitBuilder::new();
+		let inputs: [Wire; 8] = array::from_fn(|_| builder.add_witness());
+		for pair in inputs.chunks_exact(2) {
+			let (hi, lo) = builder.imul(pair[0], pair[1]);
+			builder.force_commit(hi);
+			builder.force_commit(lo);
+		}
+		let circuit = builder.build();
+
+		let mut cs = circuit.constraint_system().clone();
+		cs.validate_and_prepare().unwrap();
+		// Confirm the fixture is genuine: several products and at least one AND check.
+		assert!(cs.mul_constraints.len() >= 2, "the fixture must emit several MUL constraints");
+		assert!(!cs.and_constraints.is_empty(), "the fixture must emit an AND constraint");
+
+		// Fill each instance's eight multiplicands from a per-instance seed.
+		let log_instances = 6;
+		let table = ValueTable::populate(&circuit, log_instances, |i, w| {
+			let mut rng = StdRng::seed_from_u64(i as u64);
+			for &wire in &inputs {
+				w[wire] = Word(rng.next_u64());
+			}
+		})
+		.unwrap();
+
+		let key_collection = build_key_collection(&cs);
+
+		// Prove and verify over naive IOP channels carrying the IntMul pushforward oracle.
+		let (prover_out, prover_transcript) = prove_via_channel::<P>(&cs, &key_collection, &table);
+		let mut verifier_transcript = prover_transcript.into_verifier();
+		let verifier_out =
+			verify_via_channel(&cs, log_instances, &mut verifier_transcript).unwrap();
+		verifier_transcript.finalize().unwrap();
+
+		// Both sides agree on the shared instance challenge and the reduced claim.
+		assert_eq!(prover_out.r_rho, verifier_out.r_rho);
+		let eval_point = [
+			verifier_out.shift.r_j(),
+			verifier_out.shift.r_y(),
+			std::slice::from_ref(&verifier_out.shift.r_segment),
+		]
+		.concat();
+		assert_eq!(prover_out.witness_claim.challenges, eval_point);
+		assert_eq!(prover_out.witness_claim.eval, verifier_out.shift.witness_eval);
+
+		// The reduced claim equals the instance-folded witness evaluated at the shift point.
+		let folded_witness = fold_instances::<B128>(&table, &verifier_out.r_rho);
+		let expected = evaluate_folded_witness(
+			&folded_witness,
+			verifier_out.shift.r_j(),
+			verifier_out.shift.r_y(),
+		);
+		assert_eq!(expected, verifier_out.shift.witness_eval);
+	}
+
+	#[test]
+	fn tampered_mul_transcript_is_rejected() {
+		// One product per instance, both result words committed as hidden words.
 		let builder = CircuitBuilder::new();
 		let x = builder.add_witness();
 		let y = builder.add_witness();
-		let (hi, lo) = builder.smul(x, y);
+		let (hi, lo) = builder.imul(x, y);
 		builder.force_commit(hi);
 		builder.force_commit(lo);
 		let circuit = builder.build();
@@ -343,7 +814,94 @@ mod tests {
 		let mut cs = circuit.constraint_system().clone();
 		cs.validate_and_prepare().unwrap();
 
-		let mut verifier_transcript = VerifierTranscript::new(StdChallenger::default(), Vec::new());
-		let _ = verify_reduction(&cs, 0, &mut verifier_transcript);
+		let log_instances = 6;
+		let table = ValueTable::populate(&circuit, log_instances, |i, w| {
+			let mut rng = StdRng::seed_from_u64(i as u64 + 1);
+			w[x] = Word(rng.next_u64());
+			w[y] = Word(rng.next_u64());
+		})
+		.unwrap();
+
+		let key_collection = build_key_collection(&cs);
+		let (_, prover_transcript) = prove_via_channel::<P>(&cs, &key_collection, &table);
+		let mut proof = prover_transcript.finalize();
+
+		// Flip a bit in the IntMul check's first message: its exponentiation-root evaluation.
+		// The verifier then redraws a diverging challenge.
+		// The product tree it replays no longer folds to the claimed root, so the check rejects it.
+		proof[0] ^= 1;
+
+		let mut verifier_transcript = VerifierTranscript::new(StdChallenger::default(), proof);
+		let err = match verify_via_channel(&cs, log_instances, &mut verifier_transcript) {
+			Ok(_) => panic!("a tampered proof must not verify"),
+			Err(err) => err,
+		};
+		assert_matches!(
+			err,
+			Error::IntMul(IntMulError::ProdcheckVerify(ProdcheckError::Verification(
+				ProdcheckVerificationError::InvalidAssert
+			)))
+		);
+	}
+
+	#[test]
+	fn reduction_round_trips_with_mixed_constraints_and_wide_packing() {
+		// Independent AND constraints alongside MUL constraints, so the two operations reduce to
+		// constraint points of different lengths (`log_n_and != log_n_mul`) and to genuinely
+		// different instance points that the re-randomization must unify.
+		//
+		// Proving with a width-2 packing exercises the packed lane layout and zero-padding of the
+		// instance-axis multilinears, which the width-1 fixtures never reach.
+		type WideP = PackedBinaryGhash2x128b;
+
+		let builder = CircuitBuilder::new();
+		let inputs: [Wire; 8] = array::from_fn(|_| builder.add_witness());
+		// Four standalone AND gates on distinct wires — the AND work is not tied to the products.
+		for pair in inputs.chunks_exact(2) {
+			let and = builder.band(pair[0], pair[1]);
+			builder.force_commit(and);
+		}
+		// Two products — fewer MUL constraints than AND constraints.
+		for pair in inputs.chunks_exact(2).take(2) {
+			let (hi, lo) = builder.imul(pair[0], pair[1]);
+			builder.force_commit(hi);
+			builder.force_commit(lo);
+		}
+		let circuit = builder.build();
+
+		let mut cs = circuit.constraint_system().clone();
+		cs.validate_and_prepare().unwrap();
+		// Confirm the fixture genuinely exercises the asymmetric case: the two operations have
+		// different constraint-point lengths.
+		let log_n_and = checked_log_2(cs.and_constraints.len());
+		let log_n_mul = checked_log_2(cs.mul_constraints.len());
+		assert_ne!(
+			log_n_and, log_n_mul,
+			"the fixture must give the operations different r_x lengths"
+		);
+
+		// Fill each instance's eight inputs from a per-instance seed.
+		let log_instances = 6;
+		let table = ValueTable::populate(&circuit, log_instances, |i, w| {
+			let mut rng = StdRng::seed_from_u64(i as u64);
+			for &wire in &inputs {
+				w[wire] = Word(rng.next_u64());
+			}
+		})
+		.unwrap();
+
+		let key_collection = build_key_collection(&cs);
+
+		// Prove with the wide packing; the verifier is packing-agnostic.
+		let (prover_out, prover_transcript) =
+			prove_via_channel::<WideP>(&cs, &key_collection, &table);
+		let mut verifier_transcript = prover_transcript.into_verifier();
+		let verifier_out =
+			verify_via_channel(&cs, log_instances, &mut verifier_transcript).unwrap();
+		verifier_transcript.finalize().unwrap();
+
+		// Both sides agree on the shared instance challenge and the reduced claim.
+		assert_eq!(prover_out.r_rho, verifier_out.r_rho);
+		assert_eq!(prover_out.witness_claim.eval, verifier_out.shift.witness_eval);
 	}
 }

--- a/crates/m4-verifier/src/reduction.rs
+++ b/crates/m4-verifier/src/reduction.rs
@@ -9,21 +9,33 @@
 //! 3. The shift reduction reduces the operand claims to one evaluation of the folded witness.
 //! 4. The public-input consistency check ties in the shared constants.
 //!
+//! When the circuit has MUL constraints the IntMul check verifies too.
+//! It yields per-bit operand claims at its own instance point, distinct from the AND-check's.
+//! A batched multilinear-evaluation sumcheck unifies both onto one shared `r_rho`.
+//! Both operand claims at that point then feed the shift.
+//!
 //! The output is that witness claim together with `r_rho`.
 //! The caller binds it to the committed trace by ring-switching at `r_j || r_rho || r_y`.
 //! Evaluating the trace's instance coordinates at `r_rho` performs that instance fold.
 
 use binius_core::{constraint_system::ConstraintSystem, word::Word};
 use binius_field::{AESTowerField8b as B8, Field};
-use binius_ip::channel::IPVerifierChannel;
-use binius_math::BinarySubspace;
+use binius_iop::channel::IOPVerifierChannel;
+use binius_ip::sumcheck::{BatchSumcheckOutput, batch_verify};
+use binius_math::{
+	BinarySubspace,
+	inner_product::inner_product,
+	multilinear::eq::eq_ind,
+	univariate::{evaluate_univariate, lagrange_evals_scalars},
+};
 use binius_utils::checked_arithmetics::checked_log_2;
 use binius_verifier::{
 	Error,
 	config::B128,
 	protocols::{
 		bitand::AndCheckOutput,
-		shift::{self, OperatorData, VerifyOutput},
+		intmul::{IntMulOutput, verify as verify_intmul_reduction},
+		shift::{self, BITAND_ARITY, INTMUL_ARITY, OperatorData, VerifyOutput},
 	},
 };
 
@@ -31,7 +43,10 @@ use crate::verify_bitand_reduction;
 
 /// The verifier's output of the M4 constraint reduction.
 pub struct ReductionVerifierOutput {
-	/// The instance-fold challenge: the low coordinates of the AND-check row point.
+	/// The shared instance-fold challenge the witness is folded at.
+	///
+	/// Without MUL constraints this is the low half of the AND-check row point.
+	/// With MUL constraints the re-randomization sumcheck produces it fresh.
 	pub r_rho: Vec<B128>,
 	/// The reduced claim about the instance-folded witness, from the shift reduction.
 	pub shift: VerifyOutput<B128>,
@@ -48,30 +63,36 @@ pub struct ReductionVerifierOutput {
 /// # Errors
 ///
 /// Returns an error if the AND-check, the shift reduction, or the public-input check fails.
-///
-/// # Panics
-///
-/// Panics if the constraint system has any MUL constraints, which this reduction does not handle.
 pub fn verify_reduction<Channel>(
 	cs: &ConstraintSystem,
 	log_instances: usize,
 	channel: &mut Channel,
 ) -> Result<ReductionVerifierOutput, Error>
 where
-	Channel: IPVerifierChannel<B128, Elem = B128>,
+	Channel: IOPVerifierChannel<B128, Elem = B128>,
 {
-	assert!(
-		cs.mul_constraints.is_empty(),
-		"the M4 reduction handles only AND constraints; the circuit must have no MUL constraints"
-	);
-
-	// One base domain shared by the AND-check and the shift, consistent by construction.
+	// One base domain shared by the AND-check, the shift, and the IntMul operand collapse.
 	// The AND-check's univariate-skip domain spans one dimension above the 64-bit word.
 	let andcheck_domain = BinarySubspace::<B8>::with_dim(Word::LOG_BITS + 1);
 	// The shift domain drops that extra dimension.
 	let shift_domain = andcheck_domain
 		.reduce_dim(Word::LOG_BITS)
 		.isomorphic::<B128>();
+
+	// SOUNDNESS: the IntMul check verifies before the BitAnd check, mirroring the prover.
+	// Its per-bit operand evaluations are read from the transcript here.
+	// BitAnd then draws the univariate challenge that collapses them.
+	// Reading them first stops a malicious prover choosing them as a function of that challenge.
+	// Do not reorder these.
+	//
+	// The IntMul columns span every instance's constraints.
+	// So the check runs over `log_instances + log_n_mul` row variables.
+	let intmul_output = if cs.n_mul_constraints() > 0 {
+		let log_n_mul = checked_log_2(cs.n_mul_constraints());
+		Some(verify_intmul_reduction::<B128, _>(log_instances + log_n_mul, channel)?)
+	} else {
+		None
+	};
 
 	// AND-check over all `K * n_and` rows.
 	let log_n_and = checked_log_2(cs.and_constraints.len());
@@ -83,13 +104,32 @@ where
 		eval_point,
 	} = verify_bitand_reduction(log_instances + log_n_and, &andcheck_domain, channel)?;
 
-	// The row point is `r_rho || r_x`: the instance index low, the constraint index high.
-	let (r_rho, r_x) = eval_point.split_at(log_instances);
+	// The AND-check row point is `r_rho_and || r_x_and`: the instance index low, the constraint
+	// index high.
+	let (r_rho_and, r_x_and) = eval_point.split_at(log_instances);
+
+	// Reduce to one shared instance point and both operand claims at it.
+	let (r_rho, bitand, intmul) = match intmul_output {
+		Some(intmul_output) => {
+			// Both operations enter the re-randomization as operand claims at their own instance
+			// point. BitAnd is already oblong; IntMul is collapsed from its per-bit form.
+			let lagrange = lagrange_evals_scalars::<B128, B128>(&shift_domain, z_challenge);
+			RerandomizedOperations {
+				bitand: OperationClaim::new([a_eval, b_eval, c_eval], r_x_and, r_rho_and),
+				intmul: OperationClaim::from_intmul(intmul_output, &lagrange, log_instances),
+			}
+			.verify(channel)?
+		}
+		// No MUL constraints: the AND-check instance point is used directly.
+		// The IntMul claim is a zero claim at an empty point.
+		None => (
+			r_rho_and.to_vec(),
+			OperatorData::new(r_x_and.to_vec(), [a_eval, b_eval, c_eval]),
+			OperatorData::new(Vec::new(), [B128::ZERO; 4]),
+		),
+	};
 
 	// Reduce the operand claims to one witness evaluation.
-	// No MUL constraints here, so the intmul claim is a zero claim at an empty point.
-	let bitand = OperatorData::new(r_x.to_vec(), [a_eval, b_eval, c_eval]);
-	let intmul = OperatorData::new(Vec::new(), [B128::ZERO; 4]);
 	let shift = shift::verify::<B128, _>(cs, &bitand, &intmul, channel)?;
 
 	// Tie in the shared constants through the public-input consistency check.
@@ -106,8 +146,136 @@ where
 		channel,
 	)?;
 
-	Ok(ReductionVerifierOutput {
-		r_rho: r_rho.to_vec(),
-		shift,
-	})
+	Ok(ReductionVerifierOutput { r_rho, shift })
+}
+
+/// The degree of the re-randomization's round polynomials.
+///
+/// Each operand is a multilinear evaluation, expressed with the quadratic evaluator.
+/// Its degree-2 prime polynomial gains one degree from the equality factor, giving 3.
+// TODO: a degree-1 multilinear-eval store evaluator would drop this to 2; none exists yet.
+const RERAND_DEGREE: usize = 3;
+
+/// The shared instance point together with both operations' operand data at that point.
+type RerandOutput = (Vec<B128>, OperatorData<B128, BITAND_ARITY>, OperatorData<B128, INTMUL_ARITY>);
+
+/// One operation's oblong operand claims and the points they are claimed at.
+///
+/// The AND-check and the IntMul check both reduce to this shape.
+/// The re-randomization transports the claims to the instance point shared by both operations.
+struct OperationClaim<const ARITY: usize> {
+	/// The oblong operand claim per operand, in operand order.
+	operand_claims: [B128; ARITY],
+	/// The constraint-index point the operands are claimed at.
+	r_x: Vec<B128>,
+	/// The instance-index point the operands are claimed at.
+	r_rho: Vec<B128>,
+}
+
+impl<const ARITY: usize> OperationClaim<ARITY> {
+	/// The operand claims at the constraint point `r_x` and instance point `r_rho`.
+	fn new(operand_claims: [B128; ARITY], r_x: &[B128], r_rho: &[B128]) -> Self {
+		Self {
+			operand_claims,
+			r_x: r_x.to_vec(),
+			r_rho: r_rho.to_vec(),
+		}
+	}
+}
+
+impl OperationClaim<INTMUL_ARITY> {
+	/// Builds the IntMul claim by collapsing its per-bit operand claims to oblong claims.
+	///
+	/// The Lagrange weights fold the per-bit claims at the univariate challenge.
+	/// This gives the oblong form the BitAnd claims already have.
+	/// The IntMul row point splits into an instance part (low) and a constraint part (high).
+	fn from_intmul(
+		intmul_output: IntMulOutput<B128>,
+		lagrange: &[B128],
+		log_instances: usize,
+	) -> Self {
+		let IntMulOutput {
+			eval_point: r_out_mul,
+			a_evals,
+			b_evals,
+			c_lo_evals,
+			c_hi_evals,
+		} = intmul_output;
+		let oblong = |evals: Vec<B128>| inner_product(evals, lagrange.iter().copied());
+		let (r_rho, r_x) = r_out_mul.split_at(log_instances);
+		Self::new(
+			[
+				oblong(a_evals),
+				oblong(b_evals),
+				oblong(c_lo_evals),
+				oblong(c_hi_evals),
+			],
+			r_x,
+			r_rho,
+		)
+	}
+}
+
+/// The two operations' claims entering the batched instance re-randomization.
+struct RerandomizedOperations {
+	/// The BitAnd operand claims at the AND-check instance point.
+	bitand: OperationClaim<BITAND_ARITY>,
+	/// The IntMul operand claims at the IntMul instance point.
+	intmul: OperationClaim<INTMUL_ARITY>,
+}
+
+impl RerandomizedOperations {
+	/// Verifies the batched sumcheck that unifies the two operations' instance points.
+	///
+	/// - Check the sumcheck transporting every operand claim onto one shared instance point.
+	/// - Read the reduced operand evaluations at that point.
+	/// - Bind them to the sumcheck.
+	///
+	/// # Returns
+	///
+	/// The shared instance point, the BitAnd operand data, and the IntMul operand data.
+	fn verify<Channel>(self, channel: &mut Channel) -> Result<RerandOutput, Error>
+	where
+		Channel: IOPVerifierChannel<B128, Elem = B128>,
+	{
+		// Both operations reduce over the same instance axis; recover its width from either point.
+		let log_instances = self.bitand.r_rho.len();
+
+		// Verify the batched sumcheck: one multilinear-eval claim per operand, ordered
+		// [BitAnd a, b, c | IntMul a, b, lo, hi].
+		let sums: Vec<B128> = self
+			.bitand
+			.operand_claims
+			.iter()
+			.copied()
+			.chain(self.intmul.operand_claims)
+			.collect();
+		let BatchSumcheckOutput {
+			batch_coeff,
+			eval,
+			mut challenges,
+		} = batch_verify(log_instances, RERAND_DEGREE, &sums, channel)?;
+		challenges.reverse();
+		let r_rho = challenges;
+
+		// The prover wrote the reduced operand evaluations at `r_rho`, grouped by operation.
+		// These are the operand claims the shift consumes.
+		let bitand_evals = channel.recv_array::<BITAND_ARITY>()?;
+		let intmul_evals = channel.recv_array::<INTMUL_ARITY>()?;
+
+		// Bind the reduced evals to the sumcheck: each claim's contribution is its
+		// eq(instance_point, r_rho) weight times its reduced eval, batched by `batch_coeff`.
+		let eq_and = eq_ind(&self.bitand.r_rho, &r_rho);
+		let eq_mul = eq_ind(&self.intmul.r_rho, &r_rho);
+		let expected: Vec<B128> = bitand_evals
+			.map(|eval| eq_and * eval)
+			.into_iter()
+			.chain(intmul_evals.map(|eval| eq_mul * eval))
+			.collect();
+		channel.assert_zero(evaluate_univariate(&expected, batch_coeff) - eval)?;
+
+		let bitand_data = OperatorData::new(self.bitand.r_x, bitand_evals);
+		let intmul_data = OperatorData::new(self.intmul.r_x, intmul_evals);
+		Ok((r_rho, bitand_data, intmul_data))
+	}
 }

--- a/crates/m4-verifier/src/verify.rs
+++ b/crates/m4-verifier/src/verify.rs
@@ -14,6 +14,7 @@ use binius_transcript::{VerifierTranscript, fiat_shamir::Challenger};
 use binius_verifier::{
 	Error,
 	config::{B1, B128},
+	protocols::intmul::common::LIMB_BITS,
 	ring_switch::{self, RingSwitchVerifyOutput},
 };
 
@@ -59,9 +60,19 @@ impl Verifier {
 		// The committed shape follows from one instance's length and the instance count.
 		let layout = BatchCommitLayout::for_constraint_system(cs, log_instances);
 
-		// One oracle: the packed batch witness, committed without zero-knowledge.
+		// The packed batch witness, committed without zero-knowledge.
 		// ZK-ness is a higher-level choice that M4 does not make here.
-		let oracle_specs = vec![OracleSpec::new(layout.log_witness_elems)];
+		let mut oracle_specs = vec![OracleSpec::new(layout.log_witness_elems)];
+
+		// With MUL constraints the IntMul check commits one further oracle: its logup* pushforward.
+		// The pushforward spans the generator-power table, so its size is fixed by the table alone.
+		// It is independent of the instance and constraint counts.
+		// It is committed after the trace, so it follows the trace in the spec order.
+		// This spec must stay in sync with the oracle the IntMul check commits
+		// (`logup_star::verify` receives one oracle of `LIMB_BITS` variables).
+		if !cs.mul_constraints.is_empty() {
+			oracle_specs.push(OracleSpec::new(LIMB_BITS));
+		}
 
 		// Pick the proof-size-optimal FRI fold arity for this codeword length.
 		let log_code_len = layout.log_witness_elems + log_inv_rate;


### PR DESCRIPTION
Closes [BINIUS-274](https://linear.app/jimpo/issue/BINIUS-274/enable-intmul-constraints-for-m4).

Wires the IntMul check into the data-parallel M4 reduction, so circuits with MUL constraints (not just AND) prove and verify.

### The problem

The M4 witness is a multilinear over three axes: `Z || RHO || Y` — bit within a word, instance, wire.
Each operation transforms it into operand columns indexed `Z || RHO || X`, where `X` is that operation's constraint index.

The AND-check and the IntMul check each reduce their columns to operand claims, but at **different** points:
- both share the bit point `r_Z` (the AND-check's univariate challenge),
- but their instance points `r_rho` differ — they are independent Fiat-Shamir draws,
- and their constraint points `r_x` differ in length (`log(n_and)` vs `log(n_mul)`).

The committed witness can only be folded over the instance axis **once**.
So the two instance points must be unified before the shift reduction folds the witness.

### The idea

This takes strategy #2 from the issue: **re-randomize only the instance variables**, leaving each operation's `r_x` alone.

For each of the 3 AND operands and 4 IntMul operands, fold the operand column down to a per-instance multilinear:

```
M_op[rho] = sum_{local, bit} lagrange(r_Z)[bit] * eq(r_x_op, local) * bit_b(column[rho * n_op + local])
```

- the Lagrange weights collapse the bit axis at the shared `r_Z`,
- the `eq(r_x_op)` tensor collapses that operation's constraint axis,
- what remains is a $2^m$ buffer over the $m$ instance variables.

A batched `MultilinearEvalProver` sumcheck then transports all these claims from their own instance points onto **one** shared `r_rho`.
The witness is folded once there, and the reduced evaluations become the operand claims the shift consumes — each operation keeping its own `r_x`.

### The change

The reduction gains the IntMul path; the no-MUL path is unchanged.

```
reduction.rs (prover + verifier):
- AND-check -> shift, IntMul columns built and dropped
+ IntMul check -> AND-check -> re-randomize RHO -> shift, with both operand claims
```

- The IntMul check runs **before** the AND-check (soundness, below).
- The IntMul per-bit operand claims are collapsed to oblong claims at the AND-check's `r_Z` via `lagrange_evals`, matching the AND operand claims' form.
- The verifier declares the IntMul logup* pushforward as a second committed oracle (`OracleSpec::new(LIMB_BITS)`), opened by the existing final oracle-relations call.

### Soundness

- **Ordering:** the IntMul check runs before the AND-check draws `r_Z`, so its per-bit operand evaluations are bound to the transcript first. A malicious prover therefore cannot choose them as a function of `r_Z`. The verifier enforces the same order.
- **Transport:** the batched multilinear-evaluation sumcheck binds each reduced operand evaluation to its operation-check claim; the shift then binds those same evaluations to the folded witness, which the ring-switch binds to the committed trace. The chain holds at the shared `r_rho`.
- The transcript for a circuit with no MUL constraints is byte-identical to before.

### Scope

- **new:** the IntMul check, the RHO re-randomization sumcheck, and the per-operand fold in the M4 prover/verifier reduction; the conditional logup* oracle spec.
- **changed:** the reduction's channel bound (`IPProverChannel` -> `IOPProverChannel`, and the verifier equivalent) so the IntMul check can commit and open its oracle.
- **fix:** the prover now zero-pads the public constants to the layout's power-of-two word count before the shift; the verifier already tolerated the short slice, and small MUL circuits tripped a size assertion without this.
- **left as follow-up:** the issue's lambda-combination of the 7 per-operand buffers into 2 per-operation buffers. It is a cost micro-optimization (the buffers are only $2^m$) and would require the shared shift protocol to accept a pre-batched claim, touching the single-instance path.

### Verification

- `cargo check --workspace --all-targets`, `clippy -p binius-m4-prover -p binius-m4-verifier --all-targets`, nightly `fmt --all` — clean.
- New tests: full protocol round-trip under real FRI with a MUL circuit (both oracles open), a four-product reduction round-trip exercising a non-trivial `r_x_mul`, and strict tamper rejection asserting the exact IntMul product-check error variant.
- Existing no-MUL round-trip and tamper tests pass unchanged in behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)