### PR TITLE
Stop copying per-gate slices in dead-code elimination and CSE

### DIFF
--- a/crates/frontend/src/compiler/cse.rs
+++ b/crates/frontend/src/compiler/cse.rs
@@ -25,6 +25,7 @@
 
 use cranelift_entity::EntitySet;
 use rustc_hash::FxHashMap;
+use smallvec::SmallVec;
 
 use super::{
 	gate::opcode::Opcode,
@@ -120,13 +121,15 @@ pub fn dedup_gates(
 ///
 /// Output, auxiliary, and scratch wires are excluded.
 /// They are freshly allocated per gate, so including them would make identical gates differ.
+///
+/// One is built per gate, so each field is held inline at the arity the opcodes actually use.
 #[derive(PartialEq, Eq, Hash)]
 struct GateStructure {
 	opcode: Opcode,
 	/// The constant and input wires, in order, which is what the gate reads.
-	reads: Vec<Wire>,
-	immediates: Vec<u32>,
-	dimensions: Vec<usize>,
+	reads: SmallVec<[Wire; 4]>,
+	immediates: SmallVec<[u32; 2]>,
+	dimensions: SmallVec<[usize; 1]>,
 }
 
 /// Extracts the structural identity of a gate.
@@ -141,8 +144,8 @@ fn structure_of(graph: &GateGraph, gate: Gate, hint_registry: &HintRegistry) -> 
 			.chain(param.inputs)
 			.copied()
 			.collect(),
-		immediates: data.immediates.clone(),
-		dimensions: data.dimensions.clone(),
+		immediates: SmallVec::from_slice(&data.immediates),
+		dimensions: SmallVec::from_slice(&data.dimensions),
 	}
 }
 

--- a/crates/frontend/src/compiler/dce.rs
+++ b/crates/frontend/src/compiler/dce.rs
@@ -69,14 +69,16 @@ pub fn live_gates(
 
 	// Propagate liveness backward along def→use edges.
 	// A live gate needs its inputs, so each input wire and the gate defining it are also live.
+	//
+	// Reborrowed shared, now that the rebuild above is the last mutation.
+	// The live set and worklist are locals, so an input slice can stay borrowed while they grow.
+	let graph: &GateGraph = graph;
 	while let Some(gate) = work.pop() {
-		// Copy the inputs out first, ending the graph borrow before the set is mutated.
-		let inputs = graph
+		for &input in graph
 			.gate_data(gate)
 			.gate_param_with_registry(hint_registry)
 			.inputs
-			.to_vec();
-		for input in inputs {
+		{
 			if let Some(def) = graph.wire_def[input]
 				&& live.insert(def)
 			{


### PR DESCRIPTION
Dead-code elimination and CSE each allocated once per gate while sweeping the graph.
Neither needs to. Both passes report exactly the same gates, so the compiled constraint system is unchanged.

### The problem

Both passes visit every gate in the graph.
On a circuit of 512 independent Keccak-f[1600] permutations that is **1.4M gates**.
Each pass was doing one heap allocation per gate to get through it.

Together they are 37% of circuit compilation:

| pass | time | share of compile |
|---|---|---|
| `cse::dedup_gates` | 389 ms | 29% |
| `dce::live_gates` | 102 ms | 8% |

### The idea, part 1 — DCE does not need the copy at all

Liveness propagation copied each live gate's input slice before walking it:

```
let inputs = graph.gate_data(gate)
    .gate_param_with_registry(hint_registry)
    .inputs
    .to_vec();          // one Vec per live gate
for input in inputs { ... live.insert(def) ... }
```

The comment said this ended a graph borrow before the live set was mutated.
But `live` and `work` are **locals** — they are not part of the graph, so there is no conflict to avoid.
The only thing the borrow checker objected to is that `graph` arrives as `&mut GateGraph`.

Reborrowing it shared, after the last mutation, removes the copy entirely:

```
let graph: &GateGraph = graph;      // rebuild_wire_defs above was the last mutation
for &input in graph.gate_data(gate)
    .gate_param_with_registry(hint_registry)
    .inputs
{ ... }
```

Nearly every gate is live in a real circuit, so that is ~1.4M allocations gone.

### The idea, part 2 — CSE can own its key without the heap

CSE keys a hash map on each gate's structure, and that key has to **own** its wire list: the graph is rewired while the map is alive, so it cannot borrow from it.

It does not have to own it on the *heap*, though. Every fixed-shape opcode is small:

```
reads       <= 4 wires        (only IcmpUlt, IaddCinCout, Iadd32CinCout, IsubBinBout, Bmul, IcmpEq exceed it)
immediates  <= 2              (Shift declares 2, Hint 1, every other opcode none)
dimensions  <= 1              (only BxorMulti and Hint carry any)
```

`SmallVec<[Wire; 4]>` is **24 bytes — exactly the size of `Vec<Wire>`**, so holding those inline costs no extra space and skips the allocation for the common gate.

### The change

```
dce.rs:
- let inputs = graph.gate_data(gate)...inputs.to_vec();     // one Vec per live gate
- for input in inputs {
+ let graph: &GateGraph = graph;
+ for &input in graph.gate_data(gate)...inputs {

cse.rs — GateStructure:
- reads: Vec<Wire>,  immediates: Vec<u32>,  dimensions: Vec<usize>,
+ reads: SmallVec<[Wire; 4]>,  immediates: SmallVec<[u32; 2]>,  dimensions: SmallVec<[usize; 1]>,
```

`smallvec` is already a dependency of `binius-frontend`.

### Soundness

Neither pass changes what it computes.

- DCE seeds and propagates over the same wires in the same order, so the same set of gates comes back live. Iterating a slice in place visits exactly what the copy did.
- CSE's key compares and hashes the same fields in the same order. `SmallVec` derives `PartialEq`/`Eq`/`Hash` elementwise, as `Vec` does, so two gates are structurally equal under exactly the same conditions as before.
- Nothing about the observable/force-committed guard, the canonical-gate choice, or the remap moves.

### Scope

- **changed:** the liveness loop in `dce.rs`, and `GateStructure` plus its constructor in `cse.rs`
- **untouched:** `GateData` itself still holds `Vec`s — this PR only changes what the two passes build on top of it
- **untouched:** every pass ordering and every option default

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-frontend -p binius-circuits --all-targets -- -D warnings` — clean
- `cargo +nightly fmt --all` — no changes
- `cargo nextest run -p binius-frontend -p binius-circuits` — 528 passed

### Benchmark

M1 Pro, `--release`, interleaved against `main`. Per-pass figures are Keccak x512 (1.4M gates); totals are min of 7 reps.

| | main | this PR | change |
|---|---|---|---|
| `cse::dedup_gates` | 389 ms | 331 ms | **−15%** |
| `dce::live_gates` | 102 ms | 65 ms | **−36%** |
| total compile, 512 x Keccak | 1.293 s | 1.172 s | **−9.4%** |
| total compile, 512 x SHA-256 | 1.330 s | 1.226 s | **−7.8%** |

One number to *ignore*: graph construction also appears to improve, and it does not.
Neither pass runs during construction — they are both inside `build()`.
The harness alternates construct and compile, so the allocator state that `build()` leaves behind shifts the next construction. That is an artifact, not a win.

🤖 Generated with [Claude Code](https://claude.com/claude-code)