### PR TITLE
[sumcheck] Fuse fold into map_reduce for MleStore

### DIFF
--- a/crates/ip-prover/benches/bivariate_product.rs
+++ b/crates/ip-prover/benches/bivariate_product.rs
@@ -7,7 +7,7 @@
 
 use binius_field::{FieldOps, PackedField, arch::OptimalPackedB128};
 use binius_ip_prover::sumcheck::{
-	batch::{batch_prove, batch_prove_mle},
+	self,
 	bivariate_product_evaluator::BivariateProductEvaluator,
 	mle_store::MleStore,
 	quadratic_mle_evaluator::QuadraticMleEvaluator,
@@ -48,7 +48,7 @@ fn product_eval_claim(a: &FieldBuffer<P>, b: &FieldBuffer<P>, eval_point: &[F]) 
 // `BivariateProductEvaluator` over the two store columns.
 fn bench_shared_sumcheck_bivariate_product(c: &mut Criterion) {
 	let mut group = c.benchmark_group("bivariate_product/shared_sumcheck");
-	let mut rng = StdRng::seed_from_u64(0);
+	let mut rng = rand::rng();
 
 	for n_vars in [12, 16, 20] {
 		group.throughput(Throughput::Elements(1 << n_vars));
@@ -57,18 +57,17 @@ fn bench_shared_sumcheck_bivariate_product(c: &mut Criterion) {
 			let b_multilinear = random_field_buffer::<P>(&mut rng, n_vars);
 			// The plain sum claim is the sum of `a * b` over the hypercube.
 			let sum_claim = inner_product_par(&a, &b_multilinear);
-
-			let mut transcript = ProverTranscript::new(StdChallenger::default());
+			let transcript = ProverTranscript::new(StdChallenger::default());
 
 			b.iter_batched(
-				|| (a.clone(), b_multilinear.clone()),
-				|(a, b_multilinear)| {
+				|| (transcript.clone(), a.clone(), b_multilinear.clone()),
+				|(mut transcript, a, b_multilinear)| {
 					let mut store = MleStore::new(n_vars);
 					let cols = [a, b_multilinear].map(|col| store.push_owned(col));
 					let evaluator = BivariateProductEvaluator::new(cols, sum_claim);
 					let prover = SharedSumcheckProver::new(store, vec![evaluator]);
 
-					batch_prove(vec![prover], &mut transcript)
+					sumcheck::prove_single(prover, &mut transcript)
 				},
 				BatchSize::SmallInput,
 			);
@@ -91,12 +90,11 @@ fn bench_shared_mlecheck_bivariate_product(c: &mut Criterion) {
 			let b_multilinear = random_field_buffer::<P>(&mut rng, n_vars);
 			let eval_point = random_scalars::<F>(&mut rng, n_vars);
 			let eval_claim = product_eval_claim(&a, &b_multilinear, &eval_point);
-
-			let mut transcript = ProverTranscript::new(StdChallenger::default());
+			let transcript = ProverTranscript::new(StdChallenger::default());
 
 			b.iter_batched(
-				|| (a.clone(), b_multilinear.clone(), eval_point.clone()),
-				|(a, b_multilinear, eval_point)| {
+				|| (transcript.clone(), a.clone(), b_multilinear.clone(), eval_point.clone()),
+				|(mut transcript, a, b_multilinear, eval_point)| {
 					let mut store = MleStore::new(n_vars);
 					let cols = [a, b_multilinear].map(|col| store.push_owned(col));
 					// A single-claim evaluator reading the store's columns and one eq tracker
@@ -111,7 +109,7 @@ fn bench_shared_mlecheck_bivariate_product(c: &mut Criterion) {
 					);
 					let prover = SharedMleCheckProver::new(store, vec![evaluator], eval_point);
 
-					batch_prove_mle(vec![prover], &mut transcript)
+					sumcheck::prove_single_mlecheck(prover, &mut transcript)
 				},
 				BatchSize::SmallInput,
 			);

--- a/crates/ip-prover/src/sumcheck/gruen32.rs
+++ b/crates/ip-prover/src/sumcheck/gruen32.rs
@@ -81,6 +81,11 @@ impl<F: Field, P: PackedField<Scalar = F>> Gruen32<P> {
 		&self.chunk_eq_expansion
 	}
 
+	pub fn eq_expansion_mut(&mut self) -> &mut FieldBuffer<P> {
+		assert_eq!(self.suffix_eq_expansion.log_len(), 0);
+		&mut self.chunk_eq_expansion
+	}
+
 	pub const fn chunk_eq_expansion(&self) -> &FieldBuffer<P> {
 		&self.chunk_eq_expansion
 	}
@@ -125,6 +130,37 @@ impl<F: Field, P: PackedField<Scalar = F>> Gruen32<P> {
 		} else if self.chunk_eq_expansion.log_len() > 0 {
 			let new_log_len = self.chunk_eq_expansion.log_len() - 1;
 			eq_ind_truncate_low_inplace(&mut self.chunk_eq_expansion, new_log_len);
+		}
+
+		// Update the prefix product (1)
+		let alpha = self.next_coordinate();
+		self.eq_prefix_eval *= eq_one_var(challenge, alpha);
+
+		self.n_vars_remaining -= 1;
+	}
+
+	/// Advances the tracker by one variable, truncating the eq-indicator buffers without
+	/// contracting their values.
+	///
+	/// This is the bookkeeping half of [`Self::fold`] — it drops the folded-out variable and
+	/// updates the prefix product, but leaves the values as-is. It is meant to be called from
+	/// [`super::mle_store::MleStore::map_reduce_with_fold`], which contracts the eq values itself.
+	pub fn truncate_one_var(&mut self, challenge: F) {
+		assert!(self.n_vars_remaining > 0);
+
+		// The caller has already contracted the values in place; here we only drop the folded-out
+		// variable. We are one variable less than the other multilinears.
+		debug_assert_eq!(
+			self.chunk_eq_expansion.log_len() + self.suffix_eq_expansion.log_len(),
+			self.n_vars_remaining - 1
+		);
+		// High-to-low evaluation order means we need to truncate suffix first.
+		if self.suffix_eq_expansion.log_len() > 0 {
+			let new_log_len = self.suffix_eq_expansion.log_len() - 1;
+			self.suffix_eq_expansion.truncate(new_log_len);
+		} else if self.chunk_eq_expansion.log_len() > 0 {
+			let new_log_len = self.chunk_eq_expansion.log_len() - 1;
+			self.chunk_eq_expansion.truncate(new_log_len);
 		}
 
 		// Update the prefix product (1)

--- a/crates/ip-prover/src/sumcheck/mle_store.rs
+++ b/crates/ip-prover/src/sumcheck/mle_store.rs
@@ -19,12 +19,16 @@
 //! over the columns is a plain read. A deferred-fold variant that fuses the fold into the next
 //! round's read pass can replace the internals without changing this interface.
 
+use std::iter;
+
 use binius_field::{Field, PackedField};
 use binius_math::{
 	FieldBuffer, FieldSlice,
+	line::extrapolate_line_packed,
 	multilinear::fold::{fold_highest_var, fold_highest_var_inplace},
 };
 use binius_utils::rayon;
+use itertools::izip;
 
 use super::gruen32::Gruen32;
 
@@ -347,6 +351,322 @@ impl<'a, F: Field, P: PackedField<Scalar = F>> MleStore<'a, P> {
 		};
 		map_reduce_helper(chunk, chunk_vars, &map, &reduce)
 	}
+
+	/// Folds the store with `challenge` and, in the same pass, maps and reduces the resulting
+	/// halved hypercube — equivalent to [`Self::fold`] followed by [`Self::map_reduce`], but
+	/// folding each column and eq expansion into the map's read of it so they are touched once
+	/// instead of twice.
+	///
+	/// `chunk_vars` is capped at `n_vars() - 2` (the folded store's leaf size). For a chunk size
+	/// below `P::LOG_WIDTH` the columns are already cache-resident and the fused pass cannot split
+	/// sub-packing-width leaves, so this falls back to a plain [`Self::fold`] then
+	/// [`Self::map_reduce`].
+	///
+	/// ## Preconditions
+	///
+	/// * `n_vars()` must be greater than 1.
+	pub fn map_reduce_with_fold<T: Send>(
+		&mut self,
+		chunk_vars: usize,
+		challenge: F,
+		map: impl (for<'c> Fn(EvaluationChunk<'c, P>) -> T) + Sync,
+		reduce: impl (Fn(T, T) -> T) + Sync,
+	) -> T {
+		assert!(self.n_vars > 1);
+
+		// Decrement n_vars to reflect the fold.
+		let n_vars = self.n_vars - 1;
+		let chunk_vars = chunk_vars.min(n_vars - 1);
+
+		// Small rounds are cache-resident, so fusing buys nothing, and the raw-slice split cannot
+		// express a sub-packing-width leaf; fold and map-reduce in two clean passes instead.
+		if chunk_vars < P::LOG_WIDTH {
+			self.fold(challenge);
+			return self.map_reduce(chunk_vars, map, reduce);
+		}
+
+		let challenge_broadcast = P::broadcast(challenge);
+
+		// Fresh destination buffers for the borrowed columns, held outside the column borrow so
+		// they can be moved into the store once the fold has written them.
+		let mut dsts = self
+			.columns
+			.iter()
+			.map(|column| match column {
+				Column::Borrowed(_) => Some(FieldBuffer::zeros(n_vars)),
+				_ => None,
+			})
+			.collect::<Vec<_>>();
+
+		// Build one deferred-fold producer per logical column: its low and high halves paired on
+		// the round's highest variable, folding in place (owned/split-half) or into a fresh `dst`
+		// (borrowed).
+		let mut cols = Vec::with_capacity(self.n_cols);
+		for (column, dst) in iter::zip(&mut self.columns, &mut dsts) {
+			match column {
+				Column::Borrowed(src) => {
+					let dst = dst
+						.as_mut()
+						.expect("borrowed columns get a destination buffer")
+						.as_mut();
+					let src = (src as &FieldSlice<'_, P>).as_ref();
+					debug_assert_eq!(src.len(), 1 << (n_vars + 1 - P::LOG_WIDTH));
+
+					let (seg_0, seg_1) = src.split_at(1 << (n_vars - P::LOG_WIDTH));
+					cols.push(PreFoldColumnChunk::OutOfPlace { dst, seg_0, seg_1 });
+				}
+				Column::Owned(buffer) => {
+					let seg = buffer.as_mut();
+					debug_assert_eq!(seg.len(), 1 << (n_vars + 1 - P::LOG_WIDTH));
+
+					let (seg_0, seg_1) = seg.split_at_mut(1 << (n_vars - P::LOG_WIDTH));
+					cols.push(PreFoldColumnChunk::InPlace { seg_0, seg_1 });
+				}
+				Column::SplitHalf(buffer) => {
+					let buffer_log_len = buffer.log_len();
+					let data = buffer.as_mut();
+					let (lo_half, hi_half) =
+						data.split_at_mut(1 << (buffer_log_len - 1 - P::LOG_WIDTH));
+
+					let seg_lo = &mut lo_half[..1 << (n_vars + 1 - P::LOG_WIDTH)];
+					let (seg_lo_0, seg_lo_1) = seg_lo.split_at_mut(1 << (n_vars - P::LOG_WIDTH));
+					cols.push(PreFoldColumnChunk::InPlace {
+						seg_0: seg_lo_0,
+						seg_1: seg_lo_1,
+					});
+
+					let seg_hi = &mut hi_half[..1 << (n_vars + 1 - P::LOG_WIDTH)];
+					let (seg_hi_0, seg_hi_1) = seg_hi.split_at_mut(1 << (n_vars - P::LOG_WIDTH));
+					cols.push(PreFoldColumnChunk::InPlace {
+						seg_0: seg_hi_0,
+						seg_1: seg_hi_1,
+					});
+				}
+			}
+		}
+
+		// Split each producer into the `[low, high]` pair whose outputs are the two halves of the
+		// folded column.
+		let cols = cols.into_iter().map(|col| col.split_half()).collect();
+
+		// Carry each eq expansion as an in-place producer over its low and high halves. The
+		// recursion contracts it into its front half via `fold_eq`; `truncate_one_var` below then
+		// advances each tracker's bookkeeping over the folded-out variable.
+		let eqs = self
+			.eq_trackers
+			.iter_mut()
+			.map(|tracker| {
+				let data = tracker.eq_expansion_mut().as_mut();
+				debug_assert_eq!(data.len(), 1 << (n_vars - P::LOG_WIDTH));
+
+				let (seg_0, seg_1) = data.split_at_mut(1 << (n_vars - 1 - P::LOG_WIDTH));
+				PreFoldColumnChunk::InPlace { seg_0, seg_1 }
+			})
+			.collect::<Vec<_>>();
+
+		let chunk = PreFoldEvaluationChunk {
+			n_vars: n_vars - 1,
+			challenge_broadcast: &challenge_broadcast,
+			cols,
+			eqs,
+		};
+		let result = map_reduce_with_fold_helper(chunk, chunk_vars, &map, &reduce);
+
+		// The fold wrote each column's folded data into the front of its buffer (or into `dst`);
+		// persist it so the store matches a plain `fold`.
+		for (column, dst) in iter::zip(&mut self.columns, &mut dsts) {
+			match column {
+				Column::Borrowed(_) => {
+					*column = Column::Owned(
+						dst.take()
+							.expect("borrowed columns get a destination buffer"),
+					)
+				}
+				Column::Owned(buffer) => buffer.truncate(n_vars),
+				Column::SplitHalf(_) => {}
+			}
+		}
+		for eq_tracker in &mut self.eq_trackers {
+			eq_tracker.truncate_one_var(challenge);
+		}
+		self.n_vars = n_vars;
+
+		result
+	}
+}
+
+/// The deferred fold of one column half or one eq expansion.
+///
+/// A column half folds with [`Self::fold`], interpolating `seg_0` and `seg_1` on the round's
+/// highest variable — in place over `seg_0`, or into a fresh `dst` for a borrowed column. An eq
+/// expansion folds with [`Self::fold_eq`], which contracts (sums) the halves instead of
+/// interpolating them.
+enum PreFoldColumnChunk<'a, P: PackedField> {
+	InPlace {
+		seg_0: &'a mut [P],
+		seg_1: &'a [P],
+	},
+	OutOfPlace {
+		dst: &'a mut [P],
+		seg_0: &'a [P],
+		seg_1: &'a [P],
+	},
+}
+
+impl<'a, P: PackedField> PreFoldColumnChunk<'a, P> {
+	/// Bisects the producer's output on its highest variable, splitting each segment in half.
+	const fn split_half(self) -> [Self; 2] {
+		match self {
+			Self::InPlace { seg_0, seg_1 } => {
+				let (seg_0_lo, seg_0_hi) = seg_0.split_at_mut(seg_0.len() / 2);
+				let (seg_1_lo, seg_1_hi) = seg_1.split_at(seg_1.len() / 2);
+				[
+					Self::InPlace {
+						seg_0: seg_0_lo,
+						seg_1: seg_1_lo,
+					},
+					Self::InPlace {
+						seg_0: seg_0_hi,
+						seg_1: seg_1_hi,
+					},
+				]
+			}
+			Self::OutOfPlace { dst, seg_0, seg_1 } => {
+				let (dst_lo, dst_hi) = dst.split_at_mut(dst.len() / 2);
+				let (seg_0_lo, seg_0_hi) = seg_0.split_at(seg_0.len() / 2);
+				let (seg_1_lo, seg_1_hi) = seg_1.split_at(seg_1.len() / 2);
+				[
+					Self::OutOfPlace {
+						dst: dst_lo,
+						seg_0: seg_0_lo,
+						seg_1: seg_1_lo,
+					},
+					Self::OutOfPlace {
+						dst: dst_hi,
+						seg_0: seg_0_hi,
+						seg_1: seg_1_hi,
+					},
+				]
+			}
+		}
+	}
+
+	/// Folds the segments and returns the folded output slice.
+	fn fold(self, challenge_broadcast: &P) -> &'a [P] {
+		match self {
+			Self::InPlace { seg_0, seg_1 } => {
+				for (out, &hi) in iter::zip(&mut *seg_0, seg_1) {
+					*out = extrapolate_line_packed(*out, hi, *challenge_broadcast);
+				}
+				seg_0
+			}
+			Self::OutOfPlace { dst, seg_0, seg_1 } => {
+				for (out, &lo, &hi) in izip!(&mut *dst, seg_0, seg_1) {
+					*out = extrapolate_line_packed(lo, hi, *challenge_broadcast);
+				}
+				dst
+			}
+		}
+	}
+
+	/// Contracts the eq expansion by summing its halves, and returns the folded output slice.
+	///
+	/// Eq-indicator folding sums the two halves (the [Gruen24] technique's part (3)), rather than
+	/// interpolating them as [`Self::fold`] does for columns.
+	///
+	/// [Gruen24]: <https://eprint.iacr.org/2024/108>
+	fn fold_eq(self) -> &'a [P] {
+		match self {
+			Self::InPlace { seg_0, seg_1 } => {
+				for (out, &hi) in iter::zip(&mut *seg_0, seg_1) {
+					*out += hi;
+				}
+				seg_0
+			}
+			Self::OutOfPlace { dst, seg_0, seg_1 } => {
+				for (out, &lo, &hi) in izip!(&mut *dst, seg_0, seg_1) {
+					*out = lo + hi;
+				}
+				dst
+			}
+		}
+	}
+}
+
+/// A range of the halved hypercube whose values have not yet been folded, the deferred-fold
+/// counterpart of [`EvaluationChunk`]. Each column is a `[low, high]` pair of fold producers and
+/// each eq expansion is a single producer; [`Self::fold`] runs them all to produce an
+/// [`EvaluationChunk`] at a leaf.
+struct PreFoldEvaluationChunk<'a, P: PackedField> {
+	n_vars: usize,
+	challenge_broadcast: &'a P,
+	cols: Vec<[PreFoldColumnChunk<'a, P>; 2]>,
+	eqs: Vec<PreFoldColumnChunk<'a, P>>,
+}
+
+impl<'a, P: PackedField> PreFoldEvaluationChunk<'a, P> {
+	/// Bisects the range on its highest remaining variable, matching
+	/// [`EvaluationChunk::split_half`].
+	fn split_half(self) -> [Self; 2] {
+		let Self {
+			n_vars,
+			challenge_broadcast,
+			cols,
+			eqs,
+		} = self;
+		let n_vars = n_vars - 1;
+		let (cols_0, cols_1) = cols
+			.into_iter()
+			.map(|[lo, hi]| {
+				let [lo_0, lo_1] = lo.split_half();
+				let [hi_0, hi_1] = hi.split_half();
+				([lo_0, hi_0], [lo_1, hi_1])
+			})
+			.unzip();
+		let (eqs_0, eqs_1) = eqs
+			.into_iter()
+			.map(|eq| {
+				let [eq_0, eq_1] = eq.split_half();
+				(eq_0, eq_1)
+			})
+			.unzip();
+		[
+			Self {
+				n_vars,
+				challenge_broadcast,
+				cols: cols_0,
+				eqs: eqs_0,
+			},
+			Self {
+				n_vars,
+				challenge_broadcast,
+				cols: cols_1,
+				eqs: eqs_1,
+			},
+		]
+	}
+
+	/// Folds every column into its low and high halves, producing the leaf [`EvaluationChunk`].
+	fn fold(self) -> EvaluationChunk<'a, P> {
+		let Self {
+			n_vars,
+			challenge_broadcast,
+			cols,
+			eqs,
+		} = self;
+		let cols = cols
+			.into_iter()
+			.map(|[lo, hi]| ColumnChunk {
+				lo: FieldSlice::from_slice(n_vars, lo.fold(challenge_broadcast)),
+				hi: FieldSlice::from_slice(n_vars, hi.fold(challenge_broadcast)),
+			})
+			.collect();
+		let eqs = eqs
+			.into_iter()
+			.map(|eq| FieldSlice::from_slice(n_vars, eq.fold_eq()))
+			.collect();
+		EvaluationChunk { n_vars, cols, eqs }
+	}
 }
 
 /// One column's low and high halves within an [`EvaluationChunk`].
@@ -438,10 +758,29 @@ fn map_reduce_helper<P: PackedField, T: Send>(
 	reduce(ret_0, ret_1)
 }
 
+fn map_reduce_with_fold_helper<P: PackedField, T: Send>(
+	chunk: PreFoldEvaluationChunk<'_, P>,
+	sub_vars: usize,
+	map: &(impl (for<'a> Fn(EvaluationChunk<'a, P>) -> T) + Sync),
+	reduce: &(impl (Fn(T, T) -> T) + Sync),
+) -> T {
+	if sub_vars == chunk.n_vars {
+		return map(chunk.fold());
+	}
+
+	let [chunk_0, chunk_1] = chunk.split_half();
+	let (ret_0, ret_1) = rayon::join(
+		move || map_reduce_with_fold_helper(chunk_0, sub_vars, map, reduce),
+		move || map_reduce_with_fold_helper(chunk_1, sub_vars, map, reduce),
+	);
+	reduce(ret_0, ret_1)
+}
+
 #[cfg(test)]
 mod tests {
 	use binius_field::{Field, FieldOps, PackedField};
 	use binius_math::test_utils::{Packed128b, random_field_buffer, random_scalars};
+	use itertools::Itertools;
 	use rand::{SeedableRng, rngs::StdRng};
 
 	use super::*;
@@ -510,6 +849,111 @@ mod tests {
 				|lhs, rhs| lhs + rhs,
 			);
 			assert_eq!(got, expected, "mismatch at chunk_vars = {chunk_vars}");
+		}
+	}
+
+	#[test]
+	fn map_reduce_with_fold_matches_fold_then_map_reduce() {
+		type P = Packed128b;
+		type F = <P as FieldOps>::Scalar;
+
+		let n_vars = 8;
+		let mut rng = StdRng::seed_from_u64(1);
+
+		// Source data. Borrowed columns are read but never mutated by either path, so both stores
+		// can share them; owned and split-half buffers are folded in place, so each store clones
+		// its own.
+		let borrowed = [
+			random_field_buffer::<P>(&mut rng, n_vars),
+			random_field_buffer::<P>(&mut rng, n_vars),
+		];
+		let owned = random_field_buffer::<P>(&mut rng, n_vars);
+		let split = random_field_buffer::<P>(&mut rng, n_vars + 1);
+		let eq_points = [
+			random_scalars::<F>(&mut rng, n_vars),
+			random_scalars::<F>(&mut rng, n_vars),
+		];
+		let challenge = random_scalars::<F>(&mut rng, 1)[0];
+
+		let build = || {
+			let mut store = MleStore::<P>::new(n_vars);
+			let mut col_ids = borrowed
+				.iter()
+				.map(|col| store.push(col.to_ref()))
+				.collect::<Vec<_>>();
+			col_ids.push(store.push_owned(owned.clone()));
+			col_ids.extend(store.push_split_half(split.clone()));
+			let eq_ids = eq_points
+				.iter()
+				.map(|point| store.register_eq_tracker(point))
+				.collect::<Vec<_>>();
+			(store, col_ids, eq_ids)
+		};
+
+		// The store's folded state: remaining variable count plus every column and eq scalar.
+		let scalars =
+			|slice: &FieldSlice<'_, P>| (0..slice.len()).map(|i| slice.get(i)).collect_vec();
+		let state = |store: &MleStore<'_, P>| {
+			let cols = store.column_slices().iter().flat_map(scalars).collect_vec();
+			let eqs = store
+				.eq_expansions()
+				.iter()
+				.flat_map(|eq| scalars(&eq.to_ref()))
+				.collect_vec();
+			(store.n_vars(), cols, eqs)
+		};
+
+		// chunk_vars below P::LOG_WIDTH takes the fallback path; at or above it takes the fused
+		// path.
+		for chunk_vars in 0..n_vars - 1 {
+			let (mut fold_first, col_ids, eq_ids) = build();
+			fold_first.fold(challenge);
+			let expected = fold_first.map_reduce(
+				chunk_vars,
+				|chunk| chunk_aggregate(&chunk, &col_ids, &eq_ids),
+				|lhs, rhs| lhs + rhs,
+			);
+
+			let (mut fused, col_ids, eq_ids) = build();
+			let got = fused.map_reduce_with_fold(
+				chunk_vars,
+				challenge,
+				|chunk| chunk_aggregate(&chunk, &col_ids, &eq_ids),
+				|lhs, rhs| lhs + rhs,
+			);
+
+			assert_eq!(got, expected, "result mismatch at chunk_vars = {chunk_vars}");
+			assert_eq!(
+				state(&fold_first),
+				state(&fused),
+				"folded-state mismatch at chunk_vars = {chunk_vars}"
+			);
+		}
+
+		// Fold both stores round by round in lockstep, exercising split-half columns once the store
+		// has shrunk below the parent buffer's length.
+		let (mut fold_first, fold_col_ids, fold_eq_ids) = build();
+		let (mut fused, fused_col_ids, fused_eq_ids) = build();
+		let challenges = random_scalars::<F>(&mut rng, n_vars);
+		for (round, &challenge) in challenges.iter().take(n_vars - 1).enumerate() {
+			let n = fused.n_vars();
+			let chunk_vars = (n - 2).min(3);
+
+			fold_first.fold(challenge);
+			let expected = fold_first.map_reduce(
+				chunk_vars,
+				|chunk| chunk_aggregate(&chunk, &fold_col_ids, &fold_eq_ids),
+				|lhs, rhs| lhs + rhs,
+			);
+			let got = fused.map_reduce_with_fold(
+				chunk_vars,
+				challenge,
+				|chunk| chunk_aggregate(&chunk, &fused_col_ids, &fused_eq_ids),
+				|lhs, rhs| lhs + rhs,
+			);
+
+			assert_eq!(got, expected, "result mismatch in round {round}");
+			assert_eq!(state(&fold_first), state(&fused), "folded-state mismatch in round {round}");
 		}
 	}
 }

--- a/crates/ip-prover/src/sumcheck/mle_store.rs
+++ b/crates/ip-prover/src/sumcheck/mle_store.rs
@@ -24,7 +24,7 @@ use binius_math::{
 	FieldBuffer, FieldSlice,
 	multilinear::fold::{fold_highest_var, fold_highest_var_inplace},
 };
-use binius_utils::rayon::prelude::*;
+use binius_utils::rayon;
 
 use super::gruen32::Gruen32;
 
@@ -308,37 +308,67 @@ impl<'a, F: Field, P: PackedField<Scalar = F>> MleStore<'a, P> {
 			.collect()
 	}
 
-	/// Prepares one round's accumulation pass over the columns and eq trackers.
+	/// Maps every chunk of the halved hypercube through `map` and combines the results with
+	/// `reduce`, driven by a recursive [`rayon::join`] tree.
 	///
-	/// The returned [`ExecuteContext`] borrows the store's expanded column slices and eq-indicator
-	/// expansions and hands each parallel chunk to the round evaluators (see
-	/// [`ExecuteContext::par_chunks`]).
-	pub fn execute_context(&self) -> ExecuteContext<'_, P> {
-		ExecuteContext {
-			n_vars: self.n_vars,
-			cols: self.column_slices(),
-			eqs: self.eq_expansions(),
-		}
+	/// The store's columns are expanded once — a split-half column becomes its two halves — and
+	/// each column is split on the round's highest variable into its low and high halves. The
+	/// recursion peels the remaining variables off both halves, and off every eq-indicator
+	/// expansion, together, so each leaf hands `map` one [`EvaluationChunk`]: the paired column
+	/// halves and the matching eq chunk, at `2^chunk_vars` scalars per half.
+	///
+	/// `chunk_vars` is capped at `n_vars() - 1`, so leaves never exceed the halved hypercube.
+	///
+	/// ## Preconditions
+	///
+	/// * `n_vars()` must be greater than 0.
+	pub fn map_reduce<T: Send>(
+		&self,
+		chunk_vars: usize,
+		map: impl (for<'c> Fn(EvaluationChunk<'c, P>) -> T) + Sync,
+		reduce: impl (Fn(T, T) -> T) + Sync,
+	) -> T {
+		assert!(self.n_vars > 0);
+		let chunk_vars = chunk_vars.min(self.n_vars - 1);
+
+		let col_slices = self.column_slices();
+		let cols = col_slices
+			.iter()
+			.map(|col| {
+				let (lo, hi) = col.split_half_ref();
+				ColumnChunk { lo, hi }
+			})
+			.collect();
+		let eqs = self.eq_expansions().iter().map(|eq| eq.to_ref()).collect();
+		let chunk = EvaluationChunk {
+			n_vars: self.n_vars - 1,
+			cols,
+			eqs,
+		};
+		map_reduce_helper(chunk, chunk_vars, &map, &reduce)
 	}
 }
 
-/// One store column's low and high halves at a single chunk of the halved hypercube.
+/// One column's low and high halves within an [`EvaluationChunk`].
 ///
 /// The column is split on the round's highest variable: `lo` fixes that variable to 0, `hi` to 1.
-/// Both range over the chunk's `2^chunk_vars` scalars.
+/// Both range over the chunk's scalars.
 pub struct ColumnChunk<'c, P: PackedField> {
 	pub lo: FieldSlice<'c, P>,
 	pub hi: FieldSlice<'c, P>,
 }
 
-/// One chunk of the halved hypercube, prepared for the round evaluators.
+/// A range of the halved hypercube, prepared for the round evaluators.
 ///
-/// With `n` variables remaining, each column splits on the highest variable into two halves of
-/// `n - 1` variables, and both halves divide into chunks of `2^chunk_vars` scalars. This holds one
-/// such chunk: the split halves of every logical column and the same chunk of every eq-indicator
-/// expansion. A column read by several evaluators is chunked a single time. Evaluators read their
-/// columns by [`ColId`] and their eq trackers by [`EqId`].
+/// Holds, over `n_vars` variables, the paired low/high halves of every logical column and the
+/// eq-indicator expansion of every tracker. Each column was split on the round's highest variable,
+/// so a [`ColumnChunk`]'s `lo` and `hi` differ only in that variable. The range is bisected — the
+/// highest remaining variable peeled off both halves of every column and off every eq expansion —
+/// down to the leaves that [`MleStore::map_reduce`] hands to its `map` callback. A
+/// column read by several evaluators is split a single time. Evaluators read their columns by
+/// [`ColId`] and their eq trackers by [`EqId`].
 pub struct EvaluationChunk<'c, P: PackedField> {
+	n_vars: usize,
 	cols: Vec<ColumnChunk<'c, P>>,
 	eqs: Vec<FieldSlice<'c, P>>,
 }
@@ -356,65 +386,130 @@ impl<'c, P: PackedField> EvaluationChunk<'c, P> {
 	pub fn eq(&self, id: EqId) -> &FieldSlice<'c, P> {
 		&self.eqs[id.index()]
 	}
+
+	/// Bisects the range into its two halves on the highest remaining variable, splitting both
+	/// halves of every column and every eq expansion. Each returned chunk has one fewer variable.
+	fn split_half(&self) -> [EvaluationChunk<'_, P>; 2] {
+		let Self { n_vars, cols, eqs } = self;
+		let (cols_0, cols_1) = cols
+			.iter()
+			.map(|ColumnChunk { lo, hi }| {
+				let (lo_0, lo_1) = lo.split_half_ref();
+				let (hi_0, hi_1) = hi.split_half_ref();
+				(ColumnChunk { lo: lo_0, hi: hi_0 }, ColumnChunk { lo: lo_1, hi: hi_1 })
+			})
+			.unzip();
+		let (eqs_0, eqs_1) = eqs.iter().map(|col| col.split_half_ref()).unzip();
+		[
+			EvaluationChunk {
+				n_vars: n_vars - 1,
+				cols: cols_0,
+				eqs: eqs_0,
+			},
+			EvaluationChunk {
+				n_vars: n_vars - 1,
+				cols: cols_1,
+				eqs: eqs_1,
+			},
+		]
+	}
 }
 
-/// A round's expanded columns and eq-indicator expansions, borrowed from an [`MleStore`].
+/// Recursively maps and reduces an [`EvaluationChunk`] for [`MleStore::map_reduce`].
 ///
-/// Produced by [`MleStore::execute_context`]. It expands the store's columns once — a split-half
-/// column becomes its two halves — and drives the parallel round pass through
-/// [`Self::par_chunks`], which slices each column and eq expansion per chunk into an
-/// [`EvaluationChunk`].
-pub struct ExecuteContext<'b, P: PackedField> {
-	// The store's remaining variable count; the halved hypercube has `n_vars - 1` variables.
-	n_vars: usize,
-	// One slice per logical column, over all `n_vars` remaining variables, in `ColId` order.
-	cols: Vec<FieldSlice<'b, P>>,
-	// One eq-indicator expansion per registered tracker, over `n_vars - 1` variables, in `EqId`
-	// order.
-	eqs: Vec<&'b FieldBuffer<P>>,
+/// Once the chunk has been narrowed to `sub_vars` variables it is handed to `map`; otherwise it is
+/// bisected with [`EvaluationChunk::split_half`] and the two halves are mapped in parallel and
+/// combined with `reduce`.
+fn map_reduce_helper<P: PackedField, T: Send>(
+	chunk: EvaluationChunk<'_, P>,
+	sub_vars: usize,
+	map: &(impl (for<'a> Fn(EvaluationChunk<'a, P>) -> T) + Sync),
+	reduce: &(impl (Fn(T, T) -> T) + Sync),
+) -> T {
+	if sub_vars == chunk.n_vars {
+		return map(chunk);
+	}
+
+	let [chunk_0, chunk_1] = chunk.split_half();
+	let (ret_0, ret_1) = rayon::join(
+		move || map_reduce_helper(chunk_0, sub_vars, map, reduce),
+		move || map_reduce_helper(chunk_1, sub_vars, map, reduce),
+	);
+	reduce(ret_0, ret_1)
 }
 
-impl<'b, P: PackedField> ExecuteContext<'b, P> {
-	/// Returns a parallel iterator over the chunks of the halved hypercube.
-	///
-	/// Each item is one [`EvaluationChunk`]: the split low/high halves of every column and the
-	/// matching chunk of every eq-indicator expansion, at `2^chunk_vars` scalars per chunk. A
-	/// column's low half is the front chunk `chunk_index` of the full column; its high half is
-	/// chunk `chunk_count + chunk_index`, the corresponding chunk of the back half — so the column
-	/// is sliced without materializing its halves separately.
-	///
-	/// ## Preconditions
-	///
-	/// * `chunk_vars` must be at most `n_vars - 1`.
-	pub fn par_chunks(
-		&self,
-		chunk_vars: usize,
-	) -> impl IndexedParallelIterator<Item = EvaluationChunk<'_, P>> {
-		// precondition
-		assert!(
-			chunk_vars < self.n_vars,
-			"chunk_vars must be at most the halved hypercube's variable count"
-		);
+#[cfg(test)]
+mod tests {
+	use binius_field::{Field, FieldOps, PackedField};
+	use binius_math::test_utils::{Packed128b, random_field_buffer, random_scalars};
+	use rand::{SeedableRng, rngs::StdRng};
 
-		let chunk_count = 1usize << (self.n_vars - 1 - chunk_vars);
-		(0..chunk_count).into_par_iter().map(move |chunk_index| {
-			// The full column at `chunk_vars` holds the low half in its first `chunk_count` chunks
-			// and the high half in the next `chunk_count`, so the two halves of this chunk are the
-			// full column's chunks `chunk_index` and `chunk_count + chunk_index`.
-			let cols = self
-				.cols
-				.iter()
-				.map(|col| ColumnChunk {
-					lo: col.chunk(chunk_vars, chunk_index),
-					hi: col.chunk(chunk_vars, chunk_count + chunk_index),
-				})
-				.collect();
-			let eqs = self
-				.eqs
-				.iter()
-				.map(|eq| eq.chunk(chunk_vars, chunk_index))
-				.collect();
-			EvaluationChunk { cols, eqs }
-		})
+	use super::*;
+
+	// A per-chunk aggregate that is sensitive to both the low/high pairing within a column and the
+	// alignment of each eq expansion with its column, so a wrong recursion pairing changes the sum.
+	fn chunk_aggregate<P: PackedField>(
+		chunk: &EvaluationChunk<'_, P>,
+		col_ids: &[ColId],
+		eq_ids: &[EqId],
+	) -> P::Scalar {
+		let mut acc = P::Scalar::ZERO;
+		for (i, &col_id) in col_ids.iter().enumerate() {
+			let col = chunk.col(col_id);
+			let eq = chunk.eq(eq_ids[i % eq_ids.len()]);
+			for j in 0..col.lo.len() {
+				acc += eq.get(j) * col.lo.get(j) * col.hi.get(j);
+			}
+		}
+		acc
+	}
+
+	#[test]
+	fn map_reduce_pairs_on_highest_variable() {
+		type P = Packed128b;
+		type F = <P as FieldOps>::Scalar;
+
+		let n_vars = 7;
+		let mut rng = StdRng::seed_from_u64(0);
+
+		// A mix of column kinds so `chunk` exercises borrowed, owned, and split-half entries.
+		let borrowed = [
+			random_field_buffer::<P>(&mut rng, n_vars),
+			random_field_buffer::<P>(&mut rng, n_vars),
+		];
+		let mut store = MleStore::<P>::new(n_vars);
+		let mut col_ids = borrowed
+			.iter()
+			.map(|col| store.push(col.to_ref()))
+			.collect::<Vec<_>>();
+		col_ids.push(store.push_owned(random_field_buffer::<P>(&mut rng, n_vars)));
+		col_ids.extend(store.push_split_half(random_field_buffer::<P>(&mut rng, n_vars + 1)));
+
+		let eq_ids = (0..2)
+			.map(|_| store.register_eq_tracker(&random_scalars::<F>(&mut rng, n_vars)))
+			.collect::<Vec<_>>();
+
+		// Independent reference: the aggregate over the whole halved hypercube, pairing each
+		// logical column's front half (highest variable = 0) with its back half (= 1) at the same
+		// index. This is the pairing `map_reduce` must reproduce, whatever the chunking.
+		let cols = store.column_slices();
+		let eqs = store.eq_expansions();
+		let half = 1usize << (n_vars - 1);
+		let mut expected = F::ZERO;
+		for (i, col) in cols.iter().enumerate() {
+			let eq = eqs[i % eqs.len()];
+			for j in 0..half {
+				expected += eq.get(j) * col.get(j) * col.get(half + j);
+			}
+		}
+
+		for chunk_vars in 0..n_vars {
+			let got = store.map_reduce(
+				chunk_vars,
+				|chunk| chunk_aggregate(&chunk, &col_ids, &eq_ids),
+				|lhs, rhs| lhs + rhs,
+			);
+			assert_eq!(got, expected, "mismatch at chunk_vars = {chunk_vars}");
+		}
 	}
 }

--- a/crates/ip-prover/src/sumcheck/round_evaluator.rs
+++ b/crates/ip-prover/src/sumcheck/round_evaluator.rs
@@ -17,7 +17,6 @@ use auto_impl::auto_impl;
 use binius_field::{Field, PackedField, WideMul};
 use binius_ip::sumcheck::RoundCoeffs;
 use binius_math::FieldBuffer;
-use binius_utils::rayon::prelude::*;
 
 use super::{
 	MleToSumCheckEvaluator,
@@ -192,24 +191,24 @@ where
 
 		// The store prepares one `EvaluationChunk` per chunk of the halved hypercube — the split
 		// column halves and eq-indicator expansions each evaluator reads.
-		let ctx = self.store.execute_context();
 		let evaluators = &self.evaluators;
-		let new_accum = || -> Vec<<P as WideMul>::Output> { vec![Default::default(); total_slots] };
-		let accum = ctx
-			.par_chunks(chunk_vars)
-			.fold(new_accum, |mut accum, chunk| {
+		let accum = self.store.map_reduce(
+			chunk_vars,
+			|chunk| {
+				let mut accum = vec![Default::default(); total_slots];
 				for (evaluator, window) in iter::zip(evaluators, offsets.windows(2)) {
 					evaluator.accumulate(&chunk, &mut accum[window[0]..window[1]]);
 				}
 				accum
-			})
-			.reduce(new_accum, |mut lhs, rhs| {
+			},
+			|mut lhs, rhs| {
 				// The only merge: sum the workers' slices slot-wise, generic over every evaluator.
 				for (dst, src) in iter::zip(&mut lhs, rhs) {
 					*dst += src;
 				}
 				lhs
-			});
+			},
+		);
 
 		// The store is read (immutably) for the round's point coordinates while the evaluators are
 		// interpolated (mutably); they are disjoint fields, so borrow the store separately.

--- a/crates/ip-prover/src/sumcheck/round_evaluator.rs
+++ b/crates/ip-prover/src/sumcheck/round_evaluator.rs
@@ -101,6 +101,10 @@ const MAX_CHUNK_VARS: usize = 12;
 pub struct SharedSumcheckProver<'a, P: PackedField, Evaluator> {
 	store: MleStore<'a, P>,
 	evaluators: Vec<Evaluator>,
+	/// A fold challenge whose store fold has been deferred so the next [`SumcheckProver::execute`]
+	/// can fuse it into that round's read pass (see [`MleStore::map_reduce_with_fold`]). The
+	/// evaluators fold eagerly; only the store's column and eq fold waits here.
+	buffered_challenge: Option<P::Scalar>,
 }
 
 impl<'a, F, P, Evaluator> SharedSumcheckProver<'a, P, Evaluator>
@@ -111,7 +115,11 @@ where
 {
 	/// Creates a prover from a store and the evaluators reading its columns, one per claim.
 	pub const fn new(store: MleStore<'a, P>, evaluators: Vec<Evaluator>) -> Self {
-		Self { store, evaluators }
+		Self {
+			store,
+			evaluators,
+			buffered_challenge: None,
+		}
 	}
 
 	/// Returns a shared reference to the underlying column store.
@@ -156,7 +164,9 @@ where
 	Evaluator: RoundEvaluator<F, P>,
 {
 	fn n_vars(&self) -> usize {
-		self.store.n_vars()
+		// A buffered challenge is a fold that has not yet reached the store, so the logical
+		// remaining-variable count is one below the store's until the next execute applies it.
+		self.store.n_vars() - self.buffered_challenge.is_some() as usize
 	}
 
 	fn n_claims(&self) -> usize {
@@ -171,7 +181,7 @@ where
 	}
 
 	fn execute(&mut self) -> Vec<RoundCoeffs<F>> {
-		let n_vars_remaining = self.store.n_vars();
+		let n_vars_remaining = self.n_vars();
 		assert!(n_vars_remaining > 0);
 
 		// One parallel pass over the halved hypercube feeds every evaluator, so shared columns
@@ -191,24 +201,29 @@ where
 
 		// The store prepares one `EvaluationChunk` per chunk of the halved hypercube — the split
 		// column halves and eq-indicator expansions each evaluator reads.
+		let buffered_challenge = self.buffered_challenge.take();
 		let evaluators = &self.evaluators;
-		let accum = self.store.map_reduce(
-			chunk_vars,
-			|chunk| {
-				let mut accum = vec![Default::default(); total_slots];
-				for (evaluator, window) in iter::zip(evaluators, offsets.windows(2)) {
-					evaluator.accumulate(&chunk, &mut accum[window[0]..window[1]]);
-				}
-				accum
-			},
-			|mut lhs, rhs| {
-				// The only merge: sum the workers' slices slot-wise, generic over every evaluator.
-				for (dst, src) in iter::zip(&mut lhs, rhs) {
-					*dst += src;
-				}
-				lhs
-			},
-		);
+		let store = &mut self.store;
+		let map = |chunk: EvaluationChunk<'_, P>| {
+			let mut accum = vec![Default::default(); total_slots];
+			for (evaluator, window) in iter::zip(evaluators, offsets.windows(2)) {
+				evaluator.accumulate(&chunk, &mut accum[window[0]..window[1]]);
+			}
+			accum
+		};
+		let reduce = |mut lhs: Vec<<P as WideMul>::Output>, rhs: Vec<<P as WideMul>::Output>| {
+			// The only merge: sum the workers' slices slot-wise, generic over every evaluator.
+			for (dst, src) in iter::zip(&mut lhs, rhs) {
+				*dst += src;
+			}
+			lhs
+		};
+		let accum = match buffered_challenge {
+			// The previous fold deferred its store fold; apply it and this round's read in one
+			// pass.
+			Some(challenge) => store.map_reduce_with_fold(chunk_vars, challenge, map, reduce),
+			None => store.map_reduce(chunk_vars, map, reduce),
+		};
 
 		// The store is read (immutably) for the round's point coordinates while the evaluators are
 		// interpolated (mutably); they are disjoint fields, so borrow the store separately.
@@ -219,15 +234,25 @@ where
 	}
 
 	fn fold(&mut self, challenge: F) {
-		// The store folds — columns and eq trackers both; evaluators only advance local
-		// bookkeeping such as claim state and equality prefix products.
-		self.store.fold(challenge);
+		// The evaluators advance their local bookkeeping (claim state, equality prefix products)
+		// now, but the store's column and eq fold is deferred: the challenge is buffered so the
+		// next execute can fuse it into that round's read pass.
 		for evaluator in &mut self.evaluators {
 			evaluator.fold(challenge);
 		}
+		debug_assert!(
+			self.buffered_challenge.is_none(),
+			"fold called twice without an intervening execute"
+		);
+		self.buffered_challenge = Some(challenge);
 	}
 
-	fn finish(self) -> Vec<F> {
+	fn finish(mut self) -> Vec<F> {
+		// The last round's fold is still buffered; apply it to the store before reading
+		// evaluations.
+		if let Some(challenge) = self.buffered_challenge.take() {
+			self.store.fold(challenge);
+		}
 		// The store owns each column once and computes its evaluation a single time, no matter how
 		// many claims read it; emit every column's evaluation in store order.
 		self.store.final_evals()
@@ -280,9 +305,11 @@ where
 		Evaluator: 'static,
 	{
 		let Self { inner, eval_point } = self;
+		// Conversion happens before proving starts, so no fold challenge is buffered yet.
 		let SharedSumcheckProver {
 			mut store,
 			evaluators,
+			buffered_challenge: _,
 		} = inner;
 		// Every claim of an MLE-check prover shares the prover's evaluation point, so its eq
 		// tracker is already registered on the store (by the evaluators reading it). Recover that


### PR DESCRIPTION
## Summary

Optimizes the sumcheck `MleStore` by restructuring it around a map/reduce pattern and then fusing each round's fold into the next round's accumulation pass, so columns and eq expansions are read once per round instead of twice.

## Changes

- **Small benchmark improvements** to the bivariate-product sumcheck benchmark.
- **Map reduce for `MleStore`** — reimplement the store's per-round work as a map/reduce, giving a cleaner base for the shared sumcheck and a foundation for fused folding.
- **Fused fold + map_reduce** — add `MleStore::map_reduce_with_fold`, which folds the store on a challenge and maps/reduces the resulting halved hypercube in a single pass. Each logical column is carried as a deferred-fold producer (`PreFoldColumnChunk`) whose halves are interpolated on the round's highest variable at the recursion leaves; eq expansions fold lazily in the same pass (`fold_eq` plus the new `Gruen32::truncate_one_var`). Falls back to plain fold + map_reduce for chunk sizes below `P::LOG_WIDTH`.
- **Fuse the fold into the next round in `SharedSumcheckProver`** — drive the prover with `map_reduce_with_fold` so each round's store fold and read pass touch the columns once. The store fold is deferred by one round; `n_vars()` subtracts the buffered challenge to keep the logical remaining-variable count correct.

## Testing

- `map_reduce_with_fold_matches_fold_then_map_reduce` checks the return value and full store state (columns and eq expansions) against fold-then-map_reduce across both code paths and multiple rounds.
- Existing differential-equivalence tests (transcripts byte-identical to the pre-store provers) and the downstream prover suites pass unchanged, confirming the fused path emits the same round polynomials and evaluations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
