### PR TITLE
BINIUS-317: remove the FieldBuffer capacity API

### DIFF
--- a/crates/ip-prover/src/logup_star/witness.rs
+++ b/crates/ip-prover/src/logup_star/witness.rs
@@ -59,16 +59,17 @@ where
 	// Why fan out: the per-looker expansion is itself parallel.
 	//   But it under-saturates the machine at moderate n.
 	//   Spreading the lookers over the cores fills them.
-	// The 2^n buffers are allocated up front on this thread, so the parallel region only fills
+	// The 2^n backing Vecs are reserved up front on this thread, so the parallel region only fills
 	// them — no allocator traffic inside the rayon closures.
 	// Invariant: the fill writes results back in looker order (the zip is index-aligned).
 	//   So numerator j stays gamma^j * eq_{r_j}.
-	let mut numerators = (0..lookers.len())
-		.map(|_| FieldBuffer::<P>::zeros_truncated(0, n))
+	let packed_len = 1 << n.saturating_sub(P::LOG_WIDTH);
+	let buffers = iter::repeat_with(|| Vec::<P>::with_capacity(packed_len))
+		.take(lookers.len())
 		.collect::<Vec<_>>();
-	(numerators.par_iter_mut(), scales.as_slice(), lookers)
+	let numerators = (buffers, scales.as_slice(), lookers)
 		.into_par_iter()
-		.for_each(|(numerator, &scale, looker)| {
+		.map(|(buffer, &scale, looker)| {
 			assert_eq!(
 				looker.eval_point.len(),
 				n,
@@ -84,8 +85,9 @@ where
 			// Looker j's numerator is gamma^j * eq_{r_j}.
 			// Seeding the expansion with gamma^j folds the scale into the tensor product.
 			// That keeps it to one pass over one 2^n buffer.
-			scaled_eq_ind_partial_eval_into(numerator, looker.eval_point, scale);
-		});
+			scaled_eq_ind_partial_eval_into(looker.eval_point, scale, buffer)
+		})
+		.collect::<Vec<_>>();
 
 	// Scatter every looker's numerator onto the shared table cube, summed into one buffer.
 	let combined = combined_pushforward::<F, P>(&numerators, lookers, table_n_vars);

--- a/crates/ip-prover/src/sumcheck/switchover.rs
+++ b/crates/ip-prover/src/sumcheck/switchover.rs
@@ -1,6 +1,10 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
-use std::ops::{Deref, DerefMut};
+use std::{
+	mem,
+	ops::{Deref, DerefMut},
+};
 
 use binius_field::{Field, PackedField};
 use binius_math::{
@@ -32,7 +36,8 @@ use binius_utils::{
 pub struct BinarySwitchover<'b, P: PackedField, B: Bitwise> {
 	n_multilinears: usize,
 	bitmasks: &'b [B],
-	tensor: FieldBuffer<P>,
+	// The folding tensor grows one variable per pre-switchover round, so it is backed by a `Vec`.
+	tensor: FieldBuffer<P, Vec<P>>,
 	folded: Option<Vec<FieldBuffer<P>>>,
 	switchover: usize,
 }
@@ -57,15 +62,17 @@ where
 
 		let n_vars = checked_log_2(bitmasks.len());
 		let switchover = switchover.min(n_vars).max(1);
-		let mut tensor = FieldBuffer::zeros_truncated(0, switchover);
-		tensor.set(0, F::ONE);
+		// The folding tensor starts as the scalar `1`, with backing reserved for the fully-grown
+		// (`switchover`-variable) tensor so the per-round growth never reallocates.
+		let tensor = FieldBuffer::scalar_with_capacity(F::ONE, switchover);
 
 		Self {
 			n_multilinears,
 			bitmasks,
 			tensor,
 			folded: None,
-			// Store this separately as `log_cap` is rounded up to the packing width
+			// The tensor grows up to this many variables; store it since it can't be recovered from
+			// the buffer once the growth completes.
 			switchover,
 		}
 	}
@@ -114,7 +121,8 @@ where
 		} else {
 			// Pre-switchover: update the folding tensor
 			assert!(self.tensor.log_len() < self.switchover);
-			tensor_prod_eq_ind_prepend(&mut self.tensor, &[challenge]);
+			let tensor = mem::replace(&mut self.tensor, FieldBuffer::new(0, vec![P::zero()]));
+			self.tensor = tensor_prod_eq_ind_prepend(tensor, &[challenge]);
 
 			if self.tensor.log_len() == self.switchover {
 				self.perform();

--- a/crates/math/src/field_buffer.rs
+++ b/crates/math/src/field_buffer.rs
@@ -133,6 +133,27 @@ impl<P: PackedField> FieldBuffer<P> {
 	}
 }
 
+impl<P: PackedField> FieldBuffer<P, Vec<P>> {
+	/// A single-scalar buffer (`log_len` 0) holding `value` in lane 0, with backing-`Vec` capacity
+	/// reserved for `log_capacity` variables.
+	///
+	/// The backing `Vec` reserves `1 << log_capacity.saturating_sub(P::LOG_WIDTH)` packed words, so
+	/// growing the buffer up to `log_capacity` variables never reallocates.
+	pub fn scalar_with_capacity(value: P::Scalar, log_capacity: usize) -> Self {
+		let mut values = Vec::with_capacity(1 << log_capacity.saturating_sub(P::LOG_WIDTH));
+		values.push(P::from_scalars([value]));
+		Self { log_len: 0, values }
+	}
+
+	/// Converts into the canonical boxed-slice-backed [`FieldBuffer`].
+	pub fn into_boxed(self) -> FieldBuffer<P> {
+		FieldBuffer {
+			log_len: self.log_len,
+			values: self.values.into_boxed_slice(),
+		}
+	}
+}
+
 #[allow(clippy::len_without_is_empty)]
 impl<P: PackedField, Data: Deref<Target = [P]>> FieldBuffer<P, Data> {
 	/// Create a new FieldBuffer from a slice of packed values.
@@ -167,6 +188,11 @@ impl<P: PackedField, Data: Deref<Target = [P]>> FieldBuffer<P, Data> {
 		);
 
 		Self { log_len, values }
+	}
+
+	/// Consumes the buffer and returns its backing data store.
+	pub fn take_data(self) -> Data {
+		self.values
 	}
 
 	/// Returns log2 the number of field elements that the underlying collection may take.

--- a/crates/math/src/field_buffer.rs
+++ b/crates/math/src/field_buffer.rs
@@ -11,7 +11,7 @@ use binius_field::{
 	packed::{get_packed_slice_unchecked, set_packed_slice_unchecked},
 };
 use binius_utils::{
-	checked_arithmetics::{checked_log_2, strict_log_2},
+	checked_arithmetics::strict_log_2,
 	rayon::{iter::Either, prelude::*, slice::ParallelSlice},
 };
 use bytemuck::zeroed_vec;
@@ -25,7 +25,7 @@ pub trait AsSlicesMut<P: PackedField, const N: usize> {
 ///
 /// This struct maintains a set of invariants:
 ///  1) `values.len()` is a power of two
-///  2) `values.len() >= 1 << log_len.saturating_sub(P::LOG_WIDTH)`.
+///  2) `values.len() == 1 << log_len.saturating_sub(P::LOG_WIDTH)`.
 #[derive(Debug, Clone, Eq)]
 pub struct FieldBuffer<P: PackedField, Data: Deref<Target = [P]> = Box<[P]>> {
 	/// log2 the number over elements in the buffer.
@@ -36,7 +36,7 @@ pub struct FieldBuffer<P: PackedField, Data: Deref<Target = [P]> = Box<[P]>> {
 
 impl<P: PackedField, Data: Deref<Target = [P]>> PartialEq for FieldBuffer<P, Data> {
 	fn eq(&self, other: &Self) -> bool {
-		// Lanes from the logical length up to the capacity hold arbitrary data.
+		// Lanes past the logical length within the final packed word hold arbitrary data.
 		// Equality compares only the live scalars, never the raw packed backing store.
 		//
 		// Invariant: buffers of different lengths are never equal.
@@ -78,34 +78,13 @@ impl<P: PackedField> FieldBuffer<P> {
 		let log_len =
 			strict_log_2(values.len()).expect("precondition: values.len() must be a power of two");
 
-		Self::from_values_truncated(values, log_len)
-	}
-
-	/// Create a new FieldBuffer from a vector of values.
-	///
-	/// Capacity `log_cap` is bumped to at least `P::LOG_WIDTH`.
-	///
-	/// # Preconditions
-	///
-	/// * `values.len()` must be a power of two.
-	/// * `values.len()` must not exceed `1 << log_cap`.
-	pub fn from_values_truncated(values: &[P::Scalar], log_cap: usize) -> Self {
-		assert!(
-			values.len().is_power_of_two(),
-			"precondition: values.len() must be a power of two"
-		);
-
-		let log_len = values.len().ilog2() as usize;
-		assert!(log_len <= log_cap, "precondition: values.len() must not exceed 1 << log_cap");
-
-		let packed_cap = 1 << log_cap.saturating_sub(P::LOG_WIDTH);
-		let mut packed_values = Vec::with_capacity(packed_cap);
+		let packed_len = 1 << log_len.saturating_sub(P::LOG_WIDTH);
+		let mut packed_values = Vec::with_capacity(packed_len);
 		packed_values.extend(
 			values
 				.chunks(P::WIDTH)
 				.map(|chunk| P::from_scalars(chunk.iter().copied())),
 		);
-		packed_values.resize(packed_cap, P::zero());
 
 		Self {
 			log_len,
@@ -115,19 +94,7 @@ impl<P: PackedField> FieldBuffer<P> {
 
 	/// Create a new [`FieldBuffer`] of zeros with the given log_len.
 	pub fn zeros(log_len: usize) -> Self {
-		Self::zeros_truncated(log_len, log_len)
-	}
-
-	/// Create a new [`FieldBuffer`] of zeros with the given log_len and capacity log_cap.
-	///
-	/// Capacity `log_cap` is bumped to at least `P::LOG_WIDTH`.
-	///
-	/// # Preconditions
-	///
-	/// * `log_len` must not exceed `log_cap`.
-	pub fn zeros_truncated(log_len: usize, log_cap: usize) -> Self {
-		assert!(log_len <= log_cap, "precondition: log_len must not exceed log_cap");
-		let packed_len = 1 << log_cap.saturating_sub(P::LOG_WIDTH);
+		let packed_len = 1 << log_len.saturating_sub(P::LOG_WIDTH);
 		let values = zeroed_vec(packed_len).into_boxed_slice();
 		Self { log_len, values }
 	}
@@ -167,25 +134,6 @@ impl<P: PackedField, Data: Deref<Target = [P]>> FieldBuffer<P, Data> {
 			values.len() == expected_packed_len,
 			"precondition: values.len() must equal expected packed length"
 		);
-		Self::new_truncated(log_len, values)
-	}
-
-	/// Create a new FieldBuffer from a slice of packed values.
-	///
-	/// # Preconditions
-	///
-	/// * `values.len()` must be at least the minimum packed length for `log_len`.
-	/// * `values.len()` must be a power of two.
-	pub fn new_truncated(log_len: usize, values: Data) -> Self {
-		let min_packed_len = 1 << log_len.saturating_sub(P::LOG_WIDTH);
-		assert!(
-			values.len() >= min_packed_len,
-			"precondition: values.len() must be at least {min_packed_len}"
-		);
-		assert!(
-			values.len().is_power_of_two(),
-			"precondition: values.len() must be a power of two"
-		);
 
 		Self { log_len, values }
 	}
@@ -193,16 +141,6 @@ impl<P: PackedField, Data: Deref<Target = [P]>> FieldBuffer<P, Data> {
 	/// Consumes the buffer and returns its backing data store.
 	pub fn take_data(self) -> Data {
 		self.values
-	}
-
-	/// Returns log2 the number of field elements that the underlying collection may take.
-	pub fn log_cap(&self) -> usize {
-		checked_log_2(self.values.len()) + P::LOG_WIDTH
-	}
-
-	/// Returns the number of field elements that the underlying collection may take.
-	pub fn cap(&self) -> usize {
-		1 << self.log_cap()
 	}
 
 	/// Returns log2 the number of field elements.
@@ -428,47 +366,6 @@ impl<P: PackedField, Data: DerefMut<Target = [P]>> FieldBuffer<P, Data> {
 	/// If `new_log_len` is not less than current `log_len()`, this has no effect.
 	pub fn truncate(&mut self, new_log_len: usize) {
 		self.log_len = self.log_len.min(new_log_len);
-	}
-
-	/// Zero extends a field buffer to a longer length.
-	///
-	/// If `new_log_len` is not greater than current `log_len()`, this has no effect.
-	///
-	/// # Preconditions
-	///
-	/// * `new_log_len` must not exceed the buffer's capacity.
-	pub fn zero_extend(&mut self, new_log_len: usize) {
-		if new_log_len <= self.log_len {
-			return;
-		}
-
-		assert!(new_log_len <= self.log_cap(), "precondition: new_log_len must not exceed log_cap");
-
-		if self.log_len < P::LOG_WIDTH {
-			let first_elem = self.values.first_mut().expect("values.len() >= 1");
-			for i in 1 << self.log_len..(1 << new_log_len).min(P::WIDTH) {
-				first_elem.set(i, P::Scalar::ZERO);
-			}
-		}
-
-		let packed_start = 1 << self.log_len.saturating_sub(P::LOG_WIDTH);
-		let packed_end = 1 << new_log_len.saturating_sub(P::LOG_WIDTH);
-		self.values[packed_start..packed_end].fill(P::zero());
-
-		self.log_len = new_log_len;
-	}
-
-	/// Sets the new log length. If the new log length is bigger than the current log length,
-	/// the new values (in case when `self.log_len < new_log_len`) will be filled with
-	/// the values from the existing buffer.
-	///
-	/// # Preconditions
-	///
-	/// * `new_log_len` must not exceed the buffer's capacity.
-	pub fn resize(&mut self, new_log_len: usize) {
-		assert!(new_log_len <= self.log_cap(), "precondition: new_log_len must not exceed log_cap");
-
-		self.log_len = new_log_len;
 	}
 
 	/// Split the buffer into mutable chunks of size `2^log_chunk_size`.
@@ -1223,7 +1120,7 @@ mod tests {
 
 	#[test]
 	fn test_to_ref_to_mut() {
-		let mut buffer = FieldBuffer::<P>::zeros_truncated(3, 5);
+		let mut buffer = FieldBuffer::<P>::zeros(3);
 
 		// Test to_ref
 		let slice_ref = buffer.to_ref();
@@ -1242,8 +1139,7 @@ mod tests {
 	fn test_split_half() {
 		// Test with buffer size > P::WIDTH (multiple packed elements)
 		let values: Vec<F> = (0..16).map(F::new).collect();
-		// Leave spare capacity for 32 elements
-		let buffer = FieldBuffer::<P>::from_values_truncated(&values, 5);
+		let buffer = FieldBuffer::<P>::from_values(&values);
 
 		let (first, second) = buffer.split_half_ref();
 		assert_eq!(first.len(), 8);
@@ -1257,9 +1153,8 @@ mod tests {
 
 		// Test with buffer size = P::WIDTH (single packed element)
 		// P::LOG_WIDTH = 2, so P::WIDTH = 4
-		// Note that underlying collection has two packed fields.
 		let values: Vec<F> = (0..4).map(F::new).collect();
-		let buffer = FieldBuffer::<P>::from_values_truncated(&values, 3);
+		let buffer = FieldBuffer::<P>::from_values(&values);
 
 		let (first, second) = buffer.split_half_ref();
 		assert_eq!(first.len(), 2);
@@ -1283,7 +1178,7 @@ mod tests {
 
 		// Test with buffer size = 2 (less than P::WIDTH)
 		let values: Vec<F> = vec![F::new(10), F::new(20)];
-		let buffer = FieldBuffer::<P>::from_values_truncated(&values, 3);
+		let buffer = FieldBuffer::<P>::from_values(&values);
 
 		let (first, second) = buffer.split_half_ref();
 		assert_eq!(first.len(), 1);
@@ -1309,50 +1204,6 @@ mod tests {
 		let values = vec![F::new(42)];
 		let buffer = FieldBuffer::<P>::from_values(&values);
 		let _ = buffer.split_half_ref();
-	}
-
-	#[test]
-	fn test_zero_extend() {
-		let log_len = 10;
-		let nonzero_scalars = (0..1 << log_len).map(|i| F::new(i + 1)).collect::<Vec<_>>();
-		let mut buffer = FieldBuffer::<P>::from_values(&nonzero_scalars);
-		buffer.truncate(0);
-
-		for i in 0..log_len {
-			buffer.zero_extend(i + 1);
-
-			for j in 1 << i..1 << (i + 1) {
-				assert!(buffer.get(j).is_zero());
-			}
-		}
-	}
-
-	#[test]
-	fn test_resize() {
-		let mut buffer = FieldBuffer::<P>::zeros(4); // 16 elements
-
-		// Fill with test data
-		for i in 0..16 {
-			buffer.set(i, F::new(i as u128));
-		}
-
-		buffer.resize(3);
-		assert_eq!(buffer.log_len(), 3);
-		assert_eq!(buffer.get(7), F::new(7));
-
-		buffer.resize(4);
-		assert_eq!(buffer.log_len(), 4);
-		assert_eq!(buffer.get(15), F::new(15));
-
-		buffer.resize(2);
-		assert_eq!(buffer.log_len(), 2);
-	}
-
-	#[test]
-	#[should_panic(expected = "precondition")]
-	fn test_resize_exceeds_capacity() {
-		let mut buffer = FieldBuffer::<P>::zeros(4); // 16 elements
-		buffer.resize(5);
 	}
 
 	#[test]
@@ -1414,14 +1265,6 @@ mod tests {
 		let collected2: Vec<F> = iter2.collect();
 		assert_eq!(collected1, collected2);
 		assert_eq!(collected1, values);
-
-		// Test with buffer that has extra capacity
-		let values: Vec<F> = (0..8).map(F::new).collect();
-		let buffer = FieldBuffer::<P>::from_values_truncated(&values, 5); // 8 elements, capacity for 32
-
-		let collected: Vec<F> = buffer.iter_scalars().collect();
-		assert_eq!(collected, values);
-		assert_eq!(collected.len(), 8); // Should only iterate over actual elements, not capacity
 	}
 
 	#[test]

--- a/crates/math/src/multilinear/eq.rs
+++ b/crates/math/src/multilinear/eq.rs
@@ -10,17 +10,13 @@ use crate::FieldBuffer;
 
 /// Left tensor of values with the eq indicator evaluated at extra_query_coordinates.
 ///
-/// This is [`hypercube::tensor_prod_eq_ind_prepend`] over the Boolean hypercube.
-///
-/// ## Preconditions
-///
-/// * `values` must have enough capacity: `values.log_cap() >= values.log_len() +
-///   extra_query_coordinates.len()`
-pub fn tensor_prod_eq_ind_prepend<P: PackedField, Data: DerefMut<Target = [P]>>(
-	values: &mut FieldBuffer<P, Data>,
+/// This is [`hypercube::tensor_prod_eq_ind_prepend`] over the Boolean hypercube. The returned
+/// buffer grows its backing `Vec` by one variable per coordinate.
+pub fn tensor_prod_eq_ind_prepend<P: PackedField>(
+	values: FieldBuffer<P, Vec<P>>,
 	extra_query_coordinates: &[P::Scalar],
-) {
-	hypercube::tensor_prod_eq_ind_prepend::<OneCube, _, _>(values, extra_query_coordinates)
+) -> FieldBuffer<P, Vec<P>> {
+	hypercube::tensor_prod_eq_ind_prepend::<OneCube, P>(values, extra_query_coordinates)
 }
 
 /// Computes the partial evaluation of the equality indicator polynomial.
@@ -63,22 +59,22 @@ pub fn scaled_eq_ind_partial_eval<P: PackedField>(
 	hypercube::scaled_eq_ind_partial_eval::<OneCube, P>(point, scale)
 }
 
-/// Writes the scaled equality indicator expansion of `point` into a caller-supplied buffer.
+/// Builds the scaled equality indicator expansion of `point` in a caller-supplied backing `Vec`.
 ///
-/// This is the in-place form of [`scaled_eq_ind_partial_eval`]: the caller owns the output buffer,
-/// so its allocation can be hoisted out of a hot or parallel region. On return `buffer` has
-/// `log_len == point.len()`; any prior contents are overwritten. A scale of one reproduces the
-/// unscaled equality indicator.
+/// This is the allocation-hoisting form of [`scaled_eq_ind_partial_eval`]: the caller owns the
+/// backing `Vec`, so its allocation can be reserved on a different thread than the one that fills
+/// it. Returns a buffer with `log_len == point.len()`. A scale of one reproduces the unscaled
+/// equality indicator.
 ///
-/// ## Preconditions
+/// # Preconditions
 ///
-/// * `buffer.log_cap()` must be at least `point.len()`.
-pub fn scaled_eq_ind_partial_eval_into<P: PackedField, Data: DerefMut<Target = [P]>>(
-	buffer: &mut FieldBuffer<P, Data>,
+/// * `buffer.capacity()` must equal `1 << point.len().saturating_sub(P::LOG_WIDTH)`.
+pub fn scaled_eq_ind_partial_eval_into<P: PackedField>(
 	point: &[P::Scalar],
 	scale: P::Scalar,
-) {
-	hypercube::scaled_eq_ind_partial_eval_into::<OneCube, _, _>(buffer, point, scale)
+	buffer: Vec<P>,
+) -> FieldBuffer<P> {
+	hypercube::scaled_eq_ind_partial_eval_into::<OneCube, P>(point, scale, buffer)
 }
 
 /// Truncate the equality indicator expansion to the low indexed variables.
@@ -191,10 +187,8 @@ mod tests {
 		let v0 = F::from(1);
 		let v1 = F::from(2);
 		let query = vec![v0, v1];
-		// log_len = 0, query.len() = 2, so total log_cap = 2
-		let mut result = FieldBuffer::zeros_truncated(0, query.len());
-		result.set(0, F::ONE);
-		tensor_prod_eq_ind::<OneCube, P, _>(&mut result, &query);
+		let result = FieldBuffer::<P, _>::scalar_with_capacity(F::ONE, query.len());
+		let result = tensor_prod_eq_ind::<OneCube, P>(result, &query);
 		let result_vec: Vec<F> = P::iter_slice(result.as_ref()).collect();
 		assert_eq!(
 			result_vec,
@@ -214,13 +208,12 @@ mod tests {
 		let exps = 4;
 		let max_n_vars = exps * (exps + 1) / 2;
 		let mut coords = Vec::with_capacity(max_n_vars);
-		let mut eq_expansion = FieldBuffer::zeros_truncated(0, max_n_vars);
-		eq_expansion.set(0, F::ONE);
+		let mut eq_expansion = FieldBuffer::<P, _>::scalar_with_capacity(F::ONE, max_n_vars);
 
 		for extra_count in 1..=exps {
 			let extra = random_scalars(&mut rng, extra_count);
 
-			tensor_prod_eq_ind::<OneCube, P, _>(&mut eq_expansion, &extra);
+			eq_expansion = tensor_prod_eq_ind::<OneCube, P>(eq_expansion, &extra);
 			coords.extend(&extra);
 
 			assert_eq!(eq_expansion.log_len(), coords.len());
@@ -398,13 +391,12 @@ mod tests {
 
 		let append = eq_ind_partial_eval(&point);
 
-		let mut prepend = FieldBuffer::<P>::zeros_truncated(0, n_vars);
+		let prepend = FieldBuffer::<P, _>::scalar_with_capacity(F::ONE, n_vars);
 		let (prefix, suffix) = point.split_at(n_vars - base_vars);
-		prepend.set(0, F::ONE);
-		tensor_prod_eq_ind::<OneCube, P, _>(&mut prepend, suffix);
-		tensor_prod_eq_ind_prepend(&mut prepend, prefix);
+		let prepend = tensor_prod_eq_ind::<OneCube, P>(prepend, suffix);
+		let prepend = tensor_prod_eq_ind_prepend(prepend, prefix);
 
-		assert_eq!(append, prepend);
+		assert_eq!(append, prepend.into_boxed());
 	}
 
 	#[test]
@@ -431,25 +423,20 @@ mod tests {
 	fn scaled_eq_ind_partial_eval_into_matches_allocating() {
 		let mut rng = StdRng::seed_from_u64(2);
 
-		// Invariant: filling a caller-allocated buffer must reproduce the allocating variant
-		// exactly, including for a buffer whose capacity exceeds the point length and whose
-		// prior contents are stale.
+		// Invariant: filling a caller-reserved backing Vec reproduces the allocating variant
+		// exactly.
 		for log_n in [0, 1, 2, 5, 8] {
 			let point = random_scalars::<F>(&mut rng, log_n);
 			let scale = random_scalars::<F>(&mut rng, 1)[0];
 
-			// Seed the reusable buffer at the maximum capacity and fill it with unrelated data to
-			// confirm `_into` overwrites rather than accumulates.
-			let mut buffer = FieldBuffer::<P>::zeros_truncated(8, 8);
-			for i in 0..buffer.len() {
-				buffer.set(i, scale + F::ONE);
-			}
+			// Reserve the exact packed capacity the routine requires.
+			let packed_len = 1 << log_n.saturating_sub(P::LOG_WIDTH);
+			let result =
+				scaled_eq_ind_partial_eval_into(&point, scale, Vec::with_capacity(packed_len));
 
-			scaled_eq_ind_partial_eval_into(&mut buffer, &point, scale);
-
-			assert_eq!(buffer.log_len(), log_n, "wrong length at log_n={log_n}");
+			assert_eq!(result.log_len(), log_n, "wrong length at log_n={log_n}");
 			assert_eq!(
-				buffer,
+				result,
 				scaled_eq_ind_partial_eval::<P>(&point, scale),
 				"mismatch at log_n={log_n}"
 			);

--- a/crates/math/src/multilinear/hypercube.rs
+++ b/crates/math/src/multilinear/hypercube.rs
@@ -123,19 +123,33 @@ impl Hypercube for InfCube {
 	}
 }
 
+/// Grows a packed backing `Vec` from `log_len` to `log_len + 1` variables, zero-initializing the
+/// newly live region so the store stays fully initialized.
+///
+/// This is a temporary placeholder for the tensor-expansion routines below: it re-initializes the
+/// region the expansion immediately overwrites. A follow-up will split the fill by packing width
+/// and use `spare_capacity_mut`/`set_len` to bump the length without the redundant writes.
+fn grow_packed_backing<P: PackedField>(data: &mut Vec<P>, log_len: usize) {
+	let new_log_len = log_len + 1;
+	// While still narrower than one packed word, zero the newly live lanes of the first word.
+	if log_len < P::LOG_WIDTH {
+		let first = &mut data[0];
+		for i in 1 << log_len..(1 << new_log_len).min(P::WIDTH) {
+			first.set(i, <P::Scalar as Field>::ZERO);
+		}
+	}
+	data.resize(1 << new_log_len.saturating_sub(P::LOG_WIDTH), P::zero());
+}
+
 /// Tensor of values with the equality indicator evaluated at `extra_query_coordinates`.
 ///
-/// Let $n$ be `values.log_len()` and $k$ be the length of `extra_query_coordinates`.
-///
-/// ## Preconditions
-///
-/// * `values` must have enough capacity: `values.log_cap() >= values.log_len() +
-///   extra_query_coordinates.len()`
+/// Let $n$ be `values.log_len()` and $k$ be the length of `extra_query_coordinates`. The returned
+/// buffer grows its backing `Vec` by one variable per coordinate.
 ///
 /// # Formal Definition
 ///
-/// `values` is updated to contain the tensor product of its $2^n$ values with the linear bases of
-/// `Cube` evaluated at $r = (r_0, \ldots, r_{k-1})$:
+/// The result is the tensor product of `values`' $2^n$ values with the linear bases of `Cube`
+/// evaluated at $r = (r_0, \ldots, r_{k-1})$:
 ///
 /// $$
 /// v \otimes b(r_0) \otimes \ldots \otimes b(r_{k-1}),
@@ -145,28 +159,26 @@ impl Hypercube for InfCube {
 ///
 /// # Interpretation
 ///
-/// Let $f$ be the $n$-variate multilinear with coefficients $v$ over `Cube`. Then `values` is
-/// updated to the coefficients of the $(n+k)$-variate multilinear
+/// Let $f$ be the $n$-variate multilinear with coefficients $v$ over `Cube`. Then the result holds
+/// the coefficients of the $(n+k)$-variate multilinear
 ///
 /// $$
 /// g(X_0, \ldots, X_{n+k-1}) = f(X_0, \ldots, X_{n-1}) \cdot
 ///     \widetilde{eq}(X_n, \ldots, X_{n+k-1}, r).
 /// $$
-pub fn tensor_prod_eq_ind<Cube: Hypercube, P: PackedField, Data: DerefMut<Target = [P]>>(
-	values: &mut FieldBuffer<P, Data>,
+pub fn tensor_prod_eq_ind<Cube: Hypercube, P: PackedField>(
+	mut values: FieldBuffer<P, Vec<P>>,
 	extra_query_coordinates: &[P::Scalar],
-) {
-	let new_log_len = values.log_len() + extra_query_coordinates.len();
-
-	assert!(
-		values.log_cap() >= new_log_len,
-		"precondition: values capacity must be sufficient for expansion"
-	);
-
+) -> FieldBuffer<P, Vec<P>> {
 	for &r_i in extra_query_coordinates {
 		let packed_r_i = P::broadcast(r_i);
 
-		values.resize(values.log_len() + 1);
+		// Grow the backing by one variable, then rewrap.
+		let new_log_len = values.log_len() + 1;
+		let mut data = values.take_data();
+		grow_packed_backing::<P>(&mut data, new_log_len - 1);
+		values = FieldBuffer::new(new_log_len, data);
+
 		let mut split = values.split_half_mut();
 		let (mut lo, mut hi) = split.halves();
 
@@ -176,6 +188,7 @@ pub fn tensor_prod_eq_ind<Cube: Hypercube, P: PackedField, Data: DerefMut<Target
 				[*lo_i, *hi_i] = Cube::expand_var(lo_i, &packed_r_i);
 			});
 	}
+	values
 }
 
 /// Left tensor of values with the equality indicator evaluated at `extra_query_coordinates`.
@@ -191,26 +204,19 @@ pub fn tensor_prod_eq_ind<Cube: Hypercube, P: PackedField, Data: DerefMut<Target
 ///
 /// # Implementation
 ///
-/// This operation is inplace, singlethreaded, and not very optimized. Main intent is to use it on
-/// small tensors out of the hot paths.
-///
-/// ## Preconditions
-///
-/// * `values` must have enough capacity: `values.log_cap() >= values.log_len() +
-///   extra_query_coordinates.len()`
-pub fn tensor_prod_eq_ind_prepend<Cube: Hypercube, P: PackedField, Data: DerefMut<Target = [P]>>(
-	values: &mut FieldBuffer<P, Data>,
+/// This operation grows the returned buffer one variable per coordinate, singlethreaded, and is not
+/// very optimized. Main intent is to use it on small tensors out of the hot paths.
+pub fn tensor_prod_eq_ind_prepend<Cube: Hypercube, P: PackedField>(
+	mut values: FieldBuffer<P, Vec<P>>,
 	extra_query_coordinates: &[P::Scalar],
-) {
-	let new_log_len = values.log_len() + extra_query_coordinates.len();
-
-	assert!(
-		values.log_cap() >= new_log_len,
-		"precondition: values capacity must be sufficient for expansion"
-	);
-
+) -> FieldBuffer<P, Vec<P>> {
 	for r_i in extra_query_coordinates.iter().rev() {
-		values.zero_extend(values.log_len() + 1);
+		// Grow the backing by one variable, then rewrap.
+		let new_log_len = values.log_len() + 1;
+		let mut data = values.take_data();
+		grow_packed_backing::<P>(&mut data, new_log_len - 1);
+		values = FieldBuffer::new(new_log_len, data);
+
 		for i in (0..values.len() / 2).rev() {
 			let value = get_packed_slice(values.as_ref(), i);
 			let [lo, hi] = Cube::expand_var(&value, r_i);
@@ -218,6 +224,7 @@ pub fn tensor_prod_eq_ind_prepend<Cube: Hypercube, P: PackedField, Data: DerefMu
 			set_packed_slice(values.as_mut(), 2 * i + 1, hi);
 		}
 	}
+	values
 }
 
 /// Computes the partial evaluation of the equality indicator polynomial.
@@ -247,43 +254,41 @@ pub fn scaled_eq_ind_partial_eval<Cube: Hypercube, P: PackedField>(
 	point: &[P::Scalar],
 	scale: P::Scalar,
 ) -> FieldBuffer<P> {
-	// The expansion starts from a single value and grows one variable at a time.
-	// Allocate at the final capacity 2^n now, so the growth never reallocates.
-	let mut buffer = FieldBuffer::zeros_truncated(0, point.len());
-	scaled_eq_ind_partial_eval_into::<Cube, _, _>(&mut buffer, point, scale);
-	buffer
+	// Reserve the final packed length up front so the per-variable growth never reallocates.
+	let packed_len = 1 << point.len().saturating_sub(P::LOG_WIDTH);
+	scaled_eq_ind_partial_eval_into::<Cube, P>(point, scale, Vec::with_capacity(packed_len))
 }
 
-/// Writes the scaled equality indicator expansion of `point` into a caller-supplied buffer.
+/// Builds the scaled equality indicator expansion of `point` in a caller-supplied backing `Vec`.
 ///
-/// This is the in-place form of [`scaled_eq_ind_partial_eval`]: the caller owns the output buffer,
-/// so its allocation can be hoisted out of a hot or parallel region and reused. On return `buffer`
-/// has `log_len == point.len()` and holds the tensor product $scale \cdot b(r_0) \otimes \ldots
-/// \otimes b(r_{n-1})$. Any prior contents are overwritten.
+/// This is the allocation-hoisting form of [`scaled_eq_ind_partial_eval`]: the caller owns the
+/// backing `Vec`, so its allocation can be reserved on a different thread than the one that fills
+/// it. The `Vec` is cleared, seeded with `scale`, grown one variable at a time into the tensor
+/// product $scale \cdot b(r_0) \otimes \ldots \otimes b(r_{n-1})$, and wrapped into the returned
+/// buffer with `log_len == point.len()`.
 ///
-/// ## Preconditions
+/// # Preconditions
 ///
-/// * `buffer.log_cap()` must be at least `point.len()`.
-pub fn scaled_eq_ind_partial_eval_into<
-	Cube: Hypercube,
-	P: PackedField,
-	Data: DerefMut<Target = [P]>,
->(
-	buffer: &mut FieldBuffer<P, Data>,
+/// * `buffer.capacity()` must equal `1 << point.len().saturating_sub(P::LOG_WIDTH)`, so the growth
+///   never reallocates and the final wrap keeps the same allocation.
+pub fn scaled_eq_ind_partial_eval_into<Cube: Hypercube, P: PackedField>(
 	point: &[P::Scalar],
 	scale: P::Scalar,
-) {
-	assert!(
-		buffer.log_cap() >= point.len(),
-		"precondition: buffer capacity must be sufficient for expansion"
+	mut buffer: Vec<P>,
+) -> FieldBuffer<P> {
+	let packed_len = 1 << point.len().saturating_sub(P::LOG_WIDTH);
+	assert_eq!(
+		buffer.capacity(),
+		packed_len,
+		"precondition: buffer capacity must match the packed expansion length"
 	);
 
-	// The expansion starts from a single value and grows one variable at a time, so reset the
-	// buffer to a single scalar seeded with the scale. The expansion multiplies it through, so
-	// every coefficient ends up scaled.
-	buffer.truncate(0);
-	buffer.set(0, scale);
-	tensor_prod_eq_ind::<Cube, _, _>(buffer, point);
+	// Seed a single-scalar buffer with the scale; the expansion multiplies it through, so every
+	// coefficient ends up scaled.
+	buffer.clear();
+	buffer.push(P::from_scalars(iter::once(scale)));
+	let values = FieldBuffer::new(0, buffer);
+	tensor_prod_eq_ind::<Cube, P>(values, point).into_boxed()
 }
 
 /// Truncate the equality indicator expansion to the low indexed variables.
@@ -592,12 +597,11 @@ mod tests {
 			let point = random_scalars::<F>(&mut rng, log_n);
 			let (prefix, suffix) = point.split_at(log_n / 2);
 
-			let mut prepend = FieldBuffer::<P>::zeros_truncated(0, log_n);
-			prepend.set(0, F::ONE);
-			tensor_prod_eq_ind::<InfCube, _, _>(&mut prepend, suffix);
-			tensor_prod_eq_ind_prepend::<InfCube, _, _>(&mut prepend, prefix);
+			let prepend = FieldBuffer::<P, _>::scalar_with_capacity(F::ONE, log_n);
+			let prepend = tensor_prod_eq_ind::<InfCube, P>(prepend, suffix);
+			let prepend = tensor_prod_eq_ind_prepend::<InfCube, P>(prepend, prefix);
 
-			prop_assert_eq!(prepend, eq_ind_partial_eval::<InfCube, P>(&point));
+			prop_assert_eq!(prepend.into_boxed(), eq_ind_partial_eval::<InfCube, P>(&point));
 		}
 
 		/// Truncation strips the trailing variables of an expansion, for either cube.


### PR DESCRIPTION
## Summary

Removes `FieldBuffer`'s pseudo-capacity — a second, buffer-level length (`values.len()` allowed to exceed the packed length implied by `log_len`) with its own constructor/accessor family. It existed only to serve in-place tensor expansion growing into pre-allocated slack, and leaked into unrelated preconditions and docs. Per [BINIUS-317](https://linear.app/jimpo/issue/BINIUS-317/remove-the-fieldbuffer-capacity-api).

Removes the seven methods: `new_truncated`, `from_values_truncated`, `zeros_truncated`, `zero_extend`, `resize`, `cap`, `log_cap`.

Stacked on the just-merged [#1847](https://github.com/binius-zk/binius64/pull/1847) (BINIUS-315) — it reshapes the `scaled_eq_ind_partial_eval_into` and logup\* code that #1847 introduced.

## Commits

1. **Grow the tensor-expansion backing instead of using buffer capacity.** In-place tensor expansion (`tensor_prod_eq_ind`, `tensor_prod_eq_ind_prepend`) previously bumped `log_len` into slack (`resize`/`zero_extend`). They now take `&mut FieldBuffer<P, Vec<P>>` and actually grow the backing `Vec` one variable at a time via a new `grow` helper (zero-extend semantics, keeping the store fully initialized — see the UB note below). `scaled_eq_ind_partial_eval[_into]` becomes the natural shape jimpo described: build a `Vec<P>` (caller-reserved for the hoisting `_into` form, mirroring `power_table_into`'s `(…, buffer: Vec<P>) -> FieldBuffer<P>` idiom from #1847), grow it, wrap once. `switchover`'s folding tensor and the logup\* numerator buffers become `Vec`-backed accordingly. After this commit nothing outside `field_buffer.rs` touches the capacity API.
2. **Remove the FieldBuffer capacity API.** Delete the seven methods, inline `new`/`from_values`/`zeros` (they no longer build slack), tighten the struct invariant to `values.len() == 1 << log_len.saturating_sub(P::LOG_WIDTH)`, and drop the capacity-only tests.

## Correctness note

The issue flags a UB pitfall: the first sub-packing-width expansion step reads `values[0]` as a whole packed word including lanes past `log_len`, so the backing must stay initialized. The seed is built with `P::from_scalars(iter::once(scale))`, which zero-fills the unused lanes (documented contract), and `grow` zeros both newly-live sub-word lanes and any appended packed words — so the store is always fully initialized, matching the old `zeros_truncated` seed.

## Acceptance

The seven methods are gone; `binius-math` and `binius-ip-prover` build and test clean; no remaining reference to buffer capacity in `FieldBuffer` docs or preconditions (only `Vec` capacity, which is real). Each commit builds + tests green in isolation. Verified: nightly `fmt --check`, `clippy -D warnings` (rayon and single-threaded configs), rust-doc `-D warnings`, and `cargo test --workspace`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)