### PR TITLE
Iterate M128 bytes through u128, and drop fold_b128_elems_inplace

### DIFF
--- a/crates/field/src/arch/aarch64/m128.rs
+++ b/crates/field/src/arch/aarch64/m128.rs
@@ -462,14 +462,20 @@ impl Divisible<u16> for M128 {
 impl Divisible<u8> for M128 {
 	const LOG_N: usize = 4;
 
+	/// Iterates bytes by way of `u128` rather than NEON lane extracts.
+	///
+	/// `u128` occupies a general-purpose register pair, so a value loaded from memory becomes a
+	/// single `ldp` and each byte a bitfield extract. Extracting the bytes out of the vector type
+	/// instead lets LLVM split the load into one narrow load per byte, which doubles the memory
+	/// operations of a bytewise lookup loop.
 	#[inline]
 	fn value_iter(value: Self) -> impl ExactSizeIterator<Item = u8> + Send + Clone {
-		mapget::value_iter(value)
+		u128::from(value).to_le_bytes().into_iter()
 	}
 
 	#[inline]
 	fn ref_iter(value: &Self) -> impl ExactSizeIterator<Item = u8> + Send + Clone + '_ {
-		mapget::value_iter(*value)
+		<Self as Divisible<u8>>::value_iter(*value)
 	}
 
 	#[inline]

--- a/crates/prover/benches/ring_switch.rs
+++ b/crates/prover/benches/ring_switch.rs
@@ -4,9 +4,7 @@ use std::mem::size_of;
 
 use binius_field::{BinaryField, ExtensionField, arch::OptimalPackedB128};
 use binius_math::test_utils::random_field_buffer;
-use binius_prover::ring_switch::{
-	fold_1b_rows_for_b128, fold_b128_elems_inplace, fold_elems_inplace,
-};
+use binius_prover::ring_switch::{fold_1b_rows_for_b128, fold_elems_inplace};
 use binius_utils::checked_arithmetics::log2_strict_usize;
 use binius_verifier::config::{B1, B128};
 use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
@@ -58,37 +56,5 @@ fn bench_fold_elems_inplace(c: &mut Criterion) {
 	group.finish();
 }
 
-fn bench_fold_b128_elems_inplace(c: &mut Criterion) {
-	let mut group = c.benchmark_group("ring_switch/fold_b128_elems_inplace");
-
-	type P = OptimalPackedB128;
-
-	for log_len in [12, 16] {
-		// Calculate throughput based on the size of elems buffer in bytes
-		let elem_bytes = (1 << log_len) * size_of::<P>();
-		group.throughput(Throughput::Bytes(elem_bytes as u64));
-		group.bench_function(format!("log_len={log_len}"), |b| {
-			let mut rng = rand::rng();
-
-			let elems = random_field_buffer::<P>(&mut rng, log_len);
-			let vec =
-				random_field_buffer::<B128>(&mut rng, <B128 as ExtensionField<B1>>::LOG_DEGREE);
-
-			b.iter_batched(
-				|| elems.clone(),
-				|elems| fold_b128_elems_inplace(elems, &vec),
-				BatchSize::SmallInput,
-			);
-		});
-	}
-
-	group.finish();
-}
-
-criterion_group!(
-	ring_switch,
-	bench_fold_1b_rows_for_b128,
-	bench_fold_elems_inplace,
-	bench_fold_b128_elems_inplace
-);
+criterion_group!(ring_switch, bench_fold_1b_rows_for_b128, bench_fold_elems_inplace);
 criterion_main!(ring_switch);

--- a/crates/prover/src/ring_switch.rs
+++ b/crates/prover/src/ring_switch.rs
@@ -22,10 +22,7 @@ use binius_math::{
 	multilinear::eq::{eq_ind_partial_eval, eq_ind_partial_eval_in},
 	tensor_algebra::TensorAlgebra,
 };
-use binius_utils::{
-	checked_arithmetics::{checked_int_div, checked_log_2},
-	rayon::prelude::*,
-};
+use binius_utils::{checked_arithmetics::checked_log_2, rayon::prelude::*};
 use binius_verifier::config::{B1, B128};
 use itertools::izip;
 
@@ -44,11 +41,15 @@ use itertools::izip;
 /// ## Preconditions
 ///
 /// * `vec` has length equal to the extension degree of `F` over `B1`
-pub fn fold_elems_inplace<F, P>(mut elems: FieldBuffer<P>, vec: &FieldBuffer<F>) -> FieldBuffer<P>
+pub fn fold_elems_inplace<F, P, Data>(
+	mut elems: FieldBuffer<P, Data>,
+	vec: &FieldBuffer<F>,
+) -> FieldBuffer<P, Data>
 where
 	F: BinaryField,
 	F::Underlier: Divisible<u8>,
 	P: PackedField<Scalar = F>,
+	Data: DerefMut<Target = [P]>,
 {
 	assert_eq!(vec.log_len(), F::LOG_DEGREE); // precondition
 
@@ -67,74 +68,6 @@ where
 				.into_iter()
 				.map(|scalar| transform.transform(&scalar)),
 		);
-	});
-
-	elems
-}
-
-/// Optimized version of [`fold_elems_inplace`] specifically for B128 fields.
-///
-/// This function transforms a [`FieldBuffer`] by mapping every B128 scalar to the inner product
-/// of its B1 components and a given vector of B128 field elements. It implements the same
-/// computation as [`fold_elems_inplace`] but uses direct byte iteration and lookup tables
-/// for better performance with B128 fields.
-///
-/// The optimization works by:
-/// 1. Creating 8-bit lookup tables (256 entries) for each byte position in B128
-/// 2. Directly iterating over the bytes of B128 elements
-/// 3. Using lookup tables to compute partial sums without the ByteIteratorCallback abstraction
-///
-/// ## Arguments
-///
-/// * `elems` - the buffer of B128 elements to transform
-/// * `vec` - the vector of B128 field elements (must have length 128 = B128 extension degree)
-///
-/// ## Returns
-///
-/// The transformed buffer with each element replaced by its inner product result
-///
-/// ## Preconditions
-///
-/// * `vec` must have log length equal to B128's extension degree over B1 (7)
-pub fn fold_b128_elems_inplace<P, Data>(
-	mut elems: FieldBuffer<P, Data>,
-	vec: &FieldBuffer<B128>,
-) -> FieldBuffer<P, Data>
-where
-	P: PackedField<Scalar = B128>,
-	Data: DerefMut<Target = [P]>,
-{
-	assert_eq!(vec.len(), B128::N_BITS); // precondition
-
-	// Create lookup tables for 8-bit chunks
-	const CHUNK_BITS: usize = 8;
-
-	// Build lookup tables for each byte position
-	// Each table has 256 entries for all possible 8-bit values
-	let lookup_tables = vec
-		.as_ref()
-		.chunks(CHUNK_BITS)
-		.map(|chunk| {
-			let chunk = <[B128; CHUNK_BITS]>::try_from(chunk)
-				.expect("vec.len() == 128; thus, chunks must be exact CHUNK_BITS in size");
-			expand_subset_sums_array::<_, CHUNK_BITS, { 1 << CHUNK_BITS }>(chunk)
-		})
-		.collect::<Vec<_>>();
-
-	assert_eq!(lookup_tables.len(), checked_int_div(B128::N_BITS, CHUNK_BITS));
-
-	elems.as_mut().par_iter_mut().for_each(|packed_elem| {
-		*packed_elem = P::from_scalars(packed_elem.into_iter().map(|scalar| {
-			let bytes = u128::from(scalar.val()).to_le_bytes();
-			bytes
-				.into_iter()
-				.enumerate()
-				.map(|(i, byte)| {
-					// Safety: i is in the range 0..16, and byte is in range 0..256
-					unsafe { lookup_tables.get_unchecked(i).get_unchecked(byte as usize) }
-				})
-				.sum()
-		}));
 	});
 
 	elems
@@ -349,7 +282,7 @@ where
 
 	// Compute ring-switching equality indicator (transparent poly)
 	let rs_eq_ind = tracing::debug_span!("Compute ring-switching equality indicator")
-		.in_scope(|| fold_b128_elems_inplace(suffix_tensor, &eq_r_double_prime));
+		.in_scope(|| fold_elems_inplace(suffix_tensor, &eq_r_double_prime));
 
 	RingSwitchOutput {
 		rs_eq_ind,
@@ -360,8 +293,8 @@ where
 #[cfg(test)]
 mod test {
 	use binius_field::{
-		BinaryField128bGhash, ExtensionField, PackedBinaryGhash2x128b, PackedBinaryGhash4x128b,
-		PackedField, PackedSubfield, cast_ext,
+		BinaryField128bGhash, ExtensionField, PackedBinaryGhash2x128b, PackedField, PackedSubfield,
+		cast_ext,
 	};
 	use binius_math::{
 		FieldBuffer,
@@ -466,7 +399,7 @@ mod test {
 
 		// Method 2: Tensor expand prefix, call fold_elems_inplace, then evaluate_inplace on suffix
 		let prefix_tensor = eq_ind_partial_eval::<F>(prefix);
-		let bit_matrix_packed = FieldBuffer::new(
+		let bit_matrix_packed = FieldBuffer::<P>::new(
 			n,
 			bit_matrix
 				.as_ref()
@@ -479,35 +412,5 @@ mod test {
 
 		// Compare all three results
 		assert_eq!(reference_result, method2_result, "Method 2 does not match reference");
-	}
-
-	#[test]
-	fn test_fold_b128_elems_consistency() {
-		let mut rng = StdRng::seed_from_u64(0);
-		type P = PackedBinaryGhash4x128b;
-
-		// Parameters - test with various sizes
-		for n in [4, 6, 8, 10] {
-			// Generate a random buffer of B128 elements
-			let elems = random_field_buffer::<P>(&mut rng, n);
-
-			// Generate a random vector of 128 B128 field elements (for the inner product)
-			let vec =
-				random_field_buffer::<B128>(&mut rng, <B128 as ExtensionField<B1>>::LOG_DEGREE);
-
-			// Call the generic fold_elems_inplace function
-			let result_generic = fold_elems_inplace(elems.clone(), &vec);
-
-			// Call the specialized fold_b128_elems_inplace function
-			let result_specialized = fold_b128_elems_inplace(elems.clone(), &vec);
-
-			// Both results should be identical
-			assert_eq!(
-				result_generic.as_ref(),
-				result_specialized.as_ref(),
-				"fold_b128_elems_inplace does not match fold_elems_inplace for n = {}",
-				n
-			);
-		}
 	}
 }


### PR DESCRIPTION
## Motivation

`fold_b128_elems_inplace` existed as a hand-specialized copy of `fold_elems_inplace` for B128, and it was ~30% faster. Disassembling both on aarch64 showed the two loops are otherwise identical — same 16 four-Russians lookup tables (the table-building code is byte-for-byte the same symbol), same 16 `ldr q` lookups, same 8-deep `eor`/`eor3` reduction, same store. The only difference was how the 16 index bytes get extracted:

| | `fold_elems_inplace` | `fold_b128_elems_inplace` |
|---|---|---|
| Byte extraction | 16 × `ldrb` | 1 × `ldp` + 16 × `ubfx`/`lsr`/`and` |
| **Memory ops / element** | **33** | **18** |
| Instrs / element | 43 | 44 |

`B128 = BinaryField128bGhash(M128)`, so its underlier is the NEON vector type. `Divisible<u8> for M128` extracted bytes via `vgetq_lane_u8`; since the value's only consumers are byte extractions and its def is a load from the buffer, LLVM discards the lane extracts and splits the 16-byte load into one narrow load per byte. `fold_b128_elems_inplace` avoided this only incidentally, by routing through `u128::from(scalar.val()).to_le_bytes()` — `u128` is a GPR-pair type, so LLVM commits to `ldp` + bitfield extracts instead.

I confirmed this is the whole story by extracting both loops into a standalone harness with identical tables, buffer and reduction, varying only the byte extraction: 14.45 vs 10.43 cycles/element, `mem_access` 33.4 vs 18.4 per element, `stall_backend` 54.4% → 32.3% with `stall_backend_mem` ~1% and identical `l1d_cache_refill` in both. It's load/store issue-slot pressure, not cache behaviour.

## Changes

**1. Iterate M128 bytes through `u128` instead of NEON lane extracts.** `Divisible<u8> for M128`: `value_iter` becomes `u128::from(value).to_le_bytes().into_iter()`, `ref_iter` delegates to it. Endianness is not a concern — this is an arch-specific module.

**2. Remove `fold_b128_elems_inplace`.** The two now compile to the same inner loop and benchmark within noise of each other, so the specialized copy has no reason to exist. `fold_elems_inplace` gains the `Data` type parameter the specialized function carried, so it can fold the allocator-backed suffix tensor in `prove`.

## Benchmarks

Neoverse V3, `RUSTFLAGS="-Ctarget-cpu=native"`, criterion `--save-baseline` / `--baseline`. `impl_divisible_bitmask!(M128, 1, 2, 4)` builds the sub-byte iterators on top of `Divisible<u8>`, so change 1 reaches well beyond ring-switch — swept accordingly.

| benchmark | change |
|---|---|
| `ring_switch/fold_elems_inplace/log_len=12` | **−21.7%** |
| `ring_switch/fold_elems_inplace/log_len=16` | **−24.6%** |
| `fold_1b_rows_for_b128/log_len=12` | −1.5% |
| `evaluate/univariate fold 2^21` | −2.3% |
| `evaluate/remaining zerocheck 2^21` | −1.8% |
| `fold_across_words/1048576` | −1.9% |
| `fold_1b_rows_for_b128/log_len=16`, `and_reduction` | −0.7%, −0.3% |
| `fold_across_words/4096` & `/65536`, `fold_words/1048576`, NTT precompute | flat |
| `fold_words/4096` | +0.38% |
| `evaluate/univariate_round_message 2^21` | +0.53% |

No meaningful regressions — the two positives are both under 0.6% and read as code-alignment noise.

`fold_elems_inplace` now lands on the deleted `fold_b128_elems_inplace` to within noise (19.90 vs 19.81 µs at log_len=12; 274.7 vs 277.7 µs at log_len=16).

## Testing

- `cargo test --workspace`: 1350 passed, 0 failed. This is one fewer than before because `test_fold_b128_elems_consistency` — which cross-checked the two implementations — goes away with the function it tested. It passed on the tree with change 1 applied and both functions still present, which is the state that mattered for validating change 1.
- `cargo clippy --all --all-features --tests --benches --examples -- -D warnings`: clean.
- `cargo +nightly-2026-07-01 fmt`: clean.
- `typos` is not installed in my environment, so I did not run it.

## Note for reviewers

One incidental change: `FieldBuffer::new(...)` in `test_fold_across_bit_columns` needed a `FieldBuffer::<P>::new(...)` annotation, since widening `fold_elems_inplace` with `Data` left the `.collect()` target type ambiguous.

Separately, `Divisible<u8>::slice_iter` for M128 still uses `mapget::slice_iter`, which computes `idx / 16` and `idx % 16` per byte and calls `get()`. That's a different code path from the one changed here and may have a similar problem; it is not addressed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)