### PR TITLE
BINIUS-366: Cap fold splitting with a minimum rayon chunk size

### DIFF
--- a/crates/math/src/multilinear/fold.rs
+++ b/crates/math/src/multilinear/fold.rs
@@ -8,6 +8,9 @@ use binius_utils::{random_access_sequence::RandomAccessSequence, rayon::prelude:
 
 use crate::{FieldBuffer, FieldVec, field_buffer::BufferData, line::extrapolate_line_packed};
 
+/// Minimum packed words a worker takes per fold chunk.
+const FOLD_MIN_CHUNK: usize = 1 << 14;
+
 /// Computes the partial evaluation of a multilinear on its highest variable, inplace.
 ///
 /// Each scalar of the result requires one multiplication to compute. Multilinear evaluations
@@ -26,6 +29,7 @@ pub fn fold_highest_var_inplace<P: PackedField, Data: BufferData<P>>(
 		let (mut lo, mut hi) = split.halves();
 		(lo.as_mut(), hi.as_mut())
 			.into_par_iter()
+			.with_min_len(FOLD_MIN_CHUNK)
 			.for_each(|(lo_i, hi_i)| {
 				*lo_i = extrapolate_line_packed(*lo_i, *hi_i, broadcast_scalar)
 			});
@@ -63,6 +67,7 @@ pub fn fold_highest_var<A: Allocator, P: PackedField, Data: Deref<Target = [P]>>
 	let spare = &mut data.spare_capacity_mut()[..len];
 	(spare, lo.as_ref(), hi.as_ref())
 		.into_par_iter()
+		.with_min_len(FOLD_MIN_CHUNK)
 		.for_each(|(out, &lo_i, &hi_i)| {
 			out.write(extrapolate_line_packed(lo_i, hi_i, broadcast_scalar));
 		});
@@ -136,6 +141,7 @@ mod tests {
 
 	use super::*;
 	use crate::{
+		line::extrapolate_line,
 		multilinear::{eq::eq_ind_partial_eval, evaluate::evaluate},
 		test_utils::{B128, Packed128b, random_field_buffer, random_scalars},
 	};
@@ -159,6 +165,33 @@ mod tests {
 		}
 
 		assert_eq!(multilinear.get(0), eval);
+	}
+
+	#[test]
+	fn test_fold_highest_var_inplace_above_split_threshold() {
+		let mut rng = StdRng::seed_from_u64(0);
+
+		// The parallel fold splits only when the half exceeds the minimum chunk size.
+		//
+		// Fixture state: n_vars = 18 -> half = 2^17 scalars = 2^15 packed words (width 4).
+		//
+		//     2^15 words / FOLD_MIN_CHUNK (2^14) = 2 minimum chunks -> a rayon build splits
+		//
+		// So this size pins the split path to the scalar reference; smaller tests run inline.
+		let n_vars = 18;
+		let half = 1 << (n_vars - 1);
+		let original = random_field_buffer::<P>(&mut rng, n_vars);
+		let challenge = random_scalars::<F>(&mut rng, 1)[0];
+
+		let mut folded = original.clone();
+		fold_highest_var_inplace(&mut folded, challenge);
+		assert_eq!(folded.log_len(), n_vars - 1);
+
+		// Scalar reference: each output interpolates one (lo, hi) pair at the challenge.
+		for i in 0..half {
+			let expected = extrapolate_line(original.get(i), original.get(i | half), challenge);
+			assert_eq!(folded.get(i), expected, "mismatch at index {i}");
+		}
 	}
 
 	#[test]


### PR DESCRIPTION
Closes [BINIUS-366](https://linear.app/jimpo/issue/BINIUS-366).

Makes multilinear folds profitable under rayon by giving the parallel loops a minimum chunk size.
Same arithmetic, same results — only the work-splitting policy changes.

### The problem

Every highest-variable fold runs its loop through `into_par_iter().for_each` with no minimum split length.
Waking the thread pool and joining costs 50–150 µs per call (M1 Pro, 10 threads), regardless of size.
One output word is one $\mathbb{F}_{2^{128}}$ multiply — a few ns — so small folds drown in overhead.

A fold chain halves the buffer each round, so most rounds of any chain sit below the crossover.
Net effect: a 20-round chain at 2^20 got **zero** parallel speedup (1.67 ms sequential vs 1.67 ms with rayon).

### The idea

```
.into_par_iter().with_min_len(FOLD_MIN_CHUNK)   // FOLD_MIN_CHUNK = 1 << 14 packed words
```

Rayon never splits below the minimum, and unsplit work runs inline on the calling thread.
So small folds return to exact sequential cost — no branch in our code.
Large folds improve too: the minimum stops rayon from over-splitting them into stolen crumbs.

### Per fold

One fold, width-1 packing, 10-thread pool:

| input scalars | sequential | rayon before | rayon after |
|---|---|---|---|
| 2^10 | 0.68 µs | 52 µs | 0.67 µs |
| 2^14 | 13.9 µs | 111 µs | 13.5 µs |
| 2^16 | 43 µs | 141 µs | 58 µs |
| 2^18 | 216 µs | 233 µs | 153 µs |
| 2^20 | 869 µs | 443 µs | 253 µs |
| 2^22 | 3.50 ms | 1.61 ms | 867 µs |

Below the crossover the overhead is gone; above it the fold is another ~1.75× faster than rayon-before (4.0× vs sequential at 2^22).
`1 << 14` beat `1 << 15` on both the gate bench (796 µs vs 848 µs) and large single folds (253 µs vs 394 µs at 2^20).

### The change

`crates/math/src/multilinear/fold.rs`: one documented constant, `with_min_len` on the two fold loops (in-place and out-of-place).
Same pattern and rationale as `LAYER_BUILD_MIN_CHUNK` in the fractional-addition prover.

### What it is not

- Not a sequential/parallel branch — rayon's own splitter handles both regimes.
- The sequential build is untouched: the shim's `with_min_len` is a no-op (verified: 1.69 ms vs 1.67 ms baseline).
- One narrow trade-off: folds of 2^16–2^17 input scalars now split into two chunks and run ~15–20 µs slower than pure sequential (58 µs vs 43 µs at 2^16) — still well below rayon-before's 141 µs.

### Verification

- `cargo check --workspace --all-targets`, `cargo clippy -p binius-math --all-targets`, nightly `fmt` — clean.
- `cargo nextest run -p binius-math` — 128/128; `--features rayon -E 'test(fold)'` — 4/4 under real rayon.
- New test folds at 2^18 scalars (above the split threshold, so a rayon build actually splits) and pins every output to the scalar `extrapolate_line` reference.

### Benchmark

`cargo bench -p binius-math --features rayon --bench multilinear_evaluate`, 2^20 variables, clean named criterion baseline, idle M1 Pro:

| bench | before | after | change |
|---|---|---|---|
| `evaluate_inplace` (20-fold chain) | 1.666 ms | 796 µs | −51% |
| `evaluate` (sqrt-memory) | 786 µs | 506 µs | −36% |

`evaluate` improves because its small fold tail was paying the pool-wake tax on every tiny round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
