### PR TITLE
BINIUS-113: remove dead trait methods from binius-field (group B)

### DIFF
--- a/crates/field/src/binary_field.rs
+++ b/crates/field/src/binary_field.rs
@@ -476,15 +476,6 @@ macro_rules! impl_field_extension {
 			}
 
 			#[inline]
-			fn into_iter_bases(self) -> impl Iterator<Item = $subfield_name> {
-				use binius_utils::iter::IterExtensions;
-				use $crate::underlier::{Divisible, WithUnderlier};
-
-				Divisible::<<$subfield_name as WithUnderlier>::Underlier>::value_iter(self.0)
-					.map_skippable($subfield_name::from)
-			}
-
-			#[inline]
 			unsafe fn get_base_unchecked(&self, i: usize) -> $subfield_name {
 				use $crate::underlier::{Divisible, WithUnderlier};
 				// Safety: the caller guarantees `i < Self::N` (over subfield elements).

--- a/crates/field/src/extension.rs
+++ b/crates/field/src/extension.rs
@@ -61,9 +61,6 @@ pub trait ExtensionField<F: Field>:
 	/// Iterator over base field elements.
 	fn iter_bases(&self) -> impl Iterator<Item = F>;
 
-	/// Convert into an iterator over base field elements.
-	fn into_iter_bases(self) -> impl Iterator<Item = F>;
-
 	/// Returns the i-th base field element.
 	#[inline]
 	fn get_base(&self, i: usize) -> F {
@@ -104,11 +101,6 @@ impl<F: Field> ExtensionField<F> for F {
 	#[inline(always)]
 	fn iter_bases(&self) -> impl Iterator<Item = F> {
 		iter::once(*self)
-	}
-
-	#[inline(always)]
-	fn into_iter_bases(self) -> impl Iterator<Item = F> {
-		iter::once(self)
 	}
 
 	#[inline(always)]

--- a/crates/field/src/packed.rs
+++ b/crates/field/src/packed.rs
@@ -92,18 +92,6 @@ pub trait PackedField:
 	/// Construct a packed field element from a function that returns scalar values by index.
 	fn from_fn(f: impl FnMut(usize) -> Self::Scalar) -> Self;
 
-	/// Creates a packed field from a fallible function applied to each index.
-	fn try_from_fn<E>(mut f: impl FnMut(usize) -> Result<Self::Scalar, E>) -> Result<Self, E> {
-		let mut result = Self::default();
-		for i in 0..Self::WIDTH {
-			let scalar = f(i)?;
-			unsafe {
-				result.set_unchecked(i, scalar);
-			};
-		}
-		Ok(result)
-	}
-
 	/// Construct a packed field element from a sequence of scalars.
 	///
 	/// If the number of values in the sequence is less than the packing width, the remaining

--- a/crates/field/src/packed_extension.rs
+++ b/crates/field/src/packed_extension.rs
@@ -11,7 +11,7 @@ use crate::{
 /// scalar type and preserving the order of the smaller elements. This is what makes the reinterpret
 /// casts ([`cast_bases_mut`], [`cast_base_mut`], [`cast_ext`]) sound: the `FSub` scalars of
 /// `cast_bases_mut(exts)` are exactly the scalars yielded by
-/// `exts.iter().flat_map(|ext| ext.into_iter_bases())`.
+/// `exts.iter().flat_map(|ext| ext.iter_bases())`.
 pub type PackedSubfield<P, FSub> = PackedPrimitiveType<<P as WithUnderlier>::Underlier, FSub>;
 
 /// Reinterpret a mutable slice of packed extension field elements as a mutable slice of the

--- a/crates/field/src/underlier/underlier_type.rs
+++ b/crates/field/src/underlier/underlier_type.rs
@@ -129,25 +129,6 @@ pub unsafe trait WithUnderlier:
 	}
 
 	#[inline]
-	fn to_underliers_arr<const N: usize>(val: [Self; N]) -> [Self::Underlier; N] {
-		val.map(Self::to_underlier)
-	}
-
-	#[inline]
-	fn to_underliers_arr_ref<const N: usize>(val: &[Self; N]) -> &[Self::Underlier; N] {
-		Self::to_underliers_ref(val)
-			.try_into()
-			.expect("array size is valid")
-	}
-
-	#[inline]
-	fn to_underliers_arr_ref_mut<const N: usize>(val: &mut [Self; N]) -> &mut [Self::Underlier; N] {
-		Self::to_underliers_ref_mut(val)
-			.try_into()
-			.expect("array size is valid")
-	}
-
-	#[inline]
 	fn from_underlier(val: Self::Underlier) -> Self {
 		Self::wrap(val)
 	}
@@ -170,27 +151,6 @@ pub unsafe trait WithUnderlier:
 	#[inline]
 	fn from_underliers_ref_mut(val: &mut [Self::Underlier]) -> &mut [Self] {
 		Self::wrap_slice_mut(val)
-	}
-
-	#[inline]
-	fn from_underliers_arr<const N: usize>(val: [Self::Underlier; N]) -> [Self; N] {
-		val.map(Self::from_underlier)
-	}
-
-	#[inline]
-	fn from_underliers_arr_ref<const N: usize>(val: &[Self::Underlier; N]) -> &[Self; N] {
-		Self::from_underliers_ref(val)
-			.try_into()
-			.expect("array size is valid")
-	}
-
-	#[inline]
-	fn from_underliers_arr_ref_mut<const N: usize>(
-		val: &mut [Self::Underlier; N],
-	) -> &mut [Self; N] {
-		Self::from_underliers_ref_mut(val)
-			.try_into()
-			.expect("array size is valid")
 	}
 
 	#[inline]


### PR DESCRIPTION
Part of [BINIUS-113](https://linear.app/jimpo/issue/BINIUS-113). One of several cleanup sub-PRs — does **not** close that umbrella investigation.

Removes trait methods in `binius-field` that are never called anywhere in the workspace. Pure deletion — no behavior change.

### The problem

The BINIUS-113 audit turned up a handful of trait methods that are defined (some with default bodies, some required with concrete impls) but invoked from nowhere. Unlike a free function, a dead trait method can't be caught by the compiler's `dead_code` lint when the trait is public, so these sat unnoticed.

### The change

- **`PackedField::try_from_fn`** (default method) — no caller. The `try_from_fn` matches elsewhere are `array_util::try_from_fn`, a different function.
- **`ExtensionField::into_iter_bases`** (required method) — removed the declaration, its blanket `impl<F: Field>` body, and the `impl_field_extension!` macro impl. The borrowing sibling `iter_bases` is the one actually used and stays. A doc comment in `packed_extension.rs` that referenced `into_iter_bases` now points at `iter_bases` (same scalar order).
- **`WithUnderlier::{to,from}_underliers_arr{,_ref,_ref_mut}`** (six default array helpers) — no callers. The slice-level helpers they delegate to (`to_underliers_ref`, `from_underliers_ref`, …) stay, still used across the arch code.

### One correction to the audit: `PackedField::pow` stays

The audit listed `PackedField::pow` as dead. It is **not** — it is live through method resolution, and removing it fails to compile.

Every scalar field is also a width-1 `PackedField`, so a scalar has two `pow` methods in scope:

```
Field::pow<S: AsRef<[u64]>>(&self, exp: S)   // scalar
PackedField::pow(self, exp: u64)             // packed
```

A call like `B128::MULTIPLICATIVE_GENERATOR.pow(6765)` (in `binius-spartan-frontend`) or `generator.pow(i as u64)` (a `binius-field` test) binds to `PackedField::pow`, because a bare integer / `u64` argument does **not** satisfy `AsRef<[u64]>`. Delete `PackedField::pow` and those calls reroute to `Field::pow`, which then rejects the `u64` argument — a compile error. So `pow` is load-bearing and is left in place.

### Scope

- **removed:** `try_from_fn`, `into_iter_bases` (+ 2 impls), 6 `WithUnderlier` array helpers
- **kept:** `pow` (live via resolution), `iter_bases`, and every slice helper the deleted methods wrapped
- **untouched:** all live code paths

### Verification

- `cargo check -p binius-field --all-targets`, `cargo clippy -p binius-field --all-targets` — clean
- `cargo test -p binius-field` — 208 passed
- `cargo check -p binius-field --target x86_64-unknown-linux-gnu` with `-D warnings` under `+sse2,+avx2,+avx512f,+gfni` — clean
- `cargo check` on every workspace consumer of the touched traits (`binius-math`, `binius-prover`, `binius-verifier`, `binius-hash`, `binius-iop`, `binius-ip`, `binius-transcript`, `binius-core`) — clean
- nightly `fmt` — applied

Note: `binius-frontend` currently fails a full `--workspace --all-targets` build on an unresolved `binius_core::consts` import. That breakage is pre-existing on `main` (reproduces with this branch's changes stashed) and is unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)