### PR TITLE
Merge the duplicate inherent impl blocks and lint against new ones

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,7 @@ ureq = "3.1"
 [workspace.lints.clippy]
 needless_range_loop = "allow"
 missing_const_for_fn = "warn"
+multiple_inherent_impl = "warn"
 needless_collect = "warn"
 redundant_clone = "warn"
 needless_pass_by_value = "warn"

--- a/crates/core/src/constraint_system/system.rs
+++ b/crates/core/src/constraint_system/system.rs
@@ -81,9 +81,7 @@ impl ConstraintSystem {
 	///
 	/// [`Self::validate_shape`] rejects any system whose public segment is shorter than this.
 	pub const MIN_WORDS_PER_SEGMENT: usize = 2;
-}
 
-impl ConstraintSystem {
 	/// Returns the number of constants.
 	pub const fn n_const(&self) -> usize {
 		self.constants.len()

--- a/crates/core/src/word.rs
+++ b/crates/core/src/word.rs
@@ -44,63 +44,7 @@ impl Word {
 	///
 	/// This is a canonical representation of true.
 	pub const MSB_ONE: Word = Word(0x8000000000000000);
-}
 
-impl fmt::Debug for Word {
-	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-		write!(f, "Word({:#018x})", self.0)
-	}
-}
-
-impl BitAnd for Word {
-	type Output = Self;
-
-	fn bitand(self, rhs: Self) -> Self::Output {
-		Word(self.0 & rhs.0)
-	}
-}
-
-impl BitOr for Word {
-	type Output = Self;
-
-	fn bitor(self, rhs: Self) -> Self::Output {
-		Word(self.0 | rhs.0)
-	}
-}
-
-impl BitXor for Word {
-	type Output = Self;
-
-	fn bitxor(self, rhs: Self) -> Self::Output {
-		Word(self.0 ^ rhs.0)
-	}
-}
-
-impl Shl<u32> for Word {
-	type Output = Self;
-
-	fn shl(self, rhs: u32) -> Self::Output {
-		Word(self.0 << rhs)
-	}
-}
-
-impl Shr<u32> for Word {
-	type Output = Self;
-
-	fn shr(self, rhs: u32) -> Self::Output {
-		Word(self.0 >> rhs)
-	}
-}
-
-impl Not for Word {
-	type Output = Self;
-
-	fn not(self) -> Self::Output {
-		Word(!self.0)
-	}
-}
-
-impl Word {
 	/// Creates a new `Word` from a 64-bit unsigned integer.
 	pub const fn from_u64(value: u64) -> Word {
 		Word(value)
@@ -357,6 +301,60 @@ impl Word {
 	/// Returns true if the MSB is 0, false otherwise.
 	pub const fn is_msb_false(self) -> bool {
 		!self.is_msb_true()
+	}
+}
+
+impl fmt::Debug for Word {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		write!(f, "Word({:#018x})", self.0)
+	}
+}
+
+impl BitAnd for Word {
+	type Output = Self;
+
+	fn bitand(self, rhs: Self) -> Self::Output {
+		Word(self.0 & rhs.0)
+	}
+}
+
+impl BitOr for Word {
+	type Output = Self;
+
+	fn bitor(self, rhs: Self) -> Self::Output {
+		Word(self.0 | rhs.0)
+	}
+}
+
+impl BitXor for Word {
+	type Output = Self;
+
+	fn bitxor(self, rhs: Self) -> Self::Output {
+		Word(self.0 ^ rhs.0)
+	}
+}
+
+impl Shl<u32> for Word {
+	type Output = Self;
+
+	fn shl(self, rhs: u32) -> Self::Output {
+		Word(self.0 << rhs)
+	}
+}
+
+impl Shr<u32> for Word {
+	type Output = Self;
+
+	fn shr(self, rhs: u32) -> Self::Output {
+		Word(self.0 >> rhs)
+	}
+}
+
+impl Not for Word {
+	type Output = Self;
+
+	fn not(self) -> Self::Output {
+		Word(!self.0)
 	}
 }
 

--- a/crates/frontend/src/ops.rs
+++ b/crates/frontend/src/ops.rs
@@ -73,6 +73,9 @@ fn smul64(builder: &CircuitBuilder, a: Wire, b: Wire) -> (Wire, Wire) {
 	(hi, lo)
 }
 
+// The builder's own API lives in `compiler`; this block deliberately keeps the word operations in
+// their own module rather than growing that one.
+#[allow(clippy::multiple_inherent_impl)]
 impl CircuitBuilder {
 	/// 64-bit unsigned integer addition, returning the sum and carry-out.
 	///

--- a/crates/iop/src/fri/batch.rs
+++ b/crates/iop/src/fri/batch.rs
@@ -224,52 +224,7 @@ where
 			values,
 		)
 	}
-}
 
-/// Folds a coset of a codeword into a single value with the given folding challenges.
-///
-/// This implements the fold operation from Definition 4.6 of [DP24], reading twiddle factors from
-/// the domain context. `log_len` is the base-2 log of the length of the codeword the coset belongs
-/// to; the twiddle layer is absolute within the full NTT domain and decreases with each challenge.
-///
-/// [DP24]: <https://eprint.iacr.org/2024/504>
-pub fn fold_coset<F, DC>(
-	domain_context: &DC,
-	mut log_len: usize,
-	chunk_index: usize,
-	challenges: &[F],
-	mut values: Vec<F>,
-) -> F
-where
-	F: BinaryField,
-	DC: DomainContext<Field = F>,
-{
-	let mut log_size = challenges.len();
-	for &challenge in challenges {
-		for index_offset in 0..1 << (log_size - 1) {
-			// Perform the inverse additive NTT butterfly, then extrapolate the resulting line at
-			// the folding challenge.
-			let mut u = values[index_offset << 1];
-			let mut v = values[(index_offset << 1) | 1];
-			let twiddle =
-				domain_context.twiddle(log_len - 1, (chunk_index << (log_size - 1)) | index_offset);
-			v += u;
-			u += v * twiddle;
-			values[index_offset] = extrapolate_line(u, v, challenge);
-		}
-
-		log_len -= 1;
-		log_size -= 1;
-	}
-
-	values[0]
-}
-
-impl<F, C, DC> FRIOracle<F, C, DC>
-where
-	F: BinaryField,
-	DC: DomainContext<Field = F>,
-{
 	/// Opens queried locations on the base codeword, reducing claims about it to the virtual
 	/// oracle.
 	///
@@ -321,6 +276,45 @@ where
 			})
 			.collect()
 	}
+}
+
+/// Folds a coset of a codeword into a single value with the given folding challenges.
+///
+/// This implements the fold operation from Definition 4.6 of [DP24], reading twiddle factors from
+/// the domain context. `log_len` is the base-2 log of the length of the codeword the coset belongs
+/// to; the twiddle layer is absolute within the full NTT domain and decreases with each challenge.
+///
+/// [DP24]: <https://eprint.iacr.org/2024/504>
+pub fn fold_coset<F, DC>(
+	domain_context: &DC,
+	mut log_len: usize,
+	chunk_index: usize,
+	challenges: &[F],
+	mut values: Vec<F>,
+) -> F
+where
+	F: BinaryField,
+	DC: DomainContext<Field = F>,
+{
+	let mut log_size = challenges.len();
+	for &challenge in challenges {
+		for index_offset in 0..1 << (log_size - 1) {
+			// Perform the inverse additive NTT butterfly, then extrapolate the resulting line at
+			// the folding challenge.
+			let mut u = values[index_offset << 1];
+			let mut v = values[(index_offset << 1) | 1];
+			let twiddle =
+				domain_context.twiddle(log_len - 1, (chunk_index << (log_size - 1)) | index_offset);
+			v += u;
+			u += v * twiddle;
+			values[index_offset] = extrapolate_line(u, v, challenge);
+		}
+
+		log_len -= 1;
+		log_size -= 1;
+	}
+
+	values[0]
 }
 
 impl<F, C, DC> ProxTestOracle<F> for FRIOracle<F, C, DC>

--- a/crates/math/src/batch_invert.rs
+++ b/crates/math/src/batch_invert.rs
@@ -127,6 +127,14 @@ impl<P: PackedField> BatchInversion<P> {
 			}
 		}
 	}
+
+	fn batch_invert_nonzero(&mut self, elements: &mut [P]) {
+		batch_invert_nonzero_with_scratchpad(
+			elements,
+			&mut self.scratchpad,
+			self.scalar_inverter.as_deref_mut(),
+		);
+	}
 }
 
 fn min_scratchpad_size(mut n: usize) -> usize {
@@ -138,16 +146,6 @@ fn min_scratchpad_size(mut n: usize) -> usize {
 		size += n;
 	}
 	size
-}
-
-impl<P: PackedField> BatchInversion<P> {
-	fn batch_invert_nonzero(&mut self, elements: &mut [P]) {
-		batch_invert_nonzero_with_scratchpad(
-			elements,
-			&mut self.scratchpad,
-			self.scalar_inverter.as_deref_mut(),
-		);
-	}
 }
 
 fn batch_invert_nonzero_with_scratchpad<P: PackedField>(

--- a/crates/math/src/field_buffer.rs
+++ b/crates/math/src/field_buffer.rs
@@ -114,6 +114,17 @@ impl<P: PackedField> FieldBuffer<P> {
 		let values = zeroed_vec(packed_len);
 		Self { log_len, values }
 	}
+
+	/// A single-scalar buffer (`log_len` 0) holding `value` in lane 0, with backing-`Vec` capacity
+	/// reserved for `log_capacity` variables.
+	///
+	/// The backing `Vec` reserves `1 << log_capacity.saturating_sub(P::LOG_WIDTH)` packed words, so
+	/// growing the buffer up to `log_capacity` variables never reallocates.
+	pub fn scalar_with_capacity(value: P::Scalar, log_capacity: usize) -> Self {
+		let mut values = Vec::with_capacity(1 << log_capacity.saturating_sub(P::LOG_WIDTH));
+		values.push(P::from_scalars([value]));
+		Self { log_len: 0, values }
+	}
 }
 
 impl<P: PackedField, Data: VecLike<P>> FieldBuffer<P, Data> {
@@ -172,18 +183,6 @@ impl<P: PackedField, Data: VecLike<P>> FieldBuffer<P, Data> {
 	}
 }
 
-impl<P: PackedField> FieldBuffer<P, Vec<P>> {
-	/// A single-scalar buffer (`log_len` 0) holding `value` in lane 0, with backing-`Vec` capacity
-	/// reserved for `log_capacity` variables.
-	///
-	/// The backing `Vec` reserves `1 << log_capacity.saturating_sub(P::LOG_WIDTH)` packed words, so
-	/// growing the buffer up to `log_capacity` variables never reallocates.
-	pub fn scalar_with_capacity(value: P::Scalar, log_capacity: usize) -> Self {
-		let mut values = Vec::with_capacity(1 << log_capacity.saturating_sub(P::LOG_WIDTH));
-		values.push(P::from_scalars([value]));
-		Self { log_len: 0, values }
-	}
-}
 #[allow(clippy::len_without_is_empty)]
 impl<P: PackedField, Data: Deref<Target = [P]>> FieldBuffer<P, Data> {
 	/// Create a new FieldBuffer from a slice of packed values.

--- a/crates/transcript/src/transcript.rs
+++ b/crates/transcript/src/transcript.rs
@@ -52,9 +52,7 @@ impl<Challenger_: Challenger> VerifierTranscript<Challenger_> {
 			options,
 		}
 	}
-}
 
-impl<Challenger_: Challenger> VerifierTranscript<Challenger_> {
 	pub fn finalize(self) -> Result<(), Error> {
 		if self.combined.buffer.has_remaining() {
 			return Err(Error::TranscriptNotEmpty {
@@ -224,24 +222,7 @@ impl<Challenger_: Challenger> ProverTranscript<Challenger_> {
 			options,
 		}
 	}
-}
 
-impl<Challenger_: Default + Challenger> ProverTranscript<Challenger_> {
-	pub fn into_verifier(self) -> VerifierTranscript<Challenger_> {
-		let options = self.options;
-		let transcript = self.finalize();
-
-		VerifierTranscript::with_opts(Challenger_::default(), transcript, options)
-	}
-}
-
-impl<Challenger_: Default + Challenger> Default for ProverTranscript<Challenger_> {
-	fn default() -> Self {
-		Self::new(Challenger_::default())
-	}
-}
-
-impl<Challenger_: Challenger> ProverTranscript<Challenger_> {
 	pub fn finalize(self) -> Vec<u8> {
 		let transcript = self.combined.buffer.to_vec();
 
@@ -323,6 +304,21 @@ impl<Challenger_: Challenger> ProverTranscript<Challenger_> {
 			buffer: &mut self.combined,
 			options: self.options,
 		}
+	}
+}
+
+impl<Challenger_: Default + Challenger> ProverTranscript<Challenger_> {
+	pub fn into_verifier(self) -> VerifierTranscript<Challenger_> {
+		let options = self.options;
+		let transcript = self.finalize();
+
+		VerifierTranscript::with_opts(Challenger_::default(), transcript, options)
+	}
+}
+
+impl<Challenger_: Default + Challenger> Default for ProverTranscript<Challenger_> {
+	fn default() -> Self {
+		Self::new(Challenger_::default())
 	}
 }
 


### PR DESCRIPTION
Folds every accidentally-split inherent `impl` block in the workspace into one, and turns on the clippy lint that catches the next one.
Pure refactor — every method body is byte-identical, only `impl` headers and item order change.

### The problem

`ConstraintSystem` declared its associated consts and its methods in two separate blocks, back to back:

```
impl ConstraintSystem {
    pub const SERIALIZATION_VERSION: u32 = 7;
    pub const MIN_WORDS_PER_SEGMENT: usize = 2;
}

impl ConstraintSystem {
    pub const fn n_const(&self) -> usize { ... }
```

Nothing distinguishes the two — same self type, same (absent) bounds, same file, adjacent lines.
A reader has to check the headers character by character to conclude that the split means nothing.

It turns out six types in the workspace do this. `clippy::multiple_inherent_impl` finds them all.

### The idea

Fold each pair into one block.
Where the split had unrelated items wedged between its halves, **move the wedged items, not the methods** — so no method body appears in the diff as a rewrite, and each file keeps a sensible top-to-bottom order.

### The sites

| type | file | how it was split | fix |
|---|---|---|---|
| `ConstraintSystem` | `core/src/constraint_system/system.rs` | consts, then methods — adjacent | dropped the boundary |
| `Word` | `core/src/word.rs` | consts, six operator impls, then methods | consts + methods merged; operator impls now follow |
| `BatchInversion` | `math/src/batch_invert.rs` | split by the free `min_scratchpad_size` | method moved up into the first block |
| `FieldBuffer<P>` | `math/src/field_buffer.rs` | one block as `FieldBuffer<P>`, one as `FieldBuffer<P, Vec<P>>` | merged under the shorter header |
| `VerifierTranscript` | `transcript/src/transcript.rs` | two adjacent blocks | dropped the boundary |
| `ProverTranscript` | `transcript/src/transcript.rs` | split by `into_verifier` and the `Default` impl | those two now follow the merged block |
| `FRIOracle` | `iop/src/fri/batch.rs` | split by the free `fold_coset` it calls | `reduce_queries` moved up; free fn follows |

`FieldBuffer` deserves a note: `Data` defaults to `Vec<P>`, so `FieldBuffer<P>` and `FieldBuffer<P, Vec<P>>` name the *same* type. The two blocks were one impl spelled two ways.

### The change

The shape of every fix, using `ConstraintSystem`:

```
 impl ConstraintSystem {
     pub const SERIALIZATION_VERSION: u32 = 7;
     pub const MIN_WORDS_PER_SEGMENT: usize = 2;
-}
-
-impl ConstraintSystem {
+
     /// Returns the number of constants.
     pub const fn n_const(&self) -> usize {
```

### Guarding against the next one

`clippy::multiple_inherent_impl = "warn"` joins the workspace lint table in `Cargo.toml`, next to the `missing_const_for_fn` and `redundant_clone` warns already there.

One split survives on purpose. `CircuitBuilder` has its own API in `frontend::compiler` and its ~1300 lines of word operations in `frontend::ops`; merging those would mean collapsing two modules, not tidying a header. That block gets an `#[allow]` naming the reason:

```
// The builder's own API lives in `compiler`; this block deliberately keeps the word operations in
// their own module rather than growing that one.
#[allow(clippy::multiple_inherent_impl)]
impl CircuitBuilder {
```

### Scope

- **changed:** the six files above, plus the lint entry in `Cargo.toml` and the `#[allow]` in `frontend/src/ops.rs`
- **not changed:** any method body, signature, visibility, doc comment, or bound — the merged blocks carry exactly the items the split blocks did
- no public API change, so no call site moves

Line-level check that the moves are faithful: for each touched file, the sorted set of non-blank lines outside `impl` headers is identical before and after, except for the duplicate `where` clauses the merge removes in `batch.rs`.

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy --workspace --all-targets` — clean, with the new lint active (zero warnings)
- `cargo +nightly fmt --all --check` — clean
- `cargo test -p binius-core -p binius-math -p binius-transcript -p binius-iop -p binius-frontend` — all pass (86 / 191 / 2 / 141 / 5 across the lib suites, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
