### PR TITLE
BINIUS-313: remove eq tracker from SharedMleCheckProver

### DIFF
--- a/crates/ip-prover/src/sumcheck/mle_store.rs
+++ b/crates/ip-prover/src/sumcheck/mle_store.rs
@@ -321,6 +321,11 @@ impl<'a, F: Field, P: PackedField<Scalar = F>> MleStore<'a, P> {
 	/// expansion, together, so each leaf hands `map` one [`EvaluationChunk`]: the paired column
 	/// halves and the matching eq chunk, at `2^chunk_vars` scalars per half.
 	///
+	/// `reduce(low, high, level)` combines the two sub-results of a bisection, where `level` is the
+	/// index of the variable that was bisected to produce them (`low` fixes it to 0, `high` to 1).
+	/// A plain sum ignores `level`; an eq-weighted reduction uses it to pick the round's
+	/// coordinate.
+	///
 	/// `chunk_vars` is capped at `n_vars() - 1`, so leaves never exceed the halved hypercube.
 	///
 	/// ## Preconditions
@@ -330,7 +335,7 @@ impl<'a, F: Field, P: PackedField<Scalar = F>> MleStore<'a, P> {
 		&self,
 		chunk_vars: usize,
 		map: impl (for<'c> Fn(EvaluationChunk<'c, P>) -> T) + Sync,
-		reduce: impl (Fn(T, T) -> T) + Sync,
+		reduce: impl (Fn(T, T, usize) -> T) + Sync,
 	) -> T {
 		assert!(self.n_vars > 0);
 		let chunk_vars = chunk_vars.min(self.n_vars - 1);
@@ -370,7 +375,7 @@ impl<'a, F: Field, P: PackedField<Scalar = F>> MleStore<'a, P> {
 		chunk_vars: usize,
 		challenge: F,
 		map: impl (for<'c> Fn(EvaluationChunk<'c, P>) -> T) + Sync,
-		reduce: impl (Fn(T, T) -> T) + Sync,
+		reduce: impl (Fn(T, T, usize) -> T) + Sync,
 	) -> T {
 		assert!(self.n_vars > 1);
 
@@ -744,36 +749,40 @@ fn map_reduce_helper<P: PackedField, T: Send>(
 	chunk: EvaluationChunk<'_, P>,
 	sub_vars: usize,
 	map: &(impl (for<'a> Fn(EvaluationChunk<'a, P>) -> T) + Sync),
-	reduce: &(impl (Fn(T, T) -> T) + Sync),
+	reduce: &(impl (Fn(T, T, usize) -> T) + Sync),
 ) -> T {
 	if sub_vars == chunk.n_vars {
 		return map(chunk);
 	}
 
+	// The bisection binds the highest remaining variable; its index is the reduction level.
+	let level = chunk.n_vars - 1;
 	let [chunk_0, chunk_1] = chunk.split_half();
 	let (ret_0, ret_1) = rayon::join(
 		move || map_reduce_helper(chunk_0, sub_vars, map, reduce),
 		move || map_reduce_helper(chunk_1, sub_vars, map, reduce),
 	);
-	reduce(ret_0, ret_1)
+	reduce(ret_0, ret_1, level)
 }
 
 fn map_reduce_with_fold_helper<P: PackedField, T: Send>(
 	chunk: PreFoldEvaluationChunk<'_, P>,
 	sub_vars: usize,
 	map: &(impl (for<'a> Fn(EvaluationChunk<'a, P>) -> T) + Sync),
-	reduce: &(impl (Fn(T, T) -> T) + Sync),
+	reduce: &(impl (Fn(T, T, usize) -> T) + Sync),
 ) -> T {
 	if sub_vars == chunk.n_vars {
 		return map(chunk.fold());
 	}
 
+	// The bisection binds the highest remaining variable; its index is the reduction level.
+	let level = chunk.n_vars - 1;
 	let [chunk_0, chunk_1] = chunk.split_half();
 	let (ret_0, ret_1) = rayon::join(
 		move || map_reduce_with_fold_helper(chunk_0, sub_vars, map, reduce),
 		move || map_reduce_with_fold_helper(chunk_1, sub_vars, map, reduce),
 	);
-	reduce(ret_0, ret_1)
+	reduce(ret_0, ret_1, level)
 }
 
 #[cfg(test)]
@@ -846,7 +855,7 @@ mod tests {
 			let got = store.map_reduce(
 				chunk_vars,
 				|chunk| chunk_aggregate(&chunk, &col_ids, &eq_ids),
-				|lhs, rhs| lhs + rhs,
+				|lhs, rhs, _level| lhs + rhs,
 			);
 			assert_eq!(got, expected, "mismatch at chunk_vars = {chunk_vars}");
 		}
@@ -911,7 +920,7 @@ mod tests {
 			let expected = fold_first.map_reduce(
 				chunk_vars,
 				|chunk| chunk_aggregate(&chunk, &col_ids, &eq_ids),
-				|lhs, rhs| lhs + rhs,
+				|lhs, rhs, _level| lhs + rhs,
 			);
 
 			let (mut fused, col_ids, eq_ids) = build();
@@ -919,7 +928,7 @@ mod tests {
 				chunk_vars,
 				challenge,
 				|chunk| chunk_aggregate(&chunk, &col_ids, &eq_ids),
-				|lhs, rhs| lhs + rhs,
+				|lhs, rhs, _level| lhs + rhs,
 			);
 
 			assert_eq!(got, expected, "result mismatch at chunk_vars = {chunk_vars}");
@@ -943,13 +952,13 @@ mod tests {
 			let expected = fold_first.map_reduce(
 				chunk_vars,
 				|chunk| chunk_aggregate(&chunk, &fold_col_ids, &fold_eq_ids),
-				|lhs, rhs| lhs + rhs,
+				|lhs, rhs, _level| lhs + rhs,
 			);
 			let got = fused.map_reduce_with_fold(
 				chunk_vars,
 				challenge,
 				|chunk| chunk_aggregate(&chunk, &fused_col_ids, &fused_eq_ids),
-				|lhs, rhs| lhs + rhs,
+				|lhs, rhs, _level| lhs + rhs,
 			);
 
 			assert_eq!(got, expected, "result mismatch in round {round}");

--- a/crates/ip-prover/src/sumcheck/mle_to_sumcheck.rs
+++ b/crates/ip-prover/src/sumcheck/mle_to_sumcheck.rs
@@ -156,7 +156,13 @@ where
 		let eq_prefix = store.eq_prefix(self.eq_tracker);
 		let alpha = store.eq_alpha(self.eq_tracker);
 		let inner_claim = claim * eq_prefix.invert_or_zero();
-		let round_coeffs = self.inner.interpolate(store, accum, inner_claim, alpha);
+		// The inner MLE-check evaluator now takes a reduced accumulator; the plain sumcheck prover
+		// driving this wrapper leaves the wide accumulators unreduced, so reduce them here.
+		let reduced = accum
+			.iter()
+			.map(|slot| P::reduce(slot.clone()))
+			.collect::<Vec<_>>();
+		let round_coeffs = self.inner.interpolate(store, &reduced, inner_claim, alpha);
 
 		// Multiply the inner MLE-check round polynomial by (X - α) and the equality prefix.
 		round_coeffs_by_eq(&round_coeffs, alpha) * eq_prefix

--- a/crates/ip-prover/src/sumcheck/quadratic_mle_evaluator.rs
+++ b/crates/ip-prover/src/sumcheck/quadratic_mle_evaluator.rs
@@ -166,7 +166,7 @@ where
 	fn interpolate(
 		&self,
 		store: &MleStore<'_, P>,
-		accum: &[<P as WideMul>::Output],
+		accum: &[P],
 		claim: F,
 		alpha: F,
 	) -> RoundCoeffs<F> {
@@ -174,11 +174,12 @@ where
 		let n_vars_remaining = store.n_vars();
 		assert!(n_vars_remaining > 0);
 
-		// Reduce the wide accumulators, sum packed lanes into scalars, then interpolate. `claim` is
-		// this round's prime eval; `alpha`, this round's eq coordinate, ties it to the point.
+		// `accum` is already reduced (the prover's `map` pass reduced the wide accumulators). Sum
+		// the packed lanes into scalars, then interpolate. `claim` is this round's prime eval;
+		// `alpha`, this round's eq coordinate, ties it to the point.
 		RoundEvals2 {
-			y_1: P::reduce(accum[0].clone()),
-			y_inf: P::reduce(accum[1].clone()),
+			y_1: accum[0],
+			y_inf: accum[1],
 		}
 		.sum_scalars(n_vars_remaining)
 		.interpolate_eq(claim, alpha)

--- a/crates/ip-prover/src/sumcheck/round_evaluator.rs
+++ b/crates/ip-prover/src/sumcheck/round_evaluator.rs
@@ -292,8 +292,11 @@ where
 			}
 			accum
 		};
-		let reduce = |mut lhs: Vec<<P as WideMul>::Output>, rhs: Vec<<P as WideMul>::Output>| {
-			// The only merge: sum the workers' slices slot-wise, generic over every evaluator.
+		let reduce = |mut lhs: Vec<<P as WideMul>::Output>,
+		              rhs: Vec<<P as WideMul>::Output>,
+		              _level: usize| {
+			// The only merge: sum the workers' slices slot-wise, generic over every evaluator. Plain
+			// sumcheck has no eq factor, so the reduction level is unused.
 			for (dst, src) in iter::zip(&mut lhs, rhs) {
 				*dst += src;
 			}
@@ -511,7 +514,9 @@ where
 			}
 			accum
 		};
-		let reduce = |mut lhs: Vec<<P as WideMul>::Output>, rhs: Vec<<P as WideMul>::Output>| {
+		let reduce = |mut lhs: Vec<<P as WideMul>::Output>,
+		              rhs: Vec<<P as WideMul>::Output>,
+		              _level: usize| {
 			for (dst, src) in iter::zip(&mut lhs, rhs) {
 				*dst += src;
 			}

--- a/crates/ip-prover/src/sumcheck/round_evaluator.rs
+++ b/crates/ip-prover/src/sumcheck/round_evaluator.rs
@@ -25,12 +25,12 @@ use std::iter;
 use auto_impl::auto_impl;
 use binius_field::{Field, PackedField, WideMul};
 use binius_ip::sumcheck::RoundCoeffs;
-use binius_math::{FieldBuffer, FieldSlice};
+use binius_math::{FieldBuffer, FieldSlice, multilinear::eq::eq_ind_partial_eval};
 
 use super::{
 	MleToSumCheckEvaluator,
 	common::{MleCheckProver, SumcheckProver},
-	mle_store::{ColId, EqId, EvaluationChunk, MleStore},
+	mle_store::{ColId, EvaluationChunk, MleStore},
 	round_state::RoundState,
 };
 
@@ -72,7 +72,8 @@ pub trait SumcheckRoundEvaluator<F: Field, P: PackedField<Scalar = F>>: Send + S
 	///
 	/// The driving prover prepares `chunk` — the split, per-chunk column halves and eq-indicator
 	/// expansions — so the evaluator only reads its columns by [`ColId`] and eq trackers by
-	/// [`EqId`]. `accum` is this evaluator's run of [`Self::degree`] wide slots, zero-initialized
+	/// [`EqId`](super::mle_store::EqId). `accum` is this evaluator's run of [`Self::degree`] wide
+	/// slots, zero-initialized
 	/// on the first chunk and carried across the worker's chunks.
 	fn accumulate(&self, chunk: &EvaluationChunk<'_, P>, accum: &mut [<P as WideMul>::Output]);
 
@@ -127,11 +128,13 @@ pub trait MleCheckRoundEvaluator<F: Field, P: PackedField<Scalar = F>>: Send + S
 	///
 	/// As [`SumcheckRoundEvaluator::interpolate`], but the round coordinate is passed in as `alpha`
 	/// rather than read from a stored eq tracker; `store` supplies only the remaining-variable
-	/// count.
+	/// count. Unlike the sumcheck trait, `accum` is already reduced to `P` — the driving
+	/// [`SharedMleCheckProver`] reduces the wide accumulators in its `map` pass so the eq-weighted
+	/// `reduce` can operate on `P`.
 	fn interpolate(
 		&self,
 		store: &MleStore<'_, P>,
-		accum: &[<P as WideMul>::Output],
+		accum: &[P],
 		claim: F,
 		alpha: F,
 	) -> RoundCoeffs<F>;
@@ -295,8 +298,8 @@ where
 		let reduce = |mut lhs: Vec<<P as WideMul>::Output>,
 		              rhs: Vec<<P as WideMul>::Output>,
 		              _level: usize| {
-			// The only merge: sum the workers' slices slot-wise, generic over every evaluator. Plain
-			// sumcheck has no eq factor, so the reduction level is unused.
+			// The only merge: sum the workers' slices slot-wise, generic over every evaluator.
+			// Plain sumcheck has no eq factor, so the reduction level is unused.
 			for (dst, src) in iter::zip(&mut lhs, rhs) {
 				*dst += src;
 			}
@@ -366,13 +369,13 @@ pub struct SharedMleCheckProver<'a, F: Field, P: PackedField<Scalar = F>, Evalua
 	/// The claim ↔ round-coeffs state machine, one entry per evaluator; see the field of the same
 	/// name on [`SharedSumcheckProver`].
 	round_states: Vec<RoundState<RoundCoeffs<F>, F>>,
-	/// The shared evaluation point's eq-indicator tracker, folded by the store each round. The
-	/// prover reads the round's eq chunk and coordinate `alpha` from it and passes them to the
-	/// evaluators.
-	eq_tracker: EqId,
 	/// A fold challenge whose store fold is deferred; see the field of the same name on
 	/// [`SharedSumcheckProver`].
 	buffered_challenge: Option<F>,
+	/// The shared evaluation point of every claim. The prover keeps no eq-indicator tracker: each
+	/// round it expands only a `chunk_vars`-wide prefix of this point as the per-chunk eq
+	/// indicator and folds the higher coordinates through the eq-weighted `reduce` (see
+	/// [`Self::execute`]).
 	eval_point: Vec<F>,
 }
 
@@ -386,7 +389,7 @@ where
 	/// initial claim — one `(claim, evaluator)` per claim — and the evaluation point shared by all
 	/// of the evaluators' claims.
 	pub fn new(
-		mut store: MleStore<'a, P>,
+		store: MleStore<'a, P>,
 		claims_with_evaluators: impl IntoIterator<Item = (F, Evaluator)>,
 		eval_point: Vec<F>,
 	) -> Self {
@@ -396,9 +399,6 @@ where
 			store.n_vars(),
 			"evaluation point length must equal the store's number of variables"
 		);
-		// Every claim shares the point, so register its eq-indicator tracker once; the prover owns
-		// it and supplies the round eq chunk and coordinate to each evaluator.
-		let eq_tracker = store.register_eq_tracker(&eval_point);
 		let (round_states, evaluators) = claims_with_evaluators
 			.into_iter()
 			.map(|(claim, evaluator)| (RoundState::Claim(claim), evaluator))
@@ -407,7 +407,6 @@ where
 			store,
 			evaluators,
 			round_states,
-			eq_tracker,
 			buffered_challenge: None,
 			eval_point,
 		}
@@ -430,13 +429,16 @@ where
 		Evaluator: 'static,
 	{
 		let Self {
-			store,
+			mut store,
 			evaluators,
 			round_states,
-			eq_tracker,
 			buffered_challenge: _,
-			eval_point: _,
+			eval_point,
 		} = self;
+		// The plain sumcheck prover this converts to has no eq machinery, so its wrappers read the
+		// eq indicator from a store tracker. This prover kept none, so register one here for the
+		// shared point.
+		let eq_tracker = store.register_eq_tracker(&eval_point);
 		// Wrap each MLE-check evaluator so it emits sumcheck round polynomials, handing it the
 		// shared eq tracker the store folds. Conversion happens before proving starts, so no fold
 		// challenge is buffered yet, and — since no variable has been folded — the equality
@@ -477,8 +479,8 @@ where
 	fn round_claim(&self) -> Vec<F> {
 		// The claim is held directly before this round's polynomial is produced, and afterwards
 		// recovered from that prime polynomial as the eq-lerp of its endpoints at the round
-		// coordinate.
-		let alpha = self.store.eq_alpha(self.eq_tracker);
+		// coordinate — the highest remaining coordinate of the shared point.
+		let alpha = self.eval_point[self.n_vars() - 1];
 		self.round_states
 			.iter()
 			.map(|state| match state {
@@ -500,25 +502,32 @@ where
 			.last()
 			.expect("offsets has one entry per evaluator, plus one");
 
+		// The eq indicator factors into a chunk part over the low `chunk_vars` coordinates and a
+		// suffix part over the higher ones. Materialize only the chunk part, shared by every chunk
+		// and evaluator; the suffix coordinates are folded in below through `reduce`. The highest
+		// remaining coordinate is this round's `alpha`, folded into the interpolation, not the sum.
+		let alpha = self.eval_point[n_vars_remaining - 1];
+		let eq_chunk = eq_ind_partial_eval::<P>(&self.eval_point[..chunk_vars]);
+
 		let buffered_challenge = self.buffered_challenge.take();
 		let evaluators = &self.evaluators;
-		let eq_tracker = self.eq_tracker;
+		let eval_point = &self.eval_point;
 		let store = &mut self.store;
 		let map = |chunk: EvaluationChunk<'_, P>| {
-			// The eq-indicator chunk is shared by every evaluator: look it up once, then hand each
-			// a borrowing view.
-			let eq_ind = chunk.eq(eq_tracker);
 			let mut accum = vec![Default::default(); total_slots];
 			for (evaluator, window) in iter::zip(evaluators, offsets.windows(2)) {
-				evaluator.accumulate(&chunk, eq_ind.to_ref(), &mut accum[window[0]..window[1]]);
+				evaluator.accumulate(&chunk, eq_chunk.to_ref(), &mut accum[window[0]..window[1]]);
 			}
-			accum
+			// Reduce the wide accumulators so the eq-weighted `reduce` can linearly extrapolate on
+			// P.
+			accum.into_iter().map(P::reduce).collect::<Vec<P>>()
 		};
-		let reduce = |mut lhs: Vec<<P as WideMul>::Output>,
-		              rhs: Vec<<P as WideMul>::Output>,
-		              _level: usize| {
-			for (dst, src) in iter::zip(&mut lhs, rhs) {
-				*dst += src;
+		let reduce = |mut lhs: Vec<P>, rhs: Vec<P>, level: usize| {
+			// Fold the `level`-th (suffix) coordinate: eq weights the low half by `1 - z` and the
+			// high half by `z`, i.e. the linear extrapolation `lo + z * (hi - lo)`.
+			let z = P::broadcast(eval_point[level]);
+			for (lo, hi) in iter::zip(&mut lhs, rhs) {
+				*lo += z * (hi - *lo);
 			}
 			lhs
 		};
@@ -527,10 +536,10 @@ where
 			None => store.map_reduce(chunk_vars, map, reduce),
 		};
 
-		// Each evaluator interpolates its prime round polynomial from its claim and the round
-		// coordinate; the prover then records the coefficients for the coming fold.
+		// Each evaluator interpolates its prime round polynomial from its (reduced) accumulator,
+		// its claim, and the round coordinate; the prover then records the coefficients for the
+		// fold.
 		let store = &self.store;
-		let alpha = store.eq_alpha(self.eq_tracker);
 		let round_coeffs: Vec<RoundCoeffs<F>> =
 			iter::zip(iter::zip(&self.evaluators, &self.round_states), offsets.windows(2))
 				.map(|((evaluator, state), window)| {
@@ -671,9 +680,14 @@ mod tests {
 
 	// Prove the two fractional-addition claims through the MLE-check batch driver, then verify.
 	// The two claims share one store, so the four columns are folded and evaluated once.
+	//
+	// The 14- and 15-variable cases exceed `MAX_CHUNK_VARS`, so the eq indicator no longer fits in
+	// one chunk prefix: they exercise `SharedMleCheckProver`'s suffix folding, where the higher eq
+	// coordinates are linearly extrapolated in `reduce` — 15 in particular hits that path through
+	// both `map_reduce` (round 0) and the fused `map_reduce_with_fold` (round 1).
 	#[test]
 	fn test_shared_frac_add_prove_verify() {
-		for n_vars in [1, 2, 3, 8] {
+		for n_vars in [1, 2, 3, 8, 14, 15] {
 			let mut rng = StdRng::seed_from_u64(0);
 			let (cols, eval_point, claims) = frac_instance(&mut rng, n_vars);
 


### PR DESCRIPTION
Closes BINIUS-313.

`SharedMleCheckProver` no longer materializes the full `2^{n-1}` eq-indicator tensor. It now stores just the shared `eval_point` (no `eq_tracker`, no `register_eq_tracker`) and, each round, expands only a `chunk_vars`-wide prefix of the point as the per-chunk eq indicator, folding the higher (suffix) coordinates through the eq-weighted `reduce`.

Per the discussion on the issue, this uses **option (1)** for the accumulator reconciliation.

## Two commits

**1. Thread the reduction level through `MleStore::map_reduce`.** The `reduce` closure of `map_reduce`/`map_reduce_with_fold` now takes a third arg, `level` — the index of the variable bisected to produce the two sub-results. Purely mechanical: every caller (both shared provers, the store's own tests) keeps its existing additive behavior by ignoring `level`.

**2. Rework the eq handling in `SharedMleCheckProver`.**
- `execute` builds `eq_ind_partial_eval(&eval_point[..chunk_vars])` — a `2^chunk_vars` tensor over the low coordinates — and passes it as the `eq_ind` to every `accumulate`. Its `map` closure then `P::reduce`s the wide accumulators.
- Its `reduce` closure, instead of adding, does a linear extrapolation `lo + z·(hi − lo)` with `z = eval_point[level]` — the eq weighting of the `level`-th (suffix) coordinate. So the eq indicator factors as (materialized prefix) ⊗ (suffix folded lazily in the reduction tree); nothing beyond `2^chunk_vars` (≤ `2^12`) is ever expanded, independent of `n`.
- `MleCheckRoundEvaluator::interpolate` now takes a reduced `&[P]` accumulator (the `map` already reduced); `QuadraticMleEvaluator::interpolate` drops its own `P::reduce`.
- `into_shared_sumcheck` registers the shared eq tracker at conversion time (the plain-sumcheck path still uses it).

Per the issue, **`MleToSumCheckEvaluator` is otherwise unchanged** — it just reduces its wide accumulator to `&[P]` before delegating to the inner evaluator (a 2-line adaptation to the new `interpolate` signature). The sumcheck path continues to weight by the full eq tensor via the store tracker.

## Testing
- Extended `test_shared_frac_add_prove_verify` with `n_vars ∈ {14, 15}` — these exceed `MAX_CHUNK_VARS`, so they actually exercise the new suffix folding (15 hits it through both `map_reduce` and the fused `map_reduce_with_fold`); the earlier `n_vars ≤ 8` cases kept everything in the prefix and never invoked the new `reduce`. All round-trip prove→verify, so a wrong eq weighting fails verification.
- `cargo test` green: `binius-ip-prover` (58), `binius-m4-prover` (40), `binius-iop-prover` (35 + integration) — covers the standalone MLE-check prover, the wrapped logUp* final layer, the M4 operand path.
- clippy (`--tests --benches`) and nightly `fmt --check` clean; `cargo doc -D warnings` clean. Each commit builds + tests green independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)