### PR TITLE
Activate the needless_pass_by_value clippy lint and clear the workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,6 +105,7 @@ needless_range_loop = "allow"
 missing_const_for_fn = "warn"
 needless_collect = "warn"
 redundant_clone = "warn"
+needless_pass_by_value = "warn"
 
 [workspace.metadata.typos]
 default.extend-words = { "typ" = "typ", "Toom" = "Toom", "inouts" = "inouts" }

--- a/crates/circuits/src/bignum/prime_field.rs
+++ b/crates/circuits/src/bignum/prime_field.rs
@@ -90,7 +90,7 @@ impl PseudoMersennePrimeField {
 	/// Equivalent formula: `(fe ** 2) % modulus`
 	pub fn square(&self, b: &CircuitBuilder, fe: &BigUint) -> BigUint {
 		assert!(fe.limbs.len() == self.limbs_len());
-		self.reduce_product(b, textbook_square(b, fe))
+		self.reduce_product(b, &textbook_square(b, fe))
 	}
 
 	/// Field multiplication.
@@ -99,10 +99,10 @@ impl PseudoMersennePrimeField {
 	/// Note: Both fe1 and fe2 may be greater or equal to modulus.
 	pub fn mul(&self, b: &CircuitBuilder, fe1: &BigUint, fe2: &BigUint) -> BigUint {
 		assert!(fe1.limbs.len() == self.limbs_len() && fe2.limbs.len() == self.limbs_len());
-		self.reduce_product(b, textbook_mul(b, fe1, fe2))
+		self.reduce_product(b, &textbook_mul(b, fe1, fe2))
 	}
 
-	fn reduce_product(&self, b: &CircuitBuilder, product: BigUint) -> BigUint {
+	fn reduce_product(&self, b: &CircuitBuilder, product: &BigUint) -> BigUint {
 		let (quotient, remainder) = BigUintDivideHint::call(b, &product.limbs, &self.modulus.limbs);
 
 		let zero = b.add_constant(Word::ZERO);
@@ -115,7 +115,7 @@ impl PseudoMersennePrimeField {
 		// constraint: product == remainder + quotient * modulus
 		PseudoMersenneModReduce::new(
 			b,
-			&product,
+			product,
 			self.modulus_po2,
 			&self.modulus_subtrahend,
 			&quotient,

--- a/crates/circuits/src/bitcoin/double_sha256.rs
+++ b/crates/circuits/src/bitcoin/double_sha256.rs
@@ -24,7 +24,7 @@ impl DoubleSha256 {
 	/// - `message.len() * 8 == message_len`
 	pub fn construct_circuit(
 		builder: &CircuitBuilder,
-		message: Vec<Wire>,
+		message: &[Wire],
 		digest: [Wire; 4],
 	) -> Self {
 		let mask32 = builder.add_constant(Word::MASK_32);
@@ -34,7 +34,7 @@ impl DoubleSha256 {
 		// 64-bit wire into its two schedule words (mirrors `sha256::sha256_varlen`'s input
 		// prologue).
 		let mut message_be: Vec<Wire> = Vec::with_capacity(message.len() * 2);
-		for &w in &message {
+		for &w in message {
 			let swapped = swap_bytes_32(builder, w);
 			message_be.push(builder.band(swapped, mask32));
 			message_be.push(builder.shr(swapped, 32));
@@ -83,8 +83,7 @@ mod tests {
 		let builder = CircuitBuilder::new();
 		let block_header: [Wire; 10] = array::from_fn(|_| builder.add_witness());
 		let block_hash: [Wire; 4] = array::from_fn(|_| builder.add_witness());
-		let double_sha_256 =
-			DoubleSha256::construct_circuit(&builder, block_header.to_vec(), block_hash);
+		let double_sha_256 = DoubleSha256::construct_circuit(&builder, &block_header, block_hash);
 		let circuit = builder.build();
 
 		// populate_witness
@@ -110,8 +109,7 @@ mod tests {
 		let builder = CircuitBuilder::new();
 		let block_header: [Wire; 10] = array::from_fn(|_| builder.add_witness());
 		let block_hash: [Wire; 4] = array::from_fn(|_| builder.add_witness());
-		let double_sha_256 =
-			DoubleSha256::construct_circuit(&builder, block_header.to_vec(), block_hash);
+		let double_sha_256 = DoubleSha256::construct_circuit(&builder, &block_header, block_hash);
 		let circuit = builder.build();
 
 		// populate_witness

--- a/crates/circuits/src/bitcoin/header_chain.rs
+++ b/crates/circuits/src/bitcoin/header_chain.rs
@@ -43,7 +43,7 @@ impl HeaderChain {
 			// hash equals `latest_digest`
 			header_digests.push(DoubleSha256::construct_circuit(
 				builder,
-				headers[0].to_vec(),
+				&headers[0],
 				latest_digest,
 			));
 
@@ -60,11 +60,7 @@ impl HeaderChain {
 		for i in 1..headers.len() {
 			// hash equals the "previous block hash" in the newer block
 			let digest = previous_block_hash(builder, &headers[i - 1]);
-			header_digests.push(DoubleSha256::construct_circuit(
-				builder,
-				headers[i].to_vec(),
-				digest,
-			));
+			header_digests.push(DoubleSha256::construct_circuit(builder, &headers[i], digest));
 
 			// hash is smaller than target (proof of work)
 			// NOTE: One could save constraints by noting that the target only changes every 2016

--- a/crates/circuits/src/bitcoin/merkle_path.rs
+++ b/crates/circuits/src/bitcoin/merkle_path.rs
@@ -45,7 +45,7 @@ impl MerklePath {
 				builder.select(sib.1, sib.0[2], leaf[2]),
 				builder.select(sib.1, sib.0[3], leaf[3]),
 			];
-			pairs.push((DoubleSha256::construct_circuit(builder, message, digest), digest));
+			pairs.push((DoubleSha256::construct_circuit(builder, &message, digest), digest));
 
 			let current_length = builder.add_constant_64(i as u64);
 			let past_length = builder.icmp_ult(current_length, length);

--- a/crates/circuits/src/hash_based_sig/xmss.rs
+++ b/crates/circuits/src/hash_based_sig/xmss.rs
@@ -291,7 +291,7 @@ mod tests {
 	}
 
 	impl TestCase {
-		fn run(&self, spec: WinternitzSpec) {
+		fn run(&self, spec: &WinternitzSpec) {
 			let mut rng = StdRng::seed_from_u64(42);
 
 			match self {
@@ -301,9 +301,9 @@ mod tests {
 				} => {
 					// Generate test data
 					let test_data =
-						XmssTestData::generate(&spec, *tree_size, *signing_epoch, &mut rng);
+						XmssTestData::generate(spec, *tree_size, *signing_epoch, &mut rng);
 
-					let result = test_data.run(&spec);
+					let result = test_data.run(spec);
 					result.unwrap_or_else(|e| {
 						panic!("Test expected to pass but failed: {}", e);
 					});
@@ -315,12 +315,12 @@ mod tests {
 				} => {
 					// Generate test data
 					let mut test_data =
-						XmssTestData::generate(&spec, *tree_size, *signing_epoch, &mut rng);
+						XmssTestData::generate(spec, *tree_size, *signing_epoch, &mut rng);
 
 					// Apply corruption
 					corrupt_fn(&mut test_data);
 
-					let result = test_data.run(&spec);
+					let result = test_data.run(spec);
 					assert!(result.is_err(), "Test expected to fail but passed");
 				}
 			}
@@ -391,7 +391,7 @@ mod tests {
 			tree_size,
 			signing_epoch,
 		}
-		.run(spec);
+		.run(&spec);
 	}
 
 	/// Invalid test cases with various corruption scenarios
@@ -408,6 +408,6 @@ mod tests {
 			signing_epoch: 1,
 			corrupt_fn,
 		}
-		.run(test_spec_small());
+		.run(&test_spec_small());
 	}
 }

--- a/crates/circuits/src/hash_based_sig/xmss_aggregate.rs
+++ b/crates/circuits/src/hash_based_sig/xmss_aggregate.rs
@@ -157,7 +157,7 @@ mod tests {
 	}
 
 	impl MultisigTestCase {
-		fn run(&self, spec: WinternitzSpec) {
+		fn run(&self, spec: &WinternitzSpec) {
 			let mut rng = StdRng::seed_from_u64(42);
 
 			match self {
@@ -170,10 +170,10 @@ mod tests {
 						*num_validators,
 						*tree_height,
 						*epoch,
-						&spec,
+						spec,
 						&mut rng,
 					);
-					test_data.run(&spec, *tree_height).unwrap();
+					test_data.run(spec, *tree_height).unwrap();
 				}
 				MultisigTestCase::Invalid {
 					num_validators,
@@ -185,11 +185,11 @@ mod tests {
 						*num_validators,
 						*tree_height,
 						*epoch,
-						&spec,
+						spec,
 						&mut rng,
 					);
 					corrupt_fn(&mut test_data);
-					let result = test_data.run(&spec, *tree_height);
+					let result = test_data.run(spec, *tree_height);
 					assert!(result.is_err(), "Test expected to fail but passed");
 				}
 			}
@@ -332,7 +332,7 @@ mod tests {
 			tree_height,
 			epoch,
 		}
-		.run(spec);
+		.run(&spec);
 	}
 
 	fn corrupt_one_validator_signature(test_data: &mut MultisigTestData) {
@@ -447,6 +447,6 @@ mod tests {
 			epoch: 2, // All validators sign at epoch 2
 			corrupt_fn,
 		}
-		.run(test_spec_small());
+		.run(&test_spec_small());
 	}
 }

--- a/crates/circuits/src/sha256/compress.rs
+++ b/crates/circuits/src/sha256/compress.rs
@@ -27,7 +27,7 @@ const K: [u32; 64] = [
 /// 4 x 64-bit words.
 ///
 /// The elements are referred to as a–h or H0–H7.
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct State(pub [Wire; 8]);
 
 impl State {
@@ -323,7 +323,7 @@ fn compress_inner(
 	}
 
 	let w: &[Wire; 64] = (&*w).try_into().unwrap();
-	let mut state = state_in.clone();
+	let mut state = state_in;
 	for t in 0..64 {
 		state = round(builder, k[t], w[t], state);
 	}

--- a/crates/circuits/src/sha256/mod.rs
+++ b/crates/circuits/src/sha256/mod.rs
@@ -302,7 +302,7 @@ pub fn sha256_varlen(builder: &CircuitBuilder, message: &ByteVec) -> [Wire; 4] {
 	while block_no + 1 < n_blocks {
 		let out = sha256_compress_2x_seq(
 			&builder.subcircuit(format!("compress[{block_no}..{}]", block_no + 2)),
-			states[block_no].clone(),
+			states[block_no],
 			[mk_m(block_no), mk_m(block_no + 1)],
 		);
 		// The mask restores the empty high half that the single-lane digest packing relies on.
@@ -316,7 +316,7 @@ pub fn sha256_varlen(builder: &CircuitBuilder, message: &ByteVec) -> [Wire; 4] {
 	if block_no < n_blocks {
 		let state_out = sha256_compress(
 			&builder.subcircuit(format!("compress[{block_no}]")),
-			states[block_no].clone(),
+			states[block_no],
 			mk_m(block_no),
 		);
 		states.push(state_out);

--- a/crates/circuits/src/sha512/compress.rs
+++ b/crates/circuits/src/sha512/compress.rs
@@ -101,7 +101,7 @@ const K: [u64; 80] = [
 /// The state size is 512 bits.
 ///
 /// The elements are referred to as a–h or H0–H7.
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct State(pub [Wire; 8]);
 
 impl State {
@@ -151,7 +151,7 @@ pub fn compress(builder: &CircuitBuilder, state_in: State, m: [Wire; 16]) -> Sta
 	}
 
 	let w: &[Wire; 80] = (&*w).try_into().unwrap();
-	let mut state = state_in.clone();
+	let mut state = state_in;
 	for t in 0..80 {
 		state = round(builder, t, state, w);
 	}

--- a/crates/circuits/src/sha512/mod.rs
+++ b/crates/circuits/src/sha512/mod.rs
@@ -255,11 +255,8 @@ pub fn sha512_varlen(builder: &CircuitBuilder, message: &ByteVec) -> [Wire; 8] {
 		let m: [Wire; 16] = padded_message[block_no << 4..(block_no + 1) << 4]
 			.try_into()
 			.unwrap();
-		let state_out = compress(
-			&builder.subcircuit(format!("compress[{block_no}]")),
-			states[block_no].clone(),
-			m,
-		);
+		let state_out =
+			compress(&builder.subcircuit(format!("compress[{block_no}]")), states[block_no], m);
 		states.push(state_out);
 	}
 

--- a/crates/circuits/src/slice.rs
+++ b/crates/circuits/src/slice.rs
@@ -197,7 +197,7 @@ mod tests {
 	/// Run a success-case test: pack `input_data` and `expected_slice_data` into the test setup,
 	/// run the circuit, and verify constraints.
 	fn run_slice_success(
-		setup: SliceTestSetup,
+		setup: &SliceTestSetup,
 		len_input_val: u64,
 		len_slice_val: u64,
 		offset_val: u64,
@@ -219,7 +219,7 @@ mod tests {
 
 	/// Run a failure-case test: expect `populate_wire_witness` to error.
 	fn run_slice_failure(
-		setup: SliceTestSetup,
+		setup: &SliceTestSetup,
 		len_input_val: u64,
 		len_slice_val: u64,
 		offset_val: u64,
@@ -245,7 +245,7 @@ mod tests {
 			0x0e, 0x0f,
 		];
 		let slice_data = [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07];
-		run_slice_success(setup, 16, 8, 0, &input_data, &slice_data);
+		run_slice_success(&setup, 16, 8, 0, &input_data, &slice_data);
 	}
 
 	#[test]
@@ -257,7 +257,7 @@ mod tests {
 			0x0e, 0x0f,
 		];
 		let slice_data = [0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a];
-		run_slice_success(setup, 16, 8, 3, &input_data, &slice_data);
+		run_slice_success(&setup, 16, 8, 3, &input_data, &slice_data);
 	}
 
 	#[test]
@@ -266,7 +266,7 @@ mod tests {
 		let setup = build_slice_check(2, 1);
 		let dummy_input = vec![0u8; 10];
 		let dummy_slice = vec![0u8; 8];
-		run_slice_failure(setup, 10, 8, 5, &dummy_input, &dummy_slice);
+		run_slice_failure(&setup, 10, 8, 5, &dummy_input, &dummy_slice);
 	}
 
 	#[test]
@@ -275,7 +275,7 @@ mod tests {
 		let setup = build_slice_check(2, 1);
 		let input_data = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
 		let slice_data = vec![5, 6, 7, 8, 9];
-		run_slice_success(setup, 10, 5, 5, &input_data, &slice_data);
+		run_slice_success(&setup, 10, 5, 5, &input_data, &slice_data);
 	}
 
 	#[test]
@@ -283,7 +283,7 @@ mod tests {
 		// len_slice = 0 — output is all zeros.
 		let setup = build_slice_check(2, 1);
 		let input_data = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
-		run_slice_success(setup, 10, 0, 5, &input_data, &[]);
+		run_slice_success(&setup, 10, 0, 5, &input_data, &[]);
 	}
 
 	#[test]
@@ -294,7 +294,7 @@ mod tests {
 		let input_data = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
 		// Actual extracted slice at offset 2 with len 5 is [2,3,4,5,6]; we claim [0,1,2,3,4].
 		let wrong_slice_data = vec![0, 1, 2, 3, 4];
-		run_slice_failure(setup, 10, 5, 2, &input_data, &wrong_slice_data);
+		run_slice_failure(&setup, 10, 5, 2, &input_data, &wrong_slice_data);
 	}
 
 	#[test]
@@ -302,7 +302,7 @@ mod tests {
 		// Empty slice at offset 10, where len_input = 10.
 		let setup = build_slice_check(2, 1);
 		let input_data = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
-		run_slice_success(setup, 10, 0, 10, &input_data, &[]);
+		run_slice_success(&setup, 10, 0, 10, &input_data, &[]);
 	}
 
 	#[test]
@@ -318,7 +318,7 @@ mod tests {
 				let setup = build_slice_check(3, 1);
 				let input_data: Vec<u8> = (0..24).map(|i| i as u8).collect();
 				let slice_data: Vec<u8> = input_data[offset_val..offset_val + 8].to_vec();
-				run_slice_success(setup, 24, 8, offset_val as u64, &input_data, &slice_data);
+				run_slice_success(&setup, 24, 8, offset_val as u64, &input_data, &slice_data);
 			}
 		}
 	}
@@ -338,7 +338,7 @@ mod tests {
 			0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, // word 0
 			0x08, 0x09, 0x0a, 0x0b, 0x00, 0x00, 0x00, 0x00, // word 1 padded to 16 bytes
 		];
-		run_slice_success(setup, 20, 12, 0, &input_data, &correct_slice);
+		run_slice_success(&setup, 20, 12, 0, &input_data, &correct_slice);
 	}
 
 	#[test]
@@ -416,14 +416,14 @@ mod tests {
 	fn test_edge_case_len_input_zero() {
 		// Empty input + empty slice at offset 0.
 		let setup = build_slice_check(2, 1);
-		run_slice_success(setup, 0, 0, 0, &[], &[]);
+		run_slice_success(&setup, 0, 0, 0, &[], &[]);
 	}
 
 	#[test]
 	fn test_edge_case_len_input_zero_with_nonzero_slice() {
 		// Empty input + non-empty slice → bounds check fails.
 		let setup = build_slice_check(2, 1);
-		run_slice_failure(setup, 0, 5, 0, &[], &[1, 2, 3, 4, 5]);
+		run_slice_failure(&setup, 0, 5, 0, &[], &[1, 2, 3, 4, 5]);
 	}
 
 	#[test]
@@ -433,7 +433,7 @@ mod tests {
 		let input_data = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
 		// Slice is 8 bytes, so word 1 is fully zero-padded.
 		let slice_data = vec![2, 3, 4, 5, 6, 7, 8, 9];
-		run_slice_success(setup, 12, 8, 2, &input_data, &slice_data);
+		run_slice_success(&setup, 12, 8, 2, &input_data, &slice_data);
 	}
 
 	#[test]

--- a/crates/core/src/constraint_system/system.rs
+++ b/crates/core/src/constraint_system/system.rs
@@ -878,7 +878,7 @@ mod tests {
 		let private = (0..cs.n_hidden_words())
 			.map(|i| Word::from_u64(0x5A5A_A5A5 ^ (i as u64 * 0x9E37_79B9)))
 			.collect::<Vec<_>>();
-		let values = ValueVec::new_from_data(public, private);
+		let values = ValueVec::new_from_data(&public, &private);
 
 		// Split into public and non-public witnesses and serialize all artifacts
 		let public_data = ValuesData::from(values.public());
@@ -901,7 +901,7 @@ mod tests {
 		assert_eq!(cs2.n_hidden_words(), non_pub2.len());
 
 		// Reconstruct ValueVec from deserialized pieces
-		let reconstructed = ValueVec::new_from_data(pub2.into_owned(), non_pub2.into_owned());
+		let reconstructed = ValueVec::new_from_data(&pub2, &non_pub2);
 
 		assert_eq!(reconstructed.combined_witness(), values.combined_witness());
 	}

--- a/crates/core/src/constraint_system/value_vec.rs
+++ b/crates/core/src/constraint_system/value_vec.rs
@@ -106,11 +106,11 @@ impl ValueVec {
 	/// Creates a value vector from the words of its public and hidden segments.
 	///
 	/// The vector has no scratch tail; scratch words only exist while a circuit is evaluated.
-	pub fn new_from_data(public: Vec<Word>, private: Vec<Word>) -> ValueVec {
+	pub fn new_from_data(public: &[Word], private: &[Word]) -> ValueVec {
 		// Fresh 16-byte-aligned buffer holding the public words followed by the hidden ones.
 		let mut data = AlignedWords::zeroed(public.len() + private.len());
-		data[..public.len()].copy_from_slice(&public);
-		data[public.len()..].copy_from_slice(&private);
+		data[..public.len()].copy_from_slice(public);
+		data[public.len()..].copy_from_slice(private);
 
 		ValueVec {
 			n_public_words: public.len(),
@@ -188,7 +188,7 @@ mod tests {
 
 		let public = values.public();
 		let non_public = values.non_public();
-		let combined = ValueVec::new_from_data(public.to_vec(), non_public.to_vec());
+		let combined = ValueVec::new_from_data(public, non_public);
 		assert_eq!(combined.combined_witness(), values.combined_witness());
 	}
 
@@ -273,7 +273,7 @@ mod tests {
 			// A vector built from the layout carries the scratch tail; one built from its
 			// segments holds only those words.
 			let zeroed = ValueVec::new(&layout);
-			let vv = ValueVec::new_from_data(public_padded.clone(), private.clone());
+			let vv = ValueVec::new_from_data(&public_padded, &private);
 
 			// Alignment survives construction for any word count.
 			assert_16_byte_aligned(vv.combined_witness());

--- a/crates/examples/benches/blake2b.rs
+++ b/crates/examples/benches/blake2b.rs
@@ -84,7 +84,7 @@ impl ExampleBenchmark for Blake2bBenchmark {
 
 fn bench_blake2b_hash(c: &mut Criterion) {
 	let benchmark = Blake2bBenchmark::new();
-	run_cs_benchmark(c, benchmark, "blake2b", &BLAKE2B_PEAK_ALLOC);
+	run_cs_benchmark(c, &benchmark, "blake2b", &BLAKE2B_PEAK_ALLOC);
 }
 
 criterion_group!(benches, bench_blake2b_hash);

--- a/crates/examples/benches/blake2s.rs
+++ b/crates/examples/benches/blake2s.rs
@@ -84,7 +84,7 @@ impl ExampleBenchmark for Blake2sBenchmark {
 
 fn bench_blake2s_hash(c: &mut Criterion) {
 	let benchmark = Blake2sBenchmark::new();
-	run_cs_benchmark(c, benchmark, "blake2s", &BLAKE2S_PEAK_ALLOC);
+	run_cs_benchmark(c, &benchmark, "blake2s", &BLAKE2S_PEAK_ALLOC);
 }
 
 criterion_group!(benches, bench_blake2s_hash);

--- a/crates/examples/benches/ethsign.rs
+++ b/crates/examples/benches/ethsign.rs
@@ -79,7 +79,7 @@ impl ExampleBenchmark for EthSignBenchmark {
 
 fn bench_ethsign_signatures(c: &mut Criterion) {
 	let benchmark = EthSignBenchmark::new();
-	run_cs_benchmark(c, benchmark, "ethsign", &ETHSIGN_PEAK_ALLOC);
+	run_cs_benchmark(c, &benchmark, "ethsign", &ETHSIGN_PEAK_ALLOC);
 }
 
 criterion_group!(ethsign, bench_ethsign_signatures);

--- a/crates/examples/benches/hashsign.rs
+++ b/crates/examples/benches/hashsign.rs
@@ -97,7 +97,7 @@ impl ExampleBenchmark for HashSignBenchmark {
 
 fn bench_hashsign(c: &mut Criterion) {
 	let benchmark = HashSignBenchmark::new();
-	run_cs_benchmark(c, benchmark, "hashsign", &HASHSIGN_PEAK_ALLOC);
+	run_cs_benchmark(c, &benchmark, "hashsign", &HASHSIGN_PEAK_ALLOC);
 }
 
 criterion_group!(hashsign, bench_hashsign);

--- a/crates/examples/benches/keccak.rs
+++ b/crates/examples/benches/keccak.rs
@@ -84,7 +84,7 @@ impl ExampleBenchmark for KeccakBenchmark {
 
 fn bench_keccak(c: &mut Criterion) {
 	let benchmark = KeccakBenchmark::new();
-	run_cs_benchmark(c, benchmark, "keccak", &KECCAK_PEAK_ALLOC);
+	run_cs_benchmark(c, &benchmark, "keccak", &KECCAK_PEAK_ALLOC);
 }
 
 criterion_group!(keccak, bench_keccak);

--- a/crates/examples/benches/sha256.rs
+++ b/crates/examples/benches/sha256.rs
@@ -84,7 +84,7 @@ impl ExampleBenchmark for Sha256Benchmark {
 
 fn bench_sha256_hash(c: &mut Criterion) {
 	let benchmark = Sha256Benchmark::new();
-	run_cs_benchmark(c, benchmark, "sha256", &SHA256_PEAK_ALLOC);
+	run_cs_benchmark(c, &benchmark, "sha256", &SHA256_PEAK_ALLOC);
 }
 
 criterion_group!(benches, bench_sha256_hash);

--- a/crates/examples/benches/sha512.rs
+++ b/crates/examples/benches/sha512.rs
@@ -84,7 +84,7 @@ impl ExampleBenchmark for Sha512Benchmark {
 
 fn bench_sha512_hash(c: &mut Criterion) {
 	let benchmark = Sha512Benchmark::new();
-	run_cs_benchmark(c, benchmark, "sha512", &SHA512_PEAK_ALLOC);
+	run_cs_benchmark(c, &benchmark, "sha512", &SHA512_PEAK_ALLOC);
 }
 
 criterion_group!(benches, bench_sha512_hash);

--- a/crates/examples/benches/utils/independent_hashes.rs
+++ b/crates/examples/benches/utils/independent_hashes.rs
@@ -130,7 +130,7 @@ pub fn run_independent_hash_benchmark<E>(
 	let benchmark = IndependentHashBenchmark::<E>::new(primitive);
 	run_cs_benchmark_with_extra_groups(
 		c,
-		benchmark,
+		&benchmark,
 		primitive.group_prefix(),
 		peak_alloc,
 		bench_witness_generation_and_proving,
@@ -160,7 +160,7 @@ fn bench_witness_generation_and_proving<B>(
 			ctx.circuit.populate_wire_witness(&mut filler).unwrap();
 			let witness = filler.into_value_vec();
 			let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
-			ctx.prover.prove(witness, &mut prover_transcript).unwrap();
+			ctx.prover.prove(&witness, &mut prover_transcript).unwrap();
 			prover_transcript
 		})
 	});

--- a/crates/examples/benches/utils/runner.rs
+++ b/crates/examples/benches/utils/runner.rs
@@ -69,11 +69,21 @@ pub struct ConstraintSystemBenchmarkContext<'a, B: ExampleBenchmark> {
 	pub prover: &'a Prover<OptimalPackedB128, StdHashSuite>,
 }
 
+// Every field is a shared reference, so the context is a cheap by-value view for any `B`.
+// (A derive would demand `B: Copy`, which the benchmark types don't and needn't satisfy.)
+impl<B: ExampleBenchmark> Clone for ConstraintSystemBenchmarkContext<'_, B> {
+	fn clone(&self) -> Self {
+		*self
+	}
+}
+
+impl<B: ExampleBenchmark> Copy for ConstraintSystemBenchmarkContext<'_, B> {}
+
 /// Run a complete benchmark suite for a constraint system
 #[allow(dead_code)]
 pub fn run_cs_benchmark<B: ExampleBenchmark>(
 	c: &mut Criterion,
-	benchmark: B,
+	benchmark: &B,
 	group_prefix: &str,
 	peak_alloc: &impl PeakMemAllocTrait,
 ) {
@@ -83,7 +93,7 @@ pub fn run_cs_benchmark<B: ExampleBenchmark>(
 /// Run a complete benchmark suite for a constraint system, with benchmark-specific extra groups.
 pub fn run_cs_benchmark_with_extra_groups<B, F>(
 	c: &mut Criterion,
-	benchmark: B,
+	benchmark: &B,
 	group_prefix: &str,
 	peak_alloc: &impl PeakMemAllocTrait,
 	extra_groups: F,
@@ -126,9 +136,7 @@ pub fn run_cs_benchmark_with_extra_groups<B, F>(
 	// Track memory for proof generation
 	peak_alloc.reset_peak_memory();
 	let mut prover_transcript_mem = ProverTranscript::new(StdChallenger::default());
-	prover
-		.prove(witness.clone(), &mut prover_transcript_mem)
-		.unwrap();
+	prover.prove(&witness, &mut prover_transcript_mem).unwrap();
 	let proof_bytes = prover_transcript_mem.finalize();
 	let proof_peak_bytes = peak_alloc.get_peak_memory();
 
@@ -176,9 +184,7 @@ pub fn run_cs_benchmark_with_extra_groups<B, F>(
 		group.bench_function(BenchmarkId::from_parameter(&bench_name), |b| {
 			b.iter(|| {
 				let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
-				prover
-					.prove(witness.clone(), &mut prover_transcript)
-					.unwrap();
+				prover.prove(&witness, &mut prover_transcript).unwrap();
 				prover_transcript
 			})
 		});
@@ -191,7 +197,7 @@ pub fn run_cs_benchmark_with_extra_groups<B, F>(
 		ConstraintSystemBenchmarkContext {
 			group_prefix,
 			bench_name: &bench_name,
-			benchmark: &benchmark,
+			benchmark,
 			circuit: &circuit,
 			example: &example,
 			instance: &instance,

--- a/crates/examples/examples/tutorials/end_to_end_example.rs
+++ b/crates/examples/examples/tutorials/end_to_end_example.rs
@@ -65,7 +65,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 	let challenger = StdChallenger::default();
 	let mut prover_transcript = ProverTranscript::new(challenger.clone());
 	let public_words = witness_vec.public().to_vec();
-	prover.prove(witness_vec, &mut prover_transcript)?;
+	prover.prove(&witness_vec, &mut prover_transcript)?;
 	let proof = prover_transcript.finalize();
 
 	let mut verifier_transcript = VerifierTranscript::new(challenger, proof);

--- a/crates/examples/src/bin/prover.rs
+++ b/crates/examples/src/bin/prover.rs
@@ -66,10 +66,7 @@ fn main() -> Result<()> {
 		.context("Failed to deserialize non-public ValuesData")?;
 
 	// Reconstruct the full ValueVec
-	// Take ownership of the underlying vectors without extra copies
-	let public: Vec<_> = public.into();
-	let non_public: Vec<_> = non_public.into();
-	let witness = ValueVec::new_from_data(public, non_public);
+	let witness = ValueVec::new_from_data(&public, &non_public);
 
 	// Setup prover (verifier is not used here)
 	let (_verifier, prover) = setup::<StdHashSuite>(cs, args.log_inv_rate as usize, None)?;
@@ -77,7 +74,7 @@ fn main() -> Result<()> {
 	// Prove
 	let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 	prover
-		.prove(witness, &mut prover_transcript)
+		.prove(&witness, &mut prover_transcript)
 		.context("Proving failed")?;
 	let transcript = prover_transcript.finalize();
 

--- a/crates/examples/src/circuits/bitcoin_block_contains_transaction.rs
+++ b/crates/examples/src/circuits/bitcoin_block_contains_transaction.rs
@@ -47,8 +47,7 @@ impl BlockContainsTransaction {
 		);
 
 		// `block_header` hashes to `block_hash`
-		let block_header =
-			DoubleSha256::construct_circuit(builder, block_header.to_vec(), block_hash);
+		let block_header = DoubleSha256::construct_circuit(builder, &block_header, block_hash);
 
 		Self {
 			merkle_path,

--- a/crates/examples/src/circuits/subset_sum.rs
+++ b/crates/examples/src/circuits/subset_sum.rs
@@ -77,7 +77,7 @@ impl SubsetSum {
 	///
 	/// - `values` is the list of integers available
 	/// - `target` is the target value that a sublist should sum to
-	pub fn populate_problem(&self, filler: &mut WitnessFiller<'_>, values: Vec<u64>, target: u64) {
+	pub fn populate_problem(&self, filler: &mut WitnessFiller<'_>, values: &[u64], target: u64) {
 		assert_eq!(values.len(), self.len);
 
 		for i in 0..self.len {
@@ -92,7 +92,7 @@ impl SubsetSum {
 	///
 	/// - `selection` should have the same length as the original list, and should contain `true`
 	///   for every number that should be included in the sublist
-	pub fn populate_solution(&self, filler: &mut WitnessFiller<'_>, selection: Vec<bool>) {
+	pub fn populate_solution(&self, filler: &mut WitnessFiller<'_>, selection: &[bool]) {
 		assert_eq!(selection.len(), self.len);
 
 		for i in 0..self.len {
@@ -122,8 +122,8 @@ mod tests {
 
 		// populate witness
 		let mut filler = circuit.new_witness_filler();
-		subset_sum.populate_problem(&mut filler, vec![2, 5, 5, 3, 7], 17);
-		subset_sum.populate_solution(&mut filler, vec![false, true, true, false, true]);
+		subset_sum.populate_problem(&mut filler, &[2, 5, 5, 3, 7], 17);
+		subset_sum.populate_solution(&mut filler, &[false, true, true, false, true]);
 		circuit.populate_wire_witness(&mut filler).unwrap();
 
 		// check
@@ -141,8 +141,8 @@ mod tests {
 
 		// populate witness
 		let mut filler = circuit.new_witness_filler();
-		subset_sum.populate_problem(&mut filler, vec![2, 5, 5, 3, 7], 17);
-		subset_sum.populate_solution(&mut filler, vec![false, true, true, false, false]);
+		subset_sum.populate_problem(&mut filler, &[2, 5, 5, 3, 7], 17);
+		subset_sum.populate_solution(&mut filler, &[false, true, true, false, false]);
 		circuit.populate_wire_witness(&mut filler).unwrap_err();
 	}
 
@@ -157,7 +157,7 @@ mod tests {
 
 		// populate witness
 		let mut filler = circuit.new_witness_filler();
-		subset_sum.populate_problem(&mut filler, vec![3], 1);
+		subset_sum.populate_problem(&mut filler, &[3], 1);
 		// This is trying to be a malicious prover: If the constraints are not assembled
 		// carefully, this could pass because `values ^ selection` sums to target.
 		// In other words, we carefully selected the bits of `selection` so that they
@@ -176,10 +176,10 @@ mod tests {
 
 		// populate witness
 		let mut filler = circuit.new_witness_filler();
-		subset_sum.populate_problem(&mut filler, vec![2 << 62, 3 << 62], 1 << 62);
+		subset_sum.populate_problem(&mut filler, &[2 << 62, 3 << 62], 1 << 62);
 		// This is a valid solution modulo 2^64, so if the constraints are not assembled
 		// carefully, this could pass.
-		subset_sum.populate_solution(&mut filler, vec![true, true]);
+		subset_sum.populate_solution(&mut filler, &[true, true]);
 		circuit.populate_wire_witness(&mut filler).unwrap_err();
 	}
 }

--- a/crates/examples/src/circuits/zklogin.rs
+++ b/crates/examples/src/circuits/zklogin.rs
@@ -117,7 +117,7 @@ pub struct ZkLogin {
 }
 
 impl ZkLogin {
-	pub fn new(b: &mut CircuitBuilder, config: Config) -> Self {
+	pub fn new(b: &mut CircuitBuilder, config: &Config) -> Self {
 		let sub = ByteVec::new_inout(b, config.max_len_jwt_sub);
 		let aud = ByteVec::new_inout(b, config.max_len_jwt_aud);
 		let iss = ByteVec::new_inout(b, config.max_len_jwt_iss);
@@ -570,7 +570,7 @@ impl ExampleCircuit for ZkLoginExample {
 
 	fn build(params: Params, builder: &mut CircuitBuilder) -> Result<Self> {
 		let config = params.config.unwrap_or_default();
-		let zklogin = ZkLogin::new(builder, config);
+		let zklogin = ZkLogin::new(builder, &config);
 
 		Ok(Self { zklogin })
 	}

--- a/crates/examples/src/cli.rs
+++ b/crates/examples/src/cli.rs
@@ -57,7 +57,7 @@ fn prove_with_hash_suite<H>(
 	log_inv_rate: usize,
 	zk: bool,
 	message: Option<&[u8]>,
-	witness: ValueVec,
+	witness: &ValueVec,
 	output: Option<&str>,
 ) -> Result<()>
 where
@@ -66,14 +66,14 @@ where
 {
 	if zk {
 		let (verifier, prover) = setup_zk::<H>(cs, log_inv_rate)?;
-		let proof_bytes = create_proof_zk(&prover, witness.clone(), message)?;
+		let proof_bytes = create_proof_zk(&prover, witness, message)?;
 		maybe_write_proof(&proof_bytes, output)?;
-		check_proof_zk(&verifier, &witness, proof_bytes, message)?;
+		check_proof_zk(&verifier, witness, proof_bytes, message)?;
 	} else {
 		let (verifier, prover) = setup::<H>(cs, log_inv_rate, None)?;
-		let proof_bytes = create_proof(&prover, witness.clone())?;
+		let proof_bytes = create_proof(&prover, witness)?;
 		maybe_write_proof(&proof_bytes, output)?;
-		check_proof(&verifier, &witness, proof_bytes)?;
+		check_proof(&verifier, witness, proof_bytes)?;
 	}
 	Ok(())
 }
@@ -84,7 +84,7 @@ fn verify_with_hash_suite<H>(
 	log_inv_rate: usize,
 	zk: bool,
 	message: Option<&[u8]>,
-	witness: ValueVec,
+	witness: &ValueVec,
 	proof_bytes: Vec<u8>,
 ) -> Result<()>
 where
@@ -93,10 +93,10 @@ where
 {
 	if zk {
 		let verifier = setup_zk_verifier::<H>(cs, log_inv_rate)?;
-		check_proof_zk(&verifier, &witness, proof_bytes, message)?;
+		check_proof_zk(&verifier, witness, proof_bytes, message)?;
 	} else {
 		let verifier = setup_verifier::<H>(cs, log_inv_rate)?;
-		check_proof(&verifier, &witness, proof_bytes)?;
+		check_proof(&verifier, witness, proof_bytes)?;
 	}
 	Ok(())
 }
@@ -562,7 +562,7 @@ where
 
 	/// Run the circuit with parsed ArgMatches (implementation).
 	#[allow(unused_variables)]
-	fn run_with_matches_impl(matches: clap::ArgMatches, circuit_name: &str) -> Result<()> {
+	fn run_with_matches_impl(matches: &clap::ArgMatches, circuit_name: &str) -> Result<()> {
 		// Honour `RAYON_NUM_THREADS=1` by pinning the pool to this thread, which keeps profiles
 		// free of worker frames. This must run before anything else touches the pool, because the
 		// first use builds it and it can only be built once — `current_num_threads` below is one
@@ -607,18 +607,18 @@ where
 
 		// Check if a subcommand was used
 		match matches.subcommand() {
-			Some(("prove", sub_matches)) => Self::run_prove(sub_matches.clone()),
-			Some(("stat", sub_matches)) => Self::run_stat(sub_matches.clone()),
-			Some(("composition", sub_matches)) => Self::run_composition(sub_matches.clone()),
+			Some(("prove", sub_matches)) => Self::run_prove(sub_matches),
+			Some(("stat", sub_matches)) => Self::run_stat(sub_matches),
+			Some(("composition", sub_matches)) => Self::run_composition(sub_matches),
 			Some(("check-snapshot", sub_matches)) => {
-				Self::run_check_snapshot_impl(sub_matches.clone(), circuit_name)
+				Self::run_check_snapshot_impl(sub_matches, circuit_name)
 			}
 			Some(("bless-snapshot", sub_matches)) => {
-				Self::run_bless_snapshot_impl(sub_matches.clone(), circuit_name)
+				Self::run_bless_snapshot_impl(sub_matches, circuit_name)
 			}
-			Some(("save", sub_matches)) => Self::run_save(sub_matches.clone()),
-			Some(("load-prove", sub_matches)) => Self::run_load_prove(sub_matches.clone()),
-			Some(("verify", sub_matches)) => Self::run_verify(sub_matches.clone()),
+			Some(("save", sub_matches)) => Self::run_save(sub_matches),
+			Some(("load-prove", sub_matches)) => Self::run_load_prove(sub_matches),
+			Some(("verify", sub_matches)) => Self::run_verify(sub_matches),
 			Some((cmd, _)) => anyhow::bail!("Unknown subcommand: {}", cmd),
 			None => {
 				// No subcommand - default to prove behavior for backward compatibility
@@ -627,7 +627,7 @@ where
 		}
 	}
 
-	fn run_prove(matches: clap::ArgMatches) -> Result<()> {
+	fn run_prove(matches: &clap::ArgMatches) -> Result<()> {
 		// Extract common arguments
 		let log_inv_rate = *matches
 			.get_one::<u32>("log_inv_rate")
@@ -649,8 +649,8 @@ where
 		let message = sign_message.as_deref().map(str::as_bytes);
 
 		// Parse Params and Instance from matches
-		let params = E::Params::from_arg_matches(&matches)?;
-		let instance = E::Instance::from_arg_matches(&matches)?;
+		let params = E::Params::from_arg_matches(matches)?;
+		let instance = E::Instance::from_arg_matches(matches)?;
 
 		// Build the circuit
 		let build_scope = tracing::info_span!("Building circuit").entered();
@@ -686,7 +686,7 @@ where
 					log_inv_rate as usize,
 					zk,
 					message,
-					witness,
+					&witness,
 					output,
 				)?;
 			}
@@ -697,7 +697,7 @@ where
 					log_inv_rate as usize,
 					zk,
 					message,
-					witness,
+					&witness,
 					output,
 				)?;
 			}
@@ -706,9 +706,9 @@ where
 		Ok(())
 	}
 
-	fn run_stat(matches: clap::ArgMatches) -> Result<()> {
+	fn run_stat(matches: &clap::ArgMatches) -> Result<()> {
 		// Parse Params from matches
-		let params = E::Params::from_arg_matches(&matches)?;
+		let params = E::Params::from_arg_matches(matches)?;
 
 		// Build the circuit
 		let mut builder = CircuitBuilder::new();
@@ -722,9 +722,9 @@ where
 		Ok(())
 	}
 
-	fn run_composition(matches: clap::ArgMatches) -> Result<()> {
+	fn run_composition(matches: &clap::ArgMatches) -> Result<()> {
 		// Parse Params from matches
-		let params = E::Params::from_arg_matches(&matches)?;
+		let params = E::Params::from_arg_matches(matches)?;
 
 		// Build the circuit
 		let mut builder = CircuitBuilder::new();
@@ -738,9 +738,9 @@ where
 		Ok(())
 	}
 
-	fn run_check_snapshot_impl(matches: clap::ArgMatches, circuit_name: &str) -> Result<()> {
+	fn run_check_snapshot_impl(matches: &clap::ArgMatches, circuit_name: &str) -> Result<()> {
 		// Parse Params from matches
-		let params = E::Params::from_arg_matches(&matches)?;
+		let params = E::Params::from_arg_matches(matches)?;
 
 		// Build the circuit
 		let mut builder = CircuitBuilder::new();
@@ -753,9 +753,9 @@ where
 		Ok(())
 	}
 
-	fn run_bless_snapshot_impl(matches: clap::ArgMatches, circuit_name: &str) -> Result<()> {
+	fn run_bless_snapshot_impl(matches: &clap::ArgMatches, circuit_name: &str) -> Result<()> {
 		// Parse Params from matches
-		let params = E::Params::from_arg_matches(&matches)?;
+		let params = E::Params::from_arg_matches(matches)?;
 
 		// Build the circuit
 		let mut builder = CircuitBuilder::new();
@@ -768,7 +768,7 @@ where
 		Ok(())
 	}
 
-	fn run_save(matches: clap::ArgMatches) -> Result<()> {
+	fn run_save(matches: &clap::ArgMatches) -> Result<()> {
 		// Extract optional output paths
 		let cs_path = matches.get_one::<String>("cs_path").cloned();
 		let pub_witness_path = matches.get_one::<String>("pub_witness_path").cloned();
@@ -786,8 +786,8 @@ where
 		}
 
 		// Parse Params and Instance
-		let params = E::Params::from_arg_matches(&matches)?;
-		let instance = E::Instance::from_arg_matches(&matches)?;
+		let params = E::Params::from_arg_matches(matches)?;
+		let instance = E::Instance::from_arg_matches(matches)?;
 
 		// Build circuit
 		let mut builder = CircuitBuilder::new();
@@ -831,7 +831,7 @@ where
 		Ok(())
 	}
 
-	fn run_load_prove(matches: clap::ArgMatches) -> Result<()> {
+	fn run_load_prove(matches: &clap::ArgMatches) -> Result<()> {
 		// Extract file paths and parameters
 		let cs_path = matches
 			.get_one::<String>("cs_path")
@@ -877,8 +877,7 @@ where
 		tracing::info!("Non-public data loaded from '{}'", non_pub_data_path);
 
 		// Reconstruct the full witness from its two segments
-		let witness =
-			ValueVec::new_from_data(pub_witness_data.into_owned(), non_pub_data.into_owned());
+		let witness = ValueVec::new_from_data(&pub_witness_data, &non_pub_data);
 		drop(witness_load_scope);
 
 		match hash_suite {
@@ -886,20 +885,20 @@ where
 				tracing::info!("Using SHA-256 hash suite for Merkle tree");
 				let (verifier, prover) =
 					setup::<StdHashSuite>(cs, log_inv_rate as usize, maybe_key_collection)?;
-				prove_verify(&verifier, &prover, witness)?;
+				prove_verify(&verifier, &prover, &witness)?;
 			}
 			HashSuiteType::Blake3 => {
 				tracing::info!("Using Blake3 hash suite for Merkle tree");
 				let (verifier, prover) =
 					setup::<Blake3HashSuite>(cs, log_inv_rate as usize, maybe_key_collection)?;
-				prove_verify(&verifier, &prover, witness)?;
+				prove_verify(&verifier, &prover, &witness)?;
 			}
 		};
 
 		Ok(())
 	}
 
-	fn run_verify(matches: clap::ArgMatches) -> Result<()> {
+	fn run_verify(matches: &clap::ArgMatches) -> Result<()> {
 		let proof_file = matches
 			.get_one::<String>("proof_file")
 			.expect("proof_file is required");
@@ -919,8 +918,8 @@ where
 		let (proof_bytes, _) = proof.into_owned();
 
 		// Parse Params and Instance from matches
-		let params = E::Params::from_arg_matches(&matches)?;
-		let instance = E::Instance::from_arg_matches(&matches)?;
+		let params = E::Params::from_arg_matches(matches)?;
+		let instance = E::Instance::from_arg_matches(matches)?;
 
 		// Build the circuit
 		let build_scope = tracing::info_span!("Building circuit").entered();
@@ -946,7 +945,7 @@ where
 					log_inv_rate as usize,
 					zk,
 					message,
-					witness,
+					&witness,
 					proof_bytes,
 				)?;
 			}
@@ -957,7 +956,7 @@ where
 					log_inv_rate as usize,
 					zk,
 					message,
-					witness,
+					&witness,
 					proof_bytes,
 				)?;
 			}
@@ -978,7 +977,7 @@ where
 	pub fn run(self) -> Result<()> {
 		let name = self.name.clone();
 		let matches = self.command.get_matches();
-		Self::run_with_matches_impl(matches, &name)
+		Self::run_with_matches_impl(&matches, &name)
 	}
 
 	/// Parse arguments and run with custom argument strings (useful for testing).
@@ -992,6 +991,6 @@ where
 	{
 		let name = self.name.clone();
 		let matches = self.command.try_get_matches_from(args)?;
-		Self::run_with_matches_impl(matches, &name)
+		Self::run_with_matches_impl(&matches, &name)
 	}
 }

--- a/crates/examples/src/lib.rs
+++ b/crates/examples/src/lib.rs
@@ -106,7 +106,7 @@ where
 {
 	let _setup_guard = tracing::info_span!("ZK setup", log_inv_rate).entered();
 	let verifier = ZKVerifier::<H>::setup(cs, log_inv_rate)?;
-	let prover = ZKProver::setup(verifier.clone())?;
+	let prover = ZKProver::setup(&verifier)?;
 	Ok((verifier, prover))
 }
 
@@ -133,7 +133,7 @@ where
 }
 
 /// Run the prover and return the raw proof transcript bytes.
-pub fn create_proof<H>(prover: &Prover<OptimalPackedB128, H>, witness: ValueVec) -> Result<Vec<u8>>
+pub fn create_proof<H>(prover: &Prover<OptimalPackedB128, H>, witness: &ValueVec) -> Result<Vec<u8>>
 where
 	H: HashSuite,
 	Output<H::LeafHash>: SerializeBytes + DeserializeBytes,
@@ -147,7 +147,7 @@ where
 /// Run the ZK prover and return the raw proof transcript bytes.
 pub fn create_proof_zk<H>(
 	prover: &ZKProver<OptimalPackedB128, H>,
-	witness: ValueVec,
+	witness: &ValueVec,
 	message: Option<&[u8]>,
 ) -> Result<Vec<u8>>
 where
@@ -209,31 +209,31 @@ where
 pub fn prove_verify<H>(
 	verifier: &Verifier<H>,
 	prover: &Prover<OptimalPackedB128, H>,
-	witness: ValueVec,
+	witness: &ValueVec,
 ) -> Result<()>
 where
 	H: HashSuite,
 	Output<H::LeafHash>: SerializeBytes + DeserializeBytes,
 {
-	let proof_bytes = create_proof(prover, witness.clone())?;
+	let proof_bytes = create_proof(prover, witness)?;
 	tracing::info!("Proof size: {} KiB", proof_bytes.len() / 1024);
-	check_proof(verifier, &witness, proof_bytes)?;
+	check_proof(verifier, witness, proof_bytes)?;
 	Ok(())
 }
 
 pub fn prove_verify_zk<H>(
 	verifier: &ZKVerifier<H>,
 	prover: &ZKProver<OptimalPackedB128, H>,
-	witness: ValueVec,
+	witness: &ValueVec,
 	message: Option<&[u8]>,
 ) -> Result<()>
 where
 	H: HashSuite,
 	Output<H::LeafHash>: SerializeBytes + DeserializeBytes,
 {
-	let proof_bytes = create_proof_zk(prover, witness.clone(), message)?;
+	let proof_bytes = create_proof_zk(prover, witness, message)?;
 	tracing::info!("Proof size: {} KiB", proof_bytes.len() / 1024);
-	check_proof_zk(verifier, &witness, proof_bytes, message)?;
+	check_proof_zk(verifier, witness, proof_bytes, message)?;
 	Ok(())
 }
 

--- a/crates/field/src/underlier/divisible.rs
+++ b/crates/field/src/underlier/divisible.rs
@@ -316,7 +316,7 @@ pub mod bitmask {
 	///
 	/// The caller must ensure that `index < Big::N` (over `SmallU<BITS>` elements).
 	#[inline]
-	pub unsafe fn get<Big, const BITS: usize>(value: Big, index: usize) -> SmallU<BITS>
+	pub unsafe fn get<Big, const BITS: usize>(value: &Big, index: usize) -> SmallU<BITS>
 	where
 		Big: Divisible<u8>,
 	{
@@ -324,7 +324,7 @@ pub mod bitmask {
 		let byte_index = index / elems_per_byte;
 		let sub_index = index % elems_per_byte;
 		// Safety: `index < Big::N` over `SmallU<BITS>` implies `byte_index < Big::N` over `u8`.
-		let byte = unsafe { Divisible::<u8>::get_unchecked(&value, byte_index) };
+		let byte = unsafe { Divisible::<u8>::get_unchecked(value, byte_index) };
 		let shift = sub_index * BITS;
 		SmallU::<BITS>::new(byte >> shift)
 	}
@@ -619,7 +619,7 @@ macro_rules! impl_divisible_bitmask {
 				#[inline]
 				unsafe fn get_unchecked(&self, index: usize) -> $crate::underlier::SmallU<$bits> {
 					// Safety: the caller guarantees `index < Self::N`.
-					unsafe { $crate::underlier::bitmask::get::<Self, $bits>(*self, index) }
+					unsafe { $crate::underlier::bitmask::get::<Self, $bits>(self, index) }
 				}
 
 				#[inline]

--- a/crates/frontend/src/compiler/gate/opcode.rs
+++ b/crates/frontend/src/compiler/gate/opcode.rs
@@ -47,6 +47,7 @@ pub enum Opcode {
 
 /// The shape of an opcode is a description of it's inputs and outputs. It allows treating a gate as
 /// a black box, correctly identifying its inputs or outputs.
+#[derive(Clone, Copy)]
 pub struct OpcodeShape {
 	/// The constants the gate with this opcode expects.
 	pub const_in: &'static [Word],

--- a/crates/frontend/src/compiler/gate_fusion/patch.rs
+++ b/crates/frontend/src/compiler/gate_fusion/patch.rs
@@ -595,9 +595,9 @@ mod tests {
 		map
 	}
 
-	fn assert_operand_eq(actual: &WireOperand, expected: Vec<ShiftedWire>, ctx: &str) {
+	fn assert_operand_eq(actual: &WireOperand, expected: &[ShiftedWire], ctx: &str) {
 		let am = operand_count_map(actual.as_slice());
-		let em = operand_count_map(&expected);
+		let em = operand_count_map(expected);
 		assert_eq!(
 			am, em,
 			"operand mismatch for {}\nexpected: {:?}\nactual:   {:?}",
@@ -999,7 +999,7 @@ mod tests {
 		let a = &cb2.imul_constraints[0].a;
 		assert_operand_eq(
 			a,
-			vec![
+			&[
 				ShiftedWire {
 					wire: w(0),
 					shift: Shift::None,
@@ -1055,7 +1055,7 @@ mod tests {
 		let m = &cb2.imul_constraints[0];
 		assert_operand_eq(
 			&m.a,
-			vec![ShiftedWire {
+			&[ShiftedWire {
 				wire: w(1),
 				shift: Shift::Sll(30),
 			}],
@@ -1063,7 +1063,7 @@ mod tests {
 		);
 		assert_operand_eq(
 			&m.b,
-			vec![
+			&[
 				ShiftedWire {
 					wire: w(3),
 					shift: Shift::None,
@@ -1106,7 +1106,7 @@ mod tests {
 		let m = &cb2.imul_constraints[0];
 		assert_operand_eq(
 			&m.hi,
-			vec![ShiftedWire {
+			&[ShiftedWire {
 				wire: w(1),
 				shift: Shift::Sll(20),
 			}],
@@ -1114,7 +1114,7 @@ mod tests {
 		);
 		assert_operand_eq(
 			&m.lo,
-			vec![
+			&[
 				ShiftedWire {
 					wire: w(3),
 					shift: Shift::None,

--- a/crates/frontend/src/compiler/gate_fusion/tests/awhole.rs
+++ b/crates/frontend/src/compiler/gate_fusion/tests/awhole.rs
@@ -158,7 +158,7 @@ fn mk_circuit_builder() -> CircuitBuilder {
 	CircuitBuilder::with_opts(opts)
 }
 
-fn compile(circuit_builder: CircuitBuilder) -> ConstraintSystem {
+fn compile(circuit_builder: &CircuitBuilder) -> ConstraintSystem {
 	let circuit = circuit_builder.build();
 	circuit.constraint_system().clone()
 }
@@ -178,7 +178,7 @@ fn test_mul_inlining_duplicate_linear_in_mul() {
 
 	let (_hi, _lo) = b.imul(y, y);
 
-	let cs = compile(b);
+	let cs = compile(&b);
 
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"IMUL[0]: (v[2] ⊕ v[3]) * (v[2] ⊕ v[3]) = (HI: v[4], LO: v[5])");
 }
@@ -201,7 +201,7 @@ fn test_mul_and_and_shared_linear_uses() {
 	let z = b.add_witness();
 	let (_hi, _lo) = b.imul(y, z);
 
-	let cs = compile(b);
+	let cs = compile(&b);
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @r"
 	AND[0]: (v[2] ⊕ v[3]) ∧ (v[4]) = (v[6])
 	IMUL[0]: (v[2] ⊕ v[3]) * (v[5]) = (HI: v[7], LO: v[8])
@@ -230,7 +230,7 @@ fn test_mul_inlining_into_hi_lo() {
 	// We cannot directly modify outputs, but using them later in ANDs will keep them alive
 	// The important check is that IMUL constraint references should inline hi_src and lo_src
 
-	let cs = compile(b);
+	let cs = compile(&b);
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @r"
 	AND[0]: (v[2] ⊕ v[3]) ∧ (all-1) = (v[8])
 	AND[1]: (v[4] ⊕ v[5]) ∧ (all-1) = (v[9])
@@ -257,7 +257,7 @@ fn test_mul_inlining_distinct_linears() {
 
 	let (_hi, _lo) = b.imul(y1, y2);
 
-	let cs = compile(b);
+	let cs = compile(&b);
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"IMUL[0]: (v[2] ⊕ v[3]) * (v[4]≪3 ⊕ v[5]) = (HI: v[6], LO: v[7])");
 }
 
@@ -268,7 +268,7 @@ fn test_xor_unused_preserved() {
 	let v0 = b.add_constant_64(0xe4);
 	let v1 = b.add_witness();
 	let _v2 = b.bxor(v0, v1);
-	let cs = compile(b);
+	let cs = compile(&b);
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (0xe4 ⊕ v[2]) ∧ (all-1) = (v[3])");
 }
 
@@ -279,7 +279,7 @@ fn test_xor_into_assert() {
 	let v1 = b.add_witness();
 	let v2 = b.bxor(v0, v1);
 	b.assert_zero("derp", v2);
-	let cs = compile(b);
+	let cs = compile(&b);
 	insta::assert_snapshot!(
 		stringify_constraint_system(&cs),
 		@"AND[0]: (0xe4 ⊕ v[2]) ∧ (all-1) = (0)",
@@ -300,7 +300,7 @@ fn test_xor_into_and_single_use() {
 	let v3 = b.add_witness();
 	let _v4 = b.band(v3, v2);
 
-	let cs = compile(b);
+	let cs = compile(&b);
 	insta::assert_snapshot!(
 		stringify_constraint_system(&cs),
 		@"AND[0]: (v[4]) ∧ (v[2] ⊕ v[3]) = (v[5])",
@@ -324,7 +324,7 @@ fn test_xor_used_on_both_sides() {
 	let rhs = b.bxor(v4, v2); // v4 ^ v2
 	let _v6 = b.band(lhs, rhs);
 
-	let cs = compile(b);
+	let cs = compile(&b);
 	// v2 is preserved since it's still referenced after lhs and rhs are inlined
 	// Expected: v[6] (which is v2 = v0^v1) should be fully inlined as (v[2] ⊕ v[3])
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (v[2] ⊕ v[3] ⊕ v[4]) ∧ (v[5] ⊕ v[2] ⊕ v[3]) = (v[6])");
@@ -343,7 +343,7 @@ fn test_shifted_base_into_and() {
 	let v2 = b.add_witness();
 	let _v3 = b.band(v2, v1);
 
-	let cs = compile(b);
+	let cs = compile(&b);
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (v[3]) ∧ (v[2]≪33) = (v[4])");
 }
 
@@ -363,7 +363,7 @@ fn test_mixed_xor_of_shifts_into_and() {
 	let v3 = b.add_witness();
 	let _v4 = b.band(v3, v2);
 
-	let cs = compile(b);
+	let cs = compile(&b);
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (v[4]) ∧ (v[2]≫7 ⊕ v[3]≪3) = (v[5])");
 }
 
@@ -386,7 +386,7 @@ fn test_deep_xor_in_both_a_and_c() {
 	let mask = b.add_witness();
 	let _v7 = b.band(lhs, mask);
 
-	let cs = compile(b);
+	let cs = compile(&b);
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (v[2] ⊕ v[3] ⊕ v[4]a≫1 ⊕ v[5]) ∧ (v[6]) = (v[7])");
 }
 
@@ -409,7 +409,7 @@ fn test_fuse_across_parens() {
 	let v5 = b.add_witness();
 	let _v6 = b.band(lhs, v5);
 
-	let cs = compile(b);
+	let cs = compile(&b);
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (v[2]≪33 ⊕ v[3] ⊕ v[4] ⊕ v[5]) ∧ (v[6]) = (v[7])");
 }
 
@@ -437,7 +437,7 @@ fn test_multiple_producers_into_one_consumer() {
 	let v4 = b.add_witness();
 	let _v5 = b.band(lhs, v4);
 
-	let cs = compile(b);
+	let cs = compile(&b);
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (v[2] ⊕ v[3] ⊕ v[4]≫5) ∧ (v[5]) = (v[6])");
 }
 
@@ -458,7 +458,7 @@ fn test_xor_producer_used_twice_inside_one_side() {
 	let v4 = b.add_witness();
 	let _v5 = b.band(lhs, v4);
 
-	let cs = compile(b);
+	let cs = compile(&b);
 	// When used twice, the XOR terms should be inlined twice
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (v[2] ⊕ v[3] ⊕ v[2] ⊕ v[3] ⊕ v[4]) ∧ (v[5]) = (v[6])");
 }
@@ -481,7 +481,7 @@ fn test_chain_two_level_fusion() {
 	let v5 = b.add_witness();
 	let _v6 = b.band(v5, v4);
 
-	let cs = compile(b);
+	let cs = compile(&b);
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (v[5]) ∧ (v[2] ⊕ v[3] ⊕ v[4]) = (v[6])");
 }
 
@@ -506,7 +506,7 @@ fn test_chain_with_shifts_inside_producers() {
 	let v5 = b.add_witness();
 	let _v6 = b.band(v5, v4);
 
-	let cs = compile(b);
+	let cs = compile(&b);
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (v[5]) ∧ (v[2]≫2 ⊕ v[3]a≫7 ⊕ v[4]≪11) = (v[6])");
 }
 
@@ -532,7 +532,7 @@ fn test_fuse_into_both_a_and_b() {
 
 	let _v6 = b.band(lhs, rhs);
 
-	let cs = compile(b);
+	let cs = compile(&b);
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (v[2] ⊕ v[3]≫3 ⊕ v[4]) ∧ (v[5] ⊕ v[2] ⊕ v[3]≫3 ⊕ v[6]) = (v[7])");
 }
 
@@ -555,7 +555,7 @@ fn test_xor_feeding_xor_via_all_one() {
 	let mask = b.add_witness();
 	let _v5 = b.band(lhs, mask);
 
-	let cs = compile(b);
+	let cs = compile(&b);
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (v[2] ⊕ v[3]≪2 ⊕ v[4] ⊕ v[5]) ∧ (v[6]) = (v[7])");
 }
 
@@ -573,7 +573,7 @@ fn test_not_pattern_via_xor_with_all_one() {
 	let v2 = b.add_witness();
 	let _v3 = b.band(v2, v1);
 
-	let cs = compile(b);
+	let cs = compile(&b);
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (v[3]) ∧ (v[2] ⊕ all-1) = (v[4])");
 }
 
@@ -592,7 +592,7 @@ fn test_dont_inline_xor_into_shifted_use() {
 	let v3 = b.add_witness();
 	let _v4 = b.band(v2_sll, v3);
 
-	let cs = compile(b);
+	let cs = compile(&b);
 	// The optimization successfully inlines despite the shift at the use site
 	// This shows gate fusion can handle shifts in the consuming constraint
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (v[2]≪5 ⊕ v[3]≪5) ∧ (v[4]) = (v[5])");
@@ -612,7 +612,7 @@ fn test_dont_inline_shifted_producer_into_shifted_use() {
 	let v2 = b.add_witness();
 	let _v3 = b.band(v1_sll, v2);
 
-	let cs = compile(b);
+	let cs = compile(&b);
 	// Cannot compose different shift types (srl then sll), so it commits the intermediate
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @r"
 	AND[0]: (v[4]≪3) ∧ (v[3]) = (v[5])
@@ -638,7 +638,7 @@ fn test_dont_inline_xor_into_shifted_xor_use() {
 	let v4 = b.add_witness();
 	let _v5 = b.band(lhs, v4);
 
-	let cs = compile(b);
+	let cs = compile(&b);
 	// The optimization can actually compose shifts of the same type (shr)
 	// So it inlines despite the shift at use site
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (v[2]≫9 ⊕ v[3]≫11 ⊕ v[4]) ∧ (v[5]) = (v[6])");
@@ -663,7 +663,7 @@ fn test_mixed_one_unshifted_use_one_shifted_use() {
 	let v5 = b.add_witness();
 	let _v6 = b.band(v2_srl, v5);
 
-	let cs = compile(b);
+	let cs = compile(&b);
 	// The optimization can inline into both uses since shifts distribute over XOR
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @r"
 	AND[0]: (v[4]) ∧ (v[2] ⊕ v[3]) = (v[6])
@@ -687,7 +687,7 @@ fn test_rotr_overflow_to_zero() {
 	let v3 = b.add_witness();
 	let _v4 = b.band(v3, v2);
 
-	let cs = compile(b);
+	let cs = compile(&b);
 	// rotr(v0, 64) should be simplified to v0 (no rotation)
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (v[3]) ∧ (v[2]) = (v[4])");
 }
@@ -708,7 +708,7 @@ fn test_rotr_wrap_around() {
 	let v3 = b.add_witness();
 	let _v4 = b.band(v3, v2);
 
-	let cs = compile(b);
+	let cs = compile(&b);
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (v[3]) ∧ (v[2]≫≫16) = (v[4])");
 }
 
@@ -732,7 +732,7 @@ fn test_rotr_in_xor_overflow() {
 	let v5 = b.add_witness();
 	let _v6 = b.band(v5, v4);
 
-	let cs = compile(b);
+	let cs = compile(&b);
 	// rotr(v0 ^ v1, 64) should be just v0 ^ v1
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (v[4]) ∧ (v[2] ⊕ v[3]) = (v[5])");
 }
@@ -754,7 +754,7 @@ fn test_rotr_chain_with_wrap() {
 	let v4 = b.add_witness();
 	let _v5 = b.band(v4, v3);
 
-	let cs = compile(b);
+	let cs = compile(&b);
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (v[3]) ∧ (v[2]≫≫11) = (v[4])");
 }
 
@@ -775,7 +775,7 @@ fn test_rotr_distributes_over_xor_expanded() {
 	let v4 = b.add_witness();
 	let _v5 = b.band(v4, v3);
 
-	let cs = compile(b);
+	let cs = compile(&b);
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (v[4]) ∧ (v[2]≫≫6 ⊕ v[3]≫≫6) = (v[5])");
 }
 
@@ -825,7 +825,7 @@ fn test_depth_limit_deep_chain() {
 	let w9 = b.add_witness();
 	let _result = b.band(v8, w9);
 
-	let cs = compile(b);
+	let cs = compile(&b);
 
 	// The deep chain should cause intermediate commitments due to depth limit
 	// We expect the optimizer to commit some intermediate value and create multiple AND constraints
@@ -879,7 +879,7 @@ fn test_depth_limit_with_shifts() {
 	let w9 = b.add_witness();
 	let _result = b.band(v8, w9);
 
-	let cs = compile(b);
+	let cs = compile(&b);
 
 	// With shifts in the chain, the depth limit should still apply
 	// The optimizer should handle the complexity and commit when needed

--- a/crates/hash/src/parallel_digest.rs
+++ b/crates/hash/src/parallel_digest.rs
@@ -323,7 +323,7 @@ mod tests {
 	fn check_parallel_digest_consistency<
 		D: ParallelDigest<Digest: BlockSizeUser + Send + Sync + Clone>,
 	>(
-		data: Vec<Vec<u8>>,
+		data: &[Vec<u8>],
 	) {
 		let parallel_digest = D::new();
 		let mut parallel_results = repeat_with(MaybeUninit::<Output<D::Digest>>::uninit)
@@ -341,14 +341,14 @@ mod tests {
 	#[test]
 	fn test_empty_data() {
 		let data = generate_mock_data(0, 16);
-		check_parallel_digest_consistency::<ParallelMultidigestImpl<MockMultiDigest, 4>>(data);
+		check_parallel_digest_consistency::<ParallelMultidigestImpl<MockMultiDigest, 4>>(&data);
 	}
 
 	#[test]
 	fn test_non_empty_data() {
 		for n_hashes in [1, 2, 4, 8, 9] {
 			let data = generate_mock_data(n_hashes, 16);
-			check_parallel_digest_consistency::<ParallelMultidigestImpl<MockMultiDigest, 4>>(data);
+			check_parallel_digest_consistency::<ParallelMultidigestImpl<MockMultiDigest, 4>>(&data);
 		}
 	}
 

--- a/crates/iop-prover/src/basefold/channel.rs
+++ b/crates/iop-prover/src/basefold/channel.rs
@@ -653,7 +653,7 @@ mod tests {
 		let oracle_specs = vec![OracleSpec::new_zk(n_vars)];
 
 		let verifier_compiler = BaseFoldVerifierCompiler::new(
-			make_merkle_scheme(),
+			&make_merkle_scheme(),
 			oracle_specs,
 			LOG_INV_RATE,
 			n_test_queries,
@@ -725,7 +725,7 @@ mod tests {
 		let oracle_specs = vec![OracleSpec::new_zk(n_vars_1), OracleSpec::new_zk(n_vars_2)];
 
 		let verifier_compiler = BaseFoldVerifierCompiler::new(
-			make_merkle_scheme(),
+			&make_merkle_scheme(),
 			oracle_specs,
 			LOG_INV_RATE,
 			n_test_queries,
@@ -808,7 +808,7 @@ mod tests {
 			n_vars_list.iter().map(|&n| OracleSpec::new_zk(n)).collect();
 
 		let verifier_compiler = BaseFoldVerifierCompiler::new(
-			make_merkle_scheme(),
+			&make_merkle_scheme(),
 			oracle_specs,
 			LOG_INV_RATE,
 			n_test_queries,
@@ -905,7 +905,7 @@ mod tests {
 			.collect();
 
 		let verifier_compiler = BaseFoldVerifierCompiler::new(
-			make_merkle_scheme(),
+			&make_merkle_scheme(),
 			oracle_specs,
 			LOG_INV_RATE,
 			n_test_queries,

--- a/crates/iop-prover/src/basefold/compiler.rs
+++ b/crates/iop-prover/src/basefold/compiler.rs
@@ -53,7 +53,7 @@ where
 	/// flexible batch size.
 	pub fn new<H>(
 		ntt: NTT,
-		merkle_scheme: BinaryMerkleTreeScheme<F, H>,
+		merkle_scheme: &BinaryMerkleTreeScheme<F, H>,
 		oracle_specs: Vec<OracleSpec>,
 		log_inv_rate: usize,
 		n_test_queries: usize,
@@ -71,7 +71,7 @@ where
 		// equal-length mask); non-ZK oracles take a flexible batch size.
 		let (fri_params, _) = FRIParams::optimal_for_batch(
 			ntt.domain_context(),
-			&merkle_scheme,
+			merkle_scheme,
 			&oracle_specs,
 			log_inv_rate,
 			n_test_queries,

--- a/crates/iop-prover/src/basefold/opening.rs
+++ b/crates/iop-prover/src/basefold/opening.rs
@@ -146,8 +146,8 @@ mod test {
 	/// combined FRI path. If `tamper`, the claim is corrupted and verification must fail. (The
 	/// multi-oracle path is exercised end-to-end by the channel tests.)
 	fn run_mlecheck_basefold_zk_prove_and_verify<F, P>(
-		witness: FieldBuffer<P>,
-		evaluation_point: Vec<F>,
+		witness: &FieldBuffer<P>,
+		evaluation_point: &[F],
 		tamper: bool,
 	) -> Result<()>
 	where
@@ -198,7 +198,7 @@ mod test {
 				*w = extrapolate_line_packed(*w, m, gamma_broadcast);
 			});
 
-		let eval_point_eq = eq_ind_partial_eval::<P>(&evaluation_point);
+		let eval_point_eq = eq_ind_partial_eval::<P>(evaluation_point);
 		let mut eval_claim = inner_product_buffers(&witness_prime, &eval_point_eq);
 		if tamper {
 			eval_claim += F::ONE;
@@ -208,7 +208,7 @@ mod test {
 			FRIFoldProver::new_batch(&fri_params, &ntt, vec![(codeword, codeword_commitment)]);
 		prove_mlecheck_basefold(
 			witness_prime,
-			&evaluation_point,
+			evaluation_point,
 			eval_claim,
 			Some(batch_challenge),
 			&[],
@@ -234,7 +234,7 @@ mod test {
 			&fri_params,
 			&[retrieved_commitment],
 			eval_claim,
-			&evaluation_point,
+			evaluation_point,
 			Some(batch_challenge_v),
 			&[],
 			&mut verifier_channel,
@@ -252,7 +252,7 @@ mod test {
 		let witness = random_field_buffer::<P>(&mut rng, n_vars);
 		let evaluation_point = random_scalars(&mut rng, n_vars);
 
-		run_mlecheck_basefold_zk_prove_and_verify::<_, P>(witness, evaluation_point, false)
+		run_mlecheck_basefold_zk_prove_and_verify::<_, P>(&witness, &evaluation_point, false)
 			.unwrap();
 	}
 
@@ -266,7 +266,7 @@ mod test {
 		let evaluation_point = random_scalars(&mut rng, n_vars);
 
 		let result =
-			run_mlecheck_basefold_zk_prove_and_verify::<_, P>(witness, evaluation_point, true);
+			run_mlecheck_basefold_zk_prove_and_verify::<_, P>(&witness, &evaluation_point, true);
 		assert!(result.is_err());
 	}
 }

--- a/crates/iop-prover/src/logup_star.rs
+++ b/crates/iop-prover/src/logup_star.rs
@@ -94,7 +94,7 @@ where
 		.iter()
 		.map(|looker| looker.eval_claim)
 		.collect::<Vec<_>>();
-	let combined_eval_claim = evaluate_univariate(&claims, gamma);
+	let combined_eval_claim = evaluate_univariate(&claims, &gamma);
 
 	// Run the reduction over the committed Y and the numerators, viewing the channel as IP.
 	let output = reduction::prove_reduction(
@@ -389,7 +389,7 @@ mod tests {
 		let oracle_specs = vec![OracleSpec::new_zk(m)];
 
 		let verifier_compiler = BaseFoldVerifierCompiler::new(
-			BinaryMerkleTreeScheme::<F, StdHashSuite>::new(),
+			&BinaryMerkleTreeScheme::<F, StdHashSuite>::new(),
 			oracle_specs,
 			LOG_INV_RATE,
 			n_test_queries,

--- a/crates/iop/src/basefold/channel.rs
+++ b/crates/iop/src/basefold/channel.rs
@@ -107,7 +107,7 @@ where
 			return Ok(());
 		}
 
-		verify_batch_zk_basefold(&mut channel, oracle_specs, fri_params, oracle_commitments, queue)
+		verify_batch_zk_basefold(&mut channel, oracle_specs, fri_params, &oracle_commitments, queue)
 	}
 }
 
@@ -132,7 +132,7 @@ fn verify_batch_zk_basefold<F, Channel>(
 	channel: &mut Channel,
 	oracle_specs: &[OracleSpec],
 	fri_params: &FRIParams<F>,
-	oracle_commitments: Vec<Channel::Commitment>,
+	oracle_commitments: &[Channel::Commitment],
 	relations: Vec<OracleLinearRelation<BaseFoldOracle, F>>,
 ) -> Result<(), Error>
 where
@@ -200,7 +200,7 @@ where
 			alpha_i * transparent_eval * pad_eq
 		})
 		.collect::<Vec<_>>();
-	let expected = evaluate_univariate(&contributions, sumcheck_batch_coeff);
+	let expected = evaluate_univariate(&contributions, &sumcheck_batch_coeff);
 	channel.assert_zero(sumcheck_reduced_eval - expected)?;
 
 	// === Phase B: single combined-FRI MLE-check over the piecewise-concatenated oracle ===
@@ -225,7 +225,7 @@ where
 	// The opening routine asserts the final FRI/MLE-check consistency internally.
 	basefold::verify_mlecheck_basefold(
 		fri_params,
-		&oracle_commitments,
+		oracle_commitments,
 		s_prime,
 		&point,
 		gamma,

--- a/crates/iop/src/basefold/compiler.rs
+++ b/crates/iop/src/basefold/compiler.rs
@@ -44,7 +44,7 @@ where
 	/// oracle fixes `log_batch_size = 1` (message ‖ equal-length mask), a non-ZK oracle takes a
 	/// flexible batch size. Requires at least one oracle spec.
 	pub fn new<H, Strategy>(
-		merkle_scheme: BinaryMerkleTreeScheme<F, H>,
+		merkle_scheme: &BinaryMerkleTreeScheme<F, H>,
 		oracle_specs: Vec<OracleSpec>,
 		log_inv_rate: usize,
 		n_test_queries: usize,
@@ -76,7 +76,7 @@ where
 		// ‖ mask), non-ZK oracles take a flexible batch size.
 		let (fri_params, _) = FRIParams::optimal_for_batch(
 			&domain_context,
-			&merkle_scheme,
+			merkle_scheme,
 			&oracle_specs,
 			log_inv_rate,
 			n_test_queries,

--- a/crates/iop/src/basefold/opening.rs
+++ b/crates/iop/src/basefold/opening.rs
@@ -103,7 +103,7 @@ where
 		let alpha = eval_point[n_vars - 1 - round];
 		let round_coeffs = round_proof.recover(sum, alpha);
 		let challenge = channel.sample();
-		sum = round_coeffs.evaluate(challenge);
+		sum = round_coeffs.evaluate(&challenge);
 		challenges.push(challenge);
 	}
 

--- a/crates/iop/src/logup_star.rs
+++ b/crates/iop/src/logup_star.rs
@@ -83,7 +83,7 @@ where
 	let oracle = channel.recv_oracle(table_n_vars, true)?;
 
 	// Run the bare reduction over the same channel, viewed as an IP channel.
-	let output = reduction::verify_reduction::<F, C>(gamma, table_n_vars, lookers, channel)?;
+	let output = reduction::verify_reduction::<F, C>(&gamma, table_n_vars, lookers, channel)?;
 
 	// Open the pushforward relation through the channel; a deferring channel (e.g. BaseFold)
 	// batches it with every other queued relation in `finish()`.

--- a/crates/ip-prover/src/fracaddcheck.rs
+++ b/crates/ip-prover/src/fracaddcheck.rs
@@ -388,7 +388,7 @@ where
 		.map(|(_frac, prover)| prover)
 		.collect();
 	let (mut fractions, eval_point) =
-		reduce_layer::<A, F, P, _>(alloc, layer_provers, eval_point, k, channel);
+		reduce_layer::<A, F, P, _>(alloc, layer_provers, &eval_point, k, channel);
 
 	// Drop the padded (2^k) selector slots, keeping one reduced fraction per input prover.
 	fractions.truncate(n);
@@ -459,7 +459,7 @@ where
 	let (provers, claimed_fractions, eval_point) = (0..n_layers - 1).fold(
 		(provers, claimed_fractions, eval_point),
 		|(provers, claimed_fractions, eval_point), _| {
-			batch_prove_layer(provers, claimed_fractions, eval_point, k, channel)
+			batch_prove_layer(provers, &claimed_fractions, &eval_point, k, channel)
 		},
 	);
 
@@ -513,7 +513,7 @@ fn combine_claims<F: Field>(coeffs: Vec<RoundCoeffs<F>>, batch_coeff: F) -> Roun
 fn reduce_layer<'a, A, F, P, MP>(
 	alloc: &'a A,
 	mut layer_provers: Vec<MP>,
-	eval_point: Vec<F>,
+	eval_point: &[F],
 	k: usize,
 	channel: &mut impl IPProverChannel<F>,
 ) -> (Vec<(F, F)>, Vec<F>)
@@ -660,8 +660,8 @@ where
 #[allow(clippy::type_complexity)]
 fn batch_prove_layer<'a, A, F, P>(
 	provers: Vec<FracAddCheckProver<'a, A, P>>,
-	claimed_fractions: Vec<(F, F)>,
-	eval_point: Vec<F>,
+	claimed_fractions: &[(F, F)],
+	eval_point: &[F],
 	k: usize,
 	channel: &mut impl IPProverChannel<F>,
 ) -> (Vec<FracAddCheckProver<'a, A, P>>, Vec<(F, F)>, Vec<F>)
@@ -674,7 +674,7 @@ where
 	// coordinates.
 	let alloc = provers[0].alloc;
 	let inner_coords = eval_point[k..].to_vec();
-	let (layer_provers, next_provers): (Vec<_>, Vec<_>) = iter::zip(provers, &claimed_fractions)
+	let (layer_provers, next_provers): (Vec<_>, Vec<_>) = iter::zip(provers, claimed_fractions)
 		.map(|(prover, &(num, den))| {
 			let (remaining, layer_prover, _cols) = prover.layer_prover((
 				MultilinearEvalClaim {

--- a/crates/ip-prover/src/logup_star/prove.rs
+++ b/crates/ip-prover/src/logup_star/prove.rs
@@ -101,7 +101,7 @@ where
 		.iter()
 		.map(|looker| looker.eval_claim)
 		.collect::<Vec<_>>();
-	let combined_eval_claim = evaluate_univariate(&claims, gamma);
+	let combined_eval_claim = evaluate_univariate(&claims, &gamma);
 
 	// The self-contained prover commits nothing.
 	// It runs the reduction over the witnesses directly.
@@ -379,7 +379,7 @@ mod tests {
 		};
 		let gamma = IPVerifierChannel::<F>::sample(&mut verifier_transcript);
 		let verifier_out = logup_star::verify_reduction::<F, _>(
-			gamma,
+			&gamma,
 			m,
 			&[looker_claim],
 			&mut verifier_transcript,
@@ -462,7 +462,7 @@ mod tests {
 		};
 		let gamma = IPVerifierChannel::<F>::sample(&mut verifier_transcript);
 		let result = logup_star::verify_reduction::<F, _>(
-			gamma,
+			&gamma,
 			table.log_len(),
 			&[looker_claim],
 			&mut verifier_transcript,
@@ -516,7 +516,7 @@ mod tests {
 			.collect::<Vec<_>>();
 		let gamma = IPVerifierChannel::<F>::sample(&mut verifier_transcript);
 		let verifier_out = logup_star::verify_reduction::<F, _>(
-			gamma,
+			&gamma,
 			m,
 			&looker_claims,
 			&mut verifier_transcript,

--- a/crates/ip-prover/src/prodcheck.rs
+++ b/crates/ip-prover/src/prodcheck.rs
@@ -284,7 +284,7 @@ pub fn batch_prove<'a, A: Allocator, F: Field, P: PackedField<Scalar = F>>(
 	// Finish the retained final layer: run it exactly as an interior reduction layer does.
 	let (claimed_products, provers): (Vec<_>, Vec<_>) = provers.into_iter().unzip();
 	let (provers, mut evals, eval_point) =
-		batch_prove_layer(provers, claimed_products, eval_point, k, channel);
+		batch_prove_layer(provers, claimed_products, &eval_point, k, channel);
 	debug_assert!(provers.is_empty(), "the final layer leaves no provers");
 
 	// Drop the padded (2^k) selector slots, keeping one reduced eval per input prover.
@@ -329,7 +329,7 @@ pub fn batch_prove_until_final_layer<'a, A: Allocator, F: Field, P: PackedField<
 	let (provers, claimed_products, eval_point) = (0..n_layers - 1).fold(
 		(provers, claimed_products, eval_point),
 		|(provers, claimed_products, eval_point), _| {
-			batch_prove_layer(provers, claimed_products, eval_point, k, channel)
+			batch_prove_layer(provers, claimed_products, &eval_point, k, channel)
 		},
 	);
 
@@ -346,7 +346,7 @@ pub fn batch_prove_until_final_layer<'a, A: Allocator, F: Field, P: PackedField<
 fn batch_prove_layer<'a, A: Allocator, F: Field, P: PackedField<Scalar = F>>(
 	provers: Vec<ProdcheckProver<'a, A, P>>,
 	claimed_products: Vec<F>,
-	eval_point: Vec<F>,
+	eval_point: &[F],
 	k: usize,
 	channel: &mut impl IPProverChannel<F>,
 ) -> (Vec<ProdcheckProver<'a, A, P>>, Vec<F>, Vec<F>) {

--- a/crates/ip-prover/src/sumcheck/batch.rs
+++ b/crates/ip-prover/src/sumcheck/batch.rs
@@ -347,7 +347,7 @@ mod tests {
 
 		let composed_evals = vec![eval_a_0 * eval_b_0, eval_a_1 * eval_b_1];
 		let expected_batched_eval =
-			evaluate_univariate(&composed_evals, sumcheck_output.batch_coeff);
+			evaluate_univariate(&composed_evals, &sumcheck_output.batch_coeff);
 
 		assert_eq!(
 			expected_batched_eval, sumcheck_output.eval,

--- a/crates/ip-prover/src/sumcheck/bivariate_product_mle.rs
+++ b/crates/ip-prover/src/sumcheck/bivariate_product_mle.rs
@@ -132,8 +132,8 @@ mod tests {
 		prover: impl MleCheckProver<F>,
 		eval_claim: F,
 		eval_point: &[F],
-		multilinear_a: FieldBuffer<P>,
-		multilinear_b: FieldBuffer<P>,
+		multilinear_a: &FieldBuffer<P>,
+		multilinear_b: &FieldBuffer<P>,
 	) where
 		F: Field,
 		P: PackedField<Scalar = F>,
@@ -173,8 +173,8 @@ mod tests {
 		// Check that the original multilinears evaluate to the claimed values at the challenge
 		// point The prover binds variables from high to low, but evaluate expects them from low
 		// to high
-		let eval_a = evaluate(&multilinear_a, &reduced_eval_point);
-		let eval_b = evaluate(&multilinear_b, &reduced_eval_point);
+		let eval_a = evaluate(multilinear_a, &reduced_eval_point);
+		let eval_b = evaluate(multilinear_b, &reduced_eval_point);
 
 		assert_eq!(
 			eval_a, multilinear_evals[0],
@@ -196,8 +196,8 @@ mod tests {
 		mlecheck_prover: impl MleCheckProver<F>,
 		eval_claim: F,
 		eval_point: &[F],
-		multilinear_a: FieldBuffer<P>,
-		multilinear_b: FieldBuffer<P>,
+		multilinear_a: &FieldBuffer<P>,
+		multilinear_b: &FieldBuffer<P>,
 	) where
 		F: Field,
 		P: PackedField<Scalar = F>,
@@ -244,8 +244,8 @@ mod tests {
 
 		// Check that the original multilinears evaluate to the claimed values at the challenge
 		// point
-		let eval_a = evaluate(&multilinear_a, &reduced_eval_point);
-		let eval_b = evaluate(&multilinear_b, &reduced_eval_point);
+		let eval_a = evaluate(multilinear_a, &reduced_eval_point);
+		let eval_b = evaluate(multilinear_b, &reduced_eval_point);
 
 		assert_eq!(
 			eval_a, multilinear_evals[0],
@@ -297,8 +297,8 @@ mod tests {
 			mlecheck_prover,
 			eval_claim,
 			&eval_point,
-			multilinear_a.clone(),
-			multilinear_b.clone(),
+			&multilinear_a,
+			&multilinear_b,
 		);
 
 		// Create another prover for the wrapped test
@@ -313,8 +313,8 @@ mod tests {
 			mlecheck_prover,
 			eval_claim,
 			&eval_point,
-			multilinear_a,
-			multilinear_b,
+			&multilinear_a,
+			&multilinear_b,
 		);
 	}
 }

--- a/crates/ip-prover/src/sumcheck/frac_add_mle.rs
+++ b/crates/ip-prover/src/sumcheck/frac_add_mle.rs
@@ -78,10 +78,10 @@ mod tests {
 		prover: impl SumcheckProver<F>,
 		eval_claims: [F; 2],
 		eval_point: &[F],
-		num_a: FieldBuffer<P>,
-		num_b: FieldBuffer<P>,
-		den_a: FieldBuffer<P>,
-		den_b: FieldBuffer<P>,
+		num_a: &FieldBuffer<P>,
+		num_b: &FieldBuffer<P>,
+		den_a: &FieldBuffer<P>,
+		den_b: &FieldBuffer<P>,
 	) where
 		F: Field,
 		P: PackedField<Scalar = F>,
@@ -117,10 +117,10 @@ mod tests {
 
 		// Check that the original multilinears evaluate to the claimed values at the challenge
 		// point
-		let eval_num_a = evaluate(&num_a, &reduced_eval_point);
-		let eval_den_a = evaluate(&den_a, &reduced_eval_point);
-		let eval_num_b = evaluate(&num_b, &reduced_eval_point);
-		let eval_den_b = evaluate(&den_b, &reduced_eval_point);
+		let eval_num_a = evaluate(num_a, &reduced_eval_point);
+		let eval_den_a = evaluate(den_a, &reduced_eval_point);
+		let eval_num_b = evaluate(num_b, &reduced_eval_point);
+		let eval_den_b = evaluate(den_b, &reduced_eval_point);
 
 		assert_eq!(
 			eval_num_a, multilinear_evals[0],
@@ -212,10 +212,10 @@ mod tests {
 			prover,
 			eval_claims,
 			&eval_point,
-			num_a,
-			num_b,
-			den_a,
-			den_b,
+			&num_a,
+			&num_b,
+			&den_a,
+			&den_b,
 		);
 	}
 }

--- a/crates/ip-prover/src/sumcheck/multilinear_eval.rs
+++ b/crates/ip-prover/src/sumcheck/multilinear_eval.rs
@@ -256,7 +256,7 @@ mod tests {
 			let round = prover.execute();
 			assert_eq!(prover.round_claim(), before);
 			let challenge = F::random(&mut rng);
-			let expected_next = round[0].evaluate(challenge);
+			let expected_next = round[0].evaluate(&challenge);
 			prover.fold(challenge);
 			assert_eq!(prover.round_claim(), vec![expected_next]);
 		}

--- a/crates/ip-prover/src/sumcheck/padded.rs
+++ b/crates/ip-prover/src/sumcheck/padded.rs
@@ -255,7 +255,7 @@ mod tests {
 				RoundProof(RoundCoeffs(verifier_transcript.recv_many(degree).unwrap()));
 			let challenge = verifier_transcript.sample();
 			let round_coeffs = round_proof.recover(running_sum);
-			running_sum = round_coeffs.evaluate(challenge);
+			running_sum = round_coeffs.evaluate(&challenge);
 			challenges.push(challenge);
 		}
 		let reduced_eval = running_sum;

--- a/crates/ip-prover/src/sumcheck/quadratic_mle_evaluator.rs
+++ b/crates/ip-prover/src/sumcheck/quadratic_mle_evaluator.rs
@@ -353,7 +353,7 @@ mod tests {
 			let round = prover.execute();
 			assert_eq!(prover.round_claim(), expected, "claim recovered from coeffs");
 			let challenge = F::random(&mut rng);
-			expected = round.iter().map(|r| r.evaluate(challenge)).collect();
+			expected = round.iter().map(|r| r.evaluate(&challenge)).collect();
 			prover.fold(challenge);
 		}
 	}

--- a/crates/ip-prover/src/sumcheck/round_evaluator.rs
+++ b/crates/ip-prover/src/sumcheck/round_evaluator.rs
@@ -341,7 +341,7 @@ where
 		// The store's column and eq fold is deferred: the challenge is buffered so the next
 		// execute can fuse it into that round's read pass.
 		for state in &mut self.round_states {
-			let claim = state.coeffs().evaluate(challenge);
+			let claim = state.coeffs().evaluate(&challenge);
 			*state = RoundState::Claim(claim);
 		}
 		debug_assert!(
@@ -571,7 +571,7 @@ where
 		// Reduce each evaluator's prime round polynomial against the challenge to form its next
 		// claim; the store's column and eq fold is deferred to the next execute.
 		for state in &mut self.round_states {
-			let claim = state.coeffs().evaluate(challenge);
+			let claim = state.coeffs().evaluate(&challenge);
 			*state = RoundState::Claim(claim);
 		}
 		debug_assert!(
@@ -748,7 +748,7 @@ mod tests {
 			let packed = std::array::from_fn(|i| P::broadcast(verified_evals[i]));
 			let composed = [comp_num, comp_den]
 				.map(|comp| comp(packed).iter().next().expect("packed field has a lane"));
-			let expected = evaluate_univariate(&composed, sumcheck_output.batch_coeff);
+			let expected = evaluate_univariate(&composed, &sumcheck_output.batch_coeff);
 			assert_eq!(expected, sumcheck_output.eval, "reduced evaluation must match the batch");
 
 			assert_eq!(output.challenges, sumcheck_output.challenges);
@@ -859,7 +859,7 @@ mod tests {
 				<[F; 6]>::try_from(verified_evals).expect("six column evaluations");
 			let eq = eq_ind(&z, &point);
 			let reduced = [(y0 * d1 + y1 * d0) * eq, (d0 * d1) * eq, y0 * t0, y1 * t1];
-			let expected = evaluate_univariate(&reduced, sumcheck_output.batch_coeff);
+			let expected = evaluate_univariate(&reduced, &sumcheck_output.batch_coeff);
 			assert_eq!(expected, sumcheck_output.eval, "reduced evaluation must match the batch");
 
 			assert_eq!(output.challenges, sumcheck_output.challenges);

--- a/crates/ip-prover/src/sumcheck/selector_mle.rs
+++ b/crates/ip-prover/src/sumcheck/selector_mle.rs
@@ -243,7 +243,7 @@ where
 
 		let sums = prime_coeffs
 			.iter()
-			.map(|coeffs| coeffs.evaluate(challenge))
+			.map(|coeffs| coeffs.evaluate(&challenge))
 			.collect();
 
 		self.gruen32s

--- a/crates/ip-prover/src/sumcheck/switchover.rs
+++ b/crates/ip-prover/src/sumcheck/switchover.rs
@@ -201,5 +201,5 @@ fn get_binary_chunk<P, DataOut, DataIn>(
 		chunk_vars,
 		chunk_index,
 	);
-	binary_fold_high(dest, tensor, matrix_vert_slice);
+	binary_fold_high(dest, tensor, &matrix_vert_slice);
 }

--- a/crates/ip-prover/src/sumcheck/zk_mlecheck.rs
+++ b/crates/ip-prover/src/sumcheck/zk_mlecheck.rs
@@ -161,7 +161,7 @@ impl<F: Field, P: PackedField<Scalar = F>, Data: Deref<Target = [P]>> Mask<P, Da
 	/// Evaluates g_i(x) for a specific variable using Horner's method.
 	pub fn evaluate_univariate(&self, var_index: usize, x: F) -> F {
 		let coeffs: Vec<_> = self.coeffs_for_var(var_index).collect();
-		evaluate_univariate(&coeffs, x)
+		evaluate_univariate(&coeffs, &x)
 	}
 
 	/// Computes the MLE of the mask polynomial at a point.
@@ -316,7 +316,7 @@ impl<F: Field, P: PackedField<Scalar = F>, Data: Deref<Target = [P]>> SumcheckPr
 		let coeffs = self.last_coeffs_or_claim.coeffs();
 
 		// Evaluate round polynomial at challenge to get new claim
-		let new_claim = coeffs.evaluate(challenge);
+		let new_claim = coeffs.evaluate(&challenge);
 
 		let var_idx = self.current_var_index();
 

--- a/crates/ip/src/logup_star/final_layer.rs
+++ b/crates/ip/src/logup_star/final_layer.rs
@@ -63,7 +63,7 @@ pub struct FinalLayer<F> {
 /// * `channel` - The verifier channel.
 pub fn verify_final_layer<F, C>(
 	m: usize,
-	c: C::Elem,
+	c: &C::Elem,
 	eval_claim: C::Elem,
 	layer1_num: C::Elem,
 	layer1_den: C::Elem,
@@ -108,7 +108,7 @@ where
 
 	// Table-side denominator halves D_0, D_1 are public: D = c - J with J(x) = sum_t basis(t) *
 	// x_t.
-	let (d_0, d_1) = denominator_halves::<F, C::Elem>(&c, &rho, m);
+	let (d_0, d_1) = denominator_halves::<F, C::Elem>(c, &rho, m);
 
 	// Reconstruct the batched summand at the challenge point and check it equals the reduced eval.
 	//

--- a/crates/ip/src/logup_star/verify.rs
+++ b/crates/ip/src/logup_star/verify.rs
@@ -90,7 +90,7 @@ pub struct LookerClaim<'a, Elem> {
 /// - the index evaluations do not combine to the batched leaf denominator,
 /// - the batched final layer is inconsistent.
 pub fn verify_reduction<F, C>(
-	gamma: C::Elem,
+	gamma: &C::Elem,
 	table_n_vars: usize,
 	lookers: &[LookerClaim<'_, C::Elem>],
 	channel: &mut C,
@@ -216,7 +216,7 @@ where
 		pushforward_eval_claim,
 	} = verify_final_layer::<F, C>(
 		m,
-		c,
+		&c,
 		combined_eval_claim,
 		layer1_num,
 		layer1_den,
@@ -254,6 +254,6 @@ mod tests {
 			eval_point: &[],
 			eval_claim: B128::ZERO,
 		};
-		let _ = verify_reduction::<B128, _>(B128::ZERO, 0, &[claim], &mut verifier);
+		let _ = verify_reduction::<B128, _>(&B128::ZERO, 0, &[claim], &mut verifier);
 	}
 }

--- a/crates/ip/src/mlecheck.rs
+++ b/crates/ip/src/mlecheck.rs
@@ -96,7 +96,7 @@ where
 		let challenge = channel.sample();
 
 		let round_coeffs = round_proof.recover(eval, z_i.clone());
-		eval = round_coeffs.evaluate(challenge.clone());
+		eval = round_coeffs.evaluate(&challenge);
 		challenges.push(challenge);
 	}
 
@@ -261,8 +261,8 @@ mod tests {
 	fn test_recover_with_degree<F: Field>(mut rng: impl Rng, alpha: F, degree: usize) {
 		let coeffs = RoundCoeffs(random_scalars(&mut rng, degree + 1));
 
-		let v0 = coeffs.evaluate(F::ZERO);
-		let v1 = coeffs.evaluate(F::ONE);
+		let v0 = coeffs.evaluate(&F::ZERO);
+		let v1 = coeffs.evaluate(&F::ONE);
 		let eval = extrapolate_line_packed(v0, v1, alpha);
 
 		let proof = RoundProof::truncate(coeffs.clone());

--- a/crates/ip/src/sumcheck/batch.rs
+++ b/crates/ip/src/sumcheck/batch.rs
@@ -47,7 +47,7 @@ where
 	// Random linear-combination coefficient that binds all sum claims together.
 	let batch_coeff = channel.sample();
 	// Combine the individual sum claims into a single scalar for sumcheck verification.
-	let sum = evaluate_univariate(sums, batch_coeff.clone());
+	let sum = evaluate_univariate(sums, &batch_coeff);
 
 	let SumcheckOutput { eval, challenges } =
 		sumcheck::verify::<F, C>(n_vars, degree, sum, channel)?;
@@ -77,7 +77,7 @@ where
 	// Random linear-combination coefficient that binds all eval claims together.
 	let batch_coeff = channel.sample();
 	// Combine the individual eval claims into a single scalar for MLE-check verification.
-	let eval = evaluate_univariate(evals, batch_coeff.clone());
+	let eval = evaluate_univariate(evals, &batch_coeff);
 
 	let SumcheckOutput { eval, challenges } =
 		mlecheck::verify::<F, C>(point, degree, eval, channel)?;

--- a/crates/ip/src/sumcheck/common.rs
+++ b/crates/ip/src/sumcheck/common.rs
@@ -42,7 +42,7 @@ impl<F> RoundCoeffs<F> {
 
 impl<F: FieldOps> RoundCoeffs<F> {
 	/// Evaluate the polynomial at a point.
-	pub fn evaluate(&self, x: F) -> F {
+	pub fn evaluate(&self, x: &F) -> F {
 		// Horner's method over the monomial coefficients.
 		evaluate_univariate(&self.0, x)
 	}
@@ -261,7 +261,7 @@ mod tests {
 			let recovered = coeffs.truncate().recover(sum);
 
 			// Evaluate the recovered polynomial at both endpoints and confirm they sum to s.
-			assert_eq!(recovered.evaluate(B128::ZERO) + recovered.evaluate(B128::ONE), sum);
+			assert_eq!(recovered.evaluate(&B128::ZERO) + recovered.evaluate(&B128::ONE), sum);
 		}
 	}
 
@@ -272,7 +272,7 @@ mod tests {
 		for degree in DEGREES {
 			let coeffs = RoundCoeffs(random_scalars::<B128>(&mut rng, degree + 1));
 			// Direct evaluation at the two endpoints.
-			let expected = coeffs.evaluate(B128::ZERO) + coeffs.evaluate(B128::ONE);
+			let expected = coeffs.evaluate(&B128::ZERO) + coeffs.evaluate(&B128::ONE);
 			// The shortcut must agree with direct evaluation.
 			assert_eq!(coeffs.sum_over_endpoints(), expected);
 		}
@@ -288,8 +288,8 @@ mod tests {
 			let alpha = B128::random(&mut rng);
 
 			// The two endpoint values that define the line.
-			let r_0 = coeffs.evaluate(B128::ZERO);
-			let r_1 = coeffs.evaluate(B128::ONE);
+			let r_0 = coeffs.evaluate(&B128::ZERO);
+			let r_1 = coeffs.evaluate(&B128::ONE);
 			// The point on that line at alpha: R(0) + alpha * (R(1) - R(0)).
 			let expected = r_0 + alpha * (r_1 - r_0);
 
@@ -318,9 +318,9 @@ mod tests {
 		let x = B128::random(&mut rng);
 
 		// Longer accumulator, shorter addend: the accumulator keeps its high-degree tail.
-		assert_eq!((long.clone() + &short).evaluate(x), long.evaluate(x) + short.evaluate(x));
+		assert_eq!((long.clone() + &short).evaluate(&x), long.evaluate(&x) + short.evaluate(&x));
 		// Shorter accumulator, longer addend: the accumulator is padded up to the larger degree.
-		assert_eq!((short.clone() + &long).evaluate(x), short.evaluate(x) + long.evaluate(x));
+		assert_eq!((short.clone() + &long).evaluate(&x), short.evaluate(&x) + long.evaluate(&x));
 	}
 
 	#[test]
@@ -332,7 +332,7 @@ mod tests {
 		let x = B128::random(&mut rng);
 
 		// (c * R)(x) must equal c * R(x).
-		assert_eq!((coeffs.clone() * scalar).evaluate(x), coeffs.evaluate(x) * scalar);
+		assert_eq!((coeffs.clone() * scalar).evaluate(&x), coeffs.evaluate(&x) * scalar);
 	}
 
 	#[test]
@@ -348,9 +348,9 @@ mod tests {
 		// Fold the polynomials together with the iterator sum.
 		let total: RoundCoeffs<B128> = parts.iter().cloned().sum();
 		// Reference: add the individual evaluations at x.
-		let expected: B128 = parts.iter().map(|c| c.evaluate(x)).sum();
+		let expected: B128 = parts.iter().map(|c| c.evaluate(&x)).sum();
 
-		assert_eq!(total.evaluate(x), expected);
+		assert_eq!(total.evaluate(&x), expected);
 	}
 
 	#[test]
@@ -358,7 +358,7 @@ mod tests {
 		// A polynomial with no coefficients is the zero polynomial.
 		let coeffs = RoundCoeffs::<B128>(vec![]);
 		// It evaluates to zero everywhere.
-		assert_eq!(coeffs.evaluate(B128::random(rng())), B128::ZERO);
+		assert_eq!(coeffs.evaluate(&B128::random(rng())), B128::ZERO);
 		// Both endpoints are zero, so their sum is zero.
 		assert_eq!(coeffs.sum_over_endpoints(), B128::ZERO);
 		// The line through (0, 0) and (1, 0) is zero at every alpha.

--- a/crates/ip/src/sumcheck/verify.rs
+++ b/crates/ip/src/sumcheck/verify.rs
@@ -52,7 +52,7 @@ where
 		let challenge = channel.sample();
 
 		let round_coeffs = round_proof.recover(sum);
-		sum = round_coeffs.evaluate(challenge.clone());
+		sum = round_coeffs.evaluate(&challenge);
 		challenges.push(challenge);
 	}
 

--- a/crates/m4-prover/src/operand_witness.rs
+++ b/crates/m4-prover/src/operand_witness.rs
@@ -373,7 +373,7 @@ mod tests {
 		let univariate_domain = BinarySubspace::<B8>::with_dim(Word::LOG_BITS + 1)
 			.isomorphic::<B128>()
 			.reduce_dim(SKIPPED_VARS);
-		let lagrange = lagrange_evals_scalars(&univariate_domain, z_challenge);
+		let lagrange = lagrange_evals_scalars(&univariate_domain, &z_challenge);
 		let folded: FieldBuffer<B128> = BitAxisFolder::new(&lagrange).fold(&GlobalAllocator, col);
 		evaluate(&folded, eval_point)
 	}

--- a/crates/m4-prover/src/prove.rs
+++ b/crates/m4-prover/src/prove.rs
@@ -244,7 +244,7 @@ impl IOPProver {
 			// oblong claims at their own instance point.
 			// BitAnd is already oblong.
 			// IntMul and BinMul are collapsed from their per-bit form.
-			let lagrange = lagrange_evals_scalars::<B128, B128>(&shift_domain, z_challenge);
+			let lagrange = lagrange_evals_scalars::<B128, B128>(&shift_domain, &z_challenge);
 			let and_columns = and_columns
 				.expect("AND columns are retained whenever there are IMUL or BMUL constraints");
 			let log_instances = table.log_instances();

--- a/crates/m4-prover/src/shift.rs
+++ b/crates/m4-prover/src/shift.rs
@@ -226,9 +226,9 @@ where
 	);
 
 	run_sumcheck::<F, P, _, _>(
-		public_folded,
+		&public_folded,
 		hidden_folded,
-		public_monster,
+		&public_monster,
 		hidden_monster,
 		public_words,
 		r_j,
@@ -479,7 +479,7 @@ mod tests {
 		r_rho: &[B128],
 	) -> [B128; 3] {
 		let [a, b] = build_operation_columns(table, constants, and_constraints, &GlobalAllocator);
-		let lagrange = lagrange_evals_scalars::<B128, B128>(domain_subspace, r_z);
+		let lagrange = lagrange_evals_scalars::<B128, B128>(domain_subspace, &r_z);
 		let row_point: Vec<B128> = r_rho.iter().chain(r_x).copied().collect();
 		let operand_eval = |column: &[Word]| {
 			let folded_column = fold_words::<B128, P, _>(&GlobalAllocator, column, &lagrange);

--- a/crates/m4-verifier/src/verify.rs
+++ b/crates/m4-verifier/src/verify.rs
@@ -199,7 +199,7 @@ impl IOPVerifier {
 			// instance point. BitAnd is already oblong; IntMul and BinMul are collapsed from their
 			// per-bit form.
 			let lagrange =
-				lagrange_evals_scalars::<B128, Channel::Elem>(&shift_domain, z_challenge.clone());
+				lagrange_evals_scalars::<B128, Channel::Elem>(&shift_domain, &z_challenge);
 			RerandomizedOperations {
 				bitand: OperationClaim::new([a_eval, b_eval, c_eval], r_x_and, r_rho_and),
 				intmul: intmul_output
@@ -306,7 +306,7 @@ impl Verifier {
 		let n_test_queries = calculate_n_test_queries(SECURITY_BITS, log_inv_rate);
 
 		let iop_compiler = BaseFoldVerifierCompiler::new(
-			merkle_scheme,
+			&merkle_scheme,
 			oracle_specs,
 			log_inv_rate,
 			n_test_queries,
@@ -557,7 +557,7 @@ impl<F: FieldOps> RerandomizedOperations<F> {
 			let eq_binmul = eq_ind(&binmul.r_rho, &r_rho);
 			expected.extend(evals.iter().map(|eval| eval.clone() * &eq_binmul));
 		}
-		channel.assert_zero(evaluate_univariate(&expected, batch_coeff) - eval)?;
+		channel.assert_zero(evaluate_univariate(&expected, &batch_coeff) - eval)?;
 
 		let bitand_data = OperatorData::new(self.bitand.r_x, bitand_evals);
 		let intmul_data = match (self.intmul, intmul_evals) {

--- a/crates/math/src/field_buffer.rs
+++ b/crates/math/src/field_buffer.rs
@@ -49,6 +49,8 @@ pub struct FieldBuffer<P: PackedField, Data: Deref<Target = [P]> = Vec<P>> {
 	values: Data,
 }
 
+impl<P: PackedField, Data: Deref<Target = [P]> + Copy> Copy for FieldBuffer<P, Data> {}
+
 impl<P: PackedField, Data: Deref<Target = [P]>> PartialEq for FieldBuffer<P, Data> {
 	fn eq(&self, other: &Self) -> bool {
 		// Equality compares only the live scalars, never the raw packed backing store.
@@ -657,7 +659,7 @@ impl<'a, P: PackedField, Data: DerefMut<Target = [P]>> From<&'a mut FieldBuffer<
 	}
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub enum FieldSliceData<'a, P> {
 	Single(P),
 	Slice(&'a [P]),

--- a/crates/math/src/multilinear/fold.rs
+++ b/crates/math/src/multilinear/fold.rs
@@ -92,7 +92,7 @@ pub fn fold_highest_var<A: Allocator, P: PackedField, Data: Deref<Target = [P]>>
 pub fn binary_fold_high<P, DataOut, DataIn>(
 	values: &mut FieldBuffer<P, DataOut>,
 	tensor: &FieldBuffer<P, DataIn>,
-	bits: impl RandomAccessSequence<bool> + Sync,
+	bits: &(impl RandomAccessSequence<bool> + Sync),
 ) where
 	P: PackedField,
 	DataOut: DerefMut<Target = [P]>,
@@ -238,7 +238,7 @@ mod tests {
 		let mut bits_buffer = FieldBuffer::<P>::from_values(&bits_scalars);
 
 		let mut binary_fold_result = FieldBuffer::<P>::zeros(n_vars - tensor_n_vars);
-		binary_fold_high(&mut binary_fold_result, &tensor, bits.as_slice());
+		binary_fold_high(&mut binary_fold_result, &tensor, &bits.as_slice());
 
 		for &scalar in point.iter().rev() {
 			fold_highest_var_inplace(&mut bits_buffer, scalar);

--- a/crates/math/src/ntt/tests_evaluation.rs
+++ b/crates/math/src/ntt/tests_evaluation.rs
@@ -188,7 +188,7 @@ impl<F: Field> MulAssign<F> for Polynomial<F> {
 /// Computes the subspace polynomial of a given binary field subspace $V$.
 ///
 /// That is, it computes $\prod_{a \in V} (X - a)$.
-fn subspace_polynomial<F: BinaryField>(subspace: BinarySubspace<F>) -> Polynomial<F> {
+fn subspace_polynomial<F: BinaryField>(subspace: &BinarySubspace<F>) -> Polynomial<F> {
 	let mut poly = Polynomial::one();
 
 	for elem in subspace.iter() {
@@ -219,8 +219,7 @@ fn novel_basis<DC: DomainContext>(domain_context: &DC) -> Vec<Polynomial<DC::Fie
 
 	// collect subspace polynomials $W_i$ (this is *not* yet $\hat{W}_i$)
 	let mut w_hat: Vec<_> = (0..log_d)
-		.map(|i| domain.reduce_dim(i))
-		.map(subspace_polynomial)
+		.map(|i| subspace_polynomial(&domain.reduce_dim(i)))
 		.collect();
 	// and normalize them to get $\hat{W}_i$
 	for i in 0..log_d {

--- a/crates/math/src/ntt/tests_reference.rs
+++ b/crates/math/src/ntt/tests_reference.rs
@@ -185,7 +185,7 @@ impl<F: BinaryField> NTTFactory<F> for NeighborsLastMultiThreadFactory {
 	NeighborsLastMultiThreadFactory { log_base_len: 3, log_num_shares: 1000 }
 )]
 fn test_forward_transform_is_identity(#[case] ntt_factory: impl NTTFactory<B128>) {
-	fn test_forward_transform_is_identity_helper<F, P>(ntt_factory: impl NTTFactory<F>)
+	fn test_forward_transform_is_identity_helper<F, P>(ntt_factory: &impl NTTFactory<F>)
 	where
 		F: BinaryField,
 		P: PackedField<Scalar = F>,
@@ -204,7 +204,7 @@ fn test_forward_transform_is_identity(#[case] ntt_factory: impl NTTFactory<B128>
 		assert_eq!(data, data_clone);
 	}
 
-	test_forward_transform_is_identity_helper::<_, Packed128b>(ntt_factory);
+	test_forward_transform_is_identity_helper::<_, Packed128b>(&ntt_factory);
 }
 
 fn test_equivalence_ntts_domain_contexts<P: PackedField>()

--- a/crates/math/src/tensor_algebra.rs
+++ b/crates/math/src/tensor_algebra.rs
@@ -76,9 +76,9 @@ where
 	}
 
 	/// Multiply by an element from the vertical subring.
-	pub fn scale_vertical(mut self, scalar: FE) -> Self {
+	pub fn scale_vertical(mut self, scalar: &FE) -> Self {
 		for elem_i in &mut self.elems {
-			*elem_i *= scalar.clone();
+			*elem_i *= scalar;
 		}
 		self
 	}
@@ -88,7 +88,7 @@ where
 	/// Internally, this performs a transpose, vertical scaling, then transpose sequence. If
 	/// multiple horizontal scaling operations are required and performance is a concern, it may be
 	/// better for the caller to do the transposes directly and amortize their cost.
-	pub fn scale_horizontal(self, scalar: FE) -> Self {
+	pub fn scale_horizontal(self, scalar: &FE) -> Self {
 		self.transpose().scale_vertical(scalar).transpose()
 	}
 
@@ -233,7 +233,7 @@ mod tests {
 		let vert = FE::random(&mut rng);
 		let hztl = FE::random(&mut rng);
 
-		let expected = TensorAlgebra::<F, _>::from_vertical(vert).scale_horizontal(hztl);
+		let expected = TensorAlgebra::<F, _>::from_vertical(vert).scale_horizontal(&hztl);
 		assert_eq!(TensorAlgebra::tensor(vert, hztl), expected);
 	}
 
@@ -250,18 +250,18 @@ mod tests {
 
 		// Scale horizontally by an extension element, and we should no longer be vertical.
 		let hztl = FE::new(1111);
-		let elem = elem.scale_horizontal(hztl);
+		let elem = elem.scale_horizontal(&hztl);
 		assert_eq!(elem.try_extract_vertical(), None);
 
 		// Scale back by the inverse to get back to the vertical subring.
 		// Safety: `hztl` is the non-zero constant 1111.
 		let hztl_inv = unsafe { hztl.invert() };
-		let elem = elem.scale_horizontal(hztl_inv);
+		let elem = elem.scale_horizontal(&hztl_inv);
 		assert_eq!(elem.try_extract_vertical(), Some(vert));
 
 		// If we scale horizontally by an F element, we should remain in the vertical subring.
 		let hztl_subfield = FE::from(F::ONE);
-		let elem = elem.scale_horizontal(hztl_subfield);
+		let elem = elem.scale_horizontal(&hztl_subfield);
 		assert_eq!(elem.try_extract_vertical(), Some(vert * hztl_subfield));
 	}
 }

--- a/crates/math/src/univariate.rs
+++ b/crates/math/src/univariate.rs
@@ -11,7 +11,7 @@ use super::{BinarySubspace, FieldBuffer};
 /// # Arguments
 /// * `coeffs` - Slice of coefficients ordered from low-degree terms to high-degree terms
 /// * `x` - Point at which to evaluate the polynomial
-pub fn evaluate_univariate<F: FieldOps>(coeffs: &[F], x: F) -> F {
+pub fn evaluate_univariate<F: FieldOps>(coeffs: &[F], x: &F) -> F {
 	let Some((highest_degree, rest)) = coeffs.split_last() else {
 		return F::zero();
 	};
@@ -19,7 +19,7 @@ pub fn evaluate_univariate<F: FieldOps>(coeffs: &[F], x: F) -> F {
 	// Evaluate using Horner's method
 	rest.iter()
 		.rev()
-		.fold(highest_degree.clone(), |acc, coeff| acc * &x + coeff)
+		.fold(highest_degree.clone(), |acc, coeff| acc * x + coeff)
 }
 
 /// Optimized Lagrange evaluation for power-of-2 domains in binary fields.
@@ -46,7 +46,7 @@ pub fn evaluate_univariate<F: FieldOps>(coeffs: &[F], x: F) -> F {
 /// # Returns
 /// A vector of Lagrange polynomial evaluations, one for each domain element
 pub fn lagrange_evals<F: BinaryField>(subspace: &BinarySubspace<F>, z: F) -> FieldBuffer<F> {
-	let result = lagrange_evals_scalars(subspace, z);
+	let result = lagrange_evals_scalars(subspace, &z);
 	FieldBuffer::new(subspace.dim(), result)
 }
 
@@ -63,7 +63,7 @@ pub fn lagrange_evals<F: BinaryField>(subspace: &BinarySubspace<F>, z: F) -> Fie
 /// A vector of Lagrange polynomial evaluations, one for each domain element
 pub fn lagrange_evals_scalars<F: BinaryField, E: FieldOps + From<F>>(
 	subspace: &BinarySubspace<F>,
-	z: E,
+	z: &E,
 ) -> Vec<E> {
 	let domain: Vec<E> = subspace.iter().map(E::from).collect();
 	let n = domain.len();
@@ -113,7 +113,7 @@ pub fn lagrange_evals_scalars<F: BinaryField, E: FieldOps + From<F>>(
 pub fn extrapolate_over_subspace<F: BinaryField, E: FieldOps + From<F>>(
 	subspace: &BinarySubspace<F>,
 	values: &[E],
-	z: E,
+	z: &E,
 ) -> E {
 	let n = 1 << subspace.dim();
 	assert_eq!(values.len(), n);
@@ -271,7 +271,7 @@ mod tests {
 			let coeffs = random_scalars(&mut rng, n_coeffs);
 			let x = F::random(&mut rng);
 			assert_eq!(
-				evaluate_univariate(&coeffs, x),
+				evaluate_univariate(&coeffs, &x),
 				evaluate_univariate_with_powers(&coeffs, x)
 			);
 		}
@@ -320,7 +320,7 @@ mod tests {
 		// Evaluate polynomial at domain points
 		let domain_evals: Vec<F> = domain
 			.iter()
-			.map(|&point| evaluate_univariate(&coeffs, point))
+			.map(|&point| evaluate_univariate(&coeffs, &point))
 			.collect();
 
 		// Test interpolation at random point
@@ -328,7 +328,7 @@ mod tests {
 		let lagrange_coeffs = lagrange_evals(&subspace, test_point);
 		let interpolated =
 			inner_product(domain_evals.iter().copied(), lagrange_coeffs.iter_scalars());
-		let direct = evaluate_univariate(&coeffs, test_point);
+		let direct = evaluate_univariate(&coeffs, &test_point);
 
 		assert_eq!(interpolated, direct, "Polynomial interpolation accuracy failed");
 	}
@@ -345,11 +345,11 @@ mod tests {
 		let values = domain
 			.points()
 			.iter()
-			.map(|&x| evaluate_univariate(&coeffs, x))
+			.map(|&x| evaluate_univariate(&coeffs, &x))
 			.collect::<Vec<_>>();
 
 		let x = B128::random(&mut rng);
-		let expected_y = evaluate_univariate(&coeffs, x);
+		let expected_y = evaluate_univariate(&coeffs, &x);
 		assert_eq!(domain.extrapolate(&values, x), expected_y);
 	}
 
@@ -379,13 +379,13 @@ mod tests {
 			// Evaluate at all domain points
 			let values: Vec<F> = subspace
 				.iter()
-				.map(|point| evaluate_univariate(&coeffs, point))
+				.map(|point| evaluate_univariate(&coeffs, &point))
 				.collect();
 
 			// Extrapolate at a random point
 			let z = F::random(&mut rng);
-			let extrapolated = extrapolate_over_subspace(&subspace, &values, z);
-			let expected = evaluate_univariate(&coeffs, z);
+			let extrapolated = extrapolate_over_subspace(&subspace, &values, &z);
+			let expected = evaluate_univariate(&coeffs, &z);
 
 			assert_eq!(extrapolated, expected, "Mismatch for log_domain_size={log_domain_size}");
 		}
@@ -403,8 +403,8 @@ mod tests {
 			let values: Vec<F> = random_scalars(&mut rng, n);
 
 			let z = F::random(&mut rng);
-			let extrapolated = extrapolate_over_subspace(&subspace, &values, z);
-			let lagrange = lagrange_evals_scalars(&subspace, z);
+			let extrapolated = extrapolate_over_subspace(&subspace, &values, &z);
+			let lagrange = lagrange_evals_scalars(&subspace, &z);
 			let expected = inner_product(values.iter().copied(), lagrange);
 
 			assert_eq!(extrapolated, expected, "Mismatch for log_domain_size={log_domain_size}");

--- a/crates/prover/benches/and_reduction.rs
+++ b/crates/prover/benches/and_reduction.rs
@@ -96,7 +96,7 @@ fn bench(c: &mut Criterion) {
 
 	group.bench_function(format!("univariate fold 2^{log_words}"), |bench| {
 		bench.iter(|| {
-			let lagrange_evals = lagrange_evals_scalars(&univariate_domain, univariate_challenge);
+			let lagrange_evals = lagrange_evals_scalars(&univariate_domain, &univariate_challenge);
 			let folder = BitAxisFolder::new(&lagrange_evals);
 			folder.fold_bitand_operands::<OptimalPackedB128, _>(
 				&GlobalAllocator,
@@ -106,7 +106,7 @@ fn bench(c: &mut Criterion) {
 		});
 	});
 
-	let lagrange_evals = lagrange_evals_scalars(&univariate_domain, univariate_challenge);
+	let lagrange_evals = lagrange_evals_scalars(&univariate_domain, &univariate_challenge);
 	let folder = BitAxisFolder::new(&lagrange_evals);
 
 	let mut univariate_message_coeffs = vec![B128::ZERO; 2 * ROWS_PER_HYPERCUBE_VERTEX];
@@ -116,7 +116,7 @@ fn bench(c: &mut Criterion) {
 	let next_round_claim = extrapolate_over_subspace(
 		&prover_message_domain.clone().isomorphic::<B128>(),
 		&univariate_message_coeffs,
-		univariate_challenge,
+		&univariate_challenge,
 	);
 
 	let pool = BufferPool::new();

--- a/crates/prover/benches/intmul.rs
+++ b/crates/prover/benches/intmul.rs
@@ -55,7 +55,7 @@ const N_TEST_QUERIES: usize = 1;
 fn basefold_compiler() -> BaseFoldProverCompiler<P, NeighborsLastSingleThread<GenericPreExpanded<F>>>
 {
 	let verifier_compiler = BaseFoldVerifierCompiler::new(
-		BinaryMerkleTreeScheme::<F, StdHashSuite>::new(),
+		&BinaryMerkleTreeScheme::<F, StdHashSuite>::new(),
 		vec![OracleSpec::new(LIMB_BITS)],
 		LOG_INV_RATE,
 		N_TEST_QUERIES,

--- a/crates/prover/benches/shift_reduction.rs
+++ b/crates/prover/benches/shift_reduction.rs
@@ -387,9 +387,9 @@ fn bench_shift_phases(c: &mut Criterion) {
 			|(public_folded, hidden_folded, public_monster, hidden_monster, r_j)| {
 				let mut transcript = ProverTranscript::<StdChallenger>::default();
 				run_sumcheck::<F, P, _, _>(
-					public_folded,
+					&public_folded,
 					hidden_folded,
-					public_monster,
+					&public_monster,
 					hidden_monster,
 					public_words,
 					r_j,

--- a/crates/prover/src/and_reduction/mod.rs
+++ b/crates/prover/src/and_reduction/mod.rs
@@ -68,7 +68,7 @@ where
 		a,
 		b,
 		big_field_zerocheck_challenges,
-		prover_message_domain,
+		&prover_message_domain,
 	);
 
 	prover.prove_with_channel(channel, alloc)

--- a/crates/prover/src/and_reduction/prover.rs
+++ b/crates/prover/src/and_reduction/prover.rs
@@ -89,7 +89,7 @@ where
 		first_col: Data,
 		second_col: Data,
 		big_field_zerocheck_challenges: Vec<F>,
-		prover_message_domain: BinarySubspace<B8>,
+		prover_message_domain: &BinarySubspace<B8>,
 	) -> Self {
 		let univariate_round_message = tracing::debug_span!("Compute univariate round message")
 			.in_scope(|| {
@@ -98,7 +98,7 @@ where
 					&first_col,
 					&second_col,
 					&big_field_zerocheck_challenges,
-					&prover_message_domain,
+					prover_message_domain,
 				)
 			});
 
@@ -162,12 +162,12 @@ where
 	/// 5. Constructs the AND reduction sumcheck prover with the folded multilinears
 	pub fn fold_and_send_reduced_prover<'alloc, A: Allocator>(
 		self,
-		round_message_domain: BinarySubspace<F>,
+		round_message_domain: &BinarySubspace<F>,
 		challenge: F,
 		alloc: &'alloc A,
 	) -> impl MleCheckProver<F> + 'alloc {
 		let univariate_domain = round_message_domain.reduce_dim(round_message_domain.dim() - 1);
-		let lagrange_evals = lagrange_evals_scalars(&univariate_domain, challenge);
+		let lagrange_evals = lagrange_evals_scalars(&univariate_domain, &challenge);
 		let folder = BitAxisFolder::new(&lagrange_evals);
 
 		let proving_polys =
@@ -195,9 +195,9 @@ where
 			|[a, b, _]| a * b,
 			verifier_field_zerocheck_challenges,
 			extrapolate_over_subspace(
-				&round_message_domain,
+				round_message_domain,
 				&first_round_message_coeffs,
-				challenge,
+				&challenge,
 			),
 		)
 	}
@@ -239,7 +239,7 @@ where
 		let univariate_round_message_domain = self.univariate_round_message_domain.clone();
 		let sumcheck_prover = tracing::debug_span!("Fold univariate round").in_scope(|| {
 			self.fold_and_send_reduced_prover(
-				univariate_round_message_domain,
+				&univariate_round_message_domain,
 				univariate_sumcheck_challenge,
 				alloc,
 			)
@@ -324,7 +324,7 @@ mod test {
 			first_mlv.clone(),
 			second_mlv.clone(),
 			big_field_zerocheck_challenges.to_vec(),
-			prover_message_domain,
+			&prover_message_domain,
 		);
 
 		let prove_output = prover.prove_with_channel(&mut prover_challenger, &GlobalAllocator);
@@ -366,7 +366,7 @@ mod test {
 		let one_bit_mlvs = [first_mlv, second_mlv, third_mlv];
 
 		let verifier_lagrange_evals =
-			lagrange_evals_scalars(&verifier_univariate_domain, z_challenge);
+			lagrange_evals_scalars(&verifier_univariate_domain, &z_challenge);
 		let folder = BitAxisFolder::new(&verifier_lagrange_evals);
 		for (i, eval) in [a_eval, b_eval, c_eval].iter().enumerate() {
 			let folded: FieldBuffer<B128> = folder.fold(&GlobalAllocator, &one_bit_mlvs[i]);

--- a/crates/prover/src/and_reduction/sumcheck_round_messages.rs
+++ b/crates/prover/src/and_reduction/sumcheck_round_messages.rs
@@ -351,11 +351,11 @@ mod test {
 		let expected_next_round_sum = extrapolate_over_subspace(
 			&verifier_message_domain,
 			&first_round_message_coeffs,
-			first_sumcheck_challenge,
+			&first_sumcheck_challenge,
 		);
 
 		let lagrange_evals =
-			lagrange_evals_scalars(&verifier_input_domain, first_sumcheck_challenge);
+			lagrange_evals_scalars(&verifier_input_domain, &first_sumcheck_challenge);
 		let folder = BitAxisFolder::new(&lagrange_evals);
 
 		let folded_first_mle: FieldBuffer<B128> = folder.fold(&GlobalAllocator, mlv_1);

--- a/crates/prover/src/protocols/intmul/witness.rs
+++ b/crates/prover/src/protocols/intmul/witness.rs
@@ -216,6 +216,8 @@ where
 /// The root fields are consumed by the phase provers as ordinary `FieldBuffer`s; the pooled block
 /// cannot be handed out as a `Vec` directly (its allocation is over-aligned for the free list), so
 /// it is copied out and the pooled block recycled.
+// Takes `src` by value so the pooled block returns to the free list here, not at the caller.
+#[allow(clippy::needless_pass_by_value)]
 fn unpool<A: Allocator, P: PackedField>(src: FieldVec<P, A>) -> FieldBuffer<P> {
 	FieldBuffer::new(src.log_len(), src.as_ref().to_vec())
 }

--- a/crates/prover/src/protocols/shift/phase_2.rs
+++ b/crates/prover/src/protocols/shift/phase_2.rs
@@ -101,9 +101,9 @@ where
 	);
 
 	run_sumcheck(
-		public_folded,
+		&public_folded,
 		hidden_folded,
-		public_monster,
+		&public_monster,
 		hidden_monster,
 		public_words,
 		r_j,
@@ -215,9 +215,9 @@ fn fold_segments<F: Field, P: PackedField<Scalar = F>, Data: DerefMut<Target = [
 #[allow(clippy::too_many_arguments)]
 #[instrument(skip_all, name = "run_sumcheck")]
 pub fn run_sumcheck<F, P: PackedField<Scalar = F>, Channel: IPProverChannel<F>, A: Allocator>(
-	public_folded: FieldVec<P, A>,
+	public_folded: &FieldVec<P, A>,
 	hidden_folded: FieldVec<P, A>,
-	public_monster: FieldVec<P, A>,
+	public_monster: &FieldVec<P, A>,
 	hidden_monster: FieldVec<P, A>,
 	public_words: &[Word],
 	r_j: Vec<F>,
@@ -235,15 +235,15 @@ where
 
 	// Round 1: bind the segment selector.
 	let round_coeffs =
-		first_round_coeffs(&public_folded, &hidden_folded, &public_monster, &hidden_monster, gamma);
+		first_round_coeffs(public_folded, &hidden_folded, public_monster, &hidden_monster, gamma);
 	channel.send_many(round_coeffs.clone().truncate().coeffs());
 	let alpha = channel.sample();
-	let round_sum = round_coeffs.evaluate(alpha);
+	let round_sum = round_coeffs.evaluate(&alpha);
 
 	// Fold the segment pairs at the selector challenge and run the remaining rounds with the
 	// standard prover.
-	let folded_witness = fold_segments(&public_folded, hidden_folded, alpha);
-	let folded_monster = fold_segments(&public_monster, hidden_monster, alpha);
+	let folded_witness = fold_segments(public_folded, hidden_folded, alpha);
+	let folded_monster = fold_segments(public_monster, hidden_monster, alpha);
 	let prover = bivariate_product_prover(alloc, [folded_witness, folded_monster], round_sum);
 
 	let ProveSingleOutput {

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -87,7 +87,7 @@ impl IOPProver {
 	/// For most users, [`Prover::prove`] is the simpler interface.
 	pub fn prove<A, P, Channel>(
 		&self,
-		witness: ValueVec,
+		witness: &ValueVec,
 		channel: &mut Channel,
 		alloc: &A,
 	) -> Result<(), Error>
@@ -140,7 +140,7 @@ impl IOPProver {
 			)
 			.entered();
 			let mul_columns = tracing::debug_span!("Assemble columns")
-				.in_scope(|| build_operation_columns(&cs.imul_constraints, &witness, alloc));
+				.in_scope(|| build_operation_columns(&cs.imul_constraints, witness, alloc));
 
 			let [a, b, lo, hi] = &mul_columns;
 			let intmul_output = intmul::prove::<_, _, P, _>([a, b, lo, hi], &mut *channel, alloc)?;
@@ -163,7 +163,7 @@ impl IOPProver {
 			)
 			.entered();
 			let binmul_columns = tracing::debug_span!("Assemble columns")
-				.in_scope(|| build_operation_columns(&cs.bmul_constraints, &witness, alloc));
+				.in_scope(|| build_operation_columns(&cs.bmul_constraints, witness, alloc));
 
 			let [a_lo, a_hi, b_lo, b_hi, c_lo, c_hi] = &binmul_columns;
 			let binmul_output = binmul::prove::<_, _, P, _>(
@@ -184,7 +184,7 @@ impl IOPProver {
 		let bitand_claim = {
 			// Only the `A` and `B` columns are built; the reduction derives `C = A & B`.
 			let bitand_columns = tracing::debug_span!("Assemble columns")
-				.in_scope(|| build_operation_columns(&cs.and_constraints, &witness, alloc));
+				.in_scope(|| build_operation_columns(&cs.and_constraints, witness, alloc));
 
 			let AndCheckOutput {
 				a_eval,
@@ -432,7 +432,7 @@ where
 
 	pub fn prove<Challenger_: Challenger>(
 		&self,
-		witness: ValueVec,
+		witness: &ValueVec,
 		transcript: &mut ProverTranscript<Challenger_>,
 	) -> Result<(), Error> {
 		let cs = self.iop_prover.constraint_system();

--- a/crates/prover/src/ring_switch.rs
+++ b/crates/prover/src/ring_switch.rs
@@ -187,6 +187,8 @@ where
 /// * `S` must be a power of two
 /// * `LOG_N` must be less than or equal to `P::LOG_WIDTH`
 /// * `LOG_N` must be less than or equal to `log2(S)`
+// The array of `&mut` lanes is itself a cheap borrow bundle; passing it by value is the point.
+#[allow(clippy::needless_pass_by_value)]
 fn square_transpose_const_size<P: PackedField, const LOG_N: usize, const S: usize>(
 	elems: [&mut P; S],
 ) {

--- a/crates/prover/src/zk_config.rs
+++ b/crates/prover/src/zk_config.rs
@@ -62,7 +62,7 @@ where
 	Output<H::LeafHash>: SerializeBytes,
 {
 	/// Constructs a ZK prover from a [`ZKVerifier`].
-	pub fn setup(zk_verifier: ZKVerifier<H>) -> Result<Self, Error> {
+	pub fn setup(zk_verifier: &ZKVerifier<H>) -> Result<Self, Error> {
 		let key_collection = {
 			let _guard = tracing::debug_span!("Build key collection").entered();
 			build_key_collection(zk_verifier.inner_iop_verifier().constraint_system())
@@ -74,7 +74,7 @@ where
 	/// dominant key-collection build. Private: external callers use [`Self::setup`], or
 	/// [`DeserializeBytes::deserialize`] to reuse a serialized prover.
 	fn setup_with_key_collection(
-		zk_verifier: ZKVerifier<H>,
+		zk_verifier: &ZKVerifier<H>,
 		key_collection: KeyCollection,
 	) -> Result<Self, Error> {
 		// Build the inner IOPProver.
@@ -128,12 +128,12 @@ where
 	/// Generates a ZK proof for a witness.
 	pub fn prove<Challenger_: Challenger>(
 		&self,
-		witness: ValueVec,
+		witness: &ValueVec,
 		mut rng: impl CryptoRng,
 		transcript: &mut ProverTranscript<Challenger_>,
 	) -> Result<(), Error> {
-		// Clone public words before moving witness into prove().
-		let public_words = witness.public().to_vec();
+		// The replay closure captures the public words as a borrowed slice.
+		let public_words = witness.public();
 
 		// Working buffers for this proof are drawn from the prover's pool, recycling blocks freed
 		// by earlier proofs. The inner IOP proof and the outer wrapper proof (run inside
@@ -154,7 +154,7 @@ where
 				let inner_iop_verifier = &self.inner_iop_verifier;
 				move |replay_channel: &mut ReplayChannel<B128>| {
 					inner_iop_verifier
-						.verify(&public_words, replay_channel)
+						.verify(public_words, replay_channel)
 						.expect("replay verification should not fail");
 				}
 			},
@@ -197,7 +197,7 @@ where
 	/// [`Self::prove`] logic. See [`binius_verifier::signature`] for details.
 	pub fn prove_sig<Challenger_: Challenger>(
 		&self,
-		witness: ValueVec,
+		witness: &ValueVec,
 		message: &[u8],
 		rng: impl CryptoRng,
 		transcript: &mut ProverTranscript<Challenger_>,
@@ -250,7 +250,7 @@ where
 		let key_collection = KeyCollection::deserialize(&mut read_buf)?;
 		let zk_verifier = ZKVerifier::setup(constraint_system, log_inv_rate)
 			.map_err(|_| SerializationError::InvalidConstruction { name: "ZKProver" })?;
-		Self::setup_with_key_collection(zk_verifier, key_collection)
+		Self::setup_with_key_collection(&zk_verifier, key_collection)
 			.map_err(|_| SerializationError::InvalidConstruction { name: "ZKProver" })
 	}
 }

--- a/crates/prover/tests/prove_verify.rs
+++ b/crates/prover/tests/prove_verify.rs
@@ -15,7 +15,7 @@ use binius_utils::{DeserializeBytes, SerializeBytes};
 use binius_verifier::{Verifier, config::StdChallenger, zk_config::ZKVerifier};
 use rand::{SeedableRng, rngs::StdRng};
 
-fn prove_verify(cs: ConstraintSystem, witness: ValueVec) {
+fn prove_verify(cs: ConstraintSystem, witness: &ValueVec) {
 	const LOG_INV_RATE: usize = 1;
 
 	let verifier = Verifier::<StdHashSuite>::setup(cs, LOG_INV_RATE).unwrap();
@@ -23,9 +23,7 @@ fn prove_verify(cs: ConstraintSystem, witness: ValueVec) {
 	let prover = Prover::<OptimalPackedB128, StdHashSuite>::setup(verifier.clone()).unwrap();
 
 	let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
-	prover
-		.prove(witness.clone(), &mut prover_transcript)
-		.unwrap();
+	prover.prove(witness, &mut prover_transcript).unwrap();
 
 	let mut verifier_transcript = prover_transcript.into_verifier();
 	verifier
@@ -34,18 +32,17 @@ fn prove_verify(cs: ConstraintSystem, witness: ValueVec) {
 	verifier_transcript.finalize().unwrap();
 }
 
-fn prove_verify_zk(cs: ConstraintSystem, witness: ValueVec) {
+fn prove_verify_zk(cs: ConstraintSystem, witness: &ValueVec) {
 	const LOG_INV_RATE: usize = 1;
 
 	let zk_verifier = ZKVerifier::<StdHashSuite>::setup(cs, LOG_INV_RATE).unwrap();
 
-	let zk_prover =
-		ZKProver::<OptimalPackedB128, StdHashSuite>::setup(zk_verifier.clone()).unwrap();
+	let zk_prover = ZKProver::<OptimalPackedB128, StdHashSuite>::setup(&zk_verifier).unwrap();
 
 	let mut rng = StdRng::seed_from_u64(0);
 	let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 	zk_prover
-		.prove(witness.clone(), &mut rng, &mut prover_transcript)
+		.prove(witness, &mut rng, &mut prover_transcript)
 		.unwrap();
 
 	let mut verifier_transcript = prover_transcript.into_verifier();
@@ -55,12 +52,11 @@ fn prove_verify_zk(cs: ConstraintSystem, witness: ValueVec) {
 	verifier_transcript.finalize().unwrap();
 }
 
-fn prove_verify_zk_serialized(cs: ConstraintSystem, witness: ValueVec) {
+fn prove_verify_zk_serialized(cs: ConstraintSystem, witness: &ValueVec) {
 	const LOG_INV_RATE: usize = 1;
 
 	let zk_verifier = ZKVerifier::<StdHashSuite>::setup(cs, LOG_INV_RATE).unwrap();
-	let zk_prover =
-		ZKProver::<OptimalPackedB128, StdHashSuite>::setup(zk_verifier.clone()).unwrap();
+	let zk_prover = ZKProver::<OptimalPackedB128, StdHashSuite>::setup(&zk_verifier).unwrap();
 
 	// Round-trip both through serialization, mimicking save-to-disk / reload-in-a-fresh-process.
 	// The reloaded prover (which reuses the deserialized KeyCollection and recomputes the cheaper
@@ -77,7 +73,7 @@ fn prove_verify_zk_serialized(cs: ConstraintSystem, witness: ValueVec) {
 	let mut rng = StdRng::seed_from_u64(0);
 	let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 	zk_prover
-		.prove(witness.clone(), &mut rng, &mut prover_transcript)
+		.prove(witness, &mut rng, &mut prover_transcript)
 		.unwrap();
 
 	let mut verifier_transcript = prover_transcript.into_verifier();
@@ -129,7 +125,7 @@ fn sha256_preimage_circuit() -> (ConstraintSystem, ValueVec) {
 #[test]
 fn test_prove_verify_sha256_preimage() {
 	let (cs, witness) = sha256_preimage_circuit();
-	prove_verify(cs, witness);
+	prove_verify(cs, &witness);
 }
 
 /// Builds a circuit that computes the 7th power of an input GHASH-field element `x` using four
@@ -179,8 +175,8 @@ fn binmul_seventh_power_circuit() -> (ConstraintSystem, ValueVec) {
 fn test_prove_verify_binmul_seventh_power() {
 	let (cs, witness) = binmul_seventh_power_circuit();
 	assert!(cs.n_bmul_constraints() > 0, "circuit should have BMUL constraints");
-	prove_verify(cs.clone(), witness.clone());
-	prove_verify_zk(cs, witness);
+	prove_verify(cs.clone(), &witness);
+	prove_verify_zk(cs, &witness);
 }
 
 /// Builds a circuit whose AND, IMUL and BMUL constraint counts are all non-powers of two, so every
@@ -285,8 +281,8 @@ fn test_prove_verify_non_power_of_two_constraint_counts() {
 			 of two for this test to exercise padding"
 		);
 	}
-	prove_verify(cs.clone(), witness.clone());
-	prove_verify_zk(cs, witness);
+	prove_verify(cs.clone(), &witness);
+	prove_verify_zk(cs, &witness);
 }
 
 /// A SHA-256 circuit uses only AND constraints, so its constraint system has zero IMUL
@@ -297,20 +293,20 @@ fn test_prove_verify_non_power_of_two_constraint_counts() {
 fn test_prove_verify_zero_imul_constraints() {
 	let (cs, witness) = sha256_preimage_circuit();
 	assert_eq!(cs.n_imul_constraints(), 0, "SHA-256 circuit should have no IMUL constraints");
-	prove_verify(cs.clone(), witness.clone());
-	prove_verify_zk(cs, witness);
+	prove_verify(cs.clone(), &witness);
+	prove_verify_zk(cs, &witness);
 }
 
 #[test]
 fn test_zk_prove_verify_sha256_preimage() {
 	let (cs, witness) = sha256_preimage_circuit();
-	prove_verify_zk(cs, witness);
+	prove_verify_zk(cs, &witness);
 }
 
 #[test]
 fn test_zk_prove_verify_serialized() {
 	let (cs, witness) = sha256_preimage_circuit();
-	prove_verify_zk_serialized(cs, witness);
+	prove_verify_zk_serialized(cs, &witness);
 }
 
 /// Produces a ZK signature-of-knowledge proof over `sign_message`, then verifies it against
@@ -319,24 +315,23 @@ fn test_zk_prove_verify_serialized() {
 /// Signatures of knowledge are only supported by the ZK prover/verifier.
 fn sign_verify(
 	cs: ConstraintSystem,
-	witness: ValueVec,
+	witness: &ValueVec,
 	sign_message: Option<&[u8]>,
 	verify_message: Option<&[u8]>,
 ) -> bool {
 	const LOG_INV_RATE: usize = 1;
 
 	let zk_verifier = ZKVerifier::<StdHashSuite>::setup(cs, LOG_INV_RATE).unwrap();
-	let zk_prover =
-		ZKProver::<OptimalPackedB128, StdHashSuite>::setup(zk_verifier.clone()).unwrap();
+	let zk_prover = ZKProver::<OptimalPackedB128, StdHashSuite>::setup(&zk_verifier).unwrap();
 
 	let mut rng = StdRng::seed_from_u64(0);
 	let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 	match sign_message {
 		Some(message) => zk_prover
-			.prove_sig(witness.clone(), message, &mut rng, &mut prover_transcript)
+			.prove_sig(witness, message, &mut rng, &mut prover_transcript)
 			.unwrap(),
 		None => zk_prover
-			.prove(witness.clone(), &mut rng, &mut prover_transcript)
+			.prove(witness, &mut rng, &mut prover_transcript)
 			.unwrap(),
 	}
 
@@ -356,26 +351,26 @@ fn sign_verify(
 fn test_signature_of_knowledge_roundtrip() {
 	let (cs, witness) = sha256_preimage_circuit();
 	// Signing and verifying with the same message succeeds.
-	assert!(sign_verify(cs, witness, Some(b"hello world"), Some(b"hello world")));
+	assert!(sign_verify(cs, &witness, Some(b"hello world"), Some(b"hello world")));
 }
 
 #[test]
 fn test_signature_of_knowledge_wrong_message_fails() {
 	let (cs, witness) = sha256_preimage_circuit();
 	// A proof signed over one message must not verify against a different message.
-	assert!(!sign_verify(cs, witness, Some(b"hello world"), Some(b"goodbye world")));
+	assert!(!sign_verify(cs, &witness, Some(b"hello world"), Some(b"goodbye world")));
 }
 
 #[test]
 fn test_signature_of_knowledge_missing_message_fails() {
 	let (cs, witness) = sha256_preimage_circuit();
 	// A signature of knowledge must not verify as a plain proof of knowledge (no message).
-	assert!(!sign_verify(cs, witness, Some(b"hello world"), None));
+	assert!(!sign_verify(cs, &witness, Some(b"hello world"), None));
 }
 
 #[test]
 fn test_plain_proof_rejects_message() {
 	let (cs, witness) = sha256_preimage_circuit();
 	// A plain proof of knowledge must not verify when a message is supplied.
-	assert!(!sign_verify(cs, witness, None, Some(b"hello world")));
+	assert!(!sign_verify(cs, &witness, None, Some(b"hello world")));
 }

--- a/crates/spartan-frontend/src/circuits.rs
+++ b/crates/spartan-frontend/src/circuits.rs
@@ -242,7 +242,7 @@ mod tests {
 			B128::random(&mut rng),
 		];
 		let z_val = B128::random(&mut rng);
-		let expected = univariate::evaluate_univariate(&coeffs_vals, z_val);
+		let expected = univariate::evaluate_univariate(&coeffs_vals, &z_val);
 
 		test_helper::<UnivariateCircuit, 5>([
 			coeffs_vals[0],

--- a/crates/spartan-frontend/src/constraint_system.rs
+++ b/crates/spartan-frontend/src/constraint_system.rs
@@ -350,7 +350,7 @@ impl<F: Field> ConstraintSystem<F> {
 	}
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct BlindingInfo {
 	/// The number of random dummy wires that must be added.
 	pub n_dummy_wires: usize,

--- a/crates/spartan-prover/src/lib.rs
+++ b/crates/spartan-prover/src/lib.rs
@@ -178,7 +178,7 @@ impl<F: Field> IOPProver<F> {
 	///   [`Self::commit_precommit`])
 	pub fn prove<P, Channel, A>(
 		&self,
-		witness: Witness<F>,
+		witness: &Witness<F>,
 		precommit_oracle: Channel::Oracle,
 		precommit_packed: FieldVec<P, A>,
 		mut rng: impl CryptoRng,
@@ -283,7 +283,7 @@ impl<F: Field> IOPProver<F> {
 		let lambda = channel.sample();
 
 		// Batch together the constraint operand evaluation claims.
-		let batched_sum = evaluate_univariate(&mulcheck_evals, lambda);
+		let batched_sum = evaluate_univariate(&mulcheck_evals, &lambda);
 
 		// Compute eq indicator tensor for r_x (shared across all segment evaluations)
 		let r_x_tensor = eq_ind_partial_eval::<F>(&r_x);
@@ -292,7 +292,7 @@ impl<F: Field> IOPProver<F> {
 		let public_eval = evaluate_wiring_mle_public(
 			cs.mul_constraints(),
 			witness.public(),
-			lambda,
+			&lambda,
 			r_x_tensor.as_ref(),
 		);
 
@@ -338,7 +338,7 @@ where
 	/// Constructs a prover corresponding to a constraint system verifier.
 	///
 	/// See [`Prover`] struct documentation for details.
-	pub fn setup(verifier: Verifier<F, H>) -> Result<Self, Error> {
+	pub fn setup(verifier: &Verifier<F, H>) -> Result<Self, Error> {
 		let log_num_shares = binius_utils::rayon::current_num_threads().ilog2() as usize;
 
 		// Get the largest subspace from the verifier compiler for NTT creation
@@ -384,7 +384,7 @@ where
 	/// * The witness length must match the constraint system size
 	pub fn prove<Challenger_: Challenger>(
 		&self,
-		witness: Witness<F>,
+		witness: &Witness<F>,
 		mut rng: impl CryptoRng,
 		transcript: &mut ProverTranscript<Challenger_>,
 	) -> Result<(), Error> {
@@ -402,7 +402,7 @@ where
 		let alloc = &self.pool;
 		let (precommit_oracle, precommit_packed) =
 			self.iop_prover
-				.commit_precommit::<P, _, _>(&witness, &mut rng, &mut channel, &alloc);
+				.commit_precommit::<P, _, _>(witness, &mut rng, &mut channel, &alloc);
 		// The IOP prover only queues the oracle relations; `finish` runs the single combined
 		// opening.
 		self.iop_prover.prove::<P, _, _>(

--- a/crates/spartan-prover/src/wiring.rs
+++ b/crates/spartan-prover/src/wiring.rs
@@ -317,7 +317,7 @@ mod tests {
 			}
 		}
 
-		evaluate_univariate(&acc, lambda)
+		evaluate_univariate(&acc, &lambda)
 	}
 
 	#[test]
@@ -348,7 +348,7 @@ mod tests {
 		let expected = evaluate_segment_wiring_mle(
 			&constraints,
 			WitnessSegment::Private,
-			lambda,
+			&lambda,
 			r_x_tensor.as_ref(),
 			&r_y,
 		);
@@ -392,7 +392,7 @@ mod tests {
 		let expected = evaluate_segment_wiring_mle(
 			&constraints,
 			WitnessSegment::Private,
-			lambda,
+			&lambda,
 			r_x_tensor.as_ref(),
 			&r_y,
 		);
@@ -490,9 +490,9 @@ mod tests {
 		let r_x_tensor = eq_ind_partial_eval::<B128>(&r_x);
 
 		// Compute the batched sum and public contribution
-		let batched_sum = evaluate_univariate(&mulcheck_evals, lambda);
+		let batched_sum = evaluate_univariate(&mulcheck_evals, &lambda);
 		let public_eval =
-			evaluate_wiring_mle_public(&constraints, &public, lambda, r_x_tensor.as_ref());
+			evaluate_wiring_mle_public(&constraints, &public, &lambda, r_x_tensor.as_ref());
 		let trace_claim = batched_sum - public_eval;
 
 		// Fold constraints to get the private wiring polynomial
@@ -525,12 +525,12 @@ mod tests {
 		let verifier_lambda: B128 = verifier_channel.sample();
 
 		// Compute the same claim on the verifier side
-		let verifier_batched_sum = evaluate_univariate(&mulcheck_evals, verifier_lambda);
+		let verifier_batched_sum = evaluate_univariate(&mulcheck_evals, &verifier_lambda);
 		let verifier_r_x_tensor = eq_ind_partial_eval::<B128>(&r_x);
 		let verifier_public_eval = evaluate_wiring_mle_public(
 			&constraints,
 			&public,
-			verifier_lambda,
+			&verifier_lambda,
 			verifier_r_x_tensor.as_ref(),
 		);
 		let verifier_trace_claim = verifier_batched_sum - verifier_public_eval;

--- a/crates/spartan-prover/src/wrapper/zk_wrapped_prover_channel.rs
+++ b/crates/spartan-prover/src/wrapper/zk_wrapped_prover_channel.rs
@@ -218,7 +218,7 @@ where
 
 		// Validate and generate the outer proof.
 		outer_prover.prove::<P, _, _>(
-			witness,
+			&witness,
 			precommit_oracle,
 			precommit_packed,
 			rng,

--- a/crates/spartan-prover/tests/integration_test.rs
+++ b/crates/spartan-prover/tests/integration_test.rs
@@ -43,11 +43,11 @@ fn test_power7_circuit_prover_verifier() {
 	let log_inv_rate = 1;
 	let verifier =
 		Verifier::<_, StdHashSuite>::setup(cs, log_inv_rate).expect("verifier setup failed");
-	let prover = Prover::<OptimalPackedB128, StdHashSuite>::setup(verifier.clone())
-		.expect("prover setup failed");
+	let prover =
+		Prover::<OptimalPackedB128, StdHashSuite>::setup(&verifier).expect("prover setup failed");
 
 	let cs = verifier.constraint_system();
-	let layout = layout.with_blinding(cs.blinding_info().clone());
+	let layout = layout.with_blinding(*cs.blinding_info());
 
 	// Choose test values: x = random, y = x^7
 	let mut rng = StdRng::seed_from_u64(0);
@@ -78,7 +78,7 @@ fn test_power7_circuit_prover_verifier() {
 	// Generate proof
 	let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 	prover
-		.prove(witness, &mut rng, &mut prover_transcript)
+		.prove(&witness, &mut rng, &mut prover_transcript)
 		.expect("prove failed");
 
 	// Verify proof
@@ -103,11 +103,11 @@ fn test_tampered_derived_value_fails_verification() {
 	let log_inv_rate = 1;
 	let verifier =
 		Verifier::<_, StdHashSuite>::setup(cs, log_inv_rate).expect("verifier setup failed");
-	let prover = Prover::<OptimalPackedB128, StdHashSuite>::setup(verifier.clone())
-		.expect("prover setup failed");
+	let prover =
+		Prover::<OptimalPackedB128, StdHashSuite>::setup(&verifier).expect("prover setup failed");
 
 	let cs = verifier.constraint_system();
-	let layout = layout.with_blinding(cs.blinding_info().clone());
+	let layout = layout.with_blinding(*cs.blinding_info());
 
 	let mut rng = StdRng::seed_from_u64(0);
 	let x_val = B128::random(&mut rng);
@@ -138,7 +138,7 @@ fn test_tampered_derived_value_fails_verification() {
 	// The prover observes its tampered public into the transcript while proving.
 	let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 	prover
-		.prove(tampered_witness, &mut rng, &mut prover_transcript)
+		.prove(&tampered_witness, &mut rng, &mut prover_transcript)
 		.expect("prove failed");
 
 	// The verifier verifies against the recomputed (correct) public and must reject the proof.

--- a/crates/spartan-prover/tests/wrapper_integration_test.rs
+++ b/crates/spartan-prover/tests/wrapper_integration_test.rs
@@ -62,7 +62,7 @@ fn test_zk_wrapped_prove_verify() {
 			n_dummy_constraints: 0,
 		},
 	);
-	let inner_layout = inner_layout.with_blinding(inner_cs.blinding_info().clone());
+	let inner_layout = inner_layout.with_blinding(*inner_cs.blinding_info());
 
 	let inner_iop_verifier = IOPVerifier::new(inner_cs.clone());
 	let inner_iop_prover = IOPProver::new(inner_cs.clone());
@@ -75,7 +75,7 @@ fn test_zk_wrapped_prove_verify() {
 	let dummy_public_elems = builder_channel.observe_many(&dummy_public);
 	// IronSpartanBuilderChannel::Oracle = () and recv_oracle is a no-op, so pass () directly.
 	inner_iop_verifier
-		.verify((), dummy_public_elems, &mut builder_channel)
+		.verify((), &dummy_public_elems, &mut builder_channel)
 		.expect("symbolic verify failed");
 	let outer_builder = builder_channel.finish();
 	let (outer_cs, outer_layout) = compile(outer_builder);
@@ -88,7 +88,7 @@ fn test_zk_wrapped_prove_verify() {
 		n_dummy_constraints: 2,
 	};
 	let outer_cs = ConstraintSystemPadded::new(outer_cs, blinding_info);
-	let outer_layout = Arc::new(outer_layout.with_blinding(outer_cs.blinding_info().clone()));
+	let outer_layout = Arc::new(outer_layout.with_blinding(*outer_cs.blinding_info()));
 
 	// === Step 5: Make combined proof compiler (inner + outer oracle specs) ===
 	let outer_iop_verifier = IOPVerifier::new(outer_cs.clone());
@@ -107,7 +107,7 @@ fn test_zk_wrapped_prove_verify() {
 	.concat();
 
 	let zk_basefold_compiler = BaseFoldVerifierCompiler::new(
-		merkle_scheme,
+		&merkle_scheme,
 		combined_oracle_specs,
 		log_inv_rate,
 		n_test_queries,
@@ -159,7 +159,7 @@ fn test_zk_wrapped_prove_verify() {
 				let inner_public_elems = replay_channel.observe_many(public);
 				// ReplayChannel::Oracle = () and recv_oracle is a no-op, so pass ().
 				inner_iop_verifier
-					.verify((), inner_public_elems, replay_channel)
+					.verify((), &inner_public_elems, replay_channel)
 					.expect("replay verification should not fail");
 			}
 		},
@@ -178,7 +178,7 @@ fn test_zk_wrapped_prove_verify() {
 		);
 	inner_iop_prover
 		.prove::<OptimalPackedB128, _, _>(
-			inner_witness,
+			&inner_witness,
 			inner_precommit_oracle,
 			inner_precommit_packed,
 			&mut rng,
@@ -215,7 +215,7 @@ fn test_zk_wrapped_prove_verify() {
 		.recv_oracle(outer_oracle_specs[0].log_msg_len, true)
 		.unwrap();
 	inner_iop_verifier
-		.verify(inner_precommit_oracle, inner_public_elems, &mut wrapped_verifier_channel)
+		.verify(inner_precommit_oracle, &inner_public_elems, &mut wrapped_verifier_channel)
 		.expect("inner IOP verify failed");
 
 	// Finish verifies the outer proof.

--- a/crates/spartan-verifier/src/lib.rs
+++ b/crates/spartan-verifier/src/lib.rs
@@ -137,7 +137,7 @@ impl<F: Field> IOPVerifier<F> {
 		let public = vec![DummyElem::<F>::default(); 1 << cs.log_public()];
 		// Discarded: the setup channel performs no real verification; we only read back the
 		// recorded oracle specs.
-		let _ = self.verify((), public, &mut channel);
+		let _ = self.verify((), &public, &mut channel);
 		channel.into_oracle_specs()
 	}
 
@@ -159,7 +159,7 @@ impl<F: Field> IOPVerifier<F> {
 	pub fn verify<Channel>(
 		&self,
 		precommit_oracle: Channel::Oracle,
-		public: Vec<Channel::Elem>,
+		public: &[Channel::Elem],
 		channel: &mut Channel,
 	) -> Result<(), Error>
 	where
@@ -197,7 +197,7 @@ impl<F: Field> IOPVerifier<F> {
 		let lambda = channel.sample();
 
 		// Batch together the constraint operand evaluation claims.
-		let batched_sum = evaluate_univariate(&[a_eval, b_eval, c_eval], lambda.clone());
+		let batched_sum = evaluate_univariate(&[a_eval, b_eval, c_eval], &lambda);
 
 		// Compute rₓ^⊤ (M_A + λ M_B + λ² M_C) x. Shared via `Rc` so the transparent closures can
 		// own it and outlive this call (the opening is deferred to the channel's `finish()`). `Rc`
@@ -210,12 +210,7 @@ impl<F: Field> IOPVerifier<F> {
 		// field values, run the MLE evaluation in plaintext, and materialize the result as a
 		// single inout wire instead of building the entire sub-circuit.
 		let public_eval = {
-			let inputs = [
-				public.as_slice(),
-				slice::from_ref(&lambda),
-				r_x_tensor.as_ref(),
-			]
-			.concat();
+			let inputs = [public, slice::from_ref(&lambda), r_x_tensor.as_ref()].concat();
 
 			let eval_fn = wiring::PublicWiringEvalFn::new(cs.mul_constraints(), public.len());
 			channel.compute_public_value(&inputs, eval_fn)
@@ -292,7 +287,7 @@ where
 
 		// Create the BaseFold ZK compiler for IOP verification
 		let basefold_compiler = BaseFoldVerifierCompiler::new(
-			merkle_scheme,
+			&merkle_scheme,
 			oracle_specs,
 			log_inv_rate,
 			n_test_queries,
@@ -346,7 +341,7 @@ where
 		let precommit_oracle =
 			channel.recv_oracle(self.constraint_system().log_precommit() as usize, true)?;
 		self.iop_verifier
-			.verify(precommit_oracle, public.to_vec(), &mut channel)?;
+			.verify(precommit_oracle, public, &mut channel)?;
 		Ok(channel.finish()?)
 	}
 }

--- a/crates/spartan-verifier/src/wiring.rs
+++ b/crates/spartan-verifier/src/wiring.rs
@@ -20,7 +20,7 @@ pub fn eval_transparent<F: FieldOps + 'static>(
 	lambda: F,
 ) -> binius_iop::channel::TransparentEvalFn<F> {
 	Box::new(move |r_y: &[F]| {
-		evaluate_segment_wiring_mle(&mul_constraints, segment, lambda.clone(), &r_x_tensor, r_y)
+		evaluate_segment_wiring_mle(&mul_constraints, segment, &lambda, &r_x_tensor, r_y)
 	})
 }
 
@@ -32,7 +32,7 @@ pub fn eval_transparent<F: FieldOps + 'static>(
 pub fn evaluate_segment_wiring_mle<F: FieldOps>(
 	mul_constraints: &[MulConstraint<WitnessIndex>],
 	segment: WitnessSegment,
-	lambda: F,
+	lambda: &F,
 	r_x_tensor: &[F],
 	r_y: &[F],
 ) -> F {
@@ -65,7 +65,7 @@ pub fn evaluate_segment_wiring_mle<F: FieldOps>(
 pub fn evaluate_wiring_mle_public<F: FieldOps>(
 	mul_constraints: &[MulConstraint<WitnessIndex>],
 	public: &[F],
-	lambda: F,
+	lambda: &F,
 	r_x_tensor: &[F],
 ) -> F {
 	let mut acc = [F::zero(), F::zero(), F::zero()];
@@ -119,7 +119,7 @@ impl<F: Field> FieldFn<F> for PublicWiringEvalFn<'_> {
 	fn call<E: FieldOps<Scalar = F> + From<F>>(&self, inputs: &[E]) -> E {
 		// Split the flat input back into its three parts.
 		let public = &inputs[..self.public_len];
-		let lambda = inputs[self.public_len].clone();
+		let lambda = &inputs[self.public_len];
 		let r_x_tensor = &inputs[self.public_len + 1..];
 
 		evaluate_wiring_mle_public(self.mul_constraints, public, lambda, r_x_tensor)

--- a/crates/spartan-verifier/src/wrapper/mod.rs
+++ b/crates/spartan-verifier/src/wrapper/mod.rs
@@ -194,7 +194,7 @@ mod tests {
 		let public_elems = channel.observe_many(&public);
 		// IronSpartanBuilderChannel::Oracle = () and recv_oracle is a no-op, so pass () directly.
 		iop_verifier
-			.verify((), public_elems, &mut channel)
+			.verify((), &public_elems, &mut channel)
 			.expect("symbolic verify failed");
 
 		let builder = channel.finish();

--- a/crates/spartan-verifier/src/wrapper/zk_wrapped_channel.rs
+++ b/crates/spartan-verifier/src/wrapper/zk_wrapped_channel.rs
@@ -156,7 +156,7 @@ where
 
 		let mut inner_channel = self.inner_channel;
 		self.outer_verifier
-			.verify(self.precommit_oracle, public, &mut inner_channel)?;
+			.verify(self.precommit_oracle, &public, &mut inner_channel)?;
 		// Both the inner and outer proofs queued their oracle relations onto `inner_channel`; run
 		// the single combined opening over all committed oracles now. `instance_gen` stays alive in
 		// `self` for the duration, so the transparent closures' `Weak` upgrades succeed.

--- a/crates/spartan-verifier/tests/proof_size_test.rs
+++ b/crates/spartan-verifier/tests/proof_size_test.rs
@@ -61,7 +61,7 @@ fn test_ip_proof_size() {
 		.expect("recv_oracle on size-tracking channel should succeed");
 	verifier
 		.iop_verifier()
-		.verify(precommit_oracle, public_elems, &mut channel)
+		.verify(precommit_oracle, &public_elems, &mut channel)
 		.expect("verify with size tracking channel should succeed");
 	let proof_size = channel.proof_size();
 

--- a/crates/verifier/src/protocols/bitand.rs
+++ b/crates/verifier/src/protocols/bitand.rs
@@ -114,7 +114,7 @@ where
 	let sumcheck_claim = extrapolate_over_subspace(
 		round_message_univariate_domain,
 		&univariate_message_coeffs,
-		univariate_sumcheck_challenge.clone(),
+		&univariate_sumcheck_challenge,
 	);
 
 	let SumcheckOutput {

--- a/crates/verifier/src/protocols/intmul/verify.rs
+++ b/crates/verifier/src/protocols/intmul/verify.rs
@@ -144,7 +144,7 @@ where
 		gpow_c_lo_eval.clone() * gpow_c_hi_eval.clone() * eq_ind(c_eval_point, &eval_point);
 
 	let expected_terms = [expected_selected_agg, expected_c_prod_eval];
-	let expected_batched_eval = evaluate_univariate(&expected_terms, batch_coeff);
+	let expected_batched_eval = evaluate_univariate(&expected_terms, &batch_coeff);
 
 	channel.assert_zero(expected_batched_eval - eval)?;
 
@@ -365,7 +365,7 @@ where
 		expected_overflow_eval,
 		expected_b_rerand_eval,
 	];
-	let expected_batched_eval = evaluate_univariate(&expected_unbatched_evals, batch_coeff);
+	let expected_batched_eval = evaluate_univariate(&expected_unbatched_evals, &batch_coeff);
 
 	// Compare expected evaluation against given evaluation `eval`.
 	channel.assert_zero(expected_batched_eval - eval)?;

--- a/crates/verifier/src/protocols/shift/monster.rs
+++ b/crates/verifier/src/protocols/shift/monster.rs
@@ -385,7 +385,7 @@ mod tests {
 			let s = rng.random_range(0..64);
 
 			let challenge = subspace.get(i);
-			let l_tilde = lagrange_evals_scalars(&subspace, challenge);
+			let l_tilde = lagrange_evals_scalars(&subspace, &challenge);
 
 			let r_j = index_to_hypercube_point::<BinaryField128bGhash>(Word::LOG_BITS, j);
 			let r_s = index_to_hypercube_point::<BinaryField128bGhash>(Word::LOG_BITS, s);
@@ -436,7 +436,7 @@ mod tests {
 		// Generate random evaluation points
 		let challenge = BinaryField128bGhash::random(&mut rng);
 		let subspace = BinarySubspace::<BinaryField128bGhash>::with_dim(Word::LOG_BITS);
-		let l_tilde = lagrange_evals_scalars(&subspace, challenge);
+		let l_tilde = lagrange_evals_scalars(&subspace, &challenge);
 		let r_j = random_scalars::<BinaryField128bGhash>(&mut rng, Word::LOG_BITS);
 		let r_s = random_scalars::<BinaryField128bGhash>(&mut rng, Word::LOG_BITS);
 

--- a/crates/verifier/src/protocols/shift/verify.rs
+++ b/crates/verifier/src/protocols/shift/verify.rs
@@ -83,8 +83,8 @@ impl<F: FieldOps, const ARITY: usize> OperatorData<F, ARITY> {
 	// evaluation claim can be added to other batched evaluation claims
 	// without further random scaling.
 	fn batched_eval(&self, lambda: F) -> F {
-		let lambda_clone = lambda.clone();
-		lambda_clone * evaluate_univariate(&self.evals, lambda)
+		let eval = evaluate_univariate(&self.evals, &lambda);
+		lambda * eval
 	}
 }
 
@@ -474,7 +474,7 @@ impl<F: BinaryField> MonsterEvalFn<'_, F> {
 		let mut r_y_tensor = Vec::with_capacity(cs.value_vec_len());
 		r_y_tensor.extend_from_slice(&public_tensor);
 		r_y_tensor.extend_from_slice(&hidden_tensor[..cs.value_vec_len() - n_public_words]);
-		let l_tilde = lagrange_evals_scalars(self.subspace, r_zhat_prime_v);
+		let l_tilde = lagrange_evals_scalars(self.subspace, &r_zhat_prime_v);
 		let h_op_evals = evaluate_h_op(&l_tilde, r_j_v, r_s_v);
 
 		// Tensor the shift-selector evaluations with the shift-amount equality indicator once, so

--- a/crates/verifier/src/ring_switch.rs
+++ b/crates/verifier/src/ring_switch.rs
@@ -113,8 +113,8 @@ where
 		|eval, (vert_i, hztl_i)| {
 			// This formula is specific to characteristic 2 fields
 			// Here we know that $h v + (1 - h) (1 - v) = 1 + h + v$.
-			let vert_scaled = eval.clone().scale_vertical(vert_i.clone());
-			let hztl_scaled = eval.clone().scale_horizontal(hztl_i.clone());
+			let vert_scaled = eval.clone().scale_vertical(vert_i);
+			let hztl_scaled = eval.clone().scale_horizontal(hztl_i);
 
 			eval + &vert_scaled + &hztl_scaled
 		},

--- a/crates/verifier/src/verify.rs
+++ b/crates/verifier/src/verify.rs
@@ -230,7 +230,7 @@ impl IOPVerifier {
 				c_hi_evals,
 				eval_point,
 			}) => {
-				let l_tilde = lagrange_evals_scalars(&domain_subspace, r_zhat_prime.clone());
+				let l_tilde = lagrange_evals_scalars(&domain_subspace, &r_zhat_prime);
 				let make_final_claim =
 					|evals| inner_product_scalars(evals, l_tilde.iter().cloned());
 				OperatorData::new(
@@ -261,7 +261,7 @@ impl IOPVerifier {
 				c_lo_evals,
 				c_hi_evals,
 			}) => {
-				let l_tilde = lagrange_evals_scalars(&domain_subspace, r_zhat_prime.clone());
+				let l_tilde = lagrange_evals_scalars(&domain_subspace, &r_zhat_prime);
 				let make_final_claim =
 					|evals| inner_product_scalars(evals, l_tilde.iter().cloned());
 				OperatorData::new(
@@ -396,7 +396,7 @@ where
 		let n_test_queries = calculate_n_test_queries(SECURITY_BITS, log_inv_rate);
 
 		let iop_compiler = BaseFoldVerifierCompiler::new(
-			merkle_scheme,
+			&merkle_scheme,
 			oracle_specs,
 			log_inv_rate,
 			n_test_queries,

--- a/crates/verifier/src/zk_config.rs
+++ b/crates/verifier/src/zk_config.rs
@@ -107,7 +107,7 @@ where
 			n_dummy_constraints: 2,
 		};
 		let outer_cs = ConstraintSystemPadded::new(outer_cs, blinding_info);
-		let outer_layout = Arc::new(outer_layout.with_blinding(outer_cs.blinding_info().clone()));
+		let outer_layout = Arc::new(outer_layout.with_blinding(*outer_cs.blinding_info()));
 		let outer_iop_verifier = IronSpartanIOPVerifier::new(outer_cs);
 
 		// Transcript layout: outer precommit oracle first (committed at wrapper construction),
@@ -122,7 +122,7 @@ where
 
 		let merkle_scheme = BinaryMerkleTreeScheme::<B128, H>::new();
 		let basefold_compiler = BaseFoldVerifierCompiler::new(
-			merkle_scheme,
+			&merkle_scheme,
 			oracle_specs,
 			log_inv_rate,
 			n_test_queries,


### PR DESCRIPTION
@jimpo We have this in Plonky3 and in general this is a good way to avoid useless cloning or alloc (we can still have an allowance at the few places where this makes no sense to do). Don't hesitate to close if you don't like it.

Turns on `needless_pass_by_value = "warn"` workspace-wide and fixes every hit.
Pure refactor — no behavior change, and a net deletion because most fixes removed a clone at the call site rather than adding one.

### The problem

The lint fires when a function takes an argument **by value and never consumes it**.

That is not a style nit — it is a cost the *caller* pays.
A callee that only reads its argument but demands ownership forces every caller holding a borrow to `clone()` or `to_vec()` first.

The clearest case in this repo is `evaluate_univariate`:

```rust
pub fn evaluate_univariate<F: FieldOps>(coeffs: &[F], x: F) -> F
```

`F: FieldOps` is not `Copy`, so a caller with a borrowed challenge has no choice:

```rust
let sum = evaluate_univariate(sums, batch_coeff.clone());
```

That clone exists only to satisfy the signature. The function never keeps `x`.

### The idea

Fix each of the ~90 hits by asking what the signature was *trying* to say, rather than mechanically inserting `&`.
That gives four distinct answers.

**1. Take a reference** — the argument is read, and ownership was never needed.

Four generic-field helpers were the biggest win, because they sit under the whole verifier stack:

```
- evaluate_univariate(coeffs: &[F], x: F)          + evaluate_univariate(coeffs: &[F], x: &F)
- lagrange_evals_scalars(subspace, z: E)           + lagrange_evals_scalars(subspace, z: &E)
- extrapolate_over_subspace(subspace, vals, z: E)  + extrapolate_over_subspace(subspace, vals, z: &E)
- RoundCoeffs::evaluate(&self, x: F)               + RoundCoeffs::evaluate(&self, x: &F)
```

That alone deleted a dozen `.clone()` calls across `binius-verifier`, `binius-ip`, `binius-iop`, `binius-spartan-*` and `binius-m4-*`.

Two more in the same family:

- `ValueVec::new_from_data` took two `Vec<Word>` and immediately copied both into a fresh 16-byte-aligned buffer. It never kept either `Vec`, so the caller in `examples/src/bin/prover.rs` was doing a "take ownership without extra copies" dance that bought nothing.
- The `Prover::prove` / `ZKProver::prove` / spartan `prove` chain took the witness by value and only ever read it, so every test and bench that proved and then verified against the same witness was cloning it.

**2. Derive `Copy`** — the type *is* a value, and the lint is pointing at a missing derive.

| type | what it actually is |
|---|---|
| `sha256::State`, `sha512::State` | `[Wire; 8]` — eight wire indices |
| `OpcodeShape` | six `usize` plus a `&'static [Word]` |
| `BlindingInfo` | two `usize` |
| `FieldSliceData` | a borrowed view (`Single(P)` or `Slice(&[P])`) |
| `FieldBuffer<P, Data>` where `Data: Copy` | a buffer over a `Copy` store |

The last one is the load-bearing entry: it makes `FieldSlice` a genuine cheap view, which is what lets `clone_from_slice` and `encode_batch` keep taking it by value without tripping the lint. Making the two SHA `State`s `Copy` also removed five `state.clone()` calls that clippy then flagged as clone-on-Copy.

`ConstraintSystemBenchmarkContext` is seven shared references, so it is `Copy` too — but written by hand rather than derived, since a derive would demand `B: Copy` from benchmark types that have no reason to satisfy it.

**3. Take `&ArgMatches`** — the examples CLI had eight `run_*(matches: clap::ArgMatches)` entry points, each reached through a `sub_matches.clone()` in the dispatch `match`. Eight clones of a parsed-argument tree, deleted.

**4. Allow, with a reason** — two places where by-value is exactly the point:

- `unpool` (`prover/src/protocols/intmul/witness.rs`) takes `FieldVec<P, A>` by value *so that* the pooled block returns to the free list when the function ends. A reference would move the recycling point to the caller and defeat the function.
- `square_transpose_const_size` (`prover/src/ring_switch.rs`) takes `[&mut P; S]`. The array of mutable lanes already *is* the borrow bundle; `&[&mut P; S]` would be strictly worse.

Both carry a one-line comment saying why.

### The change

```diff
 [workspace.lints.clippy]
 needless_range_loop = "allow"
 missing_const_for_fn = "warn"
 needless_collect = "warn"
 redundant_clone = "warn"
+needless_pass_by_value = "warn"
```

A representative call site, showing why the diff shrinks:

```diff
-let sum = evaluate_univariate(sums, batch_coeff.clone());
+let sum = evaluate_univariate(sums, &batch_coeff);
```

### Scope

- **103 files, +452 / −463** across 18 crates.
- Heaviest: `binius-examples` (13 files), `binius-prover` (11), `binius-ip-prover` (11), `binius-circuits` (10).
- **Signature changes visible outside the workspace:** `Prover::prove`, `ZKProver::prove` / `prove_sig` / `setup`, spartan `Verifier::verify`, `BaseFold{Prover,Verifier}Compiler::new` (the `merkle_scheme` argument), and `ValueVec::new_from_data`. Each is strictly more permissive for callers, but they are breaking signature changes for anything outside this repo.
- **Left untouched:** the two `#[allow]`ed functions above, and every protocol behavior — no transcript, no field arithmetic, and no proof bytes change.

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy --workspace --all-targets` — **zero warnings** with the lint active
- `cargo +nightly fmt --all --check` — clean
- `cargo test --workspace` — green, no failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)