### PR TITLE
Name the operand-column builder for what it builds

### DIFF
--- a/crates/m4-prover/Cargo.toml
+++ b/crates/m4-prover/Cargo.toml
@@ -23,7 +23,6 @@ binius-transcript = { path = "../transcript" }
 binius-utils = { path = "../utils" }
 binius-verifier = { path = "../verifier" }
 bytemuck.workspace = true
-itertools.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]

--- a/crates/m4-prover/src/operand_witness.rs
+++ b/crates/m4-prover/src/operand_witness.rs
@@ -5,7 +5,7 @@
 //!
 //! Every AND, IMUL, and BMUL constraint is projected to its fixed-arity operand columns (`[A, B]`
 //! for AND, `[A, B, LO, HI]` for IMUL, `[A_LO, A_HI, B_LO, B_HI, C_LO, C_HI]` for BMUL), one
-//! column per operand, stacked over every instance in the batch. [`build_operation_witness`] is the
+//! column per operand, stacked over every instance in the batch. [`build_operand_column`] is the
 //! shared arity-generic core: it projects one operand per constraint into one column.
 //! [`build_operation_columns`] wraps it for any constraint type that exposes a fixed-arity operand
 //! array, building the leading `N_COLS` columns of the array in parallel: the four IntMul columns,
@@ -27,7 +27,7 @@ use crate::ValueTable;
 
 /// Builds the leading `N_COLS` operand columns of a batched fixed-arity operation.
 ///
-/// This is the constraint-generic entry point to `build_operation_witness`: it projects every
+/// This is the constraint-generic entry point to `build_operand_column`: it projects every
 /// constraint to its operand array and builds one column per operand position, all in parallel.
 /// The columns follow the constraint type's storage order, so column `i` holds operand `i` of
 /// every constraint.
@@ -61,7 +61,7 @@ where
 	(0..N_COLS)
 		.into_par_iter()
 		.map(|op_idx| {
-			build_operation_witness(
+			build_operand_column(
 				table,
 				constants,
 				constraints
@@ -75,7 +75,7 @@ where
 		.unwrap_or_else(|_| unreachable!("source iterator has N_COLS elements"))
 }
 
-/// Builds the operand-column witness of a batched fixed-arity operation over every instance.
+/// Builds one operand column of a batched fixed-arity operation, over every instance.
 ///
 /// This is the arity-generic core shared by every per-operation witness: BitAnd projects each
 /// constraint to its three operands `[A, B, C]`; IntMul projects to its four `[A, B, LO, HI]`.
@@ -108,7 +108,7 @@ where
 ///   Their count need not be a power of two; the constraint axis is zero-padded up to one, and a
 ///   zero row satisfies every constraint type.
 /// - `alloc`: the allocator backing the returned column.
-pub fn build_operation_witness<'a, A: Allocator>(
+pub fn build_operand_column<'a, A: Allocator>(
 	table: &ValueTable,
 	constants: &[Word],
 	operands: impl IndexedParallelIterator<Item = &'a Operand>,


### PR DESCRIPTION
Renames one function and drops one unused dependency in `binius-m4-prover`.
Pure refactor — no behavior change, no protocol change.

### The problem

`build_operation_witness` builds **one** column, from one operand per constraint.
Its caller `build_operation_columns` is the one that builds the witness, by calling it `N_COLS` times.
So the singular helper is named for the plural thing, and the wrapper's body reads as if it loops over whole witnesses.

Separately, `itertools` is declared as a dependency with zero occurrences in the crate:

```
cd crates/m4-prover && grep -rn "itertools" . --include="*.rs" | wc -l   # 0
```

### The change

```diff
-pub fn build_operation_witness<'a, A: Allocator>(
+pub fn build_operand_column<'a, A: Allocator>(
```

The wrapper now reads as what it is — one call per operand position:

```diff
 (0..N_COLS)
     .into_par_iter()
     .map(|op_idx| {
-        build_operation_witness(
+        build_operand_column(
```

The summary line follows the name: "Builds one operand column of a batched fixed-arity operation, over every instance."

### Scope

- **changed:** `crates/m4-prover/src/operand_witness.rs` — the definition, its one call site, its summary line, and the two rustdoc references that name it
- **changed:** `crates/m4-prover/Cargo.toml` — `itertools` removed
- **untouched:** visibility, signatures, and every line of logic. `Cargo.lock` is unaffected, since other crates still depend on `itertools`.

### One note for reviewers

The reference at `operand_witness.rs:30` is deliberately a plain code span, not an intra-doc link.
`build_operation_columns` is publicly re-exported from the crate root, while `build_operand_column` is `pub` inside a private module — so linking from the former's docs to the latter trips `rustdoc::private_intra_doc_links`, which is an error under `-D warnings`.
The module-level reference at line 8 is a link, and that one is fine: a private module's docs are not public documentation.

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-m4-prover --all-targets --all-features` — clean, no warnings
- `cargo test -p binius-m4-prover --all-features` — 38 + 5 passed, 0 failed
- `cargo doc -p binius-m4-prover --no-deps` — clean
- `cargo +nightly fmt --all` — no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)