### PR TITLE
[binius-arith-bench] Change ghash_sq irreducible to Y^2 + X*Y + X

### DIFF
--- a/crates/arith-bench/benches/field_mul.rs
+++ b/crates/arith-bench/benches/field_mul.rs
@@ -544,6 +544,50 @@ fn bench_ghash(c: &mut Criterion) {
 		);
 	}
 
+	// Benchmark mul_x operations (the multiply-by-X used by the GHASH² reduction).
+	run_unary_op_benchmark(&mut group, "soft64::mul_x", ghash::soft64::mul_x, &mut rng, 128);
+
+	#[cfg(all(target_feature = "pclmulqdq", target_feature = "sse2"))]
+	{
+		run_unary_op_benchmark(
+			&mut group,
+			"mul_x_clmul::<__m128i>",
+			ghash::clmul::mul_x::<__m128i>,
+			&mut rng,
+			128,
+		);
+	}
+
+	#[cfg(all(
+		target_feature = "vpclmulqdq",
+		target_feature = "avx2",
+		target_feature = "sse2"
+	))]
+	{
+		run_unary_op_benchmark(
+			&mut group,
+			"mul_x_clmul::<__m256i>",
+			ghash::clmul::mul_x::<__m256i>,
+			&mut rng,
+			128,
+		);
+	}
+
+	#[cfg(all(
+		target_arch = "aarch64",
+		target_feature = "neon",
+		target_feature = "aes"
+	))]
+	{
+		run_unary_op_benchmark(
+			&mut group,
+			"mul_x_clmul::uint64x2_t",
+			ghash::clmul::mul_x::<uint64x2_t>,
+			&mut rng,
+			128,
+		);
+	}
+
 	group.finish();
 
 	let mut group = c.benchmark_group("ghash_google");

--- a/crates/arith-bench/benches/field_mul.rs
+++ b/crates/arith-bench/benches/field_mul.rs
@@ -976,7 +976,7 @@ fn bench_ghash_sq(c: &mut Criterion) {
 		);
 	}
 
-	// Benchmark uint64x2_t (AARCH64 NEON)
+	// Benchmark poly64x2_t (AARCH64 NEON)
 	#[cfg(all(
 		target_arch = "aarch64",
 		target_feature = "neon",
@@ -985,8 +985,8 @@ fn bench_ghash_sq(c: &mut Criterion) {
 	{
 		run_mul_benchmark(
 			&mut group,
-			"aarch64::mul_sliced::uint64x2_t",
-			ghash_sq::aarch64::mul_sliced::<uint64x2_t>,
+			"aarch64::mul_sliced",
+			ghash_sq::aarch64::mul_sliced,
 			&mut rng,
 			256,
 		);
@@ -1146,8 +1146,8 @@ fn bench_ghash_sq_inner_product(c: &mut Criterion) {
 	{
 		run_inner_product_benchmark(
 			&mut group,
-			"aarch64::mul_sliced::<uint64x2_t>",
-			ghash_sq::aarch64::mul_sliced::<uint64x2_t>,
+			"aarch64::mul_sliced",
+			ghash_sq::aarch64::mul_sliced,
 			&mut rng,
 			LOG_LEN,
 			128,
@@ -1155,8 +1155,8 @@ fn bench_ghash_sq_inner_product(c: &mut Criterion) {
 
 		run_inner_product_benchmark(
 			&mut group,
-			"aarch64::mul_wide_sliced::<uint64x2_t>",
-			ghash_sq::aarch64::mul_wide_sliced::<uint64x2_t>,
+			"aarch64::mul_wide_sliced",
+			ghash_sq::aarch64::mul_wide_sliced,
 			&mut rng,
 			LOG_LEN,
 			128,

--- a/crates/arith-bench/src/arch/aarch64.rs
+++ b/crates/arith-bench/src/arch/aarch64.rs
@@ -261,7 +261,8 @@ mod tests {
 	use super::*;
 	use crate::{
 		ghash::{
-			INV_X, ONE, X, clmul::mul_inv_x as ghash_mul_inv_x, clmul::mul_x as ghash_mul_x,
+			INV_X, ONE, X,
+			clmul::{mul_inv_x as ghash_mul_inv_x, mul_x as ghash_mul_x},
 			mul_clmul as ghash_mul, square_clmul as ghash_square,
 		},
 		polyval::{MONTGOMERY_ONE, mul_clmul as polyval_mul},

--- a/crates/arith-bench/src/arch/aarch64.rs
+++ b/crates/arith-bench/src/arch/aarch64.rs
@@ -261,8 +261,8 @@ mod tests {
 	use super::*;
 	use crate::{
 		ghash::{
-			INV_X, ONE, clmul::mul_inv_x as ghash_mul_inv_x, mul_clmul as ghash_mul,
-			square_clmul as ghash_square,
+			INV_X, ONE, X, clmul::mul_inv_x as ghash_mul_inv_x, clmul::mul_x as ghash_mul_x,
+			mul_clmul as ghash_mul, square_clmul as ghash_square,
 		},
 		polyval::{MONTGOMERY_ONE, mul_clmul as polyval_mul},
 		rijndael::vmull::mul as rijndael_mul,
@@ -376,6 +376,13 @@ mod tests {
 			a in arb_uint64x2_t()
 		) {
 			test_mul_by_constant(a, INV_X, ghash_mul, ghash_mul_inv_x, "GHASH");
+		}
+
+		#[test]
+		fn test_uint64x2_t_ghash_mul_x_proptest(
+			a in arb_uint64x2_t()
+		) {
+			test_mul_by_constant(a, X, ghash_mul, ghash_mul_x, "GHASH");
 		}
 
 		#[test]

--- a/crates/arith-bench/src/arch/aarch64.rs
+++ b/crates/arith-bench/src/arch/aarch64.rs
@@ -191,9 +191,13 @@ impl crate::underlier::OpsClmul for uint64x2_t {
 	}
 
 	#[inline]
-	fn extract_hi_lo_64(a: Self, b: Self) -> Self {
+	fn alignr_epi8<const IMM8: i32>(a: Self, b: Self) -> Self {
+		// palignr concatenates `a` (high) : `b` (low) and shifts right by IMM8 bytes, which is the
+		// low-first byte extract `vext(b, a, IMM8)`.
 		unsafe {
-			vcombine_u64(vcreate_u64(vgetq_lane_u64(a, 1)), vcreate_u64(vgetq_lane_u64(b, 0)))
+			let a_bytes: uint8x16_t = std::mem::transmute(a);
+			let b_bytes: uint8x16_t = std::mem::transmute(b);
+			std::mem::transmute::<uint8x16_t, uint64x2_t>(vextq_u8::<IMM8>(b_bytes, a_bytes))
 		}
 	}
 

--- a/crates/arith-bench/src/arch/x86_64.rs
+++ b/crates/arith-bench/src/arch/x86_64.rs
@@ -543,8 +543,8 @@ mod tests {
 		)
 	))]
 	use crate::ghash::{
-		INV_X, ONE, clmul::mul_inv_x as ghash_mul_inv_x, mul_clmul as ghash_mul,
-		square_clmul as ghash_square,
+		INV_X, ONE, X, clmul::mul_inv_x as ghash_mul_inv_x, clmul::mul_x as ghash_mul_x,
+		mul_clmul as ghash_mul, square_clmul as ghash_square,
 	};
 	#[cfg(any(
 		all(target_feature = "pclmulqdq", target_feature = "sse2"),
@@ -878,6 +878,14 @@ mod tests {
 
 		#[test]
 		#[cfg(all(target_feature = "pclmulqdq", target_feature = "sse2"))]
+		fn test_m128i_ghash_mul_x_proptest(
+			a in arb_m128i()
+		) {
+			test_mul_by_constant(a, X, ghash_mul, ghash_mul_x, "GHASH");
+		}
+
+		#[test]
+		#[cfg(all(target_feature = "pclmulqdq", target_feature = "sse2"))]
 		fn test_m128i_ghash_square_proptest(
 			a in arb_m128i()
 		) {
@@ -928,6 +936,14 @@ mod tests {
 			a in arb_m256i()
 		) {
 			test_mul_by_constant(a, INV_X, ghash_mul, ghash_mul_inv_x, "GHASH");
+		}
+
+		#[test]
+		#[cfg(all(target_feature = "vpclmulqdq", target_feature = "avx2", target_feature = "sse2"))]
+		fn test_m256i_ghash_mul_x_proptest(
+			a in arb_m256i()
+		) {
+			test_mul_by_constant(a, X, ghash_mul, ghash_mul_x, "GHASH");
 		}
 
 		#[test]

--- a/crates/arith-bench/src/arch/x86_64.rs
+++ b/crates/arith-bench/src/arch/x86_64.rs
@@ -149,7 +149,11 @@ impl crate::underlier::OpsGfni for __m128i {
 	}
 }
 
-#[cfg(all(target_feature = "pclmulqdq", target_feature = "sse2"))]
+#[cfg(all(
+	target_feature = "pclmulqdq",
+	target_feature = "sse2",
+	target_feature = "ssse3"
+))]
 impl crate::underlier::OpsClmul for __m128i {
 	#[inline]
 	fn clmulepi64<const IMM8: i32>(a: Self, b: Self) -> Self {
@@ -167,10 +171,8 @@ impl crate::underlier::OpsClmul for __m128i {
 	}
 
 	#[inline]
-	fn extract_hi_lo_64(a: Self, b: Self) -> Self {
-		unsafe {
-			_mm_castps_si128(_mm_shuffle_ps::<0x4E>(_mm_castsi128_ps(a), _mm_castsi128_ps(b)))
-		}
+	fn alignr_epi8<const IMM8: i32>(a: Self, b: Self) -> Self {
+		unsafe { _mm_alignr_epi8::<IMM8>(a, b) }
 	}
 
 	#[inline]
@@ -427,13 +429,8 @@ impl crate::underlier::OpsClmul for __m256i {
 	}
 
 	#[inline]
-	fn extract_hi_lo_64(a: Self, b: Self) -> Self {
-		unsafe {
-			_mm256_castps_si256(_mm256_shuffle_ps::<0x4E>(
-				_mm256_castsi256_ps(a),
-				_mm256_castsi256_ps(b),
-			))
-		}
+	fn alignr_epi8<const IMM8: i32>(a: Self, b: Self) -> Self {
+		unsafe { _mm256_alignr_epi8::<IMM8>(a, b) }
 	}
 
 	#[inline]

--- a/crates/arith-bench/src/ghash/aarch64.rs
+++ b/crates/arith-bench/src/ghash/aarch64.rs
@@ -1,11 +1,12 @@
 // Copyright 2026 The Binius Developers
 //! Direct aarch64 `PMULL`-accelerated GHASH multiplication.
 //!
-//! GHASH elements are represented as `poly64x2_t` (a SIMD vector type, so the multiply stays in
-//! NEON registers across call boundaries). The `PMULL` / `PMULL2` instructions (`vmull_p64` /
-//! `vmull_high_p64`) drive the carryless multiplies, pairwise 128-bit XORs use `vaddq_p128`, and
-//! three-way XORs go through [`xor3`] (`EOR3` when the `SHA3` extension is available). The
-//! multiply is split into two phases:
+//! GHASH elements and the limbs of an unreduced product are represented as `poly64x2_t` (a SIMD
+//! vector type, so the arithmetic stays in NEON registers across call boundaries — a `p128`/`u128`
+//! limb would be legalized into general-purpose register pairs whenever it is XORed). The `PMULL` /
+//! `PMULL2` instructions (`vmull_p64` / `vmull_high_p64`) drive the carryless multiplies, pairwise
+//! XORs are `vaddq_p64` and three-way XORs go through `xor3` (`EOR3` when the `SHA3` extension is
+//! available). The multiply is split into two phases:
 //!
 //! * `mul_wide`, which produces the unreduced product as three 128-bit limbs `[t0, t1, t2]`: `t0 =
 //!   x0·y0` (low), `t2 = x1·y1` (high), and `t1` the middle (cross) term sitting at offset `X^64`,
@@ -22,40 +23,44 @@ use core::arch::aarch64::*;
 const POLY: u128 = 0x87 << 64;
 
 /// Three-way 128-bit XOR. Uses a single `EOR3` instruction when the `SHA3` extension is
-/// available, otherwise two `vaddq_p128`s.
+/// available, otherwise two `EOR`s.
 #[cfg(target_feature = "sha3")]
 #[inline]
-fn xor3(a: u128, b: u128, c: u128) -> u128 {
+fn xor3(a: poly64x2_t, b: poly64x2_t, c: poly64x2_t) -> poly64x2_t {
 	unsafe {
-		vreinterpretq_p128_u64(veor3q_u64(
-			vreinterpretq_u64_p128(a),
-			vreinterpretq_u64_p128(b),
-			vreinterpretq_u64_p128(c),
+		vreinterpretq_p64_u64(veor3q_u64(
+			vreinterpretq_u64_p64(a),
+			vreinterpretq_u64_p64(b),
+			vreinterpretq_u64_p64(c),
 		))
 	}
 }
 
+/// Three-way 128-bit XOR.
 #[cfg(not(target_feature = "sha3"))]
 #[inline]
-fn xor3(a: u128, b: u128, c: u128) -> u128 {
-	unsafe { vaddq_p128(vaddq_p128(a, b), c) }
+fn xor3(a: poly64x2_t, b: poly64x2_t, c: poly64x2_t) -> poly64x2_t {
+	unsafe { vaddq_p64(vaddq_p64(a, b), c) }
 }
 
 /// Schoolbook widening multiply: four `PMULL`s, no reduction.
 ///
 /// Returns `[t0, t1, t2]` (low, middle, high) as described in the [module docs](self).
 #[inline]
-pub fn mul_wide_schoolbook(x: poly64x2_t, y: poly64x2_t) -> [u128; 3] {
+pub fn mul_wide_schoolbook(x: poly64x2_t, y: poly64x2_t) -> [poly64x2_t; 3] {
 	unsafe {
 		// Cross term x0·y1 ⊕ x1·y0: swapping y's lanes makes PMULL (low×low) and PMULL2
 		// (high×high) compute the opposite-index pairings without moving lanes to scalars.
 		let y_swapped = vextq_p64::<1>(y, y);
-		let cross_a = vmull_p64(vgetq_lane_p64::<0>(x), vgetq_lane_p64::<0>(y_swapped));
-		let cross_b = vmull_high_p64(x, y_swapped);
-		let t1 = vaddq_p128(cross_a, cross_b);
+		let cross_a = vreinterpretq_p64_p128(vmull_p64(
+			vgetq_lane_p64::<0>(x),
+			vgetq_lane_p64::<0>(y_swapped),
+		));
+		let cross_b = vreinterpretq_p64_p128(vmull_high_p64(x, y_swapped));
+		let t1 = vaddq_p64(cross_a, cross_b);
 
-		let t0 = vmull_p64(vgetq_lane_p64::<0>(x), vgetq_lane_p64::<0>(y));
-		let t2 = vmull_high_p64(x, y);
+		let t0 = vreinterpretq_p64_p128(vmull_p64(vgetq_lane_p64::<0>(x), vgetq_lane_p64::<0>(y)));
+		let t2 = vreinterpretq_p64_p128(vmull_high_p64(x, y));
 
 		[t0, t1, t2]
 	}
@@ -66,21 +71,18 @@ pub fn mul_wide_schoolbook(x: poly64x2_t, y: poly64x2_t) -> [u128; 3] {
 /// The middle term is `(x0 ⊕ x1)·(y0 ⊕ y1) ⊕ t0 ⊕ t2`, trading one carryless multiply for two
 /// 128-bit XORs. Returns `[t0, t1, t2]` (low, middle, high).
 #[inline]
-pub fn mul_wide_karatsuba(x: poly64x2_t, y: poly64x2_t) -> [u128; 3] {
+pub fn mul_wide_karatsuba(x: poly64x2_t, y: poly64x2_t) -> [poly64x2_t; 3] {
 	unsafe {
-		let t0 = vmull_p64(vgetq_lane_p64::<0>(x), vgetq_lane_p64::<0>(y));
-		let t2 = vmull_high_p64(x, y);
+		let t0 = vreinterpretq_p64_p128(vmull_p64(vgetq_lane_p64::<0>(x), vgetq_lane_p64::<0>(y)));
+		let t2 = vreinterpretq_p64_p128(vmull_high_p64(x, y));
 
 		// Fold each operand's halves in-vector: lane 0 of `v ⊕ swap(v)` holds v0 ⊕ v1.
-		let x_fold = vreinterpretq_p64_p128(vaddq_p128(
-			vreinterpretq_p128_p64(x),
-			vreinterpretq_p128_p64(vextq_p64::<1>(x, x)),
+		let x_fold = vaddq_p64(x, vextq_p64::<1>(x, x));
+		let y_fold = vaddq_p64(y, vextq_p64::<1>(y, y));
+		let mid = vreinterpretq_p64_p128(vmull_p64(
+			vgetq_lane_p64::<0>(x_fold),
+			vgetq_lane_p64::<0>(y_fold),
 		));
-		let y_fold = vreinterpretq_p64_p128(vaddq_p128(
-			vreinterpretq_p128_p64(y),
-			vreinterpretq_p128_p64(vextq_p64::<1>(y, y)),
-		));
-		let mid = vmull_p64(vgetq_lane_p64::<0>(x_fold), vgetq_lane_p64::<0>(y_fold));
 		let t1 = xor3(mid, t0, t2);
 
 		[t0, t1, t2]
@@ -90,36 +92,115 @@ pub fn mul_wide_karatsuba(x: poly64x2_t, y: poly64x2_t) -> [u128; 3] {
 /// Folds the 128-bit limb `b`, positioned at offset `X^64`, into the accumulator `a`, returning
 /// the 128-bit value congruent to `a + b·X^64` modulo the GHASH polynomial.
 #[inline]
-fn fold(a: u128, b: u128) -> u128 {
+fn fold(a: poly64x2_t, b: poly64x2_t) -> poly64x2_t {
 	unsafe {
-		let bv = vreinterpretq_p64_p128(b);
 		// b.lo·X^64 stays within the limb: move the low lane into the high lane, zero the low.
 		let zero = vreinterpretq_p64_p128(0u128);
-		let shifted = vreinterpretq_p128_p64(vextq_p64::<1>(zero, bv));
+		let shifted = vextq_p64::<1>(zero, b);
 		// b.hi·X^128 ≡ b.hi·POLY since X^128 ≡ X^7 + X^2 + X + 1; the degree-7 POLY keeps this
 		// within 128 bits, so no second fold is needed.
-		let folded = vmull_high_p64(bv, vreinterpretq_p64_p128(POLY));
+		let folded = vreinterpretq_p64_p128(vmull_high_p64(b, vreinterpretq_p64_p128(POLY)));
 		xor3(a, shifted, folded)
 	}
 }
 
 /// Reduces the wide product `[t0, t1, t2]` to a single GHASH element.
 #[inline]
-pub fn reduce([t0, t1, t2]: [u128; 3]) -> u128 {
+pub fn reduce([t0, t1, t2]: [poly64x2_t; 3]) -> poly64x2_t {
 	let t1 = fold(t1, t2);
 	fold(t0, t1)
+}
+
+/// Multiply a GHASH element by X.
+///
+/// This is equivalent to `mul(x, X)` but optimized: a full 128-bit left shift by one, folding in
+/// the reduction polynomial if bit 127 overflowed (`X^128 ≡ X^7 + X^2 + X + 1 = 0x87`).
+#[inline]
+pub fn mul_x(x: poly64x2_t) -> poly64x2_t {
+	unsafe {
+		let v = vreinterpretq_u64_p64(x);
+
+		// Full 128-bit left shift by one: shift each lane, then carry bit 63 of the low lane into
+		// bit 0 of the high lane. `vextq_u64::<1>(zero, w)` is a shift of `w` left by 8 bytes.
+		let zero = vreinterpretq_u64_p128(0);
+		let carry = vextq_u64::<1>(zero, vshrq_n_u64::<63>(v));
+		let shifted = veorq_u64(vshlq_n_u64::<1>(v), carry);
+
+		// All-ones in both lanes iff bit 127 was set: duplicate the high lane, then broadcast its
+		// sign bit with an arithmetic shift.
+		let msb_mask = vreinterpretq_u64_s64(vshrq_n_s64::<63>(vreinterpretq_s64_u64(
+			vdupq_laneq_u64::<1>(v),
+		)));
+
+		// Conditionally fold in the reduction polynomial, which sits in the low lane.
+		let poly = vreinterpretq_u64_p128(0x87);
+		vreinterpretq_p64_u64(veorq_u64(shifted, vandq_u64(poly, msb_mask)))
+	}
+}
+
+/// Multiply an unreduced widening product (the three 128-bit limbs `[t0, t1, t2]` from a
+/// `mul_wide`, at weights `X^0, X^64, X^128`) by X: a one-bit left shift of the represented
+/// 256-bit polynomial.
+///
+/// Requires each limb's bit 127 to be zero, which holds for any XOR-accumulation of `mul_wide`
+/// outputs since each limb is then a sum of carry-less products of two 64-bit halves. The shift
+/// therefore never overflows the three limbs — no reduction is needed here, keeping it deferred to
+/// the single [`reduce`]. Because both this shift and [`reduce`] are F2-linear, the multiply-by-X
+/// may be applied to XOR-accumulated products and reduced once.
+///
+/// The result does *not* satisfy that invariant (bit 126 of a limb shifts into bit 127), so this is
+/// not to be applied twice; reduce in between.
+#[inline]
+pub fn mul_x_wide([t0, t1, t2]: [poly64x2_t; 3]) -> [poly64x2_t; 3] {
+	unsafe {
+		let v0 = vreinterpretq_u64_p64(t0);
+		let v1 = vreinterpretq_u64_p64(t1);
+		let v2 = vreinterpretq_u64_p64(t2);
+
+		// Shift each 64-bit lane up by one; `srl` holds the bit shifted out of the top of each
+		// lane, which belongs 64 bit positions higher — i.e. in the lanes of the next limb, since
+		// consecutive limbs overlap by 64 bits.
+		let sll0 = vreinterpretq_p64_u64(vshlq_n_u64::<1>(v0));
+		let sll1 = vreinterpretq_p64_u64(vshlq_n_u64::<1>(v1));
+		let sll2 = vreinterpretq_p64_u64(vshlq_n_u64::<1>(v2));
+
+		let srl0 = vreinterpretq_p64_u64(vshrq_n_u64::<63>(v0));
+		let srl1 = vreinterpretq_p64_u64(vshrq_n_u64::<63>(v1));
+		let srl2 = vreinterpretq_p64_u64(vshrq_n_u64::<63>(v2));
+
+		// `t2` has no higher limb to carry into: its low lane's carry belongs in its own high lane,
+		// where rotating the lanes puts it. The rotation also wraps the high lane's carry — bit 255
+		// of the product — back into the low lane, which is harmless precisely because `t2`'s bit
+		// 127, and hence that carry, is zero.
+		let carry2 = vextq_p64::<1>(srl2, srl2);
+
+		[sll0, vaddq_p64(sll1, srl0), xor3(sll2, srl1, carry2)]
+	}
+}
+
+/// Square a GHASH element.
+///
+/// Squaring is a carry-less multiply of `x` by itself, so the cross term `x0·y1 ⊕ x1·y0` cancels:
+/// only the two corner products remain, and the middle limb of the wide product is zero.
+#[inline]
+pub fn square(x: poly64x2_t) -> poly64x2_t {
+	unsafe {
+		let t0 = vreinterpretq_p64_p128(vmull_p64(vgetq_lane_p64::<0>(x), vgetq_lane_p64::<0>(x)));
+		let t2 = vreinterpretq_p64_p128(vmull_high_p64(x, x));
+		reduce([t0, vreinterpretq_p64_p128(0), t2])
+	}
 }
 
 /// Multiply two GHASH elements using the schoolbook widening multiply.
 #[inline]
 pub fn mul_schoolbook(x: poly64x2_t, y: poly64x2_t) -> poly64x2_t {
-	unsafe { vreinterpretq_p64_p128(reduce(mul_wide_schoolbook(x, y))) }
+	reduce(mul_wide_schoolbook(x, y))
 }
 
 /// Multiply two GHASH elements using the Karatsuba widening multiply.
 #[inline]
 pub fn mul_karatsuba(x: poly64x2_t, y: poly64x2_t) -> poly64x2_t {
-	unsafe { vreinterpretq_p64_p128(reduce(mul_wide_karatsuba(x, y))) }
+	reduce(mul_wide_karatsuba(x, y))
 }
 
 #[cfg(test)]
@@ -127,7 +208,7 @@ mod tests {
 	use proptest::prelude::*;
 
 	use super::*;
-	use crate::ghash::soft64;
+	use crate::{Underlier, ghash::soft64};
 
 	fn to_poly(x: u128) -> poly64x2_t {
 		unsafe { vreinterpretq_p64_p128(x) }
@@ -146,6 +227,38 @@ mod tests {
 		#[test]
 		fn test_mul_karatsuba_matches_soft64(a in any::<u128>(), b in any::<u128>()) {
 			prop_assert_eq!(from_poly(mul_karatsuba(to_poly(a), to_poly(b))), soft64::mul(a, b));
+		}
+
+		#[test]
+		fn test_square_matches_soft64(a in any::<u128>()) {
+			prop_assert_eq!(from_poly(square(to_poly(a))), soft64::square(a));
+		}
+
+		#[test]
+		fn test_mul_x_matches_soft64(a in any::<u128>()) {
+			prop_assert_eq!(from_poly(mul_x(to_poly(a))), soft64::mul_x(a));
+		}
+
+		// `mul_x_wide` on an unreduced product then `reduce` equals `mul_x` after `reduce`: both
+		// paths compute X times the represented field element (the multiply-by-X commutes with the
+		// F2-linear reduction).
+		#[test]
+		fn test_mul_x_wide_matches_soft64(a in any::<u128>(), b in any::<u128>()) {
+			let wide = mul_wide_karatsuba(to_poly(a), to_poly(b));
+			prop_assert_eq!(from_poly(reduce(mul_x_wide(wide))), soft64::mul_x(soft64::mul(a, b)));
+		}
+
+		// The reduction is F2-linear, so accumulating two unreduced products by XOR and reducing
+		// once equals reducing each and summing.
+		#[test]
+		fn test_wide_deferred_reduction(
+			a1 in any::<u128>(), b1 in any::<u128>(),
+			a2 in any::<u128>(), b2 in any::<u128>(),
+		) {
+			let p = mul_wide_karatsuba(to_poly(a1), to_poly(b1));
+			let q = mul_wide_schoolbook(to_poly(a2), to_poly(b2));
+			let acc = reduce(<[poly64x2_t; 3]>::xor(p, q));
+			prop_assert_eq!(from_poly(acc), soft64::mul(a1, b1) ^ soft64::mul(a2, b2));
 		}
 	}
 }

--- a/crates/arith-bench/src/ghash/clmul.rs
+++ b/crates/arith-bench/src/ghash/clmul.rs
@@ -54,6 +54,46 @@ pub fn mul_inv_x<U: Underlier + OpsClmul + PackedUnderlier<u128>>(x: U) -> U {
 	U::xor(shifted, U::and(inv_x, lsb_mask))
 }
 
+/// Multiply a packed GHASH field element by X using SIMD operations.
+///
+/// This is equivalent to `mul(x, broadcast(X))` but optimized: per 128-bit lane, left-shift by 1
+/// and conditionally XOR with the reduction polynomial if bit 127 overflowed
+/// (`X^128 ≡ X^7 + X^2 + X + 1 = 0x87`).
+#[inline]
+pub fn mul_x<U: Underlier + OpsClmul + PackedUnderlier<u128>>(x: U) -> U {
+	let poly = <U as PackedUnderlier<u128>>::broadcast(0x87);
+
+	// Full 128-bit left shift by one, per 128-bit lane.
+	let shifted = shift_left_1(x);
+
+	// Build a mask from bit 127 of each 128-bit element (bit 63 of the high qword): duplicate the
+	// high qword into both lanes, then broadcast its sign bit.
+	let msb_mask = U::movepi64_mask(U::unpackhi_epi64(x, x));
+
+	// Conditionally fold in the reduction polynomial where bit 127 overflowed.
+	U::xor(shifted, U::and(poly, msb_mask))
+}
+
+/// Left-shift each 128-bit lane by one bit, carrying bit 63 of the low qword into bit 0 of the high
+/// qword. The bit shifted out of the top of each lane (bit 127) is dropped.
+#[inline]
+fn shift_left_1<U: Underlier + OpsClmul>(x: U) -> U {
+	U::xor(U::slli_epi64::<1>(x), U::slli_si128::<8>(U::srli_epi64::<63>(x)))
+}
+
+/// Multiply an unreduced widening product (the three 128-bit limbs `[t0, t1, t2]` from
+/// [`mul_wide`], at weights `X^0, X^64, X^128`) by X: a one-bit left shift of each limb.
+///
+/// Each limb is a carry-less product of two 64-bit halves, so its bit 127 is zero and the per-limb
+/// shift never overflows — no reduction is needed here, keeping it deferred to the single
+/// [`reduce`]. Shifting each limb left by one multiplies the represented 256-bit polynomial by X;
+/// because both this shift and [`reduce`] are F2-linear, the multiply-by-X may be applied to
+/// XOR-accumulated products and reduced once.
+#[inline]
+pub fn mul_x_wide<U: Underlier + OpsClmul + PackedUnderlier<u128>>([t0, t1, t2]: [U; 3]) -> [U; 3] {
+	[shift_left_1(t0), shift_left_1(t1), shift_left_1(t2)]
+}
+
 /// Widening (unreduced) CLMUL GHASH multiply: the schoolbook product as three 128-bit limbs
 /// `[t0, t1, t2]`, without the modular reduction.
 ///
@@ -396,5 +436,17 @@ mod tests {
 			prop_assert_eq!(from_u(acc), soft64::mul(a1, b1) ^ soft64::mul(a2, b2));
 		}
 
+		// The CLMUL multiply-by-X agrees with the soft64 reference.
+		#[test]
+		fn test_clmul_mul_x_matches_soft64(a in any::<u128>()) {
+			prop_assert_eq!(from_u(mul_x(to_u(a))), soft64::mul_x(a));
+		}
+
+		// The CLMUL widening multiply-by-X, reduced, agrees with soft64's `mul_x ∘ reduce`.
+		#[test]
+		fn test_clmul_mul_x_wide_matches_soft64(a in any::<u128>(), b in any::<u128>()) {
+			let wide = mul_wide(to_u(a), to_u(b));
+			prop_assert_eq!(from_u(reduce(mul_x_wide(wide))), soft64::mul_x(soft64::mul(a, b)));
+		}
 	}
 }

--- a/crates/arith-bench/src/ghash/clmul.rs
+++ b/crates/arith-bench/src/ghash/clmul.rs
@@ -91,7 +91,19 @@ fn shift_left_1<U: Underlier + OpsClmul>(x: U) -> U {
 /// XOR-accumulated products and reduced once.
 #[inline]
 pub fn mul_x_wide<U: Underlier + OpsClmul + PackedUnderlier<u128>>([t0, t1, t2]: [U; 3]) -> [U; 3] {
-	[shift_left_1(t0), shift_left_1(t1), shift_left_1(t2)]
+	let t0_sll = U::slli_epi64::<1>(t0);
+	let t1_sll = U::slli_epi64::<1>(t1);
+	let t2_sll = U::slli_epi64::<1>(t2);
+
+	let t0_srl = U::srli_epi64::<63>(t0);
+	let t1_srl = U::srli_epi64::<63>(t1);
+	let t2_srl = U::srli_epi64::<63>(t2);
+
+	[
+		t0_sll,
+		U::xor(t1_sll, t0_srl),
+		U::xor(U::xor(t2_sll, t1_srl), U::slli_si128::<8>(t2_srl)),
+	]
 }
 
 /// Widening (unreduced) CLMUL GHASH multiply: the schoolbook product as three 128-bit limbs

--- a/crates/arith-bench/src/ghash/mod.rs
+++ b/crates/arith-bench/src/ghash/mod.rs
@@ -18,6 +18,12 @@ pub const ONE: u128 = 0x01;
 /// X^{-1} = X^127 + X^6 + X + 1 modulo X^128 + X^7 + X^2 + X + 1.
 pub const INV_X: u128 = 0x80000000000000000000000000000043;
 
+/// The field generator X in GHASH.
+///
+/// In the polynomial-basis representation used here (bit `i` is the coefficient of `X^i`), `X` is
+/// simply `X^1`.
+pub const X: u128 = 0x02;
+
 // Re-export mul_clmul for backward compatibility
 #[allow(unused_imports)]
 pub use clmul::{mul as mul_clmul, square as square_clmul};

--- a/crates/arith-bench/src/ghash/soft64.rs
+++ b/crates/arith-bench/src/ghash/soft64.rs
@@ -148,8 +148,8 @@ pub const fn mul_x(x: u128) -> u128 {
 ///
 /// A widening product of two GHASH elements has degree at most 254, so bit 255 is zero and the
 /// shift never overflows the four limbs — no reduction is needed here, keeping it deferred to the
-/// single [`reduce`]. Because both this shift and [`reduce`] are F2-linear, the multiply-by-X may be
-/// applied to XOR-accumulated products and reduced once.
+/// single [`reduce`]. Because both this shift and [`reduce`] are F2-linear, the multiply-by-X may
+/// be applied to XOR-accumulated products and reduced once.
 pub const fn mul_x_wide([v0, v1, v2, v3]: [u64; 4]) -> [u64; 4] {
 	[
 		v0 << 1,

--- a/crates/arith-bench/src/ghash/soft64.rs
+++ b/crates/arith-bench/src/ghash/soft64.rs
@@ -132,13 +132,40 @@ pub const fn mul_inv_x(x: u128) -> u128 {
 	shifted ^ (super::INV_X & (lsb.wrapping_neg()))
 }
 
+/// Multiply a GHASH field element by X.
+///
+/// This is equivalent to `mul(x, X)` but optimized: left-shift by 1 and conditionally fold in the
+/// reduction polynomial if bit 127 overflowed. `X^128 ≡ X^7 + X^2 + X + 1 = 0x87`.
+pub const fn mul_x(x: u128) -> u128 {
+	let msb = x >> 127;
+	let shifted = x << 1;
+	// If bit 127 was set, XOR with 0x87; the mask is all-ones when msb=1, all-zeros when msb=0.
+	shifted ^ (0x87 & msb.wrapping_neg())
+}
+
+/// Multiply an unreduced widening product (the four 64-bit limbs `[v0, v1, v2, v3]` of a 256-bit
+/// value, as returned by [`mul_wide`]) by X: a one-bit left shift of the whole 256-bit value.
+///
+/// A widening product of two GHASH elements has degree at most 254, so bit 255 is zero and the
+/// shift never overflows the four limbs — no reduction is needed here, keeping it deferred to the
+/// single [`reduce`]. Because both this shift and [`reduce`] are F2-linear, the multiply-by-X may be
+/// applied to XOR-accumulated products and reduced once.
+pub const fn mul_x_wide([v0, v1, v2, v3]: [u64; 4]) -> [u64; 4] {
+	[
+		v0 << 1,
+		(v1 << 1) | (v0 >> 63),
+		(v2 << 1) | (v1 >> 63),
+		(v3 << 1) | (v2 >> 63),
+	]
+}
+
 #[cfg(test)]
 mod tests {
 	use proptest::prelude::*;
 
 	use super::*;
 	use crate::{
-		ghash::{INV_X, ONE},
+		ghash::{INV_X, ONE, X},
 		test_utils::multiplication_tests::{
 			test_mul_associative, test_mul_commutative, test_mul_distributive,
 			test_square_equals_mul,
@@ -184,6 +211,24 @@ mod tests {
 			a in any::<u128>(),
 		) {
 			prop_assert_eq!(mul_inv_x(a), mul(a, INV_X), "mul_inv_x does not match mul by INV_X");
+		}
+
+		#[test]
+		fn test_ghash_soft64_mul_x(
+			a in any::<u128>(),
+		) {
+			prop_assert_eq!(mul_x(a), mul(a, X), "mul_x does not match mul by X");
+		}
+
+		// `mul_x_wide` on an unreduced product then `reduce` equals `mul_x` after `reduce`: both
+		// paths compute X times the represented field element (the multiply-by-X commutes with the
+		// F2-linear reduction).
+		#[test]
+		fn test_ghash_soft64_mul_x_wide(
+			a in any::<u128>(), b in any::<u128>(),
+		) {
+			let wide = mul_wide(a, b);
+			prop_assert_eq!(reduce(mul_x_wide(wide)), mul_x(reduce(wide)));
 		}
 
 

--- a/crates/arith-bench/src/ghash_sq/aarch64.rs
+++ b/crates/arith-bench/src/ghash_sq/aarch64.rs
@@ -14,7 +14,7 @@ pub fn mul_sliced<U: Underlier + OpsClmul + PackedUnderlier<u128>>(x: [U; 2], y:
 		y,
 		ghash::clmul::mul_wide,
 		ghash::clmul::reduce,
-		ghash::clmul::mul_inv_x,
+		ghash::clmul::mul_x_wide,
 	)
 }
 
@@ -33,13 +33,13 @@ pub fn mul_wide_sliced<U: Underlier + OpsClmul + PackedUnderlier<u128>>(
 /// arithmetic; see [`super::sliced::reduce_sliced`].
 #[inline]
 pub fn reduce_sliced<U: Underlier + OpsClmul + PackedUnderlier<u128>>(t: [[U; 3]; 3]) -> [U; 2] {
-	super::sliced::reduce_sliced(t, ghash::clmul::reduce, ghash::clmul::mul_inv_x)
+	super::sliced::reduce_sliced(t, ghash::clmul::reduce, ghash::clmul::mul_x_wide)
 }
 
 /// Square packed GHASH² elements in sliced representation using CLMUL arithmetic.
 #[inline]
 pub fn square_sliced<U: Underlier + OpsClmul + PackedUnderlier<u128>>(x: [U; 2]) -> [U; 2] {
-	super::sliced::square_sliced(x, ghash::clmul::square, ghash::clmul::mul_inv_x)
+	super::sliced::square_sliced(x, ghash::clmul::square, ghash::clmul::mul_x)
 }
 
 /// Multiply a GHASH² element stored as a pair of NEON registers.

--- a/crates/arith-bench/src/ghash_sq/aarch64.rs
+++ b/crates/arith-bench/src/ghash_sq/aarch64.rs
@@ -1,65 +1,83 @@
 // Copyright 2026 The Binius Developers
-//! GHASH² sliced multiplication and squaring using aarch64 CLMUL (PMULL) instructions.
+//! GHASH² sliced multiplication and squaring using aarch64 `PMULL` instructions.
+//!
+//! Elements are held as `poly64x2_t` and the unreduced widening products as the three 128-bit
+//! limbs `[poly64x2_t; 3]` of [`crate::ghash::aarch64`], so the arithmetic stays in NEON registers.
 
-#[cfg(target_arch = "aarch64")]
-use std::arch::aarch64::uint64x2_t;
+use core::arch::aarch64::poly64x2_t;
 
-use crate::{PackedUnderlier, Underlier, ghash, underlier::OpsClmul};
+use crate::ghash::aarch64 as ghash;
 
-/// Multiply packed GHASH² elements in sliced representation using CLMUL arithmetic.
+/// Multiply packed GHASH² elements in sliced representation using `PMULL` arithmetic.
 #[inline]
-pub fn mul_sliced<U: Underlier + OpsClmul + PackedUnderlier<u128>>(x: [U; 2], y: [U; 2]) -> [U; 2] {
-	super::sliced::mul_sliced(
-		x,
-		y,
-		ghash::clmul::mul_wide,
-		ghash::clmul::reduce,
-		ghash::clmul::mul_x_wide,
-	)
+pub fn mul_sliced(x: [poly64x2_t; 2], y: [poly64x2_t; 2]) -> [poly64x2_t; 2] {
+	super::sliced::mul_sliced(x, y, ghash::mul_wide_schoolbook, ghash::reduce, ghash::mul_x_wide)
 }
 
-/// Widening (unreduced) multiply of packed GHASH² elements in sliced representation using CLMUL
-/// arithmetic. Returns the three raw GHASH products (`[U; 3]` each); see
+/// Widening (unreduced) multiply of packed GHASH² elements in sliced representation using `PMULL`
+/// arithmetic. Returns the three raw GHASH products (`[poly64x2_t; 3]` each); see
 /// [`super::sliced::mul_wide_sliced`] and reduce with [`reduce_sliced`].
 #[inline]
-pub fn mul_wide_sliced<U: Underlier + OpsClmul + PackedUnderlier<u128>>(
-	x: [U; 2],
-	y: [U; 2],
-) -> [[U; 3]; 3] {
-	super::sliced::mul_wide_sliced(x, y, ghash::clmul::mul_wide)
+pub fn mul_wide_sliced(x: [poly64x2_t; 2], y: [poly64x2_t; 2]) -> [[poly64x2_t; 3]; 3] {
+	super::sliced::mul_wide_sliced(x, y, ghash::mul_wide_schoolbook)
 }
 
-/// Reduce the three raw products from [`mul_wide_sliced`] into a GHASH² element using CLMUL
+/// Reduce the three raw products from [`mul_wide_sliced`] into a GHASH² element using `PMULL`
 /// arithmetic; see [`super::sliced::reduce_sliced`].
 #[inline]
-pub fn reduce_sliced<U: Underlier + OpsClmul + PackedUnderlier<u128>>(t: [[U; 3]; 3]) -> [U; 2] {
-	super::sliced::reduce_sliced(t, ghash::clmul::reduce, ghash::clmul::mul_x_wide)
+pub fn reduce_sliced(t: [[poly64x2_t; 3]; 3]) -> [poly64x2_t; 2] {
+	super::sliced::reduce_sliced(t, ghash::reduce, ghash::mul_x_wide)
 }
 
-/// Square packed GHASH² elements in sliced representation using CLMUL arithmetic.
+/// Square packed GHASH² elements in sliced representation using `PMULL` arithmetic.
 #[inline]
-pub fn square_sliced<U: Underlier + OpsClmul + PackedUnderlier<u128>>(x: [U; 2]) -> [U; 2] {
-	super::sliced::square_sliced(x, ghash::clmul::square, ghash::clmul::mul_x)
+pub fn square_sliced(x: [poly64x2_t; 2]) -> [poly64x2_t; 2] {
+	super::sliced::square_sliced(x, ghash::square, ghash::mul_x)
 }
 
-/// Multiply a GHASH² element stored as a pair of NEON registers.
-#[cfg(all(
-	target_arch = "aarch64",
-	target_feature = "neon",
-	target_feature = "aes"
-))]
-#[inline]
-pub fn mul_neon(x: [uint64x2_t; 2], y: [uint64x2_t; 2]) -> [uint64x2_t; 2] {
-	mul_sliced(x, y)
-}
+#[cfg(test)]
+mod tests {
+	use core::arch::aarch64::{vreinterpretq_p64_p128, vreinterpretq_p128_p64};
 
-/// Square a GHASH² element stored as a pair of NEON registers.
-#[cfg(all(
-	target_arch = "aarch64",
-	target_feature = "neon",
-	target_feature = "aes"
-))]
-#[inline]
-pub fn square_neon(x: [uint64x2_t; 2]) -> [uint64x2_t; 2] {
-	square_sliced(x)
+	use proptest::prelude::*;
+
+	use super::*;
+	use crate::{Underlier, ghash_sq::soft64};
+
+	fn to_poly(x: [u128; 2]) -> [poly64x2_t; 2] {
+		x.map(|v| unsafe { vreinterpretq_p64_p128(v) })
+	}
+
+	fn from_poly(x: [poly64x2_t; 2]) -> [u128; 2] {
+		x.map(|v| unsafe { vreinterpretq_p128_p64(v) })
+	}
+
+	proptest! {
+		// The PMULL sliced multiply agrees with the soft64 reference.
+		#[test]
+		fn test_mul_sliced_matches_soft64(a in any::<[u128; 2]>(), b in any::<[u128; 2]>()) {
+			prop_assert_eq!(from_poly(mul_sliced(to_poly(a), to_poly(b))), soft64::mul_sliced(a, b));
+		}
+
+		// The PMULL sliced square agrees with the soft64 reference.
+		#[test]
+		fn test_square_sliced_matches_soft64(a in any::<[u128; 2]>()) {
+			prop_assert_eq!(from_poly(square_sliced(to_poly(a))), soft64::square_sliced(a));
+		}
+
+		// Deferred reduction: accumulating the three raw products by XOR and calling reduce_sliced
+		// once equals summing the reduced products.
+		#[test]
+		fn test_wide_sliced_deferred_reduction(
+			a1 in any::<[u128; 2]>(), b1 in any::<[u128; 2]>(),
+			a2 in any::<[u128; 2]>(), b2 in any::<[u128; 2]>(),
+		) {
+			let acc = <[[poly64x2_t; 3]; 3]>::xor(
+				mul_wide_sliced(to_poly(a1), to_poly(b1)),
+				mul_wide_sliced(to_poly(a2), to_poly(b2)),
+			);
+			let sum = <[u128; 2]>::xor(soft64::mul_sliced(a1, b1), soft64::mul_sliced(a2, b2));
+			prop_assert_eq!(from_poly(reduce_sliced(acc)), sum);
+		}
+	}
 }

--- a/crates/arith-bench/src/ghash_sq/mod.rs
+++ b/crates/arith-bench/src/ghash_sq/mod.rs
@@ -5,7 +5,7 @@
 //! extension of the GHASH field. Elements are pairs (a, b) representing a + bY, where a and b are
 //! elements of the GHASH field GF(2)\[X\] / (X^128 + X^7 + X^2 + X + 1).
 //!
-//! The extension is defined by the irreducible polynomial Y^2 + Y + X^{-1} over the GHASH field.
+//! The extension is defined by the irreducible polynomial Y^2 + X*Y + X over the GHASH field.
 
 pub mod aarch64;
 pub mod sliced;

--- a/crates/arith-bench/src/ghash_sq/mod.rs
+++ b/crates/arith-bench/src/ghash_sq/mod.rs
@@ -7,6 +7,7 @@
 //!
 //! The extension is defined by the irreducible polynomial Y^2 + X*Y + X over the GHASH field.
 
+#[cfg(target_arch = "aarch64")]
 pub mod aarch64;
 pub mod sliced;
 pub mod soft64;

--- a/crates/arith-bench/src/ghash_sq/sliced.rs
+++ b/crates/arith-bench/src/ghash_sq/sliced.rs
@@ -62,7 +62,7 @@ pub fn reduce_sliced<U: Underlier, W: Underlier>(
 ) -> [U; 2] {
 	let x_t2 = ghash_mul_x_wide(t2);
 	let z0 = ghash_reduce(W::xor(t0, x_t2));
-	let z1 = ghash_reduce(W::xor(W::xor(W::xor(t1, t0), t2), x_t2));
+	let z1 = U::xor(z0, ghash_reduce(W::xor(t1, t2)));
 	[z0, z1]
 }
 

--- a/crates/arith-bench/src/ghash_sq/sliced.rs
+++ b/crates/arith-bench/src/ghash_sq/sliced.rs
@@ -8,16 +8,21 @@
 //!
 //! This layout enables SIMD-parallel multiplication of multiple GHASH² elements, since the
 //! underlying GHASH operations operate on all packed lanes simultaneously.
+//!
+//! The extension is defined by the irreducible polynomial `Y² + X·Y + X` over the GHASH field, so
+//! `Y² = X·Y + X`. Reducing this way multiplies by `X` (a left shift) rather than by `X⁻¹`, and the
+//! multiply-by-`X` is applied to the *unreduced* widening product, which saves one base-field
+//! reduction per multiply (two instead of three).
 
 use crate::Underlier;
 
 /// Widening (unreduced) multiply of packed GHASH² elements in sliced representation.
 ///
 /// Returns the three raw base-field products `[t0, t1, t2] = [x0·y0, (x0+x1)·(y0+y1), x1·y1]` — the
-/// Karatsuba terms for `Y² + Y + X⁻¹` — still *unreduced*. No combination or multiply-by-`X⁻¹` is
+/// Karatsuba terms for `Y² + X·Y + X` — still *unreduced*. No combination or multiply-by-`X` is
 /// done here: those are F2-linear and deferred to [`reduce_sliced`], so an inner product
 /// XOR-accumulates the three products (`W` is an [`Underlier`] via the blanket array impl) and pays
-/// the reduction and the `X⁻¹` exactly once at the end rather than per term.
+/// the reduction and the `X` exactly once at the end rather than per term.
 #[inline]
 pub fn mul_wide_sliced<U: Underlier, W>(
 	x: [U; 2],
@@ -37,19 +42,27 @@ pub fn mul_wide_sliced<U: Underlier, W>(
 /// Reduce the three raw products `[t0, t1, t2]` from [`mul_wide_sliced`] into the two GHASH²
 /// coefficients.
 ///
-/// The cross term is recovered by Karatsuba as `t1 + t0 + t2` and, over `Y² + Y + X⁻¹`, the `t2`
-/// term collapses so that `z0 = t0 + X⁻¹·t2` and `z1 = t1 + t0`. The multiply-by-`X⁻¹` lives here —
-/// applied to the reduced `t2` — so an inner product performs it (and every base-field reduction)
-/// only once, on the accumulated products.
+/// Over `Y² + X·Y + X` (so `Y² = X·Y + X`), writing `x = x0 + x1·Y` and `y = y0 + y1·Y`:
+///
+/// ```text
+/// z0 = x0·y0 + X·(x1·y1)             = t0 + X·t2
+/// z1 = x0·y1 + x1·y0 + X·(x1·y1)     = (t1 + t0 + t2) + X·t2
+/// ```
+///
+/// with Karatsuba recovering the cross term `x0·y1 + x1·y0` as `t1 + t0 + t2`. The multiply-by-`X`
+/// (a plain shift of the unreduced `t2`) and the XOR combinations live here, applied to the raw
+/// products, so only the two output coefficients are reduced — two base-field reductions instead of
+/// three. An inner product therefore performs each reduction (and the `X`) only once, on the
+/// accumulated products.
 #[inline]
-pub fn reduce_sliced<U: Underlier, W>(
+pub fn reduce_sliced<U: Underlier, W: Underlier>(
 	[t0, t1, t2]: [W; 3],
 	ghash_reduce: impl Fn(W) -> U,
-	ghash_mul_inv_x: impl Fn(U) -> U,
+	ghash_mul_x_wide: impl Fn(W) -> W,
 ) -> [U; 2] {
-	let r0 = ghash_reduce(t0);
-	let z0 = U::xor(r0, ghash_mul_inv_x(ghash_reduce(t2)));
-	let z1 = U::xor(ghash_reduce(t1), r0);
+	let x_t2 = ghash_mul_x_wide(t2);
+	let z0 = ghash_reduce(W::xor(t0, x_t2));
+	let z1 = ghash_reduce(W::xor(W::xor(W::xor(t1, t0), t2), x_t2));
 	[z0, z1]
 }
 
@@ -57,40 +70,39 @@ pub fn reduce_sliced<U: Underlier, W>(
 ///
 /// Given `x = [x0, x1]` and `y = [y0, y1]` representing packed GHASH² elements where `x0`/`y0`
 /// hold the lower limbs and `x1`/`y1` hold the upper limbs, computes the product in the extension
-/// field defined by Y² + Y + X⁻¹.
+/// field defined by `Y² + X·Y + X`.
 ///
 /// Composes [`mul_wide_sliced`] with [`reduce_sliced`].
 #[inline]
-pub fn mul_sliced<U: Underlier, W>(
+pub fn mul_sliced<U: Underlier, W: Underlier>(
 	x: [U; 2],
 	y: [U; 2],
 	ghash_wide_mul: impl Fn(U, U) -> W,
 	ghash_reduce: impl Fn(W) -> U,
-	ghash_mul_inv_x: impl Fn(U) -> U,
+	ghash_mul_x_wide: impl Fn(W) -> W,
 ) -> [U; 2] {
-	reduce_sliced(mul_wide_sliced(x, y, ghash_wide_mul), ghash_reduce, ghash_mul_inv_x)
+	reduce_sliced(mul_wide_sliced(x, y, ghash_wide_mul), ghash_reduce, ghash_mul_x_wide)
 }
 
 /// Square a packed GHASH² element in sliced representation.
 ///
 /// Given `x = [x0, x1]` representing a packed GHASH² element where `x0` holds the lower limb and
-/// `x1` holds the upper limb, computes the square in the extension field defined by
-/// Y² + Y + X⁻¹.
+/// `x1` holds the upper limb, computes the square in the extension field defined by `Y² + X·Y + X`.
 ///
-/// Uses the identity (a + bY)² = a² + b²X⁻¹ + b²Y, requiring two base-field squarings and one
-/// multiply-by-X⁻¹.
+/// Uses the identity `(a + bY)² = a² + b²·Y² = (a² + X·b²) + (X·b²)·Y`, requiring two base-field
+/// squarings and one multiply-by-`X`.
 #[inline]
 pub fn square_sliced<U: Underlier>(
 	x: [U; 2],
 	ghash_square: impl Fn(U) -> U,
-	ghash_mul_inv_x: impl Fn(U) -> U,
+	ghash_mul_x: impl Fn(U) -> U,
 ) -> [U; 2] {
 	let [x0, x1] = x;
 
-	let t0 = ghash_square(x0);
-	let t2 = ghash_square(x1);
+	let a2 = ghash_square(x0);
+	let x_b2 = ghash_mul_x(ghash_square(x1));
 
-	let z0 = U::xor(t0, ghash_mul_inv_x(t2));
-	let z1 = t2;
+	let z0 = U::xor(a2, x_b2);
+	let z1 = x_b2;
 	[z0, z1]
 }

--- a/crates/arith-bench/src/ghash_sq/soft64.rs
+++ b/crates/arith-bench/src/ghash_sq/soft64.rs
@@ -11,7 +11,7 @@ pub fn mul_sliced(x: [u128; 2], y: [u128; 2]) -> [u128; 2] {
 		y,
 		ghash::soft64::mul_wide,
 		ghash::soft64::reduce,
-		ghash::soft64::mul_inv_x,
+		ghash::soft64::mul_x_wide,
 	)
 }
 
@@ -27,13 +27,13 @@ pub fn mul_wide_sliced(x: [u128; 2], y: [u128; 2]) -> [[u64; 4]; 3] {
 /// arithmetic; see [`super::sliced::reduce_sliced`].
 #[inline]
 pub fn reduce_sliced(t: [[u64; 4]; 3]) -> [u128; 2] {
-	super::sliced::reduce_sliced(t, ghash::soft64::reduce, ghash::soft64::mul_inv_x)
+	super::sliced::reduce_sliced(t, ghash::soft64::reduce, ghash::soft64::mul_x_wide)
 }
 
 /// Square packed GHASH² elements in sliced representation using soft64 arithmetic.
 #[inline]
 pub fn square_sliced(x: [u128; 2]) -> [u128; 2] {
-	super::sliced::square_sliced(x, ghash::soft64::square, ghash::soft64::mul_inv_x)
+	super::sliced::square_sliced(x, ghash::soft64::square, ghash::soft64::mul_x)
 }
 
 #[cfg(test)]
@@ -100,7 +100,7 @@ mod tests {
 
 		// Deferred reduction: accumulating the three raw products by XOR and calling reduce_sliced
 		// once equals summing the reduced products — the F2-linear property the inner-product
-		// benchmark relies on (the multiply-by-X⁻¹ is likewise deferred into reduce_sliced).
+		// benchmark relies on (the multiply-by-X is likewise deferred into reduce_sliced).
 		#[test]
 		fn test_ghash_sq_soft64_wide_deferred_reduction(
 			a1 in any::<[u128; 2]>(), b1 in any::<[u128; 2]>(),

--- a/crates/arith-bench/src/ghash_sq/x86_64.rs
+++ b/crates/arith-bench/src/ghash_sq/x86_64.rs
@@ -15,7 +15,7 @@ pub fn mul_sliced<U: Underlier + OpsClmul + PackedUnderlier<u128>>(x: [U; 2], y:
 		y,
 		ghash::clmul::mul_wide,
 		ghash::clmul::reduce,
-		ghash::clmul::mul_inv_x,
+		ghash::clmul::mul_x_wide,
 	)
 }
 
@@ -34,13 +34,13 @@ pub fn mul_wide_sliced<U: Underlier + OpsClmul + PackedUnderlier<u128>>(
 /// arithmetic; see [`super::sliced::reduce_sliced`].
 #[inline]
 pub fn reduce_sliced<U: Underlier + OpsClmul + PackedUnderlier<u128>>(t: [[U; 3]; 3]) -> [U; 2] {
-	super::sliced::reduce_sliced(t, ghash::clmul::reduce, ghash::clmul::mul_inv_x)
+	super::sliced::reduce_sliced(t, ghash::clmul::reduce, ghash::clmul::mul_x_wide)
 }
 
 /// Square packed GHASH² elements in sliced representation using CLMUL arithmetic.
 #[inline]
 pub fn square_sliced<U: Underlier + OpsClmul + PackedUnderlier<u128>>(x: [U; 2]) -> [U; 2] {
-	super::sliced::square_sliced(x, ghash::clmul::square, ghash::clmul::mul_inv_x)
+	super::sliced::square_sliced(x, ghash::clmul::square, ghash::clmul::mul_x)
 }
 
 /// Multiply a GHASH² element stored as a pair of 128-bit registers.
@@ -74,17 +74,24 @@ pub fn square_m128i(x: [__m128i; 2]) -> [__m128i; 2] {
 ))]
 #[inline]
 pub fn mul_m256i(x: __m256i, y: __m256i) -> __m256i {
+	// Lane 0 = t0 = x0·y0, lane 1 = t2 = x1·y1 (both reduced).
 	let t0_t2 = ghash::clmul::mul(x, y);
 	let x0_y0 = unsafe { _mm256_permute2x128_si256::<0x20>(x, y) };
 	let x1_y1 = unsafe { _mm256_permute2x128_si256::<0x31>(x, y) };
 	let xxor_yxor = Underlier::xor(x0_y0, x1_y1);
-	let invx = <__m256i as PackedUnderlier<u128>>::broadcast(ghash::INV_X);
+	let x_bcast = <__m256i as PackedUnderlier<u128>>::broadcast(ghash::X);
 
-	let invx_xxor = unsafe { _mm256_permute2x128_si256::<0x20>(invx, xxor_yxor) };
+	// One fused multiply produces both [X·t2, t1]: lane 0 multiplies the broadcast X by t2, lane 1
+	// forms the Karatsuba middle product (x0+x1)·(y0+y1) = t1.
+	let x_xxor = unsafe { _mm256_permute2x128_si256::<0x20>(x_bcast, xxor_yxor) };
 	let t2_yxor = unsafe { _mm256_permute2x128_si256::<0x31>(t0_t2, xxor_yxor) };
-	let t2invx_t1 = ghash::clmul::mul(invx_xxor, t2_yxor);
-	let t0_t0 = unsafe { _mm256_permute2x128_si256::<0x00>(t0_t2, t0_t2) };
-	Underlier::xor(t0_t0, t2invx_t1)
+	let xt2_t1 = ghash::clmul::mul(x_xxor, t2_yxor);
+
+	// c = [t0 + X·t2, t2 + t1] = [z0, t1 + t2].
+	let c = Underlier::xor(t0_t2, xt2_t1);
+	// [0, z0], so the final XOR leaves lane 0 = z0 and sets lane 1 = z0 + t1 + t2 = z1.
+	let zero_z0 = unsafe { _mm256_permute2x128_si256::<0x08>(c, c) };
+	Underlier::xor(c, zero_z0)
 }
 
 /// Multiply packed GHASH² elements in 256-bit registers.
@@ -127,8 +134,10 @@ pub fn mul_m256i_hybrid(x: __m256i, y: __m256i) -> __m256i {
 
 	let t1 = ghash::clmul::mul(Underlier::xor(x0, x1), Underlier::xor(y0, y1));
 
-	let z0 = Underlier::xor(t0, ghash::clmul::mul_inv_x(t2));
-	let z1 = Underlier::xor(t1, t0);
+	// Y² = X·Y + X, so z0 = t0 + X·t2 and z1 = (t1 + t0 + t2) + X·t2.
+	let x_t2 = ghash::clmul::mul_x(t2);
+	let z0 = Underlier::xor(t0, x_t2);
+	let z1 = Underlier::xor(Underlier::xor(Underlier::xor(t1, t0), t2), x_t2);
 	unsafe { _mm256_set_m128i(z1, z0) }
 }
 

--- a/crates/arith-bench/src/ghash_sq/x86_64.rs
+++ b/crates/arith-bench/src/ghash_sq/x86_64.rs
@@ -137,7 +137,7 @@ pub fn mul_m256i_hybrid(x: __m256i, y: __m256i) -> __m256i {
 	// Y² = X·Y + X, so z0 = t0 + X·t2 and z1 = (t1 + t0 + t2) + X·t2.
 	let x_t2 = ghash::clmul::mul_x(t2);
 	let z0 = Underlier::xor(t0, x_t2);
-	let z1 = Underlier::xor(Underlier::xor(Underlier::xor(t1, t0), t2), x_t2);
+	let z1 = Underlier::xor(z0, Underlier::xor(t1, t2));
 	unsafe { _mm256_set_m128i(z1, z0) }
 }
 

--- a/crates/arith-bench/src/ghash_sq/x86_64.rs
+++ b/crates/arith-bench/src/ghash_sq/x86_64.rs
@@ -65,7 +65,60 @@ pub fn square_m128i(x: [__m128i; 2]) -> [__m128i; 2] {
 	square_sliced(x)
 }
 
-/// Multiply packed GHASH² elements in 256-bit registers.
+/// Widening (unreduced) schoolbook multiply of two GHASH² elements packed in a 256-bit register.
+///
+/// Returns the raw products as `[corners, cross]`: `corners = [t0, t2]` packs `t0 = x0·y0` in
+/// lane 0 and `t2 = x1·y1` in lane 1 (one 256-bit `mul_wide`), and `cross = [x1·y0, x0·y1]` is a
+/// second `mul_wide` of the lane-swapped `x` against `y`. All four are raw base-field widening
+/// products; the cross-term sum, multiply-by-`X`, and base-field reduction are F2-linear and
+/// deferred to [`reduce_m256i`], so an inner product XOR-accumulates the products and reduces once.
+#[cfg(all(
+	target_arch = "x86_64",
+	target_feature = "vpclmulqdq",
+	target_feature = "avx2",
+	target_feature = "sse2"
+))]
+#[inline]
+pub fn mul_m256i_wide(x: __m256i, y: __m256i) -> [[__m256i; 3]; 2] {
+	// Lane 0 = t0 = x0·y0, lane 1 = t2 = x1·y1 (unreduced).
+	let corners = ghash::clmul::mul_wide(x, y);
+	// Swap the 128-bit lanes of x to [x1, x0], so multiplying by y gives the cross products
+	// lane 0 = x1·y0, lane 1 = x0·y1 (unreduced).
+	let x_swapped = unsafe { _mm256_permute2x128_si256::<0x01>(x, x) };
+	let cross = ghash::clmul::mul_wide(x_swapped, y);
+	[corners, cross]
+}
+
+/// Reduce the raw products from [`mul_m256i_wide`] into a GHASH² element packed in a 256-bit
+/// register.
+#[cfg(all(
+	target_arch = "x86_64",
+	target_feature = "vpclmulqdq",
+	target_feature = "avx2",
+	target_feature = "sse2"
+))]
+#[inline]
+pub fn reduce_m256i([corners, cross]: [[__m256i; 3]; 2]) -> __m256i {
+	// Reduce the corners together (lane 0 = t0, lane 1 = t2), then extract the two base elements.
+	let t0_t2 = ghash::clmul::reduce(corners);
+	let t0 = unsafe { _mm256_extracti128_si256::<0>(t0_t2) };
+	let t2 = unsafe { _mm256_extracti128_si256::<1>(t0_t2) };
+
+	// Sum the two cross products x1·y0 + x0·y1 by extracting and XORing the lanes, then reduce.
+	let cross_lo: [__m128i; 3] =
+		std::array::from_fn(|i| unsafe { _mm256_extracti128_si256::<0>(cross[i]) });
+	let cross_hi: [__m128i; 3] =
+		std::array::from_fn(|i| unsafe { _mm256_extracti128_si256::<1>(cross[i]) });
+	let cross_sum = ghash::clmul::reduce(Underlier::xor(cross_lo, cross_hi));
+
+	// Y² = X·Y + X, so z0 = t0 + X·t2 and z1 = (x0·y1 + x1·y0) + X·t2.
+	let x_t2 = ghash::clmul::mul_x(t2);
+	let z0 = Underlier::xor(t0, x_t2);
+	let z1 = Underlier::xor(cross_sum, x_t2);
+	unsafe { _mm256_set_m128i(z1, z0) }
+}
+
+/// Multiply packed GHASH² elements in 256-bit registers with a schoolbook widening multiply.
 #[cfg(all(
 	target_arch = "x86_64",
 	target_feature = "vpclmulqdq",
@@ -74,27 +127,45 @@ pub fn square_m128i(x: [__m128i; 2]) -> [__m128i; 2] {
 ))]
 #[inline]
 pub fn mul_m256i(x: __m256i, y: __m256i) -> __m256i {
-	// Lane 0 = t0 = x0·y0, lane 1 = t2 = x1·y1 (both reduced).
-	let t0_t2 = ghash::clmul::mul(x, y);
-	let x0_y0 = unsafe { _mm256_permute2x128_si256::<0x20>(x, y) };
-	let x1_y1 = unsafe { _mm256_permute2x128_si256::<0x31>(x, y) };
-	let xxor_yxor = Underlier::xor(x0_y0, x1_y1);
-	let x_bcast = <__m256i as PackedUnderlier<u128>>::broadcast(ghash::X);
-
-	// One fused multiply produces both [X·t2, t1]: lane 0 multiplies the broadcast X by t2, lane 1
-	// forms the Karatsuba middle product (x0+x1)·(y0+y1) = t1.
-	let x_xxor = unsafe { _mm256_permute2x128_si256::<0x20>(x_bcast, xxor_yxor) };
-	let t2_yxor = unsafe { _mm256_permute2x128_si256::<0x31>(t0_t2, xxor_yxor) };
-	let xt2_t1 = ghash::clmul::mul(x_xxor, t2_yxor);
-
-	// c = [t0 + X·t2, t2 + t1] = [z0, t1 + t2].
-	let c = Underlier::xor(t0_t2, xt2_t1);
-	// [0, z0], so the final XOR leaves lane 0 = z0 and sets lane 1 = z0 + t1 + t2 = z1.
-	let zero_z0 = unsafe { _mm256_permute2x128_si256::<0x08>(c, c) };
-	Underlier::xor(c, zero_z0)
+	reduce_m256i(mul_m256i_wide(x, y))
 }
 
-/// Multiply packed GHASH² elements in 256-bit registers.
+/// Widening (unreduced) multiply of two GHASH² elements packed in a 256-bit register, using only
+/// 128-bit CLMUL by extracting the lanes.
+///
+/// Returns the three raw base-field products `[t0, t1, t2]` in sliced form (`[[__m128i; 3]; 3]`);
+/// see [`mul_wide_sliced`]. Reduce with [`reduce_m256i_as_m128i`].
+#[cfg(all(
+	target_arch = "x86_64",
+	target_feature = "pclmulqdq",
+	target_feature = "sse2",
+	target_feature = "avx2"
+))]
+#[inline]
+pub fn mul_m256i_as_m128i_wide(x: __m256i, y: __m256i) -> [[__m128i; 3]; 3] {
+	let x0 = unsafe { _mm256_extracti128_si256::<0>(x) };
+	let x1 = unsafe { _mm256_extracti128_si256::<1>(x) };
+	let y0 = unsafe { _mm256_extracti128_si256::<0>(y) };
+	let y1 = unsafe { _mm256_extracti128_si256::<1>(y) };
+
+	mul_wide_sliced([x0, x1], [y0, y1])
+}
+
+/// Reduce the raw products from [`mul_m256i_as_m128i_wide`] into a GHASH² element packed in a
+/// 256-bit register.
+#[cfg(all(
+	target_arch = "x86_64",
+	target_feature = "pclmulqdq",
+	target_feature = "sse2",
+	target_feature = "avx2"
+))]
+#[inline]
+pub fn reduce_m256i_as_m128i(t: [[__m128i; 3]; 3]) -> __m256i {
+	let [z0, z1] = reduce_sliced(t);
+	unsafe { _mm256_set_m128i(z1, z0) }
+}
+
+/// Multiply packed GHASH² elements in 256-bit registers, using only 128-bit CLMUL.
 #[cfg(all(
 	target_arch = "x86_64",
 	target_feature = "pclmulqdq",
@@ -103,17 +174,64 @@ pub fn mul_m256i(x: __m256i, y: __m256i) -> __m256i {
 ))]
 #[inline]
 pub fn mul_m256i_as_m128i(x: __m256i, y: __m256i) -> __m256i {
+	reduce_m256i_as_m128i(mul_m256i_as_m128i_wide(x, y))
+}
+
+/// Widening (unreduced) multiply of two GHASH² elements packed in a 256-bit register, forming the
+/// corner products `t0`/`t2` with one 256-bit `mul_wide` and the middle product `t1` with a 128-bit
+/// `mul_wide` on the extracted lanes.
+///
+/// Returns `(corners, middle)`: `corners = [t0, t2]` packs `t0 = x0·y0` in lane 0 and `t2 = x1·y1`
+/// in lane 1, and `middle` is `t1 = (x0+x1)·(y0+y1)` as a 128-bit widening product. Both are raw
+/// base-field products; reduce with [`reduce_m256i_hybrid`].
+#[cfg(all(
+	target_arch = "x86_64",
+	target_feature = "pclmulqdq",
+	target_feature = "sse2",
+	target_feature = "vpclmulqdq",
+	target_feature = "avx2",
+))]
+#[inline]
+pub fn mul_m256i_hybrid_wide(x: __m256i, y: __m256i) -> ([__m256i; 3], [__m128i; 3]) {
+	// Lane 0 = t0 = x0·y0, lane 1 = t2 = x1·y1 (unreduced).
+	let corners = ghash::clmul::mul_wide(x, y);
+
 	let x0 = unsafe { _mm256_extracti128_si256::<0>(x) };
 	let x1 = unsafe { _mm256_extracti128_si256::<1>(x) };
 	let y0 = unsafe { _mm256_extracti128_si256::<0>(y) };
 	let y1 = unsafe { _mm256_extracti128_si256::<1>(y) };
 
-	let [z0, z1] = mul_sliced([x0, x1], [y0, y1]);
+	// t1 = (x0+x1)·(y0+y1) (unreduced).
+	let middle = ghash::clmul::mul_wide(Underlier::xor(x0, x1), Underlier::xor(y0, y1));
+	(corners, middle)
+}
 
+/// Reduce the raw products from [`mul_m256i_hybrid_wide`] into a GHASH² element packed in a 256-bit
+/// register.
+#[cfg(all(
+	target_arch = "x86_64",
+	target_feature = "pclmulqdq",
+	target_feature = "sse2",
+	target_feature = "vpclmulqdq",
+	target_feature = "avx2",
+))]
+#[inline]
+pub fn reduce_m256i_hybrid((corners, middle): ([__m256i; 3], [__m128i; 3])) -> __m256i {
+	// Reduce the corners together (lane 0 = t0, lane 1 = t2), then extract the two base elements.
+	let t0_t2 = ghash::clmul::reduce(corners);
+	let t0 = unsafe { _mm256_extracti128_si256::<0>(t0_t2) };
+	let t2 = unsafe { _mm256_extracti128_si256::<1>(t0_t2) };
+	let t1 = ghash::clmul::reduce(middle);
+
+	// Y² = X·Y + X, so z0 = t0 + X·t2 and z1 = (t1 + t0 + t2) + X·t2.
+	let x_t2 = ghash::clmul::mul_x(t2);
+	let z0 = Underlier::xor(t0, x_t2);
+	let z1 = Underlier::xor(z0, Underlier::xor(t1, t2));
 	unsafe { _mm256_set_m128i(z1, z0) }
 }
 
-/// Multiply packed GHASH² elements in 256-bit registers.
+/// Multiply packed GHASH² elements in 256-bit registers, mixing a 256-bit corner multiply with a
+/// 128-bit middle multiply.
 #[cfg(all(
 	target_arch = "x86_64",
 	target_feature = "pclmulqdq",
@@ -123,22 +241,7 @@ pub fn mul_m256i_as_m128i(x: __m256i, y: __m256i) -> __m256i {
 ))]
 #[inline]
 pub fn mul_m256i_hybrid(x: __m256i, y: __m256i) -> __m256i {
-	let t0_t2 = ghash::clmul::mul(x, y);
-
-	let x0 = unsafe { _mm256_extracti128_si256::<0>(x) };
-	let x1 = unsafe { _mm256_extracti128_si256::<1>(x) };
-	let y0 = unsafe { _mm256_extracti128_si256::<0>(y) };
-	let y1 = unsafe { _mm256_extracti128_si256::<1>(y) };
-	let t0 = unsafe { _mm256_extracti128_si256::<0>(t0_t2) };
-	let t2 = unsafe { _mm256_extracti128_si256::<1>(t0_t2) };
-
-	let t1 = ghash::clmul::mul(Underlier::xor(x0, x1), Underlier::xor(y0, y1));
-
-	// Y² = X·Y + X, so z0 = t0 + X·t2 and z1 = (t1 + t0 + t2) + X·t2.
-	let x_t2 = ghash::clmul::mul_x(t2);
-	let z0 = Underlier::xor(t0, x_t2);
-	let z1 = Underlier::xor(z0, Underlier::xor(t1, t2));
-	unsafe { _mm256_set_m128i(z1, z0) }
+	reduce_m256i_hybrid(mul_m256i_hybrid_wide(x, y))
 }
 
 // CLMUL sliced multiply cross-checks that run wherever `pclmulqdq` is available (the tests below

--- a/crates/arith-bench/src/polyval/clmul.rs
+++ b/crates/arith-bench/src/polyval/clmul.rs
@@ -62,7 +62,7 @@ fn karatsuba2<U: Underlier + OpsClmul>(h: U, m: U, l: U) -> (U, U) {
 	let t = {
 		//   {m0, m1} ^ {l1, h0}
 		// = {m0^l1, m1^h0}
-		let t0 = { U::xor(m, U::extract_hi_lo_64(l, h)) };
+		let t0 = { U::xor(m, U::alignr_epi8::<8>(h, l)) };
 
 		//   {h0, h1} ^ {l0, l1}
 		// = {h0^l0, h1^l1}

--- a/crates/arith-bench/src/underlier.rs
+++ b/crates/arith-bench/src/underlier.rs
@@ -155,7 +155,11 @@ pub trait OpsClmul {
 	fn duplicate_hi_64(a: Self) -> Self;
 	fn swap_hi_lo_64(a: Self) -> Self;
 
-	fn extract_hi_lo_64(a: Self, b: Self) -> Self;
+	/// Concatenates `a` (high half) and `b` (low half) into a 256-bit intermediate, shifts it right
+	/// by `IMM8` bytes, and returns the low 128 bits — the `palignr` operation.
+	///
+	/// For 256-bit values, this operates on each 128-bit lane independently.
+	fn alignr_epi8<const IMM8: i32>(a: Self, b: Self) -> Self;
 
 	fn unpacklo_epi64(a: Self, b: Self) -> Self;
 


### PR DESCRIPTION
Implements [BINIUS-291](https://linear.app/jimpo/issue/BINIUS-291/binius-arith-bench-change-ghash-sq-irreducible).

Constructs GHASH² modulo `Y² + X·Y + X` (so `Y² = X·Y + X`) instead of `Y² + Y + X⁻¹`. The reduction then multiplies by `X` (a left shift) rather than `X⁻¹`, and — crucially — the multiply-by-`X` is applied to the **unreduced** widening product, mirroring the monbijou extension reductions. Because a 128×128 carryless product has degree ≤ 254, the shift can't overflow, so `reduce_sliced` folds with **two** base-field reductions instead of three.

### Commits
1. **Add GHASH `mul_x` / `mul_x_wide` primitives** — a reduced `mul_x` (128-bit left shift, folding `X¹²⁸ ≡ 0x87` on overflow) and a `mul_x_wide` on the unreduced widening product (plain shift, no reduction), in both soft64 and clmul. Adds a `ghash::X` generator constant and proptests cross-checking against `mul` by `X` on every underlier. Pure addition.
2. **Change ghash_sq irreducible to `Y² + X·Y + X`** — `reduce_sliced` now takes `ghash_mul_x_wide` and `square_sliced` a reduced `ghash_mul_x`; the soft64/x86_64/aarch64 wrappers and the packed `__m256i` variants (`mul_m256i`, `mul_m256i_hybrid`) are updated to the new formulas. Adds `mul_x` benchmarks alongside the existing `mul_inv_x` ones.

### Correctness
- Full `binius-arith-bench` suite green (soft64 + `__m128i` clmul: field axioms, square-equals-mul, deferred-reduction linearity, and sliced-matches-soft64 cross-checks all confirm the new field on both paths).
- aarch64 cross-checked (`cargo check --target aarch64-unknown-linux-gnu --tests`, `+neon,+aes`).
- `__m256i`/vpclmulqdq variants compile-checked but **not run locally** (this box lacks `vpclmulqdq`); their proptests (`mul_m256i` vs the `__m128i` reference) will exercise on a vpclmul CI runner. I verified the `mul_m256i` permute algebra by hand.

### Benchmark: the experimental finding (a trade-off)

Old vs new irreducible, this machine (x86_64, `-C target-cpu=native`, `pclmulqdq+avx2`, no vpclmul), criterion sample-size 30:

| Benchmark | Old | New | Δ |
|---|---|---|---|
| `soft64::mul_sliced` | 226 µs | 204 µs | **−10%** |
| `soft64::mul_sliced` (inner product) | 220 µs | 196 µs | **−10%** |
| `soft64::square_sliced` | 11.6 µs | 11.3 µs | ~0 (noise) |
| `soft64::mul_wide_sliced` (inner product) | 180 µs | 184 µs | ~0 (noise) |
| **`x86_64::mul_sliced::<__m128i>`** | 9.26 µs | 10.0 µs | **+9%** |
| **`x86_64::mul_sliced::<__m128i>`** (inner product) | 10.0 µs | 11.0 µs | **+9%** |

**Interpretation:** the change helps the **software** path (~10% faster) because a soft64 base-field reduction is expensive, so trading one reduction for a wide left-shift is a net win. It **regresses the CLMUL** path (~9%) because there a reduction is only ~2 `clmul`s — cheaper than the wide multiply-by-`X` (three 128-bit shifts + extra wide XORs) that replaces it. On CLMUL you can't drop below three reductions *without* the wide mul-by-X, and that shift costs more than the reduction it saves, so the fused approach that wins in software loses on hardware.

`mul_wide_sliced` (the widening/deferred-reduction inner-product path) is unchanged — it produces the same three products; only the final `reduce_sliced` differs, which is amortized away over a long inner product.

**This is an experiment → opened as a draft for your call.** The issue framed the new irreducible as "a little bit nicer"; it is, for software, but it's a genuine software-vs-CLMUL trade-off rather than a strict win. Options: (a) take it as-is if the soft64 path is what matters; (b) keep the new irreducible but leave the CLMUL `reduce_sliced` on three reductions (no wide mul-by-X) so CLMUL doesn't regress; (c) drop it. Happy to do (b) or measure the `__m256i`/vpclmul packed variants on a suitable runner if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)