### PR TITLE
Share the operator-claims bundle with the single-instance shift prover

### DIFF
--- a/crates/m4-prover/src/lib.rs
+++ b/crates/m4-prover/src/lib.rs
@@ -3,7 +3,6 @@
 
 //! Witness table and prover for the data-parallel Binius64 M4 proof system.
 
-mod operator_claims;
 mod prove;
 mod shift;
 #[cfg(test)]

--- a/crates/m4-prover/src/prove.rs
+++ b/crates/m4-prover/src/prove.rs
@@ -25,7 +25,7 @@ use binius_prover::{
 	and_reduction,
 	protocols::{
 		binmul, intmul,
-		shift::{KeyCollection, OperatorData, build_key_collection},
+		shift::{KeyCollection, OperatorClaims, OperatorData, build_key_collection},
 	},
 	ring_switch::{self, RingSwitchOutput},
 };
@@ -43,7 +43,6 @@ use binius_verifier::{
 
 use crate::{
 	ValueTable,
-	operator_claims::OperatorClaims,
 	shift::prove as prove_shift,
 	witness::{FoldedWitness, OperandColumns},
 };

--- a/crates/m4-prover/src/shift.rs
+++ b/crates/m4-prover/src/shift.rs
@@ -13,7 +13,7 @@ use binius_math::{BinarySubspace, FieldBuffer, FieldVec, multilinear::eq::eq_ind
 use binius_prover::{
 	fold_word::fold_words,
 	protocols::shift::{
-		KeyCollection, KeySegment,
+		KeyCollection, KeySegment, OperatorClaims, PreparedOperatorClaims,
 		monster::{build_h_parts, build_monster_segments},
 		phase_1::{build_g_parts, run_phase_1_sumcheck},
 		phase_2::run_sumcheck,
@@ -21,10 +21,7 @@ use binius_prover::{
 };
 use binius_verifier::protocols::shift::SHIFT_VARIANT_COUNT;
 
-use crate::{
-	operator_claims::{OperatorClaims, PreparedOperatorClaims},
-	witness::{FoldedWitness, FoldedWord},
-};
+use crate::witness::{FoldedWitness, FoldedWord};
 
 /// The number of variables in each "g" (and "h") multilinear of phase 1: one 6-bit shift-amount
 /// axis and one 6-bit bit-position axis.
@@ -79,15 +76,8 @@ where
 	// constants shared by every instance, so the single-instance builder folds them directly from
 	// their bits; the hidden words are already folded over instances. This scalar path drives the
 	// single-instance phase-1 sumcheck.
-	let mut g_parts = build_g_parts::<F, F, _>(
-		alloc,
-		public_words,
-		&key_collection.public,
-		&prepared.zero,
-		&prepared.bitand,
-		&prepared.intmul,
-		&prepared.binmul,
-	);
+	let mut g_parts =
+		build_g_parts::<F, F, _>(alloc, public_words, &key_collection.public, &prepared);
 	let hidden_g_parts = build_g_parts_from_folded_words(
 		alloc,
 		folded_witness.words(),
@@ -119,10 +109,7 @@ where
 	let (public_monster, hidden_monster) = build_monster_segments::<F, P, _>(
 		alloc,
 		key_collection,
-		&prepared.zero,
-		&prepared.bitand,
-		&prepared.intmul,
-		&prepared.binmul,
+		&prepared,
 		domain_subspace,
 		&r_j,
 		&r_s,
@@ -516,10 +503,7 @@ mod tests {
 			&GlobalAllocator,
 			public_words,
 			&key_collection.public,
-			&prepared.zero,
-			&prepared.bitand,
-			&prepared.intmul,
-			&prepared.binmul,
+			&prepared,
 		);
 		let hidden_g_parts = build_g_parts_from_folded_words(
 			&GlobalAllocator,

--- a/crates/prover/benches/shift_reduction.rs
+++ b/crates/prover/benches/shift_reduction.rs
@@ -11,7 +11,7 @@ use binius_math::{BinarySubspace, multilinear::eq::eq_ind_partial_eval};
 use binius_prover::{
 	fold_word::fold_words,
 	protocols::shift::{
-		OperatorData, PreparedOperatorData, build_key_collection,
+		OperatorClaims, OperatorData, build_key_collection,
 		monster::{build_h_parts, build_monster_segments},
 		phase_1::{build_g_parts, run_phase_1_sumcheck},
 		phase_2::run_sumcheck,
@@ -21,7 +21,7 @@ use binius_prover::{
 use binius_transcript::ProverTranscript;
 use binius_verifier::{
 	config::StdChallenger,
-	protocols::shift::{BINMUL_ARITY, OperatorData as VerifierOperatorData, ZERO_ARITY, verify},
+	protocols::shift::{OperatorData as VerifierOperatorData, verify},
 };
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use sha2::{Digest, Sha256 as Sha256Hasher};
@@ -139,10 +139,12 @@ fn bench_prove_and_verify(c: &mut Criterion) {
 				prove::<F, P, _, _>(
 					&key_collection,
 					value_vec.combined_witness(),
-					OperatorData::zero_claim(r_zhat_prime),
-					prover_bitand_data,
-					prover_intmul_data,
-					OperatorData::zero_claim(r_zhat_prime),
+					OperatorClaims {
+						zero: OperatorData::zero_claim(r_zhat_prime),
+						bitand: prover_bitand_data,
+						intmul: prover_intmul_data,
+						binmul: OperatorData::zero_claim(r_zhat_prime),
+					},
 					&subspace,
 					&mut prover_transcript,
 					&alloc,
@@ -167,10 +169,12 @@ fn bench_prove_and_verify(c: &mut Criterion) {
 		prove::<F, P, _, _>(
 			&key_collection,
 			value_vec.combined_witness(),
-			OperatorData::zero_claim(r_zhat_prime),
-			prover_bitand_data,
-			prover_intmul_data,
-			OperatorData::zero_claim(r_zhat_prime),
+			OperatorClaims {
+				zero: OperatorData::zero_claim(r_zhat_prime),
+				bitand: prover_bitand_data,
+				intmul: prover_intmul_data,
+				binmul: OperatorData::zero_claim(r_zhat_prime),
+			},
 			&subspace,
 			&mut prover_transcript,
 			&&BufferPool::new(),
@@ -235,34 +239,23 @@ fn bench_shift_phases(c: &mut Criterion) {
 
 	// Prepare the operator data. Lambda sampling is cheap and not part of any benched phase, so a
 	// random lambda (rather than one drawn from a transcript) yields realistic-magnitude data.
-	let prepared_bitand = PreparedOperatorData::new(
-		OperatorData {
+	// SHA256 has no ZERO or BMUL constraints, so those two are zero claims at an empty point,
+	// matching the real prover (`prove.rs` `None` branch).
+	let prepared = OperatorClaims {
+		zero: OperatorData::zero_claim(r_zhat_prime),
+		bitand: OperatorData {
 			evals: bitand_evals,
 			r_zhat_prime,
 			r_x_prime: r_x_prime_bitand,
 		},
-		F::random(&mut rng),
-	);
-	let prepared_intmul = PreparedOperatorData::new(
-		OperatorData {
+		intmul: OperatorData {
 			evals: intmul_evals,
 			r_zhat_prime,
 			r_x_prime: r_x_prime_intmul,
 		},
-		F::random(&mut rng),
-	);
-	// SHA256 has no ZERO constraints, so the Zero operator is the zero claim at an empty point,
-	// matching the real prover.
-	let prepared_zero = PreparedOperatorData::new(
-		OperatorData::<F, ZERO_ARITY>::zero_claim(r_zhat_prime),
-		F::random(&mut rng),
-	);
-	// SHA256 has no BMUL constraints, so the BinMul operator is the zero claim at an empty point,
-	// matching the real prover (`prove.rs` `None` branch).
-	let prepared_bmul = PreparedOperatorData::new(
-		OperatorData::<F, BINMUL_ARITY>::zero_claim(r_zhat_prime),
-		F::random(&mut rng),
-	);
+		binmul: OperatorData::zero_claim(r_zhat_prime),
+	}
+	.prepare(|| F::random(&mut rng));
 
 	// The phases are sequential and stateful: each consumes the previous one's outputs. Rather than
 	// re-deriving predecessors inside each phase's per-iteration setup, advance the protocol once
@@ -277,19 +270,13 @@ fn bench_shift_phases(c: &mut Criterion) {
 			&GlobalAllocator,
 			public_words,
 			&key_collection.public,
-			&prepared_zero,
-			&prepared_bitand,
-			&prepared_intmul,
-			&prepared_bmul,
+			&prepared,
 		);
 		let hidden_g_parts = build_g_parts::<F, P, _>(
 			&GlobalAllocator,
 			hidden_words,
 			&key_collection.hidden,
-			&prepared_zero,
-			&prepared_bitand,
-			&prepared_intmul,
-			&prepared_bmul,
+			&prepared,
 		);
 		for (g, hidden_g) in g_parts.iter_mut().zip(&hidden_g_parts) {
 			for (slot, add) in g.as_mut().iter_mut().zip(hidden_g.as_ref()) {
@@ -301,7 +288,7 @@ fn bench_shift_phases(c: &mut Criterion) {
 
 	let g_parts = build_combined_g_parts();
 	let h_parts =
-		build_h_parts::<F, P, _>(&GlobalAllocator, &subspace, prepared_bitand.r_zhat_prime);
+		build_h_parts::<F, P, _>(&GlobalAllocator, &subspace, prepared.bitand.r_zhat_prime);
 	let SumcheckOutput {
 		challenges: mut r_jr_s,
 		eval: gamma,
@@ -324,10 +311,7 @@ fn bench_shift_phases(c: &mut Criterion) {
 	let (public_monster, hidden_monster) = build_monster_segments::<F, P, _>(
 		&GlobalAllocator,
 		&key_collection,
-		&prepared_zero,
-		&prepared_bitand,
-		&prepared_intmul,
-		&prepared_bmul,
+		&prepared,
 		&subspace,
 		&r_j,
 		&r_s,
@@ -343,7 +327,7 @@ fn bench_shift_phases(c: &mut Criterion) {
 	});
 	group.bench_function("phase1_build_h_parts", |b| {
 		b.iter(|| {
-			build_h_parts::<F, P, _>(&GlobalAllocator, &subspace, prepared_bitand.r_zhat_prime)
+			build_h_parts::<F, P, _>(&GlobalAllocator, &subspace, prepared.bitand.r_zhat_prime)
 		});
 	});
 	group.bench_function("phase1_run_sumcheck", |b| {
@@ -364,10 +348,7 @@ fn bench_shift_phases(c: &mut Criterion) {
 			build_monster_segments::<F, P, _>(
 				&GlobalAllocator,
 				&key_collection,
-				&prepared_zero,
-				&prepared_bitand,
-				&prepared_intmul,
-				&prepared_bmul,
+				&prepared,
 				&subspace,
 				&r_j,
 				&r_s,

--- a/crates/prover/src/protocols/shift/claims.rs
+++ b/crates/prover/src/protocols/shift/claims.rs
@@ -19,8 +19,9 @@
 use std::ops::Index;
 
 use binius_field::Field;
-use binius_prover::protocols::shift::{Operation, OperatorData, PreparedOperatorData};
 use binius_verifier::protocols::shift::{BINMUL_ARITY, BITAND_ARITY, INTMUL_ARITY, ZERO_ARITY};
+
+use super::{Operation, OperatorData, PreparedOperatorData};
 
 /// The operand evaluation claim of every operation, as the shift reduction receives them.
 ///

--- a/crates/prover/src/protocols/shift/mod.rs
+++ b/crates/prover/src/protocols/shift/mod.rs
@@ -7,6 +7,7 @@ mod key_collection;
 // `monster`, `phase_1`, and `phase_2` are internal implementation, exposed (via `#[doc(hidden)]`
 // `pub mod`) only so the `shift_reduction` benchmark can time individual phase functions (see
 // `benches/shift_reduction.rs`). Not a stable API.
+mod claims;
 #[doc(hidden)]
 pub mod monster;
 #[doc(hidden)]
@@ -15,5 +16,6 @@ pub mod phase_1;
 pub mod phase_2;
 mod prove;
 
+pub use claims::{OperatorClaims, PreparedOperatorClaims};
 pub use key_collection::{KeyCollection, KeySegment, Operation, build_key_collection};
 pub use prove::{OperatorData, PreparedOperatorData, prove};

--- a/crates/prover/src/protocols/shift/monster.rs
+++ b/crates/prover/src/protocols/shift/monster.rs
@@ -19,8 +19,8 @@ use tracing::instrument;
 
 use super::{
 	SHIFT_VARIANT_COUNT,
+	claims::PreparedOperatorClaims,
 	key_collection::{KeyCollection, KeySegment, Operation},
-	prove::PreparedOperatorData,
 };
 
 /// Constructs the three "h" multilinear polynomials for shift operations at a
@@ -140,14 +140,10 @@ where
 /// hidden piece over `log_witness_words` variables (the hidden words at the base, zeros above).
 /// The sparse first sumcheck round consumes them without materializing the combined buffer.
 #[instrument(skip_all, name = "build_monster_segments")]
-#[allow(clippy::too_many_arguments)]
 pub fn build_monster_segments<F, P: PackedField<Scalar = F>, A: Allocator>(
 	alloc: &A,
 	key_collection: &KeyCollection,
-	zero_operator_data: &PreparedOperatorData<F>,
-	bitand_operator_data: &PreparedOperatorData<F>,
-	intmul_operator_data: &PreparedOperatorData<F>,
-	binmul_operator_data: &PreparedOperatorData<F>,
+	prepared: &PreparedOperatorClaims<F>,
 	domain_subspace: &BinarySubspace<F>,
 	r_j: &[F],
 	r_s: &[F],
@@ -157,10 +153,10 @@ where
 {
 	// Compute h evaluations
 	let [zero_h_ops, bitand_h_ops, intmul_h_ops, binmul_h_ops] = [
-		zero_operator_data.r_zhat_prime,
-		bitand_operator_data.r_zhat_prime,
-		intmul_operator_data.r_zhat_prime,
-		binmul_operator_data.r_zhat_prime,
+		prepared.zero.r_zhat_prime,
+		prepared.bitand.r_zhat_prime,
+		prepared.intmul.r_zhat_prime,
+		prepared.binmul.r_zhat_prime,
 	]
 	.map(|r_zhat_prime| {
 		let l_tilde = lagrange_evals(domain_subspace, r_zhat_prime);
@@ -190,23 +186,23 @@ where
 		}
 	};
 
-	populate_scalars(&mut zero_scalars, ZERO_ARITY, &zero_operator_data.lambda_powers, &zero_h_ops);
+	populate_scalars(&mut zero_scalars, ZERO_ARITY, &prepared.zero.lambda_powers, &zero_h_ops);
 	populate_scalars(
 		&mut bitand_scalars,
 		BITAND_ARITY,
-		&bitand_operator_data.lambda_powers,
+		&prepared.bitand.lambda_powers,
 		&bitand_h_ops,
 	);
 	populate_scalars(
 		&mut intmul_scalars,
 		INTMUL_ARITY,
-		&intmul_operator_data.lambda_powers,
+		&prepared.intmul.lambda_powers,
 		&intmul_h_ops,
 	);
 	populate_scalars(
 		&mut binmul_scalars,
 		BINMUL_ARITY,
-		&binmul_operator_data.lambda_powers,
+		&prepared.binmul.lambda_powers,
 		&binmul_h_ops,
 	);
 
@@ -217,16 +213,17 @@ where
 			.word_keys(index)
 			.iter()
 			.map(|key| {
-				let (operator_data, scalars, arity) = match key.operation {
-					Operation::Zero => (zero_operator_data, &zero_scalars, ZERO_ARITY),
-					Operation::BitwiseAnd => (bitand_operator_data, &bitand_scalars, BITAND_ARITY),
-					Operation::IntegerMul => (intmul_operator_data, &intmul_scalars, INTMUL_ARITY),
-					Operation::BinMul => (binmul_operator_data, &binmul_scalars, BINMUL_ARITY),
+				// The scalar table is per operation, and its stride is that operation's arity.
+				let (scalars, arity) = match key.operation {
+					Operation::Zero => (&zero_scalars, ZERO_ARITY),
+					Operation::BitwiseAnd => (&bitand_scalars, BITAND_ARITY),
+					Operation::IntegerMul => (&intmul_scalars, INTMUL_ARITY),
+					Operation::BinMul => (&binmul_scalars, BINMUL_ARITY),
 				};
 				let base = key.id as usize * arity;
 				key.accumulate_wide(
 					&segment.constraint_indices,
-					operator_data.r_x_prime_tensor.as_ref(),
+					prepared[key.operation].r_x_prime_tensor.as_ref(),
 					&scalars[base..base + arity],
 				)
 			})

--- a/crates/prover/src/protocols/shift/phase_1.rs
+++ b/crates/prover/src/protocols/shift/phase_1.rs
@@ -19,9 +19,9 @@ use itertools::izip;
 use tracing::instrument;
 
 use super::{
-	key_collection::{KeyCollection, KeySegment, Operation},
+	claims::PreparedOperatorClaims,
+	key_collection::{KeyCollection, KeySegment},
 	monster::build_h_parts,
-	prove::PreparedOperatorData,
 };
 
 // This is the number of variables in the g (and h) multilinears of phase 1.
@@ -31,14 +31,10 @@ const LOG_LEN: usize = Word::LOG_BITS + Word::LOG_BITS;
 /// Proves the first phase of the shift reduction.
 /// Computes the g and h multilinears and performs the sumcheck.
 #[instrument(skip_all, name = "prover_phase_1")]
-#[allow(clippy::too_many_arguments)]
 pub fn prove_phase_1<F, P, Channel, A>(
 	key_collection: &KeyCollection,
 	words: &[Word],
-	zero_data: &PreparedOperatorData<F>,
-	bitand_data: &PreparedOperatorData<F>,
-	intmul_data: &PreparedOperatorData<F>,
-	binmul_data: &PreparedOperatorData<F>,
+	prepared: &PreparedOperatorClaims<F>,
 	domain_subspace: &BinarySubspace<F>,
 	channel: &mut Channel,
 	alloc: &A,
@@ -52,24 +48,10 @@ where
 	// Build the g parts for the public and hidden segments separately, then sum them. The public
 	// words are the prefix of `words`, and each segment's key ranges are segment-relative.
 	let (public_words, hidden_words) = words.split_at(key_collection.public.n_words());
-	let mut g_parts = build_g_parts::<_, P, _>(
-		alloc,
-		public_words,
-		&key_collection.public,
-		zero_data,
-		bitand_data,
-		intmul_data,
-		binmul_data,
-	);
-	let hidden_g_parts = build_g_parts::<_, P, _>(
-		alloc,
-		hidden_words,
-		&key_collection.hidden,
-		zero_data,
-		bitand_data,
-		intmul_data,
-		binmul_data,
-	);
+	let mut g_parts =
+		build_g_parts::<_, P, _>(alloc, public_words, &key_collection.public, prepared);
+	let hidden_g_parts =
+		build_g_parts::<_, P, _>(alloc, hidden_words, &key_collection.hidden, prepared);
 	for (g, hidden_g) in g_parts.iter_mut().zip(&hidden_g_parts) {
 		for (slot, add) in g.as_mut().iter_mut().zip(hidden_g.as_ref()) {
 			*slot += *add;
@@ -77,7 +59,7 @@ where
 	}
 
 	// BitAnd, IntMul and BinMul share the same `r_zhat_prime`.
-	let h_parts = build_h_parts(alloc, domain_subspace, bitand_data.r_zhat_prime);
+	let h_parts = build_h_parts(alloc, domain_subspace, prepared.bitand.r_zhat_prime);
 
 	run_phase_1_sumcheck(g_parts, h_parts, channel, alloc)
 }
@@ -207,10 +189,7 @@ pub fn build_g_parts<F: BinaryField, P: PackedField<Scalar = F>, A: Allocator>(
 	alloc: &A,
 	words: &[Word],
 	segment: &KeySegment,
-	zero_operator_data: &PreparedOperatorData<F>,
-	bitand_operator_data: &PreparedOperatorData<F>,
-	intmul_operator_data: &PreparedOperatorData<F>,
-	binmul_operator_data: &PreparedOperatorData<F>,
+	prepared: &PreparedOperatorClaims<F>,
 ) -> [FieldVec<P, A>; SHIFT_VARIANT_COUNT] {
 	let acc_size: usize = SHIFT_VARIANT_COUNT << (LOG_LEN.saturating_sub(P::LOG_WIDTH));
 
@@ -237,12 +216,7 @@ pub fn build_g_parts<F: BinaryField, P: PackedField<Scalar = F>, A: Allocator>(
 				let keys = &segment.keys[*start as usize..*end as usize];
 
 				for key in keys {
-					let operator_data = match key.operation {
-						Operation::Zero => zero_operator_data,
-						Operation::BitwiseAnd => bitand_operator_data,
-						Operation::IntegerMul => intmul_operator_data,
-						Operation::BinMul => binmul_operator_data,
-					};
+					let operator_data = &prepared[key.operation];
 
 					let acc = key.accumulate(
 						&segment.constraint_indices,

--- a/crates/prover/src/protocols/shift/phase_2.rs
+++ b/crates/prover/src/protocols/shift/phase_2.rs
@@ -28,7 +28,7 @@ use binius_verifier::protocols::shift::evaluate_words_mle;
 use tracing::instrument;
 
 use super::{
-	key_collection::KeyCollection, monster::build_monster_segments, prove::PreparedOperatorData,
+	claims::PreparedOperatorClaims, key_collection::KeyCollection, monster::build_monster_segments,
 };
 use crate::fold_word::fold_words;
 
@@ -42,31 +42,25 @@ use crate::fold_word::fold_words;
 /// 1. **Challenge Splitting**: Splits phase 1 challenges into `r_j` and `r_s` components
 /// 2. **Segment Folding**: Folds the public and hidden words using the `r_j` challenges
 /// 3. **Monster Multilinear Construction**: Builds the monster segments from the key collection and
-///    operator data
+///    the prepared claims
 /// 4. **Sumcheck Execution**: Runs the bivariate product sumcheck with a sparse first round over
 ///    the segment selector
 ///
 /// # Parameters
 /// - `key_collection`: Prover's key collection representing the constraint system
 /// - `words`: The value vector words
-/// - `bitand_data`: Operator data for bit multiplication constraints
-/// - `intmul_data`: Operator data for integer multiplication constraints
-/// - `binmul_data`: Operator data for GHASH-field multiplication (BMUL) constraints
+/// - `prepared`: The prepared claim of each operation, indexed by the operation a key names
 /// - `phase_1_output`: Challenges and evaluation from the first phase
 /// - `channel`: The prover's channel
 ///
 /// # Returns
 /// Returns `SumcheckOutput` containing the combined challenges `[r_j, r_y]` and the witness
 /// evaluation, or an error if the protocol fails.
-#[allow(clippy::too_many_arguments)]
 #[instrument(skip_all, name = "prove_phase_2")]
 pub fn prove_phase_2<F, P: PackedField<Scalar = F>, Channel, A>(
 	key_collection: &KeyCollection,
 	words: &[Word],
-	zero_data: &PreparedOperatorData<F>,
-	bitand_data: &PreparedOperatorData<F>,
-	intmul_data: &PreparedOperatorData<F>,
-	binmul_data: &PreparedOperatorData<F>,
+	prepared: &PreparedOperatorClaims<F>,
 	domain_subspace: &BinarySubspace<F>,
 	phase_1_output: SumcheckOutput<F>,
 	channel: &mut Channel,
@@ -96,17 +90,8 @@ where
 	let public_folded = fold_words::<_, P, _>(alloc, public_words, r_j_tensor.as_ref());
 	let hidden_folded = fold_words::<_, P, _>(alloc, hidden_words, r_j_tensor.as_ref());
 
-	let (public_monster, hidden_monster) = build_monster_segments(
-		alloc,
-		key_collection,
-		zero_data,
-		bitand_data,
-		intmul_data,
-		binmul_data,
-		domain_subspace,
-		&r_j,
-		&r_s,
-	);
+	let (public_monster, hidden_monster) =
+		build_monster_segments(alloc, key_collection, prepared, domain_subspace, &r_j, &r_s);
 
 	run_sumcheck(
 		&public_folded,

--- a/crates/prover/src/protocols/shift/prove.rs
+++ b/crates/prover/src/protocols/shift/prove.rs
@@ -8,9 +8,11 @@ use binius_ip_prover::channel::IPProverChannel;
 use binius_math::{
 	BinarySubspace, FieldBuffer, inner_product::inner_product, multilinear::eq::eq_ind_partial_eval,
 };
-use binius_verifier::protocols::shift::{BINMUL_ARITY, BITAND_ARITY, INTMUL_ARITY, ZERO_ARITY};
 
-use super::{key_collection::KeyCollection, phase_1::prove_phase_1, phase_2::prove_phase_2};
+use super::{
+	claims::OperatorClaims, key_collection::KeyCollection, phase_1::prove_phase_1,
+	phase_2::prove_phase_2,
+};
 
 /// One operation's operand evaluation claims, with the point they are claimed at.
 ///
@@ -120,42 +122,29 @@ impl<F: Field> PreparedOperatorData<F> {
 	}
 }
 
-/// Proves the shift protocol reduction using a two-phase approach.
+/// Proves the shift protocol reduction, collapsing every operation's claims into one.
 ///
-/// This function orchestrates the complete shift protocol proof, reducing bitand and intmul
-/// evaluation claims to a single multilinear claim on the witness. The protocol consists
-/// of two sequential sumcheck phases that progressively reduce the complexity of the claims.
+/// The result is a single multilinear evaluation claim on the witness.
 ///
-/// # Protocol Overview
-/// 1. **Lambda Sampling**: Samples random coefficients for batching operator claims
-/// 2. **Phase 1**: Proves batched operator claims over shift variants and operand positions
-/// 3. **Phase 2**: Reduces to witness evaluation using monster multilinear polynomial
+/// Two sumcheck phases run in sequence:
+///
+/// 1. phase 1 proves the batched claims over the shift variants and operand positions;
+/// 2. phase 2 reduces those to a witness evaluation, against the monster multilinear.
 ///
 /// # Parameters
-/// - `key_collection`: Prover's key collection representing the constraint system
-/// - `words`: The witness words (must have power-of-2 length)
-/// - `zero_data`: Operator data for the linear (ZERO) constraints
-/// - `bitand_data`: Operator data for bit multiplication (AND) constraints
-/// - `intmul_data`: Operator data for integer multiplication (IMUL) constraints
-/// - `binmul_data`: Operator data for GHASH-field multiplication (BMUL) constraints
-/// - `transcript`: The prover's transcript for interactive protocol
-///
-/// Each of the four carries its own arity, so no two can be passed in the other's place.
+/// - `key_collection`: the prover's key collection for the constraint system.
+/// - `words`: the witness words, which must have a power-of-two length.
+/// - `claims`: the operand evaluation claim of each operation.
+/// - `domain_subspace`: the univariate evaluation domain.
+/// - `channel`: the prover channel driving the interactive protocol.
+/// - `alloc`: the allocator backing the reduction's intermediate buffers.
 ///
 /// # Returns
-/// Returns `SumcheckOutput` containing the final challenges and witness evaluation,
-/// or an error if the proof generation fails.
-///
-/// # Requirements
-/// - `words` must have power-of-2 length for efficient multilinear operations
-#[allow(clippy::too_many_arguments)]
+/// The `SumcheckOutput` with the final challenges and the witness evaluation.
 pub fn prove<F, P, Channel, A>(
 	key_collection: &KeyCollection,
 	words: &[Word],
-	zero_data: OperatorData<F, ZERO_ARITY>,
-	bitand_data: OperatorData<F, BITAND_ARITY>,
-	intmul_data: OperatorData<F, INTMUL_ARITY>,
-	binmul_data: OperatorData<F, BINMUL_ARITY>,
+	claims: OperatorClaims<F>,
 	domain_subspace: &BinarySubspace<F>,
 	channel: &mut Channel,
 	alloc: &A,
@@ -166,52 +155,32 @@ where
 	Channel: IPProverChannel<F>,
 	A: Allocator,
 {
-	// Sample lambdas, one for each operator.
-	let zero_lambda = channel.sample();
-	let bitand_lambda = channel.sample();
-	let intmul_lambda = channel.sample();
-	let binmul_lambda = channel.sample();
+	// One batching coefficient per operation, expanded along with its constraint point.
+	// SOUNDNESS: `prepare` draws in the order the verifier draws in; do not reorder it.
+	let prepared = {
+		let _scope = tracing::debug_span!("Expand tensor queries").entered();
+		claims.prepare(|| channel.sample())
+	};
 
-	// Create prepared operator data with sampled lambdas
-	let expand_scope = tracing::debug_span!("Expand tensor queries").entered();
-	let prepared_zero_data = PreparedOperatorData::new(zero_data, zero_lambda);
-	let prepared_bitand_data = PreparedOperatorData::new(bitand_data, bitand_lambda);
-	let prepared_intmul_data = PreparedOperatorData::new(intmul_data, intmul_lambda);
-	let prepared_binmul_data = PreparedOperatorData::new(binmul_data, binmul_lambda);
-	drop(expand_scope);
-
-	// Prove the first phase, receiving a `SumcheckOutput`
-	// with challenges made of `r_j` and `r_s`,
-	// and eval equal to `gamma` (see paper).
+	// Phase 1 outputs challenges `r_j || r_s`, and `gamma` as its evaluation (see paper).
 	let phase_1_output = prove_phase_1::<_, P, _, _>(
 		key_collection,
 		words,
-		&prepared_zero_data,
-		&prepared_bitand_data,
-		&prepared_intmul_data,
-		&prepared_binmul_data,
+		&prepared,
 		domain_subspace,
 		channel,
 		alloc,
 	);
 
-	// Prove the second phase, receiving a `SumcheckOutput`
-	// with challenges `r_y` and eval the evaluation of
-	// the witness at oblong point had by univariate
-	// variable `r_j` and multilinear variable `r_y`.
-	let SumcheckOutput { challenges, eval } = prove_phase_2::<_, P, _, _>(
+	// Phase 2 outputs challenges `r_y`, and the witness evaluation at the oblong point given by
+	// the univariate variable `r_j` and the multilinear variable `r_y`.
+	prove_phase_2::<_, P, _, _>(
 		key_collection,
 		words,
-		&prepared_zero_data,
-		&prepared_bitand_data,
-		&prepared_intmul_data,
-		&prepared_binmul_data,
+		&prepared,
 		domain_subspace,
 		phase_1_output,
 		channel,
 		alloc,
-	);
-
-	// Return evaluation claim on the witness.
-	SumcheckOutput { challenges, eval }
+	)
 }

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -33,7 +33,8 @@ use crate::{
 	protocols::{
 		binmul, intmul,
 		shift::{
-			KeyCollection, OperatorData, build_key_collection, prove as prove_shift_reduction,
+			KeyCollection, OperatorClaims, OperatorData, build_key_collection,
+			prove as prove_shift_reduction,
 		},
 	},
 	ring_switch,
@@ -296,10 +297,12 @@ impl IOPProver {
 		} = prove_shift_reduction::<_, P, _, _>(
 			&self.key_collection,
 			witness.combined_witness(),
-			zero_claim,
-			bitand_claim,
-			intmul_claim,
-			binmul_claim,
+			OperatorClaims {
+				zero: zero_claim,
+				bitand: bitand_claim,
+				intmul: intmul_claim,
+				binmul: binmul_claim,
+			},
 			&subspace,
 			&mut *channel,
 			alloc,

--- a/crates/prover/tests/shift.rs
+++ b/crates/prover/tests/shift.rs
@@ -18,7 +18,7 @@ use binius_math::{
 };
 use binius_prover::{
 	fold_word::fold_words,
-	protocols::shift::{OperatorData, build_key_collection, prove},
+	protocols::shift::{OperatorClaims, OperatorData, build_key_collection, prove},
 };
 use binius_transcript::ProverTranscript;
 use binius_utils::checked_arithmetics::log2_ceil_usize;
@@ -315,10 +315,12 @@ fn test_shift_prove_and_verify() {
 		let prover_output = prove::<F, P, _, _>(
 			&key_collection,
 			value_vec.combined_witness(),
-			prover_zero_data.clone(),
-			prover_bitand_data.clone(),
-			prover_intmul_data.clone(),
-			prover_binmul_data.clone(),
+			OperatorClaims {
+				zero: prover_zero_data.clone(),
+				bitand: prover_bitand_data.clone(),
+				intmul: prover_intmul_data.clone(),
+				binmul: prover_binmul_data.clone(),
+			},
 			&subspace,
 			&mut prover_transcript,
 			&GlobalAllocator,


### PR DESCRIPTION
Follows #2011 and #2012. Now rebased onto them — this PR contains only its own commit.

Pure refactor — no behavior change, no transcript change.

### The problem

#2011 bundled the shift reduction's four operator claims into `OperatorClaims`, but put the type in `m4-prover`.
So only the batched prover got the benefit.

The single-instance shift reduction — the code both provers actually run — kept passing four positional arguments at every seam.

`shift::prove` is the worst case. The same four-way pattern appears **four times in one function**:

```rust
zero_data: OperatorData<F, ZERO_ARITY>,          // 1. four parameters
bitand_data: OperatorData<F, BITAND_ARITY>,
intmul_data: OperatorData<F, INTMUL_ARITY>,
binmul_data: OperatorData<F, BINMUL_ARITY>,
..
let zero_lambda = channel.sample();              // 2. four draws
let bitand_lambda = channel.sample();
let intmul_lambda = channel.sample();
let binmul_lambda = channel.sample();

let prepared_zero_data = PreparedOperatorData::new(zero_data, zero_lambda);      // 3. four prepares
let prepared_bitand_data = PreparedOperatorData::new(bitand_data, bitand_lambda);
let prepared_intmul_data = PreparedOperatorData::new(intmul_data, intmul_lambda);
let prepared_binmul_data = PreparedOperatorData::new(binmul_data, binmul_lambda);

prove_phase_1(.., &prepared_zero_data, &prepared_bitand_data, ..);   // 4. and again, twice
prove_phase_2(.., &prepared_zero_data, &prepared_bitand_data, ..);
```

That one function needs `#[allow(clippy::too_many_arguments)]`. So do three others.

### The idea

Move `OperatorClaims` and `PreparedOperatorClaims` out of `m4-prover` and into `binius-prover::protocols::shift`, next to the `Operation` enum and the `OperatorData` they are built from.

That is where they belonged: the types they wrap already live there, and both provers call the same reduction.

### The change

`shift::prove` in full, after:

```rust
let prepared = claims.prepare(|| channel.sample());

let phase_1_output =
    prove_phase_1::<_, P, _, _>(key_collection, words, &prepared, domain_subspace, channel, alloc);

prove_phase_2::<_, P, _, _>(
    key_collection, words, &prepared, domain_subspace, phase_1_output, channel, alloc,
)
```

Five signatures shrink:

| function | before | after |
|---|---|---|
| `shift::prove` | 9 args + `#[allow(too_many_arguments)]` | **6** |
| `prove_phase_1` | 9 args + `#[allow(too_many_arguments)]` | **6** |
| `prove_phase_2` | 10 args + `#[allow(too_many_arguments)]` | **7** |
| `build_monster_segments` | 9 args + `#[allow(too_many_arguments)]` | **6** |
| `build_g_parts` | 7 args | **4** |

All four suppressions on those functions are gone.

`build_g_parts` also dispatched on the key's operation to pick one of its four parameters:

```diff
- let operator_data = match key.operation {
-     Operation::Zero => zero_operator_data,
-     Operation::BitwiseAnd => bitand_operator_data,
-     Operation::IntegerMul => intmul_operator_data,
-     Operation::BinMul => binmul_operator_data,
- };
+ let operator_data = &prepared[key.operation];
```

Net **−223 / +119** lines.

### Two incidental fixes in `shift::prove`

Both were sitting under the argument noise:

- It destructured its own return value and rebuilt it: `let SumcheckOutput { challenges, eval } = prove_phase_2(..); SumcheckOutput { challenges, eval }`. Now it just returns.
- Its `# Parameters` doc never listed `zero_data`, and documented a `transcript` parameter that does not exist — the argument is `channel`. Rewritten.

### Soundness

- `prepare` draws one coefficient per operation in the order `[Zero, AND, IMUL, BMUL]`, the same order the four `channel.sample()` calls used, and the same order the verifier draws in. A test pins it.
- The same values reach the same subroutines, so the transcript is byte-identical.

One nuance worth stating: the old code drew all four lambdas *before* the `Expand tensor queries` tracing span and expanded inside it.
`prepare` interleaves draw-then-expand per operation, so that span now covers the draws too.
Nothing else touches the channel in between, so this changes span coverage only — not the transcript.

### Scope

- **moved:** `m4-prover/src/operator_claims.rs` → `prover/src/protocols/shift/claims.rs`, with its two tests
- **changed:** `prove.rs`, `phase_1.rs`, `phase_2.rs`, `monster.rs` in the shift module; the single-instance `prover/src/prove.rs` call site; `m4-prover`'s `shift.rs` and `prove.rs`
- **also updated:** `crates/prover/tests/shift.rs` and `crates/prover/benches/shift_reduction.rs`
- **untouched:** the verifier, and the reduction's math

### What is left

One four-arm match survives, at `monster.rs:218`:

```rust
let (scalars, arity) = match key.operation {
    Operation::Zero => (&zero_scalars, ZERO_ARITY),
    ..
};
```

The operator data there now comes from `prepared[key.operation]`, but the per-operation *scalar tables* and their arities are separate locals.
Collapsing those needs a generic per-operation container — `Index<Operation>` over an arbitrary `T` — rather than the two concrete bundles this PR moves.
That is a judgement call about a new abstraction, so it is deliberately left out.

### Verification

Re-run after rebasing onto #2012:

- `cargo check --workspace --all-targets` — clean
- `cargo clippy --workspace --all-targets` — clean
- `cargo +nightly fmt --all --check` — clean
- `cargo test -p binius-m4-prover -p binius-prover` — 43 + 5 + 28 + 13 + 1 pass, including `prove_keccak_permutation_3x` and the single-instance `test_shift_prove_and_verify`

The unit counts move 45 → 43 and 26 → 28 because the two `claims` tests change crates with the module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)