### PR TITLE
BINIUS-218: parallelize the batched fracadd GKR across instances

### DIFF
--- a/crates/ip-prover/src/fracaddcheck.rs
+++ b/crates/ip-prover/src/fracaddcheck.rs
@@ -7,7 +7,9 @@ use binius_ip::{mlecheck, prodcheck::MultilinearEvalClaim, sumcheck::RoundCoeffs
 use binius_math::{
 	FieldBuffer, line::extrapolate_line_packed, multilinear::eq::eq_ind_partial_eval,
 };
-use binius_utils::rayon::iter::{IntoParallelIterator, ParallelIterator};
+use binius_utils::rayon::iter::{
+	IntoParallelIterator, IntoParallelRefMutIterator, ParallelIterator,
+};
 use itertools::izip;
 
 use crate::{
@@ -455,7 +457,7 @@ fn reduce_layer<F, P, MP>(
 where
 	F: Field,
 	P: PackedField<Scalar = F>,
-	MP: MleCheckProver<F>,
+	MP: MleCheckProver<F> + Send,
 {
 	// Split eval_point into outer (selector) and inner (content) coordinates.
 	let (outer_coords, inner_coords) = eval_point.split_at(k);
@@ -477,8 +479,17 @@ where
 	// Content rounds: fold the content variables of every instance in lockstep, sending the
 	// eq(selector)-weighted sum of the per-instance (num, den)-batched round polynomials.
 	for _round in 0..inner_coords.len() {
-		let real_coeffs: RoundCoeffs<F> = iter::zip(&mut layer_provers, eq_weights.iter_scalars())
-			.map(|(prover, eq_i)| combine_claims(prover.execute(), batch_coeff) * eq_i)
+		// The instances are independent within a round, so their polynomials compute in parallel.
+		//
+		// One instance's round is too small a parallel region to fill the pool alone.
+		let per_instance: Vec<RoundCoeffs<F>> = layer_provers
+			.par_iter_mut()
+			.map(|prover| combine_claims(prover.execute(), batch_coeff))
+			.collect();
+
+		// Weight instance j's polynomial by eq_j and sum, in instance order.
+		let real_coeffs: RoundCoeffs<F> = iter::zip(per_instance, eq_weights.iter_scalars())
+			.map(|(coeffs, eq_i)| coeffs * eq_i)
 			.sum();
 		let round_coeffs = real_coeffs + &RoundCoeffs(vec![pad_eq_sum * batch_coeff]);
 


### PR DESCRIPTION
Part of [BINIUS-218](https://linear.app/jimpo/issue/BINIUS-218/logup-witness-inefficiencies) — this does not close it.

Computes the batched fractional-addition GKR rounds the same way, but fans the per-instance work across the thread pool instead of running it one instance at a time.
Output is bit-identical — no protocol change, no new soundness assumption.

### The problem

The logUp* looker side batches one fractional-addition GKR instance per looker — 12 instances in the intmul caller.
Every sumcheck round asks each instance for a small round polynomial, then sends only their eq-weighted sum.

The rounds ran the instances **serially**, and each instance parallelized only internally, over its own shrinking layer.
Most rounds are far too small for that inner parallelism to fill the pool, so the workers spent the rounds waking, stealing, and spinning.

The result is anti-scaling: with the `rayon` feature on, the looker-side GKR got slower the more threads it had.

| threads (12 lookers, $n = 18$) | looker-side GKR |
|---|---|
| 1 (serial build) | 92 ms |
| 2 | 127 ms |
| 4 | 159 ms |
| 8 | 274 ms |

### The idea

Flip the parallel axis.
The instances are independent within a round — only the channel interaction is shared.
So give the pool one task per instance instead of one sliver of one instance:

```
before: for each instance: split its layer across all workers   (12 tiny regions per round)
after:  one region per round, one whole instance per task       (12 real tasks)
```

Inside the early, wide rounds an instance still splits further; nested rayon composes fine.

### The change

One loop in `reduce_layer` (`crates/ip-prover/src/fracaddcheck.rs`):

```
- serial: zip(provers, eq_weights).map(combine(prover.execute()) * eq_i).sum()
+ par_iter_mut over provers: combine(prover.execute()), collected in instance order
+ then the eq-weighted sum, serial, in instance order
```

Plus `Send` on the private prover bound — the evaluator trait objects were already `Send + Sync`, so every caller compiles unchanged.

### Soundness — preserved, for free

- The verifier only sees the combined polynomial `sum_j eq_j * p_j`; parallelism changes when each instance's polynomial is computed, not its value.
- The weighted sum still runs serially in instance order, so the sent bytes are identical.
- The fracaddcheck and logUp* round-trip tests replay the prover transcript through the real verifier, pinning this.

### Scope

- **changed:** the content-round loop in `reduce_layer`, one import, one trait bound
- everything else — layer construction, selector rounds, finish — untouched

### Verification

- `cargo check --workspace --all-targets`, `clippy -p binius-ip-prover --all-targets` (with and without `rayon`), nightly `fmt` — clean
- `cargo test -p binius-ip-prover`: 58/58 pass, with and without `--features rayon`
- `cargo test -p binius-iop-prover logup_star` (committed pushforward, incl. the BaseFold round trip) — pass

### Benchmark

`batch_prove`, 12 instances (the intmul regime), full reduction, medians on an M1 Pro, `--release --features rayon`:

| n_layers | before | after | speedup |
|---|---|---|---|
| 16 | 182.5 ms | 20.8 ms | 8.8× |
| 18 | 296.7 ms | 46.1 ms | 6.4× |
| 20 | 465.0 ms | 107.4 ms | 4.3× |

End-to-end intmul phase 5 (tracing span timings, same machine):

| log(mults) | phase 5 before → after | looker-side GKR before → after |
|---|---|---|
| 18 | 410 ms → 124 ms | 318 ms → 37 ms |
| 20 | 670 ms → 262 ms | 476 ms → 86 ms |

Serial builds (no `rayon` feature) are unchanged within noise: 23.7 / 87.3 / 341.0 ms before vs 23.8 / 88.4 / 338.9 ms after.
The throwaway benches used for these numbers are not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)