### PR TITLE
Delete four unreachable items from the FRI module

### DIFF
--- a/crates/iop/src/fri/batch.rs
+++ b/crates/iop/src/fri/batch.rs
@@ -171,11 +171,14 @@ impl<F: BinaryField, C> ProxTestOracle<F> for BatchBrakedownOracle<F, C> {
 	}
 }
 
-/// A [ProxTestOracle] implementation for a FRI-style code proximity check.
+/// A single FRI reduction: one committed oracle, and the fold of each opened coset.
 ///
 /// Note that this is distinct from the full FRI query-phase verifier in the `verify` module. This
 /// one only verifies the openings of a single committed oracle and folds each opened coset into a
 /// single value using FRI folding.
+///
+/// Unlike a [`ProxTestOracle`], this reduces *claims* about the base codeword rather than opening
+/// the virtual oracle outright — see [`Self::reduce_queries`].
 pub struct FRIOracle<F, C, DC>
 where
 	DC: DomainContext<Field = F>,
@@ -205,6 +208,11 @@ where
 		}
 	}
 
+	/// The base-2 logarithm of the length of the virtual (folded) oracle.
+	const fn log_len(&self) -> usize {
+		self.depth
+	}
+
 	/// The base-2 log of the size of each coset opened from the committed oracle.
 	const fn coset_log_size(&self) -> usize {
 		self.challenges.len()
@@ -228,12 +236,15 @@ where
 	/// Opens queried locations on the base codeword, reducing claims about it to the virtual
 	/// oracle.
 	///
-	/// Whereas [`Self::open_queries`] indexes the virtual oracle, this indexes the base codeword:
-	/// each index lies in the range `0..2^(self.log_len() + self.coset_log_size())` and splits into
-	/// the high `self.log_len()` bits (the coset index into the committed oracle) and the low
-	/// `self.coset_log_size()` bits (the offset within the coset). For each query, the opened coset
-	/// value at that offset is checked against `claims[i]`, after which the coset is folded into
-	/// the virtual oracle value as in [`Self::open_queries`].
+	/// An index addresses the base codeword, and splits in two:
+	///
+	/// ```text
+	///     high log_len() bits          the coset index into the committed oracle
+	///     low coset_log_size() bits    the offset within that coset
+	/// ```
+	///
+	/// Each query checks the opened coset at its offset against the matching claim.
+	/// The coset then folds into the virtual oracle value.
 	///
 	/// ## Preconditions
 	/// `claims` must have the same length as `indices`, and the indices must lie in the range
@@ -315,33 +326,6 @@ where
 	}
 
 	values[0]
-}
-
-impl<F, C, DC> ProxTestOracle<F> for FRIOracle<F, C, DC>
-where
-	F: BinaryField,
-	DC: DomainContext<Field = F>,
-{
-	type Commitment = C;
-
-	fn log_len(&self) -> usize {
-		self.depth
-	}
-
-	fn open_queries<Channel>(
-		&self,
-		indices: &[usize],
-		channel: &mut Channel,
-	) -> Result<Vec<F>, Error>
-	where
-		Channel: MerkleIPVerifierChannel<F, Commitment = C>,
-	{
-		assert!(indices.iter().all(|&index| index < 1 << self.log_len())); // precondition
-		let values = channel.recv_openings(&self.commitment, indices)?;
-		Ok(iter::zip(values.chunks(1 << self.coset_log_size()), indices)
-			.map(|(coset, &index)| self.fold_coset(index, coset.to_vec()))
-			.collect())
-	}
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/iop/src/fri/error.rs
+++ b/crates/iop/src/fri/error.rs
@@ -40,12 +40,6 @@ impl From<batch::Error> for Error {
 pub enum VerificationError {
 	#[error("incorrect codeword folding in query round {query_round} at index {index}")]
 	IncorrectFold { query_round: usize, index: usize },
-	#[error("the size of the query proof is incorrect, expected {expected}")]
-	IncorrectQueryProofLength { expected: usize },
-	#[error(
-		"the number of values in round {round} of the query proof is incorrect, expected {coset_size}"
-	)]
-	IncorrectQueryProofValuesLength { round: usize, coset_size: usize },
 	#[error("The dimension-1 codeword must contain the same values")]
 	IncorrectDegree,
 	#[error("Merkle tree error: {0}")]

--- a/crates/iop/src/fri/fold.rs
+++ b/crates/iop/src/fri/fold.rs
@@ -3,10 +3,8 @@
 
 use std::iter;
 
-use binius_field::{BinaryField, ExtensionField, Field, PackedField};
-use binius_math::{
-	inner_product::inner_product_packed, line::extrapolate_line_packed, ntt::AdditiveNTT,
-};
+use binius_field::{BinaryField, ExtensionField};
+use binius_math::{line::extrapolate_line_packed, ntt::AdditiveNTT};
 
 use super::{FRIParams, error::Error};
 use crate::merkle_channel::MerkleIPVerifierChannel;
@@ -95,37 +93,6 @@ where
 	}
 
 	values[0]
-}
-
-/// Calculate the fold of an interleaved chunk of values with random folding challenges.
-///
-/// The elements in the `values` vector are the interleaved cosets of a batch of codewords at the
-/// index `coset_index`. That is, the layout of elements in the values slice is
-///
-/// ```text
-/// [a0, b0, c0, d0, a1, b1, c1, d1, ...]
-/// ```
-///
-/// where `a0, a1, ...` form a coset of a codeword `a`, `b0, b1, ...` form a coset of a codeword
-/// `b`, and similarly for `c` and `d`.
-///
-/// The fold operation first folds the adjacent symbols in the slice using regular multilinear
-/// tensor folding for the symbols from different cosets and FRI folding for the cosets themselves
-/// using the remaining challenges.
-//
-/// NB: This method is on a hot path and does not perform any allocations or
-/// precondition checks.
-///
-/// See [DP24], Def. 3.6 and Lemma 3.9 for more details.
-///
-/// [DP24]: <https://eprint.iacr.org/2024/504>
-#[inline]
-pub fn fold_interleaved_chunk<F, P>(log_batch_size: usize, values: &[P], tensor: &[P]) -> F
-where
-	F: Field,
-	P: PackedField<Scalar = F>,
-{
-	inner_product_packed(log_batch_size, values.iter().copied(), tensor.iter().copied())
 }
 
 /// A stateful verifier for the FRI fold phase that tracks when to receive commitments.


### PR DESCRIPTION
Four public items in `crates/iop/src/fri/` that nothing in the workspace calls.
Pure deletion — no caller to update, because there are none. Independent of #2045 and #2046.

### What was audited

Every public item in the module, counted across the whole workspace, with each zero-hit item read
by hand. Private and `pub(crate)` items need no audit: rustc's `dead_code` lint already covers
them, and the workspace lints clean. Only items that are both `pub` and reachable through a
`pub mod` could hide.

Four did.

### `fold::fold_interleaved_chunk`

A public one-line wrapper over `inner_product_packed`. Zero callers — not in `binius-iop-prover`,
not in tests.

### Two `VerificationError` variants

`IncorrectQueryProofLength` and `IncorrectQueryProofValuesLength` are never constructed. They read
like leftovers from a query-proof format that checked lengths explicitly; the current channel does
not.

### `impl ProxTestOracle for FRIOracle`

Never dispatched. The query verifier holds `Vec<FRIOracle<..>>` concretely and drives it through
the inherent `reduce_queries`:

```
codeword_oracle.open_queries(&indices, channel)?   // BatchBrakedownOracle — the trait
oracle.reduce_queries(&indices, &claims, channel)  // FRIOracle — inherent, takes claims
```

Those are different operations. `open_queries` opens the virtual oracle outright; `reduce_queries`
checks claims about the *base* codeword against an opened coset and then folds. The FRI oracle only
ever does the second, which is why its trait half went unused.

The impl cannot simply be deleted, though: `reduce_queries` calls `self.log_len()`, which the trait
provided. So `log_len` becomes an inherent method and the impl goes.

### What is left of the abstraction

`ProxTestOracle` keeps two implementors: `BrakedownOracle`, and the `BatchBrakedownOracle` that
composes several of them. That is exactly the polymorphism the query verifier uses — it opens the
batch through the trait — so the trait stays.

Worth noting for a future reader: the prover side mirrors this with its own `ProxTestOracleProver`,
where `FRIOracleProver` *does* implement the trait, because the prover really does just open each
oracle. The asymmetry is real, not an oversight.

### Scope

- **deleted:** `fold_interleaved_chunk`, two error variants, one trait impl
- **changed:** `FRIOracle::log_len` from trait method to inherent; two now-unused imports in
  `fold.rs`; `FRIOracle`'s doc comment, which claimed an impl it no longer has
- **left untouched:** everything else — no call site needed updating

### Verification

- `cargo clippy --workspace --all-targets`, `cargo +nightly fmt --all` — clean
- `cargo test -p binius-iop --lib fri::` — 5 passed
- `cargo test -p binius-iop-prover --lib fri` — 13 passed, the prove/verify roundtrips that exercise
  the query phase end to end

🤖 Generated with [Claude Code](https://claude.com/claude-code)