### PR TITLE
BINIUS-361: keep the intmul tree roots in the allocator

### DIFF
--- a/crates/ip-prover/src/sumcheck/selector_mle.rs
+++ b/crates/ip-prover/src/sumcheck/selector_mle.rs
@@ -3,7 +3,9 @@
 
 use binius_field::{Field, PackedField, WideMul};
 use binius_ip::sumcheck::RoundCoeffs;
-use binius_math::{FieldBuffer, multilinear::fold::fold_highest_var_inplace};
+use binius_math::{
+	FieldBuffer, field_buffer::BufferData, multilinear::fold::fold_highest_var_inplace,
+};
 use binius_utils::{bitwise::Bitwise, rayon::prelude::*};
 use itertools::izip;
 
@@ -33,15 +35,17 @@ pub struct Claim<F: Field> {
 /// switchover. See `BinarySwitchover` for more in-depth explanation of the mechanism. Also note
 /// that the need to expand the equality indicator for each multilinear still results in some
 /// blowup.
-pub struct SelectorMlecheckProver<'b, P: PackedField, B: Bitwise> {
+pub struct SelectorMlecheckProver<'b, P: PackedField, B: Bitwise, Data: BufferData<P> = Vec<P>> {
 	last_coeffs_or_sums: RoundState<Vec<RoundCoeffs<P::Scalar>>, Vec<P::Scalar>>,
-	selected: FieldBuffer<P>,
+	selected: FieldBuffer<P, Data>,
 	eq_trackers: Vec<ChunkedEqTracker<P>>,
 	weights: Vec<P::Scalar>,
 	switchover: BinarySwitchover<'b, P, B>,
 }
 
-impl<'b, F: Field, P: PackedField<Scalar = F>, B: Bitwise> SelectorMlecheckProver<'b, P, B> {
+impl<'b, F: Field, P: PackedField<Scalar = F>, B: Bitwise, Data: BufferData<P>>
+	SelectorMlecheckProver<'b, P, B, Data>
+{
 	/// Constructs a prover, given `bitmasks` as representation of 1-bit columns, `selected` being
 	/// the shared large field multilinear, individual `claims` per selector, `weights` to combine
 	/// the per-selector round polynomials into one (one weight per claim), and `switchover` as the
@@ -51,7 +55,7 @@ impl<'b, F: Field, P: PackedField<Scalar = F>, B: Bitwise> SelectorMlecheckProve
 	/// per-selector claims. Supplying the equality-indicator tensor `eq_k(γ, ·)` as the weights
 	/// batches the claims with `eq_k(γ, i)`.
 	pub fn new(
-		selected: FieldBuffer<P>,
+		selected: FieldBuffer<P, Data>,
 		claims: Vec<Claim<F>>,
 		bitmasks: &'b [B],
 		weights: Vec<F>,
@@ -95,11 +99,12 @@ impl<'b, F: Field, P: PackedField<Scalar = F>, B: Bitwise> SelectorMlecheckProve
 	}
 }
 
-impl<'b, F, P, B> SumcheckProver<F> for SelectorMlecheckProver<'b, P, B>
+impl<'b, F, P, B, Data> SumcheckProver<F> for SelectorMlecheckProver<'b, P, B, Data>
 where
 	F: Field,
 	P: PackedField<Scalar = F>,
 	B: Bitwise,
+	Data: BufferData<P>,
 {
 	fn n_vars(&self) -> usize {
 		self.selected.log_len()
@@ -126,6 +131,10 @@ where
 			.unwrap_or_default();
 		let chunk_count = 1 << (self.n_vars() - 1 - chunk_vars);
 
+		// The fold below reads both halves concurrently from many rayon tasks.
+		// Borrowed halves cross that boundary for any backing store the buffer is built on.
+		let (selected_0, selected_1) = self.selected.split_half_ref();
+
 		let packed_prime_evals = (0..chunk_count)
 			.into_par_iter()
 			.fold(
@@ -137,8 +146,6 @@ where
 					)
 				},
 				|(mut packed_prime_evals, mut binary_chunk_0, mut binary_chunk_1), chunk_index| {
-					let (selected_0, selected_1) = self.selected.split_half_ref();
-
 					let selected_0_chunk = selected_0.chunk(chunk_vars, chunk_index);
 					let selected_1_chunk = selected_1.chunk(chunk_vars, chunk_index);
 

--- a/crates/prover/benches/intmul.rs
+++ b/crates/prover/benches/intmul.rs
@@ -339,7 +339,9 @@ fn bench_intmul_components(c: &mut Criterion) {
 	// Computing the leaves of the variable-base exponentiation tree (`a` root as base, `b` as
 	// exponents).
 	group.bench_function("b_leaves", |bencher| {
-		bencher.iter(|| compute_b_leaves::<_, F, P>(&alloc, &witness.a_root, witness.b_exponents));
+		bencher.iter(|| {
+			compute_b_leaves::<_, F, P>(&alloc, witness.a_root.to_ref(), witness.b_exponents)
+		});
 	});
 
 	// Computing a product tree over the leaves.

--- a/crates/prover/src/protocols/intmul/prove.rs
+++ b/crates/prover/src/protocols/intmul/prove.rs
@@ -460,7 +460,7 @@ where
 		&mut self,
 		twisted_eval_points: &[Vec<F>],
 		twisted_evals: &[F],
-		selector: FieldBuffer<P>,
+		selector: FieldVec<P, A>,
 		b_exponents: &[Word],
 		c_lo_hi_roots: [FieldVec<P, A>; 2],
 		c_eval_point: &[F],

--- a/crates/prover/src/protocols/intmul/witness.rs
+++ b/crates/prover/src/protocols/intmul/witness.rs
@@ -7,7 +7,10 @@ use binius_compute::{Allocator, VecLike};
 use binius_core::word::Word;
 use binius_field::{BinaryField, Field, PackedField};
 use binius_ip_prover::prodcheck::ProdcheckProver;
-use binius_math::{FieldVec, field_buffer::FieldBuffer};
+use binius_math::{
+	FieldVec,
+	field_buffer::{FieldBuffer, FieldSlice},
+};
 use binius_utils::{
 	checked_arithmetics::{checked_log_2, strict_log_2},
 	rayon::{
@@ -54,7 +57,7 @@ pub struct Witness<'a, 'alloc, A: Allocator, P: PackedField> {
 	/// Prodcheck prover for the `a` exponentiation tree (leaf layer retained).
 	pub a_prodcheck: ProdcheckProver<'alloc, A, P>,
 	/// The root of the `a` tree (product of all leaves element-wise); the `b` variable base.
-	pub a_root: FieldBuffer<P>,
+	pub a_root: FieldVec<P, A>,
 	/// The exponents for `b` (needed for phase 5).
 	#[getset(skip)]
 	pub b_exponents: &'a [Word],
@@ -64,7 +67,7 @@ pub struct Witness<'a, 'alloc, A: Allocator, P: PackedField> {
 	/// The prover for the prodcheck reduction on b_leaves.
 	pub b_prodcheck: ProdcheckProver<'alloc, A, P>,
 	/// The root of the b tree (product of all leaves element-wise).
-	pub b_root: FieldBuffer<P>,
+	pub b_root: FieldVec<P, A>,
 	/// The exponents for `c_lo` (needed for the phase 5 lookup indices, parity zerocheck on
 	/// `c_lo_0`, and the raw per-bit output evaluations).
 	#[getset(skip)]
@@ -174,7 +177,6 @@ where
 			tracing::debug_span!("Compute fixed-base prodcheck layers").entered();
 		let a_leaves = limb_leaves::<A, F, P>(alloc, &tables[..N_LIMBS], a);
 		let (a_prodcheck, a_root) = ProdcheckProver::new(LOG_N_LIMBS, alloc, a_leaves);
-		let a_root = unpool::<A, P>(a_root);
 
 		let c_lo_leaves = limb_leaves::<A, F, P>(alloc, &tables[..N_LIMBS], c_lo);
 		let (c_lo_prodcheck, c_lo_root) = ProdcheckProver::new(LOG_N_LIMBS, alloc, c_lo_leaves);
@@ -186,7 +188,7 @@ where
 		// Compute b_leaves as concatenated leaves for prodcheck; the variable base is the `a` root.
 		let variable_base_tree_scope =
 			tracing::debug_span!("Compute variable-base prodcheck layers").entered();
-		let b_leaves = compute_b_leaves(alloc, &a_root, b);
+		let b_leaves = compute_b_leaves(alloc, a_root.to_ref(), b);
 		// The prodcheck prover folds its leaf layer in place, and phase 1 reads the leaves again
 		// afterwards, so the prover gets a clone.
 		let (b_prodcheck, b_root) = ProdcheckProver::new(
@@ -194,7 +196,6 @@ where
 			alloc,
 			FieldBuffer::clone_from_slice(alloc, b_leaves.to_ref()),
 		);
-		let b_root = unpool::<A, P>(b_root);
 		drop(variable_base_tree_scope);
 
 		Ok(Self {
@@ -214,17 +215,6 @@ where
 			tables,
 		})
 	}
-}
-
-/// Copies a pooled tree root into a plain `Vec`-backed buffer.
-///
-/// The root fields are consumed by the phase provers as ordinary `FieldBuffer`s; the pooled block
-/// cannot be handed out as a `Vec` directly (its allocation is over-aligned for the free list), so
-/// it is copied out and the pooled block recycled.
-// Takes `src` by value so the pooled block returns to the free list here, not at the caller.
-#[allow(clippy::needless_pass_by_value)]
-fn unpool<A: Allocator, P: PackedField>(src: FieldVec<P, A>) -> FieldBuffer<P> {
-	FieldBuffer::new(src.log_len(), src.as_ref().to_vec())
 }
 
 /// Number of packed columns filled as one independent group before chaining to the next block.
@@ -357,7 +347,7 @@ where
 #[doc(hidden)] // exposed for benchmarking (`benches/intmul.rs`), not a stable API
 pub fn compute_b_leaves<A, F, P>(
 	alloc: &A,
-	bases: &FieldBuffer<P>,
+	bases: FieldSlice<'_, P>,
 	exponents: &[Word],
 ) -> FieldVec<P, A>
 where
@@ -394,7 +384,7 @@ where
 /// Parallel implementation of compute_b_leaves for when bases is large enough to parallelize.
 fn compute_b_leaves_parallel<A, F, P>(
 	alloc: &A,
-	bases: &FieldBuffer<P>,
+	bases: FieldSlice<'_, P>,
 	exponents: &[Word],
 ) -> FieldVec<P, A>
 where
@@ -508,7 +498,7 @@ mod tests {
 		// (`c_lo_root * c_hi_root`); this equality is what lets the prover reuse `b_root` in place
 		// of a separately stored `c_root`.
 		let c_root = buffer_bivariate_product(witness.c_lo_root(), witness.c_hi_root());
-		assert_eq!(witness.b_root(), &c_root);
+		assert_eq!(witness.b_root().to_ref(), c_root.to_ref());
 	}
 
 	#[test]
@@ -588,7 +578,7 @@ mod tests {
 				.map(|_| Word::from_u64(rng.random()))
 				.collect::<Vec<_>>();
 
-			let leaves = compute_b_leaves::<_, F, P>(&GlobalAllocator, &bases, &exponents);
+			let leaves = compute_b_leaves::<_, F, P>(&GlobalAllocator, bases.to_ref(), &exponents);
 
 			for (i, &base0) in base_scalars.iter().enumerate() {
 				let mut base = base0;


### PR DESCRIPTION
Closes [BINIUS-361](https://linear.app/jimpo/issue/BINIUS-361/remove-the-unpool-bridge-in-intmul-witness).

Deletes the `unpool` bridge in the intmul witness by letting the two tree roots it copied stay in the allocator.
Pure refactor — no protocol change, no transcript change.

### The problem

BINIUS-360 removed `pooled_copy`, which copied a `Vec`-backed buffer into an allocator-backed one.
Its mirror image survived: `unpool` copied the other way, out of the pool into a plain `Vec`.

Two of the four intmul tree roots went through it, while the other two were already pooled:

```
a_root      pooled -> unpool -> Vec
b_root      pooled -> unpool -> Vec
c_lo_root   pooled
c_hi_root   pooled
```

Each `unpool` was a full-buffer copy plus a global allocation that bypassed the pool.
At $2^{14}$ exponents over 128-bit scalars that is 256 KiB per root, so 512 KiB copied per witness.

### The idea

Same argument as BINIUS-360: the consumer should hold the buffer in the form it actually needs.
So the question is what each root is really used for — checked, not assumed.

- **The `b` root** feeds one in-place evaluation, and that was already generic over the backing store.
  Nothing to do beyond changing the field type.
- **The `a` root** feeds the variable-base leaf construction, which only reads it.
  That takes a `FieldSlice` now, as the issue guessed.
- **The `a` root** also feeds the selector mlecheck in phase 3, which owns the buffer and folds it.
  That prover gains a backing-store parameter.

### The one wrinkle worth reviewing

`Allocator::Vec<T>` is declared `Send` but **not** `Sync`, and BINIUS-360 deliberately left it that way.

The selector prover read its buffer from inside a rayon `fold`, which would have demanded exactly that missing `Sync`:

```
- fold(.., |acc, chunk_index| {
-     let (selected_0, selected_1) = self.selected.split_half_ref();   // &self.selected shared across tasks
+ let (selected_0, selected_1) = self.selected.split_half_ref();       // hoisted: halves are slice-backed
+ fold(.., |acc, chunk_index| {
```

Hoisting the split above the parallel region means what the tasks share is slice-backed, so no bound on the allocator changes.
Edition 2024 disjoint captures do the rest — the buffer itself is no longer captured at all.
The split was loop-invariant, so this also drops a redundant per-chunk split.

### Scope

- **removed:** `unpool` and its two call sites
- **changed:** two witness fields become allocator-backed; the leaf builder takes a slice; phase 3's parameter follows
- **changed:** the selector mlecheck prover gains a backing-store parameter, defaulting to the previous `Vec`
- **untouched:** the `Allocator` trait, the protocol, and every transcript value

### Verification

- `cargo build --workspace --all-targets` and `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-prover -p binius-ip-prover --all-targets` — no warnings
- `cargo +nightly fmt --all` — clean
- `cargo test -p binius-prover -p binius-ip-prover` — all pass, including the 13 prove/verify integration tests and the intmul witness consistency tests

### Benchmark — no measurable change, which is the expected result

`intmul/prove/witness/16384`, single-threaded, 15 s measurement:

| | median | 95% CI |
|---|---|---|
| before | 17.10 ms | [16.58, 18.09] ms |
| after | 16.56 ms | [16.22, 17.37] ms |

Criterion reports $-3.98\%$ at $p = 0.24$ — "no change in performance detected".

That number is noise, not signal.
Two back-to-back runs of the **unmodified** baseline gave 20.3 ms and 17.1 ms, so this bench's noise floor is roughly $\pm 20\%$.

The real effect is knowable and small: 512 KiB of copying and 2 heap allocations removed, against a ~17 ms witness build dominated by the power tables and leaf gathers.
That is on the order of $0.1\%$, correctly reported as no change.

So this is worth taking as the cleanup it is, not as a speedup.

### One memory note for review

The pooled root blocks are now retained until phase 3 consumes them, rather than returning to the free list immediately.
Pool high-water can therefore rise by up to 512 KiB while global heap drops by the same amount.
Peak total is unchanged or slightly better, since previously the pooled block and its `Vec` copy were both live during the copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
