### PR TITLE
BINIUS-302: handle binmul constraints in the M4 prover and verifier

### DIFF
--- a/crates/m4-prover/src/operand_witness.rs
+++ b/crates/m4-prover/src/operand_witness.rs
@@ -2,18 +2,21 @@
 
 //! The batched operand-column witnesses built from a populated batch value table.
 //!
-//! Every AND and IMUL constraint is projected to its fixed-arity operand columns (`[A, B, C]` for
-//! AND, `[A, B, HI, LO]` for IMUL), one column per operand, stacked over every instance in the
-//! batch. [`build_operation_witness`] is the shared arity-generic core: it projects one operand
-//! per constraint into one column. [`BatchAndCheckWitness`] builds the three AND columns and
-//! drives the AND-check zerocheck; [`build_intmul_witness`] builds the four IntMul columns, not
-//! yet consumed downstream.
+//! Every AND, IMUL, and BMUL constraint is projected to its fixed-arity operand columns (`[A, B,
+//! C]` for AND, `[A, B, HI, LO]` for IMUL, `[A_LO, A_HI, B_LO, B_HI, C_LO, C_HI]` for BMUL), one
+//! column per operand, stacked over every instance in the batch. [`build_operation_witness`] is the
+//! shared arity-generic core: it projects one operand per constraint into one column.
+//! [`BatchAndCheckWitness`] builds the three AND columns and drives the AND-check zerocheck;
+//! [`build_intmul_witness`] builds the four IntMul columns; [`build_binmul_witness`] builds the six
+//! BinMul columns.
 
 use std::{iter, mem::MaybeUninit, ptr};
 
 use binius_core::{
 	ValueIndex,
-	constraint_system::{AndConstraint, ImulConstraint, Operand, ShiftVariant, ShiftedValueIndex},
+	constraint_system::{
+		AndConstraint, BmulConstraint, ImulConstraint, Operand, ShiftVariant, ShiftedValueIndex,
+	},
 	word::Word,
 };
 use binius_field::{AESTowerField8b as B8, PackedField};
@@ -498,6 +501,75 @@ pub fn build_intmul_witness(
 	[a, b, hi, lo]
 }
 
+/// Builds the batched BinMul operand witness from a populated wire-major batch table.
+///
+/// Every BMUL constraint contributes one row per instance to each of the six operand columns
+/// `A_LO`, `A_HI`, `B_LO`, `B_HI`, `C_LO`, `C_HI`, laid out constraint-major. This delegates to the
+/// arity-generic `build_operation_witness`, projecting each constraint to its six operands. The
+/// operands are the `(lo, hi)` word pairs carrying the two GHASH-field multiplicands and their
+/// product.
+///
+/// # Arguments
+///
+/// - `table`: the wire-major batch witness holding every instance's hidden words.
+/// - `constants`: the circuit's constant words, shared by every instance.
+/// - `bmul_constraints`: the per-instance BMUL constraints, shared by every instance.
+///
+/// Pass constraints from a prepared constraint system, so their count is a power of two.
+///
+/// # Panics
+///
+/// Panics if the constraint count is not a power of two.
+pub fn build_binmul_witness(
+	table: &ValueTable,
+	constants: &[Word],
+	bmul_constraints: &[BmulConstraint],
+) -> [Vec<Word>; 6] {
+	let a_lo_iter = bmul_constraints
+		.par_iter()
+		.map(|constraint| &constraint.a_lo);
+	let a_hi_iter = bmul_constraints
+		.par_iter()
+		.map(|constraint| &constraint.a_hi);
+	let b_lo_iter = bmul_constraints
+		.par_iter()
+		.map(|constraint| &constraint.b_lo);
+	let b_hi_iter = bmul_constraints
+		.par_iter()
+		.map(|constraint| &constraint.b_hi);
+	let c_lo_iter = bmul_constraints
+		.par_iter()
+		.map(|constraint| &constraint.c_lo);
+	let c_hi_iter = bmul_constraints
+		.par_iter()
+		.map(|constraint| &constraint.c_hi);
+	let (((a_lo, a_hi), (b_lo, b_hi)), (c_lo, c_hi)) = rayon::join(
+		|| {
+			rayon::join(
+				|| {
+					rayon::join(
+						|| build_operation_witness(table, constants, a_lo_iter),
+						|| build_operation_witness(table, constants, a_hi_iter),
+					)
+				},
+				|| {
+					rayon::join(
+						|| build_operation_witness(table, constants, b_lo_iter),
+						|| build_operation_witness(table, constants, b_hi_iter),
+					)
+				},
+			)
+		},
+		|| {
+			rayon::join(
+				|| build_operation_witness(table, constants, c_lo_iter),
+				|| build_operation_witness(table, constants, c_hi_iter),
+			)
+		},
+	);
+	[a_lo, a_hi, b_lo, b_hi, c_lo, c_hi]
+}
+
 #[cfg(test)]
 mod tests {
 	use assert_matches::assert_matches;
@@ -769,6 +841,106 @@ mod tests {
 				assert_eq!(b[idx], vv.eval_operand(&con.b));
 				assert_eq!(hi[idx], vv.eval_operand(&con.hi));
 				assert_eq!(lo[idx], vv.eval_operand(&con.lo));
+			}
+		}
+	}
+
+	// A circuit computing one GHASH-field product `(a_lo, a_hi) * (b_lo, b_hi)`, with both product
+	// words committed.
+	//
+	//     inputs : a_lo, a_hi, b_lo, b_hi   (witness)
+	//     gate   : (c_lo, c_hi) = bmul(a_lo, a_hi, b_lo, b_hi)   → 1 BMUL constraint
+	//
+	// `force_commit` makes `c_lo` and `c_hi` hidden words, so the BMUL operands read them from the
+	// table.
+	struct BinMulCircuit {
+		circuit: Circuit,
+		a_lo: Wire,
+		a_hi: Wire,
+		b_lo: Wire,
+		b_hi: Wire,
+	}
+
+	fn binmul_circuit() -> BinMulCircuit {
+		let builder = CircuitBuilder::new();
+		let a_lo = builder.add_witness();
+		let a_hi = builder.add_witness();
+		let b_lo = builder.add_witness();
+		let b_hi = builder.add_witness();
+		let (c_lo, c_hi) = builder.bmul(a_lo, a_hi, b_lo, b_hi);
+		builder.force_commit(c_lo);
+		builder.force_commit(c_hi);
+		BinMulCircuit {
+			circuit: builder.build(),
+			a_lo,
+			a_hi,
+			b_lo,
+			b_hi,
+		}
+	}
+
+	// Populate one instance per input tuple; the circuit derives the two product words.
+	fn populate_binmul_table(c: &BinMulCircuit, inputs: &[(u64, u64, u64, u64)]) -> ValueTable {
+		let log_instances = inputs.len().ilog2() as usize;
+		ValueTable::populate(&c.circuit, log_instances, |i, filler| {
+			let (a_lo, a_hi, b_lo, b_hi) = inputs[i];
+			filler[c.a_lo] = Word(a_lo);
+			filler[c.a_hi] = Word(a_hi);
+			filler[c.b_lo] = Word(b_lo);
+			filler[c.b_hi] = Word(b_hi);
+		})
+		.unwrap()
+	}
+
+	// The arity-6 BinMul witness lays out its six operand columns [a_lo, a_hi, b_lo, b_hi, c_lo,
+	// c_hi] constraint-major, each row matching the single-instance operand evaluator.
+	#[test]
+	fn binmul_operand_columns_match_the_single_instance_reference() {
+		let c = binmul_circuit();
+		let constants = &c.circuit.constraint_system().constants;
+
+		// Fixture state: 2^2 = 4 instances with distinct GHASH-field operands.
+		let inputs = [
+			(1, 0, 1, 0),
+			(0xFFFF_FFFF_FFFF_FFFF, 0x0123_4567_89AB_CDEF, 0xDEAD_BEEF_CAFE_BABE, 0x1),
+			(0x1234, 0x5678, 0x9ABC, 0xDEF0),
+			(
+				0xAAAA_AAAA_AAAA_AAAA,
+				0x5555_5555_5555_5555,
+				0xF0F0_F0F0_F0F0_F0F0,
+				0x0F0F_0F0F_0F0F_0F0F,
+			),
+		];
+		let table = populate_binmul_table(&c, &inputs);
+
+		// The prepared per-instance BMUL constraints, padded to a power of two.
+		let mut cs = c.circuit.constraint_system().clone();
+		cs.validate_and_prepare().unwrap();
+		let bmul_constraints = &cs.bmul_constraints;
+		assert!(!bmul_constraints.is_empty(), "the circuit must emit a BMUL constraint");
+
+		let [a_lo, a_hi, b_lo, b_hi, c_lo, c_hi] =
+			build_binmul_witness(&table, constants, bmul_constraints);
+
+		// Shape: K * n_binmul rows, with K = 4.
+		let n_binmul = bmul_constraints.len();
+		for col in [&a_lo, &a_hi, &b_lo, &b_hi, &c_lo, &c_hi] {
+			assert_eq!(col.len(), 4 * n_binmul);
+		}
+
+		// Invariant: row `j * n_instances + instance` is constraint `j` of that instance, and each
+		// of the six columns equals the single-instance reference for its inputs.
+		let n_instances = table.n_instances();
+		for instance in 0..n_instances {
+			let vv = table.instance_value_vec(instance, constants);
+			for (j, con) in bmul_constraints.iter().enumerate() {
+				let idx = j * n_instances + instance;
+				assert_eq!(a_lo[idx], vv.eval_operand(&con.a_lo));
+				assert_eq!(a_hi[idx], vv.eval_operand(&con.a_hi));
+				assert_eq!(b_lo[idx], vv.eval_operand(&con.b_lo));
+				assert_eq!(b_hi[idx], vv.eval_operand(&con.b_hi));
+				assert_eq!(c_lo[idx], vv.eval_operand(&con.c_lo));
+				assert_eq!(c_hi[idx], vv.eval_operand(&con.c_hi));
 			}
 		}
 	}

--- a/crates/m4-prover/src/prove.rs
+++ b/crates/m4-prover/src/prove.rs
@@ -23,6 +23,7 @@ use binius_math::{
 use binius_prover::{
 	fold_word::fold_words,
 	protocols::{
+		binmul::{BinMulWitness, prove as prove_binmul_reduction},
 		intmul::{prove::IntMulProver, witness::Witness as IntMulWitness},
 		shift::{KeyCollection, OperatorData, build_key_collection},
 	},
@@ -33,15 +34,16 @@ use binius_utils::{checked_arithmetics::checked_log_2, rayon::prelude::*};
 use binius_verifier::{
 	config::B128,
 	protocols::{
+		binmul::BinMulOutput,
 		bitand::AndCheckOutput,
 		intmul::IntMulOutput,
-		shift::{BITAND_ARITY, INTMUL_ARITY},
+		shift::{BINMUL_ARITY, BITAND_ARITY, INTMUL_ARITY},
 	},
 };
 
 use crate::{
 	BatchAndCheckWitness, ValueTable,
-	operand_witness::build_intmul_witness,
+	operand_witness::{build_binmul_witness, build_intmul_witness},
 	shift::{fold_instances, prove as prove_shift},
 };
 
@@ -158,8 +160,31 @@ impl IOPProver {
 			(columns, output)
 		});
 
+		// Build the BinMul operand columns and run the BinMul check, only when the circuit has BMUL
+		// constraints.
+		//
+		// SOUNDNESS: the BinMul check runs after the IntMul check and before the BitAnd check
+		// below. Its per-bit operand evaluations are bound to the transcript here, before BitAnd
+		// draws the univariate challenge that collapses them. Do not reorder these, and keep the
+		// same order in `IOPVerifier::verify`.
+		//
+		// The six columns are the `(lo, hi)` word pairs of the two multiplicands and the product of
+		// every constraint over every instance, laid out constraint-major. They are kept alongside
+		// the check output; the re-randomization re-reads them to build the instance-axis
+		// multilinears it transports. BinMul commits no oracle, so nothing is added to
+		// `oracle_specs`.
+		let bmul = (!cs.bmul_constraints.is_empty()).then(|| {
+			let columns = {
+				let _scope = tracing::debug_span!("Assemble BinMul witness").entered();
+				build_binmul_witness(table, &cs.constants, &cs.bmul_constraints)
+			};
+			let output = prove_binmul::<P, _>(&columns, channel);
+			(columns, output)
+		});
+
 		// AND-check the `A & B == C` relation over all `K * n_and` rows.
-		// Retain the operand columns when IntMul ran, since the re-randomization re-reads them.
+		// Retain the operand columns when IntMul or BinMul ran, since the re-randomization re-reads
+		// them.
 		let (
 			and_columns,
 			AndCheckOutput {
@@ -176,7 +201,7 @@ impl IOPProver {
 				let _scope = tracing::debug_span!("Assemble BitAnd witness").entered();
 				BatchAndCheckWitness::build(table, &cs.constants, &cs.and_constraints)
 			};
-			let and_columns = mul.is_some().then(|| {
+			let and_columns = (mul.is_some() || bmul.is_some()).then(|| {
 				[
 					and_witness.a().to_vec(),
 					and_witness.b().to_vec(),
@@ -191,35 +216,33 @@ impl IOPProver {
 		let (r_rho_and, r_x_and) = eval_point.split_at(table.log_instances());
 
 		// Reduce to one shared instance point `r_rho` and the operand claims at that point.
-		let (r_rho, bitand_data, intmul_data) = match mul {
-			Some((mul_columns, intmul_output)) => {
-				// Both operations enter the re-randomization as operand columns with their oblong
-				// claims at their own instance point.
-				// BitAnd is already oblong.
-				// IntMul is collapsed from its per-bit form.
-				let lagrange = lagrange_evals_scalars::<B128, B128>(&shift_domain, z_challenge);
-				let and_columns = and_columns
-					.expect("AND columns are retained whenever there are IMUL constraints");
-				RerandomizedOperations {
-					bitand: Operation::new(
-						&and_columns,
-						[a_eval, b_eval, c_eval],
-						r_x_and,
-						r_rho_and,
-					),
-					intmul: Operation::from_intmul(
-						&mul_columns,
-						intmul_output,
-						&lagrange,
-						table.log_instances(),
-					),
-				}
-				.prove::<P, _>(&lagrange, z_challenge, channel)
+		//
+		// The re-randomization runs whenever IntMul or BinMul is present: BitAnd always enters,
+		// plus each present multiplication operation, all unified onto one shared `r_rho`.
+		let (r_rho, bitand_data, intmul_data, binmul_data) = if mul.is_some() || bmul.is_some() {
+			// Every present operation enters the re-randomization as operand columns with their
+			// oblong claims at their own instance point.
+			// BitAnd is already oblong.
+			// IntMul and BinMul are collapsed from their per-bit form.
+			let lagrange = lagrange_evals_scalars::<B128, B128>(&shift_domain, z_challenge);
+			let and_columns = and_columns
+				.expect("AND columns are retained whenever there are IMUL or BMUL constraints");
+			let log_instances = table.log_instances();
+			RerandomizedOperations {
+				bitand: Operation::new(&and_columns, [a_eval, b_eval, c_eval], r_x_and, r_rho_and),
+				intmul: mul.as_ref().map(|(columns, output)| {
+					Operation::from_intmul(columns, output.clone(), &lagrange, log_instances)
+				}),
+				binmul: bmul.as_ref().map(|(columns, output)| {
+					Operation::from_binmul(columns, output.clone(), &lagrange, log_instances)
+				}),
 			}
-			// No IMUL constraints: the AND-check instance point is used directly.
-			// The IntMul claim is a zero claim at an empty point, contributing nothing to the
-			// shift.
-			None => (
+			.prove::<P, _>(&lagrange, z_challenge, channel)
+		} else {
+			// Neither IMUL nor BMUL constraints: the AND-check instance point is used directly.
+			// The IntMul and BinMul claims are zero claims at an empty point, contributing nothing
+			// to the shift.
+			(
 				r_rho_and.to_vec(),
 				OperatorData {
 					evals: vec![a_eval, b_eval, c_eval],
@@ -227,11 +250,16 @@ impl IOPProver {
 					r_x_prime: r_x_and.to_vec(),
 				},
 				OperatorData {
-					evals: vec![B128::ZERO; 4],
+					evals: vec![B128::ZERO; INTMUL_ARITY],
 					r_zhat_prime: z_challenge,
 					r_x_prime: Vec::new(),
 				},
-			),
+				OperatorData {
+					evals: vec![B128::ZERO; BINMUL_ARITY],
+					r_zhat_prime: z_challenge,
+					r_x_prime: Vec::new(),
+				},
+			)
 		};
 
 		// Fold the committed witness over the instance axis at the shared point.
@@ -257,13 +285,7 @@ impl IOPProver {
 				&folded_witness,
 				bitand_data,
 				intmul_data,
-				// M4 has no BMUL constraints: the BinMul claim is a zero claim at an empty point,
-				// contributing nothing to the shift.
-				OperatorData {
-					evals: vec![B128::ZERO; 6],
-					r_zhat_prime: z_challenge,
-					r_x_prime: Vec::new(),
-				},
+				binmul_data,
 				&shift_domain,
 				channel,
 			)
@@ -397,6 +419,35 @@ where
 	prover.prove(witness)
 }
 
+/// Runs the BinMul check over the batched operand columns.
+///
+/// The six columns are the `(lo, hi)` word pairs of the two GHASH-field multiplicands and their
+/// product, in the order `[a_lo, a_hi, b_lo, b_hi, c_lo, c_hi]`.
+/// Each is `K * n_binmul` rows, laid out constraint-major.
+/// The check reduces the GHASH-field multiplication relation to per-bit evaluation claims on the
+/// six columns. Those claims share a common row point.
+fn prove_binmul<P, Channel>(columns: &[Vec<Word>; 6], channel: &mut Channel) -> BinMulOutput<B128>
+where
+	P: PackedField<Scalar = B128>,
+	Channel: IOPProverChannel<P>,
+{
+	let _scope = tracing::debug_span!("BinMul check").entered();
+
+	// The columns are the multiplicands' and product's low and high words, in the order the BinMul
+	// witness expects.
+	let [a_lo, a_hi, b_lo, b_hi, c_lo, c_hi] = columns;
+	let witness = BinMulWitness {
+		a_lo,
+		a_hi,
+		b_lo,
+		b_hi,
+		c_lo,
+		c_hi,
+	};
+
+	prove_binmul_reduction::<B128, P, _>(&witness, channel)
+}
+
 /// One operation's operand columns, oblong claims, and the points they are claimed at.
 ///
 /// The AND-check and the IntMul check both reduce to this shape.
@@ -497,52 +548,108 @@ impl<'a> Operation<'a, INTMUL_ARITY> {
 	}
 }
 
-/// The two operations entering the batched instance re-randomization.
+impl<'a> Operation<'a, BINMUL_ARITY> {
+	/// Builds the BinMul operation by collapsing its per-bit operand claims to oblong claims.
+	///
+	/// The Lagrange weights fold the per-bit claims at the univariate challenge.
+	/// This gives the oblong form the BitAnd claims already have.
+	/// The BinMul row point splits into an instance part (low) and a constraint part (high).
+	fn from_binmul(
+		columns: &'a [Vec<Word>; BINMUL_ARITY],
+		binmul_output: BinMulOutput<B128>,
+		lagrange: &[B128],
+		log_instances: usize,
+	) -> Self {
+		let BinMulOutput {
+			eval_point: r_out_binmul,
+			a_lo_evals,
+			a_hi_evals,
+			b_lo_evals,
+			b_hi_evals,
+			c_lo_evals,
+			c_hi_evals,
+		} = binmul_output;
+		let oblong =
+			|evals: &[B128]| inner_product(evals.iter().copied(), lagrange.iter().copied());
+		let (r_rho, r_x) = r_out_binmul.split_at(log_instances);
+		Self::new(
+			columns,
+			[
+				oblong(&a_lo_evals),
+				oblong(&a_hi_evals),
+				oblong(&b_lo_evals),
+				oblong(&b_hi_evals),
+				oblong(&c_lo_evals),
+				oblong(&c_hi_evals),
+			],
+			r_x,
+			r_rho,
+		)
+	}
+}
+
+/// The operations entering the batched instance re-randomization.
+///
+/// BitAnd is always present. IntMul and BinMul enter only when the circuit carries their
+/// constraints; an absent operation reduces to a zero claim contributing nothing to the shift.
 struct RerandomizedOperations<'a> {
 	/// The BitAnd operation, at the AND-check instance point.
 	bitand: Operation<'a, BITAND_ARITY>,
-	/// The IntMul operation, at the IntMul instance point.
-	intmul: Operation<'a, INTMUL_ARITY>,
+	/// The IntMul operation, at the IntMul instance point, when the circuit has IMUL constraints.
+	intmul: Option<Operation<'a, INTMUL_ARITY>>,
+	/// The BinMul operation, at the BinMul instance point, when the circuit has BMUL constraints.
+	binmul: Option<Operation<'a, BINMUL_ARITY>>,
 }
 
 impl RerandomizedOperations<'_> {
-	/// Re-randomizes both operations' instance points to one shared point.
+	/// Re-randomizes every present operation's instance point to one shared point.
 	///
 	/// Each operation reduces to operand claims at its own instance point.
 	/// The witness folds over the instance axis only once, so the points must be unified first.
 	///
-	/// - Push both operations' operand multilinears onto one store.
+	/// - Push every present operation's operand multilinears onto one store.
 	/// - Register one equality tracker per operation, so each indicator is expanded once.
 	/// - A batched sumcheck transports every claim to one shared instance point.
 	/// - The reduced evaluations there are the operand claims the shift consumes.
 	///
+	/// The operands are pushed in the order [BitAnd | IntMul (if present) | BinMul (if present)],
+	/// so the reduced evaluations split back into contiguous per-operation segments in that same
+	/// order. An absent operation reduces to a zero claim at an empty point.
+	///
 	/// # Returns
 	///
-	/// The shared instance point, the BitAnd operand data, and the IntMul operand data.
+	/// The shared instance point, the BitAnd operand data, the IntMul operand data, and the BinMul
+	/// operand data.
 	fn prove<P, Channel>(
 		self,
 		lagrange: &[B128],
 		z_challenge: B128,
 		channel: &mut Channel,
-	) -> (Vec<B128>, OperatorData<B128>, OperatorData<B128>)
+	) -> (Vec<B128>, OperatorData<B128>, OperatorData<B128>, OperatorData<B128>)
 	where
 		P: PackedField<Scalar = B128>,
 		Channel: IOPProverChannel<P>,
 	{
 		let _scope = tracing::debug_span!("Re-randomize instances").entered();
 
-		// Both operations reduce over the same instance axis.
-		// Recover its width from either point.
+		// Every operation reduces over the same instance axis.
+		// Recover its width from the BitAnd point.
 		let log_instances = self.bitand.r_rho.len();
 
-		// One shared store over the instance axis holds every operation's operand multilinears.
-		// The evaluators list the operands in order [BitAnd a, b, c | IntMul a, b, lo, hi].
+		// One shared store over the instance axis holds every present operation's operand
+		// multilinears. The evaluators list the operands in push order
+		// [BitAnd a, b, c | IntMul a, b, lo, hi | BinMul a_lo, a_hi, b_lo, b_hi, c_lo, c_hi].
 		// The verifier reads the reduced evaluations back in the same order.
 		let mut store = MleStore::<P>::new(log_instances);
 		let mut evaluators: Vec<Box<dyn RoundEvaluator<B128, P>>> =
-			Vec::with_capacity(BITAND_ARITY + INTMUL_ARITY);
+			Vec::with_capacity(BITAND_ARITY + INTMUL_ARITY + BINMUL_ARITY);
 		self.bitand.push_to(lagrange, &mut store, &mut evaluators);
-		self.intmul.push_to(lagrange, &mut store, &mut evaluators);
+		if let Some(intmul) = &self.intmul {
+			intmul.push_to(lagrange, &mut store, &mut evaluators);
+		}
+		if let Some(binmul) = &self.binmul {
+			binmul.push_to(lagrange, &mut store, &mut evaluators);
+		}
 
 		// One shared prover drives all claims over the store in a single round pass.
 		// Its evaluations are the store's per-column values at the shared instance point, in push
@@ -551,19 +658,48 @@ impl RerandomizedOperations<'_> {
 		let output = batch_prove_and_write_evals(vec![shared], channel);
 		let reduced = &output.multilinear_evals[0];
 
-		// The reduced evaluations split back into the two operations at the operand-count boundary.
-		let split = self.bitand.operand_claims.len();
+		// The reduced evaluations split back into contiguous per-operation segments, in push order.
+		let mut offset = 0;
 		let bitand_data = OperatorData {
-			evals: reduced[..split].to_vec(),
+			evals: reduced[offset..offset + BITAND_ARITY].to_vec(),
 			r_zhat_prime: z_challenge,
 			r_x_prime: self.bitand.r_x,
 		};
-		let intmul_data = OperatorData {
-			evals: reduced[split..].to_vec(),
-			r_zhat_prime: z_challenge,
-			r_x_prime: self.intmul.r_x,
+		offset += BITAND_ARITY;
+
+		// IntMul: the next INTMUL_ARITY reduced evaluations when present, else a zero claim.
+		let intmul_data = match self.intmul {
+			Some(intmul) => {
+				let data = OperatorData {
+					evals: reduced[offset..offset + INTMUL_ARITY].to_vec(),
+					r_zhat_prime: z_challenge,
+					r_x_prime: intmul.r_x,
+				};
+				offset += INTMUL_ARITY;
+				data
+			}
+			None => OperatorData {
+				evals: vec![B128::ZERO; INTMUL_ARITY],
+				r_zhat_prime: z_challenge,
+				r_x_prime: Vec::new(),
+			},
 		};
-		(output.challenges, bitand_data, intmul_data)
+
+		// BinMul: the final BINMUL_ARITY reduced evaluations when present, else a zero claim.
+		let binmul_data = match self.binmul {
+			Some(binmul) => OperatorData {
+				evals: reduced[offset..offset + BINMUL_ARITY].to_vec(),
+				r_zhat_prime: z_challenge,
+				r_x_prime: binmul.r_x,
+			},
+			None => OperatorData {
+				evals: vec![B128::ZERO; BINMUL_ARITY],
+				r_zhat_prime: z_challenge,
+				r_x_prime: Vec::new(),
+			},
+		};
+
+		(output.challenges, bitand_data, intmul_data, binmul_data)
 	}
 }
 
@@ -854,6 +990,133 @@ mod tests {
 		assert_ne!(
 			log_n_and, log_n_imul,
 			"the fixture must give the operations different r_x lengths"
+		);
+
+		let log_instances = 6;
+		let table = ValueTable::populate(&circuit, log_instances, |i, w| {
+			let mut rng = StdRng::seed_from_u64(i as u64);
+			for &wire in &inputs {
+				w[wire] = Word(rng.next_u64());
+			}
+		})
+		.unwrap();
+
+		// Prove with the wide packing; the verifier is packing-agnostic.
+		let verifier = Verifier::setup(&cs, log_instances, 1);
+		let prover = Prover::<WideP>::setup(&verifier);
+
+		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
+		prover.prove(&table, &mut prover_transcript);
+
+		let mut verifier_transcript = prover_transcript.into_verifier();
+		verifier
+			.verify(&mut verifier_transcript)
+			.expect("a faithful proof verifies");
+		verifier_transcript
+			.finalize()
+			.expect("no trailing proof data");
+	}
+
+	// A circuit carrying BMUL constraints round-trips through the whole protocol.
+	//
+	// BinMul commits no oracle, so the proof still commits only the trace oracle. The BinMul and
+	// AND checks reduce to different instance points, which the re-randomization unifies before
+	// the witness is folded.
+	//
+	// Fixture: one GHASH-field product `x * x` per instance over 2^6 instances, both product words
+	// force-committed. The `bmul` gate emits one BMUL constraint.
+	//
+	// A faithful proof verifies and no trailing data is left.
+	#[test]
+	fn protocol_round_trips_with_binmul() {
+		// One GHASH-field squaring per instance: `(c_lo, c_hi) = (x_lo, x_hi)^2`, with both result
+		// words committed as hidden words.
+		let builder = CircuitBuilder::new();
+		let x_lo = builder.add_witness();
+		let x_hi = builder.add_witness();
+		let (c_lo, c_hi) = builder.bmul(x_lo, x_hi, x_lo, x_hi);
+		builder.force_commit(c_lo);
+		builder.force_commit(c_hi);
+		let circuit = builder.build();
+
+		let mut cs = circuit.constraint_system().clone();
+		cs.validate_and_prepare().unwrap();
+		// Confirm the fixture genuinely exercises the BinMul path.
+		assert!(!cs.bmul_constraints.is_empty(), "the fixture must emit a BMUL constraint");
+
+		// Fill each instance's multiplicand from a per-instance seed; the circuit derives the two
+		// product words.
+		let log_instances = 6;
+		let table = ValueTable::populate(&circuit, log_instances, |i, w| {
+			let mut rng = StdRng::seed_from_u64(i as u64);
+			w[x_lo] = Word(rng.next_u64());
+			w[x_hi] = Word(rng.next_u64());
+		})
+		.unwrap();
+
+		// Setup once: the verifier fixes the shape and FRI parameters, the prover inherits them.
+		let verifier = Verifier::setup(&cs, log_instances, 1);
+		let prover = Prover::<P>::setup(&verifier);
+
+		// Prover: commit the trace, reduce, and open on a fresh transcript.
+		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
+		prover.prove(&table, &mut prover_transcript);
+
+		// Verifier: replay the same transcript end to end.
+		let mut verifier_transcript = prover_transcript.into_verifier();
+		verifier
+			.verify(&mut verifier_transcript)
+			.expect("a faithful proof verifies");
+		verifier_transcript
+			.finalize()
+			.expect("no trailing proof data");
+	}
+
+	// AND, IMUL, and BMUL constraints together, so the three operations reduce to constraint points
+	// of differing lengths and to genuinely different instance points that the re-randomization
+	// must unify onto one shared point.
+	//
+	// Proving with a width-2 packing exercises the packed lane layout and zero-padding of the
+	// instance-axis multilinears, which the width-1 fixtures never reach.
+	#[test]
+	fn protocol_round_trips_with_and_intmul_binmul_and_wide_packing() {
+		use binius_field::PackedBinaryGhash2x128b;
+		use binius_frontend::Wire;
+
+		type WideP = PackedBinaryGhash2x128b;
+
+		let builder = CircuitBuilder::new();
+		let inputs: [Wire; 8] = array::from_fn(|_| builder.add_witness());
+		// Four standalone AND gates on distinct wires.
+		for pair in inputs.chunks_exact(2) {
+			let and = builder.band(pair[0], pair[1]);
+			builder.force_commit(and);
+		}
+		// Two integer products — fewer IMUL constraints than AND constraints.
+		for pair in inputs.chunks_exact(2).take(2) {
+			let (hi, lo) = builder.imul(pair[0], pair[1]);
+			builder.force_commit(hi);
+			builder.force_commit(lo);
+		}
+		// One GHASH-field product — the fewest of the three operations.
+		let (c_lo, c_hi) = builder.bmul(inputs[0], inputs[1], inputs[2], inputs[3]);
+		builder.force_commit(c_lo);
+		builder.force_commit(c_hi);
+		let circuit = builder.build();
+
+		let mut cs = circuit.constraint_system().clone();
+		cs.validate_and_prepare().unwrap();
+		// Confirm the fixture genuinely exercises the asymmetric case: the three operations do not
+		// all reduce to constraint points of the same length.
+		let log_n_and = checked_log_2(cs.and_constraints.len());
+		let log_n_imul = checked_log_2(cs.imul_constraints.len());
+		let log_n_binmul = checked_log_2(cs.bmul_constraints.len());
+		assert!(!cs.imul_constraints.is_empty(), "the fixture must emit IMUL constraints");
+		assert!(!cs.bmul_constraints.is_empty(), "the fixture must emit BMUL constraints");
+		let lengths = [log_n_and, log_n_imul, log_n_binmul];
+		assert!(
+			lengths.iter().any(|&len| len != lengths[0]),
+			"the fixture must give the operations differing r_x lengths"
 		);
 
 		let log_instances = 6;

--- a/crates/m4-verifier/src/verify.rs
+++ b/crates/m4-verifier/src/verify.rs
@@ -27,9 +27,10 @@ use binius_verifier::{
 	Error,
 	config::{B1, B128},
 	protocols::{
+		binmul::{BinMulOutput, verify as verify_binmul_reduction},
 		bitand::AndCheckOutput,
 		intmul::{IntMulOutput, verify as verify_intmul_reduction},
-		shift::{self, BITAND_ARITY, INTMUL_ARITY, OperatorData},
+		shift::{self, BINMUL_ARITY, BITAND_ARITY, INTMUL_ARITY, OperatorData},
 	},
 	ring_switch::{self, RingSwitchVerifyOutput},
 	verify_bitand_reduction,
@@ -161,6 +162,20 @@ impl IOPVerifier {
 			None
 		};
 
+		// SOUNDNESS: the BinMul check verifies after the IntMul check and before the BitAnd check,
+		// mirroring the prover. Its per-bit operand evaluations are read from the transcript here,
+		// before BitAnd draws the univariate challenge that collapses them. Do not reorder these,
+		// and keep the same order in `IOPProver::prove`.
+		//
+		// The BinMul columns span every instance's constraints.
+		// So the check runs over `log_instances + log_n_binmul` row variables.
+		let binmul_output = if cs.n_bmul_constraints() > 0 {
+			let log_n_binmul = checked_log_2(cs.n_bmul_constraints());
+			Some(verify_binmul_reduction::<B128, _>(log_instances + log_n_binmul, channel)?)
+		} else {
+			None
+		};
+
 		// AND-check over all `K * n_and` rows.
 		let log_n_and = checked_log_2(cs.and_constraints.len());
 		let AndCheckOutput {
@@ -175,34 +190,35 @@ impl IOPVerifier {
 		// index high.
 		let (r_rho_and, r_x_and) = eval_point.split_at(log_instances);
 
-		// Reduce to one shared instance point and both operand claims at it.
-		let (r_rho, bitand, intmul) = match intmul_output {
-			Some(intmul_output) => {
-				// Both operations enter the re-randomization as operand claims at their own
-				// instance point. BitAnd is already oblong; IntMul is collapsed from its
-				// per-bit form.
-				let lagrange = lagrange_evals_scalars::<B128, Channel::Elem>(
-					&shift_domain,
-					z_challenge.clone(),
-				);
-				RerandomizedOperations {
-					bitand: OperationClaim::new([a_eval, b_eval, c_eval], r_x_and, r_rho_and),
-					intmul: OperationClaim::from_intmul(intmul_output, &lagrange, log_instances),
-				}
-				.verify(channel)?
+		// Reduce to one shared instance point and every operand claim at it.
+		//
+		// The re-randomization runs whenever IntMul or BinMul is present: BitAnd always enters,
+		// plus each present multiplication operation, all unified onto one shared `r_rho`.
+		let (r_rho, bitand, intmul, binmul) = if intmul_output.is_some() || binmul_output.is_some()
+		{
+			// Every present operation enters the re-randomization as operand claims at its own
+			// instance point. BitAnd is already oblong; IntMul and BinMul are collapsed from their
+			// per-bit form.
+			let lagrange =
+				lagrange_evals_scalars::<B128, Channel::Elem>(&shift_domain, z_challenge.clone());
+			RerandomizedOperations {
+				bitand: OperationClaim::new([a_eval, b_eval, c_eval], r_x_and, r_rho_and),
+				intmul: intmul_output
+					.map(|output| OperationClaim::from_intmul(output, &lagrange, log_instances)),
+				binmul: binmul_output
+					.map(|output| OperationClaim::from_binmul(output, &lagrange, log_instances)),
 			}
-			// No IMUL constraints: the AND-check instance point is used directly.
-			// The IntMul claim is a zero claim at an empty point.
-			None => (
+			.verify(channel)?
+		} else {
+			// Neither IMUL nor BMUL constraints: the AND-check instance point is used directly.
+			// The IntMul and BinMul claims are zero claims at an empty point.
+			(
 				r_rho_and.to_vec(),
 				OperatorData::new(r_x_and.to_vec(), [a_eval, b_eval, c_eval]),
 				OperatorData::new(Vec::new(), std::array::from_fn(|_| Channel::Elem::zero())),
-			),
+				OperatorData::new(Vec::new(), std::array::from_fn(|_| Channel::Elem::zero())),
+			)
 		};
-
-		// M4 has no BMUL constraints: the BinMul claim is a zero claim at an empty point,
-		// contributing nothing to the shift.
-		let binmul = OperatorData::new(Vec::new(), std::array::from_fn(|_| Channel::Elem::zero()));
 
 		// Reduce the operand claims to one witness evaluation.
 		let shift = shift::verify::<B128, _>(cs, &bitand, &intmul, &binmul, channel)?;
@@ -360,8 +376,13 @@ impl Verifier {
 // TODO: a degree-1 multilinear-eval store evaluator would drop this to 2; none exists yet.
 const RERAND_DEGREE: usize = 3;
 
-/// The shared instance point together with both operations' operand data at that point.
-type RerandOutput<F> = (Vec<F>, OperatorData<F, BITAND_ARITY>, OperatorData<F, INTMUL_ARITY>);
+/// The shared instance point together with every operation's operand data at that point.
+type RerandOutput<F> = (
+	Vec<F>,
+	OperatorData<F, BITAND_ARITY>,
+	OperatorData<F, INTMUL_ARITY>,
+	OperatorData<F, BINMUL_ARITY>,
+);
 
 /// One operation's oblong operand claims and the points they are claimed at.
 ///
@@ -419,39 +440,86 @@ impl<F: FieldOps> OperationClaim<F, INTMUL_ARITY> {
 	}
 }
 
-/// The two operations' claims entering the batched instance re-randomization.
+impl<F: FieldOps> OperationClaim<F, BINMUL_ARITY> {
+	/// Builds the BinMul claim by collapsing its per-bit operand claims to oblong claims.
+	///
+	/// The Lagrange weights fold the per-bit claims at the univariate challenge.
+	/// This gives the oblong form the BitAnd claims already have.
+	/// The BinMul row point splits into an instance part (low) and a constraint part (high).
+	fn from_binmul(binmul_output: BinMulOutput<F>, lagrange: &[F], log_instances: usize) -> Self {
+		let BinMulOutput {
+			eval_point: r_out_binmul,
+			a_lo_evals,
+			a_hi_evals,
+			b_lo_evals,
+			b_hi_evals,
+			c_lo_evals,
+			c_hi_evals,
+		} = binmul_output;
+		let oblong = |evals: Vec<F>| inner_product_scalars(evals, lagrange.iter().cloned());
+		let (r_rho, r_x) = r_out_binmul.split_at(log_instances);
+		Self::new(
+			[
+				oblong(a_lo_evals),
+				oblong(a_hi_evals),
+				oblong(b_lo_evals),
+				oblong(b_hi_evals),
+				oblong(c_lo_evals),
+				oblong(c_hi_evals),
+			],
+			r_x,
+			r_rho,
+		)
+	}
+}
+
+/// The operations' claims entering the batched instance re-randomization.
+///
+/// BitAnd is always present. IntMul and BinMul enter only when the circuit carries their
+/// constraints; an absent operation reduces to a zero claim contributing nothing to the shift.
 struct RerandomizedOperations<F> {
 	/// The BitAnd operand claims at the AND-check instance point.
 	bitand: OperationClaim<F, BITAND_ARITY>,
-	/// The IntMul operand claims at the IntMul instance point.
-	intmul: OperationClaim<F, INTMUL_ARITY>,
+	/// The IntMul operand claims at the IntMul instance point, when the circuit has IMUL
+	/// constraints.
+	intmul: Option<OperationClaim<F, INTMUL_ARITY>>,
+	/// The BinMul operand claims at the BinMul instance point, when the circuit has BMUL
+	/// constraints.
+	binmul: Option<OperationClaim<F, BINMUL_ARITY>>,
 }
 
 impl<F: FieldOps> RerandomizedOperations<F> {
-	/// Verifies the batched sumcheck that unifies the two operations' instance points.
+	/// Verifies the batched sumcheck that unifies every present operation's instance point.
 	///
 	/// - Check the sumcheck transporting every operand claim onto one shared instance point.
 	/// - Read the reduced operand evaluations at that point.
 	/// - Bind them to the sumcheck.
 	///
+	/// The operands are ordered [BitAnd | IntMul (if present) | BinMul (if present)], matching the
+	/// prover's push order, so the sums, the reduced evaluations, and the binding all agree. An
+	/// absent operation reduces to a zero claim at an empty point.
+	///
 	/// # Returns
 	///
-	/// The shared instance point, the BitAnd operand data, and the IntMul operand data.
+	/// The shared instance point, the BitAnd operand data, the IntMul operand data, and the BinMul
+	/// operand data.
 	fn verify<Channel>(self, channel: &mut Channel) -> Result<RerandOutput<F>, Error>
 	where
 		Channel: IPVerifierChannel<B128, Elem = F>,
 	{
-		// Both operations reduce over the same instance axis; recover its width from either point.
+		// Every operation reduces over the same instance axis; recover its width from the BitAnd
+		// point.
 		let log_instances = self.bitand.r_rho.len();
 
-		// Verify the batched sumcheck: one multilinear-eval claim per operand, ordered
-		// [BitAnd a, b, c | IntMul a, b, lo, hi].
-		let sums: Vec<F> = self
-			.bitand
-			.operand_claims
-			.into_iter()
-			.chain(self.intmul.operand_claims)
-			.collect();
+		// Verify the batched sumcheck: one multilinear-eval claim per operand, in push order
+		// [BitAnd a, b, c | IntMul a, b, lo, hi | BinMul a_lo, a_hi, b_lo, b_hi, c_lo, c_hi].
+		let mut sums: Vec<F> = self.bitand.operand_claims.to_vec();
+		if let Some(intmul) = &self.intmul {
+			sums.extend(intmul.operand_claims.iter().cloned());
+		}
+		if let Some(binmul) = &self.binmul {
+			sums.extend(binmul.operand_claims.iter().cloned());
+		}
 		let BatchSumcheckOutput {
 			batch_coeff,
 			eval,
@@ -460,25 +528,47 @@ impl<F: FieldOps> RerandomizedOperations<F> {
 		challenges.reverse();
 		let r_rho = challenges;
 
-		// The prover wrote the reduced operand evaluations at `r_rho`, grouped by operation.
-		// These are the operand claims the shift consumes.
+		// The prover wrote the reduced operand evaluations at `r_rho`, grouped by operation in push
+		// order. These are the operand claims the shift consumes.
 		let bitand_evals = channel.recv_array::<BITAND_ARITY>()?;
-		let intmul_evals = channel.recv_array::<INTMUL_ARITY>()?;
+		let intmul_evals = self
+			.intmul
+			.as_ref()
+			.map(|_| channel.recv_array::<INTMUL_ARITY>())
+			.transpose()?;
+		let binmul_evals = self
+			.binmul
+			.as_ref()
+			.map(|_| channel.recv_array::<BINMUL_ARITY>())
+			.transpose()?;
 
 		// Bind the reduced evals to the sumcheck: each claim's contribution is its
-		// eq(instance_point, r_rho) weight times its reduced eval, batched by `batch_coeff`.
+		// eq(instance_point, r_rho) weight times its reduced eval, batched by `batch_coeff`. The
+		// contributions follow the same push order as `sums`.
 		let eq_and = eq_ind(&self.bitand.r_rho, &r_rho);
-		let eq_mul = eq_ind(&self.intmul.r_rho, &r_rho);
-		let expected: Vec<F> = bitand_evals
-			.clone()
-			.map(|eval| eval * &eq_and)
-			.into_iter()
-			.chain(intmul_evals.clone().map(|eval| eval * &eq_mul))
+		let mut expected: Vec<F> = bitand_evals
+			.iter()
+			.map(|eval| eval.clone() * &eq_and)
 			.collect();
+		if let (Some(intmul), Some(evals)) = (&self.intmul, &intmul_evals) {
+			let eq_mul = eq_ind(&intmul.r_rho, &r_rho);
+			expected.extend(evals.iter().map(|eval| eval.clone() * &eq_mul));
+		}
+		if let (Some(binmul), Some(evals)) = (&self.binmul, &binmul_evals) {
+			let eq_binmul = eq_ind(&binmul.r_rho, &r_rho);
+			expected.extend(evals.iter().map(|eval| eval.clone() * &eq_binmul));
+		}
 		channel.assert_zero(evaluate_univariate(&expected, batch_coeff) - eval)?;
 
 		let bitand_data = OperatorData::new(self.bitand.r_x, bitand_evals);
-		let intmul_data = OperatorData::new(self.intmul.r_x, intmul_evals);
-		Ok((r_rho, bitand_data, intmul_data))
+		let intmul_data = match (self.intmul, intmul_evals) {
+			(Some(intmul), Some(evals)) => OperatorData::new(intmul.r_x, evals),
+			_ => OperatorData::new(Vec::new(), std::array::from_fn(|_| F::zero())),
+		};
+		let binmul_data = match (self.binmul, binmul_evals) {
+			(Some(binmul), Some(evals)) => OperatorData::new(binmul.r_x, evals),
+			_ => OperatorData::new(Vec::new(), std::array::from_fn(|_| F::zero())),
+		};
+		Ok((r_rho, bitand_data, intmul_data, binmul_data))
 	}
 }


### PR DESCRIPTION
Linear: [BINIUS-302](https://linear.app/jimpo/issue/BINIUS-302/proveverify-binmul-constraints-in-m4)

The M4 analog of #1827 (BINIUS-300): makes `binius-m4-prover`/`binius-m4-verifier` actually **handle BinMul (GHASH-field mul) constraints** — run the binmul reduction, build a real operand claim, and thread it through the instance re-randomization and the shift — instead of the zero/skipped claim #1827 fanned through M4. Reuses the merged `binmul` reduction (`binius_prover`/`binius_verifier::protocols::binmul`) verbatim; mirrors the existing IntMul handling.

### How it works (mirrors IntMul)
1. **BinMul check phase.** Runs after IntMul and before BitAnd (same order on both sides), over `log_instances + log_n_binmul` rows, only when `cs.bmul_constraints` is non-empty. Per-bit operand evals are bound to the transcript before BitAnd draws the univariate challenge that collapses them. BinMul commits no oracle, so `oracle_specs` is unchanged.
2. **Re-randomization → shared `r_rho`.** M4 unifies each operation's operand claims onto one shared instance point via a batched multilinear-eval sumcheck. This was hardcoded for BitAnd + optional IntMul; it now takes BitAnd (always) + **optional IntMul + optional BinMul**. The re-randomization runs whenever *either* multiplication op is present; operands are pushed/read in the order `[BitAnd | IntMul? | BinMul?]`, and the reduced evals split back into contiguous per-op segments in that same order. Absent ops reduce to a zero claim at an empty point (the pre-existing direct-path behavior).
3. **Shift.** The real `binmul_data` now flows into `shift::{prove,verify,check_eval}` (M4's shift.rs was already binmul-aware from #1827).

`Operation::from_binmul` / `OperationClaim::from_binmul` collapse the six per-bit eval columns (`[a_lo, a_hi, b_lo, b_hi, c_lo, c_hi]`) at the univariate challenge and split `eval_point` at `log_instances` into `(r_rho, r_x)` — exactly like `from_intmul`. `build_binmul_witness` projects the six operands constraint-major via the existing arity-generic `build_operation_witness`.

### Naming
Protocol layer uses `binmul` (`build_binmul_witness`, `prove_binmul`, `verify_binmul_reduction`, `binmul_data`, `from_binmul`); the `bmul` abbreviation stays for the constraint-system/frontend (`cs.bmul_constraints`, `circuit.bmul`).

### Scope note
Like #1827, "reuse the protocol logic" still touches the M4 **re-randomization** (the soundness core that connects operand claims to the folded witness), so this is a real cross-cutting change there, not just a witness builder. I extended it with concrete optional fields mirroring IntMul rather than generalizing to N operations (per *avoid premature generalization*) — happy to generalize if you'd prefer now that there are three.

### Validation
- New tests: `protocol_round_trips_with_binmul` (one `bmul` squaring per instance over 2⁶ instances, both product words committed) and `protocol_round_trips_with_and_intmul_binmul_and_wide_packing` (AND + IMUL + BMUL together at different instance points, `PackedBinaryGhash2x128b`) — full end-to-end prove→verify, which fails if the prover/verifier push order or segment split desyncs. Plus a `build_binmul_witness` column-layout unit test.
- `cargo test -p binius-m4-prover -p binius-m4-verifier` — green (incl. all existing `protocol_round_trips*`).
- `cargo clippy --all --tests --benches --examples -- -D warnings` and `cargo +nightly-2026-01-01 fmt --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)