### PR TITLE
BINIUS-347: stop computing wires the optimiser already dropped

### DIFF
--- a/crates/circuits/src/bignum/big_uint_divide.rs
+++ b/crates/circuits/src/bignum/big_uint_divide.rs
@@ -107,6 +107,10 @@ mod tests {
 		let m = builder.add_constant_64(u64::MAX - 4);
 
 		let (q, r) = BigUintDivideHint::call(&builder, &[d0, d1], &[m]);
+		// Pin the hint outputs, so the hint gate is evaluated rather than dropped as unread.
+		for wire in q.iter().chain(&r) {
+			builder.force_commit(*wire);
+		}
 
 		let circuit = builder.build();
 		let mut w = circuit.new_witness_filler();
@@ -131,6 +135,10 @@ mod tests {
 		let m1 = builder.add_constant_64(0);
 
 		let (q, r) = BigUintDivideHint::call(&builder, &[d0, d1], &[m0, m1]);
+		// Pin the hint outputs, so the hint gate is evaluated rather than dropped as unread.
+		for wire in q.iter().chain(&r) {
+			builder.force_commit(*wire);
+		}
 
 		let circuit = builder.build();
 		let mut w = circuit.new_witness_filler();

--- a/crates/circuits/src/bignum/big_uint_mod_pow.rs
+++ b/crates/circuits/src/bignum/big_uint_mod_pow.rs
@@ -83,6 +83,10 @@ mod tests {
 
 		let c = builder.add_constant_64(0x123456789abcdef0);
 		let modpow = BigUintModPowHint::call(&builder, &[c], &[c, c], &[c, c, c]);
+		// Pin the hint outputs, so the hint gate is evaluated rather than dropped as unread.
+		for wire in &modpow {
+			builder.force_commit(*wire);
+		}
 
 		let circuit = builder.build();
 		let mut w = circuit.new_witness_filler();

--- a/crates/circuits/src/bignum/mod_inverse.rs
+++ b/crates/circuits/src/bignum/mod_inverse.rs
@@ -109,6 +109,10 @@ mod tests {
 		let m1 = builder.add_constant_64((1u64 << 63) - 1);
 
 		let (quotient, inverse) = ModInverseHint::call(&builder, &[b], &[m0, m1]);
+		// Pin the hint outputs, so the hint gate is evaluated rather than dropped as unread.
+		for wire in quotient.iter().chain(&inverse) {
+			builder.force_commit(*wire);
+		}
 
 		let circuit = builder.build();
 		let mut w = circuit.new_witness_filler();
@@ -134,6 +138,10 @@ mod tests {
 		let m1 = builder.add_constant_64(0x3ffff7ffffffffff);
 
 		let (quotient, inverse) = ModInverseHint::call(&builder, &[b], &[m0, m1]);
+		// Pin the hint outputs, so the hint gate is evaluated rather than dropped as unread.
+		for wire in quotient.iter().chain(&inverse) {
+			builder.force_commit(*wire);
+		}
 
 		let circuit = builder.build();
 		let mut w = circuit.new_witness_filler();

--- a/crates/circuits/src/bignum/tests.rs
+++ b/crates/circuits/src/bignum/tests.rs
@@ -26,6 +26,16 @@ pub fn biguint_to_num_biguint(w: &WitnessFiller, biguint: &BigUint) -> num_bigin
 	from_u64_limbs(&limb_vals)
 }
 
+/// Pins every limb of a value the caller reads back out of the witness.
+///
+/// A value nothing else reads is dropped as unread.
+/// It would then be neither constrained nor computed.
+fn force_commit_biguint(builder: &CircuitBuilder, value: &BigUint) {
+	for &limb in &value.limbs {
+		builder.force_commit(limb);
+	}
+}
+
 #[test]
 fn test_add_overflow_detection_via_final_carry() {
 	// This test demonstrates that the final carry check catches overflow
@@ -320,6 +330,7 @@ proptest! {
 		let b = BigUint::new_inout(&builder, b_limbs.len());
 
 		let result = textbook_mul(&builder, &a, &b);
+		force_commit_biguint(&builder, &result);
 
 		let cs = builder.build();
 		let mut w = cs.new_witness_filler();
@@ -353,6 +364,7 @@ proptest! {
 
 		let a = BigUint::new_witness(&builder, a_limbs.len());
 		let result = textbook_square(&builder, &a);
+		force_commit_biguint(&builder, &result);
 
 		let cs = builder.build();
 
@@ -393,6 +405,8 @@ proptest! {
 
 		let lt_flag = biguint_lt(&builder, &a, &b);
 		let eq_flag = biguint_eq(&builder, &a, &b);
+		builder.force_commit(lt_flag);
+		builder.force_commit(eq_flag);
 
 		let cs = builder.build();
 		let mut w = cs.new_witness_filler();
@@ -421,6 +435,8 @@ proptest! {
 
 		let square_result = textbook_square(&builder, &a);
 		let mul_result = textbook_mul(&builder, &a, &a);
+		force_commit_biguint(&builder, &square_result);
+		force_commit_biguint(&builder, &mul_result);
 
 		let cs = builder.build();
 		let mut w = cs.new_witness_filler();

--- a/crates/circuits/src/ecdsa/tests.rs
+++ b/crates/circuits/src/ecdsa/tests.rs
@@ -33,6 +33,8 @@ pub fn test_bitcoin_ecdsa_test_vector() {
 	};
 
 	let signature_valid = bitcoin_verify(&builder, pk, &z, &r, &s);
+	// Pin the validity flag, so the verification is constrained.
+	builder.force_commit(signature_valid);
 
 	let cs = builder.build();
 	let mut w = cs.new_witness_filler();

--- a/crates/circuits/src/keccak/permutation.rs
+++ b/crates/circuits/src/keccak/permutation.rs
@@ -224,6 +224,11 @@ mod tests {
 
 		let mut state_wires = input_wires;
 		circuit_fn(&builder, &mut state_wires);
+		// Pin the output state, which nothing else reads.
+		// Otherwise the whole component is dropped and the comparison checks uncomputed words.
+		for wire in state_wires {
+			builder.force_commit(wire);
+		}
 		let circuit = builder.build();
 
 		let mut expected_output = input_state;

--- a/crates/circuits/src/secp256k1/endosplit.rs
+++ b/crates/circuits/src/secp256k1/endosplit.rs
@@ -199,6 +199,13 @@ mod tests {
 			let (k1_neg, k2_neg, k1_abs, k2_abs) =
 				Secp256k1EndosplitHint::call(&builder, &k);
 
+			// Pin every output, so the split is constrained and not merely evaluated.
+			builder.force_commit(k1_neg);
+			builder.force_commit(k2_neg);
+			for &limb in k1_abs.iter().chain(&k2_abs) {
+				builder.force_commit(limb);
+			}
+
 			let circuit = builder.build();
 			let mut w = circuit.new_witness_filler();
 			circuit.populate_wire_witness(&mut w).unwrap();

--- a/crates/circuits/src/secp256k1/point.rs
+++ b/crates/circuits/src/secp256k1/point.rs
@@ -25,6 +25,17 @@ impl Secp256k1Affine {
 		}
 	}
 
+	/// Pins both coordinates and the infinity flag as committed.
+	///
+	/// A value nothing else reads is dropped as unread, so it is neither constrained nor computed.
+	/// Pinning a point makes it an output of the circuit in its own right.
+	pub fn force_commit(&self, b: &CircuitBuilder) {
+		for &limb in self.x.limbs.iter().chain(&self.y.limbs) {
+			b.force_commit(limb);
+		}
+		b.force_commit(self.is_point_at_infinity);
+	}
+
 	/// Generator basepoint.
 	pub fn generator(b: &CircuitBuilder) -> Self {
 		let (x, y) = coords_gen(b);

--- a/crates/circuits/src/secp256k1/tests.rs
+++ b/crates/circuits/src/secp256k1/tests.rs
@@ -27,6 +27,8 @@ fn test_secp256k1_group_order() {
 			acc = curve.add(&builder, &acc, &generator);
 		}
 	}
+	// Pin the accumulator, so the whole scalar ladder is constrained and not merely evaluated.
+	acc.force_commit(&builder);
 
 	let cs = builder.build();
 	let mut w = cs.new_witness_filler();
@@ -49,6 +51,8 @@ fn test_secp256k1_pow2pow137() {
 		acc = curve.double(&builder, &acc);
 		acc = curve.add(&builder, &generator, &acc);
 	}
+	// Pin the accumulator, so the whole ladder is constrained and not merely evaluated.
+	acc.force_commit(&builder);
 
 	let cs = builder.build();
 	let mut w = cs.new_witness_filler();
@@ -76,6 +80,9 @@ fn test_secp256k1_generator_double_and_add() {
 	let generator = Secp256k1Affine::generator(&builder);
 	let double = curve.double(&builder, &generator);
 	let triple = curve.add(&builder, &double, &generator);
+	// Pin both results, so the doubling and the addition are constrained.
+	double.force_commit(&builder);
+	triple.force_commit(&builder);
 
 	let cs = builder.build();
 	let mut w = cs.new_witness_filler();

--- a/crates/examples/snapshots/bitcoin_headers.snap
+++ b/crates/examples/snapshots/bitcoin_headers.snap
@@ -2,7 +2,7 @@ bitcoin_headers circuit
 --
 Gates & Instructions
 ├─ Number of gates: 47,258
-└─ Number of evaluation instructions: 47,378
+└─ Number of evaluation instructions: 46,302
 
 Constraints
 ├─ AND constraints: 20,221 used (61.7% of 2^15)

--- a/crates/examples/snapshots/bitcoin_p2pkh.snap
+++ b/crates/examples/snapshots/bitcoin_p2pkh.snap
@@ -2,7 +2,7 @@ bitcoin_p2pkh circuit
 --
 Gates & Instructions
 ├─ Number of gates: 150,957
-└─ Number of evaluation instructions: 178,391
+└─ Number of evaluation instructions: 165,000
 
 Constraints
 ├─ AND constraints: 113,587 used (86.7% of 2^17)

--- a/crates/examples/snapshots/blake3.snap
+++ b/crates/examples/snapshots/blake3.snap
@@ -2,7 +2,7 @@ blake3 circuit
 --
 Gates & Instructions
 ├─ Number of gates: 7,624
-└─ Number of evaluation instructions: 7,624
+└─ Number of evaluation instructions: 7,520
 
 Constraints
 ├─ AND constraints: 5,451 used (66.5% of 2^13)

--- a/crates/examples/snapshots/blake3_compress.snap
+++ b/crates/examples/snapshots/blake3_compress.snap
@@ -2,7 +2,7 @@ blake3_compress circuit
 --
 Gates & Instructions
 ├─ Number of gates: 6,336
-└─ Number of evaluation instructions: 6,336
+└─ Number of evaluation instructions: 0
 
 Constraints
 ├─ AND constraints: 0 used (0.0% of 2^0)

--- a/crates/examples/snapshots/ec_msm.snap
+++ b/crates/examples/snapshots/ec_msm.snap
@@ -2,7 +2,7 @@ ec_msm circuit
 --
 Gates & Instructions
 ├─ Number of gates: 208,914
-└─ Number of evaluation instructions: 246,270
+└─ Number of evaluation instructions: 226,510
 
 Constraints
 ├─ AND constraints: 158,253 used (60.4% of 2^18)

--- a/crates/examples/snapshots/ethsign.snap
+++ b/crates/examples/snapshots/ethsign.snap
@@ -2,7 +2,7 @@ ethsign circuit
 --
 Gates & Instructions
 ├─ Number of gates: 214,965
-└─ Number of evaluation instructions: 252,550
+└─ Number of evaluation instructions: 232,559
 
 Constraints
 ├─ AND constraints: 160,106 used (61.1% of 2^18)

--- a/crates/examples/snapshots/hashsign.snap
+++ b/crates/examples/snapshots/hashsign.snap
@@ -2,7 +2,7 @@ hashsign circuit
 --
 Gates & Instructions
 ├─ Number of gates: 408,450
-└─ Number of evaluation instructions: 409,098
+└─ Number of evaluation instructions: 400,087
 
 Constraints
 ├─ AND constraints: 297,991 used (56.8% of 2^19)

--- a/crates/examples/snapshots/keccak.snap
+++ b/crates/examples/snapshots/keccak.snap
@@ -2,7 +2,7 @@ keccak circuit
 --
 Gates & Instructions
 ├─ Number of gates: 22,189
-└─ Number of evaluation instructions: 22,189
+└─ Number of evaluation instructions: 22,107
 
 Constraints
 ├─ AND constraints: 5,750 used (70.2% of 2^13)

--- a/crates/examples/snapshots/sha256.snap
+++ b/crates/examples/snapshots/sha256.snap
@@ -2,7 +2,7 @@ sha256 circuit
 --
 Gates & Instructions
 ├─ Number of gates: 20,616
-└─ Number of evaluation instructions: 20,616
+└─ Number of evaluation instructions: 20,535
 
 Constraints
 ├─ AND constraints: 8,880 used (54.2% of 2^14)

--- a/crates/examples/snapshots/sha512.snap
+++ b/crates/examples/snapshots/sha512.snap
@@ -2,7 +2,7 @@ sha512 circuit
 --
 Gates & Instructions
 ├─ Number of gates: 24,839
-└─ Number of evaluation instructions: 24,839
+└─ Number of evaluation instructions: 24,758
 
 Constraints
 ├─ AND constraints: 10,311 used (62.9% of 2^14)

--- a/crates/examples/snapshots/zklogin.snap
+++ b/crates/examples/snapshots/zklogin.snap
@@ -2,7 +2,7 @@ zklogin circuit
 --
 Gates & Instructions
 ├─ Number of gates: 485,515
-└─ Number of evaluation instructions: 550,362
+└─ Number of evaluation instructions: 429,895
 
 Constraints
 ├─ AND constraints: 357,836 used (68.3% of 2^19)

--- a/crates/frontend/src/compiler/cse.rs
+++ b/crates/frontend/src/compiler/cse.rs
@@ -55,18 +55,23 @@ pub fn dedup_gates(
 	// Gate ids are collected up front so the graph can be mutated inside the loop.
 	let gate_ids: Vec<Gate> = graph.gates.keys().collect();
 	for gate in gate_ids {
-		// Hint gates carry their shape in the registry and are rarely duplicated, so skip them.
-		if matches!(graph.gate_data(gate).opcode, Opcode::Hint) {
-			continue;
-		}
-
 		// Rewrite this gate's wires to their canonical form.
 		// An input that fed an earlier duplicate is remapped.
 		// Output, aux, and scratch wires are never keys in the map, so they pass through unchanged.
+		//
+		// Every gate is rewritten, hints included.
+		// A collapsed duplicate no longer emits a constraint.
+		// So a reader left pointing at its output would read a wire nothing defines.
 		for wire in graph.gates[gate].wires.iter_mut() {
 			if let Some(&canon) = remap.get(wire) {
 				*wire = canon;
 			}
+		}
+
+		// Hint gates carry their shape in the registry and are rarely duplicated.
+		// So one is never collapsed, and never becomes a canonical target either.
+		if matches!(graph.gate_data(gate).opcode, Opcode::Hint) {
+			continue;
 		}
 
 		let hash = structural_hash(graph, gate, hint_registry);
@@ -147,8 +152,10 @@ fn structurally_equal(graph: &GateGraph, a: Gate, b: Gate, hint_registry: &HintR
 
 #[cfg(test)]
 mod tests {
+	use binius_core::word::Word;
+
 	use super::*;
-	use crate::compiler::gate_graph::GateGraph;
+	use crate::compiler::{gate_graph::GateGraph, hints::Hint};
 
 	#[test]
 	fn duplicate_and_gate_is_collapsed() {
@@ -183,6 +190,65 @@ mod tests {
 		// The reader now consumes the canonical output, not the dead duplicate's.
 		let reader_inputs = graph.gate_data(reader).gate_param().inputs.to_vec();
 		assert_eq!(reader_inputs, vec![o1], "reader must be redirected to the canonical wire");
+	}
+
+	#[test]
+	fn a_hint_reading_a_duplicate_is_redirected() {
+		// Invariant: every reader of a collapsed duplicate is rewritten onto the canonical wire,
+		// including a hint. A hint is never itself collapsed, but it still has to be rewritten:
+		// the duplicate stops emitting a constraint, so its output is defined by nothing.
+		//
+		// Fixture: two identical ANDs, with the duplicate's output feeding a hint.
+		//
+		//   g1: x & y -> o1   (canonical)
+		//   g2: x & y -> o2   (duplicate -> dead)
+		//   hint(o2)          -> must be rewritten to hint(o1)
+		struct IdentityHint;
+
+		impl Hint for IdentityHint {
+			const NAME: &'static str = "test::cse_identity";
+
+			fn shape(&self, _dimensions: &[usize]) -> (usize, usize) {
+				(1, 1)
+			}
+
+			fn execute(&self, _dimensions: &[usize], inputs: &[Word], outputs: &mut [Word]) {
+				outputs[0] = inputs[0];
+			}
+		}
+
+		let mut graph = GateGraph::new();
+		let root = graph.path_spec_tree.root();
+		let mut registry = HintRegistry::new();
+		let hint_id = registry.register(IdentityHint);
+
+		let x = graph.add_inout();
+		let y = graph.add_inout();
+
+		let o1 = graph.add_internal();
+		let g1 = graph.emit_gate(root, Opcode::Band, vec![x, y], vec![o1]);
+		let o2 = graph.add_internal();
+		let g2 = graph.emit_gate(root, Opcode::Band, vec![x, y], vec![o2]);
+
+		// The hint consumes the duplicate's output.
+		let hint_out = graph.add_internal();
+		let hint_gate = graph.emit_hint_gate(root, hint_id, &[], vec![o2], vec![hint_out]);
+
+		let dead = dedup_gates(&mut graph, &EntitySet::new(), &registry);
+
+		// The duplicate still collapses; a hint reader does not prevent that.
+		assert!(!dead.contains(g1));
+		assert!(dead.contains(g2));
+		// The hint is never collapsed itself.
+		assert!(!dead.contains(hint_gate));
+
+		// The hint now reads the canonical output, so it reads a wire a surviving gate defines.
+		let hint_inputs = graph
+			.gate_data(hint_gate)
+			.gate_param_with_registry(&registry)
+			.inputs
+			.to_vec();
+		assert_eq!(hint_inputs, vec![o1], "the hint must be redirected onto the canonical wire");
 	}
 
 	#[test]

--- a/crates/frontend/src/compiler/eval_form/mod.rs
+++ b/crates/frontend/src/compiler/eval_form/mod.rs
@@ -18,12 +18,12 @@ use binius_core::{ValueIndex, ValueVec, Word};
 use binius_utils::{rayon::prelude::*, strided_array::StridedArray2DViewMut};
 pub use builder::BytecodeBuilder;
 pub use const_eval::evaluate_gate_constants;
-use cranelift_entity::SecondaryMap;
+use cranelift_entity::{EntitySet, SecondaryMap};
 
 use crate::compiler::{
 	circuit::PopulateError,
 	gate,
-	gate_graph::{GateGraph, Wire},
+	gate_graph::{Gate, GateGraph, Wire},
 	hints::HintRegistry,
 	pathspec::PathSpecTree,
 };
@@ -44,10 +44,14 @@ impl EvalForm {
 	/// `hint_registry` already holds every hint the caller registered via
 	/// [`CircuitBuilder::call_hint`](crate::compiler::CircuitBuilder::call_hint); bytecode
 	/// emission only reads from it to resolve `Opcode::Hint` gates.
+	///
+	/// `evaluated` selects the gates to compile.
+	/// A gate left out writes only values that no remaining gate reads, so its slots stay zero.
 	pub(crate) fn build(
 		gate_graph: &GateGraph,
 		wire_mapping: &SecondaryMap<Wire, ValueIndex>,
 		hint_registry: HintRegistry,
+		evaluated: &EntitySet<Gate>,
 	) -> Self {
 		let mut builder = BytecodeBuilder::new();
 
@@ -60,11 +64,11 @@ impl EvalForm {
 			}
 		};
 
-		// Build bytecode for each gate
-		for (gate_id, data) in gate_graph.gates.iter() {
+		// Build bytecode for each gate that still has to be evaluated.
+		for gate_id in evaluated.iter() {
 			gate::emit_gate_bytecode(
 				gate_id,
-				data,
+				&gate_graph.gates[gate_id],
 				gate_graph,
 				&mut builder,
 				wire_to_reg,

--- a/crates/frontend/src/compiler/gate_fusion/tests/awhole.rs
+++ b/crates/frontend/src/compiler/gate_fusion/tests/awhole.rs
@@ -37,6 +37,9 @@ fn test_bmul_gate_end_to_end() {
 	let b_lo = builder.add_witness();
 	let b_hi = builder.add_witness();
 	let (c_lo, c_hi) = builder.bmul(a_lo, a_hi, b_lo, b_hi);
+	// Pin the product, so the BMUL constraint survives and the words are actually checked.
+	builder.force_commit(c_lo);
+	builder.force_commit(c_hi);
 	let circuit = builder.build();
 
 	let mut w = circuit.new_witness_filler();

--- a/crates/frontend/src/compiler/mod.rs
+++ b/crates/frontend/src/compiler/mod.rs
@@ -252,20 +252,37 @@ impl CircuitBuilder {
 			.enable_dead_code_elimination
 			.then(|| dce::live_gates(&mut graph, &shared.force_committed, &shared.hint_registry));
 
+		// Split the gates into the two sets the rest of compilation works from.
+		//
+		// A gate is redundant when either pass ruled it out:
+		// - a collapsed duplicate, whose outputs are now read through the canonical gate,
+		// - a gate no assertion and no observable wire transitively reads.
+		//
+		// Both kinds constrain only wires that nothing reads, so neither emits a constraint.
+		// Neither needs its value computed either, with one exception.
+		// An assertion writes no value, and its instruction is what reports a failing witness.
+		// So it is still evaluated even when its constraint is redundant.
+		let mut constrained_gates = EntitySet::new();
+		let mut evaluated_gates = EntitySet::new();
+		for (gate_id, data) in graph.gates.iter() {
+			let collapsed = dead_gates
+				.as_ref()
+				.is_some_and(|dead| dead.contains(gate_id));
+			let unread = live_gates
+				.as_ref()
+				.is_some_and(|live| !live.contains(gate_id));
+			let needed = !collapsed && !unread;
+
+			if needed {
+				constrained_gates.insert(gate_id);
+			}
+			if needed || data.shape(&shared.hint_registry).n_out == 0 {
+				evaluated_gates.insert(gate_id);
+			}
+		}
+
 		let mut builder = ConstraintBuilder::new();
-		for (gate_id, _) in graph.gates.iter() {
-			// Drop collapsed duplicates: their outputs are now read through the canonical gate.
-			if let Some(dead_gates) = &dead_gates
-				&& dead_gates.contains(gate_id)
-			{
-				continue;
-			}
-			// Drop dead gates: they would only add constraints on wires that nothing reads.
-			if let Some(live_gates) = &live_gates
-				&& !live_gates.contains(gate_id)
-			{
-				continue;
-			}
+		for gate_id in constrained_gates.iter() {
 			gate::constrain(gate_id, &graph, &mut builder);
 		}
 
@@ -354,7 +371,12 @@ impl CircuitBuilder {
 		}
 
 		// Build evaluation form (consumes the hint registry the user populated via call_hint).
-		let eval_form = eval_form::EvalForm::build(&graph, &wire_mapping, shared.hint_registry);
+		let eval_form = eval_form::EvalForm::build(
+			&graph,
+			&wire_mapping,
+			shared.hint_registry,
+			&evaluated_gates,
+		);
 
 		Circuit::new(graph, cs, wire_mapping, eval_form)
 	}

--- a/crates/frontend/src/compiler/tests.rs
+++ b/crates/frontend/src/compiler/tests.rs
@@ -89,6 +89,9 @@ fn test_iadd_cin_cout_max_values() {
 	let b = builder.add_constant_64(0xFFFFFFFFFFFFFFFF);
 	let cin_wire = builder.add_constant(Word::ZERO);
 	let (sum_wire, cout_wire) = builder.iadd_cin_cout(a, b, cin_wire);
+	// Pin both outputs, so the addition is constrained and not merely evaluated.
+	builder.force_commit(sum_wire);
+	builder.force_commit(cout_wire);
 
 	let circuit = builder.build();
 	let mut w = circuit.new_witness_filler();
@@ -106,6 +109,11 @@ fn test_iadd_cin_cout_zero() {
 	let b = builder.add_constant_64(0);
 	let cin_wire = builder.add_constant(Word::ZERO);
 	let (sum_wire, cout_wire) = builder.iadd_cin_cout(a, b, cin_wire);
+	// Pin both outputs.
+	// An all-zero value vector satisfies the assertions below, so without this the test would
+	// pass without the addition ever being checked.
+	builder.force_commit(sum_wire);
+	builder.force_commit(cout_wire);
 
 	let circuit = builder.build();
 	let mut w = circuit.new_witness_filler();
@@ -123,6 +131,9 @@ fn test_isub_bin_bout_from_zero() {
 	let b = builder.add_constant_64(u64::MAX);
 	let bin_wire = builder.add_constant(Word::ONE << 63);
 	let (diff_wire, bout_wire) = builder.isub_bin_bout(a, b, bin_wire);
+	// Pin both outputs, so the subtraction is constrained and not merely evaluated.
+	builder.force_commit(diff_wire);
+	builder.force_commit(bout_wire);
 
 	let circuit = builder.build();
 	let mut w = circuit.new_witness_filler();
@@ -180,6 +191,9 @@ fn test_call_hint_user_registered() {
 	let out2 = builder.call_hint(XorAllHint, &[inputs.len()], &inputs);
 	assert_eq!(out1.len(), 1);
 	assert_eq!(out2.len(), 1);
+	// Pin both hint outputs, so the hint gates are evaluated rather than dropped as unread.
+	builder.force_commit(out1[0]);
+	builder.force_commit(out2[0]);
 
 	let circuit = builder.build();
 	let mut w = circuit.new_witness_filler();
@@ -195,6 +209,8 @@ fn prop_check_icmp_ult(a: u64, b: u64, expected_result: Word) {
 	let a_wire = builder.add_constant_64(a);
 	let b_wire = builder.add_constant_64(b);
 	let result_wire = builder.icmp_ult(a_wire, b_wire);
+	// Pin the result, so the comparison is constrained and not merely evaluated.
+	builder.force_commit(result_wire);
 
 	let circuit = builder.build();
 	let mut w = circuit.new_witness_filler();
@@ -211,6 +227,8 @@ fn prop_check_icmp_eq(a: u64, b: u64, expected_result: Word) {
 	let a_wire = builder.add_constant_64(a);
 	let b_wire = builder.add_constant_64(b);
 	let result_wire = builder.icmp_eq(a_wire, b_wire);
+	// Pin the result, so the comparison is constrained and not merely evaluated.
+	builder.force_commit(result_wire);
 
 	let circuit = builder.build();
 	let mut w = circuit.new_witness_filler();
@@ -237,6 +255,11 @@ proptest! {
 		let a2_wire = builder.add_constant_64(a2);
 		let b2_wire = builder.add_constant_64(b2);
 		let (sum2_wire, cout2_wire) = builder.iadd_cin_cout(a2_wire, b2_wire, cout1_wire);
+		// Pin every value this test reads, so both additions are constrained.
+		builder.force_commit(sum1_wire);
+		builder.force_commit(cout1_wire);
+		builder.force_commit(sum2_wire);
+		builder.force_commit(cout2_wire);
 
 		let circuit = builder.build();
 		let mut w = circuit.new_witness_filler();
@@ -322,6 +345,8 @@ fn test_bxor_linear_constraint() {
 
 	// bxor internally creates a linear constraint
 	let c = builder.bxor(a, b);
+	// Pin the result, so its linear cone survives dead-code elimination.
+	builder.force_commit(c);
 
 	let circuit = builder.build();
 
@@ -355,6 +380,10 @@ fn test_shift_operations_with_linear_constraints() {
 	let shr_result = builder.shr(b, 16);
 	// Combine with XOR
 	let combined = builder.bxor(shl_result, shr_result);
+	// Pin every value this test reads, so each one is constrained rather than only evaluated.
+	builder.force_commit(shl_result);
+	builder.force_commit(shr_result);
+	builder.force_commit(combined);
 
 	let circuit = builder.build();
 
@@ -384,6 +413,11 @@ fn test_32bit_half_shift_operations() {
 	let srl32_result = builder.srl32(a, 4);
 	let sra32_result = builder.sra32(a, 4);
 	let rotr32_result = builder.rotr32(a, 4);
+	// Pin every result, so each lane-local shift is constrained rather than only evaluated.
+	builder.force_commit(sll32_result);
+	builder.force_commit(srl32_result);
+	builder.force_commit(sra32_result);
+	builder.force_commit(rotr32_result);
 
 	let circuit = builder.build();
 
@@ -426,6 +460,9 @@ fn test_rotr_operation_expansion() {
 	// rotr internally expands to: (a >> 12) XOR (a << 52)
 	let rotr_result = builder.rotr(a, 12);
 	let combined = builder.bxor(rotr_result, b);
+	// Pin both values this test reads, so each is constrained rather than only evaluated.
+	builder.force_commit(rotr_result);
+	builder.force_commit(combined);
 
 	let circuit = builder.build();
 
@@ -461,6 +498,10 @@ fn test_multiple_xor_operations() {
 	let result2 = builder.bxor(c, d);
 	// Chain XOR operations
 	let final_result = builder.bxor(result1, result2);
+	// Pin every intermediate this test reads, so each is constrained rather than only evaluated.
+	builder.force_commit(result1);
+	builder.force_commit(result2);
+	builder.force_commit(final_result);
 
 	let circuit = builder.build();
 
@@ -507,8 +548,15 @@ fn test_linear_constraint_conversion_to_and() {
 	let combined2 = builder.bxor(sar_result, rotr_result);
 	let final_result = builder.bxor(combined1, combined2);
 
-	// Pin the result as committed so its linear cone survives dead-code elimination.
-	// A computation read by nothing is otherwise dropped, leaving no AND constraint to check.
+	// Pin every value this test reads.
+	// A computation nothing reads is dropped, leaving no constraint and no instruction.
+	builder.force_commit(xor_result);
+	builder.force_commit(shift_left);
+	builder.force_commit(shift_right);
+	builder.force_commit(sar_result);
+	builder.force_commit(rotr_result);
+	builder.force_commit(combined1);
+	builder.force_commit(combined2);
 	builder.force_commit(final_result);
 
 	let circuit = builder.build();
@@ -566,6 +614,8 @@ proptest! {
 
 		// XOR the shifted values
 		let result = builder.bxor(shifted_a, shifted_b);
+		// Pin the result, so its linear cone survives dead-code elimination.
+		builder.force_commit(result);
 
 		let circuit = builder.build();
 		let mut w = circuit.new_witness_filler();
@@ -590,6 +640,8 @@ proptest! {
 
 		let wire_value = builder.add_constant_64(value);
 		let rotr_result = builder.rotr(wire_value, shift);
+		// Pin the result, so its linear cone survives dead-code elimination.
+		builder.force_commit(rotr_result);
 
 		let circuit = builder.build();
 		let mut w = circuit.new_witness_filler();


### PR DESCRIPTION
Closes [BINIUS-347](https://linear.app/jimpo/issue/BINIUS-347).

Two optimiser passes already delete redundant work from the constraints. The witness generator never heard about them, so every proof still computed values no constraint mentions. It does not any more — witness filling drops 21% on zklogin.

Also fixes a latent bug in the duplicate-collapsing pass that this change exposes.

### The problem

Compiling a circuit produces two artifacts:

- the constraints a proof checks,
- the instructions that fill in the witness.

Two clean-up passes run before the constraints are emitted.
One collapses duplicated work, the other drops work nothing reads.

Both fed the constraints only.
The instruction stream never heard about either.

The committed statistics showed it in plain sight — gate count and instruction count equal to the digit:

```
keccak:  Number of gates: 22,189
         Number of evaluation instructions: 22,189
```

If anything were being skipped, those two numbers would differ.

### The idea

Compute the dropped set once and hand it to both.

An assertion is the one exception.
It produces no value, so nothing reads it by definition.
Its instruction is the only thing that reports a failing witness, so it keeps running even when its constraint is redundant.

### Worked example

```
t1 = a & b          <- read by t3
t2 = a & b          <- duplicate of t1
t3 = t1 ^ c         <- read by the assertion
t4 = a & c          <- nothing reads it
assert t3 == out

before:  constraints t1, t3, assert           -> 3
         instructions t1, t2, t3, t4, assert  -> 5

after:   constraints t1, t3, assert           -> 3   (unchanged)
         instructions t1, t3, assert          -> 3
```

### A latent bug this exposes

The duplicate-collapsing pass rewrites every reader of a dropped value onto the surviving copy.
The early exit for hint gates sat **before** that rewrite rather than after it.

So a hint kept pointing at a wire whose defining gate no longer emits a constraint.

That is invisible today only because the dropped gate is still evaluated.
Stop evaluating it and the hint reads zero, and every circuit that divides or inverts fails to populate.

```diff
 for gate in gate_ids {
-    if matches!(graph.gate_data(gate).opcode, Opcode::Hint) { continue; }
-
     for wire in graph.gates[gate].wires.iter_mut() { /* canonicalise */ }
+
+    if matches!(graph.gate_data(gate).opcode, Opcode::Hint) { continue; }
```

Canonicalise every gate, then exclude hints from being collapse candidates.
That alone fixed 7 of the 12 remaining test failures, and has its own regression test.

### What the existing tests revealed

Around forty tests build a circuit, leave the result neither asserted nor committed, then read an intermediate value back out of the witness.

Several passed **for the wrong reason**.
One asserts a sum and a carry are both zero, which any all-zero buffer satisfies, and its constraint check ran against a system holding no constraint about those wires.

Each now pins what it inspects, so the value is constrained rather than merely computed.

### Soundness

Constraints, constants and the committed layout are untouched.
Only the instruction stream shrinks, and only by instructions writing values no constraint names.

The skipped set is closed under reading: any gate whose output a kept gate reads is itself kept, because the liveness pass marks the definer of every input of a live gate.

### Scope

- **frontend:** the dropped set is computed once and threaded into the evaluation form; the hint canonicalisation fix
- **circuits:** test sites pin what they inspect; a point type gains a method to pin a curve point
- **examples:** statistics snapshots refreshed, 11 of 13 changed

### Verification

- `cargo check --workspace --all-targets` — clean
- `clippy -p binius-frontend -p binius-circuits --all-targets --all-features -D warnings` — clean
- nightly `fmt --all --check` — clean
- `binius-frontend` 159 tests, `binius-circuits` 320 tests — pass
- all 13 circuit statistics snapshots re-blessed and re-checked

### Benchmark

Instructions removed, from the snapshot diff:

| circuit | before | after | saved | |
|---|---|---|---|---|
| blake3_compress | 6,336 | 0 | 6,336 | 100.0% |
| zklogin | 550,362 | 429,895 | 120,467 | 21.9% |
| ec_msm | 246,270 | 226,510 | 19,760 | 8.0% |
| ethsign | 252,550 | 232,559 | 19,991 | 7.9% |
| bitcoin_p2pkh | 178,391 | 165,000 | 13,391 | 7.5% |
| bitcoin_headers | 47,378 | 46,302 | 1,076 | 2.3% |
| hashsign | 409,098 | 400,087 | 9,011 | 2.2% |
| blake3 | 7,624 | 7,520 | 104 | 1.4% |
| sha256 | 20,616 | 20,535 | 81 | 0.4% |
| keccak | 22,189 | 22,107 | 82 | 0.4% |
| sha512 | 24,839 | 24,758 | 81 | 0.3% |
| **total** | **1,765,653** | **1,575,273** | **190,380** | **10.8%** |

Wall time, measuring `populate_wire_witness` alone, with the two core files reverted in place for the baseline:

| circuit | before | after | change |
|---|---|---|---|
| sha256 | 354.91 us | 354.10 us | no change (p = 0.07) |
| zklogin | 10.092 ms | 7.9854 ms | **-20.9%** (p = 0.00) |

Time tracks instruction count almost exactly.

Hand-written hash gadgets are already tight, so they barely move.
The win is in large composed circuits, where redundancy accumulates in the seams between gadgets — and those are the circuits where witness generation costs real time.

`blake3_compress` reaching zero is not caused by this change: that example already had **0 AND constraints** on main, since everything it computes is neither asserted nor committed. The change only makes its witness generation agree with its constraint system. Worth a follow-up to make that example prove something.

<details>
<summary>Benchmark source used to produce the timings</summary>

Not part of this change. Drop in as `crates/examples/benches/witness_fill.rs`, add a `[[bench]]` entry with `harness = false`, and run `cargo bench --bench witness_fill -p binius-examples`.

```rust
// Copyright 2026 The Binius Developers
//! Times witness filling alone, isolated from circuit construction and from the example's own
//! input preparation.
//!
//! Throwaway harness for measuring one change; not intended to be committed.

use binius_examples::{
	ExampleCircuit,
	circuits::{sha256::Sha256Example, zklogin::ZkLoginExample},
};
use binius_frontend::CircuitBuilder;
use clap::Parser;
use criterion::{Criterion, criterion_group, criterion_main};

/// Wraps an example's instance arguments so clap can supply their declared defaults.
#[derive(Parser)]
struct DefaultArgs<T: clap::Args> {
	#[command(flatten)]
	inner: T,
}

fn default_args<T: clap::Args>() -> T {
	DefaultArgs::<T>::parse_from(["bench"]).inner
}

/// Builds one example circuit, fills its inputs once, then times only the wire-witness pass.
fn bench_one<E: ExampleCircuit>(c: &mut Criterion, name: &str)
where
	E::Params: clap::Args,
	E::Instance: clap::Args + Clone,
{
	let mut builder = CircuitBuilder::new();
	let example = E::build(default_args::<E::Params>(), &mut builder).expect("circuit builds");
	let circuit = builder.build();

	// Input preparation is setup, not the measurement, so it happens once here.
	let mut filler = circuit.new_witness_filler();
	example
		.populate_witness(default_args::<E::Instance>(), &mut filler)
		.expect("inputs populate");

	// Filling is idempotent: it rewrites the constants and every derived value, leaving the
	// input rows alone. So one filler can be reused across iterations.
	circuit
		.populate_wire_witness(&mut filler)
		.expect("circuit is satisfiable");

	let mut group = c.benchmark_group("populate_wire_witness");
	group.bench_function(name, |b| {
		b.iter(|| circuit.populate_wire_witness(&mut filler).unwrap())
	});
	group.finish();
}

fn bench_witness_fill(c: &mut Criterion) {
	bench_one::<Sha256Example>(c, "sha256");
	bench_one::<ZkLoginExample>(c, "zklogin");
}

criterion_group!(benches, bench_witness_fill);
criterion_main!(benches);
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
