### PR TITLE
BINIUS-427 (2/2): add the WordIP channel traits

### DIFF
--- a/crates/field/src/util.rs
+++ b/crates/field/src/util.rs
@@ -85,6 +85,30 @@ pub fn expand_subset_sums_array<P: PackedField, const N: usize, const N_EXP2: us
 	expanded
 }
 
+/// Expands `elems` into all `2^elems.len()` subset sums, indexed by subset bitmask.
+///
+/// The dynamically sized counterpart of [`expand_subset_sums_array`], for callers whose element
+/// count is only known at run time. Entry `mask` holds the sum of `elems[i]` over every bit `i` set
+/// in `mask`, so entry `0` is zero and entry `2^i` is `elems[i]`.
+///
+/// Each entry costs one addition, where summing a subset directly would cost one per set bit.
+///
+/// ## Preconditions
+///
+/// * `elems.len()` must be less than `usize::BITS`
+pub fn expand_subset_sums<P: PackedField>(elems: &[P]) -> Vec<P> {
+	assert!(elems.len() < usize::BITS as usize); // precondition
+
+	let mut expanded = vec![P::zero(); 1 << elems.len()];
+	for (i, &elem_i) in elems.iter().enumerate() {
+		let (lo_half, hi_half) = expanded[..1 << (i + 1)].split_at_mut(1 << i);
+		for (lo_half_i, hi_half_i) in iter::zip(lo_half, hi_half) {
+			*hi_half_i = *lo_half_i + elem_i;
+		}
+	}
+	expanded
+}
+
 /// Expands `elems` into all `2^N` subset XOR combinations, indexed by subset bitmask.
 ///
 /// Entry `mask` holds the XOR of `elems[i]` over every bit `i` set in `mask`. This is the

--- a/crates/iop-prover/Cargo.toml
+++ b/crates/iop-prover/Cargo.toml
@@ -9,6 +9,7 @@ workspace = true
 
 [dependencies]
 binius-compute = { path = "../compute" }
+binius-core = { path = "../core" }
 binius-field = { path = "../field" }
 binius-hash = { path = "../hash" }
 binius-iop = { path = "../iop" }

--- a/crates/iop-prover/src/basefold/channel.rs
+++ b/crates/iop-prover/src/basefold/channel.rs
@@ -8,7 +8,7 @@ use binius_compute::Allocator;
 use binius_field::{BinaryField, PackedField};
 use binius_iop::{channel::OracleSpec, fri::FRIParams};
 use binius_ip_prover::{
-	channel::IPProverChannel,
+	channel::{IPProverChannel, WordIPProverChannel},
 	sumcheck::{
 		self, PaddedSumcheckDecorator, batch::BatchSumcheckOutput,
 		bivariate_product_evaluator::BivariateProductEvaluator, mle_store::MleStore,
@@ -493,6 +493,26 @@ where
 
 	fn sample(&mut self) -> F {
 		self.channel.sample()
+	}
+}
+
+impl<F, P, NTT, Channel, A> WordIPProverChannel<F>
+	for BaseFoldProverChannel<'_, F, P, NTT, Channel, A>
+where
+	F: BinaryField,
+	P: PackedField<Scalar = F>,
+	NTT: AdditiveNTT<Field = F> + Sync,
+	Channel: MerkleIPProverChannel<F>,
+	A: Allocator,
+{
+	type Word = Channel::Word;
+
+	fn observe_words(&mut self, words: &[Self::Word]) {
+		self.channel.observe_words(words);
+	}
+
+	fn sample_bits(&mut self, bits: usize) -> Self::Word {
+		self.channel.sample_bits(bits)
 	}
 }
 

--- a/crates/iop-prover/src/fri/query.rs
+++ b/crates/iop-prover/src/fri/query.rs
@@ -15,7 +15,7 @@ pub trait ProxTestOracleProver<F: Field> {
 
 	/// Sends the per-oracle batched query openings: the oracle's optimal Merkle layer once,
 	/// followed by each queried coset's values and Merkle opening proof.
-	fn open_queries<Channel>(&self, indices: &[usize], channel: &mut Channel)
+	fn open_queries<Channel>(&self, indices: &[Channel::Word], channel: &mut Channel)
 	where
 		Channel: MerkleIPProverChannel<F, Commitment = Self::Commitment>;
 }
@@ -60,7 +60,7 @@ where
 {
 	type Commitment = C;
 
-	fn open_queries<Channel>(&self, indices: &[usize], channel: &mut Channel)
+	fn open_queries<Channel>(&self, indices: &[Channel::Word], channel: &mut Channel)
 	where
 		Channel: MerkleIPProverChannel<F, Commitment = Self::Commitment>,
 	{
@@ -69,7 +69,7 @@ where
 		// the verifier.
 		let lifted_indices = indices
 			.iter()
-			.map(|&index| index >> self.log_lift)
+			.map(|index| index.clone() >> self.log_lift as u32)
 			.collect::<Vec<_>>();
 		channel.send_openings(&self.commitment, self.codeword.to_ref(), &lifted_indices);
 	}
@@ -105,7 +105,7 @@ where
 {
 	type Commitment = C;
 
-	fn open_queries<Channel>(&self, indices: &[usize], channel: &mut Channel)
+	fn open_queries<Channel>(&self, indices: &[Channel::Word], channel: &mut Channel)
 	where
 		Channel: MerkleIPProverChannel<F, Commitment = Self::Commitment>,
 	{
@@ -155,7 +155,7 @@ where
 {
 	type Commitment = C;
 
-	fn open_queries<Channel>(&self, indices: &[usize], channel: &mut Channel)
+	fn open_queries<Channel>(&self, indices: &[Channel::Word], channel: &mut Channel)
 	where
 		Channel: MerkleIPProverChannel<F, Commitment = Self::Commitment>,
 	{
@@ -213,7 +213,7 @@ where
 	///
 	/// * `indices` - the sampled query indices into the original codeword domain
 	#[instrument(skip_all, name = "fri::FRIQueryProver::prove_queries", level = "debug")]
-	pub fn prove_queries<Channel>(&self, indices: &[usize], channel: &mut Channel)
+	pub fn prove_queries<Channel>(&self, indices: &[Channel::Word], channel: &mut Channel)
 	where
 		Channel: MerkleIPProverChannel<F, Commitment = C>,
 	{
@@ -223,9 +223,10 @@ where
 		// right by the round's arity before opening it.
 		let mut indices = indices.to_vec();
 		for fri_oracle in &self.fri_oracles {
-			for index in &mut indices {
-				*index >>= fri_oracle.coset_log_size();
-			}
+			indices = indices
+				.into_iter()
+				.map(|index| index >> fri_oracle.coset_log_size() as u32)
+				.collect();
 			fri_oracle.open_queries(&indices, channel);
 		}
 	}

--- a/crates/iop-prover/src/merkle_channel.rs
+++ b/crates/iop-prover/src/merkle_channel.rs
@@ -13,22 +13,23 @@
 
 use std::{borrow::BorrowMut, marker::PhantomData};
 
+use binius_core::word::Word;
 use binius_field::{Field, PackedField};
 use binius_hash::binary_merkle_tree::{BinaryMerkleTree, HashSuite};
 use binius_iop::merkle_tree::MerkleTreeScheme;
-use binius_ip_prover::channel::IPProverChannel;
+use binius_ip_prover::channel::{IPProverChannel, WordIPProverChannel};
 use binius_math::FieldSlice;
-use binius_transcript::{
-	ProverTranscript,
-	fiat_shamir::{CanSampleBits, Challenger},
-};
+use binius_transcript::{ProverTranscript, fiat_shamir::Challenger};
 use binius_utils::{SerializeBytes, checked_arithmetics::checked_log_2};
 use digest::Output;
 
 use crate::merkle_tree::{MerkleTreeProver, commit_field_buffer, prover::BinaryMerkleTreeProver};
 
-/// An extension of [`IPProverChannel`] that can send and open Merkle commitments.
-pub trait MerkleIPProverChannel<F: Field>: IPProverChannel<F> {
+/// An extension of [`WordIPProverChannel`] that can send and open Merkle commitments.
+///
+/// Query indices are [`Self::Word`](WordIPProverChannel::Word)s, matching the verifier's
+/// `MerkleIPVerifierChannel`.
+pub trait MerkleIPProverChannel<F: Field>: WordIPProverChannel<F> {
 	/// A Merkle commitment, carrying the data required to open it later.
 	type Commitment;
 
@@ -59,7 +60,7 @@ pub trait MerkleIPProverChannel<F: Field>: IPProverChannel<F> {
 		&mut self,
 		commitment: &Self::Commitment,
 		data: FieldSlice<P>,
-		indices: &[usize],
+		indices: &[Self::Word],
 	);
 
 	/// Sends the full committed vector, bound by a Merkle commitment.
@@ -72,12 +73,6 @@ pub trait MerkleIPProverChannel<F: Field>: IPProverChannel<F> {
 		commitment: &Self::Commitment,
 		data: FieldSlice<P>,
 	);
-
-	/// Samples a uniform integer with the given number of bits.
-	///
-	/// Protocols use this to sample query indices for [`Self::send_openings`], matching the
-	/// verifier's samples.
-	fn sample_bits(&mut self, bits: usize) -> usize;
 }
 
 /// A [`MerkleIPProverChannel`] over a [`ProverTranscript`], committing with a
@@ -152,6 +147,25 @@ where
 	}
 }
 
+impl<F, T, Challenger_, H> WordIPProverChannel<F>
+	for ProverMerkleTranscriptChannel<T, Challenger_, F, H>
+where
+	F: Field,
+	T: BorrowMut<ProverTranscript<Challenger_>>,
+	Challenger_: Challenger,
+	H: HashSuite,
+{
+	type Word = Word;
+
+	fn observe_words(&mut self, words: &[Word]) {
+		WordIPProverChannel::<F>::observe_words(self.transcript.borrow_mut(), words);
+	}
+
+	fn sample_bits(&mut self, bits: usize) -> Word {
+		WordIPProverChannel::<F>::sample_bits(self.transcript.borrow_mut(), bits)
+	}
+}
+
 impl<F, T, Challenger_, H> MerkleIPProverChannel<F>
 	for ProverMerkleTranscriptChannel<T, Challenger_, F, H>
 where
@@ -186,10 +200,14 @@ where
 		&mut self,
 		commitment: &Self::Commitment,
 		data: FieldSlice<P>,
-		indices: &[usize],
+		indices: &[Word],
 	) {
 		let tree_depth = commitment.depth;
 		debug_assert_eq!(tree_depth, data.log_len() - commitment.log_leaf_size);
+		let indices = indices
+			.iter()
+			.map(|index| index.as_u64() as usize)
+			.collect::<Vec<_>>();
 		assert!(indices.iter().all(|&index| index < 1 << tree_depth)); // precondition
 
 		// Write the optimal internal layer once, then the leaf values and opening proof for each
@@ -199,7 +217,7 @@ where
 		let layer = self.merkle_prover.layer(&commitment.committed, layer_depth);
 		let mut advice = self.transcript.borrow_mut().decommitment();
 		advice.write_slice(layer);
-		for &index in indices {
+		for &index in &indices {
 			let leaf = data.chunk(commitment.log_leaf_size, index);
 			advice.write_scalar_iter(leaf.iter_scalars());
 			self.merkle_prover.prove_opening(
@@ -223,17 +241,15 @@ where
 		let mut advice = self.transcript.borrow_mut().decommitment();
 		advice.write_scalar_iter(data.iter_scalars());
 	}
-
-	fn sample_bits(&mut self, bits: usize) -> usize {
-		CanSampleBits::sample_bits(self.transcript.borrow_mut(), bits) as usize
-	}
 }
 
 #[cfg(test)]
 mod tests {
+	use binius_core::word::Word;
 	use binius_field::{BinaryField128bGhash as B128, PackedBinaryGhash2x128b};
 	use binius_hash::{StdDigest, StdHashSuite};
 	use binius_iop::merkle_channel::{MerkleIPVerifierChannel, VerifierMerkleTranscriptChannel};
+	use binius_ip::channel::WordIPVerifierChannel;
 	use binius_math::{FieldBuffer, test_utils::random_scalars};
 	use binius_transcript::{ProverTranscript, fiat_shamir::HasherChallenger};
 	use rand::prelude::*;
@@ -251,7 +267,9 @@ mod tests {
 	const DEPTH: usize = LOG_LEN - LOG_LEAF_SIZE;
 	const N_QUERIES: usize = 5;
 
-	fn sample_indices(channel: &mut impl MerkleIPProverChannel<B128>) -> Vec<usize> {
+	fn sample_indices<Channel: MerkleIPProverChannel<B128>>(
+		channel: &mut Channel,
+	) -> Vec<Channel::Word> {
 		(0..N_QUERIES).map(|_| channel.sample_bits(DEPTH)).collect()
 	}
 
@@ -285,7 +303,8 @@ mod tests {
 			.recv_openings(&commitment, &indices)
 			.unwrap();
 		assert_eq!(values.len(), N_QUERIES * LEAF_SIZE);
-		for (chunk, &index) in values.chunks(LEAF_SIZE).zip(&indices) {
+		for (chunk, index) in values.chunks(LEAF_SIZE).zip(&indices) {
+			let index = index.as_u64() as usize;
 			assert_eq!(chunk, &scalars[index * LEAF_SIZE..(index + 1) * LEAF_SIZE]);
 		}
 
@@ -322,7 +341,8 @@ mod tests {
 			let values = verifier_channel
 				.recv_openings(&commitment, &indices)
 				.unwrap();
-			for (chunk, &index) in values.chunks(LEAF_SIZE).zip(&indices) {
+			for (chunk, index) in values.chunks(LEAF_SIZE).zip(&indices) {
+				let index = index.as_u64() as usize;
 				assert_eq!(chunk, &scalars[index * LEAF_SIZE..(index + 1) * LEAF_SIZE]);
 			}
 		}
@@ -352,7 +372,10 @@ mod tests {
 			.collect::<Vec<_>>();
 
 		// Requesting openings at indices other than the ones the prover opened must fail.
-		let wrong_indices = indices.iter().map(|&index| index ^ 1).collect::<Vec<_>>();
+		let wrong_indices = indices
+			.iter()
+			.map(|&index| index ^ Word::ONE)
+			.collect::<Vec<_>>();
 		assert!(
 			verifier_channel
 				.recv_openings(&commitment, &wrong_indices)

--- a/crates/iop/Cargo.toml
+++ b/crates/iop/Cargo.toml
@@ -8,6 +8,7 @@ authors.workspace = true
 workspace = true
 
 [dependencies]
+binius-core = { path = "../core" }
 binius-field = { path = "../field" }
 binius-hash = { path = "../hash" }
 binius-ip = { path = "../ip" }

--- a/crates/iop/src/basefold/channel.rs
+++ b/crates/iop/src/basefold/channel.rs
@@ -4,7 +4,7 @@
 
 use binius_field::{BinaryField, util::FieldFn};
 use binius_ip::{
-	channel::IPVerifierChannel,
+	channel::{IPVerifierChannel, WordIPVerifierChannel},
 	sumcheck::{self, BatchSumcheckOutput},
 };
 use binius_math::{
@@ -281,6 +281,30 @@ where
 
 	fn compute_public_value(&mut self, inputs: &[Self::Elem], f: impl FieldFn<F>) -> Self::Elem {
 		self.channel.compute_public_value(inputs, f)
+	}
+}
+
+impl<F, Channel> WordIPVerifierChannel<F> for BaseFoldVerifierChannel<'_, F, Channel>
+where
+	F: BinaryField,
+	Channel: MerkleIPVerifierChannel<F, Elem: From<F> + 'static>,
+{
+	type Word = Channel::Word;
+
+	fn observe_words(&mut self, words: &[Self::Word]) {
+		self.channel.observe_words(words);
+	}
+
+	fn subset_sum(&mut self, elems: &[Self::Elem], word: &Self::Word) -> Self::Elem {
+		self.channel.subset_sum(elems, word)
+	}
+
+	fn select(&mut self, elems: &[Self::Elem], word: &Self::Word) -> Self::Elem {
+		self.channel.select(elems, word)
+	}
+
+	fn sample_bits(&mut self, bits: usize) -> Self::Word {
+		self.channel.sample_bits(bits)
 	}
 }
 

--- a/crates/iop/src/channel/oracle_setup.rs
+++ b/crates/iop/src/channel/oracle_setup.rs
@@ -8,12 +8,13 @@ use std::{
 	ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
 
+use binius_core::word::Word;
 use binius_field::{
 	ExtensionField, Field, FieldOps,
 	arithmetic_traits::{InvertOrZero, Square},
 	util::FieldFn,
 };
-use binius_ip::channel::IPVerifierChannel;
+use binius_ip::channel::{IPVerifierChannel, WordIPVerifierChannel};
 
 use crate::channel::{Error, IOPVerifierChannel, OracleLinearRelation, OracleSpec};
 
@@ -199,6 +200,26 @@ impl<F: Field> IPVerifierChannel<F> for OracleSetupChannel {
 		// The setup channel performs no real computation; skipping `f` is permitted (see the
 		// `IPVerifierChannel::compute_public_value` contract).
 		DummyElem(PhantomData)
+	}
+}
+
+impl<F: Field> WordIPVerifierChannel<F> for OracleSetupChannel {
+	type Word = Word;
+
+	// The dry run records oracle shapes only, so nothing reaches a Fiat-Shamir state.
+	fn observe_words(&mut self, _words: &[Word]) {}
+
+	fn subset_sum(&mut self, _elems: &[DummyElem<F>], _word: &Word) -> DummyElem<F> {
+		DummyElem(PhantomData)
+	}
+
+	fn select(&mut self, _elems: &[DummyElem<F>], _word: &Word) -> DummyElem<F> {
+		DummyElem(PhantomData)
+	}
+
+	// The recorded oracle shapes do not depend on which leaves a protocol would query.
+	fn sample_bits(&mut self, _bits: usize) -> Word {
+		Word::ZERO
 	}
 }
 

--- a/crates/iop/src/channel/size_tracking.rs
+++ b/crates/iop/src/channel/size_tracking.rs
@@ -4,8 +4,9 @@
 
 use std::{marker::PhantomData, mem::size_of};
 
+use binius_core::word::Word;
 use binius_field::{Field, util::FieldFn};
-use binius_ip::channel::IPVerifierChannel;
+use binius_ip::channel::{IPVerifierChannel, WordIPVerifierChannel, select_word, subset_sum_word};
 use binius_utils::serialization::FixedSizeSerializeBytes;
 
 use crate::{
@@ -103,6 +104,30 @@ where
 	}
 }
 
+impl<F, MerkleScheme_> WordIPVerifierChannel<F> for SizeTrackingChannel<'_, F, MerkleScheme_>
+where
+	F: Field + FixedSizeSerializeBytes,
+	MerkleScheme_: MerkleTreeScheme<F>,
+{
+	type Word = Word;
+
+	// Observing feeds the Fiat-Shamir state rather than the proof tape, so it costs no bytes.
+	fn observe_words(&mut self, _words: &[Word]) {}
+
+	fn subset_sum(&mut self, elems: &[F], word: &Word) -> F {
+		subset_sum_word(elems, *word)
+	}
+
+	fn select(&mut self, elems: &[F], word: &Word) -> F {
+		select_word(elems, *word)
+	}
+
+	// Which leaves are opened does not change what an opening costs, only how many.
+	fn sample_bits(&mut self, _bits: usize) -> Word {
+		Word::ZERO
+	}
+}
+
 impl<F, MerkleScheme_> MerkleIPVerifierChannel<F> for SizeTrackingChannel<'_, F, MerkleScheme_>
 where
 	F: Field + FixedSizeSerializeBytes,
@@ -123,7 +148,7 @@ where
 	fn recv_openings(
 		&mut self,
 		commitment: &Self::Commitment,
-		indices: &[usize],
+		indices: &[Word],
 	) -> Result<Vec<F>, Error> {
 		// A multi-opening sends one internal layer, then one branch per index up to that layer.
 		// The scheme prices both, since it is the scheme that decides where the layer sits.
@@ -145,10 +170,5 @@ where
 		let len = commitment.leaf_size << commitment.depth;
 		self.proof_size += len * F::BYTE_SIZE;
 		Ok(vec![F::ZERO; len])
-	}
-
-	fn sample_bits(&mut self, _bits: usize) -> usize {
-		// Which leaves are opened does not change what the opening costs, only how many.
-		0
 	}
 }

--- a/crates/iop/src/fri/batch.rs
+++ b/crates/iop/src/fri/batch.rs
@@ -2,7 +2,8 @@
 
 use std::iter;
 
-use binius_field::{BinaryField, FieldOps};
+use binius_field::{BinaryField, FieldOps, util::expand_subset_sums};
+use binius_ip::channel::WordIPVerifierChannel;
 use binius_math::{line::extrapolate_line, multilinear, ntt::DomainContext};
 
 use crate::merkle_channel::MerkleIPVerifierChannel;
@@ -22,26 +23,22 @@ pub trait ProxTestOracle<F: BinaryField, E> {
 	/// The Merkle commitment handle for the committed oracle.
 	type Commitment;
 
-	/// The base-2 logarithm of the length of the virtual oracle.
-	///
-	/// The virtual oracle is defined by the committed oracle and the folding challenges. Indices
-	/// passed to [`Self::open_queries`] must lie in the range `0..2^self.log_len()`.
-	fn log_len(&self) -> usize;
-
 	/// Opens queried locations on the virtual oracle.
 	///
 	/// This has a batch interface for verifying multiple queries because opening multiple Merkle
 	/// tree locations at once amortizes the proof size.
 	///
 	/// ## Preconditions
-	/// The `indices` must lie in the range `0..2^self.log_len()`.
+	/// The `indices` must address the virtual oracle, which spans the committed tree depth
+	/// duplicated over the lift factor. The channel guarantees the bound by masking what
+	/// [`WordIPVerifierChannel::sample_bits`] returns.
 	///
 	/// ## Returns
 	/// The values of the virtual oracle at the queried indices. The virtual oracle is defined by
 	/// the committed oracle and the folding challenges.
 	fn open_queries<Channel>(
 		&self,
-		indices: &[usize],
+		indices: &[Channel::Word],
 		channel: &mut Channel,
 	) -> Result<Vec<E>, Error>
 	where
@@ -54,8 +51,6 @@ pub trait ProxTestOracle<F: BinaryField, E> {
 pub struct BrakedownOracle<E, C> {
 	challenges: Vec<E>,
 	commitment: C,
-	/// The depth of the committed Merkle tree.
-	depth: usize,
 	/// log2 the lift factor (oracle padding). The committed codeword is virtually duplicated
 	/// `2^log_lift` times to reach the common first-round length; a query at global index `k`
 	/// reads the committed codeword at `k >> log_lift`. Zero when no lifting is needed.
@@ -65,14 +60,13 @@ pub struct BrakedownOracle<E, C> {
 impl<E, C> BrakedownOracle<E, C> {
 	/// Constructs a new oracle from the committed interleaved codeword and the folding challenges.
 	///
-	/// `depth` is the depth of the committed Merkle tree. `log_lift` is the oracle-padding lift
-	/// factor (the committed codeword is virtually duplicated `2^log_lift` times to reach the
-	/// common first-round length); pass `0` when no lifting is needed.
-	pub const fn new(challenges: Vec<E>, commitment: C, depth: usize, log_lift: usize) -> Self {
+	/// `log_lift` is the oracle-padding lift factor (the committed codeword is virtually
+	/// duplicated `2^log_lift` times to reach the common first-round length); pass `0` when no
+	/// lifting is needed.
+	pub const fn new(challenges: Vec<E>, commitment: C, log_lift: usize) -> Self {
 		Self {
 			challenges,
 			commitment,
-			depth,
 			log_lift,
 		}
 	}
@@ -81,26 +75,19 @@ impl<E, C> BrakedownOracle<E, C> {
 impl<F: BinaryField, E: FieldOps<Scalar = F>, C> ProxTestOracle<F, E> for BrakedownOracle<E, C> {
 	type Commitment = C;
 
-	fn log_len(&self) -> usize {
-		// The virtual (lifted) oracle length: the committed tree depth duplicated `2^log_lift`
-		// times.
-		self.depth + self.log_lift
-	}
-
 	fn open_queries<Channel>(
 		&self,
-		indices: &[usize],
+		indices: &[Channel::Word],
 		channel: &mut Channel,
 	) -> Result<Vec<E>, Error>
 	where
 		Channel: MerkleIPVerifierChannel<F, Commitment = C, Elem = E>,
 	{
-		assert!(indices.iter().all(|&index| index < 1 << self.log_len())); // precondition
 		// Translate each query on the virtual lifted oracle into a query on the committed codeword
 		// by dropping the low `log_lift` bits (the duplicated copies).
 		let lifted_indices = indices
 			.iter()
-			.map(|&index| index >> self.log_lift)
+			.map(|index| index.clone() >> self.log_lift as u32)
 			.collect::<Vec<_>>();
 		let values = channel.recv_openings(&self.commitment, &lifted_indices)?;
 		Ok(values
@@ -142,21 +129,9 @@ impl<F: BinaryField, E: FieldOps<Scalar = F>, C> ProxTestOracle<F, E>
 {
 	type Commitment = C;
 
-	fn log_len(&self) -> usize {
-		// Every bundled oracle reports the same virtual (lifted) length: the common first-round
-		// codeword length they are batched into.
-		debug_assert!(
-			self.oracles
-				.iter()
-				.all(|oracle| ProxTestOracle::<F, E>::log_len(oracle)
-					== ProxTestOracle::<F, E>::log_len(&self.oracles[0]))
-		);
-		ProxTestOracle::<F, E>::log_len(&self.oracles[0])
-	}
-
 	fn open_queries<Channel>(
 		&self,
-		indices: &[usize],
+		indices: &[Channel::Word],
 		channel: &mut Channel,
 	) -> Result<Vec<E>, Error>
 	where
@@ -207,11 +182,6 @@ impl<E, C, DC> FRIOracle<E, C, DC> {
 		}
 	}
 
-	/// The base-2 logarithm of the length of the virtual (folded) oracle.
-	const fn log_len(&self) -> usize {
-		self.depth
-	}
-
 	/// The base-2 log of the size of each coset opened from the committed oracle.
 	const fn coset_log_size(&self) -> usize {
 		self.challenges.len()
@@ -229,13 +199,22 @@ where
 	/// The committed oracle's codeword length in log terms is the Merkle tree depth plus the number
 	/// of folding challenges (one coset per leaf), which is the `log_len` consumed by
 	/// [`fold_coset`].
-	fn fold_coset(&self, chunk_index: usize, values: Vec<E>) -> E {
+	fn fold_coset<Channel>(
+		&self,
+		chunk_index: &Channel::Word,
+		values: Vec<E>,
+		channel: &mut Channel,
+	) -> E
+	where
+		Channel: WordIPVerifierChannel<F, Elem = E>,
+	{
 		fold_coset(
 			&self.domain_context,
 			self.depth + self.challenges.len(),
 			chunk_index,
 			&self.challenges,
 			values,
+			channel,
 		)
 	}
 
@@ -245,7 +224,7 @@ where
 	/// An index addresses the base codeword, and splits in two:
 	///
 	/// ```text
-	///     high log_len() bits          the coset index into the committed oracle
+	///     high depth bits              the coset index into the committed oracle
 	///     low coset_log_size() bits    the offset within that coset
 	/// ```
 	///
@@ -253,14 +232,13 @@ where
 	/// asserted over the channel. The coset then folds into the virtual oracle value.
 	///
 	/// ## Preconditions
-	/// `claims` must have the same length as `indices`, and the indices must lie in the range
-	/// `0..2^(self.log_len() + self.coset_log_size())`.
+	/// `claims` must have the same length as `indices`.
 	///
 	/// ## Returns
 	/// The values of the virtual oracle at the queried coset indices.
 	pub fn reduce_queries<Channel>(
 		&self,
-		indices: &[usize],
+		indices: &[Channel::Word],
 		claims: &[E],
 		channel: &mut Channel,
 	) -> Result<Vec<E>, Error>
@@ -268,26 +246,23 @@ where
 		Channel: MerkleIPVerifierChannel<F, Commitment = C, Elem = E>,
 	{
 		assert_eq!(indices.len(), claims.len()); // precondition
-		assert!(
-			indices
-				.iter()
-				.all(|&index| index < 1 << (self.log_len() + self.coset_log_size()))
-		); // precondition
 
 		let coset_log_size = self.coset_log_size();
-		let coset_mask = (1 << coset_log_size) - 1;
 		let coset_indices = indices
 			.iter()
-			.map(|&index| index >> coset_log_size)
+			.map(|index| index.clone() >> coset_log_size as u32)
 			.collect::<Vec<_>>();
 
 		let values = channel.recv_openings(&self.commitment, &coset_indices)?;
 		iter::zip(values.chunks(1 << coset_log_size), iter::zip(&coset_indices, indices))
 			.zip(claims)
-			.map(|((coset, (&coset_index, &index)), claim)| {
-				// Check the claimed base-codeword value against the opened coset.
-				channel.assert_zero(coset[index & coset_mask].clone() - claim.clone())?;
-				Ok(self.fold_coset(coset_index, coset.to_vec()))
+			.map(|((coset, (coset_index, index)), claim)| {
+				// Check the claimed base-codeword value against the opened coset. `select` reads
+				// the offset from the low `coset_log_size` bits of the index, which is the
+				// coset mask.
+				let opened = channel.select(coset, index);
+				channel.assert_zero(opened - claim.clone())?;
+				Ok(self.fold_coset(coset_index, coset.to_vec(), channel))
 			})
 			.collect()
 	}
@@ -299,29 +274,56 @@ where
 /// the domain context. `log_len` is the base-2 log of the length of the codeword the coset belongs
 /// to; the twiddle layer is absolute within the full NTT domain and decreases with each challenge.
 ///
+/// `chunk_index` names the coset within that codeword and is a channel word, so it need not be
+/// known when the protocol is described. A twiddle is read as a sum over the set bits of its block
+/// index: `DomainContext::twiddle` is `F2`-linear in that argument and vanishes at zero, so the
+/// twiddle of a block is the sum of the twiddles of the individual bits. The bits below the coset
+/// offset width are known here, and the rest come from `chunk_index` via
+/// [`WordIPVerifierChannel::subset_sum`].
+///
 /// [DP24]: <https://eprint.iacr.org/2024/504>
-pub fn fold_coset<F, E, DC>(
+pub fn fold_coset<F, E, DC, Channel>(
 	domain_context: &DC,
 	mut log_len: usize,
-	chunk_index: usize,
+	chunk_index: &Channel::Word,
 	challenges: &[E],
 	mut values: Vec<E>,
+	channel: &mut Channel,
 ) -> E
 where
 	F: BinaryField,
 	E: FieldOps<Scalar = F> + From<F>,
 	DC: DomainContext<Field = F>,
+	Channel: WordIPVerifierChannel<F, Elem = E>,
 {
 	let mut log_size = challenges.len();
 	for challenge in challenges {
-		for index_offset in 0..1 << (log_size - 1) {
+		let layer = log_len - 1;
+		// The twiddle of a block index is the sum of the basis elements its set bits select. That
+		// basis is the layer's subspace above the normalizing element, which `twiddle` itself
+		// indexes into.
+		let layer_subspace = domain_context.subspace(layer + 1);
+		let twiddle_basis = &layer_subspace.basis()[1..];
+
+		// A block index is `(chunk_index << shift) | index_offset`, so its low `shift` bits are the
+		// offset within the coset and the rest are the coset index.
+		let shift = log_size - 1;
+		let chunk_basis = twiddle_basis[shift..]
+			.iter()
+			.copied()
+			.map(E::from)
+			.collect::<Vec<_>>();
+		let chunk_twiddle = channel.subset_sum(&chunk_basis, chunk_index);
+		let offset_twiddles = expand_subset_sums(&twiddle_basis[..shift]);
+
+		for index_offset in 0..1 << shift {
+			let twiddle = chunk_twiddle.clone() + E::from(offset_twiddles[index_offset]);
+
 			// Perform the inverse additive NTT butterfly, then extrapolate the resulting line at
 			// the folding challenge.
-			let twiddle =
-				domain_context.twiddle(log_len - 1, (chunk_index << (log_size - 1)) | index_offset);
 			let mut u = values[index_offset << 1].clone();
 			let v = values[(index_offset << 1) | 1].clone() + &u;
-			u += v.clone() * E::from(twiddle);
+			u += v.clone() * twiddle;
 			values[index_offset] = extrapolate_line(u, v, challenge.clone());
 		}
 

--- a/crates/iop/src/fri/verify.rs
+++ b/crates/iop/src/fri/verify.rs
@@ -3,6 +3,7 @@
 
 use std::iter::{self, repeat_with};
 
+use binius_core::word::Word;
 use binius_field::{BinaryField, FieldOps};
 use binius_math::ntt::domain_context::GenericOnTheFly;
 use binius_utils::checked_arithmetics::log2_ceil_usize;
@@ -100,7 +101,6 @@ where
 		// holds whenever `log_lift <= log_dim`, so assert it here rather than trusting the
 		// caller.
 		let log_dim = params.rs_code().log_dim();
-		let log_inv_rate = params.rs_code().log_inv_rate();
 		for spec in params.input_oracles() {
 			assert!(
 				spec.log_lift <= log_dim,
@@ -135,15 +135,13 @@ where
 		let later_challenges = &challenges[max_early + log_n_oracles..params.log_batch_size()];
 		let codeword_sub_oracles = iter::zip(codeword_commitments, params.input_oracles())
 			.map(|(commitment, spec)| {
-				// The oracle's own codeword has dimension `log_dim - log_lift`, so its Merkle tree
-				// depth is that plus the inverse rate. It is lifted to the common first-round
-				// length (`index_bits`) by duplicating each entry `2^log_lift` times.
-				let depth = (log_dim - spec.log_lift) + log_inv_rate;
+				// The oracle is lifted to the common first-round length (`index_bits`) by
+				// duplicating each entry `2^log_lift` times.
 				let early_window = &early_challenges[max_early - spec.log_early_batch_size..];
 				let later_window = &later_challenges[max_later - spec.log_later_batch_size..];
 				let fold_challenges: Vec<E> =
 					early_window.iter().chain(later_window).cloned().collect();
-				BrakedownOracle::new(fold_challenges, commitment.clone(), depth, spec.log_lift)
+				BrakedownOracle::new(fold_challenges, commitment.clone(), spec.log_lift)
 			})
 			.collect();
 		let codeword_oracle = BatchBrakedownOracle::new(codeword_sub_oracles, outer_challenges);
@@ -199,9 +197,10 @@ where
 		let mut claims = self.codeword_oracle.open_queries(&indices, channel)?;
 		for (oracle, &arity) in self.fri_oracles.iter().zip(self.params.fold_arities()) {
 			claims = oracle.reduce_queries(&indices, &claims, channel)?;
-			for index in &mut indices {
-				*index >>= arity;
-			}
+			indices = indices
+				.into_iter()
+				.map(|index| index >> arity as u32)
+				.collect();
 		}
 
 		// Check the fully-reduced queries against the terminal codeword sent in full.
@@ -217,7 +216,7 @@ where
 	fn verify_terminal_queries<Channel>(
 		&self,
 		claims: &[E],
-		indices: &[usize],
+		indices: &[Channel::Word],
 		channel: &mut Channel,
 	) -> Result<E, Error>
 	where
@@ -229,8 +228,9 @@ where
 		let terminate_codeword = channel.recv_committed_vector(&self.terminal_commitment)?;
 
 		// Check the fully-reduced claims against the terminal codeword the verifier holds in full.
-		iter::zip(claims, indices).try_for_each(|(claim, &index)| {
-			channel.assert_zero(claim.clone() - terminate_codeword[index].clone())
+		iter::zip(claims, indices).try_for_each(|(claim, index)| {
+			let entry = channel.select(&terminate_codeword, index);
+			channel.assert_zero(claim.clone() - entry)
 		})?;
 
 		// Fold each coset of the terminal codeword and check that the folds are all equal, i.e.
@@ -242,12 +242,16 @@ where
 			.chunks(1 << n_final_challenges)
 			.enumerate()
 			.map(|(coset_index, coset)| {
+				// The coset index is fixed by the protocol here rather than sampled, so it is
+				// lifted from a concrete word.
+				let coset_index = Channel::Word::from(Word::from_u64(coset_index as u64));
 				fold_coset(
 					&domain_context,
 					log_len,
-					coset_index,
+					&coset_index,
 					self.final_challenges,
 					coset.to_vec(),
+					channel,
 				)
 			})
 			.collect::<Vec<_>>();

--- a/crates/iop/src/merkle_channel.rs
+++ b/crates/iop/src/merkle_channel.rs
@@ -14,20 +14,22 @@
 
 use std::{borrow::BorrowMut, marker::PhantomData};
 
+use binius_core::word::Word;
 use binius_field::{Field, util::FieldFn};
 use binius_hash::binary_merkle_tree::HashSuite;
-use binius_ip::channel::IPVerifierChannel;
-use binius_transcript::{
-	VerifierTranscript,
-	fiat_shamir::{CanSampleBits, Challenger},
-};
+use binius_ip::channel::{IPVerifierChannel, WordIPVerifierChannel};
+use binius_transcript::{VerifierTranscript, fiat_shamir::Challenger};
 use binius_utils::{DeserializeBytes, FixedSizeSerializeBytes};
 use digest::Output;
 
 use crate::merkle_tree::{BinaryMerkleTreeScheme, Commitment, MerkleTreeScheme};
 
-/// An extension of [`IPVerifierChannel`] that can receive and open Merkle commitments.
-pub trait MerkleIPVerifierChannel<F: Field>: IPVerifierChannel<F> {
+/// An extension of [`WordIPVerifierChannel`] that can receive and open Merkle commitments.
+///
+/// Query indices are [`Self::Word`](WordIPVerifierChannel::Word)s, since a protocol samples them
+/// with [`WordIPVerifierChannel::sample_bits`] and a channel that builds a circuit carries them as
+/// wires.
+pub trait MerkleIPVerifierChannel<F: Field>: WordIPVerifierChannel<F> {
 	/// A Merkle commitment.
 	type Commitment: Clone;
 
@@ -50,7 +52,7 @@ pub trait MerkleIPVerifierChannel<F: Field>: IPVerifierChannel<F> {
 	fn recv_openings(
 		&mut self,
 		commitment: &Self::Commitment,
-		indices: &[usize],
+		indices: &[Self::Word],
 	) -> Result<Vec<Self::Elem>, Error>;
 
 	/// Receives the full committed vector, bound by a Merkle commitment.
@@ -60,11 +62,6 @@ pub trait MerkleIPVerifierChannel<F: Field>: IPVerifierChannel<F> {
 		&mut self,
 		commitment: &Self::Commitment,
 	) -> Result<Vec<Self::Elem>, Error>;
-
-	/// Samples a uniform integer with the given number of bits.
-	///
-	/// Protocols use this to sample query indices for [`Self::recv_openings`].
-	fn sample_bits(&mut self, bits: usize) -> usize;
 }
 
 /// A [`MerkleIPVerifierChannel`] over a [`VerifierTranscript`], verifying openings with a
@@ -151,6 +148,33 @@ where
 	}
 }
 
+impl<F, T, Challenger_, H> WordIPVerifierChannel<F>
+	for VerifierMerkleTranscriptChannel<T, Challenger_, F, H>
+where
+	F: Field,
+	T: BorrowMut<VerifierTranscript<Challenger_>>,
+	Challenger_: Challenger,
+	H: HashSuite,
+{
+	type Word = Word;
+
+	fn observe_words(&mut self, words: &[Word]) {
+		WordIPVerifierChannel::<F>::observe_words(self.transcript.borrow_mut(), words);
+	}
+
+	fn subset_sum(&mut self, elems: &[F], word: &Word) -> F {
+		WordIPVerifierChannel::<F>::subset_sum(self.transcript.borrow_mut(), elems, word)
+	}
+
+	fn select(&mut self, elems: &[F], word: &Word) -> F {
+		WordIPVerifierChannel::<F>::select(self.transcript.borrow_mut(), elems, word)
+	}
+
+	fn sample_bits(&mut self, bits: usize) -> Word {
+		WordIPVerifierChannel::<F>::sample_bits(self.transcript.borrow_mut(), bits)
+	}
+}
+
 impl<F, T, Challenger_, H> MerkleIPVerifierChannel<F>
 	for VerifierMerkleTranscriptChannel<T, Challenger_, F, H>
 where
@@ -177,9 +201,13 @@ where
 	fn recv_openings(
 		&mut self,
 		commitment: &Self::Commitment,
-		indices: &[usize],
+		indices: &[Word],
 	) -> Result<Vec<F>, Error> {
 		let tree_depth = commitment.commitment.depth;
+		let indices = indices
+			.iter()
+			.map(|index| index.as_u64() as usize)
+			.collect::<Vec<_>>();
 		assert!(indices.iter().all(|&index| index < 1 << tree_depth)); // precondition
 
 		// Read and verify the optimal internal layer once, then verify every opening against it.
@@ -190,7 +218,7 @@ where
 			.verify_layer(&commitment.commitment.root, layer_depth, &layer_digests)?;
 
 		let mut values = Vec::with_capacity(indices.len() * commitment.leaf_size);
-		for &index in indices {
+		for &index in &indices {
 			let leaf = advice.read_scalar_slice::<F>(commitment.leaf_size)?;
 			self.scheme.verify_opening(
 				index,
@@ -215,10 +243,6 @@ where
 		self.scheme
 			.verify_vector(&commitment.commitment.root, &data, commitment.leaf_size)?;
 		Ok(data)
-	}
-
-	fn sample_bits(&mut self, bits: usize) -> usize {
-		CanSampleBits::sample_bits(self.transcript.borrow_mut(), bits) as usize
 	}
 }
 

--- a/crates/ip-prover/Cargo.toml
+++ b/crates/ip-prover/Cargo.toml
@@ -9,6 +9,7 @@ workspace = true
 
 [dependencies]
 binius-compute = { path = "../compute" }
+binius-core = { path = "../core" }
 binius-field = { path = "../field" }
 binius-ip = { path = "../ip" }
 binius-math = { path = "../math" }

--- a/crates/ip-prover/src/channel.rs
+++ b/crates/ip-prover/src/channel.rs
@@ -14,10 +14,13 @@
 //! communication mechanism, whether it's an actual interactive channel or a non-interactive
 //! transcript using the Fiat-Shamir heuristic.
 
+use std::ops::Shr;
+
+use binius_core::word::Word;
 use binius_field::Field;
 use binius_transcript::{
 	ProverTranscript,
-	fiat_shamir::{CanSample, Challenger},
+	fiat_shamir::{CanSample, CanSampleBits, Challenger},
 };
 
 /// Channel for sending prover messages and sampling challenges in a public-coin interactive
@@ -67,6 +70,29 @@ pub trait IPProverChannel<F: Field> {
 	}
 }
 
+/// A prover channel whose protocol carries 64-bit words alongside field elements.
+///
+/// The prover-side counterpart of
+/// [`WordIPVerifierChannel`](binius_ip::channel::WordIPVerifierChannel). It carries only the
+/// operations both parties perform — lifting constants, observing, shifting and sampling — since
+/// the arithmetic over a word's bits is the verifier's alone.
+pub trait WordIPProverChannel<F: Field>: IPProverChannel<F> {
+	/// The word type this channel carries.
+	///
+	/// Mirrors [`WordIPVerifierChannel::Word`](binius_ip::channel::WordIPVerifierChannel::Word),
+	/// including the [`From<Word>`](From) and [`Shr`] bounds that keep lifting and index
+	/// arithmetic plain operations rather than channel methods.
+	type Word: Clone + From<Word> + Shr<u32, Output = Self::Word>;
+
+	/// Feeds words into the Fiat-Shamir state, each as eight little-endian bytes.
+	fn observe_words(&mut self, words: &[Self::Word]);
+
+	/// Samples a uniform word of the given bit width, matching what the verifier samples.
+	///
+	/// The result is masked to `bits` bits.
+	fn sample_bits(&mut self, bits: usize) -> Self::Word;
+}
+
 impl<F, Challenger_> IPProverChannel<F> for ProverTranscript<Challenger_>
 where
 	F: Field,
@@ -90,5 +116,21 @@ where
 
 	fn sample(&mut self) -> F {
 		CanSample::sample(self)
+	}
+}
+
+impl<F, Challenger_> WordIPProverChannel<F> for ProverTranscript<Challenger_>
+where
+	F: Field,
+	Challenger_: Challenger,
+{
+	type Word = Word;
+
+	fn observe_words(&mut self, words: &[Word]) {
+		self.observe().write_slice(words);
+	}
+
+	fn sample_bits(&mut self, bits: usize) -> Word {
+		Word::from_u64(CanSampleBits::<u32>::sample_bits(self, bits) as u64)
 	}
 }

--- a/crates/ip/Cargo.toml
+++ b/crates/ip/Cargo.toml
@@ -9,6 +9,7 @@ workspace = true
 
 [dependencies]
 array-util.workspace = true
+binius-core = { path = "../core" }
 binius-field = { path = "../field" }
 binius-math = { path = "../math" }
 binius-transcript = { path = "../transcript" }

--- a/crates/ip/src/channel.rs
+++ b/crates/ip/src/channel.rs
@@ -15,13 +15,17 @@
 //! This abstraction allows protocol implementations to be generic over the underlying
 //! communication mechanism, whether it's an actual interactive channel or a non-interactive
 //! transcript using the Fiat-Shamir heuristic.
+//!
+//! [`WordIPVerifierChannel`] extends it for protocols that also carry 64-bit words, such as a
+//! constraint system's public inputs or a code proximity test's query indices.
 
-use std::iter::repeat_with;
+use std::{iter::repeat_with, ops::Shr};
 
+use binius_core::word::Word;
 use binius_field::{Field, field::FieldOps, util::FieldFn};
 use binius_transcript::{
 	VerifierTranscript,
-	fiat_shamir::{CanSample, Challenger},
+	fiat_shamir::{CanSample, CanSampleBits, Challenger},
 };
 
 /// Channel for receiving prover messages and sampling challenges in a public-coin interactive
@@ -110,6 +114,84 @@ pub trait IPVerifierChannel<F: Field> {
 	fn compute_public_value(&mut self, inputs: &[Self::Elem], f: impl FieldFn<F>) -> Self::Elem;
 }
 
+/// A verifier channel whose protocol carries 64-bit words alongside field elements.
+///
+/// Some values a verifier handles are words rather than field elements: the public inputs of a
+/// Binius64 constraint system, and the query indices a code proximity test samples. A channel that
+/// symbolically executes a verifier to build a circuit carries those as wires, so protocol code
+/// cannot name a concrete word type and goes through [`Self::Word`] instead.
+///
+/// [`Self::subset_sum`] and [`Self::select`] are how protocol code reaches the bits of a word. A
+/// channel over concrete values reads them directly; a circuit-building one emits a sub-circuit.
+pub trait WordIPVerifierChannel<F: Field>: IPVerifierChannel<F> {
+	/// The word type this channel carries.
+	///
+	/// A channel over concrete values uses [`Word`]. A channel that builds a circuit uses a wire
+	/// type that folds the operations below over a builder.
+	///
+	/// [`From<Word>`](From) lifts a word the protocol description fixes, such as a constraint
+	/// system constant, and [`Shr`] is the index arithmetic a code proximity test performs between
+	/// fold rounds. Both are plain operations on the type rather than channel methods, so protocol
+	/// code writes `word.into()` and `word >> n` whatever the channel is. The shift amount is a
+	/// `u32` to match [`Word`]'s own [`Shl`](std::ops::Shl) and [`Shr`] impls.
+	type Word: Clone + From<Word> + Shr<u32, Output = Self::Word>;
+
+	/// Feeds words into the Fiat-Shamir state, each as eight little-endian bytes.
+	fn observe_words(&mut self, words: &[Self::Word]);
+
+	/// Returns the sum of the `elems` selected by the low bits of `word`, low bit first.
+	///
+	/// This is the inner product of `elems` with the bit decomposition of `word`. Bits of `word`
+	/// at or above `elems.len()` do not contribute.
+	///
+	/// ## Preconditions
+	///
+	/// * `elems.len()` must be at most 64.
+	fn subset_sum(&mut self, elems: &[Self::Elem], word: &Self::Word) -> Self::Elem;
+
+	/// Returns the element of `elems` at the index in the low bits of `word`.
+	///
+	/// Bits of `word` at or above `log2(elems.len())` are ignored.
+	///
+	/// ## Preconditions
+	///
+	/// * `elems` must be non-empty and its length must be a power of two.
+	fn select(&mut self, elems: &[Self::Elem], word: &Self::Word) -> Self::Elem;
+
+	/// Samples a uniform word of the given bit width.
+	///
+	/// The result is masked to `bits` bits. Protocols rely on that bound, so an implementation
+	/// must enforce it rather than assume the sampled value already fits.
+	fn sample_bits(&mut self, bits: usize) -> Self::Word;
+}
+
+/// [`WordIPVerifierChannel::subset_sum`] over a concrete word, for channels carrying [`Word`].
+///
+/// ## Preconditions
+///
+/// * `elems.len()` must be at most 64.
+pub fn subset_sum_word<E: FieldOps>(elems: &[E], word: Word) -> E {
+	assert!(elems.len() <= Word::BITS); // precondition
+
+	elems
+		.iter()
+		.enumerate()
+		.filter(|&(bit, _)| word.extract_bit(bit))
+		.map(|(_, elem)| elem.clone())
+		.sum()
+}
+
+/// [`WordIPVerifierChannel::select`] over a concrete word, for channels carrying [`Word`].
+///
+/// ## Preconditions
+///
+/// * `elems` must be non-empty and its length must be a power of two.
+pub fn select_word<E: FieldOps>(elems: &[E], word: Word) -> E {
+	assert!(!elems.is_empty() && elems.len().is_power_of_two()); // precondition
+
+	elems[word.as_u64() as usize & (elems.len() - 1)].clone()
+}
+
 impl<F, Challenger_> IPVerifierChannel<F> for VerifierTranscript<Challenger_>
 where
 	F: Field,
@@ -155,6 +237,30 @@ where
 
 	fn compute_public_value(&mut self, inputs: &[F], f: impl FieldFn<F>) -> F {
 		f.call_native(inputs)
+	}
+}
+
+impl<F, Challenger_> WordIPVerifierChannel<F> for VerifierTranscript<Challenger_>
+where
+	F: Field,
+	Challenger_: Challenger,
+{
+	type Word = Word;
+
+	fn observe_words(&mut self, words: &[Word]) {
+		self.observe().write_slice(words);
+	}
+
+	fn subset_sum(&mut self, elems: &[F], word: &Word) -> F {
+		subset_sum_word(elems, *word)
+	}
+
+	fn select(&mut self, elems: &[F], word: &Word) -> F {
+		select_word(elems, *word)
+	}
+
+	fn sample_bits(&mut self, bits: usize) -> Word {
+		Word::from_u64(CanSampleBits::<u32>::sample_bits(self, bits) as u64)
 	}
 }
 

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -12,6 +12,7 @@ use binius_field::{AESTowerField8b as B8, Field, PackedField};
 use binius_hash::binary_merkle_tree::HashSuite;
 use binius_iop_prover::{basefold::compiler::BaseFoldProverCompiler, channel::IOPProverChannel};
 use binius_ip::sumcheck::SumcheckOutput;
+use binius_ip_prover::channel::WordIPProverChannel;
 use binius_math::{
 	BinarySubspace, FieldBuffer, FieldVec,
 	inner_product::inner_product,
@@ -26,7 +27,6 @@ use binius_utils::{
 use binius_verifier::{
 	IOPVerifier, Verifier,
 	config::{B128, LOG_WORDS_PER_ELEM},
-	encode_inout,
 	protocols::{binmul::BinMulOutput, bitand::AndCheckOutput, intmul::IntMulOutput, zero},
 };
 use digest::Output;
@@ -96,7 +96,7 @@ impl IOPProver {
 	where
 		A: Allocator,
 		P: PackedField<Scalar = B128>,
-		Channel: IOPProverChannel<P, A>,
+		Channel: IOPProverChannel<P, A> + WordIPProverChannel<B128, Word = Word>,
 	{
 		let cs = &self.constraint_system;
 
@@ -109,10 +109,9 @@ impl IOPProver {
 			pack_witness::<P, _>(alloc, self.log_witness_elems, witness.non_public())?;
 		drop(setup_guard);
 
-		// Observe the inout values as B128 elements (includes them in Fiat-Shamir). The constants
-		// are fixed by the constraint system, so only the per-instance values are observed, and
-		// the encoding is shared with the verifier so the two transcripts cannot drift.
-		channel.observe_many(&encode_inout(witness.inout()));
+		// Observe the inout words, which includes them in Fiat-Shamir. The constants are fixed by
+		// the constraint system, so only the per-instance values are observed.
+		channel.observe_words(witness.inout());
 
 		// [phase] Witness Commit - witness generation and commitment
 		let witness_commit_guard = tracing::info_span!("Commit witness").entered();

--- a/crates/spartan-prover/Cargo.toml
+++ b/crates/spartan-prover/Cargo.toml
@@ -9,6 +9,7 @@ workspace = true
 
 [dependencies]
 binius-compute = { path = "../compute" }
+binius-core = { path = "../core" }
 binius-field = { path = "../field" }
 binius-hash = { path = "../hash" }
 binius-iop = { path = "../iop" }

--- a/crates/spartan-prover/src/wrapper/replay_channel.rs
+++ b/crates/spartan-prover/src/wrapper/replay_channel.rs
@@ -10,9 +10,10 @@ use std::{
 	vec::IntoIter as VecIntoIter,
 };
 
+use binius_core::word::Word;
 use binius_field::{Field, util::FieldFn};
 use binius_iop::channel::{IOPVerifierChannel, OracleLinearRelation, OracleSpec};
-use binius_ip::channel::IPVerifierChannel;
+use binius_ip::channel::{IPVerifierChannel, WordIPVerifierChannel, select_word, subset_sum_word};
 use binius_spartan_frontend::{
 	circuit_builder::{CircuitBuilder, WireAllocator, WitnessError, WitnessGenerator},
 	constraint_system::{WireKind, Witness, WitnessLayout},
@@ -139,6 +140,26 @@ impl<F: Field> IPVerifierChannel<F> for ReplayChannel<F> {
 			witness_gen.hint_varsize(&input_wires, 1, move |vals| vec![f.call_native(vals)])[0]
 		};
 		CircuitElem::wire(&self.witness_gen, out_wire)
+	}
+}
+
+impl<F: Field> WordIPVerifierChannel<F> for ReplayChannel<F> {
+	type Word = Word;
+
+	// The recorded interaction already holds whatever the Fiat-Shamir state produced, so replaying
+	// observes nothing. This mirrors `IronSpartanBuilderChannel::observe_words`.
+	fn observe_words(&mut self, _words: &[Word]) {}
+
+	fn subset_sum(&mut self, elems: &[Self::Elem], word: &Word) -> Self::Elem {
+		subset_sum_word(elems, *word)
+	}
+
+	fn select(&mut self, elems: &[Self::Elem], word: &Word) -> Self::Elem {
+		select_word(elems, *word)
+	}
+
+	fn sample_bits(&mut self, _bits: usize) -> Word {
+		Word::ZERO
 	}
 }
 

--- a/crates/spartan-prover/src/wrapper/zk_wrapped_prover_channel.rs
+++ b/crates/spartan-prover/src/wrapper/zk_wrapped_prover_channel.rs
@@ -21,7 +21,7 @@ use binius_iop_prover::{
 	channel::IOPProverChannel,
 	merkle_channel::MerkleIPProverChannel,
 };
-use binius_ip_prover::channel::IPProverChannel;
+use binius_ip_prover::channel::{IPProverChannel, WordIPProverChannel};
 use binius_math::{FieldSlice, FieldVec, ntt::AdditiveNTT};
 use binius_spartan_frontend::constraint_system::{BlindingInfo, WitnessLayout};
 use binius_spartan_verifier::IOPVerifier;
@@ -260,6 +260,28 @@ where
 		let val = self.inner_channel.sample();
 		self.interaction.push(val);
 		val
+	}
+}
+
+impl<F, P, NTT, Channel, ReplayFn, A> WordIPProverChannel<F>
+	for ZKWrappedProverChannel<'_, P, NTT, Channel, ReplayFn, A>
+where
+	F: BinaryField,
+	P: PackedField<Scalar = F>,
+	NTT: AdditiveNTT<Field = F> + Sync,
+	Channel: MerkleIPProverChannel<F>,
+	A: Allocator,
+{
+	type Word = Channel::Word;
+
+	fn observe_words(&mut self, words: &[Self::Word]) {
+		// Only the inner Fiat-Shamir state takes the words. Nothing is recorded for replay, since
+		// the replay channel observes nothing either.
+		self.inner_channel.observe_words(words);
+	}
+
+	fn sample_bits(&mut self, bits: usize) -> Self::Word {
+		self.inner_channel.sample_bits(bits)
 	}
 }
 

--- a/crates/spartan-verifier/Cargo.toml
+++ b/crates/spartan-verifier/Cargo.toml
@@ -8,6 +8,7 @@ authors.workspace = true
 workspace = true
 
 [dependencies]
+binius-core = { path = "../core" }
 binius-field = { path = "../field" }
 binius-hash = { path = "../hash", default-features = false }
 binius-iop = { path = "../iop" }

--- a/crates/spartan-verifier/src/wrapper/builder_channel.rs
+++ b/crates/spartan-verifier/src/wrapper/builder_channel.rs
@@ -8,9 +8,10 @@ use std::{
 	rc::{Rc, Weak},
 };
 
+use binius_core::word::Word;
 use binius_field::{Field, util::FieldFn};
 use binius_iop::channel::{IOPVerifierChannel, OracleLinearRelation, OracleSpec};
-use binius_ip::channel::IPVerifierChannel;
+use binius_ip::channel::{IPVerifierChannel, WordIPVerifierChannel, select_word, subset_sum_word};
 use binius_spartan_frontend::circuit_builder::{CircuitBuilder, ConstraintBuilder};
 
 use super::circuit_elem::CircuitElem;
@@ -121,6 +122,26 @@ impl<F: Field> IPVerifierChannel<F> for IronSpartanBuilderChannel<F> {
 			builder.hint_varsize(&input_wires, 1, move |vals| vec![f.call_native(vals)])[0]
 		};
 		CircuitElem::wire(&self.builder, out_wire)
+	}
+}
+
+impl<F: Field> WordIPVerifierChannel<F> for IronSpartanBuilderChannel<F> {
+	type Word = Word;
+
+	// The outer verifier rebinds the public inputs, so the wrapper records no Fiat-Shamir state.
+	fn observe_words(&mut self, _words: &[Word]) {}
+
+	fn subset_sum(&mut self, elems: &[Self::Elem], word: &Word) -> Self::Elem {
+		// The word is concrete, so which elements the sum runs over is settled while building.
+		subset_sum_word(elems, *word)
+	}
+
+	fn select(&mut self, elems: &[Self::Elem], word: &Word) -> Self::Elem {
+		select_word(elems, *word)
+	}
+
+	fn sample_bits(&mut self, _bits: usize) -> Word {
+		Word::ZERO
 	}
 }
 

--- a/crates/spartan-verifier/src/wrapper/zk_wrapped_channel.rs
+++ b/crates/spartan-verifier/src/wrapper/zk_wrapped_channel.rs
@@ -13,13 +13,14 @@
 
 use std::{cell::RefCell, rc::Rc, sync::Arc};
 
+use binius_core::word::Word;
 use binius_field::{BinaryField, util::FieldFn};
 use binius_iop::{
 	basefold::channel::{BaseFoldOracle, BaseFoldVerifierChannel},
 	channel::{IOPVerifierChannel, OracleLinearRelation, OracleSpec},
 	merkle_channel::MerkleIPVerifierChannel,
 };
-use binius_ip::channel::IPVerifierChannel;
+use binius_ip::channel::{IPVerifierChannel, WordIPVerifierChannel, select_word, subset_sum_word};
 use binius_spartan_frontend::{
 	circuit_builder::{CircuitBuilder, InstanceGenerator, WireAllocator},
 	constraint_system::{WireKind, WitnessLayout},
@@ -224,6 +225,32 @@ where
 			instance_gen.hint_varsize(&input_wires, 1, move |vals| vec![f.call_native(vals)])[0]
 		};
 		CircuitElem::wire(&self.instance_gen, out_wire)
+	}
+}
+
+impl<F, Channel> WordIPVerifierChannel<F> for ZKWrappedVerifierChannel<'_, F, Channel>
+where
+	F: BinaryField,
+	Channel: MerkleIPVerifierChannel<F, Elem = F, Word = Word>,
+{
+	type Word = Word;
+
+	fn observe_words(&mut self, words: &[Word]) {
+		// The inner channel holds the Fiat-Shamir state the inner prover mirrors, so the words go
+		// there. The outer verifier recomputes what depends on them from the public segment.
+		self.inner_channel.observe_words(words);
+	}
+
+	fn subset_sum(&mut self, elems: &[Self::Elem], word: &Word) -> Self::Elem {
+		subset_sum_word(elems, *word)
+	}
+
+	fn select(&mut self, elems: &[Self::Elem], word: &Word) -> Self::Elem {
+		select_word(elems, *word)
+	}
+
+	fn sample_bits(&mut self, bits: usize) -> Word {
+		self.inner_channel.sample_bits(bits)
 	}
 }
 

--- a/crates/verifier/src/verify.rs
+++ b/crates/verifier/src/verify.rs
@@ -15,7 +15,7 @@ use binius_iop::{
 		IOPVerifierChannel, OracleLinearRelation, OracleSpec, oracle_setup::OracleSetupChannel,
 	},
 };
-use binius_ip::channel::IPVerifierChannel;
+use binius_ip::channel::{IPVerifierChannel, WordIPVerifierChannel};
 use binius_math::BinarySubspace;
 use binius_transcript::{VerifierTranscript, fiat_shamir::Challenger};
 use binius_utils::DeserializeBytes;
@@ -127,7 +127,7 @@ impl IOPVerifier {
 	/// For most users, [`Verifier::verify`] is the simpler interface.
 	pub fn verify<Channel>(&self, inout: &[Word], channel: &mut Channel) -> Result<(), Error>
 	where
-		Channel: IOPVerifierChannel<B128>,
+		Channel: IOPVerifierChannel<B128> + WordIPVerifierChannel<B128, Word = Word>,
 		Channel::Elem: FieldOps<Scalar = B128> + From<B128>,
 	{
 		// The caller passes only the inout values. The constants are already part of the
@@ -142,7 +142,7 @@ impl IOPVerifier {
 
 		// Only the inout values go into Fiat-Shamir: they are what varies per instance, and the
 		// constants are fixed by the constraint system the transcript is already bound to.
-		channel.observe_many(&encode_inout(inout));
+		channel.observe_words(inout);
 
 		// The shift reduction reads the whole public segment, which is the constants followed by
 		// the inout values — the order the value vector places them in.
@@ -364,24 +364,4 @@ where
 		chain!(small_field_zerocheck_challenges, big_field_zerocheck_challenges)
 			.collect::<Vec<_>>();
 	verify_with_channel(&zerocheck_challenges, channel, eval_domain)
-}
-
-/// Encodes the inout words as the field elements both sides observe in Fiat-Shamir.
-///
-/// Two words share one element, so an odd count leaves a final element whose high half is zero.
-/// The prover and the verifier both go through here, which is what keeps their transcripts
-/// identical.
-pub fn encode_inout(inout: &[Word]) -> Vec<B128> {
-	let (pairs, remainder) = inout.as_chunks::<2>();
-	let mut elems = pairs
-		.iter()
-		.map(|[w0, w1]| B128::new(((w1.as_u64() as u128) << 64) | w0.as_u64() as u128))
-		.collect::<Vec<_>>();
-
-	// An odd word count leaves one word over, which takes the low half of a final element.
-	if let [w0] = remainder {
-		elems.push(B128::new(w0.as_u64() as u128));
-	}
-
-	elems
 }


### PR DESCRIPTION
Second of two PRs for [BINIUS-427](https://linear.app/jimpo/issue/BINIUS-427/add-wordip-channel-traits-and-generalize-the-iop-verifier-stack-over), split per review. #2088 landed the BaseFold `Elem` generalization, so this is now rebased onto `main` and stands alone.

#2088 let the BaseFold and FRI verifiers run over a symbolic element type. This one does the same for the words a protocol carries.

## The trait pair

`WordIPVerifierChannel` (binius-ip) and `WordIPProverChannel` (binius-ip-prover), each with a `Word` associated type: `Word` for a channel over concrete values, a wire type for one that builds a circuit. Both crates gain a `binius-core` dependency, which the architecture allows.

Per review, lifting and index arithmetic are bounds on the associated type rather than channel methods:

```rust
type Word: Clone + From<Word> + Shr<u32, Output = Self::Word>;
```

so protocol code writes `word.into()` and `index >> n` whatever the channel is, and a symbolic channel folds those over its builder the way `CircuitElem` does for arithmetic. That removed 20 method impls across ten channels.

The remaining three operations do need the channel, since they either touch the Fiat-Shamir state or emit a sub-circuit: `observe_words`, `subset_sum` and `select`.

## Why the words have to be symbolic

Query indices come from `sample_bits`, so they cannot stay `usize`. They do not stay inside the Merkle channel either — they escape into `fri` in five places:

* `*index >>= arity` and `terminate_codeword[index]` in `fri/verify.rs`
* `index >> log_lift` and `index >> coset_log_size` before `recv_openings`, in `fri/batch.rs`
* `coset[index & coset_mask]` in `FRIOracle::reduce_queries`
* `chunk_index` feeding `DomainContext::twiddle` in `fold_coset`

The `Shr` bound covers three, `select` the fourth, `subset_sum` the fifth.

`subset_sum` is what a twiddle at a symbolic block index needs. `DomainContext::twiddle` is F2-linear in that argument and vanishes at zero, so the twiddle of a block is the sum of the twiddles of its individual bits. The basis is read through the trait as `twiddle(layer, 1 << bit)` rather than reaching into `GenericOnTheFly`'s subspace representation.

The same word problem appears one layer up in `shift::check_eval`, which is generic over `IPVerifierChannel` rather than the Merkle channel — hence the traits sit below `MerkleIP*` rather than on it.

## Two consequences worth reviewer attention

**The transcript changes for an odd `n_inout`.** `observe_words` replaces `encode_inout`, which is deleted. `encode_inout` packed two words into a `B128` serialized with `put_u128_le`, so for an even count the byte stream was already the words at eight little-endian bytes each and is unchanged. An odd count left a half-element with eight bytes of zero padding; observing words directly drops it. Prover and verifier move together, and the example snapshots hold circuit statistics rather than proof bytes, so nothing needs reblessing.

**Three items became dead code.** `ProxTestOracle::log_len`, `FRIOracle::log_len` and `BrakedownOracle::depth` served only the index-range preconditions, which cannot be checked against a symbolic word. Those asserts are gone, so the items are too (CI runs `-D warnings`), and the guarantee moves onto `sample_bits`, which masks its result to the requested width. `BrakedownOracle::new` loses its `depth` parameter as a result.

## Scope boundary

`IOPVerifier::verify` is pinned to `WordIPVerifierChannel<B128, Word = Word>`, and `IOPProver::prove` to the prover equivalent, so `observe_words` type-checks against the still-native `&[Word]` parameter. Relaxing that to a free associated type is [BINIUS-433](https://linear.app/jimpo/issue/BINIUS-433/take-the-inner-statement-symbolically-in-iopverifierverify), and is what actually lets a circuit-building channel run the verifier end to end.

Every channel over concrete values takes `type Word = Word` and the obvious implementation, so behaviour is unchanged: `subset_sum` is an XOR-sum over natively known bits emitting no constraints, `select` is an array index.

## Testing

Rebased onto `main` at `c7e9fc29`; no conflicts.

* `cargo check --workspace --all-targets`: clean, including every example.
* `cargo test --workspace --exclude binius-examples --exclude binius-arith-bench`: **1400 passed, 0 failed, 19 ignored** across 50 binaries.
* `cargo clippy --all-features --tests -- -D warnings`: clean on all eight crates touched.

`binius-examples` is excluded for disk, not correctness — linking its 328 example binaries needs ~6.3G my volume cannot spare; they all compile under `cargo check --all-targets`. `binius-arith-bench` does not build on aarch64 at stock `HEAD` and depends on nothing here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)