### PR TITLE
Revert "BINIUS-391: let the IntMul check consume unpadded operand columns"

### DIFF
--- a/crates/prover/src/protocols/intmul/error.rs
+++ b/crates/prover/src/protocols/intmul/error.rs
@@ -1,8 +1,9 @@
 // Copyright 2025 Irreducible Inc.
-// Copyright 2026 The Binius Developers
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
+	#[error("Exponent length should be a power of two")]
+	ExponentsPowerOfTwoLengthRequired,
 	#[error("All exponent slices must have the same length")]
 	ExponentLengthMismatch,
 	#[error("transcript error")]

--- a/crates/prover/src/protocols/intmul/prove.rs
+++ b/crates/prover/src/protocols/intmul/prove.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-use std::{iter, marker::PhantomData};
+use std::marker::PhantomData;
 
 use binius_compute::Allocator;
 use binius_core::word::Word;
@@ -49,22 +49,15 @@ use crate::fold_word::{fold_across_words, fold_words};
 /// Proves the integer multiplication (IntMul) reduction over the four operand columns.
 ///
 /// The four `columns` are the multiplicand `a`, the multiplicand `b`, and the product's low and
-/// high words, in the order `[a, b, lo, hi]`, all of equal length. This builds the [`Witness`],
-/// drives an [`IntMulProver`], and reduces the multiplication relation to per-bit evaluation claims
-/// on the four columns at a common point. See [`IntMulProver::prove`] for the protocol description
-/// and [`IntMulOutput`] for the output shape.
-///
-/// # Padding
-///
-/// The columns' length need not be a power of two. The reduction runs over the constraint axis of
-/// `2^ceil(log2(n))` rows, with the rows past the columns' end read as `Word::ZERO`; a zero row
-/// satisfies `0 * 0 = 0 || 0`, so no claim moves. The padding is never materialized as words:
-/// every buffer built from the columns spans the whole axis and derives its own padding value,
-/// which is the multiplicative identity in the product-check trees and zero elsewhere.
+/// high words, in the order `[a, b, lo, hi]`, each of power-of-two length. This builds the
+/// [`Witness`], drives an [`IntMulProver`], and reduces the multiplication relation to per-bit
+/// evaluation claims on the four columns at a common point. See [`IntMulProver::prove`] for the
+/// protocol description and [`IntMulOutput`] for the output shape.
 ///
 /// # Errors
 ///
-/// Returns an error when the operand columns' lengths disagree.
+/// Returns an error when the operand columns do not have a power-of-two length or their lengths
+/// disagree.
 pub fn prove<A, F, P, Channel>(
 	columns: [&[Word]; 4],
 	channel: &mut Channel,
@@ -261,14 +254,9 @@ where
 			.into_par_iter()
 			.map(|j| {
 				let (tree, limb) = (j / N_LIMBS, j % N_LIMBS);
-				// The columns' padding rows are `Word::ZERO`, whose every limb index is 0 — the
-				// shared table's row 0. So a padding row looks up `base^0 = 1`, as it does in the
-				// product-check trees.
-				let n_padding = (1 << n_vars) - exponents[tree].len();
 				exponents[tree]
 					.iter()
 					.map(|&word| limb_index(word, limb))
-					.chain(iter::repeat_n(0, n_padding))
 					.collect::<Vec<_>>()
 			})
 			.collect::<Vec<_>>();
@@ -359,7 +347,7 @@ where
 		// Fold the 2^k b bit-columns by the recombination tensor into a single field multilinear
 		// B(x) = sum_i eq(r_I^b, i) * b(i, x), then re-randomize its claim B(r_2) = b_recomb from
 		// `b_eval_point` (r_2) to the shared point via a single-claim MLE-eval check.
-		assert!(b_exponents.len() <= 1 << n_vars);
+		assert_eq!(b_exponents.len(), 1 << n_vars);
 		let b_tensor = eq_ind_partial_eval_scalars::<F>(r_ib);
 		let b_folded = fold_words::<_, P, _>(alloc, b_exponents, &b_tensor);
 		let b_sumcheck_prover = MleToSumCheckDecorator::new(multilinear_eval_prover(
@@ -485,7 +473,7 @@ where
 				.iter()
 				.all(|point| point.len() == n_vars)
 		);
-		assert!(b_exponents.len() <= 1 << n_vars);
+		assert_eq!(b_exponents.len(), 1 << n_vars);
 
 		let selector_claims = izip!(twisted_eval_points, twisted_evals)
 			.map(|(point, &value)| Claim {
@@ -505,19 +493,11 @@ where
 		// `SelectorMlecheckProver` reads the exponent bits through the `Bitwise` bitmask
 		// abstraction, which is implemented for the primitive integer types. `Word` is
 		// `repr(transparent)` over `u64`, so reinterpret the slice in place.
-		// `SelectorMlecheckProver` requires one bitmask per row of the constraint axis
-		// (`crates/ip-prover/src/sumcheck/selector_mle.rs:73`), so this is the one place the
-		// reduction still needs the columns' padding rows as words. A padding row is `Word::ZERO`,
-		// so its bitmask is zero.
-		//
-		// TODO(BINIUS-391): relax `SelectorMlecheckProver` and `BinarySwitchover` to read a missing
-		// row's bitmask as zero, and drop this copy.
-		let mut b_bitmasks = bytemuck::cast_slice::<_, u64>(b_exponents).to_vec();
-		b_bitmasks.resize(1 << n_vars, 0);
+		let b_bitmasks: &[u64] = bytemuck::cast_slice(b_exponents);
 		let selector_prover = SelectorMlecheckProver::new(
 			selector,
 			selector_claims,
-			&b_bitmasks,
+			b_bitmasks,
 			eq_weights,
 			self.switchover,
 		);
@@ -621,13 +601,9 @@ where
 			(0..N_LIMBS)
 				.map(|limb| {
 					let table = &tables[twists[tree * N_LIMBS + limb] / LIMB_BITS];
-					// As in `limb_leaves`, the columns' padding rows are `Word::ZERO`, which
-					// indexes row 0 of the table — `base^0 = 1`.
-					let n_padding = (1 << n_vars) - exponents[tree].len();
 					let column_scalars = exponents[tree]
 						.iter()
 						.map(|&word| table.get(limb_index(word, limb)))
-						.chain(iter::repeat_n(table.get(0), n_padding))
 						.collect::<Vec<_>>();
 					let column = FieldBuffer::<P>::from_values(&column_scalars);
 					inner_product_buffers(&column, &x_tensor)

--- a/crates/prover/src/protocols/intmul/tests.rs
+++ b/crates/prover/src/protocols/intmul/tests.rs
@@ -7,8 +7,7 @@ use binius_field::{BinaryField128bGhash, PackedBinaryGhash2x128b, Random};
 use binius_iop::channel::{OracleSpec, naive::NaiveVerifierChannel};
 use binius_iop_prover::channel::naive::NaiveProverChannel;
 use binius_math::{inner_product::inner_product_buffers, multilinear::eq::eq_ind_partial_eval};
-use binius_transcript::{ProverTranscript, VerifierTranscript};
-use binius_utils::checked_arithmetics::log2_ceil_usize;
+use binius_transcript::ProverTranscript;
 use binius_verifier::{
 	config::StdChallenger,
 	protocols::intmul::{
@@ -19,10 +18,7 @@ use binius_verifier::{
 use itertools::izip;
 use rand::prelude::*;
 
-use super::{
-	prove::{IntMulProver, prove},
-	witness::Witness,
-};
+use super::{prove::IntMulProver, witness::Witness};
 use crate::fold_word::fold_words;
 
 type F = BinaryField128bGhash;
@@ -39,37 +35,31 @@ pub fn evaluate_witness(words: &[Word], eval_point: &[F]) -> F {
 	inner_product_buffers(&partially_folded_witness, &suffix_tensor)
 }
 
-/// The four operand columns `(a, b, c_lo, c_hi)` of an IntMul witness.
-type WordColumns = (Vec<Word>, Vec<Word>, Vec<Word>, Vec<Word>);
-
-/// Build a valid IntMul witness of `n` random products `a * b = c_hi || c_lo`.
-fn random_products(rng: &mut impl Rng, n: usize) -> WordColumns {
-	let mut a = Vec::with_capacity(n);
-	let mut b = Vec::with_capacity(n);
-	let mut c_lo = Vec::with_capacity(n);
-	let mut c_hi = Vec::with_capacity(n);
-
-	for _ in 0..n {
-		let a_i = rng.random_range(1..u64::MAX);
-		let b_i = rng.random_range(1..u64::MAX);
-
-		let full_result = (a_i as u128) * (b_i as u128);
-
-		a.push(Word::from_u64(a_i));
-		b.push(Word::from_u64(b_i));
-		c_lo.push(Word::from_u64(full_result as u64));
-		c_hi.push(Word::from_u64((full_result >> 64) as u64));
-	}
-
-	(a, b, c_lo, c_hi)
-}
-
 #[test]
 fn prove_and_verify() {
 	let mut rng = StdRng::seed_from_u64(0);
 
 	const LOG_EXPONENTS: usize = 5;
-	let (a, b, c_lo, c_hi) = random_products(&mut rng, 1 << LOG_EXPONENTS);
+	const NUM_EXPONENTS: usize = 1 << LOG_EXPONENTS;
+	let mut a = Vec::with_capacity(NUM_EXPONENTS);
+	let mut b = Vec::with_capacity(NUM_EXPONENTS);
+	let mut c_lo = Vec::with_capacity(NUM_EXPONENTS);
+	let mut c_hi = Vec::with_capacity(NUM_EXPONENTS);
+
+	for _ in 0..NUM_EXPONENTS {
+		let a_i = rng.random_range(1..u64::MAX);
+		let b_i = rng.random_range(1..u64::MAX);
+
+		let full_result = (a_i as u128) * (b_i as u128);
+
+		let c_lo_i = full_result as u64;
+		let c_hi_i = (full_result >> 64) as u64;
+
+		a.push(Word::from_u64(a_i));
+		b.push(Word::from_u64(b_i));
+		c_lo.push(Word::from_u64(c_lo_i));
+		c_hi.push(Word::from_u64(c_hi_i));
+	}
 
 	let alloc = GlobalAllocator;
 	let witness = Witness::<_, P>::new(&alloc, &a, &b, &c_lo, &c_hi).unwrap();
@@ -122,60 +112,4 @@ fn prove_and_verify() {
 
 	// Check verifier output is consistent with prover output
 	assert_eq!(prove_output, verify_output);
-}
-
-// A witness whose constraint count is not a power of two proves exactly as the same witness
-// zero-extended up to the constraint axis: byte-identical transcript, identical output claims, and
-// the proof still verifies against the axis's variable count.
-//
-// This is the guarantee that lets the M4 prover stop materializing the padding rows (BINIUS-388)
-// without moving anything on the wire. Byte-identity is the whole story here, and it is exactly
-// what makes the word-level zero-extension the safe design: the padded side is the pre-existing,
-// tested path, so the two sides agreeing byte for byte leaves no room for the reduction's phases to
-// have been given the wrong padding value.
-#[test]
-fn unpadded_columns_prove_identically_to_padded_ones() {
-	let mut rng = StdRng::seed_from_u64(1);
-
-	// Constraint counts short of, just past, and well past a power of two.
-	for n in [3, 5, 33] {
-		let (a, b, c_lo, c_hi) = random_products(&mut rng, n);
-		let n_vars = log2_ceil_usize(n);
-
-		// The same witness with explicit zero rows up to the axis. `0 * 0 = 0 || 0`, so the padded
-		// witness is equally satisfying.
-		let pad = |words: &[Word]| {
-			let mut padded = words.to_vec();
-			padded.resize(1 << n_vars, Word::ZERO);
-			padded
-		};
-		let (a_pad, b_pad, c_lo_pad, c_hi_pad) = (pad(&a), pad(&b), pad(&c_lo), pad(&c_hi));
-
-		// One proof per shape, each on a fresh transcript over the same challenger seed.
-		let run = |columns: [&[Word]; 4]| {
-			let oracle_specs = [OracleSpec::new(LIMB_BITS)];
-			let mut transcript = ProverTranscript::<StdChallenger>::default();
-			let mut channel =
-				NaiveProverChannel::<F, _>::new(&mut transcript, oracle_specs.to_vec());
-			let output = prove::<_, F, P, _>(columns, &mut channel, &GlobalAllocator)
-				.expect("the four columns have equal length");
-			channel.finish();
-			(output, transcript.finalize())
-		};
-		let (unpadded_output, unpadded_proof) = run([&a, &b, &c_lo, &c_hi]);
-		let (padded_output, padded_proof) = run([&a_pad, &b_pad, &c_lo_pad, &c_hi_pad]);
-
-		assert_eq!(unpadded_output, padded_output, "claims differ at n = {n}");
-		assert_eq!(unpadded_proof, padded_proof, "transcript differs at n = {n}");
-
-		let oracle_specs = [OracleSpec::new(LIMB_BITS)];
-		let mut verifier_transcript =
-			VerifierTranscript::new(StdChallenger::default(), unpadded_proof);
-		let mut verifier_channel =
-			NaiveVerifierChannel::new(&mut verifier_transcript, &oracle_specs);
-		let verify_output = verify(n_vars, &mut verifier_channel).unwrap();
-		verifier_channel.finish();
-
-		assert_eq!(unpadded_output, verify_output, "verifier disagrees at n = {n}");
-	}
 }

--- a/crates/prover/src/protocols/intmul/witness.rs
+++ b/crates/prover/src/protocols/intmul/witness.rs
@@ -9,7 +9,7 @@ use binius_field::{BinaryField, Field, PackedField};
 use binius_ip_prover::prodcheck::ProdcheckProver;
 use binius_math::{FieldVec, field_buffer::FieldBuffer};
 use binius_utils::{
-	checked_arithmetics::log2_ceil_usize,
+	checked_arithmetics::{checked_log_2, strict_log_2},
 	rayon::{
 		prelude::*,
 		task_size::{IndexedParallelIteratorExt, WorkPerItem},
@@ -122,13 +122,6 @@ where
 	/// Constructs a new integer multiplication witness from the statement.
 	///
 	/// The GKR prodcheck provers draw their layer buffers from `alloc`.
-	///
-	/// The four columns must have equal length, but need not have a power-of-two one: the reduction
-	/// runs over the constraint axis of `2^ceil(log2(n))` rows, and the rows past the columns' end
-	/// read as `Word::ZERO`. Every buffer built here still spans that whole axis, and each derives
-	/// its own value for a padding row rather than being handed one. In the product-check trees
-	/// that value is the multiplicative **identity**, not zero: a zero exponent word indexes row 0
-	/// of a power table, which holds `base^0 = 1`. So no tree's product moves.
 	pub fn new(
 		alloc: &'alloc A,
 		a: &'a [Word],
@@ -138,10 +131,15 @@ where
 	) -> Result<Self, Error> {
 		assert!(2 * Word::BITS <= F::N_BITS);
 
+		// Statement should be of pow-2 length.
+		let Some(n_vars) = strict_log_2(a.len()) else {
+			return Err(Error::ExponentsPowerOfTwoLengthRequired);
+		};
+
 		// All statement slices should be of same length.
-		if [b, c_lo, c_hi]
+		if [a, b, c_lo, c_hi]
 			.iter()
-			.any(|exponents| exponents.len() != a.len())
+			.any(|exponents| exponents.len() != 1 << n_vars)
 		{
 			return Err(Error::ExponentLengthMismatch);
 		}
@@ -333,18 +331,13 @@ where
 {
 	assert_eq!(tables.len(), N_LIMBS);
 
-	// `exponents` need not fill the constraint axis. Its rows past the end are `Word::ZERO`, which
-	// indexes row 0 of every table — and that row holds `base^0 = 1`. So a padding row contributes
-	// the multiplicative identity to the product check, leaving each tree's product unchanged.
-	let n_vars = log2_ceil_usize(exponents.len());
-	let n_padding = (1 << n_vars) - exponents.len();
+	let n_vars = checked_log_2(exponents.len());
 	let scalars = (0..N_LIMBS)
 		.flat_map(|limb| {
 			let table = &tables[limb];
 			exponents
 				.iter()
 				.map(move |&word| table.get(limb_index(word, limb)))
-				.chain(iter::repeat_n(table.get(0), n_padding))
 		})
 		.collect::<Vec<_>>();
 
@@ -381,12 +374,7 @@ where
 	let mut out = FieldBuffer::zeros_in(alloc, n_vars + Word::LOG_BITS);
 	let n_elems = 1 << n_vars;
 
-	// Rows past the columns' end are `Word::ZERO`: every bit is clear, so each of their leaves is
-	// `F::ONE` — the identity the product check needs from a padding row.
-	let padding = iter::repeat_n(Word::ZERO, n_elems - exponents.len());
-	let exponents = exponents.iter().copied().chain(padding);
-
-	for (i, (mut base, exp)) in iter::zip(bases.iter_scalars(), exponents).enumerate() {
+	for (i, (mut base, &exp)) in iter::zip(bases.iter_scalars(), exponents).enumerate() {
 		for z in 0..Word::BITS {
 			// Branchless select of `base` when bit `z` is set, else `F::ONE`: on the selected lane
 			// `mask` is all-ones so `select` keeps `base - 1` and the `+ 1` restores `base`; on the
@@ -428,16 +416,9 @@ where
 			.expect("dimensions match capacity");
 
 		let ones = P::broadcast(F::ONE);
-		(strided.par_iter_cols(), bases.as_ref())
+		(strided.par_iter_cols(), bases.as_ref(), exponents.par_chunks(P::WIDTH))
 			.into_par_iter()
-			.enumerate()
-			.for_each(|(packed_index, (mut col, packed_base))| {
-				// The columns' rows this packed element covers. Rows past their end are absent, and
-				// `make_mask` reads a lane it is not given as clear, so those lanes' leaves are all
-				// `F::ONE` — the identity the product check needs from a padding row.
-				let start = (packed_index * P::WIDTH).min(exponents.len());
-				let exp_chunk = &exponents[start..(start + P::WIDTH).min(exponents.len())];
-
+			.for_each(|(mut col, packed_base, exp_chunk)| {
 				// Keep base as packed element for efficient squaring
 				let mut packed_base = *packed_base;
 
@@ -488,38 +469,25 @@ where
 	F: Field,
 	P: PackedField<Scalar = F>,
 {
-	let n_vars = log2_ceil_usize(exponents.len());
+	let n_vars = checked_log_2(exponents.len());
+	let p_width = P::WIDTH.min(1 << n_vars);
 	let packed_len = 1 << n_vars.saturating_sub(P::LOG_WIDTH);
-
-	// Select `elements[1]` if bit `bit_offset` of the word is set, else `elements[0]`. A row past
-	// the columns' end is `Word::ZERO`, whose bits are all clear, so it selects `elements[0]`.
-	let select = |&word: &Word| elements[word.extract_bit(bit_offset) as usize];
-	let padding = elements[0];
-
 	let mut values = alloc.alloc::<P>(packed_len);
-
-	// The packed elements `exponents` fills whole. Rounding down to a multiple of `P::WIDTH` keeps
-	// every lane of this loop in range, so it packs without a per-lane bounds check.
-	let mut chunks = exponents.chunks_exact(P::WIDTH);
-	values.extend(
-		chunks
-			.by_ref()
-			.map(|chunk| P::from_scalars(chunk.iter().map(select))),
-	);
-
-	// The columns' trailing words share a packed element with the start of the padding.
-	let tail = chunks.remainder();
-	if !tail.is_empty() {
-		values.push(P::from_scalars(
-			tail.iter()
-				.map(select)
-				.chain(iter::repeat(padding))
-				.take(P::WIDTH),
-		));
-	}
-
-	// The rest of the constraint axis is padding.
-	values.resize(packed_len, P::broadcast(padding));
+	values.extend((0..packed_len).map(|i| {
+		let scalars = (0..p_width).map(|j| {
+			let index = i << P::LOG_WIDTH | j;
+			// Select `elements[1]` if bit `bit_offset` of `exponents[index]` is set, else
+			// `elements[0]`.
+			unsafe {
+				// Safety:
+				// - `index` is guaranteed to be in-bounds
+				// - `elements` has two values
+				let is_set = exponents.get_unchecked(index).extract_bit(bit_offset);
+				*elements.get_unchecked(is_set as usize)
+			}
+		});
+		P::from_scalars(scalars)
+	}));
 
 	FieldBuffer::new(n_vars, values)
 }


### PR DESCRIPTION
Reverts binius-zk/binius64#1969