### PR TITLE
BINIUS-315: hoist large allocations out of parallel regions in witness generation

### DIFF
--- a/crates/ip-prover/src/logup_star/witness.rs
+++ b/crates/ip-prover/src/logup_star/witness.rs
@@ -12,8 +12,8 @@
 use std::iter;
 
 use binius_field::{BinaryField, Divisible, Field, PackedField, util::powers};
-use binius_math::{FieldBuffer, multilinear::eq::scaled_eq_ind_partial_eval};
-use binius_utils::rayon::prelude::*;
+use binius_math::{FieldBuffer, multilinear::eq::scaled_eq_ind_partial_eval_into};
+use binius_utils::rayon::{current_num_threads, prelude::*};
 
 use super::prove::Looker;
 
@@ -59,12 +59,16 @@ where
 	// Why fan out: the per-looker expansion is itself parallel.
 	//   But it under-saturates the machine at moderate n.
 	//   Spreading the lookers over the cores fills them.
-	// Invariant: the parallel build writes results back in looker order.
+	// The 2^n buffers are allocated up front on this thread, so the parallel region only fills
+	// them — no allocator traffic inside the rayon closures.
+	// Invariant: the fill writes results back in looker order (the zip is index-aligned).
 	//   So numerator j stays gamma^j * eq_{r_j}.
-	let numerators = (0..lookers.len())
+	let mut numerators = (0..lookers.len())
+		.map(|_| FieldBuffer::<P>::zeros_truncated(0, n))
+		.collect::<Vec<_>>();
+	(numerators.par_iter_mut(), scales.as_slice(), lookers)
 		.into_par_iter()
-		.map(|j| {
-			let looker = &lookers[j];
+		.for_each(|(numerator, &scale, looker)| {
 			assert_eq!(
 				looker.eval_point.len(),
 				n,
@@ -80,9 +84,8 @@ where
 			// Looker j's numerator is gamma^j * eq_{r_j}.
 			// Seeding the expansion with gamma^j folds the scale into the tensor product.
 			// That keeps it to one pass over one 2^n buffer.
-			scaled_eq_ind_partial_eval::<P>(looker.eval_point, scales[j])
-		})
-		.collect::<Vec<_>>();
+			scaled_eq_ind_partial_eval_into(numerator, looker.eval_point, scale);
+		});
 
 	// Scatter every looker's numerator onto the shared table cube, summed into one buffer.
 	let combined = combined_pushforward::<F, P>(&numerators, lookers, table_n_vars);
@@ -129,27 +132,38 @@ where
 {
 	// One accumulator slot per table position.
 	let table_size = 1usize << table_n_vars;
+	let n_lookers = numerators.len();
 
-	let buckets = (0..numerators.len())
+	// One accumulator per worker, allocated up front on this thread rather than inside the
+	// parallel region. Each worker scatters a contiguous chunk of lookers into its own
+	// accumulator; the chunk count is capped at the number of workers (and at the looker count),
+	// so at most one accumulator is allocated per busy core.
+	let n_workers = current_num_threads().clamp(1, n_lookers.max(1));
+	let chunk_size = n_lookers.div_ceil(n_workers).max(1);
+	let mut accumulators = iter::repeat_with(|| vec![F::ZERO; table_size])
+		.take(n_lookers.div_ceil(chunk_size))
+		.collect::<Vec<_>>();
+
+	(
+		accumulators.par_iter_mut(),
+		numerators.par_chunks(chunk_size),
+		lookers.par_chunks(chunk_size),
+	)
 		.into_par_iter()
-		// Each task scatters a contiguous run of lookers into its own accumulator.
-		.fold(
-			|| vec![F::ZERO; table_size],
-			|mut acc, j| {
-				scatter_add(&mut acc, &numerators[j], lookers[j].index);
-				acc
-			},
-		)
-		// Merge the per-task accumulators position by position into one.
-		.reduce(
-			|| vec![F::ZERO; table_size],
-			|mut acc, partial| {
-				for (slot, add) in iter::zip(acc.iter_mut(), partial) {
-					*slot += add;
-				}
-				acc
-			},
-		);
+		.for_each(|(acc, numerator_chunk, looker_chunk)| {
+			for (numerator, looker) in iter::zip(numerator_chunk, looker_chunk) {
+				scatter_add(acc, numerator, looker.index);
+			}
+		});
+
+	// Merge the per-worker accumulators position by position into the first. The merge is a single
+	// pass of `n_workers` sums per slot, negligible against the scatter over every looker row.
+	let mut buckets = accumulators.pop().expect("at least one accumulator");
+	for partial in &accumulators {
+		for (slot, add) in iter::zip(buckets.iter_mut(), partial) {
+			*slot += *add;
+		}
+	}
 
 	// Repack the merged scalar accumulator into the packed table buffer.
 	FieldBuffer::from_values(&buckets)

--- a/crates/math/src/multilinear/eq.rs
+++ b/crates/math/src/multilinear/eq.rs
@@ -1,4 +1,5 @@
 // Copyright 2024-2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 use std::ops::DerefMut;
 
@@ -60,6 +61,24 @@ pub fn scaled_eq_ind_partial_eval<P: PackedField>(
 	scale: P::Scalar,
 ) -> FieldBuffer<P> {
 	hypercube::scaled_eq_ind_partial_eval::<OneCube, P>(point, scale)
+}
+
+/// Writes the scaled equality indicator expansion of `point` into a caller-supplied buffer.
+///
+/// This is the in-place form of [`scaled_eq_ind_partial_eval`]: the caller owns the output buffer,
+/// so its allocation can be hoisted out of a hot or parallel region. On return `buffer` has
+/// `log_len == point.len()`; any prior contents are overwritten. A scale of one reproduces the
+/// unscaled equality indicator.
+///
+/// ## Preconditions
+///
+/// * `buffer.log_cap()` must be at least `point.len()`.
+pub fn scaled_eq_ind_partial_eval_into<P: PackedField, Data: DerefMut<Target = [P]>>(
+	buffer: &mut FieldBuffer<P, Data>,
+	point: &[P::Scalar],
+	scale: P::Scalar,
+) {
+	hypercube::scaled_eq_ind_partial_eval_into::<OneCube, _, _>(buffer, point, scale)
 }
 
 /// Truncate the equality indicator expansion to the low indexed variables.
@@ -403,6 +422,35 @@ mod tests {
 			assert_eq!(
 				scaled_eq_ind_partial_eval::<P>(&point, F::ONE),
 				eq_ind_partial_eval::<P>(&point),
+				"mismatch at log_n={log_n}"
+			);
+		}
+	}
+
+	#[test]
+	fn scaled_eq_ind_partial_eval_into_matches_allocating() {
+		let mut rng = StdRng::seed_from_u64(2);
+
+		// Invariant: filling a caller-allocated buffer must reproduce the allocating variant
+		// exactly, including for a buffer whose capacity exceeds the point length and whose
+		// prior contents are stale.
+		for log_n in [0, 1, 2, 5, 8] {
+			let point = random_scalars::<F>(&mut rng, log_n);
+			let scale = random_scalars::<F>(&mut rng, 1)[0];
+
+			// Seed the reusable buffer at the maximum capacity and fill it with unrelated data to
+			// confirm `_into` overwrites rather than accumulates.
+			let mut buffer = FieldBuffer::<P>::zeros_truncated(8, 8);
+			for i in 0..buffer.len() {
+				buffer.set(i, scale + F::ONE);
+			}
+
+			scaled_eq_ind_partial_eval_into(&mut buffer, &point, scale);
+
+			assert_eq!(buffer.log_len(), log_n, "wrong length at log_n={log_n}");
+			assert_eq!(
+				buffer,
+				scaled_eq_ind_partial_eval::<P>(&point, scale),
 				"mismatch at log_n={log_n}"
 			);
 		}

--- a/crates/math/src/multilinear/hypercube.rs
+++ b/crates/math/src/multilinear/hypercube.rs
@@ -1,4 +1,5 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 //! Multilinear tensor expansions, generic over the hypercube the coefficients are indexed by.
 //!
@@ -248,14 +249,41 @@ pub fn scaled_eq_ind_partial_eval<Cube: Hypercube, P: PackedField>(
 ) -> FieldBuffer<P> {
 	// The expansion starts from a single value and grows one variable at a time.
 	// Allocate at the final capacity 2^n now, so the growth never reallocates.
-	let log_size = point.len();
-	let mut buffer = FieldBuffer::zeros_truncated(0, log_size);
-
-	// Seed the starting value with the scale.
-	// The expansion multiplies it through, so every coefficient ends up scaled.
-	buffer.set(0, scale);
-	tensor_prod_eq_ind::<Cube, _, _>(&mut buffer, point);
+	let mut buffer = FieldBuffer::zeros_truncated(0, point.len());
+	scaled_eq_ind_partial_eval_into::<Cube, _, _>(&mut buffer, point, scale);
 	buffer
+}
+
+/// Writes the scaled equality indicator expansion of `point` into a caller-supplied buffer.
+///
+/// This is the in-place form of [`scaled_eq_ind_partial_eval`]: the caller owns the output buffer,
+/// so its allocation can be hoisted out of a hot or parallel region and reused. On return `buffer`
+/// has `log_len == point.len()` and holds the tensor product $scale \cdot b(r_0) \otimes \ldots
+/// \otimes b(r_{n-1})$. Any prior contents are overwritten.
+///
+/// ## Preconditions
+///
+/// * `buffer.log_cap()` must be at least `point.len()`.
+pub fn scaled_eq_ind_partial_eval_into<
+	Cube: Hypercube,
+	P: PackedField,
+	Data: DerefMut<Target = [P]>,
+>(
+	buffer: &mut FieldBuffer<P, Data>,
+	point: &[P::Scalar],
+	scale: P::Scalar,
+) {
+	assert!(
+		buffer.log_cap() >= point.len(),
+		"precondition: buffer capacity must be sufficient for expansion"
+	);
+
+	// The expansion starts from a single value and grows one variable at a time, so reset the
+	// buffer to a single scalar seeded with the scale. The expansion multiplies it through, so
+	// every coefficient ends up scaled.
+	buffer.truncate(0);
+	buffer.set(0, scale);
+	tensor_prod_eq_ind::<Cube, _, _>(buffer, point);
 }
 
 /// Truncate the equality indicator expansion to the low indexed variables.

--- a/crates/prover/src/protocols/intmul/witness.rs
+++ b/crates/prover/src/protocols/intmul/witness.rs
@@ -120,9 +120,15 @@ where
 			.step_by(LIMB_BITS)
 			.take(2 * N_LIMBS)
 			.collect::<Vec<_>>();
-		let tables = bases
+		// Allocate the table buffers up front on this thread, so the parallel region only fills
+		// them — no allocator traffic inside the rayon closures.
+		let packed_len = 1 << LIMB_BITS.saturating_sub(P::LOG_WIDTH);
+		let buffers = iter::repeat_with(|| Vec::<P>::with_capacity(packed_len))
+			.take(bases.len())
+			.collect::<Vec<_>>();
+		let tables = (bases, buffers)
 			.into_par_iter()
-			.map(|base| power_table::<F, P>(LIMB_BITS, base))
+			.map(|(base, buffer)| power_table_into(LIMB_BITS, base, buffer))
 			.collect::<Vec<_>>();
 		drop(power_table_scope);
 
@@ -191,6 +197,32 @@ where
 	F: Field,
 	P: PackedField<Scalar = F>,
 {
+	let buffer = Vec::with_capacity(1 << log_size.saturating_sub(P::LOG_WIDTH));
+	power_table_into(log_size, base, buffer)
+}
+
+/// Fill `buffer` with the power table of `base` and wrap it as a [`FieldBuffer`] of `2^log_size`
+/// rows: row `i` holds `base^i`.
+///
+/// The caller supplies the backing `Vec`, so its allocation can be hoisted out of a hot or parallel
+/// region; `buffer` is cleared and refilled here without reallocating.
+///
+/// # Preconditions
+///
+/// * `buffer.capacity()` must equal `1 << log_size.saturating_sub(P::LOG_WIDTH)`.
+fn power_table_into<F, P>(log_size: usize, base: F, mut buffer: Vec<P>) -> FieldBuffer<P>
+where
+	F: Field,
+	P: PackedField<Scalar = F>,
+{
+	let packed_len = 1 << log_size.saturating_sub(P::LOG_WIDTH);
+	assert_eq!(
+		buffer.capacity(),
+		packed_len,
+		"precondition: buffer capacity must match the packed table length"
+	);
+	buffer.clear();
+
 	// The first block spans `2^log_block` scalars = `2^LOG_STRIDE` packed elements.
 	let log_block = P::LOG_WIDTH + LOG_STRIDE;
 
@@ -198,38 +230,33 @@ where
 	// also covers `log_size < P::LOG_WIDTH` (a single partially-filled packed element).
 	if log_size <= log_block {
 		let (scalars, _) = sequential_powers(1 << log_size, base);
-		return FieldBuffer::<P>::from_values(&scalars);
+		buffer.extend(
+			scalars
+				.chunks(P::WIDTH)
+				.map(|chunk| P::from_scalars(chunk.iter().copied())),
+		);
+		return FieldBuffer::new(log_size, buffer.into_boxed_slice());
 	}
 
 	// Build the first block's `2^log_block` sequential powers, packed into `2^LOG_STRIDE` elements;
 	// `incr = base^(2^log_block)` is the per-block increment.
 	let (block_scalars, incr_scalar) = sequential_powers(1 << log_block, base);
 	let incr = P::broadcast(incr_scalar);
-
-	let block_len = 1 << LOG_STRIDE; // packed elements per block
-	let packed_len = 1 << (log_size - P::LOG_WIDTH);
-	let mut table = Vec::<P>::with_capacity(packed_len);
-	table.extend(
+	buffer.extend(
 		block_scalars
 			.chunks(P::WIDTH)
 			.map(|chunk| P::from_scalars(chunk.iter().copied())),
 	);
-	table.resize(packed_len, P::zero());
 
-	// Fill each block from the previous one; the `block_len` multiplies within a block are
-	// independent, so only the block-to-block step carries a dependency.
-	let mut blocks = table.chunks_mut(block_len);
-	let mut prev = blocks
-		.next()
-		.expect("log_size > log_block, so packed_len > block_len");
-	for cur in blocks {
-		for (dst, &src) in cur.iter_mut().zip(prev.iter()) {
-			*dst = src * incr;
-		}
-		prev = cur;
+	// Fill each remaining packed element from the one a block earlier; the `block_len` multiplies
+	// within a block are independent, so only the block-to-block step carries a dependency.
+	let block_len = 1 << LOG_STRIDE; // packed elements per block
+	for i in block_len..packed_len {
+		let next = buffer[i - block_len] * incr;
+		buffer.push(next);
 	}
 
-	FieldBuffer::new(log_size, table.into_boxed_slice())
+	FieldBuffer::new(log_size, buffer.into_boxed_slice())
 }
 
 /// Extract limb `l` of an exponent word as a table row index.


### PR DESCRIPTION
## Summary

Behavior-preserving refactor. Hoists large buffer allocations out of rayon closures at the three witness-generation sites called out in [BINIUS-315](https://linear.app/jimpo/issue/BINIUS-315/hoist-large-allocations-out-of-parallel-regions-in-witness-generation), so allocation happens once on the calling thread rather than per rayon task. This removes per-task allocator traffic and is a prerequisite for the `Pool`/`PoolVec` allocator work (which is cheapest to reason about when allocation is single-threaded).

The fix follows the existing model at `crates/prover/src/protocols/intmul/witness.rs` (`compute_b_leaves_parallel`): pre-allocate the output buffers on the calling thread, then `par_iter_mut` over them and fill in place — turning `map(|x| alloc_and_fill(x))` into `zip(&mut outs).for_each(|(out, x)| fill(out, x))`.

## Commits

1. **Add `scaled_eq_ind_partial_eval_into` for caller-allocated output** — the enabling API in `binius-math`. Writes the scaled eq-indicator expansion into a caller-supplied buffer (the in-place form of `scaled_eq_ind_partial_eval`, which is refactored to delegate to it). New test asserts it reproduces the allocating variant exactly, including buffer reuse with stale contents.
2. **Hoist logup\* witness allocations out of parallel regions** — addresses issue sites 1 and 3 in `logup_star/witness.rs`:
   - *Site 3* (numerators): pre-allocate one `2^n` buffer per looker, fill via `scaled_eq_ind_partial_eval_into` in the parallel region.
   - *Site 1* (`combined_pushforward`): replace the `fold`/`reduce` — which allocated a full `2^m` table per rayon task *and* per reduce step — with one accumulator per worker allocated up front, each scattering a contiguous chunk of lookers, then a single-pass merge.
3. **Hoist intmul power table allocations out of parallel region** — addresses issue site 2. Split `power_table` into a thin allocating wrapper and a new `power_table_into` that fills a caller-provided buffer; the `Witness::new` call site pre-allocates the `2 * N_LIMBS` tables and fills them via `par_iter_mut`.

## Acceptance

- No `FieldBuffer` or comparably-sized `Vec` is allocated inside a rayon closure in `crates/prover/src/protocols/intmul/witness.rs` or `crates/ip-prover/src/logup_star/witness.rs`. The two noted related sites (the `buffer_bivariate_product` collect and the pushforward repack) already run on the calling thread and are left for the pool-allocator work.
- No regression: the per-closure compute is byte-identical to before; only the allocation site moved. The one structural change is site 1 (fold/reduce → static chunking + sequential merge). Lookers are equal-cost (same `n`), so static chunking across `current_num_threads()` workers is balanced, and the merge is negligible against the scatter over every looker row. **Flag if you'd rather keep rayon's dynamic work-stealing here.**

Verified green: nightly `fmt --check`, `clippy --tests --benches --examples -D warnings`, rust-doc `-D warnings`, and unit tests (`binius-math` eq, `ip-prover` logup\_star, `prover` intmul::witness). Each commit builds in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)