### PR TITLE
Size FRI Merkle trees by coset count in the arity cost model

### DIFF
--- a/crates/iop/src/fri/common.rs
+++ b/crates/iop/src/fri/common.rs
@@ -599,19 +599,36 @@ where
 		}
 	}
 
+	/// The proof bytes one reduction of the given arity contributes.
+	///
+	/// Each test query sends one opened coset and its Merkle branch:
+	///
+	/// ```text
+	///     coset     2^arity field elements
+	///     branch    one hash per tree level
+	/// ```
+	///
+	/// The oracle commits one coset per leaf.
+	/// So its tree holds `2^(log_code_len - arity)` leaves, not `2^log_code_len`.
+	///
+	/// Sizing the tree by the codeword length would charge `arity` extra hashes per branch.
+	/// The arities chosen would then minimize a proof size no prover produces.
 	fn compute_layer_reduction_size(&self, log_code_len: usize, arity: usize) -> usize {
 		// Each queried coset contains 2^arity values.
 		let leaf_size = F::BYTE_SIZE << arity;
 		// One coset per test query.
 		let leaves_size = leaf_size * self.n_test_queries;
 
+		// One leaf per coset, so the tree is `arity` levels shorter than the codeword.
+		let log_n_cosets = log_code_len - arity;
+
 		// Size of the Merkle multi-proof.
 		let optimal_layer = self
 			.merkle_scheme
-			.optimal_verify_layer(self.n_test_queries, log_code_len);
+			.optimal_verify_layer(self.n_test_queries, log_n_cosets);
 		let merkle_size =
 			self.merkle_scheme
-				.proof_size(1 << log_code_len, self.n_test_queries, optimal_layer);
+				.proof_size(1 << log_n_cosets, self.n_test_queries, optimal_layer);
 
 		leaves_size + merkle_size
 	}
@@ -831,12 +848,68 @@ mod tests {
 	};
 
 	use super::*;
-	use crate::merkle_tree::BinaryMerkleTreeScheme;
+	use crate::{fri::proof_size, merkle_tree::BinaryMerkleTreeScheme};
 
 	type TestMerkleScheme = BinaryMerkleTreeScheme<B128, StdHashSuite>;
 
 	fn test_merkle_scheme() -> TestMerkleScheme {
 		BinaryMerkleTreeScheme::new()
+	}
+
+	// Invariant: the size the arity search minimizes is the size a prover actually sends.
+	//
+	//     cost model    what `compute_layer_reduction_size` charges, and the search minimizes
+	//     proof_size    the exact byte count
+	//
+	// Nothing compared the two, so they were free to disagree.
+	//
+	// The cost model omits the commitment digests, which do not vary with the arity choice.
+	// One input oracle carries `2 + fold_arities.len()` of them.
+	//
+	// Only the single-oracle case is pinned.
+	// `proof_size` charges one combined initial fold.
+	// A batch instead commits one tree per oracle, so the two still diverge for N > 1.
+	// That is a defect in `proof_size`, tracked separately.
+	#[test]
+	fn optimizer_estimate_matches_exact_proof_size() {
+		let merkle_scheme = test_merkle_scheme();
+		let digest_size = size_of::<<TestMerkleScheme as MerkleTreeScheme<B128>>::Digest>();
+
+		// Large enough for the widest case below: a ZK oracle commits `log_msg_len + 1`.
+		let ntt = NeighborsLastReference {
+			domain_context: GaoMateerOnTheFly::<B128>::generate(24),
+		};
+
+		for log_inv_rate in [1, 2, 3] {
+			for n_test_queries in [32, 128, 232] {
+				for log_msg_len in [0, 1, 4, 8, 12, 16, 20] {
+					// A ZK oracle pins its batch size at 1; a non-ZK oracle takes a flexible one,
+					// so the two exercise different branches of the selection.
+					for oracle in [
+						OracleSpec::new(log_msg_len),
+						OracleSpec::new_zk(log_msg_len),
+					] {
+						let (params, estimate) = FRIParams::optimal_for_batch(
+							ntt.domain_context(),
+							&merkle_scheme,
+							std::slice::from_ref(&oracle),
+							log_inv_rate,
+							n_test_queries,
+						);
+
+						let digests = (2 + params.fold_arities().len()) * digest_size;
+						assert_eq!(
+							estimate + digests,
+							proof_size(&params, &merkle_scheme),
+							"log_msg_len={log_msg_len} is_zk={} log_inv_rate={log_inv_rate} \
+							 n_test_queries={n_test_queries} arities={:?}",
+							oracle.is_zk,
+							params.fold_arities(),
+						);
+					}
+				}
+			}
+		}
 	}
 
 	#[test]
@@ -986,8 +1059,12 @@ mod tests {
 		assert_eq!(fri_params.input_oracles[2].log_lift, 0);
 		assert_eq!(fri_params.input_oracles[2].log_batch_size(), 16 - reduced_log_dim);
 
-		// Pin the estimated proof size to detect unintended changes in the optimizer.
-		assert_eq!(proof_size, 229376);
+		// Pin the estimated proof size, to catch unintended changes in the optimizer.
+		//
+		// This sums one reduction per committed oracle.
+		// `size_estimation::proof_size` does not, so the two disagree for a batch.
+		// `optimizer_estimate_matches_exact_proof_size` pins them together for one oracle.
+		assert_eq!(proof_size, 188416);
 	}
 
 	#[test]


### PR DESCRIPTION
The dynamic program that picks FRI fold arities was minimizing a proof size no prover ever produces.
No protocol change — every pinned arity is unchanged. What moves is a reported number.

### The problem

A FRI oracle does not commit one value per Merkle leaf. It commits a whole **coset**.

With arity $a$, each leaf holds $2^a$ values, so a codeword of length $2^n$ builds a tree of
$2^{n-a}$ leaves — not $2^n$.

A Merkle branch is one hash per level. The cost model sized the tree by the codeword length, so it
charged $n$ hashes per branch where the prover sends $n - a$.

That is $a$ extra hashes, per test query, in every round.

### The worked example

A $2^{16}$ message at rate $1/4$ with 128 queries. Two reductions, both arity 4:

```
4 extra hashes x 32 bytes x 128 queries = 16,384 bytes per reduction
                            x 2 reductions = 32,768 bytes
```

Measured estimate before: **163,840**. After: **131,072**. Difference: **32,768** — exactly the
predicted number, which is what makes this a diagnosis rather than a guess.

### The change

```
compute_layer_reduction_size(log_code_len, arity):
- optimal_verify_layer(n_test_queries, log_code_len)
- proof_size(1 << log_code_len, n_test_queries, optimal_layer)
+ log_n_cosets = log_code_len - arity
+ optimal_verify_layer(n_test_queries, log_n_cosets)
+ proof_size(1 << log_n_cosets, n_test_queries, optimal_layer)
```

Both calls have to change together. Correcting only the second panics with
`layer_depth must be at most log2(len)`, since the layer was chosen for the taller tree. They now
share one `log_n_cosets` binding, so the two cannot drift apart.

### The test is the real deliverable

Two functions in this crate compute the size of a FRI proof:

- `ReductionOptimizer::compute_layer_reduction_size` — the cost model the arity search minimizes,
  and the number `FRIParams::optimal_for_batch` hands back to its caller.
- `size_estimation::proof_size` — the exact byte count, used by `binius-spartan-verifier`, the
  benches, and `channel::size_tracking`.

Nothing compared them, which is why they could disagree by 25% indefinitely.

`optimizer_estimate_matches_exact_proof_size` now pins the identity

```
estimate + (2 + n_arities) * digest_size == proof_size(params)
```

over 3 rates x 3 query counts x 7 message lengths x {zk, non-zk} = 126 configurations.

The digest term is what the cost model omits on purpose: the commitment digests are constant with
respect to the arity choice, so they cannot affect the minimization.

### What this does not change

- **No protocol change.** All four pre-existing arity tests pass untouched, so the wrong cost model
  happened to pick the right arities anyway.
- **No prover or verifier behavior.** Only the reported estimate moves.
- `test_optimal_for_batch_three_oracles` pins that estimate; it moves from `229376` to `188416`.

### Scope

- **changed:** `compute_layer_reduction_size` (2 lines), one pinned constant
- **new:** `optimizer_estimate_matches_exact_proof_size`
- **left untouched:** `size_estimation::proof_size` — see below

### A second, separate bug — deliberately not fixed here

While pinning the two models I found they still diverge for a **batch** of input oracles:

| case | cost model | `proof_size` | agree |
|---|---|---|---|
| 1 oracle, non-zk | 131,072 | 131,168 | yes (+96 digests) |
| 1 oracle, zk | 184,320 | 184,448 | yes (+128 digests) |
| 2 oracles | 172,032 | 163,936 | no |
| 3 oracles | 188,416 | 360,544 | no |

The cost model is the one that is right here: it already sums one reduction per committed input
oracle, matching `BatchBrakedownOracle::open_queries`, which opens each committed tree in turn.

`size_estimation::proof_size` charges a single combined initial fold over a virtual codeword of
`log_len()`, and counts `2 + n_arities` commitment digests where a batch of $N$ oracles needs
$N + 1 + n_{\text{arities}}$.

Fixing that needs a decision about the intended batched proof layout, so it belongs in its own PR.
The new test scopes itself to single-oracle parameters and says so in a comment.

### Verification

- `cargo clippy --workspace --all-targets`, `cargo +nightly fmt --all` — clean
- `cargo test -p binius-iop --lib fri::` — 6 passed, including the four arity tests unchanged
- `cargo test -p binius-spartan-verifier --test proof_size_test` — passes; it is the one downstream
  test that pins a proof size

🤖 Generated with [Claude Code](https://claude.com/claude-code)