### PR TITLE
Delete the checked-in proptest regression seeds and ignore the folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ perfetto_traces/
 *.perfetto-trace
 .last_perfetto_trace_path
 *.pending-snap
+# Proptest failure seeds, written by whichever crate's tests happened to fail locally
+proptest-regressions/

--- a/crates/circuits/proptest-regressions/concat.txt
+++ b/crates/circuits/proptest-regressions/concat.txt
@@ -1,8 +1,0 @@
-# Seeds for failure cases proptest has generated in the past. It is
-# automatically read and these particular cases re-run before any
-# novel cases are generated.
-#
-# It is recommended to check this file in to source control so that
-# everyone who runs the test benefits from these saved cases.
-cc aa6139073fbf3838e94c5edae473d19199ce90bc7607a33d68a3a94387b7787d # shrinks to term_specs = [([97], 8), ([135, 169, 119, 151, 72, 136, 141, 165, 217], 16)]
-cc c3794747371d19a48f6c46e6eeb6f5a5e95754abb0664a8d8b92174ff7055c8f # shrinks to n_terms = 2, base_size = 121

--- a/crates/circuits/proptest-regressions/hash_based_sig/chain_verification.txt
+++ b/crates/circuits/proptest-regressions/hash_based_sig/chain_verification.txt
@@ -1,7 +1,0 @@
-# Seeds for failure cases proptest has generated in the past. It is
-# automatically read and these particular cases re-run before any
-# novel cases are generated.
-#
-# It is recommended to check this file in to source control so that
-# everyone who runs the test benefits from these saved cases.
-cc 34e58b17f8ddae654ed26644dae446a9665b1c131205fe12c209147395a68624 # shrinks to (starting_position_val, max_chain_len) = (0, 1), chain_index_val = 0, domain_param_bytes = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], signature_hash_bytes = [0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]

--- a/crates/circuits/proptest-regressions/hash_based_sig/hashing/chain.txt
+++ b/crates/circuits/proptest-regressions/hash_based_sig/hashing/chain.txt
@@ -1,7 +1,0 @@
-# Seeds for failure cases proptest has generated in the past. It is
-# automatically read and these particular cases re-run before any
-# novel cases are generated.
-#
-# It is recommended to check this file in to source control so that
-# everyone who runs the test benefits from these saved cases.
-cc 25bf5aac87e3e81cce96618429eff6503409b8d0c01c0a224c2df5ab3b319477 # shrinks to domain_param_len = 9, chain_index = 0, position = 0

--- a/crates/circuits/proptest-regressions/hash_based_sig/hashing/message.txt
+++ b/crates/circuits/proptest-regressions/hash_based_sig/hashing/message.txt
@@ -1,7 +1,0 @@
-# Seeds for failure cases proptest has generated in the past. It is
-# automatically read and these particular cases re-run before any
-# novel cases are generated.
-#
-# It is recommended to check this file in to source control so that
-# everyone who runs the test benefits from these saved cases.
-cc 6a4a4b1b66bf85ba8a46e4e4b360cd5945cd4a67d8471b5223a0c37731c59d62 # shrinks to domain_param_len = 1, nonce_len = 7, message_len = 121

--- a/crates/circuits/proptest-regressions/hash_based_sig/hashing/public_key.txt
+++ b/crates/circuits/proptest-regressions/hash_based_sig/hashing/public_key.txt
@@ -1,7 +1,0 @@
-# Seeds for failure cases proptest has generated in the past. It is
-# automatically read and these particular cases re-run before any
-# novel cases are generated.
-#
-# It is recommended to check this file in to source control so that
-# everyone who runs the test benefits from these saved cases.
-cc e486398ef8e561f09e65830d550e1f79389a4407307338efeb92eefde4775d1f # shrinks to domain_param_len = 9, num_hashes = 1

--- a/crates/circuits/proptest-regressions/hash_based_sig/hashing/tree.txt
+++ b/crates/circuits/proptest-regressions/hash_based_sig/hashing/tree.txt
@@ -1,7 +1,0 @@
-# Seeds for failure cases proptest has generated in the past. It is
-# automatically read and these particular cases re-run before any
-# novel cases are generated.
-#
-# It is recommended to check this file in to source control so that
-# everyone who runs the test benefits from these saved cases.
-cc d9e55e29c308d14d3500ad626be5a90f0b07d2c77baf6136a29b6e9ce00ac49a # shrinks to domain_param_len = 25, level = 0, index = 0

--- a/crates/prover/proptest-regressions/fri/fold.txt
+++ b/crates/prover/proptest-regressions/fri/fold.txt
@@ -1,8 +1,0 @@
-# Seeds for failure cases proptest has generated in the past. It is
-# automatically read and these particular cases re-run before any
-# novel cases are generated.
-#
-# It is recommended to check this file in to source control so that
-# everyone who runs the test benefits from these saved cases.
-cc 2ce3065cd63f4dc407359d34133ca788c9c95c97ec85df47645836147d70c0e4 # shrinks to log_dim = 0, arity = 0
-cc b89c959ccca065493f9c6e5b3aa3bfbfc8702981e1c14124f343a440b19ae063 # shrinks to log_dim = 0, arity = 1


### PR DESCRIPTION
Removes both `proptest-regressions/` folders and adds a `.gitignore` rule so a locally failing test run stops producing a tracked file. No source changes.

### The problem

Two crates carry a checked-in `proptest-regressions/` folder, and neither was added on purpose.

| Folder | Arrived in | State |
|---|---|---|
| `crates/prover/proptest-regressions/` | `eee53055` (new NTT implementation), `df4ca262` (directory consolidation) | dead outright |
| `crates/circuits/proptest-regressions/` | `5a915b3a` (blake3 refactor) | 4 of 6 files live |

Both were swept in alongside unrelated feature work. Nothing in `CONTRIBUTING.md`, `AGENTS.md`, or CI references them, so no workflow depends on them being present.

### Why the prover one is dead

Its only file is `fri/fold.txt`, holding two seeds keyed to `log_dim` and `arity`.

- `crates/prover/src/fri/` no longer exists — FRI moved to `iop-prover`.
- The prover crate contains zero `proptest!` blocks.

So proptest has not loaded those seeds in a long time. Two of the circuits files are stale the same way: they name a `hash_based_sig::hashing::chain` module that is now `chain_blake3`.

### The change

Delete both folders, and add to `.gitignore`:

```
# Proptest failure seeds, written by whichever crate's tests happened to fail locally
proptest-regressions/
```

A trailing-slash pattern with no leading slash matches at any depth, so this covers every current and future crate without per-crate entries.

The rule alone would not have been enough — `.gitignore` never untracks what git already tracks, so the seven files had to go via `git rm` for the rule to describe reality.

### Scope

- **deleted:** all 7 seed files across the two folders (−51 lines)
- **changed:** `.gitignore` (+2 lines)
- **untouched:** every `.rs` file — no test bodies, no source

### What this trades away

Four of the circuits files were live, mapping to real proptests in `concat`, `hashing/message`, `hashing/public_key`, and `hashing/tree`.

Proptest re-runs saved seeds before generating novel cases, so those four were acting as free pinned regression cases. After this they are gone, and a regression on one of those exact shapes needs a lucky seed to resurface rather than being caught deterministically.

That seemed the right trade given none of them were curated deliberately, and two of the six had already rotted into orphans by following a module rename — which is the durable argument for promoting a shrunken counterexample into a named `#[test]` rather than leaving it in a path-keyed seed file.

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo test -p binius-prover` — 26 + 13 + 1 passed, 0 failed
- `cargo test -p binius-circuits` — 332 + 3 + 1 passed, 0 failed (8 ignored, pre-existing)
- `git check-ignore -v` on regenerated paths in both crates — both matched by the new rule
- recreated both folders, confirmed `git status` reports nothing, then removed them

Neither test run regenerated a folder, which is the check that matters here: proptest writes a seed file only on failure, so an empty tree after a full run means every property held on freshly generated cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)