### PR TITLE
BINIUS-406: remove the stop-before-the-final-layer batch drivers

### DIFF
--- a/crates/ip-prover/src/fracaddcheck/mod.rs
+++ b/crates/ip-prover/src/fracaddcheck/mod.rs
@@ -24,7 +24,7 @@ use crate::{
 		batch::batch_prove_mle_with_coeff_and_write_evals,
 		common::MleCheckProver,
 		frac_add_mle::{self, FracAddFusedEvaluator},
-		mle_store::{ColId, MleStore},
+		mle_store::MleStore,
 		round_evaluator::{MleCheckRoundEvaluator, SharedMleCheckProver},
 	},
 };
@@ -175,14 +175,12 @@ where
 
 	/// Pops the last layer and returns a sumcheck prover for it.
 	///
-	/// Returns `(layer_prover, remaining, cols)` where:
-	/// - `remaining` is `Some(self)` if there are more layers, `None` otherwise
-	/// - `layer_prover` is a sumcheck prover for the popped layer
-	/// - `cols` contains the [`MleStore`] column IDs `[num_0, num_1, den_0, den_1]`
+	/// Returns `(remaining, layer_prover)` where `remaining` is `Some(self)` if there are more
+	/// layers and `None` otherwise.
 	pub fn layer_prover(
 		mut self,
 		claim: FracEvalClaim<F>,
-	) -> (Option<Self>, LayerProver<'a, A, F, P>, [ColId; 4]) {
+	) -> (Option<Self>, LayerProver<'a, A, F, P>) {
 		let (num_claim, den_claim) = claim;
 		assert_eq!(
 			num_claim.point, den_claim.point,
@@ -202,14 +200,14 @@ where
 		// and of the denominator buffer. The store takes ownership of the two popped buffers and
 		// shares each between its halves, so the prover is self-contained with no up-front copy of
 		// the popped layer.
-		let (layer_prover, cols) = frac_add_mle::new_split_half(
+		let layer_prover = frac_add_mle::new_split_half(
 			alloc,
 			num,
 			den,
 			num_claim.point,
 			[num_claim.eval, den_claim.eval],
 		);
-		(remaining, layer_prover, cols)
+		(remaining, layer_prover)
 	}
 
 	/// Pops the last layer as a prover carrying the two fractional claims batched into one.
@@ -389,8 +387,7 @@ pub struct BatchProveOutput<F> {
 /// multilinears at a shared `content_point`. When the fractions are scalars (each prover reduces
 /// over all of its variables), `content_point` is empty.
 ///
-/// This delegates to [`batch_prove_until_final_layer`] and then runs the final layer's MLE-check,
-/// returning the reduced per-input-prover fractions at the reduced evaluation point. The batched
+/// Returns the reduced per-input-prover fractions at the reduced evaluation point. The batched
 /// claim is checked by the ordinary `binius_ip::fracaddcheck::verify` recursion over
 /// `k + n_layers` variables (the eq(selector)-weighted combination of the returned fractions),
 /// with the selector coordinates forming the first `k` coordinates of the claim point — there is
@@ -425,82 +422,10 @@ where
 	F: Field,
 	P: PackedField<Scalar = F>,
 {
-	let n = provers.len();
-	let k = selector_point.len();
-	let alloc = provers[0].alloc;
-
-	let BatchProveUntilFinalLayerOutput {
-		eval_point,
-		final_layer,
-	} = batch_prove_until_final_layer(
-		provers,
-		claimed_fractions,
-		selector_point,
-		content_point,
-		channel,
-	);
-
-	// Finish the retained final layer: run its per-instance content MLE-checks and the selector
-	// merge, exactly as an interior reduction layer does.
-	let layer_provers = final_layer
-		.into_iter()
-		.map(|(_frac, prover)| prover)
-		.collect();
-	let (mut fractions, eval_point) =
-		reduce_layer::<A, F, P, _>(alloc, layer_provers, &eval_point, k, channel);
-
-	// Drop the padded (2^k) selector slots, keeping one reduced fraction per input prover.
-	fractions.truncate(n);
-
-	BatchProveOutput {
-		eval_point,
-		fractions,
-	}
-}
-
-/// Output of [`batch_prove_until_final_layer`].
-///
-/// After running `n_layers - 1` reductions, holds — for each input prover, in input order — its
-/// reduced `(num, den)` fraction paired with the [`MleCheckProver`] `MP` for its final (widest)
-/// layer, at the shared `eval_point` (`selector ++ content`).
-pub struct BatchProveUntilFinalLayerOutput<F, MP> {
-	/// The reduced evaluation point (`selector ++ content`) at which the final layer is claimed.
-	pub eval_point: Vec<F>,
-	/// Each input prover's reduced `(num, den)` fraction and final-layer MLE-check prover.
-	pub final_layer: Vec<((F, F), MP)>,
-}
-
-/// Runs a batched fractional-addition check up to (but not finishing) the final layer's MLE-check.
-///
-/// Runs `n_layers - 1` of the per-layer reductions, then — for each input prover — pops its final
-/// (widest) layer as an [`MleCheckProver`] (via `FracAddCheckProver::layer_prover`), seeded at
-/// the reduced content coordinates with the prover's reduced `(num, den)` fraction claim.
-///
-/// # Returns
-/// * the reduced evaluation point (`selector ++ content`) at which the final layer is claimed, and
-/// * for each input prover, its reduced `(num, den)` fraction paired with the final-layer
-///   [`MleCheckProver`].
-///
-/// The caller finishes the final layer — e.g. [`batch_prove`] runs its MLE-check directly, or the
-/// logUp* final layer splices these provers into another reduction.
-///
-/// Arguments and preconditions are as for [`batch_prove`].
-pub fn batch_prove_until_final_layer<'a, A, F, P, Channel>(
-	provers: Vec<FracAddCheckProver<'a, A, P>>,
-	claimed_fractions: Vec<(F, F)>,
-	selector_point: Vec<F>,
-	content_point: Vec<F>,
-	channel: &mut Channel,
-) -> BatchProveUntilFinalLayerOutput<F, LayerProver<'a, A, F, P>>
-where
-	A: Allocator,
-	F: Field,
-	P: PackedField<Scalar = F>,
-	Channel: IPProverChannel<F>,
-{
 	assert!(!provers.is_empty()); // precondition
 	assert_eq!(claimed_fractions.len(), provers.len()); // precondition
 
+	let n = provers.len();
 	let k = selector_point.len();
 	assert!(provers.len() <= (1 << k)); // precondition
 
@@ -513,39 +438,20 @@ where
 	// layer this seeds each layer prover with a claim at `content_point`.
 	let eval_point = [selector_point, content_point].concat();
 
-	// Run `n_layers - 1` reductions, stopping one layer short so each prover retains its final
-	// (widest) layer for the caller to finish.
-	let (provers, claimed_fractions, eval_point) = (0..n_layers - 1).fold(
+	let (provers, mut fractions, eval_point) = (0..n_layers).fold(
 		(provers, claimed_fractions, eval_point),
 		|(provers, claimed_fractions, eval_point), _| {
 			batch_prove_layer(provers, &claimed_fractions, &eval_point, k, channel)
 		},
 	);
+	debug_assert!(provers.is_empty(), "the final layer leaves no provers");
 
-	// Pop each remaining single-layer prover's final layer as an MLE-check prover, seeded at the
-	// content coordinates with its reduced fraction. `claimed_fractions` is padded to `2^k`; zip
-	// with the `n` real provers keeps only the real (input-prover) entries.
-	let inner_coords = eval_point[k..].to_vec();
-	let final_layer = iter::zip(provers, claimed_fractions)
-		.map(|(prover, (num, den))| {
-			let (remaining, mle_prover, _cols) = prover.layer_prover((
-				MultilinearEvalClaim {
-					eval: num,
-					point: inner_coords.clone(),
-				},
-				MultilinearEvalClaim {
-					eval: den,
-					point: inner_coords.clone(),
-				},
-			));
-			debug_assert!(remaining.is_none(), "one retained layer per prover");
-			((num, den), mle_prover)
-		})
-		.collect();
+	// Drop the padded (2^k) selector slots, keeping one reduced fraction per input prover.
+	fractions.truncate(n);
 
-	BatchProveUntilFinalLayerOutput {
+	BatchProveOutput {
 		eval_point,
-		final_layer,
+		fractions,
 	}
 }
 
@@ -734,7 +640,7 @@ where
 	let inner_coords = eval_point[k..].to_vec();
 	let (layer_provers, next_provers): (Vec<_>, Vec<_>) = iter::zip(provers, claimed_fractions)
 		.map(|(prover, &(num, den))| {
-			let (remaining, layer_prover, _cols) = prover.layer_prover((
+			let (remaining, layer_prover) = prover.layer_prover((
 				MultilinearEvalClaim {
 					eval: num,
 					point: inner_coords.clone(),
@@ -799,8 +705,8 @@ pub struct BatchProveUnequalDepthsOutput<F, Prover> {
 ///
 /// # Returns
 ///
-/// Like [`batch_prove_until_final_layer`], this stops one layer short, returning each tree's
-/// reduced fraction beside the prover for its final (widest) layer — the layer whose reduction
+/// This stops one layer short, returning each tree's reduced fraction beside the prover for its
+/// final (widest) layer — the layer whose reduction
 /// dominates the cost, which a caller can therefore batch with other sumchecks. Running those
 /// provers and the selector rounds that follow finishes the check.
 ///
@@ -922,7 +828,7 @@ where
 				next_provers.push(prover);
 				Either::Right(ConstantFraction::new(num_claim, den_claim))
 			} else {
-				let (rest, layer_prover, _cols) = prover.layer_prover((
+				let (rest, layer_prover) = prover.layer_prover((
 					MultilinearEvalClaim {
 						eval: num_claim,
 						point: point.clone(),
@@ -1223,8 +1129,7 @@ mod tests {
 
 	#[test]
 	fn test_batch_prove_single_layer() {
-		// n_layers=1 edge case: batch_prove_until_final_layer runs 0 reductions and the single
-		// (final) layer is finished by batch_prove.
+		// n_layers=1 edge case: the single layer is the final one.
 		test_batch_prove_verify_helper::<Packed128b>(1, 4);
 	}
 

--- a/crates/ip-prover/src/fracaddcheck/zero_pad_mle.rs
+++ b/crates/ip-prover/src/fracaddcheck/zero_pad_mle.rs
@@ -381,7 +381,7 @@ mod tests {
 	) {
 		let alloc = GlobalAllocator;
 		let n_vars = eval_point.len();
-		let (mut reference, _cols) =
+		let mut reference =
 			frac_add_mle::new_split_half(&alloc, padded_num, padded_den, eval_point, claims);
 
 		for round in 0..n_vars {
@@ -436,7 +436,7 @@ mod tests {
 
 				let prefixes = pad_eq_prefixes(&eval_point, pad_len);
 				let pad_eq_inv = prefixes[pad_len].invert_or_zero();
-				let (inner, _cols) = frac_add_mle::new_split_half(
+				let inner = frac_add_mle::new_split_half(
 					&alloc,
 					num,
 					den,

--- a/crates/ip-prover/src/prodcheck/mod.rs
+++ b/crates/ip-prover/src/prodcheck/mod.rs
@@ -105,15 +105,6 @@ where
 		self.layers.len()
 	}
 
-	/// Consumes the prover and returns its single remaining (widest) layer.
-	///
-	/// # Preconditions
-	/// * `self.n_layers() == 1`
-	pub fn into_final_layer(mut self) -> FieldVec<P, A> {
-		assert_eq!(self.layers.len(), 1, "precondition: exactly one remaining layer");
-		self.layers.pop().expect("layers has exactly one element")
-	}
-
 	/// Pops the widest remaining layer and returns it.
 	///
 	/// # Preconditions
@@ -213,17 +204,6 @@ pub struct BatchProveOutput<F> {
 	pub evals: Vec<F>,
 }
 
-/// Output of [`batch_prove_until_final_layer`].
-///
-/// After running `n_layers - 1` reduction layers, each prover retains its final (widest) layer.
-/// `provers` pairs each remaining prover with its reduced evaluation at `eval_point`.
-pub struct BatchProveUntilFinalLayerOutput<'a, A: Allocator, P: PackedField> {
-	/// The reduced evaluation point shared by all remaining provers.
-	pub eval_point: Vec<P::Scalar>,
-	/// Each remaining prover (with its final layer) paired with its reduced eval at `eval_point`.
-	pub provers: Vec<(P::Scalar, ProdcheckProver<'a, A, P>)>,
-}
-
 /// Runs a batched product check protocol for multiple independent prodcheck provers.
 ///
 /// This combines n provers, each for an $m$-variate multilinear, using multilinear interpolation
@@ -252,8 +232,7 @@ pub struct BatchProveUntilFinalLayerOutput<'a, A: Allocator, P: PackedField> {
 /// * `claimed_products.len() == provers.len()`.
 /// * `content_point.len() == witness.log_len() - n_layers` for each prover.
 ///
-/// This delegates to [`batch_prove_until_final_layer`] and then runs the final retained layer,
-/// returning the reduced per-input-prover evaluations at the reduced evaluation point. The
+/// Returns the reduced per-input-prover evaluations at the reduced evaluation point. The
 /// batched claim is checked by the ordinary `binius_ip::prodcheck::verify` recursion over
 /// `n_layers` layers (the eq(selector)-weighted combination of the returned evaluations), with
 /// the selector coordinates forming the first `k` coordinates of the claim point.
@@ -285,49 +264,10 @@ pub fn batch_prove<'a, A: Allocator, F: Field, P: PackedField<Scalar = F>>(
 	content_point: Vec<F>,
 	channel: &mut impl IPProverChannel<F>,
 ) -> BatchProveOutput<F> {
-	let n = provers.len();
-	let k = selector_point.len();
-
-	let BatchProveUntilFinalLayerOutput {
-		eval_point,
-		provers,
-	} = batch_prove_until_final_layer(
-		provers,
-		claimed_products,
-		selector_point,
-		content_point,
-		channel,
-	);
-
-	// Finish the retained final layer: run it exactly as an interior reduction layer does.
-	let (claimed_products, provers): (Vec<_>, Vec<_>) = provers.into_iter().unzip();
-	let (provers, evals, eval_point) =
-		batch_prove_layer(provers, claimed_products, &eval_point, k, channel);
-	debug_assert!(provers.is_empty(), "the final layer leaves no provers");
-	debug_assert_eq!(evals.len(), n);
-
-	BatchProveOutput { eval_point, evals }
-}
-
-/// Runs a batched product check up to (but not finishing) the final layer.
-///
-/// Runs `n_layers - 1` of the per-layer reductions, stopping one layer short so that each prover
-/// retains its final (widest) layer. The remaining provers are returned (each paired with its
-/// reduced eval at the shared reduced `eval_point`) rather than combined into a single claim, so
-/// the caller can finish the final layer itself — e.g. [`batch_prove`] runs it directly, or a
-/// caller splices the retained layers into another reduction.
-///
-/// Arguments and preconditions are as for [`batch_prove`].
-pub fn batch_prove_until_final_layer<'a, A: Allocator, F: Field, P: PackedField<Scalar = F>>(
-	provers: Vec<ProdcheckProver<'a, A, P>>,
-	claimed_products: Vec<F>,
-	selector_point: Vec<F>,
-	content_point: Vec<F>,
-	channel: &mut impl IPProverChannel<F>,
-) -> BatchProveUntilFinalLayerOutput<'a, A, P> {
 	assert!(!provers.is_empty()); // precondition
 	assert_eq!(claimed_products.len(), provers.len()); // precondition
 
+	let n = provers.len();
 	let k = selector_point.len();
 	assert!(provers.len() <= (1 << k)); // precondition
 
@@ -340,22 +280,16 @@ pub fn batch_prove_until_final_layer<'a, A: Allocator, F: Field, P: PackedField<
 	// layer this seeds each layer prover with `claim{point: content_point, eval: claimed_product}`.
 	let eval_point = [selector_point, content_point].concat();
 
-	// Run `n_layers - 1` reductions, stopping one layer short so each prover retains its final
-	// (widest) layer for the caller to finish.
-	let (provers, claimed_products, eval_point) = (0..n_layers - 1).fold(
+	let (provers, evals, eval_point) = (0..n_layers).fold(
 		(provers, claimed_products, eval_point),
 		|(provers, claimed_products, eval_point), _| {
 			batch_prove_layer(provers, claimed_products, &eval_point, k, channel)
 		},
 	);
+	debug_assert!(provers.is_empty(), "the final layer leaves no provers");
+	debug_assert_eq!(evals.len(), n);
 
-	// Pair each remaining (single-layer) prover with its reduced eval at `eval_point`.
-	let provers = iter::zip(claimed_products, provers).collect();
-
-	BatchProveUntilFinalLayerOutput {
-		eval_point,
-		provers,
-	}
+	BatchProveOutput { eval_point, evals }
 }
 
 #[allow(clippy::type_complexity)]
@@ -545,8 +479,8 @@ pub struct BatchProveUnequalDepthsOutput<F, Prover> {
 ///
 /// # Returns
 ///
-/// Like [`batch_prove_until_final_layer`], this stops one layer short, returning each tree's
-/// reduced claim beside the prover for its final (widest) layer — the layer whose reduction
+/// This stops one layer short, returning each tree's reduced claim beside the prover for its
+/// final (widest) layer — the layer whose reduction
 /// dominates the cost, which a caller can therefore batch with other sumchecks. Running those
 /// provers and the selector rounds that follow finishes the check.
 ///

--- a/crates/ip-prover/src/sumcheck/frac_add_mle.rs
+++ b/crates/ip-prover/src/sumcheck/frac_add_mle.rs
@@ -34,10 +34,6 @@ pub type LayerProver<'a, A, F, P> =
 /// * `eval_point` - The shared point at which both claims are taken.
 /// * `claims` - The layer's claimed numerator and denominator evaluations, in that order.
 ///
-/// # Returns
-///
-/// The prover and its store's column ids `[num_0, num_1, den_0, den_1]`.
-///
 /// # Preconditions
 /// * `num.log_len() == den.log_len()`
 /// * `num.log_len() == eval_point.len() + 1`
@@ -47,7 +43,7 @@ pub fn new_split_half<'alloc, A, F, P>(
 	den: FieldVec<P, A>,
 	eval_point: Vec<F>,
 	claims: [F; 2],
-) -> (LayerProver<'alloc, A, F, P>, [ColId; 4])
+) -> LayerProver<'alloc, A, F, P>
 where
 	A: Allocator,
 	F: Field,
@@ -70,7 +66,7 @@ where
 		(num_claim, Box::new(num_evaluator)),
 		(den_claim, Box::new(den_evaluator)),
 	];
-	(SharedMleCheckProver::new(store, claims_with_evaluators, eval_point), cols)
+	SharedMleCheckProver::new(store, claims_with_evaluators, eval_point)
 }
 
 /// Creates the round evaluators for the fractional-addition claims required in logUp*.


### PR DESCRIPTION
The follow-up [BINIUS-406](https://linear.app/jimpo/issue/BINIUS-406/logup-star-run-the-full-fracaddcheck-for-the-pushforward) calls for: *"we don't even need `batch_prove_until_final_layer` for either fracaddcheck or prodcheck — these can be removed entirely as a follow-up."*

Stacked on #2052, which removes their only caller and has now merged.

## What goes

`batch_prove_until_final_layer` existed so the logUp* table side could retain its final layer and splice it into the batched final-layer sumcheck. #2052 replaces that reduction, leaving both the fracaddcheck and prodcheck variants without a caller. Each `batch_prove` now runs its own layer loop for all `n_layers` rounds instead of `n_layers - 1` plus a hand-finished last one — the preconditions move up into it, and the two output structs go.

Two more things were only ever there for the same reduction:

- **`layer_prover`'s store column ids.** All three remaining callers already ignored them (`_cols`); it now returns `(remaining, layer_prover)`. `frac_add_mle::new_split_half` loses the ids with it.
- **`prodcheck::into_final_layer`**, which had no caller at all.

## What stays

`batch_prove_unequal_depths` still stops one layer short here. That behaviour has no caller either — it was added with the driver and has only ever been exercised by its own tests — but it is a different idiom, so removing it belongs with the change that makes the driver run every layer rather than with this one. BINIUS-407 does exactly that.

## Testing

Pure removal, no behavior change. The full `binius-ip` / `binius-ip-prover` / `binius-iop` / `binius-iop-prover` suites pass, including the fracaddcheck and prodcheck batch tests that exercise `batch_prove` directly (`test_batch_prove_*`, `test_unequal_depths_*`) and the logUp* round trips. Workspace clippy `-D warnings` is clean, which is what catches the now-dead imports and returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)