### PR TITLE
BINIUS-218: parallelize the looker circuit build with a serial layer cutoff

### DIFF
--- a/crates/ip-prover/src/fracaddcheck.rs
+++ b/crates/ip-prover/src/fracaddcheck.rs
@@ -8,7 +8,7 @@ use binius_math::{
 	FieldBuffer, line::extrapolate_line_packed, multilinear::eq::eq_ind_partial_eval,
 };
 use binius_utils::rayon::iter::{
-	IntoParallelIterator, IntoParallelRefMutIterator, ParallelIterator,
+	IndexedParallelIterator, IntoParallelIterator, IntoParallelRefMutIterator, ParallelIterator,
 };
 use itertools::izip;
 
@@ -28,12 +28,12 @@ use crate::{
 /// Both claims share the same evaluation point, that of the layer they describe.
 pub type FracEvalClaim<F> = (MultilinearEvalClaim<F>, MultilinearEvalClaim<F>);
 
-/// Packed-word count below which a fractional-addition layer builds serially.
+/// Minimum packed words a worker takes per fractional-addition layer chunk.
 ///
-/// One output word is three field multiplies, couples of ns.
-/// A parallel region costs tens of microseconds to dispatch.
-/// Below a few thousand words the dispatch dominates.
-const SERIAL_LAYER_BUILD_CUTOFF: usize = 1 << 13;
+/// One output word is three field multiplies, a few ns.
+/// Splitting work across workers costs tens of microseconds.
+/// Below a few thousand words per chunk the split dominates.
+const LAYER_BUILD_MIN_CHUNK: usize = 1 << 13;
 
 /// The store-based MLE-check prover for one fractional-addition layer.
 ///
@@ -90,22 +90,12 @@ where
 
 			// One packed word of the next layer from the sibling halves:
 			//     a_0/b_0 + a_1/b_1 = (a_0*b_1 + a_1*b_0) / (b_0*b_1)
-			let frac_add =
-				|(&a_0, &b_0, &a_1, &b_1): (&P, &P, &P, &P)| (a_0 * b_1 + a_1 * b_0, b_0 * b_1);
-
-			// Small layers build serially: the dispatch would cost more than the work.
-			let halves = (num_0.as_ref(), den_0.as_ref(), num_1.as_ref(), den_1.as_ref());
 			let (next_layer_num, next_layer_den) =
-				if num_0.as_ref().len() < SERIAL_LAYER_BUILD_CUTOFF {
-					izip!(halves.0, halves.1, halves.2, halves.3)
-						.map(frac_add)
-						.collect::<(Vec<_>, Vec<_>)>()
-				} else {
-					halves
-						.into_par_iter()
-						.map(frac_add)
-						.collect::<(Vec<_>, Vec<_>)>()
-				};
+				(num_0.as_ref(), den_0.as_ref(), num_1.as_ref(), den_1.as_ref())
+					.into_par_iter()
+					.with_min_len(LAYER_BUILD_MIN_CHUNK)
+					.map(|(&a_0, &b_0, &a_1, &b_1)| (a_0 * b_1 + a_1 * b_0, b_0 * b_1))
+					.collect::<(Vec<_>, Vec<_>)>();
 
 			let next_layer = (
 				FieldBuffer::new(num.log_len() - 1, next_layer_num),

--- a/crates/ip-prover/src/fracaddcheck.rs
+++ b/crates/ip-prover/src/fracaddcheck.rs
@@ -28,6 +28,13 @@ use crate::{
 /// Both claims share the same evaluation point, that of the layer they describe.
 pub type FracEvalClaim<F> = (MultilinearEvalClaim<F>, MultilinearEvalClaim<F>);
 
+/// Packed-word count below which a fractional-addition layer builds serially.
+///
+/// One output word is three field multiplies, couples of ns.
+/// A parallel region costs tens of microseconds to dispatch.
+/// Below a few thousand words the dispatch dominates.
+const SERIAL_LAYER_BUILD_CUTOFF: usize = 1 << 13;
+
 /// The store-based MLE-check prover for one fractional-addition layer.
 ///
 /// Returned by `FracAddCheckProver::layer_prover`. It owns its four half-columns, so it is
@@ -81,11 +88,24 @@ where
 			let (num_0, num_1) = num.split_half_ref();
 			let (den_0, den_1) = den.split_half_ref();
 
+			// One packed word of the next layer from the sibling halves:
+			//     a_0/b_0 + a_1/b_1 = (a_0*b_1 + a_1*b_0) / (b_0*b_1)
+			let frac_add =
+				|(&a_0, &b_0, &a_1, &b_1): (&P, &P, &P, &P)| (a_0 * b_1 + a_1 * b_0, b_0 * b_1);
+
+			// Small layers build serially: the dispatch would cost more than the work.
+			let halves = (num_0.as_ref(), den_0.as_ref(), num_1.as_ref(), den_1.as_ref());
 			let (next_layer_num, next_layer_den) =
-				(num_0.as_ref(), den_0.as_ref(), num_1.as_ref(), den_1.as_ref())
-					.into_par_iter()
-					.map(|(&a_0, &b_0, &a_1, &b_1)| (a_0 * b_1 + a_1 * b_0, b_0 * b_1))
-					.collect::<(Vec<_>, Vec<_>)>();
+				if num_0.as_ref().len() < SERIAL_LAYER_BUILD_CUTOFF {
+					izip!(halves.0, halves.1, halves.2, halves.3)
+						.map(frac_add)
+						.collect::<(Vec<_>, Vec<_>)>()
+				} else {
+					halves
+						.into_par_iter()
+						.map(frac_add)
+						.collect::<(Vec<_>, Vec<_>)>()
+				};
 
 			let next_layer = (
 				FieldBuffer::new(num.log_len() - 1, next_layer_num),

--- a/crates/ip-prover/src/logup_star/prove.rs
+++ b/crates/ip-prover/src/logup_star/prove.rs
@@ -5,7 +5,7 @@
 use binius_field::{BinaryField, Divisible, Field, PackedField};
 use binius_ip::{MultilinearEvalClaim, logup_star::LogupOutput};
 use binius_math::{FieldBuffer, univariate::evaluate_univariate};
-use binius_utils::checked_arithmetics::log2_ceil_usize;
+use binius_utils::{checked_arithmetics::log2_ceil_usize, rayon::prelude::*};
 
 use super::{
 	final_layer::{FinalLayerOutput, prove_final_layer},
@@ -162,7 +162,10 @@ where
 	//     looker j: gamma^j * eq_{r_j}(i) / (c - I_j(i))   over n variables
 	//     table:    Y(v)                  / (c - v)         over m variables
 	let circuits_guard = tracing::debug_span!("Build fracadd circuits").entered();
-	let (looker_provers, looker_roots): (Vec<_>, Vec<_>) = std::iter::zip(lookers, numerators)
+	// The circuits are independent, so they build in parallel across lookers.
+	// The collect preserves looker order, so circuit j keeps numerator gamma^j.
+	let (looker_provers, looker_roots): (Vec<_>, Vec<_>) = (lookers, numerators)
+		.into_par_iter()
 		.map(|(looker, numerator)| {
 			let den = witness::looker_denominator::<F, P>(c, looker.index);
 			let (prover, root) = FracAddCheckProver::new(n, (numerator, den));


### PR DESCRIPTION
Part of [BINIUS-218](https://linear.app/jimpo/issue/BINIUS-218/logup-witness-inefficiencies) — this does not close it.

Builds the same logUp* fractional-addition circuits, but fans the per-looker builds across the thread pool and stops dispatching layers too small to pay for a parallel region.
Output is bit-identical — no protocol change, no new soundness assumption.

### The problem

Two dispatch problems compound in the circuit-build stage:

- The prover builds one fractional-addition circuit per looker (12 in the intmul caller), **one looker at a time**.
- Inside each build, **every** layer goes through the pool — including layers of a few dozen packed words.

One output word is three $\mathbb{F}_{2^{128}}$ multiplies, roughly 10ns.
A parallel region costs tens of microseconds to dispatch and join.
So with the `rayon` feature on, small builds were a net **loss** against single-threaded:

| `n_vars` (single circuit) | serial build | rayon build |
|---|---|---|
| 12 | 20 µs | 523 µs |
| 16 | 313 µs | 1.12 ms |
| 20 | 5.0 ms | 4.78 ms |

Only at $2^{20}$ did the pool break even.

### The idea

- Fan the circuit builds out across lookers — the circuits are independent, one task per looker.
- Below a cutoff of $2^{13}$ packed words, build the layer serially; above it, keep the parallel build.

The cutoff is where the ~10ns-per-word work overtakes the tens-of-microseconds dispatch, and the criterion sweep below confirms it.

### The change

Two spots:

```
crates/ip-prover/src/logup_star/prove.rs
-   serial: iter::zip(lookers, numerators).map(build circuit).unzip()
+   (lookers, numerators).into_par_iter().map(build circuit).unzip()   // order-preserving

crates/ip-prover/src/fracaddcheck.rs
+   const SERIAL_LAYER_BUILD_CUTOFF: usize = 1 << 13;
    per layer: below the cutoff -> serial izip build; otherwise -> the existing parallel build
```

### Soundness — preserved, for free

- Pure scheduling: the same values are computed by the same formula, only on different workers.
- The parallel collect preserves looker order, so circuit $j$ keeps its $\gamma^j$-scaled numerator.
- The fracaddcheck and logUp* round-trip tests replay the prover transcript through the real verifier, pinning bit-identity.

### Scope

- **changed:** the looker loop in the logUp* reduction, plus the layer-build loop and one named constant in fracaddcheck
- the GKR rounds themselves are untouched — their cross-instance parallelization is #1880

### Verification

- `cargo check --workspace --all-targets`, `clippy -p binius-ip-prover --all-targets` (with and without `rayon`), nightly `fmt` — clean
- `cargo test -p binius-ip-prover`: 58/58 pass, with and without `--features rayon`
- `cargo test -p binius-iop-prover logup_star` (committed pushforward, incl. the BaseFold round trip) — pass

### Benchmark

All numbers: medians on an M1 Pro.

**Single-circuit build** — the existing criterion bench, reproducible with
`cargo bench -p binius-prover --features rayon --bench fracaddcheck -- new`:

| `n_vars` | before | after | speedup |
|---|---|---|---|
| 12 | 523 µs | 17.9 µs | 29× |
| 16 | 1.12 ms | 560 µs | 2.0× |
| 20 | 4.78 ms | 4.38 ms | 1.09× |

After the cutoff, the $2^{12}$ build beats even the single-threaded 20 µs — rayon is no longer a regression at any size.

**12-looker build stage** — the \"Build fracadd circuits\" span inside intmul phase 5:

| log(mults) | before | after |
|---|---|---|
| 18 | 32.8 ms | 11.7 ms (2.8×) |
| 20 | 74.8 ms | 52.1 ms (1.4×) |

At $2^{20}$ the stage is memory-bandwidth bound (~200 MB of layer traffic), so the fan-out gain compresses.

**Serial builds** (no `rayon` feature): unchanged or slightly better — 21.0 → 17.8 µs, 315 → 306 µs, and within noise at `n_vars=20`.

The span numbers come from a throwaway tracing-forest harness that is not part of this PR; for the interested reader it is reproduced below (drop it in `crates/prover/tests/`, add `tracing-forest.workspace = true` and `tracing-subscriber.workspace = true` to that crate's dev-dependencies, and run `cargo test -p binius-prover --release --features rayon --test phase5_profile -- --nocapture`).

<details>
<summary>phase5_profile.rs — the span-timing harness</summary>

```rust
// Temporary profiling harness for BINIUS-218 analysis. NOT for commit.
//
// Runs intmul phases 1-5 at a configurable size and prints the tracing-forest
// timing tree, so the logup* witness spans inside phase 5 can be compared.
//
// Run: cargo test -p binius-prover --release --features rayon --test phase5_profile -- --nocapture

use binius_core::word::Word;
use binius_field::{BinaryField128bGhash, PackedBinaryGhash1x128b};
use binius_hash::StdHashSuite;
use binius_iop::{
	basefold::compiler::BaseFoldVerifierCompiler, channel::OracleSpec, fri::MinProofSizeStrategy,
	merkle_tree::BinaryMerkleTreeScheme,
};
use binius_iop_prover::basefold::compiler::BaseFoldProverCompiler;
use binius_math::{
	multilinear::evaluate::evaluate,
	ntt::{NeighborsLastSingleThread, domain_context::GenericPreExpanded},
	test_utils::random_scalars,
};
use binius_prover::protocols::intmul::{prove::IntMulProver, witness::Witness};
use binius_transcript::ProverTranscript;
use binius_verifier::{
	config::StdChallenger,
	protocols::intmul::common::{LIMB_BITS, frobenius_twist},
};
use rand::prelude::*;
use tracing::level_filters::LevelFilter;
use tracing_forest::ForestLayer;
use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};

type P = PackedBinaryGhash1x128b;
type F = BinaryField128bGhash;

const LOG_NUM: usize = 20;
const LOG_INV_RATE: usize = 1;
const N_TEST_QUERIES: usize = 1;

fn generate_test_data(log_num: usize) -> (Vec<Word>, Vec<Word>, Vec<Word>, Vec<Word>) {
	let num_exponents = 1 << log_num;
	let mut rng = StdRng::seed_from_u64(0);
	let mut a = Vec::with_capacity(num_exponents);
	let mut b = Vec::with_capacity(num_exponents);
	let mut c_lo = Vec::with_capacity(num_exponents);
	let mut c_hi = Vec::with_capacity(num_exponents);
	for _ in 0..num_exponents {
		let a_i = rng.random_range(1..u64::MAX);
		let b_i = rng.random_range(1..u64::MAX);
		let full = (a_i as u128) * (b_i as u128);
		a.push(Word::from_u64(a_i));
		b.push(Word::from_u64(b_i));
		c_lo.push(Word::from_u64(full as u64));
		c_hi.push(Word::from_u64((full >> 64) as u64));
	}
	(a, b, c_lo, c_hi)
}

#[test]
fn profile_phase5() {
	let env_filter = EnvFilter::builder()
		.with_default_directive(LevelFilter::DEBUG.into())
		.from_env_lossy();
	let _ = tracing_subscriber::registry()
		.with(env_filter)
		.with(ForestLayer::default())
		.try_init();

	let (a, b, c_lo, c_hi) = generate_test_data(LOG_NUM);
	let witness = Witness::<P>::new(&a, &b, &c_lo, &c_hi).unwrap();

	let n_vars = witness.b_root.log_len();
	let initial_eval_point = random_scalars::<F>(&mut StdRng::seed_from_u64(1), n_vars);
	let exp_eval = evaluate(&witness.b_root, &initial_eval_point);

	let phase1 = {
		let mut transcript = ProverTranscript::new(StdChallenger::default());
		let mut prover = IntMulProver::<P, _>::new(0, &mut transcript);
		prover.phase1(&initial_eval_point, witness.b_prodcheck.clone(), &witness.b_leaves, exp_eval)
	};
	let phase2 = frobenius_twist(Word::LOG_BITS, &phase1.eval_point, &phase1.b_leaves_evals);
	let phase3 = {
		let mut transcript = ProverTranscript::new(StdChallenger::default());
		let mut prover = IntMulProver::<P, _>::new(0, &mut transcript);
		prover.phase3(
			&phase2.twisted_eval_points,
			&phase2.twisted_evals,
			witness.a_root.clone(),
			witness.b_exponents,
			[witness.c_lo_root.clone(), witness.c_hi_root.clone()],
			&initial_eval_point,
			exp_eval,
		)
	};
	let phase4 = {
		let mut transcript = ProverTranscript::new(StdChallenger::default());
		let mut prover = IntMulProver::<P, _>::new(0, &mut transcript);
		prover.phase4(
			&phase3.eval_point,
			(phase3.gpow_a_eval, witness.a_prodcheck.clone()),
			(phase3.gpow_c_lo_eval, witness.c_lo_prodcheck.clone()),
			(phase3.gpow_c_hi_eval, witness.c_hi_prodcheck.clone()),
			[
				witness.a_exponents,
				witness.c_lo_exponents,
				witness.c_hi_exponents,
			],
			&witness.tables,
		)
	};

	let verifier_compiler = BaseFoldVerifierCompiler::new(
		BinaryMerkleTreeScheme::<F, StdHashSuite>::new(),
		vec![OracleSpec::new(LIMB_BITS)],
		LOG_INV_RATE,
		N_TEST_QUERIES,
		&MinProofSizeStrategy,
	);
	let domain_context =
		GenericPreExpanded::generate_from_subspace(verifier_compiler.max_subspace());
	let ntt = NeighborsLastSingleThread::new(domain_context);
	let compiler = BaseFoldProverCompiler::<P, _>::from_verifier_compiler(&verifier_compiler, ntt);

	// Two timed runs of phase 5 (first warms allocators/caches).
	for run in 0..2 {
		let mut channel = compiler
			.create_channel_without_zk_from_transcript::<StdHashSuite, StdChallenger, _>(
				ProverTranscript::default(),
			);
		let span = tracing::info_span!("phase5", run, log_num = LOG_NUM);
		let _guard = span.enter();
		let mut prover = IntMulProver::<P, _>::new(0, &mut channel);
		let _ = prover.phase5(
			&phase4,
			witness.b_exponents,
			&phase3.eval_point,
			&phase3.r_ib,
			phase3.b_recomb,
			witness.a_exponents,
			witness.c_lo_exponents,
			witness.c_hi_exponents,
			&witness.tables[0],
		);
	}
}
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)