### PR TITLE
BINIUS-290: optimize monbijou x86_64 mul_x with a 128-bit shift

### DIFF
--- a/crates/arith-bench/src/monbijou/x86_64.rs
+++ b/crates/arith-bench/src/monbijou/x86_64.rs
@@ -186,14 +186,18 @@ pub fn reduce_sliced_192b<U: Underlier + OpsClmul + PackedUnderlier<u64>>(
 	[z0, z1, z2]
 }
 
-/// Multiply an unreduced base-field product by X, per lane: shift each 64-bit lane left by one and
-/// fold the overflow bit (bit 63) back in with the low terms of the reduction polynomial
-/// (X^4 + X^3 + X + 1).
+/// Multiply an unreduced product by X: a plain 128-bit left shift by one.
+///
+/// The input is a carry-less product of two 64-bit values, so its bit 127 is zero and it has degree
+/// at most 126. Multiplying by X can therefore never overflow the 128-bit container, so no modular
+/// reduction is needed here — it stays deferred to the single [`reduce`].
+///
+/// `slli_epi64::<1>` shifts each 64-bit lane left by one; `slli_si128::<8>` carries bit 63 of the
+/// low lane into bit 0 of the high lane. The bit shifted out of the high lane is bit 127, which the
+/// precondition guarantees is zero.
 #[inline]
 fn mul_x<U: Underlier + OpsClmul + PackedUnderlier<u64>>(p: U) -> U {
-	const POLY: u64 = 0x1B;
-	let poly = <U as PackedUnderlier<u64>>::broadcast(POLY);
-	U::xor(U::slli_epi64::<1>(p), U::and(poly, U::movepi64_mask(p)))
+	U::xor(U::slli_epi64::<1>(p), U::slli_si128::<8>(U::srli_epi64::<63>(p)))
 }
 
 /// Multiply an unreduced product pair `[lo, hi]` by X, applying [`mul_x`] to each limb.


### PR DESCRIPTION
Resolves [BINIUS-290](https://linear.app/jimpo/issue/BINIUS-290/binius-arith-bench-optimize-mul-x-in-monbijoux86-64).

`mul_x` (in `crates/arith-bench/src/monbijou/x86_64.rs`) multiplies an unreduced product by `X`. Its input is always a carry-less product of two 64-bit values, so bit 127 is zero and the product has degree ≤ 126 — multiplying by `X` therefore never overflows the 128-bit container and needs no reduction. It was doing a per-64-bit-lane shift plus a mask-driven conditional add of the reduction tail (`movepi64_mask` + `broadcast(0x1B)` + `and`); that conditional fold only ever fires on bit 127, which the precondition guarantees is zero, so it was a redundant no-op.

## What changed

- **`crates/arith-bench/src/monbijou/x86_64.rs`** — replaced the conditional-modulus-add body of `mul_x` with a true 128-bit left-shift-by-one:
  ```rust
  U::xor(U::slli_epi64::&lt;1&gt;(p), U::slli_si128::&lt;8&gt;(U::srli_epi64::&lt;63&gt;(p)))
  ```
  `slli_epi64::&lt;1&gt;` shifts each 64-bit lane; `slli_si128::&lt;8&gt;(srli_epi64::&lt;63&gt;(p))` carries bit 63 of the low lane into bit 0 of the high lane (the bit shifted out of the high lane is bit 127 = 0). This matches the existing aarch64 `mul_x` and the `soft64` reference (`[lo &lt;&lt; 1, (hi &lt;&lt; 1) | (lo &gt;&gt; 63)]`). All required `Underlier` ops already exist; no new trait methods. Dropped the now-unused `POLY` constant.

All four `mul_x`/`mul_x_wide` call sites (in `reduce_128b`, `reduce_sliced_128b`, `reduce_sliced_192b`) feed fresh 64×64 clmul products, so the bit-127-zero precondition holds everywhere.

## Correctness

The x86_64 monbijou tests are proptest differential tests against the portable `soft64` reference. All pass with the new `mul_x` (`RUSTFLAGS="-C target-cpu=native" cargo test -p binius-arith-bench monbijou`, 29 tests incl. `base_mul_matches_soft64`, `sliced_matches_soft64_192b`, and the 128b commutative/associative/distributive proptests). Clippy (`--tests --benches -D warnings`) and nightly fmt clean.

Performance numbers to follow in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)