### PR TITLE
BINIUS-386: always lower linear constraints to Zero constraints

### DIFF
--- a/crates/examples/snapshots/bitcoin_headers.snap
+++ b/crates/examples/snapshots/bitcoin_headers.snap
@@ -5,10 +5,10 @@ Gates & Instructions
 └─ Number of evaluation instructions: 47,238
 
 Constraints
-├─ ZERO constraints: 0 used (0.0% of 0)
-│  [░░░░░░░░░░] spare: 0
-├─ AND constraints: 20,038 used (61.2% of 2^15)
-│  [▓▓▓▓▓▓░░░░] spare: 12,730
+├─ ZERO constraints: 4,694 used (57.3% of 2^13)
+│  [▓▓▓▓▓░░░░░] spare: 3,498
+├─ AND constraints: 15,344 used (93.7% of 2^14)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 1,040
 ├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
 ├─ BMUL constraints: 0 used (0.0% of 0)

--- a/crates/examples/snapshots/bitcoin_p2pkh.snap
+++ b/crates/examples/snapshots/bitcoin_p2pkh.snap
@@ -5,10 +5,10 @@ Gates & Instructions
 └─ Number of evaluation instructions: 176,783
 
 Constraints
-├─ ZERO constraints: 0 used (0.0% of 0)
-│  [░░░░░░░░░░] spare: 0
-├─ AND constraints: 113,485 used (86.6% of 2^17)
-│  [▓▓▓▓▓▓▓▓░░] spare: 17,587
+├─ ZERO constraints: 1,918 used (93.7% of 2^11)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 130
+├─ AND constraints: 111,567 used (85.1% of 2^17)
+│  [▓▓▓▓▓▓▓▓░░] spare: 19,505
 ├─ IMUL constraints: 15,186 used (92.7% of 2^14)
 │  [▓▓▓▓▓▓▓▓▓░] spare: 1,198
 ├─ BMUL constraints: 0 used (0.0% of 0)

--- a/crates/examples/snapshots/blake2b.snap
+++ b/crates/examples/snapshots/blake2b.snap
@@ -5,10 +5,10 @@ Gates & Instructions
 └─ Number of evaluation instructions: 10,824
 
 Constraints
-├─ ZERO constraints: 0 used (0.0% of 0)
-│  [░░░░░░░░░░] spare: 0
-├─ AND constraints: 8,160 used (99.6% of 2^13)
-│  [▓▓▓▓▓▓▓▓▓░] spare: 32
+├─ ZERO constraints: 3,544 used (86.5% of 2^12)
+│  [▓▓▓▓▓▓▓▓░░] spare: 552
+├─ AND constraints: 4,616 used (56.3% of 2^13)
+│  [▓▓▓▓▓░░░░░] spare: 3,576
 ├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
 ├─ BMUL constraints: 0 used (0.0% of 0)

--- a/crates/examples/snapshots/blake2s.snap
+++ b/crates/examples/snapshots/blake2s.snap
@@ -5,10 +5,10 @@ Gates & Instructions
 └─ Number of evaluation instructions: 18,568
 
 Constraints
-├─ ZERO constraints: 0 used (0.0% of 0)
-│  [░░░░░░░░░░] spare: 0
-├─ AND constraints: 13,656 used (83.3% of 2^14)
-│  [▓▓▓▓▓▓▓▓░░] spare: 2,728
+├─ ZERO constraints: 5,968 used (72.9% of 2^13)
+│  [▓▓▓▓▓▓▓░░░] spare: 2,224
+├─ AND constraints: 7,688 used (93.8% of 2^13)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 504
 ├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
 ├─ BMUL constraints: 0 used (0.0% of 0)

--- a/crates/examples/snapshots/blake3.snap
+++ b/crates/examples/snapshots/blake3.snap
@@ -5,10 +5,10 @@ Gates & Instructions
 └─ Number of evaluation instructions: 7,256
 
 Constraints
-├─ ZERO constraints: 0 used (0.0% of 0)
-│  [░░░░░░░░░░] spare: 0
-├─ AND constraints: 5,141 used (62.8% of 2^13)
-│  [▓▓▓▓▓▓░░░░] spare: 3,051
+├─ ZERO constraints: 2,381 used (58.1% of 2^12)
+│  [▓▓▓▓▓░░░░░] spare: 1,715
+├─ AND constraints: 2,760 used (67.4% of 2^12)
+│  [▓▓▓▓▓▓░░░░] spare: 1,336
 ├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
 ├─ BMUL constraints: 0 used (0.0% of 0)

--- a/crates/examples/snapshots/ec_msm.snap
+++ b/crates/examples/snapshots/ec_msm.snap
@@ -5,10 +5,10 @@ Gates & Instructions
 └─ Number of evaluation instructions: 244,030
 
 Constraints
-├─ ZERO constraints: 0 used (0.0% of 0)
-│  [░░░░░░░░░░] spare: 0
-├─ AND constraints: 158,253 used (60.4% of 2^18)
-│  [▓▓▓▓▓▓░░░░] spare: 103,891
+├─ ZERO constraints: 2,140 used (52.2% of 2^12)
+│  [▓▓▓▓▓░░░░░] spare: 1,956
+├─ AND constraints: 156,113 used (59.6% of 2^18)
+│  [▓▓▓▓▓░░░░░] spare: 106,031
 ├─ IMUL constraints: 20,548 used (62.7% of 2^15)
 │  [▓▓▓▓▓▓░░░░] spare: 12,220
 ├─ BMUL constraints: 0 used (0.0% of 0)

--- a/crates/examples/snapshots/ethsign.snap
+++ b/crates/examples/snapshots/ethsign.snap
@@ -5,10 +5,10 @@ Gates & Instructions
 └─ Number of evaluation instructions: 250,294
 
 Constraints
-├─ ZERO constraints: 0 used (0.0% of 0)
-│  [░░░░░░░░░░] spare: 0
-├─ AND constraints: 159,863 used (61.0% of 2^18)
-│  [▓▓▓▓▓▓░░░░] spare: 102,281
+├─ ZERO constraints: 2,173 used (53.1% of 2^12)
+│  [▓▓▓▓▓░░░░░] spare: 1,923
+├─ AND constraints: 157,690 used (60.2% of 2^18)
+│  [▓▓▓▓▓▓░░░░] spare: 104,454
 ├─ IMUL constraints: 20,554 used (62.7% of 2^15)
 │  [▓▓▓▓▓▓░░░░] spare: 12,214
 ├─ BMUL constraints: 0 used (0.0% of 0)

--- a/crates/examples/snapshots/hashsign.snap
+++ b/crates/examples/snapshots/hashsign.snap
@@ -5,10 +5,10 @@ Gates & Instructions
 └─ Number of evaluation instructions: 413,730
 
 Constraints
-├─ ZERO constraints: 0 used (0.0% of 0)
-│  [░░░░░░░░░░] spare: 0
-├─ AND constraints: 275,951 used (52.6% of 2^19)
-│  [▓▓▓▓▓░░░░░] spare: 248,337
+├─ ZERO constraints: 130,443 used (99.5% of 2^17)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 629
+├─ AND constraints: 145,508 used (55.5% of 2^18)
+│  [▓▓▓▓▓░░░░░] spare: 116,636
 ├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
 ├─ BMUL constraints: 0 used (0.0% of 0)

--- a/crates/examples/snapshots/sha256.snap
+++ b/crates/examples/snapshots/sha256.snap
@@ -5,10 +5,10 @@ Gates & Instructions
 └─ Number of evaluation instructions: 20,312
 
 Constraints
-├─ ZERO constraints: 0 used (0.0% of 0)
-│  [░░░░░░░░░░] spare: 0
-├─ AND constraints: 8,616 used (52.6% of 2^14)
-│  [▓▓▓▓▓░░░░░] spare: 7,768
+├─ ZERO constraints: 2,041 used (99.7% of 2^11)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 7
+├─ AND constraints: 6,575 used (80.3% of 2^13)
+│  [▓▓▓▓▓▓▓▓░░] spare: 1,617
 ├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
 ├─ BMUL constraints: 0 used (0.0% of 0)

--- a/crates/examples/snapshots/sha512.snap
+++ b/crates/examples/snapshots/sha512.snap
@@ -5,10 +5,10 @@ Gates & Instructions
 └─ Number of evaluation instructions: 24,839
 
 Constraints
-├─ ZERO constraints: 0 used (0.0% of 0)
-│  [░░░░░░░░░░] spare: 0
-├─ AND constraints: 10,311 used (62.9% of 2^14)
-│  [▓▓▓▓▓▓░░░░] spare: 6,073
+├─ ZERO constraints: 2,041 used (99.7% of 2^11)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 7
+├─ AND constraints: 8,270 used (50.5% of 2^14)
+│  [▓▓▓▓▓░░░░░] spare: 8,114
 ├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
 ├─ BMUL constraints: 0 used (0.0% of 0)

--- a/crates/examples/snapshots/zklogin.snap
+++ b/crates/examples/snapshots/zklogin.snap
@@ -5,10 +5,10 @@ Gates & Instructions
 └─ Number of evaluation instructions: 459,115
 
 Constraints
-├─ ZERO constraints: 0 used (0.0% of 0)
-│  [░░░░░░░░░░] spare: 0
-├─ AND constraints: 258,569 used (98.6% of 2^18)
-│  [▓▓▓▓▓▓▓▓▓░] spare: 3,575
+├─ ZERO constraints: 23,445 used (71.5% of 2^15)
+│  [▓▓▓▓▓▓▓░░░] spare: 9,323
+├─ AND constraints: 235,124 used (89.7% of 2^18)
+│  [▓▓▓▓▓▓▓▓░░] spare: 27,020
 ├─ IMUL constraints: 8,262 used (50.4% of 2^14)
 │  [▓▓▓▓▓░░░░░] spare: 8,122
 ├─ BMUL constraints: 0 used (0.0% of 0)

--- a/crates/frontend/src/compiler/constraint_builder/constraint.rs
+++ b/crates/frontend/src/compiler/constraint_builder/constraint.rs
@@ -123,23 +123,6 @@ pub struct WireLinearConstraint {
 }
 
 impl WireLinearConstraint {
-	/// Lowers to `RHS & all_ones == DST`.
-	///
-	/// AND against the all-ones wire is the identity on `&`, so this encodes
-	/// the equality `RHS == DST` with the only opcode available for it.
-	pub(super) fn into_and_constraint(
-		self,
-		wire_mapping: &SecondaryMap<Wire, ValueIndex>,
-		all_ones: ValueIndex,
-	) -> AndConstraint {
-		let dst = wire_mapping[self.dst];
-		AndConstraint([
-			self.rhs.into_value_indices(wire_mapping),
-			vec![ShiftedValueIndex::plain(all_ones)],
-			vec![ShiftedValueIndex::plain(dst)],
-		])
-	}
-
 	/// Lowers to the Zero constraint `RHS ^ DST == 0`.
 	///
 	/// This is the direct encoding of the equality: one constraint array instead of the three an
@@ -193,7 +176,7 @@ mod tests {
 		);
 
 		let (_zero_constraints, and_constraints, imul_constraints, bmul_constraints) =
-			builder.build(&wire_mapping, all_one_wire, false);
+			builder.build(&wire_mapping);
 
 		assert_eq!(and_constraints.len(), 0);
 		assert_eq!(imul_constraints.len(), 0);

--- a/crates/frontend/src/compiler/constraint_builder/expr.rs
+++ b/crates/frontend/src/compiler/constraint_builder/expr.rs
@@ -166,24 +166,24 @@ mod tests {
 			wire_c,
 		);
 
-		let (_zero_constraints, and_constraints, imul_constraints, _bmul_constraints) =
-			builder.build(&wire_mapping, all_one_wire, false);
+		let (zero_constraints, and_constraints, imul_constraints, _bmul_constraints) =
+			builder.build(&wire_mapping);
 
-		assert_eq!(and_constraints.len(), 1);
+		assert_eq!(zero_constraints.len(), 1);
+		assert_eq!(and_constraints.len(), 0);
 		assert_eq!(imul_constraints.len(), 0);
 
-		let and_c = &and_constraints[0];
-		assert_eq!(and_c.a().len(), 3);
+		// The operand is the three RHS terms plus the destination.
+		let val = zero_constraints[0].val();
+		assert_eq!(val.len(), 4);
 
 		assert!(
-			and_c
-				.a()
-				.iter()
+			val.iter()
 				.any(|svi| svi.value_index == ValueIndex(0) && svi.amount == 0),
 			"plain(a) from rotr(a, 0)"
 		);
 		assert!(
-			and_c.a().iter().any(|svi| {
+			val.iter().any(|svi| {
 				svi.value_index == ValueIndex(1)
 					&& svi.amount == 5
 					&& matches!(svi.shift_variant, ShiftVariant::Sll)
@@ -191,7 +191,7 @@ mod tests {
 			"native sll(b, 5)"
 		);
 		assert!(
-			and_c.a().iter().any(|svi| {
+			val.iter().any(|svi| {
 				svi.value_index == ValueIndex(0)
 					&& svi.amount == 12
 					&& matches!(svi.shift_variant, ShiftVariant::Rotr)

--- a/crates/frontend/src/compiler/constraint_builder/mod.rs
+++ b/crates/frontend/src/compiler/constraint_builder/mod.rs
@@ -38,8 +38,7 @@ pub struct ConstraintBuilder {
 	pub imul_constraints: Vec<WireImulConstraint>,
 	/// GHASH-field multiply constraints over `(lo, hi)` limb pairs.
 	pub bmul_constraints: Vec<WireBmulConstraint>,
-	/// Linear constraints `RHS == DST`, lowered by [`build`](Self::build) to either an AND against
-	/// the all-ones wire or a Zero constraint.
+	/// Linear constraints `RHS == DST`, lowered by [`build`](Self::build) to Zero constraints.
 	pub linear_constraints: Vec<WireLinearConstraint>,
 }
 
@@ -111,19 +110,13 @@ impl ConstraintBuilder {
 
 	/// Lowers every wire-level constraint to its core `ValueIndex` form.
 	///
-	/// A linear constraint lowers one of two ways, selected by `linear_to_zero`:
-	///
-	/// - `false` — to `RHS & all_one == DST`, an AND against the all-ones wire that acts as the
-	///   identity for `&`;
-	/// - `true` — to the Zero constraint `RHS ^ DST == 0`, which carries one constraint array
-	///   rather than three.
+	/// A linear constraint lowers to the Zero constraint `RHS ^ DST == 0`, which carries one
+	/// constraint array where an AND against the all-ones constant would carry three.
 	pub fn build(
 		self,
 		wire_mapping: &SecondaryMap<Wire, ValueIndex>,
-		all_one: Wire,
-		linear_to_zero: bool,
 	) -> (Vec<ZeroConstraint>, Vec<AndConstraint>, Vec<ImulConstraint>, Vec<BmulConstraint>) {
-		let mut and_constraints = self
+		let and_constraints = self
 			.and_constraints
 			.into_iter()
 			.map(|c| c.into_constraint(wire_mapping))
@@ -141,21 +134,11 @@ impl ConstraintBuilder {
 			.map(|c| c.into_constraint(wire_mapping))
 			.collect();
 
-		let mut zero_constraints = Vec::new();
-		if linear_to_zero {
-			zero_constraints.extend(
-				self.linear_constraints
-					.into_iter()
-					.map(|c| c.into_zero_constraint(wire_mapping)),
-			);
-		} else if !self.linear_constraints.is_empty() {
-			let all_one = wire_mapping[all_one];
-			and_constraints.extend(
-				self.linear_constraints
-					.into_iter()
-					.map(|c| c.into_and_constraint(wire_mapping, all_one)),
-			);
-		}
+		let zero_constraints = self
+			.linear_constraints
+			.into_iter()
+			.map(|c| c.into_zero_constraint(wire_mapping))
+			.collect();
 
 		(zero_constraints, and_constraints, imul_constraints, bmul_constraints)
 	}

--- a/crates/frontend/src/compiler/constraint_builder/shift.rs
+++ b/crates/frontend/src/compiler/constraint_builder/shift.rs
@@ -274,36 +274,29 @@ mod tests {
 			let mut builder = ConstraintBuilder::new();
 			builder.linear(expr::xor2(expr::rotr(wire_a, 0), wire_b), wire_c);
 
-			let (_zero_constraints, and_constraints, imul_constraints, _bmul_constraints) =
-				builder.build(&wire_mapping, all_one_wire, false);
+			let (zero_constraints, and_constraints, imul_constraints, _bmul_constraints) =
+				builder.build(&wire_mapping);
 
-			// Linear lowers to `(a ^ b) & all_one = c`.
-			assert_eq!(and_constraints.len(), 1);
+			// Linear lowers to the ZERO constraint `a ^ b ^ c = 0`.
+			assert_eq!(zero_constraints.len(), 1);
+			assert_eq!(and_constraints.len(), 0);
 			assert_eq!(imul_constraints.len(), 0);
 
-			let and_c = &and_constraints[0];
-
-			assert_eq!(and_c.a().len(), 2);
+			let val = zero_constraints[0].val();
+			assert_eq!(val.len(), 3);
 			assert!(
-				and_c
-					.a()
-					.iter()
+				val.iter()
 					.any(|svi| svi.value_index == ValueIndex(0) && svi.amount == 0)
 			);
 			assert!(
-				and_c
-					.a()
-					.iter()
+				val.iter()
 					.any(|svi| svi.value_index == ValueIndex(1) && svi.amount == 0)
 			);
-
-			assert_eq!(and_c.b().len(), 1);
-			assert_eq!(and_c.b()[0].value_index, ValueIndex(3));
-			assert_eq!(and_c.b()[0].amount, 0);
-
-			assert_eq!(and_c.c().len(), 1);
-			assert_eq!(and_c.c()[0].value_index, ValueIndex(2));
-			assert_eq!(and_c.c()[0].amount, 0);
+			// The destination joins the operand rather than sitting in its own `c`.
+			assert!(
+				val.iter()
+					.any(|svi| svi.value_index == ValueIndex(2) && svi.amount == 0)
+			);
 		}
 
 		// c = rotr(a, 5) ^ b  ->  native rotr(a, 5).
@@ -311,23 +304,22 @@ mod tests {
 			let mut builder = ConstraintBuilder::new();
 			builder.linear(expr::xor2(expr::rotr(wire_a, 5), wire_b), wire_c);
 
-			let (_zero_constraints, and_constraints, imul_constraints, _bmul_constraints) =
-				builder.build(&wire_mapping, all_one_wire, false);
+			let (zero_constraints, and_constraints, imul_constraints, _bmul_constraints) =
+				builder.build(&wire_mapping);
 
-			assert_eq!(and_constraints.len(), 1);
+			assert_eq!(zero_constraints.len(), 1);
+			assert_eq!(and_constraints.len(), 0);
 			assert_eq!(imul_constraints.len(), 0);
 
-			let and_c = &and_constraints[0];
-			assert_eq!(and_c.a().len(), 2);
-			assert!(and_c.a().iter().any(|svi| {
+			let val = zero_constraints[0].val();
+			assert_eq!(val.len(), 3);
+			assert!(val.iter().any(|svi| {
 				svi.value_index == ValueIndex(0)
 					&& svi.amount == 5
 					&& matches!(svi.shift_variant, ShiftVariant::Rotr)
 			}));
 			assert!(
-				and_c
-					.a()
-					.iter()
+				val.iter()
 					.any(|svi| svi.value_index == ValueIndex(1) && svi.amount == 0)
 			);
 		}
@@ -352,7 +344,7 @@ mod tests {
 			let mut builder = ConstraintBuilder::new();
 			builder.and(wire_a, expr::rotr(wire_b, 0), wire_c);
 
-			let (_, and_constraints, _, _) = builder.build(&wire_mapping, all_one_wire, false);
+			let (_, and_constraints, _, _) = builder.build(&wire_mapping);
 
 			assert_eq!(and_constraints.len(), 1);
 			let and_c = &and_constraints[0];
@@ -375,7 +367,7 @@ mod tests {
 			let mut builder = ConstraintBuilder::new();
 			builder.and(wire_a, expr::rotr(wire_b, 8), wire_c);
 
-			let (_, and_constraints, _, _) = builder.build(&wire_mapping, all_one_wire, false);
+			let (_, and_constraints, _, _) = builder.build(&wire_mapping);
 
 			assert_eq!(and_constraints.len(), 1);
 			let and_c = &and_constraints[0];

--- a/crates/frontend/src/compiler/gate_fusion/mod.rs
+++ b/crates/frontend/src/compiler/gate_fusion/mod.rs
@@ -11,9 +11,8 @@
 //! `ConstraintBuilder` which this pass operates consists of AND, IMUL and linear constraints.
 //! Linear constraints are basically are constraints that define a single wire using a XOR
 //! combination and/or shifts. Since our system does not suppose standalone linear combinations a
-//! wire whose definition survives has to be committed, and its definition costs a constraint of
-//! its own — an AND against the all-ones wire, or a Zero constraint under
-//! `enable_zero_constraints`.
+//! wire whose definition survives has to be committed, and its definition costs a Zero constraint
+//! of its own.
 //!
 //! BUT we have a chance of avoiding that if we manage to inline that wire into every consumer
 //! constraint which means we don't have to commit that value and thus we don't spend a constraint

--- a/crates/frontend/src/compiler/gate_fusion/patch.rs
+++ b/crates/frontend/src/compiler/gate_fusion/patch.rs
@@ -205,10 +205,10 @@ fn build_non_lin_patch(
 /// definition and all definitions that could be inlined into it. Therefore, the returned
 /// patch will replace the given linear definition and the cone of linear definitions it used.
 ///
-/// The patch stays linear: the wire has to be committed, but *how* the defining equation is
-/// enforced — an AND against the all-ones wire, or a Zero constraint — is
-/// [`ConstraintBuilder::build`](crate::compiler::constraint_builder::ConstraintBuilder::build)'s
-/// decision, taken from the `enable_zero_constraints` option.
+/// The patch stays linear: the wire has to be committed, and its defining equation is enforced by
+/// the Zero constraint
+/// [`ConstraintBuilder::build`](crate::compiler::constraint_builder::ConstraintBuilder::build)
+/// lowers it to.
 fn build_committed_lin_def_patch(_cb: &ConstraintBuilder, leg: &LeGraph, root: Wire) -> Patch {
 	// `subsumes` is a list of constraints that become redundant with application of this patch.
 	// The first redundant constraint is the linear definition that's being committed.

--- a/crates/frontend/src/compiler/gate_fusion/tests/awhole.rs
+++ b/crates/frontend/src/compiler/gate_fusion/tests/awhole.rs
@@ -57,6 +57,15 @@ fn stringify_constraint_system(cs: &ConstraintSystem) -> String {
 
 	let mut output = String::new();
 
+	// ZERO constraints
+	if !cs.zero_constraints.is_empty() {
+		for (i, constraint) in cs.zero_constraints.iter().enumerate() {
+			write!(output, "ZERO[{}]: (", i).unwrap();
+			format_operand(&mut output, constraint.val(), cs);
+			writeln!(output, ") = 0").unwrap();
+		}
+	}
+
 	// AND constraints
 	if !cs.and_constraints.is_empty() {
 		for (i, constraint) in cs.and_constraints.iter().enumerate() {
@@ -154,8 +163,6 @@ fn mk_circuit_builder() -> CircuitBuilder {
 		enable_algebraic_folding: false,
 		// Scratch pooling only moves uncommitted slots, so it cannot affect these snapshots.
 		enable_scratch_pooling: false,
-		// The snapshots record the AND constraints linear constraints lower to.
-		enable_zero_constraints: false,
 		// Zero propagation would forward past the gates these snapshots assert on.
 		enable_zero_propagation: false,
 	};
@@ -236,8 +243,8 @@ fn test_mul_inlining_into_hi_lo() {
 
 	let cs = compile(&b);
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @r"
-	AND[0]: (v[2] ⊕ v[3]) ∧ (all-1) = (v[8])
-	AND[1]: (v[4] ⊕ v[5]) ∧ (all-1) = (v[9])
+	ZERO[0]: (v[2] ⊕ v[3] ⊕ v[8]) = 0
+	ZERO[1]: (v[4] ⊕ v[5] ⊕ v[9]) = 0
 	IMUL[0]: (v[6]) * (v[7]) = (HI: v[10], LO: v[11])
 	");
 }
@@ -273,7 +280,7 @@ fn test_xor_unused_preserved() {
 	let v1 = b.add_witness();
 	let _v2 = b.bxor(v0, v1);
 	let cs = compile(&b);
-	insta::assert_snapshot!(stringify_constraint_system(&cs), @"AND[0]: (0xe4 ⊕ v[2]) ∧ (all-1) = (v[3])");
+	insta::assert_snapshot!(stringify_constraint_system(&cs), @"ZERO[0]: (0xe4 ⊕ v[2] ⊕ v[3]) = 0");
 }
 
 #[test]
@@ -619,8 +626,8 @@ fn test_dont_inline_shifted_producer_into_shifted_use() {
 	let cs = compile(&b);
 	// Cannot compose different shift types (srl then sll), so it commits the intermediate
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @r"
+	ZERO[0]: (v[2]≫7 ⊕ v[4]) = 0
 	AND[0]: (v[4]≪3) ∧ (v[3]) = (v[5])
-	AND[1]: (v[2]≫7) ∧ (all-1) = (v[4])
 	");
 }
 
@@ -835,8 +842,8 @@ fn test_depth_limit_deep_chain() {
 	// We expect the optimizer to commit some intermediate value and create multiple AND constraints
 	// The exact output depends on where the depth limit triggers commitment
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @r"
+	ZERO[0]: (v[2] ⊕ v[3] ⊕ v[12]) = 0
 	AND[0]: (v[12] ⊕ v[4] ⊕ v[5] ⊕ v[6] ⊕ v[7] ⊕ v[8] ⊕ v[9] ⊕ v[10]) ∧ (v[11]) = (v[13])
-	AND[1]: (v[2] ⊕ v[3]) ∧ (all-1) = (v[12])
 	");
 }
 
@@ -888,7 +895,7 @@ fn test_depth_limit_with_shifts() {
 	// With shifts in the chain, the depth limit should still apply
 	// The optimizer should handle the complexity and commit when needed
 	insta::assert_snapshot!(stringify_constraint_system(&cs), @r"
+	ZERO[0]: (v[2]≫3 ⊕ v[3]≫3 ⊕ v[4] ⊕ v[12]) = 0
 	AND[0]: (v[12]≪7 ⊕ v[5]≪7 ⊕ v[6] ⊕ v[7] ⊕ v[8] ⊕ v[9] ⊕ v[10]) ∧ (v[11]) = (v[13])
-	AND[1]: (v[2]≫3 ⊕ v[3]≫3 ⊕ v[4]) ∧ (all-1) = (v[12])
 	");
 }

--- a/crates/frontend/src/compiler/mod.rs
+++ b/crates/frontend/src/compiler/mod.rs
@@ -43,7 +43,7 @@ mod zero_fold;
 pub use gate_graph::Wire;
 use scratch_alloc::{ScratchAlloc, ScratchPolicy};
 
-/// Which compiler passes run, and how linear constraints are lowered.
+/// Which compiler passes run.
 ///
 /// This is the only knob: a circuit compiles the same way whatever the process environment holds.
 /// A caller that wants a non-default pass set builds through [`CircuitBuilder::with_opts`],
@@ -53,7 +53,7 @@ use scratch_alloc::{ScratchAlloc, ScratchPolicy};
 /// use binius_frontend::{CircuitBuilder, Options};
 ///
 /// let builder = CircuitBuilder::with_opts(Options {
-///     enable_zero_constraints: true,
+///     enable_gate_fusion: false,
 ///     ..Options::default()
 /// });
 /// ```
@@ -70,9 +70,6 @@ pub struct Options {
 	pub enable_algebraic_folding: bool,
 	/// Share scratch slots between values whose lifetimes do not overlap.
 	pub enable_scratch_pooling: bool,
-	/// Lower linear constraints to Zero constraints instead of AND constraints against the
-	/// all-ones constant.
-	pub enable_zero_constraints: bool,
 	/// Forward past the gates a zero operand turns into the identity.
 	pub enable_zero_propagation: bool,
 }
@@ -88,9 +85,6 @@ impl Default for Options {
 			// Why off: sharing slots stops an uncommitted value from being readable afterwards.
 			// A caller that inspects one has to opt in knowingly.
 			enable_scratch_pooling: false,
-			// Why off: both proof systems reduce Zero constraints, but the AND lowering stays the
-			// default until the two are compared.
-			enable_zero_constraints: false,
 			enable_zero_propagation: true,
 		}
 	}
@@ -116,7 +110,7 @@ pub(crate) struct Shared {
 /// Methods like [`band`] and [`iadd_32`] add gates to the graph and return handles
 /// to output wires.
 ///
-/// During [`build`], the gate graph compiles into AND, IMUL, and BMUL constraints
+/// During [`build`], the gate graph compiles into ZERO, AND, IMUL, and BMUL constraints
 /// that the proof system operates on directly.
 ///
 /// # Wire Types
@@ -157,7 +151,7 @@ pub(crate) struct Shared {
 /// **Linear operations** - XOR and shifts generate virtual linear constraints.
 /// During compilation these either:
 /// - Fuse into adjacent non-linear gates (near-zero cost)
-/// - Materialize as AND constraints
+/// - Materialize as ZERO constraints, which the Zero reduction discharges without a prover message
 ///
 /// Gate fusion inlines compatible XOR expressions and shifts into existing AND gates.
 /// Incompatible operations (e.g., right shift into left shift) and heuristic limits
@@ -359,7 +353,7 @@ impl CircuitBuilder {
 		debug_assert_eq!(constants.first(), Some(&Word::ALL_ONE));
 
 		let (mut zero_constraints, mut and_constraints, mut imul_constraints, mut bmul_constraints) =
-			builder.build(&wire_mapping, all_one, shared.opts.enable_zero_constraints);
+			builder.build(&wire_mapping);
 
 		// Filter zero constant terms from all operands. Any shift of Word::ZERO is zero, so
 		// terms referencing a zero constant contribute nothing to an XOR operand.

--- a/crates/frontend/src/compiler/tests.rs
+++ b/crates/frontend/src/compiler/tests.rs
@@ -89,14 +89,13 @@ fn test_algebraic_fold_bxor_self_is_zero_in_witness() {
 	verify_constraints(circuit.constraint_system(), &w.value_vec).unwrap();
 }
 
-/// Builds `assert_eq(x ^ y, z)` under the given lowering of linear constraints.
+/// Builds `assert_eq(x ^ y, z)`.
 ///
 /// Gate fusion is off so that the `bxor` gate keeps its own linear constraint instead of being
 /// inlined into the assertion's operand; the assertion itself emits an AND constraint either way.
-fn build_xor_circuit(enable_zero_constraints: bool) -> (Circuit, Wire, Wire, Wire) {
+fn build_xor_circuit() -> (Circuit, Wire, Wire, Wire) {
 	let builder = CircuitBuilder::with_opts(Options {
 		enable_gate_fusion: false,
-		enable_zero_constraints,
 		..Options::default()
 	});
 	let x = builder.add_inout();
@@ -107,18 +106,8 @@ fn build_xor_circuit(enable_zero_constraints: bool) -> (Circuit, Wire, Wire, Wir
 }
 
 #[test]
-fn test_zero_constraints_disabled_by_default() {
-	let (circuit, ..) = build_xor_circuit(false);
-	let cs = circuit.constraint_system();
-
-	// The `bxor` linear constraint and the assertion, both as AND constraints.
-	assert_eq!(cs.n_zero_constraints(), 0);
-	assert_eq!(cs.n_and_constraints(), 2);
-}
-
-#[test]
-fn test_zero_constraints_replace_the_linear_and_constraints() {
-	let (zero_circuit, x, y, z) = build_xor_circuit(true);
+fn test_linear_constraints_lower_to_zero_constraints() {
+	let (zero_circuit, x, y, z) = build_xor_circuit();
 	let cs = zero_circuit.constraint_system();
 
 	// The `bxor` linear constraint moves to the ZERO set, leaving only the assertion's AND.
@@ -143,13 +132,10 @@ fn test_zero_constraints_replace_the_linear_and_constraints() {
 /// Builds `((x << 32) >> 32) & y == z` with gate fusion left on.
 ///
 /// A left-then-right shift pair is not expressible as one shifted operand, so fusion cannot
-/// inline the intermediate into the `band` and has to commit it. That committed definition is the
-/// one the option has to reach.
-fn build_committed_lin_def_circuit(enable_zero_constraints: bool) -> (Circuit, Wire, Wire, Wire) {
-	let builder = CircuitBuilder::with_opts(Options {
-		enable_zero_constraints,
-		..Options::default()
-	});
+/// inline the intermediate into the `band` and has to commit it. That committed definition lowers
+/// to a ZERO constraint like any other linear constraint.
+fn build_committed_lin_def_circuit() -> (Circuit, Wire, Wire, Wire) {
+	let builder = CircuitBuilder::new();
 	let x = builder.add_inout();
 	let y = builder.add_inout();
 	let z = builder.add_inout();
@@ -160,19 +146,18 @@ fn build_committed_lin_def_circuit(enable_zero_constraints: bool) -> (Circuit, W
 
 #[test]
 fn test_zero_constraints_reach_a_fused_committed_lin_def() {
-	let (and_circuit, ..) = build_committed_lin_def_circuit(false);
-	let (zero_circuit, x, y, z) = build_committed_lin_def_circuit(true);
-	let and_cs = and_circuit.constraint_system();
+	let (zero_circuit, x, y, z) = build_committed_lin_def_circuit();
 	let zero_cs = zero_circuit.constraint_system();
 
-	// With the option off every committed definition is an AND against all-ones.
-	assert_eq!(and_cs.n_zero_constraints(), 0);
-
-	// With it on they move to the ZERO set, one for one, and nothing else changes.
-	assert!(zero_cs.n_zero_constraints() > 0);
-	assert_eq!(
-		zero_cs.n_zero_constraints(),
-		and_cs.n_and_constraints() - zero_cs.n_and_constraints()
+	// The committed shift pair is a ZERO constraint, and it names no all-ones constant — the AND
+	// set holds only the `band` and the assertion.
+	assert_eq!(zero_cs.n_zero_constraints(), 1);
+	assert_eq!(zero_cs.n_and_constraints(), 2);
+	assert!(
+		zero_cs.zero_constraints[0]
+			.val()
+			.iter()
+			.all(|svi| svi.value_index != ValueIndex(0))
 	);
 
 	let mut filler = zero_circuit.new_witness_filler();
@@ -586,7 +571,7 @@ fn test_multiple_xor_operations() {
 }
 
 #[test]
-fn test_linear_constraint_conversion_to_and() {
+fn test_linear_constraint_conversion_to_zero() {
 	// This test verifies that linear constraints (created by XOR/shift operations)
 	// are properly converted to AND constraints during circuit building.
 	// The conversion happens in constraint_builder.rs build() method.
@@ -610,20 +595,20 @@ fn test_linear_constraint_conversion_to_and() {
 	let final_result = builder.bxor(combined1, combined2);
 
 	// Pin the result as committed so its linear cone survives dead-code elimination.
-	// A computation read by nothing is otherwise dropped, leaving no AND constraint to check.
+	// A computation read by nothing is otherwise dropped, leaving no constraint to check.
 	builder.force_commit(final_result);
 
 	let circuit = builder.build();
 
-	// Get the constraint system which should have AND constraints
-	// (linear constraints were converted to AND constraints)
+	// Get the constraint system which should have ZERO constraints
+	// (linear constraints were converted to ZERO constraints)
 	let cs = circuit.constraint_system();
 
-	// The circuit should have AND constraints but no separate linear constraints
+	// The circuit should have ZERO constraints but no separate linear constraints
 	// (they were all converted during build)
 	assert!(
-		!cs.and_constraints.is_empty(),
-		"Should have AND constraints from converted linear constraints"
+		!cs.zero_constraints.is_empty(),
+		"Should have ZERO constraints from converted linear constraints"
 	);
 
 	// Test with values to ensure correctness

--- a/crates/m4-prover/src/prove.rs
+++ b/crates/m4-prover/src/prove.rs
@@ -946,9 +946,8 @@ mod tests {
 		// runs.
 		//
 		// Gate fusion is off: it inlines a linear definition into the gate that consumes it, which
-		// would leave no linear constraint for the option to lower.
+		// would leave no linear constraint to lower.
 		let builder = CircuitBuilder::with_opts(Options {
-			enable_zero_constraints: true,
 			enable_gate_fusion: false,
 			..Options::default()
 		});
@@ -1010,9 +1009,8 @@ mod tests {
 		use binius_core::constraint_system::ZeroConstraint;
 		use binius_frontend::{Options, Wire};
 
-		// Gate fusion off, so the `bxor` survives as a linear constraint the option can lower.
+		// Gate fusion off, so the `bxor` survives as a linear constraint to lower.
 		let builder = CircuitBuilder::with_opts(Options {
-			enable_zero_constraints: true,
 			enable_gate_fusion: false,
 			..Options::default()
 		});

--- a/crates/m4-prover/src/shift.rs
+++ b/crates/m4-prover/src/shift.rs
@@ -567,6 +567,10 @@ mod tests {
 			BinarySubspace::<AESTowerField8b>::with_dim(Word::LOG_BITS).isomorphic();
 		let r_z = B128::random(&mut rng);
 		let r_x = random_scalars::<B128>(&mut rng, cs.log_and_constraints().unwrap_or(0));
+		// The Zero claim closes at its own constraint point, as wide as the ZERO set. Its value is
+		// zero at any point: a satisfied ZERO constraint array vanishes identically, so its
+		// multilinear extension is the zero polynomial.
+		let r_x_zero = random_scalars::<B128>(&mut rng, cs.log_zero_constraints().unwrap_or(0));
 		let r_rho = random_scalars::<B128>(&mut rng, log_instances);
 
 		// The hidden witness folded over instances (one FoldedWord per committed word), and the
@@ -597,7 +601,7 @@ mod tests {
 			OperatorData {
 				evals: vec![B128::ZERO],
 				r_zhat_prime: r_z,
-				r_x_prime: Vec::new(),
+				r_x_prime: r_x_zero.clone(),
 			},
 			OperatorData {
 				evals: bitand_evals.to_vec(),
@@ -621,7 +625,7 @@ mod tests {
 
 		// Verify against the single-instance shift verifier.
 		let mut verifier_transcript = prover_transcript.into_verifier();
-		let verifier_zero = VerifierOperatorData::new(Vec::new(), [B128::ZERO]);
+		let verifier_zero = VerifierOperatorData::new(r_x_zero, [B128::ZERO]);
 		let verifier_bitand = VerifierOperatorData::new(r_x, bitand_evals);
 		let verifier_intmul = VerifierOperatorData::new(Vec::new(), intmul_evals);
 		let verifier_bmul = VerifierOperatorData::new(Vec::new(), [B128::ZERO; 6]);
@@ -748,11 +752,12 @@ mod tests {
 			},
 			B128::random(&mut rng),
 		);
+		// The ZERO set has its own constraint point, as wide as the set itself.
 		let prepared_zero = PreparedOperatorData::new(
 			OperatorData {
-				evals: Vec::new(),
+				evals: vec![B128::ZERO],
 				r_zhat_prime: r_z,
-				r_x_prime: Vec::new(),
+				r_x_prime: random_scalars::<B128>(&mut rng, cs.log_zero_constraints().unwrap_or(0)),
 			},
 			B128::random(&mut rng),
 		);

--- a/crates/prover/tests/prove_verify.rs
+++ b/crates/prover/tests/prove_verify.rs
@@ -305,15 +305,14 @@ fn test_prove_verify_zero_imul_constraints() {
 /// constraints from `band` gates.
 ///
 /// Gate fusion is off: it inlines a linear definition into the gate that consumes it, which would
-/// leave no linear constraint for the option to lower. The remaining passes are off so the counts
-/// are exactly what the gates emit.
+/// leave no linear constraint to lower. The remaining passes are off so the counts are exactly what
+/// the gates emit.
 fn zero_constraint_circuit(
 	n_xor: usize,
 	n_rotr: usize,
 	n_and: usize,
 ) -> (ConstraintSystem, ValueVec) {
 	let builder = CircuitBuilder::with_opts(Options {
-		enable_zero_constraints: true,
 		enable_gate_fusion: false,
 		enable_common_subexpression_elimination: false,
 		enable_dead_code_elimination: false,

--- a/crates/prover/tests/shift.rs
+++ b/crates/prover/tests/shift.rs
@@ -297,12 +297,16 @@ fn test_shift_prove_and_verify() {
 			r_zhat_prime,
 			r_x_prime: r_x_prime_intmul.clone(),
 		};
-		// These circuits have no ZERO constraints, so the Zero claim is the zero claim at an empty
-		// point, exactly as the prover synthesizes it.
+		// The Zero claim closes at its own constraint point, as wide as the ZERO set. Its value is
+		// zero at any point: a satisfied ZERO constraint array vanishes identically, so its
+		// multilinear extension is the zero polynomial.
+		let r_x_prime_zero = (0..cs.log_zero_constraints().unwrap_or(0) as u128)
+			.map(F::new)
+			.collect::<Vec<_>>();
 		let prover_zero_data = OperatorData {
 			evals: vec![F::ZERO],
 			r_zhat_prime,
-			r_x_prime: Vec::new(),
+			r_x_prime: r_x_prime_zero.clone(),
 		};
 		// These circuits have no BMUL constraints, so the BinMul claim is the zero claim at an
 		// empty point (the prover's skipped-case `None` branch).
@@ -327,7 +331,7 @@ fn test_shift_prove_and_verify() {
 		// Create verifier transcript and call the verifier
 		let mut verifier_transcript = prover_transcript.into_verifier();
 
-		let verifier_zero_data = VerifierOperatorData::new(Vec::new(), [F::ZERO]);
+		let verifier_zero_data = VerifierOperatorData::new(r_x_prime_zero, [F::ZERO]);
 		let verifier_bitand_data = VerifierOperatorData::new(r_x_prime_bitand, bitand_evals);
 		let verifier_intmul_data = VerifierOperatorData::new(r_x_prime_intmul, intmul_evals);
 		let verifier_binmul_data = VerifierOperatorData::new(Vec::new(), [F::ZERO; 6]);


### PR DESCRIPTION
Closes [BINIUS-386](https://linear.app/jimpo/issue/BINIUS-386/remove-the-compile-time-option-for-zero-constraints-make-it-always-on). Follow-up to #1963.

`Options::enable_zero_constraints` is gone. A linear constraint now always lowers to the Zero constraint `RHS ^ DST = 0`, never to an AND against the all-ones constant. The AND lowering was the only reader of the builder's all-ones wire, so `ConstraintBuilder::build` no longer takes it, and `WireLinearConstraint::into_and_constraint` is deleted.

### Effect on real circuits

Every linear constraint that survives fusion moves from the AND set to the ZERO set, one for one — the AND drop equals the ZERO count in all 11 affected examples. Six circuits drop a full power of two in the **padded** AND allocation, which is what the BitAnd sumcheck actually runs over:

| circuit | AND before | AND after | ZERO | AND allocation |
| --- | ---: | ---: | ---: | --- |
| hashsign | 275,951 | 145,508 | 130,443 | 2^19 → 2^18 |
| zklogin | 258,569 | 235,124 | 23,445 | 2^18 (unchanged) |
| bitcoin_headers | 20,038 | 15,344 | 4,694 | 2^15 → 2^14 |
| blake2s | 13,656 | 7,688 | 5,968 | 2^14 → 2^13 |
| sha512 | 10,311 | 8,270 | 2,041 | 2^14 (unchanged) |
| sha256 | 8,616 | 6,575 | 2,041 | 2^14 → 2^13 |
| blake2b | 8,160 | 4,616 | 3,544 | 2^13 (unchanged) |
| blake3 | 5,141 | 2,760 | 2,381 | 2^13 → 2^12 |
| ethsign | 159,863 | 157,690 | 2,173 | 2^18 (unchanged) |
| ec_msm | 158,253 | 156,113 | 2,140 | 2^18 (unchanged) |
| bitcoin_p2pkh | 113,485 | 111,567 | 1,918 | 2^17 (unchanged) |

Nearly half of `hashsign`'s constraints turn out to be linear. `keccak` is unaffected — its linear constraints all fuse away — and `blake3_compress` has no constraints at all, so those two snapshots are byte-identical.

**These are constraint counts, not timings.** I have not measured prove time; the padded-allocation halvings should show up there, since the Zero reduction carries no sumcheck round, but that claim is unverified in this PR.

### Tests

Three fixtures hand-built a Zero claim with an *empty* constraint point, which worked only while their circuits had no ZERO constraints. Now they have them, and `accumulate_wide` indexed a length-1 tensor with constraint index 1:

- `crates/m4-prover/src/shift.rs` — `prove_and_verify_round_trip` and `phase_1_g_h_inner_product_matches_batched_evals`
- `crates/prover/tests/shift.rs` — `test_shift_prove_and_verify`

Each needed a point of width `log_zero_constraints()`, not a different value: a satisfied ZERO constraint array vanishes identically, so its multilinear extension is the zero polynomial and evaluates to `0` at any point.

Also updated:

- `test_linear_constraint_conversion_to_and` → `..._to_zero`; its central assertion was on the AND set.
- #1963's `test_zero_constraints_reach_a_fused_committed_lin_def` compared option-off against option-on, which is no longer expressible. It now pins the behaviour with exact counts (1 ZERO, 2 AND) and checks the operand names no all-ones constant — a stronger assertion than the differential it replaces.
- The gate-fusion tests' `stringify_constraint_system` only printed AND and IMUL, so affected snapshots would have rendered **empty** rather than showing the change. It prints ZERO constraints now, and the five inline snapshots read e.g. `ZERO[0]: (v[2]≫7 ⊕ v[4]) = 0` where they read `AND[1]: (v[2]≫7) ∧ (all-1) = (v[4])`.

All 13 example snapshots pass `check-snapshot`, and clippy ran directly on the four changed crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)