### PR TITLE
BINIUS-324: add Dependabot and bump the crates behind a major release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+updates:
+  # Rust crate dependencies declared in the workspace Cargo.toml.
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # Bundle the low-risk patch + minor bumps into a single weekly PR: one CI run,
+    # one review, one merge for the routine sweep. Major (breaking) bumps are left
+    # out of the group on purpose, so each lands as its own PR -- a k256 / num-bigint
+    # style upgrade needs a careful review and must not block the routine batch.
+    groups:
+      cargo:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Third-party GitHub Actions pinned in .github/workflows and .github/actions
+  # (actions/checkout, taiki-e/install-action, wasmerio/setup-wasmer, ...).
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ bytemuck = { version = "1.18.0", features = [
 bytes = "1.7.2"
 cfg-if = "1.0.0"
 clap = { version = "4.5", features = ["derive"] }
-cranelift-entity = "0.132.0"
+cranelift-entity = "0.133.1"
 criterion = { version = "0.8.0", default-features = false }
 derive_more = { version = "2.1.1", features = [
     "add",
@@ -57,14 +57,14 @@ hex = "0.4"
 hex-literal = "1.0.0"
 hmac = "0.13.0"
 hybrid-array = "0.4.7"
-itertools = "0.14.0"
+itertools = "0.15.0"
 jwt-simple = { version = "0.12.16", default-features = false, features = [
     "pure-rust",
 ] }
-k256 = "0.13.4"
+k256 = "0.14.0"
 keccak = "0.2.0"
 lazy_static = "1.5.0"
-num-bigint = "0.4.6"
+num-bigint = "0.5.1"
 num-integer = "0.1.46"
 num-traits = "0.2.19"
 paste = "1.0.15"

--- a/crates/circuits/src/bitcoin/p2pkh_signature.rs
+++ b/crates/circuits/src/bitcoin/p2pkh_signature.rs
@@ -147,10 +147,7 @@ mod tests {
 	/// Compute compressed SEC1 public key from a 32-byte big-endian private key.
 	/// Panics if the scalar is zero.
 	pub fn compressed_pubkey_from_be_sk(sk_be: [u8; 32]) -> [u8; 33] {
-		use k256::{
-			ProjectivePoint, Scalar,
-			elliptic_curve::{ops::MulByGenerator, sec1::ToEncodedPoint},
-		};
+		use k256::{ProjectivePoint, Scalar, elliptic_curve::sec1::ToSec1Point};
 
 		// Interpret big-endian bytes as scalar mod curve order via Horner's method
 		let mut s = Scalar::from(0u64);
@@ -161,7 +158,7 @@ mod tests {
 		assert!(!bool::from(s.is_zero()), "private key must be non-zero");
 
 		let affine = ProjectivePoint::mul_by_generator(&s).to_affine();
-		let ep = affine.to_encoded_point(true);
+		let ep = affine.to_sec1_point(true);
 		let mut out = [0u8; 33];
 		out.copy_from_slice(ep.as_bytes());
 		out

--- a/crates/circuits/src/ecdsa/scalar_mul.rs
+++ b/crates/circuits/src/ecdsa/scalar_mul.rs
@@ -280,7 +280,7 @@ mod tests {
 	use binius_frontend::CircuitBuilder;
 	use k256::{
 		ProjectivePoint, Scalar, U256,
-		elliptic_curve::{ops::MulByGenerator, scalar::FromUintUnchecked, sec1::ToEncodedPoint},
+		elliptic_curve::{scalar::FromUintUnchecked, sec1::ToSec1Point},
 	};
 	use rand::prelude::*;
 
@@ -310,7 +310,7 @@ mod tests {
 		let k256_point = ProjectivePoint::mul_by_generator(&k256_scalar).to_affine();
 
 		// Extract coordinates from k256 result
-		let point_bytes = k256_point.to_encoded_point(false).to_bytes();
+		let point_bytes = k256_point.to_sec1_point(false).to_bytes();
 		let x_coord = num_bigint::BigUint::from_bytes_be(&point_bytes[1..33]);
 		let y_coord = num_bigint::BigUint::from_bytes_be(&point_bytes[33..65]);
 
@@ -369,7 +369,7 @@ mod tests {
 				BigUint::new_constant(&builder, &scalar_bigint).zero_extend(&builder, N_LIMBS),
 			);
 
-			let point_bytes = point.to_affine().to_encoded_point(false).to_bytes();
+			let point_bytes = point.to_affine().to_sec1_point(false).to_bytes();
 			let x_coord = num_bigint::BigUint::from_bytes_be(&point_bytes[1..33]);
 			let y_coord = num_bigint::BigUint::from_bytes_be(&point_bytes[33..65]);
 			points.push(Secp256k1Affine {
@@ -381,7 +381,7 @@ mod tests {
 
 		let result = msm_fn(&builder, &curve, window, &scalars, &points);
 
-		let expected_bytes = expected.to_affine().to_encoded_point(false).to_bytes();
+		let expected_bytes = expected.to_affine().to_sec1_point(false).to_bytes();
 		let expected_x = BigUint::new_constant(
 			&builder,
 			&num_bigint::BigUint::from_bytes_be(&expected_bytes[1..33]),

--- a/crates/examples/src/circuits/ec_msm.rs
+++ b/crates/examples/src/circuits/ec_msm.rs
@@ -12,7 +12,7 @@ use binius_frontend::{CircuitBuilder, WitnessFiller};
 use clap::Args;
 use k256::{
 	ProjectivePoint, Scalar, U256,
-	elliptic_curve::{ops::MulByGenerator, scalar::FromUintUnchecked, sec1::ToEncodedPoint},
+	elliptic_curve::{scalar::FromUintUnchecked, sec1::ToSec1Point},
 };
 use rand::prelude::*;
 
@@ -134,7 +134,7 @@ impl ExampleCircuit for EcMsmExample {
 
 /// Populate the `x` and `y` limb wires from a k256 projective point's affine coordinates.
 fn populate_point(w: &mut WitnessFiller, p: &ProjectivePoint, x: &BigUint, y: &BigUint) {
-	let bytes = p.to_affine().to_encoded_point(false).to_bytes();
+	let bytes = p.to_affine().to_sec1_point(false).to_bytes();
 	// Uncompressed SEC1 encoding: `0x04 || x (32 bytes) || y (32 bytes)`.
 	x.populate_limbs(w, &le_limbs(&num_bigint::BigUint::from_bytes_be(&bytes[1..33])));
 	y.populate_limbs(w, &le_limbs(&num_bigint::BigUint::from_bytes_be(&bytes[33..65])));


### PR DESCRIPTION
@jimpo Just a bump of the deps and I've added a dependabot, similarly to what we have in Plonky3 on a weekly basis, this helps to track dep bumps.

Closes [BINIUS-324](https://linear.app/jimpo/issue/BINIUS-324).

Bumps the four direct crates that were behind a major release, and adds Dependabot so the repo stops drifting. No protocol or witness change — the bumped crypto crates back reference code, not the circuits themselves.

### The problem

Several workspace crates were behind on a major (breaking) release, and nothing was watching for drift.
Everything was current *within* its declared semver range — but a handful of direct crates had a newer major sitting unadopted, and there was no `.github/dependabot.yml` to catch the next one.
Left alone the gap only grows: the longer a major bump waits, the more painful the eventual migration.

### The idea

Two moves, one theme — stop the drift now, and keep it from coming back.

1. Bump every direct dependency that can actually move to its latest release.
2. Add Dependabot so future bumps arrive as small, reviewable PRs on a weekly cadence.

### The change — bumps

Four direct workspace dependencies moved to their current versions:

| crate | from | to | code change |
|---|---|---|---|
| `itertools` | 0.14 | 0.15 | none |
| `cranelift-entity` | 0.132 | 0.133 | none |
| `num-bigint` | 0.4 | 0.5 | none |
| `k256` | 0.13 | 0.14 | two API renames |

`k256` 0.14 (elliptic-curve 0.14) renamed two APIs used by the secp256k1 / ECDSA reference code in tests and the `ec_msm` example:

- `elliptic_curve::ops::MulByGenerator` is gone — `mul_by_generator` is now an inherent method on `ProjectivePoint`, so the trait import is dropped.
- `sec1::ToEncodedPoint::to_encoded_point` is deprecated in favour of `sec1::ToSec1Point::to_sec1_point` — switched to the new name so the `-D warnings` build stays clean.

### The change — Dependabot

`.github/dependabot.yml` watches the two ecosystems the repo actually uses:

- `cargo` — weekly. Patch and minor bumps are grouped into one PR; major bumps are left out of the group so each lands as its own reviewable PR.
- `github-actions` — weekly, grouped (the repo pins `actions/checkout`, `taiki-e/install-action`, `wasmerio/setup-wasmer`, and more).

Grouping the routine patch/minor bumps keeps them to a single CI run and merge; isolating majors means a breaking bump (a `k256` / `num-bigint` style upgrade) never blocks the routine batch.

### What could not move — and why

Three dependencies are pinned by upstreams and cannot advance yet:

- `bitcoin_hashes` (0.14 → 1.1): the `bitcoin` crate 0.32.7 (latest stable; 0.33 is beta only) requires `bitcoin_hashes` 0.14. Bumping ours to 1.x pulls a second copy and breaks interop with `bitcoin`'s own hash types. It can move only once `bitcoin` 0.33 is adopted.
- `generic-array` (0.14.7 → 0.14.9) and `ml-dsa` (0.1.0-rc.11 → 0.1.1): transitive, held by `aead` and `jwt-simple` / `superboring`. They advance only when those upstreams release.

### Soundness

The bumped crypto crates back reference code, not the protocol itself.
`num-bigint` and `k256` provide the out-of-circuit reference — BigUint arithmetic and secp256k1 scalar-mul — that tests check the circuits against.
All binius-circuits `ecdsa` / `secp256k1` / `bignum` / `bitcoin` reference-vs-circuit tests pass, so the reference still matches the circuits under the new versions — no protocol or witness change.

### Scope

- **changed:** `Cargo.toml` (four version bumps); three call sites migrated to the `k256` 0.14 API (`ecdsa/scalar_mul.rs`, `bitcoin/p2pkh_signature.rs`, `examples/.../ec_msm.rs`).
- **new:** `.github/dependabot.yml` (cargo + github-actions).
- **left untouched:** `bitcoin_hashes` and the two transitive deps — blocked upstream, see above.

### Verification

- `cargo build --workspace --lib --bins --tests --examples` — clean
- `cargo clippy -p binius-circuits -p binius-examples --all-targets -- -D warnings` — clean
- nightly `cargo fmt --all` — clean
- `cargo nextest run -p binius-circuits` on the ecdsa / secp256k1 / bignum / bitcoin tests — 43 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)