### PR TITLE
BINIUS-418: commit one logUp* pushforward oracle per table

### DIFF
--- a/crates/iop-prover/src/logup_star.rs
+++ b/crates/iop-prover/src/logup_star.rs
@@ -1,135 +1,137 @@
 // Copyright 2026 The Binius Developers
 
-//! logUp* proving with the pushforward committed as an oracle.
+//! logUp* proving with the pushforwards committed as oracles.
 //!
-//! The bare reduction returns a claimed evaluation of the pushforward `Y = I_* eq_r`.
-//! It commits nothing, so that claim cannot be checked on its own.
-//! This layer commits `Y` over the IOP channel and returns the relation that opens it.
+//! The bare reduction returns a claimed evaluation of each table's pushforward `Y = I_* eq_r`.
+//! It commits nothing, so those claims cannot be checked on their own.
+//! This layer commits one `Y` per table over the IOP channel and returns the relations that open
+//! them.
 //!
-//! The commit precedes the reduction, so the logUp challenge binds the committed `Y`.
-//! The table `T` and index `I` stay the caller's oracles, so their claims are returned unchanged.
-//! `Y` is the only oracle this protocol introduces, per [Soukhanov25, Section 3].
+//! The commits precede the reduction, so its logUp challenges bind the committed oracles.
+//! The tables `T` and indexes `I` stay the caller's oracles, so their claims are returned
+//! unchanged. The pushforwards are the only oracles this protocol introduces, per
+//! [Soukhanov25, Section 3].
 //!
 //! [Soukhanov25]: <https://eprint.iacr.org/2025/946>
 
 use binius_compute::Allocator;
 use binius_field::{BinaryField, Divisible, PackedField};
-pub use binius_ip_prover::logup_star::Looker;
-use binius_ip_prover::logup_star::{self as reduction, witness};
-use binius_math::{FieldSlice, multilinear::eq::eq_ind_partial_eval_in};
+use binius_ip_prover::logup_star::{self as reduction, LogupTableOutput, witness};
+pub use binius_ip_prover::logup_star::{Looker, TableLookup};
+use binius_math::{FieldBuffer, multilinear::eq::eq_ind_partial_eval_in};
+use itertools::izip;
 
 use crate::channel::IOPProverChannel;
 
 /// The reduced claims of a committed logUp* proof.
 ///
 /// The table and index claims are left for the caller to open against its own commitments.
-/// The pushforward claim is opened against the commitment sent here, through the channel.
+/// The pushforward claims are opened against the commitments sent here, through the channel.
 pub struct LogupProof<F> {
-	/// The `m`-coordinate point shared by the table and pushforward claims.
+	/// The point the table claims are drawn from, spanning the widest table.
+	///
+	/// A table over `m` variables is claimed at its **first `m`** coordinates.
 	pub table_eval_point: Vec<F>,
-	/// The claimed evaluation of the table `T` at the point.
-	pub table_eval_claim: F,
-	/// The `n`-coordinate point shared by the index claims.
+	/// The point the index claims are drawn from, spanning the deepest looker.
+	///
+	/// A looker over `n` variables is claimed at its **last `n`** coordinates.
 	pub index_eval_point: Vec<F>,
-	/// The claimed evaluations of the per-looker embedded index columns at the point.
-	pub index_eval_claims: Vec<F>,
+	/// One entry per table, in the order the tables were given.
+	pub tables: Vec<LogupTableOutput<F>>,
 }
 
-/// Prove a logUp* reduction whose pushforward is committed as an oracle.
+/// Prove a logUp* reduction whose pushforwards are committed as oracles.
 ///
-/// This wraps [`binius_ip_prover::logup_star::prove`] with the pushforward commitment.
-/// It builds the pushforward `Y` once, commits it, then runs the reduction over that same buffer.
-/// Committing before the reduction binds `Y` into the logUp challenge.
+/// This wraps [`binius_ip_prover::logup_star::prove_reduction`] with the pushforward commitments.
+/// It builds each table's pushforward `Y` once, commits it, then runs the reduction over those same
+/// buffers. Committing before the reduction binds every `Y` into the logUp challenges.
 ///
-/// The relation `<Y, eq_r'> = Y(r')` at the reduced table point `r'` is opened through the
-/// channel, which may defer the actual opening to `finish()`.
+/// The relations `<Y, eq_r> = Y(r)` at each table's reduced point are opened through the channel,
+/// which may defer the actual openings to `finish()`.
+///
+/// One oracle per table is the simple arrangement; the pushforwards could instead be concatenated
+/// into a single oracle, which is left for later.
 ///
 /// # Arguments
 ///
-/// * `table` - The table multilinear `T` over `m` variables (`2^m` entries).
-/// * `lookers` - The looker columns and claims; every evaluation point must have the same length
-///   `n` and every index column `2^n` entries.
-/// * `channel` - The IOP prover channel, whose next oracle has message length `2^m`.
+/// * `tables` - One [`binius_ip_prover::logup_star::TableLookup`] per table, by value: its
+///   multilinear and the lookers that read it.
+/// * `channel` - The IOP prover channel, whose next `tables.len()` oracles have message lengths
+///   `2^m` in table order.
+/// * `alloc` - The allocator the witnesses are drawn from.
 ///
 /// # Preconditions
 ///
-/// - The table has at least one variable.
-/// - Every index entry is less than `2^m`.
-#[tracing::instrument(
-	skip_all,
-	level = "debug",
-	name = "logup* (committed)",
-	fields(n_lookers = lookers.len(), table_n_vars = table.log_len())
-)]
-pub fn prove<F, P, Channel, A>(
-	table: FieldSlice<P>,
-	lookers: &[Looker<'_, F>],
+/// - `tables` is non-empty, each has at least one variable, and each has at least one looker.
+/// - Every index entry is less than the size of the table its looker reads.
+#[tracing::instrument(skip_all, level = "debug", name = "logup* (committed)")]
+pub fn prove<'a, F, P, Channel, A>(
+	tables: impl IntoIterator<Item = reduction::TableLookup<'a, P>>,
 	channel: &mut Channel,
 	alloc: &A,
 ) -> LogupProof<F>
 where
 	F: BinaryField<Underlier: Divisible<u64>>,
-	P: PackedField<Scalar = F>,
+	P: PackedField<Scalar = F> + 'a,
 	Channel: IOPProverChannel<P, A>,
 	A: Allocator,
 {
-	// Sample the looker batching challenge, then build the witnesses that do not depend on the
-	// logUp challenge c.
+	// The tables are walked several times — to build the witnesses, to run the reduction, and to
+	// open the commitments — so the iterator is materialized once here.
+	let tables = tables.into_iter().collect::<Vec<_>>();
+
+	// Sample the looker batching challenge before the commitments: the prover needs gamma to build
+	// the pushforwards it commits.
 	//
-	//     gamma^i * eq_{r_i} = the per-looker scaled numerators
-	//     Y = sum_i gamma^i * (I_i)_* eq_{r_i}     the combined pushforward
-	//
-	// The reduction takes a list of tables; this layer commits one pushforward, so it runs it over
-	// the one table.
+	//     gamma^i * eq_{r_i} = a table's scaled numerators
+	//     Y = the scatter of that table's numerators
 	let gamma = channel.sample();
-	let tables = [reduction::TableLookup {
-		table,
-		lookers: lookers.to_vec(),
-	}];
 	let (numerators, pushforwards) = witness::combined_lookers::<A, F, P>(alloc, gamma, &tables);
-	let [pushforward]: [_; 1] = pushforwards
-		.try_into()
-		.unwrap_or_else(|_| unreachable!("this layer runs the reduction over one table"));
 
-	// Commit Y before the reduction, so the logUp challenge binds the commitment.
-	let oracle = tracing::debug_span!("Commit pushforward")
-		.in_scope(|| channel.send_oracle(pushforward.to_ref()));
+	// Commit every Y before the reduction, so the logUp challenges bind the commitments.
+	let oracles = tracing::debug_span!("Commit pushforwards").in_scope(|| {
+		pushforwards
+			.iter()
+			.map(|pushforward| channel.send_oracle(pushforward.to_ref()))
+			.collect::<Vec<_>>()
+	});
 
-	// Run the reduction over the committed Y and the numerators, viewing the channel as IP.
-	let output = reduction::prove_reduction(
-		alloc,
-		gamma,
-		&tables,
-		numerators,
-		&[pushforward.to_ref()],
-		channel,
-	);
-	let [table_output] = <[_; 1]>::try_from(output.tables)
-		.unwrap_or_else(|_| unreachable!("this layer runs the reduction over one table"));
+	// Run the reduction over the committed pushforwards and the numerators, viewing the channel as
+	// IP.
+	let pushforward_slices = pushforwards
+		.iter()
+		.map(FieldBuffer::to_ref)
+		.collect::<Vec<_>>();
+	let output =
+		reduction::prove_reduction(alloc, gamma, &tables, numerators, &pushforward_slices, channel);
 
-	// Open the pushforward relation through the channel; a deferring channel (e.g. BaseFold)
-	// batches it with every other queued relation in `finish()`.
+	// Open each pushforward relation through the channel; a deferring channel (e.g. BaseFold)
+	// batches them with every other queued relation in `finish()`.
 	//
-	//     <Y, eq_r'> = Y(r') = pushforward_eval_claim
-	let _open_guard = tracing::debug_span!("Open pushforward relation").entered();
-	let transparent = eq_ind_partial_eval_in::<A, P>(alloc, &output.table_eval_point);
-	channel.prove_oracle_relations([(
-		oracle,
-		pushforward,
-		transparent,
-		table_output.pushforward_claim,
-	)]);
+	//     <Y, eq_r> = Y(r) = that table's pushforward claim
+	//
+	// A table's own point is the first m coordinates of the shared reduced point.
+	let _open_guard = tracing::debug_span!("Open pushforward relations").entered();
+	let relations = izip!(oracles, pushforwards, &tables, &output.tables)
+		.map(|(oracle, pushforward, table, table_output)| {
+			let m = table.table.log_len();
+			let transparent = eq_ind_partial_eval_in::<A, P>(alloc, &output.table_eval_point[..m]);
+			(oracle, pushforward, transparent, table_output.pushforward_claim)
+		})
+		.collect::<Vec<_>>();
+	channel.prove_oracle_relations(relations);
 
 	LogupProof {
 		table_eval_point: output.table_eval_point,
-		table_eval_claim: table_output.eval_claim,
 		index_eval_point: output.index_eval_point,
-		index_eval_claims: table_output.index_eval_claims,
+		tables: output.tables,
 	}
 }
 
 #[cfg(test)]
 mod tests {
+	use std::iter;
+
 	use binius_compute::GlobalAllocator;
 	use binius_field::{
 		BinaryField1b, ExtensionField, Field,
@@ -165,17 +167,30 @@ mod tests {
 			.fold(E::ZERO, |acc, b| acc + b)
 	}
 
-	// Build a random instance and return (table, index, eval_point, eq_r scalars, true eval claim).
-	fn random_instance<E, Q>(
+	/// One looker of a test instance: its column and its honest claim against its table.
+	struct TestLooker<E> {
+		index: Vec<usize>,
+		eval_point: Vec<E>,
+		eval_claim: E,
+	}
+
+	/// One table of a test instance: its values and the lookers that read it.
+	struct TestTable<E, Q: PackedField> {
+		values: FieldBuffer<Q>,
+		lookers: Vec<TestLooker<E>>,
+	}
+
+	// Draw a looker over `n` variables reading `table_values`, with its honest claim.
+	fn random_looker<E, Q>(
 		rng: &mut StdRng,
 		n: usize,
-		m: usize,
-	) -> (FieldBuffer<Q>, Vec<usize>, Vec<E>, Vec<E>, E)
+		table_values: &FieldBuffer<Q>,
+	) -> TestLooker<E>
 	where
 		E: Field,
 		Q: PackedField<Scalar = E>,
 	{
-		let table = random_field_buffer::<Q>(&mut *rng, m);
+		let m = table_values.log_len();
 		let index = (0..(1usize << n))
 			.map(|_| rng.random_range(0..(1usize << m)))
 			.collect::<Vec<_>>();
@@ -186,179 +201,218 @@ mod tests {
 		let eval_claim = index
 			.iter()
 			.zip(&eq_r)
-			.map(|(&j, &eq)| eq * table.get(j))
+			.map(|(&j, &eq)| eq * table_values.get(j))
 			.fold(E::ZERO, |acc, t| acc + t);
 
-		(table, index, eval_point, eq_r, eval_claim)
+		TestLooker {
+			index,
+			eval_point,
+			eval_claim,
+		}
 	}
 
-	fn check_prove_verify(n: usize, m: usize, seed: u64) {
+	// Build the instance named by `spec`: one entry per table, giving its variable count and the
+	// variable counts of the lookers that read it.
+	fn random_instance<E, Q>(spec: &[(usize, Vec<usize>)], seed: u64) -> Vec<TestTable<E, Q>>
+	where
+		E: Field,
+		Q: PackedField<Scalar = E>,
+	{
 		let mut rng = StdRng::seed_from_u64(seed);
-		let (table, index, eval_point, eq_r, eval_claim) = random_instance::<F, P>(&mut rng, n, m);
+		spec.iter()
+			.map(|(m, looker_n_vars)| {
+				let values = random_field_buffer::<Q>(&mut rng, *m);
+				let lookers = looker_n_vars
+					.iter()
+					.map(|&n| random_looker::<E, Q>(&mut rng, n, &values))
+					.collect::<Vec<_>>();
+				TestTable { values, lookers }
+			})
+			.collect()
+	}
 
-		// The one oracle is the pushforward Y, of message length 2^m.
-		let specs = vec![OracleSpec::new(m)];
+	// Assert both sides agree and that every reduced claim is the honest evaluation. The
+	// pushforward claims are bound by the channel's own opening, so they need no assertion here.
+	fn check_proofs<Q>(
+		prover_proof: &LogupProof<F>,
+		verifier_proof: &verify_logup::LogupProof<F>,
+		tables: &[TestTable<F, Q>],
+		shape: &str,
+	) where
+		Q: PackedField<Scalar = F>,
+	{
+		assert_eq!(
+			prover_proof.table_eval_point, verifier_proof.table_eval_point,
+			"table point ({shape})"
+		);
+		assert_eq!(
+			prover_proof.index_eval_point, verifier_proof.index_eval_point,
+			"index point ({shape})"
+		);
+		assert_eq!(prover_proof.tables, verifier_proof.tables, "per-table claims ({shape})");
 
-		// Prove: commit Y, run the reduction, then open Y as the caller would.
+		// A table's claim is at the first m coordinates of the shared table point; its lookers'
+		// claims are at their own suffixes of the shared index point.
+		let table_point = &prover_proof.table_eval_point;
+		let index_point = &prover_proof.index_eval_point;
+		for (table_index, table) in tables.iter().enumerate() {
+			let m = table.values.log_len();
+			assert_eq!(
+				prover_proof.tables[table_index].eval_claim,
+				evaluate(&table.values, &table_point[..m]),
+				"table claim wrong for table {table_index} ({shape})"
+			);
+
+			let claims = &prover_proof.tables[table_index].index_eval_claims;
+			assert_eq!(claims.len(), table.lookers.len(), "claim count ({shape})");
+			for (looker, claim) in iter::zip(&table.lookers, claims) {
+				let embedded = looker
+					.index
+					.iter()
+					.map(|&j| iota::<F>(j, m))
+					.collect::<Vec<_>>();
+				let embedded = FieldBuffer::<P>::from_values(&embedded);
+				let own_point = &index_point[index_point.len() - looker.eval_point.len()..];
+				assert_eq!(
+					*claim,
+					evaluate(&embedded, own_point),
+					"index claim wrong for table {table_index}, n={} ({shape})",
+					looker.eval_point.len()
+				);
+			}
+		}
+	}
+
+	// Build the prover-side witnesses for an instance.
+	fn prover_tables<'a, Q>(tables: &'a [TestTable<F, Q>]) -> Vec<TableLookup<'a, Q>>
+	where
+		Q: PackedField<Scalar = F>,
+	{
+		tables
+			.iter()
+			.map(|table| TableLookup {
+				table: table.values.to_ref(),
+				lookers: table
+					.lookers
+					.iter()
+					.map(|looker| Looker {
+						index: &looker.index,
+						eval_point: &looker.eval_point,
+						eval_claim: looker.eval_claim,
+					})
+					.collect(),
+			})
+			.collect()
+	}
+
+	// Build the verifier-side claims for an instance.
+	fn verifier_tables<'a, Q>(
+		tables: &'a [TestTable<F, Q>],
+	) -> Vec<binius_ip::logup_star::TableLookup<'a, F>>
+	where
+		Q: PackedField<Scalar = F>,
+	{
+		tables
+			.iter()
+			.map(|table| binius_ip::logup_star::TableLookup {
+				n_vars: table.values.log_len(),
+				lookers: table
+					.lookers
+					.iter()
+					.map(|looker| LookerClaim {
+						eval_point: &looker.eval_point,
+						eval_claim: looker.eval_claim,
+					})
+					.collect(),
+			})
+			.collect()
+	}
+
+	/// Round-trip a whole instance over the naive channel and check every reduced claim.
+	fn check_prove_verify(spec: &[(usize, Vec<usize>)], seed: u64) {
+		let tables = random_instance::<F, P>(spec, seed);
+		let shape = format!("{spec:?}");
+
+		// One oracle per table: pushforward Y, of message length 2^m, in table order.
+		let specs = tables
+			.iter()
+			.map(|table| OracleSpec::new(table.values.log_len()))
+			.collect::<Vec<_>>();
+
+		// Prove: commit every Y, run the reduction, then open them as the caller would.
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 		let mut prover_channel =
 			NaiveProverChannel::<F, _>::new(&mut prover_transcript, specs.clone());
-		let looker = reduction::Looker {
-			index: &index,
-			eval_point: &eval_point,
-			eval_claim,
-		};
 		let prover_proof =
-			prove::<F, P, _, _>(table.to_ref(), &[looker], &mut prover_channel, &GlobalAllocator);
-
+			prove::<F, P, _, _>(prover_tables(&tables), &mut prover_channel, &GlobalAllocator);
 		prover_channel.finish();
 
-		// Verify: receive Y, run the reduction, then open the pushforward relation.
+		// Verify: receive every Y, run the reduction, then open the pushforward relations.
 		let mut verifier_transcript = prover_transcript.into_verifier();
 		let mut verifier_channel =
 			NaiveVerifierChannel::<F, _>::new(&mut verifier_transcript, &specs);
-		let looker_claim = LookerClaim {
-			eval_point: &eval_point,
-			eval_claim,
-		};
-		let verifier_proof = verify_logup::verify(m, &[looker_claim], &mut verifier_channel)
+		let verifier_proof = verify_logup::verify(verifier_tables(&tables), &mut verifier_channel)
 			.expect("verification succeeds");
 		verifier_channel.finish();
 
-		// The prover and verifier must derive identical reduced claims from the same transcript.
-		assert_eq!(prover_proof.table_eval_point, verifier_proof.table_eval_point, "table point");
-		assert_eq!(prover_proof.table_eval_claim, verifier_proof.table_eval_claim, "table claim");
-		assert_eq!(prover_proof.index_eval_point, verifier_proof.index_eval_point, "index point");
-		assert_eq!(
-			prover_proof.index_eval_claims, verifier_proof.index_eval_claims,
-			"index claims"
-		);
-
-		// The reduced table claim is the honest evaluation of T at the reduced point.
-		assert_eq!(
-			prover_proof.table_eval_claim,
-			evaluate(&table, &prover_proof.table_eval_point),
-			"table claim wrong (n={n}, m={m})"
-		);
-
-		// The pushforward opening is checked inside the channel; nothing further to assert here.
-		let _ = eq_r;
-
-		// The index claim is the honest evaluation of the embedded index column.
-		let index_embedded = index.iter().map(|&j| iota::<F>(j, m)).collect::<Vec<_>>();
-		let index_embedded = FieldBuffer::<P>::from_values(&index_embedded);
-		assert_eq!(
-			prover_proof.index_eval_claims,
-			vec![evaluate(&index_embedded, &prover_proof.index_eval_point)],
-			"index claim wrong (n={n}, m={m})"
-		);
+		check_proofs(&prover_proof, &verifier_proof, &tables, &shape);
 	}
 
 	#[test]
 	fn test_prove_verify_round_trip() {
 		// A spread of shapes: m << n (the target regime), m == n, and a wide table.
 		for (n, m) in [(6, 2), (5, 3), (4, 4), (3, 5), (7, 1)] {
-			check_prove_verify(n, m, 0);
+			check_prove_verify(&[(m, vec![n])], 0);
 		}
 	}
 
 	#[test]
 	fn test_multi_looker_committed_round_trip() {
-		let mut rng = StdRng::seed_from_u64(13);
-		let (n, m) = (5, 3);
-
-		let (table, index_0, eval_point_0, eq_r_0, eval_claim_0) =
-			random_instance::<F, P>(&mut rng, n, m);
-		let (_, index_1, eval_point_1, eq_r_1, _) = random_instance::<F, P>(&mut rng, n, m);
-		// The second looker's claim reads the shared table.
-		let eval_claim_1 = index_1
-			.iter()
-			.zip(&eq_r_1)
-			.map(|(&j, &eq)| eq * table.get(j))
-			.fold(F::ZERO, |acc, t| acc + t);
-
-		let specs = vec![OracleSpec::new(m)];
-
-		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
-		let mut prover_channel =
-			NaiveProverChannel::<F, _>::new(&mut prover_transcript, specs.clone());
-		let lookers = [
-			reduction::Looker {
-				index: &index_0,
-				eval_point: &eval_point_0,
-				eval_claim: eval_claim_0,
-			},
-			reduction::Looker {
-				index: &index_1,
-				eval_point: &eval_point_1,
-				eval_claim: eval_claim_1,
-			},
-		];
-		let prover_proof =
-			prove::<F, P, _, _>(table.to_ref(), &lookers, &mut prover_channel, &GlobalAllocator);
-		prover_channel.finish();
-
-		let mut verifier_transcript = prover_transcript.into_verifier();
-		let mut verifier_channel =
-			NaiveVerifierChannel::<F, _>::new(&mut verifier_transcript, &specs);
-		let looker_claims = [
-			LookerClaim {
-				eval_point: &eval_point_0,
-				eval_claim: eval_claim_0,
-			},
-			LookerClaim {
-				eval_point: &eval_point_1,
-				eval_claim: eval_claim_1,
-			},
-		];
-		let verifier_proof = verify_logup::verify(m, &looker_claims, &mut verifier_channel)
-			.expect("verification succeeds");
-		verifier_channel.finish();
-
-		assert_eq!(prover_proof.table_eval_point, verifier_proof.table_eval_point);
-		assert_eq!(prover_proof.table_eval_claim, verifier_proof.table_eval_claim);
-		assert_eq!(prover_proof.index_eval_claims, verifier_proof.index_eval_claims);
-		assert_eq!(prover_proof.table_eval_claim, evaluate(&table, &prover_proof.table_eval_point),);
-		// The eq_r tensors of both lookers went into the shared pushforward; nothing further to
-		// check here beyond the openings above.
-		let _ = (eq_r_0, eq_r_1);
+		// Several lookers sharing one committed pushforward.
+		check_prove_verify(&[(3, vec![5, 5])], 13);
 	}
 
 	#[test]
 	fn test_prove_verify_single_table_variable() {
 		// m = 1 exercises the batched final layer with an empty layer-1 point.
-		check_prove_verify(4, 1, 1);
+		check_prove_verify(&[(1, vec![4])], 1);
+	}
+
+	#[test]
+	fn test_multi_table_committed_round_trip() {
+		// One oracle per table, received in table order. The shapes mix table sizes, looker
+		// lengths, and how many lookers each table has, and put the deepest instance on either
+		// side.
+		for spec in [
+			vec![(3usize, vec![5usize, 3usize]), (2, vec![2, 6])],
+			vec![(4, vec![1]), (2, vec![3]), (5, vec![2])],
+			vec![(2, vec![4, 4, 2]), (3, vec![5])],
+			vec![(1, vec![0]), (4, vec![3])],
+		] {
+			check_prove_verify(&spec, 23);
+		}
 	}
 
 	#[test]
 	fn test_verifier_rejects_wrong_eval_claim() {
-		let mut rng = StdRng::seed_from_u64(3);
-		let (table, index, eval_point, _eq_r, eval_claim) = random_instance::<F, P>(&mut rng, 5, 3);
+		let mut tables = random_instance::<F, P>(&[(3, vec![5])], 3);
 		let specs = vec![OracleSpec::new(3)];
 
 		// Prove a false statement by perturbing the looked-up evaluation.
-		let wrong_claim = eval_claim + F::ONE;
+		tables[0].lookers[0].eval_claim += F::ONE;
+
 		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
 		let mut prover_channel =
 			NaiveProverChannel::<F, _>::new(&mut prover_transcript, specs.clone());
-		let looker = reduction::Looker {
-			index: &index,
-			eval_point: &eval_point,
-			eval_claim: wrong_claim,
-		};
 		let _prover_proof =
-			prove::<F, P, _, _>(table.to_ref(), &[looker], &mut prover_channel, &GlobalAllocator);
+			prove::<F, P, _, _>(prover_tables(&tables), &mut prover_channel, &GlobalAllocator);
 		prover_channel.finish();
 
 		// The reduction's product check must surface the inconsistency as a verification failure.
 		let mut verifier_transcript = prover_transcript.into_verifier();
 		let mut verifier_channel =
 			NaiveVerifierChannel::<F, _>::new(&mut verifier_transcript, &specs);
-		let looker_claim = LookerClaim {
-			eval_point: &eval_point,
-			eval_claim: wrong_claim,
-		};
-		let result = verify_logup::verify(3, &[looker_claim], &mut verifier_channel);
+		let result = verify_logup::verify(verifier_tables(&tables), &mut verifier_channel);
 		assert!(result.is_err(), "verifier must reject a wrong eval claim");
 	}
 
@@ -378,15 +432,19 @@ mod tests {
 		type BP = PackedBinaryGhash1x128b;
 		type Chal = HasherChallenger<StdDigest>;
 
-		let (n, m) = (6, 2);
-		let mut rng = StdRng::seed_from_u64(7);
-		let (table, index, eval_point, eq_r, eval_claim) = random_instance::<F, BP>(&mut rng, n, m);
+		// Two tables of different sizes, so the real FRI path carries one masked oracle per table
+		// and each is opened at its own prefix of the reduced point.
+		let spec = [(2usize, vec![6usize, 2usize]), (4, vec![3])];
+		let tables = random_instance::<F, BP>(&spec, 7);
 
-		// One witness-dependent (ZK) oracle: the pushforward Y, with 2^m entries.
+		// One witness-dependent (ZK) oracle per table: the pushforward Y, with 2^m entries.
 		const LOG_INV_RATE: usize = 1;
 		const SECURITY_BITS: usize = 32;
 		let n_test_queries = SECURITY_BITS.div_ceil(LOG_INV_RATE);
-		let oracle_specs = vec![OracleSpec::new_zk(m)];
+		let oracle_specs = tables
+			.iter()
+			.map(|table| OracleSpec::new_zk(table.values.log_len()))
+			.collect::<Vec<_>>();
 
 		let verifier_compiler = BaseFoldVerifierCompiler::new(
 			&BinaryMerkleTreeScheme::<F, StdHashSuite>::new(),
@@ -396,7 +454,7 @@ mod tests {
 			&MinProofSizeStrategy,
 		);
 
-		// Prove: commit Y with real FRI, run the reduction, open the pushforward.
+		// Prove: commit the pushforwards with real FRI, run the reduction, open them.
 		let domain_context =
 			GenericOnTheFly::generate_from_subspace(verifier_compiler.max_subspace());
 		let ntt = NeighborsLastSingleThread::new(domain_context);
@@ -411,42 +469,24 @@ mod tests {
 				prover_channel_rng,
 			);
 
-		let looker = reduction::Looker {
-			index: &index,
-			eval_point: &eval_point,
-			eval_claim,
-		};
 		let alloc = GlobalAllocator;
 		let prover_proof =
-			prove::<F, BP, _, _>(table.to_ref(), &[looker], &mut prover_channel, &alloc);
+			prove::<F, BP, _, _>(prover_tables(&tables), &mut prover_channel, &alloc);
 		prover_channel.finish(&alloc);
 
-		// Verify: receive Y, run the reduction, open the pushforward through the real FRI check.
+		// Verify: receive the pushforwards, run the reduction, open them through the real FRI
+		// check.
 		let mut verifier_transcript = prover_transcript.into_verifier();
 		let mut verifier_channel = verifier_compiler
 			.create_channel_from_transcript::<StdHashSuite, Chal, _>(&mut verifier_transcript);
-		let looker_claim = LookerClaim {
-			eval_point: &eval_point,
-			eval_claim,
-		};
-		let verifier_proof = verify_logup::verify(m, &[looker_claim], &mut verifier_channel)
+		let verifier_proof = verify_logup::verify(verifier_tables(&tables), &mut verifier_channel)
 			.expect("verification succeeds");
 		verifier_channel
 			.finish()
-			.expect("the batched FRI opening verifies");
+			.expect("the batched FRI openings verify");
 
-		// The FRI opening already bound Y to its claim.
+		// The FRI openings already bound every Y to its claim.
 		// Cross-check the table and index claims against honest values.
-		assert_eq!(prover_proof.table_eval_point, verifier_proof.table_eval_point);
-		assert_eq!(prover_proof.table_eval_claim, verifier_proof.table_eval_claim);
-		assert_eq!(prover_proof.index_eval_claims, verifier_proof.index_eval_claims);
-		assert_eq!(
-			prover_proof.table_eval_claim,
-			evaluate(&table, &prover_proof.table_eval_point),
-			"table claim must be the honest table evaluation"
-		);
-
-		// The FRI opening already bound the pushforward claim inside the channel.
-		let _ = eq_r;
+		check_proofs(&prover_proof, &verifier_proof, &tables, "basefold");
 	}
 }

--- a/crates/iop/src/logup_star.rs
+++ b/crates/iop/src/logup_star.rs
@@ -1,20 +1,23 @@
 // Copyright 2026 The Binius Developers
 
-//! logUp* verification with the pushforward committed as an oracle.
+//! logUp* verification with the pushforwards committed as oracles.
 //!
-//! The bare reduction returns a claimed evaluation of the pushforward `Y = I_* eq_r`.
-//! It never binds `Y` to a commitment, so that claim cannot be checked on its own.
-//! This layer receives the `Y` oracle over the IOP channel and returns the relation that opens it.
+//! The bare reduction returns a claimed evaluation of each table's pushforward `Y = I_* eq_r`.
+//! It never binds them to commitments, so those claims cannot be checked on their own.
+//! This layer receives one `Y` oracle per table over the IOP channel and returns the relations that
+//! open them.
 //!
-//! The receive precedes the reduction, so the logUp challenge binds the received `Y`.
-//! The table `T` and index `I` stay the caller's oracles, so their claims are returned unchanged.
-//! `Y` is the only oracle this protocol introduces, per [Soukhanov25, Section 3].
+//! The receives precede the reduction, so its logUp challenges bind the received oracles.
+//! The tables `T` and indexes `I` stay the caller's oracles, so their claims are returned
+//! unchanged. The pushforwards are the only oracles this protocol introduces, per
+//! [Soukhanov25, Section 3].
 //!
 //! [Soukhanov25]: <https://eprint.iacr.org/2025/946>
 
 use binius_field::{BinaryField1b, ExtensionField, Field};
 use binius_ip::logup_star as reduction;
 use binius_math::multilinear::eq::eq_ind;
+use itertools::izip;
 
 use crate::channel::{Error as ChannelError, IOPVerifierChannel, OracleLinearRelation};
 
@@ -32,86 +35,94 @@ pub enum Error {
 /// The reduced claims of a committed logUp* verification.
 ///
 /// The table and index claims are left for the caller to open against its own commitments.
-/// The pushforward claim is opened against the commitment received here, through the channel.
+/// The pushforward claims are opened against the commitments received here, through the channel.
 pub struct LogupProof<Elem> {
-	/// The `m`-coordinate point shared by the table and pushforward claims.
+	/// The point the table claims are drawn from, spanning the widest table.
+	///
+	/// A table over `m` variables is claimed at its **first `m`** coordinates.
 	pub table_eval_point: Vec<Elem>,
-	/// The claimed evaluation of the table `T` at the point.
-	pub table_eval_claim: Elem,
-	/// The `n`-coordinate point shared by the index claims.
+	/// The point the index claims are drawn from, spanning the deepest looker.
+	///
+	/// A looker over `n` variables is claimed at its **last `n`** coordinates.
 	pub index_eval_point: Vec<Elem>,
-	/// The claimed evaluations of the per-looker embedded index columns at the point.
-	pub index_eval_claims: Vec<Elem>,
+	/// One entry per table, in the order the tables were given.
+	pub tables: Vec<reduction::LogupTableOutput<Elem>>,
 }
 
-/// Verify a logUp* reduction whose pushforward is committed as an oracle.
+/// Verify a logUp* reduction whose pushforwards are committed as oracles.
 ///
-/// This wraps [`binius_ip::logup_star::verify_reduction`] with the pushforward commitment: the
-/// looker batching challenge is sampled first (the prover builds the combined pushforward from
-/// it), then the `Y` oracle is received before the reduction, so the logUp challenge binds the
-/// commitment. The relation `<Y, eq_r'> = Y(r')` at the reduced table point `r'` is opened
-/// through the channel, which may defer the actual opening to `finish()`.
+/// This wraps [`binius_ip::logup_star::verify_reduction`] with the pushforward commitments. The
+/// looker batching challenge is sampled first — the prover needs it to build the pushforwards —
+/// then one `Y` oracle is received per table, in table order, before the reduction, so the logUp
+/// challenges bind every commitment. The relations `<Y, eq_r> = Y(r)` at each table's reduced point
+/// are opened through the channel, which may defer the actual openings to `finish()`.
+///
+/// One oracle per table is the simple arrangement; the pushforwards could instead be concatenated
+/// into a single oracle, which is left for later.
 ///
 /// # Arguments
 ///
-/// * `table_n_vars` - The number of table variables `m` (`2^m` entries).
-/// * `lookers` - The looker claims; every evaluation point must have the same length `n`.
-/// * `channel` - The IOP verifier channel carrying the `Y` commitment.
+/// * `tables` - One [`binius_ip::logup_star::TableLookup`] per table, by value. The lookers'
+///   evaluation points may differ in length, from each other and from the table.
+/// * `channel` - The IOP verifier channel carrying the `Y` commitments.
 ///
 /// # Errors
 ///
-/// Returns an error when the pushforward commitment is missing or the reduction identity fails.
-pub fn verify<F, C>(
-	table_n_vars: usize,
-	lookers: &[reduction::LookerClaim<'_, C::Elem>],
+/// Returns an error when a pushforward commitment is missing or the reduction identity fails.
+pub fn verify<'a, F, C>(
+	tables: impl IntoIterator<Item = reduction::TableLookup<'a, C::Elem>>,
 	channel: &mut C,
 ) -> Result<LogupProof<C::Elem>, Error>
 where
 	F: Field + ExtensionField<BinaryField1b>,
 	C: IOPVerifierChannel<F>,
-	C::Elem: From<F>,
+	C::Elem: From<F> + 'a,
 {
-	// Sample the looker batching challenge before the commitment: the prover needs gamma to build
-	// the combined pushforward it commits.
+	// The tables are walked twice — once to receive their commitments, once to open them — so the
+	// iterator is materialized once here.
+	let tables = tables.into_iter().collect::<Vec<_>>();
+	// Only the variable counts are needed after the reduction consumes the tables.
+	let table_n_vars = tables.iter().map(|table| table.n_vars).collect::<Vec<_>>();
+
+	// Sample the looker batching challenge before the commitments: the prover needs gamma to build
+	// the pushforwards it commits.
 	let gamma = channel.sample();
 
-	// Receive the pushforward Y commitment next, so the reduction's logUp challenge binds it.
+	// Receive the pushforward commitments next, so the reduction's logUp challenges bind them.
 	//
-	//     Y has 2^m entries, so its message length is table_n_vars.
+	//     Y for a table over m variables has 2^m entries, so its message length is m.
 	//     Y is witness-dependent (it scatters the numerators by the secret indexes), so it may be
 	//     masked.
-	let oracle = channel.recv_oracle(table_n_vars, true)?;
+	let oracles = table_n_vars
+		.iter()
+		.map(|&n_vars| channel.recv_oracle(n_vars, true))
+		.collect::<Result<Vec<_>, _>>()?;
 
-	// Run the bare reduction over the same channel, viewed as an IP channel. The reduction takes a
-	// list of tables; this layer commits one pushforward, so it runs it over the one table.
-	let output = reduction::verify_reduction::<F, C>(
-		&gamma,
-		[reduction::TableLookup {
-			n_vars: table_n_vars,
-			lookers: lookers.to_vec(),
-		}],
-		channel,
-	)?;
-	let [table] = <[_; 1]>::try_from(output.tables)
-		.unwrap_or_else(|_| unreachable!("this layer runs the reduction over one table"));
+	// Run the bare reduction over the same channel, viewed as an IP channel.
+	let output = reduction::verify_reduction::<F, C>(&gamma, tables, channel)?;
 
-	// Open the pushforward relation through the channel; a deferring channel (e.g. BaseFold)
-	// batches it with every other queued relation in `finish()`.
+	// Open each pushforward relation through the channel; a deferring channel (e.g. BaseFold)
+	// batches them with every other queued relation in `finish()`.
 	//
-	//     <Y, eq_r'> = Y(r') = pushforward_eval_claim
+	//     <Y, eq_r> = Y(r) = that table's pushforward claim
 	//
-	// BaseFold reduces this inner product to a challenge point, where the transparent is eq(r', .).
-	let point = output.table_eval_point.clone();
-	channel.verify_oracle_relations([OracleLinearRelation {
-		oracle,
-		transparent: Box::new(move |challenge: &[C::Elem]| eq_ind(&point, challenge)),
-		claim: table.pushforward_claim,
-	}])?;
+	// BaseFold reduces each inner product to a challenge point, where the transparent is eq(r, .).
+	// A table's own point is the first m coordinates of the shared reduced point.
+	let relations = izip!(oracles, &table_n_vars, &output.tables)
+		.map(|(oracle, &n_vars, table_output)| {
+			let point = output.table_eval_point[..n_vars].to_vec();
+			OracleLinearRelation {
+				oracle,
+				transparent: Box::new(move |challenge: &[C::Elem]| eq_ind(&point, challenge)),
+				claim: table_output.pushforward_claim.clone(),
+			}
+		})
+		.collect::<Vec<_>>();
+	channel.verify_oracle_relations(relations)?;
 
 	Ok(LogupProof {
 		table_eval_point: output.table_eval_point,
-		table_eval_claim: table.eval_claim,
 		index_eval_point: output.index_eval_point,
-		index_eval_claims: table.index_eval_claims,
+		tables: output.tables,
 	})
 }

--- a/crates/ip-prover/src/logup_star/mod.rs
+++ b/crates/ip-prover/src/logup_star/mod.rs
@@ -32,6 +32,6 @@ mod prove;
 mod pushforward;
 pub mod witness;
 
-pub use binius_ip::logup_star::LogupOutput;
+pub use binius_ip::logup_star::{LogupOutput, LogupTableOutput};
 
 pub use self::prove::{Looker, TableLookup, prove, prove_reduction};

--- a/crates/prover/src/protocols/intmul/prove.rs
+++ b/crates/prover/src/protocols/intmul/prove.rs
@@ -292,7 +292,16 @@ where
 			})
 			.collect::<Vec<_>>();
 		let log_cols = log2_ceil_usize(N_LIMB_COLUMNS);
-		let logup_proof = logup_star::prove(table, &lookers, self.channel, self.alloc);
+		// Every limb column reads the one shared power table, so the reduction runs over a
+		// single-table list.
+		let logup_proof = logup_star::prove(
+			[logup_star::TableLookup { table, lookers }],
+			self.channel,
+			self.alloc,
+		);
+		let [table_output] = logup_proof.tables.as_slice() else {
+			unreachable!("the reduction runs over the one power table")
+		};
 
 		// The index entries are the GF(2)-linear embeddings iota(e) = Σ_u basis(u) · bit_u(e),
 		// materialized by a table of all 2^LIMB_BITS embeddings.
@@ -311,7 +320,7 @@ where
 		// Collapse the per-column claims into a single claim on the eq(ρ)-folded column V by
 		// sampling ρ, so the final unification runs over the content variables only.
 		let rho = self.channel.sample_many(log_cols);
-		let mut padded_column_evals = logup_proof.index_eval_claims.clone();
+		let mut padded_column_evals = table_output.index_eval_claims.clone();
 		padded_column_evals.resize(1 << log_cols, F::ZERO);
 		let folded_index_claim =
 			evaluate(&FieldBuffer::<P>::from_values(&padded_column_evals), &rho);

--- a/crates/verifier/src/protocols/intmul/verify.rs
+++ b/crates/verifier/src/protocols/intmul/verify.rs
@@ -8,7 +8,7 @@ use binius_field::{BinaryField, BinaryField1b, ExtensionField, Field, field::Fie
 use binius_iop::{channel::IOPVerifierChannel, logup_star};
 use binius_ip::{
 	channel::IPVerifierChannel,
-	logup_star::LookerClaim,
+	logup_star::{LookerClaim, TableLookup},
 	prodcheck::{self, MultilinearEvalClaim},
 	sumcheck::{BatchSumcheckOutput, batch_verify},
 };
@@ -283,16 +283,27 @@ where
 		})
 		.collect::<Vec<_>>();
 	let log_cols = log2_ceil_usize(N_LIMB_COLUMNS);
-	let logup_proof = logup_star::verify::<F, C>(LIMB_BITS, &looker_claims, channel)?;
+	// Every limb column reads the one shared power table, so the reduction runs over a single-table
+	// list and returns a single table claim.
+	let logup_proof = logup_star::verify::<F, C>(
+		[TableLookup {
+			n_vars: LIMB_BITS,
+			lookers: looker_claims,
+		}],
+		channel,
+	)?;
+	let [table_output] = logup_proof.tables.as_slice() else {
+		unreachable!("the reduction runs over the one power table")
+	};
 
 	// The table is succinct: the verifier evaluates its MLE directly.
 	let expected_table_eval = eval_power_table_mle::<F, C::Elem>(&logup_proof.table_eval_point);
-	channel.assert_zero(expected_table_eval - logup_proof.table_eval_claim)?;
+	channel.assert_zero(expected_table_eval - table_output.eval_claim.clone())?;
 
 	// The reduction hands back the per-column embedded-index claims directly, all at the shared
 	// content point (padding columns read row 0, whose embedding is zero).
 	let index_content_point = logup_proof.index_eval_point.as_slice();
-	let mut padded_column_evals = logup_proof.index_eval_claims.clone();
+	let mut padded_column_evals = table_output.index_eval_claims.clone();
 	padded_column_evals.resize(1 << log_cols, C::Elem::zero());
 
 	// Collapse the per-column claims into a single claim on the eq(ρ)-folded column V by sampling


### PR DESCRIPTION
Last of three PRs for [BINIUS-418](https://linear.app/jimpo/issue/BINIUS-418/logup-star-multi-table-batch-lookup). #2067 and #2069 have merged, so this is now based on `main` and is the whole remaining diff.

#2069 made the bare reduction multi-table but left the committed layer pinned to one pushforward. This lifts that: `binius_iop::logup_star` and `binius_iop_prover::logup_star` take a list of tables and commit **one `Y` oracle per table**, in table order, before the reduction — so the per-table logUp challenges bind every commitment. Each relation `<Y, eq_r> = Y(r)` is opened at that table's own prefix of the shared reduced point.

One oracle per table is what the issue asked for ("for now, each pushforward can be a separate oracle"); a single concatenated oracle is left for later, noted in both docstrings.

Both layers take the reduction's own `TableLookup` rather than a bespoke type — with `gamma` now a plain argument, there was nothing left for a separate struct to carry. They return the same `Vec<LogupTableOutput>` too, rather than re-wrapping it.

`intmul` stays single-table — every limb column reads the one shared power table — so it passes a one-element list and destructures the single `LogupTableOutput`. Its transcript is unchanged, which `size_tracking_matches_real_proof_bytes` confirms.

## Tests

The committed round-trip helper is parameterized by `[(table_n_vars, [looker_n_vars])]`, the same shape as the bare one, so every prior case runs through it.

The one worth pointing at is **`test_basefold_round_trip`, now over two tables of different sizes** (`m = 2` and `m = 4`) with three lookers spread across them at three different lengths. That exercises the real FRI path with two *masked* ZK oracles of unequal message length, opened at different prefixes of the same reduced point — the end-to-end check that the padding conventions on both sides of the stack line up. It is the strongest evidence in the stack that the whole thing composes, since nothing about it is mocked.

Also added `test_multi_table_committed_round_trip` over four shapes on the naive channel.

## Verification

- `cargo test` green on `binius-ip`, `binius-ip-prover`, `binius-iop`, `binius-iop-prover`, `binius-prover`, `binius-verifier`, `binius-spartan-prover`, `binius-spartan-verifier`, re-run after the rebase onto merged `main`.
- `cargo clippy --all --tests --benches --examples -- -D warnings` clean.
- `cargo +nightly-2026-07-01 fmt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)