### PR TITLE
Store wire kinds directly instead of wrapping them

### DIFF
--- a/crates/frontend/src/compiler/const_prop.rs
+++ b/crates/frontend/src/compiler/const_prop.rs
@@ -59,7 +59,7 @@ pub fn constant_propagation(graph: &mut GateGraph, hint_registry: &HintRegistry)
 					};
 					for (i, &output_wire) in output_wires.iter().enumerate() {
 						// Skip if output is already constant
-						if graph.wire_data(output_wire).kind.is_const() {
+						if graph.wire_kind(output_wire).is_const() {
 							continue;
 						}
 
@@ -105,7 +105,7 @@ fn try_evaluate_gate_with_constants(
 
 	let mut input_constants = Vec::new();
 	for &input_wire in gate_param.inputs {
-		if let WireKind::Constant(val) = graph.wire_data(input_wire).kind {
+		if let WireKind::Constant(val) = graph.wire_kind(input_wire) {
 			input_constants.push(val);
 		} else {
 			// Not all inputs are constant, can't evaluate.
@@ -148,8 +148,8 @@ mod tests {
 		let test_gate = graph.emit_gate(root, Opcode::Bxor, vec![and_out, and_out], vec![test_out]);
 
 		// Initially, xor_out and and_out are not constants
-		assert!(!matches!(graph.wires[xor_out].kind, WireKind::Constant(_)));
-		assert!(!matches!(graph.wires[and_out].kind, WireKind::Constant(_)));
+		assert!(!matches!(graph.wires[xor_out], WireKind::Constant(_)));
+		assert!(!matches!(graph.wires[and_out], WireKind::Constant(_)));
 
 		// Run constant propagation
 		let replaced = constant_propagation(&mut graph, &HintRegistry::new());
@@ -158,15 +158,15 @@ mod tests {
 		assert_eq!(replaced, 3);
 
 		// The original wires remain as witness wires
-		assert!(matches!(graph.wires[xor_out].kind, WireKind::Witness));
-		assert!(matches!(graph.wires[and_out].kind, WireKind::Witness));
+		assert!(matches!(graph.wires[xor_out], WireKind::Witness));
+		assert!(matches!(graph.wires[and_out], WireKind::Witness));
 
 		// But the gates that used them should now use constant wires
 		// Check that and_gate now uses a constant wire with value 6 instead of xor_out
 		let and_gate_data = &graph.gates[and_gate];
 		let and_inputs = and_gate_data.gate_param().inputs;
 		// First input should be a constant with value 6 (5 ^ 3)
-		match graph.wires[and_inputs[0]].kind {
+		match graph.wires[and_inputs[0]] {
 			WireKind::Constant(val) => assert_eq!(val, Word(6)),
 			_ => panic!("Expected and_gate's first input to be constant 6"),
 		}
@@ -175,7 +175,7 @@ mod tests {
 		let test_gate_data = &graph.gates[test_gate];
 		let test_inputs = test_gate_data.gate_param().inputs;
 		// Both inputs should be constants with value 0 (6 & 1)
-		match graph.wires[test_inputs[0]].kind {
+		match graph.wires[test_inputs[0]] {
 			WireKind::Constant(val) => assert_eq!(val, Word(0)),
 			_ => panic!("Expected test_gate's input to be constant 0"),
 		}
@@ -221,13 +221,13 @@ mod tests {
 		assert_eq!(replaced, 3);
 
 		// The original wires remain as witness wires
-		assert!(matches!(graph.wires[shr_out].kind, WireKind::Witness));
-		assert!(matches!(graph.wires[shl_out].kind, WireKind::Witness));
+		assert!(matches!(graph.wires[shr_out], WireKind::Witness));
+		assert!(matches!(graph.wires[shl_out], WireKind::Witness));
 
 		// Check that shl_gate now uses a constant wire with value 4 (16 >> 2)
 		let shl_gate_data = &graph.gates[shl_gate];
 		let shl_inputs = shl_gate_data.gate_param().inputs;
-		match graph.wires[shl_inputs[0]].kind {
+		match graph.wires[shl_inputs[0]] {
 			WireKind::Constant(val) => assert_eq!(val, Word(4)),
 			_ => panic!("Expected shl_gate's input to be constant 4"),
 		}
@@ -235,7 +235,7 @@ mod tests {
 		// Check that test_gate now uses a constant wire with value 8 (4 << 1)
 		let test_gate_data = &graph.gates[test_gate];
 		let test_inputs = test_gate_data.gate_param().inputs;
-		match graph.wires[test_inputs[0]].kind {
+		match graph.wires[test_inputs[0]] {
 			WireKind::Constant(val) => assert_eq!(val, Word(8)),
 			_ => panic!("Expected test_gate's input to be constant 8"),
 		}
@@ -298,16 +298,16 @@ mod tests {
 		assert_eq!(replaced, 4);
 
 		// The original wires remain as witness wires.
-		assert!(matches!(graph.wires[quotient].kind, WireKind::Witness));
-		assert!(matches!(graph.wires[remainder].kind, WireKind::Witness));
+		assert!(matches!(graph.wires[quotient], WireKind::Witness));
+		assert!(matches!(graph.wires[remainder], WireKind::Witness));
 
 		let test_q_inputs = graph.gates[test_q_gate].gate_param().inputs;
-		match graph.wires[test_q_inputs[0]].kind {
+		match graph.wires[test_q_inputs[0]] {
 			WireKind::Constant(val) => assert_eq!(val, Word(14)), // 100 / 7 = 14
 			_ => panic!("Expected test_q_gate's input to be constant 14"),
 		}
 		let test_r_inputs = graph.gates[test_r_gate].gate_param().inputs;
-		match graph.wires[test_r_inputs[0]].kind {
+		match graph.wires[test_r_inputs[0]] {
 			WireKind::Constant(val) => assert_eq!(val, Word(2)), // 100 % 7 = 2
 			_ => panic!("Expected test_r_gate's input to be constant 2"),
 		}

--- a/crates/frontend/src/compiler/cse.rs
+++ b/crates/frontend/src/compiler/cse.rs
@@ -80,8 +80,7 @@ pub fn dedup_gates(
 			.outputs
 			.iter()
 			.any(|&wire| {
-				matches!(graph.wire_data(wire).kind, WireKind::Inout)
-					|| force_committed.contains(wire)
+				matches!(graph.wire_kind(wire), WireKind::Inout) || force_committed.contains(wire)
 			});
 
 		// A gate producing an observable wire is never collapsed, though it can still be canonical.

--- a/crates/frontend/src/compiler/dce.rs
+++ b/crates/frontend/src/compiler/dce.rs
@@ -56,9 +56,8 @@ pub fn live_gates(
 
 	// Seed 2: gates that define an observable wire.
 	// Observable means a public input/output, or a wire the circuit author pinned as committed.
-	for (wire, wire_data) in graph.wires.iter() {
-		let observable =
-			matches!(wire_data.kind, WireKind::Inout) || force_committed.contains(wire);
+	for (wire, kind) in graph.wires.iter() {
+		let observable = matches!(kind, WireKind::Inout) || force_committed.contains(wire);
 		if observable
 			&& let Some(def) = graph.wire_def[wire]
 			&& live.insert(def)

--- a/crates/frontend/src/compiler/gate_graph.rs
+++ b/crates/frontend/src/compiler/gate_graph.rs
@@ -65,11 +65,6 @@ impl WireKind {
 	}
 }
 
-#[derive(Copy, Clone)]
-pub struct WireData {
-	pub kind: WireKind,
-}
-
 /// Gate ID - identifies a gate in the graph
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Gate(u32);
@@ -194,7 +189,7 @@ impl GateData {
 pub struct GateGraph {
 	// Primary maps
 	pub gates: PrimaryMap<Gate, GateData>,
-	pub wires: PrimaryMap<Wire, WireData>,
+	pub wires: PrimaryMap<Wire, WireKind>,
 
 	pub path_spec_tree: PathSpecTree,
 	pub gate_origin: SecondaryMap<Gate, PathSpec>,
@@ -260,40 +255,30 @@ impl GateGraph {
 
 	pub fn add_inout(&mut self) -> Wire {
 		self.n_inout += 1;
-		self.wires.push(WireData {
-			kind: WireKind::Inout,
-		})
+		self.wires.push(WireKind::Inout)
 	}
 
 	pub fn add_witness(&mut self) -> Wire {
 		self.n_witness += 1;
-		self.wires.push(WireData {
-			kind: WireKind::Witness,
-		})
+		self.wires.push(WireKind::Witness)
 	}
 
 	pub fn add_internal(&mut self) -> Wire {
 		// Internal wires are treated as witnesses for allocation purposes
 		self.n_witness += 1;
-		self.wires.push(WireData {
-			kind: WireKind::Internal,
-		})
+		self.wires.push(WireKind::Internal)
 	}
 
 	pub fn add_scratch(&mut self) -> Wire {
 		// Scratch wires are temporary storage, not part of witness
-		self.wires.push(WireData {
-			kind: WireKind::Scratch,
-		})
+		self.wires.push(WireKind::Scratch)
 	}
 
 	pub fn add_constant(&mut self, word: Word) -> Wire {
 		if let Some(wire) = self.const_pool.get(word) {
 			return wire;
 		}
-		let wire = self.wires.push(WireData {
-			kind: WireKind::Constant(word),
-		});
+		let wire = self.wires.push(WireKind::Constant(word));
 		self.const_pool.insert(word, wire);
 		wire
 	}
@@ -485,14 +470,14 @@ impl GateGraph {
 		self.use_edges[run].iter().copied()
 	}
 
-	/// Returns an iterator over all constant wires and their data
-	pub fn iter_const_wires(&self) -> impl Iterator<Item = (Wire, &WireData)> {
-		self.wires.iter().filter(|(_, data)| data.kind.is_const())
+	/// Returns an iterator over all constant wires and their kind
+	pub fn iter_const_wires(&self) -> impl Iterator<Item = (Wire, &WireKind)> {
+		self.wires.iter().filter(|(_, kind)| kind.is_const())
 	}
 
-	/// Gets wire data by reference
-	pub fn wire_data(&self, wire: Wire) -> &WireData {
-		&self.wires[wire]
+	/// Gets the kind of the given wire
+	pub fn wire_kind(&self, wire: Wire) -> WireKind {
+		self.wires[wire]
 	}
 
 	/// Gets gate data by reference
@@ -793,7 +778,7 @@ mod tests {
 		assert!(inputs.contains(&bin));
 		// The constant wire is surfaced first.
 		let const_wire = inputs[0];
-		match graph.wires[const_wire].kind {
+		match graph.wires[const_wire] {
 			WireKind::Constant(word) => assert_eq!(word, Word::ALL_ONE),
 			_ => panic!("Expected constant wire"),
 		}

--- a/crates/frontend/src/compiler/mod.rs
+++ b/crates/frontend/src/compiler/mod.rs
@@ -290,8 +290,8 @@ impl CircuitBuilder {
 		// Gate fusion is what decides that.
 		// The rest exist purely during witness evaluation, so they form the scratch segment.
 		let mut scratch_wires = EntitySet::new();
-		for (wire, wire_data) in graph.wires.iter() {
-			if matches!(wire_data.kind, WireKind::Internal | WireKind::Scratch)
+		for (wire, kind) in graph.wires.iter() {
+			if matches!(kind, WireKind::Internal | WireKind::Scratch)
 				&& !constrained_wires.contains(wire)
 			{
 				scratch_wires.insert(wire);
@@ -317,9 +317,9 @@ impl CircuitBuilder {
 			constants,
 		} = {
 			let mut value_vec_alloc = value_vec_alloc::Alloc::new(scratch_alloc.n_slots());
-			for (wire, wire_data) in graph.wires.iter() {
-				match wire_data.kind {
-					WireKind::Constant(ref value) => {
+			for (wire, kind) in graph.wires.iter() {
+				match kind {
+					WireKind::Constant(value) => {
 						value_vec_alloc.add_constant(wire, *value);
 					}
 					WireKind::Inout => value_vec_alloc.add_inout(wire),
@@ -476,7 +476,7 @@ impl CircuitBuilder {
 	fn const_of(&self, wire: Wire) -> Option<Word> {
 		let shared = self.shared.borrow();
 		let shared = shared.as_ref().expect("CircuitBuilder used after build");
-		match shared.graph.wires[wire].kind {
+		match shared.graph.wires[wire] {
 			WireKind::Constant(word) => Some(word),
 			_ => None,
 		}

--- a/crates/frontend/src/compiler/zero_fold.rs
+++ b/crates/frontend/src/compiler/zero_fold.rs
@@ -70,7 +70,7 @@ pub fn zero_propagation(
 fn find_zero_constant(graph: &GateGraph) -> Option<Wire> {
 	graph
 		.iter_const_wires()
-		.find(|(_, data)| data.kind.const_value() == Some(Word::ZERO))
+		.find(|(_, kind)| kind.const_value() == Some(Word::ZERO))
 		.map(|(wire, _)| wire)
 }
 


### PR DESCRIPTION
`WireData` is a struct with one field. Deleting it and storing the `WireKind` directly removes a `.kind` from every reader.
Pure refactor — same layout, same wire kinds, same compiled circuit.

### The problem

`WireData` wraps exactly one thing, and always has:

```
#[derive(Copy, Clone)]
pub struct WireData {
    pub kind: WireKind,
}
```

Nothing else was ever added to it, and the type name appears **nowhere** outside `gate_graph.rs`.

So `PrimaryMap<Wire, WireData>` says what `PrimaryMap<Wire, WireKind>` says.
The wrapper's only effect is that every reader writes `.kind` to get past it.

### The idea

Store the kind directly. The map already keys on `Wire`, so the wrapper adds no information.

```
- pub wires: PrimaryMap<Wire, WireData>,
+ pub wires: PrimaryMap<Wire, WireKind>,
```

That drops the struct, its five construction sites, and the `.kind` at every use:

```
- self.wires.push(WireData { kind: WireKind::Inout })
+ self.wires.push(WireKind::Inout)

- matches!(wire_data.kind, WireKind::Inout)
+ matches!(kind, WireKind::Inout)
```

### The accessor is renamed with it

`wire_data` returned a `WireData`. With the wrapper gone it returns a `WireKind`, so the old name would describe the wrong thing:

```
- pub fn wire_data(&self, wire: Wire) -> &WireData
+ pub fn wire_kind(&self, wire: Wire) -> WireKind
```

It also returns **by value**. `WireKind` is `Copy` and 16 bytes, so handing back a reference bought nothing.

Three call sites follow the rename — in `cse.rs` and `const_prop.rs`.

### Soundness

Nothing observable moves.

- `WireKind` is unchanged, so every wire still carries the same kind.
- `PrimaryMap<Wire, WireKind>` has the same element layout the wrapper had: a one-field `#[repr(Rust)]` struct is laid out as its field.
- Wire creation order is untouched, so the value-vector allocator sees wires in the same order and assigns the same indices.
- The all-one constant is still seeded first and still lands at value index 0 — the `debug_assert` in `build()` covers it.

### Scope

- **deleted:** `WireData`
- **renamed:** `wire_data` to `wire_kind`, returning by value
- **changed:** the five push sites, plus `.kind` removal in `mod.rs`, `dce.rs`, `cse.rs`, `zero_fold.rs`, `const_prop.rs`
- **untouched:** `WireKind` itself, and `GateData`, which genuinely holds several fields

Most of the line count is mechanical: 32 of the changed lines are `const_prop.rs` test assertions losing a `.kind`.

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-frontend -p binius-circuits --all-targets -- -D warnings` — clean
- `cargo +nightly fmt --all` — no changes
- `cargo nextest run -p binius-frontend -p binius-circuits` — 528 passed

No benchmark: this is a rename and an unwrap, so there is nothing to measure.
`WireKind` is still 16 bytes, and the wire map is still one entry per wire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)