### PR TITLE
BINIUS-423: pass the phase-1 claimed sum in from the caller

### DIFF
--- a/crates/m4-prover/src/shift.rs
+++ b/crates/m4-prover/src/shift.rs
@@ -78,7 +78,8 @@ where
 		*slot += *add;
 	}
 	let h = build_h::<F, F, _>(alloc, domain_subspace, prepared.bitand.r_zhat_prime);
-	let phase_1_output = run_phase_1_sumcheck::<F, F, _, _>(g, h, channel, alloc);
+	let phase_1_output =
+		run_phase_1_sumcheck::<F, F, _, _>(g, h, prepared.batched_eval(), channel, alloc);
 
 	// Phase 2: split the phase-1 challenges into the bit position `r_j`, the shift amount `r_s`
 	// and the shift variant `r_v`, in increasing order of significance.

--- a/crates/prover/benches/shift_reduction.rs
+++ b/crates/prover/benches/shift_reduction.rs
@@ -315,7 +315,13 @@ fn bench_shift_phases(c: &mut Criterion) {
 		eval: gamma,
 	} = {
 		let mut transcript = ProverTranscript::<StdChallenger>::default();
-		run_phase_1_sumcheck::<F, P, _, _>(g.clone(), h.clone(), &mut transcript, &GlobalAllocator)
+		run_phase_1_sumcheck::<F, P, _, _>(
+			g.clone(),
+			h.clone(),
+			prepared.batched_eval(),
+			&mut transcript,
+			&GlobalAllocator,
+		)
 	};
 	// Split the phase-1 challenges into the bit position, the shift amount and the shift variant.
 	let r_v = r_j.split_off(Word::LOG_BITS * 2);
@@ -349,7 +355,13 @@ fn bench_shift_phases(c: &mut Criterion) {
 			|| (g.clone(), h.clone()),
 			|(g, h)| {
 				let mut transcript = ProverTranscript::<StdChallenger>::default();
-				run_phase_1_sumcheck::<F, P, _, _>(g, h, &mut transcript, &GlobalAllocator)
+				run_phase_1_sumcheck::<F, P, _, _>(
+					g,
+					h,
+					prepared.batched_eval(),
+					&mut transcript,
+					&GlobalAllocator,
+				)
 			},
 			BatchSize::SmallInput,
 		);

--- a/crates/prover/src/protocols/shift/claims.rs
+++ b/crates/prover/src/protocols/shift/claims.rs
@@ -82,6 +82,22 @@ pub struct PreparedOperatorClaims<F: Field> {
 	pub binmul: PreparedOperatorData<F>,
 }
 
+impl<F: Field> PreparedOperatorClaims<F> {
+	/// The four operations' claims collapsed into the single value the reduction proves.
+	///
+	/// Each operation's batched evaluation already carries a random factor of its own, drawn for
+	/// it alone, so the four sum directly with no further scaling.
+	///
+	/// This is the claim phase 1 hands its sumcheck, and it is the same value the verifier
+	/// computes from the operand evaluation claims before running its own.
+	pub fn batched_eval(&self) -> F {
+		self.zero.batched_eval
+			+ self.bitand.batched_eval
+			+ self.intmul.batched_eval
+			+ self.binmul.batched_eval
+	}
+}
+
 impl<F: Field> Index<Operation> for PreparedOperatorClaims<F> {
 	type Output = PreparedOperatorData<F>;
 

--- a/crates/prover/src/protocols/shift/phase_1.rs
+++ b/crates/prover/src/protocols/shift/phase_1.rs
@@ -11,7 +11,7 @@ use binius_ip_prover::{
 	channel::IPProverChannel,
 	sumcheck::{ProveSingleOutput, bivariate_product_prover, prove_single},
 };
-use binius_math::{BinarySubspace, FieldBuffer, FieldVec, inner_product::inner_product_buffers};
+use binius_math::{BinarySubspace, FieldBuffer, FieldVec};
 use binius_utils::rayon::{
 	prelude::*,
 	task_size::{IndexedParallelIteratorExt, WorkPerItem},
@@ -63,7 +63,7 @@ where
 	// BitAnd, IntMul and BinMul share the same `r_zhat_prime`.
 	let h = build_h(alloc, domain_subspace, prepared.bitand.r_zhat_prime);
 
-	run_phase_1_sumcheck(g, h, channel, alloc)
+	run_phase_1_sumcheck(g, h, prepared.batched_eval(), channel, alloc)
 }
 
 /// Runs the phase 1 sumcheck protocol for shift constraint verification.
@@ -74,6 +74,17 @@ where
 ///
 /// The `g` multilinear carries the witness and the batching randomness; `h` encodes what each
 /// shift does at the univariate challenge point.
+///
+/// # Arguments
+///
+/// - `sum`: the claim being proved, as the operations' batched evaluations give it. This is the
+///   same value the verifier feeds its own sumcheck, so the prover proves the statement it was
+///   handed rather than whatever `g · h` happens to come to.
+///
+/// The two agree exactly when the witness satisfies the constraint system — which is what this
+/// reduction exists to establish, so it is not something the prover can check on its way in. On an
+/// unsatisfying witness they differ, and that difference travels through both phases to the
+/// reduction's final evaluation check, which is where verification fails.
 ///
 /// # Returns
 ///
@@ -87,10 +98,10 @@ pub fn run_phase_1_sumcheck<
 >(
 	g: FieldVec<P, A>,
 	h: FieldVec<P, A>,
+	sum: F,
 	channel: &mut Channel,
 	alloc: &A,
 ) -> SumcheckOutput<F> {
-	let sum = inner_product_buffers(&g, &h);
 	let prover = bivariate_product_prover(alloc, [g, h], sum);
 
 	let ProveSingleOutput {


### PR DESCRIPTION
Closes [BINIUS-423](https://linear.app/jimpo/issue/BINIUS-423/pass-the-phase-1-claimed-sum-in-from-the-caller), your follow-up on [#2070](https://github.com/binius-zk/binius64/pull/2070#discussion_r3751332226).

`run_phase_1_sumcheck` opened with `let sum = inner_product_buffers(&g, &h)`, so the prover derived the claim from its own buffers and proved whatever they came to. It now takes the claim, formed where the claims are:

```rust
run_phase_1_sumcheck(g, h, prepared.batched_eval(), channel, alloc)
```

`PreparedOperatorClaims::batched_eval()` sums the four operations' batched evaluations — the same value `shift::verify` feeds `verify_sumcheck`, so both sides now name one claim. Each operation's batched evaluation already carries a random factor of its own, so they sum with no further scaling.

## Correction to how I described this on #2070

I wrote there that passing the claim in makes a mismatch fail earlier. **It does not**, and I want that on the record rather than propagated. `binius_ip::sumcheck::verify` *recovers* each round polynomial's missing coefficient from the running sum instead of checking against it, so a wrong claim cannot fail inside the sumcheck — the discrepancy rides through to the reduction's final evaluation check, exactly where it surfaced before. The value is what you said: the prover proves the claim it was handed rather than one derived from its own buffers, and an inner product over 32,768 field elements goes away.

## What the tests taught me

I first added `debug_assert_eq!(sum, inner_product_buffers(&g, &h))` to keep the two definitions tied. `test_prove_verify_rejects_violated_zero_constraint` immediately failed — that test proves an intentionally violated witness, and on an unsatisfying witness the two *should* disagree. The assert was asserting the very property the reduction exists to establish, so it is gone; the doc comment says so instead. All 13 `prove_verify` tests pass, including that rejection test, so a bad witness is still caught.

## Verification

`cargo check --workspace --all-targets`, clippy `-D warnings` over prover + m4-prover, `cargo doc --no-deps --document-private-items`, and fmt all clean. Tests: prover lib 37, `prove_verify` 13, m4-prover lib 43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
