### PR TITLE
Inline the single-use choose_batch_size_and_arities helper

### DIFF
--- a/crates/iop/src/fri/common.rs
+++ b/crates/iop/src/fri/common.rs
@@ -200,14 +200,23 @@ where
 		MerkleScheme: MerkleTreeScheme<F>,
 		Strategy: AritySelectionStrategy,
 	{
-		let (log_batch_size, fold_arities) = choose_batch_size_and_arities::<F, _, _>(
+		assert!(log_batch_size.is_none_or(|b| b <= log_msg_len)); // precondition
+
+		let mut fold_arities = strategy.choose_arities::<F, _>(
 			merkle_scheme,
-			log_msg_len,
-			log_batch_size,
+			log_msg_len - log_batch_size.unwrap_or(0),
 			log_inv_rate,
 			n_test_queries,
-			strategy,
 		);
+		// Without a fixed batch size, the first chosen arity becomes the batch size.
+		let log_batch_size = log_batch_size.unwrap_or_else(|| {
+			// Edge case: no folds were chosen, so batch down to a log_dim = 0 code.
+			if fold_arities.is_empty() {
+				log_msg_len
+			} else {
+				fold_arities.remove(0)
+			}
+		});
 
 		let log_dim = log_msg_len - log_batch_size;
 		let rs_code =
@@ -318,48 +327,6 @@ where
 	/// together, so it equals [`Self::n_fold_rounds`].
 	pub const fn log_msg_len(&self) -> usize {
 		self.max_log_msg_len + self.log_n_oracles
-	}
-}
-
-fn choose_batch_size_and_arities<F, MerkleScheme, Strategy>(
-	merkle_scheme: &MerkleScheme,
-	log_msg_len: usize,
-	log_batch_size: Option<usize>,
-	log_inv_rate: usize,
-	n_test_queries: usize,
-	strategy: &Strategy,
-) -> (usize, Vec<usize>)
-where
-	F: BinaryField,
-	MerkleScheme: MerkleTreeScheme<F>,
-	Strategy: AritySelectionStrategy,
-{
-	match log_batch_size {
-		Some(log_batch_size) => {
-			assert!(log_batch_size <= log_msg_len); // precondition
-			let fold_arities = strategy.choose_arities::<F, _>(
-				merkle_scheme,
-				log_msg_len - log_batch_size,
-				log_inv_rate,
-				n_test_queries,
-			);
-			(log_batch_size, fold_arities)
-		}
-		None => {
-			let mut fold_arities = strategy.choose_arities::<F, _>(
-				merkle_scheme,
-				log_msg_len,
-				log_inv_rate,
-				n_test_queries,
-			);
-			let log_batch_size = if !fold_arities.is_empty() {
-				fold_arities.remove(0)
-			} else {
-				// Edge case: fold to log_dim = 0 code.
-				log_msg_len
-			};
-			(log_batch_size, fold_arities)
-		}
 	}
 }
 


### PR DESCRIPTION
Folds a private one-caller helper in `crates/iop/src/fri/common.rs` into its only call site.
Pure refactor — no behavior change.

### The problem

`choose_batch_size_and_arities` is a private free function with **exactly one caller**, `FRIParams::with_strategy`.

Its entire body is a two-arm `match` on `Option<usize>`.

To express that, it carries 6 parameters, 3 generic parameters, and 3 where-clauses — every one of which just restates a bound the caller already has in scope.

### The idea

The two arms differ in only one place.

Both call `strategy.choose_arities` with the same merkle scheme, rate, and query count; only the message length changes:

```
Some(b) => choose_arities(log_msg_len - b)
None    => choose_arities(log_msg_len)
```

That is one expression, `log_msg_len - log_batch_size.unwrap_or(0)`, so the call happens once.

What is left is the part that genuinely branches: where the batch size comes from.

With a fixed one, it is the caller's. Without, it is the first arity the strategy chose.

### The change

```
 pub fn with_strategy<DC, MerkleScheme, Strategy>(...) -> Self {
-    let (log_batch_size, fold_arities) = choose_batch_size_and_arities::<F, _, _>(
-        merkle_scheme, log_msg_len, log_batch_size, log_inv_rate, n_test_queries, strategy,
-    );
+    assert!(log_batch_size.is_none_or(|b| b <= log_msg_len)); // precondition
+
+    let mut fold_arities = strategy.choose_arities::<F, _>(
+        merkle_scheme,
+        log_msg_len - log_batch_size.unwrap_or(0),
+        log_inv_rate,
+        n_test_queries,
+    );
+    // Without a fixed batch size, the first chosen arity becomes the batch size.
+    let log_batch_size = log_batch_size.unwrap_or_else(|| {
+        // Edge case: no folds were chosen, so batch down to a log_dim = 0 code.
+        if fold_arities.is_empty() {
+            log_msg_len
+        } else {
+            fold_arities.remove(0)
+        }
+    });
```

Net: 13 lines added, 46 removed.

### Why the assert stays explicit

The `Some` arm's `assert!(log_batch_size <= log_msg_len)` becomes an `is_none_or` guard covering both arms.

It is not decoration: it is what protects the subtraction.

Without it, a `log_batch_size` exceeding `log_msg_len` wraps to a near-`usize::MAX` length in a build with overflow checks off, instead of failing loudly at the documented precondition.

### Scope

- **changed:** `FRIParams::with_strategy` in `crates/iop/src/fri/common.rs`
- **removed:** the private `choose_batch_size_and_arities`
- **untouched:** `choose_batch_size_and_arities_multi`, the similarly-named batch-of-oracles selector, which has real logic and its own caller
- no public API moves; the helper was never exported

### Behavior

Identical on every path:

- same precondition, now checked for both `Some` and `None` inputs
- same single `choose_arities` call with the same arguments
- same edge case — an empty arity list means batching the whole message into a `log_dim = 0` code

### Verification

- `cargo build --workspace --lib --bins --tests --examples` — clean (the CI build command)
- `cargo clippy -p binius-iop --all-targets -- -D warnings` — clean
- `cargo +nightly fmt --all` — no diff
- `cargo test -p binius-iop` — 6/6 pass, including `test_with_strategy_fixed_batch_size` and `test_with_strategy_min_proof_size`, which cover the `Some` and `None` branches respectively
- `cargo test -p binius-iop-prover` — 40/40 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)