### PR TITLE
BINIUS-316: pool the prover's FieldBuffer working memory via Allocator

### DIFF
--- a/crates/compute/src/buffer_pool.rs
+++ b/crates/compute/src/buffer_pool.rs
@@ -158,6 +158,13 @@ impl<T> PoolVec<'_, T> {
 		self.data.clear();
 	}
 
+	/// Shrinks the buffer to its first `len` elements, retaining its capacity.
+	///
+	/// Has no effect if `len` is at least the current length. Mirrors [`Vec::truncate`].
+	pub fn truncate(&mut self, len: usize) {
+		self.data.truncate(len);
+	}
+
 	/// Returns the spare capacity of the buffer as a slice of `MaybeUninit<T>`.
 	///
 	/// Mirrors [`Vec::spare_capacity_mut`]: used to write into a freshly allocated buffer in place

--- a/crates/compute/src/buffer_pool.rs
+++ b/crates/compute/src/buffer_pool.rs
@@ -196,6 +196,18 @@ impl<T: Clone> PoolVec<'_, T> {
 	}
 }
 
+impl<T: Clone> Clone for PoolVec<'_, T> {
+	/// Clones into a fresh block drawn from the same pool, so the clone is itself a genuine pooled
+	/// buffer whose [`Drop`] reclaims correctly. (A `#[derive]`d clone would duplicate the inner
+	/// `Vec` into a plain, non-pool allocation, which the reclaiming `Drop` must never hand back to
+	/// the free list.)
+	fn clone(&self) -> Self {
+		let mut cloned = self.pool.alloc_vec::<T>(self.data.len());
+		cloned.extend_from_slice(&self.data);
+		cloned
+	}
+}
+
 impl<T> Drop for PoolVec<'_, T> {
 	fn drop(&mut self) {
 		let mut data = mem::take(&mut self.data);

--- a/crates/compute/src/lib.rs
+++ b/crates/compute/src/lib.rs
@@ -26,15 +26,21 @@ pub use buffer_pool::{BufferPool, PoolVec};
 /// Abstracts the allocation seam so callers can be generic over how their working buffers are
 /// backed. The primary implementation is `&BufferPool`, whose [`Vec`](Allocator::Vec) is
 /// [`PoolVec`] — a buffer drawn from a recycling pool.
-pub trait Allocator {
+///
+/// [`Sync`] is required because the prover shares `&impl Allocator` across rayon tasks (e.g. the
+/// parallel fractional-addition GKR reduction); both `&BufferPool` and `GlobalAllocator` are
+/// `Sync`.
+pub trait Allocator: Sync {
 	/// The buffer type this allocator hands out for element type `T`.
 	///
 	/// It is both a [`VecLike`] (growable) and a [`BufferData`] (shrinkable-in-place) buffer, so an
-	/// allocated buffer can back a `binius_math::FieldBuffer` directly.
-	type Vec<T>: VecLike<T> + BufferData<T>;
+	/// allocated buffer can back a `binius_math::FieldBuffer` directly. It is also [`Send`] so the
+	/// prover can move pooled buffers across rayon tasks (e.g. the parallel fractional-addition GKR
+	/// reduction); every element type the prover pools is itself `Send`.
+	type Vec<T: Send>: VecLike<T> + BufferData<T> + Send;
 
 	/// Allocates an empty buffer with room for at least `capacity` elements of type `T`.
-	fn alloc<T>(&self, capacity: usize) -> Self::Vec<T>;
+	fn alloc<T: Send>(&self, capacity: usize) -> Self::Vec<T>;
 }
 
 /// Backing store of a `binius_math::FieldBuffer` that can be shrunk in place.
@@ -152,9 +158,9 @@ impl<T> VecLike<T> for PoolVec<'_, T> {
 }
 
 impl<'alloc> Allocator for &'alloc BufferPool {
-	type Vec<T> = PoolVec<'alloc, T>;
+	type Vec<T: Send> = PoolVec<'alloc, T>;
 
-	fn alloc<T>(&self, capacity: usize) -> Self::Vec<T> {
+	fn alloc<T: Send>(&self, capacity: usize) -> Self::Vec<T> {
 		// Copy the `&'alloc BufferPool` out of `&self` so the returned `PoolVec` borrows the pool
 		// for `'alloc`, not merely for this call's `&self` borrow.
 		let pool: &'alloc BufferPool = self;
@@ -206,9 +212,9 @@ impl<T> VecLike<T> for Vec<T> {
 pub struct GlobalAllocator;
 
 impl Allocator for GlobalAllocator {
-	type Vec<T> = Vec<T>;
+	type Vec<T: Send> = Vec<T>;
 
-	fn alloc<T>(&self, capacity: usize) -> Self::Vec<T> {
+	fn alloc<T: Send>(&self, capacity: usize) -> Self::Vec<T> {
 		Vec::with_capacity(capacity)
 	}
 }

--- a/crates/compute/src/lib.rs
+++ b/crates/compute/src/lib.rs
@@ -12,6 +12,7 @@
 //! buffers.
 
 use std::{
+	mem,
 	mem::MaybeUninit,
 	ops::{Deref, DerefMut},
 };
@@ -27,10 +28,54 @@ pub use buffer_pool::{BufferPool, PoolVec};
 /// [`PoolVec`] — a buffer drawn from a recycling pool.
 pub trait Allocator {
 	/// The buffer type this allocator hands out for element type `T`.
-	type Vec<T>: VecLike<T>;
+	///
+	/// It is both a [`VecLike`] (growable) and a [`BufferData`] (shrinkable-in-place) buffer, so an
+	/// allocated buffer can back a `binius_math::FieldBuffer` directly.
+	type Vec<T>: VecLike<T> + BufferData<T>;
 
 	/// Allocates an empty buffer with room for at least `capacity` elements of type `T`.
 	fn alloc<T>(&self, capacity: usize) -> Self::Vec<T>;
+}
+
+/// Backing store of a `binius_math::FieldBuffer` that can be shrunk in place.
+///
+/// This lives here, rather than in `binius-math`, so that it can be a bound on
+/// [`Allocator::Vec`] — that bound is what lets generic allocation code back a `FieldBuffer` with
+/// an allocator's buffer `A::Vec<P>` without threading a `where A::Vec<P>: BufferData<P>` clause
+/// through every signature. `FieldBuffer::truncate` shrinks its backing store to match a smaller
+/// `log_len`, so it is available only for the mutable backings that support that in place: the
+/// growable [`VecLike`] buffers (`Vec<T>` and [`PoolVec`]) and `&mut [T]`.
+///
+/// A single blanket `impl<V: VecLike<T>> BufferData<T> for V` would be nicer, but it collides with
+/// the `&mut [T]` impl (coherence cannot rule out a downstream `VecLike for &mut [T]`), and the
+/// `&mut [T]` backing is required — the sumcheck store folds and truncates slice-backed halves. So
+/// the two `VecLike` backings are enumerated explicitly instead.
+pub trait BufferData<T>: DerefMut<Target = [T]> {
+	/// Shrinks the store in place to its first `len` elements.
+	///
+	/// `len` must be at most the current length.
+	fn truncate(&mut self, len: usize);
+}
+
+impl<T> BufferData<T> for Vec<T> {
+	fn truncate(&mut self, len: usize) {
+		Vec::truncate(self, len);
+	}
+}
+
+impl<T> BufferData<T> for PoolVec<'_, T> {
+	fn truncate(&mut self, len: usize) {
+		PoolVec::truncate(self, len);
+	}
+}
+
+impl<T> BufferData<T> for &mut [T] {
+	fn truncate(&mut self, len: usize) {
+		// A `&'a mut [T]` cannot be re-sliced in place through `&mut self`, so move it out and
+		// slice the owned value back in.
+		let full = mem::take(self);
+		*self = &mut full[..len];
+	}
 }
 
 /// A growable, `Vec`-like buffer.

--- a/crates/iop-prover/Cargo.toml
+++ b/crates/iop-prover/Cargo.toml
@@ -8,6 +8,7 @@ authors.workspace = true
 workspace = true
 
 [dependencies]
+binius-compute = { path = "../compute" }
 binius-field = { path = "../field" }
 binius-hash = { path = "../hash" }
 binius-iop = { path = "../iop" }

--- a/crates/iop-prover/src/basefold/channel.rs
+++ b/crates/iop-prover/src/basefold/channel.rs
@@ -367,7 +367,7 @@ fn prove_batch_zk_basefold<A, F, P, NTT, Channel>(
 
 		let eq_tensor = eq_ind_partial_eval_scalars(&outer_challenges);
 
-		let mut combined = FieldBuffer::<P>::zeros(max_n);
+		let mut combined = FieldBuffer::<P>::zeros_in(alloc, max_n);
 		let mut s_prime = F::ZERO;
 		for (fri_oracle, witness_prime, eq_i, alpha_i) in
 			izip!(fri_params.input_oracles(), witness_primes, eq_tensor, alphas)

--- a/crates/iop-prover/src/basefold/channel.rs
+++ b/crates/iop-prover/src/basefold/channel.rs
@@ -2,13 +2,16 @@
 
 //! BaseFold ZK implementation of the IOP prover channel.
 
+use binius_compute::Allocator;
 use binius_field::{BinaryField, PackedField};
 use binius_iop::{channel::OracleSpec, fri::FRIParams};
 use binius_ip_prover::{
 	channel::IPProverChannel,
 	sumcheck::{
-		self, PaddedSumcheckDecorator, batch::BatchSumcheckOutput,
-		bivariate_product_evaluator::BivariateProductEvaluator, mle_store::MleStore,
+		self, PaddedSumcheckDecorator,
+		batch::BatchSumcheckOutput,
+		bivariate_product_evaluator::BivariateProductEvaluator,
+		mle_store::{MleStore, pooled_copy},
 		round_evaluator::SharedSumcheckProver,
 	},
 };
@@ -140,7 +143,7 @@ where
 	/// (in oracle-index order). Mirrors [`BaseFoldVerifierChannel::finish`].
 	///
 	/// [`BaseFoldVerifierChannel::finish`]: binius_iop::basefold::channel::BaseFoldVerifierChannel::finish
-	pub fn finish(self) {
+	pub fn finish<A: Allocator>(self, alloc: &A) {
 		let Self {
 			mut channel,
 			ntt,
@@ -166,6 +169,7 @@ where
 			&fri_params,
 			committed_oracles,
 			queue,
+			alloc,
 		);
 	}
 }
@@ -184,14 +188,16 @@ where
 /// index, so the two orders are reconciled by indexing rather than by sorting the relations; the
 /// per-oracle data (`oracle_specs`, `fri_params`, `committed_oracles`) is all indexed by oracle
 /// index.
-fn prove_batch_zk_basefold<F, P, NTT, Channel>(
+fn prove_batch_zk_basefold<A, F, P, NTT, Channel>(
 	channel: &mut Channel,
 	ntt: &NTT,
 	oracle_specs: &[OracleSpec],
 	fri_params: &FRIParams<F>,
 	committed_oracles: Vec<CommittedOracleData<P, Channel::Commitment>>,
 	relations: Vec<QueuedRelation<P>>,
+	alloc: &A,
 ) where
+	A: Allocator,
 	F: BinaryField,
 	P: PackedField<Scalar = F>,
 	NTT: AdditiveNTT<Field = F> + Sync,
@@ -316,9 +322,9 @@ fn prove_batch_zk_basefold<F, P, NTT, Channel>(
 				claim
 			};
 
-			let mut store = MleStore::new(n_i);
+			let mut store = MleStore::new(n_i, alloc);
 			let message_col = store.push(message);
-			let transparent_col = store.push_owned(transparent);
+			let transparent_col = store.push_owned(pooled_copy(alloc, &transparent));
 			let inner = SharedSumcheckProver::new(
 				store,
 				[(sum_prime, BivariateProductEvaluator::new([message_col, transparent_col]))],
@@ -412,6 +418,7 @@ fn prove_batch_zk_basefold<F, P, NTT, Channel>(
 		&outer_challenges,
 		fri_folder,
 		channel,
+		alloc,
 	);
 }
 
@@ -552,6 +559,7 @@ where
 
 #[cfg(test)]
 mod tests {
+	use binius_compute::GlobalAllocator;
 	use binius_field::{
 		BinaryField, BinaryField128bGhash, Field, PackedBinaryGhash1x128b, PackedField,
 	};
@@ -655,7 +663,7 @@ mod tests {
 			transparent_poly.clone(),
 			eval_claim,
 		)]);
-		prover_channel.finish();
+		prover_channel.finish(&GlobalAllocator);
 
 		// === VERIFIER SIDE ===
 		let mut verifier_transcript = prover_transcript.into_verifier();
@@ -725,7 +733,7 @@ mod tests {
 			(oracle_1, buffer_1, transparent_poly_1.clone(), eval_claim_1),
 			(oracle_2, buffer_2, transparent_poly_2.clone(), eval_claim_2),
 		]);
-		prover_channel.finish();
+		prover_channel.finish(&GlobalAllocator);
 
 		// === VERIFIER SIDE ===
 		let mut verifier_transcript = prover_transcript.into_verifier();
@@ -813,7 +821,7 @@ mod tests {
 			})
 			.collect();
 		prover_channel.prove_oracle_relations(prover_relations);
-		prover_channel.finish();
+		prover_channel.finish(&GlobalAllocator);
 
 		// === VERIFIER SIDE ===
 		let mut verifier_transcript = prover_transcript.into_verifier();
@@ -909,7 +917,7 @@ mod tests {
 			})
 			.collect();
 		prover_channel.prove_oracle_relations(prover_relations);
-		prover_channel.finish();
+		prover_channel.finish(&GlobalAllocator);
 
 		let mut verifier_transcript = prover_transcript.into_verifier();
 		let mut verifier_channel = verifier_compiler

--- a/crates/iop-prover/src/basefold/opening.rs
+++ b/crates/iop-prover/src/basefold/opening.rs
@@ -3,10 +3,11 @@
 
 //! The core BaseFold opening protocol on the prover side.
 
+use binius_compute::Allocator;
 use binius_field::{BinaryField, PackedField};
 use binius_ip::mlecheck;
 use binius_ip_prover::sumcheck::{
-	common::SumcheckProver, multilinear_eval::multilinear_eval_prover,
+	common::SumcheckProver, mle_store::pooled_copy, multilinear_eval::multilinear_eval_prover,
 };
 use binius_math::{FieldBuffer, ntt::AdditiveNTT};
 
@@ -40,7 +41,8 @@ use crate::{fri::FRIFoldProver, merkle_channel::MerkleIPProverChannel};
 ///
 /// The final FRI value equals the final MLE-check value.
 /// The verifier asserts that equality when it runs the matching opening.
-pub fn prove_mlecheck_basefold<F, P, NTT, Channel>(
+#[allow(clippy::too_many_arguments)]
+pub fn prove_mlecheck_basefold<A, F, P, NTT, Channel>(
 	witness: FieldBuffer<P>,
 	eval_point: &[F],
 	eval_claim: F,
@@ -48,7 +50,9 @@ pub fn prove_mlecheck_basefold<F, P, NTT, Channel>(
 	outer_challenges: &[F],
 	mut fri_folder: FRIFoldProver<'_, F, P, NTT, Channel::Commitment>,
 	channel: &mut Channel,
+	alloc: &A,
 ) where
+	A: Allocator,
 	F: BinaryField,
 	P: PackedField<Scalar = F>,
 	NTT: AdditiveNTT<Field = F> + Sync,
@@ -78,7 +82,8 @@ pub fn prove_mlecheck_basefold<F, P, NTT, Channel>(
 		fri_folder.receive_challenge(outer_challenge);
 	}
 
-	let mut sumcheck = multilinear_eval_prover(witness, eval_point, eval_claim);
+	let mut sumcheck =
+		multilinear_eval_prover(alloc, pooled_copy(alloc, &witness), eval_point, eval_claim);
 	for _ in 0..n_vars {
 		let mut round_coeffs_vec = sumcheck.execute();
 		let round_coeffs = round_coeffs_vec
@@ -102,6 +107,7 @@ pub fn prove_mlecheck_basefold<F, P, NTT, Channel>(
 #[cfg(test)]
 mod test {
 	use anyhow::Result;
+	use binius_compute::GlobalAllocator;
 	use binius_field::{BinaryField, PackedBinaryGhash1x128b, PackedField};
 	use binius_hash::{StdDigest, StdHashSuite};
 	use binius_iop::{
@@ -209,6 +215,7 @@ mod test {
 			&[],
 			fri_folder,
 			&mut prover_channel,
+			&GlobalAllocator,
 		);
 		drop(prover_channel);
 

--- a/crates/iop-prover/src/basefold/opening.rs
+++ b/crates/iop-prover/src/basefold/opening.rs
@@ -7,9 +7,9 @@ use binius_compute::Allocator;
 use binius_field::{BinaryField, PackedField};
 use binius_ip::mlecheck;
 use binius_ip_prover::sumcheck::{
-	common::SumcheckProver, mle_store::pooled_copy, multilinear_eval::multilinear_eval_prover,
+	common::SumcheckProver, multilinear_eval::multilinear_eval_prover,
 };
-use binius_math::{FieldBuffer, ntt::AdditiveNTT};
+use binius_math::{FieldVec, ntt::AdditiveNTT};
 
 use crate::{fri::FRIFoldProver, merkle_channel::MerkleIPProverChannel};
 
@@ -43,7 +43,7 @@ use crate::{fri::FRIFoldProver, merkle_channel::MerkleIPProverChannel};
 /// The verifier asserts that equality when it runs the matching opening.
 #[allow(clippy::too_many_arguments)]
 pub fn prove_mlecheck_basefold<A, F, P, NTT, Channel>(
-	witness: FieldBuffer<P>,
+	witness: FieldVec<P, A>,
 	eval_point: &[F],
 	eval_claim: F,
 	batch_challenge: Option<F>,
@@ -82,8 +82,7 @@ pub fn prove_mlecheck_basefold<A, F, P, NTT, Channel>(
 		fri_folder.receive_challenge(outer_challenge);
 	}
 
-	let mut sumcheck =
-		multilinear_eval_prover(alloc, pooled_copy(alloc, &witness), eval_point, eval_claim);
+	let mut sumcheck = multilinear_eval_prover(alloc, witness, eval_point, eval_claim);
 	for _ in 0..n_vars {
 		let mut round_coeffs_vec = sumcheck.execute();
 		let round_coeffs = round_coeffs_vec

--- a/crates/iop-prover/src/logup_star.rs
+++ b/crates/iop-prover/src/logup_star.rs
@@ -12,6 +12,7 @@
 //!
 //! [Soukhanov25]: <https://eprint.iacr.org/2025/946>
 
+use binius_compute::Allocator;
 use binius_field::{BinaryField, Divisible, PackedField};
 pub use binius_ip_prover::logup_star::Looker;
 use binius_ip_prover::logup_star::{self as reduction, witness};
@@ -62,15 +63,17 @@ pub struct LogupProof<F> {
 	name = "logup* (committed)",
 	fields(n_lookers = lookers.len(), table_n_vars = table.log_len())
 )]
-pub fn prove<F, P, Channel>(
+pub fn prove<F, P, Channel, A>(
 	table: &FieldBuffer<P>,
 	lookers: &[Looker<'_, F>],
 	channel: &mut Channel,
+	alloc: &A,
 ) -> LogupProof<F>
 where
 	F: BinaryField<Underlier: Divisible<u64>>,
 	P: PackedField<Scalar = F>,
 	Channel: IOPProverChannel<P>,
+	A: Allocator,
 {
 	let m = table.log_len();
 
@@ -95,6 +98,7 @@ where
 
 	// Run the reduction over the committed Y and the numerators, viewing the channel as IP.
 	let output = reduction::prove_reduction(
+		alloc,
 		table,
 		lookers,
 		combined_eval_claim,
@@ -126,6 +130,7 @@ where
 
 #[cfg(test)]
 mod tests {
+	use binius_compute::GlobalAllocator;
 	use binius_field::{
 		BinaryField1b, ExtensionField, Field,
 		arch::{OptimalB128, OptimalPackedB128},
@@ -203,7 +208,8 @@ mod tests {
 			eval_point: &eval_point,
 			eval_claim,
 		};
-		let prover_proof = prove::<F, P, _>(&table, &[looker], &mut prover_channel);
+		let prover_proof =
+			prove::<F, P, _, _>(&table, &[looker], &mut prover_channel, &GlobalAllocator);
 
 		prover_channel.finish();
 
@@ -288,7 +294,8 @@ mod tests {
 				eval_claim: eval_claim_1,
 			},
 		];
-		let prover_proof = prove::<F, P, _>(&table, &lookers, &mut prover_channel);
+		let prover_proof =
+			prove::<F, P, _, _>(&table, &lookers, &mut prover_channel, &GlobalAllocator);
 		prover_channel.finish();
 
 		let mut verifier_transcript = prover_transcript.into_verifier();
@@ -339,7 +346,8 @@ mod tests {
 			eval_point: &eval_point,
 			eval_claim: wrong_claim,
 		};
-		let _prover_proof = prove::<F, P, _>(&table, &[looker], &mut prover_channel);
+		let _prover_proof =
+			prove::<F, P, _, _>(&table, &[looker], &mut prover_channel, &GlobalAllocator);
 		prover_channel.finish();
 
 		// The reduction's product check must surface the inconsistency as a verification failure.
@@ -408,8 +416,9 @@ mod tests {
 			eval_point: &eval_point,
 			eval_claim,
 		};
-		let prover_proof = prove::<F, BP, _>(&table, &[looker], &mut prover_channel);
-		prover_channel.finish();
+		let alloc = GlobalAllocator;
+		let prover_proof = prove::<F, BP, _, _>(&table, &[looker], &mut prover_channel, &alloc);
+		prover_channel.finish(&alloc);
 
 		// Verify: receive Y, run the reduction, open the pushforward through the real FRI check.
 		let mut verifier_transcript = prover_transcript.into_verifier();

--- a/crates/ip-prover/Cargo.toml
+++ b/crates/ip-prover/Cargo.toml
@@ -8,6 +8,7 @@ authors.workspace = true
 workspace = true
 
 [dependencies]
+binius-compute = { path = "../compute" }
 binius-field = { path = "../field" }
 binius-ip = { path = "../ip" }
 binius-math = { path = "../math" }

--- a/crates/ip-prover/benches/bivariate_product.rs
+++ b/crates/ip-prover/benches/bivariate_product.rs
@@ -5,11 +5,12 @@
 //! the hypercube), and a [`SharedMleCheckProver`] driving one [`QuadraticMleEvaluator`] (the
 //! evaluation claim on the product's multilinear extension at a random point).
 
+use binius_compute::BufferPool;
 use binius_field::{FieldOps, PackedField, arch::OptimalPackedB128};
 use binius_ip_prover::sumcheck::{
 	self,
 	bivariate_product_evaluator::BivariateProductEvaluator,
-	mle_store::MleStore,
+	mle_store::{MleStore, pooled_copy},
 	quadratic_mle_evaluator::QuadraticMleEvaluator,
 	round_evaluator::{SharedMleCheckProver, SharedSumcheckProver},
 };
@@ -62,8 +63,11 @@ fn bench_shared_sumcheck_bivariate_product(c: &mut Criterion) {
 			b.iter_batched(
 				|| (transcript.clone(), a.clone(), b_multilinear.clone()),
 				|(mut transcript, a, b_multilinear)| {
-					let mut store = MleStore::new(n_vars);
-					let cols = [a, b_multilinear].map(|col| store.push_owned(col));
+					let pool = BufferPool::new();
+					let alloc = &pool;
+					let mut store = MleStore::new(n_vars, &alloc);
+					let cols =
+						[a, b_multilinear].map(|col| store.push_owned(pooled_copy(&alloc, &col)));
 					let evaluator = BivariateProductEvaluator::new(cols);
 					let prover = SharedSumcheckProver::new(store, [(sum_claim, evaluator)]);
 
@@ -95,8 +99,11 @@ fn bench_shared_mlecheck_bivariate_product(c: &mut Criterion) {
 			b.iter_batched(
 				|| (transcript.clone(), a.clone(), b_multilinear.clone(), eval_point.clone()),
 				|(mut transcript, a, b_multilinear, eval_point)| {
-					let mut store = MleStore::new(n_vars);
-					let cols = [a, b_multilinear].map(|col| store.push_owned(col));
+					let pool = BufferPool::new();
+					let alloc = &pool;
+					let mut store = MleStore::new(n_vars, &alloc);
+					let cols =
+						[a, b_multilinear].map(|col| store.push_owned(pooled_copy(&alloc, &col)));
 					let evaluator = QuadraticMleEvaluator::new(cols, product::<P>, product::<P>);
 					let prover =
 						SharedMleCheckProver::new(store, [(eval_claim, evaluator)], eval_point);

--- a/crates/ip-prover/benches/bivariate_product.rs
+++ b/crates/ip-prover/benches/bivariate_product.rs
@@ -10,15 +10,13 @@ use binius_field::{FieldOps, PackedField, arch::OptimalPackedB128};
 use binius_ip_prover::sumcheck::{
 	self,
 	bivariate_product_evaluator::BivariateProductEvaluator,
-	mle_store::{MleStore, pooled_copy},
+	mle_store::MleStore,
 	quadratic_mle_evaluator::QuadraticMleEvaluator,
 	round_evaluator::{SharedMleCheckProver, SharedSumcheckProver},
 };
 use binius_math::{
-	FieldBuffer,
-	inner_product::inner_product_par,
-	multilinear::evaluate::evaluate_inplace,
-	test_utils::{random_field_buffer, random_scalars},
+	FieldBuffer, inner_product::inner_product_par, multilinear::evaluate::evaluate_inplace,
+	test_utils::random_scalars,
 };
 use binius_transcript::{ProverTranscript, fiat_shamir::HasherChallenger};
 use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
@@ -36,7 +34,15 @@ fn product<Pf: PackedField>([a, b]: [Pf; 2]) -> Pf {
 
 // The evaluation of the product `a * b`'s multilinear extension at `eval_point`, the MLE-check
 // claim.
-fn product_eval_claim(a: &FieldBuffer<P>, b: &FieldBuffer<P>, eval_point: &[F]) -> F {
+fn product_eval_claim<DataA, DataB>(
+	a: &FieldBuffer<P, DataA>,
+	b: &FieldBuffer<P, DataB>,
+	eval_point: &[F],
+) -> F
+where
+	DataA: std::ops::Deref<Target = [P]>,
+	DataB: std::ops::Deref<Target = [P]>,
+{
 	let n_vars = eval_point.len();
 	let packed_len = 1 << n_vars.saturating_sub(P::LOG_WIDTH);
 	let product_vals: Vec<P> = (0..packed_len)
@@ -54,8 +60,13 @@ fn bench_shared_sumcheck_bivariate_product(c: &mut Criterion) {
 	for n_vars in [12, 16, 20] {
 		group.throughput(Throughput::Elements(1 << n_vars));
 		group.bench_function(format!("n_vars={n_vars}"), |b| {
-			let a = random_field_buffer::<P>(&mut rng, n_vars);
-			let b_multilinear = random_field_buffer::<P>(&mut rng, n_vars);
+			let a_scalars = random_scalars::<F>(&mut rng, 1 << n_vars);
+			let b_scalars = random_scalars::<F>(&mut rng, 1 << n_vars);
+			let pool = BufferPool::new();
+			let alloc = &pool;
+			// Build the two multilinears once; each iteration clones them from the pool.
+			let a = FieldBuffer::<P>::from_values_in(&alloc, &a_scalars);
+			let b_multilinear = FieldBuffer::<P>::from_values_in(&alloc, &b_scalars);
 			// The plain sum claim is the sum of `a * b` over the hypercube.
 			let sum_claim = inner_product_par(&a, &b_multilinear);
 			let transcript = ProverTranscript::new(StdChallenger::default());
@@ -63,11 +74,8 @@ fn bench_shared_sumcheck_bivariate_product(c: &mut Criterion) {
 			b.iter_batched(
 				|| (transcript.clone(), a.clone(), b_multilinear.clone()),
 				|(mut transcript, a, b_multilinear)| {
-					let pool = BufferPool::new();
-					let alloc = &pool;
 					let mut store = MleStore::new(n_vars, &alloc);
-					let cols =
-						[a, b_multilinear].map(|col| store.push_owned(pooled_copy(&alloc, &col)));
+					let cols = [a, b_multilinear].map(|col| store.push_owned(col));
 					let evaluator = BivariateProductEvaluator::new(cols);
 					let prover = SharedSumcheckProver::new(store, [(sum_claim, evaluator)]);
 
@@ -90,8 +98,13 @@ fn bench_shared_mlecheck_bivariate_product(c: &mut Criterion) {
 	for n_vars in [12, 16, 20] {
 		group.throughput(Throughput::Elements(1 << n_vars));
 		group.bench_function(format!("n_vars={n_vars}"), |b| {
-			let a = random_field_buffer::<P>(&mut rng, n_vars);
-			let b_multilinear = random_field_buffer::<P>(&mut rng, n_vars);
+			let a_scalars = random_scalars::<F>(&mut rng, 1 << n_vars);
+			let b_scalars = random_scalars::<F>(&mut rng, 1 << n_vars);
+			let pool = BufferPool::new();
+			let alloc = &pool;
+			// Build the two multilinears once; each iteration clones them from the pool.
+			let a = FieldBuffer::<P>::from_values_in(&alloc, &a_scalars);
+			let b_multilinear = FieldBuffer::<P>::from_values_in(&alloc, &b_scalars);
 			let eval_point = random_scalars::<F>(&mut rng, n_vars);
 			let eval_claim = product_eval_claim(&a, &b_multilinear, &eval_point);
 			let transcript = ProverTranscript::new(StdChallenger::default());
@@ -99,11 +112,8 @@ fn bench_shared_mlecheck_bivariate_product(c: &mut Criterion) {
 			b.iter_batched(
 				|| (transcript.clone(), a.clone(), b_multilinear.clone(), eval_point.clone()),
 				|(mut transcript, a, b_multilinear, eval_point)| {
-					let pool = BufferPool::new();
-					let alloc = &pool;
 					let mut store = MleStore::new(n_vars, &alloc);
-					let cols =
-						[a, b_multilinear].map(|col| store.push_owned(pooled_copy(&alloc, &col)));
+					let cols = [a, b_multilinear].map(|col| store.push_owned(col));
 					let evaluator = QuadraticMleEvaluator::new(cols, product::<P>, product::<P>);
 					let prover =
 						SharedMleCheckProver::new(store, [(eval_claim, evaluator)], eval_point);

--- a/crates/ip-prover/src/fracaddcheck.rs
+++ b/crates/ip-prover/src/fracaddcheck.rs
@@ -6,7 +6,7 @@ use binius_compute::{Allocator, VecLike};
 use binius_field::{Field, PackedField};
 use binius_ip::{mlecheck, prodcheck::MultilinearEvalClaim, sumcheck::RoundCoeffs};
 use binius_math::{
-	FieldBuffer, line::extrapolate_line_packed, multilinear::eq::eq_ind_partial_eval,
+	FieldBuffer, FieldVec, line::extrapolate_line_packed, multilinear::eq::eq_ind_partial_eval,
 };
 use binius_utils::rayon::iter::{
 	IntoParallelIterator, IntoParallelRefMutIterator, ParallelIterator,
@@ -19,7 +19,7 @@ use crate::{
 		batch::batch_prove_mle_and_write_evals,
 		common::{MleCheckProver, SumcheckProver},
 		frac_add_mle,
-		mle_store::{ColId, MleStore, PooledColumn, pooled_copy},
+		mle_store::{ColId, MleStore},
 		round_evaluator::{MleCheckRoundEvaluator, SharedMleCheckProver},
 	},
 };
@@ -38,7 +38,7 @@ pub type LayerProver<'a, A, F, P> =
 	SharedMleCheckProver<'a, A, F, P, Box<dyn MleCheckRoundEvaluator<A, F, P> + 'a>>;
 
 /// A numerator/denominator pair of pooled column buffers.
-type PooledFractionalBuffer<A, P> = (PooledColumn<A, P>, PooledColumn<A, P>);
+type PooledFractionalBuffer<A, P> = (FieldVec<P, A>, FieldVec<P, A>);
 
 /// Prover for the fractional addition protocol.
 ///
@@ -49,6 +49,18 @@ pub struct FracAddCheckProver<'a, A: Allocator, P: PackedField> {
 	layers: Vec<PooledFractionalBuffer<A, P>>,
 	/// Allocator the layer buffers are drawn from.
 	pub(crate) alloc: &'a A,
+}
+
+impl<A: Allocator, P: PackedField> Clone for FracAddCheckProver<'_, A, P>
+where
+	A::Vec<P>: Clone,
+{
+	fn clone(&self) -> Self {
+		Self {
+			layers: self.layers.clone(),
+			alloc: self.alloc,
+		}
+	}
 }
 
 impl<'a, A, F, P> FracAddCheckProver<'a, A, P>
@@ -562,12 +574,12 @@ where
 	// packed, so the store owns them directly.
 	let mut selector_store = MleStore::new(k, alloc);
 	let selector_cols = [
-		FieldBuffer::<P>::from_values(&num_0s),
-		FieldBuffer::<P>::from_values(&num_1s),
-		FieldBuffer::<P>::from_values(&den_0s),
-		FieldBuffer::<P>::from_values(&den_1s),
+		FieldBuffer::<P>::from_values_in(alloc, &num_0s),
+		FieldBuffer::<P>::from_values_in(alloc, &num_1s),
+		FieldBuffer::<P>::from_values_in(alloc, &den_0s),
+		FieldBuffer::<P>::from_values_in(alloc, &den_1s),
 	]
-	.map(|buffer| selector_store.push_owned(pooled_copy(alloc, &buffer)));
+	.map(|buffer| selector_store.push_owned(buffer));
 	let (selector_num, selector_den) = frac_add_mle::evaluators::<A, F, P>(selector_cols);
 	let selector_claims_with_evaluators: [(F, Box<dyn MleCheckRoundEvaluator<A, F, P> + 'a>); 2] = [
 		(num_eval, Box::new(selector_num)),
@@ -674,7 +686,6 @@ mod tests {
 	use rand::prelude::*;
 
 	use super::*;
-	use crate::sumcheck::mle_store::pooled_copy;
 
 	fn test_frac_add_check_prove_verify_helper<P: PackedField>(n: usize, k: usize) {
 		let mut rng = StdRng::seed_from_u64(0);
@@ -685,11 +696,8 @@ mod tests {
 		let witness_den = random_field_buffer::<P>(&mut rng, n + k);
 
 		// 2. Create prover (computes fractional-add layers)
-		let (prover, sums) = FracAddCheckProver::new(
-			k,
-			&alloc,
-			(pooled_copy(&alloc, &witness_num), pooled_copy(&alloc, &witness_den)),
-		);
+		let (prover, sums) =
+			FracAddCheckProver::new(k, &alloc, (witness_num.clone(), witness_den.clone()));
 
 		// 3. Generate random n-dimensional challenge point
 		let eval_point = random_scalars::<P::Scalar>(&mut rng, n);
@@ -754,11 +762,8 @@ mod tests {
 		let witness_den = random_field_buffer::<P>(&mut rng, n + k);
 
 		// Create prover (computes fractional-add layers)
-		let (_prover, sums) = FracAddCheckProver::new(
-			k,
-			&alloc,
-			(pooled_copy(&alloc, &witness_num), pooled_copy(&alloc, &witness_den)),
-		);
+		let (_prover, sums) =
+			FracAddCheckProver::new(k, &alloc, (witness_num.clone(), witness_den.clone()));
 
 		// For each index i in the sums layer, verify it equals the fractional sum of witness values
 		// at indices i + z * 2^n for z in 0..2^k (strided access, not contiguous)
@@ -843,11 +848,7 @@ mod tests {
 		let (provers, individual_sums): (Vec<_>, Vec<_>) = witnesses
 			.iter()
 			.map(|witness| {
-				FracAddCheckProver::new(
-					n_layers,
-					&alloc,
-					(pooled_copy(&alloc, &witness.0), pooled_copy(&alloc, &witness.1)),
-				)
+				FracAddCheckProver::new(n_layers, &alloc, (witness.0.clone(), witness.1.clone()))
 			})
 			.unzip();
 
@@ -977,11 +978,7 @@ mod tests {
 		let (provers, individual_sums): (Vec<_>, Vec<_>) = witnesses
 			.iter()
 			.map(|witness| {
-				FracAddCheckProver::new(
-					n_layers,
-					&alloc,
-					(pooled_copy(&alloc, &witness.0), pooled_copy(&alloc, &witness.1)),
-				)
+				FracAddCheckProver::new(n_layers, &alloc, (witness.0.clone(), witness.1.clone()))
 			})
 			.unzip();
 

--- a/crates/ip-prover/src/fracaddcheck.rs
+++ b/crates/ip-prover/src/fracaddcheck.rs
@@ -2,6 +2,7 @@
 
 use std::iter;
 
+use binius_compute::{Allocator, VecLike};
 use binius_field::{Field, PackedField};
 use binius_ip::{mlecheck, prodcheck::MultilinearEvalClaim, sumcheck::RoundCoeffs};
 use binius_math::{
@@ -17,8 +18,8 @@ use crate::{
 	sumcheck::{
 		batch::batch_prove_mle_and_write_evals,
 		common::{MleCheckProver, SumcheckProver},
-		frac_add_mle::{self, FractionalBuffer},
-		mle_store::{ColId, MleStore},
+		frac_add_mle,
+		mle_store::{ColId, MleStore, PooledColumn, pooled_copy},
 		round_evaluator::{MleCheckRoundEvaluator, SharedMleCheckProver},
 	},
 };
@@ -33,20 +34,26 @@ pub type FracEvalClaim<F> = (MultilinearEvalClaim<F>, MultilinearEvalClaim<F>);
 /// Returned by `FracAddCheckProver::layer_prover`. It owns its four half-columns, so it is
 /// self-contained: a caller can drive it, batch it, or extend its store with more columns and
 /// evaluators (as the logUp* final layer does).
-pub type LayerProver<F, P> =
-	SharedMleCheckProver<'static, F, P, Box<dyn MleCheckRoundEvaluator<F, P>>>;
+pub type LayerProver<'a, A, F, P> =
+	SharedMleCheckProver<'a, A, F, P, Box<dyn MleCheckRoundEvaluator<A, F, P> + 'a>>;
+
+/// A numerator/denominator pair of pooled column buffers.
+type PooledFractionalBuffer<A, P> = (PooledColumn<A, P>, PooledColumn<A, P>);
 
 /// Prover for the fractional addition protocol.
 ///
 /// Each layer is a double of the numerator and denominator values of fractional terms. Each layer
 /// represents the addition of siblings with respect to the fractional addition rule:
 /// $$\frac{a_0}{b_0} + \frac{a_1}{b_1} = \frac{a_0b_1 + a_1b_0}{b_0b_1}$
-pub struct FracAddCheckProver<P: PackedField> {
-	layers: Vec<(FieldBuffer<P>, FieldBuffer<P>)>,
+pub struct FracAddCheckProver<'a, A: Allocator, P: PackedField> {
+	layers: Vec<PooledFractionalBuffer<A, P>>,
+	/// Allocator the layer buffers are drawn from.
+	pub(crate) alloc: &'a A,
 }
 
-impl<F, P> FracAddCheckProver<P>
+impl<'a, A, F, P> FracAddCheckProver<'a, A, P>
 where
+	A: Allocator,
 	F: Field,
 	P: PackedField<Scalar = F>,
 {
@@ -62,7 +69,11 @@ where
 	///
 	/// # Preconditions
 	/// * `witness.0.log_len() >= k`
-	pub fn new(k: usize, witness: FractionalBuffer<P>) -> (Self, FractionalBuffer<P>) {
+	pub fn new(
+		k: usize,
+		alloc: &'a A,
+		witness: PooledFractionalBuffer<A, P>,
+	) -> (Self, PooledFractionalBuffer<A, P>) {
 		let (witness_num, witness_den) = witness;
 		assert_eq!(
 			witness_num.log_len(),
@@ -78,6 +89,8 @@ where
 			let prev_layer = layers.last().expect("layers is non-empty");
 
 			let (num, den) = prev_layer;
+			let num_log_len = num.log_len() - 1;
+			let den_log_len = den.log_len() - 1;
 			let (num_0, num_1) = num.split_half_ref();
 			let (den_0, den_1) = den.split_half_ref();
 
@@ -87,16 +100,18 @@ where
 					.map(|(&a_0, &b_0, &a_1, &b_1)| (a_0 * b_1 + a_1 * b_0, b_0 * b_1))
 					.collect::<(Vec<_>, Vec<_>)>();
 
-			let next_layer = (
-				FieldBuffer::new(num.log_len() - 1, next_layer_num),
-				FieldBuffer::new(den.log_len() - 1, next_layer_den),
-			);
+			let mut num_data = alloc.alloc::<P>(next_layer_num.len());
+			num_data.extend_from_slice(&next_layer_num);
+			let mut den_data = alloc.alloc::<P>(next_layer_den.len());
+			den_data.extend_from_slice(&next_layer_den);
+			let next_layer =
+				(FieldBuffer::new(num_log_len, num_data), FieldBuffer::new(den_log_len, den_data));
 
 			layers.push(next_layer);
 		}
 
 		let sums = layers.pop().expect("layers has k+1 elements");
-		(Self { layers }, sums)
+		(Self { layers, alloc }, sums)
 	}
 
 	/// Returns the number of remaining layers to prove.
@@ -110,16 +125,18 @@ where
 	/// - `remaining` is `Some(self)` if there are more layers, `None` otherwise
 	/// - `layer_prover` is a sumcheck prover for the popped layer
 	/// - `cols` contains the [`MleStore`] column IDs `[num_0, num_1, den_0, den_1]`
+	#[allow(clippy::type_complexity)]
 	pub fn layer_prover(
 		mut self,
 		claim: FracEvalClaim<F>,
-	) -> (Option<Self>, LayerProver<F, P>, [ColId; 4]) {
+	) -> (Option<Self>, LayerProver<'a, A, F, P>, [ColId; 4]) {
 		let (num_claim, den_claim) = claim;
 		assert_eq!(
 			num_claim.point, den_claim.point,
 			"fractional claims must share the evaluation point"
 		);
 
+		let alloc = self.alloc;
 		let (num, den) = self.layers.pop().expect("layers is non-empty");
 
 		let remaining = if self.layers.is_empty() {
@@ -132,13 +149,13 @@ where
 		// and of the denominator buffer. The store takes ownership of the two popped buffers and
 		// shares each between its halves, so the prover is self-contained with no up-front copy of
 		// the popped layer.
-		let mut store = MleStore::new(num.log_len() - 1);
+		let mut store = MleStore::new(num.log_len() - 1, alloc);
 		let [num_0, num_1] = store.push_split_half(num);
 		let [den_0, den_1] = store.push_split_half(den);
 		let cols = [num_0, num_1, den_0, den_1];
-		let (num_evaluator, den_evaluator) = frac_add_mle::evaluators(cols);
+		let (num_evaluator, den_evaluator) = frac_add_mle::evaluators::<A, F, P>(cols);
 
-		let claims_with_evaluators: [(F, Box<dyn MleCheckRoundEvaluator<F, P>>); 2] = [
+		let claims_with_evaluators: [(F, Box<dyn MleCheckRoundEvaluator<A, F, P> + 'a>); 2] = [
 			(num_claim.eval, Box::new(num_evaluator)),
 			(den_claim.eval, Box::new(den_evaluator)),
 		];
@@ -296,19 +313,21 @@ pub struct BatchProveOutput<F> {
 /// * `2^selector_point.len() >= provers.len()`.
 /// * `claimed_fractions.len() == provers.len()`.
 /// * `content_point.len() == witness.log_len() - n_layers` for each prover.
-pub fn batch_prove<F, P>(
-	provers: Vec<FracAddCheckProver<P>>,
+pub fn batch_prove<'a, A, F, P>(
+	provers: Vec<FracAddCheckProver<'a, A, P>>,
 	claimed_fractions: Vec<(F, F)>,
 	selector_point: Vec<F>,
 	content_point: Vec<F>,
 	channel: &mut impl IPProverChannel<F>,
 ) -> BatchProveOutput<F>
 where
+	A: Allocator,
 	F: Field,
 	P: PackedField<Scalar = F>,
 {
 	let n = provers.len();
 	let k = selector_point.len();
+	let alloc = provers[0].alloc;
 
 	let BatchProveUntilFinalLayerOutput {
 		eval_point,
@@ -328,7 +347,7 @@ where
 		.map(|(_frac, prover)| prover)
 		.collect();
 	let (mut fractions, eval_point) =
-		reduce_layer::<F, P, _>(layer_provers, eval_point, k, channel);
+		reduce_layer::<A, F, P, _>(alloc, layer_provers, eval_point, k, channel);
 
 	// Drop the padded (2^k) selector slots, keeping one reduced fraction per input prover.
 	fractions.truncate(n);
@@ -366,14 +385,15 @@ pub struct BatchProveUntilFinalLayerOutput<F, MP> {
 /// logUp* final layer splices these provers into another reduction.
 ///
 /// Arguments and preconditions are as for [`batch_prove`].
-pub fn batch_prove_until_final_layer<F, P, Channel>(
-	provers: Vec<FracAddCheckProver<P>>,
+pub fn batch_prove_until_final_layer<'a, A, F, P, Channel>(
+	provers: Vec<FracAddCheckProver<'a, A, P>>,
 	claimed_fractions: Vec<(F, F)>,
 	selector_point: Vec<F>,
 	content_point: Vec<F>,
 	channel: &mut Channel,
-) -> BatchProveUntilFinalLayerOutput<F, LayerProver<F, P>>
+) -> BatchProveUntilFinalLayerOutput<F, LayerProver<'a, A, F, P>>
 where
+	A: Allocator,
 	F: Field,
 	P: PackedField<Scalar = F>,
 	Channel: IPProverChannel<F>,
@@ -448,13 +468,16 @@ fn combine_claims<F: Field>(coeffs: Vec<RoundCoeffs<F>>, batch_coeff: F) -> Roun
 /// The two (numerator, denominator) claims of every layer are batched via a single `batch_coeff`
 /// that the verifier's `batch_verify_mle` samples once per layer, before the round polynomials; the
 /// same coefficient is reused for the content and selector rounds.
-fn reduce_layer<F, P, MP>(
+#[allow(clippy::type_complexity)]
+fn reduce_layer<'a, A, F, P, MP>(
+	alloc: &'a A,
 	mut layer_provers: Vec<MP>,
 	eval_point: Vec<F>,
 	k: usize,
 	channel: &mut impl IPProverChannel<F>,
 ) -> (Vec<(F, F)>, Vec<F>)
 where
+	A: Allocator,
 	F: Field,
 	P: PackedField<Scalar = F>,
 	MP: MleCheckProver<F> + Send,
@@ -537,16 +560,16 @@ where
 	// Selector rounds: fold the selector variables with a single fractional-addition MLE-check over
 	// the packed reduced halves, reusing the same `batch_coeff`. The reduced halves are freshly
 	// packed, so the store owns them directly.
-	let mut selector_store = MleStore::new(k);
+	let mut selector_store = MleStore::new(k, alloc);
 	let selector_cols = [
 		FieldBuffer::<P>::from_values(&num_0s),
 		FieldBuffer::<P>::from_values(&num_1s),
 		FieldBuffer::<P>::from_values(&den_0s),
 		FieldBuffer::<P>::from_values(&den_1s),
 	]
-	.map(|buffer| selector_store.push_owned(buffer));
-	let (selector_num, selector_den) = frac_add_mle::evaluators(selector_cols);
-	let selector_claims_with_evaluators: [(F, Box<dyn MleCheckRoundEvaluator<F, P>>); 2] = [
+	.map(|buffer| selector_store.push_owned(pooled_copy(alloc, &buffer)));
+	let (selector_num, selector_den) = frac_add_mle::evaluators::<A, F, P>(selector_cols);
+	let selector_claims_with_evaluators: [(F, Box<dyn MleCheckRoundEvaluator<A, F, P> + 'a>); 2] = [
 		(num_eval, Box::new(selector_num)),
 		(den_eval, Box::new(selector_den)),
 	];
@@ -594,19 +617,21 @@ where
 /// Runs one interior batched fracaddcheck layer, returning the remaining provers, the reduced
 /// per-instance fractions (padded to `2^k`), and the next evaluation point.
 #[allow(clippy::type_complexity)]
-fn batch_prove_layer<F, P>(
-	provers: Vec<FracAddCheckProver<P>>,
+fn batch_prove_layer<'a, A, F, P>(
+	provers: Vec<FracAddCheckProver<'a, A, P>>,
 	claimed_fractions: Vec<(F, F)>,
 	eval_point: Vec<F>,
 	k: usize,
 	channel: &mut impl IPProverChannel<F>,
-) -> (Vec<FracAddCheckProver<P>>, Vec<(F, F)>, Vec<F>)
+) -> (Vec<FracAddCheckProver<'a, A, P>>, Vec<(F, F)>, Vec<F>)
 where
+	A: Allocator,
 	F: Field,
 	P: PackedField<Scalar = F>,
 {
 	// Build a fractional-addition MLE-check prover per instance, seeded with a claim at the content
 	// coordinates.
+	let alloc = provers[0].alloc;
 	let inner_coords = eval_point[k..].to_vec();
 	let (layer_provers, next_provers): (Vec<_>, Vec<_>) = iter::zip(provers, &claimed_fractions)
 		.map(|(prover, &(num, den))| {
@@ -625,7 +650,7 @@ where
 		.unzip();
 
 	let (next_fractions, next_point) =
-		reduce_layer::<F, P, _>(layer_provers, eval_point, k, channel);
+		reduce_layer::<A, F, P, _>(alloc, layer_provers, eval_point, k, channel);
 
 	let next_provers = next_provers.into_iter().flatten().collect();
 
@@ -645,19 +670,26 @@ mod tests {
 	use binius_utils::checked_arithmetics::log2_ceil_usize;
 
 	type StdChallenger = HasherChallenger<sha2::Sha256>;
+	use binius_compute::GlobalAllocator;
 	use rand::prelude::*;
 
 	use super::*;
+	use crate::sumcheck::mle_store::pooled_copy;
 
 	fn test_frac_add_check_prove_verify_helper<P: PackedField>(n: usize, k: usize) {
 		let mut rng = StdRng::seed_from_u64(0);
+		let alloc = GlobalAllocator;
 
 		// 1. Create random witness with log_len = n + k
 		let witness_num = random_field_buffer::<P>(&mut rng, n + k);
 		let witness_den = random_field_buffer::<P>(&mut rng, n + k);
 
 		// 2. Create prover (computes fractional-add layers)
-		let (prover, sums) = FracAddCheckProver::new(k, (witness_num.clone(), witness_den.clone()));
+		let (prover, sums) = FracAddCheckProver::new(
+			k,
+			&alloc,
+			(pooled_copy(&alloc, &witness_num), pooled_copy(&alloc, &witness_den)),
+		);
 
 		// 3. Generate random n-dimensional challenge point
 		let eval_point = random_scalars::<P::Scalar>(&mut rng, n);
@@ -715,14 +747,18 @@ mod tests {
 
 	fn test_frac_add_check_layer_computation_helper<P: PackedField>(n: usize, k: usize) {
 		let mut rng = StdRng::seed_from_u64(0);
+		let alloc = GlobalAllocator;
 
 		// Create random witness with log_len = n + k
 		let witness_num = random_field_buffer::<P>(&mut rng, n + k);
 		let witness_den = random_field_buffer::<P>(&mut rng, n + k);
 
 		// Create prover (computes fractional-add layers)
-		let (_prover, sums) =
-			FracAddCheckProver::new(k, (witness_num.clone(), witness_den.clone()));
+		let (_prover, sums) = FracAddCheckProver::new(
+			k,
+			&alloc,
+			(pooled_copy(&alloc, &witness_num), pooled_copy(&alloc, &witness_den)),
+		);
 
 		// For each index i in the sums layer, verify it equals the fractional sum of witness values
 		// at indices i + z * 2^n for z in 0..2^k (strided access, not contiguous)
@@ -790,6 +826,7 @@ mod tests {
 	/// (0-variate).
 	fn test_batch_prove_verify_helper<P: PackedField>(n_layers: usize, n_provers: usize) {
 		let mut rng = StdRng::seed_from_u64(42);
+		let alloc = GlobalAllocator;
 
 		let log_n_provers = log2_ceil_usize(n_provers);
 
@@ -805,7 +842,13 @@ mod tests {
 
 		let (provers, individual_sums): (Vec<_>, Vec<_>) = witnesses
 			.iter()
-			.map(|witness| FracAddCheckProver::new(n_layers, witness.clone()))
+			.map(|witness| {
+				FracAddCheckProver::new(
+					n_layers,
+					&alloc,
+					(pooled_copy(&alloc, &witness.0), pooled_copy(&alloc, &witness.1)),
+				)
+			})
 			.unzip();
 
 		// Fractions are 0-variate (scalars): just get the single (num, den) value.
@@ -916,6 +959,7 @@ mod tests {
 		content_len: usize,
 	) {
 		let mut rng = StdRng::seed_from_u64(7);
+		let alloc = GlobalAllocator;
 
 		let log_n_provers = log2_ceil_usize(n_provers);
 
@@ -932,7 +976,13 @@ mod tests {
 
 		let (provers, individual_sums): (Vec<_>, Vec<_>) = witnesses
 			.iter()
-			.map(|witness| FracAddCheckProver::new(n_layers, witness.clone()))
+			.map(|witness| {
+				FracAddCheckProver::new(
+					n_layers,
+					&alloc,
+					(pooled_copy(&alloc, &witness.0), pooled_copy(&alloc, &witness.1)),
+				)
+			})
 			.unzip();
 
 		// Shared content point; each claimed fraction is its multilinears evaluated there.

--- a/crates/ip-prover/src/logup_star/final_layer.rs
+++ b/crates/ip-prover/src/logup_star/final_layer.rs
@@ -13,6 +13,7 @@
 //!
 //! This is the prover mirror of the verifier's final layer in [`binius_ip::logup_star`].
 
+use binius_compute::Allocator;
 use binius_field::{Field, PackedField};
 use binius_math::{FieldBuffer, inner_product::inner_product_par, line::extrapolate_line};
 
@@ -21,7 +22,7 @@ use crate::{
 	fracaddcheck::{FracAddCheckProver, FracEvalClaim},
 	sumcheck::{
 		batch::batch_prove, bivariate_product_evaluator::BivariateProductEvaluator,
-		round_evaluator::SumcheckRoundEvaluator,
+		mle_store::pooled_copy, round_evaluator::SumcheckRoundEvaluator,
 	},
 };
 
@@ -74,20 +75,22 @@ pub struct FinalLayerOutput<F> {
 /// * `table` - The table `T` over the `m`-variable cube.
 /// * `channel` - The prover channel.
 #[tracing::instrument(skip_all, level = "debug", name = "logup* final layer")]
-pub fn prove_final_layer<F, P>(
+pub fn prove_final_layer<'a, A, F, P>(
 	eval_claim: F,
-	table_prover: FracAddCheckProver<P>,
+	table_prover: FracAddCheckProver<'a, A, P>,
 	layer1: FracEvalClaim<F>,
 	pushforward: &FieldBuffer<P>,
 	table: &FieldBuffer<P>,
 	channel: &mut impl IPProverChannel<F>,
 ) -> FinalLayerOutput<F>
 where
+	A: Allocator,
 	F: Field,
 	P: PackedField<Scalar = F>,
 {
 	// Both layer-1 claims share the point Z.
 	debug_assert_eq!(layer1.0.point, layer1.1.point, "layer-1 claims must share the point");
+	let alloc = table_prover.alloc;
 
 	// S_1, S_2: the fractional-addition numerator/denominator, weighted by eq(.; Z).
 	//
@@ -128,12 +131,12 @@ where
 
 	// S_3a, S_3b: each half is a bivariate product over the shared Y column and the pushed T
 	// column.
-	let t_0_col = prover.push_owned_column(t_0);
-	let t_1_col = prover.push_owned_column(t_1);
+	let t_0_col = prover.push_owned_column(pooled_copy(alloc, &t_0));
+	let t_1_col = prover.push_owned_column(pooled_copy(alloc, &t_1));
 	let product_0 = BivariateProductEvaluator::new([y_0_col, t_0_col]);
-	prover.add_evaluator(e_0, Box::new(product_0) as Box<dyn SumcheckRoundEvaluator<F, P>>);
+	prover.add_evaluator(e_0, Box::new(product_0) as Box<dyn SumcheckRoundEvaluator<A, F, P> + 'a>);
 	let product_1 = BivariateProductEvaluator::new([y_1_col, t_1_col]);
-	prover.add_evaluator(e_1, Box::new(product_1) as Box<dyn SumcheckRoundEvaluator<F, P>>);
+	prover.add_evaluator(e_1, Box::new(product_1) as Box<dyn SumcheckRoundEvaluator<A, F, P> + 'a>);
 
 	// Drive the one shared-store sumcheck.
 	//

--- a/crates/ip-prover/src/logup_star/final_layer.rs
+++ b/crates/ip-prover/src/logup_star/final_layer.rs
@@ -13,16 +13,18 @@
 //!
 //! This is the prover mirror of the verifier's final layer in [`binius_ip::logup_star`].
 
-use binius_compute::Allocator;
+use binius_compute::{Allocator, VecLike};
 use binius_field::{Field, PackedField};
-use binius_math::{FieldBuffer, inner_product::inner_product_par, line::extrapolate_line};
+use binius_math::{
+	FieldBuffer, FieldVec, inner_product::inner_product_par, line::extrapolate_line,
+};
 
 use crate::{
 	channel::IPProverChannel,
 	fracaddcheck::{FracAddCheckProver, FracEvalClaim},
 	sumcheck::{
 		batch::batch_prove, bivariate_product_evaluator::BivariateProductEvaluator,
-		mle_store::pooled_copy, round_evaluator::SumcheckRoundEvaluator,
+		round_evaluator::SumcheckRoundEvaluator,
 	},
 };
 
@@ -118,8 +120,8 @@ where
 	// Y_0, Y_1 are already store columns (the fractional numerator halves), so only the table
 	// halves T_0, T_1 are pushed as new columns. Only Y_0 is needed here, to form e_0; e_1 follows
 	// as e - e_0.
-	let [y_0, _y_1] = split_halves(pushforward);
-	let [t_0, t_1] = split_halves(table);
+	let [y_0, _y_1] = split_halves(alloc, pushforward);
+	let [t_0, t_1] = split_halves(alloc, table);
 
 	// e_0 is the first half's product sum.
 	// Only e_0 is sent, since the verifier recovers e_1 = e - e_0.
@@ -131,8 +133,8 @@ where
 
 	// S_3a, S_3b: each half is a bivariate product over the shared Y column and the pushed T
 	// column.
-	let t_0_col = prover.push_owned_column(pooled_copy(alloc, &t_0));
-	let t_1_col = prover.push_owned_column(pooled_copy(alloc, &t_1));
+	let t_0_col = prover.push_owned_column(t_0);
+	let t_1_col = prover.push_owned_column(t_1);
 	let product_0 = BivariateProductEvaluator::new([y_0_col, t_0_col]);
 	prover.add_evaluator(e_0, Box::new(product_0) as Box<dyn SumcheckRoundEvaluator<A, F, P> + 'a>);
 	let product_1 = BivariateProductEvaluator::new([y_1_col, t_1_col]);
@@ -172,11 +174,20 @@ where
 /// Split a multilinear on its highest variable into owned low and high halves.
 ///
 /// The low half fixes the highest variable to 0, the high half to 1.
-fn split_halves<P: PackedField>(buffer: &FieldBuffer<P>) -> [FieldBuffer<P>; 2] {
-	// split_half_ref borrows the two halves; copy each into an owned buffer for the sub-provers.
+fn split_halves<A: Allocator, P: PackedField>(
+	alloc: &A,
+	buffer: &FieldBuffer<P>,
+) -> [FieldVec<P, A>; 2] {
+	// split_half_ref borrows the two halves; copy each straight into an allocator buffer for the
+	// sub-provers, so the split is a single copy rather than a `Vec` build followed by a pooled
+	// copy.
 	let (low, high) = buffer.split_half_ref();
+	let mut low_data = alloc.alloc::<P>(low.as_ref().len());
+	low_data.extend_from_slice(low.as_ref());
+	let mut high_data = alloc.alloc::<P>(high.as_ref().len());
+	high_data.extend_from_slice(high.as_ref());
 	[
-		FieldBuffer::new(low.log_len(), low.as_ref().into()),
-		FieldBuffer::new(high.log_len(), high.as_ref().into()),
+		FieldBuffer::new(low.log_len(), low_data),
+		FieldBuffer::new(high.log_len(), high_data),
 	]
 }

--- a/crates/ip-prover/src/logup_star/prove.rs
+++ b/crates/ip-prover/src/logup_star/prove.rs
@@ -170,21 +170,15 @@ where
 	let circuits_guard = tracing::debug_span!("Build fracadd circuits").entered();
 	let (looker_provers, looker_roots): (Vec<_>, Vec<_>) = std::iter::zip(lookers, numerators)
 		.map(|(looker, numerator)| {
-			let den = witness::looker_denominator::<F, P>(c, looker.index);
-			let (prover, root) = FracAddCheckProver::new(
-				n,
-				alloc,
-				(pooled_copy(alloc, &numerator), pooled_copy(alloc, &den)),
-			);
+			let den = witness::looker_denominator::<A, F, P>(alloc, c, looker.index);
+			let (prover, root) =
+				FracAddCheckProver::new(n, alloc, (pooled_copy(alloc, &numerator), den));
 			(prover, (root.0.get(0), root.1.get(0)))
 		})
 		.unzip();
-	let table_den = witness::table_denominator::<F, P>(c, m);
-	let (table_prover, table_root) = FracAddCheckProver::new(
-		m,
-		alloc,
-		(pooled_copy(alloc, pushforward), pooled_copy(alloc, &table_den)),
-	);
+	let table_den = witness::table_denominator::<A, F, P>(alloc, c, m);
+	let (table_prover, table_root) =
+		FracAddCheckProver::new(m, alloc, (pooled_copy(alloc, pushforward), table_den));
 	let num_r = table_root.0.get(0);
 	let den_r = table_root.1.get(0);
 
@@ -206,8 +200,8 @@ where
 		log_lookers,
 		alloc,
 		(
-			pooled_copy(alloc, &FieldBuffer::<P>::from_values(&root_nums)),
-			pooled_copy(alloc, &FieldBuffer::<P>::from_values(&root_dens)),
+			FieldBuffer::<P>::from_values_in(alloc, &root_nums),
+			FieldBuffer::<P>::from_values_in(alloc, &root_dens),
 		),
 	);
 	let num_l = top_root.0.get(0);

--- a/crates/ip-prover/src/logup_star/prove.rs
+++ b/crates/ip-prover/src/logup_star/prove.rs
@@ -2,6 +2,7 @@
 
 //! The top-level logUp* proving routine.
 
+use binius_compute::Allocator;
 use binius_field::{BinaryField, Divisible, Field, PackedField};
 use binius_ip::{MultilinearEvalClaim, logup_star::LogupOutput};
 use binius_math::{FieldBuffer, univariate::evaluate_univariate};
@@ -14,6 +15,7 @@ use super::{
 use crate::{
 	channel::IPProverChannel,
 	fracaddcheck::{self, FracAddCheckProver, FracEvalClaim},
+	sumcheck::mle_store::pooled_copy,
 };
 
 /// Prove a logUp* indexed-lookup reduction.
@@ -61,12 +63,14 @@ pub struct Looker<'a, F> {
 	pub eval_claim: F,
 }
 
-pub fn prove<F, P>(
+pub fn prove<A, F, P>(
+	alloc: &A,
 	table: &FieldBuffer<P>,
 	lookers: &[Looker<'_, F>],
 	channel: &mut impl IPProverChannel<F>,
 ) -> LogupOutput<F>
 where
+	A: Allocator,
 	F: BinaryField<Underlier: Divisible<u64>>,
 	P: PackedField<Scalar = F>,
 {
@@ -102,7 +106,7 @@ where
 
 	// The self-contained prover commits nothing.
 	// It runs the reduction over the witnesses directly.
-	prove_reduction(table, lookers, combined_eval_claim, numerators, &pushforward, channel)
+	prove_reduction(alloc, table, lookers, combined_eval_claim, numerators, &pushforward, channel)
 }
 
 /// Run the logUp* reduction over the pre-built witnesses `numerators` and pushforward `Y`.
@@ -135,7 +139,8 @@ where
 	name = "logup* reduction",
 	fields(n_lookers = lookers.len(), table_n_vars = table.log_len())
 )]
-pub fn prove_reduction<F, P>(
+pub fn prove_reduction<A, F, P>(
+	alloc: &A,
 	table: &FieldBuffer<P>,
 	lookers: &[Looker<'_, F>],
 	eval_claim: F,
@@ -144,6 +149,7 @@ pub fn prove_reduction<F, P>(
 	channel: &mut impl IPProverChannel<F>,
 ) -> LogupOutput<F>
 where
+	A: Allocator,
 	F: BinaryField<Underlier: Divisible<u64>>,
 	P: PackedField<Scalar = F>,
 {
@@ -165,13 +171,20 @@ where
 	let (looker_provers, looker_roots): (Vec<_>, Vec<_>) = std::iter::zip(lookers, numerators)
 		.map(|(looker, numerator)| {
 			let den = witness::looker_denominator::<F, P>(c, looker.index);
-			let (prover, root) = FracAddCheckProver::new(n, (numerator, den));
+			let (prover, root) = FracAddCheckProver::new(
+				n,
+				alloc,
+				(pooled_copy(alloc, &numerator), pooled_copy(alloc, &den)),
+			);
 			(prover, (root.0.get(0), root.1.get(0)))
 		})
 		.unzip();
 	let table_den = witness::table_denominator::<F, P>(c, m);
-	let (table_prover, table_root) =
-		FracAddCheckProver::new(m, (FieldBuffer::clone(pushforward), table_den));
+	let (table_prover, table_root) = FracAddCheckProver::new(
+		m,
+		alloc,
+		(pooled_copy(alloc, pushforward), pooled_copy(alloc, &table_den)),
+	);
 	let num_r = table_root.0.get(0);
 	let den_r = table_root.1.get(0);
 
@@ -191,7 +204,11 @@ where
 	root_dens.resize(1 << log_lookers, F::ONE);
 	let (top_prover, top_root) = FracAddCheckProver::new(
 		log_lookers,
-		(FieldBuffer::<P>::from_values(&root_nums), FieldBuffer::<P>::from_values(&root_dens)),
+		alloc,
+		(
+			pooled_copy(alloc, &FieldBuffer::<P>::from_values(&root_nums)),
+			pooled_copy(alloc, &FieldBuffer::<P>::from_values(&root_dens)),
+		),
 	);
 	let num_l = top_root.0.get(0);
 	let den_l = top_root.1.get(0);
@@ -279,6 +296,7 @@ const fn root_claim<F: Field>(num: F, den: F) -> FracEvalClaim<F> {
 
 #[cfg(test)]
 mod tests {
+	use binius_compute::GlobalAllocator;
 	use binius_field::{
 		BinaryField1b, ExtensionField, Field,
 		arch::{OptimalB128, OptimalPackedB128},
@@ -333,6 +351,7 @@ mod tests {
 
 	fn check_prove_verify(n: usize, m: usize, seed: u64) {
 		let mut rng = StdRng::seed_from_u64(seed);
+		let alloc = GlobalAllocator;
 		let (table, index, eval_point, eq_r, eval_claim) = random_instance(&mut rng, n, m);
 
 		// Prove, then replay the transcript through the verifier.
@@ -342,7 +361,8 @@ mod tests {
 			eval_point: &eval_point,
 			eval_claim,
 		};
-		let prover_out = prove::<F, P>(&table, &[looker], &mut prover_transcript);
+		let prover_out =
+			prove::<GlobalAllocator, F, P>(&alloc, &table, &[looker], &mut prover_transcript);
 
 		let mut verifier_transcript = prover_transcript.into_verifier();
 		let looker_claim = logup_star::LookerClaim {
@@ -413,6 +433,7 @@ mod tests {
 	#[test]
 	fn test_verifier_rejects_wrong_eval_claim() {
 		let mut rng = StdRng::seed_from_u64(3);
+		let alloc = GlobalAllocator;
 		let (table, index, eval_point, _eq_r, eval_claim) = random_instance(&mut rng, 5, 3);
 
 		// Prove a false statement by perturbing the looked-up evaluation.
@@ -423,7 +444,7 @@ mod tests {
 			eval_point: &eval_point,
 			eval_claim: wrong_claim,
 		};
-		prove::<F, P>(&table, &[looker], &mut prover_transcript);
+		prove::<GlobalAllocator, F, P>(&alloc, &table, &[looker], &mut prover_transcript);
 
 		// The product-check inconsistency must surface as a verification failure.
 		let mut verifier_transcript = prover_transcript.into_verifier();
@@ -444,6 +465,7 @@ mod tests {
 	#[test]
 	fn test_multi_looker_round_trip() {
 		let mut rng = StdRng::seed_from_u64(11);
+		let alloc = GlobalAllocator;
 		let (n, m) = (5, 3);
 		let n_lookers = 3usize;
 
@@ -473,7 +495,8 @@ mod tests {
 				eval_claim: *eval_claim,
 			})
 			.collect::<Vec<_>>();
-		let prover_out = prove::<F, P>(&table, &prover_lookers, &mut prover_transcript);
+		let prover_out =
+			prove::<GlobalAllocator, F, P>(&alloc, &table, &prover_lookers, &mut prover_transcript);
 
 		let mut verifier_transcript = prover_transcript.into_verifier();
 		let looker_claims = lookers
@@ -509,6 +532,7 @@ mod tests {
 	#[should_panic(expected = "table must have at least one variable")]
 	fn test_zero_variable_table_panics() {
 		let mut rng = StdRng::seed_from_u64(0);
+		let alloc = GlobalAllocator;
 
 		// A zero-variable table has a single entry and no variable for the GKR to split on.
 		// The precondition assertion must fire before any transcript interaction.
@@ -519,13 +543,14 @@ mod tests {
 			eval_point: &[],
 			eval_claim: F::ZERO,
 		};
-		let _ = prove::<F, P>(&table, &[looker], &mut transcript);
+		let _ = prove::<GlobalAllocator, F, P>(&alloc, &table, &[looker], &mut transcript);
 	}
 
 	#[test]
 	#[should_panic(expected = "index column has 3 entries but 16 were expected for 4 variables")]
 	fn test_rejects_index_length_mismatch() {
 		let mut rng = StdRng::seed_from_u64(0);
+		let alloc = GlobalAllocator;
 		let table = random_field_buffer::<P>(&mut rng, 3);
 		let eval_point = random_scalars::<F>(&mut rng, 4);
 		let mut transcript = ProverTranscript::new(StdChallenger::default());
@@ -536,13 +561,14 @@ mod tests {
 			eval_point: &eval_point,
 			eval_claim: F::ZERO,
 		};
-		let _ = prove::<F, P>(&table, &[looker], &mut transcript);
+		let _ = prove::<GlobalAllocator, F, P>(&alloc, &table, &[looker], &mut transcript);
 	}
 
 	#[test]
 	#[should_panic(expected = "every index entry must be less than the table size")]
 	fn test_out_of_range_index_panics() {
 		let mut rng = StdRng::seed_from_u64(0);
+		let alloc = GlobalAllocator;
 		let table = random_field_buffer::<P>(&mut rng, 2);
 		let eval_point = random_scalars::<F>(&mut rng, 1);
 		let mut transcript = ProverTranscript::new(StdChallenger::default());
@@ -554,6 +580,6 @@ mod tests {
 			eval_point: &eval_point,
 			eval_claim: F::ZERO,
 		};
-		let _ = prove::<F, P>(&table, &[looker], &mut transcript);
+		let _ = prove::<GlobalAllocator, F, P>(&alloc, &table, &[looker], &mut transcript);
 	}
 }

--- a/crates/ip-prover/src/logup_star/witness.rs
+++ b/crates/ip-prover/src/logup_star/witness.rs
@@ -11,8 +11,9 @@
 
 use std::iter;
 
+use binius_compute::{Allocator, VecLike};
 use binius_field::{BinaryField, Divisible, Field, PackedField, util::powers};
-use binius_math::{FieldBuffer, multilinear::eq::scaled_eq_ind_partial_eval_into};
+use binius_math::{FieldBuffer, FieldVec, multilinear::eq::scaled_eq_ind_partial_eval_into};
 use binius_utils::rayon::{current_num_threads, prelude::*};
 
 use super::prove::Looker;
@@ -217,8 +218,9 @@ where
 /// # Preconditions
 ///
 /// * `index.len()` is a power of two.
-pub fn looker_denominator<F, P>(c: F, index: &[usize]) -> FieldBuffer<P>
+pub fn looker_denominator<A, F, P>(alloc: &A, c: F, index: &[usize]) -> FieldVec<P, A>
 where
+	A: Allocator,
 	F: BinaryField<Underlier: Divisible<u64>>,
 	P: PackedField<Scalar = F>,
 {
@@ -226,12 +228,20 @@ where
 	let log_len = index.len().ilog2() as usize;
 
 	// One denominator per row: c minus the row's embedded index value.
-	// Subtract a full word at a time: one packed subtraction per word, built in parallel.
+	// Subtract a full word at a time: one packed subtraction per word, built in parallel straight
+	// into the allocator's buffer.
+	let packed_len = 1 << log_len.saturating_sub(P::LOG_WIDTH);
 	let c_packed = P::broadcast(c);
-	let packed = index
-		.par_chunks(P::WIDTH)
-		.map(|chunk| c_packed - P::from_scalars(chunk.iter().copied().map(embed_position::<F>)))
-		.collect::<Vec<_>>();
+	let mut packed = alloc.alloc::<P>(packed_len);
+	packed
+		.spare_capacity_mut()
+		.par_iter_mut()
+		.zip(index.par_chunks(P::WIDTH))
+		.for_each(|(slot, chunk)| {
+			slot.write(c_packed - P::from_scalars(chunk.iter().copied().map(embed_position::<F>)));
+		});
+	// Safety: every packed slot is written exactly once by the parallel loop above.
+	unsafe { packed.set_len(packed_len) };
 
 	FieldBuffer::new(log_len, packed)
 }
@@ -239,8 +249,9 @@ where
 /// Build the table denominator `c - J` over the `m`-variable table cube.
 ///
 /// Entry `j` is `c - iota(j)`, the logUp denominator for table position `j`.
-pub fn table_denominator<F, P>(c: F, table_n_vars: usize) -> FieldBuffer<P>
+pub fn table_denominator<A, F, P>(alloc: &A, c: F, table_n_vars: usize) -> FieldVec<P, A>
 where
+	A: Allocator,
 	F: BinaryField<Underlier: Divisible<u64>>,
 	P: PackedField<Scalar = F>,
 {
@@ -248,7 +259,7 @@ where
 	let values = (0..1usize << table_n_vars)
 		.map(|j| c - embed_position::<F>(j))
 		.collect::<Vec<_>>();
-	FieldBuffer::from_values(&values)
+	FieldBuffer::from_values_in(alloc, &values)
 }
 
 /// Build the pushforward `Y = I_* eq_r` over the `m`-variable table cube.
@@ -285,6 +296,7 @@ where
 
 #[cfg(test)]
 mod tests {
+	use binius_compute::GlobalAllocator;
 	use binius_field::{
 		Field,
 		arch::{OptimalB128, OptimalPackedB128},
@@ -420,14 +432,14 @@ mod tests {
 		let c = F::new(7);
 
 		// n = 0: a single row, so the packed word carries one meaningful lane.
-		let one_row = looker_denominator::<F, P>(c, &[3])
+		let one_row = looker_denominator::<_, F, P>(&GlobalAllocator, c, &[3])
 			.iter_scalars()
 			.collect::<Vec<_>>();
 		assert_eq!(one_row, denominator_reference(c, &[3]));
 
 		// n = 2: four rows with distinct embedded positions.
 		let index = [0usize, 1, 2, 5];
-		let four_rows = looker_denominator::<F, P>(c, &index)
+		let four_rows = looker_denominator::<_, F, P>(&GlobalAllocator, c, &index)
 			.iter_scalars()
 			.collect::<Vec<_>>();
 		assert_eq!(four_rows, denominator_reference(c, &index));
@@ -446,7 +458,9 @@ mod tests {
 				.map(|_| rng.random_range(0..(1usize << 12)))
 				.collect::<Vec<_>>();
 
-			let got = looker_denominator::<F, P>(c, &index).iter_scalars().collect::<Vec<_>>();
+			let got = looker_denominator::<_, F, P>(&GlobalAllocator, c, &index)
+				.iter_scalars()
+				.collect::<Vec<_>>();
 			prop_assert_eq!(got, denominator_reference(c, &index));
 		}
 	}

--- a/crates/ip-prover/src/prodcheck.rs
+++ b/crates/ip-prover/src/prodcheck.rs
@@ -6,7 +6,7 @@ use binius_compute::{Allocator, VecLike};
 use binius_field::{Field, PackedField};
 use binius_ip::{mlecheck, prodcheck::MultilinearEvalClaim};
 use binius_math::{
-	FieldBuffer, line::extrapolate_line_packed, multilinear::eq::eq_ind_partial_eval,
+	FieldBuffer, FieldVec, line::extrapolate_line_packed, multilinear::eq::eq_ind_partial_eval,
 };
 use binius_utils::rayon::prelude::*;
 use itertools::izip;
@@ -16,7 +16,6 @@ use crate::{
 	sumcheck::{
 		ProveSingleOutput, bivariate_product_mle,
 		common::{MleCheckProver, SumcheckProver},
-		mle_store::{PooledColumn, pooled_copy},
 		prove_single_mlecheck,
 	},
 };
@@ -29,9 +28,24 @@ pub struct ProdcheckProver<'a, A: Allocator, P: PackedField> {
 	/// Product layers from largest (original witness) to second-smallest.
 	/// `layers[0]` is the original witness. The final products layer is returned
 	/// separately from the constructor.
-	layers: Vec<PooledColumn<A, P>>,
+	layers: Vec<FieldVec<P, A>>,
 	/// Allocator the product layers are drawn from.
 	alloc: &'a A,
+}
+
+// A manual `Clone` impl (rather than `#[derive(Clone)]`) so the bound lands on the layer buffer
+// `A::Vec<P>` rather than on `A` and `P`: a derive would require `A: Clone` yet still fail to clone
+// the layers unless `A::Vec<P>: Clone`. Holds for the `Vec`-backed `GlobalAllocator`.
+impl<A: Allocator, P: PackedField> Clone for ProdcheckProver<'_, A, P>
+where
+	A::Vec<P>: Clone,
+{
+	fn clone(&self) -> Self {
+		Self {
+			layers: self.layers.clone(),
+			alloc: self.alloc,
+		}
+	}
 }
 
 impl<'a, A, F, P> ProdcheckProver<'a, A, P>
@@ -52,7 +66,7 @@ where
 	///
 	/// # Preconditions
 	/// * `witness.log_len() >= k`
-	pub fn new(k: usize, alloc: &'a A, witness: PooledColumn<A, P>) -> (Self, PooledColumn<A, P>) {
+	pub fn new(k: usize, alloc: &'a A, witness: FieldVec<P, A>) -> (Self, FieldVec<P, A>) {
 		assert!(witness.log_len() >= k); // precondition
 
 		let mut layers = Vec::with_capacity(k + 1);
@@ -87,7 +101,7 @@ where
 	///
 	/// # Preconditions
 	/// * `self.n_layers() == 1`
-	pub fn into_final_layer(mut self) -> PooledColumn<A, P> {
+	pub fn into_final_layer(mut self) -> FieldVec<P, A> {
 		assert_eq!(self.layers.len(), 1, "precondition: exactly one remaining layer");
 		self.layers.pop().expect("layers has exactly one element")
 	}
@@ -404,13 +418,13 @@ fn batch_prove_layer<'a, A: Allocator, F: Field, P: PackedField<Scalar = F>>(
 		.map(|(&v0, &v1, &eq_i)| v0 * v1 * eq_i)
 		.sum();
 
-	// Selector rounds: pack eval pairs into FieldBuffers and use a single prover.
-	let buffer_0 = FieldBuffer::<P>::from_values(&vals_0);
-	let buffer_1 = FieldBuffer::<P>::from_values(&vals_1);
-
+	// Selector rounds: pack eval pairs straight into allocator buffers and use a single prover.
 	let outer_prover = bivariate_product_mle::new(
 		alloc,
-		[pooled_copy(alloc, &buffer_0), pooled_copy(alloc, &buffer_1)],
+		[
+			FieldBuffer::<P>::from_values_in(alloc, &vals_0),
+			FieldBuffer::<P>::from_values_in(alloc, &vals_1),
+		],
 		outer_coords.to_vec(),
 		eval,
 	);
@@ -460,7 +474,6 @@ mod tests {
 	use rand::prelude::*;
 
 	use super::*;
-	use crate::sumcheck::mle_store::pooled_copy;
 
 	/// Combines the per-input-prover evals returned by [`batch_prove`] into the single
 	/// [`MultilinearEvalClaim`] the verifier produces: the eq(selector)-weighted sum over the
@@ -488,7 +501,7 @@ mod tests {
 		let witness = random_field_buffer::<P>(&mut rng, n + k);
 
 		// 2. Create prover (computes product layers)
-		let (prover, products) = ProdcheckProver::new(k, &alloc, pooled_copy(&alloc, &witness));
+		let (prover, products) = ProdcheckProver::new(k, &alloc, witness.clone());
 
 		// 3. Generate random n-dimensional challenge point
 		let eval_point = random_scalars::<P::Scalar>(&mut rng, n);
@@ -534,7 +547,7 @@ mod tests {
 		let witness = random_field_buffer::<P>(&mut rng, n + k);
 
 		// Create prover (computes product layers)
-		let (_prover, products) = ProdcheckProver::new(k, &alloc, pooled_copy(&alloc, &witness));
+		let (_prover, products) = ProdcheckProver::new(k, &alloc, witness.clone());
 
 		// For each index i in the products layer, verify it equals the product of witness values
 		// at indices i + z * 2^n for z in 0..2^k (strided access, not contiguous)
@@ -578,7 +591,7 @@ mod tests {
 		// Create ProdcheckProver for each
 		let provers_and_products: Vec<_> = witnesses
 			.iter()
-			.map(|witness| ProdcheckProver::new(n_layers, &alloc, pooled_copy(&alloc, witness)))
+			.map(|witness| ProdcheckProver::new(n_layers, &alloc, witness.clone()))
 			.collect();
 
 		let (provers, individual_products): (Vec<_>, Vec<_>) =
@@ -699,7 +712,7 @@ mod tests {
 
 		let provers_and_products: Vec<_> = witnesses
 			.iter()
-			.map(|witness| ProdcheckProver::new(n_layers, &alloc, pooled_copy(&alloc, witness)))
+			.map(|witness| ProdcheckProver::new(n_layers, &alloc, witness.clone()))
 			.collect();
 
 		let (provers, individual_products): (Vec<_>, Vec<_>) =

--- a/crates/ip-prover/src/prodcheck.rs
+++ b/crates/ip-prover/src/prodcheck.rs
@@ -2,6 +2,7 @@
 
 use std::iter;
 
+use binius_compute::{Allocator, VecLike};
 use binius_field::{Field, PackedField};
 use binius_ip::{mlecheck, prodcheck::MultilinearEvalClaim};
 use binius_math::{
@@ -15,6 +16,7 @@ use crate::{
 	sumcheck::{
 		ProveSingleOutput, bivariate_product_mle,
 		common::{MleCheckProver, SumcheckProver},
+		mle_store::{PooledColumn, pooled_copy},
 		prove_single_mlecheck,
 	},
 };
@@ -23,16 +25,18 @@ use crate::{
 ///
 /// This prover reduces the claim that a multilinear polynomial evaluates to a product over a
 /// Boolean hypercube to a single multilinear evaluation claim.
-#[derive(Clone)]
-pub struct ProdcheckProver<P: PackedField> {
+pub struct ProdcheckProver<'a, A: Allocator, P: PackedField> {
 	/// Product layers from largest (original witness) to second-smallest.
 	/// `layers[0]` is the original witness. The final products layer is returned
 	/// separately from the constructor.
-	layers: Vec<FieldBuffer<P>>,
+	layers: Vec<PooledColumn<A, P>>,
+	/// Allocator the product layers are drawn from.
+	alloc: &'a A,
 }
 
-impl<F, P> ProdcheckProver<P>
+impl<'a, A, F, P> ProdcheckProver<'a, A, P>
 where
+	A: Allocator,
 	F: Field,
 	P: PackedField<Scalar = F>,
 {
@@ -48,7 +52,7 @@ where
 	///
 	/// # Preconditions
 	/// * `witness.log_len() >= k`
-	pub fn new(k: usize, witness: FieldBuffer<P>) -> (Self, FieldBuffer<P>) {
+	pub fn new(k: usize, alloc: &'a A, witness: PooledColumn<A, P>) -> (Self, PooledColumn<A, P>) {
 		assert!(witness.log_len() >= k); // precondition
 
 		let mut layers = Vec::with_capacity(k + 1);
@@ -56,19 +60,22 @@ where
 
 		for _ in 0..k {
 			let prev_layer = layers.last().expect("layers is non-empty");
+			let next_log_len = prev_layer.log_len() - 1;
 			let (half_0, half_1) = prev_layer.split_half_ref();
 
-			let next_layer_evals = (half_0.as_ref(), half_1.as_ref())
+			let next_layer_evals: Vec<P> = (half_0.as_ref(), half_1.as_ref())
 				.into_par_iter()
 				.map(|(v0, v1)| *v0 * *v1)
 				.collect();
-			let next_layer = FieldBuffer::new(prev_layer.log_len() - 1, next_layer_evals);
+			let mut next_data = alloc.alloc::<P>(next_layer_evals.len());
+			next_data.extend_from_slice(&next_layer_evals);
+			let next_layer = FieldBuffer::new(next_log_len, next_data);
 
 			layers.push(next_layer);
 		}
 
 		let products = layers.pop().expect("layers has k+1 elements");
-		(Self { layers }, products)
+		(Self { layers, alloc }, products)
 	}
 
 	/// Returns the number of remaining layers to prove.
@@ -80,7 +87,7 @@ where
 	///
 	/// # Preconditions
 	/// * `self.n_layers() == 1`
-	pub fn into_final_layer(mut self) -> FieldBuffer<P> {
+	pub fn into_final_layer(mut self) -> PooledColumn<A, P> {
 		assert_eq!(self.layers.len(), 1, "precondition: exactly one remaining layer");
 		self.layers.pop().expect("layers has exactly one element")
 	}
@@ -93,7 +100,8 @@ where
 	pub fn layer_prover(
 		mut self,
 		claim: MultilinearEvalClaim<F>,
-	) -> (impl MleCheckProver<F>, Option<Self>) {
+	) -> (impl MleCheckProver<F> + 'a, Option<Self>) {
+		let alloc = self.alloc;
 		let layer = self.layers.pop().expect("layers is non-empty");
 
 		let remaining = if self.layers.is_empty() {
@@ -105,7 +113,7 @@ where
 		// The layer has one more variable than the claim point.
 		// Its low and high halves are the two multilinears whose product this layer reduces.
 		// Sharing the buffer between the halves avoids copying this (largest) layer.
-		let prover = bivariate_product_mle::new_split_half(layer, claim.point, claim.eval);
+		let prover = bivariate_product_mle::new_split_half(alloc, layer, claim.point, claim.eval);
 
 		(prover, remaining)
 	}
@@ -177,11 +185,11 @@ pub struct BatchProveOutput<F> {
 ///
 /// After running `n_layers - 1` reduction layers, each prover retains its final (widest) layer.
 /// `provers` pairs each remaining prover with its reduced evaluation at `eval_point`.
-pub struct BatchProveUntilFinalLayerOutput<P: PackedField> {
+pub struct BatchProveUntilFinalLayerOutput<'a, A: Allocator, P: PackedField> {
 	/// The reduced evaluation point shared by all remaining provers.
 	pub eval_point: Vec<P::Scalar>,
 	/// Each remaining prover (with its final layer) paired with its reduced eval at `eval_point`.
-	pub provers: Vec<(P::Scalar, ProdcheckProver<P>)>,
+	pub provers: Vec<(P::Scalar, ProdcheckProver<'a, A, P>)>,
 }
 
 /// Runs a batched product check protocol for multiple independent prodcheck provers.
@@ -238,8 +246,8 @@ pub struct BatchProveUntilFinalLayerOutput<P: PackedField> {
 /// $$
 /// \hat{f}(Y_0, \ldots, Y_{k-1}, X_0, \ldots, X_{m-1}) = \sum_{i \in B_k} \textsf{eq}(i; Y) f_i(X).
 /// $$
-pub fn batch_prove<F: Field, P: PackedField<Scalar = F>>(
-	provers: Vec<ProdcheckProver<P>>,
+pub fn batch_prove<'a, A: Allocator, F: Field, P: PackedField<Scalar = F>>(
+	provers: Vec<ProdcheckProver<'a, A, P>>,
 	claimed_products: Vec<F>,
 	selector_point: Vec<F>,
 	content_point: Vec<F>,
@@ -280,13 +288,13 @@ pub fn batch_prove<F: Field, P: PackedField<Scalar = F>>(
 /// caller splices the retained layers into another reduction.
 ///
 /// Arguments and preconditions are as for [`batch_prove`].
-pub fn batch_prove_until_final_layer<F: Field, P: PackedField<Scalar = F>>(
-	provers: Vec<ProdcheckProver<P>>,
+pub fn batch_prove_until_final_layer<'a, A: Allocator, F: Field, P: PackedField<Scalar = F>>(
+	provers: Vec<ProdcheckProver<'a, A, P>>,
 	claimed_products: Vec<F>,
 	selector_point: Vec<F>,
 	content_point: Vec<F>,
 	channel: &mut impl IPProverChannel<F>,
-) -> BatchProveUntilFinalLayerOutput<P> {
+) -> BatchProveUntilFinalLayerOutput<'a, A, P> {
 	assert!(!provers.is_empty()); // precondition
 	assert_eq!(claimed_products.len(), provers.len()); // precondition
 
@@ -321,14 +329,15 @@ pub fn batch_prove_until_final_layer<F: Field, P: PackedField<Scalar = F>>(
 }
 
 #[allow(clippy::type_complexity)]
-fn batch_prove_layer<F: Field, P: PackedField<Scalar = F>>(
-	provers: Vec<ProdcheckProver<P>>,
+fn batch_prove_layer<'a, A: Allocator, F: Field, P: PackedField<Scalar = F>>(
+	provers: Vec<ProdcheckProver<'a, A, P>>,
 	claimed_products: Vec<F>,
 	eval_point: Vec<F>,
 	k: usize,
 	channel: &mut impl IPProverChannel<F>,
-) -> (Vec<ProdcheckProver<P>>, Vec<F>, Vec<F>) {
+) -> (Vec<ProdcheckProver<'a, A, P>>, Vec<F>, Vec<F>) {
 	// Split eval_point into outer (selector) and inner (content) coordinates.
+	let alloc = provers[0].alloc;
 	let (outer_coords, inner_coords) = eval_point.split_at(k);
 
 	let (mut layer_provers, next_provers): (Vec<_>, Vec<_>) = iter::zip(provers, claimed_products)
@@ -399,8 +408,12 @@ fn batch_prove_layer<F: Field, P: PackedField<Scalar = F>>(
 	let buffer_0 = FieldBuffer::<P>::from_values(&vals_0);
 	let buffer_1 = FieldBuffer::<P>::from_values(&vals_1);
 
-	let outer_prover =
-		bivariate_product_mle::new([buffer_0, buffer_1], outer_coords.to_vec(), eval);
+	let outer_prover = bivariate_product_mle::new(
+		alloc,
+		[pooled_copy(alloc, &buffer_0), pooled_copy(alloc, &buffer_1)],
+		outer_coords.to_vec(),
+		eval,
+	);
 
 	let ProveSingleOutput {
 		multilinear_evals: outer_evals,
@@ -443,9 +456,11 @@ mod tests {
 	use binius_utils::checked_arithmetics::log2_ceil_usize;
 
 	type StdChallenger = HasherChallenger<sha2::Sha256>;
+	use binius_compute::GlobalAllocator;
 	use rand::prelude::*;
 
 	use super::*;
+	use crate::sumcheck::mle_store::pooled_copy;
 
 	/// Combines the per-input-prover evals returned by [`batch_prove`] into the single
 	/// [`MultilinearEvalClaim`] the verifier produces: the eq(selector)-weighted sum over the
@@ -467,12 +482,13 @@ mod tests {
 
 	fn test_prodcheck_prove_verify_helper<P: PackedField>(n: usize, k: usize) {
 		let mut rng = StdRng::seed_from_u64(0);
+		let alloc = GlobalAllocator;
 
 		// 1. Create random witness with log_len = n + k
 		let witness = random_field_buffer::<P>(&mut rng, n + k);
 
 		// 2. Create prover (computes product layers)
-		let (prover, products) = ProdcheckProver::new(k, witness.clone());
+		let (prover, products) = ProdcheckProver::new(k, &alloc, pooled_copy(&alloc, &witness));
 
 		// 3. Generate random n-dimensional challenge point
 		let eval_point = random_scalars::<P::Scalar>(&mut rng, n);
@@ -512,12 +528,13 @@ mod tests {
 
 	fn test_prodcheck_layer_computation_helper<P: PackedField>(n: usize, k: usize) {
 		let mut rng = StdRng::seed_from_u64(0);
+		let alloc = GlobalAllocator;
 
 		// Create random witness with log_len = n + k
 		let witness = random_field_buffer::<P>(&mut rng, n + k);
 
 		// Create prover (computes product layers)
-		let (_prover, products) = ProdcheckProver::new(k, witness.clone());
+		let (_prover, products) = ProdcheckProver::new(k, &alloc, pooled_copy(&alloc, &witness));
 
 		// For each index i in the products layer, verify it equals the product of witness values
 		// at indices i + z * 2^n for z in 0..2^k (strided access, not contiguous)
@@ -549,6 +566,7 @@ mod tests {
 	/// * `n_provers` - Number of provers to batch
 	fn test_batch_prove_verify_helper<P: PackedField>(n_layers: usize, n_provers: usize) {
 		let mut rng = StdRng::seed_from_u64(42);
+		let alloc = GlobalAllocator;
 
 		let log_n_provers = log2_ceil_usize(n_provers);
 
@@ -558,9 +576,9 @@ mod tests {
 			.collect();
 
 		// Create ProdcheckProver for each
-		let provers_and_products: Vec<(ProdcheckProver<P>, FieldBuffer<P>)> = witnesses
+		let provers_and_products: Vec<_> = witnesses
 			.iter()
-			.map(|witness| ProdcheckProver::new(n_layers, witness.clone()))
+			.map(|witness| ProdcheckProver::new(n_layers, &alloc, pooled_copy(&alloc, witness)))
 			.collect();
 
 		let (provers, individual_products): (Vec<_>, Vec<_>) =
@@ -670,6 +688,7 @@ mod tests {
 		content_len: usize,
 	) {
 		let mut rng = StdRng::seed_from_u64(7);
+		let alloc = GlobalAllocator;
 
 		let log_n_provers = log2_ceil_usize(n_provers);
 
@@ -678,9 +697,9 @@ mod tests {
 			.map(|_| random_field_buffer::<P>(&mut rng, content_len + n_layers))
 			.collect();
 
-		let provers_and_products: Vec<(ProdcheckProver<P>, FieldBuffer<P>)> = witnesses
+		let provers_and_products: Vec<_> = witnesses
 			.iter()
-			.map(|witness| ProdcheckProver::new(n_layers, witness.clone()))
+			.map(|witness| ProdcheckProver::new(n_layers, &alloc, pooled_copy(&alloc, witness)))
 			.collect();
 
 		let (provers, individual_products): (Vec<_>, Vec<_>) =

--- a/crates/ip-prover/src/sumcheck/batch.rs
+++ b/crates/ip-prover/src/sumcheck/batch.rs
@@ -258,7 +258,7 @@ mod tests {
 	use rand::prelude::*;
 
 	use super::batch_prove_mle;
-	use crate::sumcheck::{bivariate_product_mle, mle_store::pooled_copy};
+	use crate::sumcheck::bivariate_product_mle;
 
 	fn product_eval_claim<F, P>(
 		multilinear_a: &FieldBuffer<P>,
@@ -301,19 +301,13 @@ mod tests {
 
 		let prover_0 = bivariate_product_mle::new(
 			&alloc,
-			[
-				pooled_copy(&alloc, &multilinear_a_0),
-				pooled_copy(&alloc, &multilinear_b_0),
-			],
+			[multilinear_a_0.clone(), multilinear_b_0.clone()],
 			eval_point.clone(),
 			eval_claim_0,
 		);
 		let prover_1 = bivariate_product_mle::new(
 			&alloc,
-			[
-				pooled_copy(&alloc, &multilinear_a_1),
-				pooled_copy(&alloc, &multilinear_b_1),
-			],
+			[multilinear_a_1.clone(), multilinear_b_1.clone()],
 			eval_point.clone(),
 			eval_claim_1,
 		);

--- a/crates/ip-prover/src/sumcheck/batch.rs
+++ b/crates/ip-prover/src/sumcheck/batch.rs
@@ -254,10 +254,11 @@ mod tests {
 	use binius_transcript::{ProverTranscript, fiat_shamir::HasherChallenger};
 
 	type StdChallenger = HasherChallenger<sha2::Sha256>;
+	use binius_compute::GlobalAllocator;
 	use rand::prelude::*;
 
 	use super::batch_prove_mle;
-	use crate::sumcheck::bivariate_product_mle;
+	use crate::sumcheck::{bivariate_product_mle, mle_store::pooled_copy};
 
 	fn product_eval_claim<F, P>(
 		multilinear_a: &FieldBuffer<P>,
@@ -286,6 +287,7 @@ mod tests {
 
 		let n_vars = 6;
 		let mut rng = StdRng::seed_from_u64(0);
+		let alloc = GlobalAllocator;
 
 		let eval_point = random_scalars::<F>(&mut rng, n_vars);
 
@@ -298,12 +300,20 @@ mod tests {
 		let eval_claim_1 = product_eval_claim(&multilinear_a_1, &multilinear_b_1, &eval_point);
 
 		let prover_0 = bivariate_product_mle::new(
-			[multilinear_a_0.clone(), multilinear_b_0.clone()],
+			&alloc,
+			[
+				pooled_copy(&alloc, &multilinear_a_0),
+				pooled_copy(&alloc, &multilinear_b_0),
+			],
 			eval_point.clone(),
 			eval_claim_0,
 		);
 		let prover_1 = bivariate_product_mle::new(
-			[multilinear_a_1.clone(), multilinear_b_1.clone()],
+			&alloc,
+			[
+				pooled_copy(&alloc, &multilinear_a_1),
+				pooled_copy(&alloc, &multilinear_b_1),
+			],
 			eval_point.clone(),
 			eval_claim_1,
 		);

--- a/crates/ip-prover/src/sumcheck/bivariate_product_evaluator.rs
+++ b/crates/ip-prover/src/sumcheck/bivariate_product_evaluator.rs
@@ -1,12 +1,12 @@
 // Copyright 2026 The Binius Developers
 
+use binius_compute::Allocator;
 use binius_field::{Field, PackedField, WideMul};
 use binius_ip::sumcheck::RoundCoeffs;
-use binius_math::FieldBuffer;
 use itertools::izip;
 
 use super::{
-	mle_store::{ColId, EvaluationChunk, MleStore},
+	mle_store::{ColId, EvaluationChunk, MleStore, PooledColumn},
 	round_evals::WideRoundEvals2,
 	round_evaluator::{SharedSumcheckProver, SumcheckRoundEvaluator},
 };
@@ -36,22 +36,23 @@ impl BivariateProductEvaluator {
 /// the two columns into a fresh [`MleStore`] and drives a single [`BivariateProductEvaluator`]. The
 /// multilinears must have the same number of variables; the returned prover's `finish` emits their
 /// two evaluations in the given order.
-pub fn bivariate_product_prover<F: Field, P: PackedField<Scalar = F>>(
-	multilinears: [FieldBuffer<P>; 2],
+pub fn bivariate_product_prover<'alloc, A: Allocator, F: Field, P: PackedField<Scalar = F>>(
+	alloc: &'alloc A,
+	multilinears: [PooledColumn<A, P>; 2],
 	sum: F,
-) -> SharedSumcheckProver<'static, P, BivariateProductEvaluator> {
+) -> SharedSumcheckProver<'alloc, A, P, BivariateProductEvaluator> {
 	assert_eq!(
 		multilinears[0].log_len(),
 		multilinears[1].log_len(),
 		"multilinears must have equal number of variables"
 	);
 
-	let mut store = MleStore::new(multilinears[0].log_len());
+	let mut store = MleStore::new(multilinears[0].log_len(), alloc);
 	let cols = multilinears.map(|col| store.push_owned(col));
 	SharedSumcheckProver::new(store, [(sum, BivariateProductEvaluator::new(cols))])
 }
 
-impl<F: Field, P: PackedField<Scalar = F>> SumcheckRoundEvaluator<F, P>
+impl<A: Allocator, F: Field, P: PackedField<Scalar = F>> SumcheckRoundEvaluator<A, F, P>
 	for BivariateProductEvaluator
 {
 	fn degree(&self) -> usize {
@@ -89,7 +90,7 @@ impl<F: Field, P: PackedField<Scalar = F>> SumcheckRoundEvaluator<F, P>
 
 	fn interpolate(
 		&self,
-		store: &MleStore<'_, P>,
+		store: &MleStore<'_, A, P>,
 		accum: &[<P as WideMul>::Output],
 		claim: F,
 	) -> RoundCoeffs<F> {
@@ -111,6 +112,7 @@ impl<F: Field, P: PackedField<Scalar = F>> SumcheckRoundEvaluator<F, P>
 
 #[cfg(test)]
 mod tests {
+	use binius_compute::GlobalAllocator;
 	use binius_field::arch::{OptimalB128, OptimalPackedB128};
 	use binius_ip::sumcheck::verify;
 	use binius_math::{
@@ -121,7 +123,7 @@ mod tests {
 	use rand::prelude::*;
 
 	use super::*;
-	use crate::sumcheck::prove::prove_single;
+	use crate::sumcheck::{mle_store::pooled_copy, prove::prove_single};
 
 	type StdChallenger = HasherChallenger<sha2::Sha256>;
 
@@ -135,13 +137,20 @@ mod tests {
 
 		let n_vars = 8;
 		let mut rng = StdRng::seed_from_u64(0);
+		let alloc = GlobalAllocator;
 
 		let multilinear_a = random_field_buffer::<P>(&mut rng, n_vars);
 		let multilinear_b = random_field_buffer::<P>(&mut rng, n_vars);
 		let expected_sum = inner_product_par(&multilinear_a, &multilinear_b);
 
-		let prover =
-			bivariate_product_prover([multilinear_a.clone(), multilinear_b.clone()], expected_sum);
+		let prover = bivariate_product_prover(
+			&alloc,
+			[
+				pooled_copy(&alloc, &multilinear_a),
+				pooled_copy(&alloc, &multilinear_b),
+			],
+			expected_sum,
+		);
 
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 		let output = prove_single(prover, &mut prover_transcript);

--- a/crates/ip-prover/src/sumcheck/bivariate_product_evaluator.rs
+++ b/crates/ip-prover/src/sumcheck/bivariate_product_evaluator.rs
@@ -3,10 +3,11 @@
 use binius_compute::Allocator;
 use binius_field::{Field, PackedField, WideMul};
 use binius_ip::sumcheck::RoundCoeffs;
+use binius_math::FieldVec;
 use itertools::izip;
 
 use super::{
-	mle_store::{ColId, EvaluationChunk, MleStore, PooledColumn},
+	mle_store::{ColId, EvaluationChunk, MleStore},
 	round_evals::WideRoundEvals2,
 	round_evaluator::{SharedSumcheckProver, SumcheckRoundEvaluator},
 };
@@ -38,7 +39,7 @@ impl BivariateProductEvaluator {
 /// two evaluations in the given order.
 pub fn bivariate_product_prover<'alloc, A: Allocator, F: Field, P: PackedField<Scalar = F>>(
 	alloc: &'alloc A,
-	multilinears: [PooledColumn<A, P>; 2],
+	multilinears: [FieldVec<P, A>; 2],
 	sum: F,
 ) -> SharedSumcheckProver<'alloc, A, P, BivariateProductEvaluator> {
 	assert_eq!(
@@ -123,7 +124,7 @@ mod tests {
 	use rand::prelude::*;
 
 	use super::*;
-	use crate::sumcheck::{mle_store::pooled_copy, prove::prove_single};
+	use crate::sumcheck::prove::prove_single;
 
 	type StdChallenger = HasherChallenger<sha2::Sha256>;
 
@@ -145,10 +146,7 @@ mod tests {
 
 		let prover = bivariate_product_prover(
 			&alloc,
-			[
-				pooled_copy(&alloc, &multilinear_a),
-				pooled_copy(&alloc, &multilinear_b),
-			],
+			[multilinear_a.clone(), multilinear_b.clone()],
 			expected_sum,
 		);
 

--- a/crates/ip-prover/src/sumcheck/bivariate_product_mle.rs
+++ b/crates/ip-prover/src/sumcheck/bivariate_product_mle.rs
@@ -1,10 +1,10 @@
 // Copyright 2023-2025 Irreducible Inc.
 
+use binius_compute::Allocator;
 use binius_field::{Field, PackedField};
-use binius_math::FieldBuffer;
 
 use super::{
-	mle_store::MleStore,
+	mle_store::{MleStore, PooledColumn},
 	quadratic_mle_evaluator::{QuadraticMleEvaluator, quadratic_mlecheck_prover},
 	round_evaluator::SharedMleCheckProver,
 };
@@ -53,18 +53,27 @@ use crate::sumcheck::common::MleCheckProver;
 /// Note 2: evaluation points are 0 (implicit), 1 and Karatsuba infinity.
 ///
 /// [Gruen24]: <https://eprint.iacr.org/2024/108>
-pub fn new<F, P>(
-	multilinears: [FieldBuffer<P>; 2],
+pub fn new<'alloc, A, F, P>(
+	alloc: &'alloc A,
+	multilinears: [PooledColumn<A, P>; 2],
 	eval_point: Vec<F>,
 	eval_claim: F,
-) -> impl MleCheckProver<F>
+) -> impl MleCheckProver<F> + 'alloc
 where
+	A: Allocator,
 	F: Field,
 	P: PackedField<Scalar = F>,
 {
 	// The product is symmetric, so the infinity composition (highest-degree terms) equals the full
 	// composition.
-	quadratic_mlecheck_prover(multilinears, |[a, b]| a * b, |[a, b]| a * b, eval_point, eval_claim)
+	quadratic_mlecheck_prover(
+		alloc,
+		multilinears,
+		|[a, b]| a * b,
+		|[a, b]| a * b,
+		eval_point,
+		eval_claim,
+	)
 }
 
 /// Reduces the product of the two halves of a single buffer, sharing one allocation.
@@ -80,16 +89,18 @@ where
 /// # Returns
 ///
 /// A prover whose reduction emits the low half's evaluation, then the high half's.
-pub fn new_split_half<F, P>(
-	buffer: FieldBuffer<P>,
+pub fn new_split_half<'alloc, A, F, P>(
+	alloc: &'alloc A,
+	buffer: PooledColumn<A, P>,
 	eval_point: Vec<F>,
 	eval_claim: F,
-) -> impl MleCheckProver<F>
+) -> impl MleCheckProver<F> + 'alloc
 where
+	A: Allocator,
 	F: Field,
 	P: PackedField<Scalar = F>,
 {
-	let mut store = MleStore::new(eval_point.len());
+	let mut store = MleStore::new(eval_point.len(), alloc);
 	// The store checks that the buffer has exactly one more variable than itself.
 	let cols = store.push_split_half(buffer);
 	let evaluator =
@@ -109,11 +120,14 @@ mod tests {
 	use binius_transcript::{ProverTranscript, fiat_shamir::HasherChallenger};
 
 	type StdChallenger = HasherChallenger<sha2::Sha256>;
+	use binius_compute::GlobalAllocator;
 	use itertools::{self, Itertools};
 	use rand::prelude::*;
 
 	use super::*;
-	use crate::sumcheck::{MleToSumCheckDecorator, prove::prove_single, prove_single_mlecheck};
+	use crate::sumcheck::{
+		MleToSumCheckDecorator, mle_store::pooled_copy, prove::prove_single, prove_single_mlecheck,
+	};
 
 	fn test_mlecheck_prove_verify<F, P>(
 		prover: impl MleCheckProver<F>,
@@ -257,6 +271,7 @@ mod tests {
 
 		let n_vars = 8;
 		let mut rng = StdRng::seed_from_u64(0);
+		let alloc = GlobalAllocator;
 
 		// Generate two random multilinear polynomials
 		let multilinear_a = random_field_buffer::<P>(&mut rng, n_vars);
@@ -272,8 +287,15 @@ mod tests {
 		let eval_claim = evaluate(&product_buffer, &eval_point);
 
 		// Create the prover
-		let mlecheck_prover =
-			new([multilinear_a.clone(), multilinear_b.clone()], eval_point.clone(), eval_claim);
+		let mlecheck_prover = new(
+			&alloc,
+			[
+				pooled_copy(&alloc, &multilinear_a),
+				pooled_copy(&alloc, &multilinear_b),
+			],
+			eval_point.clone(),
+			eval_claim,
+		);
 
 		test_mlecheck_prove_verify(
 			mlecheck_prover,
@@ -284,8 +306,15 @@ mod tests {
 		);
 
 		// Create another prover for the wrapped test
-		let mlecheck_prover =
-			new([multilinear_a.clone(), multilinear_b.clone()], eval_point.clone(), eval_claim);
+		let mlecheck_prover = new(
+			&alloc,
+			[
+				pooled_copy(&alloc, &multilinear_a),
+				pooled_copy(&alloc, &multilinear_b),
+			],
+			eval_point.clone(),
+			eval_claim,
+		);
 
 		test_wrapped_sumcheck_prove_verify(
 			mlecheck_prover,

--- a/crates/ip-prover/src/sumcheck/bivariate_product_mle.rs
+++ b/crates/ip-prover/src/sumcheck/bivariate_product_mle.rs
@@ -2,9 +2,10 @@
 
 use binius_compute::Allocator;
 use binius_field::{Field, PackedField};
+use binius_math::FieldVec;
 
 use super::{
-	mle_store::{MleStore, PooledColumn},
+	mle_store::MleStore,
 	quadratic_mle_evaluator::{QuadraticMleEvaluator, quadratic_mlecheck_prover},
 	round_evaluator::SharedMleCheckProver,
 };
@@ -55,7 +56,7 @@ use crate::sumcheck::common::MleCheckProver;
 /// [Gruen24]: <https://eprint.iacr.org/2024/108>
 pub fn new<'alloc, A, F, P>(
 	alloc: &'alloc A,
-	multilinears: [PooledColumn<A, P>; 2],
+	multilinears: [FieldVec<P, A>; 2],
 	eval_point: Vec<F>,
 	eval_claim: F,
 ) -> impl MleCheckProver<F> + 'alloc
@@ -91,7 +92,7 @@ where
 /// A prover whose reduction emits the low half's evaluation, then the high half's.
 pub fn new_split_half<'alloc, A, F, P>(
 	alloc: &'alloc A,
-	buffer: PooledColumn<A, P>,
+	buffer: FieldVec<P, A>,
 	eval_point: Vec<F>,
 	eval_claim: F,
 ) -> impl MleCheckProver<F> + 'alloc
@@ -125,9 +126,7 @@ mod tests {
 	use rand::prelude::*;
 
 	use super::*;
-	use crate::sumcheck::{
-		MleToSumCheckDecorator, mle_store::pooled_copy, prove::prove_single, prove_single_mlecheck,
-	};
+	use crate::sumcheck::{MleToSumCheckDecorator, prove::prove_single, prove_single_mlecheck};
 
 	fn test_mlecheck_prove_verify<F, P>(
 		prover: impl MleCheckProver<F>,
@@ -289,10 +288,7 @@ mod tests {
 		// Create the prover
 		let mlecheck_prover = new(
 			&alloc,
-			[
-				pooled_copy(&alloc, &multilinear_a),
-				pooled_copy(&alloc, &multilinear_b),
-			],
+			[multilinear_a.clone(), multilinear_b.clone()],
 			eval_point.clone(),
 			eval_claim,
 		);
@@ -308,10 +304,7 @@ mod tests {
 		// Create another prover for the wrapped test
 		let mlecheck_prover = new(
 			&alloc,
-			[
-				pooled_copy(&alloc, &multilinear_a),
-				pooled_copy(&alloc, &multilinear_b),
-			],
+			[multilinear_a.clone(), multilinear_b.clone()],
 			eval_point.clone(),
 			eval_claim,
 		);

--- a/crates/ip-prover/src/sumcheck/frac_add_mle.rs
+++ b/crates/ip-prover/src/sumcheck/frac_add_mle.rs
@@ -1,5 +1,6 @@
 // Copyright 2025-2026 The Binius Developers
 
+use binius_compute::Allocator;
 use binius_field::{Field, PackedField};
 use binius_math::FieldBuffer;
 
@@ -21,10 +22,14 @@ pub type FractionalBuffer<P> = (FieldBuffer<P>, FieldBuffer<P>);
 /// that point's eq tracker and holds the two claimed evaluations, so the evaluators carry neither.
 ///
 /// [`SharedMleCheckProver`]: crate::sumcheck::round_evaluator::SharedMleCheckProver
-pub fn evaluators<F, P>(
+pub fn evaluators<A, F, P>(
 	cols: [ColId; 4],
-) -> (impl MleCheckRoundEvaluator<F, P> + 'static, impl MleCheckRoundEvaluator<F, P> + 'static)
+) -> (
+	impl MleCheckRoundEvaluator<A, F, P> + 'static,
+	impl MleCheckRoundEvaluator<A, F, P> + 'static,
+)
 where
+	A: Allocator,
 	F: Field,
 	P: PackedField<Scalar = F>,
 {
@@ -56,6 +61,7 @@ mod tests {
 	use binius_transcript::{ProverTranscript, fiat_shamir::HasherChallenger};
 
 	type StdChallenger = HasherChallenger<sha2::Sha256>;
+	use binius_compute::GlobalAllocator;
 	use itertools::{Itertools, izip};
 	use rand::prelude::*;
 
@@ -64,7 +70,7 @@ mod tests {
 		MleToSumCheckEvaluator,
 		batch::batch_prove,
 		common::SumcheckProver,
-		mle_store::MleStore,
+		mle_store::{MleStore, pooled_copy},
 		round_evaluator::{SharedSumcheckProver, SumcheckRoundEvaluator},
 	};
 
@@ -156,12 +162,14 @@ mod tests {
 	}
 
 	#[test]
+	#[allow(clippy::type_complexity)]
 	fn test_frac_add_sumcheck() {
 		type F = OptimalB128;
 		type P = OptimalPackedB128;
 
 		let n_vars = 8;
 		let mut rng = StdRng::seed_from_u64(0);
+		let alloc = GlobalAllocator;
 
 		let num_a = random_field_buffer::<P>(&mut rng, n_vars);
 		let num_b = random_field_buffer::<P>(&mut rng, n_vars);
@@ -187,16 +195,17 @@ mod tests {
 			evaluate(&denominator_buffer, &eval_point),
 		];
 
-		let mut store = MleStore::new(n_vars);
+		let mut store = MleStore::new(n_vars, &alloc);
 		let cols = [num_a.clone(), num_b.clone(), den_a.clone(), den_b.clone()]
-			.map(|col| store.push_owned(col));
+			.map(|col| store.push_owned(pooled_copy(&alloc, &col)));
 		let (num_evaluator, den_evaluator) = evaluators(cols);
 
 		// Register the shared point's eq tracker for the sumcheck wrappers (a plain sumcheck prover
 		// knows nothing of eq indicators, so the wrappers hold the tracker themselves).
 		let eq_tracker = store.register_eq_tracker(&eval_point);
 		// Wrap each MLE-check evaluator so it emits sumcheck-compatible round polynomials.
-		let claims_with_evaluators: [(F, Box<dyn SumcheckRoundEvaluator<F, P>>); 2] = [
+		let claims_with_evaluators: [(F, Box<dyn SumcheckRoundEvaluator<GlobalAllocator, F, P>>);
+			2] = [
 			(eval_claims[0], Box::new(MleToSumCheckEvaluator::new(num_evaluator, eq_tracker))),
 			(eval_claims[1], Box::new(MleToSumCheckEvaluator::new(den_evaluator, eq_tracker))),
 		];

--- a/crates/ip-prover/src/sumcheck/frac_add_mle.rs
+++ b/crates/ip-prover/src/sumcheck/frac_add_mle.rs
@@ -70,7 +70,7 @@ mod tests {
 		MleToSumCheckEvaluator,
 		batch::batch_prove,
 		common::SumcheckProver,
-		mle_store::{MleStore, pooled_copy},
+		mle_store::MleStore,
 		round_evaluator::{SharedSumcheckProver, SumcheckRoundEvaluator},
 	};
 
@@ -197,7 +197,7 @@ mod tests {
 
 		let mut store = MleStore::new(n_vars, &alloc);
 		let cols = [num_a.clone(), num_b.clone(), den_a.clone(), den_b.clone()]
-			.map(|col| store.push_owned(pooled_copy(&alloc, &col)));
+			.map(|col| store.push_owned(col));
 		let (num_evaluator, den_evaluator) = evaluators(cols);
 
 		// Register the shared point's eq tracker for the sumcheck wrappers (a plain sumcheck prover

--- a/crates/ip-prover/src/sumcheck/mle_store.rs
+++ b/crates/ip-prover/src/sumcheck/mle_store.rs
@@ -24,7 +24,7 @@ use std::iter;
 use binius_compute::{Allocator, VecLike};
 use binius_field::{Field, PackedField};
 use binius_math::{
-	FieldBuffer, FieldSlice,
+	FieldBuffer, FieldSlice, FieldVec,
 	line::extrapolate_line_packed,
 	multilinear::fold::{fold_highest_var, fold_highest_var_inplace},
 };
@@ -32,20 +32,6 @@ use binius_utils::rayon;
 use itertools::izip;
 
 use super::gruen32::Gruen32;
-
-/// A column buffer whose backing store is drawn from an [`Allocator`] `A`.
-///
-/// For `A = &BufferPool` this is a pooled buffer; for `A = GlobalAllocator` it is an ordinary
-/// `Vec`-backed buffer.
-pub type PooledColumn<A, P> = FieldBuffer<P, <A as Allocator>::Vec<P>>;
-
-/// Allocates a zeroed buffer of `log_len` variables from `alloc`.
-pub fn pooled_zeros<A: Allocator, P: PackedField>(alloc: &A, log_len: usize) -> PooledColumn<A, P> {
-	let packed_len = 1 << log_len.saturating_sub(P::LOG_WIDTH);
-	let mut data = alloc.alloc::<P>(packed_len);
-	data.resize(packed_len, P::default());
-	FieldBuffer::new(log_len, data)
-}
 
 /// Copies `src` into a buffer freshly allocated from `alloc`.
 ///
@@ -56,25 +42,10 @@ pub fn pooled_zeros<A: Allocator, P: PackedField>(alloc: &A, log_len: usize) -> 
 pub fn pooled_copy<A: Allocator, P: PackedField, Data: std::ops::Deref<Target = [P]>>(
 	alloc: &A,
 	src: &FieldBuffer<P, Data>,
-) -> PooledColumn<A, P> {
+) -> FieldVec<P, A> {
 	let mut data = alloc.alloc::<P>(src.as_ref().len());
 	data.extend_from_slice(src.as_ref());
 	FieldBuffer::new(src.log_len(), data)
-}
-
-/// Folds `values` on its highest variable into a freshly allocated buffer from `alloc`.
-///
-/// The intermediate `Vec` produced by the fold is copied into the allocator's buffer; an
-/// allocator-aware fold would write the result directly into that buffer.
-fn fold_into_pooled<A: Allocator, P: PackedField, Data: std::ops::Deref<Target = [P]>>(
-	alloc: &A,
-	values: &FieldBuffer<P, Data>,
-	scalar: P::Scalar,
-) -> PooledColumn<A, P> {
-	let folded = fold_highest_var(values, scalar);
-	let mut data = alloc.alloc::<P>(folded.as_ref().len());
-	data.extend_from_slice(folded.as_ref());
-	FieldBuffer::new(folded.log_len(), data)
 }
 
 /// Identifier of a column held by an [`MleStore`].
@@ -107,14 +78,14 @@ impl EqId {
 /// made to separate them.
 enum Column<'a, A: Allocator, P: PackedField> {
 	Borrowed(FieldSlice<'a, P>),
-	Owned(PooledColumn<A, P>),
+	Owned(FieldVec<P, A>),
 	/// A parent buffer whose low and high halves are two adjacent columns.
 	///
 	/// Pushed by [`MleStore::push_split_half`]. The buffer keeps its original length for the life
 	/// of the store; each [`MleStore::fold`] advances both halves in place within it, and the two
 	/// columns are read as the front `2^n_vars` scalars of the low and high halves. This shares one
 	/// allocation between the sibling columns with no copy at any point.
-	SplitHalf(PooledColumn<A, P>),
+	SplitHalf(FieldVec<P, A>),
 }
 
 /// A store of equal-length multilinear columns shared by a group of round evaluators.
@@ -165,7 +136,7 @@ impl<'a, A: Allocator, F: Field, P: PackedField<Scalar = F>> MleStore<'a, A, P> 
 	}
 
 	/// Pushes an owned column and returns its identifier.
-	pub fn push_owned(&mut self, column: PooledColumn<A, P>) -> ColId {
+	pub fn push_owned(&mut self, column: FieldVec<P, A>) -> ColId {
 		// precondition
 		assert_eq!(
 			column.log_len(),
@@ -191,7 +162,7 @@ impl<'a, A: Allocator, F: Field, P: PackedField<Scalar = F>> MleStore<'a, A, P> 
 	/// Each [`Self::fold`] advances both halves in place within the buffer. `buffer` splits on its
 	/// highest variable, so its low half fixes that variable to 0 and its high half to 1 —
 	/// matching the store's high-to-low fold order.
-	pub fn push_split_half(&mut self, buffer: PooledColumn<A, P>) -> [ColId; 2] {
+	pub fn push_split_half(&mut self, buffer: FieldVec<P, A>) -> [ColId; 2] {
 		// precondition
 		assert_eq!(
 			buffer.log_len(),
@@ -301,7 +272,7 @@ impl<'a, A: Allocator, F: Field, P: PackedField<Scalar = F>> MleStore<'a, A, P> 
 				Column::Borrowed(slice) => {
 					// The first fold of a borrowed column writes into a fresh half-size owned
 					// buffer, avoiding an up-front copy of the full column.
-					*column = Column::Owned(fold_into_pooled(alloc, slice, challenge));
+					*column = Column::Owned(fold_highest_var(alloc, slice, challenge));
 				}
 				Column::SplitHalf(buffer) => {
 					// Fold each half on its own highest variable in place. The two halves are the
@@ -448,7 +419,7 @@ impl<'a, A: Allocator, F: Field, P: PackedField<Scalar = F>> MleStore<'a, A, P> 
 			.columns
 			.iter()
 			.map(|column| match column {
-				Column::Borrowed(_) => Some(pooled_zeros(alloc, n_vars)),
+				Column::Borrowed(_) => Some(FieldBuffer::zeros_in(alloc, n_vars)),
 				_ => None,
 			})
 			.collect::<Vec<_>>();
@@ -882,15 +853,8 @@ mod tests {
 			.iter()
 			.map(|col| store.push(col.to_ref()))
 			.collect::<Vec<_>>();
-		col_ids.push(
-			store.push_owned(pooled_copy(&alloc, &random_field_buffer::<P>(&mut rng, n_vars))),
-		);
-		col_ids.extend(
-			store.push_split_half(pooled_copy(
-				&alloc,
-				&random_field_buffer::<P>(&mut rng, n_vars + 1),
-			)),
-		);
+		col_ids.push(store.push_owned(random_field_buffer::<P>(&mut rng, n_vars)));
+		col_ids.extend(store.push_split_half(random_field_buffer::<P>(&mut rng, n_vars + 1)));
 
 		let eq_ids = (0..2)
 			.map(|_| store.register_eq_tracker(&random_scalars::<F>(&mut rng, n_vars)))
@@ -950,8 +914,8 @@ mod tests {
 				.iter()
 				.map(|col| store.push(col.to_ref()))
 				.collect::<Vec<_>>();
-			col_ids.push(store.push_owned(pooled_copy(&alloc, &owned)));
-			col_ids.extend(store.push_split_half(pooled_copy(&alloc, &split)));
+			col_ids.push(store.push_owned(owned.clone()));
+			col_ids.extend(store.push_split_half(split.clone()));
 			let eq_ids = eq_points
 				.iter()
 				.map(|point| store.register_eq_tracker(point))

--- a/crates/ip-prover/src/sumcheck/mle_store.rs
+++ b/crates/ip-prover/src/sumcheck/mle_store.rs
@@ -21,6 +21,7 @@
 
 use std::iter;
 
+use binius_compute::{Allocator, VecLike};
 use binius_field::{Field, PackedField};
 use binius_math::{
 	FieldBuffer, FieldSlice,
@@ -31,6 +32,50 @@ use binius_utils::rayon;
 use itertools::izip;
 
 use super::gruen32::Gruen32;
+
+/// A column buffer whose backing store is drawn from an [`Allocator`] `A`.
+///
+/// For `A = &BufferPool` this is a pooled buffer; for `A = GlobalAllocator` it is an ordinary
+/// `Vec`-backed buffer.
+pub type PooledColumn<A, P> = FieldBuffer<P, <A as Allocator>::Vec<P>>;
+
+/// Allocates a zeroed buffer of `log_len` variables from `alloc`.
+pub fn pooled_zeros<A: Allocator, P: PackedField>(alloc: &A, log_len: usize) -> PooledColumn<A, P> {
+	let packed_len = 1 << log_len.saturating_sub(P::LOG_WIDTH);
+	let mut data = alloc.alloc::<P>(packed_len);
+	data.resize(packed_len, P::default());
+	FieldBuffer::new(log_len, data)
+}
+
+/// Copies `src` into a buffer freshly allocated from `alloc`.
+///
+/// This is the bridge for a `Vec`-backed buffer built by `binius-math` (e.g. `from_values`): the
+/// live buffer is a genuine allocation from `alloc` (so under a pool it recycles through the free
+/// list), and the source is dropped. Prefer building directly into `alloc` where an allocator-aware
+/// constructor exists.
+pub fn pooled_copy<A: Allocator, P: PackedField, Data: std::ops::Deref<Target = [P]>>(
+	alloc: &A,
+	src: &FieldBuffer<P, Data>,
+) -> PooledColumn<A, P> {
+	let mut data = alloc.alloc::<P>(src.as_ref().len());
+	data.extend_from_slice(src.as_ref());
+	FieldBuffer::new(src.log_len(), data)
+}
+
+/// Folds `values` on its highest variable into a freshly allocated buffer from `alloc`.
+///
+/// The intermediate `Vec` produced by the fold is copied into the allocator's buffer; an
+/// allocator-aware fold would write the result directly into that buffer.
+fn fold_into_pooled<A: Allocator, P: PackedField, Data: std::ops::Deref<Target = [P]>>(
+	alloc: &A,
+	values: &FieldBuffer<P, Data>,
+	scalar: P::Scalar,
+) -> PooledColumn<A, P> {
+	let folded = fold_highest_var(values, scalar);
+	let mut data = alloc.alloc::<P>(folded.as_ref().len());
+	data.extend_from_slice(folded.as_ref());
+	FieldBuffer::new(folded.log_len(), data)
+}
 
 /// Identifier of a column held by an [`MleStore`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -60,38 +105,41 @@ impl EqId {
 /// A `Borrowed` or `Owned` entry is a single column. A `SplitHalf` entry holds two adjacent
 /// columns — the low and high halves of one parent buffer — in a single allocation, so no copy is
 /// made to separate them.
-enum Column<'a, P: PackedField> {
+enum Column<'a, A: Allocator, P: PackedField> {
 	Borrowed(FieldSlice<'a, P>),
-	Owned(FieldBuffer<P>),
+	Owned(PooledColumn<A, P>),
 	/// A parent buffer whose low and high halves are two adjacent columns.
 	///
 	/// Pushed by [`MleStore::push_split_half`]. The buffer keeps its original length for the life
 	/// of the store; each [`MleStore::fold`] advances both halves in place within it, and the two
 	/// columns are read as the front `2^n_vars` scalars of the low and high halves. This shares one
 	/// allocation between the sibling columns with no copy at any point.
-	SplitHalf(FieldBuffer<P>),
+	SplitHalf(PooledColumn<A, P>),
 }
 
 /// A store of equal-length multilinear columns shared by a group of round evaluators.
 ///
 /// See the [module documentation](self) for the folding invariant.
-pub struct MleStore<'a, P: PackedField> {
+pub struct MleStore<'a, A: Allocator, P: PackedField> {
 	n_vars: usize,
-	columns: Vec<Column<'a, P>>,
+	columns: Vec<Column<'a, A, P>>,
 	/// Number of logical columns, counting each [`Column::SplitHalf`] entry as two. This is the
 	/// number of assigned [`ColId`]s and the length of the [`Self::final_evals`] output.
 	n_cols: usize,
 	eq_trackers: Vec<Gruen32<P>>,
+	/// Allocator the owned/promoted columns are drawn from; borrowed for `'a`.
+	alloc: &'a A,
 }
 
-impl<'a, F: Field, P: PackedField<Scalar = F>> MleStore<'a, P> {
+impl<'a, A: Allocator, F: Field, P: PackedField<Scalar = F>> MleStore<'a, A, P> {
 	/// Creates an empty store over columns with `n_vars` variables.
-	pub const fn new(n_vars: usize) -> Self {
+	pub const fn new(n_vars: usize, alloc: &'a A) -> Self {
 		Self {
 			n_vars,
 			columns: Vec::new(),
 			n_cols: 0,
 			eq_trackers: Vec::new(),
+			alloc,
 		}
 	}
 
@@ -117,7 +165,7 @@ impl<'a, F: Field, P: PackedField<Scalar = F>> MleStore<'a, P> {
 	}
 
 	/// Pushes an owned column and returns its identifier.
-	pub fn push_owned(&mut self, column: FieldBuffer<P>) -> ColId {
+	pub fn push_owned(&mut self, column: PooledColumn<A, P>) -> ColId {
 		// precondition
 		assert_eq!(
 			column.log_len(),
@@ -143,7 +191,7 @@ impl<'a, F: Field, P: PackedField<Scalar = F>> MleStore<'a, P> {
 	/// Each [`Self::fold`] advances both halves in place within the buffer. `buffer` splits on its
 	/// highest variable, so its low half fixes that variable to 0 and its high half to 1 —
 	/// matching the store's high-to-low fold order.
-	pub fn push_split_half(&mut self, buffer: FieldBuffer<P>) -> [ColId; 2] {
+	pub fn push_split_half(&mut self, buffer: PooledColumn<A, P>) -> [ColId; 2] {
 		// precondition
 		assert_eq!(
 			buffer.log_len(),
@@ -246,13 +294,14 @@ impl<'a, F: Field, P: PackedField<Scalar = F>> MleStore<'a, P> {
 		// The number of live variables in each column before this fold; a split-half buffer keeps
 		// its full length, so its halves must be truncated to this before folding.
 		let n_vars = self.n_vars;
+		let alloc = self.alloc;
 		for column in &mut self.columns {
 			match column {
 				Column::Owned(buffer) => fold_highest_var_inplace(buffer, challenge),
 				Column::Borrowed(slice) => {
 					// The first fold of a borrowed column writes into a fresh half-size owned
 					// buffer, avoiding an up-front copy of the full column.
-					*column = Column::Owned(fold_highest_var(slice, challenge));
+					*column = Column::Owned(fold_into_pooled(alloc, slice, challenge));
 				}
 				Column::SplitHalf(buffer) => {
 					// Fold each half on its own highest variable in place. The two halves are the
@@ -394,11 +443,12 @@ impl<'a, F: Field, P: PackedField<Scalar = F>> MleStore<'a, P> {
 
 		// Fresh destination buffers for the borrowed columns, held outside the column borrow so
 		// they can be moved into the store once the fold has written them.
+		let alloc = self.alloc;
 		let mut dsts = self
 			.columns
 			.iter()
 			.map(|column| match column {
-				Column::Borrowed(_) => Some(FieldBuffer::zeros(n_vars)),
+				Column::Borrowed(_) => Some(pooled_zeros(alloc, n_vars)),
 				_ => None,
 			})
 			.collect::<Vec<_>>();
@@ -787,6 +837,7 @@ fn map_reduce_with_fold_helper<P: PackedField, T: Send>(
 
 #[cfg(test)]
 mod tests {
+	use binius_compute::GlobalAllocator;
 	use binius_field::{Field, FieldOps, PackedField};
 	use binius_math::test_utils::{Packed128b, random_field_buffer, random_scalars};
 	use itertools::Itertools;
@@ -819,19 +870,27 @@ mod tests {
 
 		let n_vars = 7;
 		let mut rng = StdRng::seed_from_u64(0);
+		let alloc = GlobalAllocator;
 
 		// A mix of column kinds so `chunk` exercises borrowed, owned, and split-half entries.
 		let borrowed = [
 			random_field_buffer::<P>(&mut rng, n_vars),
 			random_field_buffer::<P>(&mut rng, n_vars),
 		];
-		let mut store = MleStore::<P>::new(n_vars);
+		let mut store = MleStore::<GlobalAllocator, P>::new(n_vars, &alloc);
 		let mut col_ids = borrowed
 			.iter()
 			.map(|col| store.push(col.to_ref()))
 			.collect::<Vec<_>>();
-		col_ids.push(store.push_owned(random_field_buffer::<P>(&mut rng, n_vars)));
-		col_ids.extend(store.push_split_half(random_field_buffer::<P>(&mut rng, n_vars + 1)));
+		col_ids.push(
+			store.push_owned(pooled_copy(&alloc, &random_field_buffer::<P>(&mut rng, n_vars))),
+		);
+		col_ids.extend(
+			store.push_split_half(pooled_copy(
+				&alloc,
+				&random_field_buffer::<P>(&mut rng, n_vars + 1),
+			)),
+		);
 
 		let eq_ids = (0..2)
 			.map(|_| store.register_eq_tracker(&random_scalars::<F>(&mut rng, n_vars)))
@@ -883,15 +942,16 @@ mod tests {
 			random_scalars::<F>(&mut rng, n_vars),
 		];
 		let challenge = random_scalars::<F>(&mut rng, 1)[0];
+		let alloc = GlobalAllocator;
 
 		let build = || {
-			let mut store = MleStore::<P>::new(n_vars);
+			let mut store = MleStore::<GlobalAllocator, P>::new(n_vars, &alloc);
 			let mut col_ids = borrowed
 				.iter()
 				.map(|col| store.push(col.to_ref()))
 				.collect::<Vec<_>>();
-			col_ids.push(store.push_owned(owned.clone()));
-			col_ids.extend(store.push_split_half(split.clone()));
+			col_ids.push(store.push_owned(pooled_copy(&alloc, &owned)));
+			col_ids.extend(store.push_split_half(pooled_copy(&alloc, &split)));
 			let eq_ids = eq_points
 				.iter()
 				.map(|point| store.register_eq_tracker(point))
@@ -902,7 +962,7 @@ mod tests {
 		// The store's folded state: remaining variable count plus every column and eq scalar.
 		let scalars =
 			|slice: &FieldSlice<'_, P>| (0..slice.len()).map(|i| slice.get(i)).collect_vec();
-		let state = |store: &MleStore<'_, P>| {
+		let state = |store: &MleStore<'_, GlobalAllocator, P>| {
 			let cols = store.column_slices().iter().flat_map(scalars).collect_vec();
 			let eqs = store
 				.eq_expansions()

--- a/crates/ip-prover/src/sumcheck/mle_to_sumcheck.rs
+++ b/crates/ip-prover/src/sumcheck/mle_to_sumcheck.rs
@@ -1,6 +1,7 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
+use binius_compute::Allocator;
 use binius_field::{Field, PackedField, WideMul};
 use binius_ip::sumcheck::RoundCoeffs;
 use binius_math::multilinear::eq::eq_one_var;
@@ -123,11 +124,12 @@ impl<Inner> MleToSumCheckEvaluator<Inner> {
 	}
 }
 
-impl<F, P, Inner> SumcheckRoundEvaluator<F, P> for MleToSumCheckEvaluator<Inner>
+impl<A, F, P, Inner> SumcheckRoundEvaluator<A, F, P> for MleToSumCheckEvaluator<Inner>
 where
+	A: Allocator,
 	F: Field,
 	P: PackedField<Scalar = F>,
-	Inner: MleCheckRoundEvaluator<F, P>,
+	Inner: MleCheckRoundEvaluator<A, F, P>,
 {
 	fn degree(&self) -> usize {
 		// The eq factor multiplies the emitted round polynomial, not the accumulator: the wide
@@ -142,7 +144,7 @@ where
 
 	fn interpolate(
 		&self,
-		store: &MleStore<'_, P>,
+		store: &MleStore<'_, A, P>,
 		accum: &[<P as WideMul>::Output],
 		claim: F,
 	) -> RoundCoeffs<F> {

--- a/crates/ip-prover/src/sumcheck/multilinear_eval.rs
+++ b/crates/ip-prover/src/sumcheck/multilinear_eval.rs
@@ -4,10 +4,10 @@
 use binius_compute::Allocator;
 use binius_field::{Field, PackedField, WideMul};
 use binius_ip::sumcheck::RoundCoeffs;
-use binius_math::FieldSlice;
+use binius_math::{FieldSlice, FieldVec};
 
 use super::{
-	mle_store::{ColId, EvaluationChunk, MleStore, PooledColumn},
+	mle_store::{ColId, EvaluationChunk, MleStore},
 	round_evals::RoundEvals1,
 	round_evaluator::{MleCheckRoundEvaluator, SharedMleCheckProver},
 };
@@ -107,7 +107,7 @@ where
 /// Panics if the witness length does not match the evaluation point length.
 pub fn multilinear_eval_prover<'alloc, A, F, P>(
 	alloc: &'alloc A,
-	witness: PooledColumn<A, P>,
+	witness: FieldVec<P, A>,
 	eval_point: &[F],
 	eval_claim: F,
 ) -> SharedMleCheckProver<'alloc, A, F, P, MultilinearEvalEvaluator>
@@ -146,7 +146,7 @@ mod tests {
 
 	use super::*;
 	use crate::sumcheck::{
-		common::SumcheckProver, mle_store::pooled_copy, prove_single_mlecheck,
+		common::SumcheckProver, prove_single_mlecheck,
 		quadratic_mle_evaluator::quadratic_mlecheck_prover,
 	};
 
@@ -170,10 +170,10 @@ mod tests {
 		let eval_claim = evaluate(&witness, &eval_point);
 
 		let mut eval_prover =
-			multilinear_eval_prover(&alloc, pooled_copy(&alloc, &witness), &eval_point, eval_claim);
+			multilinear_eval_prover(&alloc, witness.clone(), &eval_point, eval_claim);
 		let mut quadratic_prover = quadratic_mlecheck_prover(
 			&alloc,
-			[pooled_copy(&alloc, &witness)],
+			[witness],
 			|[a]: [P; 1]| a,
 			|[_a]: [P; 1]| P::zero(),
 			eval_point,
@@ -213,8 +213,7 @@ mod tests {
 		let eval_point = random_scalars::<F>(&mut rng, n_vars);
 		let eval_claim = evaluate(&witness, &eval_point);
 
-		let prover =
-			multilinear_eval_prover(&alloc, pooled_copy(&alloc, &witness), &eval_point, eval_claim);
+		let prover = multilinear_eval_prover(&alloc, witness.clone(), &eval_point, eval_claim);
 
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 		let output = prove_single_mlecheck(prover, &mut prover_transcript);
@@ -249,8 +248,7 @@ mod tests {
 		let eval_point = random_scalars::<F>(&mut rng, n_vars);
 		let eval_claim = evaluate(&witness, &eval_point);
 
-		let mut prover =
-			multilinear_eval_prover(&alloc, pooled_copy(&alloc, &witness), &eval_point, eval_claim);
+		let mut prover = multilinear_eval_prover(&alloc, witness, &eval_point, eval_claim);
 		assert_eq!(prover.round_claim(), vec![eval_claim]);
 
 		for _ in 0..n_vars {

--- a/crates/ip-prover/src/sumcheck/multilinear_eval.rs
+++ b/crates/ip-prover/src/sumcheck/multilinear_eval.rs
@@ -1,12 +1,13 @@
 // Copyright 2026 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
+use binius_compute::Allocator;
 use binius_field::{Field, PackedField, WideMul};
 use binius_ip::sumcheck::RoundCoeffs;
-use binius_math::{FieldBuffer, FieldSlice};
+use binius_math::FieldSlice;
 
 use super::{
-	mle_store::{ColId, EvaluationChunk, MleStore},
+	mle_store::{ColId, EvaluationChunk, MleStore, PooledColumn},
 	round_evals::RoundEvals1,
 	round_evaluator::{MleCheckRoundEvaluator, SharedMleCheckProver},
 };
@@ -30,8 +31,9 @@ impl MultilinearEvalEvaluator {
 	}
 }
 
-impl<F, P> MleCheckRoundEvaluator<F, P> for MultilinearEvalEvaluator
+impl<A, F, P> MleCheckRoundEvaluator<A, F, P> for MultilinearEvalEvaluator
 where
+	A: Allocator,
 	F: Field,
 	P: PackedField<Scalar = F>,
 {
@@ -63,7 +65,7 @@ where
 
 	fn interpolate(
 		&self,
-		store: &MleStore<'_, P>,
+		store: &MleStore<'_, A, P>,
 		accum: &[P],
 		claim: F,
 		alpha: F,
@@ -103,12 +105,14 @@ where
 /// # Panics
 ///
 /// Panics if the witness length does not match the evaluation point length.
-pub fn multilinear_eval_prover<F, P>(
-	witness: FieldBuffer<P>,
+pub fn multilinear_eval_prover<'alloc, A, F, P>(
+	alloc: &'alloc A,
+	witness: PooledColumn<A, P>,
 	eval_point: &[F],
 	eval_claim: F,
-) -> SharedMleCheckProver<'static, F, P, MultilinearEvalEvaluator>
+) -> SharedMleCheckProver<'alloc, A, F, P, MultilinearEvalEvaluator>
 where
+	A: Allocator,
 	F: Field,
 	P: PackedField<Scalar = F>,
 {
@@ -119,8 +123,7 @@ where
 	);
 
 	// The store owns the witness as its single column.
-	// With no borrowed data, the shared prover is `'static`.
-	let mut store = MleStore::new(eval_point.len());
+	let mut store = MleStore::new(eval_point.len(), alloc);
 	let col = store.push_owned(witness);
 	let evaluator = MultilinearEvalEvaluator::new(col);
 	SharedMleCheckProver::new(store, [(eval_claim, evaluator)], eval_point.to_vec())
@@ -128,6 +131,7 @@ where
 
 #[cfg(test)]
 mod tests {
+	use binius_compute::GlobalAllocator;
 	use binius_field::{
 		FieldOps, Random,
 		arch::{OptimalB128, OptimalPackedB128},
@@ -142,7 +146,7 @@ mod tests {
 
 	use super::*;
 	use crate::sumcheck::{
-		common::SumcheckProver, prove_single_mlecheck,
+		common::SumcheckProver, mle_store::pooled_copy, prove_single_mlecheck,
 		quadratic_mle_evaluator::quadratic_mlecheck_prover,
 	};
 
@@ -159,14 +163,17 @@ mod tests {
 	fn test_conformance_with_quadratic_mlecheck() {
 		let mut rng = StdRng::seed_from_u64(0);
 		let n_vars = 8;
+		let alloc = GlobalAllocator;
 
 		let witness = random_field_buffer::<P>(&mut rng, n_vars);
 		let eval_point = random_scalars::<F>(&mut rng, n_vars);
 		let eval_claim = evaluate(&witness, &eval_point);
 
-		let mut eval_prover = multilinear_eval_prover(witness.clone(), &eval_point, eval_claim);
+		let mut eval_prover =
+			multilinear_eval_prover(&alloc, pooled_copy(&alloc, &witness), &eval_point, eval_claim);
 		let mut quadratic_prover = quadratic_mlecheck_prover(
-			[witness],
+			&alloc,
+			[pooled_copy(&alloc, &witness)],
 			|[a]: [P; 1]| a,
 			|[_a]: [P; 1]| P::zero(),
 			eval_point,
@@ -200,12 +207,14 @@ mod tests {
 	fn test_prove_verify_roundtrip() {
 		let mut rng = StdRng::seed_from_u64(1);
 		let n_vars = 7;
+		let alloc = GlobalAllocator;
 
 		let witness = random_field_buffer::<P>(&mut rng, n_vars);
 		let eval_point = random_scalars::<F>(&mut rng, n_vars);
 		let eval_claim = evaluate(&witness, &eval_point);
 
-		let prover = multilinear_eval_prover(witness.clone(), &eval_point, eval_claim);
+		let prover =
+			multilinear_eval_prover(&alloc, pooled_copy(&alloc, &witness), &eval_point, eval_claim);
 
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 		let output = prove_single_mlecheck(prover, &mut prover_transcript);
@@ -234,12 +243,14 @@ mod tests {
 	fn test_round_claim_invariant() {
 		let mut rng = StdRng::seed_from_u64(2);
 		let n_vars = 6;
+		let alloc = GlobalAllocator;
 
 		let witness = random_field_buffer::<P>(&mut rng, n_vars);
 		let eval_point = random_scalars::<F>(&mut rng, n_vars);
 		let eval_claim = evaluate(&witness, &eval_point);
 
-		let mut prover = multilinear_eval_prover(witness, &eval_point, eval_claim);
+		let mut prover =
+			multilinear_eval_prover(&alloc, pooled_copy(&alloc, &witness), &eval_point, eval_claim);
 		assert_eq!(prover.round_claim(), vec![eval_claim]);
 
 		for _ in 0..n_vars {

--- a/crates/ip-prover/src/sumcheck/padded.rs
+++ b/crates/ip-prover/src/sumcheck/padded.rs
@@ -133,7 +133,6 @@ mod tests {
 	use super::*;
 	use crate::sumcheck::{
 		bivariate_product_evaluator::{BivariateProductEvaluator, bivariate_product_prover},
-		mle_store::pooled_copy,
 		prove::prove_single,
 		round_evaluator::SharedSumcheckProver,
 	};
@@ -150,8 +149,7 @@ mod tests {
 		let a = random_field_buffer::<P>(&mut *rng, n_vars);
 		let b = random_field_buffer::<P>(&mut *rng, n_vars);
 		let sum = inner_product_par(&a, &b);
-		let prover =
-			bivariate_product_prover(alloc, [pooled_copy(alloc, &a), pooled_copy(alloc, &b)], sum);
+		let prover = bivariate_product_prover(alloc, [a, b], sum);
 		(prover, sum)
 	}
 
@@ -238,11 +236,7 @@ mod tests {
 		let a = random_field_buffer::<P>(&mut rng, n_vars);
 		let b = random_field_buffer::<P>(&mut rng, n_vars);
 		let sum = inner_product_par(&a, &b);
-		let inner = bivariate_product_prover(
-			&alloc,
-			[pooled_copy(&alloc, &a), pooled_copy(&alloc, &b)],
-			sum,
-		);
+		let inner = bivariate_product_prover(&alloc, [a.clone(), b.clone()], sum);
 		let padded = PaddedSumcheckDecorator::new(inner, n_extra_vars);
 
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());

--- a/crates/ip-prover/src/sumcheck/padded.rs
+++ b/crates/ip-prover/src/sumcheck/padded.rs
@@ -113,6 +113,7 @@ impl<F: Field, Inner: SumcheckProver<F>> SumcheckProver<F> for PaddedSumcheckDec
 
 #[cfg(test)]
 mod tests {
+	use binius_compute::GlobalAllocator;
 	use binius_field::{
 		Random,
 		arch::{OptimalB128, OptimalPackedB128},
@@ -132,6 +133,7 @@ mod tests {
 	use super::*;
 	use crate::sumcheck::{
 		bivariate_product_evaluator::{BivariateProductEvaluator, bivariate_product_prover},
+		mle_store::pooled_copy,
 		prove::prove_single,
 		round_evaluator::SharedSumcheckProver,
 	};
@@ -140,14 +142,16 @@ mod tests {
 	type P = OptimalPackedB128;
 	type StdChallenger = HasherChallenger<sha2::Sha256>;
 
-	fn make_inner(
+	fn make_inner<'alloc>(
 		rng: &mut impl Rng,
+		alloc: &'alloc GlobalAllocator,
 		n_vars: usize,
-	) -> (SharedSumcheckProver<'static, P, BivariateProductEvaluator>, F) {
+	) -> (SharedSumcheckProver<'alloc, GlobalAllocator, P, BivariateProductEvaluator>, F) {
 		let a = random_field_buffer::<P>(&mut *rng, n_vars);
 		let b = random_field_buffer::<P>(&mut *rng, n_vars);
 		let sum = inner_product_par(&a, &b);
-		let prover = bivariate_product_prover([a, b], sum);
+		let prover =
+			bivariate_product_prover(alloc, [pooled_copy(alloc, &a), pooled_copy(alloc, &b)], sum);
 		(prover, sum)
 	}
 
@@ -158,11 +162,12 @@ mod tests {
 		let mut rng = StdRng::seed_from_u64(0);
 		let n_vars = 6;
 		let n_extra_vars = 3;
+		let alloc = GlobalAllocator;
 
-		let (inner, sum) = make_inner(&mut rng, n_vars);
+		let (inner, sum) = make_inner(&mut rng, &alloc, n_vars);
 		// A parallel bare inner prover, driven only on the inner-phase challenges, to compare round
 		// polynomials against.
-		let (mut bare_inner, _) = make_inner(&mut StdRng::seed_from_u64(0), n_vars);
+		let (mut bare_inner, _) = make_inner(&mut StdRng::seed_from_u64(0), &alloc, n_vars);
 		let mut padded = PaddedSumcheckDecorator::new(inner, n_extra_vars);
 
 		let challenges = (0..n_vars + n_extra_vars)
@@ -204,8 +209,9 @@ mod tests {
 		let mut rng = StdRng::seed_from_u64(1);
 		let n_vars = 5;
 		let n_extra_vars = 2;
+		let alloc = GlobalAllocator;
 
-		let (inner, _) = make_inner(&mut rng, n_vars);
+		let (inner, _) = make_inner(&mut rng, &alloc, n_vars);
 		let mut padded = PaddedSumcheckDecorator::new(inner, n_extra_vars);
 
 		for _ in 0..n_vars + n_extra_vars {
@@ -227,11 +233,16 @@ mod tests {
 		let n_vars = 7;
 		let n_extra_vars = 4;
 		let total_vars = n_vars + n_extra_vars;
+		let alloc = GlobalAllocator;
 
 		let a = random_field_buffer::<P>(&mut rng, n_vars);
 		let b = random_field_buffer::<P>(&mut rng, n_vars);
 		let sum = inner_product_par(&a, &b);
-		let inner = bivariate_product_prover([a.clone(), b.clone()], sum);
+		let inner = bivariate_product_prover(
+			&alloc,
+			[pooled_copy(&alloc, &a), pooled_copy(&alloc, &b)],
+			sum,
+		);
 		let padded = PaddedSumcheckDecorator::new(inner, n_extra_vars);
 
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
@@ -280,8 +291,9 @@ mod tests {
 	fn test_no_padding_passthrough() {
 		let mut rng = StdRng::seed_from_u64(3);
 		let n_vars = 6;
+		let alloc = GlobalAllocator;
 
-		let (inner, sum) = make_inner(&mut rng, n_vars);
+		let (inner, sum) = make_inner(&mut rng, &alloc, n_vars);
 		let padded = PaddedSumcheckDecorator::new(inner, 0);
 		assert_eq!(padded.n_vars(), n_vars);
 

--- a/crates/ip-prover/src/sumcheck/quadratic_mle_evaluator.rs
+++ b/crates/ip-prover/src/sumcheck/quadratic_mle_evaluator.rs
@@ -1,11 +1,12 @@
 // Copyright 2026 The Binius Developers
 
+use binius_compute::Allocator;
 use binius_field::{Field, PackedField, WideMul};
 use binius_ip::sumcheck::RoundCoeffs;
-use binius_math::{FieldBuffer, FieldSlice};
+use binius_math::FieldSlice;
 
 use super::{
-	mle_store::{ColId, ColumnChunk, EvaluationChunk, MleStore},
+	mle_store::{ColId, ColumnChunk, EvaluationChunk, MleStore, PooledColumn},
 	round_evals::RoundEvals2,
 	round_evaluator::{MleCheckRoundEvaluator, SharedMleCheckProver},
 };
@@ -91,29 +92,40 @@ impl<Composition, InfinityComposition, const N: usize>
 /// # Panics
 ///
 /// Panics if any multilinear's variable count differs from `eval_point.len()`, or if `N == 0`.
-pub fn quadratic_mlecheck_prover<F, P, Composition, InfinityComposition, const N: usize>(
-	multilinears: [FieldBuffer<P>; N],
+pub fn quadratic_mlecheck_prover<
+	'alloc,
+	A,
+	F,
+	P,
+	Composition,
+	InfinityComposition,
+	const N: usize,
+>(
+	alloc: &'alloc A,
+	multilinears: [PooledColumn<A, P>; N],
 	composition: Composition,
 	infinity_composition: InfinityComposition,
 	eval_point: Vec<F>,
 	eval_claim: F,
-) -> SharedMleCheckProver<'static, F, P, QuadraticMleEvaluator<Composition, InfinityComposition, N>>
+) -> SharedMleCheckProver<'alloc, A, F, P, QuadraticMleEvaluator<Composition, InfinityComposition, N>>
 where
+	A: Allocator,
 	F: Field,
 	P: PackedField<Scalar = F>,
 	Composition: Fn([P; N]) -> P + Send + Sync,
 	InfinityComposition: Fn([P; N]) -> P + Send + Sync,
 {
-	let mut store = MleStore::new(eval_point.len());
+	let mut store = MleStore::new(eval_point.len(), alloc);
 	// Hand each column to the store, which checks its variable count against the point length.
 	let cols = multilinears.map(|col| store.push_owned(col));
 	let evaluator = QuadraticMleEvaluator::new(cols, composition, infinity_composition);
 	SharedMleCheckProver::new(store, [(eval_claim, evaluator)], eval_point)
 }
 
-impl<F, P, Composition, InfinityComposition, const N: usize> MleCheckRoundEvaluator<F, P>
+impl<A, F, P, Composition, InfinityComposition, const N: usize> MleCheckRoundEvaluator<A, F, P>
 	for QuadraticMleEvaluator<Composition, InfinityComposition, N>
 where
+	A: Allocator,
 	F: Field,
 	P: PackedField<Scalar = F>,
 	Composition: Fn([P; N]) -> P + Send + Sync,
@@ -165,7 +177,7 @@ where
 
 	fn interpolate(
 		&self,
-		store: &MleStore<'_, P>,
+		store: &MleStore<'_, A, P>,
 		accum: &[P],
 		claim: F,
 		alpha: F,
@@ -190,9 +202,11 @@ where
 mod tests {
 	use std::{array, iter};
 
+	use binius_compute::GlobalAllocator;
 	use binius_field::{Random, arch::OptimalPackedB128, field::FieldOps};
 	use binius_ip::mlecheck;
 	use binius_math::{
+		FieldBuffer,
 		multilinear::evaluate::evaluate,
 		test_utils::{random_field_buffer, random_scalars},
 	};
@@ -201,7 +215,7 @@ mod tests {
 	use rand::prelude::*;
 
 	use super::*;
-	use crate::sumcheck::{common::SumcheckProver, prove_single_mlecheck};
+	use crate::sumcheck::{common::SumcheckProver, mle_store::pooled_copy, prove_single_mlecheck};
 
 	type StdChallenger = HasherChallenger<sha2::Sha256>;
 
@@ -218,6 +232,7 @@ mod tests {
 	{
 		let n_vars = 8;
 		let mut rng = StdRng::seed_from_u64(0);
+		let alloc = GlobalAllocator;
 
 		let multilinears: [_; N] = array::from_fn(|_| random_field_buffer::<P>(&mut rng, n_vars));
 
@@ -230,7 +245,8 @@ mod tests {
 		let eval_claim = evaluate(&composite_vals, &eval_point);
 
 		let prover = quadratic_mlecheck_prover(
-			multilinears.clone(),
+			&alloc,
+			array::from_fn(|i| pooled_copy(&alloc, &multilinears[i])),
 			composition.clone(),
 			infinity_composition,
 			eval_point.clone(),
@@ -311,6 +327,7 @@ mod tests {
 
 		let n_vars = 8;
 		let mut rng = StdRng::seed_from_u64(0);
+		let alloc = GlobalAllocator;
 
 		let multilinears: [_; 2] = array::from_fn(|_| random_field_buffer::<P>(&mut rng, n_vars));
 		let composition = |[a, b]: [P; 2]| a * b;
@@ -322,7 +339,8 @@ mod tests {
 		let eval_claim = evaluate(&composite_vals, &eval_point);
 
 		let mut prover = quadratic_mlecheck_prover(
-			multilinears,
+			&alloc,
+			array::from_fn(|i| pooled_copy(&alloc, &multilinears[i])),
 			composition,
 			composition,
 			eval_point,

--- a/crates/ip-prover/src/sumcheck/quadratic_mle_evaluator.rs
+++ b/crates/ip-prover/src/sumcheck/quadratic_mle_evaluator.rs
@@ -3,10 +3,10 @@
 use binius_compute::Allocator;
 use binius_field::{Field, PackedField, WideMul};
 use binius_ip::sumcheck::RoundCoeffs;
-use binius_math::FieldSlice;
+use binius_math::{FieldSlice, FieldVec};
 
 use super::{
-	mle_store::{ColId, ColumnChunk, EvaluationChunk, MleStore, PooledColumn},
+	mle_store::{ColId, ColumnChunk, EvaluationChunk, MleStore},
 	round_evals::RoundEvals2,
 	round_evaluator::{MleCheckRoundEvaluator, SharedMleCheckProver},
 };
@@ -102,7 +102,7 @@ pub fn quadratic_mlecheck_prover<
 	const N: usize,
 >(
 	alloc: &'alloc A,
-	multilinears: [PooledColumn<A, P>; N],
+	multilinears: [FieldVec<P, A>; N],
 	composition: Composition,
 	infinity_composition: InfinityComposition,
 	eval_point: Vec<F>,
@@ -215,7 +215,7 @@ mod tests {
 	use rand::prelude::*;
 
 	use super::*;
-	use crate::sumcheck::{common::SumcheckProver, mle_store::pooled_copy, prove_single_mlecheck};
+	use crate::sumcheck::{common::SumcheckProver, prove_single_mlecheck};
 
 	type StdChallenger = HasherChallenger<sha2::Sha256>;
 
@@ -246,7 +246,7 @@ mod tests {
 
 		let prover = quadratic_mlecheck_prover(
 			&alloc,
-			array::from_fn(|i| pooled_copy(&alloc, &multilinears[i])),
+			multilinears.clone(),
 			composition.clone(),
 			infinity_composition,
 			eval_point.clone(),
@@ -340,7 +340,7 @@ mod tests {
 
 		let mut prover = quadratic_mlecheck_prover(
 			&alloc,
-			array::from_fn(|i| pooled_copy(&alloc, &multilinears[i])),
+			multilinears,
 			composition,
 			composition,
 			eval_point,

--- a/crates/ip-prover/src/sumcheck/round_evaluator.rs
+++ b/crates/ip-prover/src/sumcheck/round_evaluator.rs
@@ -23,14 +23,15 @@
 use std::iter;
 
 use auto_impl::auto_impl;
+use binius_compute::Allocator;
 use binius_field::{Field, PackedField, WideMul};
 use binius_ip::sumcheck::RoundCoeffs;
-use binius_math::{FieldBuffer, FieldSlice, multilinear::eq::eq_ind_partial_eval};
+use binius_math::{FieldSlice, multilinear::eq::eq_ind_partial_eval};
 
 use super::{
 	MleToSumCheckEvaluator,
 	common::{MleCheckProver, SumcheckProver},
-	mle_store::{ColId, EvaluationChunk, MleStore},
+	mle_store::{ColId, EvaluationChunk, MleStore, PooledColumn},
 	round_state::RoundState,
 };
 
@@ -58,7 +59,9 @@ use super::{
 /// evaluators can drive a shared prover as `Vec<Box<dyn SumcheckRoundEvaluator<F, P>>>` while a
 /// homogeneous group avoids boxing.
 #[auto_impl(Box)]
-pub trait SumcheckRoundEvaluator<F: Field, P: PackedField<Scalar = F>>: Send + Sync {
+pub trait SumcheckRoundEvaluator<A: Allocator, F: Field, P: PackedField<Scalar = F>>:
+	Send + Sync
+{
 	/// The number of accumulator slots this evaluator's claim uses.
 	///
 	/// This is the count of sampled round-polynomial evaluations the accumulation pass collects;
@@ -86,7 +89,7 @@ pub trait SumcheckRoundEvaluator<F: Field, P: PackedField<Scalar = F>>: Send + S
 	/// the eq trackers are at the current round's state.
 	fn interpolate(
 		&self,
-		store: &MleStore<'_, P>,
+		store: &MleStore<'_, A, P>,
 		accum: &[<P as WideMul>::Output],
 		claim: F,
 	) -> RoundCoeffs<F>;
@@ -106,7 +109,9 @@ pub trait SumcheckRoundEvaluator<F: Field, P: PackedField<Scalar = F>>: Send + S
 /// [`SumcheckRoundEvaluator`]: stateless across rounds, degree-sized accumulator slots owned by the
 /// prover, one virtual [`Self::accumulate`] entry per chunk.
 #[auto_impl(Box)]
-pub trait MleCheckRoundEvaluator<F: Field, P: PackedField<Scalar = F>>: Send + Sync {
+pub trait MleCheckRoundEvaluator<A: Allocator, F: Field, P: PackedField<Scalar = F>>:
+	Send + Sync
+{
 	/// The number of accumulator slots this evaluator's claim uses. See
 	/// [`SumcheckRoundEvaluator::degree`].
 	fn degree(&self) -> usize;
@@ -133,7 +138,7 @@ pub trait MleCheckRoundEvaluator<F: Field, P: PackedField<Scalar = F>>: Send + S
 	/// `reduce` can operate on `P`.
 	fn interpolate(
 		&self,
-		store: &MleStore<'_, P>,
+		store: &MleStore<'_, A, P>,
 		accum: &[P],
 		claim: F,
 		alpha: F,
@@ -167,8 +172,8 @@ fn accum_offsets(degrees: impl IntoIterator<Item = usize>) -> Vec<usize> {
 /// and lists the round polynomials in evaluator registration order. [`Self::fold`] folds each
 /// shared column and eq tracker once. [`Self::finish`] emits each store column's evaluation once,
 /// computed a single time by the store no matter how many claims read the column.
-pub struct SharedSumcheckProver<'a, P: PackedField, Evaluator> {
-	store: MleStore<'a, P>,
+pub struct SharedSumcheckProver<'a, A: Allocator, P: PackedField, Evaluator> {
+	store: MleStore<'a, A, P>,
 	evaluators: Vec<Evaluator>,
 	/// The claim ↔ round-coeffs state machine, one entry per evaluator (parallel to `evaluators`).
 	///
@@ -185,11 +190,12 @@ pub struct SharedSumcheckProver<'a, P: PackedField, Evaluator> {
 	buffered_challenge: Option<P::Scalar>,
 }
 
-impl<'a, F, P, Evaluator> SharedSumcheckProver<'a, P, Evaluator>
+impl<'a, A, F, P, Evaluator> SharedSumcheckProver<'a, A, P, Evaluator>
 where
+	A: Allocator,
 	F: Field,
 	P: PackedField<Scalar = F>,
-	Evaluator: SumcheckRoundEvaluator<F, P>,
+	Evaluator: SumcheckRoundEvaluator<A, F, P>,
 {
 	/// Creates a prover from a store and the evaluators reading its columns, each paired with its
 	/// initial claim — one `(claim, evaluator)` per claim.
@@ -197,7 +203,7 @@ where
 	/// Taking an [`IntoIterator`] lets callers pass an array of pairs directly, rather than two
 	/// parallel `Vec`s; the pairs are unzipped into the evaluators and their initial round states.
 	pub fn new(
-		store: MleStore<'a, P>,
+		store: MleStore<'a, A, P>,
 		claims_with_evaluators: impl IntoIterator<Item = (F, Evaluator)>,
 	) -> Self {
 		let (round_states, evaluators) = claims_with_evaluators
@@ -213,7 +219,7 @@ where
 	}
 
 	/// Returns a shared reference to the underlying column store.
-	pub const fn store(&self) -> &MleStore<'a, P> {
+	pub const fn store(&self) -> &MleStore<'a, A, P> {
 		&self.store
 	}
 
@@ -222,7 +228,7 @@ where
 	/// Lets a caller extend the shared store with a fresh column that a later-added evaluator
 	/// reads: the logUp* final layer pushes the table halves this way before adding its product
 	/// evaluators. See [`MleStore::push_owned`].
-	pub fn push_owned_column(&mut self, column: FieldBuffer<P>) -> ColId {
+	pub fn push_owned_column(&mut self, column: PooledColumn<A, P>) -> ColId {
 		self.store.push_owned(column)
 	}
 
@@ -236,11 +242,12 @@ where
 	}
 }
 
-impl<F, P, Evaluator> SumcheckProver<F> for SharedSumcheckProver<'_, P, Evaluator>
+impl<A, F, P, Evaluator> SumcheckProver<F> for SharedSumcheckProver<'_, A, P, Evaluator>
 where
+	A: Allocator,
 	F: Field,
 	P: PackedField<Scalar = F>,
-	Evaluator: SumcheckRoundEvaluator<F, P>,
+	Evaluator: SumcheckRoundEvaluator<A, F, P>,
 {
 	fn n_vars(&self) -> usize {
 		// A buffered challenge is a fold that has not yet reached the store, so the logical
@@ -363,8 +370,8 @@ where
 /// of the MLE-check protocol. Because the point is shared, the prover owns its eq-indicator tracker
 /// and hands the round's eq chunk and coordinate to the evaluators, which therefore store no
 /// tracker id.
-pub struct SharedMleCheckProver<'a, F: Field, P: PackedField<Scalar = F>, Evaluator> {
-	store: MleStore<'a, P>,
+pub struct SharedMleCheckProver<'a, A: Allocator, F: Field, P: PackedField<Scalar = F>, Evaluator> {
+	store: MleStore<'a, A, P>,
 	evaluators: Vec<Evaluator>,
 	/// The claim ↔ round-coeffs state machine, one entry per evaluator; see the field of the same
 	/// name on [`SharedSumcheckProver`].
@@ -379,17 +386,18 @@ pub struct SharedMleCheckProver<'a, F: Field, P: PackedField<Scalar = F>, Evalua
 	eval_point: Vec<F>,
 }
 
-impl<'a, F, P, Evaluator> SharedMleCheckProver<'a, F, P, Evaluator>
+impl<'a, A, F, P, Evaluator> SharedMleCheckProver<'a, A, F, P, Evaluator>
 where
+	A: Allocator,
 	F: Field,
 	P: PackedField<Scalar = F>,
-	Evaluator: MleCheckRoundEvaluator<F, P>,
+	Evaluator: MleCheckRoundEvaluator<A, F, P>,
 {
 	/// Creates a prover from a store, the evaluators reading its columns each paired with its
 	/// initial claim — one `(claim, evaluator)` per claim — and the evaluation point shared by all
 	/// of the evaluators' claims.
 	pub fn new(
-		store: MleStore<'a, P>,
+		store: MleStore<'a, A, P>,
 		claims_with_evaluators: impl IntoIterator<Item = (F, Evaluator)>,
 		eval_point: Vec<F>,
 	) -> Self {
@@ -424,9 +432,9 @@ where
 	/// [Gruen24]: <https://eprint.iacr.org/2024/108>
 	pub fn into_shared_sumcheck(
 		self,
-	) -> SharedSumcheckProver<'a, P, Box<dyn SumcheckRoundEvaluator<F, P>>>
+	) -> SharedSumcheckProver<'a, A, P, Box<dyn SumcheckRoundEvaluator<A, F, P> + 'a>>
 	where
-		Evaluator: 'static,
+		Evaluator: 'a,
 	{
 		let Self {
 			mut store,
@@ -448,7 +456,7 @@ where
 			.into_iter()
 			.map(|evaluator| {
 				Box::new(MleToSumCheckEvaluator::new(evaluator, eq_tracker))
-					as Box<dyn SumcheckRoundEvaluator<F, P>>
+					as Box<dyn SumcheckRoundEvaluator<A, F, P> + 'a>
 			})
 			.collect();
 		SharedSumcheckProver {
@@ -460,11 +468,12 @@ where
 	}
 }
 
-impl<F, P, Evaluator> SumcheckProver<F> for SharedMleCheckProver<'_, F, P, Evaluator>
+impl<A, F, P, Evaluator> SumcheckProver<F> for SharedMleCheckProver<'_, A, F, P, Evaluator>
 where
+	A: Allocator,
 	F: Field,
 	P: PackedField<Scalar = F>,
-	Evaluator: MleCheckRoundEvaluator<F, P>,
+	Evaluator: MleCheckRoundEvaluator<A, F, P>,
 {
 	fn n_vars(&self) -> usize {
 		// A buffered challenge is a fold that has not yet reached the store, so the logical
@@ -580,11 +589,12 @@ where
 	}
 }
 
-impl<F, P, Evaluator> MleCheckProver<F> for SharedMleCheckProver<'_, F, P, Evaluator>
+impl<A, F, P, Evaluator> MleCheckProver<F> for SharedMleCheckProver<'_, A, F, P, Evaluator>
 where
+	A: Allocator,
 	F: Field,
 	P: PackedField<Scalar = F>,
-	Evaluator: MleCheckRoundEvaluator<F, P>,
+	Evaluator: MleCheckRoundEvaluator<A, F, P>,
 {
 	fn eval_point(&self) -> &[F] {
 		&self.eval_point[..self.n_vars()]
@@ -596,6 +606,7 @@ where
 // claims over shared columns).
 #[cfg(test)]
 mod tests {
+	use binius_compute::GlobalAllocator;
 	use binius_field::FieldOps;
 	use binius_ip::sumcheck::{batch_verify, batch_verify_mle};
 	use binius_math::{
@@ -670,16 +681,24 @@ mod tests {
 
 	// The store + evaluator MLE-check prover for the two fractional-addition claims, borrowing the
 	// four shared columns.
+	#[allow(clippy::type_complexity)]
 	fn new_frac_prover<'a>(
+		alloc: &'a GlobalAllocator,
 		cols: &'a [FieldBuffer<P>; 4],
 		eval_point: &[F],
 		claims: [F; 2],
-	) -> SharedMleCheckProver<'a, F, P, Box<dyn MleCheckRoundEvaluator<F, P>>> {
-		let mut store = MleStore::new(eval_point.len());
+	) -> SharedMleCheckProver<
+		'a,
+		GlobalAllocator,
+		F,
+		P,
+		Box<dyn MleCheckRoundEvaluator<GlobalAllocator, F, P>>,
+	> {
+		let mut store = MleStore::new(eval_point.len(), alloc);
 		let col_ids = cols.each_ref().map(|col| store.push(col.to_ref()));
 		let (num_ev, den_ev) = frac_add_mle::evaluators(col_ids);
-		let claims_with_evaluators: [(F, Box<dyn MleCheckRoundEvaluator<F, P>>); 2] =
-			[(claims[0], Box::new(num_ev)), (claims[1], Box::new(den_ev))];
+		let claims_with_evaluators: [(F, Box<dyn MleCheckRoundEvaluator<GlobalAllocator, F, P>>);
+			2] = [(claims[0], Box::new(num_ev)), (claims[1], Box::new(den_ev))];
 		SharedMleCheckProver::new(store, claims_with_evaluators, eval_point.to_vec())
 	}
 
@@ -697,9 +716,12 @@ mod tests {
 			let (cols, eval_point, claims) = frac_instance(&mut rng, n_vars);
 
 			// Prove: one shared prover carries both claims over the four columns.
+			let alloc = GlobalAllocator;
 			let mut transcript = ProverTranscript::new(StdChallenger::default());
-			let output =
-				batch_prove_mle(vec![new_frac_prover(&cols, &eval_point, claims)], &mut transcript);
+			let output = batch_prove_mle(
+				vec![new_frac_prover(&alloc, &cols, &eval_point, claims)],
+				&mut transcript,
+			);
 
 			// The shared prover emits the four column evaluations once, in push order.
 			assert_eq!(output.multilinear_evals.len(), 1);
@@ -740,6 +762,7 @@ mod tests {
 	// two plain product claims, all sharing the pushforward halves in one store. Prove through the
 	// sumcheck batch driver, then verify the reduced evaluation against the batched compositions.
 	#[test]
+	#[allow(clippy::type_complexity)]
 	fn test_shared_final_layer_prove_verify() {
 		for m in [1, 2, 3, 6] {
 			let mut rng = StdRng::seed_from_u64(0);
@@ -771,7 +794,8 @@ mod tests {
 			let e_1 = inner_product_par(&y_1, &t_1);
 
 			// One store with six borrowed columns, in push order [Y_0, Y_1, D_0, D_1, T_0, T_1].
-			let mut store = MleStore::new(m - 1);
+			let alloc = GlobalAllocator;
+			let mut store = MleStore::new(m - 1, &alloc);
 			let [y_0_col, y_1_col, d_0_col, d_1_col, t_0_col, t_1_col] =
 				[&y_0, &y_1, &d_0, &d_1, &t_0, &t_1].map(|col| store.push(col.to_ref()));
 
@@ -790,7 +814,10 @@ mod tests {
 
 			// Claims paired with evaluators in order: the two fractional claims, then the two
 			// product sums.
-			let claims_with_evaluators: [(F, Box<dyn SumcheckRoundEvaluator<F, P>>); 4] = [
+			let claims_with_evaluators: [(
+				F,
+				Box<dyn SumcheckRoundEvaluator<GlobalAllocator, F, P>>,
+			); 4] = [
 				(frac_claims[0], Box::new(num_evaluator)),
 				(frac_claims[1], Box::new(den_evaluator)),
 				(e_0, Box::new(product_0)),

--- a/crates/ip-prover/src/sumcheck/round_evaluator.rs
+++ b/crates/ip-prover/src/sumcheck/round_evaluator.rs
@@ -26,12 +26,12 @@ use auto_impl::auto_impl;
 use binius_compute::Allocator;
 use binius_field::{Field, PackedField, WideMul};
 use binius_ip::sumcheck::RoundCoeffs;
-use binius_math::{FieldSlice, multilinear::eq::eq_ind_partial_eval};
+use binius_math::{FieldSlice, FieldVec, multilinear::eq::eq_ind_partial_eval};
 
 use super::{
 	MleToSumCheckEvaluator,
 	common::{MleCheckProver, SumcheckProver},
-	mle_store::{ColId, EvaluationChunk, MleStore, PooledColumn},
+	mle_store::{ColId, EvaluationChunk, MleStore},
 	round_state::RoundState,
 };
 
@@ -228,7 +228,7 @@ where
 	/// Lets a caller extend the shared store with a fresh column that a later-added evaluator
 	/// reads: the logUp* final layer pushes the table halves this way before adding its product
 	/// evaluators. See [`MleStore::push_owned`].
-	pub fn push_owned_column(&mut self, column: PooledColumn<A, P>) -> ColId {
+	pub fn push_owned_column(&mut self, column: FieldVec<P, A>) -> ColId {
 		self.store.push_owned(column)
 	}
 

--- a/crates/ip-prover/src/sumcheck/zk_mlecheck.rs
+++ b/crates/ip-prover/src/sumcheck/zk_mlecheck.rs
@@ -665,14 +665,16 @@ mod tests {
 
 	#[test]
 	fn test_libra_eval_sumcheck() {
+		use binius_compute::GlobalAllocator;
 		use binius_ip::{mlecheck::libra_eval, sumcheck::verify};
 		use binius_math::{inner_product::inner_product_par, multilinear::evaluate::evaluate};
 
-		use crate::sumcheck::{bivariate_product_prover, prove_single};
+		use crate::sumcheck::{bivariate_product_prover, mle_store::pooled_copy, prove_single};
 
 		let mut rng = StdRng::seed_from_u64(0);
 		let n_vars = 6;
 		let degree = 2;
+		let alloc = GlobalAllocator;
 
 		// Create random mask buffer (g')
 		let (m_n, m_d) = mask_buffer_dimensions(n_vars, degree, 0);
@@ -690,8 +692,14 @@ mod tests {
 		let claimed_sum = inner_product_par(&mask_buffer, &libra_eval_tensor);
 
 		// Create the bivariate product sumcheck prover
-		let prover =
-			bivariate_product_prover([mask_buffer.clone(), libra_eval_tensor], claimed_sum);
+		let prover = bivariate_product_prover(
+			&alloc,
+			[
+				pooled_copy(&alloc, &mask_buffer),
+				pooled_copy(&alloc, &libra_eval_tensor),
+			],
+			claimed_sum,
+		);
 
 		// Run the proving protocol
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());

--- a/crates/ip-prover/src/sumcheck/zk_mlecheck.rs
+++ b/crates/ip-prover/src/sumcheck/zk_mlecheck.rs
@@ -669,7 +669,7 @@ mod tests {
 		use binius_ip::{mlecheck::libra_eval, sumcheck::verify};
 		use binius_math::{inner_product::inner_product_par, multilinear::evaluate::evaluate};
 
-		use crate::sumcheck::{bivariate_product_prover, mle_store::pooled_copy, prove_single};
+		use crate::sumcheck::{bivariate_product_prover, prove_single};
 
 		let mut rng = StdRng::seed_from_u64(0);
 		let n_vars = 6;
@@ -692,14 +692,8 @@ mod tests {
 		let claimed_sum = inner_product_par(&mask_buffer, &libra_eval_tensor);
 
 		// Create the bivariate product sumcheck prover
-		let prover = bivariate_product_prover(
-			&alloc,
-			[
-				pooled_copy(&alloc, &mask_buffer),
-				pooled_copy(&alloc, &libra_eval_tensor),
-			],
-			claimed_sum,
-		);
+		let prover =
+			bivariate_product_prover(&alloc, [mask_buffer.clone(), libra_eval_tensor], claimed_sum);
 
 		// Run the proving protocol
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());

--- a/crates/m4-prover/Cargo.toml
+++ b/crates/m4-prover/Cargo.toml
@@ -14,6 +14,7 @@ binius-frontend = { path = "../frontend" }
 binius-hash = { path = "../hash" }
 binius-iop-prover = { path = "../iop-prover" }
 binius-ip = { path = "../ip" }
+binius-compute = { path = "../compute" }
 binius-ip-prover = { path = "../ip-prover" }
 binius-m4-verifier = { path = "../m4-verifier" }
 binius-math = { path = "../math" }

--- a/crates/m4-prover/src/operand_witness.rs
+++ b/crates/m4-prover/src/operand_witness.rs
@@ -606,7 +606,7 @@ mod tests {
 			.isomorphic::<B128>()
 			.reduce_dim(SKIPPED_VARS);
 		let lagrange = lagrange_evals_scalars(&univariate_domain, z_challenge);
-		let folded: FieldBuffer<B128> = BitAxisFolder::new(&lagrange).fold(col);
+		let folded: FieldBuffer<B128> = BitAxisFolder::new(&lagrange).fold(&GlobalAllocator, col);
 		evaluate(&folded, eval_point)
 	}
 

--- a/crates/m4-prover/src/operand_witness.rs
+++ b/crates/m4-prover/src/operand_witness.rs
@@ -13,6 +13,7 @@
 
 use std::{iter, mem::MaybeUninit, ptr};
 
+use binius_compute::Allocator;
 use binius_core::{
 	ValueIndex,
 	constraint_system::{
@@ -168,14 +169,16 @@ impl BatchAndCheckWitness {
 	/// - The claimed `A`, `B`, `C` evaluations.
 	/// - The univariate (bit-index) challenge.
 	/// - The multilinear evaluation point reached by the sumcheck.
-	pub fn prove<P, Channel>(
+	pub fn prove<P, Channel, A>(
 		self,
 		prover_message_domain: &BinarySubspace<B8>,
 		channel: &mut Channel,
+		alloc: &A,
 	) -> AndCheckOutput<B128>
 	where
 		P: PackedField<Scalar = B128>,
 		Channel: IPProverChannel<B128>,
+		A: Allocator,
 	{
 		let (a, b) = self.into_columns();
 
@@ -201,7 +204,7 @@ impl BatchAndCheckWitness {
 			prover_message_domain.isomorphic(),
 		);
 
-		prover.prove_with_channel(channel)
+		prover.prove_with_channel(channel, alloc)
 	}
 }
 
@@ -562,6 +565,7 @@ pub fn build_binmul_witness(
 #[cfg(test)]
 mod tests {
 	use assert_matches::assert_matches;
+	use binius_compute::GlobalAllocator;
 	use binius_core::constraint_system::ValueVec;
 	use binius_field::PackedBinaryGhash1x128b;
 	use binius_frontend::{Circuit, CircuitBuilder, Wire};
@@ -1058,7 +1062,8 @@ mod tests {
 
 		// Prover and verifier agree on the reduced claim over the batched columns.
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
-		let prove_output = witness.prove::<P, _>(&message_domain(), &mut prover_transcript);
+		let prove_output =
+			witness.prove::<P, _, _>(&message_domain(), &mut prover_transcript, &GlobalAllocator);
 
 		let mut verifier_transcript = prover_transcript.into_verifier();
 		let verify_output = verify_bitand_reduction(
@@ -1089,7 +1094,8 @@ mod tests {
 
 		// Produce a faithful proof.
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
-		let _ = witness.prove::<P, _>(&message_domain(), &mut prover_transcript);
+		let _ =
+			witness.prove::<P, _, _>(&message_domain(), &mut prover_transcript, &GlobalAllocator);
 		let mut proof = prover_transcript.finalize();
 
 		// Mutation: flip a bit in the prover's first message, the univariate round evaluations.
@@ -1143,7 +1149,7 @@ mod tests {
 			let log_total = checked_log_2(witness.a().len());
 
 			let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
-			let prove_output = witness.prove::<P, _>(&message_domain(), &mut prover_transcript);
+			let prove_output = witness.prove::<P, _, _>(&message_domain(), &mut prover_transcript, &GlobalAllocator);
 
 			let mut verifier_transcript = prover_transcript.into_verifier();
 			let verify_output =

--- a/crates/m4-prover/src/prove.rs
+++ b/crates/m4-prover/src/prove.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-use binius_compute::{Allocator, BufferPool};
+use binius_compute::{Allocator, BufferPool, VecLike};
 use binius_core::{constraint_system::ConstraintSystem, word::Word};
 use binius_field::{AESTowerField8b as B8, Field, PackedField};
 use binius_hash::StdHashSuite;
@@ -9,13 +9,13 @@ use binius_iop_prover::{basefold::compiler::BaseFoldProverCompiler, channel::IOP
 use binius_ip_prover::sumcheck::{
 	MleToSumCheckEvaluator,
 	batch::batch_prove_and_write_evals,
-	mle_store::{MleStore, pooled_copy},
+	mle_store::MleStore,
 	quadratic_mle_evaluator::QuadraticMleEvaluator,
 	round_evaluator::{SharedSumcheckProver, SumcheckRoundEvaluator},
 };
 use binius_m4_verifier::{IOPVerifier, Verifier};
 use binius_math::{
-	BinarySubspace, FieldBuffer,
+	BinarySubspace, FieldBuffer, FieldVec,
 	inner_product::inner_product,
 	multilinear::eq::eq_ind_partial_eval_scalars,
 	ntt::{NeighborsLastMultiThread, domain_context::GenericPreExpanded},
@@ -525,9 +525,11 @@ impl<'a, const ARITY: usize> Operation<'a, ARITY> {
 		// The constraint tensor is the same for every operand of this operation, so expand it once.
 		let r_x_tensor = eq_ind_partial_eval_scalars::<B128>(&self.r_x);
 		for (column, &claim) in self.columns.iter().zip(&self.operand_claims) {
-			let col = store.push_owned(pooled_copy(
+			let col = store.push_owned(operand_rho_multilinear::<A, P>(
 				alloc,
-				&operand_rho_multilinear::<P>(column, lagrange, &r_x_tensor),
+				column,
+				lagrange,
+				&r_x_tensor,
 			));
 			let evaluator = QuadraticMleEvaluator::new(
 				[col],
@@ -753,21 +755,24 @@ impl RerandomizedOperations<'_> {
 ///
 /// Its evaluation at the operation's instance point equals that operation's oblong operand claim.
 /// So the re-randomization sumcheck can transport that claim to a shared instance point.
-fn operand_rho_multilinear<P>(
+fn operand_rho_multilinear<A, P>(
+	alloc: &A,
 	column: &[Word],
 	lagrange: &[B128],
 	r_x_tensor: &[B128],
-) -> FieldBuffer<P>
+) -> FieldVec<P, A>
 where
+	A: Allocator,
 	P: PackedField<Scalar = B128>,
 {
 	// Fold each word's bits at the univariate challenge: one scalar per row, laid out
 	// constraint-major.
 	// Folding into scalars keeps the row indexing flat for the constraint fold.
-	let folded_rows = fold_words::<B128, B128>(column, lagrange);
+	let folded_rows = fold_words::<B128, B128, _>(alloc, column, lagrange);
 	let folded_rows = folded_rows.as_ref();
 
-	// Produce the packed instance-axis multilinear directly, one packed element per parallel task.
+	// Produce the packed instance-axis multilinear directly into the allocator's buffer, one packed
+	// element per parallel task.
 	// Each element's lanes are the constraint folds of consecutive instances.
 	// Lanes past the instance count are the multilinear's zero padding.
 	//
@@ -777,10 +782,14 @@ where
 	let n_instances = folded_rows.len() / n_constraints;
 	let log_instances = checked_log_2(n_instances);
 	let log_packed = log_instances.saturating_sub(P::LOG_WIDTH);
-	let packed = (0..1usize << log_packed)
-		.into_par_iter()
-		.map(|packed_index| {
-			P::from_scalars((0..P::WIDTH).map(|lane| {
+	let packed_len = 1usize << log_packed;
+	let mut packed = alloc.alloc::<P>(packed_len);
+	packed
+		.spare_capacity_mut()
+		.par_iter_mut()
+		.enumerate()
+		.for_each(|(packed_index, slot)| {
+			slot.write(P::from_scalars((0..P::WIDTH).map(|lane| {
 				let instance = (packed_index << P::LOG_WIDTH) | lane;
 				if instance < n_instances {
 					r_x_tensor
@@ -793,9 +802,10 @@ where
 				} else {
 					B128::ZERO
 				}
-			}))
-		})
-		.collect::<Vec<P>>();
+			})));
+		});
+	// Safety: every packed slot is written exactly once by the parallel loop above.
+	unsafe { packed.set_len(packed_len) };
 
 	FieldBuffer::new(log_instances, packed)
 }

--- a/crates/m4-prover/src/prove.rs
+++ b/crates/m4-prover/src/prove.rs
@@ -1,6 +1,7 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
+use binius_compute::{Allocator, BufferPool};
 use binius_core::{constraint_system::ConstraintSystem, word::Word};
 use binius_field::{AESTowerField8b as B8, Field, PackedField};
 use binius_hash::StdHashSuite;
@@ -8,7 +9,7 @@ use binius_iop_prover::{basefold::compiler::BaseFoldProverCompiler, channel::IOP
 use binius_ip_prover::sumcheck::{
 	MleToSumCheckEvaluator,
 	batch::batch_prove_and_write_evals,
-	mle_store::MleStore,
+	mle_store::{MleStore, pooled_copy},
 	quadratic_mle_evaluator::QuadraticMleEvaluator,
 	round_evaluator::{SharedSumcheckProver, SumcheckRoundEvaluator},
 };
@@ -106,10 +107,11 @@ impl IOPProver {
 	///
 	/// This is the core proving logic, independent of the specific IOP compilation strategy. For
 	/// most users, [`Prover::prove`] is the simpler interface.
-	pub fn prove<P, Channel>(&self, table: &ValueTable, channel: &mut Channel)
+	pub fn prove<P, Channel, A>(&self, table: &ValueTable, channel: &mut Channel, alloc: &A)
 	where
 		P: PackedField<Scalar = B128>,
 		Channel: IOPProverChannel<P>,
+		A: Allocator,
 	{
 		let cs = &self.cs;
 
@@ -156,7 +158,7 @@ impl IOPProver {
 					build_intmul_witness(table, &cs.constants, &cs.imul_constraints);
 				[a, b, lo, hi]
 			};
-			let output = prove_intmul::<P, _>(&columns, channel);
+			let output = prove_intmul::<P, _, _>(&columns, channel, alloc);
 			(columns, output)
 		});
 
@@ -178,7 +180,7 @@ impl IOPProver {
 				let _scope = tracing::debug_span!("Assemble BinMul witness").entered();
 				build_binmul_witness(table, &cs.constants, &cs.bmul_constraints)
 			};
-			let output = prove_binmul::<P, _>(&columns, channel);
+			let output = prove_binmul::<P, _, _>(&columns, channel, alloc);
 			(columns, output)
 		});
 
@@ -212,7 +214,7 @@ impl IOPProver {
 					.collect();
 				[and_witness.a().to_vec(), and_witness.b().to_vec(), c_column]
 			});
-			(and_columns, and_witness.prove::<P, _>(&andcheck_domain, channel))
+			(and_columns, and_witness.prove::<P, _, _>(&andcheck_domain, channel, alloc))
 		};
 
 		// The AND-check row point is `r_rho_and || r_x_and`: the instance index on the low
@@ -241,7 +243,7 @@ impl IOPProver {
 					Operation::from_binmul(columns, output.clone(), &lagrange, log_instances)
 				}),
 			}
-			.prove::<P, _>(&lagrange, z_challenge, channel)
+			.prove::<P, _, _>(&lagrange, z_challenge, channel, alloc)
 		} else {
 			// Neither IMUL nor BMUL constraints: the AND-check instance point is used directly.
 			// The IntMul and BinMul claims are zero claims at an empty point, contributing nothing
@@ -283,7 +285,7 @@ impl IOPProver {
 		// Reduce the operand claims to one witness evaluation.
 		let witness_claim = {
 			let _scope = tracing::debug_span!("Prove shift reduction").entered();
-			prove_shift::<B128, P, _>(
+			prove_shift::<B128, P, _, _>(
 				&self.key_collection,
 				&public_words,
 				&folded_witness,
@@ -292,6 +294,7 @@ impl IOPProver {
 				binmul_data,
 				&shift_domain,
 				channel,
+				alloc,
 			)
 		};
 
@@ -388,10 +391,14 @@ where
 			.basefold_compiler
 			.create_channel_without_zk_from_transcript::<StdHashSuite, Challenger_, _>(transcript);
 
-		self.iop_prover.prove::<P, _>(table, &mut channel);
+		// Working buffers for this proof are drawn from a single pool that lives for the call.
+		let pool = BufferPool::new();
+		let alloc = &pool;
+		self.iop_prover
+			.prove::<P, _, _>(table, &mut channel, &alloc);
 
 		let _scope = tracing::debug_span!("PCS opening").entered();
-		channel.finish();
+		channel.finish(&alloc);
 	}
 }
 
@@ -402,10 +409,15 @@ where
 /// Each is `K * n_imul` rows, laid out constraint-major.
 /// The check reduces the multiplication relation to per-bit evaluation claims on the four columns.
 /// Those claims share a common row point.
-fn prove_intmul<P, Channel>(columns: &[Vec<Word>; 4], channel: &mut Channel) -> IntMulOutput<B128>
+fn prove_intmul<P, Channel, A>(
+	columns: &[Vec<Word>; 4],
+	channel: &mut Channel,
+	alloc: &A,
+) -> IntMulOutput<B128>
 where
 	P: PackedField<Scalar = B128>,
 	Channel: IOPProverChannel<P>,
+	A: Allocator,
 {
 	let _scope = tracing::debug_span!("IntMul check").entered();
 
@@ -415,11 +427,11 @@ where
 
 	// A prepared constraint system pads its constraint and instance counts to powers of two, so the
 	// columns always have a power-of-two length as the witness requires.
-	let witness = IntMulWitness::<P>::new(a, b, lo, hi)
+	let witness = IntMulWitness::<_, P>::new(alloc, a, b, lo, hi)
 		.expect("a prepared constraint system yields power-of-two operand columns");
 
 	// Switchover 0 keeps the exponentiation trees in the small field for every round.
-	let mut prover = IntMulProver::<P, _>::new(0, channel);
+	let mut prover = IntMulProver::<_, P, _>::new(0, channel, alloc);
 	prover.prove(witness)
 }
 
@@ -430,10 +442,15 @@ where
 /// Each is `K * n_binmul` rows, laid out constraint-major.
 /// The check reduces the GHASH-field multiplication relation to per-bit evaluation claims on the
 /// six columns. Those claims share a common row point.
-fn prove_binmul<P, Channel>(columns: &[Vec<Word>; 6], channel: &mut Channel) -> BinMulOutput<B128>
+fn prove_binmul<P, Channel, A>(
+	columns: &[Vec<Word>; 6],
+	channel: &mut Channel,
+	alloc: &A,
+) -> BinMulOutput<B128>
 where
 	P: PackedField<Scalar = B128>,
 	Channel: IOPProverChannel<P>,
+	A: Allocator,
 {
 	let _scope = tracing::debug_span!("BinMul check").entered();
 
@@ -449,7 +466,7 @@ where
 		c_hi,
 	};
 
-	prove_binmul_reduction::<B128, P, _>(&witness, channel)
+	prove_binmul_reduction::<_, B128, P, _>(&witness, channel, alloc)
 }
 
 /// One operation's operand columns, oblong claims, and the points they are claimed at.
@@ -491,13 +508,15 @@ impl<'a, const ARITY: usize> Operation<'a, ARITY> {
 	/// So the store expands that indicator once, not once per operand.
 	/// Each operand's instance-axis multilinear becomes a store column.
 	/// Its evaluator is an identity-composition quadratic MLE-check: a multilinear evaluation.
-	fn push_to<P>(
+	fn push_to<'alloc, A, P>(
 		&self,
 		lagrange: &[B128],
-		store: &mut MleStore<P>,
-		evaluators: &mut Vec<Box<dyn SumcheckRoundEvaluator<B128, P>>>,
+		store: &mut MleStore<'alloc, A, P>,
+		evaluators: &mut Vec<Box<dyn SumcheckRoundEvaluator<A, B128, P> + 'alloc>>,
 		claims: &mut Vec<B128>,
+		alloc: &'alloc A,
 	) where
+		A: Allocator,
 		P: PackedField<Scalar = B128>,
 	{
 		// The wrappers run under a plain sumcheck prover, so each holds this operation's shared eq
@@ -506,7 +525,10 @@ impl<'a, const ARITY: usize> Operation<'a, ARITY> {
 		// The constraint tensor is the same for every operand of this operation, so expand it once.
 		let r_x_tensor = eq_ind_partial_eval_scalars::<B128>(&self.r_x);
 		for (column, &claim) in self.columns.iter().zip(&self.operand_claims) {
-			let col = store.push_owned(operand_rho_multilinear::<P>(column, lagrange, &r_x_tensor));
+			let col = store.push_owned(pooled_copy(
+				alloc,
+				&operand_rho_multilinear::<P>(column, lagrange, &r_x_tensor),
+			));
 			let evaluator = QuadraticMleEvaluator::new(
 				[col],
 				|[operand]: [P; 1]| operand,
@@ -627,15 +649,17 @@ impl RerandomizedOperations<'_> {
 	///
 	/// The shared instance point, the BitAnd operand data, the IntMul operand data, and the BinMul
 	/// operand data.
-	fn prove<P, Channel>(
+	fn prove<'alloc, P, Channel, A>(
 		self,
 		lagrange: &[B128],
 		z_challenge: B128,
 		channel: &mut Channel,
+		alloc: &'alloc A,
 	) -> (Vec<B128>, OperatorData<B128>, OperatorData<B128>, OperatorData<B128>)
 	where
 		P: PackedField<Scalar = B128>,
 		Channel: IOPProverChannel<P>,
+		A: Allocator,
 	{
 		let _scope = tracing::debug_span!("Re-randomize instances").entered();
 
@@ -647,17 +671,17 @@ impl RerandomizedOperations<'_> {
 		// multilinears. The evaluators list the operands in push order
 		// [BitAnd a, b, c | IntMul a, b, lo, hi | BinMul a_lo, a_hi, b_lo, b_hi, c_lo, c_hi].
 		// The verifier reads the reduced evaluations back in the same order.
-		let mut store = MleStore::<P>::new(log_instances);
-		let mut evaluators: Vec<Box<dyn SumcheckRoundEvaluator<B128, P>>> =
+		let mut store = MleStore::<A, P>::new(log_instances, alloc);
+		let mut evaluators: Vec<Box<dyn SumcheckRoundEvaluator<A, B128, P> + 'alloc>> =
 			Vec::with_capacity(BITAND_ARITY + INTMUL_ARITY + BINMUL_ARITY);
 		let mut claims: Vec<B128> = Vec::with_capacity(BITAND_ARITY + INTMUL_ARITY + BINMUL_ARITY);
 		self.bitand
-			.push_to(lagrange, &mut store, &mut evaluators, &mut claims);
+			.push_to(lagrange, &mut store, &mut evaluators, &mut claims, alloc);
 		if let Some(intmul) = &self.intmul {
-			intmul.push_to(lagrange, &mut store, &mut evaluators, &mut claims);
+			intmul.push_to(lagrange, &mut store, &mut evaluators, &mut claims, alloc);
 		}
 		if let Some(binmul) = &self.binmul {
-			binmul.push_to(lagrange, &mut store, &mut evaluators, &mut claims);
+			binmul.push_to(lagrange, &mut store, &mut evaluators, &mut claims, alloc);
 		}
 
 		// One shared prover drives all claims over the store in a single round pass.

--- a/crates/m4-prover/src/shift.rs
+++ b/crates/m4-prover/src/shift.rs
@@ -2,13 +2,14 @@
 
 //! The batched shift-reduction prover for the data-parallel Binius64 M4 proof system.
 
-use binius_compute::Allocator;
+use binius_compute::{Allocator, VecLike};
 use binius_core::word::Word;
 use binius_field::{BinaryField, PackedField};
 use binius_ip::sumcheck::SumcheckOutput;
 use binius_ip_prover::channel::IPProverChannel;
 use binius_math::{
-	BinarySubspace, FieldBuffer, inner_product::inner_product, multilinear::eq::eq_ind_partial_eval,
+	BinarySubspace, FieldBuffer, FieldVec, inner_product::inner_product,
+	multilinear::eq::eq_ind_partial_eval,
 };
 use binius_prover::{
 	fold_word::{WordFolder, fold_words},
@@ -145,7 +146,8 @@ where
 	// constants shared by every instance, so the single-instance builder folds them directly from
 	// their bits; the hidden words are already folded over instances. This scalar path drives the
 	// single-instance phase-1 sumcheck.
-	let mut g_parts = build_g_parts::<F, F>(
+	let mut g_parts = build_g_parts::<F, F, _>(
+		alloc,
 		public_words,
 		&key_collection.public,
 		&prepared_bitand,
@@ -153,6 +155,7 @@ where
 		&prepared_bmul,
 	);
 	let hidden_g_parts = build_g_parts_from_folded_words(
+		alloc,
 		folded_witness,
 		&key_collection.hidden,
 		&prepared_bitand,
@@ -164,7 +167,7 @@ where
 			*slot += *add;
 		}
 	}
-	let h_parts = build_h_parts::<F, F>(domain_subspace, prepared_bitand.r_zhat_prime);
+	let h_parts = build_h_parts::<F, F, _>(alloc, domain_subspace, prepared_bitand.r_zhat_prime);
 	let phase_1_output = run_phase_1_sumcheck::<F, F, _, _>(g_parts, h_parts, channel, alloc);
 
 	// Phase 2: split the phase-1 challenges into the bit half `r_j` and the shift half `r_s`.
@@ -181,15 +184,16 @@ where
 	// folded bits against the `r_j` tensor. The committed word count need not be a power of two, so
 	// the scalars are zero-padded up to the next one, mirroring `fold_words`'s own padding of the
 	// public segment.
-	let public_folded = fold_words::<F, P>(public_words, r_j_tensor.as_ref());
+	let public_folded = fold_words::<F, P, _>(alloc, public_words, r_j_tensor.as_ref());
 	let mut hidden_scalars: Vec<F> = folded_witness
 		.iter()
 		.map(|word| inner_product(word.iter().copied(), r_j_tensor.as_ref().iter().copied()))
 		.collect();
 	hidden_scalars.resize(1 << log2_ceil_usize(hidden_scalars.len()), F::ZERO);
-	let hidden_folded = FieldBuffer::<P>::from_values(&hidden_scalars);
+	let hidden_folded = FieldBuffer::<P>::from_values_in(alloc, &hidden_scalars);
 
-	let (public_monster, hidden_monster) = build_monster_segments::<F, P>(
+	let (public_monster, hidden_monster) = build_monster_segments::<F, P, _>(
+		alloc,
 		key_collection,
 		&prepared_bitand,
 		&prepared_intmul,
@@ -234,13 +238,14 @@ where
 ///
 /// This scalar implementation ignores the packed-field and parallelism optimizations of the
 /// single-instance builder.
-pub fn build_g_parts_from_folded_words<F: BinaryField>(
+pub fn build_g_parts_from_folded_words<F: BinaryField, A: Allocator>(
+	alloc: &A,
 	folded_words: &[FoldedWord<F>],
 	segment: &KeySegment,
 	bitand_operator_data: &PreparedOperatorData<F>,
 	intmul_operator_data: &PreparedOperatorData<F>,
 	binmul_operator_data: &PreparedOperatorData<F>,
-) -> [FieldBuffer<F>; SHIFT_VARIANT_COUNT] {
+) -> [FieldVec<F, A>; SHIFT_VARIANT_COUNT] {
 	// One flat accumulator holding SHIFT_VARIANT_COUNT multilinears of LOG_LEN variables each, laid
 	// out variant-major. Kept on the heap rather than a stack array: it is thousands of elements.
 	#[allow(clippy::useless_vec)]
@@ -271,13 +276,18 @@ pub fn build_g_parts_from_folded_words<F: BinaryField>(
 		}
 	}
 
-	// Split the flat accumulator into one multilinear per shift variant.
+	// Split the flat accumulator into one multilinear per shift variant, each built straight into
+	// the allocator's buffer rather than into a `Vec` copy.
 	multilinears
 		.chunks(1 << LOG_LEN)
-		.map(|chunk| FieldBuffer::new(LOG_LEN, chunk.to_vec()))
+		.map(|chunk| {
+			let mut data = alloc.alloc::<F>(chunk.len());
+			data.extend_from_slice(chunk);
+			FieldBuffer::new(LOG_LEN, data)
+		})
 		.collect::<Vec<_>>()
 		.try_into()
-		.expect("chunks yield SHIFT_VARIANT_COUNT parts of size 1 << LOG_LEN")
+		.unwrap_or_else(|_| panic!("chunks yield SHIFT_VARIANT_COUNT parts of size 1 << LOG_LEN"))
 }
 
 #[cfg(test)]
@@ -430,7 +440,7 @@ mod tests {
 				let vv = table.instance_value_vec(rho, constants);
 				committed.extend_from_slice(&vv.combined_witness()[offset..]);
 			}
-			let folded_words = fold_words::<B128, P>(&committed, &bit_tensor);
+			let folded_words = fold_words::<B128, P, _>(&GlobalAllocator, &committed, &bit_tensor);
 
 			let mut point = r_wire.to_vec();
 			point.extend_from_slice(&r_rho);
@@ -459,7 +469,7 @@ mod tests {
 		let lagrange = lagrange_evals_scalars::<B128, B128>(domain_subspace, r_z);
 		let row_point: Vec<B128> = r_rho.iter().chain(r_x).copied().collect();
 		let operand_eval = |column: &[Word]| {
-			let folded_column = fold_words::<B128, P>(column, &lagrange);
+			let folded_column = fold_words::<B128, P, _>(&GlobalAllocator, column, &lagrange);
 			evaluate(&folded_column, &row_point)
 		};
 		// The batch witness stores only the `A` and `B` columns.
@@ -718,7 +728,8 @@ mod tests {
 		// The g parts: the public segment folds from raw constant words via the single-instance
 		// builder, the hidden segment from the instance-folded words. Add them. The h parts come
 		// from the single-instance prover.
-		let mut g_parts = build_g_parts::<B128, B128>(
+		let mut g_parts = build_g_parts::<B128, B128, _>(
+			&GlobalAllocator,
 			public_words,
 			&key_collection.public,
 			&prepared_bitand,
@@ -726,6 +737,7 @@ mod tests {
 			&prepared_bmul,
 		);
 		let hidden_g_parts = build_g_parts_from_folded_words(
+			&GlobalAllocator,
 			&hidden_folded,
 			&key_collection.hidden,
 			&prepared_bitand,
@@ -737,7 +749,7 @@ mod tests {
 				*slot += *add;
 			}
 		}
-		let h_parts = build_h_parts::<B128, B128>(&domain_subspace, r_z);
+		let h_parts = build_h_parts::<B128, B128, _>(&GlobalAllocator, &domain_subspace, r_z);
 		let inner_product: B128 = g_parts
 			.iter()
 			.zip(&h_parts)

--- a/crates/m4-prover/src/shift.rs
+++ b/crates/m4-prover/src/shift.rs
@@ -2,6 +2,7 @@
 
 //! The batched shift-reduction prover for the data-parallel Binius64 M4 proof system.
 
+use binius_compute::Allocator;
 use binius_core::word::Word;
 use binius_field::{BinaryField, PackedField};
 use binius_ip::sumcheck::SumcheckOutput;
@@ -114,7 +115,7 @@ pub fn fold_instances<F: BinaryField>(table: &ValueTable, r_rho: &[F]) -> Vec<Fo
 /// # Returns
 /// The `SumcheckOutput` with the final challenges and the reduced witness evaluation.
 #[allow(clippy::too_many_arguments)]
-pub fn prove<F, P, Channel>(
+pub fn prove<F, P, Channel, A>(
 	key_collection: &KeyCollection,
 	public_words: &[Word],
 	folded_witness: &[FoldedWord<F>],
@@ -123,11 +124,13 @@ pub fn prove<F, P, Channel>(
 	binmul_data: OperatorData<F>,
 	domain_subspace: &BinarySubspace<F>,
 	channel: &mut Channel,
+	alloc: &A,
 ) -> SumcheckOutput<F>
 where
 	F: BinaryField,
 	P: PackedField<Scalar = F>,
 	Channel: IPProverChannel<F>,
+	A: Allocator,
 {
 	// Sample one batching lambda per operator, then prepare the operator data (tensor expansions
 	// and lambda powers).
@@ -162,7 +165,7 @@ where
 		}
 	}
 	let h_parts = build_h_parts::<F, F>(domain_subspace, prepared_bitand.r_zhat_prime);
-	let phase_1_output = run_phase_1_sumcheck::<F, F, _>(g_parts, h_parts, channel);
+	let phase_1_output = run_phase_1_sumcheck::<F, F, _, _>(g_parts, h_parts, channel, alloc);
 
 	// Phase 2: split the phase-1 challenges into the bit half `r_j` and the shift half `r_s`.
 	let SumcheckOutput {
@@ -196,7 +199,7 @@ where
 		&r_s,
 	);
 
-	run_sumcheck::<F, P, _>(
+	run_sumcheck::<F, P, _, _>(
 		public_folded,
 		hidden_folded,
 		public_monster,
@@ -205,6 +208,7 @@ where
 		r_j,
 		gamma,
 		channel,
+		alloc,
 	)
 }
 
@@ -280,6 +284,7 @@ pub fn build_g_parts_from_folded_words<F: BinaryField>(
 mod tests {
 	use std::iter;
 
+	use binius_compute::GlobalAllocator;
 	use binius_core::{constraint_system::AndConstraint, verify::verify_constraints, word::Word};
 	use binius_field::{AESTowerField8b, Field, PackedBinaryGhash1x128b, Random};
 	use binius_math::{
@@ -559,7 +564,7 @@ mod tests {
 
 		// Prove.
 		let mut prover_transcript = ProverTranscript::<StdChallenger>::default();
-		let prover_output = prove::<B128, P, _>(
+		let prover_output = prove::<B128, P, _, _>(
 			&key_collection,
 			public_words,
 			&folded_witness,
@@ -580,6 +585,7 @@ mod tests {
 			},
 			&domain_subspace,
 			&mut prover_transcript,
+			&GlobalAllocator,
 		);
 
 		// Verify against the single-instance shift verifier.

--- a/crates/math/Cargo.toml
+++ b/crates/math/Cargo.toml
@@ -8,6 +8,7 @@ authors.workspace = true
 workspace = true
 
 [dependencies]
+binius-compute = { path = "../compute" }
 binius-field = { path = "../field", default-features = false }
 binius-utils = { path = "../utils", default-features = false }
 bytemuck = { workspace = true, features = ["extern_crate_alloc"] }

--- a/crates/math/src/field_buffer.rs
+++ b/crates/math/src/field_buffer.rs
@@ -2,7 +2,6 @@
 // Copyright 2026 The Binius Developers
 
 use std::{
-	mem,
 	ops::{Deref, DerefMut, Index, IndexMut},
 	slice,
 };
@@ -22,34 +21,11 @@ pub trait AsSlicesMut<P: PackedField, const N: usize> {
 	fn as_slices_mut(&mut self) -> [FieldSliceMut<'_, P>; N];
 }
 
-/// Backing store of a [`FieldBuffer`] that can be shrunk in place.
-///
-/// [`FieldBuffer::truncate`] shrinks its backing store to match the smaller `log_len`, so it is
-/// available only for the mutable backings that support that in place: `Vec<T>` and `&mut [T]`. A
-/// shared `&[T]` view could reslice too, but truncation must also zero the dead lanes of a
-/// sub-packing-width word (see [`FieldBuffer::truncate`]), which a shared borrow cannot do — hence
-/// the [`DerefMut`] bound.
-pub trait BufferData<T>: DerefMut<Target = [T]> {
-	/// Shrinks the store in place to its first `len` elements.
-	///
-	/// `len` must be at most the current length.
-	fn truncate(&mut self, len: usize);
-}
-
-impl<T> BufferData<T> for Vec<T> {
-	fn truncate(&mut self, len: usize) {
-		Vec::truncate(self, len);
-	}
-}
-
-impl<T> BufferData<T> for &mut [T] {
-	fn truncate(&mut self, len: usize) {
-		// A `&'a mut [T]` cannot be re-sliced in place through `&mut self`, so move it out and
-		// slice the owned value back in.
-		let full = mem::take(self);
-		*self = &mut full[..len];
-	}
-}
+// The `BufferData` bound on `FieldBuffer`'s backing store lives in `binius-compute` so that it can
+// bound `Allocator::Vec` (letting an allocator's buffer back a `FieldBuffer` without a
+// `where`-clause on every signature) and so its `PoolVec` can implement it. Re-exported here since
+// it is part of this module's public API.
+pub use binius_compute::BufferData;
 
 /// A power-of-two-sized buffer containing field elements, stored in packed fields.
 ///

--- a/crates/math/src/field_buffer.rs
+++ b/crates/math/src/field_buffer.rs
@@ -6,6 +6,7 @@ use std::{
 	slice,
 };
 
+use binius_compute::{Allocator, VecLike};
 use binius_field::{
 	Field, PackedField,
 	packed::{get_packed_slice_unchecked, set_packed_slice_unchecked},
@@ -110,6 +111,46 @@ impl<P: PackedField> FieldBuffer<P> {
 		let packed_len = 1 << log_len.saturating_sub(P::LOG_WIDTH);
 		let values = zeroed_vec(packed_len);
 		Self { log_len, values }
+	}
+}
+
+impl<P: PackedField> FieldBuffer<P> {
+	/// Builds a [`FieldBuffer`] from scalar values directly into a buffer drawn from `alloc`.
+	///
+	/// The allocator-aware counterpart to [`from_values`](Self::from_values): the packed values are
+	/// written straight into the allocator's buffer, avoiding an intermediate `Vec` and copy. Under
+	/// a `BufferPool` the result is a recyclable pooled buffer.
+	///
+	/// # Preconditions
+	///
+	/// * `values.len()` must be a power of two.
+	pub fn from_values_in<A: Allocator>(
+		alloc: &A,
+		values: &[P::Scalar],
+	) -> FieldBuffer<P, A::Vec<P>> {
+		let log_len =
+			strict_log_2(values.len()).expect("precondition: values.len() must be a power of two");
+
+		let packed_len = 1 << log_len.saturating_sub(P::LOG_WIDTH);
+		let mut packed_values = alloc.alloc::<P>(packed_len);
+		packed_values.extend(
+			values
+				.chunks(P::WIDTH)
+				.map(|chunk| P::from_scalars(chunk.iter().copied())),
+		);
+
+		FieldBuffer::new(log_len, packed_values)
+	}
+
+	/// Builds a zeroed [`FieldBuffer`] of `log_len` variables into a buffer drawn from `alloc`.
+	///
+	/// The allocator-aware counterpart to [`zeros`](Self::zeros). Under a `BufferPool` the result
+	/// is a recyclable pooled buffer.
+	pub fn zeros_in<A: Allocator>(alloc: &A, log_len: usize) -> FieldBuffer<P, A::Vec<P>> {
+		let packed_len = 1 << log_len.saturating_sub(P::LOG_WIDTH);
+		let mut values = alloc.alloc::<P>(packed_len);
+		values.resize(packed_len, P::default());
+		FieldBuffer::new(log_len, values)
 	}
 }
 
@@ -549,6 +590,12 @@ impl<F: Field, Data: DerefMut<Target = [F]>> IndexMut<usize> for FieldBuffer<F, 
 		&mut self.values[index]
 	}
 }
+
+/// Alias for a field buffer whose backing store is drawn from an [`Allocator`] `A`.
+///
+/// For `A = &BufferPool` this is a pooled buffer; for `A = GlobalAllocator` it is an ordinary
+/// `Vec`-backed buffer.
+pub type FieldVec<P, A> = FieldBuffer<P, <A as Allocator>::Vec<P>>;
 
 /// Alias for a field buffer over a borrowed slice.
 pub type FieldSlice<'a, P> = FieldBuffer<P, FieldSliceData<'a, P>>;

--- a/crates/math/src/lib.rs
+++ b/crates/math/src/lib.rs
@@ -28,6 +28,6 @@ pub mod test_utils;
 pub mod univariate;
 
 pub use binary_subspace::BinarySubspace;
-pub use field_buffer::{AsSlicesMut, FieldBuffer, FieldSlice, FieldSliceMut};
+pub use field_buffer::{AsSlicesMut, FieldBuffer, FieldSlice, FieldSliceMut, FieldVec};
 pub use matrix::Matrix;
 pub use reed_solomon::ReedSolomonCode;

--- a/crates/math/src/multilinear/fold.rs
+++ b/crates/math/src/multilinear/fold.rs
@@ -2,10 +2,11 @@
 
 use std::ops::{Deref, DerefMut};
 
+use binius_compute::{Allocator, VecLike};
 use binius_field::{Field, PackedField};
 use binius_utils::{random_access_sequence::RandomAccessSequence, rayon::prelude::*};
 
-use crate::{FieldBuffer, field_buffer::BufferData, line::extrapolate_line_packed};
+use crate::{FieldBuffer, FieldVec, field_buffer::BufferData, line::extrapolate_line_packed};
 
 /// Computes the partial evaluation of a multilinear on its highest variable, inplace.
 ///
@@ -36,28 +37,38 @@ pub fn fold_highest_var_inplace<P: PackedField, Data: BufferData<P>>(
 /// Computes the partial evaluation of a multilinear on its highest variable, out of place.
 ///
 /// This is the out-of-place counterpart of [`fold_highest_var_inplace`].
-/// It reads `values` and returns a fresh half-size buffer, leaving the input untouched.
-/// Use it when the input is borrowed or must be preserved; otherwise prefer the in-place version.
+/// It reads `values` and writes the fresh half-size result directly into a buffer drawn from
+/// `alloc`, leaving the input untouched. Use it when the input is borrowed or must be preserved;
+/// otherwise prefer the in-place version.
 ///
 /// ## Preconditions
 ///
 /// * `values.log_len() >= 1` (buffer must have at least 2 elements)
-pub fn fold_highest_var<P: PackedField, Data: Deref<Target = [P]>>(
+pub fn fold_highest_var<A: Allocator, P: PackedField, Data: Deref<Target = [P]>>(
+	alloc: &A,
 	values: &FieldBuffer<P, Data>,
 	scalar: P::Scalar,
-) -> FieldBuffer<P> {
+) -> FieldVec<P, A> {
 	assert!(values.log_len() > 0, "precondition: buffer must have at least one variable");
 
 	// The two halves are the multilinear specialized to 0 and to 1 on the highest variable.
 	let broadcast_scalar = P::broadcast(scalar);
 	let (lo, hi) = values.split_half_ref();
 
-	// Interpolate the line through each (lo, hi) pair at the challenge into a fresh buffer.
-	let folded = (lo.as_ref(), hi.as_ref())
+	// Interpolate the line through each (lo, hi) pair at the challenge directly into a fresh buffer
+	// drawn from the allocator, writing the uninitialized spare capacity in parallel rather than
+	// zero-filling first.
+	let len = lo.as_ref().len();
+	let mut data = alloc.alloc::<P>(len);
+	let spare = &mut data.spare_capacity_mut()[..len];
+	(spare, lo.as_ref(), hi.as_ref())
 		.into_par_iter()
-		.map(|(&lo_i, &hi_i)| extrapolate_line_packed(lo_i, hi_i, broadcast_scalar))
-		.collect();
-	FieldBuffer::new(values.log_len() - 1, folded)
+		.for_each(|(out, &lo_i, &hi_i)| {
+			out.write(extrapolate_line_packed(lo_i, hi_i, broadcast_scalar));
+		});
+	// SAFETY: the parallel loop initialized all `len` slots.
+	unsafe { data.set_len(len) };
+	FieldBuffer::new(values.log_len() - 1, data)
 }
 
 /// Computes the fold high of a binary multilinear with a fold tensor.
@@ -120,6 +131,7 @@ pub fn binary_fold_high<P, DataOut, DataIn>(
 mod tests {
 	use std::iter::repeat_with;
 
+	use binius_compute::GlobalAllocator;
 	use rand::prelude::*;
 
 	use super::*;
@@ -158,7 +170,7 @@ mod tests {
 			let challenge = random_scalars::<F>(&mut rng, 1)[0];
 
 			// Out-of-place: leaves the input untouched, returns a fresh buffer.
-			let out_of_place = fold_highest_var(&multilinear, challenge);
+			let out_of_place = fold_highest_var(&GlobalAllocator, &multilinear, challenge);
 
 			// In-place reference: fold a copy and compare.
 			let mut in_place = multilinear;

--- a/crates/prover/benches/and_reduction.rs
+++ b/crates/prover/benches/and_reduction.rs
@@ -1,12 +1,10 @@
 // Copyright 2025 Irreducible Inc.
 use std::iter::repeat_with;
 
-use binius_compute::BufferPool;
+use binius_compute::{BufferPool, GlobalAllocator};
 use binius_core::word::Word;
 use binius_field::{Field, Random};
-use binius_ip_prover::sumcheck::{
-	common::SumcheckProver, mle_store::pooled_copy, quadratic_mlecheck_prover,
-};
+use binius_ip_prover::sumcheck::{common::SumcheckProver, quadratic_mlecheck_prover};
 use binius_math::{
 	BinarySubspace,
 	univariate::{extrapolate_over_subspace, lagrange_evals_scalars},
@@ -76,13 +74,16 @@ fn bench(c: &mut Criterion) {
 		bench.iter(|| {
 			let lagrange_evals = lagrange_evals_scalars(&univariate_domain, univariate_challenge);
 			let folder = BitAxisFolder::new(&lagrange_evals);
-			folder.fold_bitand_operands::<OptimalPackedB128>(&a_words, &b_words)
+			folder.fold_bitand_operands::<OptimalPackedB128, _>(
+				&GlobalAllocator,
+				&a_words,
+				&b_words,
+			)
 		});
 	});
 
 	let lagrange_evals = lagrange_evals_scalars(&univariate_domain, univariate_challenge);
 	let folder = BitAxisFolder::new(&lagrange_evals);
-	let proving_polys = folder.fold_bitand_operands::<OptimalPackedB128>(&a_words, &b_words);
 
 	let mut univariate_message_coeffs = vec![B128::ZERO; 2 * ROWS_PER_HYPERCUBE_VERTEX];
 	univariate_message_coeffs[ROWS_PER_HYPERCUBE_VERTEX..2 * ROWS_PER_HYPERCUBE_VERTEX]
@@ -97,6 +98,9 @@ fn bench(c: &mut Criterion) {
 	let pool = BufferPool::new();
 
 	let alloc = &pool;
+	// Fold the operands once; each iteration clones the result from the pool.
+	let proving_polys =
+		folder.fold_bitand_operands::<OptimalPackedB128, _>(&alloc, &a_words, &b_words);
 	group.bench_function(format!("remaining zerocheck 2^{log_words}"), |bench| {
 		bench.iter_batched(
 			|| proving_polys.clone(),
@@ -110,7 +114,7 @@ fn bench(c: &mut Criterion) {
 
 				let mut prover = quadratic_mlecheck_prover(
 					&alloc,
-					proving_polys.map(|c| pooled_copy(&alloc, &c)),
+					proving_polys,
 					|[a, b, c]| a * b - c,
 					|[a, b, _]| a * b,
 					multilinear_zerocheck_challenges,

--- a/crates/prover/benches/and_reduction.rs
+++ b/crates/prover/benches/and_reduction.rs
@@ -1,9 +1,12 @@
 // Copyright 2025 Irreducible Inc.
 use std::iter::repeat_with;
 
+use binius_compute::BufferPool;
 use binius_core::word::Word;
 use binius_field::{Field, Random};
-use binius_ip_prover::sumcheck::{common::SumcheckProver, quadratic_mlecheck_prover};
+use binius_ip_prover::sumcheck::{
+	common::SumcheckProver, mle_store::pooled_copy, quadratic_mlecheck_prover,
+};
 use binius_math::{
 	BinarySubspace,
 	univariate::{extrapolate_over_subspace, lagrange_evals_scalars},
@@ -91,6 +94,9 @@ fn bench(c: &mut Criterion) {
 		univariate_challenge,
 	);
 
+	let pool = BufferPool::new();
+
+	let alloc = &pool;
 	group.bench_function(format!("remaining zerocheck 2^{log_words}"), |bench| {
 		bench.iter_batched(
 			|| proving_polys.clone(),
@@ -103,7 +109,8 @@ fn bench(c: &mut Criterion) {
 						.collect();
 
 				let mut prover = quadratic_mlecheck_prover(
-					proving_polys,
+					&alloc,
+					proving_polys.map(|c| pooled_copy(&alloc, &c)),
 					|[a, b, c]| a * b - c,
 					|[a, b, _]| a * b,
 					multilinear_zerocheck_challenges,

--- a/crates/prover/benches/batch_quadratic_mle.rs
+++ b/crates/prover/benches/batch_quadratic_mle.rs
@@ -7,14 +7,12 @@ use binius_field::{Field, FieldOps, PackedField, arch::OptimalPackedB128};
 use binius_ip::mlecheck;
 use binius_ip_prover::sumcheck::{
 	common::MleCheckProver,
-	mle_store::{MleStore, pooled_copy},
+	mle_store::MleStore,
 	quadratic_mle_evaluator::QuadraticMleEvaluator,
 	round_evaluator::{MleCheckRoundEvaluator, SharedMleCheckProver},
 };
 use binius_math::{
-	FieldBuffer,
-	multilinear::evaluate::evaluate_inplace,
-	test_utils::{random_field_buffer, random_scalars},
+	FieldBuffer, multilinear::evaluate::evaluate_inplace, test_utils::random_scalars,
 };
 use binius_transcript::{
 	ProverTranscript,
@@ -46,10 +44,11 @@ fn comp_1_inf<Pf: PackedField>([a, b, c]: [Pf; N]) -> Pf {
 	(a + b) * c
 }
 
-fn eval_claims<Ff, Pf>(multilinears: &[FieldBuffer<Pf>; N], eval_point: &[Ff]) -> [Ff; M]
+fn eval_claims<Ff, Pf, D>(multilinears: &[FieldBuffer<Pf, D>; N], eval_point: &[Ff]) -> [Ff; M]
 where
 	Ff: Field,
 	Pf: PackedField<Scalar = Ff>,
+	D: std::ops::Deref<Target = [Pf]>,
 {
 	let n_vars = eval_point.len();
 	let packed_len = 1 << n_vars.saturating_sub(Pf::LOG_WIDTH);
@@ -103,21 +102,23 @@ fn bench_batch_quadratic_mlecheck_prove(c: &mut Criterion) {
 	for n_vars in [12, 16, 20] {
 		group.throughput(Throughput::Elements(1 << n_vars));
 		group.bench_function(format!("n_vars={n_vars}/claims={M}"), |b| {
-			let multilinears: [FieldBuffer<P>; N] =
-				array::from_fn(|_| random_field_buffer::<P>(&mut rng, n_vars));
-			let eval_point = random_scalars::<F>(&mut rng, n_vars);
-			let eval_claims = eval_claims::<F, P>(&multilinears, &eval_point);
-
-			let mut transcript = ProverTranscript::new(StdChallenger::default());
+			let scalars: [Vec<F>; N] =
+				array::from_fn(|_| random_scalars::<F>(&mut rng, 1 << n_vars));
 			let pool = BufferPool::new();
 			let alloc = &pool;
+			// Build the multilinears once; each iteration clones them from the pool.
+			let multilinears: [FieldBuffer<P, _>; N] =
+				array::from_fn(|j| FieldBuffer::<P>::from_values_in(&alloc, &scalars[j]));
+			let eval_point = random_scalars::<F>(&mut rng, n_vars);
+			let eval_claims = eval_claims::<F, P, _>(&multilinears, &eval_point);
+
+			let mut transcript = ProverTranscript::new(StdChallenger::default());
 
 			b.iter_batched(
 				|| (multilinears.clone(), eval_point.clone()),
-				|(multilinears, eval_point)| {
+				|(multilinears, eval_point): ([FieldBuffer<P, _>; N], _)| {
 					let mut store = MleStore::new(eval_point.len(), &alloc);
-					let cols = multilinears
-						.map(|multilinear| store.push_owned(pooled_copy(&alloc, &multilinear)));
+					let cols = multilinears.map(|multilinear| store.push_owned(multilinear));
 					// One single-claim evaluator per composition, sharing the store's columns; the
 					// prover owns the eq tracker for the shared point.
 					let evaluator_0 =

--- a/crates/prover/benches/batch_quadratic_mle.rs
+++ b/crates/prover/benches/batch_quadratic_mle.rs
@@ -2,11 +2,12 @@
 
 use std::array;
 
+use binius_compute::BufferPool;
 use binius_field::{Field, FieldOps, PackedField, arch::OptimalPackedB128};
 use binius_ip::mlecheck;
 use binius_ip_prover::sumcheck::{
 	common::MleCheckProver,
-	mle_store::MleStore,
+	mle_store::{MleStore, pooled_copy},
 	quadratic_mle_evaluator::QuadraticMleEvaluator,
 	round_evaluator::{MleCheckRoundEvaluator, SharedMleCheckProver},
 };
@@ -94,6 +95,7 @@ where
 	prover.finish()
 }
 
+#[allow(clippy::type_complexity)]
 fn bench_batch_quadratic_mlecheck_prove(c: &mut Criterion) {
 	let mut group = c.benchmark_group("mlecheck/batch_quadratic");
 	let mut rng = StdRng::seed_from_u64(0);
@@ -107,19 +109,25 @@ fn bench_batch_quadratic_mlecheck_prove(c: &mut Criterion) {
 			let eval_claims = eval_claims::<F, P>(&multilinears, &eval_point);
 
 			let mut transcript = ProverTranscript::new(StdChallenger::default());
+			let pool = BufferPool::new();
+			let alloc = &pool;
 
 			b.iter_batched(
 				|| (multilinears.clone(), eval_point.clone()),
 				|(multilinears, eval_point)| {
-					let mut store = MleStore::new(eval_point.len());
-					let cols = multilinears.map(|multilinear| store.push_owned(multilinear));
+					let mut store = MleStore::new(eval_point.len(), &alloc);
+					let cols = multilinears
+						.map(|multilinear| store.push_owned(pooled_copy(&alloc, &multilinear)));
 					// One single-claim evaluator per composition, sharing the store's columns; the
 					// prover owns the eq tracker for the shared point.
 					let evaluator_0 =
 						QuadraticMleEvaluator::new(cols, comp_0::<P>, comp_0_inf::<P>);
 					let evaluator_1 =
 						QuadraticMleEvaluator::new(cols, comp_1::<P>, comp_1_inf::<P>);
-					let claims_with_evaluators: [(F, Box<dyn MleCheckRoundEvaluator<F, P>>); 2] = [
+					let claims_with_evaluators: [(
+						F,
+						Box<dyn MleCheckRoundEvaluator<&BufferPool, F, P> + '_>,
+					); 2] = [
 						(eval_claims[0], Box::new(evaluator_0)),
 						(eval_claims[1], Box::new(evaluator_1)),
 					];

--- a/crates/prover/benches/binmul.rs
+++ b/crates/prover/benches/binmul.rs
@@ -1,5 +1,6 @@
 // Copyright 2026 The Binius Developers
 
+use binius_compute::BufferPool;
 use binius_core::word::Word;
 use binius_field::{BinaryField128bGhash, Random, arch::OptimalPackedB128};
 use binius_prover::protocols::binmul::{BinMulWitness, prove};
@@ -71,7 +72,7 @@ fn bench_binmul_prove(c: &mut Criterion) {
 						c_lo: &c_lo,
 						c_hi: &c_hi,
 					};
-					prove::<F, P, _>(&witness, transcript)
+					prove::<_, F, P, _>(&witness, transcript, &&BufferPool::new())
 				},
 				BatchSize::SmallInput,
 			);

--- a/crates/prover/benches/binmul.rs
+++ b/crates/prover/benches/binmul.rs
@@ -60,6 +60,8 @@ fn bench_binmul_prove(c: &mut Criterion) {
 		group.throughput(Throughput::Elements(1 << log_n));
 		group.bench_function(format!("n_vars={log_n}"), |b| {
 			let (a_lo, a_hi, b_lo, b_hi, c_lo, c_hi) = random_witness(&mut rng, log_n);
+			let pool = BufferPool::new();
+			let alloc = &pool;
 
 			b.iter_batched_ref(
 				|| ProverTranscript::new(StdChallenger::default()),
@@ -72,7 +74,7 @@ fn bench_binmul_prove(c: &mut Criterion) {
 						c_lo: &c_lo,
 						c_hi: &c_hi,
 					};
-					prove::<_, F, P, _>(&witness, transcript, &&BufferPool::new())
+					prove::<_, F, P, _>(&witness, transcript, &alloc)
 				},
 				BatchSize::SmallInput,
 			);

--- a/crates/prover/benches/fold_words.rs
+++ b/crates/prover/benches/fold_words.rs
@@ -1,4 +1,5 @@
 // Copyright 2025 Irreducible Inc.
+use binius_compute::BufferPool;
 use binius_core::word::Word;
 use binius_field::arch::OptimalPackedB128;
 use binius_math::test_utils::random_scalars;
@@ -23,7 +24,9 @@ fn bench_fold_words(c: &mut Criterion) {
 				.collect::<Vec<_>>();
 			let vec = random_scalars::<B128>(&mut rng, Word::BITS);
 
-			b.iter(|| fold_words::<_, OptimalPackedB128>(&words, &vec));
+			let pool = BufferPool::new();
+			let alloc = &pool;
+			b.iter(|| fold_words::<_, OptimalPackedB128, _>(&alloc, &words, &vec));
 		});
 	}
 

--- a/crates/prover/benches/fracaddcheck.rs
+++ b/crates/prover/benches/fracaddcheck.rs
@@ -1,8 +1,9 @@
 // Copyright 2025-2026 The Binius Developers
 
+use binius_compute::BufferPool;
 use binius_field::arch::OptimalPackedB128;
 use binius_ip::prodcheck::MultilinearEvalClaim;
-use binius_ip_prover::fracaddcheck::FracAddCheckProver;
+use binius_ip_prover::{fracaddcheck::FracAddCheckProver, sumcheck::mle_store::pooled_copy};
 use binius_math::{multilinear::evaluate::evaluate, test_utils::random_field_buffer};
 use binius_transcript::ProverTranscript;
 use binius_verifier::config::StdChallenger;
@@ -23,11 +24,17 @@ fn bench_fracaddcheck_new(c: &mut Criterion) {
 			let mut rng = rand::rng();
 			let witness_num = random_field_buffer::<P>(&mut rng, n_vars);
 			let witness_den = random_field_buffer::<P>(&mut rng, n_vars);
+			let pool = BufferPool::new();
+			let alloc = &pool;
 
 			b.iter_batched(
 				|| (witness_num.clone(), witness_den.clone()),
 				|(witness_num, witness_den)| {
-					FracAddCheckProver::<P>::new(k, (witness_num, witness_den))
+					FracAddCheckProver::<_, P>::new(
+						k,
+						&alloc,
+						(pooled_copy(&alloc, &witness_num), pooled_copy(&alloc, &witness_den)),
+					)
 				},
 				BatchSize::SmallInput,
 			);
@@ -50,10 +57,15 @@ fn bench_fracaddcheck_prove(c: &mut Criterion) {
 			let mut rng = rand::rng();
 			let witness_num = random_field_buffer::<P>(&mut rng, n_vars);
 			let witness_den = random_field_buffer::<P>(&mut rng, n_vars);
+			let pool = BufferPool::new();
+			let alloc = &pool;
 
 			// Pre-compute the claim (final sums layer evaluation at empty point).
-			let (_prover, sums) =
-				FracAddCheckProver::new(k, (witness_num.clone(), witness_den.clone()));
+			let (_prover, sums) = FracAddCheckProver::new(
+				k,
+				&alloc,
+				(pooled_copy(&alloc, &witness_num), pooled_copy(&alloc, &witness_den)),
+			);
 			let sum_num_eval = evaluate(&sums.0, &[]);
 			let sum_den_eval = evaluate(&sums.1, &[]);
 			let claim = (
@@ -71,8 +83,11 @@ fn bench_fracaddcheck_prove(c: &mut Criterion) {
 
 			b.iter_batched(
 				|| {
-					let (prover, _sums) =
-						FracAddCheckProver::new(k, (witness_num.clone(), witness_den.clone()));
+					let (prover, _sums) = FracAddCheckProver::new(
+						k,
+						&alloc,
+						(pooled_copy(&alloc, &witness_num), pooled_copy(&alloc, &witness_den)),
+					);
 					(prover, claim.clone())
 				},
 				|(prover, claim)| prover.prove(claim, &mut transcript),

--- a/crates/prover/benches/fracaddcheck.rs
+++ b/crates/prover/benches/fracaddcheck.rs
@@ -1,15 +1,16 @@
 // Copyright 2025-2026 The Binius Developers
 
 use binius_compute::BufferPool;
-use binius_field::arch::OptimalPackedB128;
+use binius_field::{FieldOps, arch::OptimalPackedB128};
 use binius_ip::prodcheck::MultilinearEvalClaim;
-use binius_ip_prover::{fracaddcheck::FracAddCheckProver, sumcheck::mle_store::pooled_copy};
-use binius_math::{multilinear::evaluate::evaluate, test_utils::random_field_buffer};
+use binius_ip_prover::fracaddcheck::FracAddCheckProver;
+use binius_math::{FieldBuffer, multilinear::evaluate::evaluate, test_utils::random_scalars};
 use binius_transcript::ProverTranscript;
 use binius_verifier::config::StdChallenger;
 use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
 
 type P = OptimalPackedB128;
+type F = <P as FieldOps>::Scalar;
 
 fn bench_fracaddcheck_new(c: &mut Criterion) {
 	let mut group = c.benchmark_group("fracaddcheck/new");
@@ -22,19 +23,18 @@ fn bench_fracaddcheck_new(c: &mut Criterion) {
 		group.throughput(Throughput::Elements(1 << n_vars));
 		group.bench_function(format!("n_vars={n_vars}"), |b| {
 			let mut rng = rand::rng();
-			let witness_num = random_field_buffer::<P>(&mut rng, n_vars);
-			let witness_den = random_field_buffer::<P>(&mut rng, n_vars);
+			let num_scalars = random_scalars::<F>(&mut rng, 1 << n_vars);
+			let den_scalars = random_scalars::<F>(&mut rng, 1 << n_vars);
 			let pool = BufferPool::new();
 			let alloc = &pool;
+			// Build the witness pair once; each iteration clones it from the pool.
+			let witness_num = FieldBuffer::<P>::from_values_in(&alloc, &num_scalars);
+			let witness_den = FieldBuffer::<P>::from_values_in(&alloc, &den_scalars);
 
 			b.iter_batched(
 				|| (witness_num.clone(), witness_den.clone()),
 				|(witness_num, witness_den)| {
-					FracAddCheckProver::<_, P>::new(
-						k,
-						&alloc,
-						(pooled_copy(&alloc, &witness_num), pooled_copy(&alloc, &witness_den)),
-					)
+					FracAddCheckProver::<_, P>::new(k, &alloc, (witness_num, witness_den))
 				},
 				BatchSize::SmallInput,
 			);
@@ -55,16 +55,19 @@ fn bench_fracaddcheck_prove(c: &mut Criterion) {
 		group.throughput(Throughput::Elements(1 << n_vars));
 		group.bench_function(format!("n_vars={n_vars}"), |b| {
 			let mut rng = rand::rng();
-			let witness_num = random_field_buffer::<P>(&mut rng, n_vars);
-			let witness_den = random_field_buffer::<P>(&mut rng, n_vars);
+			let num_scalars = random_scalars::<F>(&mut rng, 1 << n_vars);
+			let den_scalars = random_scalars::<F>(&mut rng, 1 << n_vars);
 			let pool = BufferPool::new();
 			let alloc = &pool;
 
-			// Pre-compute the claim (final sums layer evaluation at empty point).
-			let (_prover, sums) = FracAddCheckProver::new(
+			// Build the prover once, then clone it per iteration (untimed setup).
+			let (prover, sums) = FracAddCheckProver::new(
 				k,
 				&alloc,
-				(pooled_copy(&alloc, &witness_num), pooled_copy(&alloc, &witness_den)),
+				(
+					FieldBuffer::<P>::from_values_in(&alloc, &num_scalars),
+					FieldBuffer::<P>::from_values_in(&alloc, &den_scalars),
+				),
 			);
 			let sum_num_eval = evaluate(&sums.0, &[]);
 			let sum_den_eval = evaluate(&sums.1, &[]);
@@ -82,14 +85,7 @@ fn bench_fracaddcheck_prove(c: &mut Criterion) {
 			let mut transcript = ProverTranscript::new(StdChallenger::default());
 
 			b.iter_batched(
-				|| {
-					let (prover, _sums) = FracAddCheckProver::new(
-						k,
-						&alloc,
-						(pooled_copy(&alloc, &witness_num), pooled_copy(&alloc, &witness_den)),
-					);
-					(prover, claim.clone())
-				},
+				|| (prover.clone(), claim.clone()),
 				|(prover, claim)| prover.prove(claim, &mut transcript),
 				BatchSize::SmallInput,
 			);

--- a/crates/prover/benches/intmul.rs
+++ b/crates/prover/benches/intmul.rs
@@ -1,4 +1,5 @@
 // Copyright 2025-2026 The Binius Developers
+use binius_compute::BufferPool;
 use binius_core::word::Word;
 use binius_field::{BinaryField128bGhash, Field, PackedBinaryGhash1x128b};
 use binius_hash::StdHashSuite;
@@ -11,6 +12,7 @@ use binius_ip_prover::{
 	prodcheck::ProdcheckProver,
 	sumcheck::{
 		batch::batch_prove,
+		mle_store::pooled_copy,
 		selector_mle::{Claim, SelectorMlecheckProver},
 	},
 };
@@ -101,31 +103,33 @@ fn bench_intmul_prove(c: &mut Criterion) {
 
 	let num_exponents = 1 << LOG_NUM;
 	let (a, b, c_lo, c_hi) = generate_test_data(LOG_NUM);
+	let pool = BufferPool::new();
+	let alloc = &pool;
 
 	group.bench_with_input(
 		BenchmarkId::new("witness", num_exponents),
 		&num_exponents,
-		|bencher, _| bencher.iter(|| Witness::<P>::new(&a, &b, &c_lo, &c_hi).unwrap()),
+		|bencher, _| bencher.iter(|| Witness::<_, P>::new(&alloc, &a, &b, &c_lo, &c_hi).unwrap()),
 	);
 
 	// prove
-	let witness = Witness::<P>::new(&a, &b, &c_lo, &c_hi).unwrap();
+	let witness = Witness::<_, P>::new(&alloc, &a, &b, &c_lo, &c_hi).unwrap();
 	let compiler = basefold_compiler();
 
 	group.bench_with_input(
 		BenchmarkId::new("prove", num_exponents),
 		&witness,
-		|bencher, witness| {
+		|bencher, _witness| {
 			bencher.iter_batched_ref(
 				|| {
 					let channel = compiler
 						.create_channel_without_zk_from_transcript::<StdHashSuite, StdChallenger, _>(
 							ProverTranscript::default(),
 						);
-					(Some(witness.clone()), channel)
+					(Some(Witness::<_, P>::new(&alloc, &a, &b, &c_lo, &c_hi).unwrap()), channel)
 				},
 				|(witness, channel)| {
-					let mut intmul_prover = IntMulProver::new(0, channel);
+					let mut intmul_prover = IntMulProver::new(0, channel, &alloc);
 					intmul_prover.prove(witness.take().expect("set in setup"));
 				},
 				BatchSize::SmallInput,
@@ -146,8 +150,8 @@ fn bench_intmul_prove(c: &mut Criterion) {
 						)
 				},
 				|channel| {
-					let mut intmul_prover = IntMulProver::new(0, channel);
-					let witness = Witness::<P>::new(&a, &b, &c_lo, &c_hi).unwrap();
+					let mut intmul_prover = IntMulProver::new(0, channel, &alloc);
+					let witness = Witness::<_, P>::new(&alloc, &a, &b, &c_lo, &c_hi).unwrap();
 					intmul_prover.prove(witness);
 				},
 				BatchSize::SmallInput,
@@ -164,7 +168,9 @@ fn bench_intmul_phases(c: &mut Criterion) {
 	group.throughput(Throughput::Elements(1 << LOG_NUM));
 
 	let (a, b, c_lo, c_hi) = generate_test_data(LOG_NUM);
-	let witness = Witness::<P>::new(&a, &b, &c_lo, &c_hi).unwrap();
+	let pool = BufferPool::new();
+	let alloc = &pool;
+	let witness = Witness::<_, P>::new(&alloc, &a, &b, &c_lo, &c_hi).unwrap();
 
 	// The proving phases are sequential and stateful: each consumes the outputs of the previous
 	// one. Rather than re-deriving every predecessor inside each phase's per-iteration setup, we
@@ -178,13 +184,14 @@ fn bench_intmul_phases(c: &mut Criterion) {
 
 	let phase1 = {
 		let mut transcript = ProverTranscript::new(StdChallenger::default());
-		let mut prover = IntMulProver::<P, _>::new(0, &mut transcript);
-		prover.phase1(&initial_eval_point, witness.b_prodcheck.clone(), &witness.b_leaves, exp_eval)
+		let mut prover = IntMulProver::<_, P, _>::new(0, &mut transcript, &alloc);
+		let w = Witness::<_, P>::new(&alloc, &a, &b, &c_lo, &c_hi).unwrap();
+		prover.phase1(&initial_eval_point, w.b_prodcheck, &witness.b_leaves, exp_eval)
 	};
 	let phase2 = frobenius_twist(Word::LOG_BITS, &phase1.eval_point, &phase1.b_leaves_evals);
 	let phase3 = {
 		let mut transcript = ProverTranscript::new(StdChallenger::default());
-		let mut prover = IntMulProver::<P, _>::new(0, &mut transcript);
+		let mut prover = IntMulProver::<_, P, _>::new(0, &mut transcript, &alloc);
 		prover.phase3(
 			&phase2.twisted_eval_points,
 			&phase2.twisted_evals,
@@ -197,12 +204,13 @@ fn bench_intmul_phases(c: &mut Criterion) {
 	};
 	let phase4 = {
 		let mut transcript = ProverTranscript::new(StdChallenger::default());
-		let mut prover = IntMulProver::<P, _>::new(0, &mut transcript);
+		let mut prover = IntMulProver::<_, P, _>::new(0, &mut transcript, &alloc);
+		let w = Witness::<_, P>::new(&alloc, &a, &b, &c_lo, &c_hi).unwrap();
 		prover.phase4(
 			&phase3.eval_point,
-			(phase3.gpow_a_eval, witness.a_prodcheck.clone()),
-			(phase3.gpow_c_lo_eval, witness.c_lo_prodcheck.clone()),
-			(phase3.gpow_c_hi_eval, witness.c_hi_prodcheck.clone()),
+			(phase3.gpow_a_eval, w.a_prodcheck),
+			(phase3.gpow_c_lo_eval, w.c_lo_prodcheck),
+			(phase3.gpow_c_hi_eval, w.c_hi_prodcheck),
 			[
 				witness.a_exponents,
 				witness.c_lo_exponents,
@@ -214,10 +222,14 @@ fn bench_intmul_phases(c: &mut Criterion) {
 
 	group.bench_function("phase1", |bencher| {
 		bencher.iter_batched(
-			|| witness.b_prodcheck.clone(),
+			|| {
+				Witness::<_, P>::new(&alloc, &a, &b, &c_lo, &c_hi)
+					.unwrap()
+					.b_prodcheck
+			},
 			|b_prodcheck| {
 				let mut transcript = ProverTranscript::new(StdChallenger::default());
-				let mut prover = IntMulProver::<P, _>::new(0, &mut transcript);
+				let mut prover = IntMulProver::<_, P, _>::new(0, &mut transcript, &alloc);
 				prover.phase1(&initial_eval_point, b_prodcheck, &witness.b_leaves, exp_eval)
 			},
 			BatchSize::SmallInput,
@@ -235,7 +247,7 @@ fn bench_intmul_phases(c: &mut Criterion) {
 			|| (witness.a_root.clone(), [witness.c_lo_root.clone(), witness.c_hi_root.clone()]),
 			|(a_root, c_lo_hi_roots)| {
 				let mut transcript = ProverTranscript::new(StdChallenger::default());
-				let mut prover = IntMulProver::<P, _>::new(0, &mut transcript);
+				let mut prover = IntMulProver::<_, P, _>::new(0, &mut transcript, &alloc);
 				prover.phase3(
 					&phase2.twisted_eval_points,
 					&phase2.twisted_evals,
@@ -253,15 +265,12 @@ fn bench_intmul_phases(c: &mut Criterion) {
 	group.bench_function("phase4", |bencher| {
 		bencher.iter_batched(
 			|| {
-				(
-					witness.a_prodcheck.clone(),
-					witness.c_lo_prodcheck.clone(),
-					witness.c_hi_prodcheck.clone(),
-				)
+				let w = Witness::<_, P>::new(&alloc, &a, &b, &c_lo, &c_hi).unwrap();
+				(w.a_prodcheck, w.c_lo_prodcheck, w.c_hi_prodcheck)
 			},
 			|(a_prodcheck, c_lo_prodcheck, c_hi_prodcheck)| {
 				let mut transcript = ProverTranscript::new(StdChallenger::default());
-				let mut prover = IntMulProver::<P, _>::new(0, &mut transcript);
+				let mut prover = IntMulProver::<_, P, _>::new(0, &mut transcript, &alloc);
 				prover.phase4(
 					&phase3.eval_point,
 					(phase3.gpow_a_eval, a_prodcheck),
@@ -289,7 +298,7 @@ fn bench_intmul_phases(c: &mut Criterion) {
 					)
 			},
 			|channel| {
-				let mut prover = IntMulProver::<P, _>::new(0, channel);
+				let mut prover = IntMulProver::<_, P, _>::new(0, channel, &alloc);
 				prover.phase5(
 					&phase4,
 					witness.b_exponents,
@@ -315,7 +324,9 @@ fn bench_intmul_components(c: &mut Criterion) {
 	group.throughput(Throughput::Elements(1 << LOG_NUM));
 
 	let (a, b, c_lo, c_hi) = generate_test_data(LOG_NUM);
-	let witness = Witness::<P>::new(&a, &b, &c_lo, &c_hi).unwrap();
+	let pool = BufferPool::new();
+	let alloc = &pool;
+	let witness = Witness::<_, P>::new(&alloc, &a, &b, &c_lo, &c_hi).unwrap();
 
 	// Building one twisted power table (the `a` / `c_lo` / `c_hi` limb columns read 2·N_LIMBS of
 	// these).
@@ -334,7 +345,9 @@ fn bench_intmul_components(c: &mut Criterion) {
 	group.bench_function("product_tree", |bencher| {
 		bencher.iter_batched(
 			|| witness.b_leaves.clone(),
-			|b_leaves| ProdcheckProver::<P>::new(Word::LOG_BITS, b_leaves),
+			|b_leaves| {
+				ProdcheckProver::<_, P>::new(Word::LOG_BITS, &alloc, pooled_copy(&alloc, &b_leaves))
+			},
 			BatchSize::SmallInput,
 		);
 	});
@@ -349,8 +362,9 @@ fn bench_intmul_components(c: &mut Criterion) {
 	let exp_eval = evaluate(&witness.b_root, &initial_eval_point);
 	let phase1 = {
 		let mut transcript = ProverTranscript::new(StdChallenger::default());
-		let mut prover = IntMulProver::<P, _>::new(0, &mut transcript);
-		prover.phase1(&initial_eval_point, witness.b_prodcheck.clone(), &witness.b_leaves, exp_eval)
+		let mut prover = IntMulProver::<_, P, _>::new(0, &mut transcript, &alloc);
+		let w = Witness::<_, P>::new(&alloc, &a, &b, &c_lo, &c_hi).unwrap();
+		prover.phase1(&initial_eval_point, w.b_prodcheck, &witness.b_leaves, exp_eval)
 	};
 	let phase2 = frobenius_twist(Word::LOG_BITS, &phase1.eval_point, &phase1.b_leaves_evals);
 

--- a/crates/prover/benches/intmul.rs
+++ b/crates/prover/benches/intmul.rs
@@ -12,11 +12,11 @@ use binius_ip_prover::{
 	prodcheck::ProdcheckProver,
 	sumcheck::{
 		batch::batch_prove,
-		mle_store::pooled_copy,
 		selector_mle::{Claim, SelectorMlecheckProver},
 	},
 };
 use binius_math::{
+	FieldBuffer,
 	multilinear::{eq::eq_ind_partial_eval_scalars, evaluate::evaluate},
 	ntt::{NeighborsLastSingleThread, domain_context::GenericPreExpanded},
 	test_utils::random_scalars,
@@ -119,14 +119,14 @@ fn bench_intmul_prove(c: &mut Criterion) {
 	group.bench_with_input(
 		BenchmarkId::new("prove", num_exponents),
 		&witness,
-		|bencher, _witness| {
+		|bencher, witness| {
 			bencher.iter_batched_ref(
 				|| {
 					let channel = compiler
 						.create_channel_without_zk_from_transcript::<StdHashSuite, StdChallenger, _>(
 							ProverTranscript::default(),
 						);
-					(Some(Witness::<_, P>::new(&alloc, &a, &b, &c_lo, &c_hi).unwrap()), channel)
+					(Some(witness.clone()), channel)
 				},
 				|(witness, channel)| {
 					let mut intmul_prover = IntMulProver::new(0, channel, &alloc);
@@ -192,12 +192,14 @@ fn bench_intmul_phases(c: &mut Criterion) {
 	let phase3 = {
 		let mut transcript = ProverTranscript::new(StdChallenger::default());
 		let mut prover = IntMulProver::<_, P, _>::new(0, &mut transcript, &alloc);
+		// The roots are pooled buffers consumed by phase3; rebuild a witness to source them.
+		let w = Witness::<_, P>::new(&alloc, &a, &b, &c_lo, &c_hi).unwrap();
 		prover.phase3(
 			&phase2.twisted_eval_points,
 			&phase2.twisted_evals,
-			witness.a_root.clone(),
+			w.a_root,
 			witness.b_exponents,
-			[witness.c_lo_root.clone(), witness.c_hi_root.clone()],
+			[w.c_lo_root, w.c_hi_root],
 			&initial_eval_point,
 			exp_eval,
 		)
@@ -222,11 +224,7 @@ fn bench_intmul_phases(c: &mut Criterion) {
 
 	group.bench_function("phase1", |bencher| {
 		bencher.iter_batched(
-			|| {
-				Witness::<_, P>::new(&alloc, &a, &b, &c_lo, &c_hi)
-					.unwrap()
-					.b_prodcheck
-			},
+			|| witness.b_prodcheck.clone(),
 			|b_prodcheck| {
 				let mut transcript = ProverTranscript::new(StdChallenger::default());
 				let mut prover = IntMulProver::<_, P, _>::new(0, &mut transcript, &alloc);
@@ -265,8 +263,11 @@ fn bench_intmul_phases(c: &mut Criterion) {
 	group.bench_function("phase4", |bencher| {
 		bencher.iter_batched(
 			|| {
-				let w = Witness::<_, P>::new(&alloc, &a, &b, &c_lo, &c_hi).unwrap();
-				(w.a_prodcheck, w.c_lo_prodcheck, w.c_hi_prodcheck)
+				(
+					witness.a_prodcheck.clone(),
+					witness.c_lo_prodcheck.clone(),
+					witness.c_hi_prodcheck.clone(),
+				)
 			},
 			|(a_prodcheck, c_lo_prodcheck, c_hi_prodcheck)| {
 				let mut transcript = ProverTranscript::new(StdChallenger::default());
@@ -342,12 +343,13 @@ fn bench_intmul_components(c: &mut Criterion) {
 	});
 
 	// Computing a product tree over the leaves.
+	let b_leaves_scalars: Vec<F> = witness.b_leaves.iter_scalars().collect();
+	// Build the leaves once; each iteration clones them from the pool.
+	let b_leaves = FieldBuffer::<P>::from_values_in(&alloc, &b_leaves_scalars);
 	group.bench_function("product_tree", |bencher| {
 		bencher.iter_batched(
-			|| witness.b_leaves.clone(),
-			|b_leaves| {
-				ProdcheckProver::<_, P>::new(Word::LOG_BITS, &alloc, pooled_copy(&alloc, &b_leaves))
-			},
+			|| b_leaves.clone(),
+			|b_leaves| ProdcheckProver::<_, P>::new(Word::LOG_BITS, &alloc, b_leaves),
 			BatchSize::SmallInput,
 		);
 	});

--- a/crates/prover/benches/prodcheck.rs
+++ b/crates/prover/benches/prodcheck.rs
@@ -1,8 +1,9 @@
 // Copyright 2025-2026 The Binius Developers
 
+use binius_compute::BufferPool;
 use binius_field::arch::OptimalPackedB128;
 use binius_ip::prodcheck::MultilinearEvalClaim;
-use binius_ip_prover::prodcheck::ProdcheckProver;
+use binius_ip_prover::{prodcheck::ProdcheckProver, sumcheck::mle_store::pooled_copy};
 use binius_math::{multilinear::evaluate::evaluate, test_utils::random_field_buffer};
 use binius_transcript::ProverTranscript;
 use binius_verifier::config::StdChallenger;
@@ -22,10 +23,12 @@ fn bench_prodcheck_new(c: &mut Criterion) {
 		group.bench_function(format!("n_vars={n_vars}"), |b| {
 			let mut rng = rand::rng();
 			let witness = random_field_buffer::<P>(&mut rng, n_vars);
+			let pool = BufferPool::new();
+			let alloc = &pool;
 
 			b.iter_batched(
 				|| witness.clone(),
-				|witness| ProdcheckProver::<P>::new(k, witness),
+				|witness| ProdcheckProver::<_, P>::new(k, &alloc, pooled_copy(&alloc, &witness)),
 				BatchSize::SmallInput,
 			);
 		});
@@ -46,9 +49,12 @@ fn bench_prodcheck_prove(c: &mut Criterion) {
 		group.bench_function(format!("n_vars={n_vars}"), |b| {
 			let mut rng = rand::rng();
 			let witness = random_field_buffer::<P>(&mut rng, n_vars);
+			let pool = BufferPool::new();
+			let alloc = &pool;
 
 			// Pre-compute the claim (products layer evaluation at empty point)
-			let (_prover, products) = ProdcheckProver::new(k, witness.clone());
+			let (_prover, products) =
+				ProdcheckProver::new(k, &alloc, pooled_copy(&alloc, &witness));
 			let products_eval = evaluate(&products, &[]);
 			let claim = MultilinearEvalClaim {
 				eval: products_eval,
@@ -59,7 +65,8 @@ fn bench_prodcheck_prove(c: &mut Criterion) {
 
 			b.iter_batched(
 				|| {
-					let (prover, _products) = ProdcheckProver::new(k, witness.clone());
+					let (prover, _products) =
+						ProdcheckProver::new(k, &alloc, pooled_copy(&alloc, &witness));
 					(prover, claim.clone())
 				},
 				|(prover, claim)| prover.prove(claim, &mut transcript),

--- a/crates/prover/benches/prodcheck.rs
+++ b/crates/prover/benches/prodcheck.rs
@@ -1,15 +1,16 @@
 // Copyright 2025-2026 The Binius Developers
 
 use binius_compute::BufferPool;
-use binius_field::arch::OptimalPackedB128;
+use binius_field::{FieldOps, arch::OptimalPackedB128};
 use binius_ip::prodcheck::MultilinearEvalClaim;
-use binius_ip_prover::{prodcheck::ProdcheckProver, sumcheck::mle_store::pooled_copy};
-use binius_math::{multilinear::evaluate::evaluate, test_utils::random_field_buffer};
+use binius_ip_prover::prodcheck::ProdcheckProver;
+use binius_math::{FieldBuffer, multilinear::evaluate::evaluate, test_utils::random_scalars};
 use binius_transcript::ProverTranscript;
 use binius_verifier::config::StdChallenger;
 use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
 
 type P = OptimalPackedB128;
+type F = <P as FieldOps>::Scalar;
 
 fn bench_prodcheck_new(c: &mut Criterion) {
 	let mut group = c.benchmark_group("prodcheck/new");
@@ -22,13 +23,15 @@ fn bench_prodcheck_new(c: &mut Criterion) {
 		group.throughput(Throughput::Elements(1 << n_vars));
 		group.bench_function(format!("n_vars={n_vars}"), |b| {
 			let mut rng = rand::rng();
-			let witness = random_field_buffer::<P>(&mut rng, n_vars);
+			let witness_scalars = random_scalars::<F>(&mut rng, 1 << n_vars);
 			let pool = BufferPool::new();
 			let alloc = &pool;
+			// Build the witness once; each iteration clones it from the pool.
+			let witness = FieldBuffer::<P>::from_values_in(&alloc, &witness_scalars);
 
 			b.iter_batched(
 				|| witness.clone(),
-				|witness| ProdcheckProver::<_, P>::new(k, &alloc, pooled_copy(&alloc, &witness)),
+				|witness| ProdcheckProver::<_, P>::new(k, &alloc, witness),
 				BatchSize::SmallInput,
 			);
 		});
@@ -48,13 +51,16 @@ fn bench_prodcheck_prove(c: &mut Criterion) {
 		group.throughput(Throughput::Elements(1 << n_vars));
 		group.bench_function(format!("n_vars={n_vars}"), |b| {
 			let mut rng = rand::rng();
-			let witness = random_field_buffer::<P>(&mut rng, n_vars);
+			let witness_scalars = random_scalars::<F>(&mut rng, 1 << n_vars);
 			let pool = BufferPool::new();
 			let alloc = &pool;
 
-			// Pre-compute the claim (products layer evaluation at empty point)
-			let (_prover, products) =
-				ProdcheckProver::new(k, &alloc, pooled_copy(&alloc, &witness));
+			// Build the prover once, then clone it per iteration (untimed setup).
+			let (prover, products) = ProdcheckProver::new(
+				k,
+				&alloc,
+				FieldBuffer::<P>::from_values_in(&alloc, &witness_scalars),
+			);
 			let products_eval = evaluate(&products, &[]);
 			let claim = MultilinearEvalClaim {
 				eval: products_eval,
@@ -64,11 +70,7 @@ fn bench_prodcheck_prove(c: &mut Criterion) {
 			let mut transcript = ProverTranscript::new(StdChallenger::default());
 
 			b.iter_batched(
-				|| {
-					let (prover, _products) =
-						ProdcheckProver::new(k, &alloc, pooled_copy(&alloc, &witness));
-					(prover, claim.clone())
-				},
+				|| (prover.clone(), claim.clone()),
 				|(prover, claim)| prover.prove(claim, &mut transcript),
 				BatchSize::SmallInput,
 			);

--- a/crates/prover/benches/shift_reduction.rs
+++ b/crates/prover/benches/shift_reduction.rs
@@ -2,7 +2,7 @@
 // Copyright 2026 The Binius Developers
 
 use binius_circuits::sha256::sha256_fixed;
-use binius_compute::BufferPool;
+use binius_compute::{BufferPool, GlobalAllocator};
 use binius_core::{ValueVec, constraint_system::ConstraintSystem, word::Word};
 use binius_field::{AESTowerField8b, BinaryField128bGhash, Field, Random, arch::OptimalPackedB128};
 use binius_frontend::{CircuitBuilder, Wire};
@@ -120,6 +120,8 @@ fn bench_prove_and_verify(c: &mut Criterion) {
 		group.sample_size(10);
 
 		group.bench_function("prove", |b| {
+			let pool = BufferPool::new();
+			let alloc = &pool;
 			b.iter(|| {
 				let prover_bitand_data = OperatorData {
 					evals: bitand_evals.to_vec(),
@@ -146,7 +148,7 @@ fn bench_prove_and_verify(c: &mut Criterion) {
 					},
 					&subspace,
 					&mut prover_transcript,
-					&&BufferPool::new(),
+					&alloc,
 				)
 			})
 		});
@@ -273,14 +275,16 @@ fn bench_shift_phases(c: &mut Criterion) {
 	// segment parts.
 	let build_combined_g_parts = || {
 		let (public_words, hidden_words) = words.split_at(key_collection.public.n_words());
-		let mut g_parts = build_g_parts::<F, P>(
+		let mut g_parts = build_g_parts::<F, P, _>(
+			&GlobalAllocator,
 			public_words,
 			&key_collection.public,
 			&prepared_bitand,
 			&prepared_intmul,
 			&prepared_bmul,
 		);
-		let hidden_g_parts = build_g_parts::<F, P>(
+		let hidden_g_parts = build_g_parts::<F, P, _>(
+			&GlobalAllocator,
 			hidden_words,
 			&key_collection.hidden,
 			&prepared_bitand,
@@ -296,7 +300,8 @@ fn bench_shift_phases(c: &mut Criterion) {
 	};
 
 	let g_parts = build_combined_g_parts();
-	let h_parts = build_h_parts::<F, P>(&subspace, prepared_bitand.r_zhat_prime);
+	let h_parts =
+		build_h_parts::<F, P, _>(&GlobalAllocator, &subspace, prepared_bitand.r_zhat_prime);
 	let SumcheckOutput {
 		challenges: mut r_jr_s,
 		eval: gamma,
@@ -306,7 +311,7 @@ fn bench_shift_phases(c: &mut Criterion) {
 			g_parts.clone(),
 			h_parts.clone(),
 			&mut transcript,
-			&&BufferPool::new(),
+			&GlobalAllocator,
 		)
 	};
 	// Split phase-1 challenges into `r_j` (low) and `r_s` (high) halves.
@@ -314,9 +319,10 @@ fn bench_shift_phases(c: &mut Criterion) {
 	let r_j = r_jr_s;
 	let r_j_tensor = eq_ind_partial_eval::<F>(&r_j);
 	let (public_words, hidden_words) = words.split_at(key_collection.public.n_words());
-	let public_folded = fold_words::<F, P>(public_words, r_j_tensor.as_ref());
-	let hidden_folded = fold_words::<F, P>(hidden_words, r_j_tensor.as_ref());
-	let (public_monster, hidden_monster) = build_monster_segments::<F, P>(
+	let public_folded = fold_words::<F, P, _>(&GlobalAllocator, public_words, r_j_tensor.as_ref());
+	let hidden_folded = fold_words::<F, P, _>(&GlobalAllocator, hidden_words, r_j_tensor.as_ref());
+	let (public_monster, hidden_monster) = build_monster_segments::<F, P, _>(
+		&GlobalAllocator,
 		&key_collection,
 		&prepared_bitand,
 		&prepared_intmul,
@@ -335,14 +341,16 @@ fn bench_shift_phases(c: &mut Criterion) {
 		b.iter(&build_combined_g_parts);
 	});
 	group.bench_function("phase1_build_h_parts", |b| {
-		b.iter(|| build_h_parts::<F, P>(&subspace, prepared_bitand.r_zhat_prime));
+		b.iter(|| {
+			build_h_parts::<F, P, _>(&GlobalAllocator, &subspace, prepared_bitand.r_zhat_prime)
+		});
 	});
 	group.bench_function("phase1_run_sumcheck", |b| {
 		b.iter_batched(
 			|| (g_parts.clone(), h_parts.clone()),
 			|(g, h)| {
 				let mut transcript = ProverTranscript::<StdChallenger>::default();
-				run_phase_1_sumcheck::<F, P, _, _>(g, h, &mut transcript, &&BufferPool::new())
+				run_phase_1_sumcheck::<F, P, _, _>(g, h, &mut transcript, &GlobalAllocator)
 			},
 			BatchSize::SmallInput,
 		);
@@ -352,7 +360,8 @@ fn bench_shift_phases(c: &mut Criterion) {
 	// its buffers and `r_j` by value.
 	group.bench_function("phase2_build_monster_segments", |b| {
 		b.iter(|| {
-			build_monster_segments::<F, P>(
+			build_monster_segments::<F, P, _>(
+				&GlobalAllocator,
 				&key_collection,
 				&prepared_bitand,
 				&prepared_intmul,
@@ -385,7 +394,7 @@ fn bench_shift_phases(c: &mut Criterion) {
 					r_j,
 					gamma,
 					&mut transcript,
-					&&BufferPool::new(),
+					&GlobalAllocator,
 				)
 			},
 			BatchSize::SmallInput,

--- a/crates/prover/benches/shift_reduction.rs
+++ b/crates/prover/benches/shift_reduction.rs
@@ -2,6 +2,7 @@
 // Copyright 2026 The Binius Developers
 
 use binius_circuits::sha256::sha256_fixed;
+use binius_compute::BufferPool;
 use binius_core::{ValueVec, constraint_system::ConstraintSystem, word::Word};
 use binius_field::{AESTowerField8b, BinaryField128bGhash, Field, Random, arch::OptimalPackedB128};
 use binius_frontend::{CircuitBuilder, Wire};
@@ -133,7 +134,7 @@ fn bench_prove_and_verify(c: &mut Criterion) {
 
 				let mut prover_transcript = ProverTranscript::<StdChallenger>::default();
 
-				prove::<F, P, _>(
+				prove::<F, P, _, _>(
 					&key_collection,
 					value_vec.combined_witness(),
 					prover_bitand_data,
@@ -145,6 +146,7 @@ fn bench_prove_and_verify(c: &mut Criterion) {
 					},
 					&subspace,
 					&mut prover_transcript,
+					&&BufferPool::new(),
 				)
 			})
 		});
@@ -163,7 +165,7 @@ fn bench_prove_and_verify(c: &mut Criterion) {
 
 		let mut prover_transcript = ProverTranscript::<StdChallenger>::default();
 
-		prove::<F, P, _>(
+		prove::<F, P, _, _>(
 			&key_collection,
 			value_vec.combined_witness(),
 			prover_bitand_data,
@@ -175,6 +177,7 @@ fn bench_prove_and_verify(c: &mut Criterion) {
 			},
 			&subspace,
 			&mut prover_transcript,
+			&&BufferPool::new(),
 		);
 
 		let setup_verifier_transcript = prover_transcript.into_verifier();
@@ -299,7 +302,12 @@ fn bench_shift_phases(c: &mut Criterion) {
 		eval: gamma,
 	} = {
 		let mut transcript = ProverTranscript::<StdChallenger>::default();
-		run_phase_1_sumcheck::<F, P, _>(g_parts.clone(), h_parts.clone(), &mut transcript)
+		run_phase_1_sumcheck::<F, P, _, _>(
+			g_parts.clone(),
+			h_parts.clone(),
+			&mut transcript,
+			&&BufferPool::new(),
+		)
 	};
 	// Split phase-1 challenges into `r_j` (low) and `r_s` (high) halves.
 	let r_s = r_jr_s.split_off(Word::LOG_BITS);
@@ -334,7 +342,7 @@ fn bench_shift_phases(c: &mut Criterion) {
 			|| (g_parts.clone(), h_parts.clone()),
 			|(g, h)| {
 				let mut transcript = ProverTranscript::<StdChallenger>::default();
-				run_phase_1_sumcheck::<F, P, _>(g, h, &mut transcript)
+				run_phase_1_sumcheck::<F, P, _, _>(g, h, &mut transcript, &&BufferPool::new())
 			},
 			BatchSize::SmallInput,
 		);
@@ -368,7 +376,7 @@ fn bench_shift_phases(c: &mut Criterion) {
 			},
 			|(public_folded, hidden_folded, public_monster, hidden_monster, r_j)| {
 				let mut transcript = ProverTranscript::<StdChallenger>::default();
-				run_sumcheck::<F, P, _>(
+				run_sumcheck::<F, P, _, _>(
 					public_folded,
 					hidden_folded,
 					public_monster,
@@ -377,6 +385,7 @@ fn bench_shift_phases(c: &mut Criterion) {
 					r_j,
 					gamma,
 					&mut transcript,
+					&&BufferPool::new(),
 				)
 			},
 			BatchSize::SmallInput,

--- a/crates/prover/benches/sumcheck.rs
+++ b/crates/prover/benches/sumcheck.rs
@@ -1,7 +1,10 @@
 // Copyright 2025 Irreducible Inc.
 
+use binius_compute::BufferPool;
 use binius_field::{arch::OptimalPackedB128, packed::PackedField};
-use binius_ip_prover::sumcheck::{prove_single_mlecheck, quadratic_mlecheck_prover};
+use binius_ip_prover::sumcheck::{
+	mle_store::pooled_copy, prove_single_mlecheck, quadratic_mlecheck_prover,
+};
 use binius_math::{
 	inner_product::inner_product_par,
 	test_utils::{random_field_buffer, random_scalars},
@@ -31,13 +34,16 @@ fn bench_mlecheck_prove(c: &mut Criterion) {
 			let eval_claim = inner_product_par(&multilinear_a, &multilinear_b);
 
 			let mut transcript = ProverTranscript::new(StdChallenger::default());
+			let pool = BufferPool::new();
+			let alloc = &pool;
 
 			// Benchmark only the proving phase
 			b.iter_batched(
 				|| [multilinear_a.clone(), multilinear_b.clone()],
 				|multilinears| {
 					let prover = quadratic_mlecheck_prover(
-						multilinears,
+						&alloc,
+						multilinears.map(|m| pooled_copy(&alloc, &m)),
 						|[a, b]| a * b,
 						|[a, b]| a * b,
 						eval_point.clone(),
@@ -67,6 +73,8 @@ fn bench_mlecheck_prove(c: &mut Criterion) {
 					.sum();
 
 			let mut transcript = ProverTranscript::new(StdChallenger::default());
+			let pool = BufferPool::new();
+			let alloc = &pool;
 
 			// Benchmark only the proving phase
 			b.iter_batched(
@@ -79,7 +87,8 @@ fn bench_mlecheck_prove(c: &mut Criterion) {
 				},
 				|multilinears| {
 					let prover = quadratic_mlecheck_prover(
-						multilinears,
+						&alloc,
+						multilinears.map(|m| pooled_copy(&alloc, &m)),
 						|[a, b, c]| a * b - c,
 						|[a, b, _c]| a * b,
 						eval_point.clone(),

--- a/crates/prover/benches/sumcheck.rs
+++ b/crates/prover/benches/sumcheck.rs
@@ -1,14 +1,9 @@
 // Copyright 2025 Irreducible Inc.
 
 use binius_compute::BufferPool;
-use binius_field::{arch::OptimalPackedB128, packed::PackedField};
-use binius_ip_prover::sumcheck::{
-	mle_store::pooled_copy, prove_single_mlecheck, quadratic_mlecheck_prover,
-};
-use binius_math::{
-	inner_product::inner_product_par,
-	test_utils::{random_field_buffer, random_scalars},
-};
+use binius_field::{FieldOps, arch::OptimalPackedB128, packed::PackedField};
+use binius_ip_prover::sumcheck::{prove_single_mlecheck, quadratic_mlecheck_prover};
+use binius_math::{FieldBuffer, inner_product::inner_product_par, test_utils::random_scalars};
 use binius_transcript::ProverTranscript;
 use binius_utils::rayon::prelude::*;
 use binius_verifier::config::StdChallenger;
@@ -16,6 +11,7 @@ use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_mai
 use rand::{SeedableRng, prelude::StdRng};
 
 type P = OptimalPackedB128;
+type F = <P as FieldOps>::Scalar;
 
 fn bench_mlecheck_prove(c: &mut Criterion) {
 	let mut group = c.benchmark_group("mlecheck");
@@ -27,15 +23,18 @@ fn bench_mlecheck_prove(c: &mut Criterion) {
 		// Consider each element to be one hypercube vertex.
 		group.throughput(Throughput::Elements(1 << n_vars));
 		group.bench_function(format!("A*B/n_vars={n_vars}"), |b| {
-			let multilinear_a = random_field_buffer::<P>(&mut rng, n_vars);
-			let multilinear_b = random_field_buffer::<P>(&mut rng, n_vars);
+			let a_scalars = random_scalars::<F>(&mut rng, 1 << n_vars);
+			let b_scalars = random_scalars::<F>(&mut rng, 1 << n_vars);
+			let pool = BufferPool::new();
+			let alloc = &pool;
+			// Build the multilinears once; each iteration clones them from the pool.
+			let multilinear_a = FieldBuffer::<P>::from_values_in(&alloc, &a_scalars);
+			let multilinear_b = FieldBuffer::<P>::from_values_in(&alloc, &b_scalars);
 
 			let eval_point = random_scalars(&mut rng, n_vars);
 			let eval_claim = inner_product_par(&multilinear_a, &multilinear_b);
 
 			let mut transcript = ProverTranscript::new(StdChallenger::default());
-			let pool = BufferPool::new();
-			let alloc = &pool;
 
 			// Benchmark only the proving phase
 			b.iter_batched(
@@ -43,7 +42,7 @@ fn bench_mlecheck_prove(c: &mut Criterion) {
 				|multilinears| {
 					let prover = quadratic_mlecheck_prover(
 						&alloc,
-						multilinears.map(|m| pooled_copy(&alloc, &m)),
+						multilinears,
 						|[a, b]| a * b,
 						|[a, b]| a * b,
 						eval_point.clone(),
@@ -58,9 +57,15 @@ fn bench_mlecheck_prove(c: &mut Criterion) {
 
 		// Benchmark mul gate composition: a * b - c
 		group.bench_function(format!("A*B-C/n_vars={n_vars}"), |b| {
-			let multilinear_a = random_field_buffer::<P>(&mut rng, n_vars);
-			let multilinear_b = random_field_buffer::<P>(&mut rng, n_vars);
-			let multilinear_c = random_field_buffer::<P>(&mut rng, n_vars);
+			let a_scalars = random_scalars::<F>(&mut rng, 1 << n_vars);
+			let b_scalars = random_scalars::<F>(&mut rng, 1 << n_vars);
+			let c_scalars = random_scalars::<F>(&mut rng, 1 << n_vars);
+			let pool = BufferPool::new();
+			let alloc = &pool;
+			// Build the multilinears once; each iteration clones them from the pool.
+			let multilinear_a = FieldBuffer::<P>::from_values_in(&alloc, &a_scalars);
+			let multilinear_b = FieldBuffer::<P>::from_values_in(&alloc, &b_scalars);
+			let multilinear_c = FieldBuffer::<P>::from_values_in(&alloc, &c_scalars);
 
 			let eval_point = random_scalars(&mut rng, n_vars);
 			let eval_claim =
@@ -73,8 +78,6 @@ fn bench_mlecheck_prove(c: &mut Criterion) {
 					.sum();
 
 			let mut transcript = ProverTranscript::new(StdChallenger::default());
-			let pool = BufferPool::new();
-			let alloc = &pool;
 
 			// Benchmark only the proving phase
 			b.iter_batched(
@@ -88,7 +91,7 @@ fn bench_mlecheck_prove(c: &mut Criterion) {
 				|multilinears| {
 					let prover = quadratic_mlecheck_prover(
 						&alloc,
-						multilinears.map(|m| pooled_copy(&alloc, &m)),
+						multilinears,
 						|[a, b, c]| a * b - c,
 						|[a, b, _c]| a * b,
 						eval_point.clone(),

--- a/crates/prover/src/and_reduction/prover.rs
+++ b/crates/prover/src/and_reduction/prover.rs
@@ -7,8 +7,7 @@ use binius_field::{AESTowerField8b as B8, BinaryField, PackedField};
 use binius_ip_prover::{
 	channel::IPProverChannel,
 	sumcheck::{
-		ProveSingleOutput, common::MleCheckProver, mle_store::pooled_copy, prove_single_mlecheck,
-		quadratic_mlecheck_prover,
+		ProveSingleOutput, common::MleCheckProver, prove_single_mlecheck, quadratic_mlecheck_prover,
 	},
 };
 use binius_math::{
@@ -172,7 +171,7 @@ where
 		let folder = BitAxisFolder::new(&lagrange_evals);
 
 		let proving_polys =
-			folder.fold_bitand_operands::<PChallenge>(&self.first_col, &self.second_col);
+			folder.fold_bitand_operands::<PChallenge, _>(alloc, &self.first_col, &self.second_col);
 
 		let upcasted_small_field_challenges = PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES
 			.iter()
@@ -191,7 +190,7 @@ where
 
 		quadratic_mlecheck_prover(
 			alloc,
-			proving_polys.map(|col| pooled_copy(alloc, &col)),
+			proving_polys,
 			|[a, b, c]| a * b - c,
 			|[a, b, _]| a * b,
 			verifier_field_zerocheck_challenges,
@@ -370,7 +369,7 @@ mod test {
 			lagrange_evals_scalars(&verifier_univariate_domain, z_challenge);
 		let folder = BitAxisFolder::new(&verifier_lagrange_evals);
 		for (i, eval) in [a_eval, b_eval, c_eval].iter().enumerate() {
-			let folded: FieldBuffer<B128> = folder.fold(&one_bit_mlvs[i]);
+			let folded: FieldBuffer<B128> = folder.fold(&GlobalAllocator, &one_bit_mlvs[i]);
 			assert_eq!(evaluate(&folded, &eval_point), *eval);
 		}
 	}

--- a/crates/prover/src/and_reduction/prover.rs
+++ b/crates/prover/src/and_reduction/prover.rs
@@ -1,12 +1,14 @@
 // Copyright 2025 Irreducible Inc.
 use std::{marker::PhantomData, ops::Deref};
 
+use binius_compute::Allocator;
 use binius_core::word::Word;
 use binius_field::{AESTowerField8b as B8, BinaryField, PackedField};
 use binius_ip_prover::{
 	channel::IPProverChannel,
 	sumcheck::{
-		ProveSingleOutput, common::MleCheckProver, prove_single_mlecheck, quadratic_mlecheck_prover,
+		ProveSingleOutput, common::MleCheckProver, mle_store::pooled_copy, prove_single_mlecheck,
+		quadratic_mlecheck_prover,
 	},
 };
 use binius_math::{
@@ -159,11 +161,12 @@ where
 	/// 3. Combines the zerocheck challenges (small field + big field)
 	/// 4. Evaluates the univariate polynomial at the challenge to get the sumcheck claim
 	/// 5. Constructs the AND reduction sumcheck prover with the folded multilinears
-	pub fn fold_and_send_reduced_prover(
+	pub fn fold_and_send_reduced_prover<'alloc, A: Allocator>(
 		self,
 		round_message_domain: BinarySubspace<F>,
 		challenge: F,
-	) -> impl MleCheckProver<F> {
+		alloc: &'alloc A,
+	) -> impl MleCheckProver<F> + 'alloc {
 		let univariate_domain = round_message_domain.reduce_dim(round_message_domain.dim() - 1);
 		let lagrange_evals = lagrange_evals_scalars(&univariate_domain, challenge);
 		let folder = BitAxisFolder::new(&lagrange_evals);
@@ -187,7 +190,8 @@ where
 			.copy_from_slice(&self.univariate_round_message);
 
 		quadratic_mlecheck_prover(
-			proving_polys,
+			alloc,
+			proving_polys.map(|col| pooled_copy(alloc, &col)),
 			|[a, b, c]| a * b - c,
 			|[a, b, _]| a * b,
 			verifier_field_zerocheck_challenges,
@@ -223,7 +227,11 @@ where
 	/// 2. **Challenge**: Sample univariate challenge z via Fiat-Shamir
 	/// 3. **Transition**: Fold oblong multilinears at Z = z
 	/// 4. **Phase 2**: Execute sumcheck protocol on folded multilinears
-	pub fn prove_with_channel(self, channel: &mut impl IPProverChannel<F>) -> AndCheckOutput<F> {
+	pub fn prove_with_channel<A: Allocator>(
+		self,
+		channel: &mut impl IPProverChannel<F>,
+		alloc: &A,
+	) -> AndCheckOutput<F> {
 		let univariate_message_coeffs = self.execute();
 
 		channel.send_many(univariate_message_coeffs);
@@ -234,6 +242,7 @@ where
 			self.fold_and_send_reduced_prover(
 				univariate_round_message_domain,
 				univariate_sumcheck_challenge,
+				alloc,
 			)
 		});
 
@@ -262,6 +271,7 @@ where
 mod test {
 	use std::{iter, iter::repeat_with};
 
+	use binius_compute::GlobalAllocator;
 	use binius_core::word::Word;
 	use binius_field::{AESTowerField8b, arch::OptimalPackedB128};
 	use binius_math::{
@@ -318,7 +328,7 @@ mod test {
 			prover_message_domain,
 		);
 
-		let prove_output = prover.prove_with_channel(&mut prover_challenger);
+		let prove_output = prover.prove_with_channel(&mut prover_challenger, &GlobalAllocator);
 
 		// Verifier is instantiated
 		let mut verifier_challenger = prover_challenger.into_verifier();

--- a/crates/prover/src/and_reduction/sumcheck_round_messages.rs
+++ b/crates/prover/src/and_reduction/sumcheck_round_messages.rs
@@ -213,6 +213,7 @@ impl<F: BinaryField + From<B8>> B8ToExtMulMap<F> {
 mod test {
 	use std::iter::repeat_with;
 
+	use binius_compute::GlobalAllocator;
 	use binius_field::{BinaryField128bGhash as B128, Field, Random};
 	use binius_math::{
 		BinarySubspace, FieldBuffer,
@@ -300,9 +301,9 @@ mod test {
 			lagrange_evals_scalars(&verifier_input_domain, first_sumcheck_challenge);
 		let folder = BitAxisFolder::new(&lagrange_evals);
 
-		let folded_first_mle: FieldBuffer<B128> = folder.fold(&mlv_1);
-		let folded_second_mle: FieldBuffer<B128> = folder.fold(&mlv_2);
-		let folded_third_mle: FieldBuffer<B128> = folder.fold(&mlv_3);
+		let folded_first_mle: FieldBuffer<B128> = folder.fold(&GlobalAllocator, &mlv_1);
+		let folded_second_mle: FieldBuffer<B128> = folder.fold(&GlobalAllocator, &mlv_2);
+		let folded_third_mle: FieldBuffer<B128> = folder.fold(&GlobalAllocator, &mlv_3);
 
 		let upcasted_small_field_challenges: Vec<_> = small_field_zerocheck_challenges
 			.into_iter()

--- a/crates/prover/src/fold_word.rs
+++ b/crates/prover/src/fold_word.rs
@@ -3,6 +3,7 @@
 
 use std::{array, borrow::Cow, hint::assert_unchecked, iter, ops::BitXor};
 
+use binius_compute::{Allocator, VecLike};
 use binius_core::word::Word;
 use binius_field::{
 	BinaryField, Divisible, Field, PackedField, UnderlierType, WideMul, WithUnderlier,
@@ -42,26 +43,32 @@ const BITS_PER_BYTE: usize = Word::BITS / Word::BYTES;
 /// * `vec` contains exactly [`Word::BITS`] elements
 ///
 /// [Method of Four Russians]: <https://en.wikipedia.org/wiki/Method_of_Four_Russians>
-pub fn fold_words<F, P>(words: &[Word], vec: &[F]) -> FieldBuffer<P>
+pub fn fold_words<F, P, A>(alloc: &A, words: &[Word], vec: &[F]) -> FieldBuffer<P, A::Vec<P>>
 where
 	F: BinaryField,
 	P: PackedField<Scalar = F>,
+	A: Allocator,
 {
-	BitAxisFolder::new(vec).fold(words)
+	BitAxisFolder::new(vec).fold(alloc, words)
 }
 
-fn fold_words_with_transform<F, P, T>(transform: &T, words: &[Word]) -> FieldBuffer<P>
+fn fold_words_with_transform<F, P, T, A>(
+	alloc: &A,
+	transform: &T,
+	words: &[Word],
+) -> FieldBuffer<P, A::Vec<P>>
 where
 	F: Field,
 	P: PackedField<Scalar = F>,
 	T: Transformation<u64, F>,
+	A: Allocator,
 {
 	// `words` need not have a power-of-two length; the high words up to the next power of two are
 	// treated as zero, so the remaining slots after the last real word are zero-filled by resize.
 	let log_n = log2_ceil_usize(words.len());
 	let capacity = 1 << log_n.saturating_sub(P::LOG_WIDTH);
 
-	let mut values = Vec::<P>::with_capacity(capacity);
+	let mut values = alloc.alloc::<P>(capacity);
 
 	let chunk_size = P::WIDTH;
 	let n_chunks = words.len() / chunk_size;
@@ -176,15 +183,17 @@ impl<UOut: UnderlierType> LinearTransformationFactory<u64, UOut>
 /// # Preconditions
 ///
 /// * The two word-lists have equal length.
-fn fold_bitand_operands_with_transform<F, P, T>(
+fn fold_bitand_operands_with_transform<F, P, T, A>(
+	alloc: &A,
 	transform: &T,
 	a_words: &[Word],
 	b_words: &[Word],
-) -> [FieldBuffer<P>; 3]
+) -> [FieldBuffer<P, A::Vec<P>>; 3]
 where
 	F: Field,
 	P: PackedField<Scalar = F>,
 	T: Transformation<u64, F>,
+	A: Allocator,
 {
 	assert_eq!(a_words.len(), b_words.len());
 
@@ -195,9 +204,9 @@ where
 	let capacity = 1 << log_n.saturating_sub(P::LOG_WIDTH);
 
 	// One output buffer per folded column, filled through spare capacity.
-	let mut a_values = Vec::<P>::with_capacity(capacity);
-	let mut b_values = Vec::<P>::with_capacity(capacity);
-	let mut c_values = Vec::<P>::with_capacity(capacity);
+	let mut a_values = alloc.alloc::<P>(capacity);
+	let mut b_values = alloc.alloc::<P>(capacity);
+	let mut c_values = alloc.alloc::<P>(capacity);
 
 	// Phase 1: partition the inputs into full packed-width chunks and a short tail.
 	//
@@ -294,11 +303,12 @@ impl<F: BinaryField> BitAxisFolder<F> {
 
 	/// Folds `words` into a [`FieldBuffer`], mapping each word to the inner product of its bits
 	/// with the scalar vector. See [`fold_words`] for the exact contract.
-	pub fn fold<P>(&self, words: &[Word]) -> FieldBuffer<P>
+	pub fn fold<P, A>(&self, alloc: &A, words: &[Word]) -> FieldBuffer<P, A::Vec<P>>
 	where
 		P: PackedField<Scalar = F>,
+		A: Allocator,
 	{
-		fold_words_with_transform(&self.transform, words)
+		fold_words_with_transform(alloc, &self.transform, words)
 	}
 
 	/// Folds the two stored BitAnd operand columns and their derived AND column in one pass.
@@ -315,11 +325,17 @@ impl<F: BinaryField> BitAxisFolder<F> {
 	/// # Preconditions
 	///
 	/// * The two word-lists have equal length.
-	pub fn fold_bitand_operands<P>(&self, a: &[Word], b: &[Word]) -> [FieldBuffer<P>; 3]
+	pub fn fold_bitand_operands<P, A>(
+		&self,
+		alloc: &A,
+		a: &[Word],
+		b: &[Word],
+	) -> [FieldBuffer<P, A::Vec<P>>; 3]
 	where
 		P: PackedField<Scalar = F>,
+		A: Allocator,
 	{
-		fold_bitand_operands_with_transform(&self.transform, a, b)
+		fold_bitand_operands_with_transform(alloc, &self.transform, a, b)
 	}
 }
 
@@ -646,6 +662,7 @@ pub(crate) fn duplicate_to_fixed_chunks<const N: usize>(words: &[Word]) -> Cow<'
 
 #[cfg(test)]
 mod tests {
+	use binius_compute::GlobalAllocator;
 	use binius_field::arch::OptimalPackedB128;
 	use binius_math::test_utils::{random_field_buffer, random_scalars};
 	use binius_utils::checked_arithmetics::log2_strict_usize;
@@ -697,7 +714,7 @@ mod tests {
 		let vec = random_scalars(&mut rng, Word::BITS);
 
 		// Compute using both methods
-		let result_optimized = fold_words::<B128, B128>(&words, &vec);
+		let result_optimized = fold_words::<B128, B128, _>(&GlobalAllocator, &words, &vec);
 		let result_naive = naive_fold_words::<B128, B128>(&words, &vec);
 
 		// Compare results
@@ -742,12 +759,27 @@ mod tests {
 			let folder = BitAxisFolder::new(&vec);
 
 			// Fold the two stored columns and the derived column in one fused pass.
-			let [a_fused, b_fused, c_fused] =
-				folder.fold_bitand_operands::<OptimalPackedB128>(&a_words, &b_words);
+			let [a_fused, b_fused, c_fused] = folder.fold_bitand_operands::<OptimalPackedB128, _>(
+				&GlobalAllocator,
+				&a_words,
+				&b_words,
+			);
 			// Each fused output must equal the independent single-column fold.
-			assert_eq!(a_fused, folder.fold(&a_words), "a mismatch at n_words = {n_words}");
-			assert_eq!(b_fused, folder.fold(&b_words), "b mismatch at n_words = {n_words}");
-			assert_eq!(c_fused, folder.fold(&c_words), "c mismatch at n_words = {n_words}");
+			assert_eq!(
+				a_fused,
+				folder.fold(&GlobalAllocator, &a_words),
+				"a mismatch at n_words = {n_words}"
+			);
+			assert_eq!(
+				b_fused,
+				folder.fold(&GlobalAllocator, &b_words),
+				"b mismatch at n_words = {n_words}"
+			);
+			assert_eq!(
+				c_fused,
+				folder.fold(&GlobalAllocator, &c_words),
+				"c mismatch at n_words = {n_words}"
+			);
 		}
 	}
 

--- a/crates/prover/src/protocols/binmul.rs
+++ b/crates/prover/src/protocols/binmul.rs
@@ -1,10 +1,13 @@
 // Copyright 2026 The Binius Developers
 
+use binius_compute::Allocator;
 use binius_core::word::Word;
 use binius_field::{BinaryField, PackedField};
 use binius_ip_prover::{
 	channel::IPProverChannel,
-	sumcheck::{ProveSingleOutput, prove_single_mlecheck, quadratic_mlecheck_prover},
+	sumcheck::{
+		ProveSingleOutput, mle_store::pooled_copy, prove_single_mlecheck, quadratic_mlecheck_prover,
+	},
 };
 use binius_math::field_buffer::FieldBuffer;
 use binius_utils::checked_arithmetics::strict_log_2;
@@ -57,8 +60,13 @@ where
 /// hypercube $\mathbb{B}_\ell$ over the GHASH field, where each element is carried by a `(lo, hi)`
 /// pair of 64-bit words. See [`binius_verifier::protocols::binmul::verify`] for the protocol
 /// description and output shape.
-pub fn prove<F, P, Channel>(witness: &BinMulWitness, channel: &mut Channel) -> BinMulOutput<F>
+pub fn prove<A, F, P, Channel>(
+	witness: &BinMulWitness,
+	channel: &mut Channel,
+	alloc: &A,
+) -> BinMulOutput<F>
 where
+	A: Allocator,
 	F: BinaryField + From<u128>,
 	P: PackedField<Scalar = F>,
 	Channel: IPProverChannel<F>,
@@ -86,7 +94,12 @@ where
 	// Product zerocheck: 0 = sum_x eq(r_z, x) * (A(x) * B(x) - C(x)). The composition A * B - C has
 	// degree 2; the eq factor is folded internally by the MLE-check.
 	let prover = quadratic_mlecheck_prover(
-		[a, b, c],
+		alloc,
+		[
+			pooled_copy(alloc, &a),
+			pooled_copy(alloc, &b),
+			pooled_copy(alloc, &c),
+		],
 		|[a, b, c]| a * b - c,
 		|[a, b, _c]| a * b,
 		r_z,
@@ -130,6 +143,7 @@ where
 
 #[cfg(test)]
 mod tests {
+	use binius_compute::GlobalAllocator;
 	use binius_core::word::Word;
 	use binius_field::{BinaryField128bGhash, PackedBinaryGhash2x128b, Random};
 	use binius_iop::channel::{OracleSpec, naive::NaiveVerifierChannel};
@@ -225,7 +239,7 @@ mod tests {
 		let mut prover_transcript = ProverTranscript::<StdChallenger>::default();
 		let mut prover_channel =
 			NaiveProverChannel::<F, _>::new(&mut prover_transcript, oracle_specs.to_vec());
-		let prove_output = prove::<F, P, _>(&witness, &mut prover_channel);
+		let prove_output = prove::<_, F, P, _>(&witness, &mut prover_channel, &GlobalAllocator);
 		prover_channel.finish();
 
 		let BinMulOutput {
@@ -295,7 +309,7 @@ mod tests {
 		let mut prover_transcript = ProverTranscript::<StdChallenger>::default();
 		let mut prover_channel =
 			NaiveProverChannel::<F, _>::new(&mut prover_transcript, oracle_specs.to_vec());
-		let _ = prove::<F, P, _>(&witness, &mut prover_channel);
+		let _ = prove::<_, F, P, _>(&witness, &mut prover_channel, &GlobalAllocator);
 		prover_channel.finish();
 
 		let mut verifier_transcript = prover_transcript.into_verifier();

--- a/crates/prover/src/protocols/binmul.rs
+++ b/crates/prover/src/protocols/binmul.rs
@@ -5,11 +5,9 @@ use binius_core::word::Word;
 use binius_field::{BinaryField, PackedField};
 use binius_ip_prover::{
 	channel::IPProverChannel,
-	sumcheck::{
-		ProveSingleOutput, mle_store::pooled_copy, prove_single_mlecheck, quadratic_mlecheck_prover,
-	},
+	sumcheck::{ProveSingleOutput, prove_single_mlecheck, quadratic_mlecheck_prover},
 };
-use binius_math::field_buffer::FieldBuffer;
+use binius_math::{FieldVec, field_buffer::FieldBuffer};
 use binius_utils::checked_arithmetics::strict_log_2;
 pub use binius_verifier::protocols::binmul::BinMulOutput;
 
@@ -34,22 +32,23 @@ pub struct BinMulWitness<'a> {
 ///
 /// The scalar at hypercube index `i` is the field element carried by the pair `(lo[i], hi[i])`:
 /// `lo[i]` supplies the low 64 bits and `hi[i]` the high 64 bits of the 128-bit value.
-fn build_table<F, P>(lo: &[Word], hi: &[Word]) -> FieldBuffer<P>
+fn build_table<A, F, P>(alloc: &A, lo: &[Word], hi: &[Word]) -> FieldVec<P, A>
 where
+	A: Allocator,
 	F: BinaryField + From<u128>,
 	P: PackedField<Scalar = F>,
 {
 	let n_vars = strict_log_2(lo.len())
 		.expect("precondition: the number of constraints must be a power of two");
 	let p_width = P::WIDTH.min(1 << n_vars);
-	let values = (0..1 << n_vars.saturating_sub(P::LOG_WIDTH))
-		.map(|i| {
-			P::from_scalars((0..p_width).map(|j| {
-				let index = i << P::LOG_WIDTH | j;
-				F::from((lo[index].as_u64() as u128) | ((hi[index].as_u64() as u128) << 64))
-			}))
-		})
-		.collect::<Vec<_>>();
+	let packed_len = 1 << n_vars.saturating_sub(P::LOG_WIDTH);
+	let mut values = alloc.alloc::<P>(packed_len);
+	values.extend((0..packed_len).map(|i| {
+		P::from_scalars((0..p_width).map(|j| {
+			let index = i << P::LOG_WIDTH | j;
+			F::from((lo[index].as_u64() as u128) | ((hi[index].as_u64() as u128) << 64))
+		}))
+	}));
 
 	FieldBuffer::new(n_vars, values)
 }
@@ -84,9 +83,9 @@ where
 	}
 
 	// Build the packed GHASH-field multilinear tables A, B, C from the (lo, hi) word pairs.
-	let a = build_table::<F, P>(witness.a_lo, witness.a_hi);
-	let b = build_table::<F, P>(witness.b_lo, witness.b_hi);
-	let c = build_table::<F, P>(witness.c_lo, witness.c_hi);
+	let a = build_table::<A, F, P>(alloc, witness.a_lo, witness.a_hi);
+	let b = build_table::<A, F, P>(alloc, witness.b_lo, witness.b_hi);
+	let c = build_table::<A, F, P>(alloc, witness.c_lo, witness.c_hi);
 
 	// Sample the zerocheck challenge r_z.
 	let r_z = channel.sample_many(n_vars);
@@ -95,11 +94,7 @@ where
 	// degree 2; the eq factor is folded internally by the MLE-check.
 	let prover = quadratic_mlecheck_prover(
 		alloc,
-		[
-			pooled_copy(alloc, &a),
-			pooled_copy(alloc, &b),
-			pooled_copy(alloc, &c),
-		],
+		[a, b, c],
 		|[a, b, c]| a * b - c,
 		|[a, b, _c]| a * b,
 		r_z,
@@ -173,8 +168,11 @@ mod tests {
 		let prefix_tensor = eq_ind_partial_eval::<F>(prefix);
 		let suffix_tensor = eq_ind_partial_eval::<F>(suffix);
 
-		let partially_folded_witness =
-			crate::fold_word::fold_words::<_, F>(words, prefix_tensor.as_ref());
+		let partially_folded_witness = crate::fold_word::fold_words::<_, F, _>(
+			&GlobalAllocator,
+			words,
+			prefix_tensor.as_ref(),
+		);
 
 		inner_product_buffers(&partially_folded_witness, &suffix_tensor)
 	}

--- a/crates/prover/src/protocols/intmul/prove.rs
+++ b/crates/prover/src/protocols/intmul/prove.rs
@@ -18,13 +18,13 @@ use binius_ip_prover::{
 		MleToSumCheckDecorator,
 		batch::{BatchSumcheckOutput, batch_prove, batch_prove_and_write_evals},
 		bivariate_product_mle,
-		mle_store::pooled_copy,
 		multilinear_eval::multilinear_eval_prover,
 		quadratic_mlecheck_prover,
 		selector_mle::{Claim, SelectorMlecheckProver},
 	},
 };
 use binius_math::{
+	FieldVec,
 	field_buffer::FieldBuffer,
 	inner_product::inner_product_buffers,
 	multilinear::{
@@ -281,11 +281,11 @@ where
 					.sum::<F>()
 			})
 			.collect::<Vec<_>>();
-		let folded_column = FieldBuffer::<P>::from_values(&folded_column_scalars);
+		let folded_column = FieldBuffer::<P>::from_values_in(alloc, &folded_column_scalars);
 		drop(fold_guard);
 		let index_prover = MleToSumCheckDecorator::new(multilinear_eval_prover(
 			alloc,
-			pooled_copy(alloc, &folded_column),
+			folded_column,
 			index_content_point,
 			folded_index_claim,
 		));
@@ -294,19 +294,15 @@ where
 		let binary_elements = [F::zero(), F::one()];
 
 		// TODO: Use a special 1-bit-optimized MLE-check with switchover to save memory.
-		let a_0: FieldBuffer<P> = two_valued_field_buffer(0, a_exponents, binary_elements);
-		let b_0: FieldBuffer<P> = two_valued_field_buffer(0, b_exponents, binary_elements);
-		let c_lo_0: FieldBuffer<P> = two_valued_field_buffer(0, c_lo_exponents, binary_elements);
+		let a_0 = two_valued_field_buffer::<A, _, P>(alloc, 0, a_exponents, binary_elements);
+		let b_0 = two_valued_field_buffer::<A, _, P>(alloc, 0, b_exponents, binary_elements);
+		let c_lo_0 = two_valued_field_buffer::<A, _, P>(alloc, 0, c_lo_exponents, binary_elements);
 
 		// The overflow parity check binds at the Phase-2 constraint point `b_eval_point` (r_2) —
 		// reused for free from the `b` re-randomization.
 		let overflow_prover = MleToSumCheckDecorator::new(quadratic_mlecheck_prover(
 			alloc,
-			[
-				pooled_copy(alloc, &a_0),
-				pooled_copy(alloc, &b_0),
-				pooled_copy(alloc, &c_lo_0),
-			],
+			[a_0, b_0, c_lo_0],
 			|[a, b, c]| a * b - c,
 			|[a, b, _c]| a * b,
 			b_eval_point.to_vec(),
@@ -318,10 +314,10 @@ where
 		// `b_eval_point` (r_2) to the shared point via a single-claim MLE-eval check.
 		assert_eq!(b_exponents.len(), 1 << n_vars);
 		let b_tensor = eq_ind_partial_eval_scalars::<F>(r_ib);
-		let b_folded = fold_words::<_, P>(b_exponents, &b_tensor);
+		let b_folded = fold_words::<_, P, _>(alloc, b_exponents, &b_tensor);
 		let b_sumcheck_prover = MleToSumCheckDecorator::new(multilinear_eval_prover(
 			alloc,
-			pooled_copy(alloc, &b_folded),
+			b_folded,
 			b_eval_point,
 			b_recomb,
 		));
@@ -429,7 +425,7 @@ where
 		twisted_evals: &[F],
 		selector: FieldBuffer<P>,
 		b_exponents: &[Word],
-		c_lo_hi_roots: [FieldBuffer<P>; 2],
+		c_lo_hi_roots: [FieldVec<P, A>; 2],
 		c_eval_point: &[F],
 		c_root_eval: F,
 	) -> Phase3Output<F> {
@@ -469,12 +465,8 @@ where
 			self.switchover,
 		);
 
-		let c_root_sumcheck_prover = bivariate_product_mle::new(
-			alloc,
-			c_lo_hi_roots.map(|root| pooled_copy(alloc, &root)),
-			c_eval_point.to_vec(),
-			c_root_eval,
-		);
+		let c_root_sumcheck_prover =
+			bivariate_product_mle::new(alloc, c_lo_hi_roots, c_eval_point.to_vec(), c_root_eval);
 
 		let c_root_prover = MleToSumCheckDecorator::new(c_root_sumcheck_prover);
 

--- a/crates/prover/src/protocols/intmul/prove.rs
+++ b/crates/prover/src/protocols/intmul/prove.rs
@@ -3,6 +3,7 @@
 
 use std::marker::PhantomData;
 
+use binius_compute::Allocator;
 use binius_core::word::Word;
 use binius_field::{BinaryField, BinaryField1b, Divisible, ExtensionField, PackedField};
 use binius_iop_prover::{
@@ -17,6 +18,7 @@ use binius_ip_prover::{
 		MleToSumCheckDecorator,
 		batch::{BatchSumcheckOutput, batch_prove, batch_prove_and_write_evals},
 		bivariate_product_mle,
+		mle_store::pooled_copy,
 		multilinear_eval::multilinear_eval_prover,
 		quadratic_mlecheck_prover,
 		selector_mle::{Claim, SelectorMlecheckProver},
@@ -43,25 +45,29 @@ use crate::fold_word::{fold_across_words, fold_words};
 
 /// A helper structure that encapsulates switchover settings and the prover channel for
 /// the integer multiplication protocol.
-pub struct IntMulProver<'a, P, Channel> {
+pub struct IntMulProver<'a, 'alloc, A: Allocator, P, Channel> {
 	_p_marker: PhantomData<P>,
 
 	switchover: usize,
 	channel: &'a mut Channel,
+	/// Pool the GKR working buffers are drawn from.
+	alloc: &'alloc A,
 }
 
-impl<'a, P, Channel> IntMulProver<'a, P, Channel> {
-	pub const fn new(switchover: usize, channel: &'a mut Channel) -> Self {
+impl<'a, 'alloc, A: Allocator, P, Channel> IntMulProver<'a, 'alloc, A, P, Channel> {
+	pub const fn new(switchover: usize, channel: &'a mut Channel, alloc: &'alloc A) -> Self {
 		Self {
 			_p_marker: PhantomData,
 			switchover,
 			channel,
+			alloc,
 		}
 	}
 }
 
-impl<F, P, Channel> IntMulProver<'_, P, Channel>
+impl<'alloc, A, F, P, Channel> IntMulProver<'_, 'alloc, A, P, Channel>
 where
+	A: Allocator,
 	F: BinaryField<Underlier: Divisible<u64>>,
 	P: PackedField<Scalar = F>,
 	Channel: IOPProverChannel<P>,
@@ -91,7 +97,7 @@ where
 	/// The output of this protocol is a set of evaluation claims on the `b` selectors representing
 	/// all of `a`, `b`, `c_lo` and `c_hi` as column-major bit matrices, at a common evaluation
 	/// point. The logup* pushforward commitment is opened through the channel inside phase 5.
-	pub fn prove(&mut self, witness: Witness<'_, P>) -> IntMulOutput<F> {
+	pub fn prove(&mut self, witness: Witness<'_, 'alloc, A, P>) -> IntMulOutput<F> {
 		let Witness {
 			a_exponents,
 			a_prodcheck,
@@ -192,6 +198,7 @@ where
 		c_hi_exponents: &[Word],
 		table: &FieldBuffer<P>,
 	) -> IntMulOutput<F> {
+		let alloc = self.alloc;
 		let n_vars = b_eval_point.len();
 		assert_eq!(phase_4_output.eval_point.len(), n_vars);
 
@@ -238,7 +245,7 @@ where
 			})
 			.collect::<Vec<_>>();
 		let log_cols = log2_ceil_usize(N_LIMB_COLUMNS);
-		let logup_proof = logup_star::prove(table, &lookers, self.channel);
+		let logup_proof = logup_star::prove(table, &lookers, self.channel, self.alloc);
 
 		// The index entries are the GF(2)-linear embeddings iota(e) = Σ_u basis(u) · bit_u(e),
 		// materialized by a table of all 2^LIMB_BITS embeddings.
@@ -277,7 +284,8 @@ where
 		let folded_column = FieldBuffer::<P>::from_values(&folded_column_scalars);
 		drop(fold_guard);
 		let index_prover = MleToSumCheckDecorator::new(multilinear_eval_prover(
-			folded_column,
+			alloc,
+			pooled_copy(alloc, &folded_column),
 			index_content_point,
 			folded_index_claim,
 		));
@@ -293,7 +301,12 @@ where
 		// The overflow parity check binds at the Phase-2 constraint point `b_eval_point` (r_2) —
 		// reused for free from the `b` re-randomization.
 		let overflow_prover = MleToSumCheckDecorator::new(quadratic_mlecheck_prover(
-			[a_0, b_0, c_lo_0],
+			alloc,
+			[
+				pooled_copy(alloc, &a_0),
+				pooled_copy(alloc, &b_0),
+				pooled_copy(alloc, &c_lo_0),
+			],
 			|[a, b, c]| a * b - c,
 			|[a, b, _c]| a * b,
 			b_eval_point.to_vec(),
@@ -306,8 +319,12 @@ where
 		assert_eq!(b_exponents.len(), 1 << n_vars);
 		let b_tensor = eq_ind_partial_eval_scalars::<F>(r_ib);
 		let b_folded = fold_words::<_, P>(b_exponents, &b_tensor);
-		let b_sumcheck_prover =
-			MleToSumCheckDecorator::new(multilinear_eval_prover(b_folded, b_eval_point, b_recomb));
+		let b_sumcheck_prover = MleToSumCheckDecorator::new(multilinear_eval_prover(
+			alloc,
+			pooled_copy(alloc, &b_folded),
+			b_eval_point,
+			b_recomb,
+		));
 
 		let batch_guard = tracing::debug_span!("Final batched sumcheck").entered();
 		let BatchSumcheckOutput {
@@ -353,8 +370,9 @@ where
 	}
 }
 
-impl<F, P, Channel> IntMulProver<'_, P, Channel>
+impl<'alloc, A, F, P, Channel> IntMulProver<'_, 'alloc, A, P, Channel>
 where
+	A: Allocator,
 	F: BinaryField,
 	P: PackedField<Scalar = F>,
 	Channel: IPProverChannel<F>,
@@ -363,7 +381,7 @@ where
 	pub fn phase1(
 		&mut self,
 		eval_point: &[F],
-		b_prover: ProdcheckProver<P>,
+		b_prover: ProdcheckProver<'alloc, A, P>,
 		b_leaves: &FieldBuffer<P>,
 		b_root_eval: F,
 	) -> Phase1Output<F> {
@@ -415,6 +433,7 @@ where
 		c_eval_point: &[F],
 		c_root_eval: F,
 	) -> Phase3Output<F> {
+		let alloc = self.alloc;
 		let n_vars = selector.log_len();
 		assert!(
 			twisted_eval_points
@@ -450,8 +469,12 @@ where
 			self.switchover,
 		);
 
-		let c_root_sumcheck_prover =
-			bivariate_product_mle::new(c_lo_hi_roots, c_eval_point.to_vec(), c_root_eval);
+		let c_root_sumcheck_prover = bivariate_product_mle::new(
+			alloc,
+			c_lo_hi_roots.map(|root| pooled_copy(alloc, &root)),
+			c_eval_point.to_vec(),
+			c_root_eval,
+		);
 
 		let c_root_prover = MleToSumCheckDecorator::new(c_root_sumcheck_prover);
 
@@ -498,9 +521,9 @@ where
 	pub fn phase4(
 		&mut self,
 		eval_point: &[F],
-		(a_root_eval, a_prover): (F, ProdcheckProver<P>),
-		(gpow_c_lo_eval, c_lo_prover): (F, ProdcheckProver<P>),
-		(gpow_c_hi_eval, c_hi_prover): (F, ProdcheckProver<P>),
+		(a_root_eval, a_prover): (F, ProdcheckProver<'alloc, A, P>),
+		(gpow_c_lo_eval, c_lo_prover): (F, ProdcheckProver<'alloc, A, P>),
+		(gpow_c_hi_eval, c_hi_prover): (F, ProdcheckProver<'alloc, A, P>),
 		exponents: [&[Word]; 3],
 		tables: &[FieldBuffer<P>],
 	) -> Phase4Output<F> {

--- a/crates/prover/src/protocols/intmul/tests.rs
+++ b/crates/prover/src/protocols/intmul/tests.rs
@@ -1,6 +1,7 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
+use binius_compute::GlobalAllocator;
 use binius_core::word::Word;
 use binius_field::{BinaryField128bGhash, PackedBinaryGhash2x128b, Random};
 use binius_iop::channel::{OracleSpec, naive::NaiveVerifierChannel};
@@ -59,7 +60,8 @@ fn prove_and_verify() {
 		c_hi.push(Word::from_u64(c_hi_i));
 	}
 
-	let witness = Witness::<P>::new(&a, &b, &c_lo, &c_hi).unwrap();
+	let alloc = GlobalAllocator;
+	let witness = Witness::<_, P>::new(&alloc, &a, &b, &c_lo, &c_hi).unwrap();
 
 	// The one oracle in the protocol is the logup* pushforward, over the table variables.
 	let oracle_specs = [OracleSpec::new(LIMB_BITS)];
@@ -68,7 +70,7 @@ fn prove_and_verify() {
 	let mut prover_transcript = ProverTranscript::<StdChallenger>::default();
 	let mut prover_channel =
 		NaiveProverChannel::<F, _>::new(&mut prover_transcript, oracle_specs.to_vec());
-	let mut prover = IntMulProver::new(0, &mut prover_channel);
+	let mut prover = IntMulProver::new(0, &mut prover_channel, &alloc);
 	let prove_output = prover.prove(witness);
 	prover_channel.finish();
 

--- a/crates/prover/src/protocols/intmul/tests.rs
+++ b/crates/prover/src/protocols/intmul/tests.rs
@@ -29,7 +29,8 @@ pub fn evaluate_witness(words: &[Word], eval_point: &[F]) -> F {
 	let prefix_tensor = eq_ind_partial_eval::<F>(prefix);
 	let suffix_tensor = eq_ind_partial_eval::<F>(suffix);
 
-	let partially_folded_witness = fold_words::<_, F>(words, prefix_tensor.as_ref());
+	let partially_folded_witness =
+		fold_words::<_, F, _>(&GlobalAllocator, words, prefix_tensor.as_ref());
 
 	inner_product_buffers(&partially_folded_witness, &suffix_tensor)
 }

--- a/crates/prover/src/protocols/intmul/witness.rs
+++ b/crates/prover/src/protocols/intmul/witness.rs
@@ -3,9 +3,13 @@
 
 use std::{iter, mem::MaybeUninit, ops::Deref};
 
+use binius_compute::Allocator;
 use binius_core::word::Word;
 use binius_field::{BinaryField, Field, PackedField};
-use binius_ip_prover::prodcheck::ProdcheckProver;
+use binius_ip_prover::{
+	prodcheck::ProdcheckProver,
+	sumcheck::mle_store::{PooledColumn, pooled_copy},
+};
 use binius_math::field_buffer::FieldBuffer;
 use binius_utils::{
 	checked_arithmetics::{checked_log_2, strict_log_2},
@@ -40,15 +44,15 @@ use super::error::Error;
 /// Protocol proves that ${(G^a)}^b = G^{c\\_lo} \times (G^{2^{2^m}})^{c\\_hi}$, which is equivalent
 /// to $a \times b = c$ modulo $2^{2^{m+1}} - 1$. The special case of `0 * 0 = 1` is handled
 /// separately.
-#[derive(Clone, Getters)]
+#[derive(Getters)]
 #[getset(get = "pub")]
-pub struct Witness<'a, P: PackedField> {
+pub struct Witness<'a, 'alloc, A: Allocator, P: PackedField> {
 	/// The exponents for `a` (needed for the phase 5 lookup indices and parity zerocheck on
 	/// `a_0`).
 	#[getset(skip)]
 	pub a_exponents: &'a [Word],
 	/// Prodcheck prover for the `a` exponentiation tree (leaf layer retained).
-	pub a_prodcheck: ProdcheckProver<P>,
+	pub a_prodcheck: ProdcheckProver<'alloc, A, P>,
 	/// The root of the `a` tree (product of all leaves element-wise); the `b` variable base.
 	pub a_root: FieldBuffer<P>,
 	/// The exponents for `b` (needed for phase 5).
@@ -58,7 +62,7 @@ pub struct Witness<'a, P: PackedField> {
 	/// Has log_len = n_vars + Word::LOG_BITS.
 	pub b_leaves: FieldBuffer<P>,
 	/// The prover for the prodcheck reduction on b_leaves.
-	pub b_prodcheck: ProdcheckProver<P>,
+	pub b_prodcheck: ProdcheckProver<'alloc, A, P>,
 	/// The root of the b tree (product of all leaves element-wise).
 	pub b_root: FieldBuffer<P>,
 	/// The exponents for `c_lo` (needed for the phase 5 lookup indices, parity zerocheck on
@@ -66,7 +70,7 @@ pub struct Witness<'a, P: PackedField> {
 	#[getset(skip)]
 	pub c_lo_exponents: &'a [Word],
 	/// Prodcheck prover for the `c_lo` exponentiation tree (leaf layer retained).
-	pub c_lo_prodcheck: ProdcheckProver<P>,
+	pub c_lo_prodcheck: ProdcheckProver<'alloc, A, P>,
 	/// The root of the `c_lo` tree.
 	pub c_lo_root: FieldBuffer<P>,
 	/// The exponents for `c_hi` (needed for the phase 5 lookup indices and raw per-bit output
@@ -74,7 +78,7 @@ pub struct Witness<'a, P: PackedField> {
 	#[getset(skip)]
 	pub c_hi_exponents: &'a [Word],
 	/// Prodcheck prover for the `c_hi` exponentiation tree (leaf layer retained).
-	pub c_hi_prodcheck: ProdcheckProver<P>,
+	pub c_hi_prodcheck: ProdcheckProver<'alloc, A, P>,
 	/// The root of the `c_hi` tree.
 	pub c_hi_root: FieldBuffer<P>,
 	/// The 2·N_LIMBS twisted power tables: `tables[s][i] = (G^{2^{ws}})^i`. Limb column `(t, l)`
@@ -83,13 +87,17 @@ pub struct Witness<'a, P: PackedField> {
 	pub tables: Vec<FieldBuffer<P>>,
 }
 
-impl<'a, F, P> Witness<'a, P>
+impl<'a, 'alloc, A, F, P> Witness<'a, 'alloc, A, P>
 where
+	A: Allocator,
 	F: BinaryField,
 	P: PackedField<Scalar = F>,
 {
 	/// Constructs a new integer multiplication witness from the statement.
+	///
+	/// The GKR prodcheck provers draw their layer buffers from `alloc`.
 	pub fn new(
+		alloc: &'alloc A,
 		a: &'a [Word],
 		b: &'a [Word],
 		c_lo: &'a [Word],
@@ -137,20 +145,28 @@ where
 		let fixed_base_tree_scope =
 			tracing::debug_span!("Compute fixed-base prodcheck layers").entered();
 		let a_leaves = limb_leaves(&tables[..N_LIMBS], a);
-		let (a_prodcheck, a_root) = ProdcheckProver::new(LOG_N_LIMBS, a_leaves);
+		let (a_prodcheck, a_root) =
+			ProdcheckProver::new(LOG_N_LIMBS, alloc, pooled_copy(alloc, &a_leaves));
+		let a_root = unpool::<A, P>(a_root);
 
 		let c_lo_leaves = limb_leaves(&tables[..N_LIMBS], c_lo);
-		let (c_lo_prodcheck, c_lo_root) = ProdcheckProver::new(LOG_N_LIMBS, c_lo_leaves);
+		let (c_lo_prodcheck, c_lo_root) =
+			ProdcheckProver::new(LOG_N_LIMBS, alloc, pooled_copy(alloc, &c_lo_leaves));
+		let c_lo_root = unpool::<A, P>(c_lo_root);
 
 		let c_hi_leaves = limb_leaves(&tables[N_LIMBS..], c_hi);
-		let (c_hi_prodcheck, c_hi_root) = ProdcheckProver::new(LOG_N_LIMBS, c_hi_leaves);
+		let (c_hi_prodcheck, c_hi_root) =
+			ProdcheckProver::new(LOG_N_LIMBS, alloc, pooled_copy(alloc, &c_hi_leaves));
+		let c_hi_root = unpool::<A, P>(c_hi_root);
 		drop(fixed_base_tree_scope);
 
 		// Compute b_leaves as concatenated leaves for prodcheck; the variable base is the `a` root.
 		let variable_base_tree_scope =
 			tracing::debug_span!("Compute variable-base prodcheck layers").entered();
 		let b_leaves = compute_b_leaves(&a_root, b);
-		let (b_prodcheck, b_root) = ProdcheckProver::new(Word::LOG_BITS, b_leaves.clone());
+		let (b_prodcheck, b_root) =
+			ProdcheckProver::new(Word::LOG_BITS, alloc, pooled_copy(alloc, &b_leaves));
+		let b_root = unpool::<A, P>(b_root);
 		drop(variable_base_tree_scope);
 
 		Ok(Self {
@@ -170,6 +186,15 @@ where
 			tables,
 		})
 	}
+}
+
+/// Copies a pooled tree root into a plain `Vec`-backed buffer.
+///
+/// The root fields are consumed by the phase provers as ordinary `FieldBuffer`s; the pooled block
+/// cannot be handed out as a `Vec` directly (its allocation is over-aligned for the free list), so
+/// it is copied out and the pooled block recycled.
+fn unpool<A: Allocator, P: PackedField>(src: PooledColumn<A, P>) -> FieldBuffer<P> {
+	FieldBuffer::new(src.log_len(), src.as_ref().to_vec())
 }
 
 /// Number of packed columns filled as one independent group before chaining to the next block.
@@ -422,13 +447,14 @@ where
 
 #[cfg(test)]
 mod tests {
+	use binius_compute::GlobalAllocator;
 	use binius_math::test_utils::Packed128b;
 
 	use super::*;
 
 	type P = Packed128b;
 
-	fn check_consistency<P: PackedField>(witness: &Witness<'_, P>) {
+	fn check_consistency<A: Allocator, P: PackedField>(witness: &Witness<'_, '_, A, P>) {
 		// The variable-base `b`-exponent tree root must equal the full product `c` root
 		// (`c_lo_root * c_hi_root`); this equality is what lets the prover reuse `b_root` in place
 		// of a separately stored `c_root`.
@@ -443,7 +469,8 @@ mod tests {
 		let c_lo = [Word::from_u64(6)]; // 2*3 = 6
 		let c_hi = [Word::from_u64(0)]; // no high bits
 
-		let witness = Witness::<P>::new(&a, &b, &c_lo, &c_hi).unwrap();
+		let alloc = GlobalAllocator;
+		let witness = Witness::<_, P>::new(&alloc, &a, &b, &c_lo, &c_hi).unwrap();
 		check_consistency(&witness);
 	}
 
@@ -454,7 +481,8 @@ mod tests {
 		let c_lo = [Word::from_u64(0)];
 		let c_hi = [Word::from_u64(2)]; // 2^32 * 2^33 = 2^65, which is 2 in the high 64 bits
 
-		let witness = Witness::<P>::new(&a, &b, &c_lo, &c_hi).unwrap();
+		let alloc = GlobalAllocator;
+		let witness = Witness::<_, P>::new(&alloc, &a, &b, &c_lo, &c_hi).unwrap();
 		check_consistency(&witness);
 	}
 
@@ -484,7 +512,8 @@ mod tests {
 			c_hi.push(Word::from_u64(c_hi_i));
 		}
 
-		let witness = Witness::<P>::new(&a, &b, &c_lo, &c_hi).unwrap();
+		let alloc = GlobalAllocator;
+		let witness = Witness::<_, P>::new(&alloc, &a, &b, &c_lo, &c_hi).unwrap();
 		check_consistency(&witness);
 	}
 	/// Directly checks `compute_b_leaves` against its specification — leaf `z` holds

--- a/crates/prover/src/protocols/intmul/witness.rs
+++ b/crates/prover/src/protocols/intmul/witness.rs
@@ -6,11 +6,8 @@ use std::{iter, mem::MaybeUninit, ops::Deref};
 use binius_compute::Allocator;
 use binius_core::word::Word;
 use binius_field::{BinaryField, Field, PackedField};
-use binius_ip_prover::{
-	prodcheck::ProdcheckProver,
-	sumcheck::mle_store::{PooledColumn, pooled_copy},
-};
-use binius_math::field_buffer::FieldBuffer;
+use binius_ip_prover::{prodcheck::ProdcheckProver, sumcheck::mle_store::pooled_copy};
+use binius_math::{FieldVec, field_buffer::FieldBuffer};
 use binius_utils::{
 	checked_arithmetics::{checked_log_2, strict_log_2},
 	rayon::prelude::*,
@@ -72,7 +69,7 @@ pub struct Witness<'a, 'alloc, A: Allocator, P: PackedField> {
 	/// Prodcheck prover for the `c_lo` exponentiation tree (leaf layer retained).
 	pub c_lo_prodcheck: ProdcheckProver<'alloc, A, P>,
 	/// The root of the `c_lo` tree.
-	pub c_lo_root: FieldBuffer<P>,
+	pub c_lo_root: FieldVec<P, A>,
 	/// The exponents for `c_hi` (needed for the phase 5 lookup indices and raw per-bit output
 	/// evaluations).
 	#[getset(skip)]
@@ -80,11 +77,37 @@ pub struct Witness<'a, 'alloc, A: Allocator, P: PackedField> {
 	/// Prodcheck prover for the `c_hi` exponentiation tree (leaf layer retained).
 	pub c_hi_prodcheck: ProdcheckProver<'alloc, A, P>,
 	/// The root of the `c_hi` tree.
-	pub c_hi_root: FieldBuffer<P>,
+	pub c_hi_root: FieldVec<P, A>,
 	/// The 2·N_LIMBS twisted power tables: `tables[s][i] = (G^{2^{ws}})^i`. Limb column `(t, l)`
 	/// is a gather from table `s(t, l)`; `tables[0]` is the shared table read by the Phase 5
 	/// logup* lookup.
 	pub tables: Vec<FieldBuffer<P>>,
+}
+
+// A manual `Clone` impl (rather than `#[derive(Clone)]`) so the bound lands on the pooled buffer
+// `A::Vec<P>` rather than on `A` and `P`. Holds for the `Vec`-backed `GlobalAllocator`.
+impl<A: Allocator, P: PackedField> Clone for Witness<'_, '_, A, P>
+where
+	A::Vec<P>: Clone,
+{
+	fn clone(&self) -> Self {
+		Self {
+			a_exponents: self.a_exponents,
+			a_prodcheck: self.a_prodcheck.clone(),
+			a_root: self.a_root.clone(),
+			b_exponents: self.b_exponents,
+			b_leaves: self.b_leaves.clone(),
+			b_prodcheck: self.b_prodcheck.clone(),
+			b_root: self.b_root.clone(),
+			c_lo_exponents: self.c_lo_exponents,
+			c_lo_prodcheck: self.c_lo_prodcheck.clone(),
+			c_lo_root: self.c_lo_root.clone(),
+			c_hi_exponents: self.c_hi_exponents,
+			c_hi_prodcheck: self.c_hi_prodcheck.clone(),
+			c_hi_root: self.c_hi_root.clone(),
+			tables: self.tables.clone(),
+		}
+	}
 }
 
 impl<'a, 'alloc, A, F, P> Witness<'a, 'alloc, A, P>
@@ -144,20 +167,15 @@ where
 		// layer is the corresponding tree root.
 		let fixed_base_tree_scope =
 			tracing::debug_span!("Compute fixed-base prodcheck layers").entered();
-		let a_leaves = limb_leaves(&tables[..N_LIMBS], a);
-		let (a_prodcheck, a_root) =
-			ProdcheckProver::new(LOG_N_LIMBS, alloc, pooled_copy(alloc, &a_leaves));
+		let a_leaves = limb_leaves::<A, F, P>(alloc, &tables[..N_LIMBS], a);
+		let (a_prodcheck, a_root) = ProdcheckProver::new(LOG_N_LIMBS, alloc, a_leaves);
 		let a_root = unpool::<A, P>(a_root);
 
-		let c_lo_leaves = limb_leaves(&tables[..N_LIMBS], c_lo);
-		let (c_lo_prodcheck, c_lo_root) =
-			ProdcheckProver::new(LOG_N_LIMBS, alloc, pooled_copy(alloc, &c_lo_leaves));
-		let c_lo_root = unpool::<A, P>(c_lo_root);
+		let c_lo_leaves = limb_leaves::<A, F, P>(alloc, &tables[..N_LIMBS], c_lo);
+		let (c_lo_prodcheck, c_lo_root) = ProdcheckProver::new(LOG_N_LIMBS, alloc, c_lo_leaves);
 
-		let c_hi_leaves = limb_leaves(&tables[N_LIMBS..], c_hi);
-		let (c_hi_prodcheck, c_hi_root) =
-			ProdcheckProver::new(LOG_N_LIMBS, alloc, pooled_copy(alloc, &c_hi_leaves));
-		let c_hi_root = unpool::<A, P>(c_hi_root);
+		let c_hi_leaves = limb_leaves::<A, F, P>(alloc, &tables[N_LIMBS..], c_hi);
+		let (c_hi_prodcheck, c_hi_root) = ProdcheckProver::new(LOG_N_LIMBS, alloc, c_hi_leaves);
 		drop(fixed_base_tree_scope);
 
 		// Compute b_leaves as concatenated leaves for prodcheck; the variable base is the `a` root.
@@ -193,7 +211,7 @@ where
 /// The root fields are consumed by the phase provers as ordinary `FieldBuffer`s; the pooled block
 /// cannot be handed out as a `Vec` directly (its allocation is over-aligned for the free list), so
 /// it is copied out and the pooled block recycled.
-fn unpool<A: Allocator, P: PackedField>(src: PooledColumn<A, P>) -> FieldBuffer<P> {
+fn unpool<A: Allocator, P: PackedField>(src: FieldVec<P, A>) -> FieldBuffer<P> {
 	FieldBuffer::new(src.log_len(), src.as_ref().to_vec())
 }
 
@@ -295,8 +313,9 @@ pub(super) const fn limb_index(word: Word, limb: usize) -> usize {
 /// corresponding word. The columns are concatenated into one `(n_vars + LOG_N_LIMBS)`-variate
 /// buffer with the limb index in the high bits, so the prodcheck's node reductions pair column `z`
 /// with column `z + N_LIMBS/2`.
-fn limb_leaves<F, P>(tables: &[FieldBuffer<P>], exponents: &[Word]) -> FieldBuffer<P>
+fn limb_leaves<A, F, P>(alloc: &A, tables: &[FieldBuffer<P>], exponents: &[Word]) -> FieldVec<P, A>
 where
+	A: Allocator,
 	F: Field,
 	P: PackedField<Scalar = F>,
 {
@@ -313,7 +332,7 @@ where
 		.collect::<Vec<_>>();
 
 	debug_assert_eq!(scalars.len(), 1 << (n_vars + LOG_N_LIMBS));
-	FieldBuffer::<P>::from_values(&scalars)
+	FieldBuffer::<P>::from_values_in(alloc, &scalars)
 }
 
 /// Compute concatenated b_leaves for prodcheck.
@@ -413,34 +432,36 @@ pub fn buffer_bivariate_product<P: PackedField, Data: Deref<Target = [P]>>(
 
 /// Constructs a field buffer with values selected from `elements` based on the bit values
 /// of `exponents`.
-pub fn two_valued_field_buffer<F, P>(
+pub fn two_valued_field_buffer<A, F, P>(
+	alloc: &A,
 	bit_offset: usize,
 	exponents: &[Word],
 	elements: [F; 2],
-) -> FieldBuffer<P>
+) -> FieldVec<P, A>
 where
+	A: Allocator,
 	F: Field,
 	P: PackedField<Scalar = F>,
 {
 	let n_vars = checked_log_2(exponents.len());
 	let p_width = P::WIDTH.min(1 << n_vars);
-	let values = (0..1 << n_vars.saturating_sub(P::LOG_WIDTH))
-		.map(|i| {
-			let scalars = (0..p_width).map(|j| {
-				let index = i << P::LOG_WIDTH | j;
-				// Select `elements[1]` if bit `bit_offset` of `exponents[index]` is set, else
-				// `elements[0]`.
-				unsafe {
-					// Safety:
-					// - `index` is guaranteed to be in-bounds
-					// - `elements` has two values
-					let is_set = exponents.get_unchecked(index).extract_bit(bit_offset);
-					*elements.get_unchecked(is_set as usize)
-				}
-			});
-			P::from_scalars(scalars)
-		})
-		.collect::<Vec<_>>();
+	let packed_len = 1 << n_vars.saturating_sub(P::LOG_WIDTH);
+	let mut values = alloc.alloc::<P>(packed_len);
+	values.extend((0..packed_len).map(|i| {
+		let scalars = (0..p_width).map(|j| {
+			let index = i << P::LOG_WIDTH | j;
+			// Select `elements[1]` if bit `bit_offset` of `exponents[index]` is set, else
+			// `elements[0]`.
+			unsafe {
+				// Safety:
+				// - `index` is guaranteed to be in-bounds
+				// - `elements` has two values
+				let is_set = exponents.get_unchecked(index).extract_bit(bit_offset);
+				*elements.get_unchecked(is_set as usize)
+			}
+		});
+		P::from_scalars(scalars)
+	}));
 
 	FieldBuffer::new(n_vars, values)
 }

--- a/crates/prover/src/protocols/shift/monster.rs
+++ b/crates/prover/src/protocols/shift/monster.rs
@@ -3,10 +3,12 @@
 
 use std::iter;
 
+use binius_compute::{Allocator, VecLike};
 use binius_core::word::Word;
 use binius_field::{BinaryField, Field, PackedField, WideMul};
 use binius_math::{
-	BinarySubspace, FieldBuffer, multilinear::eq::eq_ind_partial_eval, univariate::lagrange_evals,
+	BinarySubspace, FieldBuffer, FieldVec, multilinear::eq::eq_ind_partial_eval,
+	univariate::lagrange_evals,
 };
 use binius_utils::{checked_arithmetics::checked_log_2, rayon::prelude::*};
 use binius_verifier::protocols::shift::{BINMUL_ARITY, BITAND_ARITY, INTMUL_ARITY, evaluate_h_op};
@@ -29,59 +31,61 @@ use super::{
 ///
 /// Used in phase 1, thus returning an array of multilinear evaluations.
 #[instrument(skip_all, name = "build_h_parts")]
-pub fn build_h_parts<F, P: PackedField<Scalar = F>>(
+pub fn build_h_parts<F, P: PackedField<Scalar = F>, A: Allocator>(
+	alloc: &A,
 	domain_subspace: &BinarySubspace<F>,
 	r_zhat_prime: F,
-) -> [FieldBuffer<P>; SHIFT_VARIANT_COUNT]
+) -> [FieldVec<P, A>; SHIFT_VARIANT_COUNT]
 where
 	F: BinaryField,
 {
 	let l_tilde = lagrange_evals(domain_subspace, r_zhat_prime);
 	let l_tilde = l_tilde.as_ref();
 
-	fn build_part<F: Field, P: PackedField<Scalar = F>>(
+	fn build_part<F: Field, P: PackedField<Scalar = F>, A: Allocator>(
+		alloc: &A,
 		fill: impl Fn(usize, &mut [F; Word::BITS]),
-	) -> FieldBuffer<P> {
+	) -> FieldVec<P, A> {
 		let mut data = zeroed_vec::<[F; Word::BITS]>(Word::BITS);
 		for (s, chunk) in data.iter_mut().enumerate() {
 			fill(s, chunk);
 		}
-		FieldBuffer::from_values(&data.into_flattened())
+		FieldBuffer::from_values_in(alloc, &data.into_flattened())
 	}
 
-	let sll = build_part(|s, sll_s| {
+	let sll = build_part(alloc, |s, sll_s| {
 		sll_s[..Word::BITS - s].copy_from_slice(&l_tilde[s..]);
 	});
 
-	let srl = build_part(|s, srl_s| {
+	let srl = build_part(alloc, |s, srl_s| {
 		srl_s[s..].copy_from_slice(&l_tilde[..Word::BITS - s]);
 	});
 
-	let sra = build_part(|s, sra_s| {
+	let sra = build_part(alloc, |s, sra_s| {
 		sra_s[s..].copy_from_slice(&l_tilde[..Word::BITS - s]);
 		sra_s[Word::BITS - 1] += l_tilde[Word::BITS - s..].iter().sum::<F>();
 	});
 
-	let rotr = build_part(|s, rotr_s| {
+	let rotr = build_part(alloc, |s, rotr_s| {
 		rotr_s[..s].copy_from_slice(&l_tilde[Word::BITS - s..]);
 		rotr_s[s..].copy_from_slice(&l_tilde[..Word::BITS - s]);
 	});
 
-	let sll32 = build_part(|s, sll32_s| {
+	let sll32 = build_part(alloc, |s, sll32_s| {
 		let s = s % 32;
 		for (l_tilde_i, sll_s_i) in iter::zip(l_tilde.chunks(32), sll32_s.chunks_mut(32)) {
 			sll_s_i[..32 - s].copy_from_slice(&l_tilde_i[s..]);
 		}
 	});
 
-	let srl32 = build_part(|s, srl32_s| {
+	let srl32 = build_part(alloc, |s, srl32_s| {
 		let s = s % 32;
 		for (l_tilde_i, srl32_s_i) in iter::zip(l_tilde.chunks(32), srl32_s.chunks_mut(32)) {
 			srl32_s_i[s..].copy_from_slice(&l_tilde_i[..32 - s]);
 		}
 	});
 
-	let sra32 = build_part(|s, sra32_s| {
+	let sra32 = build_part(alloc, |s, sra32_s| {
 		let s = s % 32;
 		for (l_tilde_i, sra32_s_i) in iter::zip(l_tilde.chunks(32), sra32_s.chunks_mut(32)) {
 			sra32_s_i[s..].copy_from_slice(&l_tilde_i[..32 - s]);
@@ -89,7 +93,7 @@ where
 		}
 	});
 
-	let rotr32 = build_part(|s, rotr32_s| {
+	let rotr32 = build_part(alloc, |s, rotr32_s| {
 		let s = s % 32;
 		for (l_tilde_i, rotr32_s_i) in iter::zip(l_tilde.chunks(32), rotr32_s.chunks_mut(32)) {
 			rotr32_s_i[..s].copy_from_slice(&l_tilde_i[32 - s..]);
@@ -134,7 +138,9 @@ where
 /// hidden piece over `log_witness_words` variables (the hidden words at the base, zeros above).
 /// The sparse first sumcheck round consumes them without materializing the combined buffer.
 #[instrument(skip_all, name = "build_monster_segments")]
-pub fn build_monster_segments<F, P: PackedField<Scalar = F>>(
+#[allow(clippy::too_many_arguments)]
+pub fn build_monster_segments<F, P: PackedField<Scalar = F>, A: Allocator>(
+	alloc: &A,
 	key_collection: &KeyCollection,
 	bitand_operator_data: &PreparedOperatorData<F>,
 	intmul_operator_data: &PreparedOperatorData<F>,
@@ -142,7 +148,7 @@ pub fn build_monster_segments<F, P: PackedField<Scalar = F>>(
 	domain_subspace: &BinarySubspace<F>,
 	r_j: &[F],
 	r_s: &[F],
-) -> (FieldBuffer<P>, FieldBuffer<P>)
+) -> (FieldVec<P, A>, FieldVec<P, A>)
 where
 	F: BinaryField,
 {
@@ -229,14 +235,19 @@ where
 		// Full packed elements: each maps exactly `P::WIDTH` words, so `from_scalars` sees a
 		// statically-sized iterator. The trailing partial element is filled separately below.
 		let n_full = n_words / P::WIDTH;
-		let mut values = Vec::<P>::with_capacity(capacity);
-		(0..n_full)
-			.into_par_iter()
-			.map(|chunk_index| {
+		// Allocate the backing buffer up front from the allocator, then fill the `n_full` aligned
+		// packed elements in parallel through its spare capacity — the single allocation happens
+		// before the parallel region, which only writes.
+		let mut values = alloc.alloc::<P>(capacity);
+		values.spare_capacity_mut()[..n_full]
+			.par_iter_mut()
+			.enumerate()
+			.for_each(|(chunk_index, slot)| {
 				let start = chunk_index * P::WIDTH;
-				P::from_scalars((0..P::WIDTH).map(|i| word_scalar(segment, start + i)))
-			})
-			.collect_into_vec(&mut values);
+				slot.write(P::from_scalars((0..P::WIDTH).map(|i| word_scalar(segment, start + i))));
+			});
+		// Safety: the parallel loop above initialized every one of the `n_full` slots.
+		unsafe { values.set_len(n_full) };
 		if !n_words.is_multiple_of(P::WIDTH) {
 			let start = n_full * P::WIDTH;
 			values.push(P::from_scalars(
@@ -256,6 +267,7 @@ where
 
 #[cfg(test)]
 mod tests {
+	use binius_compute::GlobalAllocator;
 	use binius_field::{AESTowerField8b, BinaryField128bGhash, PackedBinaryGhash2x128b, Random};
 	use binius_math::{inner_product::inner_product_buffers, multilinear::eq::eq_ind_partial_eval};
 	use binius_verifier::protocols::shift::evaluate_h_op;
@@ -286,7 +298,7 @@ mod tests {
 			let succinct_evaluations = evaluate_h_op(l_tilde.as_ref(), &r_j, &r_s);
 
 			// Method 2: Direct evaluation via multilinear part
-			let h_parts = build_h_parts(&subspace, r_zhat_prime);
+			let h_parts = build_h_parts(&GlobalAllocator, &subspace, r_zhat_prime);
 			let evaluation_point: Vec<F> = [r_j.clone(), r_s.clone()].concat();
 			let tensor = eq_ind_partial_eval::<P>(&evaluation_point);
 			let direct_evaluations = h_parts.map(|buf| inner_product_buffers(&buf, &tensor));

--- a/crates/prover/src/protocols/shift/phase_1.rs
+++ b/crates/prover/src/protocols/shift/phase_1.rs
@@ -3,15 +3,15 @@
 
 use std::{iter, ops::Range};
 
-use binius_compute::Allocator;
+use binius_compute::{Allocator, VecLike};
 use binius_core::word::Word;
 use binius_field::{BinaryField, Field, PackedField};
 use binius_ip::sumcheck::{SumcheckOutput, common::RoundCoeffs};
 use binius_ip_prover::{
 	channel::IPProverChannel,
-	sumcheck::{bivariate_product_prover, common::SumcheckProver, mle_store::pooled_copy},
+	sumcheck::{bivariate_product_prover, common::SumcheckProver},
 };
-use binius_math::{BinarySubspace, FieldBuffer, inner_product::inner_product_buffers};
+use binius_math::{BinarySubspace, FieldBuffer, FieldVec, inner_product::inner_product_buffers};
 use binius_utils::rayon::prelude::*;
 use binius_verifier::protocols::shift::SHIFT_VARIANT_COUNT;
 use bytemuck::zeroed_vec;
@@ -51,14 +51,16 @@ where
 	// Build the g parts for the public and hidden segments separately, then sum them. The public
 	// words are the prefix of `words`, and each segment's key ranges are segment-relative.
 	let (public_words, hidden_words) = words.split_at(key_collection.public.n_words());
-	let mut g_parts = build_g_parts::<_, P>(
+	let mut g_parts = build_g_parts::<_, P, _>(
+		alloc,
 		public_words,
 		&key_collection.public,
 		bitand_data,
 		intmul_data,
 		binmul_data,
 	);
-	let hidden_g_parts = build_g_parts::<_, P>(
+	let hidden_g_parts = build_g_parts::<_, P, _>(
+		alloc,
 		hidden_words,
 		&key_collection.hidden,
 		bitand_data,
@@ -72,7 +74,7 @@ where
 	}
 
 	// BitAnd, IntMul and BinMul share the same `r_zhat_prime`.
-	let h_parts = build_h_parts(domain_subspace, bitand_data.r_zhat_prime);
+	let h_parts = build_h_parts(alloc, domain_subspace, bitand_data.r_zhat_prime);
 
 	run_phase_1_sumcheck(g_parts, h_parts, channel, alloc)
 }
@@ -109,8 +111,8 @@ pub fn run_phase_1_sumcheck<
 	Channel: IPProverChannel<F>,
 	A: Allocator,
 >(
-	g_parts: [FieldBuffer<P>; SHIFT_VARIANT_COUNT],
-	h_parts: [FieldBuffer<P>; SHIFT_VARIANT_COUNT],
+	g_parts: [FieldVec<P, A>; SHIFT_VARIANT_COUNT],
+	h_parts: [FieldVec<P, A>; SHIFT_VARIANT_COUNT],
 	channel: &mut Channel,
 	alloc: &A,
 ) -> SumcheckOutput<F> {
@@ -118,11 +120,7 @@ pub fn run_phase_1_sumcheck<
 	let mut provers = iter::zip(g_parts, h_parts)
 		.map(|(g_part, h_part)| {
 			let sum = inner_product_buffers(&g_part, &h_part);
-			bivariate_product_prover(
-				alloc,
-				[pooled_copy(alloc, &g_part), pooled_copy(alloc, &h_part)],
-				sum,
-			)
+			bivariate_product_prover(alloc, [g_part, h_part], sum)
 		})
 		.collect::<Vec<_>>();
 
@@ -202,13 +200,14 @@ pub fn run_phase_1_sumcheck<
 /// Used in phase 1 to construct the constant size g multilinears
 /// that will participate in the phase 1 sumcheck protocol.
 #[instrument(skip_all, name = "build_g_parts")]
-pub fn build_g_parts<F: BinaryField, P: PackedField<Scalar = F>>(
+pub fn build_g_parts<F: BinaryField, P: PackedField<Scalar = F>, A: Allocator>(
+	alloc: &A,
 	words: &[Word],
 	segment: &KeySegment,
 	bitand_operator_data: &PreparedOperatorData<F>,
 	intmul_operator_data: &PreparedOperatorData<F>,
 	binmul_operator_data: &PreparedOperatorData<F>,
-) -> [FieldBuffer<P>; SHIFT_VARIANT_COUNT] {
+) -> [FieldVec<P, A>; SHIFT_VARIANT_COUNT] {
 	let acc_size: usize = SHIFT_VARIANT_COUNT << (LOG_LEN.saturating_sub(P::LOG_WIDTH));
 
 	assert!(
@@ -299,7 +298,7 @@ pub fn build_g_parts<F: BinaryField, P: PackedField<Scalar = F>>(
 			},
 		);
 
-	build_multilinear_parts(&multilinears)
+	build_multilinear_parts(alloc, &multilinears)
 }
 
 /// Builds the multilinear parts for a single operation by combining its operand multilinears.
@@ -308,9 +307,10 @@ pub fn build_g_parts<F: BinaryField, P: PackedField<Scalar = F>>(
 /// applies lambda weighting to each operand, and combines them into parts.
 /// Each operand of index `i` gets weighted by λ^(i+1).
 #[instrument(skip_all, name = "build_multilinear_parts")]
-fn build_multilinear_parts<P: PackedField>(
+fn build_multilinear_parts<P: PackedField, A: Allocator>(
+	alloc: &A,
 	multilinears: &[P],
-) -> [FieldBuffer<P>; SHIFT_VARIANT_COUNT] {
+) -> [FieldVec<P, A>; SHIFT_VARIANT_COUNT] {
 	assert!(
 		P::LOG_WIDTH < LOG_LEN,
 		"P::WIDTH is not supposed to exceed 8, so this statement must hold"
@@ -318,8 +318,13 @@ fn build_multilinear_parts<P: PackedField>(
 
 	multilinears
 		.chunks(1 << (LOG_LEN - P::LOG_WIDTH))
-		.map(|chunk| FieldBuffer::new(LOG_LEN, chunk.to_vec()))
+		.map(|chunk| {
+			// Build each part straight into the allocator's buffer rather than into a `Vec` copy.
+			let mut data = alloc.alloc::<P>(chunk.len());
+			data.extend_from_slice(chunk);
+			FieldBuffer::new(LOG_LEN, data)
+		})
 		.collect::<Vec<_>>()
 		.try_into()
-		.expect("chunk has SHIFT_VARIANT_COUNT parts of size 1 << LOG_LEN")
+		.unwrap_or_else(|_| panic!("chunk has SHIFT_VARIANT_COUNT parts of size 1 << LOG_LEN"))
 }

--- a/crates/prover/src/protocols/shift/phase_1.rs
+++ b/crates/prover/src/protocols/shift/phase_1.rs
@@ -3,12 +3,13 @@
 
 use std::{iter, ops::Range};
 
+use binius_compute::Allocator;
 use binius_core::word::Word;
 use binius_field::{BinaryField, Field, PackedField};
 use binius_ip::sumcheck::{SumcheckOutput, common::RoundCoeffs};
 use binius_ip_prover::{
 	channel::IPProverChannel,
-	sumcheck::{bivariate_product_prover, common::SumcheckProver},
+	sumcheck::{bivariate_product_prover, common::SumcheckProver, mle_store::pooled_copy},
 };
 use binius_math::{BinarySubspace, FieldBuffer, inner_product::inner_product_buffers};
 use binius_utils::rayon::prelude::*;
@@ -30,7 +31,8 @@ const LOG_LEN: usize = Word::LOG_BITS + Word::LOG_BITS;
 /// Proves the first phase of the shift reduction.
 /// Computes the g and h multilinears and performs the sumcheck.
 #[instrument(skip_all, name = "prover_phase_1")]
-pub fn prove_phase_1<F, P, Channel>(
+#[allow(clippy::too_many_arguments)]
+pub fn prove_phase_1<F, P, Channel, A>(
 	key_collection: &KeyCollection,
 	words: &[Word],
 	bitand_data: &PreparedOperatorData<F>,
@@ -38,11 +40,13 @@ pub fn prove_phase_1<F, P, Channel>(
 	binmul_data: &PreparedOperatorData<F>,
 	domain_subspace: &BinarySubspace<F>,
 	channel: &mut Channel,
+	alloc: &A,
 ) -> SumcheckOutput<F>
 where
 	F: BinaryField,
 	P: PackedField<Scalar = F>,
 	Channel: IPProverChannel<F>,
+	A: Allocator,
 {
 	// Build the g parts for the public and hidden segments separately, then sum them. The public
 	// words are the prefix of `words`, and each segment's key ranges are segment-relative.
@@ -70,7 +74,7 @@ where
 	// BitAnd, IntMul and BinMul share the same `r_zhat_prime`.
 	let h_parts = build_h_parts(domain_subspace, bitand_data.r_zhat_prime);
 
-	run_phase_1_sumcheck(g_parts, h_parts, channel)
+	run_phase_1_sumcheck(g_parts, h_parts, channel, alloc)
 }
 
 /// Runs the phase 1 sumcheck protocol for shift constraint verification.
@@ -99,16 +103,26 @@ where
 ///
 /// `SumcheckOutput` containing the challenge vector and final evaluation `gamma`
 #[instrument(skip_all, name = "run_sumcheck")]
-pub fn run_phase_1_sumcheck<F: Field, P: PackedField<Scalar = F>, Channel: IPProverChannel<F>>(
+pub fn run_phase_1_sumcheck<
+	F: Field,
+	P: PackedField<Scalar = F>,
+	Channel: IPProverChannel<F>,
+	A: Allocator,
+>(
 	g_parts: [FieldBuffer<P>; SHIFT_VARIANT_COUNT],
 	h_parts: [FieldBuffer<P>; SHIFT_VARIANT_COUNT],
 	channel: &mut Channel,
+	alloc: &A,
 ) -> SumcheckOutput<F> {
 	// Build one shared bivariate-product prover per shift variant.
 	let mut provers = iter::zip(g_parts, h_parts)
 		.map(|(g_part, h_part)| {
 			let sum = inner_product_buffers(&g_part, &h_part);
-			bivariate_product_prover([g_part, h_part], sum)
+			bivariate_product_prover(
+				alloc,
+				[pooled_copy(alloc, &g_part), pooled_copy(alloc, &h_part)],
+				sum,
+			)
 		})
 		.collect::<Vec<_>>();
 

--- a/crates/prover/src/protocols/shift/phase_2.rs
+++ b/crates/prover/src/protocols/shift/phase_2.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-use std::iter;
+use std::{iter, ops::DerefMut};
 
 use binius_compute::Allocator;
 use binius_core::word::Word;
@@ -10,12 +10,11 @@ use binius_ip::sumcheck::{RoundCoeffs, SumcheckOutput};
 use binius_ip_prover::{
 	channel::IPProverChannel,
 	sumcheck::{
-		ProveSingleOutput, bivariate_product_prover, mle_store::pooled_copy, prove_single,
-		round_evals::RoundEvals2,
+		ProveSingleOutput, bivariate_product_prover, prove_single, round_evals::RoundEvals2,
 	},
 };
 use binius_math::{
-	BinarySubspace, FieldBuffer,
+	BinarySubspace, FieldBuffer, FieldVec,
 	multilinear::eq::{eq_ind_partial_eval, eq_ind_zero},
 };
 use binius_utils::{checked_arithmetics::log2_ceil_usize, rayon::prelude::*};
@@ -87,10 +86,11 @@ where
 	// zero-pads each fold to `log2_ceil(len)` variables, so the hidden fold already has
 	// `log_witness_words` variables (its word count is the hidden segment length).
 	let (public_words, hidden_words) = words.split_at(key_collection.public.n_words());
-	let public_folded = fold_words::<_, P>(public_words, r_j_tensor.as_ref());
-	let hidden_folded = fold_words::<_, P>(hidden_words, r_j_tensor.as_ref());
+	let public_folded = fold_words::<_, P, _>(alloc, public_words, r_j_tensor.as_ref());
+	let hidden_folded = fold_words::<_, P, _>(alloc, hidden_words, r_j_tensor.as_ref());
 
 	let (public_monster, hidden_monster) = build_monster_segments(
+		alloc,
 		key_collection,
 		bitand_data,
 		intmul_data,
@@ -126,11 +126,11 @@ where
 /// only. Both corrections run over whole packed elements: past the public length the `P`/`M_p`
 /// entries are zero, so the stray `H * M_h` lane terms cancel between the two sums. The per-point
 /// products accumulate in unreduced (wide) form and reduce once at the end.
-fn first_round_coeffs<F, P: PackedField<Scalar = F>>(
-	public_folded: &FieldBuffer<P>,
-	hidden_folded: &FieldBuffer<P>,
-	public_monster: &FieldBuffer<P>,
-	hidden_monster: &FieldBuffer<P>,
+fn first_round_coeffs<F, P: PackedField<Scalar = F>, Data: std::ops::Deref<Target = [P]>>(
+	public_folded: &FieldBuffer<P, Data>,
+	hidden_folded: &FieldBuffer<P, Data>,
+	public_monster: &FieldBuffer<P, Data>,
+	hidden_monster: &FieldBuffer<P, Data>,
 	gamma: F,
 ) -> RoundCoeffs<F>
 where
@@ -173,11 +173,11 @@ where
 /// Consumes and overwrites `hidden` for memory efficiency, returning
 /// `(1 - alpha) * public_padded + alpha * hidden` — exactly the result of
 /// `fold_highest_var_inplace` on the materialized witness buffer.
-fn fold_segments<F: Field, P: PackedField<Scalar = F>>(
-	public: &FieldBuffer<P>,
-	mut hidden: FieldBuffer<P>,
+fn fold_segments<F: Field, P: PackedField<Scalar = F>, Data: DerefMut<Target = [P]>>(
+	public: &FieldBuffer<P, Data>,
+	mut hidden: FieldBuffer<P, Data>,
 	alpha: F,
-) -> FieldBuffer<P> {
+) -> FieldBuffer<P, Data> {
 	// Scale the dominant hidden segment in place, in parallel.
 	let alpha_broadcast = P::broadcast(alpha);
 	hidden
@@ -215,10 +215,10 @@ fn fold_segments<F: Field, P: PackedField<Scalar = F>>(
 #[allow(clippy::too_many_arguments)]
 #[instrument(skip_all, name = "run_sumcheck")]
 pub fn run_sumcheck<F, P: PackedField<Scalar = F>, Channel: IPProverChannel<F>, A: Allocator>(
-	public_folded: FieldBuffer<P>,
-	hidden_folded: FieldBuffer<P>,
-	public_monster: FieldBuffer<P>,
-	hidden_monster: FieldBuffer<P>,
+	public_folded: FieldVec<P, A>,
+	hidden_folded: FieldVec<P, A>,
+	public_monster: FieldVec<P, A>,
+	hidden_monster: FieldVec<P, A>,
 	public_words: &[Word],
 	r_j: Vec<F>,
 	gamma: F,
@@ -244,14 +244,7 @@ where
 	// standard prover.
 	let folded_witness = fold_segments(&public_folded, hidden_folded, alpha);
 	let folded_monster = fold_segments(&public_monster, hidden_monster, alpha);
-	let prover = bivariate_product_prover(
-		alloc,
-		[
-			pooled_copy(alloc, &folded_witness),
-			pooled_copy(alloc, &folded_monster),
-		],
-		round_sum,
-	);
+	let prover = bivariate_product_prover(alloc, [folded_witness, folded_monster], round_sum);
 
 	let ProveSingleOutput {
 		multilinear_evals,

--- a/crates/prover/src/protocols/shift/phase_2.rs
+++ b/crates/prover/src/protocols/shift/phase_2.rs
@@ -3,13 +3,15 @@
 
 use std::iter;
 
+use binius_compute::Allocator;
 use binius_core::word::Word;
 use binius_field::{BinaryField, Field, PackedField, WideMul};
 use binius_ip::sumcheck::{RoundCoeffs, SumcheckOutput};
 use binius_ip_prover::{
 	channel::IPProverChannel,
 	sumcheck::{
-		ProveSingleOutput, bivariate_product_prover, prove_single, round_evals::RoundEvals2,
+		ProveSingleOutput, bivariate_product_prover, mle_store::pooled_copy, prove_single,
+		round_evals::RoundEvals2,
 	},
 };
 use binius_math::{
@@ -53,7 +55,7 @@ use crate::fold_word::fold_words;
 /// evaluation, or an error if the protocol fails.
 #[allow(clippy::too_many_arguments)]
 #[instrument(skip_all, name = "prove_phase_2")]
-pub fn prove_phase_2<F, P: PackedField<Scalar = F>, Channel>(
+pub fn prove_phase_2<F, P: PackedField<Scalar = F>, Channel, A>(
 	key_collection: &KeyCollection,
 	words: &[Word],
 	bitand_data: &PreparedOperatorData<F>,
@@ -62,10 +64,12 @@ pub fn prove_phase_2<F, P: PackedField<Scalar = F>, Channel>(
 	domain_subspace: &BinarySubspace<F>,
 	phase_1_output: SumcheckOutput<F>,
 	channel: &mut Channel,
+	alloc: &A,
 ) -> SumcheckOutput<F>
 where
 	F: BinaryField,
 	Channel: IPProverChannel<F>,
+	A: Allocator,
 {
 	let SumcheckOutput {
 		challenges: mut r_jr_s,
@@ -105,6 +109,7 @@ where
 		r_j,
 		gamma,
 		channel,
+		alloc,
 	)
 }
 
@@ -209,7 +214,7 @@ fn fold_segments<F: Field, P: PackedField<Scalar = F>>(
 /// evaluation.
 #[allow(clippy::too_many_arguments)]
 #[instrument(skip_all, name = "run_sumcheck")]
-pub fn run_sumcheck<F, P: PackedField<Scalar = F>, Channel: IPProverChannel<F>>(
+pub fn run_sumcheck<F, P: PackedField<Scalar = F>, Channel: IPProverChannel<F>, A: Allocator>(
 	public_folded: FieldBuffer<P>,
 	hidden_folded: FieldBuffer<P>,
 	public_monster: FieldBuffer<P>,
@@ -218,6 +223,7 @@ pub fn run_sumcheck<F, P: PackedField<Scalar = F>, Channel: IPProverChannel<F>>(
 	r_j: Vec<F>,
 	gamma: F,
 	channel: &mut Channel,
+	alloc: &A,
 ) -> SumcheckOutput<F>
 where
 	F: BinaryField,
@@ -238,7 +244,14 @@ where
 	// standard prover.
 	let folded_witness = fold_segments(&public_folded, hidden_folded, alpha);
 	let folded_monster = fold_segments(&public_monster, hidden_monster, alpha);
-	let prover = bivariate_product_prover([folded_witness, folded_monster], round_sum);
+	let prover = bivariate_product_prover(
+		alloc,
+		[
+			pooled_copy(alloc, &folded_witness),
+			pooled_copy(alloc, &folded_monster),
+		],
+		round_sum,
+	);
 
 	let ProveSingleOutput {
 		multilinear_evals,

--- a/crates/prover/src/protocols/shift/prove.rs
+++ b/crates/prover/src/protocols/shift/prove.rs
@@ -1,5 +1,6 @@
 // Copyright 2025 Irreducible Inc.
 
+use binius_compute::Allocator;
 use binius_core::word::Word;
 use binius_field::{BinaryField, Field, PackedField, util::powers};
 use binius_ip::sumcheck::SumcheckOutput;
@@ -93,7 +94,8 @@ impl<F: Field> PreparedOperatorData<F> {
 ///
 /// # Requirements
 /// - `words` must have power-of-2 length for efficient multilinear operations
-pub fn prove<F, P, Channel>(
+#[allow(clippy::too_many_arguments)]
+pub fn prove<F, P, Channel, A>(
 	key_collection: &KeyCollection,
 	words: &[Word],
 	bitand_data: OperatorData<F>,
@@ -101,11 +103,13 @@ pub fn prove<F, P, Channel>(
 	binmul_data: OperatorData<F>,
 	domain_subspace: &BinarySubspace<F>,
 	channel: &mut Channel,
+	alloc: &A,
 ) -> SumcheckOutput<F>
 where
 	F: BinaryField,
 	P: PackedField<Scalar = F>,
 	Channel: IPProverChannel<F>,
+	A: Allocator,
 {
 	// Sample lambdas, one for each operator.
 	let bitand_lambda = channel.sample();
@@ -122,7 +126,7 @@ where
 	// Prove the first phase, receiving a `SumcheckOutput`
 	// with challenges made of `r_j` and `r_s`,
 	// and eval equal to `gamma` (see paper).
-	let phase_1_output = prove_phase_1::<_, P, _>(
+	let phase_1_output = prove_phase_1::<_, P, _, _>(
 		key_collection,
 		words,
 		&prepared_bitand_data,
@@ -130,13 +134,14 @@ where
 		&prepared_binmul_data,
 		domain_subspace,
 		channel,
+		alloc,
 	);
 
 	// Prove the second phase, receiving a `SumcheckOutput`
 	// with challenges `r_y` and eval the evaluation of
 	// the witness at oblong point had by univariate
 	// variable `r_j` and multilinear variable `r_y`.
-	let SumcheckOutput { challenges, eval } = prove_phase_2::<_, P, _>(
+	let SumcheckOutput { challenges, eval } = prove_phase_2::<_, P, _, _>(
 		key_collection,
 		words,
 		&prepared_bitand_data,
@@ -145,6 +150,7 @@ where
 		domain_subspace,
 		phase_1_output,
 		channel,
+		alloc,
 	);
 
 	// Return evaluation claim on the witness.

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -138,7 +138,8 @@ impl IOPProver {
 			let mul_witness = tracing::debug_span!("Assemble columns")
 				.in_scope(|| build_intmul_witness(&cs.imul_constraints, &witness, alloc));
 
-			let intmul_output = prove_intmul_reduction::<_, _, P, _>(mul_witness, &mut *channel)?;
+			let intmul_output =
+				prove_intmul_reduction::<_, _, P, _>(mul_witness, &mut *channel, alloc)?;
 			drop(intmul_guard);
 			Some(intmul_output)
 		} else {
@@ -160,7 +161,8 @@ impl IOPProver {
 			let binmul_witness = tracing::debug_span!("Assemble columns")
 				.in_scope(|| build_binmul_witness(&cs.bmul_constraints, &witness, alloc));
 
-			let binmul_output = prove_binmul_reduction::<_, _, P, _>(binmul_witness, &mut *channel);
+			let binmul_output =
+				prove_binmul_reduction::<_, _, P, _>(binmul_witness, &mut *channel, alloc);
 			drop(binmul_guard);
 			Some(binmul_output)
 		} else {
@@ -181,7 +183,7 @@ impl IOPProver {
 				c_eval,
 				z_challenge,
 				eval_point,
-			} = prove_bitand_reduction::<_, B128, P, _>(bitand_witness, &mut *channel);
+			} = prove_bitand_reduction::<_, B128, P, _>(bitand_witness, &mut *channel, alloc);
 			OperatorData {
 				evals: vec![a_eval, b_eval, c_eval],
 				r_zhat_prime: z_challenge,
@@ -277,7 +279,7 @@ impl IOPProver {
 		let SumcheckOutput {
 			challenges: eval_point,
 			eval: _,
-		} = prove_shift_reduction::<_, P, _>(
+		} = prove_shift_reduction::<_, P, _, _>(
 			&self.key_collection,
 			witness.combined_witness(),
 			bitand_claim,
@@ -285,6 +287,7 @@ impl IOPProver {
 			binmul_claim,
 			&subspace,
 			&mut *channel,
+			alloc,
 		);
 		drop(shift_guard);
 
@@ -414,7 +417,7 @@ where
 		let alloc = &pool;
 		self.iop_prover
 			.prove::<_, P, _>(witness, &mut channel, &alloc)?;
-		channel.finish();
+		channel.finish(&alloc);
 		Ok(())
 	}
 }
@@ -490,6 +493,7 @@ pub fn pack_witness<P: PackedField<Scalar = B128>>(
 fn prove_bitand_reduction<A, F, PChallenge, Channel>(
 	witness: AndCheckWitness<A>,
 	channel: &mut Channel,
+	alloc: &A,
 ) -> AndCheckOutput<F>
 where
 	A: Allocator,
@@ -514,12 +518,13 @@ where
 		prover_message_domain.isomorphic(),
 	);
 
-	prover.prove_with_channel(channel)
+	prover.prove_with_channel(channel, alloc)
 }
 
 fn prove_intmul_reduction<A, F, P, Channel>(
 	witness: MulCheckWitness<A>,
 	channel: &mut Channel,
+	alloc: &A,
 ) -> Result<IntMulOutput<F>, Error>
 where
 	A: Allocator,
@@ -529,10 +534,10 @@ where
 {
 	let MulCheckWitness { a, b, lo, hi } = witness;
 
-	let mut mulcheck_prover = IntMulProver::new(0, channel);
+	let mut mulcheck_prover = IntMulProver::new(0, channel, alloc);
 
 	let intmul_witness = tracing::debug_span!("Build IntMul witness")
-		.in_scope(|| IntMulWitness::<P>::new(&a, &b, &lo, &hi))?;
+		.in_scope(|| IntMulWitness::<_, P>::new(alloc, &a, &b, &lo, &hi))?;
 
 	Ok(mulcheck_prover.prove(intmul_witness))
 }
@@ -540,6 +545,7 @@ where
 fn prove_binmul_reduction<A, F, P, Channel>(
 	witness: BinMulCheckWitness<A>,
 	channel: &mut Channel,
+	alloc: &A,
 ) -> BinMulOutput<F>
 where
 	A: Allocator,
@@ -567,7 +573,7 @@ where
 		c_hi: &c_hi,
 	};
 
-	prove_binmul::<F, P, _>(&binmul_witness, channel)
+	prove_binmul::<_, F, P, _>(&binmul_witness, channel, alloc)
 }
 
 /// The two materialized BitAnd operand columns.

--- a/crates/prover/tests/shift.rs
+++ b/crates/prover/tests/shift.rs
@@ -191,7 +191,7 @@ pub fn evaluate_witness<F: BinaryField>(words: &[Word], r_j: &[F], r_y: &[F]) ->
 	let r_j_tensor = eq_ind_partial_eval::<F>(r_j);
 	let r_y_tensor = eq_ind_partial_eval::<F>(r_y);
 
-	let r_j_witness = fold_words::<_, F>(words, r_j_tensor.as_ref());
+	let r_j_witness = fold_words::<_, F, _>(&GlobalAllocator, words, r_j_tensor.as_ref());
 
 	inner_product_buffers(&r_j_witness, &r_y_tensor)
 }

--- a/crates/prover/tests/shift.rs
+++ b/crates/prover/tests/shift.rs
@@ -2,6 +2,7 @@
 // Copyright 2026 The Binius Developers
 
 use binius_circuits::{fixed_byte_vec::ByteVec, sha256::sha256_varlen};
+use binius_compute::GlobalAllocator;
 use binius_core::{
 	constraint_system::{AndConstraint, ConstraintSystem, ImulConstraint, ValueVec},
 	verify::verify_constraints,
@@ -290,7 +291,7 @@ fn test_shift_prove_and_verify() {
 			r_x_prime: Vec::new(),
 		};
 
-		let prover_output = prove::<F, P, _>(
+		let prover_output = prove::<F, P, _, _>(
 			&key_collection,
 			value_vec.combined_witness(),
 			prover_bitand_data.clone(),
@@ -298,6 +299,7 @@ fn test_shift_prove_and_verify() {
 			prover_binmul_data.clone(),
 			&subspace,
 			&mut prover_transcript,
+			&GlobalAllocator,
 		);
 
 		// Create verifier transcript and call the verifier

--- a/crates/spartan-prover/Cargo.toml
+++ b/crates/spartan-prover/Cargo.toml
@@ -8,6 +8,7 @@ authors.workspace = true
 workspace = true
 
 [dependencies]
+binius-compute = { path = "../compute" }
 binius-field = { path = "../field" }
 binius-hash = { path = "../hash" }
 binius-iop = { path = "../iop" }

--- a/crates/spartan-prover/src/lib.rs
+++ b/crates/spartan-prover/src/lib.rs
@@ -43,7 +43,7 @@ use binius_hash::binary_merkle_tree::HashSuite;
 use binius_iop_prover::{basefold::compiler::BaseFoldProverCompiler, channel::IOPProverChannel};
 use binius_ip_prover::{
 	channel::IPProverChannel,
-	sumcheck::{mle_store::pooled_copy, quadratic_mlecheck_prover, zk_mlecheck},
+	sumcheck::{quadratic_mlecheck_prover, zk_mlecheck},
 };
 use binius_math::{
 	FieldBuffer, FieldSlice,
@@ -426,8 +426,13 @@ where
 	Channel: IPProverChannel<F>,
 	A: Allocator,
 {
-	let mulcheck_witness =
-		wiring::build_mulcheck_witness(mul_constraints, public, precommit_packed, private_packed);
+	let mulcheck_witness = wiring::build_mulcheck_witness(
+		alloc,
+		mul_constraints,
+		public,
+		precommit_packed,
+		private_packed,
+	);
 
 	// Sample random evaluation point for mulcheck
 	let r_mulcheck = channel.sample_many(mask.n_vars());
@@ -435,11 +440,7 @@ where
 	// Prove the mul-gate zerocheck a * b - c = 0 over the shared store.
 	let mlecheck_prover = quadratic_mlecheck_prover(
 		alloc,
-		[
-			pooled_copy(alloc, &mulcheck_witness.a),
-			pooled_copy(alloc, &mulcheck_witness.b),
-			pooled_copy(alloc, &mulcheck_witness.c),
-		],
+		[mulcheck_witness.a, mulcheck_witness.b, mulcheck_witness.c],
 		|[a, b, c]| a * b - c, // composition
 		|[a, b, _c]| a * b,    // infinity_composition (quadratic term only)
 		r_mulcheck,

--- a/crates/spartan-prover/src/lib.rs
+++ b/crates/spartan-prover/src/lib.rs
@@ -37,12 +37,13 @@ use std::{
 	ops::Deref,
 };
 
+use binius_compute::{Allocator, BufferPool};
 use binius_field::{BinaryField, Field, PackedField};
 use binius_hash::binary_merkle_tree::HashSuite;
 use binius_iop_prover::{basefold::compiler::BaseFoldProverCompiler, channel::IOPProverChannel};
 use binius_ip_prover::{
 	channel::IPProverChannel,
-	sumcheck::{quadratic_mlecheck_prover, zk_mlecheck},
+	sumcheck::{mle_store::pooled_copy, quadratic_mlecheck_prover, zk_mlecheck},
 };
 use binius_math::{
 	FieldBuffer, FieldSlice,
@@ -173,18 +174,20 @@ impl<F: Field> IOPProver<F> {
 	/// * `channel` - The IOP prover channel (public input must be observed on transcript before
 	///   creating the channel; the precommit oracle must already have been committed on it via
 	///   [`Self::commit_precommit`])
-	pub fn prove<P, Channel>(
+	pub fn prove<P, Channel, A>(
 		&self,
 		witness: Witness<F>,
 		precommit_oracle: Channel::Oracle,
 		precommit_packed: FieldBuffer<P>,
 		mut rng: impl CryptoRng,
 		channel: &mut Channel,
+		alloc: &A,
 	) -> Result<(), Error>
 	where
 		F: BinaryField,
 		P: PackedField<Scalar = F>,
 		Channel: IOPProverChannel<P>,
+		A: Allocator,
 	{
 		let _prove_guard =
 			tracing::info_span!("Prove", operation = "prove", perfetto_category = "operation")
@@ -260,13 +263,14 @@ impl<F: Field> IOPProver<F> {
 		let mask_oracle = channel.send_oracle(masks_buffer.to_ref());
 
 		// Prove the multiplication constraints
-		let (mulcheck_evals, mask_eval, r_x) = prove_mulcheck::<F, P, _>(
+		let (mulcheck_evals, mask_eval, r_x) = prove_mulcheck::<F, P, _, _>(
 			cs.mul_constraints(),
 			witness.public(),
 			precommit_packed.to_ref(),
 			private_packed.to_ref(),
 			mulcheck_mask,
 			&mut *channel,
+			alloc,
 		);
 
 		// λ is the batching challenge for the constraint operands
@@ -386,35 +390,41 @@ where
 		let mut channel = self
 			.basefold_compiler
 			.create_channel_from_transcript::<H, Challenger_, _>(transcript, &mut rng);
+		// Working buffers for this proof are drawn from a single pool that lives for the call.
+		let pool = BufferPool::new();
+		let alloc = &pool;
 		let (precommit_oracle, precommit_packed) =
 			self.iop_prover
 				.commit_precommit::<P, _>(&witness, &mut rng, &mut channel);
 		// The IOP prover only queues the oracle relations; `finish` runs the single combined
 		// opening.
-		self.iop_prover.prove::<P, _>(
+		self.iop_prover.prove::<P, _, _>(
 			witness,
 			precommit_oracle,
 			precommit_packed,
 			rng,
 			&mut channel,
+			&alloc,
 		)?;
-		channel.finish();
+		channel.finish(&alloc);
 		Ok(())
 	}
 }
 
-fn prove_mulcheck<F, P, Channel>(
+fn prove_mulcheck<F, P, Channel, A>(
 	mul_constraints: &[MulConstraint<WitnessIndex>],
 	public: &[F],
 	precommit_packed: FieldSlice<P>,
 	private_packed: FieldSlice<P>,
 	mask: zk_mlecheck::Mask<P, impl Deref<Target = [P]>>,
 	channel: &mut Channel,
+	alloc: &A,
 ) -> ([F; 3], F, Vec<F>)
 where
 	F: BinaryField,
 	P: PackedField<Scalar = F>,
 	Channel: IPProverChannel<F>,
+	A: Allocator,
 {
 	let mulcheck_witness =
 		wiring::build_mulcheck_witness(mul_constraints, public, precommit_packed, private_packed);
@@ -424,7 +434,12 @@ where
 
 	// Prove the mul-gate zerocheck a * b - c = 0 over the shared store.
 	let mlecheck_prover = quadratic_mlecheck_prover(
-		[mulcheck_witness.a, mulcheck_witness.b, mulcheck_witness.c],
+		alloc,
+		[
+			pooled_copy(alloc, &mulcheck_witness.a),
+			pooled_copy(alloc, &mulcheck_witness.b),
+			pooled_copy(alloc, &mulcheck_witness.c),
+		],
 		|[a, b, c]| a * b - c, // composition
 		|[a, b, _c]| a * b,    // infinity_composition (quadratic term only)
 		r_mulcheck,

--- a/crates/spartan-prover/src/wiring.rs
+++ b/crates/spartan-prover/src/wiring.rs
@@ -1,8 +1,9 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
+use binius_compute::{Allocator, VecLike};
 use binius_field::{Field, PackedField};
-use binius_math::{FieldBuffer, FieldSlice};
+use binius_math::{FieldBuffer, FieldSlice, FieldVec};
 use binius_spartan_frontend::constraint_system::{
 	MulConstraint, Operand, WitnessIndex, WitnessSegment,
 };
@@ -137,10 +138,10 @@ pub fn fold_constraints<F: Field, P: PackedField<Scalar = F>>(
 ///
 /// Contains the evaluated operands a, b, and c for all multiplication constraints,
 /// packed into field buffers for efficient processing.
-pub struct MulCheckWitness<P: PackedField> {
-	pub a: FieldBuffer<P>,
-	pub b: FieldBuffer<P>,
-	pub c: FieldBuffer<P>,
+pub struct MulCheckWitness<A: Allocator, P: PackedField> {
+	pub a: FieldVec<P, A>,
+	pub b: FieldVec<P, A>,
+	pub c: FieldVec<P, A>,
 }
 
 /// Evaluates an operand by XORing witness values at the specified indices.
@@ -167,12 +168,13 @@ fn eval_operand<F: Field, P: PackedField<Scalar = F>>(
 /// This is analogous to `build_bitand_witness` in binius-prover but works with B128
 /// field elements instead of word-level operations.
 #[tracing::instrument(skip_all, level = "debug")]
-pub fn build_mulcheck_witness<F: Field, P: PackedField<Scalar = F>>(
+pub fn build_mulcheck_witness<A: Allocator, F: Field, P: PackedField<Scalar = F>>(
+	alloc: &A,
 	mul_constraints: &[MulConstraint<WitnessIndex>],
 	public: &[F],
 	precommit_packed: FieldSlice<P>,
 	private_packed: FieldSlice<P>,
-) -> MulCheckWitness<P> {
+) -> MulCheckWitness<A, P> {
 	const fn get_a(c: &MulConstraint<WitnessIndex>) -> &Operand<WitnessIndex> {
 		&c.a
 	}
@@ -189,9 +191,9 @@ pub fn build_mulcheck_witness<F: Field, P: PackedField<Scalar = F>>(
 	let log_n_constraints = checked_log_2(n_constraints);
 
 	let len = 1 << log_n_constraints.saturating_sub(P::LOG_WIDTH);
-	let mut a = Vec::<P>::with_capacity(len);
-	let mut b = Vec::<P>::with_capacity(len);
-	let mut c = Vec::<P>::with_capacity(len);
+	let mut a = alloc.alloc::<P>(len);
+	let mut b = alloc.alloc::<P>(len);
+	let mut c = alloc.alloc::<P>(len);
 
 	(a.spare_capacity_mut(), b.spare_capacity_mut(), c.spare_capacity_mut())
 		.into_par_iter()
@@ -237,6 +239,7 @@ pub fn build_mulcheck_witness<F: Field, P: PackedField<Scalar = F>>(
 
 #[cfg(test)]
 mod tests {
+	use binius_compute::GlobalAllocator;
 	use binius_field::{BinaryField128bGhash as B128, Field, Random};
 	use binius_math::{
 		multilinear::{eq::eq_ind_partial_eval, evaluate::evaluate},
@@ -436,6 +439,7 @@ mod tests {
 
 		// Compute mulcheck witness
 		let mulcheck_witness = build_mulcheck_witness(
+			&GlobalAllocator,
 			&constraints,
 			&public,
 			precommit_buf.to_ref(),

--- a/crates/spartan-prover/src/wrapper/zk_wrapped_prover_channel.rs
+++ b/crates/spartan-prover/src/wrapper/zk_wrapped_prover_channel.rs
@@ -13,6 +13,7 @@
 
 use std::{iter::repeat_with, sync::Arc};
 
+use binius_compute::BufferPool;
 use binius_field::{BinaryField, PackedField};
 use binius_iop::channel::OracleSpec;
 use binius_iop_prover::{
@@ -204,17 +205,22 @@ where
 				.expect("outer witness generation should not fail")
 		};
 
+		// Working buffers for this proof are drawn from a single pool that lives for the call.
+		let pool = BufferPool::new();
+		let alloc = &pool;
+
 		// Validate and generate the outer proof.
-		outer_prover.prove::<P, _>(
+		outer_prover.prove::<P, _, _>(
 			witness,
 			precommit_oracle,
 			precommit_packed,
 			rng,
 			&mut inner_channel,
+			&alloc,
 		)?;
 		// Both the inner and outer proofs queued their oracle relations onto `inner_channel`; run
 		// the single combined opening over all committed oracles now.
-		inner_channel.finish();
+		inner_channel.finish(&alloc);
 		Ok(())
 	}
 }

--- a/crates/spartan-prover/tests/wrapper_integration_test.rs
+++ b/crates/spartan-prover/tests/wrapper_integration_test.rs
@@ -2,6 +2,7 @@
 
 use std::sync::Arc;
 
+use binius_compute::GlobalAllocator;
 use binius_field::{BinaryField128bGhash as B128, Field, Random, arch::OptimalPackedB128};
 use binius_hash::StdHashSuite;
 use binius_iop::{
@@ -174,12 +175,13 @@ fn test_zk_wrapped_prove_verify() {
 			&mut wrapped_prover_channel,
 		);
 	inner_iop_prover
-		.prove::<OptimalPackedB128, _>(
+		.prove::<OptimalPackedB128, _, _>(
 			inner_witness,
 			inner_precommit_oracle,
 			inner_precommit_packed,
 			&mut rng,
 			&mut wrapped_prover_channel,
+			&GlobalAllocator,
 		)
 		.expect("inner prove failed");
 


### PR DESCRIPTION
## Summary

Reworks milestone-b onto #1879's `Allocator`/`VecLike` abstraction, per review: the prover's owned multilinears are drawn from a generic `A: Allocator` rather than a hardcoded `BufferPool`/`PoolVec`. Production proving uses `A = &BufferPool` (the recycling free list); tests default to the non-pooling `GlobalAllocator` (plain `Vec`); the criterion benches use `BufferPool`.

Linear: [BINIUS-316](https://linear.app/jimpo/issue/BINIUS-316)

## Foundation (binius-compute + binius-math)

- Move the `BufferData` backing-store trait into `binius-compute` (alongside `Allocator`/`VecLike`) and bound `Allocator::Vec<T>: VecLike<T> + BufferData<T>`. That bound is what lets an allocator's buffer `A::Vec<P>` back a `binius_math::FieldBuffer` — and be truncated/folded in place — **generically, with no `where A::Vec<P>: BufferData<P>` clause spread across signatures**. `binius-math` re-exports `BufferData`; `&mut [T]` keeps its own explicit impl (the sumcheck store folds slice-backed split halves).

  **Note on the blanket:** the suggested `impl<V: VecLike<T>> BufferData<T> for V` turns out to be infeasible — it collides with the *required* `impl BufferData for &mut [T]` (coherence can't rule out a downstream `VecLike for &mut [T]`, and specialization is unstable), and that `&mut [T]` backing is load-bearing: the sumcheck store folds and truncates slice-backed split halves. Bounding `Allocator::Vec: VecLike + BufferData` reaches the same "no `where`-clauses" goal without a blanket, and keeps the two `VecLike` backings (`Vec`, `PoolVec`) plus `&mut [T]` as explicit impls.

## Prover

- The owned multilinears become `FieldBuffer<P, A::Vec<P>>`. The `A` parameter threads through `MleStore` (the hub), the shared sumcheck/mlecheck provers, the round evaluators, `ProdcheckProver`/`FracAddCheckProver`, the IntMul witness, the shift / bitand / binmul reductions, the logUp* reduction, and the BaseFold channel opening — bottoming out at `IOPProver::prove`, which already threads `&A` from #1879. Spartan and m4 thread it the same way.
- Buffers built by `binius-math` (`from_values`, the limb/leaf builders) are brought into the allocator by copying into a fresh block via `mle_store::pooled_copy` — a genuine, recyclable allocation under a pool.
- Functions taking `A: Allocator` default to `GlobalAllocator`/`Vec` in tests; the criterion benches use `BufferPool`.

## Testing

Green across build (all targets), tests (compute/math/ip-prover/iop-prover/prover/m4/spartan), `clippy --all-targets -D warnings`, nightly fmt, and rustdoc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)