### PR TITLE
Update GHASH² to the Y² + X·Y + X irreducible

### DIFF
--- a/crates/field/src/ghash_sq.rs
+++ b/crates/field/src/ghash_sq.rs
@@ -4,16 +4,17 @@
 //!
 //! Elements are pairs `(a, b)` representing `a + b·Y`, where `a` and `b` are elements of
 //! [`BinaryField128bGhash`]. The extension is defined by the irreducible polynomial
-//! `Y² + Y + X⁻¹` over GHASH, so that `Y² = Y + X⁻¹`.
+//! `Y² + X·Y + X` over GHASH, so that `Y² = X·Y + X`.
 //!
 //! The field is backed by [`M256`], with the low 128 bits holding the coefficient of `1` (`a`) and
 //! the high 128 bits holding the coefficient of `Y` (`b`). This is the same layout as
 //! [`PackedBinaryGhash2x128b`] (two GHASH lanes in an `M256`) and matches the `{1, Y}` basis used
 //! by the `ExtensionField<BinaryField128bGhash>` implementation.
 //!
-//! Multiplication uses the `mul_m256i_hybrid` algorithm from the `binius_arith_bench::ghash_sq`
-//! module: the two GHASH products that share the AVX2 256-bit CLMUL are batched into a single
-//! [`PackedBinaryGhash2x128b`] multiply.
+//! Reducing with `Y² = X·Y + X` multiplies by `X` (a left shift) rather than by `X⁻¹`, and the
+//! multiply-by-`X` folds into the reduction. Multiplication batches the two GHASH products that
+//! share the AVX2 256-bit CLMUL into a single [`PackedBinaryGhash2x128b`] multiply (the
+//! `mul_m256i_hybrid` algorithm).
 
 use std::{
 	fmt::{Debug, Display, Formatter},
@@ -73,16 +74,17 @@ type CrossWide = <BinaryField128bGhash as WideMul>::Output;
 ///
 /// Holds the three GHASH widening products of the Karatsuba decomposition, before any reduction.
 ///
-/// Take `x = x_0 + x_1·Y` and `y = y_0 + y_1·Y` over GHASH, with `Y^2 = Y + X^-1`.
+/// Take `x = x_0 + x_1·Y` and `y = y_0 + y_1·Y` over GHASH, with `Y^2 = X·Y + X`.
 /// Then `z = x·y` has coordinates:
-/// - `z_0 = x_0·y_0 + (x_1·y_1)·X^-1`
-/// - `z_1 = (x_0+x_1)·(y_0+y_1) + x_0·y_0`
+/// - `z_0 = x_0·y_0 + X·(x_1·y_1)`
+/// - `z_1 = (x_0·y_1 + x_1·y_0) + X·(x_1·y_1)`
 ///
 /// The three scalar products it defers are:
 /// - `x_0·y_0` and `x_1·y_1`, computed together as one packed [`PackedBinaryGhash2x128b`] multiply.
-/// - `(x_0+x_1)·(y_0+y_1)`, the Karatsuba cross term, a scalar GHASH multiply.
+/// - `(x_0+x_1)·(y_0+y_1)`, the Karatsuba cross term, a scalar GHASH multiply, which recovers the
+///   cross term `x_0·y_1 + x_1·y_0` as `(x_0+x_1)·(y_0+y_1) + x_0·y_0 + x_1·y_1`.
 ///
-/// Both the GHASH reduction and the `X^-1` scaling are GF(2)-linear.
+/// Both the GHASH reduction and the multiply-by-`X` are GF(2)-linear.
 /// So a sum of products reduces to the reduction of the XOR of their unreduced forms.
 /// An inner product over GHASH^2 then accumulates by XOR and reduces only once at the end.
 #[derive(Clone, Copy, Default, Debug)]
@@ -170,22 +172,27 @@ impl WideMul for GhashSq256b {
 		// Reduce the cross product: `t_1 = (x_0+x_1)·(y_0+y_1)`.
 		let t1 = <BinaryField128bGhash as WideMul>::reduce(wide.cross);
 
-		// Fold `Y^2 = Y + X^-1` into the basis: `z_0 = t_0 + t_2·X^-1`, `z_1 = t_1 + t_0`.
-		Self::from_coeffs([t0 + t2.mul_inv_x(), t1 + t0])
+		// Fold `Y^2 = X·Y + X` into the basis. With the Karatsuba cross term recovered as
+		// `t_1 + t_0 + t_2`: `z_0 = t_0 + X·t_2`, `z_1 = (t_1 + t_0 + t_2) + X·t_2 = z_0 + t_1 +
+		// t_2`.
+		let z0 = t0 + t2.mul_x();
+		Self::from_coeffs([z0, z0 + t1 + t2])
 	}
 }
 
 /// Squares a GHASH² element.
 ///
-/// For `x = x₀ + x₁·Y`: `(x₀ + x₁·Y)² = (x₀² + x₁²·X⁻¹) + x₁²·Y` (the cross term vanishes in
-/// characteristic two). The squares `x₀²` and `x₁²` are computed with a single packed square.
+/// For `x = x₀ + x₁·Y`: `(x₀ + x₁·Y)² = (x₀² + X·x₁²) + (X·x₁²)·Y` (the cross term vanishes in
+/// characteristic two, and `Y² = X·Y + X`). The squares `x₀²` and `x₁²` are computed with a single
+/// packed square.
 #[inline]
 fn square(x: [BinaryField128bGhash; 2]) -> [BinaryField128bGhash; 2] {
 	let t0_t2 = Square::square(PackedBinaryGhash2x128b::from_scalars(x));
 	let t0 = t0_t2.get(0);
 	let t2 = t0_t2.get(1);
 
-	[t0 + t2.mul_inv_x(), t2]
+	let x_t2 = t2.mul_x();
+	[t0 + x_t2, x_t2]
 }
 
 impl Mul<GhashSq256b> for GhashSq256b {
@@ -208,15 +215,16 @@ impl Square for GhashSq256b {
 impl InvertOrZero for GhashSq256b {
 	#[inline]
 	fn invert_or_zero(self) -> Self {
-		// For `u = a + b·Y`, the nontrivial automorphism sends `Y -> Y + 1` (the other root of
-		// `Y² + Y + X⁻¹`), so the conjugate is `ū = (a + b) + b·Y`. The norm
-		// `N = u·ū = a² + a·b + b²·X⁻¹` lies in GHASH, and `u⁻¹ = ū·N⁻¹`.
+		// For `u = a + b·Y`, the nontrivial automorphism sends `Y` to the other root of
+		// `Y² + X·Y + X`. The two roots sum to `X` and multiply to `X`, so the conjugate is
+		// `ū = (a + b·X) + b·Y`. The norm `N = u·ū = a² + X·b·(a + b)` lies in GHASH, and
+		// `u⁻¹ = ū·N⁻¹`.
 		let [a, b] = self.to_coeffs();
 
-		let norm = Square::square(a) + a * b + Square::square(b).mul_inv_x();
+		let norm = Square::square(a) + (a * b + Square::square(b)).mul_x();
 		let norm_inv = norm.invert_or_zero();
 
-		let inv_a = (a + b) * norm_inv;
+		let inv_a = (a + b.mul_x()) * norm_inv;
 		let inv_b = b * norm_inv;
 		Self::from_coeffs([inv_a, inv_b])
 	}
@@ -268,8 +276,8 @@ mod tests {
 
 	use super::*;
 
-	/// `X⁻¹` in the GHASH field, i.e. `0x43 + x^127`. Equals `Y² + Y`.
-	const GHASH_INV_X: u128 = 0x80000000000000000000000000000043;
+	/// `X`, the generator of the GHASH field in the standard polynomial basis.
+	const GHASH_X: u128 = 0x02;
 
 	/// Prime factorization of `2²⁵⁶ - 1` (the multiplicative group order). These are the
 	/// Fermat-number factors `F₀..F₇`: `2²⁵⁶ - 1 = ∏_{k=0}^{7} (2^{2^k} + 1)`.
@@ -347,9 +355,10 @@ mod tests {
 
 	#[test]
 	fn test_quadratic_relation() {
-		// The extension is defined by `Y² + Y + X⁻¹ = 0`, i.e. `Y² = Y + X⁻¹`.
+		// The extension is defined by `Y² + X·Y + X = 0`, i.e. `Y² = X·Y + X`, whose coordinates in
+		// the `{1, Y}` basis are `(X, X)`.
 		let y = ghash_sq(0, 1);
-		assert_eq!(y * y, y + ghash_sq(GHASH_INV_X, 0));
+		assert_eq!(y * y, ghash_sq(GHASH_X, GHASH_X));
 	}
 
 	#[test]
@@ -422,7 +431,7 @@ mod tests {
 			//     eager:    sum_i reduce(wide_mul(a_i, b_i))  =  sum_i a_i * b_i
 			//     deferred: reduce( sum_i wide_mul(a_i, b_i) )
 			//
-			// This holds because the GHASH reduction and the `X^-1` scaling are both GF(2)-linear.
+			// This holds because the GHASH reduction and the multiply-by-`X` are both GF(2)-linear.
 			// So a sum of products costs one reduction, not one per term.
 			let eager: GhashSq256b = pairs.iter().map(|&(a, b)| a * b).sum();
 			let deferred = GhashSq256b::reduce(

--- a/crates/field/src/packed_ghash_sq.rs
+++ b/crates/field/src/packed_ghash_sq.rs
@@ -2,7 +2,7 @@
 
 //! Packed [`GhashSq256b`] in a sliced (struct-of-arrays) layout.
 //!
-//! [`GhashSq256b`] is the degree-two extension `a + b·Y` of the GHASH field, with `Y² = Y + X⁻¹`.
+//! [`GhashSq256b`] is the degree-two extension `a + b·Y` of the GHASH field, with `Y² = X·Y + X`.
 //! The packings here store the `a` and `b` coordinates of every lane in two separate packed GHASH
 //! registers via [`SlicedPackedField`], so a batch multiply runs as three packed GHASH multiplies
 //! over the whole batch (Karatsuba over `Y`) rather than a schoolbook product per element.
@@ -10,8 +10,8 @@
 //! Only the field arithmetic lives here: a widening multiply ([`WideMul`]) with a deferred
 //! reduction, plus [`Square`] and [`InvertOrZero`]. `Mul` and the rest of the [`PackedField`]
 //! surface are provided generically by [`SlicedPackedField`]. The coordinate register is a
-//! [`PackedPrimitiveType`], so the reduction scales by `X⁻¹` with a per-lane bit shift
-//! ([`ghash_mul_inv_x`]) rather than a full field multiply, and the batch costs three GHASH
+//! [`PackedPrimitiveType`], so the reduction scales by `X` with a per-lane bit shift
+//! ([`ghash_mul_x`]) rather than a full field multiply, and the batch costs three GHASH
 //! multiplies, not four.
 
 use std::{
@@ -42,31 +42,31 @@ pub type SlicedGhashSq4x256b = SlicedGhashSq256b<M512>;
 /// The unreduced widening product of the coordinate GHASH multiply.
 type GhashWide<U> = <Ghash<U> as WideMul>::Output;
 
-/// Multiplies every 128-bit GHASH lane of an underlier by `X⁻¹`.
+/// Multiplies every 128-bit GHASH lane of an underlier by `X`.
 ///
-/// `X⁻¹` scaling is `GF(2)`-linear — a per-lane bit shift with a fixed compensation, not a field
+/// `X` scaling is `GF(2)`-linear — a per-lane bit shift with a fixed compensation, not a field
 /// multiply — so this is far cheaper than a CLMUL. It reuses the scalar
-/// [`BinaryField128bGhash::mul_inv_x`] on each 128-bit lane, which every supported underlier
-/// divides into.
+/// [`BinaryField128bGhash::mul_x`] on each 128-bit lane, which every supported underlier divides
+/// into.
 #[inline]
-fn ghash_mul_inv_x<U: Divisible<M128>>(u: U) -> U {
+fn ghash_mul_x<U: Divisible<M128>>(u: U) -> U {
 	U::from_iter(Divisible::<M128>::value_iter(u).map(|lane| {
 		BinaryField128bGhash::from_underlier(lane)
-			.mul_inv_x()
+			.mul_x()
 			.to_underlier()
 	}))
 }
 
-/// Multiplies every GHASH lane of a packed coordinate by `X⁻¹`.
+/// Multiplies every GHASH lane of a packed coordinate by `X`.
 #[inline]
-fn mul_inv_x<U: UnderlierType + Divisible<M128>>(coord: Ghash<U>) -> Ghash<U> {
-	Ghash::<U>::from_underlier(ghash_mul_inv_x(coord.to_underlier()))
+fn mul_x<U: UnderlierType + Divisible<M128>>(coord: Ghash<U>) -> Ghash<U> {
+	Ghash::<U>::from_underlier(ghash_mul_x(coord.to_underlier()))
 }
 
 /// The unreduced product of two GHASH² elements in sliced form.
 ///
 /// Holds the three Karatsuba GHASH widening products, deferring both the GHASH reductions and the
-/// `X⁻¹` scaling. Since those are all `GF(2)`-linear, an inner product over GHASH² accumulates
+/// multiply-by-`X`. Since those are all `GF(2)`-linear, an inner product over GHASH² accumulates
 /// these by XOR and reduces once at the end.
 #[derive(Clone, Copy, Debug, Default)]
 pub struct SlicedGhashSqWide<W> {
@@ -149,14 +149,16 @@ where
 		}
 	}
 
-	/// Reduces the three products and folds `Y² = Y + X⁻¹`: `z₀ = t₀ + t₂·X⁻¹`, `z₁ = t₁ + t₀`.
+	/// Reduces the three products and folds `Y² = X·Y + X`. With the Karatsuba cross term recovered
+	/// as `t₁ + t₀ + t₂`: `z₀ = t₀ + X·t₂`, `z₁ = (t₁ + t₀ + t₂) + X·t₂ = z₀ + t₁ + t₂`.
 	#[inline]
 	fn reduce(wide: Self::Output) -> Self {
 		let t0 = <Ghash<U> as WideMul>::reduce(wide.t0);
 		let t2 = <Ghash<U> as WideMul>::reduce(wide.t2);
 		let t1 = <Ghash<U> as WideMul>::reduce(wide.t1);
 
-		Self::from_coords([t0 + mul_inv_x(t2), t1 + t0])
+		let z0 = t0 + mul_x(t2);
+		Self::from_coords([z0, z0 + t1 + t2])
 	}
 }
 
@@ -165,7 +167,8 @@ where
 	U: UnderlierType + Divisible<M128>,
 	Ghash<U>: PackedField<Scalar = BinaryField128bGhash>,
 {
-	/// `(a + b·Y)² = (a² + b²·X⁻¹) + b²·Y` — the cross term vanishes in characteristic two.
+	/// `(a + b·Y)² = (a² + X·b²) + (X·b²)·Y` — the cross term vanishes in characteristic two, and
+	/// `Y² = X·Y + X`.
 	#[inline]
 	fn square(self) -> Self {
 		let [a, b] = self.to_coords();
@@ -173,7 +176,8 @@ where
 		let t0 = Square::square(a);
 		let t2 = Square::square(b);
 
-		Self::from_coords([t0 + mul_inv_x(t2), t2])
+		let x_t2 = mul_x(t2);
+		Self::from_coords([t0 + x_t2, x_t2])
 	}
 }
 
@@ -182,17 +186,18 @@ where
 	U: UnderlierType + Divisible<M128>,
 	Ghash<U>: PackedField<Scalar = BinaryField128bGhash>,
 {
-	/// Inverts through the norm of the degree-two extension. The conjugate of `u = a + b·Y` under
-	/// `Y ↦ Y + 1` is `ū = (a + b) + b·Y`, its norm `N = u·ū = a² + a·b + b²·X⁻¹` lies in GHASH,
-	/// and `u⁻¹ = ū·N⁻¹`. A zero lane has norm zero, so `invert_or_zero` returns zero there.
+	/// Inverts through the norm of the degree-two extension. The conjugate of `u = a + b·Y` sends
+	/// `Y` to the other root of `Y² + X·Y + X` (the roots sum to `X` and multiply to `X`), giving
+	/// `ū = (a + X·b) + b·Y`. Its norm `N = u·ū = a² + X·b·(a + b)` lies in GHASH, and
+	/// `u⁻¹ = ū·N⁻¹`. A zero lane has norm zero, so `invert_or_zero` returns zero there.
 	#[inline]
 	fn invert_or_zero(self) -> Self {
 		let [a, b] = self.to_coords();
 
-		let norm = Square::square(a) + a * b + mul_inv_x(Square::square(b));
+		let norm = Square::square(a) + mul_x(a * b + Square::square(b));
 		let norm_inv = norm.invert_or_zero();
 
-		Self::from_coords([(a + b) * norm_inv, b * norm_inv])
+		Self::from_coords([(a + mul_x(b)) * norm_inv, b * norm_inv])
 	}
 }
 
@@ -239,8 +244,8 @@ mod tests {
 		P: PackedField<Scalar = GhashSq256b> + WideMul,
 	{
 		// The deferred widening form must match the eager product, and accumulating before a single
-		// reduction must match summing the reductions (both `X⁻¹` scaling and the GHASH reduction
-		// are `GF(2)`-linear).
+		// reduction must match summing the reductions (both the multiply-by-`X` and the GHASH
+		// reduction are `GF(2)`-linear).
 		let (a1, b1) = (P::random(&mut rng), P::random(&mut rng));
 		let (a2, b2) = (P::random(&mut rng), P::random(&mut rng));
 


### PR DESCRIPTION
Part 1 of [BINIUS-336](https://linear.app/jimpo/issue/BINIUS-336).

Switches the `GhashSq256b` degree-two extension from the old irreducible `Y² + Y + X⁻¹` to `Y² + X·Y + X`, matching the GHASH² definition merged into `binius-arith-bench` in #1889.

Reducing with `Y² = X·Y + X` folds a **multiply-by-`X`** (a per-lane left shift) into the basis instead of a multiply-by-`X⁻¹`, so the reduce/square/invert paths swap `mul_inv_x` for `mul_x` (`BinaryField128bGhash::mul_x`, which already exists):

- **reduce:** `z₀ = t₀ + X·t₂`, `z₁ = (t₁ + t₀ + t₂) + X·t₂ = z₀ + t₁ + t₂`
- **square:** `(a + b·Y)² = (a² + X·b²) + (X·b²)·Y`
- **invert:** conjugate `ū = (a + X·b) + b·Y` (the roots of `Y² + X·Y + X` sum to `X` and multiply to `X`), norm `N = a² + X·b·(a + b)`

The scalar field (`ghash_sq.rs`) and the sliced packing (`packed_ghash_sq.rs`) cross-check lane-by-lane in tests, so both move together in this commit. `Y` remains a multiplicative generator under the new irreducible (`test_multiplicative_generator` passes unchanged), so the baked `MULTIPLICATIVE_GENERATOR` is untouched.

This is the atomic irreducible flip; a follow-up PR adds `PackedPrimitiveType<M256/M512, GhashSq256b>` and re-sources the scalar arithmetic from the width-1 packed type.

All 233 `binius-field` tests + doctests pass; clippy and nightly fmt clean. The changes are portable (generic over `Divisible<M128>`), no arch-specific code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)