### PR TITLE
Drop the unused auxiliary wire from the subtraction gate

### DIFF
--- a/crates/examples/snapshots/bitcoin_headers.snap
+++ b/crates/examples/snapshots/bitcoin_headers.snap
@@ -26,5 +26,5 @@ Value Vector
 │  └─ Internal: 20,091
 ├─ Total Committed: 20,352 used (62.1% of 2^15)
 │  [▓▓▓▓▓▓░░░░] spare: 12,416
-└─ Scratch (uncommitted): 39,247 (peak live: 76)
+└─ Scratch (uncommitted): 39,237 (peak live: 76)
 

--- a/crates/examples/snapshots/bitcoin_p2pkh.snap
+++ b/crates/examples/snapshots/bitcoin_p2pkh.snap
@@ -26,5 +26,5 @@ Value Vector
 │  └─ Internal: 135,849
 ├─ Total Committed: 135,993 used (51.9% of 2^18)
 │  [▓▓▓▓▓░░░░░] spare: 126,151
-└─ Scratch (uncommitted): 141,609 (peak live: 109)
+└─ Scratch (uncommitted): 127,081 (peak live: 109)
 

--- a/crates/examples/snapshots/ec_msm.snap
+++ b/crates/examples/snapshots/ec_msm.snap
@@ -26,5 +26,5 @@ Value Vector
 │  └─ Internal: 188,287
 ├─ Total Committed: 188,339 used (71.8% of 2^18)
 │  [▓▓▓▓▓▓▓░░░] spare: 73,805
-└─ Scratch (uncommitted): 191,067 (peak live: 190)
+└─ Scratch (uncommitted): 170,883 (peak live: 190)
 

--- a/crates/examples/snapshots/ethsign.snap
+++ b/crates/examples/snapshots/ethsign.snap
@@ -26,5 +26,5 @@ Value Vector
 │  └─ Internal: 190,158
 ├─ Total Committed: 190,272 used (72.6% of 2^18)
 │  [▓▓▓▓▓▓▓░░░] spare: 71,872
-└─ Scratch (uncommitted): 195,586 (peak live: 192)
+└─ Scratch (uncommitted): 175,406 (peak live: 192)
 

--- a/crates/examples/snapshots/zklogin.snap
+++ b/crates/examples/snapshots/zklogin.snap
@@ -26,5 +26,5 @@ Value Vector
 │  └─ Internal: 357,965
 ├─ Total Committed: 360,378 used (68.7% of 2^19)
 │  [▓▓▓▓▓▓░░░░] spare: 163,910
-└─ Scratch (uncommitted): 399,081 (peak live: 1,543)
+└─ Scratch (uncommitted): 346,996 (peak live: 1,543)
 

--- a/crates/frontend/src/compiler/gate/isub_bin_bout.rs
+++ b/crates/frontend/src/compiler/gate/isub_bin_bout.rs
@@ -12,7 +12,7 @@ pub const fn shape() -> OpcodeShape {
 		const_in: &[Word::ALL_ONE],
 		n_in: 3,
 		n_out: 2,
-		n_aux: 1,
+		n_aux: 0,
 		n_scratch: 0,
 		n_imm: 0,
 	}


### PR DESCRIPTION
Every subtraction gate allocated a wire that nothing writes and nothing reads. Removing it drops 52,085 words from zklogin's per-instance witness buffer, with the constraint system unchanged.

### The problem

A gate declares its wire budget as a shape: constants, inputs, outputs, auxiliaries, scratch.

The subtraction gate declared one auxiliary:

```
const_in: &[Word::ALL_ONE],
n_in: 3,
n_out: 2,
n_aux: 1,      // never read
n_scratch: 0,
```

Neither emitter ever destructures that slot. The constraint emitter takes `constants, inputs, outputs`; the bytecode emitter takes `inputs, outputs`. The borrow-out it might plausibly have held is a declared **output**, not an auxiliary.

So each subtraction carried one internal wire that nothing writes and nothing reads. Referenced by no constraint, it landed in the scratch segment — which the batched witness buffer pays for once per instance.

Three gates in the whole frontend declare an auxiliary. The other two read theirs.

### Per gate

- **before:** 6 wires (1 constant, 3 in, 2 out) plus 1 dead auxiliary
- **after:** 6 wires

→ one scratch word per subtraction, gone.

### The change

```diff
-		n_aux: 1,
+		n_aux: 0,
```

### Verification that the mechanism is what it claims

The scratch reduction matches the subtraction count exactly, circuit by circuit:

| circuit | scratch before | after | saved | subtraction gates |
|---|---|---|---|---|
| zklogin | 399,081 | 346,996 | 52,085 | **52,085** |
| ec_msm | 191,067 | 170,883 | 20,184 | 20,184 |
| ethsign | 195,586 | 175,406 | 20,180 | **20,180** |
| bitcoin_p2pkh | 141,609 | 127,081 | 14,528 | 14,528 |
| bitcoin_headers | 39,247 | 39,237 | 10 | **10** |

One word per gate, to the digit.

The eight circuits that use no subtraction — the hashes among them — show no change at all, which is the other half of the same check.

### Soundness

The wire appeared in no constraint operand and in no committed section, so nothing the proof sees can move.

The snapshot diff confirms it: across all five changed files the **only** line that differs is the scratch count. Constraint counts, constants, public and committed sections are byte-identical.

### Scope

- **changed:** one field in the subtraction gate's shape
- **refreshed:** five circuit statistics snapshots
- **unchanged:** everything else — no emitter, constraint or test referenced the slot

### Verification

- `cargo check --workspace --all-targets` — clean
- `clippy -p binius-frontend --all-targets --all-features -D warnings` — clean
- nightly `fmt --all --check` — clean
- `binius-frontend` 158 tests, `binius-circuits` 320 tests — pass
- all 13 circuit statistics snapshots re-checked, 13/13 matching

🤖 Generated with [Claude Code](https://claude.com/claude-code)