### PR TITLE
perf(circuits): drop dead work in the float64 sticky folds and slice compare

### DIFF
--- a/crates/circuits/src/concat.rs
+++ b/crates/circuits/src/concat.rs
@@ -179,7 +179,10 @@ fn assert_const_slice_eq(
 		let e = input[k];
 		if k + 1 == n_words && final_bytes != 0 {
 			let mask = b.add_constant_64((1u64 << (final_bytes * 8)) - 1);
-			b.assert_eq(format!("{name}[{k}]"), b.band(a, mask), b.band(e, mask));
+			// (a & mask) == (e & mask) is ((a ^ e) & mask) == 0: the XOR is free and
+			// drops one of the two masking ANDs.
+			let diff = b.band(b.bxor(a, e), mask);
+			b.assert_eq(format!("{name}[{k}]"), diff, b.add_constant(Word::ZERO));
 		} else {
 			b.assert_eq(format!("{name}[{k}]"), a, e);
 		}

--- a/crates/circuits/src/float64/add.rs
+++ b/crates/circuits/src/float64/add.rs
@@ -72,8 +72,10 @@ pub fn float64_add(builder: &CircuitBuilder, a: Wire, b: Wire) -> Wire {
 	// Subnormal regime if:
 	//   - we were below 1 (exp_lt_1), OR
 	//   - base exponent == 1 and the integer bit (bit 63) is 0 (no hidden 1)
-	let msb01 = bit_lsb(builder, sig_round_base, 63); // 0/1
-	let msb_is_zero = builder.icmp_eq(msb01, zero(builder)); // MSB-bool
+	// `bnot` already carries the negated integer bit in the MSB, and every consumer
+	// below reads only the MSB, so extracting bit 63 and comparing it against zero
+	// would spend two AND constraints for nothing.
+	let msb_is_zero = builder.bnot(sig_round_base); // MSB-bool
 	let base_is_one = builder.icmp_eq(exp_round_base, one(builder));
 	let in_sub_regime = builder.bor(exp_lt_1, builder.band(base_is_one, msb_is_zero));
 	let stayed_sub_mask = builder.band(in_sub_regime, builder.bnot(mant_overflow_mask));
@@ -158,10 +160,9 @@ fn fp64_order_by_exp(
 fn fp64_align_with_sticky(b: &CircuitBuilder, sig_b: Wire, d: Wire) -> Wire {
 	let (mut v, sticky) = var_shr_with_sticky(b, sig_b, d, true);
 
-	let one_const = one(b);
-	let keep = b.bnot(one_const); // ~1 = clear bit0
-	let bit0 = b.bor(b.band(v, one_const), b.band(sticky, one_const));
-	v = b.bor(b.band(v, keep), bit0);
+	// (v & ~1) | (v & 1) | (sticky & 1) == v | (sticky & 1): the fold only ever
+	// sets bit 0, so clearing it first is dead work.
+	v = b.bor(v, b.band(sticky, one(b)));
 	v
 }
 

--- a/crates/circuits/src/float64/mul.rs
+++ b/crates/circuits/src/float64/mul.rs
@@ -76,11 +76,10 @@ pub fn fp64_mul_make_round_base(b: &CircuitBuilder, m_a: Wire, m_b: Wire) -> (Wi
 	let y = b.select(top105_sel, y42, y41);
 	let sticky01 = b.select(top105_sel, sticky42, sticky41);
 
-	// Fold sticky into bit 0: new_bit0 = (y&1) | sticky01
-	let one_const = one(b);
-	let keep = b.bnot(one_const); // clear bit0
-	let new_b0 = b.bor(b.band(y, one_const), sticky01);
-	let sig_round_base = b.bor(b.band(y, keep), new_b0);
+	// Fold sticky into bit 0.
+	// (y & ~1) | (y & 1) | sticky01 == y | sticky01: `sticky01` is 0 or 1 and the
+	// fold only ever sets bit 0, so clearing it first is dead work.
+	let sig_round_base = b.bor(y, sticky01);
 
 	(sig_round_base, top105_bit01) // the bit is 0/1 for exponent bump
 }

--- a/crates/circuits/src/float64/utils.rs
+++ b/crates/circuits/src/float64/utils.rs
@@ -381,15 +381,15 @@ pub fn fp64_underflow_shift(
 	res_exp: Wire,
 ) -> (Wire, Wire, Wire) {
 	let c1 = one(b);
-	let keep = b.bnot(c1);
 
 	let exp_lt_1 = b.icmp_ult(res_exp, c1);
 	let k = isub(b, c1, res_exp); // 1 - exp
 	let k_use = b.select(exp_lt_1, k, zero(b));
 
 	let (mut sig_u, st) = var_shr_with_sticky(b, res_sig, k_use, true);
-	let bit0 = b.bor(b.band(sig_u, c1), b.band(st, c1));
-	sig_u = b.bor(b.band(sig_u, keep), bit0);
+	// (sig_u & ~1) | (sig_u & 1) | (st & 1) == sig_u | (st & 1): the sticky fold
+	// only ever sets bit 0, so clearing it first is dead work.
+	sig_u = b.bor(sig_u, b.band(st, c1));
 
 	let sig_round_base = b.select(exp_lt_1, sig_u, res_sig);
 	let exp_round_base = b.select(exp_lt_1, c1, res_exp);

--- a/crates/examples/snapshots/hashsign.snap
+++ b/crates/examples/snapshots/hashsign.snap
@@ -1,30 +1,30 @@
 hashsign circuit
 --
 Gates & Instructions
-├─ Number of gates: 408,450
-└─ Number of evaluation instructions: 409,098
+├─ Number of gates: 409,758
+└─ Number of evaluation instructions: 410,406
 
 Constraints
-├─ AND constraints: 297,991 used (56.8% of 2^19)
-│  [▓▓▓▓▓░░░░░] spare: 226,297
+├─ AND constraints: 297,984 used (56.8% of 2^19)
+│  [▓▓▓▓▓░░░░░] spare: 226,304
 ├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
 ├─ BMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-└─ Distinct value indices: 763,746
+└─ Distinct value indices: 763,739
    ├─ Distinct shifted value indices: 466,717
-   └─ Distinct unshifted value indices: 297,029
+   └─ Distinct unshifted value indices: 297,022
 
 Value Vector
 ├─ Public Section: 183 used (71.5% of 2^8)
 │  [▓▓▓▓▓▓▓░░░] spare: 73
 │  ├─ Constants: 157
 │  └─ Inout: 26
-├─ Private Section: 296,918 used (56.7%)
-│  [▓▓▓▓▓░░░░░] spare: 227,114
+├─ Private Section: 296,911 used (56.7%)
+│  [▓▓▓▓▓░░░░░] spare: 227,121
 │  ├─ Witness: 1,776
-│  └─ Internal: 295,142
-├─ Total Committed: 297,101 used (56.7% of 2^19)
-│  [▓▓▓▓▓░░░░░] spare: 227,187
-└─ Scratch (uncommitted): 262,441 (peak live: 306)
+│  └─ Internal: 295,135
+├─ Total Committed: 297,094 used (56.7% of 2^19)
+│  [▓▓▓▓▓░░░░░] spare: 227,194
+└─ Scratch (uncommitted): 263,756 (peak live: 306)
 


### PR DESCRIPTION
## What

Three float64 gadgets and the constant slice compare spend AND constraints on patterns with cheaper linear equivalents. This is the reduction category of #1686, #1804, and #1839.

Root cause, per pattern:

- The `float64` sticky folds clear bit 0 and then OR it back in: `(v & ~1) | (v & 1) | (s & 1)` is `v | (s & 1)`.
- `fp64_add` extracts bit 63 and compares it against zero, although every consumer of the result reads only the MSB.
- `assert_const_slice_eq` masks both compare operands, although the mask distributes over the XOR: `(a & m) == (e & m)` is `((a ^ e) & m) == 0`.

Fix: the sticky folds drop the clear-then-restore, the bit-63 compare becomes `bnot` whose MSB already carries the result, and the slice compare XORs first and masks once. All three are unconditional bitwise identities.

## Numbers

Deterministic AND-constraint counts (`CircuitStat::collect`):

| circuit | baseline | this PR | delta |
|---|---|---|---|
| `float64_add` | 246 | 238 | -3.3% |
| `float64_mul` | 130 | 124 | -4.6% |
| `assert_const_slice_eq` | 3 per partial word | 2 per partial word | -1 |
| `hashsign` example | 297,991 | 297,984 | -7 (via the slice compares) |

Counted by instantiating each gadget on witness wires and collecting the stats:

```rust
let b = CircuitBuilder::new();
let x = b.add_witness();
let y = b.add_witness();
b.force_commit(float64_add(&b, x, y));
let n = CircuitStat::collect(&b.build()).n_and_constraints;
```

The `hashsign` snapshot moves by the seven slice-compare words on its path and is re-blessed; the other twelve snapshots are unchanged.

## Correctness

- All three rewrites are unconditional bitwise identities, so they agree with the old forms on every witness value including adversarial ones.
- 323 `binius-circuits` tests pass, including the `float64` suites built around native `f64` edge cases (NaN, subnormals, `MIN_POSITIVE`). `clippy --all --all-features --tests --benches --examples -D warnings` and nightly `fmt --check` are clean.

## Scope

The masked-swap rewrites this PR originally carried are dropped. `merkle_path` and `fp64_order_by_exp` / `fp64_sub_path` are back on `select`, so nothing here constrains how select gates are lowered later. Their win was `float64_add` 238 -> 234 and 4 AND per Merkle level, and it can come back through the select gate itself rather than through the circuits.
