### PR TITLE
BINIUS-343: draw the M4 prover's own buffers from its BufferPool

### DIFF
--- a/crates/m4-prover/benches/assemble_operation_witness.rs
+++ b/crates/m4-prover/benches/assemble_operation_witness.rs
@@ -12,6 +12,7 @@
 use std::array;
 
 use binius_circuits::keccak::permutation::keccak_f1600;
+use binius_compute::{BufferPool, PoolVec};
 use binius_core::word::Word;
 use binius_frontend::{Circuit, CircuitBuilder, Wire};
 use binius_m4_prover::{ValueTable, build_operation_columns};
@@ -71,10 +72,21 @@ fn bench_assemble_operation_witness(c: &mut Criterion) {
 		cs.and_constraints
 	};
 
+	// The columns are drawn from a pool that lives across the timed iterations, matching how the
+	// prover recycles its working buffers between proofs.
+	//
+	// So this benchmark measures assembly onto recycled blocks, not onto fresh ones: every
+	// iteration after the first reuses the blocks its predecessor freed. Comparing it against a
+	// revision that allocated a fresh `Vec` per call therefore measures the allocator, not the
+	// assembly algorithm — the per-word work is unchanged. Read a delta here as "cost of the
+	// allocation strategy", never as an algorithmic speedup.
+	let pool = BufferPool::new();
+	let alloc = &pool;
+
 	let mut group = c.benchmark_group("assemble_operation_witness");
 	group.bench_function("bitand_keccak_f1600", |b| {
-		b.iter(|| -> [Vec<Word>; 2] {
-			build_operation_columns(&table, &constants, &and_constraints)
+		b.iter(|| -> [PoolVec<'_, Word>; 2] {
+			build_operation_columns(&table, &constants, &and_constraints, &alloc)
 		});
 	});
 

--- a/crates/m4-prover/src/operand_witness.rs
+++ b/crates/m4-prover/src/operand_witness.rs
@@ -15,6 +15,7 @@
 
 use std::{iter, mem::MaybeUninit, ptr};
 
+use binius_compute::{Allocator, VecLike};
 use binius_core::{
 	ValueIndex,
 	constraint_system::{Operand, ShiftVariant, ShiftedValueIndex},
@@ -40,17 +41,20 @@ use crate::ValueTable;
 /// - `constants`: the circuit's constant words, shared by every instance.
 /// - `constraints`: the per-instance constraints, shared by every instance. Pass constraints from a
 ///   prepared constraint system, so their count is a power of two.
+/// - `alloc`: the allocator backing the returned columns.
 ///
 /// # Panics
 ///
 /// Panics if `N_COLS` exceeds `ARITY`, or if the constraint count is not a power of two.
-pub fn build_operation_columns<C, const ARITY: usize, const N_COLS: usize>(
+pub fn build_operation_columns<C, A, const ARITY: usize, const N_COLS: usize>(
 	table: &ValueTable,
 	constants: &[Word],
 	constraints: &[C],
-) -> [Vec<Word>; N_COLS]
+	alloc: &A,
+) -> [A::Vec<Word>; N_COLS]
 where
 	C: AsRef<[Operand; ARITY]> + Sync,
+	A: Allocator,
 {
 	assert!(N_COLS <= ARITY, "N_COLS must not exceed the constraint arity");
 
@@ -63,11 +67,12 @@ where
 				constraints
 					.par_iter()
 					.map(move |constraint| &constraint.as_ref()[op_idx]),
+				alloc,
 			)
 		})
 		.collect::<Vec<_>>()
 		.try_into()
-		.expect("source iterator has N_COLS elements")
+		.unwrap_or_else(|_| unreachable!("source iterator has N_COLS elements"))
 }
 
 /// Builds the operand-column witness of a batched fixed-arity operation over every instance.
@@ -101,15 +106,17 @@ where
 /// - `constants`: the circuit's constant words, shared by every instance.
 /// - `operands`: one operand per constraint, in order; the returned column follows that same order.
 ///   Pass operands from a prepared constraint system, so their count is a power of two.
+/// - `alloc`: the allocator backing the returned column.
 ///
 /// # Panics
 ///
 /// Panics if the constraint count is not a power of two.
-pub fn build_operation_witness<'a>(
+pub fn build_operation_witness<'a, A: Allocator>(
 	table: &ValueTable,
 	constants: &[Word],
 	operands: impl IndexedParallelIterator<Item = &'a Operand>,
-) -> Vec<Word> {
+	alloc: &A,
+) -> A::Vec<Word> {
 	// Rows per instance, and total rows across the batch.
 	let log_constraints = log2_strict_usize(operands.len());
 	let log_instances = table.log_instances();
@@ -117,7 +124,7 @@ pub fn build_operation_witness<'a>(
 	let table_words = table.as_words();
 	let witness_offset = ValueIndex(table.layout().offset_witness as u32);
 
-	let mut out = Vec::<Word>::with_capacity(1 << (log_instances + log_constraints));
+	let mut out = alloc.alloc::<Word>(1 << (log_instances + log_constraints));
 
 	operands
 		.zip(out.spare_capacity_mut().par_chunks_mut(1 << log_instances))
@@ -154,10 +161,12 @@ pub fn build_operation_witness<'a>(
 			}
 		});
 
-	// The stripes partition `[0, total)` and each zeroed its whole range.
-	// So all `total` elements of every column are initialized.
-	//
-	// SAFETY: every element in `0..total` of every column was written above.
+	// SAFETY: the stripes partition `[0, total)` and each writes its whole range — the operand's
+	// first term initializes every cell, later terms XOR in place, and an empty operand zeroes the
+	// stripe. So all `total` elements are initialized. `alloc` may hand back more capacity than
+	// requested (the pool rounds the block up to a power-of-two byte count, minimum 64 bytes), so
+	// `spare_capacity_mut` can be longer than `total`; the zip against the operands truncates to
+	// `total`, and nothing past it is ever claimed by `set_len`.
 	unsafe { out.set_len(1 << (log_instances + log_constraints)) };
 	out
 }
@@ -315,7 +324,7 @@ fn accum_shifted_values(
 #[cfg(test)]
 mod tests {
 	use assert_matches::assert_matches;
-	use binius_compute::GlobalAllocator;
+	use binius_compute::{BufferPool, GlobalAllocator};
 	use binius_core::constraint_system::{AndConstraint, ValueVec};
 	use binius_field::{AESTowerField8b as B8, PackedBinaryGhash1x128b};
 	use binius_frontend::{Circuit, CircuitBuilder, Wire};
@@ -479,7 +488,8 @@ mod tests {
 		let table = populate_table(&c, &inputs);
 
 		let and_constraints = &table_constraints(&c);
-		let [a, b] = build_operation_columns(&table, constants(&c), and_constraints);
+		let [a, b] =
+			build_operation_columns(&table, constants(&c), and_constraints, &GlobalAllocator);
 
 		// Shape: K * n_and rows, with K = 4.
 		let n_and = and_constraints.len();
@@ -553,7 +563,8 @@ mod tests {
 		let imul_constraints = &cs.imul_constraints;
 		assert!(!imul_constraints.is_empty(), "the circuit must emit an IMUL constraint");
 
-		let [a, b, lo, hi] = build_operation_columns(&table, constants, imul_constraints);
+		let [a, b, lo, hi] =
+			build_operation_columns(&table, constants, imul_constraints, &GlobalAllocator);
 
 		// Shape: K * n_imul rows, with K = 4.
 		let n_imul = imul_constraints.len();
@@ -651,7 +662,7 @@ mod tests {
 		assert!(!bmul_constraints.is_empty(), "the circuit must emit a BMUL constraint");
 
 		let [a_lo, a_hi, b_lo, b_hi, c_lo, c_hi] =
-			build_operation_columns(&table, constants, bmul_constraints);
+			build_operation_columns(&table, constants, bmul_constraints, &GlobalAllocator);
 
 		// Shape: K * n_binmul rows, with K = 4.
 		let n_binmul = bmul_constraints.len();
@@ -683,7 +694,8 @@ mod tests {
 		// Fixture state: log_instances = 0 → exactly one instance (K = 1).
 		let table = populate_table(&c, &[(0xABCD, 0x0F0F, 0x55)]);
 		let and_constraints = table_constraints(&c);
-		let [a, b] = build_operation_columns(&table, constants(&c), &and_constraints);
+		let [a, b] =
+			build_operation_columns(&table, constants(&c), &and_constraints, &GlobalAllocator);
 
 		// The degenerate batch reproduces the single-instance BitAnd columns exactly.
 		let vv = table.instance_value_vec(0, constants(&c));
@@ -708,7 +720,8 @@ mod tests {
 		//
 		// The operands are empty, so the panic is the count check, never an out-of-range index.
 		let three = vec![AndConstraint::default(); 3];
-		let _: [Vec<Word>; 2] = build_operation_columns(&table, constants(&c), &three);
+		let _: [Vec<Word>; 2] =
+			build_operation_columns(&table, constants(&c), &three, &GlobalAllocator);
 	}
 
 	proptest! {
@@ -717,6 +730,9 @@ mod tests {
 		//     witness[j * n_instances + instance]  ==  eval_operand(instance value vec, constraint j)
 		//
 		// This pins the batched, slice-based evaluator to the core value-vec evaluator.
+		//
+		// The columns are drawn from a `BufferPool`, so this is the case that covers the
+		// `A::Vec = PoolVec` instantiation; the rest of the module's tests use `GlobalAllocator`.
 		#[test]
 		fn batch_rows_match_single_instance_reference(
 			inputs in prop::collection::vec((any::<u64>(), any::<u64>(), any::<u64>()), 4),
@@ -724,12 +740,13 @@ mod tests {
 			let c = and_circuit();
 			let table = populate_table(&c, &inputs);
 
+			let pool = BufferPool::new();
 			let and_constraints = table_constraints(&c);
-			let [a, b] = build_operation_columns(&table, constants(&c), &and_constraints);
+			let [a, b] = build_operation_columns(&table, constants(&c), &and_constraints, &&pool);
 
 			let (a_ref, b_ref) = reference_columns(&table, constants(&c), &and_constraints);
-			prop_assert_eq!(a, a_ref);
-			prop_assert_eq!(b, b_ref);
+			prop_assert_eq!(&*a, &a_ref[..]);
+			prop_assert_eq!(&*b, &b_ref[..]);
 		}
 	}
 
@@ -746,7 +763,8 @@ mod tests {
 			.collect();
 		let table = populate_table(&c, &inputs);
 		let and_constraints = table_constraints(&c);
-		let [a, b] = build_operation_columns(&table, constants(&c), &and_constraints);
+		let [a, b] =
+			build_operation_columns(&table, constants(&c), &and_constraints, &GlobalAllocator);
 
 		// Every instance's contribution equals its independent single-instance reference.
 		// This includes instances at or beyond STRIPE_WIDTH, which only the second stripe produces.
@@ -794,7 +812,8 @@ mod tests {
 			});
 		assert!(shifted, "fixture must contain a shifted operand");
 
-		let [a, b] = build_operation_columns(&table, constants(&c), &and_constraints);
+		let [a, b] =
+			build_operation_columns(&table, constants(&c), &and_constraints, &GlobalAllocator);
 
 		// `a` and `b` equal the shift-aware value-vec reference for the same constraints.
 		let (a_ref, b_ref) = reference_columns(&table, constants(&c), &and_constraints);
@@ -811,7 +830,8 @@ mod tests {
 		// So every coordinate is pinned and no large-field challenge is drawn.
 		let table = populate_table(&c, &[(1, 3, 7), (5, 6, 0), (9, 12, 0xFF), (0xF0, 0x0F, 1)]);
 		let and_constraints = table_constraints(&c);
-		let [a, b] = build_operation_columns(&table, constants(&c), &and_constraints);
+		let [a, b] =
+			build_operation_columns(&table, constants(&c), &and_constraints, &GlobalAllocator);
 		let log_total = checked_log_2(a.len());
 
 		// Prover and verifier agree on the reduced claim over the batched columns.
@@ -846,7 +866,8 @@ mod tests {
 			.collect();
 		let table = populate_table(&c, &inputs);
 		let and_constraints = table_constraints(&c);
-		let [a, b] = build_operation_columns(&table, constants(&c), &and_constraints);
+		let [a, b] =
+			build_operation_columns(&table, constants(&c), &and_constraints, &GlobalAllocator);
 		let log_total = checked_log_2(a.len());
 
 		// Produce a faithful proof.
@@ -895,7 +916,7 @@ mod tests {
 			let c = and_circuit();
 			let table = populate_table(&c, &inputs);
 			let and_constraints = table_constraints(&c);
-			let [a, b] = build_operation_columns(&table, constants(&c), &and_constraints);
+			let [a, b] = build_operation_columns(&table, constants(&c), &and_constraints, &GlobalAllocator);
 
 			// Keep the columns so the claimed evals can be checked against them.
 			// The witness stores no C column.

--- a/crates/m4-prover/src/prove.rs
+++ b/crates/m4-prover/src/prove.rs
@@ -299,7 +299,7 @@ impl IOPProver {
 		// Fold the committed witness over the instance axis at the shared point.
 		let folded_witness = {
 			let _scope = tracing::debug_span!("Fold instances").entered();
-			fold_instances::<B128>(table, &r_rho)
+			fold_instances::<B128, _>(table, &r_rho, alloc)
 		};
 
 		// The public segment is the shared constants, padded with zeros to the layout's
@@ -307,8 +307,16 @@ impl IOPProver {
 		// The shift folds it against the monster's public part, which is sized to that padded
 		// count. The padding makes the two lengths agree, and matches the zeros the verifier
 		// assumes.
-		let mut public_words = cs.constants.clone();
-		public_words.resize(cs.value_vec_layout.n_public_words(), Word::ZERO);
+		let n_public_words = cs.value_vec_layout.n_public_words();
+		// Growing a pooled buffer past the block it was handed would reallocate and free that block
+		// at the element's alignment rather than the pool's, so the fill below must fit exactly.
+		assert!(
+			cs.constants.len() <= n_public_words,
+			"the public segment is padded to at least the constant count"
+		);
+		let mut public_words = alloc.alloc::<Word>(n_public_words);
+		public_words.extend_from_slice(&cs.constants);
+		public_words.resize(n_public_words, Word::ZERO);
 
 		// Reduce the operand claims to one witness evaluation.
 		let witness_claim = {

--- a/crates/m4-prover/src/prove.rs
+++ b/crates/m4-prover/src/prove.rs
@@ -1,6 +1,8 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
+use std::ops::Deref;
+
 use binius_compute::{Allocator, BufferPool, VecLike};
 use binius_core::{constraint_system::ConstraintSystem, word::Word};
 use binius_field::{AESTowerField8b as B8, Field, PackedField};
@@ -152,12 +154,11 @@ impl IOPProver {
 		let mul = (!cs.imul_constraints.is_empty()).then(|| {
 			let columns = {
 				let _scope = tracing::debug_span!("Assemble IntMul witness").entered();
-				build_operation_columns(table, &cs.constants, &cs.imul_constraints)
+				build_operation_columns(table, &cs.constants, &cs.imul_constraints, alloc)
 			};
 			// A prepared constraint system pads its constraint and instance counts to powers of
 			// two, so the columns always have a power-of-two length as the witness requires.
-			let [a, b, lo, hi] = &columns;
-			let output = intmul::prove::<_, _, P, _>([a, b, lo, hi], channel, alloc)
+			let output = intmul::prove::<_, _, P, _>(column_slices(&columns), channel, alloc)
 				.expect("a prepared constraint system yields power-of-two operand columns");
 			(columns, output)
 		});
@@ -178,14 +179,9 @@ impl IOPProver {
 		let bmul = (!cs.bmul_constraints.is_empty()).then(|| {
 			let columns = {
 				let _scope = tracing::debug_span!("Assemble BinMul witness").entered();
-				build_operation_columns(table, &cs.constants, &cs.bmul_constraints)
+				build_operation_columns(table, &cs.constants, &cs.bmul_constraints, alloc)
 			};
-			let [a_lo, a_hi, b_lo, b_hi, c_lo, c_hi] = &columns;
-			let output = binmul::prove::<_, B128, P, _>(
-				[a_lo, a_hi, b_lo, b_hi, c_lo, c_hi],
-				channel,
-				alloc,
-			);
+			let output = binmul::prove::<_, B128, P, _>(column_slices(&columns), channel, alloc);
 			(columns, output)
 		});
 
@@ -206,25 +202,29 @@ impl IOPProver {
 
 			let [a, b] = {
 				let _scope = tracing::debug_span!("Assemble BitAnd witness").entered();
-				build_operation_columns(table, &cs.constants, &cs.and_constraints)
+				build_operation_columns(table, &cs.constants, &cs.and_constraints, alloc)
 			};
 			// Reduce over borrowed columns so the owned `a`/`b` can be moved into `and_columns`
 			// afterward, avoiding a full clone. Nothing touches the channel between the reduction
 			// and building `and_columns`, so the transcript is unchanged.
-			let output = and_reduction::prove::<_, B128, P, _, _>(
-				[a.as_slice(), b.as_slice()],
-				channel,
-				alloc,
-			);
+			let output = and_reduction::prove::<_, B128, P, _, _>([&a[..], &b[..]], channel, alloc);
 			let and_columns = (mul.is_some() || bmul.is_some()).then(|| {
 				// The re-randomization re-reads the three BitAnd operand columns.
 				// Only `A` and `B` are stored.
 				// On a satisfying witness `C = A & B` holds word-by-word.
 				// So `C` is materialized here, on this multiplication-only path.
-				let c_column = (a.as_slice(), b.as_slice())
+				// The multizip truncates to the shortest of its three sides, so `set_len(n_rows)`
+				// below is sound only because the two source columns have equal length.
+				debug_assert_eq!(a.len(), b.len());
+				let n_rows = a.len();
+				let mut c_column = alloc.alloc::<Word>(n_rows);
+				(&a[..], &b[..], c_column.spare_capacity_mut())
 					.into_par_iter()
-					.map(|(&a_i, &b_i)| a_i & b_i)
-					.collect();
+					.for_each(|(&a_i, &b_i, out)| {
+						out.write(a_i & b_i);
+					});
+				// Safety: every entry of `c_column` is written exactly once in the loop above.
+				unsafe { c_column.set_len(n_rows) };
 				[a, b, c_column]
 			});
 			(and_columns, output)
@@ -248,12 +248,27 @@ impl IOPProver {
 				.expect("AND columns are retained whenever there are IMUL or BMUL constraints");
 			let log_instances = table.log_instances();
 			RerandomizedOperations {
-				bitand: Operation::new(&and_columns, [a_eval, b_eval, c_eval], r_x_and, r_rho_and),
+				bitand: Operation::new(
+					column_slices(&and_columns),
+					[a_eval, b_eval, c_eval],
+					r_x_and,
+					r_rho_and,
+				),
 				intmul: mul.as_ref().map(|(columns, output)| {
-					Operation::from_intmul(columns, output.clone(), &lagrange, log_instances)
+					Operation::from_intmul(
+						column_slices(columns),
+						output.clone(),
+						&lagrange,
+						log_instances,
+					)
 				}),
 				binmul: bmul.as_ref().map(|(columns, output)| {
-					Operation::from_binmul(columns, output.clone(), &lagrange, log_instances)
+					Operation::from_binmul(
+						column_slices(columns),
+						output.clone(),
+						&lagrange,
+						log_instances,
+					)
 				}),
 			}
 			.prove::<P, _, _>(&lagrange, z_challenge, channel, alloc)
@@ -419,6 +434,17 @@ where
 	}
 }
 
+/// Borrows an operation's allocator-backed operand columns as plain word slices.
+///
+/// The reductions and [`Operation`] read the columns without caring which allocator produced them,
+/// so this drops the buffer type at the seam rather than propagating it through their signatures.
+fn column_slices<Data, const N: usize>(columns: &[Data; N]) -> [&[Word]; N]
+where
+	Data: Deref<Target = [Word]>,
+{
+	columns.each_ref().map(|column| &**column)
+}
+
 /// One operation's operand columns, oblong claims, and the points they are claimed at.
 ///
 /// The AND-check and the IntMul check both reduce to this shape.
@@ -426,7 +452,7 @@ where
 /// It then transports the claims to the instance point shared by both operations.
 struct Operation<'a, const ARITY: usize> {
 	/// The operand columns, constraint-major, one per operand.
-	columns: &'a [Vec<Word>; ARITY],
+	columns: [&'a [Word]; ARITY],
 	/// The oblong operand claim per operand: its multilinear-eval claim at the instance point.
 	operand_claims: [B128; ARITY],
 	/// The constraint-index point the operands are claimed at.
@@ -439,7 +465,7 @@ impl<'a, const ARITY: usize> Operation<'a, ARITY> {
 	/// The operand columns with their claims at the constraint point `r_x` and instance point
 	/// `r_rho`.
 	fn new(
-		columns: &'a [Vec<Word>; ARITY],
+		columns: [&'a [Word]; ARITY],
 		operand_claims: [B128; ARITY],
 		r_x: &[B128],
 		r_rho: &[B128],
@@ -474,7 +500,7 @@ impl<'a, const ARITY: usize> Operation<'a, ARITY> {
 		let eq_tracker = store.register_eq_tracker(&self.r_rho);
 		// The constraint tensor is the same for every operand of this operation, so expand it once.
 		let r_x_tensor = eq_ind_partial_eval_scalars::<B128>(&self.r_x);
-		for (column, &claim) in self.columns.iter().zip(&self.operand_claims) {
+		for (&column, &claim) in self.columns.iter().zip(&self.operand_claims) {
 			let col = store.push_owned(operand_rho_multilinear::<A, P>(
 				alloc,
 				column,
@@ -500,7 +526,7 @@ impl<'a> Operation<'a, INTMUL_ARITY> {
 	/// This gives the oblong form the BitAnd claims already have.
 	/// The IntMul row point splits into an instance part (low) and a constraint part (high).
 	fn from_intmul(
-		columns: &'a [Vec<Word>; INTMUL_ARITY],
+		columns: [&'a [Word]; INTMUL_ARITY],
 		intmul_output: IntMulOutput<B128>,
 		lagrange: &[B128],
 		log_instances: usize,
@@ -536,7 +562,7 @@ impl<'a> Operation<'a, BINMUL_ARITY> {
 	/// This gives the oblong form the BitAnd claims already have.
 	/// The BinMul row point splits into an instance part (low) and a constraint part (high).
 	fn from_binmul(
-		columns: &'a [Vec<Word>; BINMUL_ARITY],
+		columns: [&'a [Word]; BINMUL_ARITY],
 		binmul_output: BinMulOutput<B128>,
 		lagrange: &[B128],
 		log_instances: usize,
@@ -799,6 +825,80 @@ mod tests {
 		let mut cs = c.circuit.constraint_system().clone();
 		cs.validate_and_prepare().unwrap();
 		(cs, table)
+	}
+
+	// Two proofs from one `Prover` are byte-identical, and both verify.
+	//
+	// A `Prover` owns its `BufferPool` for its whole lifetime, so the second proof draws blocks the
+	// first one freed. Within a single proof the pool already recycles — each reduction returns its
+	// working buffers as it finishes, and later allocations land on them — so a round trip does
+	// exercise dirty memory. What only a second proof reaches is reuse of the blocks held for the
+	// *whole* of the first: the operand columns and the instance-folded witness, which are live
+	// until the proof ends and so are recycled nowhere else.
+	//
+	// The byte-for-byte equality is the part no other test asserts. It surfaces a slot a pooled
+	// buffer leaves unwritten when the first proof reads it fresh and the second reads the first's
+	// leftovers, without having to predict which buffer or which block that is. It is not a
+	// superset of the round-trip tests: a slot that happens to read the same both times yields two
+	// identically-wrong proofs, and the verification below is what catches those.
+	//
+	// The fixture carries AND, IMUL, and BMUL constraints so every operation's pooled buffers are
+	// live, rather than only the AND path a mul-free circuit reaches.
+	#[test]
+	fn two_proofs_from_one_prover_are_byte_identical() {
+		use binius_frontend::Wire;
+
+		let builder = CircuitBuilder::new();
+		let inputs: [Wire; 4] = array::from_fn(|_| builder.add_witness());
+		let and = builder.band(inputs[0], inputs[1]);
+		builder.force_commit(and);
+		let (hi, lo) = builder.imul(inputs[0], inputs[1]);
+		builder.force_commit(hi);
+		builder.force_commit(lo);
+		let (c_lo, c_hi) = builder.bmul(inputs[0], inputs[1], inputs[2], inputs[3]);
+		builder.force_commit(c_lo);
+		builder.force_commit(c_hi);
+		let circuit = builder.build();
+
+		let mut cs = circuit.constraint_system().clone();
+		cs.validate_and_prepare().unwrap();
+		// Confirm the fixture reaches all three operations, so the recycled buffers really do span
+		// every operand-column shape.
+		assert!(!cs.imul_constraints.is_empty(), "the fixture must emit IMUL constraints");
+		assert!(!cs.bmul_constraints.is_empty(), "the fixture must emit BMUL constraints");
+
+		let log_instances = 6;
+		let table = ValueTable::populate(&circuit, log_instances, |i, w| {
+			let mut rng = StdRng::seed_from_u64(i as u64);
+			for &wire in &inputs {
+				w[wire] = Word(rng.next_u64());
+			}
+		})
+		.unwrap();
+
+		let verifier = Verifier::setup(&cs, log_instances, 1);
+		let prover = Prover::<P>::setup(&verifier);
+
+		// One prover, two proofs of the same table: the second reuses the first's freed blocks.
+		let prove_once = || {
+			let mut transcript = ProverTranscript::new(StdChallenger::default());
+			prover.prove(&table, &mut transcript);
+			transcript.finalize()
+		};
+		let first = prove_once();
+		let second = prove_once();
+		assert_eq!(first, second, "a second proof from the same prover must reproduce the first");
+
+		// Both proofs stand on their own against the verifier.
+		for proof in [first, second] {
+			let mut verifier_transcript = VerifierTranscript::new(StdChallenger::default(), proof);
+			verifier
+				.verify(&mut verifier_transcript)
+				.expect("a faithful proof verifies");
+			verifier_transcript
+				.finalize()
+				.expect("no trailing proof data");
+		}
 	}
 
 	// The prover and verifier run the whole protocol on one transcript.

--- a/crates/m4-prover/src/shift.rs
+++ b/crates/m4-prover/src/shift.rs
@@ -2,6 +2,8 @@
 
 //! The batched shift-reduction prover for the data-parallel Binius64 M4 proof system.
 
+use std::{array, iter};
+
 use binius_compute::{Allocator, VecLike};
 use binius_core::word::Word;
 use binius_field::{BinaryField, PackedField};
@@ -202,11 +204,14 @@ where
 	// the scalars are zero-padded up to the next one, mirroring `fold_words`'s own padding of the
 	// public segment.
 	let public_folded = fold_words::<F, P, _>(alloc, public_words, r_j_tensor.as_ref());
-	let mut hidden_scalars: Vec<F> = folded_witness
-		.iter()
-		.map(|word| inner_product(word.iter().copied(), r_j_tensor.as_ref().iter().copied()))
-		.collect();
-	hidden_scalars.resize(1 << log2_ceil_usize(hidden_scalars.len()), F::ZERO);
+	let padded_len = 1 << log2_ceil_usize(folded_witness.len());
+	let mut hidden_scalars = alloc.alloc::<F>(padded_len);
+	hidden_scalars.extend(
+		folded_witness
+			.iter()
+			.map(|word| inner_product(word.iter().copied(), r_j_tensor.as_ref().iter().copied())),
+	);
+	hidden_scalars.resize(padded_len, F::ZERO);
 	let hidden_folded = FieldBuffer::<P, _>::from_values_in(alloc, &hidden_scalars);
 
 	let (public_monster, hidden_monster) = build_monster_segments::<F, P, _>(
@@ -247,11 +252,11 @@ where
 /// results to obtain the complete g parts. `folded_words` is paired with `segment.key_ranges` in
 /// order, so any power-of-two padding beyond the segment's word count is ignored.
 ///
-/// The result is a flat accumulator split into `SHIFT_VARIANT_COUNT` multilinears of [`LOG_LEN`]
-/// variables each. Each multilinear is indexed by `(shift amount, bit position)`: for shift key
-/// `id = (variant << Word::LOG_BITS) | amount`, the slot at `id * Word::BITS + bit`
-/// accumulates, over every word carrying that key, the word's folded bit times the key's
-/// lambda-weighted partial evaluation tensor.
+/// The result is `SHIFT_VARIANT_COUNT` multilinears of [`LOG_LEN`] variables each, one per shift
+/// variant. Each multilinear is indexed by `(shift amount, bit position)`: shift key
+/// `id = (variant << Word::LOG_BITS) | amount` selects multilinear `variant`, whose slot at
+/// `amount * Word::BITS + bit` accumulates, over every word carrying that key, the word's folded
+/// bit times the key's lambda-weighted partial evaluation tensor.
 ///
 /// This scalar implementation ignores the packed-field and parallelism optimizations of the
 /// single-instance builder.
@@ -263,10 +268,11 @@ pub fn build_g_parts_from_folded_words<F: BinaryField, A: Allocator>(
 	intmul_operator_data: &PreparedOperatorData<F>,
 	binmul_operator_data: &PreparedOperatorData<F>,
 ) -> [FieldVec<F, A>; SHIFT_VARIANT_COUNT] {
-	// One flat accumulator holding SHIFT_VARIANT_COUNT multilinears of LOG_LEN variables each, laid
-	// out variant-major. Kept on the heap rather than a stack array: it is thousands of elements.
-	#[allow(clippy::useless_vec)]
-	let mut multilinears = vec![F::ZERO; SHIFT_VARIANT_COUNT << LOG_LEN];
+	// One zeroed multilinear of LOG_LEN variables per shift variant, drawn from the allocator. A
+	// key belongs to exactly one variant, so the scatter below accumulates straight into these
+	// buffers.
+	let mut multilinears =
+		array::from_fn::<_, SHIFT_VARIANT_COUNT, _>(|_| FieldVec::<F, A>::zeros_in(alloc, LOG_LEN));
 
 	// Each folded word carries the keys named by the segment-relative range at its position.
 	for (word, range) in folded_words.iter().zip(&segment.key_ranges) {
@@ -285,26 +291,20 @@ pub fn build_g_parts_from_folded_words<F: BinaryField, A: Allocator>(
 				&operator_data.lambda_powers,
 			);
 
+			// The key id is `(variant << Word::LOG_BITS) | amount`, so its variant selects the
+			// multilinear and its shift amount the bit slots within that multilinear.
+			let variant = key.id as usize >> Word::LOG_BITS;
+			let amount_base = (key.id as usize & (Word::BITS - 1)) * Word::BITS;
+			let slots = &mut multilinears[variant].as_mut()[amount_base..amount_base + Word::BITS];
+
 			// Scatter the accumulator across this key's bit slots, scaling each by the folded bit.
-			let bit_base = key.id as usize * Word::BITS;
-			for (bit, &folded_bit) in word.iter().enumerate() {
-				multilinears[bit_base + bit] += acc * folded_bit;
+			for (slot, &folded_bit) in iter::zip(slots, word) {
+				*slot += acc * folded_bit;
 			}
 		}
 	}
 
-	// Split the flat accumulator into one multilinear per shift variant, each built straight into
-	// the allocator's buffer rather than into a `Vec` copy.
 	multilinears
-		.chunks(1 << LOG_LEN)
-		.map(|chunk| {
-			let mut data = alloc.alloc::<F>(chunk.len());
-			data.extend_from_slice(chunk);
-			FieldBuffer::new(LOG_LEN, data)
-		})
-		.collect::<Vec<_>>()
-		.try_into()
-		.unwrap_or_else(|_| panic!("chunks yield SHIFT_VARIANT_COUNT parts of size 1 << LOG_LEN"))
 }
 
 #[cfg(test)]

--- a/crates/m4-prover/src/shift.rs
+++ b/crates/m4-prover/src/shift.rs
@@ -73,21 +73,38 @@ pub type FoldedWord<F> = [F; Word::BITS];
 /// # Panics
 ///
 /// Panics if `r_rho.len()` does not equal the batch dimension.
-pub fn fold_instances<F: BinaryField>(table: &ValueTable, r_rho: &[F]) -> Vec<FoldedWord<F>> {
+pub fn fold_instances<F: BinaryField, A: Allocator>(
+	table: &ValueTable,
+	r_rho: &[F],
+	alloc: &A,
+) -> A::Vec<FoldedWord<F>> {
 	assert_eq!(r_rho.len(), table.log_instances(), "r_rho must match the batch dimension");
 
 	// Build the instance-fold tables once; the lookups and weights depend only on r_rho.
 	let folder = WordFolder::<F>::new(r_rho);
 
-	// Each output chunk holds one committed word position:
-	//     out[w * Word::BITS + b] = sum_rho eq(r_rho, rho) * bit_b(word[rho][w]).
-	// The word positions are independent, so fold them in parallel.
-	// Positions beyond the committed count keep their zero padding.
+	// Each output element holds one committed word position:
+	//     out[w][b] = sum_rho eq(r_rho, rho) * bit_b(word[rho][w]).
+	// The word positions are independent, so fold them in parallel, one output element per task.
+	//
+	// The table stores exactly `n_hidden_words << log_instances` words, so chunking it by the
+	// instance count yields exactly one chunk per output element. `zip` truncates to the shorter
+	// side, so this equality is what makes the loop below cover every element; assert it rather
+	// than rely on a `ValueTable` invariant stated in another module.
+	let n_words = table.n_hidden_words();
+	debug_assert_eq!(table.as_words().len(), n_words << table.log_instances());
+	let mut folded = alloc.alloc::<FoldedWord<F>>(n_words);
 	table
 		.as_words()
 		.par_chunks(1 << table.log_instances())
-		.map(|instance_words| folder.fold(instance_words))
-		.collect()
+		.zip(folded.spare_capacity_mut())
+		.for_each(|(instance_words, out)| {
+			out.write(folder.fold(instance_words));
+		});
+	// SAFETY: the chunks and the output elements are in one-to-one correspondence by the length
+	// equality asserted above, so the loop writes each of the `n_words` elements exactly once.
+	unsafe { folded.set_len(n_words) };
+	folded
 }
 
 /// Proves the batched shift-reduction, reducing the bitand and intmul evaluation claims to a single
@@ -425,7 +442,7 @@ mod tests {
 
 			// Route A: fold the instance axis, giving one FoldedWord per committed word, then
 			// evaluate that (bit, word) multilinear at r.
-			let folded = fold_instances::<B128>(&table, &r_rho);
+			let folded = fold_instances::<B128, _>(&table, &r_rho, &GlobalAllocator);
 			let (r_bit, r_wire) = r.split_at(Word::LOG_BITS);
 			let lhs = evaluate_folded_witness(&folded, r_bit, r_wire);
 
@@ -549,7 +566,7 @@ mod tests {
 
 		// The hidden witness folded over instances (one FoldedWord per committed word), and the
 		// public constants.
-		let folded_witness = fold_instances::<B128>(&table, &r_rho);
+		let folded_witness = fold_instances::<B128, _>(&table, &r_rho, &GlobalAllocator);
 		let _offset = table.layout().offset_witness;
 		let public_words = &cs.constants;
 

--- a/crates/m4-prover/src/shift.rs
+++ b/crates/m4-prover/src/shift.rs
@@ -465,7 +465,7 @@ mod tests {
 		r_x: &[B128],
 		r_rho: &[B128],
 	) -> [B128; 3] {
-		let [a, b] = build_operation_columns(table, constants, and_constraints);
+		let [a, b] = build_operation_columns(table, constants, and_constraints, &GlobalAllocator);
 		let lagrange = lagrange_evals_scalars::<B128, B128>(domain_subspace, r_z);
 		let row_point: Vec<B128> = r_rho.iter().chain(r_x).copied().collect();
 		let operand_eval = |column: &[Word]| {


### PR DESCRIPTION
Closes [BINIUS-343](https://linear.app/jimpo/issue/BINIUS-343/use-bufferpool-allocator-throughout-the-m4-prover).

## What this is

The issue asked to give `binius_m4_prover::Prover` a `BufferPool` the way `binius_prover::Prover` has one. **That half was already done** — BINIUS-337 (#1897) added `pool: BufferPool` and already threads `&self.pool` into `IOPProver::prove`, which forwards it to `intmul::prove`, `binmul::prove`, `and_reduction::prove` and the shift reduction.

What was still on the global allocator is everything the M4 prover allocates *itself*, and that is what this PR converts:

- the AND/IMUL/BMUL operand columns (`build_operation_columns`) — by far the largest Word buffers in the path
- the derived BitAnd `C` column
- `fold_instances`' `Vec<FoldedWord<F>>`
- the padded public-word buffer
- the shift g-parts scratch

Three commits, each independently green:

| commit | |
|---|---|
| `c5323fe1` | draw the M4 operand columns from the prover's BufferPool |
| `dc2f0dac` | pool the instance-folded witness and the public word buffer |
| `8f1bc4d5` | build the M4 shift g parts directly into pooled buffers |

No protocol change. Transcript is byte-identical: Keccak-f1600, 2^13 instances, `OptimalPackedB128`, 5 consecutive proofs from one `Prover` — 397232 bytes, FNV-1a `fcda4a856a3f0fd9`, same as `main`.

## Performance

i9-13900H, 6 vCPU, release, `RUSTFLAGS="-C target-cpu=native"`.

**Operand-column assembly: 61.4 ms → 20.4 ms (−67%)** — `assemble_operation_witness/bitand_keccak_f1600`, criterion, 100 samples. In-prover span `Assemble BitAnd witness` agrees: median 56.3 ms → 19.6 ms.

**This is an allocator win, not an algorithmic one, and the bench measures it as such.** The bench hoists a `BufferPool` outside the timed loop, so it compares assembly onto *recycled* blocks against fresh `Vec::with_capacity` + first-touch page faults. The per-word work is unchanged. The bench's in-file comment says this too, so the number can't drift loose from its meaning later.

**End-to-end: ≈ −3%** on `keccak_permutations/13` (medians 1.131 s → 1.095 s, interleaved A/B). Treat this as soft: same-binary repeat runs on this box vary ±2–4%, and criterion's first A/B comparison reported "no change detected" (p = 0.36). All three interleaved pairs favoured the change and ~35 ms of ~1.13 s is what the span data predicts, so I believe it's real — but the defensible claim is "a large, cleanly-measured local win that translates to roughly 3% end-to-end, at this machine's noise floor". Not the 8% one pair showed.

The win starts at proof #2 — it comes from pool reuse, so the first proof from a fresh `Prover` is unchanged.

`Fold instances` and `Prove shift reduction` did not move: the former is dominated by fold arithmetic, the latter's change removes a 512 KB zeroed alloc inside a ~1 ms span.

## New test

Adds `two_proofs_from_one_prover_are_byte_identical`: one `Prover`, two proofs of the same table, asserted byte-for-byte equal and each verified independently.

Its value is *not* "catches a bug the single-proof tests miss" — the pool already recycles **within** a proof (each reduction returns its working buffers as it finishes, so later allocations in the same `prove` call land on dirty blocks), and the existing round-trip tests do exercise that. What the new test adds is (a) proof-byte determinism across `prove` calls, which nothing else asserts and which is strictly stronger than "both verify", and (b) cross-proof reuse of the buffers held for the whole of a proof — the operand columns and the instance-folded witness — which are recycled nowhere else.

Confirmed by mutation: deleting the `public_words` zero-fill fails four existing single-proof round-trip tests as well as the new one, and deleting the empty-operand zeroing in `build_operation_witness` fails `protocol_round_trips_with_mul` while *passing* the new test. No read-before-write bug was constructible that only the two-proof test catches.

The `operand_witness` proptest `batch_rows_match_single_instance_reference` now builds through a `BufferPool`, so the `A::Vec = PoolVec` instantiation is unit-tested rather than only the `GlobalAllocator` one.

## Not done here

`table.pack::<P>()` goes through the shared `binius_prover::pack_witness`, which is still `Vec::with_capacity`. That buffer is comparable to or larger than the AND columns this PR does pool, so **"all Word and FieldBuffer allocations" is not yet true.** `binius_prover::Prover` has the same gap, and threading an allocator through `pack_witness` would change both provers — wider than this issue, so it's filed as a follow-up rather than bolted on here. Flagging it explicitly so this doesn't read as full coverage.

The two `binius-math` scalar helpers (`eq_ind_partial_eval_scalars`, `lagrange_evals_scalars`) also stay on the global allocator — small, shared, and would need a `binius-math` change. Not worth a follow-up.

## Notes for review

- `Operation` now holds `[&'a [Word]; ARITY]` instead of `&'a [Vec<Word>; ARITY]`, with a `column_slices` helper at the call site. This drops the buffer type at the allocation seam rather than adding a generic parameter to `Operation` / `RerandomizedOperations` / `from_intmul` / `from_binmul`.
- `build_g_parts_from_folded_words` now scatters straight into the per-variant pooled buffers instead of filling a flat scratch accumulator and copying out — the one change here that isn't a mechanical alloc swap. It's index-identical to the old layout for every id: with `id = (variant << Word::LOG_BITS) + amount`, `(id>>6)*4096 + (id&63)*64 + bit == id*64 + bit`.
- `prove.rs` gained an unconditional `assert!(cs.constants.len() <= n_public_words, ...)`. Overflowing that buffer would grow the `PoolVec` past its block and free 64-byte-aligned pool memory at `align_of::<Word>()` — UB, in release, which is exactly where a `debug_assert!` would have compiled out. `ValueVecLayout::validate` doesn't enforce `n_const <= offset_witness`, so a deserialized layout could violate it.
- `alloc` parameters were added to the already-`pub` `build_operation_columns` / `build_operation_witness` / `fold_instances`; no callers exist outside `binius-m4-prover`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
