### PR TITLE
Borrow the pushforward halves in the logUp* final layer

### DIFF
--- a/crates/ip-prover/src/logup_star/final_layer.rs
+++ b/crates/ip-prover/src/logup_star/final_layer.rs
@@ -120,7 +120,14 @@ where
 	// Y_0, Y_1 are already store columns (the fractional numerator halves), so only the table
 	// halves T_0, T_1 are pushed as new columns. Only Y_0 is needed here, to form e_0; e_1 follows
 	// as e - e_0.
-	let [y_0, _y_1] = split_halves(alloc, pushforward);
+	//
+	// Neither pushforward half needs to be owned:
+	//
+	//     Y_0 -> read once, by the inner product with T_0
+	//     Y_1 -> never read
+	//
+	// Borrowing them keeps 2^m field elements out of the allocator.
+	let (y_0, _y_1) = pushforward.split_half_ref();
 	let [t_0, t_1] = split_halves(alloc, table.to_ref());
 
 	// e_0 is the first half's product sum.


### PR DESCRIPTION
Removes a copy of the pushforward that nothing reads.
Pure cleanup — no behavior change, no transcript change.

### The problem

The batched final layer splits the pushforward $Y$ and the table $T$ on their highest variable:

```
let [y_0, _y_1] = split_halves(alloc, pushforward);
let [t_0, t_1] = split_halves(alloc, table.to_ref());
```

`split_halves` allocates two buffers and copies both halves into them.

For the table that is right — `t_0` and `t_1` become owned store columns.

For the pushforward it is wasted work:

- `y_0` is read exactly once, at `inner_product_par(&y_0, &t_0)`.
- `_y_1` is never read. It is allocated, filled, and dropped.

The pushforward halves are already store columns of the fractional prover, pushed by `layer_prover` as a split-half entry. The product claims read them by [`ColId`], not through these copies.

### The idea

`inner_product_par` is generic over its backing store:

```
pub fn inner_product_par<F, P, DataA, DataB>(a: &FieldBuffer<P, DataA>, b: &FieldBuffer<P, DataB>) -> F
where DataA: Deref<Target = [P]>, DataB: Deref<Target = [P]>
```

A borrowed slice satisfies that, so the halves never need to be owned.

### The change

```
- let [y_0, _y_1] = split_halves(alloc, pushforward);
+ let (y_0, _y_1) = pushforward.split_half_ref();
  let [t_0, t_1] = split_halves(alloc, table.to_ref());
```

→ two pool allocations and $2^m$ field-element copies saved per proof, 2 MB at $m = 16$.

### Scope

- One call site in `crates/ip-prover/src/logup_star/final_layer.rs`.
- `split_halves` is unchanged and still used for the table halves, which must be owned.
- No public API, no protocol, no transcript change.

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-ip-prover --features rayon --all-targets` — no warnings
- nightly `cargo fmt --all` — clean
- `cargo test -p binius-ip-prover --features rayon --lib` — 58 passed, including the 13 logUp* prove/verify round trips that pin the reduced claims against honest evaluations

Not benchmarked: the saving is two allocations and a 2 MB memcpy against a final-layer sumcheck over $2^{m-1}$ vertices with six columns, which is below what an end-to-end measurement resolves.
The claim here is that removing provably-unread work is free, not that it is visible in a benchmark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)