### PR TITLE
BINIUS-414: introduce a Shift type in binius-core

### DIFF
--- a/crates/core/src/constraint_system/constraint.rs
+++ b/crates/core/src/constraint_system/constraint.rs
@@ -441,8 +441,7 @@ mod tests {
 
 		for (orig, deser) in constraint.val().iter().zip(deserialized.val().iter()) {
 			assert_eq!(orig.value_index, deser.value_index);
-			assert_eq!(orig.shift_variant, deser.shift_variant);
-			assert_eq!(orig.amount, deser.amount);
+			assert_eq!(orig.shift, deser.shift);
 		}
 	}
 
@@ -467,7 +466,7 @@ mod tests {
 
 		for (orig, deser) in constraint.a().iter().zip(deserialized.a().iter()) {
 			assert_eq!(orig.value_index, deser.value_index);
-			assert_eq!(orig.amount, deser.amount);
+			assert_eq!(orig.shift.amount, deser.shift.amount);
 		}
 	}
 

--- a/crates/core/src/constraint_system/shift.rs
+++ b/crates/core/src/constraint_system/shift.rs
@@ -1,4 +1,5 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 use std::{iter, mem::MaybeUninit};
 
 use binius_utils::serialization::{DeserializeBytes, SerializationError, SerializeBytes};
@@ -288,33 +289,222 @@ impl DeserializeBytes for ShiftVariant {
 	}
 }
 
-/// Similar to [`ValueIndex`], but represents a value that has been shifted by a certain amount.
+/// One shift: an operation paired with the distance it moves by.
+///
+/// The amount is always below the variant's [`max_amount`](ShiftVariant::max_amount), so a `Shift`
+/// that exists denotes the same operation wherever it is read.
+///
+/// Every variant is the identity at amount 0, so the amount alone does not fix how the identity is
+/// spelled. [`Shift::IDENTITY`] is the canonical spelling, and [`Self::is_canonical`] is what says
+/// which spelling a constraint system may carry.
+///
+/// The amount is stored as a byte to keep the struct small: constraint systems hold millions of
+/// these.
+///
+/// ```
+/// use binius_core::{constraint_system::Shift, word::Word};
+///
+/// let word = Word::from_u64(0xf0);
+/// assert_eq!(Shift::srl(4).apply(word), Word::from_u64(0x0f));
+/// assert_eq!(Shift::IDENTITY.apply(word), word);
+///
+/// // Every variant is the identity at amount 0, but only one spelling is canonical.
+/// assert!(Shift::rotr(0).is_identity());
+/// assert!(!Shift::rotr(0).is_canonical());
+/// ```
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
+pub struct Shift {
+	/// The operation this shift performs.
+	pub variant: ShiftVariant,
+	/// The number of bits to shift by, below the variant's upper bound.
+	pub amount: u8,
+}
+
+impl Shift {
+	/// The canonical shift that leaves a word untouched.
+	pub const IDENTITY: Self = Self {
+		variant: ShiftVariant::Sll,
+		amount: 0,
+	};
+
+	/// A shift of `amount` bits by `variant`.
+	///
+	/// # Panics
+	///
+	/// Panics if the amount is not below the variant's [`max_amount`](ShiftVariant::max_amount):
+	/// 32 for the half-word (`*32`) variants, 64 for the rest.
+	pub fn new(variant: ShiftVariant, amount: usize) -> Self {
+		assert!(
+			amount < variant.max_amount(),
+			"shift amount n={amount} out of range for {variant:?}"
+		);
+		Self {
+			variant,
+			// An amount below 64 always fits in the byte-sized field.
+			amount: amount as u8,
+		}
+	}
+
+	/// Shift Left Logical.
+	///
+	/// # Panics
+	/// Panics if the shift amount is greater than or equal to 64.
+	pub fn sll(amount: usize) -> Self {
+		Self::new(ShiftVariant::Sll, amount)
+	}
+
+	/// Shift Right Logical.
+	///
+	/// # Panics
+	/// Panics if the shift amount is greater than or equal to 64.
+	pub fn srl(amount: usize) -> Self {
+		Self::new(ShiftVariant::Slr, amount)
+	}
+
+	/// Shift Right Arithmetic.
+	///
+	/// This is similar to the Shift Right Logical but instead of shifting in 0 bits it will
+	/// replicate the sign bit.
+	///
+	/// # Panics
+	/// Panics if the shift amount is greater than or equal to 64.
+	pub fn sar(amount: usize) -> Self {
+		Self::new(ShiftVariant::Sar, amount)
+	}
+
+	/// Rotate Right.
+	///
+	/// Rotates bits to the right, with bits shifted off the right end wrapping around to the left.
+	///
+	/// # Panics
+	/// Panics if the shift amount is greater than or equal to 64.
+	pub fn rotr(amount: usize) -> Self {
+		Self::new(ShiftVariant::Rotr, amount)
+	}
+
+	/// Shift Left Logical on 32-bit halves.
+	///
+	/// Performs independent logical left shifts on the upper and lower 32-bit halves.
+	///
+	/// # Panics
+	/// Panics if the shift amount is greater than or equal to 32.
+	pub fn sll32(amount: usize) -> Self {
+		Self::new(ShiftVariant::Sll32, amount)
+	}
+
+	/// Shift Right Logical on 32-bit halves.
+	///
+	/// Performs independent logical right shifts on the upper and lower 32-bit halves.
+	///
+	/// # Panics
+	/// Panics if the shift amount is greater than or equal to 32.
+	pub fn srl32(amount: usize) -> Self {
+		Self::new(ShiftVariant::Srl32, amount)
+	}
+
+	/// Shift Right Arithmetic on 32-bit halves.
+	///
+	/// Performs independent arithmetic right shifts on the upper and lower 32-bit halves,
+	/// sign extending each half independently.
+	///
+	/// # Panics
+	/// Panics if the shift amount is greater than or equal to 32.
+	pub fn sra32(amount: usize) -> Self {
+		Self::new(ShiftVariant::Sra32, amount)
+	}
+
+	/// Rotate Right on 32-bit halves.
+	///
+	/// Performs independent rotate right operations on the upper and lower 32-bit halves.
+	///
+	/// # Panics
+	/// Panics if the shift amount is greater than or equal to 32.
+	pub fn rotr32(amount: usize) -> Self {
+		Self::new(ShiftVariant::Rotr32, amount)
+	}
+
+	/// Whether this shift leaves every word untouched.
+	///
+	/// Every variant is the identity at amount 0, so this holds for more shifts than
+	/// [`Shift::IDENTITY`] alone.
+	#[inline]
+	pub const fn is_identity(self) -> bool {
+		self.amount == 0
+	}
+
+	/// Whether this is the canonical spelling of the operation it denotes.
+	///
+	/// Only the identity has more than one spelling, and [`Shift::IDENTITY`] is the one to use.
+	/// Constraint systems carry canonical shifts only, so that two terms denoting the same shifted
+	/// word compare equal.
+	#[inline]
+	pub const fn is_canonical(self) -> bool {
+		!self.is_identity() || matches!(self.variant, ShiftVariant::Sll)
+	}
+
+	/// Applies this shift to a word and returns the result.
+	///
+	/// # Performance
+	///
+	/// Which operation to run is decided on every call. To shift many words by one fixed shift,
+	/// resolve the variant once instead — see [`ShiftVariant::write_shifted`] and
+	/// [`ShiftVariant::xor_shifted`].
+	#[inline]
+	pub fn apply(self, word: Word) -> Word {
+		self.variant.apply(word, self.amount as usize)
+	}
+}
+
+impl SerializeBytes for Shift {
+	fn serialize(&self, mut write_buf: impl BufMut) -> Result<(), SerializationError> {
+		self.variant.serialize(&mut write_buf)?;
+		// Keep the wire format a usize so serialized systems stay byte-compatible.
+		(self.amount as usize).serialize(write_buf)
+	}
+}
+
+impl DeserializeBytes for Shift {
+	fn deserialize(mut read_buf: impl Buf) -> Result<Self, SerializationError>
+	where
+		Self: Sized,
+	{
+		let variant = ShiftVariant::deserialize(&mut read_buf)?;
+		let amount = usize::deserialize(read_buf)?;
+
+		// Reject any amount the variant cannot represent.
+		// Half-word variants cap at 32, full-width at 64.
+		// This mirrors the bound `Shift::new` enforces.
+		// An amount below 64 always fits in the byte-sized field.
+		if amount >= variant.max_amount() {
+			return Err(SerializationError::InvalidConstruction {
+				name: "Shift::amount",
+			});
+		}
+
+		Ok(Shift {
+			variant,
+			amount: amount as u8,
+		})
+	}
+}
+
+/// Similar to [`ValueIndex`], but represents a value that has been shifted.
 ///
 /// This is used in the operands to constraints like [`AndConstraint`](super::AndConstraint).
-///
-/// The canonical formto represent a value without any shifting is [`ShiftVariant::Sll`] with
-/// amount equals 0.
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
 pub struct ShiftedValueIndex {
 	/// The index of this value in the input values vector.
 	pub value_index: ValueIndex,
-	/// The flavour of the shift that the value must be shifted by.
-	pub shift_variant: ShiftVariant,
-	/// The number of bits to shift by.
-	///
-	/// Stored as a byte to keep the struct small: constraint systems hold millions of these.
-	/// Must be less than 64.
-	pub amount: u8,
+	/// The shift applied to the value.
+	pub shift: Shift,
 }
 
 impl ShiftedValueIndex {
-	/// Create a value index that just uses the specified value. Equivalent to [`Self::sll`] with
-	/// amount equals 0.
+	/// Create a value index that just uses the specified value, unshifted.
 	pub const fn plain(value_index: ValueIndex) -> Self {
 		Self {
 			value_index,
-			shift_variant: ShiftVariant::Sll,
-			amount: 0,
+			shift: Shift::IDENTITY,
 		}
 	}
 
@@ -323,11 +513,9 @@ impl ShiftedValueIndex {
 	/// # Panics
 	/// Panics if the shift amount is greater than or equal to 64.
 	pub fn sll(value_index: ValueIndex, amount: usize) -> Self {
-		assert!(amount < 64, "shift amount n={amount} out of range");
 		Self {
 			value_index,
-			shift_variant: ShiftVariant::Sll,
-			amount: amount as u8,
+			shift: Shift::sll(amount),
 		}
 	}
 
@@ -336,11 +524,9 @@ impl ShiftedValueIndex {
 	/// # Panics
 	/// Panics if the shift amount is greater than or equal to 64.
 	pub fn srl(value_index: ValueIndex, amount: usize) -> Self {
-		assert!(amount < 64, "shift amount n={amount} out of range");
 		Self {
 			value_index,
-			shift_variant: ShiftVariant::Slr,
-			amount: amount as u8,
+			shift: Shift::srl(amount),
 		}
 	}
 
@@ -352,11 +538,9 @@ impl ShiftedValueIndex {
 	/// # Panics
 	/// Panics if the shift amount is greater than or equal to 64.
 	pub fn sar(value_index: ValueIndex, amount: usize) -> Self {
-		assert!(amount < 64, "shift amount n={amount} out of range");
 		Self {
 			value_index,
-			shift_variant: ShiftVariant::Sar,
-			amount: amount as u8,
+			shift: Shift::sar(amount),
 		}
 	}
 
@@ -367,11 +551,9 @@ impl ShiftedValueIndex {
 	/// # Panics
 	/// Panics if the shift amount is greater than or equal to 64.
 	pub fn rotr(value_index: ValueIndex, amount: usize) -> Self {
-		assert!(amount < 64, "shift amount n={amount} out of range");
 		Self {
 			value_index,
-			shift_variant: ShiftVariant::Rotr,
-			amount: amount as u8,
+			shift: Shift::rotr(amount),
 		}
 	}
 
@@ -383,11 +565,9 @@ impl ShiftedValueIndex {
 	/// # Panics
 	/// Panics if the shift amount is greater than or equal to 32.
 	pub fn sll32(value_index: ValueIndex, amount: usize) -> Self {
-		assert!(amount < 32, "shift amount n={amount} out of range for 32-bit shift");
 		Self {
 			value_index,
-			shift_variant: ShiftVariant::Sll32,
-			amount: amount as u8,
+			shift: Shift::sll32(amount),
 		}
 	}
 
@@ -399,11 +579,9 @@ impl ShiftedValueIndex {
 	/// # Panics
 	/// Panics if the shift amount is greater than or equal to 32.
 	pub fn srl32(value_index: ValueIndex, amount: usize) -> Self {
-		assert!(amount < 32, "shift amount n={amount} out of range for 32-bit shift");
 		Self {
 			value_index,
-			shift_variant: ShiftVariant::Srl32,
-			amount: amount as u8,
+			shift: Shift::srl32(amount),
 		}
 	}
 
@@ -416,11 +594,9 @@ impl ShiftedValueIndex {
 	/// # Panics
 	/// Panics if the shift amount is greater than or equal to 32.
 	pub fn sra32(value_index: ValueIndex, amount: usize) -> Self {
-		assert!(amount < 32, "shift amount n={amount} out of range for 32-bit shift");
 		Self {
 			value_index,
-			shift_variant: ShiftVariant::Sra32,
-			amount: amount as u8,
+			shift: Shift::sra32(amount),
 		}
 	}
 
@@ -428,16 +604,13 @@ impl ShiftedValueIndex {
 	///
 	/// Performs independent rotate right operations on the upper and lower 32-bit halves.
 	/// Bits shifted off the right end wrap around to the left within each 32-bit half.
-	/// Only uses the lower 5 bits of the shift amount (0-31).
 	///
 	/// # Panics
 	/// Panics if the shift amount is greater than or equal to 32.
 	pub fn rotr32(value_index: ValueIndex, amount: usize) -> Self {
-		assert!(amount < 32, "shift amount n={amount} out of range for 32-bit rotate");
 		Self {
 			value_index,
-			shift_variant: ShiftVariant::Rotr32,
-			amount: amount as u8,
+			shift: Shift::rotr32(amount),
 		}
 	}
 
@@ -448,17 +621,14 @@ impl ShiftedValueIndex {
 	#[inline]
 	pub fn eval(&self, witness: &ValueVec) -> Word {
 		// Look up the referenced word, then apply this term's shift.
-		self.shift_variant
-			.apply(witness[self.value_index], self.amount as usize)
+		self.shift.apply(witness[self.value_index])
 	}
 }
 
 impl SerializeBytes for ShiftedValueIndex {
 	fn serialize(&self, mut write_buf: impl BufMut) -> Result<(), SerializationError> {
 		self.value_index.serialize(&mut write_buf)?;
-		self.shift_variant.serialize(&mut write_buf)?;
-		// Keep the wire format a u32 so serialized systems stay byte-compatible.
-		(self.amount as usize).serialize(write_buf)
+		self.shift.serialize(write_buf)
 	}
 }
 
@@ -468,24 +638,8 @@ impl DeserializeBytes for ShiftedValueIndex {
 		Self: Sized,
 	{
 		let value_index = ValueIndex::deserialize(&mut read_buf)?;
-		let shift_variant = ShiftVariant::deserialize(&mut read_buf)?;
-		let amount = usize::deserialize(read_buf)?;
-
-		// Reject any amount the variant cannot represent.
-		// Half-word variants cap at 32, full-width at 64.
-		// This mirrors the bound the constructors enforce.
-		// A value below 64 always fits in the byte-sized field.
-		if amount >= shift_variant.max_amount() {
-			return Err(SerializationError::InvalidConstruction {
-				name: "ShiftedValueIndex::amount",
-			});
-		}
-
-		Ok(ShiftedValueIndex {
-			value_index,
-			shift_variant,
-			amount: amount as u8,
-		})
+		let shift = Shift::deserialize(read_buf)?;
+		Ok(ShiftedValueIndex { value_index, shift })
 	}
 }
 
@@ -646,8 +800,8 @@ mod tests {
 
 		let deserialized = ShiftedValueIndex::deserialize(&mut buf.as_slice()).unwrap();
 		assert_eq!(shifted_value_index.value_index, deserialized.value_index);
-		assert_eq!(shifted_value_index.amount, deserialized.amount);
-		match (shifted_value_index.shift_variant, deserialized.shift_variant) {
+		assert_eq!(shifted_value_index.shift.amount, deserialized.shift.amount);
+		match (shifted_value_index.shift.variant, deserialized.shift.variant) {
 			(ShiftVariant::Slr, ShiftVariant::Slr) => {}
 			_ => panic!("ShiftVariant mismatch"),
 		}
@@ -665,7 +819,7 @@ mod tests {
 		assert!(result.is_err());
 		match result.unwrap_err() {
 			SerializationError::InvalidConstruction { name } => {
-				assert_eq!(name, "ShiftedValueIndex::amount");
+				assert_eq!(name, "Shift::amount");
 			}
 			_ => panic!("Expected InvalidConstruction error"),
 		}
@@ -707,14 +861,13 @@ mod tests {
 			deserialize_amount(ShiftVariant::Sll32, 31).unwrap(),
 			ShiftedValueIndex {
 				value_index: ValueIndex::constant(0),
-				shift_variant: ShiftVariant::Sll32,
-				amount: 31,
+				shift: Shift::sll32(31),
 			}
 		);
 		// 32 exceeds the 5-bit range and must be rejected.
 		match deserialize_amount(ShiftVariant::Sll32, 32).unwrap_err() {
 			SerializationError::InvalidConstruction { name } => {
-				assert_eq!(name, "ShiftedValueIndex::amount");
+				assert_eq!(name, "Shift::amount");
 			}
 			other => panic!("Expected InvalidConstruction, got: {other:?}"),
 		}
@@ -723,23 +876,21 @@ mod tests {
 			deserialize_amount(ShiftVariant::Sll, 32).unwrap(),
 			ShiftedValueIndex {
 				value_index: ValueIndex::constant(0),
-				shift_variant: ShiftVariant::Sll,
-				amount: 32,
+				shift: Shift::sll(32),
 			}
 		);
 		assert_eq!(
 			deserialize_amount(ShiftVariant::Sll, 63).unwrap(),
 			ShiftedValueIndex {
 				value_index: ValueIndex::constant(0),
-				shift_variant: ShiftVariant::Sll,
-				amount: 63,
+				shift: Shift::sll(63),
 			}
 		);
 	}
 
 	#[test]
 	fn shifted_value_index_fits_in_a_word() {
-		// Layout: value_index (u32, 4 bytes) + shift_variant (1 byte) + amount (u8, 1 byte).
+		// Layout: value_index (u32, 4 bytes) + Shift (variant byte + amount byte).
 		// Padded to the u32 alignment, that is 8 bytes.
 		// Holding this at one word matters: systems carry millions of these on the prover hot path.
 		assert_eq!(size_of::<ShiftedValueIndex>(), 8);

--- a/crates/core/src/constraint_system/system.rs
+++ b/crates/core/src/constraint_system/system.rs
@@ -9,8 +9,8 @@ use binius_utils::{
 use bytes::{Buf, BufMut};
 
 use super::{
-	AndConstraint, BmulConstraint, ConstraintKind, ImulConstraint, Operand, ShiftVariant,
-	ValueIndex, ValueSegment, ValueVec, ZeroConstraint,
+	AndConstraint, BmulConstraint, ConstraintKind, ImulConstraint, Operand, ValueIndex,
+	ValueSegment, ValueVec, ZeroConstraint,
 };
 use crate::{
 	error::{ConstraintSystemError, VerificationError},
@@ -303,22 +303,24 @@ impl ConstraintSystem {
 		operand_name: &'static str,
 	) -> Result<(), ConstraintSystemError> {
 		for term in operand {
-			// check canonicity. SLL is the canonical form of the operand.
-			if term.amount == 0 && term.shift_variant != ShiftVariant::Sll {
+			// check canonicity. SLL is the canonical form of the identity.
+			if !term.shift.is_canonical() {
 				return Err(ConstraintSystemError::NonCanonicalShift {
 					constraint_kind,
 					constraint_index,
 					operand_name,
 				});
 			}
-			// Half-word (*32) variants cap at 32, full-width at 64.
-			let max_amount = term.shift_variant.max_amount();
-			if usize::from(term.amount) >= max_amount {
+			// Half-word (*32) variants cap at 32, full-width at 64. `Shift::new` and the
+			// deserializer both enforce this, but the fields are public, so a hand-built term can
+			// still carry an amount the variant cannot represent.
+			let max_amount = term.shift.variant.max_amount();
+			if usize::from(term.shift.amount) >= max_amount {
 				return Err(ConstraintSystemError::ShiftAmountTooLarge {
 					constraint_kind,
 					constraint_index,
 					operand_name,
-					shift_amount: term.amount as usize,
+					shift_amount: term.shift.amount as usize,
 					max_amount,
 				});
 			}
@@ -482,7 +484,7 @@ impl DeserializeBytes for ConstraintSystem {
 mod tests {
 	use super::*;
 	use crate::{
-		constraint_system::{ShiftedValueIndex, ValuesData},
+		constraint_system::{Shift, ShiftVariant, ShiftedValueIndex, ValuesData},
 		error::ConstraintViolation,
 	};
 
@@ -955,8 +957,12 @@ mod tests {
 		cs.and_constraints.push(AndConstraint::abc(
 			vec![ShiftedValueIndex {
 				value_index: ValueIndex::constant(0),
-				shift_variant: ShiftVariant::Sll32,
-				amount: 32,
+				// Built raw: `Shift::new` would reject this amount, and `validate` is what is
+				// under test here.
+				shift: Shift {
+					variant: ShiftVariant::Sll32,
+					amount: 32,
+				},
 			}],
 			vec![ShiftedValueIndex::plain(ValueIndex::private(0))],
 			vec![ShiftedValueIndex::plain(ValueIndex::private(0))],

--- a/crates/frontend/src/compiler/constraint_builder/constraint.rs
+++ b/crates/frontend/src/compiler/constraint_builder/constraint.rs
@@ -194,12 +194,12 @@ mod tests {
 		assert!(
 			bc.c_hi()
 				.iter()
-				.any(|svi| svi.value_index == ValueIndex::private(5) && svi.amount == 0)
+				.any(|svi| svi.value_index == ValueIndex::private(5) && svi.shift.amount == 0)
 		);
 		assert!(bc.c_hi().iter().any(|svi| {
 			svi.value_index == ValueIndex::private(6)
-				&& svi.amount == 5
-				&& matches!(svi.shift_variant, ShiftVariant::Sll)
+				&& svi.shift.amount == 5
+				&& matches!(svi.shift.variant, ShiftVariant::Sll)
 		}));
 	}
 }

--- a/crates/frontend/src/compiler/constraint_builder/expr.rs
+++ b/crates/frontend/src/compiler/constraint_builder/expr.rs
@@ -179,22 +179,22 @@ mod tests {
 
 		assert!(
 			val.iter()
-				.any(|svi| svi.value_index == ValueIndex::private(0) && svi.amount == 0),
+				.any(|svi| svi.value_index == ValueIndex::private(0) && svi.shift.amount == 0),
 			"plain(a) from rotr(a, 0)"
 		);
 		assert!(
 			val.iter().any(|svi| {
 				svi.value_index == ValueIndex::private(1)
-					&& svi.amount == 5
-					&& matches!(svi.shift_variant, ShiftVariant::Sll)
+					&& svi.shift.amount == 5
+					&& matches!(svi.shift.variant, ShiftVariant::Sll)
 			}),
 			"native sll(b, 5)"
 		);
 		assert!(
 			val.iter().any(|svi| {
 				svi.value_index == ValueIndex::private(0)
-					&& svi.amount == 12
-					&& matches!(svi.shift_variant, ShiftVariant::Rotr)
+					&& svi.shift.amount == 12
+					&& matches!(svi.shift.variant, ShiftVariant::Rotr)
 			}),
 			"native rotr(a, 12)"
 		);

--- a/crates/frontend/src/compiler/constraint_builder/shift.rs
+++ b/crates/frontend/src/compiler/constraint_builder/shift.rs
@@ -286,16 +286,16 @@ mod tests {
 			assert_eq!(val.len(), 3);
 			assert!(
 				val.iter()
-					.any(|svi| svi.value_index == ValueIndex::private(0) && svi.amount == 0)
+					.any(|svi| svi.value_index == ValueIndex::private(0) && svi.shift.amount == 0)
 			);
 			assert!(
 				val.iter()
-					.any(|svi| svi.value_index == ValueIndex::private(1) && svi.amount == 0)
+					.any(|svi| svi.value_index == ValueIndex::private(1) && svi.shift.amount == 0)
 			);
 			// The destination joins the operand rather than sitting in its own `c`.
 			assert!(
 				val.iter()
-					.any(|svi| svi.value_index == ValueIndex::private(2) && svi.amount == 0)
+					.any(|svi| svi.value_index == ValueIndex::private(2) && svi.shift.amount == 0)
 			);
 		}
 
@@ -315,12 +315,12 @@ mod tests {
 			assert_eq!(val.len(), 3);
 			assert!(val.iter().any(|svi| {
 				svi.value_index == ValueIndex::private(0)
-					&& svi.amount == 5
-					&& matches!(svi.shift_variant, ShiftVariant::Rotr)
+					&& svi.shift.amount == 5
+					&& matches!(svi.shift.variant, ShiftVariant::Rotr)
 			}));
 			assert!(
 				val.iter()
-					.any(|svi| svi.value_index == ValueIndex::private(1) && svi.amount == 0)
+					.any(|svi| svi.value_index == ValueIndex::private(1) && svi.shift.amount == 0)
 			);
 		}
 	}
@@ -351,15 +351,15 @@ mod tests {
 
 			assert_eq!(and_c.a().len(), 1);
 			assert_eq!(and_c.a()[0].value_index, ValueIndex::private(0));
-			assert_eq!(and_c.a()[0].amount, 0);
+			assert_eq!(and_c.a()[0].shift.amount, 0);
 
 			assert_eq!(and_c.b().len(), 1);
 			assert_eq!(and_c.b()[0].value_index, ValueIndex::private(1));
-			assert_eq!(and_c.b()[0].amount, 0);
+			assert_eq!(and_c.b()[0].shift.amount, 0);
 
 			assert_eq!(and_c.c().len(), 1);
 			assert_eq!(and_c.c()[0].value_index, ValueIndex::private(2));
-			assert_eq!(and_c.c()[0].amount, 0);
+			assert_eq!(and_c.c()[0].shift.amount, 0);
 		}
 
 		// a & rotr(b, 8) = c  ->  b keeps native rotr(8).
@@ -374,8 +374,8 @@ mod tests {
 			assert_eq!(and_c.b().len(), 1);
 			assert!(and_c.b().iter().any(|svi| {
 				svi.value_index == ValueIndex::private(1)
-					&& svi.amount == 8
-					&& matches!(svi.shift_variant, ShiftVariant::Rotr)
+					&& svi.shift.amount == 8
+					&& matches!(svi.shift.variant, ShiftVariant::Rotr)
 			}));
 		}
 	}

--- a/crates/frontend/src/compiler/gate_fusion/tests/awhole.rs
+++ b/crates/frontend/src/compiler/gate_fusion/tests/awhole.rs
@@ -119,10 +119,10 @@ fn format_operand(
 
 		let value_name = format_value_name(term.value_index, cs);
 
-		if term.amount == 0 {
+		if term.shift.is_identity() {
 			write!(output, "{}", value_name).unwrap();
 		} else {
-			let shift_op = match term.shift_variant {
+			let shift_op = match term.shift.variant {
 				ShiftVariant::Sll => "≪",
 				ShiftVariant::Slr => "≫",
 				ShiftVariant::Sar => "a≫",
@@ -132,7 +132,7 @@ fn format_operand(
 				ShiftVariant::Sra32 => "a≫32",
 				ShiftVariant::Rotr32 => "≫≫32",
 			};
-			write!(output, "{}{}{}", value_name, shift_op, term.amount).unwrap();
+			write!(output, "{}{}{}", value_name, shift_op, term.shift.amount).unwrap();
 		}
 	}
 }

--- a/crates/frontend/src/stat.rs
+++ b/crates/frontend/src/stat.rs
@@ -348,7 +348,7 @@ impl Cx {
 	/// Records every term of one operand.
 	fn visit_operand(&mut self, operand: &Operand) {
 		for term in operand {
-			if term.amount == 0 {
+			if term.shift.is_identity() {
 				self.unshifted_terms.insert(*term);
 			} else {
 				self.shifted_terms.insert(*term);

--- a/crates/m4-prover/src/witness/operand_columns.rs
+++ b/crates/m4-prover/src/witness/operand_columns.rs
@@ -8,7 +8,7 @@ use std::{iter, mem::MaybeUninit, ptr};
 use binius_compute::{Allocator, VecLike};
 use binius_core::{
 	ValueSegment,
-	constraint_system::{Operand, ShiftVariant, ShiftedValueIndex},
+	constraint_system::{Operand, Shift, ShiftVariant, ShiftedValueIndex},
 	word::Word,
 };
 use binius_field::{Field, PackedField};
@@ -428,8 +428,7 @@ impl<'a> ValueWords<'a> {
 	fn term_words(&self, term: &ShiftedValueIndex) -> TermWords<'a> {
 		let &ShiftedValueIndex {
 			value_index,
-			shift_variant: variant,
-			amount,
+			shift: Shift { variant, amount },
 		} = term;
 
 		let row_index = match value_index.segment() {
@@ -469,7 +468,7 @@ impl<'a> ValueWords<'a> {
 mod tests {
 	use assert_matches::assert_matches;
 	use binius_compute::{BufferPool, GlobalAllocator};
-	use binius_core::constraint_system::{AndConstraint, ShiftVariant, ValueVec};
+	use binius_core::constraint_system::{AndConstraint, Shift, ShiftVariant, ValueVec};
 	use binius_field::{AESTowerField8b as B8, PackedBinaryGhash1x128b, Random};
 	use binius_frontend::{Circuit, CircuitBuilder, Wire};
 	use binius_ip::channel::Error as ChannelError;
@@ -1046,10 +1045,9 @@ mod tests {
 			let to_operand = |terms: &[(usize, ShiftVariant, u8)]| -> Operand {
 				terms
 					.iter()
-					.map(|&(wire, shift_variant, amount)| ShiftedValueIndex {
+					.map(|&(wire, variant, amount)| ShiftedValueIndex {
 						value_index: wires[wire],
-						shift_variant,
-						amount,
+						shift: Shift { variant, amount },
 					})
 					.collect()
 			};
@@ -1154,7 +1152,7 @@ mod tests {
 		let shifted = and_constraints
 			.iter()
 			.flat_map(|con| [con.a(), con.b()])
-			.any(|op| op.iter().any(|sv| sv.amount != 0));
+			.any(|op| op.iter().any(|sv| !sv.shift.is_identity()));
 		assert!(shifted, "fixture must contain a shifted operand");
 
 		let columns =

--- a/crates/prover/src/protocols/shift/key_collection.rs
+++ b/crates/prover/src/protocols/shift/key_collection.rs
@@ -358,16 +358,11 @@ fn update_with_operand(
 ) {
 	for (constraint_idx, operand_value) in operand_values.enumerate() {
 		// Each operand value is a Vec<ShiftedValueIndex> - multiple shifted word references
-		for ShiftedValueIndex {
-			value_index,
-			shift_variant,
-			amount,
-		} in operand_value.as_ref()
-		{
+		for ShiftedValueIndex { value_index, shift } in operand_value.as_ref() {
 			// The lists are indexed by word position, so resolve the term's segment-relative
 			// index against the segment starts.
 			let builder_keys = &mut builder_key_lists[cs.word_offset(*value_index)];
-			let shift = (*shift_variant, *amount);
+			let shift = (shift.variant, shift.amount);
 
 			// Find existing builder key or create a new one for this (operation, shift) pair
 			let constraint_index = ConstraintIndex {

--- a/crates/prover/tests/prove_verify.rs
+++ b/crates/prover/tests/prove_verify.rs
@@ -353,7 +353,7 @@ fn zero_constraint_circuit(
 	assert!(
 		cs.zero_constraints
 			.iter()
-			.any(|c| c.val().iter().any(|svi| svi.amount != 0)),
+			.any(|c| c.val().iter().any(|svi| !svi.shift.is_identity())),
 		"the fixture must emit a ZERO constraint with a shifted operand"
 	);
 	let witness = w.into_value_vec();

--- a/crates/verifier/src/protocols/shift/monster.rs
+++ b/crates/verifier/src/protocols/shift/monster.rs
@@ -193,8 +193,9 @@ where
 			let mut constraint_eval = E::zero();
 			for (operand_id, operand) in constraint.as_ref().iter().enumerate() {
 				for svi in operand {
-					let variant = svi.shift_variant as usize;
-					let index = (variant * Word::BITS + svi.amount as usize) * ARITY + operand_id;
+					let variant = svi.shift.variant as usize;
+					let index =
+						(variant * Word::BITS + svi.shift.amount as usize) * ARITY + operand_id;
 					constraint_eval += operand_shift_scalars[index].clone()
 						* &r_y_tensor[svi.value_index.segment() as usize]
 							[svi.value_index.index() as usize];
@@ -232,9 +233,9 @@ where
 				let mut constraint_eval = F::ZERO;
 				for (operand_id, operand) in constraint.as_ref().iter().enumerate() {
 					for svi in operand {
-						let variant = svi.shift_variant as usize;
+						let variant = svi.shift.variant as usize;
 						let index =
-							(variant * Word::BITS + svi.amount as usize) * ARITY + operand_id;
+							(variant * Word::BITS + svi.shift.amount as usize) * ARITY + operand_id;
 						constraint_eval += operand_shift_scalars[index]
 							* r_y_tensor[svi.value_index.segment() as usize]
 								[svi.value_index.index() as usize];
@@ -297,7 +298,7 @@ fn operand_shift_scalar_table<E: FieldOps>(
 mod tests {
 	use binius_core::{
 		ShiftVariant,
-		constraint_system::{AndConstraint, ShiftedValueIndex, ValueIndex},
+		constraint_system::{AndConstraint, Shift, ShiftedValueIndex, ValueIndex},
 	};
 	use binius_field::{BinaryField128bGhash, Field, Random};
 	use binius_math::{
@@ -335,8 +336,10 @@ mod tests {
 					(0..rng.random_range(0..=3))
 						.map(|_| ShiftedValueIndex {
 							value_index: ValueIndex::private(rng.random_range(0..n_words) as u32),
-							shift_variant: shift_variants[rng.random_range(0..SHIFT_VARIANT_COUNT)],
-							amount: rng.random_range(0..Word::BITS) as u8,
+							shift: Shift {
+								variant: shift_variants[rng.random_range(0..SHIFT_VARIANT_COUNT)],
+								amount: rng.random_range(0..Word::BITS) as u8,
+							},
 						})
 						.collect()
 				}))


### PR DESCRIPTION
Closes [BINIUS-414](https://linear.app/jimpo/issue/BINIUS-414/introduce-a-shift-variant-amount-type-in-binius-core), the first step of [BINIUS-408](https://linear.app/jimpo/issue/BINIUS-408/double-shifted-value-indices).

A shift is an operation paired with a distance, and every caller already handled the two together: `ShiftVariant::apply` took the amount, the nine `ShiftedValueIndex` constructors each asserted the same bound, and the canonicity rule lived in `ConstraintSystem::validate_operand` — far from the type it constrains.

Give the pair a name:

```rust
pub struct Shift {
    pub variant: ShiftVariant,
    pub amount: u8,
}

pub struct ShiftedValueIndex {
    pub value_index: ValueIndex,
    pub shift: Shift,
}
```

`Shift` owns the bound (`Shift::new` and the deserializer are the two places that enforce `amount < variant.max_amount()`), the canonicity predicate (`is_canonical`), and application (`apply`). The `ShiftedValueIndex::{sll, srl, …}` constructors stay as conveniences that build a `Shift` and wrap it.

No behavior change: the same constraint systems come out.

## Notes for review

- **`size_of::<ShiftedValueIndex>()` is still 8.** `ValueIndex` is a `u32` and `Shift` is two bytes, so the struct stays one word — `shifted_value_index_fits_in_a_word` still passes. This matters; systems carry millions of these on the prover hot path.
- **The serialized wire format is unchanged**, so no version bump and no snapshot churn. The only visible change is the `InvalidConstruction` error name, which moved from `"ShiftedValueIndex::amount"` to `"Shift::amount"` now that `Shift` is what rejects the value. Serializing a `u8` amount as a `usize` is odd, but shrinking it is a separate, snapshot-churning change and BINIUS-408 will revisit this encoding anyway.
- **`validate_operand` still checks the amount bound** even though `Shift::new` enforces it. The fields are public, so a hand-built term can still be out of range — `test_validate_rejects_half_word_shift_amount_out_of_range` constructs exactly that.
- **Frontend test assertions stay mechanical.** Comparing whole shifts (`svi.shift == Shift::rotr(5)`) reads better than separate variant/amount checks, and I did that in core/prover/m4. In the frontend `Shift` already names the compiler's own enum, so it would need an alias — that duplication is what [BINIUS-416](https://linear.app/jimpo/issue/BINIUS-416/unify-the-frontend-shiftshiftkind-with-the-core-shift-type) removes, so those sites clean up for free there rather than growing an alias here.

## Verification

`cargo check --workspace --all-targets` clean, `cargo clippy` clean over core/frontend/prover/verifier/m4-prover with `--all-targets -- -D warnings`, `cargo fmt` applied, and core (98) + frontend (197) tests plus the new doctest pass. Left the rest of the suite to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
