### PR TITLE
BINIUS-424: allow inout wires in M4 constraint systems

### DIFF
--- a/crates/core/src/constraint_system/layout.rs
+++ b/crates/core/src/constraint_system/layout.rs
@@ -94,7 +94,7 @@ impl ValueVecLayout {
 
 #[cfg(test)]
 mod tests {
-	use super::*;
+	use super::{super::InoutSegment, *};
 
 	/// A layout of two constants, two inout values and eight private values.
 	fn test_layout() -> ValueVecLayout {
@@ -140,7 +140,7 @@ mod tests {
 		assert_eq!(cs.n_public_values(), layout.offset_witness());
 
 		// The system pads the segments the protocol commits; the layout stores neither padding.
-		assert_eq!(cs.n_public_words(), 4);
-		assert_eq!(cs.n_hidden_words(), 8);
+		assert_eq!(cs.n_public_words(InoutSegment::Public), 4);
+		assert_eq!(cs.n_hidden_words(InoutSegment::Public), 8);
 	}
 }

--- a/crates/core/src/constraint_system/system.rs
+++ b/crates/core/src/constraint_system/system.rs
@@ -17,6 +17,24 @@ use crate::{
 	word::Word,
 };
 
+/// Which of the two value-vector segments holds the inout values.
+///
+/// The constants are always public and the private values always hidden, so this is the only
+/// freedom in where the segment boundary falls. A proving protocol picks the placement that suits
+/// how its verifier learns the inout words, and passes it to every accessor that reports a segment
+/// length.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InoutSegment {
+	/// The inout values are public: the verifier knows every one of them, so the reduction reads
+	/// them as shared data and nothing about them is committed.
+	Public,
+	/// The inout values are hidden: they are committed with the private values.
+	///
+	/// This is what a data-parallel protocol needs. Each instance chooses its own inout words, so
+	/// they are not one set of shared values the verifier can evaluate.
+	Hidden,
+}
+
 /// The ConstraintSystem is the core data structure in Binius64 that defines the computational
 /// constraints to be proven in zero-knowledge. It represents a system of equations over 64-bit
 /// words that must be satisfied by a valid values vector [`ValueVec`].
@@ -24,8 +42,11 @@ use crate::{
 /// # Value vector shape
 ///
 /// The constraints reference words of a value vector partitioned into two segments. The public
-/// segment holds the constants and the inout values; the hidden segment holds the private values.
-/// Each group of values is followed by padding, so the value vector runs
+/// segment holds the words the verifier evaluates itself; the hidden segment holds the words the
+/// prover commits. The constants are always public and the private values always hidden; the inout
+/// values sit in whichever segment the proving protocol places them in, which every segment-length
+/// accessor takes as an [`InoutSegment`]. Each group of values is followed by padding, so under
+/// [`InoutSegment::Public`] the value vector runs
 ///
 /// ```text
 /// [ constants | inout | pad ][ private | pad ]
@@ -93,26 +114,36 @@ impl ConstraintSystem {
 		self.n_const() + self.n_inout
 	}
 
-	/// Returns the number of words in the public segment, which is the public values themselves.
-	pub const fn n_public_words(&self) -> usize {
-		self.n_public_values()
+	/// Returns the number of words in the public segment.
+	///
+	/// This is the constants, followed by the inout values when they are placed there.
+	pub const fn n_public_words(&self, inout: InoutSegment) -> usize {
+		match inout {
+			InoutSegment::Public => self.n_public_values(),
+			InoutSegment::Hidden => self.n_const(),
+		}
 	}
 
 	/// Returns the number of word-index variables the public segment spans.
 	///
 	/// The word count need not be a power of two; the reductions read the words past it as zero.
-	pub const fn log_public_words(&self) -> usize {
-		log2_ceil_usize(self.n_public_words())
+	pub const fn log_public_words(&self, inout: InoutSegment) -> usize {
+		log2_ceil_usize(self.n_public_words(inout))
 	}
 
-	/// Returns the number of words in the hidden segment, which is the private values themselves.
-	pub const fn n_hidden_words(&self) -> usize {
-		self.n_private
+	/// Returns the number of words in the hidden segment.
+	///
+	/// This is the private values, preceded by the inout values when they are placed there.
+	pub const fn n_hidden_words(&self, inout: InoutSegment) -> usize {
+		match inout {
+			InoutSegment::Public => self.n_private,
+			InoutSegment::Hidden => self.n_inout + self.n_private,
+		}
 	}
 
 	/// Returns the number of word-index variables the hidden segment spans.
-	pub const fn log_witness_words(&self) -> usize {
-		log2_ceil_usize(self.n_hidden_words())
+	pub const fn log_witness_words(&self, inout: InoutSegment) -> usize {
+		log2_ceil_usize(self.n_hidden_words(inout))
 	}
 
 	/// Returns the number of word-index variables the shift reduction runs over.
@@ -120,11 +151,11 @@ impl ConstraintSystem {
 	/// The reduction addresses both segments with one set of word-index challenges, so it needs
 	/// as many as the wider of the two spans. The narrower segment reads the extra coordinates as
 	/// zero.
-	pub const fn log_segment_words(&self) -> usize {
-		if self.log_public_words() > self.log_witness_words() {
-			self.log_public_words()
+	pub const fn log_segment_words(&self, inout: InoutSegment) -> usize {
+		if self.log_public_words(inout) > self.log_witness_words(inout) {
+			self.log_public_words(inout)
 		} else {
-			self.log_witness_words()
+			self.log_witness_words(inout)
 		}
 	}
 
@@ -143,15 +174,16 @@ impl ConstraintSystem {
 
 	/// Returns the position of the word a [`ValueIndex`] names within the value vector.
 	///
-	/// This is the address the proving protocol reads the word at: the public segment occupies
-	/// the low positions and the hidden segment follows it. Scratch words are not part of a
+	/// This is the address the proving protocol reads the word at: the constants, then the inout
+	/// values, then the private ones. Where the segment boundary falls does not enter, so the
+	/// address is the same under either [`InoutSegment`] placement. Scratch words are not part of a
 	/// constraint system, so a scratch index lands past the last word — [`Self::validate`] rejects
 	/// any constraint naming one.
 	pub const fn word_offset(&self, index: ValueIndex) -> usize {
 		let segment_start = match index.segment() {
 			ValueSegment::Constant => 0,
 			ValueSegment::InOut => self.offset_inout(),
-			ValueSegment::Private => self.n_public_words(),
+			ValueSegment::Private => self.n_public_values(),
 			ValueSegment::Scratch => self.value_vec_len(),
 		};
 		segment_start + index.index() as usize
@@ -419,7 +451,7 @@ impl ConstraintSystem {
 
 	/// The total length of the [`ValueVec`] expected by this constraint system.
 	pub const fn value_vec_len(&self) -> usize {
-		self.n_public_words() + self.n_hidden_words()
+		self.n_public_values() + self.n_private
 	}
 }
 
@@ -665,9 +697,9 @@ mod tests {
 			..test_shape()
 		};
 		// Typical: more private values than public words, rounded up to a power of two.
-		assert_eq!(cs(60).log_witness_words(), 6);
+		assert_eq!(cs(60).log_witness_words(InoutSegment::Public), 6);
 		// Exact power-of-two private count.
-		assert_eq!(cs(32).log_witness_words(), 5);
+		assert_eq!(cs(32).log_witness_words(InoutSegment::Public), 5);
 	}
 
 	#[test]
@@ -676,23 +708,23 @@ mod tests {
 		// hidden words. Neither is padded.
 		let cs = test_shape();
 		assert_eq!(cs.n_public_values(), 5);
-		assert_eq!(cs.n_public_words(), 5);
-		assert_eq!(cs.n_hidden_words(), 6);
+		assert_eq!(cs.n_public_words(InoutSegment::Public), 5);
+		assert_eq!(cs.n_hidden_words(InoutSegment::Public), 6);
 		assert_eq!(cs.value_vec_len(), 11);
 
 		// The spans are the counts rounded up, and the reduction runs over the wider of the two.
-		assert_eq!(cs.log_public_words(), 3);
-		assert_eq!(cs.log_witness_words(), 3);
-		assert_eq!(cs.log_segment_words(), 3);
+		assert_eq!(cs.log_public_words(InoutSegment::Public), 3);
+		assert_eq!(cs.log_witness_words(InoutSegment::Public), 3);
+		assert_eq!(cs.log_segment_words(InoutSegment::Public), 3);
 
 		// A hidden segment wider than the public one sets the span.
 		let wide = ConstraintSystem {
 			n_private: 60,
 			..test_shape()
 		};
-		assert_eq!(wide.log_public_words(), 3);
-		assert_eq!(wide.log_witness_words(), 6);
-		assert_eq!(wide.log_segment_words(), 6);
+		assert_eq!(wide.log_public_words(InoutSegment::Public), 3);
+		assert_eq!(wide.log_witness_words(InoutSegment::Public), 6);
+		assert_eq!(wide.log_segment_words(InoutSegment::Public), 6);
 
 		// And a public segment wider than the hidden one sets it instead — the case the old
 		// hidden-segment padding existed to rule out.
@@ -701,9 +733,24 @@ mod tests {
 			n_private: 4,
 			..test_shape()
 		};
-		assert_eq!(public_heavy.log_public_words(), 8);
-		assert_eq!(public_heavy.log_witness_words(), 2);
-		assert_eq!(public_heavy.log_segment_words(), 8);
+		assert_eq!(public_heavy.log_public_words(InoutSegment::Public), 8);
+		assert_eq!(public_heavy.log_witness_words(InoutSegment::Public), 2);
+		assert_eq!(public_heavy.log_segment_words(InoutSegment::Public), 8);
+	}
+
+	#[test]
+	fn hidden_inout_moves_the_segment_boundary() {
+		// The same shape as above, read with the inout values in the hidden segment: three
+		// constants are the whole public segment, and the two inout values join the six private
+		// ones.
+		let cs = test_shape();
+		assert_eq!(cs.n_public_words(InoutSegment::Hidden), 3);
+		assert_eq!(cs.n_hidden_words(InoutSegment::Hidden), 8);
+
+		// The value vector is the same either way, so the word addresses are too.
+		assert_eq!(cs.value_vec_len(), 11);
+		assert_eq!(cs.word_offset(ValueIndex::inout(0)), 3);
+		assert_eq!(cs.word_offset(ValueIndex::private(0)), 5);
 	}
 
 	#[test]

--- a/crates/examples/src/cli.rs
+++ b/crates/examples/src/cli.rs
@@ -822,7 +822,10 @@ where
 		// Save KeyCollection if requested
 		if let Some(path) = key_collection_path.as_deref() {
 			let key_collection_scope = tracing::info_span!("Building key collection").entered();
-			let key_collection = binius_prover::protocols::shift::build_key_collection(cs);
+			let key_collection = binius_prover::protocols::shift::build_key_collection(
+				cs,
+				binius_core::constraint_system::InoutSegment::Public,
+			);
 			drop(key_collection_scope);
 			write_serialized(&key_collection, path)?;
 			tracing::info!("Key collection saved to '{}'", path);

--- a/crates/frontend/src/compiler/value_vec_alloc.rs
+++ b/crates/frontend/src/compiler/value_vec_alloc.rs
@@ -134,6 +134,8 @@ impl Alloc {
 
 #[cfg(test)]
 mod tests {
+	use binius_core::InoutSegment;
+
 	use super::*;
 
 	#[test]
@@ -237,6 +239,6 @@ mod tests {
 		let cs = assignment
 			.value_vec_layout
 			.constraint_system_shape(assignment.constants.clone());
-		assert_eq!(cs.n_public_words(), 1);
+		assert_eq!(cs.n_public_words(InoutSegment::Public), 1);
 	}
 }

--- a/crates/frontend/src/stat.rs
+++ b/crates/frontend/src/stat.rs
@@ -5,7 +5,7 @@
 
 use std::fmt;
 
-use binius_core::{ConstraintSystem, Operand, ShiftedValueIndex};
+use binius_core::{ConstraintSystem, InoutSegment, Operand, ShiftedValueIndex};
 use itertools::chain;
 use rustc_hash::FxHashSet;
 
@@ -112,7 +112,7 @@ impl CircuitStat {
 		let n_inout = layout.n_inout;
 		// The prover commits only the hidden segment, zero-extended to the word-index space the
 		// shift reduction runs over. That padding is the one the circuit author can still fill.
-		let committed_allocated = 1 << cs.log_segment_words();
+		let committed_allocated = 1 << cs.log_segment_words(InoutSegment::Public);
 
 		Self {
 			n_gates: circuit.n_gates(),

--- a/crates/m4-prover/benches/blake3_compressions.rs
+++ b/crates/m4-prover/benches/blake3_compressions.rs
@@ -56,7 +56,6 @@ struct Blake3Inputs {
 /// Builds a circuit for one two-lane BLAKE3 compression and force-commits its output.
 ///
 /// Force-committing the output keeps the compression alive under dead-code elimination.
-/// The circuit has no inout wires, as the batch witness table requires.
 fn build_blake3_circuit() -> (Circuit, Blake3Inputs) {
 	let builder = CircuitBuilder::new();
 

--- a/crates/m4-prover/benches/sha256_compressions.rs
+++ b/crates/m4-prover/benches/sha256_compressions.rs
@@ -47,7 +47,6 @@ struct Sha256Inputs {
 /// Builds a circuit for one two-lane SHA-256 compression and force-commits its output.
 ///
 /// Force-committing the output keeps the compression alive under dead-code elimination.
-/// The circuit has no inout wires, as the batch witness table requires.
 fn build_sha256_circuit() -> (Circuit, Sha256Inputs) {
 	let builder = CircuitBuilder::new();
 

--- a/crates/m4-prover/benches/utils/m4_bench.rs
+++ b/crates/m4-prover/benches/utils/m4_bench.rs
@@ -28,7 +28,7 @@ use criterion::{BenchmarkId, Criterion, Throughput};
 ///
 /// - `c`: the Criterion harness.
 /// - `group_name`: the benchmark group name.
-/// - `circuit`: the single-instance circuit; it must have no inout wires.
+/// - `circuit`: the single-instance circuit.
 /// - `log_instances`: base-2 logarithm of the instance count.
 /// - `log_inv_rate`: base-2 logarithm of the inverse Reed-Solomon rate.
 /// - `elements_per_instance`: primitives computed by one instance, used only for the throughput
@@ -37,7 +37,7 @@ use criterion::{BenchmarkId, Criterion, Throughput};
 ///
 /// # Panics
 ///
-/// Panics if the circuit has inout wires or IMUL constraints.
+/// Panics if the circuit has IMUL constraints.
 /// Panics if the correctness gate fails to verify.
 pub fn bench_m4_proving<F>(
 	c: &mut Criterion,

--- a/crates/m4-prover/src/prove.rs
+++ b/crates/m4-prover/src/prove.rs
@@ -295,21 +295,11 @@ impl IOPProver {
 			FoldedWitness::<B128, _>::fold_instances(table, &r_rho, alloc)
 		};
 
-		// The public segment is the shared constants, padded with zeros to the layout's
-		// power-of-two word count.
-		// The shift folds it against the monster's public part, which is sized to that padded
-		// count. The padding makes the two lengths agree, and matches the zeros the verifier
-		// assumes.
-		let n_public_words = cs.n_public_words(InoutSegment::Public);
-		// Growing a pooled buffer past the block it was handed would reallocate and free that block
-		// at the element's alignment rather than the pool's, so the fill below must fit exactly.
-		assert!(
-			cs.constants.len() <= n_public_words,
-			"the public segment is padded to at least the constant count"
-		);
-		let mut public_words = alloc.alloc::<Word>(n_public_words);
+		// The public segment is the shared constants alone: the inout values are committed, so
+		// nothing else is public. The shift folds it against the monster's public part, which is
+		// sized to the same count.
+		let mut public_words = alloc.alloc::<Word>(cs.constants.len());
 		public_words.extend_from_slice(&cs.constants);
-		public_words.resize(n_public_words, Word::ZERO);
 
 		// Reduce the operand claims to one witness evaluation.
 		let witness_claim = {
@@ -392,7 +382,7 @@ where
 
 		// Build the shift keys once from the shared constraint system.
 		let key_collection =
-			build_key_collection(verifier.constraint_system(), InoutSegment::Public);
+			build_key_collection(verifier.constraint_system(), InoutSegment::Hidden);
 
 		let iop_prover = IOPProver::new(verifier.iop_verifier().clone(), key_collection);
 
@@ -993,6 +983,68 @@ mod tests {
 			.expect("no trailing proof data");
 	}
 
+	// A circuit declaring inout wires round-trips through the whole protocol.
+	//
+	// The inout values are committed with the private ones, so they lead the hidden segment and the
+	// public segment is the constants alone. That moves the boundary the shift reduction splits at,
+	// which every stage below it must agree on: the key collection, the word-index tensor, the
+	// committed shape, and the trace point the ring-switch opens at.
+	//
+	// Fixture: a per-instance public input and output either side of a private computation, over
+	// 2^6 instances. A constant keeps the public segment non-empty, so both halves carry words.
+	#[test]
+	fn protocol_round_trips_with_inout_wires() {
+		let builder = CircuitBuilder::new();
+		let input = builder.add_inout();
+		let output = builder.add_inout();
+		let secret = builder.add_witness();
+		let k = builder.add_constant_64(0x0123_4567_89ab_cdef);
+		// output == (input & secret) ^ k, so both inout wires are read by real constraints.
+		let masked = builder.band(input, secret);
+		builder.assert_eq("output", output, builder.bxor(masked, k));
+		let circuit = builder.build();
+
+		let cs = circuit.constraint_system().clone();
+		cs.validate().unwrap();
+		// Confirm the fixture genuinely exercises the inout path, on both sides of the boundary.
+		assert!(cs.n_inout > 0, "the fixture must declare inout wires");
+		assert!(!cs.constants.is_empty(), "the public segment must hold words of its own");
+
+		// Every instance chooses its own inout words — the reason they cannot be shared public
+		// data.
+		let log_instances = 6;
+		let table = ValueTable::populate(&circuit, log_instances, |i, w| {
+			let mut rng = StdRng::seed_from_u64(i as u64);
+			let input_word = rng.next_u64();
+			let secret_word = rng.next_u64();
+			w[input] = Word(input_word);
+			w[secret] = Word(secret_word);
+			w[output] = Word((input_word & secret_word) ^ 0x0123_4567_89ab_cdef);
+		})
+		.unwrap();
+
+		// The committed segment covers the inout words as well as the private ones.
+		assert_eq!(
+			table.n_hidden_words(),
+			cs.n_hidden_words(InoutSegment::Hidden),
+			"the table commits the inout values with the private ones"
+		);
+
+		let verifier = Verifier::setup(&cs, log_instances, 1);
+		let prover = Prover::<P>::setup(&verifier);
+
+		let mut prover_transcript = ProverTranscript::new(StdChallenger::default());
+		prover.prove(&table, &mut prover_transcript);
+
+		let mut verifier_transcript = prover_transcript.into_verifier();
+		verifier
+			.verify(&mut verifier_transcript)
+			.expect("a faithful proof verifies");
+		verifier_transcript
+			.finalize()
+			.expect("no trailing proof data");
+	}
+
 	// A circuit whose constant count is not a power of two proves and verifies: the shift evaluates
 	// the constants over the layout's power-of-two word count, treating the words past the constant
 	// count as zero, so no caller padding is needed.
@@ -1010,7 +1062,7 @@ mod tests {
 		let counter = builder.add_witness();
 		let block_len = builder.add_witness();
 		let flags = builder.add_witness();
-		// Force-commit the output so the circuit has no inout wires.
+		// Force-commit the output so dead-code elimination keeps the compression.
 		let out = blake3_compress(&builder, cv, block, counter, block_len, flags);
 		for wire in out {
 			builder.force_commit(wire);

--- a/crates/m4-prover/src/prove.rs
+++ b/crates/m4-prover/src/prove.rs
@@ -2,7 +2,10 @@
 // Copyright 2026 The Binius Developers
 
 use binius_compute::{Allocator, BufferPool, VecLike};
-use binius_core::{constraint_system::ConstraintSystem, word::Word};
+use binius_core::{
+	constraint_system::{ConstraintSystem, InoutSegment},
+	word::Word,
+};
 use binius_field::{AESTowerField8b as B8, Field, PackedField};
 use binius_hash::StdHashSuite;
 use binius_iop_prover::{basefold::compiler::BaseFoldProverCompiler, channel::IOPProverChannel};
@@ -297,7 +300,7 @@ impl IOPProver {
 		// The shift folds it against the monster's public part, which is sized to that padded
 		// count. The padding makes the two lengths agree, and matches the zeros the verifier
 		// assumes.
-		let n_public_words = cs.n_public_words();
+		let n_public_words = cs.n_public_words(InoutSegment::Public);
 		// Growing a pooled buffer past the block it was handed would reallocate and free that block
 		// at the element's alignment rather than the pool's, so the fill below must fit exactly.
 		assert!(
@@ -388,7 +391,8 @@ where
 			BaseFoldProverCompiler::from_verifier_compiler(verifier.iop_compiler(), ntt);
 
 		// Build the shift keys once from the shared constraint system.
-		let key_collection = build_key_collection(verifier.constraint_system());
+		let key_collection =
+			build_key_collection(verifier.constraint_system(), InoutSegment::Public);
 
 		let iop_prover = IOPProver::new(verifier.iop_verifier().clone(), key_collection);
 

--- a/crates/m4-prover/src/shift.rs
+++ b/crates/m4-prover/src/shift.rs
@@ -303,7 +303,7 @@ mod tests {
 
 		let cs = c.circuit.constraint_system().clone();
 		cs.validate().unwrap();
-		let key_collection = build_key_collection(&cs, InoutSegment::Public);
+		let key_collection = build_key_collection(&cs, InoutSegment::Hidden);
 
 		// The univariate bit challenge, the constraint challenge, and the instance challenge.
 		let domain_subspace =
@@ -320,7 +320,6 @@ mod tests {
 		// public constants.
 		let folded_witness =
 			FoldedWitness::<B128, _>::fold_instances(&table, &r_rho, &GlobalAllocator);
-		let _offset = table.layout().offset_witness();
 		let public_words = &cs.constants;
 
 		// The bitand operand evals at (r_z, r_x, r_rho); the circuit has no IMUL constraints, so
@@ -369,7 +368,7 @@ mod tests {
 		let verifier_bmul = VerifierOperatorData::new(Vec::new(), [B128::ZERO; 6]);
 		let verifier_output = verify(
 			&cs,
-			InoutSegment::Public,
+			InoutSegment::Hidden,
 			&verifier_zero,
 			&verifier_bitand,
 			&verifier_intmul,
@@ -379,7 +378,7 @@ mod tests {
 		.unwrap();
 		check_eval(
 			&cs,
-			InoutSegment::Public,
+			InoutSegment::Hidden,
 			public_words,
 			&verifier_zero,
 			&verifier_bitand,
@@ -439,7 +438,7 @@ mod tests {
 
 		let cs = c.circuit.constraint_system().clone();
 		cs.validate().unwrap();
-		let key_collection = build_key_collection(&cs, InoutSegment::Public);
+		let key_collection = build_key_collection(&cs, InoutSegment::Hidden);
 
 		// The univariate bit challenge, the constraint challenge, and the instance challenge.
 		let domain_subspace =
@@ -459,11 +458,10 @@ mod tests {
 			&r_x,
 			&r_rho,
 		);
-		// The private values span value indices `[offset_witness, combined_len)`. The committed
-		// rows can run past them into the protocol's zero padding, which this fixture has none of.
-		let offset = table.layout().offset_witness();
+		// The hidden segment spans value indices `[offset_inout, combined_len)`.
+		let offset = table.layout().offset_inout();
 		let combined = table.layout().combined_len();
-		assert_eq!(table.n_hidden_words(), combined - offset, "fixture must have no padding");
+		assert_eq!(table.n_hidden_words(), combined - offset);
 		let public_words = &cs.constants;
 		let hidden_folded = fold_words_over_instances(&table, constants, &r_rho, offset..combined);
 

--- a/crates/m4-prover/src/shift.rs
+++ b/crates/m4-prover/src/shift.rs
@@ -201,7 +201,10 @@ mod tests {
 	use std::iter;
 
 	use binius_compute::GlobalAllocator;
-	use binius_core::{constraint_system::AndConstraint, word::Word};
+	use binius_core::{
+		constraint_system::{AndConstraint, InoutSegment},
+		word::Word,
+	};
 	use binius_field::{AESTowerField8b, Field, PackedBinaryGhash1x128b, Random};
 	use binius_math::{
 		inner_product::inner_product_buffers,
@@ -300,7 +303,7 @@ mod tests {
 
 		let cs = c.circuit.constraint_system().clone();
 		cs.validate().unwrap();
-		let key_collection = build_key_collection(&cs);
+		let key_collection = build_key_collection(&cs, InoutSegment::Public);
 
 		// The univariate bit challenge, the constraint challenge, and the instance challenge.
 		let domain_subspace =
@@ -366,6 +369,7 @@ mod tests {
 		let verifier_bmul = VerifierOperatorData::new(Vec::new(), [B128::ZERO; 6]);
 		let verifier_output = verify(
 			&cs,
+			InoutSegment::Public,
 			&verifier_zero,
 			&verifier_bitand,
 			&verifier_intmul,
@@ -375,6 +379,7 @@ mod tests {
 		.unwrap();
 		check_eval(
 			&cs,
+			InoutSegment::Public,
 			public_words,
 			&verifier_zero,
 			&verifier_bitand,
@@ -434,7 +439,7 @@ mod tests {
 
 		let cs = c.circuit.constraint_system().clone();
 		cs.validate().unwrap();
-		let key_collection = build_key_collection(&cs);
+		let key_collection = build_key_collection(&cs, InoutSegment::Public);
 
 		// The univariate bit challenge, the constraint challenge, and the instance challenge.
 		let domain_subspace =

--- a/crates/m4-prover/src/test_utils.rs
+++ b/crates/m4-prover/src/test_utils.rs
@@ -111,7 +111,6 @@ pub fn crc64_circuit() -> Crc64Circuit {
 /// The instance count is the number of tuples, which must be a power of two.
 /// Each instance's four message words are the corresponding tuple.
 /// Circuit evaluation derives the rest.
-/// The circuit has no inout wires, so it is admissible in the wire-major table.
 pub fn populate_crc64_witness(c: &Crc64Circuit, inputs: &[[u64; N_INPUT_WORDS]]) -> ValueTable {
 	let log_instances = inputs.len().ilog2() as usize;
 	ValueTable::populate(&c.circuit, log_instances, |i, filler| {

--- a/crates/m4-prover/src/value_table.rs
+++ b/crates/m4-prover/src/value_table.rs
@@ -4,7 +4,7 @@ use std::ops::{Index, IndexMut};
 
 use binius_compute::Allocator;
 use binius_core::{
-	constraint_system::{ValueIndex, ValueVec, ValueVecLayout},
+	constraint_system::{InoutSegment, ValueIndex, ValueVec, ValueVecLayout},
 	word::Word,
 };
 use binius_field::PackedField;
@@ -210,7 +210,7 @@ impl ValueTable {
 		// past it stay zero.
 		let start = layout.offset_witness() << log_instances;
 		let end = layout.combined_len() << log_instances;
-		let n_hidden_words = circuit.constraint_system().n_hidden_words();
+		let n_hidden_words = circuit.constraint_system().n_hidden_words(InoutSegment::Public);
 		let mut data = vec![Word::ZERO; n_hidden_words << log_instances];
 		data[..end - start].copy_from_slice(&working[start..end]);
 
@@ -405,7 +405,7 @@ mod tests {
 		let layout = c.circuit.value_vec_layout();
 		assert_eq!(table.log_instances(), log_instances);
 		assert_eq!(table.n_instances(), 8);
-		let n_hidden_words = c.circuit.constraint_system().n_hidden_words();
+		let n_hidden_words = c.circuit.constraint_system().n_hidden_words(InoutSegment::Public);
 		assert_eq!(table.n_hidden_words(), n_hidden_words);
 		assert_eq!(table.as_words().len(), n_hidden_words * 8);
 		// The committed rows start with the private values the layout stores.
@@ -635,7 +635,7 @@ mod tests {
 		let constants = &c.circuit.constraint_system().constants;
 
 		// Shape: 2^10 instances, one hidden-word row per committed word.
-		let n_hidden_words = c.circuit.constraint_system().n_hidden_words();
+		let n_hidden_words = c.circuit.constraint_system().n_hidden_words(InoutSegment::Public);
 		assert_eq!(table.log_instances(), log_instances);
 		assert_eq!(table.n_instances(), n_instances);
 		assert_eq!(table.n_hidden_words(), n_hidden_words);

--- a/crates/m4-prover/src/value_table.rs
+++ b/crates/m4-prover/src/value_table.rs
@@ -4,7 +4,7 @@ use std::ops::{Index, IndexMut};
 
 use binius_compute::Allocator;
 use binius_core::{
-	constraint_system::{InoutSegment, ValueIndex, ValueVec, ValueVecLayout},
+	constraint_system::{ValueIndex, ValueVec, ValueVecLayout},
 	word::Word,
 };
 use binius_field::PackedField;
@@ -31,20 +31,24 @@ const DEFAULT_PARALLEL_STRIPE_WIDTH: usize = 1024;
 /// Each row is one wire and each column is one instance.
 /// So a batched interpreter can advance every instance of a wire in a single pass.
 ///
-/// This table is specialized for the M4 accelerator setting.
-/// A circuit plugs into a larger system rather than exposing public inputs and outputs:
+/// This table is specialized for the M4 accelerator setting, where the value vector splits with
+/// the inout values on the hidden side
+/// ([`InoutSegment::Hidden`](binius_core::constraint_system::InoutSegment::Hidden)):
 ///
-/// 1. **No inout wires.** The circuit's [`ValueVecLayout`] must have `n_inout == 0`. Output wires
-///    are kept alive with
-///    [`CircuitBuilder::force_commit`](binius_frontend::CircuitBuilder::force_commit) so that
-///    dead-code elimination does not drop the circuit. Inout wires are inappropriate here, so
-///    [`Self::populate`] rejects them.
+/// 1. **Inout wires are committed.** Every instance chooses its own inout words, so they are not
+///    one set of shared values a verifier can evaluate. They are committed with the private values
+///    instead, at the front of the hidden segment. A circuit is free to declare them, and
+///    [`Self::populate`] takes their values from the same filler as the witness inputs.
 /// 2. **Constants are not stored.** The constants live once on the constraint system as a
-///    `Vec<Word>`, not replicated per instance. Only the hidden segment — the witness and internal
-///    words — is stored here. Witness generation reads the constants from that separate bank.
+///    `Vec<Word>`, not replicated per instance. Only the hidden segment — the inout, witness and
+///    internal words — is stored here. Witness generation reads the constants from that separate
+///    bank.
 ///
 /// So the stored data holds exactly the hidden segment of every instance: `n_hidden_words` rows by
 /// `2^log_instances` columns.
+///
+/// The committed inout words are not tied to any value the verifier knows, so the statement a
+/// proof over this table makes is that *some* inout values complete every instance.
 #[derive(Clone, Debug)]
 pub struct ValueTable {
 	/// The per-instance value layout, shared by every instance in the batch.
@@ -53,36 +57,30 @@ pub struct ValueTable {
 	log_instances: usize,
 	/// The number of hidden-word rows the proving protocol commits per instance.
 	///
-	/// The layout stores the private values back to back, but the shift reduction addresses the
-	/// hidden segment with the same word-index challenges as the public one, so it needs at least
-	/// the public segment's width. This is
-	/// [`ConstraintSystem::n_hidden_words`](binius_core::ConstraintSystem::n_hidden_words) of the
-	/// circuit's system, and the rows past the private values are the zero padding it implies.
+	/// This is the inout values followed by the private ones, which is
+	/// [`ConstraintSystem::n_hidden_words`](binius_core::ConstraintSystem::n_hidden_words) under
+	/// [`InoutSegment::Hidden`](binius_core::constraint_system::InoutSegment::Hidden).
 	n_hidden_words: usize,
 	/// The hidden words of every wire, in wire-major order.
 	///
 	/// Row `r` (for `r` in `0..n_hidden_words`) holds the `2^log_instances` values of hidden wire
-	/// `r` — private value `r` — one per instance. The rows are laid out contiguously, so the
-	/// length is `n_hidden_words << log_instances`.
+	/// `r` — inout value `r`, then private value `r - n_inout` — one per instance. The rows are
+	/// laid out contiguously, so the length is `n_hidden_words << log_instances`.
 	data: Vec<Word>,
 }
 
 impl ValueTable {
 	/// Builds the batch witness in wire-major order, populating all `2^log_instances` instances.
 	///
-	/// The instances are independent. For each, `fill` sets the witness input wires; the batched
+	/// The instances are independent. For each, `fill` sets the input wires; the batched
 	/// interpreter then derives every remaining wire, filling all instances of one wire at a time.
 	///
 	/// # Arguments
 	///
-	/// - `circuit`: the single-instance circuit. Its layout must have no inout wires.
+	/// - `circuit`: the single-instance circuit.
 	/// - `log_instances`: base-2 logarithm of the instance count.
-	/// - `fill`: sets the witness input wires of instance `i`, for `i` in `0..2^log_instances`. It
-	///   must assign every witness input on each call.
-	///
-	/// # Panics
-	///
-	/// Panics if the circuit's layout has any inout wires (`n_inout != 0`).
+	/// - `fill`: sets the input wires of instance `i`, for `i` in `0..2^log_instances`. It must
+	///   assign every witness input and every inout wire on each call.
 	///
 	/// # Errors
 	///
@@ -107,10 +105,6 @@ impl ValueTable {
 	///
 	/// Returns an error naming a failing instance whose inputs do not satisfy the circuit. The
 	/// reported instance is not guaranteed to be the lowest failing instance across all stripes.
-	///
-	/// # Panics
-	///
-	/// Panics if the circuit's layout has any inout wires.
 	pub fn populate_parallel<F>(
 		circuit: &Circuit,
 		log_instances: usize,
@@ -139,7 +133,7 @@ impl ValueTable {
 	///
 	/// # Panics
 	///
-	/// Panics if `stripe_width == 0` or if the circuit's layout has any inout wires.
+	/// Panics if `stripe_width == 0`.
 	pub fn populate_parallel_with_stripe_width<F>(
 		circuit: &Circuit,
 		log_instances: usize,
@@ -163,12 +157,6 @@ impl ValueTable {
 		F: Fn(usize, &mut BatchWitnessFiller<'_, '_>),
 	{
 		let layout = circuit.value_vec_layout().clone();
-		assert_eq!(
-			layout.n_inout, 0,
-			"ValueTable requires a constraint system with no inout wires; \
-			 use force_commit on output wires instead"
-		);
-
 		let n_instances = 1usize << log_instances;
 
 		// The transient working buffer spans the full value vector — constants, inputs, internal
@@ -201,23 +189,17 @@ impl ValueTable {
 			}
 		}
 
-		// Keep only the private values: rows `[offset_witness, combined_len)`. In the wire-major
-		// working buffer these rows are contiguous, so this is a single slice of the words. The
-		// constants and scratch are dropped.
-		//
-		// The committed segment is wider than the private values whenever the public segment is,
-		// so the copy lands at the front of a zeroed buffer of the committed width and the rows
-		// past it stay zero.
-		let start = layout.offset_witness() << log_instances;
+		// Keep the hidden segment: rows `[offset_inout, combined_len)`, the inout values followed
+		// by the private ones. In the wire-major working buffer these rows are contiguous, so
+		// this is a single slice of the words. The constants and scratch are dropped.
+		let start = layout.offset_inout() << log_instances;
 		let end = layout.combined_len() << log_instances;
-		let n_hidden_words = circuit.constraint_system().n_hidden_words(InoutSegment::Public);
-		let mut data = vec![Word::ZERO; n_hidden_words << log_instances];
-		data[..end - start].copy_from_slice(&working[start..end]);
+		let data = working[start..end].to_vec();
 
 		Ok(Self {
+			n_hidden_words: layout.combined_len() - layout.offset_inout(),
 			layout,
 			log_instances,
-			n_hidden_words,
 			data,
 		})
 	}
@@ -268,17 +250,16 @@ impl ValueTable {
 			"constants length must match the layout's constant count"
 		);
 
-		// The public segment holds the constants at the front; the rest of it is the zero
-		// padding a fresh value vector already carries. There are no inout wires.
+		// The constants are the whole public segment; the table stores everything after them.
 		let mut values = ValueVec::new(&self.layout);
 		for (i, &constant) in constants.iter().enumerate() {
 			values[ValueIndex::constant(i as u32)] = constant;
 		}
 
-		// Gather this instance's column of private values across every row. The stored rows run
-		// past them into the protocol's padding, which the value vector does not hold.
-		for row in 0..self.layout.n_private() {
-			*values.word_mut((self.layout.offset_witness() + row) as u32) =
+		// Gather this instance's column of hidden values across every row, which the value vector
+		// holds from the first inout word onwards.
+		for row in 0..self.n_hidden_words {
+			*values.word_mut((self.layout.offset_inout() + row) as u32) =
 				self.data[(row << self.log_instances) + instance];
 		}
 
@@ -341,6 +322,7 @@ impl IndexMut<Wire> for BatchWitnessFiller<'_, '_> {
 #[cfg(test)]
 mod tests {
 	use binius_compute::GlobalAllocator;
+	use binius_core::constraint_system::InoutSegment;
 	use binius_field::PackedBinaryGhash1x128b;
 	use binius_frontend::{AssertionFailure, CircuitBuilder, Wire};
 	use proptest::prelude::*;
@@ -405,11 +387,14 @@ mod tests {
 		let layout = c.circuit.value_vec_layout();
 		assert_eq!(table.log_instances(), log_instances);
 		assert_eq!(table.n_instances(), 8);
-		let n_hidden_words = c.circuit.constraint_system().n_hidden_words(InoutSegment::Public);
+		let n_hidden_words = c
+			.circuit
+			.constraint_system()
+			.n_hidden_words(InoutSegment::Hidden);
 		assert_eq!(table.n_hidden_words(), n_hidden_words);
 		assert_eq!(table.as_words().len(), n_hidden_words * 8);
-		// The committed rows start with the private values the layout stores.
-		assert!(n_hidden_words >= layout.n_private());
+		// The committed rows are the inout values the layout stores, then the private ones.
+		assert_eq!(n_hidden_words, layout.n_inout + layout.n_private());
 	}
 
 	#[test]
@@ -597,20 +582,50 @@ mod tests {
 		);
 	}
 
+	// Inout wires are committed, so they lead the stored rows: row `i` is inout value `i`, and the
+	// private values follow. Each instance carries its own inout words.
 	#[test]
-	#[should_panic(expected = "no inout wires")]
-	fn rejects_circuits_with_inout_wires() {
+	fn inout_wires_lead_the_committed_rows() {
 		let builder = CircuitBuilder::new();
 		let a = builder.add_inout();
-		let b = builder.add_witness();
+		let b = builder.add_inout();
+		let w = builder.add_witness();
 		let and = builder.band(a, b);
 		builder.force_commit(and);
+		builder.force_commit(builder.bxor(and, w));
 		let circuit = builder.build();
 
-		let _ = ValueTable::populate(&circuit, 1, |_, w| {
-			w[a] = Word(1);
-			w[b] = Word(1);
-		});
+		let log_instances = 2;
+		let table = ValueTable::populate(&circuit, log_instances, |i, f| {
+			f[a] = Word(i as u64);
+			f[b] = Word(i as u64 + 0x100);
+			f[w] = Word(i as u64 ^ 0xbeef);
+		})
+		.unwrap();
+
+		// Two inout values ahead of the private ones, all of them committed.
+		let layout = circuit.value_vec_layout();
+		assert_eq!(layout.n_inout, 2);
+		assert_eq!(table.n_hidden_words(), 2 + layout.n_private());
+
+		// The inout rows hold what the filler assigned, one column per instance.
+		let inout_row =
+			|row: usize| &table.as_words()[row << log_instances..(row + 1) << log_instances];
+		assert_eq!(inout_row(0), [Word(0), Word(1), Word(2), Word(3)]);
+		assert_eq!(inout_row(1), [Word(0x100), Word(0x101), Word(0x102), Word(0x103)]);
+
+		// And each instance reconstructs to a witness the constraint system accepts, inout
+		// values included.
+		let constants = &circuit.constraint_system().constants;
+		for i in 0..table.n_instances() {
+			let vv = table.instance_value_vec(i, constants);
+			assert_eq!(vv[circuit.witness_index(a)], Word(i as u64));
+			assert_eq!(vv[circuit.witness_index(b)], Word(i as u64 + 0x100));
+			circuit
+				.constraint_system()
+				.verify(&vv)
+				.unwrap_or_else(|e| panic!("instance {i} failed verification: {e}"));
+		}
 	}
 
 	// A large batch of independent random instances populates to the documented shape.
@@ -635,7 +650,10 @@ mod tests {
 		let constants = &c.circuit.constraint_system().constants;
 
 		// Shape: 2^10 instances, one hidden-word row per committed word.
-		let n_hidden_words = c.circuit.constraint_system().n_hidden_words(InoutSegment::Public);
+		let n_hidden_words = c
+			.circuit
+			.constraint_system()
+			.n_hidden_words(InoutSegment::Hidden);
 		assert_eq!(table.log_instances(), log_instances);
 		assert_eq!(table.n_instances(), n_instances);
 		assert_eq!(table.n_hidden_words(), n_hidden_words);

--- a/crates/m4-prover/src/witness/instance_fold.rs
+++ b/crates/m4-prover/src/witness/instance_fold.rs
@@ -272,17 +272,11 @@ mod tests {
 			let table = populate_crc64_witness(&c, &inputs);
 			let constants = &c.circuit.constraint_system().constants;
 
-			// The committed segment runs from the witness offset to the end of the value vector.
+			// The committed segment runs from the inout offset to the end of the value vector.
 			// Its length fixes the width of the word axis.
-			// The committed rows can run past the private values into the protocol's zero padding,
-			// which these fixtures have none of.
-			let offset = table.layout().offset_witness();
+			let offset = table.layout().offset_inout();
 			let n_committed = table.n_hidden_words();
-			assert_eq!(
-				n_committed,
-				table.layout().combined_len() - offset,
-				"fixture must have no padding"
-			);
+			assert_eq!(n_committed, table.layout().combined_len() - offset);
 			let log_committed = checked_log_2(n_committed);
 
 			// The instance-fold point, and a fresh point over the (bit, word) axes.

--- a/crates/m4-prover/src/witness/operand_columns.rs
+++ b/crates/m4-prover/src/witness/operand_columns.rs
@@ -251,20 +251,23 @@ impl<A: Allocator> OperandColumns<A, 2> {
 ///
 /// # Overview
 ///
-/// A value index splits at the witness offset:
+/// A value index splits at the inout offset:
 ///
-/// - below it, a public word: the same constant in every instance;
+/// - below it, a constant: the same word in every instance;
 /// - at or above it, a hidden word: one per instance, read from the table.
 ///
-/// Both banks are carried here, together with the offset that separates them.
+/// Both banks are carried here, together with the inout count that positions the private rows
+/// behind the inout ones.
 ///
 /// So a term resolves without its caller re-deriving that split at each use.
 #[derive(Clone, Copy)]
 struct ValueWords<'a> {
 	/// The circuit's constant words, shared by every instance.
 	constants: &'a [Word],
-	/// Every instance's hidden words, wire-major.
+	/// Every instance's hidden words, wire-major: the inout rows, then the private ones.
 	hidden: &'a [Word],
+	/// The number of inout values, which is where the private rows start.
+	n_inout: usize,
 	/// The base-2 logarithm of the instance count, which is one hidden row's stride.
 	log_instances: usize,
 }
@@ -292,6 +295,7 @@ impl<'a> ValueWords<'a> {
 		Self {
 			constants,
 			hidden: table.as_words(),
+			n_inout: table.layout().n_inout,
 			log_instances: table.log_instances(),
 		}
 	}
@@ -437,15 +441,14 @@ impl<'a> ValueWords<'a> {
 				let constant = self.constants[value_index.index() as usize];
 				return TermWords::Splat(variant.apply(constant, amount as usize));
 			}
-			// A private index names one wire, whose instances are one contiguous row.
-			ValueSegment::Private => value_index.index() as usize,
-			// An inout value is public but chosen per instance, so it would need a bank of its
-			// own rather than one shared word; `ValueTable` rejects a circuit that declares any.
+			// An inout or private index names one wire, whose instances are one contiguous row.
+			// The table stores the hidden segment, so the inout rows lead and the private ones
+			// follow them.
+			ValueSegment::InOut => value_index.index() as usize,
+			ValueSegment::Private => self.n_inout + value_index.index() as usize,
 			// A scratch word is never committed, and `ConstraintSystem::validate` rejects an
 			// operand naming one.
-			segment @ (ValueSegment::InOut | ValueSegment::Scratch) => {
-				panic!("a batched constraint system has no {segment:?} values")
-			}
+			ValueSegment::Scratch => panic!("a constraint system has no Scratch values"),
 		};
 		let row = &self.hidden
 			[(row_index << self.log_instances)..((row_index + 1) << self.log_instances)];
@@ -658,7 +661,7 @@ mod tests {
 
 	// A circuit asserting `z == (x & y) ^ w`, over four witness words.
 	//
-	//     inputs : x, y, w, z   (all witness — the wire-major table admits no inout)
+	//     inputs : x, y, w, z   (all witness wires)
 	//     gate   : and = x & y
 	//     assert : and ^ w == z
 	struct AndCircuit {

--- a/crates/m4-verifier/src/commit.rs
+++ b/crates/m4-verifier/src/commit.rs
@@ -1,6 +1,6 @@
 // Copyright 2025 Irreducible Inc.
 
-use binius_core::constraint_system::ConstraintSystem;
+use binius_core::constraint_system::{ConstraintSystem, InoutSegment};
 use binius_utils::checked_arithmetics::log2_ceil_usize;
 use binius_verifier::config::LOG_WORDS_PER_ELEM;
 
@@ -82,7 +82,7 @@ impl BatchCommitLayout {
 	pub fn for_constraint_system(cs: &ConstraintSystem, log_instances: usize) -> Self {
 		// Only the hidden segment is committed.
 		// The shared constants are known to the verifier, so they stay off the oracle.
-		Self::new(cs.n_hidden_words(), log_instances)
+		Self::new(cs.n_hidden_words(InoutSegment::Public), log_instances)
 	}
 
 	/// The number of hidden-word rows one instance occupies after power-of-two padding.

--- a/crates/m4-verifier/src/commit.rs
+++ b/crates/m4-verifier/src/commit.rs
@@ -80,9 +80,22 @@ impl BatchCommitLayout {
 	/// - `cs`: the single-instance constraint system shared by every instance.
 	/// - `log_instances`: base-2 logarithm of the instance count.
 	pub fn for_constraint_system(cs: &ConstraintSystem, log_instances: usize) -> Self {
-		// Only the hidden segment is committed.
+		// Only the hidden segment is committed, which under M4's split is the inout values
+		// followed by the private ones.
 		// The shared constants are known to the verifier, so they stay off the oracle.
-		Self::new(cs.n_hidden_words(InoutSegment::Public), log_instances)
+		let layout = Self::new(cs.n_hidden_words(InoutSegment::Hidden), log_instances);
+
+		// The shift reduction addresses both segments with one set of word-index challenges, and
+		// the ring-switch opens the trace at those challenges. So the committed rows must span
+		// exactly as many word-index variables as the reduction runs over.
+		assert_eq!(
+			layout.log_hidden_words,
+			cs.log_segment_words(InoutSegment::Hidden),
+			"the committed rows must span the reduction's word-index variables; a public segment \
+			 wider than the hidden one would draw challenges the trace has no coordinates for"
+		);
+
+		layout
 	}
 
 	/// The number of hidden-word rows one instance occupies after power-of-two padding.

--- a/crates/m4-verifier/src/verify.rs
+++ b/crates/m4-verifier/src/verify.rs
@@ -1,7 +1,10 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-use binius_core::{constraint_system::ConstraintSystem, word::Word};
+use binius_core::{
+	constraint_system::{ConstraintSystem, InoutSegment},
+	word::Word,
+};
 use binius_field::{AESTowerField8b as B8, ExtensionField, FieldOps};
 use binius_hash::StdHashSuite;
 use binius_iop::{
@@ -234,13 +237,22 @@ impl IOPVerifier {
 		};
 
 		// Reduce the operand claims to one witness evaluation.
-		let shift = shift::verify::<B128, _>(cs, &zero, &bitand, &intmul, &binmul, channel)?;
+		let shift = shift::verify::<B128, _>(
+			cs,
+			InoutSegment::Public,
+			&zero,
+			&bitand,
+			&intmul,
+			&binmul,
+			channel,
+		)?;
 
 		// Tie in the shared constants through the public-input consistency check.
 		// The shift evaluates them over the layout's power-of-two word count.
 		// Their count need not be a power of two, so they are passed unpadded.
 		shift::check_eval::<B128, _>(
 			cs,
+			InoutSegment::Public,
 			&cs.constants,
 			&zero,
 			&bitand,

--- a/crates/m4-verifier/src/verify.rs
+++ b/crates/m4-verifier/src/verify.rs
@@ -239,7 +239,7 @@ impl IOPVerifier {
 		// Reduce the operand claims to one witness evaluation.
 		let shift = shift::verify::<B128, _>(
 			cs,
-			InoutSegment::Public,
+			InoutSegment::Hidden,
 			&zero,
 			&bitand,
 			&intmul,
@@ -252,7 +252,7 @@ impl IOPVerifier {
 		// Their count need not be a power of two, so they are passed unpadded.
 		shift::check_eval::<B128, _>(
 			cs,
-			InoutSegment::Public,
+			InoutSegment::Hidden,
 			&cs.constants,
 			&zero,
 			&bitand,

--- a/crates/prover/benches/shift_reduction.rs
+++ b/crates/prover/benches/shift_reduction.rs
@@ -5,7 +5,11 @@ use std::iter;
 
 use binius_circuits::sha256::sha256_fixed;
 use binius_compute::{BufferPool, GlobalAllocator};
-use binius_core::{ValueVec, constraint_system::ConstraintSystem, word::Word};
+use binius_core::{
+	ValueVec,
+	constraint_system::{ConstraintSystem, InoutSegment},
+	word::Word,
+};
 use binius_field::{AESTowerField8b, BinaryField128bGhash, Field, Random, arch::OptimalPackedB128};
 use binius_frontend::{CircuitBuilder, Wire};
 use binius_ip::sumcheck::SumcheckOutput;
@@ -119,7 +123,7 @@ fn bench_prove_and_verify(c: &mut Criterion) {
 		let zero_evals = [F::random(&mut rng)];
 		let bitand_evals = [F::random(&mut rng); 3];
 		let intmul_evals = [F::ZERO; 4];
-		let key_collection = build_key_collection(&cs);
+		let key_collection = build_key_collection(&cs, InoutSegment::Public);
 		let subspace = BinarySubspace::<AESTowerField8b>::with_dim(Word::LOG_BITS).isomorphic();
 
 		let mut group = c.benchmark_group(format!(
@@ -214,6 +218,7 @@ fn bench_prove_and_verify(c: &mut Criterion) {
 
 				verify(
 					&cs,
+					InoutSegment::Public,
 					&VerifierOperatorData::new(r_x_prime_zero.clone(), zero_evals),
 					&verifier_bitand_data,
 					&verifier_intmul_data,
@@ -259,7 +264,7 @@ fn bench_shift_phases(c: &mut Criterion) {
 	let bitand_evals = [F::random(&mut rng); 3];
 	let intmul_evals = [F::ZERO; 4];
 
-	let key_collection = build_key_collection(&cs);
+	let key_collection = build_key_collection(&cs, InoutSegment::Public);
 	// The phase functions take each segment as the circuit declares it: `build_g` zips the
 	// words with their key ranges and `fold_words` pads each fold to `log2_ceil(len)` variables.
 	let public_words = value_vec.public();

--- a/crates/prover/src/protocols/shift/key_collection.rs
+++ b/crates/prover/src/protocols/shift/key_collection.rs
@@ -5,7 +5,7 @@ use std::{iter, mem, ops::Range};
 
 use binius_core::{
 	ShiftVariant,
-	constraint_system::{ConstraintSystem, Operand, ShiftedValueIndex},
+	constraint_system::{ConstraintSystem, InoutSegment, Operand, ShiftedValueIndex},
 	word::Word,
 };
 use binius_field::{Field, WideMul};
@@ -412,7 +412,10 @@ fn update_with_constraints<C, const ARITY: usize>(
 }
 
 /// Constructs a `KeyCollection` from a constraint system.
-pub fn build_key_collection(cs: &ConstraintSystem) -> KeyCollection {
+///
+/// `inout` is where the proving protocol places the inout values, which is what the two key
+/// segments split along.
+pub fn build_key_collection(cs: &ConstraintSystem, inout: InoutSegment) -> KeyCollection {
 	// Initialize a temporary list of builder keys lists, one for each committed word.
 	let mut builder_key_lists: Vec<Vec<BuilderKey>> =
 		(0..cs.value_vec_len()).map(|_| Vec::new()).collect();
@@ -430,7 +433,7 @@ pub fn build_key_collection(cs: &ConstraintSystem) -> KeyCollection {
 
 	// Split the builder keys lists at the public segment boundary and build one `KeySegment`
 	// per half.
-	let hidden_lists = builder_key_lists.split_off(cs.n_public_words());
+	let hidden_lists = builder_key_lists.split_off(cs.n_public_words(inout));
 	KeyCollection {
 		public: build_key_segment(builder_key_lists),
 		hidden: build_key_segment(hidden_lists),
@@ -713,7 +716,8 @@ mod tests {
 
 	#[test]
 	fn dense_shift_encoding_covers_the_pairs_its_segment_uses() {
-		let key_collection = build_key_collection(&shifted_constraint_system());
+		let key_collection =
+			build_key_collection(&shifted_constraint_system(), InoutSegment::Public);
 
 		let public_pairs = key_collection
 			.public
@@ -742,7 +746,8 @@ mod tests {
 
 	#[test]
 	fn keys_index_their_segments_dense_encoding() {
-		let key_collection = build_key_collection(&shifted_constraint_system());
+		let key_collection =
+			build_key_collection(&shifted_constraint_system(), InoutSegment::Public);
 
 		// The shifts a word's keys name, as its own segment's encoding decodes them.
 		let word_pairs = |segment: &KeySegment, word: usize| {
@@ -772,7 +777,8 @@ mod tests {
 
 	#[test]
 	fn dense_shift_encoding_survives_serialization() {
-		let key_collection = build_key_collection(&shifted_constraint_system());
+		let key_collection =
+			build_key_collection(&shifted_constraint_system(), InoutSegment::Public);
 
 		let mut buf = Vec::new();
 		key_collection.serialize(&mut buf).unwrap();

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -5,7 +5,7 @@ use std::{marker::PhantomData, mem::MaybeUninit};
 
 use binius_compute::{Allocator, BufferPool, VecLike};
 use binius_core::{
-	constraint_system::{ConstraintSystem, Operand, ValueVec},
+	constraint_system::{ConstraintSystem, InoutSegment, Operand, ValueVec},
 	word::Word,
 };
 use binius_field::{AESTowerField8b as B8, Field, PackedField};
@@ -385,7 +385,8 @@ where
 	///
 	/// See [`Prover`] struct documentation for details.
 	pub fn setup(verifier: Verifier<H>) -> Result<Self, Error> {
-		let key_collection = build_key_collection(verifier.constraint_system());
+		let key_collection =
+			build_key_collection(verifier.constraint_system(), InoutSegment::Public);
 		Self::setup_with_key_collection(verifier, key_collection)
 	}
 
@@ -443,7 +444,7 @@ where
 
 		let _prove_guard = tracing::info_span!(
 			"Prove",
-			n_hidden_words = cs.n_hidden_words(),
+			n_hidden_words = cs.n_hidden_words(InoutSegment::Public),
 			n_bitand = cs.and_constraints.len(),
 			n_intmul = cs.imul_constraints.len(),
 		)

--- a/crates/prover/src/zk_config.rs
+++ b/crates/prover/src/zk_config.rs
@@ -9,7 +9,7 @@
 use std::{marker::PhantomData, sync::Arc};
 
 use binius_compute::BufferPool;
-use binius_core::constraint_system::{ConstraintSystem, ValueVec};
+use binius_core::constraint_system::{ConstraintSystem, InoutSegment, ValueVec};
 use binius_field::{BinaryField128bGhash as B128, PackedField};
 use binius_hash::binary_merkle_tree::HashSuite;
 use binius_iop_prover::basefold::compiler::BaseFoldProverCompiler;
@@ -65,7 +65,10 @@ where
 	pub fn setup(zk_verifier: &ZKVerifier<H>) -> Result<Self, Error> {
 		let key_collection = {
 			let _guard = tracing::debug_span!("Build key collection").entered();
-			build_key_collection(zk_verifier.inner_iop_verifier().constraint_system())
+			build_key_collection(
+				zk_verifier.inner_iop_verifier().constraint_system(),
+				InoutSegment::Public,
+			)
 		};
 		Self::setup_with_key_collection(zk_verifier, key_collection)
 	}
@@ -165,7 +168,7 @@ where
 			let inner_cs = self.inner_iop_prover.constraint_system();
 			let _scope = tracing::debug_span!(
 				"Binius64",
-				n_hidden_words = inner_cs.n_hidden_words(),
+				n_hidden_words = inner_cs.n_hidden_words(InoutSegment::Public),
 				n_bitand = inner_cs.and_constraints.len(),
 				n_intmul = inner_cs.imul_constraints.len(),
 			)

--- a/crates/prover/tests/prove_verify.rs
+++ b/crates/prover/tests/prove_verify.rs
@@ -5,7 +5,7 @@ use std::collections::HashSet;
 
 use binius_circuits::sha256::{State, populate_message_block, sha256_compress};
 use binius_core::{
-	constraint_system::{ConstraintSystem, ValueSegment, ValueVec},
+	constraint_system::{ConstraintSystem, InoutSegment, ValueSegment, ValueVec},
 	word::Word,
 };
 use binius_field::{BinaryField128bGhash, Field, Random, arch::OptimalPackedB128};
@@ -439,13 +439,16 @@ fn public_heavy_circuit(n_inout: usize) -> (ConstraintSystem, ValueVec) {
 fn test_prove_verify_public_wider_than_hidden() {
 	let (cs, witness) = public_heavy_circuit(300);
 	assert!(
-		cs.log_public_words() > cs.log_witness_words(),
+		cs.log_public_words(InoutSegment::Public) > cs.log_witness_words(InoutSegment::Public),
 		"public segment ({} words) must be wider than the hidden one ({} words) for this test to \
 		 exercise the extra word-index challenges",
-		cs.n_public_words(),
-		cs.n_hidden_words(),
+		cs.n_public_words(InoutSegment::Public),
+		cs.n_hidden_words(InoutSegment::Public),
 	);
-	assert_eq!(cs.log_segment_words(), cs.log_public_words());
+	assert_eq!(
+		cs.log_segment_words(InoutSegment::Public),
+		cs.log_public_words(InoutSegment::Public)
+	);
 	prove_verify(cs.clone(), &witness);
 	prove_verify_zk(cs, &witness);
 }
@@ -483,8 +486,8 @@ fn test_prove_verify_rejects_violated_zero_constraint() {
 	let victim_word = cs.word_offset(victim);
 	words[victim_word] = words[victim_word] ^ Word::ONE;
 	let corrupted = cs.value_vec_from_data(
-		&words[cs.n_const()..cs.n_public_words()],
-		&words[cs.n_public_words()..],
+		&words[cs.n_const()..cs.n_public_values()],
+		&words[cs.n_public_values()..],
 	);
 	assert!(cs.verify(&corrupted).is_err());
 

--- a/crates/prover/tests/shift.rs
+++ b/crates/prover/tests/shift.rs
@@ -4,7 +4,7 @@
 use binius_circuits::{fixed_byte_vec::ByteVec, sha256::sha256_varlen};
 use binius_compute::GlobalAllocator;
 use binius_core::{
-	constraint_system::{AndConstraint, ConstraintSystem, ImulConstraint, ValueVec},
+	constraint_system::{AndConstraint, ConstraintSystem, ImulConstraint, InoutSegment, ValueVec},
 	word::Word,
 };
 use binius_field::{AESTowerField8b, BinaryField};
@@ -281,7 +281,7 @@ fn test_shift_prove_and_verify() {
 		};
 
 		// Build prover's constraint system
-		let key_collection = build_key_collection(&cs);
+		let key_collection = build_key_collection(&cs, InoutSegment::Public);
 
 		// Create prover transcript and call the prover
 		let mut prover_transcript = ProverTranscript::<StdChallenger>::default();
@@ -336,6 +336,7 @@ fn test_shift_prove_and_verify() {
 
 		let verifier_output = verify(
 			&cs,
+			InoutSegment::Public,
 			&verifier_zero_data,
 			&verifier_bitand_data,
 			&verifier_intmul_data,
@@ -347,6 +348,7 @@ fn test_shift_prove_and_verify() {
 		// Check consistency with verifier output
 		check_eval(
 			&cs,
+			InoutSegment::Public,
 			value_vec.public(),
 			&verifier_zero_data,
 			&verifier_bitand_data,

--- a/crates/verifier/src/protocols/shift/verify.rs
+++ b/crates/verifier/src/protocols/shift/verify.rs
@@ -3,7 +3,10 @@
 
 use std::{array, iter};
 
-use binius_core::{constraint_system::ConstraintSystem, word::Word};
+use binius_core::{
+	constraint_system::{ConstraintSystem, InoutSegment},
+	word::Word,
+};
 use binius_field::{BinaryField, field::FieldOps, util::FieldFn};
 use binius_ip::{
 	channel::IPVerifierChannel,
@@ -161,6 +164,7 @@ impl<F> VerifyOutput<F> {
 ///
 /// # Parameters
 /// - `constraint_system`: The constraint system containing AND, IMUL and BMUL constraints
+/// - `inout`: Which segment holds the inout values, which fixes where the two segments split
 /// - `bitand_data`: Operator data for bit multiplication operations
 /// - `intmul_data`: Operator data for integer multiplication operations
 /// - `binmul_data`: Operator data for GHASH-field multiplication operations
@@ -176,6 +180,7 @@ impl<F> VerifyOutput<F> {
 /// - Propagates sumcheck verification errors
 pub fn verify<F, C>(
 	constraint_system: &ConstraintSystem,
+	inout: InoutSegment,
 	zero_data: &OperatorData<C::Elem, ZERO_ARITY>,
 	bitand_data: &OperatorData<C::Elem, BITAND_ARITY>,
 	intmul_data: &OperatorData<C::Elem, INTMUL_ARITY>,
@@ -211,7 +216,7 @@ where
 	// the hidden segment in the high half-cube, selected by the top word-index variable. Each
 	// half spans the wider of the two segments, which the prover zero-pads the shorter one up
 	// to, so a public segment longer than the hidden one draws the extra word-index challenges.
-	let log_word_count = constraint_system.log_segment_words() + 1;
+	let log_word_count = constraint_system.log_segment_words(inout) + 1;
 
 	let SumcheckOutput {
 		eval,
@@ -268,6 +273,7 @@ where
 #[allow(clippy::too_many_arguments)]
 pub fn check_eval<F, C>(
 	constraint_system: &ConstraintSystem,
+	inout: InoutSegment,
 	public: &[Word],
 	zero_data: &OperatorData<C::Elem, ZERO_ARITY>,
 	bitand_data: &OperatorData<C::Elem, BITAND_ARITY>,
@@ -332,6 +338,7 @@ where
 		let eval_fn = MonsterEvalFn {
 			subspace,
 			constraint_system,
+			inout,
 			zero_r_x_prime_len,
 			bitand_r_x_prime_len,
 			intmul_r_x_prime_len,
@@ -346,7 +353,7 @@ where
 
 	// The public-half evaluation is a function of the verifier's public words (plaintext) and
 	// public-channel-derived challenges, so it is computed the same way as `monster_eval`.
-	let log_public_words = constraint_system.log_public_words();
+	let log_public_words = constraint_system.log_public_words(inout);
 	let public_eval = {
 		let inputs: Vec<C::Elem> = r_j
 			.iter()
@@ -401,6 +408,8 @@ struct MonsterEvalFn<'a, F: BinaryField> {
 	subspace: &'a BinarySubspace<F>,
 	/// The AND, IMUL and BMUL constraints whose monster multilinears are evaluated.
 	constraint_system: &'a ConstraintSystem,
+	/// Which segment holds the inout values, which fixes where the word-index tensor is cut.
+	inout: InoutSegment,
 	/// Length of the Zero operator's `r_x_prime` section.
 	zero_r_x_prime_len: usize,
 	/// Length of the BitAnd operator's `r_x_prime` section.
@@ -503,7 +512,7 @@ impl<F: BinaryField> MonsterEvalFn<'_, F> {
 		//     over the unused `r_y` coordinates — the same `padded_public_eval` factor that
 		//     `check_eval` reconstructs the witness evaluation with.
 		let cs = &self.constraint_system;
-		let log_public_words = cs.log_public_words();
+		let log_public_words = cs.log_public_words(self.inout);
 
 		let public_scale =
 			eq_one_var(r_segment.clone(), E::zero()) * eq_ind_zero(&r_y_v[log_public_words..]);
@@ -512,14 +521,22 @@ impl<F: BinaryField> MonsterEvalFn<'_, F> {
 		let hidden_tensor = scaled_eq_ind_partial_eval_scalars(r_y_v, r_segment);
 
 		// Cut the two indicators into one run per value segment, which is what an operand term's
-		// `(segment, index)` pair reads against. The constants and the inout values both sit in
-		// the public indicator, at the offsets the system places them; the padding words between
-		// them are dropped, since no index can name one.
-		let r_y_tensor = [
-			&public_tensor[..cs.n_const()],
-			&public_tensor[cs.offset_inout()..cs.offset_inout() + cs.n_inout],
-			&hidden_tensor[..cs.n_private],
-		];
+		// `(segment, index)` pair reads against. The constants lead the public indicator and the
+		// private values trail the hidden one; the inout values follow whichever indicator they
+		// are placed in. The padding words between the runs are dropped, since no index can name
+		// one.
+		let r_y_tensor = match self.inout {
+			InoutSegment::Public => [
+				&public_tensor[..cs.n_const()],
+				&public_tensor[cs.offset_inout()..cs.offset_inout() + cs.n_inout],
+				&hidden_tensor[..cs.n_private],
+			],
+			InoutSegment::Hidden => [
+				&public_tensor[..cs.n_const()],
+				&hidden_tensor[..cs.n_inout],
+				&hidden_tensor[cs.n_inout..cs.n_inout + cs.n_private],
+			],
+		};
 		let l_tilde = lagrange_evals_scalars(self.subspace, &r_zhat_prime_v);
 		let h_op_evals = evaluate_h_op(&l_tilde, r_j_v, r_s_v);
 

--- a/crates/verifier/src/verify.rs
+++ b/crates/verifier/src/verify.rs
@@ -3,7 +3,10 @@
 
 use std::marker::PhantomData;
 
-use binius_core::{constraint_system::ConstraintSystem, word::Word};
+use binius_core::{
+	constraint_system::{ConstraintSystem, InoutSegment},
+	word::Word,
+};
 use binius_field::{AESTowerField8b as B8, BinaryField, ExtensionField, FieldOps};
 use binius_hash::binary_merkle_tree::HashSuite;
 use binius_iop::{
@@ -88,7 +91,9 @@ impl IOPVerifier {
 	/// * the wider segment spans at least one field element's worth of words, which every system
 	///   with more than one public or private value satisfies
 	pub const fn log_witness_elems(&self) -> usize {
-		let log_segment_words = self.constraint_system.log_segment_words();
+		let log_segment_words = self
+			.constraint_system
+			.log_segment_words(InoutSegment::Public);
 		assert!(
 			log_segment_words >= LOG_WORDS_PER_ELEM,
 			"the committed trace is a whole number of field elements, so the wider value \
@@ -321,6 +326,7 @@ impl IOPVerifier {
 		.entered();
 		let shift_output = shift::verify(
 			self.constraint_system(),
+			InoutSegment::Public,
 			&zero_claim,
 			&bitand_claim,
 			&intmul_claim,
@@ -338,6 +344,7 @@ impl IOPVerifier {
 		.entered();
 		shift::check_eval(
 			self.constraint_system(),
+			InoutSegment::Public,
 			&public,
 			&zero_claim,
 			&bitand_claim,
@@ -410,7 +417,7 @@ where
 	pub fn setup(constraint_system: ConstraintSystem, log_inv_rate: usize) -> Result<Self, Error> {
 		constraint_system.validate()?;
 
-		let log_public_words = constraint_system.log_public_words();
+		let log_public_words = constraint_system.log_public_words(InoutSegment::Public);
 
 		let iop_verifier = IOPVerifier::new(constraint_system, log_public_words);
 
@@ -491,7 +498,7 @@ where
 
 		let _verify_scope = tracing::info_span!(
 			"Verify",
-			n_hidden_words = cs.n_hidden_words(),
+			n_hidden_words = cs.n_hidden_words(InoutSegment::Public),
 			n_bitand = cs.and_constraints.len(),
 			n_intmul = cs.imul_constraints.len(),
 		)

--- a/crates/verifier/src/zk_config.rs
+++ b/crates/verifier/src/zk_config.rs
@@ -15,7 +15,10 @@
 
 use std::{marker::PhantomData, sync::Arc};
 
-use binius_core::{constraint_system::ConstraintSystem, word::Word};
+use binius_core::{
+	constraint_system::{ConstraintSystem, InoutSegment},
+	word::Word,
+};
 use binius_field::BinaryField128bGhash as B128;
 use binius_hash::binary_merkle_tree::HashSuite;
 use binius_iop::{
@@ -65,7 +68,7 @@ where
 
 		constraint_system.validate()?;
 
-		let log_public_words = constraint_system.log_public_words();
+		let log_public_words = constraint_system.log_public_words(InoutSegment::Public);
 
 		let inner_iop_verifier = IOPVerifier::new(constraint_system, log_public_words);
 
@@ -197,7 +200,7 @@ where
 			let inner_cs = self.inner_iop_verifier.constraint_system();
 			let _scope = tracing::debug_span!(
 				"Binius64",
-				n_hidden_words = inner_cs.n_hidden_words(),
+				n_hidden_words = inner_cs.n_hidden_words(InoutSegment::Public),
 				n_bitand = inner_cs.and_constraints.len(),
 				n_intmul = inner_cs.imul_constraints.len(),
 			)


### PR DESCRIPTION
Closes [BINIUS-424](https://linear.app/jimpo/issue/BINIUS-424/m4-allow-inout-wires-in-m4-constraint-systems).

The M4 batch witness table rejected any circuit declaring inout wires, so callers had to rebuild their circuits with witness wires instead — the obstacle [BINIUS-278](https://linear.app/jimpo/issue/BINIUS-278) hit with the XMSS multi-signature builder. This lets them keep their inout wires.

## Why they were rejected

The shift reduction addresses the value vector as a public segment followed by a hidden one. M4 folds the hidden segment over the instance axis and reads the public segment as raw shared words — which is only correct because a word shared by every instance folds to itself (`sum_rho eq(r_rho, rho) = 1`). Constants have that property. Inout values do not: each instance chooses its own.

## The change

Two commits.

**1. Parameterize the segment split.** The constants are always public and the private values always hidden, but the inout values could sit in either. `InoutSegment` names that freedom, and every accessor reporting a segment length takes it. Four places read where the boundary falls and now take it as a parameter rather than deriving it: the key-collection split, the shift reduction's word count, the public half of its closing check, and the cut of the word-index tensor. `OperationEvalFn` needs no change — it already reads `r_y_tensor[segment][index]` and only wants the three lengths.

`ConstraintSystem::word_offset` loses its dependence on the split: a word's address is the constants, then the inout values, then the private ones, whichever segment the boundary lands in.

Every caller passes `InoutSegment::Public`, so this commit changes no behavior.

**2. M4 adopts `Hidden`.** `ValueTable` stores rows from the inout offset rather than the witness offset, so the committed trace is the inout words followed by the private ones and the public segment is the constants alone. The operand columns resolve an inout index to its own row and a private one behind them.

## Soundness

The inout words are committed but tied to nothing the verifier knows, so an M4 proof asserts that *some* inout values complete every instance. That is exactly the statement callers already proved by allocating the same words as witness wires, at the same cost — they no longer have to rewrite the circuit to say it. Binding the inout block to an outer system is left to whatever consumes M4; it sits at the front of the committed segment so a later connection layer can name it as a sub-cube of the trace.

The single-instance protocol is untouched: it still places inout in the public segment, where `check_eval` evaluates the verifier's own words.

## Tests

* `protocol_round_trips_with_inout_wires` — a circuit with inout wires either side of a private computation proves and verifies end to end, which is what pins the key collection, the word-index tensor, the committed shape and the ring-switch trace point to one boundary.
* `inout_wires_lead_the_committed_rows` — the inout rows lead the table and carry per-instance values; each instance reconstructs to a witness the constraint system accepts.
* `hidden_inout_moves_the_segment_boundary` — the counts move with the placement while the word addresses do not.
* The M4 shift round trip against the single-instance verifier now runs under the `Hidden` split.

## One thing worth a look

`BatchCommitLayout::for_constraint_system` gained an assert that the committed rows span exactly the reduction's word-index variables. That coupling was already load-bearing (the ring-switch opens the trace at those challenges) but silent; a public segment wider than the hidden one would have drawn challenges the trace has no coordinates for. This change makes it strictly harder to hit — the public segment shrinks and the hidden one grows — but say the word and I will drop the assert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)