### PR TITLE
Remove test-only rs_eq_ind helper from ring_switch prover

### DIFF
--- a/crates/prover/src/ring_switch.rs
+++ b/crates/prover/src/ring_switch.rs
@@ -23,36 +23,6 @@ use binius_utils::{
 use binius_verifier::config::{B1, B128};
 use itertools::izip;
 
-/// Compute the multilinear extension of the ring switching equality indicator.
-///
-/// The ring switching equality indicator is the multilinear function $A$ from [DP24],
-/// Construction 3.1. Its multilinear extension is computed by basis decomposing the
-/// field extension elements of the tensor expanded z_vals point, then recombining
-/// the sub field basis elements with the large field tensor expanded row batching
-/// scalars.
-///
-/// ## Arguments
-///
-/// * `batching_challenges` - the scaling elements for row-batching
-/// * `z_vals` - the vertical evaluation point, with $\ell'$ components
-///
-/// ## Pre-conditions
-///
-/// * the length of batching challenges must equal `FE::LOG_DEGREE`
-///
-/// [DP24]: <https://eprint.iacr.org/2024/504>
-pub fn rs_eq_ind<F>(batching_challenges: &[F], z_vals: &[F]) -> FieldBuffer<F>
-where
-	F: BinaryField,
-	F::Underlier: Divisible<u8>,
-{
-	assert_eq!(batching_challenges.len(), F::LOG_DEGREE);
-
-	let z_vals_eq_ind = eq_ind_partial_eval::<F>(z_vals);
-	let row_batching_query = eq_ind_partial_eval::<F>(batching_challenges);
-	fold_elems_inplace(z_vals_eq_ind, &row_batching_query)
-}
-
 /// Transforms a [`FieldBuffer`] by mapping every scalar to the inner product of its B1 components
 /// and a given vector of field elements.
 ///
@@ -408,7 +378,10 @@ mod test {
 
 		let row_batching_expanded_query = eq_ind_partial_eval(&row_batching_challenges);
 
-		let rs_eq = rs_eq_ind::<F>(&row_batching_challenges, &z_vals);
+		// Build the indicator the way the prover does: fold the tensor-expanded z_vals point by
+		// the tensor-expanded row-batching query.
+		let rs_eq =
+			fold_elems_inplace(eq_ind_partial_eval::<F>(&z_vals), &row_batching_expanded_query);
 
 		// test all points points in the boolean hypercube
 		for hypercube_point in 0..1 << 3 {
@@ -437,7 +410,8 @@ mod test {
 		let row_batching_expanded_query: FieldBuffer<F> =
 			eq_ind_partial_eval(&row_batching_challenges);
 
-		let rs_eq = rs_eq_ind::<F>(&row_batching_challenges, &z_vals);
+		let rs_eq =
+			fold_elems_inplace(eq_ind_partial_eval::<F>(&z_vals), &row_batching_expanded_query);
 
 		// out of range eval point
 		let eval_point: Vec<F> = random_scalars(&mut rng, n_vars_big_field);


### PR DESCRIPTION
Removes a public helper that no shipping code used. Pure cleanup — no behavior change.

### The problem

`ring_switch::rs_eq_ind` built the ring-switching equality indicator MLE, but nothing on the proving path called it.
`prove` already computes the same MLE inline via `fold_b128_elems_inplace`.
Its only callers were the two unit tests written to test it — so it was a circular, test-only `pub` API: a function whose sole reason to exist was being tested.

### The idea

Delete `rs_eq_ind`, and move its two-line body into the two tests that used it.
Those tests validate something real — that the prover-side indicator matches the verifier's `eval_rs_eq` — and that coverage is kept intact.
The construction is trivial to inline, and both tests already had the row-batching query expanded in scope:

```
- let rs_eq = rs_eq_ind::<F>(&row_batching_challenges, &z_vals);
+ let rs_eq = fold_elems_inplace(eq_ind_partial_eval::<F>(&z_vals), &row_batching_expanded_query);
```

### How this relates / what it is not

This is *not* a claim that every reference-style function should go.
`fold_elems_inplace` looks superficially similar — after this change only tests and benches call it — but it is deliberately kept.
It is the scalar reference that pins the production function `fold_b128_elems_inplace` correct (via `test_fold_b128_elems_consistency`) and it is benchmarked.
A reference implementation guarding a *different, shipping* function is a testing asset, not a test-only method.

### Scope

- **removed:** `pub fn rs_eq_ind` (crates/prover/src/ring_switch.rs)
- **changed:** two tests now build the indicator inline
- **left untouched:** `fold_elems_inplace`, `fold_b128_elems_inplace`, `fold_1b_rows_for_b128`, `prove` — all still used by production, benches, or as tested references

### Verification

- `cargo +nightly fmt --all`, `cargo check --workspace --all-targets`, `cargo clippy -p binius-prover --all-targets` — clean
- `cargo test -p binius-prover ring_switch` — 4 passed (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)