### PR TITLE
Refactor the Merkle verifier scheme

### DIFF
--- a/crates/iop/src/merkle_tree/error.rs
+++ b/crates/iop/src/merkle_tree/error.rs
@@ -6,7 +6,7 @@ use binius_utils::SerializationError;
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
 	#[error("Failed to serialize leaf element: {0}")]
-	Serialization(SerializationError),
+	Serialization(#[from] SerializationError),
 	#[error("transcript error: {0}")]
 	Transcript(#[from] binius_transcript::Error),
 	#[error("verification failure: {0}")]

--- a/crates/iop/src/merkle_tree/merkle_tree_vcs.rs
+++ b/crates/iop/src/merkle_tree/merkle_tree_vcs.rs
@@ -20,9 +20,19 @@ pub struct Commitment<Digest> {
 
 /// A Merkle tree scheme.
 pub trait MerkleTreeScheme<T: FixedSizeSerializeBytes> {
+	/// The digest of a leaf or an inner node.
 	type Digest: Clone + PartialEq + Eq;
 
 	/// Returns the optimal layer that the verifier should verify only once.
+	///
+	/// Decommitting a layer at depth `d` costs `2^d` digests but shortens every one of the
+	/// `n_queries` branches by `d`, so the proof holds
+	///
+	/// ```text
+	/// (tree_depth - d) * n_queries + 2^d
+	/// ```
+	///
+	/// digests. That is minimized at `d = ceil(log2(n_queries))`, clamped to the tree depth.
 	fn optimal_verify_layer(&self, n_queries: usize, tree_depth: usize) -> usize;
 
 	/// Returns the total byte-size of a proof for multiple opening queries.
@@ -46,7 +56,9 @@ pub trait MerkleTreeScheme<T: FixedSizeSerializeBytes> {
 	///
 	/// ## Preconditions
 	///
+	/// * `batch_size` must be non-zero.
 	/// * `data.len()` must be a multiple of `batch_size`.
+	/// * `data.len() / batch_size` must be a non-zero power of two.
 	fn verify_vector(
 		&self,
 		root: &Self::Digest,
@@ -75,6 +87,7 @@ pub trait MerkleTreeScheme<T: FixedSizeSerializeBytes> {
 	/// ## Preconditions
 	///
 	/// * `layer_digests.len()` must equal `2^layer_depth`.
+	/// * `layer_depth` must be at most `tree_depth`.
 	/// * `index` must be less than `2^tree_depth`.
 	fn verify_opening<B: Buf>(
 		&self,

--- a/crates/iop/src/merkle_tree/scheme.rs
+++ b/crates/iop/src/merkle_tree/scheme.rs
@@ -1,7 +1,10 @@
 // Copyright 2024-2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-use std::{array, fmt::Debug, marker::PhantomData};
+use std::{
+	fmt::{self, Debug, Formatter},
+	marker::PhantomData,
+};
 
 use binius_hash::{CompressionFunction, binary_merkle_tree::HashSuite, hash_serialize};
 use binius_transcript::{Buf, TranscriptReader};
@@ -10,16 +13,19 @@ use binius_utils::{
 	checked_arithmetics::{checked_log_2, log2_ceil_usize},
 };
 use digest::{Digest, Output};
-use getset::Getters;
 
 use super::{
 	error::{Error, VerificationError},
 	merkle_tree_vcs::MerkleTreeScheme,
 };
 
-#[derive(Clone, Getters)]
+/// A binary Merkle tree vector commitment, as seen by the verifier.
+///
+/// A committed vector is cut into equal-size batches of values.
+/// Each batch is hashed into one leaf digest.
+/// Pairs of digests are then folded upward until a single root digest remains.
 pub struct BinaryMerkleTreeScheme<T, H: HashSuite> {
-	#[getset(get = "pub")]
+	/// Two-to-one function folding a pair of child digests into their parent digest.
 	compression: H::Compression,
 	// This makes it so that `BinaryMerkleTreeScheme` remains Send + Sync regardless of `T`.
 	// See https://doc.rust-lang.org/nomicon/phantom-data.html#table-of-phantomdata-patterns
@@ -35,9 +41,89 @@ impl<T, H: HashSuite> Default for BinaryMerkleTreeScheme<T, H> {
 impl<T, H: HashSuite> BinaryMerkleTreeScheme<T, H> {
 	pub fn new() -> Self {
 		Self {
+			// The compression function is stateless, so one default instance serves every call.
 			compression: H::Compression::default(),
 			_phantom: PhantomData,
 		}
+	}
+
+	/// Folds a layer of digests down to the single root above it.
+	///
+	/// Each round pairs neighbours and replaces them with their parent, halving the layer:
+	///
+	/// ```text
+	///     [d_0, d_1, ..., d_{n-1}]  ->  [C(d_0, d_1), ..., C(d_{n-2}, d_{n-1})]
+	/// ```
+	///
+	/// After `log_2(n)` rounds exactly one digest is left, and that digest is the root.
+	///
+	/// # Panics
+	///
+	/// Panics unless the number of digests is a non-zero power of two.
+	///
+	/// # Performance
+	///
+	/// One allocation of `n / 2` digests in total, reused by every round after the first.
+	fn fold_to_root(&self, digests: &[Output<H::LeafHash>]) -> Output<H::LeafHash> {
+		// A layer that is not a power of two cannot be paired off cleanly.
+		// An empty layer spans no subtree at all.
+		assert!(
+			digests.len().is_power_of_two(),
+			"precondition: the number of digests must be a non-zero power of two"
+		);
+
+		// A lone digest already is the root of its subtree; folding it would invent a level.
+		if let [root] = digests {
+			return root.clone();
+		}
+
+		// The first round reads the caller's slice and writes into fresh space.
+		// That caps the scratch buffer at half the input length.
+		let mut layer = digests
+			.chunks_exact(2)
+			.map(|pair| {
+				self.compression
+					.compress([pair[0].clone(), pair[1].clone()])
+			})
+			.collect::<Vec<_>>();
+
+		// Later rounds halve the buffer in place.
+		// A parent lands strictly below both children it replaces, so nothing is overwritten early.
+		while layer.len() > 1 {
+			let half = layer.len() / 2;
+			for i in 0..half {
+				layer[i] = self
+					.compression
+					.compress([layer[2 * i].clone(), layer[2 * i + 1].clone()]);
+			}
+			// Drop the tail the round just consumed, keeping the allocation.
+			layer.truncate(half);
+		}
+
+		layer
+			.pop()
+			.expect("a non-empty layer folds down to exactly one digest")
+	}
+}
+
+impl<T, H: HashSuite> Clone for BinaryMerkleTreeScheme<T, H> {
+	fn clone(&self) -> Self {
+		// Written out rather than derived: a derived copy would demand a cloneable value type.
+		// No value of that type is ever held.
+		// The compression function is always cloneable through its own trait bound.
+		Self {
+			compression: self.compression.clone(),
+			_phantom: PhantomData,
+		}
+	}
+}
+
+impl<T, H: HashSuite> Debug for BinaryMerkleTreeScheme<T, H> {
+	fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+		// Written out for the same reason as the copy above.
+		// The compression function carries no formatting bound, and the scheme holds no state
+		// beyond it.
+		f.debug_struct("BinaryMerkleTreeScheme").finish()
 	}
 }
 
@@ -46,8 +132,9 @@ where
 	T: FixedSizeSerializeBytes,
 	H: HashSuite,
 {
+	/// Hashes one leaf from the values it holds.
 	fn compute_leaf_digest(&self, values: &[T]) -> Result<Output<H::LeafHash>, Error> {
-		hash_serialize::<T, H::LeafHash>(values).map_err(Error::Serialization)
+		Ok(hash_serialize::<T, H::LeafHash>(values)?)
 	}
 }
 
@@ -58,21 +145,27 @@ where
 {
 	type Digest = Output<H::LeafHash>;
 
-	/// This layer allows minimizing the proof size.
 	fn optimal_verify_layer(&self, n_queries: usize, tree_depth: usize) -> usize {
+		// Raising the layer by one level doubles its width but shortens every branch by one.
+		// The two effects balance where the layer width first reaches the query count.
+		//
+		// A layer can never sit below the leaves, hence the clamp.
 		log2_ceil_usize(n_queries).min(tree_depth)
 	}
 
-	/// ## Preconditions
-	/// * `len` must be a power of two.
-	/// * `layer_depth` must be at most `log2(len)`.
 	fn proof_size(&self, len: usize, n_queries: usize, layer_depth: usize) -> usize {
 		assert!(len.is_power_of_two(), "precondition: len must be a power of two");
 
+		// Depth of the tree spanning the committed vector.
 		let log_len = checked_log_2(len);
 
 		assert!(layer_depth <= log_len, "precondition: layer_depth must be at most log2(len)");
 
+		// Each query walks from its leaf up to the decommitted layer, one sibling per level.
+		// The layer itself is sent once, for all queries together.
+		//
+		//     branches: (log_len - layer_depth) * n_queries
+		//     layer   : 2^layer_depth
 		((log_len - layer_depth) * n_queries + (1 << layer_depth))
 			* <H::LeafHash as Digest>::output_size()
 	}
@@ -83,17 +176,27 @@ where
 		data: &[T],
 		batch_size: usize,
 	) -> Result<(), Error> {
+		// A zero-size batch would slice the data into unboundedly many empty leaves.
+		assert_ne!(batch_size, 0, "precondition: batch_size must be non-zero");
+		// Every leaf holds the same number of values, so the split has to come out even.
 		assert!(
 			data.len().is_multiple_of(batch_size),
 			"precondition: data length must be a multiple of batch_size"
 		);
+		// A binary tree only spans a power-of-two number of leaves.
+		assert!(
+			(data.len() / batch_size).is_power_of_two(),
+			"precondition: data.len() / batch_size must be a non-zero power of two"
+		);
 
+		// Rebuild every leaf digest from the revealed values.
 		let digests = data
 			.chunks(batch_size)
 			.map(|chunk| self.compute_leaf_digest(chunk))
 			.collect::<Result<Vec<_>, _>>()?;
 
-		if fold_digests_vector_inplace(&self.compression, digests) != *root {
+		// Rebuilding the whole tree and landing on the committed root is what binds the data.
+		if self.fold_to_root(&digests) != *root {
 			return Err(VerificationError::InvalidProof.into());
 		}
 		Ok(())
@@ -105,14 +208,16 @@ where
 		layer_depth: usize,
 		layer_digests: &[Self::Digest],
 	) -> Result<(), Error> {
+		// A layer that many levels below the root holds exactly that many digests.
 		assert_eq!(
 			layer_digests.len(),
 			1 << layer_depth,
 			"precondition: layer_digests must have 2^layer_depth entries"
 		);
 
-		let computed_root = fold_digests_vector_inplace(&self.compression, layer_digests.to_vec());
-		if computed_root != *root {
+		// Folding the claimed layer must reproduce the committed root.
+		// The fold takes one round per level, so a layer only passes at the depth it claims.
+		if self.fold_to_root(layer_digests) != *root {
 			return Err(VerificationError::InvalidProof.into());
 		}
 		Ok(())
@@ -127,45 +232,42 @@ where
 		layer_digests: &[Self::Digest],
 		proof: &mut TranscriptReader<B>,
 	) -> Result<(), Error> {
+		// A layer that many levels below the root holds exactly that many digests.
 		assert_eq!(
 			layer_digests.len(),
 			1 << layer_depth,
 			"precondition: layer_digests must have 2^layer_depth entries"
 		);
+		// The climb runs from the leaves up to the layer, so the layer cannot sit below them.
+		assert!(layer_depth <= tree_depth, "precondition: layer_depth must be at most tree_depth");
+		// A tree of that depth has exactly that many leaves to address.
 		assert!(index < (1 << tree_depth), "precondition: index must be less than 2^tree_depth");
 
-		let mut leaf_digest = self.compute_leaf_digest(values)?;
-		for branch_node in proof.read_vec(tree_depth - layer_depth)? {
-			leaf_digest = self.compression.compress(if index & 1 == 0 {
-				[leaf_digest, branch_node]
+		// Bottom of the authentication path: the leaf the opening claims.
+		let mut digest = self.compute_leaf_digest(values)?;
+
+		// Climb one level per round, folding in the sibling the advice supplies.
+		//
+		//     level k:  running digest + sibling_k  ->  running digest at level k+1
+		//
+		// The low bit of the running index says which side the running digest sits on.
+		for _ in layer_depth..tree_depth {
+			let sibling = proof.read::<Self::Digest>()?;
+			// An even index means the running digest is the left child of its parent.
+			digest = self.compression.compress(if index & 1 == 0 {
+				[digest, sibling]
 			} else {
-				[branch_node, leaf_digest]
+				[sibling, digest]
 			});
+			// Discard the bit just consumed, exposing the next level's side bit.
 			index >>= 1;
 		}
 
-		(leaf_digest == layer_digests[index])
-			.then_some(())
-			.ok_or_else(|| VerificationError::InvalidProof.into())
-	}
-}
-
-/// Compute the Merkle root over a vector of leaf digests.
-///
-/// Consumes digests because it modifies the vector in place.
-///
-/// # Preconditions
-/// - `digests.len()` is a power of two
-fn fold_digests_vector_inplace<C, D>(compression: &C, mut digests: Vec<D>) -> D
-where
-	C: CompressionFunction<D, 2>,
-	D: Clone + Default + Send + Sync + Debug,
-{
-	let log_len = checked_log_2(digests.len()); // pre-condition
-	for layer in (0..log_len).rev() {
-		for i in 0..1 << layer {
-			digests[i] = compression.compress(array::from_fn(|j| digests[2 * i + j].clone()));
+		// The climb dropped one bit per level, so what is left addresses the decommitted layer.
+		// Matching the entry there binds the leaf to the already-verified layer, hence the root.
+		if digest != layer_digests[index] {
+			return Err(VerificationError::InvalidProof.into());
 		}
+		Ok(())
 	}
-	digests[0].clone()
 }


### PR DESCRIPTION
Splits the refactoring out of #2059, which was too big to review in one piece. Pure refactor — no behaviour change, transcripts byte-identical.

The new tests and the FRI size-estimation cleanup from that PR are **not** here; they follow separately.

### The problem

**A free function that wanted to be a method.** The layer fold is generic over a compression function `C` and a digest `D`, but both are always the scheme's own two types:

```
fn fold_digests_vector_inplace<C, D>(compression: &C, mut digests: Vec<D>) -> D
where
    C: CompressionFunction<D, 2>,
    D: Clone + Default + Send + Sync + Debug,
```

Only `Clone` is ever used. `Default`, `Send`, `Sync` and `Debug` are pure over-constraint.

It also takes its input **by value**, so the one caller holding a slice clones the whole layer just to call it:

```
fold_digests_vector_inplace(&self.compression, layer_digests.to_vec())
```

**An allocation per query.** Opening a branch collects its siblings into a `Vec` to walk them exactly once.

**Preconditions that panic somewhere else.** Full-vector verification documents one precondition and has three:

- `batch_size == 0` passes the multiple-of check on empty data, then panics inside `chunks`.
- A leaf count that is not a power of two panics inside the logarithm, one call frame down.
- In opening, `layer_depth > tree_depth` underflows the subtraction that sizes the branch.

**Dead public API.** The compression getter has no callers anywhere in the workspace.

### The idea

Make the fold a method, and the rest follows.

Both type parameters and all four unused bounds disappear with the move. Taking a slice lets the first round read the caller's buffer and write into fresh space, so the scratch buffer starts at `n / 2` rather than `n`:

```
round 1:  read caller's slice (n)      -> write fresh buffer (n/2)
round 2:  halve in place                -> truncate to n/4
...
```

A parent always lands strictly below both children it replaces, so the later rounds overwrite in place safely.

### The change

```
- fn fold_digests_vector_inplace<C, D>(compression: &C, digests: Vec<D>) -> D
-     where C: CompressionFunction<D, 2>, D: Clone + Default + Send + Sync + Debug
+ fn fold_to_root(&self, digests: &[Output<H::LeafHash>]) -> Output<H::LeafHash>

- for branch_node in proof.read_vec(tree_depth - layer_depth)? {
+ for _ in layer_depth..tree_depth {
+     let sibling = proof.read::<Self::Digest>()?;
```

The range form also removes the subtraction that could underflow.

### Also in scope

- **Preconditions** asserted where they are violated, and documented on the trait rather than only in the impl.
- **The dead getter** removed. That leaves the scheme with no getters at all, so the derive goes too.
- **`Clone` written out**, because a derived one would demand that the committed value type be cloneable, though no value of that type is ever held. `Debug` added for the same shape.
- **One spelling for the three root comparisons**, which were written three different ways.
- **`#[from]` on serialization failures**, the one error variant that lacked the conversion every sibling already had.
- **Impl-level docs deleted** where they shadowed better trait docs in rustdoc. The cost model behind the optimal layer depth now lives on the trait, where it belongs.

### Soundness

- The same leaf hashes, the same fold order, the same root comparison.
- No transcript byte moves: reading siblings one at a time consumes exactly what `read_vec` consumed.
- The new asserts only fire on inputs that already panicked, one frame deeper and with a worse message.

### Scope

- **changed:** the Merkle scheme, its trait's docs, its error type
- **not here:** the test module and the FRI size-estimation cleanup from #2059 — both follow separately
- **untouched:** the branch layout, the proof-size formula, and every verifier check

### Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p binius-iop -p binius-iop-prover --all-targets` — zero warnings
- `cargo +nightly fmt --all` — clean
- `cargo test -p binius-iop -p binius-iop-prover` — 42 passed
- `cargo test -p binius-verifier -p binius-spartan-verifier` — 24 passed

Existing coverage is what guards this: every FRI and BaseFold round trip opens branches and folds layers through the rewritten code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)