### PR TITLE
BINIUS-334: fuse the RS coset replication into the first executed NTT layer

### DIFF
--- a/crates/math/src/reed_solomon.rs
+++ b/crates/math/src/reed_solomon.rs
@@ -5,7 +5,7 @@
 //!
 //! See [`ReedSolomonCode`] for details.
 
-use std::ptr;
+use std::{mem::MaybeUninit, ptr, slice::from_raw_parts_mut};
 
 use binius_field::{BinaryField, PackedField};
 use binius_utils::rayon::prelude::*;
@@ -153,24 +153,54 @@ impl<F: BinaryField> ReedSolomonCode<F> {
 		)
 		.entered();
 
-		// Repeat the message to fill the entire buffer.
 		let log_output_len = self.log_dim() + log_batch_size + self.log_inv_rate;
-		let output_data = if data.log_len() < P::LOG_WIDTH {
+
+		// Sub-packed messages replicate scalar-wise.
+		// The packed seed below cannot apply at this size.
+		if data.log_len() < P::LOG_WIDTH {
 			let mut scalars = data.iter_scalars().collect::<Vec<_>>();
 			bit_reverse_indices(&mut scalars);
 			let elem_0 = P::from_scalars(scalars.into_iter().cycle());
-			vec![elem_0; 1 << log_output_len.saturating_sub(P::LOG_WIDTH)]
+			let output_data = vec![elem_0; 1 << log_output_len.saturating_sub(P::LOG_WIDTH)];
+			let mut output = FieldBuffer::new(log_output_len, output_data);
+			ntt.forward_transform(output.to_mut(), self.log_inv_rate, log_batch_size);
+			return output;
+		}
+
+		let mut output_data = Vec::with_capacity(1 << (log_output_len - P::LOG_WIDTH));
+
+		output_data.extend_from_slice(data.as_ref());
+
+		// Bit-reverse permute the message.
+		bit_reverse_packed(FieldSliceMut::from_slice(data.log_len(), output_data.as_mut_slice()));
+
+		// The zero-padded coefficient vector turns the early NTT layers into copies:
+		// a butterfly against a zero half writes the live half into both outputs.
+		// So the state entering the first executed layer is the message repeated once per coset.
+		// The codeword is the remaining layers applied to that repetition.
+		//
+		// The fused seed goes one layer further in the same pass.
+		// Every coset block holds identical data at the first executed layer.
+		// So its butterflies can read the single message copy directly.
+		// Each coset's post-layer state is written once.
+		// The repetition is never materialized:
+		//
+		//     replicate-then-transform:  write 2^n, then read 2^n + write 2^n for the layer
+		//     fused seed:                read 2^m once, write 2^n
+		//
+		// The seed needs one executable layer and a half-coset of at least one packed element.
+		// Other shapes replicate as plain copies and keep the full early-layer skip.
+		let fused_seed =
+			self.log_inv_rate > 0 && self.log_dim() > 0 && data.log_len() > P::LOG_WIDTH;
+
+		if fused_seed {
+			seed_first_layer(
+				ntt.domain_context(),
+				&mut output_data,
+				data.log_len() - P::LOG_WIDTH,
+				self.log_inv_rate,
+			);
 		} else {
-			let mut output_data = Vec::with_capacity(1 << (log_output_len - P::LOG_WIDTH));
-
-			output_data.extend_from_slice(data.as_ref());
-
-			// Bit-reverse permute the message.
-			bit_reverse_packed(FieldSliceMut::from_slice(
-				data.log_len(),
-				output_data.as_mut_slice(),
-			));
-
 			let log_msg_len_packed = data.log_len() - P::LOG_WIDTH;
 			output_data
 				.spare_capacity_mut()
@@ -189,19 +219,152 @@ impl<F: BinaryField> ReedSolomonCode<F> {
 					let src_ptr = dst_ptr.sub((i + 1) << log_msg_len_packed);
 					ptr::copy_nonoverlapping(src_ptr, dst_ptr, 1 << log_msg_len_packed);
 				});
+		}
 
-			unsafe {
-				// Safety: the vec's spare capacity is fully initialized above.
-				output_data.set_len(1 << (log_output_len - P::LOG_WIDTH));
-			}
+		unsafe {
+			// Safety: the seed or the replicating copies initialize every element above.
+			output_data.set_len(1 << (log_output_len - P::LOG_WIDTH));
+		}
 
-			output_data
-		};
 		let mut output = FieldBuffer::new(log_output_len, output_data);
 
-		ntt.forward_transform(output.to_mut(), self.log_inv_rate, log_batch_size);
+		// The seed already computed the first executed layer.
+		// So the transform resumes one layer later.
+		let skip_early = self.log_inv_rate + usize::from(fused_seed);
+		ntt.forward_transform(output.to_mut(), skip_early, log_batch_size);
 		output
 	}
+}
+
+/// Base-2 logarithm of the seed's per-task chunk length, in packed elements.
+///
+/// A task holds one low-half and one high-half source chunk hot while writing every coset.
+/// At 128-bit elements, two chunks of `2^10` elements occupy 32 KiB — comfortably L1-resident.
+const LOG_SEED_CHUNK: usize = 10;
+
+/// Writes every coset block of the codeword at its state after one NTT layer.
+///
+/// # Overview
+///
+/// The buffer's initialized prefix holds the bit-reversed message: coset block 0.
+/// At the first executed layer, every coset block would hold that same data.
+/// So the layer's butterflies read the single message copy and write each coset directly:
+///
+/// ```text
+///     msg low half  a ──┬──> u_c = a + t_c * b     (t_c = layer twiddle of coset c)
+///     msg high half b ──┴──> v_c = u_c + b
+///
+///     coset c block:  [ u_c ... | v_c ... ]        one write per output element
+/// ```
+///
+/// The repeated-message intermediate is never materialized.
+/// The message is read once.
+/// Each source chunk stays cache-hot across all cosets.
+///
+/// After this call, the remaining layers run with one extra early layer skipped.
+/// The output equals running the skipped layer inside the transform, butterfly for butterfly.
+///
+/// # Preconditions
+///
+/// * The buffer's length is `2^log_msg_len_packed` and holds the bit-reversed message.
+/// * The buffer's capacity is `2^(log_msg_len_packed + log_inv_rate)`.
+/// * `log_msg_len_packed >= 1`, so a half-coset spans at least one packed element.
+/// * `log_inv_rate >= 1`.
+/// * The layer at index `log_inv_rate` is executable in the domain.
+fn seed_first_layer<P: PackedField>(
+	domain_context: &impl DomainContext<Field = P::Scalar>,
+	output_data: &mut Vec<P>,
+	log_msg_len_packed: usize,
+	log_inv_rate: usize,
+) {
+	debug_assert!(log_msg_len_packed >= 1);
+	debug_assert!(log_inv_rate >= 1);
+	debug_assert_eq!(output_data.len(), 1 << log_msg_len_packed);
+	debug_assert!(output_data.capacity() >= 1 << (log_msg_len_packed + log_inv_rate));
+
+	let copies = 1 << log_inv_rate;
+	// Packed lengths of one coset block and of its half, the butterfly stride.
+	let coset_packed = 1 << log_msg_len_packed;
+	let half_packed = 1 << (log_msg_len_packed - 1);
+
+	// One broadcast twiddle per coset: block c of the first executed layer.
+	let twiddles = (0..copies)
+		.map(|c| P::broadcast(domain_context.twiddle(log_inv_rate, c)))
+		.collect::<Vec<_>>();
+
+	// Partition the half-coset index space into cache-sized chunks, one task each.
+	let chunk_len = half_packed.min(1 << LOG_SEED_CHUNK);
+	let n_tasks = half_packed / chunk_len;
+
+	let base_ptr = output_data.as_mut_ptr();
+
+	// Hand each task its exclusive slice set.
+	// A task owns the two source chunks of coset 0 (initialized).
+	// It also owns the matching destination chunks of every other coset (uninitialized spare).
+	//
+	// Safety:
+	// - The slice at (coset c, half h, task k) spans chunk_len elements starting at
+	//
+	//       c * coset_packed + h * half_packed + k * chunk_len
+	//
+	// - Distinct (c, h, k) triples therefore map to disjoint element ranges.
+	// - All slices lie within the vector's capacity (checked by the debug assert above).
+	// - Coset 0 slices cover initialized elements.
+	// - Other cosets' slices stay behind `MaybeUninit` and are only written.
+	// - `output_data` is not accessed again until the parallel loop below completes.
+	let tasks = (0..n_tasks)
+		.map(|k| {
+			let offset = k * chunk_len;
+			let src_u = unsafe { from_raw_parts_mut(base_ptr.add(offset), chunk_len) };
+			let src_v =
+				unsafe { from_raw_parts_mut(base_ptr.add(half_packed + offset), chunk_len) };
+			let dsts = (1..copies)
+				.map(|c| {
+					let u_start = c * coset_packed + offset;
+					let v_start = c * coset_packed + half_packed + offset;
+					let dst_u = unsafe {
+						from_raw_parts_mut(
+							base_ptr.add(u_start).cast::<MaybeUninit<P>>(),
+							chunk_len,
+						)
+					};
+					let dst_v = unsafe {
+						from_raw_parts_mut(
+							base_ptr.add(v_start).cast::<MaybeUninit<P>>(),
+							chunk_len,
+						)
+					};
+					(dst_u, dst_v)
+				})
+				.collect::<Vec<_>>();
+			(src_u, src_v, dsts)
+		})
+		.collect::<Vec<_>>();
+
+	tasks.into_par_iter().for_each(|(src_u, src_v, dsts)| {
+		// The other cosets first: coset 0 still holds the untouched message source.
+		for (c, (dst_u, dst_v)) in dsts.into_iter().enumerate() {
+			let twiddle = twiddles[c + 1];
+			for j in 0..chunk_len {
+				// The layer butterfly: u += v * twiddle; v += u.
+				let mut u = src_u[j];
+				let v0 = src_v[j];
+				u += v0 * twiddle;
+				dst_u[j].write(u);
+				dst_v[j].write(v0 + u);
+			}
+		}
+
+		// Coset 0 last, in place: its block is the source the copies just read.
+		let twiddle = twiddles[0];
+		for j in 0..chunk_len {
+			let mut u = src_u[j];
+			let v0 = src_v[j];
+			u += v0 * twiddle;
+			src_u[j] = u;
+			src_v[j] = v0 + u;
+		}
+	});
 }
 
 #[cfg(test)]
@@ -279,6 +442,75 @@ mod tests {
 	fn test_encode_batch_below_packing_width() {
 		// Test where message length is less than the packing width and codeword length is greater.
 		test_encode_batch_helper::<PackedBinaryGhash4x128b>(1, 2, 0);
+	}
+
+	#[test]
+	fn test_encode_batch_seed_edge_shapes() {
+		// The fused seed needs one executable layer, one coset copy, and a packed half-coset.
+		// These shapes sit on each of those boundaries.
+
+		// Rate 1: no coset copies at all, nothing to seed.
+		test_encode_batch_helper::<PackedBinaryGhash1x128b>(4, 0, 1);
+		// Dimension 1: no NTT layer executes, the codeword is pure repetition.
+		test_encode_batch_helper::<PackedBinaryGhash1x128b>(0, 2, 0);
+		// Message length exactly the packing width: the half-coset is sub-packed.
+		test_encode_batch_helper::<PackedBinaryGhash4x128b>(2, 2, 0);
+		// Smallest seeded shape: one packed element per half-coset.
+		test_encode_batch_helper::<PackedBinaryGhash1x128b>(1, 1, 0);
+		// Half-coset larger than one seed chunk: the seed splits into several tasks.
+		test_encode_batch_helper::<PackedBinaryGhash1x128b>(12, 1, 1);
+	}
+
+	// Pins one shape of the fused-seed encode across every NTT driver.
+	//
+	// The reference driver is itself pinned to the zero-padded oracle by the tests above.
+	// So agreement here extends that byte-level pin to the production drivers,
+	// which run the seeded transform with one extra early layer skipped.
+	fn test_drivers_agree_helper<P: PackedField>(
+		log_dim: usize,
+		log_inv_rate: usize,
+		log_batch_size: usize,
+	) where
+		P::Scalar: BinaryField,
+	{
+		use crate::ntt::{NeighborsLastMultiThread, NeighborsLastSingleThread};
+
+		let mut rng = StdRng::seed_from_u64(0);
+
+		let rs_code = ReedSolomonCode::<P::Scalar>::new(log_dim, log_inv_rate);
+		let subspace = rs_code.subspace().clone();
+		let domain_context = GenericPreExpanded::<P::Scalar>::generate_from_subspace(&subspace);
+
+		let message = random_field_buffer::<P>(&mut rng, log_dim + log_batch_size);
+
+		let reference = NeighborsLastReference {
+			domain_context: &domain_context,
+		};
+		let single = NeighborsLastSingleThread::new(&domain_context);
+		let multi = NeighborsLastMultiThread::new(&domain_context, 2);
+
+		let encoded_ref = rs_code.encode_batch(&reference, message.to_ref(), log_batch_size);
+		let encoded_single = rs_code.encode_batch(&single, message.to_ref(), log_batch_size);
+		let encoded_multi = rs_code.encode_batch(&multi, message.to_ref(), log_batch_size);
+
+		assert_eq!(
+			encoded_single.as_ref(),
+			encoded_ref.as_ref(),
+			"single-thread driver mismatch at ({log_dim}, {log_inv_rate}, {log_batch_size})"
+		);
+		assert_eq!(
+			encoded_multi.as_ref(),
+			encoded_ref.as_ref(),
+			"multi-thread driver mismatch at ({log_dim}, {log_inv_rate}, {log_batch_size})"
+		);
+	}
+
+	#[test]
+	fn test_encode_batch_agrees_across_ntt_drivers() {
+		// Shapes chosen so the multithread driver exercises both shared and depth-first layers.
+		test_drivers_agree_helper::<PackedBinaryGhash1x128b>(6, 1, 0);
+		test_drivers_agree_helper::<PackedBinaryGhash1x128b>(8, 2, 1);
+		test_drivers_agree_helper::<PackedBinaryGhash1x128b>(10, 1, 2);
 	}
 
 	/// Pins the codeword-duplication identity that underlies Lifted FRI (oracle padding).


### PR DESCRIPTION
Closes [BINIUS-334](https://linear.app/jimpo/issue/BINIUS-334/fuse-the-reed-solomon-coset-replication-into-the-first-executed-ntt).

Makes the Reed-Solomon encoder write the codeword once instead of twice: the coset replication and the first executed NTT layer become a single seeded pass. Byte-identical output — no transcript or protocol change.

### The problem

The encoder wrote the codeword buffer twice.
A replicate pass copied the bit-reversed message into every coset block.
Then the NTT swept the full buffer in place, with the early layers skipped.
Its first executed layer re-read exactly the bytes the replicate pass had just written.

### The idea

The early-layer skip works because a butterfly against a zero half copies the live half into both outputs.
So every coset block entering the first executed layer holds identical data — the message.
That layer's butterflies can read the single message copy and write each coset's post-layer state directly:

```
    msg low half  a ──┬──> u_c = a + t_c * b     (t_c = the layer twiddle of coset c)
    msg high half b ──┴──> v_c = u_c + b

    replicate-then-transform:  write 2^n, then read 2^n + write 2^n for the layer
    fused seed:                read 2^m once, write 2^n
```

The repeated-message intermediate is never materialized.
The transform resumes with one extra early layer skipped.

### The change

- `reed_solomon.rs`: a new seed pass runs after the message bit-reversal. Each parallel task owns two L1-resident source chunks of coset 0 and the matching destination chunks of every other coset (written through `MaybeUninit` into the vector's spare capacity); coset 0's own butterfly runs in place, last. The main transform call moves from `skip_early = log_inv_rate` to `skip_early = log_inv_rate + 1`.
- Edge shapes keep the plain replicate path: rate 1 (nothing to seed), dimension 1 (no executable layer), messages at or below the packing width.

### Soundness

- The seed performs the exact layer butterflies (`u += v * t; v += u`) with the exact per-coset twiddles the transform would have used, on the same values (the replicas were copies) — so the output bytes are unchanged.
- Pinned three ways: the existing zero-padded reference oracle, a new agreement test across the reference / single-thread / multi-thread NTT drivers, and byte-identical proofs on a deterministic SHA-256 fixture (same digest before vs after, via stash A/B).

### Scope

- **changed:** one function in the encoder plus the new private seed pass
- **new:** driver-agreement test, five boundary-shape tests
- **untouched:** the NTT implementations, FRI, the verifier

### Verification

- `cargo check --workspace --all-targets`, `clippy` (0 warnings), nightly `fmt` — clean
- `binius-math` (127 + 2), `binius-iop-prover` (40), `prove_verify` (9), `binius-m4-prover` (35 + 3) — all pass
- transcript pin: byte-identical proof digest against the pre-change code

### Benchmark

Measured with the reference harness below (not part of the diff), production NTT config (multithread, pre-expanded twiddles), M1 Pro, stash A/B:

| shape | config | before | after | delta |
|---|---|---|---|---|
| log_dim 20, rate 1/2, batch 4 (128 MB codeword) | 8 threads | 35.96 ms | 34.50 ms | +4.1% |
| same | 1 thread | 165.6 ms | 162.8 ms | +1.7% |
| log_dim 16, rate 1/4 (16 MB) | 8 threads | 1.337 ms | 1.109 ms | +20.6% |
| same | 1 thread | 4.046 ms | 4.026 ms | wash |

Honest framing: single-threaded encode is compute-bound — the seed performs the same field multiplies as the layer it replaces — so the gain is purely memory-side. It shows under multi-thread load, and most strongly when the codeword is cache-resident (the regime of smaller per-oracle encodes). The change is strictly less work and byte-identical, but a modest win at commit-sized codewords.

<details>
<summary>Reference bench harness (drop into <code>crates/math/benches/reed_solomon.rs</code> and register in <code>Cargo.toml</code>)</summary>

```rust
use binius_field::PackedBinaryGhash1x128b;
use binius_math::{
	ReedSolomonCode,
	ntt::{NeighborsLastMultiThread, domain_context::GenericPreExpanded},
	test_utils::random_field_buffer,
};
use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};

fn bench_encode_batch(c: &mut Criterion) {
	type P = PackedBinaryGhash1x128b;

	let mut rng = rand::rng();
	let mut group = c.benchmark_group("rs_encode_batch");
	group.sample_size(20);

	for (log_dim, log_inv_rate, log_batch_size) in [(20, 1, 2), (16, 2, 0)] {
		let rs_code = ReedSolomonCode::new(log_dim, log_inv_rate);
		let subspace = rs_code.subspace().clone();
		let domain_context = GenericPreExpanded::generate_from_subspace(&subspace);
		let log_num_shares = binius_utils::rayon::current_num_threads().ilog2() as usize;
		let ntt = NeighborsLastMultiThread::new(domain_context, log_num_shares);

		let message = random_field_buffer::<P>(&mut rng, log_dim + log_batch_size);

		let log_codeword_len = log_dim + log_batch_size + log_inv_rate;
		group.throughput(Throughput::Bytes(16 << log_codeword_len));
		group.bench_function(
			BenchmarkId::from_parameter(format!(
				"log_dim={log_dim}/log_inv_rate={log_inv_rate}/log_batch={log_batch_size}"
			)),
			|b| b.iter(|| rs_code.encode_batch(&ntt, message.to_ref(), log_batch_size)),
		);
	}
	group.finish();
}

criterion_group!(benches, bench_encode_batch);
criterion_main!(benches);
```

Run with `cargo bench -p binius-math --features rayon --bench reed_solomon` (drop the feature for the single-threaded numbers).

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
