### PR TITLE
BINIUS-289: replace the Keccak256 struct with keccak256_varlen

### DIFF
--- a/crates/circuits/src/keccak/fixed_length.rs
+++ b/crates/circuits/src/keccak/fixed_length.rs
@@ -4,7 +4,7 @@ use binius_core::word::Word;
 use binius_frontend::{CircuitBuilder, Wire};
 
 use super::{
-	N_WORDS_PER_BLOCK, N_WORDS_PER_DIGEST, N_WORDS_PER_STATE, RATE_BYTES, permutation::Permutation,
+	N_WORDS_PER_BLOCK, N_WORDS_PER_DIGEST, N_WORDS_PER_STATE, RATE_BYTES, permutation::keccak_f1600,
 };
 
 /// Computes the Keccak-256 hash of a fixed-length message.
@@ -107,7 +107,7 @@ pub fn keccak256(
 		}
 
 		// Apply Keccak-f[1600] permutation
-		Permutation::keccak_f1600(builder, &mut state);
+		keccak_f1600(builder, &mut state);
 	}
 
 	// Return the first 4 words (256 bits) of the state as the digest

--- a/crates/circuits/src/keccak/mod.rs
+++ b/crates/circuits/src/keccak/mod.rs
@@ -5,7 +5,7 @@ pub mod permutation;
 
 use binius_core::word::Word;
 use binius_frontend::{CircuitBuilder, Wire};
-use permutation::Permutation;
+use permutation::keccak_f1600;
 
 use crate::{
 	fixed_byte_vec::ByteVec,
@@ -26,7 +26,7 @@ pub const N_WORDS_PER_BLOCK: usize = RATE_BYTES / 8;
 /// Keccak is a sponge: the message is `pad10*1`-padded (the `0x01` domain byte immediately after
 /// the message, then zeros, with `0x80` set in the final byte of the last rate block), split into
 /// 136-byte (17-word) blocks that are XORed into the 1600-bit state and permuted by
-/// [`Permutation::keccak_f1600`]. Each padded word is *computed* as a derived wire, classified by
+/// [`keccak_f1600`]. Each padded word is *computed* as a derived wire, classified by
 /// its position relative to the runtime boundary word `w_bd = len_bytes >> 3`:
 ///
 ///   1. `word_index <  w_bd` - pure message word,
@@ -148,7 +148,7 @@ pub fn keccak256_varlen(builder: &CircuitBuilder, message: &ByteVec) -> [Wire; N
 		for i in 0..N_WORDS_PER_BLOCK {
 			state[i] = builder.bxor(state[i], padded_message[block_no * N_WORDS_PER_BLOCK + i]);
 		}
-		Permutation::keccak_f1600(builder, &mut state);
+		keccak_f1600(builder, &mut state);
 		states.push(state);
 	}
 

--- a/crates/circuits/src/keccak/mod.rs
+++ b/crates/circuits/src/keccak/mod.rs
@@ -4,310 +4,214 @@ pub mod fixed_length;
 pub mod permutation;
 
 use binius_core::word::Word;
-use binius_frontend::{CircuitBuilder, Wire, WitnessFiller};
+use binius_frontend::{CircuitBuilder, Wire};
 use permutation::Permutation;
 
-use crate::multiplexer::{multi_wire_multiplex, single_wire_multiplex};
+use crate::{
+	fixed_byte_vec::ByteVec,
+	multiplexer::{multi_wire_multiplex, single_wire_multiplex},
+};
 
 pub const N_WORDS_PER_DIGEST: usize = 4;
 pub const N_WORDS_PER_STATE: usize = 25;
 pub const RATE_BYTES: usize = 136;
 pub const N_WORDS_PER_BLOCK: usize = RATE_BYTES / 8;
 
-/// Keccak-256 circuit that can handle variable-length inputs up to a specified maximum length.
+/// Computes the Keccak-256 hash of a variable-length message.
+///
+/// This gadget consumes a [`ByteVec`] whose actual length is runtime-determined and returns the
+/// 256-bit digest as 4 wires (little-endian 64-bit words), matching
+/// [`fixed_length::keccak256`]'s output layout.
+///
+/// Keccak is a sponge: the message is `pad10*1`-padded (the `0x01` domain byte immediately after
+/// the message, then zeros, with `0x80` set in the final byte of the last rate block), split into
+/// 136-byte (17-word) blocks that are XORed into the 1600-bit state and permuted by
+/// [`Permutation::keccak_f1600`]. Each padded word is *computed* as a derived wire, classified by
+/// its position relative to the runtime boundary word `w_bd = len_bytes >> 3`:
+///
+///   1. `word_index <  w_bd` - pure message word,
+///   2. `word_index == w_bd` - boundary word (trailing message bytes mixed with the `0x01`
+///      delimiter, plus `0x80` when it is also the last word of the final block),
+///   3. `word_index >  w_bd` - padding (zero, except the final block's last word, which carries the
+///      `0x80` delimiter).
+///
+/// The digest is the first four state words after the block that contains the padding, selected
+/// via a multiplexer indexed by the runtime length. Because the padded words are derived (not
+/// witnessed), no padding-correctness constraints are needed.
+///
+/// Both [`ByteVec`] and Keccak pack bytes little-endian, so — unlike
+/// [`crate::sha512::sha512_varlen`] — no byte swap is needed.
 ///
 /// # Arguments
+/// * `builder` - Circuit builder
+/// * `message` - Input message as a [`ByteVec`]; its `len_bytes` wire holds the actual length.
 ///
-/// * `len_bytes` - A wire representing the input message length in bytes
-/// * `digest` - Array of 4 wires representing the 256-bit output digest
-/// * `message` - Vector of wires representing the input message
-pub struct Keccak256 {
-	pub len_bytes: Wire,
-	pub digest: [Wire; N_WORDS_PER_DIGEST],
-	pub message: Vec<Wire>,
-	padded_message: Vec<Wire>,
-	n_blocks: usize,
-}
+/// # Returns
+/// * `[Wire; 4]` - The Keccak-256 digest as 4 little-endian 64-bit words.
+pub fn keccak256_varlen(builder: &CircuitBuilder, message: &ByteVec) -> [Wire; N_WORDS_PER_DIGEST] {
+	let len_bytes = message.len_bytes;
+	let data = &message.data;
 
-impl Keccak256 {
-	/// Returns the padded-message witness wires (filled by [`Self::populate_message`]).
-	pub fn padded_message(&self) -> &[Wire] {
-		&self.padded_message
-	}
+	let max_len_bytes = data.len() << 3;
+	// A message that exactly fills its blocks still needs one more block for the padding, hence +1.
+	let n_blocks = (max_len_bytes + 1).div_ceil(RATE_BYTES);
+	let n_words = n_blocks * N_WORDS_PER_BLOCK;
 
-	/// Create a new keccak circuit using the circuit builder
-	///
-	/// # Arguments
-	///
-	/// * `builder` - circuit builder object
-	/// * `max_len` - max message length in bytes for this circuit instance
-	/// * `len` - wire representing the claimed input message length in bytes
-	/// * `digest` - array of 4 wires representing the claimed 256-bit output digest
-	/// * `message` - vector of wires representing the claimed input message
-	///
-	/// ## Preconditions
-	/// * max_len > 0
-	pub fn new(
-		b: &CircuitBuilder,
-		len_bytes: Wire,
-		digest: [Wire; N_WORDS_PER_DIGEST],
-		message: Vec<Wire>,
-	) -> Self {
-		let max_len_bytes = message.len() << 3;
-		// number of blocks needed for the maximum sized message
-		let n_blocks = (max_len_bytes + 1).div_ceil(RATE_BYTES);
+	// Constrain the claimed length to lie within capacity.
+	let too_long = builder.icmp_ugt(len_bytes, builder.add_constant_64(max_len_bytes as u64));
+	builder.assert_false("len_check", too_long);
 
-		// constrain the message length claim to be explicitly within bounds
-		let len_check = b.icmp_ugt(len_bytes, b.add_constant_64(max_len_bytes as u64)); // len_bytes > max_len_bytes
-		b.assert_false("len_check", len_check);
+	let zero = builder.add_constant(Word::ZERO);
+	let msb_one = builder.add_constant(Word::MSB_ONE);
 
-		let padded_message: Vec<Wire> = (0..n_blocks * N_WORDS_PER_BLOCK)
-			.map(|_| b.add_witness())
-			.collect();
+	// `w_bd` is the word holding the first padding byte (`0x01`); `len_mod_8` is its byte offset
+	// within that word.
+	let w_bd = builder.shr(len_bytes, 3);
+	let len_mod_8 = builder.band(len_bytes, builder.add_constant_64(7));
 
-		// zero initialized keccak state
-		let mut states: Vec<[Wire; N_WORDS_PER_STATE]> = Vec::with_capacity(n_blocks + 1);
-		let zero = b.add_constant(Word::ZERO);
-		states.push([zero; N_WORDS_PER_STATE]);
-
-		// xor next message block into state and permute
-		for block_no in 0..n_blocks {
-			let state_in = states[block_no];
-			let mut xored_state = state_in;
-			for i in 0..N_WORDS_PER_BLOCK {
-				xored_state[i] =
-					b.bxor(state_in[i], padded_message[block_no * N_WORDS_PER_BLOCK + i]);
-			}
-
-			Permutation::keccak_f1600(b, &mut xored_state);
-
-			states.push(xored_state);
-		}
-
-		// begin "constrain claimed digest".
-		// want to do: `let block_index = (len_bytes + 1).divceil(136)`.
-		// royal pain in the ass that 136 is not a power of 2, so we can't compute this in circuit
-		// still though, i believe that there might be tricks better than what we're doing below.
-		let mut end_block_index = b.add_constant(Word::ZERO);
-		let mut is_not_last_column = b.add_constant(Word::ZERO);
-		// `is_not_last_column` will be true if and only if `len_bytes >> 3` != 16 (mod 17).
-		// true iff the WORD w/ the very first post-message byte is NOT the last word in its block.
-		for block_no in 0..n_blocks {
-			// start of this block
-			let block_start = b.add_constant_64((block_no * RATE_BYTES) as u64);
-			let block_end = b.add_constant_64(((block_no + 1) * RATE_BYTES) as u64);
-			let last_word_start = b.add_constant_64(((block_no + 1) * RATE_BYTES - 8) as u64);
-
-			let gte_start = b.icmp_ule(block_start, len_bytes);
-			let lt_end = b.icmp_ult(len_bytes, block_end);
-			let lt_last_word = b.icmp_ult(len_bytes, last_word_start);
-			let is_final_block = b.band(gte_start, lt_end);
-
-			// flag that this block is the final block per the claimed length
-			end_block_index =
-				b.select(is_final_block, b.add_constant_64(block_no as u64), end_block_index);
-			is_not_last_column = b.select(is_final_block, lt_last_word, is_not_last_column);
-		}
-
-		let inputs: Vec<&[Wire]> = states[1..].iter().map(|arr| &arr[..]).collect();
-		let computed_digest_vec = multi_wire_multiplex(b, &inputs, end_block_index);
-		let computed_digest = computed_digest_vec[..N_WORDS_PER_DIGEST]
-			.try_into()
-			.unwrap();
-		b.assert_eq_v("claimed digest is correct", digest, computed_digest);
-
-		// begin treatment of boundary word.
-		let word_boundary = b.shr(len_bytes, 3);
-		let boundary_word = single_wire_multiplex(b, &message, word_boundary);
-		let boundary_padded_word = single_wire_multiplex(b, &padded_message, word_boundary);
-		// When the last word of the message is not full, we expect a padding byte to be
-		// somewhere within the word. Since the top bit will also be in this word.
-		let candidates: Vec<Wire> = (0..8)
-			.map(|i| {
-				let mask = b.add_constant_64(0x00FFFFFFFFFFFFFF >> ((7 - i) << 3));
-				let padding_byte = b.add_constant_64(1 << (i << 3));
-				let message_low = b.band(boundary_word, mask);
-				b.bxor(message_low, padding_byte)
-			})
-			.collect();
-
-		let zero = b.add_constant(Word::ZERO);
-		let msb_one = b.add_constant(Word::MSB_ONE);
-		let len_bytes_mod_8 = b.band(len_bytes, b.add_constant_64(7));
-		let expected_partial = single_wire_multiplex(b, &candidates, len_bytes_mod_8);
-		let with_possible_end =
-			b.bxor(expected_partial, b.select(is_not_last_column, zero, msb_one));
-
-		b.assert_eq("expected partial", with_possible_end, boundary_padded_word);
-
-		// Within the final rate block, ensure that the pad byte and top bit are where they are
-		// supposed to be
-		for block_index in 0..n_blocks {
-			let is_end_block = b.icmp_eq(end_block_index, b.add_constant_64(block_index as u64));
-			for column_index in 0..N_WORDS_PER_BLOCK {
-				let word_index = block_index * N_WORDS_PER_BLOCK + column_index;
-
-				let padded_word = padded_message[word_index];
-
-				// a potentially padded word is at this index
-				let word_idx_wire = b.add_constant_64(word_index as u64);
-				if word_index < message.len() {
-					let message_word = message[word_index];
-					let is_before_end = b.icmp_ult(word_idx_wire, word_boundary);
-					b.assert_eq_cond("full", padded_word, message_word, is_before_end);
-				}
-
-				let is_past_message = b.icmp_ugt(word_idx_wire, word_boundary);
-
-				if column_index == 16 {
-					// last word in the block
-					let must_check_delimiter = b.band(is_end_block, is_not_last_column);
-					b.assert_eq_cond("delim", padded_word, msb_one, must_check_delimiter);
-					// the case we need to deal with: we're in end block but `is_not_last_column`.
-					// this means that the `boundary_message_word` is not the last word in its block
-					// then the presence of the 0x80 delimiter is NOT treated with the boundary word
-					// thus we must separately check that the ACTUAL last word in the block has it
-
-					// if `is_end_block` is true but NOT `is_not_last_column`, then we're fine.
-					// indeed: if `!is_not_last_column`, boundary message word IS in last column,
-					// so we already handled the validity of that word, and there is nothing to do.
-
-					// if NOT in end block, then again i claim there is nothing we need to check.
-					// if we're in the last column but strictly before the end block, then we're
-					// still in the message, by definition of `end_block`. indeed, the `0x80` byte
-					// happens in the soonest possible block after the message ends, and no later.
-					// thus we already checked the validity of this word above (a `message_word`).
-					// the other case is that we're strictly after the end block. in this case,
-					// we can just leave the `padded_word` completely unconstrained. after all,
-					// said word will have no effect on `digest` whatsoever, so we just leave it.
-				} else {
-					b.assert_eq_cond("after-message padding", padded_word, zero, is_past_message);
-					// we're strictly after the word w/ the 0x01 byte and not in the last column.
-					// there are two cases: either we're within the end block or strictly after it.
-					// if the former, we're after the boundary word but before the word w/ 0x80.
-					// in that case, we must for the sake of correctness assert that this word is 0.
-					// if strictly after the end block, this word will have no effect on `digest`;
-					// thus we're free to assert that it's 0, but it's not necessary for soundness.
-				}
-			}
-		}
-
-		Self {
-			len_bytes,
-			digest,
-			message,
-			padded_message,
-			n_blocks,
-		}
-	}
-
-	pub const fn max_len_bytes(&self) -> usize {
-		self.message.len() << 3
-	}
-
-	/// Populates the witness with the actual message length
-	///
-	/// ## Arguments
-	///
-	/// * w - The witness filler to populate
-	/// * len_bytes - The actual byte length of the message
-	pub fn populate_len_bytes(&self, w: &mut WitnessFiller<'_>, len_bytes: usize) {
-		assert!(
-			len_bytes <= self.max_len_bytes(),
-			"Message length {} exceeds maximum {}",
-			len_bytes,
-			self.max_len_bytes()
+	// `end_block_index` is the block that contains the padding (the block holding byte
+	// `len_bytes`). 136 is not a power of two, so this is found by a linear scan rather than a
+	// shift.
+	let mut end_block_index = zero;
+	for block_no in 0..n_blocks {
+		let block_start = builder.add_constant_64((block_no * RATE_BYTES) as u64);
+		let block_end = builder.add_constant_64(((block_no + 1) * RATE_BYTES) as u64);
+		let gte_start = builder.icmp_ule(block_start, len_bytes);
+		let lt_end = builder.icmp_ult(len_bytes, block_end);
+		let is_final_block = builder.band(gte_start, lt_end);
+		end_block_index = builder.select(
+			is_final_block,
+			builder.add_constant_64(block_no as u64),
+			end_block_index,
 		);
-		w[self.len_bytes] = Word(len_bytes as u64);
 	}
 
-	/// Populates the witness with the expected digest value packed into 4 64-bit words
-	///
-	/// ## Arguments
-	///
-	/// * w - The witness filler to populate
-	/// * digest - The expected 32-byte Keccak-256 digest
-	pub fn populate_digest(&self, w: &mut WitnessFiller<'_>, digest: [u8; 32]) {
-		for (i, bytes) in digest.chunks(8).enumerate() {
-			let word = u64::from_le_bytes(bytes.try_into().unwrap());
-			w[self.digest[i]] = Word(word);
+	// Boundary word: keep the `len_mod_8` low message bytes and place the `0x01` delimiter at byte
+	// `len_mod_8`. When `len_mod_8 == 0` the chosen candidate is `0x01` independent of the
+	// (possibly out-of-range) boundary message word.
+	let boundary_message_word = single_wire_multiplex(builder, data, w_bd);
+	let candidates: Vec<Wire> = (0..8)
+		.map(|i| {
+			let mask = builder.add_constant_64(0x00FFFFFFFFFFFFFF >> ((7 - i) << 3));
+			let delimiter = builder.add_constant_64(1u64 << (i << 3));
+			let message_low = builder.band(boundary_message_word, mask);
+			builder.bxor(message_low, delimiter)
+		})
+		.collect();
+	let boundary_word = single_wire_multiplex(builder, &candidates, len_mod_8);
+
+	// Compute every padded word as a derived wire, classified by position.
+	let padded_message: Vec<Wire> = (0..n_words)
+		.map(|word_index| {
+			let block_index = word_index / N_WORDS_PER_BLOCK;
+			let column_index = word_index % N_WORDS_PER_BLOCK;
+			let word_idx_wire = builder.add_constant_64(word_index as u64);
+
+			let is_message_word = builder.icmp_ult(word_idx_wire, w_bd);
+			let is_boundary_word = builder.icmp_eq(word_idx_wire, w_bd);
+			let is_end_block =
+				builder.icmp_eq(builder.add_constant_64(block_index as u64), end_block_index);
+
+			// Message words select the corresponding input word. Only ever chosen when
+			// `word_index < w_bd <= max_len_bytes >> 3 == data.len()`, so the index is in range and
+			// the zero fallback is never selected.
+			let msg_word = if word_index < data.len() {
+				data[word_index]
+			} else {
+				zero
+			};
+
+			// The final word of the final block carries the `0x80` delimiter — folded into the
+			// boundary word when the boundary is that word, and otherwise standing alone as a
+			// padding word.
+			let delimiter = if column_index == N_WORDS_PER_BLOCK - 1 {
+				builder.select(is_end_block, msb_one, zero)
+			} else {
+				zero
+			};
+			let boundary_val = if column_index == N_WORDS_PER_BLOCK - 1 {
+				builder.bxor(boundary_word, delimiter)
+			} else {
+				boundary_word
+			};
+
+			let boundary_or_padding = builder.select(is_boundary_word, boundary_val, delimiter);
+			builder.select(is_message_word, msg_word, boundary_or_padding)
+		})
+		.collect();
+
+	// Sponge: XOR each block into the state and permute.
+	let mut states: Vec<[Wire; N_WORDS_PER_STATE]> = Vec::with_capacity(n_blocks + 1);
+	states.push([zero; N_WORDS_PER_STATE]);
+	for block_no in 0..n_blocks {
+		let mut state = states[block_no];
+		for i in 0..N_WORDS_PER_BLOCK {
+			state[i] = builder.bxor(state[i], padded_message[block_no * N_WORDS_PER_BLOCK + i]);
 		}
+		Permutation::keccak_f1600(builder, &mut state);
+		states.push(state);
 	}
 
-	/// Populates the witness with padded byte message packed into 64-bit words
-	///
-	/// ## Arguments
-	///
-	/// * w - The witness filler to populate
-	/// * message_bytes - The input message as a byte slice
-	pub fn populate_message(&self, w: &mut WitnessFiller<'_>, message_bytes: &[u8]) {
-		assert!(
-			message_bytes.len() <= self.max_len_bytes(),
-			"Message length {} exceeds maximum {}",
-			message_bytes.len(),
-			self.max_len_bytes()
-		);
-
-		// populate message words from input bytes
-		let words = self.pack_bytes_into_words(message_bytes, self.max_len_bytes().div_ceil(8));
-		for (i, word) in words.iter().enumerate() {
-			if i < self.message.len() {
-				w[self.message[i]] = Word(*word);
-			}
-		}
-
-		let mut padded_bytes = vec![0u8; self.n_blocks * RATE_BYTES];
-
-		padded_bytes[..message_bytes.len()].copy_from_slice(message_bytes);
-
-		let msg_len = message_bytes.len();
-		let num_full_blocks = msg_len / RATE_BYTES;
-		let padding_block_start = num_full_blocks * RATE_BYTES;
-
-		padded_bytes[msg_len] = 0x01;
-
-		let padding_block_end = padding_block_start + RATE_BYTES - 1;
-		padded_bytes[padding_block_end] |= 0x80;
-
-		for block_idx in 0..self.n_blocks {
-			for (i, chunk) in padded_bytes[block_idx * RATE_BYTES..(block_idx + 1) * RATE_BYTES]
-				.chunks(8)
-				.enumerate()
-			{
-				let word = u64::from_le_bytes(chunk.try_into().unwrap());
-				w[self.padded_message[block_idx * N_WORDS_PER_BLOCK + i]] = Word(word);
-			}
-		}
-	}
-
-	fn pack_bytes_into_words(&self, bytes: &[u8], n_words: usize) -> Vec<u64> {
-		let mut words = Vec::with_capacity(n_words);
-		for i in 0..n_words {
-			if i * 8 < bytes.len() {
-				// to handle messages that are not multiples of 64, bytes are copied into
-				// a little endian byte array and then converted to a u64
-				let start = i * 8;
-				let end = ((i + 1) * 8).min(bytes.len());
-				let mut word_bytes = [0u8; 8];
-				word_bytes[..end - start].copy_from_slice(&bytes[start..end]);
-				let word = u64::from_le_bytes(word_bytes);
-				words.push(word);
-			}
-		}
-
-		words
-	}
+	// Digest = the first four state words after the block that contains the padding.
+	let inputs: Vec<&[Wire]> = states[1..].iter().map(|s| &s[..]).collect();
+	let digest_vec = multi_wire_multiplex(builder, &inputs, end_block_index);
+	digest_vec[..N_WORDS_PER_DIGEST].try_into().unwrap()
 }
 
 #[cfg(test)]
 mod tests {
-	use binius_core::verify::verify_constraints;
+	use binius_core::{Word, verify::verify_constraints};
 	use binius_frontend::{CircuitBuilder, Wire};
 	use rand::prelude::*;
 	use rstest::rstest;
 	use sha3::Digest;
 
 	use super::*;
+	use crate::fixed_byte_vec::ByteVec;
+
+	/// Builds a circuit with the given `max_message_len_bytes` capacity, runs `keccak256_varlen`
+	/// on a `ByteVec` populated with `message`, and asserts the computed digest equals the sha3
+	/// reference.
+	fn test_keccak_varlen_with_input(message: &[u8], max_message_len_bytes: usize) {
+		assert!(
+			message.len() <= max_message_len_bytes,
+			"Message length {} exceeds max capacity {} bytes",
+			message.len(),
+			max_message_len_bytes
+		);
+
+		// Compute expected digest using sha3 crate
+		let mut hasher = sha3::Keccak256::new();
+		hasher.update(message);
+		let expected_digest: [u8; 32] = hasher.finalize().into();
+
+		let b = CircuitBuilder::new();
+		let max_len_words = max_message_len_bytes.div_ceil(8);
+		let input = ByteVec::new_inout(&b, max_len_words);
+		let expected_digest_wires: [Wire; N_WORDS_PER_DIGEST] =
+			std::array::from_fn(|_| b.add_witness());
+
+		let computed_digest = keccak256_varlen(&b, &input);
+		for i in 0..N_WORDS_PER_DIGEST {
+			b.assert_eq(format!("digest[{i}]"), computed_digest[i], expected_digest_wires[i]);
+		}
+
+		let circuit = b.build();
+		let cs = circuit.constraint_system();
+		let mut witness = circuit.new_witness_filler();
+
+		input.populate_data(&mut witness, message);
+		input.populate_len_bytes(&mut witness, message.len());
+		for (i, bytes) in expected_digest.chunks(8).enumerate() {
+			witness[expected_digest_wires[i]] = Word(u64::from_le_bytes(bytes.try_into().unwrap()));
+		}
+
+		circuit
+			.populate_wire_witness(&mut witness)
+			.expect("Circuit should accept valid witness");
+		verify_constraints(cs, &witness.into_value_vec())
+			.expect("All constraints should be satisfied");
+	}
 
 	#[rstest]
 	#[case(0, 100)] // Empty message
@@ -318,49 +222,13 @@ mod tests {
 	#[case(137, 272)] // 137 bytes - crosses block boundary
 	#[case(271, 272)] // 271 bytes - one byte before two blocks
 	#[case(272, 272)] // 272 bytes - exactly two blocks
-	fn test_keccak_circuit(#[case] message_len_bytes: usize, #[case] max_message_len_bytes: usize) {
+	fn test_keccak_varlen(#[case] message_len_bytes: usize, #[case] max_message_len_bytes: usize) {
 		// Create test message with deterministic random bytes seeded by the length inputs
 		let seed = ((message_len_bytes as u64) << 32) | (max_message_len_bytes as u64);
 		let mut rng = StdRng::seed_from_u64(seed);
 		let mut message = vec![0u8; message_len_bytes];
 		rng.fill_bytes(&mut message);
 
-		// Compute expected digest using sha3 crate
-		let mut hasher = sha3::Keccak256::new();
-		hasher.update(&message);
-		let expected_digest: [u8; 32] = hasher.finalize().into();
-
-		// Build circuit
-		assert!(
-			message_len_bytes <= max_message_len_bytes,
-			"Message length {} exceeds max capacity {} bytes",
-			message_len_bytes,
-			max_message_len_bytes
-		);
-
-		let b = CircuitBuilder::new();
-		let len = b.add_witness();
-		let digest: [Wire; N_WORDS_PER_DIGEST] = std::array::from_fn(|_| b.add_inout());
-		let n_words = max_message_len_bytes.div_ceil(8);
-		let message_wires = (0..n_words).map(|_| b.add_inout()).collect();
-
-		let keccak = Keccak256::new(&b, len, digest, message_wires);
-		let circuit = b.build();
-
-		// Create and populate witness
-		let mut witness = circuit.new_witness_filler();
-		keccak.populate_len_bytes(&mut witness, message.len());
-		keccak.populate_message(&mut witness, &message);
-		keccak.populate_digest(&mut witness, expected_digest);
-
-		// Verify circuit accepts the witness
-		circuit
-			.populate_wire_witness(&mut witness)
-			.expect("Circuit should accept valid witness");
-
-		// Verify all constraints are satisfied
-		let cs = circuit.constraint_system();
-		verify_constraints(cs, &witness.into_value_vec())
-			.expect("All constraints should be satisfied");
+		test_keccak_varlen_with_input(&message, max_message_len_bytes);
 	}
 }

--- a/crates/circuits/src/keccak/permutation.rs
+++ b/crates/circuits/src/keccak/permutation.rs
@@ -2,7 +2,7 @@
 use std::array;
 
 use binius_core::word::Word;
-use binius_frontend::{CircuitBuilder, Wire, WitnessFiller};
+use binius_frontend::{CircuitBuilder, Wire};
 
 // ι round constants
 pub const RC: [u64; 24] = [
@@ -47,131 +47,91 @@ pub const fn idx(x: usize, y: usize) -> usize {
 	x + 5 * y
 }
 
-#[derive(Clone, Copy)]
-pub struct State {
-	pub words: [Wire; 25],
+/// Perform the Keccak f\[1600\] permutation in place on a 25-lane state.
+///
+/// ## Arguments
+///
+/// * `b` - The circuit builder to use.
+/// * `state` - The 25-word state to permute.
+pub fn keccak_f1600(b: &CircuitBuilder, state: &mut [Wire; 25]) {
+	for round in 0..24 {
+		keccak_permutation_round(b, state, round);
+	}
 }
 
-/// Keccak f\[1600\] permutation circuit.
-pub struct Permutation {
-	pub input_state: State,
-	pub output_state: State,
+pub fn keccak_permutation_round(b: &CircuitBuilder, state: &mut [Wire; 25], round: usize) {
+	theta(b, state);
+	rho_pi(b, state);
+	chi(b, state);
+	iota(b, state, round);
 }
 
-impl Permutation {
-	/// Create a new permutation circuit.
-	///
-	/// ## Arguments
-	///
-	/// * `b` - The circuit builder to use.
-	pub fn new(b: &CircuitBuilder, input_state: State) -> Self {
-		let mut output_state = input_state;
-		Self::keccak_f1600(b, &mut output_state.words);
+fn theta(b: &CircuitBuilder, state: &mut [Wire; 25]) {
+	let c0 = b.bxor_multi(&array::from_fn::<_, 5, _>(|y| state[idx(0, y)]));
+	let c1 = b.bxor_multi(&array::from_fn::<_, 5, _>(|y| state[idx(1, y)]));
+	let c2 = b.bxor_multi(&array::from_fn::<_, 5, _>(|y| state[idx(2, y)]));
+	let c3 = b.bxor_multi(&array::from_fn::<_, 5, _>(|y| state[idx(3, y)]));
+	let c4 = b.bxor_multi(&array::from_fn::<_, 5, _>(|y| state[idx(4, y)]));
 
-		Self {
-			input_state,
-			output_state,
-		}
+	// D[x] = C[x-1] ^ rotl1(C[x+1])
+	let d0 = b.bxor(c4, b.rotl(c1, 1));
+	let d1 = b.bxor(c0, b.rotl(c2, 1));
+	let d2 = b.bxor(c1, b.rotl(c3, 1));
+	let d3 = b.bxor(c2, b.rotl(c4, 1));
+	let d4 = b.bxor(c3, b.rotl(c0, 1));
+
+	// Fusing every linear expression into its AND leads to too many distinct shifted value
+	// indices and that slows down the shift reduction phase. Empirically we found out that
+	// preventing committing those here leads to better performance.
+	b.force_commit(d0);
+	b.force_commit(d1);
+	b.force_commit(d2);
+	b.force_commit(d3);
+	b.force_commit(d4);
+
+	// A'[x,y] = A[x,y] ^ D[x]
+	for y in 0..5 {
+		state[idx(0, y)] = b.bxor(state[idx(0, y)], d0);
+		state[idx(1, y)] = b.bxor(state[idx(1, y)], d1);
+		state[idx(2, y)] = b.bxor(state[idx(2, y)], d2);
+		state[idx(3, y)] = b.bxor(state[idx(3, y)], d3);
+		state[idx(4, y)] = b.bxor(state[idx(4, y)], d4);
 	}
+}
 
-	/// Populate the state with the given witness.
-	///
-	/// ## Arguments
-	///
-	/// * `w` - The witness to populate the state with.
-	/// * `state` - The state to populate the witness with.
-	pub fn populate_state(&self, w: &mut WitnessFiller, state: [u64; 25]) {
-		for i in 0..25 {
-			w[self.input_state.words[i]] = Word(state[i]);
-		}
+fn chi(b: &CircuitBuilder, state: &mut [Wire; 25]) {
+	for y in 0..5 {
+		let a0 = state[idx(0, y)];
+		let a1 = state[idx(1, y)];
+		let a2 = state[idx(2, y)];
+		let a3 = state[idx(3, y)];
+		let a4 = state[idx(4, y)];
+
+		state[idx(0, y)] = b.fax(b.bnot(a1), a2, a0);
+		state[idx(1, y)] = b.fax(b.bnot(a2), a3, a1);
+		state[idx(2, y)] = b.fax(b.bnot(a3), a4, a2);
+		state[idx(3, y)] = b.fax(b.bnot(a4), a0, a3);
+		state[idx(4, y)] = b.fax(b.bnot(a0), a1, a4);
 	}
+}
 
-	/// Perform the Keccak f\[1600\] permutation.
-	///
-	/// ## Arguments
-	///
-	/// * `b` - The circuit builder to use.
-	/// * `state` - The state to perform the permutation on.
-	pub fn keccak_f1600(b: &CircuitBuilder, state: &mut [Wire; 25]) {
-		for round in 0..24 {
-			Self::keccak_permutation_round(b, state, round);
-		}
-	}
-
-	pub fn keccak_permutation_round(b: &CircuitBuilder, state: &mut [Wire; 25], round: usize) {
-		Self::theta(b, state);
-		Self::rho_pi(b, state);
-		Self::chi(b, state);
-		Self::iota(b, state, round);
-	}
-
-	fn theta(b: &CircuitBuilder, state: &mut [Wire; 25]) {
-		let c0 = b.bxor_multi(&array::from_fn::<_, 5, _>(|y| state[idx(0, y)]));
-		let c1 = b.bxor_multi(&array::from_fn::<_, 5, _>(|y| state[idx(1, y)]));
-		let c2 = b.bxor_multi(&array::from_fn::<_, 5, _>(|y| state[idx(2, y)]));
-		let c3 = b.bxor_multi(&array::from_fn::<_, 5, _>(|y| state[idx(3, y)]));
-		let c4 = b.bxor_multi(&array::from_fn::<_, 5, _>(|y| state[idx(4, y)]));
-
-		// D[x] = C[x-1] ^ rotl1(C[x+1])
-		let d0 = b.bxor(c4, b.rotl(c1, 1));
-		let d1 = b.bxor(c0, b.rotl(c2, 1));
-		let d2 = b.bxor(c1, b.rotl(c3, 1));
-		let d3 = b.bxor(c2, b.rotl(c4, 1));
-		let d4 = b.bxor(c3, b.rotl(c0, 1));
-
-		// Fusing every linear expression into its AND leads to too many distinct shifted value
-		// indices and that slows down the shift reduction phase. Empirically we found out that
-		// preventing committing those here leads to better performance.
-		b.force_commit(d0);
-		b.force_commit(d1);
-		b.force_commit(d2);
-		b.force_commit(d3);
-		b.force_commit(d4);
-
-		// A'[x,y] = A[x,y] ^ D[x]
-		for y in 0..5 {
-			state[idx(0, y)] = b.bxor(state[idx(0, y)], d0);
-			state[idx(1, y)] = b.bxor(state[idx(1, y)], d1);
-			state[idx(2, y)] = b.bxor(state[idx(2, y)], d2);
-			state[idx(3, y)] = b.bxor(state[idx(3, y)], d3);
-			state[idx(4, y)] = b.bxor(state[idx(4, y)], d4);
-		}
-	}
-
-	fn chi(b: &CircuitBuilder, state: &mut [Wire; 25]) {
-		for y in 0..5 {
-			let a0 = state[idx(0, y)];
-			let a1 = state[idx(1, y)];
-			let a2 = state[idx(2, y)];
-			let a3 = state[idx(3, y)];
-			let a4 = state[idx(4, y)];
-
-			state[idx(0, y)] = b.fax(b.bnot(a1), a2, a0);
-			state[idx(1, y)] = b.fax(b.bnot(a2), a3, a1);
-			state[idx(2, y)] = b.fax(b.bnot(a3), a4, a2);
-			state[idx(3, y)] = b.fax(b.bnot(a4), a0, a3);
-			state[idx(4, y)] = b.fax(b.bnot(a0), a1, a4);
-		}
-	}
-
-	fn rho_pi(b: &CircuitBuilder, state: &mut [Wire; 25]) {
-		let mut temp = [state[0]; 25];
-		for y in 0..5 {
-			for x in 0..5 {
-				// no need to rotate if rotating by 0
-				if R[idx(x, y)] == 0 {
-					continue;
-				}
-				temp[idx(y, (2 * x + 3 * y) % 5)] = b.rotl(state[idx(x, y)], R[idx(x, y)]);
+fn rho_pi(b: &CircuitBuilder, state: &mut [Wire; 25]) {
+	let mut temp = [state[0]; 25];
+	for y in 0..5 {
+		for x in 0..5 {
+			// no need to rotate if rotating by 0
+			if R[idx(x, y)] == 0 {
+				continue;
 			}
+			temp[idx(y, (2 * x + 3 * y) % 5)] = b.rotl(state[idx(x, y)], R[idx(x, y)]);
 		}
-		*state = temp;
 	}
+	*state = temp;
+}
 
-	fn iota(b: &CircuitBuilder, state: &mut [Wire; 25], round: usize) {
-		let rc_wire = b.add_constant(Word(RC[round]));
-		state[0] = b.bxor(state[0], rc_wire);
-	}
+fn iota(b: &CircuitBuilder, state: &mut [Wire; 25], round: usize) {
+	let rc_wire = b.add_constant(Word(RC[round]));
+	state[0] = b.bxor(state[0], rc_wire);
 }
 
 #[cfg(test)]
@@ -253,38 +213,6 @@ mod tests {
 		}
 	}
 
-	#[test]
-	fn test_keccak_permutation() {
-		let mut rng = StdRng::seed_from_u64(0);
-
-		let builder = CircuitBuilder::new();
-
-		let input_words = State {
-			words: array::from_fn(|_| builder.add_inout()),
-		};
-
-		let permutation = Permutation::new(&builder, input_words);
-
-		let circuit = builder.build();
-
-		let mut w = circuit.new_witness_filler();
-
-		let initial_state = rng.random::<[u64; 25]>();
-		permutation.populate_state(&mut w, initial_state);
-
-		circuit.populate_wire_witness(&mut w).unwrap();
-
-		let mut expected_output = initial_state;
-		reference::keccak_f1600(&mut expected_output);
-
-		for i in 0..25 {
-			assert_eq!(w[permutation.output_state.words[i]], Word(expected_output[i]));
-		}
-
-		let cs = circuit.constraint_system();
-		verify_constraints(cs, &w.into_value_vec()).unwrap();
-	}
-
 	fn validate_circuit_component(
 		circuit_fn: impl FnOnce(&CircuitBuilder, &mut [Wire; 25]),
 		reference_fn: impl FnOnce(&mut [u64; 25]),
@@ -327,7 +255,7 @@ mod tests {
 		let mut rng = StdRng::seed_from_u64(0);
 		let input_state = rng.random::<[u64; 25]>();
 
-		validate_circuit_component(Permutation::keccak_f1600, reference::keccak_f1600, input_state);
+		validate_circuit_component(keccak_f1600, reference::keccak_f1600, input_state);
 	}
 
 	#[test]
@@ -336,7 +264,7 @@ mod tests {
 		let input_state = rng.random::<[u64; 25]>();
 
 		validate_circuit_component(
-			|b, state| Permutation::keccak_permutation_round(b, state, 0),
+			|b, state| keccak_permutation_round(b, state, 0),
 			|state| reference::keccak_permutation_round(state, 0),
 			input_state,
 		);
@@ -347,7 +275,7 @@ mod tests {
 		let mut rng = StdRng::seed_from_u64(0);
 		let input_state = rng.random::<[u64; 25]>();
 
-		validate_circuit_component(Permutation::theta, reference::theta, input_state);
+		validate_circuit_component(theta, reference::theta, input_state);
 	}
 
 	#[test]
@@ -355,7 +283,7 @@ mod tests {
 		let mut rng = StdRng::seed_from_u64(0);
 		let input_state = rng.random::<[u64; 25]>();
 
-		validate_circuit_component(Permutation::rho_pi, reference::rho_pi, input_state);
+		validate_circuit_component(rho_pi, reference::rho_pi, input_state);
 	}
 
 	#[test]
@@ -363,7 +291,7 @@ mod tests {
 		let mut rng = StdRng::seed_from_u64(0);
 		let input_state = rng.random::<[u64; 25]>();
 
-		validate_circuit_component(Permutation::chi, reference::chi, input_state);
+		validate_circuit_component(chi, reference::chi, input_state);
 	}
 
 	#[test]
@@ -372,7 +300,7 @@ mod tests {
 		let input_state = rng.random::<[u64; 25]>();
 
 		validate_circuit_component(
-			|b, state| Permutation::iota(b, state, 0),
+			|b, state| iota(b, state, 0),
 			|state| reference::iota(state, 0),
 			input_state,
 		);

--- a/crates/circuits/tests/gate_fusion_keccak.rs
+++ b/crates/circuits/tests/gate_fusion_keccak.rs
@@ -1,5 +1,5 @@
 // Copyright 2025 Irreducible Inc.
-use binius_circuits::keccak::permutation::Permutation;
+use binius_circuits::keccak::permutation::{keccak_f1600, keccak_permutation_round};
 use binius_frontend::{CircuitBuilder, Wire};
 
 #[test]
@@ -8,7 +8,7 @@ fn keccak() {
 	let initial_state: [Wire; 25] = std::array::from_fn(|_| builder.add_inout());
 	let expected_final_state: [Wire; 25] = std::array::from_fn(|_| builder.add_inout());
 	let mut computed_state = initial_state;
-	Permutation::keccak_f1600(&builder, &mut computed_state);
+	keccak_f1600(&builder, &mut computed_state);
 	builder.assert_eq_v("final_state", computed_state, expected_final_state);
 	let _ = builder.build();
 }
@@ -22,7 +22,7 @@ fn keccak_single_round() {
 	let mut computed_state = initial_state;
 
 	// Run just one round of Keccak
-	Permutation::keccak_permutation_round(&builder, &mut computed_state, 0);
+	keccak_permutation_round(&builder, &mut computed_state, 0);
 
 	builder.assert_eq_v("final_state", computed_state, expected_final_state);
 	let _ = builder.build();
@@ -37,14 +37,14 @@ fn keccak_two_rounds() {
 	let mut computed_state = initial_state;
 
 	// Run exactly 2 rounds of Keccak
-	Permutation::keccak_permutation_round(&builder, &mut computed_state, 0);
+	keccak_permutation_round(&builder, &mut computed_state, 0);
 	eprintln!("\n=== Round 1 output state (these become inputs to round 2) ===");
 	for (i, &wire) in computed_state.iter().enumerate() {
 		if i < 5 {
 			eprintln!("  computed_state[{}] = {:?}", i, wire);
 		}
 	}
-	Permutation::keccak_permutation_round(&builder, &mut computed_state, 1);
+	keccak_permutation_round(&builder, &mut computed_state, 1);
 
 	builder.assert_eq_v("final_state", computed_state, expected_final_state);
 	let _ = builder.build();

--- a/crates/examples/snapshots/ethsign.snap
+++ b/crates/examples/snapshots/ethsign.snap
@@ -1,28 +1,28 @@
 ethsign circuit
 --
 Gates & Instructions
-├─ Number of gates: 215,211
-└─ Number of evaluation instructions: 252,748
+├─ Number of gates: 215,205
+└─ Number of evaluation instructions: 252,790
 
 Constraints
-├─ AND constraints: 162,132 used (61.8% of 2^18)
-│  [▓▓▓▓▓▓░░░░] spare: 100,012
+├─ AND constraints: 162,095 used (61.8% of 2^18)
+│  [▓▓▓▓▓▓░░░░] spare: 100,049
 ├─ MUL constraints: 20,554 used (62.7% of 2^15)
 │  [▓▓▓▓▓▓░░░░] spare: 12,214
-└─ Distinct value indices: 367,241
-   ├─ Distinct shifted value indices: 174,974
-   └─ Distinct unshifted value indices: 192,267
+└─ Distinct value indices: 367,238
+   ├─ Distinct shifted value indices: 174,981
+   └─ Distinct unshifted value indices: 192,257
 
 Value Vector
 ├─ Public Section: 119 used (93.0% of 2^7)
 │  [▓▓▓▓▓▓▓▓▓░] spare: 9
 │  ├─ Constants: 90
 │  └─ Inout: 29
-├─ Private Section: 192,158 used (73.3%)
-│  [▓▓▓▓▓▓▓░░░] spare: 69,858
-│  ├─ Witness: 42
-│  └─ Internal: 192,116
-├─ Total Committed: 192,277 used (73.3% of 2^18)
-│  [▓▓▓▓▓▓▓░░░] spare: 69,867
-└─ Scratch (uncommitted): 193,718
+├─ Private Section: 192,147 used (73.3%)
+│  [▓▓▓▓▓▓▓░░░] spare: 69,869
+│  ├─ Witness: 0
+│  └─ Internal: 192,147
+├─ Total Committed: 192,266 used (73.3% of 2^18)
+│  [▓▓▓▓▓▓▓░░░] spare: 69,878
+└─ Scratch (uncommitted): 193,837
 

--- a/crates/examples/src/circuits/ethsign.rs
+++ b/crates/examples/src/circuits/ethsign.rs
@@ -3,7 +3,7 @@ use std::{array, iter};
 
 use anyhow::Result;
 use binius_circuits::{
-	bignum::BigUint, ecdsa::ecrecover, fixed_byte_vec::ByteVec, keccak::Keccak256,
+	bignum::BigUint, ecdsa::ecrecover, fixed_byte_vec::ByteVec, keccak::keccak256_varlen,
 };
 use binius_core::word::Word;
 use binius_frontend::{
@@ -22,8 +22,8 @@ struct Signature {
 	s: [Wire; 4],
 	recid_odd: Wire,
 	address: [Wire; 3],
-	msg_keccak: Keccak256,
-	address_keccak: Keccak256,
+	/// The signed message, hashed in-circuit by [`keccak256_varlen`].
+	msg: ByteVec,
 }
 
 /// Example circuit that proves validity of Ethereum-style ECDSA signatures.
@@ -62,13 +62,13 @@ impl ExampleCircuit for EthSignExample {
 				let recid_odd = builder.add_inout();
 				let address = array::from_fn(|_| builder.add_inout());
 
-				let msg_final_state = array::from_fn(|_| builder.add_witness());
-				let msg_keccak = Keccak256::new(builder, msg_len, msg_final_state, message);
+				let msg = ByteVec::new(message, msg_len);
+				let msg_digest = keccak256_varlen(builder, &msg);
 
 				// The Keccak digest is little endian encoded into 4 words, while Ethereum expects
 				// big endian
 				let z = BigUint {
-					limbs: msg_final_state[..4]
+					limbs: msg_digest
 						.iter()
 						.rev()
 						.map(|&word| byteswap(builder, word))
@@ -98,25 +98,21 @@ impl ExampleCircuit for EthSignExample {
 					.map(|word| byteswap(builder, word))
 					.collect::<Vec<_>>();
 
-				let address_final_state = array::from_fn(|_| builder.add_witness());
-				let address_keccak = Keccak256::new(
-					builder,
-					builder.add_constant_64(64),
-					address_final_state,
-					public_key_message,
-				);
+				// The public key is always 64 bytes; hash it with a constant-length `ByteVec`. Its
+				// data wires are derived from `ecrecover`, so nothing needs populating at witness
+				// time.
+				let address_msg = ByteVec::new_const_len(builder, public_key_message, 64);
+				let address_digest = keccak256_varlen(builder, &address_msg);
 
 				// Assert that the provided address equals digest bytes 12..32
-				assert_address_eq(builder, &address_keccak.digest, &address);
+				assert_address_eq(builder, &address_digest, &address);
 
 				Signature {
 					r,
 					s,
 					recid_odd,
 					address,
-
-					msg_keccak,
-					address_keccak,
+					msg,
 				}
 			})
 			.collect();
@@ -136,8 +132,7 @@ impl ExampleCircuit for EthSignExample {
 			s,
 			recid_odd,
 			address,
-			msg_keccak,
-			address_keccak,
+			msg,
 		} in &self.signatures
 		{
 			// Random private key
@@ -153,10 +148,9 @@ impl ExampleCircuit for EthSignExample {
 			let mut signature = secret_key.sign(&msg_hash)?;
 			let public = secret_key.public();
 
-			// Hash the message with Keccak
-			msg_keccak.populate_len_bytes(w, msg_len);
-			msg_keccak.populate_message(w, &msg_bytes);
-			msg_keccak.populate_digest(w, msg_hash);
+			// Populate the message bytes; its Keccak digest is computed in-circuit.
+			msg.populate_data(w, &msg_bytes);
+			msg.populate_len_bytes(w, msg_len);
 
 			// ethsign crate returns 0/1 recid, convert to `recid_odd` boolean
 			w[*recid_odd] = if signature.v != 0 {
@@ -172,14 +166,8 @@ impl ExampleCircuit for EthSignExample {
 			signature.s.reverse();
 			pack_bytes_into_wires_le(w, s, &signature.s);
 
-			// Hash the (big endian) public key
-			let pk_bytes = public.bytes();
-			let pk_hash = keccak256(pk_bytes);
-
-			address_keccak.populate_len_bytes(w, 64);
-			address_keccak.populate_message(w, pk_bytes);
-			address_keccak.populate_digest(w, pk_hash);
-
+			// The public key (and hence the address-hash input) is derived in-circuit from the
+			// recovered signature, so only the expected address wires need populating.
 			pack_bytes_into_wires_le(w, address, public.address());
 		}
 

--- a/crates/examples/src/circuits/independent_hashes.rs
+++ b/crates/examples/src/circuits/independent_hashes.rs
@@ -12,7 +12,7 @@
 use anyhow::{Result, ensure};
 use binius_circuits::{
 	blake3::{blake3_compress, ref_compress},
-	keccak::permutation::{Permutation, State as KeccakState},
+	keccak::permutation::keccak_f1600,
 	sha256::{State as Sha256State, populate_message_block, sha256_compress},
 };
 use binius_core::word::Word;
@@ -193,7 +193,7 @@ pub struct IndependentKeccakPermutations {
 }
 
 struct KeccakPermutation {
-	permutation: Permutation,
+	input: [Wire; 25],
 	output: [Wire; 25],
 }
 
@@ -206,17 +206,14 @@ impl ExampleCircuit for IndependentKeccakPermutations {
 
 		let permutations = (0..params.num_primitives)
 			.map(|i| {
-				let words = std::array::from_fn(|_| builder.add_witness());
-				let permutation = Permutation::new(builder, KeccakState { words });
-				let output = std::array::from_fn(|_| builder.add_inout());
-				builder.assert_eq_v(
-					format!("keccak_permutation_out[{i}]"),
-					permutation.output_state.words,
-					output,
-				);
+				let input: [Wire; 25] = std::array::from_fn(|_| builder.add_witness());
+				let mut output = input;
+				keccak_f1600(builder, &mut output);
+				let expected = std::array::from_fn(|_| builder.add_inout());
+				builder.assert_eq_v(format!("keccak_permutation_out[{i}]"), output, expected);
 				KeccakPermutation {
-					permutation,
-					output,
+					input,
+					output: expected,
 				}
 			})
 			.collect();
@@ -228,7 +225,9 @@ impl ExampleCircuit for IndependentKeccakPermutations {
 		let mut rng = StdRng::seed_from_u64(instance.seed.unwrap_or(DEFAULT_RANDOM_SEED));
 		for permutation in &self.permutations {
 			let state: [u64; 25] = std::array::from_fn(|_| rng.next_u64());
-			permutation.permutation.populate_state(w, state);
+			for (wire, value) in permutation.input.iter().zip(state) {
+				w[*wire] = Word(value);
+			}
 
 			let mut expected = state;
 			keccak::Keccak::new().with_f1600(|f1600| f1600(&mut expected));

--- a/crates/examples/src/circuits/keccak.rs
+++ b/crates/examples/src/circuits/keccak.rs
@@ -3,7 +3,10 @@
 use std::array;
 
 use anyhow::Result;
-use binius_circuits::keccak::{Keccak256, N_WORDS_PER_DIGEST, fixed_length::keccak256};
+use binius_circuits::{
+	fixed_byte_vec::ByteVec,
+	keccak::{N_WORDS_PER_DIGEST, fixed_length::keccak256, keccak256_varlen},
+};
 use binius_core::word::Word;
 use binius_frontend::{CircuitBuilder, Wire, WitnessFiller};
 use sha3::Digest;
@@ -25,7 +28,10 @@ enum KeccakCircuit {
 		digest: [Wire; N_WORDS_PER_DIGEST],
 	},
 	/// Variable-length gadget: message length is a runtime witness.
-	Variable(Keccak256),
+	Variable {
+		message: ByteVec,
+		digest: [Wire; N_WORDS_PER_DIGEST],
+	},
 }
 
 impl ExampleCircuit for KeccakExample {
@@ -51,9 +57,14 @@ impl ExampleCircuit for KeccakExample {
 			HasherMode::Variable { max_len_bytes } => {
 				let n_words = max_len_bytes.div_ceil(8);
 				let len_bytes = builder.add_witness();
+				let data = (0..n_words).map(|_| builder.add_inout()).collect();
+				let message = ByteVec::new(data, len_bytes);
 				let digest: [Wire; N_WORDS_PER_DIGEST] = array::from_fn(|_| builder.add_inout());
-				let message = (0..n_words).map(|_| builder.add_inout()).collect();
-				KeccakCircuit::Variable(Keccak256::new(builder, len_bytes, digest, message))
+				let computed_digest = keccak256_varlen(builder, &message);
+				for i in 0..N_WORDS_PER_DIGEST {
+					builder.assert_eq(format!("digest[{i}]"), computed_digest[i], digest[i]);
+				}
+				KeccakCircuit::Variable { message, digest }
 			}
 		};
 
@@ -83,10 +94,16 @@ impl ExampleCircuit for KeccakExample {
 					w[digest_wires[i]] = Word(u64::from_le_bytes(chunk.try_into().unwrap()));
 				}
 			}
-			KeccakCircuit::Variable(gadget) => {
-				gadget.populate_len_bytes(w, message.len());
-				gadget.populate_message(w, &message);
-				gadget.populate_digest(w, digest);
+			KeccakCircuit::Variable {
+				message: byte_vec,
+				digest: digest_wires,
+			} => {
+				byte_vec.populate_data(w, &message);
+				byte_vec.populate_len_bytes(w, message.len());
+				// Digest: 4 x 64-bit little-endian words.
+				for (i, chunk) in digest.chunks(8).enumerate() {
+					w[digest_wires[i]] = Word(u64::from_le_bytes(chunk.try_into().unwrap()));
+				}
 			}
 		}
 

--- a/crates/m4-prover/benches/assemble_operation_witness.rs
+++ b/crates/m4-prover/benches/assemble_operation_witness.rs
@@ -11,7 +11,7 @@
 
 use std::array;
 
-use binius_circuits::keccak::permutation::Permutation;
+use binius_circuits::keccak::permutation::keccak_f1600;
 use binius_core::word::Word;
 use binius_frontend::{Circuit, CircuitBuilder, Wire};
 use binius_m4_prover::{BatchAndCheckWitness, ValueTable};
@@ -31,7 +31,7 @@ fn build_keccak_circuit() -> (Circuit, [Wire; STATE_LANES]) {
 
 	// Permute a copy of the input wires in place; `state` then holds the output wires.
 	let mut state = input;
-	Permutation::keccak_f1600(&builder, &mut state);
+	keccak_f1600(&builder, &mut state);
 
 	// Pin the outputs so dead-code elimination keeps the whole permutation.
 	for wire in state {

--- a/crates/m4-prover/benches/keccak_witness_gen.rs
+++ b/crates/m4-prover/benches/keccak_witness_gen.rs
@@ -7,7 +7,7 @@
 
 use std::array;
 
-use binius_circuits::keccak::permutation::Permutation;
+use binius_circuits::keccak::permutation::keccak_f1600;
 use binius_core::word::Word;
 use binius_frontend::{Circuit, CircuitBuilder, Wire};
 use binius_m4_prover::ValueTable;
@@ -30,7 +30,7 @@ fn build_keccak_circuit() -> (Circuit, [Wire; STATE_LANES]) {
 
 	// Permute a copy of the input wires in place; `state` then holds the output wires.
 	let mut state = input;
-	Permutation::keccak_f1600(&builder, &mut state);
+	keccak_f1600(&builder, &mut state);
 
 	// Pin the outputs so dead-code elimination keeps the whole permutation.
 	for wire in state {

--- a/crates/m4-prover/tests/prove_hash_primitives.rs
+++ b/crates/m4-prover/tests/prove_hash_primitives.rs
@@ -15,7 +15,7 @@
 
 use std::array;
 
-use binius_circuits::{blake3::blake3_compress_2x, keccak::permutation::Permutation};
+use binius_circuits::{blake3::blake3_compress_2x, keccak::permutation::keccak_f1600};
 use binius_core::word::Word;
 use binius_frontend::{Circuit, CircuitBuilder, Wire};
 use binius_m4_prover::{BatchWitnessFiller, Prover, ValueTable};
@@ -193,7 +193,7 @@ fn build_keccak_circuit() -> (Circuit, [Wire; KECCAK_STATE_LANES]) {
 	// Permute a copy of the input in place.
 	// After the call, `state` holds the output lanes.
 	let mut state = input;
-	Permutation::keccak_f1600(&builder, &mut state);
+	keccak_f1600(&builder, &mut state);
 
 	// Force-commit the output lanes.
 	// This keeps the permutation alive under dead-code elimination.


### PR DESCRIPTION
Implements [BINIUS-289](https://linear.app/jimpo/issue/BINIUS-289). Two commits.

### 1 — `keccak256_varlen` replaces the `Keccak256` struct
Modelled on [`sha512_varlen`](crates/circuits/src/sha512/mod.rs): a free function `keccak256_varlen(builder: &CircuitBuilder, message: &ByteVec) -> [Wire; 4]` that consumes a `ByteVec` and **returns** the digest wires, replacing the old checker-style struct (which took caller-provided `len_bytes`/`digest`/`message` wires, allocated a witnessed `padded_message`, and asserted the claimed digest internally).

Each padded sponge word is now **computed** as a derived wire — classified by its runtime position relative to the boundary word `w_bd = len_bytes >> 3` (pure message word / boundary word carrying the `0x01` delimiter / padding word carrying the final `0x80`) — so the witnessed padded-message vector and all the padding-correctness constraints go away. The sponge XORs each 136-byte block into the state, permutes, and the digest is the first four state words after the padding block, selected by a length-indexed multiplexer. `ByteVec` and Keccak both pack little-endian, so (unlike SHA-512) no byte swap is needed.

Call sites updated to the return-the-digest style: the `keccak` example's variable-length branch and both `Keccak256` uses in the `ethsign` example (the 64-byte public-key address hash becomes a constant-length `ByteVec` whose data is derived in-circuit, so it needs no witness population).

### 2 — remove the `Permutation` struct
`Permutation::keccak_f1600` / `keccak_permutation_round` / `theta` / `rho_pi` / `chi` / `iota` become free functions on `[Wire; 25]`; the `Permutation` and `State` structs (and `Permutation::new`/`populate_state`) are removed. `keccak_f1600` is the whole API. Callers updated: `keccak256_varlen`, `fixed_length::keccak256`, the `gate_fusion_keccak` test, the `independent_hashes` example (now holds `[Wire; 25]` input/output directly), and the two m4-prover keccak targets.

### Verification
- circuits: 24 keccak unit tests (8 new `test_keccak_varlen` cases vs the `sha3` reference) + 3 `gate_fusion_keccak` tests pass; clippy `--all-targets -D warnings`, nightly fmt (each commit fmt-clean), and `cargo doc -D warnings` all clean.
- m4-prover `prove_keccak_permutation` passes end-to-end through the free `keccak_f1600`.
- The `keccak` (variable-length) and `ethsign` examples run end-to-end (build → witness → prove → verify).

🤖 Generated with [Claude Code](https://claude.com/claude-code)