### PR TITLE
Activate the needless_collect clippy lint and clear the workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,6 +101,7 @@ ureq = "3.1"
 [workspace.lints.clippy]
 needless_range_loop = "allow"
 missing_const_for_fn = "warn"
+needless_collect = "warn"
 redundant_clone = "warn"
 
 [workspace.metadata.typos]

--- a/crates/examples/examples/tutorials/end_to_end_example.rs
+++ b/crates/examples/examples/tutorials/end_to_end_example.rs
@@ -19,8 +19,11 @@ use sha2::{Digest, Sha256 as StdSha256};
 fn main() -> Result<(), Box<dyn std::error::Error>> {
 	let builder = CircuitBuilder::new();
 
-	let content: Vec<_> = (0..4).map(|_| builder.add_witness()).collect();
-	let nonce: Vec<_> = (0..4).map(|_| builder.add_witness()).collect();
+	// 4 witness words: the message the prover keeps secret.
+	let content: [_; 4] = core::array::from_fn(|_| builder.add_witness());
+	// 4 witness words: the nonce that blinds the content inside the hash.
+	let nonce: [_; 4] = core::array::from_fn(|_| builder.add_witness());
+	// 4 public words: the digest that prover and verifier both know.
 	let commitment: [_; 4] = core::array::from_fn(|_| builder.add_inout());
 
 	let data: Vec<_> = content.into_iter().chain(nonce).collect();

--- a/crates/field/src/underlier/divisible.rs
+++ b/crates/field/src/underlier/divisible.rs
@@ -979,9 +979,8 @@ mod tests {
 		assert_eq!(Divisible::<U4>::get(&val, 1), U4::new(0xF));
 		assert_eq!(Divisible::<U4>::get(&val, 15), U4::new(0x1));
 
-		// Test ref_iter
-		let parts: Vec<U4> = Divisible::<U4>::ref_iter(&val).collect();
-		assert_eq!(parts.len(), 16);
+		// Iterating a u64 as nibbles yields 64 / 4 = 16 parts.
+		assert_eq!(Divisible::<U4>::ref_iter(&val).count(), 16);
 	}
 
 	#[test]

--- a/crates/frontend/src/compiler/const_prop.rs
+++ b/crates/frontend/src/compiler/const_prop.rs
@@ -35,7 +35,7 @@ pub fn constant_propagation(graph: &mut GateGraph, hint_registry: &HintRegistry)
 	//
 	// The index yields readers in gate order, which is what keeps this pass deterministic.
 	for (wire, _) in graph.iter_const_wires() {
-		for gate in graph.get_wire_uses(wire).collect::<Vec<_>>() {
+		for gate in graph.get_wire_uses(wire) {
 			if in_worklist.insert(gate) {
 				worklist.push_back(gate);
 			}

--- a/crates/ip-prover/src/prodcheck.rs
+++ b/crates/ip-prover/src/prodcheck.rs
@@ -588,14 +588,11 @@ mod tests {
 			.map(|_| random_field_buffer::<P>(&mut rng, n_layers))
 			.collect();
 
-		// Create ProdcheckProver for each
-		let provers_and_products: Vec<_> = witnesses
+		// One prover per witness, each paired with the products of its own layers.
+		let (provers, individual_products): (Vec<_>, Vec<_>) = witnesses
 			.iter()
 			.map(|witness| ProdcheckProver::new(n_layers, &alloc, witness.clone()))
-			.collect();
-
-		let (provers, individual_products): (Vec<_>, Vec<_>) =
-			provers_and_products.into_iter().unzip();
+			.unzip();
 
 		// Products are 0-variate (scalars): just get the single value
 		let claimed_products: Vec<P::Scalar> = individual_products
@@ -710,13 +707,10 @@ mod tests {
 			.map(|_| random_field_buffer::<P>(&mut rng, content_len + n_layers))
 			.collect();
 
-		let provers_and_products: Vec<_> = witnesses
+		let (provers, individual_products): (Vec<_>, Vec<_>) = witnesses
 			.iter()
 			.map(|witness| ProdcheckProver::new(n_layers, &alloc, witness.clone()))
-			.collect();
-
-		let (provers, individual_products): (Vec<_>, Vec<_>) =
-			provers_and_products.into_iter().unzip();
+			.unzip();
 
 		// Shared content point; each claimed product is its multilinear evaluated there.
 		let content_point = random_scalars::<P::Scalar>(&mut rng, content_len);


### PR DESCRIPTION
Turns on a clippy lint that catches a `collect()` whose `Vec` is thrown away immediately, and fixes the four real cases it found.
No behavior change.

### The problem

`clippy::needless_collect` flags a `collect()` whose result is discarded right after it is built:

- collected only to read its length
- collected only to be turned straight back into an iterator

It is allow-by-default, so nothing in the workspace was checking for it.
The lint sits in clippy's nursery, which this workspace already opts into for `missing_const_for_fn` and `redundant_clone`.

### The change

```
[workspace.lints.clippy]
+ needless_collect = "warn"
```

Under CI's `-D warnings` that makes it an error.

### What it found

Five sites fired.
Four are real:

- **`crates/frontend/src/compiler/const_prop.rs`** — the const-propagation seed loop collected each wire's readers before walking them.
  The loop body touches only the worklist and its dedup set, never the graph, so no borrow ever required the `Vec`.
  That is one heap allocation per constant wire, on every circuit build.
- **`crates/ip-prover/src/prodcheck.rs`** (2 sites) — collected into a `Vec`, then immediately `into_iter().unzip()`.
  `unzip` drives the same iterator in the same order, so the intermediate `Vec` is a pure deletion.
- **`crates/field/src/underlier/divisible.rs`** — collected 16 nibbles to assert the length; now counts them.

```
- let parts: Vec<U4> = Divisible::<U4>::ref_iter(&val).collect();
- assert_eq!(parts.len(), 16);
+ assert_eq!(Divisible::<U4>::ref_iter(&val).count(), 16);
```

### The one false positive — and why it is worth recording

In `crates/examples/examples/tutorials/end_to_end_example.rs`, clippy wanted the wire-allocating iterator inlined into the `chain`.

But `add_witness()` has a side effect: it hands out the next wire.
A lazy iterator would defer the four content wires until after the nonce and commitment wires were requested.
Content and nonce would swap places in the value vector.

The proof would still verify — it is self-consistent — which is what makes this one dangerous.
A silent circuit-layout change with no failing test.

Rather than suppress it, the two lines became eager:

```
- let content: Vec<_> = (0..4).map(|_| builder.add_witness()).collect();
- let nonce: Vec<_> = (0..4).map(|_| builder.add_witness()).collect();
+ let content: [_; 4] = core::array::from_fn(|_| builder.add_witness());
+ let nonce: [_; 4] = core::array::from_fn(|_| builder.add_witness());
  let commitment: [_; 4] = core::array::from_fn(|_| builder.add_inout());
```

Same wire order, no lint, two fewer heap allocations, and it now matches the `commitment` line directly below it.

So the lint is active with **zero suppressions** in the tree.
Lazy iterators over side-effecting closures are the class to watch if it ever gets noisy — worth knowing before a future suggestion is applied mechanically.

### Scope

- **changed:** one lint entry, one production call site, three test/example sites
- **no** `#[allow(clippy::needless_collect)]` anywhere

### Verification

- `cargo clippy --workspace --all-targets -- -D warnings` — clean with the lint active
- `cargo +nightly fmt --all --check` — clean
- tests pass for `binius-frontend`, `binius-field`, `binius-ip-prover`
- `cargo run --example end_to_end_example` — runs end to end, prints `proof successfully verified`, confirming the rewritten wire allocation still yields a satisfiable circuit

🤖 Generated with [Claude Code](https://claude.com/claude-code)