### PR TITLE
BINIUS-296: rename integer MUL constraint to IMUL constraint

### DIFF
--- a/crates/core/src/constraint_system/constraint.rs
+++ b/crates/core/src/constraint_system/constraint.rs
@@ -82,12 +82,12 @@ impl DeserializeBytes for AndConstraint {
 	}
 }
 
-/// MUL constraint: `A * B = (HI << 64) | LO`.
+/// IMUL constraint: `A * B = (HI << 64) | LO`.
 ///
 /// 64-bit unsigned integer multiplication producing 128-bit result split into high and low 64-bit
 /// words.
 #[derive(Debug, Clone, Default)]
-pub struct MulConstraint {
+pub struct ImulConstraint {
 	/// A operand.
 	pub a: Operand,
 	/// B operand.
@@ -102,7 +102,7 @@ pub struct MulConstraint {
 	pub lo: Operand,
 }
 
-impl SerializeBytes for MulConstraint {
+impl SerializeBytes for ImulConstraint {
 	fn serialize(&self, mut write_buf: impl BufMut) -> Result<(), SerializationError> {
 		self.a.serialize(&mut write_buf)?;
 		self.b.serialize(&mut write_buf)?;
@@ -111,7 +111,7 @@ impl SerializeBytes for MulConstraint {
 	}
 }
 
-impl DeserializeBytes for MulConstraint {
+impl DeserializeBytes for ImulConstraint {
 	fn deserialize(mut read_buf: impl Buf) -> Result<Self, SerializationError>
 	where
 		Self: Sized,
@@ -121,7 +121,7 @@ impl DeserializeBytes for MulConstraint {
 		let hi = Vec::<ShiftedValueIndex>::deserialize(&mut read_buf)?;
 		let lo = Vec::<ShiftedValueIndex>::deserialize(read_buf)?;
 
-		Ok(MulConstraint { a, b, hi, lo })
+		Ok(ImulConstraint { a, b, hi, lo })
 	}
 }
 
@@ -155,8 +155,8 @@ mod tests {
 	}
 
 	#[test]
-	fn test_mul_constraint_serialization_round_trip() {
-		let constraint = MulConstraint {
+	fn test_imul_constraint_serialization_round_trip() {
+		let constraint = ImulConstraint {
 			a: vec![ShiftedValueIndex::plain(ValueIndex(0))],
 			b: vec![ShiftedValueIndex::srl(ValueIndex(1), 32)],
 			hi: vec![ShiftedValueIndex::plain(ValueIndex(2))],
@@ -166,7 +166,7 @@ mod tests {
 		let mut buf = Vec::new();
 		constraint.serialize(&mut buf).unwrap();
 
-		let deserialized = MulConstraint::deserialize(&mut buf.as_slice()).unwrap();
+		let deserialized = ImulConstraint::deserialize(&mut buf.as_slice()).unwrap();
 		assert_eq!(constraint.a.len(), deserialized.a.len());
 		assert_eq!(constraint.b.len(), deserialized.b.len());
 		assert_eq!(constraint.hi.len(), deserialized.hi.len());

--- a/crates/core/src/constraint_system/system.rs
+++ b/crates/core/src/constraint_system/system.rs
@@ -3,7 +3,7 @@
 use binius_utils::serialization::{DeserializeBytes, SerializationError, SerializeBytes};
 use bytes::{Buf, BufMut};
 
-use super::{AndConstraint, MulConstraint, Operand, ShiftVariant, ValueVec, ValueVecLayout};
+use super::{AndConstraint, ImulConstraint, Operand, ShiftVariant, ValueVec, ValueVecLayout};
 use crate::{error::ConstraintSystemError, word::Word};
 
 /// The ConstraintSystem is the core data structure in Binius64 that defines the computational
@@ -25,8 +25,8 @@ pub struct ConstraintSystem {
 	pub constants: Vec<Word>,
 	/// List of AND constraints that must be satisfied by the values vector.
 	pub and_constraints: Vec<AndConstraint>,
-	/// List of MUL constraints that must be satisfied by the values vector.
-	pub mul_constraints: Vec<MulConstraint>,
+	/// List of IMUL constraints that must be satisfied by the values vector.
+	pub imul_constraints: Vec<ImulConstraint>,
 }
 
 impl ConstraintSystem {
@@ -40,14 +40,14 @@ impl ConstraintSystem {
 		constants: Vec<Word>,
 		value_vec_layout: ValueVecLayout,
 		and_constraints: Vec<AndConstraint>,
-		mul_constraints: Vec<MulConstraint>,
+		imul_constraints: Vec<ImulConstraint>,
 	) -> Self {
 		assert_eq!(constants.len(), value_vec_layout.n_const);
 		ConstraintSystem {
 			constants,
 			value_vec_layout,
 			and_constraints,
-			mul_constraints,
+			imul_constraints,
 		}
 	}
 
@@ -71,11 +71,23 @@ impl ConstraintSystem {
 			validate_operand(&self.and_constraints[i].b, &self.value_vec_layout, "and", i, "b")?;
 			validate_operand(&self.and_constraints[i].c, &self.value_vec_layout, "and", i, "c")?;
 		}
-		for i in 0..self.mul_constraints.len() {
-			validate_operand(&self.mul_constraints[i].a, &self.value_vec_layout, "mul", i, "a")?;
-			validate_operand(&self.mul_constraints[i].b, &self.value_vec_layout, "mul", i, "b")?;
-			validate_operand(&self.mul_constraints[i].lo, &self.value_vec_layout, "mul", i, "lo")?;
-			validate_operand(&self.mul_constraints[i].hi, &self.value_vec_layout, "mul", i, "hi")?;
+		for i in 0..self.imul_constraints.len() {
+			validate_operand(&self.imul_constraints[i].a, &self.value_vec_layout, "imul", i, "a")?;
+			validate_operand(&self.imul_constraints[i].b, &self.value_vec_layout, "imul", i, "b")?;
+			validate_operand(
+				&self.imul_constraints[i].lo,
+				&self.value_vec_layout,
+				"imul",
+				i,
+				"lo",
+			)?;
+			validate_operand(
+				&self.imul_constraints[i].hi,
+				&self.value_vec_layout,
+				"imul",
+				i,
+				"hi",
+			)?;
 		}
 
 		return Ok(());
@@ -135,24 +147,25 @@ impl ConstraintSystem {
 	/// This function performs the following:
 	/// 1. Validates the value vector layout (including public input checks)
 	/// 2. Validates the constraints.
-	/// 3. Pads the AND and MUL constraints to the next po2 size
+	/// 3. Pads the AND and IMUL constraints to the next po2 size
 	pub fn validate_and_prepare(&mut self) -> Result<(), ConstraintSystemError> {
 		self.validate()?;
 
-		// Require all constraint types to have a power-of-two count. An empty MUL constraint set is
-		// kept at zero (rather than padded to a single dummy constraint) so the prover and verifier
-		// can skip the IntMul reduction entirely — see `IOPProver::prove` / `IOPVerifier::verify`.
+		// Require all constraint types to have a power-of-two count. An empty IMUL constraint set
+		// is kept at zero (rather than padded to a single dummy constraint) so the prover and
+		// verifier can skip the IntMul reduction entirely — see `IOPProver::prove` /
+		// `IOPVerifier::verify`.
 		let and_target_size = self.and_constraints.len().next_power_of_two();
-		let mul_target_size = if self.mul_constraints.is_empty() {
+		let imul_target_size = if self.imul_constraints.is_empty() {
 			0
 		} else {
-			self.mul_constraints.len().next_power_of_two()
+			self.imul_constraints.len().next_power_of_two()
 		};
 
 		self.and_constraints
 			.resize_with(and_target_size, AndConstraint::default);
-		self.mul_constraints
-			.resize_with(mul_target_size, MulConstraint::default);
+		self.imul_constraints
+			.resize_with(imul_target_size, ImulConstraint::default);
 
 		Ok(())
 	}
@@ -163,8 +176,8 @@ impl ConstraintSystem {
 	}
 
 	#[cfg(test)]
-	fn add_mul_constraint(&mut self, mul_constraint: MulConstraint) {
-		self.mul_constraints.push(mul_constraint);
+	fn add_imul_constraint(&mut self, imul_constraint: ImulConstraint) {
+		self.imul_constraints.push(imul_constraint);
 	}
 
 	/// Returns the number of AND constraints in the system.
@@ -172,9 +185,9 @@ impl ConstraintSystem {
 		self.and_constraints.len()
 	}
 
-	/// Returns the number of MUL  constraints in the system.
-	pub const fn n_mul_constraints(&self) -> usize {
-		self.mul_constraints.len()
+	/// Returns the number of IMUL  constraints in the system.
+	pub const fn n_imul_constraints(&self) -> usize {
+		self.imul_constraints.len()
 	}
 
 	/// The total length of the [`ValueVec`] expected by this constraint system.
@@ -195,7 +208,7 @@ impl SerializeBytes for ConstraintSystem {
 		self.value_vec_layout.serialize(&mut write_buf)?;
 		self.constants.serialize(&mut write_buf)?;
 		self.and_constraints.serialize(&mut write_buf)?;
-		self.mul_constraints.serialize(write_buf)
+		self.imul_constraints.serialize(write_buf)
 	}
 }
 
@@ -214,7 +227,7 @@ impl DeserializeBytes for ConstraintSystem {
 		let value_vec_layout = ValueVecLayout::deserialize(&mut read_buf)?;
 		let constants = Vec::<Word>::deserialize(&mut read_buf)?;
 		let and_constraints = Vec::<AndConstraint>::deserialize(&mut read_buf)?;
-		let mul_constraints = Vec::<MulConstraint>::deserialize(read_buf)?;
+		let imul_constraints = Vec::<ImulConstraint>::deserialize(read_buf)?;
 
 		if constants.len() != value_vec_layout.n_const {
 			return Err(SerializationError::InvalidConstruction {
@@ -226,7 +239,7 @@ impl DeserializeBytes for ConstraintSystem {
 			value_vec_layout,
 			constants,
 			and_constraints,
-			mul_constraints,
+			imul_constraints,
 		})
 	}
 }
@@ -267,14 +280,14 @@ mod tests {
 			),
 		];
 
-		let mul_constraints = vec![MulConstraint {
+		let imul_constraints = vec![ImulConstraint {
 			a: vec![ShiftedValueIndex::plain(ValueIndex(0))],
 			b: vec![ShiftedValueIndex::plain(ValueIndex(1))],
 			hi: vec![ShiftedValueIndex::plain(ValueIndex(2))],
 			lo: vec![ShiftedValueIndex::plain(ValueIndex(3))],
 		}];
 
-		ConstraintSystem::new(constants, value_vec_layout, and_constraints, mul_constraints)
+		ConstraintSystem::new(constants, value_vec_layout, and_constraints, imul_constraints)
 	}
 
 	#[test]
@@ -301,8 +314,8 @@ mod tests {
 		// Check and_constraints
 		assert_eq!(original.and_constraints.len(), deserialized.and_constraints.len());
 
-		// Check mul_constraints
-		assert_eq!(original.mul_constraints.len(), deserialized.mul_constraints.len());
+		// Check imul_constraints
+		assert_eq!(original.imul_constraints.len(), deserialized.imul_constraints.len());
 	}
 
 	#[test]
@@ -337,7 +350,7 @@ mod tests {
 
 		let constants = vec![Word::from_u64(1), Word::from_u64(2)]; // Only 2 constants
 		let and_constraints: Vec<AndConstraint> = vec![];
-		let mul_constraints: Vec<MulConstraint> = vec![];
+		let imul_constraints: Vec<ImulConstraint> = vec![];
 
 		// Serialize components manually
 		let mut buf = Vec::new();
@@ -347,7 +360,7 @@ mod tests {
 		value_vec_layout.serialize(&mut buf).unwrap();
 		constants.serialize(&mut buf).unwrap();
 		and_constraints.serialize(&mut buf).unwrap();
-		mul_constraints.serialize(&mut buf).unwrap();
+		imul_constraints.serialize(&mut buf).unwrap();
 
 		let result = ConstraintSystem::deserialize(&mut buf.as_slice());
 		assert!(result.is_err());
@@ -427,7 +440,7 @@ mod tests {
 		assert_eq!(deserialized.constants[2].as_u64(), 0xDEADBEEF);
 
 		assert_eq!(deserialized.and_constraints.len(), 2);
-		assert_eq!(deserialized.mul_constraints.len(), 1);
+		assert_eq!(deserialized.imul_constraints.len(), 1);
 
 		// Verify that the version is what we expect
 		// This is implicitly checked during deserialization, but we can also verify
@@ -503,7 +516,7 @@ mod tests {
 			vec![ValueIndex(4), ValueIndex(5)], // witness
 		));
 
-		cs.add_mul_constraint(MulConstraint {
+		cs.add_imul_constraint(ImulConstraint {
 			a: vec![ShiftedValueIndex::plain(ValueIndex(6))], // witness
 			b: vec![ShiftedValueIndex::plain(ValueIndex(7))], // witness
 			hi: vec![ShiftedValueIndex::plain(ValueIndex(8))], // internal
@@ -564,7 +577,7 @@ mod tests {
 	}
 
 	#[test]
-	fn test_validate_rejects_out_of_range_in_mul_constraint() {
+	fn test_validate_rejects_out_of_range_in_imul_constraint() {
 		let mut cs = ConstraintSystem::new(
 			vec![Word::from_u64(1), Word::from_u64(2)],
 			ValueVecLayout {
@@ -581,8 +594,8 @@ mod tests {
 			vec![],
 		);
 
-		// Add MUL constraint with out-of-range index in 'hi' operand
-		cs.add_mul_constraint(MulConstraint {
+		// Add IMUL constraint with out-of-range index in 'hi' operand
+		cs.add_imul_constraint(ImulConstraint {
 			a: vec![ShiftedValueIndex::plain(ValueIndex(0))], // valid
 			b: vec![ShiftedValueIndex::plain(ValueIndex(1))], // valid
 			hi: vec![ShiftedValueIndex::plain(ValueIndex(100))], // WAY out of range!
@@ -590,7 +603,7 @@ mod tests {
 		});
 
 		let result = cs.validate_and_prepare();
-		assert!(result.is_err(), "Should reject MUL constraint with out-of-range index");
+		assert!(result.is_err(), "Should reject IMUL constraint with out-of-range index");
 
 		match result.unwrap_err() {
 			ConstraintSystemError::OutOfRangeValueIndex {
@@ -600,7 +613,7 @@ mod tests {
 				total_len,
 				..
 			} => {
-				assert_eq!(constraint_type, "mul");
+				assert_eq!(constraint_type, "imul");
 				assert_eq!(operand_name, "hi");
 				assert_eq!(value_index, 100);
 				assert_eq!(total_len, 16);

--- a/crates/core/src/verify.rs
+++ b/crates/core/src/verify.rs
@@ -4,7 +4,7 @@
 //! [value vector][`ValueVec`].
 
 use crate::{
-	constraint_system::{AndConstraint, ConstraintSystem, MulConstraint, ValueIndex, ValueVec},
+	constraint_system::{AndConstraint, ConstraintSystem, ImulConstraint, ValueIndex, ValueVec},
 	word::Word,
 };
 
@@ -24,8 +24,11 @@ pub fn verify_and_constraint(witness: &ValueVec, constraint: &AndConstraint) -> 
 	}
 }
 
-/// Verifies that a MUL constraint is satisfied: A * B = (HI << 64) | LO
-pub fn verify_mul_constraint(witness: &ValueVec, constraint: &MulConstraint) -> Result<(), String> {
+/// Verifies that an IMUL constraint is satisfied: A * B = (HI << 64) | LO
+pub fn verify_imul_constraint(
+	witness: &ValueVec,
+	constraint: &ImulConstraint,
+) -> Result<(), String> {
 	let Word(a) = witness.eval_operand(&constraint.a);
 	let Word(b) = witness.eval_operand(&constraint.b);
 	let Word(lo) = witness.eval_operand(&constraint.lo);
@@ -40,7 +43,7 @@ pub fn verify_mul_constraint(witness: &ValueVec, constraint: &MulConstraint) -> 
 
 	if lo != expected_lo || hi != expected_hi {
 		Err(format!(
-			"MUL constraint failed: {a:016x} * {b:016x} = {hi:016x}{lo:016x} (expected {expected_hi:016x}{expected_lo:016x})",
+			"IMUL constraint failed: {a:016x} * {b:016x} = {hi:016x}{lo:016x} (expected {expected_hi:016x}{expected_lo:016x})",
 		))
 	} else {
 		Ok(())
@@ -66,9 +69,9 @@ pub fn verify_constraints(cs: &ConstraintSystem, witness: &ValueVec) -> Result<(
 		verify_and_constraint(witness, constraint)
 			.map_err(|e| format!("AND constraint {i} failed: {e}"))?;
 	}
-	for (i, constraint) in cs.mul_constraints.iter().enumerate() {
-		verify_mul_constraint(witness, constraint)
-			.map_err(|e| format!("MUL constraint {i} failed: {e}"))?;
+	for (i, constraint) in cs.imul_constraints.iter().enumerate() {
+		verify_imul_constraint(witness, constraint)
+			.map_err(|e| format!("IMUL constraint {i} failed: {e}"))?;
 	}
 	Ok(())
 }

--- a/crates/examples/examples/tutorials/circuits_gadgets.rs
+++ b/crates/examples/examples/tutorials/circuits_gadgets.rs
@@ -78,7 +78,7 @@ fn demo_byte_swapping() -> Result<()> {
 	// Show gate usage
 	println!("\nGate usage for byte swapping:");
 	println!("  AND constraints: {}", cs.n_and_constraints());
-	println!("  MUL constraints: {}", cs.n_mul_constraints());
+	println!("  IMUL constraints: {}", cs.n_imul_constraints());
 
 	Ok(())
 }

--- a/crates/examples/snapshots/bitcoin_headers.snap
+++ b/crates/examples/snapshots/bitcoin_headers.snap
@@ -7,7 +7,7 @@ Gates & Instructions
 Constraints
 ├─ AND constraints: 20,221 used (61.7% of 2^15)
 │  [▓▓▓▓▓▓░░░░] spare: 12,547
-├─ MUL constraints: 0 used (0.0% of 0)
+├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
 └─ Distinct value indices: 47,465
    ├─ Distinct shifted value indices: 27,120

--- a/crates/examples/snapshots/bitcoin_p2pkh.snap
+++ b/crates/examples/snapshots/bitcoin_p2pkh.snap
@@ -7,7 +7,7 @@ Gates & Instructions
 Constraints
 ├─ AND constraints: 114,942 used (87.7% of 2^17)
 │  [▓▓▓▓▓▓▓▓░░] spare: 16,130
-├─ MUL constraints: 15,186 used (92.7% of 2^14)
+├─ IMUL constraints: 15,186 used (92.7% of 2^14)
 │  [▓▓▓▓▓▓▓▓▓░] spare: 1,198
 └─ Distinct value indices: 265,588
    ├─ Distinct shifted value indices: 128,251

--- a/crates/examples/snapshots/blake2b.snap
+++ b/crates/examples/snapshots/blake2b.snap
@@ -7,7 +7,7 @@ Gates & Instructions
 Constraints
 ├─ AND constraints: 8,160 used (99.6% of 2^13)
 │  [▓▓▓▓▓▓▓▓▓░] spare: 32
-├─ MUL constraints: 0 used (0.0% of 0)
+├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
 └─ Distinct value indices: 21,662
    ├─ Distinct shifted value indices: 13,362

--- a/crates/examples/snapshots/blake2s.snap
+++ b/crates/examples/snapshots/blake2s.snap
@@ -7,7 +7,7 @@ Gates & Instructions
 Constraints
 ├─ AND constraints: 13,656 used (83.3% of 2^14)
 │  [▓▓▓▓▓▓▓▓░░] spare: 2,728
-├─ MUL constraints: 0 used (0.0% of 0)
+├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
 └─ Distinct value indices: 35,718
    ├─ Distinct shifted value indices: 21,916

--- a/crates/examples/snapshots/blake3.snap
+++ b/crates/examples/snapshots/blake3.snap
@@ -7,7 +7,7 @@ Gates & Instructions
 Constraints
 ├─ AND constraints: 5,451 used (66.5% of 2^13)
 │  [▓▓▓▓▓▓░░░░] spare: 2,741
-├─ MUL constraints: 0 used (0.0% of 0)
+├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
 └─ Distinct value indices: 14,634
    ├─ Distinct shifted value indices: 9,242

--- a/crates/examples/snapshots/blake3_compress.snap
+++ b/crates/examples/snapshots/blake3_compress.snap
@@ -7,7 +7,7 @@ Gates & Instructions
 Constraints
 ├─ AND constraints: 0 used (0.0% of 2^0)
 │  [░░░░░░░░░░] spare: 1
-├─ MUL constraints: 0 used (0.0% of 0)
+├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
 └─ Distinct value indices: 0
    ├─ Distinct shifted value indices: 0

--- a/crates/examples/snapshots/ec_msm.snap
+++ b/crates/examples/snapshots/ec_msm.snap
@@ -7,7 +7,7 @@ Gates & Instructions
 Constraints
 ├─ AND constraints: 160,097 used (61.1% of 2^18)
 │  [▓▓▓▓▓▓░░░░] spare: 102,047
-├─ MUL constraints: 20,548 used (62.7% of 2^15)
+├─ IMUL constraints: 20,548 used (62.7% of 2^15)
 │  [▓▓▓▓▓▓░░░░] spare: 12,220
 └─ Distinct value indices: 361,410
    ├─ Distinct shifted value indices: 171,232

--- a/crates/examples/snapshots/ethsign.snap
+++ b/crates/examples/snapshots/ethsign.snap
@@ -7,7 +7,7 @@ Gates & Instructions
 Constraints
 ├─ AND constraints: 162,095 used (61.8% of 2^18)
 │  [▓▓▓▓▓▓░░░░] spare: 100,049
-├─ MUL constraints: 20,554 used (62.7% of 2^15)
+├─ IMUL constraints: 20,554 used (62.7% of 2^15)
 │  [▓▓▓▓▓▓░░░░] spare: 12,214
 └─ Distinct value indices: 367,238
    ├─ Distinct shifted value indices: 174,981

--- a/crates/examples/snapshots/hashsign.snap
+++ b/crates/examples/snapshots/hashsign.snap
@@ -7,7 +7,7 @@ Gates & Instructions
 Constraints
 ├─ AND constraints: 297,991 used (56.8% of 2^19)
 │  [▓▓▓▓▓░░░░░] spare: 226,297
-├─ MUL constraints: 0 used (0.0% of 0)
+├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
 └─ Distinct value indices: 763,746
    ├─ Distinct shifted value indices: 466,717

--- a/crates/examples/snapshots/keccak.snap
+++ b/crates/examples/snapshots/keccak.snap
@@ -7,7 +7,7 @@ Gates & Instructions
 Constraints
 ├─ AND constraints: 5,750 used (70.2% of 2^13)
 │  [▓▓▓▓▓▓▓░░░] spare: 2,442
-├─ MUL constraints: 0 used (0.0% of 0)
+├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
 └─ Distinct value indices: 19,903
    ├─ Distinct shifted value indices: 14,001

--- a/crates/examples/snapshots/sha256.snap
+++ b/crates/examples/snapshots/sha256.snap
@@ -7,7 +7,7 @@ Gates & Instructions
 Constraints
 ├─ AND constraints: 8,880 used (54.2% of 2^14)
 │  [▓▓▓▓▓░░░░░] spare: 7,504
-├─ MUL constraints: 0 used (0.0% of 0)
+├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
 └─ Distinct value indices: 21,511
    ├─ Distinct shifted value indices: 12,563

--- a/crates/examples/snapshots/sha512.snap
+++ b/crates/examples/snapshots/sha512.snap
@@ -7,7 +7,7 @@ Gates & Instructions
 Constraints
 ├─ AND constraints: 10,311 used (62.9% of 2^14)
 │  [▓▓▓▓▓▓░░░░] spare: 6,073
-├─ MUL constraints: 0 used (0.0% of 0)
+├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
 └─ Distinct value indices: 25,089
    ├─ Distinct shifted value indices: 14,555

--- a/crates/examples/snapshots/zklogin.snap
+++ b/crates/examples/snapshots/zklogin.snap
@@ -7,7 +7,7 @@ Gates & Instructions
 Constraints
 ├─ AND constraints: 357,836 used (68.3% of 2^19)
 │  [▓▓▓▓▓▓░░░░] spare: 166,452
-├─ MUL constraints: 8,262 used (50.4% of 2^14)
+├─ IMUL constraints: 8,262 used (50.4% of 2^14)
 │  [▓▓▓▓▓░░░░░] spare: 8,122
 └─ Distinct value indices: 654,744
    ├─ Distinct shifted value indices: 294,376

--- a/crates/frontend/src/compiler/constraint_builder.rs
+++ b/crates/frontend/src/compiler/constraint_builder.rs
@@ -1,5 +1,7 @@
 // Copyright 2025 Irreducible Inc.
-use binius_core::constraint_system::{AndConstraint, MulConstraint, ShiftedValueIndex, ValueIndex};
+use binius_core::constraint_system::{
+	AndConstraint, ImulConstraint, ShiftedValueIndex, ValueIndex,
+};
 use cranelift_entity::{EntitySet, SecondaryMap};
 use smallvec::{SmallVec, smallvec};
 
@@ -8,7 +10,7 @@ use crate::compiler::Wire;
 /// Builder for creating constraints using Wire references
 pub struct ConstraintBuilder {
 	pub and_constraints: Vec<WireAndConstraint>,
-	pub mul_constraints: Vec<WireMulConstraint>,
+	pub imul_constraints: Vec<WireImulConstraint>,
 	pub linear_constraints: Vec<WireLinearConstraint>,
 }
 
@@ -16,7 +18,7 @@ impl ConstraintBuilder {
 	pub const fn new() -> Self {
 		Self {
 			and_constraints: Vec::new(),
-			mul_constraints: Vec::new(),
+			imul_constraints: Vec::new(),
 			linear_constraints: Vec::new(),
 		}
 	}
@@ -26,9 +28,9 @@ impl ConstraintBuilder {
 		AndConstraintBuilder::new(self)
 	}
 
-	/// Build a MUL constraint: A * B = (HI << 64) | LO
-	pub const fn mul(&mut self) -> MulConstraintBuilder<'_> {
-		MulConstraintBuilder::new(self)
+	/// Build an IMUL constraint: A * B = (HI << 64) | LO
+	pub const fn imul(&mut self) -> ImulConstraintBuilder<'_> {
+		ImulConstraintBuilder::new(self)
 	}
 
 	/// Build a linear constraint: RHS = DST
@@ -43,15 +45,15 @@ impl ConstraintBuilder {
 		self,
 		wire_mapping: &SecondaryMap<Wire, ValueIndex>,
 		all_one: Wire,
-	) -> (Vec<AndConstraint>, Vec<MulConstraint>) {
+	) -> (Vec<AndConstraint>, Vec<ImulConstraint>) {
 		let mut and_constraints = self
 			.and_constraints
 			.into_iter()
 			.map(|c| c.into_constraint(wire_mapping))
 			.collect::<Vec<_>>();
 
-		let mul_constraints = self
-			.mul_constraints
+		let imul_constraints = self
+			.imul_constraints
 			.into_iter()
 			.map(|c| c.into_constraint(wire_mapping))
 			.collect();
@@ -65,7 +67,7 @@ impl ConstraintBuilder {
 			}
 		}
 
-		(and_constraints, mul_constraints)
+		(and_constraints, imul_constraints)
 	}
 
 	pub fn mark_used_wires(&self) -> EntitySet<Wire> {
@@ -73,7 +75,7 @@ impl ConstraintBuilder {
 		for ac in &self.and_constraints {
 			ac.mark_used(&mut used_set);
 		}
-		for mc in &self.mul_constraints {
+		for mc in &self.imul_constraints {
 			mc.mark_used(&mut used_set);
 		}
 		for lc in &self.linear_constraints {
@@ -123,8 +125,8 @@ impl WireAndConstraint {
 	}
 }
 
-/// MUL constraint using Wire references
-pub struct WireMulConstraint {
+/// IMUL constraint using Wire references
+pub struct WireImulConstraint {
 	pub a: WireOperand,
 	pub b: WireOperand,
 	pub hi: WireOperand,
@@ -157,9 +159,9 @@ impl WireLinearConstraint {
 	}
 }
 
-impl WireMulConstraint {
-	fn into_constraint(self, wire_mapping: &SecondaryMap<Wire, ValueIndex>) -> MulConstraint {
-		MulConstraint {
+impl WireImulConstraint {
+	fn into_constraint(self, wire_mapping: &SecondaryMap<Wire, ValueIndex>) -> ImulConstraint {
+		ImulConstraint {
 			a: expand_and_convert_operand(self.a, wire_mapping),
 			b: expand_and_convert_operand(self.b, wire_mapping),
 			hi: expand_and_convert_operand(self.hi, wire_mapping),
@@ -392,7 +394,7 @@ impl<'a> AndConstraintBuilder<'a> {
 	}
 }
 
-pub struct MulConstraintBuilder<'a> {
+pub struct ImulConstraintBuilder<'a> {
 	builder: &'a mut ConstraintBuilder,
 	a: WireOperand,
 	b: WireOperand,
@@ -406,7 +408,7 @@ pub struct LinearConstraintBuilder<'a> {
 	dst: Option<Wire>,
 }
 
-impl<'a> MulConstraintBuilder<'a> {
+impl<'a> ImulConstraintBuilder<'a> {
 	const fn new(builder: &'a mut ConstraintBuilder) -> Self {
 		Self {
 			builder,
@@ -438,7 +440,7 @@ impl<'a> MulConstraintBuilder<'a> {
 	}
 
 	pub fn build(self) {
-		self.builder.mul_constraints.push(WireMulConstraint {
+		self.builder.imul_constraints.push(WireImulConstraint {
 			a: self.a,
 			b: self.b,
 			hi: self.hi,
@@ -659,12 +661,12 @@ mod tests {
 				.dst(wire_c)
 				.build();
 
-			let (and_constraints, mul_constraints) = builder.build(&wire_mapping, all_one_wire);
+			let (and_constraints, imul_constraints) = builder.build(&wire_mapping, all_one_wire);
 
 			// rotr(0) should be optimized to plain wire, so we expect:
 			// (a ⊕ b) & all_one = c
 			assert_eq!(and_constraints.len(), 1);
-			assert_eq!(mul_constraints.len(), 0);
+			assert_eq!(imul_constraints.len(), 0);
 
 			let and_c = &and_constraints[0];
 
@@ -706,10 +708,10 @@ mod tests {
 				.dst(wire_c)
 				.build();
 
-			let (and_constraints, mul_constraints) = builder.build(&wire_mapping, all_one_wire);
+			let (and_constraints, imul_constraints) = builder.build(&wire_mapping, all_one_wire);
 
 			assert_eq!(and_constraints.len(), 1);
-			assert_eq!(mul_constraints.len(), 0);
+			assert_eq!(imul_constraints.len(), 0);
 
 			let and_c = &and_constraints[0];
 
@@ -823,10 +825,10 @@ mod tests {
 			.dst(wire_c)
 			.build();
 
-		let (and_constraints, mul_constraints) = builder.build(&wire_mapping, all_one_wire);
+		let (and_constraints, imul_constraints) = builder.build(&wire_mapping, all_one_wire);
 
 		assert_eq!(and_constraints.len(), 1);
-		assert_eq!(mul_constraints.len(), 0);
+		assert_eq!(imul_constraints.len(), 0);
 
 		let and_c = &and_constraints[0];
 

--- a/crates/frontend/src/compiler/cse.rs
+++ b/crates/frontend/src/compiler/cse.rs
@@ -21,7 +21,7 @@
 //! It allocates almost nothing.
 //!
 //! Before this pass only constants were interned.
-//! An identical non-constant subexpression built twice now costs one AND/MUL constraint, not two.
+//! An identical non-constant subexpression built twice now costs one AND/IMUL constraint, not two.
 
 use std::hash::{Hash, Hasher};
 
@@ -40,7 +40,7 @@ use super::{
 /// - A later gate with that structure is redirected onto the canonical gate and marked dead.
 ///
 /// The caller skips dead gates at emission.
-/// Each collapsed duplicate then costs one fewer AND/MUL constraint and one fewer committed wire.
+/// Each collapsed duplicate then costs one fewer AND/IMUL constraint and one fewer committed wire.
 pub fn dedup_gates(
 	graph: &mut GateGraph,
 	force_committed: &EntitySet<Wire>,

--- a/crates/frontend/src/compiler/dce.rs
+++ b/crates/frontend/src/compiler/dce.rs
@@ -7,7 +7,7 @@
 //! - one of its outputs feeds a live gate.
 //!
 //! A dead gate only constrains wires that no assertion or public output transitively reads.
-//! Skipping it at constraint-emission time drops those AND/MUL constraints.
+//! Skipping it at constraint-emission time drops those AND/IMUL constraints.
 //! Its output wire is then referenced by nothing.
 //! An unreferenced internal wire is allocated as scratch, never committed.
 //!

--- a/crates/frontend/src/compiler/gate/imul.rs
+++ b/crates/frontend/src/compiler/gate/imul.rs
@@ -1,6 +1,6 @@
 // Copyright 2025 Irreducible Inc.
 //! Imul gate implements 64-bit × 64-bit → 128-bit unsigned multiplication.
-//! Uses the MulConstraint: X * Y = (HI << 64) | LO
+//! Uses the ImulConstraint: X * Y = (HI << 64) | LO
 
 use crate::compiler::{
 	constraint_builder::ConstraintBuilder,
@@ -26,8 +26,8 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 	let [x, y] = inputs else { unreachable!() };
 	let [hi, lo] = outputs else { unreachable!() };
 
-	// Create MulConstraint: X * Y = (HI << 64) | LO
-	builder.mul().a(*x).b(*y).hi(*hi).lo(*lo).build();
+	// Create ImulConstraint: X * Y = (HI << 64) | LO
+	builder.imul().a(*x).b(*y).hi(*hi).lo(*lo).build();
 }
 
 pub fn emit_eval_bytecode(

--- a/crates/frontend/src/compiler/gate_fusion/legraph.rs
+++ b/crates/frontend/src/compiler/gate_fusion/legraph.rs
@@ -14,7 +14,7 @@ use crate::compiler::{
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum ConstraintRef {
 	And { index: usize },
-	Mul { index: usize },
+	Imul { index: usize },
 	Linear { index: usize },
 }
 
@@ -24,7 +24,7 @@ pub enum NodeData {
 	/// Root node - represents a use site in a non-linear constraint.
 	///
 	/// These nodes are the "sinks" of the graph where linear expressions flow into
-	/// non-linear constraints (AND/MUL). They have no outgoing edges and represent
+	/// non-linear constraints (AND/IMUL). They have no outgoing edges and represent
 	/// the termination points for inlining decisions.
 	///
 	/// # Example
@@ -64,7 +64,7 @@ pub enum NodeData {
 	/// # Example
 	/// ```text
 	/// x = input()     // Creates an Opaque node for x
-	/// y = a * b       // Creates Opaque nodes for y (MUL output)
+	/// y = a * b       // Creates Opaque nodes for y (IMUL output)
 	/// ```
 	Opaque,
 }
@@ -99,7 +99,7 @@ pub struct EdgeData {
 /// Linear Expression Graph (LeGraph) - the core data structure for gate fusion optimization.
 ///
 /// This graph represents the data flow relationships between linear constraints (XOR and shift
-/// operations) and their uses in non-linear constraints (AND/MUL operations). The graph is used
+/// operations) and their uses in non-linear constraints (AND/IMUL operations). The graph is used
 /// to determine which linear constraints can be inlined into their consumers to reduce the total
 /// number of AND constraints in the final circuit.
 ///
@@ -110,7 +110,7 @@ pub struct EdgeData {
 /// 1. **Linear Definition Nodes** (`LinDef`): Represent linear constraints that define a wire as an
 ///    XOR combination of shifted values. These are candidates for inlining.
 ///
-/// 2. **Root Nodes**: Represent uses of linear definitions in non-linear constraints (AND/MUL).
+/// 2. **Root Nodes**: Represent uses of linear definitions in non-linear constraints (AND/IMUL).
 ///    These are the sinks of the graph where inlining decisions terminate.
 ///
 /// 3. **Opaque Nodes**: Represent wires that are not defined by linear constraints (e.g., inputs or
@@ -298,11 +298,11 @@ fn build_use_def(cb: &ConstraintBuilder, leg: &mut LeGraph, _stat: &mut Stat) {
 		harvest_nonlin_uses(&and.c, leg, ConstraintRef::And { index });
 	}
 
-	for (index, mul) in cb.mul_constraints.iter().enumerate() {
-		harvest_nonlin_uses(&mul.a, leg, ConstraintRef::Mul { index });
-		harvest_nonlin_uses(&mul.b, leg, ConstraintRef::Mul { index });
-		harvest_nonlin_uses(&mul.hi, leg, ConstraintRef::Mul { index });
-		harvest_nonlin_uses(&mul.lo, leg, ConstraintRef::Mul { index });
+	for (index, mul) in cb.imul_constraints.iter().enumerate() {
+		harvest_nonlin_uses(&mul.a, leg, ConstraintRef::Imul { index });
+		harvest_nonlin_uses(&mul.b, leg, ConstraintRef::Imul { index });
+		harvest_nonlin_uses(&mul.hi, leg, ConstraintRef::Imul { index });
+		harvest_nonlin_uses(&mul.lo, leg, ConstraintRef::Imul { index });
 	}
 }
 

--- a/crates/frontend/src/compiler/gate_fusion/mod.rs
+++ b/crates/frontend/src/compiler/gate_fusion/mod.rs
@@ -8,10 +8,10 @@
 //! Our AND constraints are powerful construct construct. They can handle a single AND of two XOR
 //! combinations where each of the values could be shifted.
 //!
-//! `ConstraintBuilder` which this pass operates consists of AND, MUL and linear constraints. Linear
-//! constraints are basically are constraints that define a single wire using a XOR combination
-//! and/or shifts. Since our system does not suppose standalone linear combinations they will have
-//! to be promoted to AND constraints.
+//! `ConstraintBuilder` which this pass operates consists of AND, IMUL and linear constraints.
+//! Linear constraints are basically are constraints that define a single wire using a XOR
+//! combination and/or shifts. Since our system does not suppose standalone linear combinations they
+//! will have to be promoted to AND constraints.
 //!
 //! BUT we have a chance of avoiding that if we manage to inline that wire into every consumer
 //! constraint which means we don't have to commit that value and thus we don't need an AND
@@ -38,7 +38,7 @@ pub fn run_pass(cb: &mut ConstraintBuilder, pinned_wires: &EntitySet<Wire>, all_
 	let mut leg = LeGraph::new(cb, &mut stat);
 	commit_set::run_decide_commit_set(&mut leg, &mut stat);
 	// Pin force-committed wires that are linear definitions so their values survive as committed
-	// AND constraints. Pinned wires that are not linear definitions (e.g. AND or MUL outputs) are
+	// AND constraints. Pinned wires that are not linear definitions (e.g. AND or IMUL outputs) are
 	// already committed by their own constraints, so they must be excluded here: `patch::build`
 	// treats every wire in the commit set as a linear definition and would otherwise panic.
 	let pinned_lin_defs = pinned_wires

--- a/crates/frontend/src/compiler/gate_fusion/patch.rs
+++ b/crates/frontend/src/compiler/gate_fusion/patch.rs
@@ -5,7 +5,7 @@ use super::legraph::LeGraph;
 use crate::compiler::{
 	Wire,
 	constraint_builder::{
-		ConstraintBuilder, Shift, ShiftedWire, WireAndConstraint, WireMulConstraint, WireOperand,
+		ConstraintBuilder, Shift, ShiftedWire, WireAndConstraint, WireImulConstraint, WireOperand,
 	},
 	gate_fusion::legraph::ConstraintRef,
 };
@@ -20,12 +20,12 @@ pub struct Patch {
 	/// The constraint set that is going to be replaced with this one.
 	subsumes: Vec<ConstraintRef>,
 	/// The new constraints that is going to be added to the graph.
-	added: AndOrMulConstraint,
+	added: AndOrImulConstraint,
 }
 
-enum AndOrMulConstraint {
+enum AndOrImulConstraint {
 	And(WireAndConstraint),
-	Mul(WireMulConstraint),
+	Imul(WireImulConstraint),
 }
 
 /// Apply the given patches to the constraint builder given.
@@ -33,14 +33,16 @@ pub fn apply_patches(cb: &mut ConstraintBuilder, patches: Vec<Patch>) {
 	let mut subsumes: FxHashSet<ConstraintRef> = FxHashSet::default();
 	subsumes.reserve(patches.len());
 	let mut new_and_constraints = Vec::new();
-	let mut new_mul_constraints = Vec::new();
+	let mut new_imul_constraints = Vec::new();
 
 	// Collect all subsumed constraints and new constraints to add
 	for patch in patches {
 		subsumes.extend(patch.subsumes);
 		match patch.added {
-			AndOrMulConstraint::And(and_constraint) => new_and_constraints.push(and_constraint),
-			AndOrMulConstraint::Mul(mul_constraint) => new_mul_constraints.push(mul_constraint),
+			AndOrImulConstraint::And(and_constraint) => new_and_constraints.push(and_constraint),
+			AndOrImulConstraint::Imul(imul_constraint) => {
+				new_imul_constraints.push(imul_constraint)
+			}
 		}
 	}
 
@@ -59,12 +61,12 @@ pub fn apply_patches(cb: &mut ConstraintBuilder, patches: Vec<Patch>) {
 		})
 		.collect();
 
-	let old_mul_constraints = std::mem::take(&mut cb.mul_constraints);
-	cb.mul_constraints = old_mul_constraints
+	let old_imul_constraints = std::mem::take(&mut cb.imul_constraints);
+	cb.imul_constraints = old_imul_constraints
 		.into_iter()
 		.enumerate()
 		.filter_map(|(index, constraint)| {
-			if subsumes.contains(&ConstraintRef::Mul { index }) {
+			if subsumes.contains(&ConstraintRef::Imul { index }) {
 				None
 			} else {
 				Some(constraint)
@@ -87,7 +89,7 @@ pub fn apply_patches(cb: &mut ConstraintBuilder, patches: Vec<Patch>) {
 
 	// Add the new constraints
 	cb.and_constraints.extend(new_and_constraints);
-	cb.mul_constraints.extend(new_mul_constraints);
+	cb.imul_constraints.extend(new_imul_constraints);
 }
 
 /// Builds a list of patches that would remove the inlined linear definitions and potentially
@@ -133,14 +135,14 @@ fn build_non_lin_patch(
 			let a = process_operand(leg, &mut subsumes, &cb.and_constraints[index].a);
 			let b = process_operand(leg, &mut subsumes, &cb.and_constraints[index].b);
 			let c = process_operand(leg, &mut subsumes, &cb.and_constraints[index].c);
-			AndOrMulConstraint::And(WireAndConstraint { a, b, c })
+			AndOrImulConstraint::And(WireAndConstraint { a, b, c })
 		}
-		ConstraintRef::Mul { index } => {
-			let a = process_operand(leg, &mut subsumes, &cb.mul_constraints[index].a);
-			let b = process_operand(leg, &mut subsumes, &cb.mul_constraints[index].b);
-			let lo = process_operand(leg, &mut subsumes, &cb.mul_constraints[index].lo);
-			let hi = process_operand(leg, &mut subsumes, &cb.mul_constraints[index].hi);
-			AndOrMulConstraint::Mul(WireMulConstraint { a, b, lo, hi })
+		ConstraintRef::Imul { index } => {
+			let a = process_operand(leg, &mut subsumes, &cb.imul_constraints[index].a);
+			let b = process_operand(leg, &mut subsumes, &cb.imul_constraints[index].b);
+			let lo = process_operand(leg, &mut subsumes, &cb.imul_constraints[index].lo);
+			let hi = process_operand(leg, &mut subsumes, &cb.imul_constraints[index].hi);
+			AndOrImulConstraint::Imul(WireImulConstraint { a, b, lo, hi })
 		}
 		ConstraintRef::Linear { .. } => unreachable!(),
 	};
@@ -175,7 +177,7 @@ fn build_committed_lin_def_patch(
 	// Create an AND constraint that enforces: root = new_operand
 	Patch {
 		subsumes,
-		added: AndOrMulConstraint::And(WireAndConstraint {
+		added: AndOrImulConstraint::And(WireAndConstraint {
 			a: new_operand,
 			b: vec![ShiftedWire {
 				wire: all_one,
@@ -358,7 +360,7 @@ mod tests {
 		let all_one = w(9);
 		let patch = super::build_committed_lin_def_patch(&cb_single, &leg, all_one, w(3));
 		match patch.added {
-			AndOrMulConstraint::And(ref andc) => {
+			AndOrImulConstraint::And(ref andc) => {
 				// b must be exactly [all_one]
 				assert_eq!(andc.b.len(), 1);
 				assert_eq!(andc.b[0].wire, all_one);
@@ -383,7 +385,7 @@ mod tests {
 		cb.linear().rhs(xor2(w(4), w(5))).dst(w(12)).build(); // hi_src
 		cb.linear().rhs(xor2(w(6), w(7))).dst(w(13)).build(); // lo_src
 
-		cb.mul().a(w(10)).b(w(11)).hi(w(12)).lo(w(13)).build();
+		cb.imul().a(w(10)).b(w(11)).hi(w(12)).lo(w(13)).build();
 
 		let mut stat = Stat::default();
 		let mut leg = LeGraph::new(&cb, &mut stat);
@@ -393,8 +395,8 @@ mod tests {
 		let mut cb2 = cb;
 		super::apply_patches(&mut cb2, patches);
 
-		assert_eq!(cb2.mul_constraints.len(), 1);
-		let m = &cb2.mul_constraints[0];
+		assert_eq!(cb2.imul_constraints.len(), 1);
+		let m = &cb2.imul_constraints[0];
 		assert_eq!(m.a.len(), 2);
 		assert_eq!(m.b.len(), 2);
 		assert_eq!(m.hi.len(), 2);
@@ -739,9 +741,9 @@ mod tests {
 		cb.and().a(w(3)).b(w(4)).c(w(5)).build(); // index 1
 		cb.and().a(w(6)).b(w(7)).c(w(8)).build(); // index 2
 
-		// Add some MUL constraints
-		cb.mul().a(w(9)).b(w(10)).lo(w(11)).hi(w(12)).build(); // index 0
-		cb.mul().a(w(13)).b(w(14)).lo(w(15)).hi(w(16)).build(); // index 1
+		// Add some IMUL constraints
+		cb.imul().a(w(9)).b(w(10)).lo(w(11)).hi(w(12)).build(); // index 0
+		cb.imul().a(w(13)).b(w(14)).lo(w(15)).hi(w(16)).build(); // index 1
 
 		// Add some LINEAR constraints
 		cb.linear().rhs(xor2(w(17), w(18))).dst(w(19)).build(); // index 0
@@ -750,11 +752,11 @@ mod tests {
 		// Create patches that:
 		// 1. Replace AND constraint at index 1 with a new one
 		// 2. Replace LINEAR constraint at index 0 with an AND constraint
-		// 3. Replace MUL constraint at index 0 with a new one
+		// 3. Replace IMUL constraint at index 0 with a new one
 		let patches = vec![
 			Patch {
 				subsumes: vec![ConstraintRef::And { index: 1 }],
-				added: AndOrMulConstraint::And(WireAndConstraint {
+				added: AndOrImulConstraint::And(WireAndConstraint {
 					a: vec![ShiftedWire {
 						wire: w(30),
 						shift: Shift::None,
@@ -771,7 +773,7 @@ mod tests {
 			},
 			Patch {
 				subsumes: vec![ConstraintRef::Linear { index: 0 }],
-				added: AndOrMulConstraint::And(WireAndConstraint {
+				added: AndOrImulConstraint::And(WireAndConstraint {
 					a: vec![ShiftedWire {
 						wire: w(33),
 						shift: Shift::None,
@@ -787,8 +789,8 @@ mod tests {
 				}),
 			},
 			Patch {
-				subsumes: vec![ConstraintRef::Mul { index: 0 }],
-				added: AndOrMulConstraint::Mul(WireMulConstraint {
+				subsumes: vec![ConstraintRef::Imul { index: 0 }],
+				added: AndOrImulConstraint::Imul(WireImulConstraint {
 					a: vec![ShiftedWire {
 						wire: w(36),
 						shift: Shift::None,
@@ -822,12 +824,12 @@ mod tests {
 		assert_eq!(cb.and_constraints[2].a[0].wire, w(30));
 		assert_eq!(cb.and_constraints[3].a[0].wire, w(33));
 
-		// MUL constraints: originally 2, removed index 0, added 1 new one = 2 total
-		assert_eq!(cb.mul_constraints.len(), 2);
+		// IMUL constraints: originally 2, removed index 0, added 1 new one = 2 total
+		assert_eq!(cb.imul_constraints.len(), 2);
 		// Check that original constraint at index 1 is preserved (now at index 0)
-		assert_eq!(cb.mul_constraints[0].a[0].wire, w(13));
+		assert_eq!(cb.imul_constraints[0].a[0].wire, w(13));
 		// Check new constraint is added at the end
-		assert_eq!(cb.mul_constraints[1].a[0].wire, w(36));
+		assert_eq!(cb.imul_constraints[1].a[0].wire, w(36));
 
 		// LINEAR constraints: originally 2, removed index 0 = 1 total
 		assert_eq!(cb.linear_constraints.len(), 1);
@@ -886,9 +888,9 @@ mod tests {
 
 	#[test]
 	fn test_mul_operand_duplicate_inlining() {
-		// Build MUL where the same linear def appears twice in a single operand:
+		// Build IMUL where the same linear def appears twice in a single operand:
 		// y = x ^ c
-		// MUL.a = y ^ y ^ z  (duplicate y)
+		// IMUL.a = y ^ y ^ z  (duplicate y)
 		// After inlining, expect: a = x ^ c ^ x ^ c ^ z (5 terms, preserving duplicates)
 		fn w(id: u32) -> Wire {
 			Wire::from_u32(id)
@@ -897,8 +899,8 @@ mod tests {
 		let mut cb = ConstraintBuilder::new();
 		// y = x ^ c
 		cb.linear().rhs(xor2(w(0), w(1))).dst(w(2)).build();
-		// MUL: a = y ^ y ^ z; b = u; hi, lo are outputs
-		cb.mul()
+		// IMUL: a = y ^ y ^ z; b = u; hi, lo are outputs
+		cb.imul()
 			.a(crate::compiler::constraint_builder::xor3(w(2), w(2), w(3)))
 			.b(w(4))
 			.hi(w(5))
@@ -913,9 +915,9 @@ mod tests {
 		let mut cb2 = cb;
 		super::apply_patches(&mut cb2, patches);
 
-		// Verify results: one MUL remains, and its operand a equals x ^ c ^ x ^ c ^ z
-		assert_eq!(cb2.mul_constraints.len(), 1);
-		let a = &cb2.mul_constraints[0].a;
+		// Verify results: one IMUL remains, and its operand a equals x ^ c ^ x ^ c ^ z
+		assert_eq!(cb2.imul_constraints.len(), 1);
+		let a = &cb2.imul_constraints[0].a;
 		assert_operand_eq(
 			a,
 			vec![
@@ -946,11 +948,11 @@ mod tests {
 
 	#[test]
 	fn test_mul_mixed_inlinable_and_committed() {
-		// Scenario: committed linear feeds one MUL operand; inlinable linear feeds the other.
+		// Scenario: committed linear feeds one IMUL operand; inlinable linear feeds the other.
 		// t_committed = sll(a, 40)
 		// y = sll(t_committed, 30)  // uses committed
 		// u = x ^ c                  // inlinable
-		// MUL: a=y, b=u
+		// IMUL: a=y, b=u
 		fn w(id: u32) -> Wire {
 			Wire::from_u32(id)
 		}
@@ -959,7 +961,7 @@ mod tests {
 		cb.linear().rhs(sll(w(0), 40)).dst(w(1)).build(); // t_committed
 		cb.linear().rhs(sll(w(1), 30)).dst(w(2)).build(); // y
 		cb.linear().rhs(xor2(w(3), w(4))).dst(w(5)).build(); // u
-		cb.mul().a(w(2)).b(w(5)).hi(w(6)).lo(w(7)).build();
+		cb.imul().a(w(2)).b(w(5)).hi(w(6)).lo(w(7)).build();
 
 		let mut stat = Stat::default();
 		let mut leg = LeGraph::new(&cb, &mut stat);
@@ -970,8 +972,8 @@ mod tests {
 		let mut cb2 = cb;
 		super::apply_patches(&mut cb2, patches);
 
-		assert_eq!(cb2.mul_constraints.len(), 1);
-		let m = &cb2.mul_constraints[0];
+		assert_eq!(cb2.imul_constraints.len(), 1);
+		let m = &cb2.imul_constraints[0];
 		assert_operand_eq(
 			&m.a,
 			vec![ShiftedWire {
@@ -1009,8 +1011,8 @@ mod tests {
 		cb.linear().rhs(sll(w(1), 20)).dst(w(2)).build(); // hi_src (should commit t)
 		// inlinable lo_src = x ^ c
 		cb.linear().rhs(xor2(w(3), w(4))).dst(w(5)).build();
-		// build MUL: a,b plain; hi=hi_src; lo=lo_src
-		cb.mul().a(w(6)).b(w(7)).hi(w(2)).lo(w(5)).build();
+		// build IMUL: a,b plain; hi=hi_src; lo=lo_src
+		cb.imul().a(w(6)).b(w(7)).hi(w(2)).lo(w(5)).build();
 
 		let mut stat = Stat::default();
 		let mut leg = LeGraph::new(&cb, &mut stat);
@@ -1021,8 +1023,8 @@ mod tests {
 		let mut cb2 = cb;
 		super::apply_patches(&mut cb2, patches);
 
-		assert_eq!(cb2.mul_constraints.len(), 1);
-		let m = &cb2.mul_constraints[0];
+		assert_eq!(cb2.imul_constraints.len(), 1);
+		let m = &cb2.imul_constraints[0];
 		assert_operand_eq(
 			&m.hi,
 			vec![ShiftedWire {

--- a/crates/frontend/src/compiler/gate_fusion/tests/awhole.rs
+++ b/crates/frontend/src/compiler/gate_fusion/tests/awhole.rs
@@ -44,10 +44,10 @@ fn stringify_constraint_system(cs: &ConstraintSystem) -> String {
 		}
 	}
 
-	// MUL constraints
-	if !cs.mul_constraints.is_empty() {
-		for (i, constraint) in cs.mul_constraints.iter().enumerate() {
-			write!(output, "MUL[{}]: (", i).unwrap();
+	// IMUL constraints
+	if !cs.imul_constraints.is_empty() {
+		for (i, constraint) in cs.imul_constraints.iter().enumerate() {
+			write!(output, "IMUL[{}]: (", i).unwrap();
 			format_operand(&mut output, &constraint.a, cs);
 			write!(output, ") * (").unwrap();
 			format_operand(&mut output, &constraint.b, cs);
@@ -135,12 +135,12 @@ fn compile(circuit_builder: CircuitBuilder) -> ConstraintSystem {
 	circuit.constraint_system().clone()
 }
 
-// =============== MUL tests (placed next to AND tests) ===============
+// =============== IMUL tests (placed next to AND tests) ===============
 
 #[test]
 fn test_mul_inlining_duplicate_linear_in_mul() {
 	// y = x ^ c; then mul(y, y) = (hi, lo)
-	// Expect: y is fully inlined into both a and b operands of MUL (duplicated terms).
+	// Expect: y is fully inlined into both a and b operands of IMUL (duplicated terms).
 	let b = mk_circuit_builder();
 
 	// Inputs
@@ -152,12 +152,12 @@ fn test_mul_inlining_duplicate_linear_in_mul() {
 
 	let cs = compile(b);
 
-	insta::assert_snapshot!(stringify_constraint_system(&cs), @"MUL[0]: (v[2] ⊕ v[3]) * (v[2] ⊕ v[3]) = (HI: v[4], LO: v[5])");
+	insta::assert_snapshot!(stringify_constraint_system(&cs), @"IMUL[0]: (v[2] ⊕ v[3]) * (v[2] ⊕ v[3]) = (HI: v[4], LO: v[5])");
 }
 
 #[test]
 fn test_mul_and_and_shared_linear_uses() {
-	// y = x ^ c; AND uses y and MUL uses y as one operand
+	// y = x ^ c; AND uses y and IMUL uses y as one operand
 	// Expect: y gets inlined into both constraints appropriately
 	let b = mk_circuit_builder();
 
@@ -169,20 +169,20 @@ fn test_mul_and_and_shared_linear_uses() {
 	let w = b.add_witness();
 	let _and_out = b.band(y, w);
 
-	// Use y in MUL
+	// Use y in IMUL
 	let z = b.add_witness();
 	let (_hi, _lo) = b.imul(y, z);
 
 	let cs = compile(b);
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @r"
 	AND[0]: (v[2] ⊕ v[3]) ∧ (v[4]) = (v[6])
-	MUL[0]: (v[2] ⊕ v[3]) * (v[5]) = (HI: v[7], LO: v[8])
+	IMUL[0]: (v[2] ⊕ v[3]) * (v[5]) = (HI: v[7], LO: v[8])
 	");
 }
 
 #[test]
 fn test_mul_inlining_into_hi_lo() {
-	// hi and lo are linear defs to be inlined into MUL
+	// hi and lo are linear defs to be inlined into IMUL
 	let b = mk_circuit_builder();
 
 	let a = b.add_witness();
@@ -200,13 +200,13 @@ fn test_mul_inlining_into_hi_lo() {
 	// Now enforce hi_src and lo_src via XOR-to-all-1 & = dst by using them in subsequent
 	// constraints Connect hi_src and lo_src as replacements for the outputs of imul
 	// We cannot directly modify outputs, but using them later in ANDs will keep them alive
-	// The important check is that MUL constraint references should inline hi_src and lo_src
+	// The important check is that IMUL constraint references should inline hi_src and lo_src
 
 	let cs = compile(b);
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @r"
 	AND[0]: (v[2] ⊕ v[3]) ∧ (all-1) = (v[8])
 	AND[1]: (v[4] ⊕ v[5]) ∧ (all-1) = (v[9])
-	MUL[0]: (v[6]) * (v[7]) = (HI: v[10], LO: v[11])
+	IMUL[0]: (v[6]) * (v[7]) = (HI: v[10], LO: v[11])
 	");
 }
 
@@ -230,7 +230,7 @@ fn test_mul_inlining_distinct_linears() {
 	let (_hi, _lo) = b.imul(y1, y2);
 
 	let cs = compile(b);
-	insta::assert_snapshot!(stringify_constraint_system(&cs), @"MUL[0]: (v[2] ⊕ v[3]) * (v[4]≪3 ⊕ v[5]) = (HI: v[6], LO: v[7])");
+	insta::assert_snapshot!(stringify_constraint_system(&cs), @"IMUL[0]: (v[2] ⊕ v[3]) * (v[4]≪3 ⊕ v[5]) = (HI: v[6], LO: v[7])");
 }
 
 #[test]

--- a/crates/frontend/src/compiler/gate_fusion/tests/commit_set.rs
+++ b/crates/frontend/src/compiler/gate_fusion/tests/commit_set.rs
@@ -176,14 +176,14 @@ fn test_all_or_nothing_across_and_and_mul() {
 	// x = sll(a, 20)
 	// y = x ^ c (OK to inline)
 	// z = srl(x, 5) (incompatible with sll)
-	// Use y in AND and z in MUL -> x must be committed due to mixed uses
+	// Use y in AND and z in IMUL -> x must be committed due to mixed uses
 	test_commit_set(
 		|cb| {
 			cb.linear().rhs(sll(w(0), 20)).dst(w(1)).build(); // x
 			cb.linear().rhs(xor2(w(1), w(2))).dst(w(3)).build(); // y = x ^ c
 			cb.linear().rhs(srl(w(1), 5)).dst(w(4)).build(); // z = x >> 5
 			cb.and().a(w(3)).b(w(5)).c(w(6)).build();
-			cb.mul().a(w(4)).b(w(7)).hi(w(8)).lo(w(9)).build();
+			cb.imul().a(w(4)).b(w(7)).hi(w(8)).lo(w(9)).build();
 		},
 		&[w(1)],       // x must be committed
 		&[w(3), w(4)], // y and z can inline their inputs (subject to x being committed)
@@ -487,15 +487,15 @@ fn test_complex_xor_chain() {
 }
 
 #[test]
-fn test_wire_used_in_mul_constraint() {
+fn test_wire_used_in_imul_constraint() {
 	// Test: y = x ^ a, mul(y, b) = hi:lo
-	// y should be inlinable into the MUL constraint
+	// y should be inlinable into the IMUL constraint
 	test_commit_set(
 		|cb| {
 			// y = x ^ a
 			cb.linear().rhs(xor2(w(0), w(1))).dst(w(2)).build();
 			// mul(y, b) = hi:lo
-			cb.mul().a(w(2)).b(w(3)).hi(w(4)).lo(w(5)).build();
+			cb.imul().a(w(2)).b(w(3)).hi(w(4)).lo(w(5)).build();
 		},
 		&[],     // y can be inlined
 		&[w(2)], // y should not be committed

--- a/crates/frontend/src/compiler/mod.rs
+++ b/crates/frontend/src/compiler/mod.rs
@@ -105,7 +105,7 @@ pub(crate) struct Shared {
 /// Methods like [`band`] and [`iadd_32`] add gates to the graph and return handles
 /// to output wires.
 ///
-/// During [`build`], the gate graph compiles into AND and MUL constraints
+/// During [`build`], the gate graph compiles into AND and IMUL constraints
 /// that the proof system operates on directly.
 ///
 /// # Wire Types
@@ -138,7 +138,7 @@ pub(crate) struct Shared {
 /// **AND constraints** - Baseline unit of cost. Bitwise operations and comparisons
 /// generate 1-2 AND constraints.
 ///
-/// **MUL constraints** - 64-bit multiplication costs ~3-4× more than AND constraints.
+/// **IMUL constraints** - 64-bit multiplication costs ~3-4× more than AND constraints.
 ///
 /// **Committed values** - Each public input/output and witness adds to proof size
 /// (~0.2× of an AND constraint).
@@ -320,7 +320,7 @@ impl CircuitBuilder {
 		debug_assert_eq!(wire_mapping[all_one], binius_core::ValueIndex(0));
 		debug_assert_eq!(constants.first(), Some(&Word::ALL_ONE));
 
-		let (mut and_constraints, mut mul_constraints) = builder.build(&wire_mapping, all_one);
+		let (mut and_constraints, mut imul_constraints) = builder.build(&wire_mapping, all_one);
 
 		// Filter zero constant terms from all operands. Any shift of Word::ZERO is zero, so
 		// terms referencing a zero constant contribute nothing to an XOR operand.
@@ -337,7 +337,7 @@ impl CircuitBuilder {
 				filter_zeros(&mut c.b);
 				filter_zeros(&mut c.c);
 			}
-			for c in &mut mul_constraints {
+			for c in &mut imul_constraints {
 				filter_zeros(&mut c.a);
 				filter_zeros(&mut c.b);
 				filter_zeros(&mut c.hi);
@@ -346,7 +346,7 @@ impl CircuitBuilder {
 		}
 
 		let cs =
-			ConstraintSystem::new(constants, value_vec_layout, and_constraints, mul_constraints);
+			ConstraintSystem::new(constants, value_vec_layout, and_constraints, imul_constraints);
 		if cfg!(debug_assertions) {
 			// Validate that the resulting constraint system has a good shape.
 			cs.validate().unwrap();
@@ -1031,7 +1031,7 @@ impl CircuitBuilder {
 	///
 	/// # Cost
 	///
-	/// - 1 MUL constraint,
+	/// - 1 IMUL constraint,
 	/// - 1 AND constraint (for security check).
 	pub fn imul(&self, a: Wire, b: Wire) -> (Wire, Wire) {
 		let hi = self.add_internal();

--- a/crates/frontend/src/compiler/tests.rs
+++ b/crates/frontend/src/compiler/tests.rs
@@ -639,12 +639,12 @@ fn test_zero_constant_not_in_binius64_operands() {
 			}
 		}
 	}
-	for constraint in &cs.mul_constraints {
+	for constraint in &cs.imul_constraints {
 		for operand in [&constraint.a, &constraint.b, &constraint.hi, &constraint.lo] {
 			for term in operand {
 				assert!(
 					!zero_const_indices.contains(&(term.value_index.0 as usize)),
-					"zero constant at ValueIndex({}) found in MUL operand",
+					"zero constant at ValueIndex({}) found in IMUL operand",
 					term.value_index.0
 				);
 			}

--- a/crates/frontend/src/lib.rs
+++ b/crates/frontend/src/lib.rs
@@ -5,7 +5,7 @@
 //!
 //! This crate provides the [`CircuitBuilder`] API for constructing arithmetic circuits
 //! that compile to Binius64 constraint systems. You describe your computation as a graph
-//! of operations on 64-bit words, and the frontend compiles it to AND/MUL constraints.
+//! of operations on 64-bit words, and the frontend compiles it to AND/IMUL constraints.
 //!
 //! # Usage Flow
 //!

--- a/crates/frontend/src/ops.rs
+++ b/crates/frontend/src/ops.rs
@@ -43,7 +43,7 @@ use crate::{CircuitBuilder, Wire};
 ///
 /// # Cost
 ///
-/// - 1 MUL constraint for the unsigned product.
+/// - 1 IMUL constraint for the unsigned product.
 /// - 1 AND constraint for the unsigned product security check.
 /// - 2 AND constraints for the sign masks.
 /// - 2 AND constraints for the corrections.
@@ -144,7 +144,7 @@ mod tests {
 			// Evaluate the circuit to fill every internal wire.
 			w.circuit.populate_wire_witness(&mut w).unwrap();
 
-			// All AND/MUL constraints must hold for the correct witness.
+			// All AND/IMUL constraints must hold for the correct witness.
 			let cs = circuit.constraint_system();
 			verify_constraints(cs, &w.into_value_vec()).unwrap();
 		}
@@ -259,7 +259,7 @@ mod tests {
 	}
 
 	#[test]
-	fn test_smul_constraint_verification() {
+	fn test_simul_constraint_verification() {
 		// Invariant: negative × negative gives a positive product.
 		let builder = CircuitBuilder::new();
 		let x = builder.add_inout();

--- a/crates/frontend/src/stat.rs
+++ b/crates/frontend/src/stat.rs
@@ -21,10 +21,10 @@ pub struct CircuitStat {
 	///
 	/// Affects performance of AND reduction.
 	pub n_and_constraints: usize,
-	/// Number of MUL constraints in the circuit.
+	/// Number of IMUL constraints in the circuit.
 	///
 	/// Affects performance of intmul reduction phase.
-	pub n_mul_constraints: usize,
+	pub n_imul_constraints: usize,
 	/// Number of distinct value indices with non-zero shift in the circuit.
 	///
 	/// Every use of a value with a distinct type and amount is counted here.
@@ -55,8 +55,8 @@ pub struct CircuitStat {
 	pub n_scratch: usize,
 	/// Allocated size for AND constraints (power of 2)
 	pub and_allocated: usize,
-	/// Allocated size for MUL constraints (power of 2)
-	pub mul_allocated: usize,
+	/// Allocated size for IMUL constraints (power of 2)
+	pub imul_allocated: usize,
 	/// Allocated size for public section (power of 2)
 	pub public_allocated: usize,
 	/// Allocated size for private section.
@@ -77,7 +77,7 @@ impl CircuitStat {
 
 		// Store original counts before padding
 		let n_and_constraints = cs.n_and_constraints();
-		let n_mul_constraints = cs.n_mul_constraints();
+		let n_imul_constraints = cs.n_imul_constraints();
 		let (distinct_shifted_value_indices, distinct_unshifted_value_indices) =
 			traverse_constraint_system(&cs);
 
@@ -87,7 +87,7 @@ impl CircuitStat {
 
 		// Now we have the actual allocated sizes after padding
 		let and_allocated = cs.n_and_constraints();
-		let mul_allocated = cs.n_mul_constraints();
+		let imul_allocated = cs.n_imul_constraints();
 
 		// The public section size is already determined by the layout
 		let n_const = cs.value_vec_layout.n_const;
@@ -102,7 +102,7 @@ impl CircuitStat {
 			n_gates: circuit.n_gates(),
 			n_eval_insn: circuit.n_eval_insn(),
 			n_and_constraints,
-			n_mul_constraints,
+			n_imul_constraints,
 			value_vec_len: total_allocated,
 			distinct_shifted_value_indices,
 			distinct_unshifted_value_indices,
@@ -112,7 +112,7 @@ impl CircuitStat {
 			n_internal: cs.value_vec_layout.n_internal,
 			n_scratch: cs.value_vec_layout.n_scratch,
 			and_allocated,
-			mul_allocated,
+			imul_allocated,
 			public_allocated,
 			private_allocated,
 		}
@@ -184,32 +184,32 @@ impl fmt::Display for CircuitStat {
 			fmt_num(and_spare)
 		)?;
 
-		let mul_percent = if self.mul_allocated > 0 {
-			self.n_mul_constraints as f64 / self.mul_allocated as f64 * 100.0
+		let imul_percent = if self.imul_allocated > 0 {
+			self.n_imul_constraints as f64 / self.imul_allocated as f64 * 100.0
 		} else {
 			0.0
 		};
-		let mul_spare = self.mul_allocated - self.n_mul_constraints;
-		// A circuit with no MUL constraints allocates nothing (the IntMul reduction is skipped),
+		let imul_spare = self.imul_allocated - self.n_imul_constraints;
+		// A circuit with no IMUL constraints allocates nothing (the IntMul reduction is skipped),
 		// so there is no power-of-two allocation to report — unlike AND, which is always padded to
 		// at least one.
-		let mul_allocation = if self.mul_allocated == 0 {
+		let imul_allocation = if self.imul_allocated == 0 {
 			"0".to_string()
 		} else {
-			format!("2^{}", log2(self.mul_allocated))
+			format!("2^{}", log2(self.imul_allocated))
 		};
 		writeln!(
 			f,
-			"├─ MUL constraints: {} used ({:.1}% of {})",
-			fmt_num(self.n_mul_constraints),
-			mul_percent,
-			mul_allocation
+			"├─ IMUL constraints: {} used ({:.1}% of {})",
+			fmt_num(self.n_imul_constraints),
+			imul_percent,
+			imul_allocation
 		)?;
 		writeln!(
 			f,
 			"│  {} spare: {}",
-			progress_bar(self.n_mul_constraints, self.mul_allocated),
-			fmt_num(mul_spare)
+			progress_bar(self.n_imul_constraints, self.imul_allocated),
+			fmt_num(imul_spare)
 		)?;
 		writeln!(
 			f,
@@ -306,7 +306,7 @@ fn traverse_constraint_system(cs: &ConstraintSystem) -> (usize, usize) {
 		visit_operand(&and.b, &mut cx);
 		visit_operand(&and.c, &mut cx);
 	}
-	for mul in &cs.mul_constraints {
+	for mul in &cs.imul_constraints {
 		visit_operand(&mul.a, &mut cx);
 		visit_operand(&mul.b, &mut cx);
 		visit_operand(&mul.lo, &mut cx);

--- a/crates/m4-prover/benches/utils/m4_bench.rs
+++ b/crates/m4-prover/benches/utils/m4_bench.rs
@@ -37,7 +37,7 @@ use criterion::{BenchmarkId, Criterion, Throughput};
 ///
 /// # Panics
 ///
-/// Panics if the circuit has inout wires or MUL constraints.
+/// Panics if the circuit has inout wires or IMUL constraints.
 /// Panics if the correctness gate fails to verify.
 pub fn bench_m4_proving<F>(
 	c: &mut Criterion,

--- a/crates/m4-prover/src/operand_witness.rs
+++ b/crates/m4-prover/src/operand_witness.rs
@@ -2,8 +2,8 @@
 
 //! The batched operand-column witnesses built from a populated batch value table.
 //!
-//! Every AND and MUL constraint is projected to its fixed-arity operand columns (`[A, B, C]` for
-//! AND, `[A, B, HI, LO]` for MUL), one column per operand, stacked over every instance in the
+//! Every AND and IMUL constraint is projected to its fixed-arity operand columns (`[A, B, C]` for
+//! AND, `[A, B, HI, LO]` for IMUL), one column per operand, stacked over every instance in the
 //! batch. [`build_operation_witness`] is the shared arity-generic core: it projects one operand
 //! per constraint into one column. [`BatchAndCheckWitness`] builds the three AND columns and
 //! drives the AND-check zerocheck; [`build_intmul_witness`] builds the four IntMul columns, not
@@ -13,7 +13,7 @@ use std::{iter, mem::MaybeUninit, ptr};
 
 use binius_core::{
 	ValueIndex,
-	constraint_system::{AndConstraint, MulConstraint, Operand, ShiftVariant, ShiftedValueIndex},
+	constraint_system::{AndConstraint, ImulConstraint, Operand, ShiftVariant, ShiftedValueIndex},
 	word::Word,
 };
 use binius_field::{AESTowerField8b as B8, PackedField};
@@ -457,7 +457,7 @@ fn accum_shifted_values(
 
 /// Builds the batched IntMul operand witness from a populated wire-major batch table.
 ///
-/// Every MUL constraint contributes one row per instance to each of the four operand columns
+/// Every IMUL constraint contributes one row per instance to each of the four operand columns
 /// `A`, `B`, `HI`, `LO`, laid out constraint-major. This delegates to the arity-generic
 /// `build_operation_witness`, projecting each constraint to its four operands.
 ///
@@ -465,7 +465,7 @@ fn accum_shifted_values(
 ///
 /// - `table`: the wire-major batch witness holding every instance's hidden words.
 /// - `constants`: the circuit's constant words, shared by every instance.
-/// - `mul_constraints`: the per-instance MUL constraints, shared by every instance.
+/// - `imul_constraints`: the per-instance IMUL constraints, shared by every instance.
 ///
 /// Pass constraints from a prepared constraint system, so their count is a power of two.
 ///
@@ -475,12 +475,12 @@ fn accum_shifted_values(
 pub fn build_intmul_witness(
 	table: &ValueTable,
 	constants: &[Word],
-	mul_constraints: &[MulConstraint],
+	imul_constraints: &[ImulConstraint],
 ) -> [Vec<Word>; 4] {
-	let a_operand_iter = mul_constraints.par_iter().map(|constraint| &constraint.a);
-	let b_operand_iter = mul_constraints.par_iter().map(|constraint| &constraint.b);
-	let hi_operand_iter = mul_constraints.par_iter().map(|constraint| &constraint.hi);
-	let lo_operand_iter = mul_constraints.par_iter().map(|constraint| &constraint.lo);
+	let a_operand_iter = imul_constraints.par_iter().map(|constraint| &constraint.a);
+	let b_operand_iter = imul_constraints.par_iter().map(|constraint| &constraint.b);
+	let hi_operand_iter = imul_constraints.par_iter().map(|constraint| &constraint.hi);
+	let lo_operand_iter = imul_constraints.par_iter().map(|constraint| &constraint.lo);
 	let ((a, b), (hi, lo)) = rayon::join(
 		|| {
 			rayon::join(
@@ -692,9 +692,9 @@ mod tests {
 	// A circuit computing one unsigned 64×64→128 product, with both result words committed.
 	//
 	//     inputs : x, y   (witness)
-	//     gate   : (hi, lo) = imul(x, y)   → 1 MUL constraint (+ 1 AND security check)
+	//     gate   : (hi, lo) = imul(x, y)   → 1 IMUL constraint (+ 1 AND security check)
 	//
-	// `force_commit` makes `hi` and `lo` hidden words, so the MUL operands read them from the
+	// `force_commit` makes `hi` and `lo` hidden words, so the IMUL operands read them from the
 	// table.
 	struct MulCircuit {
 		circuit: Circuit,
@@ -744,18 +744,18 @@ mod tests {
 		];
 		let table = populate_mul_table(&c, &inputs);
 
-		// The prepared per-instance MUL constraints, padded to a power of two.
+		// The prepared per-instance IMUL constraints, padded to a power of two.
 		let mut cs = c.circuit.constraint_system().clone();
 		cs.validate_and_prepare().unwrap();
-		let mul_constraints = &cs.mul_constraints;
-		assert!(!mul_constraints.is_empty(), "the circuit must emit a MUL constraint");
+		let imul_constraints = &cs.imul_constraints;
+		assert!(!imul_constraints.is_empty(), "the circuit must emit an IMUL constraint");
 
-		let [a, b, hi, lo] = build_intmul_witness(&table, constants, mul_constraints);
+		let [a, b, hi, lo] = build_intmul_witness(&table, constants, imul_constraints);
 
-		// Shape: K * n_mul rows, with K = 4.
-		let n_mul = mul_constraints.len();
+		// Shape: K * n_imul rows, with K = 4.
+		let n_imul = imul_constraints.len();
 		for col in [&a, &b, &hi, &lo] {
-			assert_eq!(col.len(), 4 * n_mul);
+			assert_eq!(col.len(), 4 * n_imul);
 		}
 
 		// Invariant: row `j * n_instances + instance` is constraint `j` of that instance, and each
@@ -763,7 +763,7 @@ mod tests {
 		let n_instances = table.n_instances();
 		for instance in 0..n_instances {
 			let vv = table.instance_value_vec(instance, constants);
-			for (j, con) in mul_constraints.iter().enumerate() {
+			for (j, con) in imul_constraints.iter().enumerate() {
 				let idx = j * n_instances + instance;
 				assert_eq!(a[idx], vv.eval_operand(&con.a));
 				assert_eq!(b[idx], vv.eval_operand(&con.b));

--- a/crates/m4-prover/src/prove.rs
+++ b/crates/m4-prover/src/prove.rs
@@ -70,7 +70,7 @@ type ProverNtt = NeighborsLastMultiThread<GenericPreExpanded<B128>>;
 ///
 /// The trace oracle is not ZK, so the channel masks nothing and needs no randomness.
 ///
-/// With MUL constraints the reduction commits one further oracle: the IntMul logup* pushforward.
+/// With IMUL constraints the reduction commits one further oracle: the IntMul logup* pushforward.
 /// The IntMul check queues that oracle's opening itself.
 /// The final combined FRI opening covers it alongside the trace, so it needs no handling here.
 pub struct IOPProver {
@@ -132,7 +132,7 @@ impl IOPProver {
 			.reduce_dim(Word::LOG_BITS)
 			.isomorphic::<B128>();
 
-		// Build the IntMul operand columns and run the IntMul check, only when the circuit has MUL
+		// Build the IntMul operand columns and run the IntMul check, only when the circuit has IMUL
 		// constraints.
 		//
 		// SOUNDNESS: the IntMul check runs before the BitAnd check below.
@@ -145,13 +145,13 @@ impl IOPProver {
 		// constraint-major.
 		// They are kept alongside the check output.
 		// The re-randomization re-reads them to build the instance-axis multilinears it transports.
-		let mul = (!cs.mul_constraints.is_empty()).then(|| {
+		let mul = (!cs.imul_constraints.is_empty()).then(|| {
 			let columns = {
 				let _scope = tracing::debug_span!("Assemble IntMul witness").entered();
 				// `build_intmul_witness` yields `[A, B, HI, LO]`; reorder to the `[A, B, LO, HI]`
 				// operand order the IntMul witness and the shift both expect.
 				let [a, b, hi, lo] =
-					build_intmul_witness(table, &cs.constants, &cs.mul_constraints);
+					build_intmul_witness(table, &cs.constants, &cs.imul_constraints);
 				[a, b, lo, hi]
 			};
 			let output = prove_intmul::<P, _>(&columns, channel);
@@ -199,7 +199,7 @@ impl IOPProver {
 				// IntMul is collapsed from its per-bit form.
 				let lagrange = lagrange_evals_scalars::<B128, B128>(&shift_domain, z_challenge);
 				let and_columns = and_columns
-					.expect("AND columns are retained whenever there are MUL constraints");
+					.expect("AND columns are retained whenever there are IMUL constraints");
 				RerandomizedOperations {
 					bitand: Operation::new(
 						&and_columns,
@@ -216,7 +216,7 @@ impl IOPProver {
 				}
 				.prove::<P, _>(&lagrange, z_challenge, channel)
 			}
-			// No MUL constraints: the AND-check instance point is used directly.
+			// No IMUL constraints: the AND-check instance point is used directly.
 			// The IntMul claim is a zero claim at an empty point, contributing nothing to the
 			// shift.
 			None => (
@@ -366,7 +366,7 @@ where
 ///
 /// The four columns are the multiplicands and the low and high product words, in the order
 /// `[A, B, LO, HI]`.
-/// Each is `K * n_mul` rows, laid out constraint-major.
+/// Each is `K * n_imul` rows, laid out constraint-major.
 /// The check reduces the multiplication relation to per-bit evaluation claims on the four columns.
 /// Those claims share a common row point.
 fn prove_intmul<P, Channel>(columns: &[Vec<Word>; 4], channel: &mut Channel) -> IntMulOutput<B128>
@@ -687,9 +687,9 @@ mod tests {
 			.expect("no trailing proof data");
 	}
 
-	// A circuit carrying MUL constraints round-trips through the whole protocol.
+	// A circuit carrying IMUL constraints round-trips through the whole protocol.
 	//
-	// With MUL constraints the proof commits two oracles rather than one:
+	// With IMUL constraints the proof commits two oracles rather than one:
 	//
 	//     trace oracle    : the packed batch witness
 	//     logup* oracle   : the IntMul check's pushforward
@@ -698,7 +698,7 @@ mod tests {
 	// unifies before the witness is folded.
 	//
 	// Fixture: one unsigned 64x64 -> 128 product per instance over 2^6 instances, both product
-	// words force-committed. The `imul` gate emits one MUL constraint and one AND security check.
+	// words force-committed. The `imul` gate emits one IMUL constraint and one AND security check.
 	//
 	// A faithful proof verifies, both oracles open, and no trailing data is left.
 	#[test]
@@ -715,7 +715,7 @@ mod tests {
 		let mut cs = circuit.constraint_system().clone();
 		cs.validate_and_prepare().unwrap();
 		// Confirm the fixture genuinely exercises the IntMul path.
-		assert!(!cs.mul_constraints.is_empty(), "the fixture must emit a MUL constraint");
+		assert!(!cs.imul_constraints.is_empty(), "the fixture must emit an IMUL constraint");
 
 		// Fill each instance's two multiplicands from a per-instance seed; the circuit derives the
 		// two product words.
@@ -810,8 +810,8 @@ mod tests {
 			.expect("no trailing proof data");
 	}
 
-	// Independent AND constraints alongside MUL constraints, so the two operations reduce to
-	// constraint points of different lengths (`log_n_and != log_n_mul`) and to genuinely different
+	// Independent AND constraints alongside IMUL constraints, so the two operations reduce to
+	// constraint points of different lengths (`log_n_and != log_n_imul`) and to genuinely different
 	// instance points that the re-randomization must unify.
 	//
 	// Proving with a width-2 packing exercises the packed lane layout and zero-padding of the
@@ -830,7 +830,7 @@ mod tests {
 			let and = builder.band(pair[0], pair[1]);
 			builder.force_commit(and);
 		}
-		// Two products — fewer MUL constraints than AND constraints.
+		// Two products — fewer IMUL constraints than AND constraints.
 		for pair in inputs.chunks_exact(2).take(2) {
 			let (hi, lo) = builder.imul(pair[0], pair[1]);
 			builder.force_commit(hi);
@@ -843,9 +843,9 @@ mod tests {
 		// Confirm the fixture genuinely exercises the asymmetric case: the two operations have
 		// different constraint-point lengths.
 		let log_n_and = checked_log_2(cs.and_constraints.len());
-		let log_n_mul = checked_log_2(cs.mul_constraints.len());
+		let log_n_imul = checked_log_2(cs.imul_constraints.len());
 		assert_ne!(
-			log_n_and, log_n_mul,
+			log_n_and, log_n_imul,
 			"the fixture must give the operations different r_x lengths"
 		);
 

--- a/crates/m4-prover/src/shift.rs
+++ b/crates/m4-prover/src/shift.rs
@@ -107,7 +107,7 @@ pub fn fold_instances<F: BinaryField>(table: &ValueTable, r_rho: &[F]) -> Vec<Fo
 /// - `public_words`: the public (constant) words, shared by every instance.
 /// - `folded_witness`: the hidden witness, folded over the instance axis, one word per entry.
 /// - `bitand_data`: operator data for the bitand (AND) constraints.
-/// - `intmul_data`: operator data for the intmul (MUL) constraints.
+/// - `intmul_data`: operator data for the intmul (IMUL) constraints.
 /// - `domain_subspace`: the univariate evaluation domain.
 /// - `channel`: the prover channel driving the interactive protocol.
 ///
@@ -527,8 +527,8 @@ mod tests {
 		let _offset = table.layout().offset_witness;
 		let public_words = &cs.constants;
 
-		// The bitand operand evals at (r_z, r_x, r_rho); the circuit has no MUL constraints, so the
-		// intmul claim is the zero claim over an empty point.
+		// The bitand operand evals at (r_z, r_x, r_rho); the circuit has no IMUL constraints, so
+		// the intmul claim is the zero claim over an empty point.
 		let bitand_evals = evaluate_and_witness::<P>(
 			&table,
 			public_words,
@@ -653,7 +653,7 @@ mod tests {
 		let hidden_folded = fold_words_over_instances(&table, constants, &r_rho, offset..combined);
 
 		// Prepare the operator data: lambda batches the three operand claims. The circuit has no
-		// MUL constraints, so the intmul claim is empty.
+		// IMUL constraints, so the intmul claim is empty.
 		let prepared_bitand = PreparedOperatorData::new(
 			OperatorData {
 				evals: bitand_evals.to_vec(),

--- a/crates/m4-prover/tests/prove_hash_primitives.rs
+++ b/crates/m4-prover/tests/prove_hash_primitives.rs
@@ -223,9 +223,9 @@ fn fill_keccak(
 
 /// Builds a circuit for one 64×64→128-bit integer multiplication and force-commits its output.
 ///
-/// Unlike the hash primitives (which are purely bitwise / carry-adder based), this circuit has MUL
+/// Unlike the hash primitives (which are purely bitwise / carry-adder based), this circuit has IMUL
 /// constraints, so its M4 proof commits the extra IntMul logup* pushforward oracle — exercising the
-/// MUL branch of `IOPVerifier::oracle_specs`.
+/// IMUL branch of `IOPVerifier::oracle_specs`.
 fn build_imul_circuit() -> (Circuit, [Wire; 2]) {
 	let builder = CircuitBuilder::new();
 
@@ -268,7 +268,7 @@ fn prove_keccak_permutation() {
 
 // Proves one 64×64→128-bit multiplication through M4 and verifies it.
 //
-// This is the only primitive here with MUL constraints, so it covers the IntMul pushforward oracle
+// This is the only primitive here with IMUL constraints, so it covers the IntMul pushforward oracle
 // spec that `IOPVerifier::oracle_specs` derives — a wrong spec list would make the shared
 // prover/verifier compiler disagree and fail the trace opening.
 #[test]

--- a/crates/m4-verifier/src/verify.rs
+++ b/crates/m4-verifier/src/verify.rs
@@ -61,7 +61,7 @@ type Scheme = BinaryMerkleTreeScheme<B128, StdHashSuite>;
 /// 4. The public-input consistency check ties in the shared constants.
 /// 5. The ring-switch opens the committed trace at `r_j || r_rho || r_y`, matching that claim.
 ///
-/// When the circuit has MUL constraints the IntMul check verifies too.
+/// When the circuit has IMUL constraints the IntMul check verifies too.
 /// It yields per-bit operand claims at its own instance point, distinct from the AND-check's.
 /// A batched multilinear-evaluation sumcheck unifies both onto one shared `r_rho`.
 /// Both operand claims at that point then feed the shift.
@@ -95,7 +95,7 @@ impl IOPVerifier {
 	}
 
 	/// Returns the oracle specs the prover commits to: the trace, plus the IntMul logup*
-	/// pushforward when the circuit has MUL constraints.
+	/// pushforward when the circuit has IMUL constraints.
 	///
 	/// The specs are derived by replaying the oracle-receiving sequence against an
 	/// [`OracleSetupChannel`] — which records each `recv_oracle` without doing real verification —
@@ -153,10 +153,10 @@ impl IOPVerifier {
 		// challenge. Do not reorder these, and keep the same order in `IOPProver::prove`.
 		//
 		// The IntMul columns span every instance's constraints.
-		// So the check runs over `log_instances + log_n_mul` row variables.
-		let intmul_output = if cs.n_mul_constraints() > 0 {
-			let log_n_mul = checked_log_2(cs.n_mul_constraints());
-			Some(verify_intmul_reduction::<B128, _>(log_instances + log_n_mul, channel)?)
+		// So the check runs over `log_instances + log_n_imul` row variables.
+		let intmul_output = if cs.n_imul_constraints() > 0 {
+			let log_n_imul = checked_log_2(cs.n_imul_constraints());
+			Some(verify_intmul_reduction::<B128, _>(log_instances + log_n_imul, channel)?)
 		} else {
 			None
 		};
@@ -191,7 +191,7 @@ impl IOPVerifier {
 				}
 				.verify(channel)?
 			}
-			// No MUL constraints: the AND-check instance point is used directly.
+			// No IMUL constraints: the AND-check instance point is used directly.
 			// The IntMul claim is a zero claim at an empty point.
 			None => (
 				r_rho_and.to_vec(),
@@ -270,7 +270,7 @@ impl Verifier {
 		let iop_verifier = IOPVerifier::new(cs.clone(), layout);
 
 		// The oracle specs the prover commits to — the trace, plus the IntMul logup* pushforward
-		// when the circuit has MUL constraints. Derived by replaying the verifier's
+		// when the circuit has IMUL constraints. Derived by replaying the verifier's
 		// oracle-receiving sequence against an `OracleSetupChannel`, so the list can never drift
 		// out of sync with the oracles the checks actually commit.
 		let oracle_specs = iop_verifier.oracle_specs();

--- a/crates/prover/benches/shift_reduction.rs
+++ b/crates/prover/benches/shift_reduction.rs
@@ -100,7 +100,7 @@ fn bench_prove_and_verify(c: &mut Criterion) {
 				.map(F::new)
 				.collect::<Vec<_>>()
 		};
-		// SHA256 has no MUL constraints, so the IntMul operator is the zero claim (four zero evals
+		// SHA256 has no IMUL constraints, so the IntMul operator is the zero claim (four zero evals
 		// at an empty point), exactly as the real prover/verifier synthesize it (`prove.rs` /
 		// `verify.rs` `None` branch). Its `r_x_prime` is therefore empty.
 		let r_x_prime_intmul: Vec<F> = Vec::new();
@@ -203,7 +203,7 @@ fn bench_shift_phases(c: &mut Criterion) {
 	let r_x_prime_bitand = (0..strict_log_2(cs.and_constraints.len()).unwrap() as u128)
 		.map(F::new)
 		.collect::<Vec<_>>();
-	// SHA256 has no MUL constraints, so the IntMul operator is the zero claim at an empty point,
+	// SHA256 has no IMUL constraints, so the IntMul operator is the zero claim at an empty point,
 	// matching the real prover (`prove.rs` `None` branch).
 	let r_x_prime_intmul: Vec<F> = Vec::new();
 	// `r_zhat_prime` is shared across the bitand and intmul operators.

--- a/crates/prover/src/protocols/shift/key_collection.rs
+++ b/crates/prover/src/protocols/shift/key_collection.rs
@@ -6,7 +6,7 @@ use std::{iter, mem, ops::Range};
 use binius_core::{
 	ShiftVariant,
 	constraint_system::{
-		AndConstraint, ConstraintSystem, MulConstraint, Operand, ShiftedValueIndex,
+		AndConstraint, ConstraintSystem, ImulConstraint, Operand, ShiftedValueIndex,
 	},
 	word::Word,
 };
@@ -27,7 +27,7 @@ use super::{BITAND_ARITY, INTMUL_ARITY, PreparedOperatorData};
 /// # Operation Types
 ///
 /// - **BitwiseAnd**: Corresponds to AND constraints of the form `A & B ^ C = 0`
-/// - **IntegerMul**: Corresponds to MUL constraints of the form `A * B = (HI << 64) | LO`
+/// - **IntegerMul**: Corresponds to IMUL constraints of the form `A * B = (HI << 64) | LO`
 ///
 /// These operations work with shifted value indices to efficiently encode
 /// computations on 64-bit words without requiring separate shift constraints.
@@ -58,7 +58,7 @@ pub enum Operation {
 ///
 /// # Structure
 ///
-/// - **Operation**: Constraint type (AND or MUL)
+/// - **Operation**: Constraint type (AND or IMUL)
 /// - **ID**: Packed encoding of operand index, shift variant, and shift amount
 /// - **Range**: Constraint indices where this shifted word appears
 ///
@@ -330,7 +330,7 @@ pub fn build_key_collection(cs: &ConstraintSystem) -> KeyCollection {
 	// Update the builder keys lists with respect to each operand of each operation
 	let bitand_operand_getters: [fn(&AndConstraint) -> &Operand; BITAND_ARITY] =
 		[|c| &c.a, |c| &c.b, |c| &c.c];
-	let intmul_operand_getters: [fn(&MulConstraint) -> &Operand; INTMUL_ARITY] =
+	let intmul_operand_getters: [fn(&ImulConstraint) -> &Operand; INTMUL_ARITY] =
 		[|c| &c.a, |c| &c.b, |c| &c.lo, |c| &c.hi];
 
 	bitand_operand_getters
@@ -352,7 +352,7 @@ pub fn build_key_collection(cs: &ConstraintSystem) -> KeyCollection {
 			update_with_operand(
 				Operation::IntegerMul,
 				operand_idx,
-				cs.mul_constraints.iter().map(get_operand),
+				cs.imul_constraints.iter().map(get_operand),
 				&mut builder_key_lists,
 			);
 		});

--- a/crates/prover/src/protocols/shift/monster.rs
+++ b/crates/prover/src/protocols/shift/monster.rs
@@ -103,7 +103,7 @@ where
 /// Constructs the "monster multilinear" that combines all shift operations into a single
 /// multilinear.
 ///
-/// This function builds a comprehensive multilinear polynomial that encapsulates both AND and MUL
+/// This function builds a comprehensive multilinear polynomial that encapsulates both AND and IMUL
 /// constraints with their associated shift operations. For each witness word, it computes the
 /// contribution from all constraints involving that word, weighted by the appropriate h-polynomial
 /// evaluations and lambda powers.

--- a/crates/prover/src/protocols/shift/prove.rs
+++ b/crates/prover/src/protocols/shift/prove.rs
@@ -14,7 +14,7 @@ use super::{key_collection::KeyCollection, phase_1::prove_phase_1, phase_2::prov
 ///
 /// Contains evaluation claims and challenge points for an operation.
 ///
-/// Each operator (AND/MUL) has multiple operand positions, each with an oblong evaluation claim.
+/// Each operator (AND/IMUL) has multiple operand positions, each with an oblong evaluation claim.
 /// The `evals` field stores these claim evaluations. The evaluation points consist of:
 /// - `r_zhat_prime`: univariate challenge point (pre-populated)
 /// - `r_x_prime`: multilinear challenge point (pre-populated)
@@ -83,7 +83,7 @@ impl<F: Field> PreparedOperatorData<F> {
 /// - `key_collection`: Prover's key collection representing the constraint system
 /// - `words`: The witness words (must have power-of-2 length)
 /// - `bitand_data`: Operator data for bit multiplication (AND) constraints
-/// - `intmul_data`: Operator data for integer multiplication (MUL) constraints
+/// - `intmul_data`: Operator data for integer multiplication (IMUL) constraints
 /// - `transcript`: The prover's transcript for interactive protocol
 ///
 /// # Returns

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -4,7 +4,7 @@
 use std::marker::PhantomData;
 
 use binius_core::{
-	constraint_system::{AndConstraint, ConstraintSystem, MulConstraint, ValueVec},
+	constraint_system::{AndConstraint, ConstraintSystem, ImulConstraint, ValueVec},
 	word::Word,
 };
 use binius_field::{AESTowerField8b as B8, BinaryField, Divisible, Field, PackedField};
@@ -115,18 +115,18 @@ impl IOPProver {
 
 		// [phase] IntMul Reduction - multiplication constraint reduction
 		//
-		// Skipped entirely (no transcript messages) when the constraint system has no MUL
+		// Skipped entirely (no transcript messages) when the constraint system has no IMUL
 		// constraints. The verifier applies the identical guard, so the transcript stays in sync;
 		// the zero `OperatorData` synthesized below then contributes nothing to the shift
 		// reduction.
-		let intmul_output = if cs.n_mul_constraints() > 0 {
+		let intmul_output = if cs.n_imul_constraints() > 0 {
 			let intmul_guard = tracing::info_span!(
 				"[phase] IntMul check",
-				n_constraints = cs.mul_constraints.len()
+				n_constraints = cs.imul_constraints.len()
 			)
 			.entered();
 			let mul_witness = tracing::debug_span!("Assemble columns")
-				.in_scope(|| build_intmul_witness(&cs.mul_constraints, &witness));
+				.in_scope(|| build_intmul_witness(&cs.imul_constraints, &witness));
 
 			let intmul_output = prove_intmul_reduction::<_, P, _>(mul_witness, &mut *channel)?;
 			drop(intmul_guard);
@@ -161,7 +161,7 @@ impl IOPProver {
 		// Build `OperatorData` for IntMul using the same `r_zhat_prime`
 		// challenge as in BitAnd. Sharing this univariate challenge
 		// improves ShiftReduction perf. When IntMul was skipped, synthesize a zero claim (four
-		// zero evals at an empty point): the shift reduction iterates the (empty) MUL constraints,
+		// zero evals at an empty point): the shift reduction iterates the (empty) IMUL constraints,
 		// so this claim contributes zero to its batched evaluation.
 		//
 		// Build the oblong domain subspace once and pass it into the shift reduction, mirroring
@@ -327,7 +327,7 @@ where
 			"Prove",
 			n_hidden_words = cs.value_vec_layout.n_hidden_words,
 			n_bitand = cs.and_constraints.len(),
-			n_intmul = cs.mul_constraints.len(),
+			n_intmul = cs.imul_constraints.len(),
 		)
 		.entered();
 
@@ -498,8 +498,11 @@ fn build_bitand_witness(and_constraints: &[AndConstraint], witness: &ValueVec) -
 	AndCheckWitness { a, b, c }
 }
 
-fn build_intmul_witness(mul_constraints: &[MulConstraint], witness: &ValueVec) -> MulCheckWitness {
-	let n_constraints = mul_constraints.len();
+fn build_intmul_witness(
+	imul_constraints: &[ImulConstraint],
+	witness: &ValueVec,
+) -> MulCheckWitness {
+	let n_constraints = imul_constraints.len();
 
 	let mut a = Vec::with_capacity(n_constraints);
 	let mut b = Vec::with_capacity(n_constraints);
@@ -507,7 +510,7 @@ fn build_intmul_witness(mul_constraints: &[MulConstraint], witness: &ValueVec) -
 	let mut hi = Vec::with_capacity(n_constraints);
 
 	(
-		mul_constraints,
+		imul_constraints,
 		a.spare_capacity_mut(),
 		b.spare_capacity_mut(),
 		lo.spare_capacity_mut(),

--- a/crates/prover/src/zk_config.rs
+++ b/crates/prover/src/zk_config.rs
@@ -155,7 +155,7 @@ where
 				"Binius64",
 				n_hidden_words = inner_cs.value_vec_layout.n_hidden_words,
 				n_bitand = inner_cs.and_constraints.len(),
-				n_intmul = inner_cs.mul_constraints.len(),
+				n_intmul = inner_cs.imul_constraints.len(),
 			)
 			.entered();
 

--- a/crates/prover/tests/prove_verify.rs
+++ b/crates/prover/tests/prove_verify.rs
@@ -132,14 +132,14 @@ fn test_prove_verify_sha256_preimage() {
 	prove_verify(cs, witness);
 }
 
-/// A SHA-256 circuit uses only AND constraints, so its constraint system has zero MUL
+/// A SHA-256 circuit uses only AND constraints, so its constraint system has zero IMUL
 /// constraints. This locks in that the prover and verifier skip the IntMul reduction entirely
-/// (rather than padding up to a dummy MUL constraint); see `IOPProver::prove` /
+/// (rather than padding up to a dummy IMUL constraint); see `IOPProver::prove` /
 /// `IOPVerifier::verify`.
 #[test]
-fn test_prove_verify_zero_mul_constraints() {
+fn test_prove_verify_zero_imul_constraints() {
 	let (cs, witness) = sha256_preimage_circuit();
-	assert_eq!(cs.n_mul_constraints(), 0, "SHA-256 circuit should have no MUL constraints");
+	assert_eq!(cs.n_imul_constraints(), 0, "SHA-256 circuit should have no IMUL constraints");
 	prove_verify(cs.clone(), witness.clone());
 	prove_verify_zk(cs, witness);
 }

--- a/crates/prover/tests/shift.rs
+++ b/crates/prover/tests/shift.rs
@@ -3,7 +3,7 @@
 
 use binius_circuits::{fixed_byte_vec::ByteVec, sha256::sha256_varlen};
 use binius_core::{
-	constraint_system::{AndConstraint, ConstraintSystem, MulConstraint, ValueVec},
+	constraint_system::{AndConstraint, ConstraintSystem, ImulConstraint, ValueVec},
 	verify::verify_constraints,
 	word::Word,
 };
@@ -150,8 +150,8 @@ pub fn compute_bitand_images(constraints: &[AndConstraint], witness: &ValueVec) 
 	[a_image, b_image, c_image]
 }
 
-// Compute the image of the witness applied to the MUL constraints
-fn compute_intmul_images(constraints: &[MulConstraint], witness: &ValueVec) -> [Vec<Word>; 4] {
+// Compute the image of the witness applied to the IMUL constraints
+fn compute_intmul_images(constraints: &[ImulConstraint], witness: &ValueVec) -> [Vec<Word>; 4] {
 	let (a_image, b_image, hi_image, lo_image) = constraints
 		.iter()
 		.map(|constraint| {
@@ -165,7 +165,7 @@ fn compute_intmul_images(constraints: &[MulConstraint], witness: &ValueVec) -> [
 	[a_image, b_image, hi_image, lo_image]
 }
 
-// Evaluate the image of the witness applied to the AND or MUL constraints
+// Evaluate the image of the witness applied to the AND or IMUL constraints
 // Univariate point is `r_zhat_prime`, multilinear point tensor-expanded is `r_x_prime_tensor`
 fn evaluate_image<F: BinaryField>(
 	subspace: &BinarySubspace<F>,
@@ -225,14 +225,15 @@ fn test_shift_prove_and_verify() {
 				.map(F::new)
 				.collect::<Vec<_>>()
 		};
-		// A constraint system may have zero MUL constraints (e.g. a pure-AND circuit like SHA-256).
-		// The IntMul operator is then empty — an empty challenge point and a zero claim — mirroring
-		// the prover/verifier skip of the IntMul reduction in `binius_prover` / `binius_verifier`.
-		let intmul_is_empty = cs.mul_constraints.is_empty();
+		// A constraint system may have zero IMUL constraints (e.g. a pure-AND circuit like
+		// SHA-256). The IntMul operator is then empty — an empty challenge point and a zero claim
+		// — mirroring the prover/verifier skip of the IntMul reduction in `binius_prover` /
+		// `binius_verifier`.
+		let intmul_is_empty = cs.imul_constraints.is_empty();
 		let r_x_prime_intmul = if intmul_is_empty {
 			Vec::new()
 		} else {
-			let log_intmul_constraint_count = strict_log_2(cs.mul_constraints.len()).unwrap();
+			let log_intmul_constraint_count = strict_log_2(cs.imul_constraints.len()).unwrap();
 			(0..log_intmul_constraint_count as u128)
 				.map(F::new)
 				.collect::<Vec<_>>()
@@ -256,7 +257,7 @@ fn test_shift_prove_and_verify() {
 		let intmul_evals: [F; 4] = if intmul_is_empty {
 			[F::ZERO; 4]
 		} else {
-			compute_intmul_images(&cs.mul_constraints, &value_vec).map(|image| {
+			compute_intmul_images(&cs.imul_constraints, &value_vec).map(|image| {
 				evaluate_image(
 					&subspace,
 					&image,

--- a/crates/verifier/src/protocols/shift/monster.rs
+++ b/crates/verifier/src/protocols/shift/monster.rs
@@ -86,7 +86,7 @@ pub fn evaluate_h_op<E: FieldOps>(l_tilde: &[E], r_j: &[E], r_s: &[E]) -> [E; SH
 
 /// Evaluates the monster multilinear polynomial for a constraint operation.
 ///
-/// The monster multilinear encodes all constraints of a given type (AND or MUL) into
+/// The monster multilinear encodes all constraints of a given type (AND or IMUL) into
 /// a single polynomial. For an operation with multiple operands, it computes:
 ///
 /// $$

--- a/crates/verifier/src/protocols/shift/verify.rs
+++ b/crates/verifier/src/protocols/shift/verify.rs
@@ -4,7 +4,7 @@
 use std::{array, iter};
 
 use binius_core::{
-	constraint_system::{AndConstraint, ConstraintSystem, MulConstraint, Operand},
+	constraint_system::{AndConstraint, ConstraintSystem, ImulConstraint, Operand},
 	word::Word,
 };
 use binius_field::{BinaryField, field::FieldOps, util::FieldFn};
@@ -102,7 +102,7 @@ impl<F: FieldOps, const ARITY: usize> OperatorData<F, ARITY> {
 pub struct VerifyOutput<F> {
 	/// Random coefficient for batching AND constraint evaluations.
 	bitand_lambda: F,
-	/// Random coefficient for batching MUL constraint evaluations.
+	/// Random coefficient for batching IMUL constraint evaluations.
 	intmul_lambda: F,
 	/// Challenge point for the bit index variables (length `Word::LOG_BITS`).
 	pub r_j: Vec<F>,
@@ -154,11 +154,11 @@ impl<F> VerifyOutput<F> {
 /// 3. **Challenge Splitting**: Splits sumcheck challenges into `r_j` and `r_s` components
 /// 4. **Second Sumcheck**: Verifies the gamma claim over `log_word_count` variables
 /// 5. **Monster Multilinear Verification**: Checks that the claimed evaluations match expected
-///    monster multilinear evaluations for both AND constraints (bitand) and MUL constraints
+///    monster multilinear evaluations for both AND constraints (bitand) and IMUL constraints
 ///    (intmul)
 ///
 /// # Parameters
-/// - `constraint_system`: The constraint system containing AND and MUL constraints (consumed)
+/// - `constraint_system`: The constraint system containing AND and IMUL constraints (consumed)
 /// - `bitand_data`: Operator data for bit multiplication operations
 /// - `intmul_data`: Operator data for integer multiplication operations
 /// - `transcript`: Interactive transcript for challenge sampling and message reading
@@ -230,7 +230,7 @@ where
 ///
 /// After the shift reduction protocol completes, this function checks that the
 /// prover-provided witness evaluation is consistent with the expected values.
-/// It computes the monster multilinear evaluations for both AND and MUL constraints
+/// It computes the monster multilinear evaluations for both AND and IMUL constraints
 /// and verifies the final equation relating the witness and monster evaluations.
 ///
 /// # Protocol Details
@@ -240,7 +240,7 @@ where
 /// eval = trace_eval * monster_eval
 /// ```
 ///
-/// where `monster_eval` is the sum of evaluations for AND and MUL constraint polynomials, and
+/// where `monster_eval` is the sum of evaluations for AND and IMUL constraint polynomials, and
 /// `trace_eval` is the witness evaluation reconstructed from its two segments:
 /// ```text
 /// trace_eval = (1 - r_segment) * prod_{k <= i} (1 - r_y_i) * public_eval + r_segment * witness_eval
@@ -371,7 +371,7 @@ impl<F: BinaryField> FieldFn<F> for PublicWordsEvalFn<'_> {
 struct MonsterEvalFn<'a, F: BinaryField> {
 	/// The evaluation subspace for the Lagrange basis over the word bits.
 	subspace: &'a BinarySubspace<F>,
-	/// The AND and MUL constraints whose monster multilinears are evaluated.
+	/// The AND and IMUL constraints whose monster multilinears are evaluated.
 	constraint_system: &'a ConstraintSystem,
 	/// Length of the BitAnd operator's `r_x_prime` section.
 	bitand_r_x_prime_len: usize,
@@ -466,12 +466,12 @@ impl<F: BinaryField> MonsterEvalFn<'_, F> {
 			eval_op(&[a, b, c], bitand_r_x_prime_v, bitand_lambda_v, &shift_scalars, &r_y_tensor)
 		};
 		// IntMul contribution: operands (a, b, lo, hi) batched by `intmul_lambda`.
-		let intmul_part = if !self.constraint_system.mul_constraints.is_empty() {
+		let intmul_part = if !self.constraint_system.imul_constraints.is_empty() {
 			let (a, b, lo, hi) = self
 				.constraint_system
-				.mul_constraints
+				.imul_constraints
 				.iter()
-				.map(|MulConstraint { a, b, hi, lo }| (a, b, lo, hi))
+				.map(|ImulConstraint { a, b, hi, lo }| (a, b, lo, hi))
 				.multiunzip();
 			eval_op(
 				&[a, b, lo, hi],

--- a/crates/verifier/src/verify.rs
+++ b/crates/verifier/src/verify.rs
@@ -152,17 +152,17 @@ impl IOPVerifier {
 		//
 		// [phase] Verify IntMul Reduction - multiplication constraint verification
 		//
-		// Skipped (no transcript reads) when the constraint system has no MUL constraints,
+		// Skipped (no transcript reads) when the constraint system has no IMUL constraints,
 		// mirroring the prover's identical guard so the transcript stays in sync.
-		let intmul_output = if self.constraint_system.n_mul_constraints() > 0 {
+		let intmul_output = if self.constraint_system.n_imul_constraints() > 0 {
 			let intmul_guard = tracing::info_span!(
 				"[phase] Verify IntMul Reduction",
 				phase = "verify_intmul_reduction",
 				perfetto_category = "phase",
-				n_constraints = self.constraint_system.n_mul_constraints()
+				n_constraints = self.constraint_system.n_imul_constraints()
 			)
 			.entered();
-			let log_n_constraints = checked_log_2(self.constraint_system.n_mul_constraints());
+			let log_n_constraints = checked_log_2(self.constraint_system.n_imul_constraints());
 			let intmul_output = verify_intmul_reduction::<B128, _>(log_n_constraints, channel)?;
 			drop(intmul_guard);
 			Some(intmul_output)
@@ -196,7 +196,7 @@ impl IOPVerifier {
 		// ShiftReduction perf and lets the verifier compute `h_op_evals` once for both
 		// operations in `shift::check_eval`. When IntMul was skipped, synthesize a zero claim
 		// (four zero evals at an empty point); it contributes zero to the shift reduction, whose
-		// monster evaluation iterates the (empty) MUL constraints.
+		// monster evaluation iterates the (empty) IMUL constraints.
 		let intmul_claim = match intmul_output {
 			Some(IntMulOutput {
 				a_evals,
@@ -400,7 +400,7 @@ where
 			"Verify",
 			n_hidden_words = cs.value_vec_layout.n_hidden_words,
 			n_bitand = cs.and_constraints.len(),
-			n_intmul = cs.mul_constraints.len(),
+			n_intmul = cs.imul_constraints.len(),
 		)
 		.entered();
 

--- a/crates/verifier/src/zk_config.rs
+++ b/crates/verifier/src/zk_config.rs
@@ -208,7 +208,7 @@ where
 				"Binius64",
 				n_hidden_words = inner_cs.value_vec_layout.n_hidden_words,
 				n_bitand = inner_cs.and_constraints.len(),
-				n_intmul = inner_cs.mul_constraints.len(),
+				n_intmul = inner_cs.imul_constraints.len(),
 			)
 			.entered();
 


### PR DESCRIPTION
Linear: [BINIUS-296](https://linear.app/jimpo/issue/BINIUS-296/frontend-rename-mul-constraints-to-imul-constraints-for-integer-mul)

Renames the integer-multiplication constraint from `mul`/`Mul` to `imul`/`Imul` throughout the (non-Spartan) constraint stack, freeing the `mul`/`bmul` namespace for the upcoming **BinMul** (GHASH-field) constraint. This is the base of a two-PR stack; **BINIUS-295** (introduce `bmul` constraints in the `ConstraintBuilder`) stacks on top.

### What changed (pure mechanical rename — no behavior change)
- **core** (`constraint_system`): `MulConstraint` → `ImulConstraint`; `ConstraintSystem::mul_constraints` → `imul_constraints`; `add_mul_constraint`/`n_mul_constraints` → `add_imul_constraint`/`n_imul_constraints`; validation label `"mul"` → `"imul"`.
- **frontend**: `ConstraintBuilder::mul()` → `imul()`, `MulConstraintBuilder`/`WireMulConstraint` → `Imul…`; gate-fusion `AndOrMulConstraint::Mul` and `ConstraintRef::Mul` variants → `Imul`; `CircuitStat` display line `MUL constraints:` → `IMUL constraints:`.
- **m4-prover / m4-verifier / prover / verifier**: updated all references to the renamed core field/type; comments/labels `MUL constraint` → `IMUL constraint`.
- **examples**: re-blessed the 13 gate-count snapshots for the new `IMUL constraints:` label (label-only change; counts unchanged, validated via `check-snapshot`).

### Scope note
The `spartan-*` crates define their **own** unrelated `MulConstraint<W>` (an R1CS rank-one `a·b=c` constraint). Those are a distinct concept and are deliberately **left untouched** — e.g. `outer_cs.mul_constraints()` (Spartan) stays, while `inner_cs.imul_constraints` (core) is renamed.

### Validation
- `cargo check --workspace --all-targets`, `cargo clippy --all --tests --benches --examples -- -D warnings` — clean.
- `cargo test` for `binius-core`, `binius-frontend`, `binius-m4-prover`, `binius-m4-verifier` — all pass.
- `cargo +nightly fmt --check` — clean.
- Example gate-count snapshots re-blessed and re-verified.

The rename is a single atomic commit by necessity — splitting it would leave a non-compiling, half-renamed tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)