### PR TITLE
perf(circuits): reduce AND in bignum modular add and is_zero

### DIFF
--- a/crates/circuits/src/bignum/addsub.rs
+++ b/crates/circuits/src/bignum/addsub.rs
@@ -72,6 +72,27 @@ pub fn add_with_carry_out(builder: &CircuitBuilder, a: &BigUint, b: &BigUint) ->
 /// # Panics
 /// - Panics if `a` and `b` have different number of limbs
 pub fn sub(builder: &CircuitBuilder, a: &BigUint, b: &BigUint) -> BigUint {
+	let zero = builder.add_constant(Word::ZERO);
+	let (diff, borrow_out) = sub_with_borrow_out(builder, a, b);
+
+	// Assert the final borrow is zero (i.e no underflow).
+	//
+	// It requires checking the MSB of the `borrow_out`
+	let borrow_out_msb = builder.shr(borrow_out, 63);
+	builder.assert_eq("sub_borrow_out", borrow_out_msb, zero);
+
+	diff
+}
+
+/// Subtracts two equally-sized `BigUint`s modulo `2^(64 * limbs)`, returning the final borrow.
+///
+/// Unlike [`sub`], underflow is not rejected: the difference wraps and the returned wire
+/// carries the borrow out of the most significant limb in its MSB.
+pub(super) fn sub_with_borrow_out(
+	builder: &CircuitBuilder,
+	a: &BigUint,
+	b: &BigUint,
+) -> (BigUint, Wire) {
 	assert_eq!(a.limbs.len(), b.limbs.len(), "sub: inputs must have the same number of limbs");
 
 	let zero = builder.add_constant(Word::ZERO);
@@ -86,13 +107,7 @@ pub fn sub(builder: &CircuitBuilder, a: &BigUint, b: &BigUint) -> BigUint {
 		borrow_in = borrow_out;
 	}
 
-	// Assert the final borrow is zero (i.e no underflow).
-	//
-	// It requires checking the MSB of the `borrow_in`
-	let borrow_out_msb = builder.shr(borrow_in, 63);
-	builder.assert_eq("sub_borrow_out", borrow_out_msb, zero);
-
-	BigUint { limbs: diff_limbs }
+	(BigUint { limbs: diff_limbs }, borrow_in)
 }
 
 /// Computes multi-operand addition with carry propagation across limb positions.

--- a/crates/circuits/src/bignum/biguint.rs
+++ b/crates/circuits/src/bignum/biguint.rs
@@ -49,14 +49,18 @@ impl BigUint {
 
 	/// Checks whether BigUint is zero and returns the check result as a boolean wire.
 	pub fn is_zero(&self, b: &CircuitBuilder) -> Wire {
-		// TODO: it's more efficient to add all-1 BigUint and check carry out (jimpo)
-		//       do this once BigUint addition returning a Wire carry out exists
+		// A BigUint is zero exactly when the bitwise OR of its limbs is zero, so one
+		// comparison suffices. Comparing each limb and folding the booleans costs an
+		// `icmp_eq` and a `band` per limb; folding with `bor` and comparing once costs
+		// a `bor` per limb after the first, plus a single `icmp_eq`.
 		let zero = b.add_constant(Word::ZERO);
-		let msb_one = b.add_constant(Word::MSB_ONE);
-		self.limbs
+		let any_bit = self
+			.limbs
 			.iter()
-			.map(|&limb| b.icmp_eq(limb, zero))
-			.fold(msb_one, |lhs, rhs| b.band(lhs, rhs))
+			.copied()
+			.reduce(|lhs, rhs| b.bor(lhs, rhs))
+			.unwrap_or(zero);
+		b.icmp_eq(any_bit, zero)
 	}
 
 	/// Pads to given limb length with zeros.

--- a/crates/circuits/src/bignum/biguint.rs
+++ b/crates/circuits/src/bignum/biguint.rs
@@ -49,10 +49,6 @@ impl BigUint {
 
 	/// Checks whether BigUint is zero and returns the check result as a boolean wire.
 	pub fn is_zero(&self, b: &CircuitBuilder) -> Wire {
-		// A BigUint is zero exactly when the bitwise OR of its limbs is zero, so one
-		// comparison suffices. Comparing each limb and folding the booleans costs an
-		// `icmp_eq` and a `band` per limb; folding with `bor` and comparing once costs
-		// a `bor` per limb after the first, plus a single `icmp_eq`.
 		let zero = b.add_constant(Word::ZERO);
 		let any_bit = self
 			.limbs

--- a/crates/circuits/src/bignum/prime_field.rs
+++ b/crates/circuits/src/bignum/prime_field.rs
@@ -4,7 +4,8 @@ use binius_core::word::Word;
 use binius_frontend::{CircuitBuilder, Wire, util::num_biguint_from_u64_limbs};
 
 use super::{
-	BigUint, BigUintDivideHint, ModDivideHint, ModInverseHint, PseudoMersenneModReduce, add,
+	BigUint, BigUintDivideHint, ModDivideHint, ModInverseHint, PseudoMersenneModReduce,
+	addsub::{add_with_carry_out, sub_with_borrow_out},
 	biguint_lt, sub, textbook_mul, textbook_square,
 };
 
@@ -54,27 +55,22 @@ impl PseudoMersennePrimeField {
 		let l = self.limbs_len();
 		assert!(fe1.limbs.len() == l && fe2.limbs.len() == l);
 
-		let zero = b.add_constant(Word::ZERO);
+		// Both inputs are reduced, so the sum is below `2 * modulus` and the overflow past
+		// the top limb is a single bit. Carrying it in a wire avoids widening every limbwise
+		// operation below by an extra limb.
+		let (sum, carry) = add_with_carry_out(b, fe1, fe2);
 
-		// May need an extra limb to accommodate overflow.
-		let extra_limbs = if self.modulus_po2 + 1 > l * Word::BITS {
-			1
-		} else {
-			0
-		};
-
-		let fe1 = fe1.pad_limbs_to(l + extra_limbs, zero);
-		let fe2 = fe2.pad_limbs_to(l + extra_limbs, zero);
-		let modulus = self.modulus.pad_limbs_to(l + extra_limbs, zero);
-
-		let unreduced_sum = add(b, &fe1, &fe2);
+		// A carry means the sum reached `2^(64 * l)`, which is above the modulus, so the
+		// comparison only matters when no carry occurred.
 		// TODO: consider nondeterminism
-		let need_reduction = b.bnot(biguint_lt(b, &unreduced_sum, &modulus));
-		let reduced = sub(b, &unreduced_sum, &modulus.zero_unless(b, need_reduction));
+		let need_reduction = b.bor(carry, b.bnot(biguint_lt(b, &sum, &self.modulus)));
 
-		// Higher limb is zero if max(fe1, fe2) < modulus (both are correctly represented)
-		let (result, _) = reduced.split_at_limbs(l);
-		result
+		// Wrapping subtraction is exact here: without a carry the difference is non-negative,
+		// and with one it borrows out by exactly the `2^(64 * l)` the carry stands for.
+		let (reduced, _borrow) =
+			sub_with_borrow_out(b, &sum, &self.modulus.zero_unless(b, need_reduction));
+
+		reduced
 	}
 
 	/// Field subtraction.

--- a/crates/examples/snapshots/bitcoin_p2pkh.snap
+++ b/crates/examples/snapshots/bitcoin_p2pkh.snap
@@ -1,28 +1,28 @@
 bitcoin_p2pkh circuit
 --
 Gates & Instructions
-├─ Number of gates: 162,929
-└─ Number of evaluation instructions: 196,108
+├─ Number of gates: 150,957
+└─ Number of evaluation instructions: 178,391
 
 Constraints
-├─ AND constraints: 125,578 used (95.8% of 2^17)
-│  [▓▓▓▓▓▓▓▓▓░] spare: 5,494
+├─ AND constraints: 114,942 used (87.7% of 2^17)
+│  [▓▓▓▓▓▓▓▓░░] spare: 16,130
 ├─ MUL constraints: 15,186 used (92.7% of 2^14)
 │  [▓▓▓▓▓▓▓▓▓░] spare: 1,198
-└─ Distinct value indices: 286,585
-   ├─ Distinct shifted value indices: 139,961
-   └─ Distinct unshifted value indices: 146,624
+└─ Distinct value indices: 265,588
+   ├─ Distinct shifted value indices: 128,251
+   └─ Distinct unshifted value indices: 137,337
 
 Value Vector
 ├─ Public Section: 135 used (52.7% of 2^8)
 │  [▓▓▓▓▓░░░░░] spare: 121
 │  ├─ Constants: 135
 │  └─ Inout: 0
-├─ Private Section: 146,500 used (55.9%)
-│  [▓▓▓▓▓░░░░░] spare: 115,388
+├─ Private Section: 137,213 used (52.4%)
+│  [▓▓▓▓▓░░░░░] spare: 124,675
 │  ├─ Witness: 9
-│  └─ Internal: 146,491
-├─ Total Committed: 146,635 used (55.9% of 2^18)
-│  [▓▓▓▓▓░░░░░] spare: 115,509
-└─ Scratch (uncommitted): 153,592
+│  └─ Internal: 137,204
+├─ Total Committed: 137,348 used (52.4% of 2^18)
+│  [▓▓▓▓▓░░░░░] spare: 124,796
+└─ Scratch (uncommitted): 140,254
 

--- a/crates/examples/snapshots/ec_msm.snap
+++ b/crates/examples/snapshots/ec_msm.snap
@@ -1,28 +1,28 @@
 ec_msm circuit
 --
 Gates & Instructions
-├─ Number of gates: 225,434
-└─ Number of evaluation instructions: 270,938
+├─ Number of gates: 208,914
+└─ Number of evaluation instructions: 246,270
 
 Constraints
-├─ AND constraints: 174,769 used (66.7% of 2^18)
-│  [▓▓▓▓▓▓░░░░] spare: 87,375
+├─ AND constraints: 160,097 used (61.1% of 2^18)
+│  [▓▓▓▓▓▓░░░░] spare: 102,047
 ├─ MUL constraints: 20,548 used (62.7% of 2^15)
 │  [▓▓▓▓▓▓░░░░] spare: 12,220
-└─ Distinct value indices: 390,322
-   ├─ Distinct shifted value indices: 187,313
-   └─ Distinct unshifted value indices: 203,009
+└─ Distinct value indices: 361,410
+   ├─ Distinct shifted value indices: 171,232
+   └─ Distinct unshifted value indices: 190,178
 
 Value Vector
 ├─ Public Section: 52 used (81.2% of 2^6)
 │  [▓▓▓▓▓▓▓▓░░] spare: 12
 │  ├─ Constants: 20
 │  └─ Inout: 32
-├─ Private Section: 202,962 used (77.4%)
-│  [▓▓▓▓▓▓▓░░░] spare: 59,118
+├─ Private Section: 190,131 used (72.5%)
+│  [▓▓▓▓▓▓▓░░░] spare: 71,949
 │  ├─ Witness: 0
-│  └─ Internal: 202,962
-├─ Total Committed: 203,014 used (77.4% of 2^18)
-│  [▓▓▓▓▓▓▓░░░] spare: 59,130
-└─ Scratch (uncommitted): 207,906
+│  └─ Internal: 190,131
+├─ Total Committed: 190,183 used (72.5% of 2^18)
+│  [▓▓▓▓▓▓▓░░░] spare: 71,961
+└─ Scratch (uncommitted): 189,223
 

--- a/crates/examples/snapshots/ethsign.snap
+++ b/crates/examples/snapshots/ethsign.snap
@@ -1,28 +1,28 @@
 ethsign circuit
 --
 Gates & Instructions
-├─ Number of gates: 231,747
-└─ Number of evaluation instructions: 277,447
+├─ Number of gates: 215,211
+└─ Number of evaluation instructions: 252,748
 
 Constraints
-├─ AND constraints: 176,819 used (67.5% of 2^18)
-│  [▓▓▓▓▓▓░░░░] spare: 85,325
+├─ AND constraints: 162,132 used (61.8% of 2^18)
+│  [▓▓▓▓▓▓░░░░] spare: 100,012
 ├─ MUL constraints: 20,554 used (62.7% of 2^15)
 │  [▓▓▓▓▓▓░░░░] spare: 12,214
-└─ Distinct value indices: 396,181
-   ├─ Distinct shifted value indices: 191,069
-   └─ Distinct unshifted value indices: 205,112
+└─ Distinct value indices: 367,241
+   ├─ Distinct shifted value indices: 174,974
+   └─ Distinct unshifted value indices: 192,267
 
 Value Vector
 ├─ Public Section: 119 used (93.0% of 2^7)
 │  [▓▓▓▓▓▓▓▓▓░] spare: 9
 │  ├─ Constants: 90
 │  └─ Inout: 29
-├─ Private Section: 205,003 used (78.2%)
-│  [▓▓▓▓▓▓▓░░░] spare: 57,013
+├─ Private Section: 192,158 used (73.3%)
+│  [▓▓▓▓▓▓▓░░░] spare: 69,858
 │  ├─ Witness: 42
-│  └─ Internal: 204,961
-├─ Total Committed: 205,122 used (78.2% of 2^18)
-│  [▓▓▓▓▓▓▓░░░] spare: 57,022
-└─ Scratch (uncommitted): 212,427
+│  └─ Internal: 192,116
+├─ Total Committed: 192,277 used (73.3% of 2^18)
+│  [▓▓▓▓▓▓▓░░░] spare: 69,867
+└─ Scratch (uncommitted): 193,718
 


### PR DESCRIPTION
## What

The secp256k1 field arithmetic that dominates the elliptic-curve example circuits (`ethsign`, `bitcoin_p2pkh`, `bip32`) spends AND constraints that two `bignum` primitives on that path do not need.

Root cause: `PseudoMersennePrimeField::add` widens both operands and the modulus by one limb to hold the single-bit overflow of a reduced-input sum, so `add`, `biguint_lt`, `zero_unless`, and the trailing `sub` all run a limb wider than the field requires. Independently, `BigUint::is_zero` compares each limb to zero with `icmp_eq` and folds the results with `band`, spending two AND per limb.

Fix: keep the overflow in a carry wire. `add_with_carry_out` already exists, so the sum stays `l` limbs and the carry feeds the reduction test `need = carry OR (sum >= modulus)`; the conditional reduction subtracts through a new crate-internal `sub_with_borrow_out`. `is_zero` ORs the limbs and compares once, costing `n` AND instead of `2n`, with the same MSB-boolean output every caller already relies on.

```text
is_zero(n limbs):  n icmp_eq + n band          ->  (n-1) bor + 1 icmp_eq   (2n -> n)
field add:         (l+1)-limb add / lt / sub    ->  l-limb add_with_carry_out + l-limb sub
```

## Numbers

Deterministic AND-constraint counts from the example circuits:

| circuit | baseline | this PR | delta |
|---|---|---|---|
| ethsign | 176,819 | 162,132 | -8.31% |
| bitcoin_p2pkh | 125,578 | 114,942 | -8.47% |
| bip32 | 768,541 | 704,760 | -8.30% |
| sha256 (no EC) | 8,880 | 8,880 | unchanged |

```
repro: cargo run --release --example ethsign -- stat
```

These are constraint counts, not prover wall-clock. binius64 pads AND constraints to a power of two and each circuit above stays in the same `2^k` bucket, so the effect is a lower constraint count and witness size (`ethsign` committed witness 205,003 -> 192,158), the same category as #1686, not a change in proving time.

The `is_zero` TODO suggested adding an all-ones `BigUint` and reading the carry out once a carry-returning add existed. That precondition now holds, but the add-all-ones route measures 8 AND at four limbs (identical to the original) while the OR-fold is 4, so this resolves the TODO by the cheaper path.

## Correctness

- Inputs to field `add` are reduced, so the sum is below `2 * modulus` and the overflow past the top limb is exactly one bit. `need = carry OR (sum >= modulus)` is exact because a carry already implies the sum exceeds the modulus, and the wrapping subtraction borrows out by exactly the `2^(64*l)` the carry represents, so `borrow_out == carry` in every reachable case. The two now-redundant assertions drop out: the old extra-limb overflow assert was always true for reduced inputs, and the underflow assert is now the expected wraparound.
- `is_zero`: a `BigUint` is zero iff the bitwise OR of its limbs is zero. The result is the same MSB-boolean, and all callers (`ecdsa`, `secp256k1` point add and double) read only the MSB.
- 345 `binius-circuits` tests pass, including the field and ECDSA property and test-vector suites. `ethsign`, `bitcoin_p2pkh`, and `bip32` prove and verify end to end. `clippy --all-targets -D warnings` and `fmt` are clean.
- Snapshots re-blessed: `ethsign`, `bitcoin_p2pkh`, `ec_msm`.

## Scope

- Only the `bignum` primitives change; public signatures are unchanged (`sub_with_borrow_out` is `pub(super)`).
- `biguint_eq` uses the same per-limb `icmp_eq` and `band` fold and reduces the same way, but it has a single call site, so it is left for a follow-up.
