### PR TITLE
BINIUS-362: move the allocator-backed FieldBuffer constructors off the Data-parameterised impl

### DIFF
--- a/crates/iop-prover/src/basefold/channel.rs
+++ b/crates/iop-prover/src/basefold/channel.rs
@@ -379,7 +379,7 @@ fn prove_batch_zk_basefold<A, F, P, NTT, Channel>(
 
 		let eq_tensor = eq_ind_partial_eval_scalars(&outer_challenges);
 
-		let mut combined = FieldBuffer::<P>::zeros_in(alloc, max_n);
+		let mut combined = FieldBuffer::zeros_in(alloc, max_n);
 		let mut s_prime = F::ZERO;
 		for (fri_oracle, witness_prime, eq_i, alpha_i) in
 			izip!(fri_params.input_oracles(), witness_primes, eq_tensor, alphas)

--- a/crates/ip-prover/benches/bivariate_product.rs
+++ b/crates/ip-prover/benches/bivariate_product.rs
@@ -5,7 +5,7 @@
 //! the hypercube), and a [`SharedMleCheckProver`] driving one [`QuadraticMleEvaluator`] (the
 //! evaluation claim on the product's multilinear extension at a random point).
 
-use binius_compute::{BufferPool, PoolVec};
+use binius_compute::BufferPool;
 use binius_field::{FieldOps, PackedField, arch::OptimalPackedB128};
 use binius_ip_prover::sumcheck::{
 	self,
@@ -76,8 +76,8 @@ fn bench_shared_sumcheck_bivariate_product(c: &mut Criterion) {
 				|| {
 					(
 						transcript.clone(),
-						FieldBuffer::<_, PoolVec<_>>::clone_from_slice(&alloc, a_buffer.to_ref()),
-						FieldBuffer::<_, PoolVec<_>>::clone_from_slice(&alloc, b_buffer.to_ref()),
+						FieldBuffer::clone_from_slice(&alloc, a_buffer.to_ref()),
+						FieldBuffer::clone_from_slice(&alloc, b_buffer.to_ref()),
 					)
 				},
 				|(mut transcript, a, b)| {
@@ -120,8 +120,8 @@ fn bench_shared_mlecheck_bivariate_product(c: &mut Criterion) {
 				|| {
 					(
 						transcript.clone(),
-						FieldBuffer::<_, PoolVec<_>>::clone_from_slice(&alloc, a_buffer.to_ref()),
-						FieldBuffer::<_, PoolVec<_>>::clone_from_slice(&alloc, b_buffer.to_ref()),
+						FieldBuffer::clone_from_slice(&alloc, a_buffer.to_ref()),
+						FieldBuffer::clone_from_slice(&alloc, b_buffer.to_ref()),
 						eval_point.clone(),
 					)
 				},

--- a/crates/ip-prover/src/logup_star/prove.rs
+++ b/crates/ip-prover/src/logup_star/prove.rs
@@ -191,7 +191,7 @@ where
 	let (table_prover, table_root) = FracAddCheckProver::new(
 		m,
 		alloc,
-		(FieldVec::<P, A>::clone_from_slice(alloc, pushforward.to_ref()), table_den),
+		(FieldBuffer::clone_from_slice(alloc, pushforward.to_ref()), table_den),
 	);
 	let num_r = table_root.0.get(0);
 	let den_r = table_root.1.get(0);

--- a/crates/ip-prover/src/sumcheck/mle_store.rs
+++ b/crates/ip-prover/src/sumcheck/mle_store.rs
@@ -404,7 +404,7 @@ impl<'a, A: Allocator, F: Field, P: PackedField<Scalar = F>> MleStore<'a, A, P> 
 			.columns
 			.iter()
 			.map(|column| match column {
-				Column::Borrowed(_) => Some(FieldVec::<P, A>::zeros_in(alloc, n_vars)),
+				Column::Borrowed(_) => Some(FieldBuffer::zeros_in(alloc, n_vars)),
 				_ => None,
 			})
 			.collect::<Vec<_>>();

--- a/crates/ip-prover/src/sumcheck/zk_mlecheck.rs
+++ b/crates/ip-prover/src/sumcheck/zk_mlecheck.rs
@@ -72,7 +72,7 @@ pub fn expand_libra_eval<A: Allocator, P: PackedField>(
 	debug_assert!(degree < 1 << m_d);
 
 	let log_size = m_n + m_d;
-	let mut buffer = FieldVec::<P, A>::zeros_in(alloc, log_size);
+	let mut buffer = FieldBuffer::zeros_in(alloc, log_size);
 	let row_stride = 1 << m_d;
 
 	for (j, &r_j) in challenge_point.iter().enumerate() {

--- a/crates/m4-prover/src/shift.rs
+++ b/crates/m4-prover/src/shift.rs
@@ -272,7 +272,7 @@ pub fn build_g_parts_from_folded_words<F: BinaryField, A: Allocator>(
 	// key belongs to exactly one variant, so the scatter below accumulates straight into these
 	// buffers.
 	let mut multilinears =
-		array::from_fn::<_, SHIFT_VARIANT_COUNT, _>(|_| FieldVec::<F, A>::zeros_in(alloc, LOG_LEN));
+		array::from_fn::<_, SHIFT_VARIANT_COUNT, _>(|_| FieldBuffer::zeros_in(alloc, LOG_LEN));
 
 	// Each folded word carries the keys named by the segment-relative range at its position.
 	for (word, range) in folded_words.iter().zip(&segment.key_ranges) {

--- a/crates/math/src/field_buffer.rs
+++ b/crates/math/src/field_buffer.rs
@@ -112,6 +112,27 @@ impl<P: PackedField> FieldBuffer<P> {
 		let values = zeroed_vec(packed_len);
 		Self { log_len, values }
 	}
+
+	/// Builds a zeroed buffer of `2^log_len` elements, backed by memory drawn from `alloc`.
+	///
+	/// The allocator-aware counterpart to [`zeros`](Self::zeros).
+	/// Under a pool the result is a recyclable pooled buffer.
+	pub fn zeros_in<A: Allocator>(alloc: &A, log_len: usize) -> FieldVec<P, A> {
+		let packed_len = 1 << log_len.saturating_sub(P::LOG_WIDTH);
+		// An allocator hands out an empty buffer, so the words are both created and zeroed here.
+		let mut values = alloc.alloc::<P>(packed_len);
+		values.resize(packed_len, P::default());
+		FieldBuffer::new(log_len, values)
+	}
+
+	/// Copies a borrowed buffer into memory drawn from `alloc`.
+	///
+	/// Whole packed words are copied, dead lanes and all, so the copy is bit-identical.
+	pub fn clone_from_slice<A: Allocator>(alloc: &A, src: FieldSlice<P>) -> FieldVec<P, A> {
+		let mut values = alloc.alloc::<P>(src.as_ref().len());
+		values.extend_from_slice(src.as_ref());
+		FieldBuffer::new(src.log_len(), values)
+	}
 }
 
 impl<P: PackedField, Data: VecLike<P>> FieldBuffer<P, Data> {
@@ -140,24 +161,6 @@ impl<P: PackedField, Data: VecLike<P>> FieldBuffer<P, Data> {
 		);
 
 		FieldBuffer::new(log_len, packed_values)
-	}
-
-	/// Builds a zeroed [`FieldBuffer`] of `log_len` variables into a buffer drawn from `alloc`.
-	///
-	/// The allocator-aware counterpart to [`zeros`](Self::zeros). Under a `BufferPool` the result
-	/// is a recyclable pooled buffer.
-	pub fn zeros_in<A: Allocator>(alloc: &A, log_len: usize) -> FieldVec<P, A> {
-		let packed_len = 1 << log_len.saturating_sub(P::LOG_WIDTH);
-		let mut values = alloc.alloc::<P>(packed_len);
-		values.resize(packed_len, P::default());
-		FieldBuffer::new(log_len, values)
-	}
-
-	/// Clones a [`FieldSlice`] into an allocated [`FieldVec`].
-	pub fn clone_from_slice<A: Allocator>(alloc: &A, src: FieldSlice<P>) -> FieldVec<P, A> {
-		let mut values = alloc.alloc::<P>(src.as_ref().len());
-		values.extend_from_slice(src.as_ref());
-		FieldBuffer::new(src.log_len(), values)
 	}
 }
 
@@ -796,6 +799,7 @@ impl<'a, P: PackedField> Drop for FieldBufferChunkMutInner<'a, P> {
 
 #[cfg(test)]
 mod tests {
+	use binius_compute::{BufferPool, GlobalAllocator};
 	use binius_field::packed::get_packed_slice;
 	use proptest::prelude::*;
 
@@ -827,6 +831,56 @@ mod tests {
 		for i in 0..2 {
 			assert_eq!(buffer.get(i), F::ZERO);
 		}
+	}
+
+	/// Runs the two allocator-backed constructors against one allocator.
+	///
+	/// Both a plain heap allocator and a recycling pool must satisfy the same contract.
+	fn check_alloc_constructors<A: Allocator>(alloc: &A) {
+		// Fixture state: a packed word holds 4 lanes, so lengths map to backing words as
+		//
+		//     16 scalars -> log_len 4 -> 4 packed words, every lane live
+		//      2 scalars -> log_len 1 -> 1 packed word,  2 lanes live and 2 dead
+		let scalars: Vec<F> = (0..16).map(F::new).collect();
+		let src = FieldBuffer::<P>::from_values(&scalars);
+
+		// A copy drawn from the allocator carries over both the length and the scalars.
+		let cloned: FieldVec<P, A> = FieldBuffer::clone_from_slice(alloc, src.to_ref());
+		assert_eq!(cloned.log_len(), 4);
+		assert_eq!(cloned.to_ref(), src.to_ref());
+
+		// Copying a source shorter than one packed word keeps the two live lanes, not four.
+		let small = FieldBuffer::<P>::from_values(&scalars[..2]);
+		let cloned_small: FieldVec<P, A> = FieldBuffer::clone_from_slice(alloc, small.to_ref());
+		assert_eq!(cloned_small.log_len(), 1);
+		assert_eq!(cloned_small.to_ref(), small.to_ref());
+
+		// 32 elements requested, 32 zeros readable: the buffer arrives at full length, not empty.
+		let mut zeros: FieldVec<P, A> = FieldBuffer::zeros_in(alloc, 5);
+		assert_eq!(zeros.log_len(), 5);
+		assert!(zeros.iter_scalars().all(|scalar| scalar == F::ZERO));
+
+		// Index 31 is the last live element, so writing it stays inside the allocated words.
+		zeros.set(31, F::new(7));
+		assert_eq!(zeros.get(31), F::new(7));
+
+		// Two elements still need the one word that spans them, rounded up from half a word.
+		let zeros_small: FieldVec<P, A> = FieldBuffer::zeros_in(alloc, 1);
+		assert_eq!(zeros_small.as_ref().len(), 1);
+		assert!(zeros_small.iter_scalars().all(|scalar| scalar == F::ZERO));
+	}
+
+	#[test]
+	fn test_alloc_constructors_global() {
+		// Every allocation is an independent heap buffer, freed on drop.
+		check_alloc_constructors(&GlobalAllocator);
+	}
+
+	#[test]
+	fn test_alloc_constructors_pooled() {
+		// A pool reuses freed blocks, so a buffer may start life on memory a prior buffer dirtied.
+		let pool = BufferPool::new();
+		check_alloc_constructors(&&pool);
 	}
 
 	#[test]

--- a/crates/prover/benches/batch_quadratic_mle.rs
+++ b/crates/prover/benches/batch_quadratic_mle.rs
@@ -2,7 +2,7 @@
 
 use std::array;
 
-use binius_compute::{BufferPool, PoolVec};
+use binius_compute::BufferPool;
 use binius_field::{Field, FieldOps, PackedField, arch::OptimalPackedB128};
 use binius_ip::mlecheck;
 use binius_ip_prover::sumcheck::{
@@ -119,10 +119,7 @@ fn bench_batch_quadratic_mlecheck_prove(c: &mut Criterion) {
 				|| {
 					(
 						multilinears.each_ref().map(|multilin| {
-							FieldBuffer::<_, PoolVec<_>>::clone_from_slice(
-								&alloc,
-								multilin.to_ref(),
-							)
+							FieldBuffer::clone_from_slice(&alloc, multilin.to_ref())
 						}),
 						eval_point.clone(),
 					)

--- a/crates/prover/benches/fracaddcheck.rs
+++ b/crates/prover/benches/fracaddcheck.rs
@@ -1,6 +1,6 @@
 // Copyright 2025-2026 The Binius Developers
 
-use binius_compute::{BufferPool, PoolVec};
+use binius_compute::BufferPool;
 use binius_field::{FieldOps, arch::OptimalPackedB128};
 use binius_ip::prodcheck::MultilinearEvalClaim;
 use binius_ip_prover::fracaddcheck::FracAddCheckProver;
@@ -36,8 +36,8 @@ fn bench_fracaddcheck_new(c: &mut Criterion) {
 			b.iter_batched(
 				|| {
 					(
-						FieldBuffer::<_, PoolVec<_>>::clone_from_slice(&alloc, num_buffer.to_ref()),
-						FieldBuffer::<_, PoolVec<_>>::clone_from_slice(&alloc, den_buffer.to_ref()),
+						FieldBuffer::clone_from_slice(&alloc, num_buffer.to_ref()),
+						FieldBuffer::clone_from_slice(&alloc, den_buffer.to_ref()),
 					)
 				},
 				|(witness_num, witness_den)| {

--- a/crates/prover/benches/intmul.rs
+++ b/crates/prover/benches/intmul.rs
@@ -1,5 +1,5 @@
 // Copyright 2025-2026 The Binius Developers
-use binius_compute::{BufferPool, PoolVec};
+use binius_compute::BufferPool;
 use binius_core::word::Word;
 use binius_field::{BinaryField128bGhash, Field, PackedBinaryGhash1x128b};
 use binius_hash::StdHashSuite;
@@ -345,7 +345,7 @@ fn bench_intmul_components(c: &mut Criterion) {
 	// Computing a product tree over the leaves.
 	group.bench_function("product_tree", |bencher| {
 		bencher.iter_batched(
-			|| FieldBuffer::<_, PoolVec<_>>::clone_from_slice(&alloc, witness.b_leaves.to_ref()),
+			|| FieldBuffer::clone_from_slice(&alloc, witness.b_leaves.to_ref()),
 			|b_leaves| ProdcheckProver::<_, P>::new(Word::LOG_BITS, &alloc, b_leaves),
 			BatchSize::SmallInput,
 		);

--- a/crates/prover/benches/prodcheck.rs
+++ b/crates/prover/benches/prodcheck.rs
@@ -1,6 +1,6 @@
 // Copyright 2025-2026 The Binius Developers
 
-use binius_compute::{BufferPool, PoolVec};
+use binius_compute::BufferPool;
 use binius_field::{FieldOps, arch::OptimalPackedB128};
 use binius_ip::prodcheck::MultilinearEvalClaim;
 use binius_ip_prover::prodcheck::ProdcheckProver;
@@ -33,7 +33,7 @@ fn bench_prodcheck_new(c: &mut Criterion) {
 			let alloc = &pool;
 
 			b.iter_batched(
-				|| FieldBuffer::<_, PoolVec<_>>::clone_from_slice(&alloc, witness_buffer.to_ref()),
+				|| FieldBuffer::clone_from_slice(&alloc, witness_buffer.to_ref()),
 				|witness| ProdcheckProver::<_, P>::new(k, &alloc, witness),
 				BatchSize::SmallInput,
 			);

--- a/crates/prover/benches/sumcheck.rs
+++ b/crates/prover/benches/sumcheck.rs
@@ -1,6 +1,6 @@
 // Copyright 2025 Irreducible Inc.
 
-use binius_compute::{BufferPool, PoolVec};
+use binius_compute::BufferPool;
 use binius_field::{arch::OptimalPackedB128, packed::PackedField};
 use binius_ip_prover::sumcheck::{prove_single_mlecheck, quadratic_mlecheck_prover};
 use binius_math::{
@@ -40,9 +40,8 @@ fn bench_mlecheck_prove(c: &mut Criterion) {
 			// Benchmark only the proving phase
 			b.iter_batched(
 				|| {
-					[multilinear_a.to_ref(), multilinear_b.to_ref()].map(|multilin| {
-						FieldBuffer::<_, PoolVec<_>>::clone_from_slice(&alloc, multilin)
-					})
+					[multilinear_a.to_ref(), multilinear_b.to_ref()]
+						.map(|multilin| FieldBuffer::clone_from_slice(&alloc, multilin))
 				},
 				|multilinears| {
 					let prover = quadratic_mlecheck_prover(
@@ -89,9 +88,7 @@ fn bench_mlecheck_prove(c: &mut Criterion) {
 						multilinear_b.to_ref(),
 						multilinear_c.to_ref(),
 					]
-					.map(|multilin| {
-						FieldBuffer::<_, PoolVec<_>>::clone_from_slice(&alloc, multilin)
-					})
+					.map(|multilin| FieldBuffer::clone_from_slice(&alloc, multilin))
 				},
 				|multilinears| {
 					let prover = quadratic_mlecheck_prover(

--- a/crates/prover/src/protocols/intmul/witness.rs
+++ b/crates/prover/src/protocols/intmul/witness.rs
@@ -187,7 +187,7 @@ where
 		let (b_prodcheck, b_root) = ProdcheckProver::new(
 			Word::LOG_BITS,
 			alloc,
-			FieldVec::<P, A>::clone_from_slice(alloc, b_leaves.to_ref()),
+			FieldBuffer::clone_from_slice(alloc, b_leaves.to_ref()),
 		);
 		let b_root = unpool::<A, P>(b_root);
 		drop(variable_base_tree_scope);
@@ -366,7 +366,7 @@ where
 	}
 
 	// Fallback: bases is too small to parallelize (n_vars < P::LOG_WIDTH)
-	let mut out = FieldVec::<P, A>::zeros_in(alloc, n_vars + Word::LOG_BITS);
+	let mut out = FieldBuffer::zeros_in(alloc, n_vars + Word::LOG_BITS);
 	let n_elems = 1 << n_vars;
 
 	for (i, (mut base, &exp)) in iter::zip(bases.iter_scalars(), exponents).enumerate() {


### PR DESCRIPTION
Closes [BINIUS-362](https://linear.app/jimpo/issue/BINIUS-362).

Lets callers build an allocator-backed field buffer without naming a generic parameter the constructor never uses.
Pure refactor — no behavior change.

### The problem

A `FieldBuffer` is parameterised by its backing store, and two of its constructors draw that store from an allocator.
Both always return `FieldVec<P, A>` — a buffer backed by `A`'s memory — so the impl block's own store parameter appears nowhere in either signature.
It was still generic, so inference had nothing to pin it with, and every caller had to name it anyway:

```
FieldVec::<P, A>::zeros_in(alloc, n_vars)
FieldBuffer::<_, PoolVec<_>>::clone_from_slice(&alloc, src.to_ref())
```

The turbofish is pure noise: `FieldVec<P, A>` *is* `FieldBuffer<P, A::Vec<P>>`, so it restates what the allocator already determines.

### The idea

Move both constructors into the impl block whose backing store is already fixed.
The return type is then the only thing left to infer, and it follows from the allocator alone:

```
FieldBuffer::zeros_in(alloc, n_vars)
FieldBuffer::clone_from_slice(&alloc, src.to_ref())
```

### Why not the `Self`-returning shape

The neighbouring `from_values_in` solves this differently — it returns `Self` and ties the store to the allocator with `where A: Allocator<Vec<P> = Data>`.
That shape does not work for these two, and the reason is worth recording.

With the store reachable only through a projection, rustc will not resolve the inference variable eagerly, so two ordinary uses break:

- a method call on the result — `buffer.set(..)` in `expand_libra_eval`
- an argument-position use — the tuple passed to `FracAddCheckProver::new` in `logup_star/prove.rs`

Both fail with `E0283: cannot infer type of the type parameter Data`, at 3 sites in `binius-ip-prover` alone.
It would have traded a turbofish for a `let x: FieldVec<P, A> = ...` annotation, which is not a win.
So `from_values_in` is left exactly as it is, and the two constructors move one block up.

### The change

```
crates/math/src/field_buffer.rs

- impl<P: PackedField, Data: VecLike<P>> FieldBuffer<P, Data> {   // store generic -> turbofish
-     pub fn zeros_in<A: Allocator>(..) -> FieldVec<P, A>
-     pub fn clone_from_slice<A: Allocator>(..) -> FieldVec<P, A>

+ impl<P: PackedField> FieldBuffer<P> {                           // store pinned -> inferable
+     pub fn zeros_in<A: Allocator>(..) -> FieldVec<P, A>
+     pub fn clone_from_slice<A: Allocator>(..) -> FieldVec<P, A>
```

Signatures, bodies, and behavior are untouched — only the enclosing impl block changes.

### Scope

- **changed:** 7 library call sites (`binius-ip-prover` x3, `binius-prover` x2, `binius-iop-prover`, `binius-m4-prover`) and 9 bench call sites, all dropping the turbofish
- **changed:** six benches drop a now-unused `PoolVec` import
- **new:** first test coverage for either constructor — length, `log_len` carry-over, scalar equality against the source, the sub-packing-width case, and in-place writability, run against both a plain heap allocator and a recycling pool
- **untouched:** `from_values_in`, for the reason above

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo +nightly fmt --all --check` — clean
- `cargo doc -p binius-math --document-private-items` — clean
- tests pass for `binius-math` (127, including the two new ones), `binius-ip-prover`, `binius-iop-prover`, `binius-m4-prover`, `binius-prover`, plus math doctests

🤖 Generated with [Claude Code](https://claude.com/claude-code)