### PR TITLE
BINIUS-401: pair the single-column evaluation pass with its equality chunk

### DIFF
--- a/crates/ip-prover/src/sumcheck/multilinear_eval.rs
+++ b/crates/ip-prover/src/sumcheck/multilinear_eval.rs
@@ -1,6 +1,8 @@
 // Copyright 2026 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
+use std::iter;
+
 use binius_compute::Allocator;
 use binius_field::{Field, PackedField, WideMul};
 use binius_ip::sumcheck::RoundCoeffs;
@@ -50,14 +52,19 @@ where
 	) {
 		// The column arrives split on the round's highest variable.
 		// Its high half is the specialization at `X = 1`.
-		let col = chunk.col(self.col);
+		let hi = chunk.col(self.col).hi.as_ref();
+		let eq_ind = eq_ind.as_ref();
+
+		// The two run in lockstep, so pairing them checks the length once per chunk.
+		// Indexing one by the other's position instead consults a bound on every element.
+		assert_eq!(hi.len(), eq_ind.len());
 
 		// R(1) = <M(.., X = 1), eq(.., z)> over this chunk.
 		// Only the eq multiply is widened.
 		// The wide accumulator is reduced once at the end of the chunk.
 		let mut y_1 = <P as WideMul>::Output::default();
-		for (idx, &eq_i) in eq_ind.as_ref().iter().enumerate() {
-			y_1 += P::wide_mul(col.hi.as_ref()[idx], eq_i);
+		for (&m_i, &eq_i) in iter::zip(hi, eq_ind) {
+			y_1 += P::wide_mul(m_i, eq_i);
 		}
 		accum[0] += y_1;
 	}


### PR DESCRIPTION
Closes [BINIUS-401](https://linear.app/jimpo/issue/BINIUS-401).

The single-column evaluation round pass indexes the column half by the equality indicator's position.
Pairing the two by iteration instead takes the loop from 20 instructions per element to 13.
Pure codegen change — every round polynomial is bit-identical.

### The problem

The pass computes one inner product: the column's `X = 1` half against the round's equality chunk.
It walks the equality chunk and indexes the column half by that position.

Indexing keeps a bounds check inside the element loop.
That branch blocks the restructuring that would otherwise stream both operands directly into vector registers.

The compiled loop spends 20 instructions per element, of which 8 do the arithmetic:

```
    per element
        cmp + b.eq          bounds check, branching to a panic path
        ldr q               the column element
        ldp x12, x13        the equality element, into general-purpose registers
        dup, dup            move its two halves back out to vector registers
        fmov, fmov
        4x pmull, 4x eor    the actual work
```

The equality element takes a detour through general-purpose registers and back.
That round trip exists only because the bounds check keeps the loop in a scalar shape.

### The idea

The column half and the equality chunk have the same length and are walked in lockstep.
So pair them by iteration rather than indexing one by the other's position.

The length invariant then gets checked once per chunk instead of once per element, and stated out loud:

```
    assert_eq!(hi.len(), eq_ind.len())
    for (m_i, eq_i) in zip(hi, eq_ind)
```

This is the shape the bivariate-product evaluator already uses.

### Per element

- **before:** 20 instructions, bounds check and branch, equality operand via a general-purpose round trip
- **after:** 13 instructions, both operands loaded straight into vector registers

→ the arithmetic is unchanged at 4 `pmull` and 4 `eor`.

### The change

```
- let col = chunk.col(self.col);
- for (idx, &eq_i) in eq_ind.as_ref().iter().enumerate() {
-     y_1 += P::wide_mul(col.hi.as_ref()[idx], eq_i);
+ let hi = chunk.col(self.col).hi.as_ref();
+ assert_eq!(hi.len(), eq_ind.len());
+ for (&m_i, &eq_i) in iter::zip(hi, eq_ind) {
+     y_1 += P::wide_mul(m_i, eq_i);
```

Two consumers pick this up without a call-site change: the BaseFold opening and the integer-multiplication protocol.

### Soundness

The same products are summed in the same order.
Every round polynomial and every reduced evaluation is bit-identical.

Pairing truncates where indexing panics, so the explicit length assertion preserves the failure behaviour for a genuine mismatch.

### Scope

- **changed:** the accumulate loop in `crates/ip-prover/src/sumcheck/multilinear_eval.rs`
- **untouched:** the interpolation, the trait, the prover constructor, and every call site
- **not done:** the parallel case is unmeasured, see the benchmark note

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-ip-prover --features rayon --all-targets` — no warnings
- nightly `cargo fmt --all` — clean
- `cargo test -p binius-ip-prover --features rayon --lib` — 60 passed
- `cargo test -p binius-iop-prover --features rayon --lib` — 40 passed

The existing conformance test drives this evaluator and the quadratic one in lockstep and compares every round polynomial, so a divergence here would fail it.

### Benchmark

Single thread, interleaved A/B, medians of 25, ns per element.
A full opening sumcheck is this prover driven over every round, so that row is the end-to-end cost for a BaseFold opening.

| stage | variables | before | after | delta |
|---|---|---|---|---|
| accumulate pass | 18 | 2.097 | 1.348 | **−35.7%** |
| accumulate pass | 20 | 2.209 | 1.449 | **−34.4%** |
| full opening sumcheck | 18 | 4.072 | 3.367 | **−17.3%** |
| full opening sumcheck | 20 | 4.355 | 3.597 | **−17.4%** |

The full-reduction figure is smaller because folding, which this does not touch, is a fixed share of it.

Apple M1 Pro. These are single-threaded numbers; the parallel case is not measured.
A sibling change to the quadratic evaluator showed that instruction-level wins like this can be masked once the pass saturates memory bandwidth, so do not assume the multi-threaded win matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)