### PR TITLE
Seed the parallel merges of the shift and ring-switch folds with a partial

### DIFF
--- a/crates/ip-prover/src/sumcheck/selector_mle.rs
+++ b/crates/ip-prover/src/sumcheck/selector_mle.rs
@@ -196,10 +196,11 @@ where
 				},
 			)
 			.map(|(evals, _, _)| evals)
-			.reduce(
-				|| vec![RoundEvals2::<P>::default(); sums.len()],
-				|lhs, rhs| izip!(lhs, rhs).map(|(l, r)| l + &r).collect(),
-			);
+			// A merge seeded with a partial that already exists never touches a buffer of zeros.
+			// An identity would allocate and zero one accumulator per merge, then add all of it.
+			.reduce_with(|lhs, rhs| izip!(lhs, rhs).map(|(l, r)| l + &r).collect())
+			// An empty hypercube yields no partials at all, and its round evals are zero.
+			.unwrap_or_else(|| vec![RoundEvals2::<P>::default(); sums.len()]);
 
 		// This prover has multiple evaluation points and cannot implement MleCheckProver.
 		let (prime_coeffs, round_coeffs) = izip!(&self.eq_trackers, sums, packed_prime_evals)

--- a/crates/prover/src/protocols/shift/phase_1.rs
+++ b/crates/prover/src/protocols/shift/phase_1.rs
@@ -293,15 +293,16 @@ pub fn build_g_parts<F: BinaryField, P: PackedField<Scalar = F>, A: Allocator>(
 				multilinears
 			},
 		)
-		.reduce(
-			|| zeroed_vec::<P>(acc_size).into_boxed_slice(),
-			|mut acc, local| {
-				izip!(acc.iter_mut(), local.iter()).for_each(|(acc, local)| {
-					*acc += *local;
-				});
-				acc
-			},
-		);
+		// A merge seeded with a partial that already exists never touches a buffer of zeros.
+		// An identity would allocate and zero one accumulator per merge, then add all of it.
+		.reduce_with(|mut acc, local| {
+			izip!(acc.iter_mut(), local.iter()).for_each(|(acc, local)| {
+				*acc += *local;
+			});
+			acc
+		})
+		// An empty word list yields no partials at all, and its parts are zero.
+		.unwrap_or_else(|| zeroed_vec::<P>(acc_size).into_boxed_slice());
 
 	build_multilinear_parts(alloc, &multilinears)
 }

--- a/crates/prover/src/ring_switch.rs
+++ b/crates/prover/src/ring_switch.rs
@@ -153,15 +153,16 @@ where
 				acc
 			},
 		)
-		.reduce(
-			|| FieldBuffer::zeros(log_scalar_bit_width),
-			|mut lhs, rhs| {
-				for (lhs_i, &rhs_i) in izip!(lhs.as_mut(), rhs.as_ref()) {
-					*lhs_i += rhs_i;
-				}
-				lhs
-			},
-		)
+		// A merge seeded with a partial that already exists never touches a buffer of zeros.
+		// An identity would allocate and zero one accumulator per merge, then add all of it.
+		.reduce_with(|mut lhs, rhs| {
+			for (lhs_i, &rhs_i) in izip!(lhs.as_mut(), rhs.as_ref()) {
+				*lhs_i += rhs_i;
+			}
+			lhs
+		})
+		// An empty matrix yields no partials at all, and folds to zero.
+		.unwrap_or_else(|| FieldBuffer::zeros(log_scalar_bit_width))
 }
 
 /// Builds the ring-switching equality indicator directly from the tensor's two factors.


### PR DESCRIPTION
Three parallel folds ended with rayon's `reduce` over an identity closure that builds a zeroed accumulator. Replacing it with `reduce_with` makes the shift protocol's g-parts build **1.58x** faster. No arithmetic changes.

### The problem

`build_g_parts` folds the witness words into an accumulator of

```
SHIFT_VARIANT_COUNT << (2 * Word::LOG_BITS)  =  4 * 4096  =  16,384 field elements  =  256 KiB
```

and finishes with

```rust
.reduce(
    || zeroed_vec::<P>(acc_size).into_boxed_slice(),
    |mut acc, local| { /* add every word of local into acc */ acc },
)
```

An identity closure costs twice over, and both costs are pure waste:

- **It roughly doubles the merges.** Rayon applies the merge once per identity as well as once per pair of partials. Instrumented on a real shift round trip: **about 14,400 merge calls with the identity, about 7,200 without.**
- **Each of those extra merges allocates 256 KiB, zeroes it, and then adds every word of a buffer of zeros** into the real accumulator.

### The idea

Seed each merge with a partial that already exists. That is exactly `reduce_with`, whose result is an `Option` because an empty iterator has no partial to seed from:

```rust
-.reduce(|| zeroed_vec::<P>(acc_size).into_boxed_slice(), op)
+.reduce_with(op)
+.unwrap_or_else(|| zeroed_vec::<P>(acc_size).into_boxed_slice())
```

The empty case, which the identity used to cover implicitly, now falls back to one zeroed accumulator. That is the correct value: an empty word list contributes nothing.

### Why this is exact

Addition in $\mathbb{F}_{2^{128}}$ is associative and commutative, and `x + 0 = x`.

- Dropping merges against zero cannot change the sum.
- The merge order rayon chooses is already unconstrained, and the result is order-independent.
- So the output is bit-identical and the transcript cannot move.

### Scope

Same one-line pattern at three sites:

- `crates/prover/src/protocols/shift/phase_1.rs` — the 256 KiB g-parts accumulator, the one measured below.
- `crates/prover/src/ring_switch.rs` — the row-fold column accumulator.
- `crates/ip-prover/src/sumcheck/selector_mle.rs` — the per-claim round evals, whose identity also allocates a `Vec` per merge.

### Verification

- `cargo check --workspace --all-targets`, `clippy` on both crates, nightly `fmt` — clean.
- `binius-prover` 40 tests and `binius-ip-prover` 59 tests pass, including the shift round trips and the prove-verify round trips that drive all three folds.

### Benchmark

Timed the g-parts build across ten shift round trips, three runs per arm, M1 Pro:

| | run 1 | run 2 | run 3 |
|---|---|---|---|
| zeroed identity | 107.1 ms | 105.8 ms | 100.6 ms |
| seeded merge | 66.7 ms | 64.4 ms | 71.9 ms |

**About 1.58x**, and the merge counts above confirm the mechanism rather than leaving it inferred.

Only this site is timed. The ring-switch numbers came out unusable on a loaded machine, and the selector site has no bench; both take the change on the reasoning above, which is a strict reduction in work at any site.

### A blocker worth flagging separately

`crates/prover/benches/shift_reduction.rs` **panics on unmodified `main`** — both the `prove` and the `phase1_*` arms:

```
thread panicked at crates/prover/src/protocols/shift/key_collection.rs:154:
index out of bounds: the len is 1 but the index is 611
```

Its `PreparedOperatorData` is built with a single lambda power while the keys index into the hundreds. So there is currently no working benchmark for the shift phase, which is why the table above comes from an in-source timer driven by `tests/shift.rs` rather than from criterion. Worth its own fix.

<details>
<summary>How the table was produced (throwaway, not part of this PR)</summary>

Add a nanosecond counter around the body of `build_g_parts` and a counter in the merge closure:

```rust
pub static NANOS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
pub static MERGES: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
```

then drive it from the existing integration test:

```rust
#[test]
fn report_merge_counts() {
    use std::sync::atomic::Ordering;
    use binius_prover::protocols::shift::phase_1::{MERGES, NANOS};

    test_shift_prove_and_verify(); // warm up
    MERGES.store(0, Ordering::Relaxed);
    NANOS.store(0, Ordering::Relaxed);
    for _ in 0..10 {
        test_shift_prove_and_verify();
    }
    println!(
        "merges={} total_ms={:.3}",
        MERGES.load(Ordering::Relaxed),
        NANOS.load(Ordering::Relaxed) as f64 / 1e6
    );
}
```

`cargo test -p binius-prover --features rayon --release --test shift report_merge_counts -- --nocapture`

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)