### PR TITLE
Re-bless the stale blake3 snapshot and guard the unchecked ones in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,9 @@ jobs:
       - name: Check circuit statistics snapshots
         run: |
           set -e
-          for example in ethsign zklogin sha256 sha512 keccak blake2s blake3_compress hashsign ec_msm; do
+          # Keep this list in sync with the committed snapshots in crates/examples/snapshots:
+          # every example that ships a .snap must be checked here, or it can drift undetected.
+          for example in ethsign zklogin sha256 sha512 keccak blake2s blake2b blake3_compress blake3 hashsign ec_msm bitcoin_header_chain bitcoin_p2pkh; do
             echo "::group::${example}"
             cargo run --example "${example}" -- check-snapshot
             echo "::endgroup::"

--- a/crates/examples/snapshots/blake3.snap
+++ b/crates/examples/snapshots/blake3.snap
@@ -5,24 +5,24 @@ Gates & Instructions
 └─ Number of evaluation instructions: 7,624
 
 Constraints
-├─ AND constraints: 5,512 used (67.3% of 2^13)
-│  [▓▓▓▓▓▓░░░░] spare: 2,680
+├─ AND constraints: 5,451 used (66.5% of 2^13)
+│  [▓▓▓▓▓▓░░░░] spare: 2,741
 ├─ MUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-└─ Distinct value indices: 14,808
-   ├─ Distinct shifted value indices: 9,355
-   └─ Distinct unshifted value indices: 5,453
+└─ Distinct value indices: 14,634
+   ├─ Distinct shifted value indices: 9,242
+   └─ Distinct unshifted value indices: 5,392
 
 Value Vector
 ├─ Public Section: 281 used (54.9% of 2^9)
 │  [▓▓▓▓▓░░░░░] spare: 231
 │  ├─ Constants: 17
 │  └─ Inout: 264
-├─ Private Section: 5,440 used (70.8%)
-│  [▓▓▓▓▓▓▓░░░] spare: 2,240
+├─ Private Section: 5,379 used (70.0%)
+│  [▓▓▓▓▓▓▓░░░] spare: 2,301
 │  ├─ Witness: 0
-│  └─ Internal: 5,440
-├─ Total Committed: 5,721 used (69.8% of 2^13)
-│  [▓▓▓▓▓▓░░░░] spare: 2,471
-└─ Scratch (uncommitted): 4,792
+│  └─ Internal: 5,379
+├─ Total Committed: 5,660 used (69.1% of 2^13)
+│  [▓▓▓▓▓▓░░░░] spare: 2,532
+└─ Scratch (uncommitted): 4,853
 


### PR DESCRIPTION
Fixes a pre-existing stale snapshot on `main`, and closes the CI gap that let it drift. Snapshot + CI-config only; no code or circuit changes.

### The problem

`blake3`'s committed snapshot no longer matches what the circuit produces:

- The blake3 circuit source is unchanged.
- But a compiler-level optimization landed after the snapshot was last written, cutting blake3's AND-constraint count by 61 (`5,512 → 5,451`) — 61 carry-type wires moved from *committed* to *scratch*.
- The snapshot was never re-blessed.

### Why CI never caught it

The `circuits-snapshot` job loops over a **hardcoded list of nine** examples, and full `blake3` is not one of them (only `blake3_compress` is). Four committed snapshots were unchecked entirely:

- `blake3`
- `blake2b`
- `bitcoin_header_chain`
- `bitcoin_p2pkh`

Any of them could drift silently, exactly as blake3 did.

### The change

1. **Re-bless `blake3`** — regenerate its `.snap` to match the circuit today. The recorded diff is a strict improvement already on main:

```
- AND constraints:       5,512     + 5,451
- Total Committed:       5,721     + 5,660
- Scratch (uncommitted): 4,792     + 4,853
```

2. **Add the four unguarded examples to the CI loop**, and add a comment tying the list to `crates/examples/snapshots/` so it cannot fall out of sync again. Every committed snapshot is now verified on every PR.

### Verification

- All four previously-unguarded snapshots checked locally: `blake3` (after the re-bless), `blake2b`, `bitcoin_header_chain`, `bitcoin_p2pkh` — all match. Only `blake3` needed re-blessing.
- Touches only `crates/examples/snapshots/blake3.snap` and `.github/workflows/ci.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
