### PR TITLE
Rebuild only the reader index in zero propagation

### DIFF
--- a/crates/frontend/src/compiler/zero_fold.rs
+++ b/crates/frontend/src/compiler/zero_fold.rs
@@ -27,9 +27,11 @@ use crate::compiler::{
 /// Zeros travel: clearing a zero leaves zero, and packing zero into a lane leaves zero. So one
 /// sweep is not enough, and the sweeps repeat until one changes nothing.
 ///
-/// Each sweep rebuilds the use-def index first. Forwarding to an ordinary wire grows that wire's
+/// Each sweep rebuilds the reader index first. Forwarding to an ordinary wire grows that wire's
 /// set of readers, which a stale index would not list, and a later sweep forwarding that same
 /// wire would then miss those readers.
+///
+/// Only the reader half is rebuilt. This pass follows readers, never definitions.
 pub fn zero_propagation(
 	graph: &mut GateGraph,
 	force_committed: &EntitySet<Wire>,
@@ -43,7 +45,7 @@ pub fn zero_propagation(
 
 	let mut total_rewritten = 0;
 	loop {
-		graph.rebuild_use_def_chains(hint_registry);
+		graph.rebuild_wire_uses(hint_registry);
 
 		// Gathered before any rewriting, since reading the graph and mutating it cannot overlap.
 		let mut forwardings = Vec::new();


### PR DESCRIPTION
Zero propagation rebuilt both halves of the use-def analysis on every sweep, but it only reads one of them.
Pure optimization — the same wires are forwarded in the same order, so the compiled circuit is unchanged.

### The problem

`zero_propagation` chases a fixpoint: a forwarded zero can expose another zero, so it sweeps until a sweep changes nothing.

Each sweep opened with a full rebuild of the use-def analysis:

```
loop {
    graph.rebuild_use_def_chains(hint_registry);   // builds wire_def AND the reader index
    ...
}
```

`rebuild_use_def_chains` builds two maps:

- `wire_def` — which gate *defines* each wire
- the reader index — which gates *read* each wire

Each is a linear sweep over every gate in the graph.

### The idea

This pass only ever follows readers.

It forwards a wire by calling `replace_wire_with_wire`, which asks `get_wire_uses` who reads the old wire so it can point them at the new one.
It never looks at `wire_def`.
The only reader of `wire_def` in the compiler is dead-code elimination, and that pass calls `rebuild_wire_defs` for itself.

So half of every rebuild was a full pass over the gate graph producing a map nothing in this pass would touch.

### The change

```
-graph.rebuild_use_def_chains(hint_registry);
+graph.rebuild_wire_uses(hint_registry);
```

`rebuild_wire_uses` was already public on `GateGraph`; this is the first caller to use it directly.

### Scope

- **changed:** one line in `crates/frontend/src/compiler/zero_fold.rs`, plus the doc comment that described the rebuild
- **untouched:** `rebuild_use_def_chains` stays, since constant propagation reads both halves
- **untouched:** every pass ordering, every option default, and the constraint system that comes out

### Soundness

Nothing about the rewrite changes.

- The pass still rebuilds the reader index once per sweep, which is what keeps forwarding correct across sweeps: forwarding onto an ordinary wire grows that wire's reader set, and a stale index would not list the readers just moved.
- The rules in `zero_identity` are untouched, so the same gates are recognized as identities.
- Forwardings are gathered in gate order and applied in that order, exactly as before.

The compiled constraint system is bit-identical.

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-frontend -p binius-circuits --all-targets -- -D warnings` — clean
- `cargo +nightly fmt --all` — no changes
- `cargo nextest run -p binius-frontend -p binius-circuits` — 528 passed

### Benchmark

Circuit compilation timed on an M1 Pro, `--release`, min of 7 reps, interleaved against `main`.

| circuit | pass alone | total compile |
|---|---|---|
| 512 x SHA-256 (100-byte message, 4 sweeps) | 265 ms → 200 ms | 1.330 s → 1.275 s (**−4.1%**) |
| 512 x Keccak-f[1600] (no zero constant) | not entered | 1.293 s → 1.295 s (no change) |

The win only shows up where the pass actually runs.
A circuit with no `Word::ZERO` constant returns before the loop, so it never pays for the rebuild in the first place — padded-message circuits are where the zero constants come from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)