### PR TITLE
BINIUS-328: implement a persistent free list for BufferPool

### DIFF
--- a/crates/compute/src/lib.rs
+++ b/crates/compute/src/lib.rs
@@ -3,49 +3,129 @@
 //! Buffer pooling for prover working memory.
 //!
 //! The prover allocates many large, short-lived buffers. [`BufferPool`] is the seam through which
-//! those allocations flow, so they can later be served from a recycling free list instead of the
-//! global allocator. Buffers are handed out as [`PoolVec`] handles that borrow the pool for
-//! `'alloc` and, in a future revision, return their block to it on drop.
+//! those allocations flow, recycling freed blocks instead of returning them to the global
+//! allocator. Buffers are handed out as [`PoolVec`] handles that borrow the pool for `'alloc` and
+//! return their block to it on drop.
 //!
-//! The current implementation is a thin pass-through over [`Vec`]: [`BufferPool::alloc_vec`] just
-//! calls [`Vec::with_capacity`]. This establishes the API and the `'alloc` lifetime threading
-//! without committing to a pool layout yet.
+//! Every pooled block is allocated with a fixed `BUFFER_ALIGN`-byte alignment — wide enough for any
+//! element type the prover uses — and sized to a power-of-two number of bytes. Because the
+//! alignment is uniform, the free list keys purely on byte size: a block freed by one element type
+//! can back a [`PoolVec`] of *any* other type of the same size. Blocks are stored as owned
+//! `Vec<AlignedChunk>`, so the pool frees them through ordinary `Vec` machinery; a [`PoolVec`]
+//! borrows a block's memory as a `Vec<T>` for its lifetime and hands it back on drop.
 
 use std::{
+	collections::HashMap,
 	fmt,
-	mem::MaybeUninit,
+	mem::{self, MaybeUninit},
 	ops::{Deref, DerefMut},
+	sync::Mutex,
 };
 
 use bytemuck::Pod;
 
+/// The alignment, in bytes, of every pooled block.
+///
+/// It must be at least the alignment of every element type passed to
+/// [`alloc_vec`](BufferPool::alloc_vec) — 64 bytes covers the widest packed field the prover
+/// allocates. Fixing the alignment is what lets the free list key on byte size alone, so a block is
+/// reusable across element types.
+const BUFFER_ALIGN: usize = 64;
+
+/// A `BUFFER_ALIGN`-aligned unit of `BUFFER_ALIGN` bytes.
+///
+/// Pooled blocks are `Vec<AlignedChunk>`; the type exists only to force the backing allocation to
+/// `BUFFER_ALIGN` alignment while remaining an owned `Vec` the pool can free directly. Its bytes
+/// are never read through this type — a block is always borrowed as a `Vec<T>` while in use.
+#[repr(align(64))]
+struct AlignedChunk(#[allow(dead_code)] [u8; BUFFER_ALIGN]);
+
 /// A pool that hands out reusable buffers for prover working memory.
 ///
-/// Allocation goes through [`alloc_vec`](Self::alloc_vec), which currently forwards to
-/// [`Vec::with_capacity`]. A pool is created once, above the code that uses it, and shared by
-/// borrow — every [`PoolVec`] it produces holds a `&'alloc BufferPool`.
+/// Allocation goes through [`alloc_vec`](Self::alloc_vec). Freed buffers are kept on an internal
+/// free list, keyed by block size (in `AlignedChunk`s), and reused to satisfy later allocations
+/// of the same size. A pool is created once, above the code that uses it, and shared by borrow —
+/// every [`PoolVec`] it produces holds a `&'alloc BufferPool`. The pool is thread-safe: the free
+/// list sits behind a [`Mutex`], so allocation and reclamation may happen from any thread.
 #[derive(Default)]
 pub struct BufferPool {
-	// No free list yet; buffers are allocated straight from the global allocator. A recycling
-	// implementation slots in behind `alloc_vec`/`PoolVec::drop` without changing their
-	// signatures.
-	_private: (),
+	free_list: Mutex<HashMap<usize, Vec<Vec<AlignedChunk>>>>,
 }
 
 impl BufferPool {
-	/// Creates a new pool.
+	/// Creates a new, empty pool.
 	pub fn new() -> Self {
 		Self::default()
 	}
 
 	/// Allocates a [`PoolVec`] with room for at least `capacity` elements.
 	///
-	/// The returned buffer is empty; fill it through the [`PoolVec`] interface.
+	/// The block size is rounded up to a power-of-two number of bytes. If the free list holds a
+	/// block of that size it is reused; otherwise a fresh block is allocated. The returned buffer
+	/// is empty; fill it through the [`PoolVec`] interface.
+	///
+	/// # Panics
+	///
+	/// Panics at compile time (via a `const` assertion) if `T`'s alignment exceeds `BUFFER_ALIGN`,
+	/// or if `T`'s size is not a power of two — either would break the byte-size keyed reuse.
 	pub fn alloc_vec<T: Pod>(&self, capacity: usize) -> PoolVec<'_, T> {
 		PoolVec {
 			pool: self,
-			data: Vec::with_capacity(capacity),
+			data: self.alloc_data(capacity),
 		}
+	}
+
+	fn alloc_data<T: Pod>(&self, capacity: usize) -> Vec<T> {
+		const {
+			assert!(
+				mem::align_of::<T>() <= BUFFER_ALIGN,
+				"element alignment exceeds the pool's buffer alignment"
+			);
+			assert!(
+				mem::size_of::<T>().is_power_of_two() || mem::size_of::<T>() == 0,
+				"element size must be a power of two for byte-size-keyed reuse"
+			);
+		}
+
+		// A zero-sized type never allocates, and a zero-capacity request need not; in both cases
+		// there is no block to pool, so hand back a plain `Vec`.
+		if mem::size_of::<T>() == 0 || capacity == 0 {
+			return Vec::with_capacity(capacity);
+		}
+
+		let byte_len = (capacity * mem::size_of::<T>())
+			.next_power_of_two()
+			.max(BUFFER_ALIGN);
+		let n_chunks = byte_len / BUFFER_ALIGN;
+		let elem_cap = byte_len / mem::size_of::<T>();
+
+		let reused = self
+			.free_list
+			.lock()
+			.expect("free list mutex poisoned")
+			.get_mut(&n_chunks)
+			.and_then(Vec::pop);
+
+		let mut block = reused.unwrap_or_else(|| Vec::with_capacity(n_chunks));
+		let ptr = block.as_mut_ptr().cast::<T>();
+		// The block owns the allocation; forget it so its `Drop` does not free the memory we are
+		// about to hand to the `Vec`.
+		mem::forget(block);
+		// SAFETY: `ptr` comes from a `Vec<AlignedChunk>` with capacity `n_chunks`, i.e. an
+		// allocation of `byte_len` bytes aligned to `BUFFER_ALIGN >= align_of::<T>()`. `T`'s size
+		// divides `byte_len` (both are powers of two and `size_of::<T>() <= byte_len`), so it
+		// holds exactly `elem_cap` elements. The length is zero, so no element needs to be
+		// initialized.
+		unsafe { Vec::from_raw_parts(ptr, 0, elem_cap) }
+	}
+
+	fn reclaim(&self, n_chunks: usize, block: Vec<AlignedChunk>) {
+		self.free_list
+			.lock()
+			.expect("free list mutex poisoned")
+			.entry(n_chunks)
+			.or_default()
+			.push(block);
 	}
 }
 
@@ -57,12 +137,10 @@ impl fmt::Debug for BufferPool {
 
 /// A `Vec`-like buffer borrowed from a [`BufferPool`] for `'alloc`.
 ///
-/// Dereferences to `[T]`, so all slice operations are available directly. Only the growth and
-/// mutation methods actually used by callers are exposed; add more as needed rather than mirroring
-/// all of [`Vec`].
+/// Dereferences to `[T]`, so all slice operations are available directly. On drop the buffer's
+/// block is returned to the pool for reuse. Only the growth and mutation methods actually used by
+/// callers are exposed; add more as needed rather than mirroring all of [`Vec`].
 pub struct PoolVec<'alloc, T: Pod> {
-	// Held so a future recycling pool can return the block on drop. Unused by the pass-through.
-	#[allow(dead_code)]
 	pool: &'alloc BufferPool,
 	data: Vec<T>,
 }
@@ -109,6 +187,37 @@ impl<T: Pod> PoolVec<'_, T> {
 	/// and the elements in `0..new_len` must be initialized.
 	pub unsafe fn set_len(&mut self, new_len: usize) {
 		unsafe { self.data.set_len(new_len) }
+	}
+}
+
+impl<T: Pod> Drop for PoolVec<'_, T> {
+	fn drop(&mut self) {
+		let data = mem::take(&mut self.data);
+		let elem_cap = data.capacity();
+		if mem::size_of::<T>() == 0 || elem_cap == 0 {
+			// Nothing was allocated (zero-sized `T` or an empty buffer); let the `Vec` drop.
+			return;
+		}
+		let byte_len = elem_cap * mem::size_of::<T>();
+		// Only the blocks we hand out are `BUFFER_ALIGN`-aligned and a whole number of chunks. If
+		// the `Vec` outgrew its block and reallocated into its own (element-aligned) storage, the
+		// pointer or byte length no longer matches; let such a `Vec` drop normally.
+		if !byte_len.is_multiple_of(BUFFER_ALIGN)
+			|| !(data.as_ptr() as usize).is_multiple_of(BUFFER_ALIGN)
+		{
+			return;
+		}
+		let n_chunks = byte_len / BUFFER_ALIGN;
+		let ptr = data.as_ptr() as *mut AlignedChunk;
+		// Take the allocation away from the `Vec` so it is not freed, then rebuild the owning
+		// block.
+		mem::forget(data);
+		// SAFETY: this memory was handed out from a `Vec<AlignedChunk>` of exactly `n_chunks`
+		// chunks (checked above: `BUFFER_ALIGN`-aligned, `byte_len` a multiple of
+		// `BUFFER_ALIGN`), so reconstructing that `Vec` restores the original owner and frees
+		// with the correct layout.
+		let block = unsafe { Vec::<AlignedChunk>::from_raw_parts(ptr, 0, n_chunks) };
+		self.pool.reclaim(n_chunks, block);
 	}
 }
 
@@ -167,5 +276,77 @@ mod tests {
 
 		buffer.clear();
 		assert!(buffer.is_empty());
+	}
+
+	#[test]
+	fn buffers_are_aligned_and_sized_to_a_power_of_two_byte_length() {
+		let pool = BufferPool::new();
+		let buffer = pool.alloc_vec::<u64>(10);
+		// 10 * 8 = 80 bytes rounds up to a 128-byte block: 16 `u64`s.
+		assert_eq!(buffer.capacity(), 16);
+		assert!((buffer.as_ptr() as usize).is_multiple_of(BUFFER_ALIGN));
+		// Small requests still take a whole minimum-size block.
+		assert_eq!(pool.alloc_vec::<u64>(1).capacity(), BUFFER_ALIGN / size_of::<u64>());
+	}
+
+	#[test]
+	fn freed_block_is_recycled_for_a_matching_request() {
+		let pool = BufferPool::new();
+
+		let addr = {
+			let buffer = pool.alloc_vec::<u64>(10);
+			buffer.as_ptr() as usize
+		};
+		// The freed block backs the next request of the same size, and comes back empty despite
+		// having been filled before.
+		let mut buffer = pool.alloc_vec::<u64>(10);
+		assert_eq!(buffer.as_ptr() as usize, addr);
+		assert!(buffer.is_empty());
+		buffer.extend_from_slice(&[1, 2, 3]);
+		assert_eq!(&*buffer, &[1, 2, 3]);
+	}
+
+	#[test]
+	fn a_block_freed_by_one_type_is_reused_by_another_of_the_same_byte_size() {
+		let pool = BufferPool::new();
+		// A `u64` buffer of 8 elements and a `u8` buffer of 64 elements are both one 64-byte block,
+		// so the freed block is reused across the two element types.
+		let addr = {
+			let buffer = pool.alloc_vec::<u64>(8);
+			buffer.as_ptr() as usize
+		};
+		let buffer = pool.alloc_vec::<u8>(64);
+		assert_eq!(buffer.as_ptr() as usize, addr);
+	}
+
+	#[test]
+	fn distinct_sizes_do_not_share_blocks() {
+		let pool = BufferPool::new();
+		let small = {
+			let buffer = pool.alloc_vec::<u64>(4);
+			buffer.as_ptr() as usize
+		};
+		// A larger request needs a bigger block and cannot reuse the small freed one.
+		let big = pool.alloc_vec::<u64>(64);
+		assert_ne!(big.as_ptr() as usize, small);
+	}
+
+	#[test]
+	fn free_list_holds_multiple_blocks_of_the_same_size() {
+		let pool = BufferPool::new();
+
+		let (addr_a, addr_b) = {
+			let a = pool.alloc_vec::<u64>(8);
+			let b = pool.alloc_vec::<u64>(8);
+			assert_ne!(a.as_ptr() as usize, b.as_ptr() as usize);
+			(a.as_ptr() as usize, b.as_ptr() as usize)
+		};
+
+		// Both freed blocks are available; two fresh allocations reuse exactly them.
+		let c = pool.alloc_vec::<u64>(8);
+		let d = pool.alloc_vec::<u64>(8);
+		let reused = [c.as_ptr() as usize, d.as_ptr() as usize];
+		assert!(reused.contains(&addr_a));
+		assert!(reused.contains(&addr_b));
 	}
 }


### PR DESCRIPTION
Implements [BINIUS-328](https://linear.app/jimpo/issue/BINIUS-328/use-persistent-allocation-pool-for-bufferpool). Follows up [#1864](https://github.com/binius-zk/binius64/pull/1864), which introduced `BufferPool` as a pass-through over `Vec::with_capacity`.

## What

`BufferPool` now recycles freed allocations instead of always going to the global allocator.

Every pooled block is a `Vec<AlignedChunk>`, where `AlignedChunk` is `#[repr(align(64))] [u8; 64]`. This forces every backing allocation to a fixed 64-byte alignment — wide enough for any element type the prover uses — so the free list keys on **byte size alone**: `Mutex<HashMap<n_chunks, Vec<Vec<AlignedChunk>>>>`.

- **`alloc_vec::<T>(capacity)`** rounds the byte length (`capacity * size_of::<T>`) up to a power of two (min one 64-byte chunk), pops a block of that size from the free list or allocates a fresh `Vec<AlignedChunk>`, and hands it out as a `Vec<T>` via `Vec::from_raw_parts`. Because the alignment is uniform, a block freed by one element type backs a `PoolVec` of any other type of the same byte size.
- **`PoolVec::drop`** checks the buffer is still 64-aligned (i.e. the `Vec` didn't outgrow its block and reallocate into element-aligned storage), then rebuilds the owning `Vec<AlignedChunk>` and parks it on the free list. Every allocation and free therefore uses the same layout, and the pool frees blocks through ordinary `Vec` machinery — no manual `dealloc`, no `unsafe impl Send`.
- A `const` assertion rejects any `T` whose alignment exceeds 64 or whose size is not a power of two at compile time (both would break byte-size-keyed reuse).

## Testing

- `cargo test -p binius-compute` — 7 tests (byte-size rounding + 64-alignment, recycle, cross-type reuse, distinct-size isolation, multi-block free list) + existing.
- `cargo miri test -p binius-compute` — clean, no UB, including the cross-type reuse path (a `u64×8` block reused as `u8×64`).
- `cargo test -p binius-prover --lib` — green (exercises the pool through the parallel witness builders).
- clippy (`-D warnings`) + nightly fmt + `cargo doc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)