### PR TITLE
Collapse the two multiplication-claim constructors into one

### DIFF
--- a/crates/m4-prover/src/prove.rs
+++ b/crates/m4-prover/src/prove.rs
@@ -33,9 +33,7 @@ use binius_transcript::{ProverTranscript, fiat_shamir::Challenger};
 use binius_verifier::{
 	config::B128,
 	protocols::{
-		binmul::BinMulOutput,
 		bitand::AndCheckOutput,
-		intmul::IntMulOutput,
 		shift::{BINMUL_ARITY, BITAND_ARITY, INTMUL_ARITY, ZERO_ARITY},
 		zero,
 	},
@@ -241,11 +239,31 @@ impl IOPProver {
 			let log_instances = table.log_instances();
 			RerandomizedOperations {
 				bitand: Operation::new(&and_columns, [a_eval, b_eval, c_eval], r_x_and, r_rho_and),
-				intmul: mul.as_ref().map(|(columns, output)| {
-					Operation::from_intmul(columns, output.clone(), &lagrange, log_instances)
+				// The operand order of each mapping is the order the columns were built in.
+				intmul: mul.as_ref().map(|(columns, out)| {
+					Operation::from_mul_check(
+						columns,
+						&out.eval_point,
+						[&out.a_evals, &out.b_evals, &out.c_lo_evals, &out.c_hi_evals],
+						&lagrange,
+						log_instances,
+					)
 				}),
-				binmul: bmul.as_ref().map(|(columns, output)| {
-					Operation::from_binmul(columns, output.clone(), &lagrange, log_instances)
+				binmul: bmul.as_ref().map(|(columns, out)| {
+					Operation::from_mul_check(
+						columns,
+						&out.eval_point,
+						[
+							&out.a_lo_evals,
+							&out.a_hi_evals,
+							&out.b_lo_evals,
+							&out.b_hi_evals,
+							&out.c_lo_evals,
+							&out.c_hi_evals,
+						],
+						&lagrange,
+						log_instances,
+					)
 				}),
 			}
 			.prove::<P, _>(zero_data, &lagrange, z_challenge, channel, alloc)
@@ -485,81 +503,26 @@ impl<'a, A: Allocator, const ARITY: usize> Operation<'a, A, ARITY> {
 			claims.push(claim);
 		}
 	}
-}
 
-impl<'a, A: Allocator> Operation<'a, A, INTMUL_ARITY> {
-	/// Builds the IntMul operation by collapsing its per-bit operand claims to oblong claims.
+	/// Builds a multiplication operation by collapsing its per-bit operand claims.
 	///
-	/// The Lagrange weights fold the per-bit claims at the univariate challenge.
-	/// This gives the oblong form the BitAnd claims already have.
-	/// The IntMul row point splits into an instance part (low) and a constraint part (high).
-	fn from_intmul(
-		columns: &'a OperandColumns<A, INTMUL_ARITY>,
-		intmul_output: IntMulOutput<B128>,
+	/// IntMul and BinMul both close with one claim per bit of each operand.
+	/// The Lagrange weights fold those into one claim per operand, at the univariate challenge.
+	///
+	/// That is the oblong form the BitAnd claims already arrive in.
+	///
+	/// The row point splits at the instance count: instances low, constraints high.
+	fn from_mul_check(
+		columns: &'a OperandColumns<A, ARITY>,
+		eval_point: &[B128],
+		per_bit_evals: [&[B128]; ARITY],
 		lagrange: &[B128],
 		log_instances: usize,
 	) -> Self {
-		let IntMulOutput {
-			eval_point: r_out_mul,
-			a_evals,
-			b_evals,
-			c_lo_evals,
-			c_hi_evals,
-		} = intmul_output;
-		let oblong =
-			|evals: &[B128]| inner_product(evals.iter().copied(), lagrange.iter().copied());
-		let (r_rho, r_x) = r_out_mul.split_at(log_instances);
-		Self::new(
-			columns,
-			[
-				oblong(&a_evals),
-				oblong(&b_evals),
-				oblong(&c_lo_evals),
-				oblong(&c_hi_evals),
-			],
-			r_x,
-			r_rho,
-		)
-	}
-}
-
-impl<'a, A: Allocator> Operation<'a, A, BINMUL_ARITY> {
-	/// Builds the BinMul operation by collapsing its per-bit operand claims to oblong claims.
-	///
-	/// The Lagrange weights fold the per-bit claims at the univariate challenge.
-	/// This gives the oblong form the BitAnd claims already have.
-	/// The BinMul row point splits into an instance part (low) and a constraint part (high).
-	fn from_binmul(
-		columns: &'a OperandColumns<A, BINMUL_ARITY>,
-		binmul_output: BinMulOutput<B128>,
-		lagrange: &[B128],
-		log_instances: usize,
-	) -> Self {
-		let BinMulOutput {
-			eval_point: r_out_binmul,
-			a_lo_evals,
-			a_hi_evals,
-			b_lo_evals,
-			b_hi_evals,
-			c_lo_evals,
-			c_hi_evals,
-		} = binmul_output;
-		let oblong =
-			|evals: &[B128]| inner_product(evals.iter().copied(), lagrange.iter().copied());
-		let (r_rho, r_x) = r_out_binmul.split_at(log_instances);
-		Self::new(
-			columns,
-			[
-				oblong(&a_lo_evals),
-				oblong(&a_hi_evals),
-				oblong(&b_lo_evals),
-				oblong(&b_hi_evals),
-				oblong(&c_lo_evals),
-				oblong(&c_hi_evals),
-			],
-			r_x,
-			r_rho,
-		)
+		let (r_rho, r_x) = eval_point.split_at(log_instances);
+		let operand_claims = per_bit_evals
+			.map(|evals| inner_product(evals.iter().copied(), lagrange.iter().copied()));
+		Self::new(columns, operand_claims, r_x, r_rho)
 	}
 }
 


### PR DESCRIPTION
Pure refactor — no behavior change, no transcript change.

**−75 / +38** lines, one file, no new type.

### The problem

`Operation::from_intmul` and `Operation::from_binmul` are the same function twice.

Both do exactly this:

```
split the row point at the instance count      -> (r_rho, r_x)
fold each operand's per-bit claims by lagrange -> one oblong claim per operand
hand the result to Operation::new
```

They differ only in **which fields they read, and in what order** — `IntMulOutput` has four, `BinMulOutput` has six.

Sixty lines, two copies, one piece of math. Fix a bug in the collapse and you have to fix it twice.

Both also took their check output **by value**, so each call site wrote `output.clone()` — cloning a struct of several `Vec<B128>`.

### The idea

Keep the math once, and move the part that actually differs to where the operation is already named.

```rust
fn from_mul_check(
    columns: &'a OperandColumns<A, ARITY>,
    eval_point: &[B128],
    per_bit_evals: [&[B128]; ARITY],
    lagrange: &[B128],
    log_instances: usize,
) -> Self {
    let (r_rho, r_x) = eval_point.split_at(log_instances);
    let operand_claims = per_bit_evals
        .map(|evals| inner_product(evals.iter().copied(), lagrange.iter().copied()));
    Self::new(columns, operand_claims, r_x, r_rho)
}
```

One method on the existing arity-generic `impl`. The two arity-specific `impl` blocks go away.

### The change

At the call site the field mapping sits next to the operation it belongs to:

```diff
- intmul: mul.as_ref().map(|(columns, output)| {
-     Operation::from_intmul(columns, output.clone(), &lagrange, log_instances)
- }),
+ intmul: mul.as_ref().map(|(columns, out)| {
+     Operation::from_mul_check(
+         columns,
+         &out.eval_point,
+         [&out.a_evals, &out.b_evals, &out.c_lo_evals, &out.c_hi_evals],
+         &lagrange,
+         log_instances,
+     )
+ }),
```

Taking slices instead of an owned output also drops the two `clone()` calls.

### Why not the trait the plan proposed

This is the inspection plan's PR 7, which sketched a `ShiftOperation<ARITY>` trait with unit structs `BitAnd`, `IntMul`, `BinMul`.

That plan told the reader to *"re-evaluate after PR 6 rather than commit to this now."*
Having done the re-evaluation, the trait does not pay:

- **Two implementors, not three.** BitAnd does not share the shape: it is always present, so no `Option`; its columns are built at arity 2 and extended to 3 by `with_derived_and`; and `AndCheckOutput` is already oblong, with no per-bit collapse to do.
- **Line count goes up.** A trait with five items plus two impls costs more than the two ~8-line call blocks it would unify.
- **It would regress tracing.** `tracing::debug_span!` needs a literal name. A single generic path would have to merge `"Assemble IntMul witness"` and `"Assemble BinMul witness"` into one span with the operation as a field, which changes span names that perf tooling may key on.

I also built and discarded a narrower version — a `MulCheckOutput<ARITY>` trait with two methods and two impls. It compiled and passed, and it was still the wrong shape: a trait whose implementations are pure field access is an indirection, not an abstraction.

What survives the re-evaluation is a plain private function.

### Scope

- **changed:** `crates/m4-prover/src/prove.rs` only
- **removed:** `from_intmul`, `from_binmul`, and the two arity-specific `impl Operation` blocks
- **added:** `from_mul_check` on the existing generic `impl`
- **untouched:** the `mul` / `bmul` check blocks in `IOPProver::prove`, and every other crate

### Tests

No new tests. The one thing that could silently break is the field-to-operand mapping, and it is now four visible words at each call site.

That mapping is covered behaviorally: swap two operands and the claims no longer match the columns, so `protocol_round_trips_with_and_intmul_binmul_and_wide_packing` fails.

I checked this rather than assuming it — a unit test on the mapping did catch a `c_lo`/`c_hi` swap — but with the mapping inline at the call site such a test only restates the code, so it is not included.

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy --workspace --all-targets` — clean
- `cargo +nightly fmt --all --check` — clean
- `cargo test -p binius-m4-prover -p binius-prover` — 43 + 5 + 28 + 13 + 1 pass, including `prove_keccak_permutation_3x` and the single-instance `test_shift_prove_and_verify`

🤖 Generated with [Claude Code](https://claude.com/claude-code)