### PR TITLE
BINIUS-417: remove Merkle leaf salting

### DIFF
--- a/crates/hash/src/binary_merkle_tree.rs
+++ b/crates/hash/src/binary_merkle_tree.rs
@@ -6,11 +6,9 @@ use std::{fmt::Debug, mem::MaybeUninit};
 use binius_field::Field;
 use binius_utils::{
 	checked_arithmetics::checked_log_2,
-	rand::par_rand,
 	rayon::{prelude::*, slice::ParallelSlice},
 };
 use digest::{Digest, FixedOutputReset, Output, block_api::BlockSizeUser};
-use rand::{CryptoRng, Rng, rngs::StdRng};
 
 use super::{
 	compress::CompressionFunction, parallel_compression::ParallelPseudoCompression,
@@ -50,75 +48,105 @@ pub enum Error {
 
 /// A binary Merkle tree that commits batches of vectors.
 ///
-/// The vector entries at each index in a batch are hashed together into leaf digests. Then a
-/// Merkle tree is constructed over the leaf digests. The implementation requires that the vector
-/// lengths are all equal to each other and a power of two.
+/// # Overview
+///
+/// The entries sharing an index across a batch are hashed together into one leaf digest.
+/// A binary tree is then folded over those leaf digests.
+///
+/// All committed vectors must have the same length, and that length must be a power of two.
 #[derive(Debug, Clone)]
-pub struct BinaryMerkleTree<D, F> {
-	/// Base-2 logarithm of the number of leaves
+pub struct BinaryMerkleTree<D> {
+	/// Base-2 logarithm of the number of leaves.
 	pub log_len: usize,
-	/// The inner nodes, arranged as a flattened array of layers with the root at the end
+	/// The inner nodes, arranged as a flattened array of layers with the root at the end.
 	pub inner_nodes: Vec<D>,
-	/// Salt values for each leaf (if using hiding commitments)
-	pub salts: Vec<F>,
 }
 
-pub fn build<F, H, R>(
+/// Commits a slice of values, cutting it into consecutive leaves.
+///
+/// # Arguments
+///
+/// * `elements` - the values to commit, in leaf order.
+/// * `batch_size` - how many consecutive values are hashed together into one leaf.
+///
+/// # Returns
+///
+/// The committed tree, or a failure describing which shape requirement the input broke.
+///
+/// # Errors
+///
+/// * The value count is not a multiple of the batch size.
+/// * The resulting leaf count is not a power of two.
+pub fn build<F, H>(
 	elements: &[F],
 	batch_size: usize,
-	salt_len: usize,
-	rng: R,
-) -> Result<BinaryMerkleTree<Output<H::LeafHash>, F>, Error>
+) -> Result<BinaryMerkleTree<Output<H::LeafHash>>, Error>
 where
 	F: Field,
 	H: HashSuite,
-	R: Rng + CryptoRng,
 {
+	// Every leaf holds the same number of values, so the split has to come out even.
 	if !elements.len().is_multiple_of(batch_size) {
 		return Err(Error::IncorrectBatchSize);
 	}
 
+	// A binary tree only spans a power-of-two number of leaves.
 	let len = elements.len() / batch_size;
-
 	if !len.is_power_of_two() {
 		return Err(Error::PowerOfTwoLengthRequired);
 	}
 
-	build_from_iterator::<_, H, _, _>(
+	// Hand the leaves over one contiguous chunk at a time.
+	build_from_iterator::<_, H, _>(
 		elements
 			.par_chunks(batch_size)
 			.map(|chunk| chunk.iter().copied()),
 		batch_size,
-		salt_len,
-		rng,
 	)
 }
 
-pub fn build_from_iterator<F, H, R, ParIter>(
+/// Commits leaves drawn from a parallel iterator, one iterator item per leaf.
+///
+/// # Overview
+///
+/// The tree is laid out as one flat buffer of layers, widest first:
+///
+/// ```text
+///     [ leaf digests | layer 1 | ... | root ]
+///        2^log_len      2^(log_len-1)    1
+/// ```
+///
+/// Each layer is written into the buffer's spare capacity.
+/// It is then read back as the input to the layer above it.
+///
+/// # Arguments
+///
+/// * `iterated_chunks` - one iterator per leaf, each yielding that leaf's values.
+/// * `n_items_per_input` - how many values every leaf iterator yields.
+///
+/// # Panics
+///
+/// Panics unless the number of leaves is a power of two.
+pub fn build_from_iterator<F, H, ParIter>(
 	iterated_chunks: ParIter,
 	n_items_per_input: usize,
-	salt_len: usize,
-	mut rng: R,
-) -> Result<BinaryMerkleTree<Output<H::LeafHash>, F>, Error>
+) -> Result<BinaryMerkleTree<Output<H::LeafHash>>, Error>
 where
 	F: Field,
 	H: HashSuite,
-	R: Rng + CryptoRng,
 	ParIter: IndexedParallelIterator<Item: IntoIterator<Item = F, IntoIter: Send>>,
 {
 	let log_len = checked_log_2(iterated_chunks.len()); // precondition
 
-	// Generate salts if needed
-	let salts =
-		par_rand::<StdRng, _, _>(salt_len << log_len, &mut rng, F::random).collect::<Vec<_>>();
-
+	// A binary tree over 2^log_len leaves has 2^(log_len+1) - 1 nodes in total.
 	let total_length = (1 << (log_len + 1)) - 1;
 	let mut inner_nodes = Vec::with_capacity(total_length);
+
+	// Fill the widest layer first, straight into uninitialized capacity.
 	hash_leaves::<F, H, _>(
 		iterated_chunks,
 		n_items_per_input,
 		&mut inner_nodes.spare_capacity_mut()[..(1 << log_len)],
-		&salts,
 	);
 
 	let (prev_layer, mut remaining) = inner_nodes.spare_capacity_mut().split_at_mut(1 << log_len);
@@ -127,6 +155,7 @@ where
 		// SAFETY: prev-layer was initialized by hash_leaves
 		prev_layer.assume_init_mut()
 	};
+	// Fold one layer per round, each half the width of the one below it.
 	let parallel_compression = H::ParCompression::default();
 	for i in 1..(log_len + 1) {
 		let (next_layer, next_remaining) = remaining.split_at_mut(1 << (log_len - i));
@@ -149,26 +178,15 @@ where
 	Ok(BinaryMerkleTree {
 		log_len,
 		inner_nodes,
-		salts,
 	})
 }
 
-impl<D: Clone, F> BinaryMerkleTree<D, F> {
+impl<D: Clone> BinaryMerkleTree<D> {
 	pub fn root(&self) -> D {
 		self.inner_nodes
 			.last()
 			.expect("MerkleTree inner nodes can't be empty")
 			.clone()
-	}
-
-	/// Returns the salt values associated with a specific leaf index in the Merkle tree.
-	///
-	/// # Arguments
-	/// * `index` - The index of the leaf. Must be less than 2^log_len (the total number of leaves).
-	pub fn get_salt(&self, index: usize) -> &[F] {
-		assert!(index < (1 << self.log_len));
-		let salt_len = self.salts.len() >> self.log_len;
-		&self.salts[index * salt_len..(index + 1) * salt_len]
 	}
 
 	pub fn layer(&self, layer_depth: usize) -> Result<&[D], Error> {
@@ -206,9 +224,8 @@ impl<D: Clone, F> BinaryMerkleTree<D, F> {
 /// Given a vector of elements and an output buffer of N hash digests, this splits the elements
 /// into N equal-sized chunks and hashes each chunks into the corresponding output digest.
 ///
-/// Each leaf is built from exactly `n_items_per_input` data elements (plus the per-leaf salt, when
-/// salts are present), so the leaf byte length is constant. This is passed to
-/// [`ParallelDigest::digest_with_const_len`] so the hasher can specialize for short leaves.
+/// Every leaf holds exactly `n_items_per_input` values, so its byte length is a constant.
+/// Passing that length to the hasher lets it specialize for short leaves.
 ///
 /// # Preconditions
 /// - Each iterator in `iterated_chunks` yields exactly `n_items_per_input` elements.
@@ -217,29 +234,12 @@ fn hash_leaves<F, H, ParIter>(
 	iterated_chunks: ParIter,
 	n_items_per_input: usize,
 	digests: &mut [MaybeUninit<Output<H::LeafHash>>],
-	salts: &[F],
 ) where
 	F: Field,
 	H: HashSuite,
 	ParIter: IndexedParallelIterator<Item: IntoIterator<Item = F, IntoIter: Send>>,
 {
-	if salts.is_empty() {
-		// Need special-case handling when salts is empty, otherwise salt_len is 0 and par_chunks
-		// cannot handle chunk size of 0.
-		let hasher = H::ParLeafHash::default();
-		hasher.digest_with_const_len(n_items_per_input, iterated_chunks, digests);
-	} else {
-		assert!(salts.len().is_multiple_of(digests.len()));
-
-		let salt_len = salts.len() / digests.len();
-
-		// Create an iterator that chains each chunk with its salt
-		let salted_iter = iterated_chunks
-			.zip(salts.par_chunks(salt_len))
-			.map(|(chunk, salt)| chunk.into_iter().chain(salt.iter().copied()));
-
-		// Each salted leaf yields the data elements followed by the salt elements.
-		let hasher = H::ParLeafHash::default();
-		hasher.digest_with_const_len(n_items_per_input + salt_len, salted_iter, digests);
-	}
+	// The constant leaf length lets the hasher skip per-leaf length bookkeeping and padding.
+	let hasher = H::ParLeafHash::default();
+	hasher.digest_with_const_len(n_items_per_input, iterated_chunks, digests);
 }

--- a/crates/iop-prover/src/basefold/compiler.rs
+++ b/crates/iop-prover/src/basefold/compiler.rs
@@ -170,9 +170,9 @@ where
 
 	/// Creates a ZK prover channel over a transcript, for the common case.
 	///
-	/// The transcript (owned or mutably borrowed) is wrapped in a
-	/// [`ProverMerkleTranscriptChannel`] with a non-hiding Merkle tree prover for the given hash
-	/// suite, then passed to [`Self::create_channel`].
+	/// The transcript may be owned or mutably borrowed.
+	/// It is wrapped in a [`ProverMerkleTranscriptChannel`] for the given hash suite.
+	/// That channel is then passed to [`Self::create_channel`].
 	pub fn create_channel_from_transcript<H, Challenger_, T, A>(
 		&self,
 		transcript: T,

--- a/crates/iop-prover/src/basefold/opening.rs
+++ b/crates/iop-prover/src/basefold/opening.rs
@@ -216,7 +216,8 @@ mod test {
 			&mut prover_channel,
 			&GlobalAllocator,
 		);
-		drop(prover_channel);
+		// Hand the transcript back, releasing the channel's borrow of it.
+		prover_channel.into_transcript();
 
 		let mut verifier_transcript = prover_transcript.into_verifier();
 		let mut verifier_channel =

--- a/crates/iop-prover/src/fri/tests.rs
+++ b/crates/iop-prover/src/fri/tests.rs
@@ -79,7 +79,8 @@ fn test_commit_prove_verify_success<F, P>(
 	}
 
 	round_prover.finish_proof(&mut prover_channel);
-	drop(prover_channel);
+	// Hand the transcript back, releasing the channel's borrow of it.
+	prover_channel.into_transcript();
 	// Now run the verifier, receiving commitments and openings over a Merkle channel.
 	let mut verifier_challenger = prover_challenger.into_verifier();
 	let mut channel = VerifierMerkleTranscriptChannel::<_, StdChallenger, _, StdHashSuite>::new(
@@ -276,7 +277,8 @@ fn test_commit_prove_verify_batched_multi_oracle() {
 		round_prover.execute_fold_round(&mut prover_channel);
 	}
 	round_prover.finish_proof(&mut prover_channel);
-	drop(prover_channel);
+	// Hand the transcript back, releasing the channel's borrow of it.
+	prover_channel.into_transcript();
 
 	// Run the verifier, receiving commitments and openings over a Merkle channel.
 	let mut verifier_challenger = prover_challenger.into_verifier();
@@ -412,7 +414,8 @@ fn test_commit_prove_verify_batched_mixed_skip() {
 		round_prover.execute_fold_round(&mut prover_channel);
 	}
 	round_prover.finish_proof(&mut prover_channel);
-	drop(prover_channel);
+	// Hand the transcript back, releasing the channel's borrow of it.
+	prover_channel.into_transcript();
 
 	// Run the verifier, receiving commitments and openings over a Merkle channel.
 	let mut verifier_challenger = prover_challenger.into_verifier();
@@ -575,7 +578,8 @@ fn test_commit_prove_verify_lifted_multi_oracle() {
 		round_prover.execute_fold_round(&mut prover_channel);
 	}
 	round_prover.finish_proof(&mut prover_channel);
-	drop(prover_channel);
+	// Hand the transcript back, releasing the channel's borrow of it.
+	prover_channel.into_transcript();
 
 	// Run the verifier, receiving commitments and openings over a Merkle channel.
 	let mut verifier_challenger = prover_challenger.into_verifier();
@@ -699,7 +703,8 @@ where
 	}
 
 	round_prover.finish_proof(&mut prover_channel);
-	drop(prover_channel);
+	// Hand the transcript back, releasing the channel's borrow of it.
+	prover_channel.into_transcript();
 
 	let scheme = binius_iop::merkle_tree::BinaryMerkleTreeScheme::new();
 	let proof_bytes = prover_transcript.finalize();

--- a/crates/iop-prover/src/merkle_channel.rs
+++ b/crates/iop-prover/src/merkle_channel.rs
@@ -24,7 +24,6 @@ use binius_transcript::{
 };
 use binius_utils::{SerializeBytes, checked_arithmetics::checked_log_2};
 use digest::Output;
-use rand::CryptoRng;
 
 use crate::merkle_tree::{MerkleTreeProver, commit_field_buffer, prover::BinaryMerkleTreeProver};
 
@@ -93,15 +92,9 @@ pub struct ProverMerkleTranscriptChannel<T, Challenger_, F, H: HashSuite> {
 }
 
 impl<T, Challenger_, F, H: HashSuite> ProverMerkleTranscriptChannel<T, Challenger_, F, H> {
-	/// Constructs a channel over the transcript with a non-hiding Merkle tree prover.
+	/// Constructs a channel over the transcript with a default Merkle tree prover.
 	pub fn new(transcript: T) -> Self {
 		Self::with_merkle_prover(transcript, BinaryMerkleTreeProver::new())
-	}
-
-	/// Constructs a channel over the transcript with a hiding Merkle tree prover, salting each
-	/// leaf with `salt_len` random field elements drawn from `rng`.
-	pub fn hiding(transcript: T, rng: impl CryptoRng, salt_len: usize) -> Self {
-		Self::with_merkle_prover(transcript, BinaryMerkleTreeProver::hiding(rng, salt_len))
 	}
 
 	/// Constructs a channel over the transcript with the given Merkle tree prover.
@@ -168,7 +161,7 @@ where
 	H: HashSuite,
 	Output<H::LeafHash>: SerializeBytes,
 {
-	type Commitment = ProverMerkleCommitment<BinaryMerkleTree<Output<H::LeafHash>, F>>;
+	type Commitment = ProverMerkleCommitment<BinaryMerkleTree<Output<H::LeafHash>>>;
 
 	fn send_merkle_commitment<P: PackedField<Scalar = F>>(
 		&mut self,
@@ -225,12 +218,10 @@ where
 	) {
 		debug_assert_eq!(commitment.depth, data.log_len() - commitment.log_leaf_size);
 
-		// Write the data in full, then whatever binding data the verifier's `verify_vector` reads
-		// while recomputing the root (the per-leaf salts, empty for non-hiding trees).
+		// The data itself is the whole opening.
+		// The verifier recomputes the root from it, so no further advice follows.
 		let mut advice = self.transcript.borrow_mut().decommitment();
 		advice.write_scalar_iter(data.iter_scalars());
-		self.merkle_prover
-			.prove_vector(&commitment.committed, &mut advice);
 	}
 
 	fn sample_bits(&mut self, bits: usize) -> usize {
@@ -242,10 +233,7 @@ where
 mod tests {
 	use binius_field::{BinaryField128bGhash as B128, PackedBinaryGhash2x128b};
 	use binius_hash::{StdDigest, StdHashSuite};
-	use binius_iop::{
-		merkle_channel::{MerkleIPVerifierChannel, VerifierMerkleTranscriptChannel},
-		merkle_tree::BinaryMerkleTreeScheme,
-	};
+	use binius_iop::merkle_channel::{MerkleIPVerifierChannel, VerifierMerkleTranscriptChannel};
 	use binius_math::{FieldBuffer, test_utils::random_scalars};
 	use binius_transcript::{ProverTranscript, fiat_shamir::HasherChallenger};
 	use rand::prelude::*;
@@ -297,48 +285,6 @@ mod tests {
 			.recv_openings(&commitment, &indices)
 			.unwrap();
 		assert_eq!(values.len(), N_QUERIES * LEAF_SIZE);
-		for (chunk, &index) in values.chunks(LEAF_SIZE).zip(&indices) {
-			assert_eq!(chunk, &scalars[index * LEAF_SIZE..(index + 1) * LEAF_SIZE]);
-		}
-
-		let vector = verifier_channel.recv_committed_vector(&commitment).unwrap();
-		assert_eq!(vector, scalars);
-
-		verifier_channel.into_transcript().finalize().unwrap();
-	}
-
-	#[test]
-	fn test_merkle_channel_roundtrip_hiding() {
-		let mut rng = StdRng::seed_from_u64(0);
-		let salt_len = 2;
-
-		let scalars = random_scalars::<B128>(&mut rng, 1 << LOG_LEN);
-		let data = FieldBuffer::<P, _>::from_values(&scalars);
-
-		let mut prover_channel = ProverChannel::hiding(
-			ProverTranscript::new(StdChallenger::default()),
-			&mut rng,
-			salt_len,
-		);
-		let commitment = prover_channel.send_merkle_commitment(data.to_ref(), LEAF_SIZE);
-		let indices = sample_indices(&mut prover_channel);
-		prover_channel.send_openings(&commitment, data.to_ref(), &indices);
-		prover_channel.send_committed_vector(&commitment, data.to_ref());
-
-		let transcript = prover_channel.into_transcript().into_verifier();
-		let mut verifier_channel =
-			VerifierChannel::with_scheme(transcript, BinaryMerkleTreeScheme::hiding(salt_len));
-		let commitment = verifier_channel
-			.recv_merkle_commitment(LEAF_SIZE, DEPTH)
-			.unwrap();
-		let verifier_indices = (0..N_QUERIES)
-			.map(|_| verifier_channel.sample_bits(DEPTH))
-			.collect::<Vec<_>>();
-		assert_eq!(verifier_indices, indices);
-
-		let values = verifier_channel
-			.recv_openings(&commitment, &indices)
-			.unwrap();
 		for (chunk, &index) in values.chunks(LEAF_SIZE).zip(&indices) {
 			assert_eq!(chunk, &scalars[index * LEAF_SIZE..(index + 1) * LEAF_SIZE]);
 		}

--- a/crates/iop-prover/src/merkle_tree/mod.rs
+++ b/crates/iop-prover/src/merkle_tree/mod.rs
@@ -92,12 +92,6 @@ pub trait MerkleTreeProver<T: FixedSizeSerializeBytes> {
 		index: usize,
 		proof: &mut TranscriptWriter<B>,
 	);
-
-	/// Generate an opening proof for the full committed vector.
-	///
-	/// This writes the binding data that [`MerkleTreeScheme::verify_vector`] reads alongside the
-	/// data itself while recomputing the root — the per-leaf salts, empty for non-hiding trees.
-	fn prove_vector<B: BufMut>(&self, committed: &Self::Committed, proof: &mut TranscriptWriter<B>);
 }
 
 /// Commits a field buffer to a Merkle tree, packing `1 << log_batch_size` scalars into each leaf.

--- a/crates/iop-prover/src/merkle_tree/prover.rs
+++ b/crates/iop-prover/src/merkle_tree/prover.rs
@@ -1,8 +1,6 @@
 // Copyright 2024-2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-use std::sync::Mutex;
-
 use binius_field::Field;
 use binius_hash::binary_merkle_tree::{self, BinaryMerkleTree, HashSuite};
 use binius_iop::merkle_tree::{BinaryMerkleTreeScheme, Commitment, MerkleTreeScheme};
@@ -10,7 +8,6 @@ use binius_transcript::{BufMut, TranscriptWriter};
 use binius_utils::rayon::iter::IndexedParallelIterator;
 use digest::Output;
 use getset::Getters;
-use rand::{CryptoRng, SeedableRng, rngs::StdRng};
 
 use super::MerkleTreeProver;
 
@@ -18,22 +15,12 @@ use super::MerkleTreeProver;
 pub struct BinaryMerkleTreeProver<T, H: HashSuite> {
 	#[getset(get = "pub")]
 	scheme: BinaryMerkleTreeScheme<T, H>,
-	salt_rng: Mutex<StdRng>,
 }
 
 impl<T, H: HashSuite> BinaryMerkleTreeProver<T, H> {
 	pub fn new() -> Self {
 		Self {
 			scheme: BinaryMerkleTreeScheme::new(),
-			// We can construct a dummy Rng with a deterministic seed because it will be unused.
-			salt_rng: Mutex::new(StdRng::seed_from_u64(0)),
-		}
-	}
-
-	pub fn hiding(mut rng: impl CryptoRng, salt_len: usize) -> Self {
-		Self {
-			scheme: BinaryMerkleTreeScheme::hiding(salt_len),
-			salt_rng: Mutex::new(StdRng::from_rng(&mut rng)),
 		}
 	}
 }
@@ -50,7 +37,7 @@ where
 	H: HashSuite,
 {
 	type Scheme = BinaryMerkleTreeScheme<F, H>;
-	type Committed = BinaryMerkleTree<Output<H::LeafHash>, F>;
+	type Committed = BinaryMerkleTree<Output<H::LeafHash>>;
 
 	fn scheme(&self) -> &Self::Scheme {
 		&self.scheme
@@ -69,23 +56,10 @@ where
 		index: usize,
 		proof: &mut TranscriptWriter<B>,
 	) {
-		let salt = committed.get_salt(index);
-		proof.write_slice(salt);
-
 		let branch = committed
 			.branch(index, layer_depth)
 			.expect("precondition: index and layer_depth must be within the committed tree");
 		proof.write_slice(&branch);
-	}
-
-	fn prove_vector<B: BufMut>(
-		&self,
-		committed: &Self::Committed,
-		proof: &mut TranscriptWriter<B>,
-	) {
-		for leaf_index in 0..1 << committed.log_len {
-			proof.write_slice(committed.get_salt(leaf_index));
-		}
 	}
 
 	#[allow(clippy::type_complexity)]
@@ -97,18 +71,8 @@ where
 	where
 		ParIter: IndexedParallelIterator<Item: IntoIterator<Item = F, IntoIter: Send>>,
 	{
-		let salt_rng = {
-			// If mutex is poisoned, panic.
-			let mut root_rng = self.salt_rng.lock().unwrap();
-			StdRng::from_rng(&mut *root_rng)
-		};
-		let tree = binary_merkle_tree::build_from_iterator::<F, H, _, _>(
-			leaves,
-			n_items_per_input,
-			self.scheme.salt_len(),
-			salt_rng,
-		)
-		.expect("precondition: the number of leaves must be a power of two");
+		let tree = binary_merkle_tree::build_from_iterator::<F, H, _>(leaves, n_items_per_input)
+			.expect("precondition: the number of leaves must be a power of two");
 
 		let commitment = Commitment {
 			root: tree.root(),

--- a/crates/iop-prover/src/merkle_tree/tests.rs
+++ b/crates/iop-prover/src/merkle_tree/tests.rs
@@ -9,7 +9,7 @@ use binius_field::{
 use binius_hash::{StdDigest, StdHashSuite};
 use binius_iop::merkle_tree::MerkleTreeScheme;
 use binius_math::{FieldBuffer, test_utils::random_scalars};
-use binius_transcript::{ProverTranscript, VerifierTranscript, fiat_shamir::HasherChallenger};
+use binius_transcript::{ProverTranscript, fiat_shamir::HasherChallenger};
 use binius_utils::rayon::prelude::*;
 use rand::prelude::*;
 
@@ -92,113 +92,20 @@ fn test_binary_merkle_vcs_verify_vector() {
 
 	let mt_prover = BinaryMerkleTreeProver::<_, StdHashSuite>::new();
 
-	let mut proof_reader = VerifierTranscript::new(StdChallenger::default(), Vec::new());
 	let data = random_scalars::<B128>(&mut rng, 4);
 	let (commitment, _) = mt_prover.commit(&data, 1);
 
 	mt_prover
 		.scheme()
-		.verify_vector(&commitment.root, &data, 1, &mut proof_reader.decommitment())
+		.verify_vector(&commitment.root, &data, 1)
 		.unwrap();
 }
 
 #[test]
-fn test_binary_merkle_vcs_hiding_commit_prove_open() {
+fn test_binary_merkle_vcs_batch_size() {
 	let mut rng = StdRng::seed_from_u64(0);
 
-	let salt_len = 2;
-	let mt_prover = BinaryMerkleTreeProver::<_, StdHashSuite>::hiding(&mut rng, salt_len);
-
-	let data = random_scalars::<B128>(&mut rng, 16);
-	let (commitment, tree) = mt_prover.commit(&data, 1);
-
-	assert_eq!(commitment.root, tree.root());
-
-	// Test that we can prove openings with salt
-	for (i, value) in data.iter().enumerate() {
-		let mut proof_writer = ProverTranscript::new(StdChallenger::default());
-		mt_prover.prove_opening(&tree, 0, i, &mut proof_writer.message());
-
-		let mut proof_reader = proof_writer.into_verifier();
-		mt_prover
-			.scheme()
-			.verify_opening(
-				i,
-				slice::from_ref(value),
-				0,
-				4,
-				&[commitment.root],
-				&mut proof_reader.message(),
-			)
-			.unwrap();
-	}
-}
-
-#[test]
-fn test_binary_merkle_vcs_hiding_verify_vector() {
-	let mut rng = StdRng::seed_from_u64(0);
-
-	let salt_len = 3;
-	let mt_prover = BinaryMerkleTreeProver::<_, StdHashSuite>::hiding(&mut rng, salt_len);
-
-	let data = random_scalars::<B128>(&mut rng, 8);
-	let (commitment, tree) = mt_prover.commit(&data, 1);
-
-	// Create a proof transcript with salt values
-	let mut proof_writer = ProverTranscript::new(StdChallenger::default());
-	// Write all salt values to the transcript
-	for i in 0..data.len() {
-		let salt = tree.get_salt(i);
-		proof_writer.message().write_slice(salt);
-	}
-
-	let mut proof_reader = proof_writer.into_verifier();
-	mt_prover
-		.scheme()
-		.verify_vector(&commitment.root, &data, 1, &mut proof_reader.message())
-		.unwrap();
-}
-
-#[test]
-fn test_binary_merkle_vcs_hiding_prove_open_against_layer() {
-	let mut rng = StdRng::seed_from_u64(0);
-
-	let salt_len = 2;
-	let mt_prover = BinaryMerkleTreeProver::<_, StdHashSuite>::hiding(&mut rng, salt_len);
-
-	let data = random_scalars::<B128>(&mut rng, 32);
-	let (_, tree) = mt_prover.commit(&data, 1);
-
-	// Openings against an internal layer must write the salt of the opened leaf, not of the
-	// layer-relative index.
-	for layer_depth in 1..5 {
-		let layer = mt_prover.layer(&tree, layer_depth);
-		for (i, value) in data.iter().enumerate() {
-			let mut proof_writer = ProverTranscript::new(StdChallenger::default());
-			mt_prover.prove_opening(&tree, layer_depth, i, &mut proof_writer.message());
-
-			let mut proof_reader = proof_writer.into_verifier();
-			mt_prover
-				.scheme()
-				.verify_opening(
-					i,
-					slice::from_ref(value),
-					layer_depth,
-					5,
-					layer,
-					&mut proof_reader.message(),
-				)
-				.unwrap();
-		}
-	}
-}
-
-#[test]
-fn test_binary_merkle_vcs_hiding_batch_size() {
-	let mut rng = StdRng::seed_from_u64(0);
-
-	let salt_len = 1;
-	let mt_prover = BinaryMerkleTreeProver::<_, StdHashSuite>::hiding(&mut rng, salt_len);
+	let mt_prover = BinaryMerkleTreeProver::<_, StdHashSuite>::new();
 
 	let data = random_scalars::<B128>(&mut rng, 32);
 	let batch_size = 4;

--- a/crates/iop/src/basefold/compiler.rs
+++ b/crates/iop/src/basefold/compiler.rs
@@ -120,9 +120,9 @@ where
 
 	/// Creates a ZK verifier channel over a transcript, for the common case.
 	///
-	/// The transcript (owned or mutably borrowed) is wrapped in a
-	/// [`VerifierMerkleTranscriptChannel`] with a non-hiding [`BinaryMerkleTreeScheme`] for the
-	/// given hash suite, then passed to [`Self::create_channel`].
+	/// The transcript may be owned or mutably borrowed.
+	/// It is wrapped in a [`VerifierMerkleTranscriptChannel`] for the given hash suite.
+	/// That channel is then passed to [`Self::create_channel`].
 	pub fn create_channel_from_transcript<H, Challenger_, T>(
 		&self,
 		transcript: T,

--- a/crates/iop/src/channel/size_tracking.rs
+++ b/crates/iop/src/channel/size_tracking.rs
@@ -35,8 +35,6 @@ pub struct CommittedShape {
 ///
 /// Zero survives every fold and equality check a verifier performs.
 /// So the verifier takes the path it would on a real proof, reaching the same receives in order.
-///
-/// The count assumes a non-hiding scheme, whose leaves carry no salt.
 pub struct SizeTrackingChannel<'a, F, MerkleScheme_> {
 	scheme: &'a MerkleScheme_,
 	proof_size: usize,

--- a/crates/iop/src/fri/size_estimation.rs
+++ b/crates/iop/src/fri/size_estimation.rs
@@ -13,8 +13,6 @@ use crate::merkle_tree::MerkleTreeScheme;
 ///   observed by Fiat-Shamir).
 /// - **Decommitment channel**: the terminal codeword, Merkle layer digests, per-query branch
 ///   digests, and per-query coset field values.
-///
-/// The estimate assumes non-hiding proofs (salt_len = 0).
 pub fn proof_size<F, VCS>(params: &FRIParams<F>, vcs: &VCS) -> usize
 where
 	F: BinaryField,

--- a/crates/iop/src/merkle_channel.rs
+++ b/crates/iop/src/merkle_channel.rs
@@ -76,7 +76,7 @@ pub struct VerifierMerkleTranscriptChannel<T, Challenger_, F, H: HashSuite> {
 }
 
 impl<T, Challenger_, F, H: HashSuite> VerifierMerkleTranscriptChannel<T, Challenger_, F, H> {
-	/// Constructs a channel over the transcript with a non-hiding Merkle tree scheme.
+	/// Constructs a channel over the transcript with a default Merkle tree scheme.
 	pub fn new(transcript: T) -> Self {
 		Self::with_scheme(transcript, BinaryMerkleTreeScheme::new())
 	}
@@ -204,14 +204,13 @@ where
 
 	fn recv_committed_vector(&mut self, commitment: &Self::Commitment) -> Result<Vec<F>, Error> {
 		let len = commitment.leaf_size << commitment.commitment.depth;
-		let mut advice = self.transcript.borrow_mut().decommitment();
-		let data = advice.read_scalar_slice::<F>(len)?;
-		self.scheme.verify_vector(
-			&commitment.commitment.root,
-			&data,
-			commitment.leaf_size,
-			&mut advice,
-		)?;
+		let data = self
+			.transcript
+			.borrow_mut()
+			.decommitment()
+			.read_scalar_slice::<F>(len)?;
+		self.scheme
+			.verify_vector(&commitment.commitment.root, &data, commitment.leaf_size)?;
 		Ok(data)
 	}
 

--- a/crates/iop/src/merkle_tree/merkle_tree_vcs.rs
+++ b/crates/iop/src/merkle_tree/merkle_tree_vcs.rs
@@ -42,15 +42,16 @@ pub trait MerkleTreeScheme<T: FixedSizeSerializeBytes> {
 
 	/// Verify the opening of the full vector.
 	///
+	/// The committed values are the whole opening, so there is no decommitment advice to read.
+	///
 	/// ## Preconditions
 	///
 	/// * `data.len()` must be a multiple of `batch_size`.
-	fn verify_vector<B: Buf>(
+	fn verify_vector(
 		&self,
 		root: &Self::Digest,
 		data: &[T],
 		batch_size: usize,
-		proof: &mut TranscriptReader<B>,
 	) -> Result<(), Error>;
 
 	/// Verify a given layer of the Merkle tree.

--- a/crates/iop/src/merkle_tree/scheme.rs
+++ b/crates/iop/src/merkle_tree/scheme.rs
@@ -10,19 +10,17 @@ use binius_utils::{
 	checked_arithmetics::{checked_log_2, log2_ceil_usize},
 };
 use digest::{Digest, Output};
-use getset::CopyGetters;
+use getset::Getters;
 
 use super::{
 	error::{Error, VerificationError},
 	merkle_tree_vcs::MerkleTreeScheme,
 };
 
-#[derive(Clone, CopyGetters)]
+#[derive(Clone, Getters)]
 pub struct BinaryMerkleTreeScheme<T, H: HashSuite> {
 	#[getset(get = "pub")]
 	compression: H::Compression,
-	#[getset(get_copy = "pub")]
-	salt_len: usize,
 	// This makes it so that `BinaryMerkleTreeScheme` remains Send + Sync regardless of `T`.
 	// See https://doc.rust-lang.org/nomicon/phantom-data.html#table-of-phantomdata-patterns
 	_phantom: PhantomData<fn() -> T>,
@@ -36,13 +34,8 @@ impl<T, H: HashSuite> Default for BinaryMerkleTreeScheme<T, H> {
 
 impl<T, H: HashSuite> BinaryMerkleTreeScheme<T, H> {
 	pub fn new() -> Self {
-		Self::hiding(0)
-	}
-
-	pub fn hiding(salt_len: usize) -> Self {
 		Self {
 			compression: H::Compression::default(),
-			salt_len,
 			_phantom: PhantomData,
 		}
 	}
@@ -53,13 +46,8 @@ where
 	T: FixedSizeSerializeBytes,
 	H: HashSuite,
 {
-	fn compute_leaf_digest<B: Buf>(
-		&self,
-		values: &[T],
-		proof: &mut TranscriptReader<B>,
-	) -> Result<Output<H::LeafHash>, Error> {
-		let salt = proof.read_vec::<T>(self.salt_len)?;
-		hash_serialize::<T, H::LeafHash>(values.iter().chain(&salt)).map_err(Error::Serialization)
+	fn compute_leaf_digest(&self, values: &[T]) -> Result<Output<H::LeafHash>, Error> {
+		hash_serialize::<T, H::LeafHash>(values).map_err(Error::Serialization)
 	}
 }
 
@@ -89,12 +77,11 @@ where
 			* <H::LeafHash as Digest>::output_size()
 	}
 
-	fn verify_vector<B: Buf>(
+	fn verify_vector(
 		&self,
 		root: &Self::Digest,
 		data: &[T],
 		batch_size: usize,
-		proof: &mut TranscriptReader<B>,
 	) -> Result<(), Error> {
 		assert!(
 			data.len().is_multiple_of(batch_size),
@@ -103,7 +90,7 @@ where
 
 		let digests = data
 			.chunks(batch_size)
-			.map(|chunk| self.compute_leaf_digest(chunk, proof))
+			.map(|chunk| self.compute_leaf_digest(chunk))
 			.collect::<Result<Vec<_>, _>>()?;
 
 		if fold_digests_vector_inplace(&self.compression, digests) != *root {
@@ -147,7 +134,7 @@ where
 		);
 		assert!(index < (1 << tree_depth), "precondition: index must be less than 2^tree_depth");
 
-		let mut leaf_digest = self.compute_leaf_digest(values, proof)?;
+		let mut leaf_digest = self.compute_leaf_digest(values)?;
 		for branch_node in proof.read_vec(tree_depth - layer_depth)? {
 			leaf_digest = self.compression.compress(if index & 1 == 0 {
 				[leaf_digest, branch_node]

--- a/crates/spartan-verifier/src/lib.rs
+++ b/crates/spartan-verifier/src/lib.rs
@@ -176,10 +176,10 @@ impl<F: Field> IOPVerifier<F> {
 			});
 		}
 
-		// Receive the private and mask oracle commitments. The private witness is
-		// witness-dependent. The mask is passed `is_witness_dependent = true` to preserve its ZK
-		// masking (it is a fresh random mask rather than witness data, but is committed with
-		// hiding in the ZK protocol).
+		// Receive the private and mask oracle commitments.
+		// The private witness is witness-dependent.
+		// The mask is a fresh random draw, not witness data.
+		// It is still flagged witness-dependent so the protocol keeps treating it as secret.
 		let private_oracle = channel.recv_oracle(cs.log_private() as usize, true)?;
 		let (m_n, m_d) = cs.mask_dims();
 		let mask_oracle = channel.recv_oracle(m_n + m_d, true)?;


### PR DESCRIPTION
Closes [BINIUS-417](https://linear.app/jimpo/issue/BINIUS-417).

Removes the ability to salt Merkle leaves. Pure removal of unused code — every path in use today already ran with the salt length at zero, so transcripts are byte-identical.

### The problem

The binary Merkle tree can salt every leaf with random field elements, to make the commitment hiding.

Nothing uses it.

- Every production call site builds a non-hiding tree.
- The only callers of the hiding constructors are four tests that exist to exercise salting itself.

And it is not free to keep:

- The tree carries a salt vector, which forces a second type parameter onto it purely to name the field.
- The prover carries a `Mutex<StdRng>`, seeded from a dummy constant whenever salting is off.
- Committing threads an RNG through two builders that otherwise need none.
- Every leaf opening reads a salt from the proof before it can hash the leaf.
- Full-vector opening exists only to write salts.

### The idea

Zero-knowledge does not come from the commitment being hiding.

It comes from the witness blinding: one extra degree of freedom in the blinded witness is enough to make the BaseFold reduction zero-knowledge.

So the salt is not load-bearing for any property the protocol claims, and it can go rather than be maintained.

### What collapses

```
BinaryMerkleTree<D, F>                        ->  BinaryMerkleTree<D>
build(elements, batch_size, salt_len, rng)    ->  build(elements, batch_size)
prove_vector(committed, proof)                ->  (deleted)
verify_vector(root, data, batch_size, proof)  ->  verify_vector(root, data, batch_size)
```

Line 1: with no salts the tree holds no field elements at all, so the type parameter has nothing left to name.

Line 3: the whole body of the full-vector proof wrote salts, so with none to write it had nothing left to do.

Line 4: with no advice to read, the committed values *are* the entire opening, so the verifier needs no transcript reader.

### The change

- `crates/hash/src/binary_merkle_tree.rs` — the salt field, salt generation, the salt accessor, and the salted branch of leaf hashing.
- `crates/iop/src/merkle_tree/` — the scheme's salt length, its hiding constructor, the salt read, and the full-vector signature.
- `crates/iop-prover/src/merkle_tree/` — the prover's RNG mutex, its hiding constructor, and the now-empty full-vector proof.
- both Merkle channels — their hiding constructors.
- five files carrying prose that assumed a non-hiding scheme, including a Spartan comment claiming the mask is *"committed with hiding"* — which is exactly the misconception this PR corrects.

### Soundness

- The verifier's checks are unchanged: same leaf hashes, same fold, same root comparison.
- Transcripts are byte-identical to today's, because every production path already set the salt length to zero.
- No claimed property is lost: the zero-knowledge argument rests on witness blinding, not on hiding commitments.

### Tests

Four salted tests turned out to be byte-identical to unsalted ones sitting beside them.

- **removed:** the salted commit/open, full-vector, and internal-layer tests, plus the salted channel round trip.
- **kept, now unsalted:** the batch-size test — the only one carrying coverage of its own, since nothing else exercises a leaf holding more than one value.

### One incidental fix

Removing the prover's mutex removed the channel's drop glue, which surfaced a `drop_non_drop` warning on six calls that dropped a channel to release its borrow of the transcript.

Handing the transcript back expresses that directly, and keeps clippy quiet.

### Scope

- **removed:** all salt and hiding machinery, across the tree, the scheme, the prover, and both channels
- **changed:** signatures that carried salt parameters; stale prose in five files
- **untouched:** the folding, the branch layout, the proof-size formula, and every other verifier check

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy` on hash, iop, iop-prover, spartan-verifier `--all-targets` — zero warnings
- `cargo +nightly fmt --all --check` — clean
- `cargo test` on hash, iop, iop-prover, spartan-verifier, spartan-prover — 82 passed, 0 failed

The Spartan crates are in the list on purpose: they are the zero-knowledge consumers, so if anything had leaned on Merkle hiding for its security argument, that is where it would have shown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)