### PR TITLE
Give the instance-folded witness a type

### DIFF
--- a/crates/m4-prover/src/prove.rs
+++ b/crates/m4-prover/src/prove.rs
@@ -47,7 +47,7 @@ use binius_verifier::{
 use crate::{
 	ValueTable,
 	shift::prove as prove_shift,
-	witness::{build_operation_columns, fold_instances, operand_rho_multilinear},
+	witness::{FoldedWitness, build_operation_columns, operand_rho_multilinear},
 };
 
 /// The multithreaded additive NTT used to encode the committed codeword.
@@ -299,7 +299,7 @@ impl IOPProver {
 		// Fold the committed witness over the instance axis at the shared point.
 		let folded_witness = {
 			let _scope = tracing::debug_span!("Fold instances").entered();
-			fold_instances::<B128, _>(table, &r_rho, alloc)
+			FoldedWitness::<B128, _>::fold_instances(table, &r_rho, alloc)
 		};
 
 		// The public segment is the shared constants, padded with zeros to the layout's

--- a/crates/m4-prover/src/shift.rs
+++ b/crates/m4-prover/src/shift.rs
@@ -4,15 +4,12 @@
 
 use std::{array, iter};
 
-use binius_compute::{Allocator, VecLike};
+use binius_compute::Allocator;
 use binius_core::word::Word;
 use binius_field::{BinaryField, PackedField};
 use binius_ip::sumcheck::SumcheckOutput;
 use binius_ip_prover::channel::IPProverChannel;
-use binius_math::{
-	BinarySubspace, FieldBuffer, FieldVec, inner_product::inner_product,
-	multilinear::eq::eq_ind_partial_eval,
-};
+use binius_math::{BinarySubspace, FieldBuffer, FieldVec, multilinear::eq::eq_ind_partial_eval};
 use binius_prover::{
 	fold_word::fold_words,
 	protocols::shift::{
@@ -22,10 +19,9 @@ use binius_prover::{
 		phase_2::run_sumcheck,
 	},
 };
-use binius_utils::checked_arithmetics::log2_ceil_usize;
 use binius_verifier::protocols::shift::SHIFT_VARIANT_COUNT;
 
-use crate::witness::FoldedWord;
+use crate::witness::{FoldedWitness, FoldedWord};
 
 /// The number of variables in each "g" (and "h") multilinear of phase 1: one 6-bit shift-amount
 /// axis and one 6-bit bit-position axis.
@@ -34,22 +30,21 @@ const LOG_LEN: usize = Word::LOG_BITS + Word::LOG_BITS;
 /// Proves the batched shift-reduction, reducing the bitand and intmul evaluation claims to a single
 /// multilinear claim on the batched witness.
 ///
-/// This mirrors the single-instance shift reduction, but the hidden witness enters already folded
-/// over the instance axis: `folded_witness` holds one [`FoldedWord`] per hidden (committed) word,
-/// the oblong representation produced by [`fold_instances`](crate::witness::fold_instances). The
-/// public words are constants shared
-/// by every instance, so they are passed unfolded as raw words.
+/// This mirrors the single-instance shift reduction, with one difference.
+/// The hidden witness enters already folded over the instance axis, as a [`FoldedWitness`].
+/// The public words are constants shared by every instance, so they are passed as raw words.
 ///
-/// The two phases call the single-instance prover's own subroutines. Phase 1 builds the hidden g
-/// parts with [`build_g_parts_from_folded_words`] and the public g parts with the single-instance
-/// `build_g_parts`, then sums them. Phase 2 derives the hidden folded segment as a partial
-/// evaluation of `folded_witness` along the bit (`r_j`) axis, folds the public segment the same
-/// way, and reuses `build_monster_segments` and `run_sumcheck` unchanged.
+/// The two phases call the single-instance prover's own subroutines.
+/// Phase 1 builds the hidden g parts with [`build_g_parts_from_folded_words`].
+/// It builds the public g parts with the single-instance `build_g_parts`, then sums the two.
+/// Phase 2 contracts the hidden witness along the bit (`r_j`) axis with
+/// [`FoldedWitness::fold_bits`], folds the public segment the same way, and reuses
+/// `build_monster_segments` and `run_sumcheck` unchanged.
 ///
 /// # Parameters
 /// - `key_collection`: the prover's key collection for the constraint system.
 /// - `public_words`: the public (constant) words, shared by every instance.
-/// - `folded_witness`: the hidden witness, folded over the instance axis, one word per entry.
+/// - `folded_witness`: the hidden witness, folded over the instance axis.
 /// - `zero_data`: operator data for the zero (ZERO) constraints.
 /// - `bitand_data`: operator data for the bitand (AND) constraints.
 /// - `intmul_data`: operator data for the intmul (IMUL) constraints.
@@ -62,7 +57,7 @@ const LOG_LEN: usize = Word::LOG_BITS + Word::LOG_BITS;
 pub fn prove<F, P, Channel, A>(
 	key_collection: &KeyCollection,
 	public_words: &[Word],
-	folded_witness: &[FoldedWord<F>],
+	folded_witness: &FoldedWitness<F, A>,
 	zero_data: OperatorData<F>,
 	bitand_data: OperatorData<F>,
 	intmul_data: OperatorData<F>,
@@ -103,7 +98,7 @@ where
 	);
 	let hidden_g_parts = build_g_parts_from_folded_words(
 		alloc,
-		folded_witness,
+		folded_witness.words(),
 		&key_collection.hidden,
 		&prepared_zero,
 		&prepared_bitand,
@@ -127,21 +122,10 @@ where
 	let r_j = r_jr_s;
 	let r_j_tensor = eq_ind_partial_eval::<F>(&r_j);
 
-	// The witness folded at `r_j`, per segment. The public fold is a raw-word fold; the hidden fold
-	// is a partial evaluation of `folded_witness` along the bit axis, contracting each word's
-	// folded bits against the `r_j` tensor. The committed word count need not be a power of two, so
-	// the scalars are zero-padded up to the next one, mirroring `fold_words`'s own padding of the
-	// public segment.
+	// The witness folded at `r_j`, per segment.
+	// The public fold is a raw-word fold; the hidden fold contracts the already-oblong bits.
 	let public_folded = fold_words::<F, P, _>(alloc, public_words, r_j_tensor.as_ref());
-	let padded_len = 1 << log2_ceil_usize(folded_witness.len());
-	let mut hidden_scalars = alloc.alloc::<F>(padded_len);
-	hidden_scalars.extend(
-		folded_witness
-			.iter()
-			.map(|word| inner_product(word.iter().copied(), r_j_tensor.as_ref().iter().copied())),
-	);
-	hidden_scalars.resize(padded_len, F::ZERO);
-	let hidden_folded = FieldBuffer::<P, _>::from_values_in(alloc, &hidden_scalars);
+	let hidden_folded = folded_witness.fold_bits::<P>(r_j_tensor.as_ref(), alloc);
 
 	let (public_monster, hidden_monster) = build_monster_segments::<F, P, _>(
 		alloc,
@@ -263,10 +247,8 @@ mod tests {
 	use super::*;
 	use crate::{
 		ValueTable,
-		test_utils::{
-			N_INPUT_WORDS, crc64_circuit, evaluate_folded_witness, populate_crc64_witness,
-		},
-		witness::{build_operation_columns, fold_instances},
+		test_utils::{N_INPUT_WORDS, crc64_circuit, populate_crc64_witness},
+		witness::build_operation_columns,
 	};
 
 	// The oblong evaluation of each bitand operand column A, B, C at the shift challenges.
@@ -359,7 +341,8 @@ mod tests {
 
 		// The hidden witness folded over instances (one FoldedWord per committed word), and the
 		// public constants.
-		let folded_witness = fold_instances::<B128, _>(&table, &r_rho, &GlobalAllocator);
+		let folded_witness =
+			FoldedWitness::<B128, _>::fold_instances(&table, &r_rho, &GlobalAllocator);
 		let _offset = table.layout().offset_witness;
 		let public_words = &cs.constants;
 
@@ -440,9 +423,8 @@ mod tests {
 		// The witness evaluation equals the instance-folded witness evaluated at the point, with
 		// the segment's zero-padding contributing the (1 - r) factors above the folded length.
 		let r_y = verifier_output.r_y();
-		let log_folded = log2_ceil_usize(folded_witness.len());
-		let base =
-			evaluate_folded_witness(&folded_witness, verifier_output.r_j(), &r_y[..log_folded]);
+		let log_folded = folded_witness.log_padded_words();
+		let base = folded_witness.evaluate(verifier_output.r_j(), &r_y[..log_folded]);
 		let expected_eval = r_y[log_folded..]
 			.iter()
 			.fold(base, |acc, &r_y_i| acc * (B128::ONE - r_y_i));

--- a/crates/m4-prover/src/test_utils.rs
+++ b/crates/m4-prover/src/test_utils.rs
@@ -7,10 +7,8 @@
 
 use binius_core::word::Word;
 use binius_frontend::{Circuit, CircuitBuilder, Wire};
-use binius_math::{inner_product::inner_product, multilinear::eq::eq_ind_partial_eval};
-use binius_verifier::config::B128;
 
-use crate::{ValueTable, witness::FoldedWord};
+use crate::ValueTable;
 
 /// The CRC-64/GO-ISO generator polynomial, in reflected form.
 ///
@@ -122,22 +120,6 @@ pub fn populate_crc64_witness(c: &Crc64Circuit, inputs: &[[u64; N_INPUT_WORDS]])
 		}
 	})
 	.unwrap()
-}
-
-/// Evaluates an instance-folded witness at the oblong point `(r_j, r_y)`.
-///
-/// Contract each word's folded bits against the `r_j` tensor.
-/// Then contract the resulting per-word multilinear at `r_y`.
-///
-/// The instance fold and the shift reduction are both checked against this.
-pub fn evaluate_folded_witness(folded: &[FoldedWord<B128>], r_j: &[B128], r_y: &[B128]) -> B128 {
-	let r_j_tensor = eq_ind_partial_eval::<B128>(r_j);
-	let per_word: Vec<B128> = folded
-		.iter()
-		.map(|word| inner_product(word.iter().copied(), r_j_tensor.as_ref().iter().copied()))
-		.collect();
-	let r_y_tensor = eq_ind_partial_eval::<B128>(r_y);
-	inner_product(per_word.iter().copied(), r_y_tensor.as_ref().iter().copied())
 }
 
 #[cfg(test)]

--- a/crates/m4-prover/src/witness/instance_fold.rs
+++ b/crates/m4-prover/src/witness/instance_fold.rs
@@ -4,96 +4,170 @@
 
 use binius_compute::{Allocator, VecLike};
 use binius_core::word::Word;
-use binius_field::BinaryField;
+use binius_field::{BinaryField, PackedField};
+use binius_math::{FieldVec, inner_product::inner_product};
 use binius_prover::fold_word::WordFolder;
-use binius_utils::rayon::prelude::*;
+use binius_utils::{checked_arithmetics::log2_ceil_usize, rayon::prelude::*};
 
 use crate::ValueTable;
 
-/// A committed witness word after folding its bits into the field.
+/// One 64-bit word with its bit axis expanded into full field elements.
 ///
-/// Each 64-bit word contributes one field element per bit position, so a folded word is the oblong
-/// representation of that word: its bit axis expanded to full field elements.
+/// Each bit position becomes one element, so the word is carried in oblong form.
 pub type FoldedWord<F> = [F; Word::BITS];
 
-/// Folds the committed witness of a batch value table along the instance axis.
+/// The committed witness of a batch, with its instance axis collapsed at a point.
 ///
-/// The committed witness has three axes:
-/// - the bits within each 64-bit word.
-/// - the committed words within one instance.
-/// - the instances themselves.
+/// # Overview
 ///
-/// This collapses the instance axis by the equality-indicator weights of `r_rho`.
-/// What remains is a multilinear over the other two axes.
+/// The committed witness spans three axes:
 ///
-/// For committed word `w` and bit `b`, the output element is
+/// - the bits within each 64-bit word;
+/// - the committed words of one instance;
+/// - the instances of the batch.
 ///
-/// ```text
-/// out[w][b] = sum_rho eq(r_rho, rho) * bit_b(word[rho][w])
-/// ```
-///
-/// so each set bit contributes its instance's equality weight to a full field element.
-///
-/// The bit axis occupies the low coordinates and the word axis the high coordinates.
-/// The result is a multilinear over `Word::LOG_BITS + log2(n_committed)` variables:
+/// Collapsing the instance axis leaves a multilinear over the remaining two:
 ///
 /// ```text
-/// index = w * Word::BITS + b     (b occupies the low Word::LOG_BITS coordinates)
+/// index = w * Word::BITS + b        b occupies the low Word::LOG_BITS coordinates
 /// ```
 ///
-/// The table stores exactly the committed (hidden) words, so nothing here is excluded.
-/// The constants and public words live once on the constraint system, folded separately.
+/// So the bit axis takes the low coordinates and the word axis the high ones.
 ///
-/// The wire-major layout makes this cheap: one wire's values across every instance are stored
-/// contiguously, so each word position is a plain sub-slice rather than a strided gather.
-///
-/// Every word position folds against the same instance point `r_rho`.
-/// So the lookup tables and per-chunk weights are built once and shared across all word positions.
-/// The word positions are independent, so the fold runs in parallel, one output word per task.
-///
-/// # Panics
-///
-/// Panics if `r_rho.len()` does not equal the batch dimension.
-pub fn fold_instances<F: BinaryField, A: Allocator>(
-	table: &ValueTable,
-	r_rho: &[F],
-	alloc: &A,
-) -> A::Vec<FoldedWord<F>> {
-	assert_eq!(r_rho.len(), table.log_instances(), "r_rho must match the batch dimension");
+/// The committed word count need not be a power of two.
+/// Anything that produces a multilinear from it zero-pads the word axis up to one.
+pub struct FoldedWitness<F: Send, A: Allocator> {
+	/// The oblong words, one per committed word of a single instance, in wire order.
+	words: A::Vec<FoldedWord<F>>,
+}
 
-	// Build the instance-fold tables once; the lookups and weights depend only on r_rho.
-	let folder = WordFolder::<F>::new(r_rho);
+impl<F: BinaryField, A: Allocator> FoldedWitness<F, A> {
+	/// Collapses the instance axis of a batch witness at a challenge point.
+	///
+	/// # Overview
+	///
+	/// Every instance is weighted by its equality indicator, and the weighted bits are summed:
+	///
+	/// ```text
+	/// out[w][b] = sum_rho eq(r_rho, rho) * bit_b(word[rho][w])
+	/// ```
+	///
+	/// So each set bit contributes its own instance's weight to a full field element.
+	///
+	/// Only the hidden segment is stored in the table, so only it is folded here.
+	/// The shared constants live on the constraint system and fold separately.
+	///
+	/// # Performance
+	///
+	/// The wire-major layout stores one wire's instances contiguously.
+	/// Each word position therefore reads a plain sub-slice, not a strided gather.
+	/// The positions are independent, so they fold in parallel, one task per output word.
+	///
+	/// # Panics
+	///
+	/// Panics if the point width does not match the batch dimension.
+	pub fn fold_instances(table: &ValueTable, r_rho: &[F], alloc: &A) -> Self {
+		// Invariant: one challenge coordinate per instance-axis variable.
+		assert_eq!(r_rho.len(), table.log_instances(), "r_rho must match the batch dimension");
 
-	// Each output element holds one committed word position:
-	//     out[w][b] = sum_rho eq(r_rho, rho) * bit_b(word[rho][w]).
-	// The word positions are independent, so fold them in parallel, one output element per task.
-	//
-	// The table stores exactly `n_hidden_words << log_instances` words, so chunking it by the
-	// instance count yields exactly one chunk per output element. `zip` truncates to the shorter
-	// side, so this equality is what makes the loop below cover every element; assert it rather
-	// than rely on a `ValueTable` invariant stated in another module.
-	let n_words = table.n_hidden_words();
-	debug_assert_eq!(table.as_words().len(), n_words << table.log_instances());
-	let mut folded = alloc.alloc::<FoldedWord<F>>(n_words);
-	table
-		.as_words()
-		.par_chunks(1 << table.log_instances())
-		.zip(folded.spare_capacity_mut())
-		.for_each(|(instance_words, out)| {
-			out.write(folder.fold(instance_words));
-		});
-	// SAFETY: the chunks and the output elements are in one-to-one correspondence by the length
-	// equality asserted above, so the loop writes each of the `n_words` elements exactly once.
-	unsafe { folded.set_len(n_words) };
-	folded
+		// The bit lookup tables and per-chunk weights depend only on the point.
+		// Build them once here, then share them across every word position.
+		let folder = WordFolder::<F>::new(r_rho);
+		let n_words = table.n_hidden_words();
+
+		// Invariant: the stored words split evenly into one chunk per committed word.
+		//
+		//     stored:      n_words * 2^log_instances
+		//     chunked by:  2^log_instances -> exactly n_words chunks
+		debug_assert_eq!(table.as_words().len(), n_words << table.log_instances());
+
+		// One output element per committed word position.
+		let mut words = alloc.alloc::<FoldedWord<F>>(n_words);
+		table
+			.as_words()
+			// One chunk is one word position across every instance of the batch.
+			.par_chunks(1 << table.log_instances())
+			.zip(words.spare_capacity_mut())
+			.for_each(|(instance_words, out)| {
+				// Collapse those instances into 64 elements, one per bit position.
+				out.write(folder.fold(instance_words));
+			});
+
+		// SAFETY: chunks and output elements correspond one-to-one by the equality above, so the
+		// loop writes each of the `n_words` elements exactly once.
+		unsafe { words.set_len(n_words) };
+
+		Self { words }
+	}
+
+	/// The oblong words, one per committed word, in wire order.
+	pub fn words(&self) -> &[FoldedWord<F>] {
+		&self.words
+	}
+
+	/// The number of word-axis variables, after padding the word count to a power of two.
+	///
+	/// This is the width of the word half of any point the witness is evaluated at.
+	pub fn log_padded_words(&self) -> usize {
+		log2_ceil_usize(self.words.len())
+	}
+
+	/// Contracts the bit axis at a point, leaving a multilinear over the word axis.
+	///
+	/// # Overview
+	///
+	/// Each word's bits are contracted against the supplied weights:
+	///
+	/// ```text
+	/// out[w] = sum_b weights[b] * word_w[b]
+	/// ```
+	///
+	/// This is the partial evaluation of the witness along its bit axis.
+	/// The word axis is zero-padded up to a power of two.
+	///
+	/// # Panics
+	///
+	/// Panics unless there is exactly one weight per bit of a word.
+	pub fn fold_bits<P>(&self, r_j_tensor: &[F], alloc: &A) -> FieldVec<P, A>
+	where
+		P: PackedField<Scalar = F>,
+	{
+		// Invariant: one weight per bit position.
+		// The contraction pairs both sides with a length-checked zip, which would otherwise panic
+		// from inside the arithmetic without naming the cause.
+		assert_eq!(r_j_tensor.len(), Word::BITS, "r_j_tensor must hold one weight per word bit");
+
+		// A multilinear needs a power-of-two word axis; the real words fill the front of it.
+		let padded_len = 1 << self.log_padded_words();
+		let mut scalars = alloc.alloc::<F>(padded_len);
+
+		// One scalar per committed word: that word's bits contracted at the point.
+		scalars.extend(
+			self.words
+				.iter()
+				.map(|word| inner_product(word.iter().copied(), r_j_tensor.iter().copied())),
+		);
+
+		// Everything past the real words is the multilinear's zero padding.
+		scalars.resize(padded_len, F::ZERO);
+
+		// Pack the scalars into the buffer shape the sumcheck consumes.
+		FieldVec::<P, A>::from_values_in(alloc, &scalars)
+	}
 }
 
 #[cfg(test)]
 mod tests {
+	use std::iter;
+
 	use binius_compute::GlobalAllocator;
 	use binius_field::PackedBinaryGhash1x128b;
+	use binius_frontend::{CircuitBuilder, Wire};
 	use binius_math::{
-		multilinear::{eq::eq_ind_partial_eval_scalars, evaluate::evaluate},
+		multilinear::{
+			eq::{eq_ind_partial_eval, eq_ind_partial_eval_scalars},
+			evaluate::evaluate,
+		},
 		test_utils::random_scalars,
 	};
 	use binius_prover::fold_word::fold_words;
@@ -102,29 +176,93 @@ mod tests {
 	use rand::prelude::*;
 
 	use super::*;
-	use crate::test_utils::{
-		N_INPUT_WORDS, crc64_circuit, evaluate_folded_witness, populate_crc64_witness,
-	};
+	use crate::test_utils::{N_INPUT_WORDS, crc64_circuit, populate_crc64_witness};
 
-	// Folding the batch over the instance axis and then evaluating over the (bit, word) axes agrees
-	// with folding each word's bits first and then evaluating over the (word, instance) axes.
+	impl<F: BinaryField, A: Allocator> FoldedWitness<F, A> {
+		/// Evaluates the witness at a point split into a bit half and a word half.
+		///
+		/// # Overview
+		///
+		/// - Contract the bit axis at the first half of the point.
+		/// - Contract the resulting per-word multilinear at the second half.
+		///
+		/// The word axis is zero-padded out to the width of the word half.
+		/// Those padded positions are zero, so they drop out of the result.
+		///
+		/// # Why this exists
+		///
+		/// This contracts scalar by scalar, where the production path packs words into field lanes.
+		/// Agreeing with it is what pins that packed path.
+		///
+		/// # Panics
+		///
+		/// Panics if the word half is too narrow to index every committed word.
+		pub fn evaluate(&self, r_j: &[F], r_y: &[F]) -> F {
+			// Expand both halves of the point into equality weights.
+			let r_j_tensor = eq_ind_partial_eval::<F>(r_j);
+			let r_y_tensor = eq_ind_partial_eval::<F>(r_y);
+			let n_padded = r_y_tensor.as_ref().len();
+
+			// Invariant: the word half addresses at least every real word.
+			assert!(self.words.len() <= n_padded, "r_y must index every committed word");
+
+			// Contract each word's bits, then extend the axis with the zeros the padding stands
+			// for.
+			let per_word = self
+				.words
+				.iter()
+				.map(|word| {
+					inner_product(word.iter().copied(), r_j_tensor.as_ref().iter().copied())
+				})
+				.chain(iter::repeat(F::ZERO))
+				.take(n_padded);
+
+			// Contract the per-word multilinear at the word half of the point.
+			inner_product(per_word, r_y_tensor.as_ref().iter().copied())
+		}
+	}
+
+	// A batch of 2^3 instances of a circuit whose committed word count is `3 * n_gates`.
 	//
-	// Both routes compute the same triple sum, just associated differently:
-	//
-	//     sum_{rho, w, b} eq(r_rho, rho) * eq(r_wire, w) * eq(r_bit, b) * bit_b(word[rho][w])
-	//
-	// The evaluation point `r` is fresh and unrelated to the reduction's own r_z / r_x challenges;
-	// its low Word::LOG_BITS coordinates are the bit axis and its high coordinates are the word
-	// axis, matching the layout `fold_instances` produces.
+	// A multiple of three is a power of two only for a hand-picked gate count.
+	// That is what lets a caller choose whether the word axis needs padding.
+	fn and_chain_table(n_gates: usize) -> ValueTable {
+		// Each gate consumes two fresh witness words and commits its result.
+		let builder = CircuitBuilder::new();
+		let inputs: Vec<Wire> = (0..2 * n_gates).map(|_| builder.add_witness()).collect();
+		for pair in inputs.chunks_exact(2) {
+			let and = builder.band(pair[0], pair[1]);
+			// Pin the output, so dead-code elimination keeps the gate.
+			builder.force_commit(and);
+		}
+		let circuit = builder.build();
+
+		// Every instance gets its own seed, so no two instances share a witness.
+		ValueTable::populate(&circuit, 3, |i, w| {
+			let mut rng = StdRng::seed_from_u64(i as u64);
+			for &wire in &inputs {
+				w[wire] = Word(rng.next_u64());
+			}
+		})
+		.unwrap()
+	}
+
 	#[test]
 	fn fold_instances_commutes_with_evaluation() {
 		type P = PackedBinaryGhash1x128b;
 
+		// Invariant: the order of the two folds does not matter.
+		// Both routes compute one triple sum, associated differently:
+		//
+		//     sum_{rho, w, b} eq(r_rho, rho) * eq(r_wire, w) * eq(r_bit, b) * bit_b(word[rho][w])
+		//
+		//     route A: fold instances first  -> evaluate over (bit, word)
+		//     route B: fold bits first       -> evaluate over (word, instance)
 		let c = crc64_circuit();
 		let mut rng = StdRng::seed_from_u64(0);
 
-		// Cover every chunk regime of the per-column fold.
-		// A sub-chunk batch (< CHUNK_SIZE instances), exactly one chunk, and several chunks.
+		// Fixture state: three batch sizes covering every chunk regime of the per-column fold.
+		// Below one chunk, exactly one chunk, and several chunks.
 		for log_instances in [3, Word::LOG_BITS, Word::LOG_BITS + 2] {
 			let n_instances = 1usize << log_instances;
 
@@ -134,28 +272,32 @@ mod tests {
 			let table = populate_crc64_witness(&c, &inputs);
 			let constants = &c.circuit.constraint_system().constants;
 
-			// The committed witness segment, whose word count fixes the word (x) axis.
+			// The committed segment runs from the witness offset to the end of the value vector.
+			// Its length fixes the width of the word axis.
 			let layout = table.layout();
 			let offset = layout.offset_witness;
 			let n_committed = layout.combined_len() - offset;
 			let log_committed = checked_log_2(n_committed);
 
 			// The instance-fold point, and a fresh point over the (bit, word) axes.
+			// This point is unrelated to the reduction's own challenges.
 			let r_rho = random_scalars::<B128>(&mut rng, log_instances);
 			let r = random_scalars::<B128>(&mut rng, Word::LOG_BITS + log_committed);
 
-			// Route A: fold the instance axis, giving one FoldedWord per committed word, then
-			// evaluate that (bit, word) multilinear at r.
-			let folded = fold_instances::<B128, _>(&table, &r_rho, &GlobalAllocator);
+			// Route A: collapse instances, then evaluate the (bit, word) multilinear.
+			// The low coordinates are the bit axis, matching the layout the fold produces.
+			let folded = FoldedWitness::<B128, _>::fold_instances(&table, &r_rho, &GlobalAllocator);
 			let (r_bit, r_wire) = r.split_at(Word::LOG_BITS);
-			let lhs = evaluate_folded_witness(&folded, r_bit, r_wire);
+			let lhs = folded.evaluate(r_bit, r_wire);
 
-			// Route B: fold each word's bits by the tensor expansion of the bit coordinates, then
-			// evaluate the resulting (word, instance) multilinear over the word and instance axes.
+			// Route B: collapse each word's bits against the bit coordinates first.
 			let bit_tensor = eq_ind_partial_eval_scalars::<B128>(r_bit);
 
-			// Gather the committed words of every instance, instance-major: index = rho *
-			// n_committed + w. Each instance is reconstructed independently of the fold under test.
+			// Gather every instance's committed words, instance-major:
+			//
+			//     index = rho * n_committed + w
+			//
+			// Each instance is reconstructed on its own, independently of the fold under test.
 			let mut committed = Vec::with_capacity(n_instances * n_committed);
 			for rho in 0..n_instances {
 				let vv = table.instance_value_vec(rho, constants);
@@ -163,11 +305,74 @@ mod tests {
 			}
 			let folded_words = fold_words::<B128, P, _>(&GlobalAllocator, &committed, &bit_tensor);
 
+			// Route B evaluates over (word, instance), so the point is reordered to match.
 			let mut point = r_wire.to_vec();
 			point.extend_from_slice(&r_rho);
 			let rhs = evaluate(&folded_words, &point);
 
 			assert_eq!(lhs, rhs, "mismatch at log_instances = {log_instances}");
 		}
+	}
+
+	#[test]
+	fn fold_bits_matches_the_scalar_contraction() {
+		let mut rng = StdRng::seed_from_u64(1);
+
+		// Invariant: packing the bit contraction into field lanes changes no evaluation.
+		// The packed buffer also carries zero padding, which must not shift the result.
+		//
+		// Fixture state: two witnesses, one per word-axis regime.
+		//
+		//     CRC-64:    1024 committed words  -> already a power of two, no padding
+		//     AND chain:    6 committed words  -> zero-padded up to 8
+		let c = crc64_circuit();
+		let inputs: Vec<[u64; N_INPUT_WORDS]> = (0..8)
+			.map(|_| std::array::from_fn(|_| rng.random()))
+			.collect();
+		let unpadded = populate_crc64_witness(&c, &inputs);
+		let padded = and_chain_table(2);
+
+		// Pin which fixture is which, so neither regime can silently stop being covered.
+		assert!(unpadded.n_hidden_words().is_power_of_two(), "fixture must skip the padding");
+		assert!(!padded.n_hidden_words().is_power_of_two(), "fixture must reach the padding");
+
+		for table in [unpadded, padded] {
+			let r_rho = random_scalars::<B128>(&mut rng, table.log_instances());
+			let folded = FoldedWitness::<B128, _>::fold_instances(&table, &r_rho, &GlobalAllocator);
+
+			// The bit point, and a word point as wide as the padded word axis.
+			let r_j = random_scalars::<B128>(&mut rng, Word::LOG_BITS);
+			let r_y = random_scalars::<B128>(&mut rng, folded.log_padded_words());
+			let r_j_tensor = eq_ind_partial_eval::<B128>(&r_j);
+
+			// The packed contraction, evaluated at the word point, against the scalar reference.
+			let packed =
+				folded.fold_bits::<PackedBinaryGhash1x128b>(r_j_tensor.as_ref(), &GlobalAllocator);
+			assert_eq!(
+				evaluate(&packed, &r_y),
+				folded.evaluate(&r_j, &r_y),
+				"mismatch at {} committed words",
+				table.n_hidden_words()
+			);
+		}
+	}
+
+	#[test]
+	#[should_panic(expected = "r_j_tensor must hold one weight per word bit")]
+	fn fold_bits_rejects_a_tensor_that_is_not_one_weight_per_bit() {
+		// Fixture state: two instances of the smallest witness that populates.
+		let c = crc64_circuit();
+		let table = populate_crc64_witness(&c, &[[0; N_INPUT_WORDS], [1; N_INPUT_WORDS]]);
+		let folded =
+			FoldedWitness::<B128, _>::fold_instances(&table, &[B128::new(7)], &GlobalAllocator);
+
+		// Mutation: one coordinate short of the bit axis.
+		//
+		//     weights supplied: 2^5 = 32
+		//     bits per word:    2^6 = 64
+		//
+		// The contraction pairs the two sides, so the width check must reject this up front.
+		let short = eq_ind_partial_eval::<B128>(&[B128::new(3); Word::LOG_BITS - 1]);
+		let _ = folded.fold_bits::<PackedBinaryGhash1x128b>(short.as_ref(), &GlobalAllocator);
 	}
 }

--- a/crates/m4-prover/src/witness/mod.rs
+++ b/crates/m4-prover/src/witness/mod.rs
@@ -5,7 +5,7 @@
 //! The table stores raw words, wire-major; no reduction reads it in that form.
 //!
 //! - [`build_operation_columns`] — one word column per operand, for the operation checks.
-//! - [`fold_instances`] — the witness with its instance axis collapsed, for the shift.
+//! - [`FoldedWitness`] — the witness with its instance axis collapsed, for the shift.
 //! - [`operand_rho_multilinear`] — one column reduced to one element per instance.
 //!
 //! A word column is constraint-major, so one constraint's instances are contiguous:
@@ -18,6 +18,6 @@ mod instance_fold;
 mod operand_columns;
 mod operand_rho;
 
-pub use instance_fold::{FoldedWord, fold_instances};
+pub use instance_fold::{FoldedWitness, FoldedWord};
 pub use operand_columns::build_operation_columns;
 pub use operand_rho::operand_rho_multilinear;


### PR DESCRIPTION
Turns the instance-folded witness from a bare array into a type that owns its operations.
Pure refactor of the arithmetic — the folding math is untouched — plus two boundary fixes described below.

### The problem

The witness, once folded over the instance axis, travelled as `A::Vec<[F; 64]>` behind a type alias.
An alias has no methods, so every operation on it was written out wherever it was needed:

| operation | where it lived |
|---|---|
| the instance fold | a free function |
| the bit-axis contraction | seven lines inline in the shift prover's phase 2 |
| evaluation | a helper in the crate's test fixtures |
| the padded word count | `log2_ceil_usize(folded_witness.len())`, respelled at each caller |

One concept, four homes, and no place to state the invariant that ties them together.

### The change

```rust
pub struct FoldedWitness<F: Send, A: Allocator> {
    words: A::Vec<FoldedWord<F>>,
}
```

with `fold_instances` as its constructor and `fold_bits`, `log_padded_words`, `words` as methods.
Phase 2 of the shift prover now reads

```
- let padded_len = 1 << log2_ceil_usize(folded_witness.len());
- let mut hidden_scalars = alloc.alloc::<F>(padded_len);
- hidden_scalars.extend(folded_witness.iter().map(|word| inner_product(..)));
- hidden_scalars.resize(padded_len, F::ZERO);
- let hidden_folded = FieldBuffer::<P, _>::from_values_in(alloc, &hidden_scalars);
+ let hidden_folded = folded_witness.fold_bits::<P>(r_j_tensor.as_ref(), alloc);
```

`FoldedWord<F> = [F; Word::BITS]` stays as the element alias.
One oblong word genuinely is an array, and the single-instance builders take it by slice.

### Two boundary fixes that fell out of the move

**The bit contraction now validates its weights.** The inner product pairs both sides with a length-checked zip, so a short weight vector used to fail with an itertools panic that named nothing. It now fails at the boundary, saying which length was wrong.

**Evaluation now pads instead of relying on truncation that never happened.** The old helper assumed the contraction would truncate to the shorter side. It does not — it panics. The helper only ever worked because its one caller had a witness with exactly 1024 committed words, a power of two. Evaluation now zero-pads the word axis out to the width of the point, which is the correct semantics for the padded multilinear, and is exercised on a non-power-of-two witness.

### Scope

- **new:** the type, its four methods, two tests
- **moved:** the instance fold and the evaluation reference, unchanged in arithmetic
- **deleted:** the free fold function and the test-fixture evaluation helper
- **untouched:** the shift protocol, the transcript, the public API

The scalar evaluation lives in an `impl` block inside the file's `mod tests`, so it carries its own imports and leaves no `#[cfg(test)]` in the production section. That block is a second inherent impl, so it was checked against the lint added in #2005 — see below.

### Not done deliberately

`fold_bits` keeps the serial body verbatim: one inner product per word into a scratch buffer, then a copy. That is an unmeasured performance lead, and folding an optimization into a refactor would make both harder to review. It is now a one-place change.

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-m4-prover --all-targets --all-features` — clean
- the same, with `-D clippy::multiple_inherent_impl -D warnings` — clean, so the added impl block does not trip #2005's lint
- `cargo test -p binius-m4-prover --all-features` — 40 + 5 passed
- `cargo doc -p binius-m4-prover --no-deps` — clean
- `cargo +nightly fmt --all` — applied

New tests, beyond the relocated fold test:

- the packed bit contraction agrees with the scalar reference, over **both** word-axis regimes — a 1024-word witness where nothing is padded, and a 6-word witness padded to 8. The test asserts which fixture is which, so neither regime can silently stop being covered.
- the weight-vector width check rejects a vector one coordinate short of the bit axis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)