### PR TITLE
BINIUS-426: build the M4 fixtures with inout wires

### DIFF
--- a/crates/m4-prover/benches/assemble_operation_witness.rs
+++ b/crates/m4-prover/benches/assemble_operation_witness.rs
@@ -24,19 +24,19 @@ const LOG_INSTANCES: usize = 13;
 /// The number of 64-bit lanes in a Keccak-f1600 state.
 const STATE_LANES: usize = 25;
 
-/// Builds a circuit that applies one Keccak-f1600 permutation to a witness-input state and
-/// force-commits the permuted output words. Returns the circuit and the 25 input state wires.
+/// Builds a circuit that applies one Keccak-f1600 permutation to a public input state and promotes
+/// the permuted lanes to public outputs. Returns the circuit and the 25 input state wires.
 fn build_keccak_circuit() -> (Circuit, [Wire; STATE_LANES]) {
 	let builder = CircuitBuilder::new();
-	let input: [Wire; STATE_LANES] = array::from_fn(|_| builder.add_witness());
+	let input: [Wire; STATE_LANES] = array::from_fn(|_| builder.add_inout());
 
 	// Permute a copy of the input wires in place; `state` then holds the output wires.
 	let mut state = input;
 	keccak_f1600(&builder, &mut state);
 
-	// Pin the outputs so dead-code elimination keeps the whole permutation.
+	// Promoting the permuted state keeps the whole permutation alive under dead-code elimination.
 	for wire in state {
-		builder.force_commit(wire);
+		builder.mark_inout(wire);
 	}
 
 	(builder.build(), input)

--- a/crates/m4-prover/benches/blake3_compressions.rs
+++ b/crates/m4-prover/benches/blake3_compressions.rs
@@ -33,12 +33,12 @@ const DEFAULT_LOG_INV_RATE: usize = 1;
 /// Compressions computed per instance: the two-lane core runs two at once.
 const COMPRESSIONS_PER_INSTANCE: u64 = 2;
 
-/// The witness input wires of one two-lane BLAKE3 compression instance.
+/// The public wires of one two-lane BLAKE3 compression instance.
 ///
 /// Each wire packs two independent compressions: lane 0 in the low 32 bits, lane 1 in the high 32
-/// bits. The output is force-committed, so the circuit has no inout wires.
+/// bits.
 #[derive(Clone, Copy)]
-struct Blake3Inputs {
+struct Blake3Wires {
 	/// The 8-word input chaining value, two lanes per word.
 	cv: [Wire; 8],
 	/// The 16-word message block, two lanes per word.
@@ -53,29 +53,29 @@ struct Blake3Inputs {
 	flags: Wire,
 }
 
-/// Builds a circuit for one two-lane BLAKE3 compression and force-commits its output.
+/// Builds a circuit for one two-lane BLAKE3 compression, with its output chaining value promoted
+/// to public outputs.
 ///
-/// Force-committing the output keeps the compression alive under dead-code elimination.
-fn build_blake3_circuit() -> (Circuit, Blake3Inputs) {
+/// That promotion keeps the compression alive under dead-code elimination.
+fn build_blake3_circuit() -> (Circuit, Blake3Wires) {
 	let builder = CircuitBuilder::new();
 
-	// Every compression input is a witness wire, filled per instance.
-	let cv = array::from_fn(|_| builder.add_witness());
-	let block = array::from_fn(|_| builder.add_witness());
-	let counter_lo = builder.add_witness();
-	let counter_hi = builder.add_witness();
-	let block_len = builder.add_witness();
-	let flags = builder.add_witness();
+	// Every compression input is public, filled per instance.
+	let cv = array::from_fn(|_| builder.add_inout());
+	let block = array::from_fn(|_| builder.add_inout());
+	let counter_lo = builder.add_inout();
+	let counter_hi = builder.add_inout();
+	let block_len = builder.add_inout();
+	let flags = builder.add_inout();
 
-	// Force-commit each output word so the compression survives dead-code elimination.
 	let out = blake3_compress_2x(&builder, cv, block, counter_lo, counter_hi, block_len, flags);
 	for wire in out {
-		builder.force_commit(wire);
+		builder.mark_inout(wire);
 	}
 
 	(
 		builder.build(),
-		Blake3Inputs {
+		Blake3Wires {
 			cv,
 			block,
 			counter_lo,
@@ -90,31 +90,30 @@ fn build_blake3_circuit() -> (Circuit, Blake3Inputs) {
 const fn pack_lanes(lane0: u32, lane1: u32) -> Word {
 	Word((lane0 as u64) | ((lane1 as u64) << 32))
 }
-
 /// Assigns one instance's two-lane BLAKE3 inputs from a per-instance seeded RNG.
 ///
 /// Each 64-bit word carries two independent 32-bit lanes, matching the two-lane core.
 /// The compression derives its output from these inputs, so any assignment is valid.
 /// Seeding per instance keeps the data non-degenerate and reproducible.
-fn fill_instance(inputs: &Blake3Inputs, i: usize, w: &mut BatchWitnessFiller<'_, '_>) {
+fn fill_instance(wires: &Blake3Wires, i: usize, w: &mut BatchWitnessFiller<'_, '_>) {
 	// Seed from the instance index so the batch is deterministic and instance-varying.
 	let mut rng = StdRng::seed_from_u64(i as u64);
 
 	// A 32-bit value per chaining-value word, per lane.
-	for wire in inputs.cv {
+	for wire in wires.cv {
 		w[wire] = pack_lanes(rng.next_u32(), rng.next_u32());
 	}
 	// A 32-bit value per message word, per lane.
-	for wire in inputs.block {
+	for wire in wires.block {
 		w[wire] = pack_lanes(rng.next_u32(), rng.next_u32());
 	}
 	// The 64-bit counter, split into low and high halves, per lane.
-	w[inputs.counter_lo] = pack_lanes(rng.next_u32(), rng.next_u32());
-	w[inputs.counter_hi] = pack_lanes(rng.next_u32(), rng.next_u32());
+	w[wires.counter_lo] = pack_lanes(rng.next_u32(), rng.next_u32());
+	w[wires.counter_hi] = pack_lanes(rng.next_u32(), rng.next_u32());
 	// A byte length in 0..=64, per lane.
-	w[inputs.block_len] = pack_lanes(rng.next_u32() % 65, rng.next_u32() % 65);
+	w[wires.block_len] = pack_lanes(rng.next_u32() % 65, rng.next_u32() % 65);
 	// Arbitrary domain-separation flags, per lane.
-	w[inputs.flags] = pack_lanes(rng.next_u32(), rng.next_u32());
+	w[wires.flags] = pack_lanes(rng.next_u32(), rng.next_u32());
 }
 
 fn bench_prove_blake3_compressions(c: &mut Criterion) {

--- a/crates/m4-prover/benches/keccak_protocol.rs
+++ b/crates/m4-prover/benches/keccak_protocol.rs
@@ -32,30 +32,29 @@ const STATE_LANES: usize = 25;
 /// Permutations computed per instance.
 const PERMUTATIONS_PER_INSTANCE: u64 = 1;
 
-/// The witness input wires of one Keccak-f[1600] permutation instance.
-///
-/// The output is force-committed, so the circuit has no inout wires.
+/// The public input wires of one Keccak-f[1600] permutation instance.
 #[derive(Clone, Copy)]
-struct KeccakInputs {
+struct KeccakWires {
 	/// The 25-word input state.
 	state: [Wire; STATE_LANES],
 }
 
-/// Builds a circuit for one Keccak-f[1600] permutation and force-commits its output.
+/// Builds a circuit for one Keccak-f[1600] permutation, with its permuted state promoted to public
+/// outputs.
 ///
-/// Force-committing the output keeps the permutation alive under dead-code elimination.
-fn build_keccak_circuit() -> (Circuit, KeccakInputs) {
+/// That promotion keeps the permutation alive under dead-code elimination.
+fn build_keccak_circuit() -> (Circuit, KeccakWires) {
 	let builder = CircuitBuilder::new();
-	let input = array::from_fn(|_| builder.add_witness());
+	let input = array::from_fn(|_| builder.add_inout());
 	let mut state = input;
 
 	keccak_f1600(&builder, &mut state);
 
 	for wire in state {
-		builder.force_commit(wire);
+		builder.mark_inout(wire);
 	}
 
-	(builder.build(), KeccakInputs { state: input })
+	(builder.build(), KeccakWires { state: input })
 }
 
 /// A deterministic, instance- and lane-dependent input word.
@@ -69,9 +68,9 @@ const fn input_word(instance: usize, lane: usize) -> Word {
 }
 
 /// Assigns one instance's Keccak input state.
-fn fill_instance(inputs: &KeccakInputs, i: usize, w: &mut BatchWitnessFiller<'_, '_>) {
+fn fill_instance(wires: &KeccakWires, i: usize, w: &mut BatchWitnessFiller<'_, '_>) {
 	for lane in 0..STATE_LANES {
-		w[inputs.state[lane]] = input_word(i, lane);
+		w[wires.state[lane]] = input_word(i, lane);
 	}
 }
 

--- a/crates/m4-prover/benches/keccak_witness_gen.rs
+++ b/crates/m4-prover/benches/keccak_witness_gen.rs
@@ -22,19 +22,19 @@ const STATE_LANES: usize = 25;
 /// Candidate instance-stripe widths for parallel [`ValueTable`] witness generation.
 const STRIPE_WIDTHS: [usize; 3] = [256, 512, 1024];
 
-/// Builds a circuit that applies one Keccak-f1600 permutation to a witness-input state and
-/// force-commits the permuted output words. Returns the circuit and the 25 input state wires.
+/// Builds a circuit that applies one Keccak-f1600 permutation to a public input state and promotes
+/// the permuted lanes to public outputs. Returns the circuit and the 25 input state wires.
 fn build_keccak_circuit() -> (Circuit, [Wire; STATE_LANES]) {
 	let builder = CircuitBuilder::new();
-	let input: [Wire; STATE_LANES] = array::from_fn(|_| builder.add_witness());
+	let input: [Wire; STATE_LANES] = array::from_fn(|_| builder.add_inout());
 
 	// Permute a copy of the input wires in place; `state` then holds the output wires.
 	let mut state = input;
 	keccak_f1600(&builder, &mut state);
 
-	// Pin the outputs so dead-code elimination keeps the whole permutation.
+	// Promoting the permuted state keeps the whole permutation alive under dead-code elimination.
 	for wire in state {
-		builder.force_commit(wire);
+		builder.mark_inout(wire);
 	}
 
 	(builder.build(), input)

--- a/crates/m4-prover/benches/sha256_compressions.rs
+++ b/crates/m4-prover/benches/sha256_compressions.rs
@@ -37,52 +37,51 @@ const COMPRESSIONS_PER_INSTANCE: u64 = 2;
 /// Each wire packs two independent compressions: lane 0 in the low 32 bits, lane 1 in the high 32
 /// bits. The output is force-committed, so the circuit has no inout wires.
 #[derive(Clone, Copy)]
-struct Sha256Inputs {
+struct Sha256Wires {
 	/// The 8-word input chaining value, two lanes per word.
 	state: [Wire; 8],
 	/// The 16-word message block, two lanes per word.
 	block: [Wire; 16],
 }
 
-/// Builds a circuit for one two-lane SHA-256 compression and force-commits its output.
+/// Builds a circuit for one two-lane SHA-256 compression, with its output state promoted to public
+/// outputs.
 ///
-/// Force-committing the output keeps the compression alive under dead-code elimination.
-fn build_sha256_circuit() -> (Circuit, Sha256Inputs) {
+/// That promotion keeps the compression alive under dead-code elimination.
+fn build_sha256_circuit() -> (Circuit, Sha256Wires) {
 	let builder = CircuitBuilder::new();
 
-	// Every compression input is a witness wire, filled per instance.
-	let state = array::from_fn(|_| builder.add_witness());
-	let block = array::from_fn(|_| builder.add_witness());
+	// Every compression input is public, filled per instance.
+	let state = array::from_fn(|_| builder.add_inout());
+	let block = array::from_fn(|_| builder.add_inout());
 
-	// Force-commit each output word so the compression survives dead-code elimination.
 	let out = sha256_compress_2x(&builder, State::new(state), block);
 	for wire in out.0 {
-		builder.force_commit(wire);
+		builder.mark_inout(wire);
 	}
 
-	(builder.build(), Sha256Inputs { state, block })
+	(builder.build(), Sha256Wires { state, block })
 }
 
 /// Packs two independent 32-bit lane values into one 64-bit word.
 const fn pack_lanes(lane0: u32, lane1: u32) -> Word {
 	Word((lane0 as u64) | ((lane1 as u64) << 32))
 }
-
 /// Assigns one instance's two-lane SHA-256 inputs from a per-instance seeded RNG.
 ///
 /// Each 64-bit word carries two independent 32-bit lanes, matching the two-lane core.
 /// The compression derives its output from these inputs, so any assignment is valid.
 /// Seeding per instance keeps the data non-degenerate and reproducible.
-fn fill_instance(inputs: &Sha256Inputs, i: usize, w: &mut BatchWitnessFiller<'_, '_>) {
+fn fill_instance(wires: &Sha256Wires, i: usize, w: &mut BatchWitnessFiller<'_, '_>) {
 	// Seed from the instance index so the batch is deterministic and instance-varying.
 	let mut rng = StdRng::seed_from_u64(i as u64);
 
 	// A 32-bit value per chaining-value word, per lane.
-	for wire in inputs.state {
+	for wire in wires.state {
 		w[wire] = pack_lanes(rng.next_u32(), rng.next_u32());
 	}
 	// A 32-bit value per message word, per lane.
-	for wire in inputs.block {
+	for wire in wires.block {
 		w[wire] = pack_lanes(rng.next_u32(), rng.next_u32());
 	}
 }

--- a/crates/m4-prover/src/prove.rs
+++ b/crates/m4-prover/src/prove.rs
@@ -724,15 +724,12 @@ mod tests {
 		use binius_frontend::Wire;
 
 		let builder = CircuitBuilder::new();
-		let inputs: [Wire; 4] = array::from_fn(|_| builder.add_witness());
-		let and = builder.band(inputs[0], inputs[1]);
-		builder.force_commit(and);
+		let inputs: [Wire; 4] = array::from_fn(|_| builder.add_inout());
 		let (hi, lo) = builder.imul(inputs[0], inputs[1]);
-		builder.force_commit(hi);
-		builder.force_commit(lo);
 		let (c_lo, c_hi) = builder.bmul(inputs[0], inputs[1], inputs[2], inputs[3]);
-		builder.force_commit(c_lo);
-		builder.force_commit(c_hi);
+		for wire in [builder.band(inputs[0], inputs[1]), hi, lo, c_lo, c_hi] {
+			builder.mark_inout(wire);
+		}
 		let circuit = builder.build();
 
 		let cs = circuit.constraint_system().clone();
@@ -798,19 +795,14 @@ mod tests {
 			enable_gate_fusion: false,
 			..Options::default()
 		});
-		let inputs: [Wire; 4] = array::from_fn(|_| builder.add_witness());
+		let inputs: [Wire; 4] = array::from_fn(|_| builder.add_inout());
 		let x = builder.bxor(inputs[0], inputs[1]);
 		let y = builder.bxor(x, inputs[2]);
-		builder.force_commit(x);
-		builder.force_commit(y);
-		let and_out = builder.band(inputs[0], inputs[1]);
-		builder.force_commit(and_out);
 		let (hi, lo) = builder.imul(inputs[0], inputs[1]);
-		builder.force_commit(hi);
-		builder.force_commit(lo);
 		let (c_lo, c_hi) = builder.bmul(inputs[0], inputs[1], inputs[2], inputs[3]);
-		builder.force_commit(c_lo);
-		builder.force_commit(c_hi);
+		for wire in [x, y, builder.band(inputs[0], inputs[1]), hi, lo, c_lo, c_hi] {
+			builder.mark_inout(wire);
+		}
 		let circuit = builder.build();
 
 		let cs = circuit.constraint_system().clone();
@@ -861,9 +853,8 @@ mod tests {
 			enable_gate_fusion: false,
 			..Options::default()
 		});
-		let inputs: [Wire; 3] = array::from_fn(|_| builder.add_witness());
-		let x = builder.bxor(inputs[0], inputs[1]);
-		builder.force_commit(x);
+		let inputs: [Wire; 3] = array::from_fn(|_| builder.add_inout());
+		builder.mark_inout(builder.bxor(inputs[0], inputs[1]));
 		let circuit = builder.build();
 
 		let mut cs = circuit.constraint_system().clone();
@@ -943,11 +934,11 @@ mod tests {
 	fn protocol_round_trips_with_mul() {
 		// One product per instance, with both result words committed as hidden words.
 		let builder = CircuitBuilder::new();
-		let x = builder.add_witness();
-		let y = builder.add_witness();
+		let x = builder.add_inout();
+		let y = builder.add_inout();
 		let (hi, lo) = builder.imul(x, y);
-		builder.force_commit(hi);
-		builder.force_commit(lo);
+		builder.mark_inout(hi);
+		builder.mark_inout(lo);
 		let circuit = builder.build();
 
 		let cs = circuit.constraint_system().clone();
@@ -1057,15 +1048,15 @@ mod tests {
 		use binius_frontend::Wire;
 
 		let builder = CircuitBuilder::new();
-		let cv: [Wire; 8] = array::from_fn(|_| builder.add_witness());
-		let block: [Wire; 16] = array::from_fn(|_| builder.add_witness());
-		let counter = builder.add_witness();
-		let block_len = builder.add_witness();
-		let flags = builder.add_witness();
-		// Force-commit the output so dead-code elimination keeps the compression.
-		let out = blake3_compress(&builder, cv, block, counter, block_len, flags);
-		for wire in out {
-			builder.force_commit(wire);
+		let cv: [Wire; 8] = array::from_fn(|_| builder.add_inout());
+		let block: [Wire; 16] = array::from_fn(|_| builder.add_inout());
+		let counter = builder.add_inout();
+		let block_len = builder.add_inout();
+		let flags = builder.add_inout();
+		// Promoting the output chaining value keeps the compression alive under dead-code
+		// elimination.
+		for wire in blake3_compress(&builder, cv, block, counter, block_len, flags) {
+			builder.mark_inout(wire);
 		}
 		let circuit = builder.build();
 
@@ -1124,17 +1115,16 @@ mod tests {
 		type WideP = PackedBinaryGhash2x128b;
 
 		let builder = CircuitBuilder::new();
-		let inputs: [Wire; 8] = array::from_fn(|_| builder.add_witness());
+		let inputs: [Wire; 8] = array::from_fn(|_| builder.add_inout());
 		// Four standalone AND gates on distinct wires — the AND work is not tied to the products.
 		for pair in inputs.chunks_exact(2) {
-			let and = builder.band(pair[0], pair[1]);
-			builder.force_commit(and);
+			builder.mark_inout(builder.band(pair[0], pair[1]));
 		}
 		// Two products — fewer IMUL constraints than AND constraints.
 		for pair in inputs.chunks_exact(2).take(2) {
 			let (hi, lo) = builder.imul(pair[0], pair[1]);
-			builder.force_commit(hi);
-			builder.force_commit(lo);
+			builder.mark_inout(hi);
+			builder.mark_inout(lo);
 		}
 		let circuit = builder.build();
 
@@ -1190,11 +1180,11 @@ mod tests {
 		// One GHASH-field squaring per instance: `(c_lo, c_hi) = (x_lo, x_hi)^2`, with both result
 		// words committed as hidden words.
 		let builder = CircuitBuilder::new();
-		let x_lo = builder.add_witness();
-		let x_hi = builder.add_witness();
+		let x_lo = builder.add_inout();
+		let x_hi = builder.add_inout();
 		let (c_lo, c_hi) = builder.bmul(x_lo, x_hi, x_lo, x_hi);
-		builder.force_commit(c_lo);
-		builder.force_commit(c_hi);
+		builder.mark_inout(c_lo);
+		builder.mark_inout(c_hi);
 		let circuit = builder.build();
 
 		let cs = circuit.constraint_system().clone();
@@ -1244,22 +1234,21 @@ mod tests {
 		type WideP = PackedBinaryGhash2x128b;
 
 		let builder = CircuitBuilder::new();
-		let inputs: [Wire; 8] = array::from_fn(|_| builder.add_witness());
+		let inputs: [Wire; 8] = array::from_fn(|_| builder.add_inout());
 		// Four standalone AND gates on distinct wires.
 		for pair in inputs.chunks_exact(2) {
-			let and = builder.band(pair[0], pair[1]);
-			builder.force_commit(and);
+			builder.mark_inout(builder.band(pair[0], pair[1]));
 		}
 		// Two integer products — fewer IMUL constraints than AND constraints.
 		for pair in inputs.chunks_exact(2).take(2) {
 			let (hi, lo) = builder.imul(pair[0], pair[1]);
-			builder.force_commit(hi);
-			builder.force_commit(lo);
+			builder.mark_inout(hi);
+			builder.mark_inout(lo);
 		}
 		// One GHASH-field product — the fewest of the three operations.
 		let (c_lo, c_hi) = builder.bmul(inputs[0], inputs[1], inputs[2], inputs[3]);
-		builder.force_commit(c_lo);
-		builder.force_commit(c_hi);
+		builder.mark_inout(c_lo);
+		builder.mark_inout(c_hi);
 		let circuit = builder.build();
 
 		let cs = circuit.constraint_system().clone();
@@ -1339,11 +1328,11 @@ mod tests {
 	#[test]
 	fn tampered_mul_opening_is_rejected() {
 		let builder = CircuitBuilder::new();
-		let x = builder.add_witness();
-		let y = builder.add_witness();
+		let x = builder.add_inout();
+		let y = builder.add_inout();
 		let (hi, lo) = builder.imul(x, y);
-		builder.force_commit(hi);
-		builder.force_commit(lo);
+		builder.mark_inout(hi);
+		builder.mark_inout(lo);
 		let circuit = builder.build();
 
 		let cs = circuit.constraint_system().clone();

--- a/crates/m4-prover/src/test_utils.rs
+++ b/crates/m4-prover/src/test_utils.rs
@@ -49,13 +49,10 @@ pub fn crc64_iso_reference(words: &[u64; N_INPUT_WORDS]) -> u64 {
 	crc ^ XOR_OUT
 }
 
-/// A circuit computing CRC-64/GO-ISO over four private witness words.
+/// A circuit computing CRC-64/GO-ISO over four message words.
 ///
-/// The four inputs are ordinary witness wires, not public inout wires.
-/// So the whole computation lives in the private witness.
-///
-/// The output wire is force-committed.
-/// Without an assertion or public output reading it, dead-code elimination would prune the CRC.
+/// The message words are inout wires and the CRC is promoted to one, so both are the circuit's
+/// public interface and the private witness holds only the register's intermediate states.
 pub struct Crc64Circuit {
 	pub circuit: Circuit,
 	pub input: [Wire; N_INPUT_WORDS],
@@ -66,8 +63,8 @@ pub struct Crc64Circuit {
 pub fn crc64_circuit() -> Crc64Circuit {
 	let builder = CircuitBuilder::new();
 
-	// The four message words are private witnesses supplied by the prover.
-	let input = std::array::from_fn(|_| builder.add_witness());
+	// The four message words are public inputs.
+	let input = std::array::from_fn(|_| builder.add_inout());
 
 	// The register starts at the all-ones preset and the polynomial is a constant.
 	let mut crc = builder.add_constant_64(INIT);
@@ -93,11 +90,10 @@ pub fn crc64_circuit() -> Crc64Circuit {
 		}
 	}
 
-	// Apply the final output XOR to produce the CRC value.
+	// Apply the final output XOR to produce the CRC value, and promote it to a public output.
+	// That promotion is what keeps the CRC computation alive under dead-code elimination.
 	let output = builder.bxor(crc, builder.add_constant_64(XOR_OUT));
-
-	// Pin the output so the constraint compiler keeps the CRC computation alive.
-	builder.force_commit(output);
+	builder.mark_inout(output);
 
 	Crc64Circuit {
 		circuit: builder.build(),
@@ -110,7 +106,7 @@ pub fn crc64_circuit() -> Crc64Circuit {
 ///
 /// The instance count is the number of tuples, which must be a power of two.
 /// Each instance's four message words are the corresponding tuple.
-/// Circuit evaluation derives the rest.
+/// Circuit evaluation derives the rest, including the public CRC.
 pub fn populate_crc64_witness(c: &Crc64Circuit, inputs: &[[u64; N_INPUT_WORDS]]) -> ValueTable {
 	let log_instances = inputs.len().ilog2() as usize;
 	ValueTable::populate(&c.circuit, log_instances, |i, filler| {

--- a/crates/m4-prover/src/value_table.rs
+++ b/crates/m4-prover/src/value_table.rs
@@ -333,19 +333,31 @@ mod tests {
 		N_INPUT_WORDS, crc64_circuit, crc64_iso_reference, populate_crc64_witness,
 	};
 
-	// A circuit that computes several derived words from two witness inputs and a constant, with no
-	// inout wires. Every observable output is force-committed so dead-code elimination keeps it.
+	/// The constant the mix circuit XORs its first input against.
+	const MIX_K: u64 = 0x0123_4567_89ab_cdef;
+
+	// A circuit deriving four words from two public inputs and a constant, each promoted to a
+	// public output. The promotions are what keep the derivations alive under dead-code
+	// elimination.
 	struct MixCircuit {
 		circuit: Circuit,
 		a: Wire,
 		b: Wire,
 	}
 
+	impl MixCircuit {
+		// Assigns one instance's inputs; the circuit derives its public outputs.
+		fn fill<F: IndexMut<Wire, Output = Word>>(&self, filler: &mut F, a: u64, b: u64) {
+			filler[self.a] = Word(a);
+			filler[self.b] = Word(b);
+		}
+	}
+
 	fn mix_circuit() -> MixCircuit {
 		let builder = CircuitBuilder::new();
-		let a = builder.add_witness();
-		let b = builder.add_witness();
-		let k = builder.add_constant_64(0x0123_4567_89ab_cdef);
+		let a = builder.add_inout();
+		let b = builder.add_inout();
+		let k = builder.add_constant_64(MIX_K);
 
 		let and = builder.band(a, b);
 		let xor = builder.bxor(a, k);
@@ -353,10 +365,9 @@ mod tests {
 		let rot = builder.rotr(b, 7);
 		let or = builder.bor(and, rot);
 
-		builder.force_commit(and);
-		builder.force_commit(xor);
-		builder.force_commit(sum);
-		builder.force_commit(or);
+		for wire in [and, xor, sum, or] {
+			builder.mark_inout(wire);
+		}
 
 		MixCircuit {
 			circuit: builder.build(),
@@ -368,8 +379,7 @@ mod tests {
 	// Populate one instance on its own through the ordinary single-instance flow.
 	fn reference_value_vec(c: &MixCircuit, a: u64, b: u64) -> ValueVec {
 		let mut filler = c.circuit.new_witness_filler();
-		filler[c.a] = Word(a);
-		filler[c.b] = Word(b);
+		c.fill(&mut filler, a, b);
 		c.circuit.populate_wire_witness(&mut filler).unwrap();
 		filler.into_value_vec()
 	}
@@ -379,8 +389,7 @@ mod tests {
 		let c = mix_circuit();
 		let log_instances = 3;
 		let table = ValueTable::populate(&c.circuit, log_instances, |i, w| {
-			w[c.a] = Word(i as u64);
-			w[c.b] = Word(i as u64 + 1);
+			c.fill(w, i as u64, i as u64 + 1);
 		})
 		.unwrap();
 
@@ -403,8 +412,7 @@ mod tests {
 		let constants = &c.circuit.constraint_system().constants;
 
 		let table = ValueTable::populate(&c.circuit, 2, |i, w| {
-			w[c.a] = Word(i as u64 * 0x9e37_79b9);
-			w[c.b] = Word(i as u64 ^ 0xdead);
+			c.fill(w, i as u64 * 0x9e37_79b9, i as u64 ^ 0xdead);
 		})
 		.unwrap();
 
@@ -423,8 +431,7 @@ mod tests {
 		let constants = &c.circuit.constraint_system().constants;
 
 		let table = ValueTable::populate(&c.circuit, 0, |_, w| {
-			w[c.a] = Word(0xABCD);
-			w[c.b] = Word(0x0F0F);
+			c.fill(w, 0xABCD, 0x0F0F);
 		})
 		.unwrap();
 
@@ -446,8 +453,7 @@ mod tests {
 
 			let table = ValueTable::populate(&c.circuit, 2, |i, w| {
 				let (a, b) = inputs[i];
-				w[c.a] = Word(a);
-				w[c.b] = Word(b);
+				c.fill(w, a, b);
 			})
 			.unwrap();
 
@@ -465,14 +471,20 @@ mod tests {
 		let log_instances = 3;
 
 		let serial = ValueTable::populate(&c.circuit, log_instances, |i, w| {
-			w[c.a] = Word((i as u64).wrapping_mul(0x9e37_79b9));
-			w[c.b] = Word((i as u64).rotate_left(17) ^ 0xdead_beef);
+			c.fill(
+				w,
+				(i as u64).wrapping_mul(0x9e37_79b9),
+				(i as u64).rotate_left(17) ^ 0xdead_beef,
+			);
 		})
 		.unwrap();
 
 		let default_parallel = ValueTable::populate_parallel(&c.circuit, log_instances, |i, w| {
-			w[c.a] = Word((i as u64).wrapping_mul(0x9e37_79b9));
-			w[c.b] = Word((i as u64).rotate_left(17) ^ 0xdead_beef);
+			c.fill(
+				w,
+				(i as u64).wrapping_mul(0x9e37_79b9),
+				(i as u64).rotate_left(17) ^ 0xdead_beef,
+			);
 		})
 		.unwrap();
 		assert_eq!(default_parallel.as_words(), serial.as_words());
@@ -483,8 +495,11 @@ mod tests {
 				log_instances,
 				stripe_width,
 				|i, w| {
-					w[c.a] = Word((i as u64).wrapping_mul(0x9e37_79b9));
-					w[c.b] = Word((i as u64).rotate_left(17) ^ 0xdead_beef);
+					c.fill(
+						w,
+						(i as u64).wrapping_mul(0x9e37_79b9),
+						(i as u64).rotate_left(17) ^ 0xdead_beef,
+					);
 				},
 			)
 			.unwrap();
@@ -501,8 +516,8 @@ mod tests {
 	fn unsatisfiable_instance_reports_its_index() {
 		// A circuit that asserts a == b; instances where they differ fail.
 		let builder = CircuitBuilder::new();
-		let a = builder.add_witness();
-		let b = builder.add_witness();
+		let a = builder.add_inout();
+		let b = builder.add_inout();
 		builder.assert_eq("a_eq_b", a, b);
 		let circuit = builder.build();
 
@@ -528,8 +543,8 @@ mod tests {
 	fn parallel_unsatisfiable_instance_reports_global_index_across_stripes() {
 		// A circuit that asserts a == b; instances where they differ fail.
 		let builder = CircuitBuilder::new();
-		let a = builder.add_witness();
-		let b = builder.add_witness();
+		let a = builder.add_inout();
+		let b = builder.add_inout();
 		builder.assert_eq("a_eq_b", a, b);
 		let circuit = builder.build();
 
@@ -556,8 +571,8 @@ mod tests {
 	fn parallel_failure_diagnostics_report_global_instance_across_stripes() {
 		// A circuit that asserts a == b; instances where they differ fail.
 		let builder = CircuitBuilder::new();
-		let a = builder.add_witness();
-		let b = builder.add_witness();
+		let a = builder.add_inout();
+		let b = builder.add_inout();
 		builder.assert_eq("a_eq_b", a, b);
 		let circuit = builder.build();
 
@@ -589,10 +604,12 @@ mod tests {
 		let builder = CircuitBuilder::new();
 		let a = builder.add_inout();
 		let b = builder.add_inout();
+		// A private wire, so the table carries private rows behind the inout ones.
 		let w = builder.add_witness();
 		let and = builder.band(a, b);
-		builder.force_commit(and);
-		builder.force_commit(builder.bxor(and, w));
+		let mixed = builder.bxor(and, w);
+		builder.mark_inout(and);
+		builder.mark_inout(mixed);
 		let circuit = builder.build();
 
 		let log_instances = 2;
@@ -603,10 +620,11 @@ mod tests {
 		})
 		.unwrap();
 
-		// Two inout values ahead of the private ones, all of them committed.
+		// The inout values lead the private ones, all of them committed.
 		let layout = circuit.value_vec_layout();
-		assert_eq!(layout.n_inout, 2);
-		assert_eq!(table.n_hidden_words(), 2 + layout.n_private());
+		assert_eq!(layout.n_inout, 4);
+		assert!(layout.n_private() > 0, "the fixture must carry private rows too");
+		assert_eq!(table.n_hidden_words(), layout.n_inout + layout.n_private());
 
 		// The inout rows hold what the filler assigned, one column per instance.
 		let inout_row =
@@ -679,8 +697,7 @@ mod tests {
 
 		// Fixture state: 4 instances with distinct witness inputs.
 		let table = ValueTable::populate(&c.circuit, 2, |i, w| {
-			w[c.a] = Word((i as u64).wrapping_mul(0x9e37_79b9));
-			w[c.b] = Word(i as u64 ^ 0xdead);
+			c.fill(w, (i as u64).wrapping_mul(0x9e37_79b9), i as u64 ^ 0xdead);
 		})
 		.unwrap();
 

--- a/crates/m4-prover/src/witness/instance_fold.rs
+++ b/crates/m4-prover/src/witness/instance_fold.rs
@@ -222,26 +222,26 @@ mod tests {
 		}
 	}
 
-	// A batch of 2^3 instances of a circuit whose committed word count is `3 * n_gates`.
+	// A batch of 2^3 instances of a circuit whose committed word count is `3 * n_gates`: each gate
+	// commits two inputs and the conjunction it promotes to a public output.
 	//
 	// A multiple of three is a power of two only for a hand-picked gate count.
 	// That is what lets a caller choose whether the word axis needs padding.
 	fn and_chain_table(n_gates: usize) -> ValueTable {
-		// Each gate consumes two fresh witness words and commits its result.
+		// Each gate consumes two fresh input words and promotes its result to a public output.
+		// That promotion is what keeps the gate alive under dead-code elimination.
 		let builder = CircuitBuilder::new();
-		let inputs: Vec<Wire> = (0..2 * n_gates).map(|_| builder.add_witness()).collect();
+		let inputs: Vec<Wire> = (0..2 * n_gates).map(|_| builder.add_inout()).collect();
 		for pair in inputs.chunks_exact(2) {
-			let and = builder.band(pair[0], pair[1]);
-			// Pin the output, so dead-code elimination keeps the gate.
-			builder.force_commit(and);
+			builder.mark_inout(builder.band(pair[0], pair[1]));
 		}
 		let circuit = builder.build();
 
-		// Every instance gets its own seed, so no two instances share a witness.
+		// Every instance gets its own seed, so no two instances share an input.
 		ValueTable::populate(&circuit, 3, |i, w| {
 			let mut rng = StdRng::seed_from_u64(i as u64);
 			for &wire in &inputs {
-				w[wire] = Word(rng.next_u64());
+				w[wire] = Word(rng.random());
 			}
 		})
 		.unwrap()

--- a/crates/m4-prover/src/witness/operand_columns.rs
+++ b/crates/m4-prover/src/witness/operand_columns.rs
@@ -674,10 +674,10 @@ mod tests {
 
 	fn and_circuit() -> AndCircuit {
 		let builder = CircuitBuilder::new();
-		let x = builder.add_witness();
-		let y = builder.add_witness();
-		let w = builder.add_witness();
-		let z = builder.add_witness();
+		let x = builder.add_inout();
+		let y = builder.add_inout();
+		let w = builder.add_inout();
+		let z = builder.add_inout();
 		let and = builder.band(x, y);
 		let lhs = builder.bxor(and, w);
 		builder.assert_eq("z_eq_x_and_y_xor_w", lhs, z);
@@ -775,13 +775,13 @@ mod tests {
 		assert_eq!(b, b_ref);
 	}
 
-	// A circuit computing one unsigned 64×64→128 product, with both result words committed.
+	// A circuit computing one unsigned 64×64→128 product.
 	//
-	//     inputs : x, y   (witness)
-	//     gate   : (hi, lo) = imul(x, y)   → 1 IMUL constraint (+ 1 AND security check)
+	//     inputs  : x, y                     (inout)
+	//     outputs : hi, lo                   (promoted to inout)
+	//     gate    : (hi, lo) = imul(x, y)   → 1 IMUL constraint (+ 1 AND security check)
 	//
-	// `force_commit` makes `hi` and `lo` hidden words, so the IMUL operands read them from the
-	// table.
+	// The product words are inout, so the IMUL operands read them from the table's committed rows.
 	struct MulCircuit {
 		circuit: Circuit,
 		x: Wire,
@@ -790,11 +790,11 @@ mod tests {
 
 	fn mul_circuit() -> MulCircuit {
 		let builder = CircuitBuilder::new();
-		let x = builder.add_witness();
-		let y = builder.add_witness();
+		let x = builder.add_inout();
+		let y = builder.add_inout();
 		let (hi, lo) = builder.imul(x, y);
-		builder.force_commit(hi);
-		builder.force_commit(lo);
+		builder.mark_inout(hi);
+		builder.mark_inout(lo);
 		MulCircuit {
 			circuit: builder.build(),
 			x,
@@ -859,14 +859,13 @@ mod tests {
 		}
 	}
 
-	// A circuit computing one GHASH-field product `(a_lo, a_hi) * (b_lo, b_hi)`, with both product
-	// words committed.
+	// A circuit computing one GHASH-field product `(a_lo, a_hi) * (b_lo, b_hi)`.
 	//
-	//     inputs : a_lo, a_hi, b_lo, b_hi   (witness)
-	//     gate   : (c_lo, c_hi) = bmul(a_lo, a_hi, b_lo, b_hi)   → 1 BMUL constraint
+	//     inputs  : a_lo, a_hi, b_lo, b_hi   (inout)
+	//     outputs : c_lo, c_hi               (promoted to inout)
+	//     gate    : (c_lo, c_hi) = bmul(a_lo, a_hi, b_lo, b_hi)   → 1 BMUL constraint
 	//
-	// `force_commit` makes `c_lo` and `c_hi` hidden words, so the BMUL operands read them from the
-	// table.
+	// The product words are inout, so the BMUL operands read them from the table's committed rows.
 	struct BinMulCircuit {
 		circuit: Circuit,
 		a_lo: Wire,
@@ -877,13 +876,13 @@ mod tests {
 
 	fn binmul_circuit() -> BinMulCircuit {
 		let builder = CircuitBuilder::new();
-		let a_lo = builder.add_witness();
-		let a_hi = builder.add_witness();
-		let b_lo = builder.add_witness();
-		let b_hi = builder.add_witness();
+		let a_lo = builder.add_inout();
+		let a_hi = builder.add_inout();
+		let b_lo = builder.add_inout();
+		let b_hi = builder.add_inout();
 		let (c_lo, c_hi) = builder.bmul(a_lo, a_hi, b_lo, b_hi);
-		builder.force_commit(c_lo);
-		builder.force_commit(c_hi);
+		builder.mark_inout(c_lo);
+		builder.mark_inout(c_hi);
 		BinMulCircuit {
 			circuit: builder.build(),
 			a_lo,

--- a/crates/m4-prover/tests/prove_hash_primitives.rs
+++ b/crates/m4-prover/tests/prove_hash_primitives.rs
@@ -130,12 +130,11 @@ where
 		.expect("no trailing proof data");
 }
 
-/// The witness input wires of one two-lane BLAKE3 compression.
+/// The public wires of one two-lane BLAKE3 compression.
 ///
 /// Each wire packs two independent compressions.
 /// Lane 0 sits in the low 32 bits, lane 1 in the high 32.
-/// The output is force-committed, so the circuit has no inout wires.
-struct Blake3Inputs {
+struct Blake3Wires {
 	/// The 8-word input chaining value, two lanes per word.
 	cv: [Wire; 8],
 	/// The 16-word message block, two lanes per word.
@@ -150,43 +149,42 @@ struct Blake3Inputs {
 	flags: Wire,
 }
 
-/// Builds a circuit for `N` independent two-lane BLAKE3 compressions, force-committing every
-/// output word.
+/// Builds a circuit for `N` independent two-lane BLAKE3 compressions.
 ///
 /// Each two-lane compression is itself two independent compressions, so the circuit proves
 /// `2 * N` compressions total.
 /// Packing several into one circuit fills the value vector more densely, so less of it is padding.
-fn build_blake3_circuit<const N: usize>() -> (Circuit, [Blake3Inputs; N]) {
+fn build_blake3_circuit<const N: usize>() -> (Circuit, [Blake3Wires; N]) {
 	let builder = CircuitBuilder::new();
 
-	// Every compression's inputs are witness wires.
-	let inputs: [Blake3Inputs; N] = array::from_fn(|_| Blake3Inputs {
-		cv: array::from_fn(|_| builder.add_witness()),
-		block: array::from_fn(|_| builder.add_witness()),
-		counter_lo: builder.add_witness(),
-		counter_hi: builder.add_witness(),
-		block_len: builder.add_witness(),
-		flags: builder.add_witness(),
+	// Every compression's inputs are public.
+	let wires: [Blake3Wires; N] = array::from_fn(|_| Blake3Wires {
+		cv: array::from_fn(|_| builder.add_inout()),
+		block: array::from_fn(|_| builder.add_inout()),
+		counter_lo: builder.add_inout(),
+		counter_hi: builder.add_inout(),
+		block_len: builder.add_inout(),
+		flags: builder.add_inout(),
 	});
 
-	for &Blake3Inputs {
+	for &Blake3Wires {
 		cv,
 		block,
 		counter_lo,
 		counter_hi,
 		block_len,
 		flags,
-	} in &inputs
+	} in &wires
 	{
-		// Force-commit each output word.
-		// This keeps the compression alive under dead-code elimination.
+		// Promote each output chaining-value word to a public output.
+		// That promotion keeps the compression alive under dead-code elimination.
 		let out = blake3_compress_2x(&builder, cv, block, counter_lo, counter_hi, block_len, flags);
 		for wire in out {
-			builder.force_commit(wire);
+			builder.mark_inout(wire);
 		}
 	}
 
-	(builder.build(), inputs)
+	(builder.build(), wires)
 }
 
 /// Packs two independent 32-bit lane values into one 64-bit word.
@@ -199,42 +197,41 @@ const fn pack_lanes(lane0: u32, lane1: u32) -> Word {
 /// The compression derives its output from these inputs.
 /// So any assignment is valid.
 fn fill_blake3<const N: usize>(
-	inputs: &[Blake3Inputs; N],
+	wires: &[Blake3Wires; N],
 	_instance: usize,
 	w: &mut BatchWitnessFiller<'_, '_>,
 ) {
 	let mut rng = StdRng::seed_from_u64(0);
 
-	for input in inputs {
+	for wire_set in wires {
 		// A 32-bit value per chaining-value word, per lane.
-		for wire in input.cv {
+		for wire in wire_set.cv {
 			w[wire] = pack_lanes(rng.next_u32(), rng.next_u32());
 		}
 		// A 32-bit value per message word, per lane.
-		for wire in input.block {
+		for wire in wire_set.block {
 			w[wire] = pack_lanes(rng.next_u32(), rng.next_u32());
 		}
 		// The 64-bit counter, split into low and high halves, per lane.
-		w[input.counter_lo] = pack_lanes(rng.next_u32(), rng.next_u32());
-		w[input.counter_hi] = pack_lanes(rng.next_u32(), rng.next_u32());
+		w[wire_set.counter_lo] = pack_lanes(rng.next_u32(), rng.next_u32());
+		w[wire_set.counter_hi] = pack_lanes(rng.next_u32(), rng.next_u32());
 		// A byte length in 0..=64, per lane.
-		w[input.block_len] = pack_lanes(rng.next_u32() % 65, rng.next_u32() % 65);
+		w[wire_set.block_len] = pack_lanes(rng.next_u32() % 65, rng.next_u32() % 65);
 		// Arbitrary domain-separation flags, per lane.
-		w[input.flags] = pack_lanes(rng.next_u32(), rng.next_u32());
+		w[wire_set.flags] = pack_lanes(rng.next_u32(), rng.next_u32());
 	}
 }
 
-/// Builds a circuit for `N` independent Keccak-f1600 permutations, force-committing every output
-/// state.
+/// Builds a circuit for `N` independent Keccak-f1600 permutations.
 ///
 /// The permutations share no wires.
 /// Packing several into one circuit fills the value vector more densely, so less of it is padding.
 fn build_keccak_circuit<const N: usize>() -> (Circuit, [[Wire; KECCAK_STATE_LANES]; N]) {
 	let builder = CircuitBuilder::new();
 
-	// Each permutation gets its own 25-lane witness input state.
+	// Each permutation gets its own 25-lane public input state.
 	let inputs: [[Wire; KECCAK_STATE_LANES]; N] =
-		array::from_fn(|_| array::from_fn(|_| builder.add_witness()));
+		array::from_fn(|_| array::from_fn(|_| builder.add_inout()));
 
 	for input in inputs {
 		// Permute a copy of the input in place.
@@ -242,10 +239,10 @@ fn build_keccak_circuit<const N: usize>() -> (Circuit, [[Wire; KECCAK_STATE_LANE
 		let mut state = input;
 		keccak_f1600(&builder, &mut state);
 
-		// Force-commit the output lanes.
-		// This keeps the permutation alive under dead-code elimination.
+		// Promote the permuted lanes to public outputs.
+		// That promotion keeps the permutation alive under dead-code elimination.
 		for wire in state {
-			builder.force_commit(wire);
+			builder.mark_inout(wire);
 		}
 	}
 
@@ -269,7 +266,7 @@ fn fill_keccak<const N: usize>(
 	}
 }
 
-/// Builds a circuit for one 64×64→128-bit integer multiplication and force-commits its output.
+/// Builds a circuit for one 64×64→128-bit integer multiplication.
 ///
 /// Unlike the hash primitives (which are purely bitwise / carry-adder based), this circuit has IMUL
 /// constraints, so its M4 proof commits the extra IntMul logup* pushforward oracle — exercising the
@@ -277,14 +274,14 @@ fn fill_keccak<const N: usize>(
 fn build_imul_circuit() -> (Circuit, [Wire; 2]) {
 	let builder = CircuitBuilder::new();
 
-	// Two 64-bit witness factors.
-	let a = builder.add_witness();
-	let b = builder.add_witness();
+	// Two 64-bit public factors.
+	let a = builder.add_inout();
+	let b = builder.add_inout();
 
-	// Force-commit the 128-bit product halves so the multiplication survives dead-code elimination.
+	// Promoting the product halves keeps the multiplication alive under dead-code elimination.
 	let (hi, lo) = builder.imul(a, b);
-	builder.force_commit(hi);
-	builder.force_commit(lo);
+	builder.mark_inout(hi);
+	builder.mark_inout(lo);
 
 	(builder.build(), [a, b])
 }


### PR DESCRIPTION
Closes [BINIUS-426](https://linear.app/jimpo/issue/BINIUS-426/m4-build-the-test-and-bench-circuits-with-inout-wires-instead-of-force). Follow-up to [BINIUS-424](https://linear.app/jimpo/issue/BINIUS-424) (#2077), now rebased on [#2079](https://github.com/binius-zk/binius64/pull/2079) which added `CircuitBuilder::mark_inout`.

Every circuit fixture in `binius-m4-prover` allocated its inputs as witness wires and kept its outputs alive with `force_commit`. That was forced on them: the batch witness table rejected inout wires, so a fixture had no way to declare public inputs and outputs. #2077 lifted the restriction.

## The change

Build the fixtures the way a real circuit is built: the inputs are inout wires and each gadget output is promoted to one with `mark_inout`, which is what keeps the gadget alive under dead-code elimination. **`force_commit` now has no use anywhere in the crate** — all 51 calls are gone.

## It costs nothing

An earlier revision of this PR declared separate inout outputs and `assert_eq`'d the gadget against them. That was measurably worse, and prompted #2079. Promoting instead lands exactly on the `force_commit` baseline:

| circuit | committed words | AND | ZERO |
|---|---|---|---|
| `keccak_f1600` | 625 → **625** | 600 → **600** | 0 → 0 |
| `blake3_compress_2x` | 596 → **596** | 336 → **336** | 232 → **232** |
| `sha256_compress_2x` | 934 → **934** | 728 → **728** | 182 → **182** |

Every count is unchanged from the `force_commit` form, while 50 / 36 / 32 words respectively are now public. The assert form would have cost Keccak 25 words and 25 AND constraints — 4% of the circuit — because its lanes leave the chi step as AND outputs that must be committed regardless.

So the bench circuits are byte-for-byte the same shape they were; **bench numbers remain comparable across this commit**.

## What this buys

The operand columns now resolve inout indices through their own `ValueSegment::InOut` arm, which no fixture reached before — #2077 added that arm covered only by its own round trip.

## Note on the reference implementations

The intermediate assert-based revision filled the public outputs from reference implementations (`ref_compress`, the `keccak` crate), which incidentally checked each gadget against its reference. Promotion derives the outputs from the gate instead, so those fills — and the `keccak` dev-dependency — are gone. No coverage is lost: `binius-circuits` already tests these gadgets against references itself (`compress_matches_reference` for BLAKE3, and the Keccak gadget against the `sha3` crate). Verifying hash gadgets is that crate's job, not the M4 prover's.

## Tests

No new tests; this rebuilds existing fixtures. All 44 unit tests, the 6 hash-primitive integration tests, clippy and the full `prek` hook set pass, and the benches build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)