### PR TITLE
BINIUS-380: cut the doubled hint binding and per-pair masking around SHA-256's paired core

### DIFF
--- a/crates/circuits/src/sha256/compress.rs
+++ b/crates/circuits/src/sha256/compress.rs
@@ -144,7 +144,9 @@ pub fn sha256_compress_2x(builder: &CircuitBuilder, state_in: State, m: [Wire; 1
 /// # Preconditions
 ///
 /// - Every input wire holds a valid 32-bit value in its low 32 bits.
-/// - High halves need not be empty; they are cleared internally where it matters.
+/// - High halves need not be empty.
+///   - A block word's high half is masked off.
+///   - A state word's is discarded by the shift that lifts it into the high lane.
 ///
 /// # Returns
 ///
@@ -174,23 +176,31 @@ pub fn sha256_compress_2x_seq(
 	let pack = |lo: Wire, hi: Wire| builder.bxor(lo, builder.shl(hi, 32));
 	let clear = |w: Wire| clear_high_bits(builder, w, 32);
 
-	// Bind the high half of each merged word to the real input state.
-	// The high half is the first compression's claimed input.
-	// This proves the high lane compresses the genuine state.
-	for (m, s) in iter::zip(merged, state_in.0) {
-		builder.assert_eq("sha256_compress_2x_seq.state_in", builder.shr(m, 32), clear(s));
-	}
-
 	// Merged block: low lane = second block, high lane = first block.
 	let merged_block: [Wire; 16] = array::from_fn(|i| pack(clear(blocks[1][i]), blocks[0][i]));
 
 	let out = sha256_compress_2x(builder, State::new(merged), merged_block);
 
-	// Bind the hint's honesty by equating the two derivations of the first output:
-	// - first compression's in-circuit output = high lane of the result
-	// - value the hint fed as the second input = low half of each merged word
-	for (m, o) in iter::zip(merged, out.0) {
-		builder.assert_eq("sha256_compress_2x_seq.s1_out", clear(m), builder.shr(o, 32));
+	// Bind the hinted state, one 64-bit equality per word.
+	// A single equality pins both halves, since they never overlap.
+	//
+	//     bits 32..64 <- the first compression's declared input, shifted up
+	//     bits  0..32 <- the first compression's in-circuit output, shifted down
+	//
+	//     hinted word:  [ high lane = input state | low lane = S1 output ]
+	//                          must equal                must equal
+	//                     input state << 32       ^     result >> 32
+	//
+	// Consequences, which together leave the hint no freedom:
+	// - The high lane provably compresses the caller's own state.
+	// - The low lane provably chains from what the first compression really produced.
+	//
+	// Each side is one shift of a committed word, so no masking is needed:
+	// - Shifting up discards the input's own high bits.
+	// - Shifting down discards the result's low bits.
+	for (m, (s, o)) in iter::zip(merged, iter::zip(state_in.0, out.0)) {
+		let expected = builder.bxor(builder.shl(s, 32), builder.shr(o, 32));
+		builder.assert_eq("sha256_compress_2x_seq.merged_state", m, expected);
 	}
 
 	out
@@ -733,8 +743,26 @@ mod tests {
 			0x19db_06c1,
 		];
 
+		// The chaining value the first block hands to the second, published with the same vector.
+		//
+		// Why anchor the boundary and not only the digest:
+		// - The high lane must reproduce exactly this value.
+		// - The low lane must chain from it.
+		// - So this is what pins the hinted state carried between the two lanes.
+		let expected_s1: [u32; 8] = [
+			0x85e6_55d6,
+			0x417a_1795,
+			0x3363_376a,
+			0x624c_de5c,
+			0x76e0_9589,
+			0xcac5_f811,
+			0xcc4b_32c1,
+			0xf20e_533a,
+		];
+
 		// The second compression's output is the message digest; anchor it to the RFC vector.
 		let s1 = ref_compress(IV, block0);
+		assert_eq!(s1, expected_s1);
 		let s2 = ref_compress(s1, block1);
 		assert_eq!(s2, expected);
 

--- a/crates/circuits/src/sha256/mod.rs
+++ b/crates/circuits/src/sha256/mod.rs
@@ -126,15 +126,20 @@ pub fn sha256_fixed(builder: &CircuitBuilder, message: &[Wire], len_bytes: usize
 	let mask32 = builder.add_constant(Word::MASK_32);
 	let mut state = State::iv(builder);
 	let mut block_idx = 0;
+	// The threaded state carries the pair's first compression in its high half.
+	// That half is left as it is rather than masked off, since nothing downstream reads it:
+	//
+	// - A compression never lets a carry or a rotate cross bit 32, so the halves stay apart.
+	// - The paired core takes an input state's low half only, through a left shift.
+	//
+	// So the low half of a result depends on the low halves of its inputs alone.
 	while block_idx + 1 < n_blocks {
-		let out = sha256_compress_2x_seq(
+		// The chaining state after the pair is the second compression's output, in the low half.
+		state = sha256_compress_2x_seq(
 			&builder.subcircuit(format!("sha256_fixed_compress[{block_idx}..{}]", block_idx + 2)),
 			state,
 			[blocks[block_idx], blocks[block_idx + 1]],
 		);
-		// The chaining state after the pair is the second compression's output.
-		// It sits in the low 32 bits of each word; the mask restores the empty high half.
-		state = State::new(std::array::from_fn(|i| builder.band(out.0[i], mask32)));
 		block_idx += 2;
 	}
 	if block_idx < n_blocks {
@@ -145,8 +150,16 @@ pub fn sha256_fixed(builder: &CircuitBuilder, message: &[Wire], len_bytes: usize
 		);
 	}
 
-	// Return the final state as 8 32-bit words
-	state.0
+	// The escaping digest is the one place a clean high half is required.
+	// So mask once here rather than after every pair, since a caller compares all 64 bits.
+	//
+	// Why a single-block message skips it:
+	// - Such a message never enters the paired core.
+	// - The one-lane core maps an empty high half to an empty high half.
+	if n_blocks < 2 {
+		return state.0;
+	}
+	std::array::from_fn(|i| builder.band(state.0[i], mask32))
 }
 
 /// Computes the SHA-256 hash of a variable-length message.

--- a/crates/examples/snapshots/bitcoin_headers.snap
+++ b/crates/examples/snapshots/bitcoin_headers.snap
@@ -1,32 +1,32 @@
 bitcoin_headers circuit
 --
 Gates & Instructions
-├─ Number of gates: 47,258
-└─ Number of evaluation instructions: 47,378
+├─ Number of gates: 46,938
+└─ Number of evaluation instructions: 47,058
 
 Constraints
 ├─ ZERO constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-├─ AND constraints: 20,036 used (61.1% of 2^15)
-│  [▓▓▓▓▓▓░░░░] spare: 12,732
+├─ AND constraints: 19,868 used (60.6% of 2^15)
+│  [▓▓▓▓▓▓░░░░] spare: 12,900
 ├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
 ├─ BMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-└─ Distinct value indices: 47,090
-   ├─ Distinct shifted value indices: 26,930
-   └─ Distinct unshifted value indices: 20,160
+└─ Distinct value indices: 46,754
+   ├─ Distinct shifted value indices: 26,682
+   └─ Distinct unshifted value indices: 20,072
 
 Value Vector
 ├─ Public Section: 157 used (61.3% of 2^8)
 │  [▓▓▓▓▓▓░░░░] spare: 99
 │  ├─ Constants: 157
 │  └─ Inout: 0
-├─ Private Section: 20,010 used (61.5%)
-│  [▓▓▓▓▓▓░░░░] spare: 12,502
+├─ Private Section: 19,922 used (61.3%)
+│  [▓▓▓▓▓▓░░░░] spare: 12,590
 │  ├─ Witness: 104
-│  └─ Internal: 19,906
-├─ Total Committed: 20,167 used (61.5% of 2^15)
-│  [▓▓▓▓▓▓░░░░] spare: 12,601
-└─ Scratch (uncommitted): 39,342 (peak live: 53)
+│  └─ Internal: 19,818
+├─ Total Committed: 20,079 used (61.3% of 2^15)
+│  [▓▓▓▓▓▓░░░░] spare: 12,689
+└─ Scratch (uncommitted): 39,190 (peak live: 53)
 

--- a/crates/examples/snapshots/sha256.snap
+++ b/crates/examples/snapshots/sha256.snap
@@ -1,32 +1,32 @@
 sha256 circuit
 --
 Gates & Instructions
-├─ Number of gates: 20,616
-└─ Number of evaluation instructions: 20,616
+├─ Number of gates: 20,304
+└─ Number of evaluation instructions: 20,304
 
 Constraints
 ├─ ZERO constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-├─ AND constraints: 8,856 used (54.1% of 2^14)
-│  [▓▓▓▓▓░░░░░] spare: 7,528
+├─ AND constraints: 8,608 used (52.5% of 2^14)
+│  [▓▓▓▓▓░░░░░] spare: 7,776
 ├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
 ├─ BMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-└─ Distinct value indices: 21,514
-   ├─ Distinct shifted value indices: 12,590
-   └─ Distinct unshifted value indices: 8,924
+└─ Distinct value indices: 21,074
+   ├─ Distinct shifted value indices: 12,334
+   └─ Distinct unshifted value indices: 8,740
 
 Value Vector
 ├─ Public Section: 405 used (79.1% of 2^9)
 │  [▓▓▓▓▓▓▓░░░] spare: 107
 │  ├─ Constants: 141
 │  └─ Inout: 264
-├─ Private Section: 8,784 used (55.3%)
-│  [▓▓▓▓▓░░░░░] spare: 7,088
+├─ Private Section: 8,600 used (54.2%)
+│  [▓▓▓▓▓░░░░░] spare: 7,272
 │  ├─ Witness: 0
-│  └─ Internal: 8,784
-├─ Total Committed: 9,189 used (56.1% of 2^14)
-│  [▓▓▓▓▓░░░░░] spare: 7,195
-└─ Scratch (uncommitted): 17,152 (peak live: 22)
+│  └─ Internal: 8,600
+├─ Total Committed: 9,005 used (55.0% of 2^14)
+│  [▓▓▓▓▓░░░░░] spare: 7,379
+└─ Scratch (uncommitted): 17,088 (peak live: 22)
 

--- a/crates/examples/snapshots/zklogin.snap
+++ b/crates/examples/snapshots/zklogin.snap
@@ -1,32 +1,32 @@
 zklogin circuit
 --
 Gates & Instructions
-├─ Number of gates: 485,515
-└─ Number of evaluation instructions: 549,282
+├─ Number of gates: 485,163
+└─ Number of evaluation instructions: 548,930
 
 Constraints
 ├─ ZERO constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-├─ AND constraints: 356,617 used (68.0% of 2^19)
-│  [▓▓▓▓▓▓░░░░] spare: 167,671
+├─ AND constraints: 356,369 used (68.0% of 2^19)
+│  [▓▓▓▓▓▓░░░░] spare: 167,919
 ├─ IMUL constraints: 8,262 used (50.4% of 2^14)
 │  [▓▓▓▓▓░░░░░] spare: 8,122
 ├─ BMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-└─ Distinct value indices: 653,232
-   ├─ Distinct shifted value indices: 294,083
-   └─ Distinct unshifted value indices: 359,149
+└─ Distinct value indices: 652,736
+   ├─ Distinct shifted value indices: 293,747
+   └─ Distinct unshifted value indices: 358,989
 
 Value Vector
 ├─ Public Section: 1,032 used (50.4% of 2^11)
 │  [▓▓▓▓▓░░░░░] spare: 1,016
 │  ├─ Constants: 730
 │  └─ Inout: 302
-├─ Private Section: 358,127 used (68.6%)
-│  [▓▓▓▓▓▓░░░░] spare: 164,113
+├─ Private Section: 357,967 used (68.5%)
+│  [▓▓▓▓▓▓░░░░] spare: 164,273
 │  ├─ Witness: 1,381
-│  └─ Internal: 356,746
-├─ Total Committed: 359,159 used (68.5% of 2^19)
-│  [▓▓▓▓▓▓░░░░] spare: 165,129
-└─ Scratch (uncommitted): 310,700 (peak live: 1,542)
+│  └─ Internal: 356,586
+├─ Total Committed: 358,999 used (68.5% of 2^19)
+│  [▓▓▓▓▓▓░░░░] spare: 165,289
+└─ Scratch (uncommitted): 310,596 (peak live: 1,542)
 


### PR DESCRIPTION
Closes [BINIUS-380](https://linear.app/jimpo/issue/BINIUS-380).

Cuts the redundant bindings and maskings around SHA-256's paired compression core. Same digests — the 64-round core is untouched.

Applies the two patterns reviewed and merged for BLAKE3 in #1952 to SHA-256, which was never updated.

### The core is already at its floor

A single compression compiles to **912** AND constraints:

- **600** modular additions — 144 schedule, 448 rounds, 8 feed-forward.
- **128** for choose and majority, both already in their one-constraint form (`z ^ (x & (y ^ z))` and `((x ^ z) & (y ^ z)) ^ z`).
- **~176** for sums the fusion pass must commit. A sum's carry term is left-shifted, the next round consumes it under a rotate, and those two shift kinds do not compose. 128 of these are `a` and `e` feeding the big sigmas; 46 are schedule words feeding the small ones.

I checked the add trees against the bit-equation bound: a k-operand 32-bit add needs exactly k-1 AND constraints, and carry-save gives no advantage because a majority costs the same as a full add. Nothing to win there.

So the slack is in the overhead *around* the core.

### 1. The paired core bound its hinted state twice

Each of the 8 words cost two assertions plus two maskings. The two halves are disjoint, so one 64-bit equality says the same thing:

```
hinted word:  [ high lane = input state | low lane = S1 output ]
                     must equal                must equal
                input state << 32       ^     result >> 32
```

Shifting up discards the input's own high bits; shifting down discards the result's low bits. Neither side needs a mask.

### 2. The fixed-length gadget masked the chaining state every pair

The paired core tolerates a dirty high half:

- Its hint truncates each input word to 32 bits.
- Its binding shifts the input state up, discarding the high bits anyway.
- A compression never lets a carry or a rotate cross bit 32, so the lanes stay apart.

So the paired output is threaded straight into the next pair, and only the escaping digest is masked — a caller compares all 64 bits.

A single-block message skips the mask entirely: it never enters the paired core, and the one-lane core maps an empty high half to an empty high half. Without that guard the change would have *added* 8 gates to every single-block circuit.

### Soundness

- The merged binding is logically **equivalent** to the two assertions it replaces, not weaker. Shifting up pins the high half, shifting down pins the low half, and together they pin all 64 bits.
- Dropping the intermediate mask rests on lane independence, which the gates give: `iadd_32`, `rotr32` and `srl32` all stay inside their own 32-bit half.
- The defensive masking on the paired core's **block** words stays. Message words are prover-supplied, so dirty high bits must not be able to steer a lane.

### Scope

- **changed:** the paired sequential binding, and the fixed-length gadget's chaining.
- **left untouched:** the 64-round core, the message schedule, the hint itself.
- **left untouched on purpose:** the variable-length gadget keeps its per-block mask, because its masked state feeds the digest packer, which does need a clean low half. It still inherits the binding fix.

### Verification

- `cargo check --workspace --all-targets`, clippy on the circuits crate, nightly `fmt` — clean.
- 327 circuits tests pass.
- The two-block known-answer test now pins the **chaining value handed between the blocks** (`85e655d6 417a1795 3363376a 624cde5c 76e09589 cac5f811 cc4b32c1 f20e533a`), not only the final digest. That boundary is exactly what the merged binding constrains, and it was previously checked only against our own reference.

### Benchmark

Compiled counts, from the committed snapshots and gadget-level counts:

| gadget / circuit | AND before | AND after | change | committed before | committed after |
|---|---|---|---|---|---|
| paired sequential compression | 998 | 974 | -2.4% | — | — |
| `sha256_fixed` (1 KiB) | 8,856 | 8,608 | **-2.8%** | — | — |
| `sha256_fixed` (4 KiB) | 32,808 | 31,792 | **-3.1%** | — | — |
| sha256 example | 8,856 | 8,608 | **-2.8%** | 9,189 | 9,005 |
| bitcoin_headers example | 20,036 | 19,868 | -0.8% | 20,167 | 20,079 |
| zklogin example | 356,617 | 356,369 | -0.07% | 359,159 | 358,999 |
| every other example | — | — | unchanged | — | — |

Gate count and distinct shifted value indices fall alongside AND in all three, so nothing is traded. The zklogin gain is small because it uses the variable-length gadget, which only picks up the binding fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
