### PR TITLE
BINIUS-36: convert the bitcoin struct gadgets to functions

### DIFF
--- a/crates/circuits/Cargo.toml
+++ b/crates/circuits/Cargo.toml
@@ -15,7 +15,6 @@ hex-literal.workspace = true
 num-bigint = { workspace = true }
 num-integer = { workspace = true }
 rand.workspace = true
-sha2.workspace = true
 sha3.workspace = true
 
 [dev-dependencies]

--- a/crates/circuits/src/bitcoin/double_sha256.rs
+++ b/crates/circuits/src/bitcoin/double_sha256.rs
@@ -2,68 +2,39 @@
 // Copyright 2025 Irreducible Inc.
 //! The Bitcoin double-SHA256 hash function.
 
-use binius_frontend::{CircuitBuilder, Wire, WitnessFiller};
-use sha2::Digest;
+use binius_frontend::{CircuitBuilder, Wire};
 
 use crate::{bytes::swap_bytes_32, sha256::sha256_fixed, util::clear_high_bits};
 
-/// Retained only so callers can obtain the reference digest via [`Self::populate_inner`].
+/// Returns `SHA256(SHA256(message))`.
 ///
-/// (Hopefully this struct is not needed in the future, and only the [`Self::construct_circuit`]
-/// method is needed without any return value.)
-pub struct DoubleSha256;
-
-impl DoubleSha256 {
-	/// Constructs a circuit that asserts that `digest = SHA256(SHA256(message))`.
-	/// The message length in bytes is fixed at compile time to be `message.len() * 8`.
-	///
-	/// `message` and `digest` are Bitcoin little-endian packed (8 bytes per wire).
-	///
-	/// # Preconditions
-	///
-	/// - `message.len() * 8 == message_len`
-	pub fn construct_circuit(
-		builder: &CircuitBuilder,
-		message: &[Wire],
-		digest: [Wire; 4],
-	) -> Self {
-		// First SHA-256. `message` is little-endian 8-byte wires; `sha256_fixed` consumes
-		// big-endian 32-bit schedule words, so byte-swap within each 32-bit half and split each
-		// 64-bit wire into its two schedule words (mirrors `sha256::sha256_varlen`'s input
-		// prologue).
-		let mut message_be: Vec<Wire> = Vec::with_capacity(message.len() * 2);
-		for &w in message {
-			let swapped = swap_bytes_32(builder, w);
-			message_be.push(clear_high_bits(builder, swapped, 32));
-			message_be.push(builder.shr(swapped, 32));
-		}
-		let digest_0_be = sha256_fixed(builder, &message_be, message.len() * 8); // [Wire; 8] BE
-
-		// Second SHA-256 over the 32-byte first digest. Its output words are already the big-endian
-		// 32-bit schedule words the second hash expects, so feed them straight in (no swap).
-		let digest_1_be = sha256_fixed(builder, &digest_0_be, 32); // [Wire; 8] BE
-
-		// Repack the big-endian 32-bit output words into little-endian 64-bit wires (the old
-		// `digest_to_le_wires` contract that `merkle_path`/`header_chain` depend on) and assert.
-		let computed: [Wire; 4] = std::array::from_fn(|i| {
-			let lo = swap_bytes_32(builder, digest_1_be[2 * i]);
-			let hi = swap_bytes_32(builder, digest_1_be[2 * i + 1]);
-			builder.bxor(lo, builder.shl(hi, 32))
-		});
-		builder.assert_eq_v("double sha256 digest", computed, digest);
-
-		Self
+/// The message length in bytes is fixed at compile time to be `message.len() * 8`.
+///
+/// `message` and the returned digest are Bitcoin little-endian packed (8 bytes per wire).
+pub fn double_sha256(builder: &CircuitBuilder, message: &[Wire]) -> [Wire; 4] {
+	// First SHA-256. `message` is little-endian 8-byte wires; `sha256_fixed` consumes
+	// big-endian 32-bit schedule words, so byte-swap within each 32-bit half and split each
+	// 64-bit wire into its two schedule words (mirrors `sha256::sha256_varlen`'s input
+	// prologue).
+	let mut message_be: Vec<Wire> = Vec::with_capacity(message.len() * 2);
+	for &w in message {
+		let swapped = swap_bytes_32(builder, w);
+		message_be.push(clear_high_bits(builder, swapped, 32));
+		message_be.push(builder.shr(swapped, 32));
 	}
+	let digest_0_be = sha256_fixed(builder, &message_be, message.len() * 8); // [Wire; 8] BE
 
-	/// Returns `SHA256(SHA256(message))`.
-	///
-	/// The circuit derives every internal wire from the input `message`/`digest` wires, so unlike
-	/// the old struct this populates nothing; it is retained only so callers that chain on the
-	/// returned digest bytes continue to compile.
-	pub fn populate_inner(&self, _filler: &mut WitnessFiller, message: &[u8]) -> [u8; 32] {
-		let digest_0: [u8; 32] = sha2::Sha256::digest(message).into();
-		sha2::Sha256::digest(digest_0).into()
-	}
+	// Second SHA-256 over the 32-byte first digest. Its output words are already the big-endian
+	// 32-bit schedule words the second hash expects, so feed them straight in (no swap).
+	let digest_1_be = sha256_fixed(builder, &digest_0_be, 32); // [Wire; 8] BE
+
+	// Repack the big-endian 32-bit output words into little-endian 64-bit wires, the form
+	// `merkle_path`/`header_chain` chain on.
+	std::array::from_fn(|i| {
+		let lo = swap_bytes_32(builder, digest_1_be[2 * i]);
+		let hi = swap_bytes_32(builder, digest_1_be[2 * i + 1]);
+		builder.bxor(lo, builder.shl(hi, 32))
+	})
 }
 
 #[cfg(test)]
@@ -74,52 +45,38 @@ mod tests {
 
 	use super::*;
 
-	#[test]
-	fn test_valid() {
-		// construct circuit
+	/// Builds a circuit asserting `double_sha256(header) == hash`, then runs it on the given
+	/// values.
+	fn check_double_sha256(header_value: &[u8], hash_value: &[u8]) -> anyhow::Result<()> {
 		let builder = CircuitBuilder::new();
 		let block_header: [Wire; 10] = array::from_fn(|_| builder.add_witness());
 		let block_hash: [Wire; 4] = array::from_fn(|_| builder.add_witness());
-		let double_sha_256 = DoubleSha256::construct_circuit(&builder, &block_header, block_hash);
+		builder.assert_eq_v("block hash", double_sha256(&builder, &block_header), block_hash);
 		let circuit = builder.build();
 
-		// populate_witness
 		let mut filler = circuit.new_witness_filler();
-		let block_header_value = hex!(
-			"000000264a14e21adad047d981c06a26446e345eda3d8beb807401000000000000000000fc01df2139954b36cebc3fa6fbf6a7160a67d34b67e5c4aa2a7ce46f5bb42a83642ea468b32c0217d14ba4d1"
-		);
-		let block_hash_value =
-			hex!("228561b085b7524957e515605725901238299ff2793300000000000000000000");
-		filler.pack_bytes_le(&block_header, &block_header_value);
-		filler.pack_bytes_le(&block_hash, &block_hash_value);
-		double_sha_256.populate_inner(&mut filler, &block_header_value);
-		circuit.populate_wire_witness(&mut filler).unwrap();
+		filler.pack_bytes_le(&block_header, header_value);
+		filler.pack_bytes_le(&block_hash, hash_value);
+		circuit.populate_wire_witness(&mut filler)?;
 
-		// check
 		let constraint_system = circuit.constraint_system();
-		constraint_system.verify(&filler.into_value_vec()).unwrap();
+		constraint_system.verify(&filler.into_value_vec())?;
+		Ok(())
+	}
+
+	const BLOCK_HEADER: [u8; 80] = hex!(
+		"000000264a14e21adad047d981c06a26446e345eda3d8beb807401000000000000000000fc01df2139954b36cebc3fa6fbf6a7160a67d34b67e5c4aa2a7ce46f5bb42a83642ea468b32c0217d14ba4d1"
+	);
+
+	#[test]
+	fn test_valid() {
+		let block_hash = hex!("228561b085b7524957e515605725901238299ff2793300000000000000000000");
+		check_double_sha256(&BLOCK_HEADER, &block_hash).unwrap();
 	}
 
 	#[test]
 	fn test_invalid() {
-		// construct circuit
-		let builder = CircuitBuilder::new();
-		let block_header: [Wire; 10] = array::from_fn(|_| builder.add_witness());
-		let block_hash: [Wire; 4] = array::from_fn(|_| builder.add_witness());
-		let double_sha_256 = DoubleSha256::construct_circuit(&builder, &block_header, block_hash);
-		let circuit = builder.build();
-
-		// populate_witness
-		let mut filler = circuit.new_witness_filler();
-		let block_header_value = hex!(
-			"000000264a14e21adad047d981c06a26446e345eda3d8beb807401000000000000000000fc01df2139954b36cebc3fa6fbf6a7160a67d34b67e5c4aa2a7ce46f5bb42a83642ea468b32c0217d14ba4d1"
-		);
-		let block_hash_value =
-			hex!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
-		filler.pack_bytes_le(&block_header, &block_header_value);
-		filler.pack_bytes_le(&block_hash, &block_hash_value);
-		double_sha_256.populate_inner(&mut filler, &block_header_value);
-		// should fail because the hash is wrong
-		circuit.populate_wire_witness(&mut filler).unwrap_err();
+		let block_hash = hex!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+		check_double_sha256(&BLOCK_HEADER, &block_hash).unwrap_err();
 	}
 }

--- a/crates/circuits/src/bitcoin/header_chain.rs
+++ b/crates/circuits/src/bitcoin/header_chain.rs
@@ -3,87 +3,66 @@
 //! Verifying a Bitcoin header chain.
 
 use binius_core::Word;
-use binius_frontend::{CircuitBuilder, Wire, WitnessFiller};
+use binius_frontend::{CircuitBuilder, Wire};
 
 use crate::{
 	bignum::{self, BigUint},
-	bitcoin::double_sha256::DoubleSha256,
+	bitcoin::double_sha256::double_sha256,
 };
 
-/// Stores some intermediate wires of the circuit, so that they can later be populated with
-/// [`Self::populate_inner`].
-pub struct HeaderChain {
-	header_digests: Vec<DoubleSha256>,
+/// Returns `hash(headers[0])`, the digest of the latest block in the chain.
+///
+/// Asserts the following things:
+///
+/// - `previous_block_hash(headers[i]) = hash(headers[i+1])` (hash chain)
+/// - `hash(headers[i]) < target(headers[i])` (proof of work)
+///
+/// The digest of the head is returned rather than asserted, so the caller decides what to
+/// compare it against.
+///
+/// **IMPORTANT**: This does currently NOT assert that `target(headers[i])` is in any way
+/// related to `target(headers[i+1])`, like it must be in the Bitcoin protocol. In particular,
+/// this means that one can easily satisfy this circuit with a self-mined sequence of blocks
+/// which have low difficulty.
+///
+/// **Note**: It also doesn't check many other things about the block header, like that the
+/// constraints on the timestamps.
+///
+/// # Panics
+///
+/// If `headers` is empty.
+pub fn header_chain(
+	builder: &CircuitBuilder,
+	// latest block comes first
+	headers: &[[Wire; 10]],
+) -> [Wire; 4] {
+	let latest_digest = double_sha256(builder, &headers[0]);
+	assert_fulfills_target(builder, latest_digest, headers[0][9]);
+
+	for i in 1..headers.len() {
+		// hash equals the "previous block hash" in the newer block
+		let digest = double_sha256(builder, &headers[i]);
+		builder.assert_eq_v("hash chain", digest, previous_block_hash(builder, &headers[i - 1]));
+
+		// NOTE: One could save constraints by noting that the target only changes every 2016
+		// blocks.
+		assert_fulfills_target(builder, digest, headers[i][9]);
+
+		// bits of newer block is correctly computed from bits of older block
+		// FIXME TODO
+	}
+
+	latest_digest
 }
 
-impl HeaderChain {
-	/// Constructs a circuit that asserts the following things:
-	///
-	/// - `latest_digest == hash(headers[0])` (head)
-	/// - `previous_block_hash(headers[i]) = hash(headers[i+1])` (hash chain)
-	/// - `hash(headers[i]) < target(headers[i])` (proof of work)
-	///
-	/// **IMPORTANT**: This does currently NOT assert that `target(headers[i])` is in any way
-	/// related to `target(headers[i+1])`, like it must be in the Bitcoin protocol. In particular,
-	/// this means that one can easily satisfy this circuit with a self-mined sequence of blocks
-	/// which have low difficulty.
-	///
-	/// **Note**: It also doesn't check many other things about the block header, like that the
-	/// constraints on the timestamps.
-	pub fn construct_circuit(
-		builder: &CircuitBuilder,
-		// latest block comes first
-		headers: &[[Wire; 10]],
-		latest_digest: [Wire; 4],
-	) -> Self {
-		let mut header_digests = Vec::new();
-
-		// latest header
-		{
-			// hash equals `latest_digest`
-			header_digests.push(DoubleSha256::construct_circuit(
-				builder,
-				&headers[0],
-				latest_digest,
-			));
-
-			// hash is smaller than target (proof of work)
-			let target = target(builder, headers[0][9]);
-			let digest_as_uint = BigUint {
-				limbs: latest_digest.to_vec(),
-			};
-			let fulfills_target = bignum::biguint_lt(builder, &digest_as_uint, &target);
-			builder.assert_true("PoW fulfills target", fulfills_target);
-		}
-
-		// header chain
-		for i in 1..headers.len() {
-			// hash equals the "previous block hash" in the newer block
-			let digest = previous_block_hash(builder, &headers[i - 1]);
-			header_digests.push(DoubleSha256::construct_circuit(builder, &headers[i], digest));
-
-			// hash is smaller than target (proof of work)
-			// NOTE: One could save constraints by noting that the target only changes every 2016
-			// blocks.
-			let target = target(builder, headers[i][9]);
-			let digest_as_uint = BigUint {
-				limbs: digest.to_vec(),
-			};
-			let fulfills_target = bignum::biguint_lt(builder, &digest_as_uint, &target);
-			builder.assert_true("PoW fulfills target", fulfills_target);
-
-			// bits of newer block is correctly computed from bits of older block
-			// FIXME TODO
-		}
-
-		Self { header_digests }
-	}
-
-	pub fn populate_inner(&self, filler: &mut WitnessFiller, headers: &[&[u8]]) {
-		for (header_digest, header) in self.header_digests.iter().zip(headers) {
-			header_digest.populate_inner(filler, header);
-		}
-	}
+/// Asserts the proof of work: the digest, read as a 256-bit integer, is below the header's target.
+fn assert_fulfills_target(builder: &CircuitBuilder, digest: [Wire; 4], bits: Wire) {
+	let target = target(builder, bits);
+	let digest_as_uint = BigUint {
+		limbs: digest.to_vec(),
+	};
+	let fulfills_target = bignum::biguint_lt(builder, &digest_as_uint, &target);
+	builder.assert_true("PoW fulfills target", fulfills_target);
 }
 
 /// Extracts the previous block hash from a block header.
@@ -201,7 +180,7 @@ mod tests {
 				.take(3)
 				.collect();
 		let latest_digest: [Wire; 4] = std::array::from_fn(|_| builder.add_witness());
-		let header_chain = HeaderChain::construct_circuit(&builder, &headers, latest_digest);
+		builder.assert_eq_v("latest digest", header_chain(&builder, &headers), latest_digest);
 		let circuit = builder.build();
 
 		// populate witness
@@ -223,8 +202,6 @@ mod tests {
 			filler.pack_bytes_le(header, header_value);
 		}
 		filler.pack_bytes_le(&latest_digest, &latest_digest_value);
-		let headers_value_ref: Vec<&[u8]> = headers_value.iter().map(AsRef::as_ref).collect();
-		header_chain.populate_inner(&mut filler, &headers_value_ref);
 		circuit.populate_wire_witness(&mut filler).unwrap();
 
 		// check

--- a/crates/circuits/src/bitcoin/merkle_path.rs
+++ b/crates/circuits/src/bitcoin/merkle_path.rs
@@ -1,248 +1,143 @@
 // Copyright 2025 Irreducible Inc.
 //! The merkle proof for a transaction in a Bitcoin block.
 
-use binius_frontend::{CircuitBuilder, Wire, WitnessFiller};
+use binius_core::Word;
+use binius_frontend::{CircuitBuilder, Wire};
 
-use super::double_sha256::DoubleSha256;
+use super::double_sha256::double_sha256;
 
+/// Which side of a double-SHA256 pair a merkle sibling sits on.
 #[derive(Debug, Copy, Clone)]
 pub enum SiblingSide {
 	Left,
 	Right,
 }
 
-/// Stores some intermediate wires of the circuit, so that they can later be populated with
-/// [`Self::populate_inner`].
-pub struct MerklePath {
-	pairs: Vec<(DoubleSha256, [Wire; 4])>,
+impl SiblingSide {
+	/// The wire value the side is passed to [`merkle_path`] as.
+	///
+	/// The side wire is read as a `select` condition, which tests the most significant bit, so
+	/// the two sides must be the all-zero and all-one words rather than `0` and `1`.
+	pub const fn to_word(self) -> Word {
+		match self {
+			SiblingSide::Left => Word::ZERO,
+			SiblingSide::Right => Word::ALL_ONE,
+		}
+	}
 }
 
-impl MerklePath {
-	/// Constructs a circuit that asserts that if you repeatedly hash the `leaf` together with the
-	/// `siblings` using double-SHA256, then you obtain `root`.
-	///
-	/// The extra wire for each `sibling` indicated if it's a left or a right sibling. `0` means
-	/// it's a left sibling, `1` means it's a right sibling.
-	///
-	/// `siblings.len()` determines maximal length of merkle path
-	pub fn construct_circuit(
-		builder: &CircuitBuilder,
-		mut leaf: [Wire; 4],
-		siblings: Vec<([Wire; 4], Wire)>,
-		root: [Wire; 4],
-		length: Wire,
-	) -> Self {
-		let mut pairs = Vec::new();
-		for (i, sib) in siblings.into_iter().enumerate() {
-			let digest = std::array::from_fn(|_| builder.add_witness());
-			let message = vec![
-				builder.select(sib.1, leaf[0], sib.0[0]),
-				builder.select(sib.1, leaf[1], sib.0[1]),
-				builder.select(sib.1, leaf[2], sib.0[2]),
-				builder.select(sib.1, leaf[3], sib.0[3]),
-				builder.select(sib.1, sib.0[0], leaf[0]),
-				builder.select(sib.1, sib.0[1], leaf[1]),
-				builder.select(sib.1, sib.0[2], leaf[2]),
-				builder.select(sib.1, sib.0[3], leaf[3]),
-			];
-			pairs.push((DoubleSha256::construct_circuit(builder, &message, digest), digest));
+/// Returns the merkle root obtained by folding `leaf` with `siblings` under double-SHA256.
+///
+/// Every wire is Bitcoin little-endian packed (8 bytes per wire).
+///
+/// Each sibling carries a wire saying whether it is a left or a right sibling, in the encoding
+/// [`SiblingSide::to_word`] produces. `siblings.len()` is the maximal path length; only the first
+/// `length` siblings are folded in, and the remaining levels pass the running digest through
+/// unchanged.
+pub fn merkle_path(
+	builder: &CircuitBuilder,
+	mut leaf: [Wire; 4],
+	siblings: &[([Wire; 4], Wire)],
+	length: Wire,
+) -> [Wire; 4] {
+	for (i, (sibling, is_right)) in siblings.iter().enumerate() {
+		// The pair is hashed in path order: a right sibling is appended after the running
+		// digest, a left one is prepended.
+		let message: Vec<Wire> = (0..4)
+			.map(|j| builder.select(*is_right, leaf[j], sibling[j]))
+			.chain((0..4).map(|j| builder.select(*is_right, sibling[j], leaf[j])))
+			.collect();
+		let digest = double_sha256(builder, &message);
 
-			let current_length = builder.add_constant_64(i as u64);
-			let past_length = builder.icmp_ult(current_length, length);
-			let digest_or_passthrough = [
-				builder.select(past_length, digest[0], leaf[0]),
-				builder.select(past_length, digest[1], leaf[1]),
-				builder.select(past_length, digest[2], leaf[2]),
-				builder.select(past_length, digest[3], leaf[3]),
-			];
-			leaf = digest_or_passthrough;
-		}
-		builder.assert_eq_v("last digest equals root", root, leaf);
-
-		Self { pairs }
+		// Levels at or past `length` are padding: keep the digest reached so far.
+		let within_length = builder.icmp_ult(builder.add_constant_64(i as u64), length);
+		leaf = std::array::from_fn(|j| builder.select(within_length, digest[j], leaf[j]));
 	}
-
-	pub fn populate_inner(
-		&self,
-		filler: &mut WitnessFiller,
-		mut leaf: [u8; 32],
-		siblings: &[([u8; 32], SiblingSide)],
-	) {
-		assert!(siblings.len() <= self.pairs.len());
-
-		let dummy_sibling: ([u8; 32], SiblingSide) = ([0; 32], SiblingSide::Left);
-
-		for (i, pair) in self.pairs.iter().enumerate() {
-			let sibling = siblings.get(i).unwrap_or(&dummy_sibling);
-
-			let message: Vec<u8> = match sibling.1 {
-				SiblingSide::Left => [sibling.0, leaf].concat(),
-				SiblingSide::Right => [leaf, sibling.0].concat(),
-			};
-			assert_eq!(message.len(), 64);
-			let digest = pair.0.populate_inner(filler, &message);
-			filler.pack_bytes_le(&pair.1, &digest);
-			leaf = if i < siblings.len() { digest } else { leaf };
-		}
-	}
+	leaf
 }
 
 #[cfg(test)]
 mod tests {
 	use std::array;
 
-	use binius_core::Word;
 	use hex_literal::hex;
 
 	use super::*;
 
-	#[test]
-	fn test_valid() {
-		// construct circuit
+	/// Builds a circuit asserting `merkle_path(leaf, siblings, length) == root`, then runs it.
+	fn check_merkle_path(
+		max_path_len: usize,
+		leaf_value: [u8; 32],
+		siblings_value: &[([u8; 32], SiblingSide)],
+		length_value: u64,
+		root_value: [u8; 32],
+	) -> anyhow::Result<()> {
 		let builder = CircuitBuilder::new();
 		let leaf: [Wire; 4] = array::from_fn(|_| builder.add_witness());
 		let siblings: Vec<([Wire; 4], Wire)> = std::iter::repeat_with(|| {
 			(array::from_fn(|_| builder.add_witness()), builder.add_witness())
 		})
-		.take(2)
+		.take(max_path_len)
 		.collect();
 		let root: [Wire; 4] = array::from_fn(|_| builder.add_witness());
-		let length: Wire = builder.add_witness();
-		let merkle_path =
-			MerklePath::construct_circuit(&builder, leaf, siblings.clone(), root, length);
+		let length = builder.add_witness();
+		builder.assert_eq_v("root", merkle_path(&builder, leaf, &siblings, length), root);
 		let circuit = builder.build();
 
-		// populate_witness
 		let mut filler = circuit.new_witness_filler();
-		let leaf_value = hex!("a2b6b171aae6007508e5c8fabec6b662bad3e4594e09405cac7b249e5f1e5155");
-		let siblings_value = vec![
-			(
-				hex!("1346be1a16a09b5fcc5bca52d39c2529396f0fa6a654f3978807ff79eaf91d66"),
-				SiblingSide::Right,
-			),
-			(
-				hex!("557cc3606e7197ff5a7b6cda46e409445b1ab58d8d4ebf1bc3d95764c32ad877"),
-				SiblingSide::Left,
-			),
-		];
-		let root_value = hex!("5802c63ef536216cf01a0dd0b32c01f5e31536aa773eb6e1d46fd42f66516eba");
 		filler.pack_bytes_le(&leaf, &leaf_value);
-		filler.pack_bytes_le(&siblings[0].0, &siblings_value[0].0);
-		filler[siblings[0].1] = Word::ALL_ONE;
-		filler.pack_bytes_le(&siblings[1].0, &siblings_value[1].0);
-		filler[siblings[1].1] = Word::ZERO;
+		for ((sibling, is_right), (value, side)) in siblings.iter().zip(siblings_value) {
+			filler.pack_bytes_le(sibling, value);
+			filler[*is_right] = side.to_word();
+		}
 		filler.pack_bytes_le(&root, &root_value);
-		filler[length] = Word(2);
-		merkle_path.populate_inner(&mut filler, leaf_value, &siblings_value);
-		circuit.populate_wire_witness(&mut filler).unwrap();
+		filler[length] = Word(length_value);
+		circuit.populate_wire_witness(&mut filler)?;
 
-		// check
 		let constraint_system = circuit.constraint_system();
-		constraint_system.verify(&filler.into_value_vec()).unwrap();
+		constraint_system.verify(&filler.into_value_vec())?;
+		Ok(())
+	}
+
+	const LEAF: [u8; 32] = hex!("a2b6b171aae6007508e5c8fabec6b662bad3e4594e09405cac7b249e5f1e5155");
+	const ROOT: [u8; 32] = hex!("5802c63ef536216cf01a0dd0b32c01f5e31536aa773eb6e1d46fd42f66516eba");
+	const SIBLING_0: [u8; 32] =
+		hex!("1346be1a16a09b5fcc5bca52d39c2529396f0fa6a654f3978807ff79eaf91d66");
+	const SIBLING_1: [u8; 32] =
+		hex!("557cc3606e7197ff5a7b6cda46e409445b1ab58d8d4ebf1bc3d95764c32ad877");
+
+	#[test]
+	fn test_valid() {
+		let siblings = [
+			(SIBLING_0, SiblingSide::Right),
+			(SIBLING_1, SiblingSide::Left),
+		];
+		check_merkle_path(2, LEAF, &siblings, 2, ROOT).unwrap();
 	}
 
 	#[test]
 	fn test_invalid_side() {
-		// construct circuit
-		let builder = CircuitBuilder::new();
-		let leaf: [Wire; 4] = array::from_fn(|_| builder.add_witness());
-		let siblings: Vec<([Wire; 4], Wire)> = std::iter::repeat_with(|| {
-			(array::from_fn(|_| builder.add_witness()), builder.add_witness())
-		})
-		.take(2)
-		.collect();
-		let root: [Wire; 4] = array::from_fn(|_| builder.add_witness());
-		let length: Wire = builder.add_witness();
-		let merkle_path =
-			MerklePath::construct_circuit(&builder, leaf, siblings.clone(), root, length);
-		let circuit = builder.build();
-
-		// populate_witness
-		let mut filler = circuit.new_witness_filler();
-		let leaf_value = hex!("a2b6b171aae6007508e5c8fabec6b662bad3e4594e09405cac7b249e5f1e5155");
-		let siblings_value = vec![
-			(
-				hex!("1346be1a16a09b5fcc5bca52d39c2529396f0fa6a654f3978807ff79eaf91d66"),
-				SiblingSide::Right,
-			),
-			(
-				hex!("557cc3606e7197ff5a7b6cda46e409445b1ab58d8d4ebf1bc3d95764c32ad877"),
-				SiblingSide::Right,
-			),
+		// Flipping the second sibling's side reverses the order the pair is hashed in.
+		let siblings = [
+			(SIBLING_0, SiblingSide::Right),
+			(SIBLING_1, SiblingSide::Right),
 		];
-		let root_value = hex!("5802c63ef536216cf01a0dd0b32c01f5e31536aa773eb6e1d46fd42f66516eba");
-		filler.pack_bytes_le(&leaf, &leaf_value);
-		filler.pack_bytes_le(&siblings[0].0, &siblings_value[0].0);
-		filler[siblings[0].1] = Word::ALL_ONE;
-		filler.pack_bytes_le(&siblings[1].0, &siblings_value[1].0);
-		filler[siblings[1].1] = Word::ZERO;
-		filler.pack_bytes_le(&root, &root_value);
-		filler[length] = Word(2);
-		merkle_path.populate_inner(&mut filler, leaf_value, &siblings_value);
-		circuit.populate_wire_witness(&mut filler).unwrap_err();
+		check_merkle_path(2, LEAF, &siblings, 2, ROOT).unwrap_err();
 	}
 
 	#[test]
 	fn test_invalid_path() {
-		// construct circuit
-		let builder = CircuitBuilder::new();
-		let leaf: [Wire; 4] = array::from_fn(|_| builder.add_witness());
-		let siblings: Vec<([Wire; 4], Wire)> = std::iter::repeat_with(|| {
-			(array::from_fn(|_| builder.add_witness()), builder.add_witness())
-		})
-		.take(2)
-		.collect();
-		let root: [Wire; 4] = array::from_fn(|_| builder.add_witness());
-		let length: Wire = builder.add_witness();
-		let merkle_path =
-			MerklePath::construct_circuit(&builder, leaf, siblings.clone(), root, length);
-		let circuit = builder.build();
-
-		// populate_witness
-		let mut filler = circuit.new_witness_filler();
-		let leaf_value = hex!("a2b6b171aae6007508e5c8fabec6b662bad3e4594e09405cac7b249e5f1e5155");
-		let siblings_value = vec![
-			(
-				hex!("1346be1a16a09b5fcc5bca52d39c2529396f0fa6a654f3978807ff79eaf91d66"),
-				SiblingSide::Right,
-			),
-			(
-				hex!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
-				SiblingSide::Left,
-			),
-		];
-		let root_value = hex!("5802c63ef536216cf01a0dd0b32c01f5e31536aa773eb6e1d46fd42f66516eba");
-		filler.pack_bytes_le(&leaf, &leaf_value);
-		filler.pack_bytes_le(&siblings[0].0, &siblings_value[0].0);
-		filler[siblings[0].1] = Word::ALL_ONE;
-		filler.pack_bytes_le(&siblings[1].0, &siblings_value[1].0);
-		filler[siblings[1].1] = Word::ZERO;
-		filler.pack_bytes_le(&root, &root_value);
-		filler[length] = Word(2);
-		merkle_path.populate_inner(&mut filler, leaf_value, &siblings_value);
-		circuit.populate_wire_witness(&mut filler).unwrap_err();
+		let wrong = hex!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+		let siblings = [(SIBLING_0, SiblingSide::Right), (wrong, SiblingSide::Left)];
+		check_merkle_path(2, LEAF, &siblings, 2, ROOT).unwrap_err();
 	}
 
+	/// A 12-level path in a circuit sized for 30, so the 18 padding levels must pass through.
 	#[test]
 	fn test_valid_long() {
-		// construct circuit
-		let builder = CircuitBuilder::new();
-		let leaf: [Wire; 4] = array::from_fn(|_| builder.add_witness());
-		let siblings: Vec<([Wire; 4], Wire)> = std::iter::repeat_with(|| {
-			(array::from_fn(|_| builder.add_witness()), builder.add_witness())
-		})
-		.take(30)
-		.collect();
-		let root: [Wire; 4] = array::from_fn(|_| builder.add_witness());
-		let length: Wire = builder.add_witness();
-		let merkle_path =
-			MerklePath::construct_circuit(&builder, leaf, siblings.clone(), root, length);
-		let circuit = builder.build();
-
-		// populate_witness
-		let mut filler = circuit.new_witness_filler();
-		let leaf_value = hex!("6f2f044a225e8b293c6e54cf2771bf4d17ba8904b1f61cf9c392965dcbda0b83");
-		let siblings_value = vec![
+		let leaf = hex!("6f2f044a225e8b293c6e54cf2771bf4d17ba8904b1f61cf9c392965dcbda0b83");
+		let root = hex!("fc01df2139954b36cebc3fa6fbf6a7160a67d34b67e5c4aa2a7ce46f5bb42a83");
+		let siblings = [
 			(
 				hex!("783089645b0bc42d44e9d6a7ea62adf7a8a2adc6b7f0173d663369217b771b86"),
 				SiblingSide::Right,
@@ -292,22 +187,6 @@ mod tests {
 				SiblingSide::Right,
 			),
 		];
-		let root_value = hex!("fc01df2139954b36cebc3fa6fbf6a7160a67d34b67e5c4aa2a7ce46f5bb42a83");
-		filler.pack_bytes_le(&leaf, &leaf_value);
-		for i in 0..siblings_value.len() {
-			filler.pack_bytes_le(&siblings[i].0, &siblings_value[i].0);
-			filler[siblings[i].1] = match siblings_value[i].1 {
-				SiblingSide::Left => Word::ZERO,
-				SiblingSide::Right => Word::ALL_ONE,
-			};
-		}
-		filler.pack_bytes_le(&root, &root_value);
-		merkle_path.populate_inner(&mut filler, leaf_value, &siblings_value);
-		filler[length] = Word(12);
-		circuit.populate_wire_witness(&mut filler).unwrap();
-
-		// check
-		let constraint_system = circuit.constraint_system();
-		constraint_system.verify(&filler.into_value_vec()).unwrap();
+		check_merkle_path(30, leaf, &siblings, 12, root).unwrap();
 	}
 }

--- a/crates/examples/src/circuits/bitcoin_block_contains_transaction.rs
+++ b/crates/examples/src/circuits/bitcoin_block_contains_transaction.rs
@@ -1,71 +1,40 @@
 // Copyright 2025 Irreducible Inc.
 //! Proof that a Bitcoin block contains a certain transaction.
 
-use binius_circuits::bitcoin::{
-	double_sha256::DoubleSha256,
-	merkle_path::{MerklePath, SiblingSide},
-};
-use binius_frontend::{CircuitBuilder, Wire, WitnessFiller};
+use binius_circuits::bitcoin::{double_sha256::double_sha256, merkle_path::merkle_path};
+use binius_frontend::{CircuitBuilder, Wire};
 
-/// Stores some intermediate wires of the circuit, so that they can later be populated with
-/// [`Self::populate_inner`].
-pub struct BlockContainsTransaction {
-	merkle_path: MerklePath,
-	block_header: DoubleSha256,
-}
+/// Asserts that `transaction_hash` has a valid merkle path to the merkle root in `block_header`,
+/// and that `block_header` hashes to `block_hash`.
+///
+/// **Note:** This does NOT assert that `transaction_hash` is actually the hash of a well formed
+/// transaction. In particular, `transaction_hash` might just be an internal (non-leaf) node in
+/// the transaction merkle tree, yet this circuit would pass.
+pub fn block_contains_transaction(
+	builder: &CircuitBuilder,
+	transaction_hash: [Wire; 4],
+	siblings: &[([Wire; 4], Wire)],
+	merkle_path_len: Wire,
+	block_header: [Wire; 10],
+	block_hash: [Wire; 4],
+) {
+	// extract merkle root from block header
+	let merkle_root = [
+		join(builder, block_header[5], block_header[4]),
+		join(builder, block_header[6], block_header[5]),
+		join(builder, block_header[7], block_header[6]),
+		join(builder, block_header[8], block_header[7]),
+	];
 
-impl BlockContainsTransaction {
-	/// Constructs a circuit that asserts that `transaction_hash` has a valid `merkle_path` to the
-	/// merkle root in `block_header`, and that `block_header` hashes to `block_hash`.
-	///
-	/// **Note:** This does NOT assert that `transaction_hash` is actually the hash of a well formed
-	/// transaction. In particular, `transaction_hash` might just be an internal (non-leaf) node in
-	/// the transaction merkle tree, yet this circuit would pass.
-	pub fn construct_circuit(
-		builder: &CircuitBuilder,
-		transaction_hash: [Wire; 4],
-		merkle_path: Vec<([Wire; 4], Wire)>,
-		merkle_path_len: Wire,
-		block_header: [Wire; 10],
-		block_hash: [Wire; 4],
-	) -> Self {
-		// extract merkle root from block header
-		let merkle_root = [
-			join(builder, block_header[5], block_header[4]),
-			join(builder, block_header[6], block_header[5]),
-			join(builder, block_header[7], block_header[6]),
-			join(builder, block_header[8], block_header[7]),
-		];
+	// validity of merkle path
+	builder.assert_eq_v(
+		"merkle root",
+		merkle_path(builder, transaction_hash, siblings, merkle_path_len),
+		merkle_root,
+	);
 
-		// validity of merkle path
-		let merkle_path = MerklePath::construct_circuit(
-			builder,
-			transaction_hash,
-			merkle_path,
-			merkle_root,
-			merkle_path_len,
-		);
-
-		// `block_header` hashes to `block_hash`
-		let block_header = DoubleSha256::construct_circuit(builder, &block_header, block_hash);
-
-		Self {
-			merkle_path,
-			block_header,
-		}
-	}
-
-	pub fn populate_inner(
-		&self,
-		filler: &mut WitnessFiller,
-		transaction_hash: [u8; 32],
-		merkle_path: &[([u8; 32], SiblingSide)],
-		block_header: &[u8],
-	) {
-		self.merkle_path
-			.populate_inner(filler, transaction_hash, merkle_path);
-		self.block_header.populate_inner(filler, block_header);
-	}
+	// `block_header` hashes to `block_hash`
+	builder.assert_eq_v("block hash", double_sha256(builder, &block_header), block_hash);
 }
 
 fn join(builder: &CircuitBuilder, b0: Wire, b1: Wire) -> Wire {
@@ -76,6 +45,7 @@ fn join(builder: &CircuitBuilder, b0: Wire, b1: Wire) -> Wire {
 
 #[cfg(test)]
 mod tests {
+	use binius_circuits::bitcoin::merkle_path::SiblingSide;
 	use binius_core::Word;
 	use hex_literal::hex;
 
@@ -86,7 +56,7 @@ mod tests {
 		// build circuit
 		let builder = CircuitBuilder::new();
 		let transaction_hash: [Wire; 4] = std::array::from_fn(|_| builder.add_witness());
-		let merkle_path: Vec<([Wire; 4], Wire)> = std::iter::repeat_with(|| {
+		let siblings: Vec<([Wire; 4], Wire)> = std::iter::repeat_with(|| {
 			(std::array::from_fn(|_| builder.add_witness()), builder.add_witness())
 		})
 		.take(30)
@@ -94,10 +64,10 @@ mod tests {
 		let merkle_path_len = builder.add_witness();
 		let block_header: [Wire; 10] = std::array::from_fn(|_| builder.add_witness());
 		let block_hash: [Wire; 4] = std::array::from_fn(|_| builder.add_witness());
-		let block_contains_transaction = BlockContainsTransaction::construct_circuit(
+		block_contains_transaction(
 			&builder,
 			transaction_hash,
-			merkle_path.clone(),
+			&siblings,
 			merkle_path_len,
 			block_header,
 			block_hash,
@@ -113,7 +83,7 @@ mod tests {
 			hex!("228561b085b7524957e515605725901238299ff2793300000000000000000000");
 		let transaction_hash_value =
 			hex!("6f2f044a225e8b293c6e54cf2771bf4d17ba8904b1f61cf9c392965dcbda0b83");
-		let merkle_path_value = vec![
+		let siblings_value = vec![
 			(
 				hex!("783089645b0bc42d44e9d6a7ea62adf7a8a2adc6b7f0173d663369217b771b86"),
 				SiblingSide::Right,
@@ -166,20 +136,11 @@ mod tests {
 		filler.pack_bytes_le(&block_header, &block_header_value);
 		filler.pack_bytes_le(&block_hash, &block_hash_value);
 		filler.pack_bytes_le(&transaction_hash, &transaction_hash_value);
-		for i in 0..merkle_path_value.len() {
-			filler.pack_bytes_le(&merkle_path[i].0, &merkle_path_value[i].0);
-			filler[merkle_path[i].1] = match merkle_path_value[i].1 {
-				SiblingSide::Left => Word::ZERO,
-				SiblingSide::Right => Word::ALL_ONE,
-			};
+		for ((sibling, is_right), (value, side)) in siblings.iter().zip(&siblings_value) {
+			filler.pack_bytes_le(sibling, value);
+			filler[*is_right] = side.to_word();
 		}
-		filler[merkle_path_len] = Word(12);
-		block_contains_transaction.populate_inner(
-			&mut filler,
-			transaction_hash_value,
-			&merkle_path_value,
-			&block_header_value,
-		);
+		filler[merkle_path_len] = Word(siblings_value.len() as u64);
 		circuit.populate_wire_witness(&mut filler).unwrap();
 
 		// check

--- a/crates/examples/src/circuits/bitcoin_header_chain.rs
+++ b/crates/examples/src/circuits/bitcoin_header_chain.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 Irreducible Inc.
 
 use anyhow::bail;
-use binius_circuits::bitcoin::header_chain::HeaderChain;
+use binius_circuits::bitcoin::header_chain::header_chain;
 use binius_frontend::{CircuitBuilder, Wire, WitnessFiller};
 use clap::Args;
 
@@ -15,7 +15,6 @@ use crate::ExampleCircuit;
 pub struct BitcoinHeaderChainExample {
 	latest_digest: [Wire; 4],
 	headers: Vec<[Wire; 10]>,
-	header_chain_gadget: HeaderChain,
 }
 
 #[derive(Args)]
@@ -47,12 +46,11 @@ impl ExampleCircuit for BitcoinHeaderChainExample {
 			std::iter::repeat_with(|| std::array::from_fn(|_| builder.add_witness()))
 				.take(params.num_blocks)
 				.collect();
-		let header_chain_gadget = HeaderChain::construct_circuit(builder, &headers, latest_digest);
+		builder.assert_eq_v("latest digest", header_chain(builder, &headers), latest_digest);
 
 		Ok(Self {
 			latest_digest,
 			headers,
-			header_chain_gadget,
 		})
 	}
 
@@ -67,9 +65,6 @@ impl ExampleCircuit for BitcoinHeaderChainExample {
 			filler.pack_bytes_le(header, header_value);
 		}
 		filler.pack_bytes_le(&self.latest_digest, &latest_digest_value);
-		let headers_value_ref: Vec<&[u8]> = headers_value.iter().map(AsRef::as_ref).collect();
-		self.header_chain_gadget
-			.populate_inner(filler, &headers_value_ref);
 
 		Ok(())
 	}


### PR DESCRIPTION
Part of [BINIUS-36](https://linear.app/jimpo/issue/BINIUS-36) — one more slice of the struct-gadget conversion. Not `Closes`, since `base64`, `jwt_claims`, `rs256` and the three standalone hash circuits are still struct-shaped.

Converts the four `bitcoin` gadgets to free functions that return their result wires.
Behavior is unchanged; the constraint count drops where the returned digest replaces asserted witness wires.

### The problem

Each bitcoin gadget was a struct whose only reason to exist was a `populate_*` method.

`DoubleSha256` was the extreme case — a zero-sized struct whose `populate_inner` populated nothing:

```rust
pub struct DoubleSha256;   // "Hopefully this struct is not needed in the future"

pub fn populate_inner(&self, _filler: &mut WitnessFiller, message: &[u8]) -> [u8; 32] {
    let digest_0: [u8; 32] = sha2::Sha256::digest(message).into();
    sha2::Sha256::digest(digest_0).into()
}
```

It just re-hashed the message in Rust so callers could chain the digest bytes.

`MerklePath` then built on that. Per level it allocated four fresh witness wires, asserted them equal to the computed digest, and made the caller fill them by walking the whole path again in `sha2`:

```rust
let digest = std::array::from_fn(|_| builder.add_witness());
pairs.push((DoubleSha256::construct_circuit(builder, &message, digest), digest));
```

So the digest of every internal node was a *claim* the prover had to supply and the circuit had to check — even though it is fully determined by the leaf and the siblings.

### The idea

Have the hash return its digest, the way the already-converted `slice()` and `keccak256_varlen()` gadgets do.

```
DoubleSha256::construct_circuit(b, message, digest)  ->  double_sha256(b, message) -> [Wire; 4]
MerklePath::construct_circuit(b, leaf, sibs, root, len) -> merkle_path(b, leaf, sibs, len) -> [Wire; 4]
HeaderChain::construct_circuit(b, headers, latest)   ->  header_chain(b, headers) -> [Wire; 4]
BlockContainsTransaction::construct_circuit(..)      ->  block_contains_transaction(..)
```

Once the digest is a returned wire, the witness wires that used to carry it and the assertions that used to pin it both disappear.

### Per merkle level

- **before:** 4 witness wires + 4 `assert_eq`, plus a `sha2` hash on the prover side
- **after:** the digest wires flow straight into the next level

→ 4 fewer AND constraints and 4 fewer witness values per level, and no reference hashing outside the circuit at all.

### The change

At the merkle call site:

```diff
-let digest = std::array::from_fn(|_| builder.add_witness());
-pairs.push((DoubleSha256::construct_circuit(builder, &message, digest), digest));
+let digest = double_sha256(builder, &message);
```

And the caller no longer mirrors the circuit in Rust:

```diff
-merkle_path.populate_inner(&mut filler, leaf_value, &siblings_value);
-header_chain.populate_inner(&mut filler, &headers_value_ref);
```

`header_chain` now returns `hash(headers[0])` instead of taking the claimed head digest as a parameter, so the caller decides what to compare it against — same assertion count, one less thing to thread through.

`SiblingSide` gains a `to_word()`, because the side encoding is not obvious: the wire feeds a `select` condition, which reads the **most significant** bit, so the two sides are `Word::ZERO` and `Word::ALL_ONE` rather than `0` and `1`. That mapping used to be re-spelled at each call site.

### Soundness

Nothing about what is proved changes.

- A digest that was previously a witness pinned by `assert_eq` is now the wire that assertion made it equal to.
- `header_chain` previously ran the proof-of-work check against the caller's `latest_digest` (for the head) and against the newer header's prev-hash field (for the rest); both were already forced equal to the computed hash, so running it against the computed hash directly is the same predicate.
- The `bitcoin_headers` snapshot is byte-identical, which is a decent independent check that the rewrite preserved the circuit.

### Scope

- **converted:** `bitcoin::{double_sha256, merkle_path, header_chain}` and the `bitcoin_block_contains_transaction` example circuit
- **removed:** all four structs and every `populate_inner`
- **added:** `SiblingSide::to_word()`
- **dropped:** `sha2` from `binius-circuits` `[dependencies]` — after this it is used only from test modules, which the dev-dependency already covers
- **untouched:** `bitcoin::p2pkh_signature`, and the still-struct-shaped `base64`, `jwt_claims`, `rs256`, `blake2b`, `blake2s`, `skein512`

Net −232 lines.

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-circuits -p binius-examples --all-targets` — clean
- `cargo +nightly-2026-07-01 fmt --all --check` — clean
- `cargo test -p binius-circuits -p binius-examples` — 358 pass, 0 fail
- `cargo run --example bitcoin_header_chain -- check-snapshot` — matches snapshot

### Constraint count

Measured with `CircuitStat` on the `block_contains_transaction` test circuit (30-level path), before and after:

| | AND | ZERO | witness |
|---|---|---|---|
| before | 46,937 | 13,601 | 289 |
| after | 46,817 | 13,601 | 169 |

−120 AND and −120 witness values: exactly the 4 wires and 4 assertions per level that the returned digest makes unnecessary.

The `bitcoin_headers` snapshot (47,118 gates / 15,344 AND) is unchanged — that path only swapped one set of assertions for an identically sized one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)