### PR TITLE
BINIUS-323: make the BaseFold opening self-verifying and tighten its internal API

### DIFF
--- a/crates/iop-prover/src/basefold/channel.rs
+++ b/crates/iop-prover/src/basefold/channel.rs
@@ -47,6 +47,22 @@ struct CommittedOracleData<P: PackedField, C> {
 	commitment: C,
 }
 
+/// A committed-oracle relation queued for the single batched opening.
+///
+/// Each entry pairs a committed message with the transparent multilinear it is opened against.
+/// It also records which committed oracle it refers to.
+/// That index reconciles the arrival-order and oracle-index views of the batch.
+struct QueuedRelation<P: PackedField> {
+	/// Index of the committed oracle this relation opens.
+	oracle_index: usize,
+	/// The committed multilinear message `pi_i`.
+	message: FieldBuffer<P>,
+	/// The transparent multilinear `t_i` paired with the message.
+	transparent: FieldBuffer<P>,
+	/// The claimed inner product `s_i = <pi_i, t_i>`.
+	claim: P::Scalar,
+}
+
 /// A prover channel that uses ZK BaseFold for all oracle commitments and openings.
 ///
 /// This channel owns an [`StdRng`] and generates random masks internally during
@@ -78,8 +94,8 @@ where
 	fri_params: FRIParams<F>,
 	committed_oracles: Vec<CommittedOracleData<P, Channel::Commitment>>,
 	/// Oracle relations queued by [`Self::prove_oracle_relations`], opened together in
-	/// [`Self::finish`]. Each entry is `(oracle_index, message π_i, transparent t_i, claim s_i)`.
-	queue: Vec<(usize, FieldBuffer<P>, FieldBuffer<P>, F)>,
+	/// [`Self::finish`].
+	queue: Vec<QueuedRelation<P>>,
 	next_oracle_index: usize,
 	rng: StdRng,
 }
@@ -174,7 +190,7 @@ fn prove_batch_zk_basefold<F, P, NTT, Channel>(
 	oracle_specs: &[OracleSpec],
 	fri_params: &FRIParams<F>,
 	committed_oracles: Vec<CommittedOracleData<P, Channel::Commitment>>,
-	relations: Vec<(usize, FieldBuffer<P>, FieldBuffer<P>, F)>,
+	relations: Vec<QueuedRelation<P>>,
 ) where
 	F: BinaryField,
 	P: PackedField<Scalar = F>,
@@ -201,18 +217,18 @@ fn prove_batch_zk_basefold<F, P, NTT, Channel>(
 	// oracle is present.
 	let any_zk_openings = relations
 		.iter()
-		.any(|(index, _, _, _)| oracle_specs[*index].is_zk);
+		.any(|rel| oracle_specs[rel.oracle_index].is_zk);
 	let (sigmas, gamma) = if any_zk_openings {
 		let _scope = tracing::debug_span!("Compute ZK mask opening values").entered();
 		let sigmas = relations
 			.iter()
-			.filter(|(index, _, _, _)| oracle_specs[*index].is_zk)
-			.map(|(index, _, transparent, _)| {
-				let mask = committed_oracles[*index]
+			.filter(|rel| oracle_specs[rel.oracle_index].is_zk)
+			.map(|rel| {
+				let mask = committed_oracles[rel.oracle_index]
 					.mask
 					.as_ref()
 					.expect("ZK oracle carries a mask");
-				inner_product_par(mask, transparent)
+				inner_product_par(mask, &rel.transparent)
 			})
 			.collect::<Vec<_>>();
 		channel.send_many(&sigmas);
@@ -233,39 +249,47 @@ fn prove_batch_zk_basefold<F, P, NTT, Channel>(
 	let mut prover_oracle_indices = Vec::with_capacity(n_committed);
 	let relations = relations
 		.into_iter()
-		.map(|(index, mut message, transparent, claim)| {
-			let n_i = oracle_specs[index].log_msg_len;
-			assert_eq!(message.log_len(), n_i); // pre-condition
-			assert_eq!(transparent.log_len(), n_i); // pre-condition
+		.map(
+			|QueuedRelation {
+			     oracle_index: index,
+			     mut message,
+			     transparent,
+			     claim,
+			 }| {
+				let n_i = oracle_specs[index].log_msg_len;
+				assert_eq!(message.log_len(), n_i); // pre-condition
+				assert_eq!(transparent.log_len(), n_i); // pre-condition
 
-			// ZK oracle: blind the message π_i' = (1-γ)π_i + γω_i
-			// Non-ZK oracle: the message passes through unmasked.
-			if oracle_specs[index].is_zk {
-				let mask = committed_oracles[index]
-					.mask
-					.as_ref()
-					.expect("ZK oracle carries a mask");
-				let gamma = gamma.expect("γ sampled when ZK oracles present");
+				// ZK oracle: blind the message π_i' = (1-γ)π_i + γω_i
+				// Non-ZK oracle: the message passes through unmasked.
+				if oracle_specs[index].is_zk {
+					let mask = committed_oracles[index]
+						.mask
+						.as_ref()
+						.expect("ZK oracle carries a mask");
+					let gamma = gamma.expect("γ sampled when ZK oracles present");
 
-				let gamma_broadcast = P::broadcast(gamma);
+					let gamma_broadcast = P::broadcast(gamma);
 
-				{
-					let _scope =
-						tracing::debug_span!("Fold message and ZK mask", log_len = n_i).entered();
-					(message.as_mut(), mask.as_ref()).into_par_iter().for_each(
-						|(message_i, &mask_i)| {
-							*message_i =
-								extrapolate_line_packed(*message_i, mask_i, gamma_broadcast);
-						},
-					);
+					{
+						let _scope =
+							tracing::debug_span!("Fold message and ZK mask", log_len = n_i)
+								.entered();
+						(message.as_mut(), mask.as_ref()).into_par_iter().for_each(
+							|(message_i, &mask_i)| {
+								*message_i =
+									extrapolate_line_packed(*message_i, mask_i, gamma_broadcast);
+							},
+						);
+					}
 				}
-			}
 
-			witness_primes[index] = Some(message);
-			prover_oracle_indices.push(index);
+				witness_primes[index] = Some(message);
+				prover_oracle_indices.push(index);
 
-			(index, transparent, claim)
-		})
+				(index, transparent, claim)
+			},
+		)
 		.collect::<Vec<_>>();
 
 	// Create the sumcheck provers
@@ -516,7 +540,12 @@ where
 				oracle.index,
 				self.committed_oracles.len()
 			);
-			self.queue.push((oracle.index, message, transparent, claim));
+			self.queue.push(QueuedRelation {
+				oracle_index: oracle.index,
+				message,
+				transparent,
+				claim,
+			});
 		}
 	}
 }

--- a/crates/iop-prover/src/basefold/opening.rs
+++ b/crates/iop-prover/src/basefold/opening.rs
@@ -36,8 +36,8 @@ use crate::{fri::FRIFoldProver, merkle_channel::MerkleIPProverChannel};
 /// * `channel` - the Merkle channel carrying all prover interaction: round coefficients,
 ///   challenges, commitments, and query openings
 ///
-/// The final FRI value equals the final MLE-check value `𝛑(r)` (see
-/// [`binius_iop::basefold::mlecheck_fri_consistency`]).
+/// The final FRI value equals the final MLE-check value.
+/// The verifier asserts that equality when it runs the matching opening.
 pub fn prove_mlecheck_basefold<F, P, NTT, Channel>(
 	witness: FieldBuffer<P>,
 	eval_point: &[F],
@@ -99,7 +99,7 @@ pub fn prove_mlecheck_basefold<F, P, NTT, Channel>(
 
 #[cfg(test)]
 mod test {
-	use anyhow::{Result, bail};
+	use anyhow::Result;
 	use binius_field::{BinaryField, PackedBinaryGhash1x128b, PackedField};
 	use binius_hash::{StdDigest, StdHashSuite};
 	use binius_iop::{
@@ -220,11 +220,9 @@ mod test {
 			verifier_channel.recv_merkle_commitment(2, n_vars + LOG_INV_RATE)?;
 		let batch_challenge_v: F = IPVerifierChannel::sample(&mut verifier_channel);
 
-		let verifier_basefold::ReducedOutput {
-			final_fri_value,
-			final_sumcheck_value,
-			..
-		} = verifier_basefold::verify_mlecheck_basefold(
+		// The verifier asserts FRI/MLE-check consistency internally.
+		// A tampered proof therefore surfaces here as an error.
+		verifier_basefold::verify_mlecheck_basefold(
 			&fri_params,
 			&[retrieved_commitment],
 			eval_claim,
@@ -233,10 +231,6 @@ mod test {
 			&[],
 			&mut verifier_channel,
 		)?;
-
-		if !verifier_basefold::mlecheck_fri_consistency(final_fri_value, final_sumcheck_value) {
-			bail!("MLE-check and FRI are inconsistent");
-		}
 
 		Ok(())
 	}

--- a/crates/iop-prover/src/fri/fold.rs
+++ b/crates/iop-prover/src/fri/fold.rs
@@ -156,6 +156,22 @@ where
 			.is_some_and(|round| round == self.curr_round)
 	}
 
+	/// Records the folding challenge for the current round and advances the round counter.
+	///
+	/// The challenge is buffered, not applied immediately.
+	/// Buffered challenges are consumed lazily at the next commit round.
+	/// This avoids materializing intermediate folded codewords.
+	///
+	/// The challenge order is a hard contract, shared with the verifier's fold order.
+	/// Feed challenges in the protocol's round order:
+	///
+	/// 1. the shared mask challenge `gamma`, once, if any oracle is ZK (the inner unbatch round);
+	/// 2. the `log_n_oracles` outer batching challenges (the oracle-combine rounds);
+	/// 3. one challenge per MLE-check round over the combined oracle's variables.
+	///
+	/// Steps 1 and 2 are fed up front.
+	/// Step 3 is interleaved with the fold rounds: one challenge after each fold.
+	/// The total number of challenges must equal the number of fold rounds.
 	pub fn receive_challenge(&mut self, challenge: F) {
 		self.unprocessed_challenges.push(challenge);
 		self.curr_round += 1;

--- a/crates/iop/src/basefold/channel.rs
+++ b/crates/iop/src/basefold/channel.rs
@@ -222,11 +222,8 @@ where
 		})
 		.sum::<F>();
 
-	let basefold::ReducedOutput {
-		final_fri_value,
-		final_sumcheck_value,
-		..
-	} = basefold::verify_mlecheck_basefold(
+	// The opening routine asserts the final FRI/MLE-check consistency internally.
+	basefold::verify_mlecheck_basefold(
 		fri_params,
 		&oracle_commitments,
 		s_prime,
@@ -235,9 +232,6 @@ where
 		&outer_challenges,
 		channel,
 	)?;
-
-	// The MLE-check internalizes the eq factor, so consistency is plain equality.
-	channel.assert_zero(final_sumcheck_value - final_fri_value)?;
 
 	Ok(())
 }

--- a/crates/iop/src/basefold/opening.rs
+++ b/crates/iop/src/basefold/opening.rs
@@ -3,7 +3,7 @@
 
 //! The core BaseFold opening protocol on the verifier side.
 
-use binius_field::{BinaryField, Field};
+use binius_field::BinaryField;
 use binius_ip::{mlecheck, sumcheck::RoundCoeffs};
 use binius_utils::checked_arithmetics::log2_ceil_usize;
 
@@ -38,8 +38,12 @@ use crate::{
 /// * `channel` - the Merkle channel carrying all prover interaction: round coefficients,
 ///   challenges, commitments, and query openings.
 ///
-/// The returned `challenges` are the FRI fold challenges `[γ] ++ r' ++ fresh_X`. Use
-/// [`mlecheck_fri_consistency`] to check the reduced values.
+/// The final consistency check is asserted internally, so `Ok` means the opening verified.
+///
+/// The MLE-check folds the equality-indicator factor into its round-proof recovery.
+/// So the final reduced value is the plain multilinear evaluation of the combined oracle at `r`.
+/// On an honest opening that value equals the final FRI value.
+/// This routine asserts their equality and rejects on any mismatch.
 pub fn verify_mlecheck_basefold<F, Channel>(
 	fri_params: &FRIParams<F>,
 	codeword_commitments: &[Channel::Commitment],
@@ -48,7 +52,7 @@ pub fn verify_mlecheck_basefold<F, Channel>(
 	batch_challenge: Option<F>,
 	outer_challenges: &[F],
 	channel: &mut Channel,
-) -> Result<ReducedOutput<F>, Error>
+) -> Result<(), Error>
 where
 	F: BinaryField,
 	Channel: MerkleIPVerifierChannel<F, Elem = F>,
@@ -115,26 +119,10 @@ where
 
 	let final_fri_value = fri_verifier.verify(channel)?;
 
-	Ok(ReducedOutput {
-		final_fri_value,
-		final_sumcheck_value: sum,
-		challenges,
-	})
-}
+	// The MLE-check folds the equality-indicator factor into its round-proof recovery.
+	// So the final reduced value is the plain evaluation, identical to the final FRI value.
+	// Reject on any mismatch.
+	channel.assert_zero(sum - final_fri_value)?;
 
-/// Output type of the [`verify_mlecheck_basefold`] function.
-pub struct ReducedOutput<F> {
-	pub final_fri_value: F,
-	pub final_sumcheck_value: F,
-	pub challenges: Vec<F>,
-}
-
-/// Verifies that the final FRI oracle is consistent with the MLE-check from
-/// [`verify_mlecheck_basefold`].
-///
-/// In an MLE-check the equality-indicator factor is folded into the round-proof recovery, so the
-/// final reduced value is the multilinear evaluation `π'(r)` with no extra factor. The final FRI
-/// value is the same `π'(r)`, so consistency is plain equality.
-pub fn mlecheck_fri_consistency<F: Field>(fri_final_oracle: F, sumcheck_final_claim: F) -> bool {
-	fri_final_oracle == sumcheck_final_claim
+	Ok(())
 }


### PR DESCRIPTION
Closes [BINIUS-323](https://linear.app/jimpo/issue/BINIUS-323).

Pure refactor — no protocol change. Three related rough edges from a review of the BaseFold opening path.

### The problem

The sharpest edge is a soundness footgun: the verifier's opening routine did **not** check its own core relation.

It returned two raw values — the final FRI value and the final MLE-check value — and trusted each caller to compare them, with a separate `bool`-returning helper for the comparison.

The check was optional and external: the real verifier inlined the comparison and never called the helper, so the published helper was **dead** on the verification path.

A caller that forgot the comparison would accept an invalid opening, with no type-level signal that anything was missing.

Two smaller edges: the prover queued its opening relations as an anonymous 4-tuple `(usize, FieldBuffer, FieldBuffer, F)` destructured positionally, and the fold state machine had no doc on the method carrying its most important contract (the order in which folding challenges must be fed).

### The change

Three self-contained pieces:

- **Self-verifying opening.** The opening routine performs the final consistency assert itself and returns `Result<(), Error>`. "Returned `Ok`" now means "the opening verified". The two-value output struct and the dead `bool` helper are removed; both call sites (the verifier channel and the prover's `k = 1` self-check) drop their manual compare.
- **Named queued relation.** The prover channel's queued relation becomes a named struct with `oracle_index` / `message` / `transparent` / `claim` fields instead of a positional 4-tuple. Closures read fields by name.
- **Documented fold-challenge contract.** The fold prover's challenge-receiving method now documents that challenges are buffered and applied lazily, and must be fed in a fixed order — shared mask, then the outer batching challenges, then one per MLE-check round — totaling the number of fold rounds.

All added / modified documentation follows the repo doc style: one sentence per line, no multi-line prose blocks, no references to names that can go stale.

### Soundness

No protocol change. The same equality is asserted on the same transcript channel; only which function performs it moves. Prover, transcript, and verifier all behave identically — the existing valid/invalid-proof tests still pass unchanged.

### Scope

- **changed:** `iop/basefold/opening.rs`, `iop/basefold/channel.rs`, `iop-prover/basefold/opening.rs`, `iop-prover/basefold/channel.rs`, `iop-prover/fri/fold.rs`.
- **contained:** every change lives in the `iop` / `iop-prover` crates; the modified opening routine's only callers are internal, so no downstream signature churns.
- **deferred to follow-ups:** dropping an unused arity-strategy generic (wide call-site churn across six crates) and bundling the opening routine's parameters into a claim struct (a cross-crate API-design decision).

### Verification

- `cargo +nightly fmt --all` — clean
- `cargo clippy -p binius-iop -p binius-iop-prover --all-targets` — clean
- `cargo check --all-targets` on `verifier`, `prover`, `spartan-verifier`, `spartan-prover`, `m4-verifier`, `m4-prover` — clean
- `cargo test -p binius-iop-prover` — 40 passed (BaseFold channel + FRI + valid/invalid-proof)
- `cargo test -p binius-spartan-prover --test wrapper_integration_test` — end-to-end ZK BaseFold prove/verify passes

Follows the module reorganization in BINIUS-321.

🤖 Generated with [Claude Code](https://claude.com/claude-code)