### PR TITLE
BINIUS-298: add bmul gate to CircuitBuilder

### DIFF
--- a/crates/frontend/src/compiler/constraint_builder.rs
+++ b/crates/frontend/src/compiler/constraint_builder.rs
@@ -36,10 +36,6 @@ impl ConstraintBuilder {
 	}
 
 	/// Build a BMUL constraint: (A_LO, A_HI) * (B_LO, B_HI) = (C_LO, C_HI) in the GHASH field
-	//
-	// The first non-test caller is the BMUL gate (BINIUS-298); until then this entry point is only
-	// exercised by tests, so silence the dead-code lint here rather than crate-wide.
-	#[allow(dead_code)]
 	pub const fn bmul(&mut self) -> BmulConstraintBuilder<'_> {
 		BmulConstraintBuilder::new(self)
 	}
@@ -501,9 +497,6 @@ impl<'a> ImulConstraintBuilder<'a> {
 	}
 }
 
-// Constructed via `ConstraintBuilder::bmul`, whose first non-test caller lands with the BMUL gate
-// (BINIUS-298).
-#[allow(dead_code)]
 pub struct BmulConstraintBuilder<'a> {
 	builder: &'a mut ConstraintBuilder,
 	a_lo: WireOperand,
@@ -514,9 +507,6 @@ pub struct BmulConstraintBuilder<'a> {
 	c_hi: WireOperand,
 }
 
-// The operand setters and `build` are only reached through `ConstraintBuilder::bmul`, whose first
-// non-test caller lands with the BMUL gate (BINIUS-298).
-#[allow(dead_code)]
 impl<'a> BmulConstraintBuilder<'a> {
 	const fn new(builder: &'a mut ConstraintBuilder) -> Self {
 		Self {

--- a/crates/frontend/src/compiler/eval_form/builder.rs
+++ b/crates/frontend/src/compiler/eval_form/builder.rs
@@ -141,10 +141,6 @@ impl BytecodeBuilder {
 
 	/// GHASH-field multiply: `(dst_lo, dst_hi) = (a_lo, a_hi) * (b_lo, b_hi)` in
 	/// $\mathbb{F}_{2^{128}}$, where each field element is carried by a `(lo, hi)` pair of words.
-	//
-	// The first non-test caller is the BMUL gate (BINIUS-298); until then this is only reached from
-	// tests, so silence the dead-code lint here rather than crate-wide.
-	#[allow(dead_code)]
 	pub fn emit_bmul(
 		&mut self,
 		dst_lo: u32,

--- a/crates/frontend/src/compiler/eval_form/const_eval.rs
+++ b/crates/frontend/src/compiler/eval_form/const_eval.rs
@@ -208,6 +208,26 @@ mod tests {
 	}
 
 	#[test]
+	fn test_bmul_constant_eval() {
+		// Test BMUL (4 inputs a_lo, a_hi, b_lo, b_hi; 2 outputs c_lo, c_hi). X^127 * X = X^128,
+		// which reduces (X^128 + X^7 + X^2 + X + 1 = 0) to X^7 + X^2 + X + 1 = 0x87.
+		let (graph, gate, constants) = create_test_gate(
+			Opcode::Bmul,
+			&[
+				Word::ZERO,                         // a_lo
+				Word::from_u64(0x8000000000000000), // a_hi = X^127
+				Word::from_u64(2),                  // b_lo = X
+				Word::ZERO,                         // b_hi
+			],
+		);
+
+		let result =
+			evaluate_gate_constants(&graph, gate, &constants, &HintRegistry::new()).unwrap();
+		assert_eq!(result[0], Word::from_u64(0x87)); // c_lo
+		assert_eq!(result[1], Word::ZERO); // c_hi
+	}
+
+	#[test]
 	fn test_iadd_cin_cout_constant_eval() {
 		// Test with carry in (MSB = 1 means carry bit is 1)
 		let (graph, gate, constants) = create_test_gate(

--- a/crates/frontend/src/compiler/gate/bmul.rs
+++ b/crates/frontend/src/compiler/gate/bmul.rs
@@ -1,0 +1,70 @@
+// Copyright 2026 The Binius Developers
+//! Bmul gate implements multiplication in the GHASH field GF(2^128).
+//!
+//! Each field element is carried by a `(lo, hi)` pair of 64-bit words. Uses the BmulConstraint:
+//! `(A_LO, A_HI) * (B_LO, B_HI) = (C_LO, C_HI)`.
+
+use crate::compiler::{
+	constraint_builder::ConstraintBuilder,
+	gate::opcode::OpcodeShape,
+	gate_graph::{Gate, GateData, GateParam, Wire},
+};
+
+pub const fn shape() -> OpcodeShape {
+	OpcodeShape {
+		const_in: &[],
+		n_in: 4,
+		n_out: 2,
+		n_aux: 0,
+		n_scratch: 0,
+		n_imm: 0,
+	}
+}
+
+pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) {
+	let GateParam {
+		inputs, outputs, ..
+	} = data.gate_param();
+	let [a_lo, a_hi, b_lo, b_hi] = inputs else {
+		unreachable!()
+	};
+	let [c_lo, c_hi] = outputs else {
+		unreachable!()
+	};
+
+	// Create BmulConstraint: (A_LO, A_HI) * (B_LO, B_HI) = (C_LO, C_HI) in GF(2^128).
+	builder
+		.bmul()
+		.a_lo(*a_lo)
+		.a_hi(*a_hi)
+		.b_lo(*b_lo)
+		.b_hi(*b_hi)
+		.c_lo(*c_lo)
+		.c_hi(*c_hi)
+		.build();
+}
+
+pub fn emit_eval_bytecode(
+	_gate: Gate,
+	data: &GateData,
+	builder: &mut crate::compiler::eval_form::BytecodeBuilder,
+	wire_to_reg: impl Fn(Wire) -> u32,
+) {
+	let GateParam {
+		inputs, outputs, ..
+	} = data.gate_param();
+	let [a_lo, a_hi, b_lo, b_hi] = inputs else {
+		unreachable!()
+	};
+	let [c_lo, c_hi] = outputs else {
+		unreachable!()
+	};
+	builder.emit_bmul(
+		wire_to_reg(*c_lo),
+		wire_to_reg(*c_hi),
+		wire_to_reg(*a_lo),
+		wire_to_reg(*a_hi),
+		wire_to_reg(*b_lo),
+		wire_to_reg(*b_hi),
+	);
+}

--- a/crates/frontend/src/compiler/gate/mod.rs
+++ b/crates/frontend/src/compiler/gate/mod.rs
@@ -17,6 +17,7 @@ pub mod assert_non_zero;
 pub mod assert_true;
 pub mod assert_zero;
 pub mod band;
+pub mod bmul;
 pub mod bor;
 pub mod bxor;
 pub mod bxor_multi;
@@ -52,6 +53,7 @@ pub fn constrain(gate: Gate, graph: &GateGraph, builder: &mut ConstraintBuilder)
 		Opcode::AssertTrue => assert_true::constrain(gate, data, builder),
 		Opcode::AssertEqCond => assert_eq_cond::constrain(gate, data, builder),
 		Opcode::Imul => imul::constrain(gate, data, builder),
+		Opcode::Bmul => bmul::constrain(gate, data, builder),
 		Opcode::IcmpUlt => icmp_ult::constrain(gate, data, builder),
 		Opcode::IcmpEq => icmp_eq::constrain(gate, data, builder),
 		// Hints do not introduce constraints
@@ -107,6 +109,7 @@ pub fn emit_gate_bytecode(
 			assert_true::emit_eval_bytecode(gate, data, assertion_path, builder, wire_to_reg)
 		}
 		Opcode::Imul => imul::emit_eval_bytecode(gate, data, builder, wire_to_reg),
+		Opcode::Bmul => bmul::emit_eval_bytecode(gate, data, builder, wire_to_reg),
 		Opcode::IcmpUlt => icmp_ult::emit_eval_bytecode(gate, data, builder, wire_to_reg),
 		Opcode::IcmpEq => icmp_eq::emit_eval_bytecode(gate, data, builder, wire_to_reg),
 

--- a/crates/frontend/src/compiler/gate/opcode.rs
+++ b/crates/frontend/src/compiler/gate/opcode.rs
@@ -21,6 +21,7 @@ pub enum Opcode {
 	Iadd32CinCout,
 	IsubBinBout,
 	Imul,
+	Bmul,
 
 	// Shifts
 	Shift,
@@ -102,6 +103,7 @@ impl Opcode {
 			Opcode::Iadd32CinCout => gate::iadd32_cin_cout::shape(),
 			Opcode::IsubBinBout => gate::isub_bin_bout::shape(),
 			Opcode::Imul => gate::imul::shape(),
+			Opcode::Bmul => gate::bmul::shape(),
 
 			// Shifts
 			Opcode::Shift => gate::shift::shape(),

--- a/crates/frontend/src/compiler/gate_fusion/tests/awhole.rs
+++ b/crates/frontend/src/compiler/gate_fusion/tests/awhole.rs
@@ -25,6 +25,32 @@ fn test_force_commit_non_linear_output_without_inout() {
 	verify_constraints(circuit.constraint_system(), &w.value_vec).unwrap();
 }
 
+#[test]
+fn test_bmul_gate_end_to_end() {
+	// A single BMUL gate: the eval opcode fills the product wires, and the BMUL constraint checks
+	// the GHASH multiply. Uses the field fact X^127 * X = X^128 = X^7 + X^2 + X + 1 = 0x87 (a
+	// reduction case), so this exercises the whole gate → constraint + eval-bytecode → witness →
+	// verification path. Each field element is a (lo, hi) word pair.
+	let builder = CircuitBuilder::new();
+	let a_lo = builder.add_witness();
+	let a_hi = builder.add_witness();
+	let b_lo = builder.add_witness();
+	let b_hi = builder.add_witness();
+	let (c_lo, c_hi) = builder.bmul(a_lo, a_hi, b_lo, b_hi);
+	let circuit = builder.build();
+
+	let mut w = circuit.new_witness_filler();
+	w[a_lo] = Word::ZERO;
+	w[a_hi] = Word(0x8000_0000_0000_0000); // X^127
+	w[b_lo] = Word(2); // X
+	w[b_hi] = Word::ZERO;
+	circuit.populate_wire_witness(&mut w).unwrap();
+
+	assert_eq!(w[c_lo], Word(0x87));
+	assert_eq!(w[c_hi], Word::ZERO);
+	verify_constraints(circuit.constraint_system(), &w.value_vec).unwrap();
+}
+
 /// Returns a string that represents the given constraint system in a textual form.
 fn stringify_constraint_system(cs: &ConstraintSystem) -> String {
 	use std::fmt::Write;

--- a/crates/frontend/src/compiler/mod.rs
+++ b/crates/frontend/src/compiler/mod.rs
@@ -105,7 +105,7 @@ pub(crate) struct Shared {
 /// Methods like [`band`] and [`iadd_32`] add gates to the graph and return handles
 /// to output wires.
 ///
-/// During [`build`], the gate graph compiles into AND and IMUL constraints
+/// During [`build`], the gate graph compiles into AND, IMUL, and BMUL constraints
 /// that the proof system operates on directly.
 ///
 /// # Wire Types
@@ -1053,6 +1053,25 @@ impl CircuitBuilder {
 		let mut graph = self.graph_mut();
 		graph.emit_gate(self.current_path, Opcode::Imul, [a, b], [hi, lo]);
 		(hi, lo)
+	}
+
+	/// Multiplication in the GHASH field GF(2^128).
+	///
+	/// Multiplies two field elements, each carried by a `(lo, hi)` pair of 64-bit words — `lo`
+	/// holds the coefficients of `1, X, …, X^63` and `hi` those of `X^64, …, X^127`.
+	///
+	/// Returns `(c_lo, c_hi)`, the product `(a_lo, a_hi) * (b_lo, b_hi)` in the same
+	/// representation.
+	///
+	/// # Cost
+	///
+	/// - 1 BMUL constraint.
+	pub fn bmul(&self, a_lo: Wire, a_hi: Wire, b_lo: Wire, b_hi: Wire) -> (Wire, Wire) {
+		let c_lo = self.add_internal();
+		let c_hi = self.add_internal();
+		let mut graph = self.graph_mut();
+		graph.emit_gate(self.current_path, Opcode::Bmul, [a_lo, a_hi, b_lo, b_hi], [c_lo, c_hi]);
+		(c_lo, c_hi)
 	}
 
 	/// Conditional equality assertion.

--- a/crates/frontend/src/lib.rs
+++ b/crates/frontend/src/lib.rs
@@ -5,7 +5,7 @@
 //!
 //! This crate provides the [`CircuitBuilder`] API for constructing arithmetic circuits
 //! that compile to Binius64 constraint systems. You describe your computation as a graph
-//! of operations on 64-bit words, and the frontend compiles it to AND/IMUL constraints.
+//! of operations on 64-bit words, and the frontend compiles it to AND/IMUL/BMUL constraints.
 //!
 //! # Usage Flow
 //!


### PR DESCRIPTION
Linear: [BINIUS-298](https://linear.app/jimpo/issue/BINIUS-298/frontend-add-bmul-gate-to-circuitbuilder)

Adds the `bmul` **gate** — the user-facing GHASH-field multiply on `CircuitBuilder`. This ties together the two halves that landed earlier: the `BmulConstraint` + `ConstraintBuilder::bmul` (#1822 / BINIUS-295) and the `bmul` EvalForm opcode `emit_bmul`/`exec_bmul` (#1823 / BINIUS-299). With this, `bmul` is a first-class gate exactly parallel to `imul`.

### What's here
- **`gate/bmul.rs`** (new) — mirrors `gate/imul.rs`: `shape()` (4 inputs `a_lo, a_hi, b_lo, b_hi`; 2 outputs `c_lo, c_hi`), `constrain()` (emits the `BmulConstraint` via `builder.bmul()…`), and `emit_eval_bytecode()` (emits the eval op via `emit_bmul(…)`).
- **`gate/opcode.rs`** — new `Opcode::Bmul` variant + its `shape()` arm.
- **`gate/mod.rs`** — `pub mod bmul;` + the `constrain` and `emit_gate_bytecode` dispatch arms (both matches are exhaustive, so the compiler enforces the arms).
- **`CircuitBuilder::bmul(a_lo, a_hi, b_lo, b_hi) -> (c_lo, c_hi)`** — the public API, mirroring `imul`.
- **Cleanup:** removed the `#[allow(dead_code)]` from `ConstraintBuilder::bmul`/`BmulConstraintBuilder` (#1822) and `BytecodeBuilder::emit_bmul` (#1823) — the gate is now their live caller. Also updated the crate/`CircuitBuilder` docs to mention BMUL alongside AND/IMUL (deferred in #1822 until a gate could emit them).

### Tests
- **`test_bmul_gate_end_to_end`** (awhole.rs) — builds a one-gate circuit, populates the witness (the eval fills `c`), and calls `verify_constraints`. This exercises the **whole** path: gate → constraint + eval-bytecode → witness → verification, and confirms the two sides **agree** (the eval-computed product satisfies the constraint). Uses the reduction case `X¹²⁷·X = X¹²⁸ = X⁷+X²+X+1 = 0x87`.
- **`test_bmul_constant_eval`** (const_eval.rs) — mirrors `test_imul_constant_eval`, checking the gate const-folds correctly.

### One note
`CircuitBuilder::bmul` takes 4 flat wires (like `imul`'s 2 flat wires) rather than two `(Wire, Wire)` lo/hi tuples. Flat keeps it consistent with `imul` and every other gate's flat-input convention; tuples would make the pairing harder to mis-order. Happy to switch to tuples if you'd prefer that for the field-element pairs.

### Validation
- `cargo clippy --all --tests --benches --examples -- -D warnings` and `cargo +nightly fmt --check` — clean.
- `cargo test -p binius-frontend` — 163 + 2 pass, including the two new gate tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)