### PR TITLE
Drop the unused Gate argument from per-opcode gate functions

### DIFF
--- a/crates/frontend/src/compiler/eval_form/const_eval.rs
+++ b/crates/frontend/src/compiler/eval_form/const_eval.rs
@@ -116,7 +116,7 @@ pub fn evaluate_constant_gate(
 
 	// Generate bytecode for this gate
 	let mut builder = BytecodeBuilder::new();
-	gate::emit_gate_bytecode(gate, data, graph, &mut builder, wire_to_reg, hint_registry);
+	gate::emit_gate_bytecode(gate, graph, &mut builder, wire_to_reg, hint_registry);
 	let (bytecode, _) = builder.finalize();
 
 	// Run evaluation

--- a/crates/frontend/src/compiler/eval_form/mod.rs
+++ b/crates/frontend/src/compiler/eval_form/mod.rs
@@ -61,10 +61,9 @@ impl EvalForm {
 		};
 
 		// Build bytecode for each gate
-		for (gate_id, data) in gate_graph.gates.iter() {
+		for gate_id in gate_graph.gates.keys() {
 			gate::emit_gate_bytecode(
 				gate_id,
-				data,
 				gate_graph,
 				&mut builder,
 				wire_to_reg,

--- a/crates/frontend/src/compiler/gate/assert_eq.rs
+++ b/crates/frontend/src/compiler/gate/assert_eq.rs
@@ -17,7 +17,7 @@ use binius_core::word::Word;
 use crate::compiler::{
 	constraint_builder::{ConstraintBuilder, expr},
 	gate::opcode::OpcodeShape,
-	gate_graph::{Gate, GateData, GateParam, Wire},
+	gate_graph::{GateData, GateParam, Wire},
 	pathspec::PathSpec,
 };
 
@@ -32,7 +32,7 @@ pub const fn shape() -> OpcodeShape {
 	}
 }
 
-pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) {
+pub fn constrain(data: &GateData, builder: &mut ConstraintBuilder) {
 	let GateParam {
 		constants, inputs, ..
 	} = data.gate_param();
@@ -49,7 +49,6 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 }
 
 pub fn emit_eval_bytecode(
-	_gate: Gate,
 	data: &GateData,
 	assertion_path: PathSpec,
 	builder: &mut crate::compiler::eval_form::BytecodeBuilder,

--- a/crates/frontend/src/compiler/gate/assert_eq_cond.rs
+++ b/crates/frontend/src/compiler/gate/assert_eq_cond.rs
@@ -19,7 +19,7 @@ use binius_core::constraint_system::ShiftVariant;
 use crate::compiler::{
 	constraint_builder::{ConstraintBuilder, expr},
 	gate::opcode::OpcodeShape,
-	gate_graph::{Gate, GateData, GateParam, Wire},
+	gate_graph::{GateData, GateParam, Wire},
 	pathspec::PathSpec,
 };
 
@@ -34,7 +34,7 @@ pub const fn shape() -> OpcodeShape {
 	}
 }
 
-pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) {
+pub fn constrain(data: &GateData, builder: &mut ConstraintBuilder) {
 	let GateParam { inputs, .. } = data.gate_param();
 	let [x, y, cond] = inputs else { unreachable!() };
 
@@ -49,7 +49,6 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 }
 
 pub fn emit_eval_bytecode(
-	_gate: Gate,
 	data: &GateData,
 	assertion_path: PathSpec,
 	builder: &mut crate::compiler::eval_form::BytecodeBuilder,

--- a/crates/frontend/src/compiler/gate/assert_false.rs
+++ b/crates/frontend/src/compiler/gate/assert_false.rs
@@ -18,7 +18,7 @@ use binius_core::word::Word;
 use crate::compiler::{
 	constraint_builder::{ConstraintBuilder, expr},
 	gate::opcode::OpcodeShape,
-	gate_graph::{Gate, GateData, GateParam, Wire},
+	gate_graph::{GateData, GateParam, Wire},
 	pathspec::PathSpec,
 };
 
@@ -33,7 +33,7 @@ pub const fn shape() -> OpcodeShape {
 	}
 }
 
-pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) {
+pub fn constrain(data: &GateData, builder: &mut ConstraintBuilder) {
 	let GateParam {
 		constants, inputs, ..
 	} = data.gate_param();
@@ -45,7 +45,6 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 }
 
 pub fn emit_eval_bytecode(
-	_gate: Gate,
 	data: &GateData,
 	assertion_path: PathSpec,
 	builder: &mut crate::compiler::eval_form::BytecodeBuilder,

--- a/crates/frontend/src/compiler/gate/assert_non_zero.rs
+++ b/crates/frontend/src/compiler/gate/assert_non_zero.rs
@@ -31,7 +31,7 @@ use binius_core::word::Word;
 use crate::compiler::{
 	constraint_builder::{ConstraintBuilder, expr},
 	gate::opcode::OpcodeShape,
-	gate_graph::{Gate, GateData, GateParam, Wire},
+	gate_graph::{GateData, GateParam, Wire},
 	pathspec::PathSpec,
 };
 
@@ -47,7 +47,7 @@ pub const fn shape() -> OpcodeShape {
 	}
 }
 
-pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) {
+pub fn constrain(data: &GateData, builder: &mut ConstraintBuilder) {
 	let GateParam {
 		constants,
 		inputs,
@@ -83,7 +83,6 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 }
 
 pub fn emit_eval_bytecode(
-	_gate: Gate,
 	data: &GateData,
 	assertion_path: PathSpec,
 	builder: &mut crate::compiler::eval_form::BytecodeBuilder,

--- a/crates/frontend/src/compiler/gate/assert_true.rs
+++ b/crates/frontend/src/compiler/gate/assert_true.rs
@@ -18,7 +18,7 @@ use binius_core::word::Word;
 use crate::compiler::{
 	constraint_builder::ConstraintBuilder,
 	gate::opcode::OpcodeShape,
-	gate_graph::{Gate, GateData, GateParam, Wire},
+	gate_graph::{GateData, GateParam, Wire},
 	pathspec::PathSpec,
 };
 
@@ -33,7 +33,7 @@ pub const fn shape() -> OpcodeShape {
 	}
 }
 
-pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) {
+pub fn constrain(data: &GateData, builder: &mut ConstraintBuilder) {
 	let GateParam {
 		constants, inputs, ..
 	} = data.gate_param();
@@ -45,7 +45,6 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 }
 
 pub fn emit_eval_bytecode(
-	_gate: Gate,
 	data: &GateData,
 	assertion_path: PathSpec,
 	builder: &mut crate::compiler::eval_form::BytecodeBuilder,

--- a/crates/frontend/src/compiler/gate/assert_zero.rs
+++ b/crates/frontend/src/compiler/gate/assert_zero.rs
@@ -17,7 +17,7 @@ use binius_core::word::Word;
 use crate::compiler::{
 	constraint_builder::{ConstraintBuilder, expr},
 	gate::opcode::OpcodeShape,
-	gate_graph::{Gate, GateData, GateParam, Wire},
+	gate_graph::{GateData, GateParam, Wire},
 	pathspec::PathSpec,
 };
 
@@ -32,7 +32,7 @@ pub const fn shape() -> OpcodeShape {
 	}
 }
 
-pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) {
+pub fn constrain(data: &GateData, builder: &mut ConstraintBuilder) {
 	let GateParam {
 		constants, inputs, ..
 	} = data.gate_param();
@@ -44,7 +44,6 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 }
 
 pub fn emit_eval_bytecode(
-	_gate: Gate,
 	data: &GateData,
 	assertion_path: PathSpec,
 	builder: &mut crate::compiler::eval_form::BytecodeBuilder,

--- a/crates/frontend/src/compiler/gate/band.rs
+++ b/crates/frontend/src/compiler/gate/band.rs
@@ -15,7 +15,7 @@
 use crate::compiler::{
 	constraint_builder::ConstraintBuilder,
 	gate::opcode::OpcodeShape,
-	gate_graph::{Gate, GateData, GateParam, Wire},
+	gate_graph::{GateData, GateParam, Wire},
 };
 
 pub const fn shape() -> OpcodeShape {
@@ -29,7 +29,7 @@ pub const fn shape() -> OpcodeShape {
 	}
 }
 
-pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) {
+pub fn constrain(data: &GateData, builder: &mut ConstraintBuilder) {
 	let GateParam {
 		inputs, outputs, ..
 	} = data.gate_param();
@@ -43,7 +43,6 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 }
 
 pub fn emit_eval_bytecode(
-	_gate: Gate,
 	data: &GateData,
 	builder: &mut crate::compiler::eval_form::BytecodeBuilder,
 	wire_to_reg: impl Fn(Wire) -> u32,

--- a/crates/frontend/src/compiler/gate/bmul.rs
+++ b/crates/frontend/src/compiler/gate/bmul.rs
@@ -7,7 +7,7 @@
 use crate::compiler::{
 	constraint_builder::ConstraintBuilder,
 	gate::opcode::OpcodeShape,
-	gate_graph::{Gate, GateData, GateParam, Wire},
+	gate_graph::{GateData, GateParam, Wire},
 };
 
 pub const fn shape() -> OpcodeShape {
@@ -21,7 +21,7 @@ pub const fn shape() -> OpcodeShape {
 	}
 }
 
-pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) {
+pub fn constrain(data: &GateData, builder: &mut ConstraintBuilder) {
 	let GateParam {
 		inputs, outputs, ..
 	} = data.gate_param();
@@ -45,7 +45,6 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 }
 
 pub fn emit_eval_bytecode(
-	_gate: Gate,
 	data: &GateData,
 	builder: &mut crate::compiler::eval_form::BytecodeBuilder,
 	wire_to_reg: impl Fn(Wire) -> u32,

--- a/crates/frontend/src/compiler/gate/bor.rs
+++ b/crates/frontend/src/compiler/gate/bor.rs
@@ -16,7 +16,7 @@
 use crate::compiler::{
 	constraint_builder::{ConstraintBuilder, expr},
 	gate::opcode::OpcodeShape,
-	gate_graph::{Gate, GateData, GateParam, Wire},
+	gate_graph::{GateData, GateParam, Wire},
 };
 
 pub const fn shape() -> OpcodeShape {
@@ -30,7 +30,7 @@ pub const fn shape() -> OpcodeShape {
 	}
 }
 
-pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) {
+pub fn constrain(data: &GateData, builder: &mut ConstraintBuilder) {
 	let GateParam {
 		inputs, outputs, ..
 	} = data.gate_param();
@@ -44,7 +44,6 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 }
 
 pub fn emit_eval_bytecode(
-	_gate: Gate,
 	data: &GateData,
 	builder: &mut crate::compiler::eval_form::BytecodeBuilder,
 	wire_to_reg: impl Fn(Wire) -> u32,

--- a/crates/frontend/src/compiler/gate/bxor.rs
+++ b/crates/frontend/src/compiler/gate/bxor.rs
@@ -15,7 +15,7 @@
 use crate::compiler::{
 	constraint_builder::{ConstraintBuilder, expr},
 	gate::opcode::OpcodeShape,
-	gate_graph::{Gate, GateData, GateParam, Wire},
+	gate_graph::{GateData, GateParam, Wire},
 };
 
 pub const fn shape() -> OpcodeShape {
@@ -29,7 +29,7 @@ pub const fn shape() -> OpcodeShape {
 	}
 }
 
-pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) {
+pub fn constrain(data: &GateData, builder: &mut ConstraintBuilder) {
 	let GateParam {
 		inputs, outputs, ..
 	} = data.gate_param();
@@ -43,7 +43,6 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 }
 
 pub fn emit_eval_bytecode(
-	_gate: Gate,
 	data: &GateData,
 	builder: &mut crate::compiler::eval_form::BytecodeBuilder,
 	wire_to_reg: impl Fn(Wire) -> u32,

--- a/crates/frontend/src/compiler/gate/bxor_multi.rs
+++ b/crates/frontend/src/compiler/gate/bxor_multi.rs
@@ -11,7 +11,7 @@
 use crate::compiler::{
 	constraint_builder::{ConstraintBuilder, WireExprTerm, expr},
 	gate::opcode::OpcodeShape,
-	gate_graph::{Gate, GateData, GateParam, Wire},
+	gate_graph::{GateData, GateParam, Wire},
 };
 
 pub fn shape(dimensions: &[usize]) -> OpcodeShape {
@@ -28,7 +28,7 @@ pub fn shape(dimensions: &[usize]) -> OpcodeShape {
 	}
 }
 
-pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) {
+pub fn constrain(data: &GateData, builder: &mut ConstraintBuilder) {
 	let GateParam {
 		inputs, outputs, ..
 	} = data.gate_param();
@@ -42,7 +42,6 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 }
 
 pub fn emit_eval_bytecode(
-	_gate: Gate,
 	data: &GateData,
 	builder: &mut crate::compiler::eval_form::BytecodeBuilder,
 	wire_to_reg: impl Fn(Wire) -> u32,

--- a/crates/frontend/src/compiler/gate/fax.rs
+++ b/crates/frontend/src/compiler/gate/fax.rs
@@ -16,7 +16,7 @@
 use crate::compiler::{
 	constraint_builder::{ConstraintBuilder, expr},
 	gate::opcode::OpcodeShape,
-	gate_graph::{Gate, GateData, GateParam, Wire},
+	gate_graph::{GateData, GateParam, Wire},
 };
 
 pub const fn shape() -> OpcodeShape {
@@ -30,7 +30,7 @@ pub const fn shape() -> OpcodeShape {
 	}
 }
 
-pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) {
+pub fn constrain(data: &GateData, builder: &mut ConstraintBuilder) {
 	let GateParam {
 		inputs, outputs, ..
 	} = data.gate_param();
@@ -45,7 +45,6 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 }
 
 pub fn emit_eval_bytecode(
-	_gate: Gate,
 	data: &GateData,
 	builder: &mut crate::compiler::eval_form::BytecodeBuilder,
 	wire_to_reg: impl Fn(Wire) -> u32,

--- a/crates/frontend/src/compiler/gate/iadd32.rs
+++ b/crates/frontend/src/compiler/gate/iadd32.rs
@@ -23,7 +23,7 @@
 use crate::compiler::{
 	constraint_builder::{ConstraintBuilder, expr},
 	gate::opcode::OpcodeShape,
-	gate_graph::{Gate, GateData, GateParam, Wire},
+	gate_graph::{GateData, GateParam, Wire},
 };
 
 pub const fn shape() -> OpcodeShape {
@@ -37,7 +37,7 @@ pub const fn shape() -> OpcodeShape {
 	}
 }
 
-pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) {
+pub fn constrain(data: &GateData, builder: &mut ConstraintBuilder) {
 	let GateParam {
 		inputs, outputs, ..
 	} = data.gate_param();
@@ -67,7 +67,6 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 }
 
 pub fn emit_eval_bytecode(
-	_gate: Gate,
 	data: &GateData,
 	builder: &mut crate::compiler::eval_form::BytecodeBuilder,
 	wire_to_reg: impl Fn(Wire) -> u32,

--- a/crates/frontend/src/compiler/gate/iadd32_cin_cout.rs
+++ b/crates/frontend/src/compiler/gate/iadd32_cin_cout.rs
@@ -26,7 +26,7 @@
 use crate::compiler::{
 	constraint_builder::{ConstraintBuilder, expr},
 	gate::opcode::OpcodeShape,
-	gate_graph::{Gate, GateData, GateParam, Wire},
+	gate_graph::{GateData, GateParam, Wire},
 };
 
 pub const fn shape() -> OpcodeShape {
@@ -40,7 +40,7 @@ pub const fn shape() -> OpcodeShape {
 	}
 }
 
-pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) {
+pub fn constrain(data: &GateData, builder: &mut ConstraintBuilder) {
 	let GateParam {
 		inputs, outputs, ..
 	} = data.gate_param();
@@ -72,7 +72,6 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 }
 
 pub fn emit_eval_bytecode(
-	_gate: Gate,
 	data: &GateData,
 	builder: &mut crate::compiler::eval_form::BytecodeBuilder,
 	wire_to_reg: impl Fn(Wire) -> u32,

--- a/crates/frontend/src/compiler/gate/iadd_cin_cout.rs
+++ b/crates/frontend/src/compiler/gate/iadd_cin_cout.rs
@@ -30,7 +30,7 @@
 use crate::compiler::{
 	constraint_builder::{ConstraintBuilder, expr},
 	gate::opcode::OpcodeShape,
-	gate_graph::{Gate, GateData, GateParam, Wire},
+	gate_graph::{GateData, GateParam, Wire},
 };
 
 pub const fn shape() -> OpcodeShape {
@@ -44,7 +44,7 @@ pub const fn shape() -> OpcodeShape {
 	}
 }
 
-pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) {
+pub fn constrain(data: &GateData, builder: &mut ConstraintBuilder) {
 	let GateParam {
 		inputs, outputs, ..
 	} = data.gate_param();
@@ -75,7 +75,6 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 }
 
 pub fn emit_eval_bytecode(
-	_gate: Gate,
 	data: &GateData,
 	builder: &mut crate::compiler::eval_form::BytecodeBuilder,
 	wire_to_reg: impl Fn(Wire) -> u32,

--- a/crates/frontend/src/compiler/gate/icmp_eq.rs
+++ b/crates/frontend/src/compiler/gate/icmp_eq.rs
@@ -38,7 +38,7 @@ use binius_core::word::Word;
 use crate::compiler::{
 	constraint_builder::{ConstraintBuilder, expr},
 	gate::opcode::OpcodeShape,
-	gate_graph::{Gate, GateData, GateParam, Wire},
+	gate_graph::{GateData, GateParam, Wire},
 };
 
 pub const fn shape() -> OpcodeShape {
@@ -52,7 +52,7 @@ pub const fn shape() -> OpcodeShape {
 	}
 }
 
-pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) {
+pub fn constrain(data: &GateData, builder: &mut ConstraintBuilder) {
 	let GateParam {
 		constants,
 		inputs,
@@ -78,7 +78,6 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 }
 
 pub fn emit_eval_bytecode(
-	_gate: Gate,
 	data: &GateData,
 	builder: &mut crate::compiler::eval_form::BytecodeBuilder,
 	wire_to_reg: impl Fn(Wire) -> u32,

--- a/crates/frontend/src/compiler/gate/icmp_ult.rs
+++ b/crates/frontend/src/compiler/gate/icmp_ult.rs
@@ -25,7 +25,7 @@ use binius_core::word::Word;
 use crate::compiler::{
 	constraint_builder::{ConstraintBuilder, expr},
 	gate::opcode::OpcodeShape,
-	gate_graph::{Gate, GateData, GateParam, Wire},
+	gate_graph::{GateData, GateParam, Wire},
 };
 
 pub const fn shape() -> OpcodeShape {
@@ -39,7 +39,7 @@ pub const fn shape() -> OpcodeShape {
 	}
 }
 
-pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) {
+pub fn constrain(data: &GateData, builder: &mut ConstraintBuilder) {
 	let GateParam {
 		inputs,
 		outputs,
@@ -63,7 +63,6 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 }
 
 pub fn emit_eval_bytecode(
-	_gate: Gate,
 	data: &GateData,
 	builder: &mut crate::compiler::eval_form::BytecodeBuilder,
 	wire_to_reg: impl Fn(Wire) -> u32,

--- a/crates/frontend/src/compiler/gate/imul.rs
+++ b/crates/frontend/src/compiler/gate/imul.rs
@@ -5,7 +5,7 @@
 use crate::compiler::{
 	constraint_builder::ConstraintBuilder,
 	gate::opcode::OpcodeShape,
-	gate_graph::{Gate, GateData, GateParam, Wire},
+	gate_graph::{GateData, GateParam, Wire},
 };
 
 pub const fn shape() -> OpcodeShape {
@@ -19,7 +19,7 @@ pub const fn shape() -> OpcodeShape {
 	}
 }
 
-pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) {
+pub fn constrain(data: &GateData, builder: &mut ConstraintBuilder) {
 	let GateParam {
 		inputs, outputs, ..
 	} = data.gate_param();
@@ -31,7 +31,6 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 }
 
 pub fn emit_eval_bytecode(
-	_gate: Gate,
 	data: &GateData,
 	builder: &mut crate::compiler::eval_form::BytecodeBuilder,
 	wire_to_reg: impl Fn(Wire) -> u32,

--- a/crates/frontend/src/compiler/gate/isub_bin_bout.rs
+++ b/crates/frontend/src/compiler/gate/isub_bin_bout.rs
@@ -4,7 +4,7 @@ use binius_core::word::Word;
 use crate::compiler::{
 	constraint_builder::{ConstraintBuilder, expr},
 	gate::opcode::OpcodeShape,
-	gate_graph::{Gate, GateData, GateParam, Wire},
+	gate_graph::{GateData, GateParam, Wire},
 };
 
 pub const fn shape() -> OpcodeShape {
@@ -18,7 +18,7 @@ pub const fn shape() -> OpcodeShape {
 	}
 }
 
-pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) {
+pub fn constrain(data: &GateData, builder: &mut ConstraintBuilder) {
 	let GateParam {
 		constants,
 		inputs,
@@ -55,7 +55,6 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 }
 
 pub fn emit_eval_bytecode(
-	_gate: Gate,
 	data: &GateData,
 	builder: &mut crate::compiler::eval_form::BytecodeBuilder,
 	wire_to_reg: impl Fn(Wire) -> u32,

--- a/crates/frontend/src/compiler/gate/mod.rs
+++ b/crates/frontend/src/compiler/gate/mod.rs
@@ -2,7 +2,7 @@
 use crate::compiler::{
 	constraint_builder::ConstraintBuilder,
 	eval_form::BytecodeBuilder,
-	gate_graph::{Gate, GateData, GateGraph},
+	gate_graph::{Gate, GateGraph},
 	hints::HintRegistry,
 };
 
@@ -35,27 +35,27 @@ pub mod shift;
 pub fn constrain(gate: Gate, graph: &GateGraph, builder: &mut ConstraintBuilder) {
 	let data = &graph.gates[gate];
 	match data.opcode {
-		Opcode::Band => band::constrain(gate, data, builder),
-		Opcode::Bxor => bxor::constrain(gate, data, builder),
-		Opcode::BxorMulti => bxor_multi::constrain(gate, data, builder),
-		Opcode::Bor => bor::constrain(gate, data, builder),
-		Opcode::Fax => fax::constrain(gate, data, builder),
-		Opcode::Select => select::constrain(gate, data, builder),
-		Opcode::IaddCinCout => iadd_cin_cout::constrain(gate, data, builder),
-		Opcode::Iadd32 => iadd32::constrain(gate, data, builder),
-		Opcode::Iadd32CinCout => iadd32_cin_cout::constrain(gate, data, builder),
-		Opcode::IsubBinBout => isub_bin_bout::constrain(gate, data, builder),
-		Opcode::Shift => shift::constrain(gate, data, builder),
-		Opcode::AssertEq => assert_eq::constrain(gate, data, builder),
-		Opcode::AssertZero => assert_zero::constrain(gate, data, builder),
-		Opcode::AssertNonZero => assert_non_zero::constrain(gate, data, builder),
-		Opcode::AssertFalse => assert_false::constrain(gate, data, builder),
-		Opcode::AssertTrue => assert_true::constrain(gate, data, builder),
-		Opcode::AssertEqCond => assert_eq_cond::constrain(gate, data, builder),
-		Opcode::Imul => imul::constrain(gate, data, builder),
-		Opcode::Bmul => bmul::constrain(gate, data, builder),
-		Opcode::IcmpUlt => icmp_ult::constrain(gate, data, builder),
-		Opcode::IcmpEq => icmp_eq::constrain(gate, data, builder),
+		Opcode::Band => band::constrain(data, builder),
+		Opcode::Bxor => bxor::constrain(data, builder),
+		Opcode::BxorMulti => bxor_multi::constrain(data, builder),
+		Opcode::Bor => bor::constrain(data, builder),
+		Opcode::Fax => fax::constrain(data, builder),
+		Opcode::Select => select::constrain(data, builder),
+		Opcode::IaddCinCout => iadd_cin_cout::constrain(data, builder),
+		Opcode::Iadd32 => iadd32::constrain(data, builder),
+		Opcode::Iadd32CinCout => iadd32_cin_cout::constrain(data, builder),
+		Opcode::IsubBinBout => isub_bin_bout::constrain(data, builder),
+		Opcode::Shift => shift::constrain(data, builder),
+		Opcode::AssertEq => assert_eq::constrain(data, builder),
+		Opcode::AssertZero => assert_zero::constrain(data, builder),
+		Opcode::AssertNonZero => assert_non_zero::constrain(data, builder),
+		Opcode::AssertFalse => assert_false::constrain(data, builder),
+		Opcode::AssertTrue => assert_true::constrain(data, builder),
+		Opcode::AssertEqCond => assert_eq_cond::constrain(data, builder),
+		Opcode::Imul => imul::constrain(data, builder),
+		Opcode::Bmul => bmul::constrain(data, builder),
+		Opcode::IcmpUlt => icmp_ult::constrain(data, builder),
+		Opcode::IcmpEq => icmp_eq::constrain(data, builder),
 		// Hints do not introduce constraints
 		Opcode::Hint => (),
 	}
@@ -64,54 +64,52 @@ pub fn constrain(gate: Gate, graph: &GateGraph, builder: &mut ConstraintBuilder)
 /// Emit bytecode for a single gate
 pub fn emit_gate_bytecode(
 	gate: Gate,
-	data: &GateData,
 	graph: &GateGraph,
 	builder: &mut BytecodeBuilder,
 	wire_to_reg: impl Fn(crate::compiler::gate_graph::Wire) -> u32 + Copy,
 	hint_registry: &HintRegistry,
 ) {
+	let data = &graph.gates[gate];
 	match data.opcode {
-		Opcode::Band => band::emit_eval_bytecode(gate, data, builder, wire_to_reg),
-		Opcode::Bxor => bxor::emit_eval_bytecode(gate, data, builder, wire_to_reg),
-		Opcode::BxorMulti => bxor_multi::emit_eval_bytecode(gate, data, builder, wire_to_reg),
-		Opcode::Bor => bor::emit_eval_bytecode(gate, data, builder, wire_to_reg),
-		Opcode::Fax => fax::emit_eval_bytecode(gate, data, builder, wire_to_reg),
-		Opcode::Select => select::emit_eval_bytecode(gate, data, builder, wire_to_reg),
-		Opcode::IaddCinCout => iadd_cin_cout::emit_eval_bytecode(gate, data, builder, wire_to_reg),
-		Opcode::Iadd32 => iadd32::emit_eval_bytecode(gate, data, builder, wire_to_reg),
-		Opcode::Iadd32CinCout => {
-			iadd32_cin_cout::emit_eval_bytecode(gate, data, builder, wire_to_reg)
-		}
-		Opcode::IsubBinBout => isub_bin_bout::emit_eval_bytecode(gate, data, builder, wire_to_reg),
-		Opcode::Shift => shift::emit_eval_bytecode(gate, data, builder, wire_to_reg),
+		Opcode::Band => band::emit_eval_bytecode(data, builder, wire_to_reg),
+		Opcode::Bxor => bxor::emit_eval_bytecode(data, builder, wire_to_reg),
+		Opcode::BxorMulti => bxor_multi::emit_eval_bytecode(data, builder, wire_to_reg),
+		Opcode::Bor => bor::emit_eval_bytecode(data, builder, wire_to_reg),
+		Opcode::Fax => fax::emit_eval_bytecode(data, builder, wire_to_reg),
+		Opcode::Select => select::emit_eval_bytecode(data, builder, wire_to_reg),
+		Opcode::IaddCinCout => iadd_cin_cout::emit_eval_bytecode(data, builder, wire_to_reg),
+		Opcode::Iadd32 => iadd32::emit_eval_bytecode(data, builder, wire_to_reg),
+		Opcode::Iadd32CinCout => iadd32_cin_cout::emit_eval_bytecode(data, builder, wire_to_reg),
+		Opcode::IsubBinBout => isub_bin_bout::emit_eval_bytecode(data, builder, wire_to_reg),
+		Opcode::Shift => shift::emit_eval_bytecode(data, builder, wire_to_reg),
 		Opcode::AssertEq => {
 			let assertion_path = graph.assertion_names[gate];
-			assert_eq::emit_eval_bytecode(gate, data, assertion_path, builder, wire_to_reg)
+			assert_eq::emit_eval_bytecode(data, assertion_path, builder, wire_to_reg)
 		}
 		Opcode::AssertZero => {
 			let assertion_path = graph.assertion_names[gate];
-			assert_zero::emit_eval_bytecode(gate, data, assertion_path, builder, wire_to_reg)
+			assert_zero::emit_eval_bytecode(data, assertion_path, builder, wire_to_reg)
 		}
 		Opcode::AssertNonZero => {
 			let assertion_path = graph.assertion_names[gate];
-			assert_non_zero::emit_eval_bytecode(gate, data, assertion_path, builder, wire_to_reg)
+			assert_non_zero::emit_eval_bytecode(data, assertion_path, builder, wire_to_reg)
 		}
 		Opcode::AssertEqCond => {
 			let assertion_path = graph.assertion_names[gate];
-			assert_eq_cond::emit_eval_bytecode(gate, data, assertion_path, builder, wire_to_reg)
+			assert_eq_cond::emit_eval_bytecode(data, assertion_path, builder, wire_to_reg)
 		}
 		Opcode::AssertFalse => {
 			let assertion_path = graph.assertion_names[gate];
-			assert_false::emit_eval_bytecode(gate, data, assertion_path, builder, wire_to_reg)
+			assert_false::emit_eval_bytecode(data, assertion_path, builder, wire_to_reg)
 		}
 		Opcode::AssertTrue => {
 			let assertion_path = graph.assertion_names[gate];
-			assert_true::emit_eval_bytecode(gate, data, assertion_path, builder, wire_to_reg)
+			assert_true::emit_eval_bytecode(data, assertion_path, builder, wire_to_reg)
 		}
-		Opcode::Imul => imul::emit_eval_bytecode(gate, data, builder, wire_to_reg),
-		Opcode::Bmul => bmul::emit_eval_bytecode(gate, data, builder, wire_to_reg),
-		Opcode::IcmpUlt => icmp_ult::emit_eval_bytecode(gate, data, builder, wire_to_reg),
-		Opcode::IcmpEq => icmp_eq::emit_eval_bytecode(gate, data, builder, wire_to_reg),
+		Opcode::Imul => imul::emit_eval_bytecode(data, builder, wire_to_reg),
+		Opcode::Bmul => bmul::emit_eval_bytecode(data, builder, wire_to_reg),
+		Opcode::IcmpUlt => icmp_ult::emit_eval_bytecode(data, builder, wire_to_reg),
+		Opcode::IcmpEq => icmp_eq::emit_eval_bytecode(data, builder, wire_to_reg),
 
 		Opcode::Hint => {
 			// Generic hint: hint already lives in the registry from `CircuitBuilder::call_hint`,

--- a/crates/frontend/src/compiler/gate/select.rs
+++ b/crates/frontend/src/compiler/gate/select.rs
@@ -20,7 +20,7 @@
 use crate::compiler::{
 	constraint_builder::{ConstraintBuilder, expr},
 	gate::opcode::OpcodeShape,
-	gate_graph::{Gate, GateData, GateParam, Wire},
+	gate_graph::{GateData, GateParam, Wire},
 };
 
 pub const fn shape() -> OpcodeShape {
@@ -34,7 +34,7 @@ pub const fn shape() -> OpcodeShape {
 	}
 }
 
-pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) {
+pub fn constrain(data: &GateData, builder: &mut ConstraintBuilder) {
 	let GateParam {
 		inputs, outputs, ..
 	} = data.gate_param();
@@ -53,7 +53,6 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 }
 
 pub fn emit_eval_bytecode(
-	_gate: Gate,
 	data: &GateData,
 	builder: &mut crate::compiler::eval_form::BytecodeBuilder,
 	wire_to_reg: impl Fn(Wire) -> u32,

--- a/crates/frontend/src/compiler/gate/shift.rs
+++ b/crates/frontend/src/compiler/gate/shift.rs
@@ -20,7 +20,7 @@ use binius_core::constraint_system::ShiftVariant;
 use crate::compiler::{
 	constraint_builder::{ConstraintBuilder, WireExprTerm, expr},
 	gate::opcode::OpcodeShape,
-	gate_graph::{Gate, GateData, GateParam, Wire},
+	gate_graph::{GateData, GateParam, Wire},
 };
 
 pub const fn shape() -> OpcodeShape {
@@ -55,7 +55,7 @@ const fn shifted_term(variant: ShiftVariant, x: Wire, n: u32) -> WireExprTerm {
 	}
 }
 
-pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) {
+pub fn constrain(data: &GateData, builder: &mut ConstraintBuilder) {
 	let GateParam {
 		inputs,
 		outputs,
@@ -72,7 +72,6 @@ pub fn constrain(_gate: Gate, data: &GateData, builder: &mut ConstraintBuilder) 
 }
 
 pub fn emit_eval_bytecode(
-	_gate: Gate,
 	data: &GateData,
 	builder: &mut crate::compiler::eval_form::BytecodeBuilder,
 	wire_to_reg: impl Fn(Wire) -> u32,


### PR DESCRIPTION
Every per-opcode `constrain` and `emit_eval_bytecode` in `compiler/gate/` declared its first parameter as `_gate: Gate` — 42 functions across 21 modules, none of which referenced it. The gate identity was threaded through the dispatchers purely to keep the signatures uniform.

## The change

`constrain` and `emit_eval_bytecode` now take `data: &GateData` directly. The `Gate` import goes away in every module that only needed it for that parameter.

`emit_gate_bytecode` keeps its own `gate` parameter: it is genuinely used for the six `graph.assertion_names[gate]` lookups that supply the assertion path to the `Assert*` emitters. It does lose the `data: &GateData` argument, though — at both call sites `data` was already `&graph.gates[gate]`, so it now performs that lookup internally, matching what the sibling `constrain` dispatcher has always done. Callers pass `(gate, graph, ...)`, and `EvalForm::build` iterates `gates.keys()` instead of `gates.iter()`.

No behavior change; this is signature-only.

## Testing

`cargo build --workspace` with no new warnings, `cargo clippy -p binius-frontend --all-features --tests --benches -- -D warnings`, `cargo test -p binius-frontend` (167 tests), and `cargo fmt --all --check` — all clean.

Note that `cargo clippy` over the whole workspace currently fails in `binius-iop-prover` (`channel.rs:407`, `<A as Allocator>::Vec<P> cannot be shared between threads safely`). That failure reproduces on an unmodified `main` and is unrelated to this PR — `binius-iop-prover` does not depend on `binius-frontend`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
