### PR TITLE
BINIUS-327: remove tensor_prod_eq_ind_prepend

### DIFF
--- a/crates/ip-prover/src/sumcheck/switchover.rs
+++ b/crates/ip-prover/src/sumcheck/switchover.rs
@@ -9,8 +9,9 @@ use std::{
 use binius_field::{Field, PackedField};
 use binius_math::{
 	FieldBuffer, FieldSlice,
+	bit_reverse::bit_reverse_packed,
 	multilinear::{
-		eq::tensor_prod_eq_ind_prepend,
+		eq::tensor_prod_eq_ind,
 		fold::{binary_fold_high, fold_highest_var_inplace},
 	},
 };
@@ -121,8 +122,14 @@ where
 		} else {
 			// Pre-switchover: update the folding tensor
 			assert!(self.tensor.log_len() < self.switchover);
-			let tensor = mem::replace(&mut self.tensor, FieldBuffer::new(0, vec![P::zero()]));
-			self.tensor = tensor_prod_eq_ind_prepend(tensor, &[challenge]);
+			let mut tensor = mem::replace(&mut self.tensor, FieldBuffer::new(0, vec![P::zero()]));
+			// Prepend the new variable via bit-reverse + append + bit-reverse. This does not need
+			// to be fast: it runs once per pre-switchover round on a small tensor (see
+			// BINIUS-327).
+			bit_reverse_packed(tensor.to_mut());
+			let mut tensor = tensor_prod_eq_ind(tensor, &[challenge]);
+			bit_reverse_packed(tensor.to_mut());
+			self.tensor = tensor;
 
 			if self.tensor.log_len() == self.switchover {
 				self.perform();

--- a/crates/math/src/multilinear/eq.rs
+++ b/crates/math/src/multilinear/eq.rs
@@ -6,15 +6,15 @@ use binius_field::{PackedField, field::FieldOps};
 use super::hypercube::{self, Hypercube, OneCube};
 use crate::{FieldBuffer, field_buffer::BufferData};
 
-/// Left tensor of values with the eq indicator evaluated at extra_query_coordinates.
+/// Tensor of values with the eq indicator evaluated at extra_query_coordinates.
 ///
-/// This is [`hypercube::tensor_prod_eq_ind_prepend`] over the Boolean hypercube. The returned
-/// buffer grows its backing `Vec` by one variable per coordinate.
-pub fn tensor_prod_eq_ind_prepend<P: PackedField>(
+/// This is [`hypercube::tensor_prod_eq_ind`] over the Boolean hypercube. The returned buffer grows
+/// its backing `Vec` by one variable per coordinate.
+pub fn tensor_prod_eq_ind<P: PackedField>(
 	values: FieldBuffer<P, Vec<P>>,
 	extra_query_coordinates: &[P::Scalar],
 ) -> FieldBuffer<P, Vec<P>> {
-	hypercube::tensor_prod_eq_ind_prepend::<OneCube, P>(values, extra_query_coordinates)
+	hypercube::tensor_prod_eq_ind::<OneCube, P>(values, extra_query_coordinates)
 }
 
 /// Computes the partial evaluation of the equality indicator polynomial.
@@ -379,22 +379,25 @@ mod tests {
 	}
 
 	#[test]
-	fn test_tensor_prod_eq_prepend_conforms_to_append() {
+	fn test_tensor_prod_eq_prepend_via_bit_reverse() {
+		// `BinarySwitchover` prepends one variable per round as bit-reverse + append + bit-reverse.
+		// Check that this composition, iterated over all coordinates (including the
+		// sub-packing-width early rounds), matches a full eq expansion.
+		use crate::bit_reverse::bit_reverse_packed;
+
 		let mut rng = StdRng::seed_from_u64(0);
 
 		let n_vars = 10;
-		let base_vars = 4;
-
 		let point = random_scalars::<F>(&mut rng, n_vars);
 
-		let append = eq_ind_partial_eval(&point);
+		let mut tensor = FieldBuffer::<P>::from_values(&[F::ONE]);
+		for &r in point.iter().rev() {
+			bit_reverse_packed(tensor.to_mut());
+			tensor = tensor_prod_eq_ind::<OneCube, P>(tensor, &[r]);
+			bit_reverse_packed(tensor.to_mut());
+		}
 
-		let prepend = FieldBuffer::<P, _>::scalar_with_capacity(F::ONE, n_vars);
-		let (prefix, suffix) = point.split_at(n_vars - base_vars);
-		let prepend = tensor_prod_eq_ind::<OneCube, P>(prepend, suffix);
-		let prepend = tensor_prod_eq_ind_prepend(prepend, prefix);
-
-		assert_eq!(append, prepend);
+		assert_eq!(tensor, eq_ind_partial_eval(&point));
 	}
 
 	#[test]

--- a/crates/math/src/multilinear/hypercube.rs
+++ b/crates/math/src/multilinear/hypercube.rs
@@ -8,11 +8,7 @@
 
 use std::{iter, slice};
 
-use binius_field::{
-	Field, PackedField,
-	field::FieldOps,
-	packed::{get_packed_slice, set_packed_slice},
-};
+use binius_field::{Field, PackedField, field::FieldOps};
 use binius_utils::rayon::prelude::*;
 
 use crate::{FieldBuffer, field_buffer::BufferData};
@@ -123,24 +119,6 @@ impl Hypercube for InfCube {
 	}
 }
 
-/// Grows a packed backing `Vec` from `log_len` to `log_len + 1` variables, zero-initializing the
-/// newly live region so the store stays fully initialized.
-///
-/// Used by [`tensor_prod_eq_ind_prepend`], the singlethreaded small-tensor variant, where the
-/// redundant re-initialization of the region the expansion overwrites is not worth optimizing away.
-/// Its sibling [`tensor_prod_eq_ind`] instead grows through spare capacity to skip that write.
-fn grow_packed_backing<P: PackedField>(data: &mut Vec<P>, log_len: usize) {
-	let new_log_len = log_len + 1;
-	// While still narrower than one packed word, zero the newly live lanes of the first word.
-	if log_len < P::LOG_WIDTH {
-		let first = &mut data[0];
-		for i in 1 << log_len..(1 << new_log_len).min(P::WIDTH) {
-			first.set(i, <P::Scalar as Field>::ZERO);
-		}
-	}
-	data.resize(1 << new_log_len.saturating_sub(P::LOG_WIDTH), P::zero());
-}
-
 /// Tensor of values with the equality indicator evaluated at `extra_query_coordinates`.
 ///
 /// Let $n$ be `values.log_len()` and $k$ be the length of `extra_query_coordinates`. The returned
@@ -224,42 +202,6 @@ pub fn tensor_prod_eq_ind<Cube: Hypercube, P: PackedField>(
 	}
 
 	FieldBuffer::new(final_log_len, data)
-}
-
-/// Left tensor of values with the equality indicator evaluated at `extra_query_coordinates`.
-///
-/// # Formal definition
-///
-/// This differs from [`tensor_prod_eq_ind`] in the tensor product being applied on the left and in
-/// reversed order:
-///
-/// $$
-/// b(r_{k-1}) \otimes \ldots \otimes b(r_0) \otimes v
-/// $$
-///
-/// # Implementation
-///
-/// This operation grows the returned buffer one variable per coordinate, singlethreaded, and is not
-/// very optimized. Main intent is to use it on small tensors out of the hot paths.
-pub fn tensor_prod_eq_ind_prepend<Cube: Hypercube, P: PackedField>(
-	mut values: FieldBuffer<P, Vec<P>>,
-	extra_query_coordinates: &[P::Scalar],
-) -> FieldBuffer<P, Vec<P>> {
-	for r_i in extra_query_coordinates.iter().rev() {
-		// Grow the backing by one variable, then rewrap.
-		let new_log_len = values.log_len() + 1;
-		let mut data = values.take_data();
-		grow_packed_backing::<P>(&mut data, new_log_len - 1);
-		values = FieldBuffer::new(new_log_len, data);
-
-		for i in (0..values.len() / 2).rev() {
-			let value = get_packed_slice(values.as_ref(), i);
-			let [lo, hi] = Cube::expand_var(&value, r_i);
-			set_packed_slice(values.as_mut(), 2 * i, lo);
-			set_packed_slice(values.as_mut(), 2 * i + 1, hi);
-		}
-	}
-	values
 }
 
 /// Computes the partial evaluation of the equality indicator polynomial.
@@ -616,23 +558,6 @@ mod tests {
 				eq_ind_partial_eval::<InfCube, P>(&point).iter_scalars().collect::<Vec<_>>(),
 				eq_ind_partial_eval_scalars::<InfCube, F>(&point)
 			);
-		}
-
-		/// Prepending the leading coordinates yields the same expansion as appending all of them.
-		#[test]
-		fn tensor_prod_eq_ind_prepend_conforms_to_append(
-			seed in any::<u64>(),
-			log_n in 1usize..=8,
-		) {
-			let mut rng = StdRng::seed_from_u64(seed);
-			let point = random_scalars::<F>(&mut rng, log_n);
-			let (prefix, suffix) = point.split_at(log_n / 2);
-
-			let prepend = FieldBuffer::<P, _>::scalar_with_capacity(F::ONE, log_n);
-			let prepend = tensor_prod_eq_ind::<InfCube, P>(prepend, suffix);
-			let prepend = tensor_prod_eq_ind_prepend::<InfCube, P>(prepend, prefix);
-
-			prop_assert_eq!(prepend, eq_ind_partial_eval::<InfCube, P>(&point));
 		}
 
 		/// Truncation strips the trailing variables of an expansion, for either cube.


### PR DESCRIPTION
## Summary

[BINIUS-327](https://linear.app/jimpo/issue/BINIUS-327). `tensor_prod_eq_ind_prepend` had a single caller, `BinarySwitchover`, and doesn't need to be performant. Per the issue, replace that usage with `bit_reverse_packed` → `tensor_prod_eq_ind` (append) → `bit_reverse_packed`, which computes the same prepend, and delete the dedicated primitive along with its now-dead `grow_packed_backing` helper (the last "grow" site).

## What changed

- **`BinarySwitchover::fold`** (`switchover.rs`): the pre-switchover tensor update now bit-reverses, appends the new variable with `tensor_prod_eq_ind`, and bit-reverses back — reversing the coefficient order turns an append into a prepend. This runs once per pre-switchover round on a small tensor, so the extra passes are immaterial.
- Removed `tensor_prod_eq_ind_prepend` (the `hypercube` generic + the `eq` OneCube wrapper) and added an `eq::tensor_prod_eq_ind` OneCube wrapper in its place.
- Removed `grow_packed_backing` (only `tensor_prod_eq_ind_prepend` used it) — this was the last remaining "grow" helper; `tensor_prod_eq_ind` grows through reserved spare capacity instead.
- Replaced the prepend-conformance proptest with `test_tensor_prod_eq_prepend_via_bit_reverse`, which checks the bit-reverse-sandwich composition (iterated one variable at a time, including the sub-packing-width early rounds `BinarySwitchover` actually hits) equals a full `eq_ind_partial_eval`.

## Verification

Green: `binius-math` (125 + 2 doc, incl. the new test), `binius-ip-prover` (switchover), `binius-prover` (end-to-end intmul→switchover), `clippy -D warnings` (default + `rayon`), nightly `fmt`, `rustdoc`, and a full `--workspace --all-targets` build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)