### PR TITLE
BINIUS-326: harden the BaseFold verifier channel

### DIFF
--- a/crates/iop/src/basefold/channel.rs
+++ b/crates/iop/src/basefold/channel.rs
@@ -321,8 +321,7 @@ where
 
 		let commitment = self
 			.channel
-			.recv_merkle_commitment(1 << fri_oracle.log_batch_size(), depth)
-			.map_err(|_| Error::ProofEmpty)?;
+			.recv_merkle_commitment(1 << fri_oracle.log_batch_size(), depth)?;
 
 		self.oracle_commitments.push(commitment);
 		self.next_oracle_index += 1;

--- a/crates/iop/src/channel/mod.rs
+++ b/crates/iop/src/channel/mod.rs
@@ -22,6 +22,8 @@ pub enum Error {
 	IPChannel(#[from] binius_ip::channel::Error),
 	#[error("sumcheck error: {0}")]
 	Sumcheck(#[from] binius_ip::sumcheck::Error),
+	#[error("Merkle channel error: {0}")]
+	Merkle(#[from] crate::merkle_channel::Error),
 }
 
 /// Specification for an oracle to be committed in the IOP.


### PR DESCRIPTION
Closes [BINIUS-326](https://linear.app/jimpo/issue/BINIUS-326).

Hardens one error path in the BaseFold verifier channel. Pure robustness — no protocol change, passing proofs are byte-for-byte identical.

### The problem

`recv_oracle` mapped every Merkle-commitment receive failure to a generic `Error::ProofEmpty`, throwing away the real cause. A genuine Merkle failure surfaced as a misleading "proof is empty" error.

### The idea

Keep the real error. Add a `Merkle` error variant and propagate the underlying `merkle_channel::Error` with `?` instead of flattening it.

### The change

```diff
  // recv_oracle: keep the real Merkle error instead of flattening it
- .recv_merkle_commitment(1 << fri_oracle.log_batch_size(), depth)
- .map_err(|_| Error::ProofEmpty)?;
+ .recv_merkle_commitment(1 << fri_oracle.log_batch_size(), depth)?;
```

### Soundness

No protocol change. The edit touches only an error path: it surfaces the same failures, just with the true cause attached. The witness, transcript, and challenge sampling are all untouched, so passing proofs are byte-for-byte identical.

### Scope

- **new:** `Merkle(#[from] merkle_channel::Error)` variant on the IOP channel `Error`.
- **changed:** the Merkle error propagation in `recv_oracle`.
- the accepting path and all existing channel tests are untouched.

The duplicate-oracle-relation guard from the first revision was dropped per review — that restriction is only a prover-side limitation, and the verifier is sound with multiple linear relations on the same oracle.

### Verification

- `cargo check`, `clippy -p binius-iop -p binius-iop-prover --all-targets` — clean.
- `cargo test -p binius-iop-prover basefold::channel` — 7/7 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
