### PR TITLE
Bundle the shift reduction's four operator claims into one type

### DIFF
--- a/crates/m4-prover/src/lib.rs
+++ b/crates/m4-prover/src/lib.rs
@@ -3,6 +3,7 @@
 
 //! Witness table and prover for the data-parallel Binius64 M4 proof system.
 
+mod operator_claims;
 mod prove;
 mod shift;
 #[cfg(test)]

--- a/crates/m4-prover/src/operator_claims.rs
+++ b/crates/m4-prover/src/operator_claims.rs
@@ -1,0 +1,156 @@
+// Copyright 2026 The Binius Developers
+
+//! The shift reduction's operand evaluation claims, one per operation.
+//!
+//! The reduction closes four constraint families in one proof: ZERO, AND, IMUL and BMUL.
+//!
+//! Each family arrives with its own operand evaluation claim.
+//! Those four claims then travel together through both phases of the reduction.
+//!
+//! Passed as four positional arguments, two same-typed neighbours are interchangeable.
+//! The compiler accepts either order, so a swap yields a wrong proof instead of an error.
+//!
+//! Bundled instead, each claim is named where it is built.
+//! It is then reached by indexing on [`Operation`] where it is read.
+
+use std::ops::Index;
+
+use binius_field::Field;
+use binius_prover::protocols::shift::{Operation, OperatorData, PreparedOperatorData};
+
+/// The operand evaluation claim of every operation, as the shift reduction receives them.
+///
+/// A shift key names the operation it belongs to, so its claim is reached by indexing:
+///
+/// ```text
+/// claims[key.operation]
+/// ```
+#[derive(Debug, Clone)]
+pub struct OperatorClaims<F: Field> {
+	/// The claim for the ZERO constraints, `VAL == 0`.
+	pub zero: OperatorData<F>,
+	/// The claim for the AND constraints, `A & B ^ C == 0`.
+	pub bitand: OperatorData<F>,
+	/// The claim for the IMUL constraints, `A * B == (HI << 64) | LO`.
+	pub intmul: OperatorData<F>,
+	/// The claim for the BMUL constraints, `A * B == C` in the GHASH field.
+	pub binmul: OperatorData<F>,
+}
+
+impl<F: Field> OperatorClaims<F> {
+	/// Draws one batching coefficient per operation and folds it into that operation's claim.
+	///
+	/// An operation holds one claim per operand, and the reduction proves them all at once.
+	/// Batching weights operand `i` by the `i`-th power of the operation's own coefficient.
+	///
+	/// The powers start at the first, never the zeroth.
+	/// So each operation's batched value already carries a random factor of its own.
+	/// The four can then be summed directly, with no further scaling to separate them.
+	///
+	/// The coefficients are drawn in the order `[Zero, BitwiseAnd, IntegerMul, BinMul]`.
+	/// The verifier draws in that same order, so this sequence is protocol, not detail.
+	///
+	/// # Arguments
+	///
+	/// - `sample`: draws the next batching coefficient from the transcript.
+	pub fn prepare(self, mut sample: impl FnMut() -> F) -> PreparedOperatorClaims<F> {
+		PreparedOperatorClaims {
+			zero: PreparedOperatorData::new(self.zero, sample()),
+			bitand: PreparedOperatorData::new(self.bitand, sample()),
+			intmul: PreparedOperatorData::new(self.intmul, sample()),
+			binmul: PreparedOperatorData::new(self.binmul, sample()),
+		}
+	}
+}
+
+impl<F: Field> Index<Operation> for OperatorClaims<F> {
+	type Output = OperatorData<F>;
+
+	fn index(&self, operation: Operation) -> &OperatorData<F> {
+		match operation {
+			Operation::Zero => &self.zero,
+			Operation::BitwiseAnd => &self.bitand,
+			Operation::IntegerMul => &self.intmul,
+			Operation::BinMul => &self.binmul,
+		}
+	}
+}
+
+/// The claims with their batching coefficients folded in, as both proving phases read them.
+///
+/// Each entry also carries the tensor expansion of its constraint point.
+/// That expansion is shared by every key of the operation, so it is built once here.
+#[derive(Debug, Clone)]
+pub struct PreparedOperatorClaims<F: Field> {
+	/// The prepared claim for the ZERO constraints.
+	pub zero: PreparedOperatorData<F>,
+	/// The prepared claim for the AND constraints.
+	pub bitand: PreparedOperatorData<F>,
+	/// The prepared claim for the IMUL constraints.
+	pub intmul: PreparedOperatorData<F>,
+	/// The prepared claim for the BMUL constraints.
+	pub binmul: PreparedOperatorData<F>,
+}
+
+impl<F: Field> Index<Operation> for PreparedOperatorClaims<F> {
+	type Output = PreparedOperatorData<F>;
+
+	fn index(&self, operation: Operation) -> &PreparedOperatorData<F> {
+		match operation {
+			Operation::Zero => &self.zero,
+			Operation::BitwiseAnd => &self.bitand,
+			Operation::IntegerMul => &self.intmul,
+			Operation::BinMul => &self.binmul,
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use binius_verifier::config::B128;
+
+	use super::*;
+
+	// One claim per operation, each tagged by a distinct operand count.
+	// A mis-wired index arm therefore returns a count no assertion accepts.
+	fn claims_tagged_by_arity() -> OperatorClaims<B128> {
+		OperatorClaims {
+			zero: OperatorData::zero_claim(1, B128::ZERO),
+			bitand: OperatorData::zero_claim(2, B128::ZERO),
+			intmul: OperatorData::zero_claim(3, B128::ZERO),
+			binmul: OperatorData::zero_claim(4, B128::ZERO),
+		}
+	}
+
+	#[test]
+	fn each_operation_indexes_its_own_claim() {
+		// Invariant: an operation indexes its own claim, never a neighbour's.
+		let claims = claims_tagged_by_arity();
+
+		assert_eq!(claims[Operation::Zero].evals.len(), 1);
+		assert_eq!(claims[Operation::BitwiseAnd].evals.len(), 2);
+		assert_eq!(claims[Operation::IntegerMul].evals.len(), 3);
+		assert_eq!(claims[Operation::BinMul].evals.len(), 4);
+	}
+
+	#[test]
+	fn prepare_draws_one_coefficient_per_operation_in_transcript_order() {
+		// Invariant: the coefficients are drawn in the order [Zero, AND, IMUL, BMUL].
+		// The verifier draws in that order; any other batches a claim by the wrong coefficient.
+		//
+		// This stand-in transcript hands out 1, 2, 3, 4, so a coefficient names its draw position.
+		let mut draws = 0u128;
+		let prepared = claims_tagged_by_arity().prepare(|| {
+			draws += 1;
+			B128::new(draws)
+		});
+
+		assert_eq!(draws, 4, "one draw per operation");
+
+		// Powers start at the first, so a claim's leading power is the coefficient it was given.
+		assert_eq!(prepared[Operation::Zero].lambda_powers[0], B128::new(1));
+		assert_eq!(prepared[Operation::BitwiseAnd].lambda_powers[0], B128::new(2));
+		assert_eq!(prepared[Operation::IntegerMul].lambda_powers[0], B128::new(3));
+		assert_eq!(prepared[Operation::BinMul].lambda_powers[0], B128::new(4));
+	}
+}

--- a/crates/m4-prover/src/prove.rs
+++ b/crates/m4-prover/src/prove.rs
@@ -43,6 +43,7 @@ use binius_verifier::{
 
 use crate::{
 	ValueTable,
+	operator_claims::OperatorClaims,
 	shift::prove as prove_shift,
 	witness::{FoldedWitness, OperandColumns},
 };
@@ -230,7 +231,7 @@ impl IOPProver {
 		//
 		// The re-randomization runs whenever IntMul or BinMul is present: BitAnd always enters,
 		// plus each present multiplication operation, all unified onto one shared `r_rho`.
-		let (r_rho, bitand_data, intmul_data, binmul_data) = if mul.is_some() || bmul.is_some() {
+		let (r_rho, claims) = if mul.is_some() || bmul.is_some() {
 			// Every present operation enters the re-randomization as operand columns with their
 			// oblong claims at their own instance point.
 			// BitAnd is already oblong.
@@ -248,27 +249,22 @@ impl IOPProver {
 					Operation::from_binmul(columns, output.clone(), &lagrange, log_instances)
 				}),
 			}
-			.prove::<P, _>(&lagrange, z_challenge, channel, alloc)
+			.prove::<P, _>(zero_data, &lagrange, z_challenge, channel, alloc)
 		} else {
 			// Neither IMUL nor BMUL constraints: the AND-check instance point is used directly.
 			// The IntMul and BinMul claims are zero claims at an empty point, contributing nothing
 			// to the shift.
 			(
 				r_rho_and.to_vec(),
-				OperatorData {
-					evals: vec![a_eval, b_eval, c_eval],
-					r_zhat_prime: z_challenge,
-					r_x_prime: r_x_and.to_vec(),
-				},
-				OperatorData {
-					evals: vec![B128::ZERO; INTMUL_ARITY],
-					r_zhat_prime: z_challenge,
-					r_x_prime: Vec::new(),
-				},
-				OperatorData {
-					evals: vec![B128::ZERO; BINMUL_ARITY],
-					r_zhat_prime: z_challenge,
-					r_x_prime: Vec::new(),
+				OperatorClaims {
+					zero: zero_data,
+					bitand: OperatorData {
+						evals: vec![a_eval, b_eval, c_eval],
+						r_zhat_prime: z_challenge,
+						r_x_prime: r_x_and.to_vec(),
+					},
+					intmul: OperatorData::zero_claim(INTMUL_ARITY, z_challenge),
+					binmul: OperatorData::zero_claim(BINMUL_ARITY, z_challenge),
 				},
 			)
 		};
@@ -302,10 +298,7 @@ impl IOPProver {
 				&self.key_collection,
 				&public_words,
 				&folded_witness,
-				zero_data,
-				bitand_data,
-				intmul_data,
-				binmul_data,
+				claims,
 				&shift_domain,
 				channel,
 				alloc,
@@ -595,21 +588,30 @@ impl<A: Allocator> RerandomizedOperations<'_, A> {
 	/// - A batched sumcheck transports every claim to one shared instance point.
 	/// - The reduced evaluations there are the operand claims the shift consumes.
 	///
-	/// The operands are pushed in the order [BitAnd | IntMul (if present) | BinMul (if present)],
-	/// so the reduced evaluations split back into contiguous per-operation segments in that same
-	/// order. An absent operation reduces to a zero claim at an empty point.
+	/// The operands are pushed in the order [BitAnd | IntMul (if present) | BinMul (if present)].
+	/// The reduced evaluations therefore split back into per-operation segments in that same order.
+	/// An absent operation reduces to a zero claim at an empty point.
+	///
+	/// The Zero reduction closes at its own constraint point, so it takes no part in this.
+	/// Its claim passes straight through into the returned bundle.
+	///
+	/// # Arguments
+	///
+	/// - `zero`: the Zero reduction's claim, carried into the result unchanged.
+	/// - `lagrange`: the Lagrange weights at the shared univariate challenge.
+	/// - `z_challenge`: that univariate challenge, carried by every returned claim.
 	///
 	/// # Returns
 	///
-	/// The shared instance point, the BitAnd operand data, the IntMul operand data, and the BinMul
-	/// operand data.
+	/// The shared instance point, and the operand claims of every operation at that point.
 	fn prove<'alloc, P, Channel>(
 		self,
+		zero: OperatorData<B128>,
 		lagrange: &[B128],
 		z_challenge: B128,
 		channel: &mut Channel,
 		alloc: &'alloc A,
-	) -> (Vec<B128>, OperatorData<B128>, OperatorData<B128>, OperatorData<B128>)
+	) -> (Vec<B128>, OperatorClaims<B128>)
 	where
 		P: PackedField<Scalar = B128>,
 		Channel: IOPProverChannel<P, A>,
@@ -646,7 +648,7 @@ impl<A: Allocator> RerandomizedOperations<'_, A> {
 
 		// The reduced evaluations split back into contiguous per-operation segments, in push order.
 		let mut offset = 0;
-		let bitand_data = OperatorData {
+		let bitand = OperatorData {
 			evals: reduced[offset..offset + BITAND_ARITY].to_vec(),
 			r_zhat_prime: z_challenge,
 			r_x_prime: self.bitand.r_x,
@@ -654,7 +656,7 @@ impl<A: Allocator> RerandomizedOperations<'_, A> {
 		offset += BITAND_ARITY;
 
 		// IntMul: the next INTMUL_ARITY reduced evaluations when present, else a zero claim.
-		let intmul_data = match self.intmul {
+		let intmul = match self.intmul {
 			Some(intmul) => {
 				let data = OperatorData {
 					evals: reduced[offset..offset + INTMUL_ARITY].to_vec(),
@@ -664,32 +666,32 @@ impl<A: Allocator> RerandomizedOperations<'_, A> {
 				offset += INTMUL_ARITY;
 				data
 			}
-			None => OperatorData {
-				evals: vec![B128::ZERO; INTMUL_ARITY],
-				r_zhat_prime: z_challenge,
-				r_x_prime: Vec::new(),
-			},
+			None => OperatorData::zero_claim(INTMUL_ARITY, z_challenge),
 		};
 
 		// BinMul: the final BINMUL_ARITY reduced evaluations when present, else a zero claim.
-		let binmul_data = match self.binmul {
+		let binmul = match self.binmul {
 			Some(binmul) => OperatorData {
 				evals: reduced[offset..offset + BINMUL_ARITY].to_vec(),
 				r_zhat_prime: z_challenge,
 				r_x_prime: binmul.r_x,
 			},
-			None => OperatorData {
-				evals: vec![B128::ZERO; BINMUL_ARITY],
-				r_zhat_prime: z_challenge,
-				r_x_prime: Vec::new(),
-			},
+			None => OperatorData::zero_claim(BINMUL_ARITY, z_challenge),
 		};
 
 		// `batch_prove` returns binding-order challenges; reverse to variable-indexed to match
 		// the verifier's `r_rho`.
 		let mut r_rho = output.challenges;
 		r_rho.reverse();
-		(r_rho, bitand_data, intmul_data, binmul_data)
+		(
+			r_rho,
+			OperatorClaims {
+				zero,
+				bitand,
+				intmul,
+				binmul,
+			},
+		)
 	}
 }
 

--- a/crates/m4-prover/src/shift.rs
+++ b/crates/m4-prover/src/shift.rs
@@ -13,7 +13,7 @@ use binius_math::{BinarySubspace, FieldBuffer, FieldVec, multilinear::eq::eq_ind
 use binius_prover::{
 	fold_word::fold_words,
 	protocols::shift::{
-		KeyCollection, KeySegment, Operation, OperatorData, PreparedOperatorData,
+		KeyCollection, KeySegment,
 		monster::{build_h_parts, build_monster_segments},
 		phase_1::{build_g_parts, run_phase_1_sumcheck},
 		phase_2::run_sumcheck,
@@ -21,14 +21,18 @@ use binius_prover::{
 };
 use binius_verifier::protocols::shift::SHIFT_VARIANT_COUNT;
 
-use crate::witness::{FoldedWitness, FoldedWord};
+use crate::{
+	operator_claims::{OperatorClaims, PreparedOperatorClaims},
+	witness::{FoldedWitness, FoldedWord},
+};
 
 /// The number of variables in each "g" (and "h") multilinear of phase 1: one 6-bit shift-amount
 /// axis and one 6-bit bit-position axis.
 const LOG_LEN: usize = Word::LOG_BITS + Word::LOG_BITS;
 
-/// Proves the batched shift-reduction, reducing the bitand and intmul evaluation claims to a single
-/// multilinear claim on the batched witness.
+/// Proves the batched shift-reduction, collapsing every operation's claims into one.
+///
+/// The result is a single multilinear claim on the batched witness.
 ///
 /// This mirrors the single-instance shift reduction, with one difference.
 /// The hidden witness enters already folded over the instance axis, as a [`FoldedWitness`].
@@ -37,31 +41,26 @@ const LOG_LEN: usize = Word::LOG_BITS + Word::LOG_BITS;
 /// The two phases call the single-instance prover's own subroutines.
 /// Phase 1 builds the hidden g parts with [`build_g_parts_from_folded_words`].
 /// It builds the public g parts with the single-instance `build_g_parts`, then sums the two.
-/// Phase 2 contracts the hidden witness along the bit (`r_j`) axis with
-/// [`FoldedWitness::fold_bits`], folds the public segment the same way, and reuses
-/// `build_monster_segments` and `run_sumcheck` unchanged.
+/// Phase 2 contracts the hidden witness along its bit axis with [`FoldedWitness::fold_bits`].
+/// It folds the public segment the same way, at the same challenge `r_j`.
+/// It then reuses `build_monster_segments` and `run_sumcheck` unchanged.
 ///
 /// # Parameters
 /// - `key_collection`: the prover's key collection for the constraint system.
 /// - `public_words`: the public (constant) words, shared by every instance.
 /// - `folded_witness`: the hidden witness, folded over the instance axis.
-/// - `zero_data`: operator data for the zero (ZERO) constraints.
-/// - `bitand_data`: operator data for the bitand (AND) constraints.
-/// - `intmul_data`: operator data for the intmul (IMUL) constraints.
+/// - `claims`: the operand evaluation claim of each operation.
 /// - `domain_subspace`: the univariate evaluation domain.
 /// - `channel`: the prover channel driving the interactive protocol.
+/// - `alloc`: the allocator backing the reduction's intermediate buffers.
 ///
 /// # Returns
 /// The `SumcheckOutput` with the final challenges and the reduced witness evaluation.
-#[allow(clippy::too_many_arguments)]
 pub fn prove<F, P, Channel, A>(
 	key_collection: &KeyCollection,
 	public_words: &[Word],
 	folded_witness: &FoldedWitness<F, A>,
-	zero_data: OperatorData<F>,
-	bitand_data: OperatorData<F>,
-	intmul_data: OperatorData<F>,
-	binmul_data: OperatorData<F>,
+	claims: OperatorClaims<F>,
 	domain_subspace: &BinarySubspace<F>,
 	channel: &mut Channel,
 	alloc: &A,
@@ -72,16 +71,9 @@ where
 	Channel: IPProverChannel<F>,
 	A: Allocator,
 {
-	// Sample one batching lambda per operator, then prepare the operator data (tensor expansions
-	// and lambda powers).
-	let zero_lambda = channel.sample();
-	let bitand_lambda = channel.sample();
-	let intmul_lambda = channel.sample();
-	let binmul_lambda = channel.sample();
-	let prepared_zero = PreparedOperatorData::new(zero_data, zero_lambda);
-	let prepared_bitand = PreparedOperatorData::new(bitand_data, bitand_lambda);
-	let prepared_intmul = PreparedOperatorData::new(intmul_data, intmul_lambda);
-	let prepared_bmul = PreparedOperatorData::new(binmul_data, binmul_lambda);
+	// One batching coefficient per operation, drawn from the channel.
+	// SOUNDNESS: `prepare` draws in the order the verifier draws in; do not reorder it.
+	let prepared = claims.prepare(|| channel.sample());
 
 	// Phase 1: build the g parts once per key segment, then add them. The public words are
 	// constants shared by every instance, so the single-instance builder folds them directly from
@@ -91,26 +83,23 @@ where
 		alloc,
 		public_words,
 		&key_collection.public,
-		&prepared_zero,
-		&prepared_bitand,
-		&prepared_intmul,
-		&prepared_bmul,
+		&prepared.zero,
+		&prepared.bitand,
+		&prepared.intmul,
+		&prepared.binmul,
 	);
 	let hidden_g_parts = build_g_parts_from_folded_words(
 		alloc,
 		folded_witness.words(),
 		&key_collection.hidden,
-		&prepared_zero,
-		&prepared_bitand,
-		&prepared_intmul,
-		&prepared_bmul,
+		&prepared,
 	);
 	for (g, hidden_g) in g_parts.iter_mut().zip(&hidden_g_parts) {
 		for (slot, add) in g.as_mut().iter_mut().zip(hidden_g.as_ref()) {
 			*slot += *add;
 		}
 	}
-	let h_parts = build_h_parts::<F, F, _>(alloc, domain_subspace, prepared_bitand.r_zhat_prime);
+	let h_parts = build_h_parts::<F, F, _>(alloc, domain_subspace, prepared.bitand.r_zhat_prime);
 	let phase_1_output = run_phase_1_sumcheck::<F, F, _, _>(g_parts, h_parts, channel, alloc);
 
 	// Phase 2: split the phase-1 challenges into the bit half `r_j` and the shift half `r_s`.
@@ -130,10 +119,10 @@ where
 	let (public_monster, hidden_monster) = build_monster_segments::<F, P, _>(
 		alloc,
 		key_collection,
-		&prepared_zero,
-		&prepared_bitand,
-		&prepared_intmul,
-		&prepared_bmul,
+		&prepared.zero,
+		&prepared.bitand,
+		&prepared.intmul,
+		&prepared.binmul,
 		domain_subspace,
 		&r_j,
 		&r_s,
@@ -154,34 +143,51 @@ where
 
 /// Constructs the phase-1 "g" multilinear parts, one per shift variant, from instance-folded words.
 ///
-/// This is the batched analogue of the single-instance [`build_g_parts`]: it consumes a key
-/// segment's words already folded over the instance axis, so each word is a [`FoldedWord`] whose
-/// bits are full field elements rather than a packed `u64`. Where the single-instance builder
-/// scatters an accumulator onto a word's set bits by masking, this scales the accumulator by each
-/// folded bit with a field multiplication, which coincides with masking when the folded bit is 0 or
-/// 1.
+/// This is the batched analogue of the single-instance [`build_g_parts`].
+/// It consumes a key segment's words already folded over the instance axis.
+/// So each word is a [`FoldedWord`], whose bits are field elements rather than a packed `u64`.
 ///
-/// Use this for the hidden (committed) segment, whose words are folded over instances, and the
-/// single-instance [`build_g_parts`] for the public segment, whose words are constants; add the two
-/// results to obtain the complete g parts. `folded_words` is paired with `segment.key_ranges` in
-/// order, so any power-of-two padding beyond the segment's word count is ignored.
+/// The single-instance builder scatters an accumulator onto a word's set bits by masking.
+/// This one scales the accumulator by each folded bit with a field multiplication.
+/// The two coincide when the folded bit is 0 or 1.
 ///
-/// The result is `SHIFT_VARIANT_COUNT` multilinears of [`LOG_LEN`] variables each, one per shift
-/// variant. Each multilinear is indexed by `(shift amount, bit position)`: shift key
-/// `id = (variant << Word::LOG_BITS) | amount` selects multilinear `variant`, whose slot at
-/// `amount * Word::BITS + bit` accumulates, over every word carrying that key, the word's folded
-/// bit times the key's lambda-weighted partial evaluation tensor.
+/// Use this for the hidden (committed) segment, whose words are folded over instances.
+/// Use [`build_g_parts`] for the public segment, whose words are shared constants.
+/// Adding the two results gives the complete g parts.
 ///
-/// This scalar implementation ignores the packed-field and parallelism optimizations of the
-/// single-instance builder.
+/// # Arguments
+///
+/// - `folded_words`: the segment's words folded over instances, in `segment.key_ranges` order.
+/// - `segment`: the shift keys of this segment, grouped by the word they act on.
+/// - `prepared`: the per-operation claims, indexed by the operation each key names.
+///
+/// Words past the segment's key ranges are power-of-two padding, and are ignored.
+///
+/// # Returns
+///
+/// `SHIFT_VARIANT_COUNT` multilinears of [`LOG_LEN`] variables, one per shift variant.
+///
+/// A key's id splits into the variant and the shift amount:
+///
+/// ```text
+/// id = (variant << Word::LOG_BITS) | amount
+/// ```
+///
+/// The variant picks the multilinear, and the amount picks the run of bit slots within it:
+///
+/// ```text
+/// g[variant][amount * Word::BITS + bit] += folded_bit * acc(key)
+/// ```
+///
+/// where `acc(key)` is the key's lambda-weighted partial evaluation tensor.
+/// Every word carrying that key accumulates into the same slots.
+///
+/// This scalar implementation ignores the single-instance builder's packing and parallelism.
 pub fn build_g_parts_from_folded_words<F: BinaryField, A: Allocator>(
 	alloc: &A,
 	folded_words: &[FoldedWord<F>],
 	segment: &KeySegment,
-	zero_operator_data: &PreparedOperatorData<F>,
-	bitand_operator_data: &PreparedOperatorData<F>,
-	intmul_operator_data: &PreparedOperatorData<F>,
-	binmul_operator_data: &PreparedOperatorData<F>,
+	prepared: &PreparedOperatorClaims<F>,
 ) -> [FieldVec<F, A>; SHIFT_VARIANT_COUNT] {
 	// One zeroed multilinear of LOG_LEN variables per shift variant, drawn from the allocator. A
 	// key belongs to exactly one variant, so the scatter below accumulates straight into these
@@ -193,12 +199,7 @@ pub fn build_g_parts_from_folded_words<F: BinaryField, A: Allocator>(
 	for (word, range) in folded_words.iter().zip(&segment.key_ranges) {
 		let keys = &segment.keys[range.start as usize..range.end as usize];
 		for key in keys {
-			let operator_data = match key.operation {
-				Operation::Zero => zero_operator_data,
-				Operation::BitwiseAnd => bitand_operator_data,
-				Operation::IntegerMul => intmul_operator_data,
-				Operation::BinMul => binmul_operator_data,
-			};
+			let operator_data = &prepared[key.operation];
 
 			// The lambda-weighted partial evaluation tensor for this shifted word.
 			let acc = key.accumulate(
@@ -236,11 +237,15 @@ mod tests {
 		test_utils::random_scalars,
 		univariate::lagrange_evals_scalars,
 	};
-	use binius_prover::protocols::shift::{build_key_collection, monster::build_h_parts};
+	use binius_prover::protocols::shift::{
+		OperatorData, build_key_collection, monster::build_h_parts,
+	};
 	use binius_transcript::ProverTranscript;
 	use binius_verifier::{
 		config::{B128, StdChallenger},
-		protocols::shift::{OperatorData as VerifierOperatorData, check_eval, verify},
+		protocols::shift::{
+			BINMUL_ARITY, INTMUL_ARITY, OperatorData as VerifierOperatorData, check_eval, verify,
+		},
 	};
 	use rand::prelude::*;
 
@@ -366,25 +371,19 @@ mod tests {
 			&key_collection,
 			public_words,
 			&folded_witness,
-			OperatorData {
-				evals: vec![B128::ZERO],
-				r_zhat_prime: r_z,
-				r_x_prime: r_x_zero.clone(),
-			},
-			OperatorData {
-				evals: bitand_evals.to_vec(),
-				r_zhat_prime: r_z,
-				r_x_prime: r_x.clone(),
-			},
-			OperatorData {
-				evals: intmul_evals.to_vec(),
-				r_zhat_prime: r_z,
-				r_x_prime: Vec::new(),
-			},
-			OperatorData {
-				evals: vec![B128::ZERO; 6],
-				r_zhat_prime: r_z,
-				r_x_prime: Vec::new(),
+			OperatorClaims {
+				zero: OperatorData {
+					evals: vec![B128::ZERO],
+					r_zhat_prime: r_z,
+					r_x_prime: r_x_zero.clone(),
+				},
+				bitand: OperatorData {
+					evals: bitand_evals.to_vec(),
+					r_zhat_prime: r_z,
+					r_x_prime: r_x.clone(),
+				},
+				intmul: OperatorData::zero_claim(INTMUL_ARITY, r_z),
+				binmul: OperatorData::zero_claim(BINMUL_ARITY, r_z),
 			},
 			&domain_subspace,
 			&mut prover_transcript,
@@ -494,40 +493,23 @@ mod tests {
 		let hidden_folded = fold_words_over_instances(&table, constants, &r_rho, offset..combined);
 
 		// Prepare the operator data: lambda batches the three operand claims. The circuit has no
-		// IMUL constraints, so the intmul claim is empty.
-		let prepared_bitand = PreparedOperatorData::new(
-			OperatorData {
-				evals: bitand_evals.to_vec(),
-				r_zhat_prime: r_z,
-				r_x_prime: r_x,
-			},
-			B128::random(&mut rng),
-		);
-		let prepared_intmul = PreparedOperatorData::new(
-			OperatorData {
-				evals: Vec::new(),
-				r_zhat_prime: r_z,
-				r_x_prime: Vec::new(),
-			},
-			B128::random(&mut rng),
-		);
-		let prepared_bmul = PreparedOperatorData::new(
-			OperatorData {
-				evals: Vec::new(),
-				r_zhat_prime: r_z,
-				r_x_prime: Vec::new(),
-			},
-			B128::random(&mut rng),
-		);
+		// IMUL or BMUL constraints, so those two claims carry no operands at all.
 		// The ZERO set has its own constraint point, as wide as the set itself.
-		let prepared_zero = PreparedOperatorData::new(
-			OperatorData {
+		let claims = OperatorClaims {
+			zero: OperatorData {
 				evals: vec![B128::ZERO],
 				r_zhat_prime: r_z,
 				r_x_prime: random_scalars::<B128>(&mut rng, cs.log_zero_constraints().unwrap_or(0)),
 			},
-			B128::random(&mut rng),
-		);
+			bitand: OperatorData {
+				evals: bitand_evals.to_vec(),
+				r_zhat_prime: r_z,
+				r_x_prime: r_x,
+			},
+			intmul: OperatorData::zero_claim(0, r_z),
+			binmul: OperatorData::zero_claim(0, r_z),
+		};
+		let prepared = claims.prepare(|| B128::random(&mut rng));
 
 		// The g parts: the public segment folds from raw constant words via the single-instance
 		// builder, the hidden segment from the instance-folded words. Add them. The h parts come
@@ -536,19 +518,16 @@ mod tests {
 			&GlobalAllocator,
 			public_words,
 			&key_collection.public,
-			&prepared_zero,
-			&prepared_bitand,
-			&prepared_intmul,
-			&prepared_bmul,
+			&prepared.zero,
+			&prepared.bitand,
+			&prepared.intmul,
+			&prepared.binmul,
 		);
 		let hidden_g_parts = build_g_parts_from_folded_words(
 			&GlobalAllocator,
 			&hidden_folded,
 			&key_collection.hidden,
-			&prepared_zero,
-			&prepared_bitand,
-			&prepared_intmul,
-			&prepared_bmul,
+			&prepared,
 		);
 		for (g, hidden_g) in g_parts.iter_mut().zip(&hidden_g_parts) {
 			for (slot, add) in g.as_mut().iter_mut().zip(hidden_g.as_ref()) {
@@ -563,7 +542,7 @@ mod tests {
 			.sum();
 
 		// The lambda-powers scaling of the batched AND-check evals, plus the empty intmul claim.
-		let expected = prepared_bitand.batched_eval() + prepared_intmul.batched_eval();
+		let expected = prepared.bitand.batched_eval() + prepared.intmul.batched_eval();
 		assert_eq!(inner_product, expected);
 	}
 }

--- a/crates/prover/src/protocols/shift/prove.rs
+++ b/crates/prover/src/protocols/shift/prove.rs
@@ -11,38 +11,71 @@ use binius_math::{
 
 use super::{key_collection::KeyCollection, phase_1::prove_phase_1, phase_2::prove_phase_2};
 
-/// Holds the prover data for an operator.
+/// One operation's operand evaluation claims, with the point they are claimed at.
 ///
-/// Contains evaluation claims and challenge points for an operation.
+/// An operation constrains several operands at once: AND has three, IMUL four, BMUL six.
+/// Each operand is one column of the witness, and each column carries one evaluation claim.
 ///
-/// Each operator (AND/IMUL) has multiple operand positions, each with an oblong evaluation claim.
-/// The `evals` field stores these claim evaluations. The evaluation points consist of:
-/// - `r_zhat_prime`: univariate challenge point (pre-populated)
-/// - `r_x_prime`: multilinear challenge point (pre-populated)
+/// Every operand of an operation is claimed at the same point.
+/// So the point is stored once here rather than once per operand.
+///
+/// That point is oblong: a univariate coordinate over the bit axis, then the constraint index.
 #[derive(Debug, Clone)]
 pub struct OperatorData<F: Field> {
+	/// The claimed evaluation of each operand column, in the operation's operand order.
 	pub evals: Vec<F>,
+	/// The univariate challenge folding the bit axis, shared by every operation.
 	pub r_zhat_prime: F,
+	/// The multilinear challenge over the constraint index.
 	pub r_x_prime: Vec<F>,
 }
 
-/// Prepared operator data for proving.
+impl<F: Field> OperatorData<F> {
+	/// The claim of an operation the constraint system does not use.
+	///
+	/// Every operand evaluates to zero, at the empty constraint point.
+	///
+	/// That operation's constraint set is empty.
+	/// So the shift finds no key naming it, and the claim contributes nothing to the batch.
+	///
+	/// # Arguments
+	///
+	/// - `arity`: the operation's operand count, which fixes how many zero evaluations it carries.
+	/// - `r_zhat_prime`: the univariate challenge, shared by every operation.
+	pub fn zero_claim(arity: usize, r_zhat_prime: F) -> Self {
+		Self {
+			evals: vec![F::ZERO; arity],
+			r_zhat_prime,
+			r_x_prime: Vec::new(),
+		}
+	}
+}
+
+/// One operation's claims, with the expansions both proving phases need precomputed.
 ///
-/// Contains evaluation claims, challenge points, and precomputed values needed during proving:
-/// - `evals`: evaluation claims for each operand position
-/// - `r_zhat_prime`: univariate challenge point
-/// - `r_x_prime_tensor`: tensor expansion of r_x_prime for efficient proving
-/// - `lambda`: sampled random value for operand weighting
+/// Every shift key of the operation reads the same two expansions, so each is built once here:
+///
+/// - the constraint point, expanded into its equality-indicator tensor;
+/// - the batching coefficient, expanded into its powers, one per operand.
 #[derive(Debug, Clone)]
 pub struct PreparedOperatorData<F: Field> {
+	/// The claimed evaluation of each operand column, in the operation's operand order.
 	pub evals: Vec<F>,
+	/// The univariate challenge folding the bit axis, shared by every operation.
 	pub r_zhat_prime: F,
+	/// The equality-indicator tensor of the constraint point, one weight per constraint.
 	pub r_x_prime_tensor: FieldBuffer<F>,
+	/// The batching coefficient's powers, one per operand, starting at the first power.
 	pub lambda_powers: Vec<F>,
 }
 
 impl<F: Field> PreparedOperatorData<F> {
-	/// Creates a new prepared operator data from operator data and lambda.
+	/// Expands one operation's claims against the batching coefficient drawn for it.
+	///
+	/// # Arguments
+	///
+	/// - `operator_data`: the operand claims, and the point they are claimed at.
+	/// - `lambda`: the batching coefficient for this operation.
 	pub fn new(operator_data: OperatorData<F>, lambda: F) -> Self {
 		let OperatorData {
 			evals,
@@ -59,11 +92,16 @@ impl<F: Field> PreparedOperatorData<F> {
 		}
 	}
 
-	/// Returns the batched evaluation of the oblong evaluation claims.
-	/// Since the univariate evaluation of the evals at lambda is
-	/// further multiplied by lambda, the batched evaluation claims
-	/// for different operators can soundly be added without further
-	/// random scaling.
+	/// The operand claims collapsed into one value by the batching coefficient.
+	///
+	/// Operand `i` is weighted by the `i`-th power, and the powers start at the first:
+	///
+	/// ```text
+	/// batched = sum_i evals[i] * lambda^(i + 1)
+	/// ```
+	///
+	/// So the result already carries a random factor unique to this operation.
+	/// Two operations' batched values can therefore be summed with no further scaling.
 	pub fn batched_eval(&self) -> F {
 		inner_product(self.evals.iter().copied(), self.lambda_powers.iter().copied())
 	}

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -23,7 +23,13 @@ use binius_utils::{SerializeBytes, rayon::prelude::*};
 use binius_verifier::{
 	IOPVerifier, Verifier,
 	config::{B128, LOG_WORDS_PER_ELEM},
-	protocols::{binmul::BinMulOutput, bitand::AndCheckOutput, intmul::IntMulOutput, zero},
+	protocols::{
+		binmul::BinMulOutput,
+		bitand::AndCheckOutput,
+		intmul::IntMulOutput,
+		shift::{BINMUL_ARITY, INTMUL_ARITY},
+		zero,
+	},
 };
 use digest::Output;
 
@@ -233,11 +239,7 @@ impl IOPProver {
 					r_x_prime: eval_point,
 				}
 			}
-			None => OperatorData {
-				evals: vec![B128::ZERO; 4],
-				r_zhat_prime: bitand_claim.r_zhat_prime,
-				r_x_prime: Vec::new(),
-			},
+			None => OperatorData::zero_claim(INTMUL_ARITY, bitand_claim.r_zhat_prime),
 		};
 
 		// Build `OperatorData` for BinMul using the same shared `r_zhat_prime` challenge,
@@ -271,11 +273,7 @@ impl IOPProver {
 					r_x_prime: eval_point,
 				}
 			}
-			None => OperatorData {
-				evals: vec![B128::ZERO; 6],
-				r_zhat_prime: bitand_claim.r_zhat_prime,
-				r_x_prime: Vec::new(),
-			},
+			None => OperatorData::zero_claim(BINMUL_ARITY, bitand_claim.r_zhat_prime),
 		};
 
 		// [phase] Zero Reduction - linear constraint reduction


### PR DESCRIPTION
Pure refactor — no behavior change, no transcript change.

Removes a class of bug rather than moving code: a positional swap of same-typed arguments in a soundness-critical signature.

### The problem

The batched shift reduction closes four constraint families at once:

```
ZERO   VAL == 0
AND    A & B ^ C == 0
IMUL   A * B == (HI << 64) | LO
BMUL   A * B == C            (in the GHASH field)
```

Each family arrives with its own operand evaluation claim, an `OperatorData<F>`.
The four then travel together through every stage of the reduction.

They travelled as **four positional arguments**.

All four have the same type, so the compiler accepts them in any order:

```rust
prove_shift(.., zero_data, bitand_data, intmul_data, binmul_data, ..)
//                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
//                          swap any two of these and it still compiles
```

A swap does not fail to build and does not fail a test that only checks self-consistency — it batches one operation's claims by another's coefficient and produces a wrong proof.

That signature also carried the crate's only lint suppression, `#[allow(clippy::too_many_arguments)]`, to stay quiet at ten parameters.

### The idea

`binius-prover` already has an `Operation` enum — `Zero | BitwiseAnd | IntegerMul | BinMul`.
`shift.rs` imported it, then matched on it to pick between four separately-named parameters.

So bundle the four claims and index the bundle by that enum:

```rust
pub struct OperatorClaims<F: Field> {
    pub zero:   OperatorData<F>,
    pub bitand: OperatorData<F>,
    pub intmul: OperatorData<F>,
    pub binmul: OperatorData<F>,
}

impl<F: Field> Index<Operation> for OperatorClaims<F> { .. }
```

Each claim is **named** where it is built, and **reached by its operation** where it is read.

`PreparedOperatorClaims<F>` is the same bundle after batching coefficients are folded in, which is the form both proving phases consume.

### The change

Four seams collapse.

| site | before | after |
|---|---|---|
| `shift::prove` | 10 args + `#[allow(clippy::too_many_arguments)]` | 7 args, suppression gone |
| `build_g_parts_from_folded_words` | 7 args | 4 args |
| its `match key.operation` | 4 arms | `&prepared[key.operation]` |
| `RerandomizedOperations::prove` | returns a 4-tuple of same-typed values | returns `(Vec<B128>, OperatorClaims<B128>)` |

The four-arm dispatch, in full:

```diff
- let operator_data = match key.operation {
-     Operation::Zero => zero_operator_data,
-     Operation::BitwiseAnd => bitand_operator_data,
-     Operation::IntegerMul => intmul_operator_data,
-     Operation::BinMul => binmul_operator_data,
- };
+ let operator_data = &prepared[key.operation];
```

**The crate is now suppression-free** — `#[allow(clippy::too_many_arguments)]` was its only one.

### The batching coefficients

The four coefficients were four loose `channel.sample()` calls followed by four `PreparedOperatorData::new` calls:

```diff
- let zero_lambda = channel.sample();
- let bitand_lambda = channel.sample();
- let intmul_lambda = channel.sample();
- let binmul_lambda = channel.sample();
- let prepared_zero = PreparedOperatorData::new(zero_data, zero_lambda);
- let prepared_bitand = PreparedOperatorData::new(bitand_data, bitand_lambda);
- let prepared_intmul = PreparedOperatorData::new(intmul_data, intmul_lambda);
- let prepared_bmul = PreparedOperatorData::new(binmul_data, binmul_lambda);
+ let prepared = claims.prepare(|| channel.sample());
```

The draw order is Fiat-Shamir state: the verifier draws in the order `[Zero, AND, IMUL, BMUL]`, so the prover must too.

That was an implicit property of eight adjacent statements.
It is now one documented contract inside `OperatorClaims::prepare`, with a test that pins it.

### Soundness

- The transcript is byte-identical: the same four coefficients are drawn in the same order, and the same values reach the same subroutines.
- `prepare` visits its fields in declaration order, which Rust evaluates top to bottom — the test asserts the resulting order rather than trusting it.
- Nothing about the batching, the constraint points, or the reduced claims changes.

### `OperatorData::zero_claim`

An operation the circuit does not use still enters the reduction, as zero evaluations at an empty constraint point.
That literal was hand-written **ten times** across both provers:

```diff
- OperatorData {
-     evals: vec![B128::ZERO; BINMUL_ARITY],
-     r_zhat_prime: z_challenge,
-     r_x_prime: Vec::new(),
- }
+ OperatorData::zero_claim(BINMUL_ARITY, z_challenge)
```

The two sites in the single-instance prover also stop spelling the arity as a bare `4` / `6` and use `INTMUL_ARITY` / `BINMUL_ARITY`.

### Scope

- **new:** `crates/m4-prover/src/operator_claims.rs` — `OperatorClaims`, `PreparedOperatorClaims`, their `Index<Operation>` impls, `prepare`
- **changed:** `m4-prover`'s `shift.rs` and `prove.rs` call sites
- **additive upstream:** `OperatorData::zero_claim` in `binius-prover`; no signature there changes
- **docs:** `OperatorData` and `PreparedOperatorData` gain per-field docs, which they had none of; `PreparedOperatorData::new`, `batched_eval`, and the two `m4-prover` functions whose signatures changed are rewritten to the repo's one-idea-per-line style

### Tests

Two new unit tests, on behavior with no previous direct coverage:

| test | what it pins |
|---|---|
| `each_operation_indexes_its_own_claim` | every enum variant reaches its own field — the claims are tagged by distinct operand counts, so a mis-wired arm returns a count no assertion accepts |
| `prepare_draws_one_coefficient_per_operation_in_transcript_order` | exactly four draws, in `[Zero, AND, IMUL, BMUL]` order — a stand-in transcript hands out 1, 2, 3, 4, so each claim's leading lambda power names the position it was drawn at |

### What this is *not*

This does **not** make the prover's `OperatorData` arity-generic.
`OperatorData<F, BITAND_ARITY>` and `OperatorData<F, BINMUL_ARITY>` are still the same type; the struct fields are what keeps them apart.
That is a separate, cross-crate change.

Two notes for a follow-up, out of scope here:

- The same four-arm `match key.operation` still exists in `binius-prover`, at `protocols/shift/phase_1.rs:241` and `monster.rs:221`, and `binius_prover::protocols::shift::prove` carries the identical four-positional signature and its own `#[allow(clippy::too_many_arguments)]`. Moving `OperatorClaims` up into that crate would collapse those too.
- The mirrored extraction in `m4-verifier/verify.rs` is deliberately untouched: the verifier's `OperatorData<F, ARITY>` is already arity-typed and the three arities are 3, 4 and 6 — all distinct, so a positional swap there is already a compile error.

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-m4-prover -p binius-prover --all-targets` — clean
- `cargo +nightly fmt --all --check` — clean
- `cargo test -p binius-m4-prover -p binius-prover` — 42 + 5 + 26 + 13 + 1 pass, including `prove_keccak_permutation_3x`, `prove_blake3_compression_3x`, and the single-instance `test_shift_prove_and_verify`

🤖 Generated with [Claude Code](https://claude.com/claude-code)