### PR TITLE
Add PackedPrimitiveType packings for GhashSq256b and derive scalar arithmetic

### DIFF
--- a/crates/field/src/arch/portable/m256.rs
+++ b/crates/field/src/arch/portable/m256.rs
@@ -1,9 +1,17 @@
 // Copyright 2023-2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-use crate::{arch::M128, underlier::ScaledUnderlier};
+use crate::{
+	arch::M128,
+	underlier::{Divisible, ScaledUnderlier, impl_divisible_self},
+};
 
 pub type M256 = ScaledUnderlier<M128, 2>;
+
+// Reflexive `Divisible<Self>`, needed by the width-one `PackedPrimitiveType<M256, _>` packing whose
+// scalar (e.g. `GhashSq256b`) is itself `M256`-backed. `M256` is a `ScaledUnderlier` alias here, so
+// this is the portable/aarch64 counterpart to the native `impl_divisible_self!(M256)` on x86_64.
+impl_divisible_self!(M256);
 
 pub const fn m256_from_u128s(lo: u128, hi: u128) -> M256 {
 	ScaledUnderlier([M128::from_u128(lo), M128::from_u128(hi)])

--- a/crates/field/src/arch/x86_64/m256.rs
+++ b/crates/field/src/arch/x86_64/m256.rs
@@ -19,7 +19,10 @@ use super::m128::{M128, m128i_from_u128};
 use crate::{
 	BinaryField,
 	arch::portable::packed::PackedPrimitiveType,
-	underlier::{Divisible, NumCast, SmallU, UnderlierType, impl_divisible_bitmask, mapget},
+	underlier::{
+		Divisible, NumCast, SmallU, UnderlierType, impl_divisible_bitmask, impl_divisible_self,
+		mapget,
+	},
 };
 
 const fn u128_from_m128i(x: __m128i) -> u128 {
@@ -539,6 +542,10 @@ unsafe fn interleave_bits_imm<const BLOCK_LEN: i32>(
 }
 
 // Divisible implementations using SIMD extract/insert intrinsics
+
+// Reflexive `Divisible<Self>`, needed by the width-one `PackedPrimitiveType<M256, _>` packing whose
+// scalar (e.g. `GhashSq256b`) is itself `M256`-backed.
+impl_divisible_self!(M256);
 
 impl Divisible<M128> for M256 {
 	const LOG_N: usize = 1;

--- a/crates/field/src/ghash_sq.rs
+++ b/crates/field/src/ghash_sq.rs
@@ -35,7 +35,6 @@ use super::{
 use crate::{
 	BinaryField128bGhash, Divisible, Field, PackedBinaryGhash2x128b, PackedField,
 	arch::{M128, M256, m256_from_u128s},
-	arithmetic_traits::{InvertOrZero, Square, WideMul},
 	mul_by_binary_field_1b,
 	underlier::U1,
 };
@@ -43,7 +42,11 @@ use crate::{
 // The multiplicative generator is `Y` (low 128 bits = 0, high 128 bits = 1).
 // `tests::test_multiplicative_generator` verifies it generates GF(2^256)* against the known
 // factorization of 2^256 - 1.
-binary_field!(custom_arithmetic pub GhashSq256b(M256), m256_from_u128s(0, 1));
+//
+// The field's `Mul`/`Square`/`InvertOrZero`/`WideMul` are the width-one packing's arithmetic,
+// derived by the `binary_field!` macro from [`PackedGhashSq1x256b`] (`PackedPrimitiveType<M256,
+// GhashSq256b>`), whose implementation lives in `packed_ghash_sq`.
+binary_field!(pub GhashSq256b(M256), m256_from_u128s(0, 1));
 
 unsafe impl Pod for GhashSq256b {}
 
@@ -61,172 +64,6 @@ impl GhashSq256b {
 	#[inline]
 	fn from_coeffs(coeffs: [BinaryField128bGhash; 2]) -> Self {
 		Self(PackedBinaryGhash2x128b::from_scalars(coeffs).to_underlier())
-	}
-}
-
-/// The two unreduced GHASH products `[x_0·y_0, x_1·y_1]` batched into one packed widening multiply.
-type DiagWide = <PackedBinaryGhash2x128b as WideMul>::Output;
-
-/// The single unreduced GHASH product `(x_0+x_1)·(y_0+y_1)` from a scalar widening multiply.
-type CrossWide = <BinaryField128bGhash as WideMul>::Output;
-
-/// The unreduced product of two GHASH^2 elements.
-///
-/// Holds the three GHASH widening products of the Karatsuba decomposition, before any reduction.
-///
-/// Take `x = x_0 + x_1·Y` and `y = y_0 + y_1·Y` over GHASH, with `Y^2 = X·Y + X`.
-/// Then `z = x·y` has coordinates:
-/// - `z_0 = x_0·y_0 + X·(x_1·y_1)`
-/// - `z_1 = (x_0·y_1 + x_1·y_0) + X·(x_1·y_1)`
-///
-/// The three scalar products it defers are:
-/// - `x_0·y_0` and `x_1·y_1`, computed together as one packed [`PackedBinaryGhash2x128b`] multiply.
-/// - `(x_0+x_1)·(y_0+y_1)`, the Karatsuba cross term, a scalar GHASH multiply, which recovers the
-///   cross term `x_0·y_1 + x_1·y_0` as `(x_0+x_1)·(y_0+y_1) + x_0·y_0 + x_1·y_1`.
-///
-/// Both the GHASH reduction and the multiply-by-`X` are GF(2)-linear.
-/// So a sum of products reduces to the reduction of the XOR of their unreduced forms.
-/// An inner product over GHASH^2 then accumulates by XOR and reduces only once at the end.
-#[derive(Clone, Copy, Default, Debug)]
-pub struct WideGhashSqProduct {
-	/// Unreduced `[x_0·y_0, x_1·y_1]`, the diagonal Karatsuba products in their two packed lanes.
-	diag: DiagWide,
-	/// Unreduced `(x_0+x_1)·(y_0+y_1)`, the Karatsuba cross product.
-	cross: CrossWide,
-}
-
-impl Add for WideGhashSqProduct {
-	type Output = Self;
-
-	#[inline]
-	fn add(self, rhs: Self) -> Self {
-		Self {
-			diag: self.diag + rhs.diag,
-			cross: self.cross + rhs.cross,
-		}
-	}
-}
-
-impl AddAssign for WideGhashSqProduct {
-	#[inline]
-	fn add_assign(&mut self, rhs: Self) {
-		self.diag += rhs.diag;
-		self.cross += rhs.cross;
-	}
-}
-
-impl Sub for WideGhashSqProduct {
-	type Output = Self;
-
-	#[inline]
-	fn sub(self, rhs: Self) -> Self {
-		Self {
-			diag: self.diag - rhs.diag,
-			cross: self.cross - rhs.cross,
-		}
-	}
-}
-
-impl SubAssign for WideGhashSqProduct {
-	#[inline]
-	fn sub_assign(&mut self, rhs: Self) {
-		self.diag -= rhs.diag;
-		self.cross -= rhs.cross;
-	}
-}
-
-impl Sum for WideGhashSqProduct {
-	#[inline]
-	fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
-		iter.fold(Self::default(), |acc, x| acc + x)
-	}
-}
-
-impl WideMul for GhashSq256b {
-	type Output = WideGhashSqProduct;
-
-	#[inline]
-	fn wide_mul(a: Self, b: Self) -> Self::Output {
-		let [x0, x1] = a.to_coeffs();
-		let [y0, y1] = b.to_coeffs();
-
-		// Diagonal `[x_0·y_0, x_1·y_1]` as one two-lane packed widening multiply.
-		// On AVX2 this is a single `vpclmulqdq` over both lanes — the `mul_m256i_hybrid` algorithm.
-		let diag = <PackedBinaryGhash2x128b as WideMul>::wide_mul(
-			PackedBinaryGhash2x128b::from_scalars([x0, x1]),
-			PackedBinaryGhash2x128b::from_scalars([y0, y1]),
-		);
-		// Karatsuba cross product `(x_0+x_1)·(y_0+y_1)` as a scalar widening multiply.
-		let cross = <BinaryField128bGhash as WideMul>::wide_mul(x0 + x1, y0 + y1);
-
-		WideGhashSqProduct { diag, cross }
-	}
-
-	#[inline]
-	fn reduce(wide: Self::Output) -> Self {
-		// Reduce the batched diagonal back to its two GHASH lanes: `t_0 = x_0·y_0`, `t_2 =
-		// x_1·y_1`.
-		let diag = <PackedBinaryGhash2x128b as WideMul>::reduce(wide.diag);
-		let t0 = diag.get(0);
-		let t2 = diag.get(1);
-		// Reduce the cross product: `t_1 = (x_0+x_1)·(y_0+y_1)`.
-		let t1 = <BinaryField128bGhash as WideMul>::reduce(wide.cross);
-
-		// Fold `Y^2 = X·Y + X` into the basis. With the Karatsuba cross term recovered as
-		// `t_1 + t_0 + t_2`: `z_0 = t_0 + X·t_2`, `z_1 = (t_1 + t_0 + t_2) + X·t_2 = z_0 + t_1 +
-		// t_2`.
-		let z0 = t0 + t2.mul_x();
-		Self::from_coeffs([z0, z0 + t1 + t2])
-	}
-}
-
-/// Squares a GHASH² element.
-///
-/// For `x = x₀ + x₁·Y`: `(x₀ + x₁·Y)² = (x₀² + X·x₁²) + (X·x₁²)·Y` (the cross term vanishes in
-/// characteristic two, and `Y² = X·Y + X`). The squares `x₀²` and `x₁²` are computed with a single
-/// packed square.
-#[inline]
-fn square(x: [BinaryField128bGhash; 2]) -> [BinaryField128bGhash; 2] {
-	let t0_t2 = Square::square(PackedBinaryGhash2x128b::from_scalars(x));
-	let t0 = t0_t2.get(0);
-	let t2 = t0_t2.get(1);
-
-	let x_t2 = t2.mul_x();
-	[t0 + x_t2, x_t2]
-}
-
-impl Mul<GhashSq256b> for GhashSq256b {
-	type Output = Self;
-
-	#[inline]
-	fn mul(self, rhs: Self) -> Self {
-		crate::tracing::trace_multiplication!(GhashSq256b);
-		Self::reduce(Self::wide_mul(self, rhs))
-	}
-}
-
-impl Square for GhashSq256b {
-	#[inline]
-	fn square(self) -> Self {
-		Self::from_coeffs(square(self.to_coeffs()))
-	}
-}
-
-impl InvertOrZero for GhashSq256b {
-	#[inline]
-	fn invert_or_zero(self) -> Self {
-		// For `u = a + b·Y`, the nontrivial automorphism sends `Y` to the other root of
-		// `Y² + X·Y + X`. The two roots sum to `X` and multiply to `X`, so the conjugate is
-		// `ū = (a + b·X) + b·Y`. The norm `N = u·ū = a² + X·b·(a + b)` lies in GHASH, and
-		// `u⁻¹ = ū·N⁻¹`.
-		let [a, b] = self.to_coeffs();
-
-		let norm = Square::square(a) + (a * b + Square::square(b)).mul_x();
-		let norm_inv = norm.invert_or_zero();
-
-		let inv_a = (a + b.mul_x()) * norm_inv;
-		let inv_b = b * norm_inv;
-		Self::from_coeffs([inv_a, inv_b])
 	}
 }
 
@@ -275,6 +112,7 @@ mod tests {
 	use proptest::prelude::*;
 
 	use super::*;
+	use crate::arithmetic_traits::{InvertOrZero, Square, WideMul};
 
 	/// `X`, the generator of the GHASH field in the standard polynomial basis.
 	const GHASH_X: u128 = 0x02;

--- a/crates/field/src/packed_extension.rs
+++ b/crates/field/src/packed_extension.rs
@@ -38,6 +38,16 @@ where
 	PackedSubfield::<P, FSub>::from_underlier_ref_mut(packed.to_underlier_ref_mut())
 }
 
+/// Reinterpret a packed extension field element as the corresponding packed subfield element.
+pub fn cast_base<FSub, P>(ext: P) -> PackedSubfield<P, FSub>
+where
+	FSub: BinaryField,
+	P: PackedField<Scalar: ExtensionField<FSub>> + WithUnderlier,
+	PackedSubfield<P, FSub>: PackedField<Scalar = FSub>,
+{
+	PackedSubfield::<P, FSub>::from_underlier(ext.to_underlier())
+}
+
 /// Reinterpret a packed subfield element as the corresponding packed extension field element.
 pub fn cast_ext<FSub, P>(base: PackedSubfield<P, FSub>) -> P
 where

--- a/crates/field/src/packed_ghash_sq.rs
+++ b/crates/field/src/packed_ghash_sq.rs
@@ -1,28 +1,40 @@
 // Copyright 2026 The Binius Developers
 
-//! Packed [`GhashSq256b`] in a sliced (struct-of-arrays) layout.
+//! Packed [`GhashSq256b`] in two layouts: sliced (struct-of-arrays) and interleaved
+//! (array-of-structs).
 //!
 //! [`GhashSq256b`] is the degree-two extension `a + b·Y` of the GHASH field, with `Y² = X·Y + X`.
-//! The packings here store the `a` and `b` coordinates of every lane in two separate packed GHASH
-//! registers via [`SlicedPackedField`], so a batch multiply runs as three packed GHASH multiplies
-//! over the whole batch (Karatsuba over `Y`) rather than a schoolbook product per element.
+//! Both layouts reduce a batch multiply to three packed GHASH multiplies (Karatsuba over `Y`)
+//! rather than a schoolbook product per element, and both defer the GHASH reductions and the
+//! multiply-by-`X` — all `GF(2)`-linear — so an inner product reduces once at the end.
 //!
-//! Only the field arithmetic lives here: a widening multiply ([`WideMul`]) with a deferred
-//! reduction, plus [`Square`] and [`InvertOrZero`]. `Mul` and the rest of the [`PackedField`]
-//! surface are provided generically by [`SlicedPackedField`]. The coordinate register is a
-//! [`PackedPrimitiveType`], so the reduction scales by `X` with a per-lane bit shift
-//! ([`ghash_mul_x`]) rather than a full field multiply, and the batch costs three GHASH
-//! multiplies, not four.
+//! - The **sliced** packings ([`SlicedGhashSq256b`]) store the `a` and `b` coordinates of every
+//!   lane in two separate packed GHASH registers via [`SlicedPackedField`]; `Mul` and the rest of
+//!   the [`PackedField`] surface come generically from [`SlicedPackedField`].
+//! - The **interleaved** packings ([`PackedGhashSq1x256b`] / [`PackedGhashSq2x256b`], i.e.
+//!   `PackedPrimitiveType<M256/M512, GhashSq256b>`) store each scalar as one contiguous 256-bit
+//!   value — the same layout as the scalar field. The width-one packing carries the field
+//!   arithmetic (and the scalar [`GhashSq256b`] derives its own from it), while the width-two
+//!   packing divides into two width-one lanes.
+//!
+//! In both, the coordinate register is a [`PackedPrimitiveType`], so the multiply-by-`X` in the
+//! reduction is a per-lane bit shift ([`ghash_mul_x`]) rather than a full field multiply.
 
 use std::{
 	iter::Sum,
 	ops::{Add, AddAssign, Sub, SubAssign},
 };
 
+use bytemuck::TransparentWrapper;
+
 use crate::{
-	BinaryField128bGhash, Divisible, GhashSq256b, PackedField, WideMul,
-	arch::{M128, M256, M512, PackedPrimitiveType},
+	BinaryField128bGhash, Divisible, GhashSq256b, PackedBinaryGhash2x128b, PackedField, WideMul,
+	arch::{
+		Divide, M128, M256, M512, MulFromWideMul, PackedPrimitiveType,
+		portable::packed_macros::{portable_macros::*, *},
+	},
 	arithmetic_traits::{InvertOrZero, Square},
+	cast_base, cast_ext,
 	sliced_packed_field::SlicedPackedField,
 	underlier::{UnderlierType, WithUnderlier},
 };
@@ -200,6 +212,187 @@ where
 		Self::from_coords([(a + mul_x(b)) * norm_inv, b * norm_inv])
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Interleaved (array-of-structs) packings: `PackedPrimitiveType<M256/M512, GhashSq256b>`.
+//
+// Unlike the sliced packings above, these store each GHASH² scalar as one contiguous 256-bit value
+// (low 128 bits = coefficient of `1`, high 128 bits = coefficient of `Y`) — the same layout as the
+// scalar `GhashSq256b`. The width-one M256 packing carries the field arithmetic (the scalar field
+// derives its own `Mul`/`Square`/`InvertOrZero`/`WideMul` from it via `binary_field!`); the
+// width-two M512 packing divides into two independent M256 lanes.
+// ---------------------------------------------------------------------------
+
+/// The two unreduced GHASH products `[a·e, b·f]` batched into one packed widening multiply.
+type DiagWide = <PackedBinaryGhash2x128b as WideMul>::Output;
+/// The single unreduced GHASH cross product `(a+b)·(e+f)` from a scalar widening multiply.
+type CrossWide = <BinaryField128bGhash as WideMul>::Output;
+
+/// The unreduced product of two [`PackedGhashSq1x256b`] elements.
+///
+/// Holds the three GHASH widening products of the Karatsuba decomposition over `Y`, deferring both
+/// the GHASH reductions and the multiply-by-`X` — all `GF(2)`-linear — so an inner product over
+/// GHASH² accumulates these by XOR and reduces only once at the end.
+#[derive(Clone, Copy, Default, Debug)]
+pub struct WideGhashSqProduct {
+	/// Unreduced `[a·e, b·f]`, the diagonal Karatsuba products in their two packed GHASH lanes.
+	diag: DiagWide,
+	/// Unreduced `(a+b)·(e+f)`, the Karatsuba cross product.
+	cross: CrossWide,
+}
+
+impl Add for WideGhashSqProduct {
+	type Output = Self;
+
+	#[inline]
+	fn add(self, rhs: Self) -> Self {
+		Self {
+			diag: self.diag + rhs.diag,
+			cross: self.cross + rhs.cross,
+		}
+	}
+}
+
+impl AddAssign for WideGhashSqProduct {
+	#[inline]
+	fn add_assign(&mut self, rhs: Self) {
+		self.diag += rhs.diag;
+		self.cross += rhs.cross;
+	}
+}
+
+impl Sub for WideGhashSqProduct {
+	type Output = Self;
+
+	#[inline]
+	fn sub(self, rhs: Self) -> Self {
+		Self {
+			diag: self.diag - rhs.diag,
+			cross: self.cross - rhs.cross,
+		}
+	}
+}
+
+impl SubAssign for WideGhashSqProduct {
+	#[inline]
+	fn sub_assign(&mut self, rhs: Self) {
+		self.diag -= rhs.diag;
+		self.cross -= rhs.cross;
+	}
+}
+
+impl Sum for WideGhashSqProduct {
+	#[inline]
+	fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+		iter.fold(Self::default(), |acc, x| acc + x)
+	}
+}
+
+/// [`WideMul`] strategy for [`PackedGhashSq1x256b`]: the `mul_m256i_hybrid` algorithm.
+#[repr(transparent)]
+#[derive(TransparentWrapper)]
+pub struct GhashSqWideMul<T>(T);
+
+impl WideMul for GhashSqWideMul<PackedGhashSq1x256b> {
+	type Output = WideGhashSqProduct;
+
+	#[inline]
+	fn wide_mul(a: Self, b: Self) -> Self::Output {
+		let a = cast_base::<BinaryField128bGhash, _>(Self::peel(a));
+		let b = cast_base::<BinaryField128bGhash, _>(Self::peel(b));
+
+		// Diagonal `[a·e, b·f]` as one two-lane packed widening multiply — a single 256-bit
+		// VPCLMUL on AVX2, two 128-bit PMULL on aarch64 via the scaled `M256`.
+		let diag = PackedBinaryGhash2x128b::wide_mul(a, b);
+		// Karatsuba cross product `(a+b)·(e+f)` as a scalar widening multiply.
+		let cross = BinaryField128bGhash::wide_mul(a.get(0) + a.get(1), b.get(0) + b.get(1));
+
+		WideGhashSqProduct { diag, cross }
+	}
+
+	#[inline]
+	fn reduce(wide: Self::Output) -> Self {
+		// Reduce the batched diagonal back to `t_0 = a·e`, `t_2 = b·f`, and the cross to `t_1`.
+		let diag = PackedBinaryGhash2x128b::reduce(wide.diag);
+		let t0 = diag.get(0);
+		let t2 = diag.get(1);
+		let t1 = BinaryField128bGhash::reduce(wide.cross);
+
+		// Fold `Y² = X·Y + X`, recovering the cross term as `t_1 + t_0 + t_2`:
+		// `z_0 = t_0 + X·t_2`, `z_1 = (t_1 + t_0 + t_2) + X·t_2 = z_0 + t_1 + t_2`.
+		let z0 = t0 + t2.mul_x();
+		Self::wrap(cast_ext::<BinaryField128bGhash, _>(PackedBinaryGhash2x128b::from_scalars([
+			z0,
+			z0 + t1 + t2,
+		])))
+	}
+}
+
+/// [`Square`] strategy for [`PackedGhashSq1x256b`].
+#[repr(transparent)]
+#[derive(TransparentWrapper)]
+pub struct GhashSqSquare<T>(T);
+
+impl Square for GhashSqSquare<PackedGhashSq1x256b> {
+	/// `(a + b·Y)² = (a² + X·b²) + (X·b²)·Y` — the cross term vanishes in characteristic two.
+	#[inline]
+	fn square(self) -> Self {
+		let sq = Square::square(cast_base::<BinaryField128bGhash, _>(Self::peel(self)));
+
+		let x_t2 = sq.get(1).mul_x();
+		Self::wrap(cast_ext::<BinaryField128bGhash, _>(PackedBinaryGhash2x128b::from_scalars([
+			sq.get(0) + x_t2,
+			x_t2,
+		])))
+	}
+}
+
+/// [`InvertOrZero`] strategy for [`PackedGhashSq1x256b`].
+#[repr(transparent)]
+#[derive(TransparentWrapper)]
+pub struct GhashSqInvert<T>(T);
+
+impl InvertOrZero for GhashSqInvert<PackedGhashSq1x256b> {
+	/// Inverts through the norm: conjugate `ū = (a + X·b) + b·Y` (the roots of `Y² + X·Y + X` sum
+	/// to `X` and multiply to `X`), norm `N = a² + X·b·(a + b)`, and `u⁻¹ = ū·N⁻¹`.
+	#[inline]
+	fn invert_or_zero(self) -> Self {
+		let coords = cast_base::<BinaryField128bGhash, _>(Self::peel(self));
+		let a = coords.get(0);
+		let b = coords.get(1);
+
+		let norm = Square::square(a) + (a * b + Square::square(b)).mul_x();
+		let norm_inv = norm.invert_or_zero();
+
+		Self::wrap(cast_ext::<BinaryField128bGhash, _>(PackedBinaryGhash2x128b::from_scalars([
+			(a + b.mul_x()) * norm_inv,
+			b * norm_inv,
+		])))
+	}
+}
+
+/// [`Divide`] strategy specializing the width-two M512 packing into two width-one M256 lanes.
+type GhashSqDivide2x<T> = Divide<M256, T, 2>;
+
+define_packed_binary_field!(
+	PackedGhashSq1x256b,
+	GhashSq256b,
+	M256,
+	(MulFromWideMul),
+	(GhashSqSquare),
+	(GhashSqInvert),
+	(GhashSqWideMul)
+);
+
+define_packed_binary_field!(
+	PackedGhashSq2x256b,
+	GhashSq256b,
+	M512,
+	(MulFromWideMul),
+	(GhashSqDivide2x),
+	(GhashSqDivide2x),
+	(GhashSqDivide2x)
+);
 
 #[cfg(test)]
 mod tests {
@@ -391,4 +584,9 @@ mod tests {
 	width_tests!(width1, SlicedGhashSq1x256b);
 	width_tests!(width2, SlicedGhashSq2x256b);
 	width_tests!(width4, SlicedGhashSq4x256b);
+
+	// The interleaved `PackedPrimitiveType` packings must agree lane-by-lane with the same scalar
+	// reference field as the sliced packings above.
+	width_tests!(packed_width1, PackedGhashSq1x256b);
+	width_tests!(packed_width2, PackedGhashSq2x256b);
 }


### PR DESCRIPTION
Part 2 of [BINIUS-336](https://linear.app/jimpo/issue/BINIUS-336), following the now-merged #1894 (the irreducible flip).

Adds the `PackedPrimitiveType` packings the issue asks for and makes the scalar field derive its arithmetic from them.

### New interleaved (array-of-structs) packings
- **`PackedGhashSq1x256b`** = `PackedPrimitiveType<M256, GhashSq256b>` (width 1)
- **`PackedGhashSq2x256b`** = `PackedPrimitiveType<M512, GhashSq256b>` (width 2)

Each stores a GHASH² scalar as one contiguous 256-bit value (the same layout as the scalar field), alongside the existing sliced (`SlicedGhashSq*`) packings, which remain.

The width-one packing carries the field arithmetic. Its widening multiply **is** the `mul_m256i_hybrid` algorithm: the diagonal Karatsuba products `[a·e, b·f]` batch into one `PackedBinaryGhash2x128b` widening multiply — a single 256-bit VPCLMUL on AVX2, two 128-bit PMULL on aarch64 via the scaled `M256` — plus a scalar cross product, reduced with `Y² = X·Y + X`. The width-two packing divides into two width-one `M256` lanes (`Divide<M256, _, 2>`).

Delegating the diagonal to the base GHASH packed coordinate type gives the per-arch algorithms (x86_64 hybrid, aarch64 NEON) for free from that type's arch specialization — no new `unsafe` intrinsics and no dependency on `binius-arith-bench` (a bench harness `binius-field` doesn't depend on; see the Linear thread).

### Scalar field derives its arithmetic
`GhashSq256b` drops the `custom_arithmetic` modifier and uses plain `binary_field!`, so its `Mul`/`Square`/`InvertOrZero`/`WideMul` derive from the width-one packing via `@arithmetic_via_packed`. The duplicated hand-written scalar arithmetic (~110 lines) is removed; behavior is identical (same `reduce∘wide_mul`).

### Reflexive `Divisible<M256>`
Added for `M256` (native on x86_64, `ScaledUnderlier` on portable/aarch64) — the width-one `PackedPrimitiveType<M256, _>` packing needs `M256: Divisible<M256>` because its scalar is itself `M256`-backed. This is the `M256` counterpart to the existing `impl_divisible_self!(M128)`; verified it does not collide with the generic `ScaledUnderlier` `Divisible` impl.

### Testing
The two new packings run through the same lane-by-lane-vs-scalar proptest suite as the sliced packings (`packed_width1`/`packed_width2`). Full matrix green: x86_64 (native + portable), aarch64 (lib + tests, cross-compiled), wasm32, clippy `-D warnings`, nightly fmt, rust-doc `-D warnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)