### PR TITLE
BINIUS-286: use the OracleSetupChannel to determine M4 oracle specs

### DIFF
--- a/crates/m4-prover/tests/prove_hash_primitives.rs
+++ b/crates/m4-prover/tests/prove_hash_primitives.rs
@@ -221,6 +221,37 @@ fn fill_keccak(
 	}
 }
 
+/// Builds a circuit for one 64×64→128-bit integer multiplication and force-commits its output.
+///
+/// Unlike the hash primitives (which are purely bitwise / carry-adder based), this circuit has MUL
+/// constraints, so its M4 proof commits the extra IntMul logup* pushforward oracle — exercising the
+/// MUL branch of `IOPVerifier::oracle_specs`.
+fn build_imul_circuit() -> (Circuit, [Wire; 2]) {
+	let builder = CircuitBuilder::new();
+
+	// Two 64-bit witness factors.
+	let a = builder.add_witness();
+	let b = builder.add_witness();
+
+	// Force-commit the 128-bit product halves so the multiplication survives dead-code elimination.
+	let (hi, lo) = builder.imul(a, b);
+	builder.force_commit(hi);
+	builder.force_commit(lo);
+
+	(builder.build(), [a, b])
+}
+
+/// Fills the multiplication instance's two factor wires with random 64-bit words.
+///
+/// The product is derived from these inputs, so any assignment is valid.
+fn fill_imul(inputs: &[Wire; 2], _instance: usize, w: &mut BatchWitnessFiller<'_, '_>) {
+	let mut rng = StdRng::seed_from_u64(0);
+
+	for &wire in inputs {
+		w[wire] = Word(rng.next_u64());
+	}
+}
+
 // Proves one BLAKE3 compression through M4 and verifies it.
 #[test]
 fn prove_blake3_compression() {
@@ -233,4 +264,15 @@ fn prove_blake3_compression() {
 fn prove_keccak_permutation() {
 	let (circuit, input) = build_keccak_circuit();
 	prove_once("keccak", &circuit, |instance, w| fill_keccak(&input, instance, w));
+}
+
+// Proves one 64×64→128-bit multiplication through M4 and verifies it.
+//
+// This is the only primitive here with MUL constraints, so it covers the IntMul pushforward oracle
+// spec that `IOPVerifier::oracle_specs` derives — a wrong spec list would make the shared
+// prover/verifier compiler disagree and fail the trace opening.
+#[test]
+fn prove_integer_multiplication() {
+	let (circuit, inputs) = build_imul_circuit();
+	prove_once("imul", &circuit, |instance, w| fill_imul(&inputs, instance, w));
 }

--- a/crates/m4-verifier/src/verify.rs
+++ b/crates/m4-verifier/src/verify.rs
@@ -9,6 +9,7 @@ use binius_iop::{
 	channel::{IOPVerifierChannel, OracleLinearRelation, OracleSpec},
 	fri::{ConstantArityStrategy, calculate_n_test_queries},
 	merkle_tree::BinaryMerkleTreeScheme,
+	oracle_setup_channel::OracleSetupChannel,
 };
 use binius_ip::{
 	channel::IPVerifierChannel,
@@ -27,7 +28,7 @@ use binius_verifier::{
 	config::{B1, B128},
 	protocols::{
 		bitand::AndCheckOutput,
-		intmul::{IntMulOutput, common::LIMB_BITS, verify as verify_intmul_reduction},
+		intmul::{IntMulOutput, verify as verify_intmul_reduction},
 		shift::{self, BITAND_ARITY, INTMUL_ARITY, OperatorData},
 	},
 	ring_switch::{self, RingSwitchVerifyOutput},
@@ -91,6 +92,24 @@ impl IOPVerifier {
 	/// Consumes the IOP verifier and returns the inner constraint system.
 	pub fn into_constraint_system(self) -> ConstraintSystem {
 		self.cs
+	}
+
+	/// Returns the oracle specs the prover commits to: the trace, plus the IntMul logup*
+	/// pushforward when the circuit has MUL constraints.
+	///
+	/// The specs are derived by replaying the oracle-receiving sequence against an
+	/// [`OracleSetupChannel`] — which records each `recv_oracle` without doing real verification —
+	/// rather than hand-maintaining the list. M4 commits its oracles without zero-knowledge, so the
+	/// setup channel is constructed with `is_zk = false`.
+	pub fn oracle_specs(&self) -> Vec<OracleSpec> {
+		let mut channel = OracleSetupChannel::new(false);
+		// The setup channel performs no real verification — every `recv_*` / `sample` /
+		// `assert_zero` is a no-op — so `verify` cannot fail here; it only records the
+		// `recv_oracle` calls read back below. An error would mean that invariant broke, so
+		// surface it rather than swallowing it.
+		self.verify(&mut channel)
+			.expect("verifying against the no-op OracleSetupChannel cannot fail");
+		channel.into_oracle_specs()
 	}
 
 	/// Verifies one M4 proof using an IOP channel.
@@ -250,19 +269,11 @@ impl Verifier {
 		let layout = BatchCommitLayout::for_constraint_system(cs, log_instances);
 		let iop_verifier = IOPVerifier::new(cs.clone(), layout);
 
-		// The packed batch witness, committed without zero-knowledge.
-		// ZK-ness is a higher-level choice that M4 does not make here.
-		let mut oracle_specs = vec![OracleSpec::new(layout.log_witness_elems)];
-
-		// With MUL constraints the IntMul check commits one further oracle: its logup* pushforward.
-		// The pushforward spans the generator-power table, so its size is fixed by the table alone.
-		// It is independent of the instance and constraint counts.
-		// It is committed after the trace, so it follows the trace in the spec order.
-		// This spec must stay in sync with the oracle the IntMul check commits
-		// (`logup_star::verify` receives one oracle of `LIMB_BITS` variables).
-		if !cs.mul_constraints.is_empty() {
-			oracle_specs.push(OracleSpec::new(LIMB_BITS));
-		}
+		// The oracle specs the prover commits to — the trace, plus the IntMul logup* pushforward
+		// when the circuit has MUL constraints. Derived by replaying the verifier's
+		// oracle-receiving sequence against an `OracleSetupChannel`, so the list can never drift
+		// out of sync with the oracles the checks actually commit.
+		let oracle_specs = iop_verifier.oracle_specs();
 
 		// Pick the proof-size-optimal FRI fold arity for this codeword length.
 		let log_code_len = layout.log_witness_elems + log_inv_rate;


### PR DESCRIPTION
Resolves [BINIUS-286](https://linear.app/jimpo/issue/BINIUS-286/use-the-oraclesetupchannel-to-determine-oracle-specs-for-m4).

The M4 verifier hand-maintained its oracle-spec list, with a comment warning it "must stay in sync with the oracle the IntMul check commits." This replaces that with a dry run against `OracleSetupChannel`, exactly as `binius_prover::Verifier` (`IOPVerifier::oracle_specs`) already does — so the list can never drift out of sync with what the checks actually commit.

## What changed

- **`crates/m4-verifier/src/verify.rs`** — added `IOPVerifier::oracle_specs(&amp;self) -&gt; Vec&lt;OracleSpec&gt;`: it drives `self.verify` against an `OracleSetupChannel` (which records each `recv_oracle` and no-ops everything else), then returns `channel.into_oracle_specs()`. `Verifier::setup` now calls it instead of building `vec![OracleSpec::new(log_witness_elems), (mul?) OracleSpec::new(LIMB_BITS)]` by hand. Dropped the now-unused `LIMB_BITS` import.

Simpler than the spartan reference: M4's `IOPVerifier::verify` receives its trace oracle internally (no precommit-oracle argument to pre-record) and takes no public-inputs vector, and M4 commits without zero-knowledge, so the setup channel is `OracleSetupChannel::new(false)`.

## Correctness / tests

The derived specs must match what the prover commits, since `Prover::setup(&amp;verifier)` builds the shared FRI compiler from them — a wrong list makes the trace opening fail. The existing `prove_hash_primitives` tests (BLAKE3, Keccak) cover the trace-only branch, but both are MUL-free (`iadd_32` carry adders, not `imul`). I added **`prove_integer_multiplication`** — a minimal `imul` circuit — which is the one primitive here with MUL constraints, so it exercises the IntMul logup* pushforward-oracle branch end-to-end. All three prove/verify.

`cargo check --workspace --tests --benches` clean; `binius-m4-verifier` / `binius-m4-prover` suites pass; clippy (`--tests --benches -D warnings`) and nightly fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)