### PR TITLE
[keccak] Fuse chi and iota, and stop force-committing the D wires

### DIFF
--- a/crates/circuits/src/keccak/permutation.rs
+++ b/crates/circuits/src/keccak/permutation.rs
@@ -62,8 +62,7 @@ pub fn keccak_f1600(b: &CircuitBuilder, state: &mut [Wire; 25]) {
 pub fn keccak_permutation_round(b: &CircuitBuilder, state: &mut [Wire; 25], round: usize) {
 	theta(b, state);
 	rho_pi(b, state);
-	chi(b, state);
-	iota(b, state, round);
+	chi_iota(b, state, round);
 }
 
 fn theta(b: &CircuitBuilder, state: &mut [Wire; 25]) {
@@ -80,15 +79,6 @@ fn theta(b: &CircuitBuilder, state: &mut [Wire; 25]) {
 	let d3 = b.bxor(c2, b.rotl(c4, 1));
 	let d4 = b.bxor(c3, b.rotl(c0, 1));
 
-	// Fusing every linear expression into its AND leads to too many distinct shifted value
-	// indices and that slows down the shift reduction phase. Empirically we found out that
-	// preventing committing those here leads to better performance.
-	b.force_commit(d0);
-	b.force_commit(d1);
-	b.force_commit(d2);
-	b.force_commit(d3);
-	b.force_commit(d4);
-
 	// A'[x,y] = A[x,y] ^ D[x]
 	for y in 0..5 {
 		state[idx(0, y)] = b.bxor(state[idx(0, y)], d0);
@@ -99,7 +89,9 @@ fn theta(b: &CircuitBuilder, state: &mut [Wire; 25]) {
 	}
 }
 
-fn chi(b: &CircuitBuilder, state: &mut [Wire; 25]) {
+fn chi_iota(b: &CircuitBuilder, state: &mut [Wire; 25], round: usize) {
+	let rc = b.add_constant(Word(RC[round]));
+
 	for y in 0..5 {
 		let a0 = state[idx(0, y)];
 		let a1 = state[idx(1, y)];
@@ -107,7 +99,11 @@ fn chi(b: &CircuitBuilder, state: &mut [Wire; 25]) {
 		let a3 = state[idx(3, y)];
 		let a4 = state[idx(4, y)];
 
-		state[idx(0, y)] = b.fax(b.bnot(a1), a2, a0);
+		// For the state element at (0, 0), the output state has the round constant accumulated in.
+		// For circuit efficiency, we do this as part of the fused AND-XOR.
+		let a0_iota = if y == 0 { b.bxor(a0, rc) } else { a0 };
+
+		state[idx(0, y)] = b.fax(b.bnot(a1), a2, a0_iota);
 		state[idx(1, y)] = b.fax(b.bnot(a2), a3, a1);
 		state[idx(2, y)] = b.fax(b.bnot(a3), a4, a2);
 		state[idx(3, y)] = b.fax(b.bnot(a4), a0, a3);
@@ -127,11 +123,6 @@ fn rho_pi(b: &CircuitBuilder, state: &mut [Wire; 25]) {
 		}
 	}
 	*state = temp;
-}
-
-fn iota(b: &CircuitBuilder, state: &mut [Wire; 25], round: usize) {
-	let rc_wire = b.add_constant(Word(RC[round]));
-	state[0] = b.bxor(state[0], rc_wire);
 }
 
 #[cfg(test)]
@@ -287,21 +278,21 @@ mod tests {
 	}
 
 	#[test]
-	fn test_chi() {
+	fn test_chi_iota() {
 		let mut rng = StdRng::seed_from_u64(0);
 		let input_state = rng.random::<[u64; 25]>();
 
-		validate_circuit_component(chi, reference::chi, input_state);
-	}
-
-	#[test]
-	fn test_iota() {
-		let mut rng = StdRng::seed_from_u64(0);
-		let input_state = rng.random::<[u64; 25]>();
+		// The circuit fuses χ and ι into one pass, so it is checked against the two reference
+		// steps run back to back. Round 6 has a round constant with bits spread across all four
+		// 16-bit halves, so a misplaced constant shows up in the output.
+		const ROUND: usize = 6;
 
 		validate_circuit_component(
-			|b, state| iota(b, state, 0),
-			|state| reference::iota(state, 0),
+			|b, state| chi_iota(b, state, ROUND),
+			|state| {
+				reference::chi(state);
+				reference::iota(state, ROUND);
+			},
 			input_state,
 		);
 	}

--- a/crates/examples/snapshots/ethsign.snap
+++ b/crates/examples/snapshots/ethsign.snap
@@ -5,26 +5,26 @@ Gates & Instructions
 └─ Number of evaluation instructions: 252,550
 
 Constraints
-├─ AND constraints: 160,106 used (61.1% of 2^18)
-│  [▓▓▓▓▓▓░░░░] spare: 102,038
+├─ AND constraints: 159,866 used (61.0% of 2^18)
+│  [▓▓▓▓▓▓░░░░] spare: 102,278
 ├─ IMUL constraints: 20,554 used (62.7% of 2^15)
 │  [▓▓▓▓▓▓░░░░] spare: 12,214
 ├─ BMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-└─ Distinct value indices: 370,387
-   ├─ Distinct shifted value indices: 180,124
-   └─ Distinct unshifted value indices: 190,263
+└─ Distinct value indices: 379,033
+   ├─ Distinct shifted value indices: 189,010
+   └─ Distinct unshifted value indices: 190,023
 
 Value Vector
 ├─ Public Section: 114 used (89.1% of 2^7)
 │  [▓▓▓▓▓▓▓▓░░] spare: 14
 │  ├─ Constants: 85
 │  └─ Inout: 29
-├─ Private Section: 190,158 used (72.6%)
-│  [▓▓▓▓▓▓▓░░░] spare: 71,858
+├─ Private Section: 189,918 used (72.5%)
+│  [▓▓▓▓▓▓▓░░░] spare: 72,098
 │  ├─ Witness: 0
-│  └─ Internal: 190,158
-├─ Total Committed: 190,272 used (72.6% of 2^18)
-│  [▓▓▓▓▓▓▓░░░] spare: 71,872
-└─ Scratch (uncommitted): 175,406 (peak live: 192)
+│  └─ Internal: 189,918
+├─ Total Committed: 190,032 used (72.5% of 2^18)
+│  [▓▓▓▓▓▓▓░░░] spare: 72,112
+└─ Scratch (uncommitted): 175,646 (peak live: 192)
 

--- a/crates/examples/snapshots/keccak.snap
+++ b/crates/examples/snapshots/keccak.snap
@@ -5,26 +5,26 @@ Gates & Instructions
 └─ Number of evaluation instructions: 22,189
 
 Constraints
-├─ AND constraints: 5,750 used (70.2% of 2^13)
-│  [▓▓▓▓▓▓▓░░░] spare: 2,442
+├─ AND constraints: 4,783 used (58.4% of 2^13)
+│  [▓▓▓▓▓░░░░░] spare: 3,409
 ├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
 ├─ BMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-└─ Distinct value indices: 19,903
-   ├─ Distinct shifted value indices: 14,001
-   └─ Distinct unshifted value indices: 5,902
+└─ Distinct value indices: 57,196
+   ├─ Distinct shifted value indices: 52,360
+   └─ Distinct unshifted value indices: 4,836
 
 Value Vector
 ├─ Public Section: 157 used (61.3% of 2^8)
 │  [▓▓▓▓▓▓░░░░] spare: 99
 │  ├─ Constants: 25
 │  └─ Inout: 132
-├─ Private Section: 5,746 used (72.4%)
-│  [▓▓▓▓▓▓▓░░░] spare: 2,190
+├─ Private Section: 4,779 used (60.2%)
+│  [▓▓▓▓▓▓░░░░] spare: 3,157
 │  ├─ Witness: 0
-│  └─ Internal: 5,746
-├─ Total Committed: 5,903 used (72.1% of 2^13)
-│  [▓▓▓▓▓▓▓░░░] spare: 2,289
-└─ Scratch (uncommitted): 16,439 (peak live: 26)
+│  └─ Internal: 4,779
+├─ Total Committed: 4,936 used (60.3% of 2^13)
+│  [▓▓▓▓▓▓░░░░] spare: 3,256
+└─ Scratch (uncommitted): 17,406 (peak live: 27)
 

--- a/crates/m4-prover/tests/prove_hash_primitives.rs
+++ b/crates/m4-prover/tests/prove_hash_primitives.rs
@@ -17,14 +17,14 @@ use std::array;
 
 use binius_circuits::{blake3::blake3_compress_2x, keccak::permutation::keccak_f1600};
 use binius_core::word::Word;
-use binius_frontend::{Circuit, CircuitBuilder, Wire};
+use binius_frontend::{Circuit, CircuitBuilder, CircuitStat, Wire};
 use binius_m4_prover::{BatchWitnessFiller, Prover, ValueTable};
 use binius_m4_verifier::Verifier;
 use binius_prover::OptimalPackedB128;
 use binius_transcript::ProverTranscript;
 use binius_verifier::config::StdChallenger;
 use rand::prelude::*;
-use tracing::{info_span, level_filters::LevelFilter};
+use tracing::{debug, info_span, level_filters::LevelFilter};
 use tracing_forest::ForestLayer;
 use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
 
@@ -60,8 +60,8 @@ fn init_tracing() {
 /// Proves one instance of `circuit` through M4 and verifies it.
 ///
 /// Witness generation runs in one span.
-/// Proving runs in another.
-/// The prover's internal spans nest beneath the proving span.
+/// Proving runs twice: a warmup run whose proof is discarded, then the run that is kept.
+/// Each proving run gets its own span, and the prover's internal spans nest beneath it.
 ///
 /// # Panics
 ///
@@ -72,6 +72,10 @@ where
 	F: Fn(usize, &mut BatchWitnessFiller<'_, '_>),
 {
 	init_tracing();
+
+	// Report the circuit's constraint counts and value-vector occupancy.
+	// The spare-capacity lines show how much of each padded section is wasted.
+	debug!("{name} circuit stats:\n{}", CircuitStat::collect(circuit));
 
 	// Generate the single-instance witness in its own span.
 	let table = info_span!("witness_generation", primitive = name)
@@ -85,6 +89,13 @@ where
 	// Build the prover from it, sharing its FRI parameters.
 	let verifier = Verifier::setup(&cs, LOG_INSTANCES, LOG_INV_RATE);
 	let prover = Prover::<OptimalPackedB128>::setup(&verifier);
+
+	// Warm up first, discarding the proof.
+	// This pays the one-time costs — thread-pool spin-up, lazily built tables, page faults on the
+	// prover's scratch buffers — so the timed run below measures steady-state proving.
+	let mut warmup_transcript = ProverTranscript::new(StdChallenger::default());
+	info_span!("prove_warmup", primitive = name)
+		.in_scope(|| prover.prove(&table, &mut warmup_transcript));
 
 	// Prove in a span.
 	// The prover's commit, reduction, and opening spans nest beneath it.
@@ -183,40 +194,47 @@ fn fill_blake3(inputs: &Blake3Inputs, _instance: usize, w: &mut BatchWitnessFill
 	w[inputs.flags] = pack_lanes(rng.next_u32(), rng.next_u32());
 }
 
-/// Builds a circuit for one Keccak-f1600 permutation and force-commits its output state.
-fn build_keccak_circuit() -> (Circuit, [Wire; KECCAK_STATE_LANES]) {
+/// Builds a circuit for `N` independent Keccak-f1600 permutations, force-committing every output
+/// state.
+///
+/// The permutations share no wires.
+/// Packing several into one circuit fills the value vector more densely, so less of it is padding.
+fn build_keccak_circuit<const N: usize>() -> (Circuit, [[Wire; KECCAK_STATE_LANES]; N]) {
 	let builder = CircuitBuilder::new();
 
-	// The 25-lane input state is witness input.
-	let input: [Wire; KECCAK_STATE_LANES] = array::from_fn(|_| builder.add_witness());
+	// Each permutation gets its own 25-lane witness input state.
+	let inputs: [[Wire; KECCAK_STATE_LANES]; N] =
+		array::from_fn(|_| array::from_fn(|_| builder.add_witness()));
 
-	// Permute a copy of the input in place.
-	// After the call, `state` holds the output lanes.
-	let mut state = input;
-	keccak_f1600(&builder, &mut state);
+	for input in inputs {
+		// Permute a copy of the input in place.
+		// After the call, `state` holds the output lanes.
+		let mut state = input;
+		keccak_f1600(&builder, &mut state);
 
-	// Force-commit the output lanes.
-	// This keeps the permutation alive under dead-code elimination.
-	for wire in state {
-		builder.force_commit(wire);
+		// Force-commit the output lanes.
+		// This keeps the permutation alive under dead-code elimination.
+		for wire in state {
+			builder.force_commit(wire);
+		}
 	}
 
-	(builder.build(), input)
+	(builder.build(), inputs)
 }
 
-/// Fills the Keccak instance's 25 input state lanes with random 64-bit words.
+/// Fills every Keccak input state lane with a random 64-bit word.
 ///
 /// Keccak proving is data-independent.
 /// So any state is valid.
-fn fill_keccak(
-	input: &[Wire; KECCAK_STATE_LANES],
+fn fill_keccak<const N: usize>(
+	inputs: &[[Wire; KECCAK_STATE_LANES]; N],
 	_instance: usize,
 	w: &mut BatchWitnessFiller<'_, '_>,
 ) {
 	let mut rng = StdRng::seed_from_u64(0);
 
-	// One random 64-bit word per state lane.
-	for &wire in input {
+	// One random 64-bit word per state lane, across all permutations.
+	for &wire in inputs.iter().flatten() {
 		w[wire] = Word(rng.next_u64());
 	}
 }
@@ -262,8 +280,18 @@ fn prove_blake3_compression() {
 // Proves one Keccak-f1600 permutation through M4 and verifies it.
 #[test]
 fn prove_keccak_permutation() {
-	let (circuit, input) = build_keccak_circuit();
-	prove_once("keccak", &circuit, |instance, w| fill_keccak(&input, instance, w));
+	let (circuit, inputs) = build_keccak_circuit::<1>();
+	prove_once("keccak", &circuit, |instance, w| fill_keccak(&inputs, instance, w));
+}
+
+// Proves three independent Keccak-f1600 permutations through M4 and verifies them.
+//
+// Three permutations per instance pack the value vector more densely than one, so a smaller share
+// of the committed trace is padding.
+#[test]
+fn prove_keccak_permutation_3x() {
+	let (circuit, inputs) = build_keccak_circuit::<3>();
+	prove_once("keccak_3x", &circuit, |instance, w| fill_keccak(&inputs, instance, w));
 }
 
 // Proves one 64×64→128-bit multiplication through M4 and verifies it.


### PR DESCRIPTION
Two changes to the Keccak permutation circuit, plus the M4 test scaffolding used to measure them.

## Fuse χ and ι

The ι step XORs the round constant into lane (0,0). That XOR is linear, so rather than emitting it as its own gate after χ, it folds into the fused AND-XOR that χ already emits for that lane: `chi_iota` computes `a0 ^ RC[round]` and passes it as the addend of the `fax` gate. The separate `iota` function goes away and `chi` becomes `chi_iota`, taking the round index.

## Stop force-committing the θ D wires

The five `force_commit` calls on the θ D wires were there to hold down the number of distinct shifted value indices, at the cost of five extra committed values per round. They're dropped here — 121 fewer AND constraints and 121 fewer committed values per permutation.

The tradeoff the old comment described is real and shows up in the reblessed snapshots: the `keccak` circuit's distinct shifted value indices go from 14,001 to 52,360. Proving still comes out well ahead (see below), but this is the number to watch if the shift reduction phase regresses.

## Reblessed snapshots

`ethsign` and `keccak` are the only two of the thirteen checked snapshots that drift.

`keccak`:

| | before | after |
|---|---|---|
| AND constraints | 5,750 (70.2% of 2^13) | 4,783 (58.4%) |
| Total committed | 5,903 (72.1% of 2^13) | 4,936 (60.3%) |
| Distinct shifted value indices | 14,001 | 52,360 |

`ethsign` moves less, since Keccak is only part of it: 160,106 → 159,866 AND constraints, 190,272 → 190,032 committed, and 180,124 → 189,010 distinct shifted value indices.

## Test changes

`test_chi` and `test_iota` become a single `test_chi_iota`. The reference implementation still keeps χ and ι as separate steps — the test runs them back to back to match the fused circuit. It uses round 6, whose round constant has bits in all four 16-bit halves, so a misplaced constant shows up in the output.

The M4 integration test gains `prove_keccak_permutation_3x`: the Keccak circuit builder and witness filler are now generic over a const `N`, so one circuit holds `N` independent permutations, each with its own 25-lane witness input state and all 25 output lanes force-committed. The existing single-permutation test instantiates `N = 1`.

`prove_once` also now logs `CircuitStat` at DEBUG and runs a discarded warmup proof before the timed one, so a `RUST_LOG=debug` run shows constraint counts and value-vector occupancy above a steady-state timing tree.

### On the 3x variant

Packing three permutations per instance is there to cut padding, and with the D wires no longer force-committed it does:

| | gates | AND used | AND alloc | committed |
|---|---|---|---|---|
| 1x | 2,760 | 600 | 2^10 (58.6%) | 648 / 2^10 (63.3%) |
| 3x | 8,280 | 1,800 | 2^11 (87.9%) | 1,898 / 2^11 (92.7%) |

Dropping the D-wire commits removes 121 AND constraints and 121 committed values per permutation (5 per round × 24 rounds, plus the constant). That is what lets three permutations fit under 2^11 — at 1,800 of 2,048 they use 87.9% of the AND allocation and 92.7% of the committed value vector, against 58.6% / 63.3% for a single permutation.

3 is the best multiplier here: 2x lands at 1,200 of 2^11 (58.6%) and 4x at 2,400 of 2^12 (58.6%), both back at single-permutation density.

The denser packing shows up in proving throughput. At `LOG_INSTANCES = 13` and rate 1/2, on the timed (post-warmup) run:

| | permutations proved | prove | per permutation |
|---|---|---|---|
| 1x | 8,192 | 963 ms | 118 µs |
| 3x | 24,576 | 1.87 s | 76 µs |

about 1.55× the throughput per permutation.

The circuit changes themselves also speed up proving. The 3x test was added before them, so it gives a direct before/after on the same circuit: the timed run went from 3.50 s to 1.87 s, about 1.9×, despite the rise in distinct shifted value indices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
