### PR TITLE
Borrow the logUp* table instead of copying its halves

### DIFF
--- a/crates/iop-prover/src/logup_star.rs
+++ b/crates/iop-prover/src/logup_star.rs
@@ -17,7 +17,7 @@ use binius_field::{BinaryField, Divisible, PackedField};
 pub use binius_ip_prover::logup_star::Looker;
 use binius_ip_prover::logup_star::{self as reduction, witness};
 use binius_math::{
-	FieldBuffer, multilinear::eq::eq_ind_partial_eval_in, univariate::evaluate_univariate,
+	FieldSlice, multilinear::eq::eq_ind_partial_eval_in, univariate::evaluate_univariate,
 };
 
 use crate::channel::IOPProverChannel;
@@ -64,7 +64,7 @@ pub struct LogupProof<F> {
 	fields(n_lookers = lookers.len(), table_n_vars = table.log_len())
 )]
 pub fn prove<F, P, Channel, A>(
-	table: &FieldBuffer<P>,
+	table: FieldSlice<P>,
 	lookers: &[Looker<'_, F>],
 	channel: &mut Channel,
 	alloc: &A,
@@ -209,7 +209,7 @@ mod tests {
 			eval_claim,
 		};
 		let prover_proof =
-			prove::<F, P, _, _>(&table, &[looker], &mut prover_channel, &GlobalAllocator);
+			prove::<F, P, _, _>(table.to_ref(), &[looker], &mut prover_channel, &GlobalAllocator);
 
 		prover_channel.finish();
 
@@ -295,7 +295,7 @@ mod tests {
 			},
 		];
 		let prover_proof =
-			prove::<F, P, _, _>(&table, &lookers, &mut prover_channel, &GlobalAllocator);
+			prove::<F, P, _, _>(table.to_ref(), &lookers, &mut prover_channel, &GlobalAllocator);
 		prover_channel.finish();
 
 		let mut verifier_transcript = prover_transcript.into_verifier();
@@ -347,7 +347,7 @@ mod tests {
 			eval_claim: wrong_claim,
 		};
 		let _prover_proof =
-			prove::<F, P, _, _>(&table, &[looker], &mut prover_channel, &GlobalAllocator);
+			prove::<F, P, _, _>(table.to_ref(), &[looker], &mut prover_channel, &GlobalAllocator);
 		prover_channel.finish();
 
 		// The reduction's product check must surface the inconsistency as a verification failure.
@@ -417,7 +417,8 @@ mod tests {
 			eval_claim,
 		};
 		let alloc = GlobalAllocator;
-		let prover_proof = prove::<F, BP, _, _>(&table, &[looker], &mut prover_channel, &alloc);
+		let prover_proof =
+			prove::<F, BP, _, _>(table.to_ref(), &[looker], &mut prover_channel, &alloc);
 		prover_channel.finish(&alloc);
 
 		// Verify: receive Y, run the reduction, open the pushforward through the real FRI check.

--- a/crates/ip-prover/src/logup_star/final_layer.rs
+++ b/crates/ip-prover/src/logup_star/final_layer.rs
@@ -72,15 +72,16 @@ pub struct FinalLayerOutput<F> {
 /// * `eval_claim` - The product claim `e = <T, Y>`.
 /// * `table_prover` - The table-side fractional-addition prover, holding only its leaf layer.
 /// * `layer1` - The layer-1 numerator and denominator claims, sharing the point `Z`.
-/// * `pushforward` - The pushforward `Y` over the `m`-variable cube.
 /// * `table` - The table `T` over the `m`-variable cube.
 /// * `channel` - The prover channel.
+///
+/// The pushforward `Y` is not passed: it is the table circuit's leaf numerator, so `table_prover`
+/// already carries it.
 #[tracing::instrument(skip_all, level = "debug", name = "logup* final layer")]
 pub fn prove_final_layer<'a, A, F, P>(
 	eval_claim: F,
 	table_prover: FracAddCheckProver<'a, A, P>,
 	layer1: FracEvalClaim<F>,
-	pushforward: FieldSlice<P>,
 	table: FieldSlice<'a, P>,
 	channel: &mut impl IPProverChannel<F>,
 ) -> FinalLayerOutput<F>
@@ -117,19 +118,18 @@ where
 	//
 	// Y_0, Y_1 are already store columns (the fractional numerator halves), so only the table
 	// halves T_0, T_1 are pushed as new columns. Only Y_0 is needed here, to form e_0; e_1 follows
-	// as e - e_0.
+	// as e - e_0; the inner product below reads Y_0 back from the store.
 	//
-	// Both splits borrow, so neither the pushforward nor the table is copied. The pushforward
-	// halves are read exactly once, by the inner product below (Y_1 not at all); the table halves
-	// live on as borrowed store columns, which the store's first fold contracts into half-size
-	// buffers of its own. That keeps 2^m field elements per multilinear out of the allocator.
-	let (y_0, _y_1) = pushforward.split_half_ref();
+	// The table split borrows, so the table is not copied: its halves live on as borrowed store
+	// columns, which the store's first fold contracts into half-size buffers of its own. That keeps
+	// 2^m field elements out of the allocator.
 	let (t_0, t_1) = table.split_half_ref();
 
 	// e_0 is the first half's product sum.
 	// Only e_0 is sent, since the verifier recovers e_1 = e - e_0.
 	//
 	//     e_0 = sum_{x'} (Y_0 * T_0)(x'),   e_1 = e - e_0 = sum_{x'} (Y_1 * T_1)(x')
+	let y_0 = prover.store().column(y_0_col);
 	let e_0 = inner_product_par(&y_0, &t_0);
 	channel.send_one(e_0);
 	let e_1 = eval_claim - e_0;

--- a/crates/ip-prover/src/logup_star/final_layer.rs
+++ b/crates/ip-prover/src/logup_star/final_layer.rs
@@ -13,11 +13,9 @@
 //!
 //! This is the prover mirror of the verifier's final layer in [`binius_ip::logup_star`].
 
-use binius_compute::{Allocator, VecLike};
+use binius_compute::Allocator;
 use binius_field::{Field, PackedField};
-use binius_math::{
-	FieldBuffer, FieldSlice, FieldVec, inner_product::inner_product_par, line::extrapolate_line,
-};
+use binius_math::{FieldSlice, inner_product::inner_product_par, line::extrapolate_line};
 
 use crate::{
 	channel::IPProverChannel,
@@ -58,9 +56,10 @@ pub struct FinalLayerOutput<F> {
 ///
 /// The fractional prover popped for the leaf layer already owns the four columns `[Y_0, Y_1, D_0,
 /// D_1]`, and its numerator halves `Y_0, Y_1` are the pushforward halves the product claims read.
-/// So only the table halves `T_0, T_1` are pushed as new columns, and converting the fractional
-/// prover to a plain sumcheck (folding the `eq` factor into its round polynomials) lets all four
-/// claims batch as one shared-store sumcheck over `[Y_0, Y_1, D_0, D_1, T_0, T_1]`.
+/// So only the table halves `T_0, T_1` are pushed as new columns — borrowed from the caller's
+/// table — and converting the fractional prover to a plain sumcheck (folding the `eq` factor into
+/// its round polynomials) lets all four claims batch as one shared-store sumcheck over
+/// `[Y_0, Y_1, D_0, D_1, T_0, T_1]`.
 ///
 /// The split obeys `e_0 + e_1 = e`, so only `e_0` is sent.
 /// The verifier recovers `e_1 = e - e_0`.
@@ -82,7 +81,7 @@ pub fn prove_final_layer<'a, A, F, P>(
 	table_prover: FracAddCheckProver<'a, A, P>,
 	layer1: FracEvalClaim<F>,
 	pushforward: FieldSlice<P>,
-	table: &FieldBuffer<P>,
+	table: FieldSlice<'a, P>,
 	channel: &mut impl IPProverChannel<F>,
 ) -> FinalLayerOutput<F>
 where
@@ -92,7 +91,6 @@ where
 {
 	// Both layer-1 claims share the point Z.
 	debug_assert_eq!(layer1.0.point, layer1.1.point, "layer-1 claims must share the point");
-	let alloc = table_prover.alloc;
 
 	// S_1, S_2: the fractional-addition numerator/denominator, weighted by eq(.; Z).
 	//
@@ -121,14 +119,12 @@ where
 	// halves T_0, T_1 are pushed as new columns. Only Y_0 is needed here, to form e_0; e_1 follows
 	// as e - e_0.
 	//
-	// Neither pushforward half needs to be owned:
-	//
-	//     Y_0 -> read once, by the inner product with T_0
-	//     Y_1 -> never read
-	//
-	// Borrowing them keeps 2^m field elements out of the allocator.
+	// Both splits borrow, so neither the pushforward nor the table is copied. The pushforward
+	// halves are read exactly once, by the inner product below (Y_1 not at all); the table halves
+	// live on as borrowed store columns, which the store's first fold contracts into half-size
+	// buffers of its own. That keeps 2^m field elements per multilinear out of the allocator.
 	let (y_0, _y_1) = pushforward.split_half_ref();
-	let [t_0, t_1] = split_halves(alloc, table.to_ref());
+	let (t_0, t_1) = table.split_half_ref();
 
 	// e_0 is the first half's product sum.
 	// Only e_0 is sent, since the verifier recovers e_1 = e - e_0.
@@ -139,9 +135,10 @@ where
 	let e_1 = eval_claim - e_0;
 
 	// S_3a, S_3b: each half is a bivariate product over the shared Y column and the pushed T
-	// column.
-	let t_0_col = prover.push_owned_column(t_0);
-	let t_1_col = prover.push_owned_column(t_1);
+	// column. The table halves are borrowed, so the store's first fold is the only place a table
+	// column is written, at half the table's size.
+	let t_0_col = prover.push_column(t_0);
+	let t_1_col = prover.push_column(t_1);
 	let product_0 = BivariateProductEvaluator::new([y_0_col, t_0_col]);
 	prover.add_evaluator(e_0, Box::new(product_0) as Box<dyn SumcheckRoundEvaluator<F, P> + 'a>);
 	let product_1 = BivariateProductEvaluator::new([y_1_col, t_1_col]);
@@ -178,25 +175,4 @@ where
 		table_eval_claim,
 		pushforward_eval_claim,
 	}
-}
-
-/// Split a multilinear on its highest variable into owned low and high halves.
-///
-/// The low half fixes the highest variable to 0, the high half to 1.
-fn split_halves<A: Allocator, P: PackedField>(
-	alloc: &A,
-	buffer: FieldSlice<P>,
-) -> [FieldVec<P, A>; 2] {
-	// split_half_ref borrows the two halves; copy each straight into an allocator buffer for the
-	// sub-provers, so the split is a single copy rather than a `Vec` build followed by a pooled
-	// copy.
-	let (low, high) = buffer.split_half_ref();
-	let mut low_data = alloc.alloc::<P>(low.as_ref().len());
-	low_data.extend_from_slice(low.as_ref());
-	let mut high_data = alloc.alloc::<P>(high.as_ref().len());
-	high_data.extend_from_slice(high.as_ref());
-	[
-		FieldBuffer::new(low.log_len(), low_data),
-		FieldBuffer::new(high.log_len(), high_data),
-	]
 }

--- a/crates/ip-prover/src/logup_star/final_layer.rs
+++ b/crates/ip-prover/src/logup_star/final_layer.rs
@@ -137,8 +137,8 @@ where
 	// S_3a, S_3b: each half is a bivariate product over the shared Y column and the pushed T
 	// column. The table halves are borrowed, so the store's first fold is the only place a table
 	// column is written, at half the table's size.
-	let t_0_col = prover.push_column(t_0);
-	let t_1_col = prover.push_column(t_1);
+	let t_0_col = prover.store_mut().push(t_0);
+	let t_1_col = prover.store_mut().push(t_1);
 	let product_0 = BivariateProductEvaluator::new([y_0_col, t_0_col]);
 	prover.add_evaluator(e_0, Box::new(product_0) as Box<dyn SumcheckRoundEvaluator<F, P> + 'a>);
 	let product_1 = BivariateProductEvaluator::new([y_1_col, t_1_col]);

--- a/crates/ip-prover/src/logup_star/prove.rs
+++ b/crates/ip-prover/src/logup_star/prove.rs
@@ -64,7 +64,7 @@ pub struct Looker<'a, F> {
 
 pub fn prove<A, F, P>(
 	alloc: &A,
-	table: &FieldBuffer<P>,
+	table: FieldSlice<P>,
 	lookers: &[Looker<'_, F>],
 	channel: &mut impl IPProverChannel<F>,
 ) -> LogupOutput<F>
@@ -148,7 +148,7 @@ where
 )]
 pub fn prove_reduction<A, F, P>(
 	alloc: &A,
-	table: &FieldBuffer<P>,
+	table: FieldSlice<P>,
 	lookers: &[Looker<'_, F>],
 	eval_claim: F,
 	numerators: Vec<FieldVec<P, A>>,
@@ -369,8 +369,12 @@ mod tests {
 			eval_point: &eval_point,
 			eval_claim,
 		};
-		let prover_out =
-			prove::<GlobalAllocator, F, P>(&alloc, &table, &[looker], &mut prover_transcript);
+		let prover_out = prove::<GlobalAllocator, F, P>(
+			&alloc,
+			table.to_ref(),
+			&[looker],
+			&mut prover_transcript,
+		);
 
 		let mut verifier_transcript = prover_transcript.into_verifier();
 		let looker_claim = logup_star::LookerClaim {
@@ -452,7 +456,7 @@ mod tests {
 			eval_point: &eval_point,
 			eval_claim: wrong_claim,
 		};
-		prove::<GlobalAllocator, F, P>(&alloc, &table, &[looker], &mut prover_transcript);
+		prove::<GlobalAllocator, F, P>(&alloc, table.to_ref(), &[looker], &mut prover_transcript);
 
 		// The product-check inconsistency must surface as a verification failure.
 		let mut verifier_transcript = prover_transcript.into_verifier();
@@ -503,8 +507,12 @@ mod tests {
 				eval_claim: *eval_claim,
 			})
 			.collect::<Vec<_>>();
-		let prover_out =
-			prove::<GlobalAllocator, F, P>(&alloc, &table, &prover_lookers, &mut prover_transcript);
+		let prover_out = prove::<GlobalAllocator, F, P>(
+			&alloc,
+			table.to_ref(),
+			&prover_lookers,
+			&mut prover_transcript,
+		);
 
 		let mut verifier_transcript = prover_transcript.into_verifier();
 		let looker_claims = lookers
@@ -551,7 +559,7 @@ mod tests {
 			eval_point: &[],
 			eval_claim: F::ZERO,
 		};
-		let _ = prove::<GlobalAllocator, F, P>(&alloc, &table, &[looker], &mut transcript);
+		let _ = prove::<GlobalAllocator, F, P>(&alloc, table.to_ref(), &[looker], &mut transcript);
 	}
 
 	#[test]
@@ -569,7 +577,7 @@ mod tests {
 			eval_point: &eval_point,
 			eval_claim: F::ZERO,
 		};
-		let _ = prove::<GlobalAllocator, F, P>(&alloc, &table, &[looker], &mut transcript);
+		let _ = prove::<GlobalAllocator, F, P>(&alloc, table.to_ref(), &[looker], &mut transcript);
 	}
 
 	#[test]
@@ -588,6 +596,6 @@ mod tests {
 			eval_point: &eval_point,
 			eval_claim: F::ZERO,
 		};
-		let _ = prove::<GlobalAllocator, F, P>(&alloc, &table, &[looker], &mut transcript);
+		let _ = prove::<GlobalAllocator, F, P>(&alloc, table.to_ref(), &[looker], &mut transcript);
 	}
 }

--- a/crates/ip-prover/src/logup_star/prove.rs
+++ b/crates/ip-prover/src/logup_star/prove.rs
@@ -275,7 +275,7 @@ where
 		table_eval_point,
 		table_eval_claim,
 		pushforward_eval_claim,
-	} = prove_final_layer(eval_claim, table_leaf_prover, layer1, pushforward, table, channel);
+	} = prove_final_layer(eval_claim, table_leaf_prover, layer1, table, channel);
 
 	LogupOutput {
 		table_eval_point,

--- a/crates/ip-prover/src/sumcheck/mle_store.rs
+++ b/crates/ip-prover/src/sumcheck/mle_store.rs
@@ -256,6 +256,30 @@ impl<'a, A: Allocator, F: Field, P: PackedField<Scalar = F>> MleStore<'a, A, P> 
 		self.n_vars -= 1;
 	}
 
+	/// Returns the borrowed view of one logical column, addressed by its [`ColId`].
+	///
+	/// The slice spans the column's `2^n_vars()` live scalars, so it tracks the store's folding.
+	pub fn column(&self, id: ColId) -> FieldSlice<'_, P> {
+		// A split-half entry carries two logical columns, so walk the physical entries counting
+		// down the logical index rather than indexing `columns` directly.
+		let mut index = id.index();
+		for column in &self.columns {
+			match column {
+				Column::Borrowed(slice) if index == 0 => return slice.to_ref(),
+				Column::Owned(buffer) if index == 0 => return buffer.to_ref(),
+				Column::SplitHalf(buffer) if index < 2 => {
+					// The buffer holds the two columns as its low and high halves; each column is
+					// the front `2^n_vars` scalars of one half, so read it as that half's chunk 0.
+					let half_start = index << (buffer.log_len() - 1 - self.n_vars);
+					return buffer.chunk(self.n_vars, half_start);
+				}
+				Column::SplitHalf(_) => index -= 2,
+				_ => index -= 1,
+			}
+		}
+		panic!("column id {} is out of range for a store of {} columns", id.index(), self.n_cols);
+	}
+
 	/// Expands the store into one borrowed slice per logical column, in [`ColId`] order.
 	///
 	/// A split-half entry expands into the front `2^n_vars` scalars of its low and high
@@ -820,6 +844,39 @@ mod tests {
 			}
 		}
 		acc
+	}
+
+	// `column` and `column_slices` walk the entries independently, so pin them to each other over
+	// every entry kind and over the folds that shrink a split-half column inside its parent buffer.
+	#[test]
+	fn column_matches_column_slices() {
+		type P = Packed128b;
+		type F = <P as FieldOps>::Scalar;
+
+		let n_vars = 5;
+		let mut rng = StdRng::seed_from_u64(2);
+		let alloc = GlobalAllocator;
+
+		// A split-half entry sits between single-column entries, so the walk has to skip two
+		// logical columns in one step to reach the last id.
+		let borrowed = random_field_buffer::<P>(&mut rng, n_vars);
+		let mut store = MleStore::<GlobalAllocator, P>::new(n_vars, &alloc);
+		let mut col_ids = vec![store.push(borrowed.to_ref())];
+		col_ids.push(store.push_owned(random_field_buffer::<P>(&mut rng, n_vars)));
+		col_ids.extend(store.push_split_half(random_field_buffer::<P>(&mut rng, n_vars + 1)));
+		col_ids.push(store.push_owned(random_field_buffer::<P>(&mut rng, n_vars)));
+
+		let challenges = random_scalars::<F>(&mut rng, n_vars);
+		for (round, &challenge) in challenges.iter().enumerate() {
+			for (&id, expected) in iter::zip(&col_ids, store.column_slices()) {
+				let got = store.column(id);
+				assert_eq!(got.log_len(), expected.log_len(), "length mismatch in round {round}");
+				for i in 0..expected.len() {
+					assert_eq!(got.get(i), expected.get(i), "scalar {i} mismatch in round {round}");
+				}
+			}
+			store.fold(challenge);
+		}
 	}
 
 	#[test]

--- a/crates/ip-prover/src/sumcheck/round_evaluator.rs
+++ b/crates/ip-prover/src/sumcheck/round_evaluator.rs
@@ -3,7 +3,8 @@
 //! Round evaluators over a shared [`MleStore`] and the provers that drive them.
 //!
 //! A round evaluator holds the per-round-polynomial logic for one composite claim over store
-//! columns. Evaluators hold [`ColId`]s and receive column data by argument; they hold no mutable
+//! columns. Evaluators hold [`ColId`](super::mle_store::ColId)s and receive column data by
+//! argument; they hold no mutable
 //! per-round state — they neither fold nor track the round claim. The driving prover owns the
 //! `RoundState` machine (the claim ↔ coeffs alternation) for each evaluator, and the store folds
 //! the columns (see the [`mle_store`](super::mle_store) module documentation).
@@ -31,7 +32,7 @@ use binius_math::{FieldSlice, multilinear::eq::eq_ind_partial_eval};
 use super::{
 	MleToSumCheckEvaluator,
 	common::{MleCheckProver, SumcheckProver},
-	mle_store::{ColId, EvaluationChunk, MleStore, RoundContext},
+	mle_store::{EvaluationChunk, MleStore, RoundContext},
 	round_state::RoundState,
 };
 
@@ -75,7 +76,8 @@ pub trait SumcheckRoundEvaluator<F: Field, P: PackedField<Scalar = F>>: Send + S
 	/// Accumulates one chunk of the halved hypercube into `accum`.
 	///
 	/// The driving prover prepares `chunk` — the split, per-chunk column halves and eq-indicator
-	/// expansions — so the evaluator only reads its columns by [`ColId`] and eq trackers by
+	/// expansions — so the evaluator only reads its columns by [`ColId`](super::mle_store::ColId)
+	/// and eq trackers by
 	/// [`EqId`](super::mle_store::EqId). `accum` is this evaluator's run of [`Self::degree`] wide
 	/// slots, zero-initialized
 	/// on the first chunk and carried across the worker's chunks.
@@ -352,13 +354,12 @@ where
 		&self.group.store
 	}
 
-	/// Pushes a borrowed column onto the store, returning its id.
+	/// Returns an exclusive reference to the underlying column store.
 	///
-	/// Lets a caller extend the shared store with a column that a later-added evaluator reads: the
-	/// logUp* final layer pushes the table halves this way before adding its product evaluators.
-	/// The column is not copied. See [`MleStore::push`].
-	pub fn push_column(&mut self, column: FieldSlice<'a, P>) -> ColId {
-		self.group.store.push(column)
+	/// Lets a caller extend the shared store with columns that a later-added evaluator reads: the
+	/// logUp* final layer pushes the table halves onto it before adding its product evaluators.
+	pub const fn store_mut(&mut self) -> &mut MleStore<'a, A, P> {
+		&mut self.group.store
 	}
 
 	/// Adds one more evaluator — a claim reading the shared store, with its initial claim — to the

--- a/crates/ip-prover/src/sumcheck/round_evaluator.rs
+++ b/crates/ip-prover/src/sumcheck/round_evaluator.rs
@@ -26,7 +26,7 @@ use auto_impl::auto_impl;
 use binius_compute::Allocator;
 use binius_field::{Field, PackedField, WideMul};
 use binius_ip::sumcheck::RoundCoeffs;
-use binius_math::{FieldSlice, FieldVec, multilinear::eq::eq_ind_partial_eval};
+use binius_math::{FieldSlice, multilinear::eq::eq_ind_partial_eval};
 
 use super::{
 	MleToSumCheckEvaluator,
@@ -352,13 +352,13 @@ where
 		&self.group.store
 	}
 
-	/// Pushes an owned column onto the store, returning its id.
+	/// Pushes a borrowed column onto the store, returning its id.
 	///
-	/// Lets a caller extend the shared store with a fresh column that a later-added evaluator
-	/// reads: the logUp* final layer pushes the table halves this way before adding its product
-	/// evaluators. See [`MleStore::push_owned`].
-	pub fn push_owned_column(&mut self, column: FieldVec<P, A>) -> ColId {
-		self.group.store.push_owned(column)
+	/// Lets a caller extend the shared store with a column that a later-added evaluator reads: the
+	/// logUp* final layer pushes the table halves this way before adding its product evaluators.
+	/// The column is not copied. See [`MleStore::push`].
+	pub fn push_column(&mut self, column: FieldSlice<'a, P>) -> ColId {
+		self.group.store.push(column)
 	}
 
 	/// Adds one more evaluator — a claim reading the shared store, with its initial claim — to the

--- a/crates/prover/benches/intmul.rs
+++ b/crates/prover/benches/intmul.rs
@@ -309,7 +309,7 @@ fn bench_intmul_phases(c: &mut Criterion) {
 					witness.a_exponents,
 					witness.c_lo_exponents,
 					witness.c_hi_exponents,
-					&witness.tables[0],
+					witness.tables[0].to_ref(),
 				)
 			},
 			BatchSize::SmallInput,

--- a/crates/prover/src/protocols/intmul/prove.rs
+++ b/crates/prover/src/protocols/intmul/prove.rs
@@ -220,7 +220,7 @@ where
 			a_exponents,
 			c_lo_exponents,
 			c_hi_exponents,
-			&tables[0],
+			tables[0].to_ref(),
 		)
 	}
 
@@ -238,7 +238,7 @@ where
 		a_exponents: &[Word],
 		c_lo_exponents: &[Word],
 		c_hi_exponents: &[Word],
-		table: &FieldBuffer<P>,
+		table: FieldSlice<P>,
 	) -> IntMulOutput<F> {
 		let alloc = self.alloc;
 		let n_vars = b_eval_point.len();
@@ -577,7 +577,7 @@ where
 		(gpow_c_lo_eval, c_lo_prover): (F, ProdcheckProver<'alloc, A, P>),
 		(gpow_c_hi_eval, c_hi_prover): (F, ProdcheckProver<'alloc, A, P>),
 		exponents: [&[Word]; 3],
-		tables: &[FieldBuffer<P>],
+		tables: &[FieldVec<P, A>],
 	) -> Phase4Output<F> {
 		let n_vars = eval_point.len();
 

--- a/crates/prover/src/protocols/intmul/witness.rs
+++ b/crates/prover/src/protocols/intmul/witness.rs
@@ -87,7 +87,7 @@ pub struct Witness<'a, 'alloc, A: Allocator, P: PackedField> {
 	/// The 2·N_LIMBS twisted power tables: `tables[s][i] = (G^{2^{ws}})^i`. Limb column `(t, l)`
 	/// is a gather from table `s(t, l)`; `tables[0]` is the shared table read by the Phase 5
 	/// logup* lookup.
-	pub tables: Vec<FieldBuffer<P>>,
+	pub tables: Vec<FieldVec<P, A>>,
 }
 
 // A manual `Clone` impl (rather than `#[derive(Clone)]`) so the bound lands on the pooled buffer
@@ -164,7 +164,7 @@ where
 		// Allocate the table buffers up front on this thread, so the parallel region only fills
 		// them — no allocator traffic inside the rayon closures.
 		let packed_len = 1 << LIMB_BITS.saturating_sub(P::LOG_WIDTH);
-		let buffers = iter::repeat_with(|| Vec::<P>::with_capacity(packed_len))
+		let buffers = iter::repeat_with(|| alloc.alloc::<P>(packed_len))
 			.take(bases.len())
 			.collect::<Vec<_>>();
 		let tables = (bases, buffers)
@@ -251,22 +251,22 @@ where
 /// Fill `buffer` with the power table of `base` and wrap it as a [`FieldBuffer`] of `2^log_size`
 /// rows: row `i` holds `base^i`.
 ///
-/// The caller supplies the backing `Vec`, so its allocation can be hoisted out of a hot or parallel
-/// region; `buffer` is cleared and refilled here without reallocating.
+/// The caller supplies the backing buffer, so its allocation can be hoisted out of a hot or
+/// parallel region; `buffer` is cleared and refilled here without reallocating.
 ///
 /// # Preconditions
 ///
-/// * `buffer.capacity()` must equal `1 << log_size.saturating_sub(P::LOG_WIDTH)`.
-fn power_table_into<F, P>(log_size: usize, base: F, mut buffer: Vec<P>) -> FieldBuffer<P>
+/// * `buffer.capacity()` must be at least `1 << log_size.saturating_sub(P::LOG_WIDTH)`.
+fn power_table_into<F, P, V>(log_size: usize, base: F, mut buffer: V) -> FieldBuffer<P, V>
 where
 	F: Field,
 	P: PackedField<Scalar = F>,
+	V: VecLike<P>,
 {
 	let packed_len = 1 << log_size.saturating_sub(P::LOG_WIDTH);
-	assert_eq!(
-		buffer.capacity(),
-		packed_len,
-		"precondition: buffer capacity must match the packed table length"
+	assert!(
+		buffer.capacity() >= packed_len,
+		"precondition: buffer capacity must cover the packed table length"
 	);
 	buffer.clear();
 
@@ -317,7 +317,7 @@ pub(super) const fn limb_index(word: Word, limb: usize) -> usize {
 /// corresponding word. The columns are concatenated into one `(n_vars + LOG_N_LIMBS)`-variate
 /// buffer with the limb index in the high bits, so the prodcheck's node reductions pair column `z`
 /// with column `z + N_LIMBS/2`.
-fn limb_leaves<A, F, P>(alloc: &A, tables: &[FieldBuffer<P>], exponents: &[Word]) -> FieldVec<P, A>
+fn limb_leaves<A, F, P>(alloc: &A, tables: &[FieldVec<P, A>], exponents: &[Word]) -> FieldVec<P, A>
 where
 	A: Allocator,
 	F: Field,


### PR DESCRIPTION
Three commits, each independently reviewable.

## 1. Borrow the logUp* table halves instead of copying them

`logup_star::prove` and `prove_reduction` took the table as `&FieldBuffer<P>`, and the batched final layer split it into two allocator-owned halves before pushing them as sumcheck store columns. That split cost a full copy of the table — `2^m` field elements — on every proof, even though the store folds each column into a fresh half-size buffer on the first challenge anyway.

The table is now taken as `FieldSlice<P>` and the halves are pushed borrowed. `SharedSumcheckProver` grew a `push_column` forwarder onto the store's existing `MleStore::push`; `push_owned_column` lost its last caller and went away (`MleStore::push_owned` itself stays). The `split_halves` helper and its two allocator buffers are gone.

The store's column push order is unchanged — `[Y_0, Y_1, D_0, D_1, T_0, T_1]` — so the round polynomials, the six-way final evaluation destructure, and the transcript are all identical.

The signature change threads through `iop_prover::logup_star::prove` and `IntMulProver::phase5`; callers pass `.to_ref()`.

With the table now borrowed by the reduction, the caller owns it for the whole proof, so intmul's power tables move into the allocator alongside the tree roots: `Witness::tables` becomes `Vec<FieldVec<P, A>>` and `power_table_into` is generic over `V: VecLike<P>`. Its capacity precondition relaxes from `==` to `>=`, since `Allocator::alloc` promises only "at least" the requested capacity and `BufferPool` rounds the byte length up to a power of two — the old assertion would have been a latent panic for any table size that rounds up.

## 2. Expose the shared sumcheck prover's store instead of one push forwarder

`push_column` was a one-method forwarder for the single caller that extends the store after construction. Replaced with `store_mut`, the exclusive-reference counterpart of the existing `store` accessor, so the caller reaches `MleStore::push` itself.

## 3. Read `Y_0` from the `MleStore` instead of passing the pushforward

`prove_final_layer` took the pushforward `Y` only to split off its low half for the inner product that forms `e_0`. But `Y` is the table circuit's leaf numerator, so the fractional prover handed in alongside it already carries it: `layer_prover` pushes the leaf layer's halves onto the shared store and returns their column ids, and `y_0_col` is exactly that low half.

`MleStore` gains `column`, returning one logical column as a `FieldSlice` over its live scalars; a split-half entry carries two logical columns, so the lookup walks the physical entries counting the logical index down. `column_slices` keeps its own walk so the bulk path stays linear in the column count, and a new test pins the two against each other over every entry kind and across the folds that shrink a split-half column inside its parent buffer.

`prove_reduction` keeps its own `pushforward` argument: it is what `FieldBuffer::clone_from_slice` builds the table circuit's leaf layer from in the first place.

## Testing

No transcript change in any of the three commits, so the existing logUp* round-trip tests are the check that matters — including `test_prove_verify_single_table_variable` (m = 1, where each table half is a sub-packing-width `Single`) and `test_basefold_round_trip` (real FRI over the pooled allocator). All of `binius-ip-prover`, `binius-iop-prover`, and the intmul tests pass; `cargo check --workspace --all-targets` and clippy `-D warnings` are clean on the touched crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
