### PR TITLE
Shared prover constructors take IntoIterator of (claim, evaluator)

### DIFF
--- a/crates/iop-prover/src/basefold_channel.rs
+++ b/crates/iop-prover/src/basefold_channel.rs
@@ -302,11 +302,7 @@ fn prove_batch_zk_basefold<F, P, NTT, Channel>(
 			let transparent_col = store.push_owned(transparent);
 			let inner = SharedSumcheckProver::new(
 				store,
-				vec![BivariateProductEvaluator::new([
-					message_col,
-					transparent_col,
-				])],
-				vec![sum_prime],
+				[(sum_prime, BivariateProductEvaluator::new([message_col, transparent_col]))],
 			);
 			PaddedSumcheckDecorator::new(inner, max_n - n_i)
 		})

--- a/crates/ip-prover/benches/bivariate_product.rs
+++ b/crates/ip-prover/benches/bivariate_product.rs
@@ -65,7 +65,7 @@ fn bench_shared_sumcheck_bivariate_product(c: &mut Criterion) {
 					let mut store = MleStore::new(n_vars);
 					let cols = [a, b_multilinear].map(|col| store.push_owned(col));
 					let evaluator = BivariateProductEvaluator::new(cols);
-					let prover = SharedSumcheckProver::new(store, vec![evaluator], vec![sum_claim]);
+					let prover = SharedSumcheckProver::new(store, [(sum_claim, evaluator)]);
 
 					sumcheck::prove_single(prover, &mut transcript)
 				},
@@ -102,12 +102,8 @@ fn bench_shared_mlecheck_bivariate_product(c: &mut Criterion) {
 					let eq_tracker = store.register_eq_tracker(&eval_point);
 					let evaluator =
 						QuadraticMleEvaluator::new(cols, eq_tracker, product::<P>, product::<P>);
-					let prover = SharedMleCheckProver::new(
-						store,
-						vec![evaluator],
-						vec![eval_claim],
-						eval_point,
-					);
+					let prover =
+						SharedMleCheckProver::new(store, [(eval_claim, evaluator)], eval_point);
 
 					sumcheck::prove_single_mlecheck(prover, &mut transcript)
 				},

--- a/crates/ip-prover/src/fracaddcheck.rs
+++ b/crates/ip-prover/src/fracaddcheck.rs
@@ -136,10 +136,15 @@ where
 		let (num_evaluator, den_evaluator) =
 			frac_add_mle::evaluators(&mut store, cols, num_claim.point.clone());
 
-		let evaluators: Vec<Box<dyn RoundEvaluator<F, P>>> =
-			vec![Box::new(num_evaluator), Box::new(den_evaluator)];
-		let claims = vec![num_claim.eval, den_claim.eval];
-		(remaining, SharedMleCheckProver::new(store, evaluators, claims, num_claim.point), cols)
+		let claims_with_evaluators: [(F, Box<dyn RoundEvaluator<F, P>>); 2] = [
+			(num_claim.eval, Box::new(num_evaluator)),
+			(den_claim.eval, Box::new(den_evaluator)),
+		];
+		(
+			remaining,
+			SharedMleCheckProver::new(store, claims_with_evaluators, num_claim.point),
+			cols,
+		)
 	}
 
 	/// Runs the fractional addition check protocol and returns the final evaluation claims.
@@ -531,13 +536,13 @@ where
 	.map(|buffer| selector_store.push_owned(buffer));
 	let (selector_num, selector_den) =
 		frac_add_mle::evaluators(&mut selector_store, selector_cols, outer_coords.to_vec());
-	let selector_evaluators: Vec<Box<dyn RoundEvaluator<F, P>>> =
-		vec![Box::new(selector_num), Box::new(selector_den)];
-	let selector_claims = vec![num_eval, den_eval];
+	let selector_claims_with_evaluators: [(F, Box<dyn RoundEvaluator<F, P>>); 2] = [
+		(num_eval, Box::new(selector_num)),
+		(den_eval, Box::new(selector_den)),
+	];
 	let mut selector_prover = SharedMleCheckProver::new(
 		selector_store,
-		selector_evaluators,
-		selector_claims,
+		selector_claims_with_evaluators,
 		outer_coords.to_vec(),
 	);
 

--- a/crates/ip-prover/src/logup_star/final_layer.rs
+++ b/crates/ip-prover/src/logup_star/final_layer.rs
@@ -131,9 +131,9 @@ where
 	let t_0_col = prover.push_owned_column(t_0);
 	let t_1_col = prover.push_owned_column(t_1);
 	let product_0 = BivariateProductEvaluator::new([y_0_col, t_0_col]);
-	prover.add_evaluator(Box::new(product_0) as Box<dyn RoundEvaluator<F, P>>, e_0);
+	prover.add_evaluator(e_0, Box::new(product_0) as Box<dyn RoundEvaluator<F, P>>);
 	let product_1 = BivariateProductEvaluator::new([y_1_col, t_1_col]);
-	prover.add_evaluator(Box::new(product_1) as Box<dyn RoundEvaluator<F, P>>, e_1);
+	prover.add_evaluator(e_1, Box::new(product_1) as Box<dyn RoundEvaluator<F, P>>);
 
 	// Drive the one shared-store sumcheck.
 	//

--- a/crates/ip-prover/src/sumcheck/bivariate_product_evaluator.rs
+++ b/crates/ip-prover/src/sumcheck/bivariate_product_evaluator.rs
@@ -48,7 +48,7 @@ pub fn bivariate_product_prover<F: Field, P: PackedField<Scalar = F>>(
 
 	let mut store = MleStore::new(multilinears[0].log_len());
 	let cols = multilinears.map(|col| store.push_owned(col));
-	SharedSumcheckProver::new(store, vec![BivariateProductEvaluator::new(cols)], vec![sum])
+	SharedSumcheckProver::new(store, [(sum, BivariateProductEvaluator::new(cols))])
 }
 
 impl<F: Field, P: PackedField<Scalar = F>> RoundEvaluator<F, P> for BivariateProductEvaluator {

--- a/crates/ip-prover/src/sumcheck/bivariate_product_mle.rs
+++ b/crates/ip-prover/src/sumcheck/bivariate_product_mle.rs
@@ -99,7 +99,7 @@ where
 		|[a, b]: [P; 2]| a * b,
 		|[a, b]: [P; 2]| a * b,
 	);
-	SharedMleCheckProver::new(store, vec![evaluator], vec![eval_claim], eval_point)
+	SharedMleCheckProver::new(store, [(eval_claim, evaluator)], eval_point)
 }
 
 #[cfg(test)]

--- a/crates/ip-prover/src/sumcheck/frac_add_mle.rs
+++ b/crates/ip-prover/src/sumcheck/frac_add_mle.rs
@@ -201,11 +201,11 @@ mod tests {
 		// Both evaluators share the point's eq tracker; recover its id for the sumcheck wrappers.
 		let eq_tracker = store.register_eq_tracker(&eval_point);
 		// Wrap each MLE-check evaluator so it emits sumcheck-compatible round polynomials.
-		let evaluators: Vec<Box<dyn RoundEvaluator<F, P>>> = vec![
-			Box::new(MleToSumCheckEvaluator::new(num_evaluator, eq_tracker)),
-			Box::new(MleToSumCheckEvaluator::new(den_evaluator, eq_tracker)),
+		let claims_with_evaluators: [(F, Box<dyn RoundEvaluator<F, P>>); 2] = [
+			(eval_claims[0], Box::new(MleToSumCheckEvaluator::new(num_evaluator, eq_tracker))),
+			(eval_claims[1], Box::new(MleToSumCheckEvaluator::new(den_evaluator, eq_tracker))),
 		];
-		let prover = SharedSumcheckProver::new(store, evaluators, eval_claims.to_vec());
+		let prover = SharedSumcheckProver::new(store, claims_with_evaluators);
 
 		test_frac_add_sumcheck_prove_verify(
 			prover,

--- a/crates/ip-prover/src/sumcheck/quadratic_mle_evaluator.rs
+++ b/crates/ip-prover/src/sumcheck/quadratic_mle_evaluator.rs
@@ -120,7 +120,7 @@ where
 	// Register the evaluation point's equality-indicator tracker once for the sole evaluator.
 	let eq_tracker = store.register_eq_tracker(&eval_point);
 	let evaluator = QuadraticMleEvaluator::new(cols, eq_tracker, composition, infinity_composition);
-	SharedMleCheckProver::new(store, vec![evaluator], vec![eval_claim], eval_point)
+	SharedMleCheckProver::new(store, [(eval_claim, evaluator)], eval_point)
 }
 
 impl<F, P, Composition, InfinityComposition, const N: usize> RoundEvaluator<F, P>

--- a/crates/ip-prover/src/sumcheck/round_evaluator.rs
+++ b/crates/ip-prover/src/sumcheck/round_evaluator.rs
@@ -130,12 +130,19 @@ where
 	P: PackedField<Scalar = F>,
 	Evaluator: RoundEvaluator<F, P>,
 {
-	/// Creates a prover from a store, the evaluators reading its columns, and the initial claim of
-	/// each evaluator — all three lists in the same order, one entry per claim.
-	pub fn new(store: MleStore<'a, P>, evaluators: Vec<Evaluator>, claims: Vec<F>) -> Self {
-		// precondition
-		assert_eq!(evaluators.len(), claims.len(), "one initial claim per evaluator is required");
-		let round_states = claims.into_iter().map(RoundState::Claim).collect();
+	/// Creates a prover from a store and the evaluators reading its columns, each paired with its
+	/// initial claim — one `(claim, evaluator)` per claim.
+	///
+	/// Taking an [`IntoIterator`] lets callers pass an array of pairs directly, rather than two
+	/// parallel `Vec`s; the pairs are unzipped into the evaluators and their initial round states.
+	pub fn new(
+		store: MleStore<'a, P>,
+		claims_with_evaluators: impl IntoIterator<Item = (F, Evaluator)>,
+	) -> Self {
+		let (round_states, evaluators) = claims_with_evaluators
+			.into_iter()
+			.map(|(claim, evaluator)| (RoundState::Claim(claim), evaluator))
+			.unzip();
 		Self {
 			store,
 			evaluators,
@@ -162,7 +169,7 @@ where
 	/// group.
 	///
 	/// Its round polynomial is appended after the existing evaluators' in [`Self::execute`].
-	pub fn add_evaluator(&mut self, evaluator: Evaluator, claim: F) {
+	pub fn add_evaluator(&mut self, claim: F, evaluator: Evaluator) {
 		self.evaluators.push(evaluator);
 		self.round_states.push(RoundState::Claim(claim));
 	}
@@ -313,12 +320,12 @@ where
 	P: PackedField<Scalar = F>,
 	Evaluator: RoundEvaluator<F, P>,
 {
-	/// Creates a prover from a store, the evaluators reading its columns and their initial claims —
-	/// one per claim — and the evaluation point shared by all of the evaluators' claims.
+	/// Creates a prover from a store, the evaluators reading its columns each paired with its
+	/// initial claim — one `(claim, evaluator)` per claim — and the evaluation point shared by all
+	/// of the evaluators' claims.
 	pub fn new(
 		store: MleStore<'a, P>,
-		evaluators: Vec<Evaluator>,
-		claims: Vec<F>,
+		claims_with_evaluators: impl IntoIterator<Item = (F, Evaluator)>,
 		eval_point: Vec<F>,
 	) -> Self {
 		// precondition
@@ -328,7 +335,7 @@ where
 			"evaluation point length must equal the store's number of variables"
 		);
 		Self {
-			inner: SharedSumcheckProver::new(store, evaluators, claims),
+			inner: SharedSumcheckProver::new(store, claims_with_evaluators),
 			eval_point,
 		}
 	}
@@ -509,9 +516,9 @@ mod tests {
 		let mut store = MleStore::new(eval_point.len());
 		let col_ids = cols.each_ref().map(|col| store.push(col.to_ref()));
 		let (num_ev, den_ev) = frac_add_mle::evaluators(&mut store, col_ids, eval_point.to_vec());
-		let evaluators: Vec<Box<dyn RoundEvaluator<F, P>>> =
-			vec![Box::new(num_ev), Box::new(den_ev)];
-		SharedMleCheckProver::new(store, evaluators, claims.to_vec(), eval_point.to_vec())
+		let claims_with_evaluators: [(F, Box<dyn RoundEvaluator<F, P>>); 2] =
+			[(claims[0], Box::new(num_ev)), (claims[1], Box::new(den_ev))];
+		SharedMleCheckProver::new(store, claims_with_evaluators, eval_point.to_vec())
 	}
 
 	// Prove the two fractional-addition claims through the MLE-check batch driver, then verify.
@@ -616,15 +623,15 @@ mod tests {
 			let product_0 = BivariateProductEvaluator::new([y_0_col, t_0_col]);
 			let product_1 = BivariateProductEvaluator::new([y_1_col, t_1_col]);
 
-			let evaluators: Vec<Box<dyn RoundEvaluator<F, P>>> = vec![
-				Box::new(num_evaluator),
-				Box::new(den_evaluator),
-				Box::new(product_0),
-				Box::new(product_1),
+			// Claims paired with evaluators in order: the two fractional claims, then the two
+			// product sums.
+			let claims_with_evaluators: [(F, Box<dyn RoundEvaluator<F, P>>); 4] = [
+				(frac_claims[0], Box::new(num_evaluator)),
+				(frac_claims[1], Box::new(den_evaluator)),
+				(e_0, Box::new(product_0)),
+				(e_1, Box::new(product_1)),
 			];
-			// Claims in evaluator order: the two fractional claims, then the two product sums.
-			let claims = vec![frac_claims[0], frac_claims[1], e_0, e_1];
-			let shared = SharedSumcheckProver::new(store, evaluators, claims);
+			let shared = SharedSumcheckProver::new(store, claims_with_evaluators);
 
 			// Prove and record the four claim sums in evaluator order.
 			let mut transcript = ProverTranscript::new(StdChallenger::default());

--- a/crates/m4-prover/src/prove.rs
+++ b/crates/m4-prover/src/prove.rs
@@ -658,7 +658,7 @@ impl RerandomizedOperations<'_> {
 		// One shared prover drives all claims over the store in a single round pass.
 		// Its evaluations are the store's per-column values at the shared instance point, in push
 		// order.
-		let shared = SharedSumcheckProver::new(store, evaluators, claims);
+		let shared = SharedSumcheckProver::new(store, claims.into_iter().zip(evaluators));
 		let output = batch_prove_and_write_evals(vec![shared], channel);
 		let reduced = &output.multilinear_evals[0];
 

--- a/crates/prover/benches/batch_quadratic_mle.rs
+++ b/crates/prover/benches/batch_quadratic_mle.rs
@@ -120,10 +120,12 @@ fn bench_batch_quadratic_mlecheck_prove(c: &mut Criterion) {
 						QuadraticMleEvaluator::new(cols, eq_tracker, comp_0::<P>, comp_0_inf::<P>);
 					let evaluator_1 =
 						QuadraticMleEvaluator::new(cols, eq_tracker, comp_1::<P>, comp_1_inf::<P>);
-					let evaluators: Vec<Box<dyn RoundEvaluator<F, P>>> =
-						vec![Box::new(evaluator_0), Box::new(evaluator_1)];
-					let claims = vec![eval_claims[0], eval_claims[1]];
-					let prover = SharedMleCheckProver::new(store, evaluators, claims, eval_point);
+					let claims_with_evaluators: [(F, Box<dyn RoundEvaluator<F, P>>); 2] = [
+						(eval_claims[0], Box::new(evaluator_0)),
+						(eval_claims[1], Box::new(evaluator_1)),
+					];
+					let prover =
+						SharedMleCheckProver::new(store, claims_with_evaluators, eval_point);
 
 					prove_batch_mlecheck(prover, &mut transcript)
 				},


### PR DESCRIPTION
Follow-up to the [review comment](https://github.com/binius-zk/binius64/pull/1834#discussion_r3607969425) on #1834 (BINIUS-305).

`SharedSumcheckProver::new` and `SharedMleCheckProver::new` now take `claims_with_evaluators: impl IntoIterator<Item = (F, Evaluator)>` instead of two parallel `Vec`s, so callers can pass an array of pairs directly and the prover unzips into the evaluators and their initial round states. `add_evaluator(claim, evaluator)` is flipped to the same claim-first order for consistency.

Call sites that had one or two evaluators now pass an array literal (no `vec!`); the multi-evaluator sites (logUp* fracadd layers, M4 operands) build/zip the pairs.

Stacked under BINIUS-306.

## Testing
- `cargo test` green: `binius-ip-prover` (58), `binius-m4-prover` (40), `binius-iop-prover` (35 + integration).
- clippy (`--tests --benches`) and nightly `fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)