### PR TITLE
BINIUS-382: mask low 32 bits with clear_high_bits instead of a bitand

### DIFF
--- a/crates/circuits/src/bitcoin/double_sha256.rs
+++ b/crates/circuits/src/bitcoin/double_sha256.rs
@@ -1,11 +1,11 @@
+// Copyright 2026 The Binius Developers
 // Copyright 2025 Irreducible Inc.
 //! The Bitcoin double-SHA256 hash function.
 
-use binius_core::word::Word;
 use binius_frontend::{CircuitBuilder, Wire, WitnessFiller};
 use sha2::Digest;
 
-use crate::{bytes::swap_bytes_32, sha256::sha256_fixed};
+use crate::{bytes::swap_bytes_32, sha256::sha256_fixed, util::clear_high_bits};
 
 /// Retained only so callers can obtain the reference digest via [`Self::populate_inner`].
 ///
@@ -27,8 +27,6 @@ impl DoubleSha256 {
 		message: &[Wire],
 		digest: [Wire; 4],
 	) -> Self {
-		let mask32 = builder.add_constant(Word::MASK_32);
-
 		// First SHA-256. `message` is little-endian 8-byte wires; `sha256_fixed` consumes
 		// big-endian 32-bit schedule words, so byte-swap within each 32-bit half and split each
 		// 64-bit wire into its two schedule words (mirrors `sha256::sha256_varlen`'s input
@@ -36,7 +34,7 @@ impl DoubleSha256 {
 		let mut message_be: Vec<Wire> = Vec::with_capacity(message.len() * 2);
 		for &w in message {
 			let swapped = swap_bytes_32(builder, w);
-			message_be.push(builder.band(swapped, mask32));
+			message_be.push(clear_high_bits(builder, swapped, 32));
 			message_be.push(builder.shr(swapped, 32));
 		}
 		let digest_0_be = sha256_fixed(builder, &message_be, message.len() * 8); // [Wire; 8] BE

--- a/crates/circuits/src/bitcoin/p2pkh_signature.rs
+++ b/crates/circuits/src/bitcoin/p2pkh_signature.rs
@@ -11,6 +11,7 @@ use crate::{
 	ripemd::ripemd160_fixed,
 	secp256k1::{Secp256k1, Secp256k1Affine},
 	sha256::sha256_fixed,
+	util::clear_high_bits,
 };
 
 /// Convert 20-byte address payload into five little-endian u32 words (circuit witness layout).
@@ -120,7 +121,7 @@ pub fn compress_pubkey(builder: &CircuitBuilder, x: &BigUint, y: &BigUint) -> Ve
 
 	// We need to produce 9 words (33 bytes) for sha256_fixed
 	// Each word represents 4 bytes packed in big-endian format
-	let lower_32_bits = |limb| builder.band(limb, builder.add_constant_64(0xFFFFFFFF));
+	let lower_32_bits = |limb| clear_high_bits(builder, limb, 32);
 	vec![
 		builder.bor(builder.shr(x.limbs[3], 40), prefix_byte),
 		lower_32_bits(builder.shr(x.limbs[3], 8)),

--- a/crates/circuits/src/blake2s/mod.rs
+++ b/crates/circuits/src/blake2s/mod.rs
@@ -1,3 +1,4 @@
+// Copyright 2026 The Binius Developers
 // Copyright 2025 Irreducible Inc.
 //! Blake2s hash function circuit implementation
 //!
@@ -46,6 +47,8 @@ mod tests;
 use binius_core::word::Word;
 use binius_frontend::{CircuitBuilder, Wire, WitnessFiller};
 use constants::{IV, SIGMA};
+
+use crate::util::clear_high_bits;
 
 /// Blake2s G mixing function - the core cryptographic primitive.
 ///
@@ -345,7 +348,7 @@ impl Blake2s {
 
 				// Select low or high dword from the qword
 				let message_dword = if word_idx % 2 == 0 {
-					builder.band(message_qword, builder.add_constant_64(0xFFFF_FFFF))
+					clear_high_bits(builder, message_qword, 32)
 				} else {
 					builder.shr(message_qword, 32)
 				};

--- a/crates/circuits/src/blake3/compress.rs
+++ b/crates/circuits/src/blake3/compress.rs
@@ -42,8 +42,7 @@ pub fn blake3_compress(
 	flags: Wire,
 ) -> [Wire; 8] {
 	// Split the counter into 32-bit halves.
-	let mask_lo32 = builder.add_constant(Word(0xFFFF_FFFF));
-	let t_low = builder.band(counter, mask_lo32);
+	let t_low = clear_high_bits(builder, counter, 32);
 	let t_high = builder.shr(counter, 32);
 
 	let v: [Wire; 16] = [

--- a/crates/circuits/src/hash_based_sig/hashing/chain_blake3.rs
+++ b/crates/circuits/src/hash_based_sig/hashing/chain_blake3.rs
@@ -1,3 +1,4 @@
+// Copyright 2026 The Binius Developers
 // Copyright 2025 Irreducible Inc.
 //! BLAKE3 chain hash for Winternitz hash chains.
 //!
@@ -23,6 +24,7 @@ use crate::{
 	blake3::{blake3_compress, blake3_compress_2x, ref_compress},
 	concat::concat,
 	fixed_byte_vec::ByteVec,
+	util::clear_high_bits,
 };
 
 /// Tweak separator byte for chain hashing.
@@ -39,8 +41,8 @@ const EPOCH_BYTES: usize = 4;
 const CHAIN_INDEX_BYTES: usize = 1;
 const POSITION_BYTES: usize = 1;
 
-/// Mask selecting the low 32 bits of a 64-bit word.
-const LOW32_MASK: u64 = 0xFFFF_FFFF;
+/// Mask selecting the high 32 bits of a 64-bit word.
+const HIGH32_MASK: u64 = 0xFFFF_FFFF_0000_0000;
 
 /// BLAKE3 block size in bytes (one compression).
 const BLOCK_BYTES: usize = 64;
@@ -59,13 +61,12 @@ pub const fn chain_tweak_len(param_len: usize) -> usize {
 ///
 /// Returns exactly `num_words` words.
 fn split_u32_words(builder: &CircuitBuilder, data: &[Wire], num_words: usize) -> Vec<Wire> {
-	let mask = builder.add_constant_64(LOW32_MASK);
 	let mut words = Vec::with_capacity(num_words);
 	for &w in data {
 		if words.len() >= num_words {
 			break;
 		}
-		words.push(builder.band(w, mask));
+		words.push(clear_high_bits(builder, w, 32));
 		if words.len() >= num_words {
 			break;
 		}
@@ -183,15 +184,14 @@ fn interleave_cv_2x(
 	hash0: [Wire; 4],
 	hash1: [Wire; 4],
 ) -> [Wire; CV_WORDS] {
-	let low = builder.add_constant_64(LOW32_MASK);
-	let high = builder.add_constant_64(!LOW32_MASK);
+	let high = builder.add_constant_64(HIGH32_MASK);
 	std::array::from_fn(|i| {
 		// Two output words come from one input wire, so the wire index advances at half the rate.
 		let k = i / 2;
 		if i % 2 == 0 {
 			// An even word is each value's lower half.
 			// The first value already sits there; the second lifts into the upper half.
-			builder.bxor(builder.band(hash0[k], low), builder.shl(hash1[k], 32))
+			builder.bxor(clear_high_bits(builder, hash0[k], 32), builder.shl(hash1[k], 32))
 		} else {
 			// An odd word is each value's upper half.
 			// The first value drops into the lower half; the second already sits in place.
@@ -208,11 +208,10 @@ fn interleave_cv_2x(
 /// - The second is built from the high halves.
 /// - Each 64-bit result wire consumes two consecutive output words.
 fn deinterleave_cv_2x(builder: &CircuitBuilder, out: &[Wire; CV_WORDS]) -> ([Wire; 4], [Wire; 4]) {
-	let low = builder.add_constant_64(LOW32_MASK);
-	let high = builder.add_constant_64(!LOW32_MASK);
+	let high = builder.add_constant_64(HIGH32_MASK);
 	// Low halves: the even word stays put, the odd word lifts into the upper half.
 	let lane0 = std::array::from_fn(|k| {
-		builder.bxor(builder.band(out[2 * k], low), builder.shl(out[2 * k + 1], 32))
+		builder.bxor(clear_high_bits(builder, out[2 * k], 32), builder.shl(out[2 * k + 1], 32))
 	});
 	// High halves: the even word drops down, the odd word already sits in the upper half.
 	let lane1 = std::array::from_fn(|k| {

--- a/crates/circuits/src/lib.rs
+++ b/crates/circuits/src/lib.rs
@@ -1,3 +1,4 @@
+// Copyright 2026 The Binius Developers
 // Copyright 2025 Irreducible Inc.
 
 //! Standard library of circuit gadgets for Binius64.
@@ -43,4 +44,4 @@ pub mod sha512;
 pub mod shift;
 pub mod skein512;
 pub mod slice;
-mod util;
+pub mod util;

--- a/crates/circuits/src/popcount.rs
+++ b/crates/circuits/src/popcount.rs
@@ -1,3 +1,4 @@
+// Copyright 2026 The Binius Developers
 // Copyright 2025 Irreducible Inc.
 //! Popcount circuit implementation for counting 1-bits in a 64-bit word.
 //!
@@ -31,6 +32,8 @@
 
 use binius_frontend::{CircuitBuilder, Wire};
 
+use crate::util::clear_high_bits;
+
 /// Computes the population count (number of 1-bits) of a 64-bit word.
 ///
 /// This function implements the SWAR algorithm to efficiently count bits
@@ -52,7 +55,6 @@ pub fn popcount(builder: &mut CircuitBuilder, input: Wire) -> Wire {
 	let mask_0f0f = builder.add_constant_64(0x0F0F0F0F0F0F0F0F); // 00001111...
 	let mask_00ff = builder.add_constant_64(0x00FF00FF00FF00FF); // 8 ones, 8 zeros...
 	let mask_0000ffff = builder.add_constant_64(0x0000FFFF0000FFFF); // 16 ones, 16 zeros...
-	let mask_00000000ffffffff = builder.add_constant_64(0x00000000FFFFFFFF); // 32 ones
 
 	// Step 1: Count bits in 2-bit groups using subtraction trick
 	// n = n - ((n >> 1) & 0x5555555555555555)
@@ -100,7 +102,7 @@ pub fn popcount(builder: &mut CircuitBuilder, input: Wire) -> Wire {
 	let (n_sum6, _carry) = builder.iadd(n_step5, n_shr_32);
 
 	// The final result is in the lower bits and represents the popcount (0-64)
-	builder.band(n_sum6, mask_00000000ffffffff)
+	clear_high_bits(builder, n_sum6, 32)
 }
 
 #[cfg(test)]

--- a/crates/circuits/src/sha256/mod.rs
+++ b/crates/circuits/src/sha256/mod.rs
@@ -1,3 +1,4 @@
+// Copyright 2026 The Binius Developers
 // Copyright 2025 Irreducible Inc.
 pub mod compress;
 
@@ -12,6 +13,7 @@ use crate::{
 	bytes::swap_bytes_32,
 	fixed_byte_vec::ByteVec,
 	multiplexer::{multi_wire_multiplex, single_wire_multiplex},
+	util::clear_high_bits,
 };
 
 /// Computes SHA-256 hash of a fixed-length message.
@@ -123,7 +125,6 @@ pub fn sha256_fixed(builder: &CircuitBuilder, message: &[Wire], len_bytes: usize
 		.collect();
 	let n_blocks = blocks.len();
 
-	let mask32 = builder.add_constant(Word::MASK_32);
 	let mut state = State::iv(builder);
 	let mut block_idx = 0;
 	// The threaded state carries the pair's first compression in its high half.
@@ -151,7 +152,8 @@ pub fn sha256_fixed(builder: &CircuitBuilder, message: &[Wire], len_bytes: usize
 	}
 
 	// The escaping digest is the one place a clean high half is required.
-	// So mask once here rather than after every pair, since a caller compares all 64 bits.
+	// So clear the high half once here rather than after every pair, since a caller compares all
+	// 64 bits.
 	//
 	// Why a single-block message skips it:
 	// - Such a message never enters the paired core.
@@ -159,7 +161,7 @@ pub fn sha256_fixed(builder: &CircuitBuilder, message: &[Wire], len_bytes: usize
 	if n_blocks < 2 {
 		return state.0;
 	}
-	std::array::from_fn(|i| builder.band(state.0[i], mask32))
+	std::array::from_fn(|i| clear_high_bits(builder, state.0[i], 32))
 }
 
 /// Computes the SHA-256 hash of a variable-length message.
@@ -218,11 +220,10 @@ pub fn sha256_varlen(builder: &CircuitBuilder, message: &ByteVec) -> [Wire; 4] {
 	// 64-bit data word carries two schedule words: `swap_bytes_32` byte-reverses within each 32-bit
 	// half, so the low half becomes the big-endian schedule word for the first four bytes and the
 	// high half the schedule word for the next four. Split each into two low-32 wires.
-	let mask32 = builder.add_constant(Word::MASK_32);
 	let mut message_be: Vec<Wire> = Vec::with_capacity(message.data.len() * 2);
 	for &word in &message.data {
 		let swapped = swap_bytes_32(builder, word);
-		message_be.push(builder.band(swapped, mask32));
+		message_be.push(clear_high_bits(builder, swapped, 32));
 		message_be.push(builder.shr(swapped, 32));
 	}
 
@@ -318,9 +319,11 @@ pub fn sha256_varlen(builder: &CircuitBuilder, message: &ByteVec) -> [Wire; 4] {
 			states[block_no],
 			[mk_m(block_no), mk_m(block_no + 1)],
 		);
-		// The mask restores the empty high half that the single-lane digest packing relies on.
+		// Clearing the high half restores the empty half that the single-lane digest packing
+		// relies on.
 		let state_first = State::new(std::array::from_fn(|i| builder.shr(out.0[i], 32)));
-		let state_second = State::new(std::array::from_fn(|i| builder.band(out.0[i], mask32)));
+		let state_second =
+			State::new(std::array::from_fn(|i| clear_high_bits(builder, out.0[i], 32)));
 		states.push(state_first);
 		states.push(state_second);
 		block_no += 2;

--- a/crates/circuits/src/util.rs
+++ b/crates/circuits/src/util.rs
@@ -6,9 +6,23 @@ use binius_frontend::{CircuitBuilder, Wire};
 
 /// Zero the high `n` bits of a 64-bit word, keeping the low `64 - n` bits in place.
 ///
-/// Lowers to a left-then-right shift pair, which is cheaper than masking with a `band`
-/// against a constant.
-pub(crate) fn clear_high_bits(builder: &CircuitBuilder, w: Wire, n: u32) -> Wire {
+/// Lowers to a left-then-right shift pair. The two shifts do not compose into one shifted
+/// operand, so gate fusion commits the intermediate and spends one constraint on it — the same
+/// count masking with a `band` against a constant costs today. The pair is the cheaper form only
+/// once a committed linear definition lowers to a Zero constraint rather than an AND constraint.
+///
+/// # Example
+///
+/// ```
+/// use binius_circuits::util::clear_high_bits;
+/// use binius_frontend::CircuitBuilder;
+///
+/// let builder = CircuitBuilder::new();
+/// let word = builder.add_witness();
+/// // Keep the low 32 bits, zeroing the high 32.
+/// let low_half = clear_high_bits(&builder, word, 32);
+/// ```
+pub fn clear_high_bits(builder: &CircuitBuilder, w: Wire, n: u32) -> Wire {
 	builder.shr(builder.shl(w, n), n)
 }
 

--- a/crates/examples/snapshots/bitcoin_headers.snap
+++ b/crates/examples/snapshots/bitcoin_headers.snap
@@ -1,32 +1,32 @@
 bitcoin_headers circuit
 --
 Gates & Instructions
-├─ Number of gates: 46,938
-└─ Number of evaluation instructions: 47,058
+├─ Number of gates: 47,118
+└─ Number of evaluation instructions: 47,238
 
 Constraints
 ├─ ZERO constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-├─ AND constraints: 19,868 used (60.6% of 2^15)
-│  [▓▓▓▓▓▓░░░░] spare: 12,900
+├─ AND constraints: 20,038 used (61.2% of 2^15)
+│  [▓▓▓▓▓▓░░░░] spare: 12,730
 ├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
 ├─ BMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-└─ Distinct value indices: 46,754
-   ├─ Distinct shifted value indices: 26,682
-   └─ Distinct unshifted value indices: 20,072
+└─ Distinct value indices: 47,383
+   ├─ Distinct shifted value indices: 27,142
+   └─ Distinct unshifted value indices: 20,241
 
 Value Vector
-├─ Public Section: 157 used (61.3% of 2^8)
-│  [▓▓▓▓▓▓░░░░] spare: 99
-│  ├─ Constants: 157
+├─ Public Section: 156 used (60.9% of 2^8)
+│  [▓▓▓▓▓▓░░░░] spare: 100
+│  ├─ Constants: 156
 │  └─ Inout: 0
-├─ Private Section: 19,922 used (61.3%)
-│  [▓▓▓▓▓▓░░░░] spare: 12,590
+├─ Private Section: 20,092 used (61.8%)
+│  [▓▓▓▓▓▓░░░░] spare: 12,420
 │  ├─ Witness: 104
-│  └─ Internal: 19,818
-├─ Total Committed: 20,079 used (61.3% of 2^15)
-│  [▓▓▓▓▓▓░░░░] spare: 12,689
-└─ Scratch (uncommitted): 39,190 (peak live: 53)
+│  └─ Internal: 19,988
+├─ Total Committed: 20,248 used (61.8% of 2^15)
+│  [▓▓▓▓▓▓░░░░] spare: 12,520
+└─ Scratch (uncommitted): 39,200 (peak live: 53)
 

--- a/crates/examples/snapshots/bitcoin_p2pkh.snap
+++ b/crates/examples/snapshots/bitcoin_p2pkh.snap
@@ -1,32 +1,32 @@
 bitcoin_p2pkh circuit
 --
 Gates & Instructions
-├─ Number of gates: 150,957
-└─ Number of evaluation instructions: 176,775
+├─ Number of gates: 150,965
+└─ Number of evaluation instructions: 176,783
 
 Constraints
 ├─ ZERO constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-├─ AND constraints: 113,474 used (86.6% of 2^17)
-│  [▓▓▓▓▓▓▓▓░░] spare: 17,598
+├─ AND constraints: 113,485 used (86.6% of 2^17)
+│  [▓▓▓▓▓▓▓▓░░] spare: 17,587
 ├─ IMUL constraints: 15,186 used (92.7% of 2^14)
 │  [▓▓▓▓▓▓▓▓▓░] spare: 1,198
 ├─ BMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-└─ Distinct value indices: 267,485
-   ├─ Distinct shifted value indices: 131,616
-   └─ Distinct unshifted value indices: 135,869
+└─ Distinct value indices: 267,510
+   ├─ Distinct shifted value indices: 131,631
+   └─ Distinct unshifted value indices: 135,879
 
 Value Vector
-├─ Public Section: 135 used (52.7% of 2^8)
-│  [▓▓▓▓▓░░░░░] spare: 121
-│  ├─ Constants: 135
+├─ Public Section: 134 used (52.3% of 2^8)
+│  [▓▓▓▓▓░░░░░] spare: 122
+│  ├─ Constants: 134
 │  └─ Inout: 0
-├─ Private Section: 135,745 used (51.8%)
-│  [▓▓▓▓▓░░░░░] spare: 126,143
+├─ Private Section: 135,756 used (51.8%)
+│  [▓▓▓▓▓░░░░░] spare: 126,132
 │  ├─ Witness: 9
-│  └─ Internal: 135,736
-├─ Total Committed: 135,880 used (51.8% of 2^18)
-│  [▓▓▓▓▓░░░░░] spare: 126,264
-└─ Scratch (uncommitted): 108,459 (peak live: 109)
+│  └─ Internal: 135,747
+├─ Total Committed: 135,890 used (51.8% of 2^18)
+│  [▓▓▓▓▓░░░░░] spare: 126,254
+└─ Scratch (uncommitted): 108,456 (peak live: 109)
 

--- a/crates/examples/snapshots/blake2s.snap
+++ b/crates/examples/snapshots/blake2s.snap
@@ -1,8 +1,8 @@
 blake2s circuit
 --
 Gates & Instructions
-├─ Number of gates: 18,440
-└─ Number of evaluation instructions: 18,440
+├─ Number of gates: 18,568
+└─ Number of evaluation instructions: 18,568
 
 Constraints
 ├─ ZERO constraints: 0 used (0.0% of 0)
@@ -13,9 +13,9 @@ Constraints
 │  [░░░░░░░░░░] spare: 0
 ├─ BMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-└─ Distinct value indices: 35,718
-   ├─ Distinct shifted value indices: 21,916
-   └─ Distinct unshifted value indices: 13,802
+└─ Distinct value indices: 35,845
+   ├─ Distinct shifted value indices: 22,172
+   └─ Distinct unshifted value indices: 13,673
 
 Value Vector
 ├─ Public Section: 45 used (70.3% of 2^6)
@@ -28,5 +28,5 @@ Value Vector
 │  └─ Internal: 13,648
 ├─ Total Committed: 13,829 used (84.4% of 2^14)
 │  [▓▓▓▓▓▓▓▓░░] spare: 2,555
-└─ Scratch (uncommitted): 12,464 (peak live: 27)
+└─ Scratch (uncommitted): 12,592 (peak live: 34)
 

--- a/crates/examples/snapshots/hashsign.snap
+++ b/crates/examples/snapshots/hashsign.snap
@@ -1,32 +1,32 @@
 hashsign circuit
 --
 Gates & Instructions
-├─ Number of gates: 404,574
-└─ Number of evaluation instructions: 405,222
+├─ Number of gates: 413,082
+└─ Number of evaluation instructions: 413,730
 
 Constraints
 ├─ ZERO constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-├─ AND constraints: 274,964 used (52.4% of 2^19)
-│  [▓▓▓▓▓░░░░░] spare: 249,324
+├─ AND constraints: 275,951 used (52.6% of 2^19)
+│  [▓▓▓▓▓░░░░░] spare: 248,337
 ├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
 ├─ BMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-└─ Distinct value indices: 715,106
-   ├─ Distinct shifted value indices: 441,103
-   └─ Distinct unshifted value indices: 274,003
+└─ Distinct value indices: 729,782
+   ├─ Distinct shifted value indices: 454,807
+   └─ Distinct unshifted value indices: 274,975
 
 Value Vector
 ├─ Public Section: 184 used (71.9% of 2^8)
 │  [▓▓▓▓▓▓▓░░░] spare: 72
 │  ├─ Constants: 158
 │  └─ Inout: 26
-├─ Private Section: 273,891 used (52.3%)
-│  [▓▓▓▓▓░░░░░] spare: 250,141
+├─ Private Section: 274,878 used (52.5%)
+│  [▓▓▓▓▓░░░░░] spare: 249,154
 │  ├─ Witness: 1,776
-│  └─ Internal: 272,115
-├─ Total Committed: 274,075 used (52.3% of 2^19)
-│  [▓▓▓▓▓░░░░░] spare: 250,213
-└─ Scratch (uncommitted): 280,944 (peak live: 305)
+│  └─ Internal: 273,102
+├─ Total Committed: 275,062 used (52.5% of 2^19)
+│  [▓▓▓▓▓░░░░░] spare: 249,226
+└─ Scratch (uncommitted): 288,465 (peak live: 593)
 

--- a/crates/examples/snapshots/sha256.snap
+++ b/crates/examples/snapshots/sha256.snap
@@ -1,32 +1,32 @@
 sha256 circuit
 --
 Gates & Instructions
-├─ Number of gates: 20,304
-└─ Number of evaluation instructions: 20,304
+├─ Number of gates: 20,312
+└─ Number of evaluation instructions: 20,312
 
 Constraints
 ├─ ZERO constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-├─ AND constraints: 8,608 used (52.5% of 2^14)
-│  [▓▓▓▓▓░░░░░] spare: 7,776
+├─ AND constraints: 8,616 used (52.6% of 2^14)
+│  [▓▓▓▓▓░░░░░] spare: 7,768
 ├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
 ├─ BMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-└─ Distinct value indices: 21,074
-   ├─ Distinct shifted value indices: 12,334
-   └─ Distinct unshifted value indices: 8,740
+└─ Distinct value indices: 21,097
+   ├─ Distinct shifted value indices: 12,350
+   └─ Distinct unshifted value indices: 8,747
 
 Value Vector
-├─ Public Section: 405 used (79.1% of 2^9)
-│  [▓▓▓▓▓▓▓░░░] spare: 107
-│  ├─ Constants: 141
+├─ Public Section: 404 used (78.9% of 2^9)
+│  [▓▓▓▓▓▓▓░░░] spare: 108
+│  ├─ Constants: 140
 │  └─ Inout: 264
-├─ Private Section: 8,600 used (54.2%)
-│  [▓▓▓▓▓░░░░░] spare: 7,272
+├─ Private Section: 8,608 used (54.2%)
+│  [▓▓▓▓▓░░░░░] spare: 7,264
 │  ├─ Witness: 0
-│  └─ Internal: 8,600
-├─ Total Committed: 9,005 used (55.0% of 2^14)
-│  [▓▓▓▓▓░░░░░] spare: 7,379
+│  └─ Internal: 8,608
+├─ Total Committed: 9,012 used (55.0% of 2^14)
+│  [▓▓▓▓▓░░░░░] spare: 7,372
 └─ Scratch (uncommitted): 17,088 (peak live: 22)
 

--- a/crates/examples/snapshots/zklogin.snap
+++ b/crates/examples/snapshots/zklogin.snap
@@ -1,32 +1,32 @@
 zklogin circuit
 --
 Gates & Instructions
-├─ Number of gates: 485,163
-└─ Number of evaluation instructions: 548,930
+├─ Number of gates: 485,432
+└─ Number of evaluation instructions: 549,199
 
 Constraints
 ├─ ZERO constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-├─ AND constraints: 356,369 used (68.0% of 2^19)
-│  [▓▓▓▓▓▓░░░░] spare: 167,919
+├─ AND constraints: 356,445 used (68.0% of 2^19)
+│  [▓▓▓▓▓▓░░░░] spare: 167,843
 ├─ IMUL constraints: 8,262 used (50.4% of 2^14)
 │  [▓▓▓▓▓░░░░░] spare: 8,122
 ├─ BMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-└─ Distinct value indices: 652,736
-   ├─ Distinct shifted value indices: 293,747
-   └─ Distinct unshifted value indices: 358,989
+└─ Distinct value indices: 653,530
+   ├─ Distinct shifted value indices: 294,466
+   └─ Distinct unshifted value indices: 359,064
 
 Value Vector
-├─ Public Section: 1,032 used (50.4% of 2^11)
-│  [▓▓▓▓▓░░░░░] spare: 1,016
-│  ├─ Constants: 730
+├─ Public Section: 1,031 used (50.3% of 2^11)
+│  [▓▓▓▓▓░░░░░] spare: 1,017
+│  ├─ Constants: 729
 │  └─ Inout: 302
-├─ Private Section: 357,967 used (68.5%)
-│  [▓▓▓▓▓▓░░░░] spare: 164,273
+├─ Private Section: 358,043 used (68.6%)
+│  [▓▓▓▓▓▓░░░░] spare: 164,197
 │  ├─ Witness: 1,381
-│  └─ Internal: 356,586
-├─ Total Committed: 358,999 used (68.5% of 2^19)
-│  [▓▓▓▓▓▓░░░░] spare: 165,289
-└─ Scratch (uncommitted): 310,596 (peak live: 1,542)
+│  └─ Internal: 356,662
+├─ Total Committed: 359,074 used (68.5% of 2^19)
+│  [▓▓▓▓▓▓░░░░] spare: 165,214
+└─ Scratch (uncommitted): 310,789 (peak live: 1,542)
 

--- a/crates/examples/src/circuits/bip32.rs
+++ b/crates/examples/src/circuits/bip32.rs
@@ -1,3 +1,4 @@
+// Copyright 2026 The Binius Developers
 // Copyright 2025 Irreducible Inc.
 //! BIP32 hierarchical-deterministic key derivation as a Binius64 circuit gadget.
 //!
@@ -27,6 +28,7 @@ use binius_circuits::{
 	multiplexer::multi_wire_multiplex,
 	secp256k1::{Secp256k1, Secp256k1Affine},
 	sha256::sha256_fixed,
+	util::clear_high_bits,
 };
 use binius_core::word::Word;
 use binius_frontend::{CircuitBuilder, Wire, WitnessFiller};
@@ -161,7 +163,7 @@ fn assemble_message(b: &CircuitBuilder, prefix: Wire, value: &[Wire; 4], index: 
 	let m1 = b.bxor(b.shl(value[0], 56), b.shr(value[1], 8));
 	let m2 = b.bxor(b.shl(value[1], 56), b.shr(value[2], 8));
 	let m3 = b.bxor(b.shl(value[2], 56), b.shr(value[3], 8));
-	let index_bytes = b.band(index, b.add_constant_64(0xFFFF_FFFF));
+	let index_bytes = clear_high_bits(b, index, 32);
 	let m4 = b.bxor(b.shl(value[3], 56), b.shl(index_bytes, 24));
 	[m0, m1, m2, m3, m4]
 }


### PR DESCRIPTION
Closes [BINIUS-382](https://linear.app/jimpo/issue/BINIUS-382).

Replaces every `band` against a 32-bit low mask with `clear_high_bits(builder, w, 32)`, so masking
to a word's low half is spelled one way across the circuit library.

> [!IMPORTANT]
> **This does not pay off yet, and costs a little today.** The premise on the issue was that
> `clear_high_bits` avoids an AND constraint. It does not — not under the default options, and not
> under `enable_zero_constraints` either. Measurements and the reason are below. Opening it anyway
> per @jimpo's call that the win lands once linear constraints lower to Zero constraints; the
> compiler is not there yet.

### Sites converted

| file | sites |
|---|---|
| `sha256/mod.rs` | 3 — the fixed-length escaping digest (added by #1960), the var-length BE split, the var-length paired chaining |
| `hash_based_sig/hashing/chain_blake3.rs` | 3 — `split_u32_words`, `interleave_cv_2x`, `deinterleave_cv_2x` |
| `bitcoin/double_sha256.rs`, `bitcoin/p2pkh_signature.rs`, `blake2s/mod.rs`, `blake3/compress.rs`, `popcount.rs`, `examples/circuits/bip32.rs` | 1 each |

`binius_circuits::util` becomes `pub` so `bip32`, in the examples crate, can reach the gadget.
In `chain_blake3.rs` the only surviving use of `LOW32_MASK` was `!LOW32_MASK`, so the constant is
now spelled `HIGH32_MASK` directly.

### Why it costs constraints today

`clear_high_bits` is `shr(shl(w, n), n)`. Both shifts are linear constraints, but `Sll(32)` and
`Srl(32)` do not compose into a single shifted operand (`constraint_builder/shift.rs:229`), so the
intermediate has to be committed. Gate fusion then lowers that committed linear definition to an
**AND constraint** against all-ones — `build_committed_lin_def_patch` builds a
`NonLinearConstraint::And` unconditionally (`gate_fusion/patch.rs:214-229`).

So the shift pair costs the same one AND constraint the `band` did. The regression on top is that
`band(x, mask)` could absorb the surrounding shift/XOR chain into its own operands, whereas the
committed `sll` intermediate cannot.

### Benchmark: compiled circuit stats (default options)

Baseline is the committed snapshots at `main`. Blessed snapshots are in this PR.

| example | AND before | AND after | change | committed before | committed after |
|---|---|---|---|---|---|
| hashsign | 274,964 | 275,951 | **+987** (+0.36%) | 274,075 | 275,062 |
| bitcoin_headers | 19,868 | 20,038 | +170 (+0.86%) | 20,079 | 20,248 |
| zklogin | 356,369 | 356,445 | +76 (+0.02%) | 358,999 | 359,074 |
| bitcoin_p2pkh | 113,474 | 113,485 | +11 | 135,880 | 135,890 |
| sha256 | 8,608 | 8,616 | +8 | 9,005 | 9,012 |
| blake2s | 13,656 | 13,656 | unchanged | 13,829 | 13,829 |
| ethsign, sha512, keccak, blake2b, blake3, blake3_compress, ec_msm | — | — | unchanged | — | — |

`blake2s` is the shape the issue expected: +128 gates, but AND and committed both unchanged — there
the shift pair fuses away entirely.

### The Zero-constraint option does not flip it

I rebuilt with `enable_zero_constraints: true` (`compiler/mod.rs:77`) to check where the payoff is:

| example | ZERO | AND (flag on) | AND (flag off) |
|---|---|---|---|
| sha256 | 0 | 8,616 | 8,616 |
| hashsign | 0 | 275,951 | 275,951 |
| bitcoin_headers | 0 | 20,038 | 20,038 |

Zero constraints stay at **0** and nothing moves, because the flag is read in
`ConstraintBuilder::build`, which runs *after* gate fusion has already promoted every committed
linear definition to an AND constraint. No linear constraint survives for the flag to act on.

Realising the win therefore needs `build_committed_lin_def_patch` (and the `commit_set` decision
that feeds it) to emit a Zero constraint when the option is on — a compiler change, not a flag
flip. Happy to open that as a follow-up issue if you want this landed as the call-site half.

### Scope

- **converted:** every `band` against a compile-time 32-bit low mask in library and example code.
- **left alone:** low masks of other widths — `(1 << k) - 1` in `chain_blake3::zeroed_u32_words`,
  `ripemd`, `concat`, `blake2b`, `keccak`, and the uniform 32/16/8/4/2 ladder in `float64/utils.rs`,
  where converting only the 32 stage would break the pattern. The same transform generalises to all
  of them, but that is a wider change than this issue asked for.
- **left alone:** high-half masks, which want a `clear_low_bits` counterpart rather than this one.
- **left alone:** the two test-only sites (`sha256/compress.rs:479`, `prover/tests/prove_verify.rs:111`).

### Verification

- 327 circuits tests pass; the new `clear_high_bits` doctest passes.
- `cargo clippy -p binius-circuits -p binius-examples --tests --benches --examples -- -D warnings` clean.
- `cargo +nightly-2026-07-01 fmt --check` clean.
- All 13 snapshots re-blessed; 6 changed.
- The stale claim on `clear_high_bits` that the shift pair "is cheaper than masking with a `band`"
  is corrected to describe what the compiler actually does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)