### PR TITLE
BINIUS-436: add CircuitBuilder::mark_inout

### DIFF
--- a/crates/frontend/src/compiler/circuit.rs
+++ b/crates/frontend/src/compiler/circuit.rs
@@ -217,7 +217,9 @@ impl Circuit {
 	/// - [`CircuitBuilder::add_witness`] that were not created by the gates,
 	///
 	/// The wires created by [`CircuitBuilder::add_constant`] (and its convenience methods)
-	/// are automatically populated by this function as well.
+	/// are automatically populated by this function as well. So is a wire promoted with
+	/// [`CircuitBuilder::mark_inout`]: it is public but gate-derived, so the caller leaves it
+	/// unset and reads the computed value back afterwards.
 	///
 	/// # Errors
 	///
@@ -228,6 +230,7 @@ impl Circuit {
 	/// [`CircuitBuilder::add_constant`]: super::CircuitBuilder::add_constant
 	/// [`CircuitBuilder::add_inout`]: super::CircuitBuilder::add_inout
 	/// [`CircuitBuilder::add_witness`]: super::CircuitBuilder::add_witness
+	/// [`CircuitBuilder::mark_inout`]: super::CircuitBuilder::mark_inout
 	pub fn populate_wire_witness(&self, w: &mut WitnessFiller) -> Result<(), PopulateError> {
 		// Fill the constant part from the witness.
 		for (index, constant) in self.constraint_system.constants.iter().enumerate() {
@@ -249,14 +252,17 @@ impl Circuit {
 	/// instance's [`ValueVec`] uses) and columns are instances. Its height must be the full
 	/// value-vector length (including scratch) and its width is the instance count.
 	///
-	/// The caller must fill each instance's input rows first — the witness wires and any inout
-	/// wires. This function fills the constant rows (broadcasting each constant across every
+	/// The caller must fill each instance's input rows first — the witness wires and any declared
+	/// inout wires, but not a wire promoted with [`CircuitBuilder::mark_inout`], which its gate
+	/// derives. This function fills the constant rows (broadcasting each constant across every
 	/// instance) and then evaluates the circuit gate-by-gate for all instances.
 	///
 	/// # Errors
 	///
 	/// If any instance is not satisfiable, returns an error naming the lowest-indexed failing
 	/// instance and its assertion failures.
+	///
+	/// [`CircuitBuilder::mark_inout`]: super::CircuitBuilder::mark_inout
 	pub fn populate_wire_witness_batched(
 		&self,
 		values: &mut StridedArray2DViewMut<'_, Word>,

--- a/crates/frontend/src/compiler/mod.rs
+++ b/crates/frontend/src/compiler/mod.rs
@@ -434,6 +434,49 @@ impl CircuitBuilder {
 			.insert(wire);
 	}
 
+	/// Promotes a gate-created wire to a public output.
+	///
+	/// The wire moves from the private segment to the inout one, joining the circuit's public
+	/// interface. This is what a circuit exposing a gadget's result wants: declaring a separate
+	/// inout wire and asserting the result against it costs a second committed word and a
+	/// constraint whenever the result is a wire that has to be committed anyway.
+	///
+	/// The value is still derived by the gate producing it, so a witness filler must *not* assign
+	/// it — unlike a wire from [`Self::add_inout`], which the filler is required to set.
+	///
+	/// Promoting also pins the wire, so this subsumes [`Self::force_commit`] rather than needing
+	/// it alongside.
+	///
+	/// # Position in the segment
+	///
+	/// The inout segment is ordered by wire creation, so a promoted wire follows the declared
+	/// inout wires and sits among its fellow promotions in the order their gates created them —
+	/// which is not necessarily the order they are promoted in. That is invisible to a caller
+	/// filling by [`Wire`], but a caller building the positional public-input vector a verifier
+	/// takes should read each index back with
+	/// [`Circuit::witness_index`](super::Circuit::witness_index) rather than assume promotion
+	/// order.
+	///
+	/// # Panics
+	///
+	/// Panics unless the wire is a gate-created internal wire. A constant, an input, or an
+	/// already-public wire has nothing to promote.
+	pub fn mark_inout(&self, wire: Wire) {
+		{
+			let mut graph = self.graph_mut();
+			assert!(
+				matches!(graph.wire_kind(wire), WireKind::Internal),
+				"only a gate-created wire can be promoted to a public output"
+			);
+			graph.wires[wire] = WireKind::Inout;
+		}
+
+		// Dead-code elimination and CSE already treat an inout wire as observable, but gate fusion
+		// reads only the pinned set: without this it would inline a linear definition and leave the
+		// public word with no constraint defining it.
+		self.force_commit(wire);
+	}
+
 	/// Shares the value-vector slots of values the constraint system never references.
 	///
 	/// # Overview

--- a/crates/frontend/src/compiler/tests.rs
+++ b/crates/frontend/src/compiler/tests.rs
@@ -983,3 +983,107 @@ fn test_zero_constant_not_in_binius64_operands() {
 		assert_no_zero_constants(&constraint.0, "BMUL");
 	}
 }
+
+// Promoting a gate output to a public output costs neither a second committed word nor a
+// constraint, unlike declaring an inout wire and asserting the gate output against it.
+//
+// The three circuits below compute the same conjunction and differ only in how its result is
+// exposed. `a & b` is an AND-gate output, so it occupies a committed word in every one of them.
+#[test]
+fn mark_inout_promotes_without_duplicating() {
+	// The inout count, the private count, and the AND-constraint count of one circuit.
+	let shape = |build: &dyn Fn(&CircuitBuilder)| {
+		let builder = CircuitBuilder::new();
+		build(&builder);
+		let circuit = builder.build();
+		let layout = circuit.value_vec_layout();
+		(layout.n_inout, layout.n_private(), circuit.constraint_system().and_constraints.len())
+	};
+
+	// The result kept alive by pinning: private, and not part of the public interface.
+	let (pinned_inout, pinned_private, pinned_and) = shape(&|builder| {
+		let a = builder.add_inout();
+		let b = builder.add_inout();
+		builder.force_commit(builder.band(a, b));
+	});
+
+	// The result asserted against a separately declared public output.
+	let (asserted_inout, asserted_private, asserted_and) = shape(&|builder| {
+		let a = builder.add_inout();
+		let b = builder.add_inout();
+		let out = builder.add_inout();
+		builder.assert_eq("out", out, builder.band(a, b));
+	});
+
+	// The result promoted in place.
+	let (promoted_inout, promoted_private, promoted_and) = shape(&|builder| {
+		let a = builder.add_inout();
+		let b = builder.add_inout();
+		builder.mark_inout(builder.band(a, b));
+	});
+
+	// Asserting duplicates the conjunction: its own committed word, plus the declared output's,
+	// plus the AND constraint tying them together.
+	assert_eq!(asserted_inout + asserted_private, pinned_inout + pinned_private + 1);
+	assert_eq!(asserted_and, pinned_and + 1);
+
+	// Promoting costs nothing over pinning — it is the same word, relabelled public.
+	assert_eq!(promoted_inout + promoted_private, pinned_inout + pinned_private);
+	assert_eq!(promoted_and, pinned_and);
+	assert_eq!(promoted_inout, pinned_inout + 1);
+	assert_eq!(promoted_private, pinned_private - 1);
+}
+
+// A promoted wire is derived by the gate that produces it, so a filler leaves it alone and reads
+// the computed value back — unlike a declared inout wire, which the filler must assign.
+//
+// The XOR is the case promotion has to pin: gate fusion inlines a linear definition into its
+// consumers, which would leave the public word with nothing defining it.
+#[test]
+fn mark_inout_wire_is_derived_by_population() {
+	let builder = CircuitBuilder::new();
+	let a = builder.add_inout();
+	let b = builder.add_inout();
+	let c = builder.add_inout();
+	// The XOR feeds the AND, so gate fusion has somewhere to inline it — the case promotion has
+	// to pin against.
+	let xor = builder.bxor(a, b);
+	let and = builder.band(xor, c);
+	builder.mark_inout(xor);
+	builder.mark_inout(and);
+	let circuit = builder.build();
+
+	// Both promoted wires are public.
+	assert_eq!(circuit.value_vec_layout().n_inout, 5);
+	for wire in [xor, and] {
+		assert_eq!(circuit.witness_index(wire).segment(), ValueSegment::InOut);
+	}
+
+	// Only the two inputs are assigned; the derived words are left unset.
+	let mut filler = circuit.new_witness_filler();
+	filler[a] = Word(0xF0F0_F0F0_F0F0_F0F0);
+	filler[b] = Word(0xFF00_FF00_FF00_FF00);
+	filler[c] = Word(0xFFFF_0000_FFFF_0000);
+	circuit.populate_wire_witness(&mut filler).unwrap();
+
+	assert_eq!(filler[xor], Word(0x0FF0_0FF0_0FF0_0FF0));
+	assert_eq!(filler[and], Word(0x0FF0_0000_0FF0_0000));
+
+	// Every promoted word is defined by a constraint. This is what pinning buys for the XOR: left
+	// unpinned, gate fusion would inline the linear definition and leave the public word free for
+	// a prover to choose.
+	let cs = circuit.constraint_system();
+	let operands = cs
+		.zero_constraints
+		.iter()
+		.flat_map(|c| c.0.iter())
+		.chain(cs.and_constraints.iter().flat_map(|c| c.0.iter()));
+	let constrained: HashSet<ValueIndex> =
+		operands.flatten().map(|term| term.value_index).collect();
+	for wire in [xor, and] {
+		assert!(
+			constrained.contains(&circuit.witness_index(wire)),
+			"a promoted word must be defined by a constraint"
+		);
+	}
+}


### PR DESCRIPTION
Closes [BINIUS-436](https://linear.app/jimpo/issue/BINIUS-436/frontend-circuitbuildermark_inout-to-promote-a-gate-output). Blocks [#2078](https://github.com/binius-zk/binius64/pull/2078), which should use this instead of `assert_eq`.

A circuit exposing a gadget's result as a public output has to declare a separate inout wire and assert the result against it. Where the result is a wire that must be committed anyway — a non-linear gate output — that duplicates it: the wire keeps its committed word, the inout word is added beside it, and the assert costs a constraint.

Measured on the M4 fixtures (committed = `n_inout + n_private`):

| circuit | committed | AND |
|---|---|---|
| `blake3_compress_2x` | 596 → 596 | 336 → 344 (ZERO 232 → 224) |
| `sha256_compress_2x` | 934 → 934 | 728 → 736 (ZERO 182 → 174) |
| `keccak_f1600` | 625 → **650** (+4.0%) | 600 → **625** (+4.2%) |
| `imul` | 4 → **6** | 0 → 2 |

BLAKE3 and SHA-256 end on XOR, so gate fusion inlines the output into the assert and nothing grows. Keccak's lanes come out of the chi step's AND and IMUL's `hi`/`lo` are IMUL outputs, so those pay in full.

## The change

`mark_inout(wire)` moves a gate-created wire from the private segment to the inout one, so the wire *is* the public output. Segment placement is decided by the wire kind in the routing loop, so flipping the kind is the whole placement change.

Measured on Keccak with the three options side by side:

```
force_commit         n_inout=  0  committed= 625  and= 600
inout + assert_eq    n_inout= 50  committed= 650  and= 625
inout + mark_inout   n_inout= 50  committed= 625  and= 600
```

Promotion matches the `force_commit` baseline exactly while making 50 words public.

## Why it also pins

Dead-code elimination and CSE already treat an inout wire as observable, so they need nothing. Gate fusion is different: it reads only the pinned set, and an unpinned **linear** definition gets inlined into its consumer — which would leave the public word with no constraint defining it, free for a prover to choose.

I verified this is load-bearing rather than assuming it: with the `force_commit` call removed, `mark_inout_wire_is_derived_by_population` fails on "a promoted word must be defined by a constraint". The fixture is an XOR feeding an AND, so fusion has somewhere to inline it — an unconsumed linear wire does not reproduce it.

## Population contract

A promoted value is derived by its gate, so a filler must **not** assign it, unlike a declared inout wire which the filler is required to set. `populate_wire_witness` and `populate_wire_witness_batched` now say which is which.

## Ordering — worth your eye

The inout segment is ordered by wire creation, so a promoted wire follows the declared inout wires and sits among its fellow promotions in *gate-creation* order, not the order they were promoted in. For Keccak the two coincide (the promoted lanes land at indices 25–49 in lane order), so this is documented rather than engineered around.

That is invisible to a caller filling by `Wire` — which is what M4 and `WitnessFiller` do — but `Verifier::verify(&inout, ...)` takes a positional `&[Word]`. The doc directs such a caller to read each index back with `Circuit::witness_index`. If you would rather `mark_inout` record call order and have the allocator honor it, that is a small change and I will make it.

## Tests

* `mark_inout_promotes_without_duplicating` — the same conjunction exposed three ways; asserting costs a word and a constraint over pinning, promoting costs neither, and the wire really does move from private to public.
* `mark_inout_wire_is_derived_by_population` — a promoted wire is derived without the filler assigning it, and every promoted word is defined by a constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)