### PR TITLE
BINIUS-368: Fuse the subspace Lagrange evaluation into one allocation

### DIFF
--- a/crates/math/src/univariate.rs
+++ b/crates/math/src/univariate.rs
@@ -1,6 +1,8 @@
 // Copyright 2024-2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
+use std::{iter, mem};
+
 use binius_field::{BinaryField, Field, field::FieldOps};
 use itertools::izip;
 
@@ -36,8 +38,8 @@ pub fn evaluate_univariate<F: FieldOps>(coeffs: &[F], x: F) -> F {
 /// 3. Replace inversions with multiplications for better performance
 ///
 /// # Complexity
-/// - Time: O(n) where n = subspace size, using 4n - 2 multiplications and 1 inversion
-/// - Space: O(n) for prefix/suffix arrays
+/// - Time: O(n) where n = subspace size, using about 4n multiplications and 1 inversion
+/// - Space: O(n) — the output vector is the only allocation
 ///
 /// # Parameters
 /// - `subspace`: The binary subspace defining the evaluation domain
@@ -65,31 +67,37 @@ pub fn lagrange_evals_scalars<F: BinaryField, E: FieldOps + From<F>>(
 	subspace: &BinarySubspace<F>,
 	z: E,
 ) -> Vec<E> {
-	let domain: Vec<E> = subspace.iter().map(E::from).collect();
-	let n = domain.len();
-
-	// Compute single barycentric weight for the additive subgroup
-	let w = domain[1..]
+	// The shared barycentric weight of an additive subgroup: w = 1 / prod_{j >= 1} d_j.
+	let w = subspace
 		.iter()
+		.skip(1)
+		.map(E::from)
 		.fold(E::one(), |acc, d| acc * d)
 		.invert_or_zero();
 
-	// Compute prefix products: prefix[i] = ∏_{j=0}^{i-1} (z - domain[j])
-	let mut prefixes = vec![E::one(); n];
-	for i in 1..n {
-		prefixes[i] = prefixes[i - 1].clone() * (z.clone() - domain[i - 1].clone());
+	// Seed the output with the linear terms t_i = z - d_i.
+	let mut result: Vec<E> = subspace.iter().map(|d| z.clone() - E::from(d)).collect();
+
+	// Backward sweep: replace t_i with w * prod_{j > i} t_j.
+	// Seeding the accumulator with the weight absorbs the multiply-by-w pass.
+	let mut suffix = w;
+	for r_i in result.iter_mut().rev() {
+		let t_i = mem::replace(r_i, suffix.clone());
+		suffix *= t_i;
 	}
 
-	// Compute suffix products: suffix[i] = ∏_{j=i+1}^{n-1} (z - domain[j])
-	let mut suffixes = vec![E::one(); n];
-	for i in (0..n - 1).rev() {
-		suffixes[i] = suffixes[i + 1].clone() * (z.clone() - domain[i + 1].clone());
+	// Forward sweep: multiply in prefix_i = prod_{j < i} t_j, completing
+	//
+	//     L_i(z) = w * prod_{j > i} t_j * prod_{j < i} t_j = w * prod_{j != i} (z - d_j).
+	//
+	// The terms are recomputed on the fly; iterating the subspace is a cheap XOR walk.
+	let mut prefix = E::one();
+	for (r_i, d) in iter::zip(&mut result, subspace.iter()) {
+		*r_i *= prefix.clone();
+		prefix *= z.clone() - E::from(d);
 	}
 
-	// Combine prefix, suffix, and weight: L_i(z) = prefix[i] * suffix[i] * w
-	izip!(prefixes, suffixes)
-		.map(|(p, s)| p * s * w.clone())
-		.collect()
+	result
 }
 
 /// Extrapolate a polynomial from its evaluations over a binary subspace to a point.


### PR DESCRIPTION
Closes [BINIUS-368](https://linear.app/jimpo/issue/BINIUS-368).

Fuses `lagrange_evals_scalars` — the engine under both subspace Lagrange entry points — from four allocations and ~5n multiplications into one allocation and ~4n.
Same identity, same results; 1.4–1.9× measured across verifier-realistic domain sizes.

### The problem

The routine computes the barycentric form

```
L_i(z) = w * prod_{j != i} (z - d_j)
```

where an additive subgroup admits a single shared weight `w`.
It materialized four vectors: the converted domain, prefix products, suffix products, and the combined output.
The combine step spent two multiplies per element, one of them a clone of `w`.
The same file already has the fused shape (`EvaluationDomain::lagrange_evals`); the subspace variant — 42 call sites across the workspace — never got it.

### The idea

One output vector, two sweeps:

```
result[i] = z - d_i                        // seed with the linear terms t_i
backward:  result[i] = w * prod_{j>i} t_j  // suffix sweep, accumulator seeded with w
forward:   result[i] *= prod_{j<i} t_j     // prefix sweep, terms recomputed on the fly
```

- Seeding the suffix accumulator with `w` absorbs the whole multiply-by-weight pass.
- Recomputing `t_i` in the forward sweep is free: iterating a binary subspace is an XOR walk.

### Per domain point

- **before:** 1 prefix mul + 1 suffix mul + 2 combine muls (plus a `w` clone), across 4 vectors
- **after:** 1 suffix mul + 2 forward muls, in place

→ ~20% fewer $\mathbb{F}_{2^{128}}$ multiplies and 3 fewer allocations; the measured win is larger because the dropped allocations, their zero-init, and the clones go with them.

### Soundness

- The computed value is the same barycentric formula, term for term.
- `invert_or_zero` boundary behavior and the dim-0 result (`[1]`) are unchanged.
- The existing suite pins it: the delta property `L_i(x_j)` at every domain point, partition of unity, interpolation accuracy against Horner evaluation, and a cross-check against the independent fold-based `extrapolate_over_subspace` for dims 0–6.

### Scope

- `crates/math/src/univariate.rs`, one function body (+27/−19); both entry points inherit it.
- `EvaluationDomain` and `extrapolate_over_subspace` untouched.

### Verification

- `cargo check --workspace --all-targets`, `cargo clippy -p binius-math --all-targets`, nightly `fmt` — clean.
- `cargo nextest run -p binius-math` — 128/128.

### Benchmark

Probe crates against the old and new code, two order-swapped runs each, idle M1 Pro:

| domain | old | new | speedup |
|---|---|---|---|
| dim 3 (n=8) | 354–555 ns | 315–320 ns | 1.1–1.8× |
| dim 5 (n=32) | 1.16–1.56 µs | 0.83–0.84 µs | 1.4–1.9× |
| dim 7 (n=128) | 4.66–5.40 µs | 2.80–2.97 µs | 1.6–1.9× |
| dim 8 (n=256) | 9.09–9.82 µs | 5.56–6.08 µs | 1.6× |

🤖 Generated with [Claude Code](https://claude.com/claude-code)