### PR TITLE
BINIUS-404: remove all value vector padding

### DIFF
--- a/crates/core/src/constraint_system/system.rs
+++ b/crates/core/src/constraint_system/system.rs
@@ -78,12 +78,6 @@ impl ConstraintSystem {
 	/// Serialization format version for compatibility checking
 	pub const SERIALIZATION_VERSION: u32 = 9;
 
-	/// The minimum number of words in the public segment.
-	///
-	/// The public segment is padded up to at least this many words, so that
-	/// [`Self::log_public_words`] is never smaller than its logarithm.
-	pub const MIN_WORDS_PER_SEGMENT: usize = 2;
-
 	/// Returns the number of constants.
 	pub const fn n_const(&self) -> usize {
 		self.constants.len()
@@ -99,44 +93,39 @@ impl ConstraintSystem {
 		self.n_const() + self.n_inout
 	}
 
-	/// Returns the number of words in the public segment, which the proving protocol pads to a
-	/// power of two of at least [`Self::MIN_WORDS_PER_SEGMENT`] words.
-	///
-	/// The padding is the protocol's, not the system's: no [`ValueIndex`] reaches a padding word,
-	/// and the words past [`Self::n_public_values`] are zero.
+	/// Returns the number of words in the public segment, which is the public values themselves.
 	pub const fn n_public_words(&self) -> usize {
-		let n_values = if self.n_public_values() < Self::MIN_WORDS_PER_SEGMENT {
-			Self::MIN_WORDS_PER_SEGMENT
-		} else {
-			self.n_public_values()
-		};
-		n_values.next_power_of_two()
+		self.n_public_values()
 	}
 
-	/// Returns the base-2 logarithm of the public segment length in words.
+	/// Returns the number of word-index variables the public segment spans.
+	///
+	/// The word count need not be a power of two; the reductions read the words past it as zero.
 	pub const fn log_public_words(&self) -> usize {
-		self.n_public_words().trailing_zeros() as usize
+		log2_ceil_usize(self.n_public_words())
 	}
 
-	/// Returns the number of words in the hidden segment.
-	///
-	/// The hidden segment holds the private values, padded up to the public segment length so
-	/// that [`Self::log_witness_words`] is at least [`Self::log_public_words`] — the shift
-	/// reduction addresses both halves with one set of word-index challenges.
+	/// Returns the number of words in the hidden segment, which is the private values themselves.
 	pub const fn n_hidden_words(&self) -> usize {
-		if self.n_private < self.n_public_words() {
-			self.n_public_words()
-		} else {
-			self.n_private
-		}
+		self.n_private
 	}
 
-	/// Returns the base-2 logarithm of the hidden segment length in words, rounded up to a
-	/// power of two.
-	///
-	/// This is at least [`Self::log_public_words`].
+	/// Returns the number of word-index variables the hidden segment spans.
 	pub const fn log_witness_words(&self) -> usize {
 		log2_ceil_usize(self.n_hidden_words())
+	}
+
+	/// Returns the number of word-index variables the shift reduction runs over.
+	///
+	/// The reduction addresses both segments with one set of word-index challenges, so it needs
+	/// as many as the wider of the two spans. The narrower segment reads the extra coordinates as
+	/// zero.
+	pub const fn log_segment_words(&self) -> usize {
+		if self.log_public_words() > self.log_witness_words() {
+			self.log_public_words()
+		} else {
+			self.log_witness_words()
+		}
 	}
 
 	/// Returns the number of values the given segment holds, excluding the padding after them.
@@ -682,35 +671,39 @@ mod tests {
 	}
 
 	#[test]
-	fn segment_lengths_are_derived_from_the_value_counts() {
-		// Three constants and two inout values are five public words, padded to eight; six
-		// private values are fewer than that, so the hidden segment is padded to eight too.
+	fn segment_lengths_are_the_value_counts() {
+		// Three constants and two inout values are five public words; six private values are six
+		// hidden words. Neither is padded.
 		let cs = test_shape();
 		assert_eq!(cs.n_public_values(), 5);
-		assert_eq!(cs.n_public_words(), 8);
-		assert_eq!(cs.log_public_words(), 3);
-		assert_eq!(cs.n_hidden_words(), 8);
-		assert_eq!(cs.log_witness_words(), 3);
-		assert_eq!(cs.value_vec_len(), 16);
+		assert_eq!(cs.n_public_words(), 5);
+		assert_eq!(cs.n_hidden_words(), 6);
+		assert_eq!(cs.value_vec_len(), 11);
 
-		// A system with more private values than public words pads the hidden segment to the
-		// private count instead, and the two logarithms come apart.
+		// The spans are the counts rounded up, and the reduction runs over the wider of the two.
+		assert_eq!(cs.log_public_words(), 3);
+		assert_eq!(cs.log_witness_words(), 3);
+		assert_eq!(cs.log_segment_words(), 3);
+
+		// A hidden segment wider than the public one sets the span.
 		let wide = ConstraintSystem {
 			n_private: 60,
 			..test_shape()
 		};
-		assert_eq!(wide.n_public_words(), 8);
-		assert_eq!(wide.n_hidden_words(), 60);
+		assert_eq!(wide.log_public_words(), 3);
 		assert_eq!(wide.log_witness_words(), 6);
+		assert_eq!(wide.log_segment_words(), 6);
 
-		// An empty system still meets the minimum segment size.
-		let empty = ConstraintSystem {
-			constants: vec![],
-			n_inout: 0,
-			n_private: 0,
+		// And a public segment wider than the hidden one sets it instead — the case the old
+		// hidden-segment padding existed to rule out.
+		let public_heavy = ConstraintSystem {
+			n_inout: 200,
+			n_private: 4,
 			..test_shape()
 		};
-		assert_eq!(empty.n_public_words(), ConstraintSystem::MIN_WORDS_PER_SEGMENT);
+		assert_eq!(public_heavy.log_public_words(), 8);
+		assert_eq!(public_heavy.log_witness_words(), 2);
+		assert_eq!(public_heavy.log_segment_words(), 8);
 	}
 
 	#[test]

--- a/crates/examples/snapshots/bitcoin_headers.snap
+++ b/crates/examples/snapshots/bitcoin_headers.snap
@@ -18,15 +18,13 @@ Constraints
    └─ Distinct unshifted value indices: 20,161
 
 Value Vector
-├─ Public Section: 156 used (60.9% of 2^8)
-│  [▓▓▓▓▓▓░░░░] spare: 100
+├─ Public Section: 156 (not committed)
 │  ├─ Constants: 156
 │  └─ Inout: 0
-├─ Private Section: 20,012 used (61.6%)
-│  [▓▓▓▓▓▓░░░░] spare: 12,500
+├─ Private Section: 20,012
 │  ├─ Witness: 104
 │  └─ Internal: 19,908
-├─ Total Committed: 20,168 used (61.5% of 2^15)
-│  [▓▓▓▓▓▓░░░░] spare: 12,600
+├─ Committed Trace: 20,012 used (61.1% of 2^15)
+│  [▓▓▓▓▓▓░░░░] spare: 12,756
 └─ Scratch (uncommitted): 39,280 (peak live: 53)
 

--- a/crates/examples/snapshots/bitcoin_p2pkh.snap
+++ b/crates/examples/snapshots/bitcoin_p2pkh.snap
@@ -18,15 +18,13 @@ Constraints
    └─ Distinct unshifted value indices: 135,875
 
 Value Vector
-├─ Public Section: 134 used (52.3% of 2^8)
-│  [▓▓▓▓▓░░░░░] spare: 122
+├─ Public Section: 134 (not committed)
 │  ├─ Constants: 134
 │  └─ Inout: 0
-├─ Private Section: 135,752 used (51.8%)
-│  [▓▓▓▓▓░░░░░] spare: 126,136
+├─ Private Section: 135,752
 │  ├─ Witness: 9
 │  └─ Internal: 135,743
-├─ Total Committed: 135,886 used (51.8% of 2^18)
-│  [▓▓▓▓▓░░░░░] spare: 126,258
+├─ Committed Trace: 135,752 used (51.8% of 2^18)
+│  [▓▓▓▓▓░░░░░] spare: 126,392
 └─ Scratch (uncommitted): 108,460 (peak live: 109)
 

--- a/crates/examples/snapshots/blake2b.snap
+++ b/crates/examples/snapshots/blake2b.snap
@@ -18,15 +18,13 @@ Constraints
    └─ Distinct unshifted value indices: 7,847
 
 Value Vector
-├─ Public Section: 28 used (87.5% of 2^5)
-│  [▓▓▓▓▓▓▓▓░░] spare: 4
+├─ Public Section: 28 (not committed)
 │  ├─ Constants: 28
 │  └─ Inout: 0
-├─ Private Section: 7,832 used (96.0%)
-│  [▓▓▓▓▓▓▓▓▓░] spare: 328
+├─ Private Section: 7,832
 │  ├─ Witness: 136
 │  └─ Internal: 7,696
-├─ Total Committed: 7,860 used (95.9% of 2^13)
-│  [▓▓▓▓▓▓▓▓▓░] spare: 332
+├─ Committed Trace: 7,832 used (95.6% of 2^13)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 360
 └─ Scratch (uncommitted): 7,728 (peak live: 21)
 

--- a/crates/examples/snapshots/blake2s.snap
+++ b/crates/examples/snapshots/blake2s.snap
@@ -18,15 +18,13 @@ Constraints
    └─ Distinct unshifted value indices: 12,999
 
 Value Vector
-├─ Public Section: 45 used (70.3% of 2^6)
-│  [▓▓▓▓▓▓▓░░░] spare: 19
+├─ Public Section: 45 (not committed)
 │  ├─ Constants: 45
 │  └─ Inout: 0
-├─ Private Section: 13,108 used (80.3%)
-│  [▓▓▓▓▓▓▓▓░░] spare: 3,212
+├─ Private Section: 13,108
 │  ├─ Witness: 136
 │  └─ Internal: 12,972
-├─ Total Committed: 13,153 used (80.3% of 2^14)
-│  [▓▓▓▓▓▓▓▓░░] spare: 3,231
+├─ Committed Trace: 13,108 used (80.0% of 2^14)
+│  [▓▓▓▓▓▓▓▓░░] spare: 3,276
 └─ Scratch (uncommitted): 13,268 (peak live: 37)
 

--- a/crates/examples/snapshots/blake3.snap
+++ b/crates/examples/snapshots/blake3.snap
@@ -18,15 +18,13 @@ Constraints
    └─ Distinct unshifted value indices: 4,762
 
 Value Vector
-├─ Public Section: 281 used (54.9% of 2^9)
-│  [▓▓▓▓▓░░░░░] spare: 231
+├─ Public Section: 281 (not committed)
 │  ├─ Constants: 17
 │  └─ Inout: 264
-├─ Private Section: 4,749 used (61.8%)
-│  [▓▓▓▓▓▓░░░░] spare: 2,931
+├─ Private Section: 4,749
 │  ├─ Witness: 0
 │  └─ Internal: 4,749
-├─ Total Committed: 5,030 used (61.4% of 2^13)
-│  [▓▓▓▓▓▓░░░░] spare: 3,162
+├─ Committed Trace: 4,749 used (58.0% of 2^13)
+│  [▓▓▓▓▓░░░░░] spare: 3,443
 └─ Scratch (uncommitted): 5,179 (peak live: 42)
 

--- a/crates/examples/snapshots/blake3_compress.snap
+++ b/crates/examples/snapshots/blake3_compress.snap
@@ -18,15 +18,13 @@ Constraints
    └─ Distinct unshifted value indices: 0
 
 Value Vector
-├─ Public Section: 5 used (62.5% of 2^3)
-│  [▓▓▓▓▓▓░░░░] spare: 3
+├─ Public Section: 5 (not committed)
 │  ├─ Constants: 5
 │  └─ Inout: 0
-├─ Private Section: 168 used (67.7%)
-│  [▓▓▓▓▓▓░░░░] spare: 80
+├─ Private Section: 168
 │  ├─ Witness: 168
 │  └─ Internal: 0
-├─ Total Committed: 173 used (67.6% of 2^8)
-│  [▓▓▓▓▓▓░░░░] spare: 83
+├─ Committed Trace: 168 used (65.6% of 2^8)
+│  [▓▓▓▓▓▓░░░░] spare: 88
 └─ Scratch (uncommitted): 9,024 (peak live: 18)
 

--- a/crates/examples/snapshots/ec_msm.snap
+++ b/crates/examples/snapshots/ec_msm.snap
@@ -18,15 +18,13 @@ Constraints
    └─ Distinct unshifted value indices: 188,334
 
 Value Vector
-├─ Public Section: 52 used (81.2% of 2^6)
-│  [▓▓▓▓▓▓▓▓░░] spare: 12
+├─ Public Section: 52 (not committed)
 │  ├─ Constants: 20
 │  └─ Inout: 32
-├─ Private Section: 188,287 used (71.8%)
-│  [▓▓▓▓▓▓▓░░░] spare: 73,793
+├─ Private Section: 188,287
 │  ├─ Witness: 0
 │  └─ Internal: 188,287
-├─ Total Committed: 188,339 used (71.8% of 2^18)
-│  [▓▓▓▓▓▓▓░░░] spare: 73,805
+├─ Committed Trace: 188,287 used (71.8% of 2^18)
+│  [▓▓▓▓▓▓▓░░░] spare: 73,857
 └─ Scratch (uncommitted): 145,377 (peak live: 190)
 

--- a/crates/examples/snapshots/ethsign.snap
+++ b/crates/examples/snapshots/ethsign.snap
@@ -18,15 +18,13 @@ Constraints
    └─ Distinct unshifted value indices: 190,020
 
 Value Vector
-├─ Public Section: 114 used (89.1% of 2^7)
-│  [▓▓▓▓▓▓▓▓░░] spare: 14
+├─ Public Section: 114 (not committed)
 │  ├─ Constants: 85
 │  └─ Inout: 29
-├─ Private Section: 189,915 used (72.5%)
-│  [▓▓▓▓▓▓▓░░░] spare: 72,101
+├─ Private Section: 189,915
 │  ├─ Witness: 0
 │  └─ Internal: 189,915
-├─ Total Committed: 190,029 used (72.5% of 2^18)
-│  [▓▓▓▓▓▓▓░░░] spare: 72,115
+├─ Committed Trace: 189,915 used (72.4% of 2^18)
+│  [▓▓▓▓▓▓▓░░░] spare: 72,229
 └─ Scratch (uncommitted): 149,996 (peak live: 192)
 

--- a/crates/examples/snapshots/hashsign.snap
+++ b/crates/examples/snapshots/hashsign.snap
@@ -18,15 +18,13 @@ Constraints
    └─ Distinct unshifted value indices: 255,046
 
 Value Vector
-├─ Public Section: 184 used (71.9% of 2^8)
-│  [▓▓▓▓▓▓▓░░░] spare: 72
+├─ Public Section: 184 (not committed)
 │  ├─ Constants: 158
 │  └─ Inout: 26
-├─ Private Section: 254,949 used (97.4%)
-│  [▓▓▓▓▓▓▓▓▓░] spare: 6,939
+├─ Private Section: 254,949
 │  ├─ Witness: 1,776
 │  └─ Internal: 253,173
-├─ Total Committed: 255,133 used (97.3% of 2^18)
-│  [▓▓▓▓▓▓▓▓▓░] spare: 7,011
+├─ Committed Trace: 254,949 used (97.3% of 2^18)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 7,195
 └─ Scratch (uncommitted): 308,394 (peak live: 595)
 

--- a/crates/examples/snapshots/keccak.snap
+++ b/crates/examples/snapshots/keccak.snap
@@ -18,15 +18,13 @@ Constraints
    └─ Distinct unshifted value indices: 4,836
 
 Value Vector
-├─ Public Section: 157 used (61.3% of 2^8)
-│  [▓▓▓▓▓▓░░░░] spare: 99
+├─ Public Section: 157 (not committed)
 │  ├─ Constants: 25
 │  └─ Inout: 132
-├─ Private Section: 4,779 used (60.2%)
-│  [▓▓▓▓▓▓░░░░] spare: 3,157
+├─ Private Section: 4,779
 │  ├─ Witness: 0
 │  └─ Internal: 4,779
-├─ Total Committed: 4,936 used (60.3% of 2^13)
-│  [▓▓▓▓▓▓░░░░] spare: 3,256
+├─ Committed Trace: 4,779 used (58.3% of 2^13)
+│  [▓▓▓▓▓░░░░░] spare: 3,413
 └─ Scratch (uncommitted): 17,406 (peak live: 27)
 

--- a/crates/examples/snapshots/sha256.snap
+++ b/crates/examples/snapshots/sha256.snap
@@ -18,15 +18,13 @@ Constraints
    └─ Distinct unshifted value indices: 8,711
 
 Value Vector
-├─ Public Section: 404 used (78.9% of 2^9)
-│  [▓▓▓▓▓▓▓░░░] spare: 108
+├─ Public Section: 404 (not committed)
 │  ├─ Constants: 140
 │  └─ Inout: 264
-├─ Private Section: 8,572 used (54.0%)
-│  [▓▓▓▓▓░░░░░] spare: 7,300
+├─ Private Section: 8,572
 │  ├─ Witness: 0
 │  └─ Internal: 8,572
-├─ Total Committed: 8,976 used (54.8% of 2^14)
-│  [▓▓▓▓▓░░░░░] spare: 7,408
+├─ Committed Trace: 8,572 used (52.3% of 2^14)
+│  [▓▓▓▓▓░░░░░] spare: 7,812
 └─ Scratch (uncommitted): 17,124 (peak live: 22)
 

--- a/crates/examples/snapshots/sha512.snap
+++ b/crates/examples/snapshots/sha512.snap
@@ -18,15 +18,13 @@ Constraints
    └─ Distinct unshifted value indices: 10,500
 
 Value Vector
-├─ Public Section: 237 used (92.6% of 2^8)
-│  [▓▓▓▓▓▓▓▓▓░] spare: 19
+├─ Public Section: 237 (not committed)
 │  ├─ Constants: 101
 │  └─ Inout: 136
-├─ Private Section: 10,269 used (63.7%)
-│  [▓▓▓▓▓▓░░░░] spare: 5,859
+├─ Private Section: 10,269
 │  ├─ Witness: 0
 │  └─ Internal: 10,269
-├─ Total Committed: 10,506 used (64.1% of 2^14)
-│  [▓▓▓▓▓▓░░░░] spare: 5,878
+├─ Committed Trace: 10,269 used (62.7% of 2^14)
+│  [▓▓▓▓▓▓░░░░] spare: 6,115
 └─ Scratch (uncommitted): 21,402 (peak live: 13)
 

--- a/crates/examples/snapshots/zklogin.snap
+++ b/crates/examples/snapshots/zklogin.snap
@@ -18,15 +18,13 @@ Constraints
    └─ Distinct unshifted value indices: 260,605
 
 Value Vector
-├─ Public Section: 1,031 used (50.3% of 2^11)
-│  [▓▓▓▓▓░░░░░] spare: 1,017
+├─ Public Section: 1,031 (not committed)
 │  ├─ Constants: 729
 │  └─ Inout: 302
-├─ Private Section: 259,584 used (99.8%)
-│  [▓▓▓▓▓▓▓▓▓░] spare: 512
+├─ Private Section: 259,584
 │  ├─ Witness: 1,381
 │  └─ Internal: 258,203
-├─ Total Committed: 260,615 used (99.4% of 2^18)
-│  [▓▓▓▓▓▓▓▓▓░] spare: 1,529
+├─ Committed Trace: 259,584 used (99.0% of 2^18)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 2,560
 └─ Scratch (uncommitted): 320,445 (peak live: 1,542)
 

--- a/crates/frontend/src/compiler/value_vec_alloc.rs
+++ b/crates/frontend/src/compiler/value_vec_alloc.rs
@@ -134,8 +134,6 @@ impl Alloc {
 
 #[cfg(test)]
 mod tests {
-	use binius_core::ConstraintSystem;
-
 	use super::*;
 
 	#[test]
@@ -219,7 +217,7 @@ mod tests {
 	}
 
 	#[test]
-	fn test_minimum_segment_size() {
+	fn segments_are_stored_unpadded() {
 		// Test that the public section meets the minimum size requirement
 		let mut alloc = Alloc::new(0);
 
@@ -233,13 +231,12 @@ mod tests {
 
 		let assignment = alloc.into_assignment();
 
-		// The layout stores the single constant on its own; the constraint system pads the public
-		// segment it commits up to the minimum.
+		// Nothing is padded: the layout stores the single constant on its own and the constraint
+		// system's public segment is exactly that one word.
 		assert_eq!(assignment.value_vec_layout.offset_witness(), 1);
 		let cs = assignment
 			.value_vec_layout
 			.constraint_system_shape(assignment.constants.clone());
-		assert!(cs.n_public_words() >= ConstraintSystem::MIN_WORDS_PER_SEGMENT);
-		assert!(cs.n_public_words().is_power_of_two());
+		assert_eq!(cs.n_public_words(), 1);
 	}
 }

--- a/crates/frontend/src/stat.rs
+++ b/crates/frontend/src/stat.rs
@@ -46,10 +46,10 @@ pub struct CircuitStat {
 	///
 	/// Affects performance of shift reduction phase.
 	pub distinct_unshifted_value_indices: usize,
-	/// Length of the value vector.
+	/// Length of the committed trace in words, a power of two.
 	///
 	/// Affects performance of committing.
-	pub value_vec_len: usize,
+	pub committed_allocated: usize,
 	/// Number of constant values used by the circuit.
 	pub n_const: usize,
 	/// Number of public input values in the circuit.
@@ -77,16 +77,6 @@ pub struct CircuitStat {
 	pub imul_allocated: usize,
 	/// Allocated size for BMUL constraints (power of 2)
 	pub bmul_allocated: usize,
-	/// Allocated size for public section (power of 2)
-	pub public_allocated: usize,
-	/// Allocated size for private section.
-	///
-	/// This is the space available for witness and internal values. Note that unlike
-	/// `public_allocated` and the total committed length, this is NOT necessarily a
-	/// power of two. It's simply the difference between the total committed length
-	/// (power of 2) and the public section size (power of 2). For example, if total
-	/// is 8192 and public is 128, private is 8064.
-	pub private_allocated: usize,
 }
 
 impl CircuitStat {
@@ -115,16 +105,14 @@ impl CircuitStat {
 		let imul_allocated = pad_or_skip(n_imul_constraints);
 		let bmul_allocated = pad_or_skip(n_bmul_constraints);
 
-		// The value counts come from the layout; the padded segment widths are the constraint
-		// system's, since the layout stores the sections back to back.
+		// The value counts come from the layout. Neither segment is padded, so each holds exactly
+		// the values the circuit declared and there is no spare capacity to report against.
 		let layout = circuit.value_vec_layout();
 		let n_const = layout.n_const;
 		let n_inout = layout.n_inout;
-		let public_allocated = cs.n_public_words();
-		// The prover commits to a power-of-two-length witness polynomial, so report that padded
-		// size rather than the two segment widths on their own.
-		let total_allocated = cs.value_vec_len().next_power_of_two();
-		let private_allocated = total_allocated - public_allocated;
+		// The prover commits only the hidden segment, zero-extended to the word-index space the
+		// shift reduction runs over. That padding is the one the circuit author can still fill.
+		let committed_allocated = 1 << cs.log_segment_words();
 
 		Self {
 			n_gates: circuit.n_gates(),
@@ -133,7 +121,7 @@ impl CircuitStat {
 			n_and_constraints,
 			n_imul_constraints,
 			n_bmul_constraints,
-			value_vec_len: total_allocated,
+			committed_allocated,
 			distinct_shifted_value_indices,
 			distinct_unshifted_value_indices,
 			n_const,
@@ -146,8 +134,6 @@ impl CircuitStat {
 			and_allocated,
 			imul_allocated,
 			bmul_allocated,
-			public_allocated,
-			private_allocated,
 		}
 	}
 }
@@ -191,7 +177,6 @@ impl fmt::Display for CircuitStat {
 		// Use pre-calculated values
 		let public_used = self.n_const + self.n_inout;
 		let private_used = self.n_witness + self.n_internal;
-		let total_used = public_used + private_used;
 
 		// Gates & Instructions
 		writeln!(f, "Gates & Instructions")?;
@@ -253,58 +238,34 @@ impl fmt::Display for CircuitStat {
 		// Value Vector
 		writeln!(f, "Value Vector")?;
 
-		// Public Section
-		let public_percent = public_used as f64 / self.public_allocated as f64 * 100.0;
-		let public_spare = self.public_allocated - public_used;
-		writeln!(
-			f,
-			"├─ Public Section: {} used ({:.1}% of 2^{})",
-			fmt_num(public_used),
-			public_percent,
-			log2(self.public_allocated)
-		)?;
-		writeln!(
-			f,
-			"│  {} spare: {}",
-			progress_bar(public_used, self.public_allocated),
-			fmt_num(public_spare)
-		)?;
+		// Public Section. The segment holds exactly the values the circuit declared, and the
+		// verifier knows them, so there is neither padding nor a commitment to measure it against.
+		writeln!(f, "├─ Public Section: {} (not committed)", fmt_num(public_used))?;
 		writeln!(f, "│  ├─ Constants: {}", fmt_num(self.n_const))?;
 		writeln!(f, "│  └─ Inout: {}", fmt_num(self.n_inout))?;
 
-		// Private Section (no allocated size shown since it's not a power of 2)
-		let private_percent = private_used as f64 / self.private_allocated as f64 * 100.0;
-		let private_spare = self.private_allocated - private_used;
-		writeln!(
-			f,
-			"├─ Private Section: {} used ({:.1}%)",
-			fmt_num(private_used),
-			private_percent
-		)?;
-		writeln!(
-			f,
-			"│  {} spare: {}",
-			progress_bar(private_used, self.private_allocated),
-			fmt_num(private_spare)
-		)?;
+		// Private Section, likewise exactly the declared values.
+		writeln!(f, "├─ Private Section: {}", fmt_num(private_used))?;
 		writeln!(f, "│  ├─ Witness: {}", fmt_num(self.n_witness))?;
 		writeln!(f, "│  └─ Internal: {}", fmt_num(self.n_internal))?;
 
-		// Total Committed
-		let total_percent = total_used as f64 / self.value_vec_len as f64 * 100.0;
-		let total_spare = self.value_vec_len - total_used;
+		// Committed Trace: the hidden segment zero-extended to the shift reduction's word-index
+		// space. This is the only padded length left, and the one more values can grow into for
+		// free.
+		let committed_percent = private_used as f64 / self.committed_allocated as f64 * 100.0;
+		let committed_spare = self.committed_allocated - private_used;
 		writeln!(
 			f,
-			"├─ Total Committed: {} used ({:.1}% of 2^{})",
-			fmt_num(total_used),
-			total_percent,
-			log2(self.value_vec_len)
+			"├─ Committed Trace: {} used ({:.1}% of 2^{})",
+			fmt_num(private_used),
+			committed_percent,
+			log2(self.committed_allocated)
 		)?;
 		writeln!(
 			f,
 			"│  {} spare: {}",
-			progress_bar(total_used, self.value_vec_len),
-			fmt_num(total_spare)
+			progress_bar(private_used, self.committed_allocated),
+			fmt_num(committed_spare)
 		)?;
 
 		// Report the segment length alongside the floor it could reach if its slots were shared.

--- a/crates/prover/src/protocols/shift/monster.rs
+++ b/crates/prover/src/protocols/shift/monster.rs
@@ -10,7 +10,7 @@ use binius_math::{
 	BinarySubspace, FieldBuffer, FieldVec, inner_product::inner_product,
 	multilinear::eq::eq_ind_partial_eval, univariate::lagrange_evals,
 };
-use binius_utils::{checked_arithmetics::checked_log_2, rayon::prelude::*};
+use binius_utils::{checked_arithmetics::log2_ceil_usize, rayon::prelude::*};
 use binius_verifier::protocols::shift::{
 	BINMUL_ARITY, BITAND_ARITY, INTMUL_ARITY, ZERO_ARITY, evaluate_h_op,
 };
@@ -296,7 +296,8 @@ where
 		FieldBuffer::new(log_len, values)
 	};
 
-	let log_public_words = checked_log_2(key_collection.public.n_words());
+	// The segment word count need not be a power of two; the monster spans the rounded-up count.
+	let log_public_words = log2_ceil_usize(key_collection.public.n_words());
 	let public_monster = build_segment(&key_collection.public, log_public_words);
 	let hidden_monster = build_segment(&key_collection.hidden, key_collection.log_witness_words());
 

--- a/crates/prover/src/protocols/shift/phase_2.rs
+++ b/crates/prover/src/protocols/shift/phase_2.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-use std::{iter, ops::DerefMut};
+use std::{cmp::max, iter, ops::DerefMut};
 
 use binius_compute::Allocator;
 use binius_core::word::Word;
@@ -84,13 +84,19 @@ where
 	let r_j_tensor = eq_ind_partial_eval::<F>(&r_j);
 
 	// Fold each segment separately; the combined witness is never materialized. `fold_words`
-	// zero-pads each fold to `log2_ceil(len)` variables, so the hidden fold already has
-	// `log_witness_words` variables (its word count is the hidden segment length).
+	// zero-pads each fold to `log2_ceil(len)` variables, so each fold spans its own segment.
 	let public_folded = fold_words::<_, P, _>(alloc, words.public, r_j_tensor.as_ref());
 	let hidden_folded = fold_words::<_, P, _>(alloc, words.hidden, r_j_tensor.as_ref());
 
 	let (public_monster, hidden_monster) =
 		build_monster_segments(alloc, key_collection, prepared, domain_subspace, &r_j, &r_s, &r_v);
+
+	// Both halves of the sumcheck share one word-index address space, spanning the wider of the
+	// two segments. The hidden segment is normally the wider one, but a system with more public
+	// words than private values inverts that, and the hidden half zero-extends to match.
+	let log_segment_words = max(public_folded.log_len(), hidden_folded.log_len());
+	let hidden_folded = zero_extend(alloc, hidden_folded, log_segment_words);
+	let hidden_monster = zero_extend(alloc, hidden_monster, log_segment_words);
 
 	run_sumcheck(
 		&public_folded,
@@ -103,6 +109,33 @@ where
 		channel,
 		alloc,
 	)
+}
+
+/// Zero-extends a segment buffer to span `log_len` word-index variables.
+///
+/// Returns the buffer untouched when it already spans that many, which is the common case: the
+/// hidden segment is normally the wider of the two, so no copy happens.
+///
+/// ## Preconditions
+/// * `log_len` is at least `buffer.log_len()`
+fn zero_extend<F, P: PackedField<Scalar = F>, A: Allocator>(
+	alloc: &A,
+	buffer: FieldVec<P, A>,
+	log_len: usize,
+) -> FieldVec<P, A>
+where
+	F: BinaryField,
+{
+	assert!(log_len >= buffer.log_len());
+	if log_len == buffer.log_len() {
+		return buffer;
+	}
+
+	// Whole packed words copy across: a trailing partial word carries zero high lanes, which are
+	// exactly the zeros the extension pads with.
+	let mut extended = FieldVec::<P, A>::zeros_in(alloc, log_len);
+	extended.as_mut()[..buffer.as_ref().len()].copy_from_slice(buffer.as_ref());
+	extended
 }
 
 /// Computes the phase-2 first-round message: the degree-2 round polynomial that binds the segment
@@ -222,6 +255,8 @@ pub fn run_sumcheck<F, P: PackedField<Scalar = F>, Channel: IPProverChannel<F>, 
 where
 	F: BinaryField,
 {
+	// The hidden pair is the dense one both the first round and `fold_segments` iterate over, so
+	// it spans the whole word-index space and the public pair sits at its base.
 	let log_hidden = hidden_folded.log_len();
 	assert_eq!(hidden_monster.log_len(), log_hidden);
 	assert_eq!(public_monster.log_len(), public_folded.log_len());

--- a/crates/prover/src/protocols/shift/prove.rs
+++ b/crates/prover/src/protocols/shift/prove.rs
@@ -1,9 +1,7 @@
 // Copyright 2025 Irreducible Inc.
 
-use std::borrow::Cow;
-
 use binius_compute::Allocator;
-use binius_core::{ConstraintSystem, word::Word};
+use binius_core::word::Word;
 use binius_field::{BinaryField, Field, PackedField, util::powers};
 use binius_ip::sumcheck::SumcheckOutput;
 use binius_ip_prover::channel::IPProverChannel;
@@ -144,17 +142,6 @@ impl<F: Field> PreparedOperatorData<F> {
 ///
 /// # Returns
 /// The `SumcheckOutput` with the final challenges and the witness evaluation.
-/// Zero-fills a segment up to a minimum length, borrowing it when it already reaches that.
-fn pad_to_min(words: &[Word], min_words: usize) -> Cow<'_, [Word]> {
-	if words.len() >= min_words {
-		Cow::Borrowed(words)
-	} else {
-		let mut padded = words.to_vec();
-		padded.resize(min_words, Word::ZERO);
-		Cow::Owned(padded)
-	}
-}
-
 pub fn prove<F, P, Channel, A>(
 	key_collection: &KeyCollection,
 	public_words: &[Word],
@@ -170,19 +157,12 @@ where
 	Channel: IPProverChannel<F>,
 	A: Allocator,
 {
-	// The segments are passed as the circuit declares them, at whatever length that is: phase 1
+	// The segments are passed as the circuit declares them, at whatever length that is. Phase 1
 	// zips each word with its key range, so a segment shorter than its key ranges stops at its
 	// last value — the words past it carry no keys — and phase 2's `fold_words` zero-pads each
-	// fold up to `log2_ceil(len)` variables. Neither needs a power-of-two segment.
-	//
-	// The one length the folds cannot infer is the minimum segment size, which the constraint
-	// system applies to the public segment and the monster multilinear is therefore built at. A
-	// circuit declaring fewer public values than that (only the all-one constant, say) would fold
-	// to a narrower multilinear than the monster it is checked against, so the floor is applied
-	// here. It costs at most `MIN_WORDS_PER_SEGMENT` words.
-	let public_words = pad_to_min(public_words, ConstraintSystem::MIN_WORDS_PER_SEGMENT);
+	// fold up to `log2_ceil(len)` variables. Neither needs a padded segment.
 	let words = SegmentWords {
-		public: &public_words,
+		public: public_words,
 		hidden: hidden_words,
 	};
 

--- a/crates/prover/tests/prove_verify.rs
+++ b/crates/prover/tests/prove_verify.rs
@@ -386,6 +386,70 @@ fn test_prove_verify_fewer_zero_than_and_constraints() {
 	prove_verify(cs, &witness);
 }
 
+/// Builds a circuit whose public segment is wider than its hidden one: `n_inout` input/output
+/// values against a handful of private ones.
+///
+/// Each inout value is asserted equal to the same AND output, which lowers to a ZERO constraint
+/// and commits nothing further, so the hidden segment stays at three words however many inout
+/// values the circuit declares. The optimization passes are off so that the repeated assertions
+/// survive as distinct constraints.
+fn public_heavy_circuit(n_inout: usize) -> (ConstraintSystem, ValueVec) {
+	let builder = CircuitBuilder::with_opts(Options {
+		enable_gate_fusion: false,
+		enable_common_subexpression_elimination: false,
+		enable_dead_code_elimination: false,
+		enable_algebraic_folding: false,
+		..Options::default()
+	});
+	let a = builder.add_witness();
+	let b = builder.add_witness();
+	let and_out = builder.band(a, b);
+
+	let inout = (0..n_inout)
+		.map(|_| builder.add_inout())
+		.collect::<Vec<_>>();
+	for &wire in &inout {
+		builder.assert_eq("inout_is_and_output", wire, and_out);
+	}
+
+	let circuit = builder.build();
+	let mut w = circuit.new_witness_filler();
+	let (a_val, b_val) = (Word(0x0123_4567_89AB_CDEF), Word(0xFEDC_BA98_7654_3210));
+	w[a] = a_val;
+	w[b] = b_val;
+	for &wire in &inout {
+		w[wire] = a_val & b_val;
+	}
+	circuit.populate_wire_witness(&mut w).unwrap();
+
+	let cs = circuit.constraint_system().clone();
+	let witness = w.into_value_vec();
+	cs.verify(&witness).unwrap();
+	(cs, witness)
+}
+
+/// A public segment wider than the hidden one proves and verifies.
+///
+/// Neither segment is padded to the other's length, so the shift reduction's word-index space
+/// spans the *wider* of the two — here the public one. Both sides size that space from
+/// `log_segment_words`, and the hidden half zero-extends up to it, so the sumcheck draws word-index
+/// challenges the hidden segment alone would not have called for. Every other circuit in this file
+/// has the hidden segment wider, which is the case the padding used to guarantee.
+#[test]
+fn test_prove_verify_public_wider_than_hidden() {
+	let (cs, witness) = public_heavy_circuit(300);
+	assert!(
+		cs.log_public_words() > cs.log_witness_words(),
+		"public segment ({} words) must be wider than the hidden one ({} words) for this test to \
+		 exercise the extra word-index challenges",
+		cs.n_public_words(),
+		cs.n_hidden_words(),
+	);
+	assert_eq!(cs.log_segment_words(), cs.log_public_words());
+	prove_verify(cs.clone(), &witness);
+	prove_verify_zk(cs, &witness);
+}
+
 /// A witness violating one ZERO constraint is rejected. The prover has nothing to send for the
 /// Zero reduction, so it claims the constant zero regardless; the shift reduction, running against
 /// the committed witness, is what catches the discrepancy.

--- a/crates/verifier/src/protocols/shift/verify.rs
+++ b/crates/verifier/src/protocols/shift/verify.rs
@@ -110,7 +110,7 @@ pub struct VerifyOutput<F> {
 	pub r_s: Vec<F>,
 	/// Challenge point for the shift-variant variables (length `LOG_SHIFT_VARIANT_COUNT`).
 	pub r_v: Vec<F>,
-	/// Challenge point for the word index variables (length `log_witness_words`).
+	/// Challenge point for the word index variables (length `log_segment_words`).
 	pub r_y: Vec<F>,
 	/// Challenge for the witness's segment selector variable.
 	pub r_segment: F,
@@ -208,9 +208,10 @@ where
 	let r_s = r_j.split_off(Word::LOG_BITS);
 
 	// The second sumcheck runs over the witness: the public segment in the low half-cube and
-	// the hidden segment in the high half-cube, selected by the top word-index variable. This
-	// matches the prover, which zero-pads each segment to the half size.
-	let log_word_count = constraint_system.log_witness_words() + 1;
+	// the hidden segment in the high half-cube, selected by the top word-index variable. Each
+	// half spans the wider of the two segments, which the prover zero-pads the shorter one up
+	// to, so a public segment longer than the hidden one draws the extra word-index challenges.
+	let log_word_count = constraint_system.log_segment_words() + 1;
 
 	let SumcheckOutput {
 		eval,

--- a/crates/verifier/src/verify.rs
+++ b/crates/verifier/src/verify.rs
@@ -77,11 +77,24 @@ impl IOPVerifier {
 
 	/// Returns log2 of the number of field elements in the packed trace.
 	///
-	/// The trace oracle commits only the witness's hidden segment, padded to the segment
-	/// length; the public segment is a verifier-known polynomial.
+	/// The trace oracle commits only the witness's hidden segment; the public segment is a
+	/// verifier-known polynomial. The shift reduction claims that segment over the shared
+	/// word-index space, which spans the wider of the two segments, so the oracle covers
+	/// `log_segment_words` words. That is the hidden segment's own length for every system
+	/// whose private values outnumber its public ones, and the committed words above the
+	/// hidden segment are zero.
+	///
+	/// ## Preconditions
+	/// * the wider segment spans at least one field element's worth of words, which every system
+	///   with more than one public or private value satisfies
 	pub const fn log_witness_elems(&self) -> usize {
-		let log_witness_words = self.constraint_system.log_witness_words();
-		log_witness_words - LOG_WORDS_PER_ELEM
+		let log_segment_words = self.constraint_system.log_segment_words();
+		assert!(
+			log_segment_words >= LOG_WORDS_PER_ELEM,
+			"the committed trace is a whole number of field elements, so the wider value \
+			 segment spans at least that many words"
+		);
+		log_segment_words - LOG_WORDS_PER_ELEM
 	}
 
 	/// Returns log2 of the number of words in the committed trace.
@@ -397,10 +410,7 @@ where
 	pub fn setup(constraint_system: ConstraintSystem, log_inv_rate: usize) -> Result<Self, Error> {
 		constraint_system.validate()?;
 
-		// The validated layout guarantees a power-of-two public segment of at least one full
-		// element.
 		let log_public_words = constraint_system.log_public_words();
-		assert!(log_public_words >= LOG_WORDS_PER_ELEM);
 
 		let iop_verifier = IOPVerifier::new(constraint_system, log_public_words);
 

--- a/crates/verifier/src/zk_config.rs
+++ b/crates/verifier/src/zk_config.rs
@@ -38,10 +38,7 @@ use binius_utils::{DeserializeBytes, SerializeBytes, serialization::Serializatio
 use bytes::{Buf, BufMut};
 use digest::Output;
 
-use crate::{
-	config::LOG_WORDS_PER_ELEM,
-	verify::{IOPVerifier, SECURITY_BITS},
-};
+use crate::verify::{IOPVerifier, SECURITY_BITS};
 
 /// Zero-knowledge verifier for Binius64 constraint systems.
 ///
@@ -68,10 +65,7 @@ where
 
 		constraint_system.validate()?;
 
-		// The validated layout guarantees a power-of-two public segment of at least one full
-		// element.
 		let log_public_words = constraint_system.log_public_words();
-		assert!(log_public_words >= LOG_WORDS_PER_ELEM);
 
 		let inner_iop_verifier = IOPVerifier::new(constraint_system, log_public_words);
 


### PR DESCRIPTION
Part of [BINIUS-404](https://linear.app/binius/issue/BINIUS-404). Follows #2048, #2050, #2056 and #2060.

The value vector's segments now hold exactly the values a circuit declares. `MIN_WORDS_PER_SEGMENT` is gone, the public segment is no longer rounded up to a power of two, and the hidden segment is no longer padded to the public segment's length. `n_public_words` and `n_hidden_words` are the value counts themselves.

Nothing needed the padding. Phase 1 zips each word with its key range, so a segment shorter than its key ranges stops at its last value, and phase 2's `fold_words` zero-pads each fold up to `log2_ceil(len)` variables. That let `pad_to_min` go too — there is no padding left anywhere in the shift prover.

## The wider-public case

Dropping the hidden segment's padding removes the guarantee that it is the wider of the two. The shift reduction now sizes its word-index space from a new `ConstraintSystem::log_segment_words` — the wider of the two segments — so a system with more public words than private values makes the sumcheck draw the extra word-index challenges, and the hidden half zero-extends up to that width (`zero_extend` in `phase_2.rs`, a no-op whenever the hidden segment is already the wider one, which is every circuit that does work).

The verifier's `check_eval` and `MonsterEvalFn` turned out to be width-general already: `hidden_tensor` is built over the whole of `r_y`, and the public side's `eq_ind_zero(&r_y[log_public_words..])` degenerates to 1 when public is the wider segment. Only the challenge count needed changing.

## Two things worth a look

**The committed trace spans `log_segment_words`, not `log_witness_words`.** This is the one place a zero-extension survives, so it sits closest to "no more padding hidden words to the length of public". It isn't optional: the shift reduction claims the hidden segment over the *shared* word-index space, and `ring_switch::prove` asserts `packed_witness.log_len() + 7 == eval_point.len()`, so the oracle has to span that space. `pack_witness` already zero-pads, so it is a one-line change, and it is a no-op for every system whose private values outnumber its public ones. The alternative — keeping the oracle at the hidden segment's own width and dividing `eq_ind_zero` out of the witness evaluation at the PCS boundary — buys a smaller commitment only in the pathological case, at the cost of another division-by-challenge incompleteness. Happy to switch if you'd rather not extend the oracle.

**`log_witness_elems` gained an assert.** `MIN_WORDS_PER_SEGMENT` used to guarantee `log_segment_words >= LOG_WORDS_PER_ELEM`; without it a degenerate circuit (at most one public *and* at most one private word) would underflow a `usize` and wrap into a huge allocation in release. It now panics with a message instead. No real circuit reaches it, so I didn't promote it to a `validate()` error — say the word if you'd prefer that.

## Testing

Added `test_prove_verify_public_wider_than_hidden` (300 inout values, 3 private). **No existing test covered a public segment wider than the hidden one** — that is precisely what the old padding ruled out — so without it this case would have shipped untested. It caught the `ring_switch` sizing above.

Locally green with `RUSTFLAGS="-C target-cpu=native"`: core 98, verifier 43 + 13, prover 5 + 37 + 14, m4-prover 13; workspace `clippy -D warnings`, `fmt` and `cargo doc` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)