### PR TITLE
BINIUS-407: combine the looker-side and table-side fracaddchecks

### DIFF
--- a/crates/ip-prover/src/fracaddcheck/mod.rs
+++ b/crates/ip-prover/src/fracaddcheck/mod.rs
@@ -662,18 +662,6 @@ where
 	(next_provers, next_fractions, next_point)
 }
 
-/// Output of [`batch_prove_unequal_depths`].
-///
-/// After `n_layers - 1` reduction layers, each tree retains its final (widest) layer, wrapped in
-/// the padding prover that corrects it to the batch's depth.
-pub struct BatchProveUnequalDepthsOutput<F, Prover> {
-	/// The reduced evaluation point shared by all remaining provers.
-	pub eval_point: Vec<F>,
-	/// Each input prover's reduced (padded) `(num, den)` fraction paired with the not-yet-run
-	/// prover for its final layer, in input order.
-	pub provers: Vec<((F, F), Prover)>,
-}
-
 /// Runs a batched fractional-addition check for trees of *unequal* depths.
 ///
 /// This is [`batch_prove`] without the requirement that every prover have the same layer count.
@@ -698,27 +686,26 @@ pub struct BatchProveUnequalDepthsOutput<F, Prover> {
 ///
 /// # Preconditions
 /// * `provers` must be non-empty.
-/// * Every prover's witness must have exactly `prover.n_layers()` variables, which must be at least
-///   1.
+/// * Every prover's witness must have exactly `prover.n_layers()` variables. A tree of depth zero
+///   is allowed — it is all padding, so its leaf claim is its root — but at least one tree must
+///   have a layer.
 /// * `2^selector_point.len() >= provers.len()`.
 /// * `claimed_fractions.len() == provers.len()`.
 ///
 /// # Returns
 ///
-/// This stops one layer short, returning each tree's reduced fraction beside the prover for its
-/// final (widest) layer — the layer whose reduction
-/// dominates the cost, which a caller can therefore batch with other sumchecks. Running those
-/// provers and the selector rounds that follow finishes the check.
+/// A [`BatchProveOutput`] whose `fractions` are each tree's leaf claim, in input order, at the
+/// shared reduced `eval_point`.
 ///
-/// The returned fractions and, after the final layer, the per-tree leaf evaluations are claims on
-/// the *padded* witnesses. [`binius_ip::fracaddcheck::unpad_leaf_claim`] reduces one to the claims
-/// on the tree's own witness.
+/// Those leaf claims are on the *padded* witnesses.
+/// [`binius_ip::fracaddcheck::unpad_leaf_claim`] reduces one to the claims on the tree's own
+/// witness, given how much depth that tree was padded by.
 pub fn batch_prove_unequal_depths<'a, A, F, P>(
 	provers: Vec<FracAddCheckProver<'a, A, P>>,
 	claimed_fractions: Vec<(F, F)>,
 	selector_point: Vec<F>,
 	channel: &mut impl IPProverChannel<F>,
-) -> BatchProveUnequalDepthsOutput<F, PaddedLayerProver<'a, A, F, P>>
+) -> BatchProveOutput<F>
 where
 	A: Allocator,
 	F: Field,
@@ -729,7 +716,6 @@ where
 
 	let k = selector_point.len();
 	assert!(provers.len() <= (1 << k)); // precondition
-	assert!(provers.iter().all(|prover| prover.n_layers() >= 1)); // precondition
 
 	let alloc = provers[0].alloc;
 	let mut provers = provers;
@@ -738,18 +724,20 @@ where
 		.map(FracAddCheckProver::n_layers)
 		.max()
 		.expect("provers is non-empty");
+	assert!(n_layers >= 1); // precondition
 	// How much depth each tree is padded by.
 	let pad_lens = provers
 		.iter()
 		.map(|prover| n_layers - prover.n_layers())
 		.collect::<Vec<_>>();
 
+	let n_trees = provers.len();
 	let mut claims = claimed_fractions;
 	let mut eval_point = selector_point;
 
-	// Reduce down to the final layer. Each iteration reduces the layer whose node variables are the
-	// point's suffix past the selector coordinates.
-	for _ in 0..n_layers - 1 {
+	// Each iteration reduces the layer whose node variables are the point's suffix past the
+	// selector coordinates. A tree the batch has not yet reached contributes a padding layer.
+	for _ in 0..n_layers {
 		let (next_provers, layer_provers) =
 			layer_provers(provers, &pad_lens, &claims, &eval_point[k..]);
 		provers = next_provers;
@@ -758,15 +746,20 @@ where
 		claims = next_claims;
 		eval_point = next_point;
 	}
+	// A depth-0 tree is all padding, so it is passed through every round and never popped; every
+	// tree that had a layer has spent them all.
+	debug_assert!(
+		provers.iter().all(|prover| prover.n_layers() == 0),
+		"every tree with layers is exhausted after n_layers reductions"
+	);
 
-	let n_trees = provers.len();
-	let (_exhausted, layer_provers) = layer_provers(provers, &pad_lens, &claims, &eval_point[k..]);
 	// `reduce_layer` pads its output to the 2^k selector slots; only the real trees remain.
-	claims.truncate(n_trees);
+	let mut fractions = claims;
+	fractions.truncate(n_trees);
 
-	BatchProveUnequalDepthsOutput {
+	BatchProveOutput {
 		eval_point,
-		provers: iter::zip(claims, layer_provers).collect(),
+		fractions,
 	}
 }
 
@@ -1310,21 +1303,15 @@ mod tests {
 		};
 
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
-		let BatchProveUnequalDepthsOutput {
+		let BatchProveOutput {
 			eval_point,
-			provers,
+			fractions,
 		} = batch_prove_unequal_depths(
 			provers,
 			claimed_fractions,
 			selector_point,
 			&mut prover_transcript,
 		);
-
-		// Finish the retained final layer: run it exactly as an interior reduction layer does.
-		let (_claims, provers): (Vec<_>, Vec<_>) = provers.into_iter().unzip();
-		let (mut fractions, eval_point) =
-			reduce_layer::<_, _, P, _>(&alloc, provers, &eval_point, k, &mut prover_transcript);
-		fractions.truncate(depths.len());
 
 		// The verifier's control flow depends only on the maximum depth.
 		let mut verifier_transcript = prover_transcript.into_verifier();
@@ -1370,6 +1357,12 @@ mod tests {
 	}
 
 	#[test]
+	fn test_unequal_depths_zero_depth_tree() {
+		// A depth-0 tree never pops a layer: it is all padding, so its leaf claim is its root.
+		test_unequal_depths_helper::<Packed128b>(&[0, 3]);
+	}
+
+	#[test]
 	fn test_unequal_depths_maximal_padding() {
 		// A single-layer tree beside a deep one: all but its last reduction is padding.
 		test_unequal_depths_helper::<Packed128b>(&[1, 6]);
@@ -1397,17 +1390,12 @@ mod tests {
 				unequal_depth_provers::<P>(&mut rng, &alloc, &depths);
 
 			let mut transcript = ProverTranscript::new(StdChallenger::default());
-			let BatchProveUnequalDepthsOutput {
-				eval_point,
-				provers,
-			} = batch_prove_unequal_depths(
+			batch_prove_unequal_depths(
 				provers,
 				claimed_fractions,
 				selector_point.clone(),
 				&mut transcript,
 			);
-			let (_claims, provers): (Vec<_>, Vec<_>) = provers.into_iter().unzip();
-			reduce_layer::<_, _, P, _>(&alloc, provers, &eval_point, k, &mut transcript);
 			transcript.finalize()
 		};
 

--- a/crates/ip-prover/src/logup_star/prove.rs
+++ b/crates/ip-prover/src/logup_star/prove.rs
@@ -4,7 +4,7 @@
 
 use binius_compute::Allocator;
 use binius_field::{BinaryField, Divisible, Field, PackedField};
-use binius_ip::{MultilinearEvalClaim, logup_star::LogupOutput};
+use binius_ip::{MultilinearEvalClaim, fracaddcheck::unpad_leaf_claim, logup_star::LogupOutput};
 use binius_math::{FieldBuffer, FieldSlice, FieldVec, univariate::evaluate_univariate};
 use binius_utils::{checked_arithmetics::log2_ceil_usize, rayon::prelude::*};
 
@@ -26,7 +26,10 @@ use crate::{
 /// sharing the table. The lookers batch by a random linear combination: a challenge `gamma`
 /// scales looker `j`'s equality-indicator numerator by `gamma^j`, and the pushforward is the
 /// gamma-weighted sum of the per-looker pushforwards, still with only `2^m` entries. The
-/// looked-up vectors are never committed.
+/// looked-up vectors are never committed. Every fractional-addition circuit — the lookers' over
+/// `n` variables and the table's over `m` — is an instance of one GKR of
+/// `ceil(log2(#lookers + 1)) + max(n, m)` layers, with the shallower side padded by zero
+/// fractions.
 /// See [Soukhanov25] for the construction.
 ///
 /// [Soukhanov25]: <https://eprint.iacr.org/2025/946>
@@ -162,22 +165,23 @@ where
 {
 	let m = table.log_len();
 	let n = lookers[0].eval_point.len();
-	let log_lookers = log2_ceil_usize(lookers.len());
+	// One batch instance per looker, plus the table.
+	let k = log2_ceil_usize(lookers.len() + 1);
 
 	// Sample the logUp challenge c that randomizes the logarithmic-derivative denominators.
 	// This is the prover's first transcript action, mirroring the verifier.
 	// A committing caller must absorb the I, T, and Y commitments into the transcript before this.
 	let c = channel.sample();
 
-	// Build the fractional-addition circuits, one per looker plus the table side.
-	// Constructing a circuit computes every layer and returns its single root fraction.
+	// Build the fractional-addition circuits, one per looker plus the table side. Constructing a
+	// circuit computes every layer and returns its single root fraction.
 	//
 	//     looker j: gamma^j * eq_{r_j}(i) / (c - I_j(i))   over n variables
 	//     table:    Y(v)                  / (c - v)         over m variables
 	let circuits_guard = tracing::debug_span!("Build fracadd circuits").entered();
 	// The circuits are independent, so they build in parallel across lookers.
 	// The collect preserves looker order, so circuit j keeps numerator gamma^j.
-	let (looker_provers, looker_roots): (Vec<_>, Vec<_>) = (lookers, numerators)
+	let (mut provers, mut roots): (Vec<_>, Vec<_>) = (lookers, numerators)
 		.into_par_iter()
 		.map(|(looker, numerator)| {
 			let den = witness::looker_denominator::<A, F, P>(alloc, c, looker.index);
@@ -185,6 +189,8 @@ where
 			(prover, (root.0.get(0), root.1.get(0)))
 		})
 		.unzip();
+	// The table's fraction enters the sum of every instance negated, which is what makes that sum's
+	// numerator vanish. The negation rides on the denominator, which is built here anyway.
 	let table_den = witness::table_denominator::<A, F, P>(alloc, c, m);
 	// The pushforward is borrowed — a committing caller keeps it for the oracle opening — so the
 	// table circuit's leaf layer, which it folds in place, is a clone drawn from `alloc`.
@@ -193,80 +199,84 @@ where
 		alloc,
 		(FieldBuffer::clone_from_slice(alloc, pushforward.to_ref()), table_den),
 	);
-	let num_r = table_root.0.get(0);
-	let den_r = table_root.1.get(0);
+	provers.push(table_prover);
+	roots.push((table_root.0.get(0), table_root.1.get(0)));
 
-	// Top circuit: interpolate the per-looker root fractions into a multilinear pair over the
-	// looker variables, padded with the zero fraction (numerators with 0, denominators with 1).
-	// Its root is the fractional sum of every looker circuit, so the looker side runs as one
-	// GKR circuit over n + log_lookers variables.
-	let mut root_nums = looker_roots
-		.iter()
-		.map(|&(num_j, _)| num_j)
-		.collect::<Vec<_>>();
-	let mut root_dens = looker_roots
-		.iter()
-		.map(|&(_, den_j)| den_j)
-		.collect::<Vec<_>>();
-	root_nums.resize(1 << log_lookers, F::ZERO);
-	root_dens.resize(1 << log_lookers, F::ONE);
-	let (top_prover, top_root) = FracAddCheckProver::new(
-		log_lookers,
-		alloc,
+	// Top circuit: interpolate every instance's root fraction into a multilinear pair over the k
+	// selector variables, padded with the zero fraction. Its own root is the fractional sum of all
+	// of them, and the table's denominator is already negated, so that sum is
+	//
+	//     sum_j num_j / den_j  -  num_r / den_r
+	//
+	// which is zero exactly when the logUp identity holds.
+	let (top_prover, (top_root_num, top_root_den)) = FracAddCheckProver::new(k, alloc, {
+		let (mut root_nums, mut root_dens): (Vec<_>, Vec<_>) = roots.iter().copied().unzip();
+		root_nums.resize(1 << k, F::ZERO);
+		root_dens.resize(1 << k, F::ONE);
 		(
 			FieldBuffer::<P, _>::from_values_in(alloc, &root_nums),
 			FieldBuffer::<P, _>::from_values_in(alloc, &root_dens),
-		),
-	);
-	let num_l = top_root.0.get(0);
-	let den_l = top_root.1.get(0);
+		)
+	});
+	let root_den = top_root_den.get(0);
 	drop(circuits_guard);
 
-	// The two root fractions; their equality is the logUp identity the verifier checks.
-	//
-	//     num_l / den_l = sum_j gamma^j sum_i eq_{r_j}(i) / (c - I_j(i))
-	//     num_r / den_r = sum_v Y(v) / (c - v)
-	channel.send_many(&[num_l, den_l, num_r, den_r]);
-
-	let looker_gkr_guard = tracing::debug_span!("Looker-side GKR").entered();
-	// Looker side, first phase: run the top circuit over the looker variables to completion,
-	// reducing its root to a claim on the interpolated root fractions at a selector point.
-	let (top_remaining, (top_num_claim, _top_den_claim)) =
-		top_prover.prove_layers(log_lookers, root_claim(num_l, den_l), channel);
-	debug_assert!(
-		top_remaining.is_none_or(|prover| prover.n_layers() == 0),
-		"the top circuit runs all log_lookers layers"
+	// A witness satisfying the lookup identity zeroes the root numerator, so it is not sent: the
+	// verifier supplies the zero itself, and a prover whose lookups do not match cannot make the
+	// rest of the GKR agree with it.
+	debug_assert_eq!(
+		top_root_num.get(0),
+		F::ZERO,
+		"the lookup identity must hold: the looker fractions must sum to the table's"
 	);
-	let selector_point = top_num_claim.point;
+	channel.send_one(root_den);
 
-	// Looker side, second phase: continue with the batched GKR over the per-looker circuits down
-	// to the leaf claims, seeded at the selector point. With no looker variables there are no
-	// layers to run: the roots are already the leaf fractions.
-	let batch_output = if n == 0 {
-		fracaddcheck::BatchProveOutput {
-			eval_point: selector_point,
-			fractions: looker_roots,
-		}
-	} else {
-		fracaddcheck::batch_prove(looker_provers, looker_roots, selector_point, Vec::new(), channel)
-	};
-	drop(looker_gkr_guard);
+	// One GKR over the whole thing: k layers of top circuit down to the per-instance roots, then
+	// max(n, m) more over the instances themselves. The looker trees have depth n and the table
+	// tree depth m, so the batch pads the shallower side up — the padding costs O(1) per round and
+	// the layer count depends only on that maximum.
+	let gkr_guard = tracing::debug_span!("Combined GKR").entered();
+	let (top_num_claim, _top_den_claim) = top_prover.prove(root_claim(F::ZERO, root_den), channel);
+	let selector_point = top_num_claim.point;
+	let fracaddcheck::BatchProveOutput {
+		eval_point,
+		fractions,
+	} = fracaddcheck::batch_prove_unequal_depths(provers, roots, selector_point, channel);
+	drop(gkr_guard);
+
+	// The leaf claims are on the padded witnesses; divide the padding back out to land on each
+	// circuit's own leaves. The node coordinates are the point past the selector ones.
+	let node_point = &eval_point[k..];
+	let n_layers = node_point.len();
+	let (table_fraction, looker_fractions) = fractions
+		.split_last()
+		.expect("the batch holds one tree per looker plus the table");
 
 	// The per-looker leaf denominators are c - I_j(content), so the index claims are their
-	// c-complements. Send them so the verifier can check they combine to the batched leaf.
-	let index_eval_point = batch_output.eval_point[log_lookers..].to_vec();
-	let index_eval_claims = batch_output
-		.fractions
+	// c-complements. The numerators are the transparent scaled equality indicators, which the
+	// verifier evaluates itself.
+	let looker_leaves = looker_fractions
 		.iter()
-		.map(|&(_num_leaf, den_leaf)| c - den_leaf)
+		.map(|&fraction| unpad_leaf_claim(fraction, node_point, n_layers - n))
 		.collect::<Vec<_>>();
-	channel.send_many(&index_eval_claims);
+	let index_eval_point = looker_leaves
+		.first()
+		.expect("at least one looker")
+		.point
+		.clone();
+	let index_eval_claims = looker_leaves
+		.iter()
+		.map(|leaf| c - leaf.den_eval)
+		.collect::<Vec<_>>();
 
-	// Table side: run the GKR to its leaf, claiming the pushforward Y and the denominator D at a
-	// shared point. D is the public c - J, so only the Y claim carries forward.
-	let table_gkr_guard = tracing::debug_span!("Table-side GKR layers").entered();
-	let (table_num_claim, _table_den_claim) = table_prover.prove(root_claim(num_r, den_r), channel);
-	drop(table_gkr_guard);
+	// The table leaf claims Y at the point past its own padding; its denominator is the public
+	// J - c, which the verifier checks itself.
+	let table_leaf = unpad_leaf_claim(*table_fraction, node_point, n_layers - m);
+
+	// Send the claims the verifier cannot derive: the index evaluations and Y's. Together with the
+	// transparent halves they rebuild the batch's leaf claim.
+	channel.send_many(&index_eval_claims);
+	channel.send_one(table_leaf.num_eval);
 
 	// Reduce the leaf claim on Y and the product claim <T, Y> = e to one shared evaluation point.
 	let PushforwardOutput {
@@ -278,8 +288,8 @@ where
 		table,
 		pushforward,
 		eval_claim,
-		table_num_claim.eval,
-		&table_num_claim.point,
+		table_leaf.num_eval,
+		&table_leaf.point,
 		channel,
 	);
 
@@ -292,9 +302,7 @@ where
 	}
 }
 
-/// The root claim of a fractional-addition circuit, over zero variables.
-///
-/// The circuit collapses to one fraction `num / den` at its root, evaluated at the empty point.
+/// The claim on a circuit's root, which is a single fraction over no variables.
 const fn root_claim<F: Field>(num: F, den: F) -> FracEvalClaim<F> {
 	(
 		MultilinearEvalClaim {

--- a/crates/ip-prover/src/logup_star/pushforward.rs
+++ b/crates/ip-prover/src/logup_star/pushforward.rs
@@ -3,7 +3,7 @@
 //! The pushforward reduction that closes the table side.
 //!
 //! The table-side fractional-addition GKR runs all the way to its leaf, which claims the
-//! pushforward `Y` at a point `z`. Its denominator half is the public `D = c - J`, so the verifier
+//! pushforward `Y` at a point `z`. Its denominator half is the public `D = J - c`, so the verifier
 //! checks that one itself. That leaves two claims that both read `Y`:
 //!
 //! - the GKR leaf claim `Y(z)`,

--- a/crates/ip-prover/src/logup_star/witness.rs
+++ b/crates/ip-prover/src/logup_star/witness.rs
@@ -6,7 +6,7 @@
 //!
 //! - the looker numerator `eq_r`, the equality indicator at the evaluation point,
 //! - the looker denominator `c - I`, with `I` the embedded index column,
-//! - the table denominator `c - J`, with `J` the embedded table positions,
+//! - the negated table denominator `J - c`, with `J` the embedded table positions,
 //! - the pushforward `Y = I_* eq_r`, the looker numerator scattered onto table positions.
 
 use std::iter;
@@ -262,18 +262,20 @@ where
 	FieldBuffer::new(log_len, packed)
 }
 
-/// Build the table denominator `c - J` over the `m`-variable table cube.
+/// Build the negated table denominator `J - c` over the `m`-variable table cube.
 ///
-/// Entry `j` is `c - iota(j)`, the logUp denominator for table position `j`.
+/// Entry `j` is `iota(j) - c`. The logUp denominator for table position `j` is `c - iota(j)`; the
+/// table's fraction enters the sum of every instance negated, and carrying that negation on the
+/// denominator rather than the numerator costs nothing here, where the entries are built anyway.
 pub fn table_denominator<A, F, P>(alloc: &A, c: F, table_n_vars: usize) -> FieldVec<P, A>
 where
 	A: Allocator,
 	F: BinaryField<Underlier: Divisible<u64>>,
 	P: PackedField<Scalar = F>,
 {
-	// One denominator per table position: shift the challenge by the position's embedding.
+	// One denominator per table position: shift the position's embedding by the challenge.
 	let values = (0..1usize << table_n_vars)
-		.map(|j| c - embed_position::<F>(j))
+		.map(|j| embed_position::<F>(j) - c)
 		.collect::<Vec<_>>();
 	FieldBuffer::from_values_in(alloc, &values)
 }

--- a/crates/ip/src/fracaddcheck.rs
+++ b/crates/ip/src/fracaddcheck.rs
@@ -5,7 +5,7 @@
 //! Each layer represents combining siblings with the fractional-addition rule:
 //! (a0 / b0) + (a1 / b1) = (a0 * b1 + a1 * b0) / (b0 * b1).
 
-use binius_field::Field;
+use binius_field::{Field, field::FieldOps};
 use binius_math::{line::extrapolate_line, multilinear::eq::eq_one_var};
 use binius_transcript::Error as TranscriptError;
 
@@ -81,6 +81,28 @@ where
 		},
 		channel,
 	)
+}
+
+/// Pads a leaf fraction — the forward map that [`unpad_leaf_claim`] inverts.
+///
+/// Padding a tree scales its numerator by the padding coordinates' equality weight $q$ and sends
+/// its denominator through the one-padding selector $\textsf{sel}(q, v) = 1 + (v - 1) q$. A
+/// verifier that rebuilds a padded batch's leaf claim from transparent parts applies this to each
+/// tree, so the two directions live together.
+///
+/// The weight is a parameter rather than the padding coordinates, so a caller padding several
+/// trees computes each distinct one once.
+///
+/// # Arguments
+///
+/// * `fraction` - The unpadded leaf's numerator and denominator.
+/// * `pad_eq` - The padding coordinates' equality weight $\text{eq}(0^\nu; X_\text{pad})$, which is
+///   [`eq_ind_zero`] over the lowest coordinates of the leaf point.
+///
+/// [`eq_ind_zero`]: binius_math::multilinear::eq::eq_ind_zero
+pub fn pad_leaf_fraction<E: FieldOps>(fraction: (E, E), pad_eq: E) -> (E, E) {
+	let (num, den) = fraction;
+	(num * pad_eq.clone(), E::one() + (den - E::one()) * pad_eq)
 }
 
 /// Reduces a leaf claim on a zero-fraction-padded witness to the claim on the witness itself.

--- a/crates/ip/src/logup_star/error.rs
+++ b/crates/ip/src/logup_star/error.rs
@@ -16,13 +16,11 @@ pub enum Error {
 
 #[derive(Debug, thiserror::Error)]
 pub enum VerificationError {
-	#[error("the two lookup fractional sums are not equal")]
-	LookupSumMismatch,
 	#[error("the eq_r multilinear evaluation is incorrect")]
 	IncorrectXEvaluation,
 	#[error("the index evaluations do not combine to the leaf denominator")]
 	IncorrectIndexEvaluation,
-	#[error("the table-side leaf denominator is not the transparent c - J")]
+	#[error("the table-side leaf denominator is not the transparent J - c")]
 	IncorrectTableDenominator,
 	#[error("the pushforward reduction evaluation is incorrect")]
 	PushforwardMismatch,

--- a/crates/ip/src/logup_star/pushforward.rs
+++ b/crates/ip/src/logup_star/pushforward.rs
@@ -3,7 +3,7 @@
 //! The pushforward reduction that closes the table side.
 //!
 //! The table-side fractional-addition GKR runs to its leaf, which claims the pushforward `Y` at a
-//! point `z`; its denominator half is the public `D = c - J`, which the verifier checks itself.
+//! point `z`; its denominator half is the public `D = J - c`, which the verifier checks itself.
 //! That leaves two claims that both read `Y` — the leaf claim `Y(z)` and the product claim
 //! `<T, Y> = e` — and one batched `m`-variable sumcheck reduces them to a single evaluation point.
 
@@ -93,11 +93,12 @@ where
 	})
 }
 
-/// Evaluate the table-side denominator multilinear at a point.
+/// Evaluate the negated table-side denominator multilinear at a point.
 ///
-/// The denominator is `D(x) = c - J(x)` with the index embedding
-/// `J(x) = sum_{t} basis(t) * x_t`, so it is transparent: the verifier evaluates it itself rather
-/// than taking the prover's word for the GKR leaf's denominator half.
+/// The logUp denominator is `c - J(x)` with the index embedding `J(x) = sum_{t} basis(t) * x_t`.
+/// The table's fraction enters the sum of every instance negated, and that negation is carried on
+/// the denominator, so this returns `J(x) - c`. Either way it is transparent: the verifier
+/// evaluates it itself rather than taking the prover's word for the GKR leaf's denominator half.
 ///
 /// In characteristic 2 subtraction is addition, but the field operations are written generically.
 ///
@@ -119,7 +120,7 @@ where
 		})
 		.fold(E::zero(), |acc, term| acc + term);
 
-	c.clone() - j
+	j - c.clone()
 }
 
 #[cfg(test)]
@@ -156,9 +157,10 @@ mod tests {
 		let c = B128::random(&mut rng);
 		let point = random_scalars::<B128>(&mut rng, m);
 
-		// The explicitly built denominator multilinear D[j] = c - iota(j) over the table cube.
+		// The explicitly built negated denominator multilinear D[j] = iota(j) - c over the table
+		// cube.
 		let d_values = (0..(1usize << m))
-			.map(|j| c - iota(j, m))
+			.map(|j| iota(j, m) - c)
 			.collect::<Vec<_>>();
 
 		assert_eq!(

--- a/crates/ip/src/logup_star/verify.rs
+++ b/crates/ip/src/logup_star/verify.rs
@@ -6,7 +6,10 @@ use std::iter;
 
 use binius_field::{BinaryField1b, ExtensionField, Field, field::FieldOps, util::powers};
 use binius_math::{
-	multilinear::{eq::eq_ind, evaluate::evaluate_inplace_scalars},
+	multilinear::{
+		eq::{eq_ind, eq_ind_zero},
+		evaluate::evaluate_inplace_scalars,
+	},
 	univariate::evaluate_univariate,
 };
 
@@ -34,10 +37,19 @@ pub struct LookerClaim<'a, Elem> {
 /// Reduces the claims `(I_j^* T)(r_j) = e_j` to the claims in [`LogupOutput`]. The lookers batch
 /// by a random linear combination: the challenge `gamma` scales looker `j`'s numerator by
 /// `gamma^j`, the pushforward is the gamma-weighted sum of the per-looker pushforwards, and the
-/// product check binds `<T, Y>` to the gamma-combination of the claims. The looker side runs as
-/// one GKR circuit over `k + n` variables (`k = ceil(log2 #lookers)`): the top `k` layers
-/// fractionally add the per-looker circuit roots (padded with the zero fraction `0/1`), so the
-/// reduced index claims share one evaluation point.
+/// product check binds `<T, Y>` to the gamma-combination of the claims.
+///
+/// Every fractional-addition circuit — one per looker over `n` variables, plus the table's over
+/// `m` — is an instance of **one** GKR of `k + max(n, m)` layers, where
+/// `k = ceil(log2(#lookers + 1))`. Its top `k` layers add the per-instance root fractions
+/// together and its lower `max(n, m)` run the instances in a batch, with the shallower side padded
+/// by zero fractions — that leaves a fractional sum unchanged and costs `O(1)` per round, so the
+/// layer count depends only on the deeper side.
+///
+/// The table's fraction enters that sum negated, so the circuit's root is
+/// `sum_j num_j/den_j - num_r/den_r`, whose numerator vanishes exactly when the lookup identity
+/// holds. The verifier therefore reads only the root *denominator* and supplies the zero numerator
+/// itself: the identity is enforced by the shape of the claim rather than by a separate check.
 ///
 /// The caller samples `gamma` itself, before receiving the pushforward commitment: the prover
 /// needs `gamma` to build the combined pushforward, so the commitment must come after.
@@ -58,11 +70,10 @@ pub struct LookerClaim<'a, Elem> {
 ///
 /// ```text
 ///     1. sample c                                  (logUp challenge)
-///     2. recv [num_L, den_L, num_R, den_R]         (root fractions of both GKR circuits)
-///     3. looker-side GKR, k + n layers             (see fracaddcheck::verify)
-///     4. recv per-looker index evaluations
-///     5. table-side GKR, all m layers              (see fracaddcheck::verify)
-///     6. pushforward reduction:
+///     2. recv den_root                             (the root denominator; its numerator is 0)
+///     3. combined GKR, k + max(n, m) layers        (see fracaddcheck::verify)
+///     4. recv per-looker index evaluations, then Y (the non-transparent leaf halves)
+///     5. pushforward reduction:
 ///        a. sample batch_coeff
 ///        b. m rounds of degree-2 sumcheck
 ///        c. recv [Y, T]                            (evaluations at the challenge point)
@@ -83,10 +94,9 @@ pub struct LookerClaim<'a, Elem> {
 ///
 /// Returns an error when the proof is malformed or any verification identity fails:
 ///
-/// - the two lookup sums disagree,
-/// - the batched `eq_r` evaluation is wrong,
-/// - the index evaluations do not combine to the batched leaf denominator,
-/// - the table-side leaf denominator is not the transparent `c - J`,
+/// - a GKR layer's reduction is inconsistent, which is where a violated lookup identity surfaces,
+/// - the transparent leaf numerators do not interpolate to the batch's leaf numerator,
+/// - the index and table denominators do not interpolate to the batch's leaf denominator,
 /// - the pushforward reduction is inconsistent.
 pub fn verify_reduction<F, C>(
 	gamma: &C::Elem,
@@ -109,100 +119,94 @@ where
 		lookers.iter().all(|looker| looker.eval_point.len() == n),
 		"every looker evaluation point must have the same length"
 	);
-	let log_lookers = lookers.len().next_power_of_two().ilog2() as usize;
 
 	// Sample the logUp challenge c that randomizes the logarithmic-derivative denominators.
 	let c = channel.sample();
 
-	// Read the root fractions of both fractional-addition GKR circuits.
-	//
-	//     looker side: num_L / den_L = sum_j gamma^j sum_{i in B_n} eq_{r_j}(i) / (c - I_j(i))
-	//     table  side: num_R / den_R = sum_{v in B_m} Y(v) / (c - v)
-	let [num_l, den_l, num_r, den_r] = channel
-		.recv_array()
+	// Read the root denominator. The root numerator is not on the transcript: the whole circuit
+	// sums the looker fractions against the negated table fraction, so its value is zero exactly
+	// when the lookup identity holds, and the verifier supplies that zero itself.
+	let root_den: C::Elem = channel
+		.recv_one()
 		.map_err(|_| VerificationError::TranscriptIsEmpty)?;
 
-	// The lookup identity is the equality of the two fractional sums.
-	//
-	//     num_L / den_L = num_R / den_R   <=>   num_L * den_R - num_R * den_L = 0
-	let sum_diff = num_l.clone() * den_r.clone() - num_r.clone() * den_l.clone();
-	channel
-		.assert_zero(sum_diff)
-		.map_err(|_| VerificationError::LookupSumMismatch)?;
-
-	// Looker side: run the full GKR down to the leaf claim. The top log_lookers layers
-	// fractionally add the per-looker circuit roots (interpolated over the looker variables,
-	// padded with the zero fraction 0/1), and the remaining n layers run the per-looker circuits
-	// batched by the selector coordinates those top layers bind.
+	// One GKR over the whole thing, from that single root fraction down to the leaves: k layers
+	// interpolating the per-instance roots, then max(n, m) more over the instances. The looker
+	// trees have depth n and the table tree depth m, so the shallower side is padded by zero
+	// fractions — the layer count never reveals which is which.
+	let n_instances = lookers.len() + 1;
+	let k = n_instances.next_power_of_two().ilog2() as usize;
+	let n_layers = k + n.max(m);
 	let FracAddEvalClaim {
-		num_eval: looker_num,
-		den_eval: looker_den,
+		num_eval: leaf_num,
+		den_eval: leaf_den,
 		point: leaf_point,
 	} = fracaddcheck::verify::<F, C>(
-		n + log_lookers,
+		n_layers,
 		FracAddEvalClaim {
-			num_eval: num_l,
-			den_eval: den_l,
+			num_eval: C::Elem::zero(),
+			den_eval: root_den,
 			point: Vec::new(),
 		},
 		channel,
 	)?;
 
-	// The leaf point splits into the selector coordinates and the shared content point.
-	let (selector_coords, content_point) = leaf_point.split_at(log_lookers);
+	// The leaf point splits into the selector coordinates and the shared node point.
+	let (selector_coords, node_point) = leaf_point.split_at(k);
 
-	// The per-looker leaf numerators are transparent scaled equality indicators, so the verifier
-	// evaluates the batched leaf numerator by itself (padding numerators are zero):
-	//
-	//     N(leaf) = sum_j eq(selector_coords, j) * gamma^j * eq(r_j, content_point)
-	let mut eq_evals = iter::zip(lookers, powers(gamma.clone()))
-		.map(|(looker, power)| power * eq_ind::<C::Elem>(looker.eval_point, content_point))
-		.collect::<Vec<_>>();
-	eq_evals.resize(1 << log_lookers, C::Elem::zero());
-	let expected_num = evaluate_inplace_scalars(eq_evals, selector_coords);
-	channel
-		.assert_zero(looker_num - expected_num)
-		.map_err(|_| VerificationError::IncorrectXEvaluation)?;
-
-	// Receive the per-looker index evaluations and check they combine to the batched leaf
-	// denominator, whose per-looker leaves are c - I_j (padding denominators are one):
-	//
-	//     den(leaf) = sum_j eq(selector_coords, j) * (c - I_j(content_point))
-	let index_eval_claims = channel
+	// Read the claims the verifier cannot derive: the per-looker index evaluations and Y's.
+	let index_eval_claims: Vec<C::Elem> = channel
 		.recv_many(lookers.len())
 		.map_err(|_| VerificationError::TranscriptIsEmpty)?;
-	let mut den_evals = index_eval_claims
-		.iter()
-		.map(|eval| c.clone() - eval.clone())
-		.collect::<Vec<_>>();
-	den_evals.resize(1 << log_lookers, C::Elem::one());
-	let expected_den = evaluate_inplace_scalars(den_evals, selector_coords);
-	channel
-		.assert_zero(looker_den - expected_den)
-		.map_err(|_| VerificationError::IncorrectIndexEvaluation)?;
+	let pushforward_eval: C::Elem = channel
+		.recv_one()
+		.map_err(|_| VerificationError::TranscriptIsEmpty)?;
 
-	// Table side: run the full GKR down to the leaf claim on the pushforward and the denominator.
+	// Rebuild each circuit's padded leaf fraction and check they interpolate to the batch's leaf.
 	//
-	//     Y(z) and D(z), where D = c - J is the table-side denominator
-	let FracAddEvalClaim {
-		num_eval: pushforward_eval,
-		den_eval: table_den_eval,
-		point: table_leaf_point,
-	} = fracaddcheck::verify::<F, C>(
-		m,
-		FracAddEvalClaim {
-			num_eval: num_r,
-			den_eval: den_r,
-			point: Vec::new(),
-		},
-		channel,
-	)?;
+	// The node point spans max(n, m) coordinates, so looker j is padded by `max(n, m) - n` and the
+	// table by `max(n, m) - m`; padding scales a numerator by the padding coordinates' equality
+	// weight q and sends a denominator through sel(q, .), so both halves follow from the claims
+	// above.
+	let n_node_vars = node_point.len();
+	let (looker_pad, table_pad) = (n_node_vars - n, n_node_vars - m);
+	let looker_content = &node_point[looker_pad..];
+	let table_point = &node_point[table_pad..];
 
-	// The denominator is transparent, so the verifier evaluates it rather than trusting the leaf.
-	let expected_den = denominator_eval::<F, C::Elem>(&c, &table_leaf_point);
+	// Both padding weights are prefixes of the node point, and every looker shares the same one, so
+	// compute each once rather than per tree.
+	let looker_pad_eq = eq_ind_zero::<C::Elem>(&node_point[..looker_pad]);
+	let table_pad_eq = eq_ind_zero::<C::Elem>(&node_point[..table_pad]);
+
+	// Looker numerators are transparent: gamma^j scales the equality indicator at r_j. The
+	// denominators are c - I_j, from the index evaluations just read.
+	let (mut leaf_nums, mut leaf_dens): (Vec<_>, Vec<_>) =
+		iter::zip(iter::zip(lookers, powers(gamma.clone())), &index_eval_claims)
+			.map(|((looker, power), index_eval)| {
+				let num = power * eq_ind::<C::Elem>(looker.eval_point, looker_content);
+				let den = c.clone() - index_eval.clone();
+				fracaddcheck::pad_leaf_fraction((num, den), looker_pad_eq.clone())
+			})
+			.unzip();
+
+	// The table's numerator is Y, just read. Its denominator is the transparent J - c, the logUp
+	// denominator negated — the table's fraction enters the sum that way, which is what makes the
+	// root numerator vanish.
+	let (table_num, table_den) = fracaddcheck::pad_leaf_fraction(
+		(pushforward_eval.clone(), denominator_eval::<F, C::Elem>(&c, table_point)),
+		table_pad_eq,
+	);
+	leaf_nums.push(table_num);
+	leaf_dens.push(table_den);
+
+	leaf_nums.resize(1 << k, C::Elem::zero());
+	leaf_dens.resize(1 << k, C::Elem::one());
 	channel
-		.assert_zero(table_den_eval - expected_den)
-		.map_err(|_| VerificationError::IncorrectTableDenominator)?;
+		.assert_zero(leaf_num - evaluate_inplace_scalars(leaf_nums, selector_coords))
+		.map_err(|_| VerificationError::IncorrectXEvaluation)?;
+	channel
+		.assert_zero(leaf_den - evaluate_inplace_scalars(leaf_dens, selector_coords))
+		.map_err(|_| VerificationError::IncorrectIndexEvaluation)?;
 
 	// Reduce the leaf claim on Y and the product claim <T, Y> = e to a single shared evaluation.
 	// The product check binds <T, Y> to the gamma-combination of the looker claims.
@@ -215,13 +219,13 @@ where
 		table_eval_point,
 		table_eval_claim,
 		pushforward_eval_claim,
-	} = verify_pushforward::<F, C>(combined_eval_claim, pushforward_eval, &table_leaf_point, channel)?;
+	} = verify_pushforward::<F, C>(combined_eval_claim, pushforward_eval, table_point, channel)?;
 
 	Ok(LogupOutput {
 		table_eval_point,
 		table_eval_claim,
 		pushforward_eval_claim,
-		index_eval_point: content_point.to_vec(),
+		index_eval_point: looker_content.to_vec(),
 		index_eval_claims,
 	})
 }


### PR DESCRIPTION
Closes [BINIUS-407](https://linear.app/jimpo/issue/BINIUS-407/logup-star-combine-fracaddcheck-for-looker-side-and-table-side), using the unequal-depth batching from BINIUS-403 (#2042, #2043).

#2053 has merged, so this is rebased directly onto `main` and stands alone.

## The problem

logUp* ran *three* fractional-addition GKRs: one batch over the looker circuits (`n` layers), one over the table's (`m` layers), and — because a batch could only hold trees of the same depth — a third "top" circuit of `log_lookers` layers whose only job was to fractionally add the per-looker roots into a single claim. The two surviving roots then went on the transcript so the verifier could cross-multiply them and check the lookup identity itself.

## What changes

Unequal-depth batching removes the equal-depth constraint, so all of it collapses into **one** circuit of `k + max(n, m)` layers, `k = ceil(log2(n_instances))`:

- the lower `max(n, m)` layers run every instance — one per looker over `n` variables, the table's over `m` — as a single batch, with the shallower side padded by zero fractions. Padding costs `O(1)` per round, so the layer count reveals only the deeper side.
- the top `k` layers add those instances' root fractions together.

The table's fraction enters that sum **negated**, so the circuit's root is

```
sum_j num_j / den_j  -  num_r / den_r
```

whose numerator vanishes exactly when the lookup identity holds. So the numerator is never sent: the transcript carries **one scalar**, the root denominator, and the verifier supplies the zero itself. The identity is enforced by the shape of the claim rather than by a separate cross-multiplication — a prover whose lookups disagree cannot make the GKR meet a zero numerator — and `VerificationError::LookupSumMismatch` goes with the check it named. In characteristic 2 the negation is the identity, so the table's halves are used as they stand rather than spending a pass over `2^m` elements.

The `k` selector coordinates now fall out of the GKR's own rounds, so the verifier no longer samples them or interpolates the roots into a batch input claim. The prover runs two provers in sequence: the `k`-layer top circuit, whose output point seeds the batched unequal-depths driver for the rest.

The leaf claims come back on the *padded* witnesses. The prover divides each back onto its own circuit's leaves with `unpad_leaf_claim`; the verifier runs the same map forward through a new `fracaddcheck::pad_leaf_fraction` on the halves it can derive — the lookers' `gamma^j`-scaled equality indicators and the table's transparent `c - J` — then interpolates and checks them against the batch's leaf. That leaves the per-looker index evaluations and `Y` as the only leaf halves on the transcript.

A single-row looker no longer needs its own code path: its circuit has depth 0, which the batch carries as pure padding.

## Commits

1. **Run every layer in the unequal-depths fracadd driver.** `batch_prove_unequal_depths` stopped one layer short so a caller could batch the widest layer with other sumchecks. Nothing did — it was added with the driver and has had no caller outside its own tests. It now returns the plain `BatchProveOutput`, and `BatchProveUnequalDepthsOutput` goes. The precondition relaxes to admit depth-0 trees, which commit 2 needs.
2. **The combination itself**, as described above.

## Testing

- Round trips over the spread `(n, m) = (6,2) (5,3) (4,4) (3,5) (7,1)`, covering padding in both directions and the equal-depth case.
- `test_prove_verify_single_looker_row` now exercises the depth-0 circuit through the batch rather than a special case.
- New `test_unequal_depths_zero_depth_tree` (`&[0, 3]`) pins the driver's depth-0 handling directly.
- Full `binius-ip` / `binius-ip-prover` / `binius-iop` / `binius-iop-prover` suites pass; workspace clippy `-D warnings`, `fmt --check`, and rustdoc `-D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)