### PR TITLE
BINIUS-397: dense shift encoding for the phase-1 g accumulator

### DIFF
--- a/crates/m4-prover/src/shift.rs
+++ b/crates/m4-prover/src/shift.rs
@@ -154,13 +154,8 @@ where
 ///
 /// `SHIFT_VARIANT_COUNT` multilinears of [`LOG_LEN`] variables, one per shift variant.
 ///
-/// A key's id splits into the variant and the shift amount:
-///
-/// ```text
-/// id = (variant << Word::LOG_BITS) | amount
-/// ```
-///
-/// The variant picks the multilinear, and the amount picks the run of bit slots within it:
+/// The segment's dense shift encoding decodes a key's shift index into the variant and the shift
+/// amount. The variant picks the multilinear, and the amount picks the run of bit slots within it:
 ///
 /// ```text
 /// g[variant][amount * Word::BITS + bit] += folded_bit * acc(key)
@@ -195,11 +190,12 @@ pub fn build_g_parts_from_folded_words<F: BinaryField, A: Allocator>(
 				&operator_data.lambda_powers,
 			);
 
-			// The key id is `(variant << Word::LOG_BITS) | amount`, so its variant selects the
-			// multilinear and its shift amount the bit slots within that multilinear.
-			let variant = key.id as usize >> Word::LOG_BITS;
-			let amount_base = (key.id as usize & (Word::BITS - 1)) * Word::BITS;
-			let slots = &mut multilinears[variant].as_mut()[amount_base..amount_base + Word::BITS];
+			// The key's shift variant selects the multilinear, and its shift amount the bit slots
+			// within that multilinear.
+			let (variant, amount) = segment.dense_shift_enc.decode(key.dense_shift_idx as usize);
+			let amount_base = amount as usize * Word::BITS;
+			let slots =
+				&mut multilinears[variant as usize].as_mut()[amount_base..amount_base + Word::BITS];
 
 			// Scatter the accumulator across this key's bit slots, scaling each by the folded bit.
 			for (slot, &folded_bit) in iter::zip(slots, word) {

--- a/crates/prover/benches/shift_reduction.rs
+++ b/crates/prover/benches/shift_reduction.rs
@@ -101,6 +101,11 @@ fn bench_prove_and_verify(c: &mut Criterion) {
 				.map(F::new)
 				.collect::<Vec<_>>()
 		};
+		// The circuit's digest assertions lower to ZERO constraints, so the Zero reduction runs
+		// over its own constraint point, as wide as the ZERO set.
+		let r_x_prime_zero = (0..cs.log_zero_constraints().unwrap_or(0) as u128)
+			.map(F::new)
+			.collect::<Vec<_>>();
 		// SHA256 has no IMUL constraints, so the IntMul operator is the zero claim (four zero evals
 		// at an empty point), exactly as the real prover/verifier synthesize it (`prove.rs` /
 		// `verify.rs` `None` branch). Its `r_x_prime` is therefore empty.
@@ -109,6 +114,7 @@ fn bench_prove_and_verify(c: &mut Criterion) {
 		// Sample univariate eval point — shared across bitand and intmul operators.
 		let r_zhat_prime = F::random(&mut rng);
 
+		let zero_evals = [F::random(&mut rng)];
 		let bitand_evals = [F::random(&mut rng); 3];
 		let intmul_evals = [F::ZERO; 4];
 		let key_collection = build_key_collection(&cs);
@@ -123,6 +129,11 @@ fn bench_prove_and_verify(c: &mut Criterion) {
 			let pool = BufferPool::new();
 			let alloc = &pool;
 			b.iter(|| {
+				let prover_zero_data = OperatorData {
+					evals: zero_evals,
+					r_zhat_prime,
+					r_x_prime: r_x_prime_zero.clone(),
+				};
 				let prover_bitand_data = OperatorData {
 					evals: bitand_evals,
 					r_zhat_prime,
@@ -140,7 +151,7 @@ fn bench_prove_and_verify(c: &mut Criterion) {
 					&key_collection,
 					value_vec.combined_witness(),
 					OperatorClaims {
-						zero: OperatorData::zero_claim(r_zhat_prime),
+						zero: prover_zero_data,
 						bitand: prover_bitand_data,
 						intmul: prover_intmul_data,
 						binmul: OperatorData::zero_claim(r_zhat_prime),
@@ -153,6 +164,11 @@ fn bench_prove_and_verify(c: &mut Criterion) {
 		});
 
 		// Pre-run the prover to get the transcript for verifier benchmarking
+		let prover_zero_data = OperatorData {
+			evals: zero_evals,
+			r_zhat_prime,
+			r_x_prime: r_x_prime_zero.clone(),
+		};
 		let prover_bitand_data = OperatorData {
 			evals: bitand_evals,
 			r_zhat_prime,
@@ -170,7 +186,7 @@ fn bench_prove_and_verify(c: &mut Criterion) {
 			&key_collection,
 			value_vec.combined_witness(),
 			OperatorClaims {
-				zero: OperatorData::zero_claim(r_zhat_prime),
+				zero: prover_zero_data,
 				bitand: prover_bitand_data,
 				intmul: prover_intmul_data,
 				binmul: OperatorData::zero_claim(r_zhat_prime),
@@ -194,7 +210,7 @@ fn bench_prove_and_verify(c: &mut Criterion) {
 
 				verify(
 					&cs,
-					&VerifierOperatorData::new(Vec::new(), [F::ZERO]),
+					&VerifierOperatorData::new(r_x_prime_zero.clone(), zero_evals),
 					&verifier_bitand_data,
 					&verifier_intmul_data,
 					&verifier_binmul_data,
@@ -225,11 +241,17 @@ fn bench_shift_phases(c: &mut Criterion) {
 	let r_x_prime_bitand = (0..cs.log_and_constraints().unwrap_or(0) as u128)
 		.map(F::new)
 		.collect::<Vec<_>>();
+	// The circuit's digest assertions lower to ZERO constraints, so the Zero reduction runs over
+	// its own constraint point, as wide as the ZERO set.
+	let r_x_prime_zero = (0..cs.log_zero_constraints().unwrap_or(0) as u128)
+		.map(F::new)
+		.collect::<Vec<_>>();
 	// SHA256 has no IMUL constraints, so the IntMul operator is the zero claim at an empty point,
 	// matching the real prover (`prove.rs` `None` branch).
 	let r_x_prime_intmul: Vec<F> = Vec::new();
 	// `r_zhat_prime` is shared across the bitand and intmul operators.
 	let r_zhat_prime = F::random(&mut rng);
+	let zero_evals = [F::random(&mut rng)];
 	let bitand_evals = [F::random(&mut rng); 3];
 	let intmul_evals = [F::ZERO; 4];
 
@@ -239,10 +261,14 @@ fn bench_shift_phases(c: &mut Criterion) {
 
 	// Prepare the operator data. Lambda sampling is cheap and not part of any benched phase, so a
 	// random lambda (rather than one drawn from a transcript) yields realistic-magnitude data.
-	// SHA256 has no ZERO or BMUL constraints, so those two are zero claims at an empty point,
-	// matching the real prover (`prove.rs` `None` branch).
+	// SHA256 has no BMUL constraints, so that one is a zero claim at an empty point, matching the
+	// real prover (`prove.rs` `None` branch).
 	let prepared = OperatorClaims {
-		zero: OperatorData::zero_claim(r_zhat_prime),
+		zero: OperatorData {
+			evals: zero_evals,
+			r_zhat_prime,
+			r_x_prime: r_x_prime_zero,
+		},
 		bitand: OperatorData {
 			evals: bitand_evals,
 			r_zhat_prime,

--- a/crates/prover/src/protocols/shift/key_collection.rs
+++ b/crates/prover/src/protocols/shift/key_collection.rs
@@ -13,9 +13,24 @@ use binius_utils::{
 	checked_arithmetics::log2_ceil_usize,
 	serialization::{DeserializeBytes, SerializationError, SerializeBytes},
 };
+use binius_verifier::protocols::shift::SHIFT_VARIANT_COUNT;
 use bytes::{Buf, BufMut};
 
 use super::PreparedOperatorData;
+
+/// The number of shifts a key could name, over which [`shift_index`] is dense.
+const SHIFT_PAIR_COUNT: usize = SHIFT_VARIANT_COUNT * Word::BITS;
+
+/// Places a shift in the full space of `SHIFT_PAIR_COUNT` shifts, for the tables that build and
+/// invert a [`DenseShiftEncoding`].
+///
+/// # Panics
+///
+/// Panics if the shift amount is not below `Word::BITS`.
+fn shift_index((variant, amount): (ShiftVariant, u8)) -> usize {
+	assert!((amount as usize) < Word::BITS, "shift amount {amount} out of range");
+	variant as usize * Word::BITS + amount as usize
+}
 
 /// Represents the type of operations handled by the shift protocol.
 ///
@@ -40,16 +55,79 @@ pub enum Operation {
 	BinMul,
 }
 
-/// A `Key` specifies an operation, an identifier for a 2D matrix, and a range of constraint
-/// indices.
+/// A dense re-encoding of the shifts occurring in a key segment.
 ///
-/// The matrix encodes constraint information with respect exactly one operand of that operation,
-/// one shift variant, and one shift amount. Every `Key` corresponds to a unique word (not
-/// referenced) in the `Key`. The `range` specifies a range within a list of constraint indices,
-/// those constraint indices in which the word participates with respect to the key. If constraint
-/// index `i` is among the values within the range, that means the word participates in constraint
-/// `i` of operation `operation` as part of the operand encoded in the `id`, with the word shifted
-/// with the shift variant and amount also encoded in the `id`.
+/// A key names one of `SHIFT_PAIR_COUNT` shifts, of which a constraint system typically uses a few
+/// dozen. Encoding the shifts a segment does use as a contiguous range lets the prover size its
+/// per-shift tables by the shifts actually used rather than by the whole space.
+#[derive(Debug, Clone, Default)]
+pub struct DenseShiftEncoding {
+	/// The shift each dense index encodes, ordered by variant and then by amount.
+	shifts: Vec<(ShiftVariant, u8)>,
+}
+
+impl DenseShiftEncoding {
+	/// Builds the encoding of the shifts in an iterator, which need be neither sorted nor distinct.
+	///
+	/// # Panics
+	///
+	/// Panics if any shift amount is not below `Word::BITS`.
+	fn new(shifts: impl IntoIterator<Item = (ShiftVariant, u8)>) -> Self {
+		let mut used = [None; SHIFT_PAIR_COUNT];
+		for shift in shifts {
+			used[shift_index(shift)] = Some(shift);
+		}
+		Self {
+			shifts: used.into_iter().flatten().collect(),
+		}
+	}
+
+	/// The number of distinct shifts the segment uses.
+	pub const fn len(&self) -> usize {
+		self.shifts.len()
+	}
+
+	/// Whether the segment uses no shifted values at all.
+	pub const fn is_empty(&self) -> bool {
+		self.shifts.is_empty()
+	}
+
+	/// The shift a dense index encodes.
+	///
+	/// # Panics
+	///
+	/// Panics if the dense index is not below [`Self::len`].
+	#[inline]
+	pub fn decode(&self, dense_idx: usize) -> (ShiftVariant, u8) {
+		self.shifts[dense_idx]
+	}
+
+	/// The shifts the segment uses, in dense index order.
+	pub fn iter(&self) -> impl Iterator<Item = (ShiftVariant, u8)> + '_ {
+		self.shifts.iter().copied()
+	}
+
+	/// The dense index of every shift, for lookup while the keys are built.
+	///
+	/// The entries of the shifts the segment does not use are meaningless.
+	fn inverse(&self) -> [u16; SHIFT_PAIR_COUNT] {
+		let mut inverse = [0u16; SHIFT_PAIR_COUNT];
+		for (dense_idx, &shift) in self.shifts.iter().enumerate() {
+			inverse[shift_index(shift)] = dense_idx as u16;
+		}
+		inverse
+	}
+}
+
+/// A `Key` specifies an operation, a shift, and a range of constraint indices.
+///
+/// The key identifies a 2D matrix of constraint information: the constraints of one operation in
+/// which one witness word participates, shifted by one shift variant and one shift amount. Every
+/// `Key` corresponds to a unique word (not referenced in the `Key`). The `range` specifies a range
+/// within a list of constraint indices, those constraint indices in which the word participates
+/// with respect to the key. If constraint index `i` is among the values within the range, that
+/// means the word participates in constraint `i` of operation `operation`, as the operand that
+/// constraint index names, shifted by the variant and amount the key's shift index encodes.
 ///
 /// # Relationship to Formal Specification
 ///
@@ -60,30 +138,26 @@ pub enum Operation {
 ///
 /// # Structure
 ///
-/// - **Operation**: Constraint type (AND or IMUL)
-/// - **ID**: Packed encoding of operand index, shift variant, and shift amount
+/// - **Operation**: Constraint type (ZERO, AND, IMUL or BMUL)
+/// - **Dense shift index**: The shift variant and shift amount, as encoded by the segment
 /// - **Range**: Constraint indices where this shifted word appears
 ///
-/// # ID Encoding
+/// # Shift index encoding
 ///
-/// The `id` packs three values:
-/// - Operand index (which operand in the constraint)
-/// - Shift variant (logical left, logical right, arithmetic right)
-/// - Shift amount (0 to `Word::BITS-1` bits)
-///
-/// This ordering places shift information (fundamental to Binius64) in lower bits,
-/// with operation and operand data in higher bits. Future operations can simply extend
-/// the `id` range with higher bits without breaking the semantic meaning of lower bits.
+/// The shift index is an index into the [`DenseShiftEncoding`] of the [`KeySegment`] holding the
+/// key, which decodes it back to the shift variant and shift amount. Keys index the shifts their
+/// segment actually uses rather than the whole shift space, so a table the prover builds per shift
+/// is proportional to the former.
 ///
 /// # Performance Considerations
 ///
-/// The operation remains separate from `id` for cleaner code organization with no
-/// performance cost. During proving, only the operation needs extraction while
-/// the packed operand index, shift variant, and shift amount remain undifferentiated.
+/// The operation remains separate from the shift index for cleaner code organization with no
+/// performance cost. During proving, only the operation needs extraction; the shift index is used
+/// as it stands.
 #[derive(Debug, Clone)]
 pub struct Key {
 	pub operation: Operation,
-	pub id: u16,
+	pub dense_shift_idx: u16,
 	pub range: Range<u32>,
 }
 
@@ -193,6 +267,7 @@ impl Key {
 /// - **key_ranges**: For every word of the segment there is a range of keys within the `keys`
 ///   vector
 /// - **constraint_indices**: Flattened list of constraint indices referenced by the keys
+/// - **dense_shift_enc**: The `(shift variant, shift amount)` pairs the segment's keys name
 ///
 /// # Organization
 ///
@@ -205,6 +280,7 @@ pub struct KeySegment {
 	pub keys: Vec<Key>,
 	pub key_ranges: Vec<Range<u32>>,
 	pub constraint_indices: Vec<ConstraintIndex>,
+	pub dense_shift_enc: DenseShiftEncoding,
 }
 
 impl KeySegment {
@@ -258,7 +334,8 @@ impl KeyCollection {
 /// rather than a range that indexes into the flattened `constraint_indices` vector.
 /// During construction, these indices are later flattened to create the final `Key`.
 struct BuilderKey {
-	pub id: u16,
+	/// The `(shift variant, shift amount)` of the shifted value the key references.
+	pub shift: (ShiftVariant, u8),
 	pub operation: Operation,
 	pub constraint_indices: Vec<ConstraintIndex>,
 }
@@ -288,32 +365,21 @@ fn update_with_operand(
 		{
 			// Access and update the builder keys corresponding to the word index (`value_index.0`)
 			let builder_keys = &mut builder_key_lists[value_index.0 as usize];
-			// Encode (shift_variant, shift_amount) into a single ID
-			let shift_variant_val: u16 = match shift_variant {
-				ShiftVariant::Sll => 0,
-				ShiftVariant::Slr => 1,
-				ShiftVariant::Sar => 2,
-				ShiftVariant::Rotr => 3,
-				ShiftVariant::Sll32 => 4,
-				ShiftVariant::Srl32 => 5,
-				ShiftVariant::Sra32 => 6,
-				ShiftVariant::Rotr32 => 7,
-			};
-			let id = (shift_variant_val << Word::LOG_BITS) + *amount as u16;
+			let shift = (*shift_variant, *amount);
 
-			// Find existing builder key or create a new one for this (operation, id) pair
+			// Find existing builder key or create a new one for this (operation, shift) pair
 			let constraint_index = ConstraintIndex {
 				operand_index: operand_index as u8,
 				constraint_index: constraint_idx as u32,
 			};
 			if let Some(builder_key) = builder_keys
 				.iter_mut()
-				.find(|key| key.id == id && key.operation == operation)
+				.find(|key| key.shift == shift && key.operation == operation)
 			{
 				builder_key.constraint_indices.push(constraint_index);
 			} else {
 				builder_keys.push(BuilderKey {
-					id,
+					shift,
 					operation,
 					constraint_indices: vec![constraint_index],
 				});
@@ -367,8 +433,16 @@ pub fn build_key_collection(cs: &ConstraintSystem) -> KeyCollection {
 	}
 }
 
-/// Computes all three fields of a [`KeySegment`] from the builder keys lists of its words.
+/// Computes all fields of a [`KeySegment`] from the builder keys lists of its words.
 fn build_key_segment(builder_key_lists: Vec<Vec<BuilderKey>>) -> KeySegment {
+	let dense_shift_enc = DenseShiftEncoding::new(
+		builder_key_lists
+			.iter()
+			.flatten()
+			.map(|builder_key| builder_key.shift),
+	);
+	let dense_shift_idx = dense_shift_enc.inverse();
+
 	let key_ranges = builder_key_lists
 		.iter()
 		.scan(0u32, |offset, builder_keys| {
@@ -383,7 +457,7 @@ fn build_key_segment(builder_key_lists: Vec<Vec<BuilderKey>>) -> KeySegment {
 
 	for builder_key in builder_key_lists.into_iter().flatten() {
 		let BuilderKey {
-			id,
+			shift,
 			operation,
 			constraint_indices: mut builder_constraint_indices,
 		} = builder_key;
@@ -395,7 +469,7 @@ fn build_key_segment(builder_key_lists: Vec<Vec<BuilderKey>>) -> KeySegment {
 		constraint_indices.extend(builder_constraint_indices);
 		let end = constraint_indices.len() as u32;
 		keys.push(Key {
-			id,
+			dense_shift_idx: dense_shift_idx[shift_index(shift)],
 			operation,
 			range: start..end,
 		});
@@ -405,6 +479,7 @@ fn build_key_segment(builder_key_lists: Vec<Vec<BuilderKey>>) -> KeySegment {
 		keys,
 		key_ranges,
 		constraint_indices,
+		dense_shift_enc,
 	}
 }
 
@@ -441,7 +516,7 @@ impl DeserializeBytes for Operation {
 impl SerializeBytes for Key {
 	fn serialize(&self, mut write_buf: impl BufMut) -> Result<(), SerializationError> {
 		self.operation.serialize(&mut write_buf)?;
-		self.id.serialize(&mut write_buf)?;
+		self.dense_shift_idx.serialize(&mut write_buf)?;
 		self.range.start.serialize(&mut write_buf)?;
 		self.range.end.serialize(write_buf)
 	}
@@ -450,12 +525,12 @@ impl SerializeBytes for Key {
 impl DeserializeBytes for Key {
 	fn deserialize(mut read_buf: impl Buf) -> Result<Self, SerializationError> {
 		let operation = Operation::deserialize(&mut read_buf)?;
-		let id = u16::deserialize(&mut read_buf)?;
+		let dense_shift_idx = u16::deserialize(&mut read_buf)?;
 		let start = u32::deserialize(&mut read_buf)?;
 		let end = u32::deserialize(&mut read_buf)?;
 		Ok(Key {
 			operation,
-			id,
+			dense_shift_idx,
 			range: start..end,
 		})
 	}
@@ -479,6 +554,46 @@ impl DeserializeBytes for ConstraintIndex {
 	}
 }
 
+impl SerializeBytes for DenseShiftEncoding {
+	fn serialize(&self, mut write_buf: impl BufMut) -> Result<(), SerializationError> {
+		(self.shifts.len() as u32).serialize(&mut write_buf)?;
+		for (variant, amount) in &self.shifts {
+			variant.serialize(&mut write_buf)?;
+			amount.serialize(&mut write_buf)?;
+		}
+		Ok(())
+	}
+}
+
+impl DeserializeBytes for DenseShiftEncoding {
+	fn deserialize(mut read_buf: impl Buf) -> Result<Self, SerializationError> {
+		let len = u32::deserialize(&mut read_buf)? as usize;
+		let mut shifts = Vec::with_capacity(len);
+		for _ in 0..len {
+			let variant = ShiftVariant::deserialize(&mut read_buf)?;
+			let amount = u8::deserialize(&mut read_buf)?;
+			shifts.push((variant, amount));
+		}
+
+		// A dense index is only meaningful against a list of distinct shifts, which the ordering
+		// this writes them in also gives.
+		let amounts_in_range = shifts
+			.iter()
+			.all(|&(_, amount)| (amount as usize) < Word::BITS);
+		if !amounts_in_range
+			|| !shifts
+				.windows(2)
+				.all(|shifts| shift_index(shifts[0]) < shift_index(shifts[1]))
+		{
+			return Err(SerializationError::InvalidConstruction {
+				name: "DenseShiftEncoding::shifts",
+			});
+		}
+
+		Ok(DenseShiftEncoding { shifts })
+	}
+}
+
 impl SerializeBytes for KeySegment {
 	fn serialize(&self, mut write_buf: impl BufMut) -> Result<(), SerializationError> {
 		self.keys.serialize(&mut write_buf)?;
@@ -490,7 +605,8 @@ impl SerializeBytes for KeySegment {
 			range.end.serialize(&mut write_buf)?;
 		}
 
-		self.constraint_indices.serialize(write_buf)
+		self.constraint_indices.serialize(&mut write_buf)?;
+		self.dense_shift_enc.serialize(write_buf)
 	}
 }
 
@@ -508,19 +624,21 @@ impl DeserializeBytes for KeySegment {
 		}
 
 		let constraint_indices = Vec::<ConstraintIndex>::deserialize(&mut read_buf)?;
+		let dense_shift_enc = DenseShiftEncoding::deserialize(&mut read_buf)?;
 
 		Ok(KeySegment {
 			keys,
 			key_ranges,
 			constraint_indices,
+			dense_shift_enc,
 		})
 	}
 }
 
 impl SerializeBytes for KeyCollection {
 	fn serialize(&self, mut write_buf: impl BufMut) -> Result<(), SerializationError> {
-		// Version for forward compatibility; version 2 introduced the public/non-public split.
-		const VERSION: u32 = 2;
+		// Version for forward compatibility; version 3 introduced the dense shift encoding.
+		const VERSION: u32 = 3;
 		VERSION.serialize(&mut write_buf)?;
 
 		self.public.serialize(&mut write_buf)?;
@@ -530,7 +648,7 @@ impl SerializeBytes for KeyCollection {
 
 impl DeserializeBytes for KeyCollection {
 	fn deserialize(mut read_buf: impl Buf) -> Result<Self, SerializationError> {
-		const VERSION: u32 = 2;
+		const VERSION: u32 = 3;
 		let version = u32::deserialize(&mut read_buf)?;
 		if version != VERSION {
 			return Err(SerializationError::InvalidConstruction {
@@ -547,6 +665,7 @@ impl DeserializeBytes for KeyCollection {
 
 #[cfg(test)]
 mod tests {
+	use binius_core::constraint_system::{AndConstraint, ValueIndex};
 	use binius_field::{BinaryField128bGhash, Field};
 	use binius_math::FieldBuffer;
 
@@ -556,6 +675,145 @@ mod tests {
 
 	fn f(value: u128) -> F {
 		F::new(value)
+	}
+
+	/// A constraint system with a handful of distinct shifts, differing between the two segments.
+	///
+	/// The public segment references `(Sll, 0)` and `(Slr, 3)`; the hidden one references
+	/// `(Sll, 0)`, `(Sar, 7)` and `(Rotr, 1)`.
+	fn shifted_constraint_system() -> ConstraintSystem {
+		let public = ValueIndex(1);
+		let hidden = ValueIndex(5);
+		ConstraintSystem {
+			constants: vec![Word::ZERO; 4],
+			n_const_pad: 0,
+			n_inout: 0,
+			n_inout_pad: 0,
+			n_private: 4,
+			n_private_pad: 0,
+			zero_constraints: Vec::new(),
+			and_constraints: vec![AndConstraint([
+				vec![
+					ShiftedValueIndex::plain(public),
+					ShiftedValueIndex::srl(public, 3),
+				],
+				vec![ShiftedValueIndex::sar(hidden, 7)],
+				vec![
+					ShiftedValueIndex::rotr(hidden, 1),
+					ShiftedValueIndex::plain(hidden),
+				],
+			])],
+			imul_constraints: Vec::new(),
+			bmul_constraints: Vec::new(),
+		}
+	}
+
+	#[test]
+	fn dense_shift_encoding_covers_the_pairs_its_segment_uses() {
+		let key_collection = build_key_collection(&shifted_constraint_system());
+
+		let public_pairs = key_collection
+			.public
+			.dense_shift_enc
+			.iter()
+			.collect::<Vec<_>>();
+		assert_eq!(public_pairs, [(ShiftVariant::Sll, 0), (ShiftVariant::Slr, 3)]);
+
+		let hidden_pairs = key_collection
+			.hidden
+			.dense_shift_enc
+			.iter()
+			.collect::<Vec<_>>();
+		assert_eq!(
+			hidden_pairs,
+			[
+				(ShiftVariant::Sll, 0),
+				(ShiftVariant::Sar, 7),
+				(ShiftVariant::Rotr, 1),
+			]
+		);
+
+		// The point of the encoding: a segment names far fewer pairs than the space holds.
+		assert!(key_collection.hidden.dense_shift_enc.len() < SHIFT_PAIR_COUNT);
+	}
+
+	#[test]
+	fn keys_index_their_segments_dense_encoding() {
+		let key_collection = build_key_collection(&shifted_constraint_system());
+
+		// The shifts a word's keys name, as its own segment's encoding decodes them.
+		let word_pairs = |segment: &KeySegment, word: usize| {
+			let mut pairs = segment
+				.word_keys(word)
+				.iter()
+				.map(|key| segment.dense_shift_enc.decode(key.dense_shift_idx as usize))
+				.collect::<Vec<_>>();
+			pairs.sort();
+			pairs
+		};
+
+		// Value index 1 is the second public word; value index 5 the second hidden one.
+		assert_eq!(
+			word_pairs(&key_collection.public, 1),
+			[(ShiftVariant::Sll, 0), (ShiftVariant::Slr, 3)]
+		);
+		assert_eq!(
+			word_pairs(&key_collection.hidden, 1),
+			[
+				(ShiftVariant::Sll, 0),
+				(ShiftVariant::Sar, 7),
+				(ShiftVariant::Rotr, 1),
+			]
+		);
+	}
+
+	#[test]
+	fn dense_shift_encoding_survives_serialization() {
+		let key_collection = build_key_collection(&shifted_constraint_system());
+
+		let mut buf = Vec::new();
+		key_collection.serialize(&mut buf).unwrap();
+		let deserialized = KeyCollection::deserialize(buf.as_slice()).unwrap();
+
+		for (segment, deserialized) in [
+			(&key_collection.public, &deserialized.public),
+			(&key_collection.hidden, &deserialized.hidden),
+		] {
+			assert_eq!(
+				segment.dense_shift_enc.iter().collect::<Vec<_>>(),
+				deserialized.dense_shift_enc.iter().collect::<Vec<_>>()
+			);
+		}
+	}
+
+	#[test]
+	fn dense_shift_encoding_rejects_an_unordered_serialization() {
+		let encoding = DenseShiftEncoding {
+			shifts: vec![(ShiftVariant::Slr, 3), (ShiftVariant::Sll, 0)],
+		};
+
+		let mut buf = Vec::new();
+		encoding.serialize(&mut buf).unwrap();
+
+		assert!(matches!(
+			DenseShiftEncoding::deserialize(buf.as_slice()),
+			Err(SerializationError::InvalidConstruction { .. })
+		));
+	}
+
+	#[test]
+	fn dense_shift_encoding_rejects_an_out_of_range_shift_amount() {
+		let encoding = DenseShiftEncoding {
+			shifts: vec![(ShiftVariant::Sll, Word::BITS as u8)],
+		};
+
+		let mut buf = Vec::new();
+		encoding.serialize(&mut buf).unwrap();
+
+		assert!(matches!(
+			DenseShiftEncoding::deserialize(buf.as_slice()),
+			Err(SerializationError::InvalidConstruction { .. })
+		));
 	}
 
 	#[test]
@@ -584,7 +842,7 @@ mod tests {
 		];
 		let key = Key {
 			operation: Operation::BitwiseAnd,
-			id: 0,
+			dense_shift_idx: 0,
 			range: 0..constraint_indices.len() as u32,
 		};
 		let operator_data = PreparedOperatorData {
@@ -641,7 +899,7 @@ mod tests {
 		];
 		let non_contiguous_key = Key {
 			operation: Operation::BitwiseAnd,
-			id: 0,
+			dense_shift_idx: 0,
 			range: 0..non_contiguous_constraint_indices.len() as u32,
 		};
 		let non_contiguous_expected = non_contiguous_key
@@ -660,7 +918,7 @@ mod tests {
 
 		let empty_key = Key {
 			operation: Operation::BitwiseAnd,
-			id: 0,
+			dense_shift_idx: 0,
 			range: 0..0,
 		};
 		assert_eq!(

--- a/crates/prover/src/protocols/shift/mod.rs
+++ b/crates/prover/src/protocols/shift/mod.rs
@@ -17,5 +17,7 @@ pub mod phase_2;
 mod prove;
 
 pub use claims::{OperatorClaims, PreparedOperatorClaims};
-pub use key_collection::{KeyCollection, KeySegment, Operation, build_key_collection};
+pub use key_collection::{
+	DenseShiftEncoding, KeyCollection, KeySegment, Operation, build_key_collection,
+};
 pub use prove::{OperatorData, PreparedOperatorData, prove};

--- a/crates/prover/src/protocols/shift/monster.rs
+++ b/crates/prover/src/protocols/shift/monster.rs
@@ -20,8 +20,19 @@ use tracing::instrument;
 use super::{
 	SHIFT_VARIANT_COUNT,
 	claims::PreparedOperatorClaims,
-	key_collection::{KeyCollection, KeySegment, Operation},
+	key_collection::{DenseShiftEncoding, KeyCollection, KeySegment, Operation},
 };
+
+/// The phase-2 scalar weights of one key segment, one table per operation.
+///
+/// A table holds the `arity` weights of each shift the segment uses, in dense shift index order,
+/// so a key's weights are the chunk at `key.dense_shift_idx * arity`.
+struct ScalarTables<F> {
+	zero: Vec<F>,
+	bitand: Vec<F>,
+	intmul: Vec<F>,
+	binmul: Vec<F>,
+}
 
 /// Constructs the three "h" multilinear polynomials for shift operations at a
 /// univariate challenge point. See the paper for definition of h polynomials.
@@ -127,11 +138,12 @@ where
 ///
 /// For each word w, computes:
 /// ```text
-/// ∑_{key ∈ keys[w]} key.accumulate(constraint_indices, tensor, scalars[key.id])
+/// ∑_{key ∈ keys[w]} key.accumulate(constraint_indices, tensor, scalars[key.dense_shift_idx])
 /// ```
-/// where `scalars[key.id]` is the contiguous per-operand chunk encoding
+/// where `scalars[key.dense_shift_idx]` is the contiguous per-operand chunk encoding
 /// `λ^(operand_idx+1) × h_op[shift_variant] × r_s_tensor[shift_amount]` for operand index
-/// `operand_idx` and `shift_variant` in {SLL, SRL, SRA} and `shift_amount` in [0, Word::BITS).
+/// `operand_idx`, and `(shift_variant, shift_amount)` the pair the key's segment decodes its dense
+/// shift index to.
 ///
 /// # Usage
 ///
@@ -165,62 +177,60 @@ where
 
 	let r_s_tensor = eq_ind_partial_eval::<F>(r_s);
 
-	// Allocate and populate the scalars, laid out with the operand index innermost so that the
-	// `arity` weights for one `key.id` (= `op * Word::BITS + s`) form a contiguous chunk that
-	// [`Key::accumulate`] can index directly by operand index.
-	let mut zero_scalars = vec![F::ZERO; ZERO_ARITY * SHIFT_VARIANT_COUNT * Word::BITS];
-	let mut bitand_scalars = vec![F::ZERO; BITAND_ARITY * SHIFT_VARIANT_COUNT * Word::BITS];
-	let mut intmul_scalars = vec![F::ZERO; INTMUL_ARITY * SHIFT_VARIANT_COUNT * Word::BITS];
-	let mut binmul_scalars = vec![F::ZERO; BINMUL_ARITY * SHIFT_VARIANT_COUNT * Word::BITS];
-
-	let populate_scalars = |scalars: &mut [F], arity: usize, lambda_powers: &[F], h_ops: &[F]| {
-		for op in 0..SHIFT_VARIANT_COUNT {
-			for s in 0..Word::BITS {
-				let key_id = op * Word::BITS + s;
-				let op_s_scalar = h_ops[op] * r_s_tensor.as_ref()[s];
+	// The scalars of one operation, laid out with the operand index innermost so that the `arity`
+	// weights for one `key.dense_shift_idx` form a contiguous chunk that [`Key::accumulate_wide`]
+	// can index directly by operand index.
+	let build_scalars =
+		|arity: usize, lambda_powers: &[F], h_ops: &[F], dense_shift_enc: &DenseShiftEncoding| {
+			let mut scalars = vec![F::ZERO; arity * dense_shift_enc.len()];
+			for (dense_shift_idx, (variant, amount)) in dense_shift_enc.iter().enumerate() {
+				let shift_scalar = h_ops[variant as usize] * r_s_tensor.as_ref()[amount as usize];
 				for operand_idx in 0..arity {
-					scalars[key_id * arity + operand_idx] =
-						lambda_powers[operand_idx] * op_s_scalar;
+					scalars[dense_shift_idx * arity + operand_idx] =
+						lambda_powers[operand_idx] * shift_scalar;
 				}
 			}
-		}
-	};
+			scalars
+		};
 
-	populate_scalars(&mut zero_scalars, ZERO_ARITY, &prepared.zero.lambda_powers, &zero_h_ops);
-	populate_scalars(
-		&mut bitand_scalars,
-		BITAND_ARITY,
-		&prepared.bitand.lambda_powers,
-		&bitand_h_ops,
-	);
-	populate_scalars(
-		&mut intmul_scalars,
-		INTMUL_ARITY,
-		&prepared.intmul.lambda_powers,
-		&intmul_h_ops,
-	);
-	populate_scalars(
-		&mut binmul_scalars,
-		BINMUL_ARITY,
-		&prepared.binmul.lambda_powers,
-		&binmul_h_ops,
-	);
+	// Each segment has its own dense shift encoding, so it has its own scalar tables.
+	let build_scalar_tables = |dense_shift_enc: &DenseShiftEncoding| ScalarTables {
+		zero: build_scalars(ZERO_ARITY, &prepared.zero.lambda_powers, &zero_h_ops, dense_shift_enc),
+		bitand: build_scalars(
+			BITAND_ARITY,
+			&prepared.bitand.lambda_powers,
+			&bitand_h_ops,
+			dense_shift_enc,
+		),
+		intmul: build_scalars(
+			INTMUL_ARITY,
+			&prepared.intmul.lambda_powers,
+			&intmul_h_ops,
+			dense_shift_enc,
+		),
+		binmul: build_scalars(
+			BINMUL_ARITY,
+			&prepared.binmul.lambda_powers,
+			&binmul_h_ops,
+			dense_shift_enc,
+		),
+	};
 
 	// The scalar for one word of a segment: the accumulated contribution of all its keys. The
 	// per-key wide accumulations are summed unreduced and reduced once at the end.
-	let word_scalar = |segment: &KeySegment, index: usize| {
+	let word_scalar = |segment: &KeySegment, tables: &ScalarTables<F>, index: usize| {
 		let wide = segment
 			.word_keys(index)
 			.iter()
 			.map(|key| {
 				// The scalar table is per operation, and its stride is that operation's arity.
 				let (scalars, arity) = match key.operation {
-					Operation::Zero => (&zero_scalars, ZERO_ARITY),
-					Operation::BitwiseAnd => (&bitand_scalars, BITAND_ARITY),
-					Operation::IntegerMul => (&intmul_scalars, INTMUL_ARITY),
-					Operation::BinMul => (&binmul_scalars, BINMUL_ARITY),
+					Operation::Zero => (&tables.zero, ZERO_ARITY),
+					Operation::BitwiseAnd => (&tables.bitand, BITAND_ARITY),
+					Operation::IntegerMul => (&tables.intmul, INTMUL_ARITY),
+					Operation::BinMul => (&tables.binmul, BINMUL_ARITY),
 				};
-				let base = key.id as usize * arity;
+				let base = key.dense_shift_idx as usize * arity;
 				key.accumulate_wide(
 					&segment.constraint_indices,
 					prepared[key.operation].r_x_prime_tensor.as_ref(),
@@ -234,6 +244,7 @@ where
 	// Each segment sits at the base of its buffer: the public piece fills its power-of-two
 	// length exactly, the hidden piece is zero-padded up to the hidden segment length.
 	let build_segment = |segment: &KeySegment, log_len: usize| {
+		let tables = build_scalar_tables(&segment.dense_shift_enc);
 		let capacity = 1 << log_len.saturating_sub(P::LOG_WIDTH);
 		let n_words = segment.n_words();
 		// Full packed elements: each maps exactly `P::WIDTH` words, so `from_scalars` sees a
@@ -248,14 +259,16 @@ where
 			.enumerate()
 			.for_each(|(chunk_index, slot)| {
 				let start = chunk_index * P::WIDTH;
-				slot.write(P::from_scalars((0..P::WIDTH).map(|i| word_scalar(segment, start + i))));
+				slot.write(P::from_scalars(
+					(0..P::WIDTH).map(|i| word_scalar(segment, &tables, start + i)),
+				));
 			});
 		// Safety: the parallel loop above initialized every one of the `n_full` slots.
 		unsafe { values.set_len(n_full) };
 		if !n_words.is_multiple_of(P::WIDTH) {
 			let start = n_full * P::WIDTH;
 			values.push(P::from_scalars(
-				(start..n_words).map(|word_index| word_scalar(segment, word_index)),
+				(start..n_words).map(|word_index| word_scalar(segment, &tables, word_index)),
 			));
 		}
 		values.resize(capacity, P::default());

--- a/crates/prover/src/protocols/shift/phase_1.rs
+++ b/crates/prover/src/protocols/shift/phase_1.rs
@@ -1,9 +1,9 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-use std::{iter, ops::Range};
+use std::{array, iter, ops::Range};
 
-use binius_compute::{Allocator, VecLike};
+use binius_compute::Allocator;
 use binius_core::word::Word;
 use binius_field::{BinaryField, Field, PackedField};
 use binius_ip::sumcheck::{SumcheckOutput, common::RoundCoeffs};
@@ -20,7 +20,7 @@ use tracing::instrument;
 
 use super::{
 	claims::PreparedOperatorClaims,
-	key_collection::{KeyCollection, KeySegment},
+	key_collection::{DenseShiftEncoding, KeyCollection, KeySegment},
 	monster::build_h_parts,
 };
 
@@ -161,9 +161,8 @@ pub fn run_phase_1_sumcheck<
 /// segment.
 ///
 /// This builds the g multilinear polynomials used in phase 1 of the shift protocol, over the words
-/// of a single value-vector segment (public or hidden). For each operation (BITAND and INTMUL) it
-/// constructs three multilinear polynomials corresponding to the three shift variants (SLL, SRL,
-/// SRA).
+/// of a single value-vector segment (public or hidden). It constructs one multilinear polynomial
+/// per shift variant.
 ///
 /// The value vector's public and hidden words participate through their own [`KeySegment`], so a
 /// caller builds each segment's parts with the matching words and sums the two results.
@@ -176,9 +175,14 @@ pub fn run_phase_1_sumcheck<
 /// 4. **Word Expansion**: Expand each witness word bitwise to populate the g multilinears
 /// 5. **Lambda Weighting**: Apply lambda powers to weight different operand positions
 ///
+/// The accumulator holds one row of `Word::BITS` scalars per shift the segment uses, addressed by
+/// the keys' dense shift index. A scatter through the segment's encoding then spreads those rows
+/// over the full `(shift variant, shift amount)` space of the returned parts.
+///
 /// # Returns
 ///
-/// An array of multilinear extensions of each shift variant part.
+/// An array of multilinear extensions of each shift variant part. Within a part, the rows of
+/// `Word::BITS` scalars run in order of shift amount.
 ///
 /// # Usage
 ///
@@ -191,7 +195,9 @@ pub fn build_g_parts<F: BinaryField, P: PackedField<Scalar = F>, A: Allocator>(
 	segment: &KeySegment,
 	prepared: &PreparedOperatorClaims<F>,
 ) -> [FieldVec<P, A>; SHIFT_VARIANT_COUNT] {
-	let acc_size: usize = SHIFT_VARIANT_COUNT << (LOG_LEN.saturating_sub(P::LOG_WIDTH));
+	// One row of `Word::BITS` scalars per shift the segment uses.
+	let row_len = Word::BITS >> P::LOG_WIDTH;
+	let acc_size = segment.dense_shift_enc.len() * row_len;
 
 	const {
 		assert!(
@@ -233,8 +239,12 @@ pub fn build_g_parts<F: BinaryField, P: PackedField<Scalar = F>, A: Allocator>(
 					//         values[start + i] += acc;
 					//     }
 					// }
-					let start = key.id as usize * (Word::BITS >> P::LOG_WIDTH);
-					let values = &mut multilinears[start..start + (Word::BITS >> P::LOG_WIDTH)];
+					debug_assert!(
+						(key.dense_shift_idx as usize) < segment.dense_shift_enc.len(),
+						"a key indexes the dense shift encoding of its own segment"
+					);
+					let start = key.dense_shift_idx as usize * row_len;
+					let values = &mut multilinears[start..start + row_len];
 					let values_per_byte = Word::BYTES >> P::LOG_WIDTH;
 					let mut remaining_word = word.0;
 					let mut byte_index = 0;
@@ -280,35 +290,39 @@ pub fn build_g_parts<F: BinaryField, P: PackedField<Scalar = F>, A: Allocator>(
 		// An empty word list yields no partials at all, and its parts are zero.
 		.unwrap_or_else(|| zeroed_vec::<P>(acc_size).into_boxed_slice());
 
-	build_multilinear_parts(alloc, &multilinears)
+	scatter_multilinear_parts(alloc, &multilinears, &segment.dense_shift_enc)
 }
 
-/// Builds the multilinear parts for a single operation by combining its operand multilinears.
+/// Spreads the rows of a dense phase-1 accumulator over the multilinear parts of every shift
+/// variant.
 ///
-/// Takes the raw multilinears for all operands and shift variants of an operation,
-/// applies lambda weighting to each operand, and combines them into parts.
-/// Each operand of index `i` gets weighted by λ^(i+1).
-#[instrument(skip_all, name = "build_multilinear_parts")]
-fn build_multilinear_parts<P: PackedField, A: Allocator>(
+/// The accumulator holds the rows of `Word::BITS` scalars the segment's keys accumulate into, one
+/// per shift the segment uses and in dense shift index order. Each row lands in the part of its
+/// shift variant, at the offset its shift amount names; every row the segment does not use stays
+/// zero.
+#[instrument(skip_all, name = "scatter_multilinear_parts")]
+fn scatter_multilinear_parts<P: PackedField, A: Allocator>(
 	alloc: &A,
 	multilinears: &[P],
+	dense_shift_enc: &DenseShiftEncoding,
 ) -> [FieldVec<P, A>; SHIFT_VARIANT_COUNT] {
 	const {
 		assert!(
-			P::LOG_WIDTH < LOG_LEN,
+			P::LOG_WIDTH <= Word::LOG_BITS,
 			"P::WIDTH is not supposed to exceed 8, so this statement must hold"
 		);
 	}
 
-	multilinears
-		.chunks(1 << (LOG_LEN - P::LOG_WIDTH))
-		.map(|chunk| {
-			// Build each part straight into the allocator's buffer rather than into a `Vec` copy.
-			let mut data = alloc.alloc::<P>(chunk.len());
-			data.extend_from_slice(chunk);
-			FieldBuffer::new(LOG_LEN, data)
-		})
-		.collect::<Vec<_>>()
-		.try_into()
-		.unwrap_or_else(|_| panic!("chunk has SHIFT_VARIANT_COUNT parts of size 1 << LOG_LEN"))
+	// A row is a whole number of packed elements, so it copies into a part at row alignment.
+	let row_len = Word::BITS >> P::LOG_WIDTH;
+	let mut parts =
+		array::from_fn::<_, SHIFT_VARIANT_COUNT, _>(|_| FieldBuffer::zeros_in(alloc, LOG_LEN));
+	for ((variant, amount), row) in iter::zip(dense_shift_enc.iter(), multilinears.chunks(row_len))
+	{
+		// Dense indices are distinct, so no two rows land in the same place and each destination
+		// is still zero.
+		parts[variant as usize].as_mut()[amount as usize * row_len..][..row_len]
+			.copy_from_slice(row);
+	}
+	parts
 }


### PR DESCRIPTION
Closes [BINIUS-397](https://linear.app/jimpo/issue/BINIUS-397/dense-shift-encoding-for-the-phase-1-g-accumulator).

`build_g_parts` accumulated into a buffer covering the whole `(shift variant, shift amount)` space — 8 variants × 64 amounts = 512 rows of 64 scalars, or 512 KiB over `B128` — allocated and zeroed once per rayon fold partial, then summed again in `reduce_with`. A constraint system uses a few dozen of those rows, so nearly all of that traffic was over zeros.

Each key segment now records the pairs it actually uses, and its keys index that dense encoding. The phase-1 accumulator holds one row per pair used; a scatter through the encoding restores the sparse layout callers expect. Phase 2's per-operation scalar tables shrink the same way, and become per segment since the encoding is.

The returned `g` parts are bit-identical, so proofs are byte-identical — the transcript is unaffected.

### Commits

1. **Give the shift-reduction bench a real ZERO claim** — a pre-existing bug found while measuring, unrelated to the rest: `benches/shift_reduction.rs` hands the ZERO operator `OperatorData::zero_claim`, whose contract is *an operation the constraint system does not use*, while the SHA256 circuit it benchmarks asserts its digest and those assertions lower to ZERO constraints. Both bench functions panic on `main` (`index out of bounds` in `Key::accumulate_wide`, indexing a length-1 tensor). It sits at the bottom of the stack because the issue's verification plan runs this bench. Happy to split it out if you'd rather.
2. **Add a dense shift encoding to each key segment** — the `DenseShiftEncoding` type, a `KeySegment` field, serialization, `KeyCollection::VERSION` 2 → 3. Purely additive; keys still carry the sparse id.
3. **Index shift keys by a dense shift index** — `Key::id` → `Key::dense_shift_idx`, and the three consumers move over. The rename is deliberate: `key.id * stride` is textually valid under either meaning, so every use had to be a compile error until audited.

### Sizes, on the SHA256 circuit over a 16 KiB message

| segment | pairs used (of 512) | phase-1 accumulator, per fold partial |
|---|---|---|
| public | 8 | 512 KiB → 8 KiB |
| hidden | 16 | 512 KiB → 16 KiB |

Both now fit comfortably in L2 instead of evicting it. The phase-2 scalar tables shrink by the same factor.

### Compatibility

The `VERSION` bump rejects prebuilt key-collection files and serialized ZK bundles (`crates/examples/src/cli.rs`, `crates/prover/src/zk_config.rs`) — they must be regenerated. That is an explicit deserialization error, not silent corruption.

### Verification

- `cargo test --workspace` green, including the transcript round-trips (`crates/prover/tests/prove_verify.rs`) and the m4 cross-check of `build_g_parts` against the folded builder.
- Four new unit tests in `key_collection.rs`: the encoding covers exactly the pairs its segment uses, keys index their own segment's encoding, the encoding survives serialization, and a non-ascending encoding is rejected on deserialization.
- `cargo clippy --all --tests --benches --examples -- -D warnings`, `cargo +nightly-2026-07-01 fmt`, `cargo doc` clean.
- Benchmarks in a comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)