### PR TITLE
BINIUS-409: open one committed oracle at several points in a single BaseFold batch

### DIFF
--- a/crates/iop-prover/src/basefold/channel.rs
+++ b/crates/iop-prover/src/basefold/channel.rs
@@ -2,10 +2,10 @@
 
 //! BaseFold ZK implementation of the IOP prover channel.
 
-use std::ops::Deref;
+use std::{iter, ops::Deref};
 
 use binius_compute::Allocator;
-use binius_field::{BinaryField, PackedField};
+use binius_field::{BinaryField, PackedField, util::powers};
 use binius_iop::{channel::OracleSpec, fri::FRIParams};
 use binius_ip_prover::{
 	channel::IPProverChannel,
@@ -16,7 +16,7 @@ use binius_ip_prover::{
 	},
 };
 use binius_math::{
-	FieldBuffer, FieldSlice, FieldSliceMut, FieldVec,
+	FieldBuffer, FieldSlice, FieldSliceMut,
 	inner_product::inner_product_par,
 	line::{extrapolate_line, extrapolate_line_packed},
 	multilinear::eq::{eq_ind_partial_eval_scalars, eq_ind_zero},
@@ -34,7 +34,7 @@ use rand::{Rng, SeedableRng, rngs::StdRng};
 
 use crate::{
 	basefold::prove_mlecheck_basefold,
-	channel::IOPProverChannel,
+	channel::{IOPProverChannel, OracleOpening, TransparentClaim},
 	fri::{self, FRIFoldProver, MaskedCodeword},
 	merkle_channel::MerkleIPProverChannel,
 };
@@ -56,12 +56,15 @@ struct CommittedOracleData<P: PackedField, C> {
 	commitment: C,
 }
 
-/// A committed-oracle relation queued for the single batched opening.
+/// A committed-oracle relation entering the single batched opening.
 ///
 /// Each entry pairs a committed message with the transparent multilinear it is opened against.
 /// It also records which committed oracle it refers to.
 /// That index reconciles the arrival-order and oracle-index views of the batch.
-struct QueuedRelation<P: PackedField, Data: Deref<Target = [P]>> {
+///
+/// An oracle opened at several points yields one of these, whose transparent and claim are the
+/// batched combination of its claims — see [`combine_claims_per_oracle`].
+struct OracleRelation<P: PackedField, Data: Deref<Target = [P]>> {
 	/// Index of the committed oracle this relation opens.
 	oracle_index: usize,
 	/// The committed multilinear message `pi_i`, backed by the caller's allocator.
@@ -106,9 +109,9 @@ where
 	/// The combined FRI parameters over all committed oracles.
 	fri_params: FRIParams<F>,
 	committed_oracles: Vec<CommittedOracleData<P, Channel::Commitment>>,
-	/// Oracle relations queued by [`Self::prove_oracle_relations`], opened together in
+	/// Oracle openings queued by [`Self::prove_oracle_relations`], opened together in
 	/// [`Self::finish`].
-	queue: Vec<QueuedRelation<P, A::Vec<P>>>,
+	queue: Vec<OracleOpening<BaseFoldOracle, P, A>>,
 	next_oracle_index: usize,
 	rng: StdRng,
 }
@@ -193,7 +196,11 @@ where
 /// point `r`, then opens all committed oracles together with a single combined FRI. Mirrors
 /// [`binius_iop::basefold::channel::BaseFoldVerifierChannel::finish`].
 ///
-/// The masking inner products and the batched sumcheck process the `relations` in arrival order (so
+/// An oracle opened at several points arrives as one [`OracleOpening`] carrying several claims.
+/// [`combine_claims_per_oracle`] batches each oracle's claims into one, so everything below sees
+/// exactly one relation per committed oracle.
+///
+/// The masking inner products and the batched sumcheck process those relations in arrival order (so
 /// each reduced eval lines up with its batched-claim coefficient), while the per-oracle evaluations
 /// α_i and the FRI openings are emitted in oracle-index order. Each relation carries its oracle's
 /// index, so the two orders are reconciled by indexing rather than by sorting the relations; the
@@ -205,7 +212,7 @@ fn prove_batch_zk_basefold<A, F, P, NTT, Channel>(
 	oracle_specs: &[OracleSpec],
 	fri_params: &FRIParams<F>,
 	committed_oracles: Vec<CommittedOracleData<P, Channel::Commitment>>,
-	relations: Vec<QueuedRelation<P, A::Vec<P>>>,
+	openings: Vec<OracleOpening<BaseFoldOracle, P, A>>,
 	alloc: &A,
 ) where
 	A: Allocator,
@@ -217,9 +224,9 @@ fn prove_batch_zk_basefold<A, F, P, NTT, Channel>(
 	let n_committed = committed_oracles.len();
 	assert_eq!(oracle_specs.len(), n_committed);
 
-	// TODO: Remove this limitation, it shouldn't be necessary. It is currently because of how the
-	// sumcheck reduces to the multilinear evaluations (alphas).
-	assert_eq!(relations.len(), n_committed, "expects exactly one relation per committed oracle",);
+	// Batch each oracle's claims into one relation, before σ: a σ below is an inner product
+	// against the *combined* transparent.
+	let relations = combine_claims_per_oracle(openings, n_committed, channel);
 
 	// `𝐧 = max_i log_msg_len_i`, the variable count of the combined opening / materialized buffer.
 	let max_n = oracle_specs
@@ -271,7 +278,7 @@ fn prove_batch_zk_basefold<A, F, P, NTT, Channel>(
 	let relations = relations
 		.into_iter()
 		.map(
-			|QueuedRelation {
+			|OracleRelation {
 			     oracle_index: index,
 			     mut message,
 			     transparent,
@@ -444,6 +451,107 @@ fn prove_batch_zk_basefold<A, F, P, NTT, Channel>(
 	);
 }
 
+/// Batches each opening's claims into exactly one relation per committed oracle.
+///
+/// One committed message may be opened at several points, one [`TransparentClaim`] each.
+/// A sampled `lambda` batches them into one:
+///
+/// ```text
+/// T_i = sum_j lambda_i^j * t_j     the combined transparent
+/// S_i = sum_j lambda_i^j * s_j     the combined claim
+/// ```
+///
+/// The combination accumulates into the first transparent in place, so it allocates nothing.
+/// An oracle with one claim samples no `lambda` and passes through untouched.
+///
+/// This mirrors `combine_relations_per_oracle` on the verifier side, which draws the same
+/// `lambda` at the same point of the transcript.
+///
+/// # Panics
+///
+/// Panics unless every committed oracle appears in exactly one opening with at least one claim.
+fn combine_claims_per_oracle<A, F, P, Channel>(
+	openings: Vec<OracleOpening<BaseFoldOracle, P, A>>,
+	n_committed: usize,
+	channel: &mut Channel,
+) -> Vec<OracleRelation<P, A::Vec<P>>>
+where
+	A: Allocator,
+	F: BinaryField,
+	P: PackedField<Scalar = F>,
+	Channel: MerkleIPProverChannel<F>,
+{
+	assert_eq!(
+		openings.len(),
+		n_committed,
+		"every committed oracle must appear in exactly one opening"
+	);
+
+	let mut seen = vec![false; n_committed];
+	openings
+		.into_iter()
+		.map(|opening| {
+			let OracleOpening {
+				oracle,
+				message,
+				claims,
+			} = opening;
+			let oracle_index = oracle.index;
+			assert!(
+				!std::mem::replace(&mut seen[oracle_index], true),
+				"oracle {oracle_index} appears in two openings"
+			);
+
+			let mut claims = claims.into_iter();
+			let TransparentClaim {
+				mut transparent,
+				claim,
+			} = claims.next().expect("an opening holds at least one claim");
+
+			// A single claim is already the combined claim; batching it would only add a challenge.
+			let Some(second) = claims.next() else {
+				return OracleRelation {
+					oracle_index,
+					message,
+					transparent,
+					claim,
+				};
+			};
+
+			// SOUNDNESS: `lambda` is drawn after the claims are bound to the transcript, so the
+			// prover cannot choose a claim as a function of it.
+			let lambda = channel.sample();
+
+			// Fold the remaining transparents into the first, weighted by the powers of `lambda`.
+			// The claims are folded over the same powers, so both sides stay in step.
+			let mut combined_claim = claim;
+			for (
+				power,
+				TransparentClaim {
+					transparent: t,
+					claim,
+				},
+			) in iter::zip(powers(lambda).skip(1), iter::once(second).chain(claims))
+			{
+				assert_eq!(
+					t.log_len(),
+					transparent.log_len(),
+					"every transparent on one oracle spans the oracle's variables"
+				);
+				accumulate_scaled_buffer(transparent.to_mut(), t.to_ref(), P::broadcast(power));
+				combined_claim += power * claim;
+			}
+
+			OracleRelation {
+				oracle_index,
+				message,
+				transparent,
+				claim: combined_claim,
+			}
+		})
+		.collect()
+}
+
 fn accumulate_scaled_buffer<P: PackedField>(
 	mut dst: FieldSliceMut<P>,
 	src: FieldSlice<P>,
@@ -563,25 +671,19 @@ where
 
 	fn prove_oracle_relations(
 		&mut self,
-		oracle_relations: impl IntoIterator<
-			Item = (Self::Oracle, FieldVec<P, A>, FieldVec<P, A>, P::Scalar),
-		>,
+		openings: impl IntoIterator<Item = OracleOpening<Self::Oracle, P, A>>,
 	) {
-		// Queue the relations; the actual opening (masking + sumcheck + combined FRI) happens once,
+		// Queue the openings; the actual opening (masking + sumcheck + combined FRI) happens once,
 		// over all committed oracles, in [`Self::finish`].
-		for (oracle, message, transparent, claim) in oracle_relations {
+		for opening in openings {
 			assert!(
-				oracle.index < self.committed_oracles.len(),
+				opening.oracle.index < self.committed_oracles.len(),
 				"oracle index {} out of bounds, expected < {}",
-				oracle.index,
+				opening.oracle.index,
 				self.committed_oracles.len()
 			);
-			self.queue.push(QueuedRelation {
-				oracle_index: oracle.index,
-				message,
-				transparent,
-				claim,
-			});
+			assert!(!opening.claims.is_empty(), "an opening must carry at least one claim");
+			self.queue.push(opening);
 		}
 	}
 }
@@ -609,7 +711,7 @@ mod tests {
 	use binius_transcript::{ProverTranscript, fiat_shamir::HasherChallenger};
 	use rand::{Rng, SeedableRng, rngs::StdRng};
 
-	use super::IOPProverChannel;
+	use super::{IOPProverChannel, OracleOpening, TransparentClaim};
 	use crate::basefold::compiler::BaseFoldProverCompiler;
 
 	type StdChallenger = HasherChallenger<StdDigest>;
@@ -686,7 +788,7 @@ mod tests {
 		let oracle = prover_channel.send_oracle(buffer.to_ref());
 		assert_eq!(oracle.index, 0);
 
-		prover_channel.prove_oracle_relations([(
+		prover_channel.prove_oracle_relations([OracleOpening::single(
 			oracle,
 			buffer,
 			transparent_poly.clone(),
@@ -759,8 +861,8 @@ mod tests {
 		let oracle_2 = prover_channel.send_oracle(buffer_2.to_ref());
 
 		prover_channel.prove_oracle_relations([
-			(oracle_1, buffer_1, transparent_poly_1.clone(), eval_claim_1),
-			(oracle_2, buffer_2, transparent_poly_2.clone(), eval_claim_2),
+			OracleOpening::single(oracle_1, buffer_1, transparent_poly_1.clone(), eval_claim_1),
+			OracleOpening::single(oracle_2, buffer_2, transparent_poly_2.clone(), eval_claim_2),
 		]);
 		prover_channel.finish(&GlobalAllocator);
 
@@ -846,7 +948,7 @@ mod tests {
 			.into_iter()
 			.zip(&data)
 			.map(|(oracle, (buffer, transparent, claim))| {
-				(oracle, buffer.clone(), transparent.clone(), *claim)
+				OracleOpening::single(oracle, buffer.clone(), transparent.clone(), *claim)
 			})
 			.collect();
 		prover_channel.prove_oracle_relations(prover_relations);
@@ -942,7 +1044,7 @@ mod tests {
 			.into_iter()
 			.zip(&data)
 			.map(|(oracle, (buffer, transparent, claim))| {
-				(oracle, buffer.clone(), transparent.clone(), *claim)
+				OracleOpening::single(oracle, buffer.clone(), transparent.clone(), *claim)
 			})
 			.collect();
 		prover_channel.prove_oracle_relations(prover_relations);
@@ -1018,5 +1120,211 @@ mod tests {
 	#[test]
 	fn test_basefold_channel_invalid_proof() {
 		assert!(!run_zk_channel(&[6, 8], true));
+	}
+
+	/// One committed oracle together with every point it is opened at.
+	struct MultiClaimOracle<P: PackedField> {
+		/// The committed message.
+		message: FieldBuffer<P>,
+		/// One transparent multilinear and its true claim per opening point.
+		claims: Vec<(FieldBuffer<P>, P::Scalar)>,
+	}
+
+	/// Builds one oracle over `n_vars` variables, opened at `n_claims` independent random points.
+	fn generate_multi_claim_oracle<F, P, R: Rng>(
+		rng: &mut R,
+		n_vars: usize,
+		n_claims: usize,
+	) -> MultiClaimOracle<P>
+	where
+		F: BinaryField,
+		P: PackedField<Scalar = F>,
+	{
+		let message = random_field_buffer::<P>(&mut *rng, n_vars);
+		let claims = (0..n_claims)
+			.map(|_| {
+				let point = random_scalars::<F>(&mut *rng, n_vars);
+				let transparent = eq_ind_partial_eval::<P>(&point);
+				let claim = inner_product_buffers(&message, &transparent);
+				(transparent, claim)
+			})
+			.collect();
+		MultiClaimOracle { message, claims }
+	}
+
+	/// Runs a full prove/verify cycle where an oracle may be opened at several points.
+	///
+	/// Each spec is `(n_vars, is_zk, n_claims)`. `tamper` names a `(oracle, claim)` position whose
+	/// verifier-side claim is corrupted; verification must then fail.
+	///
+	/// The verifier queues its relations flat, interleaved across oracles, which is what a composed
+	/// protocol produces. Grouping them back per oracle is the channel's job.
+	fn run_multi_claim_channel(
+		specs: &[(usize, bool, usize)],
+		tamper: Option<(usize, usize)>,
+	) -> bool {
+		type F = BinaryField128bGhash;
+		type P = PackedBinaryGhash1x128b;
+
+		let mut rng = StdRng::seed_from_u64(0);
+		let data: Vec<MultiClaimOracle<P>> = specs
+			.iter()
+			.map(|&(n_vars, _, n_claims)| {
+				generate_multi_claim_oracle::<F, P, _>(&mut rng, n_vars, n_claims)
+			})
+			.collect();
+
+		let n_test_queries = calculate_n_test_queries(SECURITY_BITS, LOG_INV_RATE);
+		let oracle_specs: Vec<OracleSpec> = specs
+			.iter()
+			.map(|&(n_vars, is_zk, _)| {
+				if is_zk {
+					OracleSpec::new_zk(n_vars)
+				} else {
+					OracleSpec::new(n_vars)
+				}
+			})
+			.collect();
+
+		let verifier_compiler = BaseFoldVerifierCompiler::new(
+			&make_merkle_scheme(),
+			oracle_specs,
+			LOG_INV_RATE,
+			n_test_queries,
+			&MinProofSizeStrategy,
+		);
+
+		// === PROVER SIDE ===
+		let ntt = make_ntt(verifier_compiler.max_subspace());
+		let prover_compiler =
+			BaseFoldProverCompiler::<P, _>::from_verifier_compiler(&verifier_compiler, ntt);
+
+		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
+		let prover_rng = StdRng::seed_from_u64(1);
+		let mut prover_channel = prover_compiler
+			.create_channel_from_transcript::<StdHashSuite, StdChallenger, _, _>(
+				&mut prover_transcript,
+				prover_rng,
+			);
+
+		let oracles: Vec<_> = data
+			.iter()
+			.map(|oracle| prover_channel.send_oracle(oracle.message.to_ref()))
+			.collect();
+		// A spec with no claims commits an oracle the batch never opens, so it queues no opening.
+		let openings: Vec<_> = oracles
+			.iter()
+			.zip(&data)
+			.filter(|(_, entry)| !entry.claims.is_empty())
+			.map(|(&oracle, entry)| OracleOpening {
+				oracle,
+				message: entry.message.clone(),
+				claims: entry
+					.claims
+					.iter()
+					.map(|(transparent, claim)| TransparentClaim {
+						transparent: transparent.clone(),
+						claim: *claim,
+					})
+					.collect(),
+			})
+			.collect();
+		prover_channel.prove_oracle_relations(openings);
+		prover_channel.finish(&GlobalAllocator);
+
+		// === VERIFIER SIDE ===
+		let mut verifier_transcript = prover_transcript.into_verifier();
+		let mut verifier_channel = verifier_compiler
+			.create_channel_from_transcript::<StdHashSuite, StdChallenger, _>(
+				&mut verifier_transcript,
+			);
+
+		let v_oracles: Vec<_> = specs
+			.iter()
+			.map(|&(n_vars, _, _)| verifier_channel.recv_oracle(n_vars, true).unwrap())
+			.collect();
+
+		// Queue claim 0 of every oracle, then claim 1 of every oracle, and so on. The interleaving
+		// is what forces the channel to group by oracle rather than trust arrival order.
+		let max_claims = specs.iter().map(|&(_, _, n)| n).max().unwrap_or(0);
+		let relations: Vec<_> = (0..max_claims)
+			.flat_map(|claim_index| {
+				v_oracles
+					.iter()
+					.zip(&data)
+					.enumerate()
+					.filter_map(move |(oracle_index, (&oracle, entry))| {
+						let (transparent, claim) = entry.claims.get(claim_index)?;
+						let transparent = transparent.clone();
+						let claim = if tamper == Some((oracle_index, claim_index)) {
+							*claim + F::ONE
+						} else {
+							*claim
+						};
+						Some(OracleLinearRelation {
+							oracle,
+							transparent: Box::new(move |point: &[F]| {
+								let eq = eq_ind_partial_eval::<P>(point);
+								inner_product_buffers(&transparent, &eq)
+							}),
+							claim,
+						})
+					})
+					.collect::<Vec<_>>()
+			})
+			.collect();
+		verifier_channel
+			.verify_oracle_relations(relations)
+			.expect("verify_oracle_relations only queues");
+		verifier_channel.finish().is_ok()
+	}
+
+	#[test]
+	fn test_basefold_channel_two_claims_on_one_oracle() {
+		// The shape a composed protocol produces: one committed trace, opened at two points.
+		assert!(run_multi_claim_channel(&[(8, true, 2)], None));
+	}
+
+	#[test]
+	fn test_basefold_channel_multi_claim_mixed_arities() {
+		// Unequal claim counts and unequal sizes, so the grouping cannot rely on arrival order
+		// lining up with oracle index.
+		assert!(run_multi_claim_channel(&[(6, true, 3), (8, true, 1), (7, true, 2)], None));
+	}
+
+	#[test]
+	fn test_basefold_channel_multi_claim_mixed_zk() {
+		// A non-ZK oracle with several claims contributes no σ, while the ZK one contributes one σ
+		// against its *combined* transparent.
+		assert!(run_multi_claim_channel(&[(8, false, 2), (6, true, 2)], None));
+	}
+
+	#[test]
+	fn test_basefold_channel_multi_claim_rejects_tampered_first_claim() {
+		assert!(!run_multi_claim_channel(&[(8, true, 2)], Some((0, 0))));
+	}
+
+	#[test]
+	fn test_basefold_channel_multi_claim_rejects_tampered_later_claim() {
+		// The later claim is the one the batching challenge weights; corrupting it must be caught
+		// just as surely as the first.
+		assert!(!run_multi_claim_channel(
+			&[(6, true, 3), (8, true, 1), (7, true, 2)],
+			Some((0, 2))
+		));
+	}
+
+	#[test]
+	fn test_basefold_channel_multi_claim_rejects_tampered_non_zk_claim() {
+		assert!(!run_multi_claim_channel(&[(8, false, 2), (6, true, 2)], Some((0, 1))));
+	}
+
+	#[test]
+	#[should_panic(expected = "every committed oracle must appear in exactly one opening")]
+	fn test_basefold_channel_rejects_an_unopened_oracle() {
+		// Committing an oracle the batch never opens leaves it without an α, so the opening cannot
+		// be assembled. The prover says so rather than emitting a proof that cannot verify.
+		// The verifier asserts the mirror condition on its own relation list.
+		run_multi_claim_channel(&[(8, true, 1), (6, true, 0)], None);
 	}
 }

--- a/crates/iop-prover/src/channel/mod.rs
+++ b/crates/iop-prover/src/channel/mod.rs
@@ -10,6 +10,51 @@ use binius_iop::channel::OracleSpec;
 use binius_ip_prover::channel::IPProverChannel;
 use binius_math::{FieldSlice, FieldVec};
 
+/// One transparent multilinear paired with the inner product it is claimed to have.
+///
+/// The transparent multilinear is public data both parties can evaluate.
+/// The claim is the value the prover asserts for `<message, transparent>`.
+pub struct TransparentClaim<P: PackedField, A: Allocator> {
+	/// The transparent multilinear `t`, over the oracle's own variable count.
+	pub transparent: FieldVec<P, A>,
+	/// The claimed inner product `<pi, t>`.
+	pub claim: P::Scalar,
+}
+
+/// One committed oracle opened against one or more transparent multilinears.
+///
+/// A committed message may be claimed at several points in the same proof.
+/// Each point contributes one [`TransparentClaim`], and they open together.
+///
+/// The message is held once per oracle, not once per claim.
+/// So opening a large trace at several points never copies the trace.
+pub struct OracleOpening<O, P: PackedField, A: Allocator> {
+	/// The handle of the oracle being opened.
+	pub oracle: O,
+	/// The committed multilinear `pi`, the buffer this oracle was committed with.
+	pub message: FieldVec<P, A>,
+	/// The claims on this oracle, in the order the verifier queues them.
+	///
+	/// Must hold at least one claim.
+	pub claims: Vec<TransparentClaim<P, A>>,
+}
+
+impl<O, P: PackedField, A: Allocator> OracleOpening<O, P, A> {
+	/// An opening with a single claim, the common case.
+	pub fn single(
+		oracle: O,
+		message: FieldVec<P, A>,
+		transparent: FieldVec<P, A>,
+		claim: P::Scalar,
+	) -> Self {
+		Self {
+			oracle,
+			message,
+			claims: vec![TransparentClaim { transparent, claim }],
+		}
+	}
+}
+
 /// Channel for IOP provers that extends the IP prover channel with oracle operations.
 ///
 /// In an IOP, the prover can:
@@ -41,24 +86,28 @@ pub trait IOPProverChannel<P: PackedField, A: Allocator>: IPProverChannel<P::Sca
 
 	/// Generates opening proofs for all oracle linear relations.
 	///
-	/// Each item is `(oracle, message, transparent_poly, eval_claim)` where `message` is
-	/// the same buffer that was passed to `send_oracle()` for this oracle. Callers provide
-	/// the message here so the channel does not need to store it internally.
+	/// One [`OracleOpening`] carries a committed message and every transparent it opens against.
+	/// The caller supplies the message, so the channel never stores it.
 	///
-	/// The channel owns each message and transparent multilinear until the opening runs, so both
-	/// are drawn from the caller's allocator `A` — a pooled buffer stays pooled all the way
-	/// through the opening.
+	/// The channel owns each message and transparent until the opening runs.
+	/// Both are drawn from the caller's allocator `A`, so a pooled buffer stays pooled throughout.
+	///
+	/// The verifier queues a flat relation list and groups it by oracle.
+	/// Two orders must agree between the two sides:
+	///
+	/// ```text
+	/// across oracles  -> the order each oracle is first opened in
+	/// within one      -> the order of that oracle's claims
+	/// ```
 	///
 	/// # Preconditions
 	///
 	/// * `remaining_oracle_specs()` must be empty (all oracles committed).
-	/// * All oracle handles in `oracle_relations` must be valid handles returned by
-	///   `send_oracle()`.
+	/// * All oracle handles in `openings` must be valid handles returned by `send_oracle()`.
 	/// * Each `message` must match the buffer previously committed via `send_oracle()`.
+	/// * Every committed oracle must appear in exactly one opening, with at least one claim.
 	fn prove_oracle_relations(
 		&mut self,
-		oracle_relations: impl IntoIterator<
-			Item = (Self::Oracle, FieldVec<P, A>, FieldVec<P, A>, P::Scalar),
-		>,
+		openings: impl IntoIterator<Item = OracleOpening<Self::Oracle, P, A>>,
 	);
 }

--- a/crates/iop-prover/src/channel/naive.rs
+++ b/crates/iop-prover/src/channel/naive.rs
@@ -6,13 +6,13 @@ use binius_compute::GlobalAllocator;
 use binius_field::{Field, PackedField};
 use binius_iop::channel::OracleSpec;
 use binius_ip_prover::channel::IPProverChannel;
-use binius_math::{FieldBuffer, FieldSlice, inner_product::inner_product_buffers};
+use binius_math::{FieldSlice, inner_product::inner_product_buffers};
 use binius_transcript::{
 	ProverTranscript,
 	fiat_shamir::{CanSample, Challenger},
 };
 
-use crate::channel::IOPProverChannel;
+use crate::channel::{IOPProverChannel, OracleOpening, TransparentClaim};
 
 /// Oracle handle returned by [`NaiveProverChannel::send_oracle`].
 #[derive(Debug, Clone, Copy)]
@@ -154,13 +154,19 @@ where
 
 	fn prove_oracle_relations(
 		&mut self,
-		oracle_relations: impl IntoIterator<
-			Item = (Self::Oracle, FieldBuffer<P>, FieldBuffer<P>, P::Scalar),
-		>,
+		openings: impl IntoIterator<Item = OracleOpening<Self::Oracle, P, GlobalAllocator>>,
 	) {
 		// For the naive channel, we write the transparent polynomial to the transcript
 		// so the verifier can read it and verify the inner product directly.
-		for (oracle, message, transparent_poly, eval_claim) in oracle_relations {
+		//
+		// Each claim is written on its own, in the order the verifier queues its relations.
+		// So this channel needs no batching challenge.
+		for OracleOpening {
+			oracle,
+			message,
+			claims,
+		} in openings
+		{
 			let index = oracle.index;
 			assert!(index < self.n_committed, "oracle index {index} out of bounds");
 
@@ -172,20 +178,22 @@ where
 				message.log_len()
 			);
 
-			// Write the transparent polynomial to the transcript
-			self.transcript
-				.message()
-				.write_scalar_iter(transparent_poly.iter_scalars());
+			for TransparentClaim { transparent, claim } in claims {
+				// Write the transparent polynomial to the transcript
+				self.transcript
+					.message()
+					.write_scalar_iter(transparent.iter_scalars());
 
-			// Sample evaluation point challenges (verifier will sample the same)
-			let _point: Vec<F> = CanSample::sample_vec(&mut self.transcript, log_msg_len);
+				// Sample evaluation point challenges (verifier will sample the same)
+				let _point: Vec<F> = CanSample::sample_vec(&mut self.transcript, log_msg_len);
 
-			// Debug assertion: prover should provide consistent eval claims
-			let actual_eval: F = inner_product_buffers(&message, &transparent_poly);
-			debug_assert_eq!(
-				actual_eval, eval_claim,
-				"NaiveProverChannel: eval_claim mismatch for oracle {index}"
-			);
+				// Debug assertion: prover should provide consistent eval claims
+				let actual_eval: F = inner_product_buffers(&message, &transparent);
+				debug_assert_eq!(
+					actual_eval, claim,
+					"NaiveProverChannel: eval_claim mismatch for oracle {index}"
+				);
+			}
 		}
 	}
 }

--- a/crates/iop-prover/src/logup_star.rs
+++ b/crates/iop-prover/src/logup_star.rs
@@ -20,7 +20,7 @@ use binius_math::{
 	FieldSlice, multilinear::eq::eq_ind_partial_eval_in, univariate::evaluate_univariate,
 };
 
-use crate::channel::IOPProverChannel;
+use crate::channel::{IOPProverChannel, OracleOpening};
 
 /// The reduced claims of a committed logUp* proof.
 ///
@@ -113,7 +113,7 @@ where
 	//     <Y, eq_r'> = Y(r') = pushforward_eval_claim
 	let _open_guard = tracing::debug_span!("Open pushforward relation").entered();
 	let transparent = eq_ind_partial_eval_in::<A, P>(alloc, &output.table_eval_point);
-	channel.prove_oracle_relations([(
+	channel.prove_oracle_relations([OracleOpening::single(
 		oracle,
 		pushforward,
 		transparent,

--- a/crates/iop/src/basefold/channel.rs
+++ b/crates/iop/src/basefold/channel.rs
@@ -83,13 +83,18 @@ where
 	/// Consumes the channel and verifies the single combined opening over **all** committed
 	/// oracles.
 	///
-	/// All oracle relations queued by
-	/// [`verify_oracle_relations`](IOPVerifierChannel::verify_oracle_relations) across every call
-	/// are processed here in one batch: masking, one batched sumcheck reducing the masked claims
-	/// to a shared point `r`, then one combined FRI opening over every committed oracle
-	/// (in oracle-index order). Because the whole opening is deferred to this point, every oracle
-	/// is committed and there is a single sumcheck point, so the precomputed combined `FRIParams`
-	/// (`optimal_for_batch` over all oracle specs) serves the opening.
+	/// Opens every queued relation in one batch:
+	///
+	/// ```text
+	/// 1. batch each oracle's claims into one relation
+	/// 2. mask the ZK oracles' claims
+	/// 3. one batched sumcheck reduces them to a shared point `r`
+	/// 4. one combined FRI opens every oracle, in oracle-index order
+	/// ```
+	///
+	/// Relations reach the queue through [`IOPVerifierChannel::verify_oracle_relations`].
+	/// Deferring the whole opening to here is what makes step 3 a single sumcheck.
+	/// So the combined `FRIParams` precomputed over every oracle spec serves it.
 	///
 	/// Returns the Merkle channel, so a caller can still reach what it accumulated.
 	pub fn finish(self) -> Result<Channel, Error> {
@@ -127,15 +132,21 @@ where
 /// point `r`, then opens all committed oracles together with a single combined FRI over the
 /// piecewise-concatenated oracle.
 ///
-/// The masking inner products and the batched sumcheck process the `relations` in arrival order (so
-/// each reduced eval lines up with its batched-claim coefficient), while the per-oracle evaluations
-/// α_i are indexed by oracle index. Each relation carries its oracle's index, so the two orders are
-/// reconciled by indexing rather than by sorting the relations; `oracle_specs` and
-/// `oracle_commitments` are indexed by oracle index.
+/// One queued relation opens one oracle against one transparent multilinear.
+/// An oracle claimed at several points therefore arrives as several relations.
+/// [`combine_relations_per_oracle`] batches those into one relation per oracle first.
+/// So everything below sees exactly one relation per committed oracle.
 ///
-/// Phase B collapses the oracle-index variables up front at sampled batching challenges `r'`: the
-/// combined target is `s' = Σ_i e[i]·α_i·∏_{j≥n_i}(1 - r_j)` with `e = eq_ind_partial_eval(r')`,
-/// and the single combined FRI (`fri_params`) opens all `k` committed `[π_i ‖ ω_i]` codewords.
+/// Two orders meet here, and each relation's oracle index reconciles them:
+///
+/// ```text
+/// arrival order    -> the masking σ_i and the batched sumcheck's claims
+/// oracle index     -> α_i, `oracle_specs`, `oracle_commitments`
+/// ```
+///
+/// Phase B collapses the oracle-index variables at sampled batching challenges `r'`.
+/// The combined target is `s' = Σ_i e[i]·α_i·∏_{j≥n_i}(1 - r_j)` for `e = eq_ind_partial_eval(r')`.
+/// One combined FRI then opens all `k` committed `[π_i ‖ ω_i]` codewords.
 fn verify_batch_zk_basefold<F, Channel>(
 	channel: &mut Channel,
 	oracle_specs: &[OracleSpec],
@@ -148,6 +159,10 @@ where
 	Channel: MerkleIPVerifierChannel<F, Elem = F>,
 {
 	let n_committed = oracle_commitments.len();
+
+	// Batch each oracle's claims into one relation, before σ: a σ below is an inner product
+	// against the *combined* transparent.
+	let relations = combine_relations_per_oracle(relations, n_committed, channel);
 
 	// `𝐧 = max_i log_msg_len_i`, the variable count of the combined opening / materialized buffer.
 	let max_n = oracle_specs
@@ -242,6 +257,92 @@ where
 	)?;
 
 	Ok(())
+}
+
+/// Batches the queued relations into exactly one relation per committed oracle.
+///
+/// One committed message may be opened at several points.
+/// Those arrive as several relations naming the same oracle.
+/// A sampled `lambda` batches their claims into one:
+///
+/// ```text
+/// T_i = sum_j lambda_i^j * t_j     the combined transparent
+/// S_i = sum_j lambda_i^j * s_j     the combined claim
+/// ```
+///
+/// The inner product is linear in the transparent.
+/// So `<pi_i, T_i> = S_i` holds exactly when every `<pi_i, t_j> = s_j` does.
+/// A cheating prover survives with probability at most `(n_claims - 1) / |F|`.
+///
+/// An oracle with one claim samples no `lambda` and passes through untouched.
+/// So a batch of single-claim relations leaves the transcript as if this step did not exist.
+///
+/// The returned relations follow the order the oracles were *first* queued in.
+/// That is not ascending oracle index; the prover groups its openings the same way.
+///
+/// # Panics
+///
+/// Panics unless every committed oracle carries at least one relation.
+/// These relations are the verifier's own, not the prover's.
+/// So a mismatch is a bug in the calling protocol, never a malformed proof.
+fn combine_relations_per_oracle<F, Channel>(
+	relations: Vec<OracleLinearRelation<BaseFoldOracle, F>>,
+	n_committed: usize,
+	channel: &mut Channel,
+) -> Vec<OracleLinearRelation<BaseFoldOracle, F>>
+where
+	F: BinaryField,
+	Channel: MerkleIPVerifierChannel<F, Elem = F>,
+{
+	// Bucket the relations by oracle, recording the order the oracles first appear in.
+	let mut groups: Vec<(BaseFoldOracle, Vec<OracleLinearRelation<BaseFoldOracle, F>>)> =
+		Vec::new();
+	let mut group_of_oracle = vec![None; n_committed];
+	for relation in relations {
+		let index = relation.oracle.index;
+		let group = *group_of_oracle[index].get_or_insert_with(|| {
+			groups.push((relation.oracle, Vec::new()));
+			groups.len() - 1
+		});
+		groups[group].1.push(relation);
+	}
+
+	assert_eq!(
+		groups.len(),
+		n_committed,
+		"every committed oracle must carry at least one relation"
+	);
+
+	groups
+		.into_iter()
+		.map(|(oracle, mut group)| {
+			// A single claim is already the combined claim; batching it would only add a challenge.
+			if group.len() == 1 {
+				return group.pop().expect("the group holds one relation");
+			}
+
+			// SOUNDNESS: `lambda` is drawn after the claims are bound to the transcript, so the
+			// prover cannot choose a claim as a function of it.
+			let lambda = channel.sample();
+
+			let (transparents, claims): (Vec<_>, Vec<_>) = group
+				.into_iter()
+				.map(|relation| (relation.transparent, relation.claim))
+				.unzip();
+
+			OracleLinearRelation {
+				oracle,
+				transparent: Box::new(move |point: &[F]| {
+					let evals = transparents
+						.iter()
+						.map(|transparent| transparent(point))
+						.collect::<Vec<_>>();
+					evaluate_univariate(&evals, &lambda)
+				}),
+				claim: evaluate_univariate(&claims, &lambda),
+			}
+		})
+		.collect()
 }
 
 impl<F, Channel> IPVerifierChannel<F> for BaseFoldVerifierChannel<'_, F, Channel>

--- a/crates/m4-prover/src/prove.rs
+++ b/crates/m4-prover/src/prove.rs
@@ -5,7 +5,10 @@ use binius_compute::{Allocator, BufferPool, VecLike};
 use binius_core::{constraint_system::ConstraintSystem, word::Word};
 use binius_field::{AESTowerField8b as B8, Field, PackedField};
 use binius_hash::StdHashSuite;
-use binius_iop_prover::{basefold::compiler::BaseFoldProverCompiler, channel::IOPProverChannel};
+use binius_iop_prover::{
+	basefold::compiler::BaseFoldProverCompiler,
+	channel::{IOPProverChannel, OracleOpening},
+};
 use binius_ip_prover::sumcheck::{
 	MleToSumCheckEvaluator,
 	batch::batch_prove_and_write_evals,
@@ -346,7 +349,12 @@ impl IOPProver {
 
 		// Queue the trace opening against the ring-switch's transparent multilinear.
 		// The final call runs the single combined FRI opening and writes it to the transcript.
-		channel.prove_oracle_relations([(trace_oracle, trace_packed, rs_eq_ind, sumcheck_claim)]);
+		channel.prove_oracle_relations([OracleOpening::single(
+			trace_oracle,
+			trace_packed,
+			rs_eq_ind,
+			sumcheck_claim,
+		)]);
 	}
 }
 

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -10,7 +10,10 @@ use binius_core::{
 };
 use binius_field::{AESTowerField8b as B8, Field, PackedField};
 use binius_hash::binary_merkle_tree::HashSuite;
-use binius_iop_prover::{basefold::compiler::BaseFoldProverCompiler, channel::IOPProverChannel};
+use binius_iop_prover::{
+	basefold::compiler::BaseFoldProverCompiler,
+	channel::{IOPProverChannel, OracleOpening},
+};
 use binius_ip::sumcheck::SumcheckOutput;
 use binius_math::{
 	BinarySubspace, FieldBuffer, FieldVec,
@@ -332,7 +335,12 @@ impl IOPProver {
 
 		// Prove oracle relations via channel (runs BaseFold internally). The intmul pushforward
 		// relation, when the IntMul reduction ran, was already queued inside phase 5.
-		channel.prove_oracle_relations([(trace_oracle, witness_packed, rs_eq_ind, sumcheck_claim)]);
+		channel.prove_oracle_relations([OracleOpening::single(
+			trace_oracle,
+			witness_packed,
+			rs_eq_ind,
+			sumcheck_claim,
+		)]);
 
 		drop(pcs_guard);
 

--- a/crates/spartan-prover/src/lib.rs
+++ b/crates/spartan-prover/src/lib.rs
@@ -40,7 +40,10 @@ use std::{
 use binius_compute::{Allocator, BufferPool, VecLike};
 use binius_field::{BinaryField, Field, PackedField};
 use binius_hash::binary_merkle_tree::HashSuite;
-use binius_iop_prover::{basefold::compiler::BaseFoldProverCompiler, channel::IOPProverChannel};
+use binius_iop_prover::{
+	basefold::compiler::BaseFoldProverCompiler,
+	channel::{IOPProverChannel, OracleOpening},
+};
 use binius_ip_prover::{
 	channel::IPProverChannel,
 	sumcheck::{quadratic_mlecheck_prover, zk_mlecheck},
@@ -319,9 +322,19 @@ impl<F: Field> IOPProver<F> {
 
 		// Prove all oracle relations.
 		channel.prove_oracle_relations([
-			(precommit_oracle, precommit_packed, precommit_wiring_poly, precommit_claim),
-			(private_oracle, private_packed, private_wiring_poly, private_claim),
-			(mask_oracle, masks_buffer, libra_eval_tensor, mask_eval),
+			OracleOpening::single(
+				precommit_oracle,
+				precommit_packed,
+				precommit_wiring_poly,
+				precommit_claim,
+			),
+			OracleOpening::single(
+				private_oracle,
+				private_packed,
+				private_wiring_poly,
+				private_claim,
+			),
+			OracleOpening::single(mask_oracle, masks_buffer, libra_eval_tensor, mask_eval),
 		]);
 
 		Ok(())

--- a/crates/spartan-prover/src/wiring.rs
+++ b/crates/spartan-prover/src/wiring.rs
@@ -420,7 +420,9 @@ mod tests {
 		use binius_iop::channel::{
 			IOPVerifierChannel, OracleLinearRelation, OracleSpec, naive::NaiveVerifierChannel,
 		};
-		use binius_iop_prover::channel::{IOPProverChannel, naive::NaiveProverChannel};
+		use binius_iop_prover::channel::{
+			IOPProverChannel, OracleOpening, naive::NaiveProverChannel,
+		};
 		use binius_ip::channel::IPVerifierChannel;
 		use binius_ip_prover::channel::IPProverChannel;
 		use binius_math::{inner_product::inner_product_buffers, test_utils::random_field_buffer};
@@ -504,7 +506,7 @@ mod tests {
 		);
 
 		// Finish the IOP with the oracle relation
-		prover_channel.prove_oracle_relations([(
+		prover_channel.prove_oracle_relations([OracleOpening::single(
 			witness_oracle,
 			private_buf,
 			wiring_poly.clone(),

--- a/crates/spartan-prover/src/wrapper/zk_wrapped_prover_channel.rs
+++ b/crates/spartan-prover/src/wrapper/zk_wrapped_prover_channel.rs
@@ -18,7 +18,7 @@ use binius_field::{BinaryField, PackedField};
 use binius_iop::channel::OracleSpec;
 use binius_iop_prover::{
 	basefold::channel::{BaseFoldOracle, BaseFoldProverChannel},
-	channel::IOPProverChannel,
+	channel::{IOPProverChannel, OracleOpening},
 	merkle_channel::MerkleIPProverChannel,
 };
 use binius_ip_prover::channel::IPProverChannel;
@@ -290,20 +290,20 @@ where
 
 	fn prove_oracle_relations(
 		&mut self,
-		oracle_relations: impl IntoIterator<
-			Item = (Self::Oracle, FieldVec<P, A>, FieldVec<P, A>, P::Scalar),
-		>,
+		openings: impl IntoIterator<Item = OracleOpening<Self::Oracle, P, A>>,
 	) {
-		let oracle_relations = oracle_relations.into_iter().collect::<Vec<_>>();
+		let openings = openings.into_iter().collect::<Vec<_>>();
 
 		// For each oracle opening, the prover sends the decrypted evaluation. The outer verifier
 		// checks in the circuit equality of this value with the expected expression over encrypted
 		// values.
-		for (_, _, _, claim) in &oracle_relations {
-			self.inner_channel.send_one(*claim);
-			self.interaction.push(*claim);
+		//
+		// An oracle opened at several points sends one evaluation per claim, in claim order.
+		for claim in openings.iter().flat_map(|opening| &opening.claims) {
+			self.inner_channel.send_one(claim.claim);
+			self.interaction.push(claim.claim);
 		}
 
-		self.inner_channel.prove_oracle_relations(oracle_relations)
+		self.inner_channel.prove_oracle_relations(openings)
 	}
 }


### PR DESCRIPTION
@jimpo First step for being able to use M4 in Binius64, not sure if this is the approach you wanted to take, just a first item here, I've others in the pipeline on top.

Closes [BINIUS-409](https://linear.app/jimpo/issue/BINIUS-409).

Lets one committed oracle be opened at several points in the same batched BaseFold opening.
Single-claim batches produce byte-identical proofs — no protocol change for anything that exists today.

### The problem

The batched opening assumes exactly one relation per committed oracle.
The prover asserts it outright, with a `TODO` to remove the limitation.

A relation also carries the committed message it opens.
So a second claim on the same oracle means handing the channel a second copy of that message.
For a trace-sized oracle that is a full extra copy of the trace, per claim.

This blocks the chip architecture directly.
There, one trace commitment holds the main circuit's words and every chip's block.
The main reduction and each chip reduction each end with their own evaluation claim on that one commitment.

### A latent inconsistency in the masking

The two sides count the zero-knowledge masking values differently:

- the prover sends one `sigma` per ZK **relation**
- the verifier reads one `sigma` per ZK **oracle**

Those agree only while the one-relation-per-oracle assert holds, which is why nothing is broken today.
Lifting the assert without addressing this would desynchronise the transcript.

### The idea

Batch each oracle's claims into one before the opening runs, using a sampled `lambda`:

```
T_i = sum_j lambda_i^j * t_j     the combined transparent
S_i = sum_j lambda_i^j * s_j     the combined claim
```

The inner product is linear in the transparent.
So `<pi_i, T_i> = S_i` holds exactly when every `<pi_i, t_j> = s_j` does.

Everything downstream then sees one relation per committed oracle, exactly as today.
The `sigma` accounting stays per-oracle and becomes correct by construction rather than by assumption.

This is also cheaper than making the masking per-relation.
Batching first costs one sumcheck per oracle; masking per-relation would cost one per claim.

### The change

The prover-side item carries one message per oracle with a list of claims:

```diff
- (oracle, message, transparent, claim)
+ OracleOpening { oracle, message, claims: [(transparent, claim), ...] }
```

The verifier keeps its flat relation list and groups it by oracle inside the channel.
Groups follow first-arrival order, not ascending oracle index, so existing transcripts do not move.

`lambda` is drawn only when an oracle carries more than one claim, and always before `sigma`.
A `sigma` is an inner product against the **combined** transparent, so that order is load-bearing.

### Soundness

The batching is a random linear combination of inner-product claims on one message.
A prover holding a wrong claim survives with probability at most $(k - 1) / |F|$ for $k$ claims.

`lambda` is drawn after every claim is already bound to the transcript.
So no claim can be chosen as a function of it.

An oracle with a single claim draws no challenge at all.
So the existing protocol is left exactly as it is.

### Scope

- **changed:** the verifier channel in `binius-iop`; the channel trait, BaseFold channel and naive channel in `binius-iop-prover`
- **changed:** six call sites across `binius-prover`, `binius-m4-prover` and `binius-spartan-prover`, each a one-line switch to `OracleOpening::single`
- **removed:** the `TODO` and the one-relation-per-oracle assert it guarded
- **untouched:** the masking, sumcheck and FRI stages, which still see one relation per oracle

### Verification

- `cargo check --workspace --all-targets` — clean
- `clippy` on the five touched crates with `-D warnings` — clean
- nightly `fmt --all --check` — clean
- `binius-iop-prover`, `binius-iop`, `binius-prover`, `binius-m4-prover`, `binius-spartan-prover` test suites pass

Seven new channel tests cover the new capability: two claims on one oracle, mixed claim counts with the verifier queueing relations interleaved across oracles, a mixed ZK/non-ZK batch, tampered claims in first, later and non-ZK positions, and a committed oracle left unopened.

**Regression check:** the `sha256` example's proof is byte-identical to `main` (same SHA-256 digest), confirming single-claim batches draw no extra challenge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)