### PR TITLE
BINIUS-329: derive the AND-reduction C operand on the fly instead of materializing it

### DIFF
--- a/crates/m4-prover/src/operand_witness.rs
+++ b/crates/m4-prover/src/operand_witness.rs
@@ -2,11 +2,12 @@
 
 //! The batched operand-column witnesses built from a populated batch value table.
 //!
-//! Every AND, IMUL, and BMUL constraint is projected to its fixed-arity operand columns (`[A, B,
-//! C]` for AND, `[A, B, HI, LO]` for IMUL, `[A_LO, A_HI, B_LO, B_HI, C_LO, C_HI]` for BMUL), one
+//! Every AND, IMUL, and BMUL constraint is projected to its fixed-arity operand columns (`[A, B]`
+//! for AND, `[A, B, HI, LO]` for IMUL, `[A_LO, A_HI, B_LO, B_HI, C_LO, C_HI]` for BMUL), one
 //! column per operand, stacked over every instance in the batch. [`build_operation_witness`] is the
 //! shared arity-generic core: it projects one operand per constraint into one column.
-//! [`BatchAndCheckWitness`] builds the three AND columns and drives the AND-check zerocheck;
+//! [`BatchAndCheckWitness`] builds the two AND columns and drives the AND-check zerocheck.
+//! The AND check's C column is never materialized: the reduction derives `C = A & B` on the fly.
 //! [`build_intmul_witness`] builds the four IntMul columns; [`build_binmul_witness`] builds the six
 //! BinMul columns.
 
@@ -36,10 +37,12 @@ use crate::ValueTable;
 
 /// The operand columns of the BitAnd check for a whole batch of instances.
 ///
-/// The BitAnd check works on three columns of words, one row per AND constraint.
-/// It enforces the bitwise relation `A & B == C` on every row.
+/// The BitAnd check works on the operand columns of `A & B == C`, one row per AND constraint.
+/// Only `A` and `B` are held.
+/// On a satisfying witness `C = A & B` holds word-by-word.
+/// So the reduction derives `C` on the fly and the column is never materialized.
 ///
-/// This holds those three columns for a batch of `K = 2^log_instances` instances at once.
+/// This holds the two columns for a batch of `K = 2^log_instances` instances at once.
 /// The rows are stacked in constraint-major order, with the constraint index on the high
 /// coordinates:
 ///
@@ -47,7 +50,6 @@ use crate::ValueTable;
 ///      constraint 0         constraint 1          constraint n_and-1
 ///   A: [ a_0 .. a_{K-1} ][ a_0 .. a_{K-1} ] ... [ a_0 .. a_{K-1} ]
 ///   B: [ b_0 .. b_{K-1} ][ b_0 .. b_{K-1} ] ... [ b_0 .. b_{K-1} ]
-///   C: [ c_0 .. c_{K-1} ][ c_0 .. c_{K-1} ] ... [ c_0 .. c_{K-1} ]
 ///       \____ K ____/
 /// ```
 ///
@@ -69,16 +71,16 @@ pub struct BatchAndCheckWitness {
 	a: Vec<Word>,
 	/// Operand `B` of every constraint of every instance, constraint-major.
 	b: Vec<Word>,
-	/// Operand `C` of every constraint of every instance, constraint-major.
-	c: Vec<Word>,
 }
 
 impl BatchAndCheckWitness {
 	/// Builds the batched BitAnd witness from a populated wire-major batch table.
 	///
-	/// Every AND constraint contributes one row per instance to each of the three operand
-	/// columns `A`, `B`, `C`, laid out constraint-major. This delegates to the arity-generic
-	/// `build_operation_witness`, projecting each constraint to its three operands.
+	/// Every AND constraint contributes one row per instance to the `A` and `B` columns.
+	/// The rows are laid out constraint-major.
+	/// This delegates to the arity-generic column builder, one call per operand.
+	/// The constraint's `C` operand is never evaluated.
+	/// The reduction derives `C = A & B` instead.
 	///
 	/// # Arguments
 	///
@@ -103,14 +105,7 @@ impl BatchAndCheckWitness {
 			|| build_operation_witness(table, constants, b_operand_iter),
 		);
 
-		// Instead of constructing c from the original word Vec, it's cheaper to compute it from the
-		// constraint relation.
-		let c = (a.as_slice(), b.as_slice())
-			.into_par_iter()
-			.map(|(&a_i, &b_i)| a_i & b_i)
-			.collect();
-
-		Self { a, b, c }
+		Self { a, b }
 	}
 
 	/// Operand `A` column, `K * n_and` rows in constraint-major order.
@@ -123,16 +118,11 @@ impl BatchAndCheckWitness {
 		&self.b
 	}
 
-	/// Operand `C` column, `K * n_and` rows in constraint-major order.
-	pub fn c(&self) -> &[Word] {
-		&self.c
-	}
-
-	/// Consumes the witness into its three operand columns `(A, B, C)`.
+	/// Consumes the witness into its two operand columns `(A, B)`.
 	///
 	/// This is the shape the AND reduction destructures to drive its sumcheck.
-	pub fn into_columns(self) -> (Vec<Word>, Vec<Word>, Vec<Word>) {
-		(self.a, self.b, self.c)
+	pub fn into_columns(self) -> (Vec<Word>, Vec<Word>) {
+		(self.a, self.b)
 	}
 
 	/// Proves the batched BitAnd check: `A & B == C` on every row of every instance.
@@ -158,7 +148,7 @@ impl BatchAndCheckWitness {
 	/// This reuses the single-instance kernel verbatim, only over `K * n_and` rows.
 	/// The block-diagonal batch structure is exploited later, in the lincheck, not here.
 	///
-	/// The reduction folds the three bit-columns into one multilinear evaluation point.
+	/// The reduction folds `A`, `B`, and the derived `C = A & B` to one evaluation point.
 	/// It returns the claimed evaluations of `A`, `B`, `C` at that point.
 	/// A later shift reduction ties those claims back to the committed witness.
 	///
@@ -187,7 +177,7 @@ impl BatchAndCheckWitness {
 		P: PackedField<Scalar = B128>,
 		Channel: IPProverChannel<B128>,
 	{
-		let (a, b, c) = self.into_columns();
+		let (a, b) = self.into_columns();
 
 		// X has `log_instances + log(n_and)` coordinates: the row count is a power of two.
 		let log_total_constraints = checked_log_2(a.len());
@@ -207,7 +197,6 @@ impl BatchAndCheckWitness {
 			log_total_constraints,
 			a,
 			b,
-			c,
 			big_field_zerocheck_challenges,
 			prover_message_domain.isomorphic(),
 		);
@@ -683,19 +672,16 @@ mod tests {
 
 	// The reference for one instance: the core operand evaluator on its reconstructed value vec.
 	// This is exactly what the single-instance BitAnd witness builder computes.
-	fn reference_rows(
-		and_constraints: &[AndConstraint],
-		vv: &ValueVec,
-	) -> (Vec<Word>, Vec<Word>, Vec<Word>) {
+	// Only the `A` and `B` columns exist.
+	// The batch witness derives `C = A & B` rather than storing it.
+	fn reference_rows(and_constraints: &[AndConstraint], vv: &ValueVec) -> (Vec<Word>, Vec<Word>) {
 		let mut a = Vec::new();
 		let mut b = Vec::new();
-		let mut c = Vec::new();
 		for constraint in and_constraints {
 			a.push(vv.eval_operand(&constraint.a));
 			b.push(vv.eval_operand(&constraint.b));
-			c.push(vv.eval_operand(&constraint.c));
 		}
-		(a, b, c)
+		(a, b)
 	}
 
 	// The reference columns across the whole batch, transposed to the batch witness's
@@ -705,22 +691,20 @@ mod tests {
 		table: &ValueTable,
 		constants: &[Word],
 		and_constraints: &[AndConstraint],
-	) -> (Vec<Word>, Vec<Word>, Vec<Word>) {
+	) -> (Vec<Word>, Vec<Word>) {
 		let n_and = and_constraints.len();
 		let n_instances = table.n_instances();
 		let mut a = vec![Word::ZERO; n_and * n_instances];
 		let mut b = vec![Word::ZERO; n_and * n_instances];
-		let mut c = vec![Word::ZERO; n_and * n_instances];
 		for instance in 0..n_instances {
 			let vv = table.instance_value_vec(instance, constants);
-			let (a_ref, b_ref, c_ref) = reference_rows(and_constraints, &vv);
+			let (a_ref, b_ref) = reference_rows(and_constraints, &vv);
 			for j in 0..n_and {
 				a[j * n_instances + instance] = a_ref[j];
 				b[j * n_instances + instance] = b_ref[j];
-				c[j * n_instances + instance] = c_ref[j];
 			}
 		}
-		(a, b, c)
+		(a, b)
 	}
 
 	#[test]
@@ -743,13 +727,11 @@ mod tests {
 		let n_and = and_constraints.len();
 		assert_eq!(witness.a().len(), 4 * n_and);
 		assert_eq!(witness.b().len(), 4 * n_and);
-		assert_eq!(witness.c().len(), 4 * n_and);
 
 		// Invariant: row `j * n_instances + instance` is constraint `j` of that instance.
-		let (a_ref, b_ref, c_ref) = reference_columns(&table, constants(&c), and_constraints);
+		let (a_ref, b_ref) = reference_columns(&table, constants(&c), and_constraints);
 		assert_eq!(witness.a(), a_ref.as_slice());
 		assert_eq!(witness.b(), b_ref.as_slice());
-		assert_eq!(witness.c(), c_ref.as_slice());
 	}
 
 	// A circuit computing one unsigned 64×64→128 product, with both result words committed.
@@ -937,23 +919,6 @@ mod tests {
 	}
 
 	#[test]
-	fn and_relation_holds_on_every_row() {
-		let c = and_circuit();
-
-		// Fixture state: 4 satisfying instances, each tuple `(x, y, w)`.
-		let table = populate_table(&c, &[(1, 3, 7), (5, 6, 0), (9, 12, 0xFF), (0xF0, 0x0F, 1)]);
-		let witness = BatchAndCheckWitness::build(&table, constants(&c), &table_constraints(&c));
-
-		// The single AND constraint is `and = x & y`, so each row is `A=x`, `B=y`, `C=x&y`.
-		// A satisfying witness therefore makes `A & B == C` hold on every row.
-		//
-		// Padded rows have empty operands, so `0 & 0 == 0` holds there too.
-		for ((a, b), c) in witness.a().iter().zip(witness.b()).zip(witness.c()) {
-			assert_eq!(a.0 & b.0, c.0);
-		}
-	}
-
-	#[test]
 	fn single_instance_batch_matches_the_reference() {
 		let c = and_circuit();
 
@@ -964,10 +929,9 @@ mod tests {
 
 		// The degenerate batch reproduces the single-instance BitAnd columns exactly.
 		let vv = table.instance_value_vec(0, constants(&c));
-		let (a_ref, b_ref, c_ref) = reference_rows(&and_constraints, &vv);
+		let (a_ref, b_ref) = reference_rows(&and_constraints, &vv);
 		assert_eq!(witness.a(), a_ref.as_slice());
 		assert_eq!(witness.b(), b_ref.as_slice());
-		assert_eq!(witness.c(), c_ref.as_slice());
 	}
 
 	#[test]
@@ -995,7 +959,6 @@ mod tests {
 		//     witness[j * n_instances + instance]  ==  eval_operand(instance value vec, constraint j)
 		//
 		// This pins the batched, slice-based evaluator to the core value-vec evaluator.
-		// And since each instance is satisfying, the AND relation `A & B == C` holds on every row.
 		#[test]
 		fn batch_rows_match_single_instance_reference(
 			inputs in prop::collection::vec((any::<u64>(), any::<u64>(), any::<u64>()), 4),
@@ -1006,15 +969,9 @@ mod tests {
 			let and_constraints = table_constraints(&c);
 			let witness = BatchAndCheckWitness::build(&table, constants(&c),&and_constraints);
 
-			let (a_ref, b_ref, c_ref) = reference_columns(&table, constants(&c), &and_constraints);
+			let (a_ref, b_ref) = reference_columns(&table, constants(&c), &and_constraints);
 			prop_assert_eq!(witness.a(), a_ref.as_slice());
 			prop_assert_eq!(witness.b(), b_ref.as_slice());
-			prop_assert_eq!(witness.c(), c_ref.as_slice());
-
-			// The built columns satisfy the AND constraint on every row, padding included.
-			for ((a, b), c) in witness.a().iter().zip(witness.b()).zip(witness.c()) {
-				prop_assert_eq!(a.0 & b.0, c.0);
-			}
 		}
 	}
 
@@ -1035,10 +992,9 @@ mod tests {
 
 		// Every instance's contribution equals its independent single-instance reference.
 		// This includes instances at or beyond STRIPE_WIDTH, which only the second stripe produces.
-		let (a_ref, b_ref, c_ref) = reference_columns(&table, constants(&c), &and_constraints);
+		let (a_ref, b_ref) = reference_columns(&table, constants(&c), &and_constraints);
 		assert_eq!(witness.a(), a_ref.as_slice());
 		assert_eq!(witness.b(), b_ref.as_slice());
-		assert_eq!(witness.c(), c_ref.as_slice());
 	}
 
 	#[test]
@@ -1053,9 +1009,9 @@ mod tests {
 		// The circuit compiler emits unshifted operands here, so the shifted branch of the
 		// accumulator would otherwise go untested by this module.
 		//
-		// The `c` operand is deliberately unrelated to `a & b`: `BatchAndCheckWitness::build`
-		// derives `c` from `a` and `b` rather than evaluating the constraint's `c` operand, so this
-		// fixture need not satisfy the AND relation to exercise `a` and `b`'s shift handling.
+		// The `c` operand is deliberately unrelated to `a & b`.
+		// The batch witness builder never evaluates a constraint's `c` operand.
+		// So this fixture need not satisfy the AND relation to exercise the shift handling.
 		let x = c.circuit.witness_index(c.x);
 		let y = c.circuit.witness_index(c.y);
 		let z = c.circuit.witness_index(c.z);
@@ -1083,14 +1039,9 @@ mod tests {
 		let witness = BatchAndCheckWitness::build(&table, constants(&c), &and_constraints);
 
 		// `a` and `b` equal the shift-aware value-vec reference for the same constraints.
-		let (a_ref, b_ref, _) = reference_columns(&table, constants(&c), &and_constraints);
+		let (a_ref, b_ref) = reference_columns(&table, constants(&c), &and_constraints);
 		assert_eq!(witness.a(), a_ref.as_slice());
 		assert_eq!(witness.b(), b_ref.as_slice());
-
-		// `c` is defined as `a & b`, not evaluated from the constraint's `c` operand.
-		for ((a, b), c) in witness.a().iter().zip(witness.b()).zip(witness.c()) {
-			assert_eq!(a.0 & b.0, c.0);
-		}
 	}
 
 	#[test]
@@ -1181,9 +1132,14 @@ mod tests {
 			let witness = BatchAndCheckWitness::build(&table, constants(&c),&and_constraints);
 
 			// Keep the columns so the claimed evals can be checked against them.
+			// The witness stores no C column.
+			// Materialize the same derived `a & b` words the reduction folds.
+			// The claimed C evaluation is then pinned to that exact column.
 			let a_cols = witness.a().to_vec();
 			let b_cols = witness.b().to_vec();
-			let c_cols = witness.c().to_vec();
+			let c_cols: Vec<Word> = iter::zip(witness.a(), witness.b())
+				.map(|(&a, &b)| a & b)
+				.collect();
 			let log_total = checked_log_2(witness.a().len());
 
 			let mut prover_transcript = ProverTranscript::new(StdChallenger::default());

--- a/crates/m4-prover/src/prove.rs
+++ b/crates/m4-prover/src/prove.rs
@@ -202,11 +202,15 @@ impl IOPProver {
 				BatchAndCheckWitness::build(table, &cs.constants, &cs.and_constraints)
 			};
 			let and_columns = (mul.is_some() || bmul.is_some()).then(|| {
-				[
-					and_witness.a().to_vec(),
-					and_witness.b().to_vec(),
-					and_witness.c().to_vec(),
-				]
+				// The re-randomization re-reads the three BitAnd operand columns.
+				// Only `A` and `B` are stored.
+				// On a satisfying witness `C = A & B` holds word-by-word.
+				// So `C` is materialized here, on this multiplication-only path.
+				let c_column = (and_witness.a(), and_witness.b())
+					.into_par_iter()
+					.map(|(&a_i, &b_i)| a_i & b_i)
+					.collect();
+				[and_witness.a().to_vec(), and_witness.b().to_vec(), c_column]
 			});
 			(and_columns, and_witness.prove::<P, _>(&andcheck_domain, channel))
 		};

--- a/crates/m4-prover/src/shift.rs
+++ b/crates/m4-prover/src/shift.rs
@@ -278,6 +278,8 @@ pub fn build_g_parts_from_folded_words<F: BinaryField>(
 
 #[cfg(test)]
 mod tests {
+	use std::iter;
+
 	use binius_core::{constraint_system::AndConstraint, verify::verify_constraints, word::Word};
 	use binius_field::{AESTowerField8b, Field, PackedBinaryGhash1x128b, Random};
 	use binius_math::{
@@ -455,10 +457,16 @@ mod tests {
 			let folded_column = fold_words::<B128, P>(column, &lagrange);
 			evaluate(&folded_column, &row_point)
 		};
+		// The batch witness stores only the `A` and `B` columns.
+		// The reduction reads `C` as the word-by-word AND of the two.
+		// Materialize that same derived column so its evaluation matches the reduction's claim.
+		let c_column: Vec<Word> = iter::zip(witness.a(), witness.b())
+			.map(|(&a, &b)| a & b)
+			.collect();
 		[
 			operand_eval(witness.a()),
 			operand_eval(witness.b()),
-			operand_eval(witness.c()),
+			operand_eval(&c_column),
 		]
 	}
 

--- a/crates/prover/benches/and_reduction.rs
+++ b/crates/prover/benches/and_reduction.rs
@@ -1,5 +1,5 @@
 // Copyright 2025 Irreducible Inc.
-use std::{iter, iter::repeat_with};
+use std::iter::repeat_with;
 
 use binius_core::word::Word;
 use binius_field::{Field, Random};
@@ -35,9 +35,6 @@ fn bench(c: &mut Criterion) {
 	let b_words: Vec<Word> = repeat_with(|| Word(rng.random()))
 		.take(1 << log_words)
 		.collect();
-	let c_words: Vec<Word> = iter::zip(&a_words, &b_words)
-		.map(|(&a, &b)| a & b)
-		.collect();
 
 	let prover_message_domain = BinarySubspace::with_dim(SKIPPED_VARS + 1);
 
@@ -57,7 +54,6 @@ fn bench(c: &mut Criterion) {
 				log_words,
 				&a_words,
 				&b_words,
-				&c_words,
 				&big_field_zerocheck_challenges,
 				&prover_message_domain,
 			)
@@ -68,7 +64,6 @@ fn bench(c: &mut Criterion) {
 		log_words,
 		&a_words,
 		&b_words,
-		&c_words,
 		&big_field_zerocheck_challenges,
 		&prover_message_domain,
 	);
@@ -78,14 +73,13 @@ fn bench(c: &mut Criterion) {
 		bench.iter(|| {
 			let lagrange_evals = lagrange_evals_scalars(&univariate_domain, univariate_challenge);
 			let folder = BitAxisFolder::new(&lagrange_evals);
-			[&a_words, &b_words, &c_words].map(|mlv| folder.fold::<OptimalPackedB128>(mlv))
+			folder.fold_bitand_operands::<OptimalPackedB128>(&a_words, &b_words)
 		});
 	});
 
 	let lagrange_evals = lagrange_evals_scalars(&univariate_domain, univariate_challenge);
 	let folder = BitAxisFolder::new(&lagrange_evals);
-	let proving_polys =
-		[&a_words, &b_words, &c_words].map(|mlv| folder.fold::<OptimalPackedB128>(mlv));
+	let proving_polys = folder.fold_bitand_operands::<OptimalPackedB128>(&a_words, &b_words);
 
 	let mut univariate_message_coeffs = vec![B128::ZERO; 2 * ROWS_PER_HYPERCUBE_VERTEX];
 	univariate_message_coeffs[ROWS_PER_HYPERCUBE_VERTEX..2 * ROWS_PER_HYPERCUBE_VERTEX]

--- a/crates/prover/src/and_reduction/prover.rs
+++ b/crates/prover/src/and_reduction/prover.rs
@@ -39,7 +39,6 @@ where
 	log_words: usize,
 	first_col: Data,
 	second_col: Data,
-	third_col: Data,
 	big_field_zerocheck_challenges: Vec<FChallenge>,
 	univariate_round_message: [FChallenge; ROWS_PER_HYPERCUBE_VERTEX],
 	univariate_round_message_domain: BinarySubspace<FChallenge>,
@@ -58,12 +57,23 @@ where
 	/// that will be sent in the first round. The polynomial encodes the AND constraint verification
 	/// across all values in the oblong dimension.
 	///
+	/// The C operand of the AND constraint `A & B ^ C = 0` is not an input.
+	/// The prover derives it word-by-word as `A & B`.
+	///
+	/// # Why deriving C is sound
+	///
+	/// - A satisfying witness makes `C = A & B` hold on every row.
+	/// - Folding is F2-linear on word bits.
+	/// - Equal words therefore fold to equal field elements.
+	/// - So an honest prover emits the exact same transcript as with an explicit C column.
+	/// - A cheating witness is still rejected.
+	/// - The shift reduction later checks the claimed C evaluation against the committed witness.
+	///
 	/// # Arguments
 	///
 	/// * `log_words` - Base-2 logarithm of the number of words in each column
 	/// * `first_col` - The oblong multilinear polynomial A in the AND constraint A & B ^ C = 0
 	/// * `second_col` - The oblong multilinear polynomial B in the AND constraint
-	/// * `third_col` - The oblong multilinear polynomial C in the AND constraint
 	/// * `big_field_zerocheck_challenges` - Challenges Z_{k+1},...,Zₙ in the large field FChallenge
 	/// * `prover_message_domain` - The domain for evaluating the univariate polynomial
 	///
@@ -73,12 +83,10 @@ where
 	/// 1. Computes the equality indicator polynomial from the big field challenges
 	/// 2. Uses the NTT lookup to efficiently compute the univariate polynomial evaluations
 	/// 3. Caches these evaluations for later use in the execute() method
-	#[allow(clippy::too_many_arguments)]
 	pub fn new(
 		log_words: usize,
 		first_col: Data,
 		second_col: Data,
-		third_col: Data,
 		big_field_zerocheck_challenges: Vec<F>,
 		prover_message_domain: BinarySubspace<B8>,
 	) -> Self {
@@ -88,7 +96,6 @@ where
 					log_words,
 					&first_col,
 					&second_col,
-					&third_col,
 					&big_field_zerocheck_challenges,
 					&prover_message_domain,
 				)
@@ -98,7 +105,6 @@ where
 			log_words,
 			first_col,
 			second_col,
-			third_col,
 			univariate_round_message,
 			big_field_zerocheck_challenges,
 			univariate_round_message_domain: prover_message_domain.isomorphic(),
@@ -149,7 +155,7 @@ where
 	/// # Process
 	///
 	/// 1. Creates a fold lookup table for efficiently folding at the challenge point
-	/// 2. Folds each of the three oblong multilinears (A, B, C) at Z = challenge
+	/// 2. Folds A, B, and the derived C = A & B at Z = challenge, in one fused pass
 	/// 3. Combines the zerocheck challenges (small field + big field)
 	/// 4. Evaluates the univariate polynomial at the challenge to get the sumcheck claim
 	/// 5. Constructs the AND reduction sumcheck prover with the folded multilinears
@@ -162,8 +168,8 @@ where
 		let lagrange_evals = lagrange_evals_scalars(&univariate_domain, challenge);
 		let folder = BitAxisFolder::new(&lagrange_evals);
 
-		let proving_polys = [&self.first_col, &self.second_col, &self.third_col]
-			.map(|col| folder.fold::<PChallenge>(col));
+		let proving_polys =
+			folder.fold_bitand_operands::<PChallenge>(&self.first_col, &self.second_col);
 
 		let upcasted_small_field_challenges = PROVER_SMALL_FIELD_ZEROCHECK_CHALLENGES
 			.iter()
@@ -299,6 +305,8 @@ mod test {
 		];
 		let first_mlv = random_words(log_num_rows, &mut rng);
 		let second_mlv = random_words(log_num_rows, &mut rng);
+		// The prover receives only the A and B columns.
+		// This materialized C = A & B feeds only the verifier-side fold check at the end.
 		let third_mlv: Vec<Word> = iter::zip(&first_mlv, &second_mlv)
 			.map(|(&a, &b)| a & b)
 			.collect();
@@ -315,7 +323,6 @@ mod test {
 			log_num_rows,
 			pool_words(&pool, &first_mlv),
 			pool_words(&pool, &second_mlv),
-			pool_words(&pool, &third_mlv),
 			big_field_zerocheck_challenges.to_vec(),
 			prover_message_domain,
 		);

--- a/crates/prover/src/and_reduction/sumcheck_round_messages.rs
+++ b/crates/prover/src/and_reduction/sumcheck_round_messages.rs
@@ -42,12 +42,16 @@ use crate::fold_word::duplicate_to_fixed_chunks;
 /// sends only enough values such that the verifier learns a domain of evaluations of size >
 /// deg(R₀(Z))
 ///
+/// The product constraint column C is not an input.
+/// Each C word is derived in registers as the AND of the matching A and B words.
+/// A satisfying witness makes that derivation exact on every row.
+/// So no third column is ever built or streamed.
+///
 /// # Arguments
 ///
 /// * `log_words` - Base-2 logarithm of the number of words in each column
 /// * `a_words` - First multiplicand (a) as a one-bit oblong multilinear polynomial
 /// * `b_words` - Second multiplicand (b) as a one-bit oblong multilinear polynomial
-/// * `c_words` - Product constraint (c) as a one-bit oblong multilinear polynomial
 /// * `eq_ind_big_field_challenges` - Partial equality indicator evaluations for big field variables
 /// * `prover_message_domain` - The NTT domain subspace (dimension `SKIPPED_VARS + 1`) from which
 ///   the low-degree-extension lookup table is built internally
@@ -65,7 +69,6 @@ pub fn univariate_round_message_extension_domain<F>(
 	log_words: usize,
 	a_words: &[Word],
 	b_words: &[Word],
-	c_words: &[Word],
 	big_field_challenges: &[F],
 	prover_message_domain: &BinarySubspace<B8>,
 ) -> [F; ROWS_PER_HYPERCUBE_VERTEX]
@@ -78,7 +81,7 @@ where
 	const LOG_CHUNK_SIZE: usize = N_FIXED_SMALL_CHALLENGES + N_FIXED_LARGE_CHALLENGES;
 
 	assert_eq!(big_field_challenges.len(), log_words.saturating_sub(N_FIXED_SMALL_CHALLENGES));
-	for col in [a_words, b_words, c_words] {
+	for col in [a_words, b_words] {
 		assert_eq!(col.len(), 1 << log_words);
 	}
 
@@ -256,6 +259,8 @@ mod test {
 		let log_num_words = log_num_rows - SKIPPED_VARS;
 		let mlv_1 = random_words(log_num_words, &mut rng);
 		let mlv_2 = random_words(log_num_words, &mut rng);
+		// The round message derives C = A & B internally.
+		// This materialized copy feeds only the verifier-side transparent fold below.
 		let mlv_3: Vec<Word> = iter::zip(&mlv_1, &mlv_2).map(|(&a, &b)| a & b).collect();
 
 		// Agreed-upon proof parameter
@@ -269,7 +274,6 @@ mod test {
 			log_num_words,
 			&mlv_1,
 			&mlv_2,
-			&mlv_3,
 			&big_field_zerocheck_challenges,
 			&prover_message_domain,
 		);

--- a/crates/prover/src/fold_word.rs
+++ b/crates/prover/src/fold_word.rs
@@ -151,6 +151,117 @@ impl<UOut: UnderlierType> LinearTransformationFactory<u64, UOut>
 	}
 }
 
+/// Folds two operand word-lists and their word-by-word bitwise AND in one pass.
+///
+/// # Overview
+///
+/// The BitAnd zerocheck folds three columns of the constraint `A & B = C`.
+/// On a satisfying witness the third column equals the AND of the first two.
+/// So this fold reads only the two stored columns and derives the third in registers:
+///
+/// ```text
+///     stream A ──┬──> fold ──> folded A
+///     stream B ──┼──> fold ──> folded B
+///                └──> A & B ──> fold ──> folded C   (no third input stream)
+/// ```
+///
+/// Each output equals [`fold_words_with_transform`] on the corresponding word-list.
+///
+/// # Performance
+///
+/// - Two input streams instead of three.
+/// - Two register ANDs per word pair replace one memory stream.
+/// - The bytewise lookup tables stay hot across all three outputs.
+///
+/// # Preconditions
+///
+/// * The two word-lists have equal length.
+fn fold_bitand_operands_with_transform<F, P, T>(
+	transform: &T,
+	a_words: &[Word],
+	b_words: &[Word],
+) -> [FieldBuffer<P>; 3]
+where
+	F: Field,
+	P: PackedField<Scalar = F>,
+	T: Transformation<u64, F>,
+{
+	assert_eq!(a_words.len(), b_words.len());
+
+	// Padding contract, mirrored from the single-column fold:
+	// the high words up to the next power of two read as zero.
+	// `0 & 0 = 0`, so the derived column stays consistent over that padding.
+	let log_n = log2_ceil_usize(a_words.len());
+	let capacity = 1 << log_n.saturating_sub(P::LOG_WIDTH);
+
+	// One output buffer per folded column, filled through spare capacity.
+	let mut a_values = Vec::<P>::with_capacity(capacity);
+	let mut b_values = Vec::<P>::with_capacity(capacity);
+	let mut c_values = Vec::<P>::with_capacity(capacity);
+
+	// Phase 1: partition the inputs into full packed-width chunks and a short tail.
+	//
+	//     words:  [ chunk 0 | chunk 1 | ... | chunk n-1 | tail (< P::WIDTH) ]
+	let n_chunks = a_words.len() / P::WIDTH;
+	let (a_aligned, a_remaining) = a_words.split_at(n_chunks * P::WIDTH);
+	let (b_aligned, b_remaining) = b_words.split_at(n_chunks * P::WIDTH);
+
+	let a_out = &mut a_values.spare_capacity_mut()[..n_chunks];
+	let b_out = &mut b_values.spare_capacity_mut()[..n_chunks];
+	let c_out = &mut c_values.spare_capacity_mut()[..n_chunks];
+
+	// Phase 2: fold the aligned chunks in parallel.
+	// Each task owns one chunk of both inputs and writes one packed element per output.
+	(
+		a_out,
+		b_out,
+		c_out,
+		a_aligned.par_chunks_exact(P::WIDTH),
+		b_aligned.par_chunks_exact(P::WIDTH),
+	)
+		.into_par_iter()
+		.for_each(|(a_i, b_i, c_i, a_chunk, b_chunk)| {
+			// Safety:
+			// - both aligned slices have length n_chunks * P::WIDTH
+			// - both are split into P::WIDTH chunks
+			unsafe {
+				assert_unchecked(a_chunk.len() == P::WIDTH);
+				assert_unchecked(b_chunk.len() == P::WIDTH);
+			}
+			// Fold each stored column by bytewise table lookup.
+			a_i.write(P::from_scalars(a_chunk.iter().map(|&word| transform.transform(&word.0))));
+			b_i.write(P::from_scalars(b_chunk.iter().map(|&word| transform.transform(&word.0))));
+			// Derive the third column in registers, then fold it the same way.
+			c_i.write(P::from_scalars(
+				iter::zip(a_chunk, b_chunk).map(|(&a, &b)| transform.transform(&(a & b).0)),
+			));
+		});
+
+	// Safety: every one of the n_chunks slots of each vector is initialized above.
+	unsafe {
+		a_values.set_len(n_chunks);
+		b_values.set_len(n_chunks);
+		c_values.set_len(n_chunks);
+	}
+
+	// Phase 3: fold the short tail into one final packed element per output.
+	if !a_remaining.is_empty() {
+		a_values
+			.push(P::from_scalars(a_remaining.iter().map(|&word| transform.transform(&word.0))));
+		b_values
+			.push(P::from_scalars(b_remaining.iter().map(|&word| transform.transform(&word.0))));
+		c_values.push(P::from_scalars(
+			iter::zip(a_remaining, b_remaining).map(|(&a, &b)| transform.transform(&(a & b).0)),
+		));
+	}
+
+	// Phase 4: zero-pad each output up to the power-of-two capacity.
+	[a_values, b_values, c_values].map(|mut values| {
+		values.resize(capacity, P::default());
+		FieldBuffer::new(log_n, values)
+	})
+}
+
 /// The concrete transform [`BitAxisFolder`] folds each word through: the [`u64`]-specialized
 /// bytewise lookup, wrapped to output field elements of `F`.
 type BitAxisTransform<F> = OutputWrappingTransformation<
@@ -188,6 +299,27 @@ impl<F: BinaryField> BitAxisFolder<F> {
 		P: PackedField<Scalar = F>,
 	{
 		fold_words_with_transform(&self.transform, words)
+	}
+
+	/// Folds the two stored BitAnd operand columns and their derived AND column in one pass.
+	///
+	/// # Returns
+	///
+	/// Three folded buffers, in order:
+	/// - the first operand column, folded as by [`fold`](Self::fold).
+	/// - the second operand column, folded the same way.
+	/// - the word-by-word AND of the two columns, folded the same way.
+	///
+	/// The AND column is derived in registers and never written to memory.
+	///
+	/// # Preconditions
+	///
+	/// * The two word-lists have equal length.
+	pub fn fold_bitand_operands<P>(&self, a: &[Word], b: &[Word]) -> [FieldBuffer<P>; 3]
+	where
+		P: PackedField<Scalar = F>,
+	{
+		fold_bitand_operands_with_transform(&self.transform, a, b)
 	}
 }
 
@@ -570,6 +702,53 @@ mod tests {
 
 		// Compare results
 		assert_eq!(result_optimized, result_naive);
+	}
+
+	#[test]
+	fn test_fold_bitand_operands_matches_separate_folds() {
+		let mut rng = StdRng::seed_from_u64(0);
+
+		// Invariant: the fused three-output fold equals three independent single-column folds.
+		//
+		//     fused(A, B)  ==  [ fold(A), fold(B), fold(A & B) ]
+		//
+		// The single-column fold is itself pinned to a naive reference elsewhere in this module.
+		//
+		// Fixture state: word counts crossing every regime of the fused kernel.
+		//
+		//     0             → empty input, output is one zero element
+		//     1             → tail only, no aligned chunk
+		//     width         → exactly one aligned chunk, no tail
+		//     width + 1     → aligned chunk plus tail
+		//     4*width       → several aligned chunks
+		//     4*width + 3   → several chunks plus tail
+		//     40            → non-power-of-two, exercises the zero padding
+		let width = OptimalPackedB128::WIDTH;
+		for n_words in [0, 1, width, width + 1, 4 * width, 4 * width + 3, 40] {
+			// Two random operand columns of the chosen length.
+			let a_words = (0..n_words)
+				.map(|_| Word::from_u64(rng.random::<u64>()))
+				.collect::<Vec<_>>();
+			let b_words = (0..n_words)
+				.map(|_| Word::from_u64(rng.random::<u64>()))
+				.collect::<Vec<_>>();
+			// The reference third column, materialized word-by-word.
+			let c_words = iter::zip(&a_words, &b_words)
+				.map(|(&a, &b)| a & b)
+				.collect::<Vec<_>>();
+
+			// One random bit-weight vector shared by all folds.
+			let vec = random_scalars::<B128>(&mut rng, Word::BITS);
+			let folder = BitAxisFolder::new(&vec);
+
+			// Fold the two stored columns and the derived column in one fused pass.
+			let [a_fused, b_fused, c_fused] =
+				folder.fold_bitand_operands::<OptimalPackedB128>(&a_words, &b_words);
+			// Each fused output must equal the independent single-column fold.
+			assert_eq!(a_fused, folder.fold(&a_words), "a mismatch at n_words = {n_words}");
+			assert_eq!(b_fused, folder.fold(&b_words), "b mismatch at n_words = {n_words}");
+			assert_eq!(c_fused, folder.fold(&c_words), "c mismatch at n_words = {n_words}");
+		}
 	}
 
 	fn naive_fold_words_both_axes<F, P>(

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -494,7 +494,7 @@ where
 	Channel: binius_ip_prover::channel::IPProverChannel<F>,
 {
 	let prover_message_domain = BinarySubspace::<B8>::with_dim(Word::LOG_BITS + 1);
-	let AndCheckWitness { a, b, c } = witness;
+	let AndCheckWitness { a, b } = witness;
 
 	let log_constraint_count = checked_log_2(a.len());
 
@@ -506,7 +506,6 @@ where
 		log_constraint_count,
 		a,
 		b,
-		c,
 		big_field_zerocheck_challenges,
 		prover_message_domain.isomorphic(),
 	);
@@ -565,10 +564,14 @@ where
 	prove_binmul::<F, P, _>(&binmul_witness, channel)
 }
 
+/// The two materialized BitAnd operand columns.
+///
+/// The C operand column is not built.
+/// On a satisfying witness `C = A & B` holds word-by-word.
+/// So the AND reduction derives C from these two columns on the fly.
 struct AndCheckWitness<'alloc> {
 	a: PoolVec<'alloc, Word>,
 	b: PoolVec<'alloc, Word>,
-	c: PoolVec<'alloc, Word>,
 }
 
 struct MulCheckWitness<'alloc> {
@@ -596,24 +599,21 @@ fn build_bitand_witness<'alloc>(
 
 	let mut a = pool.alloc_vec::<Word>(n_constraints);
 	let mut b = pool.alloc_vec::<Word>(n_constraints);
-	let mut c = pool.alloc_vec::<Word>(n_constraints);
 
-	(and_constraints, a.spare_capacity_mut(), b.spare_capacity_mut(), c.spare_capacity_mut())
+	(and_constraints, a.spare_capacity_mut(), b.spare_capacity_mut())
 		.into_par_iter()
-		.for_each(|(constraint, a_i, b_i, c_i)| {
+		.for_each(|(constraint, a_i, b_i)| {
 			a_i.write(witness.eval_operand(&constraint.a));
 			b_i.write(witness.eval_operand(&constraint.b));
-			c_i.write(witness.eval_operand(&constraint.c));
 		});
 
-	// Safety: all entries in a, b, c are initialized in the parallel loop above.
+	// Safety: all entries in a and b are initialized in the parallel loop above.
 	unsafe {
 		a.set_len(n_constraints);
 		b.set_len(n_constraints);
-		c.set_len(n_constraints);
 	}
 
-	AndCheckWitness { a, b, c }
+	AndCheckWitness { a, b }
 }
 
 fn build_intmul_witness<'alloc>(


### PR DESCRIPTION
Closes [BINIUS-329](https://linear.app/jimpo/issue/BINIUS-329/stop-materializing-the-and-reduction-c-operand-derive-it-as-in).

Stops building and streaming the BitAnd C operand column; the prover derives `C = A & B` in registers wherever it is needed. Transcript-identical — proof bytes are unchanged.

### The problem

The BitAnd zerocheck proves `A & B == C` over one row per AND constraint.
The prover materialized all three operand columns as full word buffers, 8 bytes per row each.
The monolithic prover built C by evaluating its operand — a XOR of shifted witness words — for every constraint.
The univariate fold then streamed all three buffers through memory.
The prover is memory-bandwidth-bound on Apple Silicon, so every full-buffer build and stream is wall-clock time.

### The idea

On a satisfying witness, `C = A & B` holds word-by-word — that is the constraint itself.
So the C column carries no information: any consumer holding the A and B words recreates the C word with one register AND.
The round-1 univariate message already derived C this way internally; this PR completes the picture.

```
    stream A ──┬──> fold ──> folded A
    stream B ──┼──> fold ──> folded B
               └──> A & B ──> fold ──> folded C   (no third input stream)
```

### Per proof

- **before:** build C (one operand evaluation per constraint) + hold a third column + stream it in the fold → 3 input streams
- **after:** no C build, no C buffer, 2 input streams + one register AND per word pair

→ one full build pass deleted, fold traffic cut from 3 columns to 2, peak memory down by 8 bytes per constraint row.

### The change

```diff
-		let proving_polys = [&self.first_col, &self.second_col, &self.third_col]
-			.map(|col| folder.fold::<PChallenge>(col));
+		let proving_polys =
+			folder.fold_bitand_operands::<PChallenge>(&self.first_col, &self.second_col);
```

- `fold_word.rs`: new fused three-output fold over the two stored columns.
- `and_reduction`: the prover takes only A and B; the round-1 message drops its assert-only C parameter.
- monolithic `prove.rs`: the witness builder no longer evaluates the C operand.
- `m4-prover`: the batch witness holds only A and B; the IMUL/BMUL re-randomization path (the one true C consumer) re-derives the column locally.

### Soundness

- Folding is $\mathbb{F}_2$-linear on word bits, so equal words fold to equal field elements.
- An honest prover emits the exact same transcript: verified byte-identical proofs on a deterministic SHA-256 fixture, before vs after (same digest, 35,936 bytes).
- A cheating witness is still rejected: the shift reduction binds the claimed C evaluation to the committed witness. The verifier is untouched.
- This is *not* Flock-style protocol "skipping c" (paper section 4.4), which changes the transcript — nothing about the protocol moves here.

### Scope

- **new:** fused fold kernel + a test pinning it to three independent folds across all length regimes (empty, sub-width, aligned, tail, non-power-of-two)
- **changed:** the AND-reduction prover signature, both witness builders, one test helper, the `and_reduction` bench (now measures the fused path)
- **untouched:** verifier, transcript, IntMul/BinMul reductions, shift argument

### Verification

- `cargo check --workspace --all-targets`, `clippy -p binius-prover -p binius-m4-prover --all-targets`, nightly `fmt` — clean
- `binius-prover` lib (25) + `prove_verify` (9) + `shift` (1); `binius-m4-prover` (34 + 3) — all pass
- transcript pin: byte-identical proof digest against the pre-change code (stash A/B in the same tree)

### Benchmark

Isolated micro benches, M1 Pro, `--features rayon`, back-to-back stash A/B:

| bench | before | after | speedup |
|---|---|---|---|
| univariate fold, 2^21 words | 3.84 ms | 3.14 ms | 1.22× |
| m4 BitAnd witness assembly (keccak-f1600) | 5.01 ms | 2.90 ms | 1.73× |

The fold row understates the win: its baseline folds a pre-materialized C, so the deleted C build pass is on top of the 1.22×.

🤖 Generated with [Claude Code](https://claude.com/claude-code)