### PR TITLE
BINIUS-359: correct frontend comments that describe code as it is not

### DIFF
--- a/crates/frontend/src/compiler/circuit.rs
+++ b/crates/frontend/src/compiler/circuit.rs
@@ -17,7 +17,7 @@ use crate::compiler::{
 /// Error returned when populating wire witness fails due to assertion failures.
 #[derive(Debug)]
 pub struct PopulateError {
-	/// List of assertion failure messages (limited to MAX_ASSERTION_MESSAGES).
+	/// List of assertion failure messages (limited to MAX_ASSERTION_FAILURES).
 	pub messages: Vec<String>,
 	/// Total count of assertion failures (may exceed messages.len()).
 	pub total_count: usize,

--- a/crates/frontend/src/compiler/gate/assert_true.rs
+++ b/crates/frontend/src/compiler/gate/assert_true.rs
@@ -11,7 +11,7 @@
 //! # Constraints
 //!
 //! The gate generates 1 AND constraint:
-//! - `x ∧ 0x8000000000000000 = 0`
+//! - `x ∧ 0x8000000000000000 = 0x8000000000000000`
 
 use binius_core::word::Word;
 

--- a/crates/frontend/src/compiler/gate/bor.rs
+++ b/crates/frontend/src/compiler/gate/bor.rs
@@ -5,8 +5,8 @@
 //!
 //! # Algorithm
 //!
-//! Computes the bitwise OR using De Morgan's law: `x | y = ¬(¬x ∧ ¬y)`.
-//! This is implemented as `x ∧ y = (x ⊕ y ⊕ z)`.
+//! Computes the bitwise OR from the identity `x | y = (x ∧ y) ⊕ x ⊕ y`.
+//! Rearranged so the AND stands alone, that identity is the constraint below.
 //!
 //! # Constraints
 //!

--- a/crates/frontend/src/compiler/mod.rs
+++ b/crates/frontend/src/compiler/mod.rs
@@ -1073,8 +1073,7 @@ impl CircuitBuilder {
 	///
 	/// # Cost
 	///
-	/// - 1 IMUL constraint,
-	/// - 1 AND constraint (for security check).
+	/// 1 IMUL constraint.
 	pub fn imul(&self, a: Wire, b: Wire) -> (Wire, Wire) {
 		let hi = self.add_internal();
 		let lo = self.add_internal();

--- a/crates/frontend/src/compiler/pathspec.rs
+++ b/crates/frontend/src/compiler/pathspec.rs
@@ -41,8 +41,11 @@ impl PathSpecTree {
 
 	/// Writes a string representation of the given path spec into a given string buffer.
 	///
-	/// Note that the string buffer is not reset, which allows appending to the existing contents
-	/// of the string but poses a string of mangling of the string.
+	/// Every component is written with a leading `'.'`, including the first.
+	/// So a path one level below the root renders as `.name`, not `name`.
+	///
+	/// The buffer is appended to rather than reset.
+	/// A caller that reuses a buffer therefore has to clear it first.
 	pub fn stringify(&self, ls: PathSpec, out: &mut String) {
 		fn stringify_rec(
 			root: PathSpec,

--- a/crates/frontend/src/ops.rs
+++ b/crates/frontend/src/ops.rs
@@ -44,10 +44,10 @@ use crate::{CircuitBuilder, Wire};
 /// # Cost
 ///
 /// - 1 IMUL constraint for the unsigned product.
-/// - 1 AND constraint for the unsigned product security check.
-/// - 2 AND constraints for the sign masks.
 /// - 2 AND constraints for the corrections.
 /// - 2 AND constraints for the two high-word subtractions.
+///
+/// The two sign masks cost nothing of their own, since a shift folds into whatever reads it.
 fn smul64(builder: &CircuitBuilder, a: Wire, b: Wire) -> (Wire, Wire) {
 	// Unsigned 128-bit product of the raw bit patterns.
 	// Only the high word needs a signed correction; the low word is already final.


### PR DESCRIPTION
Closes [BINIUS-359](https://linear.app/jimpo/issue/BINIUS-359).

Fixes five frontend comments that claim something the code does not do. Comments only — no code changes.

### The problem

A wrong comment is worse than no comment.

A reader who checks it against the code has to work out which of the two is lying. A reader who does not check carries the wrong model away.

Two of these five are **cost documentation** — the kind circuit authors actually budget against.

### The wrong right-hand side

`gate/assert_true.rs` billed the constraint as equalling zero:

```diff
 //! The gate generates 1 AND constraint:
-//! - `x ∧ 0x8000000000000000 = 0`
+//! - `x ∧ 0x8000000000000000 = 0x8000000000000000`
```

`constrain` emits `x ∧ msb_one = msb_one`. The two lines above the wrong one already stated it correctly, so the file contradicted itself.

### The wrong identity

`gate/bor.rs` claimed De Morgan:

```diff
-//! Computes the bitwise OR using De Morgan's law: `x | y = ¬(¬x ∧ ¬y)`.
-//! This is implemented as `x ∧ y = (x ⊕ y ⊕ z)`.
+//! Computes the bitwise OR from the identity `x | y = (x ∧ y) ⊕ x ⊕ y`.
+//! Rearranged so the AND stands alone, that identity is the constraint below.
```

The emitted constraint is `x ∧ y = x ⊕ y ⊕ z`. That is the *second* identity rearranged, not the first. De Morgan would need two complements the gate never forms.

### The wrong constant name

`compiler/circuit.rs` referred to `MAX_ASSERTION_MESSAGES`. No such constant exists — it is `MAX_ASSERTION_FAILURES`.

### The wrong costs

Both `CircuitBuilder::imul` and `ops::smul64` billed an AND constraint for a "security check". Nothing emits one: `gate/imul.rs::constrain` pushes the IMUL constraint and stops, and nothing in `binius-core` appends an AND per IMUL.

I measured rather than reasoned — probe circuits with the outputs consumed, taking the marginal cost across sizes so the harness's own constraints cancel:

| operation | doc claimed | measured |
|---|---|---|
| `imul` | 1 IMUL + 1 AND | 1 IMUL + **0 AND** |
| `smul64` | 1 IMUL + 7 AND | 1 IMUL + **4 AND** |

```diff
 /// # Cost
 ///
-/// - 1 IMUL constraint,
-/// - 1 AND constraint (for security check).
+/// 1 IMUL constraint.
 pub fn imul(&self, a: Wire, b: Wire) -> (Wire, Wire) {
```

`smul64` was wrong twice over. Beyond the phantom security check, its "2 AND constraints for the sign masks" does not hold either — the sign masks are `sar` shifts, and a shift folds into whatever operand reads it:

```diff
 /// - 1 IMUL constraint for the unsigned product.
-/// - 1 AND constraint for the unsigned product security check.
-/// - 2 AND constraints for the sign masks.
 /// - 2 AND constraints for the corrections.
 /// - 2 AND constraints for the two high-word subtractions.
+///
+/// The two sign masks cost nothing of their own, since a shift folds into whatever reads it.
```

That leaves 2 + 2 = 4 AND, matching the measurement. Both figures were re-measured after rebasing onto current `main`, since #1910 and #1926 changed gates underneath them; both still hold.

### The undocumented behavior

`pathspec.rs::stringify` writes a leading `'.'` before *every* component, including the first, so a root-level path renders as `.a_eq_b`. Nothing said so, though it is visible in a test's expected string.

I documented it rather than fixing it — changing it would churn every assertion message and every snapshot that contains one, which does not belong in a comments PR.

### Two sites needed nothing

The audit originally flagged seven. Two have since been fixed by other work, and this PR no longer touches either:

- a "we used to have a gate for this" comment in `compiler/mod.rs`, of the kind `AGENTS.md` forbids — already gone from `main`;
- `gate_graph.rs::update_use_def_for_gate`, documented as being for "a newly added gate" when its only caller walked every gate. #1913 deleted that function outright, replacing it with `rebuild_wire_defs` and `rebuild_wire_uses`, each correctly documented. The stale comment went with it.

### Scope

- 6 files, +12 −10
- **doc comments only** — no expression, signature or control flow is touched

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-frontend --all-targets --all-features -- -D warnings` — clean
- `cargo +nightly fmt --all` — clean
- `cargo test -p binius-frontend` — 173 passed

The two corrected cost figures come from temporary probe circuits, run and then removed; they are not part of this diff. No snapshot run can be needed — no code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
