### PR TITLE
Collapse the three round-evaluation structs into RoundEvals<T, D>

### DIFF
--- a/crates/ip-prover/src/sumcheck/bivariate_product_evaluator.rs
+++ b/crates/ip-prover/src/sumcheck/bivariate_product_evaluator.rs
@@ -8,7 +8,7 @@ use itertools::izip;
 
 use super::{
 	mle_store::{ColId, EvaluationChunk, MleStore, RoundContext},
-	round_evals::{RoundEvals2, WideRoundEvals2},
+	round_evals::RoundEvals,
 	round_evaluator::{SharedSumcheckProver, SumcheckRoundEvaluator},
 };
 
@@ -70,7 +70,8 @@ impl<F: Field, P: PackedField<Scalar = F>> SumcheckRoundEvaluator<F, P>
 		//
 		// The per-point products are accumulated in unreduced (wide) form and reduced a single
 		// time in interpolate, amortizing the GF(2^128) reduction over the whole sum.
-		let mut evals = WideRoundEvals2::<<P as WideMul>::Output>::default();
+		let mut y_1 = <P as WideMul>::Output::default();
+		let mut y_inf = <P as WideMul>::Output::default();
 		for (&a_0_i, &a_1_i, &b_0_i, &b_1_i) in
 			izip!(a.lo.as_ref(), a.hi.as_ref(), b.lo.as_ref(), b.hi.as_ref())
 		{
@@ -78,15 +79,11 @@ impl<F: Field, P: PackedField<Scalar = F>> SumcheckRoundEvaluator<F, P>
 			let a_inf_i = a_0_i + a_1_i;
 			let b_inf_i = b_0_i + b_1_i;
 
-			evals += WideRoundEvals2 {
-				y_1: P::wide_mul(a_1_i, b_1_i),
-				y_inf: P::wide_mul(a_inf_i, b_inf_i),
-			};
+			y_1 += P::wide_mul(a_1_i, b_1_i);
+			y_inf += P::wide_mul(a_inf_i, b_inf_i);
 		}
 
-		// The evaluator's single-claim run holds `y_1` in slot 0 and `y_inf` in slot 1.
-		accum[0] += evals.y_1;
-		accum[1] += evals.y_inf;
+		RoundEvals([y_1, y_inf]).add_to(accum);
 	}
 
 	fn interpolate(&self, ctx: &RoundContext<'_, P>, accum: &[P], claim: F) -> RoundCoeffs<F> {
@@ -96,12 +93,9 @@ impl<F: Field, P: PackedField<Scalar = F>> SumcheckRoundEvaluator<F, P>
 
 		// `claim` is this round's sum.
 		// The evaluation at 0, which was never sampled, is recovered from it.
-		RoundEvals2 {
-			y_1: accum[0],
-			y_inf: accum[1],
-		}
-		.sum_scalars(n_vars_remaining)
-		.interpolate(claim)
+		RoundEvals::<P, 2>::from_slots(accum)
+			.sum_scalars(n_vars_remaining)
+			.interpolate(claim)
 	}
 }
 

--- a/crates/ip-prover/src/sumcheck/eq_tracker.rs
+++ b/crates/ip-prover/src/sumcheck/eq_tracker.rs
@@ -30,7 +30,7 @@ use binius_math::{
 	multilinear::eq::{eq_ind_partial_eval, eq_ind_truncate_low_inplace, eq_one_var},
 };
 
-use super::round_evals::{RoundEvals2, round_coeffs_by_eq};
+use super::round_evals::RoundEvals;
 
 /// Where the rounds have reached in the point, and the product they accrued.
 #[derive(Debug, Clone)]
@@ -230,7 +230,7 @@ impl<F: Field, P: PackedField<Scalar = F>> ChunkedEqTracker<P> {
 	pub fn interpolate2(
 		&self,
 		sum: F,
-		prime_evals: RoundEvals2<F>,
+		prime_evals: RoundEvals<F, 2>,
 	) -> (RoundCoeffs<F>, RoundCoeffs<F>) {
 		let alpha = self.next_coordinate();
 
@@ -240,7 +240,7 @@ impl<F: Field, P: PackedField<Scalar = F>> ChunkedEqTracker<P> {
 
 		// Multiplying the linear term back in restores the second factor.
 		// Scaling by the accrued product restores the first.
-		let round_coeffs = round_coeffs_by_eq(&prime_coeffs, alpha) * self.prefix.eq_prefix_eval;
+		let round_coeffs = prime_coeffs.mul_by_eq(alpha) * self.prefix.eq_prefix_eval;
 
 		(prime_coeffs, round_coeffs)
 	}

--- a/crates/ip-prover/src/sumcheck/frac_add_mle.rs
+++ b/crates/ip-prover/src/sumcheck/frac_add_mle.rs
@@ -7,7 +7,7 @@ use binius_math::FieldSlice;
 use crate::sumcheck::{
 	mle_store::{ColId, ColumnChunk, EvaluationChunk, RoundContext},
 	quadratic_mle_evaluator::QuadraticMleEvaluator,
-	round_evals::RoundEvals2,
+	round_evals::RoundEvals,
 	round_evaluator::MleCheckRoundEvaluator,
 };
 
@@ -57,7 +57,7 @@ where
 /// The sums `den_a.lo + den_a.hi` and `den_b.lo + den_b.hi` are then formed once, not twice.
 ///
 /// It emits one round polynomial, already batched, rather than one per claim.
-/// That is exact, because [`RoundEvals2::interpolate_eq`] is affine in its claim and evaluations:
+/// That is exact, because [`RoundEvals::interpolate_eq`] is affine in its claim and evaluations:
 ///
 /// ```text
 ///     interp(c_num + z*c_den, y_num + z*y_den) = interp(c_num, y_num) + z*interp(c_den, y_den)
@@ -138,10 +138,10 @@ where
 			den_y_inf += P::wide_mul(da * db, eq_i);
 		}
 
-		accum[0] += num_y_1;
-		accum[1] += num_y_inf;
-		accum[2] += den_y_1;
-		accum[3] += den_y_inf;
+		// The run holds the two claims back to back: numerator first, then denominator.
+		let (numerator, denominator) = accum.split_at_mut(2);
+		RoundEvals([num_y_1, num_y_inf]).add_to(numerator);
+		RoundEvals([den_y_1, den_y_inf]).add_to(denominator);
 	}
 
 	fn interpolate(
@@ -156,16 +156,9 @@ where
 		assert!(n_vars_remaining > 0);
 
 		// Sum each claim's packed lanes into scalars.
-		let numerator = RoundEvals2 {
-			y_1: accum[0],
-			y_inf: accum[1],
-		}
-		.sum_scalars(n_vars_remaining);
-		let denominator = RoundEvals2 {
-			y_1: accum[2],
-			y_inf: accum[3],
-		}
-		.sum_scalars(n_vars_remaining);
+		let (num_slots, den_slots) = accum.split_at(2);
+		let numerator = RoundEvals::<P, 2>::from_slots(num_slots).sum_scalars(n_vars_remaining);
+		let denominator = RoundEvals::<P, 2>::from_slots(den_slots).sum_scalars(n_vars_remaining);
 
 		// Batch the sampled evaluations, then interpolate once against the batched claim.
 		// That order is equivalent to interpolating each claim and batching the polynomials.

--- a/crates/ip-prover/src/sumcheck/mle_to_sumcheck.rs
+++ b/crates/ip-prover/src/sumcheck/mle_to_sumcheck.rs
@@ -8,7 +8,6 @@ use binius_math::multilinear::eq::eq_one_var;
 use crate::sumcheck::{
 	common::{MleCheckProver, SumcheckProver},
 	mle_store::{EqId, EvaluationChunk, RoundContext},
-	round_evals::round_coeffs_by_eq,
 	round_evaluator::{MleCheckRoundEvaluator, SumcheckRoundEvaluator},
 };
 
@@ -57,7 +56,7 @@ impl<F: Field, InnerProver: MleCheckProver<F>> SumcheckProver<F>
 		let alpha = self.mlecheck_prover.eval_point()[self.n_vars() - 1];
 		round_coeffs_multi
 			.into_iter()
-			.map(|round_coeffs| round_coeffs_by_eq(&round_coeffs, alpha) * self.eq_prefix_eval)
+			.map(|round_coeffs| round_coeffs.mul_by_eq(alpha) * self.eq_prefix_eval)
 			.collect()
 	}
 
@@ -140,6 +139,6 @@ where
 		let round_coeffs = self.inner.interpolate(ctx, accum, inner_claim, alpha);
 
 		// Multiply the inner MLE-check round polynomial by (X - α) and the equality prefix.
-		round_coeffs_by_eq(&round_coeffs, alpha) * eq_prefix
+		round_coeffs.mul_by_eq(alpha) * eq_prefix
 	}
 }

--- a/crates/ip-prover/src/sumcheck/mod.rs
+++ b/crates/ip-prover/src/sumcheck/mod.rs
@@ -13,10 +13,6 @@ pub mod multilinear_eval;
 mod padded;
 mod prove;
 pub mod quadratic_mle_evaluator;
-// `round_evals` is internal implementation, exposed (via `#[doc(hidden)]` `pub mod`) only so
-// `binius-prover` can compute the shift reduction's sparse first sumcheck round with the exact
-// interpolation the in-crate provers use. Not a stable API.
-#[doc(hidden)]
 pub mod round_evals;
 pub mod round_evaluator;
 mod round_state;

--- a/crates/ip-prover/src/sumcheck/multilinear_eval.rs
+++ b/crates/ip-prover/src/sumcheck/multilinear_eval.rs
@@ -8,7 +8,7 @@ use binius_math::{FieldSlice, FieldVec};
 
 use super::{
 	mle_store::{ColId, EvaluationChunk, MleStore, RoundContext},
-	round_evals::RoundEvals1,
+	round_evals::RoundEvals,
 	round_evaluator::{MleCheckRoundEvaluator, SharedMleCheckProver},
 };
 
@@ -59,7 +59,7 @@ where
 		for (idx, &eq_i) in eq_ind.as_ref().iter().enumerate() {
 			y_1 += P::wide_mul(col.hi.as_ref()[idx], eq_i);
 		}
-		accum[0] += y_1;
+		RoundEvals([y_1]).add_to(accum);
 	}
 
 	fn interpolate(
@@ -78,7 +78,7 @@ where
 		// Sum its lanes, then interpolate.
 		// `claim` is this round's prime evaluation.
 		// `alpha` is the eq coordinate that ties it to the point.
-		RoundEvals1 { y_1: accum[0] }
+		RoundEvals::<P, 1>::from_slots(accum)
 			.sum_scalars(n_vars_remaining)
 			.interpolate_eq(claim, alpha)
 	}

--- a/crates/ip-prover/src/sumcheck/quadratic_mle_evaluator.rs
+++ b/crates/ip-prover/src/sumcheck/quadratic_mle_evaluator.rs
@@ -7,7 +7,7 @@ use binius_math::{FieldSlice, FieldVec};
 
 use super::{
 	mle_store::{ColId, ColumnChunk, EvaluationChunk, MleStore, RoundContext},
-	round_evals::RoundEvals2,
+	round_evals::RoundEvals,
 	round_evaluator::{MleCheckRoundEvaluator, SharedMleCheckProver},
 };
 
@@ -148,7 +148,6 @@ where
 		// corresponds to x=0, the high half to x=1.
 		let cols: [&ColumnChunk<'_, P>; N] = self.cols.map(|id| chunk.col(id));
 
-		// The evaluator's run holds `y_1` in slot 0 and `y_inf` in slot 1.
 		let mut y_1 = <P as WideMul>::Output::default();
 		let mut y_inf = <P as WideMul>::Output::default();
 		for (idx, &eq_i) in eq_ind.as_ref().iter().enumerate() {
@@ -173,8 +172,7 @@ where
 			y_inf += P::wide_mul((self.infinity_composition)(evals_inf), eq_i);
 		}
 
-		accum[0] += y_1;
-		accum[1] += y_inf;
+		RoundEvals([y_1, y_inf]).add_to(accum);
 	}
 
 	fn interpolate(
@@ -191,12 +189,9 @@ where
 		// `accum` is already reduced (the prover's `map` pass reduced the wide accumulators). Sum
 		// the packed lanes into scalars, then interpolate. `claim` is this round's prime eval;
 		// `alpha`, this round's eq coordinate, ties it to the point.
-		RoundEvals2 {
-			y_1: accum[0],
-			y_inf: accum[1],
-		}
-		.sum_scalars(n_vars_remaining)
-		.interpolate_eq(claim, alpha)
+		RoundEvals::<P, 2>::from_slots(accum)
+			.sum_scalars(n_vars_remaining)
+			.interpolate_eq(claim, alpha)
 	}
 }
 

--- a/crates/ip-prover/src/sumcheck/round_evals.rs
+++ b/crates/ip-prover/src/sumcheck/round_evals.rs
@@ -1,204 +1,355 @@
 // Copyright 2023-2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-use std::ops::{Add, AddAssign, Mul};
+//! Sampled round-polynomial evaluations, and their interpolation to monomial coefficients.
+//!
+//! A sumcheck round produces one univariate polynomial per claim.
+//! The prover samples it at a few nodes, then solves for its coefficients.
+//!
+//! ```text
+//!     accumulate    sum the composition over the halved hypercube, at each sampled node
+//!     reduce        collapse the wide accumulator, once per round
+//!     sum_scalars   sum the packed lanes into field elements
+//!     interpolate   recover the node at 0 from the round claim, then solve
+//! ```
+//!
+//! The evaluation at 0 is never sampled.
+//! Recovering it from the round claim saves the prover one node per round.
+
+use std::{
+	array, iter,
+	ops::{Add, AddAssign, Mul},
+};
 
 use binius_field::{Field, PackedField, WideMul};
 use binius_ip::sumcheck::RoundCoeffs;
 
-// Sumcheck round evaluations for degree-1 polynomials, on point 1 alone.
-#[derive(Clone, Debug, Default)]
-pub struct RoundEvals1<P: PackedField> {
-	pub y_1: P,
-}
-
-impl<P: PackedField> RoundEvals1<P> {
-	pub fn sum_scalars(self, n_vars: usize) -> RoundEvals1<P::Scalar> {
-		RoundEvals1 {
-			y_1: self.y_1.iter().take(1 << n_vars).sum(),
-		}
-	}
-}
-
-impl<F: Field> RoundEvals1<F> {
-	// Interpolation routine for evaluations on P'(x) in Mlechecks.
-	pub fn interpolate_eq(self, sum: F, alpha: F) -> RoundCoeffs<F> {
-		let y_0 = (sum - self.y_1 * alpha) * (F::ONE - alpha).invert_or_zero();
-		calculate_round_coeffs_from_evals_1(y_0, self.y_1)
-	}
-}
-
-impl<P: PackedField> Add<&Self> for RoundEvals1<P> {
-	type Output = Self;
-
-	fn add(mut self, rhs: &Self) -> Self::Output {
-		self += rhs;
-		self
-	}
-}
-
-impl<P: PackedField> AddAssign<&Self> for RoundEvals1<P> {
-	fn add_assign(&mut self, rhs: &Self) {
-		self.y_1 += rhs.y_1;
-	}
-}
-
-impl<P: PackedField> Mul<P::Scalar> for RoundEvals1<P> {
-	type Output = Self;
-
-	fn mul(mut self, rhs: P::Scalar) -> Self::Output {
-		self.y_1 *= rhs;
-		self
-	}
-}
-
-// Sumcheck round evaluations for degree-2 polynomials, on points 1 and ∞. The latter
-// is defined as limit of P(X)/X^n as X approaches infinity, which equals the leading coefficient.
-// This is the Karatsuba trick. Take note that it may require removing lower-degree terms from the
-// composition polynomial.
-#[derive(Clone, Copy, Debug, Default)]
-pub struct RoundEvals2<P: PackedField> {
-	pub y_1: P,
-	pub y_inf: P,
-}
-
-impl<P: PackedField> RoundEvals2<P> {
-	pub fn sum_scalars(self, n_vars: usize) -> RoundEvals2<P::Scalar> {
-		RoundEvals2 {
-			y_1: self.y_1.iter().take(1 << n_vars).sum(),
-			y_inf: self.y_inf.iter().take(1 << n_vars).sum(),
-		}
-	}
-}
-
-impl<F: Field> RoundEvals2<F> {
-	// Regular degree-2 interpolation routine.
-	pub fn interpolate(self, sum: F) -> RoundCoeffs<F> {
-		// Computing evaluation at 0 from sum claim and evaluation on 1.
-		let y_0 = sum - self.y_1;
-		calculate_round_coeffs_from_evals_2(y_0, self.y_1, self.y_inf)
-	}
-
-	// Interpolation routine for evaluations on P'(x) in Mlechecks.
-	pub fn interpolate_eq(self, sum: F, alpha: F) -> RoundCoeffs<F> {
-		// We are given a sum claim on prime polynomial from the previous round, we also know that
-		//  sum = (1 - alpha) * P'(0) + alpha * P'(1)
-		let y_0 = (sum - self.y_1 * alpha) * (F::ONE - alpha).invert_or_zero();
-		calculate_round_coeffs_from_evals_2(y_0, self.y_1, self.y_inf)
-	}
-}
-
-impl<P: PackedField> Add<&Self> for RoundEvals2<P> {
-	type Output = Self;
-
-	fn add(mut self, rhs: &Self) -> Self::Output {
-		self += rhs;
-		self
-	}
-}
-
-impl<P: PackedField> AddAssign<&Self> for RoundEvals2<P> {
-	fn add_assign(&mut self, rhs: &Self) {
-		self.y_1 += rhs.y_1;
-		self.y_inf += rhs.y_inf;
-	}
-}
-
-impl<P: PackedField> Mul<P::Scalar> for RoundEvals2<P> {
-	type Output = Self;
-
-	fn mul(mut self, rhs: P::Scalar) -> Self::Output {
-		self.y_1 *= rhs;
-		self.y_inf *= rhs;
-		self
-	}
-}
-
-/// Widening (unreduced) accumulator for degree-2 sumcheck round evaluations.
+/// The `D` sampled evaluations of one claim's round polynomial.
 ///
-/// Stores `y_1` and `y_inf` as unreduced [`WideMul::Output`] values that can be summed via
-/// addition (XOR in GF(2)) without intermediate reduction. After accumulation, call
-/// [`reduce`](Self::reduce) to convert back to a `RoundEvals2<P>`.
-#[derive(Clone, Copy)]
-pub struct WideRoundEvals2<W> {
-	pub y_1: W,
-	pub y_inf: W,
-}
+/// A degree-`D` polynomial needs `D + 1` values.
+/// The round claim supplies the one at 0, so only `D` are sampled:
+///
+/// ```text
+///     D = 1    [ R(1) ]
+///     D = 2    [ R(1), R(inf) ]
+/// ```
+///
+/// Invariant: slot 0 is `R(1)`, which every recovery of `R(0)` reads.
+///
+/// `R(inf)` is the leading coefficient, at one addition per element.
+/// Any finite node past 1 would cost a full extrapolation.
+///
+/// `T` narrows as the round advances:
+///
+/// ```text
+///     accumulate    wide, unreduced
+///     reduce        packed
+///     sum_scalars   scalar
+/// ```
+#[derive(Clone, Copy, Debug)]
+pub struct RoundEvals<T, const D: usize>(pub [T; D]);
 
-impl<W: Default> Default for WideRoundEvals2<W> {
+impl<T: Default, const D: usize> Default for RoundEvals<T, D> {
 	fn default() -> Self {
-		Self {
-			y_1: W::default(),
-			y_inf: W::default(),
+		Self(array::from_fn(|_| T::default()))
+	}
+}
+
+impl<T, const D: usize> RoundEvals<T, D> {
+	/// Reads one evaluator's run of accumulator slots.
+	///
+	/// # Panics
+	///
+	/// Panics unless the run holds exactly `D` slots.
+	/// A mismatch means the evaluator's reported degree disagrees with the `D` its body uses.
+	pub fn from_slots(slots: &[T]) -> Self
+	where
+		T: Copy,
+	{
+		Self(
+			<[T; D]>::try_from(slots)
+				.expect("slot run length must equal the evaluator's reported degree"),
+		)
+	}
+
+	/// Adds these evaluations into one evaluator's run of accumulator slots.
+	///
+	/// An evaluator sums into locals through its hot loop, then calls this once per chunk.
+	/// The running sums therefore stay in registers, not in the shared accumulator buffer.
+	///
+	/// # Panics
+	///
+	/// Panics unless the run holds exactly `D` slots, as in [`Self::from_slots`].
+	pub fn add_to(self, slots: &mut [T])
+	where
+		T: AddAssign,
+	{
+		assert_eq!(slots.len(), D, "slot run length must equal the evaluator's reported degree");
+		for (slot, eval) in iter::zip(slots, self.0) {
+			*slot += eval;
+		}
+	}
+
+	/// Reduces every wide slot, once the round's accumulation is complete.
+	///
+	/// Accumulation sums unreduced products.
+	/// So the modular reduction is paid once per round, not once per hypercube element.
+	pub fn reduce<P: PackedField + WideMul<Output = T>>(self) -> RoundEvals<P, D> {
+		RoundEvals(self.0.map(P::reduce))
+	}
+}
+
+impl<P: PackedField, const D: usize> RoundEvals<P, D> {
+	/// Sums the packed lanes of every slot into a scalar.
+	///
+	/// A round narrower than one packed word leaves the trailing lanes dead.
+	/// So only the first `2^n_vars` are summed.
+	pub fn sum_scalars(self, n_vars: usize) -> RoundEvals<P::Scalar, D> {
+		RoundEvals(self.0.map(|eval| eval.iter().take(1 << n_vars).sum()))
+	}
+}
+
+impl<F: Field, const D: usize> RoundEvals<F, D> {
+	/// Recovers `R(0)` from an MLE-check round claim, at any prime degree.
+	///
+	/// The verifier reduces with `claim = (1 - alpha) * R(0) + alpha * R(1)`.
+	///
+	/// Solving for `R(0)` divides by `1 - alpha`.
+	/// That is non-zero for an honest challenge.
+	fn eval_at_zero_eq(&self, claim: F, alpha: F) -> F {
+		(claim - self.0[0] * alpha) * (F::ONE - alpha).invert_or_zero()
+	}
+}
+
+impl<F: Field> RoundEvals<F, 1> {
+	/// Interpolates the prime round polynomial of an MLE-check.
+	///
+	/// # Arguments
+	///
+	/// * `claim` - This round's claim on the prime polynomial.
+	/// * `alpha` - The coordinate of the evaluation point that this round binds.
+	pub fn interpolate_eq(self, claim: F, alpha: F) -> RoundCoeffs<F> {
+		let y_0 = self.eval_at_zero_eq(claim, alpha);
+		let [y_1] = self.0;
+
+		// For P(X) = c_1 X + c_0:
+		//
+		//     P(0) =       c_0
+		//     P(1) = c_1 + c_0
+		RoundCoeffs(vec![y_0, y_1 - y_0])
+	}
+}
+
+impl<F: Field> RoundEvals<F, 2> {
+	/// Interpolates a plain sumcheck round polynomial.
+	///
+	/// # Arguments
+	///
+	/// * `claim` - This round's sum claim.
+	pub fn interpolate(self, claim: F) -> RoundCoeffs<F> {
+		// The verifier checks `claim = R(0) + R(1)`, so the prover never samples 0.
+		let y_0 = claim - self.0[0];
+		self.coeffs_from_zero(y_0)
+	}
+
+	/// Interpolates the prime round polynomial of an MLE-check.
+	///
+	/// # Arguments
+	///
+	/// * `claim` - This round's claim on the prime polynomial.
+	/// * `alpha` - The coordinate of the evaluation point that this round binds.
+	pub fn interpolate_eq(self, claim: F, alpha: F) -> RoundCoeffs<F> {
+		let y_0 = self.eval_at_zero_eq(claim, alpha);
+		self.coeffs_from_zero(y_0)
+	}
+
+	/// Solves for the monomial coefficients, given the recovered evaluation at 0.
+	fn coeffs_from_zero(self, y_0: F) -> RoundCoeffs<F> {
+		let [y_1, y_inf] = self.0;
+
+		// For P(X) = c_2 X^2 + c_1 X + c_0:
+		//
+		//     P(0)   =             c_0
+		//     P(1)   = c_2 + c_1 + c_0
+		//     P(inf) = c_2
+		RoundCoeffs(vec![y_0, y_1 - y_0 - y_inf, y_inf])
+	}
+}
+
+impl<T: AddAssign + Copy, const D: usize> AddAssign<&Self> for RoundEvals<T, D> {
+	fn add_assign(&mut self, rhs: &Self) {
+		for (slot, &eval) in iter::zip(&mut self.0, &rhs.0) {
+			*slot += eval;
 		}
 	}
 }
 
-impl<W> WideRoundEvals2<W> {
-	pub fn reduce<P: PackedField + WideMul<Output = W>>(self) -> RoundEvals2<P> {
-		RoundEvals2 {
-			y_1: P::reduce(self.y_1),
-			y_inf: P::reduce(self.y_inf),
-		}
-	}
-}
-
-impl<W: Add<Output = W>> Add for WideRoundEvals2<W> {
+impl<T: AddAssign + Copy, const D: usize> Add<&Self> for RoundEvals<T, D> {
 	type Output = Self;
 
-	fn add(self, rhs: Self) -> Self {
-		Self {
-			y_1: self.y_1 + rhs.y_1,
-			y_inf: self.y_inf + rhs.y_inf,
+	fn add(mut self, rhs: &Self) -> Self::Output {
+		self += rhs;
+		self
+	}
+}
+
+impl<P: PackedField, const D: usize> Mul<P::Scalar> for RoundEvals<P, D> {
+	type Output = Self;
+
+	fn mul(mut self, rhs: P::Scalar) -> Self::Output {
+		for eval in &mut self.0 {
+			*eval *= rhs;
+		}
+		self
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use binius_field::FieldOps;
+	use binius_math::test_utils::Packed128b;
+	use proptest::prelude::*;
+
+	use super::*;
+
+	type P = Packed128b;
+	type F = <P as FieldOps>::Scalar;
+
+	#[test]
+	fn from_slots_reads_the_run_in_order() {
+		let slots = [F::from(1u128), F::from(2u128), F::from(3u128)];
+		// Only the run handed over is read, not the slots on either side of it.
+		let evals = RoundEvals::<F, 2>::from_slots(&slots[1..]);
+		assert_eq!(evals.0, [F::from(2u128), F::from(3u128)]);
+	}
+
+	#[test]
+	#[should_panic(expected = "slot run length must equal the evaluator's reported degree")]
+	fn from_slots_rejects_a_run_of_the_wrong_length() {
+		let slots = [F::from(1u128), F::from(2u128), F::from(3u128)];
+		let _ = RoundEvals::<F, 2>::from_slots(&slots);
+	}
+
+	#[test]
+	fn add_to_accumulates_into_the_run_alone() {
+		let mut slots = [F::from(1u128), F::from(2u128), F::from(3u128)];
+		// A two-slot run written at offset 1 must leave slot 0 untouched.
+		RoundEvals::<F, 2>([F::from(4u128), F::from(5u128)]).add_to(&mut slots[1..]);
+		assert_eq!(slots[0], F::from(1u128));
+		assert_eq!(slots[1], F::from(2u128) + F::from(4u128));
+		assert_eq!(slots[2], F::from(3u128) + F::from(5u128));
+	}
+
+	#[test]
+	#[should_panic(expected = "slot run length must equal the evaluator's reported degree")]
+	fn add_to_rejects_a_run_of_the_wrong_length() {
+		let mut slots = [F::from(1u128)];
+		RoundEvals::<F, 2>([F::from(2u128), F::from(3u128)]).add_to(&mut slots);
+	}
+
+	proptest! {
+		// Invariant: a plain sumcheck round polynomial reproduces the claim over its endpoints.
+		//
+		// This is the identity the verifier checks each round.
+		// The two sampled nodes must also come back out of the coefficients.
+		#[test]
+		fn interpolate_2_satisfies_the_sumcheck_identity(
+			y_1 in any::<u128>(),
+			y_inf in any::<u128>(),
+			claim in any::<u128>(),
+		) {
+			let [y_1, y_inf, claim] = [y_1, y_inf, claim].map(F::from);
+
+			let coeffs = RoundEvals::<F, 2>([y_1, y_inf]).interpolate(claim);
+
+			prop_assert_eq!(coeffs.0.len(), 3);
+			prop_assert_eq!(coeffs.sum_over_endpoints(), claim);
+			prop_assert_eq!(coeffs.evaluate(&F::ONE), y_1);
+			// The leading coefficient is by definition the evaluation at infinity.
+			prop_assert_eq!(coeffs.0[2], y_inf);
+		}
+
+		// Invariant: a degree-2 prime round polynomial reproduces the MLE-check claim.
+		//
+		// The verifier reduces with `claim = (1 - alpha) R(0) + alpha R(1)`.
+		// alpha = 1 makes that recovery singular, so an honest challenge excludes it.
+		#[test]
+		fn interpolate_eq_2_satisfies_the_mlecheck_identity(
+			y_1 in any::<u128>(),
+			y_inf in any::<u128>(),
+			claim in any::<u128>(),
+			alpha in any::<u128>(),
+		) {
+			let [y_1, y_inf, claim, alpha] = [y_1, y_inf, claim, alpha].map(F::from);
+			prop_assume!(alpha != F::ONE);
+
+			let coeffs = RoundEvals::<F, 2>([y_1, y_inf]).interpolate_eq(claim, alpha);
+
+			prop_assert_eq!(coeffs.0.len(), 3);
+			let reduced = (F::ONE - alpha) * coeffs.evaluate(&F::ZERO)
+				+ alpha * coeffs.evaluate(&F::ONE);
+			prop_assert_eq!(reduced, claim);
+			prop_assert_eq!(coeffs.evaluate(&F::ONE), y_1);
+			prop_assert_eq!(coeffs.0[2], y_inf);
+		}
+
+		// Invariant: the degree-1 prime polynomial satisfies the same MLE-check identity.
+		//
+		// One sampled node suffices, since the claim pins the second.
+		#[test]
+		fn interpolate_eq_1_satisfies_the_mlecheck_identity(
+			y_1 in any::<u128>(),
+			claim in any::<u128>(),
+			alpha in any::<u128>(),
+		) {
+			let [y_1, claim, alpha] = [y_1, claim, alpha].map(F::from);
+			prop_assume!(alpha != F::ONE);
+
+			let coeffs = RoundEvals::<F, 1>([y_1]).interpolate_eq(claim, alpha);
+
+			prop_assert_eq!(coeffs.0.len(), 2);
+			let reduced = (F::ONE - alpha) * coeffs.evaluate(&F::ZERO)
+				+ alpha * coeffs.evaluate(&F::ONE);
+			prop_assert_eq!(reduced, claim);
+			prop_assert_eq!(coeffs.evaluate(&F::ONE), y_1);
+		}
+
+		// Invariant: deferring the reduction changes nothing but the number of reductions.
+		//
+		// This is what lets an evaluator accumulate wide across a whole chunk.
+		//
+		//     reduce(w_a + w_b)  ==  reduce(w_a) + reduce(w_b)
+		#[test]
+		fn reduce_is_additive_over_the_wide_accumulator(
+			a in any::<u128>(),
+			b in any::<u128>(),
+			c in any::<u128>(),
+			d in any::<u128>(),
+		) {
+			let [a, b, c, d] = [a, b, c, d].map(|bits| P::broadcast(F::from(bits)));
+			let first = RoundEvals::<_, 2>([P::wide_mul(a, b), P::wide_mul(b, c)]);
+			let second = RoundEvals::<_, 2>([P::wide_mul(c, d), P::wide_mul(d, a)]);
+
+			// Accumulate both contributions into one run, exactly as an evaluator does.
+			let mut acc = RoundEvals::<<P as WideMul>::Output, 2>::default();
+			first.add_to(&mut acc.0);
+			second.add_to(&mut acc.0);
+			let deferred = acc.reduce::<P>();
+
+			let eager = first.reduce::<P>() + &second.reduce::<P>();
+
+			prop_assert_eq!(deferred.0[0], eager.0[0]);
+			prop_assert_eq!(deferred.0[1], eager.0[1]);
+		}
+
+		// Invariant: `sum_scalars` collapses only the live lanes of each slot.
+		#[test]
+		fn sum_scalars_sums_the_live_lanes(bits in any::<u128>(), n_vars in 0usize..=2) {
+			let value = F::from(bits);
+			let evals = RoundEvals::<P, 1>([P::broadcast(value)]);
+
+			let expected: F = (0..1 << n_vars).map(|_| value).sum();
+			prop_assert_eq!(evals.sum_scalars(n_vars).0[0], expected);
 		}
 	}
-}
-
-impl<W: AddAssign> AddAssign for WideRoundEvals2<W> {
-	fn add_assign(&mut self, rhs: Self) {
-		self.y_1 += rhs.y_1;
-		self.y_inf += rhs.y_inf;
-	}
-}
-
-// Computes the coefficients of a degree 1 polynomial interpolating two points (0, y_0) and (1,
-// y_1).
-fn calculate_round_coeffs_from_evals_1<F: Field>(y_0: F, y_1: F) -> RoundCoeffs<F> {
-	// For a polynomial P(X) = c_1 x + c_0:
-	//
-	// P(0) =        c_0
-	// P(1) = c_1  + c_0
-
-	let c_0 = y_0;
-	let c_1 = y_1 - c_0;
-	RoundCoeffs(vec![c_0, c_1])
-}
-
-// Computes the coefficients of a degree 2 polynomial interpolating three points: (0, y_0),
-// (1, y_1), and (infinity, y_inf).
-fn calculate_round_coeffs_from_evals_2<F: Field>(y_0: F, y_1: F, y_inf: F) -> RoundCoeffs<F> {
-	// For a polynomial P(X) = c_2 x² + c_1 x + c_0:
-	//
-	// P(0) =                  c_0
-	// P(1) = c_2    + c_1   + c_0
-	// P(∞) = c_2
-
-	let c_0 = y_0;
-	let c_2 = y_inf;
-	let c_1 = y_1 - c_0 - c_2;
-	RoundCoeffs(vec![c_0, c_1, c_2])
-}
-
-// Multiplication of a polynomial in monomial form by eq(x, alpha).
-pub fn round_coeffs_by_eq<F: Field>(prime: &RoundCoeffs<F>, alpha: F) -> RoundCoeffs<F> {
-	// eq(X, α) = (1 − α) + (2 α − 1) X
-	// NB: In characteristic 2, this expression can be simplified to 1 + α + challenge.
-	let (prime_by_constant_term, mut prime_by_linear_term) = if F::CHARACTERISTIC == 2 {
-		(prime.clone() * (F::ONE + alpha), prime.clone())
-	} else {
-		(prime.clone() * (F::ONE - alpha), prime.clone() * (alpha.double() - F::ONE))
-	};
-
-	prime_by_linear_term.0.insert(0, F::ZERO); // Multiply prime polynomial by X
-	prime_by_constant_term + &prime_by_linear_term
 }

--- a/crates/ip-prover/src/sumcheck/round_evaluator.rs
+++ b/crates/ip-prover/src/sumcheck/round_evaluator.rs
@@ -145,20 +145,6 @@ pub trait MleCheckRoundEvaluator<F: Field, P: PackedField<Scalar = F>>: Send + S
 /// evaluators read it, mirroring the chunking of the pre-store quadratic prover.
 const MAX_CHUNK_VARS: usize = 12;
 
-/// Prefix sums of a group of evaluators' accumulator-slot counts.
-///
-/// The returned Vec has one more entry than there are evaluators; `offsets[i]..offsets[i + 1]` is
-/// evaluator `i`'s run in the flat accumulator buffer, and the last entry is its total length. Both
-/// shared provers lay out their per-worker accumulator this way.
-fn accum_offsets(degrees: impl IntoIterator<Item = usize>) -> Vec<usize> {
-	iter::once(0)
-		.chain(degrees.into_iter().scan(0, |acc, degree| {
-			*acc += degree;
-			Some(*acc)
-		}))
-		.collect()
-}
-
 /// The state a group of claims shares, whichever protocol drives them.
 ///
 /// One store of columns, one evaluator per claim, and each claim's position in the round cycle.
@@ -219,26 +205,30 @@ where
 
 	/// Interpolates every claim's round polynomial, then records it for the coming fold.
 	///
+	/// The group serves both evaluator traits, so each protocol passes its own accessors in.
+	///
 	/// # Arguments
 	///
-	/// * `offsets` - Prefix sums bounding each evaluator's run of accumulator slots.
 	/// * `accum` - Every evaluator's slots, summed across workers and reduced.
+	/// * `degree` - One evaluator's slot count.
 	/// * `interpolate` - The protocol's call into one evaluator.
 	fn interpolate_round(
 		&mut self,
-		offsets: &[usize],
 		accum: &[P],
+		degree: impl Fn(&Evaluator) -> usize,
 		interpolate: impl Fn(&Evaluator, &RoundContext<'_, P>, &[P], F) -> RoundCoeffs<F>,
 	) -> Vec<RoundCoeffs<F>> {
 		// The store has not folded this round, so its view carries this round's coordinates.
 		let ctx = self.store.round_context();
-		let round_coeffs: Vec<RoundCoeffs<F>> =
-			iter::zip(iter::zip(&self.evaluators, &self.round_states), offsets.windows(2))
-				.map(|((evaluator, state), window)| {
-					let claim = *state.claim();
-					interpolate(evaluator, &ctx, &accum[window[0]..window[1]], claim)
-				})
-				.collect();
+		// Evaluators own consecutive runs of the accumulator, so one walk hands out every run.
+		let mut rest = accum;
+		let mut round_coeffs = Vec::with_capacity(self.evaluators.len());
+		for (evaluator, state) in iter::zip(&self.evaluators, &self.round_states) {
+			let (slots, tail) = rest.split_at(degree(evaluator));
+			rest = tail;
+			round_coeffs.push(interpolate(evaluator, &ctx, slots, *state.claim()));
+		}
+		debug_assert!(rest.is_empty(), "the runs must tile the accumulator exactly");
 		// The coefficients become the round state the coming fold reduces.
 		for (state, coeffs) in iter::zip(&mut self.round_states, &round_coeffs) {
 			*state = RoundState::Coeffs(coeffs.clone());
@@ -360,17 +350,13 @@ where
 		let chunk_vars = (n_vars_remaining - 1).min(MAX_CHUNK_VARS.max(P::LOG_WIDTH));
 
 		// Each evaluator owns a contiguous run of `degree` wide slots in one flat per-worker
-		// buffer; `offsets` holds the run boundaries as a prefix sum, so `offsets[i]..offsets[i +
-		// 1]` is evaluator `i`'s slice.
-		let offsets = accum_offsets(
-			self.group
-				.evaluators
-				.iter()
-				.map(|evaluator| evaluator.degree()),
-		);
-		let total_slots = *offsets
-			.last()
-			.expect("offsets has one entry per evaluator, plus one");
+		// buffer, laid out in registration order.
+		let total_slots: usize = self
+			.group
+			.evaluators
+			.iter()
+			.map(|evaluator| evaluator.degree())
+			.sum();
 
 		// The store prepares one `EvaluationChunk` per chunk of the halved hypercube — the split
 		// column halves and eq-indicator expansions each evaluator reads.
@@ -380,9 +366,14 @@ where
 		let store = &mut group.store;
 		let map = |chunk: EvaluationChunk<'_, P>| {
 			let mut accum = vec![Default::default(); total_slots];
-			for (evaluator, window) in iter::zip(evaluators, offsets.windows(2)) {
-				evaluator.accumulate(&chunk, &mut accum[window[0]..window[1]]);
+			// One walk hands each evaluator its own run, so no offset table is built per round.
+			let mut rest = accum.as_mut_slice();
+			for evaluator in evaluators {
+				let (slots, tail) = rest.split_at_mut(evaluator.degree());
+				rest = tail;
+				evaluator.accumulate(&chunk, slots);
 			}
+			debug_assert!(rest.is_empty(), "the runs must tile the accumulator exactly");
 			accum
 		};
 		let reduce = |mut lhs: Vec<<P as WideMul>::Output>,
@@ -406,10 +397,11 @@ where
 		// Interpolation runs on reduced values.
 		let accum = accum.into_iter().map(P::reduce).collect::<Vec<P>>();
 
-		self.group
-			.interpolate_round(&offsets, &accum, |evaluator, ctx, slots, claim| {
-				evaluator.interpolate(ctx, slots, claim)
-			})
+		self.group.interpolate_round(
+			&accum,
+			|evaluator| evaluator.degree(),
+			|evaluator, ctx, slots, claim| evaluator.interpolate(ctx, slots, claim),
+		)
 	}
 
 	fn fold(&mut self, challenge: F) {
@@ -519,15 +511,12 @@ where
 		// One parallel pass over the halved hypercube feeds every evaluator; see
 		// [`SharedSumcheckProver::execute`].
 		let chunk_vars = (n_vars_remaining - 1).min(MAX_CHUNK_VARS.max(P::LOG_WIDTH));
-		let offsets = accum_offsets(
-			self.group
-				.evaluators
-				.iter()
-				.map(|evaluator| evaluator.degree()),
-		);
-		let total_slots = *offsets
-			.last()
-			.expect("offsets has one entry per evaluator, plus one");
+		let total_slots: usize = self
+			.group
+			.evaluators
+			.iter()
+			.map(|evaluator| evaluator.degree())
+			.sum();
 
 		// The eq indicator factors into a chunk part over the low `chunk_vars` coordinates and a
 		// suffix part over the higher ones. Materialize only the chunk part, shared by every chunk
@@ -543,9 +532,14 @@ where
 		let store = &mut group.store;
 		let map = |chunk: EvaluationChunk<'_, P>| {
 			let mut accum = vec![Default::default(); total_slots];
-			for (evaluator, window) in iter::zip(evaluators, offsets.windows(2)) {
-				evaluator.accumulate(&chunk, eq_chunk.to_ref(), &mut accum[window[0]..window[1]]);
+			// One walk hands each evaluator its own run, so no offset table is built per round.
+			let mut rest = accum.as_mut_slice();
+			for evaluator in evaluators {
+				let (slots, tail) = rest.split_at_mut(evaluator.degree());
+				rest = tail;
+				evaluator.accumulate(&chunk, eq_chunk.to_ref(), slots);
 			}
+			debug_assert!(rest.is_empty(), "the runs must tile the accumulator exactly");
 			// Reduce the wide accumulators so the eq-weighted `reduce` can linearly extrapolate on
 			// P.
 			accum.into_iter().map(P::reduce).collect::<Vec<P>>()
@@ -564,10 +558,11 @@ where
 			None => store.map_reduce(chunk_vars, map, reduce),
 		};
 
-		self.group
-			.interpolate_round(&offsets, &accum, |evaluator, ctx, slots, claim| {
-				evaluator.interpolate(ctx, slots, claim, alpha)
-			})
+		self.group.interpolate_round(
+			&accum,
+			|evaluator| evaluator.degree(),
+			|evaluator, ctx, slots, claim| evaluator.interpolate(ctx, slots, claim, alpha),
+		)
 	}
 
 	fn fold(&mut self, challenge: F) {

--- a/crates/ip-prover/src/sumcheck/selector_mle.rs
+++ b/crates/ip-prover/src/sumcheck/selector_mle.rs
@@ -10,11 +10,8 @@ use binius_utils::{bitwise::Bitwise, rayon::prelude::*};
 use itertools::izip;
 
 use super::{
-	common::SumcheckProver,
-	eq_tracker::ChunkedEqTracker,
-	round_evals::{RoundEvals2, WideRoundEvals2},
-	round_state::RoundState,
-	switchover::BinarySwitchover,
+	common::SumcheckProver, eq_tracker::ChunkedEqTracker, round_evals::RoundEvals,
+	round_state::RoundState, switchover::BinarySwitchover,
 };
 
 pub struct Claim<F: Field> {
@@ -140,7 +137,7 @@ where
 			.fold(
 				|| {
 					(
-						vec![RoundEvals2::default(); sums.len()],
+						vec![RoundEvals::<P, 2>::default(); sums.len()],
 						FieldBuffer::<P>::zeros(chunk_vars),
 						FieldBuffer::<P>::zeros(chunk_vars),
 					)
@@ -173,7 +170,8 @@ where
 						// at the end of the chunk. Only the final multiply by `eq_i` is widened;
 						// the `composition` product is reduced as usual because it feeds into that
 						// widening multiply.
-						let mut chunk_wide = WideRoundEvals2::<<P as WideMul>::Output>::default();
+						let mut wide_y_1 = <P as WideMul>::Output::default();
+						let mut wide_y_inf = <P as WideMul>::Output::default();
 						for (&eq_i, &selected_0_i, &selected_1_i, &selector_0_i, &selector_1_i) in izip!(
 							eq_chunk.as_ref(),
 							selected_0_chunk.as_ref(),
@@ -189,10 +187,10 @@ where
 							// @inf: selector * selected (note that lower degree terms are dropped)
 							let y_1_prod = selector_1_i * (selected_1_i - P::one()) + P::one();
 							let y_inf_prod = selector_inf_i * selected_inf_i;
-							chunk_wide.y_1 += P::wide_mul(eq_i, y_1_prod);
-							chunk_wide.y_inf += P::wide_mul(eq_i, y_inf_prod);
+							wide_y_1 += P::wide_mul(eq_i, y_1_prod);
+							wide_y_inf += P::wide_mul(eq_i, y_inf_prod);
 						}
-						let chunk_round_evals = chunk_wide.reduce::<P>();
+						let chunk_round_evals = RoundEvals([wide_y_1, wide_y_inf]).reduce::<P>();
 
 						// Apply the common factor from the outer product representation of the eq
 						// ind
@@ -207,7 +205,7 @@ where
 			// An identity would allocate and zero one accumulator per merge, then add all of it.
 			.reduce_with(|lhs, rhs| izip!(lhs, rhs).map(|(l, r)| l + &r).collect())
 			// An empty hypercube yields no partials at all, and its round evals are zero.
-			.unwrap_or_else(|| vec![RoundEvals2::<P>::default(); sums.len()]);
+			.unwrap_or_else(|| vec![RoundEvals::<P, 2>::default(); sums.len()]);
 
 		// This prover has multiple evaluation points and cannot implement MleCheckProver.
 		let (prime_coeffs, round_coeffs) = izip!(&self.eq_trackers, sums, packed_prime_evals)

--- a/crates/ip/src/sumcheck/common.rs
+++ b/crates/ip/src/sumcheck/common.rs
@@ -2,7 +2,7 @@
 
 use std::ops::{Add, AddAssign, Index, Mul, MulAssign};
 
-use binius_field::field::FieldOps;
+use binius_field::{Field, field::FieldOps};
 use binius_math::univariate::evaluate_univariate;
 
 /// A univariate polynomial in monomial basis.
@@ -82,6 +82,34 @@ impl<F: FieldOps> RoundCoeffs<F> {
 		let (r_0, r_1) = self.endpoints();
 		// Line through the endpoints, sampled at alpha: R(0) + alpha * (R(1) - R(0)).
 		r_0.clone() + alpha * (r_1 - r_0)
+	}
+}
+
+impl<F: Field> RoundCoeffs<F> {
+	/// Multiplies this polynomial by the equality factor $\text{eq}(X, \alpha)$.
+	///
+	/// $$
+	/// \text{eq}(X, \alpha) = (1 - \alpha) + (2 \alpha - 1) X
+	/// $$
+	///
+	/// An MLE-check prover interpolates the prime polynomial, which carries no equality factor.
+	/// This multiplies the factor back in.
+	///
+	/// Monomial form makes that one scaling and one shift.
+	/// Sampling the factored polynomial instead would cost an extra evaluation point.
+	///
+	/// The factor is linear, so the result has one more coefficient than `self`.
+	pub fn mul_by_eq(&self, alpha: F) -> Self {
+		// NB: In characteristic 2, eq(X, alpha) simplifies to (1 + alpha) + X.
+		let (by_constant_term, mut by_linear_term) = if F::CHARACTERISTIC == 2 {
+			(self.clone() * (F::ONE + alpha), self.clone())
+		} else {
+			(self.clone() * (F::ONE - alpha), self.clone() * (alpha.double() - F::ONE))
+		};
+
+		// Prepending a zero coefficient multiplies the polynomial by X.
+		by_linear_term.0.insert(0, F::ZERO);
+		by_constant_term + &by_linear_term
 	}
 }
 
@@ -214,7 +242,7 @@ impl<F: FieldOps> RoundProof<F> {
 #[cfg(test)]
 mod tests {
 	use binius_field::{Field, Random, arch::OptimalB128 as B128};
-	use binius_math::test_utils::random_scalars;
+	use binius_math::{multilinear::eq::eq_one_var, test_utils::random_scalars};
 	use rand::prelude::*;
 
 	use super::*;
@@ -262,6 +290,30 @@ mod tests {
 
 			// Evaluate the recovered polynomial at both endpoints and confirm they sum to s.
 			assert_eq!(recovered.evaluate(&B128::ZERO) + recovered.evaluate(&B128::ONE), sum);
+		}
+	}
+
+	#[test]
+	fn mul_by_eq_multiplies_pointwise() {
+		let mut rng = rng();
+		// Invariant: scaling by the equality factor is exact at every point.
+		//
+		//     (R * eq)(x) == R(x) * eq(x, alpha)
+		//
+		// The prover interpolates the prime polynomial and multiplies the factor back in here,
+		// so a discrepancy would send a round polynomial the verifier cannot reproduce.
+		for degree in DEGREES {
+			let coeffs = RoundCoeffs(random_scalars::<B128>(&mut rng, degree + 1));
+			let alpha = B128::random(&mut rng);
+
+			let scaled = coeffs.mul_by_eq(alpha);
+
+			// The equality factor is linear, so the product gains exactly one degree.
+			assert_eq!(scaled.0.len(), coeffs.0.len() + 1);
+			for x in random_scalars::<B128>(&mut rng, 4) {
+				let eq_at_x = eq_one_var(x, alpha);
+				assert_eq!(scaled.evaluate(&x), coeffs.evaluate(&x) * eq_at_x);
+			}
 		}
 	}
 

--- a/crates/prover/src/protocols/shift/phase_2.rs
+++ b/crates/prover/src/protocols/shift/phase_2.rs
@@ -10,7 +10,7 @@ use binius_ip::sumcheck::{RoundCoeffs, SumcheckOutput};
 use binius_ip_prover::{
 	channel::IPProverChannel,
 	sumcheck::{
-		ProveSingleOutput, bivariate_product_prover, prove_single, round_evals::RoundEvals2,
+		ProveSingleOutput, bivariate_product_prover, prove_single, round_evals::RoundEvals,
 	},
 };
 use binius_math::{
@@ -159,7 +159,7 @@ where
 	let y_1 = sum_lanes(wide_dense);
 	let y_inf = y_1 + sum_lanes(wide_low_hidden) + sum_lanes(wide_low_cross);
 
-	RoundEvals2 { y_1, y_inf }.interpolate(gamma)
+	RoundEvals([y_1, y_inf]).interpolate(gamma)
 }
 
 /// Folds the two segment buffers of the witness at the selector challenge.


### PR DESCRIPTION
Replaces `RoundEvals1`, `RoundEvals2` and `WideRoundEvals2` with one const-generic type.
Pure refactor — no behavior change, no protocol change.

### The problem

Three structs held the sampled evaluations of a round polynomial:

```
RoundEvals1<P>      { y_1 }             degree-1 prime polynomials
RoundEvals2<P>      { y_1, y_inf }      degree-2 prime and sumcheck polynomials
WideRoundEvals2<W>  { y_1, y_inf }      the same, unreduced
```

The degree lived in the *name*, so everything over them was written once per degree.
`Default`, `Add`, `AddAssign`, `Mul`, `sum_scalars` and `reduce` were each spelled twice.

Worse, the MLE-check claim-to-$R(0)$ recovery was copy-pasted:

```
// RoundEvals1::interpolate_eq
let y_0 = (sum - self.y_1 * alpha) * (F::ONE - alpha).invert_or_zero();
// RoundEvals2::interpolate_eq  — byte for byte identical
let y_0 = (sum - self.y_1 * alpha) * (F::ONE - alpha).invert_or_zero();
```

Two places to get one formula wrong, and a third struct waiting to be written the first time a degree-3 composition appears.

### The idea

The element type and the node count are both parameters, not names:

```rust
pub struct RoundEvals<T, const D: usize>(pub [T; D]);
```

`T` narrows as the round advances — wide and unreduced while accumulating, packed after `reduce`, scalar after `sum_scalars`.
So all three old structs are instantiations of one:

| before | after |
|---|---|
| `RoundEvals1<P>` | `RoundEvals<P, 1>` |
| `RoundEvals2<P>` | `RoundEvals<P, 2>` |
| `WideRoundEvals2<W>` | `RoundEvals<W, 2>` |

### What stays per-degree, and why

Only the coefficient solve. The node sets genuinely differ:

```
D = 1    samples 1 alone         a line needs one node past 0
D = 2    samples 1 and infinity  infinity is the leading coefficient
```

$R(\infty)$ costs one addition per element, where any finite node past 1 costs a full extrapolation.
For a line the high half of a column *is* $R(1)$, so sampling infinity there would only add work.

Generalising the solve over `D` would be a coincidence that holds at $D \le 2$ and breaks silently at $D = 3$, so it is left explicit.
The recovery of $R(0)$ — the part that was actually duplicated — is now one method shared by both.

### Evaluators stop indexing slots by hand

The accumulator crosses the `dyn` boundary as an untyped `&mut [W]`, so every evaluator ended with:

```rust
accum[0] += y_1;
accum[1] += y_inf;
```

repeated in four evaluators, with "slot 0 is `y_1`, slot 1 is `y_inf`" enforced only by a comment.

```diff
- accum[0] += y_1;
- accum[1] += y_inf;
+ RoundEvals([y_1, y_inf]).add_to(accum);
```

`add_to` checks the run length once per chunk, so the comment becomes a check.
It takes the evaluations by value, so the hot loop still accumulates into locals and the running sums stay in registers.

### One less allocation per round

Both shared provers built a prefix-sum table every round to bound each evaluator's run:

```diff
- let offsets = accum_offsets(evaluators.iter().map(|e| e.degree()));   // Vec, every round
- for (evaluator, window) in iter::zip(evaluators, offsets.windows(2)) {
-     evaluator.accumulate(&chunk, &mut accum[window[0]..window[1]]);
- }
+ let mut rest = accum.as_mut_slice();
+ for evaluator in evaluators {
+     let (slots, tail) = rest.split_at_mut(evaluator.degree());
+     rest = tail;
+     evaluator.accumulate(&chunk, slots);
+ }
```

The runs are consecutive, so one walk hands them out. `accum_offsets` is deleted.

### `round_coeffs_by_eq` moves onto its type

It took `&RoundCoeffs<F>` and returned `RoundCoeffs<F>`, so it was a method living in the wrong crate.
It is now `RoundCoeffs::mul_by_eq` in `binius-ip`, next to `sum_over_endpoints` and `lerp_over_endpoints`.

### Scope

- **changed:** `round_evals.rs` rewritten; the four evaluators, `eq_tracker`, `selector_mle`, `round_evaluator`
- **changed:** `binius-ip` gains `RoundCoeffs::mul_by_eq`
- **changed:** one external call site, `prover/src/protocols/shift/phase_2.rs`
- **left untouched:** the node sets, the interpolation arithmetic, every emitted round polynomial

### Verification

- `cargo check --workspace --all-targets` and `cargo clippy --workspace --all-targets` — clean
- `cargo +nightly fmt --all` — clean
- full workspace test suite — 54 binaries, all green
- new tests: 5 proptests pinning the verifier identities that this code has to satisfy

| property | what it pins |
|---|---|
| `interpolate_2_satisfies_the_sumcheck_identity` | $R(0) + R(1) = \text{claim}$, and both nodes survive the solve |
| `interpolate_eq_2_satisfies_the_mlecheck_identity` | $(1-\alpha)R(0) + \alpha R(1) = \text{claim}$ |
| `interpolate_eq_1_satisfies_the_mlecheck_identity` | the same, at degree 1 |
| `reduce_is_additive_over_the_wide_accumulator` | deferring the reduction changes nothing — what makes wide accumulation legal |
| `mul_by_eq_multiplies_pointwise` | $(R \cdot \text{eq})(x) = R(x) \cdot \text{eq}(x, \alpha)$, previously untested |

Plus unit tests for the slot-run conversions, including both length-mismatch panics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)