### PR TITLE
Move MIN_WORDS_PER_SEGMENT onto ValueVecLayout, drop the consts module

### DIFF
--- a/crates/core/src/constraint_system/layout.rs
+++ b/crates/core/src/constraint_system/layout.rs
@@ -7,7 +7,7 @@ use binius_utils::{
 use bytes::{Buf, BufMut};
 
 use super::ValueIndex;
-use crate::{consts, error::ConstraintSystemError};
+use crate::error::ConstraintSystemError;
 
 /// Description of a layout of the value vector for a particular circuit.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -39,6 +39,11 @@ pub struct ValueVecLayout {
 }
 
 impl ValueVecLayout {
+	/// The minimum number of words in the public segment.
+	///
+	/// [`Self::validate`] rejects any layout whose public segment is shorter than this.
+	pub const MIN_WORDS_PER_SEGMENT: usize = 2;
+
 	/// Validates that the value vec layout has a correct shape.
 	///
 	/// Specifically checks that:
@@ -53,7 +58,7 @@ impl ValueVecLayout {
 		}
 
 		let pub_input_size = self.offset_witness;
-		if pub_input_size < consts::MIN_WORDS_PER_SEGMENT {
+		if pub_input_size < Self::MIN_WORDS_PER_SEGMENT {
 			return Err(ConstraintSystemError::PublicInputTooShort { pub_input_size });
 		}
 

--- a/crates/core/src/consts.rs
+++ b/crates/core/src/consts.rs
@@ -1,7 +1,0 @@
-// Copyright 2025 Irreducible Inc.
-//! Protocol-level constants for the Binius64 constraint system.
-
-/// The minimum number of words per segment.
-///
-/// This is the minimum size requirement for public input segments in the constraint system.
-pub const MIN_WORDS_PER_SEGMENT: usize = 2;

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 Irreducible Inc.
 //! Hosts error definitions for the core crate.
 
-use crate::consts::MIN_WORDS_PER_SEGMENT;
+use crate::ValueVecLayout;
 
 /// Constraint system related error.
 #[allow(missing_docs)] // errors are self-documenting
@@ -10,7 +10,8 @@ pub enum ConstraintSystemError {
 	#[error("the public input segment must have power of two length")]
 	PublicInputPowerOfTwo,
 	#[error(
-		"the public input segment must be at least {MIN_WORDS_PER_SEGMENT} words, got: {pub_input_size}"
+		"the public input segment must be at least {} words, got: {pub_input_size}",
+		ValueVecLayout::MIN_WORDS_PER_SEGMENT
 	)]
 	PublicInputTooShort { pub_input_size: usize },
 	#[error(

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -6,7 +6,6 @@
 #![warn(rustdoc::missing_crate_level_docs)]
 
 pub mod constraint_system;
-pub mod consts;
 pub mod error;
 pub mod verify;
 pub mod word;

--- a/crates/frontend/src/compiler/value_vec_alloc.rs
+++ b/crates/frontend/src/compiler/value_vec_alloc.rs
@@ -1,6 +1,6 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
-use binius_core::{ValueIndex, ValueVecLayout, Word, consts::MIN_WORDS_PER_SEGMENT};
+use binius_core::{ValueIndex, ValueVecLayout, Word};
 use cranelift_entity::SecondaryMap;
 
 use crate::compiler::Wire;
@@ -98,7 +98,7 @@ impl Alloc {
 			cur_index += 1;
 		}
 		// Ensure the public section meets the minimum size requirement
-		cur_index = cur_index.max(MIN_WORDS_PER_SEGMENT as u32);
+		cur_index = cur_index.max(ValueVecLayout::MIN_WORDS_PER_SEGMENT as u32);
 		cur_index = cur_index.next_power_of_two();
 		let offset_witness = cur_index as usize;
 		for wire in self.w_witness.into_iter().chain(self.w_internal) {
@@ -246,7 +246,7 @@ mod tests {
 		// Even with just one constant, the witness should start at MIN_WORDS_PER_SEGMENT
 		// (which should be a power of 2)
 		let witness_idx = assignment.wire_mapping[witness1];
-		assert!(witness_idx.0 >= MIN_WORDS_PER_SEGMENT as u32);
+		assert!(witness_idx.0 >= ValueVecLayout::MIN_WORDS_PER_SEGMENT as u32);
 		assert!(witness_idx.0.is_power_of_two());
 	}
 }


### PR DESCRIPTION
Pure refactor — no behavior change. The emitted layouts and error strings are identical.

### The problem

`binius-core`'s `consts` module had shrunk to a single surviving constant.

Recent PRs moved or removed all its siblings:

- `LOG_BYTE_BITS` became `Word::LOG_BYTES` (#1851)
- `BYTE_BITS` was deleted as dead (#1856)
- `MIN_MUL_CONSTRAINTS` / `MIN_AND_CONSTRAINTS` went earlier (#1543, #1460)

That left `MIN_WORDS_PER_SEGMENT` alone in a whole `pub mod consts` — a module file for one constant is dead weight.

### The idea

`MIN_WORDS_PER_SEGMENT` is exactly the invariant that `ValueVecLayout::validate` enforces on the public segment.

So it belongs *on that type*, mirroring the `Word::LOG_BYTES` pattern of hanging a constant off the type it describes.

```diff
-// crates/core/src/consts.rs
-pub const MIN_WORDS_PER_SEGMENT: usize = 2;

+// crates/core/src/constraint_system/layout.rs
+impl ValueVecLayout {
+    pub const MIN_WORDS_PER_SEGMENT: usize = 2;
+    ...
+}
```

### The change

The three consumers now reach the constant through the type:

- `layout.rs` — `consts::MIN_WORDS_PER_SEGMENT` → `Self::MIN_WORDS_PER_SEGMENT`, and the `consts` import is dropped.
- `error.rs` — an associated-const path cannot be an implicit `format!` capture, so the message switches to an explicit arg:

```diff
-    #[error("... at least {MIN_WORDS_PER_SEGMENT} words, got: {pub_input_size}")]
+    #[error("... at least {} words, got: {pub_input_size}", ValueVecLayout::MIN_WORDS_PER_SEGMENT)]
```

- `crates/frontend/.../value_vec_alloc.rs` — the use-site and its test reference `ValueVecLayout::MIN_WORDS_PER_SEGMENT` (the crate already imported `ValueVecLayout`).

The rendered error message is byte-identical: "the public input segment must be at least 2 words, got: ...".

### Scope

- **removed:** `crates/core/src/consts.rs` and `pub mod consts;` from `lib.rs`
- **changed:** `constraint_system/layout.rs` (const definition + call site), `error.rs` (import + format arg), `frontend/.../value_vec_alloc.rs` (import + 2 sites)
- **left untouched:** the value `2` and the validation logic — only its home moved

Dropping `pub mod consts` is technically a public-API change to `binius-core`, but the frontend was the only workspace consumer (updated here), consistent with how #1851 / #1856 treated these consts.

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-core -p binius-frontend --all-targets` — clean
- `cargo +nightly fmt --all` — no changes
- `cargo test -p binius-core -p binius-frontend` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)