### PR TITLE
fix(field): repair the wasm32 SIMD GHASH module, orphaned by the Broadcast/Transformation removal

### DIFF
--- a/crates/field/src/arch/wasm32/packed_ghash_128.rs
+++ b/crates/field/src/arch/wasm32/packed_ghash_128.rs
@@ -9,18 +9,8 @@
 
 use std::arch::wasm32::*;
 
-use super::{super::portable::packed::PackedPrimitiveType, m128::M128};
-use crate::{
-	BinaryField128bGhash,
-	arch::{
-		PairwiseStrategy,
-		portable::{
-			packed_macros::impl_broadcast,
-			univariate_mul_utils_128::{Underlier128bLanes, spread_bits_64},
-		},
-	},
-	arithmetic_traits::impl_transformation_with_strategy,
-};
+use super::m128::M128;
+use crate::arch::portable::univariate_mul_utils_128::{Underlier128bLanes, spread_bits_64};
 
 /// Widening-multiply wrapper used by the GHASH packing: the reduction-deferring portable
 /// [`GhashWideMul`](crate::arch::portable::arithmetic::ghash::GhashWideMul). The WASM SIMD `M128`
@@ -33,9 +23,6 @@ pub type GhashSquare1x<T> = crate::arch::portable::arithmetic::ghash::GhashSoftM
 
 /// Invert wrapper for the `PackedBinaryGhash1x128b` packing: the shared Itoh-Tsujii inversion.
 pub type GhashInvert1x<T> = crate::arch::portable::arithmetic::itoh_tsujii::GhashItohTsujii<T>;
-
-// Define broadcast
-impl_broadcast!(M128, BinaryField128bGhash);
 
 impl Underlier128bLanes for M128 {
 	type U64 = u64;
@@ -62,9 +49,3 @@ impl Underlier128bLanes for M128 {
 		(Self::from(spread_bits_64(hi)), Self::from(spread_bits_64(lo)))
 	}
 }
-
-// Define linear transformations
-impl_transformation_with_strategy!(
-	PackedPrimitiveType<M128, BinaryField128bGhash>,
-	PairwiseStrategy
-);


### PR DESCRIPTION
## What's broken

`binius-field` does not compile for `wasm32-unknown-unknown` when `simd128` is enabled:

```
$ RUSTFLAGS="-C target-feature=+simd128" cargo build -p binius-field \
      --target wasm32-unknown-unknown

error[E0432]: unresolved imports
  `crate::arch::portable::packed_macros::impl_broadcast`,
  `crate::arithmetic_traits::impl_transformation_with_strategy`
  --> crates/field/src/arch/wasm32/packed_ghash_128.rs:18:4
```

`crates/field/src/arch/wasm32/packed_ghash_128.rs` still calls `impl_broadcast!` and
`impl_transformation_with_strategy!`. Both macros — and the `Broadcast` trait and the
`impl_transformation` mechanism they belonged to — were removed from the crate. The other
architecture modules were updated; `aarch64/packed_ghash_128.rs`, for instance, is now type
aliases only and calls neither macro.

`wasm32` was missed because `crates/field/src/arch/wasm32/mod.rs` gates the module behind
`#[cfg(target_feature = "simd128")]`, and nothing in CI builds with that flag. Without it the
target falls through to `portable` and compiles fine, so the breakage is invisible unless you
explicitly ask for SIMD — which is what someone optimising a browser build would do.

## The fix

Delete the two orphaned macro invocations and their now-unused imports. Nothing replaces
them: the abstractions they referenced no longer exist, and no other architecture module
provides an equivalent.

The module's actual contribution — `impl Underlier128bLanes for M128`, using
`u64x2_extract_lane`, `u64x2` and `u64x2_splat` — is untouched.

## Verification

- `binius-field`, `binius-circuits`, `binius-prover` and `binius-verifier` all build for
  `wasm32-unknown-unknown` with `-C target-feature=+simd128`.
- Native `cargo test -p binius-field` still passes (226 tests, 0 failures). The change is
  `wasm32`-only and cannot affect other targets.
- A ZK proof generated and verified in Chrome 150 on the resulting module: correct proof,
  63 MB heap, entropy via `getrandom`'s JS backend.

## On performance — please don't merge this expecting a speedup

Measured on the SIMD build against the portable fallback, same circuit, same browser:
**477–488 ms vs 497 ms, about 2%.**

That is what the module's own definitions predict. All three arithmetic wrappers alias the
portable implementations:

```rust
pub type GhashWideMul1x<T> = crate::arch::portable::arithmetic::ghash::GhashWideMul<T>;
pub type GhashSquare1x<T>  = crate::arch::portable::arithmetic::ghash::GhashSoftMul<T>;
pub type GhashInvert1x<T>  = crate::arch::portable::arithmetic::itoh_tsujii::GhashItohTsujii<T>;
```

Only lane splitting and joining use wasm intrinsics; the arithmetic is portable. So this is
a **correctness** fix, not an optimisation. It seems worth taking because a code path that
cannot compile is worse than no code path, and this one specifically penalises users who
reach for the obvious performance flag.

## Suggested follow-up (not in this PR)

Consider adding a `wasm32-unknown-unknown` build with `+simd128` to CI. Without one this
module is unbuildable by construction and will rot again — it is the only architecture
module that no CI configuration compiles.

---

Found while porting an Ed25519 circuit to Binius64. Happy to adjust scope or split this
differently if you'd prefer.
