### PR TITLE
BINIUS-354: remove frontend API and parameters that nothing reads

### DIFF
--- a/crates/frontend/src/compiler/circuit.rs
+++ b/crates/frontend/src/compiler/circuit.rs
@@ -268,11 +268,6 @@ impl Circuit {
 		&self.constraint_system
 	}
 
-	/// Returns the evaluation form (witness-filling bytecode) for this circuit.
-	pub const fn eval_form(&self) -> &EvalForm {
-		&self.eval_form
-	}
-
 	/// Returns the number of gates in this circuit.
 	///
 	/// Depending on what type of gates this circuit uses, the number of constraints might be

--- a/crates/frontend/src/compiler/eval_form/const_eval.rs
+++ b/crates/frontend/src/compiler/eval_form/const_eval.rs
@@ -71,10 +71,14 @@ fn extract_outputs(value_vec: &ValueVec, shape: &OpcodeShape) -> Vec<Word> {
 		.collect()
 }
 
-/// Convenience function to evaluate a gate with constant inputs.
+/// Evaluate a gate with constant inputs, reusing the gate's own eval bytecode.
 ///
-/// This is a cleaner alternative to `evaluate_constant_gate` that eliminates
-/// parameter redundancy by looking up gate data internally.
+/// Constant folding and the witness pass run the same bytecode, so the two cannot drift apart.
+///
+/// `hint_registry` must contain any hint referenced by the gate. For
+/// [`Opcode::Hint`](gate::opcode::Opcode::Hint) gates this is the registry populated by
+/// [`CircuitBuilder::call_hint`](crate::compiler::CircuitBuilder::call_hint); for other
+/// gates an empty registry is fine.
 pub fn evaluate_gate_constants(
 	graph: &GateGraph,
 	gate: Gate,
@@ -84,16 +88,7 @@ pub fn evaluate_gate_constants(
 	evaluate_constant_gate(gate, &graph.gates[gate], graph, constants, hint_registry)
 }
 
-/// Evaluate a gate with constant inputs using the existing interpreter logic.
-///
-/// This function reuses the `emit_eval_bytecode` logic from each gate module
-/// to ensure consistency between runtime evaluation and constant propagation.
-///
-/// `hint_registry` must contain any hint referenced by the gate. For
-/// [`Opcode::Hint`](gate::opcode::Opcode::Hint) gates this is the registry populated by
-/// [`CircuitBuilder::call_hint`](crate::compiler::CircuitBuilder::call_hint); for other
-/// gates an empty registry is fine.
-pub fn evaluate_constant_gate(
+fn evaluate_constant_gate(
 	gate: Gate,
 	data: &GateData,
 	graph: &GateGraph,

--- a/crates/frontend/src/compiler/eval_form/interpreter.rs
+++ b/crates/frontend/src/compiler/eval_form/interpreter.rs
@@ -123,7 +123,7 @@ impl<'a> Interpreter<'a> {
 		path_spec_tree: Option<&PathSpecTree>,
 	) -> Result<(), PopulateError> {
 		let mut ctx = ExecutionContext::new(value_vec);
-		self.run(&mut ctx)?;
+		self.run(&mut ctx);
 		ctx.check_assertions(path_spec_tree)
 	}
 
@@ -131,8 +131,7 @@ impl<'a> Interpreter<'a> {
 	///
 	/// Assertion failures are recorded on the context.
 	/// Call the context's assertion check to turn them into an error.
-	pub fn run(&mut self, ctx: &mut ExecutionContext<'_>) -> Result<(), PopulateError> {
+	pub fn run(&mut self, ctx: &mut ExecutionContext<'_>) {
 		self.executor.run(ctx);
-		Ok(())
 	}
 }

--- a/crates/frontend/src/compiler/eval_form/mod.rs
+++ b/crates/frontend/src/compiler/eval_form/mod.rs
@@ -138,9 +138,4 @@ impl EvalForm {
 	pub const fn n_eval_insn(&self) -> usize {
 		self.n_eval_insn
 	}
-
-	/// Returns the compiled evaluation bytecode.
-	pub fn bytecode(&self) -> &[u8] {
-		&self.bytecode
-	}
 }

--- a/crates/frontend/src/compiler/eval_form/tests.rs
+++ b/crates/frontend/src/compiler/eval_form/tests.rs
@@ -4,7 +4,6 @@
 use binius_core::{ValueIndex, ValueVec, ValueVecLayout, word::Word};
 
 use crate::compiler::{
-	circuit::PopulateError,
 	eval_form::{
 		BytecodeBuilder,
 		interpreter::{ExecutionContext, Interpreter},
@@ -61,15 +60,13 @@ impl InterpreterTest {
 
 	/// Run the test and expect success (no assertion failures)
 	fn expect_success(self) {
-		let (result, ctx) = self.execute();
-		assert!(result.is_ok(), "Interpreter should execute successfully");
+		let ctx = self.execute();
 		assert!(ctx.check_assertions(None).is_ok(), "Should have no assertion failures");
 	}
 
 	/// Run the test and expect assertion failure
 	fn expect_assertion_failure(self) {
-		let (result, ctx) = self.execute();
-		assert!(result.is_ok(), "Interpreter should execute successfully");
+		let ctx = self.execute();
 		assert!(ctx.check_assertions(None).is_err(), "Should have assertion failures");
 	}
 
@@ -99,8 +96,7 @@ impl InterpreterTest {
 		let mut interpreter = Interpreter::new(&bytecode, &hint_registry);
 		let mut ctx = ExecutionContext::new(&mut value_vec);
 
-		let result = interpreter.run(&mut ctx);
-		assert!(result.is_ok(), "Interpreter should execute successfully");
+		interpreter.run(&mut ctx);
 
 		// Check the expected values
 		for (idx, expected_value) in expected {
@@ -113,8 +109,8 @@ impl InterpreterTest {
 		}
 	}
 
-	/// Execute the bytecode and return the result and context
-	fn execute(self) -> (Result<(), PopulateError>, ExecutionContext<'static>) {
+	/// Execute the bytecode and return the context holding any assertion failures
+	fn execute(self) -> ExecutionContext<'static> {
 		let (bytecode, _) = self.builder.finalize();
 
 		// Create value vec with the right size
@@ -142,8 +138,8 @@ impl InterpreterTest {
 		let value_vec = Box::leak(Box::new(value_vec));
 		let mut ctx = ExecutionContext::new(value_vec);
 
-		let result = interpreter.run(&mut ctx);
-		(result, ctx)
+		interpreter.run(&mut ctx);
+		ctx
 	}
 }
 

--- a/crates/frontend/src/compiler/gate_fusion/legraph.rs
+++ b/crates/frontend/src/compiler/gate_fusion/legraph.rs
@@ -5,7 +5,6 @@ use cranelift_entity::EntitySet;
 use petgraph::graph::{DiGraph, NodeIndex};
 use rustc_hash::FxHashMap;
 
-use super::Stat;
 use crate::compiler::{
 	Wire,
 	constraint_builder::{ConstraintBuilder, Shift, WireOperand},
@@ -157,7 +156,7 @@ impl LeGraph {
 	/// 2. Tracks uses of linear definitions in other linear constraints
 	/// 3. Identifies "root" uses where linear definitions flow into non-linear constraints
 	/// 4. Builds edges with appropriate shift annotations
-	pub fn new(cb: &ConstraintBuilder, stat: &mut Stat) -> Self {
+	pub fn new(cb: &ConstraintBuilder) -> Self {
 		let mut leg = Self {
 			pg: DiGraph::new(),
 			wire_to_node: FxHashMap::default(),
@@ -166,7 +165,7 @@ impl LeGraph {
 			roots: Vec::new(),
 			opaque: Vec::new(),
 		};
-		build_use_def(cb, &mut leg, stat);
+		build_use_def(cb, &mut leg);
 		leg
 	}
 
@@ -277,7 +276,7 @@ impl LeGraph {
 	}
 }
 
-fn build_use_def(cb: &ConstraintBuilder, leg: &mut LeGraph, _stat: &mut Stat) {
+fn build_use_def(cb: &ConstraintBuilder, leg: &mut LeGraph) {
 	// Collect defs from linear constraints.
 	//
 	// Linear constraints are simple definitions. We assert that this is the case here.

--- a/crates/frontend/src/compiler/gate_fusion/mod.rs
+++ b/crates/frontend/src/compiler/gate_fusion/mod.rs
@@ -35,7 +35,7 @@ use stat::Stat;
 pub fn run_pass(cb: &mut ConstraintBuilder, pinned_wires: &EntitySet<Wire>, all_one: Wire) {
 	let mut stat = Stat::new(cb);
 
-	let mut leg = LeGraph::new(cb, &mut stat);
+	let mut leg = LeGraph::new(cb);
 	commit_set::run_decide_commit_set(&mut leg, &mut stat);
 	// Pin force-committed wires that are linear definitions so their values survive as committed
 	// AND constraints. Pinned wires that are not linear definitions (e.g. AND or IMUL outputs) are

--- a/crates/frontend/src/compiler/gate_fusion/patch.rs
+++ b/crates/frontend/src/compiler/gate_fusion/patch.rs
@@ -304,7 +304,7 @@ mod tests {
 		build_constraints(&mut cb);
 
 		let mut stat = Stat::default();
-		let mut leg = LeGraph::new(&cb, &mut stat);
+		let mut leg = LeGraph::new(&cb);
 		crate::compiler::gate_fusion::commit_set::run_decide_commit_set(&mut leg, &mut stat);
 
 		// Verify commit set
@@ -394,8 +394,7 @@ mod tests {
 			.dst(w(3))
 			.build();
 
-		let mut stat = Stat::default();
-		let leg = LeGraph::new(&cb_single, &mut stat);
+		let leg = LeGraph::new(&cb_single);
 		let all_one = w(9);
 		let patch = super::build_committed_lin_def_patch(&cb_single, &leg, all_one, w(3));
 		match patch.added {
@@ -427,7 +426,7 @@ mod tests {
 		cb.imul().a(w(10)).b(w(11)).hi(w(12)).lo(w(13)).build();
 
 		let mut stat = Stat::default();
-		let mut leg = LeGraph::new(&cb, &mut stat);
+		let mut leg = LeGraph::new(&cb);
 		crate::compiler::gate_fusion::commit_set::run_decide_commit_set(&mut leg, &mut stat);
 
 		let patches = super::build(&cb, &leg, w(9));
@@ -469,7 +468,7 @@ mod tests {
 			.build();
 
 		let mut stat = Stat::default();
-		let mut leg = LeGraph::new(&cb, &mut stat);
+		let mut leg = LeGraph::new(&cb);
 		crate::compiler::gate_fusion::commit_set::run_decide_commit_set(&mut leg, &mut stat);
 
 		let patches = super::build(&cb, &leg, w(40));
@@ -548,7 +547,7 @@ mod tests {
 				cb.and().a(w(4)).b(w(5)).c(w(6)).build();
 
 				let mut stat = Stat::default();
-				let mut leg = LeGraph::new(&cb, &mut stat);
+				let mut leg = LeGraph::new(&cb);
 				crate::compiler::gate_fusion::commit_set::run_decide_commit_set(
 					&mut leg, &mut stat,
 				);
@@ -968,7 +967,7 @@ mod tests {
 		cb.and().a(w(2)).b(w(7)).c(w(8)).build();
 
 		let mut stat = Stat::default();
-		let mut leg = LeGraph::new(&cb, &mut stat);
+		let mut leg = LeGraph::new(&cb);
 		crate::compiler::gate_fusion::commit_set::run_decide_commit_set(&mut leg, &mut stat);
 
 		// Sanity: y should be committed; t and z should not be
@@ -1009,7 +1008,7 @@ mod tests {
 			.build();
 
 		let mut stat = Stat::default();
-		let mut leg = LeGraph::new(&cb, &mut stat);
+		let mut leg = LeGraph::new(&cb);
 		crate::compiler::gate_fusion::commit_set::run_decide_commit_set(&mut leg, &mut stat);
 
 		let patches = super::build(&cb, &leg, w(7));
@@ -1065,7 +1064,7 @@ mod tests {
 		cb.imul().a(w(2)).b(w(5)).hi(w(6)).lo(w(7)).build();
 
 		let mut stat = Stat::default();
-		let mut leg = LeGraph::new(&cb, &mut stat);
+		let mut leg = LeGraph::new(&cb);
 		crate::compiler::gate_fusion::commit_set::run_decide_commit_set(&mut leg, &mut stat);
 
 		assert!(leg.commit_set().contains(w(1)), "t_committed should be committed");
@@ -1116,7 +1115,7 @@ mod tests {
 		cb.imul().a(w(6)).b(w(7)).hi(w(2)).lo(w(5)).build();
 
 		let mut stat = Stat::default();
-		let mut leg = LeGraph::new(&cb, &mut stat);
+		let mut leg = LeGraph::new(&cb);
 		crate::compiler::gate_fusion::commit_set::run_decide_commit_set(&mut leg, &mut stat);
 
 		assert!(leg.commit_set().contains(w(1)), "inner t should be committed");

--- a/crates/frontend/src/compiler/gate_fusion/tests/commit_set.rs
+++ b/crates/frontend/src/compiler/gate_fusion/tests/commit_set.rs
@@ -20,7 +20,7 @@ fn test_commit_set(
 	build_constraints(&mut cb);
 
 	let mut stat = Stat::default();
-	let mut leg = LeGraph::new(&cb, &mut stat);
+	let mut leg = LeGraph::new(&cb);
 	commit_set::run_decide_commit_set(&mut leg, &mut stat);
 	let commit_set = leg.commit_set();
 

--- a/crates/frontend/src/ops.rs
+++ b/crates/frontend/src/ops.rs
@@ -48,7 +48,7 @@ use crate::{CircuitBuilder, Wire};
 /// - 2 AND constraints for the sign masks.
 /// - 2 AND constraints for the corrections.
 /// - 2 AND constraints for the two high-word subtractions.
-pub fn smul64(builder: &CircuitBuilder, a: Wire, b: Wire) -> (Wire, Wire) {
+fn smul64(builder: &CircuitBuilder, a: Wire, b: Wire) -> (Wire, Wire) {
 	// Unsigned 128-bit product of the raw bit patterns.
 	// Only the high word needs a signed correction; the low word is already final.
 	let (hi_u, lo) = builder.imul(a, b);
@@ -101,8 +101,6 @@ impl CircuitBuilder {
 	/// Returns `(hi, lo)` where the signed product equals `(hi << 64) | lo`.
 	///
 	/// The high word is the sign extension of the product.
-	///
-	/// Thin wrapper over [`smul64`].
 	pub fn smul(&self, a: Wire, b: Wire) -> (Wire, Wire) {
 		smul64(self, a, b)
 	}


### PR DESCRIPTION
Closes [BINIUS-354](https://linear.app/jimpo/issue/BINIUS-354).

Deletes frontend accessors, functions and parameters that have no caller. Pure refactor — no behavior change.

### The problem

Each item here is small on its own. Together they cost more than their line count, because each one *claims* something untrue:

- a `pub fn` claims someone depends on it, so nobody dares delete it;
- a `&mut Stat` parameter claims the pass records statistics, when the body ignores it;
- a `Result` return claims the call can fail, when the only value it can produce is `Ok(())`.

A reader has to check each claim before they can rule it out.

### The change

**Removed outright** — zero callers anywhere:

- `Circuit::eval_form()`
- `EvalForm::bytecode()`

**Narrowed to private** — no callers outside their module:

- `ops::smul64`, reached through `CircuitBuilder::smul`
- `const_eval::evaluate_constant_gate`, reached through `evaluate_gate_constants` (whose doc comment absorbed the removed one)

**Dead parameter dropped.** `LeGraph::new` took a `&mut Stat` for the sole purpose of forwarding it two levels down:

```diff
-pub fn new(cb: &ConstraintBuilder, stat: &mut Stat) -> Self {
+pub fn new(cb: &ConstraintBuilder) -> Self {
         ...
-        build_use_def(cb, &mut leg, stat);
+        build_use_def(cb, &mut leg);
 }

-fn build_use_def(cb: &ConstraintBuilder, leg: &mut LeGraph, _stat: &mut Stat) {
+fn build_use_def(cb: &ConstraintBuilder, leg: &mut LeGraph) {
```

The `_stat` binding is the tell — the body never touched it.

**Return type narrowed.** `Interpreter::run` could only ever return `Ok(())`:

```diff
-pub fn run(&mut self, ctx: &mut ExecutionContext<'_>) -> Result<(), PopulateError> {
+pub fn run(&mut self, ctx: &mut ExecutionContext<'_>) {
         self.executor.run(ctx);
-        Ok(())
 }
```

Assertion failures are recorded *on the context* and turned into an error later by `check_assertions`. They never surface here. The old signature advertised a failure mode that does not exist, and the call sites carried `assert!(result.is_ok(), ...)` lines that could not fail.

### Deliberately kept

- `EvalForm::value_vec_mut` looks unused at a glance but has a real test caller, so it stays.

### On the one public item

`ops::smul64` was reachable as `binius_frontend::ops::smul64`, so narrowing it is technically an API change. It has no in-tree user, and `CircuitBuilder::smul` is the intended entry point — its doc even described itself as a thin wrapper over `smul64`. That line is now redundant and gone too.

### Scope

- 10 files, −24 net lines
- all in `binius-frontend`; no other crate touched

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-frontend --all-targets --all-features -- -D warnings` — clean
- `cargo +nightly fmt --all` — clean
- `cargo test -p binius-frontend` — 165 passed

No snapshot run: nothing here reaches gate shapes, constraint emission or bytecode, so no circuit's statistics can move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)