### PR TITLE
Make each constraint's ARITY its own single source of truth

### DIFF
--- a/crates/core/src/constraint_system/constraint.rs
+++ b/crates/core/src/constraint_system/constraint.rs
@@ -1,6 +1,6 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
-use std::{array, fmt};
+use std::fmt;
 
 use binius_utils::serialization::{DeserializeBytes, SerializationError, SerializeBytes};
 use bytes::{Buf, BufMut};
@@ -21,15 +21,6 @@ use super::{ShiftedValueIndex, ValueIndex};
 /// vec![x >> 5, y << 5] = (x >> 5) ^ (y << 5)
 /// ```
 pub type Operand = Vec<ShiftedValueIndex>;
-
-/// Number of operands of a [`ZeroConstraint`].
-const ZERO_ARITY: usize = 1;
-/// Number of operands of an [`AndConstraint`].
-const AND_ARITY: usize = 3;
-/// Number of operands of an [`ImulConstraint`].
-const IMUL_ARITY: usize = 4;
-/// Number of operands of a [`BmulConstraint`].
-const BMUL_ARITY: usize = 6;
 
 /// The kind of a constraint of a [`ConstraintSystem`](super::ConstraintSystem).
 ///
@@ -59,28 +50,6 @@ impl fmt::Display for ConstraintKind {
 	}
 }
 
-/// Serializes the operands of a constraint in storage order.
-fn serialize_operands(
-	operands: &[Operand],
-	mut write_buf: impl BufMut,
-) -> Result<(), SerializationError> {
-	for operand in operands {
-		operand.serialize(&mut write_buf)?;
-	}
-	Ok(())
-}
-
-/// Deserializes the operands of a constraint of the given arity in storage order.
-fn deserialize_operands<const ARITY: usize>(
-	mut read_buf: impl Buf,
-) -> Result<[Operand; ARITY], SerializationError> {
-	let mut operands = array::from_fn::<_, ARITY, _>(|_| Operand::new());
-	for operand in &mut operands {
-		*operand = Vec::<ShiftedValueIndex>::deserialize(&mut read_buf)?;
-	}
-	Ok(operands)
-}
-
 /// Zero constraint: `VAL = 0`.
 ///
 /// This constraint verifies that a single operand vanishes, where the operand is the XOR of
@@ -90,15 +59,15 @@ fn deserialize_operands<const ARITY: usize>(
 ///
 /// The operands are stored in the order given by [`ZeroConstraint::OPERAND_NAMES`].
 #[derive(Debug, Clone, Default)]
-pub struct ZeroConstraint(pub [Operand; ZERO_ARITY]);
+pub struct ZeroConstraint(pub [Operand; ZeroConstraint::ARITY]);
 
 impl ZeroConstraint {
 	/// Number of operands.
-	pub const ARITY: usize = ZERO_ARITY;
+	pub const ARITY: usize = 1;
 	/// Kind of this constraint.
 	pub const KIND: ConstraintKind = ConstraintKind::Zero;
 	/// Names of the operands, in storage order.
-	pub const OPERAND_NAMES: [&'static str; ZERO_ARITY] = ["val"];
+	pub const OPERAND_NAMES: [&'static str; Self::ARITY] = ["val"];
 
 	/// Creates a new Zero constraint from an XOR combination of the given unshifted values.
 	pub fn plain(val: impl IntoIterator<Item = ValueIndex>) -> ZeroConstraint {
@@ -116,15 +85,15 @@ impl ZeroConstraint {
 	}
 }
 
-impl AsRef<[Operand; ZERO_ARITY]> for ZeroConstraint {
-	fn as_ref(&self) -> &[Operand; ZERO_ARITY] {
+impl AsRef<[Operand; ZeroConstraint::ARITY]> for ZeroConstraint {
+	fn as_ref(&self) -> &[Operand; Self::ARITY] {
 		&self.0
 	}
 }
 
 impl SerializeBytes for ZeroConstraint {
 	fn serialize(&self, write_buf: impl BufMut) -> Result<(), SerializationError> {
-		serialize_operands(&self.0, write_buf)
+		self.0.serialize(write_buf)
 	}
 }
 
@@ -133,7 +102,7 @@ impl DeserializeBytes for ZeroConstraint {
 	where
 		Self: Sized,
 	{
-		Ok(ZeroConstraint(deserialize_operands(read_buf)?))
+		<[Operand; Self::ARITY]>::deserialize(read_buf).map(Self)
 	}
 }
 
@@ -144,15 +113,15 @@ impl DeserializeBytes for ZeroConstraint {
 ///
 /// The operands are stored in the order given by [`AndConstraint::OPERAND_NAMES`].
 #[derive(Debug, Clone, Default)]
-pub struct AndConstraint(pub [Operand; AND_ARITY]);
+pub struct AndConstraint(pub [Operand; AndConstraint::ARITY]);
 
 impl AndConstraint {
 	/// Number of operands.
-	pub const ARITY: usize = AND_ARITY;
+	pub const ARITY: usize = 3;
 	/// Kind of this constraint.
 	pub const KIND: ConstraintKind = ConstraintKind::And;
 	/// Names of the operands, in storage order.
-	pub const OPERAND_NAMES: [&'static str; AND_ARITY] = ["a", "b", "c"];
+	pub const OPERAND_NAMES: [&'static str; Self::ARITY] = ["a", "b", "c"];
 
 	/// Creates a new AND constraint from XOR combinations of the given unshifted values.
 	pub fn plain_abc(
@@ -196,15 +165,15 @@ impl AndConstraint {
 	}
 }
 
-impl AsRef<[Operand; AND_ARITY]> for AndConstraint {
-	fn as_ref(&self) -> &[Operand; AND_ARITY] {
+impl AsRef<[Operand; AndConstraint::ARITY]> for AndConstraint {
+	fn as_ref(&self) -> &[Operand; Self::ARITY] {
 		&self.0
 	}
 }
 
 impl SerializeBytes for AndConstraint {
 	fn serialize(&self, write_buf: impl BufMut) -> Result<(), SerializationError> {
-		serialize_operands(&self.0, write_buf)
+		self.0.serialize(write_buf)
 	}
 }
 
@@ -213,7 +182,7 @@ impl DeserializeBytes for AndConstraint {
 	where
 		Self: Sized,
 	{
-		Ok(AndConstraint(deserialize_operands(read_buf)?))
+		<[Operand; Self::ARITY]>::deserialize(read_buf).map(Self)
 	}
 }
 
@@ -224,15 +193,15 @@ impl DeserializeBytes for AndConstraint {
 ///
 /// The operands are stored in the order given by [`ImulConstraint::OPERAND_NAMES`].
 #[derive(Debug, Clone, Default)]
-pub struct ImulConstraint(pub [Operand; IMUL_ARITY]);
+pub struct ImulConstraint(pub [Operand; ImulConstraint::ARITY]);
 
 impl ImulConstraint {
 	/// Number of operands.
-	pub const ARITY: usize = IMUL_ARITY;
+	pub const ARITY: usize = 4;
 	/// Kind of this constraint.
 	pub const KIND: ConstraintKind = ConstraintKind::Imul;
 	/// Names of the operands, in storage order.
-	pub const OPERAND_NAMES: [&'static str; IMUL_ARITY] = ["a", "b", "lo", "hi"];
+	pub const OPERAND_NAMES: [&'static str; Self::ARITY] = ["a", "b", "lo", "hi"];
 
 	/// A operand.
 	pub const fn a(&self) -> &Operand {
@@ -259,15 +228,15 @@ impl ImulConstraint {
 	}
 }
 
-impl AsRef<[Operand; IMUL_ARITY]> for ImulConstraint {
-	fn as_ref(&self) -> &[Operand; IMUL_ARITY] {
+impl AsRef<[Operand; ImulConstraint::ARITY]> for ImulConstraint {
+	fn as_ref(&self) -> &[Operand; Self::ARITY] {
 		&self.0
 	}
 }
 
 impl SerializeBytes for ImulConstraint {
 	fn serialize(&self, write_buf: impl BufMut) -> Result<(), SerializationError> {
-		serialize_operands(&self.0, write_buf)
+		self.0.serialize(write_buf)
 	}
 }
 
@@ -276,7 +245,7 @@ impl DeserializeBytes for ImulConstraint {
 	where
 		Self: Sized,
 	{
-		Ok(ImulConstraint(deserialize_operands(read_buf)?))
+		<[Operand; Self::ARITY]>::deserialize(read_buf).map(Self)
 	}
 }
 
@@ -288,15 +257,15 @@ impl DeserializeBytes for ImulConstraint {
 ///
 /// The operands are stored in the order given by [`BmulConstraint::OPERAND_NAMES`].
 #[derive(Debug, Clone, Default)]
-pub struct BmulConstraint(pub [Operand; BMUL_ARITY]);
+pub struct BmulConstraint(pub [Operand; BmulConstraint::ARITY]);
 
 impl BmulConstraint {
 	/// Number of operands.
-	pub const ARITY: usize = BMUL_ARITY;
+	pub const ARITY: usize = 6;
 	/// Kind of this constraint.
 	pub const KIND: ConstraintKind = ConstraintKind::Bmul;
 	/// Names of the operands, in storage order.
-	pub const OPERAND_NAMES: [&'static str; BMUL_ARITY] =
+	pub const OPERAND_NAMES: [&'static str; Self::ARITY] =
 		["a_lo", "a_hi", "b_lo", "b_hi", "c_lo", "c_hi"];
 
 	/// Low word of the A operand.
@@ -330,15 +299,15 @@ impl BmulConstraint {
 	}
 }
 
-impl AsRef<[Operand; BMUL_ARITY]> for BmulConstraint {
-	fn as_ref(&self) -> &[Operand; BMUL_ARITY] {
+impl AsRef<[Operand; BmulConstraint::ARITY]> for BmulConstraint {
+	fn as_ref(&self) -> &[Operand; Self::ARITY] {
 		&self.0
 	}
 }
 
 impl SerializeBytes for BmulConstraint {
 	fn serialize(&self, write_buf: impl BufMut) -> Result<(), SerializationError> {
-		serialize_operands(&self.0, write_buf)
+		self.0.serialize(write_buf)
 	}
 }
 
@@ -347,7 +316,7 @@ impl DeserializeBytes for BmulConstraint {
 	where
 		Self: Sized,
 	{
-		Ok(BmulConstraint(deserialize_operands(read_buf)?))
+		<[Operand; Self::ARITY]>::deserialize(read_buf).map(Self)
 	}
 }
 


### PR DESCRIPTION
Pure refactor of `crates/core/src/constraint_system/constraint.rs` — no wire-format change, no behavior change.

Two small pieces of redundancy: the arity of each constraint was written down twice, and the operand (de)serialization helpers reimplemented something `binius-utils` already provides.

### The problem — the arity is stated twice

Every constraint type carried its operand count in two places:

```rust
const ZERO_ARITY: usize = 1;                 // private to the module
pub struct ZeroConstraint(pub [Operand; ZERO_ARITY]);
impl ZeroConstraint {
    pub const ARITY: usize = ZERO_ARITY;     // the one callers can actually see
}
```

Callers outside the module only ever see `ZeroConstraint::ARITY`, so the module constant was pure indirection — a second name for the same number, four times over.

### The idea

Put the literal on the associated const and delete the module constants.
Everything else derives from it, including the struct's own field type:

```rust
pub struct ZeroConstraint(pub [Operand; ZeroConstraint::ARITY]);

impl ZeroConstraint {
    pub const ARITY: usize = 1;
    pub const OPERAND_NAMES: [&'static str; Self::ARITY] = ["val"];
}

impl AsRef<[Operand; ZeroConstraint::ARITY]> for ZeroConstraint {
    fn as_ref(&self) -> &[Operand; Self::ARITY] { &self.0 }
}
```

Referencing a type's own associated const in its field type is **not** a definitional cycle: rustc evaluates `ZeroConstraint::ARITY` without needing the layout of `ZeroConstraint`.

The tuple-struct field and the `AsRef` trait argument need the qualified `ZeroConstraint::ARITY` (no `Self` is in scope at those positions); inside the impl blocks `Self::ARITY` works.

### The problem — two hand-rolled serialization helpers

The module also had:

```rust
fn serialize_operands(operands: &[Operand], mut write_buf: impl BufMut) -> ...
fn deserialize_operands<const ARITY: usize>(mut read_buf: impl Buf) -> ...
```

Both duplicate generic impls that already live upstream in `crates/utils/src/serialization.rs:301-317`:

```
impl<T: SerializeBytes,   const N: usize> SerializeBytes   for [T; N]   // items back to back, no length prefix
impl<T: DeserializeBytes, const N: usize> DeserializeBytes for [T; N]   // array_util::try_from_fn
```

That is byte-for-byte the format the local helpers were producing.

### The change

Delete both helpers; each of the eight impls delegates to the field.

```
 impl SerializeBytes for ZeroConstraint {
-    serialize_operands(&self.0, write_buf)
+    self.0.serialize(write_buf)
 }

 impl DeserializeBytes for ZeroConstraint {
-    Ok(ZeroConstraint(deserialize_operands(read_buf)?))
+    <[Operand; Self::ARITY]>::deserialize(read_buf).map(Self)
 }
```

Writing the loop out four times instead would be four chances to drift, and the loop was never the interesting part. Delegating leaves the arity as the only thing that varies per constraint — and because `deserialize` names `Self::ARITY`, the array length it reads cannot disagree with the struct's own field type.

### Scope

- **changed:** `crates/core/src/constraint_system/constraint.rs` only — 29 insertions, 60 deletions
- **removed:** four module constants, two helper functions, the `std::array` import and the `array::from_fn::<_, ARITY, _>` turbofish
- **unchanged:** every public item — `ARITY`, `KIND`, `OPERAND_NAMES`, the accessors, `AsRef`, and both serialization traits keep their signatures
- no other crate referenced the deleted constants (the similarly-named `ZERO_ARITY` / `BITAND_ARITY` in `crates/verifier/src/protocols/shift/` are a separate, untouched set)

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-core --all-targets` — clean
- `cargo +nightly fmt --all` — no diff
- `cargo test -p binius-core` — 86 passed, 3 ignored
- the format-compatibility tests matter most here: `test_deserialize_from_reference_binary_file` (system), `test_proof_deserialize_from_reference_binary_file`, and `test_witness_deserialize_from_reference_binary_file` all still decode fixtures written before this change, which is the real evidence the wire format is untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)