### PR TITLE
BINIUS-321: group BaseFold and the IOP channels into module folders mirroring fri/

### DIFF
--- a/crates/iop-prover/src/basefold/channel.rs
+++ b/crates/iop-prover/src/basefold/channel.rs
@@ -1,11 +1,6 @@
 // Copyright 2026 The Binius Developers
 
 //! BaseFold ZK implementation of the IOP prover channel.
-//!
-//! This module provides [`BaseFoldProverChannel`], which implements [`IOPProverChannel`]
-//! using FRI commitment and the batched ZK BaseFold opening protocol. ZK oracles are blinded with a
-//! mask generated internally; non-ZK oracles are committed without a mask. All committed oracles
-//! are opened with a single combined FRI.
 
 use binius_field::{BinaryField, PackedField};
 use binius_iop::{channel::OracleSpec, fri::FRIParams};
@@ -128,7 +123,7 @@ where
 	/// shared point `r`, then one combined FRI opening over every committed oracle
 	/// (in oracle-index order). Mirrors [`BaseFoldVerifierChannel::finish`].
 	///
-	/// [`BaseFoldVerifierChannel::finish`]: binius_iop::basefold_channel::BaseFoldVerifierChannel::finish
+	/// [`BaseFoldVerifierChannel::finish`]: binius_iop::basefold::channel::BaseFoldVerifierChannel::finish
 	pub fn finish(self) {
 		let Self {
 			mut channel,
@@ -165,7 +160,7 @@ where
 /// [`BaseFoldProverChannel`] — through its [`MerkleIPProverChannel`] interface: it sends the
 /// masked inner products σ_i, runs one batched sumcheck reducing the masked claims to a shared
 /// point `r`, then opens all committed oracles together with a single combined FRI. Mirrors
-/// [`binius_iop::basefold_channel::BaseFoldVerifierChannel::finish`].
+/// [`binius_iop::basefold::channel::BaseFoldVerifierChannel::finish`].
 ///
 /// The masking inner products and the batched sumcheck process the `relations` in arrival order (so
 /// each reduced eval lines up with its batched-claim coefficient), while the per-oracle evaluations
@@ -533,7 +528,7 @@ mod tests {
 	};
 	use binius_hash::{StdDigest, StdHashSuite};
 	use binius_iop::{
-		basefold_compiler::BaseFoldVerifierCompiler,
+		basefold::compiler::BaseFoldVerifierCompiler,
 		channel::{IOPVerifierChannel, OracleLinearRelation, OracleSpec},
 		fri::MinProofSizeStrategy,
 		merkle_tree::BinaryMerkleTreeScheme,
@@ -549,7 +544,7 @@ mod tests {
 	use rand::{Rng, SeedableRng, rngs::StdRng};
 
 	use super::IOPProverChannel;
-	use crate::basefold_compiler::BaseFoldProverCompiler;
+	use crate::basefold::compiler::BaseFoldProverCompiler;
 
 	type StdChallenger = HasherChallenger<StdDigest>;
 

--- a/crates/iop-prover/src/basefold/compiler.rs
+++ b/crates/iop-prover/src/basefold/compiler.rs
@@ -1,16 +1,13 @@
 // Copyright 2026 The Binius Developers
 
 //! BaseFold compiler for IOP provers.
-//!
-//! This module provides [`BaseFoldProverCompiler`], which precomputes FRI parameters and can
-//! create prover channel instances.
 
 use std::{borrow::BorrowMut, marker::PhantomData};
 
 use binius_field::{BinaryField, PackedField};
 use binius_hash::binary_merkle_tree::HashSuite;
 use binius_iop::{
-	basefold_compiler::BaseFoldVerifierCompiler, channel::OracleSpec, fri::FRIParams,
+	basefold::compiler::BaseFoldVerifierCompiler, channel::OracleSpec, fri::FRIParams,
 	merkle_tree::BinaryMerkleTreeScheme,
 };
 use binius_math::ntt::AdditiveNTT;
@@ -20,7 +17,7 @@ use digest::Output;
 use rand::{Rng, SeedableRng, rngs::StdRng};
 
 use crate::{
-	basefold_channel::BaseFoldProverChannel,
+	basefold::channel::BaseFoldProverChannel,
 	merkle_channel::{MerkleIPProverChannel, ProverMerkleTranscriptChannel},
 };
 

--- a/crates/iop-prover/src/basefold/mod.rs
+++ b/crates/iop-prover/src/basefold/mod.rs
@@ -1,0 +1,10 @@
+// Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
+
+//! Prover for the BaseFold sumcheck-PIOP to IP compiler.
+
+pub mod channel;
+pub mod compiler;
+mod opening;
+
+pub use opening::*;

--- a/crates/iop-prover/src/basefold/opening.rs
+++ b/crates/iop-prover/src/basefold/opening.rs
@@ -1,6 +1,8 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
+//! The core BaseFold opening protocol on the prover side.
+
 use binius_field::{BinaryField, PackedField};
 use binius_ip::mlecheck;
 use binius_ip_prover::sumcheck::{common::SumcheckProver, multilinear_eval::MultilinearEvalProver};

--- a/crates/iop-prover/src/channel/mod.rs
+++ b/crates/iop-prover/src/channel/mod.rs
@@ -1,18 +1,8 @@
 // Copyright 2026 The Binius Developers
 
 //! Channel abstraction for interactive oracle protocol (IOP) provers.
-//!
-//! An IOP extends the public-coin interactive protocol model with oracle access: the prover can
-//! commit to oracles (e.g., Merkle trees) that the verifier can query at specific positions. This
-//! module provides the [`IOPProverChannel`] trait that models the prover's view of such an
-//! interaction.
-//!
-//! The trait extends [`IPProverChannel`] with additional methods for:
-//! - Committing oracles to the verifier
-//! - Responding to oracle queries with opening proofs
-//!
-//! This abstraction allows protocol implementations to be generic over the underlying
-//! communication and commitment mechanisms.
+
+pub mod naive;
 
 use binius_field::PackedField;
 use binius_iop::channel::OracleSpec;

--- a/crates/iop-prover/src/channel/naive.rs
+++ b/crates/iop-prover/src/channel/naive.rs
@@ -1,10 +1,6 @@
 // Copyright 2026 The Binius Developers
 
-//! Naive implementation of IOP prover channel for testing.
-//!
-//! This module provides [`NaiveProverChannel`], a simple implementation of [`IOPProverChannel`]
-//! that writes full polynomial data to the transcript instead of using FRI commitments.
-//! This is intended for unit testing of protocols without the overhead of BaseFold/FRI.
+//! Naive [`IOPProverChannel`] for testing: writes full polynomials instead of using FRI.
 
 use binius_field::{Field, PackedField};
 use binius_iop::channel::OracleSpec;

--- a/crates/iop-prover/src/lib.rs
+++ b/crates/iop-prover/src/lib.rs
@@ -26,11 +26,8 @@
 #![warn(rustdoc::missing_crate_level_docs)]
 
 pub mod basefold;
-pub mod basefold_channel;
-pub mod basefold_compiler;
 pub mod channel;
 pub mod fri;
 pub mod logup_star;
 pub mod merkle_channel;
 pub mod merkle_tree;
-pub mod naive_channel;

--- a/crates/iop-prover/src/logup_star.rs
+++ b/crates/iop-prover/src/logup_star.rs
@@ -131,7 +131,8 @@ mod tests {
 		arch::{OptimalB128, OptimalPackedB128},
 	};
 	use binius_iop::{
-		channel::OracleSpec, logup_star as verify_logup, naive_channel::NaiveVerifierChannel,
+		channel::{OracleSpec, naive::NaiveVerifierChannel},
+		logup_star as verify_logup,
 	};
 	use binius_ip::logup_star::LookerClaim;
 	use binius_math::{
@@ -143,7 +144,7 @@ mod tests {
 	use rand::prelude::*;
 
 	use super::*;
-	use crate::naive_channel::NaiveProverChannel;
+	use crate::channel::naive::NaiveProverChannel;
 
 	type F = OptimalB128;
 	type P = OptimalPackedB128;
@@ -358,12 +359,12 @@ mod tests {
 		use binius_field::PackedBinaryGhash1x128b;
 		use binius_hash::{StdDigest, StdHashSuite};
 		use binius_iop::{
-			basefold_compiler::BaseFoldVerifierCompiler, fri::MinProofSizeStrategy,
+			basefold::compiler::BaseFoldVerifierCompiler, fri::MinProofSizeStrategy,
 			merkle_tree::BinaryMerkleTreeScheme,
 		};
 		use binius_math::ntt::{NeighborsLastSingleThread, domain_context::GenericOnTheFly};
 
-		use crate::basefold_compiler::BaseFoldProverCompiler;
+		use crate::basefold::compiler::BaseFoldProverCompiler;
 
 		// The commitment field is the GHASH 128-bit field; use a single-lane packing for BaseFold.
 		type BP = PackedBinaryGhash1x128b;

--- a/crates/iop/src/basefold/channel.rs
+++ b/crates/iop/src/basefold/channel.rs
@@ -1,11 +1,6 @@
 // Copyright 2026 The Binius Developers
 
 //! BaseFold ZK implementation of the IOP verifier channel.
-//!
-//! This module provides [`BaseFoldVerifierChannel`], which implements [`IOPVerifierChannel`]
-//! using FRI commitment and the batched ZK BaseFold opening protocol. ZK oracles are blinded with a
-//! mask; non-ZK oracles are committed without a mask. All committed oracles are opened with a
-//! single combined FRI.
 
 use binius_field::{BinaryField, util::FieldFn};
 use binius_ip::{

--- a/crates/iop/src/basefold/compiler.rs
+++ b/crates/iop/src/basefold/compiler.rs
@@ -1,9 +1,6 @@
 // Copyright 2026 The Binius Developers
 
 //! BaseFold compiler for IOP verifiers.
-//!
-//! This module provides [`BaseFoldVerifierCompiler`], which precomputes FRI parameters and can
-//! create verifier channel instances.
 
 use std::borrow::BorrowMut;
 
@@ -15,7 +12,7 @@ use binius_utils::{DeserializeBytes, FixedSizeSerializeBytes};
 use digest::Output;
 
 use crate::{
-	basefold_channel::BaseFoldVerifierChannel,
+	basefold::channel::BaseFoldVerifierChannel,
 	channel::OracleSpec,
 	fri::{AritySelectionStrategy, FRIParams},
 	merkle_channel::{MerkleIPVerifierChannel, VerifierMerkleTranscriptChannel},

--- a/crates/iop/src/basefold/error.rs
+++ b/crates/iop/src/basefold/error.rs
@@ -1,0 +1,29 @@
+// Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
+
+use crate::fri;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+	#[error("FRI: {0}")]
+	FRI(#[source] fri::Error),
+	#[error("IP channel: {0}")]
+	IPChannel(#[from] binius_ip::channel::Error),
+	#[error("verification error: {0}")]
+	Verification(#[from] VerificationError),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum VerificationError {
+	#[error("FRI: {0}")]
+	FRI(#[from] fri::VerificationError),
+}
+
+impl From<fri::Error> for Error {
+	fn from(err: fri::Error) -> Self {
+		match err {
+			fri::Error::Verification(err) => Error::Verification(err.into()),
+			_ => Error::FRI(err),
+		}
+	}
+}

--- a/crates/iop/src/basefold/mod.rs
+++ b/crates/iop/src/basefold/mod.rs
@@ -1,0 +1,29 @@
+// Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
+
+//! Verifier for the BaseFold sumcheck-PIOP to IP compiler.
+//!
+//! [BaseFold] is a generalized polynomial commitment scheme that allows compilation of
+//! sumcheck-PIOP protocols to IOPs. The protocol is an interactive argument for sumcheck claims
+//! of multivariate polynomials defined as the product of a committed multilinear polynomial and a
+//! transparent multilinear polynomial. When the transparent polynomial is a multilinear equality
+//! indicator, this BaseFold instance becomes a multilinear polynomial commitment scheme. The core
+//! idea is to commit the multilinear polynomial using FRI and open the sumcheck claim using an
+//! interleaved instance of sumcheck on the composite polynomial and FRI on the committed codeword,
+//! sharing folding challenges.
+//!
+//! This module implements the version specialized for binary field FRI described in [DP24],
+//! Section 4. Moreover, this module includes the classic [BCS16] compiler for IOPs to IPs that
+//! commits and opens oracle messages using Merkle trees.
+//!
+//! [BaseFold]: <https://link.springer.com/chapter/10.1007/978-3-031-68403-6_5>
+//! [DP24]: <https://eprint.iacr.org/2024/504>
+//! [BCS16]: <https://eprint.iacr.org/2016/116>
+
+pub mod channel;
+pub mod compiler;
+mod error;
+mod opening;
+
+pub use error::*;
+pub use opening::*;

--- a/crates/iop/src/basefold/opening.rs
+++ b/crates/iop/src/basefold/opening.rs
@@ -1,31 +1,15 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-//! Verifier for the BaseFold sumcheck-PIOP to IP compiler.
-//!
-//! [BaseFold] is a generalized polynomial commitment scheme that allows compilation of
-//! sumcheck-PIOP protocols to IOPs. The protocol is an interactive argument for sumcheck claims
-//! of multivariate polynomials defined as the product of a committed multilinear polynomial and a
-//! transparent multilinear polynomial. When the transparent polynomial is a multilinear equality
-//! indicator, this BaseFold instance becomes a multilinear polynomial commitment scheme. The core
-//! idea is to commit the multilinear polynomial using FRI and open the sumcheck claim using an
-//! interleaved instance of sumcheck on the composite polynomial and FRI on the committed codeword,
-//! sharing folding challenges.
-//!
-//! This module implements the version specialized for binary field FRI described in [DP24],
-//! Section 4. Moreover, this module includes the classic [BCS16] compiler for IOPs to IPs that
-//! commits and opens oracle messages using Merkle trees.
-//!
-//! [BaseFold]: <https://link.springer.com/chapter/10.1007/978-3-031-68403-6_5>
-//! [DP24]: <https://eprint.iacr.org/2024/504>
-//! [BCS16]: <https://eprint.iacr.org/2016/116>
+//! The core BaseFold opening protocol on the verifier side.
 
 use binius_field::{BinaryField, Field};
 use binius_ip::{mlecheck, sumcheck::RoundCoeffs};
 use binius_utils::checked_arithmetics::log2_ceil_usize;
 
+use super::error::Error;
 use crate::{
-	fri::{self, FRIFoldVerifier, FRIParams, verify::FRIQueryVerifier},
+	fri::{FRIFoldVerifier, FRIParams, verify::FRIQueryVerifier},
 	merkle_channel::MerkleIPVerifierChannel,
 };
 
@@ -153,29 +137,4 @@ pub struct ReducedOutput<F> {
 /// value is the same `π'(r)`, so consistency is plain equality.
 pub fn mlecheck_fri_consistency<F: Field>(fri_final_oracle: F, sumcheck_final_claim: F) -> bool {
 	fri_final_oracle == sumcheck_final_claim
-}
-
-#[derive(Debug, thiserror::Error)]
-pub enum Error {
-	#[error("FRI: {0}")]
-	FRI(#[source] fri::Error),
-	#[error("IP channel: {0}")]
-	IPChannel(#[from] binius_ip::channel::Error),
-	#[error("verification error: {0}")]
-	Verification(#[from] VerificationError),
-}
-
-#[derive(Debug, thiserror::Error)]
-pub enum VerificationError {
-	#[error("FRI: {0}")]
-	FRI(#[from] fri::VerificationError),
-}
-
-impl From<fri::Error> for Error {
-	fn from(err: fri::Error) -> Self {
-		match err {
-			fri::Error::Verification(err) => Error::Verification(err.into()),
-			_ => Error::FRI(err),
-		}
-	}
 }

--- a/crates/iop/src/channel/mod.rs
+++ b/crates/iop/src/channel/mod.rs
@@ -1,18 +1,10 @@
 // Copyright 2026 The Binius Developers
 
 //! Channel abstraction for interactive oracle protocol (IOP) verifiers.
-//!
-//! An IOP extends the public-coin interactive protocol model with oracle access: the prover can
-//! commit to oracles (e.g., Merkle trees) that the verifier can query at specific positions. This
-//! module provides the [`IOPVerifierChannel`] trait that models the verifier's view of such an
-//! interaction.
-//!
-//! The trait extends [`IPVerifierChannel`] with additional methods for:
-//! - Receiving oracle commitments from the prover
-//! - Querying oracle positions and receiving opening proofs
-//!
-//! This abstraction allows protocol implementations to be generic over the underlying
-//! communication and commitment mechanisms.
+
+pub mod naive;
+pub mod oracle_setup;
+pub mod size_tracking;
 
 use binius_field::Field;
 use binius_ip::channel::IPVerifierChannel;

--- a/crates/iop/src/channel/naive.rs
+++ b/crates/iop/src/channel/naive.rs
@@ -1,10 +1,6 @@
 // Copyright 2026 The Binius Developers
 
-//! Naive implementation of IOP verifier channel for testing.
-//!
-//! This module provides [`NaiveVerifierChannel`], a simple implementation of [`IOPVerifierChannel`]
-//! that reads full polynomial data from the transcript instead of verifying FRI commitments.
-//! This is intended for unit testing of protocols without the overhead of BaseFold/FRI.
+//! Naive [`IOPVerifierChannel`] for testing: reads full polynomials instead of verifying FRI.
 
 use binius_field::{Field, util::FieldFn};
 use binius_ip::channel::IPVerifierChannel;

--- a/crates/iop/src/channel/oracle_setup.rs
+++ b/crates/iop/src/channel/oracle_setup.rs
@@ -1,14 +1,6 @@
 // Copyright 2026 The Binius Developers
 
-//! An [`IOPVerifierChannel`] that records the sequence of oracle specifications an IOP uses,
-//! without performing any actual verification.
-//!
-//! Running an IOP verifier against an `OracleSetupChannel` (a dry run: all `recv_*` methods return
-//! dummy values and `assert_zero` is a no-op, like [`SizeTrackingChannel`]) discovers the
-//! [`OracleSpec`] sequence directly from the `recv_oracle` calls, so the specs need not be
-//! hardcoded and kept in sync with the verification logic by hand.
-//!
-//! [`SizeTrackingChannel`]: crate::size_tracking_channel::SizeTrackingChannel
+//! An [`IOPVerifierChannel`] dry run that records the [`OracleSpec`] sequence an IOP uses.
 
 use std::{
 	iter::{Product, Sum},

--- a/crates/iop/src/channel/size_tracking.rs
+++ b/crates/iop/src/channel/size_tracking.rs
@@ -1,9 +1,6 @@
 // Copyright 2026 The Binius Developers
 
-//! A lightweight [`IOPVerifierChannel`] implementation that counts proof bytes without
-//! performing any actual verification.
-//!
-//! This is useful for estimating proof sizes without running the full protocol.
+//! An [`IOPVerifierChannel`] that counts proof bytes without verifying, for proof-size estimation.
 
 use binius_field::{BinaryField, util::FieldFn};
 use binius_ip::channel::IPVerifierChannel;

--- a/crates/iop/src/lib.rs
+++ b/crates/iop/src/lib.rs
@@ -26,13 +26,8 @@
 #![warn(rustdoc::missing_crate_level_docs)]
 
 pub mod basefold;
-pub mod basefold_channel;
-pub mod basefold_compiler;
 pub mod channel;
 pub mod fri;
 pub mod logup_star;
 pub mod merkle_channel;
 pub mod merkle_tree;
-pub mod naive_channel;
-pub mod oracle_setup_channel;
-pub mod size_tracking_channel;

--- a/crates/m4-prover/src/prove.rs
+++ b/crates/m4-prover/src/prove.rs
@@ -4,7 +4,7 @@
 use binius_core::{constraint_system::ConstraintSystem, word::Word};
 use binius_field::{AESTowerField8b as B8, Field, PackedField};
 use binius_hash::StdHashSuite;
-use binius_iop_prover::{basefold_compiler::BaseFoldProverCompiler, channel::IOPProverChannel};
+use binius_iop_prover::{basefold::compiler::BaseFoldProverCompiler, channel::IOPProverChannel};
 use binius_ip_prover::sumcheck::{
 	MleToSumCheckEvaluator,
 	batch::batch_prove_and_write_evals,

--- a/crates/m4-verifier/src/verify.rs
+++ b/crates/m4-verifier/src/verify.rs
@@ -5,11 +5,12 @@ use binius_core::{constraint_system::ConstraintSystem, word::Word};
 use binius_field::{AESTowerField8b as B8, ExtensionField, FieldOps};
 use binius_hash::StdHashSuite;
 use binius_iop::{
-	basefold_compiler::BaseFoldVerifierCompiler,
-	channel::{IOPVerifierChannel, OracleLinearRelation, OracleSpec},
+	basefold::compiler::BaseFoldVerifierCompiler,
+	channel::{
+		IOPVerifierChannel, OracleLinearRelation, OracleSpec, oracle_setup::OracleSetupChannel,
+	},
 	fri::{ConstantArityStrategy, calculate_n_test_queries},
 	merkle_tree::BinaryMerkleTreeScheme,
-	oracle_setup_channel::OracleSetupChannel,
 };
 use binius_ip::{
 	channel::IPVerifierChannel,

--- a/crates/prover/benches/intmul.rs
+++ b/crates/prover/benches/intmul.rs
@@ -3,10 +3,10 @@ use binius_core::word::Word;
 use binius_field::{BinaryField128bGhash, Field, PackedBinaryGhash1x128b};
 use binius_hash::StdHashSuite;
 use binius_iop::{
-	basefold_compiler::BaseFoldVerifierCompiler, channel::OracleSpec, fri::MinProofSizeStrategy,
+	basefold::compiler::BaseFoldVerifierCompiler, channel::OracleSpec, fri::MinProofSizeStrategy,
 	merkle_tree::BinaryMerkleTreeScheme,
 };
-use binius_iop_prover::basefold_compiler::BaseFoldProverCompiler;
+use binius_iop_prover::basefold::compiler::BaseFoldProverCompiler;
 use binius_ip_prover::{
 	prodcheck::ProdcheckProver,
 	sumcheck::{

--- a/crates/prover/src/protocols/binmul.rs
+++ b/crates/prover/src/protocols/binmul.rs
@@ -132,8 +132,8 @@ where
 mod tests {
 	use binius_core::word::Word;
 	use binius_field::{BinaryField128bGhash, PackedBinaryGhash2x128b, Random};
-	use binius_iop::{channel::OracleSpec, naive_channel::NaiveVerifierChannel};
-	use binius_iop_prover::naive_channel::NaiveProverChannel;
+	use binius_iop::channel::{OracleSpec, naive::NaiveVerifierChannel};
+	use binius_iop_prover::channel::naive::NaiveProverChannel;
 	use binius_math::{inner_product::inner_product_buffers, multilinear::eq::eq_ind_partial_eval};
 	use binius_transcript::ProverTranscript;
 	use binius_verifier::{

--- a/crates/prover/src/protocols/intmul/tests.rs
+++ b/crates/prover/src/protocols/intmul/tests.rs
@@ -3,8 +3,8 @@
 
 use binius_core::word::Word;
 use binius_field::{BinaryField128bGhash, PackedBinaryGhash2x128b, Random};
-use binius_iop::{channel::OracleSpec, naive_channel::NaiveVerifierChannel};
-use binius_iop_prover::naive_channel::NaiveProverChannel;
+use binius_iop::channel::{OracleSpec, naive::NaiveVerifierChannel};
+use binius_iop_prover::channel::naive::NaiveProverChannel;
 use binius_math::{inner_product::inner_product_buffers, multilinear::eq::eq_ind_partial_eval};
 use binius_transcript::ProverTranscript;
 use binius_verifier::{

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -11,7 +11,7 @@ use binius_core::{
 };
 use binius_field::{AESTowerField8b as B8, BinaryField, Divisible, Field, PackedField};
 use binius_hash::binary_merkle_tree::HashSuite;
-use binius_iop_prover::{basefold_compiler::BaseFoldProverCompiler, channel::IOPProverChannel};
+use binius_iop_prover::{basefold::compiler::BaseFoldProverCompiler, channel::IOPProverChannel};
 use binius_ip::sumcheck::SumcheckOutput;
 use binius_math::{
 	BinarySubspace, FieldBuffer,

--- a/crates/prover/src/zk_config.rs
+++ b/crates/prover/src/zk_config.rs
@@ -11,7 +11,7 @@ use std::{marker::PhantomData, sync::Arc};
 use binius_core::constraint_system::{ConstraintSystem, ValueVec};
 use binius_field::{BinaryField128bGhash as B128, PackedField};
 use binius_hash::binary_merkle_tree::HashSuite;
-use binius_iop_prover::basefold_compiler::BaseFoldProverCompiler;
+use binius_iop_prover::basefold::compiler::BaseFoldProverCompiler;
 use binius_math::ntt::{NeighborsLastMultiThread, domain_context::GenericPreExpanded};
 use binius_spartan_frontend::constraint_system::WitnessLayout;
 use binius_spartan_prover::wrapper::{ReplayChannel, ZKWrappedProverChannel};

--- a/crates/spartan-prover/src/lib.rs
+++ b/crates/spartan-prover/src/lib.rs
@@ -39,7 +39,7 @@ use std::{
 
 use binius_field::{BinaryField, Field, PackedField};
 use binius_hash::binary_merkle_tree::HashSuite;
-use binius_iop_prover::{basefold_compiler::BaseFoldProverCompiler, channel::IOPProverChannel};
+use binius_iop_prover::{basefold::compiler::BaseFoldProverCompiler, channel::IOPProverChannel};
 use binius_ip_prover::{
 	channel::IPProverChannel,
 	sumcheck::{quadratic_mlecheck_prover, zk_mlecheck},

--- a/crates/spartan-prover/src/wiring.rs
+++ b/crates/spartan-prover/src/wiring.rs
@@ -401,11 +401,10 @@ mod tests {
 	#[test]
 	fn test_wiring_prove_verify() {
 		use binius_hash::StdDigest;
-		use binius_iop::{
-			channel::{IOPVerifierChannel, OracleLinearRelation, OracleSpec},
-			naive_channel::NaiveVerifierChannel,
+		use binius_iop::channel::{
+			IOPVerifierChannel, OracleLinearRelation, OracleSpec, naive::NaiveVerifierChannel,
 		};
-		use binius_iop_prover::{channel::IOPProverChannel, naive_channel::NaiveProverChannel};
+		use binius_iop_prover::channel::{IOPProverChannel, naive::NaiveProverChannel};
 		use binius_ip::channel::IPVerifierChannel;
 		use binius_ip_prover::channel::IPProverChannel;
 		use binius_math::{inner_product::inner_product_buffers, test_utils::random_field_buffer};

--- a/crates/spartan-prover/src/wrapper/mod.rs
+++ b/crates/spartan-prover/src/wrapper/mod.rs
@@ -9,7 +9,7 @@
 //! prover.
 //!
 //! [`ZKWrappedVerifierChannel`]: binius_spartan_verifier::wrapper::ZKWrappedVerifierChannel
-//! [`BaseFoldProverChannel`]: binius_iop_prover::basefold_channel::BaseFoldProverChannel
+//! [`BaseFoldProverChannel`]: binius_iop_prover::basefold::channel::BaseFoldProverChannel
 //! [`finish`]: ZKWrappedProverChannel::finish
 
 pub mod replay_channel;

--- a/crates/spartan-prover/src/wrapper/zk_wrapped_prover_channel.rs
+++ b/crates/spartan-prover/src/wrapper/zk_wrapped_prover_channel.rs
@@ -8,7 +8,7 @@
 //! each value. After the inner proof is run, [`finish`] replays the recorded interaction through
 //! a caller-provided closure to fill the outer witness, then runs the outer IOP prover.
 //!
-//! [`BaseFoldProverChannel`]: binius_iop_prover::basefold_channel::BaseFoldProverChannel
+//! [`BaseFoldProverChannel`]: binius_iop_prover::basefold::channel::BaseFoldProverChannel
 //! [`finish`]: ZKWrappedProverChannel::finish
 
 use std::{iter::repeat_with, sync::Arc};
@@ -16,7 +16,7 @@ use std::{iter::repeat_with, sync::Arc};
 use binius_field::{BinaryField, PackedField};
 use binius_iop::channel::OracleSpec;
 use binius_iop_prover::{
-	basefold_channel::{BaseFoldOracle, BaseFoldProverChannel},
+	basefold::channel::{BaseFoldOracle, BaseFoldProverChannel},
 	channel::IOPProverChannel,
 	merkle_channel::MerkleIPProverChannel,
 };

--- a/crates/spartan-prover/tests/wrapper_integration_test.rs
+++ b/crates/spartan-prover/tests/wrapper_integration_test.rs
@@ -5,12 +5,12 @@ use std::sync::Arc;
 use binius_field::{BinaryField128bGhash as B128, Field, Random, arch::OptimalPackedB128};
 use binius_hash::StdHashSuite;
 use binius_iop::{
-	basefold_compiler::BaseFoldVerifierCompiler,
+	basefold::compiler::BaseFoldVerifierCompiler,
 	channel::IOPVerifierChannel,
 	fri::{self, MinProofSizeStrategy},
 	merkle_tree::BinaryMerkleTreeScheme,
 };
-use binius_iop_prover::basefold_compiler::BaseFoldProverCompiler;
+use binius_iop_prover::basefold::compiler::BaseFoldProverCompiler;
 use binius_ip::channel::IPVerifierChannel;
 use binius_ip_prover::channel::IPProverChannel;
 use binius_math::ntt::{NeighborsLastSingleThread, domain_context::GenericOnTheFly};

--- a/crates/spartan-verifier/src/lib.rs
+++ b/crates/spartan-verifier/src/lib.rs
@@ -39,11 +39,13 @@ use binius_field::{BinaryField, Field, field::FieldOps};
 use binius_hash::binary_merkle_tree::HashSuite;
 use binius_iop::{
 	basefold,
-	basefold_compiler::BaseFoldVerifierCompiler,
-	channel::{IOPVerifierChannel, OracleLinearRelation, OracleSpec},
+	basefold::compiler::BaseFoldVerifierCompiler,
+	channel::{
+		IOPVerifierChannel, OracleLinearRelation, OracleSpec,
+		oracle_setup::{DummyElem, OracleSetupChannel},
+	},
 	fri::{self, MinProofSizeStrategy},
 	merkle_tree::BinaryMerkleTreeScheme,
-	oracle_setup_channel::{DummyElem, OracleSetupChannel},
 };
 use binius_ip::{channel::IPVerifierChannel, mlecheck, sumcheck};
 use binius_math::{multilinear::eq::eq_ind_partial_eval_scalars, univariate::evaluate_univariate};

--- a/crates/spartan-verifier/src/wrapper/zk_wrapped_channel.rs
+++ b/crates/spartan-verifier/src/wrapper/zk_wrapped_channel.rs
@@ -15,7 +15,7 @@ use std::{cell::RefCell, rc::Rc, sync::Arc};
 
 use binius_field::{BinaryField, util::FieldFn};
 use binius_iop::{
-	basefold_channel::{BaseFoldOracle, BaseFoldVerifierChannel},
+	basefold::channel::{BaseFoldOracle, BaseFoldVerifierChannel},
 	channel::{IOPVerifierChannel, OracleLinearRelation, OracleSpec},
 	merkle_channel::MerkleIPVerifierChannel,
 };

--- a/crates/spartan-verifier/tests/proof_size_test.rs
+++ b/crates/spartan-verifier/tests/proof_size_test.rs
@@ -3,8 +3,8 @@
 use binius_field::BinaryField128bGhash as B128;
 use binius_hash::StdHashSuite;
 use binius_iop::{
-	channel::IOPVerifierChannel, merkle_tree::BinaryMerkleTreeScheme,
-	size_tracking_channel::SizeTrackingChannel,
+	channel::{IOPVerifierChannel, size_tracking::SizeTrackingChannel},
+	merkle_tree::BinaryMerkleTreeScheme,
 };
 use binius_ip::channel::IPVerifierChannel;
 use binius_spartan_frontend::{

--- a/crates/verifier/src/verify.rs
+++ b/crates/verifier/src/verify.rs
@@ -7,9 +7,10 @@ use binius_core::{constraint_system::ConstraintSystem, word::Word};
 use binius_field::{AESTowerField8b as B8, BinaryField, ExtensionField, FieldOps};
 use binius_hash::binary_merkle_tree::HashSuite;
 use binius_iop::{
-	basefold_compiler::BaseFoldVerifierCompiler,
-	channel::{IOPVerifierChannel, OracleLinearRelation, OracleSpec},
-	oracle_setup_channel::OracleSetupChannel,
+	basefold::compiler::BaseFoldVerifierCompiler,
+	channel::{
+		IOPVerifierChannel, OracleLinearRelation, OracleSpec, oracle_setup::OracleSetupChannel,
+	},
 };
 use binius_ip::channel::IPVerifierChannel;
 use binius_math::{

--- a/crates/verifier/src/zk_config.rs
+++ b/crates/verifier/src/zk_config.rs
@@ -19,7 +19,7 @@ use binius_core::{constraint_system::ConstraintSystem, word::Word};
 use binius_field::BinaryField128bGhash as B128;
 use binius_hash::binary_merkle_tree::HashSuite;
 use binius_iop::{
-	basefold_compiler::BaseFoldVerifierCompiler,
+	basefold::compiler::BaseFoldVerifierCompiler,
 	channel::OracleSpec,
 	fri::{self, MinProofSizeStrategy},
 	merkle_tree::BinaryMerkleTreeScheme,


### PR DESCRIPTION
@jimpo Just to mimic the FRI stuff, I feel this is easier to reason about within module.

Closes [BINIUS-321](https://linear.app/jimpo/issue/BINIUS-321).

Pure refactor — no behavior change. Every file moved with `git mv`; the protocol the prover and verifier run is byte-for-byte identical.

### The problem

The `iop` (verifier) and `iop-prover` (prover) crates already keep FRI in a tidy `fri/` module folder — a thin `mod.rs` façade over concept submodules.

But BaseFold, the layer built directly on top of FRI, sat as three loose flat files: `basefold.rs`, `basefold_channel.rs`, `basefold_compiler.rs`.

The channel abstraction was scattered the same way: the `IOP*Channel` trait in `channel.rs`, with its non-protocol impls (`naive_channel`, `size_tracking_channel`, `oracle_setup_channel`) as flat siblings beside it.

So the directory listing hid the structure — you could not tell which file was the protocol core, which was the trait, and which were test/estimation doubles.

The prover `basefold_channel.rs` had grown to 961 lines (~45% of it inline tests).

### The idea

Mirror the existing `fri/` pattern. `fri/mod.rs` is a façade: module doc, submodule declarations, and `pub use` re-exports so the public path is independent of the file layout.

```
before                              after
------                              -----
basefold.rs                         basefold/mod.rs        (doc + re-exports)
basefold_channel.rs                 basefold/opening.rs    (prove/verify_mlecheck_basefold)
basefold_compiler.rs                basefold/channel.rs    (BaseFold*Channel + trait impls)
                                    basefold/compiler.rs   (BaseFold*Compiler)
                                    basefold/error.rs      (verifier only, mirrors fri/error.rs)

channel.rs                          channel/mod.rs         (IOP*Channel trait + OracleSpec)
naive_channel.rs                    channel/naive.rs
size_tracking_channel.rs            channel/size_tracking.rs   (verifier only)
oracle_setup_channel.rs             channel/oracle_setup.rs    (verifier only)
```

### The change

- Files moved with `git mv`, so history is preserved as renames (diff shows 75–99% similarity).
- Inline `#[cfg(test)] mod tests` blocks travelled with their files — no separate `tests.rs` was introduced.
- **No compatibility aliases.** Every call site was renamed to the new paths (`basefold::channel::`, `basefold::compiler::`, `channel::naive::`, `channel::size_tracking::`, `channel::oracle_setup::`) across `spartan-*`, `prover`, `verifier`, `m4-*`, and the internal `iop`/`iop-prover` references. Zero old paths remain.
- Verbose `//!` header docs (the "This module provides X, which implements Y…" blocks) were trimmed to one-liners.

### Scope

- **moved:** the three `basefold*.rs` and four channel files, in both crates.
- **renamed:** all downstream + internal references; zero old paths remain.
- **left untouched:** `merkle_channel` stays its own module — a distinct transport trait that both FRI and BaseFold sit on, not a peer impl of `IOP*Channel`. All protocol logic is byte-for-byte unchanged.

### Soundness

Pure refactor. No arithmetic, challenge, or transcript logic was modified — only file locations and import paths.

### Verification

- `cargo check --all-targets` on `iop`, `iop-prover`, `verifier`, `prover`, `spartan-verifier`, `spartan-prover`, `m4-verifier`, `m4-prover` — clean
- `cargo clippy -p binius-iop -p binius-iop-prover --all-targets` — clean
- `cargo +nightly fmt --all` — clean
- `cargo test -p binius-iop-prover` — 40 passed (all BaseFold channel + FRI tests)
- `cargo test -p binius-spartan-prover --test wrapper_integration_test` — end-to-end ZK BaseFold prove/verify passes

Note: `cargo check --workspace --all-targets` currently fails on a pre-existing, unrelated error in `binius-prover` (`fold_word.rs` imports `binius_field::util::expand_subset_xors`, which no longer exists). It is present on a clean `main` and is not touched by this PR.

### Context

First, purely-mechanical step of a larger BaseFold cleanup identified in a review of the implementation. Follow-ups (API hardening and adversarial-proof tests) are separate issues, so this move PR stays trivially reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)