### PR TITLE
BINIUS-113: remove dead x86_64 TowerSimdType methods and GFNI affine

### DIFF
--- a/crates/field/src/arch/x86_64/gfni/gfni_arithmetics.rs
+++ b/crates/field/src/arch/x86_64/gfni/gfni_arithmetics.rs
@@ -23,8 +23,6 @@ pub const IDENTITY_MAP: i64 = u64::from_le_bytes([
 ]) as i64;
 
 pub(super) trait GfniType: Copy + TowerSimdType {
-	#[allow(unused)]
-	fn gf2p8affine_epi64_epi8(x: Self, a: Self) -> Self;
 	fn gf2p8mul_epi8(a: Self, b: Self) -> Self;
 	fn gf2p8affineinv_epi64_epi8(x: Self, a: Self) -> Self;
 }

--- a/crates/field/src/arch/x86_64/gfni/m128.rs
+++ b/crates/field/src/arch/x86_64/gfni/m128.rs
@@ -9,11 +9,6 @@ use crate::arch::x86_64::m128::M128;
 
 impl GfniType for M128 {
 	#[inline(always)]
-	fn gf2p8affine_epi64_epi8(x: Self, a: Self) -> Self {
-		unsafe { _mm_gf2p8affine_epi64_epi8::<0>(x.0, a.0) }.into()
-	}
-
-	#[inline(always)]
 	fn gf2p8mul_epi8(a: Self, b: Self) -> Self {
 		unsafe { _mm_gf2p8mul_epi8(a.0, b.0) }.into()
 	}

--- a/crates/field/src/arch/x86_64/gfni/m256.rs
+++ b/crates/field/src/arch/x86_64/gfni/m256.rs
@@ -9,11 +9,6 @@ use crate::arch::x86_64::m256::M256;
 
 impl GfniType for M256 {
 	#[inline(always)]
-	fn gf2p8affine_epi64_epi8(x: Self, a: Self) -> Self {
-		unsafe { _mm256_gf2p8affine_epi64_epi8::<0>(x.0, a.0) }.into()
-	}
-
-	#[inline(always)]
 	fn gf2p8mul_epi8(a: Self, b: Self) -> Self {
 		unsafe { _mm256_gf2p8mul_epi8(a.0, b.0) }.into()
 	}

--- a/crates/field/src/arch/x86_64/gfni/m512.rs
+++ b/crates/field/src/arch/x86_64/gfni/m512.rs
@@ -9,11 +9,6 @@ use crate::arch::x86_64::m512::M512;
 
 impl GfniType for M512 {
 	#[inline(always)]
-	fn gf2p8affine_epi64_epi8(x: Self, a: Self) -> Self {
-		unsafe { _mm512_gf2p8affine_epi64_epi8::<0>(x.0, a.0) }.into()
-	}
-
-	#[inline(always)]
 	fn gf2p8mul_epi8(a: Self, b: Self) -> Self {
 		unsafe { _mm512_gf2p8mul_epi8(a.0, b.0) }.into()
 	}

--- a/crates/field/src/arch/x86_64/simd/m128.rs
+++ b/crates/field/src/arch/x86_64/simd/m128.rs
@@ -3,78 +3,11 @@
 use core::arch::x86_64::*;
 
 use super::simd_arithmetic::TowerSimdType;
-use crate::{BinaryField, arch::x86_64::m128::M128};
+use crate::arch::x86_64::m128::M128;
 
 impl TowerSimdType for M128 {
 	#[inline(always)]
-	fn xor(a: Self, b: Self) -> Self {
-		unsafe { _mm_xor_si128(a.0, b.0) }.into()
-	}
-
-	#[inline(always)]
-	fn shuffle_epi8(a: Self, b: Self) -> Self {
-		unsafe { _mm_shuffle_epi8(a.0, b.0) }.into()
-	}
-
-	#[inline(always)]
-	fn blend_odd_even<Scalar: BinaryField>(a: Self, b: Self) -> Self {
-		let mask = Self::even_mask::<Scalar>();
-		unsafe { _mm_blendv_epi8(a.0, b.0, mask.0) }.into()
-	}
-
-	#[inline(always)]
-	fn set_alpha_even<Scalar: BinaryField>(self) -> Self {
-		unsafe {
-			let alpha = Self::alpha::<Scalar>();
-			let mask = Self::even_mask::<Scalar>();
-			// NOTE: There appears to be a bug in _mm_blendv_epi8 where the mask bit selects b, not
-			// a
-			_mm_blendv_epi8(self.0, alpha.0, mask.0)
-		}
-		.into()
-	}
-
-	#[inline(always)]
-	fn set1_epi128(val: __m128i) -> Self {
-		val.into()
-	}
-
-	#[inline(always)]
 	fn set_epi_64(val: i64) -> Self {
 		unsafe { _mm_set1_epi64x(val) }.into()
-	}
-
-	#[inline(always)]
-	fn bslli_epi128<const IMM8: i32>(self) -> Self {
-		unsafe { _mm_bslli_si128::<IMM8>(self.0) }.into()
-	}
-
-	#[inline(always)]
-	fn bsrli_epi128<const IMM8: i32>(self) -> Self {
-		unsafe { _mm_bsrli_si128::<IMM8>(self.0) }.into()
-	}
-
-	#[inline(always)]
-	fn apply_mask<Scalar: BinaryField>(mut mask: Self, a: Self) -> Self {
-		let tower_level = Scalar::N_BITS.ilog2();
-		match tower_level {
-			0..=2 => {
-				for i in 0..tower_level {
-					mask |= mask >> (1 << i);
-				}
-
-				unsafe { _mm_and_si128(a.0, mask.0) }
-			}
-			3 => unsafe { _mm_blendv_epi8(_mm_setzero_si128(), a.0, mask.0) },
-			4..=7 => {
-				let shuffle = Self::make_epi8_mask_shuffle::<Scalar>();
-				unsafe {
-					let mask = _mm_shuffle_epi8(mask.0, shuffle.0);
-					_mm_blendv_epi8(_mm_setzero_si128(), a.0, mask)
-				}
-			}
-			_ => panic!("unsupported bit count"),
-		}
-		.into()
 	}
 }

--- a/crates/field/src/arch/x86_64/simd/m256.rs
+++ b/crates/field/src/arch/x86_64/simd/m256.rs
@@ -3,78 +3,11 @@
 use core::arch::x86_64::*;
 
 use super::simd_arithmetic::TowerSimdType;
-use crate::{BinaryField, arch::x86_64::m256::M256};
+use crate::arch::x86_64::m256::M256;
 
 impl TowerSimdType for M256 {
 	#[inline(always)]
-	fn xor(a: Self, b: Self) -> Self {
-		unsafe { _mm256_xor_si256(a.0, b.0) }.into()
-	}
-
-	#[inline(always)]
-	fn shuffle_epi8(a: Self, b: Self) -> Self {
-		unsafe { _mm256_shuffle_epi8(a.0, b.0) }.into()
-	}
-
-	#[inline(always)]
-	fn blend_odd_even<Scalar: BinaryField>(a: Self, b: Self) -> Self {
-		let mask = Self::even_mask::<Scalar>();
-		unsafe { _mm256_blendv_epi8(a.0, b.0, mask.0) }.into()
-	}
-
-	#[inline(always)]
-	fn set_alpha_even<Scalar: BinaryField>(self) -> Self {
-		unsafe {
-			let alpha = Self::alpha::<Scalar>();
-			let mask = Self::even_mask::<Scalar>();
-			// NOTE: There appears to be a bug in _mm_blendv_epi8 where the mask bit selects b, not
-			// a
-			_mm256_blendv_epi8(self.0, alpha.0, mask.0)
-		}
-		.into()
-	}
-
-	#[inline(always)]
-	fn set1_epi128(val: __m128i) -> Self {
-		unsafe { _mm256_broadcastsi128_si256(val) }.into()
-	}
-
-	#[inline(always)]
 	fn set_epi_64(val: i64) -> Self {
 		unsafe { _mm256_set1_epi64x(val) }.into()
-	}
-
-	#[inline(always)]
-	fn apply_mask<Scalar: BinaryField>(mut mask: Self, a: Self) -> Self {
-		let tower_level = Scalar::N_BITS.ilog2();
-		match tower_level {
-			0..=2 => {
-				for i in 0..tower_level {
-					mask |= mask >> (1 << i);
-				}
-
-				unsafe { _mm256_and_si256(mask.0, a.0) }
-			}
-			3 => unsafe { _mm256_blendv_epi8(_mm256_setzero_si256(), a.0, mask.0) },
-			4..=7 => {
-				let shuffle = Self::make_epi8_mask_shuffle::<Scalar>();
-				unsafe {
-					let mask = _mm256_shuffle_epi8(mask.0, shuffle.0);
-					_mm256_blendv_epi8(_mm256_setzero_si256(), a.0, mask)
-				}
-			}
-			_ => panic!("unsupported bit count"),
-		}
-		.into()
-	}
-
-	#[inline(always)]
-	fn bslli_epi128<const IMM8: i32>(self) -> Self {
-		unsafe { _mm256_bslli_epi128::<IMM8>(self.0) }.into()
-	}
-
-	#[inline(always)]
-	fn bsrli_epi128<const IMM8: i32>(self) -> Self {
-		unsafe { _mm256_bsrli_epi128::<IMM8>(self.0) }.into()
 	}
 }

--- a/crates/field/src/arch/x86_64/simd/m512.rs
+++ b/crates/field/src/arch/x86_64/simd/m512.rs
@@ -3,89 +3,11 @@
 use core::arch::x86_64::*;
 
 use super::simd_arithmetic::TowerSimdType;
-use crate::{BinaryField, arch::x86_64::m512::M512};
+use crate::arch::x86_64::m512::M512;
 
 impl TowerSimdType for M512 {
 	#[inline(always)]
-	fn xor(a: Self, b: Self) -> Self {
-		unsafe { _mm512_xor_si512(a.0, b.0) }.into()
-	}
-
-	#[inline(always)]
-	fn shuffle_epi8(a: Self, b: Self) -> Self {
-		unsafe { _mm512_shuffle_epi8(a.0, b.0) }.into()
-	}
-
-	#[inline(always)]
-	fn blend_odd_even<Scalar: BinaryField>(a: Self, b: Self) -> Self {
-		let mask = even_mask::<Scalar>();
-		unsafe { _mm512_mask_blend_epi8(mask, b.0, a.0) }.into()
-	}
-
-	#[inline(always)]
-	fn set_alpha_even<Scalar: BinaryField>(self) -> Self {
-		unsafe {
-			let alpha = Self::alpha::<Scalar>();
-			let mask = even_mask::<Scalar>();
-			// NOTE: There appears to be a bug in _mm_blendv_epi8 where the mask bit selects b, not
-			// a
-			_mm512_mask_blend_epi8(mask, alpha.0, self.0)
-		}
-		.into()
-	}
-
-	#[inline(always)]
-	fn set1_epi128(val: __m128i) -> Self {
-		unsafe { _mm512_broadcast_i32x4(val) }.into()
-	}
-
-	#[inline(always)]
 	fn set_epi_64(val: i64) -> Self {
 		unsafe { _mm512_set1_epi64(val) }.into()
-	}
-
-	#[inline(always)]
-	fn bslli_epi128<const IMM8: i32>(self) -> Self {
-		unsafe { _mm512_bslli_epi128::<IMM8>(self.0) }.into()
-	}
-
-	#[inline(always)]
-	fn bsrli_epi128<const IMM8: i32>(self) -> Self {
-		unsafe { _mm512_bsrli_epi128::<IMM8>(self.0) }.into()
-	}
-
-	#[inline(always)]
-	fn apply_mask<Scalar: BinaryField>(mut mask: Self, a: Self) -> Self {
-		let tower_level = Scalar::N_BITS.ilog2();
-		match tower_level {
-			0..=2 => {
-				for i in 0..tower_level {
-					mask |= mask >> (1 << i);
-				}
-
-				unsafe { _mm512_and_si512(a.0, mask.0) }
-			}
-			3 => unsafe { _mm512_maskz_mov_epi8(_mm512_movepi8_mask(mask.0), a.0) },
-			4 => unsafe { _mm512_maskz_mov_epi16(_mm512_movepi16_mask(mask.0), a.0) },
-			5..=7 => {
-				let shuffle = Self::make_epi8_mask_shuffle::<Scalar>();
-				unsafe {
-					let mask = _mm512_shuffle_epi8(mask.0, shuffle.0);
-					_mm512_maskz_mov_epi8(_mm512_movepi8_mask(mask), a.0)
-				}
-			}
-			_ => panic!("unsupported bit count"),
-		}
-		.into()
-	}
-}
-
-fn even_mask<Scalar: BinaryField>() -> u64 {
-	match Scalar::N_BITS.ilog2() {
-		3 => 0xAAAAAAAAAAAAAAAA,
-		4 => 0xCCCCCCCCCCCCCCCC,
-		5 => 0xF0F0F0F0F0F0F0F0,
-		6 => 0xFF00FF00FF00FF00,
-		_ => panic!("unsupported bit count"),
 	}
 }

--- a/crates/field/src/arch/x86_64/simd/simd_arithmetic.rs
+++ b/crates/field/src/arch/x86_64/simd/simd_arithmetic.rs
@@ -1,114 +1,13 @@
 // Copyright 2024-2025 Irreducible Inc.
 
-use std::{any::TypeId, arch::x86_64::*};
+use crate::underlier::UnderlierType;
 
-use crate::{BinaryField, aes_field::AESTowerField8b, underlier::UnderlierType};
-
+/// SIMD underlier operations backing the x86_64 GFNI field arithmetic.
+///
+/// Only exercised when the `gfni` target feature is enabled.
+/// On other x86_64 builds nothing calls it, hence the `dead_code` allow.
 #[allow(dead_code)]
 pub trait TowerSimdType: Sized + Copy + UnderlierType {
-	/// Blend odd and even elements
-	fn blend_odd_even<Scalar: BinaryField>(a: Self, b: Self) -> Self;
-	/// Set alpha to even elements
-	fn set_alpha_even<Scalar: BinaryField>(self) -> Self;
-	/// Apply `mask` to `a` (set zeros at positions where high bit of the `mask` is 0).
-	fn apply_mask<Scalar: BinaryField>(mask: Self, a: Self) -> Self;
-
-	/// Bit xor operation
-	fn xor(a: Self, b: Self) -> Self;
-
-	/// Shuffle 8-bit elements within 128-bit lanes
-	fn shuffle_epi8(a: Self, b: Self) -> Self;
-
-	/// Byte shifts within 128-bit lanes
-	fn bslli_epi128<const IMM8: i32>(self) -> Self;
-	fn bsrli_epi128<const IMM8: i32>(self) -> Self;
-
-	/// Initialize value with a single element
-	fn set1_epi128(val: __m128i) -> Self;
+	/// Broadcast a 64-bit value across every 64-bit lane.
 	fn set_epi_64(val: i64) -> Self;
-
-	#[inline(always)]
-	fn dup_shuffle<Scalar: BinaryField>() -> Self {
-		let shuffle_mask_128 = unsafe {
-			match Scalar::N_BITS.ilog2() {
-				3 => _mm_set_epi8(14, 14, 12, 12, 10, 10, 8, 8, 6, 6, 4, 4, 2, 2, 0, 0),
-				4 => _mm_set_epi8(13, 12, 13, 12, 9, 8, 9, 8, 5, 4, 5, 4, 1, 0, 1, 0),
-				5 => _mm_set_epi8(11, 10, 9, 8, 11, 10, 9, 8, 3, 2, 1, 0, 3, 2, 1, 0),
-				6 => _mm_set_epi8(7, 6, 5, 4, 3, 2, 1, 0, 7, 6, 5, 4, 3, 2, 1, 0),
-				_ => panic!("unsupported bit count"),
-			}
-		};
-
-		Self::set1_epi128(shuffle_mask_128)
-	}
-
-	#[inline(always)]
-	fn flip_shuffle<Scalar: BinaryField>() -> Self {
-		let flip_mask_128 = unsafe {
-			match Scalar::N_BITS.ilog2() {
-				3 => _mm_set_epi8(14, 15, 12, 13, 10, 11, 8, 9, 6, 7, 4, 5, 2, 3, 0, 1),
-				4 => _mm_set_epi8(13, 12, 15, 14, 9, 8, 11, 10, 5, 4, 7, 6, 1, 0, 3, 2),
-				5 => _mm_set_epi8(11, 10, 9, 8, 15, 14, 13, 12, 3, 2, 1, 0, 7, 6, 5, 4),
-				6 => _mm_set_epi8(7, 6, 5, 4, 3, 2, 1, 0, 15, 14, 13, 12, 11, 10, 9, 8),
-				_ => panic!("unsupported bit count"),
-			}
-		};
-
-		Self::set1_epi128(flip_mask_128)
-	}
-
-	/// Creates mask to propagate the highest bit form mask to other element bytes
-	#[inline(always)]
-	fn make_epi8_mask_shuffle<Scalar: BinaryField>() -> Self {
-		let epi8_mask_128 = unsafe {
-			match Scalar::N_BITS.ilog2() {
-				4 => _mm_set_epi8(15, 15, 13, 13, 11, 11, 9, 9, 7, 7, 5, 5, 3, 3, 1, 1),
-				5 => _mm_set_epi8(15, 15, 15, 15, 11, 11, 11, 11, 7, 7, 7, 7, 3, 3, 3, 3),
-				6 => _mm_set_epi8(15, 15, 15, 15, 15, 15, 15, 15, 7, 7, 7, 7, 7, 7, 7, 7),
-				7 => _mm_set1_epi8(15),
-				_ => panic!("unsupported bit count"),
-			}
-		};
-
-		Self::set1_epi128(epi8_mask_128)
-	}
-
-	#[inline(always)]
-	fn alpha<Scalar: BinaryField>() -> Self {
-		let alpha_128 = {
-			match Scalar::N_BITS.ilog2() {
-				3 => {
-					// Compiler will optimize this if out for each instantiation
-					let type_id = TypeId::of::<Scalar>();
-					let value = if type_id == TypeId::of::<AESTowerField8b>() {
-						0xd3u8 as i8
-					} else {
-						panic!("tower field not supported")
-					};
-					unsafe { _mm_set1_epi8(value) }
-				}
-				4 => unsafe { _mm_set1_epi16(0x0100) },
-				5 => unsafe { _mm_set1_epi32(0x00010000) },
-				6 => unsafe { _mm_set1_epi64x(0x0000000100000000) },
-				_ => panic!("unsupported bit count"),
-			}
-		};
-
-		Self::set1_epi128(alpha_128)
-	}
-
-	#[inline(always)]
-	fn even_mask<Scalar: BinaryField>() -> Self {
-		let mask_128 = {
-			match Scalar::N_BITS.ilog2() {
-				3 => unsafe { _mm_set1_epi16(0x00FF) },
-				4 => unsafe { _mm_set1_epi32(0x0000FFFF) },
-				5 => unsafe { _mm_set1_epi64x(0x00000000FFFFFFFF) },
-				6 => unsafe { _mm_set_epi64x(0, -1) },
-				_ => panic!("unsupported bit count"),
-			}
-		};
-
-		Self::set1_epi128(mask_128)
-	}
 }


### PR DESCRIPTION
Part of [BINIUS-113](https://linear.app/jimpo/issue/BINIUS-113). One of several cleanup sub-PRs — does **not** close that umbrella investigation.

Removes x86_64-only dead code in `binius-field` that was hidden behind `#[allow(dead_code)]` / `#[allow(unused)]`. Pure deletion — no behavior change.

### The problem

`arch/x86_64/simd/simd_arithmetic.rs` defines `TowerSimdType`, a SIMD helper trait implemented for `M128`/`M256`/`M512`. Most of it is a tower-arithmetic method set that **nothing calls on any x86_64 configuration** — it predates the GFNI path that now does AES/tower multiply in a single instruction. The `#[allow(dead_code)]` on the trait masked all of it. Separately, `GfniType::gf2p8affine_epi64_epi8` is declared and implemented three times but never invoked.

### The cascade

The nine methods called out in the audit are the entry points, but they pull helpers with them. Once the callers go, the helpers are unreachable:

```
blend_odd_even  -> even_mask
set_alpha_even  -> alpha, even_mask
apply_mask      -> make_epi8_mask_shuffle
dup_shuffle / flip_shuffle / make_epi8_mask_shuffle / alpha / even_mask -> set1_epi128
```

So removing the nine orphans `make_epi8_mask_shuffle`, `alpha`, `even_mask`, `set1_epi128` (and the module-level `even_mask` in `m512.rs`). Verified each of those has no other caller before deleting it.

### The change

`TowerSimdType` collapses to the one method GFNI actually uses:

```
pub trait TowerSimdType: Sized + Copy + UnderlierType {
    fn set_epi_64(val: i64) -> Self;   // used by GFNI inversion (IDENTITY_MAP)
}
```

- **Removed from `TowerSimdType`** (decls + the `M128`/`M256`/`M512` impls): `blend_odd_even`, `set_alpha_even`, `apply_mask`, `xor`, `shuffle_epi8`, `bslli_epi128`, `bsrli_epi128`, `dup_shuffle`, `flip_shuffle`, `make_epi8_mask_shuffle`, `alpha`, `even_mask`, `set1_epi128`, plus the free `even_mask` in `m512.rs`.
- **Removed from `GfniType`** (decl + three impls): `gf2p8affine_epi64_epi8`. Its `#[allow(unused)]` goes with it.
- **Kept:** `set_epi_64`; and `GfniType::gf2p8mul_epi8` / `gf2p8affineinv_epi64_epi8`, both live (Mul / WideMul / InvertOrZero).

### Why `TowerSimdType` keeps its `#[allow(dead_code)]`

`set_epi_64` is used only by the GFNI code, and the `gfni` module is `#[cfg(target_feature = "gfni")]`. On x86_64 builds **without** GFNI the trait has no caller and the compiler flags it — confirmed: dropping the allow fails a `-D warnings` build in the sse2-only config. So the allow stays, now justified purely by the cfg-gating rather than by masking dead methods.

### Scope

- **removed:** 13 unused `TowerSimdType` items + 1 free fn + `gf2p8affine_epi64_epi8` (×4)
- **kept:** `set_epi_64`, the two live GFNI ops, and the load-bearing `#[allow(dead_code)]`
- **untouched:** all live GFNI arithmetic; the portable and aarch64 arches

### Verification

This is x86_64-only code, so it was cross-compiled (this host is aarch64):

- `cargo check -p binius-field --target x86_64-unknown-linux-gnu` with `-D warnings` under three feature sets — all clean:
  - `+sse2,+avx2,+avx512f,+gfni` (all impls + GFNI live)
  - `+sse2` only (no GFNI — the config that needs the allow)
  - `+sse2,+avx2` (no GFNI, no AVX-512)
- `cargo clippy` on the `x86_64` target with GFNI — clean
- native `cargo check --workspace --all-targets`, `cargo test -p binius-field` (208 passed), nightly `fmt` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)