### PR TITLE
Fold the packed-arithmetic impls into the binary_field! macro

### DIFF
--- a/crates/field/src/aes_field.rs
+++ b/crates/field/src/aes_field.rs
@@ -14,9 +14,7 @@ use binius_utils::{
 use bytemuck::{Pod, Zeroable};
 
 use super::{
-	binary_field::{
-		BinaryField, BinaryField1b, binary_field, impl_arithmetic_via_packed, impl_field_extension,
-	},
+	binary_field::{BinaryField, BinaryField1b, binary_field, impl_field_extension},
 	mul_by_binary_field_1b,
 };
 use crate::{ExtensionField, Field, underlier::U1};
@@ -101,8 +99,6 @@ unsafe impl Pod for AESTowerField8b {}
 impl_field_extension!(BinaryField1b(U1) < @3 => AESTowerField8b(u8));
 
 mul_by_binary_field_1b!(AESTowerField8b);
-
-impl_arithmetic_via_packed!(AESTowerField8b, u8);
 
 impl SerializeBytes for AESTowerField8b {
 	fn serialize(&self, write_buf: impl BufMut) -> Result<(), SerializationError> {

--- a/crates/field/src/binary_field.rs
+++ b/crates/field/src/binary_field.rs
@@ -23,9 +23,22 @@ pub trait BinaryField:
 	const N_BITS: usize = Self::ORDER_EXPONENT;
 }
 
-/// Macro to generate an implementation of a BinaryField.
+/// Generates a binary field type over an underlier `$typ`.
+///
+/// The default form derives the field's arithmetic from its width-one packing.
+/// The `custom_arithmetic` form omits that, for a field that defines its own arithmetic.
 macro_rules! binary_field {
+	// Default: the field's arithmetic is its width-one packing's arithmetic.
 	($vis:vis $name:ident($typ:ty), $gen:expr) => {
+		binary_field!(@base $vis $name($typ), $gen);
+		binary_field!(@arithmetic_via_packed $name, $typ);
+	};
+	// The field provides its own `Mul`/`Square`/`InvertOrZero`/`WideMul` separately.
+	(custom_arithmetic $vis:vis $name:ident($typ:ty), $gen:expr) => {
+		binary_field!(@base $vis $name($typ), $gen);
+	};
+
+	(@base $vis:vis $name:ident($typ:ty), $gen:expr) => {
 		#[derive(Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Zeroable, bytemuck::TransparentWrapper)]
 		#[repr(transparent)]
 		$vis struct $name(pub(crate) $typ);
@@ -296,7 +309,61 @@ macro_rules! binary_field {
 				return val.0
 			}
 		}
-	}
+	};
+
+	// Each op lifts the underlier into the width-one packing, runs its arithmetic, and lowers back.
+	(@arithmetic_via_packed $name:ident, $typ:ty) => {
+		impl Mul<Self> for $name {
+			type Output = Self;
+
+			#[inline]
+			fn mul(self, rhs: Self) -> Self {
+				$crate::tracing::trace_multiplication!($name);
+				type P = $crate::arch::PackedPrimitiveType<$typ, $name>;
+				Self((P::from_underlier(self.0) * P::from_underlier(rhs.0)).to_underlier())
+			}
+		}
+
+		impl $crate::arithmetic_traits::Square for $name {
+			#[inline]
+			fn square(self) -> Self {
+				type P = $crate::arch::PackedPrimitiveType<$typ, $name>;
+				Self(
+					$crate::arithmetic_traits::Square::square(P::from_underlier(self.0)).to_underlier(),
+				)
+			}
+		}
+
+		impl $crate::arithmetic_traits::InvertOrZero for $name {
+			#[inline]
+			fn invert_or_zero(self) -> Self {
+				type P = $crate::arch::PackedPrimitiveType<$typ, $name>;
+				Self(
+					$crate::arithmetic_traits::InvertOrZero::invert_or_zero(P::from_underlier(self.0))
+						.to_underlier(),
+				)
+			}
+		}
+
+		impl $crate::arithmetic_traits::WideMul for $name {
+			type Output = <$crate::arch::PackedPrimitiveType<$typ, $name> as $crate::arithmetic_traits::WideMul>::Output;
+
+			#[inline]
+			fn wide_mul(a: Self, b: Self) -> Self::Output {
+				type P = $crate::arch::PackedPrimitiveType<$typ, $name>;
+				<P as $crate::arithmetic_traits::WideMul>::wide_mul(
+					P::from_underlier(a.0),
+					P::from_underlier(b.0),
+				)
+			}
+
+			#[inline]
+			fn reduce(wide: Self::Output) -> Self {
+				type P = $crate::arch::PackedPrimitiveType<$typ, $name>;
+				Self(<P as $crate::arithmetic_traits::WideMul>::reduce(wide).to_underlier())
+			}
+		}
+	};
 }
 
 pub(crate) use binary_field;
@@ -496,70 +563,7 @@ macro_rules! impl_field_extension {
 
 pub(crate) use impl_field_extension;
 
-/// Implements a field's arithmetic via its width-one `PackedPrimitiveType<$typ, Self>` packing.
-///
-/// The field stays a newtype over `$typ`.
-/// The packing is the single source of truth for `Mul`/`Square`/`InvertOrZero`/`WideMul`.
-macro_rules! impl_arithmetic_via_packed {
-	($name:ident, $typ:ty) => {
-		impl Mul<Self> for $name {
-			type Output = Self;
-
-			#[inline]
-			fn mul(self, rhs: Self) -> Self {
-				$crate::tracing::trace_multiplication!($name);
-				type P = $crate::arch::PackedPrimitiveType<$typ, $name>;
-				Self((P::from_underlier(self.0) * P::from_underlier(rhs.0)).to_underlier())
-			}
-		}
-
-		impl $crate::arithmetic_traits::Square for $name {
-			#[inline]
-			fn square(self) -> Self {
-				type P = $crate::arch::PackedPrimitiveType<$typ, $name>;
-				Self(
-					$crate::arithmetic_traits::Square::square(P::from_underlier(self.0)).to_underlier(),
-				)
-			}
-		}
-
-		impl $crate::arithmetic_traits::InvertOrZero for $name {
-			#[inline]
-			fn invert_or_zero(self) -> Self {
-				type P = $crate::arch::PackedPrimitiveType<$typ, $name>;
-				Self(
-					$crate::arithmetic_traits::InvertOrZero::invert_or_zero(P::from_underlier(self.0))
-						.to_underlier(),
-				)
-			}
-		}
-
-		impl $crate::arithmetic_traits::WideMul for $name {
-			type Output = <$crate::arch::PackedPrimitiveType<$typ, $name> as $crate::arithmetic_traits::WideMul>::Output;
-
-			#[inline]
-			fn wide_mul(a: Self, b: Self) -> Self::Output {
-				type P = $crate::arch::PackedPrimitiveType<$typ, $name>;
-				<P as $crate::arithmetic_traits::WideMul>::wide_mul(
-					P::from_underlier(a.0),
-					P::from_underlier(b.0),
-				)
-			}
-
-			#[inline]
-			fn reduce(wide: Self::Output) -> Self {
-				type P = $crate::arch::PackedPrimitiveType<$typ, $name>;
-				Self(<P as $crate::arithmetic_traits::WideMul>::reduce(wide).to_underlier())
-			}
-		}
-	};
-}
-
-pub(crate) use impl_arithmetic_via_packed;
-
 binary_field!(pub BinaryField1b(U1), U1::new(0x1));
-
-impl_arithmetic_via_packed!(BinaryField1b, U1);
 
 macro_rules! serialize_deserialize {
 	($bin_type:ty) => {

--- a/crates/field/src/ghash.rs
+++ b/crates/field/src/ghash.rs
@@ -17,9 +17,7 @@ use binius_utils::{
 use bytemuck::{Pod, Zeroable};
 
 use super::{
-	binary_field::{
-		BinaryField, BinaryField1b, binary_field, impl_arithmetic_via_packed, impl_field_extension,
-	},
+	binary_field::{BinaryField, BinaryField1b, binary_field, impl_field_extension},
 	extension::ExtensionField,
 };
 use crate::{
@@ -87,8 +85,6 @@ impl BinaryField128bGhash {
 		Self::new(result)
 	}
 }
-
-impl_arithmetic_via_packed!(BinaryField128bGhash, M128);
 
 impl_field_extension!(BinaryField1b(U1) < @7 => BinaryField128bGhash(M128));
 

--- a/crates/field/src/ghash_sq.rs
+++ b/crates/field/src/ghash_sq.rs
@@ -42,7 +42,7 @@ use crate::{
 // The multiplicative generator is `Y` (low 128 bits = 0, high 128 bits = 1).
 // `tests::test_multiplicative_generator` verifies it generates GF(2^256)* against the known
 // factorization of 2^256 - 1.
-binary_field!(pub GhashSq256b(M256), m256_from_u128s(0, 1));
+binary_field!(custom_arithmetic pub GhashSq256b(M256), m256_from_u128s(0, 1));
 
 unsafe impl Pod for GhashSq256b {}
 


### PR DESCRIPTION
Follow-up to [#1865](https://github.com/binius-zk/binius64/pull/1865), implementing jimpo's suggestion from the review there ([#pullrequestreview-4753095129](https://github.com/binius-zk/binius64/pull/1865#pullrequestreview-4753095129)):

> I think we can go a step further and make `impl_arithmetic_via_packed!` part of the `binary_field!` macro — basically, this is just how all binary field arithmetic is defined. Leaving as a follow-up.

Pure refactor — the generated impls are identical, only emitted from a different place. No behavior change.

### The problem

After #1865, every binary field's arithmetic was "lift the scalar into its width-one `PackedPrimitiveType<U, Self>` packing, run the packing's arithmetic, lower back". But each field spelled that out as a separate step:

```rust
binary_field!(pub BinaryField128bGhash(M128), ...);
impl_arithmetic_via_packed!(BinaryField128bGhash, M128);   // <- always paired
```

The two always went together, so the pairing was boilerplate: nothing defines a binary field over an underlier without also wanting exactly this arithmetic — except the one field that can't have it.

### The idea

Make packing-derived arithmetic the **default** of `binary_field!`, and let the one exception opt out.

`binary_field!` now dispatches over internal arms:

- `@base` — the struct, `WithUnderlier`, the width-one `Field`/`Divisible`/`Maskable`/`PackedField` plumbing, `Display`/`Debug`/`From`/… (unchanged).
- `@arithmetic_via_packed` — `Mul`/`Square`/`InvertOrZero`/`WideMul`, each lifting the underlier into `PackedPrimitiveType<U, Self>` and lowering the result back.

The public forms:

- **default** `binary_field!(pub Field(U), gen)` → `@base` + `@arithmetic_via_packed`
- **`custom_arithmetic`** `binary_field!(custom_arithmetic pub Field(U), gen)` → `@base` only

### The change

```diff
 // BinaryField1b / AESTowerField8b / BinaryField128bGhash
-binary_field!(pub BinaryField128bGhash(M128), ...);
-impl_arithmetic_via_packed!(BinaryField128bGhash, M128);
+binary_field!(pub BinaryField128bGhash(M128), ...);

 // GhashSq256b keeps its own (Karatsuba) arithmetic
-binary_field!(pub GhashSq256b(M256), ...);
+binary_field!(custom_arithmetic pub GhashSq256b(M256), ...);
```

The standalone `impl_arithmetic_via_packed!` macro, its `pub(crate) use`, and the three explicit call sites (plus their imports in `ghash.rs`/`aes_field.rs`) are gone.

### Why GhashSq256b opts out

`GhashSq256b` is a degree-two extension over GHASH backed by `M256`. `M256` has no reflexive `Divisible<M256>`, so there is no width-one `PackedPrimitiveType<M256, GhashSq256b>` packing to delegate to. It keeps its bespoke Karatsuba `Mul`/`Square`/`InvertOrZero`/`WideMul`, and the `custom_arithmetic` form simply skips emitting the packing-derived ones (which would otherwise collide).

### Scope

- **changed:** `crates/field/src/binary_field.rs` (the fold) and one-line updates to `aes_field.rs`, `ghash.rs`, `ghash_sq.rs`.
- **left untouched:** every generated impl, and all `GhashSq256b` arithmetic.

### Verification

- `cargo check --workspace`, `cargo clippy -p binius-field --all-targets`, nightly `cargo fmt --all --check` — clean.
- `binius-field`: 207 tests + doctests pass (the field arithmetic proptests cover all four fields).

🤖 Generated with [Claude Code](https://claude.com/claude-code)