### PR TITLE
Drop the allocator generic from the round-evaluator traits

### DIFF
--- a/crates/ip-prover/src/fracaddcheck.rs
+++ b/crates/ip-prover/src/fracaddcheck.rs
@@ -36,7 +36,7 @@ pub type FracEvalClaim<F> = (MultilinearEvalClaim<F>, MultilinearEvalClaim<F>);
 /// self-contained: a caller can drive it, batch it, or extend its store with more columns and
 /// evaluators (as the logUp* final layer does).
 pub type LayerProver<'a, A, F, P> =
-	SharedMleCheckProver<'a, A, F, P, Box<dyn MleCheckRoundEvaluator<A, F, P> + 'a>>;
+	SharedMleCheckProver<'a, A, F, P, Box<dyn MleCheckRoundEvaluator<F, P> + 'a>>;
 
 /// A numerator/denominator pair of pooled column buffers.
 type PooledFractionalBuffer<A, P> = (FieldVec<P, A>, FieldVec<P, A>);
@@ -177,7 +177,6 @@ where
 	/// - `remaining` is `Some(self)` if there are more layers, `None` otherwise
 	/// - `layer_prover` is a sumcheck prover for the popped layer
 	/// - `cols` contains the [`MleStore`] column IDs `[num_0, num_1, den_0, den_1]`
-	#[allow(clippy::type_complexity)]
 	pub fn layer_prover(
 		mut self,
 		claim: FracEvalClaim<F>,
@@ -205,9 +204,9 @@ where
 		let [num_0, num_1] = store.push_split_half(num);
 		let [den_0, den_1] = store.push_split_half(den);
 		let cols = [num_0, num_1, den_0, den_1];
-		let (num_evaluator, den_evaluator) = frac_add_mle::evaluators::<A, F, P>(cols);
+		let (num_evaluator, den_evaluator) = frac_add_mle::evaluators::<F, P>(cols);
 
-		let claims_with_evaluators: [(F, Box<dyn MleCheckRoundEvaluator<A, F, P> + 'a>); 2] = [
+		let claims_with_evaluators: [(F, Box<dyn MleCheckRoundEvaluator<F, P> + 'a>); 2] = [
 			(num_claim.eval, Box::new(num_evaluator)),
 			(den_claim.eval, Box::new(den_evaluator)),
 		];
@@ -229,7 +228,6 @@ where
 	/// It must then drive the returned prover with a driver that does not sample another one.
 	/// The round polynomials and reduced column evaluations match [`Self::layer_prover`]'s.
 	/// So the transcript is unchanged.
-	#[allow(clippy::type_complexity)]
 	fn fused_layer_prover(
 		mut self,
 		claim: FracEvalClaim<F>,
@@ -258,7 +256,7 @@ where
 		let evaluator = FracAddFusedEvaluator::new([num_0, num_1, den_0, den_1], batch_coeff);
 
 		// One claim, batched the way the verifier batches the two it holds.
-		let claims_with_evaluators: [(F, Box<dyn MleCheckRoundEvaluator<A, F, P> + 'a>); 1] =
+		let claims_with_evaluators: [(F, Box<dyn MleCheckRoundEvaluator<F, P> + 'a>); 1] =
 			[(num_claim.eval + batch_coeff * den_claim.eval, Box::new(evaluator))];
 		(remaining, SharedMleCheckProver::new(store, claims_with_evaluators, num_claim.point))
 	}
@@ -575,7 +573,6 @@ fn combine_claims<F: Field>(coeffs: Vec<RoundCoeffs<F>>, batch_coeff: F) -> Roun
 /// The two (numerator, denominator) claims of every layer are batched via a single `batch_coeff`
 /// that the verifier's `batch_verify_mle` samples once per layer, before the round polynomials; the
 /// same coefficient is reused for the content and selector rounds.
-#[allow(clippy::type_complexity)]
 fn reduce_layer<'a, A, F, P, MP>(
 	alloc: &'a A,
 	mut layer_provers: Vec<MP>,
@@ -675,8 +672,8 @@ where
 		FieldBuffer::from_values_in(alloc, &den_1s),
 	]
 	.map(|buffer| selector_store.push_owned(buffer));
-	let (selector_num, selector_den) = frac_add_mle::evaluators::<A, F, P>(selector_cols);
-	let selector_claims_with_evaluators: [(F, Box<dyn MleCheckRoundEvaluator<A, F, P> + 'a>); 2] = [
+	let (selector_num, selector_den) = frac_add_mle::evaluators::<F, P>(selector_cols);
+	let selector_claims_with_evaluators: [(F, Box<dyn MleCheckRoundEvaluator<F, P> + 'a>); 2] = [
 		(num_eval, Box::new(selector_num)),
 		(den_eval, Box::new(selector_den)),
 	];

--- a/crates/ip-prover/src/logup_star/final_layer.rs
+++ b/crates/ip-prover/src/logup_star/final_layer.rs
@@ -143,9 +143,9 @@ where
 	let t_0_col = prover.push_owned_column(t_0);
 	let t_1_col = prover.push_owned_column(t_1);
 	let product_0 = BivariateProductEvaluator::new([y_0_col, t_0_col]);
-	prover.add_evaluator(e_0, Box::new(product_0) as Box<dyn SumcheckRoundEvaluator<A, F, P> + 'a>);
+	prover.add_evaluator(e_0, Box::new(product_0) as Box<dyn SumcheckRoundEvaluator<F, P> + 'a>);
 	let product_1 = BivariateProductEvaluator::new([y_1_col, t_1_col]);
-	prover.add_evaluator(e_1, Box::new(product_1) as Box<dyn SumcheckRoundEvaluator<A, F, P> + 'a>);
+	prover.add_evaluator(e_1, Box::new(product_1) as Box<dyn SumcheckRoundEvaluator<F, P> + 'a>);
 
 	// Drive the one shared-store sumcheck.
 	//

--- a/crates/ip-prover/src/sumcheck/bivariate_product_evaluator.rs
+++ b/crates/ip-prover/src/sumcheck/bivariate_product_evaluator.rs
@@ -7,7 +7,7 @@ use binius_math::FieldVec;
 use itertools::izip;
 
 use super::{
-	mle_store::{ColId, EvaluationChunk, MleStore},
+	mle_store::{ColId, EvaluationChunk, MleStore, RoundContext},
 	round_evals::WideRoundEvals2,
 	round_evaluator::{SharedSumcheckProver, SumcheckRoundEvaluator},
 };
@@ -53,7 +53,7 @@ pub fn bivariate_product_prover<'alloc, A: Allocator, F: Field, P: PackedField<S
 	SharedSumcheckProver::new(store, [(sum, BivariateProductEvaluator::new(cols))])
 }
 
-impl<A: Allocator, F: Field, P: PackedField<Scalar = F>> SumcheckRoundEvaluator<A, F, P>
+impl<F: Field, P: PackedField<Scalar = F>> SumcheckRoundEvaluator<F, P>
 	for BivariateProductEvaluator
 {
 	fn degree(&self) -> usize {
@@ -91,12 +91,12 @@ impl<A: Allocator, F: Field, P: PackedField<Scalar = F>> SumcheckRoundEvaluator<
 
 	fn interpolate(
 		&self,
-		store: &MleStore<'_, A, P>,
+		ctx: &RoundContext<'_, P>,
 		accum: &[<P as WideMul>::Output],
 		claim: F,
 	) -> RoundCoeffs<F> {
 		// The store has not yet folded this round, so its remaining-variable count is this round's.
-		let n_vars_remaining = store.n_vars();
+		let n_vars_remaining = ctx.n_vars();
 		assert!(n_vars_remaining > 0);
 
 		let evals = WideRoundEvals2 {

--- a/crates/ip-prover/src/sumcheck/frac_add_mle.rs
+++ b/crates/ip-prover/src/sumcheck/frac_add_mle.rs
@@ -1,12 +1,11 @@
 // Copyright 2025-2026 The Binius Developers
 
-use binius_compute::Allocator;
 use binius_field::{Field, PackedField, WideMul};
 use binius_ip::sumcheck::RoundCoeffs;
 use binius_math::FieldSlice;
 
 use crate::sumcheck::{
-	mle_store::{ColId, ColumnChunk, EvaluationChunk, MleStore},
+	mle_store::{ColId, ColumnChunk, EvaluationChunk, RoundContext},
 	quadratic_mle_evaluator::QuadraticMleEvaluator,
 	round_evals::RoundEvals2,
 	round_evaluator::MleCheckRoundEvaluator,
@@ -22,14 +21,10 @@ use crate::sumcheck::{
 /// that point's eq tracker and holds the two claimed evaluations, so the evaluators carry neither.
 ///
 /// [`SharedMleCheckProver`]: crate::sumcheck::round_evaluator::SharedMleCheckProver
-pub fn evaluators<A, F, P>(
+pub fn evaluators<F, P>(
 	cols: [ColId; 4],
-) -> (
-	impl MleCheckRoundEvaluator<A, F, P> + 'static,
-	impl MleCheckRoundEvaluator<A, F, P> + 'static,
-)
+) -> (impl MleCheckRoundEvaluator<F, P> + 'static, impl MleCheckRoundEvaluator<F, P> + 'static)
 where
-	A: Allocator,
 	F: Field,
 	P: PackedField<Scalar = F>,
 {
@@ -91,9 +86,8 @@ impl<F: Field> FracAddFusedEvaluator<F> {
 	}
 }
 
-impl<A, F, P> MleCheckRoundEvaluator<A, F, P> for FracAddFusedEvaluator<F>
+impl<F, P> MleCheckRoundEvaluator<F, P> for FracAddFusedEvaluator<F>
 where
-	A: Allocator,
 	F: Field,
 	P: PackedField<Scalar = F>,
 {
@@ -152,13 +146,13 @@ where
 
 	fn interpolate(
 		&self,
-		store: &MleStore<'_, A, P>,
+		ctx: &RoundContext<'_, P>,
 		accum: &[P],
 		claim: F,
 		alpha: F,
 	) -> RoundCoeffs<F> {
 		// The store has not yet folded this round, so its count is this round's.
-		let n_vars_remaining = store.n_vars();
+		let n_vars_remaining = ctx.n_vars();
 		assert!(n_vars_remaining > 0);
 
 		// Sum each claim's packed lanes into scalars.
@@ -235,7 +229,6 @@ mod tests {
 	}
 
 	#[test]
-	#[allow(clippy::type_complexity)]
 	fn fused_evaluator_matches_batched_split_evaluators() {
 		type F = OptimalB128;
 		type P = OptimalPackedB128;
@@ -258,8 +251,8 @@ mod tests {
 			let [s_num_a, s_num_b] = split_store.push_split_half(num_parent.clone());
 			let [s_den_a, s_den_b] = split_store.push_split_half(den_parent.clone());
 			let (num_evaluator, den_evaluator) =
-				evaluators::<GlobalAllocator, F, P>([s_num_a, s_num_b, s_den_a, s_den_b]);
-			let split_claims: [(F, Box<dyn MleCheckRoundEvaluator<GlobalAllocator, F, P>>); 2] = [
+				evaluators::<F, P>([s_num_a, s_num_b, s_den_a, s_den_b]);
+			let split_claims: [(F, Box<dyn MleCheckRoundEvaluator<F, P>>); 2] = [
 				(num_claim, Box::new(num_evaluator)),
 				(den_claim, Box::new(den_evaluator)),
 			];
@@ -392,7 +385,6 @@ mod tests {
 	}
 
 	#[test]
-	#[allow(clippy::type_complexity)]
 	fn test_frac_add_sumcheck() {
 		type F = OptimalB128;
 		type P = OptimalPackedB128;
@@ -434,8 +426,7 @@ mod tests {
 		// knows nothing of eq indicators, so the wrappers hold the tracker themselves).
 		let eq_tracker = store.register_eq_tracker(&eval_point);
 		// Wrap each MLE-check evaluator so it emits sumcheck-compatible round polynomials.
-		let claims_with_evaluators: [(F, Box<dyn SumcheckRoundEvaluator<GlobalAllocator, F, P>>);
-			2] = [
+		let claims_with_evaluators: [(F, Box<dyn SumcheckRoundEvaluator<F, P>>); 2] = [
 			(eval_claims[0], Box::new(MleToSumCheckEvaluator::new(num_evaluator, eq_tracker))),
 			(eval_claims[1], Box::new(MleToSumCheckEvaluator::new(den_evaluator, eq_tracker))),
 		];

--- a/crates/ip-prover/src/sumcheck/mle_store.rs
+++ b/crates/ip-prover/src/sumcheck/mle_store.rs
@@ -205,26 +205,14 @@ impl<'a, A: Allocator, F: Field, P: PackedField<Scalar = F>> MleStore<'a, A, P> 
 			.collect()
 	}
 
-	/// Returns the highest remaining coordinate of a registered eq tracker.
+	/// Returns the read-only view of the current round that the evaluators interpolate against.
 	///
-	/// This is the coordinate of the variable bound in the current round — the round's `alpha`. The
-	/// store pops one coordinate off each tracker as [`Self::fold`] advances, so this is always the
-	/// coordinate for the round about to run, and an evaluator reads it here instead of tracking
-	/// the point and remaining-variable count itself.
-	pub fn eq_alpha(&self, id: EqId) -> F {
-		self.eq_trackers[id.0].next_coordinate()
-	}
-
-	/// Returns the equality prefix of a registered eq tracker.
-	///
-	/// This is the product of the equality terms of all previously bound coordinates, which the
-	/// [Gruen24] technique multiplies into each round polynomial. The store maintains it on the
-	/// tracker across [`Self::fold`] calls, so an eq-weighted evaluator reads it here rather than
-	/// accumulating its own copy.
-	///
-	/// [Gruen24]: <https://eprint.iacr.org/2024/108>
-	pub fn eq_prefix(&self, id: EqId) -> F {
-		self.eq_trackers[id.0].eq_prefix_eval()
+	/// Valid until the next [`Self::fold`], which is when the values it exposes advance.
+	pub fn round_context(&self) -> RoundContext<'_, P> {
+		RoundContext {
+			n_vars: self.n_vars,
+			eq_trackers: &self.eq_trackers,
+		}
 	}
 
 	/// Folds every column and every eq tracker with a verifier challenge.
@@ -665,6 +653,39 @@ impl<'a, P: PackedField> PreFoldEvaluationChunk<'a, P> {
 			.map(|eq| FieldSlice::from_slice(n_vars, eq.fold_eq()))
 			.collect();
 		EvaluationChunk { n_vars, cols, eqs }
+	}
+}
+
+/// The scalar state of one round, as an evaluator may read it while interpolating.
+///
+/// Holds no columns and no allocator, so an evaluator is generic over neither.
+/// The store has not folded this round yet, so every value here is the current round's.
+pub struct RoundContext<'a, P: PackedField> {
+	n_vars: usize,
+	eq_trackers: &'a [Gruen32<P>],
+}
+
+impl<F: Field, P: PackedField<Scalar = F>> RoundContext<'_, P> {
+	/// Returns the number of variables not yet bound, this round's included.
+	pub const fn n_vars(&self) -> usize {
+		self.n_vars
+	}
+
+	/// Returns the coordinate of the variable this round binds, for a registered eq tracker.
+	///
+	/// This is the round's `alpha`: the highest coordinate of that tracker's point still unbound.
+	pub fn eq_alpha(&self, id: EqId) -> F {
+		self.eq_trackers[id.index()].next_coordinate()
+	}
+
+	/// Returns the equality prefix of a registered eq tracker.
+	///
+	/// This is the product of the equality terms over all coordinates bound so far.
+	/// The [Gruen24] technique multiplies it into each round polynomial.
+	///
+	/// [Gruen24]: <https://eprint.iacr.org/2024/108>
+	pub fn eq_prefix(&self, id: EqId) -> F {
+		self.eq_trackers[id.index()].eq_prefix_eval()
 	}
 }
 

--- a/crates/ip-prover/src/sumcheck/mle_to_sumcheck.rs
+++ b/crates/ip-prover/src/sumcheck/mle_to_sumcheck.rs
@@ -1,14 +1,13 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-use binius_compute::Allocator;
 use binius_field::{Field, PackedField, WideMul};
 use binius_ip::sumcheck::RoundCoeffs;
 use binius_math::multilinear::eq::eq_one_var;
 
 use crate::sumcheck::{
 	common::{MleCheckProver, SumcheckProver},
-	mle_store::{EqId, EvaluationChunk, MleStore},
+	mle_store::{EqId, EvaluationChunk, RoundContext},
 	round_evals::round_coeffs_by_eq,
 	round_evaluator::{MleCheckRoundEvaluator, SumcheckRoundEvaluator},
 };
@@ -124,12 +123,11 @@ impl<Inner> MleToSumCheckEvaluator<Inner> {
 	}
 }
 
-impl<A, F, P, Inner> SumcheckRoundEvaluator<A, F, P> for MleToSumCheckEvaluator<Inner>
+impl<F, P, Inner> SumcheckRoundEvaluator<F, P> for MleToSumCheckEvaluator<Inner>
 where
-	A: Allocator,
 	F: Field,
 	P: PackedField<Scalar = F>,
-	Inner: MleCheckRoundEvaluator<A, F, P>,
+	Inner: MleCheckRoundEvaluator<F, P>,
 {
 	fn degree(&self) -> usize {
 		// The eq factor multiplies the emitted round polynomial, not the accumulator: the wide
@@ -144,7 +142,7 @@ where
 
 	fn interpolate(
 		&self,
-		store: &MleStore<'_, A, P>,
+		ctx: &RoundContext<'_, P>,
 		accum: &[<P as WideMul>::Output],
 		claim: F,
 	) -> RoundCoeffs<F> {
@@ -155,8 +153,8 @@ where
 		//
 		// alpha and the equality prefix are read from the shared eq tracker (the store has not yet
 		// folded this round, so the tracker is at the current round's alpha and prefix).
-		let eq_prefix = store.eq_prefix(self.eq_tracker);
-		let alpha = store.eq_alpha(self.eq_tracker);
+		let eq_prefix = ctx.eq_prefix(self.eq_tracker);
+		let alpha = ctx.eq_alpha(self.eq_tracker);
 		let inner_claim = claim * eq_prefix.invert_or_zero();
 		// The inner MLE-check evaluator now takes a reduced accumulator; the plain sumcheck prover
 		// driving this wrapper leaves the wide accumulators unreduced, so reduce them here.
@@ -164,7 +162,7 @@ where
 			.iter()
 			.map(|slot| P::reduce(slot.clone()))
 			.collect::<Vec<_>>();
-		let round_coeffs = self.inner.interpolate(store, &reduced, inner_claim, alpha);
+		let round_coeffs = self.inner.interpolate(ctx, &reduced, inner_claim, alpha);
 
 		// Multiply the inner MLE-check round polynomial by (X - α) and the equality prefix.
 		round_coeffs_by_eq(&round_coeffs, alpha) * eq_prefix

--- a/crates/ip-prover/src/sumcheck/multilinear_eval.rs
+++ b/crates/ip-prover/src/sumcheck/multilinear_eval.rs
@@ -7,7 +7,7 @@ use binius_ip::sumcheck::RoundCoeffs;
 use binius_math::{FieldSlice, FieldVec};
 
 use super::{
-	mle_store::{ColId, EvaluationChunk, MleStore},
+	mle_store::{ColId, EvaluationChunk, MleStore, RoundContext},
 	round_evals::RoundEvals1,
 	round_evaluator::{MleCheckRoundEvaluator, SharedMleCheckProver},
 };
@@ -31,9 +31,8 @@ impl MultilinearEvalEvaluator {
 	}
 }
 
-impl<A, F, P> MleCheckRoundEvaluator<A, F, P> for MultilinearEvalEvaluator
+impl<F, P> MleCheckRoundEvaluator<F, P> for MultilinearEvalEvaluator
 where
-	A: Allocator,
 	F: Field,
 	P: PackedField<Scalar = F>,
 {
@@ -65,14 +64,14 @@ where
 
 	fn interpolate(
 		&self,
-		store: &MleStore<'_, A, P>,
+		ctx: &RoundContext<'_, P>,
 		accum: &[P],
 		claim: F,
 		alpha: F,
 	) -> RoundCoeffs<F> {
 		// The store has not folded this round yet.
 		// Its remaining-variable count is therefore this round's.
-		let n_vars_remaining = store.n_vars();
+		let n_vars_remaining = ctx.n_vars();
 		assert!(n_vars_remaining > 0);
 
 		// `accum` is already reduced by the prover's map pass.

--- a/crates/ip-prover/src/sumcheck/quadratic_mle_evaluator.rs
+++ b/crates/ip-prover/src/sumcheck/quadratic_mle_evaluator.rs
@@ -6,7 +6,7 @@ use binius_ip::sumcheck::RoundCoeffs;
 use binius_math::{FieldSlice, FieldVec};
 
 use super::{
-	mle_store::{ColId, ColumnChunk, EvaluationChunk, MleStore},
+	mle_store::{ColId, ColumnChunk, EvaluationChunk, MleStore, RoundContext},
 	round_evals::RoundEvals2,
 	round_evaluator::{MleCheckRoundEvaluator, SharedMleCheckProver},
 };
@@ -122,10 +122,9 @@ where
 	SharedMleCheckProver::new(store, [(eval_claim, evaluator)], eval_point)
 }
 
-impl<A, F, P, Composition, InfinityComposition, const N: usize> MleCheckRoundEvaluator<A, F, P>
+impl<F, P, Composition, InfinityComposition, const N: usize> MleCheckRoundEvaluator<F, P>
 	for QuadraticMleEvaluator<Composition, InfinityComposition, N>
 where
-	A: Allocator,
 	F: Field,
 	P: PackedField<Scalar = F>,
 	Composition: Fn([P; N]) -> P + Send + Sync,
@@ -177,13 +176,13 @@ where
 
 	fn interpolate(
 		&self,
-		store: &MleStore<'_, A, P>,
+		ctx: &RoundContext<'_, P>,
 		accum: &[P],
 		claim: F,
 		alpha: F,
 	) -> RoundCoeffs<F> {
 		// The store has not yet folded this round, so its remaining-variable count is this round's.
-		let n_vars_remaining = store.n_vars();
+		let n_vars_remaining = ctx.n_vars();
 		assert!(n_vars_remaining > 0);
 
 		// `accum` is already reduced (the prover's `map` pass reduced the wide accumulators). Sum

--- a/crates/ip-prover/src/sumcheck/round_evaluator.rs
+++ b/crates/ip-prover/src/sumcheck/round_evaluator.rs
@@ -31,7 +31,7 @@ use binius_math::{FieldSlice, FieldVec, multilinear::eq::eq_ind_partial_eval};
 use super::{
 	MleToSumCheckEvaluator,
 	common::{MleCheckProver, SumcheckProver},
-	mle_store::{ColId, EvaluationChunk, MleStore},
+	mle_store::{ColId, EvaluationChunk, MleStore, RoundContext},
 	round_state::RoundState,
 };
 
@@ -59,9 +59,7 @@ use super::{
 /// evaluators can drive a shared prover as `Vec<Box<dyn SumcheckRoundEvaluator<F, P>>>` while a
 /// homogeneous group avoids boxing.
 #[auto_impl(Box)]
-pub trait SumcheckRoundEvaluator<A: Allocator, F: Field, P: PackedField<Scalar = F>>:
-	Send + Sync
-{
+pub trait SumcheckRoundEvaluator<F: Field, P: PackedField<Scalar = F>>: Send + Sync {
 	/// The number of accumulator slots this evaluator's claim uses.
 	///
 	/// This is the count of sampled round-polynomial evaluations the accumulation pass collects;
@@ -84,12 +82,12 @@ pub trait SumcheckRoundEvaluator<A: Allocator, F: Field, P: PackedField<Scalar =
 	/// round claim.
 	///
 	/// `accum` is this evaluator's run of [`Self::degree`] slots, summed across all workers, and
-	/// `claim` is the prover's round claim for this evaluator. Reads the shared `store` for the
-	/// round's point coordinates; the store has not yet folded this round, so `store.n_vars()` and
-	/// the eq trackers are at the current round's state.
+	/// `claim` is the prover's round claim for this evaluator. `ctx` carries the round's scalar
+	/// state: the remaining-variable count and, for an eq-weighted evaluator, its tracker's
+	/// coordinate and equality prefix.
 	fn interpolate(
 		&self,
-		store: &MleStore<'_, A, P>,
+		ctx: &RoundContext<'_, P>,
 		accum: &[<P as WideMul>::Output],
 		claim: F,
 	) -> RoundCoeffs<F>;
@@ -109,9 +107,7 @@ pub trait SumcheckRoundEvaluator<A: Allocator, F: Field, P: PackedField<Scalar =
 /// [`SumcheckRoundEvaluator`]: stateless across rounds, degree-sized accumulator slots owned by the
 /// prover, one virtual [`Self::accumulate`] entry per chunk.
 #[auto_impl(Box)]
-pub trait MleCheckRoundEvaluator<A: Allocator, F: Field, P: PackedField<Scalar = F>>:
-	Send + Sync
-{
+pub trait MleCheckRoundEvaluator<F: Field, P: PackedField<Scalar = F>>: Send + Sync {
 	/// The number of accumulator slots this evaluator's claim uses. See
 	/// [`SumcheckRoundEvaluator::degree`].
 	fn degree(&self) -> usize;
@@ -132,13 +128,13 @@ pub trait MleCheckRoundEvaluator<A: Allocator, F: Field, P: PackedField<Scalar =
 	/// coordinate `alpha`.
 	///
 	/// As [`SumcheckRoundEvaluator::interpolate`], but the round coordinate is passed in as `alpha`
-	/// rather than read from a stored eq tracker; `store` supplies only the remaining-variable
-	/// count. Unlike the sumcheck trait, `accum` is already reduced to `P` — the driving
+	/// rather than read from a tracker; `ctx` supplies only the remaining-variable count. Unlike
+	/// the sumcheck trait, `accum` is already reduced to `P` — the driving
 	/// [`SharedMleCheckProver`] reduces the wide accumulators in its `map` pass so the eq-weighted
 	/// `reduce` can operate on `P`.
 	fn interpolate(
 		&self,
-		store: &MleStore<'_, A, P>,
+		ctx: &RoundContext<'_, P>,
 		accum: &[P],
 		claim: F,
 		alpha: F,
@@ -195,7 +191,7 @@ where
 	A: Allocator,
 	F: Field,
 	P: PackedField<Scalar = F>,
-	Evaluator: SumcheckRoundEvaluator<A, F, P>,
+	Evaluator: SumcheckRoundEvaluator<F, P>,
 {
 	/// Creates a prover from a store and the evaluators reading its columns, each paired with its
 	/// initial claim — one `(claim, evaluator)` per claim.
@@ -247,7 +243,7 @@ where
 	A: Allocator,
 	F: Field,
 	P: PackedField<Scalar = F>,
-	Evaluator: SumcheckRoundEvaluator<A, F, P>,
+	Evaluator: SumcheckRoundEvaluator<F, P>,
 {
 	fn n_vars(&self) -> usize {
 		// A buffered challenge is a fold that has not yet reached the store, so the logical
@@ -319,15 +315,15 @@ where
 			None => store.map_reduce(chunk_vars, map, reduce),
 		};
 
-		// The store is read (immutably) for the round's point coordinates. Each evaluator takes its
-		// current round claim (held in `round_states`) and produces its round polynomial; the
-		// prover then records those coefficients as the round state for the coming fold.
-		let store = &self.store;
+		// Each evaluator takes its current round claim (held in `round_states`) and produces its
+		// round polynomial against this round's view of the store; the prover then records those
+		// coefficients as the round state for the coming fold.
+		let ctx = self.store.round_context();
 		let round_coeffs: Vec<RoundCoeffs<F>> =
 			iter::zip(iter::zip(&self.evaluators, &self.round_states), offsets.windows(2))
 				.map(|((evaluator, state), window)| {
 					let claim = *state.claim();
-					evaluator.interpolate(store, &accum[window[0]..window[1]], claim)
+					evaluator.interpolate(&ctx, &accum[window[0]..window[1]], claim)
 				})
 				.collect();
 		for (state, coeffs) in iter::zip(&mut self.round_states, &round_coeffs) {
@@ -391,7 +387,7 @@ where
 	A: Allocator,
 	F: Field,
 	P: PackedField<Scalar = F>,
-	Evaluator: MleCheckRoundEvaluator<A, F, P>,
+	Evaluator: MleCheckRoundEvaluator<F, P>,
 {
 	/// Creates a prover from a store, the evaluators reading its columns each paired with its
 	/// initial claim — one `(claim, evaluator)` per claim — and the evaluation point shared by all
@@ -432,7 +428,7 @@ where
 	/// [Gruen24]: <https://eprint.iacr.org/2024/108>
 	pub fn into_shared_sumcheck(
 		self,
-	) -> SharedSumcheckProver<'a, A, P, Box<dyn SumcheckRoundEvaluator<A, F, P> + 'a>>
+	) -> SharedSumcheckProver<'a, A, P, Box<dyn SumcheckRoundEvaluator<F, P> + 'a>>
 	where
 		Evaluator: 'a,
 	{
@@ -456,7 +452,7 @@ where
 			.into_iter()
 			.map(|evaluator| {
 				Box::new(MleToSumCheckEvaluator::new(evaluator, eq_tracker))
-					as Box<dyn SumcheckRoundEvaluator<A, F, P> + 'a>
+					as Box<dyn SumcheckRoundEvaluator<F, P> + 'a>
 			})
 			.collect();
 		SharedSumcheckProver {
@@ -473,7 +469,7 @@ where
 	A: Allocator,
 	F: Field,
 	P: PackedField<Scalar = F>,
-	Evaluator: MleCheckRoundEvaluator<A, F, P>,
+	Evaluator: MleCheckRoundEvaluator<F, P>,
 {
 	fn n_vars(&self) -> usize {
 		// A buffered challenge is a fold that has not yet reached the store, so the logical
@@ -553,12 +549,12 @@ where
 		// Each evaluator interpolates its prime round polynomial from its (reduced) accumulator,
 		// its claim, and the round coordinate; the prover then records the coefficients for the
 		// fold.
-		let store = &self.store;
+		let ctx = self.store.round_context();
 		let round_coeffs: Vec<RoundCoeffs<F>> =
 			iter::zip(iter::zip(&self.evaluators, &self.round_states), offsets.windows(2))
 				.map(|((evaluator, state), window)| {
 					let claim = *state.claim();
-					evaluator.interpolate(store, &accum[window[0]..window[1]], claim, alpha)
+					evaluator.interpolate(&ctx, &accum[window[0]..window[1]], claim, alpha)
 				})
 				.collect();
 		for (state, coeffs) in iter::zip(&mut self.round_states, &round_coeffs) {
@@ -594,7 +590,7 @@ where
 	A: Allocator,
 	F: Field,
 	P: PackedField<Scalar = F>,
-	Evaluator: MleCheckRoundEvaluator<A, F, P>,
+	Evaluator: MleCheckRoundEvaluator<F, P>,
 {
 	fn eval_point(&self) -> &[F] {
 		&self.eval_point[..self.n_vars()]
@@ -681,24 +677,17 @@ mod tests {
 
 	// The store + evaluator MLE-check prover for the two fractional-addition claims, borrowing the
 	// four shared columns.
-	#[allow(clippy::type_complexity)]
 	fn new_frac_prover<'a>(
 		alloc: &'a GlobalAllocator,
 		cols: &'a [FieldBuffer<P>; 4],
 		eval_point: &[F],
 		claims: [F; 2],
-	) -> SharedMleCheckProver<
-		'a,
-		GlobalAllocator,
-		F,
-		P,
-		Box<dyn MleCheckRoundEvaluator<GlobalAllocator, F, P>>,
-	> {
+	) -> SharedMleCheckProver<'a, GlobalAllocator, F, P, Box<dyn MleCheckRoundEvaluator<F, P>>> {
 		let mut store = MleStore::new(eval_point.len(), alloc);
 		let col_ids = cols.each_ref().map(|col| store.push(col.to_ref()));
 		let (num_ev, den_ev) = frac_add_mle::evaluators(col_ids);
-		let claims_with_evaluators: [(F, Box<dyn MleCheckRoundEvaluator<GlobalAllocator, F, P>>);
-			2] = [(claims[0], Box::new(num_ev)), (claims[1], Box::new(den_ev))];
+		let claims_with_evaluators: [(F, Box<dyn MleCheckRoundEvaluator<F, P>>); 2] =
+			[(claims[0], Box::new(num_ev)), (claims[1], Box::new(den_ev))];
 		SharedMleCheckProver::new(store, claims_with_evaluators, eval_point.to_vec())
 	}
 
@@ -759,7 +748,6 @@ mod tests {
 	// two plain product claims, all sharing the pushforward halves in one store. Prove through the
 	// sumcheck batch driver, then verify the reduced evaluation against the batched compositions.
 	#[test]
-	#[allow(clippy::type_complexity)]
 	fn test_shared_final_layer_prove_verify() {
 		for m in [1, 2, 3, 6] {
 			let mut rng = StdRng::seed_from_u64(0);
@@ -811,10 +799,7 @@ mod tests {
 
 			// Claims paired with evaluators in order: the two fractional claims, then the two
 			// product sums.
-			let claims_with_evaluators: [(
-				F,
-				Box<dyn SumcheckRoundEvaluator<GlobalAllocator, F, P>>,
-			); 4] = [
+			let claims_with_evaluators: [(F, Box<dyn SumcheckRoundEvaluator<F, P>>); 4] = [
 				(frac_claims[0], Box::new(num_evaluator)),
 				(frac_claims[1], Box::new(den_evaluator)),
 				(e_0, Box::new(product_0)),

--- a/crates/m4-prover/src/prove.rs
+++ b/crates/m4-prover/src/prove.rs
@@ -516,7 +516,7 @@ impl<'a, const ARITY: usize> Operation<'a, ARITY> {
 		&self,
 		lagrange: &[B128],
 		store: &mut MleStore<'alloc, A, P>,
-		evaluators: &mut Vec<Box<dyn SumcheckRoundEvaluator<A, B128, P> + 'alloc>>,
+		evaluators: &mut Vec<Box<dyn SumcheckRoundEvaluator<B128, P> + 'alloc>>,
 		claims: &mut Vec<B128>,
 		alloc: &'alloc A,
 	) where
@@ -678,7 +678,7 @@ impl RerandomizedOperations<'_> {
 		// [BitAnd a, b, c | IntMul a, b, lo, hi | BinMul a_lo, a_hi, b_lo, b_hi, c_lo, c_hi].
 		// The verifier reads the reduced evaluations back in the same order.
 		let mut store = MleStore::<A, P>::new(log_instances, alloc);
-		let mut evaluators: Vec<Box<dyn SumcheckRoundEvaluator<A, B128, P> + 'alloc>> =
+		let mut evaluators: Vec<Box<dyn SumcheckRoundEvaluator<B128, P> + 'alloc>> =
 			Vec::with_capacity(BITAND_ARITY + INTMUL_ARITY + BINMUL_ARITY);
 		let mut claims: Vec<B128> = Vec::with_capacity(BITAND_ARITY + INTMUL_ARITY + BINMUL_ARITY);
 		self.bitand

--- a/crates/prover/benches/batch_quadratic_mle.rs
+++ b/crates/prover/benches/batch_quadratic_mle.rs
@@ -96,7 +96,6 @@ where
 	prover.finish()
 }
 
-#[allow(clippy::type_complexity)]
 fn bench_batch_quadratic_mlecheck_prove(c: &mut Criterion) {
 	let mut group = c.benchmark_group("mlecheck/batch_quadratic");
 	let mut rng = StdRng::seed_from_u64(0);
@@ -133,10 +132,8 @@ fn bench_batch_quadratic_mlecheck_prove(c: &mut Criterion) {
 						QuadraticMleEvaluator::new(cols, comp_0::<P>, comp_0_inf::<P>);
 					let evaluator_1 =
 						QuadraticMleEvaluator::new(cols, comp_1::<P>, comp_1_inf::<P>);
-					let claims_with_evaluators: [(
-						F,
-						Box<dyn MleCheckRoundEvaluator<&BufferPool, F, P> + '_>,
-					); 2] = [
+					let claims_with_evaluators: [(F, Box<dyn MleCheckRoundEvaluator<F, P> + '_>);
+						2] = [
 						(eval_claims[0], Box::new(evaluator_0)),
 						(eval_claims[1], Box::new(evaluator_1)),
 					];


### PR DESCRIPTION
Removes a generic parameter that no implementor uses. Pure refactor — no behavior change, no transcript change.

### The problem

Both round-evaluator traits carry an allocator parameter:

```rust
pub trait SumcheckRoundEvaluator<A: Allocator, F: Field, P: PackedField<Scalar = F>>: Send + Sync
pub trait MleCheckRoundEvaluator <A: Allocator, F: Field, P: PackedField<Scalar = F>>: Send + Sync
```

No evaluator uses `A` for anything. It is there for one reason: the interpolation step takes `&MleStore<'_, A, P>`, and the store is generic over the allocator its columns are drawn from.

The cost is paid at every mention of an evaluator:

- `frac_add_mle::evaluators<A, F, P>` is generic over an `A` that appears nowhere in its body — it exists only to satisfy the return-type bound.
- Every boxed evaluator has to name the allocator: `Box<dyn SumcheckRoundEvaluator<GlobalAllocator, F, P>>` in the tests, `<A, B128, P>` in `m4-prover`, `<&BufferPool, F, P>` in a bench.
- Those long types tripped `clippy::type_complexity` in nine places, each silenced with an `allow`.

### The idea

Look at what the five implementors actually read from the store while interpolating:

| implementor | reads |
|---|---|
| bivariate product | remaining-variable count |
| quadratic | remaining-variable count |
| multilinear evaluation | remaining-variable count |
| fused fractional addition | remaining-variable count |
| MLE-to-sumcheck wrapper | its eq tracker's coordinate and equality prefix |

Three methods, none of which allocates or touches a column. So the interpolation step takes a view of the round rather than the store:

```rust
/// The scalar state of one round, as an evaluator may read it while interpolating.
///
/// Holds no columns and no allocator, so an evaluator is generic over neither.
/// The store has not folded this round yet, so every value here is the current round's.
pub struct RoundContext<'a, P: PackedField> {
    n_vars: usize,
    eq_trackers: &'a [Gruen32<P>],
}
```

exposing `n_vars()`, `eq_alpha(EqId)`, and `eq_prefix(EqId)`, and built by `MleStore::round_context()`.

The view borrows the trackers rather than copying out scalars, so it costs nothing per round. It is parameterised by the packed type, not the scalar, for that reason: the coordinate and prefix are computed from tracker state, so a scalar-parameterised view would have meant materialising two vectors every round.

### It also closes a foot-gun

Interpolation previously received the whole store. An evaluator could call `store.column_slices()` there and read the columns — which at that point have **not** been folded for the round being interpolated. That would compile and silently produce a wrong round polynomial.

The view exposes no columns, so it is no longer expressible.

### The change

```diff
- fn interpolate(&self, store: &MleStore<'_, A, P>, accum: &[..], claim: F) -> RoundCoeffs<F>
+ fn interpolate(&self, ctx: &RoundContext<'_, P>,  accum: &[..], claim: F) -> RoundCoeffs<F>
```

| | before | after |
|---|---|---|
| trait parameters | `<A: Allocator, F, P>` | `<F, P>` |
| boxed evaluator | `Box<dyn SumcheckRoundEvaluator<GlobalAllocator, F, P>>` | `Box<dyn SumcheckRoundEvaluator<F, P>>` |
| `frac_add_mle::evaluators` | `<A, F, P>` | `<F, P>` |
| `clippy::type_complexity` allows | 9 | 1 |

I removed all nine allows, ran clippy, and restored only the one it still asks for: `batch_prove_layer`'s three-tuple return, which is unrelated to this change.

Two store methods became dead once the wrapper reads its eq state from the view — `eq_alpha` and `eq_prefix` had exactly one caller each — so they are removed rather than left unreferenced.

### Scope

- **changed:** both traits, all five evaluator implementations, the two shared provers' call sites, and the boxed-evaluator spellings in `fracaddcheck.rs`, `logup_star/final_layer.rs`, `m4-prover`, and one bench.
- **unchanged:** the provers still carry the allocator, since they own the store. Every public constructor keeps its signature. No accumulation loop is touched.
- 108 insertions, 121 deletions across 11 files.

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy` over the touched crates, `--all-targets --all-features` — clean
- `cargo nextest run --workspace` — 1416 passed, 0 failed, 4 skipped
- `RUSTDOCFLAGS="-D warnings" cargo doc -p binius-ip-prover --no-deps` — clean
- `cargo +nightly fmt --all --check` — clean

Entirely type-level, so no benchmark: the accumulation and interpolation bodies are untouched, and the view is a borrow rather than a copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)