### PR TITLE
Make the witness-population errors real errors

### DIFF
--- a/crates/frontend/Cargo.toml
+++ b/crates/frontend/Cargo.toml
@@ -18,6 +18,7 @@ petgraph.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 smallvec.workspace = true
+thiserror.workspace = true
 rustc-hash.workspace = true
 
 [dev-dependencies]

--- a/crates/frontend/src/compiler/circuit.rs
+++ b/crates/frontend/src/compiler/circuit.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 use std::{
-	error, fmt,
+	fmt,
 	ops::{Index, IndexMut},
 };
 
@@ -18,29 +18,61 @@ use crate::compiler::{
 	gate_graph::{GateGraph, Wire},
 };
 
-/// Error returned when populating wire witness fails due to assertion failures.
-#[derive(Debug)]
+/// A single assertion that did not hold while populating the witness.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AssertionFailure {
+	/// The circuit path the assertion was declared under, such as `.sha256.round[3]`.
+	///
+	/// Empty for an assertion at the circuit root.
+	pub path: String,
+	/// What the assertion required, against the words it saw instead.
+	///
+	/// A diagnostic for a human to read.
+	/// Its wording is not part of the API, so do not match on it.
+	pub detail: String,
+}
+
+impl fmt::Display for AssertionFailure {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		if self.path.is_empty() {
+			f.write_str(&self.detail)
+		} else {
+			write!(f, "{}: {}", self.path, self.detail)
+		}
+	}
+}
+
+/// Witness population failed because the circuit is not satisfied.
+///
+/// Evaluation runs to completion rather than stopping at the first bad assertion.
+/// So a caller sees every violation at once.
+///
+/// The retained list is capped at [`MAX_ASSERTION_FAILURES`](crate::MAX_ASSERTION_FAILURES).
+/// [`Self::total`] counts every violation, capped or not.
+/// The two disagree exactly when the cap was reached.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub struct PopulateError {
-	/// List of assertion failure messages (limited to MAX_ASSERTION_FAILURES).
-	pub messages: Vec<String>,
-	/// Total count of assertion failures (may exceed messages.len()).
-	pub total_count: usize,
+	/// The failures that were retained, in the order evaluation found them.
+	pub failures: Vec<AssertionFailure>,
+	/// How many assertions failed in total, which may exceed `failures.len()`.
+	pub total: usize,
 }
 
 impl fmt::Display for PopulateError {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-		writeln!(f, "assertions failed:")?;
-		for message in &self.messages {
-			writeln!(f, "{message}")?;
+		// No trailing newline: the caller owns how this is framed.
+		write!(f, "circuit not satisfied: {} assertion(s) failed", self.total)?;
+		for failure in &self.failures {
+			write!(f, "\n  {failure}")?;
 		}
-		if self.total_count > self.messages.len() {
-			writeln!(f, "(Some assertions are omitted. Total: {})", self.total_count)?;
+		let omitted = self.total.saturating_sub(self.failures.len());
+		if omitted > 0 {
+			write!(f, "\n  ... and {omitted} more, omitted")?;
 		}
 		Ok(())
 	}
 }
-
-impl error::Error for PopulateError {}
 
 /// A helper struct for filling witness values in a circuit.
 pub struct WitnessFiller<'a> {
@@ -181,9 +213,9 @@ impl Circuit {
 	///
 	/// # Errors
 	///
-	/// In case the circuit is not satisfiable (any assertion fails), this function will return
-	/// an error with a list of assertion failure messages.
-	///
+	/// Returns [`PopulateError`] when any assertion fails.
+	/// Each failure names the circuit path the assertion was declared under.
+	/// Evaluation runs to completion first, so every violation is reported at once.
 	///
 	/// [`CircuitBuilder::add_constant`]: super::CircuitBuilder::add_constant
 	/// [`CircuitBuilder::add_inout`]: super::CircuitBuilder::add_inout
@@ -296,5 +328,79 @@ impl Circuit {
 	/// Returns a string with a JSON dump that is useful to profile the circuit.
 	pub fn simple_json_dump(&self) -> String {
 		dump_composition(&self.gate_graph)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn failure(path: &str, detail: &str) -> AssertionFailure {
+		AssertionFailure {
+			path: path.to_string(),
+			detail: detail.to_string(),
+		}
+	}
+
+	#[test]
+	fn a_failure_at_the_root_renders_without_a_separator() {
+		// A root assertion has no path, so there is nothing to prefix and no stray colon.
+		assert_eq!(failure("", "Word(0x1) != Word(0x2)").to_string(), "Word(0x1) != Word(0x2)");
+	}
+
+	#[test]
+	fn a_nested_failure_renders_path_then_detail() {
+		// The path and the detail are stored apart; rendering is what joins them.
+		assert_eq!(
+			failure(".sha256.round", "Word(0x1) != 0").to_string(),
+			".sha256.round: Word(0x1) != 0"
+		);
+	}
+
+	#[test]
+	fn the_error_lists_every_retained_failure_and_never_ends_with_a_newline() {
+		// Invariant: a caller frames the message, so it must not arrive with its own line break.
+		let err = PopulateError {
+			failures: vec![failure(".a", "one"), failure(".b", "two")],
+			total: 2,
+		};
+		let rendered = err.to_string();
+		assert_eq!(rendered, "circuit not satisfied: 2 assertion(s) failed\n  .a: one\n  .b: two");
+		assert!(!rendered.ends_with('\n'));
+	}
+
+	#[test]
+	fn a_capped_error_reports_how_many_it_dropped() {
+		// `total` counts past the cap, so the difference is what the list does not show.
+		let err = PopulateError {
+			failures: vec![failure(".a", "one")],
+			total: 7,
+		};
+		assert_eq!(
+			err.to_string(),
+			"circuit not satisfied: 7 assertion(s) failed\n  .a: one\n  ... and 6 more, omitted"
+		);
+	}
+
+	#[test]
+	fn an_uncapped_error_reports_no_omissions() {
+		// Equal counts mean the cap was never reached, so no trailing note is added.
+		let err = PopulateError {
+			failures: vec![failure(".a", "one")],
+			total: 1,
+		};
+		assert_eq!(err.to_string(), "circuit not satisfied: 1 assertion(s) failed\n  .a: one");
+	}
+
+	#[test]
+	fn the_error_is_a_std_error() {
+		// The whole point of the type: it can cross an API boundary as a `dyn Error`.
+		let err = PopulateError {
+			failures: vec![failure(".a", "one")],
+			total: 1,
+		};
+		let boxed: Box<dyn std::error::Error> = Box::new(err);
+		assert!(boxed.to_string().starts_with("circuit not satisfied"));
+		assert!(boxed.source().is_none());
 	}
 }

--- a/crates/frontend/src/compiler/eval_form/assertion.rs
+++ b/crates/frontend/src/compiler/eval_form/assertion.rs
@@ -8,23 +8,16 @@ use crate::compiler::pathspec::{PathSpec, PathSpecTree};
 /// Failures past the cap are counted but not stored.
 pub const MAX_ASSERTION_FAILURES: usize = 100;
 
-/// Renders a failure message, prefixed by the path the assertion was raised under.
+/// Renders the circuit path an assertion was raised under.
 ///
-/// The prefix is dropped when no tree is available to resolve the path, or when it renders empty.
-pub fn symbolicate(
-	path_spec_tree: Option<&PathSpecTree>,
-	path_spec: PathSpec,
-	message: String,
-) -> String {
+/// Empty when no tree is available to resolve the path, or when the assertion sits at the root.
+/// The path is kept apart from the failure detail so a caller can group failures by subcircuit.
+pub fn render_path(path_spec_tree: Option<&PathSpecTree>, path_spec: PathSpec) -> String {
 	let Some(tree) = path_spec_tree else {
-		return message;
+		return String::new();
 	};
 
 	let mut path = String::new();
 	tree.stringify(path_spec, &mut path);
-	if path.is_empty() {
-		message
-	} else {
-		format!("{path}: {message}")
-	}
+	path
 }

--- a/crates/frontend/src/compiler/eval_form/batch.rs
+++ b/crates/frontend/src/compiler/eval_form/batch.rs
@@ -23,11 +23,11 @@ use binius_core::Word;
 use binius_utils::strided_array::StridedArray2DViewMut;
 
 use super::{
-	assertion::{MAX_ASSERTION_FAILURES, symbolicate},
+	assertion::{MAX_ASSERTION_FAILURES, render_path},
 	exec::EvalContext,
 };
 use crate::compiler::{
-	circuit::PopulateError,
+	circuit::{AssertionFailure, PopulateError},
 	pathspec::{PathSpec, PathSpecTree},
 };
 
@@ -42,11 +42,16 @@ struct InstanceAssertionFailure {
 ///
 /// Serial batched evaluation reports the lowest-indexed failing instance. Parallel batched
 /// evaluation runs over independent stripes, and may report the first failing stripe observed.
-#[derive(Debug)]
+///
+/// The inner [`PopulateError`] is the error's source, so the pair renders as one chain.
+#[derive(Debug, thiserror::Error)]
+#[error("instance {instance} is not satisfied: {source}")]
+#[non_exhaustive]
 pub struct BatchPopulateError {
 	/// The index of the reported failing instance.
 	pub instance: usize,
 	/// The assertion failures recorded for that instance.
+	#[source]
 	pub source: PopulateError,
 }
 
@@ -87,19 +92,22 @@ impl<'a, 'v> BatchExecutionContext<'a, 'v> {
 			return Ok(());
 		};
 
-		// Collect and symbolicate just the reported instance's messages.
-		let mut messages = Vec::new();
-		let mut total_count = 0;
-		for failure in self.failures.into_iter().filter(|f| f.instance == instance) {
-			total_count += 1;
-			messages.push(symbolicate(path_spec_tree, failure.path_spec, failure.message));
-		}
+		// Keep just the reported instance's failures, resolving each path against the tree.
+		let failures: Vec<AssertionFailure> = self
+			.failures
+			.into_iter()
+			.filter(|f| f.instance == instance)
+			.map(|f| AssertionFailure {
+				path: render_path(path_spec_tree, f.path_spec),
+				detail: f.message,
+			})
+			.collect();
 
 		Err(BatchPopulateError {
 			instance,
 			source: PopulateError {
-				messages,
-				total_count,
+				total: failures.len(),
+				failures,
 			},
 		})
 	}
@@ -148,7 +156,7 @@ mod tests {
 	use binius_core::Word;
 	use binius_utils::strided_array::StridedArray2DViewMut;
 
-	use crate::compiler::CircuitBuilder;
+	use crate::compiler::{CircuitBuilder, circuit::AssertionFailure};
 
 	// The batched interpreter must reproduce, for every instance, exactly what the single-instance
 	// interpreter produces for the same inputs. This is the core equivalence guarantee.
@@ -249,10 +257,20 @@ mod tests {
 			.populate_wire_witness_batched(&mut view)
 			.expect_err("instances 2 and 3 violate a == b");
 		assert_eq!(err.instance, 2);
-		assert_eq!(err.source.total_count, 1);
+		assert_eq!(err.source.total, 1);
 		assert_eq!(
-			err.source.messages,
-			vec![".a_eq_b: Word(0x0000000000000004) != Word(0x0000000000000005)".to_string()]
+			err.source.failures,
+			vec![AssertionFailure {
+				path: ".a_eq_b".to_string(),
+				detail: "Word(0x0000000000000004) != Word(0x0000000000000005)".to_string(),
+			}]
 		);
+		// thiserror supplies the instance prefix and chains the inner error as the source.
+		let rendered = err.to_string();
+		assert!(rendered.starts_with("instance 2 is not satisfied: "), "{rendered}");
+		assert!(rendered.contains(".a_eq_b: Word(0x0000000000000004)"), "{rendered}");
+		// An error message must not carry its own trailing newline.
+		assert!(!rendered.ends_with('\n'), "{rendered}");
+		assert!(std::error::Error::source(&err).is_some(), "the inner error must be the source");
 	}
 }

--- a/crates/frontend/src/compiler/eval_form/mod.rs
+++ b/crates/frontend/src/compiler/eval_form/mod.rs
@@ -15,6 +15,7 @@ mod scalar;
 #[cfg(test)]
 mod tests;
 
+pub use assertion::MAX_ASSERTION_FAILURES;
 use batch::BatchExecutionContext;
 pub use batch::BatchPopulateError;
 use binius_core::{ValueIndex, ValueVec, Word};

--- a/crates/frontend/src/compiler/eval_form/scalar.rs
+++ b/crates/frontend/src/compiler/eval_form/scalar.rs
@@ -9,16 +9,16 @@
 use binius_core::{ValueIndex, ValueVec, Word};
 
 use super::{
-	assertion::{MAX_ASSERTION_FAILURES, symbolicate},
+	assertion::{MAX_ASSERTION_FAILURES, render_path},
 	exec::EvalContext,
 };
 use crate::compiler::{
-	circuit::PopulateError,
+	circuit::{AssertionFailure, PopulateError},
 	pathspec::{PathSpec, PathSpecTree},
 };
 
-/// Assertion failure information
-struct AssertionFailure {
+/// One recorded assertion failure, before its path is resolved against the tree.
+struct RecordedFailure {
 	path_spec: PathSpec,
 	message: String,
 }
@@ -29,7 +29,7 @@ pub struct ExecutionContext<'a> {
 	/// Assertion failures recorded during the evaluation of the circuit.
 	///
 	/// This list is capped by [`MAX_ASSERTION_FAILURES`].
-	assertion_failures: Vec<AssertionFailure>,
+	assertion_failures: Vec<RecordedFailure>,
 	/// The total number of assert violations recorded.
 	assertion_count: usize,
 }
@@ -53,12 +53,15 @@ impl<'a> ExecutionContext<'a> {
 		}
 
 		Err(PopulateError {
-			messages: self
+			failures: self
 				.assertion_failures
 				.into_iter()
-				.map(|f| symbolicate(path_spec_tree, f.path_spec, f.message))
+				.map(|f| AssertionFailure {
+					path: render_path(path_spec_tree, f.path_spec),
+					detail: f.message,
+				})
 				.collect(),
-			total_count: self.assertion_count,
+			total: self.assertion_count,
 		})
 	}
 }
@@ -82,7 +85,7 @@ impl EvalContext for ExecutionContext<'_> {
 		self.assertion_count += 1;
 		if self.assertion_failures.len() < MAX_ASSERTION_FAILURES {
 			self.assertion_failures
-				.push(AssertionFailure { path_spec, message });
+				.push(RecordedFailure { path_spec, message });
 		}
 	}
 }

--- a/crates/frontend/src/compiler/tests.rs
+++ b/crates/frontend/src/compiler/tests.rs
@@ -866,10 +866,11 @@ fn test_scratch_pooling_rejects_a_bad_assignment() {
 		.populate_wire_witness(&mut w)
 		.expect_err("a perturbed expected value must fail the chain assertion");
 	// Exactly one assertion exists in the fixture, so exactly one failure is reported.
-	assert_eq!(err.total_count, 1);
-	assert_eq!(err.messages.len(), 1);
-	// The message is prefixed with the path of the assertion that failed, naming the chain.
-	assert!(err.messages[0].starts_with(".chain: "), "unexpected message: {}", err.messages[0]);
+	assert_eq!(err.total, 1);
+	assert_eq!(err.failures.len(), 1);
+	// The failure names the path of the assertion that failed, apart from the detail.
+	assert_eq!(err.failures[0].path, ".chain");
+	assert!(!err.failures[0].detail.is_empty());
 }
 
 #[test]

--- a/crates/frontend/src/lib.rs
+++ b/crates/frontend/src/lib.rs
@@ -32,8 +32,8 @@ pub mod stat;
 
 pub use compiler::{
 	CircuitBuilder, Options, Wire,
-	circuit::{Circuit, PopulateError, WitnessFiller},
-	eval_form::BatchPopulateError,
+	circuit::{AssertionFailure, Circuit, PopulateError, WitnessFiller},
+	eval_form::{BatchPopulateError, MAX_ASSERTION_FAILURES},
 	hints::{self, Hint},
 };
 pub use stat::CircuitStat;

--- a/crates/m4-prover/src/value_table.rs
+++ b/crates/m4-prover/src/value_table.rs
@@ -326,7 +326,7 @@ impl IndexMut<Wire> for BatchWitnessFiller<'_, '_> {
 mod tests {
 	use binius_compute::GlobalAllocator;
 	use binius_field::PackedBinaryGhash1x128b;
-	use binius_frontend::{CircuitBuilder, Wire};
+	use binius_frontend::{AssertionFailure, CircuitBuilder, Wire};
 	use proptest::prelude::*;
 	use rand::prelude::*;
 
@@ -510,10 +510,13 @@ mod tests {
 
 		let err = result.expect_err("instance 2 violates a == b");
 		assert_eq!(err.instance, 2);
-		assert_eq!(err.source.total_count, 1);
+		assert_eq!(err.source.total, 1);
 		assert_eq!(
-			err.source.messages,
-			vec![".a_eq_b: Word(0x0000000000000002) != Word(0x0000000000000063)".to_string()]
+			err.source.failures,
+			vec![AssertionFailure {
+				path: ".a_eq_b".to_string(),
+				detail: "Word(0x0000000000000002) != Word(0x0000000000000063)".to_string(),
+			}]
 		);
 	}
 
@@ -535,10 +538,13 @@ mod tests {
 
 		let err = result.expect_err("instance 5 violates a == b");
 		assert_eq!(err.instance, 5);
-		assert_eq!(err.source.total_count, 1);
+		assert_eq!(err.source.total, 1);
 		assert_eq!(
-			err.source.messages,
-			vec![".a_eq_b: Word(0x0000000000000005) != Word(0x0000000000000063)".to_string()]
+			err.source.failures,
+			vec![AssertionFailure {
+				path: ".a_eq_b".to_string(),
+				detail: "Word(0x0000000000000005) != Word(0x0000000000000063)".to_string(),
+			}]
 		);
 	}
 
@@ -562,13 +568,13 @@ mod tests {
 			.expect_err("instances fail");
 
 		assert!(parallel.instance == 5 || parallel.instance == 7);
-		assert_eq!(parallel.source.total_count, 1);
+		assert_eq!(parallel.source.total, 1);
 		assert_eq!(
-			parallel.source.messages,
-			vec![format!(
-				".a_eq_b: Word(0x{0:016x}) != Word(0x0000000000000063)",
-				parallel.instance
-			)]
+			parallel.source.failures,
+			vec![AssertionFailure {
+				path: ".a_eq_b".to_string(),
+				detail: format!("Word(0x{0:016x}) != Word(0x0000000000000063)", parallel.instance),
+			}]
 		);
 	}
 


### PR DESCRIPTION
`BatchPopulateError` implements neither `Display` nor `Error`, so a downstream caller cannot print it or box it.
This gives both witness-population errors the standard treatment, and stops gluing the assertion path into a string.

### The problem

`BatchPopulateError` has exactly one `impl` block — the derived `Debug`:

```
$ grep -rn 'for BatchPopulateError' crates/
(nothing)
```

It is `pub use`d from `binius-frontend`, and `ValueTable::populate*` in `binius-m4-prover` returns it verbatim.
So it is in two crates' public APIs, and a caller cannot do either basic thing with it:

```
error[E0277]: the trait bound `BatchPopulateError: std::error::Error` is not satisfied
  = note: required for the cast from `Box<BatchPopulateError>` to `Box<dyn std::error::Error>`
error[E0277]: `BatchPopulateError` doesn't implement `std::fmt::Display`
```

`?` works today only because every caller's return type is *literally* `BatchPopulateError`, riding the identity `From`.
The field is even named **`source`**, which reads as `Error::source()` but was never wired to it.

Separately, `PopulateError` carried its failures as `Vec<String>`.
`symbolicate` had already glued the circuit path onto the diagnostic with `format!("{path}: {message}")`, so the one piece of machine-usable structure was only recoverable by parsing prose.

### The idea

Use `thiserror`, which is already the house style — **ten** of the workspace crates use it, and `binius-frontend` did not even have the dependency.

For `BatchPopulateError` it fits exactly, and wires up the source chain the field name was already claiming:

```
#[derive(Debug, thiserror::Error)]
#[error("instance {instance} is not satisfied: {source}")]
#[non_exhaustive]
pub struct BatchPopulateError {
    pub instance: usize,
    #[source]
    pub source: PopulateError,
}
```

For `PopulateError`, keep the path and the diagnostic apart instead of pre-joining them:

```
pub struct AssertionFailure {
    pub path: String,      // ".sha256.round[3]", empty at the circuit root
    pub detail: String,    // "Word(0x1) != Word(0x2)"
}
```

So `symbolicate(tree, path_spec, message) -> String` becomes `render_path(tree, path_spec) -> String`, and rendering is what joins them again.

### What is *not* structured, and why

The `detail` stays a `String`. That is deliberate.

- Those strings come from six sites in `exec.rs` — `"{val:?} != 0"`, `"{val:?} MSB is true"`, and so on.
- They are diagnostics for a human, not something a caller branches on.
- A variant per assert opcode would have tripled the diff for no caller benefit.

The docs say so plainly, so nobody matches on the wording.

The **path** is different: it is a real field a caller can group by, which is why it is split out.

### Two smaller fixes that fall out

**The `Display` no longer ends with a newline.** Every arm was `writeln!`, so the message arrived with its own trailing break — the Rust API guidelines ask that the caller own the framing:

```
circuit not satisfied: 1 assertion(s) failed
  .mixer.x_eq_y: Word(0x0000000000000001) != Word(0x0000000000000002)
```

**`MAX_ASSERTION_FAILURES` is now exported.** The old doc on `messages` named it, but it lived behind a private module, so no crate user could see it or link to it. It is the reason `total` can exceed `failures.len()`, so it belongs in the API.

### Scope

- **new:** `AssertionFailure`, exported alongside `MAX_ASSERTION_FAILURES`
- **changed:** `PopulateError` — `messages: Vec<String>` to `failures: Vec<AssertionFailure>`, `total_count` to `total`
- **changed:** `BatchPopulateError` — gains `Display`, `Error`, and a real source chain
- **changed:** `symbolicate` to `render_path`, and both execution contexts that build failures
- **`#[non_exhaustive]`** on both error types; `AssertionFailure` is left constructible, since tests build it to compare against
- **untouched:** what counts as a failure, the cap, and which instance a batch reports

### Breaking change

`binius-m4-prover` propagates `BatchPopulateError` out of `ValueTable::populate*`, and three of its tests read the old fields. Updated here. Nothing outside tests touched them.

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo +nightly fmt --all --check` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc -p binius-frontend --no-deps` — clean, so the new doc link resolves
- `cargo nextest run -p binius-frontend -p binius-circuits -p binius-m4-prover` — **582 passed**

`circuit.rs` had no test module at all. It now has six, covering root-versus-nested rendering, the no-trailing-newline invariant, the capped and uncapped omission lines, and `Box<dyn Error>` round-tripping.

The fix is confirmed from outside the workspace: a scratch crate that failed to compile against `main` now builds and prints the error, its structured fields, and its source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)