### PR TITLE
BINIUS-365: Replace encode_batch's raw-pointer replication with safe doubling

### DIFF
--- a/crates/math/src/reed_solomon.rs
+++ b/crates/math/src/reed_solomon.rs
@@ -5,10 +5,7 @@
 //!
 //! See [`ReedSolomonCode`] for details.
 
-use std::ptr;
-
 use binius_field::{BinaryField, PackedField};
-use binius_utils::rayon::prelude::*;
 use getset::{CopyGetters, Getters};
 
 use super::{
@@ -161,7 +158,8 @@ impl<F: BinaryField> ReedSolomonCode<F> {
 			let elem_0 = P::from_scalars(scalars.into_iter().cycle());
 			vec![elem_0; 1 << log_output_len.saturating_sub(P::LOG_WIDTH)]
 		} else {
-			let mut output_data = Vec::with_capacity(1 << (log_output_len - P::LOG_WIDTH));
+			let output_packed_len = 1 << (log_output_len - P::LOG_WIDTH);
+			let mut output_data = Vec::with_capacity(output_packed_len);
 
 			output_data.extend_from_slice(data.as_ref());
 
@@ -171,28 +169,19 @@ impl<F: BinaryField> ReedSolomonCode<F> {
 				output_data.as_mut_slice(),
 			));
 
-			let log_msg_len_packed = data.log_len() - P::LOG_WIDTH;
-			output_data
-				.spare_capacity_mut()
-				.par_chunks_exact_mut(1 << log_msg_len_packed)
-				.enumerate()
-				.for_each(|(i, output_chunk)| unsafe {
-					let dst_ptr = output_chunk.as_mut_ptr();
-
-					// TODO(https://github.com/rust-lang/rust/issues/81944):
-					// Improve unsafe code with Vec::split_at_spare_mut when stable
-
-					// Safety:
-					// - log_output_len == log_msg_len_packed + self.log_inv_rate
-					// - i + 1 is in the range 1..1 << self.log_inv_rate
-					// - dst_ptr is disjoint from src_ptr and within the Vec capacity
-					let src_ptr = dst_ptr.sub((i + 1) << log_msg_len_packed);
-					ptr::copy_nonoverlapping(src_ptr, dst_ptr, 1 << log_msg_len_packed);
-				});
-
-			unsafe {
-				// Safety: the vec's spare capacity is fully initialized above.
-				output_data.set_len(1 << (log_output_len - P::LOG_WIDTH));
+			// Fill the codeword buffer by repeatedly doubling the initialized prefix.
+			// Each pass appends one copy of everything written so far.
+			//
+			//     [msg] -> [msg|msg] -> [msg|msg|msg|msg] -> ...
+			//
+			// The forward transform below skips its first `log_inv_rate` layers.
+			// Each skipped layer would butterfly a coefficient with a zero pad:
+			//
+			//     u += v * twiddle; v += u;   with v = 0   =>   (c, 0) -> (c, c)
+			//
+			// That is one doubling per layer, so the doublings reproduce the skipped work.
+			while output_data.len() < output_packed_len {
+				output_data.extend_from_within(..);
 			}
 
 			output_data


### PR DESCRIPTION
Closes [BINIUS-365](https://linear.app/jimpo/issue/BINIUS-365).

Fixes a Stacked Borrows provenance violation in Reed–Solomon encoding by replacing the parallel raw-pointer message replication with safe in-place doubling.
Output is bit-identical — no protocol change, and the function no longer contains any `unsafe`.

### The problem

`encode_batch` fills the codeword buffer by copying the bit-reversed message into every replica slot through raw pointers.
Each task takes a pointer to its own spare-capacity chunk, then walks *backwards out of that chunk* to reach the source message.
A pointer derived from a slice borrow may only access that slice, so Miri rejects the read under Stacked Borrows:

```
error: Undefined Behavior: attempting a read access using <10486578> at alloc7140506[0x0],
       but that tag does not exist in the borrow stack for this location
  --> crates/math/src/reed_solomon.rs:190
help: <10486578> was created by a SharedReadWrite retag at offsets [0x100..0x200]
  --> reed_solomon.rs:180: let dst_ptr = output_chunk.as_mut_ptr();
```

The old safety comment argues the source and destination ranges are disjoint.
That is true and beside the point: the violated rule is pointer *provenance*, not overlap.
Tree Borrows accepts the code, so this is latent — today's codegen is correct — but the encode path of every commit should satisfy both candidate aliasing models.

### The idea

Every replica is a copy of the same prefix, so the buffer can be filled by doubling it in place:

```
[msg] -> [msg|msg] -> [msg|msg|msg|msg] -> ...
```

`Vec::extend_from_within` does exactly this with safe code.
Total copy traffic is unchanged (`output - message` words), and this also deletes the `set_len` on spare capacity.

### The change

```diff
-			let log_msg_len_packed = data.log_len() - P::LOG_WIDTH;
-			output_data
-				.spare_capacity_mut()
-				.par_chunks_exact_mut(1 << log_msg_len_packed)
-				.enumerate()
-				.for_each(|(i, output_chunk)| unsafe {
-					let dst_ptr = output_chunk.as_mut_ptr();
-					let src_ptr = dst_ptr.sub((i + 1) << log_msg_len_packed);
-					ptr::copy_nonoverlapping(src_ptr, dst_ptr, 1 << log_msg_len_packed);
-				});
-
-			unsafe {
-				output_data.set_len(1 << (log_output_len - P::LOG_WIDTH));
-			}
+			while output_data.len() < output_packed_len {
+				output_data.extend_from_within(..);
+			}
```

The `std::ptr` and rayon imports drop out of the file.

### What it is not

The replication loses its rayon parallelism.
This is deliberate: the copies are one pass over the buffer, while the NTT that follows makes one pass per layer (~20 at prover sizes), so parallel memcpy here is noise — confirmed by the benchmark below.

### Soundness

- The doubling produces the same buffer contents as the per-replica copies, so the codeword is bit-identical.
- The existing test pins `encode_batch` against a reference full-size NTT on zero-padded coefficients.

### Verification

- `cargo check --workspace --all-targets`, `cargo clippy -p binius-math --all-targets`, nightly `fmt` — clean.
- `cargo nextest run -p binius-math` — 127/127 pass.
- Miri on the encode tests: previously UB under Stacked Borrows, now passes under both Stacked Borrows and Tree Borrows.

### Benchmark

`encode_batch` end to end, multithreaded NTT (8 shares, rayon on), rate 1/2, Apple M1 Pro, 3 interleaved runs per side:

| codeword | before (parallel raw-pointer copy) | after (safe doubling) |
|---|---|---|
| 2^20 | 4.47–5.10 ms | 4.48–5.89 ms |
| 2^24 | 72.4–83.3 ms | 74.7–76.7 ms |

The ranges overlap on both sizes — no measurable cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)