### PR TITLE
Type the constraint kind in validation errors instead of a string literal

### DIFF
--- a/crates/core/src/constraint_system/constraint.rs
+++ b/crates/core/src/constraint_system/constraint.rs
@@ -1,6 +1,6 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
-use std::array;
+use std::{array, fmt};
 
 use binius_utils::serialization::{DeserializeBytes, SerializationError, SerializeBytes};
 use bytes::{Buf, BufMut};
@@ -30,6 +30,34 @@ const AND_ARITY: usize = 3;
 const IMUL_ARITY: usize = 4;
 /// Number of operands of a [`BmulConstraint`].
 const BMUL_ARITY: usize = 6;
+
+/// The kind of a constraint of a [`ConstraintSystem`](super::ConstraintSystem).
+///
+/// Each variant identifies one of the constraint types the system holds, and its [`fmt::Display`]
+/// impl gives the lowercase name used in diagnostics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ConstraintKind {
+	/// A [`ZeroConstraint`].
+	Zero,
+	/// An [`AndConstraint`].
+	And,
+	/// An [`ImulConstraint`].
+	Imul,
+	/// A [`BmulConstraint`].
+	Bmul,
+}
+
+impl fmt::Display for ConstraintKind {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		let name = match self {
+			Self::Zero => "zero",
+			Self::And => "and",
+			Self::Imul => "imul",
+			Self::Bmul => "bmul",
+		};
+		f.write_str(name)
+	}
+}
 
 /// Serializes the operands of a constraint in storage order.
 fn serialize_operands(
@@ -67,6 +95,8 @@ pub struct ZeroConstraint(pub [Operand; ZERO_ARITY]);
 impl ZeroConstraint {
 	/// Number of operands.
 	pub const ARITY: usize = ZERO_ARITY;
+	/// Kind of this constraint.
+	pub const KIND: ConstraintKind = ConstraintKind::Zero;
 	/// Names of the operands, in storage order.
 	pub const OPERAND_NAMES: [&'static str; ZERO_ARITY] = ["val"];
 
@@ -119,6 +149,8 @@ pub struct AndConstraint(pub [Operand; AND_ARITY]);
 impl AndConstraint {
 	/// Number of operands.
 	pub const ARITY: usize = AND_ARITY;
+	/// Kind of this constraint.
+	pub const KIND: ConstraintKind = ConstraintKind::And;
 	/// Names of the operands, in storage order.
 	pub const OPERAND_NAMES: [&'static str; AND_ARITY] = ["a", "b", "c"];
 
@@ -197,6 +229,8 @@ pub struct ImulConstraint(pub [Operand; IMUL_ARITY]);
 impl ImulConstraint {
 	/// Number of operands.
 	pub const ARITY: usize = IMUL_ARITY;
+	/// Kind of this constraint.
+	pub const KIND: ConstraintKind = ConstraintKind::Imul;
 	/// Names of the operands, in storage order.
 	pub const OPERAND_NAMES: [&'static str; IMUL_ARITY] = ["a", "b", "lo", "hi"];
 
@@ -259,6 +293,8 @@ pub struct BmulConstraint(pub [Operand; BMUL_ARITY]);
 impl BmulConstraint {
 	/// Number of operands.
 	pub const ARITY: usize = BMUL_ARITY;
+	/// Kind of this constraint.
+	pub const KIND: ConstraintKind = ConstraintKind::Bmul;
 	/// Names of the operands, in storage order.
 	pub const OPERAND_NAMES: [&'static str; BMUL_ARITY] =
 		["a_lo", "a_hi", "b_lo", "b_hi", "c_lo", "c_hi"];

--- a/crates/core/src/constraint_system/system.rs
+++ b/crates/core/src/constraint_system/system.rs
@@ -11,8 +11,8 @@ use bytes::{Buf, BufMut};
 #[cfg(doc)]
 use super::ValueVec;
 use super::{
-	AndConstraint, BmulConstraint, ImulConstraint, Operand, ShiftVariant, ValueIndex,
-	ZeroConstraint,
+	AndConstraint, BmulConstraint, ConstraintKind, ImulConstraint, Operand, ShiftVariant,
+	ValueIndex, ZeroConstraint,
 };
 use crate::{error::ConstraintSystemError, word::Word};
 
@@ -185,27 +185,42 @@ impl ConstraintSystem {
 
 		self.validate_shape()?;
 
-		for (i, zero) in self.zero_constraints.iter().enumerate() {
-			for (operand, name) in iter::zip(&zero.0, ZeroConstraint::OPERAND_NAMES) {
-				self.validate_operand(operand, "zero", i, name)?;
-			}
-		}
-		for (i, and) in self.and_constraints.iter().enumerate() {
-			for (operand, name) in iter::zip(&and.0, AndConstraint::OPERAND_NAMES) {
-				self.validate_operand(operand, "and", i, name)?;
-			}
-		}
-		for (i, imul) in self.imul_constraints.iter().enumerate() {
-			for (operand, name) in iter::zip(&imul.0, ImulConstraint::OPERAND_NAMES) {
-				self.validate_operand(operand, "imul", i, name)?;
-			}
-		}
-		for (i, bmul) in self.bmul_constraints.iter().enumerate() {
-			for (operand, name) in iter::zip(&bmul.0, BmulConstraint::OPERAND_NAMES) {
-				self.validate_operand(operand, "bmul", i, name)?;
-			}
-		}
+		self.validate_constraints(
+			&self.zero_constraints,
+			ZeroConstraint::KIND,
+			ZeroConstraint::OPERAND_NAMES,
+		)?;
+		self.validate_constraints(
+			&self.and_constraints,
+			AndConstraint::KIND,
+			AndConstraint::OPERAND_NAMES,
+		)?;
+		self.validate_constraints(
+			&self.imul_constraints,
+			ImulConstraint::KIND,
+			ImulConstraint::OPERAND_NAMES,
+		)?;
+		self.validate_constraints(
+			&self.bmul_constraints,
+			BmulConstraint::KIND,
+			BmulConstraint::OPERAND_NAMES,
+		)?;
 
+		Ok(())
+	}
+
+	/// Checks every operand of every constraint of one kind, in storage order.
+	fn validate_constraints<C: AsRef<[Operand; ARITY]>, const ARITY: usize>(
+		&self,
+		constraints: &[C],
+		constraint_kind: ConstraintKind,
+		operand_names: [&'static str; ARITY],
+	) -> Result<(), ConstraintSystemError> {
+		for (i, constraint) in constraints.iter().enumerate() {
+			for (operand, name) in iter::zip(constraint.as_ref(), operand_names) {
+				self.validate_operand(operand, constraint_kind, i, name)?;
+			}
+		}
 		Ok(())
 	}
 
@@ -213,7 +228,7 @@ impl ConstraintSystem {
 	fn validate_operand(
 		&self,
 		operand: &Operand,
-		constraint_type: &'static str,
+		constraint_kind: ConstraintKind,
 		constraint_index: usize,
 		operand_name: &'static str,
 	) -> Result<(), ConstraintSystemError> {
@@ -221,7 +236,7 @@ impl ConstraintSystem {
 			// check canonicity. SLL is the canonical form of the operand.
 			if term.amount == 0 && term.shift_variant != ShiftVariant::Sll {
 				return Err(ConstraintSystemError::NonCanonicalShift {
-					constraint_type,
+					constraint_kind,
 					constraint_index,
 					operand_name,
 				});
@@ -230,7 +245,7 @@ impl ConstraintSystem {
 			let max_amount = term.shift_variant.max_amount();
 			if usize::from(term.amount) >= max_amount {
 				return Err(ConstraintSystemError::ShiftAmountTooLarge {
-					constraint_type,
+					constraint_kind,
 					constraint_index,
 					operand_name,
 					shift_amount: term.amount as usize,
@@ -240,7 +255,7 @@ impl ConstraintSystem {
 			// Check if the value index is out of bounds.
 			if term.value_index.0 as usize >= self.value_vec_len() {
 				return Err(ConstraintSystemError::OutOfRangeValueIndex {
-					constraint_type,
+					constraint_kind,
 					constraint_index,
 					operand_name,
 					value_index: term.value_index.0,
@@ -250,7 +265,7 @@ impl ConstraintSystem {
 			// No value should refer to padding.
 			if self.is_padding(term.value_index) {
 				return Err(ConstraintSystemError::PaddingValueIndex {
-					constraint_type,
+					constraint_kind,
 					constraint_index,
 					operand_name,
 				});
@@ -689,9 +704,9 @@ mod tests {
 
 		match result.unwrap_err() {
 			ConstraintSystemError::PaddingValueIndex {
-				constraint_type, ..
+				constraint_kind, ..
 			} => {
-				assert_eq!(constraint_type, "and");
+				assert_eq!(constraint_kind, ConstraintKind::And);
 			}
 			other => panic!("Expected PaddingValueIndex error, got: {:?}", other),
 		}
@@ -748,13 +763,13 @@ mod tests {
 
 		match cs.validate().unwrap_err() {
 			ConstraintSystemError::OutOfRangeValueIndex {
-				constraint_type,
+				constraint_kind,
 				operand_name,
 				value_index,
 				total_len,
 				..
 			} => {
-				assert_eq!(constraint_type, "zero");
+				assert_eq!(constraint_kind, ConstraintKind::Zero);
 				assert_eq!(operand_name, "val");
 				assert_eq!(value_index, 100);
 				assert_eq!(total_len, 16);
@@ -798,13 +813,13 @@ mod tests {
 
 		match result.unwrap_err() {
 			ConstraintSystemError::OutOfRangeValueIndex {
-				constraint_type,
+				constraint_kind,
 				operand_name,
 				value_index,
 				total_len,
 				..
 			} => {
-				assert_eq!(constraint_type, "and");
+				assert_eq!(constraint_kind, ConstraintKind::And);
 				assert_eq!(operand_name, "b");
 				assert_eq!(value_index, 16);
 				assert_eq!(total_len, 16);
@@ -830,13 +845,13 @@ mod tests {
 
 		match result.unwrap_err() {
 			ConstraintSystemError::OutOfRangeValueIndex {
-				constraint_type,
+				constraint_kind,
 				operand_name,
 				value_index,
 				total_len,
 				..
 			} => {
-				assert_eq!(constraint_type, "imul");
+				assert_eq!(constraint_kind, ConstraintKind::Imul);
 				assert_eq!(operand_name, "hi");
 				assert_eq!(value_index, 100);
 				assert_eq!(total_len, 16);
@@ -864,13 +879,13 @@ mod tests {
 
 		match result.unwrap_err() {
 			ConstraintSystemError::OutOfRangeValueIndex {
-				constraint_type,
+				constraint_kind,
 				operand_name,
 				value_index,
 				total_len,
 				..
 			} => {
-				assert_eq!(constraint_type, "bmul");
+				assert_eq!(constraint_kind, ConstraintKind::Bmul);
 				assert_eq!(operand_name, "c_hi");
 				assert_eq!(value_index, 100);
 				assert_eq!(total_len, 16);
@@ -927,13 +942,13 @@ mod tests {
 
 		match cs.validate().unwrap_err() {
 			ConstraintSystemError::ShiftAmountTooLarge {
-				constraint_type,
+				constraint_kind,
 				constraint_index,
 				operand_name,
 				shift_amount,
 				max_amount,
 			} => {
-				assert_eq!(constraint_type, "and");
+				assert_eq!(constraint_kind, ConstraintKind::And);
 				assert_eq!(constraint_index, 0);
 				assert_eq!(operand_name, "a");
 				assert_eq!(shift_amount, 32);

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 Irreducible Inc.
 //! Hosts error definitions for the core crate.
 
-use crate::ConstraintSystem;
+use crate::{ConstraintSystem, constraint_system::ConstraintKind};
 
 /// Constraint system related error.
 #[allow(missing_docs)] // errors are self-documenting
@@ -22,36 +22,36 @@ pub enum ConstraintSystemError {
 		hidden_len: usize,
 	},
 	#[error(
-		"{constraint_type} #{constraint_index} uses non canonical shift in its {operand_name} operand"
+		"{constraint_kind} #{constraint_index} uses non canonical shift in its {operand_name} operand"
 	)]
 	NonCanonicalShift {
-		constraint_type: &'static str,
+		constraint_kind: ConstraintKind,
 		constraint_index: usize,
 		operand_name: &'static str,
 	},
 	#[error(
-		"{constraint_type} #{constraint_index} refers to padding in its {operand_name} operand"
+		"{constraint_kind} #{constraint_index} refers to padding in its {operand_name} operand"
 	)]
 	PaddingValueIndex {
-		constraint_type: &'static str,
+		constraint_kind: ConstraintKind,
 		operand_name: &'static str,
 		constraint_index: usize,
 	},
 	#[error(
-		"{constraint_type} #{constraint_index} uses shift amount n={shift_amount}>={max_amount} in {operand_name} operand"
+		"{constraint_kind} #{constraint_index} uses shift amount n={shift_amount}>={max_amount} in {operand_name} operand"
 	)]
 	ShiftAmountTooLarge {
-		constraint_type: &'static str,
+		constraint_kind: ConstraintKind,
 		constraint_index: usize,
 		operand_name: &'static str,
 		shift_amount: usize,
 		max_amount: usize,
 	},
 	#[error(
-		"{constraint_type} #{constraint_index} refers to out-of-range value index in {operand_name} operand (index {value_index} >= total length {total_len})"
+		"{constraint_kind} #{constraint_index} refers to out-of-range value index in {operand_name} operand (index {value_index} >= total length {total_len})"
 	)]
 	OutOfRangeValueIndex {
-		constraint_type: &'static str,
+		constraint_kind: ConstraintKind,
 		constraint_index: usize,
 		operand_name: &'static str,
 		value_index: u32,


### PR DESCRIPTION
Replaces the `&'static str` constraint kind in `ConstraintSystemError` with an enum, and collapses the four validation loops that fed it into one.
Pure refactor — no behavior change, and the rendered error messages are byte-identical.

### The problem

`ConstraintSystem::validate` reports which constraint kind failed by passing a string literal:

```
self.validate_operand(operand, "zero", i, name)?;
self.validate_operand(operand, "and",  i, name)?;
self.validate_operand(operand, "imul", i, name)?;
self.validate_operand(operand, "bmul", i, name)?;
```

Nothing ties the literal to the constraint type it names.
The tests then re-spell the same literals to assert on the error (`assert_eq!(constraint_type, "and")`), so the set of kinds lives in ten places and is checked by none.

### The idea

The kind is a property of the constraint type, so let the type carry it.

`ConstraintKind { Zero, And, Imul, Bmul }` gets a `Display` impl printing the same lowercase names, and each constraint struct gets a `KIND` associated const, right next to the `ARITY` and `OPERAND_NAMES` consts it already has:

```
impl AndConstraint {
    pub const ARITY: usize = AND_ARITY;
+   /// Kind of this constraint.
+   pub const KIND: ConstraintKind = ConstraintKind::And;
    pub const OPERAND_NAMES: [&'static str; AND_ARITY] = ["a", "b", "c"];
```

Once the kind travels with the type, the four loops are the same loop, so they fold into one helper generic over the `AsRef<[Operand; ARITY]>` bound the prover and verifier already use for these types.

### The change

```
-for (i, and) in self.and_constraints.iter().enumerate() {
-    for (operand, name) in iter::zip(&and.0, AndConstraint::OPERAND_NAMES) {
-        self.validate_operand(operand, "and", i, name)?;
-    }
-}
+self.validate_constraints(
+    &self.and_constraints,
+    AndConstraint::KIND,
+    AndConstraint::OPERAND_NAMES,
+)?;
```

with the shared helper:

```
fn validate_constraints<C: AsRef<[Operand; ARITY]>, const ARITY: usize>(
    &self,
    constraints: &[C],
    constraint_kind: ConstraintKind,
    operand_names: [&'static str; ARITY],
) -> Result<(), ConstraintSystemError>
```

### What is *not* changed

`operand_name` stays a `&'static str`.

The operand set is per-kind — `val` for ZERO, `a, b, c` for AND, `a_lo, a_hi, ...` for BMUL — so one flat enum would just union unrelated names.
`OPERAND_NAMES`, indexed by storage position, already types that relationship.

Error message text is unchanged: `Display` for `ConstraintKind` prints exactly the old literals, so every `#[error(...)]` renders as before.

### Scope

- **new:** `ConstraintKind` in `crates/core/src/constraint_system/constraint.rs`, plus a `KIND` const on `ZeroConstraint`, `AndConstraint`, `ImulConstraint`, `BmulConstraint`
- **changed:** the four validation variants in `crates/core/src/error.rs` now hold `constraint_kind: ConstraintKind` (field renamed from `constraint_type`)
- **changed:** `validate` in `crates/core/src/constraint_system/system.rs` — four loops become four calls to one generic helper
- **changed:** six test assertions now compare against `ConstraintKind::*` rather than string literals
- no other crate matched on these error fields, so the blast radius is `binius-core` only

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-core --all-targets` — clean
- `cargo +nightly fmt --all --check` — clean
- `cargo test -p binius-core --lib` — 86 passed, 0 failed (3 ignored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
