### PR TITLE
Check the set_len invariant in the fracaddcheck layer build

### DIFF
--- a/crates/ip-prover/src/fracaddcheck.rs
+++ b/crates/ip-prover/src/fracaddcheck.rs
@@ -130,10 +130,28 @@ where
 					num_out.write(num_0 * den_1 + num_1 * den_0);
 					den_out.write(den_0 * den_1);
 				});
-			// Safety: the length claims below cover only slots this loop initialized.
-			// - A parallel zip yields as many items as its shortest input holds.
-			// - The sibling halves each hold exactly one word per claimed slot.
-			// - Each item initializes one numerator slot and one denominator slot.
+			// Invariant: every zip input holds at least `out_len` words.
+			//
+			// A parallel zip yields as many items as its shortest input holds.
+			// A shorter input would leave trailing slots uninitialized.
+			//
+			//     spare capacity:  >= out_len   allocated for at least that many
+			//     sibling halves:  == out_len   halves of two equal-length buffers
+			debug_assert!(
+				num_data.spare_capacity_mut().len() >= out_len
+					&& den_data.spare_capacity_mut().len() >= out_len,
+				"allocated buffers must hold every claimed slot"
+			);
+			debug_assert!(
+				[den_0.as_ref(), num_1.as_ref(), den_1.as_ref()]
+					.iter()
+					.all(|half| half.len() == out_len),
+				"the four sibling halves must hold exactly one word per claimed slot"
+			);
+			// Safety: both length claims cover only initialized slots.
+			// - The assertions above bound every zip input below by `out_len`.
+			// - So the loop ran `out_len` items.
+			// - Each item wrote one numerator slot and one denominator slot.
 			unsafe {
 				num_data.set_len(out_len);
 				den_data.set_len(out_len);


### PR DESCRIPTION
Turns the safety argument behind an `unsafe set_len` into a checked invariant.
Pure hardening — no behavior change, and release builds are byte-identical.

### The problem

Building one fractional-addition layer writes both output buffers through a parallel zip over six inputs, then claims their length:

```
(num_spare, den_spare, num_0, den_0, num_1, den_1)
    .into_par_iter()
    .for_each(|(num_out, den_out, ..)| { num_out.write(..); den_out.write(..); });

unsafe { num_data.set_len(out_len); den_data.set_len(out_len); }
```

A parallel zip yields as many items as its **shortest** input holds.
So if any one of the six were shorter than `out_len`, the loop would stop early and `set_len(out_len)` would publish uninitialized memory.

The invariant does hold. But it held as prose in a comment, at a site where being wrong is undefined behaviour:

- `Allocator::alloc` promises room for *at least* `capacity`, so both spare slices are `>= out_len`.
- The four halves are `out_len` long because the numerator and denominator buffers have equal length — asserted once for the witness, then preserved by construction at every layer.

That last step is a whole-loop induction the reader has to reconstruct.

### The change

Assert the six lengths immediately before the `unsafe`, and let the safety comment lean on the assert instead of on the induction:

```
+ debug_assert!(num_spare.len() >= out_len && den_spare.len() >= out_len, ..);
+ debug_assert!([den_0, num_1, den_1].iter().all(|h| h.len() == out_len), ..);
  unsafe { num_data.set_len(out_len); den_data.set_len(out_len); }
```

`num_0` is not asserted: `out_len` is *defined* as its length, so the check would be a tautology.

### Scope

- One file, one function: the layer loop in `FracAddCheckProver::new`.
- Both checks are `debug_assert`, so release codegen is unchanged.
- No public API, no transcript, no protocol change.

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-ip-prover --all-targets`, and again with `--features rayon` — no warnings
- nightly `cargo fmt --all` — clean
- `cargo test -p binius-ip-prover --features rayon --lib` — 58 passed
- `cargo +nightly miri test -p binius-ip-prover --lib fracaddcheck` — 8 passed, under both Stacked Borrows and `-Zmiri-tree-borrows`

Note on the release test run: `cargo test --release` reports one failure, `logup_star::prove::tests::test_out_of_range_index_panics`.
That is pre-existing on `main` and unrelated to this change — it asserts a panic raised by a `debug_assert`, which release compiles out.
Verified identical on an untouched `main` checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)