### PR TITLE
BINIUS-338: pick the packed GHASH² widening multiply per architecture

### DIFF
--- a/crates/field/src/arch/aarch64/arithmetic/ghash.rs
+++ b/crates/field/src/arch/aarch64/arithmetic/ghash.rs
@@ -18,8 +18,9 @@ use bytemuck::TransparentWrapper;
 
 use super::super::m128::M128;
 use crate::{
-	BinaryField128bGhash as GhashB128, WideMul, arch::PackedPrimitiveType,
-	arithmetic_traits::Square,
+	BinaryField128bGhash as GhashB128, WideMul,
+	arch::PackedPrimitiveType,
+	arithmetic_traits::{MulXWide, Square},
 };
 
 // The reduction polynomial x^128 + x^7 + x^2 + x + 1 is represented as 0x87.
@@ -144,6 +145,37 @@ impl WideGhashProduct {
 	}
 }
 
+impl MulXWide for WideGhashProduct {
+	/// Shifts the represented 256-bit polynomial `lo + mid·X^64 + hi·X^128` left by one bit.
+	///
+	/// Each 64-bit lane shifts up by one; the bit leaving the top of a lane belongs 64 bit
+	/// positions higher, which — since consecutive limbs overlap by 64 bits — is the corresponding
+	/// lane of the next limb. `hi` has no limb above it, so its low lane's carry goes to its own
+	/// high lane, where rotating the lanes puts it.
+	///
+	/// Every limb is a carry-less product of 64-bit halves, so it has degree at most 126, and
+	/// XOR-accumulating such products preserves that. Bit 127 of `hi` is therefore clear, and the
+	/// bit the rotation wraps back into the low lane is zero.
+	#[inline]
+	fn mul_x_wide(self) -> Self {
+		let (v0, v1, v2): (uint64x2_t, uint64x2_t, uint64x2_t) =
+			(self.lo.into(), self.mid.into(), self.hi.into());
+
+		unsafe {
+			let (sll0, sll1, sll2) =
+				(vshlq_n_u64::<1>(v0), vshlq_n_u64::<1>(v1), vshlq_n_u64::<1>(v2));
+			let (srl0, srl1, srl2) =
+				(vshrq_n_u64::<63>(v0), vshrq_n_u64::<63>(v1), vshrq_n_u64::<63>(v2));
+
+			Self {
+				lo: sll0.into(),
+				mid: veorq_u64(sll1, srl0).into(),
+				hi: veorq_u64(veorq_u64(sll2, srl1), vextq_u64::<1>(srl2, srl2)).into(),
+			}
+		}
+	}
+}
+
 impl Add for WideGhashProduct {
 	type Output = Self;
 
@@ -212,5 +244,24 @@ impl WideMul for GhashClMulWideMul<PackedPrimitiveType<M128, GhashB128>> {
 
 	fn reduce(wide: Self::Output) -> Self {
 		Self::wrap(PackedPrimitiveType::wrap(wide.reduce()))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use proptest::{prelude::any, proptest};
+
+	use super::{M128, MulXWide, WideGhashProduct};
+
+	proptest! {
+		// Scaling by X commutes with the reduction: scaling the unreduced product matches
+		// multiplying the reduced product by X (the field element 2).
+		#[test]
+		fn mul_x_wide_commutes_with_reduce(a in any::<u128>(), b in any::<u128>()) {
+			let wide = WideGhashProduct::wide_mul(M128::from_u128(a), M128::from_u128(b));
+			let mul_x = WideGhashProduct::wide_mul(wide.reduce(), M128::from_u128(2)).reduce();
+
+			assert_eq!(wide.mul_x_wide().reduce(), mul_x);
+		}
 	}
 }

--- a/crates/field/src/arch/mod.rs
+++ b/crates/field/src/arch/mod.rs
@@ -14,6 +14,7 @@ cfg_if! {
 		pub use x86_64::packed_ghash_128::{GhashWideMul1x, GhashSquare1x, GhashInvert1x};
 		pub use x86_64::packed_ghash_256::{GhashWideMul2x, GhashSquare2x, GhashInvert2x};
 		pub use x86_64::packed_ghash_512::{GhashWideMul4x, GhashSquare4x, GhashInvert4x};
+		pub use x86_64::packed_ghash_sq_256::GhashSqWideMul1x;
 		pub use x86_64::packed_aes_128::{AesWideMul16x, AesSquare16x, AesInvert16x};
 		pub use x86_64::packed_aes_256::{AesWideMul32x, AesSquare32x, AesInvert32x};
 		pub use x86_64::packed_aes_512::{AesWideMul64x, AesSquare64x, AesInvert64x};
@@ -24,6 +25,7 @@ cfg_if! {
 		pub use portable::{packed_aes_256, packed_aes_512, packed_ghash_256, packed_ghash_512};
 		pub use portable::packed_ghash_256::{GhashWideMul2x, GhashSquare2x, GhashInvert2x};
 		pub use portable::packed_ghash_512::{GhashWideMul4x, GhashSquare4x, GhashInvert4x};
+		pub use portable::packed_ghash_sq_256::GhashSqWideMul1x;
 		pub use aarch64::packed_aes_128::{AesWideMul16x, AesSquare16x, AesInvert16x};
 		pub use portable::packed_aes_256::{AesWideMul32x, AesSquare32x, AesInvert32x};
 		pub use portable::packed_aes_512::{AesWideMul64x, AesSquare64x, AesInvert64x};
@@ -34,6 +36,7 @@ cfg_if! {
 		pub use portable::{M128, M256, M512, m256_from_u128s, packed_aes_128, packed_aes_256, packed_aes_512, packed_ghash_512};
 		pub use portable::packed_ghash_256::{GhashWideMul2x, GhashSquare2x, GhashInvert2x};
 		pub use portable::packed_ghash_512::{GhashWideMul4x, GhashSquare4x, GhashInvert4x};
+		pub use portable::packed_ghash_sq_256::GhashSqWideMul1x;
 		pub use portable::packed_aes_128::{AesWideMul16x, AesSquare16x, AesInvert16x};
 		pub use portable::packed_aes_256::{AesWideMul32x, AesSquare32x, AesInvert32x};
 		pub use portable::packed_aes_512::{AesWideMul64x, AesSquare64x, AesInvert64x};
@@ -42,6 +45,7 @@ cfg_if! {
 		pub use portable::packed_ghash_128::{GhashWideMul1x, GhashSquare1x, GhashInvert1x};
 		pub use portable::packed_ghash_256::{GhashWideMul2x, GhashSquare2x, GhashInvert2x};
 		pub use portable::packed_ghash_512::{GhashWideMul4x, GhashSquare4x, GhashInvert4x};
+		pub use portable::packed_ghash_sq_256::GhashSqWideMul1x;
 		pub use portable::packed_aes_128::{AesWideMul16x, AesSquare16x, AesInvert16x};
 		pub use portable::packed_aes_256::{AesWideMul32x, AesSquare32x, AesInvert32x};
 		pub use portable::packed_aes_512::{AesWideMul64x, AesSquare64x, AesInvert64x};

--- a/crates/field/src/arch/portable/arithmetic/ghash.rs
+++ b/crates/field/src/arch/portable/arithmetic/ghash.rs
@@ -12,8 +12,9 @@ use bytemuck::TransparentWrapper;
 
 use super::super::univariate_mul_utils_128::{Underlier64bLanes, Underlier128bLanes, bmul64};
 use crate::{
-	BinaryField128bGhash as GhashB128, WideMul, arch::PackedPrimitiveType,
-	arithmetic_traits::Square,
+	BinaryField128bGhash as GhashB128, WideMul,
+	arch::PackedPrimitiveType,
+	arithmetic_traits::{MulXWide, Square},
 };
 
 /// Multiply two GHASH field elements using software implementation.
@@ -116,6 +117,23 @@ impl<U: Underlier128bLanes> WideGhashProduct<U> {
 	#[inline]
 	pub fn reduce(self) -> U {
 		reduce_64(self.v0, self.v1, self.v2, self.v3)
+	}
+}
+
+impl<U: Underlier128bLanes> MulXWide for WideGhashProduct<U> {
+	/// Shifts the 256-bit schoolbook product left by one bit, carrying between the four 64-bit
+	/// limbs.
+	///
+	/// The product of two 128-bit polynomials has degree at most 254, and XOR-accumulating such
+	/// products preserves that, so the top bit of `v3` is always clear and nothing is shifted out.
+	#[inline]
+	fn mul_x_wide(self) -> Self {
+		Self {
+			v0: self.v0.shl_64(1),
+			v1: self.v1.shl_64(1) ^ self.v0.shr_64(63),
+			v2: self.v2.shl_64(1) ^ self.v1.shr_64(63),
+			v3: self.v3.shl_64(1) ^ self.v2.shr_64(63),
+		}
 	}
 }
 
@@ -222,7 +240,7 @@ impl<U: Underlier128bLanes> Square for GhashSoftMul<PackedPrimitiveType<U, Ghash
 mod tests {
 	use proptest::{prelude::any, proptest};
 
-	use super::{super::super::m128::M128, ghash_mul, ghash_wide_mul};
+	use super::{super::super::m128::M128, MulXWide, ghash_mul, ghash_wide_mul};
 
 	// Exercises the deferred wide-mul building blocks (`ghash_wide_mul` + `WideGhashProduct`) that
 	// `GhashWideMul` wraps, directly on the portable `M128`. This runs on every host, whereas the
@@ -246,6 +264,15 @@ mod tests {
 			let (a2, b2) = (M128::from(a2), M128::from(b2));
 			let acc = ghash_wide_mul(a1, b1) + ghash_wide_mul(a2, b2);
 			assert_eq!(acc.reduce(), ghash_mul(a1, b1) ^ ghash_mul(a2, b2));
+		}
+
+		// Scaling by X commutes with the reduction: scaling the unreduced product matches
+		// multiplying the reduced product by X (the field element 2).
+		#[test]
+		fn mul_x_wide_commutes_with_reduce(a in any::<u128>(), b in any::<u128>()) {
+			let (a, b) = (M128::from(a), M128::from(b));
+			let wide = ghash_wide_mul(a, b);
+			assert_eq!(wide.mul_x_wide().reduce(), ghash_mul(wide.reduce(), M128::from(2u128)));
 		}
 	}
 }

--- a/crates/field/src/arch/portable/arithmetic/ghash_sq.rs
+++ b/crates/field/src/arch/portable/arithmetic/ghash_sq.rs
@@ -1,0 +1,57 @@
+// Copyright 2026 The Binius Developers
+
+//! Portable GHASH² widening multiply: three independent GHASH multiplies over the coordinates.
+//!
+//! This is the strategy for targets whose widest carry-less multiply is 128 bits, where batching
+//! the Karatsuba diagonal into a two-lane packed GHASH multiply buys nothing — that packed multiply
+//! decomposes back into two independent 128-bit multiplies, each with its own reduction. Keeping
+//! the three Karatsuba products separate instead lets the multiply-by-`X` of the irreducible
+//! polynomial be applied to an *unreduced* product ([`MulXWide`]), which folds it into a reduction
+//! that has to happen anyway: two GHASH reductions per GHASH² product rather than three.
+
+use bytemuck::TransparentWrapper;
+
+use crate::{
+	BinaryField128bGhash, PackedGhashSq1x256b, SlicedGhashSqWide, WideMul,
+	arithmetic_traits::MulXWide,
+	packed_ghash_sq::{ghash_sq_coords, ghash_sq_from_coords},
+};
+
+/// The unreduced product of a single GHASH coordinate multiply.
+type GhashWide = <BinaryField128bGhash as WideMul>::Output;
+
+/// [`WideMul`] strategy for [`PackedGhashSq1x256b`] keeping the three Karatsuba products of the
+/// coordinate multiply separate, so that the multiply-by-`X` can be deferred into a reduction.
+#[repr(transparent)]
+#[derive(TransparentWrapper)]
+pub struct GhashSqSlicedWideMul<T>(T);
+
+impl WideMul for GhashSqSlicedWideMul<PackedGhashSq1x256b> {
+	type Output = SlicedGhashSqWide<GhashWide>;
+
+	/// Karatsuba over `Y`: defers the three GHASH products `a·e`, `b·f`, `(a+b)·(e+f)`.
+	#[inline]
+	fn wide_mul(a: Self, b: Self) -> Self::Output {
+		let [a0, a1] = ghash_sq_coords(Self::peel(a));
+		let [b0, b1] = ghash_sq_coords(Self::peel(b));
+
+		SlicedGhashSqWide {
+			t0: BinaryField128bGhash::wide_mul(a0, b0),
+			t2: BinaryField128bGhash::wide_mul(a1, b1),
+			t1: BinaryField128bGhash::wide_mul(a0 + a1, b0 + b1),
+		}
+	}
+
+	/// Folds `Y² = X·Y + X`, recovering the Karatsuba cross term as `t₁ + t₀ + t₂`:
+	/// `z₀ = t₀ + X·t₂` and `z₁ = (t₁ + t₀ + t₂) + X·t₂ = z₀ + t₁ + t₂`.
+	///
+	/// Scaling `t₂` by `X` while it is still unreduced turns `z₀` into a single reduction of an
+	/// accumulated wide product, so the two coordinates cost two reductions in total.
+	#[inline]
+	fn reduce(wide: Self::Output) -> Self {
+		let z0 = BinaryField128bGhash::reduce(wide.t0 + wide.t2.mul_x_wide());
+		let z1 = z0 + BinaryField128bGhash::reduce(wide.t1 + wide.t2);
+
+		Self::wrap(ghash_sq_from_coords([z0, z1]))
+	}
+}

--- a/crates/field/src/arch/portable/arithmetic/mod.rs
+++ b/crates/field/src/arch/portable/arithmetic/mod.rs
@@ -1,4 +1,5 @@
 // Copyright 2026 The Binius Developers
 
 pub mod ghash;
+pub mod ghash_sq;
 pub mod itoh_tsujii;

--- a/crates/field/src/arch/portable/mod.rs
+++ b/crates/field/src/arch/portable/mod.rs
@@ -22,6 +22,7 @@ pub mod packed_aes_8;
 pub mod packed_ghash_128;
 pub mod packed_ghash_256;
 pub mod packed_ghash_512;
+pub mod packed_ghash_sq_256;
 
 pub(crate) mod univariate_mul_utils_128;
 

--- a/crates/field/src/arch/portable/packed_ghash_sq_256.rs
+++ b/crates/field/src/arch/portable/packed_ghash_sq_256.rs
@@ -1,0 +1,7 @@
+// Copyright 2026 The Binius Developers
+
+//! Portable strategy selection for the `PackedGhashSq1x256b` packing.
+
+/// Widening-multiply wrapper used by the `PackedGhashSq1x256b` packing: the sliced Karatsuba
+/// multiply, which defers the multiply-by-`X` into one of its two GHASH reductions.
+pub type GhashSqWideMul1x<T> = super::arithmetic::ghash_sq::GhashSqSlicedWideMul<T>;

--- a/crates/field/src/arch/x86_64/arithmetic/ghash.rs
+++ b/crates/field/src/arch/x86_64/arithmetic/ghash.rs
@@ -14,8 +14,10 @@ use std::{
 use bytemuck::TransparentWrapper;
 
 use crate::{
-	BinaryField128bGhash as GhashB128, Divisible, WideMul, arch::PackedPrimitiveType,
-	arithmetic_traits::Square, underlier::UnderlierType,
+	BinaryField128bGhash as GhashB128, Divisible, WideMul,
+	arch::PackedPrimitiveType,
+	arithmetic_traits::{MulXWide, Square},
+	underlier::UnderlierType,
 };
 
 /// Trait for underliers that support CLMUL operations which are needed for the
@@ -31,6 +33,13 @@ pub trait ClMulUnderlier: UnderlierType + Divisible<u128> {
 	/// For each 128-bit lane, shifts the lower 64 bits to the upper 64 bits and zeroes the lower
 	/// 64-bit.
 	fn move_64_to_hi(a: Self) -> Self;
+
+	/// For each 64-bit lane, shifts the value left by one bit.
+	fn shl_1_epi64(a: Self) -> Self;
+
+	/// For each 64-bit lane, shifts the value right by 63 bits, leaving the lane's top bit as its
+	/// low bit.
+	fn shr_63_epi64(a: Self) -> Self;
 }
 
 /// The version of the multiplication for optimized suqare operation.
@@ -134,6 +143,32 @@ impl<U: ClMulUnderlier> WideGhashProduct<U> {
 	}
 }
 
+impl<U: ClMulUnderlier> MulXWide for WideGhashProduct<U> {
+	/// Shifts the represented 256-bit polynomial `lo + mid·X^64 + hi·X^128` left by one bit.
+	///
+	/// Each 64-bit lane shifts up by one; the bit leaving the top of a lane belongs 64 bit
+	/// positions higher, which — since consecutive limbs overlap by 64 bits — is the corresponding
+	/// lane of the next limb. `hi` has no limb above it, so its low lane's carry moves to its own
+	/// high lane.
+	///
+	/// Every limb is a carry-less product of 64-bit halves, so it has degree at most 126, and
+	/// XOR-accumulating such products preserves that. Bit 127 of `hi` is therefore clear and
+	/// nothing is shifted out of the top.
+	#[inline]
+	fn mul_x_wide(self) -> Self {
+		let (shl_lo, shl_mid, shl_hi) =
+			(U::shl_1_epi64(self.lo), U::shl_1_epi64(self.mid), U::shl_1_epi64(self.hi));
+		let (carry_lo, carry_mid, carry_hi) =
+			(U::shr_63_epi64(self.lo), U::shr_63_epi64(self.mid), U::shr_63_epi64(self.hi));
+
+		Self {
+			lo: shl_lo,
+			mid: shl_mid ^ carry_lo,
+			hi: shl_hi ^ carry_mid ^ U::move_64_to_hi(carry_hi),
+		}
+	}
+}
+
 impl<U: ClMulUnderlier> Add for WideGhashProduct<U> {
 	type Output = Self;
 
@@ -207,9 +242,40 @@ impl<U: ClMulUnderlier> WideMul for GhashClMulWideMul<PackedPrimitiveType<U, Gha
 
 #[cfg(test)]
 mod tests {
-	use rand::{SeedableRng, rngs::StdRng};
+	use rand::{Rng, SeedableRng, rngs::StdRng};
 
-	use crate::{Random, WideMul, arch::OptimalPackedB128};
+	use super::{ClMulUnderlier, WideGhashProduct};
+	use crate::{Divisible, Random, WideMul, arch::OptimalPackedB128, arithmetic_traits::MulXWide};
+
+	/// Scaling by X commutes with the reduction: scaling the unreduced product matches multiplying
+	/// the reduced product by X (the field element 2) in every 128-bit lane.
+	#[allow(dead_code)]
+	fn check_mul_x_wide<U: ClMulUnderlier>(mut rng: impl Rng) {
+		let x = <U as Divisible<u128>>::broadcast(2);
+
+		for _ in 0..64 {
+			let wide = WideGhashProduct::wide_mul(U::random(&mut rng), U::random(&mut rng));
+
+			assert_eq!(
+				wide.mul_x_wide().reduce(),
+				WideGhashProduct::wide_mul(wide.reduce(), x).reduce()
+			);
+		}
+	}
+
+	// Covers every CLMUL underlier width the target supports, since the `MulXWide` impl is shared
+	// but its per-lane shift is not.
+	#[cfg(target_feature = "pclmulqdq")]
+	#[test]
+	fn mul_x_wide_commutes_with_reduce() {
+		let mut rng = StdRng::seed_from_u64(0);
+
+		check_mul_x_wide::<crate::arch::x86_64::m128::M128>(&mut rng);
+		#[cfg(all(target_feature = "avx2", target_feature = "vpclmulqdq"))]
+		check_mul_x_wide::<crate::arch::x86_64::m256::M256>(&mut rng);
+		#[cfg(all(target_feature = "avx512f", target_feature = "vpclmulqdq"))]
+		check_mul_x_wide::<crate::arch::x86_64::m512::M512>(&mut rng);
+	}
 
 	/// Stress-test accumulation of many widening products. Correctness / linearity for each
 	/// individual packed width is covered by the proptest suite in `packed_ghash.rs`.

--- a/crates/field/src/arch/x86_64/arithmetic/ghash_sq.rs
+++ b/crates/field/src/arch/x86_64/arithmetic/ghash_sq.rs
@@ -1,0 +1,123 @@
+// Copyright 2026 The Binius Developers
+
+//! GHASH² widening multiply for targets with a 256-bit carry-less multiply.
+//!
+//! The two diagonal Karatsuba products `[a·e, b·f]` are batched into a single
+//! [`PackedBinaryGhash2x128b`] widening multiply — one VPCLMUL over both 128-bit lanes — leaving
+//! only the Karatsuba cross product to a scalar widening multiply.
+
+use std::{
+	iter::Sum,
+	ops::{Add, AddAssign, Sub, SubAssign},
+};
+
+use bytemuck::TransparentWrapper;
+
+use crate::{
+	BinaryField128bGhash, Divisible, PackedBinaryGhash2x128b, PackedGhashSq1x256b, WideMul,
+	cast_base, packed_ghash_sq::ghash_sq_from_coords,
+};
+
+/// The two unreduced GHASH products `[a·e, b·f]` batched into one packed widening multiply.
+type DiagWide = <PackedBinaryGhash2x128b as WideMul>::Output;
+/// The single unreduced GHASH cross product `(a+b)·(e+f)` from a scalar widening multiply.
+type CrossWide = <BinaryField128bGhash as WideMul>::Output;
+
+/// The unreduced product of two [`PackedGhashSq1x256b`] elements.
+///
+/// Holds the three GHASH widening products of the Karatsuba decomposition over `Y`, deferring both
+/// the GHASH reductions and the multiply-by-`X` — all `GF(2)`-linear — so an inner product over
+/// GHASH² accumulates these by XOR and reduces only once at the end.
+#[derive(Clone, Copy, Default, Debug)]
+pub struct WideGhashSqProduct {
+	/// Unreduced `[a·e, b·f]`, the diagonal Karatsuba products in their two packed GHASH lanes.
+	diag: DiagWide,
+	/// Unreduced `(a+b)·(e+f)`, the Karatsuba cross product.
+	cross: CrossWide,
+}
+
+impl Add for WideGhashSqProduct {
+	type Output = Self;
+
+	#[inline]
+	fn add(self, rhs: Self) -> Self {
+		Self {
+			diag: self.diag + rhs.diag,
+			cross: self.cross + rhs.cross,
+		}
+	}
+}
+
+impl AddAssign for WideGhashSqProduct {
+	#[inline]
+	fn add_assign(&mut self, rhs: Self) {
+		self.diag += rhs.diag;
+		self.cross += rhs.cross;
+	}
+}
+
+impl Sub for WideGhashSqProduct {
+	type Output = Self;
+
+	#[inline]
+	fn sub(self, rhs: Self) -> Self {
+		Self {
+			diag: self.diag - rhs.diag,
+			cross: self.cross - rhs.cross,
+		}
+	}
+}
+
+impl SubAssign for WideGhashSqProduct {
+	#[inline]
+	fn sub_assign(&mut self, rhs: Self) {
+		self.diag -= rhs.diag;
+		self.cross -= rhs.cross;
+	}
+}
+
+impl Sum for WideGhashSqProduct {
+	#[inline]
+	fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+		iter.fold(Self::default(), |acc, x| acc + x)
+	}
+}
+
+/// [`WideMul`] strategy for [`PackedGhashSq1x256b`] batching the Karatsuba diagonal into a single
+/// two-lane packed GHASH widening multiply.
+#[repr(transparent)]
+#[derive(TransparentWrapper)]
+pub struct GhashSqHybridWideMul<T>(T);
+
+impl WideMul for GhashSqHybridWideMul<PackedGhashSq1x256b> {
+	type Output = WideGhashSqProduct;
+
+	#[inline]
+	fn wide_mul(a: Self, b: Self) -> Self::Output {
+		// The GHASH² coordinates already sit in the two 128-bit lanes of the 256-bit value, so
+		// viewing an operand as a packed GHASH pair is a free reinterpretation.
+		let a = cast_base::<BinaryField128bGhash, _>(Self::peel(a));
+		let b = cast_base::<BinaryField128bGhash, _>(Self::peel(b));
+
+		WideGhashSqProduct {
+			// Diagonal `[a·e, b·f]` as one two-lane packed widening multiply.
+			diag: PackedBinaryGhash2x128b::wide_mul(a, b),
+			// Karatsuba cross product `(a+b)·(e+f)` as a scalar widening multiply.
+			cross: BinaryField128bGhash::wide_mul(a.get(0) + a.get(1), b.get(0) + b.get(1)),
+		}
+	}
+
+	#[inline]
+	fn reduce(wide: Self::Output) -> Self {
+		// Reduce the batched diagonal back to `t_0 = a·e`, `t_2 = b·f`, and the cross to `t_1`.
+		let diag = PackedBinaryGhash2x128b::reduce(wide.diag);
+		let t0 = diag.get(0);
+		let t2 = diag.get(1);
+		let t1 = BinaryField128bGhash::reduce(wide.cross);
+
+		// Fold `Y² = X·Y + X`, recovering the cross term as `t_1 + t_0 + t_2`:
+		// `z_0 = t_0 + X·t_2`, `z_1 = (t_1 + t_0 + t_2) + X·t_2 = z_0 + t_1 + t_2`.
+		let z0 = t0 + t2.mul_x();
+		Self::wrap(ghash_sq_from_coords([z0, z0 + t1 + t2]))
+	}
+}

--- a/crates/field/src/arch/x86_64/arithmetic/mod.rs
+++ b/crates/field/src/arch/x86_64/arithmetic/mod.rs
@@ -1,3 +1,7 @@
 // Copyright 2026 The Binius Developers
 
 pub mod ghash;
+// The GHASH² strategy here is only selected where a 256-bit carry-less multiply exists;
+// otherwise the portable sliced strategy is used.
+#[cfg(all(target_feature = "vpclmulqdq", target_feature = "avx2"))]
+pub mod ghash_sq;

--- a/crates/field/src/arch/x86_64/mod.rs
+++ b/crates/field/src/arch/x86_64/mod.rs
@@ -3,6 +3,7 @@
 use cfg_if::cfg_if;
 
 pub mod arithmetic;
+pub mod packed_ghash_sq_256;
 
 #[cfg(target_feature = "gfni")]
 mod gfni;

--- a/crates/field/src/arch/x86_64/packed_ghash_128.rs
+++ b/crates/field/src/arch/x86_64/packed_ghash_128.rs
@@ -76,4 +76,14 @@ impl ghash::ClMulUnderlier for M128 {
 	fn move_64_to_hi(a: Self) -> Self {
 		unsafe { std::arch::x86_64::_mm_slli_si128::<8>(a.into()) }.into()
 	}
+
+	#[inline]
+	fn shl_1_epi64(a: Self) -> Self {
+		unsafe { std::arch::x86_64::_mm_slli_epi64::<1>(a.into()) }.into()
+	}
+
+	#[inline]
+	fn shr_63_epi64(a: Self) -> Self {
+		unsafe { std::arch::x86_64::_mm_srli_epi64::<63>(a.into()) }.into()
+	}
 }

--- a/crates/field/src/arch/x86_64/packed_ghash_256.rs
+++ b/crates/field/src/arch/x86_64/packed_ghash_256.rs
@@ -48,5 +48,15 @@ mod vpclmulqdq {
 		fn move_64_to_hi(a: Self) -> Self {
 			unsafe { std::arch::x86_64::_mm256_slli_si256::<8>(a.into()) }.into()
 		}
+
+		#[inline]
+		fn shl_1_epi64(a: Self) -> Self {
+			unsafe { std::arch::x86_64::_mm256_slli_epi64::<1>(a.into()) }.into()
+		}
+
+		#[inline]
+		fn shr_63_epi64(a: Self) -> Self {
+			unsafe { std::arch::x86_64::_mm256_srli_epi64::<63>(a.into()) }.into()
+		}
 	}
 }

--- a/crates/field/src/arch/x86_64/packed_ghash_512.rs
+++ b/crates/field/src/arch/x86_64/packed_ghash_512.rs
@@ -55,4 +55,14 @@ impl ghash::ClMulUnderlier for M512 {
 		}
 		.into()
 	}
+
+	#[inline]
+	fn shl_1_epi64(a: Self) -> Self {
+		unsafe { std::arch::x86_64::_mm512_slli_epi64::<1>(a.into()) }.into()
+	}
+
+	#[inline]
+	fn shr_63_epi64(a: Self) -> Self {
+		unsafe { std::arch::x86_64::_mm512_srli_epi64::<63>(a.into()) }.into()
+	}
 }

--- a/crates/field/src/arch/x86_64/packed_ghash_sq_256.rs
+++ b/crates/field/src/arch/x86_64/packed_ghash_sq_256.rs
@@ -1,0 +1,15 @@
+// Copyright 2026 The Binius Developers
+
+//! x86_64 strategy selection for the `PackedGhashSq1x256b` packing.
+
+/// Widening-multiply wrapper used by the `PackedGhashSq1x256b` packing: batch the Karatsuba
+/// diagonal into a single 256-bit carry-less multiply when VPCLMULQDQ is available, otherwise the
+/// sliced Karatsuba multiply, which trades that batching for one fewer GHASH reduction.
+///
+/// AVX2 is part of the condition because without it `PackedBinaryGhash2x128b` is backed by the
+/// scaled `M256`, whose widening multiply is two independent 128-bit multiplies — exactly what the
+/// batching is meant to avoid.
+#[cfg(all(target_feature = "vpclmulqdq", target_feature = "avx2"))]
+pub type GhashSqWideMul1x<T> = super::arithmetic::ghash_sq::GhashSqHybridWideMul<T>;
+#[cfg(not(all(target_feature = "vpclmulqdq", target_feature = "avx2")))]
+pub type GhashSqWideMul1x<T> = crate::arch::portable::arithmetic::ghash_sq::GhashSqSlicedWideMul<T>;

--- a/crates/field/src/arithmetic_traits.rs
+++ b/crates/field/src/arithmetic_traits.rs
@@ -39,6 +39,18 @@ pub trait WideMul: Sized {
 	fn reduce(wide: Self::Output) -> Self;
 }
 
+/// An unreduced widening product (a [`WideMul::Output`]) that can be scaled by the field element
+/// `X` while still unreduced.
+///
+/// Scaling by `X` and the modular reduction are both `GF(2)`-linear, and they commute:
+/// `reduce(wide.mul_x_wide()) == reduce(wide).mul_x()`. Doing the scaling on the unreduced product
+/// lets an extension-field multiply fold the `X` of its irreducible polynomial into a product it is
+/// going to reduce anyway, saving a reduction over scaling the reduced coordinate.
+pub trait MulXWide {
+	/// Returns the unreduced product scaled by `X`.
+	fn mul_x_wide(self) -> Self;
+}
+
 /// Value that can be inverted
 pub trait InvertOrZero {
 	/// Returns the inverted value or zero in case when `self` is zero

--- a/crates/field/src/packed_ghash_sq.rs
+++ b/crates/field/src/packed_ghash_sq.rs
@@ -19,6 +19,10 @@
 //!
 //! In both, the coordinate register is a [`PackedPrimitiveType`], so the multiply-by-`X` in the
 //! reduction is a per-lane bit shift ([`ghash_mul_x`]) rather than a full field multiply.
+//!
+//! The width-one packing's widening multiply is architecture-specific — see [`GhashSqWideMul1x`],
+//! which selects between batching the Karatsuba diagonal into one 256-bit carry-less multiply and
+//! keeping the three products separate to defer the multiply-by-`X` past a reduction.
 
 use std::{
 	iter::Sum,
@@ -30,7 +34,7 @@ use bytemuck::TransparentWrapper;
 use crate::{
 	BinaryField128bGhash, Divisible, GhashSq256b, PackedBinaryGhash2x128b, PackedField, WideMul,
 	arch::{
-		Divide, M128, M256, M512, MulFromWideMul, PackedPrimitiveType,
+		Divide, GhashSqWideMul1x, M128, M256, M512, MulFromWideMul, PackedPrimitiveType,
 		portable::packed_macros::{portable_macros::*, *},
 	},
 	arithmetic_traits::{InvertOrZero, Square},
@@ -75,19 +79,20 @@ fn mul_x<U: UnderlierType + Divisible<M128>>(coord: Ghash<U>) -> Ghash<U> {
 	Ghash::<U>::from_underlier(ghash_mul_x(coord.to_underlier()))
 }
 
-/// The unreduced product of two GHASH² elements in sliced form.
+/// The unreduced product of two GHASH² elements, as three separate GHASH products.
 ///
 /// Holds the three Karatsuba GHASH widening products, deferring both the GHASH reductions and the
 /// multiply-by-`X`. Since those are all `GF(2)`-linear, an inner product over GHASH² accumulates
-/// these by XOR and reduces once at the end.
+/// these by XOR and reduces once at the end. Used both by the sliced packings and — where there is
+/// no wider carry-less multiply to batch the diagonal into — by the interleaved width-one packing.
 #[derive(Clone, Copy, Debug, Default)]
 pub struct SlicedGhashSqWide<W> {
 	/// Unreduced `a·e`, the low diagonal Karatsuba product.
-	t0: W,
+	pub(crate) t0: W,
 	/// Unreduced `b·f`, the high diagonal Karatsuba product.
-	t2: W,
+	pub(crate) t2: W,
 	/// Unreduced `(a+b)·(e+f)`, the Karatsuba cross product.
-	t1: W,
+	pub(crate) t1: W,
 }
 
 impl<W: Add<Output = W>> Add for SlicedGhashSqWide<W> {
@@ -221,111 +226,25 @@ where
 // scalar `GhashSq256b`. The width-one M256 packing carries the field arithmetic (the scalar field
 // derives its own `Mul`/`Square`/`InvertOrZero`/`WideMul` from it via `binary_field!`); the
 // width-two M512 packing divides into two independent M256 lanes.
+//
+// The width-one `WideMul` itself is architecture-specific and lives with the other per-target
+// strategies under `arch`, reached here through the `GhashSqWideMul1x` alias.
 // ---------------------------------------------------------------------------
 
-/// The two unreduced GHASH products `[a·e, b·f]` batched into one packed widening multiply.
-type DiagWide = <PackedBinaryGhash2x128b as WideMul>::Output;
-/// The single unreduced GHASH cross product `(a+b)·(e+f)` from a scalar widening multiply.
-type CrossWide = <BinaryField128bGhash as WideMul>::Output;
-
-/// The unreduced product of two [`PackedGhashSq1x256b`] elements.
+/// The GHASH coordinates `[a, b]` of a width-one GHASH² element `a + b·Y`.
 ///
-/// Holds the three GHASH widening products of the Karatsuba decomposition over `Y`, deferring both
-/// the GHASH reductions and the multiply-by-`X` — all `GF(2)`-linear — so an inner product over
-/// GHASH² accumulates these by XOR and reduces only once at the end.
-#[derive(Clone, Copy, Default, Debug)]
-pub struct WideGhashSqProduct {
-	/// Unreduced `[a·e, b·f]`, the diagonal Karatsuba products in their two packed GHASH lanes.
-	diag: DiagWide,
-	/// Unreduced `(a+b)·(e+f)`, the Karatsuba cross product.
-	cross: CrossWide,
+/// The coordinates already sit in the two 128-bit lanes of the 256-bit value, so this is a free
+/// reinterpretation followed by two lane reads.
+#[inline]
+pub(crate) fn ghash_sq_coords(elem: PackedGhashSq1x256b) -> [BinaryField128bGhash; 2] {
+	let coords = cast_base::<BinaryField128bGhash, _>(elem);
+	[coords.get(0), coords.get(1)]
 }
 
-impl Add for WideGhashSqProduct {
-	type Output = Self;
-
-	#[inline]
-	fn add(self, rhs: Self) -> Self {
-		Self {
-			diag: self.diag + rhs.diag,
-			cross: self.cross + rhs.cross,
-		}
-	}
-}
-
-impl AddAssign for WideGhashSqProduct {
-	#[inline]
-	fn add_assign(&mut self, rhs: Self) {
-		self.diag += rhs.diag;
-		self.cross += rhs.cross;
-	}
-}
-
-impl Sub for WideGhashSqProduct {
-	type Output = Self;
-
-	#[inline]
-	fn sub(self, rhs: Self) -> Self {
-		Self {
-			diag: self.diag - rhs.diag,
-			cross: self.cross - rhs.cross,
-		}
-	}
-}
-
-impl SubAssign for WideGhashSqProduct {
-	#[inline]
-	fn sub_assign(&mut self, rhs: Self) {
-		self.diag -= rhs.diag;
-		self.cross -= rhs.cross;
-	}
-}
-
-impl Sum for WideGhashSqProduct {
-	#[inline]
-	fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
-		iter.fold(Self::default(), |acc, x| acc + x)
-	}
-}
-
-/// [`WideMul`] strategy for [`PackedGhashSq1x256b`]: the `mul_m256i_hybrid` algorithm.
-#[repr(transparent)]
-#[derive(TransparentWrapper)]
-pub struct GhashSqWideMul<T>(T);
-
-impl WideMul for GhashSqWideMul<PackedGhashSq1x256b> {
-	type Output = WideGhashSqProduct;
-
-	#[inline]
-	fn wide_mul(a: Self, b: Self) -> Self::Output {
-		let a = cast_base::<BinaryField128bGhash, _>(Self::peel(a));
-		let b = cast_base::<BinaryField128bGhash, _>(Self::peel(b));
-
-		// Diagonal `[a·e, b·f]` as one two-lane packed widening multiply — a single 256-bit
-		// VPCLMUL on AVX2, two 128-bit PMULL on aarch64 via the scaled `M256`.
-		let diag = PackedBinaryGhash2x128b::wide_mul(a, b);
-		// Karatsuba cross product `(a+b)·(e+f)` as a scalar widening multiply.
-		let cross = BinaryField128bGhash::wide_mul(a.get(0) + a.get(1), b.get(0) + b.get(1));
-
-		WideGhashSqProduct { diag, cross }
-	}
-
-	#[inline]
-	fn reduce(wide: Self::Output) -> Self {
-		// Reduce the batched diagonal back to `t_0 = a·e`, `t_2 = b·f`, and the cross to `t_1`.
-		let diag = PackedBinaryGhash2x128b::reduce(wide.diag);
-		let t0 = diag.get(0);
-		let t2 = diag.get(1);
-		let t1 = BinaryField128bGhash::reduce(wide.cross);
-
-		// Fold `Y² = X·Y + X`, recovering the cross term as `t_1 + t_0 + t_2`:
-		// `z_0 = t_0 + X·t_2`, `z_1 = (t_1 + t_0 + t_2) + X·t_2 = z_0 + t_1 + t_2`.
-		let z0 = t0 + t2.mul_x();
-		Self::wrap(cast_ext::<BinaryField128bGhash, _>(PackedBinaryGhash2x128b::from_scalars([
-			z0,
-			z0 + t1 + t2,
-		])))
-	}
+/// Assembles a width-one GHASH² element `a + b·Y` from its GHASH coordinates `[a, b]`.
+#[inline]
+pub(crate) fn ghash_sq_from_coords(coords: [BinaryField128bGhash; 2]) -> PackedGhashSq1x256b {
+	cast_ext::<BinaryField128bGhash, _>(PackedBinaryGhash2x128b::from_scalars(coords))
 }
 
 /// [`Square`] strategy for [`PackedGhashSq1x256b`].
@@ -340,10 +259,7 @@ impl Square for GhashSqSquare<PackedGhashSq1x256b> {
 		let sq = Square::square(cast_base::<BinaryField128bGhash, _>(Self::peel(self)));
 
 		let x_t2 = sq.get(1).mul_x();
-		Self::wrap(cast_ext::<BinaryField128bGhash, _>(PackedBinaryGhash2x128b::from_scalars([
-			sq.get(0) + x_t2,
-			x_t2,
-		])))
+		Self::wrap(ghash_sq_from_coords([sq.get(0) + x_t2, x_t2]))
 	}
 }
 
@@ -357,17 +273,12 @@ impl InvertOrZero for GhashSqInvert<PackedGhashSq1x256b> {
 	/// to `X` and multiply to `X`), norm `N = a² + X·b·(a + b)`, and `u⁻¹ = ū·N⁻¹`.
 	#[inline]
 	fn invert_or_zero(self) -> Self {
-		let coords = cast_base::<BinaryField128bGhash, _>(Self::peel(self));
-		let a = coords.get(0);
-		let b = coords.get(1);
+		let [a, b] = ghash_sq_coords(Self::peel(self));
 
 		let norm = Square::square(a) + (a * b + Square::square(b)).mul_x();
 		let norm_inv = norm.invert_or_zero();
 
-		Self::wrap(cast_ext::<BinaryField128bGhash, _>(PackedBinaryGhash2x128b::from_scalars([
-			(a + b.mul_x()) * norm_inv,
-			b * norm_inv,
-		])))
+		Self::wrap(ghash_sq_from_coords([(a + b.mul_x()) * norm_inv, b * norm_inv]))
 	}
 }
 
@@ -381,7 +292,7 @@ define_packed_binary_field!(
 	(MulFromWideMul),
 	(GhashSqSquare),
 	(GhashSqInvert),
-	(GhashSqWideMul)
+	(GhashSqWideMul1x)
 );
 
 define_packed_binary_field!(


### PR DESCRIPTION
Closes [BINIUS-338](https://linear.app/jimpo/issue/BINIUS-338/special-arithmetic-for-packed-ghash2-on-aarch64-and-portable).

#1896 gave `PackedGhashSq1x256b` a single widening-multiply strategy: batch the two diagonal
Karatsuba products `[a·e, b·f]` into one `PackedBinaryGhash2x128b` widening multiply, then scale the
reduced `t₂` by `X`. That batching is a single instruction only where a 256-bit carry-less multiply
exists. Everywhere else the packed multiply decomposes back into two independent 128-bit multiplies,
each with its own reduction, so the batching buys nothing and the multiply costs three GHASH
reductions instead of two.

### Two strategies, selected per architecture

Following the `GhashWideMul1x/2x/4x` pattern, `arch` now picks the width-one GHASH² `WideMul`
through a `GhashSqWideMul1x` alias:

- **`GhashSqHybridWideMul`** (`arch/x86_64/arithmetic/ghash_sq.rs`) — the existing `mul_m256i_hybrid`
  algorithm, moved unchanged. Selected under VPCLMULQDQ + AVX2. (AVX2 is part of the condition
  because without it `PackedBinaryGhash2x128b` is backed by the scaled `M256`, whose widening
  multiply is two independent 128-bit multiplies — exactly what the batching is meant to avoid.)
- **`GhashSqSlicedWideMul`** (`arch/portable/arithmetic/ghash_sq.rs`) — the `mul_sliced` algorithm
  from `binius-arith-bench`: keep the three Karatsuba products separate and scale `t₂` by `X` while
  it is still *unreduced*, folding the multiply-by-`X` into a reduction that has to happen anyway.
  Two GHASH reductions per GHASH² product rather than three. Selected on aarch64, portable, wasm32
  and the remaining x86_64 configurations.

Both reuse `SlicedGhashSqWide` / the packing's coordinate helpers, so the GHASH²-specific algebra is
stated once.

### `MulXWide`

Scaling an unreduced product is a new trait in `arithmetic_traits`, implemented for the portable,
aarch64 and x86_64 `WideGhashProduct`s (the x86 one via a new `ClMulUnderlier::shift_left_1` for
M128/M256/M512). Each backend carries a proptest that `reduce(w.mul_x_wide())` equals
`reduce(w) · X`. The shift is exact because every limb is a carry-less product of 64-bit halves, so
its top bit is clear and XOR-accumulation preserves that.

### Benchmarks

Measured with `binius-arith-bench`'s multiply harness (16-element batch, 64 passes) on Neoverse V3,
so the numbers are directly comparable to that crate's:

| | before | after |
|---|---|---|
| aarch64, `-Ctarget-cpu=native` | 194.9 Melem/s | **210.2 Melem/s** (+7.9 %) |
| portable | 13.99 Melem/s | **14.32 Melem/s** (+2.4 %) |

For reference `binius-arith-bench`'s `ghash_sq::aarch64::mul_sliced` measures 228.8 Melem/s. The
remaining gap is not algorithmic: both compile to the same 16 PMULLs (12 for the three coordinate
products, 4 for two reductions) with the same XOR/shift mix, and the base GHASH multiply is
instruction-identical between the crates (18 instructions, 6 PMULLs). `binius-field`'s GHASH² body
is 59 instructions to arith-bench's 56 — one extra `dup` and two extra `ext`, from LLVM lowering one
reduction's `pmull2`-by-poly through a rotate/64-bit-eor sequence instead of `ext` + `pmull2`.
Holding `0x87` in the high lane so `PMULL2` reads it in place (as arith-bench does) changed neither
the instruction count nor the throughput, so that experiment is not included here.

Note that the pre-existing `ghash_widening` bench `black_box`es each 32-byte operand per multiply and
reports the opposite ordering for these two strategies; the harness above is the one to trust for
multiply cost.

### Testing

Both packings run through the existing lane-by-lane-vs-scalar suite, plus the new `MulXWide`
proptests. Green on aarch64 native + portable (tests, clippy `-D warnings`, rustdoc, nightly fmt),
`cargo check` cross-compiled for x86_64 across five target-feature combinations (baseline, PCLMUL,
VPCLMUL-without-AVX2, AVX2+VPCLMUL, AVX-512), and the wasm32 build. (`wasm32 + simd128` fails
identically on `main` — pre-existing, untouched here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
