### PR TITLE
Make the prover's OperatorData arity-generic, matching the verifier

### DIFF
--- a/crates/m4-prover/src/operator_claims.rs
+++ b/crates/m4-prover/src/operator_claims.rs
@@ -7,34 +7,34 @@
 //! Each family arrives with its own operand evaluation claim.
 //! Those four claims then travel together through both phases of the reduction.
 //!
-//! Passed as four positional arguments, two same-typed neighbours are interchangeable.
-//! The compiler accepts either order, so a swap yields a wrong proof instead of an error.
+//! Passed as four positional arguments, they are easy to hand over in the wrong order.
+//! Bundling them names each claim where it is built.
 //!
-//! Bundled instead, each claim is named where it is built.
-//! It is then reached by indexing on [`Operation`] where it is read.
+//! Each claim also carries its operation's arity in its type, so no two share one.
+//! Putting a BMUL claim in the IMUL field is a type error, not a wrong proof.
+//!
+//! The batched form erases that arity, because a shift key picks its operation at run time.
+//! There the operation is named by indexing instead: `prepared[key.operation]`.
 
 use std::ops::Index;
 
 use binius_field::Field;
 use binius_prover::protocols::shift::{Operation, OperatorData, PreparedOperatorData};
+use binius_verifier::protocols::shift::{BINMUL_ARITY, BITAND_ARITY, INTMUL_ARITY, ZERO_ARITY};
 
 /// The operand evaluation claim of every operation, as the shift reduction receives them.
 ///
-/// A shift key names the operation it belongs to, so its claim is reached by indexing:
-///
-/// ```text
-/// claims[key.operation]
-/// ```
+/// The four fields have four distinct types, one per arity, so none can stand in for another.
 #[derive(Debug, Clone)]
 pub struct OperatorClaims<F: Field> {
 	/// The claim for the ZERO constraints, `VAL == 0`.
-	pub zero: OperatorData<F>,
+	pub zero: OperatorData<F, ZERO_ARITY>,
 	/// The claim for the AND constraints, `A & B ^ C == 0`.
-	pub bitand: OperatorData<F>,
+	pub bitand: OperatorData<F, BITAND_ARITY>,
 	/// The claim for the IMUL constraints, `A * B == (HI << 64) | LO`.
-	pub intmul: OperatorData<F>,
+	pub intmul: OperatorData<F, INTMUL_ARITY>,
 	/// The claim for the BMUL constraints, `A * B == C` in the GHASH field.
-	pub binmul: OperatorData<F>,
+	pub binmul: OperatorData<F, BINMUL_ARITY>,
 }
 
 impl<F: Field> OperatorClaims<F> {
@@ -50,6 +50,8 @@ impl<F: Field> OperatorClaims<F> {
 	/// The coefficients are drawn in the order `[Zero, BitwiseAnd, IntegerMul, BinMul]`.
 	/// The verifier draws in that same order, so this sequence is protocol, not detail.
 	///
+	/// The arities are erased on the way out, since both proving phases dispatch on a shift key.
+	///
 	/// # Arguments
 	///
 	/// - `sample`: draws the next batching coefficient from the transcript.
@@ -59,19 +61,6 @@ impl<F: Field> OperatorClaims<F> {
 			bitand: PreparedOperatorData::new(self.bitand, sample()),
 			intmul: PreparedOperatorData::new(self.intmul, sample()),
 			binmul: PreparedOperatorData::new(self.binmul, sample()),
-		}
-	}
-}
-
-impl<F: Field> Index<Operation> for OperatorClaims<F> {
-	type Output = OperatorData<F>;
-
-	fn index(&self, operation: Operation) -> &OperatorData<F> {
-		match operation {
-			Operation::Zero => &self.zero,
-			Operation::BitwiseAnd => &self.bitand,
-			Operation::IntegerMul => &self.intmul,
-			Operation::BinMul => &self.binmul,
 		}
 	}
 }
@@ -111,26 +100,28 @@ mod tests {
 
 	use super::*;
 
-	// One claim per operation, each tagged by a distinct operand count.
-	// A mis-wired index arm therefore returns a count no assertion accepts.
-	fn claims_tagged_by_arity() -> OperatorClaims<B128> {
+	// A zero claim per operation, each at the arity its field's type fixes.
+	fn zero_claims() -> OperatorClaims<B128> {
 		OperatorClaims {
-			zero: OperatorData::zero_claim(1, B128::ZERO),
-			bitand: OperatorData::zero_claim(2, B128::ZERO),
-			intmul: OperatorData::zero_claim(3, B128::ZERO),
-			binmul: OperatorData::zero_claim(4, B128::ZERO),
+			zero: OperatorData::zero_claim(B128::ZERO),
+			bitand: OperatorData::zero_claim(B128::ZERO),
+			intmul: OperatorData::zero_claim(B128::ZERO),
+			binmul: OperatorData::zero_claim(B128::ZERO),
 		}
 	}
 
 	#[test]
-	fn each_operation_indexes_its_own_claim() {
-		// Invariant: an operation indexes its own claim, never a neighbour's.
-		let claims = claims_tagged_by_arity();
+	fn prepare_carries_each_operations_arity_into_the_erased_form() {
+		// Invariant: erasing the arity keeps it as a length, one lambda power per operand.
+		//
+		// The four arities are 1, 3, 4 and 6, all distinct.
+		// So a claim reached through the wrong index arm shows up as the wrong count.
+		let prepared = zero_claims().prepare(|| B128::ONE);
 
-		assert_eq!(claims[Operation::Zero].evals.len(), 1);
-		assert_eq!(claims[Operation::BitwiseAnd].evals.len(), 2);
-		assert_eq!(claims[Operation::IntegerMul].evals.len(), 3);
-		assert_eq!(claims[Operation::BinMul].evals.len(), 4);
+		assert_eq!(prepared[Operation::Zero].lambda_powers.len(), ZERO_ARITY);
+		assert_eq!(prepared[Operation::BitwiseAnd].lambda_powers.len(), BITAND_ARITY);
+		assert_eq!(prepared[Operation::IntegerMul].lambda_powers.len(), INTMUL_ARITY);
+		assert_eq!(prepared[Operation::BinMul].lambda_powers.len(), BINMUL_ARITY);
 	}
 
 	#[test]
@@ -140,7 +131,7 @@ mod tests {
 		//
 		// This stand-in transcript hands out 1, 2, 3, 4, so a coefficient names its draw position.
 		let mut draws = 0u128;
-		let prepared = claims_tagged_by_arity().prepare(|| {
+		let prepared = zero_claims().prepare(|| {
 			draws += 1;
 			B128::new(draws)
 		});

--- a/crates/m4-prover/src/prove.rs
+++ b/crates/m4-prover/src/prove.rs
@@ -36,7 +36,7 @@ use binius_verifier::{
 		binmul::BinMulOutput,
 		bitand::AndCheckOutput,
 		intmul::IntMulOutput,
-		shift::{BINMUL_ARITY, BITAND_ARITY, INTMUL_ARITY},
+		shift::{BINMUL_ARITY, BITAND_ARITY, INTMUL_ARITY, ZERO_ARITY},
 		zero,
 	},
 };
@@ -222,7 +222,7 @@ impl IOPProver {
 		// `IOPVerifier::verify` for why it skips the re-randomization below.
 		let log_n_zero = cs.log_zero_constraints().unwrap_or(0);
 		let zero_data = OperatorData {
-			evals: vec![B128::ZERO],
+			evals: [B128::ZERO],
 			r_zhat_prime: z_challenge,
 			r_x_prime: zero::reduction_point(r_x_and, log_n_zero, || channel.sample()),
 		};
@@ -259,12 +259,12 @@ impl IOPProver {
 				OperatorClaims {
 					zero: zero_data,
 					bitand: OperatorData {
-						evals: vec![a_eval, b_eval, c_eval],
+						evals: [a_eval, b_eval, c_eval],
 						r_zhat_prime: z_challenge,
 						r_x_prime: r_x_and.to_vec(),
 					},
-					intmul: OperatorData::zero_claim(INTMUL_ARITY, z_challenge),
-					binmul: OperatorData::zero_claim(BINMUL_ARITY, z_challenge),
+					intmul: OperatorData::zero_claim(z_challenge),
+					binmul: OperatorData::zero_claim(z_challenge),
 				},
 			)
 		};
@@ -606,7 +606,7 @@ impl<A: Allocator> RerandomizedOperations<'_, A> {
 	/// The shared instance point, and the operand claims of every operation at that point.
 	fn prove<'alloc, P, Channel>(
 		self,
-		zero: OperatorData<B128>,
+		zero: OperatorData<B128, ZERO_ARITY>,
 		lagrange: &[B128],
 		z_challenge: B128,
 		channel: &mut Channel,
@@ -646,37 +646,37 @@ impl<A: Allocator> RerandomizedOperations<'_, A> {
 		let output = batch_prove_and_write_evals(vec![shared], channel);
 		let reduced = &output.multilinear_evals[0];
 
-		// The reduced evaluations split back into contiguous per-operation segments, in push order.
-		let mut offset = 0;
+		// The reduced evaluations split back into per-operation chunks, in push order.
+		// Each chunk is as wide as its operation's arity, so the split is driven by the types.
+		let (bitand_evals, reduced) = split_evals(reduced);
 		let bitand = OperatorData {
-			evals: reduced[offset..offset + BITAND_ARITY].to_vec(),
+			evals: bitand_evals,
 			r_zhat_prime: z_challenge,
 			r_x_prime: self.bitand.r_x,
 		};
-		offset += BITAND_ARITY;
 
-		// IntMul: the next INTMUL_ARITY reduced evaluations when present, else a zero claim.
-		let intmul = match self.intmul {
+		// IntMul: the next chunk when present, else a zero claim that leaves the rest untouched.
+		let (intmul, reduced) = match self.intmul {
 			Some(intmul) => {
+				let (evals, reduced) = split_evals(reduced);
 				let data = OperatorData {
-					evals: reduced[offset..offset + INTMUL_ARITY].to_vec(),
+					evals,
 					r_zhat_prime: z_challenge,
 					r_x_prime: intmul.r_x,
 				};
-				offset += INTMUL_ARITY;
-				data
+				(data, reduced)
 			}
-			None => OperatorData::zero_claim(INTMUL_ARITY, z_challenge),
+			None => (OperatorData::zero_claim(z_challenge), reduced),
 		};
 
-		// BinMul: the final BINMUL_ARITY reduced evaluations when present, else a zero claim.
+		// BinMul: the final chunk when present, else a zero claim.
 		let binmul = match self.binmul {
 			Some(binmul) => OperatorData {
-				evals: reduced[offset..offset + BINMUL_ARITY].to_vec(),
+				evals: split_evals(reduced).0,
 				r_zhat_prime: z_challenge,
 				r_x_prime: binmul.r_x,
 			},
-			None => OperatorData::zero_claim(BINMUL_ARITY, z_challenge),
+			None => OperatorData::zero_claim(z_challenge),
 		};
 
 		// `batch_prove` returns binding-order challenges; reverse to variable-indexed to match
@@ -693,6 +693,20 @@ impl<A: Allocator> RerandomizedOperations<'_, A> {
 			},
 		)
 	}
+}
+
+/// Takes one operation's reduced evaluations off the front, and returns the rest.
+///
+/// The chunk width is the operation's arity, inferred from the claim it is about to fill.
+///
+/// # Panics
+///
+/// Panics if fewer than `ARITY` evaluations remain.
+fn split_evals<const ARITY: usize>(reduced: &[B128]) -> ([B128; ARITY], &[B128]) {
+	let (chunk, rest) = reduced
+		.split_first_chunk::<ARITY>()
+		.expect("the sumcheck returns one evaluation per pushed operand");
+	(*chunk, rest)
 }
 
 #[cfg(test)]

--- a/crates/m4-prover/src/shift.rs
+++ b/crates/m4-prover/src/shift.rs
@@ -243,9 +243,7 @@ mod tests {
 	use binius_transcript::ProverTranscript;
 	use binius_verifier::{
 		config::{B128, StdChallenger},
-		protocols::shift::{
-			BINMUL_ARITY, INTMUL_ARITY, OperatorData as VerifierOperatorData, check_eval, verify,
-		},
+		protocols::shift::{OperatorData as VerifierOperatorData, check_eval, verify},
 	};
 	use rand::prelude::*;
 
@@ -373,17 +371,17 @@ mod tests {
 			&folded_witness,
 			OperatorClaims {
 				zero: OperatorData {
-					evals: vec![B128::ZERO],
+					evals: [B128::ZERO],
 					r_zhat_prime: r_z,
 					r_x_prime: r_x_zero.clone(),
 				},
 				bitand: OperatorData {
-					evals: bitand_evals.to_vec(),
+					evals: bitand_evals,
 					r_zhat_prime: r_z,
 					r_x_prime: r_x.clone(),
 				},
-				intmul: OperatorData::zero_claim(INTMUL_ARITY, r_z),
-				binmul: OperatorData::zero_claim(BINMUL_ARITY, r_z),
+				intmul: OperatorData::zero_claim(r_z),
+				binmul: OperatorData::zero_claim(r_z),
 			},
 			&domain_subspace,
 			&mut prover_transcript,
@@ -493,21 +491,21 @@ mod tests {
 		let hidden_folded = fold_words_over_instances(&table, constants, &r_rho, offset..combined);
 
 		// Prepare the operator data: lambda batches the three operand claims. The circuit has no
-		// IMUL or BMUL constraints, so those two claims carry no operands at all.
+		// IMUL or BMUL constraints, so those two are zero claims at an empty point.
 		// The ZERO set has its own constraint point, as wide as the set itself.
 		let claims = OperatorClaims {
 			zero: OperatorData {
-				evals: vec![B128::ZERO],
+				evals: [B128::ZERO],
 				r_zhat_prime: r_z,
 				r_x_prime: random_scalars::<B128>(&mut rng, cs.log_zero_constraints().unwrap_or(0)),
 			},
 			bitand: OperatorData {
-				evals: bitand_evals.to_vec(),
+				evals: bitand_evals,
 				r_zhat_prime: r_z,
 				r_x_prime: r_x,
 			},
-			intmul: OperatorData::zero_claim(0, r_z),
-			binmul: OperatorData::zero_claim(0, r_z),
+			intmul: OperatorData::zero_claim(r_z),
+			binmul: OperatorData::zero_claim(r_z),
 		};
 		let prepared = claims.prepare(|| B128::random(&mut rng));
 

--- a/crates/m4-prover/src/shift.rs
+++ b/crates/m4-prover/src/shift.rs
@@ -540,7 +540,7 @@ mod tests {
 			.sum();
 
 		// The lambda-powers scaling of the batched AND-check evals, plus the empty intmul claim.
-		let expected = prepared.bitand.batched_eval() + prepared.intmul.batched_eval();
+		let expected = prepared.bitand.batched_eval + prepared.intmul.batched_eval;
 		assert_eq!(inner_product, expected);
 	}
 }

--- a/crates/prover/benches/shift_reduction.rs
+++ b/crates/prover/benches/shift_reduction.rs
@@ -21,7 +21,7 @@ use binius_prover::{
 use binius_transcript::ProverTranscript;
 use binius_verifier::{
 	config::StdChallenger,
-	protocols::shift::{OperatorData as VerifierOperatorData, verify},
+	protocols::shift::{BINMUL_ARITY, OperatorData as VerifierOperatorData, ZERO_ARITY, verify},
 };
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use sha2::{Digest, Sha256 as Sha256Hasher};
@@ -124,12 +124,12 @@ fn bench_prove_and_verify(c: &mut Criterion) {
 			let alloc = &pool;
 			b.iter(|| {
 				let prover_bitand_data = OperatorData {
-					evals: bitand_evals.to_vec(),
+					evals: bitand_evals,
 					r_zhat_prime,
 					r_x_prime: r_x_prime_bitand.clone(),
 				};
 				let prover_intmul_data = OperatorData {
-					evals: intmul_evals.to_vec(),
+					evals: intmul_evals,
 					r_zhat_prime,
 					r_x_prime: r_x_prime_intmul.clone(),
 				};
@@ -139,18 +139,10 @@ fn bench_prove_and_verify(c: &mut Criterion) {
 				prove::<F, P, _, _>(
 					&key_collection,
 					value_vec.combined_witness(),
-					OperatorData {
-						evals: vec![F::ZERO],
-						r_zhat_prime,
-						r_x_prime: Vec::new(),
-					},
+					OperatorData::zero_claim(r_zhat_prime),
 					prover_bitand_data,
 					prover_intmul_data,
-					OperatorData {
-						evals: vec![F::ZERO; 6],
-						r_zhat_prime,
-						r_x_prime: Vec::new(),
-					},
+					OperatorData::zero_claim(r_zhat_prime),
 					&subspace,
 					&mut prover_transcript,
 					&alloc,
@@ -160,12 +152,12 @@ fn bench_prove_and_verify(c: &mut Criterion) {
 
 		// Pre-run the prover to get the transcript for verifier benchmarking
 		let prover_bitand_data = OperatorData {
-			evals: bitand_evals.to_vec(),
+			evals: bitand_evals,
 			r_zhat_prime,
 			r_x_prime: r_x_prime_bitand.clone(),
 		};
 		let prover_intmul_data = OperatorData {
-			evals: intmul_evals.to_vec(),
+			evals: intmul_evals,
 			r_zhat_prime,
 			r_x_prime: r_x_prime_intmul.clone(),
 		};
@@ -175,18 +167,10 @@ fn bench_prove_and_verify(c: &mut Criterion) {
 		prove::<F, P, _, _>(
 			&key_collection,
 			value_vec.combined_witness(),
-			OperatorData {
-				evals: vec![F::ZERO],
-				r_zhat_prime,
-				r_x_prime: Vec::new(),
-			},
+			OperatorData::zero_claim(r_zhat_prime),
 			prover_bitand_data,
 			prover_intmul_data,
-			OperatorData {
-				evals: vec![F::ZERO; 6],
-				r_zhat_prime,
-				r_x_prime: Vec::new(),
-			},
+			OperatorData::zero_claim(r_zhat_prime),
 			&subspace,
 			&mut prover_transcript,
 			&&BufferPool::new(),
@@ -253,7 +237,7 @@ fn bench_shift_phases(c: &mut Criterion) {
 	// random lambda (rather than one drawn from a transcript) yields realistic-magnitude data.
 	let prepared_bitand = PreparedOperatorData::new(
 		OperatorData {
-			evals: bitand_evals.to_vec(),
+			evals: bitand_evals,
 			r_zhat_prime,
 			r_x_prime: r_x_prime_bitand,
 		},
@@ -261,7 +245,7 @@ fn bench_shift_phases(c: &mut Criterion) {
 	);
 	let prepared_intmul = PreparedOperatorData::new(
 		OperatorData {
-			evals: intmul_evals.to_vec(),
+			evals: intmul_evals,
 			r_zhat_prime,
 			r_x_prime: r_x_prime_intmul,
 		},
@@ -270,21 +254,13 @@ fn bench_shift_phases(c: &mut Criterion) {
 	// SHA256 has no ZERO constraints, so the Zero operator is the zero claim at an empty point,
 	// matching the real prover.
 	let prepared_zero = PreparedOperatorData::new(
-		OperatorData {
-			evals: vec![F::ZERO],
-			r_zhat_prime,
-			r_x_prime: Vec::new(),
-		},
+		OperatorData::<F, ZERO_ARITY>::zero_claim(r_zhat_prime),
 		F::random(&mut rng),
 	);
 	// SHA256 has no BMUL constraints, so the BinMul operator is the zero claim at an empty point,
 	// matching the real prover (`prove.rs` `None` branch).
 	let prepared_bmul = PreparedOperatorData::new(
-		OperatorData {
-			evals: vec![F::ZERO; 6],
-			r_zhat_prime,
-			r_x_prime: Vec::new(),
-		},
+		OperatorData::<F, BINMUL_ARITY>::zero_claim(r_zhat_prime),
 		F::random(&mut rng),
 	);
 

--- a/crates/prover/src/protocols/shift/key_collection.rs
+++ b/crates/prover/src/protocols/shift/key_collection.rs
@@ -588,7 +588,7 @@ mod tests {
 			range: 0..constraint_indices.len() as u32,
 		};
 		let operator_data = PreparedOperatorData {
-			evals: vec![],
+			batched_eval: F::ZERO,
 			r_zhat_prime: F::ZERO,
 			r_x_prime_tensor: FieldBuffer::from_values(&[
 				f(2),

--- a/crates/prover/src/protocols/shift/prove.rs
+++ b/crates/prover/src/protocols/shift/prove.rs
@@ -70,15 +70,29 @@ impl<F: Field, const ARITY: usize> OperatorData<F, ARITY> {
 ///
 /// The arity is erased here, unlike in [`OperatorData`].
 /// Both phases pick an operation at run time, from a shift key, so all four must share a type.
+///
+/// The individual operand claims do not survive that erasure, because nothing downstream reads
+/// them one at a time — only their batched combination, which is a single scalar.
 #[derive(Debug, Clone)]
 pub struct PreparedOperatorData<F: Field> {
-	/// The claimed evaluation of each operand column, in the operation's operand order.
-	pub evals: Vec<F>,
+	/// The operand claims collapsed into one value by the batching coefficient.
+	///
+	/// Operand `i` is weighted by the `i`-th power, and the powers start at the first:
+	///
+	/// ```text
+	/// batched_eval = sum_i evals[i] * lambda^(i + 1)
+	/// ```
+	///
+	/// So this already carries a random factor unique to its operation.
+	/// Two operations' batched values can therefore be summed with no further scaling.
+	pub batched_eval: F,
 	/// The univariate challenge folding the bit axis, shared by every operation.
 	pub r_zhat_prime: F,
 	/// The equality-indicator tensor of the constraint point, one weight per constraint.
 	pub r_x_prime_tensor: FieldBuffer<F>,
 	/// The batching coefficient's powers, one per operand, starting at the first power.
+	///
+	/// A shift key names the operand it acts on, so these stay indexable at run time.
 	pub lambda_powers: Vec<F>,
 }
 
@@ -96,27 +110,13 @@ impl<F: Field> PreparedOperatorData<F> {
 			r_x_prime,
 		} = operator_data;
 		let r_x_prime_tensor = eq_ind_partial_eval::<F>(&r_x_prime);
-		let lambda_powers = powers(lambda).skip(1).take(ARITY).collect();
+		let lambda_powers: Vec<F> = powers(lambda).skip(1).take(ARITY).collect();
 		Self {
-			evals: evals.to_vec(),
+			batched_eval: inner_product(evals, lambda_powers.iter().copied()),
 			r_zhat_prime,
 			r_x_prime_tensor,
 			lambda_powers,
 		}
-	}
-
-	/// The operand claims collapsed into one value by the batching coefficient.
-	///
-	/// Operand `i` is weighted by the `i`-th power, and the powers start at the first:
-	///
-	/// ```text
-	/// batched = sum_i evals[i] * lambda^(i + 1)
-	/// ```
-	///
-	/// So the result already carries a random factor unique to this operation.
-	/// Two operations' batched values can therefore be summed with no further scaling.
-	pub fn batched_eval(&self) -> F {
-		inner_product(self.evals.iter().copied(), self.lambda_powers.iter().copied())
 	}
 }
 

--- a/crates/prover/src/protocols/shift/prove.rs
+++ b/crates/prover/src/protocols/shift/prove.rs
@@ -8,29 +8,40 @@ use binius_ip_prover::channel::IPProverChannel;
 use binius_math::{
 	BinarySubspace, FieldBuffer, inner_product::inner_product, multilinear::eq::eq_ind_partial_eval,
 };
+use binius_verifier::protocols::shift::{BINMUL_ARITY, BITAND_ARITY, INTMUL_ARITY, ZERO_ARITY};
 
 use super::{key_collection::KeyCollection, phase_1::prove_phase_1, phase_2::prove_phase_2};
 
 /// One operation's operand evaluation claims, with the point they are claimed at.
 ///
-/// An operation constrains several operands at once: AND has three, IMUL four, BMUL six.
+/// An operation constrains a fixed number of operands at once, its arity:
+///
+/// ```text
+/// ZERO 1   AND 3   IMUL 4   BMUL 6
+/// ```
+///
 /// Each operand is one column of the witness, and each column carries one evaluation claim.
+///
+/// The arity is a type parameter, so no two operations share a type.
+/// Two operations' claims therefore cannot be passed in each other's place.
+///
+/// This mirrors [`binius_verifier::protocols::shift::OperatorData`], which is already arity-typed.
 ///
 /// Every operand of an operation is claimed at the same point.
 /// So the point is stored once here rather than once per operand.
 ///
 /// That point is oblong: a univariate coordinate over the bit axis, then the constraint index.
 #[derive(Debug, Clone)]
-pub struct OperatorData<F: Field> {
+pub struct OperatorData<F: Field, const ARITY: usize> {
 	/// The claimed evaluation of each operand column, in the operation's operand order.
-	pub evals: Vec<F>,
+	pub evals: [F; ARITY],
 	/// The univariate challenge folding the bit axis, shared by every operation.
 	pub r_zhat_prime: F,
 	/// The multilinear challenge over the constraint index.
 	pub r_x_prime: Vec<F>,
 }
 
-impl<F: Field> OperatorData<F> {
+impl<F: Field, const ARITY: usize> OperatorData<F, ARITY> {
 	/// The claim of an operation the constraint system does not use.
 	///
 	/// Every operand evaluates to zero, at the empty constraint point.
@@ -40,11 +51,10 @@ impl<F: Field> OperatorData<F> {
 	///
 	/// # Arguments
 	///
-	/// - `arity`: the operation's operand count, which fixes how many zero evaluations it carries.
 	/// - `r_zhat_prime`: the univariate challenge, shared by every operation.
-	pub fn zero_claim(arity: usize, r_zhat_prime: F) -> Self {
+	pub const fn zero_claim(r_zhat_prime: F) -> Self {
 		Self {
-			evals: vec![F::ZERO; arity],
+			evals: [F::ZERO; ARITY],
 			r_zhat_prime,
 			r_x_prime: Vec::new(),
 		}
@@ -57,6 +67,9 @@ impl<F: Field> OperatorData<F> {
 ///
 /// - the constraint point, expanded into its equality-indicator tensor;
 /// - the batching coefficient, expanded into its powers, one per operand.
+///
+/// The arity is erased here, unlike in [`OperatorData`].
+/// Both phases pick an operation at run time, from a shift key, so all four must share a type.
 #[derive(Debug, Clone)]
 pub struct PreparedOperatorData<F: Field> {
 	/// The claimed evaluation of each operand column, in the operation's operand order.
@@ -76,16 +89,16 @@ impl<F: Field> PreparedOperatorData<F> {
 	///
 	/// - `operator_data`: the operand claims, and the point they are claimed at.
 	/// - `lambda`: the batching coefficient for this operation.
-	pub fn new(operator_data: OperatorData<F>, lambda: F) -> Self {
+	pub fn new<const ARITY: usize>(operator_data: OperatorData<F, ARITY>, lambda: F) -> Self {
 		let OperatorData {
 			evals,
 			r_zhat_prime,
 			r_x_prime,
 		} = operator_data;
 		let r_x_prime_tensor = eq_ind_partial_eval::<F>(&r_x_prime);
-		let lambda_powers = powers(lambda).skip(1).take(evals.len()).collect();
+		let lambda_powers = powers(lambda).skip(1).take(ARITY).collect();
 		Self {
-			evals,
+			evals: evals.to_vec(),
 			r_zhat_prime,
 			r_x_prime_tensor,
 			lambda_powers,
@@ -121,10 +134,13 @@ impl<F: Field> PreparedOperatorData<F> {
 /// # Parameters
 /// - `key_collection`: Prover's key collection representing the constraint system
 /// - `words`: The witness words (must have power-of-2 length)
+/// - `zero_data`: Operator data for the linear (ZERO) constraints
 /// - `bitand_data`: Operator data for bit multiplication (AND) constraints
 /// - `intmul_data`: Operator data for integer multiplication (IMUL) constraints
 /// - `binmul_data`: Operator data for GHASH-field multiplication (BMUL) constraints
 /// - `transcript`: The prover's transcript for interactive protocol
+///
+/// Each of the four carries its own arity, so no two can be passed in the other's place.
 ///
 /// # Returns
 /// Returns `SumcheckOutput` containing the final challenges and witness evaluation,
@@ -136,10 +152,10 @@ impl<F: Field> PreparedOperatorData<F> {
 pub fn prove<F, P, Channel, A>(
 	key_collection: &KeyCollection,
 	words: &[Word],
-	zero_data: OperatorData<F>,
-	bitand_data: OperatorData<F>,
-	intmul_data: OperatorData<F>,
-	binmul_data: OperatorData<F>,
+	zero_data: OperatorData<F, ZERO_ARITY>,
+	bitand_data: OperatorData<F, BITAND_ARITY>,
+	intmul_data: OperatorData<F, INTMUL_ARITY>,
+	binmul_data: OperatorData<F, BINMUL_ARITY>,
 	domain_subspace: &BinarySubspace<F>,
 	channel: &mut Channel,
 	alloc: &A,

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -23,13 +23,7 @@ use binius_utils::{SerializeBytes, rayon::prelude::*};
 use binius_verifier::{
 	IOPVerifier, Verifier,
 	config::{B128, LOG_WORDS_PER_ELEM},
-	protocols::{
-		binmul::BinMulOutput,
-		bitand::AndCheckOutput,
-		intmul::IntMulOutput,
-		shift::{BINMUL_ARITY, INTMUL_ARITY},
-		zero,
-	},
+	protocols::{binmul::BinMulOutput, bitand::AndCheckOutput, intmul::IntMulOutput, zero},
 };
 use digest::Output;
 
@@ -200,7 +194,7 @@ impl IOPProver {
 				eval_point,
 			} = and_reduction::prove::<_, B128, P, _, _>(bitand_columns, &mut *channel, alloc);
 			OperatorData {
-				evals: vec![a_eval, b_eval, c_eval],
+				evals: [a_eval, b_eval, c_eval],
 				r_zhat_prime: z_challenge,
 				r_x_prime: eval_point,
 			}
@@ -229,7 +223,7 @@ impl IOPProver {
 				let l_tilde = lagrange_evals(&subspace, r_zhat_prime);
 				let make_final_claim = |evals| inner_product(evals, l_tilde.iter_scalars());
 				OperatorData {
-					evals: vec![
+					evals: [
 						make_final_claim(a_evals),
 						make_final_claim(b_evals),
 						make_final_claim(c_lo_evals),
@@ -239,7 +233,7 @@ impl IOPProver {
 					r_x_prime: eval_point,
 				}
 			}
-			None => OperatorData::zero_claim(INTMUL_ARITY, bitand_claim.r_zhat_prime),
+			None => OperatorData::zero_claim(bitand_claim.r_zhat_prime),
 		};
 
 		// Build `OperatorData` for BinMul using the same shared `r_zhat_prime` challenge,
@@ -261,7 +255,7 @@ impl IOPProver {
 				let l_tilde = lagrange_evals(&subspace, r_zhat_prime);
 				let make_final_claim = |evals| inner_product(evals, l_tilde.iter_scalars());
 				OperatorData {
-					evals: vec![
+					evals: [
 						make_final_claim(a_lo_evals),
 						make_final_claim(a_hi_evals),
 						make_final_claim(b_lo_evals),
@@ -273,7 +267,7 @@ impl IOPProver {
 					r_x_prime: eval_point,
 				}
 			}
-			None => OperatorData::zero_claim(BINMUL_ARITY, bitand_claim.r_zhat_prime),
+			None => OperatorData::zero_claim(bitand_claim.r_zhat_prime),
 		};
 
 		// [phase] Zero Reduction - linear constraint reduction
@@ -282,7 +276,7 @@ impl IOPProver {
 		// `IOPVerifier::verify` for why it carries no message.
 		let log_n_zero = cs.log_zero_constraints().unwrap_or(0);
 		let zero_claim = OperatorData {
-			evals: vec![B128::ZERO],
+			evals: [B128::ZERO],
 			r_zhat_prime: bitand_claim.r_zhat_prime,
 			r_x_prime: zero::reduction_point(&bitand_claim.r_x_prime, log_n_zero, || {
 				channel.sample()

--- a/crates/prover/tests/shift.rs
+++ b/crates/prover/tests/shift.rs
@@ -288,12 +288,12 @@ fn test_shift_prove_and_verify() {
 		let mut prover_transcript = ProverTranscript::<StdChallenger>::default();
 
 		let prover_bitand_data = OperatorData {
-			evals: bitand_evals.to_vec(),
+			evals: bitand_evals,
 			r_zhat_prime,
 			r_x_prime: r_x_prime_bitand.clone(),
 		};
 		let prover_intmul_data = OperatorData {
-			evals: intmul_evals.to_vec(),
+			evals: intmul_evals,
 			r_zhat_prime,
 			r_x_prime: r_x_prime_intmul.clone(),
 		};
@@ -304,17 +304,13 @@ fn test_shift_prove_and_verify() {
 			.map(F::new)
 			.collect::<Vec<_>>();
 		let prover_zero_data = OperatorData {
-			evals: vec![F::ZERO],
+			evals: [F::ZERO],
 			r_zhat_prime,
 			r_x_prime: r_x_prime_zero.clone(),
 		};
 		// These circuits have no BMUL constraints, so the BinMul claim is the zero claim at an
 		// empty point (the prover's skipped-case `None` branch).
-		let prover_binmul_data = OperatorData {
-			evals: vec![F::ZERO; 6],
-			r_zhat_prime,
-			r_x_prime: Vec::new(),
-		};
+		let prover_binmul_data = OperatorData::zero_claim(r_zhat_prime);
 
 		let prover_output = prove::<F, P, _, _>(
 			&key_collection,


### PR DESCRIPTION
Follows #2011, which bundled these same four claims into `OperatorClaims`. Now rebased onto it — this PR contains only its own two commits.

Pure refactor — no behavior change, no transcript change.

### The problem

The verifier already types its operand claims by arity:

```rust
// crates/verifier/src/protocols/shift/verify.rs
pub struct OperatorData<F, const ARITY: usize> {
    pub r_x_prime: Vec<F>,
    pub evals: [F; ARITY],
}
```

The prover erased it:

```rust
// crates/prover/src/protocols/shift/prove.rs
pub struct OperatorData<F: Field> {
    pub evals: Vec<F>,
    ..
}
```

So on the prover side all four operations share one type, and the compiler cannot tell a ZERO claim from a BMUL one.

#2011 bundled the four into `OperatorClaims` so they stop being *positional*.
But the fields are still mutually assignable — building a claim for one operation and storing it in another's field compiles.

`evals` was also a `Vec` for values whose length is fixed by the protocol: 1, 3, 4 and 6. Never dynamic, always heap.

### The idea

Give the prover the verifier's shape.

```rust
pub struct OperatorData<F: Field, const ARITY: usize> {
    pub evals: [F; ARITY],
    pub r_zhat_prime: F,
    pub r_x_prime: Vec<F>,
}
```

Four operations, four arities, four distinct types:

```
ZERO 1   AND 3   IMUL 4   BMUL 6
```

### What it buys

**The claims bundle becomes unswappable.** Not by convention — by the type checker:

```
error[E0308]: mismatched types
   --> crates/m4-prover/src/prove.rs:267:14
    |
267 |   binmul: OperatorData::<_, INTMUL_ARITY>::zero_claim(z_challenge),
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `6`, found `4`
```

(I checked this rather than assuming it, then reverted the probe.)

**`zero_claim` loses its arity argument** and becomes a `const fn`, since it now builds an array rather than a `vec!`:

```diff
- pub fn zero_claim(arity: usize, r_zhat_prime: F) -> Self {
-     Self { evals: vec![F::ZERO; arity], .. }
+ pub const fn zero_claim(r_zhat_prime: F) -> Self {
+     Self { evals: [F::ZERO; ARITY], .. }
```

Every call site drops the argument; the arity comes from the field it fills.

**The manual offset becomes a chunk split.** `RerandomizedOperations::prove` walked the reduced evaluations with a hand-advanced cursor:

```diff
- let mut offset = 0;
- let bitand = OperatorData { evals: reduced[offset..offset + BITAND_ARITY].to_vec(), .. };
- offset += BITAND_ARITY;
- let intmul = match self.intmul {
-     Some(intmul) => { let d = OperatorData { evals: reduced[offset..offset + INTMUL_ARITY].to_vec(), .. };
-                       offset += INTMUL_ARITY; d }
-     None => OperatorData::zero_claim(INTMUL_ARITY, z_challenge),
- };
+ let (bitand_evals, reduced) = split_evals(reduced);
+ let bitand = OperatorData { evals: bitand_evals, .. };
+ let (intmul, reduced) = match self.intmul {
+     Some(intmul) => { let (evals, reduced) = split_evals(reduced);
+                       (OperatorData { evals, .. }, reduced) }
+     None => (OperatorData::zero_claim(z_challenge), reduced),
+ };
```

`split_evals::<ARITY>` infers its width from the claim it is about to fill, so the cursor cannot drift out of step with the arities.

### Why `PreparedOperatorData` stays arity-erased

This is the one real design call, so it is worth stating.

Both proving phases pick an operation **at run time**, from a shift key:

```rust
// phase_1.rs, monster.rs
let operator_data = match key.operation {
    Operation::Zero => zero_operator_data,
    Operation::BitwiseAnd => bitand_operator_data,
    ..
};
```

Match arms must agree on a type, so the four prepared claims cannot each carry their own arity.

`PreparedOperatorData::new` is therefore the erasure point: it takes `OperatorData<F, ARITY>` and returns the flat form.
Both structs now say so in their docs.

That split is the right one anyway:

- **at construction**, the operation is known statically → the type carries it;
- **during proving**, the operation comes from a key → indexing carries it.

`PreparedOperatorClaims` keeps its `Index<Operation>` for exactly that reason.

### The second commit: the prepared form does not need the claims at all

Making `OperatorData` an array exposed a `to_vec` in the erasure, which raised the obvious question: why copy the claims into a `Vec` at all?

The answer is that they should not be copied anywhere. `PreparedOperatorData::evals` had exactly one reader in the whole repository — its own `batched_eval`, which collapses the claims to a single scalar. Nothing indexes them per operand.

So store the scalar:

```diff
  pub struct PreparedOperatorData<F: Field> {
- 	pub evals: Vec<F>,
+ 	pub batched_eval: F,
  	pub r_zhat_prime: F,
  	pub r_x_prime_tensor: FieldBuffer<F>,
  	pub lambda_powers: Vec<F>,
  }
-
- pub fn batched_eval(&self) -> F {
- 	inner_product(self.evals.iter().copied(), self.lambda_powers.iter().copied())
- }
```

Both the vector and the array-to-vector copy disappear — four heap allocations per proof, gone, for values the protocol fixes at 1, 3, 4 and 6 elements.

`lambda_powers` stays a `Vec`, and that contrast is the point: a shift key indexes it by operand at run time, so it is the one field that genuinely needs a runtime length.

### `OperatorClaims` loses its `Index<Operation>`

Heterogeneous fields cannot share one `Index::Output`, so that impl goes.

It was unused outside its own test, and what replaces it is strictly stronger: the fields are now distinguished by type rather than by an enum lookup.

### Scope

- **changed:** `OperatorData` and `PreparedOperatorData` in `binius-prover`, the two claim sites in the single-instance `prove.rs`, `OperatorClaims` and the reduced-eval split in `m4-prover`
- **new:** `split_evals`, a five-line helper in `m4-prover/src/prove.rs`
- **removed:** `impl Index<Operation> for OperatorClaims`, and the `batched_eval` method (now a field)
- **also updated:** `crates/prover/tests/shift.rs` and `crates/prover/benches/shift_reduction.rs`, which build claims by literal
- **untouched:** `phase_1`, `phase_2`, `monster`, and the verifier

### Tests

The `OperatorClaims` index test is replaced by one that covers both the index and the new erasure:

| test | what it pins |
|---|---|
| `prepare_carries_each_operations_arity_into_the_erased_form` | each operation's lambda-power count equals its arity — the four arities 1, 3, 4, 6 are distinct, so a claim reached through the wrong index arm reads back the wrong count |
| `prepare_draws_one_coefficient_per_operation_in_transcript_order` | unchanged from #2011 — four draws, in `[Zero, AND, IMUL, BMUL]` order |

### On the inspection doc's own caveat

The plan this comes from says to land PR 6 *"only if PR 5's local struct has not already removed enough of the pain."*

Honest read: it still earns its place, but the margin is narrower than that note implied.
#2011 removed the swap risk at the call sites; this removes it at construction, and drops the per-proof allocations for protocol-fixed lengths.
The `split_evals` cleanup and the `const fn` are real but small.

### Verification

Re-run after rebasing onto #2011:

- `cargo check --workspace --all-targets` — clean
- `cargo clippy --workspace --all-targets` — clean (it flagged `zero_claim` as const-able once the `vec!` was gone; applied)
- `cargo +nightly fmt --all --check` — clean
- `cargo test -p binius-m4-prover -p binius-prover` — 45 + 5 + 26 + 13 + 1 pass, including `prove_keccak_permutation_3x` and the single-instance `test_shift_prove_and_verify`

🤖 Generated with [Claude Code](https://claude.com/claude-code)