### PR TITLE
BINIUS-416: unify the frontend shift algebra with the core Shift type

### DIFF
--- a/crates/core/src/constraint_system/shift.rs
+++ b/crates/core/src/constraint_system/shift.rs
@@ -168,6 +168,15 @@ impl ShiftVariant {
 		)
 	}
 
+	/// Whether this variant wraps the bits it moves out, rather than discarding them.
+	///
+	/// A cyclic variant loses nothing, so any two of its shifts compose however far they move;
+	/// every other variant drops what it carries past the end.
+	#[inline]
+	pub const fn is_cyclic(self) -> bool {
+		matches!(self, ShiftVariant::Rotr | ShiftVariant::Rotr32)
+	}
+
 	/// The exclusive upper bound on a valid shift amount for this variant.
 	///
 	/// - Half-word (`*32`) variants read only the lower 5 bits, so amounts run `0..32`.
@@ -333,11 +342,10 @@ impl Shift {
 	///
 	/// Panics if the amount is not below the variant's [`max_amount`](ShiftVariant::max_amount):
 	/// 32 for the half-word (`*32`) variants, 64 for the rest.
-	pub fn new(variant: ShiftVariant, amount: usize) -> Self {
-		assert!(
-			amount < variant.max_amount(),
-			"shift amount n={amount} out of range for {variant:?}"
-		);
+	pub const fn new(variant: ShiftVariant, amount: usize) -> Self {
+		// A const context cannot format, so the amount and variant are left to the panic location
+		// rather than spelled into the message.
+		assert!(amount < variant.max_amount(), "shift amount out of range for this variant");
 		Self {
 			variant,
 			// An amount below 64 always fits in the byte-sized field.
@@ -349,7 +357,7 @@ impl Shift {
 	///
 	/// # Panics
 	/// Panics if the shift amount is greater than or equal to 64.
-	pub fn sll(amount: usize) -> Self {
+	pub const fn sll(amount: usize) -> Self {
 		Self::new(ShiftVariant::Sll, amount)
 	}
 
@@ -357,7 +365,7 @@ impl Shift {
 	///
 	/// # Panics
 	/// Panics if the shift amount is greater than or equal to 64.
-	pub fn srl(amount: usize) -> Self {
+	pub const fn srl(amount: usize) -> Self {
 		Self::new(ShiftVariant::Slr, amount)
 	}
 
@@ -368,7 +376,7 @@ impl Shift {
 	///
 	/// # Panics
 	/// Panics if the shift amount is greater than or equal to 64.
-	pub fn sar(amount: usize) -> Self {
+	pub const fn sar(amount: usize) -> Self {
 		Self::new(ShiftVariant::Sar, amount)
 	}
 
@@ -378,7 +386,7 @@ impl Shift {
 	///
 	/// # Panics
 	/// Panics if the shift amount is greater than or equal to 64.
-	pub fn rotr(amount: usize) -> Self {
+	pub const fn rotr(amount: usize) -> Self {
 		Self::new(ShiftVariant::Rotr, amount)
 	}
 
@@ -388,7 +396,7 @@ impl Shift {
 	///
 	/// # Panics
 	/// Panics if the shift amount is greater than or equal to 32.
-	pub fn sll32(amount: usize) -> Self {
+	pub const fn sll32(amount: usize) -> Self {
 		Self::new(ShiftVariant::Sll32, amount)
 	}
 
@@ -398,7 +406,7 @@ impl Shift {
 	///
 	/// # Panics
 	/// Panics if the shift amount is greater than or equal to 32.
-	pub fn srl32(amount: usize) -> Self {
+	pub const fn srl32(amount: usize) -> Self {
 		Self::new(ShiftVariant::Srl32, amount)
 	}
 
@@ -409,7 +417,7 @@ impl Shift {
 	///
 	/// # Panics
 	/// Panics if the shift amount is greater than or equal to 32.
-	pub fn sra32(amount: usize) -> Self {
+	pub const fn sra32(amount: usize) -> Self {
 		Self::new(ShiftVariant::Sra32, amount)
 	}
 
@@ -419,7 +427,7 @@ impl Shift {
 	///
 	/// # Panics
 	/// Panics if the shift amount is greater than or equal to 32.
-	pub fn rotr32(amount: usize) -> Self {
+	pub const fn rotr32(amount: usize) -> Self {
 		Self::new(ShiftVariant::Rotr32, amount)
 	}
 
@@ -661,7 +669,7 @@ impl ShiftedValueIndex {
 	///
 	/// # Panics
 	/// Panics if the shift amount is greater than or equal to 64.
-	pub fn sll(value_index: ValueIndex, amount: usize) -> Self {
+	pub const fn sll(value_index: ValueIndex, amount: usize) -> Self {
 		Self {
 			value_index,
 			shift: Shift::sll(amount),
@@ -672,7 +680,7 @@ impl ShiftedValueIndex {
 	///
 	/// # Panics
 	/// Panics if the shift amount is greater than or equal to 64.
-	pub fn srl(value_index: ValueIndex, amount: usize) -> Self {
+	pub const fn srl(value_index: ValueIndex, amount: usize) -> Self {
 		Self {
 			value_index,
 			shift: Shift::srl(amount),
@@ -686,7 +694,7 @@ impl ShiftedValueIndex {
 	///
 	/// # Panics
 	/// Panics if the shift amount is greater than or equal to 64.
-	pub fn sar(value_index: ValueIndex, amount: usize) -> Self {
+	pub const fn sar(value_index: ValueIndex, amount: usize) -> Self {
 		Self {
 			value_index,
 			shift: Shift::sar(amount),
@@ -699,7 +707,7 @@ impl ShiftedValueIndex {
 	///
 	/// # Panics
 	/// Panics if the shift amount is greater than or equal to 64.
-	pub fn rotr(value_index: ValueIndex, amount: usize) -> Self {
+	pub const fn rotr(value_index: ValueIndex, amount: usize) -> Self {
 		Self {
 			value_index,
 			shift: Shift::rotr(amount),
@@ -713,7 +721,7 @@ impl ShiftedValueIndex {
 	///
 	/// # Panics
 	/// Panics if the shift amount is greater than or equal to 32.
-	pub fn sll32(value_index: ValueIndex, amount: usize) -> Self {
+	pub const fn sll32(value_index: ValueIndex, amount: usize) -> Self {
 		Self {
 			value_index,
 			shift: Shift::sll32(amount),
@@ -727,7 +735,7 @@ impl ShiftedValueIndex {
 	///
 	/// # Panics
 	/// Panics if the shift amount is greater than or equal to 32.
-	pub fn srl32(value_index: ValueIndex, amount: usize) -> Self {
+	pub const fn srl32(value_index: ValueIndex, amount: usize) -> Self {
 		Self {
 			value_index,
 			shift: Shift::srl32(amount),
@@ -742,7 +750,7 @@ impl ShiftedValueIndex {
 	///
 	/// # Panics
 	/// Panics if the shift amount is greater than or equal to 32.
-	pub fn sra32(value_index: ValueIndex, amount: usize) -> Self {
+	pub const fn sra32(value_index: ValueIndex, amount: usize) -> Self {
 		Self {
 			value_index,
 			shift: Shift::sra32(amount),
@@ -756,7 +764,7 @@ impl ShiftedValueIndex {
 	///
 	/// # Panics
 	/// Panics if the shift amount is greater than or equal to 32.
-	pub fn rotr32(value_index: ValueIndex, amount: usize) -> Self {
+	pub const fn rotr32(value_index: ValueIndex, amount: usize) -> Self {
 		Self {
 			value_index,
 			shift: Shift::rotr32(amount),

--- a/crates/frontend/src/compiler/constraint_builder/expr.rs
+++ b/crates/frontend/src/compiler/constraint_builder/expr.rs
@@ -3,9 +3,10 @@
 
 //! The operand expression DSL: build a [`WireExpr`] as an XOR of shifted-wire terms.
 
+use binius_core::constraint_system::Shift;
 use smallvec::{SmallVec, smallvec};
 
-use super::shift::{Shift, ShiftedWire, WireOperand};
+use super::shift::{ShiftedWire, WireOperand};
 use crate::compiler::Wire;
 
 /// An operand under construction: the XOR of its terms.
@@ -48,7 +49,7 @@ impl WireExprTerm {
 		match self {
 			WireExprTerm::Wire(wire) => ShiftedWire {
 				wire,
-				shift: Shift::None,
+				shift: Shift::IDENTITY,
 			},
 			WireExprTerm::Shifted(wire, shift) => ShiftedWire { wire, shift },
 		}
@@ -63,42 +64,42 @@ impl From<Wire> for WireExprTerm {
 
 /// Left-shifts the whole word by `n`.
 pub const fn sll(w: Wire, n: u32) -> WireExprTerm {
-	WireExprTerm::Shifted(w, Shift::Sll(n))
+	WireExprTerm::Shifted(w, Shift::sll(n as usize))
 }
 
 /// Half-wise left-shifts each 32-bit lane by `n`.
 pub const fn sll32(w: Wire, n: u32) -> WireExprTerm {
-	WireExprTerm::Shifted(w, Shift::Sll32(n))
+	WireExprTerm::Shifted(w, Shift::sll32(n as usize))
 }
 
 /// Logically right-shifts the whole word by `n`.
 pub const fn srl(w: Wire, n: u32) -> WireExprTerm {
-	WireExprTerm::Shifted(w, Shift::Srl(n))
+	WireExprTerm::Shifted(w, Shift::srl(n as usize))
 }
 
 /// Half-wise logically right-shifts each 32-bit lane by `n`.
 pub const fn srl32(w: Wire, n: u32) -> WireExprTerm {
-	WireExprTerm::Shifted(w, Shift::Srl32(n))
+	WireExprTerm::Shifted(w, Shift::srl32(n as usize))
 }
 
 /// Arithmetically right-shifts the whole word by `n`.
 pub const fn sar(w: Wire, n: u32) -> WireExprTerm {
-	WireExprTerm::Shifted(w, Shift::Sar(n))
+	WireExprTerm::Shifted(w, Shift::sar(n as usize))
 }
 
 /// Half-wise arithmetically right-shifts each 32-bit lane by `n`.
 pub const fn sra32(w: Wire, n: u32) -> WireExprTerm {
-	WireExprTerm::Shifted(w, Shift::Sra32(n))
+	WireExprTerm::Shifted(w, Shift::sra32(n as usize))
 }
 
 /// Rotates the whole word right by `n`.
 pub const fn rotr(w: Wire, n: u32) -> WireExprTerm {
-	WireExprTerm::Shifted(w, Shift::Rotr(n))
+	WireExprTerm::Shifted(w, Shift::rotr(n as usize))
 }
 
 /// Half-wise rotates each 32-bit lane right by `n`.
 pub const fn rotr32(w: Wire, n: u32) -> WireExprTerm {
-	WireExprTerm::Shifted(w, Shift::Rotr32(n))
+	WireExprTerm::Shifted(w, Shift::rotr32(n as usize))
 }
 
 /// XOR of two terms.

--- a/crates/frontend/src/compiler/constraint_builder/mod.rs
+++ b/crates/frontend/src/compiler/constraint_builder/mod.rs
@@ -16,7 +16,7 @@ pub use constraint::{
 use cranelift_entity::{EntitySet, SecondaryMap};
 use expr::WireExpr;
 pub use expr::WireExprTerm;
-pub use shift::{Shift, ShiftKind, ShiftedWire, WireOperand};
+pub use shift::{ShiftedWire, WireOperand};
 
 use crate::compiler::Wire;
 

--- a/crates/frontend/src/compiler/constraint_builder/shift.rs
+++ b/crates/frontend/src/compiler/constraint_builder/shift.rs
@@ -1,11 +1,11 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
-//! The shift algebra shared by operands: a [`Shift`] applied to a [`Wire`].
+//! The shift algebra shared by operands: a core [`Shift`] applied to a [`Wire`].
 
 use std::ops::Index;
 
-use binius_core::constraint_system::{ShiftedValueIndex, ValueIndex};
+use binius_core::constraint_system::{Shift, ShiftedValueIndex, ValueIndex};
 use cranelift_entity::{EntitySet, SecondaryMap};
 
 use crate::compiler::Wire;
@@ -21,31 +21,13 @@ pub struct ShiftedWire {
 
 impl ShiftedWire {
 	/// Lowers this term to a core [`ShiftedValueIndex`] via the wire mapping.
-	///
-	/// A zero-amount shift is the identity, so it collapses to a plain value index.
 	pub(super) fn to_shifted_value_index(
 		self,
 		wire_mapping: &SecondaryMap<Wire, ValueIndex>,
 	) -> ShiftedValueIndex {
-		let idx = wire_mapping[self.wire];
-		match self.shift {
-			Shift::None => ShiftedValueIndex::plain(idx),
-			Shift::Sll(0)
-			| Shift::Sll32(0)
-			| Shift::Srl(0)
-			| Shift::Srl32(0)
-			| Shift::Sar(0)
-			| Shift::Sra32(0)
-			| Shift::Rotr(0)
-			| Shift::Rotr32(0) => ShiftedValueIndex::plain(idx),
-			Shift::Sll(n) => ShiftedValueIndex::sll(idx, n as usize),
-			Shift::Sll32(n) => ShiftedValueIndex::sll32(idx, n as usize),
-			Shift::Srl(n) => ShiftedValueIndex::srl(idx, n as usize),
-			Shift::Srl32(n) => ShiftedValueIndex::srl32(idx, n as usize),
-			Shift::Sar(n) => ShiftedValueIndex::sar(idx, n as usize),
-			Shift::Sra32(n) => ShiftedValueIndex::sra32(idx, n as usize),
-			Shift::Rotr(n) => ShiftedValueIndex::rotr(idx, n as usize),
-			Shift::Rotr32(n) => ShiftedValueIndex::rotr32(idx, n as usize),
+		ShiftedValueIndex {
+			value_index: wire_mapping[self.wire],
+			shift: self.shift,
 		}
 	}
 }
@@ -127,121 +109,6 @@ impl FromIterator<ShiftedWire> for WireOperand {
 impl From<Vec<ShiftedWire>> for WireOperand {
 	fn from(terms: Vec<ShiftedWire>) -> Self {
 		Self(terms)
-	}
-}
-
-/// The operation a shift performs, without its distance.
-///
-/// The `*32` kinds act half-wise on the two 32-bit lanes of a 64-bit word.
-/// The others act on the whole word.
-///
-/// The discriminant is fixed, so a caller can index by kind with one slot or bit per variant.
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, PartialOrd, Ord)]
-#[repr(u8)]
-pub enum ShiftKind {
-	/// Logical left shift of the whole word.
-	Sll = 0,
-	/// Half-wise logical left shift of each 32-bit lane.
-	Sll32 = 1,
-	/// Logical right shift of the whole word.
-	Srl = 2,
-	/// Half-wise logical right shift of each 32-bit lane.
-	Srl32 = 3,
-	/// Arithmetic right shift of the whole word.
-	Sar = 4,
-	/// Half-wise arithmetic right shift of each 32-bit lane.
-	Sra32 = 5,
-	/// Rotate-right of the whole word.
-	Rotr = 6,
-	/// Half-wise rotate-right of each 32-bit lane.
-	Rotr32 = 7,
-}
-
-impl ShiftKind {
-	/// The width this kind operates over: the whole word, or one 32-bit lane.
-	pub const fn width(self) -> u32 {
-		match self {
-			ShiftKind::Sll32 | ShiftKind::Srl32 | ShiftKind::Sra32 | ShiftKind::Rotr32 => 32,
-			_ => 64,
-		}
-	}
-
-	/// Whether this kind wraps what it moves out, rather than discarding it.
-	///
-	/// A cyclic kind loses nothing.
-	/// So any two of them compose, however far they move.
-	pub const fn is_cyclic(self) -> bool {
-		matches!(self, ShiftKind::Rotr | ShiftKind::Rotr32)
-	}
-}
-
-/// A shift folded into an operand term.
-///
-/// The `*32` variants act half-wise on the two 32-bit lanes of a 64-bit word;
-/// the others act on the whole word. The amount is the shift distance in bits.
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, PartialOrd, Ord)]
-pub enum Shift {
-	/// No shift; the wire is used as-is.
-	None,
-	/// Logical left shift of the whole word.
-	Sll(u32),
-	/// Half-wise logical left shift of each 32-bit lane.
-	Sll32(u32),
-	/// Logical right shift of the whole word.
-	Srl(u32),
-	/// Half-wise logical right shift of each 32-bit lane.
-	Srl32(u32),
-	/// Arithmetic right shift of the whole word.
-	Sar(u32),
-	/// Half-wise arithmetic right shift of each 32-bit lane.
-	Sra32(u32),
-	/// Rotate-right of the whole word.
-	Rotr(u32),
-	/// Half-wise rotate-right of each 32-bit lane.
-	Rotr32(u32),
-}
-
-impl Shift {
-	/// The operation and distance of this shift, or `None` for the identity.
-	pub const fn kind_and_amount(self) -> Option<(ShiftKind, u32)> {
-		match self {
-			Shift::None => None,
-			Shift::Sll(n) => Some((ShiftKind::Sll, n)),
-			Shift::Sll32(n) => Some((ShiftKind::Sll32, n)),
-			Shift::Srl(n) => Some((ShiftKind::Srl, n)),
-			Shift::Srl32(n) => Some((ShiftKind::Srl32, n)),
-			Shift::Sar(n) => Some((ShiftKind::Sar, n)),
-			Shift::Sra32(n) => Some((ShiftKind::Sra32, n)),
-			Shift::Rotr(n) => Some((ShiftKind::Rotr, n)),
-			Shift::Rotr32(n) => Some((ShiftKind::Rotr32, n)),
-		}
-	}
-
-	/// Folds `rhs` applied after `lhs` into a single equivalent shift.
-	///
-	/// Returns `None` when the two shifts cannot be one shift:
-	/// - `None` is the identity, so it composes with anything.
-	/// - Like-kind shifts add their amounts.
-	/// - Rotations are cyclic, so the sum wraps modulo the width and always composes.
-	/// - A shift (not a rotation) whose amounts sum past the width shifts everything out to zero,
-	///   which is not expressible as one shift, so it returns `None`.
-	/// - Different kinds never compose.
-	pub const fn compose(lhs: Shift, rhs: Shift) -> Option<Self> {
-		// A shift whose amounts sum to `>= width` clears the word, which is not
-		// expressible as a single shift, so those arms return `None`.
-		// Rotations are cyclic, so their sum wraps modulo the width instead.
-		match (lhs, rhs) {
-			(Shift::None, shift) | (shift, Shift::None) => Some(shift),
-			(Shift::Sll(a), Shift::Sll(b)) if a + b < 64 => Some(Shift::Sll(a + b)),
-			(Shift::Sll32(a), Shift::Sll32(b)) if a + b < 32 => Some(Shift::Sll32(a + b)),
-			(Shift::Srl(a), Shift::Srl(b)) if a + b < 64 => Some(Shift::Srl(a + b)),
-			(Shift::Srl32(a), Shift::Srl32(b)) if a + b < 32 => Some(Shift::Srl32(a + b)),
-			(Shift::Sar(a), Shift::Sar(b)) if a + b < 64 => Some(Shift::Sar(a + b)),
-			(Shift::Sra32(a), Shift::Sra32(b)) if a + b < 32 => Some(Shift::Sra32(a + b)),
-			(Shift::Rotr(a), Shift::Rotr(b)) => Some(Shift::Rotr((a + b) % 64)),
-			(Shift::Rotr32(a), Shift::Rotr32(b)) => Some(Shift::Rotr32((a + b) % 32)),
-			_ => None,
-		}
 	}
 }
 

--- a/crates/frontend/src/compiler/gate_fusion/commit_set.rs
+++ b/crates/frontend/src/compiler/gate_fusion/commit_set.rs
@@ -1,11 +1,11 @@
 // Copyright 2025 Irreducible Inc.
+use binius_core::constraint_system::{Shift, ShiftVariant};
 use petgraph::{
 	Direction,
 	visit::{DfsPostOrder, EdgeRef},
 };
 
 use super::{LeGraph, Stat};
-use crate::compiler::constraint_builder::{Shift, ShiftKind};
 
 /// Longest inline chain a definition of two or more terms may sit at the top of.
 ///
@@ -41,11 +41,11 @@ pub const MAX_DEPTH: usize = 6;
 /// Both fit in an integer, so the summary is [`Copy`] and allocates nothing.
 #[derive(Copy, Clone, Default)]
 struct ShiftSummary {
-	/// One bit per shift kind seen, excluding the identity.
+	/// One bit per shift variant seen, excluding the identity.
 	///
-	/// A kind's bit is its discriminant.
-	/// There are eight kinds, so a byte holds them all.
-	kinds: u8,
+	/// A variant's bit is its discriminant.
+	/// There are eight variants, so a byte holds them all.
+	variants: u8,
 	/// Total distance covered by the farthest-shifting path this summary spans.
 	///
 	/// Zero when only the identity was seen, which imposes no distance.
@@ -59,18 +59,20 @@ impl ShiftSummary {
 	}
 
 	/// The summary of this path extended by one more shift.
+	///
+	/// A shift of no distance is the identity whatever variant spells it, so it constrains
+	/// nothing and drops out here.
 	const fn with(self, shift: Shift) -> Self {
-		match shift.kind_and_amount() {
-			// The identity composes with anything, so it constrains nothing.
-			None => self,
-			// Composing two shifts of one kind adds their distances.
-			// So walking a path accumulates the distances of its links:
-			//     sll(3) then sll(5) then sll(4)  ->  sll(12)
-			// Saturating keeps an absurdly long chain from wrapping back to a small total.
-			Some((kind, amount)) => Self {
-				kinds: self.kinds | bit_of(kind),
-				total_amount: self.total_amount.saturating_add(amount),
-			},
+		if shift.is_identity() {
+			return self;
+		}
+		// Composing two shifts of one variant adds their distances.
+		// So walking a path accumulates the distances of its links:
+		//     sll(3) then sll(5) then sll(4)  ->  sll(12)
+		// Saturating keeps an absurdly long chain from wrapping back to a small total.
+		Self {
+			variants: self.variants | bit_of(shift.variant),
+			total_amount: self.total_amount.saturating_add(shift.amount as u32),
 		}
 	}
 
@@ -82,38 +84,40 @@ impl ShiftSummary {
 		//     path B accumulates sll(50)   <- binding
 		//     -> a further sll(13) fits A but leaves the width on B, so it is rejected
 		summaries.fold(Self::default(), |acc, s| Self {
-			kinds: acc.kinds | s.kinds,
+			variants: acc.variants | s.variants,
 			total_amount: acc.total_amount.max(s.total_amount),
 		})
 	}
 
 	/// Whether `shift` composes with every shift on this path.
 	const fn composable(self, shift: Shift) -> bool {
-		let Some((kind, amount)) = shift.kind_and_amount() else {
-			// The identity composes with anything already seen.
-			return true;
-		};
-
-		// Only the identity was seen, which imposes no kind and no distance.
-		if self.kinds == 0 {
+		// The identity composes with anything already seen.
+		if shift.is_identity() {
 			return true;
 		}
 
-		// A second kind on the path can never compose with this one.
-		if self.kinds != bit_of(kind) {
+		// Only identities were seen, which impose no variant and no distance.
+		if self.variants == 0 {
+			return true;
+		}
+
+		// A second variant on the path can never compose with this one.
+		if self.variants != bit_of(shift.variant) {
 			return false;
 		}
 
-		// A cyclic kind loses no bits, so its distances wrap and always compose.
-		// Any other kind drops the bits it shifts out.
+		// A cyclic variant loses no bits, so its distances wrap and always compose.
+		// Any other variant drops the bits it shifts out.
 		// So the distance the path already covers plus this one has to stay inside the width.
-		kind.is_cyclic() || self.total_amount.saturating_add(amount) < kind.width()
+		shift.variant.is_cyclic()
+			|| self.total_amount.saturating_add(shift.amount as u32)
+				< shift.variant.max_amount() as u32
 	}
 }
 
-/// The bit standing for one kind in [`ShiftSummary::kinds`].
-const fn bit_of(kind: ShiftKind) -> u8 {
-	1 << kind as u8
+/// The bit standing for one variant in [`ShiftSummary::variants`].
+const fn bit_of(variant: ShiftVariant) -> u8 {
+	1 << variant as u8
 }
 
 #[derive(Copy, Clone)]
@@ -310,6 +314,7 @@ pub fn run_decide_commit_set(leg: &mut LeGraph, stat: &mut Stat) {
 
 #[cfg(test)]
 mod tests {
+	use binius_core::constraint_system::Composition;
 	use proptest::prelude::*;
 
 	use super::*;
@@ -327,7 +332,12 @@ mod tests {
 		// So folding left over the chain gives the same answer as any other order.
 		chain
 			.iter()
-			.try_fold(Shift::None, |acc, s| Shift::compose(acc, *s))
+			.try_fold(Shift::IDENTITY, |acc, s| match Shift::compose(acc, *s) {
+				Composition::Single(shift) => Some(shift),
+				// A chain that needs two slots, or that clears the word, is not one the pass may
+				// inline into a single shifted term.
+				Composition::Zero | Composition::Pair => None,
+			})
 	}
 
 	/// Whether one more shift composes with a chain once that chain has collapsed.
@@ -335,7 +345,9 @@ mod tests {
 	/// This is the predicate the summary stands in for.
 	/// It is the reference the summary is checked against.
 	fn composable_reference(chain: &[Shift], shift: Shift) -> bool {
-		collapse(chain).is_some_and(|collapsed| Shift::compose(collapsed, shift).is_some())
+		collapse(chain).is_some_and(|collapsed| {
+			matches!(Shift::compose(collapsed, shift), Composition::Single(_))
+		})
 	}
 
 	/// The summary of one chain, accumulated link by link the way the pass accumulates it.
@@ -348,28 +360,28 @@ mod tests {
 	/// Every shift kind, at a distance inside its own width.
 	fn any_shift() -> impl Strategy<Value = Shift> {
 		prop_oneof![
-			Just(Shift::None),
-			(0u32..64).prop_map(Shift::Sll),
-			(0u32..32).prop_map(Shift::Sll32),
-			(0u32..64).prop_map(Shift::Srl),
-			(0u32..32).prop_map(Shift::Srl32),
-			(0u32..64).prop_map(Shift::Sar),
-			(0u32..32).prop_map(Shift::Sra32),
-			(0u32..64).prop_map(Shift::Rotr),
-			(0u32..32).prop_map(Shift::Rotr32),
+			Just(Shift::IDENTITY),
+			(0u32..64).prop_map(|n| Shift::sll(n as usize)),
+			(0u32..32).prop_map(|n| Shift::sll32(n as usize)),
+			(0u32..64).prop_map(|n| Shift::srl(n as usize)),
+			(0u32..32).prop_map(|n| Shift::srl32(n as usize)),
+			(0u32..64).prop_map(|n| Shift::sar(n as usize)),
+			(0u32..32).prop_map(|n| Shift::sra32(n as usize)),
+			(0u32..64).prop_map(|n| Shift::rotr(n as usize)),
+			(0u32..32).prop_map(|n| Shift::rotr32(n as usize)),
 		]
 	}
 
 	/// The eight shift constructors, in discriminant order.
-	const KINDS: [fn(u32) -> Shift; 8] = [
-		Shift::Sll,
-		Shift::Sll32,
-		Shift::Srl,
-		Shift::Srl32,
-		Shift::Sar,
-		Shift::Sra32,
-		Shift::Rotr,
-		Shift::Rotr32,
+	const KINDS: [fn(usize) -> Shift; 8] = [
+		Shift::sll,
+		Shift::srl,
+		Shift::sar,
+		Shift::rotr,
+		Shift::sll32,
+		Shift::srl32,
+		Shift::sra32,
+		Shift::rotr32,
 	];
 
 	/// A chain of one kind, mixed with identity links, as an inlined path carries.
@@ -386,7 +398,10 @@ mod tests {
 				// Identity links are legal anywhere and must not sway the answer.
 				amounts
 					.into_iter()
-					.map(|amount| amount.map_or(Shift::None, KINDS[kind]))
+					.map(|amount| match amount {
+						Some(amount) => KINDS[kind](amount as usize),
+						None => Shift::IDENTITY,
+					})
 					.collect()
 			},
 		)
@@ -402,15 +417,20 @@ mod tests {
 			// The pass commits the rest rather than inlining them, so no summary is ever built.
 			prop_assume!(collapse(&chain).is_some());
 
-			// Invariant: the summary answers exactly as the collapsed chain answers.
+			// Invariant: whatever the summary permits, the collapsed chain really composes.
 			//
-			//     chain:   [sll(3), sll(5), sll(4)]   summary: kind sll, total 12
+			//     chain:   [sll(3), sll(5), sll(4)]   summary: variant sll, total 12
 			//     collapse:              sll(12)
-			//     query sll(51) -> 12 + 51 = 63, inside 64  -> both say yes
-			//     query sll(52) -> 12 + 52 = 64, at the width -> both say no
-			prop_assert_eq!(
-				summary_of(&chain).composable(query),
-				composable_reference(&chain, query)
+			//     query sll(51) -> 12 + 51 = 63, inside 64  -> permitted, and it composes
+			//     query sll(52) -> 12 + 52 = 64, at the width -> refused
+			//
+			// The converse does not hold, and need not: the summary tracks a total distance
+			// rather than the composition itself, so it refuses chains core collapses anyway —
+			// `sar(40)` then `sar(40)` saturates to `sar(63)`, but the summary sees 80 and says
+			// no. That costs inlining, never correctness, and `patch::process_term` panics only
+			// on the direction asserted here.
+			prop_assert!(
+				!summary_of(&chain).composable(query) || composable_reference(&chain, query)
 			);
 		}
 
@@ -426,9 +446,9 @@ mod tests {
 
 			// Invariant: extending a summary by one link answers as the longer chain does.
 			// This is the step the pass takes at every graph edge it walks.
-			prop_assert_eq!(
-				summary_of(head).with(*extra).composable(query),
-				composable_reference(&chain, query)
+			prop_assert!(
+				!summary_of(head).with(*extra).composable(query)
+					|| composable_reference(&chain, query)
 			);
 		}
 
@@ -446,9 +466,9 @@ mod tests {
 			let joined = ShiftSummary::union([summary_of(&left), summary_of(&right)].into_iter());
 
 			// Invariant: a shift joins the spanning summary only when it composes with each path.
-			prop_assert_eq!(
-				joined.composable(query),
-				composable_reference(&left, query) && composable_reference(&right, query)
+			prop_assert!(
+				!joined.composable(query)
+					|| composable_reference(&left, query) && composable_reference(&right, query)
 			);
 		}
 	}

--- a/crates/frontend/src/compiler/gate_fusion/legraph.rs
+++ b/crates/frontend/src/compiler/gate_fusion/legraph.rs
@@ -1,12 +1,13 @@
 // Copyright 2025 Irreducible Inc.
 //! linear expression graph.
 
+use binius_core::constraint_system::Shift;
 use cranelift_entity::{EntitySet, SecondaryMap};
 use petgraph::graph::{DiGraph, NodeIndex};
 
 use crate::compiler::{
 	Wire,
-	constraint_builder::{ConstraintBuilder, Shift, WireOperand},
+	constraint_builder::{ConstraintBuilder, WireOperand},
 };
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/crates/frontend/src/compiler/gate_fusion/patch.rs
+++ b/crates/frontend/src/compiler/gate_fusion/patch.rs
@@ -1,12 +1,14 @@
 // Copyright 2026 The Binius Developers
 // Copyright 2025 Irreducible Inc.
 
+use binius_core::constraint_system::{Composition, Shift};
+
 use super::legraph::LeGraph;
 use crate::compiler::{
 	Wire,
 	constraint_builder::{
-		ConstraintBuilder, Shift, ShiftedWire, WireAndConstraint, WireBmulConstraint,
-		WireImulConstraint, WireLinearConstraint, WireOperand,
+		ConstraintBuilder, ShiftedWire, WireAndConstraint, WireBmulConstraint, WireImulConstraint,
+		WireLinearConstraint, WireOperand,
 	},
 	gate_fusion::legraph::ConstraintRef,
 };
@@ -239,12 +241,16 @@ fn process_term(
 			// Compose shifts: we're applying 'shift' to 'inner_term'
 			// So we need Shift::compose(inner_term.shift, shift)
 			match Shift::compose(inner_term.shift, shift) {
-				Some(composed_shift) => {
+				Composition::Single(composed_shift) => {
 					// Recursively process this term with the composed shift
 					process_term(cb, leg, new_operand, subsumes, inner_term.wire, composed_shift);
 				}
-				None => {
-					// Incompatible shifts - this shouldn't happen if commit set is correct
+				// The two shifts clear the word, so the term is identically zero. An operand is
+				// an XOR, so a zero term contributes nothing and the inlining simply drops it.
+				Composition::Zero => {}
+				// Needing both slots means the commit set inlined a definition it should have
+				// committed: the two passes disagree about what is inlinable.
+				Composition::Pair => {
 					panic!(
 						"Incompatible shifts during inlining: {:?} followed by {:?} for wire {:?}",
 						inner_term.shift, shift, inner_term.wire
@@ -336,11 +342,11 @@ mod tests {
 				vec![
 					ShiftedWire {
 						wire: w(0),
-						shift: Shift::Rotr(0),
+						shift: Shift::IDENTITY,
 					},
 					ShiftedWire {
 						wire: w(1),
-						shift: Shift::Rotr(0),
+						shift: Shift::IDENTITY,
 					},
 				],
 			)],
@@ -444,54 +450,53 @@ mod tests {
 	#[test]
 	fn test_stress_shift_combinations_no_panic() {
 		// Iterate over a small set of shift pairs; ensure commit_set + build/apply don't panic
-		use crate::compiler::constraint_builder::Shift;
 		fn w(id: u32) -> Wire {
 			Wire::from_u32(id)
 		}
 
+		use binius_core::constraint_system::ShiftVariant;
+
+		use crate::compiler::constraint_builder::WireExprTerm;
+
+		/// The expression term applying one shift to a wire.
+		///
+		/// The identity has no constructor of its own, so it reads the wire plainly.
+		fn shifted_expr(wire: Wire, shift: Shift) -> WireExprTerm {
+			let amount = shift.amount as u32;
+			if shift.is_identity() {
+				return wire.into();
+			}
+			match shift.variant {
+				ShiftVariant::Sll => expr::sll(wire, amount),
+				ShiftVariant::Slr => expr::srl(wire, amount),
+				ShiftVariant::Sar => expr::sar(wire, amount),
+				ShiftVariant::Rotr => expr::rotr(wire, amount),
+				ShiftVariant::Sll32 => expr::sll32(wire, amount),
+				ShiftVariant::Srl32 => expr::srl32(wire, amount),
+				ShiftVariant::Sra32 => expr::sra32(wire, amount),
+				ShiftVariant::Rotr32 => expr::rotr32(wire, amount),
+			}
+		}
+
 		let shifts = [
-			Shift::None,
-			Shift::Sll(5),
-			Shift::Sll32(5),
-			Shift::Srl(5),
-			Shift::Srl32(5),
-			Shift::Sar(5),
-			Shift::Sra32(5),
-			Shift::Rotr(13),
-			Shift::Rotr32(13),
+			Shift::IDENTITY,
+			Shift::sll(5),
+			Shift::sll32(5),
+			Shift::srl(5),
+			Shift::srl32(5),
+			Shift::sar(5),
+			Shift::sra32(5),
+			Shift::rotr(13),
+			Shift::rotr32(13),
 		];
 
 		for (i, s1) in shifts.iter().enumerate() {
 			for (j, s2) in shifts.iter().enumerate() {
 				let mut cb = ConstraintBuilder::new();
 				// y = shift1(x)
-				match s1 {
-					Shift::None => cb.linear(expr::xor2(w(0), w(1)), w(2)),
-					Shift::Sll(n) => cb.linear(expr::sll(w(0), *n), w(2)),
-					Shift::Sll32(n) => cb.linear(expr::sll32(w(0), *n), w(2)),
-					Shift::Srl(n) => cb.linear(expr::srl(w(0), *n), w(2)),
-					Shift::Srl32(n) => cb.linear(expr::srl32(w(0), *n), w(2)),
-					Shift::Sar(n) => {
-						cb.linear(crate::compiler::constraint_builder::expr::sar(w(0), *n), w(2))
-					}
-					Shift::Sra32(n) => cb.linear(expr::sra32(w(0), *n), w(2)),
-					Shift::Rotr(n) => cb.linear(expr::rotr(w(0), *n), w(2)),
-					Shift::Rotr32(n) => cb.linear(expr::rotr32(w(0), *n), w(2)),
-				}
+				cb.linear(shifted_expr(w(0), *s1), w(2));
 				// z = shift2(y)
-				match s2 {
-					Shift::None => cb.linear(expr::xor2(w(2), w(3)), w(4)),
-					Shift::Sll(n) => cb.linear(expr::sll(w(2), *n), w(4)),
-					Shift::Sll32(n) => cb.linear(expr::sll32(w(2), *n), w(4)),
-					Shift::Srl(n) => cb.linear(expr::srl(w(2), *n), w(4)),
-					Shift::Srl32(n) => cb.linear(expr::srl32(w(2), *n), w(4)),
-					Shift::Sar(n) => {
-						cb.linear(crate::compiler::constraint_builder::expr::sar(w(2), *n), w(4))
-					}
-					Shift::Sra32(n) => cb.linear(expr::sra32(w(2), *n), w(4)),
-					Shift::Rotr(n) => cb.linear(expr::rotr(w(2), *n), w(4)),
-					Shift::Rotr32(n) => cb.linear(expr::rotr32(w(2), *n), w(4)),
-				}
+				cb.linear(shifted_expr(w(2), *s2), w(4));
 				cb.and(w(4), w(5), w(6));
 
 				let mut stat = Stat::default();
@@ -517,7 +522,7 @@ mod tests {
 			// Not a linear def - return as is
 			result.push(ShiftedWire {
 				wire,
-				shift: Shift::None,
+				shift: Shift::IDENTITY,
 			});
 			return result;
 		}
@@ -544,8 +549,16 @@ mod tests {
 			// This is a non-committed linear def - expand recursively
 			let inner = leg.lin_def_operand(cb, wire);
 			for term in inner {
-				let composed = Shift::compose(term.shift, shift).unwrap();
-				expand_term_recursive(cb, leg, result, term.wire, composed);
+				match Shift::compose(term.shift, shift) {
+					Composition::Single(composed) => {
+						expand_term_recursive(cb, leg, result, term.wire, composed)
+					}
+					// A term the two shifts clear contributes nothing to the XOR.
+					Composition::Zero => {}
+					Composition::Pair => {
+						panic!("the commit set only inlines definitions whose shifts compose")
+					}
+				}
 			}
 		}
 	}
@@ -592,15 +605,15 @@ mod tests {
 					vec![
 						ShiftedWire {
 							wire: w(0),
-							shift: Shift::None,
+							shift: Shift::IDENTITY,
 						},
 						ShiftedWire {
 							wire: w(1),
-							shift: Shift::None,
+							shift: Shift::IDENTITY,
 						},
 						ShiftedWire {
 							wire: w(3),
-							shift: Shift::None,
+							shift: Shift::IDENTITY,
 						},
 					],
 				),
@@ -610,11 +623,11 @@ mod tests {
 					vec![
 						ShiftedWire {
 							wire: w(0),
-							shift: Shift::None,
+							shift: Shift::IDENTITY,
 						},
 						ShiftedWire {
 							wire: w(1),
-							shift: Shift::None,
+							shift: Shift::IDENTITY,
 						},
 					],
 				),
@@ -642,7 +655,7 @@ mod tests {
 					w(2),
 					vec![ShiftedWire {
 						wire: w(0),
-						shift: Shift::Sll(30),
+						shift: Shift::sll(30),
 					}],
 				),
 				// y should expand to: x << 10
@@ -650,7 +663,7 @@ mod tests {
 					w(1),
 					vec![ShiftedWire {
 						wire: w(0),
-						shift: Shift::Sll(10),
+						shift: Shift::sll(10),
 					}],
 				),
 			],
@@ -678,11 +691,11 @@ mod tests {
 					vec![
 						ShiftedWire {
 							wire: w(0),
-							shift: Shift::Rotr(5),
+							shift: Shift::rotr(5),
 						},
 						ShiftedWire {
 							wire: w(1),
-							shift: Shift::Rotr(5),
+							shift: Shift::rotr(5),
 						},
 					],
 				),
@@ -710,7 +723,7 @@ mod tests {
 					w(2),
 					vec![ShiftedWire {
 						wire: w(1),
-						shift: Shift::Srl(20),
+						shift: Shift::srl(20),
 					}],
 				),
 			],
@@ -738,23 +751,23 @@ mod tests {
 					vec![
 						ShiftedWire {
 							wire: w(0),
-							shift: Shift::None,
+							shift: Shift::IDENTITY,
 						},
 						ShiftedWire {
 							wire: w(1),
-							shift: Shift::None,
+							shift: Shift::IDENTITY,
 						},
 						ShiftedWire {
 							wire: w(2),
-							shift: Shift::None,
+							shift: Shift::IDENTITY,
 						},
 						ShiftedWire {
 							wire: w(4),
-							shift: Shift::None,
+							shift: Shift::IDENTITY,
 						},
 						ShiftedWire {
 							wire: w(5),
-							shift: Shift::None,
+							shift: Shift::IDENTITY,
 						},
 					],
 				),
@@ -792,17 +805,17 @@ mod tests {
 				added: AddedConstraint::And(WireAndConstraint {
 					a: vec![ShiftedWire {
 						wire: w(30),
-						shift: Shift::None,
+						shift: Shift::IDENTITY,
 					}]
 					.into(),
 					b: vec![ShiftedWire {
 						wire: w(31),
-						shift: Shift::None,
+						shift: Shift::IDENTITY,
 					}]
 					.into(),
 					c: vec![ShiftedWire {
 						wire: w(32),
-						shift: Shift::None,
+						shift: Shift::IDENTITY,
 					}]
 					.into(),
 				}),
@@ -812,17 +825,17 @@ mod tests {
 				added: AddedConstraint::And(WireAndConstraint {
 					a: vec![ShiftedWire {
 						wire: w(33),
-						shift: Shift::None,
+						shift: Shift::IDENTITY,
 					}]
 					.into(),
 					b: vec![ShiftedWire {
 						wire: w(34),
-						shift: Shift::None,
+						shift: Shift::IDENTITY,
 					}]
 					.into(),
 					c: vec![ShiftedWire {
 						wire: w(35),
-						shift: Shift::None,
+						shift: Shift::IDENTITY,
 					}]
 					.into(),
 				}),
@@ -832,22 +845,22 @@ mod tests {
 				added: AddedConstraint::Imul(WireImulConstraint {
 					a: vec![ShiftedWire {
 						wire: w(36),
-						shift: Shift::None,
+						shift: Shift::IDENTITY,
 					}]
 					.into(),
 					b: vec![ShiftedWire {
 						wire: w(37),
-						shift: Shift::None,
+						shift: Shift::IDENTITY,
 					}]
 					.into(),
 					lo: vec![ShiftedWire {
 						wire: w(38),
-						shift: Shift::None,
+						shift: Shift::IDENTITY,
 					}]
 					.into(),
 					hi: vec![ShiftedWire {
 						wire: w(39),
-						shift: Shift::None,
+						shift: Shift::IDENTITY,
 					}]
 					.into(),
 				}),
@@ -968,23 +981,23 @@ mod tests {
 			&[
 				ShiftedWire {
 					wire: w(0),
-					shift: Shift::None,
+					shift: Shift::IDENTITY,
 				},
 				ShiftedWire {
 					wire: w(1),
-					shift: Shift::None,
+					shift: Shift::IDENTITY,
 				},
 				ShiftedWire {
 					wire: w(0),
-					shift: Shift::None,
+					shift: Shift::IDENTITY,
 				},
 				ShiftedWire {
 					wire: w(1),
-					shift: Shift::None,
+					shift: Shift::IDENTITY,
 				},
 				ShiftedWire {
 					wire: w(3),
-					shift: Shift::None,
+					shift: Shift::IDENTITY,
 				},
 			],
 			"mul.a",
@@ -1023,7 +1036,7 @@ mod tests {
 			&m.a,
 			&[ShiftedWire {
 				wire: w(1),
-				shift: Shift::Sll(30),
+				shift: Shift::sll(30),
 			}],
 			"mul.a (committed)",
 		);
@@ -1032,11 +1045,11 @@ mod tests {
 			&[
 				ShiftedWire {
 					wire: w(3),
-					shift: Shift::None,
+					shift: Shift::IDENTITY,
 				},
 				ShiftedWire {
 					wire: w(4),
-					shift: Shift::None,
+					shift: Shift::IDENTITY,
 				},
 			],
 			"mul.b (inlinable)",
@@ -1074,7 +1087,7 @@ mod tests {
 			&m.hi,
 			&[ShiftedWire {
 				wire: w(1),
-				shift: Shift::Sll(20),
+				shift: Shift::sll(20),
 			}],
 			"mul.hi (committed)",
 		);
@@ -1083,11 +1096,11 @@ mod tests {
 			&[
 				ShiftedWire {
 					wire: w(3),
-					shift: Shift::None,
+					shift: Shift::IDENTITY,
 				},
 				ShiftedWire {
 					wire: w(4),
-					shift: Shift::None,
+					shift: Shift::IDENTITY,
 				},
 			],
 			"mul.lo (inlinable)",

--- a/crates/frontend/src/compiler/gate_fusion/tests/commit_set.rs
+++ b/crates/frontend/src/compiler/gate_fusion/tests/commit_set.rs
@@ -272,7 +272,8 @@ fn test_sar_boundary_63_vs_64() {
 
 #[test]
 fn test_zero_shift_composition() {
-	// Zero shifts still carry their type; mixed types do not compose → commit
+	// A shift of no distance is the identity, whichever variant spells it, so two of them
+	// compose however their variants differ. Nothing here needs committing.
 	test_commit_set(
 		|cb| {
 			// y = sll(x, 0)
@@ -281,8 +282,8 @@ fn test_zero_shift_composition() {
 			cb.linear(expr::srl(w(1), 0), w(2));
 			cb.and(w(2), w(3), w(4));
 		},
-		&[w(1)], // y must be committed (Sll vs Srl are incompatible)
-		&[w(2)],
+		&[],
+		&[w(1), w(2)],
 	);
 
 	// Same-type zero shifts compose trivially


### PR DESCRIPTION
Closes [BINIUS-416](https://linear.app/jimpo/issue/BINIUS-416/unify-the-frontend-shiftshiftkind-with-the-core-shift-type), the last of Stage 1 for [BINIUS-408](https://linear.app/jimpo/issue/BINIUS-408/double-shifted-value-indices).

**Re-land of #2076, now based on main.** You approved that PR at 21:44 and merged it, but I had based it on the `benji/binius-415-…` branch, so merging it landed the diff inside #2072 instead of main — hence your revert in #2080. This is the same commit (`0d5c744`), duplicated onto main now that #2072 has landed, with no content changes. My mistake, and the lesson is not to base a PR on another PR's branch in a merge-queue repo.

The compiler carried its own `Shift` and `ShiftKind` alongside core's, differing only in spelling the identity separately and in discriminant order. Both are gone: the frontend uses `binius_core::constraint_system::Shift` throughout, and `ShiftedWire::to_shifted_value_index` drops from a nine-arm translation to a field copy. `ShiftSummary` re-keys on `ShiftVariant`, and `patch.rs` takes its merge rule from core's `Composition`. Net −89 lines.

## The one behavior change, measured

Collapsing `Shift::None` into `Sll(0)` is not cosmetic. `expr::sll(w, 0)` builds an unnormalized zero-amount shift, and `ShiftSummary` used to treat that as pinning a path to the `Sll` variant — so `sll(x, 0)` feeding `srl(y, 0)` forced a commit, despite both being the identity. Unified, `is_identity()` covers both spellings and the pair composes.

`test_zero_shift_composition` asserted the old behavior, with the comment "Zero shifts still carry their type; mixed types do not compose → commit". It now asserts the corrected one. That test is the *only* thing in the tree that noticed:

| circuit | ZERO | AND | vs. before |
|---|---|---|---|
| sha256 | 2,005 | 6,575 | unchanged |
| keccak | 0 | 4,783 | unchanged |
| blake3 | 1,997 | 2,760 | unchanged |

## Notes for review (unchanged from #2076)

- **`Composition::Zero` drops the term rather than panicking**, per [your review](https://github.com/binius-zk/binius64/pull/2076#discussion_r3752726045). An operand is an XOR, so a term the two shifts clear contributes nothing. `Pair` keeps the panic and is now the only arm meaning `commit_set` and `patch` disagree.
- **`patch.rs` adopting core's stronger `compose` is invisible**: `commit_set` decides what may be inlined and `patch` only executes it, so `commit_set` stays the binding constraint.
- **The `ShiftSummary` proptests are now one-directional** — soundness only. The summary tracks a total distance rather than the composition, so it refuses chains core collapses (`sar(40)` then `sar(40)` saturates to `sar(63)`, but the summary sees 80). Soundness is what `patch::process_term`'s remaining panic actually rests on.
- **Core's `Shift` and `ShiftedValueIndex` constructors became `const fn`** so the frontend's `expr::*` and `gate/shift.rs` stay `const`; the cost is that `Shift::new`'s panic message can no longer interpolate its arguments.
- `ShiftVariant` gains `is_cyclic()`.

## Verification (re-run on the new base)

`cargo check --workspace --all-targets`, clippy `-D warnings` over core + frontend, `cargo doc --no-deps --document-private-items`, fmt — all clean. Tests: core 105, frontend 199. The counts are higher than #2076 reported because main now carries #2072's tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
