### PR TITLE
Split the round pass's parallelize and granularity decisions

### DIFF
--- a/crates/ip-prover/src/sumcheck/round_evaluator.rs
+++ b/crates/ip-prover/src/sumcheck/round_evaluator.rs
@@ -145,11 +145,45 @@ pub trait MleCheckRoundEvaluator<A: Allocator, F: Field, P: PackedField<Scalar =
 	) -> RoundCoeffs<F>;
 }
 
-/// Maximum log2 chunk size of the parallel round pass.
+/// Largest round the pass walks in one sequential leaf.
 ///
-/// Chunked accumulation keeps the equality-indicator chunk resident in L1 cache while all
-/// evaluators read it, mirroring the chunking of the pre-store quadratic prover.
+/// - The equality-indicator chunk of a round this size stays in L1 while every evaluator reads it.
+/// - A caller outside the pool parks and wakes to dispatch one leaf.
+/// - So splitting a round this small costs more than walking it.
 const MAX_CHUNK_VARS: usize = 12;
+
+/// Leaf size of a round pass that is split across the pool.
+///
+/// - Well below [`MAX_CHUNK_VARS`], so a split round becomes many small leaves.
+/// - Work-stealing can then even out cores that retire a leaf at different speeds.
+/// - Roughly one leaf per core would leave it nothing to steal.
+///
+/// Tuned on an Apple M1 Pro, whose 8 performance and 2 efficiency cores make that imbalance large.
+const PAR_CHUNK_VARS: usize = 8;
+
+/// Chunk size of one round's read pass over the halved hypercube.
+///
+/// The two constants answer separate questions.
+/// [`MAX_CHUNK_VARS`] decides whether to split the round at all.
+/// [`PAR_CHUNK_VARS`] decides how finely, once it is split.
+///
+/// ```text
+///     halved = n_vars_remaining - 1           a round reads a halved hypercube
+///
+///     halved <= MAX_CHUNK_VARS  ->  chunk = halved           one leaf, no bisection
+///     halved >  MAX_CHUNK_VARS  ->  chunk = PAR_CHUNK_VARS   2^(halved - chunk) leaves
+/// ```
+///
+/// Both constants are floored at the packing width, so a leaf never narrows below one packed word.
+fn chunk_vars_for<P: PackedField>(n_vars_remaining: usize) -> usize {
+	let halved = n_vars_remaining - 1;
+	let sequential_cap = MAX_CHUNK_VARS.max(P::LOG_WIDTH);
+	if halved <= sequential_cap {
+		halved
+	} else {
+		PAR_CHUNK_VARS.max(P::LOG_WIDTH)
+	}
+}
 
 /// Prefix sums of a group of evaluators' accumulator-slot counts.
 ///
@@ -275,12 +309,12 @@ where
 		let n_vars_remaining = self.n_vars();
 		assert!(n_vars_remaining > 0);
 
-		// One parallel pass over the halved hypercube feeds every evaluator, so shared columns
-		// and eq-indicator chunks are read once per round while they are cache-resident.
+		// One pass over the halved hypercube feeds every evaluator.
+		// Shared columns and eq-indicator chunks are read once per round, while cache-resident.
 		//
 		// TODO: dynamically choose chunk size based on the number of columns and P byte-size,
 		// based on estimated L1 cache size.
-		let chunk_vars = (n_vars_remaining - 1).min(MAX_CHUNK_VARS.max(P::LOG_WIDTH));
+		let chunk_vars = chunk_vars_for::<P>(n_vars_remaining);
 
 		// Each evaluator owns a contiguous run of `degree` wide slots in one flat per-worker
 		// buffer; `offsets` holds the run boundaries as a prefix sum, so `offsets[i]..offsets[i +
@@ -508,9 +542,9 @@ where
 		let n_vars_remaining = self.n_vars();
 		assert!(n_vars_remaining > 0);
 
-		// One parallel pass over the halved hypercube feeds every evaluator; see
+		// One pass over the halved hypercube feeds every evaluator; see
 		// [`SharedSumcheckProver::execute`].
-		let chunk_vars = (n_vars_remaining - 1).min(MAX_CHUNK_VARS.max(P::LOG_WIDTH));
+		let chunk_vars = chunk_vars_for::<P>(n_vars_remaining);
 		let offsets = accum_offsets(self.evaluators.iter().map(|evaluator| evaluator.degree()));
 		let total_slots = *offsets
 			.last()


### PR DESCRIPTION
Splits one constant that was doing two unrelated jobs, so a parallelized round gets leaves the pool can actually balance.
Transcript-invariant — same round polynomials, same reduced evaluations.

### The problem

`MleStore::map_reduce` bisects a round's read pass until the chunk narrows to `chunk_vars` variables, so the leaf count is `2^(halved - chunk_vars)`. One `min` set both ends:

```
let chunk_vars = (n_vars_remaining - 1).min(MAX_CHUNK_VARS.max(P::LOG_WIDTH));
```

That decides two different things at once, and only gets one of them right:

- **whether** to split — a round at or below 12 runs as one leaf on the caller. Correct.
- **how finely** — above 12, the leaf stays at 12, so the split is coarse:

```
    halved = 13  ->    2 leaves      <- 10 cores, 2 pieces of work
    halved = 14  ->    4 leaves
    halved = 16  ->   16 leaves
    halved = 18  ->   64 leaves
```

A 20-variable reduction spends most of its arithmetic in rounds with `halved` between 13 and 18, and hands the pool 2 to 64 pieces. With 8 performance and 2 efficiency cores, coarse pieces mean stragglers that work-stealing cannot rebalance.

Profiling `fracaddcheck/prove` at 20 variables:

- rayon workers are busy **10.4%** of the time
- the main thread spends **36.9%** of its samples parked in `LockLatch::wait_and_reset`
- thread scaling stalls: at 16 variables **2 threads beats 10**, and at 20 variables 10 threads regresses 5.7% against 8

### Why lowering the constant is not the fix

It also lowers the sequential threshold, and small rounds then pay a cross-thread park and wake for microseconds of work:

| `MAX_CHUNK_VARS` | n_vars=12 | n_vars=16 | n_vars=20 |
|---|---|---|---|
| 12 (before) | 208.9 us | 1.920 ms | 12.32 ms |
| 10 | 207.2 us | 1.929 ms | 10.63 ms |
| 8 | **359.4 us (+72%)** | 2.014 ms | 9.47 ms |

### The idea

Let each constant answer its own question.

```
    halved = n_vars_remaining - 1

    halved <= MAX_CHUNK_VARS  ->  chunk = halved           one leaf, no bisection
    halved >  MAX_CHUNK_VARS  ->  chunk = PAR_CHUNK_VARS   2^(halved - chunk) leaves
```

### The change

```
- let chunk_vars = (n_vars_remaining - 1).min(MAX_CHUNK_VARS.max(P::LOG_WIDTH));
+ let chunk_vars = chunk_vars_for::<P>(n_vars_remaining);
```

at both `execute` implementations, plus the new `PAR_CHUNK_VARS` and `chunk_vars_for`.

### Soundness — the transcript does not move

`chunk_vars` only decides how the equality indicator is factored:

- the low `chunk_vars` coordinates expand into `eq_chunk`, materialized per leaf
- the rest fold through `reduce` at their `level`

Together they always cover `[0, n_vars-1)`, whatever the split. So the round polynomial is unchanged for any `chunk_vars`, and the existing prove/verify round trips pass untouched — including the 14- and 15-variable cases in `test_shared_frac_add_prove_verify` that straddle the threshold.

### Scope

- One file: `crates/ip-prover/src/sumcheck/round_evaluator.rs`.
- Both `SharedSumcheckProver::execute` and `SharedMleCheckProver::execute`.
- Affects **every** prover built on `MleStore` — prodcheck, bivariate product, selector, zk — not just fracaddcheck.
- `PAR_CHUNK_VARS = 8` is tuned on an Apple M1 Pro. Its 8+2 heterogeneous cores plausibly *cause* the preference for fine leaves, so a homogeneous x86 box may prefer coarser. Deriving it from `current_num_threads()` was tried and measured no better here; that is left as a follow-up once x86 numbers exist.

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-ip-prover --features rayon --all-targets` — no warnings
- nightly `cargo fmt --all` — clean
- `cargo test -p binius-ip-prover --features rayon --lib` — 58 passed

### Benchmark

One fractional-addition MLE-check layer, 10 threads, interleaved A/B, 3 repetitions, medians:

| n_vars | before | after | delta |
|---|---|---|---|
| 11 (all rounds sequential) | 73.6 us | 72.6 us | -1.3% |
| 19 | 4268 us | 3266 us | **-23.5%** |

Ranges do not overlap at 19 (before min 4245 us > after max 3468 us). Single-threaded at 19 variables: 34.3 ms to 32.9 ms, -4%, so this is not trading serial work for parallel width.

The machine carried background load throughout (load average 11.4 on 10 cores), which is why every figure is an interleaved median rather than a single run.

<details>
<summary>Benchmark used (not included in this PR)</summary>

Drop this at `crates/ip-prover/benches/frac_add_layer.rs` with a matching `[[bench]]` entry to reproduce.

```rust
// Copyright 2026 The Binius Developers

//! Benchmarks one fractional-addition MLE-check layer, the round pass that dominates GKR proving.
//!
//! One layer holds a numerator and a denominator buffer, each split on its highest variable into
//! the two halves the fractional-addition rule combines:
//!
//! ```text
//!     a_0/b_0 + a_1/b_1 = (a_0*b_1 + a_1*b_0) / (b_0*b_1)
//!
//!     store columns:  [num_0, num_1, den_0, den_1]
//!     claims:         numerator   num_0*den_1 + num_1*den_0
//!                     denominator den_0*den_1
//! ```
//!
//! Both claims share one evaluation point and one column store, so the layer runs as a single
//! MLE-check. Sizes straddle the point at which a round is split across the thread pool, so the
//! sequential and parallel regimes are both covered.

use binius_compute::BufferPool;
use binius_field::{FieldOps, arch::OptimalPackedB128};
use binius_ip_prover::sumcheck::{
	batch::batch_prove_mle,
	frac_add_mle,
	mle_store::MleStore,
	round_evaluator::{MleCheckRoundEvaluator, SharedMleCheckProver},
};
use binius_math::{
	FieldBuffer, FieldSlice,
	multilinear::evaluate::evaluate_inplace,
	test_utils::{random_field_buffer, random_scalars},
};
use binius_transcript::{ProverTranscript, fiat_shamir::HasherChallenger};
use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
use rand::{SeedableRng, rngs::StdRng};

type P = OptimalPackedB128;
type F = <P as FieldOps>::Scalar;
type StdChallenger = HasherChallenger<sha2::Sha256>;

// One boxed MLE-check claim: its claimed evaluation paired with the evaluator that reduces it.
// The numerator and denominator evaluators are distinct types, so both are boxed to share a prover.
type BoxedClaim<'a> = (F, Box<dyn MleCheckRoundEvaluator<&'a BufferPool, F, P> + 'a>);

// The honest evaluation claim of a quadratic composition over the four layer halves.
//
// `compose` is applied word-wise to build the composite's multilinear extension over the halved
// hypercube, which is then evaluated at the point. This is the value the prover reduces, so
// computing it honestly keeps the benchmarked reduction on the same path a real proof takes.
fn composite_eval_claim(
	halves: [&FieldSlice<'_, P>; 4],
	eval_point: &[F],
	compose: impl Fn([P; 4]) -> P,
) -> F {
	let n_vars = eval_point.len();
	let packed_len = 1 << n_vars.saturating_sub(P::LOG_WIDTH);
	let composite: Vec<P> = (0..packed_len)
		.map(|i| compose([0, 1, 2, 3].map(|j| halves[j].as_ref()[i])))
		.collect();
	evaluate_inplace(FieldBuffer::new(n_vars, composite), eval_point)
}

// Proves one fractional-addition layer: two claims over four columns held in one shared store.
//
// The two parent buffers have `n_vars + 1` variables, so each half — and therefore the MLE-check —
// has `n_vars`. Round `r` reads a halved hypercube of `n_vars - r - 1` variables, so a single
// `n_vars` spans every round size below it.
fn bench_frac_add_layer(c: &mut Criterion) {
	let mut group = c.benchmark_group("frac_add_layer/mlecheck");
	let mut rng = StdRng::seed_from_u64(0);

	// 11 keeps every round below the pool-split threshold; 15 and 19 cross it, with 19 putting most
	// of the arithmetic in rounds that are split.
	for n_vars in [11, 15, 19] {
		// One round pass reads the halved hypercube, so count its vertices.
		group.throughput(Throughput::Elements(1 << n_vars));
		group.bench_function(format!("n_vars={n_vars}"), |b| {
			// The parent buffers carry the variable that splits them into sibling halves.
			let num_parent = random_field_buffer::<P>(&mut rng, n_vars + 1);
			let den_parent = random_field_buffer::<P>(&mut rng, n_vars + 1);
			let eval_point = random_scalars::<F>(&mut rng, n_vars);

			// The claims are the two compositions' extensions evaluated at the shared point.
			let (num_0, num_1) = num_parent.split_half_ref();
			let (den_0, den_1) = den_parent.split_half_ref();
			let halves = [&num_0, &num_1, &den_0, &den_1];
			let num_claim =
				composite_eval_claim(halves, &eval_point, |[n0, n1, d0, d1]| n0 * d1 + n1 * d0);
			let den_claim = composite_eval_claim(halves, &eval_point, |[_n0, _n1, d0, d1]| d0 * d1);

			let transcript = ProverTranscript::new(StdChallenger::default());
			let pool = BufferPool::new();
			let alloc = &pool;

			b.iter_batched(
				|| {
					// The store folds its buffers in place, so each iteration gets fresh copies.
					(
						transcript.clone(),
						FieldBuffer::clone_from_slice(&alloc, num_parent.to_ref()),
						FieldBuffer::clone_from_slice(&alloc, den_parent.to_ref()),
						eval_point.clone(),
					)
				},
				|(mut transcript, num, den, eval_point)| {
					// Each parent enters as one split-half entry, so its two halves are two
					// columns in a single allocation with no copy to separate them.
					let mut store = MleStore::new(n_vars, &alloc);
					let [num_0, num_1] = store.push_split_half(num);
					let [den_0, den_1] = store.push_split_half(den);
					let (num_evaluator, den_evaluator) =
						frac_add_mle::evaluators([num_0, num_1, den_0, den_1]);

					// The two evaluators are distinct types, so box them to share one prover.
					let claims_with_evaluators: [BoxedClaim<'_>; 2] = [
						(num_claim, Box::new(num_evaluator)),
						(den_claim, Box::new(den_evaluator)),
					];
					let prover =
						SharedMleCheckProver::new(store, claims_with_evaluators, eval_point);

					// Both claims share the prover, so the batched MLE driver reduces them
					// together — one round polynomial pair per round, as a real layer does.
					batch_prove_mle(vec![prover], &mut transcript)
				},
				BatchSize::SmallInput,
			);
		});
	}

	group.finish();
}

criterion_group!(frac_add_layer, bench_frac_add_layer);
criterion_main!(frac_add_layer);
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)