### PR TITLE
BINIUS-320: remove FieldBuffer::zeros at the production call sites

### DIFF
--- a/crates/iop-prover/src/basefold_channel.rs
+++ b/crates/iop-prover/src/basefold_channel.rs
@@ -342,7 +342,11 @@ fn prove_batch_zk_basefold<F, P, NTT, Channel>(
 
 		let eq_tensor = eq_ind_partial_eval_scalars(&outer_challenges);
 
-		let mut combined = FieldBuffer::<P>::zeros(max_n);
+		// Each oracle accumulates into only the low `2^{n_i}` of every lifted chunk.
+		// Positions that no oracle touches must read back as zero.
+		let combined_packed_len = 1 << max_n.saturating_sub(P::LOG_WIDTH);
+		let mut combined =
+			FieldBuffer::new(max_n, vec![P::zero(); combined_packed_len].into_boxed_slice());
 		let mut s_prime = F::ZERO;
 		for (fri_oracle, witness_prime, eq_i, alpha_i) in
 			izip!(fri_params.input_oracles(), witness_primes, eq_tensor, alphas)

--- a/crates/iop-prover/src/fri/fold.rs
+++ b/crates/iop-prover/src/fri/fold.rs
@@ -488,7 +488,13 @@ impl<F: Field, P: PackedField<Scalar = F>, C> BatchBrakedownFolder<P, C> {
 		let later_challenges = &challenges[max_early + log_n_oracles..];
 		let outer_tensor = eq_ind_partial_eval::<F>(outer_challenges);
 
-		let mut combined_codeword = FieldBuffer::zeros(self.log_code_len);
+		// The folders accumulate into this scalar buffer.
+		// The chunked zip stops at the shorter side, leaving a tail that no folder writes.
+		// That tail must read back as zero.
+		let mut combined_codeword = FieldBuffer::new(
+			self.log_code_len,
+			vec![F::ZERO; 1 << self.log_code_len].into_boxed_slice(),
+		);
 		let mut oracles = Vec::with_capacity(self.folders.len());
 		// TODO: Special cases when outer_challenges.len() = 0 or 1 for computational efficiency (to
 		// reduce # of scaling muls)

--- a/crates/ip-prover/src/sumcheck/mle_store.rs
+++ b/crates/ip-prover/src/sumcheck/mle_store.rs
@@ -398,7 +398,12 @@ impl<'a, F: Field, P: PackedField<Scalar = F>> MleStore<'a, P> {
 			.columns
 			.iter()
 			.map(|column| match column {
-				Column::Borrowed(_) => Some(FieldBuffer::zeros(n_vars)),
+				// The out-of-place fold below fully overwrites this buffer.
+				// It is zeroed only because construction requires initialized data.
+				Column::Borrowed(_) => Some(FieldBuffer::new(
+					n_vars,
+					vec![P::zero(); 1 << n_vars.saturating_sub(P::LOG_WIDTH)].into_boxed_slice(),
+				)),
 				_ => None,
 			})
 			.collect::<Vec<_>>();

--- a/crates/ip-prover/src/sumcheck/selector_mle.rs
+++ b/crates/ip-prover/src/sumcheck/selector_mle.rs
@@ -144,14 +144,25 @@ where
 			.unwrap_or_default();
 		let chunk_count = 1 << (self.n_vars() - 1 - chunk_vars);
 
+		// Per-thread scratchpads for the two binary chunks.
+		// Each scratchpad is fully written before it is read.
+		// The zero init is not load-bearing.
+		let scratchpad_packed_len = 1 << chunk_vars.saturating_sub(P::LOG_WIDTH);
+
 		let packed_prime_evals = (0..chunk_count)
 			.into_par_iter()
 			.fold(
 				|| {
 					(
 						vec![RoundEvals2::default(); sums.len()],
-						FieldBuffer::<P>::zeros(chunk_vars),
-						FieldBuffer::<P>::zeros(chunk_vars),
+						FieldBuffer::new(
+							chunk_vars,
+							vec![P::zero(); scratchpad_packed_len].into_boxed_slice(),
+						),
+						FieldBuffer::new(
+							chunk_vars,
+							vec![P::zero(); scratchpad_packed_len].into_boxed_slice(),
+						),
 					)
 				},
 				|(mut packed_prime_evals, mut binary_chunk_0, mut binary_chunk_1), chunk_index| {

--- a/crates/ip-prover/src/sumcheck/switchover.rs
+++ b/crates/ip-prover/src/sumcheck/switchover.rs
@@ -133,7 +133,13 @@ where
 		let all_folded = (0..self.n_multilinears)
 			.into_par_iter()
 			.map(|bit_offset| {
-				let mut folded = FieldBuffer::<P>::zeros(folded_n_vars);
+				// The binary-chunk fold below fully overwrites this buffer.
+				// It is zeroed only because construction requires initialized data.
+				let mut folded = FieldBuffer::new(
+					folded_n_vars,
+					vec![P::zero(); 1 << folded_n_vars.saturating_sub(P::LOG_WIDTH)]
+						.into_boxed_slice(),
+				);
 				get_binary_chunk(
 					&mut folded,
 					&self.tensor,

--- a/crates/ip-prover/src/sumcheck/zk_mlecheck.rs
+++ b/crates/ip-prover/src/sumcheck/zk_mlecheck.rs
@@ -68,7 +68,10 @@ pub fn expand_libra_eval<P: PackedField>(
 	debug_assert!(degree < 1 << m_d);
 
 	let log_size = m_n + m_d;
-	let mut buffer = FieldBuffer::<P>::zeros(log_size);
+	// The scatter below writes only the `n x (d+1)` submatrix.
+	// The surrounding padding zeros are read back as polynomial coefficients.
+	let packed_len = 1 << log_size.saturating_sub(P::LOG_WIDTH);
+	let mut buffer = FieldBuffer::new(log_size, vec![P::zero(); packed_len].into_boxed_slice());
 	let row_stride = 1 << m_d;
 
 	for (j, &r_j) in challenge_point.iter().enumerate() {

--- a/crates/prover/src/and_reduction/ntt_lookup.rs
+++ b/crates/prover/src/and_reduction/ntt_lookup.rs
@@ -188,7 +188,12 @@ where
 	///
 	/// The returned buffer holds both halves; the output-domain evaluations are the upper half.
 	fn transform(&self, input: u64) -> FieldBuffer<P> {
-		let mut values = FieldBuffer::<P>::zeros(SKIPPED_VARS + 1);
+		// The low half holds the input evaluations, written below.
+		// The upper half stays as explicit zero padding.
+		// The forward NTT reads that padding as the high-degree coefficients.
+		let packed_len = 1 << (SKIPPED_VARS + 1).saturating_sub(P::LOG_WIDTH);
+		let mut values =
+			FieldBuffer::new(SKIPPED_VARS + 1, vec![P::zero(); packed_len].into_boxed_slice());
 
 		// Inverse NTT the inputs in the first half of the buffer.
 		{

--- a/crates/prover/src/ring_switch.rs
+++ b/crates/prover/src/ring_switch.rs
@@ -198,6 +198,10 @@ where
 	let log_scalar_bit_width = <B128 as ExtensionField<B1>>::LOG_DEGREE;
 	assert_eq!(mat.log_len(), vec.log_len()); // precondition
 
+	// Packed length of the zeroed accumulator that the fold and reduce identities allocate.
+	// Zeros are required because both identity bodies accumulate into the buffer in place.
+	let identity_packed_len = 1 << log_scalar_bit_width.saturating_sub(B128::LOG_WIDTH);
+
 	// Group bits into 4-bit nibbles for the lookups.
 	const LOG_CHUNK_BITS: usize = 2;
 	const CHUNK_BITS: usize = 1 << LOG_CHUNK_BITS;
@@ -205,7 +209,12 @@ where
 	(vec.as_ref().par_chunks(CHUNK_BITS), mat.as_ref().par_chunks(CHUNK_BITS))
 		.into_par_iter()
 		.fold(
-			|| FieldBuffer::zeros(log_scalar_bit_width),
+			|| {
+				FieldBuffer::new(
+					log_scalar_bit_width,
+					vec![B128::ZERO; identity_packed_len].into_boxed_slice(),
+				)
+			},
 			|mut acc, (vec_chunk, mat_chunk)| {
 				let mut vec_chunk_iter = P::iter_slice(vec_chunk);
 				let mut mat_chunk_iter = P::iter_slice(mat_chunk);
@@ -245,7 +254,12 @@ where
 			},
 		)
 		.reduce(
-			|| FieldBuffer::zeros(log_scalar_bit_width),
+			|| {
+				FieldBuffer::new(
+					log_scalar_bit_width,
+					vec![B128::ZERO; identity_packed_len].into_boxed_slice(),
+				)
+			},
 			|mut lhs, rhs| {
 				for (lhs_i, &rhs_i) in izip!(lhs.as_mut(), rhs.as_ref()) {
 					*lhs_i += rhs_i;


### PR DESCRIPTION
Closes [BINIUS-320](https://linear.app/jimpo/issue/BINIUS-320).

Converts the ten production `FieldBuffer::zeros` call sites to data-first construction. Pure refactor — no behavior change, the buffers hold the same zero bytes as before.

### The problem

`FieldBuffer` has two ways to come into existence: wrap data you already built (`new` / `from_values`), or ask for a zeroed buffer by log-length (`zeros` / `zeros_truncated`).

The second path hides a requirement.

- A reader at the call site cannot tell whether the zeros are *load-bearing* (read back later) or just there because the constructor happens to zero.
- The goal is one construction path — wrap existing data — with any zeroing spelled out where it happens.

### The idea

Build the backing vector first, then wrap it:

```
- let mut buf = FieldBuffer::<P>::zeros(n);
+ let packed_len = 1 << n.saturating_sub(P::LOG_WIDTH);
+ let mut buf = FieldBuffer::new(n, vec![P::zero(); packed_len].into_boxed_slice());
```

Now the allocation and its zeros are visible, and each site carries a one-line note saying *why* the zeros are (or are not) needed.

### The change

Ten sites across four crates, grouped by why they zero:

- **Zeros are load-bearing** — an accumulator (`+=`) or a sparse scatter whose untouched positions are read back:
  - `prover/src/ring_switch.rs` — the fold and reduce identities (the $\mathbb{F}_{2^{128}}$ accumulator)
  - `iop-prover/src/basefold_channel.rs` — per-oracle lift accumulator
  - `iop-prover/src/fri/fold.rs` — combined-codeword accumulator with a truncated-zip tail
  - `ip-prover/src/sumcheck/zk_mlecheck.rs` — Libra scatter whose padding is read as coefficients
  - `prover/src/and_reduction/ntt_lookup.rs` — the upper half is the NTT's zero-padded coefficients
- **Fully overwritten scratchpads** — zeroed only to construct; a fill routine writes every element before it is read:
  - `ip-prover/src/sumcheck/mle_store.rs`, `.../switchover.rs`, `.../selector_mle.rs` (two buffers)

### Scope

- **changed:** the ten call sites above, each now data-first with a `// why` note.
- **left untouched:** the `zeros` / `zeros_truncated` constructors themselves. Their remaining callers are the capacity-allocation sites deferred to [BINIUS-317](https://linear.app/jimpo/issue/BINIUS-317), a small-input fallback the audit judged not worth converting, and the test suite. Deleting the constructor is the final step once BINIUS-317/318 clear those.
- One deliberate non-optimization: the fully-overwritten scratchpads still allocate zeros rather than uninitialized memory. Realizing that win safely needs a `Pod`/`MaybeUninit` path the generic `P: PackedField` bound does not provide, and the zeroing there is once-per-thread — not worth `unsafe`. Left as a clean follow-up.

### Soundness

- Not a protocol change. Every new buffer holds the identical zero bytes the old constructor produced (`vec![P::zero(); ..]` equals `zeroed_vec` for these binary-field packed types).
- Load-bearing sites keep their zeros; overwritten sites are provably written in full before any read.

### Verification

- `cargo check` / `cargo clippy` on `binius-prover`, `binius-iop-prover`, `binius-ip-prover` — clean
- `cargo +nightly fmt --all` — clean
- `cargo test` on the three crates — 132 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)