### PR TITLE
Drop the claim-count and round-claim methods from the prover trait

### DIFF
--- a/crates/iop-prover/src/basefold/channel.rs
+++ b/crates/iop-prover/src/basefold/channel.rs
@@ -345,7 +345,7 @@ fn prove_batch_zk_basefold<A, F, P, NTT, Channel>(
 				store,
 				[(sum_prime, BivariateProductEvaluator::new([message_col, transparent_col]))],
 			);
-			PaddedSumcheckDecorator::new(inner, max_n - n_i)
+			PaddedSumcheckDecorator::new(inner, max_n - n_i, vec![sum_prime])
 		})
 		.collect::<Vec<_>>();
 

--- a/crates/ip-prover/src/sumcheck/common.rs
+++ b/crates/ip-prover/src/sumcheck/common.rs
@@ -31,11 +31,6 @@ pub trait SumcheckProver<F: Field> {
 	/// variable with a concrete challenge.
 	fn n_vars(&self) -> usize;
 
-	/// Returns the number of claims (composite polynomials) being proved.
-	///
-	/// This is the expected length of the Vec returned by [`Self::execute`].
-	fn n_claims(&self) -> usize;
-
 	/// Computes the prover messages for this round as a univariate polynomial.
 	///
 	/// If [`Self::fold`] has already been called on the prover with the values $r_0$, ...,
@@ -49,22 +44,8 @@ pub trait SumcheckProver<F: Field> {
 	/// For high-to-low evaluation order the variables are specified in reverse order (starting with
 	/// the highest indexed one) and hypercube sums are performed over the lower indexed variables.
 	///
-	/// The returned Vec must have length equal to [`Self::n_claims`].
+	/// One entry per claim the prover carries.
 	fn execute(&mut self) -> Vec<RoundCoeffs<F>>;
-
-	/// Returns the claimed sums for the current round, one per claim.
-	///
-	/// The returned Vec has length equal to [`Self::n_claims`]. For claim $i$, this is the value
-	/// $s_i$ that the round polynomial $R_i$ returned by [`Self::execute`] satisfies via the
-	/// sumcheck identity $s_i = R_i(0) + R_i(1)$.
-	///
-	/// This may be called either before [`Self::execute`] (when the prover holds the claim sums
-	/// directly) or after it (when the prover holds the round coefficients, in which case the value
-	/// is recovered from them). A regular sumcheck prover recovers it as $R_i(0) + R_i(1)$ (see
-	/// [`RoundCoeffs::sum_over_endpoints`]), while an MLE-check prover (see [`MleCheckProver`])
-	/// recovers it as $(1 - \alpha) R_i(0) + \alpha R_i(1)$ with $\alpha$ the round's coordinate
-	/// (see [`RoundCoeffs::lerp_over_endpoints`]).
-	fn round_claim(&self) -> Vec<F>;
 
 	/// Folds the sumcheck multilinears with a new verifier challenge.
 	fn fold(&mut self, challenge: F);
@@ -84,16 +65,8 @@ where
 		either::for_both!(self, inner => inner.n_vars())
 	}
 
-	fn n_claims(&self) -> usize {
-		either::for_both!(self, inner => inner.n_claims())
-	}
-
 	fn execute(&mut self) -> Vec<RoundCoeffs<F>> {
 		either::for_both!(self, inner => inner.execute())
-	}
-
-	fn round_claim(&self) -> Vec<F> {
-		either::for_both!(self, inner => inner.round_claim())
 	}
 
 	fn fold(&mut self, challenge: F) {

--- a/crates/ip-prover/src/sumcheck/mle_to_sumcheck.rs
+++ b/crates/ip-prover/src/sumcheck/mle_to_sumcheck.rs
@@ -50,21 +50,6 @@ impl<F: Field, InnerProver: MleCheckProver<F>> SumcheckProver<F>
 		self.mlecheck_prover.n_vars()
 	}
 
-	fn n_claims(&self) -> usize {
-		self.mlecheck_prover.n_claims()
-	}
-
-	fn round_claim(&self) -> Vec<F> {
-		// The sumcheck round claim is the inner MLE-check claim scaled by the accumulated equality
-		// prefix: R^sc(0) + R^sc(1) = eq_prefix_eval * [(1 - α) p(0) + α p(1)] = eq_prefix_eval *
-		// m, where m is the inner MLE-check round claim and p its round polynomial.
-		self.mlecheck_prover
-			.round_claim()
-			.into_iter()
-			.map(|m| m * self.eq_prefix_eval)
-			.collect()
-	}
-
 	fn execute(&mut self) -> Vec<RoundCoeffs<F>> {
 		let round_coeffs_multi = self.mlecheck_prover.execute();
 

--- a/crates/ip-prover/src/sumcheck/multilinear_eval.rs
+++ b/crates/ip-prover/src/sumcheck/multilinear_eval.rs
@@ -190,9 +190,6 @@ mod tests {
 			assert_eq!(quadratic_round[0].0.pop(), Some(F::ZERO));
 			assert_eq!(eval_round[0], quadratic_round[0]);
 
-			// `round_claim` must agree across both provers and be stable across execute.
-			assert_eq!(eval_prover.round_claim(), quadratic_prover.round_claim());
-
 			let challenge = F::random(&mut rng);
 			eval_prover.fold(challenge);
 			quadratic_prover.fold(challenge);
@@ -233,31 +230,5 @@ mod tests {
 		let mut reduced_point = sumcheck_output.challenges;
 		reduced_point.reverse();
 		assert_eq!(evaluate(&witness, &reduced_point), multilinear_evals[0]);
-	}
-
-	// `round_claim` must return the same value before and after `execute` (lerp recovery), and the
-	// post-fold claim must equal the round polynomial evaluated at the challenge.
-	#[test]
-	fn test_round_claim_invariant() {
-		let mut rng = StdRng::seed_from_u64(2);
-		let n_vars = 6;
-		let alloc = GlobalAllocator;
-
-		let witness = random_field_buffer::<P>(&mut rng, n_vars);
-		let eval_point = random_scalars::<F>(&mut rng, n_vars);
-		let eval_claim = evaluate(&witness, &eval_point);
-
-		let mut prover = multilinear_eval_prover(&alloc, witness, &eval_point, eval_claim);
-		assert_eq!(prover.round_claim(), vec![eval_claim]);
-
-		for _ in 0..n_vars {
-			let before = prover.round_claim();
-			let round = prover.execute();
-			assert_eq!(prover.round_claim(), before);
-			let challenge = F::random(&mut rng);
-			let expected_next = round[0].evaluate(&challenge);
-			prover.fold(challenge);
-			assert_eq!(prover.round_claim(), vec![expected_next]);
-		}
 	}
 }

--- a/crates/ip-prover/src/sumcheck/padded.rs
+++ b/crates/ip-prover/src/sumcheck/padded.rs
@@ -38,16 +38,28 @@ pub struct PaddedSumcheckDecorator<F: Field, Inner> {
 	round: usize,
 	/// $\prod_{k < \min(\text{round}, n_\text{extra})} \text{eq}(0, r_k)$.
 	eq_prefix: F,
+	/// The inner prover's claimed sums, one per claim.
+	///
+	/// A padding round emits its polynomial from these and leaves the inner prover untouched.
+	/// They are read only during the padding rounds, where the inner claims cannot have moved.
+	claims: Vec<F>,
 }
 
 impl<F: Field, Inner: SumcheckProver<F>> PaddedSumcheckDecorator<F, Inner> {
 	/// Wraps `inner`, padding its claim with `n_extra_vars` extra (highest-indexed) variables.
-	pub const fn new(inner: Inner, n_extra_vars: usize) -> Self {
+	///
+	/// # Arguments
+	///
+	/// * `inner` - The prover whose variable count is being raised.
+	/// * `n_extra_vars` - How many padding variables to prepend.
+	/// * `claims` - The inner prover's claimed sums, one per claim.
+	pub const fn new(inner: Inner, n_extra_vars: usize, claims: Vec<F>) -> Self {
 		Self {
 			inner,
 			n_extra_vars,
 			round: 0,
 			eq_prefix: F::ONE,
+			claims,
 		}
 	}
 
@@ -62,28 +74,16 @@ impl<F: Field, Inner: SumcheckProver<F>> SumcheckProver<F> for PaddedSumcheckDec
 		self.inner.n_vars() + self.n_extra_vars.saturating_sub(self.round)
 	}
 
-	fn n_claims(&self) -> usize {
-		self.inner.n_claims()
-	}
-
-	fn round_claim(&self) -> Vec<F> {
-		// In the padding phase the inner prover is untouched, so its round claim is the original
-		// sum `s`; in the inner phase `eq_prefix` is the full padding product. Either way the
-		// padded round claim is the inner round claim scaled by `eq_prefix`.
-		self.inner
-			.round_claim()
-			.into_iter()
-			.map(|claim| claim * self.eq_prefix)
-			.collect()
-	}
-
 	fn execute(&mut self) -> Vec<RoundCoeffs<F>> {
 		if self.in_padding_phase() {
 			// R_i(X) = (s * eq_prefix) * eq(0, X), with eq(0, X) = 1 - X. The inner prover is not
 			// touched during padding rounds.
-			self.round_claim()
-				.into_iter()
-				.map(|claim| RoundCoeffs(vec![claim, -claim]))
+			self.claims
+				.iter()
+				.map(|&claim| {
+					let scaled = claim * self.eq_prefix;
+					RoundCoeffs(vec![scaled, -scaled])
+				})
 				.collect()
 		} else {
 			self.inner
@@ -166,7 +166,7 @@ mod tests {
 		// A parallel bare inner prover, driven only on the inner-phase challenges, to compare round
 		// polynomials against.
 		let (mut bare_inner, _) = make_inner(&mut StdRng::seed_from_u64(0), &alloc, n_vars);
-		let mut padded = PaddedSumcheckDecorator::new(inner, n_extra_vars);
+		let mut padded = PaddedSumcheckDecorator::new(inner, n_extra_vars, vec![sum]);
 
 		let challenges = (0..n_vars + n_extra_vars)
 			.map(|_| F::random(&mut rng))
@@ -200,26 +200,31 @@ mod tests {
 		assert_eq!(padded.n_vars(), 0);
 	}
 
-	/// `round_claim()` called before `execute()` must equal `R(0) + R(1)` of each returned round
-	/// polynomial.
 	#[test]
-	fn test_round_claim_invariant() {
+	fn test_round_polynomials_preserve_the_claim() {
+		// Invariant: every round polynomial sums over its endpoints to the running claim.
+		//
+		// This is the identity the verifier checks each round.
+		// Tracking the claim here independently, as the verifier does, keeps the check honest.
 		let mut rng = StdRng::seed_from_u64(1);
 		let n_vars = 5;
 		let n_extra_vars = 2;
 		let alloc = GlobalAllocator;
 
-		let (inner, _) = make_inner(&mut rng, &alloc, n_vars);
-		let mut padded = PaddedSumcheckDecorator::new(inner, n_extra_vars);
+		let (inner, sum) = make_inner(&mut rng, &alloc, n_vars);
+		let mut padded = PaddedSumcheckDecorator::new(inner, n_extra_vars, vec![sum]);
 
+		// The running claim starts at the inner prover's sum, before any padding is applied.
+		let mut running = sum;
 		for _ in 0..n_vars + n_extra_vars {
-			let claims = padded.round_claim();
 			let round_coeffs = padded.execute();
-			assert_eq!(claims.len(), round_coeffs.len());
-			for (claim, coeffs) in claims.iter().zip(&round_coeffs) {
-				assert_eq!(*claim, coeffs.sum_over_endpoints());
-			}
-			padded.fold(F::random(&mut rng));
+			assert_eq!(round_coeffs.len(), 1);
+			assert_eq!(running, round_coeffs[0].sum_over_endpoints());
+
+			// The next round's claim is this polynomial at the challenge.
+			let challenge = F::random(&mut rng);
+			running = round_coeffs[0].evaluate(&challenge);
+			padded.fold(challenge);
 		}
 	}
 
@@ -237,7 +242,7 @@ mod tests {
 		let b = random_field_buffer::<P>(&mut rng, n_vars);
 		let sum = inner_product_par(&a, &b);
 		let inner = bivariate_product_prover(&alloc, [a.clone(), b.clone()], sum);
-		let padded = PaddedSumcheckDecorator::new(inner, n_extra_vars);
+		let padded = PaddedSumcheckDecorator::new(inner, n_extra_vars, vec![sum]);
 
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 		let output = prove_single(padded, &mut prover_transcript);
@@ -288,7 +293,7 @@ mod tests {
 		let alloc = GlobalAllocator;
 
 		let (inner, sum) = make_inner(&mut rng, &alloc, n_vars);
-		let padded = PaddedSumcheckDecorator::new(inner, 0);
+		let padded = PaddedSumcheckDecorator::new(inner, 0, vec![sum]);
 		assert_eq!(padded.n_vars(), n_vars);
 
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());

--- a/crates/ip-prover/src/sumcheck/quadratic_mle_evaluator.rs
+++ b/crates/ip-prover/src/sumcheck/quadratic_mle_evaluator.rs
@@ -205,7 +205,7 @@ mod tests {
 	use std::{array, iter};
 
 	use binius_compute::GlobalAllocator;
-	use binius_field::{Random, arch::OptimalPackedB128, field::FieldOps};
+	use binius_field::{arch::OptimalPackedB128, field::FieldOps};
 	use binius_ip::mlecheck;
 	use binius_math::{
 		FieldBuffer,
@@ -217,7 +217,7 @@ mod tests {
 	use rand::prelude::*;
 
 	use super::*;
-	use crate::sumcheck::{common::SumcheckProver, prove_single_mlecheck};
+	use crate::sumcheck::prove_single_mlecheck;
 
 	type StdChallenger = HasherChallenger<sha2::Sha256>;
 
@@ -320,43 +320,5 @@ mod tests {
 			|[a, b, c, d]| (a + b) * (c + d),
 			|[a, b, c, d]| (a + b) * (c + d),
 		);
-	}
-
-	#[test]
-	fn test_round_claim_lerp_recovery() {
-		type P = OptimalPackedB128;
-		type F = <P as FieldOps>::Scalar;
-
-		let n_vars = 8;
-		let mut rng = StdRng::seed_from_u64(0);
-		let alloc = GlobalAllocator;
-
-		let multilinears: [_; 2] = array::from_fn(|_| random_field_buffer::<P>(&mut rng, n_vars));
-		let composition = |[a, b]: [P; 2]| a * b;
-		let composite_vals = (0..1 << n_vars.saturating_sub(P::LOG_WIDTH))
-			.map(|i| composition(array::from_fn(|j| multilinears[j].as_ref()[i])))
-			.collect_vec();
-		let composite_vals = FieldBuffer::new(n_vars, composite_vals);
-		let eval_point = random_scalars::<F>(&mut rng, n_vars);
-		let eval_claim = evaluate(&composite_vals, &eval_point);
-
-		let mut prover = quadratic_mlecheck_prover(
-			&alloc,
-			multilinears,
-			composition,
-			composition,
-			eval_point,
-			eval_claim,
-		);
-
-		let mut expected = vec![eval_claim];
-		for _ in 0..n_vars {
-			assert_eq!(prover.round_claim(), expected, "claim before execute");
-			let round = prover.execute();
-			assert_eq!(prover.round_claim(), expected, "claim recovered from coeffs");
-			let challenge = F::random(&mut rng);
-			expected = round.iter().map(|r| r.evaluate(&challenge)).collect();
-			prover.fold(challenge);
-		}
 	}
 }

--- a/crates/ip-prover/src/sumcheck/round_evaluator.rs
+++ b/crates/ip-prover/src/sumcheck/round_evaluator.rs
@@ -243,30 +243,10 @@ where
 		self.store.n_vars() - self.buffered_challenge.is_some() as usize
 	}
 
-	/// Returns the number of claims in the group.
-	const fn n_claims(&self) -> usize {
-		self.evaluators.len()
-	}
-
 	/// Adds one more claim, reading the same store, after the existing ones.
 	fn push_claim(&mut self, claim: F, evaluator: Evaluator) {
 		self.evaluators.push(evaluator);
 		self.round_states.push(RoundState::Claim(claim));
-	}
-
-	/// Returns the claim each of this round's polynomials must satisfy.
-	///
-	/// A claim held directly is returned as is.
-	/// One already turned into coefficients is read back out by `recover`, which differs per
-	/// protocol.
-	fn round_claims(&self, recover: impl Fn(&RoundCoeffs<F>) -> F) -> Vec<F> {
-		self.round_states
-			.iter()
-			.map(|state| match state {
-				RoundState::Claim(claim) => *claim,
-				RoundState::Coeffs(coeffs) => recover(coeffs),
-			})
-			.collect()
 	}
 
 	/// Interpolates every claim's round polynomial, then records it for the coming fold.
@@ -399,16 +379,6 @@ where
 {
 	fn n_vars(&self) -> usize {
 		self.group.n_vars()
-	}
-
-	fn n_claims(&self) -> usize {
-		self.group.n_claims()
-	}
-
-	fn round_claim(&self) -> Vec<F> {
-		// A regular sumcheck polynomial carries its claim as the sum over the endpoints 0 and 1.
-		self.group
-			.round_claims(|coeffs| coeffs.sum_over_endpoints())
 	}
 
 	fn execute(&mut self) -> Vec<RoundCoeffs<F>> {
@@ -573,21 +543,6 @@ where
 {
 	fn n_vars(&self) -> usize {
 		self.group.n_vars()
-	}
-
-	fn n_claims(&self) -> usize {
-		self.group.n_claims()
-	}
-
-	fn round_claim(&self) -> Vec<F> {
-		// A prime polynomial carries its claim as the eq-weighted blend of its endpoints.
-		// The blending coordinate is the highest of the point's coordinates still unbound.
-		// It is read only where coefficients are held, and that state is gone once every variable
-		// is bound, so this stays valid to call at zero remaining variables.
-		self.group.round_claims(|coeffs| {
-			let alpha = self.eval_point[self.group.n_vars() - 1];
-			coeffs.lerp_over_endpoints(alpha)
-		})
 	}
 
 	fn execute(&mut self) -> Vec<RoundCoeffs<F>> {

--- a/crates/ip-prover/src/sumcheck/selector_mle.rs
+++ b/crates/ip-prover/src/sumcheck/selector_mle.rs
@@ -105,26 +105,6 @@ where
 		self.selected.log_len()
 	}
 
-	fn n_claims(&self) -> usize {
-		// The per-selector claims are combined into a single weighted claim.
-		1
-	}
-
-	fn round_claim(&self) -> Vec<F> {
-		let per_claim: Vec<F> = match &self.last_coeffs_or_sums {
-			RoundState::Claim(sums) => sums.clone(),
-			// This prover has a separate evaluation point per claim, so each round polynomial is
-			// interpolated against its own coordinate.
-			RoundState::Coeffs(coeffs) => izip!(coeffs, &self.eq_trackers)
-				.map(|(coeffs, eq_tracker)| {
-					coeffs.lerp_over_endpoints(eq_tracker.next_coordinate())
-				})
-				.collect(),
-		};
-		// Combine the per-claim values into the single weighted claim `Σ_i weights[i] · m_i`.
-		vec![izip!(per_claim, &self.weights).map(|(m, &w)| m * w).sum()]
-	}
-
 	fn execute(&mut self) -> Vec<RoundCoeffs<F>> {
 		let sums = self.last_coeffs_or_sums.claim();
 
@@ -280,7 +260,7 @@ where
 mod tests {
 	use std::iter::repeat_with;
 
-	use binius_field::{FieldOps, Random};
+	use binius_field::FieldOps;
 	use binius_ip::sumcheck::verify;
 	use binius_math::{
 		multilinear::{eq::eq_ind, evaluate::evaluate as multilinear_evaluate},
@@ -420,50 +400,5 @@ mod tests {
 			expected_eval, sumcheck_output.eval,
 			"reduced sumcheck claim must match the composition evaluated at the challenge point"
 		);
-	}
-
-	// `round_claim` must return the same value before and after `execute()`. This prover has a
-	// distinct evaluation point per claim, so it exercises the per-claim coordinate path.
-	#[test]
-	fn test_round_claim_per_claim_coordinate() {
-		let mut rng = StdRng::seed_from_u64(1);
-		let n_vars = 6;
-		let selector_count = 3;
-
-		let selector_mask = (1u16 << selector_count) - 1;
-		let bitmasks = repeat_with(|| rng.random::<u16>() & selector_mask)
-			.take(1 << n_vars)
-			.collect_vec();
-		let selected_scalars = random_scalars::<F>(&mut rng, 1 << n_vars);
-		let selected = FieldBuffer::<P>::from_values(&selected_scalars);
-
-		let claims = (0..selector_count)
-			.map(|i| {
-				let selector_scalars = bitmasks
-					.iter()
-					.map(|b| if (b >> i) & 1 == 1 { F::ONE } else { F::ZERO })
-					.collect_vec();
-				// The composition is `selected * selector + (1 - selector)`.
-				let masked = izip!(&selected_scalars, &selector_scalars)
-					.map(|(&selected, &selector)| selected * selector + (F::ONE - selector))
-					.collect_vec();
-				let masked = FieldBuffer::<P>::from_values(&masked);
-				let point = random_scalars::<F>(&mut rng, n_vars);
-				let value = multilinear_evaluate(&masked, &point);
-				Claim { point, value }
-			})
-			.collect_vec();
-
-		let weights = random_scalars::<F>(&mut rng, selector_count);
-		let mut prover = SelectorMlecheckProver::new(selected, claims, &bitmasks, weights, 0);
-
-		for _ in 0..n_vars {
-			// The claim recovered from the round coefficients (post-execute, via lerp against each
-			// claim's coordinate) must equal the stored claim (pre-execute).
-			let before = prover.round_claim();
-			let _ = prover.execute();
-			assert_eq!(prover.round_claim(), before, "claim recovered from coeffs");
-			prover.fold(F::random(&mut rng));
-		}
 	}
 }

--- a/crates/ip-prover/src/sumcheck/zk_mlecheck.rs
+++ b/crates/ip-prover/src/sumcheck/zk_mlecheck.rs
@@ -267,21 +267,6 @@ impl<F: Field, P: PackedField<Scalar = F>, Data: Deref<Target = [P]>> SumcheckPr
 		self.n_vars_remaining
 	}
 
-	fn n_claims(&self) -> usize {
-		1
-	}
-
-	fn round_claim(&self) -> Vec<F> {
-		let claim = match &self.last_coeffs_or_claim {
-			RoundState::Claim(claim) => *claim,
-			RoundState::Coeffs(coeffs) => {
-				let alpha = self.eval_point[self.n_vars_remaining - 1];
-				coeffs.lerp_over_endpoints(alpha)
-			}
-		};
-		vec![claim]
-	}
-
 	fn execute(&mut self) -> Vec<RoundCoeffs<F>> {
 		self.last_coeffs_or_claim.claim();
 
@@ -361,8 +346,7 @@ impl<F: Field, P: PackedField<Scalar = F>, Data: Deref<Target = [P]>> MleCheckPr
 ///
 /// # Arguments
 ///
-/// * `main_prover` - The MLE-check prover for the main polynomial. Must have exactly one claim
-///   (i.e., `n_claims() == 1`).
+/// * `main_prover` - The MLE-check prover for the main polynomial. Must carry exactly one claim.
 /// * `mask` - The mask polynomial.
 /// * `channel` - The channel for sending prover messages and sampling challenges
 ///
@@ -373,19 +357,12 @@ impl<F: Field, P: PackedField<Scalar = F>, Data: Deref<Target = [P]>> MleCheckPr
 ///
 /// # Panics
 ///
-/// Panics if `main_prover.n_claims() != 1`.
+/// Panics if the main prover emits more than one round polynomial.
 pub fn prove<F: Field, P: PackedField<Scalar = F>, Data: Deref<Target = [P]>>(
 	mut main_prover: impl MleCheckProver<F>,
 	mask: Mask<P, Data>,
 	channel: &mut impl IPProverChannel<F>,
 ) -> ProveZKOutput<F> {
-	assert_eq!(
-		main_prover.n_claims(),
-		1,
-		"prove requires main_prover to have exactly 1 claim, but it has {}",
-		main_prover.n_claims()
-	);
-
 	let n_vars = main_prover.n_vars();
 	let eval_point = main_prover.eval_point().to_vec();
 
@@ -403,7 +380,13 @@ pub fn prove<F: Field, P: PackedField<Scalar = F>, Data: Deref<Target = [P]>>(
 	for _ in 0..n_vars {
 		// Execute both provers
 		let mut main_round_coeffs_vec = main_prover.execute();
-		let main_round_coeffs = main_round_coeffs_vec.pop().expect("n_claims == 1");
+		assert_eq!(
+			main_round_coeffs_vec.len(),
+			1,
+			"prove requires a main prover with one claim, but it emitted {}",
+			main_round_coeffs_vec.len()
+		);
+		let main_round_coeffs = main_round_coeffs_vec.pop().expect("length checked above");
 
 		let mut mask_round_coeffs_vec = mask_prover.execute();
 		let mask_round_coeffs = mask_round_coeffs_vec


### PR DESCRIPTION
Removes two trait methods with no callers outside the module, one of which had no single meaning. Pure refactor — no behavior change, no transcript change.

### The problem

`SumcheckProver` required six methods. Two of them earned no external use:

| method | callers outside `sumcheck/` | implementations |
|---|---|---|
| `round_claim` | none | 8 |
| `n_claims` | none | 8 |

`round_claim` is the worse of the two, because it did not mean one thing. Its own documentation said so:

> A regular sumcheck prover recovers it as $R_i(0) + R_i(1)$ … while an MLE-check prover recovers it as $(1 - \alpha) R_i(0) + \alpha R_i(1)$

Same signature, different answer depending on which prover you were holding. The trait carried a paragraph conceding this violated the Liskov substitution principle and judging it acceptable. A method whose meaning depends on the implementor is not really a trait method.

### The change

Both are gone. `SumcheckProver` is now four methods:

```rust
fn n_vars(&self) -> usize;
fn execute(&mut self) -> Vec<RoundCoeffs<F>>;
fn fold(&mut self, challenge: F);
fn finish(self) -> Vec<F>;
```

**The one consumer takes what it needs directly.** `PaddedSumcheckDecorator` called `round_claim` only during its padding rounds — where the inner prover is deliberately untouched, so the answer is always the initial sum. It now holds those sums:

```rust
pub const fn new(inner: Inner, n_extra_vars: usize, claims: Vec<F>) -> Self
```

Its single external caller already had the value: it passes `vec![sum_prime]`, the same claim it hands the inner prover one line above.

**The claim count had one use**, an assertion that the main prover carries exactly one claim before batching it with a mask polynomial. That is now checked on the emitted round polynomials, two lines from where the code already inspected them for the same purpose. One invariant, one mechanism, where there were three.

### A side effect worth noting

`sum_over_endpoints` and `lerp_over_endpoints` are now reached only by the verifier in `binius-ip`, plus two provers tracking their own state. They were prover-side claim-recovery helpers threaded through a trait; they are back to being what their names suggest.

### Tests

Three tests existed solely to exercise the removed method — each asserting it returned the same value before and after a round. That property is vacuous once the method is gone, and the identity that matters is already covered by the prove/verify roundtrips in every file. They are removed, along with one cross-check line in a conformance test.

The fourth tested something real, so it is rewritten rather than deleted. It now tracks the claim independently, the way a verifier does:

```rust
let mut running = sum;
for _ in 0..total {
    let coeffs = padded.execute();
    assert_eq!(running, coeffs[0].sum_over_endpoints());
    let challenge = F::random(&mut rng);
    running = coeffs[0].evaluate(&challenge);
    padded.fold(challenge);
}
```

That is stronger than what it replaced. Before, it compared a round polynomial against a method that could have been wrong in the same way; now it compares against an independent computation.

### Scope

- **removed:** two trait methods, their eight implementations, and the group helpers backing them.
- **changed:** `PaddedSumcheckDecorator::new` gains a `claims` argument, and its one caller passes the sum it already had.
- **unchanged:** every round polynomial, every fold, every transcript.
- 52 insertions, 283 deletions across 9 files.

### Verification

- `cargo check --workspace --all-targets` — clean. For removing trait methods this is the primary gate: every call site in every crate has to typecheck.
- `cargo nextest run -p binius-ip-prover -p binius-iop-prover` — 99 passed, 0 failed. These are the only two crates with a behavioral change; elsewhere the change is compile-time only.
- `cargo clippy --workspace --all-targets --all-features` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc -p binius-ip-prover --no-deps` — clean
- `cargo +nightly fmt --all --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)