### PR TITLE
Remove dead helpers from frontend util

### DIFF
--- a/crates/frontend/src/util.rs
+++ b/crates/frontend/src/util.rs
@@ -39,29 +39,6 @@ pub fn pack_bytes_into_wires_le(w: &mut WitnessFiller, wires: &[Wire], bytes: &[
 	}
 }
 
-/// Pack bytes into constant wires using little-endian packed 64-bit words.
-///
-/// Creates and returns a vector of constant wires containing the packed byte data.
-/// If `bytes` is not a multiple of 8, the last word is zero-padded.
-///
-/// # Example
-/// ```ignore
-/// let bytes = b"Hello";
-/// let wires = pack_bytes_into_const_wires_le(&builder, bytes);
-/// // wires.len() == 1 (5 bytes packed into 1 word, zero-padded)
-/// ```
-pub fn pack_bytes_into_const_wires_le(b: &CircuitBuilder, bytes: &[u8]) -> Vec<Wire> {
-	bytes
-		.chunks(8)
-		.map(|chunk| {
-			let mut chunk_arr = [0u8; 8];
-			chunk_arr[..chunk.len()].copy_from_slice(chunk);
-			let word = Word(u64::from_le_bytes(chunk_arr));
-			b.add_constant(word)
-		})
-		.collect()
-}
-
 /// Returns a BigUint from u64 limbs with little-endian ordering
 pub fn num_biguint_from_u64_limbs<I>(limbs: I) -> num_bigint::BigUint
 where
@@ -94,11 +71,6 @@ pub fn all_true(b: &CircuitBuilder, booleans: impl IntoIterator<Item = Wire>) ->
 		.fold(b.add_constant(Word::ALL_ONE), |lhs, rhs| b.band(lhs, rhs))
 }
 
-/// Convert MSB-bool into an all-1/all-0 mask.
-pub fn bool_to_mask(b: &CircuitBuilder, boolean: Wire) -> Wire {
-	b.sar(boolean, (Word::BITS - 1) as u32)
-}
-
 /// Swap the byte order of the word.
 ///
 /// Breaks the word down to bytes and reassembles in reversed order.
@@ -110,60 +82,4 @@ pub fn byteswap(b: &CircuitBuilder, word: Wire) -> Wire {
 	bytes
 		.reduce(|lhs, rhs| b.bxor(lhs, rhs))
 		.expect("Word::BITS > 0")
-}
-
-#[cfg(test)]
-mod tests {
-	use super::*;
-
-	/// Helper to test pack_bytes_into_const_wires_le with expected word values
-	fn test_pack_bytes(bytes: &[u8], expected_words: &[u64]) {
-		let b = CircuitBuilder::new();
-		let wires = pack_bytes_into_const_wires_le(&b, bytes);
-
-		assert_eq!(wires.len(), expected_words.len());
-
-		let circuit = b.build();
-		let mut filler = circuit.new_witness_filler();
-		circuit.populate_wire_witness(&mut filler).unwrap();
-
-		for (wire, &expected) in wires.iter().zip(expected_words) {
-			assert_eq!(filler[*wire], Word(expected));
-		}
-	}
-
-	#[test]
-	fn test_pack_bytes_into_const_wires_le_aligned() {
-		// Test with exactly 8 bytes (1 word)
-		let bytes = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
-		test_pack_bytes(&bytes, &[0x0807060504030201]);
-	}
-
-	#[test]
-	fn test_pack_bytes_into_const_wires_le_partial() {
-		// Test with 5 bytes (partial word)
-		// "Hello" in little-endian with zero padding
-		// H=0x48, e=0x65, l=0x6c, l=0x6c, o=0x6f
-		test_pack_bytes(b"Hello", &[0x6f6c6c6548]);
-	}
-
-	#[test]
-	fn test_pack_bytes_into_const_wires_le_multiple_words() {
-		// Test with 16 bytes (2 words)
-		let bytes: Vec<u8> = (0..16).collect();
-		test_pack_bytes(&bytes, &[0x0706050403020100, 0x0f0e0d0c0b0a0908]);
-	}
-
-	#[test]
-	fn test_pack_bytes_into_const_wires_le_empty() {
-		// Test with empty bytes
-		test_pack_bytes(&[], &[]);
-	}
-
-	#[test]
-	fn test_pack_bytes_into_const_wires_le_unaligned_multi() {
-		// Test with 11 bytes (1 full word + partial second word, zero-padded)
-		let bytes: Vec<u8> = (0..11).collect();
-		test_pack_bytes(&bytes, &[0x0706050403020100, 0x0a0908]);
-	}
 }


### PR DESCRIPTION
Removes two unused functions from the frontend circuit-building utilities. Pure dead-code deletion — no behavior change.

### The problem

`crates/frontend/src/util.rs` carried two helpers that nothing in the workspace calls:

- `bool_to_mask` — zero references, zero tests. Never wired into any circuit.
- `pack_bytes_into_const_wires_le` — no production consumer. Its only exercise was the file's own `tests` module; those five tests tested this one function and nothing else.

The irony: the *dead* function was the only item in the file with direct unit tests, while the heavily-used `pack_bytes_into_wires_le` (~30 call sites) has none of its own and rides on integration coverage.

### The change

```diff
- pub fn bool_to_mask(b: &CircuitBuilder, boolean: Wire) -> Wire { ... }
- pub fn pack_bytes_into_const_wires_le(b: &CircuitBuilder, bytes: &[u8]) -> Vec<Wire> { ... }
- #[cfg(test)] mod tests { ... }   // tested only the removed fn
```

84 lines deleted, one file touched. The surviving helpers (`pack_bytes_into_wires_le`, `num_biguint_from_u64_limbs`, `all_true`, `byteswap`) are untouched and still use both file imports.

### Scope

- **removed:** `bool_to_mask`, `pack_bytes_into_const_wires_le`, and the now-empty `tests` module.
- **left untouched:** every live helper in the file; no call sites changed (there were none).

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-frontend --all-targets` — clean, no warnings
- `cargo test -p binius-frontend` — passes
- nightly `cargo fmt --all` — no changes
- grep across the workspace confirms zero remaining references to either symbol

🤖 Generated with [Claude Code](https://claude.com/claude-code)