### PR TITLE
Split the Reed-Solomon codeword replication across workers

### DIFF
--- a/crates/math/src/reed_solomon.rs
+++ b/crates/math/src/reed_solomon.rs
@@ -5,7 +5,10 @@
 //!
 //! See [`ReedSolomonCode`] for details.
 
+use std::ptr;
+
 use binius_field::{BinaryField, PackedField};
+use binius_utils::rayon::{prelude::*, task_size::task_chunk_len};
 use getset::{CopyGetters, Getters};
 
 use super::{
@@ -158,39 +161,102 @@ impl<F: BinaryField> ReedSolomonCode<F> {
 			let elem_0 = P::from_scalars(scalars.into_iter().cycle());
 			vec![elem_0; 1 << log_output_len.saturating_sub(P::LOG_WIDTH)]
 		} else {
-			let output_packed_len = 1 << (log_output_len - P::LOG_WIDTH);
-			let mut output_data = Vec::with_capacity(output_packed_len);
-
-			output_data.extend_from_slice(data.as_ref());
-
-			// Bit-reverse permute the message.
-			bit_reverse_packed(FieldSliceMut::from_slice(
-				data.log_len(),
-				output_data.as_mut_slice(),
-			));
-
-			// Fill the codeword buffer by repeatedly doubling the initialized prefix.
-			// Each pass appends one copy of everything written so far.
-			//
-			//     [msg] -> [msg|msg] -> [msg|msg|msg|msg] -> ...
-			//
 			// The forward transform below skips its first `log_inv_rate` layers.
 			// Each skipped layer would butterfly a coefficient with a zero pad:
 			//
 			//     u += v * twiddle; v += u;   with v = 0   =>   (c, 0) -> (c, c)
 			//
-			// That is one doubling per layer, so the doublings reproduce the skipped work.
-			while output_data.len() < output_packed_len {
-				output_data.extend_from_within(..);
-			}
+			// That is one doubling per layer, so repeating the message does the skipped work.
+			let output_packed_len = 1 << (log_output_len - P::LOG_WIDTH);
 
-			output_data
+			// A run is the words one worker copies at a time.
+			// It is a power of two at most the message length, so it divides the message evenly.
+			let run = data
+				.as_ref()
+				.len()
+				.min(task_chunk_len::<P>().next_power_of_two());
+
+			repeated_message_buffer(data, output_packed_len, run)
 		};
 		let mut output = FieldBuffer::new(log_output_len, output_data);
 
 		ntt.forward_transform(output.to_mut(), self.log_inv_rate, log_batch_size);
 		output
 	}
+}
+
+/// Builds a buffer of `total` words holding the bit-reversed message, repeated.
+///
+/// # Overview
+///
+/// ```text
+///     [msg]  ->  [rev msg | rev msg | rev msg | rev msg]
+/// ```
+///
+/// The leading copy is filled from the message, then permuted.
+/// Every later copy is filled from that leading copy, so the permutation runs once.
+/// Both fills split into runs, so more than one worker carries a long message.
+///
+/// # Arguments
+///
+/// * `msg` - the message to repeat
+/// * `total` - word count of the returned buffer
+/// * `run` - words one worker copies at a time
+///
+/// # Preconditions
+///
+/// * `msg` holds at least one whole word, and `total` is a multiple of its word count
+/// * `run` is a power of two, and at most the message's word count
+fn repeated_message_buffer<P: PackedField>(msg: FieldSlice<P>, total: usize, run: usize) -> Vec<P> {
+	let msg_len = msg.as_ref().len();
+	debug_assert!(msg_len.is_power_of_two());
+	debug_assert!(run.is_power_of_two() && run <= msg_len);
+	debug_assert_eq!(total % msg_len, 0);
+
+	let mut output = Vec::<P>::with_capacity(total);
+
+	// Copy the message into the leading copy.
+	let head = &mut output.spare_capacity_mut()[..msg_len];
+	(head.par_chunks_mut(run), msg.as_ref().par_chunks(run))
+		.into_par_iter()
+		.for_each(|(dst, src)| {
+			// SAFETY:
+			// - The two runs have equal length: one position, two buffers of one length.
+			// - They live in different buffers, so they cannot overlap.
+			unsafe {
+				ptr::copy_nonoverlapping(src.as_ptr(), dst.as_mut_ptr().cast::<P>(), src.len());
+			}
+		});
+	// SAFETY: the loop above wrote every one of the leading `msg_len` words.
+	unsafe { output.set_len(msg_len) };
+
+	// Permute the leading copy, so the copies below inherit it.
+	bit_reverse_packed(FieldSliceMut::from_slice(msg.log_len(), output.as_mut_slice()));
+
+	// The source is read through an address rather than a borrow.
+	// That is what lets the workers read the leading copy while the rest is held mutably.
+	let msg_ptr = output.as_ptr() as usize;
+	let tail = &mut output.spare_capacity_mut()[..total - msg_len];
+	tail.par_chunks_mut(run).enumerate().for_each(|(i, dst)| {
+		// Run `i` of the tail sits one whole message past run `i` of the buffer.
+		// The message length is a power of two, so masking that position gives its source.
+		let src_offset = (i * run) & (msg_len - 1);
+
+		// SAFETY:
+		// - The offset is masked into the leading copy, and a run divides it evenly.
+		// - So the source run lies inside the leading copy, which is initialized.
+		// - Nothing writes the leading copy here, and the destination lies past it.
+		// - The address stays live because the buffer outlives this loop.
+		unsafe {
+			let msg = msg_ptr as *const P;
+			ptr::copy_nonoverlapping(msg.add(src_offset), dst.as_mut_ptr().cast::<P>(), dst.len());
+		}
+	});
+
+	// SAFETY: the loop above wrote every word between the leading copy and `total`.
+	unsafe { output.set_len(total) };
+
+	output
 }
 
 #[cfg(test)]
@@ -346,5 +412,44 @@ mod tests {
 		test_lift_duplicate_identity_helper::<PackedBinaryGhash1x128b>(0, 4, 3);
 		// Same lifts with a wider packing width.
 		test_lift_duplicate_identity_helper::<PackedBinaryGhash4x128b>(4, 8, 2);
+	}
+
+	// One serial copy of the message, one permutation, then a chain of doublings.
+	// That is the plain form of the same construction, so it pins the run-split form.
+	fn repeated_message_buffer_reference<P: PackedField>(
+		msg: FieldSlice<P>,
+		total: usize,
+	) -> Vec<P> {
+		let mut output = Vec::with_capacity(total);
+		output.extend_from_slice(msg.as_ref());
+
+		bit_reverse_packed(FieldSliceMut::from_slice(msg.log_len(), output.as_mut_slice()));
+
+		while output.len() < total {
+			output.extend_from_within(..);
+		}
+		output
+	}
+
+	#[test]
+	fn test_repeated_message_buffer_matches_the_doubling_chain() {
+		let mut rng = StdRng::seed_from_u64(0);
+
+		// Fixture state: messages of 1 to 16 words, each repeated 1 to 8 times over.
+		for log_msg in 0..5 {
+			for log_copies in 0..4 {
+				let msg = random_field_buffer::<PackedBinaryGhash1x128b>(&mut rng, log_msg);
+				let total = (1 << log_msg) << log_copies;
+				let expected = repeated_message_buffer_reference(msg.to_ref(), total);
+
+				// Every run width a caller can pass, from one word up to the whole message.
+				// A run under the message length is what splits a fill across workers.
+				// The encoder only reaches that on a message above one mebibyte.
+				for log_run in 0..=log_msg {
+					let built = repeated_message_buffer(msg.to_ref(), total, 1 << log_run);
+					assert_eq!(built, expected, "log_msg={log_msg} log_run={log_run}");
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
The encoder builds its codeword by repeating the message. That repetition was two serial memcpys; it is now two parallel passes. Byte-for-byte the same codeword — the arithmetic and the byte count are untouched, only which core writes which run.

### The problem

A Reed-Solomon codeword of a repeated message *is* the repeated message, up to the layers the transform skips:

```
u += v * twiddle; v += u;   with v = 0   =>   (c, 0) -> (c, c)
```

So the encoder repeats the message instead of zero-padding it. It did that with two serial passes:

- `extend_from_slice` copied the message in;
- a `while` loop then doubled the initialized prefix until the buffer was full.

At rate 1/2 that is two message-sized memcpys on one core, ahead of a transform that is already parallel.

### The idea

Fill the leading copy from the message, permute it, then fill every later copy from that leading copy. Both fills are one parallel pass over runs:

```
[msg]  ->  [rev msg | rev msg | rev msg | rev msg]
```

A run is a power of two no larger than the message, so it divides the message evenly and every destination run draws from one contiguous source run. The doubling chain becomes a single pass with a masked source offset.

The permutation still runs once, on the leading copy only, exactly as before.

### The change

```
-output_data.extend_from_slice(data.as_ref());
-bit_reverse_packed(..);
-while output_data.len() < output_packed_len {
-    output_data.extend_from_within(..);
-}
+repeated_message_buffer(data, output_packed_len, run)
```

The construction moves into one function so that the run splitting is testable at run widths the encoder itself only reaches on a message above one mebibyte.

### Scope

- **changed:** `crates/math/src/reed_solomon.rs` only — one file, no API change.
- The sub-packing-width branch is untouched.
- Writes go through reserved capacity, one pass, so no buffer is written twice.

### Verification

- `cargo check --workspace --all-targets`, `clippy -p binius-math --all-targets`, nightly `fmt` — clean.
- `binius-math`: 130 tests pass with `rayon` on **and** off, since the sequential shim is a different code path.
- `binius-iop-prover`: 40 tests pass (the FRI encode path is the caller).
- The new construction is pinned against the plain copy-permute-double form at every run width from one word to the whole message, across message lengths 1..16 words and 1..8 repeats. The existing encode tests independently compare against a zero-padded-NTT reference at rates 4 and 8 on two packings.
- Mutation-checked: dropping the source-offset mask, and truncating either fill to its first run, each fail the suite. The first design of the test missed the head-copy mutation, which is what prompted extracting the whole construction rather than only the doubling chain.

### Benchmark

Both constructions in one binary, criterion alternating, 16 MiB message at rate 1/2, M1 Pro, 10 threads:

| | before | after | |
|---|---|---|---|
| build the repeated buffer | 2.902 ms | 2.395 ms | **1.21x** |

Read this honestly: `encode_batch` at that shape is 46.5 ms, so the saving is about 1% of the encode, not of a proof. The copies on their own move about 1.5x, which is all a bandwidth-bound memcpy has to give when one core already reaches a good fraction of this machine's bandwidth. The value is that the pass no longer sits on one core ahead of a parallel transform.

<details>
<summary>Throwaway A/B harness used for the table (not part of this PR)</summary>

Add as `crates/math/benches/rs_replicate_ab.rs` with a matching `[[bench]]` entry, temporarily make `repeated_message_buffer` public, then
`cargo bench -p binius-math --features rayon,test-utils --bench rs_replicate_ab`.

```rust
use binius_field::{BinaryField128bGhash, PackedBinaryGhash1x128b, PackedField};
use binius_math::{
    FieldSlice, FieldSliceMut, bit_reverse::bit_reverse_packed, reed_solomon::ReedSolomonCode,
    test_utils::random_field_buffer,
};
use binius_utils::rayon::task_size::task_chunk_len;
use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};

/// The construction as of the parent commit: one serial copy, then a doubling chain.
fn head<P: PackedField>(msg: FieldSlice<P>, total: usize) -> Vec<P> {
    let mut output = Vec::with_capacity(total);
    output.extend_from_slice(msg.as_ref());
    bit_reverse_packed(FieldSliceMut::from_slice(msg.log_len(), output.as_mut_slice()));
    while output.len() < total {
        output.extend_from_within(..);
    }
    output
}

fn bench_ab(c: &mut Criterion) {
    type P = PackedBinaryGhash1x128b;
    let mut group = c.benchmark_group("rs_replicate");

    for (log_dim, log_inv_rate) in [(20usize, 1usize)] {
        let mut rng = rand::rng();
        let msg = random_field_buffer::<P>(&mut rng, log_dim);
        let total = 1 << (log_dim + log_inv_rate);
        let parameter = format!("log_dim={log_dim},rate=1/{}", 1 << log_inv_rate);
        group.throughput(Throughput::Bytes((total * 16) as u64));

        group.bench_function(BenchmarkId::new("head", &parameter), |b| {
            b.iter(|| head(msg.to_ref(), total))
        });
        let run = msg.as_ref().len().min(task_chunk_len::<P>().next_power_of_two());
        group.bench_function(BenchmarkId::new("parallel", &parameter), |b| {
            b.iter(|| binius_math::reed_solomon::repeated_message_buffer(msg.to_ref(), total, run))
        });

        // The whole encode, so the share of it this change touches is visible.
        let rs = ReedSolomonCode::<BinaryField128bGhash>::new(log_dim, log_inv_rate);
        let subspace = rs.subspace().clone();
        let dc = binius_math::ntt::domain_context::GenericPreExpanded::generate_from_subspace(
            &subspace,
        );
        let ntt = binius_math::ntt::NeighborsLastReference { domain_context: &dc };
        group.bench_function(BenchmarkId::new("encode_batch_total", &parameter), |b| {
            b.iter(|| rs.encode_batch::<P, _>(&ntt, msg.to_ref(), 0))
        });
    }

    group.finish();
}

criterion_group! {
    name = default;
    config = Criterion::default().sample_size(20).significance_level(0.01);
    targets = bench_ab
}
criterion_main!(default);
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)