### PR TITLE
Resolve a shift variant to its word operation in one place

### DIFF
--- a/crates/core/src/constraint_system/shift.rs
+++ b/crates/core/src/constraint_system/shift.rs
@@ -50,7 +50,49 @@ pub enum ShiftVariant {
 	Rotr32 = 7,
 }
 
+/// A callback that runs against one concrete word-level shift.
+///
+/// Resolving a variant once turns it into a closure over words, handed to the callback here.
+/// Each variant gets its own specialized copy, so the callback's loop keeps no per-word branch.
+pub trait ShiftKernel {
+	/// What the callback produces.
+	type Output;
+
+	/// Runs the callback against `shift`, the resolved word operation.
+	fn call(self, shift: impl Fn(Word) -> Word) -> Self::Output;
+}
+
+/// Applies a resolved shift to a single word.
+struct ShiftOneWord {
+	/// The word the shift is applied to.
+	word: Word,
+}
+
+impl ShiftKernel for ShiftOneWord {
+	type Output = Word;
+
+	#[inline]
+	fn call(self, shift: impl Fn(Word) -> Word) -> Word {
+		// A single word carries no loop to specialize, so the resolved shift runs once.
+		shift(self.word)
+	}
+}
+
 impl ShiftVariant {
+	/// Every variant, ordered so that the array index equals the discriminant.
+	///
+	/// Callers that must cover all variants iterate this: random fixtures, exhaustive checks.
+	pub const ALL: [Self; 8] = [
+		Self::Sll,
+		Self::Slr,
+		Self::Sar,
+		Self::Rotr,
+		Self::Sll32,
+		Self::Srl32,
+		Self::Sra32,
+		Self::Rotr32,
+	];
+
 	/// Decodes a variant from its `u8` discriminant.
 	///
 	/// The discriminants match the `#[repr(u8)]` layout: `0..=7` map to the eight variants.
@@ -95,34 +137,54 @@ impl ShiftVariant {
 		if self.is_half_word() { 32 } else { 64 }
 	}
 
+	/// Resolves this variant to its word-level operation and runs a callback against it.
+	///
+	/// This is the single place that says what a variant does to a word:
+	/// - Logical left and logical right shift zeros in.
+	/// - Arithmetic right replicates the sign bit.
+	/// - Rotate wraps the bits that fall off one end around to the other.
+	/// - The half-word forms apply the same operation to each 32-bit half on its own.
+	///
+	/// # Arguments
+	///
+	/// - `amount`: the shift amount in bits, below this variant's upper bound.
+	/// - `kernel`: the callback to run against the resolved operation.
+	///
+	/// # Performance
+	///
+	/// The variant is decided here, once, ahead of whatever loop the callback runs.
+	/// Each branch hands over a distinct zero-sized closure, leaving no branch in the callback.
+	#[inline]
+	pub fn dispatch<K: ShiftKernel>(self, amount: u32, kernel: K) -> K::Output {
+		match self {
+			ShiftVariant::Sll => kernel.call(move |word| word << amount),
+			ShiftVariant::Slr => kernel.call(move |word| word >> amount),
+			ShiftVariant::Sar => kernel.call(move |word| word.sar(amount)),
+			ShiftVariant::Rotr => kernel.call(move |word| word.rotr(amount)),
+			ShiftVariant::Sll32 => kernel.call(move |word| word.sll32(amount)),
+			ShiftVariant::Srl32 => kernel.call(move |word| word.srl32(amount)),
+			ShiftVariant::Sra32 => kernel.call(move |word| word.sra32(amount)),
+			ShiftVariant::Rotr32 => kernel.call(move |word| word.rotr32(amount)),
+		}
+	}
+
 	/// Applies this shift to a 64-bit word and returns the result.
 	///
-	/// The variant selects which word-level operation runs.
 	/// Full-width variants act on the whole 64-bit word.
-	/// The 32-bit variants act on the upper and lower halves independently.
+	/// The half-word variants act on the upper and lower 32-bit halves independently.
 	///
 	/// # Arguments
 	/// - The word to shift.
 	/// - The shift amount in bits.
+	///
+	/// # Performance
+	///
+	/// Which operation to run is decided on every call.
+	/// To shift many words by one fixed variant, resolve the variant once instead.
 	#[inline]
 	pub fn apply(self, word: Word, amount: usize) -> Word {
-		// The word-level operators take the amount as a 32-bit count.
-		let amount = amount as u32;
-		// Dispatch to the matching operation:
-		// - logical left / logical right shift in zeros.
-		// - arithmetic right replicates the sign bit.
-		// - rotate wraps bits around the word.
-		// - the `*32` family applies the same op to each 32-bit half on its own.
-		match self {
-			ShiftVariant::Sll => word << amount,
-			ShiftVariant::Slr => word >> amount,
-			ShiftVariant::Sar => word.sar(amount),
-			ShiftVariant::Rotr => word.rotr(amount),
-			ShiftVariant::Sll32 => word.sll32(amount),
-			ShiftVariant::Srl32 => word.srl32(amount),
-			ShiftVariant::Sra32 => word.sra32(amount),
-			ShiftVariant::Rotr32 => word.rotr32(amount),
-		}
+		// The word-level operators count the amount in 32 bits.
+		self.dispatch(amount as u32, ShiftOneWord { word })
 	}
 }
 
@@ -358,29 +420,82 @@ impl DeserializeBytes for ShiftedValueIndex {
 
 #[cfg(test)]
 mod tests {
+	use proptest::prelude::*;
+
 	use super::*;
+
+	// What each variant means, spelled out over raw integers.
+	// Independent of the word methods the implementation names, so a mis-wired variant fails here.
+	fn reference_shift(variant: ShiftVariant, word: u64, amount: u32) -> u64 {
+		// Half-word variants act on each 32-bit half on its own, reading only the low 5 bits.
+		let halves = |op: fn(u32, u32) -> u32| {
+			let amount = amount & 0x1F;
+			op(word as u32, amount) as u64 | ((op((word >> 32) as u32, amount) as u64) << 32)
+		};
+		match variant {
+			ShiftVariant::Sll => word << amount,
+			ShiftVariant::Slr => word >> amount,
+			ShiftVariant::Sar => (word as i64 >> amount) as u64,
+			ShiftVariant::Rotr => word.rotate_right(amount),
+			ShiftVariant::Sll32 => halves(|half, n| half << n),
+			ShiftVariant::Srl32 => halves(|half, n| half >> n),
+			ShiftVariant::Sra32 => halves(|half, n| ((half as i32) >> n) as u32),
+			ShiftVariant::Rotr32 => halves(|half, n| half.rotate_right(n)),
+		}
+	}
+
+	#[test]
+	fn all_covers_every_discriminant_in_order() {
+		// `ALL` is indexed by discriminant, and every entry decodes back to itself.
+		for (discriminant, variant) in ShiftVariant::ALL.into_iter().enumerate() {
+			assert_eq!(variant as usize, discriminant);
+			assert_eq!(ShiftVariant::from_u8(discriminant as u8), Some(variant));
+		}
+		// The list is exhaustive: the next discriminant, and any byte above it, decode to nothing.
+		assert_eq!(ShiftVariant::from_u8(ShiftVariant::ALL.len() as u8), None);
+		assert_eq!(ShiftVariant::from_u8(255), None);
+	}
+
+	#[test]
+	fn every_variant_is_the_identity_at_amount_zero() {
+		// The batched witness builder leans on this: at amount 0 it copies instead of dispatching.
+		for variant in ShiftVariant::ALL {
+			for word in [
+				Word::ZERO,
+				Word::ONE,
+				Word::ALL_ONE,
+				Word(0x0123_4567_89AB_CDEF),
+			] {
+				assert_eq!(variant.apply(word, 0), word, "{variant:?} is not the identity at 0");
+			}
+		}
+	}
+
+	proptest! {
+		// Invariant: each variant resolves to the operation it denotes, at every valid amount.
+		#[test]
+		fn dispatch_matches_the_reference_for_every_variant(word in any::<u64>()) {
+			for variant in ShiftVariant::ALL {
+				// Amounts run 0..max, so both extremes are covered.
+				for amount in 0..variant.max_amount() {
+					let expected = Word(reference_shift(variant, word, amount as u32));
+					// Both entry points share one resolution step, so checking both pins it.
+					prop_assert_eq!(variant.apply(Word(word), amount), expected);
+					let kernel = ShiftOneWord { word: Word(word) };
+					prop_assert_eq!(variant.dispatch(amount as u32, kernel), expected);
+				}
+			}
+		}
+	}
 
 	#[test]
 	fn test_shift_variant_serialization_round_trip() {
-		let variants = [
-			ShiftVariant::Sll,
-			ShiftVariant::Slr,
-			ShiftVariant::Sar,
-			ShiftVariant::Rotr,
-		];
-
-		for variant in variants {
+		for variant in ShiftVariant::ALL {
 			let mut buf = Vec::new();
 			variant.serialize(&mut buf).unwrap();
 
 			let deserialized = ShiftVariant::deserialize(&mut buf.as_slice()).unwrap();
-			match (variant, deserialized) {
-				(ShiftVariant::Sll, ShiftVariant::Sll)
-				| (ShiftVariant::Slr, ShiftVariant::Slr)
-				| (ShiftVariant::Sar, ShiftVariant::Sar)
-				| (ShiftVariant::Rotr, ShiftVariant::Rotr) => {}
-				_ => panic!("ShiftVariant round trip failed: {:?} != {:?}", variant, deserialized),
-			}
+			assert_eq!(variant, deserialized);
 		}
 	}
 
@@ -437,23 +552,15 @@ mod tests {
 
 	#[test]
 	fn test_max_amount_and_is_half_word() {
+		// The four full-width variants come first, then the four half-word ones.
+		let (full_width, half_word) = ShiftVariant::ALL.split_at(4);
 		// Full-width variants take amounts up to 63.
-		for variant in [
-			ShiftVariant::Sll,
-			ShiftVariant::Slr,
-			ShiftVariant::Sar,
-			ShiftVariant::Rotr,
-		] {
+		for &variant in full_width {
 			assert!(!variant.is_half_word());
 			assert_eq!(variant.max_amount(), 64);
 		}
 		// Half-word variants take amounts up to 31.
-		for variant in [
-			ShiftVariant::Sll32,
-			ShiftVariant::Srl32,
-			ShiftVariant::Sra32,
-			ShiftVariant::Rotr32,
-		] {
+		for &variant in half_word {
 			assert!(variant.is_half_word());
 			assert_eq!(variant.max_amount(), 32);
 		}
@@ -515,26 +622,5 @@ mod tests {
 		// Padded to the u32 alignment, that is 8 bytes.
 		// Holding this at one word matters: systems carry millions of these on the prover hot path.
 		assert_eq!(size_of::<ShiftedValueIndex>(), 8);
-	}
-
-	#[test]
-	fn test_shift_variant_from_u8_round_trip() {
-		// Every variant decodes back from its own discriminant.
-		let variants = [
-			ShiftVariant::Sll,
-			ShiftVariant::Slr,
-			ShiftVariant::Sar,
-			ShiftVariant::Rotr,
-			ShiftVariant::Sll32,
-			ShiftVariant::Srl32,
-			ShiftVariant::Sra32,
-			ShiftVariant::Rotr32,
-		];
-		for variant in variants {
-			assert_eq!(ShiftVariant::from_u8(variant as u8), Some(variant));
-		}
-		// The discriminants are exactly 0..=7, so 8 and above are undefined.
-		assert_eq!(ShiftVariant::from_u8(8), None);
-		assert_eq!(ShiftVariant::from_u8(255), None);
 	}
 }

--- a/crates/core/src/constraint_system/shift.rs
+++ b/crates/core/src/constraint_system/shift.rs
@@ -1,4 +1,6 @@
 // Copyright 2025 Irreducible Inc.
+use std::{iter, mem::MaybeUninit};
+
 use binius_utils::serialization::{DeserializeBytes, SerializationError, SerializeBytes};
 use bytes::{Buf, BufMut};
 
@@ -54,7 +56,7 @@ pub enum ShiftVariant {
 ///
 /// Resolving a variant once turns it into a closure over words, handed to the callback here.
 /// Each variant gets its own specialized copy, so the callback's loop keeps no per-word branch.
-pub trait ShiftKernel {
+trait ShiftKernel {
 	/// What the callback produces.
 	type Output;
 
@@ -75,6 +77,46 @@ impl ShiftKernel for ShiftOneWord {
 	fn call(self, shift: impl Fn(Word) -> Word) -> Word {
 		// A single word carries no loop to specialize, so the resolved shift runs once.
 		shift(self.word)
+	}
+}
+
+/// Writes one shifted source word into each output cell, initializing it.
+struct WriteShiftedWords<'a> {
+	/// The uninitialized output cells.
+	out: &'a mut [MaybeUninit<Word>],
+	/// The source words to shift, one per output cell.
+	src: &'a [Word],
+}
+
+impl ShiftKernel for WriteShiftedWords<'_> {
+	type Output = ();
+
+	#[inline]
+	fn call(self, shift: impl Fn(Word) -> Word) {
+		// Positions line up one to one, so the pair iterator stops at the shorter slice.
+		for (out_i, &src_i) in iter::zip(self.out, self.src) {
+			out_i.write(shift(src_i));
+		}
+	}
+}
+
+/// XORs one shifted source word into each output cell.
+struct XorShiftedWords<'a> {
+	/// The output cells, each holding a running XOR.
+	out: &'a mut [Word],
+	/// The source words to shift, one per output cell.
+	src: &'a [Word],
+}
+
+impl ShiftKernel for XorShiftedWords<'_> {
+	type Output = ();
+
+	#[inline]
+	fn call(self, shift: impl Fn(Word) -> Word) {
+		// Positions line up one to one, so the pair iterator stops at the shorter slice.
+		for (out_i, &src_i) in iter::zip(self.out, self.src) {
+			*out_i = *out_i ^ shift(src_i);
+		}
 	}
 }
 
@@ -155,7 +197,7 @@ impl ShiftVariant {
 	/// The variant is decided here, once, ahead of whatever loop the callback runs.
 	/// Each branch hands over a distinct zero-sized closure, leaving no branch in the callback.
 	#[inline]
-	pub fn dispatch<K: ShiftKernel>(self, amount: u32, kernel: K) -> K::Output {
+	fn dispatch<K: ShiftKernel>(self, amount: u32, kernel: K) -> K::Output {
 		match self {
 			ShiftVariant::Sll => kernel.call(move |word| word << amount),
 			ShiftVariant::Slr => kernel.call(move |word| word >> amount),
@@ -185,6 +227,35 @@ impl ShiftVariant {
 	pub fn apply(self, word: Word, amount: usize) -> Word {
 		// The word-level operators count the amount in 32 bits.
 		self.dispatch(amount as u32, ShiftOneWord { word })
+	}
+
+	/// Applies this shift to each source word and writes the result to the matching output cell.
+	///
+	/// Every output cell is written, so the caller need not initialize them first.
+	/// Cells past the end of either slice are left alone.
+	///
+	/// # Arguments
+	///
+	/// - `out`: the cells to initialize, one per source word.
+	/// - `src`: the words to shift.
+	/// - `amount`: the shift amount in bits, below this variant's upper bound.
+	#[inline]
+	pub fn write_shifted(self, out: &mut [MaybeUninit<Word>], src: &[Word], amount: u32) {
+		self.dispatch(amount, WriteShiftedWords { out, src })
+	}
+
+	/// Applies this shift to each source word and XORs the result into the matching output cell.
+	///
+	/// Cells past the end of either slice are left alone.
+	///
+	/// # Arguments
+	///
+	/// - `out`: the cells to accumulate into, one per source word.
+	/// - `src`: the words to shift.
+	/// - `amount`: the shift amount in bits, below this variant's upper bound.
+	#[inline]
+	pub fn xor_shifted(self, out: &mut [Word], src: &[Word], amount: u32) {
+		self.dispatch(amount, XorShiftedWords { out, src })
 	}
 }
 
@@ -483,6 +554,56 @@ mod tests {
 					prop_assert_eq!(variant.apply(Word(word), amount), expected);
 					let kernel = ShiftOneWord { word: Word(word) };
 					prop_assert_eq!(variant.dispatch(amount as u32, kernel), expected);
+				}
+			}
+		}
+	}
+
+	#[test]
+	fn slice_forms_stop_at_the_shorter_slice() {
+		// Fixture state: 3 source words, 2 output cells, shifting left by 1.
+		//
+		//     src: [1, 2, 4]  ->  [2, 4, 8]
+		//     out: [0, 0]         only two cells to fill, so the third result is dropped
+		let src = [Word(1), Word(2), Word(4)];
+		let mut out = [Word::ZERO; 2];
+		ShiftVariant::Sll.xor_shifted(&mut out, &src, 1);
+		assert_eq!(out, [Word(2), Word(4)]);
+
+		// Fixture state: 2 source words, 3 output cells preset to 1.
+		//
+		//     src: [1, 2]  ->  [2, 4]
+		//     out: [1, 1, 1]   XOR gives [3, 5, _], and the trailing cell keeps its value
+		let mut out = [Word::ONE; 3];
+		ShiftVariant::Sll.xor_shifted(&mut out, &src[..2], 1);
+		assert_eq!(out, [Word(3), Word(5), Word::ONE]);
+	}
+
+	proptest! {
+		// Invariant: the slice forms agree with the single-word form, cell by cell.
+		#[test]
+		fn slice_forms_match_the_single_word_form(src in prop::collection::vec(any::<u64>(), 1..24)) {
+			let src: Vec<Word> = src.into_iter().map(Word).collect();
+			for variant in ShiftVariant::ALL {
+				for amount in 0..variant.max_amount() {
+					let expected: Vec<Word> = src.iter().map(|&w| variant.apply(w, amount)).collect();
+
+					// The write form fills cells that start out uninitialized.
+					let mut out = vec![MaybeUninit::uninit(); src.len()];
+					variant.write_shifted(&mut out, &src, amount as u32);
+					// Safety: the call above wrote every cell, since the slices are the same length.
+					let written: Vec<Word> =
+						out.iter().map(|cell| unsafe { cell.assume_init() }).collect();
+					prop_assert_eq!(&written, &expected);
+
+					// Folding into zeroed cells reduces the XOR to the shift itself.
+					let mut out = vec![Word::ZERO; src.len()];
+					variant.xor_shifted(&mut out, &src, amount as u32);
+					prop_assert_eq!(&out, &expected);
+
+					// Folding the same term a second time cancels it, restoring the zeroes.
+					variant.xor_shifted(&mut out, &src, amount as u32);
+					prop_assert_eq!(out, vec![Word::ZERO; src.len()]);
 				}
 			}
 		}

--- a/crates/frontend/src/compiler/eval_form/const_eval.rs
+++ b/crates/frontend/src/compiler/eval_form/const_eval.rs
@@ -58,16 +58,7 @@ pub fn evaluate_gate_constants(
 			};
 			let variant = ShiftVariant::from_u8(variant as u8)
 				.expect("shift gate carries a valid ShiftVariant discriminant");
-			Ok(vec![match variant {
-				ShiftVariant::Sll => *x << n,
-				ShiftVariant::Slr => *x >> n,
-				ShiftVariant::Sar => x.sar(n),
-				ShiftVariant::Rotr => x.rotr(n),
-				ShiftVariant::Sll32 => x.sll32(n),
-				ShiftVariant::Srl32 => x.srl32(n),
-				ShiftVariant::Sra32 => x.sra32(n),
-				ShiftVariant::Rotr32 => x.rotr32(n),
-			}])
+			Ok(vec![variant.apply(*x, n as usize)])
 		}
 		Opcode::IaddCinCout => {
 			// The carry in is carried in the MSB.

--- a/crates/frontend/src/compiler/eval_form/exec.rs
+++ b/crates/frontend/src/compiler/eval_form/exec.rs
@@ -11,7 +11,10 @@
 //! The single-instance form is then the degenerate case of one instance.
 //! The dispatch loop, the opcode handlers, and the bytecode readers live here once.
 
-use binius_core::{Word, constraint_system::ShiftVariant};
+use binius_core::{
+	Word,
+	constraint_system::{ShiftKernel, ShiftVariant},
+};
 use binius_field::BinaryField128bGhash;
 use smallvec::{SmallVec, smallvec};
 
@@ -50,6 +53,29 @@ pub trait EvalContext {
 	/// The index is local to this context.
 	/// A context that covers a stripe of a larger batch remaps it to a global index.
 	fn note_assertion_failure(&mut self, instance: usize, path_spec: PathSpec, message: String);
+}
+
+/// Applies one resolved shift to a register across every instance of a context.
+struct ShiftEach<'a, C> {
+	/// The instances to read from and write back to.
+	ctx: &'a mut C,
+	/// The register each shifted word is written to.
+	dst: u32,
+	/// The register each source word is read from.
+	src: u32,
+}
+
+impl<C: EvalContext> ShiftKernel for ShiftEach<'_, C> {
+	type Output = ();
+
+	#[inline]
+	fn call(self, shift: impl Fn(Word) -> Word) {
+		let Self { ctx, dst, src } = self;
+		// One instruction covers the whole context, so the same shift runs on every instance.
+		for i in 0..ctx.n_instances() {
+			ctx.store(dst, i, shift(ctx.load(src, i)));
+		}
+	}
 }
 
 /// A bytecode program together with a cursor into it.
@@ -211,28 +237,8 @@ impl<'a> Executor<'a> {
 		let amount = self.read_u8() as u32;
 		// The variant is fixed for this instruction, so dispatch on it once, not per word.
 		//
-		// Each arm is then a branch-free tight loop, the shape Keccak's many rotations need.
-		match variant {
-			ShiftVariant::Sll => Self::shift_each(ctx, dst, src, |w| w << amount),
-			ShiftVariant::Slr => Self::shift_each(ctx, dst, src, |w| w >> amount),
-			ShiftVariant::Sar => Self::shift_each(ctx, dst, src, |w| w.sar(amount)),
-			ShiftVariant::Rotr => Self::shift_each(ctx, dst, src, |w| w.rotr(amount)),
-			ShiftVariant::Sll32 => Self::shift_each(ctx, dst, src, |w| w.sll32(amount)),
-			ShiftVariant::Srl32 => Self::shift_each(ctx, dst, src, |w| w.srl32(amount)),
-			ShiftVariant::Sra32 => Self::shift_each(ctx, dst, src, |w| w.sra32(amount)),
-			ShiftVariant::Rotr32 => Self::shift_each(ctx, dst, src, |w| w.rotr32(amount)),
-		}
-	}
-
-	/// Applies one fixed word-level shift across every instance.
-	///
-	/// The op is a distinct zero-sized closure per call site.
-	/// So the compiler monomorphizes this into a branch-free tight loop with the shift inlined.
-	#[inline]
-	fn shift_each<C: EvalContext>(ctx: &mut C, dst: u32, src: u32, op: impl Fn(Word) -> Word) {
-		for i in 0..ctx.n_instances() {
-			ctx.store(dst, i, op(ctx.load(src, i)));
-		}
+		// The kernel is then a branch-free tight loop, the shape Keccak's many rotations need.
+		variant.dispatch(amount, ShiftEach { ctx, dst, src })
 	}
 
 	// Arithmetic operations

--- a/crates/frontend/src/compiler/eval_form/exec.rs
+++ b/crates/frontend/src/compiler/eval_form/exec.rs
@@ -11,10 +11,7 @@
 //! The single-instance form is then the degenerate case of one instance.
 //! The dispatch loop, the opcode handlers, and the bytecode readers live here once.
 
-use binius_core::{
-	Word,
-	constraint_system::{ShiftKernel, ShiftVariant},
-};
+use binius_core::{Word, constraint_system::ShiftVariant};
 use binius_field::BinaryField128bGhash;
 use smallvec::{SmallVec, smallvec};
 
@@ -53,29 +50,6 @@ pub trait EvalContext {
 	/// The index is local to this context.
 	/// A context that covers a stripe of a larger batch remaps it to a global index.
 	fn note_assertion_failure(&mut self, instance: usize, path_spec: PathSpec, message: String);
-}
-
-/// Applies one resolved shift to a register across every instance of a context.
-struct ShiftEach<'a, C> {
-	/// The instances to read from and write back to.
-	ctx: &'a mut C,
-	/// The register each shifted word is written to.
-	dst: u32,
-	/// The register each source word is read from.
-	src: u32,
-}
-
-impl<C: EvalContext> ShiftKernel for ShiftEach<'_, C> {
-	type Output = ();
-
-	#[inline]
-	fn call(self, shift: impl Fn(Word) -> Word) {
-		let Self { ctx, dst, src } = self;
-		// One instruction covers the whole context, so the same shift runs on every instance.
-		for i in 0..ctx.n_instances() {
-			ctx.store(dst, i, shift(ctx.load(src, i)));
-		}
-	}
 }
 
 /// A bytecode program together with a cursor into it.
@@ -237,8 +211,28 @@ impl<'a> Executor<'a> {
 		let amount = self.read_u8() as u32;
 		// The variant is fixed for this instruction, so dispatch on it once, not per word.
 		//
-		// The kernel is then a branch-free tight loop, the shape Keccak's many rotations need.
-		variant.dispatch(amount, ShiftEach { ctx, dst, src })
+		// Each arm is then a branch-free tight loop, the shape Keccak's many rotations need.
+		match variant {
+			ShiftVariant::Sll => Self::shift_each(ctx, dst, src, |w| w << amount),
+			ShiftVariant::Slr => Self::shift_each(ctx, dst, src, |w| w >> amount),
+			ShiftVariant::Sar => Self::shift_each(ctx, dst, src, |w| w.sar(amount)),
+			ShiftVariant::Rotr => Self::shift_each(ctx, dst, src, |w| w.rotr(amount)),
+			ShiftVariant::Sll32 => Self::shift_each(ctx, dst, src, |w| w.sll32(amount)),
+			ShiftVariant::Srl32 => Self::shift_each(ctx, dst, src, |w| w.srl32(amount)),
+			ShiftVariant::Sra32 => Self::shift_each(ctx, dst, src, |w| w.sra32(amount)),
+			ShiftVariant::Rotr32 => Self::shift_each(ctx, dst, src, |w| w.rotr32(amount)),
+		}
+	}
+
+	/// Applies one fixed word-level shift across every instance.
+	///
+	/// The op is a distinct zero-sized closure per call site.
+	/// So the compiler monomorphizes this into a branch-free tight loop with the shift inlined.
+	#[inline]
+	fn shift_each<C: EvalContext>(ctx: &mut C, dst: u32, src: u32, op: impl Fn(Word) -> Word) {
+		for i in 0..ctx.n_instances() {
+			ctx.store(dst, i, op(ctx.load(src, i)));
+		}
 	}
 
 	// Arithmetic operations

--- a/crates/m4-prover/src/operand_witness.rs
+++ b/crates/m4-prover/src/operand_witness.rs
@@ -18,7 +18,7 @@ use std::{iter, mem::MaybeUninit, ptr};
 use binius_compute::{Allocator, VecLike};
 use binius_core::{
 	ValueIndex,
-	constraint_system::{Operand, ShiftKernel, ShiftedValueIndex},
+	constraint_system::{Operand, ShiftedValueIndex},
 	word::Word,
 };
 use binius_utils::{checked_arithmetics::log2_ceil_usize, rayon::prelude::*};
@@ -176,29 +176,6 @@ pub fn build_operation_witness<'a, A: Allocator>(
 	out
 }
 
-/// Writes one shifted source word into each output cell, initializing it.
-///
-/// This serves the first term of an operand's accumulation.
-/// Each cell is written rather than read, so the caller need not zero the output first.
-struct WriteShiftedWords<'a> {
-	/// The uninitialized output cells, one per instance in this stripe.
-	out: &'a mut [MaybeUninit<Word>],
-	/// The source words to shift, one per instance.
-	src: &'a [Word],
-}
-
-impl ShiftKernel for WriteShiftedWords<'_> {
-	type Output = ();
-
-	#[inline]
-	fn call(self, shift: impl Fn(Word) -> Word) {
-		// Positions line up one to one: instance `i` reads source `i` and writes cell `i`.
-		for (out_i, &src_i) in iter::zip(self.out, self.src) {
-			out_i.write(shift(src_i));
-		}
-	}
-}
-
 /// Writes one shifted value into every element of `out_chunk`, initializing it.
 ///
 /// This is the first term of an operand's accumulation: it initializes the cell rather than
@@ -252,36 +229,7 @@ fn write_shifted_values(
 				)
 			};
 		} else {
-			shift_variant.dispatch(
-				amount,
-				WriteShiftedWords {
-					out: out_chunk,
-					src,
-				},
-			);
-		}
-	}
-}
-
-/// XORs one shifted source word into each output cell.
-///
-/// This serves every term of an operand's accumulation after the first.
-/// The cells already hold the running XOR, so each is read and written back.
-struct XorShiftedWords<'a> {
-	/// The output cells holding the running XOR, one per instance in this stripe.
-	out: &'a mut [Word],
-	/// The source words to shift, one per instance.
-	src: &'a [Word],
-}
-
-impl ShiftKernel for XorShiftedWords<'_> {
-	type Output = ();
-
-	#[inline]
-	fn call(self, shift: impl Fn(Word) -> Word) {
-		// Positions line up one to one: instance `i` reads source `i` and folds into cell `i`.
-		for (out_i, &src_i) in iter::zip(self.out, self.src) {
-			*out_i = *out_i ^ shift(src_i);
+			shift_variant.write_shifted(out_chunk, src, amount);
 		}
 	}
 }
@@ -331,13 +279,7 @@ fn accum_shifted_values(
 				*out_i = *out_i ^ src_i;
 			}
 		} else {
-			shift_variant.dispatch(
-				amount,
-				XorShiftedWords {
-					out: out_chunk,
-					src,
-				},
-			);
+			shift_variant.xor_shifted(out_chunk, src, amount);
 		}
 	}
 }

--- a/crates/m4-prover/src/operand_witness.rs
+++ b/crates/m4-prover/src/operand_witness.rs
@@ -18,7 +18,7 @@ use std::{iter, mem::MaybeUninit, ptr};
 use binius_compute::{Allocator, VecLike};
 use binius_core::{
 	ValueIndex,
-	constraint_system::{Operand, ShiftVariant, ShiftedValueIndex},
+	constraint_system::{Operand, ShiftKernel, ShiftedValueIndex},
 	word::Word,
 };
 use binius_utils::{checked_arithmetics::log2_ceil_usize, rayon::prelude::*};
@@ -176,19 +176,26 @@ pub fn build_operation_witness<'a, A: Allocator>(
 	out
 }
 
-/// Writes `shift(src[i])` into `out_chunk[i]` for every `i`, initializing each cell.
+/// Writes one shifted source word into each output cell, initializing it.
 ///
-/// `shift` is a concrete per-variant closure bound once by the caller's match on
-/// [`ShiftVariant`], so each call site monomorphizes to a loop with the shift operation inlined,
-/// rather than branching on the variant every iteration.
-#[inline]
-fn write_shifted_words(
-	out_chunk: &mut [MaybeUninit<Word>],
-	src: &[Word],
-	shift: impl Fn(Word) -> Word,
-) {
-	for (out_i, &src_i) in iter::zip(out_chunk, src) {
-		out_i.write(shift(src_i));
+/// This serves the first term of an operand's accumulation.
+/// Each cell is written rather than read, so the caller need not zero the output first.
+struct WriteShiftedWords<'a> {
+	/// The uninitialized output cells, one per instance in this stripe.
+	out: &'a mut [MaybeUninit<Word>],
+	/// The source words to shift, one per instance.
+	src: &'a [Word],
+}
+
+impl ShiftKernel for WriteShiftedWords<'_> {
+	type Output = ();
+
+	#[inline]
+	fn call(self, shift: impl Fn(Word) -> Word) {
+		// Positions line up one to one: instance `i` reads source `i` and writes cell `i`.
+		for (out_i, &src_i) in iter::zip(self.out, self.src) {
+			out_i.write(shift(src_i));
+		}
 	}
 }
 
@@ -231,6 +238,8 @@ fn write_shifted_values(
 		let index = value_index.0 as usize - witness_offset.0 as usize;
 		let src = &table_words[(index << log_instances)..((index + 1) << log_instances)];
 
+		// Invariant: shifting by zero returns the word untouched, whichever variant is named.
+		// So one copy covers every variant, and the shifting path below never sees a zero amount.
 		if amount == 0 {
 			// Safety:
 			// * out_chunk.len() == src.len()
@@ -243,29 +252,37 @@ fn write_shifted_values(
 				)
 			};
 		} else {
-			match shift_variant {
-				ShiftVariant::Sll => write_shifted_words(out_chunk, src, |w| w << amount),
-				ShiftVariant::Slr => write_shifted_words(out_chunk, src, |w| w >> amount),
-				ShiftVariant::Sar => write_shifted_words(out_chunk, src, |w| w.sar(amount)),
-				ShiftVariant::Rotr => write_shifted_words(out_chunk, src, |w| w.rotr(amount)),
-				ShiftVariant::Sll32 => write_shifted_words(out_chunk, src, |w| w.sll32(amount)),
-				ShiftVariant::Srl32 => write_shifted_words(out_chunk, src, |w| w.srl32(amount)),
-				ShiftVariant::Sra32 => write_shifted_words(out_chunk, src, |w| w.sra32(amount)),
-				ShiftVariant::Rotr32 => write_shifted_words(out_chunk, src, |w| w.rotr32(amount)),
-			}
+			shift_variant.dispatch(
+				amount,
+				WriteShiftedWords {
+					out: out_chunk,
+					src,
+				},
+			);
 		}
 	}
 }
 
-/// XORs `shift(src[i])` into `out_chunk[i]` for every `i`.
+/// XORs one shifted source word into each output cell.
 ///
-/// `shift` is a concrete per-variant closure bound once by the caller's match on
-/// [`ShiftVariant`], so each call site monomorphizes to a loop with the shift operation inlined,
-/// rather than branching on the variant every iteration.
-#[inline]
-fn xor_shifted_words(out_chunk: &mut [Word], src: &[Word], shift: impl Fn(Word) -> Word) {
-	for (out_i, &src_i) in iter::zip(out_chunk, src) {
-		*out_i = *out_i ^ shift(src_i);
+/// This serves every term of an operand's accumulation after the first.
+/// The cells already hold the running XOR, so each is read and written back.
+struct XorShiftedWords<'a> {
+	/// The output cells holding the running XOR, one per instance in this stripe.
+	out: &'a mut [Word],
+	/// The source words to shift, one per instance.
+	src: &'a [Word],
+}
+
+impl ShiftKernel for XorShiftedWords<'_> {
+	type Output = ();
+
+	#[inline]
+	fn call(self, shift: impl Fn(Word) -> Word) {
+		// Positions line up one to one: instance `i` reads source `i` and folds into cell `i`.
+		for (out_i, &src_i) in iter::zip(self.out, self.src) {
+			*out_i = *out_i ^ shift(src_i);
+		}
 	}
 }
 
@@ -307,21 +324,20 @@ fn accum_shifted_values(
 		let index = value_index.0 as usize - witness_offset.0 as usize;
 		let src = &table_words[(index << log_instances)..((index + 1) << log_instances)];
 
+		// Invariant: shifting by zero returns the word untouched, whichever variant is named.
+		// So one plain XOR covers every variant, and the path below never sees a zero amount.
 		if amount == 0 {
 			for (out_i, &src_i) in iter::zip(&mut *out_chunk, src) {
 				*out_i = *out_i ^ src_i;
 			}
 		} else {
-			match shift_variant {
-				ShiftVariant::Sll => xor_shifted_words(out_chunk, src, |w| w << amount),
-				ShiftVariant::Slr => xor_shifted_words(out_chunk, src, |w| w >> amount),
-				ShiftVariant::Sar => xor_shifted_words(out_chunk, src, |w| w.sar(amount)),
-				ShiftVariant::Rotr => xor_shifted_words(out_chunk, src, |w| w.rotr(amount)),
-				ShiftVariant::Sll32 => xor_shifted_words(out_chunk, src, |w| w.sll32(amount)),
-				ShiftVariant::Srl32 => xor_shifted_words(out_chunk, src, |w| w.srl32(amount)),
-				ShiftVariant::Sra32 => xor_shifted_words(out_chunk, src, |w| w.sra32(amount)),
-				ShiftVariant::Rotr32 => xor_shifted_words(out_chunk, src, |w| w.rotr32(amount)),
-			}
+			shift_variant.dispatch(
+				amount,
+				XorShiftedWords {
+					out: out_chunk,
+					src,
+				},
+			);
 		}
 	}
 }
@@ -330,7 +346,7 @@ fn accum_shifted_values(
 mod tests {
 	use assert_matches::assert_matches;
 	use binius_compute::{BufferPool, GlobalAllocator};
-	use binius_core::constraint_system::{AndConstraint, ValueVec};
+	use binius_core::constraint_system::{AndConstraint, ShiftVariant, ValueVec};
 	use binius_field::{AESTowerField8b as B8, PackedBinaryGhash1x128b};
 	use binius_frontend::{Circuit, CircuitBuilder, Wire};
 	use binius_ip::channel::Error as ChannelError;
@@ -757,6 +773,64 @@ mod tests {
 		}
 	}
 
+	// One drawn shift term: which of the circuit's four wires to read, and how to shift it.
+	// The amount stays in `1..max_amount`, so every draw really shifts and stays in range.
+	fn any_shift_term() -> impl Strategy<Value = (usize, ShiftVariant, u8)> {
+		(0usize..4, prop::sample::select(ShiftVariant::ALL.to_vec())).prop_flat_map(
+			|(wire, shift_variant)| {
+				(1..shift_variant.max_amount())
+					.prop_map(move |amount| (wire, shift_variant, amount as u8))
+			},
+		)
+	}
+
+	proptest! {
+		// Invariant: every batch row equals the single-instance reference, for all eight shifts.
+		//
+		// The compiler emits only unshifted operands, so the fixed fixtures reach three shifts.
+		// Drawing the shift covers the other five: rotate, and the four half-word forms.
+		//
+		// Fixture state: 4 instances, 1 constraint.
+		//
+		//     operand A: 1..4 drawn terms  → always initializes its column
+		//     operand B: 0..4 drawn terms  → may be empty, pinning that column at zero
+		#[test]
+		fn shifted_operands_match_the_reference_for_every_variant(
+			inputs in prop::collection::vec((any::<u64>(), any::<u64>(), any::<u64>()), 4),
+			a_terms in prop::collection::vec(any_shift_term(), 1..4),
+			b_terms in prop::collection::vec(any_shift_term(), 0..4),
+		) {
+			let c = and_circuit();
+			let table = populate_table(&c, &inputs);
+
+			// A drawn wire slot in 0..4 names one of the circuit's four witness words.
+			let wires = [c.x, c.y, c.w, c.z].map(|wire| c.circuit.witness_index(wire));
+			// An operand is the XOR of its terms, so a term list becomes one operand directly.
+			let to_operand = |terms: &[(usize, ShiftVariant, u8)]| -> Operand {
+				terms
+					.iter()
+					.map(|&(wire, shift_variant, amount)| ShiftedValueIndex {
+						value_index: wires[wire],
+						shift_variant,
+						amount,
+					})
+					.collect()
+			};
+
+			// The third operand is never evaluated by the builder, so it stays empty.
+			// The fixture therefore need not satisfy the AND relation to exercise the shifts.
+			let and_constraints =
+				vec![AndConstraint([to_operand(&a_terms), to_operand(&b_terms), Operand::new()])];
+
+			let [a, b] = build_operation_columns(&table, constants(&c), &and_constraints, &GlobalAllocator);
+
+			// Both columns match the shift-aware value-vec evaluator on the same constraints.
+			let (a_ref, b_ref) = reference_columns(&table, constants(&c), &and_constraints);
+			prop_assert_eq!(&*a, &a_ref[..]);
+			prop_assert_eq!(&*b, &b_ref[..]);
+		}
+	}
+
 	proptest! {
 		// Invariant: every batch row equals the single-instance reference for that instance.
 		//
@@ -839,10 +913,7 @@ mod tests {
 		let shifted = and_constraints
 			.iter()
 			.flat_map(|con| [con.a(), con.b()])
-			.any(|op| {
-				op.iter()
-					.any(|sv| sv.shift_variant != ShiftVariant::Sll || sv.amount != 0)
-			});
+			.any(|op| op.iter().any(|sv| sv.amount != 0));
 		assert!(shifted, "fixture must contain a shifted operand");
 
 		let [a, b] =


### PR DESCRIPTION
Puts the mapping from a shift variant to its word-level operation in one place, without giving up the codegen the hot paths depend on.

Pure refactor — no behavior change, and no measurable perf change.

### The problem

A shift variant names an operation (`Sll`, `Rotr`, `Sra32`, …) but nothing carried that operation.

So four places wrote their own eight-arm match over the variant:

- `crates/core/.../shift.rs` — the scalar entry point
- `crates/frontend/.../const_eval.rs` — an exact duplicate of it
- `crates/frontend/.../exec.rs` — the bytecode interpreter
- `crates/m4-prover/src/operand_witness.rs` — twice, once per accumulation path

The compiler forces exhaustiveness, so nothing goes silently unhandled. But a wrong arm — an `Sra32` branch calling `srl32` — compiles fine and folds circuits wrong.

### Why those matches could not just call the scalar entry point

Three of the four sit *outside* a per-word loop on purpose.

Deciding the variant once, ahead of the loop, lets each arm inline its shift into a branch-free body. Calling the scalar entry point inside the loop puts a branch back on every word.

That is not a micro-effect. Making the slice operations below branch per word instead:

| `assemble_operation_witness/bitand_keccak_f1600` | time |
|---|---|
| variant decided once, ahead of the loop | 28.4 ms |
| variant decided per word | 124.9 ms |

→ **4.4x slower**, so the hoist is load-bearing. Dispatching through a function pointer is worse again: it trades the branch for an indirect call per word, which also blocks inlining the shift.

### The idea

Give the variant the operations directly, over the shapes callers actually have.

```
// scalar, unchanged
variant.apply(word, amount)

// over word slices
variant.write_shifted(out, src, amount)   // initializes each cell
variant.xor_shifted(out, src, amount)     // folds into a running XOR
```

Internally all three route through one match, via a private callback trait. The variant resolves itself to a closure once and hands it to a callback that is generic over that closure, so each variant still gets its own specialized copy. A closure cannot be generic over its own argument type, which is why that is a trait rather than a second closure parameter.

The trait and its three kernels are private. Callers only ever see the three methods.

### The change

```
- match shift_variant {
-     ShiftVariant::Sll => write_shifted_words(out_chunk, src, |w| w << amount),
-     ShiftVariant::Slr => write_shifted_words(out_chunk, src, |w| w >> amount),
-     ...  // 6 more arms
- }
+ shift_variant.write_shifted(out_chunk, src, amount);
```

`operand_witness.rs` loses both matches and both loop helpers, and ends up with no shift knowledge at all. The constant folder's match was a plain duplicate of the scalar entry point and now calls it.

### Scope

- **new:** two slice methods on the variant, plus the variant list as a constant
- **changed:** three call sites across two crates
- **left untouched:** the bytecode interpreter keeps its own match — it walks a context trait one instance at a time rather than a slice, so it is a genuinely different shape, and folding it in bought nothing
- **left untouched:** the symbolic expression builder and the protocol index mapping map variants to something other than a word operation, so they are unrelated matches, not duplicates
- the scalar entry point keeps its signature, so external callers are unaffected

### Tests

A shift amount of 0 is the identity for every variant, which is what lets the witness builder serve all eight with one copy instead of dispatching. That invariant crossed crates uncommented and untested; it now has both.

Two gaps closed, each verified by mutation rather than assumed:

- Every variant is pinned against a reference written over raw integers, independent of the word methods the implementation names. Wiring the `Sra32` arm to `srl32` fails it.
- The witness builder's shifted-operand fixture used only `Sll`, `Slr`, and `Sar`, so five of eight arms were never exercised there. A proptest now draws the variant and amount. Making the accumulate path overwrite rather than XOR **passes** the old fixture and **fails** the new one.

The slice methods are also pinned against the scalar one, including that XOR-ing a term twice cancels, and that a length mismatch stops at the shorter slice.

### Verification

- `cargo check --workspace --all-targets`, `cargo clippy --workspace --all-targets` — clean
- `cargo +nightly fmt --all` — clean
- `cargo test -p binius-core -p binius-frontend -p binius-m4-prover` — 309 pass
- `cargo test -p binius-prover -p binius-verifier --lib` — 40 pass

### Benchmark

The loops moved into another crate, so inlining now has to work across that boundary. Both hot functions compile to the same instruction count as `main`, so they do:

| release asm | `write_shifted_values` | `accum_shifted_values` |
|---|---|---|
| main | 164 insns | 186 insns |
| this branch | 164 insns | 186 insns |

`assemble_operation_witness/bitand_keccak_f1600` is the only bench that can move — the interpreter is byte-identical to `main` and the constant folder runs at compile time:

| tree | time | criterion |
|---|---|---|
| main | 28.516 ms | — |
| this branch | 28.794 ms | p = 0.07, no change detected |

Repeated runs of a single unchanged build drift by ±0.5% on this machine and criterion flags that as significant, so the residual here is noise, not the change. Identical codegen cannot be slower.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
