### PR TITLE
Fold the constant shift and carry-chain gates in the builder

### DIFF
--- a/crates/examples/snapshots/bitcoin_headers.snap
+++ b/crates/examples/snapshots/bitcoin_headers.snap
@@ -1,32 +1,32 @@
 bitcoin_headers circuit
 --
 Gates & Instructions
-├─ Number of gates: 47,118
-└─ Number of evaluation instructions: 47,238
+├─ Number of gates: 45,988
+└─ Number of evaluation instructions: 46,108
 
 Constraints
-├─ ZERO constraints: 4,614 used (56.3% of 2^13)
-│  [▓▓▓▓▓░░░░░] spare: 3,578
-├─ AND constraints: 15,344 used (93.7% of 2^14)
-│  [▓▓▓▓▓▓▓▓▓░] spare: 1,040
+├─ ZERO constraints: 4,610 used (56.3% of 2^13)
+│  [▓▓▓▓▓░░░░░] spare: 3,582
+├─ AND constraints: 15,340 used (93.6% of 2^14)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 1,044
 ├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
 ├─ BMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-└─ Distinct value indices: 47,303
-   ├─ Distinct shifted value indices: 27,142
-   └─ Distinct unshifted value indices: 20,161
+└─ Distinct value indices: 47,275
+   ├─ Distinct shifted value indices: 27,111
+   └─ Distinct unshifted value indices: 20,164
 
 Value Vector
-├─ Public Section: 156 used (60.9% of 2^8)
-│  [▓▓▓▓▓▓░░░░] spare: 100
-│  ├─ Constants: 156
+├─ Public Section: 192 used (75.0% of 2^8)
+│  [▓▓▓▓▓▓▓░░░] spare: 64
+│  ├─ Constants: 192
 │  └─ Inout: 0
-├─ Private Section: 20,012 used (61.6%)
-│  [▓▓▓▓▓▓░░░░] spare: 12,500
+├─ Private Section: 20,004 used (61.5%)
+│  [▓▓▓▓▓▓░░░░] spare: 12,508
 │  ├─ Witness: 104
-│  └─ Internal: 19,908
-├─ Total Committed: 20,168 used (61.5% of 2^15)
-│  [▓▓▓▓▓▓░░░░] spare: 12,600
-└─ Scratch (uncommitted): 39,280 (peak live: 53)
+│  └─ Internal: 19,900
+├─ Total Committed: 20,196 used (61.6% of 2^15)
+│  [▓▓▓▓▓▓░░░░] spare: 12,572
+└─ Scratch (uncommitted): 38,048 (peak live: 16)
 

--- a/crates/examples/snapshots/bitcoin_p2pkh.snap
+++ b/crates/examples/snapshots/bitcoin_p2pkh.snap
@@ -1,32 +1,32 @@
 bitcoin_p2pkh circuit
 --
 Gates & Instructions
-├─ Number of gates: 150,965
-└─ Number of evaluation instructions: 176,783
+├─ Number of gates: 150,776
+└─ Number of evaluation instructions: 176,594
 
 Constraints
-├─ ZERO constraints: 1,914 used (93.5% of 2^11)
-│  [▓▓▓▓▓▓▓▓▓░] spare: 134
-├─ AND constraints: 111,567 used (85.1% of 2^17)
-│  [▓▓▓▓▓▓▓▓░░] spare: 19,505
+├─ ZERO constraints: 1,910 used (93.3% of 2^11)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 138
+├─ AND constraints: 111,534 used (85.1% of 2^17)
+│  [▓▓▓▓▓▓▓▓░░] spare: 19,538
 ├─ IMUL constraints: 15,186 used (92.7% of 2^14)
 │  [▓▓▓▓▓▓▓▓▓░] spare: 1,198
 ├─ BMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-└─ Distinct value indices: 267,506
-   ├─ Distinct shifted value indices: 131,631
-   └─ Distinct unshifted value indices: 135,875
+└─ Distinct value indices: 267,421
+   ├─ Distinct shifted value indices: 131,567
+   └─ Distinct unshifted value indices: 135,854
 
 Value Vector
-├─ Public Section: 134 used (52.3% of 2^8)
-│  [▓▓▓▓▓░░░░░] spare: 122
-│  ├─ Constants: 134
+├─ Public Section: 173 used (67.6% of 2^8)
+│  [▓▓▓▓▓▓░░░░] spare: 83
+│  ├─ Constants: 173
 │  └─ Inout: 0
-├─ Private Section: 135,752 used (51.8%)
-│  [▓▓▓▓▓░░░░░] spare: 126,136
+├─ Private Section: 135,717 used (51.8%)
+│  [▓▓▓▓▓░░░░░] spare: 126,171
 │  ├─ Witness: 9
-│  └─ Internal: 135,743
-├─ Total Committed: 135,886 used (51.8% of 2^18)
-│  [▓▓▓▓▓░░░░░] spare: 126,258
-└─ Scratch (uncommitted): 108,460 (peak live: 109)
+│  └─ Internal: 135,708
+├─ Total Committed: 135,890 used (51.8% of 2^18)
+│  [▓▓▓▓▓░░░░░] spare: 126,254
+└─ Scratch (uncommitted): 108,202 (peak live: 107)
 

--- a/crates/examples/snapshots/blake2b.snap
+++ b/crates/examples/snapshots/blake2b.snap
@@ -1,32 +1,32 @@
 blake2b circuit
 --
 Gates & Instructions
-├─ Number of gates: 10,824
-└─ Number of evaluation instructions: 10,824
+├─ Number of gates: 10,820
+└─ Number of evaluation instructions: 10,820
 
 Constraints
 ├─ ZERO constraints: 3,088 used (75.4% of 2^12)
 │  [▓▓▓▓▓▓▓░░░] spare: 1,008
-├─ AND constraints: 4,616 used (56.3% of 2^13)
-│  [▓▓▓▓▓░░░░░] spare: 3,576
+├─ AND constraints: 4,612 used (56.3% of 2^13)
+│  [▓▓▓▓▓░░░░░] spare: 3,580
 ├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
 ├─ BMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-└─ Distinct value indices: 19,333
-   ├─ Distinct shifted value indices: 11,486
+└─ Distinct value indices: 19,329
+   ├─ Distinct shifted value indices: 11,482
    └─ Distinct unshifted value indices: 7,847
 
 Value Vector
-├─ Public Section: 28 used (87.5% of 2^5)
-│  [▓▓▓▓▓▓▓▓░░] spare: 4
-│  ├─ Constants: 28
+├─ Public Section: 36 used (56.2% of 2^6)
+│  [▓▓▓▓▓░░░░░] spare: 28
+│  ├─ Constants: 36
 │  └─ Inout: 0
-├─ Private Section: 7,832 used (96.0%)
-│  [▓▓▓▓▓▓▓▓▓░] spare: 328
+├─ Private Section: 7,828 used (96.3%)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 300
 │  ├─ Witness: 136
-│  └─ Internal: 7,696
-├─ Total Committed: 7,860 used (95.9% of 2^13)
-│  [▓▓▓▓▓▓▓▓▓░] spare: 332
-└─ Scratch (uncommitted): 7,728 (peak live: 21)
+│  └─ Internal: 7,692
+├─ Total Committed: 7,864 used (96.0% of 2^13)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 328
+└─ Scratch (uncommitted): 7,724 (peak live: 21)
 

--- a/crates/examples/snapshots/blake2s.snap
+++ b/crates/examples/snapshots/blake2s.snap
@@ -1,32 +1,32 @@
 blake2s circuit
 --
 Gates & Instructions
-├─ Number of gates: 18,568
-└─ Number of evaluation instructions: 18,568
+├─ Number of gates: 18,564
+└─ Number of evaluation instructions: 18,564
 
 Constraints
 ├─ ZERO constraints: 5,292 used (64.6% of 2^13)
 │  [▓▓▓▓▓▓░░░░] spare: 2,900
-├─ AND constraints: 7,688 used (93.8% of 2^13)
-│  [▓▓▓▓▓▓▓▓▓░] spare: 504
+├─ AND constraints: 7,684 used (93.8% of 2^13)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 508
 ├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
 ├─ BMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-└─ Distinct value indices: 32,509
-   ├─ Distinct shifted value indices: 19,510
+└─ Distinct value indices: 32,505
+   ├─ Distinct shifted value indices: 19,506
    └─ Distinct unshifted value indices: 12,999
 
 Value Vector
-├─ Public Section: 45 used (70.3% of 2^6)
-│  [▓▓▓▓▓▓▓░░░] spare: 19
-│  ├─ Constants: 45
+├─ Public Section: 49 used (76.6% of 2^6)
+│  [▓▓▓▓▓▓▓░░░] spare: 15
+│  ├─ Constants: 49
 │  └─ Inout: 0
-├─ Private Section: 13,108 used (80.3%)
-│  [▓▓▓▓▓▓▓▓░░] spare: 3,212
+├─ Private Section: 13,104 used (80.3%)
+│  [▓▓▓▓▓▓▓▓░░] spare: 3,216
 │  ├─ Witness: 136
-│  └─ Internal: 12,972
+│  └─ Internal: 12,968
 ├─ Total Committed: 13,153 used (80.3% of 2^14)
 │  [▓▓▓▓▓▓▓▓░░] spare: 3,231
-└─ Scratch (uncommitted): 13,268 (peak live: 37)
+└─ Scratch (uncommitted): 13,264 (peak live: 37)
 

--- a/crates/examples/snapshots/blake3.snap
+++ b/crates/examples/snapshots/blake3.snap
@@ -1,32 +1,32 @@
 blake3 circuit
 --
 Gates & Instructions
-├─ Number of gates: 7,256
-└─ Number of evaluation instructions: 7,256
+├─ Number of gates: 7,106
+└─ Number of evaluation instructions: 7,106
 
 Constraints
-├─ ZERO constraints: 1,997 used (97.5% of 2^11)
-│  [▓▓▓▓▓▓▓▓▓░] spare: 51
+├─ ZERO constraints: 1,992 used (97.3% of 2^11)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 56
 ├─ AND constraints: 2,760 used (67.4% of 2^12)
 │  [▓▓▓▓▓▓░░░░] spare: 1,336
 ├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
 ├─ BMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-└─ Distinct value indices: 12,379
-   ├─ Distinct shifted value indices: 7,617
-   └─ Distinct unshifted value indices: 4,762
+└─ Distinct value indices: 12,366
+   ├─ Distinct shifted value indices: 7,601
+   └─ Distinct unshifted value indices: 4,765
 
 Value Vector
-├─ Public Section: 281 used (54.9% of 2^9)
-│  [▓▓▓▓▓░░░░░] spare: 231
-│  ├─ Constants: 17
+├─ Public Section: 293 used (57.2% of 2^9)
+│  [▓▓▓▓▓░░░░░] spare: 219
+│  ├─ Constants: 29
 │  └─ Inout: 264
-├─ Private Section: 4,749 used (61.8%)
-│  [▓▓▓▓▓▓░░░░] spare: 2,931
+├─ Private Section: 4,744 used (61.8%)
+│  [▓▓▓▓▓▓░░░░] spare: 2,936
 │  ├─ Witness: 0
-│  └─ Internal: 4,749
-├─ Total Committed: 5,030 used (61.4% of 2^13)
-│  [▓▓▓▓▓▓░░░░] spare: 3,162
-└─ Scratch (uncommitted): 5,179 (peak live: 42)
+│  └─ Internal: 4,744
+├─ Total Committed: 5,037 used (61.5% of 2^13)
+│  [▓▓▓▓▓▓░░░░] spare: 3,155
+└─ Scratch (uncommitted): 5,034 (peak live: 41)
 

--- a/crates/examples/snapshots/ec_msm.snap
+++ b/crates/examples/snapshots/ec_msm.snap
@@ -1,32 +1,32 @@
 ec_msm circuit
 --
 Gates & Instructions
-├─ Number of gates: 208,914
-└─ Number of evaluation instructions: 244,030
+├─ Number of gates: 208,874
+└─ Number of evaluation instructions: 243,990
 
 Constraints
-├─ ZERO constraints: 2,140 used (52.2% of 2^12)
-│  [▓▓▓▓▓░░░░░] spare: 1,956
-├─ AND constraints: 156,113 used (59.6% of 2^18)
-│  [▓▓▓▓▓░░░░░] spare: 106,031
+├─ ZERO constraints: 2,136 used (52.1% of 2^12)
+│  [▓▓▓▓▓░░░░░] spare: 1,960
+├─ AND constraints: 156,101 used (59.5% of 2^18)
+│  [▓▓▓▓▓░░░░░] spare: 106,043
 ├─ IMUL constraints: 20,548 used (62.7% of 2^15)
 │  [▓▓▓▓▓▓░░░░] spare: 12,220
 ├─ BMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-└─ Distinct value indices: 364,790
-   ├─ Distinct shifted value indices: 176,456
-   └─ Distinct unshifted value indices: 188,334
+└─ Distinct value indices: 364,754
+   ├─ Distinct shifted value indices: 176,436
+   └─ Distinct unshifted value indices: 188,318
 
 Value Vector
 ├─ Public Section: 52 used (81.2% of 2^6)
 │  [▓▓▓▓▓▓▓▓░░] spare: 12
 │  ├─ Constants: 20
 │  └─ Inout: 32
-├─ Private Section: 188,287 used (71.8%)
-│  [▓▓▓▓▓▓▓░░░] spare: 73,793
+├─ Private Section: 188,271 used (71.8%)
+│  [▓▓▓▓▓▓▓░░░] spare: 73,809
 │  ├─ Witness: 0
-│  └─ Internal: 188,287
-├─ Total Committed: 188,339 used (71.8% of 2^18)
-│  [▓▓▓▓▓▓▓░░░] spare: 73,805
-└─ Scratch (uncommitted): 145,377 (peak live: 190)
+│  └─ Internal: 188,271
+├─ Total Committed: 188,323 used (71.8% of 2^18)
+│  [▓▓▓▓▓▓▓░░░] spare: 73,821
+└─ Scratch (uncommitted): 145,321 (peak live: 184)
 

--- a/crates/examples/snapshots/ethsign.snap
+++ b/crates/examples/snapshots/ethsign.snap
@@ -1,32 +1,32 @@
 ethsign circuit
 --
 Gates & Instructions
-├─ Number of gates: 214,965
-└─ Number of evaluation instructions: 250,294
+├─ Number of gates: 214,819
+└─ Number of evaluation instructions: 250,148
 
 Constraints
-├─ ZERO constraints: 2,173 used (53.1% of 2^12)
-│  [▓▓▓▓▓░░░░░] spare: 1,923
-├─ AND constraints: 157,690 used (60.2% of 2^18)
-│  [▓▓▓▓▓▓░░░░] spare: 104,454
+├─ ZERO constraints: 2,165 used (52.9% of 2^12)
+│  [▓▓▓▓▓░░░░░] spare: 1,931
+├─ AND constraints: 157,643 used (60.1% of 2^18)
+│  [▓▓▓▓▓▓░░░░] spare: 104,501
 ├─ IMUL constraints: 20,554 used (62.7% of 2^15)
 │  [▓▓▓▓▓▓░░░░] spare: 12,214
 ├─ BMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-└─ Distinct value indices: 379,027
-   ├─ Distinct shifted value indices: 189,007
-   └─ Distinct unshifted value indices: 190,020
+└─ Distinct value indices: 378,931
+   ├─ Distinct shifted value indices: 188,956
+   └─ Distinct unshifted value indices: 189,975
 
 Value Vector
-├─ Public Section: 114 used (89.1% of 2^7)
-│  [▓▓▓▓▓▓▓▓░░] spare: 14
-│  ├─ Constants: 85
+├─ Public Section: 124 used (96.9% of 2^7)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 4
+│  ├─ Constants: 95
 │  └─ Inout: 29
-├─ Private Section: 189,915 used (72.5%)
-│  [▓▓▓▓▓▓▓░░░] spare: 72,101
+├─ Private Section: 189,862 used (72.5%)
+│  [▓▓▓▓▓▓▓░░░] spare: 72,154
 │  ├─ Witness: 0
-│  └─ Internal: 189,915
-├─ Total Committed: 190,029 used (72.5% of 2^18)
-│  [▓▓▓▓▓▓▓░░░] spare: 72,115
-└─ Scratch (uncommitted): 149,996 (peak live: 192)
+│  └─ Internal: 189,862
+├─ Total Committed: 189,986 used (72.5% of 2^18)
+│  [▓▓▓▓▓▓▓░░░] spare: 72,158
+└─ Scratch (uncommitted): 149,803 (peak live: 186)
 

--- a/crates/examples/snapshots/hashsign.snap
+++ b/crates/examples/snapshots/hashsign.snap
@@ -1,8 +1,8 @@
 hashsign circuit
 --
 Gates & Instructions
-├─ Number of gates: 413,082
-└─ Number of evaluation instructions: 413,730
+├─ Number of gates: 409,566
+└─ Number of evaluation instructions: 410,214
 
 Constraints
 ├─ ZERO constraints: 110,514 used (84.3% of 2^17)
@@ -28,5 +28,5 @@ Value Vector
 │  └─ Internal: 253,173
 ├─ Total Committed: 255,133 used (97.3% of 2^18)
 │  [▓▓▓▓▓▓▓▓▓░] spare: 7,011
-└─ Scratch (uncommitted): 308,394 (peak live: 595)
+└─ Scratch (uncommitted): 304,878 (peak live: 595)
 

--- a/crates/examples/snapshots/sha256.snap
+++ b/crates/examples/snapshots/sha256.snap
@@ -1,32 +1,32 @@
 sha256 circuit
 --
 Gates & Instructions
-├─ Number of gates: 20,312
-└─ Number of evaluation instructions: 20,312
+├─ Number of gates: 19,680
+└─ Number of evaluation instructions: 19,680
 
 Constraints
-├─ ZERO constraints: 2,005 used (97.9% of 2^11)
-│  [▓▓▓▓▓▓▓▓▓░] spare: 43
-├─ AND constraints: 6,575 used (80.3% of 2^13)
-│  [▓▓▓▓▓▓▓▓░░] spare: 1,617
+├─ ZERO constraints: 1,950 used (95.2% of 2^11)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 98
+├─ AND constraints: 6,466 used (78.9% of 2^13)
+│  [▓▓▓▓▓▓▓░░░] spare: 1,726
 ├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
 ├─ BMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-└─ Distinct value indices: 21,061
-   ├─ Distinct shifted value indices: 12,350
-   └─ Distinct unshifted value indices: 8,711
+└─ Distinct value indices: 20,532
+   ├─ Distinct shifted value indices: 11,930
+   └─ Distinct unshifted value indices: 8,602
 
 Value Vector
-├─ Public Section: 404 used (78.9% of 2^9)
-│  [▓▓▓▓▓▓▓░░░] spare: 108
-│  ├─ Constants: 140
+├─ Public Section: 922 used (90.0% of 2^10)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 102
+│  ├─ Constants: 658
 │  └─ Inout: 264
-├─ Private Section: 8,572 used (54.0%)
-│  [▓▓▓▓▓░░░░░] spare: 7,300
+├─ Private Section: 8,408 used (54.7%)
+│  [▓▓▓▓▓░░░░░] spare: 6,952
 │  ├─ Witness: 0
-│  └─ Internal: 8,572
-├─ Total Committed: 8,976 used (54.8% of 2^14)
-│  [▓▓▓▓▓░░░░░] spare: 7,408
-└─ Scratch (uncommitted): 17,124 (peak live: 22)
+│  └─ Internal: 8,408
+├─ Total Committed: 9,330 used (56.9% of 2^14)
+│  [▓▓▓▓▓░░░░░] spare: 7,054
+└─ Scratch (uncommitted): 16,512 (peak live: 22)
 

--- a/crates/examples/snapshots/sha512.snap
+++ b/crates/examples/snapshots/sha512.snap
@@ -1,32 +1,32 @@
 sha512 circuit
 --
 Gates & Instructions
-├─ Number of gates: 24,839
-└─ Number of evaluation instructions: 24,839
+├─ Number of gates: 23,993
+└─ Number of evaluation instructions: 23,993
 
 Constraints
-├─ ZERO constraints: 2,007 used (98.0% of 2^11)
-│  [▓▓▓▓▓▓▓▓▓░] spare: 41
-├─ AND constraints: 8,270 used (50.5% of 2^14)
-│  [▓▓▓▓▓░░░░░] spare: 8,114
+├─ ZERO constraints: 1,944 used (94.9% of 2^11)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 104
+├─ AND constraints: 8,090 used (98.8% of 2^13)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 102
 ├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
 ├─ BMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-└─ Distinct value indices: 25,055
-   ├─ Distinct shifted value indices: 14,555
-   └─ Distinct unshifted value indices: 10,500
+└─ Distinct value indices: 24,350
+   ├─ Distinct shifted value indices: 14,030
+   └─ Distinct unshifted value indices: 10,320
 
 Value Vector
-├─ Public Section: 237 used (92.6% of 2^8)
-│  [▓▓▓▓▓▓▓▓▓░] spare: 19
-│  ├─ Constants: 101
+├─ Public Section: 1,121 used (54.7% of 2^11)
+│  [▓▓▓▓▓░░░░░] spare: 927
+│  ├─ Constants: 985
 │  └─ Inout: 136
-├─ Private Section: 10,269 used (63.7%)
-│  [▓▓▓▓▓▓░░░░] spare: 5,859
+├─ Private Section: 10,026 used (69.9%)
+│  [▓▓▓▓▓▓░░░░] spare: 4,310
 │  ├─ Witness: 0
-│  └─ Internal: 10,269
-├─ Total Committed: 10,506 used (64.1% of 2^14)
-│  [▓▓▓▓▓▓░░░░] spare: 5,878
-└─ Scratch (uncommitted): 21,402 (peak live: 13)
+│  └─ Internal: 10,026
+├─ Total Committed: 11,147 used (68.0% of 2^14)
+│  [▓▓▓▓▓▓░░░░] spare: 5,237
+└─ Scratch (uncommitted): 20,603 (peak live: 13)
 

--- a/crates/examples/snapshots/zklogin.snap
+++ b/crates/examples/snapshots/zklogin.snap
@@ -1,32 +1,32 @@
 zklogin circuit
 --
 Gates & Instructions
-├─ Number of gates: 391,028
-└─ Number of evaluation instructions: 459,115
+├─ Number of gates: 390,672
+└─ Number of evaluation instructions: 458,759
 
 Constraints
-├─ ZERO constraints: 22,862 used (69.8% of 2^15)
-│  [▓▓▓▓▓▓░░░░] spare: 9,906
-├─ AND constraints: 235,124 used (89.7% of 2^18)
-│  [▓▓▓▓▓▓▓▓░░] spare: 27,020
+├─ ZERO constraints: 22,828 used (69.7% of 2^15)
+│  [▓▓▓▓▓▓░░░░] spare: 9,940
+├─ AND constraints: 234,956 used (89.6% of 2^18)
+│  [▓▓▓▓▓▓▓▓░░] spare: 27,188
 ├─ IMUL constraints: 8,262 used (50.4% of 2^14)
 │  [▓▓▓▓▓░░░░░] spare: 8,122
 ├─ BMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-└─ Distinct value indices: 544,947
-   ├─ Distinct shifted value indices: 284,342
-   └─ Distinct unshifted value indices: 260,605
+└─ Distinct value indices: 544,593
+   ├─ Distinct shifted value indices: 284,174
+   └─ Distinct unshifted value indices: 260,419
 
 Value Vector
-├─ Public Section: 1,031 used (50.3% of 2^11)
-│  [▓▓▓▓▓░░░░░] spare: 1,017
-│  ├─ Constants: 729
+├─ Public Section: 1,051 used (51.3% of 2^11)
+│  [▓▓▓▓▓░░░░░] spare: 997
+│  ├─ Constants: 749
 │  └─ Inout: 302
-├─ Private Section: 259,584 used (99.8%)
-│  [▓▓▓▓▓▓▓▓▓░] spare: 512
+├─ Private Section: 259,387 used (99.7%)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 709
 │  ├─ Witness: 1,381
-│  └─ Internal: 258,203
-├─ Total Committed: 260,615 used (99.4% of 2^18)
-│  [▓▓▓▓▓▓▓▓▓░] spare: 1,529
-└─ Scratch (uncommitted): 320,445 (peak live: 1,542)
+│  └─ Internal: 258,006
+├─ Total Committed: 260,438 used (99.3% of 2^18)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 1,706
+└─ Scratch (uncommitted): 320,275 (peak live: 1,542)
 

--- a/crates/frontend/src/compiler/mod.rs
+++ b/crates/frontend/src/compiler/mod.rs
@@ -720,8 +720,14 @@ impl CircuitBuilder {
 	///
 	/// # Cost
 	///
-	/// 1 AND constraint, 1 linear constraint.
+	/// 1 AND constraint and 1 linear constraint, or none when both operands are constant.
 	pub fn iadd_32(&self, a: Wire, b: Wire) -> Wire {
+		// Invariant: a sum of two constants is itself known at build time.
+		// So the gate, and both constraints it would emit, fall away.
+		if let (Some(x), Some(y)) = (self.const_of(a), self.const_of(b)) {
+			let (sum, _cout) = x.iadd_cout_32(y);
+			return self.add_constant(sum);
+		}
 		let sum = self.add_internal();
 		let cout = self.add_internal();
 		let mut graph = self.graph_mut();
@@ -741,8 +747,16 @@ impl CircuitBuilder {
 	///
 	/// # Cost
 	///
-	/// 1 AND constraint, 1 linear constraint.
+	/// 1 AND constraint and 1 linear constraint, or none when every operand is constant.
 	pub fn iadd32_cin_cout(&self, a: Wire, b: Wire, cin: Wire) -> (Wire, Wire) {
+		// Invariant: both 32-bit halves of a constant addition are known at build time.
+		// The carry word is too, so both outputs fold.
+		if let (Some(x), Some(y), Some(c)) =
+			(self.const_of(a), self.const_of(b), self.const_of(cin))
+		{
+			let (sum, cout) = x.iadd32_cin_cout(y, c);
+			return (self.add_constant(sum), self.add_constant(cout));
+		}
 		let sum = self.add_internal();
 		let cout = self.add_internal();
 		let mut graph = self.graph_mut();
@@ -763,7 +777,18 @@ impl CircuitBuilder {
 	///
 	/// - 1 AND constraint,
 	/// - 1 linear constraint.
+	///
+	/// Both fall away when every operand is constant.
 	pub fn iadd_cin_cout(&self, a: Wire, b: Wire, cin: Wire) -> (Wire, Wire) {
+		// Invariant: a sum of constants is known at build time, carry word included.
+		// The carry in travels in the most significant bit.
+		// Witness evaluation reads it from there, so the fold must read it the same way.
+		if let (Some(x), Some(y), Some(c)) =
+			(self.const_of(a), self.const_of(b), self.const_of(cin))
+		{
+			let (sum, cout) = x.iadd_cin_cout(y, c >> 63);
+			return (self.add_constant(sum), self.add_constant(cout));
+		}
 		let sum = self.add_internal();
 		let cout = self.add_internal();
 		let mut graph = self.graph_mut();
@@ -784,7 +809,18 @@ impl CircuitBuilder {
 	///
 	/// - 1 AND constraint,
 	/// - 1 linear constraint.
+	///
+	/// Both fall away when every operand is constant.
 	pub fn isub_bin_bout(&self, a: Wire, b: Wire, bin: Wire) -> (Wire, Wire) {
+		// Invariant: a difference of constants is known at build time, borrow word included.
+		// The borrow in travels in the most significant bit.
+		// Witness evaluation reads it from there, so the fold must read it the same way.
+		if let (Some(x), Some(y), Some(bo)) =
+			(self.const_of(a), self.const_of(b), self.const_of(bin))
+		{
+			let (diff, bout) = x.isub_bin_bout(y, bo >> 63);
+			return (self.add_constant(diff), self.add_constant(bout));
+		}
 		let diff = self.add_internal();
 		let bout = self.add_internal();
 		let mut graph = self.graph_mut();
@@ -797,6 +833,14 @@ impl CircuitBuilder {
 	/// The variant and amount are carried as the gate's two immediates.
 	/// The caller enforces the amount range and any identity fast-paths.
 	fn emit_shift(&self, variant: ShiftVariant, x: Wire, n: u32) -> Wire {
+		// Invariant: shifting a constant yields a constant, for every variant and amount.
+		// So the gate and its constraint fall away.
+		//
+		// Why: the fold applies the very operation witness evaluation would have applied.
+		// That is what keeps a circuit that folded equal to one that did not.
+		if let Some(v) = self.const_of(x) {
+			return self.add_constant(variant.apply(v, n as usize));
+		}
 		let z = self.add_internal();
 		let mut graph = self.graph_mut();
 		graph.emit_gate_generic(
@@ -823,7 +867,7 @@ impl CircuitBuilder {
 	///
 	/// # Cost
 	///
-	/// 1 AND constraint (0 if n = 0).
+	/// 1 AND constraint, or none when the amount is zero or the operand is constant.
 	pub fn rotl32(&self, x: Wire, n: u32) -> Wire {
 		assert!(n < 32, "rotate amount n={n} out of range");
 		if n == 0 {
@@ -845,7 +889,7 @@ impl CircuitBuilder {
 	///
 	/// # Cost
 	///
-	/// 1 AND constraint (0 if n = 0).
+	/// 1 AND constraint, or none when the amount is zero or the operand is constant.
 	pub fn rotr32(&self, x: Wire, n: u32) -> Wire {
 		assert!(n < 32, "rotate amount n={n} out of range");
 		if n == 0 {
@@ -867,7 +911,7 @@ impl CircuitBuilder {
 	///
 	/// # Cost
 	///
-	/// 1 AND constraint (0 if n = 0).
+	/// 1 AND constraint, or none when the amount is zero or the operand is constant.
 	pub fn rotl(&self, x: Wire, n: u32) -> Wire {
 		assert!(n < 64, "rotate amount n={n} out of range");
 		if n == 0 {
@@ -889,7 +933,7 @@ impl CircuitBuilder {
 	///
 	/// # Cost
 	///
-	/// 1 AND constraint (0 if n = 0).
+	/// 1 AND constraint, or none when the amount is zero or the operand is constant.
 	pub fn rotr(&self, x: Wire, n: u32) -> Wire {
 		assert!(n < 64, "rotate amount n={n} out of range");
 		if n == 0 {
@@ -944,7 +988,7 @@ impl CircuitBuilder {
 	///
 	/// # Cost
 	///
-	/// 1 AND constraint.
+	/// 1 AND constraint, or none when the operand is constant.
 	pub fn shl(&self, a: Wire, n: u32) -> Wire {
 		assert!(n < 64, "shift amount n={n} out of range");
 		self.emit_shift(ShiftVariant::Sll, a, n)
@@ -958,7 +1002,7 @@ impl CircuitBuilder {
 	///
 	/// # Cost
 	///
-	/// 1 AND constraint.
+	/// 1 AND constraint, or none when the operand is constant.
 	pub fn shr(&self, a: Wire, n: u32) -> Wire {
 		assert!(n < 64, "shift amount n={n} out of range");
 		self.emit_shift(ShiftVariant::Slr, a, n)
@@ -972,7 +1016,7 @@ impl CircuitBuilder {
 	///
 	/// # Cost
 	///
-	/// 1 AND constraint.
+	/// 1 AND constraint, or none when the operand is constant.
 	pub fn sar(&self, a: Wire, n: u32) -> Wire {
 		assert!(n < 64, "shift amount n={n} out of range");
 		self.emit_shift(ShiftVariant::Sar, a, n)

--- a/crates/frontend/src/compiler/tests.rs
+++ b/crates/frontend/src/compiler/tests.rs
@@ -89,6 +89,99 @@ fn test_algebraic_fold_bxor_self_is_zero_in_witness() {
 	verify_constraints(circuit.constraint_system(), &w.value_vec).unwrap();
 }
 
+#[test]
+fn test_constant_arithmetic_folds_to_a_constant_wire() {
+	// A gate whose operands are all known needs no gate at all.
+	// The builder computes the result and hands back the interned constant for that value.
+	//
+	// Invariant: the folded wire is the wire that value would intern to on its own.
+	//
+	// Fixture state:
+	//
+	//     a   = 0x0123456789abcdef
+	//     b   = 0xfedcba9876543210
+	//     cin = 0
+	let a = Word(0x0123_4567_89ab_cdef);
+	let b = Word(0xfedc_ba98_7654_3210);
+	let builder = CircuitBuilder::new();
+	let a_wire = builder.add_constant(a);
+	let b_wire = builder.add_constant(b);
+	let zero_wire = builder.add_constant(Word::ZERO);
+
+	// One shift of each family, since all of them route through the same fold.
+	// Left and right drop the bits they push out.
+	// The arithmetic one keeps the sign bit.
+	// The rotation keeps every bit.
+	assert_eq!(builder.shl(a_wire, 8), builder.add_constant(a << 8));
+	assert_eq!(builder.shr(a_wire, 8), builder.add_constant(a >> 8));
+	assert_eq!(builder.sar(a_wire, 8), builder.add_constant(a.sar(8)));
+	assert_eq!(builder.rotr(a_wire, 8), builder.add_constant(a.rotr(8)));
+
+	// The carry-chain gates fold both outputs, not just the sum.
+	// A wrong carry word would leave the sum right, so it is asserted separately.
+	let (sum, cout) = builder.iadd_cin_cout(a_wire, b_wire, zero_wire);
+	let (want_sum, want_cout) = a.iadd_cin_cout(b, Word::ZERO);
+	assert_eq!(sum, builder.add_constant(want_sum));
+	assert_eq!(cout, builder.add_constant(want_cout));
+
+	// The subtraction folds its borrow word on the same footing.
+	let (diff, bout) = builder.isub_bin_bout(a_wire, b_wire, zero_wire);
+	let (want_diff, want_bout) = a.isub_bin_bout(b, Word::ZERO);
+	assert_eq!(diff, builder.add_constant(want_diff));
+	assert_eq!(bout, builder.add_constant(want_bout));
+
+	// The half-wise addition adds the two 32-bit lanes independently.
+	// A carry out of the low lane must not leak into the high one.
+	assert_eq!(builder.iadd_32(a_wire, b_wire), builder.add_constant(a.iadd_cout_32(b).0));
+}
+
+#[test]
+fn test_constant_chain_costs_no_constraints() {
+	// A message-schedule round of a hash mixes a word with rotations and shifts of itself, then
+	// folds the result in with a carry-chain addition:
+	//
+	//     s = rotr(k, 1) ^ rotr(k, 8) ^ shr(k, 7)
+	//     w = k + s
+	//
+	// Over a padding block every input to that is fixed at build time.
+	// So the whole round is known before proving starts.
+	//
+	// Invariant: a chain of gates on constants leaves the constraint system carrying nothing.
+	//
+	// Fixture state: one constant word, and one public output to observe the result through.
+	let k = Word(0x8000_0000_0000_0000);
+	let builder = CircuitBuilder::new();
+	let k_wire = builder.add_constant(k);
+	let zero_wire = builder.add_constant(Word::ZERO);
+
+	let mixed = builder.bxor(
+		builder.bxor(builder.rotr(k_wire, 1), builder.rotr(k_wire, 8)),
+		builder.shr(k_wire, 7),
+	);
+	let (folded, _carry) = builder.iadd_cin_cout(k_wire, mixed, zero_wire);
+
+	// Asserting against a public output keeps the dead-code pass from deleting the chain.
+	// Without it the counts below would pass for the wrong reason.
+	let out = builder.add_inout();
+	builder.assert_eq("folded", folded, out);
+
+	let circuit = builder.build();
+	let stat = crate::CircuitStat::collect(&circuit);
+
+	// The equality assertion is the one thing left.
+	// The four gates of the chain cost nothing.
+	assert_eq!(stat.n_and_constraints, 1);
+	assert_eq!(stat.n_zero_constraints, 0);
+
+	// Cheap is only correct if the value survived.
+	// Recompute it the long way and check the circuit accepts it.
+	let mixed_val = k.rotr(1) ^ k.rotr(8) ^ (k >> 7);
+	let mut w = circuit.new_witness_filler();
+	w[out] = k.iadd_cin_cout(mixed_val, Word::ZERO).0;
+	circuit.populate_wire_witness(&mut w).unwrap();
+	verify_constraints(circuit.constraint_system(), &w.value_vec).unwrap();
+}
+
 /// Builds `assert_eq(x ^ y, z)`.
 ///
 /// Gate fusion is off so that the `bxor` gate keeps its own linear constraint instead of being

--- a/crates/m4-prover/src/shift.rs
+++ b/crates/m4-prover/src/shift.rs
@@ -334,7 +334,7 @@ mod tests {
 		protocols::shift::{build_key_collection, monster::build_h_parts},
 	};
 	use binius_transcript::ProverTranscript;
-	use binius_utils::checked_arithmetics::{checked_log_2, log2_ceil_usize};
+	use binius_utils::checked_arithmetics::log2_ceil_usize;
 	use binius_verifier::{
 		config::{B128, StdChallenger},
 		protocols::shift::{OperatorData as VerifierOperatorData, check_eval, verify},
@@ -439,7 +439,10 @@ mod tests {
 			let layout = table.layout();
 			let offset = layout.offset_witness;
 			let n_committed = layout.combined_len() - offset;
-			let log_committed = checked_log_2(n_committed);
+			// The hidden segment holds one word per witness and internal value, with no padding
+			// up to a power of two. Only the public segment is padded that way. So the word axis
+			// spans the next power of two and the positions past the real words read as zero.
+			let log_committed = log2_ceil_usize(n_committed);
 
 			// The instance-fold point, and a fresh point over the (bit, word) axes.
 			let r_rho = random_scalars::<B128>(&mut rng, log_instances);
@@ -455,12 +458,18 @@ mod tests {
 			// evaluate the resulting (word, instance) multilinear over the word and instance axes.
 			let bit_tensor = eq_ind_partial_eval_scalars::<B128>(r_bit);
 
-			// Gather the committed words of every instance, instance-major: index = rho *
-			// n_committed + w. Each instance is reconstructed independently of the fold under test.
-			let mut committed = Vec::with_capacity(n_instances * n_committed);
+			// Gather the committed words of every instance, instance-major:
+			//
+			//     index = rho * 2^log_committed + w
+			//
+			// The stride is the padded word axis, so an instance that does not fill it leaves
+			// zeros behind. Each instance is reconstructed independently of the fold under test.
+			let stride = 1usize << log_committed;
+			let mut committed = vec![Word::ZERO; n_instances * stride];
 			for rho in 0..n_instances {
 				let vv = table.instance_value_vec(rho, constants);
-				committed.extend_from_slice(&vv.combined_witness()[offset..]);
+				let words = &vv.combined_witness()[offset..];
+				committed[rho * stride..][..words.len()].copy_from_slice(words);
 			}
 			let folded_words = fold_words::<B128, P, _>(&GlobalAllocator, &committed, &bit_tensor);
 
@@ -531,11 +540,14 @@ mod tests {
 	// `r_y`.
 	fn evaluate_folded_witness(folded: &[FoldedWord<B128>], r_j: &[B128], r_y: &[B128]) -> B128 {
 		let r_j_tensor = eq_ind_partial_eval::<B128>(r_j);
-		let per_word: Vec<B128> = folded
-			.iter()
-			.map(|word| inner_product(word.iter().copied(), r_j_tensor.as_ref().iter().copied()))
-			.collect();
 		let r_y_tensor = eq_ind_partial_eval::<B128>(r_y);
+
+		// The word axis spans a power of two, which the committed segment need not fill.
+		// The positions past the real words contribute nothing, so they stay zero.
+		let mut per_word = vec![B128::ZERO; r_y_tensor.as_ref().len()];
+		for (word, out) in iter::zip(folded, &mut per_word) {
+			*out = inner_product(word.iter().copied(), r_j_tensor.as_ref().iter().copied());
+		}
 		inner_product(per_word.iter().copied(), r_y_tensor.as_ref().iter().copied())
 	}
 


### PR DESCRIPTION
Makes the shift and carry-chain gates resolve at build time when every operand is a constant, the way the bitwise gates already do.

No protocol change. The folded value is the one witness evaluation would have produced.

### The problem

The builder already folds `band`, `bxor`, `bor` and `select` on constant operands — an AND of two constants interns the result and emits no gate.

The shifts and the carry-chain gates never learned the trick.
So a chain built entirely from constants still pays a gate, a committed word and a constraint at every step.

Fixed-length hash padding is where that bites.
A 1024-byte SHA-512 message needs `(1024 + 17).div_ceil(128) = 9` blocks, and every word of the ninth is a constant — the `0x80` delimiter, zeros, and the bit length.

Its message schedule is 64 rounds of

```
s0 = rotr(w, 1) ^ rotr(w, 8) ^ shr(w, 7)
w  = w + s0 + ...
```

over those constants. All of it known before proving starts. None of it folded.

### The idea

Fold the remaining gates on the same rule the bitwise ones use: if every operand is a constant, compute the result and return the interned constant.

The subtlety is *which* operation to compute with.
A folded circuit and an unfolded one must agree, so each fold applies exactly the word operation the constant evaluator applies for that opcode — including the convention that a carry-in or borrow-in travels in the most significant bit.

### The change

Five entry points in `crates/frontend/src/compiler/mod.rs`:

- the shift dispatch, which all ten shift and rotate methods route through
- 64-bit add with carry, 32-bit half-wise add, half-wise add with carry, and subtract with borrow

The carry-chain gates fold both outputs, carry word included, not just the sum.

### Results

Deterministic constraint counts, so these are exact rather than measured.

| circuit | AND before | AND after | padded AND | committed before | committed after |
|---|---:|---:|---|---:|---:|
| **sha512** | 8,270 | **8,090** | **2^14 → 2^13** | 10,506 | 11,147 |
| sha256 | 6,575 | 6,466 | 2^13 | 8,976 | 9,330 |
| ethsign | 157,690 | 157,643 | 2^18 | 190,029 | 189,986 |
| ec_msm | 156,113 | 156,101 | 2^18 | 188,339 | 188,323 |
| zklogin | 235,124 | 234,956 | 2^18 | 260,615 | **260,438** |
| bitcoin_p2pkh | 111,567 | 111,534 | 2^17 | 135,886 | 135,890 |
| bitcoin_headers | 15,344 | 15,340 | 2^14 | 20,168 | 20,196 |
| blake2s | 7,688 | 7,684 | 2^13 | — | — |
| blake2b | 4,616 | 4,612 | 2^13 | 7,860 | 7,864 |
| blake3 | 2,760 | 2,760 | 2^12 | 5,030 | 5,037 |
| hashsign, keccak | unchanged | | | | |

SHA-512 sat 78 constraints over $2^{13}$ and the fold removes 180, so its padded AND column halves from 16,384 to 8,192.

AND and ZERO counts are same-or-lower everywhere, and **no circuit crosses a boundary upward**.

### The committed-count trade

SHA-512 and SHA-256 gain committed words (+641, +354): folding interns a constant wire per intermediate, and the value-vector allocator gives every constant a slot, unlike internal wires which are filtered by constraint liveness.

`Constants: 101 → 985` on SHA-512.

Neither crosses a boundary, and the two circuits with almost no headroom are safe — hashsign is untouched, and zklogin gains 177 words of headroom rather than losing any.

Dropping the unread constants is a real follow-up worth about 800 words on SHA-512, but it needs a design decision first: a wire the builder hands back must stay readable from the witness filler, and the bytecode builder requires every wire in the graph to hold a value index. Left out of this PR deliberately.

### The shift-reduction tests this moved

Second commit, and worth reading on its own — it fixes a latent fragility rather than accommodating this change.

Two batched shift tests read the committed word count straight into `checked_log_2`, and a third uses that raw count as its instance stride. All three only work when the count is already a power of two.

Nothing guarantees it:

- only the **public** segment is padded to a power of two
- the hidden segment holds one word per witness and internal value and stops there
- shape validation asks for `hidden >= public`, never for a particular length
- the reduction itself rounds the word axis up and reads the positions past the real words as zero, via `log2_ceil_usize`

The CRC-64 fixture sat on exactly 1024 committed words, so the assumption held by luck. This PR interns one extra constant and drops one internal wire:

| | `n_const` | `offset_witness` | `n_internal` | `n_hidden` | power of two |
|---|---:|---:|---:|---:|---|
| before | 2 | 2 | 1020 | **1024** | yes |
| after | 3 | 4 | 1019 | **1023** | no |

So the fix is to round the word axis up the way the reduction does, and zero-fill past the real words — in the instance-major stride and in the per-word multilinear. Both padding sites are mutation-checked: filling either with a nonzero value turns the tests red.

The fixed tests pass on both geometries, at 1024 and at 1023, which is what makes this a generalization rather than a workaround.

### Scope

- **changed:** five gate entry points, one frontend file
- **tests:** two padding assumptions in the m4 shift reduction test helpers
- **snapshots:** 11 example snapshots reblessed
- **untouched:** the constant-propagation pass, which stays off by default; this is builder-local folding with no pass-ordering or force-committed interaction

### Verification

- `cargo check --workspace --all-targets`, clippy on the touched crates, nightly `fmt --all` — clean
- lib tests: m4-prover 38, frontend 193, circuits 332, core 87, math 129, prover 26, iop-prover 40, ip-prover 59
- m4-prover integration tests (including the hash-primitive proofs) — 5 pass
- two new frontend tests, both mutation-checked: returning the unshifted constant reddens them, and dropping the most-significant-bit carry convention reddens the suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)
