### PR TITLE
Delete the two unreferenced sumcheck entry points

### DIFF
--- a/crates/ip-prover/src/sumcheck/batch.rs
+++ b/crates/ip-prover/src/sumcheck/batch.rs
@@ -120,22 +120,6 @@ where
 	drive::batch(RoundProofKind::MleCheck, provers, channel)
 }
 
-/// Prove a batched MLE-check and write evaluation claims to the channel.
-///
-/// This is the MLE-check analog of [`batch_prove_and_write_evals`].
-pub fn batch_prove_mle_and_write_evals<F, MleCheckProver_>(
-	provers: Vec<MleCheckProver_>,
-	channel: &mut impl IPProverChannel<F>,
-) -> BatchSumcheckOutput<F>
-where
-	F: Field,
-	MleCheckProver_: MleCheckProver<F>,
-{
-	let output = batch_prove_mle(provers, channel);
-	output.send_evals(channel);
-	output
-}
-
 /// Prove a batched MLE-check whose batching coefficient the caller has already sampled.
 ///
 /// This is [`batch_prove_mle`] with the coefficient supplied rather than drawn.
@@ -156,7 +140,7 @@ where
 	drive::batch_with_coeff(RoundProofKind::MleCheck, provers, batch_coeff, channel)
 }
 
-/// [`batch_prove_mle_and_write_evals`] with the batching coefficient supplied by the caller.
+/// [`batch_prove_mle_with_coeff`], then the evaluation claims written to the channel.
 ///
 /// See [`batch_prove_mle_with_coeff`] for when a caller needs the coefficient up front.
 pub(crate) fn batch_prove_mle_with_coeff_and_write_evals<F, MleCheckProver_>(

--- a/crates/ip-prover/src/sumcheck/mle_store.rs
+++ b/crates/ip-prover/src/sumcheck/mle_store.rs
@@ -185,14 +185,6 @@ impl<'a, A: Allocator, F: Field, P: PackedField<Scalar = F>> MleStore<'a, A, P> 
 		EqId(index)
 	}
 
-	/// Returns the equality-indicator expansion of a registered tracker.
-	///
-	/// The expansion has `n_vars() - 1` variables: the tracker keeps the indicator folded on the
-	/// variable currently being bound.
-	pub fn eq_expansion(&self, id: EqId) -> &FieldBuffer<P> {
-		self.eq_trackers[id.0].expansion()
-	}
-
 	/// Returns the equality-indicator expansion of every registered tracker, in [`EqId`] order.
 	///
 	/// The driving prover slices each expansion per chunk once per round; the returned order


### PR DESCRIPTION
Removes two public items from `crates/ip-prover/src/sumcheck/` that nothing in the workspace calls.
Pure deletion — no behavior change, no remaining caller to update.

### What was audited

Every public item in the module: 64 functions and 34 types.
Each name was counted across the whole workspace, excluding its own definition, and every low-count hit was read by hand.

Private and `pub(crate)` items need no audit — rustc's `dead_code` lint already covers them, and the workspace lints clean.
So only items that are both `pub` and reachable through a `pub mod` could hide.

Two did.

### `batch_prove_mle_and_write_evals`

The MLE-check analog of `batch_prove_and_write_evals`.
Zero callers — not in `binius-prover`, not in `binius-m4-prover`, not in tests.
Its only mention anywhere was a doc link from `batch_prove_mle_with_coeff_and_write_evals`, which now names the with-coeff variant directly.

### `MleStore::eq_expansion`

Returned one registered tracker's equality expansion by `EqId`:

```rust
pub fn eq_expansion(&self, id: EqId) -> &FieldBuffer<P> {
    self.eq_trackers[id.0].expansion()
}
```

Every caller wants all the expansions at once and goes through `eq_expansions` (plural), which the round pass calls once per round.
The singular accessor was never invoked.

The one thing that made this hard to spot by grep: `binius-math` has a local variable named `eq_expansion` in `multilinear/eq.rs`, so a naive search reports hits that have nothing to do with the method.

### A consequence worth flagging

Deleting the first leaves `batch_prove_mle` with **no production caller** — only the two in-module tests exercise it.

It is deliberately kept:

- It is the symmetric public counterpart of `batch_prove`, which is widely used.
- Removing it would push both tests onto `batch_prove_mle_with_coeff`, which is `pub(crate)` and makes each test sample the batching coefficient itself.

`batch.rs` currently exposes six entry points for one operation with three orthogonal options. That is worth collapsing, but as one deliberate change to the batch API rather than by shaving off whichever arm happens to be uncalled today.

### Scope

- **deleted:** `batch_prove_mle_and_write_evals` (`batch.rs`), `MleStore::eq_expansion` (`mle_store.rs`)
- **changed:** one doc link that referenced the deleted function
- **left untouched:** everything else — no call site needed updating, because there were none

### Verification

- `cargo clippy --workspace --all-targets` — clean
- `cargo doc -p binius-ip-prover --no-deps` — clean, so no dangling intra-doc link
- `cargo +nightly fmt --all` — clean
- `cargo test -p binius-ip-prover --lib` — 60 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)