### PR TITLE
BINIUS-90: make PackedField a Field supertrait

### DIFF
--- a/crates/field/src/binary_field.rs
+++ b/crates/field/src/binary_field.rs
@@ -169,7 +169,7 @@ macro_rules! binary_field {
 		}
 
 		// A field element divides into exactly one element of itself. This makes the field a
-		// degenerate packed field of width one (see the blanket `PackedField for Field` impl).
+		// degenerate packed field of width one (see the `PackedField` impl below).
 		impl $crate::Divisible<$name> for $name {
 			const LOG_N: usize = 0;
 
@@ -225,6 +225,41 @@ macro_rules! binary_field {
 			#[inline]
 			fn select(&self, mask: &$typ) -> Self {
 				Self(self.0 & *mask)
+			}
+		}
+
+		impl $crate::PackedField for $name {
+			#[inline]
+			fn iter(&self) -> impl Iterator<Item = Self::Scalar> + Send + Clone + '_ {
+				std::iter::once(*self)
+			}
+
+			#[inline]
+			fn into_iter(self) -> impl Iterator<Item = Self::Scalar> + Send + Clone {
+				std::iter::once(self)
+			}
+
+			#[inline]
+			fn iter_slice(slice: &[Self]) -> impl Iterator<Item = Self::Scalar> + Send + Clone + '_ {
+				slice.iter().copied()
+			}
+
+			fn interleave(self, _other: Self, _log_block_len: usize) -> (Self, Self) {
+				panic!("cannot interleave when WIDTH = 1");
+			}
+
+			fn unzip(self, _other: Self, _log_block_len: usize) -> (Self, Self) {
+				panic!("cannot transpose when WIDTH = 1");
+			}
+
+			#[inline]
+			fn from_fn(mut f: impl FnMut(usize) -> Self::Scalar) -> Self {
+				f(0)
+			}
+
+			#[inline]
+			unsafe fn spread_unchecked(self, _log_block_len: usize, _block_idx: usize) -> Self {
+				self
 			}
 		}
 

--- a/crates/field/src/field.rs
+++ b/crates/field/src/field.rs
@@ -2,18 +2,17 @@
 // Copyright 2026 The Binius Developers
 
 use std::{
-	fmt::{Debug, Display},
+	fmt::Display,
 	hash::Hash,
 	iter::{Product, Sum},
 	ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
 
 use binius_utils::{DeserializeBytes, FixedSizeSerializeBytes, SerializeBytes};
-use bytemuck::Zeroable;
 
 use super::extension::ExtensionField;
 use crate::{
-	Divisible, Maskable, Random, WideMul,
+	PackedField,
 	arithmetic_traits::{InvertOrZero, Square},
 };
 
@@ -23,48 +22,12 @@ use crate::{
 /// [`CHARACTERISTIC`](Self::CHARACTERISTIC) and `k` is the
 /// [`ORDER_EXPONENT`](Self::ORDER_EXPONENT).
 pub trait Field:
-	Sized
-	+ Eq
-	+ Copy
-	+ Clone
-	+ Default
-	+ Send
-	+ Sync
-	+ Debug
+	PackedField<Scalar = Self>
 	+ Display
 	+ Hash
-	+ 'static
-	+ Neg<Output = Self>
-	+ Add<Output = Self>
-	+ Sub<Output = Self>
-	+ Mul<Output = Self>
-	+ for<'a> Add<&'a Self, Output = Self>
-	+ for<'a> Sub<&'a Self, Output = Self>
-	+ for<'a> Mul<&'a Self, Output = Self>
-	+ Sum
-	+ Product
-	+ for<'a> Sum<&'a Self>
-	+ for<'a> Product<&'a Self>
-	+ AddAssign
-	+ SubAssign
-	+ MulAssign
-	+ for<'a> AddAssign<&'a Self>
-	+ for<'a> SubAssign<&'a Self>
-	+ for<'a> MulAssign<&'a Self>
-	+ Square
-	+ InvertOrZero
-	+ Random
-	+ Zeroable
 	+ SerializeBytes
 	+ DeserializeBytes
 	+ FixedSizeSerializeBytes
-	+ WideMul<Output: Debug + Send + Sync + 'static>
-	// A field is a degenerate packed field of width one, so it divides into a single copy of
-	// itself. This mirrors `PackedField: Divisible<Self::Scalar>` for the blanket packed impl.
-	+ Divisible<Self>
-	// A field is maskable as a width-one packed field, mirroring
-	// `PackedField: Maskable<Self::Scalar>`.
-	+ Maskable<Self>
 {
 	/// The zero element of the field, the additive identity.
 	const ZERO: Self;

--- a/crates/field/src/field.rs
+++ b/crates/field/src/field.rs
@@ -76,7 +76,7 @@ pub trait Field:
 ///
 /// This trait abstracts over:
 /// - [`Field`] types (single field elements, which are trivially vectors of length 1)
-/// - [`PackedField`](crate::PackedField) types (SIMD-accelerated vectors of field elements)
+/// - [`PackedField`] types (SIMD-accelerated vectors of field elements)
 /// - Symbolic field types (for constraint system representations)
 ///
 /// Mathematically, instances of this trait represent vectors of field elements where

--- a/crates/field/src/packed.rs
+++ b/crates/field/src/packed.rs
@@ -18,7 +18,7 @@ use binius_utils::{
 use bytemuck::Zeroable;
 
 use super::{Random, arithmetic_traits::Square};
-use crate::{BinaryField, Divisible, Field, Maskable, WideMul, field::FieldOps};
+use crate::{BinaryField, Divisible, Maskable, WideMul, field::FieldOps};
 
 /// A packed field represents a vector of underlying field elements.
 ///
@@ -390,45 +390,6 @@ impl<P: PackedField> RandomAccessSequenceMut<P::Scalar> for PackedSliceMut<'_, P
 	}
 }
 
-impl<F: Field> PackedField for F {
-	// LOG_WIDTH defaults to `<Self as Divisible<Self>>::LOG_N`, which is 0 for a scalar field.
-	// Scalar element access (`get_unchecked`/`set_unchecked`) is provided by the reflexive
-	// `Divisible<Self>` impl.
-
-	#[inline]
-	fn iter(&self) -> impl Iterator<Item = Self::Scalar> + Send + Clone + '_ {
-		iter::once(*self)
-	}
-
-	#[inline]
-	fn into_iter(self) -> impl Iterator<Item = Self::Scalar> + Send + Clone {
-		iter::once(self)
-	}
-
-	#[inline]
-	fn iter_slice(slice: &[Self]) -> impl Iterator<Item = Self::Scalar> + Send + Clone + '_ {
-		slice.iter().copied()
-	}
-
-	fn interleave(self, _other: Self, _log_block_len: usize) -> (Self, Self) {
-		panic!("cannot interleave when WIDTH = 1");
-	}
-
-	fn unzip(self, _other: Self, _log_block_len: usize) -> (Self, Self) {
-		panic!("cannot transpose when WIDTH = 1");
-	}
-
-	#[inline]
-	fn from_fn(mut f: impl FnMut(usize) -> Self::Scalar) -> Self {
-		f(0)
-	}
-
-	#[inline]
-	unsafe fn spread_unchecked(self, _log_block_len: usize, _block_idx: usize) -> Self {
-		self
-	}
-}
-
 /// A helper trait to make the generic bounds shorter
 pub trait PackedBinaryField: PackedField<Scalar: BinaryField> {}
 
@@ -441,7 +402,7 @@ mod tests {
 
 	use super::*;
 	use crate::{
-		AESTowerField8b, BinaryField1b, BinaryField128bGhash, PackedAESBinaryField1x8b,
+		AESTowerField8b, BinaryField1b, BinaryField128bGhash, Field, PackedAESBinaryField1x8b,
 		PackedAESBinaryField16x8b, PackedAESBinaryField32x8b, PackedAESBinaryField64x8b,
 		PackedBinaryField1x1b, PackedBinaryField2x1b, PackedBinaryField4x1b, PackedBinaryField8x1b,
 		PackedBinaryField16x1b, PackedBinaryField32x1b, PackedBinaryField64x1b,

--- a/crates/prover/src/protocols/intmul/prove.rs
+++ b/crates/prover/src/protocols/intmul/prove.rs
@@ -4,7 +4,7 @@
 use std::marker::PhantomData;
 
 use binius_core::word::Word;
-use binius_field::{BinaryField, BinaryField1b, Divisible, ExtensionField, FieldOps, PackedField};
+use binius_field::{BinaryField, BinaryField1b, Divisible, ExtensionField, PackedField};
 use binius_iop_prover::{
 	channel::IOPProverChannel,
 	logup_star::{self, Looker},


### PR DESCRIPTION
@jimpo I read your fear on the Linear ticket, I've found this design which looks great no?

Closes [BINIUS-90](https://linear.app/jimpo/issue/BINIUS-90).

Declares in the type system what was already true: every field is a packed vector of width one. Pure refactor — no behavior change.

### The problem

"Every `Field` is also a `PackedField`" was expressed by a blanket `impl<F: Field> PackedField for F`.

- The relationship lived in an impl, not in the trait bound.
- So a `F: Field` bound alone did **not** give you the packed API — you had to add `+ PackedField` (or `+ FieldOps`) at the call site.
- And `Field` separately re-listed a long tail of bounds (arithmetic, `Divisible<Self>`, `Maskable<Self>`, `Random`, `Zeroable`, `WideMul`) that a packed field already guarantees.

### The idea

Make the relationship a **supertrait** and let each field carry its own width-one impl:

```
Field: PackedField<Scalar = Self>
```

- A `Field` bound now supplies the entire packed API for free.
- The blanket impl is gone; the `binary_field!` macro emits a per-type width-one `PackedField` impl instead — exactly how it already emits the reflexive `Divisible<Self>` / `Maskable<Self>` impls.
- The impl bodies are byte-identical to the old blanket (iterate yields the single element; `interleave` / `unzip` panic; `from_fn` calls `f(0)`).

### The change

```
// field.rs — Field's supertrait list collapses to the field-only additions
- Sized + Eq + Copy + ... + Neg + Add + ... + Divisible<Self> + Maskable<Self> + WideMul<...>
+ PackedField<Scalar = Self> + Display + Hash + SerializeBytes + DeserializeBytes + FixedSizeSerializeBytes

// packed.rs — the blanket impl is removed
- impl<F: Field> PackedField for F { ... }

// binary_field.rs — the macro now emits the width-one impl for every field type
+ impl PackedField for $name { fn from_fn(f) { f(0) } ... }
```

Everything else on the old `Field` list (all arithmetic ops, `Divisible<Self>`, `Maskable<Self>`, `Random`, `Zeroable`, `WideMul`, `Send`/`Sync`/`Copy`/`'static`/...) is now inherited transitively through `PackedField` and `FieldOps`, so listing it was redundant.

### Why this compiles — the trait-solver cycle is not real

The interesting risk: `Field` needs `PackedField`, which needs `FieldOps`, which is handed out by `impl<F: Field> FieldOps for F` — a loop back to `Field`.

It terminates because the compiler satisfies a bound by matching an impl and then checking only **that impl's own where-clauses**, not the trait's supertraits. Each field's `PackedField` impl and `Field` impl have no where-clauses, so every lookup bottoms out immediately:

```
is BinaryField1b a PackedField?  -> found `impl PackedField for BinaryField1b`, no where-clauses -> yes
is BinaryField1b a FieldOps?     -> `impl<F: Field> FieldOps for F` needs `BinaryField1b: Field` -> found impl, no where-clauses -> yes
```

Giving each field a concrete `PackedField` impl (and removing the blanket) is what keeps the first lookup from re-deriving through `Field`.

### Scope

- **changed:** `crates/field/src/{field.rs, packed.rs, binary_field.rs}` — the four field types (`BinaryField1b`, `AESTowerField8b`, `BinaryField128bGhash`, `GhashSq256b`) all satisfy the new supertrait via the macro.
- **cleanup:** dropped one now-redundant `FieldOps` import in `crates/prover/src/protocols/intmul/prove.rs`.
- **left untouched:** the `PackedPrimitiveType` and `SlicedPackedField` packed impls; the reflexive `FieldOps for F` and `ExtensionField<F> for F` blanket impls.
- No `Field` types exist outside the field crate, and there are no self-targeted `impl<P: PackedField>` / `impl<F: Field>` blankets that would newly overlap, so coherence is unaffected.

### Verification

- `cargo check --workspace --all-targets`, `clippy --workspace --all-targets`, nightly `fmt --all` — clean.
- `binius-field` tests: 208 passed, doctests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)