### PR TITLE
BINIUS-411: let the logUp* lookers have different column lengths

### DIFF
--- a/crates/ip-prover/src/logup_star/prove.rs
+++ b/crates/ip-prover/src/logup_star/prove.rs
@@ -2,6 +2,8 @@
 
 //! The top-level logUp* proving routine.
 
+use std::iter;
+
 use binius_compute::Allocator;
 use binius_field::{BinaryField, Divisible, Field, PackedField};
 use binius_ip::{MultilinearEvalClaim, fracaddcheck::unpad_leaf_claim, logup_star::LogupOutput};
@@ -26,10 +28,10 @@ use crate::{
 /// sharing the table. The lookers batch by a random linear combination: a challenge `gamma`
 /// scales looker `j`'s equality-indicator numerator by `gamma^j`, and the pushforward is the
 /// gamma-weighted sum of the per-looker pushforwards, still with only `2^m` entries. The
-/// looked-up vectors are never committed. Every fractional-addition circuit — the lookers' over
-/// `n` variables and the table's over `m` — is an instance of one GKR of
-/// `ceil(log2(#lookers + 1)) + max(n, m)` layers, with the shallower side padded by zero
-/// fractions.
+/// looked-up vectors are never committed. Every fractional-addition circuit — looker `j`'s over
+/// `n_j` variables and the table's over `m` — is an instance of one GKR of
+/// `ceil(log2(#lookers + 1)) + max(max_j n_j, m)` layers, with every shallower instance padded by
+/// zero fractions. The lookers need not agree on a length.
 /// See [Soukhanov25] for the construction.
 ///
 /// [Soukhanov25]: <https://eprint.iacr.org/2025/946>
@@ -37,9 +39,8 @@ use crate::{
 /// # Arguments
 ///
 /// * `table` - The table multilinear `T` over `m` variables (`2^m` entries).
-/// * `lookers` - The looker columns and claims; every evaluation point must have the same length
-///   `n`, every index column must have `2^n` entries, and every index entry must be less than
-///   `2^m`.
+/// * `lookers` - The looker columns and claims; evaluation points may differ in length, looker
+///   `j`'s index column must have `2^n_j` entries, and every index entry must be less than `2^m`.
 /// * `channel` - The prover channel for sending messages and sampling challenges.
 ///
 /// The logUp challenge `c` is sampled against the committed `I_j`, `T`, and pushforward `Y`.
@@ -52,8 +53,9 @@ use crate::{
 ///
 /// # Returns
 ///
-/// The reduced claims on the table, the pushforward, and the per-looker index multilinears, all
-/// index claims sharing one evaluation point.
+/// The reduced claims on the table, the pushforward, and the per-looker index multilinears. The
+/// index claims are drawn from one point spanning the deepest looker; looker `j` is claimed at its
+/// last `n_j` coordinates.
 /// The caller verifies those claims, which is out of scope here.
 /// One looker's column and claim: `(I^* T)(eval_point) = eval_claim` against the shared table.
 pub struct Looker<'a, F> {
@@ -140,8 +142,8 @@ where
 /// # Preconditions
 ///
 /// - `table.log_len()` is at least 1.
-/// - `numerators` has one `n`-variable buffer per looker; every index column has `2^n` entries,
-///   with every entry less than the table size.
+/// - `numerators` has one `n_j`-variable buffer per looker; looker `j`'s index column has `2^n_j`
+///   entries, with every entry less than the table size.
 /// - `pushforward` equals the scatter of the numerators.
 #[tracing::instrument(
 	skip_all,
@@ -164,7 +166,6 @@ where
 	P: PackedField<Scalar = F>,
 {
 	let m = table.log_len();
-	let n = lookers[0].eval_point.len();
 	// One batch instance per looker, plus the table.
 	let k = log2_ceil_usize(lookers.len() + 1);
 
@@ -176,7 +177,7 @@ where
 	// Build the fractional-addition circuits, one per looker plus the table side. Constructing a
 	// circuit computes every layer and returns its single root fraction.
 	//
-	//     looker j: gamma^j * eq_{r_j}(i) / (c - I_j(i))   over n variables
+	//     looker j: gamma^j * eq_{r_j}(i) / (c - I_j(i))   over n_j variables
 	//     table:    Y(v)                  / (c - v)         over m variables
 	let circuits_guard = tracing::debug_span!("Build fracadd circuits").entered();
 	// The circuits are independent, so they build in parallel across lookers.
@@ -185,7 +186,9 @@ where
 		.into_par_iter()
 		.map(|(looker, numerator)| {
 			let den = witness::looker_denominator::<A, F, P>(alloc, c, looker.index);
-			let (prover, root) = FracAddCheckProver::new(n, alloc, (numerator, den));
+			// Lookers may differ in length, so each circuit is built at its own depth.
+			let (prover, root) =
+				FracAddCheckProver::new(looker.eval_point.len(), alloc, (numerator, den));
 			(prover, (root.0.get(0), root.1.get(0)))
 		})
 		.unzip();
@@ -255,15 +258,20 @@ where
 	// The per-looker leaf denominators are c - I_j(content), so the index claims are their
 	// c-complements. The numerators are the transparent scaled equality indicators, which the
 	// verifier evaluates itself.
-	let looker_leaves = looker_fractions
-		.iter()
-		.map(|&fraction| unpad_leaf_claim(fraction, node_point, n_layers - n))
+	let looker_leaves = iter::zip(looker_fractions, lookers)
+		.map(|(&fraction, looker)| {
+			unpad_leaf_claim(fraction, node_point, n_layers - looker.eval_point.len())
+		})
 		.collect::<Vec<_>>();
-	let index_eval_point = looker_leaves
-		.first()
-		.expect("at least one looker")
-		.point
-		.clone();
+	// Every looker's claim is a suffix of the deepest looker's point, so that one carries them all:
+	// looker j's is its last n_j coordinates. The node point can run deeper still when the table is
+	// the deepest instance, and those extra coordinates belong to the table alone.
+	let max_n = lookers
+		.iter()
+		.map(|looker| looker.eval_point.len())
+		.max()
+		.expect("lookers is non-empty");
+	let index_eval_point = node_point[n_layers - max_n..].to_vec();
 	let index_eval_claims = looker_leaves
 		.iter()
 		.map(|leaf| c - leaf.den_eval)
@@ -555,6 +563,97 @@ mod tests {
 			let embedded = index.iter().map(|&j| iota(j, m)).collect::<Vec<_>>();
 			let embedded = FieldBuffer::<P>::from_values(&embedded);
 			assert_eq!(*claim, evaluate(&embedded, &prover_out.index_eval_point));
+		}
+	}
+
+	#[test]
+	fn test_lookers_of_unequal_length() {
+		// Lookers need not agree on a column length: each is its own instance in the batch, padded
+		// up to the deepest one. The spread puts the table both above and below the deepest looker,
+		// and repeats a length so the shared-depth path is exercised alongside the mixed one.
+		for (looker_n_vars, m) in [
+			(vec![5usize, 2, 4], 3usize),
+			(vec![2, 6], 2),
+			(vec![1, 1, 5], 4),
+			(vec![3, 3], 5),
+			(vec![0, 4], 3),
+		] {
+			check_unequal_lookers(&looker_n_vars, m);
+		}
+	}
+
+	fn check_unequal_lookers(looker_n_vars: &[usize], m: usize) {
+		let mut rng = StdRng::seed_from_u64(17);
+		let alloc = GlobalAllocator;
+
+		// One shared table; each looker draws its own index column at its own length.
+		let table = random_field_buffer::<P>(&mut rng, m);
+		let instances = looker_n_vars
+			.iter()
+			.map(|&n| {
+				let index = (0..(1usize << n))
+					.map(|_| rng.random_range(0..(1usize << m)))
+					.collect::<Vec<_>>();
+				let eval_point = random_scalars::<F>(&mut rng, n);
+				let eq_r = eq_ind_partial_eval_scalars::<F>(&eval_point);
+				let eval_claim = index
+					.iter()
+					.zip(&eq_r)
+					.map(|(&j, &eq)| eq * table.get(j))
+					.fold(F::ZERO, |acc, t| acc + t);
+				(index, eval_point, eval_claim)
+			})
+			.collect::<Vec<_>>();
+
+		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
+		let prover_lookers = instances
+			.iter()
+			.map(|(index, eval_point, eval_claim)| Looker {
+				index,
+				eval_point,
+				eval_claim: *eval_claim,
+			})
+			.collect::<Vec<_>>();
+		let prover_out = prove::<GlobalAllocator, F, P>(
+			&alloc,
+			table.to_ref(),
+			&prover_lookers,
+			&mut prover_transcript,
+		);
+
+		let mut verifier_transcript = prover_transcript.into_verifier();
+		let looker_claims = instances
+			.iter()
+			.map(|(_, eval_point, eval_claim)| logup_star::LookerClaim {
+				eval_point,
+				eval_claim: *eval_claim,
+			})
+			.collect::<Vec<_>>();
+		let gamma = IPVerifierChannel::<F>::sample(&mut verifier_transcript);
+		let verifier_out = logup_star::verify_reduction::<F, _>(
+			&gamma,
+			m,
+			&looker_claims,
+			&mut verifier_transcript,
+		)
+		.expect("verification succeeds");
+		assert_eq!(prover_out, verifier_out, "outputs disagree ({looker_n_vars:?}, m={m})");
+
+		assert_eq!(prover_out.table_eval_claim, evaluate(&table, &prover_out.table_eval_point));
+
+		// The index point spans the deepest instance; looker j's claim is at its last n_j
+		// coordinates, so a shorter looker reads a suffix of it.
+		let point = &prover_out.index_eval_point;
+		for ((index, eval_point, _), claim) in instances.iter().zip(&prover_out.index_eval_claims) {
+			let embedded = index.iter().map(|&j| iota(j, m)).collect::<Vec<_>>();
+			let embedded = FieldBuffer::<P>::from_values(&embedded);
+			let own_point = &point[point.len() - eval_point.len()..];
+			assert_eq!(
+				*claim,
+				evaluate(&embedded, own_point),
+				"index claim wrong for n={} ({looker_n_vars:?}, m={m})",
+				eval_point.len()
+			);
 		}
 	}
 

--- a/crates/ip-prover/src/logup_star/witness.rs
+++ b/crates/ip-prover/src/logup_star/witness.rs
@@ -57,7 +57,6 @@ where
 	P: PackedField<Scalar = F>,
 {
 	assert!(!lookers.is_empty(), "at least one looker is required");
-	let n = lookers[0].eval_point.len();
 
 	// The scale for looker j is gamma^j.
 	// The powers chain is sequential: each power depends on the last.
@@ -66,24 +65,24 @@ where
 
 	// Build one numerator per looker, fanned out across lookers.
 	// Why fan out: the per-looker expansion is itself parallel.
-	//   But it under-saturates the machine at moderate n.
+	//   But it under-saturates the machine at moderate n_j.
 	//   Spreading the lookers over the cores fills them.
-	// The 2^n backing buffers are drawn from `alloc` up front on this thread, so the parallel
-	// region only fills them — no allocator traffic inside the rayon closures.
+	// The 2^n_j backing buffers are drawn from `alloc` up front on this thread, so the parallel
+	// region only fills them — no allocator traffic inside the rayon closures. Lookers may differ
+	// in length, so each buffer is sized to its own looker.
 	// Invariant: the fill writes results back in looker order (the zip is index-aligned).
 	//   So numerator j stays gamma^j * eq_{r_j}.
-	let packed_len = 1 << n.saturating_sub(P::LOG_WIDTH);
-	let buffers = iter::repeat_with(|| alloc.alloc::<P>(packed_len))
-		.take(lookers.len())
+	let buffers = lookers
+		.iter()
+		.map(|looker| {
+			let packed_len = 1 << looker.eval_point.len().saturating_sub(P::LOG_WIDTH);
+			alloc.alloc::<P>(packed_len)
+		})
 		.collect::<Vec<_>>();
 	let numerators = (buffers, scales.as_slice(), lookers)
 		.into_par_iter()
 		.map(|(buffer, &scale, looker)| {
-			assert_eq!(
-				looker.eval_point.len(),
-				n,
-				"every looker evaluation point must have the same length"
-			);
+			let n = looker.eval_point.len();
 			assert_eq!(
 				looker.index.len(),
 				1 << n,
@@ -93,7 +92,7 @@ where
 			);
 			// Looker j's numerator is gamma^j * eq_{r_j}.
 			// Seeding the expansion with gamma^j folds the scale into the tensor product.
-			// That keeps it to one pass over one 2^n buffer.
+			// That keeps it to one pass over one 2^n_j buffer.
 			scaled_eq_ind_partial_eval_into(looker.eval_point, scale, buffer)
 		})
 		.collect::<Vec<_>>();

--- a/crates/ip/src/logup_star/output.rs
+++ b/crates/ip/src/logup_star/output.rs
@@ -14,8 +14,13 @@ pub struct LogupOutput<F> {
 	pub table_eval_claim: F,
 	/// The claimed evaluation of the pushforward multilinear `Y` at the table point.
 	pub pushforward_eval_claim: F,
-	/// The `n`-coordinate point shared by the index evaluation claims.
+	/// The point the index evaluation claims are drawn from, of `max_j n_j` coordinates.
+	///
+	/// Looker `j`, whose column has `n_j` variables, is claimed at the **last `n_j`** coordinates.
+	/// Lookers of equal length therefore all share the whole point; a shorter looker's point is a
+	/// suffix of a longer one's, because the batch pads each instance at its low coordinates.
 	pub index_eval_point: Vec<F>,
-	/// The claimed evaluations of the per-looker index multilinears `I_j` at the index point.
+	/// The claimed evaluations of the per-looker index multilinears `I_j`, each at its own suffix
+	/// of [`Self::index_eval_point`].
 	pub index_eval_claims: Vec<F>,
 }

--- a/crates/ip/src/logup_star/verify.rs
+++ b/crates/ip/src/logup_star/verify.rs
@@ -2,7 +2,7 @@
 
 //! The top-level logUp* verification routine.
 
-use std::iter;
+use std::{iter, slice};
 
 use binius_field::{BinaryField1b, ExtensionField, Field, field::FieldOps, util::powers};
 use binius_math::{
@@ -39,12 +39,16 @@ pub struct LookerClaim<'a, Elem> {
 /// `gamma^j`, the pushforward is the gamma-weighted sum of the per-looker pushforwards, and the
 /// product check binds `<T, Y>` to the gamma-combination of the claims.
 ///
-/// Every fractional-addition circuit — one per looker over `n` variables, plus the table's over
-/// `m` — is an instance of **one** GKR of `k + max(n, m)` layers, where
-/// `k = ceil(log2(#lookers + 1))`. Its top `k` layers add the per-instance root fractions
-/// together and its lower `max(n, m)` run the instances in a batch, with the shallower side padded
-/// by zero fractions — that leaves a fractional sum unchanged and costs `O(1)` per round, so the
-/// layer count depends only on the deeper side.
+/// Every fractional-addition circuit — one per looker `j` over `n_j` variables, plus the table's
+/// over `m` — is an instance of **one** GKR of `k + max(max_j n_j, m)` layers, where
+/// `k = ceil(log2(#lookers + 1))`. Its top `k` layers add the per-instance root fractions together
+/// and its lower `max(max_j n_j, m)` run the instances in a batch, with every shallower instance
+/// padded by zero fractions — that leaves a fractional sum unchanged and costs `O(1)` per round,
+/// so the layer count depends only on the deepest instance.
+///
+/// The lookers need not agree on a length: a looker over `n_j` variables is simply padded by
+/// `max(max_j n_j, m) - n_j`, and its reduced index claim lands on the **last `n_j`** coordinates
+/// of [`LogupOutput::index_eval_point`].
 ///
 /// The table's fraction enters that sum negated, so the circuit's root is
 /// `sum_j num_j/den_j - num_r/den_r`, whose numerator vanishes exactly when the lookup identity
@@ -61,7 +65,7 @@ pub struct LookerClaim<'a, Elem> {
 ///
 /// * `gamma` - The looker batching challenge, sampled by the caller.
 /// * `table_n_vars` - The number of variables `m` of the table multilinear (`2^m` entries).
-/// * `lookers` - The looker claims; every evaluation point must have the same length `n`.
+/// * `lookers` - The looker claims; their evaluation points may differ in length.
 /// * `channel` - The verifier channel for receiving prover messages and sampling challenges.
 ///
 /// # Transcript layout
@@ -71,7 +75,7 @@ pub struct LookerClaim<'a, Elem> {
 /// ```text
 ///     1. sample c                                  (logUp challenge)
 ///     2. recv den_root                             (the root denominator; its numerator is 0)
-///     3. combined GKR, k + max(n, m) layers        (see fracaddcheck::verify)
+///     3. combined GKR, k + max(max_j n_j, m) layers (see fracaddcheck::verify)
 ///     4. recv per-looker index evaluations, then Y (the non-transparent leaf halves)
 ///     5. pushforward reduction:
 ///        a. sample batch_coeff
@@ -114,11 +118,12 @@ where
 	assert!(!lookers.is_empty(), "at least one looker claim is required");
 
 	let m = table_n_vars;
-	let n = lookers[0].eval_point.len();
-	assert!(
-		lookers.iter().all(|looker| looker.eval_point.len() == n),
-		"every looker evaluation point must have the same length"
-	);
+	// Lookers may differ in length; the batch pads each up to the deepest instance.
+	let max_n = lookers
+		.iter()
+		.map(|looker| looker.eval_point.len())
+		.max()
+		.expect("lookers is non-empty");
 
 	// Sample the logUp challenge c that randomizes the logarithmic-derivative denominators.
 	let c = channel.sample();
@@ -131,12 +136,12 @@ where
 		.map_err(|_| VerificationError::TranscriptIsEmpty)?;
 
 	// One GKR over the whole thing, from that single root fraction down to the leaves: k layers
-	// interpolating the per-instance roots, then max(n, m) more over the instances. The looker
-	// trees have depth n and the table tree depth m, so the shallower side is padded by zero
-	// fractions — the layer count never reveals which is which.
+	// interpolating the per-instance roots, then max(max_n, m) more over the instances. Looker j's
+	// tree has depth n_j and the table tree depth m, so every shallower instance is padded by zero
+	// fractions — the layer count reveals only the deepest one.
 	let n_instances = lookers.len() + 1;
 	let k = n_instances.next_power_of_two().ilog2() as usize;
-	let n_layers = k + n.max(m);
+	let n_layers = k + max_n.max(m);
 	let FracAddEvalClaim {
 		num_eval: leaf_num,
 		den_eval: leaf_den,
@@ -164,28 +169,35 @@ where
 
 	// Rebuild each circuit's padded leaf fraction and check they interpolate to the batch's leaf.
 	//
-	// The node point spans max(n, m) coordinates, so looker j is padded by `max(n, m) - n` and the
-	// table by `max(n, m) - m`; padding scales a numerator by the padding coordinates' equality
-	// weight q and sends a denominator through sel(q, .), so both halves follow from the claims
-	// above.
+	// The node point spans max(max_n, m) coordinates, so an instance over `d` variables is padded
+	// by `max(max_n, m) - d` and its own content is the last `d` coordinates. Padding scales a
+	// numerator by the padding coordinates' equality weight q and sends a denominator through
+	// sel(q, .), so both halves follow from the claims above.
 	let n_node_vars = node_point.len();
-	let (looker_pad, table_pad) = (n_node_vars - n, n_node_vars - m);
-	let looker_content = &node_point[looker_pad..];
-	let table_point = &node_point[table_pad..];
 
-	// Both padding weights are prefixes of the node point, and every looker shares the same one, so
-	// compute each once rather than per tree.
-	let looker_pad_eq = eq_ind_zero::<C::Elem>(&node_point[..looker_pad]);
-	let table_pad_eq = eq_ind_zero::<C::Elem>(&node_point[..table_pad]);
+	// Every instance's padding weight is a prefix of the node point, so accumulate the prefixes
+	// once: `pad_eqs[p] = eq(0^p; node_point[..p])`. With lookers of differing lengths there is one
+	// weight per distinct depth, and this indexes them all in a single pass.
+	let pad_eqs = iter::once(C::Elem::one())
+		.chain(node_point.iter().scan(C::Elem::one(), |acc, coord| {
+			*acc = acc.clone() * eq_ind_zero::<C::Elem>(slice::from_ref(coord));
+			Some(acc.clone())
+		}))
+		.collect::<Vec<_>>();
+
+	let table_pad = n_node_vars - m;
+	let table_point = &node_point[table_pad..];
 
 	// Looker numerators are transparent: gamma^j scales the equality indicator at r_j. The
 	// denominators are c - I_j, from the index evaluations just read.
 	let (mut leaf_nums, mut leaf_dens): (Vec<_>, Vec<_>) =
 		iter::zip(iter::zip(lookers, powers(gamma.clone())), &index_eval_claims)
 			.map(|((looker, power), index_eval)| {
-				let num = power * eq_ind::<C::Elem>(looker.eval_point, looker_content);
+				let pad = n_node_vars - looker.eval_point.len();
+				let content = &node_point[pad..];
+				let num = power * eq_ind::<C::Elem>(looker.eval_point, content);
 				let den = c.clone() - index_eval.clone();
-				fracaddcheck::pad_leaf_fraction((num, den), looker_pad_eq.clone())
+				fracaddcheck::pad_leaf_fraction((num, den), pad_eqs[pad].clone())
 			})
 			.unzip();
 
@@ -194,7 +206,7 @@ where
 	// root numerator vanish.
 	let (table_num, table_den) = fracaddcheck::pad_leaf_fraction(
 		(pushforward_eval.clone(), denominator_eval::<F, C::Elem>(&c, table_point)),
-		table_pad_eq,
+		pad_eqs[table_pad].clone(),
 	);
 	leaf_nums.push(table_num);
 	leaf_dens.push(table_den);
@@ -225,7 +237,9 @@ where
 		table_eval_point,
 		table_eval_claim,
 		pushforward_eval_claim,
-		index_eval_point: looker_content.to_vec(),
+		// Spans the deepest looker, not the whole node point: when the table is deeper than every
+		// looker its extra coordinates belong to the table alone. Looker j reads the last n_j.
+		index_eval_point: node_point[n_node_vars - max_n..].to_vec(),
 		index_eval_claims,
 	})
 }


### PR DESCRIPTION
Closes [BINIUS-411](https://linear.app/jimpo/issue/BINIUS-411/logup-star-relax-the-equal-length-looker-requirement). Builds on #2055.

## Why this is small

Batched lookup required every looker column to be the same length. That was a restriction of the batch, not of the protocol: before #2055 the looker circuits ran as one *equal-depth* batch, so a shorter column had nowhere to go.

#2055 already made every circuit — each looker's and the table's — an instance of one unequal-depth batch that pads each up to the deepest. Lookers of differing lengths therefore need nothing new from it, only that their own depths be threaded through:

- each circuit is built at `n_j` layers rather than a shared `n`,
- its leaf claim is divided back through `n_layers - n_j` padding coordinates,
- the batch runs `k + max(max_j n_j, m)` layers,
- `witness::combined_lookers` sizes each numerator buffer to its own looker instead of a shared `2^n`.

On the verifier the padding weights are no longer a single shared value, so they accumulate as a running prefix over the node point — `pad_eqs[p] = eq(0^p; node_point[..p])` — and each instance indexes the one for its own depth. (This is the general shape you asked for in #2055; at the time all lookers shared a depth, so it was two calls. Now it isn't.)

## The output point

`LogupOutput::index_eval_point` now spans the **deepest looker**, with looker `j` claimed at its **last `n_j`** coordinates. A shorter looker's point is a suffix of a longer one's, because the batch pads at the low coordinates.

Two consequences worth stating explicitly:

- **Equal-length callers are unaffected.** They all read the whole point, exactly as before — so the intmul reduction (`crates/prover/src/protocols/intmul/prove.rs:309`, `crates/verifier/src/protocols/intmul/verify.rs:294`), which folds its per-column claims by `rho` at the shared point, needs no change and stays correct.
- **The point stops at the deepest looker, not at the whole node point.** When the table is deeper than every looker, the node point's extra low coordinates belong to the table alone and no index column can be evaluated at them. I had it returning the full node point first; the pre-existing single-looker tests caught it for exactly that `m > n` case.

## Testing

- New `test_lookers_of_unequal_length` over the shapes `([5,2,4], m=3) ([2,6], m=2) ([1,1,5], m=4) ([3,3], m=5) ([0,4], m=3)` — the table both deeper and shallower than the deepest looker, a repeated length, and a depth-0 looker. It checks each index claim at its own suffix of the point.
- Every pre-existing logup* test passes **unchanged**, which is the evidence that the uniform-length path is untouched.
- Full suites green for `binius-ip` / `ip-prover` / `iop` / `iop-prover` / `spartan-prover` / `spartan-verifier` / `prover` / `verifier` — the last two because intmul consumes this output. Workspace clippy `-D warnings`, rustdoc `-D warnings`, and `fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)