### PR TITLE
BINIUS-218: fuse the intmul index-column embed into the rho-fold

### DIFF
--- a/crates/prover/src/protocols/intmul/prove.rs
+++ b/crates/prover/src/protocols/intmul/prove.rs
@@ -207,7 +207,9 @@ where
 		];
 
 		let columns_guard = tracing::debug_span!("Gather lookup index columns").entered();
+		// The columns are independent, so they gather in parallel.
 		let index_columns = (0..N_LIMB_COLUMNS)
+			.into_par_iter()
 			.map(|j| {
 				let (tree, limb) = (j / N_LIMBS, j % N_LIMBS);
 				exponents[tree]
@@ -240,7 +242,7 @@ where
 
 		// The index entries are the GF(2)-linear embeddings iota(e) = Σ_u basis(u) · bit_u(e),
 		// materialized by a table of all 2^LIMB_BITS embeddings.
-		let embed_guard = tracing::debug_span!("Embed index columns").entered();
+		let embed_guard = tracing::debug_span!("Build embedding table").entered();
 		let mut iota_table = Vec::with_capacity(1usize << LIMB_BITS);
 		iota_table.push(F::ZERO);
 		for row in 1..1usize << LIMB_BITS {
@@ -248,13 +250,9 @@ where
 				<F as ExtensionField<BinaryField1b>>::basis(row.trailing_zeros() as usize);
 			iota_table.push(iota_table[row & (row - 1)] + low_bit_basis);
 		}
+		drop(embed_guard);
 
 		let index_content_point = logup_proof.index_eval_point.as_slice();
-		let embedded_columns = index_columns
-			.iter()
-			.map(|rows| rows.iter().map(|&row| iota_table[row]).collect::<Vec<_>>())
-			.collect::<Vec<_>>();
-		drop(embed_guard);
 
 		// Collapse the per-column claims into a single claim on the eq(ρ)-folded column V by
 		// sampling ρ, so the final unification runs over the content variables only.
@@ -265,10 +263,14 @@ where
 			evaluate(&FieldBuffer::<P>::from_values(&padded_column_evals), &rho);
 		let rho_tensor = eq_ind_partial_eval_scalars::<F>(&rho);
 		let fold_guard = tracing::debug_span!("Fold index columns by rho").entered();
+		// Each row folds through the embedding table directly, in parallel:
+		//     V[i] = sum_j rho_tensor[j] * iota(index_j[i])
+		// so no embedded column is ever materialized.
 		let folded_column_scalars = (0..1usize << n_vars)
+			.into_par_iter()
 			.map(|i| {
-				izip!(&embedded_columns, &rho_tensor)
-					.map(|(column, &weight)| column[i] * weight)
+				izip!(&index_columns, &rho_tensor)
+					.map(|(column, &weight)| iota_table[column[i]] * weight)
 					.sum::<F>()
 			})
 			.collect::<Vec<_>>();


### PR DESCRIPTION
Part of [BINIUS-218](https://linear.app/jimpo/issue/BINIUS-218/logup-witness-inefficiencies) — this does not close it.

Computes the same rho-folded index column in intmul phase 5, but folds each row straight through the embedding table instead of materializing twelve embedded columns first.
Output is bit-identical — no protocol change, no new soundness assumption.

### The problem

After the logUp* reduction, phase 5 collapses the twelve per-limb index claims into one claim on the eq($\rho$)-folded column $V$.
The old pipeline got there in two passes:

- **Embed:** materialize twelve columns of $2^n$ field elements, `iota(index_j[i])` — about 190 MB of writes at $2^{20}$ multiplications.
- **Fold:** a fully **serial** $2^n$ loop combining the twelve columns by the $\rho$ tensor.

The embedded columns exist only to feed the fold, and the fold was the last serial $O(12 \cdot 2^n)$ walk in the phase.

### The idea

The embedding is a 65536-entry table lookup, so it fuses into the fold for free:

```
V[i] = sum_j rho_tensor[j] * iota_table[index_j[i]]
```

One parallel pass over the rows, nothing intermediate.
The gather of the twelve index columns fans out across columns in the same way.

### The change

One region of `crates/prover/src/protocols/intmul/prove.rs`:

```
- embed:  embedded_columns[j][i] = iota_table[index_j[i]]      (12 x 2^n materialized)
- fold:   V[i] = sum_j embedded_columns[j][i] * rho_tensor[j]  (serial over i)
+ fold:   V[i] = sum_j iota_table[index_j[i]] * rho_tensor[j]  (parallel over i)
```

The embedding-table build keeps its own (renamed) tracing span; the gather loop gains an `into_par_iter`.

### Soundness — preserved, for free

- Per element, the inner sum keeps the same $j = 0..11$ order and the same operand order per multiply, so $V$ is value-identical.
- $\rho$ is sampled at the same transcript position; neither the embed nor the fold touches the channel.
- The intmul prove/verify round-trip tests replay the transcript through the real verifier, pinning bit-identity.

### Scope

- **changed:** the gather loop and the embed+fold region in phase 5
- the logUp* reduction itself is untouched — its parallelization is #1880 / #1881

### Verification

- `cargo check --workspace --all-targets`, `clippy -p binius-prover --all-targets` (with and without `rayon`), nightly `fmt` — clean
- intmul tests (prove/verify round trips): 6/6 pass in debug and release, with and without `--features rayon`

### Benchmark

Tracing-span timings of the phase-5 index-column stage, medians of the warmed run, M1 Pro, `--release --features rayon`:

**$2^{20}$ multiplications:**

| span | before | after |
|---|---|---|
| Gather lookup index columns | 3.2 ms | 2.2 ms |
| Embed index columns / Build embedding table | 14.8 ms | 0.5 ms |
| Fold index columns by rho | 28.7 ms | 7.4 ms |
| **stage total** | **46.7 ms** | **10.0 ms (4.7×)** |

**$2^{18}$ multiplications:** stage total 12.7 ms → 3.1 ms (4.1×).

**Serial builds** (no `rayon` feature, $2^{20}$): stage total 48.4 ms → 46.9 ms — no regression; the fused loop absorbs the embed work (30.5 + 14.7 → 43.3 ms) and drops the intermediate writes.
The 43.3 ms serial vs 7.4 ms parallel fused fold also shows the loop now scales (~5.9×) where it previously ran serially regardless of the pool.

The numbers come from a throwaway tracing-forest harness that is not part of this PR; to reproduce, drop the file below into `crates/prover/tests/`, add `tracing-forest.workspace = true` and `tracing-subscriber.workspace = true` to that crate's dev-dependencies, and run `cargo test -p binius-prover --release --features rayon --test phase5_profile -- --nocapture` (set `LOG_NUM` for the size).

<details>
<summary>phase5_profile.rs — the span-timing harness</summary>

```rust
// Temporary profiling harness for BINIUS-218 analysis. NOT for commit.
//
// Runs intmul phases 1-5 at a configurable size and prints the tracing-forest
// timing tree, so the logup* witness spans inside phase 5 can be compared.
//
// Run: cargo test -p binius-prover --release --features rayon --test phase5_profile -- --nocapture

use binius_core::word::Word;
use binius_field::{BinaryField128bGhash, PackedBinaryGhash1x128b};
use binius_hash::StdHashSuite;
use binius_iop::{
	basefold::compiler::BaseFoldVerifierCompiler, channel::OracleSpec, fri::MinProofSizeStrategy,
	merkle_tree::BinaryMerkleTreeScheme,
};
use binius_iop_prover::basefold::compiler::BaseFoldProverCompiler;
use binius_math::{
	multilinear::evaluate::evaluate,
	ntt::{NeighborsLastSingleThread, domain_context::GenericPreExpanded},
	test_utils::random_scalars,
};
use binius_prover::protocols::intmul::{prove::IntMulProver, witness::Witness};
use binius_transcript::ProverTranscript;
use binius_verifier::{
	config::StdChallenger,
	protocols::intmul::common::{LIMB_BITS, frobenius_twist},
};
use rand::prelude::*;
use tracing::level_filters::LevelFilter;
use tracing_forest::ForestLayer;
use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};

type P = PackedBinaryGhash1x128b;
type F = BinaryField128bGhash;

const LOG_NUM: usize = 20;
const LOG_INV_RATE: usize = 1;
const N_TEST_QUERIES: usize = 1;

fn generate_test_data(log_num: usize) -> (Vec<Word>, Vec<Word>, Vec<Word>, Vec<Word>) {
	let num_exponents = 1 << log_num;
	let mut rng = StdRng::seed_from_u64(0);
	let mut a = Vec::with_capacity(num_exponents);
	let mut b = Vec::with_capacity(num_exponents);
	let mut c_lo = Vec::with_capacity(num_exponents);
	let mut c_hi = Vec::with_capacity(num_exponents);
	for _ in 0..num_exponents {
		let a_i = rng.random_range(1..u64::MAX);
		let b_i = rng.random_range(1..u64::MAX);
		let full = (a_i as u128) * (b_i as u128);
		a.push(Word::from_u64(a_i));
		b.push(Word::from_u64(b_i));
		c_lo.push(Word::from_u64(full as u64));
		c_hi.push(Word::from_u64((full >> 64) as u64));
	}
	(a, b, c_lo, c_hi)
}

#[test]
fn profile_phase5() {
	let env_filter = EnvFilter::builder()
		.with_default_directive(LevelFilter::DEBUG.into())
		.from_env_lossy();
	let _ = tracing_subscriber::registry()
		.with(env_filter)
		.with(ForestLayer::default())
		.try_init();

	let (a, b, c_lo, c_hi) = generate_test_data(LOG_NUM);
	let witness = Witness::<P>::new(&a, &b, &c_lo, &c_hi).unwrap();

	let n_vars = witness.b_root.log_len();
	let initial_eval_point = random_scalars::<F>(&mut StdRng::seed_from_u64(1), n_vars);
	let exp_eval = evaluate(&witness.b_root, &initial_eval_point);

	let phase1 = {
		let mut transcript = ProverTranscript::new(StdChallenger::default());
		let mut prover = IntMulProver::<P, _>::new(0, &mut transcript);
		prover.phase1(&initial_eval_point, witness.b_prodcheck.clone(), &witness.b_leaves, exp_eval)
	};
	let phase2 = frobenius_twist(Word::LOG_BITS, &phase1.eval_point, &phase1.b_leaves_evals);
	let phase3 = {
		let mut transcript = ProverTranscript::new(StdChallenger::default());
		let mut prover = IntMulProver::<P, _>::new(0, &mut transcript);
		prover.phase3(
			&phase2.twisted_eval_points,
			&phase2.twisted_evals,
			witness.a_root.clone(),
			witness.b_exponents,
			[witness.c_lo_root.clone(), witness.c_hi_root.clone()],
			&initial_eval_point,
			exp_eval,
		)
	};
	let phase4 = {
		let mut transcript = ProverTranscript::new(StdChallenger::default());
		let mut prover = IntMulProver::<P, _>::new(0, &mut transcript);
		prover.phase4(
			&phase3.eval_point,
			(phase3.gpow_a_eval, witness.a_prodcheck.clone()),
			(phase3.gpow_c_lo_eval, witness.c_lo_prodcheck.clone()),
			(phase3.gpow_c_hi_eval, witness.c_hi_prodcheck.clone()),
			[
				witness.a_exponents,
				witness.c_lo_exponents,
				witness.c_hi_exponents,
			],
			&witness.tables,
		)
	};

	let verifier_compiler = BaseFoldVerifierCompiler::new(
		BinaryMerkleTreeScheme::<F, StdHashSuite>::new(),
		vec![OracleSpec::new(LIMB_BITS)],
		LOG_INV_RATE,
		N_TEST_QUERIES,
		&MinProofSizeStrategy,
	);
	let domain_context =
		GenericPreExpanded::generate_from_subspace(verifier_compiler.max_subspace());
	let ntt = NeighborsLastSingleThread::new(domain_context);
	let compiler = BaseFoldProverCompiler::<P, _>::from_verifier_compiler(&verifier_compiler, ntt);

	// Two timed runs of phase 5 (first warms allocators/caches).
	for run in 0..2 {
		let mut channel = compiler
			.create_channel_without_zk_from_transcript::<StdHashSuite, StdChallenger, _>(
				ProverTranscript::default(),
			);
		let span = tracing::info_span!("phase5", run, log_num = LOG_NUM);
		let _guard = span.enter();
		let mut prover = IntMulProver::<P, _>::new(0, &mut channel);
		let _ = prover.phase5(
			&phase4,
			witness.b_exponents,
			&phase3.eval_point,
			&phase3.r_ib,
			phase3.b_recomb,
			witness.a_exponents,
			witness.c_lo_exponents,
			witness.c_hi_exponents,
			&witness.tables[0],
		);
	}
}
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)