### PR TITLE
BINIUS-344: thread the prover's allocator through IOPProverChannel and pack_witness

### DIFF
--- a/crates/iop-prover/src/basefold/channel.rs
+++ b/crates/iop-prover/src/basefold/channel.rs
@@ -2,6 +2,8 @@
 
 //! BaseFold ZK implementation of the IOP prover channel.
 
+use std::ops::Deref;
+
 use binius_compute::Allocator;
 use binius_field::{BinaryField, PackedField};
 use binius_iop::{channel::OracleSpec, fri::FRIParams};
@@ -16,7 +18,7 @@ use binius_ip_prover::{
 	},
 };
 use binius_math::{
-	FieldBuffer, FieldSlice, FieldSliceMut,
+	FieldBuffer, FieldSlice, FieldSliceMut, FieldVec,
 	inner_product::inner_product_par,
 	line::{extrapolate_line, extrapolate_line_packed},
 	multilinear::eq::{eq_ind_partial_eval_scalars, eq_ind_zero},
@@ -55,11 +57,11 @@ struct CommittedOracleData<P: PackedField, C> {
 /// Each entry pairs a committed message with the transparent multilinear it is opened against.
 /// It also records which committed oracle it refers to.
 /// That index reconciles the arrival-order and oracle-index views of the batch.
-struct QueuedRelation<P: PackedField> {
+struct QueuedRelation<P: PackedField, Data: Deref<Target = [P]>> {
 	/// Index of the committed oracle this relation opens.
 	oracle_index: usize,
-	/// The committed multilinear message `pi_i`.
-	message: FieldBuffer<P>,
+	/// The committed multilinear message `pi_i`, backed by the caller's allocator.
+	message: FieldBuffer<P, Data>,
 	/// The transparent multilinear `t_i` paired with the message.
 	transparent: FieldBuffer<P>,
 	/// The claimed inner product `s_i = <pi_i, t_i>`.
@@ -81,12 +83,15 @@ struct QueuedRelation<P: PackedField> {
 /// - `P`: The packed field type with `Scalar = F`
 /// - `NTT`: The additive NTT for Reed-Solomon encoding
 /// - `Channel`: The Merkle channel carrying all prover interaction
-pub struct BaseFoldProverChannel<'a, F, P, NTT, Channel>
+/// - `A`: The allocator the queued messages are drawn from, and the one [`Self::finish`] runs the
+///   opening with
+pub struct BaseFoldProverChannel<'a, F, P, NTT, Channel, A>
 where
 	F: BinaryField,
 	P: PackedField<Scalar = F>,
 	NTT: AdditiveNTT<Field = F> + Sync,
 	Channel: MerkleIPProverChannel<F>,
+	A: Allocator,
 {
 	/// The Merkle channel carrying all prover interaction: field elements, challenges,
 	/// commitments, and openings.
@@ -98,17 +103,18 @@ where
 	committed_oracles: Vec<CommittedOracleData<P, Channel::Commitment>>,
 	/// Oracle relations queued by [`Self::prove_oracle_relations`], opened together in
 	/// [`Self::finish`].
-	queue: Vec<QueuedRelation<P>>,
+	queue: Vec<QueuedRelation<P, A::Vec<P>>>,
 	next_oracle_index: usize,
 	rng: StdRng,
 }
 
-impl<'a, F, P, NTT, Channel> BaseFoldProverChannel<'a, F, P, NTT, Channel>
+impl<'a, F, P, NTT, Channel, A> BaseFoldProverChannel<'a, F, P, NTT, Channel, A>
 where
 	F: BinaryField,
 	P: PackedField<Scalar = F>,
 	NTT: AdditiveNTT<Field = F> + Sync,
 	Channel: MerkleIPProverChannel<F>,
+	A: Allocator,
 {
 	/// Creates a new BaseFold ZK prover channel over a Merkle channel from precomputed FRI
 	/// parameters.
@@ -143,7 +149,7 @@ where
 	/// (in oracle-index order). Mirrors [`BaseFoldVerifierChannel::finish`].
 	///
 	/// [`BaseFoldVerifierChannel::finish`]: binius_iop::basefold::channel::BaseFoldVerifierChannel::finish
-	pub fn finish<A: Allocator>(self, alloc: &A) {
+	pub fn finish(self, alloc: &A) {
 		let Self {
 			mut channel,
 			ntt,
@@ -194,7 +200,7 @@ fn prove_batch_zk_basefold<A, F, P, NTT, Channel>(
 	oracle_specs: &[OracleSpec],
 	fri_params: &FRIParams<F>,
 	committed_oracles: Vec<CommittedOracleData<P, Channel::Commitment>>,
-	relations: Vec<QueuedRelation<P>>,
+	relations: Vec<QueuedRelation<P, A::Vec<P>>>,
 	alloc: &A,
 ) where
 	A: Allocator,
@@ -251,7 +257,11 @@ fn prove_batch_zk_basefold<A, F, P, NTT, Channel>(
 	// B keyed by oracle index, and pad each prover to `max_n`. `prover_oracle_indices` records the
 	// oracle index behind each (arrival-order) prover so the reduced evals can be scattered back
 	// into oracle-index order.
-	let mut witness_primes = vec![None; n_committed];
+	// Built element by element rather than with `vec![None; n]`, which needs `Clone`:
+	// `Allocator::Vec<T>` declares no `Clone` bound. Adding one would be the wrong fix — `PoolVec`
+	// does implement `Clone`, but by drawing a fresh block from the pool, so a `Clone` bound would
+	// make `vec![buffer; n]` quietly allocate `n` blocks.
+	let mut witness_primes = (0..n_committed).map(|_| None).collect::<Vec<_>>();
 	let mut prover_oracle_indices = Vec::with_capacity(n_committed);
 	let relations = relations
 		.into_iter()
@@ -444,12 +454,14 @@ fn accumulate_scaled_buffer<P: PackedField>(
 	}
 }
 
-impl<'a, F, P, NTT, Channel> IPProverChannel<F> for BaseFoldProverChannel<'a, F, P, NTT, Channel>
+impl<'a, F, P, NTT, Channel, A> IPProverChannel<F>
+	for BaseFoldProverChannel<'a, F, P, NTT, Channel, A>
 where
 	F: BinaryField,
 	P: PackedField<Scalar = F>,
 	NTT: AdditiveNTT<Field = F> + Sync,
 	Channel: MerkleIPProverChannel<F>,
+	A: Allocator,
 {
 	fn send_one(&mut self, elem: F) {
 		self.channel.send_one(elem);
@@ -472,12 +484,14 @@ where
 	}
 }
 
-impl<'a, F, P, NTT, Channel> IOPProverChannel<P> for BaseFoldProverChannel<'a, F, P, NTT, Channel>
+impl<'a, F, P, NTT, Channel, A> IOPProverChannel<P, A>
+	for BaseFoldProverChannel<'a, F, P, NTT, Channel, A>
 where
 	F: BinaryField,
 	P: PackedField<Scalar = F>,
 	NTT: AdditiveNTT<Field = F> + Sync,
 	Channel: MerkleIPProverChannel<F>,
+	A: Allocator,
 {
 	type Oracle = BaseFoldOracle;
 
@@ -538,7 +552,7 @@ where
 	fn prove_oracle_relations(
 		&mut self,
 		oracle_relations: impl IntoIterator<
-			Item = (Self::Oracle, FieldBuffer<P>, FieldBuffer<P>, P::Scalar),
+			Item = (Self::Oracle, FieldVec<P, A>, FieldBuffer<P>, P::Scalar),
 		>,
 	) {
 		// Queue the relations; the actual opening (masking + sumcheck + combined FRI) happens once,
@@ -652,7 +666,7 @@ mod tests {
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 		let prover_rng = StdRng::seed_from_u64(1);
 		let mut prover_channel = prover_compiler
-			.create_channel_from_transcript::<StdHashSuite, StdChallenger, _>(
+			.create_channel_from_transcript::<StdHashSuite, StdChallenger, _, _>(
 				&mut prover_transcript,
 				prover_rng,
 			);
@@ -724,7 +738,7 @@ mod tests {
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 		let prover_rng = StdRng::seed_from_u64(1);
 		let mut prover_channel = prover_compiler
-			.create_channel_from_transcript::<StdHashSuite, StdChallenger, _>(
+			.create_channel_from_transcript::<StdHashSuite, StdChallenger, _, _>(
 				&mut prover_transcript,
 				prover_rng,
 			);
@@ -807,7 +821,7 @@ mod tests {
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 		let prover_rng = StdRng::seed_from_u64(1);
 		let mut prover_channel = prover_compiler
-			.create_channel_from_transcript::<StdHashSuite, StdChallenger, _>(
+			.create_channel_from_transcript::<StdHashSuite, StdChallenger, _, _>(
 				&mut prover_transcript,
 				prover_rng,
 			);
@@ -903,7 +917,7 @@ mod tests {
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 		let prover_rng = StdRng::seed_from_u64(1);
 		let mut prover_channel = prover_compiler
-			.create_channel_from_transcript::<StdHashSuite, StdChallenger, _>(
+			.create_channel_from_transcript::<StdHashSuite, StdChallenger, _, _>(
 				&mut prover_transcript,
 				prover_rng,
 			);

--- a/crates/iop-prover/src/basefold/compiler.rs
+++ b/crates/iop-prover/src/basefold/compiler.rs
@@ -4,6 +4,7 @@
 
 use std::{borrow::BorrowMut, marker::PhantomData};
 
+use binius_compute::Allocator;
 use binius_field::{BinaryField, PackedField};
 use binius_hash::binary_merkle_tree::HashSuite;
 use binius_iop::{
@@ -120,13 +121,14 @@ where
 	/// oracles with this compiler's NTT, oracle specs, and combined FRI parameters. The caller
 	/// constructs the Merkle channel, so it decides how commitments are produced. The `rng` is used
 	/// to seed an internal `StdRng` for mask generation.
-	pub fn create_channel<Channel>(
+	pub fn create_channel<Channel, A>(
 		&self,
 		channel: Channel,
 		rng: impl Rng,
-	) -> BaseFoldProverChannel<'_, F, P, NTT, Channel>
+	) -> BaseFoldProverChannel<'_, F, P, NTT, Channel, A>
 	where
 		Channel: MerkleIPProverChannel<F>,
+		A: Allocator,
 	{
 		BaseFoldProverChannel::new(
 			channel,
@@ -148,12 +150,13 @@ where
 	/// Panics if any configured oracle is ZK.
 	/// A ZK oracle would draw its mask from the fixed seed, which destroys the hiding property.
 	/// So this constructor refuses to build a channel that could mask deterministically.
-	pub fn create_channel_without_zk<Channel>(
+	pub fn create_channel_without_zk<Channel, A>(
 		&self,
 		channel: Channel,
-	) -> BaseFoldProverChannel<'_, F, P, NTT, Channel>
+	) -> BaseFoldProverChannel<'_, F, P, NTT, Channel, A>
 	where
 		Channel: MerkleIPProverChannel<F>,
+		A: Allocator,
 	{
 		// A ZK oracle masks with the RNG, so a fixed seed here would silently break hiding.
 		assert!(
@@ -170,16 +173,17 @@ where
 	/// The transcript (owned or mutably borrowed) is wrapped in a
 	/// [`ProverMerkleTranscriptChannel`] with a non-hiding Merkle tree prover for the given hash
 	/// suite, then passed to [`Self::create_channel`].
-	pub fn create_channel_from_transcript<H, Challenger_, T>(
+	pub fn create_channel_from_transcript<H, Challenger_, T, A>(
 		&self,
 		transcript: T,
 		rng: impl Rng,
-	) -> BaseFoldProverChannel<'_, F, P, NTT, ProverMerkleTranscriptChannel<T, Challenger_, F, H>>
+	) -> BaseFoldProverChannel<'_, F, P, NTT, ProverMerkleTranscriptChannel<T, Challenger_, F, H>, A>
 	where
 		H: HashSuite,
 		Challenger_: Challenger,
 		T: BorrowMut<ProverTranscript<Challenger_>>,
 		Output<H::LeafHash>: SerializeBytes,
+		A: Allocator,
 	{
 		self.create_channel(ProverMerkleTranscriptChannel::new(transcript), rng)
 	}
@@ -188,15 +192,16 @@ where
 	///
 	/// The transcript handling matches [`Self::create_channel_from_transcript`]; the channel is
 	/// built with [`Self::create_channel_without_zk`] and panics under the same conditions.
-	pub fn create_channel_without_zk_from_transcript<H, Challenger_, T>(
+	pub fn create_channel_without_zk_from_transcript<H, Challenger_, T, A>(
 		&self,
 		transcript: T,
-	) -> BaseFoldProverChannel<'_, F, P, NTT, ProverMerkleTranscriptChannel<T, Challenger_, F, H>>
+	) -> BaseFoldProverChannel<'_, F, P, NTT, ProverMerkleTranscriptChannel<T, Challenger_, F, H>, A>
 	where
 		H: HashSuite,
 		Challenger_: Challenger,
 		T: BorrowMut<ProverTranscript<Challenger_>>,
 		Output<H::LeafHash>: SerializeBytes,
+		A: Allocator,
 	{
 		self.create_channel_without_zk(ProverMerkleTranscriptChannel::new(transcript))
 	}

--- a/crates/iop-prover/src/channel/mod.rs
+++ b/crates/iop-prover/src/channel/mod.rs
@@ -4,10 +4,11 @@
 
 pub mod naive;
 
+use binius_compute::Allocator;
 use binius_field::PackedField;
 use binius_iop::channel::OracleSpec;
 use binius_ip_prover::channel::IPProverChannel;
-use binius_math::{FieldBuffer, FieldSlice};
+use binius_math::{FieldBuffer, FieldSlice, FieldVec};
 
 /// Channel for IOP provers that extends the IP prover channel with oracle operations.
 ///
@@ -22,7 +23,7 @@ use binius_math::{FieldBuffer, FieldSlice};
 /// The caller must call `send_oracle()` exactly `remaining_oracle_specs().len()` times before
 /// calling `prove_oracle_relations()`. Each oracle buffer must match the corresponding
 /// specification.
-pub trait IOPProverChannel<P: PackedField>: IPProverChannel<P::Scalar> {
+pub trait IOPProverChannel<P: PackedField, A: Allocator>: IPProverChannel<P::Scalar> {
 	type Oracle: Clone;
 
 	/// Returns the specifications for the remaining oracles to be committed.
@@ -44,6 +45,11 @@ pub trait IOPProverChannel<P: PackedField>: IPProverChannel<P::Scalar> {
 	/// the same buffer that was passed to `send_oracle()` for this oracle. Callers provide
 	/// the message here so the channel does not need to store it internally.
 	///
+	/// The channel owns each message until the opening runs, so the message is drawn from the
+	/// caller's allocator `A` — a pooled message stays pooled all the way through the opening.
+	/// The transparent multilinear is `Vec`-backed: every producer of one builds it from a
+	/// `binius-math` tensor expansion that takes no allocator.
+	///
 	/// # Preconditions
 	///
 	/// * `remaining_oracle_specs()` must be empty (all oracles committed).
@@ -53,7 +59,7 @@ pub trait IOPProverChannel<P: PackedField>: IPProverChannel<P::Scalar> {
 	fn prove_oracle_relations(
 		&mut self,
 		oracle_relations: impl IntoIterator<
-			Item = (Self::Oracle, FieldBuffer<P>, FieldBuffer<P>, P::Scalar),
+			Item = (Self::Oracle, FieldVec<P, A>, FieldBuffer<P>, P::Scalar),
 		>,
 	);
 }

--- a/crates/iop-prover/src/channel/naive.rs
+++ b/crates/iop-prover/src/channel/naive.rs
@@ -2,6 +2,7 @@
 
 //! Naive [`IOPProverChannel`] for testing: writes full polynomials instead of using FRI.
 
+use binius_compute::GlobalAllocator;
 use binius_field::{Field, PackedField};
 use binius_iop::channel::OracleSpec;
 use binius_ip_prover::channel::IPProverChannel;
@@ -107,7 +108,11 @@ where
 	}
 }
 
-impl<F, P, Challenger_> IOPProverChannel<P> for NaiveProverChannel<'_, F, Challenger_>
+// Pinned to [`GlobalAllocator`], whose `Vec<P>` is a plain `Vec<P>`: this channel writes every
+// buffer straight to the transcript and never draws from a pool, so being generic over the
+// allocator would only force call sites to name one.
+impl<F, P, Challenger_> IOPProverChannel<P, GlobalAllocator>
+	for NaiveProverChannel<'_, F, Challenger_>
 where
 	F: Field,
 	P: PackedField<Scalar = F>,

--- a/crates/iop-prover/src/logup_star.rs
+++ b/crates/iop-prover/src/logup_star.rs
@@ -72,7 +72,7 @@ pub fn prove<F, P, Channel, A>(
 where
 	F: BinaryField<Underlier: Divisible<u64>>,
 	P: PackedField<Scalar = F>,
-	Channel: IOPProverChannel<P>,
+	Channel: IOPProverChannel<P, A>,
 	A: Allocator,
 {
 	let m = table.log_len();
@@ -83,7 +83,7 @@ where
 	//     gamma^j * eq_{r_j} = the per-looker scaled numerators
 	//     Y = sum_j gamma^j * (I_j)_* eq_{r_j}     the combined pushforward
 	let gamma = channel.sample();
-	let (numerators, pushforward) = witness::combined_lookers::<F, P>(lookers, gamma, m);
+	let (numerators, pushforward) = witness::combined_lookers::<A, F, P>(alloc, lookers, gamma, m);
 
 	// Commit Y before the reduction, so the logUp challenge binds the commitment.
 	let oracle = tracing::debug_span!("Commit pushforward")
@@ -406,7 +406,7 @@ mod tests {
 		let mut prover_transcript = ProverTranscript::new(Chal::default());
 		let prover_channel_rng = StdRng::seed_from_u64(8);
 		let mut prover_channel = prover_compiler
-			.create_channel_from_transcript::<StdHashSuite, Chal, _>(
+			.create_channel_from_transcript::<StdHashSuite, Chal, _, _>(
 				&mut prover_transcript,
 				prover_channel_rng,
 			);

--- a/crates/iop-prover/src/logup_star.rs
+++ b/crates/iop-prover/src/logup_star.rs
@@ -103,7 +103,7 @@ where
 		lookers,
 		combined_eval_claim,
 		numerators,
-		&pushforward,
+		pushforward.to_ref(),
 		channel,
 	);
 

--- a/crates/ip-prover/src/logup_star/final_layer.rs
+++ b/crates/ip-prover/src/logup_star/final_layer.rs
@@ -16,7 +16,7 @@
 use binius_compute::{Allocator, VecLike};
 use binius_field::{Field, PackedField};
 use binius_math::{
-	FieldBuffer, FieldVec, inner_product::inner_product_par, line::extrapolate_line,
+	FieldBuffer, FieldSlice, FieldVec, inner_product::inner_product_par, line::extrapolate_line,
 };
 
 use crate::{
@@ -81,7 +81,7 @@ pub fn prove_final_layer<'a, A, F, P>(
 	eval_claim: F,
 	table_prover: FracAddCheckProver<'a, A, P>,
 	layer1: FracEvalClaim<F>,
-	pushforward: &FieldBuffer<P>,
+	pushforward: FieldSlice<P>,
 	table: &FieldBuffer<P>,
 	channel: &mut impl IPProverChannel<F>,
 ) -> FinalLayerOutput<F>
@@ -121,7 +121,7 @@ where
 	// halves T_0, T_1 are pushed as new columns. Only Y_0 is needed here, to form e_0; e_1 follows
 	// as e - e_0.
 	let [y_0, _y_1] = split_halves(alloc, pushforward);
-	let [t_0, t_1] = split_halves(alloc, table);
+	let [t_0, t_1] = split_halves(alloc, table.to_ref());
 
 	// e_0 is the first half's product sum.
 	// Only e_0 is sent, since the verifier recovers e_1 = e - e_0.
@@ -178,7 +178,7 @@ where
 /// The low half fixes the highest variable to 0, the high half to 1.
 fn split_halves<A: Allocator, P: PackedField>(
 	alloc: &A,
-	buffer: &FieldBuffer<P>,
+	buffer: FieldSlice<P>,
 ) -> [FieldVec<P, A>; 2] {
 	// split_half_ref borrows the two halves; copy each straight into an allocator buffer for the
 	// sub-provers, so the split is a single copy rather than a `Vec` build followed by a pooled

--- a/crates/ip-prover/src/logup_star/prove.rs
+++ b/crates/ip-prover/src/logup_star/prove.rs
@@ -5,7 +5,7 @@
 use binius_compute::Allocator;
 use binius_field::{BinaryField, Divisible, Field, PackedField};
 use binius_ip::{MultilinearEvalClaim, logup_star::LogupOutput};
-use binius_math::{FieldBuffer, univariate::evaluate_univariate};
+use binius_math::{FieldBuffer, FieldSlice, univariate::evaluate_univariate};
 use binius_utils::{checked_arithmetics::log2_ceil_usize, rayon::prelude::*};
 
 use super::{
@@ -106,7 +106,15 @@ where
 
 	// The self-contained prover commits nothing.
 	// It runs the reduction over the witnesses directly.
-	prove_reduction(alloc, table, lookers, combined_eval_claim, numerators, &pushforward, channel)
+	prove_reduction(
+		alloc,
+		table,
+		lookers,
+		combined_eval_claim,
+		numerators,
+		pushforward.to_ref(),
+		channel,
+	)
 }
 
 /// Run the logUp* reduction over the pre-built witnesses `numerators` and pushforward `Y`.
@@ -145,7 +153,7 @@ pub fn prove_reduction<A, F, P>(
 	lookers: &[Looker<'_, F>],
 	eval_claim: F,
 	numerators: Vec<FieldBuffer<P>>,
-	pushforward: &FieldBuffer<P>,
+	pushforward: FieldSlice<P>,
 	channel: &mut impl IPProverChannel<F>,
 ) -> LogupOutput<F>
 where
@@ -181,7 +189,7 @@ where
 		.unzip();
 	let table_den = witness::table_denominator::<A, F, P>(alloc, c, m);
 	let (table_prover, table_root) =
-		FracAddCheckProver::new(m, alloc, (pooled_copy(alloc, pushforward), table_den));
+		FracAddCheckProver::new(m, alloc, (pooled_copy(alloc, &pushforward), table_den));
 	let num_r = table_root.0.get(0);
 	let den_r = table_root.1.get(0);
 

--- a/crates/ip-prover/src/logup_star/prove.rs
+++ b/crates/ip-prover/src/logup_star/prove.rs
@@ -95,7 +95,7 @@ where
 	//     gamma^j * eq_{r_j} = the per-looker scaled numerators
 	//     Y = sum_j gamma^j * (I_j)_* eq_{r_j}     the combined pushforward
 	let gamma = channel.sample();
-	let (numerators, pushforward) = witness::combined_lookers::<F, P>(lookers, gamma, m);
+	let (numerators, pushforward) = witness::combined_lookers::<A, F, P>(alloc, lookers, gamma, m);
 
 	// The product check binds <T, Y> to the gamma-combination of the looker claims.
 	let claims = lookers

--- a/crates/ip-prover/src/logup_star/witness.rs
+++ b/crates/ip-prover/src/logup_star/witness.rs
@@ -29,6 +29,10 @@ use super::prove::Looker;
 ///     Y = sum_j gamma^j * (I_j)_* eq_{r_j}
 /// ```
 ///
+/// The combined pushforward is drawn from `alloc`: a committing caller hands it to the channel,
+/// which owns it until the opening runs. The per-looker numerators stay `Vec`-backed — they are
+/// consumed by the reduction in this crate and never cross a channel boundary.
+///
 /// # Preconditions
 ///
 /// * `lookers` is non-empty, every looker has the same evaluation point length `n`, every index
@@ -39,12 +43,14 @@ use super::prove::Looker;
 	name = "Build logup* witnesses",
 	fields(n_lookers = lookers.len(), table_n_vars)
 )]
-pub fn combined_lookers<F, P>(
+pub fn combined_lookers<A, F, P>(
+	alloc: &A,
 	lookers: &[Looker<'_, F>],
 	gamma: F,
 	table_n_vars: usize,
-) -> (Vec<FieldBuffer<P>>, FieldBuffer<P>)
+) -> (Vec<FieldBuffer<P>>, FieldVec<P, A>)
 where
+	A: Allocator,
 	F: Field,
 	P: PackedField<Scalar = F>,
 {
@@ -91,7 +97,7 @@ where
 		.collect::<Vec<_>>();
 
 	// Scatter every looker's numerator onto the shared table cube, summed into one buffer.
-	let combined = combined_pushforward::<F, P>(&numerators, lookers, table_n_vars);
+	let combined = combined_pushforward::<A, F, P>(alloc, &numerators, lookers, table_n_vars);
 
 	(numerators, combined)
 }
@@ -124,12 +130,14 @@ where
 /// * `numerators` and `lookers` have equal length.
 /// * Each numerator has one entry per row of its looker's index column.
 /// * Every index entry is less than `2^table_n_vars`.
-fn combined_pushforward<F, P>(
+fn combined_pushforward<A, F, P>(
+	alloc: &A,
 	numerators: &[FieldBuffer<P>],
 	lookers: &[Looker<'_, F>],
 	table_n_vars: usize,
-) -> FieldBuffer<P>
+) -> FieldVec<P, A>
 where
+	A: Allocator,
 	F: Field,
 	P: PackedField<Scalar = F>,
 {
@@ -169,7 +177,7 @@ where
 	}
 
 	// Repack the merged scalar accumulator into the packed table buffer.
-	FieldBuffer::from_values(&buckets)
+	FieldBuffer::from_values_in(alloc, &buckets)
 }
 
 /// Scatter-add one looker's numerator onto the table accumulator in row order.
@@ -391,7 +399,7 @@ mod tests {
 			})
 			.collect::<Vec<_>>();
 
-		let got = combined_pushforward::<F, P>(&numerators, &lookers, m)
+		let got = combined_pushforward::<_, F, P>(&GlobalAllocator, &numerators, &lookers, m)
 			.iter_scalars()
 			.collect::<Vec<_>>();
 		assert_eq!(got, combined_reference(&numerators, &indices, m));

--- a/crates/m4-prover/src/prove.rs
+++ b/crates/m4-prover/src/prove.rs
@@ -353,7 +353,7 @@ impl IOPProver {
 			// The point is `r_j || r_rho || r_y`.
 			// Its instance coordinates fold the trace at `r_rho`.
 			let trace_point = [r_j, r_rho.as_slice(), r_y].concat();
-			ring_switch::prove(&trace_packed, &trace_point, channel)
+			ring_switch::prove(trace_packed.to_ref(), &trace_point, channel)
 		};
 
 		// Queue the trace opening against the ring-switch's transparent multilinear.

--- a/crates/m4-prover/src/prove.rs
+++ b/crates/m4-prover/src/prove.rs
@@ -112,7 +112,7 @@ impl IOPProver {
 	pub fn prove<P, Channel, A>(&self, table: &ValueTable, channel: &mut Channel, alloc: &A)
 	where
 		P: PackedField<Scalar = B128>,
-		Channel: IOPProverChannel<P>,
+		Channel: IOPProverChannel<P, A>,
 		A: Allocator,
 	{
 		let cs = &self.cs;
@@ -120,7 +120,7 @@ impl IOPProver {
 		// Pack the 2-D table into one multilinear and commit it as the trace oracle.
 		let trace_packed = {
 			let _scope = tracing::debug_span!("Prepare trace").entered();
-			table.pack::<P>()
+			table.pack::<P, _>(alloc)
 		};
 		let trace_oracle = {
 			let _scope = tracing::debug_span!("Commit trace").entered();
@@ -429,7 +429,9 @@ where
 	{
 		let mut channel = self
 			.basefold_compiler
-			.create_channel_without_zk_from_transcript::<StdHashSuite, Challenger_, _>(transcript);
+			.create_channel_without_zk_from_transcript::<StdHashSuite, Challenger_, _, _>(
+				transcript,
+			);
 
 		// Working buffers for this proof are drawn from the prover's pool, recycling blocks freed
 		// by earlier proofs.
@@ -644,7 +646,7 @@ impl RerandomizedOperations<'_> {
 	) -> (Vec<B128>, OperatorData<B128>, OperatorData<B128>, OperatorData<B128>)
 	where
 		P: PackedField<Scalar = B128>,
-		Channel: IOPProverChannel<P>,
+		Channel: IOPProverChannel<P, A>,
 		A: Allocator,
 	{
 		let _scope = tracing::debug_span!("Re-randomize instances").entered();

--- a/crates/m4-prover/src/value_table.rs
+++ b/crates/m4-prover/src/value_table.rs
@@ -2,6 +2,7 @@
 
 use std::ops::{Index, IndexMut};
 
+use binius_compute::Allocator;
 use binius_core::{
 	constraint_system::{ValueVec, ValueVecLayout},
 	word::Word,
@@ -9,7 +10,7 @@ use binius_core::{
 use binius_field::PackedField;
 use binius_frontend::{BatchPopulateError, Circuit, Wire};
 use binius_m4_verifier::BatchCommitLayout;
-use binius_math::FieldBuffer;
+use binius_math::FieldVec;
 use binius_utils::strided_array::StridedArray2DViewMut;
 use binius_verifier::config::B128;
 
@@ -280,14 +281,16 @@ impl ValueTable {
 	/// The element sequence is zero-padded up to the committed element count.
 	/// The instance index occupies the low coordinates, the hidden-word index the high coordinates.
 	/// Only the hidden segment is committed; the shared constants are not part of the oracle.
-	pub fn pack<P>(&self) -> FieldBuffer<P>
+	/// The packed buffer is drawn from `alloc`.
+	pub fn pack<P, A>(&self, alloc: &A) -> FieldVec<P, A>
 	where
 		P: PackedField<Scalar = B128>,
+		A: Allocator,
 	{
 		// The stored buffer is already the committed word sequence, wire-major.
 		// The base packer zero-pads it up to `2^log_witness_elems` elements.
 		let layout = self.commit_layout();
-		binius_prover::pack_witness::<P>(layout.log_witness_elems, self.as_words())
+		binius_prover::pack_witness::<P, A>(alloc, layout.log_witness_elems, self.as_words())
 			.expect("the hidden buffer fits in 2^log_witness_elems field elements by construction")
 	}
 }
@@ -319,6 +322,7 @@ impl IndexMut<Wire> for BatchWitnessFiller<'_, '_> {
 
 #[cfg(test)]
 mod tests {
+	use binius_compute::GlobalAllocator;
 	use binius_core::verify::verify_constraints;
 	use binius_field::PackedBinaryGhash1x128b;
 	use binius_frontend::{CircuitBuilder, Wire};
@@ -590,7 +594,10 @@ mod tests {
 		.unwrap();
 
 		let layout = table.commit_layout();
-		let packed: Vec<B128> = table.pack::<P>().iter_scalars().collect();
+		let packed: Vec<B128> = table
+			.pack::<P, _>(&GlobalAllocator)
+			.iter_scalars()
+			.collect();
 
 		// The committed scalars are the wire-major buffer taken two little-endian words per
 		// element. Indices past the stored words are the commitment's zero padding.

--- a/crates/prover/benches/intmul.rs
+++ b/crates/prover/benches/intmul.rs
@@ -123,7 +123,7 @@ fn bench_intmul_prove(c: &mut Criterion) {
 			bencher.iter_batched_ref(
 				|| {
 					let channel = compiler
-						.create_channel_without_zk_from_transcript::<StdHashSuite, StdChallenger, _>(
+						.create_channel_without_zk_from_transcript::<StdHashSuite, StdChallenger, _, _>(
 							ProverTranscript::default(),
 						);
 					(Some(witness.clone()), channel)
@@ -145,7 +145,7 @@ fn bench_intmul_prove(c: &mut Criterion) {
 			bencher.iter_batched_ref(
 				|| {
 					compiler
-						.create_channel_without_zk_from_transcript::<StdHashSuite, StdChallenger, _>(
+						.create_channel_without_zk_from_transcript::<StdHashSuite, StdChallenger, _, _>(
 							ProverTranscript::default(),
 						)
 				},
@@ -294,7 +294,7 @@ fn bench_intmul_phases(c: &mut Criterion) {
 		bencher.iter_batched_ref(
 			|| {
 				compiler
-					.create_channel_without_zk_from_transcript::<StdHashSuite, StdChallenger, _>(
+					.create_channel_without_zk_from_transcript::<StdHashSuite, StdChallenger, _, _>(
 						ProverTranscript::default(),
 					)
 			},

--- a/crates/prover/src/protocols/intmul/prove.rs
+++ b/crates/prover/src/protocols/intmul/prove.rs
@@ -67,7 +67,7 @@ where
 	A: Allocator,
 	F: BinaryField<Underlier: Divisible<u64>>,
 	P: PackedField<Scalar = F>,
-	Channel: IOPProverChannel<P>,
+	Channel: IOPProverChannel<P, A>,
 {
 	let [a, b, lo, hi] = columns;
 
@@ -105,7 +105,7 @@ where
 	A: Allocator,
 	F: BinaryField<Underlier: Divisible<u64>>,
 	P: PackedField<Scalar = F>,
-	Channel: IOPProverChannel<P>,
+	Channel: IOPProverChannel<P, A>,
 {
 	/// Prove an integer multiplication statement.
 	///

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -13,7 +13,7 @@ use binius_hash::binary_merkle_tree::HashSuite;
 use binius_iop_prover::{basefold::compiler::BaseFoldProverCompiler, channel::IOPProverChannel};
 use binius_ip::sumcheck::SumcheckOutput;
 use binius_math::{
-	BinarySubspace, FieldBuffer,
+	BinarySubspace, FieldBuffer, FieldVec,
 	inner_product::inner_product,
 	ntt::{NeighborsLastMultiThread, domain_context::GenericPreExpanded},
 	univariate::lagrange_evals,
@@ -94,7 +94,7 @@ impl IOPProver {
 	where
 		A: Allocator,
 		P: PackedField<Scalar = B128>,
-		Channel: IOPProverChannel<P>,
+		Channel: IOPProverChannel<P, A>,
 	{
 		let cs = &self.constraint_system;
 
@@ -103,13 +103,20 @@ impl IOPProver {
 		// Only the non-public words are committed as the trace oracle; the public segment is a
 		// verifier-known polynomial.
 		let setup_guard = tracing::debug_span!("Prepare witness").entered();
-		let witness_packed = pack_witness::<P>(self.log_witness_elems, witness.non_public())?;
+		let witness_packed =
+			pack_witness::<P, _>(alloc, self.log_witness_elems, witness.non_public())?;
 		drop(setup_guard);
 
-		// Observe the public input as B128 elements (includes it in Fiat-Shamir).
-		let public_packed =
-			pack_witness::<P>(self.log_public_words - LOG_WORDS_PER_ELEM, witness.public())?;
-		let public_elems = public_packed.iter_scalars().collect::<Vec<_>>();
+		// Observe the public input as B128 elements (includes it in Fiat-Shamir). The packed buffer
+		// is a temporary of this statement, so its pool block is returned immediately rather than
+		// held for the rest of the proof.
+		let public_elems = pack_witness::<P, _>(
+			alloc,
+			self.log_public_words - LOG_WORDS_PER_ELEM,
+			witness.public(),
+		)?
+		.iter_scalars()
+		.collect::<Vec<_>>();
 		channel.observe_many(&public_elems);
 
 		// [phase] Witness Commit - witness generation and commitment
@@ -443,7 +450,7 @@ where
 		// oracle is non-ZK, so no masks are drawn and the rng is never consumed.
 		let mut channel = self
 			.basefold_compiler
-			.create_channel_without_zk_from_transcript::<H, Challenger_, _>(transcript);
+			.create_channel_without_zk_from_transcript::<H, Challenger_, _, _>(transcript);
 		// Working buffers for this proof are drawn from the prover's pool, recycling blocks freed
 		// by earlier proofs. The pool is passed as an `&BufferPool` allocator.
 		let alloc = &self.pool;
@@ -461,6 +468,7 @@ where
 ///
 /// # Arguments
 ///
+/// - `alloc`: the allocator the packed buffer is drawn from.
 /// - `log_witness_elems`: base-2 logarithm of the committed field-element count.
 /// - `witness`: the committed witness words, in value-vector order.
 ///
@@ -471,10 +479,11 @@ where
 /// # Errors
 ///
 /// Returns an error when the words do not fit in `2^log_witness_elems` field elements.
-pub fn pack_witness<P: PackedField<Scalar = B128>>(
+pub fn pack_witness<P: PackedField<Scalar = B128>, A: Allocator>(
+	alloc: &A,
 	log_witness_elems: usize,
 	witness: &[Word],
-) -> Result<FieldBuffer<P>, Error> {
+) -> Result<FieldVec<P, A>, Error> {
 	// The number of field elements that constitute the packed witness.
 	let n_witness_elems = witness.len().div_ceil(1 << LOG_WORDS_PER_ELEM);
 	if n_witness_elems > 1 << log_witness_elems {
@@ -485,23 +494,34 @@ pub fn pack_witness<P: PackedField<Scalar = B128>>(
 	}
 
 	let len = 1 << log_witness_elems.saturating_sub(P::LOG_WIDTH);
-	let mut padded_witness_elems = Vec::<P>::with_capacity(len);
+	let mut padded_witness_elems = alloc.alloc::<P>(len);
 
 	// Pack word pairs into B128 elements (2 words per field element), then group into P.
 	// Zero-pad up to the power-of-two witness polynomial length after the real words.
 	let (pairs, word_remaining) = witness.as_chunks::<2>();
 	let aligned_len = pairs.len() / P::WIDTH * P::WIDTH;
 	let (pairs_aligned, word_pair_remaining) = pairs.split_at(aligned_len);
-	pairs_aligned
-		.par_chunks(P::WIDTH)
-		.map(|word_pairs| {
-			P::from_scalars(
+	// `collect_into_vec` needs a `&mut Vec`, which the generic buffer is not, so the aligned groups
+	// are written straight into the buffer's spare capacity instead.
+	let n_aligned_elems = aligned_len / P::WIDTH;
+	(
+		pairs_aligned.par_chunks(P::WIDTH),
+		padded_witness_elems.spare_capacity_mut()[..n_aligned_elems].par_iter_mut(),
+	)
+		.into_par_iter()
+		.for_each(|(word_pairs, out)| {
+			out.write(P::from_scalars(
 				word_pairs
 					.iter()
 					.map(|[w0, w1]| B128::new(((w1.0 as u128) << 64) | (w0.0 as u128))),
-			)
-		})
-		.collect_into_vec(&mut padded_witness_elems);
+			));
+		});
+	// Safety: `aligned_len` is an exact multiple of `P::WIDTH`, so the chunk iterator yields
+	// exactly `n_aligned_elems` items — the same length as the spare-capacity slice it is zipped
+	// with. That equal length is what makes this sound: rayon's zip silently truncates to the
+	// shorter side, so a mismatch would leave slots uninitialized. With the lengths equal, the loop
+	// above writes each of the first `n_aligned_elems` slots exactly once.
+	unsafe { padded_witness_elems.set_len(n_aligned_elems) };
 
 	// The trailing partial group: any leftover word pairs (fewer than `P::WIDTH` of them) together
 	// with a final unpaired word are packed into a single `P` element. This keeps the zero padding
@@ -564,6 +584,7 @@ where
 
 #[cfg(test)]
 mod tests {
+	use binius_compute::GlobalAllocator;
 	use binius_field::{Field, PackedBinaryGhash2x128b};
 
 	use super::{B128, Word, pack_witness};
@@ -593,7 +614,7 @@ mod tests {
 		let words: Vec<Word> = (1..=7u64).map(Word).collect();
 		let log_witness_elems = 3; // 8 field elements: 4 real, 4 zero-padding.
 
-		let packed = pack_witness::<P>(log_witness_elems, &words).unwrap();
+		let packed = pack_witness::<P, _>(&GlobalAllocator, log_witness_elems, &words).unwrap();
 		let got: Vec<B128> = packed.iter_scalars().collect();
 
 		assert_eq!(got, expected_scalars(&words, 1 << log_witness_elems));
@@ -611,7 +632,7 @@ mod tests {
 			// Round up to a power of two, and to at least one full packed element.
 			let log_witness_elems = n_elems.max(P::WIDTH).next_power_of_two().ilog2() as usize;
 
-			let packed = pack_witness::<P>(log_witness_elems, &words).unwrap();
+			let packed = pack_witness::<P, _>(&GlobalAllocator, log_witness_elems, &words).unwrap();
 			let got: Vec<B128> = packed.iter_scalars().collect();
 
 			assert_eq!(

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -308,7 +308,7 @@ impl IOPProver {
 		let ring_switch::RingSwitchOutput {
 			rs_eq_ind,
 			sumcheck_claim,
-		} = ring_switch::prove(&witness_packed, witness_point, &mut *channel);
+		} = ring_switch::prove(witness_packed.to_ref(), witness_point, &mut *channel);
 
 		// Prove oracle relations via channel (runs BaseFold internally). The intmul pushforward
 		// relation, when the IntMul reduction ran, was already queued inside phase 5.

--- a/crates/prover/src/ring_switch.rs
+++ b/crates/prover/src/ring_switch.rs
@@ -13,7 +13,7 @@ use binius_field::{
 };
 use binius_ip_prover::channel::IPProverChannel;
 use binius_math::{
-	FieldBuffer, inner_product::inner_product, multilinear::eq::eq_ind_partial_eval,
+	FieldBuffer, FieldSlice, inner_product::inner_product, multilinear::eq::eq_ind_partial_eval,
 	tensor_algebra::TensorAlgebra,
 };
 use binius_utils::{
@@ -303,7 +303,7 @@ pub struct RingSwitchOutput<P: PackedField> {
 /// * `packed_witness.log_len() + log_packing == eval_point.len()` where log_packing is the base-2
 ///   log of the extension degree of B128 over B1 (= 7)
 pub fn prove<P, Channel>(
-	packed_witness: &FieldBuffer<P>,
+	packed_witness: FieldSlice<P>,
 	eval_point: &[B128],
 	channel: &mut Channel,
 ) -> RingSwitchOutput<P>
@@ -321,7 +321,7 @@ where
 
 	// Ring-switching partial evaluations (Method of Four Russians)
 	let s_hat_v = tracing::debug_span!("Compute ring-switching partial evaluations")
-		.in_scope(|| fold_1b_rows_for_b128(packed_witness, &suffix_tensor));
+		.in_scope(|| fold_1b_rows_for_b128(&packed_witness, &suffix_tensor));
 	channel.send_many(s_hat_v.as_ref());
 
 	// Basis transpose

--- a/crates/prover/src/zk_config.rs
+++ b/crates/prover/src/zk_config.rs
@@ -143,7 +143,7 @@ where
 		// Create BaseFold prover channel and wrap with outer prover.
 		let basefold_channel = self
 			.basefold_compiler
-			.create_channel_from_transcript::<H, Challenger_, _>(transcript, &mut rng);
+			.create_channel_from_transcript::<H, Challenger_, _, _>(transcript, &mut rng);
 		let mut wrapped_channel = ZKWrappedProverChannel::new(
 			basefold_channel,
 			&self.outer_iop_prover,

--- a/crates/spartan-prover/src/lib.rs
+++ b/crates/spartan-prover/src/lib.rs
@@ -37,7 +37,7 @@ use std::{
 	ops::Deref,
 };
 
-use binius_compute::{Allocator, BufferPool};
+use binius_compute::{Allocator, BufferPool, VecLike};
 use binius_field::{BinaryField, Field, PackedField};
 use binius_hash::binary_merkle_tree::HashSuite;
 use binius_iop_prover::{basefold::compiler::BaseFoldProverCompiler, channel::IOPProverChannel};
@@ -46,7 +46,7 @@ use binius_ip_prover::{
 	sumcheck::{quadratic_mlecheck_prover, zk_mlecheck},
 };
 use binius_math::{
-	FieldBuffer, FieldSlice,
+	FieldBuffer, FieldSlice, FieldVec,
 	multilinear::eq::eq_ind_partial_eval,
 	ntt::{NeighborsLastMultiThread, domain_context::GenericPreExpanded},
 	univariate::evaluate_univariate,
@@ -60,11 +60,7 @@ use binius_spartan_verifier::{
 	wiring::evaluate_wiring_mle_public,
 };
 use binius_transcript::{ProverTranscript, fiat_shamir::Challenger};
-use binius_utils::{
-	SerializeBytes,
-	checked_arithmetics::checked_log_2,
-	rayon::{self, prelude::*},
-};
+use binius_utils::{SerializeBytes, checked_arithmetics::checked_log_2, rayon::prelude::*};
 use digest::Output;
 pub use error::*;
 use itertools::chain;
@@ -135,16 +131,18 @@ impl<F: Field> IOPProver<F> {
 	/// buffer must be passed into `prove`. Callers that wrap the IOP (e.g. the ZK wrapper) can
 	/// invoke this separately so the precommit oracle handle is available before the rest of
 	/// the protocol runs.
-	pub fn commit_precommit<P, Channel>(
+	pub fn commit_precommit<P, Channel, A>(
 		&self,
 		witness: &Witness<F>,
 		rng: &mut impl CryptoRng,
 		channel: &mut Channel,
-	) -> (Channel::Oracle, FieldBuffer<P>)
+		alloc: &A,
+	) -> (Channel::Oracle, FieldVec<P, A>)
 	where
 		F: BinaryField,
 		P: PackedField<Scalar = F>,
-		Channel: IOPProverChannel<P>,
+		Channel: IOPProverChannel<P, A>,
+		A: Allocator,
 	{
 		let cs = &self.constraint_system;
 		// Precommit segment has no dummy mul-constraint blinding (see ConstraintSystemPadded).
@@ -152,7 +150,8 @@ impl<F: Field> IOPProver<F> {
 			n_dummy_wires: cs.blinding_info().n_dummy_wires,
 			n_dummy_constraints: 0,
 		};
-		let precommit_packed = pack_and_blind_witness::<_, P>(
+		let precommit_packed = pack_and_blind_witness::<_, _, P>(
+			alloc,
 			cs.log_precommit() as usize,
 			witness.precommit(),
 			cs.n_precommit() as usize,
@@ -181,7 +180,7 @@ impl<F: Field> IOPProver<F> {
 		&self,
 		witness: Witness<F>,
 		precommit_oracle: Channel::Oracle,
-		precommit_packed: FieldBuffer<P>,
+		precommit_packed: FieldVec<P, A>,
 		mut rng: impl CryptoRng,
 		channel: &mut Channel,
 		alloc: &A,
@@ -189,7 +188,7 @@ impl<F: Field> IOPProver<F> {
 	where
 		F: BinaryField,
 		P: PackedField<Scalar = F>,
-		Channel: IOPProverChannel<P>,
+		Channel: IOPProverChannel<P, A>,
 		A: Allocator,
 	{
 		let _prove_guard =
@@ -240,19 +239,23 @@ impl<F: Field> IOPProver<F> {
 		let mask_degree = 2; // quadratic composition
 		let log_masks_buffer_size = m_n + m_d;
 
-		let masks_buffer = FieldBuffer::<P>::new(
-			log_masks_buffer_size,
-			repeat_with(|| P::random(&mut rng))
-				.take(1 << log_masks_buffer_size.saturating_sub(P::LOG_WIDTH))
-				.collect(),
-		);
+		let masks_buffer = {
+			// Growing a pooled buffer past the block it was handed would reallocate and free that
+			// block at the element's alignment rather than the pool's, so the fill below takes
+			// exactly the allocated count.
+			let packed_len = 1 << log_masks_buffer_size.saturating_sub(P::LOG_WIDTH);
+			let mut values = alloc.alloc::<P>(packed_len);
+			values.extend(repeat_with(|| P::random(&mut rng)).take(packed_len));
+			FieldBuffer::new(log_masks_buffer_size, values)
+		};
 
 		let mulcheck_mask =
 			zk_mlecheck::Mask::new(log_mul_constraints, mask_degree, masks_buffer.to_ref());
 
 		// Pack private witness into field elements and add blinding
 		let blinding_info = cs.blinding_info();
-		let private_packed = pack_and_blind_witness::<_, P>(
+		let private_packed = pack_and_blind_witness::<_, _, P>(
+			alloc,
 			cs.log_private() as usize,
 			witness.private(),
 			cs.n_private() as usize,
@@ -393,13 +396,13 @@ where
 		// and delegate to the IOP prover.
 		let mut channel = self
 			.basefold_compiler
-			.create_channel_from_transcript::<H, Challenger_, _>(transcript, &mut rng);
+			.create_channel_from_transcript::<H, Challenger_, _, _>(transcript, &mut rng);
 		// Working buffers for this proof are drawn from the prover's pool, recycling blocks freed
 		// by earlier proofs.
 		let alloc = &self.pool;
 		let (precommit_oracle, precommit_packed) =
 			self.iop_prover
-				.commit_precommit::<P, _>(&witness, &mut rng, &mut channel);
+				.commit_precommit::<P, _, _>(&witness, &mut rng, &mut channel, &alloc);
 		// The IOP prover only queues the oracle relations; `finish` runs the single combined
 		// opening.
 		self.iop_prover.prove::<P, _, _>(
@@ -473,29 +476,37 @@ where
 }
 
 /// Packs witness values into a [`FieldBuffer`] and adds blinding values for dummy wires.
-fn pack_and_blind_witness<F: Field, P: PackedField<Scalar = F>>(
+fn pack_and_blind_witness<A: Allocator, F: Field, P: PackedField<Scalar = F>>(
+	alloc: &A,
 	log_private: usize,
 	private: &[F],
 	n_private: usize,
 	blinding_info: &BlindingInfo,
 	mut rng: impl CryptoRng,
-) -> FieldBuffer<P> {
-	let packed = if log_private < P::LOG_WIDTH {
+) -> FieldVec<P, A> {
+	// Growing a pooled buffer past the block it was handed would reallocate and free that block at
+	// the element's alignment rather than the pool's, so the fill below must fit exactly.
+	let packed_len = 1 << log_private.saturating_sub(P::LOG_WIDTH);
+	let mut packed = alloc.alloc::<P>(packed_len);
+	if log_private < P::LOG_WIDTH {
+		// The whole segment lives in one packed element's low lanes.
+		debug_assert_eq!(packed_len, 1);
 		let elems_iter = private.iter().copied();
 		let zeros_iter = repeat_n(F::ZERO, (1 << log_private) - private.len());
 
-		let elems = P::from_scalars(chain!(elems_iter, zeros_iter));
-		vec![elems]
+		packed.push(P::from_scalars(chain!(elems_iter, zeros_iter)));
 	} else {
-		let packed_len = 1 << (log_private - P::LOG_WIDTH);
-
-		let elems_iter = private
+		// Zero the block once, then overwrite the prefix holding real scalars. The zip stops at the
+		// last real chunk, so the zero tail is the padding the buffer wants anyway. Collecting into
+		// a `Vec` first and copying that in would cost a second allocation and a full memcpy — the
+		// very thing pooling is here to remove.
+		debug_assert!(private.len() <= 1 << log_private);
+		packed.resize(packed_len, P::zero());
+		private
 			.par_chunks(P::WIDTH)
-			.map(|chunk| P::from_scalars(chunk.iter().copied()));
-		let zeros_iter = rayon::iter::repeat_n(P::zero(), packed_len - elems_iter.len());
-
-		elems_iter.chain(zeros_iter).collect::<Vec<_>>()
-	};
+			.zip(packed.par_iter_mut())
+			.for_each(|(chunk, out)| *out = P::from_scalars(chunk.iter().copied()));
+	}
 
 	let mut buffer = FieldBuffer::new(log_private, packed);
 

--- a/crates/spartan-prover/src/wrapper/zk_wrapped_prover_channel.rs
+++ b/crates/spartan-prover/src/wrapper/zk_wrapped_prover_channel.rs
@@ -22,7 +22,7 @@ use binius_iop_prover::{
 	merkle_channel::MerkleIPProverChannel,
 };
 use binius_ip_prover::channel::IPProverChannel;
-use binius_math::{FieldBuffer, FieldSlice, ntt::AdditiveNTT};
+use binius_math::{FieldBuffer, FieldSlice, FieldVec, ntt::AdditiveNTT};
 use binius_spartan_frontend::constraint_system::{BlindingInfo, WitnessLayout};
 use binius_spartan_verifier::IOPVerifier;
 use rand::CryptoRng;
@@ -45,8 +45,9 @@ where
 	P: PackedField<Scalar: BinaryField>,
 	NTT: AdditiveNTT<Field = P::Scalar> + Sync,
 	Channel: MerkleIPProverChannel<P::Scalar>,
+	A: Allocator,
 {
-	inner_channel: BaseFoldProverChannel<'a, P::Scalar, P, NTT, Channel>,
+	inner_channel: BaseFoldProverChannel<'a, P::Scalar, P, NTT, Channel, A>,
 	outer_prover: &'a IOPProver<P::Scalar>,
 	/// Allocator for the outer proof's working buffers, borrowed from the owning prover so it
 	/// outlives this per-proof channel. Used in [`Self::finish`].
@@ -61,7 +62,7 @@ where
 	/// outer encrypted transcript (to be wired up in a follow-up; for now the outer circuit has
 	/// no precommit wires that reference it).
 	precommit_oracle: BaseFoldOracle,
-	precommit_packed: FieldBuffer<P>,
+	precommit_packed: FieldVec<P, A>,
 	/// Number of outer oracles still to be committed on `inner_channel` during `finish` (the
 	/// outer prover's non-precommit oracles — private and mask).
 	n_outer_suffix_oracles: usize,
@@ -73,6 +74,7 @@ where
 	P: PackedField<Scalar = F>,
 	NTT: AdditiveNTT<Field = F> + Sync,
 	Channel: MerkleIPProverChannel<F>,
+	A: Allocator,
 {
 	/// Creates a new ZK-wrapped prover channel.
 	///
@@ -95,7 +97,7 @@ where
 	/// * `replay_fn` - Closure called during [`finish`](Self::finish) with a [`ReplayChannel`] to
 	///   replay the inner verification and fill the outer witness
 	pub fn new(
-		mut inner_channel: BaseFoldProverChannel<'a, F, P, NTT, Channel>,
+		mut inner_channel: BaseFoldProverChannel<'a, F, P, NTT, Channel, A>,
 		outer_prover: &'a IOPProver<F>,
 		outer_layout: Arc<WitnessLayout<F>>,
 		alloc: &'a A,
@@ -124,7 +126,7 @@ where
 
 		let (keys, precommit_oracle, precommit_packed) = {
 			let _scope = tracing::debug_span!("Commit Transcript Mask").entered();
-			Self::commit_transcript_mask(&mut inner_channel, outer_prover, rng)
+			Self::commit_transcript_mask(&mut inner_channel, outer_prover, alloc, rng)
 		};
 
 		Self {
@@ -147,10 +149,11 @@ where
 	/// inner verifier) contains a matching precommit wire per key that the outer proof uses to
 	/// decrypt.
 	fn commit_transcript_mask(
-		inner_channel: &mut BaseFoldProverChannel<'a, F, P, NTT, Channel>,
+		inner_channel: &mut BaseFoldProverChannel<'a, F, P, NTT, Channel, A>,
 		outer_prover: &IOPProver<F>,
+		alloc: &A,
 		mut rng: impl CryptoRng,
-	) -> (Vec<F>, BaseFoldOracle, FieldBuffer<P>) {
+	) -> (Vec<F>, BaseFoldOracle, FieldVec<P, A>) {
 		let cs = outer_prover.constraint_system();
 		let keys = repeat_with(|| F::random(&mut rng))
 			.take(cs.n_precommit() as usize)
@@ -161,7 +164,8 @@ where
 			n_dummy_wires: cs.blinding_info().n_dummy_wires,
 			n_dummy_constraints: 0,
 		};
-		let precommit_packed = pack_and_blind_witness::<_, P>(
+		let precommit_packed = pack_and_blind_witness::<_, _, P>(
+			alloc,
 			cs.log_precommit() as usize,
 			&keys,
 			cs.n_precommit() as usize,
@@ -188,7 +192,6 @@ where
 	pub fn finish(self, rng: impl CryptoRng) -> Result<(), Error>
 	where
 		ReplayFn: FnOnce(&mut ReplayChannel<F>),
-		A: Allocator,
 	{
 		let Self {
 			mut inner_channel,
@@ -236,6 +239,7 @@ where
 	P: PackedField<Scalar = F>,
 	NTT: AdditiveNTT<Field = F> + Sync,
 	Channel: MerkleIPProverChannel<F>,
+	A: Allocator,
 {
 	fn send_one(&mut self, elem: F) {
 		let key = self.next_key();
@@ -259,13 +263,14 @@ where
 	}
 }
 
-impl<F, P, NTT, Channel, ReplayFn, A> IOPProverChannel<P>
+impl<F, P, NTT, Channel, ReplayFn, A> IOPProverChannel<P, A>
 	for ZKWrappedProverChannel<'_, P, NTT, Channel, ReplayFn, A>
 where
 	F: BinaryField,
 	P: PackedField<Scalar = F>,
 	NTT: AdditiveNTT<Field = F> + Sync,
 	Channel: MerkleIPProverChannel<F>,
+	A: Allocator,
 {
 	type Oracle = BaseFoldOracle;
 
@@ -286,7 +291,7 @@ where
 	fn prove_oracle_relations(
 		&mut self,
 		oracle_relations: impl IntoIterator<
-			Item = (Self::Oracle, FieldBuffer<P>, FieldBuffer<P>, P::Scalar),
+			Item = (Self::Oracle, FieldVec<P, A>, FieldBuffer<P>, P::Scalar),
 		>,
 	) {
 		let oracle_relations = oracle_relations.into_iter().collect::<Vec<_>>();

--- a/crates/spartan-prover/tests/wrapper_integration_test.rs
+++ b/crates/spartan-prover/tests/wrapper_integration_test.rs
@@ -142,7 +142,7 @@ fn test_zk_wrapped_prove_verify() {
 	prover_transcript.observe().write_slice(&public);
 
 	let basefold_channel = zk_basefold_prover
-		.create_channel_from_transcript::<StdHashSuite, StdChallenger, _>(
+		.create_channel_from_transcript::<StdHashSuite, StdChallenger, _, _>(
 			&mut prover_transcript,
 			&mut rng,
 		);
@@ -170,10 +170,11 @@ fn test_zk_wrapped_prove_verify() {
 
 	// Commit the inner precommit oracle on the wrapped channel, then run the inner proof.
 	let (inner_precommit_oracle, inner_precommit_packed) = inner_iop_prover
-		.commit_precommit::<OptimalPackedB128, _>(
+		.commit_precommit::<OptimalPackedB128, _, _>(
 			&inner_witness,
 			&mut rng,
 			&mut wrapped_prover_channel,
+			&GlobalAllocator,
 		);
 	inner_iop_prover
 		.prove::<OptimalPackedB128, _, _>(


### PR DESCRIPTION
Closes [BINIUS-344](https://linear.app/jimpo/issue/BINIUS-344/pool-the-packed-trace-thread-an-allocator-through-pack-witness).

The packed trace was the last large per-proof buffer still on the global allocator. At keccak-f1600 / 2^13 instances it's 64 MiB, allocated and freed on every `prove` — above glibc's `DEFAULT_MMAP_THRESHOLD_MAX`, so it is always `mmap`/`munmap`ed and re-faults every proof. This draws it from the prover's `BufferPool` instead.

> This PR previously held a deliberately not-for-merge spike, pushed so the cost of the change could be judged before committing to it. That lineage is gone; the branch is now the real change. The history and the reasoning are on the Linear issue.

## The change

`pack_witness` takes an allocator and returns a pool-drawn buffer, and the channel trait gains the allocator parameter so that buffer can actually reach the channel instead of being copied back out:

```rust
pub trait IOPProverChannel<P, A: Allocator> { ... }

fn pack_witness<P, A: Allocator>(
    alloc: &A,
    log_witness_elems: usize,
    witness: &[Word],
) -> Result<FieldVec<P, A>, Error>
```

1. **`bea13e8c`** — `ring_switch::prove` takes the packed witness as a `FieldSlice` (per review feedback), dropping its `Data` type parameter.
2. **`524ca724`** — same treatment for the logUp\* pushforward in `prove_reduction` / `prove_final_layer` / `split_halves`.
3. **`8b3c4e31`** — the allocator parameter, propagated into `BaseFoldProverChannel` and `QueuedRelation`; `pack_witness` and `ValueTable::pack` take the allocator; both provers pass their pool.

18 files across 5 crates. Commits 1 and 2 are pure widenings that stand alone; commit 3 is atomic by necessity — the moment the trait requires a pool-drawn message, every producer must already be allocator-drawn, so any finer split would have to reintroduce a copy at the boundary.

**Only the message slot is generalized.** The relation item is:

```rust
type Item = (Self::Oracle, FieldBuffer<P, A::Vec<P>>, FieldBuffer<P>, P::Scalar);
```

The transparent multilinear stays `Vec`-backed, because every transparent argument at every call site already is. That keeps `binius-math` entirely out of the change — `rs_eq_ind` and `eq_ind_partial_eval` are untouched.

Two things fell out of it:

- `finish` used to take its own allocator type parameter — a *different* allocator from the one backing the queued messages. It is now the channel's own, so they match by construction. Nothing was unsound before (a `PoolVec` carries its own pool reference), but the incoherent combination is no longer expressible.
- `spartan-prover` needed real work rather than just bounds: its three messages were all `Vec`-backed, so `pack_and_blind_witness` became allocator-drawn and the ZK transcript mask is now pooled too. This isn't optional — there's no version of the change where those stay `Vec`-backed short of copying them at the boundary.

## Measurement

keccak-f1600 @ 2^13, `--release`, `RUSTFLAGS="-C target-cpu=native"`, 6-core Linux VM, 15 proofs per run on one warm `Prover`, 3 runs on `main` and 5 on the branch.

| | `main` | branch |
|---|---|---|
| `Prepare trace` span, median | 22.78 / 24.22 / 24.40 ms | 6.07 / 6.21 / 7.26 / 6.10 / 6.36 ms |
| prove wall, median per run | 919.29 / 923.74 / 926.01 ms | 903.08 / 905.23 / 913.18 / 940.29 / 1035.77 ms |

**The span goes ~23.5 ms → ~6.2 ms, −74%**, and that reproduces on every run. That's the result.

**End-to-end is a different story and I'd rather state it plainly than sell it.** −1.8% is a modelled ceiling — span delta over total — not something observed above noise. The branch's own run-to-run spread on medians is 903–1036 ms, so a single contaminated run exceeds the entire effect. The clean-run clusters (`main` 919–926, branch 903–913) don't overlap, which is the strongest honest claim available and is weaker than statistical significance. A defensible end-to-end number needs a quiet dedicated machine and many more paired runs.

For context on why: `Commit trace` is ~306 ms of a ~910 ms proof and is untouched. Packing was never where the proof time lives. On the `binius-prover` side there's even less — `Prepare witness` is 0.35% of the proof there.

## Correctness

Proof bytes are unchanged. Fingerprinted with the blinding RNG seeded so bytes are reproducible, on paths that reach the changed code:

| path | exercises | `main` | branch |
|---|---|---|---|
| ZK sha256 | `pack_and_blind_witness`, the mask, `masks_buffer` | `0xab0a04be2e6e43f6` | `0xab0a04be2e6e43f6` |
| plain sha256 | `pack_witness` | `0xc8ac80dcc67f6982` | `0xc8ac80dcc67f6982` |
| m4 keccak | `ValueTable::pack` | `0x44c84c91dee11f04` | `0x44c84c91dee11f04` |

Each proof is verified from those exact bytes before being fingerprinted, and each is proved twice — cold pool, then warm — with an equality assert, so a proof that depended on pool state would fail rather than pass quietly. That last check is the one that matters here: pooled blocks are recycled dirty, so the fills have to leave no stale bytes from a prior proof.

This is differential evidence of behavioural identity on the shapes exercised, not exhaustive input coverage.

Full `cargo test --workspace` green; each of the three commits builds and tests green on its own. No cross-compilation matrix run — the diff contains no `target_arch`, `target_feature` or intrinsic hunks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
