### PR TITLE
Move the NTT bench's env flag out of binius-utils and fix its case handling

### DIFF
--- a/crates/math/benches/ntt.rs
+++ b/crates/math/benches/ntt.rs
@@ -12,7 +12,7 @@ use binius_math::{
 	},
 	test_utils::random_field_buffer,
 };
-use binius_utils::{env::boolean_env_flag_set, rayon::ThreadPoolBuilder};
+use binius_utils::rayon::ThreadPoolBuilder;
 use criterion::{
 	BenchmarkGroup, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main,
 	measurement::WallTime,
@@ -226,11 +226,23 @@ const fn num_muls(log_d: usize, skip_early: usize, skip_late: usize) -> u64 {
 	num_rounds as u64 * muls_per_round
 }
 
+/// Returns whether `flag` is set in the environment to an affirmative value.
+///
+/// Matching ignores surrounding whitespace and ASCII case, so `On` and `TRUE` both count.
+fn env_flag_set(flag: &str) -> bool {
+	std::env::var(flag).is_ok_and(|val| {
+		let val = val.trim();
+		["1", "on", "true", "yes"]
+			.iter()
+			.any(|affirmative| val.eq_ignore_ascii_case(affirmative))
+	})
+}
+
 /// Determine the throughput variant based on an environment variable.
 fn determine_throughput_variant() -> ThroughputVariant {
 	const VAR_NAME: &str = "NTT_MUL_THROUGHPUT";
 
-	if boolean_env_flag_set(VAR_NAME) {
+	if env_flag_set(VAR_NAME) {
 		println!("{VAR_NAME} is activated - using *multiplication* throughput");
 		ThroughputVariant::Multiplication
 	} else {

--- a/crates/utils/src/env.rs
+++ b/crates/utils/src/env.rs
@@ -1,9 +1,0 @@
-// Copyright 2024-2025 Irreducible Inc.
-
-/// Read boolean flag from the environment variable.
-pub fn boolean_env_flag_set(flag: &str) -> bool {
-	match std::env::var(flag) {
-		Ok(val) => ["1", "on", "ON", "true", "TRUE", "yes", "YES"].contains(&val.as_str()),
-		Err(_) => false,
-	}
-}

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -6,7 +6,6 @@
 
 pub mod bitwise;
 pub mod checked_arithmetics;
-pub mod env;
 pub mod iter;
 #[cfg(feature = "platform-diagnostics")]
 pub mod platform_diagnostics;


### PR DESCRIPTION
Deletes the `binius_utils::env` module and inlines its one function into the only bench that calls it, fixing a silent case-sensitivity gap on the way past.

### The problem

`binius-utils` exposed a public module for a single function with a single caller.

```rust
// crates/utils/src/env.rs — the whole file
pub fn boolean_env_flag_set(flag: &str) -> bool {
    match std::env::var(flag) {
        Ok(val) => ["1", "on", "ON", "true", "TRUE", "yes", "YES"].contains(&val.as_str()),
        Err(_) => false,
    }
}
```

That caller is the `NTT_MUL_THROUGHPUT` switch in `crates/math/benches/ntt.rs`. Nothing else in the repo references `boolean_env_flag_set` or `utils::env` — not source, not docs, not CI.

It arrived by wholesale crate copy in `dd61fd30` ("Copy utils and maybe_rayon crates from binius") and was never adopted. The repo's ~20 other environment reads — `BINIUS_DUMP_PROOF`, `RAYON_NUM_THREADS`, `XMSS_TREE_HEIGHT`, and the rest — all call `std::env::var` directly.

There is no std function to replace it with, incidentally. `bool: FromStr` accepts only the exact strings `"true"` and `"false"`, so it would reject `1`, `yes`, and `on`. The concept is fine; the placement was the problem — shared-utils public surface for one bench flag.

### The silent bug

The spelling list was matched exactly, and it is not internally consistent:

- `on` and `ON` are accepted, `On` is not
- `true` and `TRUE` are accepted, `True` is not
- `yes` and `YES` are accepted, `Yes` is not
- nothing is trimmed, so `" 1"` is false

Because the bench prints "is NOT activated" and proceeds with the other throughput variant, `NTT_MUL_THROUGHPUT=True` produced a plausible-looking run measuring the wrong thing. No error, no warning.

### The change

The module is deleted. In its place, a file-private helper in the bench:

```rust
fn env_flag_set(flag: &str) -> bool {
    std::env::var(flag).is_ok_and(|val| {
        let val = val.trim();
        ["1", "on", "true", "yes"]
            .iter()
            .any(|affirmative| val.eq_ignore_ascii_case(affirmative))
    })
}
```

Four keywords instead of seven spellings, because `eq_ignore_ascii_case` now covers every casing of each. `is_ok_and` replaces the `match`.

### Scope

- **deleted:** `crates/utils/src/env.rs` and its `pub mod env;` line
- **changed:** `crates/math/benches/ntt.rs` — one import, plus the helper
- **untouched:** the bench's measurement logic and its help text, which documents `=1` and still works

### Verification

Built the bench binary and drove it through the flag matrix, reading the variant it reports:

| `NTT_MUL_THROUGHPUT` | before | after |
|---|---|---|
| unset | standard | standard |
| `1` | multiplication | multiplication |
| `on`, `TRUE`, `yes` | multiplication | multiplication |
| `On` | **standard** | multiplication |
| `True` | **standard** | multiplication |
| `Yes` | **standard** | multiplication |
| `" 1"` | **standard** | multiplication |
| `0`, `off`, `banana` | standard | standard |

The four bold rows are the silent-drop cases, confirmed against the pre-change binary rather than inferred from the source.

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-utils -p binius-math --all-targets` — no warnings
- `cargo +nightly fmt --all -- --check` — exit 0
- `cargo test -p binius-utils` — 40 + 1 passed; `cargo test -p binius-math` — 141 + 2 passed; 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)