### PR TITLE
BINIUS-393: exempt single-term linear definitions from the gate-fusion depth cap

### DIFF
--- a/crates/examples/snapshots/bitcoin_headers.snap
+++ b/crates/examples/snapshots/bitcoin_headers.snap
@@ -5,28 +5,28 @@ Gates & Instructions
 └─ Number of evaluation instructions: 47,238
 
 Constraints
-├─ ZERO constraints: 4,694 used (57.3% of 2^13)
-│  [▓▓▓▓▓░░░░░] spare: 3,498
+├─ ZERO constraints: 4,614 used (56.3% of 2^13)
+│  [▓▓▓▓▓░░░░░] spare: 3,578
 ├─ AND constraints: 15,344 used (93.7% of 2^14)
 │  [▓▓▓▓▓▓▓▓▓░] spare: 1,040
 ├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
 ├─ BMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-└─ Distinct value indices: 47,383
+└─ Distinct value indices: 47,303
    ├─ Distinct shifted value indices: 27,142
-   └─ Distinct unshifted value indices: 20,241
+   └─ Distinct unshifted value indices: 20,161
 
 Value Vector
 ├─ Public Section: 156 used (60.9% of 2^8)
 │  [▓▓▓▓▓▓░░░░] spare: 100
 │  ├─ Constants: 156
 │  └─ Inout: 0
-├─ Private Section: 20,092 used (61.8%)
-│  [▓▓▓▓▓▓░░░░] spare: 12,420
+├─ Private Section: 20,012 used (61.6%)
+│  [▓▓▓▓▓▓░░░░] spare: 12,500
 │  ├─ Witness: 104
-│  └─ Internal: 19,988
-├─ Total Committed: 20,248 used (61.8% of 2^15)
-│  [▓▓▓▓▓▓░░░░] spare: 12,520
-└─ Scratch (uncommitted): 39,200 (peak live: 53)
+│  └─ Internal: 19,908
+├─ Total Committed: 20,168 used (61.5% of 2^15)
+│  [▓▓▓▓▓▓░░░░] spare: 12,600
+└─ Scratch (uncommitted): 39,280 (peak live: 53)
 

--- a/crates/examples/snapshots/bitcoin_p2pkh.snap
+++ b/crates/examples/snapshots/bitcoin_p2pkh.snap
@@ -5,28 +5,28 @@ Gates & Instructions
 └─ Number of evaluation instructions: 176,783
 
 Constraints
-├─ ZERO constraints: 1,918 used (93.7% of 2^11)
-│  [▓▓▓▓▓▓▓▓▓░] spare: 130
+├─ ZERO constraints: 1,914 used (93.5% of 2^11)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 134
 ├─ AND constraints: 111,567 used (85.1% of 2^17)
 │  [▓▓▓▓▓▓▓▓░░] spare: 19,505
 ├─ IMUL constraints: 15,186 used (92.7% of 2^14)
 │  [▓▓▓▓▓▓▓▓▓░] spare: 1,198
 ├─ BMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-└─ Distinct value indices: 267,510
+└─ Distinct value indices: 267,506
    ├─ Distinct shifted value indices: 131,631
-   └─ Distinct unshifted value indices: 135,879
+   └─ Distinct unshifted value indices: 135,875
 
 Value Vector
 ├─ Public Section: 134 used (52.3% of 2^8)
 │  [▓▓▓▓▓░░░░░] spare: 122
 │  ├─ Constants: 134
 │  └─ Inout: 0
-├─ Private Section: 135,756 used (51.8%)
-│  [▓▓▓▓▓░░░░░] spare: 126,132
+├─ Private Section: 135,752 used (51.8%)
+│  [▓▓▓▓▓░░░░░] spare: 126,136
 │  ├─ Witness: 9
-│  └─ Internal: 135,747
-├─ Total Committed: 135,890 used (51.8% of 2^18)
-│  [▓▓▓▓▓░░░░░] spare: 126,254
-└─ Scratch (uncommitted): 108,456 (peak live: 109)
+│  └─ Internal: 135,743
+├─ Total Committed: 135,886 used (51.8% of 2^18)
+│  [▓▓▓▓▓░░░░░] spare: 126,258
+└─ Scratch (uncommitted): 108,460 (peak live: 109)
 

--- a/crates/examples/snapshots/blake2b.snap
+++ b/crates/examples/snapshots/blake2b.snap
@@ -5,28 +5,28 @@ Gates & Instructions
 └─ Number of evaluation instructions: 10,824
 
 Constraints
-├─ ZERO constraints: 3,544 used (86.5% of 2^12)
-│  [▓▓▓▓▓▓▓▓░░] spare: 552
+├─ ZERO constraints: 3,088 used (75.4% of 2^12)
+│  [▓▓▓▓▓▓▓░░░] spare: 1,008
 ├─ AND constraints: 4,616 used (56.3% of 2^13)
 │  [▓▓▓▓▓░░░░░] spare: 3,576
 ├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
 ├─ BMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-└─ Distinct value indices: 21,662
-   ├─ Distinct shifted value indices: 13,362
-   └─ Distinct unshifted value indices: 8,300
+└─ Distinct value indices: 19,333
+   ├─ Distinct shifted value indices: 11,486
+   └─ Distinct unshifted value indices: 7,847
 
 Value Vector
 ├─ Public Section: 28 used (87.5% of 2^5)
 │  [▓▓▓▓▓▓▓▓░░] spare: 4
 │  ├─ Constants: 28
 │  └─ Inout: 0
-├─ Private Section: 8,288 used (50.7%)
-│  [▓▓▓▓▓░░░░░] spare: 8,064
+├─ Private Section: 7,832 used (96.0%)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 328
 │  ├─ Witness: 136
-│  └─ Internal: 8,152
-├─ Total Committed: 8,316 used (50.8% of 2^14)
-│  [▓▓▓▓▓░░░░░] spare: 8,068
-└─ Scratch (uncommitted): 7,272 (peak live: 25)
+│  └─ Internal: 7,696
+├─ Total Committed: 7,860 used (95.9% of 2^13)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 332
+└─ Scratch (uncommitted): 7,728 (peak live: 21)
 

--- a/crates/examples/snapshots/blake2s.snap
+++ b/crates/examples/snapshots/blake2s.snap
@@ -5,28 +5,28 @@ Gates & Instructions
 └─ Number of evaluation instructions: 18,568
 
 Constraints
-├─ ZERO constraints: 5,968 used (72.9% of 2^13)
-│  [▓▓▓▓▓▓▓░░░] spare: 2,224
+├─ ZERO constraints: 5,292 used (64.6% of 2^13)
+│  [▓▓▓▓▓▓░░░░] spare: 2,900
 ├─ AND constraints: 7,688 used (93.8% of 2^13)
 │  [▓▓▓▓▓▓▓▓▓░] spare: 504
 ├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
 ├─ BMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-└─ Distinct value indices: 35,845
-   ├─ Distinct shifted value indices: 22,172
-   └─ Distinct unshifted value indices: 13,673
+└─ Distinct value indices: 32,509
+   ├─ Distinct shifted value indices: 19,510
+   └─ Distinct unshifted value indices: 12,999
 
 Value Vector
 ├─ Public Section: 45 used (70.3% of 2^6)
 │  [▓▓▓▓▓▓▓░░░] spare: 19
 │  ├─ Constants: 45
 │  └─ Inout: 0
-├─ Private Section: 13,784 used (84.5%)
-│  [▓▓▓▓▓▓▓▓░░] spare: 2,536
+├─ Private Section: 13,108 used (80.3%)
+│  [▓▓▓▓▓▓▓▓░░] spare: 3,212
 │  ├─ Witness: 136
-│  └─ Internal: 13,648
-├─ Total Committed: 13,829 used (84.4% of 2^14)
-│  [▓▓▓▓▓▓▓▓░░] spare: 2,555
-└─ Scratch (uncommitted): 12,592 (peak live: 34)
+│  └─ Internal: 12,972
+├─ Total Committed: 13,153 used (80.3% of 2^14)
+│  [▓▓▓▓▓▓▓▓░░] spare: 3,231
+└─ Scratch (uncommitted): 13,268 (peak live: 37)
 

--- a/crates/examples/snapshots/blake3.snap
+++ b/crates/examples/snapshots/blake3.snap
@@ -5,28 +5,28 @@ Gates & Instructions
 └─ Number of evaluation instructions: 7,256
 
 Constraints
-├─ ZERO constraints: 2,381 used (58.1% of 2^12)
-│  [▓▓▓▓▓░░░░░] spare: 1,715
+├─ ZERO constraints: 1,997 used (97.5% of 2^11)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 51
 ├─ AND constraints: 2,760 used (67.4% of 2^12)
 │  [▓▓▓▓▓▓░░░░] spare: 1,336
 ├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
 ├─ BMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-└─ Distinct value indices: 14,008
-   ├─ Distinct shifted value indices: 8,862
-   └─ Distinct unshifted value indices: 5,146
+└─ Distinct value indices: 12,379
+   ├─ Distinct shifted value indices: 7,617
+   └─ Distinct unshifted value indices: 4,762
 
 Value Vector
 ├─ Public Section: 281 used (54.9% of 2^9)
 │  [▓▓▓▓▓░░░░░] spare: 231
 │  ├─ Constants: 17
 │  └─ Inout: 264
-├─ Private Section: 5,133 used (66.8%)
-│  [▓▓▓▓▓▓░░░░] spare: 2,547
+├─ Private Section: 4,749 used (61.8%)
+│  [▓▓▓▓▓▓░░░░] spare: 2,931
 │  ├─ Witness: 0
-│  └─ Internal: 5,133
-├─ Total Committed: 5,414 used (66.1% of 2^13)
-│  [▓▓▓▓▓▓░░░░] spare: 2,778
-└─ Scratch (uncommitted): 4,795 (peak live: 34)
+│  └─ Internal: 4,749
+├─ Total Committed: 5,030 used (61.4% of 2^13)
+│  [▓▓▓▓▓▓░░░░] spare: 3,162
+└─ Scratch (uncommitted): 5,179 (peak live: 42)
 

--- a/crates/examples/snapshots/hashsign.snap
+++ b/crates/examples/snapshots/hashsign.snap
@@ -5,28 +5,28 @@ Gates & Instructions
 └─ Number of evaluation instructions: 413,730
 
 Constraints
-├─ ZERO constraints: 130,443 used (99.5% of 2^17)
-│  [▓▓▓▓▓▓▓▓▓░] spare: 629
+├─ ZERO constraints: 110,514 used (84.3% of 2^17)
+│  [▓▓▓▓▓▓▓▓░░] spare: 20,558
 ├─ AND constraints: 145,508 used (55.5% of 2^18)
 │  [▓▓▓▓▓░░░░░] spare: 116,636
 ├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
 ├─ BMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-└─ Distinct value indices: 729,782
-   ├─ Distinct shifted value indices: 454,807
-   └─ Distinct unshifted value indices: 274,975
+└─ Distinct value indices: 647,258
+   ├─ Distinct shifted value indices: 392,212
+   └─ Distinct unshifted value indices: 255,046
 
 Value Vector
 ├─ Public Section: 184 used (71.9% of 2^8)
 │  [▓▓▓▓▓▓▓░░░] spare: 72
 │  ├─ Constants: 158
 │  └─ Inout: 26
-├─ Private Section: 274,878 used (52.5%)
-│  [▓▓▓▓▓░░░░░] spare: 249,154
+├─ Private Section: 254,949 used (97.4%)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 6,939
 │  ├─ Witness: 1,776
-│  └─ Internal: 273,102
-├─ Total Committed: 275,062 used (52.5% of 2^19)
-│  [▓▓▓▓▓░░░░░] spare: 249,226
-└─ Scratch (uncommitted): 288,465 (peak live: 593)
+│  └─ Internal: 253,173
+├─ Total Committed: 255,133 used (97.3% of 2^18)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 7,011
+└─ Scratch (uncommitted): 308,394 (peak live: 595)
 

--- a/crates/examples/snapshots/sha256.snap
+++ b/crates/examples/snapshots/sha256.snap
@@ -5,28 +5,28 @@ Gates & Instructions
 └─ Number of evaluation instructions: 20,312
 
 Constraints
-├─ ZERO constraints: 2,041 used (99.7% of 2^11)
-│  [▓▓▓▓▓▓▓▓▓░] spare: 7
+├─ ZERO constraints: 2,005 used (97.9% of 2^11)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 43
 ├─ AND constraints: 6,575 used (80.3% of 2^13)
 │  [▓▓▓▓▓▓▓▓░░] spare: 1,617
 ├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
 ├─ BMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-└─ Distinct value indices: 21,097
+└─ Distinct value indices: 21,061
    ├─ Distinct shifted value indices: 12,350
-   └─ Distinct unshifted value indices: 8,747
+   └─ Distinct unshifted value indices: 8,711
 
 Value Vector
 ├─ Public Section: 404 used (78.9% of 2^9)
 │  [▓▓▓▓▓▓▓░░░] spare: 108
 │  ├─ Constants: 140
 │  └─ Inout: 264
-├─ Private Section: 8,608 used (54.2%)
-│  [▓▓▓▓▓░░░░░] spare: 7,264
+├─ Private Section: 8,572 used (54.0%)
+│  [▓▓▓▓▓░░░░░] spare: 7,300
 │  ├─ Witness: 0
-│  └─ Internal: 8,608
-├─ Total Committed: 9,012 used (55.0% of 2^14)
-│  [▓▓▓▓▓░░░░░] spare: 7,372
-└─ Scratch (uncommitted): 17,088 (peak live: 22)
+│  └─ Internal: 8,572
+├─ Total Committed: 8,976 used (54.8% of 2^14)
+│  [▓▓▓▓▓░░░░░] spare: 7,408
+└─ Scratch (uncommitted): 17,124 (peak live: 22)
 

--- a/crates/examples/snapshots/sha512.snap
+++ b/crates/examples/snapshots/sha512.snap
@@ -5,28 +5,28 @@ Gates & Instructions
 └─ Number of evaluation instructions: 24,839
 
 Constraints
-├─ ZERO constraints: 2,041 used (99.7% of 2^11)
-│  [▓▓▓▓▓▓▓▓▓░] spare: 7
+├─ ZERO constraints: 2,007 used (98.0% of 2^11)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 41
 ├─ AND constraints: 8,270 used (50.5% of 2^14)
 │  [▓▓▓▓▓░░░░░] spare: 8,114
 ├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
 ├─ BMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-└─ Distinct value indices: 25,089
+└─ Distinct value indices: 25,055
    ├─ Distinct shifted value indices: 14,555
-   └─ Distinct unshifted value indices: 10,534
+   └─ Distinct unshifted value indices: 10,500
 
 Value Vector
 ├─ Public Section: 237 used (92.6% of 2^8)
 │  [▓▓▓▓▓▓▓▓▓░] spare: 19
 │  ├─ Constants: 101
 │  └─ Inout: 136
-├─ Private Section: 10,303 used (63.9%)
-│  [▓▓▓▓▓▓░░░░] spare: 5,825
+├─ Private Section: 10,269 used (63.7%)
+│  [▓▓▓▓▓▓░░░░] spare: 5,859
 │  ├─ Witness: 0
-│  └─ Internal: 10,303
-├─ Total Committed: 10,540 used (64.3% of 2^14)
-│  [▓▓▓▓▓▓░░░░] spare: 5,844
-└─ Scratch (uncommitted): 21,368 (peak live: 13)
+│  └─ Internal: 10,269
+├─ Total Committed: 10,506 used (64.1% of 2^14)
+│  [▓▓▓▓▓▓░░░░] spare: 5,878
+└─ Scratch (uncommitted): 21,402 (peak live: 13)
 

--- a/crates/examples/snapshots/zklogin.snap
+++ b/crates/examples/snapshots/zklogin.snap
@@ -5,28 +5,28 @@ Gates & Instructions
 └─ Number of evaluation instructions: 459,115
 
 Constraints
-├─ ZERO constraints: 23,445 used (71.5% of 2^15)
-│  [▓▓▓▓▓▓▓░░░] spare: 9,323
+├─ ZERO constraints: 22,862 used (69.8% of 2^15)
+│  [▓▓▓▓▓▓░░░░] spare: 9,906
 ├─ AND constraints: 235,124 used (89.7% of 2^18)
 │  [▓▓▓▓▓▓▓▓░░] spare: 27,020
 ├─ IMUL constraints: 8,262 used (50.4% of 2^14)
 │  [▓▓▓▓▓░░░░░] spare: 8,122
 ├─ BMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-└─ Distinct value indices: 545,530
+└─ Distinct value indices: 544,947
    ├─ Distinct shifted value indices: 284,342
-   └─ Distinct unshifted value indices: 261,188
+   └─ Distinct unshifted value indices: 260,605
 
 Value Vector
 ├─ Public Section: 1,031 used (50.3% of 2^11)
 │  [▓▓▓▓▓░░░░░] spare: 1,017
 │  ├─ Constants: 729
 │  └─ Inout: 302
-├─ Private Section: 260,167 used (49.8%)
-│  [▓▓▓▓░░░░░░] spare: 262,073
+├─ Private Section: 259,584 used (99.8%)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 512
 │  ├─ Witness: 1,381
-│  └─ Internal: 258,786
-├─ Total Committed: 261,198 used (49.8% of 2^19)
-│  [▓▓▓▓░░░░░░] spare: 263,090
-└─ Scratch (uncommitted): 319,862 (peak live: 1,542)
+│  └─ Internal: 258,203
+├─ Total Committed: 260,615 used (99.4% of 2^18)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 1,529
+└─ Scratch (uncommitted): 320,445 (peak live: 1,542)
 

--- a/crates/frontend/src/compiler/gate_fusion/commit_set.rs
+++ b/crates/frontend/src/compiler/gate_fusion/commit_set.rs
@@ -7,20 +7,38 @@ use petgraph::{
 use super::{LeGraph, Stat};
 use crate::compiler::constraint_builder::{Shift, ShiftKind};
 
+/// Longest inline chain a definition of two or more terms may sit at the top of.
+///
+/// Inlining substitutes a definition's whole cone into every consumer.
+/// Chaining that without a bound multiplies operand sizes.
+/// Past this depth a definition is committed instead, which truncates the cone.
+///
+/// A definition of a single term is exempt, since it substitutes one term for one term.
+///
+/// # Why this value
+///
+/// The bound is empirical, not derived.
+/// It trades committed words against operand size, and both costs are prover-side.
 pub const MAX_DEPTH: usize = 6;
 
-/// Which shift kinds appeared on a path, and the largest distance any of them used.
+/// Which shift kinds appeared on a path, and how far the path shifts in total.
 ///
 /// One question is asked of a path, once per graph edge.
 /// Can a further shift compose with every shift already on it?
 ///
-/// Two shifts compose only when one is the identity, or when both share a kind.
-/// So only two facts about the path decide the answer:
+/// Inlining collapses a whole path into a single shift.
+/// So a further shift meets that collapsed shift, never the individual links.
+/// Two shifts compose only under two conditions.
 ///
-/// - which kinds are present, since a second kind already rules out composing;
-/// - the largest distance among them, since that is what pushes a sum past the width.
+/// - One of them is the identity, which composes with anything.
+/// - Both share a kind, and their distances together stay inside the word width.
 ///
-/// Both fit in an integer, so the context is [`Copy`] and allocates nothing.
+/// So only two facts about the path decide the answer.
+///
+/// - Which kinds are present, since a second kind already rules out composing.
+/// - The distance the path accumulates, since that is what a further distance adds to.
+///
+/// Both fit in an integer, so the summary is [`Copy`] and allocates nothing.
 #[derive(Copy, Clone, Default)]
 struct ShiftSummary {
 	/// One bit per shift kind seen, excluding the identity.
@@ -28,10 +46,10 @@ struct ShiftSummary {
 	/// A kind's bit is its discriminant.
 	/// There are eight kinds, so a byte holds them all.
 	kinds: u8,
-	/// Largest distance among the kinds seen.
+	/// Total distance covered by the farthest-shifting path this summary spans.
 	///
 	/// Zero when only the identity was seen, which imposes no distance.
-	max_amount: u32,
+	total_amount: u32,
 }
 
 impl ShiftSummary {
@@ -41,22 +59,31 @@ impl ShiftSummary {
 	}
 
 	/// The summary of this path extended by one more shift.
-	fn with(self, shift: Shift) -> Self {
+	const fn with(self, shift: Shift) -> Self {
 		match shift.kind_and_amount() {
 			// The identity composes with anything, so it constrains nothing.
 			None => self,
+			// Composing two shifts of one kind adds their distances.
+			// So walking a path accumulates the distances of its links:
+			//     sll(3) then sll(5) then sll(4)  ->  sll(12)
+			// Saturating keeps an absurdly long chain from wrapping back to a small total.
 			Some((kind, amount)) => Self {
 				kinds: self.kinds | bit_of(kind),
-				max_amount: self.max_amount.max(amount),
+				total_amount: self.total_amount.saturating_add(amount),
 			},
 		}
 	}
 
 	/// The summary covering every path in `summaries`.
 	fn union(summaries: impl Iterator<Item = Self>) -> Self {
+		// A further shift has to compose with every path at once.
+		// So the path that shifts farthest is the one that binds:
+		//     path A accumulates sll(10)
+		//     path B accumulates sll(50)   <- binding
+		//     -> a further sll(13) fits A but leaves the width on B, so it is rejected
 		summaries.fold(Self::default(), |acc, s| Self {
 			kinds: acc.kinds | s.kinds,
-			max_amount: acc.max_amount.max(s.max_amount),
+			total_amount: acc.total_amount.max(s.total_amount),
 		})
 	}
 
@@ -77,9 +104,10 @@ impl ShiftSummary {
 			return false;
 		}
 
-		// A cyclic kind loses nothing, so distances always compose.
-		// Otherwise the largest distance seen plus this one has to stay inside the width.
-		kind.is_cyclic() || self.max_amount + amount < kind.width()
+		// A cyclic kind loses no bits, so its distances wrap and always compose.
+		// Any other kind drops the bits it shifts out.
+		// So the distance the path already covers plus this one has to stay inside the width.
+		kind.is_cyclic() || self.total_amount.saturating_add(amount) < kind.width()
 	}
 }
 
@@ -128,7 +156,7 @@ impl CommitSetCx {
 	}
 
 	/// Create a new context by adding a new shift and incrementing depth.
-	fn add(&self, out_shift: Shift) -> CommitSetCx {
+	const fn add(&self, out_shift: Shift) -> CommitSetCx {
 		Self {
 			shifts: self.shifts.with(out_shift),
 			depth: self.depth + 1,
@@ -146,6 +174,11 @@ impl CommitSetCx {
 ///
 /// 2. Inlining is prone to term explosion. To prevent that we avoid inlining expressions that lie
 ///    past a certain depth.
+///
+/// A definition of a single term is exempt from the second case.
+/// Substituting it swaps one term for one term, so it cannot make any operand grow.
+/// Depth is still counted through such a definition.
+/// So a definition of two or more terms further up still reaches the cap and commits there.
 ///
 /// Note that this is all-or-nothing decision: if at least one user cannot inline an expression
 /// then no users should inline it.
@@ -222,7 +255,19 @@ pub fn run_decide_commit_set(leg: &mut LeGraph, stat: &mut Stat) {
 				}
 			}
 
-			if depth > MAX_DEPTH || !composable {
+			// One incoming edge is one term on the right-hand side.
+			// Substituting such a definition rewrites a consumer's term in place:
+			//
+			//     definition:  y = sll(x, 4)
+			//     consumer:    ... ^ sll(y, 3) ^ ...
+			//     substituted: ... ^ sll(x, 7) ^ ...
+			//
+			// The operand keeps its size, so no operand can grow out of a chain of these.
+			// The depth cap guards against operands growing, so it has nothing to guard here.
+			let single_term = incoming.clone().count() == 1;
+			let too_deep = depth > MAX_DEPTH && !single_term;
+
+			if too_deep || !composable {
 				// Decision: commit.
 				//
 				// Every incoming edge context is going to be a brand new one seeded with the
@@ -236,7 +281,7 @@ pub fn run_decide_commit_set(leg: &mut LeGraph, stat: &mut Stat) {
 				assert!(leg.lin_committed.insert(lin_def_wire));
 
 				stat.note_committed();
-				if depth > MAX_DEPTH {
+				if too_deep {
 					stat.note_committed_linear_depth();
 				}
 			} else {
@@ -269,11 +314,35 @@ mod tests {
 
 	use super::*;
 
-	/// The predicate the summary replaces, evaluated over the shifts themselves.
+	/// The single shift a chain collapses to, or nothing when it does not collapse.
 	///
-	/// Kept as the reference the summary is checked against.
-	fn composable_reference(path: &[Shift], shift: Shift) -> bool {
-		path.iter().all(|s| Shift::compose(*s, shift).is_some())
+	/// This is what inlining a whole path leaves behind:
+	/// ```text
+	///     [sll(3), sll(5), sll(4)]  ->  sll(12)
+	///     [sll(3), srl(5)]          ->  nothing, two kinds never merge
+	///     [sll(40), sll(30)]        ->  nothing, 70 leaves the 64-bit width
+	/// ```
+	fn collapse(chain: &[Shift]) -> Option<Shift> {
+		// Composing shifts of one kind adds their distances, and addition commutes.
+		// So folding left over the chain gives the same answer as any other order.
+		chain
+			.iter()
+			.try_fold(Shift::None, |acc, s| Shift::compose(acc, *s))
+	}
+
+	/// Whether one more shift composes with a chain once that chain has collapsed.
+	///
+	/// This is the predicate the summary stands in for.
+	/// It is the reference the summary is checked against.
+	fn composable_reference(chain: &[Shift], shift: Shift) -> bool {
+		collapse(chain).is_some_and(|collapsed| Shift::compose(collapsed, shift).is_some())
+	}
+
+	/// The summary of one chain, accumulated link by link the way the pass accumulates it.
+	fn summary_of(chain: &[Shift]) -> ShiftSummary {
+		chain
+			.iter()
+			.fold(ShiftSummary::default(), |summary, shift| summary.with(*shift))
 	}
 
 	/// Every shift kind, at a distance inside its own width.
@@ -291,51 +360,95 @@ mod tests {
 		]
 	}
 
+	/// The eight shift constructors, in discriminant order.
+	const KINDS: [fn(u32) -> Shift; 8] = [
+		Shift::Sll,
+		Shift::Sll32,
+		Shift::Srl,
+		Shift::Srl32,
+		Shift::Sar,
+		Shift::Sra32,
+		Shift::Rotr,
+		Shift::Rotr32,
+	];
+
+	/// A chain of one kind, mixed with identity links, as an inlined path carries.
+	///
+	/// A chain of two kinds never collapses, so it is out of scope here.
+	///
+	/// Distances run up to 8 over up to 11 links, which puts the total between 0 and 88.
+	/// That straddles both widths, 32 and 64, instead of blowing past them every time.
+	/// So the collapsing and the non-collapsing side of the boundary are both reachable.
+	fn same_kind_chain() -> impl Strategy<Value = Vec<Shift>> {
+		(0usize..KINDS.len(), prop::collection::vec(prop::option::of(0u32..9), 1..12)).prop_map(
+			|(kind, amounts)| {
+				// An absent distance stands for an identity link.
+				// Identity links are legal anywhere and must not sway the answer.
+				amounts
+					.into_iter()
+					.map(|amount| amount.map_or(Shift::None, KINDS[kind]))
+					.collect()
+			},
+		)
+	}
+
 	proptest! {
 		#[test]
-		fn summary_answers_as_the_shift_list_does(
-			path in prop::collection::vec(any_shift(), 1..12),
+		fn summary_answers_as_the_collapsed_chain_does(
+			chain in same_kind_chain(),
 			query in any_shift(),
 		) {
-			// Invariant: the summary decides composability exactly as walking the shifts would.
-			let summary = ShiftSummary::union(path.iter().copied().map(ShiftSummary::of));
-			prop_assert_eq!(summary.composable(query), composable_reference(&path, query));
-		}
+			// Only chains that collapse are in scope.
+			// The pass commits the rest rather than inlining them, so no summary is ever built.
+			prop_assume!(collapse(&chain).is_some());
 
-		#[test]
-		fn extending_a_path_matches_appending_to_the_list(
-			path in prop::collection::vec(any_shift(), 1..12),
-			extra in any_shift(),
-			query in any_shift(),
-		) {
-			// Invariant: extending a summary is the same as appending to the list it stands for.
-			let summary = ShiftSummary::union(path.iter().copied().map(ShiftSummary::of));
-
-			let mut extended_path = path;
-			extended_path.push(extra);
-
+			// Invariant: the summary answers exactly as the collapsed chain answers.
+			//
+			//     chain:   [sll(3), sll(5), sll(4)]   summary: kind sll, total 12
+			//     collapse:              sll(12)
+			//     query sll(51) -> 12 + 51 = 63, inside 64  -> both say yes
+			//     query sll(52) -> 12 + 52 = 64, at the width -> both say no
 			prop_assert_eq!(
-				summary.with(extra).composable(query),
-				composable_reference(&extended_path, query)
+				summary_of(&chain).composable(query),
+				composable_reference(&chain, query)
 			);
 		}
 
 		#[test]
-		fn joining_paths_matches_concatenating_the_lists(
-			left in prop::collection::vec(any_shift(), 1..8),
-			right in prop::collection::vec(any_shift(), 1..8),
+		fn extending_a_chain_matches_appending_a_link(
+			chain in same_kind_chain(),
 			query in any_shift(),
 		) {
-			// Invariant: joining two summaries is the same as concatenating the two lists.
-			let left_summary = ShiftSummary::union(left.iter().copied().map(ShiftSummary::of));
-			let right_summary = ShiftSummary::union(right.iter().copied().map(ShiftSummary::of));
-			let joined = ShiftSummary::union([left_summary, right_summary].into_iter());
+			prop_assume!(collapse(&chain).is_some());
 
-			let concatenated: Vec<Shift> = left.iter().chain(&right).copied().collect();
+			// Split the last link off, so the head is a shorter chain and the link is new to it.
+			let (extra, head) = chain.split_last().expect("the chain has at least one link");
 
+			// Invariant: extending a summary by one link answers as the longer chain does.
+			// This is the step the pass takes at every graph edge it walks.
+			prop_assert_eq!(
+				summary_of(head).with(*extra).composable(query),
+				composable_reference(&chain, query)
+			);
+		}
+
+		#[test]
+		fn joining_chains_answers_for_both(
+			left in same_kind_chain(),
+			right in same_kind_chain(),
+			query in any_shift(),
+		) {
+			prop_assume!(collapse(&left).is_some());
+			prop_assume!(collapse(&right).is_some());
+
+			// A definition with two consumers reaches its roots by two paths.
+			// Its summary spans both, since inlining it has to satisfy both at once.
+			let joined = ShiftSummary::union([summary_of(&left), summary_of(&right)].into_iter());
+
+			// Invariant: a shift joins the spanning summary only when it composes with each path.
 			prop_assert_eq!(
 				joined.composable(query),
-				composable_reference(&concatenated, query)
+				composable_reference(&left, query) && composable_reference(&right, query)
 			);
 		}
 	}

--- a/crates/frontend/src/compiler/gate_fusion/tests/awhole.rs
+++ b/crates/frontend/src/compiler/gate_fusion/tests/awhole.rs
@@ -899,3 +899,62 @@ fn test_depth_limit_with_shifts() {
 	AND[0]: (v[12]≪7 ⊕ v[5]≪7 ⊕ v[6] ⊕ v[7] ⊕ v[8] ⊕ v[9] ⊕ v[10]) ∧ (v[11]) = (v[13])
 	");
 }
+
+#[test]
+fn test_chained_shifts_beyond_the_word_width_compile() {
+	let b = mk_circuit_builder();
+
+	// Fusion may only inline a run of shifts when the run has a single-shift form.
+	// Four left shifts of 20 sum to 80, which a 64-bit word has no single-shift form for.
+	// So this run must be broken by a commit, and the circuit must still compile.
+	//
+	// Fixture state: 4 chained left shifts of 20, at depth 3, inside the cap of 6.
+	// So depth decides nothing here.
+	// The width alone forces the break.
+	let x = b.add_witness();
+	let mut v = x;
+	for _ in 0..4 {
+		v = b.shl(v, 20);
+	}
+	let y = b.add_witness();
+	let _out = b.band(v, y);
+
+	let cs = compile(&b);
+
+	// The break lands on the topmost link, which is committed as v[4].
+	// The three links below it merge into the single shift of 60 in the AND operand.
+	insta::assert_snapshot!(stringify_constraint_system(&cs), @r"
+	ZERO[0]: (v[2]≪20 ⊕ v[4]) = 0
+	AND[0]: (v[4]≪60) ∧ (v[3]) = (v[5])
+	");
+}
+
+#[test]
+fn test_chained_shifts_beyond_the_word_width_evaluate() {
+	// Breaking the run must preserve what the circuit computes, not just let it compile.
+	// A 64-bit word shifted left by 80 keeps none of its bits, so the run evaluates to zero.
+	// Masking with all ones then leaves zero, which pins the whole run to a known value.
+	let b = CircuitBuilder::new();
+	let x = b.add_witness();
+	let mut v = x;
+	for _ in 0..4 {
+		v = b.shl(v, 20);
+	}
+	let y = b.add_witness();
+	let out = b.band(v, y);
+
+	// Pin the result so dead-code elimination keeps the run alive.
+	b.force_commit(out);
+	let circuit = b.build();
+
+	// Feed a word with bits set across all four bytes, so a dropped shift would show up.
+	let mut w = circuit.new_witness_filler();
+	w[x] = Word(0xDEAD_BEEF_CAFE_BABE);
+	w[y] = Word(u64::MAX);
+	circuit.populate_wire_witness(&mut w).unwrap();
+
+	assert_eq!(w[out], Word::ZERO);
+
+	// The committed break carries its own Zero constraint, so check the constraints agree too.
+	verify_constraints(circuit.constraint_system(), &w.value_vec).unwrap();
+}

--- a/crates/frontend/src/compiler/gate_fusion/tests/commit_set.rs
+++ b/crates/frontend/src/compiler/gate_fusion/tests/commit_set.rs
@@ -2,7 +2,11 @@
 use crate::compiler::{
 	Wire,
 	constraint_builder::{ConstraintBuilder, expr},
-	gate_fusion::{Stat, commit_set, legraph::LeGraph},
+	gate_fusion::{
+		Stat,
+		commit_set::{self, MAX_DEPTH},
+		legraph::LeGraph,
+	},
 };
 
 /// Test helper to create a Wire with a given ID
@@ -707,6 +711,88 @@ fn test_rotr_with_unshifted_xor_terms() {
 }
 
 #[test]
+fn test_single_term_chain_past_the_depth_cap_stays_inlined() {
+	// A definition of one term substitutes one term for one term into each consumer.
+	// So a run of them cannot grow any operand, however long the run gets.
+	// The depth cap exists to stop operands growing, so it must not fire on such a run.
+	//
+	// Fixture state: 9 chained rotations, against a cap of 6.
+	//
+	//   w(0) ──rotr─> w(1) ──rotr─> ... ──rotr─> w(9) ──> AND
+	//   depth:            8              7  ...      0
+	//
+	// Wires w(1) and w(2) sit at depth 8 and 7, both past the cap, yet neither may commit.
+	let n = MAX_DEPTH as u32 + 3;
+
+	test_commit_set(
+		|cb| {
+			for i in 0..n {
+				cb.linear(expr::rotr(w(i), 1), w(i + 1));
+			}
+			cb.and(w(n), w(n + 1), w(n + 2));
+		},
+		// Nothing is committed: every rotation composes and none of them can grow an operand.
+		&[],
+		&(1..=n).map(w).collect::<Vec<_>>(),
+	);
+}
+
+#[test]
+fn test_depth_still_counts_through_exempt_definitions() {
+	// Exempting a definition from the cap must not reset how deep its producers sit.
+	// Otherwise a run of one-term definitions would hide an arbitrarily deep cone above it.
+	//
+	// Fixture state: one two-term definition, then 8 chained rotations, against a cap of 6.
+	//
+	//   w(0) ─┐
+	//         ├─> w(2) ──rotr─> w(3) ──rotr─> ... ──rotr─> w(10) ──> AND
+	//   w(1) ─┘
+	//   depth:      8              7             ...          0
+	//
+	// The rotations are exempt at depth 7 and below, but each one still adds a level.
+	// So the two-term definition lands at depth 8 and commits there.
+	let n = MAX_DEPTH as u32 + 2;
+
+	test_commit_set(
+		|cb| {
+			cb.linear(expr::xor2(w(0), w(1)), w(2));
+			for i in 2..n + 2 {
+				cb.linear(expr::rotr(w(i), 1), w(i + 1));
+			}
+			cb.and(w(n + 2), w(n + 3), w(n + 4));
+		},
+		&[w(2)],
+		&(3..=n + 2).map(w).collect::<Vec<_>>(),
+	);
+}
+
+#[test]
+fn test_exempt_definition_with_a_non_composing_shift_is_still_committed() {
+	// The depth exemption reasons about operand size only.
+	// It never licenses an inline that the shifts themselves forbid.
+	//
+	// Fixture state: a rotation at the top of a run of 8 left shifts, all one-term.
+	//
+	//   w(0) ──rotr─> w(1) ──sll─> w(2) ──sll─> ... ──sll─> w(9) ──> AND
+	//
+	// A rotation and a left shift are different kinds, so they never merge into one shift.
+	// Inlining w(1) would ask for exactly that merge, so w(1) has to be committed.
+	let n = MAX_DEPTH as u32 + 3;
+
+	test_commit_set(
+		|cb| {
+			cb.linear(expr::rotr(w(0), 1), w(1));
+			for i in 1..n {
+				cb.linear(expr::sll(w(i), 1), w(i + 1));
+			}
+			cb.and(w(n), w(n + 1), w(n + 2));
+		},
+		&[w(1)],
+		&(2..=n).map(w).collect::<Vec<_>>(),
+	);
+}
+
+#[test]
 fn test_rotr_with_mixed_shift_xor() {
 	// Test: y = a ^ (b << 5), z = rotr(y, 10)
 	// When we try to inline with rotr(10), the Sll(5) is incompatible
@@ -724,4 +810,60 @@ fn test_rotr_with_mixed_shift_xor() {
 		&[w(6)],       // b_shifted must be committed (can't compose Rotr with Sll)
 		&[w(2), w(3)], // y and z can still be inlined
 	);
+}
+
+#[test]
+fn test_chained_shifts_commit_before_the_accumulated_distance_leaves_the_width() {
+	// Inlining a run of same-kind shifts merges them into one shift of the summed distance.
+	// A left shift drops the bits it pushes out.
+	// So a summed distance of 64 or more has no single-shift form at all.
+	// Whether a run may be inlined therefore turns on the sum of its distances.
+	// It does not turn on any one pair of neighbours, which is why no pair here objects.
+	//
+	// Fixture state: 4 chained left shifts of 20, at depth 3, well inside the cap of 6.
+	//
+	//   w(0) ──sll20─> w(1) ──sll20─> w(2) ──sll20─> w(3) ──sll20─> w(4) ──> AND
+	//   running sum:        80             60             40             20
+	test_commit_set(
+		|cb| {
+			cb.linear(expr::sll(w(0), 20), w(1));
+			cb.linear(expr::sll(w(1), 20), w(2));
+			cb.linear(expr::sll(w(2), 20), w(3));
+			cb.linear(expr::sll(w(3), 20), w(4));
+			cb.and(w(4), w(5), w(6));
+		},
+		&[w(1)],             // reaching w(0) needs a shift of 80, past the 64-bit width
+		&[w(2), w(3), w(4)], // a shift of 60 still has a single-shift form
+	);
+}
+
+#[test]
+fn test_a_long_single_term_shift_run_commits_as_often_as_the_width_requires() {
+	// The cap exempts one-term definitions, so the width is all that can break a run of them.
+	// A run this long must therefore be broken exactly as often as the width demands.
+	//
+	// Fixture state: 65 chained left shifts of 1, every one of them exempt from the cap.
+	//
+	//   w(0) ──sll1─> w(1) ──sll1─> ... ──sll1─> w(65) ──> AND
+	//
+	// An inlined stretch may sum to at most 63, so it may span at most 63 links.
+	// Walking up from the AND, links w(65) down to w(3) fill that budget exactly.
+	// Reaching w(2) would make 64, so w(2) commits and the count restarts above it.
+	let n = 65;
+
+	let mut cb = ConstraintBuilder::new();
+	for i in 0..n {
+		cb.linear(expr::sll(w(i), 1), w(i + 1));
+	}
+	cb.and(w(n), w(n + 1), w(n + 2));
+
+	let mut stat = Stat::default();
+	let mut leg = LeGraph::new(&cb);
+	commit_set::run_decide_commit_set(&mut leg, &mut stat);
+
+	// One break covers all 65 links, and it lands on the one the width forces.
+	let committed: Vec<u32> = (1..=n)
+		.filter(|&i| leg.commit_set().contains(w(i)))
+		.collect();
+	assert_eq!(committed, vec![2]);
 }


### PR DESCRIPTION
Closes [BINIUS-393](https://linear.app/jimpo/issue/BINIUS-393).

Stops gate fusion from committing a linear definition that could never have caused the problem the depth cap guards against.
No AND constraint moves; the win is fewer Zero constraints and fewer committed words.

Ships with one correctness fix that the first change makes load-bearing — see **The second change** below.

### The problem

Gate fusion commits a linear definition for one of two reasons.

1. Its shifts do not compose with a consumer's, so it cannot be inlined at all.
2. Its inline chain runs past `MAX_DEPTH` (currently 6).

Reason 2 exists because inlining substitutes a definition's **whole cone** into every consumer.
Chain that without a bound and operand sizes multiply.

But a definition with a **single incoming edge** is one shifted term.
Substituting it rewrites a consumer's term in place:

```
definition:   y = sll(x, 4)
consumer:     ... ^ sll(y, 3) ^ ...
substituted:  ... ^ sll(x, 7) ^ ...
```

One term in, one term out.
It cannot grow anybody's operand, so committing it on depth grounds spends a Zero constraint and a committed word to prevent an explosion that cannot happen.

### Where it bites

`blake3_compress_2x` is the clearest case.
Every `iadd_32` defines `z = x ^ y ^ (cout <<32 1)`, so a left shift rides in every sum's cone.
A left shift never composes with a rotation, which forces one commit per rotation site — a structural floor of 232 Zero constraints per compression.

At the shipped cap the circuit instead has 288.
Instrumenting the pass shows the whole 56-constraint gap is pure `rotr32` definitions — one term each — committed at depth 7 against a cap of 6.

### The change

```
- if depth > MAX_DEPTH || !composable {
+ let single_term = incoming.clone().count() == 1;
+ let too_deep = depth > MAX_DEPTH && !single_term;
+
+ if too_deep || !composable {
```

- The composability check stays unconditional — the exemption is about operand size, never about legality.
- Depth still counts **through** an exempt definition, so a definition of two or more terms further up still reaches the cap and commits there.

Tuning the cap globally is not the fix.
The pass is parity-sensitive: a cap of 5 helps `blake3` and `blake2s` but costs `sha256` far more.

### The second change: the shift summary tracked the wrong quantity

The composability check reads a summary of the shifts already on a path.
It recorded the **largest** distance on that path where it needed the **accumulated** distance.

Composing shifts of one kind adds their distances, so the max under-reports:

```
path:  sll(20) then sll(20) then sll(20)
max:   20      -> " a further sll(20) fits, 20 + 20 = 40 < 64"
sum:   60      -> " a further sll(20) gives 80, which has no single-shift form"
```

This aborts the compiler on `main` today, from the public builder, with four gates:

```rust
let b = CircuitBuilder::new();
let x = b.add_witness();
let mut v = x;
for _ in 0..4 { v = b.shl(v, 20); }   // merged distance 80
let y = b.add_witness();
b.force_commit(b.band(v, y));
b.build();   // panics: Incompatible shifts during inlining: Sll(20) followed by Sll(60)
```

Exempting single-term definitions from the cap does not create this hole, but it widens it a lot.
Runs of one-term shifts are no longer truncated by depth, so `sll(1)` chained 70 deep now trips the same panic where it previously committed 8 times and stayed safe.
So the two changes ship together.

The summary now accumulates along a path and takes the worst case across paths.
Measured on every circuit below, the fix on its own is byte-identical to `main` — it costs nothing.

### Soundness

- Both changes only move the line between *commit* and *inline*; neither changes what a constraint asserts.
- Committing more is always sound: a committed definition keeps its own Zero constraint.
- Inlining more is sound exactly when the shifts compose, which is the check both changes leave in force.
- The accumulated-distance fix is strictly more conservative than what it replaces, so it can only commit more, never less.

### Scope

- **changed:** the commit decision and the shift summary, both in `commit_set.rs`.
- **untouched:** the patch/inline pass, the graph construction, and every other fusion decision.
- **re-blessed:** all 13 circuit stat snapshots; 9 moved, 4 are identical.

### Verification

- `cargo check --workspace --all-targets` — clean.
- `cargo clippy -p binius-frontend -p binius-circuits --all-targets` — clean.
- `cargo +nightly fmt --all` — clean.
- `cargo test -p binius-frontend` — 194 pass; `cargo test -p binius-circuits --lib` — 332 pass.
- 5 new tests, each confirmed to fail without the change it covers:
  - a one-term chain past the cap stays inlined;
  - depth still counts through exempt definitions;
  - an exempt definition whose shift does not compose is still committed;
  - a run of chained shifts commits before the merged distance leaves the width, at the decision level and end-to-end with a witness and `verify_constraints`.
- The three shift-summary proptests were rewritten against the collapsed-chain semantics, which is what the pass actually needs.

### Benchmark

Real circuits, from the committed stat snapshots.
AND, IMUL and BMUL counts are unchanged in every case.

| circuit | ZERO | ZERO padded | committed words | committed padded | distinct value indices |
|---|---|---|---|---|---|
| `hashsign` | 130,443 → **110,514** | `2^17` | 275,062 → **255,133** | `2^19` → **`2^18`** | 729,782 → **647,258** |
| `zklogin` | 23,445 → **22,862** | `2^15` | 261,198 → **260,615** | `2^19` → **`2^18`** | 545,530 → **544,947** |
| `blake2b` | 3,544 → **3,088** | `2^12` | 8,316 → **7,860** | `2^14` → **`2^13`** | 21,662 → **19,333** |
| `blake3` | 2,381 → **1,997** | `2^12` → **`2^11`** | 5,414 → **5,030** | `2^13` | 14,008 → **12,379** |
| `blake2s` | 5,968 → **5,292** | `2^13` | 13,829 → **13,153** | `2^14` | 35,845 → **32,509** |
| `sha512` | 2,041 → **2,007** | `2^11` | 10,540 → **10,506** | `2^14` | 25,089 → **25,055** |
| `sha256` | 2,041 → **2,005** | `2^11` | 9,012 → **8,976** | `2^14` | 21,097 → **21,061** |
| `bitcoin_headers` | 4,694 → **4,614** | `2^13` | 20,248 → **20,168** | `2^15` | 47,383 → **47,303** |
| `bitcoin_p2pkh` | 1,918 → **1,914** | `2^11` | 135,890 → **135,886** | `2^18` | 267,510 → **267,506** |

`ethsign`, `keccak`, `ec_msm` and `blake3_compress` are unchanged.

The headline is `hashsign` and `zklogin` crossing under `2^18` committed words, which halves the polynomial the prover commits to.
That is a threshold effect, so it is sensitive to circuit size rather than a guaranteed 2x — but the underlying 13-15% cut in Zero constraints and distinct value indices holds regardless.

### The cost

Raw term count is the one regression, on the two circuits that gain most elsewhere.

| circuit | ZERO | total terms |
|---|---|---|
| `blake3_compress_2x` x8 | 2,032 → **1,812** | 39,512 → 40,800 (+3.3%) |
| `blake2s` x8 | 2,944 → **2,588** | 56,988 → 58,860 (+3.3%) |

The arithmetic is direct.
Committing a definition with `c` consumers costs its cone once plus one term per consumer; inlining it costs the cone `c` times.
So dropping a commit trades terms for a Zero constraint and a committed word.
Max operand size is unchanged on every circuit measured, which confirms nothing is actually exploding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)