### PR TITLE
[ci] Use arch-aware setup-rust action for docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: ./.github/actions/setup-rust
 
       - name: Build Documentation
         run: |


### PR DESCRIPTION
This fixes an issue with flaky docs builds.