### PR TITLE
[fold_words] Specialize the bit-axis fold with WordBytewiseLookupTransformation and BitAxisFolder

### DIFF
--- a/crates/field/src/linear_transformation.rs
+++ b/crates/field/src/linear_transformation.rs
@@ -119,6 +119,7 @@ where
 	UIn: UnderlierType + Divisible<u8>,
 	UOut: UnderlierType,
 {
+	#[inline]
 	fn transform(&self, data: &UIn) -> UOut {
 		Divisible::<u8>::ref_iter(data)
 			.enumerate()

--- a/crates/field/src/linear_transformation.rs
+++ b/crates/field/src/linear_transformation.rs
@@ -1,12 +1,12 @@
 // Copyright 2024-2025 Irreducible Inc.
 
-use std::{iter, marker::PhantomData, ops::BitXor};
+use std::{marker::PhantomData, ops::BitXor};
 
 use rand::prelude::*;
 
 use crate::{
 	BinaryField, BinaryField1b, ExtensionField, UnderlierType, WithUnderlier,
-	packed::PackedBinaryField, underlier::Divisible,
+	packed::PackedBinaryField, underlier::Divisible, util::expand_subset_xors,
 };
 
 /// Generic transformation trait that is used both for scalars and packed fields
@@ -134,22 +134,6 @@ where
 			.reduce(BitXor::bitxor)
 			.unwrap_or(UOut::ZERO)
 	}
-}
-
-fn expand_subset_xors<U: UnderlierType, const N: usize, const N_EXP2: usize>(
-	elems: [U; N],
-) -> [U; N_EXP2] {
-	assert_eq!(N_EXP2, 1 << N);
-
-	let mut expanded = [U::ZERO; N_EXP2];
-	for (i, elem_i) in elems.into_iter().enumerate() {
-		let span = &mut expanded[..1 << (i + 1)];
-		let (lo_half, hi_half) = span.split_at_mut(1 << i);
-		for (lo_half_i, hi_half_i) in iter::zip(lo_half, hi_half) {
-			*hi_half_i = *lo_half_i ^ elem_i;
-		}
-	}
-	expanded
 }
 
 /// Factory for creating bytewise lookup transformations.

--- a/crates/field/src/util.rs
+++ b/crates/field/src/util.rs
@@ -2,7 +2,7 @@
 
 use std::iter;
 
-use crate::{Field, PackedField, field::FieldOps};
+use crate::{Field, PackedField, UnderlierType, field::FieldOps};
 
 /// An arithmetic function over field elements, generic in the field it evaluates in.
 ///
@@ -78,6 +78,31 @@ pub fn expand_subset_sums_array<P: PackedField, const N: usize, const N_EXP2: us
 		let (lo_half, hi_half) = span.split_at_mut(1 << i);
 		for (lo_half_i, hi_half_i) in iter::zip(lo_half, hi_half) {
 			*hi_half_i = *lo_half_i + elem_i;
+		}
+	}
+	expanded
+}
+
+/// Expands `elems` into all `2^N` subset XOR combinations, indexed by subset bitmask.
+///
+/// Entry `mask` holds the XOR of `elems[i]` over every bit `i` set in `mask`. This is the
+/// bitwise-XOR analogue of [`expand_subset_sums_array`] over raw underliers, used to build Method
+/// of Four Russians lookup tables.
+///
+/// ## Preconditions
+///
+/// * `N_EXP2` must equal `2^N`
+pub fn expand_subset_xors<U: UnderlierType, const N: usize, const N_EXP2: usize>(
+	elems: [U; N],
+) -> [U; N_EXP2] {
+	assert_eq!(N_EXP2, 1 << N);
+
+	let mut expanded = [U::ZERO; N_EXP2];
+	for (i, elem_i) in elems.into_iter().enumerate() {
+		let span = &mut expanded[..1 << (i + 1)];
+		let (lo_half, hi_half) = span.split_at_mut(1 << i);
+		for (lo_half_i, hi_half_i) in iter::zip(lo_half, hi_half) {
+			*hi_half_i = *lo_half_i ^ elem_i;
 		}
 	}
 	expanded

--- a/crates/m4-prover/src/operand_witness.rs
+++ b/crates/m4-prover/src/operand_witness.rs
@@ -574,19 +574,13 @@ pub fn build_binmul_witness(
 mod tests {
 	use assert_matches::assert_matches;
 	use binius_core::constraint_system::ValueVec;
-	use binius_field::{
-		PackedBinaryGhash1x128b,
-		linear_transformation::{
-			BytewiseLookupTransformationFactory, LinearTransformationFactory,
-			OutputWrappingTransformationFactory,
-		},
-	};
+	use binius_field::PackedBinaryGhash1x128b;
 	use binius_frontend::{Circuit, CircuitBuilder, Wire};
 	use binius_ip::channel::Error as ChannelError;
 	use binius_math::{
 		FieldBuffer, multilinear::evaluate::evaluate, univariate::lagrange_evals_scalars,
 	};
-	use binius_prover::fold_word::fold_words_with_transform;
+	use binius_prover::fold_word::BitAxisFolder;
 	use binius_transcript::{ProverTranscript, VerifierTranscript};
 	use binius_verifier::{
 		Error as VerifierError, config::StdChallenger, protocols::bitand::SKIPPED_VARS,
@@ -619,10 +613,7 @@ mod tests {
 			.isomorphic::<B128>()
 			.reduce_dim(SKIPPED_VARS);
 		let lagrange = lagrange_evals_scalars(&univariate_domain, z_challenge);
-		let transform =
-			OutputWrappingTransformationFactory::new(BytewiseLookupTransformationFactory)
-				.create(&lagrange);
-		let folded: FieldBuffer<B128> = fold_words_with_transform(&transform, col);
+		let folded: FieldBuffer<B128> = BitAxisFolder::new(&lagrange).fold(col);
 		evaluate(&folded, eval_point)
 	}
 

--- a/crates/prover/benches/and_reduction.rs
+++ b/crates/prover/benches/and_reduction.rs
@@ -2,13 +2,7 @@
 use std::{iter, iter::repeat_with};
 
 use binius_core::word::Word;
-use binius_field::{
-	Field, Random,
-	linear_transformation::{
-		BytewiseLookupTransformationFactory, LinearTransformationFactory,
-		OutputWrappingTransformationFactory,
-	},
-};
+use binius_field::{Field, Random};
 use binius_ip_prover::sumcheck::{common::SumcheckProver, quadratic_mlecheck_prover};
 use binius_math::{
 	BinarySubspace,
@@ -19,7 +13,7 @@ use binius_prover::{
 	and_reduction::{
 		NTTLookup, sumcheck_round_messages::univariate_round_message_extension_domain,
 	},
-	fold_word::fold_words_with_transform,
+	fold_word::BitAxisFolder,
 };
 use binius_verifier::{
 	config::{B128, PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES},
@@ -83,20 +77,15 @@ fn bench(c: &mut Criterion) {
 	group.bench_function(format!("univariate fold 2^{log_words}"), |bench| {
 		bench.iter(|| {
 			let lagrange_evals = lagrange_evals_scalars(&univariate_domain, univariate_challenge);
-			let transform =
-				OutputWrappingTransformationFactory::new(BytewiseLookupTransformationFactory)
-					.create(&lagrange_evals);
-
-			[&a_words, &b_words, &c_words]
-				.map(|mlv| fold_words_with_transform::<_, OptimalPackedB128, _>(&transform, mlv))
+			let folder = BitAxisFolder::new(&lagrange_evals);
+			[&a_words, &b_words, &c_words].map(|mlv| folder.fold::<OptimalPackedB128>(mlv))
 		});
 	});
 
 	let lagrange_evals = lagrange_evals_scalars(&univariate_domain, univariate_challenge);
-	let transform = OutputWrappingTransformationFactory::new(BytewiseLookupTransformationFactory)
-		.create(&lagrange_evals);
-	let proving_polys = [&a_words, &b_words, &c_words]
-		.map(|mlv| fold_words_with_transform::<_, OptimalPackedB128, _>(&transform, mlv));
+	let folder = BitAxisFolder::new(&lagrange_evals);
+	let proving_polys =
+		[&a_words, &b_words, &c_words].map(|mlv| folder.fold::<OptimalPackedB128>(mlv));
 
 	let mut univariate_message_coeffs = vec![B128::ZERO; 2 * ROWS_PER_HYPERCUBE_VERTEX];
 	univariate_message_coeffs[ROWS_PER_HYPERCUBE_VERTEX..2 * ROWS_PER_HYPERCUBE_VERTEX]

--- a/crates/prover/src/and_reduction/prover.rs
+++ b/crates/prover/src/and_reduction/prover.rs
@@ -2,13 +2,7 @@
 use std::marker::PhantomData;
 
 use binius_core::word::Word;
-use binius_field::{
-	AESTowerField8b as B8, BinaryField, PackedField,
-	linear_transformation::{
-		BytewiseLookupTransformationFactory, LinearTransformationFactory,
-		OutputWrappingTransformationFactory,
-	},
-};
+use binius_field::{AESTowerField8b as B8, BinaryField, PackedField};
 use binius_ip_prover::{
 	channel::IPProverChannel,
 	sumcheck::{
@@ -25,7 +19,7 @@ use binius_verifier::{
 };
 
 use super::sumcheck_round_messages;
-use crate::fold_word::fold_words_with_transform;
+use crate::fold_word::BitAxisFolder;
 
 /// Prover for the AND constraint reduction protocol via oblong univariate zerocheck.
 ///
@@ -161,12 +155,10 @@ where
 	) -> impl MleCheckProver<F> {
 		let univariate_domain = round_message_domain.reduce_dim(round_message_domain.dim() - 1);
 		let lagrange_evals = lagrange_evals_scalars(&univariate_domain, challenge);
-		let transform =
-			OutputWrappingTransformationFactory::new(BytewiseLookupTransformationFactory)
-				.create(&lagrange_evals);
+		let folder = BitAxisFolder::new(&lagrange_evals);
 
 		let proving_polys = [&self.first_col, &self.second_col, &self.third_col]
-			.map(|col| fold_words_with_transform::<_, PChallenge, _>(&transform, col));
+			.map(|col| folder.fold::<PChallenge>(col));
 
 		let upcasted_small_field_challenges = PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES
 			.iter()
@@ -260,14 +252,7 @@ mod test {
 	use std::{iter, iter::repeat_with};
 
 	use binius_core::word::Word;
-	use binius_field::{
-		AESTowerField8b,
-		arch::OptimalPackedB128,
-		linear_transformation::{
-			BytewiseLookupTransformationFactory, LinearTransformationFactory,
-			OutputWrappingTransformationFactory,
-		},
-	};
+	use binius_field::{AESTowerField8b, arch::OptimalPackedB128};
 	use binius_math::{
 		BinarySubspace, FieldBuffer, multilinear::evaluate::evaluate,
 		univariate::lagrange_evals_scalars,
@@ -280,7 +265,7 @@ mod test {
 	use rand::prelude::*;
 
 	use super::OblongZerocheckProver;
-	use crate::fold_word::fold_words_with_transform;
+	use crate::fold_word::BitAxisFolder;
 
 	fn random_words(log_num_words: usize, mut rng: impl Rng) -> Vec<Word> {
 		repeat_with(|| Word(rng.random()))
@@ -361,12 +346,9 @@ mod test {
 
 		let verifier_lagrange_evals =
 			lagrange_evals_scalars(&verifier_univariate_domain, z_challenge);
-		let verifier_transparent_transform =
-			OutputWrappingTransformationFactory::new(BytewiseLookupTransformationFactory)
-				.create(&verifier_lagrange_evals);
+		let folder = BitAxisFolder::new(&verifier_lagrange_evals);
 		for (i, eval) in [a_eval, b_eval, c_eval].iter().enumerate() {
-			let folded: FieldBuffer<B128> =
-				fold_words_with_transform(&verifier_transparent_transform, &one_bit_mlvs[i]);
+			let folded: FieldBuffer<B128> = folder.fold(&one_bit_mlvs[i]);
 			assert_eq!(evaluate(&folded, &eval_point), *eval);
 		}
 	}

--- a/crates/prover/src/and_reduction/sumcheck_round_messages.rs
+++ b/crates/prover/src/and_reduction/sumcheck_round_messages.rs
@@ -210,13 +210,7 @@ impl<F: BinaryField + From<B8>> B8ToExtMulMap<F> {
 mod test {
 	use std::iter::repeat_with;
 
-	use binius_field::{
-		BinaryField128bGhash as B128, Field, Random,
-		linear_transformation::{
-			BytewiseLookupTransformationFactory, LinearTransformationFactory,
-			OutputWrappingTransformationFactory,
-		},
-	};
+	use binius_field::{BinaryField128bGhash as B128, Field, Random};
 	use binius_math::{
 		BinarySubspace, FieldBuffer,
 		univariate::{extrapolate_over_subspace, lagrange_evals_scalars},
@@ -225,7 +219,7 @@ mod test {
 	use rand::prelude::*;
 
 	use super::*;
-	use crate::fold_word::fold_words_with_transform;
+	use crate::fold_word::BitAxisFolder;
 
 	fn random_words(log_num_words: usize, mut rng: impl Rng) -> Vec<Word> {
 		repeat_with(|| Word(rng.random()))
@@ -300,13 +294,11 @@ mod test {
 
 		let lagrange_evals =
 			lagrange_evals_scalars(&verifier_input_domain, first_sumcheck_challenge);
-		let transform =
-			OutputWrappingTransformationFactory::new(BytewiseLookupTransformationFactory)
-				.create(&lagrange_evals);
+		let folder = BitAxisFolder::new(&lagrange_evals);
 
-		let folded_first_mle: FieldBuffer<B128> = fold_words_with_transform(&transform, &mlv_1);
-		let folded_second_mle: FieldBuffer<B128> = fold_words_with_transform(&transform, &mlv_2);
-		let folded_third_mle: FieldBuffer<B128> = fold_words_with_transform(&transform, &mlv_3);
+		let folded_first_mle: FieldBuffer<B128> = folder.fold(&mlv_1);
+		let folded_second_mle: FieldBuffer<B128> = folder.fold(&mlv_2);
+		let folded_third_mle: FieldBuffer<B128> = folder.fold(&mlv_3);
 
 		let upcasted_small_field_challenges: Vec<_> = small_field_zerocheck_challenges
 			.into_iter()

--- a/crates/prover/src/fold_word.rs
+++ b/crates/prover/src/fold_word.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-use std::{array, borrow::Cow, iter};
+use std::{array, borrow::Cow, hint::assert_unchecked, iter};
 
 use binius_core::word::Word;
 use binius_field::{
@@ -79,12 +79,30 @@ where
 	let capacity = 1 << log_n.saturating_sub(P::LOG_WIDTH);
 
 	let mut values = Vec::<P>::with_capacity(capacity);
-	words
+
+	let chunk_size = P::WIDTH;
+	let full_chunks_boundary = words.len() / chunk_size * chunk_size;
+	let (words_aligned, words_remaining) = words.split_at(full_chunks_boundary);
+
+	words_aligned
 		.par_chunks(P::WIDTH)
 		.map(|word_chunk| {
+			// Safety:
+			// - words_aligned has length that is a multiple of P::WIDTH
+			// - words_aligned is split into P::WIDTH chunks
+			unsafe { assert_unchecked(word_chunk.len() == P::WIDTH) };
 			P::from_scalars(word_chunk.iter().map(|&word| transform.transform(&word.0)))
 		})
 		.collect_into_vec(&mut values);
+
+	if !words_remaining.is_empty() {
+		values.push(P::from_scalars(
+			words_remaining
+				.iter()
+				.map(|&word| transform.transform(&word.0)),
+		));
+	}
+
 	values.resize(capacity, P::default());
 
 	FieldBuffer::new(log_n, values.into_boxed_slice())

--- a/crates/prover/src/fold_word.rs
+++ b/crates/prover/src/fold_word.rs
@@ -81,19 +81,24 @@ where
 	let mut values = Vec::<P>::with_capacity(capacity);
 
 	let chunk_size = P::WIDTH;
-	let full_chunks_boundary = words.len() / chunk_size * chunk_size;
-	let (words_aligned, words_remaining) = words.split_at(full_chunks_boundary);
+	let n_chunks = words.len() / chunk_size;
+	let (words_aligned, words_remaining) = words.split_at(n_chunks * chunk_size);
 
-	words_aligned
-		.par_chunks(P::WIDTH)
-		.map(|word_chunk| {
+	let values_aligned = &mut values.spare_capacity_mut()[..n_chunks];
+	let word_chunks = words_aligned.par_chunks_exact(P::WIDTH);
+	assert_eq!(values_aligned.len(), word_chunks.len());
+
+	(values_aligned, word_chunks)
+		.into_par_iter()
+		.for_each(|(out, word_chunk)| {
 			// Safety:
 			// - words_aligned has length that is a multiple of P::WIDTH
 			// - words_aligned is split into P::WIDTH chunks
 			unsafe { assert_unchecked(word_chunk.len() == P::WIDTH) };
-			P::from_scalars(word_chunk.iter().map(|&word| transform.transform(&word.0)))
-		})
-		.collect_into_vec(&mut values);
+			out.write(P::from_scalars(word_chunk.iter().map(|&word| transform.transform(&word.0))));
+		});
+
+	unsafe { values.set_len(n_chunks) };
 
 	if !words_remaining.is_empty() {
 		values.push(P::from_scalars(

--- a/crates/prover/src/fold_word.rs
+++ b/crates/prover/src/fold_word.rs
@@ -5,10 +5,10 @@ use std::{array, borrow::Cow, hint::assert_unchecked, iter, ops::BitXor};
 
 use binius_core::word::Word;
 use binius_field::{
-	BinaryField, Divisible, Field, PackedField, UnderlierType, WideMul,
+	BinaryField, Divisible, Field, PackedField, UnderlierType, WideMul, WithUnderlier,
 	linear_transformation::{
 		BytewiseLookupTransformationFactory, LinearTransformationFactory,
-		OutputWrappingTransformationFactory, Transformation,
+		OutputWrappingTransformation, OutputWrappingTransformationFactory, Transformation,
 	},
 	util::{expand_subset_sums_array, expand_subset_xors},
 };
@@ -47,27 +47,10 @@ where
 	F: BinaryField,
 	P: PackedField<Scalar = F>,
 {
-	fold_words_with_transform_factory(
-		&OutputWrappingTransformationFactory::new(WordBytewiseLookupTransformationFactory),
-		words,
-		vec,
-	)
+	BitAxisFolder::new(vec).fold(words)
 }
 
-pub fn fold_words_with_transform_factory<F, P, TransformFactory>(
-	transform_factory: &TransformFactory,
-	words: &[Word],
-	vec: &[F],
-) -> FieldBuffer<P>
-where
-	F: Field,
-	P: PackedField<Scalar = F>,
-	TransformFactory: LinearTransformationFactory<u64, F>,
-{
-	fold_words_with_transform(&transform_factory.create(vec), words)
-}
-
-pub fn fold_words_with_transform<F, P, T>(transform: &T, words: &[Word]) -> FieldBuffer<P>
+fn fold_words_with_transform<F, P, T>(transform: &T, words: &[Word]) -> FieldBuffer<P>
 where
 	F: Field,
 	P: PackedField<Scalar = F>,
@@ -165,6 +148,46 @@ impl<UOut: UnderlierType> LinearTransformationFactory<u64, UOut>
 
 	fn create(&self, cols: &[UOut]) -> Self::Transform {
 		WordBytewiseLookupTransformation::new(cols)
+	}
+}
+
+/// The concrete transform [`BitAxisFolder`] folds each word through: the [`u64`]-specialized
+/// bytewise lookup, wrapped to output field elements of `F`.
+type BitAxisTransform<F> = OutputWrappingTransformation<
+	WordBytewiseLookupTransformation<<F as WithUnderlier>::Underlier>,
+	u64,
+	F,
+>;
+
+/// A reusable folder over a fixed vector of bit-index scalars, the [`fold_words`] analogue of
+/// [`WordFolder`].
+///
+/// [`fold_words`] rebuilds its Method of Four Russians lookup transform on every call. A caller
+/// folding several word-lists against the same scalar vector can instead build the transform once
+/// with [`new`](Self::new) and reuse it across [`fold`](Self::fold) calls.
+pub struct BitAxisFolder<F: BinaryField> {
+	transform: BitAxisTransform<F>,
+}
+
+impl<F: BinaryField> BitAxisFolder<F> {
+	/// Builds the folding transform for `vec`.
+	///
+	/// ## Preconditions
+	/// * `vec` contains exactly [`Word::BITS`] elements
+	pub fn new(vec: &[F]) -> Self {
+		let transform =
+			OutputWrappingTransformationFactory::new(WordBytewiseLookupTransformationFactory)
+				.create(vec);
+		Self { transform }
+	}
+
+	/// Folds `words` into a [`FieldBuffer`], mapping each word to the inner product of its bits
+	/// with the scalar vector. See [`fold_words`] for the exact contract.
+	pub fn fold<P>(&self, words: &[Word]) -> FieldBuffer<P>
+	where
+		P: PackedField<Scalar = F>,
+	{
+		fold_words_with_transform(&self.transform, words)
 	}
 }
 

--- a/crates/prover/src/fold_word.rs
+++ b/crates/prover/src/fold_word.rs
@@ -1,16 +1,16 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-use std::{array, borrow::Cow, hint::assert_unchecked, iter};
+use std::{array, borrow::Cow, hint::assert_unchecked, iter, ops::BitXor};
 
 use binius_core::word::Word;
 use binius_field::{
-	BinaryField, Field, PackedField, WideMul,
+	BinaryField, Divisible, Field, PackedField, UnderlierType, WideMul,
 	linear_transformation::{
 		BytewiseLookupTransformationFactory, LinearTransformationFactory,
 		OutputWrappingTransformationFactory, Transformation,
 	},
-	util::expand_subset_sums_array,
+	util::{expand_subset_sums_array, expand_subset_xors},
 };
 use binius_math::{
 	FieldBuffer, FieldSlice,
@@ -48,7 +48,7 @@ where
 	P: PackedField<Scalar = F>,
 {
 	fold_words_with_transform_factory(
-		&OutputWrappingTransformationFactory::new(BytewiseLookupTransformationFactory),
+		&OutputWrappingTransformationFactory::new(WordBytewiseLookupTransformationFactory),
 		words,
 		vec,
 	)
@@ -111,6 +111,61 @@ where
 	values.resize(capacity, P::default());
 
 	FieldBuffer::new(log_n, values.into_boxed_slice())
+}
+
+/// A [`u64`]-specialized bytewise lookup transformation, folding a word's bits against a fixed
+/// vector of field-element underliers.
+///
+/// Fixing the input to [`u64`] lets the per-byte lookup tables live in a fixed-length array rather
+/// than a heap-allocated [`Vec`], holding one table per byte of the word.
+///
+/// This uses the [Method of Four Russians] to optimize the computation by precomputing a lookup
+/// table for each byte position and combining bitwise chunks of the word.
+///
+/// [Method of Four Russians]: <https://en.wikipedia.org/wiki/Method_of_Four_Russians>
+#[derive(Debug)]
+pub struct WordBytewiseLookupTransformation<UOut> {
+	lookup: [[UOut; 1 << BITS_PER_BYTE]; Word::BYTES],
+}
+
+impl<UOut: UnderlierType> WordBytewiseLookupTransformation<UOut> {
+	pub fn new(cols: &[UOut]) -> Self {
+		assert_eq!(cols.len(), Word::BITS);
+
+		let lookup = array::from_fn(|byte| {
+			let group: [UOut; BITS_PER_BYTE] = cols
+				[byte * BITS_PER_BYTE..(byte + 1) * BITS_PER_BYTE]
+				.try_into()
+				.expect("cols has Word::BITS = Word::BYTES * BITS_PER_BYTE entries");
+			expand_subset_xors(group)
+		});
+
+		Self { lookup }
+	}
+}
+
+impl<UOut: UnderlierType> Transformation<u64, UOut> for WordBytewiseLookupTransformation<UOut> {
+	#[inline]
+	fn transform(&self, data: &u64) -> UOut {
+		iter::zip(Divisible::<u8>::ref_iter(data), &self.lookup)
+			.map(|(byte, table)| table[byte as usize])
+			.reduce(BitXor::bitxor)
+			.unwrap_or(UOut::ZERO)
+	}
+}
+
+/// Factory for creating [`WordBytewiseLookupTransformation`]s.
+#[derive(Debug)]
+pub struct WordBytewiseLookupTransformationFactory;
+
+impl<UOut: UnderlierType> LinearTransformationFactory<u64, UOut>
+	for WordBytewiseLookupTransformationFactory
+{
+	type Transform = WordBytewiseLookupTransformation<UOut>;
+
+	fn create(&self, cols: &[UOut]) -> Self::Transform {
+		WordBytewiseLookupTransformation::new(cols)
+	}
 }
 
 /// Folds a slice of words along both axes at once, contracting the matrix to a single scalar.


### PR DESCRIPTION
## Summary

Optimizes the `fold_words` bit-axis fold — the Method of Four Russians fold that maps each 64-bit word to one field element, inner-producting its bits against a fixed scalar vector — and reshapes its API around a reusable folder.

The series builds up in four steps:

1. **Optimize packing loop** — split the words into full `P::WIDTH` chunks plus a remainder so the hot packing loop is guaranteed to process full chunks, letting the compiler emit tighter code.
2. **Use `spare_capacity_mut`** — write the folded packed elements directly into the output `Vec`'s spare capacity in parallel, avoiding the intermediate `collect_into_vec`.
3. **Add a `u64`-specialized `WordBytewiseLookupTransformation`** — a sibling of the generic `BytewiseLookupTransformation` fixed to `u64` input, so the per-byte Method of Four Russians lookup tables live in a fixed-length `[[UOut; 256]; Word::BYTES]` array instead of a heap-allocated `Vec`. The subset-XOR table builder is hoisted into `binius_field::util` as a public `expand_subset_xors` (the bitwise-XOR analogue of `expand_subset_sums_array`) and shared between `linear_transformation` and `fold_word`.
4. **Introduce `BitAxisFolder`** — the `fold_words` analogue of `WordFolder`. It builds and stores the concrete `OutputWrappingTransformation<WordBytewiseLookupTransformation<F::Underlier>, u64, F>` once in `new(vec)` and exposes `fold::<P>(words) -> FieldBuffer<P>`, reusing the transform across calls. `fold_words_with_transform` is now private and `fold_words_with_transform_factory` is removed; every caller (the AND-reduction prover folding its three columns, its tests, the `m4-prover` consistency check, and the benches) builds a `BitAxisFolder` from the column evals instead of hand-constructing a transform.

As a result, the callers that previously used the generic `Vec`-backed `BytewiseLookupTransformation` now all fold through the fixed-array `WordBytewiseLookupTransformation` via the folder.

## Test plan

- `cargo test -p binius-field` (including the `util` subset-expansion tests)
- `cargo test -p binius-prover` — `fold_word` equivalence tests and the `and_reduction` tests
- `cargo test -p binius-m4-prover`
- `cargo clippy --all --all-features --tests --benches` and `cargo fmt` clean
- `cargo doc` builds with no broken intra-doc links

🤖 Generated with [Claude Code](https://claude.com/claude-code)
