### PR TITLE
Stop copying the constraint system to collect circuit statistics

### DIFF
--- a/crates/frontend/src/compiler/dump.rs
+++ b/crates/frontend/src/compiler/dump.rs
@@ -1,7 +1,10 @@
 // Copyright 2025 Irreducible Inc.
 use std::collections::{BTreeMap, BTreeSet};
 
+use serde::ser::SerializeStruct;
+
 use crate::compiler::{
+	gate::opcode::Opcode,
 	gate_graph::{Gate, GateGraph},
 	pathspec::PathSpec,
 };
@@ -28,10 +31,10 @@ impl PathSpecData {
 	}
 }
 
-#[derive(Clone, serde::Serialize)]
+#[derive(Clone)]
 struct GateBreakdown {
 	/// Shows how many opcodes of every type there is.
-	by_opcode: BTreeMap<String, usize>,
+	by_opcode: BTreeMap<Opcode, usize>,
 }
 
 impl GateBreakdown {
@@ -40,17 +43,37 @@ impl GateBreakdown {
 			by_opcode: BTreeMap::new(),
 		};
 		for gate in gates {
-			let opcode = format!("{:?}", gg.gates[*gate].opcode);
-			*breakdown.by_opcode.entry(opcode).or_insert(0) += 1;
+			*breakdown
+				.by_opcode
+				.entry(gg.gates[*gate].opcode)
+				.or_insert(0) += 1;
 		}
 		breakdown
 	}
 
 	fn merge(mut self, other: &GateBreakdown) -> GateBreakdown {
-		for (opcode, count) in &other.by_opcode {
-			*self.by_opcode.entry(opcode.clone()).or_insert(0) += count;
+		for (&opcode, count) in &other.by_opcode {
+			*self.by_opcode.entry(opcode).or_insert(0) += count;
 		}
 		self
+	}
+}
+
+impl serde::Serialize for GateBreakdown {
+	/// Serializes the counts under opcode names.
+	///
+	/// Names are rendered here rather than while counting.
+	/// So a circuit with a million gates names each opcode once, not once per gate.
+	fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+		let by_name: BTreeMap<String, usize> = self
+			.by_opcode
+			.iter()
+			.map(|(opcode, count)| (format!("{opcode:?}"), *count))
+			.collect();
+
+		let mut breakdown = serializer.serialize_struct("GateBreakdown", 1)?;
+		breakdown.serialize_field("by_opcode", &by_name)?;
+		breakdown.end()
 	}
 }
 
@@ -163,15 +186,22 @@ impl Cx {
 	/// Traverses the paths in the post order and computes the cumulative gate breakdowns for
 	/// each path.
 	fn compute_cum_breakdowns(&mut self) {
-		for &path_spec in &self.post_order {
-			let data = self.data.get(&path_spec).unwrap();
-			let mut cum_breakdown = data.breakdown.as_ref().unwrap().clone();
-			for &child in &data.children.clone() {
-				if let Some(child_cum) = self.data[&child].cum_breakdown.as_ref() {
+		// Children are visited before their parent, so each child total is ready when read.
+		for path_spec in self.post_order.clone() {
+			// The child list is taken out rather than copied, so the map can be read while
+			// accumulating and the list handed straight back.
+			let children = std::mem::take(&mut self.data.get_mut(&path_spec).unwrap().children);
+
+			let mut cum_breakdown = self.data[&path_spec].breakdown.as_ref().unwrap().clone();
+			for child in &children {
+				if let Some(child_cum) = self.data[child].cum_breakdown.as_ref() {
 					cum_breakdown = cum_breakdown.merge(child_cum);
 				}
 			}
-			self.data.get_mut(&path_spec).unwrap().cum_breakdown = Some(cum_breakdown);
+
+			let data = self.data.get_mut(&path_spec).unwrap();
+			data.children = children;
+			data.cum_breakdown = Some(cum_breakdown);
 		}
 	}
 

--- a/crates/frontend/src/stat.rs
+++ b/crates/frontend/src/stat.rs
@@ -79,24 +79,25 @@ pub struct CircuitStat {
 impl CircuitStat {
 	/// Creates a new `CircuitStat` instance by collecting statistics from the given circuit.
 	pub fn collect(circuit: &Circuit) -> Self {
-		// Clone the constraint system so we can prepare it
-		let mut cs = circuit.constraint_system().clone();
+		let cs = circuit.constraint_system();
 
-		// Store original counts before padding
+		// Counts as the circuit compiled them, before the prover pads anything.
 		let n_and_constraints = cs.n_and_constraints();
 		let n_imul_constraints = cs.n_imul_constraints();
 		let n_bmul_constraints = cs.n_bmul_constraints();
 		let (distinct_shifted_value_indices, distinct_unshifted_value_indices) =
-			traverse_constraint_system(&cs);
+			traverse_constraint_system(cs);
 
-		// validate_and_prepare will pad constraints to power of 2
-		cs.validate_and_prepare()
-			.expect("constraint system should be valid");
-
-		// Now we have the actual allocated sizes after padding
-		let and_allocated = cs.n_and_constraints();
-		let imul_allocated = cs.n_imul_constraints();
-		let bmul_allocated = cs.n_bmul_constraints();
+		// Sizes the prover pads each constraint set to before proving.
+		//
+		// - Every set is rounded up to a power of two.
+		// - Rounding up from zero gives one, so an empty AND set still occupies a single slot.
+		// - An empty multiply set instead stays at zero, letting its reduction be skipped whole.
+		let pad = |n: usize| n.next_power_of_two();
+		let pad_or_skip = |n: usize| if n == 0 { 0 } else { pad(n) };
+		let and_allocated = pad(n_and_constraints);
+		let imul_allocated = pad_or_skip(n_imul_constraints);
+		let bmul_allocated = pad_or_skip(n_bmul_constraints);
 
 		// The public section size is already determined by the layout
 		let n_const = cs.value_vec_layout.n_const;


### PR DESCRIPTION
Removes a deep copy of the whole constraint system, and a string allocation per gate, from the statistics and composition paths. Both outputs are byte-identical.

### The problem

Collecting circuit statistics cloned the entire constraint system, ran the prover's preparation step on the copy, then read back the padded lengths:

```rust
let mut cs = circuit.constraint_system().clone();   // every constraint, every operand
...
cs.validate_and_prepare().expect("...");            // pads each set to a power of two
let and_allocated = cs.n_and_constraints();
```

That is a full copy of the constraint system to learn two rounded numbers.

The composition dump had the same shape of problem. It counted gates into a map keyed by the opcode's formatted name:

```rust
let opcode = format!("{:?}", gg.gates[*gate].opcode);
*breakdown.by_opcode.entry(opcode).or_insert(0) += 1;
```

One short-lived `String` per gate, then one more per merge into a parent. A circuit with a million gates renders a million strings to end up with at most twenty distinct keys.

### The idea

The padding rule is arithmetic, so compute it:

- round each count up to a power of two;
- rounding up from zero gives one, so an empty AND set still occupies a single slot;
- an empty multiply set instead stays at zero, letting its reduction be skipped whole.

For the dump, key the map on the opcode itself — it is a copyable, ordered enum — and render names once, when the dump is serialized.

### The change

```diff
-let mut cs = circuit.constraint_system().clone();
-cs.validate_and_prepare().expect("constraint system should be valid");
-let and_allocated = cs.n_and_constraints();
+let pad = |n: usize| n.next_power_of_two();
+let pad_or_skip = |n: usize| if n == 0 { 0 } else { pad(n) };
+let and_allocated = pad(n_and_constraints);
```

```diff
-by_opcode: BTreeMap<String, usize>,
+by_opcode: BTreeMap<Opcode, usize>,
```

The cumulative pass also copied a node's child list on every iteration to dodge a borrow. It now takes the list out of the map and hands it straight back.

### Output is unchanged

Both the statistics text and the composition JSON were captured before and after, on sha256, keccak and zklogin, and compared byte for byte:

| circuit | `stat` | `composition` |
|---|---|---|
| sha256 | identical | identical |
| keccak | identical | identical |
| zklogin | identical | identical (2.1 MB) |

The JSON shape needed care. Keying the map on the opcode initially flattened away the `by_opcode` wrapper object, changing the schema. A hand-written serializer keeps the emitted shape exactly as it was and only moves where the names are rendered.

All 13 committed circuit statistics snapshots still match, unchanged.

### Scope

- **changed:** the padded-size computation; the dump's counting key and its serializer; one needless copy in the cumulative pass
- **unchanged:** every reported number, the JSON schema, and all 13 snapshots

Statistics collection no longer validates the constraint system as a side effect. That belongs to compilation, which already validates the layout when the circuit is built and the whole system under debug assertions.

### Verification

- `cargo check --workspace --all-targets` — clean
- `clippy -p binius-frontend --all-targets --all-features -D warnings` — clean
- nightly `fmt --all --check` — clean
- `binius-frontend` 158 tests, `binius-circuits` 320 tests — pass
- 13/13 circuit statistics snapshots match, with no re-blessing needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)