### PR TITLE
BINIUS-364: don't require a power-of-two number of constraints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,8 @@ bytemuck = { version = "1.18.0", features = [
     "derive",
     "min_const_generics",
     "must_cast",
+    # `Zeroable for MaybeUninit<T>`, so uninitialized buffers can be zero-filled safely.
+    "zeroable_maybe_uninit",
 ] }
 bytes = "1.7.2"
 cfg-if = "1.0.0"
@@ -109,4 +111,8 @@ default.extend-words = { "typ" = "typ", "Toom" = "Toom", "inouts" = "inouts" }
 default.extend-ignore-re = [
     "(?Rm)^.*(#|//)\\s*spellchecker:disable-line$",
     "ands\\.mdx",
+    # The hyphenated English prefix "mis-", as in "mis-split"; `typos` reads the bare "mis" as a
+    # misspelling of "miss". Only the prefix is exempted, so the word it attaches to is still
+    # checked.
+    "\\bmis-",
 ]

--- a/crates/core/src/constraint_system/system.rs
+++ b/crates/core/src/constraint_system/system.rs
@@ -249,15 +249,6 @@ impl ConstraintSystem {
 		Ok(())
 	}
 
-	/// [Validates][`Self::validate`] and prepares this constraint system for proving/verifying.
-	///
-	/// This function performs the following:
-	/// 1. Validates the value vector layout (including public input checks)
-	/// 2. Validates the constraints.
-	pub fn validate_and_prepare(&mut self) -> Result<(), ConstraintSystemError> {
-		self.validate()
-	}
-
 	/// Returns the number of AND constraints in the system.
 	pub const fn n_and_constraints(&self) -> usize {
 		self.and_constraints.len()
@@ -650,7 +641,7 @@ mod tests {
 			vec![ValueIndex(8)], // valid private value
 		));
 
-		let result = cs.validate_and_prepare();
+		let result = cs.validate();
 		assert!(result.is_err(), "Should reject constraint referencing padding");
 
 		match result.unwrap_err() {
@@ -681,7 +672,7 @@ mod tests {
 			vec![ShiftedValueIndex::plain(ValueIndex(13))], // hi
 		]));
 
-		let result = cs.validate_and_prepare();
+		let result = cs.validate();
 		assert!(
 			result.is_ok(),
 			"Should accept constraints with only valid references: {:?}",
@@ -690,11 +681,11 @@ mod tests {
 	}
 
 	#[test]
-	fn test_validate_and_prepare_keeps_true_constraint_counts() {
-		let mut cs = create_test_constraint_system();
+	fn test_validate_keeps_true_constraint_counts() {
+		let cs = create_test_constraint_system();
 		let (n_and, n_imul, n_bmul) =
 			(cs.n_and_constraints(), cs.n_imul_constraints(), cs.n_bmul_constraints());
-		cs.validate_and_prepare().unwrap();
+		cs.validate().unwrap();
 		assert_eq!(cs.n_and_constraints(), n_and);
 		assert_eq!(cs.n_imul_constraints(), n_imul);
 		assert_eq!(cs.n_bmul_constraints(), n_bmul);
@@ -726,7 +717,7 @@ mod tests {
 			vec![ValueIndex(8)],  // valid private value
 		));
 
-		let result = cs.validate_and_prepare();
+		let result = cs.validate();
 		assert!(result.is_err(), "Should reject constraint with out-of-range index");
 
 		match result.unwrap_err() {
@@ -758,7 +749,7 @@ mod tests {
 			vec![ShiftedValueIndex::plain(ValueIndex(100))], // hi: WAY out of range!
 		]));
 
-		let result = cs.validate_and_prepare();
+		let result = cs.validate();
 		assert!(result.is_err(), "Should reject IMUL constraint with out-of-range index");
 
 		match result.unwrap_err() {
@@ -792,7 +783,7 @@ mod tests {
 			vec![ShiftedValueIndex::plain(ValueIndex(100))], // c_hi: WAY out of range!
 		]));
 
-		let result = cs.validate_and_prepare();
+		let result = cs.validate();
 		assert!(result.is_err(), "Should reject BMUL constraint with out-of-range index");
 
 		match result.unwrap_err() {
@@ -827,7 +818,7 @@ mod tests {
 			vec![ValueIndex(8)],
 		));
 
-		let result = cs.validate_and_prepare();
+		let result = cs.validate();
 		assert!(result.is_err());
 
 		// Should get OutOfRangeValueIndex, not PaddingValueIndex
@@ -858,7 +849,7 @@ mod tests {
 			vec![ShiftedValueIndex::plain(ValueIndex(8))],
 		));
 
-		match cs.validate_and_prepare().unwrap_err() {
+		match cs.validate().unwrap_err() {
 			ConstraintSystemError::ShiftAmountTooLarge {
 				constraint_type,
 				constraint_index,

--- a/crates/core/src/constraint_system/system.rs
+++ b/crates/core/src/constraint_system/system.rs
@@ -30,6 +30,15 @@ use crate::{error::ConstraintSystemError, word::Word};
 ///
 /// A constraint may reference any value word, but not a padding word.
 ///
+/// # Constraint counts
+///
+/// The AND, IMUL and BMUL constraint counts are the true counts; none of them is rounded up to a
+/// power of two. The reductions run over power-of-two-sized operand columns, so the prover rounds
+/// each count up to a power of two and zero-fills the tail when it materializes the column;
+/// [`Self::log_and_constraints`] and its IMUL and BMUL siblings report the resulting variable
+/// count. Zero is a valid padding row for every constraint type: an empty operand evaluates to
+/// [`Word::ZERO`], and `0 & 0 ^ 0 = 0` and `0 * 0 = 0 || 0` both hold.
+///
 /// # Clone
 ///
 /// While this type is cloneable it may be expensive to do so since the constraint systems often
@@ -245,34 +254,8 @@ impl ConstraintSystem {
 	/// This function performs the following:
 	/// 1. Validates the value vector layout (including public input checks)
 	/// 2. Validates the constraints.
-	/// 3. Pads the AND, IMUL, and BMUL constraints to the next po2 size
 	pub fn validate_and_prepare(&mut self) -> Result<(), ConstraintSystemError> {
-		self.validate()?;
-
-		// Require all constraint types to have a power-of-two count. An empty IMUL (resp. BMUL)
-		// constraint set is kept at zero (rather than padded to a single dummy constraint) so the
-		// prover and verifier can skip the IntMul (resp. BinMul) reduction entirely — see
-		// `IOPProver::prove` / `IOPVerifier::verify`.
-		let and_target_size = self.and_constraints.len().next_power_of_two();
-		let imul_target_size = if self.imul_constraints.is_empty() {
-			0
-		} else {
-			self.imul_constraints.len().next_power_of_two()
-		};
-		let bmul_target_size = if self.bmul_constraints.is_empty() {
-			0
-		} else {
-			self.bmul_constraints.len().next_power_of_two()
-		};
-
-		self.and_constraints
-			.resize_with(and_target_size, AndConstraint::default);
-		self.imul_constraints
-			.resize_with(imul_target_size, ImulConstraint::default);
-		self.bmul_constraints
-			.resize_with(bmul_target_size, BmulConstraint::default);
-
-		Ok(())
+		self.validate()
 	}
 
 	/// Returns the number of AND constraints in the system.
@@ -288,6 +271,48 @@ impl ConstraintSystem {
 	/// Returns the number of BMUL constraints in the system.
 	pub const fn n_bmul_constraints(&self) -> usize {
 		self.bmul_constraints.len()
+	}
+
+	/// Returns the number of variables the BitAnd reduction runs over, or `None` when the system
+	/// has no AND constraints.
+	///
+	/// The reduction operates on operand columns with one row per AND constraint, zero-padded up
+	/// to a power of two, so it has `ceil(log2(n_and_constraints))` variables. Unlike the two
+	/// multiplication reductions, the BitAnd reduction always runs: a system with no AND
+	/// constraints still gets a single all-zero row, which every constraint type satisfies. Such a
+	/// system reduces over zero variables, so its callers read `None` as zero.
+	pub const fn log_and_constraints(&self) -> Option<usize> {
+		match self.n_and_constraints() {
+			0 => None,
+			n => Some(log2_ceil_usize(n)),
+		}
+	}
+
+	/// Returns the number of variables the IntMul reduction runs over, or `None` when the system
+	/// has no IMUL constraints.
+	///
+	/// This is `ceil(log2(n_imul_constraints))`, matching the zero-padded operand columns the
+	/// reduction consumes. `None` is the skip signal: an empty IMUL set makes the prover and
+	/// verifier skip the IntMul reduction entirely, rather than run it over a single dummy
+	/// constraint.
+	pub const fn log_imul_constraints(&self) -> Option<usize> {
+		match self.n_imul_constraints() {
+			0 => None,
+			n => Some(log2_ceil_usize(n)),
+		}
+	}
+
+	/// Returns the number of variables the BinMul reduction runs over, or `None` when the system
+	/// has no BMUL constraints.
+	///
+	/// This is `ceil(log2(n_bmul_constraints))`, matching the zero-padded operand columns the
+	/// reduction consumes. As with [`Self::log_imul_constraints`], `None` is the skip signal; both
+	/// sides skip the BinMul reduction for an empty BMUL set.
+	pub const fn log_bmul_constraints(&self) -> Option<usize> {
+		match self.n_bmul_constraints() {
+			0 => None,
+			n => Some(log2_ceil_usize(n)),
+		}
 	}
 
 	/// The total length of the [`ValueVec`] expected by this constraint system.
@@ -662,6 +687,32 @@ mod tests {
 			"Should accept constraints with only valid references: {:?}",
 			result
 		);
+	}
+
+	#[test]
+	fn test_validate_and_prepare_keeps_true_constraint_counts() {
+		let mut cs = create_test_constraint_system();
+		let (n_and, n_imul, n_bmul) =
+			(cs.n_and_constraints(), cs.n_imul_constraints(), cs.n_bmul_constraints());
+		cs.validate_and_prepare().unwrap();
+		assert_eq!(cs.n_and_constraints(), n_and);
+		assert_eq!(cs.n_imul_constraints(), n_imul);
+		assert_eq!(cs.n_bmul_constraints(), n_bmul);
+	}
+
+	#[test]
+	fn test_log_constraint_counts_round_up() {
+		let mut cs = test_shape();
+		// An empty set reports `None`; the BitAnd reduction reads that as its single all-zero
+		// padding row, i.e. zero variables.
+		assert_eq!(cs.log_and_constraints(), None);
+
+		let and =
+			AndConstraint::plain_abc(vec![ValueIndex(0)], vec![ValueIndex(4)], vec![ValueIndex(8)]);
+		cs.and_constraints = vec![and; 3];
+		assert_eq!(cs.log_and_constraints(), Some(2));
+		cs.and_constraints.push(cs.and_constraints[0].clone());
+		assert_eq!(cs.log_and_constraints(), Some(2));
 	}
 
 	#[test]

--- a/crates/m4-prover/Cargo.toml
+++ b/crates/m4-prover/Cargo.toml
@@ -22,6 +22,7 @@ binius-prover = { path = "../prover" }
 binius-transcript = { path = "../transcript" }
 binius-utils = { path = "../utils" }
 binius-verifier = { path = "../verifier" }
+bytemuck.workspace = true
 itertools.workspace = true
 tracing.workspace = true
 

--- a/crates/m4-prover/benches/assemble_operation_witness.rs
+++ b/crates/m4-prover/benches/assemble_operation_witness.rs
@@ -67,8 +67,8 @@ fn bench_assemble_operation_witness(c: &mut Criterion) {
 	// The per-instance AND constraints, prepared so their count is a power of two (a precondition
 	// of `build_operation_columns`).
 	let and_constraints = {
-		let mut cs = circuit.constraint_system().clone();
-		cs.validate_and_prepare().unwrap();
+		let cs = circuit.constraint_system().clone();
+		cs.validate().unwrap();
 		cs.and_constraints
 	};
 

--- a/crates/m4-prover/benches/assemble_operation_witness.rs
+++ b/crates/m4-prover/benches/assemble_operation_witness.rs
@@ -64,8 +64,7 @@ fn bench_assemble_operation_witness(c: &mut Criterion) {
 	// The circuit's constants, shared by every instance.
 	let constants = circuit.constraint_system().constants.clone();
 
-	// The per-instance AND constraints, prepared so their count is a power of two (a precondition
-	// of `build_operation_columns`).
+	// The per-instance AND constraints, at their true (unpadded) count.
 	let and_constraints = {
 		let cs = circuit.constraint_system().clone();
 		cs.validate().unwrap();

--- a/crates/m4-prover/benches/utils/m4_bench.rs
+++ b/crates/m4-prover/benches/utils/m4_bench.rs
@@ -50,7 +50,7 @@ pub fn bench_m4_proving<F>(
 ) where
 	F: Fn(usize, &mut BatchWitnessFiller<'_, '_>),
 {
-	// Prepare the shared single-instance constraint system once.
+	// Clone and validate the shared single-instance constraint system once.
 	let cs = circuit.constraint_system().clone();
 	cs.validate()
 		.expect("circuit produces a valid constraint system");

--- a/crates/m4-prover/benches/utils/m4_bench.rs
+++ b/crates/m4-prover/benches/utils/m4_bench.rs
@@ -51,8 +51,8 @@ pub fn bench_m4_proving<F>(
 	F: Fn(usize, &mut BatchWitnessFiller<'_, '_>),
 {
 	// Prepare the shared single-instance constraint system once.
-	let mut cs = circuit.constraint_system().clone();
-	cs.validate_and_prepare()
+	let cs = circuit.constraint_system().clone();
+	cs.validate()
 		.expect("circuit produces a valid constraint system");
 
 	// The verifier fixes the shape and FRI parameters; the prover inherits them.

--- a/crates/m4-prover/src/operand_witness.rs
+++ b/crates/m4-prover/src/operand_witness.rs
@@ -378,7 +378,7 @@ mod tests {
 		evaluate(&folded, eval_point)
 	}
 
-	// The prepared per-instance AND constraints, at their true (unpadded) count.
+	// The per-instance AND constraints, at their true (unpadded) count.
 	// This mirrors how the prover feeds constraints downstream.
 	fn table_constraints(c: &AndCircuit) -> Vec<AndConstraint> {
 		let cs = c.circuit.constraint_system().clone();
@@ -577,7 +577,7 @@ mod tests {
 		];
 		let table = populate_mul_table(&c, &inputs);
 
-		// The prepared per-instance IMUL constraints, at their true (unpadded) count.
+		// The per-instance IMUL constraints, at their true (unpadded) count.
 		let cs = c.circuit.constraint_system().clone();
 		cs.validate().unwrap();
 		let imul_constraints = &cs.imul_constraints;
@@ -675,7 +675,7 @@ mod tests {
 		];
 		let table = populate_binmul_table(&c, &inputs);
 
-		// The prepared per-instance BMUL constraints, at their true (unpadded) count.
+		// The per-instance BMUL constraints, at their true (unpadded) count.
 		let cs = c.circuit.constraint_system().clone();
 		cs.validate().unwrap();
 		let bmul_constraints = &cs.bmul_constraints;

--- a/crates/m4-prover/src/operand_witness.rs
+++ b/crates/m4-prover/src/operand_witness.rs
@@ -21,7 +21,7 @@ use binius_core::{
 	constraint_system::{Operand, ShiftVariant, ShiftedValueIndex},
 	word::Word,
 };
-use binius_utils::{checked_arithmetics::checked_log_2, rayon::prelude::*};
+use binius_utils::{checked_arithmetics::log2_ceil_usize, rayon::prelude::*};
 
 use crate::ValueTable;
 
@@ -39,13 +39,13 @@ use crate::ValueTable;
 ///
 /// - `table`: the wire-major batch witness holding every instance's hidden words.
 /// - `constants`: the circuit's constant words, shared by every instance.
-/// - `constraints`: the per-instance constraints, shared by every instance. Pass constraints from a
-///   prepared constraint system, so their count is a power of two.
+/// - `constraints`: the per-instance constraints, shared by every instance. Their count need not be
+///   a power of two; the columns are zero-padded up to one.
 /// - `alloc`: the allocator backing the returned columns.
 ///
 /// # Panics
 ///
-/// Panics if `N_COLS` exceeds `ARITY`, or if the constraint count is not a power of two.
+/// Panics if `N_COLS` exceeds `ARITY`.
 pub fn build_operation_columns<C, A, const ARITY: usize, const N_COLS: usize>(
 	table: &ValueTable,
 	constants: &[Word],
@@ -105,29 +105,36 @@ where
 /// - `table`: the wire-major batch witness holding every instance's hidden words.
 /// - `constants`: the circuit's constant words, shared by every instance.
 /// - `operands`: one operand per constraint, in order; the returned column follows that same order.
-///   Pass operands from a prepared constraint system, so their count is a power of two.
+///   Their count need not be a power of two; the constraint axis is zero-padded up to one, and a
+///   zero row satisfies every constraint type.
 /// - `alloc`: the allocator backing the returned column.
-///
-/// # Panics
-///
-/// Panics if the constraint count is not a power of two.
 pub fn build_operation_witness<'a, A: Allocator>(
 	table: &ValueTable,
 	constants: &[Word],
 	operands: impl IndexedParallelIterator<Item = &'a Operand>,
 	alloc: &A,
 ) -> A::Vec<Word> {
-	// Rows per instance, and total rows across the batch.
-	let log_constraints = checked_log_2(operands.len());
+	// Rows per instance, and total rows across the batch. The constraint axis is rounded up to a
+	// power of two, so the columns end in `(n_padded - n_constraints) << log_instances` zero rows.
+	let n_constraints = operands.len();
+	let log_constraints = log2_ceil_usize(n_constraints);
 	let log_instances = table.log_instances();
 
 	let table_words = table.as_words();
 	let witness_offset = ValueIndex(table.layout().offset_witness as u32);
 
-	let mut out = alloc.alloc::<Word>(1 << (log_instances + log_constraints));
+	let total = 1 << (log_instances + log_constraints);
+	let mut out = alloc.alloc::<Word>(total);
+	// The allocator may hand back more capacity than requested, so bound the spare slice to the row
+	// count before splitting it into the constraint rows and the zero padding.
+	let (constraint_rows, padding_rows) =
+		out.spare_capacity_mut()[..total].split_at_mut(n_constraints << log_instances);
+	// Zeroing a `MaybeUninit<Word>` initializes it to `Word::ZERO`: `Word` is `repr(transparent)`
+	// over `u64`, whose all-zero bit pattern is zero.
+	bytemuck::fill_zeroes(padding_rows);
 
 	operands
-		.zip(out.spare_capacity_mut().par_chunks_mut(1 << log_instances))
+		.zip(constraint_rows.par_chunks_mut(1 << log_instances))
 		.for_each(|(operand, out_chunk)| {
 			let mut shifted_indices_iter = operand.iter();
 
@@ -161,13 +168,11 @@ pub fn build_operation_witness<'a, A: Allocator>(
 			}
 		});
 
-	// SAFETY: the stripes partition `[0, total)` and each writes its whole range — the operand's
-	// first term initializes every cell, later terms XOR in place, and an empty operand zeroes the
-	// stripe. So all `total` elements are initialized. `alloc` may hand back more capacity than
-	// requested (the pool rounds the block up to a power-of-two byte count, minimum 64 bytes), so
-	// `spare_capacity_mut` can be longer than `total`; the zip against the operands truncates to
-	// `total`, and nothing past it is ever claimed by `set_len`.
-	unsafe { out.set_len(1 << (log_instances + log_constraints)) };
+	// SAFETY: the constraint stripes partition `[0, n_constraints << log_instances)` and each
+	// writes its whole range — the operand's first term initializes every cell, later terms XOR in
+	// place, and an empty operand zeroes the stripe. The remaining `[n_constraints <<
+	// log_instances, total)` was zeroed above. So all `total` elements are initialized.
+	unsafe { out.set_len(total) };
 	out
 }
 
@@ -373,7 +378,7 @@ mod tests {
 		evaluate(&folded, eval_point)
 	}
 
-	// The prepared per-instance AND constraints, padded to a power of two.
+	// The prepared per-instance AND constraints, at their true (unpadded) count.
 	// This mirrors how the prover feeds constraints downstream.
 	fn table_constraints(c: &AndCircuit) -> Vec<AndConstraint> {
 		let mut cs = c.circuit.constraint_system().clone();
@@ -385,6 +390,21 @@ mod tests {
 	// This circuit declares none, so the slice is empty; operands read only hidden words.
 	fn constants(c: &AndCircuit) -> &[Word] {
 		&c.circuit.constraint_system().constants
+	}
+
+	// One AND constraint whose `A` and `B` operands evaluate to a non-zero word on every instance
+	// of `table`, chosen with the reference evaluator rather than the builder under test.
+	fn all_nonzero_constraint(c: &AndCircuit, table: &ValueTable) -> AndConstraint {
+		table_constraints(c)
+			.into_iter()
+			.find(|constraint| {
+				(0..table.n_instances()).all(|instance| {
+					let vv = table.instance_value_vec(instance, constants(c));
+					vv.eval_operand(constraint.a()) != Word::ZERO
+						&& vv.eval_operand(constraint.b()) != Word::ZERO
+				})
+			})
+			.expect("the fixture has an AND constraint with non-zero A and B on every instance")
 	}
 
 	// A circuit asserting `z == (x & y) ^ w`, over four witness words.
@@ -557,7 +577,7 @@ mod tests {
 		];
 		let table = populate_mul_table(&c, &inputs);
 
-		// The prepared per-instance IMUL constraints, padded to a power of two.
+		// The prepared per-instance IMUL constraints, at their true (unpadded) count.
 		let mut cs = c.circuit.constraint_system().clone();
 		cs.validate_and_prepare().unwrap();
 		let imul_constraints = &cs.imul_constraints;
@@ -655,7 +675,7 @@ mod tests {
 		];
 		let table = populate_binmul_table(&c, &inputs);
 
-		// The prepared per-instance BMUL constraints, padded to a power of two.
+		// The prepared per-instance BMUL constraints, at their true (unpadded) count.
 		let mut cs = c.circuit.constraint_system().clone();
 		cs.validate_and_prepare().unwrap();
 		let bmul_constraints = &cs.bmul_constraints;
@@ -705,23 +725,36 @@ mod tests {
 	}
 
 	#[test]
-	#[should_panic(expected = "value is not a power of two")]
-	fn build_rejects_non_power_of_two_constraint_count() {
+	fn build_zero_pads_a_non_power_of_two_constraint_count() {
 		let c = and_circuit();
 
-		// Fixture state: a valid batch with one instance (K = 1).
-		let table = populate_table(&c, &[(1, 3, 7)]);
+		// Fixture state: a batch of 2 instances (K = 2).
+		let table = populate_table(&c, &[(1, 3, 7), (5, 6, 0)]);
+		let n_instances = table.n_instances();
 
-		// Invariant: the per-instance constraint count must be a power of two.
+		// Invariant: the constraint axis is rounded up to a power of two, so 3 constraints yield 4
+		// constraint stripes, the last of which is all zeros.
 		//
-		// Mutation: hand the builder 3 constraints.
-		//
-		//     3 is not a power of two → build asserts on the count before reading any row.
-		//
-		// The operands are empty, so the panic is the count check, never an out-of-range index.
-		let three = vec![AndConstraint::default(); 3];
-		let _: [Vec<Word>; 2] =
-			build_operation_columns(&table, constants(&c), &three, &GlobalAllocator);
+		// The three constraints all repeat one whose `A` and `B` are non-zero on every instance, so
+		// every leading stripe carries non-zero words. Asserting that pins the split point: a
+		// column zeroed past the wrong offset fails here rather than slipping through the
+		// trailing-zero check.
+		let constraints = vec![all_nonzero_constraint(&c, &table); 3];
+		let [a, b] = build_operation_columns(&table, constants(&c), &constraints, &GlobalAllocator);
+
+		for col in [&a, &b] {
+			assert_eq!(col.len(), 4 * n_instances);
+			assert!(
+				col[..3 * n_instances]
+					.iter()
+					.all(|&word| word != Word::ZERO)
+			);
+			assert!(
+				col[3 * n_instances..]
+					.iter()
+					.all(|&word| word == Word::ZERO)
+			);
+		}
 	}
 
 	proptest! {

--- a/crates/m4-prover/src/operand_witness.rs
+++ b/crates/m4-prover/src/operand_witness.rs
@@ -381,8 +381,8 @@ mod tests {
 	// The prepared per-instance AND constraints, at their true (unpadded) count.
 	// This mirrors how the prover feeds constraints downstream.
 	fn table_constraints(c: &AndCircuit) -> Vec<AndConstraint> {
-		let mut cs = c.circuit.constraint_system().clone();
-		cs.validate_and_prepare().unwrap();
+		let cs = c.circuit.constraint_system().clone();
+		cs.validate().unwrap();
 		cs.and_constraints
 	}
 
@@ -578,8 +578,8 @@ mod tests {
 		let table = populate_mul_table(&c, &inputs);
 
 		// The prepared per-instance IMUL constraints, at their true (unpadded) count.
-		let mut cs = c.circuit.constraint_system().clone();
-		cs.validate_and_prepare().unwrap();
+		let cs = c.circuit.constraint_system().clone();
+		cs.validate().unwrap();
 		let imul_constraints = &cs.imul_constraints;
 		assert!(!imul_constraints.is_empty(), "the circuit must emit an IMUL constraint");
 
@@ -676,8 +676,8 @@ mod tests {
 		let table = populate_binmul_table(&c, &inputs);
 
 		// The prepared per-instance BMUL constraints, at their true (unpadded) count.
-		let mut cs = c.circuit.constraint_system().clone();
-		cs.validate_and_prepare().unwrap();
+		let cs = c.circuit.constraint_system().clone();
+		cs.validate().unwrap();
 		let bmul_constraints = &cs.bmul_constraints;
 		assert!(!bmul_constraints.is_empty(), "the circuit must emit a BMUL constraint");
 

--- a/crates/m4-prover/src/prove.rs
+++ b/crates/m4-prover/src/prove.rs
@@ -156,10 +156,11 @@ impl IOPProver {
 				let _scope = tracing::debug_span!("Assemble IntMul witness").entered();
 				build_operation_columns(table, &cs.constants, &cs.imul_constraints, alloc)
 			};
-			// A prepared constraint system pads its constraint and instance counts to powers of
-			// two, so the columns always have a power-of-two length as the witness requires.
+			// `build_operation_columns` rounds the constraint axis up to a power of two and
+			// zero-fills the tail, and the table holds `2^log_instances` instances, so every column
+			// has the power-of-two length the IntMul witness requires.
 			let output = intmul::prove::<_, _, P, _>(column_slices(&columns), channel, alloc)
-				.expect("a prepared constraint system yields power-of-two operand columns");
+				.expect("the operand columns are equal-length and power-of-two length");
 			(columns, output)
 		});
 
@@ -1092,8 +1093,9 @@ mod tests {
 		cs.validate_and_prepare().unwrap();
 		// Confirm the fixture genuinely exercises the asymmetric case: the two operations have
 		// different constraint-point lengths.
-		let log_n_and = checked_log_2(cs.and_constraints.len());
-		let log_n_imul = checked_log_2(cs.imul_constraints.len());
+		// An absent operation contributes an empty `r_x`, as does an AND set of one row.
+		let log_n_and = cs.log_and_constraints().unwrap_or(0);
+		let log_n_imul = cs.log_imul_constraints().unwrap_or(0);
 		assert_ne!(
 			log_n_and, log_n_imul,
 			"the fixture must give the operations different r_x lengths"
@@ -1215,9 +1217,10 @@ mod tests {
 		cs.validate_and_prepare().unwrap();
 		// Confirm the fixture genuinely exercises the asymmetric case: the three operations do not
 		// all reduce to constraint points of the same length.
-		let log_n_and = checked_log_2(cs.and_constraints.len());
-		let log_n_imul = checked_log_2(cs.imul_constraints.len());
-		let log_n_binmul = checked_log_2(cs.bmul_constraints.len());
+		// An absent operation contributes an empty `r_x`, as does an AND set of one row.
+		let log_n_and = cs.log_and_constraints().unwrap_or(0);
+		let log_n_imul = cs.log_imul_constraints().unwrap_or(0);
+		let log_n_binmul = cs.log_bmul_constraints().unwrap_or(0);
 		assert!(!cs.imul_constraints.is_empty(), "the fixture must emit IMUL constraints");
 		assert!(!cs.bmul_constraints.is_empty(), "the fixture must emit BMUL constraints");
 		let lengths = [log_n_and, log_n_imul, log_n_binmul];

--- a/crates/m4-prover/src/prove.rs
+++ b/crates/m4-prover/src/prove.rs
@@ -79,7 +79,7 @@ type ProverNtt = NeighborsLastMultiThread<GenericPreExpanded<B128>>;
 /// The IntMul check queues that oracle's opening itself.
 /// The final combined FRI opening covers it alongside the trace, so it needs no handling here.
 pub struct IOPProver {
-	/// The prepared single-instance constraint system shared by every instance.
+	/// The validated single-instance constraint system shared by every instance.
 	cs: ConstraintSystem,
 	/// The shift keys for the constraint system, built once and reused across proofs.
 	key_collection: KeyCollection,

--- a/crates/m4-prover/src/prove.rs
+++ b/crates/m4-prover/src/prove.rs
@@ -833,8 +833,8 @@ mod tests {
 			.collect();
 		let table = populate_crc64_witness(&c, &inputs);
 
-		let mut cs = c.circuit.constraint_system().clone();
-		cs.validate_and_prepare().unwrap();
+		let cs = c.circuit.constraint_system().clone();
+		cs.validate().unwrap();
 		(cs, table)
 	}
 
@@ -871,8 +871,8 @@ mod tests {
 		builder.force_commit(c_hi);
 		let circuit = builder.build();
 
-		let mut cs = circuit.constraint_system().clone();
-		cs.validate_and_prepare().unwrap();
+		let cs = circuit.constraint_system().clone();
+		cs.validate().unwrap();
 		// Confirm the fixture reaches all three operations, so the recycled buffers really do span
 		// every operand-column shape.
 		assert!(!cs.imul_constraints.is_empty(), "the fixture must emit IMUL constraints");
@@ -963,8 +963,8 @@ mod tests {
 		builder.force_commit(lo);
 		let circuit = builder.build();
 
-		let mut cs = circuit.constraint_system().clone();
-		cs.validate_and_prepare().unwrap();
+		let cs = circuit.constraint_system().clone();
+		cs.validate().unwrap();
 		// Confirm the fixture genuinely exercises the IntMul path.
 		assert!(!cs.imul_constraints.is_empty(), "the fixture must emit an IMUL constraint");
 
@@ -1020,8 +1020,8 @@ mod tests {
 		}
 		let circuit = builder.build();
 
-		let mut cs = circuit.constraint_system().clone();
-		cs.validate_and_prepare().unwrap();
+		let cs = circuit.constraint_system().clone();
+		cs.validate().unwrap();
 		// Confirm the fixture is genuine: the constant count is not a power of two.
 		assert!(!cs.constants.len().is_power_of_two());
 
@@ -1089,8 +1089,8 @@ mod tests {
 		}
 		let circuit = builder.build();
 
-		let mut cs = circuit.constraint_system().clone();
-		cs.validate_and_prepare().unwrap();
+		let cs = circuit.constraint_system().clone();
+		cs.validate().unwrap();
 		// Confirm the fixture genuinely exercises the asymmetric case: the two operations have
 		// different constraint-point lengths.
 		// An absent operation contributes an empty `r_x`, as does an AND set of one row.
@@ -1148,8 +1148,8 @@ mod tests {
 		builder.force_commit(c_hi);
 		let circuit = builder.build();
 
-		let mut cs = circuit.constraint_system().clone();
-		cs.validate_and_prepare().unwrap();
+		let cs = circuit.constraint_system().clone();
+		cs.validate().unwrap();
 		// Confirm the fixture genuinely exercises the BinMul path.
 		assert!(!cs.bmul_constraints.is_empty(), "the fixture must emit a BMUL constraint");
 
@@ -1213,8 +1213,8 @@ mod tests {
 		builder.force_commit(c_hi);
 		let circuit = builder.build();
 
-		let mut cs = circuit.constraint_system().clone();
-		cs.validate_and_prepare().unwrap();
+		let cs = circuit.constraint_system().clone();
+		cs.validate().unwrap();
 		// Confirm the fixture genuinely exercises the asymmetric case: the three operations do not
 		// all reduce to constraint points of the same length.
 		// An absent operation contributes an empty `r_x`, as does an AND set of one row.
@@ -1297,8 +1297,8 @@ mod tests {
 		builder.force_commit(lo);
 		let circuit = builder.build();
 
-		let mut cs = circuit.constraint_system().clone();
-		cs.validate_and_prepare().unwrap();
+		let cs = circuit.constraint_system().clone();
+		cs.validate().unwrap();
 
 		let log_instances = 6;
 		let table = ValueTable::populate(&circuit, log_instances, |i, w| {

--- a/crates/m4-prover/src/shift.rs
+++ b/crates/m4-prover/src/shift.rs
@@ -557,7 +557,7 @@ mod tests {
 		let domain_subspace =
 			BinarySubspace::<AESTowerField8b>::with_dim(Word::LOG_BITS).isomorphic();
 		let r_z = B128::random(&mut rng);
-		let r_x = random_scalars::<B128>(&mut rng, checked_log_2(cs.n_and_constraints()));
+		let r_x = random_scalars::<B128>(&mut rng, cs.log_and_constraints().unwrap_or(0));
 		let r_rho = random_scalars::<B128>(&mut rng, log_instances);
 
 		// The hidden witness folded over instances (one FoldedWord per committed word), and the
@@ -685,7 +685,7 @@ mod tests {
 		let domain_subspace =
 			BinarySubspace::<AESTowerField8b>::with_dim(Word::LOG_BITS).isomorphic();
 		let r_z = B128::random(&mut rng);
-		let r_x = random_scalars::<B128>(&mut rng, checked_log_2(cs.n_and_constraints()));
+		let r_x = random_scalars::<B128>(&mut rng, cs.log_and_constraints().unwrap_or(0));
 		let r_rho = random_scalars::<B128>(&mut rng, log_instances);
 
 		// The batched AND-check operand evals at (r_z, r_x, r_rho), and the full folded witness at

--- a/crates/m4-prover/src/shift.rs
+++ b/crates/m4-prover/src/shift.rs
@@ -549,8 +549,8 @@ mod tests {
 			.collect();
 		let table = populate_crc64_witness(&c, &inputs);
 
-		let mut cs = c.circuit.constraint_system().clone();
-		cs.validate_and_prepare().unwrap();
+		let cs = c.circuit.constraint_system().clone();
+		cs.validate().unwrap();
 		let key_collection = build_key_collection(&cs);
 
 		// The univariate bit challenge, the constraint challenge, and the instance challenge.
@@ -677,8 +677,8 @@ mod tests {
 		let table = populate_crc64_witness(&c, &inputs);
 		let constants = &c.circuit.constraint_system().constants;
 
-		let mut cs = c.circuit.constraint_system().clone();
-		cs.validate_and_prepare().unwrap();
+		let cs = c.circuit.constraint_system().clone();
+		cs.validate().unwrap();
 		let key_collection = build_key_collection(&cs);
 
 		// The univariate bit challenge, the constraint challenge, and the instance challenge.

--- a/crates/m4-prover/tests/prove_hash_primitives.rs
+++ b/crates/m4-prover/tests/prove_hash_primitives.rs
@@ -82,8 +82,8 @@ where
 		.in_scope(|| ValueTable::populate(circuit, LOG_INSTANCES, fill).unwrap());
 
 	// Prepare the shared constraint system.
-	let mut cs = circuit.constraint_system().clone();
-	cs.validate_and_prepare().unwrap();
+	let cs = circuit.constraint_system().clone();
+	cs.validate().unwrap();
 
 	// Set up the verifier.
 	// Build the prover from it, sharing its FRI parameters.

--- a/crates/m4-prover/tests/prove_hash_primitives.rs
+++ b/crates/m4-prover/tests/prove_hash_primitives.rs
@@ -81,7 +81,7 @@ where
 	let table = info_span!("witness_generation", primitive = name)
 		.in_scope(|| ValueTable::populate(circuit, LOG_INSTANCES, fill).unwrap());
 
-	// Prepare the shared constraint system.
+	// Clone and validate the shared single-instance constraint system.
 	let cs = circuit.constraint_system().clone();
 	cs.validate().unwrap();
 

--- a/crates/m4-verifier/src/verify.rs
+++ b/crates/m4-verifier/src/verify.rs
@@ -23,7 +23,6 @@ use binius_math::{
 	univariate::{evaluate_univariate, lagrange_evals_scalars},
 };
 use binius_transcript::{VerifierTranscript, fiat_shamir::Challenger};
-use binius_utils::checked_arithmetics::checked_log_2;
 use binius_verifier::{
 	Error,
 	config::{B1, B128},
@@ -156,8 +155,7 @@ impl IOPVerifier {
 		//
 		// The IntMul columns span every instance's constraints.
 		// So the check runs over `log_instances + log_n_imul` row variables.
-		let intmul_output = if cs.n_imul_constraints() > 0 {
-			let log_n_imul = checked_log_2(cs.n_imul_constraints());
+		let intmul_output = if let Some(log_n_imul) = cs.log_imul_constraints() {
 			Some(verify_intmul_reduction::<B128, _>(log_instances + log_n_imul, channel)?)
 		} else {
 			None
@@ -170,15 +168,15 @@ impl IOPVerifier {
 		//
 		// The BinMul columns span every instance's constraints.
 		// So the check runs over `log_instances + log_n_binmul` row variables.
-		let binmul_output = if cs.n_bmul_constraints() > 0 {
-			let log_n_binmul = checked_log_2(cs.n_bmul_constraints());
+		let binmul_output = if let Some(log_n_binmul) = cs.log_bmul_constraints() {
 			Some(verify_binmul_reduction::<B128, _>(log_instances + log_n_binmul, channel)?)
 		} else {
 			None
 		};
 
-		// AND-check over all `K * n_and` rows.
-		let log_n_and = checked_log_2(cs.and_constraints.len());
+		// AND-check over all `K * n_and` rows. The check has no skip branch: an empty AND set still
+		// reduces, over the single all-zero padding row, so `None` is zero constraint variables.
+		let log_n_and = cs.log_and_constraints().unwrap_or(0);
 		let AndCheckOutput {
 			a_eval,
 			b_eval,

--- a/crates/m4-verifier/src/verify.rs
+++ b/crates/m4-verifier/src/verify.rs
@@ -68,7 +68,7 @@ type Scheme = BinaryMerkleTreeScheme<B128, StdHashSuite>;
 /// Both operand claims at that point then feed the shift.
 #[derive(Debug, Clone)]
 pub struct IOPVerifier {
-	/// The prepared single-instance constraint system shared by every instance.
+	/// The validated single-instance constraint system shared by every instance.
 	cs: ConstraintSystem,
 	/// The committed-multilinear shape of the batch.
 	layout: BatchCommitLayout,
@@ -80,7 +80,7 @@ impl IOPVerifier {
 		Self { cs, layout }
 	}
 
-	/// The prepared constraint system this verifier checks against.
+	/// The validated constraint system this verifier checks against.
 	pub const fn constraint_system(&self) -> &ConstraintSystem {
 		&self.cs
 	}
@@ -281,7 +281,7 @@ impl Verifier {
 	///
 	/// # Arguments
 	///
-	/// - `cs`: the prepared single-instance constraint system shared by every instance.
+	/// - `cs`: the validated single-instance constraint system shared by every instance.
 	/// - `log_instances`: base-2 logarithm of the instance count.
 	/// - `log_inv_rate`: base-2 logarithm of the inverse Reed-Solomon rate.
 	pub fn setup(cs: &ConstraintSystem, log_instances: usize, log_inv_rate: usize) -> Self {
@@ -319,7 +319,7 @@ impl Verifier {
 		}
 	}
 
-	/// The prepared constraint system this verifier checks against.
+	/// The validated constraint system this verifier checks against.
 	pub const fn constraint_system(&self) -> &ConstraintSystem {
 		self.iop_verifier.constraint_system()
 	}

--- a/crates/prover/benches/shift_reduction.rs
+++ b/crates/prover/benches/shift_reduction.rs
@@ -90,8 +90,8 @@ fn bench_prove_and_verify(c: &mut Criterion) {
 
 	for &log_message_len_bytes in &log_message_lengths_bytes {
 		let message_len_bytes = 1 << log_message_len_bytes;
-		let (mut cs, value_vec) = create_sha256_cs_with_witness(log_message_len_bytes, &mut rng);
-		cs.validate_and_prepare().unwrap();
+		let (cs, value_vec) = create_sha256_cs_with_witness(log_message_len_bytes, &mut rng);
+		cs.validate().unwrap();
 
 		// Sample multilinear eval points
 		let r_x_prime_bitand = {
@@ -219,8 +219,8 @@ fn bench_shift_phases(c: &mut Criterion) {
 	// benches share one setup and stay quick.
 	const LOG_MESSAGE_LEN_BYTES: usize = 14;
 
-	let (mut cs, value_vec) = create_sha256_cs_with_witness(LOG_MESSAGE_LEN_BYTES, &mut rng);
-	cs.validate_and_prepare().unwrap();
+	let (cs, value_vec) = create_sha256_cs_with_witness(LOG_MESSAGE_LEN_BYTES, &mut rng);
+	cs.validate().unwrap();
 
 	// The BitAnd reduction always runs; `None` is its single all-zero padding row.
 	let r_x_prime_bitand = (0..cs.log_and_constraints().unwrap_or(0) as u128)

--- a/crates/prover/benches/shift_reduction.rs
+++ b/crates/prover/benches/shift_reduction.rs
@@ -19,7 +19,6 @@ use binius_prover::{
 	},
 };
 use binius_transcript::ProverTranscript;
-use binius_utils::checked_arithmetics::strict_log_2;
 use binius_verifier::{
 	config::StdChallenger,
 	protocols::shift::{OperatorData as VerifierOperatorData, verify},
@@ -96,7 +95,8 @@ fn bench_prove_and_verify(c: &mut Criterion) {
 
 		// Sample multilinear eval points
 		let r_x_prime_bitand = {
-			let log_bitand_constraint_count = strict_log_2(cs.and_constraints.len()).unwrap();
+			// The BitAnd reduction always runs; `None` is its single all-zero padding row.
+			let log_bitand_constraint_count = cs.log_and_constraints().unwrap_or(0);
 			(0..log_bitand_constraint_count as u128)
 				.map(F::new)
 				.collect::<Vec<_>>()
@@ -222,7 +222,8 @@ fn bench_shift_phases(c: &mut Criterion) {
 	let (mut cs, value_vec) = create_sha256_cs_with_witness(LOG_MESSAGE_LEN_BYTES, &mut rng);
 	cs.validate_and_prepare().unwrap();
 
-	let r_x_prime_bitand = (0..strict_log_2(cs.and_constraints.len()).unwrap() as u128)
+	// The BitAnd reduction always runs; `None` is its single all-zero padding row.
+	let r_x_prime_bitand = (0..cs.log_and_constraints().unwrap_or(0) as u128)
 		.map(F::new)
 		.collect::<Vec<_>>();
 	// SHA256 has no IMUL constraints, so the IntMul operator is the zero claim at an empty point,

--- a/crates/prover/src/and_reduction/mod.rs
+++ b/crates/prover/src/and_reduction/mod.rs
@@ -51,6 +51,9 @@ where
 	let prover_message_domain = BinarySubspace::<B8>::with_dim(Word::LOG_BITS + 1);
 	let [a, b] = columns;
 
+	// The column length is the row count: one row per constraint for the single-instance prover,
+	// one per (instance, constraint) pair for the M4 batch prover, in both cases zero-padded up to
+	// a power of two.
 	let log_constraint_count = checked_log_2(a.len());
 
 	// Pin the first few zerocheck coordinates to fixed small-field elements (friendly challenges),

--- a/crates/prover/src/protocols/binmul.rs
+++ b/crates/prover/src/protocols/binmul.rs
@@ -24,7 +24,7 @@ where
 	P: PackedField<Scalar = F>,
 {
 	let n_vars = strict_log_2(lo.len())
-		.expect("precondition: the number of constraints must be a power of two");
+		.expect("precondition: the operand columns have a power-of-two length");
 	let p_width = P::WIDTH.min(1 << n_vars);
 	let packed_len = 1 << n_vars.saturating_sub(P::LOG_WIDTH);
 	let mut values = alloc.alloc::<P>(packed_len);
@@ -46,8 +46,8 @@ where
 /// description and output shape.
 ///
 /// The six `columns` are the `(lo, hi)` word pairs of the two multiplicands and the product, in the
-/// order `[a_lo, a_hi, b_lo, b_hi, c_lo, c_hi]`. Each has length $2^\ell$, where $\ell$ is the log2
-/// of the number of constraints. The GHASH-field element for constraint $x$ is
+/// order `[a_lo, a_hi, b_lo, b_hi, c_lo, c_hi]`, each of power-of-two length $2^\ell$ and all of
+/// equal length. The GHASH-field element for row $x$ is
 /// $\langle\langle z_{\textsf{lo}}, z_{\textsf{hi}} \rangle\rangle = \sum_{i=0}^{63}
 /// z_{\textsf{lo},x,i} \cdot X^i + \sum_{i=0}^{63} z_{\textsf{hi},x,i} \cdot X^{64+i}$ for each of
 /// $z \in \{a, b, c\}$.
@@ -65,7 +65,7 @@ where
 	let [a_lo, a_hi, b_lo, b_hi, c_lo, c_hi] = columns;
 
 	let n_vars = strict_log_2(a_lo.len())
-		.expect("precondition: the number of constraints must be a power of two");
+		.expect("precondition: the operand columns have a power-of-two length");
 	for column in [a_hi, b_lo, b_hi, c_lo, c_hi] {
 		assert_eq!(column.len(), a_lo.len());
 	}

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-use std::marker::PhantomData;
+use std::{marker::PhantomData, mem::MaybeUninit};
 
 use binius_compute::{Allocator, BufferPool, VecLike};
 use binius_core::{
@@ -547,7 +547,9 @@ pub fn pack_witness<P: PackedField<Scalar = B128>, A: Allocator>(
 ///
 /// Column `i` holds operand `i` of every constraint, in the constraint type's storage order — the
 /// order the shift reduction batches operands in. Each column has one row per constraint, in the
-/// same order.
+/// same order, followed by zero rows up to `constraints.len().next_power_of_two()`: the reductions
+/// consume power-of-two-length columns, and a zero row satisfies every constraint type. An empty
+/// constraint slice still yields one zero row, since that is the smallest power-of-two length.
 ///
 /// `N_COLS` may be smaller than `ARITY`, in which case the trailing operands are not evaluated. The
 /// BitAnd check uses that to skip its `C` column: on a satisfying witness `C = A & B` holds
@@ -564,17 +566,25 @@ where
 	assert!(N_COLS <= ARITY, "N_COLS must not exceed the constraint arity");
 
 	let n_constraints = constraints.len();
+	let n_rows = n_constraints.next_power_of_two();
 	(0..N_COLS)
 		.into_par_iter()
 		.map(|op_idx| {
-			let mut column = alloc.alloc::<Word>(n_constraints);
-			(constraints, column.spare_capacity_mut())
+			let mut column = alloc.alloc::<Word>(n_rows);
+			// The allocator may hand back more capacity than requested, so bound the spare slice to
+			// the row count before splitting it into the constraint rows and the zero padding.
+			let (constraint_rows, padding_rows) =
+				column.spare_capacity_mut()[..n_rows].split_at_mut(n_constraints);
+			(constraints, &mut *constraint_rows)
 				.into_par_iter()
 				.for_each(|(constraint, out)| {
 					out.write(witness.eval_operand(&constraint.as_ref()[op_idx]));
 				});
-			// Safety: every entry of `column` is written exactly once in the parallel loop above.
-			unsafe { column.set_len(n_constraints) };
+			padding_rows.fill(MaybeUninit::new(Word::ZERO));
+			// Safety: the two halves partition the first `n_rows` entries of `column`; the parallel
+			// loop writes each constraint row exactly once (the zip is over equal-length sides) and
+			// the loop above writes each padding row exactly once.
+			unsafe { column.set_len(n_rows) };
 			column
 		})
 		.collect::<Vec<_>>()

--- a/crates/prover/tests/prove_verify.rs
+++ b/crates/prover/tests/prove_verify.rs
@@ -183,6 +183,112 @@ fn test_prove_verify_binmul_seventh_power() {
 	prove_verify_zk(cs, witness);
 }
 
+/// Builds a circuit whose AND, IMUL and BMUL constraint counts are all non-powers of two, so every
+/// reduction runs over operand columns whose tail rows are zero padding.
+///
+/// Each asserted `band` contributes two AND constraints (the `band` itself and the equality), each
+/// `imul` gate one IMUL constraint, and each `bmul` gate one BMUL constraint — 6, 3 and 3 in total.
+/// The caller asserts those counts are not powers of two rather than relying on it silently.
+fn non_power_of_two_constraint_circuit() -> (ConstraintSystem, ValueVec) {
+	const N_AND_GATES: usize = 3;
+	const N_IMUL_GATES: usize = 3;
+	const N_BMUL_GATES: usize = 3;
+
+	let circuit = CircuitBuilder::new();
+
+	// `z == x & y`, with all three words private.
+	let and_wires = (0..N_AND_GATES)
+		.map(|i| {
+			let x = circuit.add_witness();
+			let y = circuit.add_witness();
+			let z = circuit.add_witness();
+			circuit.assert_eq(format!("and_{i}"), circuit.band(x, y), z);
+			(x, y, z)
+		})
+		.collect::<Vec<_>>();
+
+	// `(hi, lo) = a * b`. `force_commit` makes both product words hidden, so the IMUL operands read
+	// them from the witness rather than folding them away.
+	let imul_wires = (0..N_IMUL_GATES)
+		.map(|_| {
+			let a = circuit.add_witness();
+			let b = circuit.add_witness();
+			let (hi, lo) = circuit.imul(a, b);
+			circuit.force_commit(hi);
+			circuit.force_commit(lo);
+			(a, b)
+		})
+		.collect::<Vec<_>>();
+
+	// GHASH-field products `(c_lo, c_hi) = (a_lo, a_hi) * (b_lo, b_hi)`, likewise committed.
+	let bmul_wires = (0..N_BMUL_GATES)
+		.map(|_| {
+			let a_lo = circuit.add_witness();
+			let a_hi = circuit.add_witness();
+			let b_lo = circuit.add_witness();
+			let b_hi = circuit.add_witness();
+			let (c_lo, c_hi) = circuit.bmul(a_lo, a_hi, b_lo, b_hi);
+			circuit.force_commit(c_lo);
+			circuit.force_commit(c_hi);
+			[a_lo, a_hi, b_lo, b_hi]
+		})
+		.collect::<Vec<_>>();
+
+	let circuit = circuit.build();
+	let mut w = circuit.new_witness_filler();
+
+	for (i, &(x, y, z)) in and_wires.iter().enumerate() {
+		let x_val = Word(0x0123_4567_89AB_CDEF ^ (i as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15));
+		let y_val = Word(0xFEDC_BA98_7654_3210 ^ (i as u64).wrapping_mul(0xC2B2_AE3D_27D4_EB4F));
+		w[x] = x_val;
+		w[y] = y_val;
+		w[z] = x_val & y_val;
+	}
+
+	for (i, &(a, b)) in imul_wires.iter().enumerate() {
+		w[a] = Word(0xDEAD_BEEF_CAFE_BABE ^ (i as u64).wrapping_mul(0x1234_5678_9ABC_DEF0));
+		w[b] = Word(0x0F0F_0F0F_0F0F_0F0F ^ (i as u64).wrapping_mul(0xA5A5_A5A5_A5A5_A5A5));
+	}
+
+	let mut rng = StdRng::seed_from_u64(0);
+	for &[a_lo, a_hi, b_lo, b_hi] in &bmul_wires {
+		let a = u128::from(BinaryField128bGhash::random(&mut rng));
+		let b = u128::from(BinaryField128bGhash::random(&mut rng));
+		w[a_lo] = Word(a as u64);
+		w[a_hi] = Word((a >> 64) as u64);
+		w[b_lo] = Word(b as u64);
+		w[b_hi] = Word((b >> 64) as u64);
+	}
+
+	// The gates derive the AND, product and GHASH-product outputs, so the filled witness satisfies
+	// every constraint.
+	circuit.populate_wire_witness(&mut w).unwrap();
+
+	(circuit.constraint_system().clone(), w.into_value_vec())
+}
+
+/// A circuit whose AND, IMUL and BMUL constraint counts are all non-powers of two proves and
+/// verifies. The constraint system keeps those true counts; the prover zero-pads each operand
+/// column up to a power of two, and both sides derive their sumcheck variable counts by rounding
+/// the same true count up.
+#[test]
+fn test_prove_verify_non_power_of_two_constraint_counts() {
+	let (cs, witness) = non_power_of_two_constraint_circuit();
+	for (name, n_constraints) in [
+		("AND", cs.n_and_constraints()),
+		("IMUL", cs.n_imul_constraints()),
+		("BMUL", cs.n_bmul_constraints()),
+	] {
+		assert!(
+			n_constraints > 0 && !n_constraints.is_power_of_two(),
+			"{name} constraint count is {n_constraints}, which must be non-zero and not a power \
+			 of two for this test to exercise padding"
+		);
+	}
+	prove_verify(cs.clone(), witness.clone());
+	prove_verify_zk(cs, witness);
+}
+
 /// A SHA-256 circuit uses only AND constraints, so its constraint system has zero IMUL
 /// constraints. This locks in that the prover and verifier skip the IntMul reduction entirely
 /// (rather than padding up to a dummy IMUL constraint); see `IOPProver::prove` /

--- a/crates/prover/tests/shift.rs
+++ b/crates/prover/tests/shift.rs
@@ -21,7 +21,7 @@ use binius_prover::{
 	protocols::shift::{OperatorData, build_key_collection, prove},
 };
 use binius_transcript::ProverTranscript;
-use binius_utils::checked_arithmetics::{log2_ceil_usize, strict_log_2};
+use binius_utils::checked_arithmetics::log2_ceil_usize;
 use binius_verifier::{
 	config::StdChallenger,
 	protocols::shift::{OperatorData as VerifierOperatorData, check_eval, verify},
@@ -137,6 +137,9 @@ pub fn create_slice_cs_with_witness() -> (ConstraintSystem, ValueVec) {
 }
 
 // Compute the image of the witness applied to the AND constraints
+//
+// Each image is zero-padded to a power-of-two length, matching the operand columns the prover
+// materializes.
 pub fn compute_bitand_images(constraints: &[AndConstraint], witness: &ValueVec) -> [Vec<Word>; 3] {
 	let (a_image, b_image, c_image) = constraints
 		.iter()
@@ -146,11 +149,20 @@ pub fn compute_bitand_images(constraints: &[AndConstraint], witness: &ValueVec) 
 			let c = witness.eval_operand(constraint.c());
 			(a, b, c)
 		})
-		.multiunzip();
-	[a_image, b_image, c_image]
+		.multiunzip::<(Vec<_>, Vec<_>, Vec<_>)>();
+	[a_image, b_image, c_image].map(|image| pad_image(image, constraints.len()))
+}
+
+// Zero-pad a per-constraint image up to the power-of-two row count the reductions run over.
+fn pad_image(mut image: Vec<Word>, n_constraints: usize) -> Vec<Word> {
+	image.resize(n_constraints.next_power_of_two(), Word::ZERO);
+	image
 }
 
 // Compute the image of the witness applied to the IMUL constraints
+//
+// Each image is zero-padded to a power-of-two length, matching the operand columns the prover
+// materializes.
 fn compute_intmul_images(constraints: &[ImulConstraint], witness: &ValueVec) -> [Vec<Word>; 4] {
 	let (a_image, b_image, lo_image, hi_image) = constraints
 		.iter()
@@ -161,8 +173,8 @@ fn compute_intmul_images(constraints: &[ImulConstraint], witness: &ValueVec) -> 
 			let hi = witness.eval_operand(constraint.hi());
 			(a, b, lo, hi)
 		})
-		.multiunzip();
-	[a_image, b_image, lo_image, hi_image]
+		.multiunzip::<(Vec<_>, Vec<_>, Vec<_>, Vec<_>)>();
+	[a_image, b_image, lo_image, hi_image].map(|image| pad_image(image, constraints.len()))
 }
 
 // Evaluate the image of the witness applied to the AND or IMUL constraints
@@ -220,7 +232,9 @@ fn test_shift_prove_and_verify() {
 
 		// Sample multilinear challenge point
 		let r_x_prime_bitand = {
-			let log_bitand_constraint_count = strict_log_2(cs.and_constraints.len()).unwrap();
+			// The BitAnd reduction always runs; an empty AND set reduces over its single all-zero
+			// padding row, i.e. an empty point.
+			let log_bitand_constraint_count = cs.log_and_constraints().unwrap_or(0);
 			(0..log_bitand_constraint_count as u128)
 				.map(F::new)
 				.collect::<Vec<_>>()
@@ -230,13 +244,13 @@ fn test_shift_prove_and_verify() {
 		// — mirroring the prover/verifier skip of the IntMul reduction in `binius_prover` /
 		// `binius_verifier`.
 		let intmul_is_empty = cs.imul_constraints.is_empty();
-		let r_x_prime_intmul = if intmul_is_empty {
-			Vec::new()
-		} else {
-			let log_intmul_constraint_count = strict_log_2(cs.imul_constraints.len()).unwrap();
+		let r_x_prime_intmul = if let Some(log_intmul_constraint_count) = cs.log_imul_constraints()
+		{
 			(0..log_intmul_constraint_count as u128)
 				.map(F::new)
 				.collect::<Vec<_>>()
+		} else {
+			Vec::new()
 		};
 
 		// Sample univariate eval point — the bitand and intmul operators share

--- a/crates/prover/tests/shift.rs
+++ b/crates/prover/tests/shift.rs
@@ -215,13 +215,13 @@ fn test_shift_prove_and_verify() {
 	type P = PackedBinaryGhash2x128b;
 	let mut rng = StdRng::seed_from_u64(0);
 
-	let mut constraint_systems_to_test = vec![
+	let constraint_systems_to_test = vec![
 		create_sha256_cs_with_witness(),
 		create_slice_cs_with_witness(),
 		create_concat_cs_with_witness(),
 	];
-	for (constraint_system, _) in constraint_systems_to_test.iter_mut() {
-		constraint_system.validate_and_prepare().unwrap();
+	for (constraint_system, _) in constraint_systems_to_test.iter() {
+		constraint_system.validate().unwrap();
 	}
 
 	for (cs, value_vec) in constraint_systems_to_test.into_iter() {

--- a/crates/verifier/src/protocols/intmul/verify.rs
+++ b/crates/verifier/src/protocols/intmul/verify.rs
@@ -466,8 +466,10 @@ where
 ///
 /// ### Parameters
 ///
-/// - `n_vars`: Number of variables in the row dimension (i.e., $\log_2$ of the number of
-///   multiplication constraints).
+/// - `n_vars`: Number of variables in the row dimension — the $\log_2$ of the operand column
+///   length, which the prover zero-pads up to a power of two. The single-instance verifier passes
+///   $\lceil \log_2 n \rceil$ for $n$ IMUL constraints; the batched M4 verifier adds its $\log_2$
+///   instance count.
 ///
 /// The integer operands are fixed at the `Word::BITS` bit width.
 pub fn verify<F, C>(n_vars: usize, channel: &mut C) -> Result<IntMulOutput<C::Elem>, Error>

--- a/crates/verifier/src/protocols/shift/monster.rs
+++ b/crates/verifier/src/protocols/shift/monster.rs
@@ -1,4 +1,5 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 
 use std::iter;
 
@@ -10,7 +11,7 @@ use binius_field::{
 use binius_math::{
 	inner_product::inner_product_scalars, multilinear::eq::eq_ind_partial_eval_scalars,
 };
-use binius_utils::rayon::prelude::*;
+use binius_utils::{checked_arithmetics::log2_ceil_usize, rayon::prelude::*};
 
 use super::{
 	SHIFT_VARIANT_COUNT,
@@ -120,14 +121,14 @@ impl<'a, C, const ARITY: usize> OperationEvalFn<'a, C, ARITY> {
 
 	/// Splits the flat [`FieldFn`] input into `(r_x_prime, lambda, shift_scalars, r_y_tensor)`.
 	///
-	/// The `r_x'` section has `log2(constraints.len())` entries — the constraint counts handed to
-	/// the shift reduction are powers of two — so the split needs no state beyond the constraints.
+	/// The `r_x'` section has `ceil(log2(constraints.len()))` entries — the reductions run over the
+	/// constraint count rounded up to a power of two — so the split needs no state beyond the
+	/// constraints.
 	fn split_input<'i, E>(
 		&self,
 		input: &'i [E],
 	) -> (&'i [E], &'i E, &'i [E; SHIFT_VARIANT_COUNT * Word::BITS], &'i [E]) {
-		debug_assert!(self.constraints.len().is_power_of_two());
-		let n_vars = self.constraints.len().ilog2() as usize;
+		let n_vars = log2_ceil_usize(self.constraints.len());
 		let (r_x_prime, rest) = input.split_at(n_vars);
 		let (lambda, rest) = rest.split_first().expect("input encodes lambda");
 		let (shift_scalars, r_y_tensor) = rest.split_at(SHIFT_VARIANT_COUNT * Word::BITS);
@@ -152,11 +153,13 @@ where
 
 		// Accumulate one contribution per constraint. Within a constraint, each shifted-value term
 		// over all operands is weighted by its operand shift scalar and the word-index tensor
-		// entry; the running sum is then scaled by the constraint-index tensor entry.
+		// entry; the running sum is then scaled by the constraint-index tensor entry. The tensor
+		// covers the padded constraint count, so the zip stops at the last real constraint; the
+		// padding rows have no operand terms and contribute nothing.
 		let mut eval = E::zero();
-		for (constraint, r_x_prime_entry) in r_x_prime_tensor.iter().enumerate() {
+		for (constraint, r_x_prime_entry) in iter::zip(self.constraints, &r_x_prime_tensor) {
 			let mut constraint_eval = E::zero();
-			for (operand_id, operand) in self.constraints[constraint].as_ref().iter().enumerate() {
+			for (operand_id, operand) in constraint.as_ref().iter().enumerate() {
 				for svi in operand {
 					let variant = svi.shift_variant as usize;
 					let index = (variant * Word::BITS + svi.amount as usize) * ARITY + operand_id;
@@ -185,15 +188,16 @@ where
 
 		// One unreduced wide product per constraint. The constraints partition cleanly across
 		// rayon: each produces a single wide element and they are summed, so there is no large
-		// per-task accumulator. The single final reduction is `F`-linear.
-		let eval = r_x_prime_tensor
+		// per-task accumulator. The single final reduction is `F`-linear. The tensor covers the
+		// padded constraint count, so the zip stops at the last real constraint; the padding rows
+		// have no operand terms and contribute nothing.
+		let eval = self
+			.constraints
 			.par_iter()
-			.enumerate()
+			.zip(r_x_prime_tensor.par_iter())
 			.map(|(constraint, &r_x_prime_entry)| {
 				let mut constraint_eval = F::ZERO;
-				for (operand_id, operand) in
-					self.constraints[constraint].as_ref().iter().enumerate()
-				{
+				for (operand_id, operand) in constraint.as_ref().iter().enumerate() {
 					for svi in operand {
 						let variant = svi.shift_variant as usize;
 						let index =
@@ -250,6 +254,10 @@ fn operand_shift_scalar_table<E: FieldOps>(
 
 #[cfg(test)]
 mod tests {
+	use binius_core::{
+		ShiftVariant,
+		constraint_system::{AndConstraint, ShiftedValueIndex, ValueIndex},
+	};
 	use binius_field::{BinaryField128bGhash, Field, Random};
 	use binius_math::{
 		BinarySubspace,
@@ -260,18 +268,13 @@ mod tests {
 
 	use super::*;
 
-	/// The native `WideMul` variant must produce exactly the same result as the generic
-	/// evaluation (deferred reduction is `F`-linear).
-	#[test]
-	fn evaluate_monster_native_matches_generic() {
-		use binius_core::{
-			ShiftVariant,
-			constraint_system::{AndConstraint, ShiftedValueIndex, ValueIndex},
-		};
-
-		type F = BinaryField128bGhash;
-		let mut rng = StdRng::seed_from_u64(3);
-
+	/// Builds `n_constraints` random arity-3 constraints (like `AndConstraint`), constraint-major:
+	/// one array of operands per constraint.
+	fn random_and_constraints(
+		rng: &mut StdRng,
+		n_constraints: usize,
+		n_words: usize,
+	) -> Vec<AndConstraint> {
 		let shift_variants = [
 			ShiftVariant::Sll,
 			ShiftVariant::Slr,
@@ -282,13 +285,7 @@ mod tests {
 			ShiftVariant::Sra32,
 			ShiftVariant::Rotr32,
 		];
-		let n_words = 40usize;
-		let log_constraints = 6usize;
-		let n_constraints = 1usize << log_constraints;
-
-		// Arity-3 constraints (like `AndConstraint`), constraint-major: one array of operands per
-		// constraint.
-		let constraints: Vec<AndConstraint> = (0..n_constraints)
+		(0..n_constraints)
 			.map(|_| {
 				AndConstraint(std::array::from_fn(|_| {
 					(0..rng.random_range(0..=3))
@@ -300,19 +297,73 @@ mod tests {
 						.collect()
 				}))
 			})
-			.collect();
+			.collect()
+	}
 
-		let r_x_prime = random_scalars::<F>(&mut rng, log_constraints);
+	/// The native `WideMul` variant must produce exactly the same result as the generic
+	/// evaluation (deferred reduction is `F`-linear). Covers a power-of-two constraint count and a
+	/// non-power-of-two one, whose `r_x'` tensor runs past the last constraint.
+	#[test]
+	fn evaluate_monster_native_matches_generic() {
+		type F = BinaryField128bGhash;
+		let mut rng = StdRng::seed_from_u64(3);
+
+		let n_words = 40usize;
+		for n_constraints in [64usize, 37] {
+			let constraints = random_and_constraints(&mut rng, n_constraints, n_words);
+
+			let r_x_prime = random_scalars::<F>(&mut rng, log2_ceil_usize(n_constraints));
+			let lambda = F::random(&mut rng);
+			let shift_scalars: [F; SHIFT_VARIANT_COUNT * Word::BITS] =
+				std::array::from_fn(|_| F::random(&mut rng));
+			let r_y_tensor = random_scalars::<F>(&mut rng, n_words);
+
+			let eval_fn = OperationEvalFn::new(&constraints);
+			let input = encode_operation_input(&r_x_prime, lambda, &shift_scalars, &r_y_tensor);
+			let generic = eval_fn.call::<F>(&input);
+			let native = eval_fn.call_native(&input);
+			assert_eq!(generic, native, "n_constraints = {n_constraints}");
+		}
+	}
+
+	/// Appending all-zero padding constraints must not change the evaluation: a padding constraint
+	/// has no operand terms, so it contributes nothing. This is what lets the constraint system
+	/// keep its true count while the reductions run over the padded one.
+	///
+	/// [`FieldFn::call`] and [`FieldFn::call_native`] walk the constraints over independent zips,
+	/// so both are checked.
+	#[test]
+	fn evaluate_monster_ignores_zero_padding_constraints() {
+		type F = BinaryField128bGhash;
+		let mut rng = StdRng::seed_from_u64(5);
+
+		let n_words = 40usize;
+		let n_constraints = 21usize;
+		let constraints = random_and_constraints(&mut rng, n_constraints, n_words);
+		let padded = constraints
+			.iter()
+			.cloned()
+			.chain(iter::repeat_n(
+				AndConstraint::default(),
+				n_constraints.next_power_of_two() - n_constraints,
+			))
+			.collect::<Vec<_>>();
+
+		let r_x_prime = random_scalars::<F>(&mut rng, log2_ceil_usize(n_constraints));
 		let lambda = F::random(&mut rng);
 		let shift_scalars: [F; SHIFT_VARIANT_COUNT * Word::BITS] =
 			std::array::from_fn(|_| F::random(&mut rng));
 		let r_y_tensor = random_scalars::<F>(&mut rng, n_words);
 
-		let eval_fn = OperationEvalFn::new(&constraints);
 		let input = encode_operation_input(&r_x_prime, lambda, &shift_scalars, &r_y_tensor);
-		let generic = eval_fn.call::<F>(&input);
-		let native = eval_fn.call_native(&input);
-		assert_eq!(generic, native);
+		assert_eq!(
+			OperationEvalFn::new(&constraints).call::<F>(&input),
+			OperationEvalFn::new(&padded).call::<F>(&input)
+		);
+		assert_eq!(
+			OperationEvalFn::new(&constraints).call_native(&input),
+			OperationEvalFn::new(&padded).call_native(&input)
+		);
 	}
 
 	#[test]

--- a/crates/verifier/src/protocols/shift/verify.rs
+++ b/crates/verifier/src/protocols/shift/verify.rs
@@ -407,6 +407,25 @@ impl<F: BinaryField> MonsterEvalFn<'_, F> {
 	where
 		E: FieldOps<Scalar = F> + From<F>,
 	{
+		// Each operation's `r_x'` section is as long as its reduction has constraint variables, and
+		// [`OperationEvalFn::split_input`] re-derives that length from the constraint count alone.
+		// The two derivations must agree or both sides mis-split the same input. An absent IntMul
+		// (resp. BinMul) reduction contributes an empty point, which matches the `None` the
+		// accessor reports for an empty constraint set; so does the BitAnd reduction's single
+		// all-zero padding row.
+		debug_assert_eq!(
+			self.bitand_r_x_prime_len,
+			self.constraint_system.log_and_constraints().unwrap_or(0)
+		);
+		debug_assert_eq!(
+			self.intmul_r_x_prime_len,
+			self.constraint_system.log_imul_constraints().unwrap_or(0)
+		);
+		debug_assert_eq!(
+			self.binmul_r_x_prime_len,
+			self.constraint_system.log_bmul_constraints().unwrap_or(0)
+		);
+
 		// Split the flat input back into its sections, in the order they were concatenated.
 		let r_zhat_prime_v = vals[0].clone();
 		let bitand_lambda_v = vals[1].clone();

--- a/crates/verifier/src/verify.rs
+++ b/crates/verifier/src/verify.rs
@@ -17,7 +17,7 @@ use binius_math::{
 	BinarySubspace, inner_product::inner_product_scalars, univariate::lagrange_evals_scalars,
 };
 use binius_transcript::{VerifierTranscript, fiat_shamir::Challenger};
-use binius_utils::{DeserializeBytes, checked_arithmetics::checked_log_2};
+use binius_utils::DeserializeBytes;
 use digest::Output;
 use itertools::chain;
 
@@ -156,21 +156,21 @@ impl IOPVerifier {
 		//
 		// Skipped (no transcript reads) when the constraint system has no IMUL constraints,
 		// mirroring the prover's identical guard so the transcript stays in sync.
-		let intmul_output = if self.constraint_system.n_imul_constraints() > 0 {
-			let intmul_guard = tracing::info_span!(
-				"[phase] Verify IntMul Reduction",
-				phase = "verify_intmul_reduction",
-				perfetto_category = "phase",
-				n_constraints = self.constraint_system.n_imul_constraints()
-			)
-			.entered();
-			let log_n_constraints = checked_log_2(self.constraint_system.n_imul_constraints());
-			let intmul_output = verify_intmul_reduction::<B128, _>(log_n_constraints, channel)?;
-			drop(intmul_guard);
-			Some(intmul_output)
-		} else {
-			None
-		};
+		let intmul_output =
+			if let Some(log_n_constraints) = self.constraint_system.log_imul_constraints() {
+				let intmul_guard = tracing::info_span!(
+					"[phase] Verify IntMul Reduction",
+					phase = "verify_intmul_reduction",
+					perfetto_category = "phase",
+					n_constraints = self.constraint_system.n_imul_constraints()
+				)
+				.entered();
+				let intmul_output = verify_intmul_reduction::<B128, _>(log_n_constraints, channel)?;
+				drop(intmul_guard);
+				Some(intmul_output)
+			} else {
+				None
+			};
 
 		// [phase] Verify BinMul Reduction - GHASH-field multiplication constraint verification
 		//
@@ -178,21 +178,21 @@ impl IOPVerifier {
 		// sync with the prover. Skipped (no transcript reads) when there are no BMUL constraints,
 		// mirroring the prover's identical guard. The per-bit operand evaluations are collapsed
 		// below with the shared `r_zhat_prime` challenge that BitAnd draws.
-		let binmul_output = if self.constraint_system.n_bmul_constraints() > 0 {
-			let binmul_guard = tracing::info_span!(
-				"[phase] Verify BinMul Reduction",
-				phase = "verify_binmul_reduction",
-				perfetto_category = "phase",
-				n_constraints = self.constraint_system.n_bmul_constraints()
-			)
-			.entered();
-			let log_n_constraints = checked_log_2(self.constraint_system.n_bmul_constraints());
-			let binmul_output = verify_binmul_reduction::<B128, _>(log_n_constraints, channel)?;
-			drop(binmul_guard);
-			Some(binmul_output)
-		} else {
-			None
-		};
+		let binmul_output =
+			if let Some(log_n_constraints) = self.constraint_system.log_bmul_constraints() {
+				let binmul_guard = tracing::info_span!(
+					"[phase] Verify BinMul Reduction",
+					phase = "verify_binmul_reduction",
+					perfetto_category = "phase",
+					n_constraints = self.constraint_system.n_bmul_constraints()
+				)
+				.entered();
+				let binmul_output = verify_binmul_reduction::<B128, _>(log_n_constraints, channel)?;
+				drop(binmul_guard);
+				Some(binmul_output)
+			} else {
+				None
+			};
 
 		// [phase] Verify BitAnd Reduction - AND constraint verification
 		let bitand_guard = tracing::info_span!(
@@ -203,7 +203,9 @@ impl IOPVerifier {
 		)
 		.entered();
 		let (r_zhat_prime, bitand_claim) = {
-			let log_n_constraints = checked_log_2(self.constraint_system.n_and_constraints());
+			// The BitAnd reduction has no skip branch: an empty AND set still reduces, over the
+			// single all-zero padding row, so `None` is zero variables here.
+			let log_n_constraints = self.constraint_system.log_and_constraints().unwrap_or(0);
 			let AndCheckOutput {
 				a_eval,
 				b_eval,

--- a/crates/verifier/src/verify.rs
+++ b/crates/verifier/src/verify.rs
@@ -51,8 +51,7 @@ pub struct IOPVerifier {
 impl IOPVerifier {
 	/// Constructs an IOP verifier for a constraint system.
 	///
-	/// The constraint system must already be validated via
-	/// [`ConstraintSystem::validate_and_prepare`].
+	/// The constraint system must already be validated via [`ConstraintSystem::validate`].
 	pub const fn new(constraint_system: ConstraintSystem, log_public_words: usize) -> Self {
 		Self {
 			constraint_system,
@@ -373,11 +372,8 @@ where
 	/// Constructs a verifier for a constraint system.
 	///
 	/// See [`Verifier`] struct documentation for details.
-	pub fn setup(
-		mut constraint_system: ConstraintSystem,
-		log_inv_rate: usize,
-	) -> Result<Self, Error> {
-		constraint_system.validate_and_prepare()?;
+	pub fn setup(constraint_system: ConstraintSystem, log_inv_rate: usize) -> Result<Self, Error> {
+		constraint_system.validate()?;
 
 		// The validated layout guarantees a power-of-two public segment of at least one full
 		// element.

--- a/crates/verifier/src/verify.rs
+++ b/crates/verifier/src/verify.rs
@@ -482,7 +482,10 @@ where
 ///
 /// # Arguments
 ///
-/// - `log_constraint_count`: base-2 logarithm of the row count.
+/// - `log_constraint_count`: base-2 logarithm of the row count — the operand column length, which
+///   the prover zero-pads up to a power of two. The single-instance verifier passes `ceil(log2(n))`
+///   for `n` AND constraints; the batched M4 verifier adds its log instance count, since one row
+///   there is an (instance, constraint) pair.
 /// - `eval_domain`: the univariate-skip domain, one dimension above the 64-bit word, already lifted
 ///   to `F`. The caller passes it so it matches the shift reduction's domain by construction.
 /// - `channel`: the verifier channel that reads messages and redraws Fiat-Shamir challenges.

--- a/crates/verifier/src/zk_config.rs
+++ b/crates/verifier/src/zk_config.rs
@@ -63,13 +63,10 @@ where
 	Output<H::LeafHash>: DeserializeBytes,
 {
 	/// Constructs a ZK verifier for a constraint system.
-	pub fn setup(
-		mut constraint_system: ConstraintSystem,
-		log_inv_rate: usize,
-	) -> Result<Self, Error> {
+	pub fn setup(constraint_system: ConstraintSystem, log_inv_rate: usize) -> Result<Self, Error> {
 		let _setup_guard = tracing::debug_span!("Setup ZK verifier").entered();
 
-		constraint_system.validate_and_prepare()?;
+		constraint_system.validate()?;
 
 		// The validated layout guarantees a power-of-two public segment of at least one full
 		// element.


### PR DESCRIPTION
Closes [BINIUS-364](https://linear.app/jimpo/issue/BINIUS-364/dont-require-power-of-two-of-constraints).

The constraint system padded its AND, IMUL, and BMUL constraint vectors up to the next power of two in `validate_and_prepare`, so every consumer saw a power-of-two count and the true count was lost. This retains the true counts and moves the rounding to the two places that actually need it.

Rebased onto current `main`, which now includes #1901 (BINIUS-340). That landed first and needs nothing from this: its padding-window skipping detects all-zero windows from the column data, and the columns this produces are byte-for-byte what the padded constraint vectors produced before. The true count is simply available now for whatever wants it.

## Commits

1. **`don't require a power-of-two number of constraints`** — the substance.
2. **`retire validate_and_prepare in favour of validate`** — with the padding gone, that method was a `&mut self` wrapper whose whole body was `self.validate()`.
3. **`name and document row counts as row counts`** — naming and comments only, no behavioral change.

## Design

The prover's operand-column builders (`build_operation_columns`, in both the single-instance and M4 provers) round the constraint axis up to a power of two and zero-fill the tail. Zero is the correct padding value: an empty operand evaluates to `Word::ZERO`, and `0 & 0 ^ 0 = 0` and `0 * 0 = 0 || 0` hold, so padded rows satisfy every constraint type.

Three new accessors on `ConstraintSystem` — `log_and_constraints`, `log_imul_constraints`, `log_bmul_constraints` — give the sumcheck variable count as `log2_ceil(n_constraints)`, and both verifier stacks derive their counts from them. `log2_ceil(0) = 0` keeps the empty-AND case at a single row with no special case.

The shift reduction's monster evaluation previously iterated its `r_x'` tensor and indexed the constraints by that position. The tensor is now the longer of the two, so `call` and `call_native` zip the constraints against it instead. The extra tensor entries correspond to padding and contribute zero, so skipping them is an identity — and it is the truncation direction that is safe: `split_at` panics rather than short-slicing, so the tensor is provably never shorter than the constraint slice.

## The proof is unchanged

For any circuit this produces a **byte-identical** proof. Padding constraints were `Default`, whose operands are empty, so the operand columns already carried zero tail rows and the key collection never saw them.

Verified by proving each of the following both ways — once from the constraint system as-is, once from one whose vectors were manually resized exactly as the deleted padding block did — and comparing finalized transcript bytes:

| Stack | True counts | Old padded | Result |
|---|---|---|---|
| prover/verifier, mixed AND+IMUL+BMUL | 6/3/3 | 8/4/4 | byte-identical, both verify |
| prover/verifier, SHA-256 preimage | 918/0/0 | 1024/0/0 | byte-identical, both verify |
| m4-prover/m4-verifier, mixed, K=8 | 6/3/3 | 8/4/4 | byte-identical, both verify |

The M4 row matters independently: `m4_prover::operand_witness` is a separate padding implementation (`ptr::write_bytes` over a `MaybeUninit` tail rather than `fill`), so the single-instance results would not have covered it.

This is strong evidence rather than exhaustive coverage — three configurations plus the argument above, not a proof over all circuit shapes. A property test over randomized constraint counts would be the natural way to broaden it.

## Serialization

`SERIALIZATION_VERSION` stays at **6**. The wire format is byte-for-byte unchanged (three `Vec`s, same order). An existing serialized system with padded constraints still deserializes, still validates — padding constraints have empty operands — and yields the same proof, since a padded count is its own power of two so every `log2_ceil` derivation agrees. `test_deserialize_from_reference_binary_file` passes against the existing v6 fixture.

## Tests

`test_prove_verify_non_power_of_two_constraint_counts` is the point of the change: a circuit with 6 AND / 3 IMUL / 3 BMUL constraints — asserted non-power-of-two in the test itself, so it cannot silently rot into a power-of-two circuit — run through both `prove_verify` and `prove_verify_zk`.

Also added: `test_validate_keeps_true_constraint_counts` and `test_log_constraint_counts_round_up` (including the `n == 0` edge) in `binius-core`; `evaluate_monster_ignores_zero_padding_constraints` and a non-power-of-two case (n=37) in the existing `call`/`call_native` consistency test; and `build_zero_pads_a_non_power_of_two_constraint_count` in `m4-prover`, replacing a `#[should_panic("Not a power of two")]` test whose invariant no longer exists.

Three `debug_assert_eq!`s in `shift::verify::operation_inputs` tie each caller's `r_x'` length to the corresponding accessor. Debug assertions are on under `cargo test`, so these execute across the suite — including all six M4 `protocol_round_trips*` tests — rather than only compiling.

Workspace totals are **1338 passed / 0 failed / 16 ignored**. This branch contributes +4 (5 added, 1 removed — `build_rejects_non_power_of_two_constraint_count`, whose invariant no longer exists); the other +9 comes from the eleven commits that landed on `main` underneath.

One visible side effect worth calling out: the tracing spans reporting constraint counts now report the **true** count rather than the padded one, so a Keccak circuit logs 38400 AND constraints where it previously logged 65536. More accurate, but it will move dashboard numbers.

## Not in scope

- **Optimizing any subprotocol** with the now-available true count. None is changed here.
- **End-to-end coverage of `n_and == 0`.** That path is newly reachable, since the constraint vector is no longer padded up to one dummy constraint. Both sides still agree on zero variables and the reduction runs over a single all-zero row — bit-identical to the previous padded-to-one behaviour — but it's verified by analysis rather than by a test. `test_prove_verify_non_power_of_two_constraint_counts` asserts a non-zero count. Worth its own ticket.
- **Value-vector shape rules.** `validate_shape`'s `PublicInputPowerOfTwo` check and the hidden-segment padding are a separate, still-required invariant.
- **`ConstraintSystem::log_and_constraints()` and its callers' local names.** Commit 3 renames the AND reduction's parameter to `log_row_count`, but constraint-framed locals that feed it survive at `verifier/src/verify.rs:211`, `prover/tests/shift.rs:235`, and `prover/benches/shift_reduction.rs:98`. They mirror the public accessor, which is the actual root of the naming; its doc is accurate, so nothing misleads, but the accessor is unevenly named. Renaming a public `binius-core` accessor is a real API change and didn't belong in a comments-only commit — worth its own ticket if we want the class closed at the root.
