### PR TITLE
Add Word::LOG_BYTES and drop LOG_BYTE_BITS

### DIFF
--- a/crates/circuits/src/sha256/mod.rs
+++ b/crates/circuits/src/sha256/mod.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 Irreducible Inc.
 pub mod compress;
 
-use binius_core::{consts::LOG_BYTE_BITS, word::Word};
+use binius_core::word::Word;
 use binius_frontend::{CircuitBuilder, Wire};
 pub use compress::{
 	State, populate_message_block, ref_compress, sha256_compress, sha256_compress_2x,
@@ -194,7 +194,7 @@ pub fn sha256_varlen(builder: &CircuitBuilder, message: &ByteVec) -> [Wire; 4] {
 		"length of message in bits must fit within 32 bits"
 	);
 
-	let max_len_bytes = message.data.len() << (Word::LOG_BITS - LOG_BYTE_BITS);
+	let max_len_bytes = message.data.len() << Word::LOG_BYTES;
 	let n_blocks = (message.data.len() + 2).div_ceil(8);
 	let n_words: usize = n_blocks << 4; // 16 words per block
 

--- a/crates/circuits/src/sha512/mod.rs
+++ b/crates/circuits/src/sha512/mod.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 Irreducible Inc.
 pub mod compress;
 
-use binius_core::{consts::LOG_BYTE_BITS, word::Word};
+use binius_core::word::Word;
 use binius_frontend::{CircuitBuilder, Wire};
 pub use compress::{State, compress, pack_message_block};
 
@@ -162,7 +162,7 @@ pub fn sha512_varlen(builder: &CircuitBuilder, message: &ByteVec) -> [Wire; 8] {
 		"length of message in bits must fit in 64-bit wire"
 	);
 
-	let max_len_bytes = message.data.len() << (Word::LOG_BITS - LOG_BYTE_BITS);
+	let max_len_bytes = message.data.len() << Word::LOG_BYTES;
 	let n_blocks = (message.data.len() + 3).div_ceil(16);
 	let n_words: usize = n_blocks << 4; // 16 words per block
 

--- a/crates/core/src/consts.rs
+++ b/crates/core/src/consts.rs
@@ -1,8 +1,6 @@
 // Copyright 2025 Irreducible Inc.
 //! Protocol-level constants for the Binius64 constraint system.
 
-use binius_utils::checked_arithmetics::checked_log_2;
-
 /// The minimum number of words per segment.
 ///
 /// This is the minimum size requirement for public input segments in the constraint system.
@@ -10,6 +8,3 @@ pub const MIN_WORDS_PER_SEGMENT: usize = 2;
 
 /// The number of bits in a byte.
 pub const BYTE_BITS: usize = 8;
-
-/// log2 of [`BYTE_BITS`].
-pub const LOG_BYTE_BITS: usize = checked_log_2(BYTE_BITS);

--- a/crates/core/src/word.rs
+++ b/crates/core/src/word.rs
@@ -25,6 +25,8 @@ pub struct Word(pub u64);
 impl Word {
 	/// The size of a [`Word`] in bytes; the protocol proves constraint systems over 64-bit words.
 	pub const BYTES: usize = size_of::<Word>();
+	/// log2 of [`Word::BYTES`].
+	pub const LOG_BYTES: usize = checked_log_2(Self::BYTES);
 	/// The size of a [`Word`] in bits (mirrors [`u64::BITS`]).
 	pub const BITS: usize = Self::BYTES * 8;
 	/// log2 of [`Word::BITS`].


### PR DESCRIPTION
Pure refactor — no behavior change. The emitted circuits are bit-identical.

### The problem

The SHA-256 and SHA-512 varlen circuits both convert a word count into a byte count with the same shift:

```
let max_len_bytes = message.data.len() << (Word::LOG_BITS - LOG_BYTE_BITS);
```

`Word::LOG_BITS - LOG_BYTE_BITS` is `6 - 3 == 3`, i.e. log2 of the number of *bytes* in a word.

That is a property of `Word`, not of bytes — spelling it as a subtraction of two bit-counts obscures what it means, and it forced both circuits to import `LOG_BYTE_BITS` just to subtract it back off.

### The idea

Give `Word` the constant it already implies:

```
/// log2 of [`Word::BYTES`].
pub const LOG_BYTES: usize = checked_log_2(Self::BYTES);
```

Then the shift reads as what it is:

```diff
- let max_len_bytes = message.data.len() << (Word::LOG_BITS - LOG_BYTE_BITS);
+ let max_len_bytes = message.data.len() << Word::LOG_BYTES;
```

Since `LOG_BYTE_BITS`'s only consumer was that subtraction, it is deleted — together with the now-unused `checked_log_2` import in `consts.rs`.

### Scope

- **new:** `Word::LOG_BYTES` in `crates/core/src/word.rs`
- **changed:** the one shift in each of `crates/circuits/src/sha256/mod.rs` and `sha512/mod.rs`
- **removed:** `LOG_BYTE_BITS` and its `checked_log_2` import from `crates/core/src/consts.rs`
- **left untouched:** `MIN_WORDS_PER_SEGMENT` and `BYTE_BITS` in `consts.rs`

### Verification

- `cargo clippy -p binius-core -p binius-circuits --all-targets` — clean
- `cargo +nightly fmt --all` — no changes
- `cargo test -p binius-core -p binius-circuits sha` — 26 passed, including the `sha256_varlen` / `sha512_varlen` tests that exercise the changed shift

Note: `cargo check --workspace --all-targets` currently fails on an unrelated pre-existing error in `binius-prover` (`fold_word.rs` imports `binius_field::util::expand_subset_xors`, which no longer exists). This is present on a clean `main` and is not touched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)