### PR TITLE
Revert "Split the round pass's parallelize and granularity decisions" (#1979)

### DIFF
--- a/crates/ip-prover/src/sumcheck/round_evaluator.rs
+++ b/crates/ip-prover/src/sumcheck/round_evaluator.rs
@@ -139,45 +139,11 @@ pub trait MleCheckRoundEvaluator<F: Field, P: PackedField<Scalar = F>>: Send + S
 	) -> RoundCoeffs<F>;
 }
 
-/// Largest round the pass walks in one sequential leaf.
+/// Maximum log2 chunk size of the parallel round pass.
 ///
-/// - The equality-indicator chunk of a round this size stays in L1 while every evaluator reads it.
-/// - A caller outside the pool parks and wakes to dispatch one leaf.
-/// - So splitting a round this small costs more than walking it.
+/// Chunked accumulation keeps the equality-indicator chunk resident in L1 cache while all
+/// evaluators read it, mirroring the chunking of the pre-store quadratic prover.
 const MAX_CHUNK_VARS: usize = 12;
-
-/// Leaf size of a round pass that is split across the pool.
-///
-/// - Well below [`MAX_CHUNK_VARS`], so a split round becomes many small leaves.
-/// - Work-stealing can then even out cores that retire a leaf at different speeds.
-/// - Roughly one leaf per core would leave it nothing to steal.
-///
-/// Tuned on an Apple M1 Pro, whose 8 performance and 2 efficiency cores make that imbalance large.
-const PAR_CHUNK_VARS: usize = 8;
-
-/// Chunk size of one round's read pass over the halved hypercube.
-///
-/// The two constants answer separate questions.
-/// [`MAX_CHUNK_VARS`] decides whether to split the round at all.
-/// [`PAR_CHUNK_VARS`] decides how finely, once it is split.
-///
-/// ```text
-///     halved = n_vars_remaining - 1           a round reads a halved hypercube
-///
-///     halved <= MAX_CHUNK_VARS  ->  chunk = halved           one leaf, no bisection
-///     halved >  MAX_CHUNK_VARS  ->  chunk = PAR_CHUNK_VARS   2^(halved - chunk) leaves
-/// ```
-///
-/// Both constants are floored at the packing width, so a leaf never narrows below one packed word.
-fn chunk_vars_for<P: PackedField>(n_vars_remaining: usize) -> usize {
-	let halved = n_vars_remaining - 1;
-	let sequential_cap = MAX_CHUNK_VARS.max(P::LOG_WIDTH);
-	if halved <= sequential_cap {
-		halved
-	} else {
-		PAR_CHUNK_VARS.max(P::LOG_WIDTH)
-	}
-}
 
 /// Prefix sums of a group of evaluators' accumulator-slot counts.
 ///
@@ -386,12 +352,12 @@ where
 		let n_vars_remaining = self.group.n_vars();
 		assert!(n_vars_remaining > 0);
 
-		// One pass over the halved hypercube feeds every evaluator.
-		// Shared columns and eq-indicator chunks are read once per round, while cache-resident.
+		// One parallel pass over the halved hypercube feeds every evaluator, so shared columns
+		// and eq-indicator chunks are read once per round while they are cache-resident.
 		//
 		// TODO: dynamically choose chunk size based on the number of columns and P byte-size,
 		// based on estimated L1 cache size.
-		let chunk_vars = chunk_vars_for::<P>(n_vars_remaining);
+		let chunk_vars = (n_vars_remaining - 1).min(MAX_CHUNK_VARS.max(P::LOG_WIDTH));
 
 		// Each evaluator owns a contiguous run of `degree` wide slots in one flat per-worker
 		// buffer; `offsets` holds the run boundaries as a prefix sum, so `offsets[i]..offsets[i +
@@ -550,9 +516,9 @@ where
 		let n_vars_remaining = self.group.n_vars();
 		assert!(n_vars_remaining > 0);
 
-		// One pass over the halved hypercube feeds every evaluator; see
+		// One parallel pass over the halved hypercube feeds every evaluator; see
 		// [`SharedSumcheckProver::execute`].
-		let chunk_vars = chunk_vars_for::<P>(n_vars_remaining);
+		let chunk_vars = (n_vars_remaining - 1).min(MAX_CHUNK_VARS.max(P::LOG_WIDTH));
 		let offsets = accum_offsets(
 			self.group
 				.evaluators


### PR DESCRIPTION
Reverts #1979.

Restores the single `min` that sets the round pass's chunk size, and drops the `PAR_CHUNK_VARS` constant it introduced.
Transcript-invariant in both directions — `chunk_vars` never moves the round polynomial.

Follow-up tracked in [BINIUS-399](https://linear.app/jimpo/issue/BINIUS-399/derive-the-sumcheck-round-passs-leaf-size-from-the-task-size-cost).

### Why revert

#1979 split one constant into two:

- `MAX_CHUNK_VARS` — whether to split a round across the pool at all
- `PAR_CHUNK_VARS = 8` — how finely, once it is split

The second was tuned on one Apple M1 Pro, and its stated justification was straggler imbalance across 8 performance and 2 efficiency cores.
Per review, that is not a target worth tuning for, and a hardcoded granularity is the wrong shape for the decision.

### What the revert does not undo

The occupancy problem is real and independent of core heterogeneity.
`MleStore::map_reduce` is a binary `rayon::join` tree, so the leaf count is exactly:

```
    halved = n_vars_remaining - 1
    leaves = 2^(halved - chunk_vars)
```

With a single threshold at 12, `halved = 13` yields 2 leaves — which leaves 8 of 10 *homogeneous* cores idle for that round, and `taskset` does not change it.
A 20-variable reduction spends most of its arithmetic in rounds with `halved` between 13 and 18.

The right fix states the budget in **work per leaf** rather than in chunk variables, so one constant answers both questions:

```
    W     = total round work
    W_min = budget per leaf

    W <  W_min  ->  1 leaf                 the sequential threshold, for free
    W >= W_min  ->  leaves = W / W_min     granularity scales with the round
```

`crates/utils/src/rayon/task_size.rs` already computes this, and the `TODO` above the reverted line has asked for it since #1782.
BINIUS-399 carries that work, including the calibration question: the current 100 microsecond budget lands a 19-variable round at roughly 16 leaves, so the number needs an x86 measurement under `taskset` rather than an M1 median.

### Scope

- One file: `crates/ip-prover/src/sumcheck/round_evaluator.rs`.
- Removes `PAR_CHUNK_VARS` and `chunk_vars_for`; restores `MAX_CHUNK_VARS` and its original doc comment.
- Both call sites: `SharedSumcheckProver::execute` and `SharedMleCheckProver::execute`.

### Conflict resolution

GitHub could not revert this automatically, because #1984 moved the evaluators behind a shared group after #1979 merged.
The only conflict was `self.evaluators` versus `self.group.evaluators` at the second call site.
The resolution keeps the group indirection from #1984 and restores only the `chunk_vars` line:

```rust
- let chunk_vars = chunk_vars_for::<P>(n_vars_remaining);
+ let chunk_vars = (n_vars_remaining - 1).min(MAX_CHUNK_VARS.max(P::LOG_WIDTH));
  let offsets = accum_offsets(
      self.group
          .evaluators
          .iter()
          .map(|evaluator| evaluator.degree()),
  );
```

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-ip-prover --features rayon --all-targets` — no warnings
- nightly `cargo fmt --all --check` — clean
- `cargo test -p binius-ip-prover --features rayon --lib` — 60 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)