### PR TITLE
Promote the out-of-place highest-variable fold into binius-math

### DIFF
--- a/crates/ip-prover/src/sumcheck/mle_store.rs
+++ b/crates/ip-prover/src/sumcheck/mle_store.rs
@@ -21,8 +21,8 @@
 
 use binius_field::{Field, PackedField};
 use binius_math::{
-	FieldBuffer, FieldSlice, line::extrapolate_line_packed,
-	multilinear::fold::fold_highest_var_inplace,
+	FieldBuffer, FieldSlice,
+	multilinear::fold::{fold_highest_var, fold_highest_var_inplace},
 };
 use binius_utils::rayon::prelude::*;
 
@@ -417,23 +417,4 @@ impl<'b, P: PackedField> ExecuteContext<'b, P> {
 			EvaluationChunk { cols, eqs }
 		})
 	}
-}
-
-/// Computes the partial evaluation of a multilinear on its highest variable, out of place.
-///
-/// This is the out-of-place counterpart of [`fold_highest_var_inplace`], used for the first fold
-/// of a borrowed column.
-fn fold_highest_var<P: PackedField>(
-	values: &FieldSlice<P>,
-	challenge: P::Scalar,
-) -> FieldBuffer<P> {
-	assert!(values.log_len() > 0);
-
-	let challenge_broadcast = P::broadcast(challenge);
-	let (lo, hi) = values.split_half_ref();
-	let out_vals = (lo.as_ref(), hi.as_ref())
-		.into_par_iter()
-		.map(|(&lo_i, &hi_i)| extrapolate_line_packed(lo_i, hi_i, challenge_broadcast))
-		.collect();
-	FieldBuffer::new(values.log_len() - 1, out_vals)
 }

--- a/crates/math/src/multilinear/fold.rs
+++ b/crates/math/src/multilinear/fold.rs
@@ -33,6 +33,33 @@ pub fn fold_highest_var_inplace<P: PackedField, Data: DerefMut<Target = [P]>>(
 	values.truncate(values.log_len() - 1);
 }
 
+/// Computes the partial evaluation of a multilinear on its highest variable, out of place.
+///
+/// This is the out-of-place counterpart of [`fold_highest_var_inplace`].
+/// It reads `values` and returns a fresh half-size buffer, leaving the input untouched.
+/// Use it when the input is borrowed or must be preserved; otherwise prefer the in-place version.
+///
+/// ## Preconditions
+///
+/// * `values.log_len() >= 1` (buffer must have at least 2 elements)
+pub fn fold_highest_var<P: PackedField, Data: Deref<Target = [P]>>(
+	values: &FieldBuffer<P, Data>,
+	scalar: P::Scalar,
+) -> FieldBuffer<P> {
+	assert!(values.log_len() > 0, "precondition: buffer must have at least one variable");
+
+	// The two halves are the multilinear specialized to 0 and to 1 on the highest variable.
+	let broadcast_scalar = P::broadcast(scalar);
+	let (lo, hi) = values.split_half_ref();
+
+	// Interpolate the line through each (lo, hi) pair at the challenge into a fresh buffer.
+	let folded = (lo.as_ref(), hi.as_ref())
+		.into_par_iter()
+		.map(|(&lo_i, &hi_i)| extrapolate_line_packed(lo_i, hi_i, broadcast_scalar))
+		.collect();
+	FieldBuffer::new(values.log_len() - 1, folded)
+}
+
 /// Computes the fold high of a binary multilinear with a fold tensor.
 ///
 /// Binary multilinear is represented transparently by a boolean sequence.
@@ -120,6 +147,28 @@ mod tests {
 		}
 
 		assert_eq!(multilinear.get(0), eval);
+	}
+
+	#[test]
+	fn test_fold_highest_var_matches_inplace() {
+		let mut rng = StdRng::seed_from_u64(0);
+
+		for n_vars in 1..=10 {
+			let multilinear = random_field_buffer::<P>(&mut rng, n_vars);
+			let challenge = random_scalars::<F>(&mut rng, 1)[0];
+
+			// Out-of-place: leaves the input untouched, returns a fresh buffer.
+			let out_of_place = fold_highest_var(&multilinear, challenge);
+
+			// In-place reference: fold a copy and compare.
+			let mut in_place = multilinear;
+			fold_highest_var_inplace(&mut in_place, challenge);
+
+			assert_eq!(
+				out_of_place, in_place,
+				"out-of-place fold must equal in-place (n_vars={n_vars})"
+			);
+		}
 	}
 
 	fn test_binary_fold_high_conforms_to_regular_fold_high_helper(


### PR DESCRIPTION
Moves a general multilinear fold primitive out of the sumcheck column store and into `binius-math`, next to its in-place twin. Pure refactor — no behavior change.

### The problem

Folding a multilinear on its highest variable means, for each pair of halves, interpolating the line through them at the challenge:

```
folded[i] = lo[i] + (hi[i] - lo[i]) * challenge
```

`binius-math` already exposes this **in place** (`fold_highest_var_inplace`). But the column store needs it **out of place** for the first fold of a *borrowed* column — it can't mutate a borrow, so it writes into a fresh half-size buffer. Lacking that in the math crate, the store hand-rolled its own private copy:

```
// crates/ip-prover/src/sumcheck/mle_store.rs
fn fold_highest_var<P: PackedField>(values: &FieldSlice<P>, challenge: P::Scalar) -> FieldBuffer<P> { … }
```

So a general multilinear operation lived inside protocol code, reachable by exactly one caller, with no relation to its in-place sibling one crate down.

### The idea

Give the fold module the out-of-place counterpart it was missing, and delete the private copy.

```diff
- // private helper in mle_store.rs
- fn fold_highest_var(values: &FieldSlice<P>, challenge) -> FieldBuffer<P>
+ // public, in binius-math, beside fold_highest_var_inplace
+ pub fn fold_highest_var<P, Data: Deref<Target = [P]>>(values: &FieldBuffer<P, Data>, scalar) -> FieldBuffer<P>
```

It is generic over the buffer storage, mirroring the in-place version, so it folds any owned buffer or borrowed slice — not just the store's column type.

### Scope

- **new:** `fold_highest_var` in the math fold module + a test.
- **changed:** the store imports and calls it; the now-unused `extrapolate_line_packed` import is dropped.
- **deleted:** the store's private fold helper.
- purely additive to `binius-math`'s public API; nothing downstream changes.

### Verification

- `cargo build -p binius-math -p binius-ip-prover` — clean
- new test `test_fold_highest_var_matches_inplace`: folds the same input out-of-place and in-place across `n_vars = 1..=10` and asserts equality — the out-of-place path pinned to the in-place reference.
- `cargo test -p binius-math multilinear::fold` (3 passed) and `-p binius-ip-prover` (59 passed; the borrowed-column first-fold path is exercised by the prodcheck / fractional-addition / logUp* tests).
- `clippy --all-targets` on both crates + nightly `fmt` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)