### PR TITLE
Fold a column half and an eq expansion through one routine

### DIFF
--- a/crates/ip-prover/src/sumcheck/mle_store.rs
+++ b/crates/ip-prover/src/sumcheck/mle_store.rs
@@ -538,45 +538,39 @@ impl<'a, P: PackedField> PreFoldColumnChunk<'a, P> {
 		}
 	}
 
-	/// Folds the segments and returns the folded output slice.
-	fn fold(self, challenge_broadcast: &P) -> &'a [P] {
+	/// Combines the two segments with `combine` and returns the output slice.
+	///
+	/// The in-place form reads its low half out of the destination it overwrites.
+	/// The out-of-place form reads both halves from the borrowed source.
+	fn fold_with(self, combine: impl Fn(P, P) -> P) -> &'a [P] {
 		match self {
 			Self::InPlace { seg_0, seg_1 } => {
 				for (out, &hi) in iter::zip(&mut *seg_0, seg_1) {
-					*out = extrapolate_line_packed(*out, hi, *challenge_broadcast);
+					*out = combine(*out, hi);
 				}
 				seg_0
 			}
 			Self::OutOfPlace { dst, seg_0, seg_1 } => {
 				for (out, &lo, &hi) in izip!(&mut *dst, seg_0, seg_1) {
-					*out = extrapolate_line_packed(lo, hi, *challenge_broadcast);
+					*out = combine(lo, hi);
 				}
 				dst
 			}
 		}
 	}
 
-	/// Contracts the eq expansion by summing its halves, and returns the folded output slice.
+	/// Folds a column half, interpolating its two segments on the round's variable.
+	fn fold(self, challenge_broadcast: &P) -> &'a [P] {
+		self.fold_with(|lo, hi| extrapolate_line_packed(lo, hi, *challenge_broadcast))
+	}
+
+	/// Contracts an eq expansion by summing its two segments.
 	///
-	/// Eq-indicator folding sums the two halves (the [Gruen24] technique's part (3)), rather than
-	/// interpolating them as [`Self::fold`] does for columns.
+	/// Summing marginalises the bound variable out, which is part (3) of the [Gruen24] split.
 	///
 	/// [Gruen24]: <https://eprint.iacr.org/2024/108>
 	fn fold_eq(self) -> &'a [P] {
-		match self {
-			Self::InPlace { seg_0, seg_1 } => {
-				for (out, &hi) in iter::zip(&mut *seg_0, seg_1) {
-					*out += hi;
-				}
-				seg_0
-			}
-			Self::OutOfPlace { dst, seg_0, seg_1 } => {
-				for (out, &lo, &hi) in izip!(&mut *dst, seg_0, seg_1) {
-					*out = lo + hi;
-				}
-				dst
-			}
-		}
+		self.fold_with(|lo, hi| lo + hi)
 	}
 }
 


### PR DESCRIPTION
Removes a duplicated aliasing distinction in the fused fold. Generated code is unchanged — verified by disassembly, not by timing.

### The problem

The deferred-fold producer carried two folding methods that were the same two-arm match:

```rust
fn fold(self, challenge_broadcast: &P) -> &'a [P] {
    match self {
        Self::InPlace { seg_0, seg_1 }     => { /* *out = extrapolate(*out, hi, c) */ }
        Self::OutOfPlace { dst, seg_0, .. } => { /* *out = extrapolate(lo, hi, c)   */ }
    }
}

fn fold_eq(self) -> &'a [P] {
    match self {
        Self::InPlace { seg_0, seg_1 }     => { /* *out += hi     */ }
        Self::OutOfPlace { dst, seg_0, .. } => { /* *out = lo + hi */ }
    }
}
```

The interesting part is the same in both, and it is subtle: the in-place form reads its low half **out of the destination it is about to overwrite**, while the out-of-place form reads both halves from a borrowed source. Written twice, that is two chances to read the wrong operand — and the result would be a silently wrong fold rather than a crash.

### The change

One routine takes the combining step:

```rust
fn fold_with(self, combine: impl Fn(P, P) -> P) -> &'a [P]

fn fold(self, c: &P) -> &'a [P] { self.fold_with(|lo, hi| extrapolate_line_packed(lo, hi, *c)) }
fn fold_eq(self)     -> &'a [P] { self.fold_with(|lo, hi| lo + hi) }
```

The aliasing distinction is now stated once. What varies between a column and an equality expansion is one line each, which is what actually varies.

15 insertions, 21 deletions, one file.

### Performance: verified by disassembly

This sits inside the fused read pass, so it is worth being precise rather than reassuring.

The machine available to me was too loaded to benchmark — running the **identical binary** twice gave 2.50 ms and 12.21 ms for the same case, which criterion reported as a statistically significant `+377%`. Load average was above 20 on 10 cores throughout. No timing taken under those conditions means anything.

So I compared the generated code instead. Both versions were built in release, disassembled, and their mnemonic sequences compared function by function:

| function | main | this branch | result |
|---|---:|---:|---|
| `map_reduce_with_fold_helper` | 19 | 19 | **identical** |
| `map_reduce_helper` | 19 | 19 | **identical** |
| `BivariateProductEvaluator::accumulate` *(control)* | 18 | 18 | **identical** |

Identical across every instantiation, including the fused fold inlined into the recursion. The control is a loop this change never touches, and it also comes out identical, which shows the comparison is not simply reporting "same" for everything.

That check also earned its keep. I had initially included a second cleanup in this change — hoisting the repeated `1 << (n_vars - P::LOG_WIDTH)` shifts into named locals — which looked free and was not:

```
- subs  x19, x19, #N        // loop counter in a register
+ ldr   x8, [sp, #N]        // spilled to the stack
+ subs  x8, x8, #N
+ str   x8, [sp, #N]
```

Hoisting extended a live range across the loop; recomputing the shift lets the backend fold it into addressing modes. It cost 8 instructions and a spill, so it is not in this branch. On a loaded machine a benchmark would very likely have written that off as noise.

### An alternative that turned out not to be expressible

The larger prize here would be collapsing the two recursion trees — the pre-fold and post-fold chunk types each carry their own `split_half` and their own `map_reduce` helper, about 180 lines between them.

That is blocked one layer down, in `binius-math`:

```rust
pub fn split_half_ref(&self) -> (FieldSlice<'_, P>, FieldSlice<'_, P>)
```

Below the packing width it **materialises** new packed values via `interleave` and returns them in `FieldSliceData::Single(P)`, a variant that holds a value inline and whose `Deref` hands back `slice::from_ref` into itself. The halves therefore live inside the returned value and cannot outlive the borrow.

That forces two different lifetime disciplines, which no single trait method covers:

| | signature | why |
|---|---|---|
| post-fold | `&'s self -> [Chunk<'s>; 2]` | reborrows, lifetime shrinks each level |
| pre-fold | `self -> [Self; 2]` | holds `&mut`, must consume, `'a` preserved |

Unifying them means changing that API, not this file. Worth recording for whoever looks at it next.

### Verification

- `cargo nextest run -p binius-ip-prover` — 59 passed, 0 failed, including `map_reduce_with_fold_matches_fold_then_map_reduce`, which is the equivalence this change has to preserve
- `cargo clippy -p binius-ip-prover --all-targets --all-features` — clean
- `cargo +nightly fmt --all --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)