### PR TITLE
BINIUS-339: fold the packed AES reduction with nibble tables instead of carryless multiplies

### DIFF
--- a/crates/field/src/arch/aarch64/simd_arithmetic.rs
+++ b/crates/field/src/arch/aarch64/simd_arithmetic.rs
@@ -148,42 +148,72 @@ pub fn packed_aes_16x8b_wide_mul(a: M128, b: M128) -> WideAes16x8bProduct {
 }
 
 /// Reduces an accumulated [`WideAes16x8bProduct`] back to the packed GF(2^8) bytes.
+///
+/// # Overview
+///
+/// Each 16-bit lane holds a carryless product, or an XOR-accumulation of such products.
+/// The low byte carries degrees 0..7 and passes through unchanged.
+/// The high byte carries degrees 8..15 and folds down mod p(x) = x^8 + x^4 + x^3 + x + 1.
+///
+/// # Nibble tables
+///
+/// The fold is F_2-linear in the high byte's 8 bits.
+/// Splitting the byte into two 4-bit nibbles turns the fold into two 16-entry lookups:
+///
+/// ```text
+///     RED_LO[b3 b2 b1 b0] = b0*(x^8  mod p) + b1*(x^9  mod p) + b2*(x^10 mod p) + b3*(x^11 mod p)
+///     RED_HI[b3 b2 b1 b0] = b0*(x^12 mod p) + b1*(x^13 mod p) + b2*(x^14 mod p) + b3*(x^15 mod p)
+/// ```
+///
+/// Two byte-shuffle lookups replace a two-stage Barrett fold of four carryless multiplies.
+/// M-series cores issue four byte shuffles per cycle but only two carryless multiplies.
+/// The packed squaring above reduces its high nibble through the same table scheme.
 #[inline]
 pub fn packed_aes_16x8b_reduce(wide: WideAes16x8bProduct) -> M128 {
-	// Reduces the 16-bit output of a carryless multiplication to 8 bits using equation 22 in
-	// https://www.intel.com/content/dam/develop/external/us/en/documents/clmul-wp-rev-2-02-2014-04-20.pdf
 	unsafe {
 		let WideAes16x8bProduct { c0, c1 } = wide;
 
-		// Deinterleave the 16 per-byte carryless products into their low bytes (`lo`) and high
-		// bytes (`hi`, the part above `x^7` that the reduction folds back down).
-		let c0 = vreinterpretq_p8_p16(c0);
-		let c1 = vreinterpretq_p8_p16(c1);
+		// Deinterleave the 16 per-byte products into their low and high bytes.
+		//
+		//     c0 bytes: [ l0 h0 l1 h1 ... l7  h7  ]
+		//     c1 bytes: [ l8 h8 l9 h9 ... l15 h15 ]
+		//     cl      = [ l0 l1 ... l15 ]  (degrees 0..7, kept)
+		//     ch      = [ h0 h1 ... h15 ]  (degrees 8..15, folded below)
+		let c0 = vreinterpretq_u8_p16(c0);
+		let c1 = vreinterpretq_u8_p16(c1);
 
-		let cl = vuzp1q_p8(c0, c1);
-		let ch = vuzp2q_p8(c0, c1);
+		let cl = vuzp1q_u8(c0, c1);
+		let ch = vuzp2q_u8(c0, c1);
 
-		// Since q+(x) doesn't fit into 8 bits, we right shift the polynomial (divide by x) and
-		// correct for this later. This works because q+(x) is divisible by x/the last polynomial
-		// bit is 0. q+(x)/x = (x^8 + x^4 + x^3 + x)/x = 0b100011010 >> 1 = 0b10001101 = 0x8d
-		const QPLUS_RSH1: poly8x8_t = unsafe { std::mem::transmute(0x8d8d8d8d8d8d8d8d_u64) };
+		// Reductions of x^8, x^9, x^10, x^11 mod p(x): 0x1B, 0x36, 0x6C, 0xD8.
+		// Entry n is the XOR of the values selected by n's set bits.
+		let red_lo = vld1q_u8(
+			[
+				0x00, 0x1B, 0x36, 0x2D, 0x6C, 0x77, 0x5A, 0x41, 0xD8, 0xC3, 0xEE, 0xF5, 0xB4, 0xAF,
+				0x82, 0x99,
+			]
+			.as_ptr(),
+		);
 
-		// q*(x) = x^4 + x^3 + x + 1 = 0b00011011 = 0x1b
-		const QSTAR: poly8x8_t = unsafe { std::mem::transmute(0x1b1b1b1b1b1b1b1b_u64) };
+		// Reductions of x^12, x^13, x^14, x^15 mod p(x): 0xAB, 0x4D, 0x9A, 0x2F.
+		// Entry n is the XOR of the values selected by n's set bits.
+		let red_hi = vld1q_u8(
+			[
+				0x00, 0xAB, 0x4D, 0xE6, 0x9A, 0x31, 0xD7, 0x7C, 0x2F, 0x84, 0x62, 0xC9, 0xB5, 0x1E,
+				0xF8, 0x53,
+			]
+			.as_ptr(),
+		);
 
-		let tmp0 = vmull_p8(vget_low_p8(ch), QPLUS_RSH1);
-		let tmp1 = vmull_p8(vget_high_p8(ch), QPLUS_RSH1);
+		// Split each high byte into its two table indices.
+		let lo_nibble = vandq_u8(ch, vdupq_n_u8(0x0F));
+		let hi_nibble = vshrq_n_u8(ch, 4);
 
-		// Correct for q+(x) having been divided by x
-		let tmp0 = vreinterpretq_p8_u16(vshlq_n_u16(vreinterpretq_u16_p16(tmp0), 1));
-		let tmp1 = vreinterpretq_p8_u16(vshlq_n_u16(vreinterpretq_u16_p16(tmp1), 1));
+		// Fold the whole high byte below x^8: one lookup per nibble, XOR-combined.
+		let folded = veorq_u8(vqtbl1q_u8(red_lo, lo_nibble), vqtbl1q_u8(red_hi, hi_nibble));
 
-		let tmp_hi = vuzp2q_p8(tmp0, tmp1);
-		let tmp0 = vreinterpretq_p8_p16(vmull_p8(vget_low_p8(tmp_hi), QSTAR));
-		let tmp1 = vreinterpretq_p8_p16(vmull_p8(vget_high_p8(tmp_hi), QSTAR));
-		let tmp_lo = vuzp1q_p8(tmp0, tmp1);
-
-		vreinterpretq_p128_p8(vaddq_p8(cl, tmp_lo)).into()
+		// Reduced lane = low byte + folded high byte.
+		vreinterpretq_p128_u8(veorq_u8(cl, folded)).into()
 	}
 }
 

--- a/crates/field/src/packed_aes.rs
+++ b/crates/field/src/packed_aes.rs
@@ -161,9 +161,117 @@ mod test_utils {
 		};
 	}
 
+	/// Test the widening multiply against the plain multiply for all AES packings.
+	macro_rules! define_wide_mul_tests {
+		() => {
+			fn check_widening_correctness<P>(a: P::Underlier, b: P::Underlier)
+			where
+				P: $crate::PackedField<Scalar = $crate::AESTowerField8b>
+					+ $crate::WideMul
+					+ $crate::underlier::WithUnderlier,
+			{
+				let a = P::from_underlier(a);
+				let b = P::from_underlier(b);
+				// One deferred product, reduced immediately, must equal the plain multiply.
+				let wide = P::wide_mul(a, b);
+				let reduced = P::reduce(wide);
+				assert_eq!(reduced, a * b);
+			}
+
+			fn check_widening_linearity<P>(
+				a1: P::Underlier,
+				b1: P::Underlier,
+				a2: P::Underlier,
+				b2: P::Underlier,
+			) where
+				P: $crate::PackedField<Scalar = $crate::AESTowerField8b>
+					+ $crate::WideMul
+					+ $crate::underlier::WithUnderlier,
+			{
+				let (a1, b1) = (P::from_underlier(a1), P::from_underlier(b1));
+				let (a2, b2) = (P::from_underlier(a2), P::from_underlier(b2));
+				// Accumulated products reduce once at the end.
+				// The sum reaches wide values no single product produces, so this covers the
+				// reduction's full accumulated domain, not just fresh products.
+				let sum_reduced = P::reduce(P::wide_mul(a1, b1) + P::wide_mul(a2, b2));
+				assert_eq!(sum_reduced, a1 * b1 + a2 * b2);
+			}
+
+			proptest! {
+				#[test]
+				fn test_wide_mul_correctness_8(a in any::<u8>(), b in any::<u8>()) {
+					check_widening_correctness::<$crate::PackedAESBinaryField1x8b>(a, b);
+				}
+
+				#[test]
+				fn test_wide_mul_correctness_128(a in any::<u128>(), b in any::<u128>()) {
+					check_widening_correctness::<$crate::PackedAESBinaryField16x8b>(
+						a.into(),
+						b.into(),
+					);
+				}
+
+				#[test]
+				fn test_wide_mul_correctness_256(a in any::<[u128; 2]>(), b in any::<[u128; 2]>()) {
+					check_widening_correctness::<$crate::PackedAESBinaryField32x8b>(
+						a.into(),
+						b.into(),
+					);
+				}
+
+				#[test]
+				fn test_wide_mul_correctness_512(a in any::<[u128; 4]>(), b in any::<[u128; 4]>()) {
+					check_widening_correctness::<$crate::PackedAESBinaryField64x8b>(
+						a.into(),
+						b.into(),
+					);
+				}
+
+				#[test]
+				fn test_wide_mul_linearity_8(
+					a1 in any::<u8>(), b1 in any::<u8>(),
+					a2 in any::<u8>(), b2 in any::<u8>(),
+				) {
+					check_widening_linearity::<$crate::PackedAESBinaryField1x8b>(a1, b1, a2, b2);
+				}
+
+				#[test]
+				fn test_wide_mul_linearity_128(
+					a1 in any::<u128>(), b1 in any::<u128>(),
+					a2 in any::<u128>(), b2 in any::<u128>(),
+				) {
+					check_widening_linearity::<$crate::PackedAESBinaryField16x8b>(
+						a1.into(), b1.into(), a2.into(), b2.into(),
+					);
+				}
+
+				#[test]
+				fn test_wide_mul_linearity_256(
+					a1 in any::<[u128; 2]>(), b1 in any::<[u128; 2]>(),
+					a2 in any::<[u128; 2]>(), b2 in any::<[u128; 2]>(),
+				) {
+					check_widening_linearity::<$crate::PackedAESBinaryField32x8b>(
+						a1.into(), b1.into(), a2.into(), b2.into(),
+					);
+				}
+
+				#[test]
+				fn test_wide_mul_linearity_512(
+					a1 in any::<[u128; 4]>(), b1 in any::<[u128; 4]>(),
+					a2 in any::<[u128; 4]>(), b2 in any::<[u128; 4]>(),
+				) {
+					check_widening_linearity::<$crate::PackedAESBinaryField64x8b>(
+						a1.into(), b1.into(), a2.into(), b2.into(),
+					);
+				}
+			}
+		};
+	}
+
 	pub(crate) use define_invert_tests;
 	pub(crate) use define_multiply_tests;
 	pub(crate) use define_square_tests;
+	pub(crate) use define_wide_mul_tests;
 }
 
 #[cfg(test)]
@@ -172,9 +280,11 @@ mod tests {
 
 	use proptest::prelude::*;
 
-	use super::test_utils::{define_invert_tests, define_multiply_tests, define_square_tests};
+	use super::test_utils::{
+		define_invert_tests, define_multiply_tests, define_square_tests, define_wide_mul_tests,
+	};
 	use crate::{
-		PackedField,
+		PackedField, WideMul,
 		arithmetic_traits::{InvertOrZero, Square},
 	};
 
@@ -183,4 +293,36 @@ mod tests {
 	define_square_tests!(Square::square, PackedField);
 
 	define_invert_tests!(InvertOrZero::invert_or_zero, PackedField);
+
+	define_wide_mul_tests!();
+
+	#[test]
+	fn test_wide_mul_exhaustive_scalar_pairs() {
+		// The scalar field has only 2^8 elements, so every product admits an exhaustive check.
+		// Each byte pair is broadcast across the 128-bit packing and multiplied deferred.
+		//
+		//     reduce(wide_mul(a, b)) must equal the scalar product in every lane.
+		//
+		// The scalar multiply is an independent oracle: it runs the tower-field log/exp tables,
+		// not the packed widening path under test.
+		for a in 0..=u8::MAX {
+			for b in 0..=u8::MAX {
+				let expected = crate::AESTowerField8b::new(a) * crate::AESTowerField8b::new(b);
+
+				let a_packed =
+					crate::PackedAESBinaryField16x8b::broadcast(crate::AESTowerField8b::new(a));
+				let b_packed =
+					crate::PackedAESBinaryField16x8b::broadcast(crate::AESTowerField8b::new(b));
+				let reduced = crate::PackedAESBinaryField16x8b::reduce(
+					crate::PackedAESBinaryField16x8b::wide_mul(a_packed, b_packed),
+				);
+
+				assert_eq!(
+					reduced,
+					crate::PackedAESBinaryField16x8b::broadcast(expected),
+					"a={a:#04x} b={b:#04x}"
+				);
+			}
+		}
+	}
 }


### PR DESCRIPTION
Closes [BINIUS-339](https://linear.app/jimpo/issue/BINIUS-339).

Folds the packed AES high bytes with two nibble-table lookups instead of four carryless multiplies.
Output is byte-identical — no protocol change, transcript-identical proofs.

### The problem

The AND-reduction round message accumulates unreduced $\mathbb{F}_{2^8}$ products with the 512-bit AES packing and folds them back to field elements once per row.
On aarch64 that fold is a two-stage Barrett reduction: four `vmull_p8` carryless multiplies, plus two shifts and two extra deinterleaves.
M-series cores issue only two carryless multiplies per cycle but four byte shuffles — the fold sits on the scarcer execution ports.

### The idea

Each 16-bit product lane splits into a low byte (degrees 0..7, kept as-is) and a high byte (degrees 8..15, folded down mod $p(x) = x^8 + x^4 + x^3 + x + 1$).
The fold is $\mathbb{F}_2$-linear in the high byte's 8 bits.
Split the byte into two nibbles and the whole fold becomes two 16-entry table lookups:

```
RED_LO[b3 b2 b1 b0] = b0*(x^8  mod p) + b1*(x^9  mod p) + b2*(x^10 mod p) + b3*(x^11 mod p)
RED_HI[b3 b2 b1 b0] = b0*(x^12 mod p) + b1*(x^13 mod p) + b2*(x^14 mod p) + b3*(x^15 mod p)
```

The packed squaring in the same file already reduces its high nibble exactly this way — the trick is proven in-repo.

### Per reduction

- **before:** 4 `vmull_p8` + 2 shifts + 4 deinterleaves
- **after:** 2 `vqtbl1q_u8` + 1 AND + 1 shift + 2 deinterleaves

### The change

```diff
 // fold ch (the high bytes) down mod p(x), then XOR into cl (the low bytes)
-tmp    = (vmull_p8(ch, QPLUS_RSH1) << 1)          // 2x vmull_p8
-folded = vmull_p8(tmp.high_bytes, QSTAR).low_bytes // 2x vmull_p8
+folded = TBL(RED_LO, ch & 0x0F) ^ TBL(RED_HI, ch >> 4)  // 2x vqtbl1q_u8
 result = cl ^ folded
```

### Soundness

The tables encode the same polynomial reduction, so the output is byte-identical and the transcript is unchanged.
Pinned by tests through the public widening-multiply surface:
- an exhaustive sweep of all 256×256 scalar products against the scalar log/exp oracle (an independent code path);
- widening correctness and linearity proptests over all four AES packings, mirroring the existing GHASH widening tests — linearity covers accumulated wide values that no single product produces.

### Scope

- **changed:** the aarch64 packed AES reduce (one function body in `simd_arithmetic.rs`)
- **new:** `define_wide_mul_tests!` for the AES packings plus the exhaustive product sweep in `packed_aes.rs`
- **untouched:** the wide multiply, squaring, inversion, and every other architecture

### Verification

- `cargo check --workspace --all-targets`, `clippy -p binius-field -p binius-prover --all-targets`, nightly `fmt` — clean
- `binius-field` suite: 223 + 2 tests pass, including the 9 new widening tests and the exhaustive sweep

### Benchmark

Back-to-back stash A/B on an M1 Pro (only the kernel file swapped, benches identical on both sides):

| benchmark | Barrett (before) | nibble tables (after) | change |
|---|---|---|---|
| `and_reduction` `univariate_round_message` 2^21, 8 threads | 8.44 ms | 8.17 ms | −3.3% (p = 0.00) |
| reduce only, 64x8b packing (production shape) | 6.96 ns | 5.21 ns | −24% |
| reduce only, 16x8b packing | 1.61 ns | 1.42 ns | −12% |
| widening inner product, 16x8b, n = 16 | 21.3 ns | 21.0 ns | −1.7% |
| widening inner product, n ≥ 256 | — | — | no change (p > 0.05) |

The win concentrates in the fold itself; long inner products are dominated by the multiplies feeding it, as expected.

<details>
<summary>The throwaway microbench behind the kernel rows (not part of the PR)</summary>

The round-message row comes from the existing `and_reduction` bench.
The kernel rows come from this criterion harness, dropped into `crates/field/benches/` with a matching `[[bench]]` entry:

```rust
use std::hint::black_box;

use binius_field::{PackedAESBinaryField16x8b, PackedAESBinaryField64x8b, PackedField, WideMul};
use criterion::{
	BenchmarkGroup, Criterion, Throughput, criterion_group, criterion_main, measurement::WallTime,
};

fn bench_at_n<P: PackedField>(group: &mut BenchmarkGroup<'_, WallTime>, label: &str, n: usize)
where
	<P as WideMul>::Output: Copy,
{
	let mut rng = rand::rng();
	let a_vals: Vec<P> = (0..n).map(|_| P::random(&mut rng)).collect();
	let b_vals: Vec<P> = (0..n).map(|_| P::random(&mut rng)).collect();

	// Inner-product shape: n unreduced products accumulate by XOR, then one reduction.
	group.throughput(Throughput::Elements((n * P::WIDTH) as u64));
	group.bench_function(format!("wide_mul/{label}/n={n}"), |b| {
		b.iter(|| {
			let mut acc = <P as WideMul>::Output::default();
			for i in 0..n {
				acc += P::wide_mul(black_box(a_vals[i]), black_box(b_vals[i]));
			}
			black_box(P::reduce(acc))
		})
	});

	// Reduce-only shape: one reduction per iteration on a pre-accumulated wide product.
	let acc = (0..n)
		.fold(<P as WideMul>::Output::default(), |acc, i| acc + P::wide_mul(a_vals[i], b_vals[i]));
	group.throughput(Throughput::Elements(P::WIDTH as u64));
	group.bench_function(format!("reduce_only/{label}/n={n}"), |b| {
		b.iter(|| black_box(P::reduce(black_box(acc))))
	});
}

fn bench_aes_widening(c: &mut Criterion) {
	let mut group = c.benchmark_group("aes_widening");
	for &n in &[16, 256, 4096] {
		bench_at_n::<PackedAESBinaryField16x8b>(&mut group, "16x8b", n);
	}
	for &n in &[16, 256, 4096] {
		bench_at_n::<PackedAESBinaryField64x8b>(&mut group, "64x8b", n);
	}
	group.finish();
}

criterion_group!(benches, bench_aes_widening);
criterion_main!(benches);
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
