### PR TITLE
BINIUS-437: constrain select gates with a BMUL constraint

### DIFF
--- a/crates/examples/snapshots/bitcoin_headers.snap
+++ b/crates/examples/snapshots/bitcoin_headers.snap
@@ -7,12 +7,12 @@ Gates & Instructions
 Constraints
 ├─ ZERO constraints: 4,614 used (56.3% of 2^13)
 │  [▓▓▓▓▓░░░░░] spare: 3,578
-├─ AND constraints: 15,344 used (93.7% of 2^14)
-│  [▓▓▓▓▓▓▓▓▓░] spare: 1,040
+├─ AND constraints: 15,234 used (93.0% of 2^14)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 1,150
 ├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-├─ BMUL constraints: 0 used (0.0% of 0)
-│  [░░░░░░░░░░] spare: 0
+├─ BMUL constraints: 110 used (85.9% of 2^7)
+│  [▓▓▓▓▓▓▓▓░░] spare: 18
 └─ Distinct value indices: 47,303
    ├─ Distinct shifted value indices: 27,142
    └─ Distinct unshifted value indices: 20,161

--- a/crates/examples/snapshots/bitcoin_p2pkh.snap
+++ b/crates/examples/snapshots/bitcoin_p2pkh.snap
@@ -7,14 +7,14 @@ Gates & Instructions
 Constraints
 ├─ ZERO constraints: 1,914 used (93.5% of 2^11)
 │  [▓▓▓▓▓▓▓▓▓░] spare: 134
-├─ AND constraints: 111,567 used (85.1% of 2^17)
-│  [▓▓▓▓▓▓▓▓░░] spare: 19,505
+├─ AND constraints: 98,901 used (75.5% of 2^17)
+│  [▓▓▓▓▓▓▓░░░] spare: 32,171
 ├─ IMUL constraints: 15,186 used (92.7% of 2^14)
 │  [▓▓▓▓▓▓▓▓▓░] spare: 1,198
-├─ BMUL constraints: 0 used (0.0% of 0)
-│  [░░░░░░░░░░] spare: 0
-└─ Distinct value indices: 267,506
-   ├─ Distinct shifted value indices: 131,631
+├─ BMUL constraints: 12,666 used (77.3% of 2^14)
+│  [▓▓▓▓▓▓▓░░░] spare: 3,718
+└─ Distinct value indices: 267,507
+   ├─ Distinct shifted value indices: 131,632
    └─ Distinct unshifted value indices: 135,875
 
 Value Vector

--- a/crates/examples/snapshots/ec_msm.snap
+++ b/crates/examples/snapshots/ec_msm.snap
@@ -7,14 +7,14 @@ Gates & Instructions
 Constraints
 ├─ ZERO constraints: 2,140 used (52.2% of 2^12)
 │  [▓▓▓▓▓░░░░░] spare: 1,956
-├─ AND constraints: 156,113 used (59.6% of 2^18)
-│  [▓▓▓▓▓░░░░░] spare: 106,031
+├─ AND constraints: 132,481 used (50.5% of 2^18)
+│  [▓▓▓▓▓░░░░░] spare: 129,663
 ├─ IMUL constraints: 20,548 used (62.7% of 2^15)
 │  [▓▓▓▓▓▓░░░░] spare: 12,220
-├─ BMUL constraints: 0 used (0.0% of 0)
-│  [░░░░░░░░░░] spare: 0
-└─ Distinct value indices: 364,790
-   ├─ Distinct shifted value indices: 176,456
+├─ BMUL constraints: 23,632 used (72.1% of 2^15)
+│  [▓▓▓▓▓▓▓░░░] spare: 9,136
+└─ Distinct value indices: 364,791
+   ├─ Distinct shifted value indices: 176,457
    └─ Distinct unshifted value indices: 188,334
 
 Value Vector

--- a/crates/examples/snapshots/ethsign.snap
+++ b/crates/examples/snapshots/ethsign.snap
@@ -7,14 +7,14 @@ Gates & Instructions
 Constraints
 ├─ ZERO constraints: 2,173 used (53.1% of 2^12)
 │  [▓▓▓▓▓░░░░░] spare: 1,923
-├─ AND constraints: 157,690 used (60.2% of 2^18)
-│  [▓▓▓▓▓▓░░░░] spare: 104,454
+├─ AND constraints: 133,816 used (51.0% of 2^18)
+│  [▓▓▓▓▓░░░░░] spare: 128,328
 ├─ IMUL constraints: 20,554 used (62.7% of 2^15)
 │  [▓▓▓▓▓▓░░░░] spare: 12,214
-├─ BMUL constraints: 0 used (0.0% of 0)
-│  [░░░░░░░░░░] spare: 0
-└─ Distinct value indices: 379,027
-   ├─ Distinct shifted value indices: 189,007
+├─ BMUL constraints: 23,874 used (72.9% of 2^15)
+│  [▓▓▓▓▓▓▓░░░] spare: 8,894
+└─ Distinct value indices: 379,028
+   ├─ Distinct shifted value indices: 189,008
    └─ Distinct unshifted value indices: 190,020
 
 Value Vector

--- a/crates/examples/snapshots/hashsign.snap
+++ b/crates/examples/snapshots/hashsign.snap
@@ -7,12 +7,12 @@ Gates & Instructions
 Constraints
 ├─ ZERO constraints: 110,514 used (84.3% of 2^17)
 │  [▓▓▓▓▓▓▓▓░░] spare: 20,558
-├─ AND constraints: 145,508 used (55.5% of 2^18)
-│  [▓▓▓▓▓░░░░░] spare: 116,636
+├─ AND constraints: 142,844 used (54.5% of 2^18)
+│  [▓▓▓▓▓░░░░░] spare: 119,300
 ├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-├─ BMUL constraints: 0 used (0.0% of 0)
-│  [░░░░░░░░░░] spare: 0
+├─ BMUL constraints: 2,664 used (65.0% of 2^12)
+│  [▓▓▓▓▓▓░░░░] spare: 1,432
 └─ Distinct value indices: 647,258
    ├─ Distinct shifted value indices: 392,212
    └─ Distinct unshifted value indices: 255,046

--- a/crates/examples/snapshots/zklogin.snap
+++ b/crates/examples/snapshots/zklogin.snap
@@ -7,14 +7,14 @@ Gates & Instructions
 Constraints
 ├─ ZERO constraints: 22,862 used (69.8% of 2^15)
 │  [▓▓▓▓▓▓░░░░] spare: 9,906
-├─ AND constraints: 235,124 used (89.7% of 2^18)
-│  [▓▓▓▓▓▓▓▓░░] spare: 27,020
+├─ AND constraints: 203,408 used (77.6% of 2^18)
+│  [▓▓▓▓▓▓▓░░░] spare: 58,736
 ├─ IMUL constraints: 8,262 used (50.4% of 2^14)
 │  [▓▓▓▓▓░░░░░] spare: 8,122
-├─ BMUL constraints: 0 used (0.0% of 0)
-│  [░░░░░░░░░░] spare: 0
-└─ Distinct value indices: 544,947
-   ├─ Distinct shifted value indices: 284,342
+├─ BMUL constraints: 31,716 used (96.8% of 2^15)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 1,052
+└─ Distinct value indices: 546,028
+   ├─ Distinct shifted value indices: 285,423
    └─ Distinct unshifted value indices: 260,605
 
 Value Vector

--- a/crates/frontend/src/compiler/gate/select.rs
+++ b/crates/frontend/src/compiler/gate/select.rs
@@ -1,4 +1,5 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 //! Select operation.
 //!
 //! Returns `out = MSB(cond) ? t : f`.
@@ -6,16 +7,18 @@
 //! # Algorithm
 //!
 //! The gate inspects the MSB (Most Significant Bit) of the condition value to select between
-//! two inputs. This is computed using a single AND constraint with the formula:
-//! `out = f ⊕ ((cond ~>> 63) ∧ (t ⊕ f))`
+//! two inputs. Logically shifting the condition right by 63 leaves that bit alone in the word,
+//! so the MSB-bool becomes the GHASH-field scalar `0` or `1` and the selection is the product
+//! `out ⊕ f = (cond >> 63) · (t ⊕ f)`.
 //!
-//! The arithmetic shift right by 63 broadcasts the MSB to all bit positions, creating
-//! an all-ones mask if MSB=1 or all-zeros if MSB=0.
+//! Scaling by `1` is the field identity and scaling by `0` annihilates, so the product needs no
+//! reduction: it stays within the low 64 coefficients its factor occupies. Both factors and the
+//! product therefore have a zero high word.
 //!
 //! # Constraints
 //!
-//! The gate generates 1 AND constraint:
-//! - `(cond >> 63) ∧ (t ⊕ f) = out ⊕ f`
+//! The gate generates 1 BMUL constraint:
+//! - `(cond >> 63) · (t ⊕ f) = out ⊕ f`
 
 use crate::compiler::{
 	constraint_builder::{ConstraintBuilder, expr},
@@ -44,8 +47,17 @@ pub fn constrain(data: &GateData, builder: &mut ConstraintBuilder) {
 
 	// Constraint: Select operation
 	//
-	// (cond >> 63) ∧ (t ⊕ f) = out ⊕ f
-	builder.and(expr::sar(*cond, 63), expr::xor2(*t, *f), expr::xor2(*out, *f));
+	// (cond >> 63) · (t ⊕ f) = out ⊕ f, over the GHASH field.
+	//
+	// Every factor fits in the low word, so each high word is the empty operand.
+	builder.bmul(
+		expr::srl(*cond, 63),
+		expr::empty(),
+		expr::xor2(*t, *f),
+		expr::empty(),
+		expr::xor2(*out, *f),
+		expr::empty(),
+	);
 }
 
 pub fn emit_eval_bytecode(

--- a/crates/frontend/src/compiler/mod.rs
+++ b/crates/frontend/src/compiler/mod.rs
@@ -1347,7 +1347,7 @@ impl CircuitBuilder {
 	///
 	/// # Cost
 	///
-	/// 1 AND constraint, or none when both arms are the same wire.
+	/// 1 BMUL constraint, or none when both arms are the same wire.
 	pub fn select(&self, cond: Wire, t: Wire, f: Wire) -> Wire {
 		// Both arms identical: the result is that wire regardless of the condition.
 		// This reads no bit of `cond`, so it is independent of the MSB-boolean convention.

--- a/crates/prover/tests/shift.rs
+++ b/crates/prover/tests/shift.rs
@@ -1,10 +1,14 @@
 // Copyright 2025 Irreducible Inc.
 // Copyright 2026 The Binius Developers
 
+use std::array;
+
 use binius_circuits::{fixed_byte_vec::ByteVec, sha256::sha256_varlen};
 use binius_compute::GlobalAllocator;
 use binius_core::{
-	constraint_system::{AndConstraint, ConstraintSystem, ImulConstraint, InoutSegment, ValueVec},
+	constraint_system::{
+		AndConstraint, BmulConstraint, ConstraintSystem, ImulConstraint, InoutSegment, ValueVec,
+	},
 	word::Word,
 };
 use binius_field::{AESTowerField8b, BinaryField};
@@ -176,6 +180,20 @@ fn compute_intmul_images(constraints: &[ImulConstraint], witness: &ValueVec) -> 
 	[a_image, b_image, lo_image, hi_image].map(|image| pad_image(image, constraints.len()))
 }
 
+// Compute the image of the witness applied to the BMUL constraints
+//
+// Each image is zero-padded to a power-of-two length, matching the operand columns the prover
+// materializes.
+fn compute_binmul_images(constraints: &[BmulConstraint], witness: &ValueVec) -> [Vec<Word>; 6] {
+	array::from_fn(|op_idx| {
+		let image = constraints
+			.iter()
+			.map(|constraint| witness.eval_operand(&constraint.as_ref()[op_idx]))
+			.collect();
+		pad_image(image, constraints.len())
+	})
+}
+
 // Evaluate the image of the witness applied to the AND or IMUL constraints
 // Univariate point is `r_zhat_prime`, multilinear point tensor-expanded is `r_x_prime_tensor`
 fn evaluate_image<F: BinaryField>(
@@ -252,6 +270,18 @@ fn test_shift_prove_and_verify() {
 			Vec::new()
 		};
 
+		// A constraint system may equally have zero BMUL constraints, and the BinMul operator is
+		// then empty for the same reason.
+		let binmul_is_empty = cs.bmul_constraints.is_empty();
+		let r_x_prime_binmul = if let Some(log_binmul_constraint_count) = cs.log_bmul_constraints()
+		{
+			(0..log_binmul_constraint_count as u128)
+				.map(F::new)
+				.collect::<Vec<_>>()
+		} else {
+			Vec::new()
+		};
+
 		// Sample univariate eval point — the bitand and intmul operators share
 		// `r_zhat_prime` so the verifier can compute `h_op_evals` once for both.
 		let r_zhat_prime = F::random(&mut rng);
@@ -276,6 +306,19 @@ fn test_shift_prove_and_verify() {
 					&image,
 					r_zhat_prime,
 					eq_ind_partial_eval(&r_x_prime_intmul).as_ref(),
+				)
+			})
+		};
+
+		let binmul_evals: [F; 6] = if binmul_is_empty {
+			[F::ZERO; 6]
+		} else {
+			compute_binmul_images(&cs.bmul_constraints, &value_vec).map(|image| {
+				evaluate_image(
+					&subspace,
+					&image,
+					r_zhat_prime,
+					eq_ind_partial_eval(&r_x_prime_binmul).as_ref(),
 				)
 			})
 		};
@@ -307,9 +350,11 @@ fn test_shift_prove_and_verify() {
 			r_zhat_prime,
 			r_x_prime: r_x_prime_zero.clone(),
 		};
-		// These circuits have no BMUL constraints, so the BinMul claim is the zero claim at an
-		// empty point (the prover's skipped-case `None` branch).
-		let prover_binmul_data = OperatorData::zero_claim(r_zhat_prime);
+		let prover_binmul_data = OperatorData {
+			evals: binmul_evals,
+			r_zhat_prime,
+			r_x_prime: r_x_prime_binmul.clone(),
+		};
 
 		let prover_output = prove::<F, P, _, _>(
 			&key_collection,
@@ -332,7 +377,7 @@ fn test_shift_prove_and_verify() {
 		let verifier_zero_data = VerifierOperatorData::new(r_x_prime_zero, [F::ZERO]);
 		let verifier_bitand_data = VerifierOperatorData::new(r_x_prime_bitand, bitand_evals);
 		let verifier_intmul_data = VerifierOperatorData::new(r_x_prime_intmul, intmul_evals);
-		let verifier_binmul_data = VerifierOperatorData::new(Vec::new(), [F::ZERO; 6]);
+		let verifier_binmul_data = VerifierOperatorData::new(r_x_prime_binmul, binmul_evals);
 
 		let verifier_output = verify(
 			&cs,


### PR DESCRIPTION
Closes [BINIUS-437](https://linear.app/jimpo/issue/BINIUS-437/frontend-constrain-select-gates-with-binmul).

The select gate constrained its output with the AND constraint

```
(cond ~>> 63) & (t ^ f) = out ^ f
```

reading the condition's MSB by sign-extending it across the word. The same relation holds in the GHASH field with the MSB as a 0/1 scalar, so the gate now emits a BMUL constraint instead:

```
(cond >> 63) * (t ^ f) = out ^ f
```

Scaling by `0` or `1` needs no reduction, so both factors and the product stay inside the low 64 coefficients and all three high operands are empty — as the issue specifies.

Witness generation is untouched: the eval-form bytecode still computes `out = MSB(cond) ? t : f`.

### Test fallout

`crates/prover/tests/shift.rs` asserted that its circuits have no BMUL constraints and passed a zero claim at an empty point. Those circuits (sha256_varlen, slice, concat) all use select gates, so that claim now has to be real — it panicked in `key_collection.rs` indexing a length-1 `r_x_prime` tensor. It is now built exactly like the IMUL claim, which makes this the first test to drive a **non-empty** BMUL claim through the shift reduction.

## Circuit size

Every select moves one row from the AND set to the BMUL set. Only the six examples that use select gates change; sha256, sha512, keccak and the blake circuits are untouched.

| example | AND before | AND after | BMUL after | AND alloc | BMUL alloc |
|---|---|---|---|---|---|
| zklogin | 235,124 | 203,408 | 31,716 | 2^18 → 2^18 | 0 → 2^15 |
| ethsign | 157,690 | 133,816 | 23,874 | 2^18 → 2^18 | 0 → 2^15 |
| ec_msm | 156,113 | 132,481 | 23,632 | 2^18 → 2^18 | 0 → 2^15 |
| hashsign | 145,508 | 142,844 | 2,664 | 2^18 → 2^18 | 0 → 2^12 |
| bitcoin_p2pkh | 111,567 | 98,901 | 12,666 | 2^17 → 2^17 | 0 → 2^14 |
| bitcoin_headers | 15,344 | 15,234 | 110 | 2^14 → 2^14 | 0 → 2^7 |

The committed trace is unchanged everywhere — this moves constraint rows, not values.

**No circuit crosses a power-of-two AND boundary.** That matters, because each reduction runs over its constraint set padded to the next power of two (`build_operation_columns` in `crates/prover/src/prove.rs:577`), so dropping 31,716 AND rows out of a set that stays at 2^18 buys no prover time today. What it buys is **headroom**: zklogin's AND set goes from 89.7% of 2^18 (27,020 spare) to 77.6% (58,736 spare). It was ~27k constraints from spilling into 2^19 and roughly doubling the BitAnd reduction; that margin is now 2.2× larger.

## Perf impact (zklogin)

4 interleaved A/B reps on an idle 4-core box, `--release` with `RUSTFLAGS="-C target-cpu=native"`, default `prove` (log_inv_rate=1, sha256 suite). Interleaved because the box is shared; run-to-run spread on the total is ~±5%.

| phase | main | this PR |
|---|---|---|
| **Prove (total)** | 478 / 510 / 499 / 507 ms | 504 / 514 / 499 / 485 ms |
| BitAnd check | 185.5 ms avg | 185.0 ms avg |
| IntMul check | 171.8 ms avg | 169.0 ms avg |
| **BinMul check** | — | **8.3 ms avg** |
| Shift Reduction | 65.3 ms avg | 62.6 ms avg |

**Prove time is flat** — the medians are 503 ms vs 501 ms, inside the noise. The BitAnd reduction costs the same on both sides (both 2^18, as expected), and the new BinMul reduction adds ~8 ms at 2^15 rows.

Proof size grows deterministically: **312,112 → 318,736 bytes (+6,624, +2.1%)**. That is exactly the BinMul transcript: 6 × 64 per-bit evals (6,144 B) plus 15 mlecheck rounds × 2 coefficients × 16 B (480 B).

So: same prover time, +2.1% proof, and materially more room before zklogin's AND set doubles.

## Two things worth a look

1. **The BMUL set lands at 96.8% of 2^15 for zklogin** (1,052 spare). The next ~1k select gates push it to 2^16 and roughly double the BinMul reduction — ~8 ms, so small in absolute terms, but it is the tightest set in the circuit now.

2. **`assert_eq_cond` still uses `sar(cond, 63)`**, and zklogin's distinct shifted value indices went *up* by 1,081 (284,342 → 285,423): where a condition feeds both a select and an `assert_eq_cond`, the two used to share one `sar` key and now need `srl` and `sar` separately. `assert_eq_cond` is `sar(cond,63) & (a^b) = 0`, which is the same shape and could become `srl(cond,63) * (a^b) = 0` — that would recover the sharing and move another 1,080 rows (zklogin) out of the AND set. Out of scope here; happy to do it as a follow-up if you want it.

Verified locally with `RUSTFLAGS="-C target-cpu=native"`: full `cargo test --all` green, `cargo clippy --all --tests --benches --examples -- -D warnings` clean, `cargo fmt --check` clean, `cargo doc` clean with `RUSTDOCFLAGS=-D warnings`, and all 13 circuit-stat snapshots re-blessed and re-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)