### PR TITLE
BINIUS-316: introduce binius-compute BufferPool and pool the prover's Word buffers

### DIFF
--- a/crates/compute/Cargo.toml
+++ b/crates/compute/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "binius-compute"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+bytemuck = { workspace = true }

--- a/crates/compute/src/lib.rs
+++ b/crates/compute/src/lib.rs
@@ -1,0 +1,171 @@
+// Copyright 2026 The Binius Developers
+
+//! Buffer pooling for prover working memory.
+//!
+//! The prover allocates many large, short-lived buffers. [`BufferPool`] is the seam through which
+//! those allocations flow, so they can later be served from a recycling free list instead of the
+//! global allocator. Buffers are handed out as [`PoolVec`] handles that borrow the pool for
+//! `'alloc` and, in a future revision, return their block to it on drop.
+//!
+//! The current implementation is a thin pass-through over [`Vec`]: [`BufferPool::alloc_vec`] just
+//! calls [`Vec::with_capacity`]. This establishes the API and the `'alloc` lifetime threading
+//! without committing to a pool layout yet.
+
+use std::{
+	fmt,
+	mem::MaybeUninit,
+	ops::{Deref, DerefMut},
+};
+
+use bytemuck::Pod;
+
+/// A pool that hands out reusable buffers for prover working memory.
+///
+/// Allocation goes through [`alloc_vec`](Self::alloc_vec), which currently forwards to
+/// [`Vec::with_capacity`]. A pool is created once, above the code that uses it, and shared by
+/// borrow — every [`PoolVec`] it produces holds a `&'alloc BufferPool`.
+#[derive(Default)]
+pub struct BufferPool {
+	// No free list yet; buffers are allocated straight from the global allocator. A recycling
+	// implementation slots in behind `alloc_vec`/`PoolVec::drop` without changing their
+	// signatures.
+	_private: (),
+}
+
+impl BufferPool {
+	/// Creates a new pool.
+	pub fn new() -> Self {
+		Self::default()
+	}
+
+	/// Allocates a [`PoolVec`] with room for at least `capacity` elements.
+	///
+	/// The returned buffer is empty; fill it through the [`PoolVec`] interface.
+	pub fn alloc_vec<T: Pod>(&self, capacity: usize) -> PoolVec<'_, T> {
+		PoolVec {
+			pool: self,
+			data: Vec::with_capacity(capacity),
+		}
+	}
+}
+
+impl fmt::Debug for BufferPool {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		f.debug_struct("BufferPool").finish_non_exhaustive()
+	}
+}
+
+/// A `Vec`-like buffer borrowed from a [`BufferPool`] for `'alloc`.
+///
+/// Dereferences to `[T]`, so all slice operations are available directly. Only the growth and
+/// mutation methods actually used by callers are exposed; add more as needed rather than mirroring
+/// all of [`Vec`].
+pub struct PoolVec<'alloc, T: Pod> {
+	// Held so a future recycling pool can return the block on drop. Unused by the pass-through.
+	#[allow(dead_code)]
+	pool: &'alloc BufferPool,
+	data: Vec<T>,
+}
+
+impl<T: Pod> PoolVec<'_, T> {
+	/// Returns the number of elements the buffer can hold without reallocating.
+	pub const fn capacity(&self) -> usize {
+		self.data.capacity()
+	}
+
+	/// Appends an element to the back of the buffer.
+	pub fn push(&mut self, value: T) {
+		self.data.push(value);
+	}
+
+	/// Appends all elements of `other` to the back of the buffer.
+	pub fn extend_from_slice(&mut self, other: &[T]) {
+		self.data.extend_from_slice(other);
+	}
+
+	/// Clears the buffer, removing all elements while retaining its capacity.
+	pub fn clear(&mut self) {
+		self.data.clear();
+	}
+
+	/// Resizes the buffer to `new_len`, filling any new slots with `value`.
+	pub fn resize(&mut self, new_len: usize, value: T) {
+		self.data.resize(new_len, value);
+	}
+
+	/// Returns the spare capacity of the buffer as a slice of `MaybeUninit<T>`.
+	///
+	/// Mirrors [`Vec::spare_capacity_mut`]: used to write into a freshly allocated buffer in place
+	/// (e.g. in parallel) before committing the length with [`set_len`](Self::set_len).
+	pub fn spare_capacity_mut(&mut self) -> &mut [MaybeUninit<T>] {
+		self.data.spare_capacity_mut()
+	}
+
+	/// Forces the length of the buffer to `new_len`.
+	///
+	/// # Safety
+	///
+	/// Same contract as [`Vec::set_len`]: `new_len` must be at most [`capacity`](Self::capacity)
+	/// and the elements in `0..new_len` must be initialized.
+	pub unsafe fn set_len(&mut self, new_len: usize) {
+		unsafe { self.data.set_len(new_len) }
+	}
+}
+
+impl<T: Pod> Deref for PoolVec<'_, T> {
+	type Target = [T];
+
+	fn deref(&self) -> &[T] {
+		&self.data
+	}
+}
+
+impl<T: Pod> DerefMut for PoolVec<'_, T> {
+	fn deref_mut(&mut self) -> &mut [T] {
+		&mut self.data
+	}
+}
+
+impl<T: Pod> Extend<T> for PoolVec<'_, T> {
+	fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
+		self.data.extend(iter);
+	}
+}
+
+impl<T: Pod + fmt::Debug> fmt::Debug for PoolVec<'_, T> {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		f.debug_list().entries(self.data.iter()).finish()
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn alloc_vec_reserves_capacity_and_starts_empty() {
+		let pool = BufferPool::new();
+		let buffer = pool.alloc_vec::<u64>(16);
+		assert!(buffer.is_empty());
+		assert!(buffer.capacity() >= 16);
+	}
+
+	#[test]
+	fn push_extend_and_deref() {
+		let pool = BufferPool::new();
+		let mut buffer = pool.alloc_vec::<u64>(4);
+		buffer.push(1);
+		buffer.extend_from_slice(&[2, 3]);
+		buffer.extend([4, 5]);
+		assert_eq!(&*buffer, &[1, 2, 3, 4, 5]);
+
+		buffer[0] = 10;
+		assert_eq!(buffer[0], 10);
+
+		buffer.resize(3, 0);
+		assert_eq!(&*buffer, &[10, 2, 3]);
+
+		buffer.clear();
+		assert!(buffer.is_empty());
+	}
+}

--- a/crates/m4-prover/src/operand_witness.rs
+++ b/crates/m4-prover/src/operand_witness.rs
@@ -203,7 +203,7 @@ impl BatchAndCheckWitness {
 			log_total_constraints.saturating_sub(PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES.len());
 		let big_field_zerocheck_challenges = channel.sample_many(n_extra_zerocheck_challenges);
 
-		let prover = OblongZerocheckProver::<_, P>::new(
+		let prover = OblongZerocheckProver::<_, P, _>::new(
 			log_total_constraints,
 			a,
 			b,

--- a/crates/prover/Cargo.toml
+++ b/crates/prover/Cargo.toml
@@ -8,6 +8,7 @@ authors.workspace = true
 workspace = true
 
 [dependencies]
+binius-compute = { path = "../compute" }
 binius-core = { path = "../core" }
 binius-field = { path = "../field" }
 binius-hash = { path = "../hash" }

--- a/crates/prover/src/and_reduction/prover.rs
+++ b/crates/prover/src/and_reduction/prover.rs
@@ -1,5 +1,5 @@
 // Copyright 2025 Irreducible Inc.
-use std::marker::PhantomData;
+use std::{marker::PhantomData, ops::Deref};
 
 use binius_core::word::Word;
 use binius_field::{AESTowerField8b as B8, BinaryField, PackedField};
@@ -28,24 +28,29 @@ use crate::fold_word::BitAxisFolder;
 /// The type parameter `PChallenge` is the packed field over the challenge field `FChallenge` used
 /// for the multilinear sumcheck rounds that follow the univariate round. Packing these rounds over
 /// a wide field provides SIMD acceleration.
-pub struct OblongZerocheckProver<FChallenge, PChallenge>
+///
+/// The columns are generic over their backing store `Data` (anything that dereferences to
+/// `[Word]`), so callers can supply pooled buffers ([`PoolVec`](binius_compute::PoolVec)) or plain
+/// `Vec<Word>` interchangeably.
+pub struct OblongZerocheckProver<FChallenge, PChallenge, Data>
 where
 	FChallenge: BinaryField,
 {
 	log_words: usize,
-	first_col: Vec<Word>,
-	second_col: Vec<Word>,
-	third_col: Vec<Word>,
+	first_col: Data,
+	second_col: Data,
+	third_col: Data,
 	big_field_zerocheck_challenges: Vec<FChallenge>,
 	univariate_round_message: [FChallenge; ROWS_PER_HYPERCUBE_VERTEX],
 	univariate_round_message_domain: BinarySubspace<FChallenge>,
 	_marker: PhantomData<PChallenge>,
 }
 
-impl<F, PChallenge> OblongZerocheckProver<F, PChallenge>
+impl<F, PChallenge, Data> OblongZerocheckProver<F, PChallenge, Data>
 where
 	F: BinaryField + From<B8>,
 	PChallenge: PackedField<Scalar = F>,
+	Data: Deref<Target = [Word]>,
 {
 	/// Creates a new oblong zerocheck prover for AND constraint reduction.
 	///
@@ -71,9 +76,9 @@ where
 	#[allow(clippy::too_many_arguments)]
 	pub fn new(
 		log_words: usize,
-		first_col: Vec<Word>,
-		second_col: Vec<Word>,
-		third_col: Vec<Word>,
+		first_col: Data,
+		second_col: Data,
+		third_col: Data,
 		big_field_zerocheck_challenges: Vec<F>,
 		prover_message_domain: BinarySubspace<B8>,
 	) -> Self {
@@ -251,6 +256,7 @@ where
 mod test {
 	use std::{iter, iter::repeat_with};
 
+	use binius_compute::{BufferPool, PoolVec};
 	use binius_core::word::Word;
 	use binius_field::{AESTowerField8b, arch::OptimalPackedB128};
 	use binius_math::{
@@ -271,6 +277,13 @@ mod test {
 		repeat_with(|| Word(rng.random()))
 			.take(1 << log_num_words)
 			.collect()
+	}
+
+	/// Copies `src` into a buffer drawn from `pool`.
+	fn pool_words<'a>(pool: &'a BufferPool, src: &[Word]) -> PoolVec<'a, Word> {
+		let mut buffer = pool.alloc_vec::<Word>(src.len());
+		buffer.extend_from_slice(src);
+		buffer
 	}
 
 	#[test]
@@ -297,11 +310,12 @@ mod test {
 		// Prover is instantiated
 		let big_field_zerocheck_challenges = prover_challenger
 			.sample_vec(log_num_rows - PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES.len());
-		let prover = OblongZerocheckProver::<_, OptimalPackedB128>::new(
+		let pool = BufferPool::new();
+		let prover = OblongZerocheckProver::<_, OptimalPackedB128, _>::new(
 			log_num_rows,
-			first_mlv.clone(),
-			second_mlv.clone(),
-			third_mlv.clone(),
+			pool_words(&pool, &first_mlv),
+			pool_words(&pool, &second_mlv),
+			pool_words(&pool, &third_mlv),
 			big_field_zerocheck_challenges.to_vec(),
 			prover_message_domain,
 		);

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -3,6 +3,7 @@
 
 use std::marker::PhantomData;
 
+use binius_compute::{BufferPool, PoolVec};
 use binius_core::{
 	constraint_system::{
 		AndConstraint, BmulConstraint, ConstraintSystem, ImulConstraint, ValueVec,
@@ -87,7 +88,12 @@ impl IOPProver {
 	///
 	/// This is the core proving logic, independent of the specific IOP compilation strategy.
 	/// For most users, [`Prover::prove`] is the simpler interface.
-	pub fn prove<P, Channel>(&self, witness: ValueVec, channel: &mut Channel) -> Result<(), Error>
+	pub fn prove<P, Channel>(
+		&self,
+		witness: ValueVec,
+		channel: &mut Channel,
+		pool: &BufferPool,
+	) -> Result<(), Error>
 	where
 		P: PackedField<Scalar = B128>,
 		Channel: IOPProverChannel<P>,
@@ -129,7 +135,7 @@ impl IOPProver {
 			)
 			.entered();
 			let mul_witness = tracing::debug_span!("Assemble columns")
-				.in_scope(|| build_intmul_witness(&cs.imul_constraints, &witness));
+				.in_scope(|| build_intmul_witness(&cs.imul_constraints, &witness, pool));
 
 			let intmul_output = prove_intmul_reduction::<_, P, _>(mul_witness, &mut *channel)?;
 			drop(intmul_guard);
@@ -151,7 +157,7 @@ impl IOPProver {
 			)
 			.entered();
 			let binmul_witness = tracing::debug_span!("Assemble columns")
-				.in_scope(|| build_binmul_witness(&cs.bmul_constraints, &witness));
+				.in_scope(|| build_binmul_witness(&cs.bmul_constraints, &witness, pool));
 
 			let binmul_output = prove_binmul_reduction::<_, P, _>(binmul_witness, &mut *channel);
 			drop(binmul_guard);
@@ -166,7 +172,7 @@ impl IOPProver {
 				.entered();
 		let bitand_claim = {
 			let bitand_witness = tracing::debug_span!("Assemble columns")
-				.in_scope(|| build_bitand_witness(&cs.and_constraints, &witness));
+				.in_scope(|| build_bitand_witness(&cs.and_constraints, &witness, pool));
 
 			let AndCheckOutput {
 				a_eval,
@@ -401,7 +407,10 @@ where
 		let mut channel = self
 			.basefold_compiler
 			.create_channel_without_zk_from_transcript::<H, Challenger_, _>(transcript);
-		self.iop_prover.prove::<P, _>(witness, &mut channel)?;
+		// Working buffers for this proof are drawn from a single pool that lives for the call.
+		let pool = BufferPool::new();
+		self.iop_prover
+			.prove::<P, _>(witness, &mut channel, &pool)?;
 		channel.finish();
 		Ok(())
 	}
@@ -476,7 +485,7 @@ pub fn pack_witness<P: PackedField<Scalar = B128>>(
 }
 
 fn prove_bitand_reduction<F, PChallenge, Channel>(
-	witness: AndCheckWitness,
+	witness: AndCheckWitness<'_>,
 	channel: &mut Channel,
 ) -> AndCheckOutput<F>
 where
@@ -493,7 +502,7 @@ where
 		log_constraint_count.saturating_sub(PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES.len());
 	let big_field_zerocheck_challenges = channel.sample_many(n_extra_zerocheck_challenges);
 
-	let prover = OblongZerocheckProver::<_, PChallenge>::new(
+	let prover = OblongZerocheckProver::<_, PChallenge, _>::new(
 		log_constraint_count,
 		a,
 		b,
@@ -506,7 +515,7 @@ where
 }
 
 fn prove_intmul_reduction<F, P, Channel>(
-	witness: MulCheckWitness,
+	witness: MulCheckWitness<'_>,
 	channel: &mut Channel,
 ) -> Result<IntMulOutput<F>, Error>
 where
@@ -525,7 +534,7 @@ where
 }
 
 fn prove_binmul_reduction<F, P, Channel>(
-	witness: BinMulCheckWitness,
+	witness: BinMulCheckWitness<'_>,
 	channel: &mut Channel,
 ) -> BinMulOutput<F>
 where
@@ -556,34 +565,38 @@ where
 	prove_binmul::<F, P, _>(&binmul_witness, channel)
 }
 
-struct AndCheckWitness {
-	a: Vec<Word>,
-	b: Vec<Word>,
-	c: Vec<Word>,
+struct AndCheckWitness<'alloc> {
+	a: PoolVec<'alloc, Word>,
+	b: PoolVec<'alloc, Word>,
+	c: PoolVec<'alloc, Word>,
 }
 
-struct MulCheckWitness {
-	a: Vec<Word>,
-	b: Vec<Word>,
-	lo: Vec<Word>,
-	hi: Vec<Word>,
+struct MulCheckWitness<'alloc> {
+	a: PoolVec<'alloc, Word>,
+	b: PoolVec<'alloc, Word>,
+	lo: PoolVec<'alloc, Word>,
+	hi: PoolVec<'alloc, Word>,
 }
 
-struct BinMulCheckWitness {
-	a_lo: Vec<Word>,
-	a_hi: Vec<Word>,
-	b_lo: Vec<Word>,
-	b_hi: Vec<Word>,
-	c_lo: Vec<Word>,
-	c_hi: Vec<Word>,
+struct BinMulCheckWitness<'alloc> {
+	a_lo: PoolVec<'alloc, Word>,
+	a_hi: PoolVec<'alloc, Word>,
+	b_lo: PoolVec<'alloc, Word>,
+	b_hi: PoolVec<'alloc, Word>,
+	c_lo: PoolVec<'alloc, Word>,
+	c_hi: PoolVec<'alloc, Word>,
 }
 
-fn build_bitand_witness(and_constraints: &[AndConstraint], witness: &ValueVec) -> AndCheckWitness {
+fn build_bitand_witness<'alloc>(
+	and_constraints: &[AndConstraint],
+	witness: &ValueVec,
+	pool: &'alloc BufferPool,
+) -> AndCheckWitness<'alloc> {
 	let n_constraints = and_constraints.len();
 
-	let mut a = Vec::with_capacity(n_constraints);
-	let mut b = Vec::with_capacity(n_constraints);
-	let mut c = Vec::with_capacity(n_constraints);
+	let mut a = pool.alloc_vec::<Word>(n_constraints);
+	let mut b = pool.alloc_vec::<Word>(n_constraints);
+	let mut c = pool.alloc_vec::<Word>(n_constraints);
 
 	(and_constraints, a.spare_capacity_mut(), b.spare_capacity_mut(), c.spare_capacity_mut())
 		.into_par_iter()
@@ -603,16 +616,17 @@ fn build_bitand_witness(and_constraints: &[AndConstraint], witness: &ValueVec) -
 	AndCheckWitness { a, b, c }
 }
 
-fn build_intmul_witness(
+fn build_intmul_witness<'alloc>(
 	imul_constraints: &[ImulConstraint],
 	witness: &ValueVec,
-) -> MulCheckWitness {
+	pool: &'alloc BufferPool,
+) -> MulCheckWitness<'alloc> {
 	let n_constraints = imul_constraints.len();
 
-	let mut a = Vec::with_capacity(n_constraints);
-	let mut b = Vec::with_capacity(n_constraints);
-	let mut lo = Vec::with_capacity(n_constraints);
-	let mut hi = Vec::with_capacity(n_constraints);
+	let mut a = pool.alloc_vec::<Word>(n_constraints);
+	let mut b = pool.alloc_vec::<Word>(n_constraints);
+	let mut lo = pool.alloc_vec::<Word>(n_constraints);
+	let mut hi = pool.alloc_vec::<Word>(n_constraints);
 
 	(
 		imul_constraints,
@@ -640,18 +654,19 @@ fn build_intmul_witness(
 	MulCheckWitness { a, b, lo, hi }
 }
 
-fn build_binmul_witness(
+fn build_binmul_witness<'alloc>(
 	bmul_constraints: &[BmulConstraint],
 	witness: &ValueVec,
-) -> BinMulCheckWitness {
+	pool: &'alloc BufferPool,
+) -> BinMulCheckWitness<'alloc> {
 	let n_constraints = bmul_constraints.len();
 
-	let mut a_lo = Vec::with_capacity(n_constraints);
-	let mut a_hi = Vec::with_capacity(n_constraints);
-	let mut b_lo = Vec::with_capacity(n_constraints);
-	let mut b_hi = Vec::with_capacity(n_constraints);
-	let mut c_lo = Vec::with_capacity(n_constraints);
-	let mut c_hi = Vec::with_capacity(n_constraints);
+	let mut a_lo = pool.alloc_vec::<Word>(n_constraints);
+	let mut a_hi = pool.alloc_vec::<Word>(n_constraints);
+	let mut b_lo = pool.alloc_vec::<Word>(n_constraints);
+	let mut b_hi = pool.alloc_vec::<Word>(n_constraints);
+	let mut c_lo = pool.alloc_vec::<Word>(n_constraints);
+	let mut c_hi = pool.alloc_vec::<Word>(n_constraints);
 
 	(
 		bmul_constraints,

--- a/crates/prover/src/zk_config.rs
+++ b/crates/prover/src/zk_config.rs
@@ -8,6 +8,7 @@
 
 use std::{marker::PhantomData, sync::Arc};
 
+use binius_compute::BufferPool;
 use binius_core::constraint_system::{ConstraintSystem, ValueVec};
 use binius_field::{BinaryField128bGhash as B128, PackedField};
 use binius_hash::binary_merkle_tree::HashSuite;
@@ -159,8 +160,10 @@ where
 			)
 			.entered();
 
+			// Working buffers for this proof are drawn from a single pool that lives for the call.
+			let pool = BufferPool::new();
 			self.inner_iop_prover
-				.prove::<P, _>(witness, &mut wrapped_channel)?;
+				.prove::<P, _>(witness, &mut wrapped_channel, &pool)?;
 		}
 
 		// Finish runs the outer spartan proof.


### PR DESCRIPTION
## Summary

First increment of [BINIUS-316](https://linear.app/jimpo/issue/BINIUS-316), following @jimpo's plan on the issue: stand up a `BufferPool` allocation seam and thread it through the prover, starting with the `Word` buffers. This is the scaffolding step — `alloc_vec` is a pass-through to `Vec::with_capacity` for now (no recycling free list yet), establishing the API and the `'alloc` lifetime threading. `FieldBuffer` pooling is the next step (see below).

## What changed

**New crate `binius-compute` (`crates/compute`):**
- `BufferPool` with `alloc_vec<T: Pod>(&self, capacity) -> PoolVec<'_, T>` (currently `Vec::with_capacity`).
- `PoolVec<'alloc, T>` = `&'alloc BufferPool` + `Vec<T>`, exposing only the `Vec`-like surface callers actually use: `Deref`/`DerefMut` to `[T]`, `push`, `extend`, `extend_from_slice`, `resize`, `clear`, `capacity`, and `spare_capacity_mut` + `unsafe set_len` (needed for the parallel fixed-size fill pattern the prover uses). Kept generic over `T: Pod` so the crate needn't depend on `binius-core`.
- Unit tests for the buffer API.

**Threaded the pool through `crates/prover`:**
- `Prover::prove` and `ZKProver::prove` create a `BufferPool` for the call and pass `&pool` into `IOPProver::prove`, which forwards it to the three `build_*_witness` builders. The pool is a per-call **argument**, so `Prover`/`IOPProver` gain no lifetime (avoids the self-reference problem the issue flagged).
- The AND/IntMul/BinMul witness columns (`AndCheckWitness`, `MulCheckWitness`, `BinMulCheckWitness`) are now `PoolVec<'alloc, Word>`, allocated via `pool.alloc_vec::<Word>(n)`. These are all fixed-size, allocate-once buffers — a good fit for a future fixed-capacity pool.

## Design decisions

1. **`OblongZerocheckProver` made generic over its column backing** (`Data: Deref<Target = [Word]>`). It's shared: `m4-prover` (a separate prover, not reachable from `Prover`) also constructs it, with `Vec<Word>`. Rather than ripple a pool/lifetime through m4-prover's `ValueTable` hub — out of scope for "thread it through `Prover`" — the generic lets crates/prover pass `PoolVec` while m4-prover keeps `Vec` unchanged (one-token turbofish edit). This is the only change to m4-prover.

2. **Scope = the top-level `Prover` path's Word buffers.** `m4-prover`'s own Word buffers (`ValueTable`, `BatchAndCheckWitness`, its builders) stay `Vec<Word>`; pooling them would mean creating a pool at m4-prover's own entry and is a clean separate step. `ip-prover` has no `Vec<Word>`.

## Open / next steps (per the issue's plan)

- **FieldBuffers** — jimpo's "if that works, next step": convert the (non-trivial) `FieldBuffer` backings to `PoolVec`. Larger; proposed as the follow-up PR.
- **m4-prover Word buffers** — pool them too, or leave as a separate prover? Happy either way.
- **Real pool** — the recycling free list behind `alloc_vec`/`PoolVec::drop` slots in without changing these signatures.

## Verification

Green: `binius-compute`, `binius-prover`, `binius-m4-prover` tests (incl. the end-to-end `prove_verify`); `clippy -D warnings` (all-targets); nightly `fmt`; `rustdoc`; full workspace build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)