### PR TITLE
BINIUS-65: remove the SumcheckProver parent trait from MleCheckProver

### DIFF
--- a/crates/iop-prover/src/basefold/opening.rs
+++ b/crates/iop-prover/src/basefold/opening.rs
@@ -7,7 +7,7 @@ use binius_compute::Allocator;
 use binius_field::{BinaryField, PackedField};
 use binius_ip::mlecheck;
 use binius_ip_prover::sumcheck::{
-	common::SumcheckProver, multilinear_eval::multilinear_eval_prover,
+	common::MleCheckProver, multilinear_eval::multilinear_eval_prover,
 };
 use binius_math::{FieldVec, ntt::AdditiveNTT};
 

--- a/crates/ip-prover/src/fracaddcheck.rs
+++ b/crates/ip-prover/src/fracaddcheck.rs
@@ -18,7 +18,7 @@ use crate::{
 	channel::IPProverChannel,
 	sumcheck::{
 		batch::batch_prove_mle_with_coeff_and_write_evals,
-		common::{MleCheckProver, SumcheckProver},
+		common::MleCheckProver,
 		frac_add_mle::{self, FracAddFusedEvaluator},
 		mle_store::{ColId, MleStore},
 		round_evaluator::{MleCheckRoundEvaluator, SharedMleCheckProver},

--- a/crates/ip-prover/src/prodcheck/one_pad_mle.rs
+++ b/crates/ip-prover/src/prodcheck/one_pad_mle.rs
@@ -20,10 +20,7 @@ use binius_field::{Field, PackedField};
 use binius_ip::sumcheck::RoundCoeffs;
 use binius_math::{FieldVec, multilinear::eq::eq_one_var};
 
-use crate::sumcheck::{
-	bivariate_product_mle,
-	common::{MleCheckProver, SumcheckProver},
-};
+use crate::sumcheck::{bivariate_product_mle, common::MleCheckProver};
 
 /// The one-padding selector $\textsf{sel}(s, v) = 1 + (v - 1) s$.
 ///
@@ -58,8 +55,8 @@ fn select<F: Field>(s: F, v: F) -> F {
 ///   $e$ is the equality weight of the padding coordinates still unbound and $E(X)$ that of the
 ///   ones already bound.
 ///
-/// [`SumcheckProver::finish`] returns the *padded* layer's child evaluations
-/// $\textsf{sel}(e^*, g_b)$, which is what the batch's selector rounds consume.
+/// Finishing returns the *padded* layer's child evaluations $\textsf{sel}(e^*, g_b)$, which is
+/// what the batch's selector rounds consume.
 pub struct OnePadMleCheckProver<F: Field, Inner> {
 	/// The padded claim point `[padding | real]`, low variables first.
 	eval_point: Vec<F>,
@@ -187,7 +184,7 @@ impl<F: Field, Inner: MleCheckProver<F>> OnePadMleCheckProver<F, Inner> {
 	}
 }
 
-impl<F: Field, Inner: MleCheckProver<F>> SumcheckProver<F> for OnePadMleCheckProver<F, Inner> {
+impl<F: Field, Inner: MleCheckProver<F>> MleCheckProver<F> for OnePadMleCheckProver<F, Inner> {
 	fn n_vars(&self) -> usize {
 		self.eval_point.len() - self.round
 	}
@@ -252,9 +249,7 @@ impl<F: Field, Inner: MleCheckProver<F>> SumcheckProver<F> for OnePadMleCheckPro
 			Phase::Real(_) => panic!("finish requires every variable to be bound"),
 		}
 	}
-}
 
-impl<F: Field, Inner: MleCheckProver<F>> MleCheckProver<F> for OnePadMleCheckProver<F, Inner> {
 	fn eval_point(&self) -> &[F] {
 		&self.eval_point[..self.n_vars()]
 	}

--- a/crates/ip-prover/src/sumcheck/batch.rs
+++ b/crates/ip-prover/src/sumcheck/batch.rs
@@ -7,7 +7,7 @@ use crate::{
 	channel::IPProverChannel,
 	sumcheck::{
 		common::{MleCheckProver, SumcheckProver},
-		drive::{self, RoundProofKind},
+		drive::{self, MleCheckRounds, SumcheckRounds},
 	},
 };
 
@@ -61,7 +61,7 @@ where
 	F: Field,
 	Prover: SumcheckProver<F>,
 {
-	drive::batch(RoundProofKind::Sumcheck, provers, channel)
+	drive::batch(provers.into_iter().map(SumcheckRounds), channel)
 }
 
 /// Prove a batched sumcheck protocol and write evaluation claims to the channel.
@@ -117,7 +117,7 @@ where
 		);
 	}
 
-	drive::batch(RoundProofKind::MleCheck, provers, channel)
+	drive::batch(provers.into_iter().map(MleCheckRounds), channel)
 }
 
 /// Prove a batched MLE-check whose batching coefficient the caller has already sampled.
@@ -137,7 +137,7 @@ where
 	F: Field,
 	MleCheckProver_: MleCheckProver<F>,
 {
-	drive::batch_with_coeff(RoundProofKind::MleCheck, provers, batch_coeff, channel)
+	drive::batch_with_coeff(provers.into_iter().map(MleCheckRounds).collect(), batch_coeff, channel)
 }
 
 /// [`batch_prove_mle_with_coeff`], then the evaluation claims written to the channel.

--- a/crates/ip-prover/src/sumcheck/common.rs
+++ b/crates/ip-prover/src/sumcheck/common.rs
@@ -80,22 +80,74 @@ where
 
 /// A prover for the MLE-check variant of the sumcheck protocol.
 ///
-/// See [`binius_ip::mlecheck::verify`] for context on the protocol.
+/// The prover argues that a claimed value $s$ is the equality-weighted sum
 ///
-/// This trait inherits from [`SumcheckProver`] since it shares the same type-level interface
-/// and protocol execution pattern. However, `MleCheckProver` instances provide different
-/// guarantees for the values returned by [`SumcheckProver::execute`] compared to regular
-/// sumcheck provers.
+/// $$
+/// s = \sum_{v \in B_n} F(v) \cdot eq(v, z)
+/// $$
 ///
-/// Note that while this technically violates the Liskov substitution principle (LSP), the
-/// violation is contained and deemed acceptable for the current design. A future refactor
-/// could introduce a common `SumcheckLikeProver` parent trait if stricter LSP compliance
-/// becomes necessary.
+/// over the hypercube $B_n$, for a point $z$ agreed in advance.
+/// The weight $eq(v, z)$ is $1$ where $v = z$ and $0$ at every other vertex.
+/// For multilinear $F$ the sum is then just $F(z)$.
+///
+/// The protocol runs one round per variable:
+///
+/// - The prover sends a univariate polynomial for the round.
+/// - The verifier answers with a random challenge, binding that variable.
+/// - After the last round the prover reports the evaluations it reached.
+///
+/// Driving it out of that order panics.
+///
+/// This trait is _not_ object-safe.
+///
+/// See [`binius_ip::mlecheck::verify`] for the verifier side, and [Gruen24] for the optimization.
+///
+/// A plain sumcheck proves the same claim by folding the weight into the summand.
+/// This protocol leaves the weight out of the polynomial it sends, which is where it saves work.
+/// The two send different polynomials:
+///
+/// ```text
+///     plain sumcheck   R (X)    claim = R(0) + R(1)
+///     MLE-check        R'(X)    claim = (1 - alpha) * R'(0) + alpha * R'(1)
+/// ```
+///
+/// with `alpha` this round's coordinate of the point, and `R = R' * eq(X, alpha)`.
+///
+/// Each verifier rebuilds a different missing coefficient.
+/// One protocol's polynomial fails the other's verifier, so neither trait inherits from the other.
+/// Multiplying the weight back in converts a prover here into a plain sumcheck one.
+/// The adaptor in this module that does so is the only sound bridge.
 ///
 /// [Gruen24]: <https://eprint.iacr.org/2024/108>
-pub trait MleCheckProver<F: Field>: SumcheckProver<F> {
-	/// Returns the evaluation point for the remaining claim.
+pub trait MleCheckProver<F: Field> {
+	/// The number of variables still free.
 	///
-	/// The length of the evaluation point is equal to `self.n_vars()`.
+	/// Each round binds one variable to a challenge, so this drops by one per round.
+	fn n_vars(&self) -> usize;
+
+	/// Computes this round's message, one univariate polynomial per claim.
+	///
+	/// With $r_0$, ..., $r_{k-1}$ already bound, for claims over $C_0, ..., C_{m-1}$, the output in
+	/// low-to-high evaluation order is
+	///
+	/// $$
+	/// R'_i = \sum_{v \in B_{n-k-1}} C_i(r_0, ..., r_{k-1}, X, \{v\}) \cdot eq(\{v\}, z')
+	/// $$
+	///
+	/// where $z'$ is the part of the point summed over.
+	///
+	/// The coordinate bound this round is left out of the weight.
+	/// Multiplying it back gives the round polynomial $R_i(X) = R'_i(X) \cdot eq(X, z_k)$.
+	///
+	/// For high-to-low order the variables are taken in reverse and summed over the lower indices.
+	fn execute(&mut self) -> Vec<RoundCoeffs<F>>;
+
+	/// Binds this round's variable to the verifier challenge.
+	fn fold(&mut self, challenge: F);
+
+	/// Consumes the prover and returns every multilinear's evaluation at the challenge point.
+	fn finish(self) -> Vec<F>;
+
+	/// The still-unbound part of the evaluation point, one coordinate per free variable.
 	fn eval_point(&self) -> &[F];
 }

--- a/crates/ip-prover/src/sumcheck/drive.rs
+++ b/crates/ip-prover/src/sumcheck/drive.rs
@@ -4,11 +4,26 @@
 //!
 //! Both protocols run the identical round loop.
 //! They differ only in which coefficient of the round polynomial is left off the wire.
+//!
+//! The two prover traits are unrelated, so a wrapper each adapts them to the shared loop:
+//!
+//! ```text
+//!     a sumcheck prover  -> its wrapper  -.
+//!                                          >-- one round loop
+//!     an MLE-check prover -> its wrapper -'
+//! ```
+//!
+//! A wrapper also carries the format its prover's polynomials go out in, so the two cannot be
+//! crossed.
 
 use binius_field::Field;
 use binius_ip::{mlecheck, sumcheck::RoundCoeffs};
 
-use super::{batch::BatchSumcheckOutput, common::SumcheckProver, prove::ProveSingleOutput};
+use super::{
+	batch::BatchSumcheckOutput,
+	common::{MleCheckProver, SumcheckProver},
+	prove::ProveSingleOutput,
+};
 use crate::channel::IPProverChannel;
 
 /// Which round-proof format the verifier expects.
@@ -35,16 +50,93 @@ impl RoundProofKind {
 	}
 }
 
+/// A prover the round loop can drive, tagged with the format its round polynomials go out in.
+///
+/// The format is a constant on the type rather than an argument to the loop.
+/// A caller could pass an argument naming a format its prover does not emit; it cannot pick a
+/// wrong constant, because wrapping is the only way in and each wrapper sets its own.
+pub trait RoundProver<F: Field> {
+	/// The round-proof format this prover's round polynomials must be sent in.
+	const ROUND_PROOF_KIND: RoundProofKind;
+
+	/// The number of variables remaining, one round each.
+	fn n_vars(&self) -> usize;
+
+	/// Computes this round's polynomials, one per claim.
+	fn execute(&mut self) -> Vec<RoundCoeffs<F>>;
+
+	/// Binds the round's variable to the verifier challenge.
+	fn fold(&mut self, challenge: F);
+
+	/// Returns the multilinear evaluations at the challenge point.
+	fn finish(self) -> Vec<F>;
+}
+
+/// Drives a [`SumcheckProver`] as a plain sumcheck.
+///
+/// The layout matches the wrapped prover, so mapping a vector reuses its allocation.
+#[repr(transparent)]
+pub struct SumcheckRounds<Prover>(pub Prover);
+
+impl<F: Field, Prover: SumcheckProver<F>> RoundProver<F> for SumcheckRounds<Prover> {
+	const ROUND_PROOF_KIND: RoundProofKind = RoundProofKind::Sumcheck;
+
+	fn n_vars(&self) -> usize {
+		self.0.n_vars()
+	}
+
+	fn execute(&mut self) -> Vec<RoundCoeffs<F>> {
+		self.0.execute()
+	}
+
+	fn fold(&mut self, challenge: F) {
+		self.0.fold(challenge)
+	}
+
+	fn finish(self) -> Vec<F> {
+		self.0.finish()
+	}
+}
+
+/// Drives an [`MleCheckProver`] as an MLE-check.
+///
+/// The layout serves the same purpose as it does for the plain sumcheck wrapper.
+#[repr(transparent)]
+pub struct MleCheckRounds<Prover>(pub Prover);
+
+impl<F: Field, Prover: MleCheckProver<F>> RoundProver<F> for MleCheckRounds<Prover> {
+	const ROUND_PROOF_KIND: RoundProofKind = RoundProofKind::MleCheck;
+
+	fn n_vars(&self) -> usize {
+		self.0.n_vars()
+	}
+
+	fn execute(&mut self) -> Vec<RoundCoeffs<F>> {
+		self.0.execute()
+	}
+
+	fn fold(&mut self, challenge: F) {
+		self.0.fold(challenge)
+	}
+
+	fn finish(self) -> Vec<F> {
+		self.0.finish()
+	}
+}
+
 /// Drives one prover of a single composition through all of its rounds.
 ///
 /// # Panics
 ///
 /// Panics if the prover returns more than one composition from a round.
-pub fn single<F: Field>(
-	kind: RoundProofKind,
-	mut prover: impl SumcheckProver<F>,
+pub fn single<F, Prover>(
+	mut prover: Prover,
 	channel: &mut impl IPProverChannel<F>,
-) -> ProveSingleOutput<F> {
+) -> ProveSingleOutput<F>
+where
+	F: Field,
+	Prover: RoundProver<F>,
+{
 	let n_vars = prover.n_vars();
 	let mut challenges = Vec::with_capacity(n_vars);
 
@@ -60,7 +152,7 @@ pub fn single<F: Field>(
 		let round_coeffs = round_coeffs_vec.pop().expect("round_coeffs_vec.len() == 1");
 
 		// Commit to the round polynomial, then sample the challenge that binds this variable.
-		kind.send(round_coeffs, channel);
+		Prover::ROUND_PROOF_KIND.send(round_coeffs, channel);
 		let challenge = channel.sample();
 		challenges.push(challenge);
 		prover.fold(challenge);
@@ -81,14 +173,15 @@ pub fn single<F: Field>(
 ///
 /// Panics if the provers do not all have the same number of rounds.
 pub fn batch<F, Prover>(
-	kind: RoundProofKind,
-	provers: Vec<Prover>,
+	provers: impl IntoIterator<Item = Prover>,
 	channel: &mut impl IPProverChannel<F>,
 ) -> BatchSumcheckOutput<F>
 where
 	F: Field,
-	Prover: SumcheckProver<F>,
+	Prover: RoundProver<F>,
 {
+	let provers = provers.into_iter().collect::<Vec<_>>();
+
 	let Some(first_prover) = provers.first() else {
 		return BatchSumcheckOutput {
 			challenges: Vec::new(),
@@ -106,7 +199,7 @@ where
 	// Random linear-combination coefficient for batching multiple claims.
 	let batch_coeff = channel.sample();
 
-	batch_with_coeff(kind, provers, batch_coeff, channel)
+	batch_with_coeff(provers, batch_coeff, channel)
 }
 
 /// Drives a group of provers with a batching coefficient the caller already drew.
@@ -116,19 +209,18 @@ where
 ///
 /// The coefficient must come from the same channel immediately before this call, so that the
 /// transcript matches the one [`batch`] would have produced.
+///
+/// The group arrives materialized because every round walks all of it.
 pub fn batch_with_coeff<F, Prover>(
-	kind: RoundProofKind,
 	mut provers: Vec<Prover>,
 	batch_coeff: F,
 	channel: &mut impl IPProverChannel<F>,
 ) -> BatchSumcheckOutput<F>
 where
 	F: Field,
-	Prover: SumcheckProver<F>,
+	Prover: RoundProver<F>,
 {
-	let n_vars = provers
-		.first()
-		.map_or(0, |prover| SumcheckProver::n_vars(prover));
+	let n_vars = provers.first().map_or(0, |prover| prover.n_vars());
 
 	let mut challenges = Vec::with_capacity(n_vars);
 	for _ in 0..n_vars {
@@ -145,7 +237,7 @@ where
 			.rfold(RoundCoeffs::default(), |acc, coeffs| acc * batch_coeff + &coeffs);
 
 		// Commit to the batched round polynomial, then sample the next challenge.
-		kind.send(batched_round_coeffs, channel);
+		Prover::ROUND_PROOF_KIND.send(batched_round_coeffs, channel);
 
 		let challenge = channel.sample();
 		challenges.push(challenge);

--- a/crates/ip-prover/src/sumcheck/frac_add_mle.rs
+++ b/crates/ip-prover/src/sumcheck/frac_add_mle.rs
@@ -186,7 +186,7 @@ mod tests {
 	use crate::sumcheck::{
 		MleToSumCheckEvaluator,
 		batch::batch_prove,
-		common::SumcheckProver,
+		common::{MleCheckProver, SumcheckProver},
 		mle_store::MleStore,
 		round_evaluator::{SharedMleCheckProver, SharedSumcheckProver, SumcheckRoundEvaluator},
 	};

--- a/crates/ip-prover/src/sumcheck/multilinear_eval.rs
+++ b/crates/ip-prover/src/sumcheck/multilinear_eval.rs
@@ -145,7 +145,7 @@ mod tests {
 
 	use super::*;
 	use crate::sumcheck::{
-		common::SumcheckProver, prove_single_mlecheck,
+		common::MleCheckProver, prove_single_mlecheck,
 		quadratic_mle_evaluator::quadratic_mlecheck_prover,
 	};
 

--- a/crates/ip-prover/src/sumcheck/prove.rs
+++ b/crates/ip-prover/src/sumcheck/prove.rs
@@ -10,7 +10,7 @@ use binius_field::Field;
 
 use super::{
 	common::{MleCheckProver, SumcheckProver},
-	drive::{self, RoundProofKind},
+	drive::{self, MleCheckRounds, SumcheckRounds},
 };
 use crate::channel::IPProverChannel;
 
@@ -49,7 +49,7 @@ pub fn prove_single<F: Field>(
 	prover: impl SumcheckProver<F>,
 	channel: &mut impl IPProverChannel<F>,
 ) -> ProveSingleOutput<F> {
-	drive::single(RoundProofKind::Sumcheck, prover, channel)
+	drive::single(SumcheckRounds(prover), channel)
 }
 
 /// Executes the MLE-check proving protocol for a single multivariate polynomial.
@@ -59,7 +59,7 @@ pub fn prove_single_mlecheck<F: Field>(
 	prover: impl MleCheckProver<F>,
 	channel: &mut impl IPProverChannel<F>,
 ) -> ProveSingleOutput<F> {
-	drive::single(RoundProofKind::MleCheck, prover, channel)
+	drive::single(MleCheckRounds(prover), channel)
 }
 
 /// Output of the sumcheck proving protocol for a single multivariate polynomial.

--- a/crates/ip-prover/src/sumcheck/round_evaluator.rs
+++ b/crates/ip-prover/src/sumcheck/round_evaluator.rs
@@ -493,7 +493,7 @@ where
 	}
 }
 
-impl<A, F, P, Evaluator> SumcheckProver<F> for SharedMleCheckProver<'_, A, F, P, Evaluator>
+impl<A, F, P, Evaluator> MleCheckProver<F> for SharedMleCheckProver<'_, A, F, P, Evaluator>
 where
 	A: Allocator,
 	F: Field,
@@ -572,15 +572,7 @@ where
 	fn finish(self) -> Vec<F> {
 		self.group.finish()
 	}
-}
 
-impl<A, F, P, Evaluator> MleCheckProver<F> for SharedMleCheckProver<'_, A, F, P, Evaluator>
-where
-	A: Allocator,
-	F: Field,
-	P: PackedField<Scalar = F>,
-	Evaluator: MleCheckRoundEvaluator<F, P>,
-{
 	fn eval_point(&self) -> &[F] {
 		&self.eval_point[..self.group.n_vars()]
 	}

--- a/crates/ip-prover/src/sumcheck/zk_mlecheck.rs
+++ b/crates/ip-prover/src/sumcheck/zk_mlecheck.rs
@@ -18,10 +18,7 @@ use binius_math::{
 	univariate::evaluate_univariate,
 };
 
-use super::{
-	common::{MleCheckProver, SumcheckProver},
-	round_state::RoundState,
-};
+use super::{common::MleCheckProver, round_state::RoundState};
 use crate::channel::IPProverChannel;
 
 /// Output of the ZK MLE-check proving protocol.
@@ -260,7 +257,7 @@ impl<F: Field, P: PackedField<Scalar = F>, Data: Deref<Target = [P]>>
 	}
 }
 
-impl<F: Field, P: PackedField<Scalar = F>, Data: Deref<Target = [P]>> SumcheckProver<F>
+impl<F: Field, P: PackedField<Scalar = F>, Data: Deref<Target = [P]>> MleCheckProver<F>
 	for MleCheckMaskProver<F, P, Data>
 {
 	fn n_vars(&self) -> usize {
@@ -319,11 +316,7 @@ impl<F: Field, P: PackedField<Scalar = F>, Data: Deref<Target = [P]>> SumcheckPr
 		// (since g(r_0, ..., r_{n-1}) = sum_i g_i(r_i))
 		vec![self.prefix_sum]
 	}
-}
 
-impl<F: Field, P: PackedField<Scalar = F>, Data: Deref<Target = [P]>> MleCheckProver<F>
-	for MleCheckMaskProver<F, P, Data>
-{
 	fn eval_point(&self) -> &[F] {
 		// Return remaining coordinates (high-to-low means we return the first n_vars_remaining
 		// elements)

--- a/crates/prover/benches/and_reduction.rs
+++ b/crates/prover/benches/and_reduction.rs
@@ -4,7 +4,7 @@ use std::iter::repeat_with;
 use binius_compute::{BufferPool, GlobalAllocator};
 use binius_core::word::Word;
 use binius_field::{Field, Random};
-use binius_ip_prover::sumcheck::{common::SumcheckProver, quadratic_mlecheck_prover};
+use binius_ip_prover::sumcheck::{common::MleCheckProver, quadratic_mlecheck_prover};
 use binius_math::{
 	BinarySubspace,
 	univariate::{extrapolate_over_subspace, lagrange_evals_scalars},


### PR DESCRIPTION
Closes [BINIUS-65](https://linear.app/jimpo/issue/BINIUS-65/remove-sumcheckprover-parent-trait-from-mlecheckprover).

Makes an MLE-check prover stop satisfying a sumcheck prover bound, so the two protocols can no longer be crossed by accident.
Pure refactor — no behavior change, no transcript change.

### The problem

`MleCheckProver` inherited from `SumcheckProver`, so every MLE-check prover satisfied a plain sumcheck bound.

The two traits do not describe the same object.
An MLE-check round emits the **prime** polynomial $R'$, which has the round's equality factor divided out.
A sumcheck round emits the round polynomial $R$ itself.

Their verifiers reconstruct opposite ends:

```
sumcheck   claim = R(0) + R(1)                         -> omits the highest-degree coefficient
MLE-check  claim = (1 - alpha) * R'(0) + alpha * R'(1) -> omits the constant term
```

So the inheritance was not just untidy — it type-checked a wrong program.
Swapping `batch_prove_mle` for `batch_prove` on a `SharedMleCheckProver` compiles today, and fails only at runtime with a mismatched reduced evaluation.

The crate already had the *sound* conversion, `MleToSumCheckDecorator`, which multiplies the equality factor back in.
The supertrait was a trapdoor around it.

### The idea

Give `MleCheckProver` its own four round methods and let it inherit nothing.

The shared round loop still exists once. It moves behind an internal trait that each public trait reaches through its own wrapper:

```
SumcheckProver -> SumcheckRounds -.
                                   >-- RoundProver -> the one round loop
MleCheckProver -> MleCheckRounds -'
```

The round-proof format becomes an **associated constant** on that internal trait rather than an argument the caller passes.

- A driver argument could name a format the prover does not emit.
- A constant is fixed by the wrapper, and a wrapper is the only way into the loop.
- So the prover and the format cannot disagree.

### The change

```
prove.rs
- drive::single(RoundProofKind::MleCheck, prover, channel)
+ drive::single(MleCheckRounds(prover), channel)

batch.rs
- drive::batch(RoundProofKind::Sumcheck, provers, channel)
+ drive::batch(provers.into_iter().map(SumcheckRounds), channel)
```

`RoundProofKind` is no longer named outside the driver.

### Soundness

- No protocol, transcript, or challenge distribution changes.
- Every prover keeps the exact round polynomial it emitted before.
- The only behavioral difference is that two previously-compiling wrong programs are now type errors.

### Scope

- **changed:** `common.rs` (trait split), `drive.rs` (wrappers + associated-constant format)
- **merged impls:** `SharedMleCheckProver` and `MleCheckMaskProver` each carried both a `SumcheckProver` and an `MleCheckProver` impl; each is now one `MleCheckProver` impl
- **import swaps:** 5 consumers that drive an MLE-check prover directly now name the MLE-check trait
- **left untouched:** `MleToSumCheckDecorator`, now the only bridge between the protocols; `SelectorMlecheckProver`, which already implemented only `SumcheckProver`

Nothing legitimate depended on the supertrait — after removing it the library built with only unused-import warnings.
Every consumer that broke was already doing MLE-check work while reaching its methods through the sumcheck trait.
`crates/iop-prover/src/basefold/opening.rs` is the clearest: it already called `mlecheck::RoundProof::truncate`.

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-ip-prover -p binius-iop-prover -p binius-prover --all-targets` — clean
- `cargo +nightly fmt --all` — clean
- `cargo doc --document-private-items` — clean (CI runs it)
- 100 tests pass across `binius-ip-prover` (60) and `binius-iop-prover` (40)

The separation is enforced by the type system, not by a test.
Re-adding the parent trait would compile, so it is a review-time concern rather than a CI-time one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
