### PR TITLE
BINIUS-349: summarise the shift context gate fusion carries along each path

### DIFF
--- a/crates/frontend/src/compiler/constraint_builder/mod.rs
+++ b/crates/frontend/src/compiler/constraint_builder/mod.rs
@@ -16,7 +16,7 @@ pub use constraint::{
 };
 use cranelift_entity::{EntitySet, SecondaryMap};
 pub use expr::WireExprTerm;
-pub use shift::{Shift, ShiftedWire, WireOperand};
+pub use shift::{Shift, ShiftKind, ShiftedWire, WireOperand};
 
 use crate::compiler::Wire;
 

--- a/crates/frontend/src/compiler/constraint_builder/shift.rs
+++ b/crates/frontend/src/compiler/constraint_builder/shift.rs
@@ -112,6 +112,51 @@ impl From<Vec<ShiftedWire>> for WireOperand {
 	}
 }
 
+/// The operation a shift performs, without its distance.
+///
+/// The `*32` kinds act half-wise on the two 32-bit lanes of a 64-bit word.
+/// The others act on the whole word.
+///
+/// The discriminant is fixed, so a caller can index by kind with one slot or bit per variant.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, PartialOrd, Ord)]
+#[repr(u8)]
+pub enum ShiftKind {
+	/// Logical left shift of the whole word.
+	Sll = 0,
+	/// Half-wise logical left shift of each 32-bit lane.
+	Sll32 = 1,
+	/// Logical right shift of the whole word.
+	Srl = 2,
+	/// Half-wise logical right shift of each 32-bit lane.
+	Srl32 = 3,
+	/// Arithmetic right shift of the whole word.
+	Sar = 4,
+	/// Half-wise arithmetic right shift of each 32-bit lane.
+	Sra32 = 5,
+	/// Rotate-right of the whole word.
+	Rotr = 6,
+	/// Half-wise rotate-right of each 32-bit lane.
+	Rotr32 = 7,
+}
+
+impl ShiftKind {
+	/// The width this kind operates over: the whole word, or one 32-bit lane.
+	pub const fn width(self) -> u32 {
+		match self {
+			ShiftKind::Sll32 | ShiftKind::Srl32 | ShiftKind::Sra32 | ShiftKind::Rotr32 => 32,
+			_ => 64,
+		}
+	}
+
+	/// Whether this kind wraps what it moves out, rather than discarding it.
+	///
+	/// A cyclic kind loses nothing.
+	/// So any two of them compose, however far they move.
+	pub const fn is_cyclic(self) -> bool {
+		matches!(self, ShiftKind::Rotr | ShiftKind::Rotr32)
+	}
+}
+
 /// A shift folded into an operand term.
 ///
 /// The `*32` variants act half-wise on the two 32-bit lanes of a 64-bit word;
@@ -139,6 +184,21 @@ pub enum Shift {
 }
 
 impl Shift {
+	/// The operation and distance of this shift, or `None` for the identity.
+	pub const fn kind_and_amount(self) -> Option<(ShiftKind, u32)> {
+		match self {
+			Shift::None => None,
+			Shift::Sll(n) => Some((ShiftKind::Sll, n)),
+			Shift::Sll32(n) => Some((ShiftKind::Sll32, n)),
+			Shift::Srl(n) => Some((ShiftKind::Srl, n)),
+			Shift::Srl32(n) => Some((ShiftKind::Srl32, n)),
+			Shift::Sar(n) => Some((ShiftKind::Sar, n)),
+			Shift::Sra32(n) => Some((ShiftKind::Sra32, n)),
+			Shift::Rotr(n) => Some((ShiftKind::Rotr, n)),
+			Shift::Rotr32(n) => Some((ShiftKind::Rotr32, n)),
+		}
+	}
+
 	/// Folds `rhs` applied after `lhs` into a single equivalent shift.
 	///
 	/// Returns `None` when the two shifts cannot be one shift:

--- a/crates/frontend/src/compiler/gate_fusion/commit_set.rs
+++ b/crates/frontend/src/compiler/gate_fusion/commit_set.rs
@@ -1,19 +1,97 @@
 // Copyright 2025 Irreducible Inc.
-use std::iter;
-
 use petgraph::{
 	Direction,
 	visit::{DfsPostOrder, EdgeRef},
 };
 
 use super::{LeGraph, Stat};
-use crate::compiler::constraint_builder::Shift;
+use crate::compiler::constraint_builder::{Shift, ShiftKind};
 
 pub const MAX_DEPTH: usize = 6;
 
+/// Which shift kinds appeared on a path, and the largest distance any of them used.
+///
+/// One question is asked of a path, once per graph edge.
+/// Can a further shift compose with every shift already on it?
+///
+/// Two shifts compose only when one is the identity, or when both share a kind.
+/// So only two facts about the path decide the answer:
+///
+/// - which kinds are present, since a second kind already rules out composing;
+/// - the largest distance among them, since that is what pushes a sum past the width.
+///
+/// Both fit in an integer, so the context is [`Copy`] and allocates nothing.
+#[derive(Copy, Clone, Default)]
+struct ShiftSummary {
+	/// One bit per shift kind seen, excluding the identity.
+	///
+	/// A kind's bit is its discriminant.
+	/// There are eight kinds, so a byte holds them all.
+	kinds: u8,
+	/// Largest distance among the kinds seen.
+	///
+	/// Zero when only the identity was seen, which imposes no distance.
+	max_amount: u32,
+}
+
+impl ShiftSummary {
+	/// The summary of a path carrying one shift.
+	fn of(shift: Shift) -> Self {
+		Self::default().with(shift)
+	}
+
+	/// The summary of this path extended by one more shift.
+	fn with(self, shift: Shift) -> Self {
+		match shift.kind_and_amount() {
+			// The identity composes with anything, so it constrains nothing.
+			None => self,
+			Some((kind, amount)) => Self {
+				kinds: self.kinds | bit_of(kind),
+				max_amount: self.max_amount.max(amount),
+			},
+		}
+	}
+
+	/// The summary covering every path in `summaries`.
+	fn union(summaries: impl Iterator<Item = Self>) -> Self {
+		summaries.fold(Self::default(), |acc, s| Self {
+			kinds: acc.kinds | s.kinds,
+			max_amount: acc.max_amount.max(s.max_amount),
+		})
+	}
+
+	/// Whether `shift` composes with every shift on this path.
+	const fn composable(self, shift: Shift) -> bool {
+		let Some((kind, amount)) = shift.kind_and_amount() else {
+			// The identity composes with anything already seen.
+			return true;
+		};
+
+		// Only the identity was seen, which imposes no kind and no distance.
+		if self.kinds == 0 {
+			return true;
+		}
+
+		// A second kind on the path can never compose with this one.
+		if self.kinds != bit_of(kind) {
+			return false;
+		}
+
+		// A cyclic kind loses nothing, so distances always compose.
+		// Otherwise the largest distance seen plus this one has to stay inside the width.
+		kind.is_cyclic() || self.max_amount + amount < kind.width()
+	}
+}
+
+/// The bit standing for one kind in [`ShiftSummary::kinds`].
+const fn bit_of(kind: ShiftKind) -> u8 {
+	1 << kind as u8
+}
+
+#[derive(Copy, Clone)]
 struct CommitSetCx {
-	/// Every shift type that was used on the path to reach this node.
-	set: Vec<Shift>,
+	/// The shifts used on the path to reach this node.
+	shifts: ShiftSummary,
 	/// Number of nodes we should visit from the current node to get back to one of the roots (or
 	/// committed linear expression)
 	///
@@ -24,41 +102,35 @@ struct CommitSetCx {
 impl CommitSetCx {
 	/// Create a new context for an edge with depth 0.
 	fn new(seed_shift: Shift) -> Self {
-		let mut set = Vec::with_capacity(8);
-		set.push(seed_shift);
-		Self { set, depth: 0 }
+		Self {
+			shifts: ShiftSummary::of(seed_shift),
+			depth: 0,
+		}
 	}
 
 	/// Returns if every shift is composable with the given one.
-	fn composable(&self, shift: Shift) -> bool {
-		self.set.iter().all(|s| Shift::compose(*s, shift).is_some())
+	const fn composable(&self, shift: Shift) -> bool {
+		self.shifts.composable(shift)
 	}
 
 	/// Merge multiple contexts into a single one.
 	fn join<'a>(iter: impl Iterator<Item = &'a CommitSetCx>) -> Self {
-		let mut set = Vec::with_capacity(8);
 		let mut depth = 0;
+		let mut summaries = Vec::new();
 		for cx in iter {
-			set.extend(cx.set.iter().copied());
 			depth = depth.max(cx.depth);
+			summaries.push(cx.shifts);
 		}
-		set.sort_unstable();
-		set.dedup();
-		Self { set, depth }
+		Self {
+			shifts: ShiftSummary::union(summaries.into_iter()),
+			depth,
+		}
 	}
 
 	/// Create a new context by adding a new shift and incrementing depth.
 	fn add(&self, out_shift: Shift) -> CommitSetCx {
-		let mut set = self
-			.set
-			.iter()
-			.copied()
-			.chain(iter::once(out_shift))
-			.collect::<Vec<_>>();
-		set.sort_unstable();
-		set.dedup();
 		Self {
-			set,
+			shifts: self.shifts.with(out_shift),
 			depth: self.depth + 1,
 		}
 	}
@@ -187,6 +259,84 @@ pub fn run_decide_commit_set(leg: &mut LeGraph, stat: &mut Stat) {
 			}
 
 			stat.note_visited();
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use proptest::prelude::*;
+
+	use super::*;
+
+	/// The predicate the summary replaces, evaluated over the shifts themselves.
+	///
+	/// Kept as the reference the summary is checked against.
+	fn composable_reference(path: &[Shift], shift: Shift) -> bool {
+		path.iter().all(|s| Shift::compose(*s, shift).is_some())
+	}
+
+	/// Every shift kind, at a distance inside its own width.
+	fn any_shift() -> impl Strategy<Value = Shift> {
+		prop_oneof![
+			Just(Shift::None),
+			(0u32..64).prop_map(Shift::Sll),
+			(0u32..32).prop_map(Shift::Sll32),
+			(0u32..64).prop_map(Shift::Srl),
+			(0u32..32).prop_map(Shift::Srl32),
+			(0u32..64).prop_map(Shift::Sar),
+			(0u32..32).prop_map(Shift::Sra32),
+			(0u32..64).prop_map(Shift::Rotr),
+			(0u32..32).prop_map(Shift::Rotr32),
+		]
+	}
+
+	proptest! {
+		#[test]
+		fn summary_answers_as_the_shift_list_does(
+			path in prop::collection::vec(any_shift(), 1..12),
+			query in any_shift(),
+		) {
+			// Invariant: the summary decides composability exactly as walking the shifts would.
+			let summary = ShiftSummary::union(path.iter().copied().map(ShiftSummary::of));
+			prop_assert_eq!(summary.composable(query), composable_reference(&path, query));
+		}
+
+		#[test]
+		fn extending_a_path_matches_appending_to_the_list(
+			path in prop::collection::vec(any_shift(), 1..12),
+			extra in any_shift(),
+			query in any_shift(),
+		) {
+			// Invariant: extending a summary is the same as appending to the list it stands for.
+			let summary = ShiftSummary::union(path.iter().copied().map(ShiftSummary::of));
+
+			let mut extended_path = path;
+			extended_path.push(extra);
+
+			prop_assert_eq!(
+				summary.with(extra).composable(query),
+				composable_reference(&extended_path, query)
+			);
+		}
+
+		#[test]
+		fn joining_paths_matches_concatenating_the_lists(
+			left in prop::collection::vec(any_shift(), 1..8),
+			right in prop::collection::vec(any_shift(), 1..8),
+			query in any_shift(),
+		) {
+			// Invariant: joining two summaries is the same as concatenating the two lists.
+			let left_summary = ShiftSummary::union(left.iter().copied().map(ShiftSummary::of));
+			let right_summary = ShiftSummary::union(right.iter().copied().map(ShiftSummary::of));
+			let joined = ShiftSummary::union([left_summary, right_summary].into_iter());
+
+			let concatenated: Vec<Shift> = left.iter().chain(&right).copied().collect();
+
+			prop_assert_eq!(
+				joined.composable(query),
+				composable_reference(&concatenated, query)
+			);
 		}
 	}
 }


### PR DESCRIPTION
Closes [BINIUS-349](https://linear.app/jimpo/issue/BINIUS-349).

Gate fusion carried a growing list of shifts along every path through the linear-expression graph, re-allocating and re-sorting it per edge. It only ever needed two numbers from that list. Circuit compilation gets 7 to 16% faster; the compiled constraint system is unchanged.

### The problem

Deciding what fusion can inline walks the graph of linear expressions, carrying along the shifts seen so far on each path.

That context was the list of those shifts:

- extending a path allocated a fresh list, appended, sorted and deduplicated;
- joining the paths meeting at a node concatenated every list and sorted again.

Both happen once per graph edge, and each query re-scanned the whole list.

### The idea

The context exists to answer one question: can a further shift compose with every shift already on the path?

Two shifts compose only when one is the identity, or when both share a kind:

- a rotation is cyclic, so any two of one kind compose whatever the distances;
- a plain shift discards what it moves out, so the distances must stay inside the width.

So the individual shifts never matter. Only two facts do:

- which kinds are present, since a second kind already rules out composing;
- the largest distance among them, since that is what pushes a sum past the width.

Both fit in an integer.

### The change

```
- set: Vec<Shift>            // per edge: allocate, append, sort, dedup; scan to query
+ kinds: u8                  // one bit per shift kind seen
+ max_amount: u32            // largest distance among them
```

The context is now `Copy` and allocates nothing, and every operation on it is a handful of instructions:

```
extend:  kinds |= bit_of(kind);  max_amount = max(max_amount, amount)
join:    kinds |= other.kinds;   max_amount = max(max_amount, other.max_amount)
query:   kinds == bit_of(kind) && (kind.is_cyclic() || max_amount + amount < kind.width())
```

### Where the shift knowledge belongs

Answering that query needs two things of a shift: which operation it is, and how far it moves.

Neither existed, so the first cut wrote them beside the traversal — matching over every variant and numbering the kinds `0` to `7` by hand, with a comment explaining the numbers only had to be unique.

They are properties of a shift, so they now live on it:

- a tag naming the operation, carrying the width it acts over and whether it wraps;
- one accessor splitting a shift into that tag and its distance.

The hand-written numbering is gone: the tag's own discriminant names the flag bit. A third exhaustive match, asking "is this a rotation?", collapses into `kind.is_cyclic()`.

### Correctness

The decision the pass makes is unchanged, so the compiled constraint system is unchanged.

Three property tests pin the summary against the list it replaces, over random paths and random queries:

- answering a query matches scanning the shifts;
- extending a summary matches appending to the list;
- joining two summaries matches concatenating the two lists.

The reference implementation stays in the test module as the thing being checked against.

### Verification

- `cargo check --workspace --all-targets` — clean
- `clippy -p binius-frontend --all-targets --all-features -D warnings` — clean
- nightly `fmt --all --check` — clean
- `binius-frontend` 161 tests — pass, including the three new property tests
- circuit statistics snapshots unchanged, so no re-blessing was needed

### Benchmark

Timing `CircuitBuilder::build()` end to end:

| circuit | before | after | change |
|---|---|---|---|
| sha256 | 18.520 ms | 16.446 ms | **-11.2%** |
| keccak | 15.463 ms | 12.899 ms | **-16.5%** |
| zklogin | 641.09 ms | 594.06 ms | **-7.3%** |

All at p = 0.00. Keccak gains most, which fits: it is the shift-heaviest of the three, so its paths carried the longest lists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
