### PR TITLE
BINIUS-319: make Vec<P> the default FieldBuffer backing type

### DIFF
--- a/crates/iop-prover/src/fri/encode.rs
+++ b/crates/iop-prover/src/fri/encode.rs
@@ -142,7 +142,7 @@ where
 		combined_values.extend_from_slice(mask.as_ref());
 		combined_values
 	};
-	let combined = FieldBuffer::new(log_len + 1, combined_values.into_boxed_slice());
+	let combined = FieldBuffer::new(log_len + 1, combined_values);
 
 	let codeword = encode_interleaved(params, oracle_index, ntt, combined.to_ref());
 

--- a/crates/iop-prover/src/fri/fold.rs
+++ b/crates/iop-prover/src/fri/fold.rs
@@ -395,7 +395,7 @@ where
 			},
 		)
 		.collect();
-	FieldBuffer::new(folded_log_len, values.into_boxed_slice())
+	FieldBuffer::new(folded_log_len, values)
 }
 
 pub struct ProxTestFolder<P: PackedField, C> {
@@ -575,7 +575,7 @@ mod tests {
 
 		// Fold the message using regular folding: combine the low `arity` columns of each row
 		// with the eq tensor of the challenges (a partial evaluation of each row at the point).
-		let folded_vals: Box<[B128]> = msg
+		let folded_vals: Vec<B128> = msg
 			.chunks(arity)
 			.map(|row| inner_product_buffers(&row, &query))
 			.collect();

--- a/crates/ip-prover/src/fracaddcheck.rs
+++ b/crates/ip-prover/src/fracaddcheck.rs
@@ -86,8 +86,8 @@ where
 					.collect::<(Vec<_>, Vec<_>)>();
 
 			let next_layer = (
-				FieldBuffer::new(num.log_len() - 1, next_layer_num.into_boxed_slice()),
-				FieldBuffer::new(den.log_len() - 1, next_layer_den.into_boxed_slice()),
+				FieldBuffer::new(num.log_len() - 1, next_layer_num),
+				FieldBuffer::new(den.log_len() - 1, next_layer_den),
 			);
 
 			layers.push(next_layer);

--- a/crates/ip-prover/src/logup_star/witness.rs
+++ b/crates/ip-prover/src/logup_star/witness.rs
@@ -233,7 +233,7 @@ where
 		.map(|chunk| c_packed - P::from_scalars(chunk.iter().copied().map(embed_position::<F>)))
 		.collect::<Vec<_>>();
 
-	FieldBuffer::new(log_len, packed.into_boxed_slice())
+	FieldBuffer::new(log_len, packed)
 }
 
 /// Build the table denominator `c - J` over the `m`-variable table cube.

--- a/crates/ip-prover/src/sumcheck/batch.rs
+++ b/crates/ip-prover/src/sumcheck/batch.rs
@@ -1,4 +1,5 @@
 // Copyright 2024-2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 use binius_field::Field;
 use binius_ip::{mlecheck, sumcheck::RoundCoeffs};
@@ -274,7 +275,7 @@ mod tests {
 			.zip(multilinear_b.as_ref())
 			.map(|(&l, &r)| l * r)
 			.collect::<Vec<_>>();
-		let product_buffer = FieldBuffer::new(n_vars, product.into_boxed_slice());
+		let product_buffer = FieldBuffer::new(n_vars, product);
 		evaluate(&product_buffer, eval_point)
 	}
 

--- a/crates/m4-prover/src/prove.rs
+++ b/crates/m4-prover/src/prove.rs
@@ -769,7 +769,7 @@ where
 		})
 		.collect::<Vec<P>>();
 
-	FieldBuffer::new(log_instances, packed.into_boxed_slice())
+	FieldBuffer::new(log_instances, packed)
 }
 
 #[cfg(test)]

--- a/crates/m4-prover/src/shift.rs
+++ b/crates/m4-prover/src/shift.rs
@@ -270,7 +270,7 @@ pub fn build_g_parts_from_folded_words<F: BinaryField>(
 	// Split the flat accumulator into one multilinear per shift variant.
 	multilinears
 		.chunks(1 << LOG_LEN)
-		.map(|chunk| FieldBuffer::new(LOG_LEN, chunk.to_vec().into_boxed_slice()))
+		.map(|chunk| FieldBuffer::new(LOG_LEN, chunk.to_vec()))
 		.collect::<Vec<_>>()
 		.try_into()
 		.expect("chunks yield SHIFT_VARIANT_COUNT parts of size 1 << LOG_LEN")

--- a/crates/math/src/field_buffer.rs
+++ b/crates/math/src/field_buffer.rs
@@ -27,7 +27,7 @@ pub trait AsSlicesMut<P: PackedField, const N: usize> {
 ///  1) `values.len()` is a power of two
 ///  2) `values.len() == 1 << log_len.saturating_sub(P::LOG_WIDTH)`.
 #[derive(Debug, Clone, Eq)]
-pub struct FieldBuffer<P: PackedField, Data: Deref<Target = [P]> = Box<[P]>> {
+pub struct FieldBuffer<P: PackedField, Data: Deref<Target = [P]> = Vec<P>> {
 	/// log2 the number over elements in the buffer.
 	log_len: usize,
 	/// The packed values.
@@ -88,14 +88,14 @@ impl<P: PackedField> FieldBuffer<P> {
 
 		Self {
 			log_len,
-			values: packed_values.into_boxed_slice(),
+			values: packed_values,
 		}
 	}
 
 	/// Create a new [`FieldBuffer`] of zeros with the given log_len.
 	pub fn zeros(log_len: usize) -> Self {
 		let packed_len = 1 << log_len.saturating_sub(P::LOG_WIDTH);
-		let values = zeroed_vec(packed_len).into_boxed_slice();
+		let values = zeroed_vec(packed_len);
 		Self { log_len, values }
 	}
 }
@@ -111,16 +111,7 @@ impl<P: PackedField> FieldBuffer<P, Vec<P>> {
 		values.push(P::from_scalars([value]));
 		Self { log_len: 0, values }
 	}
-
-	/// Converts into the canonical boxed-slice-backed [`FieldBuffer`].
-	pub fn into_boxed(self) -> FieldBuffer<P> {
-		FieldBuffer {
-			log_len: self.log_len,
-			values: self.values.into_boxed_slice(),
-		}
-	}
 }
-
 #[allow(clippy::len_without_is_empty)]
 impl<P: PackedField, Data: Deref<Target = [P]>> FieldBuffer<P, Data> {
 	/// Create a new FieldBuffer from a slice of packed values.

--- a/crates/math/src/multilinear/eq.rs
+++ b/crates/math/src/multilinear/eq.rs
@@ -396,7 +396,7 @@ mod tests {
 		let prepend = tensor_prod_eq_ind::<OneCube, P>(prepend, suffix);
 		let prepend = tensor_prod_eq_ind_prepend(prepend, prefix);
 
-		assert_eq!(append, prepend.into_boxed());
+		assert_eq!(append, prepend);
 	}
 
 	#[test]

--- a/crates/math/src/multilinear/hypercube.rs
+++ b/crates/math/src/multilinear/hypercube.rs
@@ -288,7 +288,7 @@ pub fn scaled_eq_ind_partial_eval_into<Cube: Hypercube, P: PackedField>(
 	buffer.clear();
 	buffer.push(P::from_scalars(iter::once(scale)));
 	let values = FieldBuffer::new(0, buffer);
-	tensor_prod_eq_ind::<Cube, P>(values, point).into_boxed()
+	tensor_prod_eq_ind::<Cube, P>(values, point)
 }
 
 /// Truncate the equality indicator expansion to the low indexed variables.
@@ -601,7 +601,7 @@ mod tests {
 			let prepend = tensor_prod_eq_ind::<InfCube, P>(prepend, suffix);
 			let prepend = tensor_prod_eq_ind_prepend::<InfCube, P>(prepend, prefix);
 
-			prop_assert_eq!(prepend.into_boxed(), eq_ind_partial_eval::<InfCube, P>(&point));
+			prop_assert_eq!(prepend, eq_ind_partial_eval::<InfCube, P>(&point));
 		}
 
 		/// Truncation strips the trailing variables of an expansion, for either cube.

--- a/crates/math/src/reed_solomon.rs
+++ b/crates/math/src/reed_solomon.rs
@@ -1,4 +1,5 @@
 // Copyright 2023-2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 //! [Reed–Solomon] codes over binary fields.
 //!
@@ -196,7 +197,7 @@ impl<F: BinaryField> ReedSolomonCode<F> {
 
 			output_data
 		};
-		let mut output = FieldBuffer::new(log_output_len, output_data.into_boxed_slice());
+		let mut output = FieldBuffer::new(log_output_len, output_data);
 
 		ntt.forward_transform(output.to_mut(), self.log_inv_rate, log_batch_size);
 		output

--- a/crates/math/src/univariate.rs
+++ b/crates/math/src/univariate.rs
@@ -1,4 +1,5 @@
 // Copyright 2024-2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 use binius_field::{BinaryField, Field, field::FieldOps};
 use itertools::izip;
@@ -46,7 +47,7 @@ pub fn evaluate_univariate<F: FieldOps>(coeffs: &[F], x: F) -> F {
 /// A vector of Lagrange polynomial evaluations, one for each domain element
 pub fn lagrange_evals<F: BinaryField>(subspace: &BinarySubspace<F>, z: F) -> FieldBuffer<F> {
 	let result = lagrange_evals_scalars(subspace, z);
-	FieldBuffer::new(subspace.dim(), result.into_boxed_slice())
+	FieldBuffer::new(subspace.dim(), result)
 }
 
 /// Scalar variant of [`lagrange_evals`] that returns a `Vec<E>` instead of a `FieldBuffer`.

--- a/crates/prover/src/fold_word.rs
+++ b/crates/prover/src/fold_word.rs
@@ -93,7 +93,7 @@ where
 
 	values.resize(capacity, P::default());
 
-	FieldBuffer::new(log_n, values.into_boxed_slice())
+	FieldBuffer::new(log_n, values)
 }
 
 /// A [`u64`]-specialized bytewise lookup transformation, folding a word's bits against a fixed

--- a/crates/prover/src/protocols/binmul.rs
+++ b/crates/prover/src/protocols/binmul.rs
@@ -46,7 +46,7 @@ where
 				F::from((lo[index].as_u64() as u128) | ((hi[index].as_u64() as u128) << 64))
 			}))
 		})
-		.collect::<Box<[_]>>();
+		.collect::<Vec<_>>();
 
 	FieldBuffer::new(n_vars, values)
 }

--- a/crates/prover/src/protocols/intmul/witness.rs
+++ b/crates/prover/src/protocols/intmul/witness.rs
@@ -235,7 +235,7 @@ where
 				.chunks(P::WIDTH)
 				.map(|chunk| P::from_scalars(chunk.iter().copied())),
 		);
-		return FieldBuffer::new(log_size, buffer.into_boxed_slice());
+		return FieldBuffer::new(log_size, buffer);
 	}
 
 	// Build the first block's `2^log_block` sequential powers, packed into `2^LOG_STRIDE` elements;
@@ -256,7 +256,7 @@ where
 		buffer.push(next);
 	}
 
-	FieldBuffer::new(log_size, buffer.into_boxed_slice())
+	FieldBuffer::new(log_size, buffer)
 }
 
 /// Extract limb `l` of an exponent word as a table row index.
@@ -370,7 +370,7 @@ where
 	// SAFETY: All elements initialized in the parallel loop above
 	unsafe { out_vec.set_len(total) };
 
-	FieldBuffer::new(n_vars + Word::LOG_BITS, out_vec.into_boxed_slice())
+	FieldBuffer::new(n_vars + Word::LOG_BITS, out_vec)
 }
 
 /// Compute the per-vertex bivariate product of two equally sized field buffers.
@@ -382,7 +382,7 @@ pub fn buffer_bivariate_product<P: PackedField, Data: Deref<Target = [P]>>(
 	let product = (a.as_ref(), b.as_ref())
 		.into_par_iter()
 		.map(|(&a, &b)| a * b)
-		.collect::<Box<[P]>>();
+		.collect::<Vec<P>>();
 	FieldBuffer::new(a.log_len(), product)
 }
 
@@ -415,7 +415,7 @@ where
 			});
 			P::from_scalars(scalars)
 		})
-		.collect::<Box<[_]>>();
+		.collect::<Vec<_>>();
 
 	FieldBuffer::new(n_vars, values)
 }

--- a/crates/prover/src/protocols/shift/monster.rs
+++ b/crates/prover/src/protocols/shift/monster.rs
@@ -244,7 +244,7 @@ where
 			));
 		}
 		values.resize(capacity, P::default());
-		FieldBuffer::new(log_len, values.into_boxed_slice())
+		FieldBuffer::new(log_len, values)
 	};
 
 	let log_public_words = checked_log_2(key_collection.public.n_words());

--- a/crates/prover/src/protocols/shift/phase_1.rs
+++ b/crates/prover/src/protocols/shift/phase_1.rs
@@ -304,7 +304,7 @@ fn build_multilinear_parts<P: PackedField>(
 
 	multilinears
 		.chunks(1 << (LOG_LEN - P::LOG_WIDTH))
-		.map(|chunk| FieldBuffer::new(LOG_LEN, chunk.to_vec().into_boxed_slice()))
+		.map(|chunk| FieldBuffer::new(LOG_LEN, chunk.to_vec()))
 		.collect::<Vec<_>>()
 		.try_into()
 		.expect("chunk has SHIFT_VARIANT_COUNT parts of size 1 << LOG_LEN")

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -472,7 +472,7 @@ pub fn pack_witness<P: PackedField<Scalar = B128>>(
 
 	padded_witness_elems.resize(len, P::default());
 
-	Ok(FieldBuffer::new(log_witness_elems, padded_witness_elems.into_boxed_slice()))
+	Ok(FieldBuffer::new(log_witness_elems, padded_witness_elems))
 }
 
 fn prove_bitand_reduction<F, PChallenge, Channel>(

--- a/crates/spartan-prover/src/lib.rs
+++ b/crates/spartan-prover/src/lib.rs
@@ -477,7 +477,7 @@ fn pack_and_blind_witness<F: Field, P: PackedField<Scalar = F>>(
 		elems_iter.chain(zeros_iter).collect::<Vec<_>>()
 	};
 
-	let mut buffer = FieldBuffer::new(log_private, packed.into_boxed_slice());
+	let mut buffer = FieldBuffer::new(log_private, packed);
 
 	// Add blinding values after the actual private wires
 	// Set random values for non-constraint dummy wires

--- a/crates/spartan-prover/src/wiring.rs
+++ b/crates/spartan-prover/src/wiring.rs
@@ -1,4 +1,5 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 use binius_field::{Field, PackedField};
 use binius_math::{FieldBuffer, FieldSlice};
@@ -129,7 +130,7 @@ pub fn fold_constraints<F: Field, P: PackedField<Scalar = F>>(
 		})
 		.collect::<Vec<_>>();
 
-	FieldBuffer::new(log_size, result.into_boxed_slice())
+	FieldBuffer::new(log_size, result)
 }
 
 /// Witness data for multiplication constraint checking.
@@ -228,9 +229,9 @@ pub fn build_mulcheck_witness<F: Field, P: PackedField<Scalar = F>>(
 	}
 
 	MulCheckWitness {
-		a: FieldBuffer::new(log_n_constraints, a.into_boxed_slice()),
-		b: FieldBuffer::new(log_n_constraints, b.into_boxed_slice()),
-		c: FieldBuffer::new(log_n_constraints, c.into_boxed_slice()),
+		a: FieldBuffer::new(log_n_constraints, a),
+		b: FieldBuffer::new(log_n_constraints, b),
+		c: FieldBuffer::new(log_n_constraints, c),
 	}
 }
 


### PR DESCRIPTION
## Summary

Changes `FieldBuffer<P, Data>`'s default backing from `Data = Box<[P]>` to `Data = Vec<P>`, per [BINIUS-319](https://linear.app/jimpo/issue/BINIUS-319/make-vecltpgt-the-default-fieldbuffer-backing-type).

Follow-up to the just-merged [#1848](https://github.com/binius-zk/binius64/pull/1848) (BINIUS-317). With capacity removed there, `Box<[P]>` has no room for the growth-shaped algorithms; `Vec<P>` gives real, `Vec`-native spare capacity, so the default should be `Vec`.

## What changed

- **Flip the default** to `Vec<P>` and fix the owned constructors (`from_values`, `zeros`) to stop discarding the `Vec` via `into_boxed_slice`.
- **Drop `into_boxed`** — with `Vec` the default, the `Vec`→`Box` conversion `scaled_eq_ind_partial_eval` used is no longer needed; it returns the `Vec`-backed buffer directly.
- **Audit `Box<[P]>` spellings** across the workspace: ~18 sites that built a `Vec`/`Box<[_]>` and immediately wrapped it in `FieldBuffer::new(…, x.into_boxed_slice())` / `collect::<Box<[_]>>()` now keep the `Vec` (iop-prover, spartan-prover, prover, m4-prover, ip-prover, math), plus one test's explicit `Box<[B128]>`.

`take_data` and `scalar_with_capacity` (added in #1848) are unaffected — they already return/produce the `Vec` backing.

## Compatibility

Mostly source-compatible: the ~45 functions returning `FieldBuffer<P>` by value and the struct fields that spell the default need no change. `Clone`/`PartialEq`/`Copy` are unaffected (`Copy` is bounded on `Data: Copy`; `Vec` is not `Copy`, same as `Box<[P]>`). `FieldBuffer` grows by one word (`Vec` is 3 words vs `Box<[P]>`'s 2), irrelevant at these sizes.

## Verification

`fmt`, `clippy -D warnings` (rayon + single-threaded configs), and tests across `binius-math`, `binius-ip-prover`, `binius-prover`, `binius-spartan-prover`, `binius-m4-prover`, `binius-iop-prover` all green; examples build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)