### PR TITLE
BINIUS-418: batch the logUp* pushforward reduction over several tables

### DIFF
--- a/crates/ip-prover/src/logup_star/prove.rs
+++ b/crates/ip-prover/src/logup_star/prove.rs
@@ -11,7 +11,7 @@ use binius_math::{FieldBuffer, FieldSlice, FieldVec, univariate::evaluate_univar
 use binius_utils::{checked_arithmetics::log2_ceil_usize, rayon::prelude::*};
 
 use super::{
-	pushforward::{PushforwardOutput, prove_pushforward},
+	pushforward::{PushforwardOutput, TableWitness, prove_pushforward},
 	witness,
 };
 use crate::{
@@ -289,17 +289,26 @@ where
 	// Reduce the leaf claim on Y and the product claim <T, Y> = e to one shared evaluation point.
 	let PushforwardOutput {
 		table_eval_point,
-		table_eval_claim,
-		pushforward_eval_claim,
+		table_eval_claims,
+		pushforward_eval_claims,
 	} = prove_pushforward(
 		alloc,
-		table,
-		pushforward,
-		eval_claim,
-		table_leaf.num_eval,
-		&table_leaf.point,
+		[TableWitness {
+			table,
+			pushforward,
+			eval_claim,
+			pushforward_eval_claim: table_leaf.num_eval,
+			pushforward_eval_point: &table_leaf.point,
+		}],
 		channel,
 	);
+	// The reduction runs over the one shared table, so it returns one claim of each kind.
+	let [table_eval_claim]: [_; 1] = table_eval_claims
+		.try_into()
+		.unwrap_or_else(|_| unreachable!("the reduction runs over one table"));
+	let [pushforward_eval_claim]: [_; 1] = pushforward_eval_claims
+		.try_into()
+		.unwrap_or_else(|_| unreachable!("the reduction runs over one table"));
 
 	LogupOutput {
 		table_eval_point,

--- a/crates/ip-prover/src/logup_star/pushforward.rs
+++ b/crates/ip-prover/src/logup_star/pushforward.rs
@@ -2,15 +2,15 @@
 
 //! The pushforward reduction that closes the table side.
 //!
-//! The table-side fractional-addition GKR runs all the way to its leaf, which claims the
-//! pushforward `Y` at a point `z`. Its denominator half is the public `D = J - c`, so the verifier
-//! checks that one itself. That leaves two claims that both read `Y`:
+//! Each table's fractional-addition GKR runs all the way to its leaf, which claims that table's
+//! pushforward `Y_t` at a point `z_t`. Its denominator half is the public `D = J - c_t`, so the
+//! verifier checks that one itself. That leaves two claims per table that both read `Y_t`:
 //!
-//! - the GKR leaf claim `Y(z)`,
-//! - the product claim `<T, Y> = e`.
+//! - the GKR leaf claim `Y_t(z_t)`,
+//! - the product claim `<T_t, Y_t> = e_t`.
 //!
-//! One batched `m`-variable sumcheck over the shared column pair `[Y, T]` reduces both to a single
-//! evaluation point, giving one evaluation of `Y` and one of `T`.
+//! One batched sumcheck reduces every one of them to a single evaluation point, giving one
+//! evaluation of `Y_t` and one of `T_t` per table.
 //!
 //! This is the prover mirror of the verifier's pushforward reduction in [`binius_ip::logup_star`].
 
@@ -21,6 +21,7 @@ use binius_math::FieldSlice;
 use crate::{
 	channel::IPProverChannel,
 	sumcheck::{
+		PaddedSumcheckDecorator,
 		batch::batch_prove,
 		bivariate_product_evaluator::BivariateProductEvaluator,
 		mle_store::MleStore,
@@ -29,57 +30,72 @@ use crate::{
 	},
 };
 
-/// The evaluation claims that the pushforward reduction ends in.
-pub struct PushforwardOutput<F> {
-	/// The `m`-coordinate point shared by the table and pushforward evaluation claims.
-	pub table_eval_point: Vec<F>,
-	/// The claimed evaluation of the table multilinear `T` at the point.
-	pub table_eval_claim: F,
-	/// The claimed evaluation of the pushforward multilinear `Y` at the point.
-	pub pushforward_eval_claim: F,
+/// One table's witnesses and claims entering the pushforward reduction.
+pub struct TableWitness<'a, P: PackedField> {
+	/// The table `T_t` over its `m_t`-variable cube.
+	pub table: FieldSlice<'a, P>,
+	/// The pushforward `Y_t` over the same cube.
+	pub pushforward: FieldSlice<'a, P>,
+	/// The product claim `e_t = <T_t, Y_t>`.
+	pub eval_claim: P::Scalar,
+	/// The fractional-addition leaf claim `Y_t(z_t)`.
+	pub pushforward_eval_claim: P::Scalar,
+	/// The leaf point `z_t`, of length `m_t`.
+	pub pushforward_eval_point: &'a [P::Scalar],
 }
 
-/// Reduce the pushforward's two claims and the table's product claim to one evaluation point.
+/// The evaluation claims that the pushforward reduction ends in.
+pub struct PushforwardOutput<F> {
+	/// The point spanning the widest table, at which every table's claims are taken.
+	///
+	/// Table `t`, over `m_t` variables, is claimed at the **first `m_t`** coordinates: the batch
+	/// pads each table at its high coordinates.
+	pub table_eval_point: Vec<F>,
+	/// The claimed evaluations of the tables `T_t`, each at its own prefix of the point.
+	pub table_eval_claims: Vec<F>,
+	/// The claimed evaluations of the pushforwards `Y_t`, each at the same prefix.
+	pub pushforward_eval_claims: Vec<F>,
+}
+
+/// Reduce every table's pushforward and product claims to one evaluation point.
 ///
-/// Two sum claims are batched over the `m`-variable cube:
+/// Two sum claims are batched per table, over that table's `m_t`-variable cube:
 ///
 /// ```text
-///     S_1 = sum_x eq(x; z) * Y(x) = Y(z)      the GKR leaf claim, re-randomized
-///     S_2 = sum_x (Y * T)(x)      = e         the product claim
+///     S_1 = sum_x eq(x; z_t) * Y_t(x) = Y_t(z_t)      the GKR leaf claim, re-randomized
+///     S_2 = sum_x (Y_t * T_t)(x)      = e_t           the product claim
 /// ```
 ///
-/// `S_1` carries the equality factor `eq(x; z)`, so it starts as an eq-weighted MLE-check
+/// `S_1` carries the equality factor `eq(x; z_t)`, so it starts as an eq-weighted MLE-check
 /// evaluator; folding that factor into its round polynomials turns it into a plain sumcheck that
-/// batches with `S_2`, which carries no `eq` factor. Both read the same `Y` column, so the shared
-/// store holds just `[Y, T]` and the reduction emits one evaluation of each.
+/// batches with `S_2`, which carries no `eq` factor. Both read the same `Y_t` column, so a table's
+/// store holds just `[Y_t, T_t]` and the reduction emits one evaluation of each.
 ///
 /// Both summands are degree 2 per variable — `eq` times a multilinear, and a product of two
 /// multilinears — so the batched degree is 2.
 ///
+/// Tables need not agree on a size: a table shallower than the deepest one is wrapped in a
+/// [`PaddedSumcheckDecorator`], which raises it to the shared round count by multiplying its claims
+/// by an equality factor over the extra variables. Those are the highest-indexed ones and so are
+/// bound first, which puts a table's own challenges at the low coordinates of the shared point.
+///
 /// # Arguments
 ///
-/// * `alloc` - The allocator the sumcheck store draws its folded columns from.
-/// * `table` - The table `T` over the `m`-variable cube.
-/// * `pushforward` - The pushforward `Y` over the same cube.
-/// * `eval_claim` - The product claim `e = <T, Y>`.
-/// * `pushforward_eval_claim` - The GKR leaf claim `Y(z)`.
-/// * `pushforward_eval_point` - The leaf point `z`, of length `m`.
+/// * `alloc` - The allocator the sumcheck stores draw their folded columns from.
+/// * `tables` - The per-table witnesses and claims; their cubes may differ in size.
 /// * `channel` - The prover channel.
 ///
-/// Both multilinears are borrowed: the store's first fold contracts them into half-size buffers of
-/// its own, so neither is copied at full width.
+/// Every multilinear is borrowed: a store's first fold contracts its columns into half-size buffers
+/// of its own, so nothing is copied at full width.
 ///
 /// # Preconditions
 ///
-/// * `table.log_len() == pushforward.log_len() == pushforward_eval_point.len()`
+/// * `tables` is non-empty.
+/// * For each table, `table.log_len() == pushforward.log_len() == pushforward_eval_point.len()`.
 #[tracing::instrument(skip_all, level = "debug", name = "logup* pushforward reduction")]
 pub fn prove_pushforward<'a, A, F, P>(
 	alloc: &'a A,
-	table: FieldSlice<'a, P>,
-	pushforward: FieldSlice<'a, P>,
-	eval_claim: F,
-	pushforward_eval_claim: F,
-	pushforward_eval_point: &[F],
+	tables: impl IntoIterator<Item = TableWitness<'a, P>>,
 	channel: &mut impl IPProverChannel<F>,
 ) -> PushforwardOutput<F>
 where
@@ -87,41 +103,77 @@ where
 	F: Field,
 	P: PackedField<Scalar = F>,
 {
-	let m = pushforward_eval_point.len();
-	assert_eq!(table.log_len(), m); // precondition
-	assert_eq!(pushforward.log_len(), m); // precondition
+	// The witnesses are walked twice — once for the deepest table, once to build the provers — so
+	// the iterator is materialized once here.
+	let tables = tables.into_iter().collect::<Vec<_>>();
+	assert!(!tables.is_empty(), "at least one table is required"); // precondition
 
-	// S_1: the leaf claim as an eq-weighted evaluation of Y at z. The store owns both columns as
-	// borrows, so its first fold is the only place either is written, at half width.
-	let mut store = MleStore::new(m, alloc);
-	let y_col = store.push(pushforward);
-	let evaluator = MultilinearEvalEvaluator::new(y_col);
-	let mle_prover = SharedMleCheckProver::new(
-		store,
-		[(pushforward_eval_claim, evaluator)],
-		pushforward_eval_point.to_vec(),
-	);
+	let max_m = tables
+		.iter()
+		.map(|table| table.pushforward_eval_point.len())
+		.max()
+		.expect("tables is non-empty");
 
-	// Folding the eq factor into S_1's round polynomials turns it into a plain sumcheck, which is
-	// what lets the eq-free product claim join it in one evaluator group over the shared store.
-	let mut prover = mle_prover.into_shared_sumcheck();
+	let provers = tables
+		.into_iter()
+		.map(|table| {
+			let m = table.pushforward_eval_point.len();
+			assert_eq!(table.table.log_len(), m); // precondition
+			assert_eq!(table.pushforward.log_len(), m); // precondition
 
-	// S_2: the product claim over the shared Y column and the pushed table column.
-	let t_col = prover.store_mut().push(table);
-	let product = BivariateProductEvaluator::new([y_col, t_col]);
-	prover
-		.add_evaluator(eval_claim, Box::new(product) as Box<dyn SumcheckRoundEvaluator<F, P> + 'a>);
+			// S_1: the leaf claim as an eq-weighted evaluation of Y_t at z_t. The store owns both
+			// columns as borrows, so its first fold is the only place either is written, at half
+			// width.
+			let mut store = MleStore::new(m, alloc);
+			let y_col = store.push(table.pushforward);
+			let evaluator = MultilinearEvalEvaluator::new(y_col);
+			let mle_prover = SharedMleCheckProver::new(
+				store,
+				[(table.pushforward_eval_claim, evaluator)],
+				table.pushforward_eval_point.to_vec(),
+			);
 
-	// Drive the one shared-store sumcheck. The flattened round-polynomial order is
-	// [pushforward_eval, product], matching the verifier's batched claim order.
-	let output = batch_prove(vec![prover], channel);
+			// Folding the eq factor into S_1's round polynomials turns it into a plain sumcheck,
+			// which is what lets the eq-free product claim join it in one evaluator group over the
+			// shared store.
+			let mut prover = mle_prover.into_shared_sumcheck();
 
-	// The shared prover emits each store column's evaluation once, in push order [Y, T].
-	let [pushforward_eval_claim, table_eval_claim]: [F; 2] = output.multilinear_evals[0]
-		.as_slice()
-		.try_into()
-		.expect("the pushforward store has two columns");
-	channel.send_many(&[pushforward_eval_claim, table_eval_claim]);
+			// S_2: the product claim over the shared Y_t column and the pushed table column.
+			let t_col = prover.store_mut().push(table.table);
+			let product = BivariateProductEvaluator::new([y_col, t_col]);
+			prover.add_evaluator(
+				table.eval_claim,
+				Box::new(product) as Box<dyn SumcheckRoundEvaluator<F, P> + 'a>,
+			);
+
+			// Raise this table to the batch's round count. The claims are in the same order as the
+			// evaluators, which is the order the verifier batches them in.
+			PaddedSumcheckDecorator::new(
+				prover,
+				max_m - m,
+				vec![table.pushforward_eval_claim, table.eval_claim],
+			)
+		})
+		.collect::<Vec<_>>();
+
+	// Drive the one batched sumcheck. The flattened round-polynomial order is
+	// [pushforward_eval, product] per table, in table order, matching the verifier's claim order.
+	let output = batch_prove(provers, channel);
+
+	// Each table's shared prover emits its store columns' evaluations once, in push order
+	// [Y_t, T_t]. Send them in the same flat order the verifier reads.
+	let (pushforward_eval_claims, table_eval_claims): (Vec<_>, Vec<_>) = output
+		.multilinear_evals
+		.iter()
+		.map(|evals| {
+			let [pushforward_eval_claim, table_eval_claim]: [F; 2] = evals
+				.as_slice()
+				.try_into()
+				.expect("a pushforward store has two columns");
+			(pushforward_eval_claim, table_eval_claim)
+		})
+		.unzip();
+	output.send_evals(channel);
 
 	// `batch_prove` returns binding-order challenges; reverse to variable-indexed (low-to-high).
 	let mut table_eval_point = output.challenges;
@@ -129,7 +181,7 @@ where
 
 	PushforwardOutput {
 		table_eval_point,
-		table_eval_claim,
-		pushforward_eval_claim,
+		table_eval_claims,
+		pushforward_eval_claims,
 	}
 }

--- a/crates/ip/src/logup_star/pushforward.rs
+++ b/crates/ip/src/logup_star/pushforward.rs
@@ -2,13 +2,19 @@
 
 //! The pushforward reduction that closes the table side.
 //!
-//! The table-side fractional-addition GKR runs to its leaf, which claims the pushforward `Y` at a
-//! point `z`; its denominator half is the public `D = J - c`, which the verifier checks itself.
-//! That leaves two claims that both read `Y` — the leaf claim `Y(z)` and the product claim
-//! `<T, Y> = e` — and one batched `m`-variable sumcheck reduces them to a single evaluation point.
+//! Each table's fractional-addition GKR runs to its leaf, which claims that table's pushforward
+//! `Y_t` at a point `z_t`; its denominator half is the public `D = J - c_t`, which the verifier
+//! checks itself. That leaves two claims per table that both read `Y_t` — the leaf claim `Y_t(z_t)`
+//! and the product claim `<T_t, Y_t> = e_t` — and one batched sumcheck reduces all of them to a
+//! single evaluation point.
+
+use std::iter;
 
 use binius_field::{BinaryField1b, ExtensionField, Field, field::FieldOps};
-use binius_math::multilinear::eq::eq_ind;
+use binius_math::{
+	multilinear::eq::{eq_ind, eq_ind_zero},
+	univariate::evaluate_univariate,
+};
 
 use super::error::{Error, VerificationError};
 use crate::{
@@ -16,80 +22,139 @@ use crate::{
 	sumcheck::{self, BatchSumcheckOutput},
 };
 
-/// The output of the pushforward reduction.
-pub struct Pushforward<F> {
-	/// The `m`-coordinate point at which both `T` and `Y` are evaluated.
-	pub table_eval_point: Vec<F>,
-	/// The claimed evaluation of `T` at the point.
-	pub table_eval_claim: F,
-	/// The claimed evaluation of `Y` at the point.
+/// One table's two claims entering the pushforward reduction.
+#[derive(Debug, Clone)]
+pub struct TableClaim<'a, F> {
+	/// The product claim `e_t = <T_t, Y_t>`.
+	pub eval_claim: F,
+	/// The fractional-addition leaf claim `Y_t(z_t)`.
 	pub pushforward_eval_claim: F,
+	/// The leaf point `z_t`, of length `m_t`.
+	pub pushforward_eval_point: &'a [F],
 }
 
-/// Verify the pushforward reduction.
+/// The output of the pushforward reduction.
+pub struct Pushforward<F> {
+	/// The point spanning the widest table, at which every table's claims are taken.
+	///
+	/// Table `t`, over `m_t` variables, is claimed at the **first `m_t`** coordinates: the batch
+	/// pads each table at its high coordinates.
+	pub table_eval_point: Vec<F>,
+	/// The claimed evaluations of the tables `T_t`, each at its own prefix of the point.
+	pub table_eval_claims: Vec<F>,
+	/// The claimed evaluations of the pushforwards `Y_t`, each at the same prefix.
+	pub pushforward_eval_claims: Vec<F>,
+}
+
+/// Verify the pushforward reduction over one or more tables.
 ///
-/// Batches two sum claims over the `m`-variable cube:
+/// Each table contributes two sum claims over its own `m_t`-variable cube:
 ///
 /// ```text
-///     S_1 = sum_x eq(x; z) * Y(x) = Y(z)      the GKR leaf claim, re-randomized
-///     S_2 = sum_x (Y * T)(x)      = e         the product claim
+///     S_1 = sum_x eq(x; z_t) * Y_t(x) = Y_t(z_t)      the GKR leaf claim, re-randomized
+///     S_2 = sum_x (Y_t * T_t)(x)      = e_t           the product claim
 /// ```
 ///
 /// Both summands are degree 2 per variable — `eq` times a multilinear, and a product of two
-/// multilinears — so the batched degree is 2. The reduction ends in one evaluation of `Y` and one
-/// of `T` at the shared challenge point.
+/// multilinears — so the batched degree is 2.
+///
+/// Tables need not agree on a size. A table over `m_t < max_t m_t` variables is batched through
+/// the padded claim `S * eq(0^nu; X_pad)` over the padding variables, which are the highest ones
+/// and so are bound first; that equality factor sums to one over the cube, so the padded claim
+/// holds exactly when the original does. The deepest table is never padded, so every round
+/// polynomial in the batch still has degree 2.
+///
+/// The reduction ends in one evaluation of `Y_t` and one of `T_t` per table, all at the prefix of
+/// one shared point.
 ///
 /// # Arguments
 ///
-/// * `eval_claim` - The product claim `e = <T, Y>`.
-/// * `pushforward_eval_claim` - The GKR leaf claim `Y(z)`.
-/// * `pushforward_eval_point` - The leaf point `z`, of length `m`.
+/// * `tables` - The per-table claims; their leaf points may differ in length.
 /// * `channel` - The verifier channel.
-pub fn verify_pushforward<F, C>(
-	eval_claim: C::Elem,
-	pushforward_eval_claim: C::Elem,
-	pushforward_eval_point: &[C::Elem],
+///
+/// # Preconditions
+///
+/// - `tables` is non-empty.
+pub fn verify_pushforward<'a, F, C>(
+	tables: impl IntoIterator<Item = TableClaim<'a, C::Elem>>,
 	channel: &mut C,
 ) -> Result<Pushforward<C::Elem>, Error>
 where
 	F: Field + ExtensionField<BinaryField1b>,
 	C: IPVerifierChannel<F>,
-	C::Elem: From<F>,
+	C::Elem: From<F> + 'a,
 {
-	let m = pushforward_eval_point.len();
+	// The claims are walked three times — for the deepest table, for the batched sums, and for the
+	// reconstruction — so the iterator is materialized once here.
+	let tables = tables.into_iter().collect::<Vec<_>>();
+	assert!(!tables.is_empty(), "at least one table is required"); // precondition
 
-	// Batch the two sum claims with powers of a single coefficient and run the sumcheck.
+	let max_m = tables
+		.iter()
+		.map(|table| table.pushforward_eval_point.len())
+		.max()
+		.expect("tables is non-empty");
+
+	// Batch every table's two sum claims with powers of a single coefficient and run the sumcheck.
+	// The claims are flattened in table order, two per table, which is the order the prover's
+	// round polynomials arrive in.
 	//
-	//     sum = Y(z) + bc * e
+	//     sum = Y_0(z_0) + bc * e_0 + bc^2 * Y_1(z_1) + ...
+	let sums = tables
+		.iter()
+		.flat_map(|table| {
+			[
+				table.pushforward_eval_claim.clone(),
+				table.eval_claim.clone(),
+			]
+		})
+		.collect::<Vec<_>>();
 	let BatchSumcheckOutput {
 		batch_coeff,
 		eval,
 		mut challenges,
-	} = sumcheck::batch_verify::<F, C>(m, 2, &[pushforward_eval_claim, eval_claim], channel)?;
+	} = sumcheck::batch_verify::<F, C>(max_m, 2, &sums, channel)?;
 
-	// Read the pushforward and table evaluations at the sumcheck challenge point.
-	let [y_eval, t_eval] = channel
-		.recv_array()
+	// Read every table's pushforward and table evaluations at the sumcheck challenge point, in the
+	// same table order.
+	let evals: Vec<C::Elem> = channel
+		.recv_many(2 * tables.len())
 		.map_err(|_| VerificationError::TranscriptIsEmpty)?;
+	let (pushforward_eval_claims, table_eval_claims): (Vec<_>, Vec<_>) = evals
+		.chunks_exact(2)
+		.map(|pair| (pair[0].clone(), pair[1].clone()))
+		.unzip();
 
-	// Sumcheck binds variables highest-to-lowest; reverse to align with the low-to-high point z.
+	// Sumcheck binds variables highest-to-lowest; reverse to align with the low-to-high points z_t.
 	challenges.reverse();
 	let rho = challenges;
 
-	// Reconstruct the batched summand at the challenge point and check it against the reduced eval.
-	// Both claims read Y, so it factors out:
+	// Reconstruct each table's pair of summands at the challenge point and check the batch against
+	// the reduced evaluation. Both of a table's claims read Y_t, so it factors out:
 	//
-	//     eq(rho; z) * Y(rho) + bc * Y(rho) * T(rho) = Y(rho) * (eq(rho; z) + bc * T(rho))
-	let eq_eval = eq_ind::<C::Elem>(&rho, pushforward_eval_point);
-	let expected = y_eval.clone() * (eq_eval + batch_coeff * t_eval.clone());
+	//     eq(rho_t; z_t) * Y_t(rho_t) + bc * Y_t(rho_t) * T_t(rho_t)
+	//         = Y_t(rho_t) * (eq(rho_t; z_t) + bc * T_t(rho_t))
+	//
+	// and a padded table's contribution carries the padding coordinates' equality weight.
+	let contributions = iter::zip(&tables, iter::zip(&pushforward_eval_claims, &table_eval_claims))
+		.flat_map(|(table, (y_eval, t_eval))| {
+			let (own_point, padding_point) = rho.split_at(table.pushforward_eval_point.len());
+			let weighted_y = y_eval.clone() * eq_ind_zero::<C::Elem>(padding_point);
+			[
+				weighted_y.clone() * eq_ind::<C::Elem>(own_point, table.pushforward_eval_point),
+				weighted_y * t_eval.clone(),
+			]
+		})
+		.collect::<Vec<_>>();
+	let expected = evaluate_univariate(&contributions, &batch_coeff);
 	channel
 		.assert_zero(eval - expected)
 		.map_err(|_| VerificationError::PushforwardMismatch)?;
 
 	Ok(Pushforward {
 		table_eval_point: rho,
-		table_eval_claim: t_eval,
-		pushforward_eval_claim: y_eval,
+		table_eval_claims,
+		pushforward_eval_claims,
 	})
 }
 

--- a/crates/ip/src/logup_star/verify.rs
+++ b/crates/ip/src/logup_star/verify.rs
@@ -16,7 +16,7 @@ use binius_math::{
 use super::{
 	error::{Error, VerificationError},
 	output::LogupOutput,
-	pushforward::{Pushforward, denominator_eval, verify_pushforward},
+	pushforward::{Pushforward, TableClaim, denominator_eval, verify_pushforward},
 };
 use crate::{
 	channel::IPVerifierChannel,
@@ -229,9 +229,23 @@ where
 	let combined_eval_claim = evaluate_univariate(&claims, gamma);
 	let Pushforward {
 		table_eval_point,
-		table_eval_claim,
-		pushforward_eval_claim,
-	} = verify_pushforward::<F, C>(combined_eval_claim, pushforward_eval, table_point, channel)?;
+		table_eval_claims,
+		pushforward_eval_claims,
+	} = verify_pushforward::<F, C>(
+		[TableClaim {
+			eval_claim: combined_eval_claim,
+			pushforward_eval_claim: pushforward_eval,
+			pushforward_eval_point: table_point,
+		}],
+		channel,
+	)?;
+	// The reduction runs over the one shared table, so it returns one claim of each kind.
+	let [table_eval_claim]: [_; 1] = table_eval_claims
+		.try_into()
+		.unwrap_or_else(|_| unreachable!("the reduction runs over one table"));
+	let [pushforward_eval_claim]: [_; 1] = pushforward_eval_claims
+		.try_into()
+		.unwrap_or_else(|_| unreachable!("the reduction runs over one table"));
 
 	Ok(LogupOutput {
 		table_eval_point,


### PR DESCRIPTION
First of three PRs for [BINIUS-418](https://linear.app/jimpo/issue/BINIUS-418/logup-star-multi-table-batch-lookup) — multi-table batch lookup. This one is groundwork only: it generalizes the pushforward reduction to a batch of tables, but the caller still passes exactly one, so **the transcript is unchanged**.

## What changes

`prove_pushforward` / `verify_pushforward` take a slice of per-table claims instead of a single table's, and return one `(T_t, Y_t)` claim pair per table:

- **Prover** — one `SharedSumcheckProver` over `[Y_t, T_t]` per table, each wrapped in the existing `PaddedSumcheckDecorator` to raise it to the batch's round count, all driven by one `batch_prove`.
- **Verifier** — one `sumcheck::batch_verify(max_m, 2, …)` over `2 · n_tables` flattened claims, with each table's contribution carrying `eq_ind_zero` over its padding coordinates.

This is the same shape `iop/basefold/channel.rs` already uses to open oracles of unequal message length (`PaddedSumcheckDecorator` on one side, `eq_ind_zero(padding_coords)` on the other), so it is a pattern the codebase has already committed to rather than a new mechanism.

Two consequences worth naming, since they are easy to get backwards:

- The decorator pads at the **highest-indexed** variables, which are bound first. So table `t` ends up claimed at the **first `m_t`** coordinates of the shared reduced point — a prefix. That is the opposite end from the fractional-addition batch, which pads at the lowest variables and hands a shallow instance a **suffix** (`LogupOutput::index_eval_point`, #2064). Both are documented at their respective outputs.
- The deepest table is never padded, so it is in its inner phase every round and the batched round polynomial always has degree 2. That is what lets the verifier read a uniform degree, and it is why an all-padding round — which would emit fewer coefficients than the verifier reads — cannot occur.

## Why the transcript is unchanged

With one table the padding width is zero, so the decorator is a passthrough (`test_no_padding_passthrough` already covers this); the same two claims are batched in the same order; and `recv_many(2)` reads the same two scalars `recv_array::<2>` did. Corroborated by `size_tracking_matches_real_proof_bytes`, which pins a full Spartan proof's real byte count against its predicted size.

## What this PR does not do

It has no test that exercises more than one table, because `verify_pushforward` is private to `binius_ip::logup_star` and I would rather not widen the public API to reach it from a test. The multi-table round-trips land in the next PR in the stack, where the capability is reachable through `verify_reduction`. Until then the evidence for this PR is that it is transcript-preserving and every existing test passes unchanged.

The single-table callers each grow six lines that pull one claim back out of a returned `Vec`. That boilerplate disappears in the next PR, when `LogupOutput` itself becomes per-table.

## Verification

- `cargo test` green on `binius-ip`, `binius-ip-prover`, `binius-iop`, `binius-iop-prover`, `binius-prover`, `binius-verifier`, `binius-spartan-prover`, `binius-spartan-verifier` — no test changed.
- `cargo clippy --all --tests --benches --examples -- -D warnings` clean across the workspace.
- `cargo +nightly-2026-07-01 fmt`.

## Stack

1. **this PR** — batch the pushforward reduction over several tables
2. the multi-table reduction itself: one logUp challenge `c_t` per table, lookers assigned to tables, fracadd instances become `lookers ++ tables`
3. one pushforward oracle per table in `iop`/`iop-prover`, plus the `intmul` call sites

🤖 Generated with [Claude Code](https://claude.com/claude-code)