### PR TITLE
Iterate M128 byte slices by reinterpreting the slice

### DIFF
--- a/crates/field/src/arch/aarch64/m128.rs
+++ b/crates/field/src/arch/aarch64/m128.rs
@@ -480,7 +480,7 @@ impl Divisible<u8> for M128 {
 
 	#[inline]
 	fn slice_iter(slice: &[Self]) -> impl ExactSizeIterator<Item = u8> + Send + Clone + '_ {
-		mapget::slice_iter(slice)
+		crate::underlier::memcast::slice_iter::<Self, u8>(slice)
 	}
 
 	#[inline]


### PR DESCRIPTION
Follow-up to #1935, now rebased onto main after that merged — this is a single one-line commit.

## Motivation

#1935 noted that `Divisible<u8>::slice_iter` for `M128` still used `mapget::slice_iter` and might have the same problem as `ref_iter` did. It does, and worse.

`mapget::slice_iter` reaches each byte through `idx / 16`, `idx % 16`, a bounds-checked slice index, and a `vgetq_lane_u8` match on a runtime index. Reinterpreting the whole slice as bytes gives a plain slice iterator instead:

```rust
crate::underlier::memcast::slice_iter::<Self, u8>(slice)
```

This is the path `PackedField::iter_slice` takes for B1 packed into M128. `impl_divisible_bitmask!(M128, 1, 2, 4)` implements `Divisible<SmallU<1>>::slice_iter` as `SmallUDivisIter::new(Divisible::<u8>::slice_iter(slice))`, so every bit of a packed B1 slice is produced from bytes that came through here.

## Benchmarks

Neoverse V3, `RUSTFLAGS="-Ctarget-cpu=native"`, criterion `--save-baseline` / `--baseline`.

Re-measured against the post-rebase base (main @ e7071d94):

| benchmark | change |
|---|---|
| `packed_128/PackedBinaryField128x1b/iter_begin` | **−39.5%** (8.30 → 13.73 Gelem/s) |
| `packed_256/PackedBinaryField256x1b/iter_begin` | flat (−0.17%) |
| `packed_512/PackedBinaryField512x1b/iter_begin` | flat (+0.01%) |

Measured before the rebase, on the equivalent tree (#1935's two commits applied, this change on top):

| benchmark | change |
|---|---|
| `merkle_tree/SHA-256/17 log leaves 16xB128 leaf 1x128b` | **−6.4%** |
| `packed_128/PackedBinaryField128x1b/get` | −1.5% |
| `packed_128/PackedBinaryField128x1b/set` | −1.2% |
| `packed_field_iter` (all widths) | flat |
| `merkle_tree/SHA-256 ... leaf 128b` | flat |

`packed_256/set` and `packed_512/set` showed +1.2% and +2.9%, but `set` does not go through `slice_iter` at all, and the numbers were unstable across repeat runs (`packed_512/set` measured +4.3% then +2.9%; `packed_256/set` measured −0.6% then +1.2%) on ~28 ns benchmarks. I read these as code-layout noise rather than a real effect.

## Testing

On the rebased tree:

- `cargo test --workspace`: 1353 passed, 0 failed.
- `cargo clippy --all --all-features --tests --benches --examples -- -D warnings`: clean.
- `cargo +nightly-2026-07-01 fmt --check`: clean.
- `typos` is not installed in my environment, so I did not run it.

Ordering is unchanged: `must_cast_slice` yields bytes in memory order, which on this little-endian arch-specific module is the same LSB-first order `vgetq_lane_u8(v, i)` gave.

## Not addressed here

The same benchmark shows `PackedBinaryField256x1b` and `PackedBinaryField512x1b` iterating at 1.81 Gelem/s versus 13.73 for the 128-bit case — 7.6× slower per element, and unaffected by this change. On aarch64 those are `ScaledUnderlier<M128, 2>` and `ScaledUnderlier<ScaledUnderlier<M128, 2>, 2>`, and `ScaledUnderlier` has no `impl_divisible_bitmask`. Bit iteration therefore falls to the generic `Divisible<T> for ScaledUnderlier<U, N>` impl, whose `slice_iter` is `mapget::slice_iter` with `T = SmallU<1>` — so the div/mod/bounds-check/lane-extract cost is paid **per bit** rather than per byte, with `ScaledUnderlier::get_unchecked` adding a second layer of index arithmetic on top.

Fixing that means giving `ScaledUnderlier` the byte-then-`SmallUDivisIter` treatment that `impl_divisible_bitmask` gives. That is a change in the portable module affecting x86_64 fallbacks too, the generic impl lacks the `T: Pod` bound a memcast would need, and sub-byte `T` cannot be memcast at all — so it needs a real design and its own bench sweep. I have not attempted it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)