### PR TITLE
BINIUS-100: Remove the NumCast trait

### DIFF
--- a/crates/field/src/arch/aarch64/m128.rs
+++ b/crates/field/src/arch/aarch64/m128.rs
@@ -21,7 +21,7 @@ use super::super::portable::{
 use crate::{
 	BinaryField,
 	underlier::{
-		NumCast, SmallU, UnderlierType,
+		SmallU, UnderlierType,
 		divisible::{Divisible, mapget},
 		impl_divisible_bitmask, impl_divisible_self,
 	},
@@ -738,12 +738,6 @@ impl<Scalar: BinaryField> From<u128> for PackedPrimitiveType<M128, Scalar> {
 impl<Scalar: BinaryField> From<PackedPrimitiveType<M128, Scalar>> for u128 {
 	fn from(value: PackedPrimitiveType<M128, Scalar>) -> Self {
 		value.to_underlier().into()
-	}
-}
-
-impl<U: NumCast<u128>> NumCast<M128> for U {
-	fn num_cast_from(val: M128) -> Self {
-		Self::num_cast_from(val.into())
 	}
 }
 

--- a/crates/field/src/arch/portable/m128.rs
+++ b/crates/field/src/arch/portable/m128.rs
@@ -18,7 +18,7 @@ use crate::{
 	BinaryField,
 	arch::portable::packed::PackedPrimitiveType,
 	underlier::{
-		Divisible, NumCast, SmallU, UnderlierType, impl_divisible_bitmask, impl_divisible_memcast,
+		Divisible, SmallU, UnderlierType, impl_divisible_bitmask, impl_divisible_memcast,
 		impl_divisible_self,
 	},
 };
@@ -69,13 +69,6 @@ impl<const N: usize> From<SmallU<N>> for M128 {
 	#[inline(always)]
 	fn from(value: SmallU<N>) -> Self {
 		Self(value.val() as u128)
-	}
-}
-
-impl<U: NumCast<u128>> NumCast<M128> for U {
-	#[inline(always)]
-	fn num_cast_from(val: M128) -> Self {
-		Self::num_cast_from(val.0)
 	}
 }
 

--- a/crates/field/src/arch/wasm32/m128.rs
+++ b/crates/field/src/arch/wasm32/m128.rs
@@ -1,4 +1,5 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 use std::{
 	arch::wasm32::*,
@@ -18,7 +19,7 @@ use crate::{
 	BinaryField, Random,
 	arch::portable::{packed::PackedPrimitiveType, packed_arithmetic::interleave_mask_even},
 	underlier::{
-		NumCast, SmallU, U1, U2, U4, UnderlierType, WithUnderlier, impl_divisible_bitmask,
+		SmallU, U1, U2, U4, UnderlierType, WithUnderlier, impl_divisible_bitmask,
 		impl_divisible_memcast,
 	},
 };
@@ -134,13 +135,6 @@ impl<const N: usize> From<SmallU<N>> for M128 {
 	#[inline]
 	fn from(value: SmallU<N>) -> Self {
 		Self::from(value.val() as u64)
-	}
-}
-
-impl<U: NumCast<u128>> NumCast<M128> for U {
-	#[inline]
-	fn num_cast_from(val: M128) -> Self {
-		Self::num_cast_from(val.into())
 	}
 }
 

--- a/crates/field/src/arch/x86_64/m128.rs
+++ b/crates/field/src/arch/x86_64/m128.rs
@@ -23,8 +23,7 @@ use crate::{
 	BinaryField,
 	arch::portable::packed::PackedPrimitiveType,
 	underlier::{
-		Divisible, NumCast, SmallU, UnderlierType, impl_divisible_bitmask, impl_divisible_self,
-		mapget,
+		Divisible, SmallU, UnderlierType, impl_divisible_bitmask, impl_divisible_self, mapget,
 	},
 };
 
@@ -133,13 +132,6 @@ impl DeserializeBytes for M128 {
 }
 
 impl_divisible_bitmask!(M128, 1, 2, 4);
-
-impl<U: NumCast<u128>> NumCast<M128> for U {
-	#[inline(always)]
-	fn num_cast_from(val: M128) -> Self {
-		Self::num_cast_from(u128::from(val))
-	}
-}
 
 impl Default for M128 {
 	#[inline(always)]

--- a/crates/field/src/arch/x86_64/m256.rs
+++ b/crates/field/src/arch/x86_64/m256.rs
@@ -20,8 +20,7 @@ use crate::{
 	BinaryField,
 	arch::portable::packed::PackedPrimitiveType,
 	underlier::{
-		Divisible, NumCast, SmallU, UnderlierType, impl_divisible_bitmask, impl_divisible_self,
-		mapget,
+		Divisible, SmallU, UnderlierType, impl_divisible_bitmask, impl_divisible_self, mapget,
 	},
 };
 
@@ -174,24 +173,6 @@ impl DeserializeBytes for M256 {
 }
 
 impl_divisible_bitmask!(M256, 1, 2, 4);
-
-impl<U: NumCast<u128>> NumCast<M256> for U {
-	#[inline(always)]
-	fn num_cast_from(val: M256) -> Self {
-		let [low, _high] = val.into();
-		Self::num_cast_from(low)
-	}
-}
-
-// `M128` is not a `NumCast<u128>` type (so it is not covered by the blanket above), but the GHASH
-// subfield extraction for `GhashSq256b` needs to pull the low 128-bit half out as an `M128`.
-impl NumCast<M256> for M128 {
-	#[inline(always)]
-	fn num_cast_from(val: M256) -> Self {
-		let [low, _high]: [u128; 2] = val.into();
-		Self::from(low)
-	}
-}
 
 impl Default for M256 {
 	#[inline(always)]

--- a/crates/field/src/arch/x86_64/m512.rs
+++ b/crates/field/src/arch/x86_64/m512.rs
@@ -21,7 +21,7 @@ use crate::{
 		portable::packed::PackedPrimitiveType,
 		x86_64::{m128::M128, m256::M256},
 	},
-	underlier::{Divisible, NumCast, SmallU, UnderlierType, impl_divisible_bitmask, mapget},
+	underlier::{Divisible, SmallU, UnderlierType, impl_divisible_bitmask, mapget},
 };
 
 /// 512-bit value that is used for 512-bit SIMD operations
@@ -107,12 +107,6 @@ impl From<M512> for __m512i {
 	#[inline(always)]
 	fn from(value: M512) -> Self {
 		value.0
-	}
-}
-impl<U: NumCast<u128>> NumCast<M512> for U {
-	fn num_cast_from(val: M512) -> Self {
-		let [low, _, _, _] = val.into();
-		Self::num_cast_from(low)
 	}
 }
 

--- a/crates/field/src/binary_field.rs
+++ b/crates/field/src/binary_field.rs
@@ -621,8 +621,8 @@ pub(crate) mod tests {
 
 	use super::BinaryField1b as BF1;
 	use crate::{
-		AESTowerField8b, BinaryField, BinaryField1b, BinaryField128bGhash, Field,
-		arithmetic_traits::InvertOrZero,
+		AESTowerField8b, BinaryField, BinaryField1b, BinaryField128bGhash, ExtensionField, Field,
+		GhashSq256b, arithmetic_traits::InvertOrZero,
 	};
 
 	#[test]
@@ -757,6 +757,37 @@ pub(crate) mod tests {
 			let x_inverse = unsafe { x.invert() };
 			assert_eq!(x * x_inverse, BinaryField128bGhash::ONE);
 		}
+	}
+
+	/// Checks the `TryFrom` conversion narrowing an extension field element to its subfield:
+	/// elements embedded from the subfield must round-trip, and elements with a nonzero
+	/// coefficient outside the subfield must be rejected.
+	fn assert_subfield_extraction<FSub: Field, F: ExtensionField<FSub>>() {
+		assert_eq!(TryInto::<FSub>::try_into(F::from(FSub::ZERO)).ok(), Some(FSub::ZERO));
+
+		// `BinaryField1b` has a trivial multiplicative group, so for the three pairs with that
+		// subfield this sweeps `ONE` alone, which together with `ZERO` is already the whole field.
+		// Only `BinaryField128bGhash` in `GhashSq256b` walks non-trivial subfield values.
+		let mut elem = FSub::ONE;
+		for _ in 0..4 {
+			assert_eq!(TryInto::<FSub>::try_into(F::from(elem)).ok(), Some(elem));
+			elem *= FSub::MULTIPLICATIVE_GENERATOR;
+		}
+
+		// `basis(i)` for `i > 0` has a zero coefficient of `1` and a nonzero higher coefficient,
+		// so it lies outside the subfield - with or without a subfield part added on.
+		for i in 1..F::DEGREE {
+			assert!(TryInto::<FSub>::try_into(F::basis(i)).is_err());
+			assert!(TryInto::<FSub>::try_into(F::basis(i) + F::ONE).is_err());
+		}
+	}
+
+	#[test]
+	fn test_subfield_extraction() {
+		assert_subfield_extraction::<BinaryField1b, BinaryField128bGhash>();
+		assert_subfield_extraction::<BinaryField1b, AESTowerField8b>();
+		assert_subfield_extraction::<BinaryField128bGhash, GhashSq256b>();
+		assert_subfield_extraction::<BinaryField1b, GhashSq256b>();
 	}
 
 	#[test]

--- a/crates/field/src/binary_field.rs
+++ b/crates/field/src/binary_field.rs
@@ -395,7 +395,7 @@ macro_rules! impl_field_extension {
 
 			#[inline]
 			fn try_from(elem: $name) -> Result<Self, Self::Error> {
-				use $crate::underlier::{Divisible, NumCast, UnderlierType};
+				use $crate::underlier::{Divisible, UnderlierType};
 
 				// `elem` lies in the subfield iff every subfield-underlier limb above the
 				// least-significant one is zero (equivalent to `elem >> N_BITS == 0`).
@@ -403,7 +403,7 @@ macro_rules! impl_field_extension {
 					.skip(1)
 					.all(|limb| limb == <$subfield_typ as UnderlierType>::ZERO);
 				if in_subfield {
-					Ok($subfield_name(<$subfield_typ>::num_cast_from(elem.val())))
+					Ok($subfield_name(Divisible::<$subfield_typ>::get(&elem.0, 0)))
 				} else {
 					Err(())
 				}

--- a/crates/field/src/underlier/scaled.rs
+++ b/crates/field/src/underlier/scaled.rs
@@ -19,7 +19,7 @@ use rand::{
 	distr::{Distribution, StandardUniform},
 };
 
-use super::{Divisible, NumCast, U1, UnderlierType, mapget};
+use super::{Divisible, U1, UnderlierType, mapget};
 use crate::Random;
 
 /// A type that represents N elements of the same underlier type.
@@ -150,35 +150,6 @@ impl<U: UnderlierType + Pod, const N: usize> UnderlierType for ScaledUnderlier<U
 
 			(Self(a), Self(b))
 		}
-	}
-}
-
-impl<U: UnderlierType, const N: usize> NumCast<ScaledUnderlier<U, N>> for u8
-where
-	Self: NumCast<U>,
-{
-	fn num_cast_from(val: ScaledUnderlier<U, N>) -> Self {
-		Self::num_cast_from(val.0[0])
-	}
-}
-
-impl<U: UnderlierType, const N: usize> NumCast<ScaledUnderlier<U, N>> for U1
-where
-	Self: NumCast<U>,
-{
-	fn num_cast_from(val: ScaledUnderlier<U, N>) -> Self {
-		Self::num_cast_from(val.0[0])
-	}
-}
-
-// `M128` is the `BinaryField128bGhash` subfield underlier; this extracts it from the low limb of a
-// `ScaledUnderlier<M128, _>`-backed extension field (`GhashSq256b` off the AVX2 path).
-impl<U: UnderlierType, const N: usize> NumCast<ScaledUnderlier<U, N>> for crate::arch::M128
-where
-	Self: NumCast<U>,
-{
-	fn num_cast_from(val: ScaledUnderlier<U, N>) -> Self {
-		Self::num_cast_from(val.0[0])
 	}
 }
 

--- a/crates/field/src/underlier/underlier_impls.rs
+++ b/crates/field/src/underlier/underlier_impls.rs
@@ -1,9 +1,7 @@
 // Copyright 2024-2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
-use super::{
-	small_uint::{U1, U2, U4},
-	underlier_type::{NumCast, UnderlierType},
-};
+use super::underlier_type::UnderlierType;
 use crate::arch::{interleave_mask_even, interleave_with_mask};
 
 macro_rules! impl_underlier_type {
@@ -31,72 +29,3 @@ impl_underlier_type!(u16, 0, 1, 2, 3);
 impl_underlier_type!(u32, 0, 1, 2, 3, 4);
 impl_underlier_type!(u64, 0, 1, 2, 3, 4, 5);
 impl_underlier_type!(u128, 0, 1, 2, 3, 4, 5, 6);
-
-macro_rules! impl_num_cast {
-	(@pair U1, U2) => {impl_num_cast!(@small_u_from_small_u U1, U2);};
-	(@pair U1, U4) => {impl_num_cast!(@small_u_from_small_u U1, U4);};
-	(@pair U2, U4) => {impl_num_cast!(@small_u_from_small_u U2, U4);};
-	(@pair U1, $bigger:ty) => {impl_num_cast!(@small_u_from_u U1, $bigger);};
-	(@pair U2, $bigger:ty) => {impl_num_cast!(@small_u_from_u U2, $bigger);};
-	(@pair U4, $bigger:ty) => {impl_num_cast!(@small_u_from_u U4, $bigger);};
-	(@pair $smaller:ident, $bigger:ident) => {
-		impl NumCast<$bigger> for $smaller {
-			#[inline(always)]
-			fn num_cast_from(val: $bigger) -> Self {
-				val as _
-			}
-		}
-
-		impl NumCast<$smaller> for $bigger {
-			#[inline(always)]
-			fn num_cast_from(val: $smaller) -> Self {
-				val as _
-			}
-		}
-	};
-	(@small_u_from_small_u $smaller:ty, $bigger:ty) => {
-		impl NumCast<$bigger> for $smaller {
-			#[inline(always)]
-			fn num_cast_from(val: $bigger) -> Self {
-				Self::new(val.val()) & Self::ONES
-			}
-		}
-
-		impl NumCast<$smaller> for $bigger {
-			#[inline(always)]
-			fn num_cast_from(val: $smaller) -> Self {
-				Self::new(val.val())
-			}
-		}
-	};
-	(@small_u_from_u $smaller:ty, $bigger:ty) => {
-		impl NumCast<$bigger> for $smaller {
-			#[inline(always)]
-			fn num_cast_from(val: $bigger) -> Self {
-				Self::new(val as u8) & Self::ONES
-			}
-		}
-
-		impl NumCast<$smaller> for $bigger {
-			#[inline(always)]
-			fn num_cast_from(val: $smaller) -> Self {
-				val.val() as _
-			}
-		}
-	};
-	($_:ty,) => {};
-	(,) => {};
-	(all_pairs) => {};
-	(all_pairs $_:ty) => {};
-	(all_pairs $_:ty,) => {};
-	(all_pairs $smaller:ident, $head:ident, $($tail:ident,)*) => {
-		impl_num_cast!(@pair $smaller, $head);
-		impl_num_cast!(all_pairs $smaller, $($tail,)*);
-	};
-	($smaller:ident, $($tail:ident,)+) => {
-		impl_num_cast!(all_pairs $smaller, $($tail,)+);
-		impl_num_cast!($($tail,)+);
-	};
-}
-
-impl_num_cast!(U1, U2, U4, u8, u16, u32, u64, u128,);

--- a/crates/field/src/underlier/underlier_type.rs
+++ b/crates/field/src/underlier/underlier_type.rs
@@ -158,16 +158,3 @@ pub unsafe trait WithUnderlier:
 		Self::from_underlier(f(self.to_underlier()))
 	}
 }
-
-/// A trait that represents potentially lossy numeric cast.
-/// Is a drop-in replacement of `as _` in a generic code.
-pub trait NumCast<From> {
-	fn num_cast_from(val: From) -> Self;
-}
-
-impl<U: UnderlierType> NumCast<U> for U {
-	#[inline(always)]
-	fn num_cast_from(val: U) -> Self {
-		val
-	}
-}


### PR DESCRIPTION
Closes [BINIUS-100](https://linear.app/jimpo/issue/BINIUS-100).

Resolves the investigation the other way from last time: `NumCast` is **not** load-bearing any more and is deleted outright. Pure refactor inside the private `underlier` module — no behavior change, no public API change.

### The problem

`NumCast<T>` was the field crate's "`as _` for generic code": a deliberately lossy numeric cast. It carried a full N×N cast lattice — 56 primitive-pair impls, plus blanket impls on `M128` (×4 arches), `M256`, `M512` and `ScaledUnderlier` — in service of **one** call site.

An [earlier investigation](https://linear.app/jimpo/issue/BINIUS-100) concluded it had to stay. That conclusion no longer holds, for two reasons:

1. Two of its three call sites are gone. `mul_as_bigger_type` / `square_as_bigger_type` / `invert_as_bigger_type` and the dead bounds in `get_block_values` / `get_spread_bytes` were deleted in the interim.
2. The orphan-rule argument didn't apply to the casts actually reached. It held that the narrowing targets were foreign primitives (`u8`..`u128`), so `From` was blocked. But in `impl_field_extension!`, `Self` is `$subfield_typ` — the *smaller* type — so all four instantiated targets are `U1` or `M128`, both crate-local. `u8` and `M256` appear only as sources.

### The change

The one remaining call site, in `impl_field_extension!`'s `TryFrom` body:

```diff
-                Ok($subfield_name(<$subfield_typ>::num_cast_from(elem.val())))
+                Ok($subfield_name(Divisible::<$subfield_typ>::get(&elem.0, 0)))
```

This isn't merely *a* valid spelling — it's the one the surrounding code already uses. `basis` and `from_bases_sparse` in the same macro address limbs through `Divisible::get`/`set`; the `TryFrom` body was the odd one out. The `Divisible<$subfield_typ>` bound was already present on `main`, so **no new trait bound is introduced anywhere**.

The cast isn't even lossy here: the `in_subfield` guard on the line above has just proven every limb beyond the first is zero. The honest description was always "take limb 0", which `Divisible` already models.

**The real win is that the guard and the extraction now share one mechanism.** The guard already went through `Divisible::<$subfield_typ>::ref_iter`. Previously it and the extraction used two *different* mechanisms, so any disagreement between a type's `Divisible` and `NumCast` impls would have been a silent miscompute. Now "the limb `skip(1)` skipped" and "the limb we return" come from the same impl by construction.

Everything else deleted — the trait and its identity impl, the 56 pair impls, the four `M128` blankets, the `M256` blanket and the bespoke `NumCast<M256> for M128`, the `M512` blanket, the three `ScaledUnderlier` impls, and the imports left dangling — existed only to feed that one line. Afterwards `grep -rn 'NumCast\|num_cast_from'` returns nothing.

### Commits

1. **Add `TryFrom` round-trip tests for the subfield extraction path** — deliberately first, so the tests land green against the *old* `num_cast_from`. That makes them a regression test rather than a description of the new code.
2. **Remove the `NumCast` trait** — the call-site swap and the deletion are inseparable: swapping alone leaves an unreachable crate-private trait, which `dead_code` turns into an error under `-D warnings`.

### Equivalence

The four instantiations, all confirmed to reduce to the same bits:

| subfield ⊂ extension | old path | new path |
|---|---|---|
| `BinaryField1b` ⊂ `AESTowerField8b` | `U1::new(val as u8) & ONES` | `bitmask::get` → `SmallU::<1>::new`, masked |
| `BinaryField1b` ⊂ `BinaryField128bGhash` | blanket → low `u128` → bit 0 | `bitmask::get` → byte 0, bit 0 |
| `BinaryField128bGhash` ⊂ `GhashSq256b` | `From<M256> for [u128;2]` → `[0]` | `_mm256_extracti128_si256(_, 0)` — *the same intrinsic on the same lane*; portable path reduces to `self.0[0]`, as before |
| `BinaryField1b` ⊂ `GhashSq256b` | blanket → low `u128` → bit 0 | `_mm256_extract_epi8(_, 0)` → bit 0; portable → limb 0, bit 0 |

The AVX2 `M128 ← M256` path is also strictly cheaper: one extract, versus two extracts plus two `u128` round-trips plus a re-splat.

`Divisible` is contractually LSB-first regardless of target endianness, and its `memcast` helpers implement the `N - 1 - index` flip on big-endian. The deleted `NumCast` path was *not* endianness-aware (`val as _`, raw `val.0[0]`), so the new spelling is strictly more correct on a hypothetical BE target. Neither is exercised by CI.

### Verification

Both commits are independently green.

- `prek run --stage pre-push --all-files` — clippy, rustdoc, typos all pass
- `cargo test -p binius-field` with `RUSTFLAGS="-C target-cpu=native"` — **252 passed** (avx2 + avx512f + pclmulqdq → native `M128`/`M256`/`M512` paths)
- `cargo test -p binius-field` with `RUSTFLAGS` unset — **233 passed** (baseline x86-64 → `M256 = ScaledUnderlier<M128, 2>`, portable `M128` → covers `scaled.rs` and `arch/portable/m128.rs`)
- `cargo check --target aarch64-unknown-linux-gnu` with `+neon,+aes`, and `cargo build --target wasm32-unknown-unknown` — both pass, per the CONTRIBUTING.md cross-compilation matrix

The new tests were **mutation-tested**: changing `get(&elem.0, 0)` to `get(&elem.0, 1)` makes them fail, including on the AVX2 path with the body cut down to only the `BinaryField128bGhash ⊂ GhashSq256b` pair. So each pair is pinned independently.

### Deliberately out of scope

- `num-traits` at `Cargo.toml:68` is a workspace dependency no crate references. Left for a separate change.
- `crates/field/src/arch/wasm32/m128.rs:22` imports `U1, U2, U4` unused. Pre-existing on `main`; not widening this diff into it.
- **Worth its own ticket:** `arch/wasm32/m128.rs` is gated behind `target_feature = "simd128"`, which no CI command enables — so edits to that file get a false green. Enabling it surfaces a pre-existing failure in `arch/wasm32/packed_ghash_128.rs:18`, where `impl_broadcast` and `impl_transformation_with_strategy` are imported but defined nowhere in the tree. Confirmed present on pristine `main`. The `m128.rs` edit in this PR was verified to compile by stubbing that broken sibling module in a scratch tree.

Supersedes #1626, which implemented the earlier recommendation (rename to `CastFrom` + drop the dead bounds) — with the trait gone, the rename is moot.
