### PR TITLE
BINIUS-285: return batched sumcheck prover challenges in binding order

### DIFF
--- a/crates/iop-prover/src/basefold/channel.rs
+++ b/crates/iop-prover/src/basefold/channel.rs
@@ -343,8 +343,7 @@ fn prove_batch_zk_basefold<A, F, P, NTT, Channel>(
 	};
 
 	// Reduced oracle evaluations α_i = π_i'(ρ_i) come out in arrival order; scatter them into
-	// oracle-index order to match how the verifier indexes them. `output.challenges` is already
-	// reversed to low-to-high (variable-indexed) order, so ρ_i is its first n_i coords.
+	// oracle-index order to match how the verifier indexes them.
 	//
 	// TODO: This will fail if one oracle isn't opened. For robustness, we should do a regular
 	// multilinear evaluation in that case.
@@ -358,6 +357,10 @@ fn prove_batch_zk_basefold<A, F, P, NTT, Channel>(
 	// Collapse the oracle-index variables up front at sampled batching challenges `r'`: build the
 	// combined multilinear 𝛑(X) = Σ_i e[i]·π_i^↑(X) with e = eq(·, r') into one 2^𝐧 buffer, and the
 	// combined target s' = 𝛑(r) = Σ_i e[i]·α_i·∏_{j≥n_i}(1 - r_j).
+	// `batch_prove` returns binding-order challenges; reverse to variable-indexed (low-to-high),
+	// so that ρ_i is the first n_i coords.
+	let mut challenges = challenges;
+	challenges.reverse();
 	let point = &challenges;
 	let log_n_oracles = log2_ceil_usize(n_committed);
 	let outer_challenges = channel.sample_many(log_n_oracles);

--- a/crates/ip-prover/src/fracaddcheck.rs
+++ b/crates/ip-prover/src/fracaddcheck.rs
@@ -266,7 +266,9 @@ where
 			let next_num = extrapolate_line_packed(num_0, num_1, r);
 			let next_den = extrapolate_line_packed(den_0, den_1, r);
 
+			// Sumcheck binds variables high-to-low; reverse to low-to-high for the claim point.
 			let mut next_point = output.challenges;
+			next_point.reverse();
 			next_point.push(r);
 
 			let num_claim = MultilinearEvalClaim {

--- a/crates/ip-prover/src/logup_star/final_layer.rs
+++ b/crates/ip-prover/src/logup_star/final_layer.rs
@@ -160,8 +160,10 @@ where
 	let pushforward_eval_claim = extrapolate_line(y_0_eval, y_1_eval, r);
 	let table_eval_claim = extrapolate_line(t_0_eval, t_1_eval, r);
 
-	// batch_prove returns challenges low-to-high; the folded variable is the highest coordinate.
+	// `batch_prove` returns binding-order challenges; reverse to variable-indexed (low-to-high).
+	// The folded variable is the highest coordinate.
 	let mut table_eval_point = output.challenges;
+	table_eval_point.reverse();
 	table_eval_point.push(r);
 
 	FinalLayerOutput {

--- a/crates/ip-prover/src/sumcheck/batch.rs
+++ b/crates/ip-prover/src/sumcheck/batch.rs
@@ -15,9 +15,9 @@ pub struct BatchSumcheckOutput<F: Field> {
 	/// Verifier challenges for each round of the sumcheck protocol.
 	///
 	/// One challenge is generated per variable in the multivariate polynomial,
-	/// with challenges\[i\] corresponding to the i-th round of the protocol.
-	///
-	/// Note: reverse when folding high-to-low to obtain evaluation claim.
+	/// with challenges\[i\] corresponding to the i-th round of the protocol. This binding
+	/// order matches [`prove_single`](super::prove_single) and `batch_verify`; when folding
+	/// high-to-low, reverse to obtain the variable-indexed evaluation point.
 	pub challenges: Vec<F>,
 	/// Evaluation claims on non-transparent multilinears, per prover.
 	///
@@ -91,10 +91,6 @@ where
 			prover.fold(challenge);
 		}
 	}
-
-	// TODO: this differs from prove_single, which doesn't reverse.
-	// Reverse to match high-to-low folding order for evaluation points.
-	challenges.reverse();
 
 	let multilinear_evals = provers
 		.into_iter()
@@ -205,10 +201,6 @@ where
 			prover.fold(challenge);
 		}
 	}
-
-	// TODO: this differs from prove_single, which doesn't reverse.
-	// Reverse to match high-to-low folding order for evaluation points.
-	challenges.reverse();
 
 	let multilinear_evals = provers
 		.into_iter()
@@ -362,10 +354,8 @@ mod tests {
 			"Batched evaluation should match reduced evaluation"
 		);
 
-		let mut prover_challenges = output.challenges.clone();
-		prover_challenges.reverse();
 		assert_eq!(
-			prover_challenges, sumcheck_output.challenges,
+			output.challenges, sumcheck_output.challenges,
 			"Prover and verifier challenges should match"
 		);
 	}

--- a/crates/ip-prover/src/sumcheck/frac_add_mle.rs
+++ b/crates/ip-prover/src/sumcheck/frac_add_mle.rs
@@ -152,11 +152,8 @@ mod tests {
 			"Batched evaluation should equal the reduced evaluation"
 		);
 
-		// Also verify the challenges match what the prover saw
-		let mut prover_challenges = output.challenges;
-		prover_challenges.reverse();
 		assert_eq!(
-			prover_challenges, sumcheck_output.challenges,
+			output.challenges, sumcheck_output.challenges,
 			"Prover and verifier challenges should match"
 		);
 	}

--- a/crates/ip-prover/src/sumcheck/round_evaluator.rs
+++ b/crates/ip-prover/src/sumcheck/round_evaluator.rs
@@ -751,10 +751,7 @@ mod tests {
 			let expected = evaluate_univariate(&composed, sumcheck_output.batch_coeff);
 			assert_eq!(expected, sumcheck_output.eval, "reduced evaluation must match the batch");
 
-			// Prover challenges, reversed, match the verifier's.
-			let mut prover_challenges = output.challenges.clone();
-			prover_challenges.reverse();
-			assert_eq!(prover_challenges, sumcheck_output.challenges);
+			assert_eq!(output.challenges, sumcheck_output.challenges);
 		}
 	}
 
@@ -865,10 +862,7 @@ mod tests {
 			let expected = evaluate_univariate(&reduced, sumcheck_output.batch_coeff);
 			assert_eq!(expected, sumcheck_output.eval, "reduced evaluation must match the batch");
 
-			// Prover challenges, reversed, match the verifier's.
-			let mut prover_challenges = output.challenges.clone();
-			prover_challenges.reverse();
-			assert_eq!(prover_challenges, sumcheck_output.challenges);
+			assert_eq!(output.challenges, sumcheck_output.challenges);
 		}
 	}
 }

--- a/crates/m4-prover/src/prove.rs
+++ b/crates/m4-prover/src/prove.rs
@@ -734,7 +734,11 @@ impl RerandomizedOperations<'_> {
 			},
 		};
 
-		(output.challenges, bitand_data, intmul_data, binmul_data)
+		// `batch_prove` returns binding-order challenges; reverse to variable-indexed to match
+		// the verifier's `r_rho`.
+		let mut r_rho = output.challenges;
+		r_rho.reverse();
+		(r_rho, bitand_data, intmul_data, binmul_data)
 	}
 }
 

--- a/crates/prover/src/protocols/intmul/prove.rs
+++ b/crates/prover/src/protocols/intmul/prove.rs
@@ -324,7 +324,7 @@ where
 
 		let batch_guard = tracing::debug_span!("Final batched sumcheck").entered();
 		let BatchSumcheckOutput {
-			challenges,
+			mut challenges,
 			multilinear_evals: _,
 		} = batch_prove(
 			vec![
@@ -336,7 +336,9 @@ where
 		);
 		drop(batch_guard);
 
-		// `challenges` (reversed) is the shared output point for all output claims.
+		// `batch_prove` returns binding-order challenges; reversed, they are the shared output
+		// point for all output claims.
+		challenges.reverse();
 		let r_out = challenges.as_slice();
 
 		// Send the raw per-bit output evals at `r_out`, computed directly from the exponents. The
@@ -473,9 +475,12 @@ where
 		let provers = vec![Either::Left(selector_prover), Either::Right(c_root_prover)];
 		let sumcheck_guard = tracing::debug_span!("Batched selector + C-root sumcheck").entered();
 		let BatchSumcheckOutput {
-			challenges,
+			mut challenges,
 			multilinear_evals,
 		} = batch_prove_and_write_evals(provers, self.channel);
+		// `batch_prove` returns binding-order challenges; reverse to variable-indexed to match
+		// the verifier's phase-3 evaluation point.
+		challenges.reverse();
 		drop(sumcheck_guard);
 
 		let [mut selector_prover_evals, c_root_prover_evals] = multilinear_evals


### PR DESCRIPTION
Closes #1802 ([BINIUS-285](https://linear.app/jimpo/issue/BINIUS-285)).

Removes the challenge-vector reversal from `batch_prove` and `batch_prove_mle`, resolving the in-repo TODO. Every sumcheck entry point now returns challenges in binding order. **Transcript bytes are unchanged** — the transcript, the folding, and the protocol are untouched; only the order of the returned `challenges` vector changes.

### The problem

The batched sumcheck provers reversed their challenge vector before returning:

```rust
// TODO: this differs from prove_single, which doesn't reverse.
// Reverse to match high-to-low folding order for evaluation points.
challenges.reverse();
```

while `prove_single` and `batch_verify` return binding order. The two batch entry points therefore emitted opposite orders, prover-side and verifier-side outputs of the same run were not directly comparable, and the in-file test compensated by manually reversing before asserting equality.

### The change

The direction the TODO points: make the batch provers match `prove_single`.

- `batch_prove` / `batch_prove_mle` no longer reverse; the `BatchSumcheckOutput::challenges` doc now states the order.
- The six prover-side consumers that want a variable-indexed (low-to-high) point reverse locally: the basefold prover channel, the logup* final layer, the fracaddcheck layer loop, intmul phases 3 and 5, and the m4 re-randomization. This mirrors the verifier side, where every `batch_verify` caller already reverses locally (`intmul/verify.rs`, `m4-verifier/verify.rs`, `ip/logup_star`, `iop/basefold`, `ip/fracaddcheck`) — the two sides now use the same idiom.
- The compensating reversals in the `batch.rs`, `round_evaluator.rs`, and `frac_add_mle.rs` tests become direct prover-vs-verifier equality assertions.

### Compatibility

This changes the meaning of `BatchSumcheckOutput::challenges` for any out-of-tree consumer of the prover API: code reading it as a low-to-high evaluation point now reverses at the call site, as the in-tree consumers do.

Prover/verifier round-trip tests pass in `binius-ip-prover`, `binius-iop-prover`, `binius-prover`, and `binius-m4-prover` — these compare prover output against verifier output, so they would catch any consumer left uncompensated.
