### PR TITLE
Count Merkle salts in the proof size, and clean up the scheme

### DIFF
--- a/crates/iop-prover/src/fri/tests.rs
+++ b/crates/iop-prover/src/fri/tests.rs
@@ -1,7 +1,7 @@
 // Copyright 2024-2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-use std::{iter, vec};
+use std::{iter, num::NonZeroUsize, vec};
 
 use binius_field::{
 	BinaryField, BinaryField128bGhash as B128, Field, PackedBinaryGhash1x128b, PackedField,
@@ -654,11 +654,14 @@ fn test_commit_prove_verify_lifted_multi_oracle() {
 
 /// Runs the FRI prover and returns the proof bytes along with the FRI params and Merkle scheme,
 /// so the caller can check the estimated proof size.
+///
+/// A non-zero `salt_len` runs the whole protocol with a hiding Merkle scheme.
 fn generate_fri_proof<F, P>(
 	log_dimension: usize,
 	log_inv_rate: usize,
 	log_batch_size: usize,
 	arities: &[usize],
+	salt_len: usize,
 ) -> (Vec<u8>, FRIParams<F>, binius_iop::merkle_tree::BinaryMerkleTreeScheme<F, StdHashSuite>)
 where
 	F: BinaryField,
@@ -680,11 +683,20 @@ where
 
 	let codeword = encode_interleaved(&params, 0, &ntt, msg.to_ref());
 
+	let salt_len = NonZeroUsize::new(salt_len);
 	let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
-	let mut prover_channel =
-		ProverMerkleTranscriptChannel::<_, StdChallenger, _, StdHashSuite>::new(
+	let mut prover_channel = match salt_len {
+		Some(salt_len) => {
+			ProverMerkleTranscriptChannel::<_, StdChallenger, _, StdHashSuite>::hiding(
+				&mut prover_transcript,
+				&mut rng,
+				salt_len,
+			)
+		}
+		None => ProverMerkleTranscriptChannel::<_, StdChallenger, _, StdHashSuite>::new(
 			&mut prover_transcript,
-		);
+		),
+	};
 	let codeword_commitment =
 		prover_channel.send_merkle_commitment(codeword.to_ref(), 1 << log_batch_size);
 
@@ -701,7 +713,10 @@ where
 	round_prover.finish_proof(&mut prover_channel);
 	drop(prover_channel);
 
-	let scheme = binius_iop::merkle_tree::BinaryMerkleTreeScheme::new();
+	let scheme = match salt_len {
+		Some(salt_len) => binius_iop::merkle_tree::BinaryMerkleTreeScheme::hiding(salt_len),
+		None => binius_iop::merkle_tree::BinaryMerkleTreeScheme::new(),
+	};
 	let proof_bytes = prover_transcript.finalize();
 	(proof_bytes, params, scheme)
 }
@@ -709,18 +724,28 @@ where
 #[test]
 fn test_proof_size_higher_arity() {
 	let (proof_bytes, params, scheme) =
-		generate_fri_proof::<B128, PackedBinaryGhash1x128b>(8, 2, 0, &[3, 2, 1]);
+		generate_fri_proof::<B128, PackedBinaryGhash1x128b>(8, 2, 0, &[3, 2, 1], 0);
 	assert_eq!(proof_bytes.len(), fri::proof_size(&params, &scheme));
 }
 
 #[test]
 fn test_proof_size_interleaved() {
-	let (proof_bytes, params, scheme) = generate_fri_proof::<B128, Packed128b>(6, 2, 2, &[3, 2, 1]);
+	let (proof_bytes, params, scheme) =
+		generate_fri_proof::<B128, Packed128b>(6, 2, 2, &[3, 2, 1], 0);
 	assert_eq!(proof_bytes.len(), fri::proof_size(&params, &scheme));
 }
 
 #[test]
 fn test_proof_size_no_folding() {
-	let (proof_bytes, params, scheme) = generate_fri_proof::<B128, Packed128b>(4, 2, 2, &[]);
+	let (proof_bytes, params, scheme) = generate_fri_proof::<B128, Packed128b>(4, 2, 2, &[], 0);
+	assert_eq!(proof_bytes.len(), fri::proof_size(&params, &scheme));
+}
+
+#[test]
+fn test_proof_size_hiding() {
+	// A hiding scheme adds one salt per opened leaf, plus one per leaf of the terminal codeword,
+	// so the estimate is only exact if `proof_size` counts both.
+	let (proof_bytes, params, scheme) =
+		generate_fri_proof::<B128, Packed128b>(6, 2, 2, &[3, 2, 1], 3);
 	assert_eq!(proof_bytes.len(), fri::proof_size(&params, &scheme));
 }

--- a/crates/iop-prover/src/merkle_channel.rs
+++ b/crates/iop-prover/src/merkle_channel.rs
@@ -11,7 +11,7 @@
 //! opening proofs are written as unobserved decommitment advice bound to the already-observed
 //! roots.
 
-use std::{borrow::BorrowMut, marker::PhantomData};
+use std::{borrow::BorrowMut, marker::PhantomData, num::NonZeroUsize};
 
 use binius_field::{Field, PackedField};
 use binius_hash::binary_merkle_tree::{BinaryMerkleTree, HashSuite};
@@ -100,7 +100,7 @@ impl<T, Challenger_, F, H: HashSuite> ProverMerkleTranscriptChannel<T, Challenge
 
 	/// Constructs a channel over the transcript with a hiding Merkle tree prover, salting each
 	/// leaf with `salt_len` random field elements drawn from `rng`.
-	pub fn hiding(transcript: T, rng: impl CryptoRng, salt_len: usize) -> Self {
+	pub fn hiding(transcript: T, rng: impl CryptoRng, salt_len: NonZeroUsize) -> Self {
 		Self::with_merkle_prover(transcript, BinaryMerkleTreeProver::hiding(rng, salt_len))
 	}
 
@@ -240,6 +240,8 @@ where
 
 #[cfg(test)]
 mod tests {
+	use std::num::NonZeroUsize;
+
 	use binius_field::{BinaryField128bGhash as B128, PackedBinaryGhash2x128b};
 	use binius_hash::{StdDigest, StdHashSuite};
 	use binius_iop::{
@@ -310,7 +312,7 @@ mod tests {
 	#[test]
 	fn test_merkle_channel_roundtrip_hiding() {
 		let mut rng = StdRng::seed_from_u64(0);
-		let salt_len = 2;
+		let salt_len = NonZeroUsize::new(2).unwrap();
 
 		let scalars = random_scalars::<B128>(&mut rng, 1 << LOG_LEN);
 		let data = FieldBuffer::<P, _>::from_values(&scalars);

--- a/crates/iop-prover/src/merkle_tree/prover.rs
+++ b/crates/iop-prover/src/merkle_tree/prover.rs
@@ -1,7 +1,7 @@
 // Copyright 2024-2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-use std::sync::Mutex;
+use std::{num::NonZeroUsize, sync::Mutex};
 
 use binius_field::Field;
 use binius_hash::binary_merkle_tree::{self, BinaryMerkleTree, HashSuite};
@@ -22,6 +22,7 @@ pub struct BinaryMerkleTreeProver<T, H: HashSuite> {
 }
 
 impl<T, H: HashSuite> BinaryMerkleTreeProver<T, H> {
+	/// Constructs a non-hiding prover.
 	pub fn new() -> Self {
 		Self {
 			scheme: BinaryMerkleTreeScheme::new(),
@@ -30,7 +31,8 @@ impl<T, H: HashSuite> BinaryMerkleTreeProver<T, H> {
 		}
 	}
 
-	pub fn hiding(mut rng: impl CryptoRng, salt_len: usize) -> Self {
+	/// Constructs a hiding prover, salting each leaf with `salt_len` values drawn from `rng`.
+	pub fn hiding(mut rng: impl CryptoRng, salt_len: NonZeroUsize) -> Self {
 		Self {
 			scheme: BinaryMerkleTreeScheme::hiding(salt_len),
 			salt_rng: Mutex::new(StdRng::from_rng(&mut rng)),

--- a/crates/iop-prover/src/merkle_tree/tests.rs
+++ b/crates/iop-prover/src/merkle_tree/tests.rs
@@ -2,6 +2,7 @@
 // Copyright 2026 The Binius Developers
 
 use core::slice;
+use std::num::NonZeroUsize;
 
 use binius_field::{
 	BinaryField128bGhash as B128, PackedBinaryGhash2x128b, PackedBinaryGhash4x128b,
@@ -106,7 +107,7 @@ fn test_binary_merkle_vcs_verify_vector() {
 fn test_binary_merkle_vcs_hiding_commit_prove_open() {
 	let mut rng = StdRng::seed_from_u64(0);
 
-	let salt_len = 2;
+	let salt_len = NonZeroUsize::new(2).unwrap();
 	let mt_prover = BinaryMerkleTreeProver::<_, StdHashSuite>::hiding(&mut rng, salt_len);
 
 	let data = random_scalars::<B128>(&mut rng, 16);
@@ -138,7 +139,7 @@ fn test_binary_merkle_vcs_hiding_commit_prove_open() {
 fn test_binary_merkle_vcs_hiding_verify_vector() {
 	let mut rng = StdRng::seed_from_u64(0);
 
-	let salt_len = 3;
+	let salt_len = NonZeroUsize::new(3).unwrap();
 	let mt_prover = BinaryMerkleTreeProver::<_, StdHashSuite>::hiding(&mut rng, salt_len);
 
 	let data = random_scalars::<B128>(&mut rng, 8);
@@ -163,7 +164,7 @@ fn test_binary_merkle_vcs_hiding_verify_vector() {
 fn test_binary_merkle_vcs_hiding_prove_open_against_layer() {
 	let mut rng = StdRng::seed_from_u64(0);
 
-	let salt_len = 2;
+	let salt_len = NonZeroUsize::new(2).unwrap();
 	let mt_prover = BinaryMerkleTreeProver::<_, StdHashSuite>::hiding(&mut rng, salt_len);
 
 	let data = random_scalars::<B128>(&mut rng, 32);
@@ -197,7 +198,7 @@ fn test_binary_merkle_vcs_hiding_prove_open_against_layer() {
 fn test_binary_merkle_vcs_hiding_batch_size() {
 	let mut rng = StdRng::seed_from_u64(0);
 
-	let salt_len = 1;
+	let salt_len = NonZeroUsize::new(1).unwrap();
 	let mt_prover = BinaryMerkleTreeProver::<_, StdHashSuite>::hiding(&mut rng, salt_len);
 
 	let data = random_scalars::<B128>(&mut rng, 32);

--- a/crates/iop/Cargo.toml
+++ b/crates/iop/Cargo.toml
@@ -21,5 +21,6 @@ thiserror.workspace = true
 
 [dev-dependencies]
 binius-math = { path = "../math", features = ["test-utils"] }
+proptest.workspace = true
 rand.workspace = true
 sha2.workspace = true

--- a/crates/iop/src/fri/size_estimation.rs
+++ b/crates/iop/src/fri/size_estimation.rs
@@ -12,9 +12,7 @@ use crate::merkle_tree::MerkleTreeScheme;
 /// - **Message channel**: the initial codeword commitment and all round commitments (digests
 ///   observed by Fiat-Shamir).
 /// - **Decommitment channel**: the terminal codeword, Merkle layer digests, per-query branch
-///   digests, and per-query coset field values.
-///
-/// The estimate assumes non-hiding proofs (salt_len = 0).
+///   digests, per-query coset field values, and any Merkle salt a hiding scheme adds.
 pub fn proof_size<F, VCS>(params: &FRIParams<F>, vcs: &VCS) -> usize
 where
 	F: BinaryField,
@@ -23,13 +21,7 @@ where
 	let digest_size = std::mem::size_of::<VCS::Digest>();
 
 	// Serialized byte-size of a single field element.
-	let value_size = {
-		let mut buf = Vec::new();
-		F::default()
-			.serialize(&mut buf)
-			.expect("default element can be serialized to a resizable buffer");
-		buf.len()
-	};
+	let value_size = F::BYTE_SIZE;
 
 	let n_test_queries = params.n_test_queries();
 
@@ -68,6 +60,10 @@ where
 		log_n_cosets -= arity;
 		open(log_n_cosets, arity);
 	}
+
+	// The terminal codeword is never queried, but it is decommitted in full, which under a hiding
+	// scheme reveals the salt of each of its `2^log_inv_rate` leaves.
+	merkle_sizes += vcs.vector_proof_size(1 << log_inv_rate);
 
 	commitment_msg_size + terminate_codeword_size + merkle_sizes + coset_values_size
 }

--- a/crates/iop/src/merkle_tree/error.rs
+++ b/crates/iop/src/merkle_tree/error.rs
@@ -6,7 +6,7 @@ use binius_utils::SerializationError;
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
 	#[error("Failed to serialize leaf element: {0}")]
-	Serialization(SerializationError),
+	Serialization(#[from] SerializationError),
 	#[error("transcript error: {0}")]
 	Transcript(#[from] binius_transcript::Error),
 	#[error("verification failure: {0}")]

--- a/crates/iop/src/merkle_tree/merkle_tree_vcs.rs
+++ b/crates/iop/src/merkle_tree/merkle_tree_vcs.rs
@@ -19,13 +19,29 @@ pub struct Commitment<Digest> {
 }
 
 /// A Merkle tree scheme.
+///
+/// The committed values have a fixed serialized width, so a leaf's byte encoding is unambiguous
+/// and two distinct leaves can never present the same bytes to the hash.
 pub trait MerkleTreeScheme<T: FixedSizeSerializeBytes> {
+	/// The digest of a leaf or an inner node.
 	type Digest: Clone + PartialEq + Eq;
 
 	/// Returns the optimal layer that the verifier should verify only once.
+	///
+	/// Decommitting a layer at depth `d` costs `2^d` digests but shortens every one of the
+	/// `n_queries` branches by `d`, so the proof holds
+	///
+	/// ```text
+	/// (tree_depth - d) * n_queries + 2^d
+	/// ```
+	///
+	/// digests. That is minimized at `d = ceil(log2(n_queries))`, clamped to the tree depth.
 	fn optimal_verify_layer(&self, n_queries: usize, tree_depth: usize) -> usize;
 
 	/// Returns the total byte-size of a proof for multiple opening queries.
+	///
+	/// This counts the decommitment advice only: the layer digests, the per-query branches, and
+	/// any per-query salt. The opened leaf values are sent by the caller, so they are not counted.
 	///
 	/// ## Arguments
 	///
@@ -40,11 +56,24 @@ pub trait MerkleTreeScheme<T: FixedSizeSerializeBytes> {
 	/// * `layer_depth` must be at most `log2(len)`.
 	fn proof_size(&self, len: usize, n_queries: usize, layer_depth: usize) -> usize;
 
+	/// Returns the total byte-size of a proof for opening the full vector.
+	///
+	/// This counts the decommitment advice that [`Self::verify_vector`] reads, which is any
+	/// per-leaf salt. The committed values themselves are sent by the caller, so they are not
+	/// counted.
+	///
+	/// ## Arguments
+	///
+	/// * `len` - the length of the committed vector
+	fn vector_proof_size(&self, len: usize) -> usize;
+
 	/// Verify the opening of the full vector.
 	///
 	/// ## Preconditions
 	///
+	/// * `batch_size` must be non-zero.
 	/// * `data.len()` must be a multiple of `batch_size`.
+	/// * `data.len() / batch_size` must be a non-zero power of two.
 	fn verify_vector<B: Buf>(
 		&self,
 		root: &Self::Digest,
@@ -74,6 +103,7 @@ pub trait MerkleTreeScheme<T: FixedSizeSerializeBytes> {
 	/// ## Preconditions
 	///
 	/// * `layer_digests.len()` must equal `2^layer_depth`.
+	/// * `layer_depth` must be at most `tree_depth`.
 	/// * `index` must be less than `2^tree_depth`.
 	fn verify_opening<B: Buf>(
 		&self,

--- a/crates/iop/src/merkle_tree/scheme.rs
+++ b/crates/iop/src/merkle_tree/scheme.rs
@@ -1,50 +1,202 @@
 // Copyright 2024-2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-use std::{array, fmt::Debug, marker::PhantomData};
+//! Verifier side of the binary Merkle tree vector commitment.
 
-use binius_hash::{CompressionFunction, binary_merkle_tree::HashSuite, hash_serialize};
+use std::{
+	fmt::{self, Debug, Formatter},
+	marker::PhantomData,
+	num::NonZeroUsize,
+};
+
+use binius_hash::{CompressionFunction, HashBuffer, binary_merkle_tree::HashSuite};
 use binius_transcript::{Buf, TranscriptReader};
 use binius_utils::{
 	FixedSizeSerializeBytes,
 	checked_arithmetics::{checked_log_2, log2_ceil_usize},
 };
 use digest::{Digest, Output};
-use getset::CopyGetters;
 
 use super::{
 	error::{Error, VerificationError},
 	merkle_tree_vcs::MerkleTreeScheme,
 };
 
-#[derive(Clone, CopyGetters)]
+/// A binary Merkle tree vector commitment, as seen by the verifier.
+///
+/// # Overview
+///
+/// A committed vector is cut into equal-size batches of values.
+/// Each batch is hashed into one leaf digest.
+/// Pairs of digests are then folded upward until a single root digest remains.
+///
+/// ```text
+///                     root
+///                   /      \
+///            C(d_0,d_1)   C(d_2,d_3)
+///             /     \       /     \
+///           d_0    d_1    d_2    d_3     <- leaf digests
+///            |      |      |      |
+///         batch_0  ...          batch_3  <- committed values, plus salt when hiding
+/// ```
+///
+/// # Why the values need a fixed serialized width
+///
+/// Every committed value serializes to the same number of bytes.
+/// A leaf's byte string is therefore an injective encoding of the values and salt it holds.
+/// Two different leaves can never present identical bytes to the hash.
 pub struct BinaryMerkleTreeScheme<T, H: HashSuite> {
-	#[getset(get = "pub")]
+	/// Two-to-one function folding a pair of child digests into their parent digest.
 	compression: H::Compression,
-	#[getset(get_copy = "pub")]
+	/// Number of uniform values appended to each leaf before hashing.
+	///
+	/// Zero when the commitment is not hiding.
 	salt_len: usize,
-	// This makes it so that `BinaryMerkleTreeScheme` remains Send + Sync regardless of `T`.
-	// See https://doc.rust-lang.org/nomicon/phantom-data.html#table-of-phantomdata-patterns
+	/// Records the committed value type without ever holding one.
+	///
+	/// The function-pointer form keeps the scheme thread-safe whatever that type is.
+	/// See <https://doc.rust-lang.org/nomicon/phantom-data.html#table-of-phantomdata-patterns>.
 	_phantom: PhantomData<fn() -> T>,
 }
 
-impl<T, H: HashSuite> Default for BinaryMerkleTreeScheme<T, H> {
-	fn default() -> Self {
-		Self::new()
-	}
-}
-
 impl<T, H: HashSuite> BinaryMerkleTreeScheme<T, H> {
+	/// Builds a non-hiding scheme, hashing each leaf with no added randomness.
 	pub fn new() -> Self {
-		Self::hiding(0)
+		// A salt length of zero is exactly the non-hiding case.
+		Self::with_salt_len(0)
 	}
 
-	pub fn hiding(salt_len: usize) -> Self {
+	/// Builds a hiding scheme, appending uniform random values to every leaf before hashing.
+	///
+	/// # Overview
+	///
+	/// The salt is what hides a leaf.
+	/// Guessing a leaf's values is not enough to confirm the guess without the salt too.
+	///
+	/// # Arguments
+	///
+	/// * `salt_len` - how many uniform values to append to each leaf.
+	///
+	/// # Why the length is caller-chosen
+	///
+	/// The salt must carry at least as many bits of entropy as the target security level.
+	/// One value contributes its full width in bits, so the field size fixes the count.
+	pub fn hiding(salt_len: NonZeroUsize) -> Self {
+		Self::with_salt_len(salt_len.get())
+	}
+
+	/// Number of uniform values appended to each leaf before hashing.
+	///
+	/// # Returns
+	///
+	/// Zero when the scheme is not hiding, otherwise the configured salt length.
+	pub const fn salt_len(&self) -> usize {
+		self.salt_len
+	}
+
+	/// Shared constructor covering both the hiding and the non-hiding case.
+	fn with_salt_len(salt_len: usize) -> Self {
 		Self {
+			// The compression function is stateless, so one default instance serves every call.
 			compression: H::Compression::default(),
 			salt_len,
 			_phantom: PhantomData,
 		}
+	}
+
+	/// Folds a layer of digests down to the single root above it.
+	///
+	/// # Overview
+	///
+	/// Each round pairs neighbours and replaces them with their parent, halving the layer:
+	///
+	/// ```text
+	///     [d_0, d_1, ..., d_{n-1}]  ->  [C(d_0, d_1), ..., C(d_{n-2}, d_{n-1})]
+	/// ```
+	///
+	/// After `log_2(n)` rounds exactly one digest is left, and that digest is the root.
+	///
+	/// # Returns
+	///
+	/// The root digest of the subtree spanned by the given layer.
+	///
+	/// # Panics
+	///
+	/// Panics unless the number of digests is a non-zero power of two.
+	///
+	/// # Performance
+	///
+	/// One allocation of `n / 2` digests in total, reused by every round after the first.
+	fn fold_to_root(&self, digests: &[Output<H::LeafHash>]) -> Output<H::LeafHash> {
+		// A layer that is not a power of two cannot be paired off cleanly.
+		// An empty layer spans no subtree at all.
+		assert!(
+			digests.len().is_power_of_two(),
+			"precondition: the number of digests must be a non-zero power of two"
+		);
+
+		// A lone digest already is the root of its subtree; folding it would invent a level.
+		if let [root] = digests {
+			return root.clone();
+		}
+
+		// The first round reads the caller's slice and writes into fresh space.
+		// That caps the scratch buffer at half the input length.
+		let mut layer = digests
+			.chunks_exact(2)
+			.map(|pair| {
+				self.compression
+					.compress([pair[0].clone(), pair[1].clone()])
+			})
+			.collect::<Vec<_>>();
+
+		// Later rounds halve the buffer in place.
+		// A parent lands strictly below both children it replaces, so nothing is overwritten early.
+		while layer.len() > 1 {
+			let half = layer.len() / 2;
+			for i in 0..half {
+				layer[i] = self
+					.compression
+					.compress([layer[2 * i].clone(), layer[2 * i + 1].clone()]);
+			}
+			// Drop the tail the round just consumed, keeping the allocation.
+			layer.truncate(half);
+		}
+
+		layer
+			.pop()
+			.expect("a non-empty layer folds down to exactly one digest")
+	}
+}
+
+impl<T, H: HashSuite> Default for BinaryMerkleTreeScheme<T, H> {
+	fn default() -> Self {
+		// The non-hiding scheme is the one with no parameter left to choose.
+		Self::new()
+	}
+}
+
+impl<T, H: HashSuite> Clone for BinaryMerkleTreeScheme<T, H> {
+	fn clone(&self) -> Self {
+		// Written out rather than derived: a derived copy would demand a cloneable value type.
+		// No value of that type is ever held.
+		// The compression function is always cloneable through its own trait bound.
+		Self {
+			compression: self.compression.clone(),
+			salt_len: self.salt_len,
+			_phantom: PhantomData,
+		}
+	}
+}
+
+impl<T, H: HashSuite> Debug for BinaryMerkleTreeScheme<T, H> {
+	fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+		// Written out for the same reason as the copy above.
+		// The compression function carries no formatting bound.
+		// That leaves the salt length as the only state worth printing.
+		f.debug_struct("BinaryMerkleTreeScheme")
+			.field("salt_len", &self.salt_len)
+			.finish_non_exhaustive()
 	}
 }
 
@@ -53,13 +205,36 @@ where
 	T: FixedSizeSerializeBytes,
 	H: HashSuite,
 {
+	/// Hashes one leaf from the values it holds and the salt the proof supplies.
+	///
+	/// # Arguments
+	///
+	/// * `values` - the committed values of this leaf, in commitment order.
+	/// * `proof` - decommitment advice, positioned at this leaf's salt.
+	///
+	/// # Returns
+	///
+	/// The leaf digest, or a failure if the salt could not be read.
 	fn compute_leaf_digest<B: Buf>(
 		&self,
 		values: &[T],
 		proof: &mut TranscriptReader<B>,
 	) -> Result<Output<H::LeafHash>, Error> {
-		let salt = proof.read_vec::<T>(self.salt_len)?;
-		hash_serialize::<T, H::LeafHash>(values.iter().chain(&salt)).map_err(Error::Serialization)
+		let mut hasher = H::LeafHash::new();
+		{
+			// The buffer groups writes into hash blocks and flushes on scope exit.
+			// The salt therefore streams from the proof into the hash with no staging buffer.
+			let mut buffer = HashBuffer::new(&mut hasher);
+
+			// Values first, salt second: the same order the prover used when committing.
+			for value in values {
+				value.serialize(&mut buffer)?;
+			}
+			for _ in 0..self.salt_len {
+				proof.read::<T>()?.serialize(&mut buffer)?;
+			}
+		}
+		Ok(hasher.finalize())
 	}
 }
 
@@ -70,23 +245,39 @@ where
 {
 	type Digest = Output<H::LeafHash>;
 
-	/// This layer allows minimizing the proof size.
 	fn optimal_verify_layer(&self, n_queries: usize, tree_depth: usize) -> usize {
+		// Raising the layer by one level doubles its width but shortens every branch by one.
+		// The two effects balance where the layer width first reaches the query count.
+		//
+		// A layer can never sit below the leaves, hence the clamp.
 		log2_ceil_usize(n_queries).min(tree_depth)
 	}
 
-	/// ## Preconditions
-	/// * `len` must be a power of two.
-	/// * `layer_depth` must be at most `log2(len)`.
 	fn proof_size(&self, len: usize, n_queries: usize, layer_depth: usize) -> usize {
 		assert!(len.is_power_of_two(), "precondition: len must be a power of two");
 
+		// Depth of the tree spanning the committed vector.
 		let log_len = checked_log_2(len);
 
 		assert!(layer_depth <= log_len, "precondition: layer_depth must be at most log2(len)");
 
-		((log_len - layer_depth) * n_queries + (1 << layer_depth))
-			* <H::LeafHash as Digest>::output_size()
+		// Each query walks from its leaf up to the decommitted layer, one sibling per level.
+		// The layer itself is sent once, for all queries together.
+		//
+		//     branches: (log_len - layer_depth) * n_queries
+		//     layer   : 2^layer_depth
+		let n_digests = (log_len - layer_depth) * n_queries + (1 << layer_depth);
+
+		// A hiding scheme additionally reveals the salt of every opened leaf.
+		let salt_bytes = n_queries * self.salt_len * T::BYTE_SIZE;
+
+		n_digests * <H::LeafHash as Digest>::output_size() + salt_bytes
+	}
+
+	fn vector_proof_size(&self, len: usize) -> usize {
+		// Every leaf is revealed, so no branch is needed.
+		// The only advice left is one salt per leaf.
+		len * self.salt_len * T::BYTE_SIZE
 	}
 
 	fn verify_vector<B: Buf>(
@@ -96,17 +287,28 @@ where
 		batch_size: usize,
 		proof: &mut TranscriptReader<B>,
 	) -> Result<(), Error> {
+		// A zero-size batch would slice the data into unboundedly many empty leaves.
+		assert_ne!(batch_size, 0, "precondition: batch_size must be non-zero");
+		// Every leaf holds the same number of values, so the split has to come out even.
 		assert!(
 			data.len().is_multiple_of(batch_size),
 			"precondition: data length must be a multiple of batch_size"
 		);
+		// A binary tree only spans a power-of-two number of leaves.
+		assert!(
+			(data.len() / batch_size).is_power_of_two(),
+			"precondition: data.len() / batch_size must be a non-zero power of two"
+		);
 
+		// Rebuild every leaf digest from the revealed values.
+		// Each leaf's salt is read from the advice as the rebuild reaches it.
 		let digests = data
 			.chunks(batch_size)
 			.map(|chunk| self.compute_leaf_digest(chunk, proof))
 			.collect::<Result<Vec<_>, _>>()?;
 
-		if fold_digests_vector_inplace(&self.compression, digests) != *root {
+		// Rebuilding the whole tree and landing on the committed root is what binds the data.
+		if self.fold_to_root(&digests) != *root {
 			return Err(VerificationError::InvalidProof.into());
 		}
 		Ok(())
@@ -118,14 +320,16 @@ where
 		layer_depth: usize,
 		layer_digests: &[Self::Digest],
 	) -> Result<(), Error> {
+		// A layer that many levels below the root holds exactly that many digests.
 		assert_eq!(
 			layer_digests.len(),
 			1 << layer_depth,
 			"precondition: layer_digests must have 2^layer_depth entries"
 		);
 
-		let computed_root = fold_digests_vector_inplace(&self.compression, layer_digests.to_vec());
-		if computed_root != *root {
+		// Folding the claimed layer must reproduce the committed root.
+		// The fold takes one round per level, so a layer only passes at the depth it claims.
+		if self.fold_to_root(layer_digests) != *root {
 			return Err(VerificationError::InvalidProof.into());
 		}
 		Ok(())
@@ -140,45 +344,637 @@ where
 		layer_digests: &[Self::Digest],
 		proof: &mut TranscriptReader<B>,
 	) -> Result<(), Error> {
+		// A layer that many levels below the root holds exactly that many digests.
 		assert_eq!(
 			layer_digests.len(),
 			1 << layer_depth,
 			"precondition: layer_digests must have 2^layer_depth entries"
 		);
+		// The climb runs from the leaves up to the layer, so the layer cannot sit below them.
+		assert!(layer_depth <= tree_depth, "precondition: layer_depth must be at most tree_depth");
+		// A tree of that depth has exactly that many leaves to address.
 		assert!(index < (1 << tree_depth), "precondition: index must be less than 2^tree_depth");
 
-		let mut leaf_digest = self.compute_leaf_digest(values, proof)?;
-		for branch_node in proof.read_vec(tree_depth - layer_depth)? {
-			leaf_digest = self.compression.compress(if index & 1 == 0 {
-				[leaf_digest, branch_node]
+		// Bottom of the authentication path: the leaf the opening claims.
+		let mut digest = self.compute_leaf_digest(values, proof)?;
+
+		// Climb one level per round, folding in the sibling the advice supplies.
+		//
+		//     level k:  running digest + sibling_k  ->  running digest at level k+1
+		//
+		// The low bit of the running index says which side the running digest sits on.
+		for _ in layer_depth..tree_depth {
+			let sibling = proof.read::<Self::Digest>()?;
+			// An even index means the running digest is the left child of its parent.
+			digest = self.compression.compress(if index & 1 == 0 {
+				[digest, sibling]
 			} else {
-				[branch_node, leaf_digest]
+				[sibling, digest]
 			});
+			// Discard the bit just consumed, exposing the next level's side bit.
 			index >>= 1;
 		}
 
-		(leaf_digest == layer_digests[index])
-			.then_some(())
-			.ok_or_else(|| VerificationError::InvalidProof.into())
+		// The climb dropped one bit per level, so what is left addresses the decommitted layer.
+		// Matching the entry there binds the leaf to the already-verified layer, hence the root.
+		if digest != layer_digests[index] {
+			return Err(VerificationError::InvalidProof.into());
+		}
+		Ok(())
 	}
 }
 
-/// Compute the Merkle root over a vector of leaf digests.
-///
-/// Consumes digests because it modifies the vector in place.
-///
-/// # Preconditions
-/// - `digests.len()` is a power of two
-fn fold_digests_vector_inplace<C, D>(compression: &C, mut digests: Vec<D>) -> D
-where
-	C: CompressionFunction<D, 2>,
-	D: Clone + Default + Send + Sync + Debug,
-{
-	let log_len = checked_log_2(digests.len()); // pre-condition
-	for layer in (0..log_len).rev() {
-		for i in 0..1 << layer {
-			digests[i] = compression.compress(array::from_fn(|j| digests[2 * i + j].clone()));
+#[cfg(test)]
+mod tests {
+	use binius_field::{BinaryField128bGhash as B128, Field};
+	use binius_hash::{StdDigest, StdHashSuite, hash_serialize};
+	use binius_math::test_utils::random_scalars;
+	use binius_transcript::{ProverTranscript, VerifierTranscript, fiat_shamir::HasherChallenger};
+	use proptest::prelude::*;
+	use rand::{Rng, SeedableRng, rngs::StdRng};
+
+	use super::*;
+
+	type Suite = StdHashSuite;
+	type LeafHash = <Suite as HashSuite>::LeafHash;
+	type Node = Output<LeafHash>;
+	type Scheme = BinaryMerkleTreeScheme<B128, Suite>;
+	type Challenger = HasherChallenger<StdDigest>;
+
+	/// A Merkle tree built independently of the scheme under test.
+	///
+	/// # Why an independent build
+	///
+	/// Checking the verifier against trees it built itself would pass even with a wrong fold.
+	/// This one goes straight from the hash and compression primitives to the layers.
+	struct RefTree {
+		/// Digest layers, leaves first and the single-element root layer last.
+		layers: Vec<Vec<Node>>,
+		/// Committed values of each leaf, in leaf order.
+		leaves: Vec<Vec<B128>>,
+		/// Salt of each leaf, in leaf order, all empty when the tree is not salted.
+		salts: Vec<Vec<B128>>,
+	}
+
+	impl RefTree {
+		/// Commits a full tree of uniform leaves.
+		///
+		/// # Arguments
+		///
+		/// * `log_len` - base-2 logarithm of the number of leaves.
+		/// * `batch_size` - number of committed values per leaf.
+		/// * `salt_len` - number of salt values per leaf, zero for an unsalted tree.
+		fn random(rng: &mut impl Rng, log_len: usize, batch_size: usize, salt_len: usize) -> Self {
+			let compression = <Suite as HashSuite>::Compression::default();
+
+			// Draw the committed payload and the salt separately, one entry per leaf.
+			let leaves = (0..1 << log_len)
+				.map(|_| random_scalars::<B128>(&mut *rng, batch_size))
+				.collect::<Vec<_>>();
+			let salts = (0..1 << log_len)
+				.map(|_| random_scalars::<B128>(&mut *rng, salt_len))
+				.collect::<Vec<_>>();
+
+			// A leaf hashes its values first and its salt second, matching the verifier's order.
+			let leaf_digests = leaves
+				.iter()
+				.zip(&salts)
+				.map(|(values, salt)| {
+					hash_serialize::<B128, LeafHash>(values.iter().chain(salt))
+						.expect("field elements serialize into a growable buffer")
+				})
+				.collect::<Vec<_>>();
+
+			// Fold neighbouring pairs upward until the topmost layer holds one digest.
+			// Every intermediate layer is kept, since openings are checked against them.
+			let mut layers = vec![leaf_digests];
+			while layers.last().expect("layers is never empty").len() > 1 {
+				let next = layers
+					.last()
+					.expect("layers is never empty")
+					.chunks_exact(2)
+					.map(|pair| compression.compress([pair[0], pair[1]]))
+					.collect();
+				layers.push(next);
+			}
+
+			Self {
+				layers,
+				leaves,
+				salts,
+			}
+		}
+
+		/// Number of levels between the leaves and the root.
+		fn depth(&self) -> usize {
+			// One layer is stored per level, plus the leaf layer itself.
+			self.layers.len() - 1
+		}
+
+		/// The root digest of the tree.
+		fn root(&self) -> Node {
+			// The topmost layer holds exactly one digest.
+			self.layers[self.depth()][0]
+		}
+
+		/// The digests sitting the given number of levels below the root.
+		fn layer(&self, layer_depth: usize) -> Vec<Node> {
+			// Layers are stored leaves-first, so counting down from the root inverts the index.
+			self.layers[self.depth() - layer_depth].clone()
+		}
+
+		/// The sibling digests on the path from one leaf up to the given layer.
+		fn branch(&self, index: usize, layer_depth: usize) -> Vec<Node> {
+			// At level `j` the path sits at `index >> j`.
+			// Its sibling is that same position with the low bit flipped.
+			(0..self.depth() - layer_depth)
+				.map(|j| self.layers[j][(index >> j) ^ 1])
+				.collect()
+		}
+
+		/// Every committed value of the tree, concatenated in leaf order.
+		fn flat_data(&self) -> Vec<B128> {
+			self.leaves.concat()
 		}
 	}
-	digests[0].clone()
+
+	/// Builds a scheme for a salt length, hiding exactly when that length is non-zero.
+	fn scheme(salt_len: usize) -> Scheme {
+		match NonZeroUsize::new(salt_len) {
+			Some(salt_len) => Scheme::hiding(salt_len),
+			None => Scheme::new(),
+		}
+	}
+
+	/// Writes the advice one single-leaf opening consumes: the leaf salt, then the branch.
+	fn write_opening(
+		transcript: &mut ProverTranscript<Challenger>,
+		tree: &RefTree,
+		index: usize,
+		layer_depth: usize,
+	) {
+		// The verifier reads the salt while hashing the leaf, then the siblings while climbing.
+		let mut writer = transcript.decommitment();
+		writer.write_slice(&tree.salts[index]);
+		writer.write_slice(&tree.branch(index, layer_depth));
+	}
+
+	/// Writes the advice a full-vector opening consumes: every leaf's salt, in leaf order.
+	fn write_vector(transcript: &mut ProverTranscript<Challenger>, tree: &RefTree) {
+		// No branch is sent: the verifier rebuilds every leaf and folds the whole tree itself.
+		let mut writer = transcript.decommitment();
+		for salt in &tree.salts {
+			writer.write_slice(salt);
+		}
+	}
+
+	/// A transcript the tests write proof bytes into.
+	fn prover_transcript() -> ProverTranscript<Challenger> {
+		ProverTranscript::new(Challenger::default())
+	}
+
+	/// Asserts a verification failed for the one reason a tampered proof should fail.
+	fn expect_invalid_proof(result: Result<(), Error>) {
+		// Every field of the variant is pinned, so a differently-shaped failure still fails.
+		match result {
+			Err(Error::Verification(VerificationError::InvalidProof)) => {}
+			other => panic!("expected an invalid-proof rejection, got {other:?}"),
+		}
+	}
+
+	#[test]
+	fn verify_opening_accepts_every_leaf_at_every_layer_depth() {
+		let mut rng = StdRng::seed_from_u64(0);
+
+		// Invariant: an honest branch verifies from any leaf against any layer of its tree.
+		//
+		// Fixture state: 4 trees of 8 leaves, covering batched leaves and salted leaves.
+		for (batch_size, salt_len) in [(1, 0), (1, 2), (4, 0), (3, 1)] {
+			let tree = RefTree::random(&mut rng, 3, batch_size, salt_len);
+			let scheme = scheme(salt_len);
+
+			// Depth 0 is the root and depth 3 is the leaf layer.
+			// The sweep covers the longest branch, the empty branch, and every depth between.
+			for layer_depth in 0..=tree.depth() {
+				let layer = tree.layer(layer_depth);
+				for index in 0..1 << tree.depth() {
+					let mut transcript = prover_transcript();
+					write_opening(&mut transcript, &tree, index, layer_depth);
+
+					let mut verifier = transcript.into_verifier();
+					scheme
+						.verify_opening(
+							index,
+							&tree.leaves[index],
+							layer_depth,
+							tree.depth(),
+							&layer,
+							&mut verifier.decommitment(),
+						)
+						.unwrap();
+					// Nothing may be left over: the verifier must read exactly what was written.
+					verifier.finalize().unwrap();
+				}
+			}
+		}
+	}
+
+	#[test]
+	fn verify_opening_accepts_a_single_leaf_tree() {
+		let mut rng = StdRng::seed_from_u64(0);
+
+		// Invariant: a one-leaf tree has no levels, so its salted leaf digest is the root.
+		//
+		// Fixture state: 1 leaf of 2 values, salted with 1 more, depth 0.
+		//
+		//     advice = [salt]     (no siblings to send)
+		//     layer  = [root]     (the layer at depth 0 is the root itself)
+		let tree = RefTree::random(&mut rng, 0, 2, 1);
+		let scheme = scheme(1);
+
+		let mut transcript = prover_transcript();
+		write_opening(&mut transcript, &tree, 0, 0);
+
+		let mut verifier = transcript.into_verifier();
+		scheme
+			.verify_opening(0, &tree.leaves[0], 0, 0, &[tree.root()], &mut verifier.decommitment())
+			.unwrap();
+		verifier.finalize().unwrap();
+	}
+
+	#[test]
+	fn verify_opening_rejects_a_corrupted_branch() {
+		let mut rng = StdRng::seed_from_u64(0);
+		let tree = RefTree::random(&mut rng, 3, 2, 0);
+		let scheme = scheme(0);
+
+		// Invariant: every level of the climb feeds the next, so no sibling can be swapped.
+		//
+		// Fixture state: 8 leaves, unsalted, opening leaf 5 against the root.
+		//
+		// Mutation: flip the lowest bit of one sibling, one level at a time.
+		//
+		//     level 0:  [BAD, ok , ok ]
+		//     level 1:  [ok , BAD, ok ]
+		//     level 2:  [ok , ok , BAD]
+		//     -> each must climb to a root differing from the committed one
+		for level in 0..tree.depth() {
+			let mut branch = tree.branch(5, 0);
+			branch[level][0] ^= 1;
+
+			let mut transcript = prover_transcript();
+			transcript.decommitment().write_slice(&branch);
+
+			let mut verifier = transcript.into_verifier();
+			expect_invalid_proof(scheme.verify_opening(
+				5,
+				&tree.leaves[5],
+				0,
+				tree.depth(),
+				&[tree.root()],
+				&mut verifier.decommitment(),
+			));
+			verifier.finalize().unwrap();
+		}
+	}
+
+	#[test]
+	fn verify_opening_rejects_corrupted_leaf_values() {
+		let mut rng = StdRng::seed_from_u64(0);
+		let tree = RefTree::random(&mut rng, 3, 2, 0);
+		let scheme = scheme(0);
+
+		// Invariant: the branch binds the leaf's contents, not just its position.
+		//
+		// Fixture state: 8 leaves of 2 values each, unsalted, opening leaf 5.
+		let mut transcript = prover_transcript();
+		write_opening(&mut transcript, &tree, 5, 0);
+
+		// Mutation: keep the honest branch, but claim a different first value for the leaf.
+		let mut values = tree.leaves[5].clone();
+		values[0] += B128::ONE;
+
+		let mut verifier = transcript.into_verifier();
+		expect_invalid_proof(scheme.verify_opening(
+			5,
+			&values,
+			0,
+			tree.depth(),
+			&[tree.root()],
+			&mut verifier.decommitment(),
+		));
+		verifier.finalize().unwrap();
+	}
+
+	#[test]
+	fn verify_opening_rejects_a_corrupted_salt() {
+		let mut rng = StdRng::seed_from_u64(0);
+		let tree = RefTree::random(&mut rng, 3, 1, 2);
+		let scheme = scheme(2);
+
+		// Invariant: the salt is hashed into the leaf, so it is bound just like the values are.
+		//
+		// Fixture state: 8 leaves of 1 value each, salted with 2, opening leaf 5.
+		//
+		// Mutation: send leaf 6's salt alongside leaf 5's honest branch.
+		//
+		//     advice = [salt_6, branch_5 ...]
+		//     -> the leaf digest differs, so the climb lands off the root
+		let mut transcript = prover_transcript();
+		{
+			let mut writer = transcript.decommitment();
+			writer.write_slice(&tree.salts[6]);
+			writer.write_slice(&tree.branch(5, 0));
+		}
+
+		let mut verifier = transcript.into_verifier();
+		expect_invalid_proof(scheme.verify_opening(
+			5,
+			&tree.leaves[5],
+			0,
+			tree.depth(),
+			&[tree.root()],
+			&mut verifier.decommitment(),
+		));
+		verifier.finalize().unwrap();
+	}
+
+	#[test]
+	fn verify_opening_rejects_an_opening_against_a_corrupted_layer() {
+		let mut rng = StdRng::seed_from_u64(0);
+		let tree = RefTree::random(&mut rng, 3, 1, 0);
+		let scheme = scheme(0);
+
+		// Invariant: the climb ends by matching the layer entry the leaf index selects.
+		//
+		// Fixture state: 8 leaves, unsalted, opening leaf 5 against the layer at depth 2.
+		//
+		// Mutation: flip a bit in the one layer entry the climb lands on.
+		//
+		//     leaf 5 climbs 1 level -> layer index 5 >> 1 = 2
+		let mut layer = tree.layer(2);
+		layer[5 >> 1][0] ^= 1;
+
+		let mut transcript = prover_transcript();
+		write_opening(&mut transcript, &tree, 5, 2);
+
+		let mut verifier = transcript.into_verifier();
+		expect_invalid_proof(scheme.verify_opening(
+			5,
+			&tree.leaves[5],
+			2,
+			tree.depth(),
+			&layer,
+			&mut verifier.decommitment(),
+		));
+		verifier.finalize().unwrap();
+	}
+
+	#[test]
+	fn verify_layer_accepts_the_committed_layer() {
+		let mut rng = StdRng::seed_from_u64(0);
+		let tree = RefTree::random(&mut rng, 4, 1, 0);
+		let scheme = scheme(0);
+
+		// Invariant: folding any honest layer reproduces the committed root.
+		//
+		// Fixture state: 16 leaves, unsalted, depth 4.
+		//
+		// Depth 0 is the degenerate case where the layer is the root and nothing folds.
+		for layer_depth in 0..=tree.depth() {
+			scheme
+				.verify_layer(&tree.root(), layer_depth, &tree.layer(layer_depth))
+				.unwrap();
+		}
+	}
+
+	#[test]
+	fn verify_layer_rejects_a_corrupted_layer() {
+		let mut rng = StdRng::seed_from_u64(0);
+		let tree = RefTree::random(&mut rng, 4, 1, 0);
+		let scheme = scheme(0);
+
+		// Invariant: a single wrong digest anywhere in the layer changes the folded root.
+		//
+		// Fixture state: 16 leaves, unsalted, depth 4.
+		//
+		// Mutation: flip the lowest bit of the layer's first digest, at every depth in turn.
+		for layer_depth in 0..=tree.depth() {
+			let mut layer = tree.layer(layer_depth);
+			layer[0][0] ^= 1;
+			expect_invalid_proof(scheme.verify_layer(&tree.root(), layer_depth, &layer));
+		}
+	}
+
+	#[test]
+	fn verify_vector_accepts_the_committed_vector() {
+		let mut rng = StdRng::seed_from_u64(0);
+
+		// Invariant: rebuilding every leaf from the revealed values reproduces the root.
+		//
+		// Fixture state: 4 trees sweeping leaf count, batch size, and salt length.
+		//
+		//     (log_len, batch_size, salt_len)
+		//     the two log_len = 0 cases are single-leaf trees, where nothing folds at all
+		for (log_len, batch_size, salt_len) in [(0, 1, 0), (0, 3, 2), (3, 1, 0), (3, 4, 2)] {
+			let tree = RefTree::random(&mut rng, log_len, batch_size, salt_len);
+			let scheme = scheme(salt_len);
+
+			let mut transcript = prover_transcript();
+			write_vector(&mut transcript, &tree);
+
+			let mut verifier = transcript.into_verifier();
+			scheme
+				.verify_vector(
+					&tree.root(),
+					&tree.flat_data(),
+					batch_size,
+					&mut verifier.decommitment(),
+				)
+				.unwrap();
+			verifier.finalize().unwrap();
+		}
+	}
+
+	#[test]
+	fn verify_vector_rejects_a_corrupted_value() {
+		let mut rng = StdRng::seed_from_u64(0);
+		let tree = RefTree::random(&mut rng, 3, 2, 1);
+		let scheme = scheme(1);
+
+		// Invariant: the root binds every value in the vector, not only the ones later queried.
+		//
+		// Fixture state: 8 leaves of 2 values each, salted with 1, so 16 values in total.
+		let mut transcript = prover_transcript();
+		write_vector(&mut transcript, &tree);
+
+		// Mutation: alter one value in the middle of the vector.
+		//
+		//     value 7 lives in leaf 3 (7 / 2 = 3) -> that leaf digest changes -> the root changes
+		let mut data = tree.flat_data();
+		data[7] += B128::ONE;
+
+		let mut verifier = transcript.into_verifier();
+		expect_invalid_proof(scheme.verify_vector(
+			&tree.root(),
+			&data,
+			2,
+			&mut verifier.decommitment(),
+		));
+		verifier.finalize().unwrap();
+	}
+
+	#[test]
+	fn verify_vector_rejects_a_corrupted_salt() {
+		let mut rng = StdRng::seed_from_u64(0);
+		let tree = RefTree::random(&mut rng, 3, 1, 2);
+		let scheme = scheme(2);
+
+		// Invariant: a full-vector opening binds each leaf's salt as tightly as its values.
+		//
+		// Fixture state: 8 leaves of 1 value each, salted with 2.
+		//
+		// Mutation: replace the last leaf's salt with the first leaf's.
+		//
+		//     advice = [salt_0, salt_1, ..., salt_6, salt_0]
+		//                                            ^^^^^^ should be salt_7
+		let last = tree.salts.len() - 1;
+		let mut transcript = prover_transcript();
+		{
+			let mut writer = transcript.decommitment();
+			for (i, salt) in tree.salts.iter().enumerate() {
+				writer.write_slice(if i == last { &tree.salts[0] } else { salt });
+			}
+		}
+
+		let mut verifier = transcript.into_verifier();
+		expect_invalid_proof(scheme.verify_vector(
+			&tree.root(),
+			&tree.flat_data(),
+			1,
+			&mut verifier.decommitment(),
+		));
+		verifier.finalize().unwrap();
+	}
+
+	#[test]
+	fn proof_size_matches_the_advice_a_multi_opening_consumes() {
+		let mut rng = StdRng::seed_from_u64(0);
+		let indices = [1, 4, 7, 7];
+
+		// Invariant: the predicted byte count equals what a multi-opening actually writes.
+		//
+		// Fixture state: 8 leaves of 2 values each, 4 queries, one unsalted and one salted run.
+		//
+		// The salted run is the one that silently under-counts if the salt term is forgotten.
+		for salt_len in [0, 3] {
+			let tree = RefTree::random(&mut rng, 3, 2, salt_len);
+			let scheme = scheme(salt_len);
+			let layer_depth = scheme.optimal_verify_layer(indices.len(), tree.depth());
+
+			// Advice layout, exactly as the verifier consumes it:
+			//
+			//     [layer digests] [salt_1 branch_1] ... [salt_7 branch_7]
+			let mut transcript = prover_transcript();
+			transcript
+				.decommitment()
+				.write_slice(&tree.layer(layer_depth));
+			for &index in &indices {
+				write_opening(&mut transcript, &tree, index, layer_depth);
+			}
+
+			let advice = transcript.finalize();
+			assert_eq!(
+				advice.len(),
+				scheme.proof_size(1 << tree.depth(), indices.len(), layer_depth)
+			);
+
+			// A byte count only means something if those exact bytes verify, so replay them.
+			let mut verifier = VerifierTranscript::new(Challenger::default(), advice);
+			let layer_digests = verifier
+				.decommitment()
+				.read_vec::<Node>(1 << layer_depth)
+				.unwrap();
+			scheme
+				.verify_layer(&tree.root(), layer_depth, &layer_digests)
+				.unwrap();
+			for &index in &indices {
+				scheme
+					.verify_opening(
+						index,
+						&tree.leaves[index],
+						layer_depth,
+						tree.depth(),
+						&layer_digests,
+						&mut verifier.decommitment(),
+					)
+					.unwrap();
+			}
+			verifier.finalize().unwrap();
+		}
+	}
+
+	#[test]
+	fn vector_proof_size_matches_the_advice_a_full_opening_consumes() {
+		let mut rng = StdRng::seed_from_u64(0);
+
+		// Invariant: the predicted byte count equals what a full-vector opening actually writes.
+		//
+		// Fixture state: 8 leaves of 2 values each, one unsalted and one salted run.
+		//
+		//     unsalted -> no advice at all
+		//     salted   -> 8 leaves * 3 salt values each
+		for salt_len in [0, 3] {
+			let tree = RefTree::random(&mut rng, 3, 2, salt_len);
+			let scheme = scheme(salt_len);
+
+			let mut transcript = prover_transcript();
+			write_vector(&mut transcript, &tree);
+
+			let advice = transcript.finalize();
+			assert_eq!(advice.len(), scheme.vector_proof_size(1 << tree.depth()));
+
+			// Replay the same bytes to confirm the count covers a proof that really verifies.
+			let mut verifier = VerifierTranscript::new(Challenger::default(), advice);
+			scheme
+				.verify_vector(&tree.root(), &tree.flat_data(), 2, &mut verifier.decommitment())
+				.unwrap();
+			verifier.finalize().unwrap();
+		}
+	}
+
+	#[test]
+	fn salt_len_reports_the_configured_length() {
+		// Invariant: the non-hiding constructions report no salt.
+		// The hiding one reports exactly the length it was given.
+		assert_eq!(Scheme::new().salt_len(), 0);
+		assert_eq!(Scheme::default().salt_len(), 0);
+		assert_eq!(Scheme::hiding(NonZeroUsize::new(4).unwrap()).salt_len(), 4);
+	}
+
+	proptest! {
+		#[test]
+		fn optimal_verify_layer_minimizes_proof_size(
+			n_queries in 1usize..64,
+			tree_depth in 0usize..10,
+			salt_len in 0usize..3,
+		) {
+			// Invariant: the chosen layer depth is one that really minimizes the proof.
+			let scheme = scheme(salt_len);
+			let len = 1 << tree_depth;
+
+			let chosen = scheme.optimal_verify_layer(n_queries, tree_depth);
+			// A layer never sits below the leaves.
+			prop_assert!(chosen <= tree_depth);
+
+			// Search every admissible depth for the smallest proof.
+			let best = (0..=tree_depth)
+				.map(|layer_depth| scheme.proof_size(len, n_queries, layer_depth))
+				.min()
+				.expect("the range always includes layer_depth 0");
+
+			// Two depths can tie, so compare the sizes rather than the depths themselves.
+			prop_assert_eq!(scheme.proof_size(len, n_queries, chosen), best);
+		}
+	}
 }


### PR DESCRIPTION
@jimpo I've mainly added a bunch of tests here because I've noticed that on the verifier side we didn't have that much unit tests.

Fixes a proof-size estimate that under-reported for hiding commitments, and cleans up the verifier-side Merkle scheme around it.

No change to what is verified or accepted — the transcript is byte-identical.

### The problem

The prover writes a salt before every branch it opens:

```
prove_opening:  [salt] [sibling_0] [sibling_1] ... [sibling_k]
```

The scheme's proof-size estimate counted only the digests. So for any non-zero salt length it under-reported by

```
n_queries * salt_len * BYTE_SIZE
```

The FRI estimate papered over this with a comment saying it *"assumes non-hiding proofs (salt_len = 0)"*. But the scheme is the one object that knows the salt length, and the fixed serialized width of the committed values hands it the byte size for free — so the bound that made this computable was already there, just unused.

### The idea

Count the salt where it is known.

The estimate splits into the digests the branches and layer cost, plus the salt every opened leaf reveals:

```
n_digests  = (log_len - layer_depth) * n_queries + 2^layer_depth
salt_bytes = n_queries * salt_len * BYTE_SIZE
```

That alone is not enough to make FRI exact. The terminal codeword is never queried, but it is decommitted in full, which reveals a salt for each of its leaves. So the scheme also gained a companion estimate for a full-vector opening, and FRI now adds it:

```
vector_proof_size(len) = len * salt_len * BYTE_SIZE
```

The optimal layer depth is unaffected: the salt term does not depend on it, so the argmin does not move.

### The change

```
proof_size:
- ((log_len - layer_depth) * n_queries + (1 << layer_depth)) * output_size()
+ n_digests * output_size() + n_queries * self.salt_len * T::BYTE_SIZE

fri::size_estimation:
+ merkle_sizes += vcs.vector_proof_size(1 << log_inv_rate);
- /// The estimate assumes non-hiding proofs (salt_len = 0).
```

`test_proof_size_hiding` pins it: a full FRI run at `salt_len = 3` now matches the predicted byte count exactly.

### Cleanup carried in the same pass

The file needed it, and the salt fix touches most of the same lines.

**A free function that should have been a method.** Layer folding took a compression function and a `Vec` through two generic parameters that were always the same two types, behind bounds — `Default + Send + Sync + Debug` — of which only `Clone` was used. It is now a private method. One caller was cloning an entire layer purely to satisfy the `Vec` signature; taking a slice removes that, and the scratch buffer is now `n/2` rather than `n`, allocated once and halved in place.

**Two allocations off the per-query path.** Branch siblings are read one at a time instead of collected into a `Vec`, and leaf hashing serializes straight into the hasher rather than staging the salt in a `Vec` first. Hashing dominates, so this is an allocation-count win, not a measurable speedup — worth it for the code.

**Preconditions where they belong.** Full-vector verification had three, of which one was documented. A zero batch size passed the multiple-of check on empty data and then panicked inside `chunks`; a non-power-of-two leaf count panicked inside the folding helper. Both are now asserted and documented on the trait, as is `layer_depth <= tree_depth`, whose subtraction could underflow.

**API tidying.**

- The compression getter had no callers anywhere in the workspace — removed.
- The derive-macro getters are written out, so the surviving one is `const` and carries a doc comment.
- `Clone` and `Debug` are hand-written: a derive would demand `T: Clone` / `T: Debug` on a type that holds no `T`.
- The hiding constructor takes a `NonZeroUsize`, so it can no longer name a security property while silently not providing it.
- Serialization failures get `#[from]`, matching every sibling variant.

**One thing deliberately not done.** Making `batch_size` a `NonZeroUsize` was tempting, but `leaf_size` is a plain `usize` throughout FRI and BaseFold, so the type would only force a `NonZeroUsize::new(..).expect(..)` at the single call site — the same assert, relocated somewhere it reads worse — while breaking the module's uniform documented-precondition convention.

### Tests

The scheme had **no tests in its own crate**; all coverage was prover-side round trips, and every one was a happy path. For a verifier that is backwards — nothing pinned that a bad proof is rejected.

It now has twelve tests and a proptest, built against a reference tree constructed straight from the hash and compression primitives. Checking the verifier against trees it built itself would pass even with a wrong folding rule.

- **acceptance:** every leaf at every layer depth, across batched and salted trees; single-leaf trees, where nothing folds.
- **rejection, one per tamper site:** branch digest (at each level in turn), leaf values, leaf salt, layer entry, vector value, vector salt — each pinned to the full error variant.
- **size:** predicted bytes equal written bytes for both opening kinds, salted and unsalted, with the bytes replayed through the verifier so a count cannot pass on a proof that would not.
- **proptest:** the chosen layer depth really minimizes the proof, compared by size since two depths can tie.

### Documentation

The type had no doc comment at all, and neither did its constructors, its fields, or the trait's digest type. The impl-level docs on two methods were *shadowing* the trait's own docs in rustdoc, and were worse than what they replaced.

The file is now documented to the repo's standard throughout: sectioned headers, one sentence per line, ASCII diagrams for the tree shape and the climb, and line-by-line narration in every body including the tests. The trait now carries the cost model behind the optimal layer depth, and the reason the committed values need a fixed serialized width — leaf encodings are injective, so two distinct leaves can never present the same bytes to the hash.

### Scope

- **changed:** the Merkle scheme, its trait, its error type, the FRI size estimate
- **new:** a test module in the scheme, one hiding FRI proof-size test
- **rippled:** hiding constructors take `NonZeroUsize` — 3 call sites plus tests
- **untouched:** the prover, the tree builder, the channel protocol

Also folded in: the FRI estimate was serializing a default field element into a heap `Vec` to learn its width, which the existing trait bound already provides as a constant.

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-iop -p binius-iop-prover --all-targets` — zero warnings
- `cargo +nightly fmt --all --check` — clean
- `cargo test -p binius-iop -p binius-iop-prover` — 62 passed
- `cargo test` on the verifier, prover, and both Spartan crates — 82 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)