### PR TITLE
BINIUS-413: run the shift reduction phase 1 as one 15-variate sumcheck

### DIFF
--- a/crates/m4-prover/src/shift.rs
+++ b/crates/m4-prover/src/shift.rs
@@ -2,7 +2,7 @@
 
 //! The batched shift-reduction prover for the data-parallel Binius64 M4 proof system.
 
-use std::{array, iter};
+use std::iter;
 
 use binius_compute::Allocator;
 use binius_core::word::Word;
@@ -14,18 +14,13 @@ use binius_prover::{
 	fold_word::fold_words,
 	protocols::shift::{
 		KeyCollection, KeySegment, OperatorClaims, PreparedOperatorClaims,
-		monster::{build_h_parts, build_monster_segments},
-		phase_1::{build_g_parts, run_phase_1_sumcheck},
+		monster::{build_h, build_monster_segments},
+		phase_1::{PHASE_1_LOG_LEN, build_g, run_phase_1_sumcheck},
 		phase_2::run_sumcheck,
 	},
 };
-use binius_verifier::protocols::shift::SHIFT_VARIANT_COUNT;
 
 use crate::witness::{FoldedWitness, FoldedWord};
-
-/// The number of variables in each "g" (and "h") multilinear of phase 1: one 6-bit shift-amount
-/// axis and one 6-bit bit-position axis.
-const LOG_LEN: usize = Word::LOG_BITS + Word::LOG_BITS;
 
 /// Proves the batched shift-reduction, collapsing every operation's claims into one.
 ///
@@ -36,8 +31,8 @@ const LOG_LEN: usize = Word::LOG_BITS + Word::LOG_BITS;
 /// The public words are constants shared by every instance, so they are passed as raw words.
 ///
 /// The two phases call the single-instance prover's own subroutines.
-/// Phase 1 builds the hidden g parts with [`build_g_parts_from_folded_words`].
-/// It builds the public g parts with the single-instance `build_g_parts`, then sums the two.
+/// Phase 1 builds the hidden segment's g with [`build_g_from_folded_words`].
+/// It builds the public segment's g with the single-instance `build_g`, then sums the two.
 /// Phase 2 contracts the hidden witness along its bit axis with [`FoldedWitness::fold_bits`].
 /// It folds the public segment the same way, at the same challenge `r_j`.
 /// It then reuses `build_monster_segments` and `run_sumcheck` unchanged.
@@ -72,33 +67,27 @@ where
 	// SOUNDNESS: `prepare` draws in the order the verifier draws in; do not reorder it.
 	let prepared = claims.prepare(|| channel.sample());
 
-	// Phase 1: build the g parts once per key segment, then add them. The public words are
+	// Phase 1: build g once per key segment, then add them. The public words are
 	// constants shared by every instance, so the single-instance builder folds them directly from
 	// their bits; the hidden words are already folded over instances. This scalar path drives the
 	// single-instance phase-1 sumcheck.
-	let mut g_parts =
-		build_g_parts::<F, F, _>(alloc, public_words, &key_collection.public, &prepared);
-	let hidden_g_parts = build_g_parts_from_folded_words(
-		alloc,
-		folded_witness.words(),
-		&key_collection.hidden,
-		&prepared,
-	);
-	for (g, hidden_g) in g_parts.iter_mut().zip(&hidden_g_parts) {
-		for (slot, add) in g.as_mut().iter_mut().zip(hidden_g.as_ref()) {
-			*slot += *add;
-		}
+	let mut g = build_g::<F, F, _>(alloc, public_words, &key_collection.public, &prepared);
+	let hidden_g =
+		build_g_from_folded_words(alloc, folded_witness.words(), &key_collection.hidden, &prepared);
+	for (slot, add) in iter::zip(g.as_mut(), hidden_g.as_ref()) {
+		*slot += *add;
 	}
-	let h_parts = build_h_parts::<F, F, _>(alloc, domain_subspace, prepared.bitand.r_zhat_prime);
-	let phase_1_output = run_phase_1_sumcheck::<F, F, _, _>(g_parts, h_parts, channel, alloc);
+	let h = build_h::<F, F, _>(alloc, domain_subspace, prepared.bitand.r_zhat_prime);
+	let phase_1_output = run_phase_1_sumcheck::<F, F, _, _>(g, h, channel, alloc);
 
-	// Phase 2: split the phase-1 challenges into the bit half `r_j` and the shift half `r_s`.
+	// Phase 2: split the phase-1 challenges into the bit position `r_j`, the shift amount `r_s`
+	// and the shift variant `r_v`, in increasing order of significance.
 	let SumcheckOutput {
-		challenges: mut r_jr_s,
+		challenges: mut r_j,
 		eval: gamma,
 	} = phase_1_output;
-	let r_s = r_jr_s.split_off(Word::LOG_BITS);
-	let r_j = r_jr_s;
+	let r_v = r_j.split_off(Word::LOG_BITS * 2);
+	let r_s = r_j.split_off(Word::LOG_BITS);
 	let r_j_tensor = eq_ind_partial_eval::<F>(&r_j);
 
 	// The witness folded at `r_j`, per segment.
@@ -113,6 +102,7 @@ where
 		domain_subspace,
 		&r_j,
 		&r_s,
+		&r_v,
 	);
 
 	run_sumcheck::<F, P, _, _>(
@@ -130,7 +120,7 @@ where
 
 /// Constructs the phase-1 "g" multilinear parts, one per shift variant, from instance-folded words.
 ///
-/// This is the batched analogue of the single-instance [`build_g_parts`].
+/// This is the batched analogue of the single-instance [`build_g`].
 /// It consumes a key segment's words already folded over the instance axis.
 /// So each word is a [`FoldedWord`], whose bits are field elements rather than a packed `u64`.
 ///
@@ -139,8 +129,8 @@ where
 /// The two coincide when the folded bit is 0 or 1.
 ///
 /// Use this for the hidden (committed) segment, whose words are folded over instances.
-/// Use [`build_g_parts`] for the public segment, whose words are shared constants.
-/// Adding the two results gives the complete g parts.
+/// Use [`build_g`] for the public segment, whose words are shared constants.
+/// Adding the two results gives the complete g multilinear.
 ///
 /// # Arguments
 ///
@@ -152,30 +142,29 @@ where
 ///
 /// # Returns
 ///
-/// `SHIFT_VARIANT_COUNT` multilinears of [`LOG_LEN`] variables, one per shift variant.
+/// One multilinear of [`PHASE_1_LOG_LEN`] variables, holding every shift variant's part.
 ///
 /// The segment's dense shift encoding decodes a key's shift index into the variant and the shift
-/// amount. The variant picks the multilinear, and the amount picks the run of bit slots within it:
+/// amount. The variant indexes the high variables and the amount the middle ones, so a key names
+/// one run of bit slots:
 ///
 /// ```text
-/// g[variant][amount * Word::BITS + bit] += folded_bit * acc(key)
+/// g[(variant * Word::BITS + amount) * Word::BITS + bit] += folded_bit * acc(key)
 /// ```
 ///
 /// where `acc(key)` is the key's lambda-weighted partial evaluation tensor.
 /// Every word carrying that key accumulates into the same slots.
 ///
 /// This scalar implementation ignores the single-instance builder's packing and parallelism.
-pub fn build_g_parts_from_folded_words<F: BinaryField, A: Allocator>(
+pub fn build_g_from_folded_words<F: BinaryField, A: Allocator>(
 	alloc: &A,
 	folded_words: &[FoldedWord<F>],
 	segment: &KeySegment,
 	prepared: &PreparedOperatorClaims<F>,
-) -> [FieldVec<F, A>; SHIFT_VARIANT_COUNT] {
-	// One zeroed multilinear of LOG_LEN variables per shift variant, drawn from the allocator. A
-	// key belongs to exactly one variant, so the scatter below accumulates straight into these
-	// buffers.
-	let mut multilinears =
-		array::from_fn::<_, SHIFT_VARIANT_COUNT, _>(|_| FieldBuffer::zeros_in(alloc, LOG_LEN));
+) -> FieldVec<F, A> {
+	// One zeroed multilinear covering every shift, drawn from the allocator. A key names one
+	// `(variant, amount)` pair, so the scatter below accumulates straight into it.
+	let mut multilinear = FieldBuffer::zeros_in(alloc, PHASE_1_LOG_LEN);
 
 	// Each folded word carries the keys named by the segment-relative range at its position.
 	for (word, range) in folded_words.iter().zip(&segment.key_ranges) {
@@ -190,12 +179,11 @@ pub fn build_g_parts_from_folded_words<F: BinaryField, A: Allocator>(
 				&operator_data.lambda_powers,
 			);
 
-			// The key's shift variant selects the multilinear, and its shift amount the bit slots
-			// within that multilinear.
+			// The key's shift variant indexes the high variables and its shift amount the middle
+			// ones, which together name one run of bit slots.
 			let (variant, amount) = segment.dense_shift_enc.decode(key.dense_shift_idx as usize);
-			let amount_base = amount as usize * Word::BITS;
-			let slots =
-				&mut multilinears[variant as usize].as_mut()[amount_base..amount_base + Word::BITS];
+			let base = (variant as usize * Word::BITS + amount as usize) * Word::BITS;
+			let slots = &mut multilinear.as_mut()[base..base + Word::BITS];
 
 			// Scatter the accumulator across this key's bit slots, scaling each by the folded bit.
 			for (slot, &folded_bit) in iter::zip(slots, word) {
@@ -204,7 +192,7 @@ pub fn build_g_parts_from_folded_words<F: BinaryField, A: Allocator>(
 		}
 	}
 
-	multilinears
+	multilinear
 }
 
 #[cfg(test)]
@@ -220,9 +208,7 @@ mod tests {
 		test_utils::random_scalars,
 		univariate::lagrange_evals_scalars,
 	};
-	use binius_prover::protocols::shift::{
-		OperatorData, build_key_collection, monster::build_h_parts,
-	};
+	use binius_prover::protocols::shift::{OperatorData, build_key_collection, monster::build_h};
 	use binius_transcript::ProverTranscript;
 	use binius_verifier::{
 		config::{B128, StdChallenger},
@@ -268,7 +254,7 @@ mod tests {
 	}
 
 	// Folds a contiguous run of value-vector words over the instance axis, one FoldedWord per word.
-	// This lets the public and hidden segments be folded separately, matching how `build_g_parts`
+	// This lets the public and hidden segments be folded separately, matching how `build_g`
 	// consumes one segment at a time.
 	fn fold_words_over_instances(
 		table: &ValueTable,
@@ -425,8 +411,8 @@ mod tests {
 	// The phase-1 identity: summing the g·h inner products over the shift variants reconstructs the
 	// lambda-batched operand evaluation claim.
 	//
-	// The g parts come from the batched build_g_parts on the full folded witness; the h parts come
-	// from the single-instance prover's build_h_parts at the same univariate challenge r_z. Their
+	// The g multilinear comes from the batched build_g on the full folded witness; h comes
+	// from the single-instance prover's build_h at the same univariate challenge r_z. Their
 	// inner product must equal the lambda-powers scaling of the batched AND-check operand evals
 	// (the intmul claim is empty, contributing nothing).
 	#[test]
@@ -494,32 +480,26 @@ mod tests {
 		};
 		let prepared = claims.prepare(|| B128::random(&mut rng));
 
-		// The g parts: the public segment folds from raw constant words via the single-instance
-		// builder, the hidden segment from the instance-folded words. Add them. The h parts come
-		// from the single-instance prover.
-		let mut g_parts = build_g_parts::<B128, B128, _>(
+		// The g multilinear: the public segment folds from raw constant words via the
+		// single-instance builder, the hidden segment from the instance-folded words. Add them.
+		// The h multilinear comes from the single-instance prover.
+		let mut g = build_g::<B128, B128, _>(
 			&GlobalAllocator,
 			public_words,
 			&key_collection.public,
 			&prepared,
 		);
-		let hidden_g_parts = build_g_parts_from_folded_words(
+		let hidden_g = build_g_from_folded_words(
 			&GlobalAllocator,
 			&hidden_folded,
 			&key_collection.hidden,
 			&prepared,
 		);
-		for (g, hidden_g) in g_parts.iter_mut().zip(&hidden_g_parts) {
-			for (slot, add) in g.as_mut().iter_mut().zip(hidden_g.as_ref()) {
-				*slot += *add;
-			}
+		for (slot, add) in iter::zip(g.as_mut(), hidden_g.as_ref()) {
+			*slot += *add;
 		}
-		let h_parts = build_h_parts::<B128, B128, _>(&GlobalAllocator, &domain_subspace, r_z);
-		let inner_product: B128 = g_parts
-			.iter()
-			.zip(&h_parts)
-			.map(|(g, h)| inner_product_buffers(g, h))
-			.sum();
+		let h = build_h::<B128, B128, _>(&GlobalAllocator, &domain_subspace, r_z);
+		let inner_product = inner_product_buffers(&g, &h);
 
 		// The lambda-powers scaling of the batched AND-check evals, plus the empty intmul claim.
 		let expected = prepared.bitand.batched_eval + prepared.intmul.batched_eval;

--- a/crates/prover/benches/shift_reduction.rs
+++ b/crates/prover/benches/shift_reduction.rs
@@ -1,6 +1,8 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
+use std::iter;
+
 use binius_circuits::sha256::sha256_fixed;
 use binius_compute::{BufferPool, GlobalAllocator};
 use binius_core::{ValueVec, constraint_system::ConstraintSystem, word::Word};
@@ -12,8 +14,8 @@ use binius_prover::{
 	fold_word::fold_words,
 	protocols::shift::{
 		OperatorClaims, OperatorData, build_key_collection,
-		monster::{build_h_parts, build_monster_segments},
-		phase_1::{build_g_parts, run_phase_1_sumcheck},
+		monster::{build_h, build_monster_segments},
+		phase_1::{build_g, run_phase_1_sumcheck},
 		phase_2::run_sumcheck,
 		prove,
 	},
@@ -258,7 +260,7 @@ fn bench_shift_phases(c: &mut Criterion) {
 	let intmul_evals = [F::ZERO; 4];
 
 	let key_collection = build_key_collection(&cs);
-	// The phase functions take each segment as the circuit declares it: `build_g_parts` zips the
+	// The phase functions take each segment as the circuit declares it: `build_g` zips the
 	// words with their key ranges and `fold_words` pads each fold to `log2_ceil(len)` variables.
 	let public_words = value_vec.public();
 	let hidden_words = value_vec.non_public();
@@ -293,47 +295,31 @@ fn bench_shift_phases(c: &mut Criterion) {
 	// here (with a throwaway transcript) to capture each phase's inputs; the setup closures below
 	// then only clone what a phase consumes by value. The specific transcript challenges do not
 	// change the work a phase performs.
-	// `build_g_parts` runs per key segment; the full g parts are the sum of the public and hidden
-	// segment parts.
-	let build_combined_g_parts = || {
-		let mut g_parts = build_g_parts::<F, P, _>(
-			&GlobalAllocator,
-			public_words,
-			&key_collection.public,
-			&prepared,
-		);
-		let hidden_g_parts = build_g_parts::<F, P, _>(
-			&GlobalAllocator,
-			hidden_words,
-			&key_collection.hidden,
-			&prepared,
-		);
-		for (g, hidden_g) in g_parts.iter_mut().zip(&hidden_g_parts) {
-			for (slot, add) in g.as_mut().iter_mut().zip(hidden_g.as_ref()) {
-				*slot += *add;
-			}
+	// `build_g` runs per key segment; the full g multilinear is the sum of the public and
+	// hidden segment ones.
+	let build_combined_g = || {
+		let mut g =
+			build_g::<F, P, _>(&GlobalAllocator, public_words, &key_collection.public, &prepared);
+		let hidden_g =
+			build_g::<F, P, _>(&GlobalAllocator, hidden_words, &key_collection.hidden, &prepared);
+		for (slot, add) in iter::zip(g.as_mut(), hidden_g.as_ref()) {
+			*slot += *add;
 		}
-		g_parts
+		g
 	};
 
-	let g_parts = build_combined_g_parts();
-	let h_parts =
-		build_h_parts::<F, P, _>(&GlobalAllocator, &subspace, prepared.bitand.r_zhat_prime);
+	let g = build_combined_g();
+	let h = build_h::<F, P, _>(&GlobalAllocator, &subspace, prepared.bitand.r_zhat_prime);
 	let SumcheckOutput {
-		challenges: mut r_jr_s,
+		challenges: mut r_j,
 		eval: gamma,
 	} = {
 		let mut transcript = ProverTranscript::<StdChallenger>::default();
-		run_phase_1_sumcheck::<F, P, _, _>(
-			g_parts.clone(),
-			h_parts.clone(),
-			&mut transcript,
-			&GlobalAllocator,
-		)
+		run_phase_1_sumcheck::<F, P, _, _>(g.clone(), h.clone(), &mut transcript, &GlobalAllocator)
 	};
-	// Split phase-1 challenges into `r_j` (low) and `r_s` (high) halves.
-	let r_s = r_jr_s.split_off(Word::LOG_BITS);
-	let r_j = r_jr_s;
+	// Split the phase-1 challenges into the bit position, the shift amount and the shift variant.
+	let r_v = r_j.split_off(Word::LOG_BITS * 2);
+	let r_s = r_j.split_off(Word::LOG_BITS);
 	let r_j_tensor = eq_ind_partial_eval::<F>(&r_j);
 	let public_folded = fold_words::<F, P, _>(&GlobalAllocator, public_words, r_j_tensor.as_ref());
 	let hidden_folded = fold_words::<F, P, _>(&GlobalAllocator, hidden_words, r_j_tensor.as_ref());
@@ -344,24 +330,23 @@ fn bench_shift_phases(c: &mut Criterion) {
 		&subspace,
 		&r_j,
 		&r_s,
+		&r_v,
 	);
 
 	let mut group = c.benchmark_group("shift_reduction_phases");
 	group.sample_size(10);
 
-	// Phase 1. `build_g_parts` / `build_h_parts` take their inputs by reference, so no
-	// per-iteration clone is needed; `run_phase_1_sumcheck` consumes `g_parts`/`h_parts` by value.
+	// Phase 1. `build_g` / `build_h` take their inputs by reference, so no
+	// per-iteration clone is needed; `run_phase_1_sumcheck` consumes `g`/`h` by value.
 	group.bench_function("phase1_build_g_parts", |b| {
-		b.iter(&build_combined_g_parts);
+		b.iter(&build_combined_g);
 	});
 	group.bench_function("phase1_build_h_parts", |b| {
-		b.iter(|| {
-			build_h_parts::<F, P, _>(&GlobalAllocator, &subspace, prepared.bitand.r_zhat_prime)
-		});
+		b.iter(|| build_h::<F, P, _>(&GlobalAllocator, &subspace, prepared.bitand.r_zhat_prime));
 	});
 	group.bench_function("phase1_run_sumcheck", |b| {
 		b.iter_batched(
-			|| (g_parts.clone(), h_parts.clone()),
+			|| (g.clone(), h.clone()),
 			|(g, h)| {
 				let mut transcript = ProverTranscript::<StdChallenger>::default();
 				run_phase_1_sumcheck::<F, P, _, _>(g, h, &mut transcript, &GlobalAllocator)
@@ -381,6 +366,7 @@ fn bench_shift_phases(c: &mut Criterion) {
 				&subspace,
 				&r_j,
 				&r_s,
+				&r_v,
 			)
 		});
 	});

--- a/crates/prover/src/protocols/shift/mod.rs
+++ b/crates/prover/src/protocols/shift/mod.rs
@@ -2,7 +2,6 @@
 // Copyright 2026 The Binius Developers
 
 use binius_core::word::Word;
-use binius_verifier::protocols::shift::SHIFT_VARIANT_COUNT;
 
 /// The value vector's two committed segments, each at the width the protocol addresses it at.
 ///

--- a/crates/prover/src/protocols/shift/monster.rs
+++ b/crates/prover/src/protocols/shift/monster.rs
@@ -4,11 +4,11 @@
 use std::iter;
 
 use binius_compute::{Allocator, VecLike};
-use binius_core::word::Word;
+use binius_core::{ShiftVariant, word::Word};
 use binius_field::{BinaryField, Field, PackedField, WideMul};
 use binius_math::{
-	BinarySubspace, FieldBuffer, FieldVec, multilinear::eq::eq_ind_partial_eval,
-	univariate::lagrange_evals,
+	BinarySubspace, FieldBuffer, FieldVec, inner_product::inner_product,
+	multilinear::eq::eq_ind_partial_eval, univariate::lagrange_evals,
 };
 use binius_utils::{checked_arithmetics::checked_log_2, rayon::prelude::*};
 use binius_verifier::protocols::shift::{
@@ -18,10 +18,13 @@ use bytemuck::zeroed_vec;
 use tracing::instrument;
 
 use super::{
-	SHIFT_VARIANT_COUNT,
 	claims::PreparedOperatorClaims,
 	key_collection::{DenseShiftEncoding, KeyCollection, KeySegment, Operation},
+	phase_1::PHASE_1_LOG_LEN,
 };
+
+/// The width the half-word (`*32`) shift variants act over.
+const HALF_WORD_BITS: usize = 32;
 
 /// The phase-2 scalar weights of one key segment, one table per operation.
 ///
@@ -34,87 +37,94 @@ struct ScalarTables<F> {
 	binmul: Vec<F>,
 }
 
-/// Constructs the three "h" multilinear polynomials for shift operations at a
-/// univariate challenge point. See the paper for definition of h polynomials.
+/// Fills one row of the phase-1 "h" multilinear: the shift indicator of one `(variant, amount)`
+/// pair, contracted against the Lagrange evaluations at the univariate challenge.
 ///
-/// There is one h multilinear for each shift variant. For each operation, there is one univariate
-/// challenge `r_zhat_prime` at which to construct the h parts.
+/// This is the one place that says what a variant does to the challenge weights:
+/// - Logical left and logical right move the weights and leave zeros behind.
+/// - Arithmetic right piles every weight that falls off the end onto the sign position.
+/// - Rotate wraps them around instead.
+/// - The half-word forms apply the same rule to each 32-bit half, reading only the low 5 bits of
+///   the amount.
+fn fill_h_row<F: Field>(variant: ShiftVariant, amount: usize, row: &mut [F], l_tilde: &[F]) {
+	// A half-word variant repeats the full-width rule over each half, so both share one closure.
+	let halves = |row: &mut [F], rule: fn(usize, &mut [F], &[F])| {
+		let amount = amount % HALF_WORD_BITS;
+		for (row_half, l_tilde_half) in
+			iter::zip(row.chunks_mut(HALF_WORD_BITS), l_tilde.chunks(HALF_WORD_BITS))
+		{
+			rule(amount, row_half, l_tilde_half);
+		}
+	};
+
+	fn sll<F: Field>(amount: usize, row: &mut [F], l_tilde: &[F]) {
+		let width = row.len();
+		row[..width - amount].copy_from_slice(&l_tilde[amount..]);
+	}
+	fn srl<F: Field>(amount: usize, row: &mut [F], l_tilde: &[F]) {
+		let width = row.len();
+		row[amount..].copy_from_slice(&l_tilde[..width - amount]);
+	}
+	fn sar<F: Field>(amount: usize, row: &mut [F], l_tilde: &[F]) {
+		let width = row.len();
+		srl(amount, row, l_tilde);
+		// Every position past the shift reads the sign bit, so their weights pile onto it.
+		row[width - 1] += l_tilde[width - amount..].iter().sum::<F>();
+	}
+	fn rotr<F: Field>(amount: usize, row: &mut [F], l_tilde: &[F]) {
+		let width = row.len();
+		row[..amount].copy_from_slice(&l_tilde[width - amount..]);
+		row[amount..].copy_from_slice(&l_tilde[..width - amount]);
+	}
+
+	match variant {
+		ShiftVariant::Sll => sll(amount, row, l_tilde),
+		ShiftVariant::Slr => srl(amount, row, l_tilde),
+		ShiftVariant::Sar => sar(amount, row, l_tilde),
+		ShiftVariant::Rotr => rotr(amount, row, l_tilde),
+		ShiftVariant::Sll32 => halves(row, sll),
+		ShiftVariant::Srl32 => halves(row, srl),
+		ShiftVariant::Sra32 => halves(row, sar),
+		ShiftVariant::Rotr32 => halves(row, rotr),
+	}
+}
+
+/// Constructs the "h" multilinear for shift operations at a univariate challenge point.
+///
+/// See the paper for the definition of the h polynomials. There is one per shift variant, and this
+/// returns all of them as a single multilinear over [`PHASE_1_LOG_LEN`] variables: the shift
+/// variant occupies the high
+/// [`LOG_SHIFT_VARIANT_COUNT`](binius_verifier::protocols::shift::LOG_SHIFT_VARIANT_COUNT)
+/// variables, the shift amount the middle
+/// [`Word::LOG_BITS`], and the bit position the low [`Word::LOG_BITS`].
 ///
 /// # Usage in Protocol
 ///
-/// Used in phase 1, thus returning an array of multilinear evaluations.
-#[instrument(skip_all, name = "build_h_parts")]
-pub fn build_h_parts<F, P: PackedField<Scalar = F>, A: Allocator>(
+/// Phase 1 runs one sumcheck over this multilinear and its "g" counterpart, so the variant axis is
+/// folded by the sumcheck rather than summed across separate provers.
+#[instrument(skip_all, name = "build_h")]
+pub fn build_h<F, P: PackedField<Scalar = F>, A: Allocator>(
 	alloc: &A,
 	domain_subspace: &BinarySubspace<F>,
 	r_zhat_prime: F,
-) -> [FieldVec<P, A>; SHIFT_VARIANT_COUNT]
+) -> FieldVec<P, A>
 where
 	F: BinaryField,
 {
 	let l_tilde = lagrange_evals(domain_subspace, r_zhat_prime);
 	let l_tilde = l_tilde.as_ref();
 
-	fn build_part<F: Field, P: PackedField<Scalar = F>, A: Allocator>(
-		alloc: &A,
-		fill: impl Fn(usize, &mut [F; Word::BITS]),
-	) -> FieldVec<P, A> {
-		let mut data = zeroed_vec::<[F; Word::BITS]>(Word::BITS);
-		for (s, chunk) in data.iter_mut().enumerate() {
-			fill(s, chunk);
+	// One row of `Word::BITS` scalars per `(variant, amount)`, variant most significant.
+	let mut data = zeroed_vec::<F>(1 << PHASE_1_LOG_LEN);
+	for (variant, block) in
+		iter::zip(ShiftVariant::ALL, data.chunks_exact_mut(Word::BITS * Word::BITS))
+	{
+		for (amount, row) in block.chunks_exact_mut(Word::BITS).enumerate() {
+			fill_h_row(variant, amount, row, l_tilde);
 		}
-		FieldBuffer::from_values_in(alloc, &data.into_flattened())
 	}
 
-	let sll = build_part(alloc, |s, sll_s| {
-		sll_s[..Word::BITS - s].copy_from_slice(&l_tilde[s..]);
-	});
-
-	let srl = build_part(alloc, |s, srl_s| {
-		srl_s[s..].copy_from_slice(&l_tilde[..Word::BITS - s]);
-	});
-
-	let sra = build_part(alloc, |s, sra_s| {
-		sra_s[s..].copy_from_slice(&l_tilde[..Word::BITS - s]);
-		sra_s[Word::BITS - 1] += l_tilde[Word::BITS - s..].iter().sum::<F>();
-	});
-
-	let rotr = build_part(alloc, |s, rotr_s| {
-		rotr_s[..s].copy_from_slice(&l_tilde[Word::BITS - s..]);
-		rotr_s[s..].copy_from_slice(&l_tilde[..Word::BITS - s]);
-	});
-
-	let sll32 = build_part(alloc, |s, sll32_s| {
-		let s = s % 32;
-		for (l_tilde_i, sll_s_i) in iter::zip(l_tilde.chunks(32), sll32_s.chunks_mut(32)) {
-			sll_s_i[..32 - s].copy_from_slice(&l_tilde_i[s..]);
-		}
-	});
-
-	let srl32 = build_part(alloc, |s, srl32_s| {
-		let s = s % 32;
-		for (l_tilde_i, srl32_s_i) in iter::zip(l_tilde.chunks(32), srl32_s.chunks_mut(32)) {
-			srl32_s_i[s..].copy_from_slice(&l_tilde_i[..32 - s]);
-		}
-	});
-
-	let sra32 = build_part(alloc, |s, sra32_s| {
-		let s = s % 32;
-		for (l_tilde_i, sra32_s_i) in iter::zip(l_tilde.chunks(32), sra32_s.chunks_mut(32)) {
-			sra32_s_i[s..].copy_from_slice(&l_tilde_i[..32 - s]);
-			sra32_s_i[32 - 1] += l_tilde_i[32 - s..].iter().sum::<F>();
-		}
-	});
-
-	let rotr32 = build_part(alloc, |s, rotr32_s| {
-		let s = s % 32;
-		for (l_tilde_i, rotr32_s_i) in iter::zip(l_tilde.chunks(32), rotr32_s.chunks_mut(32)) {
-			rotr32_s_i[..s].copy_from_slice(&l_tilde_i[32 - s..]);
-			rotr32_s_i[s..].copy_from_slice(&l_tilde_i[..32 - s]);
-		}
-	});
-
-	[sll, srl, sra, rotr, sll32, srl32, sra32, rotr32]
+	FieldBuffer::from_values_in(alloc, &data)
 }
 
 /// Constructs the "monster multilinear" that combines all shift operations into a single
@@ -159,12 +169,17 @@ pub fn build_monster_segments<F, P: PackedField<Scalar = F>, A: Allocator>(
 	domain_subspace: &BinarySubspace<F>,
 	r_j: &[F],
 	r_s: &[F],
+	r_v: &[F],
 ) -> (FieldVec<P, A>, FieldVec<P, A>)
 where
 	F: BinaryField,
 {
-	// Compute h evaluations
-	let [zero_h_ops, bitand_h_ops, intmul_h_ops, binmul_h_ops] = [
+	// Phase 1 folded the variant axis into the sumcheck, so the h multilinear contributes one
+	// scalar per operation — the interpolation of its eight shift indicators at `r_v` — rather
+	// than one per variant.
+	let r_v_tensor = eq_ind_partial_eval::<F>(r_v);
+
+	let [zero_h_eval, bitand_h_eval, intmul_h_eval, binmul_h_eval] = [
 		prepared.zero.r_zhat_prime,
 		prepared.bitand.r_zhat_prime,
 		prepared.intmul.r_zhat_prime,
@@ -172,7 +187,8 @@ where
 	]
 	.map(|r_zhat_prime| {
 		let l_tilde = lagrange_evals(domain_subspace, r_zhat_prime);
-		evaluate_h_op(l_tilde.as_ref(), r_j, r_s)
+		let h_ops = evaluate_h_op(l_tilde.as_ref(), r_j, r_s);
+		inner_product(h_ops, r_v_tensor.as_ref().iter().copied())
 	});
 
 	let r_s_tensor = eq_ind_partial_eval::<F>(r_s);
@@ -180,11 +196,16 @@ where
 	// The scalars of one operation, laid out with the operand index innermost so that the `arity`
 	// weights for one `key.dense_shift_idx` form a contiguous chunk that [`Key::accumulate_wide`]
 	// can index directly by operand index.
+	//
+	// A key's shift now selects itself through a pure equality indicator over both of phase 1's
+	// shift axes, and the h evaluation is a single factor shared by every key of the operation.
 	let build_scalars =
-		|arity: usize, lambda_powers: &[F], h_ops: &[F], dense_shift_enc: &DenseShiftEncoding| {
+		|arity: usize, lambda_powers: &[F], h_eval: F, dense_shift_enc: &DenseShiftEncoding| {
 			let mut scalars = vec![F::ZERO; arity * dense_shift_enc.len()];
 			for (dense_shift_idx, (variant, amount)) in dense_shift_enc.iter().enumerate() {
-				let shift_scalar = h_ops[variant as usize] * r_s_tensor.as_ref()[amount as usize];
+				let shift_scalar = h_eval
+					* r_v_tensor.as_ref()[variant as usize]
+					* r_s_tensor.as_ref()[amount as usize];
 				for operand_idx in 0..arity {
 					scalars[dense_shift_idx * arity + operand_idx] =
 						lambda_powers[operand_idx] * shift_scalar;
@@ -195,23 +216,23 @@ where
 
 	// Each segment has its own dense shift encoding, so it has its own scalar tables.
 	let build_scalar_tables = |dense_shift_enc: &DenseShiftEncoding| ScalarTables {
-		zero: build_scalars(ZERO_ARITY, &prepared.zero.lambda_powers, &zero_h_ops, dense_shift_enc),
+		zero: build_scalars(ZERO_ARITY, &prepared.zero.lambda_powers, zero_h_eval, dense_shift_enc),
 		bitand: build_scalars(
 			BITAND_ARITY,
 			&prepared.bitand.lambda_powers,
-			&bitand_h_ops,
+			bitand_h_eval,
 			dense_shift_enc,
 		),
 		intmul: build_scalars(
 			INTMUL_ARITY,
 			&prepared.intmul.lambda_powers,
-			&intmul_h_ops,
+			intmul_h_eval,
 			dense_shift_enc,
 		),
 		binmul: build_scalars(
 			BINMUL_ARITY,
 			&prepared.binmul.lambda_powers,
-			&binmul_h_ops,
+			binmul_h_eval,
 			dense_shift_enc,
 		),
 	};
@@ -286,14 +307,20 @@ where
 mod tests {
 	use binius_compute::GlobalAllocator;
 	use binius_field::{AESTowerField8b, BinaryField128bGhash, PackedBinaryGhash2x128b, Random};
-	use binius_math::{inner_product::inner_product_buffers, multilinear::eq::eq_ind_partial_eval};
-	use binius_verifier::protocols::shift::evaluate_h_op;
+	use binius_math::{
+		inner_product::inner_product_buffers, multilinear::eq::eq_ind_partial_eval,
+		test_utils::random_scalars,
+	};
+	use binius_verifier::protocols::shift::{LOG_SHIFT_VARIANT_COUNT, evaluate_h_op};
 	use rand::{SeedableRng, rngs::StdRng};
 
 	use super::*;
 
-	/// Test consistency between direct multilinear evaluation of h
-	/// multilinears and the succinct `evaluate_h_op` implementation
+	/// The built h multilinear and the succinct `evaluate_h_op` must agree.
+	///
+	/// The variant axis is folded by the sumcheck now, so evaluating the whole multilinear at
+	/// `(r_j, r_s, r_v)` gives the interpolation of the eight succinct evaluations over `r_v` —
+	/// which is exactly the single scalar phase 2 weights its keys by.
 	#[test]
 	fn h_op_consistency() {
 		type F = BinaryField128bGhash;
@@ -306,22 +333,25 @@ mod tests {
 		for test_case in 0..num_random_tests {
 			let r_zhat_prime = F::random(&mut rng);
 
-			let r_j: Vec<F> = (0..6).map(|_| F::random(&mut rng)).collect();
-			let r_s: Vec<F> = (0..6).map(|_| F::random(&mut rng)).collect();
+			let r_j = random_scalars::<F>(&mut rng, Word::LOG_BITS);
+			let r_s = random_scalars::<F>(&mut rng, Word::LOG_BITS);
+			let r_v = random_scalars::<F>(&mut rng, LOG_SHIFT_VARIANT_COUNT);
 
-			// Method 1: Succinct evaluation using `evaluate_h_op`
+			// Method 1: the succinct per-variant evaluations, interpolated over the variant axis.
 			let subspace = BinarySubspace::<AESTowerField8b>::with_dim(Word::LOG_BITS).isomorphic();
 			let l_tilde = lagrange_evals(&subspace, r_zhat_prime);
 			let succinct_evaluations = evaluate_h_op(l_tilde.as_ref(), &r_j, &r_s);
+			let r_v_tensor = eq_ind_partial_eval::<F>(&r_v);
+			let succinct = inner_product(succinct_evaluations, r_v_tensor.as_ref().iter().copied());
 
-			// Method 2: Direct evaluation via multilinear part
-			let h_parts = build_h_parts(&GlobalAllocator, &subspace, r_zhat_prime);
-			let evaluation_point: Vec<F> = [r_j.clone(), r_s.clone()].concat();
+			// Method 2: evaluate the built multilinear at the whole point.
+			let h = build_h(&GlobalAllocator, &subspace, r_zhat_prime);
+			let evaluation_point = [r_j, r_s, r_v].concat();
 			let tensor = eq_ind_partial_eval::<P>(&evaluation_point);
-			let direct_evaluations = h_parts.map(|buf| inner_product_buffers(&buf, &tensor));
+			let direct = inner_product_buffers(&h, &tensor);
 
 			assert_eq!(
-				succinct_evaluations, direct_evaluations,
+				succinct, direct,
 				"H-op evaluation mismatch (test_case={test_case}): succinct != direct",
 			);
 		}

--- a/crates/prover/src/protocols/shift/phase_1.rs
+++ b/crates/prover/src/protocols/shift/phase_1.rs
@@ -1,22 +1,22 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-use std::{array, iter, ops::Range};
+use std::{iter, ops::Range};
 
 use binius_compute::Allocator;
 use binius_core::word::Word;
 use binius_field::{BinaryField, Field, PackedField};
-use binius_ip::sumcheck::{SumcheckOutput, common::RoundCoeffs};
+use binius_ip::sumcheck::SumcheckOutput;
 use binius_ip_prover::{
 	channel::IPProverChannel,
-	sumcheck::{bivariate_product_prover, common::SumcheckProver},
+	sumcheck::{ProveSingleOutput, bivariate_product_prover, prove_single},
 };
 use binius_math::{BinarySubspace, FieldBuffer, FieldVec, inner_product::inner_product_buffers};
 use binius_utils::rayon::{
 	prelude::*,
 	task_size::{IndexedParallelIteratorExt, WorkPerItem},
 };
-use binius_verifier::protocols::shift::SHIFT_VARIANT_COUNT;
+use binius_verifier::protocols::shift::LOG_SHIFT_VARIANT_COUNT;
 use bytemuck::zeroed_vec;
 use itertools::izip;
 use tracing::instrument;
@@ -25,15 +25,18 @@ use super::{
 	SegmentWords,
 	claims::PreparedOperatorClaims,
 	key_collection::{DenseShiftEncoding, KeyCollection, KeySegment},
-	monster::build_h_parts,
+	monster::build_h,
 };
 
-// This is the number of variables in the g (and h) multilinears of phase 1.
-const LOG_LEN: usize = Word::LOG_BITS + Word::LOG_BITS;
+/// The number of variables in the g (and h) multilinear of phase 1.
+///
+/// The axes run, from the low index positions up: the bit position within a word, the shift
+/// amount, and the shift variant.
+pub const PHASE_1_LOG_LEN: usize = Word::LOG_BITS + Word::LOG_BITS + LOG_SHIFT_VARIANT_COUNT;
 
-/// Constructs the "g" multilinear parts for the BITAND, INTMUL and BMUL operations.
 /// Proves the first phase of the shift reduction.
-/// Computes the g and h multilinears and performs the sumcheck.
+///
+/// Builds the g and h multilinears and runs one sumcheck over their product.
 #[instrument(skip_all, name = "prover_phase_1")]
 pub fn prove_phase_1<F, P, Channel, A>(
 	key_collection: &KeyCollection,
@@ -49,49 +52,32 @@ where
 	Channel: IPProverChannel<F>,
 	A: Allocator,
 {
-	// Build the g parts for the public and hidden segments separately, then sum them. The public
-	// words are the prefix of `words`, and each segment's key ranges are segment-relative.
-	let mut g_parts =
-		build_g_parts::<_, P, _>(alloc, words.public, &key_collection.public, prepared);
-	let hidden_g_parts =
-		build_g_parts::<_, P, _>(alloc, words.hidden, &key_collection.hidden, prepared);
-	for (g, hidden_g) in g_parts.iter_mut().zip(&hidden_g_parts) {
-		for (slot, add) in g.as_mut().iter_mut().zip(hidden_g.as_ref()) {
-			*slot += *add;
-		}
+	// Build the g multilinear for the public and hidden segments separately, then sum them. The
+	// public words are the prefix of `words`, and each segment's key ranges are segment-relative.
+	let mut g = build_g::<_, P, _>(alloc, words.public, &key_collection.public, prepared);
+	let hidden_g = build_g::<_, P, _>(alloc, words.hidden, &key_collection.hidden, prepared);
+	for (slot, add) in iter::zip(g.as_mut(), hidden_g.as_ref()) {
+		*slot += *add;
 	}
 
 	// BitAnd, IntMul and BinMul share the same `r_zhat_prime`.
-	let h_parts = build_h_parts(alloc, domain_subspace, prepared.bitand.r_zhat_prime);
+	let h = build_h(alloc, domain_subspace, prepared.bitand.r_zhat_prime);
 
-	run_phase_1_sumcheck(g_parts, h_parts, channel, alloc)
+	run_phase_1_sumcheck(g, h, channel, alloc)
 }
 
 /// Runs the phase 1 sumcheck protocol for shift constraint verification.
 ///
-/// Executes a sumcheck over bivariate products of g and h multilinear parts for each
-/// operation (BITAND, INTMUL). The protocol proves that the sum of g·h products across
-/// all shift variants equals the claimed batched evaluation.
+/// One bivariate-product sumcheck over `g` and `h`, both multilinears of [`PHASE_1_LOG_LEN`]
+/// variables. The shift variant is the high [`LOG_SHIFT_VARIANT_COUNT`] variables of each, so the
+/// sumcheck folds the variant axis rather than the prover summing a separate claim per variant.
 ///
-/// # Protocol Structure
-///
-/// For each operation, creates 3 bivariate product sumcheck provers (one per shift variant):
-/// - g_sll · h_sll with claim `sll_sum`
-/// - g_srl · h_srl with claim `srl_sum`
-/// - g_sra · h_sra with claim `sar_sum = total_sum - sll_sum - srl_sum`
-///
-/// The g parts incorporate batching randomness (lambda weighting), while h parts
-/// encode the shift operation behavior at the univariate challenge points.
-///
-/// # Parameters
-///
-/// - `g_parts`: g multilinear parts for each operation (witness-dependent)
-/// - `h_parts`: h multilinear parts for each operation (challenge-dependent)
-/// - `sums`: Expected total sums for each operation from lambda-weighted evaluation claims
+/// The `g` multilinear carries the witness and the batching randomness; `h` encodes what each
+/// shift does at the univariate challenge point.
 ///
 /// # Returns
 ///
-/// `SumcheckOutput` containing the challenge vector and final evaluation `gamma`
+/// `SumcheckOutput` containing the challenge vector and the final evaluation `gamma`.
 #[instrument(skip_all, name = "run_sumcheck")]
 pub fn run_phase_1_sumcheck<
 	F: Field,
@@ -99,69 +85,31 @@ pub fn run_phase_1_sumcheck<
 	Channel: IPProverChannel<F>,
 	A: Allocator,
 >(
-	g_parts: [FieldVec<P, A>; SHIFT_VARIANT_COUNT],
-	h_parts: [FieldVec<P, A>; SHIFT_VARIANT_COUNT],
+	g: FieldVec<P, A>,
+	h: FieldVec<P, A>,
 	channel: &mut Channel,
 	alloc: &A,
 ) -> SumcheckOutput<F> {
-	// Build one shared bivariate-product prover per shift variant.
-	let mut provers = iter::zip(g_parts, h_parts)
-		.map(|(g_part, h_part)| {
-			let sum = inner_product_buffers(&g_part, &h_part);
-			bivariate_product_prover(alloc, [g_part, h_part], sum)
-		})
-		.collect::<Vec<_>>();
+	let sum = inner_product_buffers(&g, &h);
+	let prover = bivariate_product_prover(alloc, [g, h], sum);
 
-	// Perform the sumcheck rounds, collecting challenges.
-	let n_vars = 2 * Word::LOG_BITS;
-	let mut challenges = Vec::with_capacity(n_vars);
-	for _ in 0..n_vars {
-		let mut all_round_coeffs = Vec::new();
-		for prover in &mut provers {
-			all_round_coeffs.extend(prover.execute());
-		}
-
-		let summed_round_coeffs = all_round_coeffs
-			.into_iter()
-			.rfold(RoundCoeffs::default(), |acc, coeffs| acc + &coeffs);
-
-		let round_proof = summed_round_coeffs.truncate();
-
-		channel.send_many(round_proof.coeffs());
-
-		let challenge = channel.sample();
-		challenges.push(challenge);
-
-		for prover in &mut provers {
-			prover.fold(challenge);
-		}
-	}
+	let ProveSingleOutput {
+		multilinear_evals,
+		mut challenges,
+	} = prove_single(prover, channel);
 	challenges.reverse();
 
-	let multilinear_evals = provers
-		.into_iter()
-		.map(|prover| prover.finish())
-		.collect::<Vec<Vec<F>>>();
-
-	// Evaluate the composition polynomial to compute `gamma`.
-	let gamma = multilinear_evals
-		.into_iter()
-		.map(|prover_evals| {
-			assert_eq!(prover_evals.len(), 2);
-			let h_eval = prover_evals[0];
-			let g_eval = prover_evals[1];
-			h_eval * g_eval
-		})
-		.sum();
+	let [g_eval, h_eval] = multilinear_evals
+		.try_into()
+		.expect("prover has 2 multilinear polynomials");
 
 	SumcheckOutput {
 		challenges,
-		eval: gamma,
+		eval: g_eval * h_eval,
 	}
 }
 
-/// Constructs the "g" multilinear parts for the BITAND, INTMUL and BMUL operations, for one key
-/// segment.
+/// Constructs the phase-1 "g" multilinear for one key segment.
 ///
 /// This builds the g multilinear polynomials used in phase 1 of the shift protocol, over the words
 /// of a single value-vector segment (public or hidden). It constructs one multilinear polynomial
@@ -184,20 +132,21 @@ pub fn run_phase_1_sumcheck<
 ///
 /// # Returns
 ///
-/// An array of multilinear extensions of each shift variant part. Within a part, the rows of
-/// `Word::BITS` scalars run in order of shift amount.
+/// One multilinear of [`PHASE_1_LOG_LEN`] variables holding every shift variant's part: the
+/// variant indexes the high [`LOG_SHIFT_VARIANT_COUNT`] variables, and within a variant the rows
+/// of `Word::BITS` scalars run in order of shift amount.
 ///
 /// # Usage
 ///
 /// Used in phase 1 to construct the constant size g multilinears
 /// that will participate in the phase 1 sumcheck protocol.
-#[instrument(skip_all, name = "build_g_parts")]
-pub fn build_g_parts<F: BinaryField, P: PackedField<Scalar = F>, A: Allocator>(
+#[instrument(skip_all, name = "build_g")]
+pub fn build_g<F: BinaryField, P: PackedField<Scalar = F>, A: Allocator>(
 	alloc: &A,
 	words: &[Word],
 	segment: &KeySegment,
 	prepared: &PreparedOperatorClaims<F>,
-) -> [FieldVec<P, A>; SHIFT_VARIANT_COUNT] {
+) -> FieldVec<P, A> {
 	// One row of `Word::BITS` scalars per shift the segment uses.
 	let row_len = Word::BITS >> P::LOG_WIDTH;
 	let acc_size = segment.dense_shift_enc.len() * row_len;
@@ -294,22 +243,20 @@ pub fn build_g_parts<F: BinaryField, P: PackedField<Scalar = F>, A: Allocator>(
 		// An empty word list yields no partials at all, and its parts are zero.
 		.unwrap_or_else(|| zeroed_vec::<P>(acc_size).into_boxed_slice());
 
-	scatter_multilinear_parts(alloc, &multilinears, &segment.dense_shift_enc)
+	scatter_shift_rows(alloc, &multilinears, &segment.dense_shift_enc)
 }
 
-/// Spreads the rows of a dense phase-1 accumulator over the multilinear parts of every shift
-/// variant.
+/// Spreads the rows of a dense phase-1 accumulator over the shift axes of the g multilinear.
 ///
 /// The accumulator holds the rows of `Word::BITS` scalars the segment's keys accumulate into, one
-/// per shift the segment uses and in dense shift index order. Each row lands in the part of its
-/// shift variant, at the offset its shift amount names; every row the segment does not use stays
-/// zero.
-#[instrument(skip_all, name = "scatter_multilinear_parts")]
-fn scatter_multilinear_parts<P: PackedField, A: Allocator>(
+/// per shift the segment uses and in dense shift index order. Each row lands at the offset its
+/// `(variant, amount)` pair names; every row the segment does not use stays zero.
+#[instrument(skip_all, name = "scatter_shift_rows")]
+fn scatter_shift_rows<P: PackedField, A: Allocator>(
 	alloc: &A,
 	multilinears: &[P],
 	dense_shift_enc: &DenseShiftEncoding,
-) -> [FieldVec<P, A>; SHIFT_VARIANT_COUNT] {
+) -> FieldVec<P, A> {
 	const {
 		assert!(
 			P::LOG_WIDTH <= Word::LOG_BITS,
@@ -317,16 +264,15 @@ fn scatter_multilinear_parts<P: PackedField, A: Allocator>(
 		);
 	}
 
-	// A row is a whole number of packed elements, so it copies into a part at row alignment.
+	// A row is a whole number of packed elements, so it copies in at row alignment.
 	let row_len = Word::BITS >> P::LOG_WIDTH;
-	let mut parts =
-		array::from_fn::<_, SHIFT_VARIANT_COUNT, _>(|_| FieldBuffer::zeros_in(alloc, LOG_LEN));
+	let mut g = FieldBuffer::zeros_in(alloc, PHASE_1_LOG_LEN);
 	for ((variant, amount), row) in iter::zip(dense_shift_enc.iter(), multilinears.chunks(row_len))
 	{
-		// Dense indices are distinct, so no two rows land in the same place and each destination
-		// is still zero.
-		parts[variant as usize].as_mut()[amount as usize * row_len..][..row_len]
-			.copy_from_slice(row);
+		// The variant indexes the high variables and the amount the middle ones. Dense indices are
+		// distinct, so no two rows land in the same place and each destination is still zero.
+		let offset = (variant as usize * Word::BITS + amount as usize) * row_len;
+		g.as_mut()[offset..][..row_len].copy_from_slice(row);
 	}
-	parts
+	g
 }

--- a/crates/prover/src/protocols/shift/phase_2.rs
+++ b/crates/prover/src/protocols/shift/phase_2.rs
@@ -73,14 +73,13 @@ where
 	A: Allocator,
 {
 	let SumcheckOutput {
-		challenges: mut r_jr_s,
+		challenges: mut r_j,
 		eval: gamma,
 	} = phase_1_output;
-	// Split challenges as r_j,r_s where r_j is the first Word::LOG_BITS
-	// variables and r_s is the last Word::LOG_BITS variables
-	// Thus r_s are the more significant variables.
-	let r_s = r_jr_s.split_off(Word::LOG_BITS);
-	let r_j = r_jr_s;
+	// Split the challenges as `r_j, r_s, r_v`: the bit position, then the shift amount, then the
+	// shift variant, in increasing order of significance.
+	let r_v = r_j.split_off(Word::LOG_BITS * 2);
+	let r_s = r_j.split_off(Word::LOG_BITS);
 
 	let r_j_tensor = eq_ind_partial_eval::<F>(&r_j);
 
@@ -91,7 +90,7 @@ where
 	let hidden_folded = fold_words::<_, P, _>(alloc, words.hidden, r_j_tensor.as_ref());
 
 	let (public_monster, hidden_monster) =
-		build_monster_segments(alloc, key_collection, prepared, domain_subspace, &r_j, &r_s);
+		build_monster_segments(alloc, key_collection, prepared, domain_subspace, &r_j, &r_s, &r_v);
 
 	run_sumcheck(
 		&public_folded,

--- a/crates/verifier/src/protocols/shift/mod.rs
+++ b/crates/verifier/src/protocols/shift/mod.rs
@@ -1,7 +1,12 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-pub const SHIFT_VARIANT_COUNT: usize = 8;
+/// The base-2 logarithm of [`SHIFT_VARIANT_COUNT`].
+///
+/// Phase 1 folds the shift variant with this many sumcheck variables, in the high index
+/// positions of its two multilinears.
+pub const LOG_SHIFT_VARIANT_COUNT: usize = 3;
+pub const SHIFT_VARIANT_COUNT: usize = 1 << LOG_SHIFT_VARIANT_COUNT;
 pub const ZERO_ARITY: usize = 1;
 pub const BITAND_ARITY: usize = 3;
 pub const INTMUL_ARITY: usize = 4;

--- a/crates/verifier/src/protocols/shift/verify.rs
+++ b/crates/verifier/src/protocols/shift/verify.rs
@@ -11,6 +11,7 @@ use binius_ip::{
 };
 use binius_math::{
 	BinarySubspace,
+	inner_product::inner_product_scalars,
 	line::extrapolate_line,
 	multilinear::eq::{
 		eq_ind_partial_eval_scalars, eq_ind_zero, eq_one_var, scaled_eq_ind_partial_eval_scalars,
@@ -20,8 +21,8 @@ use binius_math::{
 use getset::Getters;
 
 use super::{
-	BINMUL_ARITY, BITAND_ARITY, INTMUL_ARITY, OperationEvalFn, SHIFT_VARIANT_COUNT, ZERO_ARITY,
-	encode_operation_input, error::Error, evaluate_h_op,
+	BINMUL_ARITY, BITAND_ARITY, INTMUL_ARITY, LOG_SHIFT_VARIANT_COUNT, OperationEvalFn,
+	SHIFT_VARIANT_COUNT, ZERO_ARITY, encode_operation_input, error::Error, evaluate_h_op,
 };
 
 /// Evaluates the bit-level multilinear extension of a word slice at the point `r_j ++ r_y`.
@@ -105,8 +106,10 @@ pub struct VerifyOutput<F> {
 	binmul_lambda: F,
 	/// Challenge point for the bit index variables (length `Word::LOG_BITS`).
 	pub r_j: Vec<F>,
-	/// Challenge point for the shift variables (length `Word::LOG_BITS`).
+	/// Challenge point for the shift-amount variables (length `Word::LOG_BITS`).
 	pub r_s: Vec<F>,
+	/// Challenge point for the shift-variant variables (length `LOG_SHIFT_VARIANT_COUNT`).
+	pub r_v: Vec<F>,
 	/// Challenge point for the word index variables (length `log_witness_words`).
 	pub r_y: Vec<F>,
 	/// Challenge for the witness's segment selector variable.
@@ -150,7 +153,7 @@ impl<F> VerifyOutput<F> {
 /// 1. **Sampling Phase**: Samples random lambda coefficients for batching bitand, intmul and binmul
 ///    evaluation claims across operands.
 /// 2. **First Sumcheck**: Verifies the batched evaluation claim over `Word::LOG_BITS * 2` variables
-/// 3. **Challenge Splitting**: Splits sumcheck challenges into `r_j` and `r_s` components
+/// 3. **Challenge Splitting**: Splits sumcheck challenges into `r_j`, `r_s` and `r_v` components
 /// 4. **Second Sumcheck**: Verifies the gamma claim over `log_word_count` variables
 /// 5. **Monster Multilinear Verification**: Checks that the claimed evaluations match expected
 ///    monster multilinear evaluations for AND constraints (bitand), IMUL constraints (intmul) and
@@ -195,15 +198,14 @@ where
 
 	let SumcheckOutput {
 		eval: gamma,
-		challenges: mut r_jr_s,
-	} = verify_sumcheck(Word::LOG_BITS * 2, 2, eval, channel)?;
+		challenges: mut r_j,
+	} = verify_sumcheck(Word::LOG_BITS * 2 + LOG_SHIFT_VARIANT_COUNT, 2, eval, channel)?;
 
-	r_jr_s.reverse();
-	// Split challenges as `r_j,r_s` where `r_j` is the first `Word::LOG_BITS`
-	// variables and `r_s` is the last `Word::LOG_BITS` variables
-	// Thus `r_s` are the more significant variables.
-	let r_s = r_jr_s.split_off(Word::LOG_BITS);
-	let r_j = r_jr_s;
+	r_j.reverse();
+	// Split the challenges as `r_j, r_s, r_v`: the bit position within a word, then the shift
+	// amount, then the shift variant, in increasing order of significance.
+	let r_v = r_j.split_off(Word::LOG_BITS * 2);
+	let r_s = r_j.split_off(Word::LOG_BITS);
 
 	// The second sumcheck runs over the witness: the public segment in the low half-cube and
 	// the hidden segment in the high half-cube, selected by the top word-index variable. This
@@ -229,6 +231,7 @@ where
 		r_y,
 		r_segment,
 		r_s,
+		r_v,
 		eval,
 		witness_eval,
 	})
@@ -287,6 +290,7 @@ where
 		eval,
 		r_j,
 		r_s,
+		r_v,
 		r_y,
 		r_segment,
 		witness_eval,
@@ -305,6 +309,7 @@ where
 		let binmul_r_x_prime_len = binmul_data.r_x_prime.len();
 		let r_j_len = r_j.len();
 		let r_s_len = r_s.len();
+		let r_v_len = r_v.len();
 		let r_y_len = r_y.len();
 
 		let inputs: Vec<C::Elem> = iter::once(r_zhat_prime)
@@ -318,6 +323,7 @@ where
 			.chain(binmul_data.r_x_prime.iter().cloned())
 			.chain(r_j.iter().cloned())
 			.chain(r_s.iter().cloned())
+			.chain(r_v.iter().cloned())
 			.chain(r_y.iter().cloned())
 			.chain(iter::once(r_segment.clone()))
 			.collect();
@@ -331,6 +337,7 @@ where
 			binmul_r_x_prime_len,
 			r_j_len,
 			r_s_len,
+			r_v_len,
 			r_y_len,
 		};
 		channel.compute_public_value(&inputs, eval_fn)
@@ -384,7 +391,7 @@ impl<F: BinaryField> FieldFn<F> for PublicWordsEvalFn<'_> {
 /// The inputs are the flat concatenation of these sections, in order:
 ///
 /// ```text
-/// r_zhat_prime | zero_lambda | bitand_lambda | intmul_lambda | binmul_lambda | zero_r_x_prime.. | bitand_r_x_prime.. | intmul_r_x_prime.. | binmul_r_x_prime.. | r_j.. | r_s.. | r_y..
+/// r_zhat_prime | zero_lambda | bitand_lambda | intmul_lambda | binmul_lambda | zero_r_x_prime.. | bitand_r_x_prime.. | intmul_r_x_prime.. | binmul_r_x_prime.. | r_j.. | r_s.. | r_v.. | r_y..
 /// ```
 ///
 /// The stored lengths recover each variable-length section from that flat slice.
@@ -405,6 +412,8 @@ struct MonsterEvalFn<'a, F: BinaryField> {
 	r_j_len: usize,
 	/// Length of the `r_s` section (the shift-amount challenges).
 	r_s_len: usize,
+	/// Length of the `r_v` section (the shift-variant challenges).
+	r_v_len: usize,
 	/// Length of the `r_y` section (the column challenges).
 	r_y_len: usize,
 }
@@ -473,6 +482,8 @@ impl<F: BinaryField> MonsterEvalFn<'_, F> {
 		off += self.r_j_len;
 		let r_s_v = &vals[off..off + self.r_s_len];
 		off += self.r_s_len;
+		let r_v_v = &vals[off..off + self.r_v_len];
+		off += self.r_v_len;
 		let r_y_v = &vals[off..off + self.r_y_len];
 		off += self.r_y_len;
 		// `r_segment` is the top word-index coordinate, appended after `r_y`; it selects the public
@@ -511,13 +522,19 @@ impl<F: BinaryField> MonsterEvalFn<'_, F> {
 		let l_tilde = lagrange_evals_scalars(self.subspace, &r_zhat_prime_v);
 		let h_op_evals = evaluate_h_op(&l_tilde, r_j_v, r_s_v);
 
-		// Tensor the shift-selector evaluations with the shift-amount equality indicator once, so
-		// the BitAnd, IntMul and BinMul monster evaluations share it. Indexed by
-		// `variant * Word::BITS + amount`.
+		// Phase 1 folded the shift variant into its sumcheck, so the h multilinear contributes a
+		// single evaluation here: the multilinear interpolation of the eight shift indicators over
+		// the variant axis.
+		let eq_r_v = eq_ind_partial_eval_scalars(r_v_v);
+		let h_eval = inner_product_scalars(h_op_evals, eq_r_v.iter().cloned());
+
+		// A key's shift now selects itself through a pure equality indicator over both shift axes,
+		// scaled by that one h evaluation. Built once, so the Zero, BitAnd, IntMul and BinMul
+		// monster evaluations share it. Indexed by `variant * Word::BITS + amount`.
 		let eq_r_s = eq_ind_partial_eval_scalars(r_s_v);
 		let shift_scalars =
 			Box::new(array::from_fn::<_, { SHIFT_VARIANT_COUNT * Word::BITS }, _>(|i| {
-				h_op_evals[i / Word::BITS].clone() * &eq_r_s[i % Word::BITS]
+				h_eval.clone() * &eq_r_v[i / Word::BITS] * &eq_r_s[i % Word::BITS]
 			}));
 
 		// Re-encode the shared tensors with each operation's `r_x'` and `lambda`. IntMul and BinMul


### PR DESCRIPTION
Closes [BINIUS-413](https://linear.app/jimpo/issue/BINIUS-413/run-the-shift-reduction-phase-1-sumcheck-as-one-15-variate-sumcheck), groundwork for [BINIUS-408](https://linear.app/jimpo/issue/BINIUS-408/double-shifted-value-indices).

Phase 1 ran as a summed batch of eight 12-variate sumchecks, one per shift variant: each round executed all eight provers, summed their round coefficients, and folded them with a shared challenge. Run it instead as a single **15-variate** sumcheck, with the shift variant as three more variables in the high index positions and `g`/`h` the multilinear interpolations over them.

The claimed sum is unchanged — summing `G · H` over the 15-cube is `Σ_v Σ_{j,s} g_v(j,s) h_v(j,s)`, exactly the total the eight sumchecks claimed. What changes is that the variant axis is folded by the sumcheck instead of summed eagerly, so the final evaluation is one product at a random `r_v`.

## What it buys

Beyond deleting the per-round `RoundCoeffs` batching (`run_phase_1_sumcheck` is now `bivariate_product_prover` + `prove_single`), the variant axis collapsing makes the downstream weights simpler:

- The verifier computes **one** `h` evaluation — the interpolation of the eight shift indicators over `r_v` — instead of an array of eight.
- The per-key shift scalar becomes a pure eq-tensor product, `h_eval · eq(r_v, variant) · eq(r_s, amount)`, on both sides.

That last point is the reason this is the right groundwork: under double shifts the variant axis becomes 6 bits and the amount axis 12, so a single flat sumcheck generalizes by widening axes. A batch of per-variant provers would have had to grow to 64, and the `SHIFT_VARIANT_COUNT * Word::BITS` scalar table would have gone quadratic.

## Notes for review

- **`build_h` lost its eight per-variant closures.** They collapsed into one `fill_h_row(variant, amount, row, l_tilde)` with `sll`/`srl`/`sar`/`rotr` helpers and a `halves` closure that covers all four `*32` forms — the same "one place that says what a variant does" shape `ShiftVariant::dispatch` already uses, instead of four near-duplicate half-word closures.
- **Renamed `build_g_parts` → `build_g`, `build_h_parts` → `build_h`, `build_g_parts_from_folded_words` → `build_g_from_folded_words`, `scatter_multilinear_parts` → `scatter_shift_rows`.** They each return one multilinear now, so "parts" was actively misleading. Tracing span names moved with them.
- **`h_op_consistency` was rewritten rather than dropped.** It now asserts that the built multilinear evaluated at `(r_j, r_s, r_v)` equals the interpolation of the eight succinct `evaluate_h_op` values over `r_v` — which is exactly the scalar phase 2 weights its keys by, so it pins the new contract.
- **`build_monster_segments` still computes one `h` evaluation per operation**, from that operation's own `r_zhat_prime`, even though the verifier uses a single one. That redundancy is pre-existing (the four are equal in practice); I kept the shape rather than fold it into this change.
- `evaluate_h_op` is untouched — it is still the right primitive; the interpolation happens at its call sites.

## Verification

`cargo check --workspace --all-targets` clean; clippy clean over prover/verifier/m4-prover/m4-verifier with `--all-targets -- -D warnings`; fmt applied. Tests: prover lib 37, prover `prove_verify` 13 (including the sha256 preimage and both zk round trips), m4-prover 43 + 5 integration, verifier 13, m4-verifier 3. Left the rest to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
