### PR TITLE
BINIUS-235: drop dead ALL_ONE const_in from three gates

### DIFF
--- a/crates/frontend/src/compiler/gate/bxor.rs
+++ b/crates/frontend/src/compiler/gate/bxor.rs
@@ -12,8 +12,6 @@
 //! The gate generates 1 linear constraint:
 //! - `x ⊕ y = z`
 
-use binius_core::word::Word;
-
 use crate::compiler::{
 	constraint_builder::{ConstraintBuilder, xor2},
 	gate::opcode::OpcodeShape,
@@ -22,7 +20,7 @@ use crate::compiler::{
 
 pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
-		const_in: &[Word::ALL_ONE],
+		const_in: &[],
 		n_in: 2,
 		n_out: 1,
 		n_aux: 0,

--- a/crates/frontend/src/compiler/gate/bxor_multi.rs
+++ b/crates/frontend/src/compiler/gate/bxor_multi.rs
@@ -8,8 +8,6 @@
 //! The gate generates 1 linear constraint:
 //! - `x0 ⊕ x1 ⊕ ... ⊕ xn = z`
 
-use binius_core::word::Word;
-
 use crate::compiler::{
 	constraint_builder::{ConstraintBuilder, WireExprTerm, xor_multi},
 	gate::opcode::OpcodeShape,
@@ -21,7 +19,7 @@ pub fn shape(dimensions: &[usize]) -> OpcodeShape {
 		unreachable!()
 	};
 	OpcodeShape {
-		const_in: &[Word::ALL_ONE],
+		const_in: &[],
 		n_in: *n_inputs,
 		n_out: 1,
 		n_aux: 0,

--- a/crates/frontend/src/compiler/gate/iadd_cin_cout.rs
+++ b/crates/frontend/src/compiler/gate/iadd_cin_cout.rs
@@ -27,8 +27,6 @@
 //! 1. **Carry generation constraint**: Ensures correct carry propagation
 //! 2. **Sum constraint**: Ensures the sum equals `a ^ b ^ (cout << 1) ^ cin_msb`
 
-use binius_core::word::Word;
-
 use crate::compiler::{
 	constraint_builder::{ConstraintBuilder, sll, srl, xor3, xor4},
 	gate::opcode::OpcodeShape,
@@ -37,7 +35,7 @@ use crate::compiler::{
 
 pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
-		const_in: &[Word::ALL_ONE],
+		const_in: &[],
 		n_in: 3,
 		n_out: 2,
 		n_aux: 0,

--- a/crates/frontend/src/compiler/gate_graph.rs
+++ b/crates/frontend/src/compiler/gate_graph.rs
@@ -655,21 +655,25 @@ mod tests {
 		let mut graph = GateGraph::new();
 		let root = graph.path_spec_tree.root();
 
-		let in1 = graph.add_inout();
-		let in2 = graph.add_inout();
-		let out = graph.add_witness();
+		let a = graph.add_inout();
+		let b = graph.add_inout();
+		let bin = graph.add_inout();
+		let diff = graph.add_witness();
+		let bout = graph.add_witness();
 
-		let gate = graph.emit_gate(root, Opcode::Bxor, vec![in1, in2], vec![out]);
+		// IsubBinBout declares one constant input (ALL_ONE) alongside its three regular inputs.
+		let gate = graph.emit_gate(root, Opcode::IsubBinBout, vec![a, b, bin], vec![diff, bout]);
 
 		// No need to rebuild use-def chains for this test
 		// as we're just checking the gate structure
 
 		let inputs = get_gate_inputs(&graph, gate);
-		// Bxor has 1 constant input (ALL_ONE) + 2 regular inputs
-		assert_eq!(inputs.len(), 3);
-		assert!(inputs.contains(&in1));
-		assert!(inputs.contains(&in2));
-		// First input should be the constant wire
+		// 1 constant input (ALL_ONE) + 3 regular inputs.
+		assert_eq!(inputs.len(), 4);
+		assert!(inputs.contains(&a));
+		assert!(inputs.contains(&b));
+		assert!(inputs.contains(&bin));
+		// The constant wire is surfaced first.
 		let const_wire = inputs[0];
 		match graph.wires[const_wire].kind {
 			WireKind::Constant(word) => assert_eq!(word, Word::ALL_ONE),
@@ -677,7 +681,8 @@ mod tests {
 		}
 
 		let outputs = get_gate_outputs(&graph, gate);
-		assert_eq!(outputs.len(), 1);
-		assert!(outputs.contains(&out));
+		assert_eq!(outputs.len(), 2);
+		assert!(outputs.contains(&diff));
+		assert!(outputs.contains(&bout));
 	}
 }


### PR DESCRIPTION
Part of [BINIUS-235](https://linear.app/jimpo/issue/BINIUS-235). Pure cleanup — no circuit snapshot changes.

Removes a stale, unused constant declaration from three gates. Same class of cruft the shift gates shed in #1799.

### The problem

`bxor`, `iadd_cin_cout`, and `bxor_multi` each declare `const_in: &[Word::ALL_ONE]`, yet none of their `constrain` or `emit_eval_bytecode` bodies ever reference that constant.
It is a leftover from when these were AND constraints of the form `(a ^ b) & all_one = z`, later optimized to pure linear constraints — the declaration was never cleaned up.

### The change

- Drop `const_in: &[Word::ALL_ONE]` (→ `&[]`) in the three gates, and remove the now-unused `Word` import in each.
- An audit of the other eight gates with a non-empty `const_in` (`assert_*`, `icmp_*`, `isub_bin_bout`) confirms they genuinely use their constant — left untouched.

### Why this is snapshot-neutral

- A constant declared in `const_in` but referenced by no constraint is **never committed** — unreferenced constants are pruned.
- So removing the declaration cannot move any circuit's committed layout, constraint counts, or wire counts.
- Verified against `blake3_compress`, the degenerate zero-AND circuit that leans hardest on `bxor`: its snapshot **matches unchanged**. If the dead constant were ever committed, it would show there.

### Test

`test_gate_inputs_outputs` asserted on `bxor`'s constant input. Since `bxor` no longer has one, it is re-pointed at `isub_bin_bout` (which still carries `ALL_ONE`), preserving coverage that `const_in` constants are surfaced as gate inputs.

### Verification

- `cargo test`: `binius-frontend` 155, `binius-circuits` 342 — all pass.
- nightly `fmt --all` and `clippy -p binius-frontend --all-targets` — clean.
- `blake3_compress` snapshot matches; CI runs the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)