### PR TITLE
BINIUS-306: separate RoundEvaluator into SumcheckRoundEvaluator and MleCheckRoundEvaluator

### DIFF
--- a/crates/ip-prover/benches/bivariate_product.rs
+++ b/crates/ip-prover/benches/bivariate_product.rs
@@ -97,11 +97,7 @@ fn bench_shared_mlecheck_bivariate_product(c: &mut Criterion) {
 				|(mut transcript, a, b_multilinear, eval_point)| {
 					let mut store = MleStore::new(n_vars);
 					let cols = [a, b_multilinear].map(|col| store.push_owned(col));
-					// A single-claim evaluator reading the store's columns and one eq tracker
-					// registered for the claim's evaluation point.
-					let eq_tracker = store.register_eq_tracker(&eval_point);
-					let evaluator =
-						QuadraticMleEvaluator::new(cols, eq_tracker, product::<P>, product::<P>);
+					let evaluator = QuadraticMleEvaluator::new(cols, product::<P>, product::<P>);
 					let prover =
 						SharedMleCheckProver::new(store, [(eval_claim, evaluator)], eval_point);
 

--- a/crates/ip-prover/src/fracaddcheck.rs
+++ b/crates/ip-prover/src/fracaddcheck.rs
@@ -17,7 +17,7 @@ use crate::{
 		common::{MleCheckProver, SumcheckProver},
 		frac_add_mle::{self, FractionalBuffer},
 		mle_store::{ColId, MleStore},
-		round_evaluator::{RoundEvaluator, SharedMleCheckProver},
+		round_evaluator::{MleCheckRoundEvaluator, SharedMleCheckProver},
 	},
 };
 
@@ -31,7 +31,8 @@ pub type FracEvalClaim<F> = (MultilinearEvalClaim<F>, MultilinearEvalClaim<F>);
 /// Returned by `FracAddCheckProver::layer_prover`. It owns its four half-columns, so it is
 /// self-contained: a caller can drive it, batch it, or extend its store with more columns and
 /// evaluators (as the logUp* final layer does).
-pub type LayerProver<F, P> = SharedMleCheckProver<'static, F, P, Box<dyn RoundEvaluator<F, P>>>;
+pub type LayerProver<F, P> =
+	SharedMleCheckProver<'static, F, P, Box<dyn MleCheckRoundEvaluator<F, P>>>;
 
 /// Prover for the fractional addition protocol.
 ///
@@ -133,10 +134,9 @@ where
 		let [num_0, num_1] = store.push_split_half(num);
 		let [den_0, den_1] = store.push_split_half(den);
 		let cols = [num_0, num_1, den_0, den_1];
-		let (num_evaluator, den_evaluator) =
-			frac_add_mle::evaluators(&mut store, cols, num_claim.point.clone());
+		let (num_evaluator, den_evaluator) = frac_add_mle::evaluators(cols);
 
-		let claims_with_evaluators: [(F, Box<dyn RoundEvaluator<F, P>>); 2] = [
+		let claims_with_evaluators: [(F, Box<dyn MleCheckRoundEvaluator<F, P>>); 2] = [
 			(num_claim.eval, Box::new(num_evaluator)),
 			(den_claim.eval, Box::new(den_evaluator)),
 		];
@@ -534,9 +534,8 @@ where
 		FieldBuffer::<P>::from_values(&den_1s),
 	]
 	.map(|buffer| selector_store.push_owned(buffer));
-	let (selector_num, selector_den) =
-		frac_add_mle::evaluators(&mut selector_store, selector_cols, outer_coords.to_vec());
-	let selector_claims_with_evaluators: [(F, Box<dyn RoundEvaluator<F, P>>); 2] = [
+	let (selector_num, selector_den) = frac_add_mle::evaluators(selector_cols);
+	let selector_claims_with_evaluators: [(F, Box<dyn MleCheckRoundEvaluator<F, P>>); 2] = [
 		(num_eval, Box::new(selector_num)),
 		(den_eval, Box::new(selector_den)),
 	];

--- a/crates/ip-prover/src/logup_star/final_layer.rs
+++ b/crates/ip-prover/src/logup_star/final_layer.rs
@@ -21,7 +21,7 @@ use crate::{
 	fracaddcheck::{FracAddCheckProver, FracEvalClaim},
 	sumcheck::{
 		batch::batch_prove, bivariate_product_evaluator::BivariateProductEvaluator,
-		round_evaluator::RoundEvaluator,
+		round_evaluator::SumcheckRoundEvaluator,
 	},
 };
 
@@ -131,9 +131,9 @@ where
 	let t_0_col = prover.push_owned_column(t_0);
 	let t_1_col = prover.push_owned_column(t_1);
 	let product_0 = BivariateProductEvaluator::new([y_0_col, t_0_col]);
-	prover.add_evaluator(e_0, Box::new(product_0) as Box<dyn RoundEvaluator<F, P>>);
+	prover.add_evaluator(e_0, Box::new(product_0) as Box<dyn SumcheckRoundEvaluator<F, P>>);
 	let product_1 = BivariateProductEvaluator::new([y_1_col, t_1_col]);
-	prover.add_evaluator(e_1, Box::new(product_1) as Box<dyn RoundEvaluator<F, P>>);
+	prover.add_evaluator(e_1, Box::new(product_1) as Box<dyn SumcheckRoundEvaluator<F, P>>);
 
 	// Drive the one shared-store sumcheck.
 	//

--- a/crates/ip-prover/src/sumcheck/bivariate_product_evaluator.rs
+++ b/crates/ip-prover/src/sumcheck/bivariate_product_evaluator.rs
@@ -8,7 +8,7 @@ use itertools::izip;
 use super::{
 	mle_store::{ColId, EvaluationChunk, MleStore},
 	round_evals::WideRoundEvals2,
-	round_evaluator::{RoundEvaluator, SharedSumcheckProver},
+	round_evaluator::{SharedSumcheckProver, SumcheckRoundEvaluator},
 };
 
 /// Sumcheck round evaluator for a composite defined as the product of two store columns.
@@ -51,16 +51,12 @@ pub fn bivariate_product_prover<F: Field, P: PackedField<Scalar = F>>(
 	SharedSumcheckProver::new(store, [(sum, BivariateProductEvaluator::new(cols))])
 }
 
-impl<F: Field, P: PackedField<Scalar = F>> RoundEvaluator<F, P> for BivariateProductEvaluator {
+impl<F: Field, P: PackedField<Scalar = F>> SumcheckRoundEvaluator<F, P>
+	for BivariateProductEvaluator
+{
 	fn degree(&self) -> usize {
 		// Product of two multilinears: two sampled evaluations, `y_1` and `y_inf`.
 		2
-	}
-
-	fn claim_from_coeffs(&self, _store: &MleStore<'_, P>, coeffs: &RoundCoeffs<F>) -> F {
-		// The emitted round polynomial is a regular sumcheck polynomial, so the round claim is its
-		// sum over the endpoints {0, 1}. A plain product claim carries no eq factor.
-		coeffs.sum_over_endpoints()
 	}
 
 	fn accumulate(&self, chunk: &EvaluationChunk<'_, P>, accum: &mut [<P as WideMul>::Output]) {

--- a/crates/ip-prover/src/sumcheck/bivariate_product_mle.rs
+++ b/crates/ip-prover/src/sumcheck/bivariate_product_mle.rs
@@ -92,13 +92,8 @@ where
 	let mut store = MleStore::new(eval_point.len());
 	// The store checks that the buffer has exactly one more variable than itself.
 	let cols = store.push_split_half(buffer);
-	let eq_tracker = store.register_eq_tracker(&eval_point);
-	let evaluator = QuadraticMleEvaluator::new(
-		cols,
-		eq_tracker,
-		|[a, b]: [P; 2]| a * b,
-		|[a, b]: [P; 2]| a * b,
-	);
+	let evaluator =
+		QuadraticMleEvaluator::new(cols, |[a, b]: [P; 2]| a * b, |[a, b]: [P; 2]| a * b);
 	SharedMleCheckProver::new(store, [(eval_claim, evaluator)], eval_point)
 }
 

--- a/crates/ip-prover/src/sumcheck/frac_add_mle.rs
+++ b/crates/ip-prover/src/sumcheck/frac_add_mle.rs
@@ -4,9 +4,8 @@ use binius_field::{Field, PackedField};
 use binius_math::FieldBuffer;
 
 use crate::sumcheck::{
-	mle_store::{ColId, MleStore},
-	quadratic_mle_evaluator::QuadraticMleEvaluator,
-	round_evaluator::RoundEvaluator,
+	mle_store::ColId, quadratic_mle_evaluator::QuadraticMleEvaluator,
+	round_evaluator::MleCheckRoundEvaluator,
 };
 
 /// The numerator and denominator buffers of one fractional-addition layer.
@@ -18,32 +17,27 @@ pub type FractionalBuffer<P> = (FieldBuffer<P>, FieldBuffer<P>);
 /// fraction collections being added, split as either half of one layer buffer. The two claims —
 /// one evaluator each — are the fractional-addition numerator `num_a * den_b + num_b * den_a` over
 /// all four columns and the denominator `den_a * den_b` over `[den_a, den_b]`, both weighted by the
-/// equality indicator at `eval_point`. The evaluators share the store's eq tracker for
-/// `eval_point`. The two claimed evaluations are held by the driving prover, not the evaluators.
+/// equality indicator at the shared evaluation point. The driving [`SharedMleCheckProver`] owns
+/// that point's eq tracker and holds the two claimed evaluations, so the evaluators carry neither.
+///
+/// [`SharedMleCheckProver`]: crate::sumcheck::round_evaluator::SharedMleCheckProver
 pub fn evaluators<F, P>(
-	store: &mut MleStore<'_, P>,
 	cols: [ColId; 4],
-	eval_point: Vec<F>,
-) -> (impl RoundEvaluator<F, P> + 'static, impl RoundEvaluator<F, P> + 'static)
+) -> (impl MleCheckRoundEvaluator<F, P> + 'static, impl MleCheckRoundEvaluator<F, P> + 'static)
 where
 	F: Field,
 	P: PackedField<Scalar = F>,
 {
 	let [num_a, num_b, den_a, den_b] = cols;
-	// Both claims share the point, so register its tracker once and hand both evaluators the same
-	// id; the store then folds that tracker a single time per round.
-	let eq_tracker = store.register_eq_tracker(&eval_point);
 	// The fractional addition formulas are purely quadratic, so each infinity composition matches
 	// its regular composition.
 	let numerator = QuadraticMleEvaluator::new(
 		[num_a, num_b, den_a, den_b],
-		eq_tracker,
 		|[num_a, num_b, den_a, den_b]: [P; 4]| num_a * den_b + num_b * den_a,
 		|[num_a, num_b, den_a, den_b]: [P; 4]| num_a * den_b + num_b * den_a,
 	);
 	let denominator = QuadraticMleEvaluator::new(
 		[den_a, den_b],
-		eq_tracker,
 		|[den_a, den_b]: [P; 2]| den_a * den_b,
 		|[den_a, den_b]: [P; 2]| den_a * den_b,
 	);
@@ -71,7 +65,7 @@ mod tests {
 		batch::batch_prove,
 		common::SumcheckProver,
 		mle_store::MleStore,
-		round_evaluator::{RoundEvaluator, SharedSumcheckProver},
+		round_evaluator::{SharedSumcheckProver, SumcheckRoundEvaluator},
 	};
 
 	fn test_frac_add_sumcheck_prove_verify<F, P>(
@@ -196,12 +190,13 @@ mod tests {
 		let mut store = MleStore::new(n_vars);
 		let cols = [num_a.clone(), num_b.clone(), den_a.clone(), den_b.clone()]
 			.map(|col| store.push_owned(col));
-		let (num_evaluator, den_evaluator) = evaluators(&mut store, cols, eval_point.clone());
+		let (num_evaluator, den_evaluator) = evaluators(cols);
 
-		// Both evaluators share the point's eq tracker; recover its id for the sumcheck wrappers.
+		// Register the shared point's eq tracker for the sumcheck wrappers (a plain sumcheck prover
+		// knows nothing of eq indicators, so the wrappers hold the tracker themselves).
 		let eq_tracker = store.register_eq_tracker(&eval_point);
 		// Wrap each MLE-check evaluator so it emits sumcheck-compatible round polynomials.
-		let claims_with_evaluators: [(F, Box<dyn RoundEvaluator<F, P>>); 2] = [
+		let claims_with_evaluators: [(F, Box<dyn SumcheckRoundEvaluator<F, P>>); 2] = [
 			(eval_claims[0], Box::new(MleToSumCheckEvaluator::new(num_evaluator, eq_tracker))),
 			(eval_claims[1], Box::new(MleToSumCheckEvaluator::new(den_evaluator, eq_tracker))),
 		];

--- a/crates/ip-prover/src/sumcheck/mle_store.rs
+++ b/crates/ip-prover/src/sumcheck/mle_store.rs
@@ -3,7 +3,7 @@
 //! Shared multilinear column store for sumcheck round evaluators.
 //!
 //! An [`MleStore`] owns the equal-length multilinear columns that a group of
-//! [`RoundEvaluator`](super::round_evaluator::RoundEvaluator)s reads, along with the deduplicated
+//! [round evaluators](super::round_evaluator) reads, along with the deduplicated
 //! [`Gruen32`] equality-indicator trackers for MLE-check evaluation points. Columns enter the
 //! store either borrowed ([`MleStore::push`]) or owned ([`MleStore::push_owned`]) and are
 //! addressed by the returned [`ColId`], so several evaluators can read — and the store can fold —

--- a/crates/ip-prover/src/sumcheck/mle_to_sumcheck.rs
+++ b/crates/ip-prover/src/sumcheck/mle_to_sumcheck.rs
@@ -9,7 +9,7 @@ use crate::sumcheck::{
 	common::{MleCheckProver, SumcheckProver},
 	mle_store::{EqId, EvaluationChunk, MleStore},
 	round_evals::round_coeffs_by_eq,
-	round_evaluator::RoundEvaluator,
+	round_evaluator::{MleCheckRoundEvaluator, SumcheckRoundEvaluator},
 };
 
 /// Adaptor that exposes a `SumcheckProver` interface for an internal `MleCheckProver`.
@@ -90,21 +90,24 @@ impl<F: Field, InnerProver: MleCheckProver<F>> SumcheckProver<F>
 	}
 }
 
-/// Adaptor that turns an MLE-check [`RoundEvaluator`] into a regular sumcheck one.
+/// Adaptor that turns an [`MleCheckRoundEvaluator`] into a [`SumcheckRoundEvaluator`].
 ///
 /// This is the evaluator-level mirror of [`MleToSumCheckDecorator`], applying the same [Gruen24]
 /// technique: each round, the inner evaluator's prime round polynomials are multiplied by the
 /// linear equality term in the bound coordinate and by the accumulated equality prefix. It lets
 /// eq-weighted and plain claims live in one evaluator group behind a single
-/// [`SumcheckProver`](super::round_evaluator::SharedSumcheckProver).
+/// [`SharedSumcheckProver`].
 ///
-/// The accumulation pass is delegated to the inner evaluator untouched; only the interpolated
-/// polynomials and the claim bookkeeping change.
+/// Unlike a bare [`MleCheckRoundEvaluator`], whose driving [`SharedMleCheckProver`] owns the eq
+/// tracker, this wrapper runs under a [`SharedSumcheckProver`] that knows nothing of eq indicators.
+/// So the wrapper itself holds the [`EqId`] of the shared evaluation point's eq tracker, and
+/// supplies the round's eq chunk to [`MleCheckRoundEvaluator::accumulate`] and its alpha and
+/// equality prefix to [`MleCheckRoundEvaluator::interpolate`] — all read from that tracker, which
+/// the store folds in lockstep, so the wrapper keeps no copy of the point and no equality
+/// bookkeeping of its own.
 ///
-/// The wrapper holds only the [`EqId`] of the shared evaluation point's eq tracker. The round's
-/// alpha and the accumulated equality prefix are read from that tracker, which the store folds in
-/// lockstep — so the wrapper keeps no copy of the point and no equality bookkeeping of its own.
-///
+/// [`SharedSumcheckProver`]: super::round_evaluator::SharedSumcheckProver
+/// [`SharedMleCheckProver`]: super::round_evaluator::SharedMleCheckProver
 /// [Gruen24]: <https://eprint.iacr.org/2024/108>
 pub struct MleToSumCheckEvaluator<Inner> {
 	inner: Inner,
@@ -120,11 +123,11 @@ impl<Inner> MleToSumCheckEvaluator<Inner> {
 	}
 }
 
-impl<F, P, Inner> RoundEvaluator<F, P> for MleToSumCheckEvaluator<Inner>
+impl<F, P, Inner> SumcheckRoundEvaluator<F, P> for MleToSumCheckEvaluator<Inner>
 where
 	F: Field,
 	P: PackedField<Scalar = F>,
-	Inner: RoundEvaluator<F, P>,
+	Inner: MleCheckRoundEvaluator<F, P>,
 {
 	fn degree(&self) -> usize {
 		// The eq factor multiplies the emitted round polynomial, not the accumulator: the wide
@@ -132,14 +135,9 @@ where
 		self.inner.degree()
 	}
 
-	fn claim_from_coeffs(&self, _store: &MleStore<'_, P>, coeffs: &RoundCoeffs<F>) -> F {
-		// The emitted round polynomial is a regular sumcheck polynomial (the inner prime polynomial
-		// already multiplied by the equality factor), so its claim is the sum over the endpoints.
-		coeffs.sum_over_endpoints()
-	}
-
 	fn accumulate(&self, chunk: &EvaluationChunk<'_, P>, accum: &mut [<P as WideMul>::Output]) {
-		self.inner.accumulate(chunk, accum)
+		self.inner
+			.accumulate(chunk, chunk.eq(self.eq_tracker).to_ref(), accum)
 	}
 
 	fn interpolate(
@@ -152,14 +150,15 @@ where
 		// accumulated equality prefix. Recover `m` for the inner evaluator by dividing the prefix
 		// back out. (`invert_or_zero` mirrors the interpolation routines; the prefix is a product
 		// of non-degenerate equality factors for honest challenges.)
+		//
+		// alpha and the equality prefix are read from the shared eq tracker (the store has not yet
+		// folded this round, so the tracker is at the current round's alpha and prefix).
 		let eq_prefix = store.eq_prefix(self.eq_tracker);
-		let inner_claim = claim * eq_prefix.invert_or_zero();
-		let round_coeffs = self.inner.interpolate(store, accum, inner_claim);
-
-		// Multiply the round polynomial from the inner MLE-check evaluator by (X - α) and the
-		// equality prefix, both read from the shared eq tracker (the store has not yet folded this
-		// round, so the tracker is at the current round's alpha and prefix).
 		let alpha = store.eq_alpha(self.eq_tracker);
+		let inner_claim = claim * eq_prefix.invert_or_zero();
+		let round_coeffs = self.inner.interpolate(store, accum, inner_claim, alpha);
+
+		// Multiply the inner MLE-check round polynomial by (X - α) and the equality prefix.
 		round_coeffs_by_eq(&round_coeffs, alpha) * eq_prefix
 	}
 }

--- a/crates/ip-prover/src/sumcheck/quadratic_mle_evaluator.rs
+++ b/crates/ip-prover/src/sumcheck/quadratic_mle_evaluator.rs
@@ -2,12 +2,12 @@
 
 use binius_field::{Field, PackedField, WideMul};
 use binius_ip::sumcheck::RoundCoeffs;
-use binius_math::FieldBuffer;
+use binius_math::{FieldBuffer, FieldSlice};
 
 use super::{
-	mle_store::{ColId, ColumnChunk, EqId, EvaluationChunk, MleStore},
+	mle_store::{ColId, ColumnChunk, EvaluationChunk, MleStore},
 	round_evals::RoundEvals2,
-	round_evaluator::{RoundEvaluator, SharedMleCheckProver},
+	round_evaluator::{MleCheckRoundEvaluator, SharedMleCheckProver},
 };
 
 /// MLE-check round evaluator for one quadratic composition over N store columns.
@@ -23,8 +23,6 @@ use super::{
 pub struct QuadraticMleEvaluator<Composition, InfinityComposition, const N: usize> {
 	// Store columns holding the packed evaluations of the input multilinears.
 	cols: [ColId; N],
-	// The store's (possibly shared) eq-indicator tracker for `eval_point`.
-	eq_tracker: EqId,
 	// Full quadratic composition evaluated on the "x = 1" branch for each multilinear.
 	composition: Composition,
 	// Composition restricted to highest-degree terms for the "x = ∞" evaluation (Karatsuba).
@@ -34,27 +32,20 @@ pub struct QuadraticMleEvaluator<Composition, InfinityComposition, const N: usiz
 impl<Composition, InfinityComposition, const N: usize>
 	QuadraticMleEvaluator<Composition, InfinityComposition, N>
 {
-	/// Creates an evaluator over `cols` reading the eq tracker `eq_tracker` from `store`.
+	/// Creates an evaluator over the store columns `cols`.
 	///
-	/// The caller registers the evaluation point on the store (via
-	/// [`MleStore::register_eq_tracker`]) and passes the resulting [`EqId`]; several evaluators
-	/// sharing a point pass the same id, so the store folds that tracker once. The evaluator holds
-	/// only the tracker id and queries the store for the round's alpha and remaining-variable count
-	/// as they change — it keeps no copy of the point.
-	///
-	/// The claimed evaluation is held by the driving prover (see [`SharedMleCheckProver`]), not the
-	/// evaluator.
+	/// The evaluator holds no eq-indicator tracker and no copy of the evaluation point: the driving
+	/// [`SharedMleCheckProver`] owns the shared point's tracker and passes the round's eq chunk and
+	/// coordinate in. The claimed evaluation is likewise held by the prover, not the evaluator.
 	///
 	/// # Arguments
 	///
 	/// * `cols` - The N store columns the composition reads.
-	/// * `eq_tracker` - The registered eq tracker for the claim's evaluation point.
 	/// * `composition` - Evaluates the quadratic composition of the N column values.
 	/// * `infinity_composition` - The composition restricted to its highest-degree terms, for the
 	///   Karatsuba evaluation at infinity.
 	pub fn new(
 		cols: [ColId; N],
-		eq_tracker: EqId,
 		composition: Composition,
 		infinity_composition: InfinityComposition,
 	) -> Self {
@@ -63,7 +54,6 @@ impl<Composition, InfinityComposition, const N: usize>
 
 		Self {
 			cols,
-			eq_tracker,
 			composition,
 			infinity_composition,
 		}
@@ -117,13 +107,11 @@ where
 	let mut store = MleStore::new(eval_point.len());
 	// Hand each column to the store, which checks its variable count against the point length.
 	let cols = multilinears.map(|col| store.push_owned(col));
-	// Register the evaluation point's equality-indicator tracker once for the sole evaluator.
-	let eq_tracker = store.register_eq_tracker(&eval_point);
-	let evaluator = QuadraticMleEvaluator::new(cols, eq_tracker, composition, infinity_composition);
+	let evaluator = QuadraticMleEvaluator::new(cols, composition, infinity_composition);
 	SharedMleCheckProver::new(store, [(eval_claim, evaluator)], eval_point)
 }
 
-impl<F, P, Composition, InfinityComposition, const N: usize> RoundEvaluator<F, P>
+impl<F, P, Composition, InfinityComposition, const N: usize> MleCheckRoundEvaluator<F, P>
 	for QuadraticMleEvaluator<Composition, InfinityComposition, N>
 where
 	F: Field,
@@ -136,16 +124,12 @@ where
 		2
 	}
 
-	fn claim_from_coeffs(&self, store: &MleStore<'_, P>, coeffs: &RoundCoeffs<F>) -> F {
-		// The emitted round polynomial is the prime (eq-factored) MLE-check polynomial, so its
-		// claim is the eq-lerp of its endpoints at the round's alpha.
-		let alpha = store.eq_alpha(self.eq_tracker);
-		coeffs.lerp_over_endpoints(alpha)
-	}
-
-	fn accumulate(&self, chunk: &EvaluationChunk<'_, P>, accum: &mut [<P as WideMul>::Output]) {
-		let eq_chunk = chunk.eq(self.eq_tracker);
-
+	fn accumulate(
+		&self,
+		chunk: &EvaluationChunk<'_, P>,
+		eq_ind: FieldSlice<'_, P>,
+		accum: &mut [<P as WideMul>::Output],
+	) {
 		// Each column arrives split into low/high halves for the top variable: the low half
 		// corresponds to x=0, the high half to x=1.
 		let cols: [&ColumnChunk<'_, P>; N] = self.cols.map(|id| chunk.col(id));
@@ -153,7 +137,7 @@ where
 		// The evaluator's run holds `y_1` in slot 0 and `y_inf` in slot 1.
 		let mut y_1 = <P as WideMul>::Output::default();
 		let mut y_inf = <P as WideMul>::Output::default();
-		for (idx, &eq_i) in eq_chunk.as_ref().iter().enumerate() {
+		for (idx, &eq_i) in eq_ind.as_ref().iter().enumerate() {
 			// Gather the idx-th evaluations of every multilinear at both halves.
 			let mut evals_1 = [P::default(); N];
 			let mut evals_inf = [P::default(); N];
@@ -184,14 +168,14 @@ where
 		store: &MleStore<'_, P>,
 		accum: &[<P as WideMul>::Output],
 		claim: F,
+		alpha: F,
 	) -> RoundCoeffs<F> {
 		// The store has not yet folded this round, so its remaining-variable count is this round's.
 		let n_vars_remaining = store.n_vars();
 		assert!(n_vars_remaining > 0);
 
 		// Reduce the wide accumulators, sum packed lanes into scalars, then interpolate. `claim` is
-		// this round's prime eval; the round's coordinate ties it to the original evaluation point.
-		let alpha = store.eq_alpha(self.eq_tracker);
+		// this round's prime eval; `alpha`, this round's eq coordinate, ties it to the point.
 		RoundEvals2 {
 			y_1: P::reduce(accum[0].clone()),
 			y_inf: P::reduce(accum[1].clone()),

--- a/crates/ip-prover/src/sumcheck/round_evaluator.rs
+++ b/crates/ip-prover/src/sumcheck/round_evaluator.rs
@@ -2,38 +2,46 @@
 
 //! Round evaluators over a shared [`MleStore`] and the provers that drive them.
 //!
-//! A [`RoundEvaluator`] holds the per-round-polynomial logic for one composite claim over store
+//! A round evaluator holds the per-round-polynomial logic for one composite claim over store
 //! columns. Evaluators hold [`ColId`]s and receive column data by argument; they hold no mutable
 //! per-round state — they neither fold nor track the round claim. The driving prover owns the
 //! `RoundState` machine (the claim ↔ coeffs alternation) for each evaluator, and the store folds
 //! the columns (see the [`mle_store`](super::mle_store) module documentation).
 //!
-//! [`SharedSumcheckProver`] adapts a store plus a list of evaluators — one per claim — to the
-//! existing [`SumcheckProver`] interface, and [`SharedMleCheckProver`] to the [`MleCheckProver`]
-//! interface, so they batch alongside standalone provers unchanged.
+//! There are two evaluator traits, one per protocol:
+//! - [`SumcheckRoundEvaluator`], driven by [`SharedSumcheckProver`], emits regular sumcheck round
+//!   polynomials.
+//! - [`MleCheckRoundEvaluator`], driven by [`SharedMleCheckProver`], emits the eq-factored prime
+//!   round polynomials of the MLE-check protocol. Its claims all share one evaluation point, so the
+//!   prover — not the evaluator — owns that point's eq-indicator tracker and passes the round's eq
+//!   chunk and coordinate to the evaluator.
+//!
+//! Both provers adapt a store plus a list of evaluators — one per claim — to the [`SumcheckProver`]
+//! interface (and [`SharedMleCheckProver`] additionally to [`MleCheckProver`]), so they batch
+//! alongside standalone provers unchanged.
 
 use std::iter;
 
 use auto_impl::auto_impl;
 use binius_field::{Field, PackedField, WideMul};
 use binius_ip::sumcheck::RoundCoeffs;
-use binius_math::FieldBuffer;
+use binius_math::{FieldBuffer, FieldSlice};
 
 use super::{
 	MleToSumCheckEvaluator,
 	common::{MleCheckProver, SumcheckProver},
-	mle_store::{ColId, EvaluationChunk, MleStore},
+	mle_store::{ColId, EqId, EvaluationChunk, MleStore},
 	round_state::RoundState,
 };
 
-/// Per-round-polynomial logic for one composite claim over store columns.
+/// Per-round-polynomial logic for one plain sumcheck claim over store columns.
 ///
-/// The driving prover makes one parallel pass over column chunks per round; the hot loops stay
-/// monomorphized inside each evaluator and only the per-chunk [`Self::accumulate`] entry is
-/// virtual. Within a round the calls are: [`Self::accumulate`] from parallel workers into
+/// The driving [`SharedSumcheckProver`] makes one parallel pass over column chunks per round; the
+/// hot loops stay monomorphized inside each evaluator and only the per-chunk [`Self::accumulate`]
+/// entry is virtual. Within a round the calls are: [`Self::accumulate`] from parallel workers into
 /// per-worker accumulator slices, then [`Self::interpolate`] once on the slot-wise summed slice.
 /// The driving prover, not the evaluator, holds the round claim and reduces the round polynomial
-/// against the verifier challenge; see [`SharedSumcheckProver`].
+/// against the verifier challenge.
 ///
 /// The accumulator is a flat slice of [`Self::degree`] wide (unreduced)
 /// [`WideMul::Output`](WideMul::Output) slots. The driving prover owns the buffer, sizes it from
@@ -42,15 +50,15 @@ use super::{
 /// evaluator's run is private to that evaluator.
 ///
 /// Evaluators are stateless across rounds: they hold no round claim and never fold. The prover
-/// passes the round claim into [`Self::interpolate`] and recovers it back out of an emitted round
-/// polynomial via [`Self::claim_from_coeffs`], so the whole claim ↔ coeffs state machine lives in
-/// the prover's `RoundState`.
+/// passes the round claim into [`Self::interpolate`] and recovers it back out of the emitted round
+/// polynomial itself (as $R(0) + R(1)$), so the whole claim ↔ coeffs state machine lives in the
+/// prover's `RoundState`.
 ///
 /// The `auto_impl(Box)` derive forwards the trait through `Box`, so a heterogeneous group of
-/// evaluators can drive a shared prover as `Vec<Box<dyn RoundEvaluator<F, P>>>` while a homogeneous
-/// group avoids boxing.
+/// evaluators can drive a shared prover as `Vec<Box<dyn SumcheckRoundEvaluator<F, P>>>` while a
+/// homogeneous group avoids boxing.
 #[auto_impl(Box)]
-pub trait RoundEvaluator<F: Field, P: PackedField<Scalar = F>>: Send + Sync {
+pub trait SumcheckRoundEvaluator<F: Field, P: PackedField<Scalar = F>>: Send + Sync {
 	/// The number of accumulator slots this evaluator's claim uses.
 	///
 	/// This is the count of sampled round-polynomial evaluations the accumulation pass collects;
@@ -60,22 +68,12 @@ pub trait RoundEvaluator<F: Field, P: PackedField<Scalar = F>>: Send + Sync {
 	/// the prime degree, not the emitted round-polynomial degree.
 	fn degree(&self) -> usize;
 
-	/// Recovers this round's claim from an emitted round polynomial.
-	///
-	/// The prover holds the round claim directly before [`Self::interpolate`] runs, but once it
-	/// has replaced that claim with the round coefficients it recovers the (unchanged) claim from
-	/// them for [`SumcheckProver::round_claim`]. A regular sumcheck evaluator recovers it as
-	/// $R(0) + R(1)$ ([`RoundCoeffs::sum_over_endpoints`]); an MLE-check evaluator emitting prime
-	/// polynomials recovers it as $(1 - \alpha) R(0) + \alpha R(1)$
-	/// ([`RoundCoeffs::lerp_over_endpoints`]) with $\alpha$ read from the shared `store`.
-	fn claim_from_coeffs(&self, store: &MleStore<'_, P>, coeffs: &RoundCoeffs<F>) -> F;
-
 	/// Accumulates one chunk of the halved hypercube into `accum`.
 	///
 	/// The driving prover prepares `chunk` — the split, per-chunk column halves and eq-indicator
 	/// expansions — so the evaluator only reads its columns by [`ColId`] and eq trackers by
-	/// [`EqId`](super::mle_store::EqId). `accum` is this evaluator's run of [`Self::degree`] wide
-	/// slots, zero-initialized on the first chunk and carried across the worker's chunks.
+	/// [`EqId`]. `accum` is this evaluator's run of [`Self::degree`] wide slots, zero-initialized
+	/// on the first chunk and carried across the worker's chunks.
 	fn accumulate(&self, chunk: &EvaluationChunk<'_, P>, accum: &mut [<P as WideMul>::Output]);
 
 	/// Interpolates this round's polynomial from the slot-wise summed accumulator slice and the
@@ -93,14 +91,74 @@ pub trait RoundEvaluator<F: Field, P: PackedField<Scalar = F>>: Send + Sync {
 	) -> RoundCoeffs<F>;
 }
 
+/// Per-round-polynomial logic for one MLE-check claim over store columns.
+///
+/// This is the MLE-check counterpart of [`SumcheckRoundEvaluator`], emitting the prime
+/// (eq-factored) round polynomials of the MLE-check protocol. It differs in two ways, both because
+/// every claim of a [`SharedMleCheckProver`] shares one evaluation point whose eq-indicator tracker
+/// the prover — not the evaluator — owns:
+/// - [`Self::accumulate`] receives the round's eq-indicator chunk `eq_ind` as a separate argument,
+///   rather than the evaluator looking it up on the chunk by a stored tracker id.
+/// - [`Self::interpolate`] receives the round's eq coordinate `alpha`.
+///
+/// So the evaluator stores no eq tracker id and holds no copy of the point. Everything else matches
+/// [`SumcheckRoundEvaluator`]: stateless across rounds, degree-sized accumulator slots owned by the
+/// prover, one virtual [`Self::accumulate`] entry per chunk.
+#[auto_impl(Box)]
+pub trait MleCheckRoundEvaluator<F: Field, P: PackedField<Scalar = F>>: Send + Sync {
+	/// The number of accumulator slots this evaluator's claim uses. See
+	/// [`SumcheckRoundEvaluator::degree`].
+	fn degree(&self) -> usize;
+
+	/// Accumulates one chunk of the halved hypercube into `accum`.
+	///
+	/// `eq_ind` is the round's eq-indicator chunk (the prover looks it up once and hands it to
+	/// every evaluator); the evaluator weights its composition by it. Otherwise as
+	/// [`SumcheckRoundEvaluator::accumulate`].
+	fn accumulate(
+		&self,
+		chunk: &EvaluationChunk<'_, P>,
+		eq_ind: FieldSlice<'_, P>,
+		accum: &mut [<P as WideMul>::Output],
+	);
+
+	/// Interpolates this round's prime polynomial from the accumulator, round claim, and round
+	/// coordinate `alpha`.
+	///
+	/// As [`SumcheckRoundEvaluator::interpolate`], but the round coordinate is passed in as `alpha`
+	/// rather than read from a stored eq tracker; `store` supplies only the remaining-variable
+	/// count.
+	fn interpolate(
+		&self,
+		store: &MleStore<'_, P>,
+		accum: &[<P as WideMul>::Output],
+		claim: F,
+		alpha: F,
+	) -> RoundCoeffs<F>;
+}
+
 /// Maximum log2 chunk size of the parallel round pass.
 ///
 /// Chunked accumulation keeps the equality-indicator chunk resident in L1 cache while all
 /// evaluators read it, mirroring the chunking of the pre-store quadratic prover.
 const MAX_CHUNK_VARS: usize = 12;
 
-/// A [`SumcheckProver`] over a shared [`MleStore`] and a list of [`RoundEvaluator`]s, one per
-/// claim.
+/// Prefix sums of a group of evaluators' accumulator-slot counts.
+///
+/// The returned Vec has one more entry than there are evaluators; `offsets[i]..offsets[i + 1]` is
+/// evaluator `i`'s run in the flat accumulator buffer, and the last entry is its total length. Both
+/// shared provers lay out their per-worker accumulator this way.
+fn accum_offsets(degrees: impl IntoIterator<Item = usize>) -> Vec<usize> {
+	iter::once(0)
+		.chain(degrees.into_iter().scan(0, |acc, degree| {
+			*acc += degree;
+			Some(*acc)
+		}))
+		.collect()
+}
+
+/// A [`SumcheckProver`] over a shared [`MleStore`] and a list of [`SumcheckRoundEvaluator`]s, one
+/// per claim.
 ///
 /// Each round makes one parallel pass over the store's column chunks, feeding every evaluator,
 /// and lists the round polynomials in evaluator registration order. [`Self::fold`] folds each
@@ -113,9 +171,9 @@ pub struct SharedSumcheckProver<'a, P: PackedField, Evaluator> {
 	///
 	/// Holds each evaluator's current round claim before its round polynomial is produced, and the
 	/// produced round coefficients afterwards. The prover — not the evaluator — advances this
-	/// state: [`SumcheckProver::execute`] hands the claim to [`RoundEvaluator::interpolate`] and
-	/// stores the resulting coefficients; [`SumcheckProver::fold`] reduces them against the
-	/// challenge back to a claim.
+	/// state: [`SumcheckProver::execute`] hands the claim to
+	/// [`SumcheckRoundEvaluator::interpolate`] and stores the resulting coefficients;
+	/// [`SumcheckProver::fold`] reduces them against the challenge back to a claim.
 	round_states: Vec<RoundState<RoundCoeffs<P::Scalar>, P::Scalar>>,
 	/// A fold challenge whose store fold has been deferred so the next [`SumcheckProver::execute`]
 	/// can fuse it into that round's read pass (see [`MleStore::map_reduce_with_fold`]). Only the
@@ -128,7 +186,7 @@ impl<'a, F, P, Evaluator> SharedSumcheckProver<'a, P, Evaluator>
 where
 	F: Field,
 	P: PackedField<Scalar = F>,
-	Evaluator: RoundEvaluator<F, P>,
+	Evaluator: SumcheckRoundEvaluator<F, P>,
 {
 	/// Creates a prover from a store and the evaluators reading its columns, each paired with its
 	/// initial claim — one `(claim, evaluator)` per claim.
@@ -173,26 +231,13 @@ where
 		self.evaluators.push(evaluator);
 		self.round_states.push(RoundState::Claim(claim));
 	}
-
-	/// Prefix sums of each evaluator's [`RoundEvaluator::degree`] slot count.
-	///
-	/// The returned Vec has one more entry than there are evaluators; `offsets[i]..offsets[i + 1]`
-	/// is evaluator `i`'s run in the flat accumulator buffer, and the last entry is its length.
-	fn accum_offsets(&self) -> Vec<usize> {
-		iter::once(0)
-			.chain(self.evaluators.iter().scan(0, |acc, evaluator| {
-				*acc += evaluator.degree();
-				Some(*acc)
-			}))
-			.collect()
-	}
 }
 
 impl<F, P, Evaluator> SumcheckProver<F> for SharedSumcheckProver<'_, P, Evaluator>
 where
 	F: Field,
 	P: PackedField<Scalar = F>,
-	Evaluator: RoundEvaluator<F, P>,
+	Evaluator: SumcheckRoundEvaluator<F, P>,
 {
 	fn n_vars(&self) -> usize {
 		// A buffered challenge is a fold that has not yet reached the store, so the logical
@@ -205,12 +250,13 @@ where
 	}
 
 	fn round_claim(&self) -> Vec<F> {
-		// The claim is held directly before this round's polynomial is produced, and recovered from
-		// that polynomial afterwards (each evaluator knows how to invert its own emission).
-		iter::zip(&self.evaluators, &self.round_states)
-			.map(|(evaluator, state)| match state {
+		// The claim is held directly before this round's polynomial is produced, and afterwards
+		// recovered from that (regular sumcheck) polynomial as its sum over the endpoints {0, 1}.
+		self.round_states
+			.iter()
+			.map(|state| match state {
 				RoundState::Claim(claim) => *claim,
-				RoundState::Coeffs(coeffs) => evaluator.claim_from_coeffs(&self.store, coeffs),
+				RoundState::Coeffs(coeffs) => coeffs.sum_over_endpoints(),
 			})
 			.collect()
 	}
@@ -229,7 +275,7 @@ where
 		// Each evaluator owns a contiguous run of `degree` wide slots in one flat per-worker
 		// buffer; `offsets` holds the run boundaries as a prefix sum, so `offsets[i]..offsets[i +
 		// 1]` is evaluator `i`'s slice.
-		let offsets = self.accum_offsets();
+		let offsets = accum_offsets(self.evaluators.iter().map(|evaluator| evaluator.degree()));
 		let total_slots = *offsets
 			.last()
 			.expect("offsets has one entry per evaluator, plus one");
@@ -304,13 +350,26 @@ where
 	}
 }
 
-/// A [`MleCheckProver`] over a shared [`MleStore`] and a group of [`RoundEvaluator`]s.
+/// A [`MleCheckProver`] over a shared [`MleStore`] and a group of [`MleCheckRoundEvaluator`]s.
 ///
-/// This is the MLE-check flavor of [`SharedSumcheckProver`]: every evaluator's claim shares the
-/// prover's evaluation point, and the round polynomials are the eq-factored prime polynomials of
-/// the MLE-check protocol.
+/// This is the MLE-check counterpart of [`SharedSumcheckProver`]: every evaluator's claim shares
+/// the prover's evaluation point, and the round polynomials are the eq-factored prime polynomials
+/// of the MLE-check protocol. Because the point is shared, the prover owns its eq-indicator tracker
+/// and hands the round's eq chunk and coordinate to the evaluators, which therefore store no
+/// tracker id.
 pub struct SharedMleCheckProver<'a, F: Field, P: PackedField<Scalar = F>, Evaluator> {
-	inner: SharedSumcheckProver<'a, P, Evaluator>,
+	store: MleStore<'a, P>,
+	evaluators: Vec<Evaluator>,
+	/// The claim ↔ round-coeffs state machine, one entry per evaluator; see the field of the same
+	/// name on [`SharedSumcheckProver`].
+	round_states: Vec<RoundState<RoundCoeffs<F>, F>>,
+	/// The shared evaluation point's eq-indicator tracker, folded by the store each round. The
+	/// prover reads the round's eq chunk and coordinate `alpha` from it and passes them to the
+	/// evaluators.
+	eq_tracker: EqId,
+	/// A fold challenge whose store fold is deferred; see the field of the same name on
+	/// [`SharedSumcheckProver`].
+	buffered_challenge: Option<F>,
 	eval_point: Vec<F>,
 }
 
@@ -318,13 +377,13 @@ impl<'a, F, P, Evaluator> SharedMleCheckProver<'a, F, P, Evaluator>
 where
 	F: Field,
 	P: PackedField<Scalar = F>,
-	Evaluator: RoundEvaluator<F, P>,
+	Evaluator: MleCheckRoundEvaluator<F, P>,
 {
 	/// Creates a prover from a store, the evaluators reading its columns each paired with its
 	/// initial claim — one `(claim, evaluator)` per claim — and the evaluation point shared by all
 	/// of the evaluators' claims.
 	pub fn new(
-		store: MleStore<'a, P>,
+		mut store: MleStore<'a, P>,
 		claims_with_evaluators: impl IntoIterator<Item = (F, Evaluator)>,
 		eval_point: Vec<F>,
 	) -> Self {
@@ -334,8 +393,19 @@ where
 			store.n_vars(),
 			"evaluation point length must equal the store's number of variables"
 		);
+		// Every claim shares the point, so register its eq-indicator tracker once; the prover owns
+		// it and supplies the round eq chunk and coordinate to each evaluator.
+		let eq_tracker = store.register_eq_tracker(&eval_point);
+		let (round_states, evaluators) = claims_with_evaluators
+			.into_iter()
+			.map(|(claim, evaluator)| (RoundState::Claim(claim), evaluator))
+			.unzip();
 		Self {
-			inner: SharedSumcheckProver::new(store, claims_with_evaluators),
+			store,
+			evaluators,
+			round_states,
+			eq_tracker,
+			buffered_challenge: None,
 			eval_point,
 		}
 	}
@@ -347,37 +417,35 @@ where
 	/// This lets the eq-weighted fractional claims batch in one evaluator group alongside plain
 	/// sumcheck claims over the same store: the logUp* final layer converts the popped table
 	/// layer's prover, then adds its product evaluators to it. The store and its columns carry over
-	/// untouched; only the evaluators are wrapped.
+	/// untouched; only the evaluators are wrapped, sharing this prover's eq tracker.
 	///
 	/// [Gruen24]: <https://eprint.iacr.org/2024/108>
-	pub fn into_shared_sumcheck(self) -> SharedSumcheckProver<'a, P, Box<dyn RoundEvaluator<F, P>>>
+	pub fn into_shared_sumcheck(
+		self,
+	) -> SharedSumcheckProver<'a, P, Box<dyn SumcheckRoundEvaluator<F, P>>>
 	where
 		Evaluator: 'static,
 	{
-		let Self { inner, eval_point } = self;
-		// Conversion happens before proving starts, so no fold challenge is buffered yet and every
-		// round state is still an unreduced initial claim.
-		let SharedSumcheckProver {
-			mut store,
+		let Self {
+			store,
 			evaluators,
 			round_states,
+			eq_tracker,
 			buffered_challenge: _,
-		} = inner;
-		// Every claim of an MLE-check prover shares the prover's evaluation point, so its eq
-		// tracker is already registered on the store (by the evaluators reading it). Recover that
-		// shared id — `register_eq_tracker` deduplicates — and hand it to each wrapper, which
-		// reads the round's alpha and equality prefix from the tracker the store folds.
-		let eq_tracker = store.register_eq_tracker(&eval_point);
+			eval_point: _,
+		} = self;
+		// Wrap each MLE-check evaluator so it emits sumcheck round polynomials, handing it the
+		// shared eq tracker the store folds. Conversion happens before proving starts, so no fold
+		// challenge is buffered yet, and — since no variable has been folded — the equality
+		// prefix is one and each wrapper's sumcheck claim equals the inner MLE-check claim it
+		// carries over unchanged.
 		let evaluators = evaluators
 			.into_iter()
 			.map(|evaluator| {
 				Box::new(MleToSumCheckEvaluator::new(evaluator, eq_tracker))
-					as Box<dyn RoundEvaluator<F, P>>
+					as Box<dyn SumcheckRoundEvaluator<F, P>>
 			})
 			.collect();
-		// The wrappers emit the same claims: at the point of conversion no variable has been
-		// folded, so the equality prefix is one and the sumcheck claim equals the inner MLE-check
-		// claim.
 		SharedSumcheckProver {
 			store,
 			evaluators,
@@ -391,30 +459,105 @@ impl<F, P, Evaluator> SumcheckProver<F> for SharedMleCheckProver<'_, F, P, Evalu
 where
 	F: Field,
 	P: PackedField<Scalar = F>,
-	Evaluator: RoundEvaluator<F, P>,
+	Evaluator: MleCheckRoundEvaluator<F, P>,
 {
 	fn n_vars(&self) -> usize {
-		self.inner.n_vars()
+		// A buffered challenge is a fold that has not yet reached the store, so the logical
+		// remaining-variable count is one below the store's until the next execute applies it.
+		self.store.n_vars() - self.buffered_challenge.is_some() as usize
 	}
 
 	fn n_claims(&self) -> usize {
-		self.inner.n_claims()
+		self.evaluators.len()
 	}
 
 	fn round_claim(&self) -> Vec<F> {
-		self.inner.round_claim()
+		// The claim is held directly before this round's polynomial is produced, and afterwards
+		// recovered from that prime polynomial as the eq-lerp of its endpoints at the round
+		// coordinate.
+		let alpha = self.store.eq_alpha(self.eq_tracker);
+		self.round_states
+			.iter()
+			.map(|state| match state {
+				RoundState::Claim(claim) => *claim,
+				RoundState::Coeffs(coeffs) => coeffs.lerp_over_endpoints(alpha),
+			})
+			.collect()
 	}
 
 	fn execute(&mut self) -> Vec<RoundCoeffs<F>> {
-		self.inner.execute()
+		let n_vars_remaining = self.n_vars();
+		assert!(n_vars_remaining > 0);
+
+		// One parallel pass over the halved hypercube feeds every evaluator; see
+		// [`SharedSumcheckProver::execute`].
+		let chunk_vars = (n_vars_remaining - 1).min(MAX_CHUNK_VARS.max(P::LOG_WIDTH));
+		let offsets = accum_offsets(self.evaluators.iter().map(|evaluator| evaluator.degree()));
+		let total_slots = *offsets
+			.last()
+			.expect("offsets has one entry per evaluator, plus one");
+
+		let buffered_challenge = self.buffered_challenge.take();
+		let evaluators = &self.evaluators;
+		let eq_tracker = self.eq_tracker;
+		let store = &mut self.store;
+		let map = |chunk: EvaluationChunk<'_, P>| {
+			// The eq-indicator chunk is shared by every evaluator: look it up once, then hand each
+			// a borrowing view.
+			let eq_ind = chunk.eq(eq_tracker);
+			let mut accum = vec![Default::default(); total_slots];
+			for (evaluator, window) in iter::zip(evaluators, offsets.windows(2)) {
+				evaluator.accumulate(&chunk, eq_ind.to_ref(), &mut accum[window[0]..window[1]]);
+			}
+			accum
+		};
+		let reduce = |mut lhs: Vec<<P as WideMul>::Output>, rhs: Vec<<P as WideMul>::Output>| {
+			for (dst, src) in iter::zip(&mut lhs, rhs) {
+				*dst += src;
+			}
+			lhs
+		};
+		let accum = match buffered_challenge {
+			Some(challenge) => store.map_reduce_with_fold(chunk_vars, challenge, map, reduce),
+			None => store.map_reduce(chunk_vars, map, reduce),
+		};
+
+		// Each evaluator interpolates its prime round polynomial from its claim and the round
+		// coordinate; the prover then records the coefficients for the coming fold.
+		let store = &self.store;
+		let alpha = store.eq_alpha(self.eq_tracker);
+		let round_coeffs: Vec<RoundCoeffs<F>> =
+			iter::zip(iter::zip(&self.evaluators, &self.round_states), offsets.windows(2))
+				.map(|((evaluator, state), window)| {
+					let claim = *state.claim();
+					evaluator.interpolate(store, &accum[window[0]..window[1]], claim, alpha)
+				})
+				.collect();
+		for (state, coeffs) in iter::zip(&mut self.round_states, &round_coeffs) {
+			*state = RoundState::Coeffs(coeffs.clone());
+		}
+		round_coeffs
 	}
 
 	fn fold(&mut self, challenge: F) {
-		self.inner.fold(challenge)
+		// Reduce each evaluator's prime round polynomial against the challenge to form its next
+		// claim; the store's column and eq fold is deferred to the next execute.
+		for state in &mut self.round_states {
+			let claim = state.coeffs().evaluate(challenge);
+			*state = RoundState::Claim(claim);
+		}
+		debug_assert!(
+			self.buffered_challenge.is_none(),
+			"fold called twice without an intervening execute"
+		);
+		self.buffered_challenge = Some(challenge);
 	}
 
-	fn finish(self) -> Vec<F> {
-		self.inner.finish()
+	fn finish(mut self) -> Vec<F> {
+		if let Some(challenge) = self.buffered_challenge.take() {
+			self.store.fold(challenge);
+		}
+		self.store.final_evals()
 	}
 }
 
@@ -422,10 +565,10 @@ impl<F, P, Evaluator> MleCheckProver<F> for SharedMleCheckProver<'_, F, P, Evalu
 where
 	F: Field,
 	P: PackedField<Scalar = F>,
-	Evaluator: RoundEvaluator<F, P>,
+	Evaluator: MleCheckRoundEvaluator<F, P>,
 {
 	fn eval_point(&self) -> &[F] {
-		&self.eval_point[..self.inner.n_vars()]
+		&self.eval_point[..self.n_vars()]
 	}
 }
 
@@ -512,11 +655,11 @@ mod tests {
 		cols: &'a [FieldBuffer<P>; 4],
 		eval_point: &[F],
 		claims: [F; 2],
-	) -> SharedMleCheckProver<'a, F, P, Box<dyn RoundEvaluator<F, P>>> {
+	) -> SharedMleCheckProver<'a, F, P, Box<dyn MleCheckRoundEvaluator<F, P>>> {
 		let mut store = MleStore::new(eval_point.len());
 		let col_ids = cols.each_ref().map(|col| store.push(col.to_ref()));
-		let (num_ev, den_ev) = frac_add_mle::evaluators(&mut store, col_ids, eval_point.to_vec());
-		let claims_with_evaluators: [(F, Box<dyn RoundEvaluator<F, P>>); 2] =
+		let (num_ev, den_ev) = frac_add_mle::evaluators(col_ids);
+		let claims_with_evaluators: [(F, Box<dyn MleCheckRoundEvaluator<F, P>>); 2] =
 			[(claims[0], Box::new(num_ev)), (claims[1], Box::new(den_ev))];
 		SharedMleCheckProver::new(store, claims_with_evaluators, eval_point.to_vec())
 	}
@@ -609,12 +752,10 @@ mod tests {
 				[&y_0, &y_1, &d_0, &d_1, &t_0, &t_1].map(|col| store.push(col.to_ref()));
 
 			// The eq-weighted fractional evaluators, wrapped so they emit sumcheck round
-			// polynomials.
-			let (num_evaluator, den_evaluator) = frac_add_mle::evaluators(
-				&mut store,
-				[y_0_col, y_1_col, d_0_col, d_1_col],
-				z.to_vec(),
-			);
+			// polynomials. The wrappers, driven by a plain sumcheck prover, hold the shared eq
+			// tracker themselves.
+			let (num_evaluator, den_evaluator) =
+				frac_add_mle::evaluators([y_0_col, y_1_col, d_0_col, d_1_col]);
 			let eq_tracker = store.register_eq_tracker(&z);
 			let num_evaluator = MleToSumCheckEvaluator::new(num_evaluator, eq_tracker);
 			let den_evaluator = MleToSumCheckEvaluator::new(den_evaluator, eq_tracker);
@@ -625,7 +766,7 @@ mod tests {
 
 			// Claims paired with evaluators in order: the two fractional claims, then the two
 			// product sums.
-			let claims_with_evaluators: [(F, Box<dyn RoundEvaluator<F, P>>); 4] = [
+			let claims_with_evaluators: [(F, Box<dyn SumcheckRoundEvaluator<F, P>>); 4] = [
 				(frac_claims[0], Box::new(num_evaluator)),
 				(frac_claims[1], Box::new(den_evaluator)),
 				(e_0, Box::new(product_0)),

--- a/crates/m4-prover/src/prove.rs
+++ b/crates/m4-prover/src/prove.rs
@@ -10,7 +10,7 @@ use binius_ip_prover::sumcheck::{
 	batch::batch_prove_and_write_evals,
 	mle_store::MleStore,
 	quadratic_mle_evaluator::QuadraticMleEvaluator,
-	round_evaluator::{RoundEvaluator, SharedSumcheckProver},
+	round_evaluator::{SharedSumcheckProver, SumcheckRoundEvaluator},
 };
 use binius_m4_verifier::{IOPVerifier, Verifier};
 use binius_math::{
@@ -491,11 +491,13 @@ impl<'a, const ARITY: usize> Operation<'a, ARITY> {
 		&self,
 		lagrange: &[B128],
 		store: &mut MleStore<P>,
-		evaluators: &mut Vec<Box<dyn RoundEvaluator<B128, P>>>,
+		evaluators: &mut Vec<Box<dyn SumcheckRoundEvaluator<B128, P>>>,
 		claims: &mut Vec<B128>,
 	) where
 		P: PackedField<Scalar = B128>,
 	{
+		// The wrappers run under a plain sumcheck prover, so each holds this operation's shared eq
+		// tracker; register it once.
 		let eq_tracker = store.register_eq_tracker(&self.r_rho);
 		// The constraint tensor is the same for every operand of this operation, so expand it once.
 		let r_x_tensor = eq_ind_partial_eval_scalars::<B128>(&self.r_x);
@@ -503,7 +505,6 @@ impl<'a, const ARITY: usize> Operation<'a, ARITY> {
 			let col = store.push_owned(operand_rho_multilinear::<P>(column, lagrange, &r_x_tensor));
 			let evaluator = QuadraticMleEvaluator::new(
 				[col],
-				eq_tracker,
 				|[operand]: [P; 1]| operand,
 				|[_operand]: [P; 1]| P::zero(),
 			);
@@ -643,7 +644,7 @@ impl RerandomizedOperations<'_> {
 		// [BitAnd a, b, c | IntMul a, b, lo, hi | BinMul a_lo, a_hi, b_lo, b_hi, c_lo, c_hi].
 		// The verifier reads the reduced evaluations back in the same order.
 		let mut store = MleStore::<P>::new(log_instances);
-		let mut evaluators: Vec<Box<dyn RoundEvaluator<B128, P>>> =
+		let mut evaluators: Vec<Box<dyn SumcheckRoundEvaluator<B128, P>>> =
 			Vec::with_capacity(BITAND_ARITY + INTMUL_ARITY + BINMUL_ARITY);
 		let mut claims: Vec<B128> = Vec::with_capacity(BITAND_ARITY + INTMUL_ARITY + BINMUL_ARITY);
 		self.bitand

--- a/crates/prover/benches/batch_quadratic_mle.rs
+++ b/crates/prover/benches/batch_quadratic_mle.rs
@@ -8,7 +8,7 @@ use binius_ip_prover::sumcheck::{
 	common::MleCheckProver,
 	mle_store::MleStore,
 	quadratic_mle_evaluator::QuadraticMleEvaluator,
-	round_evaluator::{RoundEvaluator, SharedMleCheckProver},
+	round_evaluator::{MleCheckRoundEvaluator, SharedMleCheckProver},
 };
 use binius_math::{
 	FieldBuffer,
@@ -113,14 +113,13 @@ fn bench_batch_quadratic_mlecheck_prove(c: &mut Criterion) {
 				|(multilinears, eval_point)| {
 					let mut store = MleStore::new(eval_point.len());
 					let cols = multilinears.map(|multilinear| store.push_owned(multilinear));
-					// One single-claim evaluator per composition, sharing the store's columns and
-					// one eq tracker registered for the shared point.
-					let eq_tracker = store.register_eq_tracker(&eval_point);
+					// One single-claim evaluator per composition, sharing the store's columns; the
+					// prover owns the eq tracker for the shared point.
 					let evaluator_0 =
-						QuadraticMleEvaluator::new(cols, eq_tracker, comp_0::<P>, comp_0_inf::<P>);
+						QuadraticMleEvaluator::new(cols, comp_0::<P>, comp_0_inf::<P>);
 					let evaluator_1 =
-						QuadraticMleEvaluator::new(cols, eq_tracker, comp_1::<P>, comp_1_inf::<P>);
-					let claims_with_evaluators: [(F, Box<dyn RoundEvaluator<F, P>>); 2] = [
+						QuadraticMleEvaluator::new(cols, comp_1::<P>, comp_1_inf::<P>);
+					let claims_with_evaluators: [(F, Box<dyn MleCheckRoundEvaluator<F, P>>); 2] = [
 						(eval_claims[0], Box::new(evaluator_0)),
 						(eval_claims[1], Box::new(evaluator_1)),
 					];


### PR DESCRIPTION
Closes BINIUS-306.

_(The follow-up #1841 it was stacked on has merged; this PR is now based on `main`.)_

## What

Splits the single `RoundEvaluator` trait into two:

- **`SumcheckRoundEvaluator`** (renamed from `RoundEvaluator`), driven by `SharedSumcheckProver`, emits regular sumcheck round polynomials. Implemented by `BivariateProductEvaluator` and `MleToSumCheckEvaluator`.
- **`MleCheckRoundEvaluator`** (new), driven by `SharedMleCheckProver`, emits the eq-factored prime polynomials. Implemented by `QuadraticMleEvaluator`.

Per the issue, the MLE-check trait differs only in how the shared evaluation point's eq indicator reaches it — since every claim of a `SharedMleCheckProver` shares one point, the **prover** now owns that point's eq tracker and passes the round data in, so the evaluators store no tracker id:

- `MleCheckRoundEvaluator::accumulate(&self, chunk, eq_ind: FieldSlice, accum)` — the eq chunk is a separate argument (looked up once by the prover).
- `interpolate(&self, store, accum, claim, alpha)` — the round coordinate `alpha` is passed in.

`SharedMleCheckProver` is now a standalone prover (holds the store, evaluators, round states, and the one shared `eq_tracker`) rather than wrapping `SharedSumcheckProver`; its `execute` looks up the eq chunk / alpha and hands them to the evaluators. `into_shared_sumcheck` wraps each `MleCheckRoundEvaluator` in `MleToSumCheckEvaluator` (which now holds the eq tracker itself, since a plain sumcheck prover knows nothing of eq indicators) and hands over the store, round states, and tracker. `QuadraticMleEvaluator::new` and `frac_add_mle::evaluators` drop their `eq_tracker` argument; the driving prover registers it.

Now that the traits are split by protocol, round-claim recovery is uniform per prover, so there's no `claim_from_coeffs` on either evaluator trait — `SharedSumcheckProver::round_claim` recovers it as `sum_over_endpoints()` and `SharedMleCheckProver::round_claim` as `lerp_over_endpoints(alpha)`.

## Testing
- `cargo test` green: `binius-ip-prover` (58), `binius-m4-prover` (40), `binius-iop-prover` (35 + integration) — covers the standalone MLE-check prover, the wrapped logUp* final layer, the M4 operand path, and the round-claim recovery.
- clippy (`--tests --benches`) and nightly `fmt --check` clean; `cargo doc -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)