### PR TITLE
BINIUS-113: remove unused code from binius-field (group A)

### DIFF
--- a/crates/field/src/arch/portable/packed.rs
+++ b/crates/field/src/arch/portable/packed.rs
@@ -30,7 +30,7 @@ use crate::{
 	BinaryField, Divisible, ExtensionField, Field, Maskable, PackedField, WideMul,
 	arithmetic_traits::{InvertOrZero, Square},
 	field::FieldOps,
-	underlier::{NumCast, UnderlierType, WithUnderlier},
+	underlier::{UnderlierType, WithUnderlier},
 };
 
 #[derive(PartialEq, Eq, Clone, Copy, Default, bytemuck::TransparentWrapper)]
@@ -591,56 +591,4 @@ impl<U: UnderlierType, Scalar: BinaryField> Distribution<PackedPrimitiveType<U, 
 	fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> PackedPrimitiveType<U, Scalar> {
 		PackedPrimitiveType::from_underlier(U::random(rng))
 	}
-}
-
-/// Multiply `PT1` values by upcasting to wider `PT2` type with the same scalar.
-/// This is useful for the cases when SIMD multiplication is faster.
-#[allow(dead_code)]
-pub fn mul_as_bigger_type<PT1, PT2>(lhs: PT1, rhs: PT1) -> PT1
-where
-	PT1: PackedField + WithUnderlier,
-	PT2: PackedField<Scalar = PT1::Scalar> + WithUnderlier,
-	PT2::Underlier: From<PT1::Underlier>,
-	PT1::Underlier: NumCast<PT2::Underlier>,
-{
-	let bigger_lhs = PT2::from_underlier(lhs.to_underlier().into());
-	let bigger_rhs = PT2::from_underlier(rhs.to_underlier().into());
-
-	let bigger_result = bigger_lhs * bigger_rhs;
-
-	PT1::from_underlier(PT1::Underlier::num_cast_from(bigger_result.to_underlier()))
-}
-
-/// Square `PT1` values by upcasting to wider `PT2` type with the same scalar.
-/// This is useful for the cases when SIMD square is faster.
-#[allow(dead_code)]
-pub fn square_as_bigger_type<PT1, PT2>(val: PT1) -> PT1
-where
-	PT1: PackedField + WithUnderlier,
-	PT2: PackedField<Scalar = PT1::Scalar> + WithUnderlier,
-	PT2::Underlier: From<PT1::Underlier>,
-	PT1::Underlier: NumCast<PT2::Underlier>,
-{
-	let bigger_val = PT2::from_underlier(val.to_underlier().into());
-
-	let bigger_result = bigger_val.square();
-
-	PT1::from_underlier(PT1::Underlier::num_cast_from(bigger_result.to_underlier()))
-}
-
-/// Invert `PT1` values by upcasting to wider `PT2` type with the same scalar.
-/// This is useful for the cases when SIMD invert is faster.
-#[allow(dead_code)]
-pub fn invert_as_bigger_type<PT1, PT2>(val: PT1) -> PT1
-where
-	PT1: PackedField + WithUnderlier,
-	PT2: PackedField<Scalar = PT1::Scalar> + WithUnderlier,
-	PT2::Underlier: From<PT1::Underlier>,
-	PT1::Underlier: NumCast<PT2::Underlier>,
-{
-	let bigger_val = PT2::from_underlier(val.to_underlier().into());
-
-	let bigger_result = bigger_val.invert_or_zero();
-
-	PT1::from_underlier(PT1::Underlier::num_cast_from(bigger_result.to_underlier()))
 }

--- a/crates/field/src/arch/portable/packed_macros.rs
+++ b/crates/field/src/arch/portable/packed_macros.rs
@@ -67,16 +67,6 @@ pub(crate) mod portable_macros {
 				}
 			}
 		};
-		// gfni_x86 condition: bigger types are re-exported at $crate root
-		($impl_macro:ident $name:ident, (if gfni_x86 $bigger:tt else $fallback:tt)) => {
-			cfg_if! {
-				if #[cfg(all(target_arch = "x86_64", target_feature = "sse2", target_feature = "gfni"))] {
-					$impl_macro!($name => $crate::$bigger);
-				} else {
-					$impl_macro!($name @ $crate::arch::$fallback);
-				}
-			}
-		};
 		// Path to strategy in caller's scope
 		($impl_macro:ident $name:ident, ($($strategy:tt)*)) => {
 			$impl_macro!($name @ $($strategy)*);

--- a/crates/field/src/arithmetic_traits.rs
+++ b/crates/field/src/arithmetic_traits.rs
@@ -3,10 +3,8 @@
 
 use std::{
 	iter::Sum,
-	ops::{Add, AddAssign, Mul, Sub, SubAssign},
+	ops::{Add, AddAssign, Sub, SubAssign},
 };
-
-use bytemuck::TransparentWrapper;
 
 /// Value that can be multiplied by itself
 pub trait Square {
@@ -39,34 +37,6 @@ pub trait WideMul: Sized {
 
 	fn wide_mul(a: Self, b: Self) -> Self::Output;
 	fn reduce(wide: Self::Output) -> Self;
-}
-
-#[derive(TransparentWrapper)]
-#[repr(transparent)]
-pub struct TrivialWideMul<T>(T);
-
-impl<T> WideMul for TrivialWideMul<T>
-where
-	T: Default
-		+ Clone
-		+ Sum
-		+ Add<Output = T>
-		+ AddAssign
-		+ Sub<Output = T>
-		+ SubAssign
-		+ Mul<Output = T>,
-{
-	type Output = T;
-
-	#[inline]
-	fn wide_mul(a: Self, b: Self) -> T {
-		Self::peel(a) * Self::peel(b)
-	}
-
-	#[inline]
-	fn reduce(wide: T) -> Self {
-		Self::wrap(wide)
-	}
 }
 
 macro_rules! impl_trivial_wide_mul {
@@ -127,16 +97,6 @@ macro_rules! impl_mul_with {
 			}
 		}
 	};
-	($name:ty => $bigger:ty) => {
-		impl std::ops::Mul for $name {
-			type Output = Self;
-
-			#[inline]
-			fn mul(self, rhs: Self) -> Self {
-				$crate::arch::portable::packed::mul_as_bigger_type::<_, $bigger>(self, rhs)
-			}
-		}
-	};
 }
 
 pub(crate) use impl_mul_with;
@@ -154,14 +114,6 @@ macro_rules! impl_square_with {
 			}
 		}
 	};
-	($name:ty => $bigger:ty) => {
-		impl $crate::arithmetic_traits::Square for $name {
-			#[inline]
-			fn square(self) -> Self {
-				$crate::arch::portable::packed::square_as_bigger_type::<_, $bigger>(self)
-			}
-		}
-	};
 }
 
 pub(crate) use impl_square_with;
@@ -176,14 +128,6 @@ macro_rules! impl_invert_with {
 						<$($strategy)* <$name> as ::bytemuck::TransparentWrapper<$name>>::wrap(self),
 					),
 				)
-			}
-		}
-	};
-	($name:ty => $bigger:ty) => {
-		impl $crate::arithmetic_traits::InvertOrZero for $name {
-			#[inline]
-			fn invert_or_zero(self) -> Self {
-				$crate::arch::portable::packed::invert_as_bigger_type::<_, $bigger>(self)
 			}
 		}
 	};

--- a/crates/field/src/ghash.rs
+++ b/crates/field/src/ghash.rs
@@ -54,7 +54,7 @@ impl From<BinaryField128bGhash> for u128 {
 // directly. It relies on every M128 GHASH packing using a deferring wrapper whose `Output` is a
 // concrete `WideGhashProduct` (not the packed type itself): `WideMul` is a supertrait of both
 // `Field` and `PackedField`, and `BinaryField128bGhash` is the `Scalar` of
-// `PackedBinaryGhash1x128b`, so a `TrivialWideMul` fallback (whose `Output` is the packed type,
+// `PackedBinaryGhash1x128b`, so a trivial fallback (whose `Output` is the packed type,
 // bounded `Add + Mul`) would close a trait-resolution cycle through `Field: WideMul`.
 impl WideMul for BinaryField128bGhash {
 	type Output = <GhashWideMul1x<PackedBinaryGhash1x128b> as WideMul>::Output;

--- a/crates/field/src/linear_transformation.rs
+++ b/crates/field/src/linear_transformation.rs
@@ -2,74 +2,11 @@
 
 use std::{marker::PhantomData, ops::BitXor};
 
-use rand::prelude::*;
-
-use crate::{
-	BinaryField, BinaryField1b, ExtensionField, UnderlierType, WithUnderlier,
-	packed::PackedBinaryField, underlier::Divisible, util::expand_subset_xors,
-};
+use crate::{UnderlierType, WithUnderlier, underlier::Divisible, util::expand_subset_xors};
 
 /// Generic transformation trait that is used both for scalars and packed fields
 pub trait Transformation<Input, Output>: Sync {
 	fn transform(&self, data: &Input) -> Output;
-}
-
-/// An $\mathbb{F}_2$-linear transformation on binary fields.
-///
-/// Stores transposed transformation matrix as a collection of field elements. `Data` is a generic
-/// parameter because we want to be able both to have const instances that reference static arrays
-/// and owning vector elements.
-#[derive(Debug, Clone)]
-pub struct FieldLinearTransformation<OF: BinaryField, Data: AsRef<[OF]> + Sync = &'static [OF]> {
-	bases: Data,
-	_pd: PhantomData<OF>,
-}
-
-impl<OF: BinaryField> FieldLinearTransformation<OF, &'static [OF]> {
-	pub const fn new_const(bases: &'static [OF]) -> Self {
-		assert!(bases.len() == OF::DEGREE);
-
-		Self {
-			bases,
-			_pd: PhantomData,
-		}
-	}
-}
-
-impl<OF: BinaryField, Data: AsRef<[OF]> + Sync> FieldLinearTransformation<OF, Data> {
-	pub fn new(bases: Data) -> Self {
-		debug_assert_eq!(bases.as_ref().len(), OF::DEGREE);
-
-		Self {
-			bases,
-			_pd: PhantomData,
-		}
-	}
-
-	pub fn bases(&self) -> &[OF] {
-		self.bases.as_ref()
-	}
-}
-
-impl<IF: BinaryField, OF: BinaryField, Data: AsRef<[OF]> + Sync> Transformation<IF, OF>
-	for FieldLinearTransformation<OF, Data>
-{
-	fn transform(&self, data: &IF) -> OF {
-		assert_eq!(IF::DEGREE, OF::DEGREE);
-
-		ExtensionField::<BinaryField1b>::iter_bases(data)
-			.zip(self.bases.as_ref().iter())
-			.fold(OF::ZERO, |acc, (scalar, &basis_elem)| acc + basis_elem * scalar)
-	}
-}
-
-impl<OF: BinaryField> FieldLinearTransformation<OF, Vec<OF>> {
-	pub fn random(mut rng: impl Rng) -> Self {
-		Self {
-			bases: (0..OF::DEGREE).map(|_| OF::random(&mut rng)).collect(),
-			_pd: PhantomData,
-		}
-	}
 }
 
 const LOG_BITS_PER_BYTE: usize = 3;
@@ -283,11 +220,3 @@ pub type WrappingTransformation<Inner, Input, Output> = OutputWrappingTransforma
 	Input,
 	Output,
 >;
-
-pub struct IDTransformation;
-
-impl<OP: PackedBinaryField> Transformation<OP, OP> for IDTransformation {
-	fn transform(&self, data: &OP) -> OP {
-		*data
-	}
-}

--- a/crates/field/src/packed.rs
+++ b/crates/field/src/packed.rs
@@ -284,35 +284,9 @@ pub unsafe fn set_packed_slice_unchecked<P: PackedField>(
 	}
 }
 
-#[inline]
-pub fn set_packed_slice<P: PackedField>(packed: &mut [P], i: usize, scalar: P::Scalar) {
-	assert!(i >> P::LOG_WIDTH < packed.len(), "index out of bounds");
-
-	unsafe { set_packed_slice_unchecked(packed, i, scalar) }
-}
-
 #[inline(always)]
 pub const fn len_packed_slice<P: PackedField>(packed: &[P]) -> usize {
 	packed.len() << P::LOG_WIDTH
-}
-
-/// Construct a packed field element from a function that returns scalar values by index with the
-/// given offset in packed elements. E.g. if `offset` is 2, and `WIDTH` is 4, `f(9)` will be used
-/// to set the scalar at index 1 in the packed element.
-#[inline]
-pub fn packed_from_fn_with_offset<P: PackedField>(
-	offset: usize,
-	mut f: impl FnMut(usize) -> P::Scalar,
-) -> P {
-	P::from_fn(|i| f(i + offset * P::WIDTH))
-}
-
-/// Pack a slice of scalars into a vector of packed field elements.
-pub fn pack_slice<P: PackedField>(scalars: &[P::Scalar]) -> Vec<P> {
-	scalars
-		.chunks(P::WIDTH)
-		.map(|chunk| P::from_scalars(chunk.iter().copied()))
-		.collect()
 }
 
 /// A slice of packed field elements as a collection of scalars.

--- a/crates/field/src/underlier/small_uint.rs
+++ b/crates/field/src/underlier/small_uint.rs
@@ -64,18 +64,6 @@ impl<const N: usize> SmallU<N> {
 	pub const fn val(&self) -> u8 {
 		self.0
 	}
-
-	pub fn checked_add(self, rhs: Self) -> Option<Self> {
-		self.val()
-			.checked_add(rhs.val())
-			.and_then(|value| (value < Self::ONES.0).then_some(Self(value)))
-	}
-
-	pub fn checked_sub(self, rhs: Self) -> Option<Self> {
-		let a = self.val();
-		let b = rhs.val();
-		(b > a).then_some(Self(b - a))
-	}
 }
 
 impl<const N: usize> Debug for SmallU<N> {


### PR DESCRIPTION
Part of [BINIUS-113](https://linear.app/jimpo/issue/BINIUS-113). This is one of several cleanup sub-PRs and does **not** close that umbrella investigation.

Deletes public items in `binius-field` that have no caller anywhere in the workspace. Pure deletion of dead code — no behavior change.

### The problem

BINIUS-113 audited the crate for unused code. It found a set of `pub` functions, structs, and methods that are exported but called from nowhere — some already carrying `#[allow(dead_code)]` to silence the compiler, others simply never wired up. Dead exports are a maintenance tax: they show up in docs and autocomplete, invite "is this the API I should use?" confusion, and hide real coupling.

This PR removes the safest, highest-confidence batch — items with **zero references** across every crate (verified excluding `target/` and stale worktrees), so nothing downstream can break.

### The change

Each item below was confirmed to have no caller in the whole workspace before removal.

- **`packed.rs`** — `set_packed_slice`, `pack_slice`, `packed_from_fn_with_offset`.
  The `set_packed_slice_unchecked` variant (used by `binius-math`) stays.
- **`arch/portable/packed.rs`** — `mul_as_bigger_type`, `square_as_bigger_type`, `invert_as_bigger_type` (all three were `#[allow(dead_code)]`).
- **`arithmetic_traits.rs`** — `TrivialWideMul` (struct + `WideMul` impl), never instantiated.
- **`linear_transformation.rs`** — `FieldLinearTransformation` (+ `new_const`/`new`/`bases`/`random` + its `Transformation` impl) and `IDTransformation` (+ impl).
- **`small_uint.rs`** — `SmallU::checked_add`, `SmallU::checked_sub`.

Plus the imports each removal frees, and one comment in `ghash.rs` reworded to drop a reference to the now-deleted `TrivialWideMul` type.

### The dead `gfni_x86` branch

The three `*_as_bigger_type` functions looked arch-gated, but they were dead on **every** target. They were reachable only through the `($name:ty => $bigger:ty)` arms of `impl_mul_with!`/`impl_square_with!`/`impl_invert_with!`, which in turn are produced only by the `(if gfni_x86 …)` arm of `impl_strategy!`:

```
impl_strategy!(... (if gfni_x86 $bigger else $fallback))   // never invoked
  -> impl_mul_with!($name => $bigger)                      // the `=> $bigger` arm
    -> mul_as_bigger_type::<_, $bigger>(..)                // the dead fn
```

No `define_packed_binary_field!` invocation ever selects `gfni_x86` — the token appears nowhere except that macro-arm definition. So the entire chain (the `if gfni_x86` arm, the three `=> $bigger` macro arms, and the three functions) is removed together.

### What is deliberately left for follow-ups

This is only the zero-reference batch. The audit also found:

- test-only items (e.g. the `PackedSlice`/`PackedSliceMut` cluster in `packed.rs`, constructed only under `#[cfg(test)]`),
- dead trait *default* methods (`PackedField::try_from_fn`/`pow`, `ExtensionField::into_iter_bases`, the `WithUnderlier` array helpers),
- x86_64-gated dead methods on `TowerSimdType` and `gf2p8affine_epi64_epi8`,
- `pub`-but-crate-internal items that could be downgraded rather than deleted.

Those touch traits, arch code, or visibility and are left out of this PR on purpose.

One knock-on: removing `IDTransformation` also removed the last user of the `PackedBinaryField` trait, which now has no consumer. It is left in place here (it is a downgrade/removal candidate for a later batch).

### Scope

- **removed:** 8 unused `pub` items + the dead `gfni_x86` macro branch
- **changed:** freed imports; one reworded comment
- **untouched:** all live code paths; `set_packed_slice_unchecked`; the test-only / trait-default / arch-gated candidates

### Verification

- `cargo check --workspace --all-targets` — clean (no downstream crate depended on anything removed)
- `cargo clippy -p binius-field --all-targets` — clean
- `cargo test -p binius-field` — 208 passed, 0 failed (+ doctests)
- `cargo +nightly fmt` — applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)