### PR TITLE
Check BMUL constraints in verify_constraints

### DIFF
--- a/crates/core/src/verify.rs
+++ b/crates/core/src/verify.rs
@@ -6,7 +6,8 @@
 
 use crate::{
 	constraint_system::{
-		AndConstraint, ConstraintSystem, ImulConstraint, ValueIndex, ValueVec, ZeroConstraint,
+		AndConstraint, BmulConstraint, ConstraintSystem, ImulConstraint, ValueIndex, ValueVec,
+		ZeroConstraint,
 	},
 	word::Word,
 };
@@ -67,6 +68,54 @@ pub fn verify_imul_constraint(
 	}
 }
 
+/// Multiplies two elements of the GHASH field: `GF(2^128)` with reduction polynomial
+/// `X^128 + X^7 + X^2 + X + 1`, bit `i` carrying the coefficient of `X^i`.
+///
+/// Shift-and-add over `u128` — an independent restatement of the gate semantics for checking,
+/// not a call into the field crate's multiplier.
+fn ghash_mul(a: u128, b: u128) -> u128 {
+	let mut acc = 0u128;
+	let mut shifted = a;
+	for i in 0..128 {
+		if (b >> i) & 1 == 1 {
+			acc ^= shifted;
+		}
+		let overflow = shifted >> 127;
+		shifted <<= 1;
+		if overflow == 1 {
+			shifted ^= 0x87;
+		}
+	}
+	acc
+}
+
+/// Verifies that a BMUL constraint is satisfied: A * B = C in the GHASH field, each element
+/// carried by a `(lo, hi)` pair of words.
+pub fn verify_bmul_constraint(
+	witness: &ValueVec,
+	constraint: &BmulConstraint,
+) -> Result<(), String> {
+	let Word(a_lo) = witness.eval_operand(constraint.a_lo());
+	let Word(a_hi) = witness.eval_operand(constraint.a_hi());
+	let Word(b_lo) = witness.eval_operand(constraint.b_lo());
+	let Word(b_hi) = witness.eval_operand(constraint.b_hi());
+	let Word(c_lo) = witness.eval_operand(constraint.c_lo());
+	let Word(c_hi) = witness.eval_operand(constraint.c_hi());
+
+	let a = (a_lo as u128) | ((a_hi as u128) << 64);
+	let b = (b_lo as u128) | ((b_hi as u128) << 64);
+	let c = (c_lo as u128) | ((c_hi as u128) << 64);
+
+	let expected = ghash_mul(a, b);
+	if c != expected {
+		Err(format!(
+			"BMUL constraint failed: {a:032x} * {b:032x} = {c:032x} (expected {expected:032x})",
+		))
+	} else {
+		Ok(())
+	}
+}
+
 /// Verifies all constraints in a constraint system are satisfied by the witness
 pub fn verify_constraints(cs: &ConstraintSystem, witness: &ValueVec) -> Result<(), String> {
 	cs.validate_shape()
@@ -93,5 +142,77 @@ pub fn verify_constraints(cs: &ConstraintSystem, witness: &ValueVec) -> Result<(
 		verify_imul_constraint(witness, constraint)
 			.map_err(|e| format!("IMUL constraint {i} failed: {e}"))?;
 	}
+	for (i, constraint) in cs.bmul_constraints.iter().enumerate() {
+		verify_bmul_constraint(witness, constraint)
+			.map_err(|e| format!("BMUL constraint {i} failed: {e}"))?;
+	}
 	Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::constraint_system::ShiftedValueIndex;
+
+	/// Products pinned against `BinaryField128bGhash`: `X = 2`, coefficients ascend with bit
+	/// index, and `X^127 * X` wraps to the reduction polynomial.
+	#[test]
+	fn ghash_mul_matches_field_arithmetic() {
+		assert_eq!(ghash_mul(1, 0x0123_4567), 0x0123_4567);
+		assert_eq!(ghash_mul(2, 2), 4);
+		assert_eq!(ghash_mul(1 << 63, 2), 1 << 64);
+		assert_eq!(ghash_mul(1 << 127, 2), 0x87);
+		// Computed with `BinaryField128bGhash`.
+		assert_eq!(
+			ghash_mul(0x0123456789abcdef_fedcba9876543210, 0x0f1e2d3c4b5a6978_8796a5b4c3d2e1f0),
+			0x7f2984f784967f5a_7b881bf2b700d768
+		);
+	}
+
+	/// A shape whose six inout words carry one BMUL constraint's operands directly.
+	///
+	///     [ _ _ | a_lo a_hi b_lo b_hi c_lo c_hi ][ p p p p p p p p ]
+	///       0 1   2    3    4    5    6    7       8 ...        15
+	fn one_bmul_system() -> ConstraintSystem {
+		ConstraintSystem {
+			constants: vec![],
+			n_const_pad: 2,
+			n_inout: 6,
+			n_inout_pad: 0,
+			n_private: 8,
+			n_private_pad: 0,
+			zero_constraints: vec![],
+			and_constraints: vec![],
+			imul_constraints: vec![],
+			bmul_constraints: vec![BmulConstraint(std::array::from_fn(|i| {
+				vec![ShiftedValueIndex::plain(ValueIndex(2 + i as u32))]
+			}))],
+		}
+	}
+
+	fn one_bmul_witness(a: u128, b: u128, c: u128) -> ValueVec {
+		let split = |x: u128| [Word::from_u64(x as u64), Word::from_u64((x >> 64) as u64)];
+		let [a_lo, a_hi] = split(a);
+		let [b_lo, b_hi] = split(b);
+		let [c_lo, c_hi] = split(c);
+		let public = [Word::ZERO, Word::ZERO, a_lo, a_hi, b_lo, b_hi, c_lo, c_hi];
+		ValueVec::new_from_data(&public, &[Word::ZERO; 8])
+	}
+
+	#[test]
+	fn bmul_constraint_accepts_correct_product() {
+		let a = 0x0123456789abcdef_fedcba9876543210;
+		let b = 0x0f1e2d3c4b5a6978_8796a5b4c3d2e1f0;
+		let witness = one_bmul_witness(a, b, ghash_mul(a, b));
+		assert!(verify_constraints(&one_bmul_system(), &witness).is_ok());
+	}
+
+	#[test]
+	fn bmul_constraint_rejects_wrong_product() {
+		let a = 0x0123456789abcdef_fedcba9876543210;
+		let b = 0x0f1e2d3c4b5a6978_8796a5b4c3d2e1f0;
+		let witness = one_bmul_witness(a, b, ghash_mul(a, b) ^ 1);
+		let err = verify_constraints(&one_bmul_system(), &witness).unwrap_err();
+		assert!(err.contains("BMUL constraint 0 failed"), "{err}");
+	}
 }


### PR DESCRIPTION
`verify_constraints` walks the constants section, the AND constraints, and the IMUL constraints, then returns `Ok` — it never looks at `bmul_constraints`. Any test that checks a bmul gadget through this function therefore under-checks: a witness carrying a wrong GHASH product passes.

Found while writing negative tests for a bmul-based gadget — the corrupted witnesses were accepted.

## The change

`verify_bmul_constraint` checks `A * B = C` in the GHASH field, with each element carried by its `(lo, hi)` word pair, and `verify_constraints` gains the third loop.

The multiply is a self-contained shift-and-reduce over `u128` rather than a call into `binius-field`: `binius-core` doesn't depend on the field crate, and an independent restatement of the reduction is what makes the check worth having. Its convention is pinned against `BinaryField128bGhash` in the tests.

## Testing

`ghash_mul_matches_field_arithmetic` pins the products (`X * X`, the `X^63`/`X^127` boundary cases, and one random pair) against values computed with `BinaryField128bGhash`. `bmul_constraint_accepts_correct_product` and `bmul_constraint_rejects_wrong_product` run a one-constraint system through `verify_constraints`, the second flipping a single product bit that passed before.
