### PR TITLE
Drop the binius-transcript dependency from binius-hash

### DIFF
--- a/crates/hash/Cargo.toml
+++ b/crates/hash/Cargo.toml
@@ -11,7 +11,6 @@ workspace = true
 
 [dependencies]
 binius-field = { path = "../field" }
-binius-transcript = { path = "../transcript" }
 binius-utils = { path = "../utils" }
 blake3 = { workspace = true, features = ["traits-preview"] }
 bytemuck.workspace = true

--- a/crates/hash/src/serialization.rs
+++ b/crates/hash/src/serialization.rs
@@ -2,9 +2,8 @@
 
 use std::{borrow::Borrow, cmp::min};
 
-use binius_transcript::BufMut;
 use binius_utils::{SerializationError, SerializeBytes};
-use bytes::buf::UninitSlice;
+use bytes::{BufMut, buf::UninitSlice};
 use digest::{
 	Digest, Output,
 	block_api::{Block, BlockSizeUser},


### PR DESCRIPTION
`binius-hash` depended on `binius-transcript` for a single import that resolves to a `bytes` re-export. Removing it costs two lines and breaks a latent dependency cycle.

### The problem

`crates/hash/src/serialization.rs` opened with:

```rust
use binius_transcript::BufMut;
use binius_utils::{SerializationError, SerializeBytes};
use bytes::buf::UninitSlice;        // already importing from bytes directly
```

`binius_transcript::BufMut` is not a transcript type. It is a plain re-export — `transcript/src/lib.rs` has `pub use bytes::{Buf, BufMut};`.

So the entire `binius-hash -> binius-transcript` edge existed to alias `bytes::BufMut`, while the next line already imported from `bytes` and `bytes.workspace = true` was already in `crates/hash/Cargo.toml`.

That one line was the only `binius_transcript` reference anywhere in the crate — source, tests, and benches.

### Why it is worth removing, not just tidy

This is a cycle waiting to happen.

`binius-transcript` currently hashes with raw `digest` and `sha2` rather than with `binius-hash`, so the graph is acyclic today. Point the challenger at a Binius hasher — a Vision or Groestl challenger, say — and you get `hash -> transcript -> hash`, with this vestigial import as the thing to untangle first.

Removing it now means that future change is about the challenger, not about a stray re-export.

### The change

```
crates/hash/src/serialization.rs
- use binius_transcript::BufMut;
  use binius_utils::{SerializationError, SerializeBytes};
- use bytes::buf::UninitSlice;
+ use bytes::{BufMut, buf::UninitSlice};

crates/hash/Cargo.toml
- binius-transcript = { path = "../transcript" }
```

Same trait, same impl, one fewer crate in the graph. `HashBuffer`'s `unsafe impl BufMut` is untouched.

### Scope

- **changed:** one import in `crates/hash/src/serialization.rs`, one dep line in `crates/hash/Cargo.toml`
- **untouched:** every other file, and the `binius-transcript` crate itself
- no public API moves — `BufMut` was never re-exported from `binius-hash`

### Verification

- `cargo check --workspace --all-targets` — clean, after touching the crate to force a real rebuild rather than a fingerprint hit
- `cargo clippy -p binius-hash --all-targets` — no warnings
- `cargo +nightly fmt --all -- --check` — exit 0
- `cargo test -p binius-hash` — 21 passed, 0 failed
- `cargo tree -p binius-hash -i bytes` — a single `bytes v1.12.0`, so the `BufMut` the file now imports is the same trait it was getting through the re-export

That last check is the one that matters for correctness here: had the workspace carried two `bytes` majors, swapping the import path could have silently changed which `BufMut` the `unsafe impl` targets. It does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)