### PR TITLE
Drop the redundant direct bitcoin_hashes dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ base64 = "0.22.1"
 blake2 = "0.10.6"
 blake3 = "1"
 bitcoin = "0.32.7"
-bitcoin_hashes = "0.14.0"
 bytemuck = { version = "1.18.0", features = [
     "derive",
     "min_const_generics",

--- a/crates/circuits/Cargo.toml
+++ b/crates/circuits/Cargo.toml
@@ -21,7 +21,6 @@ sha3.workspace = true
 [dev-dependencies]
 anyhow.workspace = true
 bitcoin = { workspace = true }
-bitcoin_hashes = { workspace = true }
 blake2 = { workspace = true }
 blake3 = { workspace = true }
 hmac = { workspace = true }

--- a/crates/circuits/src/bitcoin/p2pkh_signature.rs
+++ b/crates/circuits/src/bitcoin/p2pkh_signature.rs
@@ -137,8 +137,7 @@ pub fn compress_pubkey(builder: &CircuitBuilder, x: &BigUint, y: &BigUint) -> Ve
 #[cfg(test)]
 mod tests {
 	use binius_core::{verify::verify_constraints, word::Word};
-	use bitcoin::PublicKey;
-	use bitcoin_hashes::Hash;
+	use bitcoin::{PublicKey, hashes::Hash};
 	use rand::prelude::*;
 
 	use super::*;

--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -18,7 +18,6 @@ binius-prover = { path = "../prover", default-features = false }
 binius-transcript = { path = "../transcript" }
 binius-utils = { path = "../utils", features = ["platform-diagnostics"] }
 binius-verifier = { path = "../verifier" }
-bitcoin_hashes.workspace = true
 bitcoin.workspace = true
 blake2.workspace = true
 blake3.workspace = true

--- a/crates/examples/src/circuits/bitcoin_p2pkh.rs
+++ b/crates/examples/src/circuits/bitcoin_p2pkh.rs
@@ -8,8 +8,7 @@ use binius_circuits::{
 	bitcoin::p2pkh_signature::{addr_bytes_to_le_words, build_p2pkh_circuit},
 };
 use binius_frontend::{CircuitBuilder, Wire, WitnessFiller};
-use bitcoin::{Network, PrivateKey, secp256k1::Secp256k1};
-use bitcoin_hashes::Hash;
+use bitcoin::{Network, PrivateKey, hashes::Hash, secp256k1::Secp256k1};
 use clap::Args;
 use rand::prelude::*;
 


### PR DESCRIPTION
Supersedes #1862 (the Dependabot `bitcoin_hashes` 0.14 → 1.1 bump).

Removes our direct `bitcoin_hashes` dependency and uses the `bitcoin::hashes` re-export instead. No behavior change.

### The problem

We declared `bitcoin_hashes` as a direct dependency, but the only thing we use it for is bringing its `Hash` trait into scope, so we can call `.to_byte_array()` on a hash value that the `bitcoin` crate hands back:

```rust
let addr = public_key.pubkey_hash().to_byte_array();
```

That hash type is owned by whatever `bitcoin_hashes` version the `bitcoin` crate itself resolves. A separate direct dependency on `bitcoin_hashes` is therefore not independent — it must stay in lockstep with `bitcoin`, and can only ever drift out of it.

That drift is exactly what #1862 hit. Dependabot bumped our direct dep to 1.1, but:

- Stable `bitcoin` is still 0.32 (0.33 is beta only), and `bitcoin 0.32` pins `bitcoin_hashes 0.14`.
- So the bump left two versions coexisting: 1.1 (direct) and 0.14 (via `bitcoin`).
- `use bitcoin_hashes::Hash` then referred to the 1.1 trait, which does not apply to the 0.14 hash type returned by `bitcoin` — every `.to_byte_array()` call stopped compiling, turning the Rust CI jobs red.

You cannot force-push to a Dependabot branch, hence this replacement PR.

### The idea

Don't declare the dependency at all. The `bitcoin` crate re-exports it:

```rust
// in bitcoin's lib.rs
pub extern crate hashes;
```

So `bitcoin::hashes::Hash` is the same trait, from the exact version `bitcoin` uses — it can never disagree with the hash types `bitcoin` produces. And with no direct declaration, Dependabot has nothing to bump independently, so this class of breakage cannot recur.

### The change

Both call sites already import from `bitcoin`, so the trait folds into the existing `use`:

```diff
- use bitcoin::PublicKey;
- use bitcoin_hashes::Hash;
+ use bitcoin::{PublicKey, hashes::Hash};
```

```diff
- use bitcoin::{Network, PrivateKey, secp256k1::Secp256k1};
- use bitcoin_hashes::Hash;
+ use bitcoin::{Network, PrivateKey, hashes::Hash, secp256k1::Secp256k1};
```

### Scope

- **removed:** `bitcoin_hashes` from the workspace `Cargo.toml`, from `crates/circuits` (a dev-dependency), and from `crates/examples`.
- **changed:** the two `use` lines above (`p2pkh_signature.rs` tests, `bitcoin_p2pkh.rs`).
- **unchanged:** `bitcoin_hashes 0.14.2` still resolves in `Cargo.lock`, now purely transitively via `bitcoin`. No `.to_byte_array()` logic changed.

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-circuits -p binius-examples --all-targets` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc -p binius-examples --no-deps` — clean
- `cargo +nightly fmt --all` — clean
- `cargo test -p binius-circuits --lib bitcoin` — 13 passed (includes the P2PKH circuit tests)

Once this lands, #1862 can be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)