### PR TITLE
perf(circuits): rotate the slice input once instead of per word

### DIFF
--- a/crates/circuits/src/multiplexer.rs
+++ b/crates/circuits/src/multiplexer.rs
@@ -115,6 +115,57 @@ pub fn single_wire_multiplex(b: &CircuitBuilder, inputs: &[Wire], sel: Wire) -> 
 	current_level[0]
 }
 
+/// Rotates `words` left by a dynamic word count, returning the first `n_out` positions.
+///
+/// `out[i]` is `words[(shift + i) % words.len()]`. A caller that only needs a prefix reads the
+/// wrap-around at positions past its own validity bound, so it must treat those as unconstrained.
+///
+/// # Arguments
+/// * `b` - Circuit builder
+/// * `words` - The array to rotate
+/// * `shift` - Rotate amount in words (only `ceil(log2(len))` LSB bits are used)
+/// * `n_out` - Number of leading positions to return
+///
+/// # Implementation Details
+///
+/// One barrel stage per bit of `shift`, largest stage first so the working window shrinks as the
+/// stages are applied. That costs one select per position per stage, where a multiplexer per
+/// output position would instead cost `words.len() - 1` selects each.
+///
+/// # Panics
+/// * If `words` is empty
+/// * If `n_out` exceeds `words.len()`
+pub fn rotate_left_dynamic(
+	b: &CircuitBuilder,
+	words: &[Wire],
+	shift: Wire,
+	n_out: usize,
+) -> Vec<Wire> {
+	let n = words.len();
+	assert!(n > 0, "words must not be empty");
+	assert!(n_out <= n, "n_out ({n_out}) must not exceed words.len() ({n})");
+
+	let n_bits = log2_ceil_usize(n);
+
+	// Width the window must have before each stage, derived back from `n_out`: a stage rotating by
+	// `2^bit` reads positions `i` and `i + 2^bit`, and indices wrap, so the width caps at `n`.
+	let mut widths = vec![n_out];
+	for bit in 0..n_bits {
+		widths.push(n.min(widths[widths.len() - 1] + (1 << bit)));
+	}
+
+	let mut current = words[..widths[n_bits]].to_vec();
+	for bit in (0..n_bits).rev() {
+		let shift_bit = b.shl(shift, (Word::BITS - 1 - bit) as u32);
+		let amount = 1usize << bit;
+		current = (0..widths[bit])
+			.map(|i| b.select(shift_bit, current[(i + amount) % current.len()], current[i]))
+			.collect();
+	}
+
+	current
+}
+
 #[inline]
 const fn log2_ceil_usize(n: usize) -> usize {
 	if n <= 1 {
@@ -129,6 +180,75 @@ mod tests {
 	use binius_core::{verify::verify_constraints, word::Word};
 
 	use super::*;
+
+	/// Exhaustively checks `rotate_left_dynamic` against `words[(shift + i) % n]` for every shift
+	/// the rotate can express, at sizes on both sides of a power of two.
+	fn verify_rotate(n: usize, n_out: usize) {
+		let builder = CircuitBuilder::new();
+		let input: Vec<Wire> = (0..n).map(|_| builder.add_inout()).collect();
+		let shift = builder.add_inout();
+		let out = rotate_left_dynamic(&builder, &input, shift, n_out);
+		let expected: Vec<Wire> = (0..n_out).map(|_| builder.add_inout()).collect();
+		for (i, (got, want)) in out.iter().zip(&expected).enumerate() {
+			builder.assert_eq(format!("rot[{i}]"), *got, *want);
+		}
+		let circuit = builder.build();
+
+		// The rotate reads `ceil(log2(n))` bits of the shift, so that range covers every distinct
+		// permutation it can produce.
+		let n_shifts = 1usize << log2_ceil_usize(n);
+		for sh in 0..n_shifts {
+			let mut w = circuit.new_witness_filler();
+			for (i, wire) in input.iter().enumerate() {
+				// Distinct per position so a wrong index cannot pass by coincidence.
+				w[*wire] = Word(0x1000 + i as u64);
+			}
+			w[shift] = Word(sh as u64);
+			for (i, wire) in expected.iter().enumerate() {
+				w[*wire] = Word(0x1000 + ((sh + i) % n) as u64);
+			}
+			circuit
+				.populate_wire_witness(&mut w)
+				.unwrap_or_else(|e| panic!("n={n} n_out={n_out} shift={sh}: {e}"));
+			verify_constraints(circuit.constraint_system(), &w.into_value_vec())
+				.unwrap_or_else(|e| panic!("n={n} n_out={n_out} shift={sh}: {e}"));
+		}
+	}
+
+	#[test]
+	fn rotate_matches_modular_index() {
+		// Powers of two, just under, just over, and a prefix much shorter than the array.
+		for (n, n_out) in [
+			(8, 8),
+			(8, 3),
+			(7, 7),
+			(9, 9),
+			(9, 2),
+			(16, 16),
+			(5, 5),
+			(1, 1),
+			(2, 2),
+		] {
+			verify_rotate(n, n_out);
+		}
+	}
+
+	#[test]
+	#[should_panic(expected = "words must not be empty")]
+	fn rotate_rejects_empty() {
+		let builder = CircuitBuilder::new();
+		let shift = builder.add_inout();
+		rotate_left_dynamic(&builder, &[], shift, 0);
+	}
+
+	#[test]
+	#[should_panic(expected = "must not exceed")]
+	fn rotate_rejects_oversized_prefix() {
+		let builder = CircuitBuilder::new();
+		let input: Vec<Wire> = (0..4).map(|_| builder.add_inout()).collect();
+		let shift = builder.add_inout();
+		rotate_left_dynamic(&builder, &input, shift, 5);
+	}
 
 	/// Helper function to verify single-wire multiplexer behavior
 	/// Takes input values and test cases as (selector, expected_output) pairs

--- a/crates/circuits/src/slice.rs
+++ b/crates/circuits/src/slice.rs
@@ -3,7 +3,7 @@ use binius_core::word::Word;
 use binius_frontend::{CircuitBuilder, Wire};
 
 use crate::{
-	multiplexer::single_wire_multiplex,
+	multiplexer::rotate_left_dynamic,
 	shift::{var_sll_bytes, var_srl_bytes},
 };
 
@@ -126,32 +126,36 @@ pub fn slice(
 		Vec::new()
 	} else {
 		let zero = b.add_constant(Word::ZERO);
-		let one = b.add_constant(Word::ONE);
 
 		// Decompose offset = word_offset * 8 + byte_offset
-		let mut word_offset = b.shr(offset, 3); // offset / 8
+		let word_offset = b.shr(offset, 3); // offset / 8
 		let byte_offset = b.band(offset, b.add_constant(Word(7))); // offset % 8
 		let (neg_byte_offset, _) = b.isub_bin_bout(b.add_constant(Word(8)), byte_offset, zero);
 		let is_aligned = b.icmp_eq(byte_offset, zero);
 
-		let mut in_word = single_wire_multiplex(b, input, word_offset);
+		// Every output word reads `input[word_offset + i]` and its successor, so one rotate of the
+		// input serves all of them. A multiplexer per output word would instead cost
+		// `input.len() - 1` selects each.
+		//
+		// The rotate wraps, so a position past `len_slice` reads the front of the input rather than
+		// the multiplexer's out-of-range value. Both are garbage that this function leaves
+		// unconstrained.
+		let window = (max_n_words + 1).min(input.len());
+		let rotated = rotate_left_dynamic(b, input, word_offset, window);
+
 		(0..max_n_words)
 			.map(|slice_idx| {
 				let b = b.subcircuit(format!("slice_word[{slice_idx}]"));
 
-				// TODO: This could maybe benefit from a CircuitBuilder::incr gate.
-				(word_offset, _) = b.iadd(word_offset, one);
-				let next_word = single_wire_multiplex(&b, input, word_offset);
+				let in_word = rotated[slice_idx % window];
+				let next_word = rotated[(slice_idx + 1) % window];
 
 				let aligned_out_word = in_word;
 				let unaligned_out_word = b.bxor(
 					var_srl_bytes(&b, in_word, byte_offset),
 					var_sll_bytes(&b, next_word, neg_byte_offset),
 				);
-				let out_word = b.select(is_aligned, aligned_out_word, unaligned_out_word);
-
-				in_word = next_word;
-				out_word
+				b.select(is_aligned, aligned_out_word, unaligned_out_word)
 			})
 			.collect()
 	}

--- a/crates/examples/snapshots/zklogin.snap
+++ b/crates/examples/snapshots/zklogin.snap
@@ -1,32 +1,32 @@
 zklogin circuit
 --
 Gates & Instructions
-├─ Number of gates: 404,792
-└─ Number of evaluation instructions: 472,879
+├─ Number of gates: 391,028
+└─ Number of evaluation instructions: 459,115
 
 Constraints
 ├─ ZERO constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-├─ AND constraints: 272,492 used (52.0% of 2^19)
-│  [▓▓▓▓▓░░░░░] spare: 251,796
+├─ AND constraints: 258,569 used (98.6% of 2^18)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 3,575
 ├─ IMUL constraints: 8,262 used (50.4% of 2^14)
 │  [▓▓▓▓▓░░░░░] spare: 8,122
 ├─ BMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-└─ Distinct value indices: 561,772
-   ├─ Distinct shifted value indices: 286,661
-   └─ Distinct unshifted value indices: 275,111
+└─ Distinct value indices: 545,530
+   ├─ Distinct shifted value indices: 284,342
+   └─ Distinct unshifted value indices: 261,188
 
 Value Vector
 ├─ Public Section: 1,031 used (50.3% of 2^11)
 │  [▓▓▓▓▓░░░░░] spare: 1,017
 │  ├─ Constants: 729
 │  └─ Inout: 302
-├─ Private Section: 274,090 used (52.5%)
-│  [▓▓▓▓▓░░░░░] spare: 248,150
+├─ Private Section: 260,167 used (49.8%)
+│  [▓▓▓▓░░░░░░] spare: 262,073
 │  ├─ Witness: 1,381
-│  └─ Internal: 272,709
-├─ Total Committed: 275,121 used (52.5% of 2^19)
-│  [▓▓▓▓▓░░░░░] spare: 249,167
+│  └─ Internal: 258,786
+├─ Total Committed: 261,198 used (49.8% of 2^19)
+│  [▓▓▓▓░░░░░░] spare: 263,090
 └─ Scratch (uncommitted): 319,862 (peak live: 1,542)
 


### PR DESCRIPTION
## What

Extracting an 85-word slice out of a 135-word input costs 12,996 AND constraints. The zklogin circuit slices twice while concatenating the JWT signing payload, and those two calls alone hold 4% of its AND constraints.

**Root cause:** `slice()` builds a fresh `single_wire_multiplex` over the whole input for every output word, so an M-word slice out of N words spends `M * (N - 1)` select gates, one AND constraint each.

**Fix:** every output word reads `input[word_offset + i]` and its successor, so one dynamic rotate of the input serves all of them. `rotate_left_dynamic` runs one barrel stage per bit of the rotate amount, largest stage first so the working window shrinks as stages are applied, costing one select per position per stage.

```text
before:  M independent multiplexer trees, M * (N - 1) selects
after:   ceil(log2 N) barrel stages over a shrinking window
```

## Numbers

AND constraint counts are deterministic (`CircuitStat::collect`).

| gadget | baseline | this PR | change |
| --- | ---: | ---: | ---: |
| `slice(input=135, slice=85)` | 12,996 | 1,465 | -88.7% |
| `slice(input=64, slice=32)` | 2,584 | 504 | -80.5% |
| `slice(input=32, slice=16)` | 775 | 247 | -68.1% |
| `slice(input=16, slice=8)` | 262 | 126 | -51.9% |
| `zklogin` example | 272,492 | 258,569 | -5.1% |

With #1898 merged, this takes zklogin from 272,492 down to 258,569, under 2^18. The AND column pads to the next power of two, so the padded work halves from 524,288 to 262,144 and the prover feels it directly. Apple M3 Pro, medians of 11 runs interleaved between the two binaries so drift hits both equally:

| span | main | this PR | change |
| --- | ---: | ---: | ---: |
| BitAnd check | 16.4 ms | 11.7 ms | -28.7% |
| Commit witness | 10.2 ms | 5.2 ms | -48.7% |
| Prove | 92.3 ms | 79.3 ms | -14.1% |

Core samples do not overlap (Prove: main 91.1 to 100.0, this PR 77.6 to 87.1).

repro:

```bash
cargo run --release --example zklogin -- stat
RUST_LOG=info cargo run --release --example zklogin -- prove
```

## Correctness

`rotate_left_dynamic` is checked against `words[(shift + i) % n]` for every shift it can express, at sizes on both sides of a power of two (7, 8, 9, 16, 5, 2, 1) and with a prefix shorter than the array. Perturbing the stage order, the stage amount, or the select arms all fail that test, so it is not vacuous.

The rotate wraps where the multiplexer previously returned its out-of-range value. Both land past `len_slice`, which `slice()` already documents as unconstrained, and both callers (`jwt_claims` and the dynamic-offset branch of `concat`) pass the result straight into `assert_slice_eq`, which forces both sides to zero past the length. The output stays a fully constrained function of the input and the offset, so a prover gains no freedom.

zklogin is the only example whose statistics move. Its proof still verifies, as do `bitcoin_p2pkh` and `ethsign` end to end.

## Scope

Only the dynamic word extraction changes. The bounds checks, the byte-level alignment path, and `assert_slice_eq` are untouched. `single_wire_multiplex` keeps its other callers in `sha256`, `sha512`, `keccak`, and the ECDSA scalar multiply; a caller that needs one element rather than a run of them is still better served by the multiplexer.

