### PR TITLE
BINIUS-384: let a committed linear definition lower to a Zero constraint

### DIFF
--- a/crates/frontend/src/compiler/gate_fusion/mod.rs
+++ b/crates/frontend/src/compiler/gate_fusion/mod.rs
@@ -10,12 +10,18 @@
 //!
 //! `ConstraintBuilder` which this pass operates consists of AND, IMUL and linear constraints.
 //! Linear constraints are basically are constraints that define a single wire using a XOR
-//! combination and/or shifts. Since our system does not suppose standalone linear combinations they
-//! will have to be promoted to AND constraints.
+//! combination and/or shifts. Since our system does not suppose standalone linear combinations a
+//! wire whose definition survives has to be committed, and its definition costs a constraint of
+//! its own — an AND against the all-ones wire, or a Zero constraint under
+//! `enable_zero_constraints`.
 //!
 //! BUT we have a chance of avoiding that if we manage to inline that wire into every consumer
-//! constraint which means we don't have to commit that value and thus we don't need an AND
-//! constraint!
+//! constraint which means we don't have to commit that value and thus we don't spend a constraint
+//! on it at all!
+//!
+//! A definition this pass does have to commit stays a linear constraint, carrying the inlined
+//! cone as its right-hand side. Which of the two lowerings it gets is
+//! [`ConstraintBuilder::build`]'s call, not this pass's.
 
 use cranelift_entity::EntitySet;
 use legraph::LeGraph;
@@ -32,13 +38,13 @@ mod tests;
 
 use stat::Stat;
 
-pub fn run_pass(cb: &mut ConstraintBuilder, pinned_wires: &EntitySet<Wire>, all_one: Wire) {
+pub fn run_pass(cb: &mut ConstraintBuilder, pinned_wires: &EntitySet<Wire>) {
 	let mut stat = Stat::new(cb);
 
 	let mut leg = LeGraph::new(cb);
 	commit_set::run_decide_commit_set(&mut leg, &mut stat);
 	// Pin force-committed wires that are linear definitions so their values survive as committed
-	// AND constraints. Pinned wires that are not linear definitions (e.g. AND or IMUL outputs) are
+	// definitions. Pinned wires that are not linear definitions (e.g. AND or IMUL outputs) are
 	// already committed by their own constraints, so they must be excluded here: `patch::build`
 	// treats every wire in the commit set as a linear definition and would otherwise panic.
 	let pinned_lin_defs = pinned_wires
@@ -46,6 +52,6 @@ pub fn run_pass(cb: &mut ConstraintBuilder, pinned_wires: &EntitySet<Wire>, all_
 		.filter(|&wire| leg.is_lin_def(wire))
 		.collect::<Vec<_>>();
 	leg.lin_committed.extend(pinned_lin_defs);
-	let patches = patch::build(cb, &leg, all_one);
+	let patches = patch::build(cb, &leg);
 	patch::apply_patches(cb, patches);
 }

--- a/crates/frontend/src/compiler/gate_fusion/patch.rs
+++ b/crates/frontend/src/compiler/gate_fusion/patch.rs
@@ -1,3 +1,4 @@
+// Copyright 2026 The Binius Developers
 // Copyright 2025 Irreducible Inc.
 use rustc_hash::FxHashSet;
 
@@ -6,7 +7,7 @@ use crate::compiler::{
 	Wire,
 	constraint_builder::{
 		ConstraintBuilder, Shift, ShiftedWire, WireAndConstraint, WireBmulConstraint,
-		WireImulConstraint, WireOperand,
+		WireImulConstraint, WireLinearConstraint, WireOperand,
 	},
 	gate_fusion::legraph::ConstraintRef,
 };
@@ -21,13 +22,17 @@ pub struct Patch {
 	/// The constraint set that is going to be replaced with this one.
 	subsumes: Vec<ConstraintRef>,
 	/// The new constraints that is going to be added to the graph.
-	added: NonLinearConstraint,
+	added: AddedConstraint,
 }
 
-enum NonLinearConstraint {
+enum AddedConstraint {
 	And(WireAndConstraint),
 	Imul(WireImulConstraint),
 	Bmul(WireBmulConstraint),
+	/// A committed linear definition, kept linear so that
+	/// [`ConstraintBuilder::build`](crate::compiler::constraint_builder::ConstraintBuilder::build)
+	/// picks its lowering.
+	Linear(WireLinearConstraint),
 }
 
 /// Apply the given patches to the constraint builder given.
@@ -37,17 +42,17 @@ pub fn apply_patches(cb: &mut ConstraintBuilder, patches: Vec<Patch>) {
 	let mut new_and_constraints = Vec::new();
 	let mut new_imul_constraints = Vec::new();
 	let mut new_bmul_constraints = Vec::new();
+	let mut new_linear_constraints = Vec::new();
 
 	// Collect all subsumed constraints and new constraints to add
 	for patch in patches {
 		subsumes.extend(patch.subsumes);
 		match patch.added {
-			NonLinearConstraint::And(and_constraint) => new_and_constraints.push(and_constraint),
-			NonLinearConstraint::Imul(imul_constraint) => {
-				new_imul_constraints.push(imul_constraint)
-			}
-			NonLinearConstraint::Bmul(bmul_constraint) => {
-				new_bmul_constraints.push(bmul_constraint)
+			AddedConstraint::And(and_constraint) => new_and_constraints.push(and_constraint),
+			AddedConstraint::Imul(imul_constraint) => new_imul_constraints.push(imul_constraint),
+			AddedConstraint::Bmul(bmul_constraint) => new_bmul_constraints.push(bmul_constraint),
+			AddedConstraint::Linear(linear_constraint) => {
+				new_linear_constraints.push(linear_constraint)
 			}
 		}
 	}
@@ -110,17 +115,18 @@ pub fn apply_patches(cb: &mut ConstraintBuilder, patches: Vec<Patch>) {
 	cb.and_constraints.extend(new_and_constraints);
 	cb.imul_constraints.extend(new_imul_constraints);
 	cb.bmul_constraints.extend(new_bmul_constraints);
+	cb.linear_constraints.extend(new_linear_constraints);
 }
 
 /// Builds a list of patches that would remove the inlined linear definitions and potentially
 /// AND constraints.
 ///
 /// NB: patches may have overlapping subsumes.
-pub fn build(cb: &ConstraintBuilder, leg: &LeGraph, all_one: Wire) -> Vec<Patch> {
+pub fn build(cb: &ConstraintBuilder, leg: &LeGraph) -> Vec<Patch> {
 	let mut patches = vec![];
 	build_non_linear_patches(cb, leg, &mut patches);
 	for committed in leg.commit_set().iter() {
-		let patch = build_committed_lin_def_patch(cb, leg, all_one, committed);
+		let patch = build_committed_lin_def_patch(cb, leg, committed);
 		patches.push(patch);
 	}
 	patches
@@ -155,14 +161,14 @@ fn build_non_lin_patch(
 			let a = process_operand(leg, &mut subsumes, &cb.and_constraints[index].a);
 			let b = process_operand(leg, &mut subsumes, &cb.and_constraints[index].b);
 			let c = process_operand(leg, &mut subsumes, &cb.and_constraints[index].c);
-			NonLinearConstraint::And(WireAndConstraint { a, b, c })
+			AddedConstraint::And(WireAndConstraint { a, b, c })
 		}
 		ConstraintRef::Imul { index } => {
 			let a = process_operand(leg, &mut subsumes, &cb.imul_constraints[index].a);
 			let b = process_operand(leg, &mut subsumes, &cb.imul_constraints[index].b);
 			let lo = process_operand(leg, &mut subsumes, &cb.imul_constraints[index].lo);
 			let hi = process_operand(leg, &mut subsumes, &cb.imul_constraints[index].hi);
-			NonLinearConstraint::Imul(WireImulConstraint { a, b, lo, hi })
+			AddedConstraint::Imul(WireImulConstraint { a, b, lo, hi })
 		}
 		ConstraintRef::Bmul { index } => {
 			let bmul = &cb.bmul_constraints[index];
@@ -172,7 +178,7 @@ fn build_non_lin_patch(
 			let b_hi = process_operand(leg, &mut subsumes, &bmul.b_hi);
 			let c_lo = process_operand(leg, &mut subsumes, &bmul.c_lo);
 			let c_hi = process_operand(leg, &mut subsumes, &bmul.c_hi);
-			NonLinearConstraint::Bmul(WireBmulConstraint {
+			AddedConstraint::Bmul(WireBmulConstraint {
 				a_lo,
 				a_hi,
 				b_lo,
@@ -198,12 +204,12 @@ fn build_non_lin_patch(
 /// Given the wire that defines a linear definition build a patch that replaces the original linear
 /// definition and all definitions that could be inlined into it. Therefore, the returned
 /// patch will replace the given linear definition and the cone of linear definitions it used.
-fn build_committed_lin_def_patch(
-	_cb: &ConstraintBuilder,
-	leg: &LeGraph,
-	all_one: Wire,
-	root: Wire,
-) -> Patch {
+///
+/// The patch stays linear: the wire has to be committed, but *how* the defining equation is
+/// enforced — an AND against the all-ones wire, or a Zero constraint — is
+/// [`ConstraintBuilder::build`](crate::compiler::constraint_builder::ConstraintBuilder::build)'s
+/// decision, taken from the `enable_zero_constraints` option.
+fn build_committed_lin_def_patch(_cb: &ConstraintBuilder, leg: &LeGraph, root: Wire) -> Patch {
 	// `subsumes` is a list of constraints that become redundant with application of this patch.
 	// The first redundant constraint is the linear definition that's being committed.
 	let mut subsumes = vec![leg.lin_def_constraint_ref(root)];
@@ -211,21 +217,12 @@ fn build_committed_lin_def_patch(
 	let old_operand = leg.lin_def_operand(root);
 	let new_operand = process_operand(leg, &mut subsumes, old_operand);
 
-	// Create an AND constraint that enforces: root = new_operand
+	// Enforce: root = new_operand, over the inlined cone rather than the original definition.
 	Patch {
 		subsumes,
-		added: NonLinearConstraint::And(WireAndConstraint {
-			a: new_operand,
-			b: vec![ShiftedWire {
-				wire: all_one,
-				shift: Shift::None,
-			}]
-			.into(),
-			c: vec![ShiftedWire {
-				wire: root,
-				shift: Shift::None,
-			}]
-			.into(),
+		added: AddedConstraint::Linear(WireLinearConstraint {
+			rhs: new_operand,
+			dst: root,
 		}),
 	}
 }
@@ -375,34 +372,24 @@ mod tests {
 	}
 
 	#[test]
-	fn test_committed_linear_of_constant_all_ones_shape() {
-		// Directly exercise build_committed_lin_def_patch for a constant RHS.
+	fn test_committed_lin_def_patch_stays_linear() {
+		// Directly exercise build_committed_lin_def_patch: a committed definition keeps its linear
+		// shape, leaving the AND-vs-Zero lowering to `ConstraintBuilder::build`.
 		fn w(id: u32) -> Wire {
 			Wire::from_u32(id)
 		}
 
 		let mut cb = ConstraintBuilder::new();
-		// x = const (opaque wire in this builder-level test)
-		// y = x  (linear def of a single opaque term)
-		cb.linear(expr::xor2(w(0), w(0)), w(1));
-		// Above uses xor2(w0,w0) which cancels logically, but at builder-level it's two terms.
-		// Use a simpler single-term variant as well
-		let mut cb_single = ConstraintBuilder::new();
-		cb_single.linear(expr::xor2(w(0), w(2)), w(3));
+		cb.linear(expr::xor2(w(0), w(2)), w(3));
 
-		let leg = LeGraph::new(&cb_single);
-		let all_one = w(9);
-		let patch = super::build_committed_lin_def_patch(&cb_single, &leg, all_one, w(3));
+		let leg = LeGraph::new(&cb);
+		let patch = super::build_committed_lin_def_patch(&cb, &leg, w(3));
 		match patch.added {
-			NonLinearConstraint::And(ref andc) => {
-				// b must be exactly [all_one]
-				assert_eq!(andc.b.len(), 1);
-				assert_eq!(andc.b[0].wire, all_one);
-				assert!(!andc.a.is_empty());
-				assert_eq!(andc.c.len(), 1);
-				assert_eq!(andc.c[0].wire, w(3));
+			AddedConstraint::Linear(ref linc) => {
+				assert!(!linc.rhs.is_empty());
+				assert_eq!(linc.dst, w(3));
 			}
-			_ => panic!("expected AND constraint in committed patch"),
+			_ => panic!("expected linear constraint in committed patch"),
 		}
 	}
 
@@ -425,7 +412,7 @@ mod tests {
 		let mut leg = LeGraph::new(&cb);
 		crate::compiler::gate_fusion::commit_set::run_decide_commit_set(&mut leg, &mut stat);
 
-		let patches = super::build(&cb, &leg, w(9));
+		let patches = super::build(&cb, &leg);
 		let mut cb2 = cb;
 		super::apply_patches(&mut cb2, patches);
 
@@ -460,7 +447,7 @@ mod tests {
 		let mut leg = LeGraph::new(&cb);
 		crate::compiler::gate_fusion::commit_set::run_decide_commit_set(&mut leg, &mut stat);
 
-		let patches = super::build(&cb, &leg, w(40));
+		let patches = super::build(&cb, &leg);
 		let mut cb2 = cb;
 		super::apply_patches(&mut cb2, patches);
 
@@ -536,7 +523,7 @@ mod tests {
 				crate::compiler::gate_fusion::commit_set::run_decide_commit_set(
 					&mut leg, &mut stat,
 				);
-				let patches = super::build(&cb, &leg, w(7));
+				let patches = super::build(&cb, &leg);
 				let mut cb2 = cb;
 				super::apply_patches(&mut cb2, patches);
 
@@ -825,7 +812,7 @@ mod tests {
 		let patches = vec![
 			Patch {
 				subsumes: vec![ConstraintRef::And { index: 1 }],
-				added: NonLinearConstraint::And(WireAndConstraint {
+				added: AddedConstraint::And(WireAndConstraint {
 					a: vec![ShiftedWire {
 						wire: w(30),
 						shift: Shift::None,
@@ -845,7 +832,7 @@ mod tests {
 			},
 			Patch {
 				subsumes: vec![ConstraintRef::Linear { index: 0 }],
-				added: NonLinearConstraint::And(WireAndConstraint {
+				added: AddedConstraint::And(WireAndConstraint {
 					a: vec![ShiftedWire {
 						wire: w(33),
 						shift: Shift::None,
@@ -865,7 +852,7 @@ mod tests {
 			},
 			Patch {
 				subsumes: vec![ConstraintRef::Imul { index: 0 }],
-				added: NonLinearConstraint::Imul(WireImulConstraint {
+				added: AddedConstraint::Imul(WireImulConstraint {
 					a: vec![ShiftedWire {
 						wire: w(36),
 						shift: Shift::None,
@@ -954,15 +941,17 @@ mod tests {
 		assert!(!leg.commit_set().contains(w(2)), "t should not be committed");
 		assert!(!leg.commit_set().contains(w(4)), "z should not be committed");
 
-		let patches = super::build(&cb, &leg, w(9));
+		let patches = super::build(&cb, &leg);
 		let mut cb2 = cb; // clone-by-move and apply patches
 		super::apply_patches(&mut cb2, patches);
 
 		// Expectations:
-		// - AND constraints: start 2, both subsumed and replaced (2), plus 1 from committed y => 3
-		assert_eq!(cb2.and_constraints.len(), 3);
-		// - Linear constraints: t, y, z all subsumed => 0 remaining
-		assert_eq!(cb2.linear_constraints.len(), 0);
+		// - AND constraints: start 2, both subsumed and replaced => 2
+		assert_eq!(cb2.and_constraints.len(), 2);
+		// - Linear constraints: t, y, z all subsumed, and committed y re-added as a linear
+		//   definition over the inlined cone => 1 remaining
+		assert_eq!(cb2.linear_constraints.len(), 1);
+		assert_eq!(cb2.linear_constraints[0].dst, w(3));
 	}
 
 	#[test]
@@ -990,7 +979,7 @@ mod tests {
 		let mut leg = LeGraph::new(&cb);
 		crate::compiler::gate_fusion::commit_set::run_decide_commit_set(&mut leg, &mut stat);
 
-		let patches = super::build(&cb, &leg, w(7));
+		let patches = super::build(&cb, &leg);
 		let mut cb2 = cb;
 		super::apply_patches(&mut cb2, patches);
 
@@ -1047,7 +1036,7 @@ mod tests {
 		crate::compiler::gate_fusion::commit_set::run_decide_commit_set(&mut leg, &mut stat);
 
 		assert!(leg.commit_set().contains(w(1)), "t_committed should be committed");
-		let patches = super::build(&cb, &leg, w(8));
+		let patches = super::build(&cb, &leg);
 		let mut cb2 = cb;
 		super::apply_patches(&mut cb2, patches);
 
@@ -1098,7 +1087,7 @@ mod tests {
 		crate::compiler::gate_fusion::commit_set::run_decide_commit_set(&mut leg, &mut stat);
 
 		assert!(leg.commit_set().contains(w(1)), "inner t should be committed");
-		let patches = super::build(&cb, &leg, w(8));
+		let patches = super::build(&cb, &leg);
 		let mut cb2 = cb;
 		super::apply_patches(&mut cb2, patches);
 

--- a/crates/frontend/src/compiler/mod.rs
+++ b/crates/frontend/src/compiler/mod.rs
@@ -284,7 +284,7 @@ impl CircuitBuilder {
 
 		// Perform fusion if the corresponding feature flag is turned on.
 		if shared.opts.enable_gate_fusion {
-			gate_fusion::run_pass(&mut builder, &shared.force_committed, all_one);
+			gate_fusion::run_pass(&mut builder, &shared.force_committed);
 		}
 
 		let constrained_wires = builder.mark_used_wires();

--- a/crates/frontend/src/compiler/tests.rs
+++ b/crates/frontend/src/compiler/tests.rs
@@ -140,6 +140,49 @@ fn test_zero_constraints_replace_the_linear_and_constraints() {
 	verify_constraints(cs, &filler.value_vec).unwrap();
 }
 
+/// Builds `((x << 32) >> 32) & y == z` with gate fusion left on.
+///
+/// A left-then-right shift pair is not expressible as one shifted operand, so fusion cannot
+/// inline the intermediate into the `band` and has to commit it. That committed definition is the
+/// one the option has to reach.
+fn build_committed_lin_def_circuit(enable_zero_constraints: bool) -> (Circuit, Wire, Wire, Wire) {
+	let builder = CircuitBuilder::with_opts(Options {
+		enable_zero_constraints,
+		..Options::default()
+	});
+	let x = builder.add_inout();
+	let y = builder.add_inout();
+	let z = builder.add_inout();
+	let low = builder.shr(builder.shl(x, 32), 32);
+	builder.assert_eq("and", builder.band(low, y), z);
+	(builder.build(), x, y, z)
+}
+
+#[test]
+fn test_zero_constraints_reach_a_fused_committed_lin_def() {
+	let (and_circuit, ..) = build_committed_lin_def_circuit(false);
+	let (zero_circuit, x, y, z) = build_committed_lin_def_circuit(true);
+	let and_cs = and_circuit.constraint_system();
+	let zero_cs = zero_circuit.constraint_system();
+
+	// With the option off every committed definition is an AND against all-ones.
+	assert_eq!(and_cs.n_zero_constraints(), 0);
+
+	// With it on they move to the ZERO set, one for one, and nothing else changes.
+	assert!(zero_cs.n_zero_constraints() > 0);
+	assert_eq!(
+		zero_cs.n_zero_constraints(),
+		and_cs.n_and_constraints() - zero_cs.n_and_constraints()
+	);
+
+	let mut filler = zero_circuit.new_witness_filler();
+	filler[x] = Word(0x1234_5678_9abc_def0);
+	filler[y] = Word(0x0fed_cba9_8765_4321);
+	filler[z] = Word(0x9abc_def0 & 0x0fed_cba9_8765_4321);
+	zero_circuit.populate_wire_witness(&mut filler).unwrap();
+	verify_constraints(zero_cs, &filler.value_vec).unwrap();
+}
+
 #[test]
 fn test_iadd_cin_cout_max_values() {
 	let builder = CircuitBuilder::new();


### PR DESCRIPTION
Closes [BINIUS-384](https://linear.app/jimpo/issue/BINIUS-384). Follow-up to #1962.

`enable_zero_constraints` had no effect on any real circuit: every example compiled to **0** Zero
constraints with it on. Gate fusion promoted every committed linear definition to an AND against
all-ones before the flag was ever read, so nothing survived for it to act on.

### The fix is a deletion, not a threading

The issue proposed threading the option down into `build_committed_lin_def_patch`. It turns out
nothing needs to know about the option there. That function was hand-building

```
new_operand & all_one == root
```

which is exactly what `ConstraintBuilder::build` already produces from a **linear** constraint when
the option is off. So the patch now emits the committed definition as a linear constraint carrying
the inlined cone, and `build` makes the AND-vs-Zero call — the one place that decision already
lived.

Consequences:

- `NonLinearConstraint` → `AddedConstraint`, with a `Linear` variant. The old name would be a lie.
- `apply_patches` extends `cb.linear_constraints` alongside the other three buckets.
- **`all_one` drops out of the fusion path entirely** — `run_pass`, `patch::build` and the patch
  builder all lose the parameter, since nothing there constructs an AND against it anymore.

### Flag off: unchanged

`build` lowers those linear constraints to the identical `RHS & all_one == DST`, so the default
compile is untouched. Verified: sha256, hashsign, bitcoin_headers, blake3, zklogin and blake2s all
report `✓ Circuit statistics match snapshot`, and no snapshot needed re-blessing.

### Flag on: the win BINIUS-382 was missing

`enable_zero_constraints: true`, before vs after, same base:

| example | AND before | AND after | change | ZERO after | committed |
|---|---|---|---|---|---|
| hashsign | 275,951 | 145,508 | **−47.3%** | 130,443 | unchanged |
| blake3 | 5,141 | 2,760 | **−46.3%** | 2,381 | unchanged |
| blake2s | 13,656 | 7,688 | **−43.7%** | 5,968 | unchanged |
| sha256 | 8,616 | 6,575 | **−23.7%** | 2,041 | unchanged |
| bitcoin_headers | 20,038 | 15,344 | **−23.4%** | 4,694 | unchanged |
| zklogin | 356,445 | 324,651 | **−8.9%** | 31,794 | unchanged |

Before is 0 Zero constraints in every case, directly measured, not inferred.

The Zero count equals the AND reduction **exactly** in all six, and `Total Committed` does not move
— a pure change of lowering, not a change in what gets committed or how much is inlined. The
spread tracks how shift-heavy a circuit is: BLAKE3/BLAKE2s chains commit many shift pairs, zklogin
is dominated by other work.

### Why the existing tests missed this

`build_xor_circuit` in `compiler/tests.rs` — which backs both existing `enable_zero_constraints`
tests — passes `enable_gate_fusion: false`. It disabled the very pass that defeated the flag, so
the option looked covered while being inert on every real circuit.

The new `test_zero_constraints_reach_a_fused_committed_lin_def` leaves fusion **on** and builds
`((x << 32) >> 32) & y == z`: the shift pair cannot fold into one shifted operand, so fusion is
forced to commit the intermediate. It asserts Zero constraints appear, that the AND count drops by
exactly that many, and that the witness still verifies. I confirmed it fails on `main`
(`assertion failed: zero_cs.n_zero_constraints() > 0`) and passes here.

### Not in scope

The `commit_set` heuristic still scores a committed definition as if it cost an AND constraint.
Now that it can cost a Zero constraint instead, the commit/inline threshold is arguably mistuned
under the flag — worth revisiting, but it changes which wires get committed, so it belongs in its
own change with its own benchmark.

### Verification

- 185 frontend tests (incl. the new guard), 327 circuits tests, 41 prover tests pass.
- `cargo clippy -p binius-frontend --tests --benches --examples -- -D warnings` clean.
- `cargo +nightly-2026-07-01 fmt --check` clean.
- Stale comments in `gate_fusion/mod.rs` that described the old unconditional AND promotion are
  updated to describe what the pass does now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)