### PR TITLE
BINIUS-358: stop letting environment variables decide what a circuit compiles to

### DIFF
--- a/crates/frontend/src/compiler/mod.rs
+++ b/crates/frontend/src/compiler/mod.rs
@@ -42,7 +42,10 @@ mod value_vec_alloc;
 pub use gate_graph::Wire;
 use scratch_alloc::{ScratchAlloc, ScratchPolicy};
 
-/// Options for the compiler.
+/// Which compiler passes run.
+///
+/// This is the only knob: a circuit compiles the same way whatever the process environment holds.
+/// A caller that wants a non-default pass set builds through [`CircuitBuilder::with_opts`].
 pub(crate) struct Options {
 	enable_gate_fusion: bool,
 	enable_constant_propagation: bool,
@@ -66,29 +69,6 @@ impl Default for Options {
 			// A caller that inspects one has to opt in knowingly.
 			enable_scratch_pooling: false,
 		}
-	}
-}
-
-impl Options {
-	fn from_env() -> Self {
-		// This is a very temporary solution for now.
-		//
-		// We do not expect those feature sets to soak here for too long neither we expect that
-		// the features are going to be detected using the environment variables.
-		let mut opts = Self::default();
-		if std::env::var("MONBIJOU_CONSTPROP").is_ok() {
-			opts.enable_constant_propagation = true;
-		}
-		if std::env::var("BINIUS_DISABLE_CSE").is_ok() {
-			opts.enable_common_subexpression_elimination = false;
-		}
-		if std::env::var("BINIUS_DISABLE_DCE").is_ok() {
-			opts.enable_dead_code_elimination = false;
-		}
-		if std::env::var("BINIUS_DISABLE_ALGEBRAIC_FOLDING").is_ok() {
-			opts.enable_algebraic_folding = false;
-		}
-		opts
 	}
 }
 
@@ -196,8 +176,7 @@ impl Default for CircuitBuilder {
 impl CircuitBuilder {
 	/// Create a new circuit builder with default options.
 	pub fn new() -> Self {
-		let opts = Options::from_env();
-		Self::with_opts(opts)
+		Self::with_opts(Options::default())
 	}
 
 	pub(crate) fn with_opts(opts: Options) -> Self {
@@ -237,10 +216,7 @@ impl CircuitBuilder {
 
 		// Run constant propagation optimization
 		if shared.opts.enable_constant_propagation {
-			let replaced = const_prop::constant_propagation(&mut graph, &shared.hint_registry);
-			if replaced > 0 {
-				eprintln!("Constant propagation: replaced {} wires with constants", replaced);
-			}
+			const_prop::constant_propagation(&mut graph, &shared.hint_registry);
 		}
 
 		// Common-subexpression elimination: collapse structurally-identical gates.


### PR DESCRIPTION
Closes [BINIUS-358](https://linear.app/jimpo/issue/BINIUS-358).

Deletes the four environment-variable feature flags, so a circuit compiles the same way regardless of process state. No behavior change under the default configuration.

### The problem

`CircuitBuilder::new()` read the environment and let it switch compiler passes:

```
fn from_env() -> Self {
    let mut opts = Self::default();
    if std::env::var("MONBIJOU_CONSTPROP").is_ok() { ... }
    if std::env::var("BINIUS_DISABLE_CSE").is_ok() { ... }
    if std::env::var("BINIUS_DISABLE_DCE").is_ok() { ... }
    if std::env::var("BINIUS_DISABLE_ALGEBRAIC_FOLDING").is_ok() { ... }
    opts
}
```

So **the constraint system a circuit compiles to depended on ambient process state**.

Two identical `CircuitBuilder::new()` calls, in identical code, could produce different constraint systems. Nothing at the call site said so.

The code already knew this was wrong:

```
// This is a very temporary solution for now.
//
// We do not expect those feature sets to soak here for too long neither we expect that
// the features are going to be detected using the environment variables.
```

### Why it actually bites

Tests inherit the environment. Verified against unmodified `main` before writing this:

```
$ BINIUS_DISABLE_ALGEBRAIC_FOLDING=1 cargo test -p binius-frontend test_algebraic_folds_return_operand_directly

thread '...' panicked at crates/frontend/src/compiler/tests.rs:61:5:
assertion `left == right` failed
test result: FAILED. 0 passed; 1 failed
```

A variable exported for one experiment turns the suite red somewhere unrelated, with no visible connection between the two.

### The idea

`Options` already exists and already carries every flag.

Make it the only knob, and let the one caller that wants a non-default pass set say so in code.

### The change

```diff
-impl Options {
-        fn from_env() -> Self { ... }      // 20 lines, four env reads
-}

 pub fn new() -> Self {
-        let opts = Options::from_env();
-        Self::with_opts(opts)
+        Self::with_opts(Options::default())
 }
```

And the constant-propagation branch stops printing to stderr from library code:

```diff
 if shared.opts.enable_constant_propagation {
-        let replaced = const_prop::constant_propagation(&mut graph, &shared.hint_registry);
-        if replaced > 0 {
-                eprintln!("Constant propagation: replaced {} wires with constants", replaced);
-        }
+        const_prop::constant_propagation(&mut graph, &shared.hint_registry);
 }
```

`CircuitBuilder::with_opts` is untouched and is the supported way to pick a pass set. It already has exactly one caller — the gate-fusion snapshot tests, which switch off CSE, DCE and folding to keep their snapshots focused on fusion.

### What this deliberately leaves open

With the variables gone, `enable_constant_propagation` is reachable only through `with_opts`, and it defaults to off.

That flag's pass is **still broken**: `create_wire_mapping` in `const_eval.rs` never maps scratch wires, so const-prop panics with `Wire ... not mapped` on any circuit containing `icmp_eq`, `icmp_ult`, `assert_non_zero` or `assert_eq_cond`.

I did not fix it here. A fix changes behavior and needs its own tests, which does not belong in a deletion PR. It stays a live decision — fix the pass, or drop the flag along with it — and this PR does not foreclose either.

### Scope

- **changed:** `crates/frontend/src/compiler/mod.rs` only
- 1 file, **−24 net lines**
- nothing outside the crate ever referenced the four names — I grepped the whole repo across `.rs`, `.md`, `.toml`, `.yml`, `.sh`; no CI job, script or doc mentions them

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-frontend --all-targets --all-features -- -D warnings` — clean
- `cargo +nightly fmt --all` — clean
- `cargo test -p binius-frontend` — 165 passed
- `grep -rn "std::env" crates/frontend/src/` — no matches

No snapshot run: the default pass set is unchanged, so every circuit compiles exactly as it did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)