### PR TITLE
Remove three unused items from the sumcheck prover module

### DIFF
--- a/crates/ip-prover/src/sumcheck/frac_add_mle.rs
+++ b/crates/ip-prover/src/sumcheck/frac_add_mle.rs
@@ -2,15 +2,11 @@
 
 use binius_compute::Allocator;
 use binius_field::{Field, PackedField};
-use binius_math::FieldBuffer;
 
 use crate::sumcheck::{
 	mle_store::ColId, quadratic_mle_evaluator::QuadraticMleEvaluator,
 	round_evaluator::MleCheckRoundEvaluator,
 };
-
-/// The numerator and denominator buffers of one fractional-addition layer.
-pub type FractionalBuffer<P> = (FieldBuffer<P>, FieldBuffer<P>);
 
 /// Creates the round evaluators for the fractional-addition claims required in logUp*.
 ///

--- a/crates/ip-prover/src/sumcheck/gruen32.rs
+++ b/crates/ip-prover/src/sumcheck/gruen32.rs
@@ -94,10 +94,6 @@ impl<F: Field, P: PackedField<Scalar = F>> Gruen32<P> {
 		&self.suffix_eq_expansion
 	}
 
-	pub const fn n_vars_remaining(&self) -> usize {
-		self.n_vars_remaining
-	}
-
 	// An interpolation routine for degree-2 round polynomials. Takes P'(x) evals and sum claim on
 	// P(x).
 	pub fn interpolate2(

--- a/crates/ip-prover/src/sumcheck/mle_store.rs
+++ b/crates/ip-prover/src/sumcheck/mle_store.rs
@@ -205,18 +205,6 @@ impl<'a, A: Allocator, F: Field, P: PackedField<Scalar = F>> MleStore<'a, A, P> 
 			.collect()
 	}
 
-	/// Returns the full evaluation point of a registered eq tracker.
-	///
-	/// The point spans all of the store's original variables — it is not truncated as the store
-	/// folds, so the remaining (unbound) coordinates are the prefix `eq_point(id)[..n_vars()]`. An
-	/// evaluator registers its point once (via [`Self::register_eq_tracker`]) and reads it back
-	/// here from the returned [`EqId`], rather than owning a second copy. Most evaluators only need
-	/// the current round's coordinate ([`Self::eq_alpha`]) and equality prefix
-	/// ([`Self::eq_prefix`]) and can avoid handling the point directly.
-	pub fn eq_point(&self, id: EqId) -> &[F] {
-		self.eq_trackers[id.0].eval_point()
-	}
-
 	/// Returns the highest remaining coordinate of a registered eq tracker.
 	///
 	/// This is the coordinate of the variable bound in the current round — the round's `alpha`. The


### PR DESCRIPTION
Deletes three items in `crates/ip-prover/src/sumcheck` that nothing calls. Pure cleanup — no behavior change.

### The problem

Three public items have no callers anywhere in the workspace:

| item | site |
|---|---|
| `FractionalBuffer<P>` | `frac_add_mle.rs:13` |
| `MleStore::eq_point` | `mle_store.rs:216` |
| `Gruen32::n_vars_remaining` | `gruen32.rs:97` |

`MleStore::eq_point` is the one worth calling out, because its doc argues for its own necessity:

> An evaluator registers its point once (via `Self::register_eq_tracker`) and reads it back here from the returned `EqId`, rather than owning a second copy.

No evaluator does that. Every evaluator reads `eq_alpha` and `eq_prefix` instead — both of which stay. So the doc describes an intended usage pattern that never materialized, which is the kind of thing that misleads the next reader of the file.

### The change

```diff
- pub type FractionalBuffer<P> = (FieldBuffer<P>, FieldBuffer<P>);
- pub fn eq_point(&self, id: EqId) -> &[F] { ... }
- pub const fn n_vars_remaining(&self) -> usize { ... }
```

Dropping `FractionalBuffer` leaves `frac_add_mle.rs` with no use for `binius_math::FieldBuffer`, so that import goes with it.

### Scope

- **removed:** the three items above, plus one now-unused import
- **untouched:** `Gruen32::eval_point` (still used by `MleStore::register_eq_tracker` for tracker dedup), and `MleStore::eq_alpha` / `eq_prefix` (read by `MleToSumCheckEvaluator`)
- 20 lines deleted, 0 added, across 3 files

Note `frac_add_mle.rs` keeps a similarly-named but distinct live type in `fracaddcheck.rs` — `PooledFractionalBuffer` — which is not affected.

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-ip-prover --all-targets --all-features` — clean
- `cargo check -p binius-prover -p binius-m4-prover -p binius-iop-prover -p binius-spartan-prover --all-targets` — clean
- `cargo test -p binius-ip-prover --all-features` — 58 passed, 0 failed
- `RUSTDOCFLAGS="-D warnings" cargo doc -p binius-ip-prover --no-deps` — clean, no dangling intra-doc links
- `cargo +nightly fmt --all --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)