### PR TITLE
BINIUS-357: give the evaluation bytecode a shared opcode type instead of loose bytes

### DIFF
--- a/crates/frontend/src/compiler/eval_form/builder.rs
+++ b/crates/frontend/src/compiler/eval_form/builder.rs
@@ -4,6 +4,8 @@
 
 use binius_core::constraint_system::ShiftVariant;
 
+use super::opcode::EvalOpcode;
+
 /// Builder for constructing bytecode during circuit compilation
 pub struct BytecodeBuilder {
 	bytecode: Vec<u8>,
@@ -21,7 +23,7 @@ impl BytecodeBuilder {
 	// Bitwise operations
 	pub fn emit_band(&mut self, dst: u32, src1: u32, src2: u32) {
 		self.n_eval_insn += 1;
-		self.emit_u8(0x01);
+		self.emit_opcode(EvalOpcode::Band);
 		self.emit_reg(dst);
 		self.emit_reg(src1);
 		self.emit_reg(src2);
@@ -29,7 +31,7 @@ impl BytecodeBuilder {
 
 	pub fn emit_bor(&mut self, dst: u32, src1: u32, src2: u32) {
 		self.n_eval_insn += 1;
-		self.emit_u8(0x02);
+		self.emit_opcode(EvalOpcode::Bor);
 		self.emit_reg(dst);
 		self.emit_reg(src1);
 		self.emit_reg(src2);
@@ -37,7 +39,7 @@ impl BytecodeBuilder {
 
 	pub fn emit_bxor(&mut self, dst: u32, src1: u32, src2: u32) {
 		self.n_eval_insn += 1;
-		self.emit_u8(0x03);
+		self.emit_opcode(EvalOpcode::Bxor);
 		self.emit_reg(dst);
 		self.emit_reg(src1);
 		self.emit_reg(src2);
@@ -45,7 +47,7 @@ impl BytecodeBuilder {
 
 	pub fn emit_bxor_multi(&mut self, dst: u32, srcs: &[u32]) {
 		self.n_eval_insn += 1;
-		self.emit_u8(0x06); // Opcode for multi-way XOR
+		self.emit_opcode(EvalOpcode::BxorMulti);
 		self.emit_reg(dst);
 		self.emit_u32(srcs.len() as u32);
 		for &src in srcs {
@@ -55,7 +57,7 @@ impl BytecodeBuilder {
 
 	pub fn emit_fax(&mut self, dst: u32, src1: u32, src2: u32, src3: u32) {
 		self.n_eval_insn += 1;
-		self.emit_u8(0x07);
+		self.emit_opcode(EvalOpcode::Fax);
 		self.emit_reg(dst);
 		self.emit_reg(src1);
 		self.emit_reg(src2);
@@ -64,7 +66,7 @@ impl BytecodeBuilder {
 
 	pub fn emit_select(&mut self, dst: u32, cond: u32, t: u32, f: u32) {
 		self.n_eval_insn += 1;
-		self.emit_u8(0x05);
+		self.emit_opcode(EvalOpcode::Select);
 		self.emit_reg(dst);
 		self.emit_reg(cond);
 		self.emit_reg(t);
@@ -73,12 +75,12 @@ impl BytecodeBuilder {
 
 	/// One instruction covering every shift and rotate variant.
 	///
-	/// Layout: `[0x10][dst reg][src reg][variant u8][amount u8]`.
+	/// Layout: `[Shift][dst reg][src reg][variant u8][amount u8]`.
 	/// The variant byte selects the shift operation.
 	/// The amount byte is the shift count in bits.
 	pub fn emit_shift(&mut self, dst: u32, src: u32, variant: ShiftVariant, amount: u8) {
 		self.n_eval_insn += 1;
-		self.emit_u8(0x10);
+		self.emit_opcode(EvalOpcode::Shift);
 		self.emit_reg(dst);
 		self.emit_reg(src);
 		self.emit_u8(variant as u8);
@@ -88,7 +90,7 @@ impl BytecodeBuilder {
 	// Arithmetic with carry
 	pub fn emit_iadd_cout(&mut self, dst_sum: u32, dst_cout: u32, src1: u32, src2: u32) {
 		self.n_eval_insn += 1;
-		self.emit_u8(0x20);
+		self.emit_opcode(EvalOpcode::IaddCout);
 		self.emit_reg(dst_sum);
 		self.emit_reg(dst_cout);
 		self.emit_reg(src1);
@@ -104,7 +106,7 @@ impl BytecodeBuilder {
 		cin: u32,
 	) {
 		self.n_eval_insn += 1;
-		self.emit_u8(0x21);
+		self.emit_opcode(EvalOpcode::IaddCinCout);
 		self.emit_reg(dst_sum);
 		self.emit_reg(dst_cout);
 		self.emit_reg(src1);
@@ -121,7 +123,7 @@ impl BytecodeBuilder {
 		bin: u32,
 	) {
 		self.n_eval_insn += 1;
-		self.emit_u8(0x23);
+		self.emit_opcode(EvalOpcode::IsubBinBout);
 		self.emit_reg(dst_diff);
 		self.emit_reg(dst_bout);
 		self.emit_reg(src1);
@@ -132,7 +134,7 @@ impl BytecodeBuilder {
 	// Multiply
 	pub fn emit_imul(&mut self, dst_hi: u32, dst_lo: u32, src1: u32, src2: u32) {
 		self.n_eval_insn += 1;
-		self.emit_u8(0x30);
+		self.emit_opcode(EvalOpcode::Imul);
 		self.emit_reg(dst_hi);
 		self.emit_reg(dst_lo);
 		self.emit_reg(src1);
@@ -151,7 +153,7 @@ impl BytecodeBuilder {
 		b_hi: u32,
 	) {
 		self.n_eval_insn += 1;
-		self.emit_u8(0x31);
+		self.emit_opcode(EvalOpcode::Bmul);
 		self.emit_reg(dst_lo);
 		self.emit_reg(dst_hi);
 		self.emit_reg(a_lo);
@@ -170,7 +172,7 @@ impl BytecodeBuilder {
 		cin: u32,
 	) {
 		self.n_eval_insn += 1;
-		self.emit_u8(0x40);
+		self.emit_opcode(EvalOpcode::Iadd32CinCout);
 		self.emit_reg(dst_sum);
 		self.emit_reg(dst_cout);
 		self.emit_reg(src1);
@@ -180,7 +182,7 @@ impl BytecodeBuilder {
 
 	pub fn emit_iadd32_cout(&mut self, dst_sum: u32, dst_cout: u32, src1: u32, src2: u32) {
 		self.n_eval_insn += 1;
-		self.emit_u8(0x46);
+		self.emit_opcode(EvalOpcode::Iadd32Cout);
 		self.emit_reg(dst_sum);
 		self.emit_reg(dst_cout);
 		self.emit_reg(src1);
@@ -190,7 +192,7 @@ impl BytecodeBuilder {
 	// Assertions
 	pub fn emit_assert_eq(&mut self, src1: u32, src2: u32, error_id: u32) {
 		self.n_eval_insn += 1;
-		self.emit_u8(0x60);
+		self.emit_opcode(EvalOpcode::AssertEq);
 		self.emit_reg(src1);
 		self.emit_reg(src2);
 		self.emit_u32(error_id);
@@ -198,7 +200,7 @@ impl BytecodeBuilder {
 
 	pub fn emit_assert_eq_cond(&mut self, cond: u32, src1: u32, src2: u32, error_id: u32) {
 		self.n_eval_insn += 1;
-		self.emit_u8(0x61);
+		self.emit_opcode(EvalOpcode::AssertEqCond);
 		self.emit_reg(cond);
 		self.emit_reg(src1);
 		self.emit_reg(src2);
@@ -207,28 +209,28 @@ impl BytecodeBuilder {
 
 	pub fn emit_assert_zero(&mut self, src: u32, error_id: u32) {
 		self.n_eval_insn += 1;
-		self.emit_u8(0x62);
+		self.emit_opcode(EvalOpcode::AssertZero);
 		self.emit_reg(src);
 		self.emit_u32(error_id);
 	}
 
 	pub fn emit_assert_non_zero(&mut self, src: u32, error_id: u32) {
 		self.n_eval_insn += 1;
-		self.emit_u8(0x63);
+		self.emit_opcode(EvalOpcode::AssertNonZero);
 		self.emit_reg(src);
 		self.emit_u32(error_id);
 	}
 
 	pub fn emit_assert_false(&mut self, src: u32, error_id: u32) {
 		self.n_eval_insn += 1;
-		self.emit_u8(0x64);
+		self.emit_opcode(EvalOpcode::AssertFalse);
 		self.emit_reg(src);
 		self.emit_u32(error_id);
 	}
 
 	pub fn emit_assert_true(&mut self, src: u32, error_id: u32) {
 		self.n_eval_insn += 1;
-		self.emit_u8(0x65);
+		self.emit_opcode(EvalOpcode::AssertTrue);
 		self.emit_reg(src);
 		self.emit_u32(error_id);
 	}
@@ -242,7 +244,7 @@ impl BytecodeBuilder {
 		outputs: &[u32],
 	) {
 		self.n_eval_insn += 1;
-		self.emit_u8(0x80);
+		self.emit_opcode(EvalOpcode::Hint);
 		self.emit_u32(hint_id);
 		self.emit_u16(dimensions.len() as u16);
 		for &dim in dimensions {
@@ -259,6 +261,10 @@ impl BytecodeBuilder {
 	}
 
 	// Low-level emitters
+	fn emit_opcode(&mut self, opcode: EvalOpcode) {
+		self.emit_u8(opcode as u8);
+	}
+
 	fn emit_u8(&mut self, val: u8) {
 		self.bytecode.push(val);
 	}

--- a/crates/frontend/src/compiler/eval_form/exec.rs
+++ b/crates/frontend/src/compiler/eval_form/exec.rs
@@ -15,6 +15,7 @@ use binius_core::{Word, constraint_system::ShiftVariant};
 use binius_field::BinaryField128bGhash;
 use smallvec::{SmallVec, smallvec};
 
+use super::opcode::EvalOpcode;
 use crate::compiler::{hints::HintRegistry, pathspec::PathSpec};
 
 /// Multiplies two GHASH field elements ($\mathbb{F}_{2^{128}}$), each carried by a `(lo, hi)` pair
@@ -82,46 +83,49 @@ impl<'a> Executor<'a> {
 	/// Panics on an unknown opcode, which can only happen if the bytecode is malformed.
 	pub fn run<C: EvalContext>(&mut self, ctx: &mut C) {
 		while self.pc < self.bytecode.len() {
-			let opcode = self.read_u8();
+			let byte = self.read_u8();
+			let opcode = EvalOpcode::from_byte(byte)
+				.unwrap_or_else(|| panic!("Unknown opcode: {byte:#x} at pc={}", self.pc - 1));
+
+			// Matching the enum rather than the byte makes the dispatch exhaustive.
+			// So a new opcode without a handler here does not compile.
 			match opcode {
 				// Bitwise operations
-				0x01 => self.exec_band(ctx),
-				0x02 => self.exec_bor(ctx),
-				0x03 => self.exec_bxor(ctx),
-				0x05 => self.exec_select(ctx),
-				0x06 => self.exec_bxor_multi(ctx),
-				0x07 => self.exec_fax(ctx),
+				EvalOpcode::Band => self.exec_band(ctx),
+				EvalOpcode::Bor => self.exec_bor(ctx),
+				EvalOpcode::Bxor => self.exec_bxor(ctx),
+				EvalOpcode::Select => self.exec_select(ctx),
+				EvalOpcode::BxorMulti => self.exec_bxor_multi(ctx),
+				EvalOpcode::Fax => self.exec_fax(ctx),
 
 				// Shifts
-				0x10 => self.exec_shift(ctx),
+				EvalOpcode::Shift => self.exec_shift(ctx),
 
 				// Arithmetic
-				0x20 => self.exec_iadd_cout(ctx),
-				0x21 => self.exec_iadd_cin_cout(ctx),
-				0x23 => self.exec_isub_bin_bout(ctx),
-				0x30 => self.exec_imul(ctx),
-				0x31 => self.exec_bmul(ctx),
+				EvalOpcode::IaddCout => self.exec_iadd_cout(ctx),
+				EvalOpcode::IaddCinCout => self.exec_iadd_cin_cout(ctx),
+				EvalOpcode::IsubBinBout => self.exec_isub_bin_bout(ctx),
+				EvalOpcode::Imul => self.exec_imul(ctx),
+				EvalOpcode::Bmul => self.exec_bmul(ctx),
 
 				// 32-bit operations
-				0x40 => self.exec_iadd32_cin_cout(ctx),
-				0x46 => self.exec_iadd32_cout(ctx),
+				EvalOpcode::Iadd32CinCout => self.exec_iadd32_cin_cout(ctx),
+				EvalOpcode::Iadd32Cout => self.exec_iadd32_cout(ctx),
 
 				// Masks
-				0x50 => self.exec_mask_low(ctx),
-				0x51 => self.exec_mask_high(ctx),
+				EvalOpcode::MaskLow => self.exec_mask_low(ctx),
+				EvalOpcode::MaskHigh => self.exec_mask_high(ctx),
 
 				// Assertions
-				0x60 => self.exec_assert_eq(ctx),
-				0x61 => self.exec_assert_eq_cond(ctx),
-				0x62 => self.exec_assert_zero(ctx),
-				0x63 => self.exec_assert_non_zero(ctx),
-				0x64 => self.exec_assert_false(ctx),
-				0x65 => self.exec_assert_true(ctx),
+				EvalOpcode::AssertEq => self.exec_assert_eq(ctx),
+				EvalOpcode::AssertEqCond => self.exec_assert_eq_cond(ctx),
+				EvalOpcode::AssertZero => self.exec_assert_zero(ctx),
+				EvalOpcode::AssertNonZero => self.exec_assert_non_zero(ctx),
+				EvalOpcode::AssertFalse => self.exec_assert_false(ctx),
+				EvalOpcode::AssertTrue => self.exec_assert_true(ctx),
 
 				// Hint calls
-				0x80 => self.exec_hint(ctx),
-
-				_ => panic!("Unknown opcode: {:#x} at pc={}", opcode, self.pc - 1),
+				EvalOpcode::Hint => self.exec_hint(ctx),
 			}
 		}
 	}

--- a/crates/frontend/src/compiler/eval_form/mod.rs
+++ b/crates/frontend/src/compiler/eval_form/mod.rs
@@ -10,6 +10,7 @@ mod builder;
 mod const_eval;
 mod exec;
 mod interpreter;
+mod opcode;
 #[cfg(test)]
 mod tests;
 

--- a/crates/frontend/src/compiler/eval_form/opcode.rs
+++ b/crates/frontend/src/compiler/eval_form/opcode.rs
@@ -1,0 +1,152 @@
+// Copyright 2026 The Binius Developers
+//! The opcode byte at the head of every evaluation instruction.
+
+/// An evaluation instruction's opcode.
+///
+/// The emitter writes a variant and the executor decodes back to that same variant.
+/// So dispatch matches on this enum rather than on a byte.
+/// An opcode the emitter can write but the executor cannot run is then a compile error.
+///
+/// A byte is never reassigned, so the gaps between families are permanent.
+/// That way an old bytecode dump keeps meaning one thing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum EvalOpcode {
+	// Bitwise.
+	Band = 0x01,
+	Bor = 0x02,
+	Bxor = 0x03,
+	Select = 0x05,
+	BxorMulti = 0x06,
+	Fax = 0x07,
+
+	// Shifts.
+	Shift = 0x10,
+
+	// Arithmetic.
+	IaddCout = 0x20,
+	IaddCinCout = 0x21,
+	IsubBinBout = 0x23,
+	Imul = 0x30,
+	Bmul = 0x31,
+
+	// 32-bit lanewise arithmetic.
+	Iadd32CinCout = 0x40,
+	Iadd32Cout = 0x46,
+
+	// Masks.
+	MaskLow = 0x50,
+	MaskHigh = 0x51,
+
+	// Assertions.
+	AssertEq = 0x60,
+	AssertEqCond = 0x61,
+	AssertZero = 0x62,
+	AssertNonZero = 0x63,
+	AssertFalse = 0x64,
+	AssertTrue = 0x65,
+
+	// Hint calls.
+	Hint = 0x80,
+}
+
+impl EvalOpcode {
+	/// Decodes an opcode byte, or `None` when no opcode claims it.
+	///
+	/// Each arm repeats the byte its variant is declared with.
+	/// `every_opcode_decodes_back_to_itself` below is what holds the two in agreement.
+	pub const fn from_byte(byte: u8) -> Option<Self> {
+		Some(match byte {
+			0x01 => Self::Band,
+			0x02 => Self::Bor,
+			0x03 => Self::Bxor,
+			0x05 => Self::Select,
+			0x06 => Self::BxorMulti,
+			0x07 => Self::Fax,
+			0x10 => Self::Shift,
+			0x20 => Self::IaddCout,
+			0x21 => Self::IaddCinCout,
+			0x23 => Self::IsubBinBout,
+			0x30 => Self::Imul,
+			0x31 => Self::Bmul,
+			0x40 => Self::Iadd32CinCout,
+			0x46 => Self::Iadd32Cout,
+			0x50 => Self::MaskLow,
+			0x51 => Self::MaskHigh,
+			0x60 => Self::AssertEq,
+			0x61 => Self::AssertEqCond,
+			0x62 => Self::AssertZero,
+			0x63 => Self::AssertNonZero,
+			0x64 => Self::AssertFalse,
+			0x65 => Self::AssertTrue,
+			0x80 => Self::Hint,
+			_ => return None,
+		})
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::EvalOpcode;
+
+	/// Every opcode, so the round-trip test can walk them.
+	///
+	/// A variant missing here is a variant the round trip never checks.
+	const ALL: &[EvalOpcode] = &[
+		EvalOpcode::Band,
+		EvalOpcode::Bor,
+		EvalOpcode::Bxor,
+		EvalOpcode::Select,
+		EvalOpcode::BxorMulti,
+		EvalOpcode::Fax,
+		EvalOpcode::Shift,
+		EvalOpcode::IaddCout,
+		EvalOpcode::IaddCinCout,
+		EvalOpcode::IsubBinBout,
+		EvalOpcode::Imul,
+		EvalOpcode::Bmul,
+		EvalOpcode::Iadd32CinCout,
+		EvalOpcode::Iadd32Cout,
+		EvalOpcode::MaskLow,
+		EvalOpcode::MaskHigh,
+		EvalOpcode::AssertEq,
+		EvalOpcode::AssertEqCond,
+		EvalOpcode::AssertZero,
+		EvalOpcode::AssertNonZero,
+		EvalOpcode::AssertFalse,
+		EvalOpcode::AssertTrue,
+		EvalOpcode::Hint,
+	];
+
+	#[test]
+	fn every_opcode_decodes_back_to_itself() {
+		// Invariant: the byte a variant is declared with is the byte that decodes to it.
+		// This is what keeps the enum and `from_byte` from drifting apart.
+		for &opcode in ALL {
+			assert_eq!(
+				EvalOpcode::from_byte(opcode as u8),
+				Some(opcode),
+				"{opcode:?} does not decode from its own discriminant"
+			);
+		}
+	}
+
+	#[test]
+	fn no_byte_decodes_to_an_opcode_it_does_not_belong_to() {
+		// Invariant: decoding is injective, so no two opcodes claim one byte.
+		for byte in 0..=u8::MAX {
+			let Some(opcode) = EvalOpcode::from_byte(byte) else {
+				continue;
+			};
+			assert_eq!(opcode as u8, byte, "{opcode:?} decoded from the wrong byte");
+		}
+	}
+
+	#[test]
+	fn an_unassigned_byte_decodes_to_nothing() {
+		// Fixture state: 0x04 sits in a gap the bitwise family left behind.
+		assert_eq!(EvalOpcode::from_byte(0x04), None);
+		// Mutation: 0xff was never assigned either.
+		assert_eq!(EvalOpcode::from_byte(0xff), None);
+	}
+}

--- a/crates/frontend/src/compiler/gate/mod.rs
+++ b/crates/frontend/src/compiler/gate/mod.rs
@@ -1,8 +1,9 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 use crate::compiler::{
 	constraint_builder::ConstraintBuilder,
 	eval_form::BytecodeBuilder,
-	gate_graph::{Gate, GateGraph},
+	gate_graph::{Gate, GateData, GateGraph, Wire},
 	hints::HintRegistry,
 };
 
@@ -66,10 +67,13 @@ pub fn emit_gate_bytecode(
 	gate: Gate,
 	graph: &GateGraph,
 	builder: &mut BytecodeBuilder,
-	wire_to_reg: impl Fn(crate::compiler::gate_graph::Wire) -> u32 + Copy,
+	wire_to_reg: impl Fn(Wire) -> u32 + Copy,
 	hint_registry: &HintRegistry,
 ) {
 	let data = &graph.gates[gate];
+
+	// The assertion gates take the path their failure is reported under; the rest do not.
+	let path = graph.assertion_names[gate];
 	match data.opcode {
 		Opcode::Band => band::emit_eval_bytecode(data, builder, wire_to_reg),
 		Opcode::Bxor => bxor::emit_eval_bytecode(data, builder, wire_to_reg),
@@ -82,47 +86,43 @@ pub fn emit_gate_bytecode(
 		Opcode::Iadd32CinCout => iadd32_cin_cout::emit_eval_bytecode(data, builder, wire_to_reg),
 		Opcode::IsubBinBout => isub_bin_bout::emit_eval_bytecode(data, builder, wire_to_reg),
 		Opcode::Shift => shift::emit_eval_bytecode(data, builder, wire_to_reg),
-		Opcode::AssertEq => {
-			let assertion_path = graph.assertion_names[gate];
-			assert_eq::emit_eval_bytecode(data, assertion_path, builder, wire_to_reg)
-		}
-		Opcode::AssertZero => {
-			let assertion_path = graph.assertion_names[gate];
-			assert_zero::emit_eval_bytecode(data, assertion_path, builder, wire_to_reg)
-		}
-		Opcode::AssertNonZero => {
-			let assertion_path = graph.assertion_names[gate];
-			assert_non_zero::emit_eval_bytecode(data, assertion_path, builder, wire_to_reg)
-		}
-		Opcode::AssertEqCond => {
-			let assertion_path = graph.assertion_names[gate];
-			assert_eq_cond::emit_eval_bytecode(data, assertion_path, builder, wire_to_reg)
-		}
-		Opcode::AssertFalse => {
-			let assertion_path = graph.assertion_names[gate];
-			assert_false::emit_eval_bytecode(data, assertion_path, builder, wire_to_reg)
-		}
-		Opcode::AssertTrue => {
-			let assertion_path = graph.assertion_names[gate];
-			assert_true::emit_eval_bytecode(data, assertion_path, builder, wire_to_reg)
-		}
 		Opcode::Imul => imul::emit_eval_bytecode(data, builder, wire_to_reg),
 		Opcode::Bmul => bmul::emit_eval_bytecode(data, builder, wire_to_reg),
 		Opcode::IcmpUlt => icmp_ult::emit_eval_bytecode(data, builder, wire_to_reg),
 		Opcode::IcmpEq => icmp_eq::emit_eval_bytecode(data, builder, wire_to_reg),
-
-		Opcode::Hint => {
-			// Generic hint: hint already lives in the registry from `CircuitBuilder::call_hint`,
-			// the gate carries the id in `imms[0]` and the user dimensions are `&data.dimensions`.
-			// `gate_param()` would panic for hints, so slice the wires directly using the
-			// shape we read back from the registry.
-			let hint_id = data.immediates[0];
-			let (n_in, n_out) = hint_registry.shape(hint_id, &data.dimensions);
-			let inputs = &data.wires[..n_in];
-			let outputs = &data.wires[n_in..n_in + n_out];
-			let input_regs: Vec<u32> = inputs.iter().map(|&wire| wire_to_reg(wire)).collect();
-			let output_regs: Vec<u32> = outputs.iter().map(|&wire| wire_to_reg(wire)).collect();
-			builder.emit_hint(hint_id, &data.dimensions, &input_regs, &output_regs);
+		Opcode::AssertEq => assert_eq::emit_eval_bytecode(data, path, builder, wire_to_reg),
+		Opcode::AssertZero => assert_zero::emit_eval_bytecode(data, path, builder, wire_to_reg),
+		Opcode::AssertNonZero => {
+			assert_non_zero::emit_eval_bytecode(data, path, builder, wire_to_reg)
 		}
+		Opcode::AssertEqCond => {
+			assert_eq_cond::emit_eval_bytecode(data, path, builder, wire_to_reg)
+		}
+		Opcode::AssertFalse => assert_false::emit_eval_bytecode(data, path, builder, wire_to_reg),
+		Opcode::AssertTrue => assert_true::emit_eval_bytecode(data, path, builder, wire_to_reg),
+		Opcode::Hint => emit_hint(data, builder, wire_to_reg, hint_registry),
 	}
+}
+
+/// Emits a hint call, the one gate with no module of its own.
+///
+/// The hint itself already lives in the registry, put there by `CircuitBuilder::call_hint`.
+/// The gate carries only its id, in `immediates[0]`, plus the user dimensions in `dimensions`.
+///
+/// `gate_param()` would panic for a hint, since its shape is not known statically.
+/// So the wires are sliced directly, using the shape read back from the registry.
+fn emit_hint(
+	data: &GateData,
+	builder: &mut BytecodeBuilder,
+	wire_to_reg: impl Fn(Wire) -> u32,
+	hint_registry: &HintRegistry,
+) {
+	let hint_id = data.immediates[0];
+	let (n_in, n_out) = hint_registry.shape(hint_id, &data.dimensions);
+	let input_regs: Vec<u32> = data.wires[..n_in].iter().map(|&w| wire_to_reg(w)).collect();
+	let output_regs: Vec<u32> = data.wires[n_in..n_in + n_out]
+		.iter()
+		.map(|&w| wire_to_reg(w))
+		.collect();
+	builder.emit_hint(hint_id, &data.dimensions, &input_regs, &output_regs);
 }


### PR DESCRIPTION
Closes [BINIUS-357](https://linear.app/jimpo/issue/BINIUS-357).

Replaces the loose hex opcode bytes with one enum, so the emitter and the executor agree at compile time. Pure refactor — no behavior change, emitted bytecode is byte-identical.

### The problem

The evaluation bytecode has two ends, and they agreed only by hand.

The emitter wrote a literal:

```
pub fn emit_band(&mut self, dst: u32, src1: u32, src2: u32) {
    self.emit_u8(0x01);
    ...
}
```

The executor read one back and matched on it:

```
match opcode {
    0x01 => self.exec_band(ctx),
    ...
    _ => panic!("Unknown opcode: {:#x} at pc={}", opcode, self.pc - 1),
}
```

Nothing connected the two. The only thing between "the emitter can write this" and "the executor can run this" was that `panic!`, reached only once some circuit actually used the gate.

The wildcard arm is what made it invisible. A `match` on `u8` can never be exhaustive, so the compiler had nothing to say.

### The idea

Name the opcodes, and let dispatch match on the name.

The wildcard disappears, the match becomes exhaustive over a real type, and the compiler starts checking what a comment used to promise.

### The change

A new `eval_form/opcode.rs`:

```
#[repr(u8)]
pub enum EvalOpcode {
    Band = 0x01,
    Bor  = 0x02,
    ...
    Hint = 0x80,
}
```

The emitter writes variants:

```diff
 pub fn emit_band(&mut self, dst: u32, src1: u32, src2: u32) {
-        self.emit_u8(0x01);
+        self.emit_opcode(EvalOpcode::Band);
```

The executor decodes once, then matches on the enum:

```diff
-let opcode = self.read_u8();
-match opcode {
-        0x01 => self.exec_band(ctx),
+let byte = self.read_u8();
+let opcode = EvalOpcode::from_byte(byte)
+        .unwrap_or_else(|| panic!("Unknown opcode: {byte:#x} at pc={}", self.pc - 1));
+match opcode {
+        EvalOpcode::Band => self.exec_band(ctx),
         ...
-        _ => panic!("Unknown opcode: ..."),
 }
```

The panic survives, but its job shrank. It now only means *this byte is not an opcode* — a malformed program. It can no longer mean *the emitter knows an instruction the executor does not*.

### The guarantee, checked

Adding a variant with no executor arm:

```
error[E0004]: non-exhaustive patterns: `EvalOpcode::ZzzProbe` not covered
   --> crates/frontend/src/compiler/eval_form/exec.rs:91:10
```

### No macro — and why

An earlier draft generated the enum and its decoder from one list, so each byte appeared once. It read worse than what it replaced, and the guarantee above does not depend on it — that comes from the enum existing and dispatch matching on it.

So `from_byte` is a plain `match`, and each byte appears twice: once as a discriminant, once as a pattern. Two tests hold the pair in agreement:

- `every_opcode_decodes_back_to_itself` — every variant decodes from its own discriminant
- `no_byte_decodes_to_an_opcode_it_does_not_belong_to` — decoding is injective, so no two opcodes claim one byte

The residual gap, stated plainly: a variant added to the enum but not to `from_byte` *and* not to the tests' `ALL` list slips past. That failure is loud and immediate — `from_byte` returns `None` and the executor panics on first use. The silent failure mode, a wrong byte in one of the two places, is fully covered.

### Two unrelated tidies in `gate/mod.rs`

Both stand on their own, neither involves the opcode work:

- the `Opcode::Hint` arm was a twelve-line block inline in the match, and becomes a named `emit_hint`;
- the six assertion arms each opened with `let assertion_path = graph.assertion_names[gate];`. That hoists above the match, collapsing each arm from three lines to one.

### What this deliberately does not do

The three gate dispatches (`Opcode::shape`, `gate::constrain`, `gate::emit_gate_bytecode`) keep their explicit matches.

They are **already** exhaustive over `Opcode` — none of them has a wildcard — so a new gate variant already fails to compile in all three today. I verified that against unmodified `main` before deciding:

```
error[E0004]: non-exhaustive patterns: `Opcode::ZzzProbe` not covered
  --> crates/frontend/src/compiler/gate/mod.rs:37:8
  --> crates/frontend/src/compiler/gate/mod.rs:73:8
  --> crates/frontend/src/compiler/gate/opcode.rs:89:9
```

Generating them from a table would deduplicate a module name across four sites and cost readability, without buying a guarantee that is missing. So it is left alone.

### On the byte gaps

`0x04`, `0x22` and `0x41`–`0x45` are unassigned, and stay that way. An opcode is never reassigned, so an old bytecode dump keeps meaning one thing. The enum documents this rather than quietly filling the holes.

### Scope

- **new:** `eval_form/opcode.rs` (~150 lines, half of it the enum, half the tests)
- **changed:** `builder.rs` (21 emitters), `exec.rs` (the dispatch), `eval_form/mod.rs` (one `mod` line), `gate/mod.rs` (the two tidies)
- no crate outside `binius-frontend` touched; `EvalOpcode` is private to the module

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-frontend --all-targets --all-features -- -D warnings` — clean
- `cargo +nightly fmt --all` — clean
- `cargo test -p binius-frontend` — 168 passed (165 existing, plus the 3 new opcode tests)

No snapshot run: opcode bytes and gate dispatch are unchanged in value, so no circuit's statistics can move.

### Merge order

Touches `exec.rs` and `builder.rs`, which #1909 and #1918 also touch. Whichever lands second needs a small rebase — mechanical, since the conflict is over which opcode rows exist, not over the mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)