### PR TITLE
BINIUS-283: warn at prover setup when the CPU's carryless multiply goes unused

### DIFF
--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -318,6 +318,31 @@ impl IOPProver {
 	}
 }
 
+/// Warns once per process if the CPU supports carryless multiply but this build does not use it.
+///
+/// The GHASH field arithmetic is selected at compile time, so a default-target x86_64 build runs
+/// the software multiply even on CPUs with PCLMULQDQ, silently costing an order of magnitude in
+/// prover throughput (see issue #1800). Building with `-C target-cpu=native` or
+/// `-C target-feature=+pclmulqdq` selects the hardware path.
+#[cfg(target_arch = "x86_64")]
+fn warn_on_software_field_arithmetic() {
+	use std::{arch::is_x86_feature_detected, sync::Once};
+
+	static ONCE: Once = Once::new();
+	ONCE.call_once(|| {
+		if !cfg!(target_feature = "pclmulqdq") && is_x86_feature_detected!("pclmulqdq") {
+			tracing::warn!(
+				"this CPU supports carryless multiply (PCLMULQDQ), but the build does not \
+				 enable it, so field arithmetic will run in software; rebuild with \
+				 `-C target-cpu=native` or `-C target-feature=+pclmulqdq`"
+			);
+		}
+	});
+}
+
+#[cfg(not(target_arch = "x86_64"))]
+const fn warn_on_software_field_arithmetic() {}
+
 /// Struct for proving instances of a particular constraint system.
 ///
 /// The [`Self::setup`] constructor pre-processes reusable structures for proving instances of the
@@ -356,6 +381,8 @@ where
 		verifier: Verifier<H>,
 		key_collection: KeyCollection,
 	) -> Result<Self, Error> {
+		warn_on_software_field_arithmetic();
+
 		// Get max subspace from verifier's IOP compiler (reuses FRI params)
 		let subspace = verifier.iop_compiler().max_subspace();
 		let domain_context = GenericPreExpanded::generate_from_subspace(subspace);


### PR DESCRIPTION
Part of #1800 ([BINIUS-283](https://linear.app/jimpo/issue/BINIUS-283)) — this addresses the *silent* half; it does **not** close the issue.

Adds a once-per-process `tracing::warn!` at `Prover::setup` when runtime detection finds PCLMULQDQ that the build did not enable. **No behavior change otherwise** — one warning line, emitted once, only on x86_64, and only when the software fallback is actually in effect.

### The problem

The GHASH multiply implementation is selected purely at compile time via `#[cfg(target_feature = ...)]`. A default-target x86_64 build (baseline up to SSE2) therefore compiles the portable software multiply even when the machine it runs on has PCLMULQDQ — roughly 24× slower at the multiply level, ~11.8× end-to-end (measurements in #1800) — with no symptom other than the missing throughput.

### The change

`Prover::setup` (via `setup_with_key_collection`, which both setup paths go through) runs one check: if `!cfg!(target_feature = "pclmulqdq")` but `is_x86_feature_detected!("pclmulqdq")`, emit a `tracing::warn!` recommending `-C target-cpu=native` or `-C target-feature=+pclmulqdq`. A `std::sync::Once` guard keeps repeated prover constructions from spamming; on non-x86_64 targets the function is an empty `const fn`.

### The real fix — and why it isn't this PR

Runtime dispatch is the actual resolution, but here it's a design decision rather than a patch. The packed width is a *type*: `OptimalPackedB128` is a cfg-selected alias, and every `FieldBuffer<P>` lays its data out in `P`'s words, so the software/128/256/512-bit paths differ in data layout — a dispatch seam has to sit above everything that touches a buffer. Two directions seem viable:

- **Top-level dispatch**: compile the prover stack per packing width and select at `Prover::setup`, erasing `P` from the public API. Full win, at the cost of binary size, compile time, and an API redesign.
- **Kernel-level partial dispatch**: runtime-select software vs. PCLMUL for the scalar multiply only — the two share the `u128` layout, so no buffer changes. Rescues default builds to 1-lane hardware speed, but puts a dispatch point in a hot kernel and leaves the packing width at 1.

Happy to implement either if you have a preference — flagging the tradeoffs here rather than picking a direction unilaterally.
