### PR TITLE
BINIUS-360: Remove remaining pooled_copy calls

### DIFF
--- a/crates/iop-prover/src/basefold/channel.rs
+++ b/crates/iop-prover/src/basefold/channel.rs
@@ -10,10 +10,8 @@ use binius_iop::{channel::OracleSpec, fri::FRIParams};
 use binius_ip_prover::{
 	channel::IPProverChannel,
 	sumcheck::{
-		self, PaddedSumcheckDecorator,
-		batch::BatchSumcheckOutput,
-		bivariate_product_evaluator::BivariateProductEvaluator,
-		mle_store::{MleStore, pooled_copy},
+		self, PaddedSumcheckDecorator, batch::BatchSumcheckOutput,
+		bivariate_product_evaluator::BivariateProductEvaluator, mle_store::MleStore,
 		round_evaluator::SharedSumcheckProver,
 	},
 };
@@ -62,8 +60,9 @@ struct QueuedRelation<P: PackedField, Data: Deref<Target = [P]>> {
 	oracle_index: usize,
 	/// The committed multilinear message `pi_i`, backed by the caller's allocator.
 	message: FieldBuffer<P, Data>,
-	/// The transparent multilinear `t_i` paired with the message.
-	transparent: FieldBuffer<P>,
+	/// The transparent multilinear `t_i` paired with the message, backed by the caller's
+	/// allocator.
+	transparent: FieldBuffer<P, Data>,
 	/// The claimed inner product `s_i = <pi_i, t_i>`.
 	claim: P::Scalar,
 }
@@ -334,7 +333,7 @@ fn prove_batch_zk_basefold<A, F, P, NTT, Channel>(
 
 			let mut store = MleStore::new(n_i, alloc);
 			let message_col = store.push(message);
-			let transparent_col = store.push_owned(pooled_copy(alloc, &transparent));
+			let transparent_col = store.push_owned(transparent);
 			let inner = SharedSumcheckProver::new(
 				store,
 				[(sum_prime, BivariateProductEvaluator::new([message_col, transparent_col]))],
@@ -552,7 +551,7 @@ where
 	fn prove_oracle_relations(
 		&mut self,
 		oracle_relations: impl IntoIterator<
-			Item = (Self::Oracle, FieldVec<P, A>, FieldBuffer<P>, P::Scalar),
+			Item = (Self::Oracle, FieldVec<P, A>, FieldVec<P, A>, P::Scalar),
 		>,
 	) {
 		// Queue the relations; the actual opening (masking + sumcheck + combined FRI) happens once,

--- a/crates/iop-prover/src/channel/mod.rs
+++ b/crates/iop-prover/src/channel/mod.rs
@@ -8,7 +8,7 @@ use binius_compute::Allocator;
 use binius_field::PackedField;
 use binius_iop::channel::OracleSpec;
 use binius_ip_prover::channel::IPProverChannel;
-use binius_math::{FieldBuffer, FieldSlice, FieldVec};
+use binius_math::{FieldSlice, FieldVec};
 
 /// Channel for IOP provers that extends the IP prover channel with oracle operations.
 ///
@@ -45,10 +45,9 @@ pub trait IOPProverChannel<P: PackedField, A: Allocator>: IPProverChannel<P::Sca
 	/// the same buffer that was passed to `send_oracle()` for this oracle. Callers provide
 	/// the message here so the channel does not need to store it internally.
 	///
-	/// The channel owns each message until the opening runs, so the message is drawn from the
-	/// caller's allocator `A` — a pooled message stays pooled all the way through the opening.
-	/// The transparent multilinear is `Vec`-backed: every producer of one builds it from a
-	/// `binius-math` tensor expansion that takes no allocator.
+	/// The channel owns each message and transparent multilinear until the opening runs, so both
+	/// are drawn from the caller's allocator `A` — a pooled buffer stays pooled all the way
+	/// through the opening.
 	///
 	/// # Preconditions
 	///
@@ -59,7 +58,7 @@ pub trait IOPProverChannel<P: PackedField, A: Allocator>: IPProverChannel<P::Sca
 	fn prove_oracle_relations(
 		&mut self,
 		oracle_relations: impl IntoIterator<
-			Item = (Self::Oracle, FieldVec<P, A>, FieldBuffer<P>, P::Scalar),
+			Item = (Self::Oracle, FieldVec<P, A>, FieldVec<P, A>, P::Scalar),
 		>,
 	);
 }

--- a/crates/iop-prover/src/logup_star.rs
+++ b/crates/iop-prover/src/logup_star.rs
@@ -17,7 +17,7 @@ use binius_field::{BinaryField, Divisible, PackedField};
 pub use binius_ip_prover::logup_star::Looker;
 use binius_ip_prover::logup_star::{self as reduction, witness};
 use binius_math::{
-	FieldBuffer, multilinear::eq::eq_ind_partial_eval, univariate::evaluate_univariate,
+	FieldBuffer, multilinear::eq::eq_ind_partial_eval_in, univariate::evaluate_univariate,
 };
 
 use crate::channel::IOPProverChannel;
@@ -112,7 +112,7 @@ where
 	//
 	//     <Y, eq_r'> = Y(r') = pushforward_eval_claim
 	let _open_guard = tracing::debug_span!("Open pushforward relation").entered();
-	let transparent = eq_ind_partial_eval::<P>(&output.table_eval_point);
+	let transparent = eq_ind_partial_eval_in::<A, P>(alloc, &output.table_eval_point);
 	channel.prove_oracle_relations([(
 		oracle,
 		pushforward,

--- a/crates/ip-prover/src/logup_star/prove.rs
+++ b/crates/ip-prover/src/logup_star/prove.rs
@@ -15,7 +15,6 @@ use super::{
 use crate::{
 	channel::IPProverChannel,
 	fracaddcheck::{self, FracAddCheckProver, FracEvalClaim},
-	sumcheck::mle_store::pooled_copy,
 };
 
 /// Prove a logUp* indexed-lookup reduction.
@@ -187,8 +186,13 @@ where
 		})
 		.unzip();
 	let table_den = witness::table_denominator::<A, F, P>(alloc, c, m);
-	let (table_prover, table_root) =
-		FracAddCheckProver::new(m, alloc, (pooled_copy(alloc, &pushforward), table_den));
+	// The pushforward is borrowed — a committing caller keeps it for the oracle opening — so the
+	// table circuit's leaf layer, which it folds in place, is a clone drawn from `alloc`.
+	let (table_prover, table_root) = FracAddCheckProver::new(
+		m,
+		alloc,
+		(FieldVec::<P, A>::clone_from_slice(alloc, pushforward.to_ref()), table_den),
+	);
 	let num_r = table_root.0.get(0);
 	let den_r = table_root.1.get(0);
 

--- a/crates/ip-prover/src/logup_star/prove.rs
+++ b/crates/ip-prover/src/logup_star/prove.rs
@@ -5,7 +5,7 @@
 use binius_compute::Allocator;
 use binius_field::{BinaryField, Divisible, Field, PackedField};
 use binius_ip::{MultilinearEvalClaim, logup_star::LogupOutput};
-use binius_math::{FieldBuffer, FieldSlice, univariate::evaluate_univariate};
+use binius_math::{FieldBuffer, FieldSlice, FieldVec, univariate::evaluate_univariate};
 use binius_utils::{checked_arithmetics::log2_ceil_usize, rayon::prelude::*};
 
 use super::{
@@ -152,7 +152,7 @@ pub fn prove_reduction<A, F, P>(
 	table: &FieldBuffer<P>,
 	lookers: &[Looker<'_, F>],
 	eval_claim: F,
-	numerators: Vec<FieldBuffer<P>>,
+	numerators: Vec<FieldVec<P, A>>,
 	pushforward: FieldSlice<P>,
 	channel: &mut impl IPProverChannel<F>,
 ) -> LogupOutput<F>
@@ -182,8 +182,7 @@ where
 		.into_par_iter()
 		.map(|(looker, numerator)| {
 			let den = witness::looker_denominator::<A, F, P>(alloc, c, looker.index);
-			let (prover, root) =
-				FracAddCheckProver::new(n, alloc, (pooled_copy(alloc, &numerator), den));
+			let (prover, root) = FracAddCheckProver::new(n, alloc, (numerator, den));
 			(prover, (root.0.get(0), root.1.get(0)))
 		})
 		.unzip();

--- a/crates/ip-prover/src/logup_star/witness.rs
+++ b/crates/ip-prover/src/logup_star/witness.rs
@@ -13,7 +13,9 @@ use std::iter;
 
 use binius_compute::{Allocator, VecLike};
 use binius_field::{BinaryField, Divisible, Field, PackedField, util::powers};
-use binius_math::{FieldBuffer, FieldVec, multilinear::eq::scaled_eq_ind_partial_eval_into};
+use binius_math::{
+	FieldBuffer, FieldSlice, FieldVec, multilinear::eq::scaled_eq_ind_partial_eval_into,
+};
 use binius_utils::rayon::{current_num_threads, prelude::*};
 
 use super::prove::Looker;
@@ -29,9 +31,9 @@ use super::prove::Looker;
 ///     Y = sum_j gamma^j * (I_j)_* eq_{r_j}
 /// ```
 ///
-/// The combined pushforward is drawn from `alloc`: a committing caller hands it to the channel,
-/// which owns it until the opening runs. The per-looker numerators stay `Vec`-backed — they are
-/// consumed by the reduction in this crate and never cross a channel boundary.
+/// Both the per-looker numerators and the combined pushforward are drawn from `alloc`: the
+/// numerators become the leaf layers of the per-looker fractional-addition circuits, and a
+/// committing caller hands the pushforward to the channel, which owns it until the opening runs.
 ///
 /// # Preconditions
 ///
@@ -48,7 +50,7 @@ pub fn combined_lookers<A, F, P>(
 	lookers: &[Looker<'_, F>],
 	gamma: F,
 	table_n_vars: usize,
-) -> (Vec<FieldBuffer<P>>, FieldVec<P, A>)
+) -> (Vec<FieldVec<P, A>>, FieldVec<P, A>)
 where
 	A: Allocator,
 	F: Field,
@@ -66,12 +68,12 @@ where
 	// Why fan out: the per-looker expansion is itself parallel.
 	//   But it under-saturates the machine at moderate n.
 	//   Spreading the lookers over the cores fills them.
-	// The 2^n backing Vecs are reserved up front on this thread, so the parallel region only fills
-	// them — no allocator traffic inside the rayon closures.
+	// The 2^n backing buffers are drawn from `alloc` up front on this thread, so the parallel
+	// region only fills them — no allocator traffic inside the rayon closures.
 	// Invariant: the fill writes results back in looker order (the zip is index-aligned).
 	//   So numerator j stays gamma^j * eq_{r_j}.
 	let packed_len = 1 << n.saturating_sub(P::LOG_WIDTH);
-	let buffers = iter::repeat_with(|| Vec::<P>::with_capacity(packed_len))
+	let buffers = iter::repeat_with(|| alloc.alloc::<P>(packed_len))
 		.take(lookers.len())
 		.collect::<Vec<_>>();
 	let numerators = (buffers, scales.as_slice(), lookers)
@@ -96,8 +98,14 @@ where
 		})
 		.collect::<Vec<_>>();
 
-	// Scatter every looker's numerator onto the shared table cube, summed into one buffer.
-	let combined = combined_pushforward::<A, F, P>(alloc, &numerators, lookers, table_n_vars);
+	// Scatter every looker's numerator onto the shared table cube, summed into one buffer. The
+	// scatter reads the numerators from rayon tasks, so it borrows them as slices: `Allocator::Vec`
+	// is declared only `Send`, so a numerator cannot be shared across tasks by reference.
+	let numerator_slices = numerators
+		.iter()
+		.map(FieldBuffer::to_ref)
+		.collect::<Vec<_>>();
+	let combined = combined_pushforward::<A, F, P>(alloc, &numerator_slices, lookers, table_n_vars);
 
 	(numerators, combined)
 }
@@ -132,7 +140,7 @@ where
 /// * Every index entry is less than `2^table_n_vars`.
 fn combined_pushforward<A, F, P>(
 	alloc: &A,
-	numerators: &[FieldBuffer<P>],
+	numerators: &[FieldSlice<'_, P>],
 	lookers: &[Looker<'_, F>],
 	table_n_vars: usize,
 ) -> FieldVec<P, A>
@@ -188,7 +196,7 @@ where
 ///
 /// The numerator is read sequentially, so each row is a lane read, not an indexed lookup.
 #[inline]
-fn scatter_add<F, P>(acc: &mut [F], numerator: &FieldBuffer<P>, index: &[usize])
+fn scatter_add<F, P>(acc: &mut [F], numerator: &FieldSlice<'_, P>, index: &[usize])
 where
 	F: Field,
 	P: PackedField<Scalar = F>,
@@ -297,7 +305,7 @@ where
 	// One accumulator slot per table position, all starting empty.
 	let mut buckets = vec![F::ZERO; 1usize << table_n_vars];
 	// Add each row's numerator value into the position it indexes into.
-	scatter_add(&mut buckets, eq_r, index);
+	scatter_add(&mut buckets, &eq_r.to_ref(), index);
 	// Repack the scalar accumulator into the packed table buffer.
 	FieldBuffer::from_values(&buckets)
 }
@@ -399,7 +407,11 @@ mod tests {
 			})
 			.collect::<Vec<_>>();
 
-		let got = combined_pushforward::<_, F, P>(&GlobalAllocator, &numerators, &lookers, m)
+		let numerator_slices = numerators
+			.iter()
+			.map(FieldBuffer::to_ref)
+			.collect::<Vec<_>>();
+		let got = combined_pushforward::<_, F, P>(&GlobalAllocator, &numerator_slices, &lookers, m)
 			.iter_scalars()
 			.collect::<Vec<_>>();
 		assert_eq!(got, combined_reference(&numerators, &indices, m));

--- a/crates/ip-prover/src/sumcheck/mle_store.rs
+++ b/crates/ip-prover/src/sumcheck/mle_store.rs
@@ -21,7 +21,7 @@
 
 use std::iter;
 
-use binius_compute::{Allocator, VecLike};
+use binius_compute::Allocator;
 use binius_field::{Field, PackedField};
 use binius_math::{
 	FieldBuffer, FieldSlice, FieldVec,
@@ -32,21 +32,6 @@ use binius_utils::rayon;
 use itertools::izip;
 
 use super::gruen32::Gruen32;
-
-/// Copies `src` into a buffer freshly allocated from `alloc`.
-///
-/// This is the bridge for a `Vec`-backed buffer built by `binius-math` (e.g. `from_values`): the
-/// live buffer is a genuine allocation from `alloc` (so under a pool it recycles through the free
-/// list), and the source is dropped. Prefer building directly into `alloc` where an allocator-aware
-/// constructor exists.
-pub fn pooled_copy<A: Allocator, P: PackedField, Data: std::ops::Deref<Target = [P]>>(
-	alloc: &A,
-	src: &FieldBuffer<P, Data>,
-) -> FieldVec<P, A> {
-	let mut data = alloc.alloc::<P>(src.as_ref().len());
-	data.extend_from_slice(src.as_ref());
-	FieldBuffer::new(src.log_len(), data)
-}
 
 /// Identifier of a column held by an [`MleStore`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/ip-prover/src/sumcheck/zk_mlecheck.rs
+++ b/crates/ip-prover/src/sumcheck/zk_mlecheck.rs
@@ -10,10 +10,12 @@
 
 use std::{iter, ops::Deref};
 
+use binius_compute::Allocator;
 use binius_field::{Field, PackedField, util::powers};
 use binius_ip::{mlecheck, sumcheck::RoundCoeffs};
 use binius_math::{
-	field_buffer::FieldBuffer, line::extrapolate_line_packed, univariate::evaluate_univariate,
+	FieldVec, field_buffer::FieldBuffer, line::extrapolate_line_packed,
+	univariate::evaluate_univariate,
 };
 
 use super::{
@@ -47,6 +49,7 @@ pub struct ProveZKOutput<F: Field> {
 ///
 /// # Arguments
 ///
+/// * `alloc` - The allocator the expansion is drawn from
 /// * `challenge_point` - The challenge point `r` from sumcheck (length `n_vars`)
 /// * `n_vars` - Number of variables in the mask polynomial
 /// * `degree` - Degree of each univariate in the mask polynomial
@@ -56,19 +59,20 @@ pub struct ProveZKOutput<F: Field> {
 /// # Panics
 ///
 /// Panics (in debug mode) if `n_vars > 2^m_n` or `degree + 1 > 2^m_d`.
-pub fn expand_libra_eval<P: PackedField>(
+pub fn expand_libra_eval<A: Allocator, P: PackedField>(
+	alloc: &A,
 	challenge_point: &[P::Scalar],
 	n_vars: usize,
 	degree: usize,
 	m_n: usize,
 	m_d: usize,
-) -> FieldBuffer<P> {
+) -> FieldVec<P, A> {
 	debug_assert!(challenge_point.len() == n_vars);
 	debug_assert!(n_vars <= 1 << m_n);
 	debug_assert!(degree < 1 << m_d);
 
 	let log_size = m_n + m_d;
-	let mut buffer = FieldBuffer::<P>::zeros(log_size);
+	let mut buffer = FieldVec::<P, A>::zeros_in(alloc, log_size);
 	let row_stride = 1 << m_d;
 
 	for (j, &r_j) in challenge_point.iter().enumerate() {
@@ -633,6 +637,7 @@ mod tests {
 
 	#[test]
 	fn test_libra_eval_inner_product_equals_mask_eval() {
+		use binius_compute::GlobalAllocator;
 		use binius_math::inner_product::inner_product_buffers;
 
 		let mut rng = StdRng::seed_from_u64(0);
@@ -653,8 +658,14 @@ mod tests {
 			.sum();
 
 		// Compute <g', libra_eval_r> using inner product
-		let libra_eval_tensor =
-			expand_libra_eval::<B128>(&challenge_point, n_vars, degree, m_n, m_d);
+		let libra_eval_tensor = expand_libra_eval::<_, B128>(
+			&GlobalAllocator,
+			&challenge_point,
+			n_vars,
+			degree,
+			m_n,
+			m_d,
+		);
 		let inner_product_eval = inner_product_buffers(&mask_buffer, &libra_eval_tensor);
 
 		assert_eq!(
@@ -685,8 +696,14 @@ mod tests {
 		let challenge_point: Vec<B128> = random_scalars(&mut rng, n_vars);
 
 		// Generate libra_eval tensor
-		let libra_eval_tensor =
-			expand_libra_eval::<B128>(&challenge_point, n_vars, degree, m_n, m_d);
+		let libra_eval_tensor = expand_libra_eval::<_, B128>(
+			&GlobalAllocator,
+			&challenge_point,
+			n_vars,
+			degree,
+			m_n,
+			m_d,
+		);
 
 		// Compute the claimed sum: <g', libra_eval_r> = g(r)
 		let claimed_sum = inner_product_par(&mask_buffer, &libra_eval_tensor);

--- a/crates/m4-prover/src/prove.rs
+++ b/crates/m4-prover/src/prove.rs
@@ -353,7 +353,7 @@ impl IOPProver {
 			// The point is `r_j || r_rho || r_y`.
 			// Its instance coordinates fold the trace at `r_rho`.
 			let trace_point = [r_j, r_rho.as_slice(), r_y].concat();
-			ring_switch::prove(trace_packed.to_ref(), &trace_point, channel)
+			ring_switch::prove(alloc, trace_packed.to_ref(), &trace_point, channel)
 		};
 
 		// Queue the trace opening against the ring-switch's transparent multilinear.

--- a/crates/math/src/multilinear/eq.rs
+++ b/crates/math/src/multilinear/eq.rs
@@ -1,6 +1,7 @@
 // Copyright 2024-2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
+use binius_compute::VecLike;
 use binius_field::{PackedField, field::FieldOps};
 
 use super::hypercube::{self, Hypercube, OneCube};
@@ -57,22 +58,22 @@ pub fn scaled_eq_ind_partial_eval<P: PackedField>(
 	hypercube::scaled_eq_ind_partial_eval::<OneCube, P>(point, scale)
 }
 
-/// Builds the scaled equality indicator expansion of `point` in a caller-supplied backing `Vec`.
+/// Builds the scaled equality indicator expansion of `point` in a caller-supplied backing buffer.
 ///
 /// This is the allocation-hoisting form of [`scaled_eq_ind_partial_eval`]: the caller owns the
-/// backing `Vec`, so its allocation can be reserved on a different thread than the one that fills
-/// it. Returns a buffer with `log_len == point.len()`. A scale of one reproduces the unscaled
-/// equality indicator.
+/// backing buffer, so its allocation can be drawn from a pool, or reserved on a different thread
+/// than the one that fills it. Returns a buffer with `log_len == point.len()`. A scale of one
+/// reproduces the unscaled equality indicator.
 ///
 /// # Preconditions
 ///
-/// * `buffer.capacity()` must equal `1 << point.len().saturating_sub(P::LOG_WIDTH)`.
-pub fn scaled_eq_ind_partial_eval_into<P: PackedField>(
+/// * `buffer.capacity()` must be at least `1 << point.len().saturating_sub(P::LOG_WIDTH)`.
+pub fn scaled_eq_ind_partial_eval_into<P: PackedField, Data: VecLike<P>>(
 	point: &[P::Scalar],
 	scale: P::Scalar,
-	buffer: Vec<P>,
-) -> FieldBuffer<P> {
-	hypercube::scaled_eq_ind_partial_eval_into::<OneCube, P>(point, scale, buffer)
+	buffer: Data,
+) -> FieldBuffer<P, Data> {
+	hypercube::scaled_eq_ind_partial_eval_into::<OneCube, P, Data>(point, scale, buffer)
 }
 
 /// Truncate the equality indicator expansion to the low indexed variables.

--- a/crates/math/src/multilinear/eq.rs
+++ b/crates/math/src/multilinear/eq.rs
@@ -1,11 +1,11 @@
 // Copyright 2024-2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-use binius_compute::VecLike;
+use binius_compute::{Allocator, VecLike};
 use binius_field::{PackedField, field::FieldOps};
 
 use super::hypercube::{self, Hypercube, OneCube};
-use crate::{FieldBuffer, field_buffer::BufferData};
+use crate::{FieldBuffer, FieldVec, field_buffer::BufferData};
 
 /// Tensor of values with the eq indicator evaluated at extra_query_coordinates.
 ///
@@ -35,6 +35,17 @@ pub fn tensor_prod_eq_ind<P: PackedField>(
 /// [DP23]: <https://eprint.iacr.org/2023/1784>
 pub fn eq_ind_partial_eval<P: PackedField>(point: &[P::Scalar]) -> FieldBuffer<P> {
 	hypercube::eq_ind_partial_eval::<OneCube, P>(point)
+}
+
+/// Builds the equality indicator expansion of `point` into a buffer drawn from `alloc`.
+///
+/// The allocator-aware counterpart to [`eq_ind_partial_eval`]: under a `BufferPool` the expansion
+/// is a recyclable pooled buffer rather than a fresh `Vec`.
+pub fn eq_ind_partial_eval_in<A: Allocator, P: PackedField>(
+	alloc: &A,
+	point: &[P::Scalar],
+) -> FieldVec<P, A> {
+	hypercube::eq_ind_partial_eval_in::<OneCube, A, P>(alloc, point)
 }
 
 /// Computes the partial evaluation of the equality indicator polynomial, scaled by a constant.

--- a/crates/math/src/multilinear/hypercube.rs
+++ b/crates/math/src/multilinear/hypercube.rs
@@ -8,6 +8,7 @@
 
 use std::{iter, slice};
 
+use binius_compute::VecLike;
 use binius_field::{Field, PackedField, field::FieldOps};
 use binius_utils::rayon::prelude::*;
 
@@ -158,6 +159,34 @@ pub fn tensor_prod_eq_ind<Cube: Hypercube, P: PackedField>(
 	let final_packed_len = 1usize << final_log_len.saturating_sub(P::LOG_WIDTH);
 	data.reserve_exact(final_packed_len.saturating_sub(data.len()));
 
+	tensor_prod_eq_ind_reserved::<Cube, P, _>(
+		FieldBuffer::new(start_log_len, data),
+		extra_query_coordinates,
+	)
+}
+
+/// [`tensor_prod_eq_ind`] over a backing store that already has room for the expansion.
+///
+/// The public entry point reserves the final capacity on its `Vec` before calling here. The
+/// allocator-backed callers ([`scaled_eq_ind_partial_eval_into`]) pass a buffer drawn at the final
+/// size, which cannot grow, so the reservation is their precondition rather than a step of the
+/// expansion.
+///
+/// # Preconditions
+///
+/// * `values.capacity()` must be at least `1 << (values.log_len() +
+///   extra_query_coordinates.len()).saturating_sub(P::LOG_WIDTH)`.
+fn tensor_prod_eq_ind_reserved<Cube: Hypercube, P: PackedField, Data: VecLike<P>>(
+	values: FieldBuffer<P, Data>,
+	extra_query_coordinates: &[P::Scalar],
+) -> FieldBuffer<P, Data> {
+	let start_log_len = values.log_len();
+	let final_log_len = start_log_len + extra_query_coordinates.len();
+	let mut data = values.take_data();
+
+	// precondition
+	debug_assert!(data.capacity() >= 1usize << final_log_len.saturating_sub(P::LOG_WIDTH));
+
 	// The coordinates split cleanly: while the expansion is narrower than one packed word it lives
 	// entirely in `data[0]`, and once it fills a word every step doubles the packed length.
 	let sub_width_count = extra_query_coordinates
@@ -233,31 +262,30 @@ pub fn scaled_eq_ind_partial_eval<Cube: Hypercube, P: PackedField>(
 ) -> FieldBuffer<P> {
 	// Reserve the final packed length up front so the per-variable growth never reallocates.
 	let packed_len = 1 << point.len().saturating_sub(P::LOG_WIDTH);
-	scaled_eq_ind_partial_eval_into::<Cube, P>(point, scale, Vec::with_capacity(packed_len))
+	scaled_eq_ind_partial_eval_into::<Cube, P, _>(point, scale, Vec::with_capacity(packed_len))
 }
 
-/// Builds the scaled equality indicator expansion of `point` in a caller-supplied backing `Vec`.
+/// Builds the scaled equality indicator expansion of `point` in a caller-supplied backing buffer.
 ///
 /// This is the allocation-hoisting form of [`scaled_eq_ind_partial_eval`]: the caller owns the
-/// backing `Vec`, so its allocation can be reserved on a different thread than the one that fills
-/// it. The `Vec` is cleared, seeded with `scale`, grown one variable at a time into the tensor
-/// product $scale \cdot b(r_0) \otimes \ldots \otimes b(r_{n-1})$, and wrapped into the returned
-/// buffer with `log_len == point.len()`.
+/// backing buffer, so its allocation can be drawn from a pool, or reserved on a different thread
+/// than the one that fills it. The buffer is cleared, seeded with `scale`, grown one variable at a
+/// time into the tensor product $scale \cdot b(r_0) \otimes \ldots \otimes b(r_{n-1})$, and wrapped
+/// into the returned buffer with `log_len == point.len()`.
 ///
 /// # Preconditions
 ///
-/// * `buffer.capacity()` must equal `1 << point.len().saturating_sub(P::LOG_WIDTH)`, so the growth
-///   never reallocates and the final wrap keeps the same allocation.
-pub fn scaled_eq_ind_partial_eval_into<Cube: Hypercube, P: PackedField>(
+/// * `buffer.capacity()` must be at least `1 << point.len().saturating_sub(P::LOG_WIDTH)`, so the
+///   growth never reallocates and the final wrap keeps the same allocation.
+pub fn scaled_eq_ind_partial_eval_into<Cube: Hypercube, P: PackedField, Data: VecLike<P>>(
 	point: &[P::Scalar],
 	scale: P::Scalar,
-	mut buffer: Vec<P>,
-) -> FieldBuffer<P> {
-	let packed_len = 1 << point.len().saturating_sub(P::LOG_WIDTH);
-	assert_eq!(
-		buffer.capacity(),
-		packed_len,
-		"precondition: buffer capacity must match the packed expansion length"
+	mut buffer: Data,
+) -> FieldBuffer<P, Data> {
+	let packed_len = 1usize << point.len().saturating_sub(P::LOG_WIDTH);
+	assert!(
+		buffer.capacity() >= packed_len,
+		"precondition: buffer capacity must cover the packed expansion length"
 	);
 
 	// Seed a single-scalar buffer with the scale; the expansion multiplies it through, so every
@@ -265,7 +293,7 @@ pub fn scaled_eq_ind_partial_eval_into<Cube: Hypercube, P: PackedField>(
 	buffer.clear();
 	buffer.push(P::from_scalars(iter::once(scale)));
 	let values = FieldBuffer::new(0, buffer);
-	tensor_prod_eq_ind::<Cube, P>(values, point)
+	tensor_prod_eq_ind_reserved::<Cube, P, Data>(values, point)
 }
 
 /// Truncate the equality indicator expansion to the low indexed variables.

--- a/crates/math/src/multilinear/hypercube.rs
+++ b/crates/math/src/multilinear/hypercube.rs
@@ -8,11 +8,11 @@
 
 use std::{iter, slice};
 
-use binius_compute::VecLike;
+use binius_compute::{Allocator, VecLike};
 use binius_field::{Field, PackedField, field::FieldOps};
 use binius_utils::rayon::prelude::*;
 
-use crate::{FieldBuffer, field_buffer::BufferData};
+use crate::{FieldBuffer, FieldVec, field_buffer::BufferData};
 
 /// A hypercube of coefficients for multilinear polynomials.
 ///
@@ -245,6 +245,22 @@ fn tensor_prod_eq_ind_reserved<Cube: Hypercube, P: PackedField, Data: VecLike<P>
 pub fn eq_ind_partial_eval<Cube: Hypercube, P: PackedField>(point: &[P::Scalar]) -> FieldBuffer<P> {
 	// The unscaled indicator is the scaled indicator with a scale of one.
 	scaled_eq_ind_partial_eval::<Cube, P>(point, P::Scalar::ONE)
+}
+
+/// Builds the equality indicator expansion of `point` into a buffer drawn from `alloc`.
+///
+/// The allocator-aware counterpart to [`eq_ind_partial_eval`]: under a `BufferPool` the expansion
+/// is a recyclable pooled buffer rather than a fresh `Vec`.
+pub fn eq_ind_partial_eval_in<Cube: Hypercube, A: Allocator, P: PackedField>(
+	alloc: &A,
+	point: &[P::Scalar],
+) -> FieldVec<P, A> {
+	let packed_len = 1 << point.len().saturating_sub(P::LOG_WIDTH);
+	scaled_eq_ind_partial_eval_into::<Cube, P, _>(
+		point,
+		P::Scalar::ONE,
+		alloc.alloc::<P>(packed_len),
+	)
 }
 
 /// Computes the partial evaluation of the equality indicator polynomial, scaled by a constant.

--- a/crates/prover/benches/intmul.rs
+++ b/crates/prover/benches/intmul.rs
@@ -186,7 +186,7 @@ fn bench_intmul_phases(c: &mut Criterion) {
 		let mut transcript = ProverTranscript::new(StdChallenger::default());
 		let mut prover = IntMulProver::<_, P, _>::new(0, &mut transcript, &alloc);
 		let w = Witness::<_, P>::new(&alloc, &a, &b, &c_lo, &c_hi).unwrap();
-		prover.phase1(&initial_eval_point, w.b_prodcheck, &witness.b_leaves, exp_eval)
+		prover.phase1(&initial_eval_point, w.b_prodcheck, witness.b_leaves.to_ref(), exp_eval)
 	};
 	let phase2 = frobenius_twist(Word::LOG_BITS, &phase1.eval_point, &phase1.b_leaves_evals);
 	let phase3 = {
@@ -228,7 +228,7 @@ fn bench_intmul_phases(c: &mut Criterion) {
 			|b_prodcheck| {
 				let mut transcript = ProverTranscript::new(StdChallenger::default());
 				let mut prover = IntMulProver::<_, P, _>::new(0, &mut transcript, &alloc);
-				prover.phase1(&initial_eval_point, b_prodcheck, &witness.b_leaves, exp_eval)
+				prover.phase1(&initial_eval_point, b_prodcheck, witness.b_leaves.to_ref(), exp_eval)
 			},
 			BatchSize::SmallInput,
 		);
@@ -339,7 +339,7 @@ fn bench_intmul_components(c: &mut Criterion) {
 	// Computing the leaves of the variable-base exponentiation tree (`a` root as base, `b` as
 	// exponents).
 	group.bench_function("b_leaves", |bencher| {
-		bencher.iter(|| compute_b_leaves::<F, P>(&witness.a_root, witness.b_exponents));
+		bencher.iter(|| compute_b_leaves::<_, F, P>(&alloc, &witness.a_root, witness.b_exponents));
 	});
 
 	// Computing a product tree over the leaves.
@@ -363,7 +363,7 @@ fn bench_intmul_components(c: &mut Criterion) {
 		let mut transcript = ProverTranscript::new(StdChallenger::default());
 		let mut prover = IntMulProver::<_, P, _>::new(0, &mut transcript, &alloc);
 		let w = Witness::<_, P>::new(&alloc, &a, &b, &c_lo, &c_hi).unwrap();
-		prover.phase1(&initial_eval_point, w.b_prodcheck, &witness.b_leaves, exp_eval)
+		prover.phase1(&initial_eval_point, w.b_prodcheck, witness.b_leaves.to_ref(), exp_eval)
 	};
 	let phase2 = frobenius_twist(Word::LOG_BITS, &phase1.eval_point, &phase1.b_leaves_evals);
 

--- a/crates/prover/src/protocols/intmul/prove.rs
+++ b/crates/prover/src/protocols/intmul/prove.rs
@@ -24,7 +24,7 @@ use binius_ip_prover::{
 	},
 };
 use binius_math::{
-	FieldVec,
+	FieldSlice, FieldVec,
 	field_buffer::FieldBuffer,
 	inner_product::inner_product_buffers,
 	multilinear::{
@@ -166,7 +166,7 @@ where
 		let Phase1Output {
 			eval_point: phase1_eval_point,
 			b_leaves_evals,
-		} = self.phase1(&initial_eval_point, b_prodcheck, &b_leaves, exp_eval);
+		} = self.phase1(&initial_eval_point, b_prodcheck, b_leaves.to_ref(), exp_eval);
 
 		// Phase 2
 		let Phase2Output {
@@ -415,7 +415,7 @@ where
 		&mut self,
 		eval_point: &[F],
 		b_prover: ProdcheckProver<'alloc, A, P>,
-		b_leaves: &FieldBuffer<P>,
+		b_leaves: FieldSlice<P>,
 		b_root_eval: F,
 	) -> Phase1Output<F> {
 		let n_vars = eval_point.len();

--- a/crates/prover/src/protocols/intmul/witness.rs
+++ b/crates/prover/src/protocols/intmul/witness.rs
@@ -3,10 +3,10 @@
 
 use std::{iter, mem::MaybeUninit, ops::Deref};
 
-use binius_compute::Allocator;
+use binius_compute::{Allocator, VecLike};
 use binius_core::word::Word;
 use binius_field::{BinaryField, Field, PackedField};
-use binius_ip_prover::{prodcheck::ProdcheckProver, sumcheck::mle_store::pooled_copy};
+use binius_ip_prover::prodcheck::ProdcheckProver;
 use binius_math::{FieldVec, field_buffer::FieldBuffer};
 use binius_utils::{
 	checked_arithmetics::{checked_log_2, strict_log_2},
@@ -57,7 +57,7 @@ pub struct Witness<'a, 'alloc, A: Allocator, P: PackedField> {
 	pub b_exponents: &'a [Word],
 	/// Concatenated b leaves for prodcheck: [L_0, L_1, ..., L_{2^k-1}].
 	/// Has log_len = n_vars + Word::LOG_BITS.
-	pub b_leaves: FieldBuffer<P>,
+	pub b_leaves: FieldVec<P, A>,
 	/// The prover for the prodcheck reduction on b_leaves.
 	pub b_prodcheck: ProdcheckProver<'alloc, A, P>,
 	/// The root of the b tree (product of all leaves element-wise).
@@ -181,9 +181,14 @@ where
 		// Compute b_leaves as concatenated leaves for prodcheck; the variable base is the `a` root.
 		let variable_base_tree_scope =
 			tracing::debug_span!("Compute variable-base prodcheck layers").entered();
-		let b_leaves = compute_b_leaves(&a_root, b);
-		let (b_prodcheck, b_root) =
-			ProdcheckProver::new(Word::LOG_BITS, alloc, pooled_copy(alloc, &b_leaves));
+		let b_leaves = compute_b_leaves(alloc, &a_root, b);
+		// The prodcheck prover folds its leaf layer in place, and phase 1 reads the leaves again
+		// afterwards, so the prover gets a clone.
+		let (b_prodcheck, b_root) = ProdcheckProver::new(
+			Word::LOG_BITS,
+			alloc,
+			FieldVec::<P, A>::clone_from_slice(alloc, b_leaves.to_ref()),
+		);
 		let b_root = unpool::<A, P>(b_root);
 		drop(variable_base_tree_scope);
 
@@ -339,9 +344,17 @@ where
 ///
 /// Each leaf `L_z` contains: if bit z of `exponents[i]` is set then `bases[i]^{2^z}` else 1
 /// The leaves are concatenated: `[L_0, L_1, ..., L_{2^k-1}]`
+///
+/// The leaves are drawn from `alloc`: the prodcheck prover folds them in place, so they are a
+/// working buffer for the whole reduction.
 #[doc(hidden)] // exposed for benchmarking (`benches/intmul.rs`), not a stable API
-pub fn compute_b_leaves<F, P>(bases: &FieldBuffer<P>, exponents: &[Word]) -> FieldBuffer<P>
+pub fn compute_b_leaves<A, F, P>(
+	alloc: &A,
+	bases: &FieldBuffer<P>,
+	exponents: &[Word],
+) -> FieldVec<P, A>
 where
+	A: Allocator,
 	F: Field,
 	P: PackedField<Scalar = F>,
 {
@@ -349,11 +362,11 @@ where
 
 	if P::LOG_WIDTH <= n_vars {
 		// Parallel optimized path
-		return compute_b_leaves_parallel(bases, exponents);
+		return compute_b_leaves_parallel(alloc, bases, exponents);
 	}
 
 	// Fallback: bases is too small to parallelize (n_vars < P::LOG_WIDTH)
-	let mut out = FieldBuffer::zeros(n_vars + Word::LOG_BITS);
+	let mut out = FieldVec::<P, A>::zeros_in(alloc, n_vars + Word::LOG_BITS);
 	let n_elems = 1 << n_vars;
 
 	for (i, (mut base, &exp)) in iter::zip(bases.iter_scalars(), exponents).enumerate() {
@@ -372,8 +385,13 @@ where
 }
 
 /// Parallel implementation of compute_b_leaves for when bases is large enough to parallelize.
-fn compute_b_leaves_parallel<F, P>(bases: &FieldBuffer<P>, exponents: &[Word]) -> FieldBuffer<P>
+fn compute_b_leaves_parallel<A, F, P>(
+	alloc: &A,
+	bases: &FieldBuffer<P>,
+	exponents: &[Word],
+) -> FieldVec<P, A>
 where
+	A: Allocator,
 	F: Field,
 	P: PackedField<Scalar = F>,
 {
@@ -382,10 +400,12 @@ where
 	let height = Word::BITS;
 	let total = n_packed * height;
 
-	let mut out_vec: Vec<P> = Vec::with_capacity(total);
+	let mut out_vec = alloc.alloc::<P>(total);
 
 	{
-		let spare: &mut [MaybeUninit<P>] = out_vec.spare_capacity_mut();
+		// An allocator may hand back more capacity than requested, so take exactly the packed
+		// length the strided view expects.
+		let spare: &mut [MaybeUninit<P>] = &mut out_vec.spare_capacity_mut()[..total];
 
 		let mut strided = StridedArray2DViewMut::without_stride(spare, height, n_packed)
 			.expect("dimensions match capacity");
@@ -560,7 +580,7 @@ mod tests {
 				.map(|_| Word::from_u64(rng.random()))
 				.collect::<Vec<_>>();
 
-			let leaves = compute_b_leaves::<F, P>(&bases, &exponents);
+			let leaves = compute_b_leaves::<_, F, P>(&GlobalAllocator, &bases, &exponents);
 
 			for (i, &base0) in base_scalars.iter().enumerate() {
 				let mut base = base0;

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -315,7 +315,7 @@ impl IOPProver {
 		let ring_switch::RingSwitchOutput {
 			rs_eq_ind,
 			sumcheck_claim,
-		} = ring_switch::prove(witness_packed.to_ref(), witness_point, &mut *channel);
+		} = ring_switch::prove(alloc, witness_packed.to_ref(), witness_point, &mut *channel);
 
 		// Prove oracle relations via channel (runs BaseFold internally). The intmul pushforward
 		// relation, when the IntMul reduction ran, was already queued inside phase 5.

--- a/crates/prover/src/ring_switch.rs
+++ b/crates/prover/src/ring_switch.rs
@@ -1,8 +1,12 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-use std::{iter, ops::Deref};
+use std::{
+	iter,
+	ops::{Deref, DerefMut},
+};
 
+use binius_compute::Allocator;
 use binius_field::{
 	BinaryField, Divisible, ExtensionField, Field, PackedField, cast_base_mut,
 	linear_transformation::{
@@ -13,7 +17,9 @@ use binius_field::{
 };
 use binius_ip_prover::channel::IPProverChannel;
 use binius_math::{
-	FieldBuffer, FieldSlice, inner_product::inner_product, multilinear::eq::eq_ind_partial_eval,
+	FieldBuffer, FieldSlice, FieldVec,
+	inner_product::inner_product,
+	multilinear::eq::{eq_ind_partial_eval, eq_ind_partial_eval_in},
 	tensor_algebra::TensorAlgebra,
 };
 use binius_utils::{
@@ -90,12 +96,13 @@ where
 /// ## Preconditions
 ///
 /// * `vec` must have log length equal to B128's extension degree over B1 (7)
-pub fn fold_b128_elems_inplace<P>(
-	mut elems: FieldBuffer<P>,
+pub fn fold_b128_elems_inplace<P, Data>(
+	mut elems: FieldBuffer<P, Data>,
 	vec: &FieldBuffer<B128>,
-) -> FieldBuffer<P>
+) -> FieldBuffer<P, Data>
 where
 	P: PackedField<Scalar = B128>,
+	Data: DerefMut<Target = [P]>,
 {
 	assert_eq!(vec.len(), B128::N_BITS); // precondition
 
@@ -157,13 +164,14 @@ where
 /// ## Preconditions
 ///
 /// * `mat` and `vec` must have the same log length
-pub fn fold_1b_rows_for_b128<P, Data>(
-	mat: &FieldBuffer<P, Data>,
-	vec: &FieldBuffer<P>,
+pub fn fold_1b_rows_for_b128<P, MatData, VecData>(
+	mat: &FieldBuffer<P, MatData>,
+	vec: &FieldBuffer<P, VecData>,
 ) -> FieldBuffer<B128>
 where
 	P: PackedField<Scalar = B128>,
-	Data: Deref<Target = [P]>,
+	MatData: Deref<Target = [P]>,
+	VecData: Deref<Target = [P]>,
 {
 	let log_scalar_bit_width = <B128 as ExtensionField<B1>>::LOG_DEGREE;
 	assert_eq!(mat.log_len(), vec.log_len()); // precondition
@@ -275,9 +283,9 @@ fn square_transpose_const_size<P: PackedField, const LOG_N: usize, const S: usiz
 }
 
 /// Output of ring-switching prover.
-pub struct RingSwitchOutput<P: PackedField> {
+pub struct RingSwitchOutput<A: Allocator, P: PackedField> {
 	/// The ring-switching equality indicator MLE (transparent poly for BaseFold).
-	pub rs_eq_ind: FieldBuffer<P>,
+	pub rs_eq_ind: FieldVec<P, A>,
 	/// The sumcheck claim.
 	pub sumcheck_claim: P::Scalar,
 }
@@ -294,6 +302,7 @@ pub struct RingSwitchOutput<P: PackedField> {
 ///
 /// ## Arguments
 ///
+/// * `alloc` - the allocator the ring-switching equality indicator is drawn from
 /// * `packed_witness` - the packed witness buffer (B1 polynomial packed into P elements)
 /// * `eval_point` - the evaluation point from shift reduction
 /// * `channel` - the prover channel for sending/sampling
@@ -302,12 +311,14 @@ pub struct RingSwitchOutput<P: PackedField> {
 ///
 /// * `packed_witness.log_len() + log_packing == eval_point.len()` where log_packing is the base-2
 ///   log of the extension degree of B128 over B1 (= 7)
-pub fn prove<P, Channel>(
+pub fn prove<A, P, Channel>(
+	alloc: &A,
 	packed_witness: FieldSlice<P>,
 	eval_point: &[B128],
 	channel: &mut Channel,
-) -> RingSwitchOutput<P>
+) -> RingSwitchOutput<A, P>
 where
+	A: Allocator,
 	P: PackedField<Scalar = B128>,
 	Channel: IPProverChannel<B128>,
 {
@@ -317,7 +328,7 @@ where
 	// Expand evaluation suffix with eq_ind
 	let eval_point_suffix = &eval_point[log_packing..];
 	let suffix_tensor = tracing::debug_span!("Expand evaluation suffix query")
-		.in_scope(|| eq_ind_partial_eval::<P>(eval_point_suffix));
+		.in_scope(|| eq_ind_partial_eval_in::<A, P>(alloc, eval_point_suffix));
 
 	// Ring-switching partial evaluations (Method of Four Russians)
 	let s_hat_v = tracing::debug_span!("Compute ring-switching partial evaluations")

--- a/crates/spartan-prover/src/lib.rs
+++ b/crates/spartan-prover/src/lib.rs
@@ -299,7 +299,7 @@ impl<F: Field> IOPProver<F> {
 		// Compute the precommit segment's contribution to the wiring check.
 		// The prover sends this as a scalar; the oracle relation then verifies it.
 		let precommit_wiring_poly =
-			fold_constraints(&self.precommit_wiring_transpose, lambda, r_x_tensor.as_ref());
+			fold_constraints(alloc, &self.precommit_wiring_transpose, lambda, r_x_tensor.as_ref());
 		let precommit_claim = binius_math::inner_product::inner_product_buffers(
 			&precommit_packed.to_ref(),
 			&precommit_wiring_poly,
@@ -310,12 +310,12 @@ impl<F: Field> IOPProver<F> {
 
 		// Fold private wiring constraints
 		let private_wiring_poly =
-			fold_constraints(&self.private_wiring_transpose, lambda, r_x_tensor.as_ref());
+			fold_constraints(alloc, &self.private_wiring_transpose, lambda, r_x_tensor.as_ref());
 
 		// Compute the mask folding polynomial (libra_eval tensor)
 		let n_vars = r_x.len();
 		let libra_eval_tensor =
-			zk_mlecheck::expand_libra_eval::<P>(&r_x, n_vars, mask_degree, m_n, m_d);
+			zk_mlecheck::expand_libra_eval::<A, P>(alloc, &r_x, n_vars, mask_degree, m_n, m_d);
 
 		// Prove all oracle relations.
 		channel.prove_oracle_relations([

--- a/crates/spartan-prover/src/wiring.rs
+++ b/crates/spartan-prover/src/wiring.rs
@@ -96,11 +96,15 @@ impl WiringTranspose {
 /// `r_x_tensor` is the eq-indicator partial evaluation at r_x, i.e.
 /// `eq_ind_partial_eval(r_x)`. Accepting it as a parameter avoids redundant
 /// computation when folding multiple segments with the same r_x.
-pub fn fold_constraints<F: Field, P: PackedField<Scalar = F>>(
+///
+/// The folded polynomial is drawn from `alloc`: it is the transparent multilinear of an oracle
+/// relation, which the channel owns until the opening runs.
+pub fn fold_constraints<A: Allocator, F: Field, P: PackedField<Scalar = F>>(
+	alloc: &A,
 	transposed: &WiringTranspose,
 	lambda: F,
 	r_x_tensor: &[F],
-) -> FieldBuffer<P> {
+) -> FieldVec<P, A> {
 	// Batching powers for the three operands
 	let lambda_powers = [F::ONE, lambda, lambda.square()];
 
@@ -108,13 +112,16 @@ pub fn fold_constraints<F: Field, P: PackedField<Scalar = F>>(
 	let log_size = transposed.log_size();
 	let len = 1 << log_size.saturating_sub(P::LOG_WIDTH);
 
-	// Process in parallel over chunks of P::WIDTH indices
-	let result = (0..len)
-		.into_par_iter()
-		.map(|packed_idx| {
+	// Fill the packed words in parallel through the allocated buffer's spare capacity, then commit
+	// the length once every word has been written.
+	let mut result = alloc.alloc::<P>(len);
+	result.spare_capacity_mut()[..len]
+		.par_iter_mut()
+		.enumerate()
+		.for_each(|(packed_idx, slot)| {
 			let base_idx = packed_idx << P::LOG_WIDTH;
 
-			P::from_fn(|scalar_idx| {
+			slot.write(P::from_fn(|scalar_idx| {
 				let idx = base_idx + scalar_idx;
 				if idx >= segment_size {
 					return F::ZERO;
@@ -127,9 +134,10 @@ pub fn fold_constraints<F: Field, P: PackedField<Scalar = F>>(
 					acc += r_x_weight * lambda_weight;
 				}
 				acc
-			})
-		})
-		.collect::<Vec<_>>();
+			}));
+		});
+	// SAFETY: the loop above initialized every one of the `len` spare words.
+	unsafe { result.set_len(len) };
 
 	FieldBuffer::new(log_size, result)
 }
@@ -393,7 +401,12 @@ mod tests {
 		// Method 2: Use fold_constraints then evaluate at r_y
 		let transposed =
 			WiringTranspose::transpose(WitnessSegment::Private, private_size, &constraints);
-		let folded = fold_constraints::<_, Packed128b>(&transposed, lambda, r_x_tensor.as_ref());
+		let folded = fold_constraints::<_, _, Packed128b>(
+			&GlobalAllocator,
+			&transposed,
+			lambda,
+			r_x_tensor.as_ref(),
+		);
 		let actual = evaluate(&folded, &r_y);
 
 		assert_eq!(
@@ -484,8 +497,12 @@ mod tests {
 		let trace_claim = batched_sum - public_eval;
 
 		// Fold constraints to get the private wiring polynomial
-		let wiring_poly =
-			fold_constraints::<_, Packed128b>(&wiring_transpose, lambda, r_x_tensor.as_ref());
+		let wiring_poly = fold_constraints::<_, _, Packed128b>(
+			&GlobalAllocator,
+			&wiring_transpose,
+			lambda,
+			r_x_tensor.as_ref(),
+		);
 
 		// Finish the IOP with the oracle relation
 		prover_channel.prove_oracle_relations([(

--- a/crates/spartan-prover/src/wrapper/zk_wrapped_prover_channel.rs
+++ b/crates/spartan-prover/src/wrapper/zk_wrapped_prover_channel.rs
@@ -22,7 +22,7 @@ use binius_iop_prover::{
 	merkle_channel::MerkleIPProverChannel,
 };
 use binius_ip_prover::channel::IPProverChannel;
-use binius_math::{FieldBuffer, FieldSlice, FieldVec, ntt::AdditiveNTT};
+use binius_math::{FieldSlice, FieldVec, ntt::AdditiveNTT};
 use binius_spartan_frontend::constraint_system::{BlindingInfo, WitnessLayout};
 use binius_spartan_verifier::IOPVerifier;
 use rand::CryptoRng;
@@ -79,9 +79,9 @@ where
 	/// Creates a new ZK-wrapped prover channel.
 	///
 	/// Commits the outer prover's precommit oracle on the inner channel as part of construction:
-	/// a random [`FieldBuffer<P>`] the size of the outer precommit oracle segment is sent to
-	/// the channel and kept for use in [`Self::finish`]. This random buffer is the one-time-pad
-	/// encryption key for the (future) outer encrypted transcript.
+	/// a random [`FieldBuffer<P>`](binius_math::FieldBuffer) the size of the outer precommit oracle
+	/// segment is sent to the channel and kept for use in [`Self::finish`]. This random buffer is
+	/// the one-time-pad encryption key for the (future) outer encrypted transcript.
 	///
 	/// The inner channel's oracle specs are expected to be laid out as
 	/// `[outer_precommit, inner..., outer_private, outer_mask]`.
@@ -291,7 +291,7 @@ where
 	fn prove_oracle_relations(
 		&mut self,
 		oracle_relations: impl IntoIterator<
-			Item = (Self::Oracle, FieldVec<P, A>, FieldBuffer<P>, P::Scalar),
+			Item = (Self::Oracle, FieldVec<P, A>, FieldVec<P, A>, P::Scalar),
 		>,
 	) {
 		let oracle_relations = oracle_relations.into_iter().collect::<Vec<_>>();


### PR DESCRIPTION
Closes [BINIUS-360](https://linear.app/jimpo/issue/BINIUS-360/remove-remaining-pooled-copy-calls).

Deletes the `pooled_copy` bridge helper by making each of its four call sites build its buffer from the allocator in the first place. `grep -rn "pooled_copy" --include="*.rs" .` now returns nothing.

Built on top of #1912 (BINIUS-344), which threaded the allocator through `IOPProverChannel` and did much of the groundwork — that's what turns the `transparent` change from a type cascade into a mechanical one.

## Commits

| # | Commit | What |
|---|---|---|
| 1 | `443673c7` | Build the logUp* numerators from the allocator. `scaled_eq_ind_partial_eval_into` becomes generic over any `VecLike` backing, so `combined_lookers` draws each looker's numerator from the caller's allocator and moves it straight into `FracAddCheckProver`. |
| 2 | `73921a4a` | Clone the logUp* pushforward with `FieldVec::clone_from_slice`. |
| 3 | `7c92dbf7` | Build intmul `b_leaves` into an allocator-backed buffer. `Witness::b_leaves` becomes a `FieldVec`; `phase1` takes a `FieldSlice`. |
| 4 | `4f7cfba8` | Draw the queued relation's transparent multilinear from the allocator. `IOPProverChannel::prove_oracle_relations` takes it as `FieldVec<P, A>` and it goes straight into the `MleStore`. |
| 5 | `8e5f4980` | Remove `pooled_copy`. |

Each commit builds independently green — `cargo test --workspace` was run separately at each of the four intermediate commits (54/54 test binaries each), not just at the tip.

## Notable decisions

- **New math API `eq_ind_partial_eval_in(alloc, point) -> FieldVec<P, A>`** in `multilinear::eq` + `hypercube`, since three transparent-producers build an eq expansion. `tensor_prod_eq_ind`'s body was split into a private `tensor_prod_eq_ind_reserved` generic over `VecLike`: an allocator buffer is drawn at final size and can't grow, so "has room for the expansion" became the private core's precondition while capacity reservation stayed in the public `Vec` entry point. `reserve_exact` was deliberately *not* added to `VecLike` — `buffer_pool.rs` refuses to reclaim a reallocated `PoolVec`, so a growable pooled buffer would be a footgun.

- **`scaled_eq_ind_partial_eval_into`'s capacity precondition relaxed from `==` to `>=`.** `BufferPool::alloc_vec` rounds capacity up to whole chunks, so exact equality can never hold for a pooled buffer — for `point.len() < P::LOG_WIDTH` the 64-byte floor makes capacity strictly exceed the request and the old assert would have fired. Both "never reallocates" and "same allocation" still hold.

- **`combined_pushforward` takes `&[FieldSlice<'_, P>]`** rather than the numerators directly. It reads them via `par_chunks`, which needs `Sync`, but `Allocator::Vec<T>` is declared only `Send`. Widening that bound was considered and rejected for this PR: `PoolVec<'_, T>` is `Sync` only when `T: Sync`, so the GAT would have to become `type Vec<T: Send + Sync>: … + Send + Sync`, propagating a new bound to every alloc site. That deserves its own commit and its own justification in the `Allocator` docs — happy to do it separately if you'd prefer the bound.

- **`fold_constraints` drops `map`+`collect`** for `spare_capacity_mut` + parallel `for_each` + `set_len`, since it now writes into an allocator buffer — the `collect` *was* the allocation being removed. This matches the idiom `build_mulcheck_witness` already uses in the same file.

- **The intmul `b_leaves` copy changed form rather than disappearing.** `ProdcheckProver` folds its leaf layer in place while `phase1` re-reads the leaves afterwards (prodcheck runs at `prove.rs:434`, leaves are read at `442`), so two live buffers are genuinely required. It's now `clone_from_slice` pooled→pooled instead of `pooled_copy` from a `Vec` — the unpooled allocation is what went away. Removing the copy entirely would need `phase1` to read the leaf layer back off the prover; that's a separate change.

## Reviewer notes

Commit 4 is ~130 lines across 6 crates, at the upper end of the cohesive-commit preference. No split leaving a compiling intermediate was found — it's one trait-signature change plus its mechanical fan-out (`ring_switch::prove` and `RingSwitchOutput<A, P>`, Spartan's `fold_constraints`, `zk_mlecheck::expand_libra_eval`). `NaiveProverChannel` needed no change, being pinned to `GlobalAllocator`. Peeling the producers out first would leave no-op commits.

A few adjacent cleanups were deliberately left out of scope and will be filed separately: aligning `build_mulcheck_witness` on the `[..len]` spare-capacity convention, removing the mirror-image `unpool` bridge at `intmul/witness.rs:214`, and moving `zeros_in`/`clone_from_slice` off the `Data`-parameterised impl that forces the `FieldVec::<P, A>::` turbofish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)