### PR TITLE
Give both round-evaluator traits one accumulator element type

### DIFF
--- a/crates/ip-prover/src/sumcheck/bivariate_product_evaluator.rs
+++ b/crates/ip-prover/src/sumcheck/bivariate_product_evaluator.rs
@@ -8,7 +8,7 @@ use itertools::izip;
 
 use super::{
 	mle_store::{ColId, EvaluationChunk, MleStore, RoundContext},
-	round_evals::WideRoundEvals2,
+	round_evals::{RoundEvals2, WideRoundEvals2},
 	round_evaluator::{SharedSumcheckProver, SumcheckRoundEvaluator},
 };
 
@@ -89,25 +89,19 @@ impl<F: Field, P: PackedField<Scalar = F>> SumcheckRoundEvaluator<F, P>
 		accum[1] += evals.y_inf;
 	}
 
-	fn interpolate(
-		&self,
-		ctx: &RoundContext<'_, P>,
-		accum: &[<P as WideMul>::Output],
-		claim: F,
-	) -> RoundCoeffs<F> {
+	fn interpolate(&self, ctx: &RoundContext<'_, P>, accum: &[P], claim: F) -> RoundCoeffs<F> {
 		// The store has not yet folded this round, so its remaining-variable count is this round's.
 		let n_vars_remaining = ctx.n_vars();
 		assert!(n_vars_remaining > 0);
 
-		let evals = WideRoundEvals2 {
-			y_1: accum[0].clone(),
-			y_inf: accum[1].clone(),
-		};
-		// `claim` is this round's sum; recover the missing evaluation at 0 from it.
-		evals
-			.reduce::<P>()
-			.sum_scalars(n_vars_remaining)
-			.interpolate(claim)
+		// `claim` is this round's sum.
+		// The evaluation at 0, which was never sampled, is recovered from it.
+		RoundEvals2 {
+			y_1: accum[0],
+			y_inf: accum[1],
+		}
+		.sum_scalars(n_vars_remaining)
+		.interpolate(claim)
 	}
 }
 

--- a/crates/ip-prover/src/sumcheck/mle_to_sumcheck.rs
+++ b/crates/ip-prover/src/sumcheck/mle_to_sumcheck.rs
@@ -140,12 +140,7 @@ where
 			.accumulate(chunk, chunk.eq(self.eq_tracker).to_ref(), accum)
 	}
 
-	fn interpolate(
-		&self,
-		ctx: &RoundContext<'_, P>,
-		accum: &[<P as WideMul>::Output],
-		claim: F,
-	) -> RoundCoeffs<F> {
+	fn interpolate(&self, ctx: &RoundContext<'_, P>, accum: &[P], claim: F) -> RoundCoeffs<F> {
 		// `claim` is the sumcheck round claim: the inner MLE-check claim `m` scaled by the
 		// accumulated equality prefix. Recover `m` for the inner evaluator by dividing the prefix
 		// back out. (`invert_or_zero` mirrors the interpolation routines; the prefix is a product
@@ -156,13 +151,8 @@ where
 		let eq_prefix = ctx.eq_prefix(self.eq_tracker);
 		let alpha = ctx.eq_alpha(self.eq_tracker);
 		let inner_claim = claim * eq_prefix.invert_or_zero();
-		// The inner MLE-check evaluator now takes a reduced accumulator; the plain sumcheck prover
-		// driving this wrapper leaves the wide accumulators unreduced, so reduce them here.
-		let reduced = accum
-			.iter()
-			.map(|slot| P::reduce(slot.clone()))
-			.collect::<Vec<_>>();
-		let round_coeffs = self.inner.interpolate(ctx, &reduced, inner_claim, alpha);
+		// The inner evaluator interpolates its prime polynomial from the same reduced slots.
+		let round_coeffs = self.inner.interpolate(ctx, accum, inner_claim, alpha);
 
 		// Multiply the inner MLE-check round polynomial by (X - α) and the equality prefix.
 		round_coeffs_by_eq(&round_coeffs, alpha) * eq_prefix

--- a/crates/ip-prover/src/sumcheck/round_evaluator.rs
+++ b/crates/ip-prover/src/sumcheck/round_evaluator.rs
@@ -44,11 +44,14 @@ use super::{
 /// The driving prover, not the evaluator, holds the round claim and reduces the round polynomial
 /// against the verifier challenge.
 ///
-/// The accumulator is a flat slice of [`Self::degree`] wide (unreduced)
-/// [`WideMul::Output`](WideMul::Output) slots. The driving prover owns the buffer, sizes it from
-/// [`Self::degree`], and sums the workers' slices slot-wise, so evaluators implement neither
-/// allocation nor merging — only the write pass and the interpolation. The slot layout within an
-/// evaluator's run is private to that evaluator.
+/// The driving prover owns the accumulator and sizes it from the degree.
+/// - Accumulation writes wide, unreduced slots, so a per-chunk sum costs no reduction.
+/// - The prover sums the workers' slices slot-wise, then reduces once per round.
+/// - Interpolation reads the reduced slots.
+///
+/// An evaluator implements neither the allocation nor the merging.
+/// It only writes its own slots and interpolates them.
+/// The slot layout within one evaluator's run is private to it.
 ///
 /// Evaluators are stateless across rounds: they hold no round claim and never fold. The prover
 /// passes the round claim into [`Self::interpolate`] and recovers it back out of the emitted round
@@ -78,34 +81,30 @@ pub trait SumcheckRoundEvaluator<F: Field, P: PackedField<Scalar = F>>: Send + S
 	/// on the first chunk and carried across the worker's chunks.
 	fn accumulate(&self, chunk: &EvaluationChunk<'_, P>, accum: &mut [<P as WideMul>::Output]);
 
-	/// Interpolates this round's polynomial from the slot-wise summed accumulator slice and the
-	/// round claim.
+	/// Interpolates this round's polynomial from the accumulator and the round claim.
 	///
-	/// `accum` is this evaluator's run of [`Self::degree`] slots, summed across all workers, and
-	/// `claim` is the prover's round claim for this evaluator. `ctx` carries the round's scalar
-	/// state: the remaining-variable count and, for an eq-weighted evaluator, its tracker's
-	/// coordinate and equality prefix.
-	fn interpolate(
-		&self,
-		ctx: &RoundContext<'_, P>,
-		accum: &[<P as WideMul>::Output],
-		claim: F,
-	) -> RoundCoeffs<F>;
+	/// # Arguments
+	///
+	/// * `ctx` - This round's scalar state: the unbound-variable count, and a registered tracker's
+	///   equality coordinate and prefix.
+	/// * `accum` - This evaluator's slots, summed across every worker and reduced.
+	/// * `claim` - This evaluator's round claim.
+	fn interpolate(&self, ctx: &RoundContext<'_, P>, accum: &[P], claim: F) -> RoundCoeffs<F>;
 }
 
 /// Per-round-polynomial logic for one MLE-check claim over store columns.
 ///
-/// This is the MLE-check counterpart of [`SumcheckRoundEvaluator`], emitting the prime
-/// (eq-factored) round polynomials of the MLE-check protocol. It differs in two ways, both because
-/// every claim of a [`SharedMleCheckProver`] shares one evaluation point whose eq-indicator tracker
-/// the prover — not the evaluator — owns:
-/// - [`Self::accumulate`] receives the round's eq-indicator chunk `eq_ind` as a separate argument,
-///   rather than the evaluator looking it up on the chunk by a stored tracker id.
-/// - [`Self::interpolate`] receives the round's eq coordinate `alpha`.
+/// This is the MLE-check counterpart of [`SumcheckRoundEvaluator`].
+/// It emits the prime, equality-factored round polynomials of the MLE-check protocol.
 ///
-/// So the evaluator stores no eq tracker id and holds no copy of the point. Everything else matches
-/// [`SumcheckRoundEvaluator`]: stateless across rounds, degree-sized accumulator slots owned by the
-/// prover, one virtual [`Self::accumulate`] entry per chunk.
+/// Every claim of one such prover shares a single evaluation point.
+/// The prover, not the evaluator, owns that point's equality indicator.
+/// Two arguments follow from that:
+/// - Accumulation receives the round's equality-indicator chunk.
+/// - Interpolation receives the round's equality coordinate.
+///
+/// So the evaluator stores no tracker identifier and no copy of the point.
+/// The accumulator contract is the one above: wide slots in, reduced slots out.
 #[auto_impl(Box)]
 pub trait MleCheckRoundEvaluator<F: Field, P: PackedField<Scalar = F>>: Send + Sync {
 	/// The number of accumulator slots this evaluator's claim uses. See
@@ -124,14 +123,11 @@ pub trait MleCheckRoundEvaluator<F: Field, P: PackedField<Scalar = F>>: Send + S
 		accum: &mut [<P as WideMul>::Output],
 	);
 
-	/// Interpolates this round's prime polynomial from the accumulator, round claim, and round
-	/// coordinate `alpha`.
+	/// Interpolates this round's prime polynomial from the accumulator and the round claim.
 	///
-	/// As [`SumcheckRoundEvaluator::interpolate`], but the round coordinate is passed in as `alpha`
-	/// rather than read from a tracker; `ctx` supplies only the remaining-variable count. Unlike
-	/// the sumcheck trait, `accum` is already reduced to `P` — the driving
-	/// [`SharedMleCheckProver`] reduces the wide accumulators in its `map` pass so the eq-weighted
-	/// `reduce` can operate on `P`.
+	/// As [`SumcheckRoundEvaluator::interpolate`], with one difference.
+	/// The round's equality coordinate arrives as an argument rather than from a tracker.
+	/// So `ctx` supplies only the unbound-variable count.
 	fn interpolate(
 		&self,
 		ctx: &RoundContext<'_, P>,
@@ -348,6 +344,10 @@ where
 			Some(challenge) => store.map_reduce_with_fold(chunk_vars, challenge, map, reduce),
 			None => store.map_reduce(chunk_vars, map, reduce),
 		};
+
+		// The workers' wide sums are complete, so every slot is reduced once for the whole round.
+		// Interpolation runs on reduced values.
+		let accum = accum.into_iter().map(P::reduce).collect::<Vec<P>>();
 
 		// Each evaluator takes its current round claim (held in `round_states`) and produces its
 		// round polynomial against this round's view of the store; the prover then records those


### PR DESCRIPTION
Puts the "who reduces, and when" decision in one place per prover instead of in prose on two traits. Pure refactor — bit-identical output, same reduction count, hot loop untouched.

### The problem

The two round-evaluator traits disagreed on what their interpolation step receives:

```rust
// sumcheck
fn interpolate(&self, ctx: &RoundContext<'_, P>, accum: &[<P as WideMul>::Output], claim: F) -> ..
// MLE-check
fn interpolate(&self, ctx: &RoundContext<'_, P>, accum: &[P],                     claim: F, alpha: F) -> ..
```

One takes unreduced wide slots and reduces them itself. The other takes slots its driving prover already reduced. Nothing in the types says which, so the contract lived in a doc comment on each trait — including the sentence "Unlike the sumcheck trait, `accum` is already reduced to `P`".

The visible cost was in the wrapper that adapts an MLE-check evaluator to the sumcheck trait. It sat on the boundary, so every round it had to convert:

```rust
let reduced = accum.iter().map(|slot| P::reduce(slot.clone())).collect::<Vec<_>>();
let round_coeffs = self.inner.interpolate(ctx, &reduced, inner_claim, alpha);
```

A heap allocation and a copy per round per evaluator, existing only because two traits disagreed on an element type.

### Which direction the unification has to go

The MLE-check prover has no choice. Its reduction step is

```
lo += z * (hi - lo)
```

a field multiply, which is only defined on reduced values. So it must reduce inside its mapping pass, and by the time interpolation runs its accumulator is already reduced. Wide slots in the MLE-check interpolation step are not reachable.

The sumcheck prover merges slots by addition, which on these values is a XOR and needs no reduction. So it can carry wide slots through the whole parallel pass and reduce once at the end.

Both interpolation steps therefore take reduced slots, and each prover reduces in exactly one place.

### The change

```diff
  // SharedSumcheckProver::execute, after the parallel pass
+ // The workers' wide sums are complete, so every slot is reduced once for the whole round.
+ // Interpolation runs on reduced values.
+ let accum = accum.into_iter().map(P::reduce).collect::<Vec<P>>();
```

```diff
  // the wrapper
- let reduced = accum.iter().map(|slot| P::reduce(slot.clone())).collect::<Vec<_>>();
- let round_coeffs = self.inner.interpolate(ctx, &reduced, inner_claim, alpha);
+ let round_coeffs = self.inner.interpolate(ctx, accum, inner_claim, alpha);
```

The bivariate-product evaluator drops its internal reduction and becomes structurally identical to the quadratic one:

```rust
RoundEvals2 { y_1: accum[0], y_inf: accum[1] }
    .sum_scalars(n_vars_remaining)
    .interpolate(claim)
```

### Why this is not a performance change

**The reduction count per round is identical.** Before, each sumcheck evaluator reduced its own `degree` slots inside interpolation, summing to the group's total slot count. Now the prover reduces that same total once. Same slots, same number of calls, different caller.

**The hot loop is untouched.** Only the interpolation signatures changed. Interpolation runs once per round per evaluator, so `O(n_vars)` times per proof rather than once per hypercube element. No accumulation body is modified — the diff contains no change to any accumulation line.

**Allocation is a wash, not a win.** Groups with an eq-wrapped evaluator lose one `Vec` per wrapped evaluator per round. Groups without one gain a single `Vec` per round, since the bivariate-product evaluator previously reduced a stack local. At 20 variables that is about 20 allocations against roughly a thousand for the whole proof, on a path well under 1% of run time.

### The traits stay separate

Their accumulation steps still differ, and that difference is structural rather than incidental:

| | sumcheck prover | MLE-check prover |
|---|---|---|
| equality indicator source | expansion registered on the store | prefix expanded per round |
| per chunk | a different slice at each leaf | the same slice at every leaf |
| scope | per evaluator, by tracker identifier | one per round, shared by all |
| higher coordinates | inside the expansion | folded through the reduction step |

The MLE-check prover expands only a low-coordinate prefix and folds the rest through its weighted reduction, which is what keeps it from ever materialising the full equality tensor. Collapsing both into one accumulation signature would mean giving that up, or passing an argument that is statically absent in one prover and present in the other, with an unwrap in the hot loop.

So this change fixes the difference that carried a real cost and leaves the one that pays for itself, now stated on the trait rather than only in prose.

### Scope

- **changed:** both trait definitions, the sumcheck prover's round pass, the bivariate-product evaluator, and the MLE-to-sumcheck wrapper.
- **unchanged:** every accumulation body, both provers' folding and parallel decomposition, all public constructors, the MLE-check prover's mapping and reduction closures.
- 47 insertions, 63 deletions across 3 files.

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-ip-prover --all-targets --all-features` — clean
- `cargo nextest run -p binius-ip-prover` — 59 passed, 0 failed, covering the prove/verify roundtrips for every evaluator and both batch drivers
- `RUSTDOCFLAGS="-D warnings" cargo doc -p binius-ip-prover --no-deps` — clean
- `cargo +nightly fmt --all --check` — clean

No benchmark, because no benchmarked code path changed: the accumulation loops are byte-identical and the reduction count is the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)