### PR TITLE
BINIUS-217: deferred-fold fused execute in the sumcheck MleStore

### DIFF
--- a/crates/ip-prover/src/sumcheck/mle_store.rs
+++ b/crates/ip-prover/src/sumcheck/mle_store.rs
@@ -15,9 +15,15 @@
 //! registered tracker advances exactly once per [`MleStore::fold`] call, no matter how many
 //! evaluators reference it.
 //!
-//! Folding is eager: [`MleStore::fold`] advances every column immediately, and the round pass
-//! over the columns is a plain read. A deferred-fold variant that fuses the fold into the next
-//! round's read pass can replace the internals without changing this interface.
+//! Folding of the columns is *deferred*: [`MleStore::fold`] records the challenge — advancing the
+//! logical variable count and the (small) eq trackers — but leaves the column data untouched, so
+//! it is O(1) in the columns. The next round's pass then folds the columns while it reads them:
+//! [`MleStore::fused_execute`] applies the pending fold to each chunk in place and feeds the folded
+//! halves straight to the evaluators, fusing fold and read into one memory pass (~1.5x the column
+//! length of memory traffic instead of a plain read plus a separate fold's ~2.5x). The eager
+//! [`MleStore::apply_pending_fold`] serves the first round, the last fold before
+//! [`MleStore::final_evals`], and rounds too small to chunk. Fusing only reorders the associative
+//! field additions, so all paths produce identical round polynomials and evaluations.
 
 use binius_field::{Field, PackedField};
 use binius_math::{
@@ -25,8 +31,31 @@ use binius_math::{
 	multilinear::fold::fold_highest_var_inplace,
 };
 use binius_utils::rayon::prelude::*;
+use itertools::izip;
 
 use super::gruen32::Gruen32;
+
+/// One logical column's four packed segments at a single chunk, for the fused deferred fold.
+///
+/// The pre-fold column at this chunk is `[q0 | q1 | q2 | q3]` (the four quarters at the chunk
+/// offset). Folding on the highest variable pairs the front half `[q0 | q1]` with the back half
+/// `[q2 | q3]`: the folded low half is `extrapolate(q0, q2, r)` written back into `q0`, and the
+/// folded high half is `extrapolate(q1, q3, r)` written back into `q1`. After the fold `q0`/`q1`
+/// hold the folded column's low/high halves, fed straight to the evaluators while cache-hot.
+struct FoldCol<'c, P: PackedField> {
+	q0: &'c mut [P],
+	q1: &'c mut [P],
+	q2: &'c [P],
+	q3: &'c [P],
+}
+
+/// One chunk's fold-and-accumulate work: every logical column's four segments and every eq
+/// expansion's slice at this chunk. Built by transposing the columns' split segments so each is a
+/// distinct rayon task owning disjoint mutable sub-slices.
+struct ChunkTask<'c, P: PackedField> {
+	cols: Vec<FoldCol<'c, P>>,
+	eqs: Vec<FieldSlice<'c, P>>,
+}
 
 /// Identifier of a column held by an [`MleStore`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -72,30 +101,45 @@ enum Column<'a, P: PackedField> {
 ///
 /// See the [module documentation](self) for the folding invariant.
 pub struct MleStore<'a, P: PackedField> {
-	n_vars: usize,
+	/// The *physical* number of variables the columns are stored at.
+	///
+	/// This is the size of the buffers on disk. The logical remaining-variable count seen by
+	/// callers ([`Self::n_vars`]) is this minus one when a [`Self::fold`] is pending, since a
+	/// pending fold has already advanced the claim state but not yet touched the column data.
+	physical_n_vars: usize,
 	columns: Vec<Column<'a, P>>,
 	/// Number of logical columns, counting each [`Column::SplitHalf`] entry as two. This is the
 	/// number of assigned [`ColId`]s and the length of the [`Self::final_evals`] output.
 	n_cols: usize,
 	eq_trackers: Vec<Gruen32<P>>,
+	/// The challenge of a deferred fold not yet applied to the columns.
+	///
+	/// [`Self::fold`] records the challenge here (advancing the logical variable count and the eq
+	/// trackers) without touching the column data; the next [`Self::execute_context`] pass — or
+	/// [`Self::apply_pending_fold`] — folds the columns while it reads them. At most one fold can
+	/// be pending, since every fold is followed by a round pass that consumes it.
+	pending_fold: Option<P::Scalar>,
 }
 
 impl<'a, F: Field, P: PackedField<Scalar = F>> MleStore<'a, P> {
 	/// Creates an empty store over columns with `n_vars` variables.
 	pub const fn new(n_vars: usize) -> Self {
 		Self {
-			n_vars,
+			physical_n_vars: n_vars,
 			columns: Vec::new(),
 			n_cols: 0,
 			eq_trackers: Vec::new(),
+			pending_fold: None,
 		}
 	}
 
 	/// Returns the number of variables remaining in the columns.
 	///
-	/// Decrements with each [`Self::fold`] call.
+	/// Decrements with each [`Self::fold`] call. A pending (deferred) fold counts as already
+	/// applied: it has advanced the claim state, so the logical count drops even before the column
+	/// data is folded.
 	pub const fn n_vars(&self) -> usize {
-		self.n_vars
+		self.physical_n_vars - self.pending_fold.is_some() as usize
 	}
 
 	/// Pushes a borrowed column and returns its identifier.
@@ -105,7 +149,7 @@ impl<'a, F: Field, P: PackedField<Scalar = F>> MleStore<'a, P> {
 		// precondition
 		assert_eq!(
 			column.log_len(),
-			self.n_vars,
+			self.n_vars(),
 			"column must have number of variables equal to the store"
 		);
 		self.columns.push(Column::Borrowed(column));
@@ -117,7 +161,7 @@ impl<'a, F: Field, P: PackedField<Scalar = F>> MleStore<'a, P> {
 		// precondition
 		assert_eq!(
 			column.log_len(),
-			self.n_vars,
+			self.n_vars(),
 			"column must have number of variables equal to the store"
 		);
 		self.columns.push(Column::Owned(column));
@@ -143,7 +187,7 @@ impl<'a, F: Field, P: PackedField<Scalar = F>> MleStore<'a, P> {
 		// precondition
 		assert_eq!(
 			buffer.log_len(),
-			self.n_vars + 1,
+			self.n_vars() + 1,
 			"buffer must have one more variable than the store so each half matches it"
 		);
 		self.columns.push(Column::SplitHalf(buffer));
@@ -161,7 +205,7 @@ impl<'a, F: Field, P: PackedField<Scalar = F>> MleStore<'a, P> {
 		// precondition
 		assert_eq!(
 			eval_point.len(),
-			self.n_vars,
+			self.n_vars(),
 			"evaluation point length must equal the store's number of variables"
 		);
 		// Trackers fold in lockstep with the store, so the remaining coordinates of an existing
@@ -169,7 +213,7 @@ impl<'a, F: Field, P: PackedField<Scalar = F>> MleStore<'a, P> {
 		let existing = self
 			.eq_trackers
 			.iter()
-			.position(|tracker| &tracker.eval_point()[..self.n_vars] == eval_point);
+			.position(|tracker| &tracker.eval_point()[..self.n_vars()] == eval_point);
 		let index = existing.unwrap_or_else(|| {
 			self.eq_trackers.push(Gruen32::new(eval_point));
 			self.eq_trackers.len() - 1
@@ -231,17 +275,56 @@ impl<'a, F: Field, P: PackedField<Scalar = F>> MleStore<'a, P> {
 		self.eq_trackers[id.0].eq_prefix_eval()
 	}
 
-	/// Folds every column and every eq tracker with a verifier challenge.
+	/// Records a deferred fold of every column and folds every eq tracker with a verifier
+	/// challenge.
+	///
+	/// The column fold is *deferred*: it is recorded (advancing the logical variable count and the
+	/// eq trackers) but not applied to the column data, so this is O(1) in the columns. The next
+	/// round pass folds the columns while it reads them — [`Self::execute_context`] applies the
+	/// pending fold as its first act — fusing fold and read into one memory pass. The eq trackers,
+	/// small relative to the columns and read by evaluators before the columns are folded, advance
+	/// eagerly here.
 	///
 	/// Columns fold on the highest variable, matching the high-to-low binding order of the
 	/// sumcheck provers this store backs.
 	pub fn fold(&mut self, challenge: F) {
 		// precondition
-		assert!(self.n_vars > 0, "fold requires at least one remaining variable");
+		assert!(self.n_vars() > 0, "fold requires at least one remaining variable");
+		debug_assert!(
+			self.pending_fold.is_none(),
+			"a pending fold must be consumed by a round pass before folding again"
+		);
 
+		for tracker in &mut self.eq_trackers {
+			tracker.fold(challenge);
+		}
+		self.pending_fold = Some(challenge);
+	}
+
+	/// Returns whether a deferred fold has been recorded but not yet applied to the columns.
+	pub const fn has_pending_fold(&self) -> bool {
+		self.pending_fold.is_some()
+	}
+
+	/// Applies any pending deferred fold to the column data, eagerly.
+	///
+	/// After this the columns are physically at [`Self::n_vars`] variables and no fold is pending.
+	/// The fused round pass ([`Self::execute_context`]) applies the pending fold as it reads
+	/// instead; this eager path is used by [`Self::final_evals`] after the last round and by rounds
+	/// too small to fuse.
+	pub fn apply_pending_fold(&mut self) {
+		if let Some(challenge) = self.pending_fold.take() {
+			self.fold_columns(challenge);
+			self.physical_n_vars -= 1;
+		}
+	}
+
+	/// Folds every column in place with `challenge`, on the highest of its `physical_n_vars`
+	/// variables. Does not update `physical_n_vars` or `pending_fold`.
+	fn fold_columns(&mut self, challenge: F) {
 		// The number of live variables in each column before this fold; a split-half buffer keeps
 		// its full length, so its halves must be truncated to this before folding.
-		let n_vars = self.n_vars;
+		let physical_n_vars = self.physical_n_vars;
 		for column in &mut self.columns {
 			match column {
 				Column::Owned(buffer) => fold_highest_var_inplace(buffer, challenge),
@@ -258,17 +341,13 @@ impl<'a, F: Field, P: PackedField<Scalar = F>> MleStore<'a, P> {
 					// its halves — so no copy is made.
 					let mut split = buffer.split_half_mut();
 					let (mut low, mut high) = split.halves();
-					low.truncate(n_vars);
-					high.truncate(n_vars);
+					low.truncate(physical_n_vars);
+					high.truncate(physical_n_vars);
 					fold_highest_var_inplace(&mut low, challenge);
 					fold_highest_var_inplace(&mut high, challenge);
 				}
 			}
 		}
-		for tracker in &mut self.eq_trackers {
-			tracker.fold(challenge);
-		}
-		self.n_vars -= 1;
 	}
 
 	/// Expands the store into one borrowed slice per logical column, in [`ColId`] order.
@@ -276,7 +355,14 @@ impl<'a, F: Field, P: PackedField<Scalar = F>> MleStore<'a, P> {
 	/// A split-half entry expands into the front `2^n_vars` scalars of its low and high
 	/// halves, so the returned length is the logical column count — larger than the physical entry
 	/// count whenever a split-half column is present.
-	pub fn column_slices(&self) -> Vec<FieldSlice<'_, P>> {
+	///
+	/// Private: with a fold pending it would misreport each column's live region (notably the
+	/// split-half fronts), so it is only ever called after the pending fold is resolved.
+	fn column_slices(&self) -> Vec<FieldSlice<'_, P>> {
+		debug_assert!(
+			self.pending_fold.is_none(),
+			"column data must not be read with a fold pending; apply it first"
+		);
 		let mut slices = Vec::with_capacity(self.n_cols);
 		for column in &self.columns {
 			match column {
@@ -286,9 +372,9 @@ impl<'a, F: Field, P: PackedField<Scalar = F>> MleStore<'a, P> {
 					// The buffer holds the two columns as its low and high halves; each column is
 					// the front `2^n_vars` scalars of one half, so read it as that half's
 					// chunk 0.
-					let high_start = 1 << (buffer.log_len() - 1 - self.n_vars);
-					slices.push(buffer.chunk(self.n_vars, 0));
-					slices.push(buffer.chunk(self.n_vars, high_start));
+					let high_start = 1 << (buffer.log_len() - 1 - self.physical_n_vars);
+					slices.push(buffer.chunk(self.physical_n_vars, 0));
+					slices.push(buffer.chunk(self.physical_n_vars, high_start));
 				}
 			}
 		}
@@ -300,7 +386,11 @@ impl<'a, F: Field, P: PackedField<Scalar = F>> MleStore<'a, P> {
 	/// Each column's evaluation is computed once, no matter how many claims read the column.
 	pub fn final_evals(&self) -> Vec<F> {
 		// precondition
-		assert_eq!(self.n_vars, 0, "final_evals requires all variables to be folded");
+		assert_eq!(self.n_vars(), 0, "final_evals requires all variables to be folded");
+		assert!(
+			self.pending_fold.is_none(),
+			"final_evals requires the last fold to be applied; call apply_pending_fold first"
+		);
 
 		self.column_slices()
 			.iter()
@@ -314,11 +404,160 @@ impl<'a, F: Field, P: PackedField<Scalar = F>> MleStore<'a, P> {
 	/// expansions and hands each parallel chunk to the round evaluators (see
 	/// [`ExecuteContext::par_chunks`]).
 	pub fn execute_context(&self) -> ExecuteContext<'_, P> {
+		debug_assert!(
+			self.pending_fold.is_none(),
+			"apply the pending fold before building an execute context"
+		);
 		ExecuteContext {
-			n_vars: self.n_vars,
+			n_vars: self.physical_n_vars,
 			cols: self.column_slices(),
 			eqs: self.eq_expansions(),
 		}
+	}
+
+	/// Returns whether any column is still borrowed (never yet folded).
+	///
+	/// A borrowed column's first fold must go out of place (it cannot be written), so the fused
+	/// deferred pass ([`Self::fused_execute`]) does not accept it; the caller folds eagerly
+	/// instead. Borrowed columns arise only from [`Self::push`], which the production provers do
+	/// not use.
+	pub fn has_borrowed_column(&self) -> bool {
+		self.columns
+			.iter()
+			.any(|column| matches!(column, Column::Borrowed(_)))
+	}
+
+	/// Runs the round's accumulation pass while applying the pending deferred fold in a single
+	/// memory pass, feeding each folded chunk to `fold_op` (a rayon fold over per-worker `A`).
+	///
+	/// For each chunk of the post-fold halved hypercube this folds every column's four segments in
+	/// place — writing the folded low/high halves back — and immediately hands those
+	/// still-cache-hot halves, as an [`EvaluationChunk`], to `fold_op`. Versus the eager path
+	/// ([`Self::apply_pending_fold`] then [`Self::execute_context`]) it reads each column once and
+	/// writes half — ~1.5x the column length rather than ~2.5x. Results are identical: fusing only
+	/// reorders the GF(2^k) additions, which are associative.
+	///
+	/// After the pass the columns are physically at [`Self::n_vars`] variables and no fold is
+	/// pending.
+	///
+	/// ## Preconditions
+	///
+	/// * a fold is pending,
+	/// * `P::LOG_WIDTH <= chunk_vars` and `chunk_vars <= n_vars() - 1`,
+	/// * no column is borrowed (see [`Self::has_borrowed_column`]).
+	pub fn fused_execute<A: Send>(
+		&mut self,
+		chunk_vars: usize,
+		identity: impl Fn() -> A + Sync + Send,
+		fold_op: impl Fn(A, &EvaluationChunk<'_, P>) -> A + Sync + Send,
+		reduce_op: impl Fn(A, A) -> A + Sync + Send,
+	) -> A {
+		let challenge = self
+			.pending_fold
+			.expect("fused_execute requires a pending fold");
+		debug_assert!(!self.has_borrowed_column(), "fused_execute needs no borrowed columns");
+		let physical_n_vars = self.physical_n_vars;
+		let log_width = P::LOG_WIDTH;
+		// The folded column has `physical_n_vars - 1` variables and its halved hypercube (over
+		// which the round accumulates) has `physical_n_vars - 2`, chunked at `chunk_vars`.
+		debug_assert!(log_width <= chunk_vars && chunk_vars + 1 < physical_n_vars);
+
+		let challenge_bcast = P::broadcast(challenge);
+		// Packed lengths. A pre-fold column is `2^physical_n_vars` scalars = four quarters of
+		// `m_packed` packed elements; each chunk covers `chunk_packed` packed elements.
+		let m_packed = 1usize << (physical_n_vars - 2 - log_width);
+		let chunk_packed = 1usize << (chunk_vars - log_width);
+		let chunk_count = m_packed / chunk_packed;
+		let region_packed = 4 * m_packed;
+
+		// Borrow the eq expansions (read-only) from a field disjoint from `columns`.
+		let eq_bufs: Vec<&FieldBuffer<P>> = self
+			.eq_trackers
+			.iter()
+			.map(|tracker| tracker.eq_expansion())
+			.collect();
+
+		// Transpose the per-column split segments into one task per chunk, so rayon owns disjoint
+		// mutable sub-slices. This is O(chunk_count * n_cols), negligible against the pass itself.
+		let mut tasks: Vec<ChunkTask<'_, P>> = (0..chunk_count)
+			.map(|_| ChunkTask {
+				cols: Vec::with_capacity(self.n_cols),
+				eqs: Vec::with_capacity(eq_bufs.len()),
+			})
+			.collect();
+		for column in &mut self.columns {
+			match column {
+				Column::Owned(buffer) => {
+					distribute_region(buffer.as_mut(), m_packed, chunk_packed, &mut tasks)
+				}
+				Column::SplitHalf(buffer) => {
+					// The buffer's low and high halves are the two logical columns; each folds
+					// independently as the front `region_packed` of its half.
+					let full = buffer.as_mut();
+					let half = full.len() / 2;
+					let (low, high) = full.split_at_mut(half);
+					distribute_region(
+						&mut low[..region_packed],
+						m_packed,
+						chunk_packed,
+						&mut tasks,
+					);
+					distribute_region(
+						&mut high[..region_packed],
+						m_packed,
+						chunk_packed,
+						&mut tasks,
+					);
+				}
+				Column::Borrowed(_) => unreachable!("fused_execute needs no borrowed columns"),
+			}
+		}
+		for eq in &eq_bufs {
+			for (task, chunk) in tasks.iter_mut().zip(eq.chunks(chunk_vars)) {
+				task.eqs.push(chunk);
+			}
+		}
+
+		let result = tasks
+			.into_par_iter()
+			.fold(&identity, |acc, mut task| {
+				// Fold each column's chunk in place: q0/q1 become the folded low/high halves.
+				for fc in &mut task.cols {
+					for (a0, a1, &b2, &b3) in
+						izip!(fc.q0.iter_mut(), fc.q1.iter_mut(), fc.q2.iter(), fc.q3.iter())
+					{
+						*a0 = extrapolate_line_packed(*a0, b2, challenge_bcast);
+						*a1 = extrapolate_line_packed(*a1, b3, challenge_bcast);
+					}
+				}
+				// Build the chunk from the just-folded, cache-hot halves and accumulate.
+				let cols = task
+					.cols
+					.iter()
+					.map(|fc| ColumnChunk {
+						lo: FieldSlice::from_slice(chunk_vars, &fc.q0[..]),
+						hi: FieldSlice::from_slice(chunk_vars, &fc.q1[..]),
+					})
+					.collect();
+				let chunk = EvaluationChunk {
+					cols,
+					eqs: task.eqs,
+				};
+				fold_op(acc, &chunk)
+			})
+			.reduce(&identity, reduce_op);
+
+		// The columns are now folded in their front halves. Owned buffers shrink to the folded
+		// size; split-half buffers keep their length (their columns are read as the front of each
+		// half).
+		for column in &mut self.columns {
+			if let Column::Owned(buffer) = column {
+				buffer.truncate(physical_n_vars - 1);
+			}
+		}
+		self.physical_n_vars -= 1;
+		self.pending_fold = None;
+		result
 	}
 }
 
@@ -419,6 +658,37 @@ impl<'b, P: PackedField> ExecuteContext<'b, P> {
 	}
 }
 
+/// Splits one logical column's pre-fold `region` into its four quarters and appends one
+/// [`FoldCol`] per chunk to `tasks`.
+///
+/// `region` is the `4 * m_packed` packed elements of a column with the fold pending. Its front half
+/// `[q0 | q1]` is taken mutably (the folded low/high halves are written back there) and its back
+/// half `[q2 | q3]` read-only; each quarter is sliced into `chunk_packed`-sized chunks aligned with
+/// `tasks`.
+fn distribute_region<'c, P: PackedField>(
+	region: &'c mut [P],
+	m_packed: usize,
+	chunk_packed: usize,
+	tasks: &mut [ChunkTask<'c, P>],
+) {
+	let (front, back) = region.split_at_mut(2 * m_packed);
+	let (q0, q1) = front.split_at_mut(m_packed);
+	let (q2, q3) = back.split_at(m_packed);
+	for (task, (((c0, c1), c2), c3)) in tasks.iter_mut().zip(
+		q0.chunks_mut(chunk_packed)
+			.zip(q1.chunks_mut(chunk_packed))
+			.zip(q2.chunks(chunk_packed))
+			.zip(q3.chunks(chunk_packed)),
+	) {
+		task.cols.push(FoldCol {
+			q0: c0,
+			q1: c1,
+			q2: c2,
+			q3: c3,
+		});
+	}
+}
+
 /// Computes the partial evaluation of a multilinear on its highest variable, out of place.
 ///
 /// This is the out-of-place counterpart of [`fold_highest_var_inplace`], used for the first fold
@@ -436,4 +706,106 @@ fn fold_highest_var<P: PackedField>(
 		.map(|(&lo_i, &hi_i)| extrapolate_line_packed(lo_i, hi_i, challenge_broadcast))
 		.collect();
 	FieldBuffer::new(values.log_len() - 1, out_vals)
+}
+
+#[cfg(test)]
+mod tests {
+	use std::ops::Deref;
+
+	use binius_field::{FieldOps, Random};
+	use binius_math::{
+		multilinear::fold::fold_highest_var_inplace, test_utils::random_field_buffer,
+	};
+	use rand::prelude::*;
+
+	use super::*;
+
+	type P = binius_math::test_utils::Packed128b;
+	type F = <P as FieldOps>::Scalar;
+
+	// Flatten a field buffer or borrowed slice into its live scalars, for column comparison.
+	fn scalars<Data: Deref<Target = [P]>>(buffer: &FieldBuffer<P, Data>) -> Vec<F> {
+		(0..1usize << buffer.log_len())
+			.map(|i| buffer.get(i))
+			.collect()
+	}
+
+	// The fused deferred fold must produce column data identical to an independent eager reference,
+	// across all three column variants and both the fused and eager-fallback paths.
+	//
+	// The reference folds owned copies of every logical column with the `binius-math` fold
+	// primitive; the store folds lazily, resolving each pending fold through the fused pass when it
+	// is legal (no borrowed column, packed-aligned chunks) and through the eager path otherwise.
+	// `Packed128b` has `LOG_WIDTH == 2`, so with `n_vars = 10` the rounds walk the whole matrix: an
+	// eager first round (the borrowed column's out-of-place first fold), then fused rounds — sized
+	// to split into multiple parallel chunks while large enough — then an eager tail, ending with
+	// the last fold applied with no trailing pass (the `finish` edge) before `final_evals`.
+	#[test]
+	fn test_fused_fold_matches_eager_reference() {
+		let n_vars = 10;
+		let mut rng = StdRng::seed_from_u64(0);
+
+		// One column of each variant. A split-half buffer carries two logical columns as its low
+		// and high halves, so it holds one extra variable.
+		let borrowed_src = random_field_buffer::<P>(&mut rng, n_vars);
+		let owned_src = random_field_buffer::<P>(&mut rng, n_vars);
+		let split_src = random_field_buffer::<P>(&mut rng, n_vars + 1);
+
+		// Independent reference: owned copies in `ColId` order (borrowed, owned, split low, split
+		// high), each folded eagerly with the math primitive.
+		let (split_lo, split_hi) = split_src.split_half_ref();
+		let mut refs: Vec<FieldBuffer<P>> = vec![
+			borrowed_src.clone(),
+			owned_src.clone(),
+			FieldBuffer::new(split_lo.log_len(), split_lo.as_ref().into()),
+			FieldBuffer::new(split_hi.log_len(), split_hi.as_ref().into()),
+		];
+
+		let mut store = MleStore::<P>::new(n_vars);
+		store.push(borrowed_src.to_ref());
+		store.push_owned(owned_src);
+		store.push_split_half(split_src);
+
+		for round in 0..n_vars {
+			let challenge = F::random(&mut rng);
+			store.fold(challenge);
+			for reference in &mut refs {
+				fold_highest_var_inplace(reference, challenge);
+			}
+
+			// A fold is now pending, so the physical column size is one above the logical count.
+			// Fuse when no borrowed column remains and the halved hypercube is packed-aligned;
+			// otherwise fall back to the eager apply. The last round (physical 1) always falls
+			// back — the `finish` edge: the last fold applied with no trailing pass.
+			let physical_n_vars = store.n_vars() + 1;
+			if !store.has_borrowed_column() && physical_n_vars >= P::LOG_WIDTH + 2 {
+				// `chunk_vars` in `[LOG_WIDTH, physical - 2]`, biased small to split into several
+				// parallel chunks whenever the round is large enough to.
+				let chunk_vars = physical_n_vars
+					.saturating_sub(3)
+					.clamp(P::LOG_WIDTH, physical_n_vars - 2);
+				store.fused_execute(chunk_vars, || (), |acc, _chunk| acc, |acc, ()| acc);
+			} else {
+				store.apply_pending_fold();
+			}
+
+			let store_cols = store.column_slices();
+			assert_eq!(store_cols.len(), refs.len());
+			for (id, (store_col, reference)) in store_cols.iter().zip(&refs).enumerate() {
+				assert_eq!(
+					scalars(store_col),
+					scalars(reference),
+					"column {id} data must match the eager reference after round {round}"
+				);
+			}
+		}
+
+		assert_eq!(
+			store.final_evals(),
+			refs.iter()
+				.map(|reference| reference.get(0))
+				.collect::<Vec<_>>(),
+			"final evaluations must match the eager reference"
+		);
+	}
 }

--- a/crates/ip-prover/src/sumcheck/round_evaluator.rs
+++ b/crates/ip-prover/src/sumcheck/round_evaluator.rs
@@ -190,26 +190,47 @@ where
 			.last()
 			.expect("offsets has one entry per evaluator, plus one");
 
-		// The store prepares one `EvaluationChunk` per chunk of the halved hypercube — the split
-		// column halves and eq-indicator expansions each evaluator reads.
-		let ctx = self.store.execute_context();
 		let evaluators = &self.evaluators;
 		let new_accum = || -> Vec<<P as WideMul>::Output> { vec![Default::default(); total_slots] };
-		let accum = ctx
-			.par_chunks(chunk_vars)
-			.fold(new_accum, |mut accum, chunk| {
-				for (evaluator, window) in iter::zip(evaluators, offsets.windows(2)) {
-					evaluator.accumulate(&chunk, &mut accum[window[0]..window[1]]);
-				}
-				accum
-			})
-			.reduce(new_accum, |mut lhs, rhs| {
-				// The only merge: sum the workers' slices slot-wise, generic over every evaluator.
-				for (dst, src) in iter::zip(&mut lhs, rhs) {
-					*dst += src;
-				}
-				lhs
-			});
+		// One chunk's contribution: every evaluator accumulates its columns' folded halves into its
+		// own run of wide slots.
+		let accumulate_chunk = |mut accum: Vec<<P as WideMul>::Output>,
+		                        chunk: &EvaluationChunk<'_, P>| {
+			for (evaluator, window) in iter::zip(evaluators, offsets.windows(2)) {
+				evaluator.accumulate(chunk, &mut accum[window[0]..window[1]]);
+			}
+			accum
+		};
+		// The only merge: sum the workers' slices slot-wise, generic over every evaluator.
+		let reduce_accum = |mut lhs: Vec<<P as WideMul>::Output>,
+		                    rhs: Vec<<P as WideMul>::Output>| {
+			for (dst, src) in iter::zip(&mut lhs, rhs) {
+				*dst += src;
+			}
+			lhs
+		};
+
+		// With a pending deferred fold and whole-packed chunks over non-borrowed columns, fold the
+		// columns while accumulating in one memory pass. Otherwise (the first round, tiny rounds
+		// whose chunks are sub-packing-width, or the test-only borrowed columns whose first fold is
+		// out of place) apply the pending fold eagerly and run a plain read pass — same result,
+		// since fusing only reorders the associative field additions.
+		let accum = if self.store.has_pending_fold()
+			&& chunk_vars >= P::LOG_WIDTH
+			&& !self.store.has_borrowed_column()
+		{
+			self.store
+				.fused_execute(chunk_vars, new_accum, accumulate_chunk, reduce_accum)
+		} else {
+			self.store.apply_pending_fold();
+			// The store prepares one `EvaluationChunk` per chunk of the halved hypercube — the
+			// split column halves and eq-indicator expansions each evaluator reads.
+			self.store
+				.execute_context()
+				.par_chunks(chunk_vars)
+				.fold(new_accum, |accum, chunk| accumulate_chunk(accum, &chunk))
+				.reduce(new_accum, reduce_accum)
+		};
 
 		// The store is read (immutably) for the round's point coordinates while the evaluators are
 		// interpolated (mutably); they are disjoint fields, so borrow the store separately.
@@ -228,9 +249,10 @@ where
 		}
 	}
 
-	fn finish(self) -> Vec<F> {
-		// The store owns each column once and computes its evaluation a single time, no matter how
-		// many claims read it; emit every column's evaluation in store order.
+	fn finish(mut self) -> Vec<F> {
+		// Apply the last round's deferred fold, then emit each column's evaluation once — the store
+		// owns each column a single time no matter how many claims read it, in store order.
+		self.store.apply_pending_fold();
 		self.store.final_evals()
 	}
 }
@@ -453,7 +475,10 @@ mod tests {
 	// polynomials, evaluation points, and final evaluations must all match exactly.
 	#[test]
 	fn test_shared_frac_add_matches_single_provers_lockstep() {
-		for n_vars in [1, 2, 3, 8] {
+		// The larger case drives many fused rounds (the borrowed columns become owned after the
+		// first fold, so every later round takes the fused deferred pass); the direct multi-chunk
+		// coverage lives in `mle_store`'s `test_fused_fold_matches_eager_reference`.
+		for n_vars in [1, 2, 3, 8, 14] {
 			let mut rng = StdRng::seed_from_u64(0);
 			let (cols, eval_point, claims) = frac_instance(&mut rng, n_vars);
 


### PR DESCRIPTION
Step 2 of [BINIUS-202](https://linear.app/jimpo/issue/BINIUS-202/rearchitect-sumcheck-proving-for-shared-multilinears) (Option A): flips the sumcheck `MleStore` from **eager** to **deferred** column folding, fusing the fold into the next round's read pass — behind the unchanged `SumcheckProver` trait, invisible to adapters and the verifier.

Resolves [BINIUS-217](https://linear.app/jimpo/issue/BINIUS-217/deferred-fold-fused-execute-in-the-sumcheck-mlestore).

## What changed

- `MleStore::fold(r)` no longer touches column data: it records the challenge in a new `pending_fold` field and advances the logical variable count (and the small eq trackers). The physical buffers stay put.
- `MleStore::fused_execute` folds each column's four segments in place — writing the folded low/high halves back — and immediately feeds those still-cache-hot halves to the round evaluators, doing the fold and the accumulation read in **one memory pass** (~1.5× the column length of traffic instead of a plain read's 1× plus a separate fold's ~1.5×). Safe Rust: `split_at_mut` carves each column's front half into the low/high write regions, then rayon owns disjoint per-chunk sub-slices (a small `ChunkTask` transpose).
- `RoundEvaluator::execute` takes the fused path when a fold is pending, chunks are whole-packed, and no column is borrowed; it falls back to the eager path (`apply_pending_fold` + plain read) for the first round, sub-packing-width tiny rounds, and the test-only borrowed columns whose first fold is out of place. `finish` applies the last pending fold before emitting evals.

Fusing only reorders the associative GF(2ᵏ) additions, so every path produces **byte-identical** round polynomials, challenges, and emitted evals.

## Correctness

The BINIUS-216 differential equivalence tests pass byte-identical (round polys, challenges, evals). Full `binius-ip-prover` suite (59 lib tests) + `binius-iop-prover` + logup/fracaddcheck production tests pass, under both the default single-threaded shim and `--features rayon` (real parallel fused pass). Clippy (`--all --tests --benches --examples -D warnings`) and nightly fmt clean.

## Performance

Measured branch vs. baseline `main`, `--release` with `RUSTFLAGS="-C target-cpu=native"`, `--features rayon`:

| Benchmark | n_vars=12 | n_vars=16 | n_vars=20 |
|---|---|---|---|
| `fracaddcheck/prove` | 2.30× | 1.72× | 1.22× |
| `bivariate_product` shared-sumcheck store micro-bench | 6.4× | 1.75× | 1.10× |

Large sizes converge toward the steady-state memory-traffic ratio (2.5·len → 1.5·len ≈ 1.67×, diluted by evaluator arithmetic and dedup across sharers); small sizes win extra from one fused parallel dispatch per round instead of two.

## Note: eq-tracker folding stays eager

The issue framed `fold(r)` as strictly O(1). The **column** (big-data) fold is deferred and fused as specified; the **eq trackers** still fold eagerly inside `fold()`, since they're small relative to the columns and are read by evaluators before the columns are folded. So `fold()` is O(eq-expansion-size), not literally O(1). Happy to fuse the eq fold too if you'd prefer strict O(1) — it's a small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)