### PR TITLE
Remove the unused BYTE_BITS constant

### DIFF
--- a/crates/core/src/consts.rs
+++ b/crates/core/src/consts.rs
@@ -5,6 +5,3 @@
 ///
 /// This is the minimum size requirement for public input segments in the constraint system.
 pub const MIN_WORDS_PER_SEGMENT: usize = 2;
-
-/// The number of bits in a byte.
-pub const BYTE_BITS: usize = 8;


### PR DESCRIPTION
Deletes a dead constant from `binius-core::consts`. Pure cleanup — no behavior change.

### The problem

`BYTE_BITS` (`= 8`) lived in the protocol-constants module but was never used.

- `git grep BYTE_BITS` across the tracked workspace matches only its own definition.
- No crate imports it, and nothing derives from it (there is no `LOG_BYTE_BITS` on `main`).

So it is pure dead weight sitting next to the constants that actually matter.

### The change

```diff
 pub const MIN_WORDS_PER_SEGMENT: usize = 2;
-
-/// The number of bits in a byte.
-pub const BYTE_BITS: usize = 8;
```

`MIN_WORDS_PER_SEGMENT` is now the only constant in the file.

### Scope

- **changed:** `crates/core/src/consts.rs` — one constant removed
- nothing else touched; no call sites to update since there were none

### Verification

- `git grep BYTE_BITS` → only the definition (now gone)
- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-core --all-targets` — clean
- nightly `cargo fmt --all` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)