### PR TITLE
BINIUS-299: add bmul opcode to the EvalForm interpreter

### DIFF
--- a/crates/frontend/Cargo.toml
+++ b/crates/frontend/Cargo.toml
@@ -9,6 +9,7 @@ workspace = true
 
 [dependencies]
 binius-core = { path = "../core" }
+binius-field = { path = "../field" }
 binius-utils = { path = "../utils" }
 cranelift-entity = { workspace = true }
 num-bigint = { workspace = true }

--- a/crates/frontend/src/compiler/eval_form/builder.rs
+++ b/crates/frontend/src/compiler/eval_form/builder.rs
@@ -139,6 +139,31 @@ impl BytecodeBuilder {
 		self.emit_reg(src2);
 	}
 
+	/// GHASH-field multiply: `(dst_lo, dst_hi) = (a_lo, a_hi) * (b_lo, b_hi)` in
+	/// $\mathbb{F}_{2^{128}}$, where each field element is carried by a `(lo, hi)` pair of words.
+	//
+	// The first non-test caller is the BMUL gate (BINIUS-298); until then this is only reached from
+	// tests, so silence the dead-code lint here rather than crate-wide.
+	#[allow(dead_code)]
+	pub fn emit_bmul(
+		&mut self,
+		dst_lo: u32,
+		dst_hi: u32,
+		a_lo: u32,
+		a_hi: u32,
+		b_lo: u32,
+		b_hi: u32,
+	) {
+		self.n_eval_insn += 1;
+		self.emit_u8(0x31);
+		self.emit_reg(dst_lo);
+		self.emit_reg(dst_hi);
+		self.emit_reg(a_lo);
+		self.emit_reg(a_hi);
+		self.emit_reg(b_lo);
+		self.emit_reg(b_hi);
+	}
+
 	// 32-bit operations
 	pub fn emit_iadd32_cin_cout(
 		&mut self,

--- a/crates/frontend/src/compiler/eval_form/exec.rs
+++ b/crates/frontend/src/compiler/eval_form/exec.rs
@@ -12,8 +12,20 @@
 //! The dispatch loop, the opcode handlers, and the bytecode readers live here once.
 
 use binius_core::{Word, constraint_system::ShiftVariant};
+use binius_field::BinaryField128bGhash;
 
 use crate::compiler::{hints::HintRegistry, pathspec::PathSpec};
+
+/// Multiplies two GHASH field elements ($\mathbb{F}_{2^{128}}$), each carried by a `(lo, hi)` pair
+/// of words — `lo` holds the coefficients of $1, X, \ldots, X^{63}$ and `hi` those of
+/// $X^{64}, \ldots, X^{127}$ — and returns the product in the same `(lo, hi)` form.
+fn ghash_mul(a_lo: Word, a_hi: Word, b_lo: Word, b_hi: Word) -> (Word, Word) {
+	let to_field = |lo: Word, hi: Word| {
+		BinaryField128bGhash::from((lo.as_u64() as u128) | ((hi.as_u64() as u128) << 64))
+	};
+	let product = u128::from(to_field(a_lo, a_hi) * to_field(b_lo, b_hi));
+	(Word::from_u64(product as u64), Word::from_u64((product >> 64) as u64))
+}
 
 /// The values one bytecode program evaluates against.
 ///
@@ -87,6 +99,7 @@ impl<'a> Executor<'a> {
 				0x21 => self.exec_iadd_cin_cout(ctx),
 				0x23 => self.exec_isub_bin_bout(ctx),
 				0x30 => self.exec_imul(ctx),
+				0x31 => self.exec_bmul(ctx),
 
 				// 32-bit operations
 				0x40 => self.exec_iadd32_cin_cout(ctx),
@@ -270,6 +283,30 @@ impl<'a> Executor<'a> {
 			let (hi, lo) = ctx.load(src1, i).imul(ctx.load(src2, i));
 			ctx.store(dst_hi, i, hi);
 			ctx.store(dst_lo, i, lo);
+		}
+	}
+
+	/// GHASH-field multiply: `(c_lo, c_hi) = (a_lo, a_hi) * (b_lo, b_hi)` in
+	/// $\mathbb{F}_{2^{128}}$.
+	///
+	/// Operands are read in the order `dst_lo, dst_hi, a_lo, a_hi, b_lo, b_hi`, matching
+	/// [`BytecodeBuilder::emit_bmul`](super::builder::BytecodeBuilder::emit_bmul).
+	fn exec_bmul<C: EvalContext>(&mut self, ctx: &mut C) {
+		let dst_lo = self.read_reg();
+		let dst_hi = self.read_reg();
+		let a_lo = self.read_reg();
+		let a_hi = self.read_reg();
+		let b_lo = self.read_reg();
+		let b_hi = self.read_reg();
+		for i in 0..ctx.n_instances() {
+			let (lo, hi) = ghash_mul(
+				ctx.load(a_lo, i),
+				ctx.load(a_hi, i),
+				ctx.load(b_lo, i),
+				ctx.load(b_hi, i),
+			);
+			ctx.store(dst_lo, i, lo);
+			ctx.store(dst_hi, i, hi);
 		}
 	}
 

--- a/crates/frontend/src/compiler/eval_form/tests.rs
+++ b/crates/frontend/src/compiler/eval_form/tests.rs
@@ -44,6 +44,21 @@ impl InterpreterTest {
 		self
 	}
 
+	/// Emit a bmul (GHASH-field multiply) instruction
+	fn bmul(
+		mut self,
+		dst_lo: u32,
+		dst_hi: u32,
+		a_lo: u32,
+		a_hi: u32,
+		b_lo: u32,
+		b_hi: u32,
+	) -> Self {
+		self.builder
+			.emit_bmul(dst_lo, dst_hi, a_lo, a_hi, b_lo, b_hi);
+		self
+	}
+
 	/// Run the test and expect success (no assertion failures)
 	fn expect_success(self) {
 		let (result, ctx) = self.execute();
@@ -243,4 +258,74 @@ fn test_select_msb_behavior() {
 		])
 		.select(3, 2, 0, 1)
 		.expect_values(vec![(3, Word(100))]);
+}
+
+// BMUL (GHASH-field multiply) tests. Each field element is a `(lo, hi)` word pair with `lo`
+// carrying the coefficients of 1..X^63 and `hi` those of X^64..X^127. Wires 0-3 hold the inputs
+// (a_lo, a_hi, b_lo, b_hi) and wires 4-5 receive the product (c_lo, c_hi). The expected values are
+// field-theory facts, independent of the implementation.
+
+#[test]
+fn test_bmul_identity() {
+	// a * 1 = a, where the field element 1 is (lo=1, hi=0).
+	InterpreterTest::new()
+		.with_values(vec![
+			Word(0x0123456789ABCDEF), // a_lo
+			Word(0xFEDCBA9876543210), // a_hi
+			Word(1),                  // b_lo = 1
+			Word::ZERO,               // b_hi
+			Word::ZERO,               // c_lo (dst)
+			Word::ZERO,               // c_hi (dst)
+		])
+		.bmul(4, 5, 0, 1, 2, 3)
+		.expect_values(vec![(4, Word(0x0123456789ABCDEF)), (5, Word(0xFEDCBA9876543210))]);
+}
+
+#[test]
+fn test_bmul_zero() {
+	// a * 0 = 0.
+	InterpreterTest::new()
+		.with_values(vec![
+			Word(0x0123456789ABCDEF), // a_lo
+			Word(0xFEDCBA9876543210), // a_hi
+			Word::ZERO,               // b_lo = 0
+			Word::ZERO,               // b_hi = 0
+			Word(0xdead),             // c_lo (dst, overwritten)
+			Word(0xbeef),             // c_hi (dst, overwritten)
+		])
+		.bmul(4, 5, 0, 1, 2, 3)
+		.expect_values(vec![(4, Word::ZERO), (5, Word::ZERO)]);
+}
+
+#[test]
+fn test_bmul_x_times_x() {
+	// X * X = X^2 (no reduction needed): X is (lo=2, hi=0), X^2 is (lo=4, hi=0).
+	InterpreterTest::new()
+		.with_values(vec![
+			Word(2),    // a_lo = X
+			Word::ZERO, // a_hi
+			Word(2),    // b_lo = X
+			Word::ZERO, // b_hi
+			Word::ZERO, // c_lo (dst)
+			Word::ZERO, // c_hi (dst)
+		])
+		.bmul(4, 5, 0, 1, 2, 3)
+		.expect_values(vec![(4, Word(4)), (5, Word::ZERO)]);
+}
+
+#[test]
+fn test_bmul_reduction() {
+	// X^127 * X = X^128, which reduces via X^128 + X^7 + X^2 + X + 1 = 0 to
+	// X^7 + X^2 + X + 1 = 0x87 (lo), 0 (hi). X^127 is bit 63 of the hi word.
+	InterpreterTest::new()
+		.with_values(vec![
+			Word::ZERO,               // a_lo
+			Word(0x8000000000000000), // a_hi = X^127
+			Word(2),                  // b_lo = X
+			Word::ZERO,               // b_hi
+			Word::ZERO,               // c_lo (dst)
+			Word::ZERO,               // c_hi (dst)
+		])
+		.bmul(4, 5, 0, 1, 2, 3)
+		.expect_values(vec![(4, Word(0x87)), (5, Word::ZERO)]);
 }


### PR DESCRIPTION
Linear: [BINIUS-299](https://linear.app/jimpo/issue/BINIUS-299/evalform-and-interpreter-opcode-for-bmul-gates)

Adds the witness-filling side of the `bmul` (BinMul / GHASH-field) gate: a new EvalForm interpreter opcode `0x31` that computes a GHASH-field product. This is the counterpart to the existing `imul` opcode (`0x30`) and a **prerequisite** for the `bmul` gate itself (BINIUS-298), which will emit this opcode.

### What's here
- **`exec.rs`** — dispatch `0x31 => exec_bmul` and `exec_bmul`, which reads 6 registers (`dst_lo, dst_hi, a_lo, a_hi, b_lo, b_hi`) and, per instance, computes `(c_lo, c_hi) = (a_lo, a_hi) · (b_lo, b_hi)` in $\mathbb{F}_{2^{128}}$. The multiply is a small private `ghash_mul` helper.
- **`builder.rs`** — `BytecodeBuilder::emit_bmul(dst_lo, dst_hi, a_lo, a_hi, b_lo, b_hi)`.
- **`tests.rs`** — four interpreter tests exercising the opcode against **field-theory facts** (implementation-independent): `a·1 = a`, `a·0 = 0`, `X·X = X²`, and `X¹²⁷·X = X¹²⁸ = X⁷+X²+X+1 = 0x87` (which exercises the reduction). These also confirm the word-pair encoding — `lo` carries coefficients of $1..X^{63}$, `hi` those of $X^{64}..X^{127}$ — matches `BinaryField128bGhash` and the spec's `⟨⟨·⟩⟩` convention.

### Two decisions worth your eye
1. **New `binius-field` dependency on `binius-frontend`.** Witness-filling for `bmul` genuinely needs $\mathbb{F}_{2^{128}}$ multiplication, so the frontend now depends on `binius-field` and computes via `BinaryField128bGhash`. The alternative — a `Word::bmul` in `binius-core` — was rejected because `binius-core` is deliberately field-free (it depends only on `binius-utils`), and pushing field arithmetic down into it is worse layering than letting the higher-level frontend depend on the field crate. Open to the other choice if you disagree.
2. **`emit_bmul` carries `#[allow(dead_code)]`.** Its first non-test caller is the `bmul` gate (BINIUS-298); until then it's only exercised by the tests here (same shape as the `ConstraintBuilder::bmul` builder in #1822). `exec_bmul` itself is live via the dispatch table.

Operand order note: `bmul` uses `lo`-first pairing (`dst_lo, dst_hi, …`) to match the spec's `⟨⟨lo, hi⟩⟩`, whereas `imul` is `hi`-first — deliberate, and `emit`/`exec` agree.

### Validation
- `cargo clippy --all --tests --benches --examples -- -D warnings` and `cargo +nightly fmt --check` — clean.
- `cargo test -p binius-frontend` — 161 + 2 pass, including the four new `bmul` tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)