### PR TITLE
BINIUS-305: move round claim/interpolation state from RoundEvaluator up into SharedSumcheckProver

### DIFF
--- a/crates/iop-prover/src/basefold_channel.rs
+++ b/crates/iop-prover/src/basefold_channel.rs
@@ -302,10 +302,11 @@ fn prove_batch_zk_basefold<F, P, NTT, Channel>(
 			let transparent_col = store.push_owned(transparent);
 			let inner = SharedSumcheckProver::new(
 				store,
-				vec![BivariateProductEvaluator::new(
-					[message_col, transparent_col],
-					sum_prime,
-				)],
+				vec![BivariateProductEvaluator::new([
+					message_col,
+					transparent_col,
+				])],
+				vec![sum_prime],
 			);
 			PaddedSumcheckDecorator::new(inner, max_n - n_i)
 		})

--- a/crates/ip-prover/benches/bivariate_product.rs
+++ b/crates/ip-prover/benches/bivariate_product.rs
@@ -64,8 +64,8 @@ fn bench_shared_sumcheck_bivariate_product(c: &mut Criterion) {
 				|(mut transcript, a, b_multilinear)| {
 					let mut store = MleStore::new(n_vars);
 					let cols = [a, b_multilinear].map(|col| store.push_owned(col));
-					let evaluator = BivariateProductEvaluator::new(cols, sum_claim);
-					let prover = SharedSumcheckProver::new(store, vec![evaluator]);
+					let evaluator = BivariateProductEvaluator::new(cols);
+					let prover = SharedSumcheckProver::new(store, vec![evaluator], vec![sum_claim]);
 
 					sumcheck::prove_single(prover, &mut transcript)
 				},
@@ -100,14 +100,14 @@ fn bench_shared_mlecheck_bivariate_product(c: &mut Criterion) {
 					// A single-claim evaluator reading the store's columns and one eq tracker
 					// registered for the claim's evaluation point.
 					let eq_tracker = store.register_eq_tracker(&eval_point);
-					let evaluator = QuadraticMleEvaluator::new(
-						cols,
-						eq_tracker,
-						product::<P>,
-						product::<P>,
-						eval_claim,
+					let evaluator =
+						QuadraticMleEvaluator::new(cols, eq_tracker, product::<P>, product::<P>);
+					let prover = SharedMleCheckProver::new(
+						store,
+						vec![evaluator],
+						vec![eval_claim],
+						eval_point,
 					);
-					let prover = SharedMleCheckProver::new(store, vec![evaluator], eval_point);
 
 					sumcheck::prove_single_mlecheck(prover, &mut transcript)
 				},

--- a/crates/ip-prover/src/fracaddcheck.rs
+++ b/crates/ip-prover/src/fracaddcheck.rs
@@ -133,16 +133,13 @@ where
 		let [num_0, num_1] = store.push_split_half(num);
 		let [den_0, den_1] = store.push_split_half(den);
 		let cols = [num_0, num_1, den_0, den_1];
-		let (num_evaluator, den_evaluator) = frac_add_mle::evaluators(
-			&mut store,
-			cols,
-			num_claim.point.clone(),
-			[num_claim.eval, den_claim.eval],
-		);
+		let (num_evaluator, den_evaluator) =
+			frac_add_mle::evaluators(&mut store, cols, num_claim.point.clone());
 
 		let evaluators: Vec<Box<dyn RoundEvaluator<F, P>>> =
 			vec![Box::new(num_evaluator), Box::new(den_evaluator)];
-		(remaining, SharedMleCheckProver::new(store, evaluators, num_claim.point), cols)
+		let claims = vec![num_claim.eval, den_claim.eval];
+		(remaining, SharedMleCheckProver::new(store, evaluators, claims, num_claim.point), cols)
 	}
 
 	/// Runs the fractional addition check protocol and returns the final evaluation claims.
@@ -532,16 +529,17 @@ where
 		FieldBuffer::<P>::from_values(&den_1s),
 	]
 	.map(|buffer| selector_store.push_owned(buffer));
-	let (selector_num, selector_den) = frac_add_mle::evaluators(
-		&mut selector_store,
-		selector_cols,
-		outer_coords.to_vec(),
-		[num_eval, den_eval],
-	);
+	let (selector_num, selector_den) =
+		frac_add_mle::evaluators(&mut selector_store, selector_cols, outer_coords.to_vec());
 	let selector_evaluators: Vec<Box<dyn RoundEvaluator<F, P>>> =
 		vec![Box::new(selector_num), Box::new(selector_den)];
-	let mut selector_prover =
-		SharedMleCheckProver::new(selector_store, selector_evaluators, outer_coords.to_vec());
+	let selector_claims = vec![num_eval, den_eval];
+	let mut selector_prover = SharedMleCheckProver::new(
+		selector_store,
+		selector_evaluators,
+		selector_claims,
+		outer_coords.to_vec(),
+	);
 
 	for _round in 0..k {
 		let round_coeffs = combine_claims(selector_prover.execute(), batch_coeff);

--- a/crates/ip-prover/src/logup_star/final_layer.rs
+++ b/crates/ip-prover/src/logup_star/final_layer.rs
@@ -130,10 +130,10 @@ where
 	// column.
 	let t_0_col = prover.push_owned_column(t_0);
 	let t_1_col = prover.push_owned_column(t_1);
-	let product_0 = BivariateProductEvaluator::new([y_0_col, t_0_col], e_0);
-	prover.add_evaluator(Box::new(product_0) as Box<dyn RoundEvaluator<F, P>>);
-	let product_1 = BivariateProductEvaluator::new([y_1_col, t_1_col], e_1);
-	prover.add_evaluator(Box::new(product_1) as Box<dyn RoundEvaluator<F, P>>);
+	let product_0 = BivariateProductEvaluator::new([y_0_col, t_0_col]);
+	prover.add_evaluator(Box::new(product_0) as Box<dyn RoundEvaluator<F, P>>, e_0);
+	let product_1 = BivariateProductEvaluator::new([y_1_col, t_1_col]);
+	prover.add_evaluator(Box::new(product_1) as Box<dyn RoundEvaluator<F, P>>, e_1);
 
 	// Drive the one shared-store sumcheck.
 	//

--- a/crates/ip-prover/src/sumcheck/bivariate_product_evaluator.rs
+++ b/crates/ip-prover/src/sumcheck/bivariate_product_evaluator.rs
@@ -9,7 +9,6 @@ use super::{
 	mle_store::{ColId, EvaluationChunk, MleStore},
 	round_evals::WideRoundEvals2,
 	round_evaluator::{RoundEvaluator, SharedSumcheckProver},
-	round_state::RoundState,
 };
 
 /// Sumcheck round evaluator for a composite defined as the product of two store columns.
@@ -17,19 +16,16 @@ use super::{
 /// This is the store-backed counterpart of the bivariate product sumcheck prover: it proves the
 /// plain (non-eq-weighted) sum claim of the product over the hypercube, emitting regular
 /// sumcheck round polynomials.
-pub struct BivariateProductEvaluator<P: PackedField> {
+pub struct BivariateProductEvaluator {
 	cols: [ColId; 2],
-	// State machine storage: last round's sum (interpolate input) or coeffs (fold input).
-	last_coeffs_or_sum: RoundState<RoundCoeffs<P::Scalar>, P::Scalar>,
 }
 
-impl<F: Field, P: PackedField<Scalar = F>> BivariateProductEvaluator<P> {
-	/// Creates an evaluator for the claimed sum of the product of two store columns.
-	pub const fn new(cols: [ColId; 2], sum: F) -> Self {
-		Self {
-			cols,
-			last_coeffs_or_sum: RoundState::Claim(sum),
-		}
+impl BivariateProductEvaluator {
+	/// Creates an evaluator for the product of two store columns.
+	///
+	/// The claimed sum is held by the driving [`SharedSumcheckProver`], not the evaluator.
+	pub const fn new(cols: [ColId; 2]) -> Self {
+		Self { cols }
 	}
 }
 
@@ -43,7 +39,7 @@ impl<F: Field, P: PackedField<Scalar = F>> BivariateProductEvaluator<P> {
 pub fn bivariate_product_prover<F: Field, P: PackedField<Scalar = F>>(
 	multilinears: [FieldBuffer<P>; 2],
 	sum: F,
-) -> SharedSumcheckProver<'static, P, BivariateProductEvaluator<P>> {
+) -> SharedSumcheckProver<'static, P, BivariateProductEvaluator> {
 	assert_eq!(
 		multilinears[0].log_len(),
 		multilinears[1].log_len(),
@@ -52,22 +48,19 @@ pub fn bivariate_product_prover<F: Field, P: PackedField<Scalar = F>>(
 
 	let mut store = MleStore::new(multilinears[0].log_len());
 	let cols = multilinears.map(|col| store.push_owned(col));
-	SharedSumcheckProver::new(store, vec![BivariateProductEvaluator::new(cols, sum)])
+	SharedSumcheckProver::new(store, vec![BivariateProductEvaluator::new(cols)], vec![sum])
 }
 
-impl<F: Field, P: PackedField<Scalar = F>> RoundEvaluator<F, P> for BivariateProductEvaluator<P> {
+impl<F: Field, P: PackedField<Scalar = F>> RoundEvaluator<F, P> for BivariateProductEvaluator {
 	fn degree(&self) -> usize {
 		// Product of two multilinears: two sampled evaluations, `y_1` and `y_inf`.
 		2
 	}
 
-	fn round_claim(&self, _store: &MleStore<'_, P>) -> F {
-		// A plain product claim carries no eq factor, so the round claim needs no point
-		// coordinates.
-		match &self.last_coeffs_or_sum {
-			RoundState::Claim(sum) => *sum,
-			RoundState::Coeffs(coeffs) => coeffs.sum_over_endpoints(),
-		}
+	fn claim_from_coeffs(&self, _store: &MleStore<'_, P>, coeffs: &RoundCoeffs<F>) -> F {
+		// The emitted round polynomial is a regular sumcheck polynomial, so the round claim is its
+		// sum over the endpoints {0, 1}. A plain product claim carries no eq factor.
+		coeffs.sum_over_endpoints()
 	}
 
 	fn accumulate(&self, chunk: &EvaluationChunk<'_, P>, accum: &mut [<P as WideMul>::Output]) {
@@ -99,12 +92,11 @@ impl<F: Field, P: PackedField<Scalar = F>> RoundEvaluator<F, P> for BivariatePro
 	}
 
 	fn interpolate(
-		&mut self,
+		&self,
 		store: &MleStore<'_, P>,
 		accum: &[<P as WideMul>::Output],
+		claim: F,
 	) -> RoundCoeffs<F> {
-		let last_sum = *self.last_coeffs_or_sum.claim();
-
 		// The store has not yet folded this round, so its remaining-variable count is this round's.
 		let n_vars_remaining = store.n_vars();
 		assert!(n_vars_remaining > 0);
@@ -113,20 +105,11 @@ impl<F: Field, P: PackedField<Scalar = F>> RoundEvaluator<F, P> for BivariatePro
 			y_1: accum[0].clone(),
 			y_inf: accum[1].clone(),
 		};
-		let round_coeffs = evals
+		// `claim` is this round's sum; recover the missing evaluation at 0 from it.
+		evals
 			.reduce::<P>()
 			.sum_scalars(n_vars_remaining)
-			.interpolate(last_sum);
-
-		self.last_coeffs_or_sum = RoundState::Coeffs(round_coeffs.clone());
-		round_coeffs
-	}
-
-	fn fold(&mut self, challenge: F) {
-		// The store folds the columns (advancing its remaining count); only the sum claim advances
-		// here.
-		let round_sum = self.last_coeffs_or_sum.coeffs().evaluate(challenge);
-		self.last_coeffs_or_sum = RoundState::Claim(round_sum);
+			.interpolate(claim)
 	}
 }
 

--- a/crates/ip-prover/src/sumcheck/bivariate_product_mle.rs
+++ b/crates/ip-prover/src/sumcheck/bivariate_product_mle.rs
@@ -98,9 +98,8 @@ where
 		eq_tracker,
 		|[a, b]: [P; 2]| a * b,
 		|[a, b]: [P; 2]| a * b,
-		eval_claim,
 	);
-	SharedMleCheckProver::new(store, vec![evaluator], eval_point)
+	SharedMleCheckProver::new(store, vec![evaluator], vec![eval_claim], eval_point)
 }
 
 #[cfg(test)]

--- a/crates/ip-prover/src/sumcheck/frac_add_mle.rs
+++ b/crates/ip-prover/src/sumcheck/frac_add_mle.rs
@@ -19,12 +19,11 @@ pub type FractionalBuffer<P> = (FieldBuffer<P>, FieldBuffer<P>);
 /// one evaluator each — are the fractional-addition numerator `num_a * den_b + num_b * den_a` over
 /// all four columns and the denominator `den_a * den_b` over `[den_a, den_b]`, both weighted by the
 /// equality indicator at `eval_point`. The evaluators share the store's eq tracker for
-/// `eval_point`.
+/// `eval_point`. The two claimed evaluations are held by the driving prover, not the evaluators.
 pub fn evaluators<F, P>(
 	store: &mut MleStore<'_, P>,
 	cols: [ColId; 4],
 	eval_point: Vec<F>,
-	eval_claims: [F; 2],
 ) -> (impl RoundEvaluator<F, P> + 'static, impl RoundEvaluator<F, P> + 'static)
 where
 	F: Field,
@@ -41,14 +40,12 @@ where
 		eq_tracker,
 		|[num_a, num_b, den_a, den_b]: [P; 4]| num_a * den_b + num_b * den_a,
 		|[num_a, num_b, den_a, den_b]: [P; 4]| num_a * den_b + num_b * den_a,
-		eval_claims[0],
 	);
 	let denominator = QuadraticMleEvaluator::new(
 		[den_a, den_b],
 		eq_tracker,
 		|[den_a, den_b]: [P; 2]| den_a * den_b,
 		|[den_a, den_b]: [P; 2]| den_a * den_b,
-		eval_claims[1],
 	);
 	(numerator, denominator)
 }
@@ -199,8 +196,7 @@ mod tests {
 		let mut store = MleStore::new(n_vars);
 		let cols = [num_a.clone(), num_b.clone(), den_a.clone(), den_b.clone()]
 			.map(|col| store.push_owned(col));
-		let (num_evaluator, den_evaluator) =
-			evaluators(&mut store, cols, eval_point.clone(), eval_claims);
+		let (num_evaluator, den_evaluator) = evaluators(&mut store, cols, eval_point.clone());
 
 		// Both evaluators share the point's eq tracker; recover its id for the sumcheck wrappers.
 		let eq_tracker = store.register_eq_tracker(&eval_point);
@@ -209,7 +205,7 @@ mod tests {
 			Box::new(MleToSumCheckEvaluator::new(num_evaluator, eq_tracker)),
 			Box::new(MleToSumCheckEvaluator::new(den_evaluator, eq_tracker)),
 		];
-		let prover = SharedSumcheckProver::new(store, evaluators);
+		let prover = SharedSumcheckProver::new(store, evaluators, eval_claims.to_vec());
 
 		test_frac_add_sumcheck_prove_verify(
 			prover,

--- a/crates/ip-prover/src/sumcheck/mle_to_sumcheck.rs
+++ b/crates/ip-prover/src/sumcheck/mle_to_sumcheck.rs
@@ -132,10 +132,10 @@ where
 		self.inner.degree()
 	}
 
-	fn round_claim(&self, store: &MleStore<'_, P>) -> F {
-		// The sumcheck round claim is the inner MLE-check claim scaled by the accumulated
-		// equality prefix; see [`MleToSumCheckDecorator::round_claim`].
-		self.inner.round_claim(store) * store.eq_prefix(self.eq_tracker)
+	fn claim_from_coeffs(&self, _store: &MleStore<'_, P>, coeffs: &RoundCoeffs<F>) -> F {
+		// The emitted round polynomial is a regular sumcheck polynomial (the inner prime polynomial
+		// already multiplied by the equality factor), so its claim is the sum over the endpoints.
+		coeffs.sum_over_endpoints()
 	}
 
 	fn accumulate(&self, chunk: &EvaluationChunk<'_, P>, accum: &mut [<P as WideMul>::Output]) {
@@ -143,22 +143,23 @@ where
 	}
 
 	fn interpolate(
-		&mut self,
+		&self,
 		store: &MleStore<'_, P>,
 		accum: &[<P as WideMul>::Output],
+		claim: F,
 	) -> RoundCoeffs<F> {
-		let round_coeffs = self.inner.interpolate(store, accum);
+		// `claim` is the sumcheck round claim: the inner MLE-check claim `m` scaled by the
+		// accumulated equality prefix. Recover `m` for the inner evaluator by dividing the prefix
+		// back out. (`invert_or_zero` mirrors the interpolation routines; the prefix is a product
+		// of non-degenerate equality factors for honest challenges.)
+		let eq_prefix = store.eq_prefix(self.eq_tracker);
+		let inner_claim = claim * eq_prefix.invert_or_zero();
+		let round_coeffs = self.inner.interpolate(store, accum, inner_claim);
 
 		// Multiply the round polynomial from the inner MLE-check evaluator by (X - α) and the
 		// equality prefix, both read from the shared eq tracker (the store has not yet folded this
 		// round, so the tracker is at the current round's alpha and prefix).
 		let alpha = store.eq_alpha(self.eq_tracker);
-		round_coeffs_by_eq(&round_coeffs, alpha) * store.eq_prefix(self.eq_tracker)
-	}
-
-	fn fold(&mut self, challenge: F) {
-		// The store folds the shared eq tracker, advancing its alpha and equality prefix, so the
-		// wrapper only advances the inner evaluator's claim state.
-		self.inner.fold(challenge)
+		round_coeffs_by_eq(&round_coeffs, alpha) * eq_prefix
 	}
 }

--- a/crates/ip-prover/src/sumcheck/padded.rs
+++ b/crates/ip-prover/src/sumcheck/padded.rs
@@ -143,7 +143,7 @@ mod tests {
 	fn make_inner(
 		rng: &mut impl Rng,
 		n_vars: usize,
-	) -> (SharedSumcheckProver<'static, P, BivariateProductEvaluator<P>>, F) {
+	) -> (SharedSumcheckProver<'static, P, BivariateProductEvaluator>, F) {
 		let a = random_field_buffer::<P>(&mut *rng, n_vars);
 		let b = random_field_buffer::<P>(&mut *rng, n_vars);
 		let sum = inner_product_par(&a, &b);

--- a/crates/ip-prover/src/sumcheck/quadratic_mle_evaluator.rs
+++ b/crates/ip-prover/src/sumcheck/quadratic_mle_evaluator.rs
@@ -8,7 +8,6 @@ use super::{
 	mle_store::{ColId, ColumnChunk, EqId, EvaluationChunk, MleStore},
 	round_evals::RoundEvals2,
 	round_evaluator::{RoundEvaluator, SharedMleCheckProver},
-	round_state::RoundState,
 };
 
 /// MLE-check round evaluator for one quadratic composition over N store columns.
@@ -21,7 +20,7 @@ use super::{
 /// The evaluator emits the prime (eq-factored) round polynomial of the MLE-check protocol. Wrap it
 /// in [`MleToSumCheckEvaluator`](super::MleToSumCheckEvaluator) to emit a regular sumcheck round
 /// polynomial.
-pub struct QuadraticMleEvaluator<P: PackedField, Composition, InfinityComposition, const N: usize> {
+pub struct QuadraticMleEvaluator<Composition, InfinityComposition, const N: usize> {
 	// Store columns holding the packed evaluations of the input multilinears.
 	cols: [ColId; N],
 	// The store's (possibly shared) eq-indicator tracker for `eval_point`.
@@ -30,17 +29,10 @@ pub struct QuadraticMleEvaluator<P: PackedField, Composition, InfinityCompositio
 	composition: Composition,
 	// Composition restricted to highest-degree terms for the "x = ∞" evaluation (Karatsuba).
 	infinity_composition: InfinityComposition,
-	// State machine storage: last round's eval (interpolate input) or coeffs (fold input).
-	last_coeffs_or_eval: RoundState<RoundCoeffs<P::Scalar>, P::Scalar>,
 }
 
-impl<F, P, Composition, InfinityComposition, const N: usize>
-	QuadraticMleEvaluator<P, Composition, InfinityComposition, N>
-where
-	F: Field,
-	P: PackedField<Scalar = F>,
-	Composition: Fn([P; N]) -> P + Send + Sync,
-	InfinityComposition: Fn([P; N]) -> P + Send + Sync,
+impl<Composition, InfinityComposition, const N: usize>
+	QuadraticMleEvaluator<Composition, InfinityComposition, N>
 {
 	/// Creates an evaluator over `cols` reading the eq tracker `eq_tracker` from `store`.
 	///
@@ -50,6 +42,9 @@ where
 	/// only the tracker id and queries the store for the round's alpha and remaining-variable count
 	/// as they change — it keeps no copy of the point.
 	///
+	/// The claimed evaluation is held by the driving prover (see [`SharedMleCheckProver`]), not the
+	/// evaluator.
+	///
 	/// # Arguments
 	///
 	/// * `cols` - The N store columns the composition reads.
@@ -57,13 +52,11 @@ where
 	/// * `composition` - Evaluates the quadratic composition of the N column values.
 	/// * `infinity_composition` - The composition restricted to its highest-degree terms, for the
 	///   Karatsuba evaluation at infinity.
-	/// * `eval_claim` - The claimed evaluation of the composition's MLE at the point.
 	pub fn new(
 		cols: [ColId; N],
 		eq_tracker: EqId,
 		composition: Composition,
 		infinity_composition: InfinityComposition,
-		eval_claim: F,
 	) -> Self {
 		// precondition
 		assert!(N > 0);
@@ -73,7 +66,6 @@ where
 			eq_tracker,
 			composition,
 			infinity_composition,
-			last_coeffs_or_eval: RoundState::Claim(eval_claim),
 		}
 	}
 }
@@ -115,12 +107,7 @@ pub fn quadratic_mlecheck_prover<F, P, Composition, InfinityComposition, const N
 	infinity_composition: InfinityComposition,
 	eval_point: Vec<F>,
 	eval_claim: F,
-) -> SharedMleCheckProver<
-	'static,
-	F,
-	P,
-	QuadraticMleEvaluator<P, Composition, InfinityComposition, N>,
->
+) -> SharedMleCheckProver<'static, F, P, QuadraticMleEvaluator<Composition, InfinityComposition, N>>
 where
 	F: Field,
 	P: PackedField<Scalar = F>,
@@ -132,13 +119,12 @@ where
 	let cols = multilinears.map(|col| store.push_owned(col));
 	// Register the evaluation point's equality-indicator tracker once for the sole evaluator.
 	let eq_tracker = store.register_eq_tracker(&eval_point);
-	let evaluator =
-		QuadraticMleEvaluator::new(cols, eq_tracker, composition, infinity_composition, eval_claim);
-	SharedMleCheckProver::new(store, vec![evaluator], eval_point)
+	let evaluator = QuadraticMleEvaluator::new(cols, eq_tracker, composition, infinity_composition);
+	SharedMleCheckProver::new(store, vec![evaluator], vec![eval_claim], eval_point)
 }
 
 impl<F, P, Composition, InfinityComposition, const N: usize> RoundEvaluator<F, P>
-	for QuadraticMleEvaluator<P, Composition, InfinityComposition, N>
+	for QuadraticMleEvaluator<Composition, InfinityComposition, N>
 where
 	F: Field,
 	P: PackedField<Scalar = F>,
@@ -150,14 +136,11 @@ where
 		2
 	}
 
-	fn round_claim(&self, store: &MleStore<'_, P>) -> F {
-		match &self.last_coeffs_or_eval {
-			RoundState::Claim(eval) => *eval,
-			RoundState::Coeffs(coeffs) => {
-				let alpha = store.eq_alpha(self.eq_tracker);
-				coeffs.lerp_over_endpoints(alpha)
-			}
-		}
+	fn claim_from_coeffs(&self, store: &MleStore<'_, P>, coeffs: &RoundCoeffs<F>) -> F {
+		// The emitted round polynomial is the prime (eq-factored) MLE-check polynomial, so its
+		// claim is the eq-lerp of its endpoints at the round's alpha.
+		let alpha = store.eq_alpha(self.eq_tracker);
+		coeffs.lerp_over_endpoints(alpha)
 	}
 
 	fn accumulate(&self, chunk: &EvaluationChunk<'_, P>, accum: &mut [<P as WideMul>::Output]) {
@@ -197,40 +180,24 @@ where
 	}
 
 	fn interpolate(
-		&mut self,
+		&self,
 		store: &MleStore<'_, P>,
 		accum: &[<P as WideMul>::Output],
+		claim: F,
 	) -> RoundCoeffs<F> {
-		// State machine: interpolate consumes the eval from the previous round and produces coeffs.
-		let last_eval = *self.last_coeffs_or_eval.claim();
-
 		// The store has not yet folded this round, so its remaining-variable count is this round's.
 		let n_vars_remaining = store.n_vars();
 		assert!(n_vars_remaining > 0);
 
-		// Reduce the wide accumulators, sum packed lanes into scalars, then interpolate. The
-		// round's coordinate ties this round's sum to the original evaluation point.
+		// Reduce the wide accumulators, sum packed lanes into scalars, then interpolate. `claim` is
+		// this round's prime eval; the round's coordinate ties it to the original evaluation point.
 		let alpha = store.eq_alpha(self.eq_tracker);
-		let round_coeffs = RoundEvals2 {
+		RoundEvals2 {
 			y_1: P::reduce(accum[0].clone()),
 			y_inf: P::reduce(accum[1].clone()),
 		}
 		.sum_scalars(n_vars_remaining)
-		.interpolate_eq(last_eval, alpha);
-
-		// State transition: interpolate produces coeffs for fold to consume.
-		self.last_coeffs_or_eval = RoundState::Coeffs(round_coeffs.clone());
-		round_coeffs
-	}
-
-	fn fold(&mut self, challenge: F) {
-		// State machine: fold consumes coeffs and produces the eval at the verifier challenge.
-		// Evaluate the round polynomial at the verifier's challenge to form the next claim. The
-		// store folds the columns and the eq tracker (advancing its remaining count and alpha) with
-		// the same challenge, so this only advances the claim state.
-		let eval = self.last_coeffs_or_eval.coeffs().evaluate(challenge);
-
-		self.last_coeffs_or_eval = RoundState::Claim(eval);
+		.interpolate_eq(claim, alpha)
 	}
 }
 

--- a/crates/ip-prover/src/sumcheck/round_evaluator.rs
+++ b/crates/ip-prover/src/sumcheck/round_evaluator.rs
@@ -3,9 +3,10 @@
 //! Round evaluators over a shared [`MleStore`] and the provers that drive them.
 //!
 //! A [`RoundEvaluator`] holds the per-round-polynomial logic for one composite claim over store
-//! columns. Evaluators hold [`ColId`]s and receive column data by argument; they never fold and
-//! hold no column references — the store folds (see the [`mle_store`](super::mle_store) module
-//! documentation).
+//! columns. Evaluators hold [`ColId`]s and receive column data by argument; they hold no mutable
+//! per-round state — they neither fold nor track the round claim. The driving prover owns the
+//! `RoundState` machine (the claim ↔ coeffs alternation) for each evaluator, and the store folds
+//! the columns (see the [`mle_store`](super::mle_store) module documentation).
 //!
 //! [`SharedSumcheckProver`] adapts a store plus a list of evaluators — one per claim — to the
 //! existing [`SumcheckProver`] interface, and [`SharedMleCheckProver`] to the [`MleCheckProver`]
@@ -22,6 +23,7 @@ use super::{
 	MleToSumCheckEvaluator,
 	common::{MleCheckProver, SumcheckProver},
 	mle_store::{ColId, EvaluationChunk, MleStore},
+	round_state::RoundState,
 };
 
 /// Per-round-polynomial logic for one composite claim over store columns.
@@ -29,14 +31,20 @@ use super::{
 /// The driving prover makes one parallel pass over column chunks per round; the hot loops stay
 /// monomorphized inside each evaluator and only the per-chunk [`Self::accumulate`] entry is
 /// virtual. Within a round the calls are: [`Self::accumulate`] from parallel workers into
-/// per-worker accumulator slices, then [`Self::interpolate`] once on the slot-wise summed slice,
-/// then [`Self::fold`] once.
+/// per-worker accumulator slices, then [`Self::interpolate`] once on the slot-wise summed slice.
+/// The driving prover, not the evaluator, holds the round claim and reduces the round polynomial
+/// against the verifier challenge; see [`SharedSumcheckProver`].
 ///
 /// The accumulator is a flat slice of [`Self::degree`] wide (unreduced)
 /// [`WideMul::Output`](WideMul::Output) slots. The driving prover owns the buffer, sizes it from
 /// [`Self::degree`], and sums the workers' slices slot-wise, so evaluators implement neither
 /// allocation nor merging — only the write pass and the interpolation. The slot layout within an
 /// evaluator's run is private to that evaluator.
+///
+/// Evaluators are stateless across rounds: they hold no round claim and never fold. The prover
+/// passes the round claim into [`Self::interpolate`] and recovers it back out of an emitted round
+/// polynomial via [`Self::claim_from_coeffs`], so the whole claim ↔ coeffs state machine lives in
+/// the prover's `RoundState`.
 ///
 /// The `auto_impl(Box)` derive forwards the trait through `Box`, so a heterogeneous group of
 /// evaluators can drive a shared prover as `Vec<Box<dyn RoundEvaluator<F, P>>>` while a homogeneous
@@ -52,12 +60,15 @@ pub trait RoundEvaluator<F: Field, P: PackedField<Scalar = F>>: Send + Sync {
 	/// the prime degree, not the emitted round-polynomial degree.
 	fn degree(&self) -> usize;
 
-	/// The current round claim.
+	/// Recovers this round's claim from an emitted round polynomial.
 	///
-	/// Reads the shared `store` for the point coordinates it needs (the store has not yet folded
-	/// this round, so `store.n_vars()` and the eq trackers are at the current round's state). See
-	/// [`SumcheckProver::round_claim`] for the contract.
-	fn round_claim(&self, store: &MleStore<'_, P>) -> F;
+	/// The prover holds the round claim directly before [`Self::interpolate`] runs, but once it
+	/// has replaced that claim with the round coefficients it recovers the (unchanged) claim from
+	/// them for [`SumcheckProver::round_claim`]. A regular sumcheck evaluator recovers it as
+	/// $R(0) + R(1)$ ([`RoundCoeffs::sum_over_endpoints`]); an MLE-check evaluator emitting prime
+	/// polynomials recovers it as $(1 - \alpha) R(0) + \alpha R(1)$
+	/// ([`RoundCoeffs::lerp_over_endpoints`]) with $\alpha$ read from the shared `store`.
+	fn claim_from_coeffs(&self, store: &MleStore<'_, P>, coeffs: &RoundCoeffs<F>) -> F;
 
 	/// Accumulates one chunk of the halved hypercube into `accum`.
 	///
@@ -67,22 +78,19 @@ pub trait RoundEvaluator<F: Field, P: PackedField<Scalar = F>>: Send + Sync {
 	/// slots, zero-initialized on the first chunk and carried across the worker's chunks.
 	fn accumulate(&self, chunk: &EvaluationChunk<'_, P>, accum: &mut [<P as WideMul>::Output]);
 
-	/// Interpolates this round's polynomial from the slot-wise summed accumulator slice.
+	/// Interpolates this round's polynomial from the slot-wise summed accumulator slice and the
+	/// round claim.
 	///
-	/// `accum` is this evaluator's run of [`Self::degree`] slots, summed across all workers. Reads
-	/// the shared `store` for the round's point coordinates; the store has not yet folded this
-	/// round, so `store.n_vars()` and the eq trackers are at the current round's state.
+	/// `accum` is this evaluator's run of [`Self::degree`] slots, summed across all workers, and
+	/// `claim` is the prover's round claim for this evaluator. Reads the shared `store` for the
+	/// round's point coordinates; the store has not yet folded this round, so `store.n_vars()` and
+	/// the eq trackers are at the current round's state.
 	fn interpolate(
-		&mut self,
+		&self,
 		store: &MleStore<'_, P>,
 		accum: &[<P as WideMul>::Output],
+		claim: F,
 	) -> RoundCoeffs<F>;
-
-	/// Advances evaluator-local bookkeeping past a fold challenge.
-	///
-	/// The store folds the shared columns and eq trackers; this only updates claim state and
-	/// equality prefix products.
-	fn fold(&mut self, challenge: F);
 }
 
 /// Maximum log2 chunk size of the parallel round pass.
@@ -101,9 +109,18 @@ const MAX_CHUNK_VARS: usize = 12;
 pub struct SharedSumcheckProver<'a, P: PackedField, Evaluator> {
 	store: MleStore<'a, P>,
 	evaluators: Vec<Evaluator>,
+	/// The claim ↔ round-coeffs state machine, one entry per evaluator (parallel to `evaluators`).
+	///
+	/// Holds each evaluator's current round claim before its round polynomial is produced, and the
+	/// produced round coefficients afterwards. The prover — not the evaluator — advances this
+	/// state: [`SumcheckProver::execute`] hands the claim to [`RoundEvaluator::interpolate`] and
+	/// stores the resulting coefficients; [`SumcheckProver::fold`] reduces them against the
+	/// challenge back to a claim.
+	round_states: Vec<RoundState<RoundCoeffs<P::Scalar>, P::Scalar>>,
 	/// A fold challenge whose store fold has been deferred so the next [`SumcheckProver::execute`]
-	/// can fuse it into that round's read pass (see [`MleStore::map_reduce_with_fold`]). The
-	/// evaluators fold eagerly; only the store's column and eq fold waits here.
+	/// can fuse it into that round's read pass (see [`MleStore::map_reduce_with_fold`]). Only the
+	/// store's column and eq fold waits here; the round claims advance eagerly in
+	/// [`SumcheckProver::fold`].
 	buffered_challenge: Option<P::Scalar>,
 }
 
@@ -113,11 +130,16 @@ where
 	P: PackedField<Scalar = F>,
 	Evaluator: RoundEvaluator<F, P>,
 {
-	/// Creates a prover from a store and the evaluators reading its columns, one per claim.
-	pub const fn new(store: MleStore<'a, P>, evaluators: Vec<Evaluator>) -> Self {
+	/// Creates a prover from a store, the evaluators reading its columns, and the initial claim of
+	/// each evaluator — all three lists in the same order, one entry per claim.
+	pub fn new(store: MleStore<'a, P>, evaluators: Vec<Evaluator>, claims: Vec<F>) -> Self {
+		// precondition
+		assert_eq!(evaluators.len(), claims.len(), "one initial claim per evaluator is required");
+		let round_states = claims.into_iter().map(RoundState::Claim).collect();
 		Self {
 			store,
 			evaluators,
+			round_states,
 			buffered_challenge: None,
 		}
 	}
@@ -136,11 +158,13 @@ where
 		self.store.push_owned(column)
 	}
 
-	/// Adds one more evaluator — a claim reading the shared store — to the group.
+	/// Adds one more evaluator — a claim reading the shared store, with its initial claim — to the
+	/// group.
 	///
 	/// Its round polynomial is appended after the existing evaluators' in [`Self::execute`].
-	pub fn add_evaluator(&mut self, evaluator: Evaluator) {
+	pub fn add_evaluator(&mut self, evaluator: Evaluator, claim: F) {
 		self.evaluators.push(evaluator);
+		self.round_states.push(RoundState::Claim(claim));
 	}
 
 	/// Prefix sums of each evaluator's [`RoundEvaluator::degree`] slot count.
@@ -174,9 +198,13 @@ where
 	}
 
 	fn round_claim(&self) -> Vec<F> {
-		self.evaluators
-			.iter()
-			.map(|evaluator| evaluator.round_claim(&self.store))
+		// The claim is held directly before this round's polynomial is produced, and recovered from
+		// that polynomial afterwards (each evaluator knows how to invert its own emission).
+		iter::zip(&self.evaluators, &self.round_states)
+			.map(|(evaluator, state)| match state {
+				RoundState::Claim(claim) => *claim,
+				RoundState::Coeffs(coeffs) => evaluator.claim_from_coeffs(&self.store, coeffs),
+			})
 			.collect()
 	}
 
@@ -225,20 +253,30 @@ where
 			None => store.map_reduce(chunk_vars, map, reduce),
 		};
 
-		// The store is read (immutably) for the round's point coordinates while the evaluators are
-		// interpolated (mutably); they are disjoint fields, so borrow the store separately.
+		// The store is read (immutably) for the round's point coordinates. Each evaluator takes its
+		// current round claim (held in `round_states`) and produces its round polynomial; the
+		// prover then records those coefficients as the round state for the coming fold.
 		let store = &self.store;
-		iter::zip(&mut self.evaluators, offsets.windows(2))
-			.map(|(evaluator, window)| evaluator.interpolate(store, &accum[window[0]..window[1]]))
-			.collect()
+		let round_coeffs: Vec<RoundCoeffs<F>> =
+			iter::zip(iter::zip(&self.evaluators, &self.round_states), offsets.windows(2))
+				.map(|((evaluator, state), window)| {
+					let claim = *state.claim();
+					evaluator.interpolate(store, &accum[window[0]..window[1]], claim)
+				})
+				.collect();
+		for (state, coeffs) in iter::zip(&mut self.round_states, &round_coeffs) {
+			*state = RoundState::Coeffs(coeffs.clone());
+		}
+		round_coeffs
 	}
 
 	fn fold(&mut self, challenge: F) {
-		// The evaluators advance their local bookkeeping (claim state, equality prefix products)
-		// now, but the store's column and eq fold is deferred: the challenge is buffered so the
-		// next execute can fuse it into that round's read pass.
-		for evaluator in &mut self.evaluators {
-			evaluator.fold(challenge);
+		// Reduce each evaluator's round polynomial against the challenge to form its next claim.
+		// The store's column and eq fold is deferred: the challenge is buffered so the next
+		// execute can fuse it into that round's read pass.
+		for state in &mut self.round_states {
+			let claim = state.coeffs().evaluate(challenge);
+			*state = RoundState::Claim(claim);
 		}
 		debug_assert!(
 			self.buffered_challenge.is_none(),
@@ -275,9 +313,14 @@ where
 	P: PackedField<Scalar = F>,
 	Evaluator: RoundEvaluator<F, P>,
 {
-	/// Creates a prover from a store, the evaluators reading its columns — one per claim — and the
-	/// evaluation point shared by all of the evaluators' claims.
-	pub fn new(store: MleStore<'a, P>, evaluators: Vec<Evaluator>, eval_point: Vec<F>) -> Self {
+	/// Creates a prover from a store, the evaluators reading its columns and their initial claims —
+	/// one per claim — and the evaluation point shared by all of the evaluators' claims.
+	pub fn new(
+		store: MleStore<'a, P>,
+		evaluators: Vec<Evaluator>,
+		claims: Vec<F>,
+		eval_point: Vec<F>,
+	) -> Self {
 		// precondition
 		assert_eq!(
 			eval_point.len(),
@@ -285,7 +328,7 @@ where
 			"evaluation point length must equal the store's number of variables"
 		);
 		Self {
-			inner: SharedSumcheckProver::new(store, evaluators),
+			inner: SharedSumcheckProver::new(store, evaluators, claims),
 			eval_point,
 		}
 	}
@@ -305,10 +348,12 @@ where
 		Evaluator: 'static,
 	{
 		let Self { inner, eval_point } = self;
-		// Conversion happens before proving starts, so no fold challenge is buffered yet.
+		// Conversion happens before proving starts, so no fold challenge is buffered yet and every
+		// round state is still an unreduced initial claim.
 		let SharedSumcheckProver {
 			mut store,
 			evaluators,
+			round_states,
 			buffered_challenge: _,
 		} = inner;
 		// Every claim of an MLE-check prover shares the prover's evaluation point, so its eq
@@ -323,7 +368,15 @@ where
 					as Box<dyn RoundEvaluator<F, P>>
 			})
 			.collect();
-		SharedSumcheckProver::new(store, evaluators)
+		// The wrappers emit the same claims: at the point of conversion no variable has been
+		// folded, so the equality prefix is one and the sumcheck claim equals the inner MLE-check
+		// claim.
+		SharedSumcheckProver {
+			store,
+			evaluators,
+			round_states,
+			buffered_challenge: None,
+		}
 	}
 }
 
@@ -455,11 +508,10 @@ mod tests {
 	) -> SharedMleCheckProver<'a, F, P, Box<dyn RoundEvaluator<F, P>>> {
 		let mut store = MleStore::new(eval_point.len());
 		let col_ids = cols.each_ref().map(|col| store.push(col.to_ref()));
-		let (num_ev, den_ev) =
-			frac_add_mle::evaluators(&mut store, col_ids, eval_point.to_vec(), claims);
+		let (num_ev, den_ev) = frac_add_mle::evaluators(&mut store, col_ids, eval_point.to_vec());
 		let evaluators: Vec<Box<dyn RoundEvaluator<F, P>>> =
 			vec![Box::new(num_ev), Box::new(den_ev)];
-		SharedMleCheckProver::new(store, evaluators, eval_point.to_vec())
+		SharedMleCheckProver::new(store, evaluators, claims.to_vec(), eval_point.to_vec())
 	}
 
 	// Prove the two fractional-addition claims through the MLE-check batch driver, then verify.
@@ -555,15 +607,14 @@ mod tests {
 				&mut store,
 				[y_0_col, y_1_col, d_0_col, d_1_col],
 				z.to_vec(),
-				frac_claims,
 			);
 			let eq_tracker = store.register_eq_tracker(&z);
 			let num_evaluator = MleToSumCheckEvaluator::new(num_evaluator, eq_tracker);
 			let den_evaluator = MleToSumCheckEvaluator::new(den_evaluator, eq_tracker);
 
 			// The two plain product claims over the pushforward and table halves.
-			let product_0 = BivariateProductEvaluator::new([y_0_col, t_0_col], e_0);
-			let product_1 = BivariateProductEvaluator::new([y_1_col, t_1_col], e_1);
+			let product_0 = BivariateProductEvaluator::new([y_0_col, t_0_col]);
+			let product_1 = BivariateProductEvaluator::new([y_1_col, t_1_col]);
 
 			let evaluators: Vec<Box<dyn RoundEvaluator<F, P>>> = vec![
 				Box::new(num_evaluator),
@@ -571,7 +622,9 @@ mod tests {
 				Box::new(product_0),
 				Box::new(product_1),
 			];
-			let shared = SharedSumcheckProver::new(store, evaluators);
+			// Claims in evaluator order: the two fractional claims, then the two product sums.
+			let claims = vec![frac_claims[0], frac_claims[1], e_0, e_1];
+			let shared = SharedSumcheckProver::new(store, evaluators, claims);
 
 			// Prove and record the four claim sums in evaluator order.
 			let mut transcript = ProverTranscript::new(StdChallenger::default());

--- a/crates/m4-prover/src/prove.rs
+++ b/crates/m4-prover/src/prove.rs
@@ -492,6 +492,7 @@ impl<'a, const ARITY: usize> Operation<'a, ARITY> {
 		lagrange: &[B128],
 		store: &mut MleStore<P>,
 		evaluators: &mut Vec<Box<dyn RoundEvaluator<B128, P>>>,
+		claims: &mut Vec<B128>,
 	) where
 		P: PackedField<Scalar = B128>,
 	{
@@ -505,9 +506,10 @@ impl<'a, const ARITY: usize> Operation<'a, ARITY> {
 				eq_tracker,
 				|[operand]: [P; 1]| operand,
 				|[_operand]: [P; 1]| P::zero(),
-				claim,
 			);
 			evaluators.push(Box::new(MleToSumCheckEvaluator::new(evaluator, eq_tracker)));
+			// The driving prover, not the evaluator, holds the claim.
+			claims.push(claim);
 		}
 	}
 }
@@ -643,18 +645,20 @@ impl RerandomizedOperations<'_> {
 		let mut store = MleStore::<P>::new(log_instances);
 		let mut evaluators: Vec<Box<dyn RoundEvaluator<B128, P>>> =
 			Vec::with_capacity(BITAND_ARITY + INTMUL_ARITY + BINMUL_ARITY);
-		self.bitand.push_to(lagrange, &mut store, &mut evaluators);
+		let mut claims: Vec<B128> = Vec::with_capacity(BITAND_ARITY + INTMUL_ARITY + BINMUL_ARITY);
+		self.bitand
+			.push_to(lagrange, &mut store, &mut evaluators, &mut claims);
 		if let Some(intmul) = &self.intmul {
-			intmul.push_to(lagrange, &mut store, &mut evaluators);
+			intmul.push_to(lagrange, &mut store, &mut evaluators, &mut claims);
 		}
 		if let Some(binmul) = &self.binmul {
-			binmul.push_to(lagrange, &mut store, &mut evaluators);
+			binmul.push_to(lagrange, &mut store, &mut evaluators, &mut claims);
 		}
 
 		// One shared prover drives all claims over the store in a single round pass.
 		// Its evaluations are the store's per-column values at the shared instance point, in push
 		// order.
-		let shared = SharedSumcheckProver::new(store, evaluators);
+		let shared = SharedSumcheckProver::new(store, evaluators, claims);
 		let output = batch_prove_and_write_evals(vec![shared], channel);
 		let reduced = &output.multilinear_evals[0];
 

--- a/crates/prover/benches/batch_quadratic_mle.rs
+++ b/crates/prover/benches/batch_quadratic_mle.rs
@@ -116,23 +116,14 @@ fn bench_batch_quadratic_mlecheck_prove(c: &mut Criterion) {
 					// One single-claim evaluator per composition, sharing the store's columns and
 					// one eq tracker registered for the shared point.
 					let eq_tracker = store.register_eq_tracker(&eval_point);
-					let evaluator_0 = QuadraticMleEvaluator::new(
-						cols,
-						eq_tracker,
-						comp_0::<P>,
-						comp_0_inf::<P>,
-						eval_claims[0],
-					);
-					let evaluator_1 = QuadraticMleEvaluator::new(
-						cols,
-						eq_tracker,
-						comp_1::<P>,
-						comp_1_inf::<P>,
-						eval_claims[1],
-					);
+					let evaluator_0 =
+						QuadraticMleEvaluator::new(cols, eq_tracker, comp_0::<P>, comp_0_inf::<P>);
+					let evaluator_1 =
+						QuadraticMleEvaluator::new(cols, eq_tracker, comp_1::<P>, comp_1_inf::<P>);
 					let evaluators: Vec<Box<dyn RoundEvaluator<F, P>>> =
 						vec![Box::new(evaluator_0), Box::new(evaluator_1)];
-					let prover = SharedMleCheckProver::new(store, evaluators, eval_point);
+					let claims = vec![eval_claims[0], eval_claims[1]];
+					let prover = SharedMleCheckProver::new(store, evaluators, claims, eval_point);
 
 					prove_batch_mlecheck(prover, &mut transcript)
 				},


### PR DESCRIPTION
Closes BINIUS-305.

## What

Removes `RoundEvaluator::fold` and the per-evaluator `last_coeffs_or_sum` state. The claim ↔ round-coeffs state machine now lives once in `SharedSumcheckProver`, as a `Vec<RoundState<RoundCoeffs, F>>` parallel to the evaluators. Evaluators become **stateless across rounds** (`interpolate` and the recovery hook take `&self`), which lines up the interface for BINIUS-306 (splitting `RoundEvaluator` into separate sumcheck/mlecheck traits, where `interpolate` will additionally receive `alpha`).

The prover now owns the whole state transition:
- `execute` reads each evaluator's current round claim from `round_states` and hands it to `RoundEvaluator::interpolate(store, accum, claim)`, then stores the returned coefficients.
- `fold` reduces each stored round polynomial against the challenge (`coeffs.evaluate(challenge)`) back to a claim — uniformly, no evaluator involvement (the old per-evaluator `fold` was always exactly this reduction).
- `round_claim` returns the held claim directly, or, once coefficients have replaced it, recovers it via the new `RoundEvaluator::claim_from_coeffs` (which each evaluator implements as its own emission inverse: `sum_over_endpoints` for plain sumcheck, `lerp_over_endpoints(alpha)` for prime MLE-check polynomials).

Initial claims now flow to the prover constructors (`SharedSumcheckProver::new`, `SharedMleCheckProver::new`, `add_evaluator`) instead of into each evaluator, and the `frac_add_mle::evaluators` helper no longer takes claims. Also drops the now-unused `P` type parameter from `BivariateProductEvaluator` and `QuadraticMleEvaluator`.

## Design note worth a look

For the wrapped `MleToSumCheckEvaluator`, the prover stores the **sumcheck** claim (= inner prime claim `m` scaled by the accumulated equality prefix), because that's what the emitted regular-sumcheck polynomial reduces to under `fold`. Its `interpolate` therefore recovers the inner prime claim by dividing the prefix back out:

```rust
let inner_claim = claim * eq_prefix.invert_or_zero();
```

The invariant `sumcheck_claim = eq_prefix * m` holds every round (starts at `eq_prefix = 1`), so this is exact; `invert_or_zero` mirrors the existing interpolation routines in `round_evals.rs`. The old design avoided this division by keeping the prime state *inside* the inner evaluator. The cost here is one field inversion per round per wrapped evaluator (a handful in the logUp* final layer; ~one per M4 operand) — negligible against the accumulation pass. If you'd rather keep it division-free, the alternative is to store the prime state in the prover and add a separate emission step to the trait; I went with the simpler version that matches the issue's "keep one RoundState per evaluator + pass the round claim to interpolate", but happy to switch.

## Testing

- `cargo test` green for `binius-ip-prover` (58), `binius-m4-prover` (40), `binius-iop-prover` (35 + integration) — covers the plain, MLE-check, wrapped-final-layer, and round-claim-recovery paths.
- clippy (`--tests --benches`) and nightly `fmt --check` clean; `cargo doc -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)