### PR TITLE
Check compile-time-known preconditions at compile time

### DIFF
--- a/crates/core/src/constraint_system/layout.rs
+++ b/crates/core/src/constraint_system/layout.rs
@@ -55,8 +55,8 @@ impl ValueVecLayout {
 	/// Returns the constraint system shape this layout realizes.
 	///
 	/// The returned system has no constraints; the caller fills them in.
-	pub fn constraint_system_shape(&self, constants: Vec<Word>) -> ConstraintSystem {
-		assert_eq!(constants.len(), self.n_const);
+	pub const fn constraint_system_shape(&self, constants: Vec<Word>) -> ConstraintSystem {
+		assert!(constants.len() == self.n_const, "constants must match the layout's n_const");
 		ConstraintSystem {
 			constants,
 			n_const_pad: self.offset_inout - self.n_const,

--- a/crates/field/src/arch/x86_64/m128.rs
+++ b/crates/field/src/arch/x86_64/m128.rs
@@ -90,10 +90,15 @@ impl<const N: usize> From<SmallU<N>> for M128 {
 
 impl From<M128> for u128 {
 	fn from(value: M128) -> Self {
+		const {
+			assert!(
+				align_of::<u128>() == 16,
+				"the store below needs a 16-byte aligned destination"
+			);
+		}
 		let mut result = 0u128;
 		unsafe {
-			// Safety: u128 is 16-byte aligned
-			assert_eq!(align_of::<u128>(), 16);
+			// Safety: u128 is 16-byte aligned, as the const assertion above checks.
 			_mm_store_si128(&raw mut result as *mut __m128i, value.0)
 		};
 		result

--- a/crates/field/src/linear_transformation.rs
+++ b/crates/field/src/linear_transformation.rs
@@ -30,7 +30,12 @@ where
 	UOut: UnderlierType,
 {
 	pub fn new(cols: &[UOut]) -> Self {
-		assert!(LOG_BITS_PER_BYTE <= UIn::LOG_BITS);
+		const {
+			assert!(
+				LOG_BITS_PER_BYTE <= UIn::LOG_BITS,
+				"the underlier must be at least a byte wide"
+			);
+		}
 		assert_eq!(cols.len(), UIn::BITS);
 
 		let lookup = cols

--- a/crates/field/src/util.rs
+++ b/crates/field/src/util.rs
@@ -70,7 +70,9 @@ pub fn powers<F: FieldOps>(val: F) -> impl Iterator<Item = F> {
 pub fn expand_subset_sums_array<P: PackedField, const N: usize, const N_EXP2: usize>(
 	elems: [P; N],
 ) -> [P; N_EXP2] {
-	assert_eq!(N_EXP2, 1 << N);
+	const {
+		assert!(N_EXP2 == 1 << N, "N_EXP2 must equal 2^N");
+	}
 
 	let mut expanded = [P::zero(); N_EXP2];
 	for (i, elem_i) in elems.into_iter().enumerate() {
@@ -95,7 +97,9 @@ pub fn expand_subset_sums_array<P: PackedField, const N: usize, const N_EXP2: us
 pub fn expand_subset_xors<U: UnderlierType, const N: usize, const N_EXP2: usize>(
 	elems: [U; N],
 ) -> [U; N_EXP2] {
-	assert_eq!(N_EXP2, 1 << N);
+	const {
+		assert!(N_EXP2 == 1 << N, "N_EXP2 must equal 2^N");
+	}
 
 	let mut expanded = [U::ZERO; N_EXP2];
 	for (i, elem_i) in elems.into_iter().enumerate() {

--- a/crates/math/src/ntt/domain_context.rs
+++ b/crates/math/src/ntt/domain_context.rs
@@ -180,7 +180,9 @@ impl TraceOneElement for binius_field::BinaryField128bGhash {
 ///   **not** work with $\mathbb{F}_{2^3}$, but it works with $\mathbb{F}_{2^4}$.
 /// - `num_basis_elements` must be nonzero
 fn gao_mateer_basis<F: BinaryField + TraceOneElement>(num_basis_elements: usize) -> Vec<F> {
-	assert!(F::N_BITS.is_power_of_two());
+	const {
+		assert!(F::N_BITS.is_power_of_two(), "the field degree over F_2 must be a power of two");
+	}
 
 	// this is beta_(F::N_BITS - 1)
 	// e.g. for a 128-bit field, this is beta_127

--- a/crates/prover/src/fold_word.rs
+++ b/crates/prover/src/fold_word.rs
@@ -636,7 +636,9 @@ pub(crate) fn fold_row_group<F, PB, const N_TABLES: usize>(
 	PB::Underlier: Divisible<u8>,
 {
 	// One byte of a row per table is what makes the nesting below line up with the columns.
-	debug_assert_eq!(PB::WIDTH, BITS_PER_BYTE * N_TABLES);
+	const {
+		assert!(PB::WIDTH == BITS_PER_BYTE * N_TABLES, "the row width must be one byte per table");
+	}
 
 	// The transpose consumes its input, so work on a copy and leave the caller's rows intact.
 	let mut group = *rows;
@@ -666,16 +668,20 @@ pub(crate) fn fold_row_group<F, PB, const N_TABLES: usize>(
 ///
 /// # Preconditions
 ///
+/// All three are checked at compile time, so a violating instantiation fails to build:
+///
 /// * The array length must be a power of two.
 /// * `LOG_N` must not exceed the base-2 log of the array length.
 /// * `LOG_N` must not exceed the base-2 log of the packed width.
 pub(crate) fn square_transpose_const_size<P: PackedField, const LOG_N: usize, const S: usize>(
 	elems: &mut [P; S],
 ) {
-	let log_size = checked_log_2(S);
+	const {
+		assert!(LOG_N <= P::LOG_WIDTH, "LOG_N must not exceed the packed width");
+		assert!(LOG_N <= checked_log_2(S), "LOG_N must not exceed the array length");
+	}
 
-	assert!(LOG_N <= P::LOG_WIDTH);
-	assert!(LOG_N <= log_size);
+	let log_size = checked_log_2(S);
 
 	// Elements per block that stays contiguous through the butterfly.
 	let log_w = log_size - LOG_N;

--- a/crates/prover/src/protocols/intmul/witness.rs
+++ b/crates/prover/src/protocols/intmul/witness.rs
@@ -129,7 +129,9 @@ where
 		c_lo: &'a [Word],
 		c_hi: &'a [Word],
 	) -> Result<Self, Error> {
-		assert!(2 * Word::BITS <= F::N_BITS);
+		const {
+			assert!(2 * Word::BITS <= F::N_BITS, "F must be wide enough to hold a 128-bit product");
+		}
 
 		// Statement should be of pow-2 length.
 		let Some(n_vars) = strict_log_2(a.len()) else {

--- a/crates/prover/src/protocols/shift/phase_1.rs
+++ b/crates/prover/src/protocols/shift/phase_1.rs
@@ -214,10 +214,12 @@ pub fn build_g_parts<F: BinaryField, P: PackedField<Scalar = F>, A: Allocator>(
 ) -> [FieldVec<P, A>; SHIFT_VARIANT_COUNT] {
 	let acc_size: usize = SHIFT_VARIANT_COUNT << (LOG_LEN.saturating_sub(P::LOG_WIDTH));
 
-	assert!(
-		P::WIDTH <= 8,
-		"the optimizations below work only when the width of `P` is less than 8 (which is true for all packed 128b fields we use for now)"
-	);
+	const {
+		assert!(
+			P::WIDTH <= 8,
+			"the optimizations below work only when the width of `P` is less than 8 (which is true for all packed 128b fields we use for now)"
+		);
+	}
 
 	// Map from a u8 with `P::WIDTH` meaningful bits to the lane mask selecting exactly those lanes,
 	// precomputed once and reused across every accumulator below.
@@ -317,10 +319,12 @@ fn build_multilinear_parts<P: PackedField, A: Allocator>(
 	alloc: &A,
 	multilinears: &[P],
 ) -> [FieldVec<P, A>; SHIFT_VARIANT_COUNT] {
-	assert!(
-		P::LOG_WIDTH < LOG_LEN,
-		"P::WIDTH is not supposed to exceed 8, so this statement must hold"
-	);
+	const {
+		assert!(
+			P::LOG_WIDTH < LOG_LEN,
+			"P::WIDTH is not supposed to exceed 8, so this statement must hold"
+		);
+	}
 
 	multilinears
 		.chunks(1 << (LOG_LEN - P::LOG_WIDTH))

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -575,7 +575,9 @@ where
 	C: AsRef<[Operand; ARITY]> + Sync,
 	A: Allocator,
 {
-	assert!(N_COLS <= ARITY, "N_COLS must not exceed the constraint arity");
+	const {
+		assert!(N_COLS <= ARITY, "N_COLS must not exceed the constraint arity");
+	}
 
 	let n_constraints = constraints.len();
 	let n_rows = n_constraints.next_power_of_two();

--- a/crates/spartan-verifier/src/wrapper/gadgets.rs
+++ b/crates/spartan-verifier/src/wrapper/gadgets.rs
@@ -24,7 +24,8 @@ use binius_spartan_frontend::circuit_builder::CircuitBuilder;
 /// # Panics
 ///
 /// * If `inputs.len() != <B::Field as ExtensionField<FSub>>::DEGREE`
-/// * If `B::Field::CHARACTERISTIC != 2`
+///
+/// Instantiating this with a `B::Field` of characteristic other than 2 fails to compile.
 pub fn square_transpose<B: CircuitBuilder, FSub: Field>(
 	builder: &mut B,
 	inputs: &[B::Wire],
@@ -32,11 +33,12 @@ pub fn square_transpose<B: CircuitBuilder, FSub: Field>(
 where
 	B::Field: ExtensionField<FSub>,
 {
-	assert_eq!(
-		B::Field::CHARACTERISTIC,
-		2,
-		"square_transpose gadget is only implemented for characteristic 2"
-	);
+	const {
+		assert!(
+			B::Field::CHARACTERISTIC == 2,
+			"square_transpose gadget is only implemented for characteristic 2"
+		);
+	}
 
 	let degree = <B::Field as ExtensionField<FSub>>::DEGREE;
 	assert_eq!(inputs.len(), degree);

--- a/crates/verifier/src/protocols/intmul/verify.rs
+++ b/crates/verifier/src/protocols/intmul/verify.rs
@@ -478,7 +478,9 @@ where
 	C: IOPVerifierChannel<F>,
 	C::Elem: FieldOps<Scalar = F> + From<F>,
 {
-	assert!(2 * Word::BITS <= F::N_BITS);
+	const {
+		assert!(2 * Word::BITS <= F::N_BITS, "F must be wide enough to hold a 128-bit product");
+	}
 
 	let initial_eval_point = channel.sample_many(n_vars);
 


### PR DESCRIPTION
Moves 13 assertions from run time to compile time by wrapping them in `const { ... }`. Pure refactor — no behavior change on any input that builds today.

### The problem

Some assertions test things the compiler already knows:

```rust
assert!(N_COLS <= ARITY, "N_COLS must not exceed the constraint arity");   // two const generics
assert!(2 * Word::BITS <= F::N_BITS);                                     // associated consts
assert_eq!(align_of::<u128>(), 16);                                       // a platform fact
```

None of these can vary at run time for a given instantiation. Yet each is re-tested on every call, and each reports a violation only once the offending code path actually executes — so a wrong type argument surfaces as a panic in a test run rather than as a build failure.

Two of the thirteen were weaker than that:

- `fold_word.rs` guarded `PB::WIDTH == BITS_PER_BYTE * N_TABLES` with a `debug_assert_eq!`. Release builds never checked it.
- `m128.rs` asserted `align_of::<u128>() == 16` **inside** the `unsafe` block whose safety comment cites it. The safety argument was checked after the fact rather than as a precondition.

### The idea

Wrap the condition in a `const` block, matching the pattern already used in `buffer_pool.rs` and `operand_columns.rs`:

```
- assert!(N_COLS <= ARITY, "N_COLS must not exceed the constraint arity");
+ const {
+     assert!(N_COLS <= ARITY, "N_COLS must not exceed the constraint arity");
+ }
```

`assert_eq!` cannot appear in a const block (its message formatting is not const), so those become `assert!` with an explicit message — which is also how the two sites that had no message at all acquired one.

### What the error looks like

A violating instantiation now fails the build, and the diagnostic names the exact type arguments:

```
error[E0080]: evaluation panicked: N_EXP2 must equal 2^N
  --> crates/field/src/util.rs:101:3
   | evaluation of `util::expand_subset_xors::<M128, 8, 256>::{constant#2}` failed here
```

That last line is the real gain over a run-time panic: the failure is attributed to a monomorphization, not to whichever call site happened to run first.

### Important: `cargo check` does not catch these

A `const` block inside a generic function is a **post-monomorphization** error — it is evaluated during codegen, once per instantiation actually used.

`cargo check` does not monomorphize, so it does not evaluate these blocks at all. I verified this the hard way: deliberately breaking one of the asserts leaves `cargo check --workspace --all-targets` completely clean, while `cargo build` fails with the `E0080` above.

**So if CI gates on `cargo check` alone, these assertions gate nothing.** `cargo build` and `cargo test` do evaluate them.

The two non-generic sites (`m128.rs`, and the concrete instantiations of the rest) are evaluated at codegen of the enclosing function, so the same rule applies.

### The change

| file | condition |
|---|---|
| `prover/src/prove.rs` | `N_COLS <= ARITY` |
| `prover/src/protocols/shift/phase_1.rs` | `P::WIDTH <= 8` and `P::LOG_WIDTH < LOG_LEN` |
| `prover/src/protocols/intmul/witness.rs` | `2 * Word::BITS <= F::N_BITS` |
| `verifier/src/protocols/intmul/verify.rs` | `2 * Word::BITS <= F::N_BITS` |
| `field/src/util.rs` | `N_EXP2 == 1 << N`, in both subset-expansion fns |
| `field/src/linear_transformation.rs` | `LOG_BITS_PER_BYTE <= UIn::LOG_BITS` |
| `math/src/ntt/domain_context.rs` | `F::N_BITS.is_power_of_two()` |
| `prover/src/fold_word.rs` | `LOG_N <= P::LOG_WIDTH` and `LOG_N <= checked_log_2(S)` |
| `prover/src/fold_word.rs` | `PB::WIDTH == BITS_PER_BYTE * N_TABLES` (was `debug_assert_eq!`) |
| `field/src/arch/x86_64/m128.rs` | `align_of::<u128>() == 16` (was inside the `unsafe` block) |
| `spartan-verifier/src/wrapper/gadgets.rs` | `B::Field::CHARACTERISTIC == 2` |

`checked_log_2` is a `const fn`, which is what lets `fold_word.rs` fold `checked_log_2(S)` for a const-generic `S`.

Doc comments filed two of these under `# Panics` / `# Preconditions`. Those are updated, since a compile error is no longer a panic.

### Also: `ValueVecLayout::constraint_system_shape` is now a `const fn`

```
- pub fn constraint_system_shape(&self, constants: Vec<Word>) -> ConstraintSystem {
-     assert_eq!(constants.len(), self.n_const);
+ pub const fn constraint_system_shape(&self, constants: Vec<Word>) -> ConstraintSystem {
+     assert!(constants.len() == self.n_const, "constants must match the layout's n_const");
```

`Vec::len` and `Vec::new` are both const, and `constants` is moved into the returned struct rather than dropped, so nothing else in the body needed to change.

Worth stating plainly: this one is not callable in a const context today, because you cannot build a non-empty `Vec` at compile time. It is marked `const` for consistency with its neighbours `n_public_words` and `combined_len`, and it costs `assert_eq!`'s "left vs right" output. Happy to drop it from this PR if you'd rather keep the richer diagnostic.

### Scope

- **converted:** 13 assertions across 11 files, listed above
- **left alone:** the ~17 equivalent asserts inside `#[cfg(test)]` modules (`Word::ZERO == Word(0)`, `SERIALIZATION_VERSION == 7`, `size_of::<ShiftedValueIndex>() == 8`, …). They would be valid const blocks, but a test that guards a constant is more useful as one red test than as a build error that hides every other test's result
- no public signature changes apart from the `const fn` above; no wire format, protocol, or numeric behavior touched

### Verification

- `cargo build --workspace --all-targets` — clean. This is the gate that matters: it codegens every instantiation in the workspace, tests and benches included, so it proves no existing instantiation violates any of the 13 conditions
- `cargo build -p binius-field --target x86_64-unknown-linux-gnu` — clean, covering the `m128.rs` site, which does not compile on aarch64
- `cargo test --workspace` — all green, zero failures
- `cargo clippy --workspace --all-targets` — clean
- `cargo +nightly fmt --all` — applied
- **negative tests:** inverting `N_EXP2 == 1 << N` and `align_of::<u128>() == 16` each produce the expected `E0080` at build time, confirming the blocks are genuinely evaluated and not silently skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)