### PR TITLE
BINIUS-400: bind the quadratic MLE-check column halves once per chunk

### DIFF
--- a/crates/ip-prover/src/sumcheck/quadratic_mle_evaluator.rs
+++ b/crates/ip-prover/src/sumcheck/quadratic_mle_evaluator.rs
@@ -148,6 +148,14 @@ where
 		// corresponds to x=0, the high half to x=1.
 		let cols: [&ColumnChunk<'_, P>; N] = self.cols.map(|id| chunk.col(id));
 
+		// Bind each half to a slice ahead of the element loop.
+		// A half is a base pointer and a length, so deriving it per element makes it a memory read.
+		//
+		//     per element, 4 columns:  derived in-loop   9 vector + 29 scalar loads
+		//                              bound here        9 vector loads
+		let los: [&[P]; N] = cols.map(|col| col.lo.as_ref());
+		let his: [&[P]; N] = cols.map(|col| col.hi.as_ref());
+
 		// The evaluator's run holds `y_1` in slot 0 and `y_inf` in slot 1.
 		let mut y_1 = <P as WideMul>::Output::default();
 		let mut y_inf = <P as WideMul>::Output::default();
@@ -157,8 +165,8 @@ where
 			let mut evals_inf = [P::default(); N];
 
 			for i in 0..N {
-				let lo_i = cols[i].lo.as_ref()[idx];
-				let hi_i = cols[i].hi.as_ref()[idx];
+				let lo_i = los[i][idx];
+				let hi_i = his[i][idx];
 
 				// Compose once with the high half and once with the lo+hi combination.
 				// The lo+hi branch corresponds to evaluation at infinity for multilinears.
@@ -294,6 +302,12 @@ mod tests {
 			output.challenges, sumcheck_output.challenges,
 			"prover and verifier challenges should match"
 		);
+	}
+
+	#[test]
+	fn test_identity_mlecheck() {
+		// One column returned unchanged: the narrowest gather a round pass performs.
+		prove_verify::<_, OptimalPackedB128, 1>(|[a]| a, |[_a]| OptimalPackedB128::zero());
 	}
 
 	#[test]


### PR DESCRIPTION
Closes [BINIUS-400](https://linear.app/jimpo/issue/BINIUS-400).

The generic quadratic MLE-check round evaluator re-derives its column descriptors on every element.
Lifting them above the loop deletes 29 of its 38 loads per element.
Pure codegen change — every round polynomial is bit-identical.

### The problem

A round pass walks the halved hypercube and gathers, per element, the low and high halves of each of its N columns.
Each half is a base pointer plus a length, reached through a reference.
Indexing through that reference inside the element loop makes the descriptor a memory read, once per element per half.

For the four-column shape the compiled loop issues 38 loads per element, of which 9 carry data:

```
    per element, 4 columns
        9   ldr q     the field elements the composition consumes
        29  ldr x/w   each half's base and length, re-read every iteration
```

The arithmetic is identical either way: 32 `pmull` and 26 `eor`.
So roughly half the loop's instructions move no data toward the result.

Evaluators that bind each chunk to a name rather than indexing an array do not have this shape.
The fractional-addition fused evaluator and the bivariate-product evaluator both compile to 9 loads.
Only the generic one, which indexes its column array by the gather loop's counter, keeps the descriptors in memory.

### The idea

Project both halves of every column to a plain slice once, above the element loop.

The gather then indexes a slice whose base is already in a register.

### Per element, four columns

- **before:** 185 instructions, 38 loads
- **after:** 106 instructions, 9 loads

→ the arithmetic is unchanged; only the redundant loads go away.

### The change

```
- let lo_i = cols[i].lo.as_ref()[idx];      // descriptor read per element
- let hi_i = cols[i].hi.as_ref()[idx];
+ let lo_i = los[i][idx];                   // slice bound once per chunk
+ let hi_i = his[i][idx];
```

This evaluator backs the AND-reduction zerocheck, the multiplication gates, the M4 operand claims, Spartan, the bivariate product, and the fractional-addition layers.
Every consumer picks the change up without touching a call site.

### Soundness

The loads removed were redundant reads of data the loop already had.
Every round polynomial and every reduced column evaluation is bit-identical.

### Scope

- **changed:** the gather in one evaluator, `crates/ip-prover/src/sumcheck/quadratic_mle_evaluator.rs`
- **new:** a single-column test case, the arity the M4 prover uses and the existing tests did not reach
- **untouched:** every call site, the trait, and the round-pass driver
- **not done:** the single-column evaluation evaluator indexes the same way and may share the defect; it is not measured here

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-ip-prover --features rayon --all-targets` — no warnings
- nightly `cargo fmt --all` — clean
- `cargo test -p binius-ip-prover --features rayon --lib` — 61 passed

### Benchmark

Round-0 accumulate pass, single thread, 18 variables, interleaved A/B, medians of 25, ns per element:

| columns | consumer | before | after | delta |
|---|---|---|---|---|
| 1 | M4 operand | 2.41 | 1.99 | −17.4% |
| 2 | bivariate product, fractional-addition denominator | 7.57 | 5.91 | −22.0% |
| 3 | AND-reduction zerocheck | 9.64 | 6.78 | −29.7% |
| 4 | fractional-addition numerator | 19.40 | 15.39 | −20.7% |

End to end, `and_reduction` remaining zerocheck at $2^{21}$:

| threads | before | after | delta |
|---|---|---|---|
| 1 | 32.709 ms | 27.064 ms | **−17.2%** |
| 10 | 5.668 ms | 5.605 ms | −1.1%, p = 0.53 |

The ten-thread result is a null result, and expected.
At that width the pass saturates memory bandwidth, so removing loads that were hitting L1 buys nothing.
The change is a win where the pass is issue-bound and neutral where it is bandwidth-bound.

Apple M1 Pro, 8 performance cores. The single-threaded figures have ±0.2% confidence intervals; the ten-thread ones were taken under background load and only support the null.

🤖 Generated with [Claude Code](https://claude.com/claude-code)