### PR TITLE
Fix rayon build of the batched-witness accumulation loop

### DIFF
--- a/crates/iop-prover/src/basefold/channel.rs
+++ b/crates/iop-prover/src/basefold/channel.rs
@@ -400,6 +400,9 @@ fn prove_batch_zk_basefold<A, F, P, NTT, Channel>(
 			);
 			let scalar_broadcast = P::broadcast(eq_i);
 			let chunk_packed = 1usize << (n_i + log_lift - P::LOG_WIDTH);
+			// Borrow as a slice before the closure: the allocator's buffer type is only `Send`, so
+			// a closure capturing the owned buffer would not be `Sync` as `for_each` requires.
+			let witness_prime = witness_prime.to_ref();
 			combined
 				.as_mut()
 				.par_chunks_mut(chunk_packed)


### PR DESCRIPTION
`cargo clippy --all-targets --all-features --workspace` fails to compile `binius-iop-prover`.

The parallel repeat-placement loop in `prove_batched_relations` captures the owned witness buffer, whose backing is the allocator's `Vec` associated type. That type is bound only `Send`, not `Sync`, so the closure does not satisfy rayon's `Sync` bound on `ParallelIterator::for_each`:

```
error[E0277]: `<A as binius_compute::Allocator>::Vec<P>` cannot be shared between threads safely
   --> crates/iop-prover/src/basefold/channel.rs:406:15
```

The failure is invisible in a default build because without the `rayon` feature `par_chunks_mut` is a serial stub with no `Sync` requirement.

Borrowing the buffer as a `FieldSlice` before the closure makes the capture slice-backed, which is `Sync`. No behavior change.

## Testing

- `cargo clippy --all-targets --all-features --workspace -- -D warnings` — clean
- `cargo test -p binius-iop-prover --features rayon` — 40 passed
- `prek run --all-files` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)