### PR TITLE
BINIUS-330: hash Merkle inner nodes four at a time through the ARM SHA-256 kernel

### DIFF
--- a/crates/hash/benches/sha256.rs
+++ b/crates/hash/benches/sha256.rs
@@ -140,5 +140,56 @@ fn bench_const_leaves(c: &mut Criterion) {
 	group.finish();
 }
 
-criterion_group!(benches, bench_sha256, bench_compress, bench_digest, bench_const_leaves);
+/// Compresses one wide Merkle tree layer: pairs of child digests into parent digests.
+///
+/// Compares the per-node scalar path against the interleaved four-way path.
+/// Both run over the same rayon pool.
+/// So the delta isolates how fully each path occupies the SHA pipeline.
+fn bench_merkle_compress(c: &mut Criterion) {
+	use std::mem::MaybeUninit;
+
+	use binius_hash::{
+		ParallelCompressionAdaptor, ParallelPseudoCompression, ParallelSha256Compression,
+		sha256::Sha256Compression,
+	};
+
+	// One layer of 2^15 parent nodes, fed by 2^16 child digests.
+	const N_NODES: usize = 1 << 15;
+	let mut rng = rng();
+	let inputs: Vec<Output<Sha256>> = (0..2 * N_NODES)
+		.map(|_| {
+			let mut digest = Output::<Sha256>::default();
+			rng.fill_bytes(&mut digest);
+			digest
+		})
+		.collect();
+	let mut out: Vec<MaybeUninit<Output<Sha256>>> = Vec::with_capacity(N_NODES);
+	// Every slot is fully written by every compression call below.
+	unsafe { out.set_len(N_NODES) };
+
+	let mut group = c.benchmark_group("sha256_merkle_compress");
+	group.throughput(Throughput::Elements(N_NODES as u64));
+
+	// The per-node reference: each node compresses through one scalar block call.
+	let per_node = ParallelCompressionAdaptor::new(Sha256Compression::default());
+	group.bench_function(BenchmarkId::new("per_node", N_NODES), |b| {
+		b.iter(|| per_node.parallel_compress(black_box(&inputs), &mut out));
+	});
+
+	// The interleaved path: four independent compressions in flight per call.
+	let interleaved = ParallelSha256Compression::default();
+	group.bench_function(BenchmarkId::new("interleaved_x4", N_NODES), |b| {
+		b.iter(|| interleaved.parallel_compress(black_box(&inputs), &mut out));
+	});
+	group.finish();
+}
+
+criterion_group!(
+	benches,
+	bench_sha256,
+	bench_compress,
+	bench_digest,
+	bench_const_leaves,
+	bench_merkle_compress
+);
 criterion_main!(benches);

--- a/crates/hash/src/lib.rs
+++ b/crates/hash/src/lib.rs
@@ -24,7 +24,7 @@ pub use parallel_digest::{
 	MultiDigest, ParallelDigest, ParallelDigestAdapter, ParallelMultidigestImpl,
 };
 pub use serialization::*;
-pub use sha256::ParallelSha256Digest;
+pub use sha256::{ParallelSha256Compression, ParallelSha256Digest};
 
 /// The standard digest is SHA-256.
 pub type StdDigest = sha2::Sha256;

--- a/crates/hash/src/sha256.rs
+++ b/crates/hash/src/sha256.rs
@@ -16,8 +16,9 @@ use sha2::{Sha256, block_api::compress256, digest::Output};
 use super::{
 	binary_merkle_tree::HashSuite,
 	compress::CompressionFunction,
-	parallel_compression::ParallelCompressionAdaptor,
+	parallel_compression::ParallelPseudoCompression,
 	parallel_digest::{ParallelDigest, ParallelDigestAdapter},
+	sha256_x4::compress256_x4,
 };
 
 /// Hashes every leaf through the four-way interleaved SHA-256 kernel.
@@ -108,7 +109,72 @@ impl HashSuite for Sha256HashSuite {
 	type LeafHash = Sha256;
 	type Compression = Sha256Compression;
 	type ParLeafHash = ParallelSha256Digest;
-	type ParCompression = ParallelCompressionAdaptor<Sha256Compression>;
+	type ParCompression = ParallelSha256Compression;
+}
+
+/// Parallel SHA-256 two-to-one compression for the inner nodes of a Merkle tree.
+///
+/// Groups of four independent compressions run through the interleaved four-way block kernel.
+/// A trailing group smaller than four compresses one node at a time.
+/// Every output byte equals compressing each node on its own with the scalar function.
+#[derive(Debug, Clone, Default)]
+pub struct ParallelSha256Compression {
+	/// The scalar two-to-one compression whose output the grouped path reproduces exactly.
+	compression: Sha256Compression,
+}
+
+impl ParallelPseudoCompression<Output<Sha256>, 2> for ParallelSha256Compression {
+	type Compression = Sha256Compression;
+
+	fn compression(&self) -> &Self::Compression {
+		&self.compression
+	}
+
+	fn parallel_compress(
+		&self,
+		inputs: &[Output<Sha256>],
+		out: &mut [MaybeUninit<Output<Sha256>>],
+	) {
+		use binius_utils::rayon::slice::{ParallelSlice, ParallelSliceMut};
+
+		assert_eq!(inputs.len(), 2 * out.len(), "Input length must be N * output length");
+
+		// Split into full groups of four compressions and a short tail.
+		//
+		//     inputs:  [ 8 digests | 8 digests | ... | tail (< 8) ]
+		//     out:     [ 4 nodes   | 4 nodes   | ... | tail (< 4) ]
+		let n_groups = out.len() / 4;
+		let (input_groups, input_tail) = inputs.split_at(8 * n_groups);
+		let (out_groups, out_tail) = out.split_at_mut(4 * n_groups);
+
+		// Each group packs four sibling pairs into four one-block messages.
+		// One interleaved call then advances all four states at once.
+		input_groups
+			.par_chunks_exact(8)
+			.zip(out_groups.par_chunks_exact_mut(4))
+			.for_each(|(pairs, out4)| {
+				// Pack each sibling pair into one 64-byte message block: left child then right.
+				let mut blocks = [[0u8; 64]; 4];
+				for (block, pair) in blocks.iter_mut().zip(pairs.chunks_exact(2)) {
+					block[..32].copy_from_slice(&pair[0]);
+					block[32..].copy_from_slice(&pair[1]);
+				}
+
+				// All four lanes start from the same fixed initial state.
+				let mut states = [self.compression.initial_state; 4];
+				compress256_x4(&mut states, [&blocks[0], &blocks[1], &blocks[2], &blocks[3]]);
+
+				// Serialize each advanced state in native word order, as the scalar path does.
+				for (slot, state) in out4.iter_mut().zip(states) {
+					slot.write(must_cast::<[u32; 8], [u8; 32]>(state).into());
+				}
+			});
+
+		// The tail (at most three nodes) compresses one pair at a time.
+		for (slot, pair) in out_tail.iter_mut().zip(input_tail.chunks_exact(2)) {
+			slot.write(self.compression.compress([pair[0], pair[1]]));
+		}
+	}
 }
 
 /// A [`ParallelDigest`] for SHA-256 that specializes
@@ -199,9 +265,55 @@ mod tests {
 	use std::iter::repeat_with;
 
 	use binius_utils::rayon::iter::{IntoParallelRefIterator, ParallelIterator};
-	use rand::{RngExt, SeedableRng, rngs::StdRng};
+	use rand::{Rng, RngExt, SeedableRng, rngs::StdRng};
 
 	use super::*;
+	use crate::parallel_compression::ParallelCompressionAdaptor;
+
+	#[test]
+	fn test_parallel_sha256_compression_matches_adaptor() {
+		let mut rng = StdRng::seed_from_u64(0);
+
+		// Invariant: the grouped four-way path equals per-node scalar compression byte for byte.
+		//
+		// Node counts crossing every regime of the grouping:
+		//
+		//     1, 2, 3   → tail only (the top Merkle layers)
+		//     4         → exactly one full group
+		//     5, 7      → full group plus tail
+		//     8, 64     → several full groups (64 = a wide tree layer)
+		for n_nodes in [1usize, 2, 3, 4, 5, 7, 8, 64] {
+			// Two random child digests per output node.
+			let inputs: Vec<Output<Sha256>> = repeat_with(|| {
+				let mut digest = Output::<Sha256>::default();
+				rng.fill_bytes(&mut digest);
+				digest
+			})
+			.take(2 * n_nodes)
+			.collect();
+
+			// Compress with the grouped four-way path.
+			let grouped = ParallelSha256Compression::default();
+			let mut got = repeat_with(MaybeUninit::<Output<Sha256>>::uninit)
+				.take(n_nodes)
+				.collect::<Vec<_>>();
+			grouped.parallel_compress(&inputs, &mut got);
+
+			// Compress every node one at a time through the scalar function as the reference.
+			let adaptor = ParallelCompressionAdaptor::new(Sha256Compression::default());
+			let mut want = repeat_with(MaybeUninit::<Output<Sha256>>::uninit)
+				.take(n_nodes)
+				.collect::<Vec<_>>();
+			adaptor.parallel_compress(&inputs, &mut want);
+
+			for (i, (got_i, want_i)) in got.iter().zip(&want).enumerate() {
+				// Safety: the compression calls above initialize every output slot.
+				let (got_i, want_i) =
+					unsafe { (got_i.assume_init_ref(), want_i.assume_init_ref()) };
+				assert_eq!(got_i, want_i, "mismatch at node {i} of {n_nodes}");
+			}
+		}
+	}
 
 	/// Checks that the specialized digest matches `Sha256::digest` over the serialized leaf bytes,
 	/// covering both the single-block fast path and the multi-block fallback.

--- a/crates/hash/src/sha256_x4.rs
+++ b/crates/hash/src/sha256_x4.rs
@@ -14,6 +14,30 @@
 /// A SHA-256 digest.
 pub type Hash = [u8; 32];
 
+/// Compresses one 64-byte block into each of four independent SHA-256 states, in place.
+///
+/// This is the four-way analogue of the portable single-stream block function.
+/// Each state absorbs its own block through the full 64 rounds plus the Davies-Meyer add.
+/// No padding or length suffix is involved.
+/// The caller owns the block contents.
+///
+/// On aarch64 with the `sha2` feature the four lanes interleave over one SHA unit.
+/// Elsewhere the lanes compress one at a time through the portable block function.
+#[inline]
+pub fn compress256_x4(states: &mut [[u32; 8]; 4], blocks: [&[u8; 64]; 4]) {
+	#[cfg(all(target_arch = "aarch64", target_feature = "sha2"))]
+	{
+		// SAFETY: the `sha2` target feature is statically enabled, so the crypto intrinsics exist.
+		unsafe { neon::compress4_states(states, blocks) }
+	}
+	#[cfg(not(all(target_arch = "aarch64", target_feature = "sha2")))]
+	{
+		for (state, block) in states.iter_mut().zip(blocks) {
+			sha2::block_api::compress256(state, std::slice::from_ref(block));
+		}
+	}
+}
+
 /// Hashes four equal-length byte inputs into four standard SHA-256 digests.
 ///
 /// The inputs hash as four independent streams.
@@ -63,7 +87,7 @@ mod neon {
 	use core::arch::aarch64::{
 		uint32x4_t, vaddq_u32, vdupq_n_u32, vld1q_u8, vld1q_u32, vreinterpretq_u8_u32,
 		vreinterpretq_u32_u8, vrev32q_u8, vsha256h2q_u32, vsha256hq_u32, vsha256su0q_u32,
-		vsha256su1q_u32, vst1q_u8,
+		vsha256su1q_u32, vst1q_u8, vst1q_u32,
 	};
 
 	use super::Hash;
@@ -166,6 +190,37 @@ mod neon {
 		}
 	}
 
+	/// Compresses one 64-byte block into each of four independent word states, in place.
+	///
+	/// The state words load and store in native word order.
+	/// No byte-swap of the state happens on either side, matching the portable block function.
+	/// Only the message block bytes swap to big-endian, inside the shared round kernel.
+	///
+	/// # Safety
+	///
+	/// The caller must enable the `sha2` target feature so the crypto intrinsics are defined.
+	#[inline]
+	pub unsafe fn compress4_states(states: &mut [[u32; 8]; 4], blocks: [&[u8; 64]; 4]) {
+		unsafe {
+			// Split each 8-word state into its (a, b, c, d) and (e, f, g, h) register halves.
+			let mut abcd = [vdupq_n_u32(0); 4];
+			let mut efgh = [vdupq_n_u32(0); 4];
+			for i in 0..4 {
+				abcd[i] = vld1q_u32(states[i].as_ptr());
+				efgh[i] = vld1q_u32(states[i].as_ptr().add(4));
+			}
+
+			// One interleaved 64-round compression, Davies-Meyer add included.
+			compress4(&mut abcd, &mut efgh, blocks.map(|block| block.as_ptr()));
+
+			// Write the advanced states back in native word order.
+			for i in 0..4 {
+				vst1q_u32(states[i].as_mut_ptr(), abcd[i]);
+				vst1q_u32(states[i].as_mut_ptr().add(4), efgh[i]);
+			}
+		}
+	}
+
 	/// Hashes four equal-length inputs with the interleaved NEON compression.
 	///
 	/// # Safety
@@ -236,9 +291,29 @@ mod neon {
 #[cfg(test)]
 mod tests {
 	use proptest::prelude::*;
-	use sha2::{Digest, Sha256};
+	use sha2::{Digest, Sha256, block_api::compress256};
 
-	use super::sha256_x4;
+	use super::{compress256_x4, sha256_x4};
+
+	proptest! {
+		#[test]
+		fn compress256_x4_matches_the_block_reference(
+			states in prop::array::uniform4(prop::array::uniform8(any::<u32>())),
+			blocks in prop::array::uniform4(any::<[u8; 64]>()),
+		) {
+			// Advance four independent random states through the four-way kernel.
+			// Random states pin the raw-compression contract, not just the fixed IV.
+			let mut got = states;
+			compress256_x4(&mut got, [&blocks[0], &blocks[1], &blocks[2], &blocks[3]]);
+
+			// Each lane must equal the portable single-stream block function on its own input.
+			for i in 0..4 {
+				let mut want = states[i];
+				compress256(&mut want, std::slice::from_ref(&blocks[i]));
+				prop_assert_eq!(got[i], want, "mismatch at lane {}", i);
+			}
+		}
+	}
 
 	proptest! {
 		#[test]


### PR DESCRIPTION
Closes [BINIUS-330](https://linear.app/jimpo/issue/BINIUS-330/hash-merkle-inner-nodes-four-at-a-time-through-the-interleaved-arm-sha).

Runs the Merkle tree's inner-node compressions four at a time through the interleaved ARM SHA-256 kernel that already hashes the leaves. Byte-identical output — no transcript or protocol change.

### The problem

Leaf hashing fills the SHA pipeline with four interleaved streams ([BINIUS-287](https://linear.app/jimpo/issue/BINIUS-287), #1805).
The inner layers do not: each two-to-one node is one scalar block call, rayon-parallel across nodes but single-stream per core.
Inner nodes are roughly a fifth of the tree's compression work.

### The idea

An inner node compresses the concatenation of its two 32-byte children — exactly one 64-byte block, no padding.
Nodes within a layer are independent, so four can advance through the SHA unit together:

```
    layer:   [ pair 0 | pair 1 | pair 2 | pair 3 | pair 4 ... ]
              \______ one interleaved 4-way call ______/  tail: scalar
```

### The change

- `sha256_x4.rs`: a new block-level entry point — the four-way, state-in/state-out analogue of the portable block function. NEON on aarch64 (reusing the existing interleaved round kernel, Davies-Meyer add included), portable fallback elsewhere, so callers need no arch cfg. The state serializes in **native word order**, matching the scalar two-to-one compression exactly (the leaf path's big-endian convention does not apply here).
- `sha256.rs`: a new parallel compression for the standard hash suite — groups of four sibling pairs per interleaved call, scalar tail for the top layers (fewer than four nodes).

### Soundness

- Byte-identical to per-node scalar compression: same rounds, same feed-forward, same state serialization.
- The verifier recomputes authentication paths with the scalar function; the 9 full prove-verify round trips pin the tree bytes end to end.

### Scope

- **new:** the block-level four-way kernel entry, the grouped parallel compression, two equality tests, one layer benchmark
- **changed:** one associated type in the SHA-256 hash suite, one re-export
- **untouched:** leaf hashing, the scalar compression, the verifier, every other hash suite

### Verification

- `cargo check --workspace --all-targets`, `clippy` (0 warnings), nightly `fmt` — clean
- proptest: four-way block kernel == portable block function on **random states** (not just the IV) and random blocks
- equality test: grouped path == per-node compression across node counts 1, 2, 3, 4, 5, 7, 8, 64 (every tail/group regime)
- `binius-hash` (19), `binius-iop-prover` (40), `prove_verify` (9), `binius-m4-prover` (35 + 3) — all pass

### Benchmark

New `sha256_merkle_compress` bench, one $2^{15}$-node layer, M1 Pro; both paths coexist in one binary so the comparison needs no checkout juggling:

| config | per-node (before) | interleaved x4 (after) | speedup |
|---|---|---|---|
| serial | 931 µs | 874 µs | 1.07× |
| rayon, 8 threads | 244 µs | 203 µs | 1.20× |

The gain is smaller than the leaf case and concentrates under full-core load, for a structural reason: an inner node is a *raw single-block* compression with independent states, which the out-of-order core already overlaps across loop iterations — unlike leaf hashing's multi-block dependent chains, where only explicit interleaving fills the pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)