### PR TITLE
Reduce both fractional-addition claims in one column pass

### DIFF
--- a/crates/ip-prover/src/fracaddcheck.rs
+++ b/crates/ip-prover/src/fracaddcheck.rs
@@ -17,9 +17,9 @@ use itertools::izip;
 use crate::{
 	channel::IPProverChannel,
 	sumcheck::{
-		batch::batch_prove_mle_and_write_evals,
+		batch::batch_prove_mle_with_coeff_and_write_evals,
 		common::{MleCheckProver, SumcheckProver},
-		frac_add_mle,
+		frac_add_mle::{self, FracAddFusedEvaluator},
 		mle_store::{ColId, MleStore},
 		round_evaluator::{MleCheckRoundEvaluator, SharedMleCheckProver},
 	},
@@ -218,6 +218,51 @@ where
 		)
 	}
 
+	/// Pops the last layer as a prover carrying the two fractional claims batched into one.
+	///
+	/// Same reduction as [`Self::layer_prover`], in one pass over the four columns instead of two.
+	/// The numerator's pass and the denominator's pass read the same denominator halves.
+	/// They read the same equality indicator too.
+	/// A fused evaluator loads both once.
+	///
+	/// The caller must sample `batch_coeff` from the channel before calling this.
+	/// It must then drive the returned prover with a driver that does not sample another one.
+	/// The round polynomials and reduced column evaluations match [`Self::layer_prover`]'s.
+	/// So the transcript is unchanged.
+	#[allow(clippy::type_complexity)]
+	fn fused_layer_prover(
+		mut self,
+		claim: FracEvalClaim<F>,
+		batch_coeff: F,
+	) -> (Option<Self>, LayerProver<'a, A, F, P>) {
+		let (num_claim, den_claim) = claim;
+		assert_eq!(
+			num_claim.point, den_claim.point,
+			"fractional claims must share the evaluation point"
+		);
+
+		let alloc = self.alloc;
+		let (num, den) = self.layers.pop().expect("layers is non-empty");
+
+		let remaining = if self.layers.is_empty() {
+			None
+		} else {
+			Some(self)
+		};
+
+		// The store owns the two popped buffers and shares each between its halves.
+		// The two-evaluator path does the same; only the evaluator group differs.
+		let mut store = MleStore::new(num.log_len() - 1, alloc);
+		let [num_0, num_1] = store.push_split_half(num);
+		let [den_0, den_1] = store.push_split_half(den);
+		let evaluator = FracAddFusedEvaluator::new([num_0, num_1, den_0, den_1], batch_coeff);
+
+		// One claim, batched the way the verifier batches the two it holds.
+		let claims_with_evaluators: [(F, Box<dyn MleCheckRoundEvaluator<A, F, P> + 'a>); 1] =
+			[(num_claim.eval + batch_coeff * den_claim.eval, Box::new(evaluator))];
+		(remaining, SharedMleCheckProver::new(store, claims_with_evaluators, num_claim.point))
+	}
+
 	/// Runs the fractional addition check protocol and returns the final evaluation claims.
 	///
 	/// This consumes the prover and runs sumcheck reductions from the smallest layer back to
@@ -278,10 +323,18 @@ where
 			let prover = prover_opt
 				.take()
 				.expect("precondition: n_layers <= self.n_layers()");
-			let (remaining, sumcheck_prover, _) = prover.layer_prover(claim);
+			// The fused evaluator emits the already-batched round polynomial.
+			// So it needs the batching coefficient at construction.
+			// Sampling it here matches the transcript position the batched driver draws it from.
+			let batch_coeff = channel.sample();
+			let (remaining, sumcheck_prover) = prover.fused_layer_prover(claim, batch_coeff);
 			prover_opt = remaining;
 
-			let output = batch_prove_mle_and_write_evals(vec![sumcheck_prover], channel);
+			let output = batch_prove_mle_with_coeff_and_write_evals(
+				vec![sumcheck_prover],
+				batch_coeff,
+				channel,
+			);
 
 			let mut multilinear_evals = output.multilinear_evals;
 			let evals = multilinear_evals.pop().expect("batch contains one prover");

--- a/crates/ip-prover/src/sumcheck/batch.rs
+++ b/crates/ip-prover/src/sumcheck/batch.rs
@@ -141,7 +141,7 @@ where
 /// agree on the same evaluation point, so the batched protocol can fold every prover with the
 /// same per-round challenge and reduce all evaluation claims via a single batching coefficient.
 pub fn batch_prove_mle<F, MleCheckProver_>(
-	mut provers: Vec<MleCheckProver_>,
+	provers: Vec<MleCheckProver_>,
 	channel: &mut impl IPProverChannel<F>,
 ) -> BatchSumcheckOutput<F>
 where
@@ -172,6 +172,30 @@ where
 	);
 	// Random linear-combination coefficient for batching multiple eval claims.
 	let batch_coeff = channel.sample();
+
+	batch_prove_mle_with_coeff(provers, batch_coeff, channel)
+}
+
+/// Prove a batched MLE-check whose batching coefficient the caller has already sampled.
+///
+/// This is [`batch_prove_mle`] with the coefficient supplied rather than drawn.
+/// A caller needs that when it must know the coefficient before building its provers.
+/// An evaluator that emits one already-batched round polynomial is such a caller.
+///
+/// The coefficient must come from the same channel immediately before this call.
+/// Then the transcript is the one [`batch_prove_mle`] would have produced.
+pub(crate) fn batch_prove_mle_with_coeff<F, MleCheckProver_>(
+	mut provers: Vec<MleCheckProver_>,
+	batch_coeff: F,
+	channel: &mut impl IPProverChannel<F>,
+) -> BatchSumcheckOutput<F>
+where
+	F: Field,
+	MleCheckProver_: MleCheckProver<F>,
+{
+	let n_vars = provers
+		.first()
+		.map_or(0, |prover| SumcheckProver::n_vars(prover));
 
 	let mut challenges = Vec::with_capacity(n_vars);
 	for _ in 0..n_vars {
@@ -222,6 +246,27 @@ where
 	MleCheckProver_: MleCheckProver<F>,
 {
 	let output = batch_prove_mle(provers, channel);
+
+	for evals in &output.multilinear_evals {
+		// Preserve per-prover ordering when emitting evaluation claims.
+		channel.send_many(evals);
+	}
+	output
+}
+
+/// [`batch_prove_mle_and_write_evals`] with the batching coefficient supplied by the caller.
+///
+/// See [`batch_prove_mle_with_coeff`] for when a caller needs the coefficient up front.
+pub(crate) fn batch_prove_mle_with_coeff_and_write_evals<F, MleCheckProver_>(
+	provers: Vec<MleCheckProver_>,
+	batch_coeff: F,
+	channel: &mut impl IPProverChannel<F>,
+) -> BatchSumcheckOutput<F>
+where
+	F: Field,
+	MleCheckProver_: MleCheckProver<F>,
+{
+	let output = batch_prove_mle_with_coeff(provers, batch_coeff, channel);
 
 	for evals in &output.multilinear_evals {
 		// Preserve per-prover ordering when emitting evaluation claims.

--- a/crates/ip-prover/src/sumcheck/frac_add_mle.rs
+++ b/crates/ip-prover/src/sumcheck/frac_add_mle.rs
@@ -1,10 +1,14 @@
 // Copyright 2025-2026 The Binius Developers
 
 use binius_compute::Allocator;
-use binius_field::{Field, PackedField};
+use binius_field::{Field, PackedField, WideMul};
+use binius_ip::sumcheck::RoundCoeffs;
+use binius_math::FieldSlice;
 
 use crate::sumcheck::{
-	mle_store::ColId, quadratic_mle_evaluator::QuadraticMleEvaluator,
+	mle_store::{ColId, ColumnChunk, EvaluationChunk, MleStore},
+	quadratic_mle_evaluator::QuadraticMleEvaluator,
+	round_evals::RoundEvals2,
 	round_evaluator::MleCheckRoundEvaluator,
 };
 
@@ -45,6 +49,136 @@ where
 	(numerator, denominator)
 }
 
+/// Round evaluator that reduces both fractional-addition claims in a single pass.
+///
+/// [`evaluators`] returns one evaluator per claim, so each claim walks the columns itself:
+///
+/// ```text
+///     numerator pass    num_a num_b den_a den_b   eq      8 column loads + 1 eq load
+///     denominator pass              den_a den_b   eq      4 column loads + 1 eq load
+/// ```
+///
+/// This evaluator reads the four columns once and fills both claims' accumulator slots.
+/// The sums `den_a.lo + den_a.hi` and `den_b.lo + den_b.hi` are then formed once, not twice.
+///
+/// It emits one round polynomial, already batched, rather than one per claim.
+/// That is exact, because [`RoundEvals2::interpolate_eq`] is affine in its claim and evaluations:
+///
+/// ```text
+///     interp(c_num + z*c_den, y_num + z*y_den) = interp(c_num, y_num) + z*interp(c_den, y_den)
+/// ```
+///
+/// So the driving prover carries the single batched claim `c_num + z*c_den`.
+/// The polynomial this emits is the one the verifier's batched MLE-check reconstructs.
+pub struct FracAddFusedEvaluator<F> {
+	/// Layer columns in the order `[num_a, num_b, den_a, den_b]`.
+	cols: [ColId; 4],
+	/// The coefficient that batches the denominator claim onto the numerator claim.
+	batch_coeff: F,
+}
+
+impl<F: Field> FracAddFusedEvaluator<F> {
+	/// Creates the fused evaluator over the four layer columns.
+	///
+	/// # Arguments
+	///
+	/// * `cols` - The columns `[num_a, num_b, den_a, den_b]`.
+	/// * `batch_coeff` - The coefficient the driving protocol batches the two claims with.
+	///
+	/// The prover's claim for this evaluator must be `num_claim + batch_coeff * den_claim`.
+	pub const fn new(cols: [ColId; 4], batch_coeff: F) -> Self {
+		Self { cols, batch_coeff }
+	}
+}
+
+impl<A, F, P> MleCheckRoundEvaluator<A, F, P> for FracAddFusedEvaluator<F>
+where
+	A: Allocator,
+	F: Field,
+	P: PackedField<Scalar = F>,
+{
+	fn degree(&self) -> usize {
+		// Four slots: the numerator's `y_1` and `y_inf`, then the denominator's.
+		// Each quadratic claim contributes the two sampled evaluations of its prime polynomial.
+		// The emitted polynomial is still degree 2.
+		4
+	}
+
+	fn accumulate(
+		&self,
+		chunk: &EvaluationChunk<'_, P>,
+		eq_ind: FieldSlice<'_, P>,
+		accum: &mut [<P as WideMul>::Output],
+	) {
+		// Each column arrives split on the round's top variable: `lo` fixes it to 0, `hi` to 1.
+		let [num_a, num_b, den_a, den_b]: [&ColumnChunk<'_, P>; 4] =
+			self.cols.map(|id| chunk.col(id));
+
+		let mut num_y_1 = <P as WideMul>::Output::default();
+		let mut num_y_inf = <P as WideMul>::Output::default();
+		let mut den_y_1 = <P as WideMul>::Output::default();
+		let mut den_y_inf = <P as WideMul>::Output::default();
+
+		for (idx, &eq_i) in eq_ind.as_ref().iter().enumerate() {
+			// One load per column half, shared by both claims.
+			let na_lo = num_a.lo.as_ref()[idx];
+			let na_hi = num_a.hi.as_ref()[idx];
+			let nb_lo = num_b.lo.as_ref()[idx];
+			let nb_hi = num_b.hi.as_ref()[idx];
+			let da_lo = den_a.lo.as_ref()[idx];
+			let da_hi = den_a.hi.as_ref()[idx];
+			let db_lo = den_b.lo.as_ref()[idx];
+			let db_hi = den_b.hi.as_ref()[idx];
+
+			// The `x = 1` branch reads the high halves directly.
+			num_y_1 += P::wide_mul(na_hi * db_hi + nb_hi * da_hi, eq_i);
+			den_y_1 += P::wide_mul(da_hi * db_hi, eq_i);
+
+			// The `x = infinity` branch reads `lo + hi`, each multilinear's leading coefficient.
+			// The two denominator sums serve both claims.
+			let na = na_lo + na_hi;
+			let nb = nb_lo + nb_hi;
+			let da = da_lo + da_hi;
+			let db = db_lo + db_hi;
+			num_y_inf += P::wide_mul(na * db + nb * da, eq_i);
+			den_y_inf += P::wide_mul(da * db, eq_i);
+		}
+
+		accum[0] += num_y_1;
+		accum[1] += num_y_inf;
+		accum[2] += den_y_1;
+		accum[3] += den_y_inf;
+	}
+
+	fn interpolate(
+		&self,
+		store: &MleStore<'_, A, P>,
+		accum: &[P],
+		claim: F,
+		alpha: F,
+	) -> RoundCoeffs<F> {
+		// The store has not yet folded this round, so its count is this round's.
+		let n_vars_remaining = store.n_vars();
+		assert!(n_vars_remaining > 0);
+
+		// Sum each claim's packed lanes into scalars.
+		let numerator = RoundEvals2 {
+			y_1: accum[0],
+			y_inf: accum[1],
+		}
+		.sum_scalars(n_vars_remaining);
+		let denominator = RoundEvals2 {
+			y_1: accum[2],
+			y_inf: accum[3],
+		}
+		.sum_scalars(n_vars_remaining);
+
+		// Batch the sampled evaluations, then interpolate once against the batched claim.
+		// That order is equivalent to interpolating each claim and batching the polynomials.
+		(numerator + &(denominator * self.batch_coeff)).interpolate_eq(claim, alpha)
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use binius_field::arch::{OptimalB128, OptimalPackedB128};
@@ -67,8 +201,111 @@ mod tests {
 		batch::batch_prove,
 		common::SumcheckProver,
 		mle_store::MleStore,
-		round_evaluator::{SharedSumcheckProver, SumcheckRoundEvaluator},
+		round_evaluator::{SharedMleCheckProver, SharedSumcheckProver, SumcheckRoundEvaluator},
 	};
+
+	// One layer's two honest claims: the numerator and denominator compositions.
+	// Each is its composite multilinear evaluated at the shared point.
+	fn layer_claims<F, P>(
+		num_parent: &FieldBuffer<P>,
+		den_parent: &FieldBuffer<P>,
+		eval_point: &[F],
+	) -> (F, F)
+	where
+		F: Field,
+		P: PackedField<Scalar = F>,
+	{
+		let n_vars = eval_point.len();
+		let (num_a, num_b) = num_parent.split_half_ref();
+		let (den_a, den_b) = den_parent.split_half_ref();
+		let packed_len = 1 << n_vars.saturating_sub(P::LOG_WIDTH);
+
+		// The composite values over the halved hypercube, word by word.
+		let numerator: Vec<P> = (0..packed_len)
+			.map(|i| num_a.as_ref()[i] * den_b.as_ref()[i] + num_b.as_ref()[i] * den_a.as_ref()[i])
+			.collect();
+		let denominator: Vec<P> = (0..packed_len)
+			.map(|i| den_a.as_ref()[i] * den_b.as_ref()[i])
+			.collect();
+
+		(
+			evaluate(&FieldBuffer::new(n_vars, numerator), eval_point),
+			evaluate(&FieldBuffer::new(n_vars, denominator), eval_point),
+		)
+	}
+
+	#[test]
+	#[allow(clippy::type_complexity)]
+	fn fused_evaluator_matches_batched_split_evaluators() {
+		type F = OptimalB128;
+		type P = OptimalPackedB128;
+
+		let mut rng = StdRng::seed_from_u64(0);
+		let alloc = GlobalAllocator;
+
+		// 1 and 3 are single-chunk rounds throughout.
+		// 8 and 14 cross the chunk cap, so 14 also exercises eq suffix folding in the driver.
+		for n_vars in [1, 3, 8, 14] {
+			// The parents carry the variable that splits them into the four layer columns.
+			let num_parent = random_field_buffer::<P>(&mut rng, n_vars + 1);
+			let den_parent = random_field_buffer::<P>(&mut rng, n_vars + 1);
+			let eval_point = random_scalars::<F>(&mut rng, n_vars);
+			let batch_coeff = random_scalars::<F>(&mut rng, 1)[0];
+			let (num_claim, den_claim) = layer_claims(&num_parent, &den_parent, &eval_point);
+
+			// Reference: one evaluator per claim, the two round polynomials batched by the driver.
+			let mut split_store = MleStore::new(n_vars, &alloc);
+			let [s_num_a, s_num_b] = split_store.push_split_half(num_parent.clone());
+			let [s_den_a, s_den_b] = split_store.push_split_half(den_parent.clone());
+			let (num_evaluator, den_evaluator) =
+				evaluators::<GlobalAllocator, F, P>([s_num_a, s_num_b, s_den_a, s_den_b]);
+			let split_claims: [(F, Box<dyn MleCheckRoundEvaluator<GlobalAllocator, F, P>>); 2] = [
+				(num_claim, Box::new(num_evaluator)),
+				(den_claim, Box::new(den_evaluator)),
+			];
+			let mut split_prover =
+				SharedMleCheckProver::new(split_store, split_claims, eval_point.clone());
+
+			// Fused: one evaluator, one claim, already batched.
+			let mut fused_store = MleStore::new(n_vars, &alloc);
+			let [f_num_a, f_num_b] = fused_store.push_split_half(num_parent.clone());
+			let [f_den_a, f_den_b] = fused_store.push_split_half(den_parent.clone());
+			let fused_evaluator =
+				FracAddFusedEvaluator::new([f_num_a, f_num_b, f_den_a, f_den_b], batch_coeff);
+			let mut fused_prover = SharedMleCheckProver::new(
+				fused_store,
+				[(num_claim + batch_coeff * den_claim, fused_evaluator)],
+				eval_point.clone(),
+			);
+
+			// Both provers see the same challenges, so every round must agree.
+			for round in 0..n_vars {
+				// The driver Horner-folds the two claims into `num + batch_coeff * den`.
+				let batched_reference = split_prover
+					.execute()
+					.into_iter()
+					.rfold(RoundCoeffs::default(), |acc, coeffs| acc * batch_coeff + &coeffs);
+
+				let fused_round = fused_prover.execute();
+				assert_eq!(fused_round.len(), 1, "the fused evaluator emits one polynomial");
+				assert_eq!(
+					fused_round[0].0, batched_reference.0,
+					"round {round} polynomial differs at n_vars={n_vars}"
+				);
+
+				let challenge = random_scalars::<F>(&mut rng, 1)[0];
+				split_prover.fold(challenge);
+				fused_prover.fold(challenge);
+			}
+
+			// Both stores hold the same four columns, so they must reduce to the same evaluations.
+			assert_eq!(
+				split_prover.finish(),
+				fused_prover.finish(),
+				"column evaluations differ at n_vars={n_vars}"
+			);
+		}
+	}
 
 	fn test_frac_add_sumcheck_prove_verify<F, P>(
 		prover: impl SumcheckProver<F>,


### PR DESCRIPTION
The two fractional-addition claims each walked the layer's columns separately. Now one evaluator walks them once and reduces both.
Transcript-identical — same round polynomials, same reduced evaluations, verifier untouched.

### The problem

`frac_add_mle::evaluators` returns one evaluator per claim, and the driver runs each over the same chunk in turn. So the denominator's pass re-reads what the numerator's pass has just read:

```
    numerator pass    num_a num_b den_a den_b   eq      8 column loads + 1 eq load
    denominator pass              den_a den_b   eq      4 column loads + 1 eq load
                                  ^^^^^^^^^^^   ^^      re-read
```

12 column loads plus 2 eq loads per element, where 8 plus 1 would do.
The sums `den_a.lo + den_a.hi` and `den_b.lo + den_b.hi` are formed twice as well, once for each pass's infinity branch.

A chunk is ^{12}$ elements at 16 bytes, so nine live slices are 576 KB — well past a 128 KB L1.

Deleting the denominator pass outright (wrong results, valid timing) costs 14.5% to 16% of `prove`, which bounds what fusing can win.

### The idea

One evaluator, four accumulator slots, both claims:

```
    slot 0,1   numerator   y_1, y_inf
    slot 2,3   denominator y_1, y_inf
```

The subtlety is the output. The driver expects one round polynomial per claim, so a fused evaluator seems to need a wider trait. It does not, because **batching commutes with interpolation**.

`RoundEvals2::interpolate_eq` computes $y_0 = (c - y_1 \alpha)(1-\alpha)^{-1}$ and then the coefficients — affine in the claim and in the sampled evaluations. So:

```
    interp(c_num + z*c_den, y_num + z*y_den) = interp(c_num, y_num) + z*interp(c_den, y_den)
```

The fused evaluator therefore batches the four slots and interpolates **once**, emitting the polynomial the verifier's batched MLE-check already reconstructs. The prover carries the single claim `num_claim + z * den_claim`.

No change to `MleCheckRoundEvaluator`.

### Per element

- **before:** 12 column loads, 2 eq loads, 2 denominator half-sums, 6 reduced multiplies, 4 wide multiplies
- **after:** 8 column loads, 1 eq load, 1 set of half-sums, 6 reduced multiplies, 4 wide multiplies

→ the multiplies are untouched; a third of the loads and the second loop disappear.

### The change

`prove_layers` samples the coefficient up front, then drives the fused prover:

```
- let (remaining, sumcheck_prover, _) = prover.layer_prover(claim);
- let output = batch_prove_mle_and_write_evals(vec![sumcheck_prover], channel);
+ let batch_coeff = channel.sample();
+ let (remaining, sumcheck_prover) = prover.fused_layer_prover(claim, batch_coeff);
+ let output = batch_prove_mle_with_coeff_and_write_evals(vec![sumcheck_prover], batch_coeff, channel);
```

`batch_prove_mle` is split around a coefficient-taking variant: it samples, then delegates. So the coefficient still comes off the channel first, at the same transcript position.

### Soundness — the transcript is identical

- The coefficient is sampled from the same channel at the same point in the order.
- Each round emits the same batched polynomial, by the affine identity above.
- `finish` reads column evaluations from the store, which is untouched.

A test pins the fused path to the two-evaluator path directly: same challenges, same coefficient, asserting equal batched polynomials every round and equal column evaluations at the end, at 1, 3, 8 and 14 variables. 14 also exercises the eq suffix folding in the driver.

The existing prove/verify round trips pass unchanged, which is the end-to-end confirmation.

### Scope

- **new:** `FracAddFusedEvaluator` in `frac_add_mle.rs`, plus its equivalence test
- **new:** `batch_prove_mle_with_coeff` and its write-evals sibling, both `pub(crate)`
- **changed:** `prove_layers` and a private `fused_layer_prover`
- **untouched:** `evaluators` and `layer_prover` stay exactly as they are — they remain the reference the new test compares against
- **deliberately not used** by the logUp* final layer: it batches four claims (`num`, `den`, `e_0`, `e_1`) in a fixed order, so its numerator and denominator must stay separate
- **not used** by the batched `reduce_layer` path either; that is a follow-up

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-ip-prover --features rayon --all-targets` — no warnings
- nightly `cargo fmt --all` — clean
- `cargo test -p binius-ip-prover --features rayon --lib` — 59 passed

### Benchmark

Evaluator only, both variants in one binary so the comparison is back-to-back in one process:

| n_vars | split | fused | delta |
|---|---|---|---|
| 15 | 810.8 us | 701.4 us | **-13.5%** |
| 19 | 4.226 ms | 3.722 ms | **-11.9%** |

The wired path, `FracAddCheckProver::prove` at 16 variables, 10 threads, interleaved A/B, 3 repetitions, medians:

| | before | after | delta |
|---|---|---|---|
| full reduction, 16 layers | 1893 us | 1595 us | **-15.7%** |

Ranges do not overlap (before min 1889 us > after max 1614 us). The machine carried background load throughout (load average 11.4 on 10 cores), which is why these are interleaved medians rather than single runs.

<details>
<summary>Benchmarks used (not included in this PR)</summary>

`crates/ip-prover/benches/frac_add_fused.rs` — split vs fused, one layer:

```rust
// Copyright 2026 The Binius Developers

//! Compares the two ways of reducing one fractional-addition MLE-check layer.
//!
//! `split` runs one evaluator per claim, so the denominator's pass re-reads `den_a`, `den_b` and
//! the equality indicator that the numerator's pass has just read. `fused` reads the four columns
//! once and fills both claims' accumulator slots, emitting the already-batched round polynomial.
//!
//! One layer holds a numerator and a denominator buffer, each split on its highest variable into
//! the two halves the fractional-addition rule combines:
//!
//! ```text
//!     a_0/b_0 + a_1/b_1 = (a_0*b_1 + a_1*b_0) / (b_0*b_1)
//!
//!     store columns:  [num_0, num_1, den_0, den_1]
//!     claims:         numerator   num_0*den_1 + num_1*den_0
//!                     denominator den_0*den_1
//! ```
//!
//! Both claims share one evaluation point and one column store, so the layer runs as a single
//! MLE-check. Sizes straddle the point at which a round is split across the thread pool, so the
//! sequential and parallel regimes are both covered.

use binius_compute::BufferPool;
use binius_field::{FieldOps, arch::OptimalPackedB128};
use binius_ip_prover::sumcheck::{
	batch::batch_prove_mle,
	frac_add_mle::{self, FracAddFusedEvaluator},
	mle_store::MleStore,
	round_evaluator::{MleCheckRoundEvaluator, SharedMleCheckProver},
};
use binius_math::{
	FieldBuffer, FieldSlice,
	multilinear::evaluate::evaluate_inplace,
	test_utils::{random_field_buffer, random_scalars},
};
use binius_transcript::{ProverTranscript, fiat_shamir::HasherChallenger};
use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
use rand::{SeedableRng, rngs::StdRng};

type P = OptimalPackedB128;
type F = <P as FieldOps>::Scalar;
type StdChallenger = HasherChallenger<sha2::Sha256>;

// One boxed MLE-check claim: its claimed evaluation paired with the evaluator that reduces it.
// The numerator and denominator evaluators are distinct types, so both are boxed to share a prover.
type BoxedClaim<'a> = (F, Box<dyn MleCheckRoundEvaluator<&'a BufferPool, F, P> + 'a>);

// The honest evaluation claim of a quadratic composition over the four layer halves.
//
// `compose` is applied word-wise to build the composite's multilinear extension over the halved
// hypercube, which is then evaluated at the point. This is the value the prover reduces, so
// computing it honestly keeps the benchmarked reduction on the same path a real proof takes.
fn composite_eval_claim(
	halves: [&FieldSlice<'_, P>; 4],
	eval_point: &[F],
	compose: impl Fn([P; 4]) -> P,
) -> F {
	let n_vars = eval_point.len();
	let packed_len = 1 << n_vars.saturating_sub(P::LOG_WIDTH);
	let composite: Vec<P> = (0..packed_len)
		.map(|i| compose([0, 1, 2, 3].map(|j| halves[j].as_ref()[i])))
		.collect();
	evaluate_inplace(FieldBuffer::new(n_vars, composite), eval_point)
}

// Proves one fractional-addition layer: two claims over four columns held in one shared store.
//
// The two parent buffers have `n_vars + 1` variables, so each half — and therefore the MLE-check —
// has `n_vars`. Round `r` reads a halved hypercube of `n_vars - r - 1` variables, so a single
// `n_vars` spans every round size below it.
fn bench_split(c: &mut Criterion) {
	let mut group = c.benchmark_group("frac_add_layer/split");
	let mut rng = StdRng::seed_from_u64(0);

	for n_vars in [15, 19] {
		// One round pass reads the halved hypercube, so count its vertices.
		group.throughput(Throughput::Elements(1 << n_vars));
		group.bench_function(format!("n_vars={n_vars}"), |b| {
			// The parent buffers carry the variable that splits them into sibling halves.
			let num_parent = random_field_buffer::<P>(&mut rng, n_vars + 1);
			let den_parent = random_field_buffer::<P>(&mut rng, n_vars + 1);
			let eval_point = random_scalars::<F>(&mut rng, n_vars);

			// The claims are the two compositions' extensions evaluated at the shared point.
			let (num_0, num_1) = num_parent.split_half_ref();
			let (den_0, den_1) = den_parent.split_half_ref();
			let halves = [&num_0, &num_1, &den_0, &den_1];
			let num_claim =
				composite_eval_claim(halves, &eval_point, |[n0, n1, d0, d1]| n0 * d1 + n1 * d0);
			let den_claim = composite_eval_claim(halves, &eval_point, |[_n0, _n1, d0, d1]| d0 * d1);

			let transcript = ProverTranscript::new(StdChallenger::default());
			let pool = BufferPool::new();
			let alloc = &pool;

			b.iter_batched(
				|| {
					// The store folds its buffers in place, so each iteration gets fresh copies.
					(
						transcript.clone(),
						FieldBuffer::clone_from_slice(&alloc, num_parent.to_ref()),
						FieldBuffer::clone_from_slice(&alloc, den_parent.to_ref()),
						eval_point.clone(),
					)
				},
				|(mut transcript, num, den, eval_point)| {
					// Each parent enters as one split-half entry, so its two halves are two
					// columns in a single allocation with no copy to separate them.
					let mut store = MleStore::new(n_vars, &alloc);
					let [num_0, num_1] = store.push_split_half(num);
					let [den_0, den_1] = store.push_split_half(den);
					let (num_evaluator, den_evaluator) =
						frac_add_mle::evaluators([num_0, num_1, den_0, den_1]);

					// The two evaluators are distinct types, so box them to share one prover.
					let claims_with_evaluators: [BoxedClaim<'_>; 2] = [
						(num_claim, Box::new(num_evaluator)),
						(den_claim, Box::new(den_evaluator)),
					];
					let prover =
						SharedMleCheckProver::new(store, claims_with_evaluators, eval_point);

					// Both claims share the prover, so the batched MLE driver reduces them
					// together — one round polynomial pair per round, as a real layer does.
					batch_prove_mle(vec![prover], &mut transcript)
				},
				BatchSize::SmallInput,
			);
		});
	}

	group.finish();
}

// The same layer reduced by the single fused evaluator.
//
// The prover carries one claim, `num + batch_coeff * den`, and the evaluator emits the batched
// round polynomial directly. `batch_coeff` is drawn like any other challenge; its value does not
// change the work done, only which polynomial comes out.
fn bench_fused(c: &mut Criterion) {
	let mut group = c.benchmark_group("frac_add_layer/fused");
	let mut rng = StdRng::seed_from_u64(0);

	for n_vars in [15, 19] {
		group.throughput(Throughput::Elements(1 << n_vars));
		group.bench_function(format!("n_vars={n_vars}"), |b| {
			let num_parent = random_field_buffer::<P>(&mut rng, n_vars + 1);
			let den_parent = random_field_buffer::<P>(&mut rng, n_vars + 1);
			let eval_point = random_scalars::<F>(&mut rng, n_vars);
			let batch_coeff = random_scalars::<F>(&mut rng, 1)[0];

			let (num_0, num_1) = num_parent.split_half_ref();
			let (den_0, den_1) = den_parent.split_half_ref();
			let halves = [&num_0, &num_1, &den_0, &den_1];
			let num_claim =
				composite_eval_claim(halves, &eval_point, |[n0, n1, d0, d1]| n0 * d1 + n1 * d0);
			let den_claim = composite_eval_claim(halves, &eval_point, |[_n0, _n1, d0, d1]| d0 * d1);
			// The driving prover holds the batched claim, so batch it once here.
			let batched_claim = num_claim + batch_coeff * den_claim;

			let transcript = ProverTranscript::new(StdChallenger::default());
			let pool = BufferPool::new();
			let alloc = &pool;

			b.iter_batched(
				|| {
					(
						transcript.clone(),
						FieldBuffer::clone_from_slice(&alloc, num_parent.to_ref()),
						FieldBuffer::clone_from_slice(&alloc, den_parent.to_ref()),
						eval_point.clone(),
					)
				},
				|(mut transcript, num, den, eval_point)| {
					let mut store = MleStore::new(n_vars, &alloc);
					let [num_0, num_1] = store.push_split_half(num);
					let [den_0, den_1] = store.push_split_half(den);
					let evaluator =
						FracAddFusedEvaluator::new([num_0, num_1, den_0, den_1], batch_coeff);
					let prover =
						SharedMleCheckProver::new(store, [(batched_claim, evaluator)], eval_point);

					batch_prove_mle(vec![prover], &mut transcript)
				},
				BatchSize::SmallInput,
			);
		});
	}

	group.finish();
}

criterion_group!(frac_add_fused, bench_split, bench_fused);
criterion_main!(frac_add_fused);
```

`crates/ip-prover/benches/frac_add_prove.rs` — the wired path:

```rust
// Copyright 2026 The Binius Developers

//! Benchmarks a full fractional-addition GKR reduction: every layer of the circuit, proved in turn.
//!
//! `k = n_vars` reduces over every variable, so the circuit collapses to a single root fraction and
//! the reduction runs one MLE-check per layer, from the narrowest layer back to the widest.

use binius_compute::BufferPool;
use binius_field::arch::OptimalPackedB128;
use binius_ip::prodcheck::MultilinearEvalClaim;
use binius_ip_prover::fracaddcheck::FracAddCheckProver;
use binius_math::{FieldBuffer, multilinear::evaluate::evaluate, test_utils::random_field_buffer};
use binius_transcript::{ProverTranscript, fiat_shamir::HasherChallenger};
use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
use rand::{SeedableRng, rngs::StdRng};

type P = OptimalPackedB128;
type StdChallenger = HasherChallenger<sha2::Sha256>;

// Proves every layer of one fractional-addition circuit over `n_vars` variables.
//
// The prover is built once outside the timed closure — building it computes the layers, which is a
// separate cost — and cloned per iteration, since proving consumes it.
fn bench_frac_add_prove(c: &mut Criterion) {
	let mut group = c.benchmark_group("frac_add_prove");
	let mut rng = StdRng::seed_from_u64(0);

	{
		// A 16-variable circuit: 16 layers, the widest holding 2^16 fractions.
		let n_vars = 16;
		// One element per hypercube vertex of the widest layer.
		group.throughput(Throughput::Elements(1 << n_vars));
		group.bench_function(format!("n_vars={n_vars}"), |b| {
			let pool = BufferPool::new();
			let alloc = &pool;

			// A full reduction: k = n_vars, so the root fraction is a single scalar pair.
			let witness_num = random_field_buffer::<P>(&mut rng, n_vars);
			let witness_den = random_field_buffer::<P>(&mut rng, n_vars);
			let (prover, sums) = FracAddCheckProver::new(
				n_vars,
				&alloc,
				(
					FieldBuffer::clone_from_slice(&alloc, witness_num.to_ref()),
					FieldBuffer::clone_from_slice(&alloc, witness_den.to_ref()),
				),
			);

			// The root claim is over zero variables, so the empty point evaluates the root itself.
			let claim = (
				MultilinearEvalClaim {
					eval: evaluate(&sums.0, &[]),
					point: Vec::new(),
				},
				MultilinearEvalClaim {
					eval: evaluate(&sums.1, &[]),
					point: Vec::new(),
				},
			);
			let transcript = ProverTranscript::new(StdChallenger::default());

			b.iter_batched(
				// Proving folds the layers in place and consumes the prover, so clone both.
				|| (prover.clone(), claim.clone(), transcript.clone()),
				|(prover, claim, mut transcript)| prover.prove(claim, &mut transcript),
				BatchSize::SmallInput,
			);
		});
	}

	group.finish();
}

criterion_group!(frac_add_prove, bench_frac_add_prove);
criterion_main!(frac_add_prove);
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)