### PR TITLE
BINIUS-378: drop the gates a zero operand turns into the identity

### DIFF
--- a/crates/examples/snapshots/bitcoin_headers.snap
+++ b/crates/examples/snapshots/bitcoin_headers.snap
@@ -7,26 +7,26 @@ Gates & Instructions
 Constraints
 ├─ ZERO constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-├─ AND constraints: 20,221 used (61.7% of 2^15)
-│  [▓▓▓▓▓▓░░░░] spare: 12,547
+├─ AND constraints: 20,036 used (61.1% of 2^15)
+│  [▓▓▓▓▓▓░░░░] spare: 12,732
 ├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
 ├─ BMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-└─ Distinct value indices: 47,465
-   ├─ Distinct shifted value indices: 27,120
-   └─ Distinct unshifted value indices: 20,345
+└─ Distinct value indices: 47,090
+   ├─ Distinct shifted value indices: 26,930
+   └─ Distinct unshifted value indices: 20,160
 
 Value Vector
 ├─ Public Section: 157 used (61.3% of 2^8)
 │  [▓▓▓▓▓▓░░░░] spare: 99
 │  ├─ Constants: 157
 │  └─ Inout: 0
-├─ Private Section: 20,195 used (62.1%)
-│  [▓▓▓▓▓▓░░░░] spare: 12,317
+├─ Private Section: 20,010 used (61.5%)
+│  [▓▓▓▓▓▓░░░░] spare: 12,502
 │  ├─ Witness: 104
-│  └─ Internal: 20,091
-├─ Total Committed: 20,352 used (62.1% of 2^15)
-│  [▓▓▓▓▓▓░░░░] spare: 12,416
-└─ Scratch (uncommitted): 39,157 (peak live: 76)
+│  └─ Internal: 19,906
+├─ Total Committed: 20,167 used (61.5% of 2^15)
+│  [▓▓▓▓▓▓░░░░] spare: 12,601
+└─ Scratch (uncommitted): 39,342 (peak live: 53)
 

--- a/crates/examples/snapshots/bitcoin_p2pkh.snap
+++ b/crates/examples/snapshots/bitcoin_p2pkh.snap
@@ -7,26 +7,26 @@ Gates & Instructions
 Constraints
 ├─ ZERO constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-├─ AND constraints: 113,587 used (86.7% of 2^17)
-│  [▓▓▓▓▓▓▓▓░░] spare: 17,485
+├─ AND constraints: 113,474 used (86.6% of 2^17)
+│  [▓▓▓▓▓▓▓▓░░] spare: 17,598
 ├─ IMUL constraints: 15,186 used (92.7% of 2^14)
 │  [▓▓▓▓▓▓▓▓▓░] spare: 1,198
 ├─ BMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-└─ Distinct value indices: 267,711
-   ├─ Distinct shifted value indices: 131,729
-   └─ Distinct unshifted value indices: 135,982
+└─ Distinct value indices: 267,485
+   ├─ Distinct shifted value indices: 131,616
+   └─ Distinct unshifted value indices: 135,869
 
 Value Vector
 ├─ Public Section: 135 used (52.7% of 2^8)
 │  [▓▓▓▓▓░░░░░] spare: 121
 │  ├─ Constants: 135
 │  └─ Inout: 0
-├─ Private Section: 135,858 used (51.9%)
-│  [▓▓▓▓▓░░░░░] spare: 126,030
+├─ Private Section: 135,745 used (51.8%)
+│  [▓▓▓▓▓░░░░░] spare: 126,143
 │  ├─ Witness: 9
-│  └─ Internal: 135,849
-├─ Total Committed: 135,993 used (51.9% of 2^18)
-│  [▓▓▓▓▓░░░░░] spare: 126,151
-└─ Scratch (uncommitted): 108,346 (peak live: 109)
+│  └─ Internal: 135,736
+├─ Total Committed: 135,880 used (51.8% of 2^18)
+│  [▓▓▓▓▓░░░░░] spare: 126,264
+└─ Scratch (uncommitted): 108,459 (peak live: 109)
 

--- a/crates/examples/snapshots/blake3.snap
+++ b/crates/examples/snapshots/blake3.snap
@@ -7,26 +7,26 @@ Gates & Instructions
 Constraints
 ├─ ZERO constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-├─ AND constraints: 5,451 used (66.5% of 2^13)
-│  [▓▓▓▓▓▓░░░░] spare: 2,741
+├─ AND constraints: 5,445 used (66.5% of 2^13)
+│  [▓▓▓▓▓▓░░░░] spare: 2,747
 ├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
 ├─ BMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-└─ Distinct value indices: 14,634
-   ├─ Distinct shifted value indices: 9,242
-   └─ Distinct unshifted value indices: 5,392
+└─ Distinct value indices: 14,616
+   ├─ Distinct shifted value indices: 9,230
+   └─ Distinct unshifted value indices: 5,386
 
 Value Vector
 ├─ Public Section: 281 used (54.9% of 2^9)
 │  [▓▓▓▓▓░░░░░] spare: 231
 │  ├─ Constants: 17
 │  └─ Inout: 264
-├─ Private Section: 5,379 used (70.0%)
-│  [▓▓▓▓▓▓▓░░░] spare: 2,301
+├─ Private Section: 5,373 used (70.0%)
+│  [▓▓▓▓▓▓░░░░] spare: 2,307
 │  ├─ Witness: 0
-│  └─ Internal: 5,379
-├─ Total Committed: 5,660 used (69.1% of 2^13)
-│  [▓▓▓▓▓▓░░░░] spare: 2,532
-└─ Scratch (uncommitted): 4,853 (peak live: 28)
+│  └─ Internal: 5,373
+├─ Total Committed: 5,654 used (69.0% of 2^13)
+│  [▓▓▓▓▓▓░░░░] spare: 2,538
+└─ Scratch (uncommitted): 4,859 (peak live: 26)
 

--- a/crates/examples/snapshots/ethsign.snap
+++ b/crates/examples/snapshots/ethsign.snap
@@ -7,26 +7,26 @@ Gates & Instructions
 Constraints
 ├─ ZERO constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-├─ AND constraints: 159,866 used (61.0% of 2^18)
-│  [▓▓▓▓▓▓░░░░] spare: 102,278
+├─ AND constraints: 159,863 used (61.0% of 2^18)
+│  [▓▓▓▓▓▓░░░░] spare: 102,281
 ├─ IMUL constraints: 20,554 used (62.7% of 2^15)
 │  [▓▓▓▓▓▓░░░░] spare: 12,214
 ├─ BMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-└─ Distinct value indices: 379,033
-   ├─ Distinct shifted value indices: 189,010
-   └─ Distinct unshifted value indices: 190,023
+└─ Distinct value indices: 379,027
+   ├─ Distinct shifted value indices: 189,007
+   └─ Distinct unshifted value indices: 190,020
 
 Value Vector
 ├─ Public Section: 114 used (89.1% of 2^7)
 │  [▓▓▓▓▓▓▓▓░░] spare: 14
 │  ├─ Constants: 85
 │  └─ Inout: 29
-├─ Private Section: 189,918 used (72.5%)
-│  [▓▓▓▓▓▓▓░░░] spare: 72,098
+├─ Private Section: 189,915 used (72.5%)
+│  [▓▓▓▓▓▓▓░░░] spare: 72,101
 │  ├─ Witness: 0
-│  └─ Internal: 189,918
-├─ Total Committed: 190,032 used (72.5% of 2^18)
-│  [▓▓▓▓▓▓▓░░░] spare: 72,112
-└─ Scratch (uncommitted): 149,993 (peak live: 192)
+│  └─ Internal: 189,915
+├─ Total Committed: 190,029 used (72.5% of 2^18)
+│  [▓▓▓▓▓▓▓░░░] spare: 72,115
+└─ Scratch (uncommitted): 149,996 (peak live: 192)
 

--- a/crates/examples/snapshots/hashsign.snap
+++ b/crates/examples/snapshots/hashsign.snap
@@ -7,26 +7,26 @@ Gates & Instructions
 Constraints
 ├─ ZERO constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-├─ AND constraints: 297,984 used (56.8% of 2^19)
-│  [▓▓▓▓▓░░░░░] spare: 226,304
+├─ AND constraints: 277,556 used (52.9% of 2^19)
+│  [▓▓▓▓▓░░░░░] spare: 246,732
 ├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
 ├─ BMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-└─ Distinct value indices: 763,739
-   ├─ Distinct shifted value indices: 466,717
-   └─ Distinct unshifted value indices: 297,022
+└─ Distinct value indices: 722,881
+   ├─ Distinct shifted value indices: 446,287
+   └─ Distinct unshifted value indices: 276,594
 
 Value Vector
 ├─ Public Section: 183 used (71.5% of 2^8)
 │  [▓▓▓▓▓▓▓░░░] spare: 73
 │  ├─ Constants: 157
 │  └─ Inout: 26
-├─ Private Section: 296,911 used (56.7%)
-│  [▓▓▓▓▓░░░░░] spare: 227,121
+├─ Private Section: 276,483 used (52.8%)
+│  [▓▓▓▓▓░░░░░] spare: 247,549
 │  ├─ Witness: 1,776
-│  └─ Internal: 295,135
-├─ Total Committed: 297,094 used (56.7% of 2^19)
-│  [▓▓▓▓▓░░░░░] spare: 227,194
-└─ Scratch (uncommitted): 263,108 (peak live: 306)
+│  └─ Internal: 274,707
+├─ Total Committed: 276,666 used (52.8% of 2^19)
+│  [▓▓▓▓▓░░░░░] spare: 247,622
+└─ Scratch (uncommitted): 283,536 (peak live: 305)
 

--- a/crates/examples/snapshots/sha256.snap
+++ b/crates/examples/snapshots/sha256.snap
@@ -7,26 +7,26 @@ Gates & Instructions
 Constraints
 ├─ ZERO constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-├─ AND constraints: 8,880 used (54.2% of 2^14)
-│  [▓▓▓▓▓░░░░░] spare: 7,504
+├─ AND constraints: 8,856 used (54.1% of 2^14)
+│  [▓▓▓▓▓░░░░░] spare: 7,528
 ├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
 ├─ BMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-└─ Distinct value indices: 21,511
-   ├─ Distinct shifted value indices: 12,563
-   └─ Distinct unshifted value indices: 8,948
+└─ Distinct value indices: 21,514
+   ├─ Distinct shifted value indices: 12,590
+   └─ Distinct unshifted value indices: 8,924
 
 Value Vector
 ├─ Public Section: 405 used (79.1% of 2^9)
 │  [▓▓▓▓▓▓▓░░░] spare: 107
 │  ├─ Constants: 141
 │  └─ Inout: 264
-├─ Private Section: 8,808 used (55.5%)
-│  [▓▓▓▓▓░░░░░] spare: 7,064
+├─ Private Section: 8,784 used (55.3%)
+│  [▓▓▓▓▓░░░░░] spare: 7,088
 │  ├─ Witness: 0
-│  └─ Internal: 8,808
-├─ Total Committed: 9,213 used (56.2% of 2^14)
-│  [▓▓▓▓▓░░░░░] spare: 7,171
-└─ Scratch (uncommitted): 17,128 (peak live: 22)
+│  └─ Internal: 8,784
+├─ Total Committed: 9,189 used (56.1% of 2^14)
+│  [▓▓▓▓▓░░░░░] spare: 7,195
+└─ Scratch (uncommitted): 17,152 (peak live: 22)
 

--- a/crates/examples/snapshots/sha512.snap
+++ b/crates/examples/snapshots/sha512.snap
@@ -28,5 +28,5 @@ Value Vector
 │  └─ Internal: 10,303
 ├─ Total Committed: 10,540 used (64.3% of 2^14)
 │  [▓▓▓▓▓▓░░░░] spare: 5,844
-└─ Scratch (uncommitted): 21,368 (peak live: 17)
+└─ Scratch (uncommitted): 21,368 (peak live: 13)
 

--- a/crates/examples/snapshots/zklogin.snap
+++ b/crates/examples/snapshots/zklogin.snap
@@ -7,26 +7,26 @@ Gates & Instructions
 Constraints
 ├─ ZERO constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-├─ AND constraints: 357,836 used (68.3% of 2^19)
-│  [▓▓▓▓▓▓░░░░] spare: 166,452
+├─ AND constraints: 356,617 used (68.0% of 2^19)
+│  [▓▓▓▓▓▓░░░░] spare: 167,671
 ├─ IMUL constraints: 8,262 used (50.4% of 2^14)
 │  [▓▓▓▓▓░░░░░] spare: 8,122
 ├─ BMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-└─ Distinct value indices: 654,744
-   ├─ Distinct shifted value indices: 294,376
-   └─ Distinct unshifted value indices: 360,368
+└─ Distinct value indices: 653,232
+   ├─ Distinct shifted value indices: 294,083
+   └─ Distinct unshifted value indices: 359,149
 
 Value Vector
 ├─ Public Section: 1,032 used (50.4% of 2^11)
 │  [▓▓▓▓▓░░░░░] spare: 1,016
 │  ├─ Constants: 730
 │  └─ Inout: 302
-├─ Private Section: 359,346 used (68.8%)
-│  [▓▓▓▓▓▓░░░░] spare: 162,894
+├─ Private Section: 358,127 used (68.6%)
+│  [▓▓▓▓▓▓░░░░] spare: 164,113
 │  ├─ Witness: 1,381
-│  └─ Internal: 357,965
-├─ Total Committed: 360,378 used (68.7% of 2^19)
-│  [▓▓▓▓▓▓░░░░] spare: 163,910
-└─ Scratch (uncommitted): 309,481 (peak live: 1,542)
+│  └─ Internal: 356,746
+├─ Total Committed: 359,159 used (68.5% of 2^19)
+│  [▓▓▓▓▓▓░░░░] spare: 165,129
+└─ Scratch (uncommitted): 310,700 (peak live: 1,542)
 

--- a/crates/frontend/src/compiler/gate_fusion/tests/awhole.rs
+++ b/crates/frontend/src/compiler/gate_fusion/tests/awhole.rs
@@ -156,6 +156,8 @@ fn mk_circuit_builder() -> CircuitBuilder {
 		enable_scratch_pooling: false,
 		// The snapshots record the AND constraints linear constraints lower to.
 		enable_zero_constraints: false,
+		// Zero propagation would forward past the gates these snapshots assert on.
+		enable_zero_propagation: false,
 	};
 	CircuitBuilder::with_opts(opts)
 }

--- a/crates/frontend/src/compiler/gate_graph.rs
+++ b/crates/frontend/src/compiler/gate_graph.rs
@@ -55,6 +55,14 @@ impl WireKind {
 	pub const fn is_const(&self) -> bool {
 		matches!(self, WireKind::Constant(_))
 	}
+
+	/// The word this wire holds, when it is a constant.
+	pub const fn const_value(&self) -> Option<Word> {
+		match self {
+			WireKind::Constant(word) => Some(*word),
+			_ => None,
+		}
+	}
 }
 
 #[derive(Copy, Clone)]
@@ -507,42 +515,51 @@ impl GateGraph {
 	}
 
 	/// Replaces every use of `old_wire` with a constant wire holding `value`.
-	pub fn replace_wire_with_constant(
-		&mut self,
-		old_wire: Wire,
-		value: Word,
-	) -> ConstantReplacement {
+	pub fn replace_wire_with_constant(&mut self, old_wire: Wire, value: Word) -> WireReplacement {
 		let const_wire = self.add_constant(value);
+		self.replace_wire_with_wire(old_wire, const_wire)
+	}
 
-		if const_wire == old_wire {
-			return ConstantReplacement {
+	/// Replaces every use of `old_wire` with `new_wire`.
+	///
+	/// The defining gate keeps `old_wire` as its output, so it is left unread and the dead-code
+	/// pass is what actually removes it.
+	///
+	/// The use-def index is not updated, and forwarding to an ordinary wire grows that wire's set
+	/// of readers. A caller that forwards again has to rebuild the index in between, or it will
+	/// miss the readers this call moved.
+	pub fn replace_wire_with_wire(&mut self, old_wire: Wire, new_wire: Wire) -> WireReplacement {
+		if new_wire == old_wire {
+			return WireReplacement {
 				n_slots_rewritten: 0,
 				affected_gates: Vec::new(),
 			};
 		}
 
 		// Collected up front: the index borrows the graph, which is about to be rewritten.
-		//
-		// The index is not updated to match. Every gate that reads `old_wire` is in this list, and
-		// a replacement only ever introduces a constant wire, so no reader can appear later.
 		let affected_gates: Vec<Gate> = self.get_wire_uses(old_wire).collect();
 
 		// The count comes from the rewrite itself, so it covers every slot the rewrite touched.
 		// Tallying inputs and outputs separately would miss a wire held only in an aux slot.
 		let n_slots_rewritten = affected_gates
 			.iter()
-			.map(|&gate| self.replace_gate_wire(gate, old_wire, const_wire))
+			.map(|&gate| self.replace_gate_wire(gate, old_wire, new_wire))
 			.sum();
 
-		ConstantReplacement {
+		WireReplacement {
 			n_slots_rewritten,
 			affected_gates,
 		}
 	}
+
+	/// Returns every gate in the graph, in construction order.
+	pub fn gates(&self) -> impl Iterator<Item = Gate> + '_ {
+		self.gates.iter().map(|(gate, _)| gate)
+	}
 }
 
-/// What replacing one wire with a constant changed.
-pub struct ConstantReplacement {
+/// What replacing one wire with another changed.
+pub struct WireReplacement {
 	/// How many wire slots were rewritten, across every affected gate.
 	pub n_slots_rewritten: usize,
 	/// The gates whose wires were rewritten.

--- a/crates/frontend/src/compiler/mod.rs
+++ b/crates/frontend/src/compiler/mod.rs
@@ -38,6 +38,7 @@ mod scratch_alloc;
 #[cfg(test)]
 mod tests;
 mod value_vec_alloc;
+mod zero_fold;
 
 pub use gate_graph::Wire;
 use scratch_alloc::{ScratchAlloc, ScratchPolicy};
@@ -56,6 +57,8 @@ pub(crate) struct Options {
 	/// Lower linear constraints to Zero constraints instead of AND constraints against the
 	/// all-ones constant.
 	enable_zero_constraints: bool,
+	/// Forward past the gates a zero operand turns into the identity.
+	enable_zero_propagation: bool,
 }
 
 impl Default for Options {
@@ -72,6 +75,7 @@ impl Default for Options {
 			// Why off: no proof system reduces Zero constraints yet, so a circuit that emits them
 			// is unprovable.
 			enable_zero_constraints: false,
+			enable_zero_propagation: true,
 		}
 	}
 }
@@ -221,6 +225,12 @@ impl CircuitBuilder {
 		// Run constant propagation optimization
 		if shared.opts.enable_constant_propagation {
 			const_prop::constant_propagation(&mut graph, &shared.hint_registry);
+		}
+
+		// Zero propagation: drop the gates a zero operand turns into the identity.
+		// This runs before the dead-code pass, which is what removes the gates it strands.
+		if shared.opts.enable_zero_propagation {
+			zero_fold::zero_propagation(&mut graph, &shared.force_committed, &shared.hint_registry);
 		}
 
 		// Common-subexpression elimination: collapse structurally-identical gates.

--- a/crates/frontend/src/compiler/zero_fold.rs
+++ b/crates/frontend/src/compiler/zero_fold.rs
@@ -1,0 +1,207 @@
+// Copyright 2026 The Binius Developers
+//! Zero propagation over the gate graph.
+
+use binius_core::word::Word;
+use cranelift_entity::EntitySet;
+
+use crate::compiler::{
+	gate::Opcode,
+	gate_graph::{Gate, GateGraph, Wire},
+	hints::HintRegistry,
+};
+
+/// Rewrites every gate that a zero operand turns into the identity.
+///
+/// Such a gate's result is already carried by another wire, so its readers are pointed at that
+/// wire instead. The gate is then unread, and the dead-code pass drops it along with the
+/// constraint it would have emitted.
+///
+/// Zeros arise from padding rather than from anything a circuit author writes by hand. A message
+/// block zero-filled to its block size is the common case, and a hash that mixes every word of
+/// its block pays a carry chain per zero word per round without this.
+///
+/// Returns the number of wire slots rewritten.
+///
+/// # Algorithm
+///
+/// Zeros travel: clearing a zero leaves zero, and packing zero into a lane leaves zero. So one
+/// sweep is not enough, and the sweeps repeat until one changes nothing.
+///
+/// Each sweep rebuilds the use-def index first. Forwarding to an ordinary wire grows that wire's
+/// set of readers, which a stale index would not list, and a later sweep forwarding that same
+/// wire would then miss those readers.
+pub fn zero_propagation(
+	graph: &mut GateGraph,
+	force_committed: &EntitySet<Wire>,
+	hint_registry: &HintRegistry,
+) -> usize {
+	// Nothing to propagate unless the circuit already holds a zero constant. Looking it up
+	// rather than interning it keeps a circuit that has none completely untouched.
+	let Some(zero) = find_zero_constant(graph) else {
+		return 0;
+	};
+
+	let mut total_rewritten = 0;
+	loop {
+		graph.rebuild_use_def_chains(hint_registry);
+
+		// Gathered before any rewriting, since reading the graph and mutating it cannot overlap.
+		let mut forwardings = Vec::new();
+		for gate in graph.gates() {
+			if let Some(pairs) = zero_identity(graph, gate, zero, force_committed, hint_registry) {
+				forwardings.extend(pairs);
+			}
+		}
+
+		let mut rewritten = 0;
+		for (from, to) in forwardings {
+			rewritten += graph.replace_wire_with_wire(from, to).n_slots_rewritten;
+		}
+
+		// A sweep that moved no reader has reached the fixpoint.
+		if rewritten == 0 {
+			return total_rewritten;
+		}
+		total_rewritten += rewritten;
+	}
+}
+
+/// The zero constant wire, if the circuit already has one.
+fn find_zero_constant(graph: &GateGraph) -> Option<Wire> {
+	graph
+		.iter_const_wires()
+		.find(|(_, data)| data.kind.const_value() == Some(Word::ZERO))
+		.map(|(wire, _)| wire)
+}
+
+/// Where each of `gate`'s outputs moves to, when a zero operand makes the gate an identity.
+///
+/// Returns nothing when no rule applies, so the gate keeps its constraint.
+///
+/// The rules, for `z` the zero word:
+///
+/// ```text
+///     shift(z, n)   -> z          every variant fills with zeros or rotates them
+///     x ^ z         -> x          the exclusive-or leaves every bit alone
+///     x + z         -> x          and carries nothing, so the carry word is z
+/// ```
+///
+/// A gate with one output pads the pair with a wire forwarded to itself, which rewrites nothing.
+fn zero_identity(
+	graph: &GateGraph,
+	gate: Gate,
+	zero: Wire,
+	force_committed: &EntitySet<Wire>,
+	hint_registry: &HintRegistry,
+) -> Option<[(Wire, Wire); 2]> {
+	let data = graph.gate_data(gate);
+	let param = data.gate_param_with_registry(hint_registry);
+	let opcode = data.opcode;
+
+	// A force-committed output has to stay a committed wire backed by its own constraint, so
+	// leave the gate alone rather than strand it.
+	if param
+		.outputs
+		.iter()
+		.any(|wire| force_committed.contains(*wire))
+	{
+		return None;
+	}
+
+	// The padding pair, which `replace_wire_with_wire` recognises as a no-op.
+	let nothing = (zero, zero);
+
+	match (opcode, param.inputs, param.outputs) {
+		// A shift of zero is zero, for every variant and amount.
+		(Opcode::Shift, [x], [z]) if *x == zero => Some([(*z, zero), nothing]),
+
+		// Exclusive-or with zero is the other operand.
+		(Opcode::Bxor, [a, b], [z]) if *b == zero => Some([(*z, *a), nothing]),
+		(Opcode::Bxor, [a, b], [z]) if *a == zero => Some([(*z, *b), nothing]),
+
+		// Adding zero leaves each half alone and produces no carry in either half.
+		(Opcode::Iadd32, [a, b], [sum, cout]) if *b == zero => Some([(*sum, *a), (*cout, zero)]),
+		(Opcode::Iadd32, [a, b], [sum, cout]) if *a == zero => Some([(*sum, *b), (*cout, zero)]),
+
+		_ => None,
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::compiler::{CircuitBuilder, Options};
+
+	/// Builds with only zero propagation and dead-code elimination active, so the AND count
+	/// reflects the pass under test rather than the rest of the pipeline.
+	fn opts_with_zero_fold(enable: bool) -> Options {
+		Options {
+			enable_zero_propagation: enable,
+			..Options::default()
+		}
+	}
+
+	#[test]
+	fn zero_addend_costs_no_carry_chain() {
+		// Invariant: a zero addend leaves the sum alone, so the carry chain is dead weight.
+		// The zero reaches the addition only after a shift and an exclusive-or, which is the
+		// shape lane packing produces, so all three rules have to fire in turn.
+		let count_and = |enable| {
+			let builder = CircuitBuilder::with_opts(opts_with_zero_fold(enable));
+			let x = builder.add_inout();
+			let zero = builder.add_constant(Word::ZERO);
+
+			// zero --shift--> zero --exclusive-or--> zero, the packed form of a padding word.
+			let packed = builder.bxor(builder.shl(zero, 32), zero);
+			let sum = builder.iadd_32(x, packed);
+
+			let out = builder.add_inout();
+			builder.assert_eq("sum", sum, out);
+			let circuit = builder.build();
+			crate::CircuitStat::collect(&circuit).n_and_constraints
+		};
+
+		// Folded, only the equality assertion remains; unfolded, the carry chain is paid too.
+		assert!(count_and(true) < count_and(false));
+		assert_eq!(count_and(true), 1);
+	}
+
+	#[test]
+	fn folded_circuit_still_computes_the_sum() {
+		// Invariant: the pass rewrites which wire carries a value, never the value itself.
+		let builder = CircuitBuilder::new();
+		let x = builder.add_inout();
+		let y = builder.add_inout();
+		let zero = builder.add_constant(Word::ZERO);
+
+		// Two additions, one foldable and one not, so the folded path has to agree with a
+		// carry chain that really runs.
+		let folded = builder.iadd_32(x, zero);
+		let real = builder.iadd_32(folded, y);
+		let out = builder.add_inout();
+		builder.assert_eq("sum", real, out);
+
+		let circuit = builder.build();
+		let mut w = circuit.new_witness_filler();
+		// Low halves overflow and high halves do not, so a carry crossing bit 32 would show.
+		w[x] = Word(0x0000_0002_FFFF_FFFF);
+		w[y] = Word(0x0000_0003_0000_0001);
+		w[out] = Word(0x0000_0005_0000_0000);
+		circuit.populate_wire_witness(&mut w).unwrap();
+	}
+
+	#[test]
+	fn a_circuit_without_zero_is_untouched() {
+		// Invariant: the pass interns nothing, so a circuit holding no zero constant keeps
+		// exactly the constants it declared.
+		let builder = CircuitBuilder::new();
+		let x = builder.add_inout();
+		let out = builder.add_inout();
+		builder.assert_eq("shifted", builder.shl(x, 8), out);
+		let circuit = builder.build();
+
+		// Only the all-one word the gate graph seeds, plus the one the assertion uses.
+		let constants = &circuit.constraint_system().constants;
+		assert!(!constants.contains(&Word::ZERO));
+	}
+}


### PR DESCRIPTION
Closes [BINIUS-378](https://linear.app/jimpo/issue/BINIUS-378).

Split out of #1952 at review request. A new gate-graph pass drops the gates a zero operand turns into the identity.

The hash-based signature circuit gains the most, at **-6.9%** AND constraints and committed values.

### The problem

Padding produces zero operands, and the compiler pays full price for them.

A parallel 32-bit addition whose addend is the zero word still emits its carry chain, spending an AND constraint on a sum that equals its other operand.

Hashes make this expensive because they mix every word of their block every round.

The Winternitz chain tweak is `param || 0x00 || epoch || chain_index || position`. At a 16-byte parameter that leaves 10 of the 16 message words zero, and BLAKE3 runs 7 rounds — so **70 carry chains per compression** exist only to add nothing.

### The idea

A gate whose operand is zero is the identity, so its result is already carried by another wire.

```
shift(0, n)  -> 0        every variant fills with zeros or rotates them
x ^ 0        -> x        the exclusive-or leaves every bit alone
x + 0        -> x        and carries nothing, so the carry word is zero
```

Point the readers at that wire and the gate becomes unread, so the existing dead-code pass removes it along with the constraint it would have emitted.

All three rules are needed together, because a zero has to survive being packed into a lane before it reaches an addition:

```
zero --shift--> zero --exclusive-or--> zero --addition--> folds away
```

That chain is also why the pass sweeps to a fixpoint rather than once.

### The change

A pass rather than a builder fold, per review. `crates/frontend/src/compiler/zero_fold.rs`, run before dead-code elimination and on by default.

The wire-to-wire replacement it needs generalises the existing constant replacement:

```
- pub fn replace_wire_with_constant(&mut self, old: Wire, value: Word) -> ConstantReplacement
+ pub fn replace_wire_with_constant(&mut self, old: Wire, value: Word) -> WireReplacement   // now delegates
+ pub fn replace_wire_with_wire(&mut self, old: Wire, new: Wire) -> WireReplacement
```

Each sweep rebuilds the use-def index first. Forwarding to an ordinary wire grows that wire's set of readers, and a stale index would not list them, so a later sweep forwarding that same wire would miss them.

### Why the rules are restricted to zero

Folding *every* known operand through a shift was the first attempt, and it measured worse.

SHA-256's round constants generate hundreds of distinct shifted values, so it traded 198 AND constraints for **320 extra committed values** and pushed its public section from $2^9$ to $2^{10}$.

Restricting to zero interns no new constant at all — **no circuit's constant count changes** in this PR.

### Soundness

- Each rule is an identity on 64-bit words, so the compiled circuit computes the same function.
- A gate whose output is force-committed is skipped, since that wire has to stay committed and backed by its own constraint.
- The pass looks the zero constant up instead of interning it, so a circuit that has none is untouched.

### Scope

- **new:** the pass and its tests.
- **changed:** one pass-pipeline hook, one graph primitive, and the fusion snapshot fixture (which asserts on gates this pass would forward past, so it opts out).
- **left untouched:** every circuit. This is a compiler change; the snapshots move because circuits get cheaper, not because they were edited.

### Verification

- `cargo check --workspace --all-targets`, clippy on the frontend, nightly `fmt` — clean.
- 182 frontend + 319 circuits + 39 shift-reduction tests pass.
- Tests cover: the full shift-then-exclusive-or-then-add chain folding to a single assertion; a folded and an unfolded addition agreeing on values that overflow the low half but not the high half; and a circuit with no zero constant keeping its constant set.

### Benchmark

Compiled counts, from the committed snapshots:

| circuit | AND before | AND after | change | committed before | committed after |
|---|---|---|---|---|---|
| hashsign | 297,984 | 277,556 | **-6.9%** | 297,094 | 276,666 |
| bitcoin_headers | 20,221 | 20,036 | -0.9% | 20,352 | 20,167 |
| zklogin | 357,836 | 356,617 | -0.3% | 360,378 | 359,159 |
| sha256 | 8,880 | 8,856 | -0.3% | 9,213 | 9,189 |
| blake3 | 5,451 | 5,445 | -0.1% | 5,660 | 5,654 |
| bitcoin_p2pkh | 113,587 | 113,474 | -0.1% | 135,993 | 135,880 |
| ethsign | 159,866 | 159,863 | -0.002% | 190,032 | 190,029 |
| keccak / blake2s / blake2b / ec_msm / sha512 | — | — | unchanged | — | — |

AND constraints and committed values both fall in every circuit that moves, and no constant count changes anywhere. The hash-based signature circuit's AND fill drops from 56.8% to 52.9% of $2^{19}$.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
