### PR TITLE
BINIUS-435: constrain assert gates with ZERO constraints instead of AND

### DIFF
--- a/crates/examples/snapshots/bitcoin_headers.snap
+++ b/crates/examples/snapshots/bitcoin_headers.snap
@@ -5,16 +5,16 @@ Gates & Instructions
 └─ Number of evaluation instructions: 47,238
 
 Constraints
-├─ ZERO constraints: 4,734 used (57.8% of 2^13)
-│  [▓▓▓▓▓░░░░░] spare: 3,458
-├─ AND constraints: 15,114 used (92.2% of 2^14)
-│  [▓▓▓▓▓▓▓▓▓░] spare: 1,270
+├─ ZERO constraints: 4,744 used (57.9% of 2^13)
+│  [▓▓▓▓▓░░░░░] spare: 3,448
+├─ AND constraints: 15,104 used (92.2% of 2^14)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 1,280
 ├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
 ├─ BMUL constraints: 110 used (85.9% of 2^7)
 │  [▓▓▓▓▓▓▓▓░░] spare: 18
-└─ Distinct value indices: 47,303
-   ├─ Distinct shifted value indices: 27,142
+└─ Distinct value indices: 47,323
+   ├─ Distinct shifted value indices: 27,162
    └─ Distinct unshifted value indices: 20,161
 
 Value Vector

--- a/crates/examples/snapshots/bitcoin_headers.snap
+++ b/crates/examples/snapshots/bitcoin_headers.snap
@@ -5,10 +5,10 @@ Gates & Instructions
 └─ Number of evaluation instructions: 47,238
 
 Constraints
-├─ ZERO constraints: 4,614 used (56.3% of 2^13)
-│  [▓▓▓▓▓░░░░░] spare: 3,578
-├─ AND constraints: 15,234 used (93.0% of 2^14)
-│  [▓▓▓▓▓▓▓▓▓░] spare: 1,150
+├─ ZERO constraints: 4,734 used (57.8% of 2^13)
+│  [▓▓▓▓▓░░░░░] spare: 3,458
+├─ AND constraints: 15,114 used (92.2% of 2^14)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 1,270
 ├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
 ├─ BMUL constraints: 110 used (85.9% of 2^7)

--- a/crates/examples/snapshots/bitcoin_p2pkh.snap
+++ b/crates/examples/snapshots/bitcoin_p2pkh.snap
@@ -5,16 +5,16 @@ Gates & Instructions
 └─ Number of evaluation instructions: 176,783
 
 Constraints
-├─ ZERO constraints: 9,769 used (59.6% of 2^14)
-│  [▓▓▓▓▓░░░░░] spare: 6,615
-├─ AND constraints: 91,046 used (69.5% of 2^17)
-│  [▓▓▓▓▓▓░░░░] spare: 40,026
+├─ ZERO constraints: 16,582 used (50.6% of 2^15)
+│  [▓▓▓▓▓░░░░░] spare: 16,186
+├─ AND constraints: 84,233 used (64.3% of 2^17)
+│  [▓▓▓▓▓▓░░░░] spare: 46,839
 ├─ IMUL constraints: 15,186 used (92.7% of 2^14)
 │  [▓▓▓▓▓▓▓▓▓░] spare: 1,198
 ├─ BMUL constraints: 12,666 used (77.3% of 2^14)
 │  [▓▓▓▓▓▓▓░░░] spare: 3,718
-└─ Distinct value indices: 267,507
-   ├─ Distinct shifted value indices: 131,632
+└─ Distinct value indices: 275,067
+   ├─ Distinct shifted value indices: 139,192
    └─ Distinct unshifted value indices: 135,875
 
 Value Vector

--- a/crates/examples/snapshots/bitcoin_p2pkh.snap
+++ b/crates/examples/snapshots/bitcoin_p2pkh.snap
@@ -5,10 +5,10 @@ Gates & Instructions
 └─ Number of evaluation instructions: 176,783
 
 Constraints
-├─ ZERO constraints: 1,914 used (93.5% of 2^11)
-│  [▓▓▓▓▓▓▓▓▓░] spare: 134
-├─ AND constraints: 98,901 used (75.5% of 2^17)
-│  [▓▓▓▓▓▓▓░░░] spare: 32,171
+├─ ZERO constraints: 9,769 used (59.6% of 2^14)
+│  [▓▓▓▓▓░░░░░] spare: 6,615
+├─ AND constraints: 91,046 used (69.5% of 2^17)
+│  [▓▓▓▓▓▓░░░░] spare: 40,026
 ├─ IMUL constraints: 15,186 used (92.7% of 2^14)
 │  [▓▓▓▓▓▓▓▓▓░] spare: 1,198
 ├─ BMUL constraints: 12,666 used (77.3% of 2^14)

--- a/crates/examples/snapshots/blake2b.snap
+++ b/crates/examples/snapshots/blake2b.snap
@@ -5,17 +5,17 @@ Gates & Instructions
 └─ Number of evaluation instructions: 10,824
 
 Constraints
-├─ ZERO constraints: 3,088 used (75.4% of 2^12)
-│  [▓▓▓▓▓▓▓░░░] spare: 1,008
-├─ AND constraints: 4,616 used (56.3% of 2^13)
-│  [▓▓▓▓▓░░░░░] spare: 3,576
+├─ ZERO constraints: 3,096 used (75.6% of 2^12)
+│  [▓▓▓▓▓▓▓░░░] spare: 1,000
+├─ AND constraints: 4,608 used (56.2% of 2^13)
+│  [▓▓▓▓▓░░░░░] spare: 3,584
 ├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
 ├─ BMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-└─ Distinct value indices: 19,333
+└─ Distinct value indices: 19,332
    ├─ Distinct shifted value indices: 11,486
-   └─ Distinct unshifted value indices: 7,847
+   └─ Distinct unshifted value indices: 7,846
 
 Value Vector
 ├─ Public Section: 28 (not committed)

--- a/crates/examples/snapshots/blake2s.snap
+++ b/crates/examples/snapshots/blake2s.snap
@@ -5,17 +5,17 @@ Gates & Instructions
 └─ Number of evaluation instructions: 18,568
 
 Constraints
-├─ ZERO constraints: 5,292 used (64.6% of 2^13)
-│  [▓▓▓▓▓▓░░░░] spare: 2,900
-├─ AND constraints: 7,688 used (93.8% of 2^13)
-│  [▓▓▓▓▓▓▓▓▓░] spare: 504
+├─ ZERO constraints: 5,300 used (64.7% of 2^13)
+│  [▓▓▓▓▓▓░░░░] spare: 2,892
+├─ AND constraints: 7,680 used (93.8% of 2^13)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 512
 ├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
 ├─ BMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-└─ Distinct value indices: 32,509
+└─ Distinct value indices: 32,508
    ├─ Distinct shifted value indices: 19,510
-   └─ Distinct unshifted value indices: 12,999
+   └─ Distinct unshifted value indices: 12,998
 
 Value Vector
 ├─ Public Section: 45 (not committed)

--- a/crates/examples/snapshots/blake3.snap
+++ b/crates/examples/snapshots/blake3.snap
@@ -5,17 +5,17 @@ Gates & Instructions
 └─ Number of evaluation instructions: 7,256
 
 Constraints
-├─ ZERO constraints: 1,997 used (97.5% of 2^11)
-│  [▓▓▓▓▓▓▓▓▓░] spare: 51
-├─ AND constraints: 2,760 used (67.4% of 2^12)
-│  [▓▓▓▓▓▓░░░░] spare: 1,336
+├─ ZERO constraints: 2,069 used (50.5% of 2^12)
+│  [▓▓▓▓▓░░░░░] spare: 2,027
+├─ AND constraints: 2,688 used (65.6% of 2^12)
+│  [▓▓▓▓▓▓░░░░] spare: 1,408
 ├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
 ├─ BMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-└─ Distinct value indices: 12,379
+└─ Distinct value indices: 12,378
    ├─ Distinct shifted value indices: 7,617
-   └─ Distinct unshifted value indices: 4,762
+   └─ Distinct unshifted value indices: 4,761
 
 Value Vector
 ├─ Public Section: 281 (not committed)

--- a/crates/examples/snapshots/ec_msm.snap
+++ b/crates/examples/snapshots/ec_msm.snap
@@ -5,10 +5,10 @@ Gates & Instructions
 └─ Number of evaluation instructions: 244,030
 
 Constraints
-├─ ZERO constraints: 2,140 used (52.2% of 2^12)
-│  [▓▓▓▓▓░░░░░] spare: 1,956
-├─ AND constraints: 132,481 used (50.5% of 2^18)
-│  [▓▓▓▓▓░░░░░] spare: 129,663
+├─ ZERO constraints: 12,728 used (77.7% of 2^14)
+│  [▓▓▓▓▓▓▓░░░] spare: 3,656
+├─ AND constraints: 121,893 used (93.0% of 2^17)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 9,179
 ├─ IMUL constraints: 20,548 used (62.7% of 2^15)
 │  [▓▓▓▓▓▓░░░░] spare: 12,220
 ├─ BMUL constraints: 23,632 used (72.1% of 2^15)

--- a/crates/examples/snapshots/ec_msm.snap
+++ b/crates/examples/snapshots/ec_msm.snap
@@ -5,16 +5,16 @@ Gates & Instructions
 └─ Number of evaluation instructions: 244,030
 
 Constraints
-├─ ZERO constraints: 12,728 used (77.7% of 2^14)
-│  [▓▓▓▓▓▓▓░░░] spare: 3,656
-├─ AND constraints: 121,893 used (93.0% of 2^17)
-│  [▓▓▓▓▓▓▓▓▓░] spare: 9,179
+├─ ZERO constraints: 21,926 used (66.9% of 2^15)
+│  [▓▓▓▓▓▓░░░░] spare: 10,842
+├─ AND constraints: 112,695 used (86.0% of 2^17)
+│  [▓▓▓▓▓▓▓▓░░] spare: 18,377
 ├─ IMUL constraints: 20,548 used (62.7% of 2^15)
 │  [▓▓▓▓▓▓░░░░] spare: 12,220
 ├─ BMUL constraints: 23,632 used (72.1% of 2^15)
 │  [▓▓▓▓▓▓▓░░░] spare: 9,136
-└─ Distinct value indices: 364,791
-   ├─ Distinct shifted value indices: 176,457
+└─ Distinct value indices: 374,994
+   ├─ Distinct shifted value indices: 186,660
    └─ Distinct unshifted value indices: 188,334
 
 Value Vector

--- a/crates/examples/snapshots/ethsign.snap
+++ b/crates/examples/snapshots/ethsign.snap
@@ -5,10 +5,10 @@ Gates & Instructions
 └─ Number of evaluation instructions: 250,294
 
 Constraints
-├─ ZERO constraints: 2,173 used (53.1% of 2^12)
-│  [▓▓▓▓▓░░░░░] spare: 1,923
-├─ AND constraints: 133,816 used (51.0% of 2^18)
-│  [▓▓▓▓▓░░░░░] spare: 128,328
+├─ ZERO constraints: 12,714 used (77.6% of 2^14)
+│  [▓▓▓▓▓▓▓░░░] spare: 3,670
+├─ AND constraints: 123,275 used (94.1% of 2^17)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 7,797
 ├─ IMUL constraints: 20,554 used (62.7% of 2^15)
 │  [▓▓▓▓▓▓░░░░] spare: 12,214
 ├─ BMUL constraints: 23,874 used (72.9% of 2^15)

--- a/crates/examples/snapshots/ethsign.snap
+++ b/crates/examples/snapshots/ethsign.snap
@@ -5,16 +5,16 @@ Gates & Instructions
 └─ Number of evaluation instructions: 250,294
 
 Constraints
-├─ ZERO constraints: 12,714 used (77.6% of 2^14)
-│  [▓▓▓▓▓▓▓░░░] spare: 3,670
-├─ AND constraints: 123,275 used (94.1% of 2^17)
-│  [▓▓▓▓▓▓▓▓▓░] spare: 7,797
+├─ ZERO constraints: 21,921 used (66.9% of 2^15)
+│  [▓▓▓▓▓▓░░░░] spare: 10,847
+├─ AND constraints: 114,068 used (87.0% of 2^17)
+│  [▓▓▓▓▓▓▓▓░░] spare: 17,004
 ├─ IMUL constraints: 20,554 used (62.7% of 2^15)
 │  [▓▓▓▓▓▓░░░░] spare: 12,214
 ├─ BMUL constraints: 23,874 used (72.9% of 2^15)
 │  [▓▓▓▓▓▓▓░░░] spare: 8,894
-└─ Distinct value indices: 379,028
-   ├─ Distinct shifted value indices: 189,008
+└─ Distinct value indices: 389,239
+   ├─ Distinct shifted value indices: 199,219
    └─ Distinct unshifted value indices: 190,020
 
 Value Vector

--- a/crates/examples/snapshots/hashsign.snap
+++ b/crates/examples/snapshots/hashsign.snap
@@ -5,10 +5,10 @@ Gates & Instructions
 └─ Number of evaluation instructions: 413,730
 
 Constraints
-├─ ZERO constraints: 110,514 used (84.3% of 2^17)
-│  [▓▓▓▓▓▓▓▓░░] spare: 20,558
-├─ AND constraints: 142,844 used (54.5% of 2^18)
-│  [▓▓▓▓▓░░░░░] spare: 119,300
+├─ ZERO constraints: 116,975 used (89.2% of 2^17)
+│  [▓▓▓▓▓▓▓▓░░] spare: 14,097
+├─ AND constraints: 136,383 used (52.0% of 2^18)
+│  [▓▓▓▓▓░░░░░] spare: 125,761
 ├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
 ├─ BMUL constraints: 2,664 used (65.0% of 2^12)

--- a/crates/examples/snapshots/keccak.snap
+++ b/crates/examples/snapshots/keccak.snap
@@ -5,10 +5,10 @@ Gates & Instructions
 └─ Number of evaluation instructions: 22,189
 
 Constraints
-├─ ZERO constraints: 0 used (0.0% of 0)
-│  [░░░░░░░░░░] spare: 0
-├─ AND constraints: 4,783 used (58.4% of 2^13)
-│  [▓▓▓▓▓░░░░░] spare: 3,409
+├─ ZERO constraints: 4 used (100.0% of 2^2)
+│  [▓▓▓▓▓▓▓▓▓▓] spare: 0
+├─ AND constraints: 4,779 used (58.3% of 2^13)
+│  [▓▓▓▓▓░░░░░] spare: 3,413
 ├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
 ├─ BMUL constraints: 0 used (0.0% of 0)

--- a/crates/examples/snapshots/sha256.snap
+++ b/crates/examples/snapshots/sha256.snap
@@ -5,17 +5,17 @@ Gates & Instructions
 └─ Number of evaluation instructions: 20,312
 
 Constraints
-├─ ZERO constraints: 2,005 used (97.9% of 2^11)
-│  [▓▓▓▓▓▓▓▓▓░] spare: 43
-├─ AND constraints: 6,575 used (80.3% of 2^13)
-│  [▓▓▓▓▓▓▓▓░░] spare: 1,617
+├─ ZERO constraints: 2,077 used (50.7% of 2^12)
+│  [▓▓▓▓▓░░░░░] spare: 2,019
+├─ AND constraints: 6,503 used (79.4% of 2^13)
+│  [▓▓▓▓▓▓▓░░░] spare: 1,689
 ├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
 ├─ BMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-└─ Distinct value indices: 21,061
+└─ Distinct value indices: 21,060
    ├─ Distinct shifted value indices: 12,350
-   └─ Distinct unshifted value indices: 8,711
+   └─ Distinct unshifted value indices: 8,710
 
 Value Vector
 ├─ Public Section: 404 (not committed)

--- a/crates/examples/snapshots/sha512.snap
+++ b/crates/examples/snapshots/sha512.snap
@@ -5,17 +5,17 @@ Gates & Instructions
 └─ Number of evaluation instructions: 24,839
 
 Constraints
-├─ ZERO constraints: 2,007 used (98.0% of 2^11)
-│  [▓▓▓▓▓▓▓▓▓░] spare: 41
-├─ AND constraints: 8,270 used (50.5% of 2^14)
-│  [▓▓▓▓▓░░░░░] spare: 8,114
+├─ ZERO constraints: 2,015 used (98.4% of 2^11)
+│  [▓▓▓▓▓▓▓▓▓░] spare: 33
+├─ AND constraints: 8,262 used (50.4% of 2^14)
+│  [▓▓▓▓▓░░░░░] spare: 8,122
 ├─ IMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
 ├─ BMUL constraints: 0 used (0.0% of 0)
 │  [░░░░░░░░░░] spare: 0
-└─ Distinct value indices: 25,055
+└─ Distinct value indices: 25,054
    ├─ Distinct shifted value indices: 14,555
-   └─ Distinct unshifted value indices: 10,500
+   └─ Distinct unshifted value indices: 10,499
 
 Value Vector
 ├─ Public Section: 237 (not committed)

--- a/crates/examples/snapshots/zklogin.snap
+++ b/crates/examples/snapshots/zklogin.snap
@@ -5,16 +5,16 @@ Gates & Instructions
 └─ Number of evaluation instructions: 459,115
 
 Constraints
-├─ ZERO constraints: 38,296 used (58.4% of 2^16)
-│  [▓▓▓▓▓░░░░░] spare: 27,240
-├─ AND constraints: 187,974 used (71.7% of 2^18)
-│  [▓▓▓▓▓▓▓░░░] spare: 74,170
+├─ ZERO constraints: 38,358 used (58.5% of 2^16)
+│  [▓▓▓▓▓░░░░░] spare: 27,178
+├─ AND constraints: 187,912 used (71.7% of 2^18)
+│  [▓▓▓▓▓▓▓░░░] spare: 74,232
 ├─ IMUL constraints: 8,262 used (50.4% of 2^14)
 │  [▓▓▓▓▓░░░░░] spare: 8,122
 ├─ BMUL constraints: 31,716 used (96.8% of 2^15)
 │  [▓▓▓▓▓▓▓▓▓░] spare: 1,052
-└─ Distinct value indices: 546,028
-   ├─ Distinct shifted value indices: 285,423
+└─ Distinct value indices: 546,132
+   ├─ Distinct shifted value indices: 285,527
    └─ Distinct unshifted value indices: 260,605
 
 Value Vector

--- a/crates/examples/snapshots/zklogin.snap
+++ b/crates/examples/snapshots/zklogin.snap
@@ -5,10 +5,10 @@ Gates & Instructions
 └─ Number of evaluation instructions: 459,115
 
 Constraints
-├─ ZERO constraints: 22,862 used (69.8% of 2^15)
-│  [▓▓▓▓▓▓░░░░] spare: 9,906
-├─ AND constraints: 203,408 used (77.6% of 2^18)
-│  [▓▓▓▓▓▓▓░░░] spare: 58,736
+├─ ZERO constraints: 38,296 used (58.4% of 2^16)
+│  [▓▓▓▓▓░░░░░] spare: 27,240
+├─ AND constraints: 187,974 used (71.7% of 2^18)
+│  [▓▓▓▓▓▓▓░░░] spare: 74,170
 ├─ IMUL constraints: 8,262 used (50.4% of 2^14)
 │  [▓▓▓▓▓░░░░░] spare: 8,122
 ├─ BMUL constraints: 31,716 used (96.8% of 2^15)

--- a/crates/frontend/src/compiler/constraint_builder/constraint.rs
+++ b/crates/frontend/src/compiler/constraint_builder/constraint.rs
@@ -114,6 +114,28 @@ impl WireBmulConstraint {
 	}
 }
 
+/// Zero constraint `VAL == 0`, over a wire operand.
+///
+/// This is an assertion, so it defines no wire. Gate fusion inlines definitions into it the way it
+/// inlines them into an AND operand, but never reads it as a definition of anything.
+pub struct WireZeroConstraint {
+	/// XOR of shifted values that must vanish.
+	pub val: WireOperand,
+}
+
+impl WireZeroConstraint {
+	pub(super) fn into_constraint(
+		self,
+		wire_mapping: &SecondaryMap<Wire, ValueIndex>,
+	) -> ZeroConstraint {
+		ZeroConstraint([self.val.into_value_indices(wire_mapping)])
+	}
+
+	pub(super) fn mark_used(&self, used_set: &mut EntitySet<Wire>) {
+		self.val.mark_used(used_set);
+	}
+}
+
 /// Linear constraint `RHS == DST`, over a wire operand and a destination wire.
 pub struct WireLinearConstraint {
 	/// XOR of shifted values that must equal `dst`.

--- a/crates/frontend/src/compiler/constraint_builder/mod.rs
+++ b/crates/frontend/src/compiler/constraint_builder/mod.rs
@@ -12,6 +12,7 @@ use binius_core::constraint_system::{
 };
 pub use constraint::{
 	WireAndConstraint, WireBmulConstraint, WireImulConstraint, WireLinearConstraint,
+	WireZeroConstraint,
 };
 use cranelift_entity::{EntitySet, SecondaryMap};
 use expr::WireExpr;
@@ -22,7 +23,7 @@ use crate::compiler::Wire;
 
 /// Accumulates the constraints a circuit emits, expressed over [`Wire`]s.
 ///
-/// Gates push into the four typed buckets, one method per constraint shape.
+/// Gates push into the five typed buckets, one method per constraint shape.
 ///
 /// Every operand is a parameter of that method:
 ///
@@ -40,6 +41,8 @@ pub struct ConstraintBuilder {
 	pub bmul_constraints: Vec<WireBmulConstraint>,
 	/// Linear constraints `RHS == DST`, lowered by [`build`](Self::build) to Zero constraints.
 	pub linear_constraints: Vec<WireLinearConstraint>,
+	/// Zero constraints `VAL == 0`, which assert rather than define.
+	pub zero_constraints: Vec<WireZeroConstraint>,
 }
 
 impl ConstraintBuilder {
@@ -50,6 +53,7 @@ impl ConstraintBuilder {
 			imul_constraints: Vec::new(),
 			bmul_constraints: Vec::new(),
 			linear_constraints: Vec::new(),
+			zero_constraints: Vec::new(),
 		}
 	}
 
@@ -108,6 +112,16 @@ impl ConstraintBuilder {
 		});
 	}
 
+	/// Appends the assertion `val == 0`.
+	///
+	/// Unlike [`linear`](Self::linear) this defines no wire, so it is the right shape for an
+	/// assertion gate: the equation it states is enforced without naming a value it produces.
+	pub fn zero(&mut self, val: impl Into<WireExpr>) {
+		self.zero_constraints.push(WireZeroConstraint {
+			val: val.into().into_operand(),
+		});
+	}
+
 	/// Lowers every wire-level constraint to its core `ValueIndex` form.
 	///
 	/// A linear constraint lowers to the Zero constraint `RHS ^ DST == 0`, which carries one
@@ -138,6 +152,11 @@ impl ConstraintBuilder {
 			.linear_constraints
 			.into_iter()
 			.map(|c| c.into_zero_constraint(wire_mapping))
+			.chain(
+				self.zero_constraints
+					.into_iter()
+					.map(|c| c.into_constraint(wire_mapping)),
+			)
 			.collect();
 
 		(zero_constraints, and_constraints, imul_constraints, bmul_constraints)
@@ -159,6 +178,9 @@ impl ConstraintBuilder {
 		}
 		for lc in &self.linear_constraints {
 			lc.mark_used(&mut used_set);
+		}
+		for zc in &self.zero_constraints {
+			zc.mark_used(&mut used_set);
 		}
 		used_set
 	}

--- a/crates/frontend/src/compiler/gate/assert_eq.rs
+++ b/crates/frontend/src/compiler/gate/assert_eq.rs
@@ -1,18 +1,17 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 //! Equality assertion.
 //!
-//! Enforces `x = y` using an AND constraint.
+//! Enforces `x = y` using a ZERO constraint.
 //!
 //! # Algorithm
 //!
 //! Uses the property that `x = y` iff `x ^ y = 0`.
-//! This is enforced as `(x ⊕ y) ∧ all-1 = 0`.
 //!
 //! # Constraints
 //!
-//! The gate generates 1 AND constraint:
-//! - `(x ⊕ y) ∧ all-1 = 0`
-use binius_core::word::Word;
+//! The gate generates 1 ZERO constraint:
+//! - `x ⊕ y = 0`
 
 use crate::compiler::{
 	constraint_builder::{ConstraintBuilder, expr},
@@ -24,7 +23,7 @@ use crate::compiler::{
 
 pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
-		const_in: &[Word::ALL_ONE],
+		const_in: &[],
 		n_in: 2,
 		n_out: 0,
 		n_aux: 0,
@@ -34,14 +33,11 @@ pub const fn shape() -> OpcodeShape {
 }
 
 pub fn constrain(data: &GateData, builder: &mut ConstraintBuilder) {
-	let GateParam {
-		constants, inputs, ..
-	} = data.gate_param();
-	let [all_one] = constants else { unreachable!() };
+	let GateParam { inputs, .. } = data.gate_param();
 	let [x, y] = inputs else { unreachable!() };
 
-	// Constraint: (x ⊕ y) ∧ all-1 = 0
-	builder.and(expr::xor2(*x, *y), *all_one, expr::empty());
+	// Constraint: x ⊕ y = 0
+	builder.zero(expr::xor2(*x, *y));
 }
 
 pub fn emit_eval_bytecode(

--- a/crates/frontend/src/compiler/gate/assert_false.rs
+++ b/crates/frontend/src/compiler/gate/assert_false.rs
@@ -1,19 +1,19 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 //! Assert that a wire, interpreted as a MSB-bool, is false.
 //! i.e., we are checking whether its most-significant bit is 0. all lower bits get ignored.
 //!
-//! Enforces `x & 0x8000000000000000 = 0` using an AND constraint.
+//! Enforces `MSB(x) = 0` using a ZERO constraint.
 //!
 //! # Algorithm
 //!
-//! Uses the constraint `x ∧ 0x8000000000000000 = 0`.
+//! `sar(x, 63)` broadcasts the most-significant bit across the whole word, so it vanishes exactly
+//! when the bit is clear.
 //!
 //! # Constraints
 //!
-//! The gate generates 1 AND constraint:
-//! - `x ∧ 0x8000000000000000 = 0`
-
-use binius_core::word::Word;
+//! The gate generates 1 ZERO constraint:
+//! - `sar(x, 63) = 0`
 
 use crate::compiler::{
 	constraint_builder::{ConstraintBuilder, expr},
@@ -25,7 +25,7 @@ use crate::compiler::{
 
 pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
-		const_in: &[Word::MSB_ONE],
+		const_in: &[],
 		n_in: 1,
 		n_out: 0,
 		n_aux: 0,
@@ -35,14 +35,11 @@ pub const fn shape() -> OpcodeShape {
 }
 
 pub fn constrain(data: &GateData, builder: &mut ConstraintBuilder) {
-	let GateParam {
-		constants, inputs, ..
-	} = data.gate_param();
-	let [msb_one] = constants else { unreachable!() };
+	let GateParam { inputs, .. } = data.gate_param();
 	let [x] = inputs else { unreachable!() };
 
-	// Constraint: x ∧ msb_one = msb_one
-	builder.and(*x, *msb_one, expr::empty());
+	// Constraint: sar(x, 63) = 0
+	builder.zero(expr::sar(*x, 63));
 }
 
 pub fn emit_eval_bytecode(

--- a/crates/frontend/src/compiler/gate/assert_non_zero.rs
+++ b/crates/frontend/src/compiler/gate/assert_non_zero.rs
@@ -1,4 +1,5 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 //! Assert that a wire isn't zero.
 //!
 //! Enforces `x ≠ 0`.
@@ -24,7 +25,7 @@
 //!
 //! The gate generates 2 constraints:
 //! - AND: `(x ⊕ cin) ∧ (all-1 ⊕ cin) = cin ⊕ cout`
-//! - AND: `sar(cout, 63) ∧ all-1 = all-1` (forces `MSB(cout) = 1`, i.e. `x ≠ 0`)
+//! - ZERO: `sar(cout, 63) ⊕ all-1 = 0` (forces `MSB(cout) = 1`, i.e. `x ≠ 0`)
 
 use binius_core::word::Word;
 
@@ -65,12 +66,11 @@ pub fn constrain(data: &GateData, builder: &mut ConstraintBuilder) {
 	// (x ⊕ cin) ∧ (all-1 ⊕ cin) = cin ⊕ cout
 	builder.and(expr::xor2(*x, cin), expr::xor2(*all_one, cin), expr::xor2(cin, *cout));
 
-	// Constraint 2 (AND): sar(cout, 63) ∧ all_one = all_one, i.e. MSB(cout) = 1 (x ≠ 0).
+	// Constraint 2 (ZERO): sar(cout, 63) ⊕ all_one = 0, i.e. MSB(cout) = 1 (x ≠ 0).
 	// sar(cout, 63) sign-extends the MSB across all 64 bits, so it equals all_one iff
-	// MSB(cout) = 1; the AND with all_one then equals all_one iff MSB(cout) = 1. This is
-	// emitted as an AND (which defines no wire) so gate fusion cannot inline it and
-	// substitute the constant back into Constraint 1, reopening the soundness hole.
-	builder.and(expr::sar(*cout, 63), *all_one, *all_one);
+	// MSB(cout) = 1. This is an assertion, which defines no wire, so gate fusion cannot inline it
+	// and substitute the constant back into Constraint 1, reopening the soundness hole.
+	builder.zero(expr::xor2(expr::sar(*cout, 63), *all_one));
 }
 
 pub fn emit_eval_bytecode(

--- a/crates/frontend/src/compiler/gate/assert_true.rs
+++ b/crates/frontend/src/compiler/gate/assert_true.rs
@@ -1,22 +1,24 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 //! Assert that a wire, interpreted as a MSB-bool, is true.
 //! i.e., we are checking whether its most-significant bit is 1. all lower bits get ignored.
 //!
-//! Enforces `x & 0x8000000000000000 = 0x8000000000000000` using an AND constraint.
+//! Enforces `MSB(x) = 1` using a ZERO constraint.
 //!
 //! # Algorithm
 //!
-//! Uses the constraint `x ∧ 0x8000000000000000 = 0x8000000000000000`.
+//! `sar(x, 63)` broadcasts the most-significant bit across the whole word, so it is all-1 when the
+//! bit is set and 0 when it is clear. Equating it with all-1 therefore says the bit is set.
 //!
 //! # Constraints
 //!
-//! The gate generates 1 AND constraint:
-//! - `x ∧ 0x8000000000000000 = 0x8000000000000000`
+//! The gate generates 1 ZERO constraint:
+//! - `sar(x, 63) ⊕ all-1 = 0`
 
 use binius_core::word::Word;
 
 use crate::compiler::{
-	constraint_builder::ConstraintBuilder,
+	constraint_builder::{ConstraintBuilder, expr},
 	eval_form::BytecodeBuilder,
 	gate::opcode::OpcodeShape,
 	gate_graph::{GateData, GateParam, Wire},
@@ -25,7 +27,7 @@ use crate::compiler::{
 
 pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
-		const_in: &[Word::MSB_ONE],
+		const_in: &[Word::ALL_ONE],
 		n_in: 1,
 		n_out: 0,
 		n_aux: 0,
@@ -38,11 +40,11 @@ pub fn constrain(data: &GateData, builder: &mut ConstraintBuilder) {
 	let GateParam {
 		constants, inputs, ..
 	} = data.gate_param();
-	let [msb_one] = constants else { unreachable!() };
+	let [all_one] = constants else { unreachable!() };
 	let [x] = inputs else { unreachable!() };
 
-	// Constraint: x ∧ msb_one = msb_one
-	builder.and(*x, *msb_one, *msb_one);
+	// Constraint: sar(x, 63) ⊕ all-1 = 0
+	builder.zero(expr::xor2(expr::sar(*x, 63), *all_one));
 }
 
 pub fn emit_eval_bytecode(

--- a/crates/frontend/src/compiler/gate/assert_zero.rs
+++ b/crates/frontend/src/compiler/gate/assert_zero.rs
@@ -1,21 +1,16 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 //! Assert that a wire equals zero.
 //!
-//! Enforces `x = 0` using an AND constraint.
-//!
-//! # Algorithm
-//!
-//! Uses the constraint `x ∧ all-1 = 0`, which forces `x = 0`.
+//! Enforces `x = 0` using a ZERO constraint.
 //!
 //! # Constraints
 //!
-//! The gate generates 1 AND constraint:
-//! - `x ∧ all-1 = 0`
-
-use binius_core::word::Word;
+//! The gate generates 1 ZERO constraint:
+//! - `x = 0`
 
 use crate::compiler::{
-	constraint_builder::{ConstraintBuilder, expr},
+	constraint_builder::ConstraintBuilder,
 	eval_form::BytecodeBuilder,
 	gate::opcode::OpcodeShape,
 	gate_graph::{GateData, GateParam, Wire},
@@ -24,7 +19,7 @@ use crate::compiler::{
 
 pub const fn shape() -> OpcodeShape {
 	OpcodeShape {
-		const_in: &[Word::ALL_ONE],
+		const_in: &[],
 		n_in: 1,
 		n_out: 0,
 		n_aux: 0,
@@ -34,14 +29,11 @@ pub const fn shape() -> OpcodeShape {
 }
 
 pub fn constrain(data: &GateData, builder: &mut ConstraintBuilder) {
-	let GateParam {
-		constants, inputs, ..
-	} = data.gate_param();
-	let [all_one] = constants else { unreachable!() };
+	let GateParam { inputs, .. } = data.gate_param();
 	let [x] = inputs else { unreachable!() };
 
-	// Constraint: x ∧ all-1 = 0
-	builder.and(*x, *all_one, expr::empty());
+	// Constraint: x = 0
+	builder.zero(*x);
 }
 
 pub fn emit_eval_bytecode(

--- a/crates/frontend/src/compiler/gate_fusion/legraph.rs
+++ b/crates/frontend/src/compiler/gate_fusion/legraph.rs
@@ -1,4 +1,5 @@
 // Copyright 2025 Irreducible Inc.
+// Copyright 2026 The Binius Developers
 //! linear expression graph.
 
 use binius_core::constraint_system::Shift;
@@ -15,16 +16,17 @@ pub enum ConstraintRef {
 	And { index: usize },
 	Imul { index: usize },
 	Bmul { index: usize },
+	Zero { index: usize },
 	Linear { index: usize },
 }
 
 /// Represents the different types of nodes in the Linear Expression Graph.
 #[derive(Debug)]
 pub enum NodeData {
-	/// Root node - represents a use site in a non-linear constraint.
+	/// Root node - represents a use site in a constraint that defines no wire.
 	///
 	/// These nodes are the "sinks" of the graph where linear expressions flow into
-	/// non-linear constraints (AND/IMUL). They have no outgoing edges and represent
+	/// AND/IMUL/BMUL/ZERO constraints. They have no outgoing edges and represent
 	/// the termination points for inlining decisions.
 	///
 	/// # Example
@@ -289,8 +291,8 @@ impl LeGraph {
 		}
 	}
 
-	/// Notes a use of a wire of a linear producer by a non-linear user.
-	fn note_nonlinear_use(&mut self, producer: Wire, shift: Shift, constraint: ConstraintRef) {
+	/// Notes a use of a wire of a linear producer by a user that defines no wire.
+	fn note_root_use(&mut self, producer: Wire, shift: Shift, constraint: ConstraintRef) {
 		let node_p = self.node_of(producer);
 		let root_node = self.pg.add_node(NodeData::Root { constraint });
 		self.roots.push(root_node);
@@ -315,32 +317,36 @@ fn build_use_def(cb: &ConstraintBuilder, leg: &mut LeGraph) {
 	}
 
 	for (index, and) in cb.and_constraints.iter().enumerate() {
-		harvest_nonlin_uses(&and.a, leg, ConstraintRef::And { index });
-		harvest_nonlin_uses(&and.b, leg, ConstraintRef::And { index });
-		harvest_nonlin_uses(&and.c, leg, ConstraintRef::And { index });
+		harvest_root_uses(&and.a, leg, ConstraintRef::And { index });
+		harvest_root_uses(&and.b, leg, ConstraintRef::And { index });
+		harvest_root_uses(&and.c, leg, ConstraintRef::And { index });
 	}
 
 	for (index, mul) in cb.imul_constraints.iter().enumerate() {
-		harvest_nonlin_uses(&mul.a, leg, ConstraintRef::Imul { index });
-		harvest_nonlin_uses(&mul.b, leg, ConstraintRef::Imul { index });
-		harvest_nonlin_uses(&mul.hi, leg, ConstraintRef::Imul { index });
-		harvest_nonlin_uses(&mul.lo, leg, ConstraintRef::Imul { index });
+		harvest_root_uses(&mul.a, leg, ConstraintRef::Imul { index });
+		harvest_root_uses(&mul.b, leg, ConstraintRef::Imul { index });
+		harvest_root_uses(&mul.hi, leg, ConstraintRef::Imul { index });
+		harvest_root_uses(&mul.lo, leg, ConstraintRef::Imul { index });
 	}
 
 	for (index, mul) in cb.bmul_constraints.iter().enumerate() {
-		harvest_nonlin_uses(&mul.a_lo, leg, ConstraintRef::Bmul { index });
-		harvest_nonlin_uses(&mul.a_hi, leg, ConstraintRef::Bmul { index });
-		harvest_nonlin_uses(&mul.b_lo, leg, ConstraintRef::Bmul { index });
-		harvest_nonlin_uses(&mul.b_hi, leg, ConstraintRef::Bmul { index });
-		harvest_nonlin_uses(&mul.c_lo, leg, ConstraintRef::Bmul { index });
-		harvest_nonlin_uses(&mul.c_hi, leg, ConstraintRef::Bmul { index });
+		harvest_root_uses(&mul.a_lo, leg, ConstraintRef::Bmul { index });
+		harvest_root_uses(&mul.a_hi, leg, ConstraintRef::Bmul { index });
+		harvest_root_uses(&mul.b_lo, leg, ConstraintRef::Bmul { index });
+		harvest_root_uses(&mul.b_hi, leg, ConstraintRef::Bmul { index });
+		harvest_root_uses(&mul.c_lo, leg, ConstraintRef::Bmul { index });
+		harvest_root_uses(&mul.c_hi, leg, ConstraintRef::Bmul { index });
+	}
+
+	for (index, zero) in cb.zero_constraints.iter().enumerate() {
+		harvest_root_uses(&zero.val, leg, ConstraintRef::Zero { index });
 	}
 }
 
-fn harvest_nonlin_uses(operand: &WireOperand, leg: &mut LeGraph, constraint: ConstraintRef) {
+fn harvest_root_uses(operand: &WireOperand, leg: &mut LeGraph, constraint: ConstraintRef) {
 	for term in operand {
 		if leg.is_lin_def(term.wire) {
-			leg.note_nonlinear_use(term.wire, term.shift, constraint);
+			leg.note_root_use(term.wire, term.shift, constraint);
 		}
 	}
 }

--- a/crates/frontend/src/compiler/gate_fusion/patch.rs
+++ b/crates/frontend/src/compiler/gate_fusion/patch.rs
@@ -8,7 +8,7 @@ use crate::compiler::{
 	Wire,
 	constraint_builder::{
 		ConstraintBuilder, ShiftedWire, WireAndConstraint, WireBmulConstraint, WireImulConstraint,
-		WireLinearConstraint, WireOperand,
+		WireLinearConstraint, WireOperand, WireZeroConstraint,
 	},
 	gate_fusion::legraph::ConstraintRef,
 };
@@ -30,6 +30,7 @@ enum AddedConstraint {
 	And(WireAndConstraint),
 	Imul(WireImulConstraint),
 	Bmul(WireBmulConstraint),
+	Zero(WireZeroConstraint),
 	/// A committed linear definition, kept linear so that
 	/// [`ConstraintBuilder::build`](crate::compiler::constraint_builder::ConstraintBuilder::build)
 	/// picks its lowering.
@@ -43,11 +44,13 @@ pub fn apply_patches(cb: &mut ConstraintBuilder, patches: Vec<Patch>) {
 	let mut subsumed_and = vec![false; cb.and_constraints.len()];
 	let mut subsumed_imul = vec![false; cb.imul_constraints.len()];
 	let mut subsumed_bmul = vec![false; cb.bmul_constraints.len()];
+	let mut subsumed_zero = vec![false; cb.zero_constraints.len()];
 	let mut subsumed_linear = vec![false; cb.linear_constraints.len()];
 
 	let mut new_and_constraints = Vec::new();
 	let mut new_imul_constraints = Vec::new();
 	let mut new_bmul_constraints = Vec::new();
+	let mut new_zero_constraints = Vec::new();
 	let mut new_linear_constraints = Vec::new();
 
 	// Collect all subsumed constraints and new constraints to add.
@@ -58,6 +61,7 @@ pub fn apply_patches(cb: &mut ConstraintBuilder, patches: Vec<Patch>) {
 				ConstraintRef::And { index } => subsumed_and[index] = true,
 				ConstraintRef::Imul { index } => subsumed_imul[index] = true,
 				ConstraintRef::Bmul { index } => subsumed_bmul[index] = true,
+				ConstraintRef::Zero { index } => subsumed_zero[index] = true,
 				ConstraintRef::Linear { index } => subsumed_linear[index] = true,
 			}
 		}
@@ -65,6 +69,7 @@ pub fn apply_patches(cb: &mut ConstraintBuilder, patches: Vec<Patch>) {
 			AddedConstraint::And(and_constraint) => new_and_constraints.push(and_constraint),
 			AddedConstraint::Imul(imul_constraint) => new_imul_constraints.push(imul_constraint),
 			AddedConstraint::Bmul(bmul_constraint) => new_bmul_constraints.push(bmul_constraint),
+			AddedConstraint::Zero(zero_constraint) => new_zero_constraints.push(zero_constraint),
 			AddedConstraint::Linear(linear_constraint) => {
 				new_linear_constraints.push(linear_constraint)
 			}
@@ -75,12 +80,14 @@ pub fn apply_patches(cb: &mut ConstraintBuilder, patches: Vec<Patch>) {
 	retain_unsubsumed(&mut cb.and_constraints, &subsumed_and);
 	retain_unsubsumed(&mut cb.imul_constraints, &subsumed_imul);
 	retain_unsubsumed(&mut cb.bmul_constraints, &subsumed_bmul);
+	retain_unsubsumed(&mut cb.zero_constraints, &subsumed_zero);
 	retain_unsubsumed(&mut cb.linear_constraints, &subsumed_linear);
 
 	// Add the new constraints
 	cb.and_constraints.extend(new_and_constraints);
 	cb.imul_constraints.extend(new_imul_constraints);
 	cb.bmul_constraints.extend(new_bmul_constraints);
+	cb.zero_constraints.extend(new_zero_constraints);
 	cb.linear_constraints.extend(new_linear_constraints);
 }
 
@@ -100,7 +107,7 @@ fn retain_unsubsumed<T>(constraints: &mut Vec<T>, subsumed: &[bool]) {
 /// NB: patches may have overlapping subsumes.
 pub fn build(cb: &ConstraintBuilder, leg: &LeGraph) -> Vec<Patch> {
 	let mut patches = vec![];
-	build_non_linear_patches(cb, leg, &mut patches);
+	build_root_patches(cb, leg, &mut patches);
 	for committed in leg.commit_set().iter() {
 		let patch = build_committed_lin_def_patch(cb, leg, committed);
 		patches.push(patch);
@@ -108,8 +115,8 @@ pub fn build(cb: &ConstraintBuilder, leg: &LeGraph) -> Vec<Patch> {
 	patches
 }
 
-/// Collect patches for the non-linear constraints that inline linear definitions.
-fn build_non_linear_patches(cb: &ConstraintBuilder, leg: &LeGraph, patches: &mut Vec<Patch>) {
+/// Collect patches for the root constraints that inline linear definitions.
+fn build_root_patches(cb: &ConstraintBuilder, leg: &LeGraph, patches: &mut Vec<Patch>) {
 	// Collect *distinct* constraint references for each root constraint.
 	let mut constraints = Vec::with_capacity(leg.roots.len());
 	for root in leg.roots.iter() {
@@ -120,16 +127,12 @@ fn build_non_linear_patches(cb: &ConstraintBuilder, leg: &LeGraph, patches: &mut
 
 	// Create a patch for each distinct constraint.
 	for constraint_ref in constraints {
-		let patch = build_non_lin_patch(cb, leg, constraint_ref);
+		let patch = build_root_patch(cb, leg, constraint_ref);
 		patches.push(patch);
 	}
 }
 
-fn build_non_lin_patch(
-	cb: &ConstraintBuilder,
-	leg: &LeGraph,
-	constraint_ref: ConstraintRef,
-) -> Patch {
+fn build_root_patch(cb: &ConstraintBuilder, leg: &LeGraph, constraint_ref: ConstraintRef) -> Patch {
 	let mut subsumes = vec![constraint_ref];
 
 	let new_constraint = match constraint_ref {
@@ -162,6 +165,10 @@ fn build_non_lin_patch(
 				c_lo,
 				c_hi,
 			})
+		}
+		ConstraintRef::Zero { index } => {
+			let val = process_operand(cb, leg, &mut subsumes, &cb.zero_constraints[index].val);
+			AddedConstraint::Zero(WireZeroConstraint { val })
 		}
 		ConstraintRef::Linear { .. } => unreachable!(),
 	};

--- a/crates/frontend/src/compiler/gate_fusion/tests/awhole.rs
+++ b/crates/frontend/src/compiler/gate_fusion/tests/awhole.rs
@@ -297,7 +297,7 @@ fn test_xor_into_assert() {
 	let cs = compile(&b);
 	insta::assert_snapshot!(
 		stringify_constraint_system(&cs),
-		@"AND[0]: (0xe4 ⊕ v[0]) ∧ (all-1) = (0)",
+		@"ZERO[0]: (0xe4 ⊕ v[0]) = 0",
 	);
 }
 

--- a/crates/frontend/src/compiler/tests.rs
+++ b/crates/frontend/src/compiler/tests.rs
@@ -91,7 +91,7 @@ fn test_algebraic_fold_bxor_self_is_zero_in_witness() {
 /// Builds `assert_eq(x ^ y, z)`.
 ///
 /// Gate fusion is off so that the `bxor` gate keeps its own linear constraint instead of being
-/// inlined into the assertion's operand; the assertion itself emits an AND constraint either way.
+/// inlined into the assertion's operand.
 fn build_xor_circuit() -> (Circuit, Wire, Wire, Wire) {
 	let builder = CircuitBuilder::with_opts(Options {
 		enable_gate_fusion: false,
@@ -109,9 +109,10 @@ fn test_linear_constraints_lower_to_zero_constraints() {
 	let (zero_circuit, x, y, z) = build_xor_circuit();
 	let cs = zero_circuit.constraint_system();
 
-	// The `bxor` linear constraint moves to the ZERO set, leaving only the assertion's AND.
-	assert_eq!(cs.n_zero_constraints(), 1);
-	assert_eq!(cs.n_and_constraints(), 1);
+	// Both the `bxor` linear constraint and the assertion land in the ZERO set, so the AND set is
+	// empty.
+	assert_eq!(cs.n_zero_constraints(), 2);
+	assert_eq!(cs.n_and_constraints(), 0);
 
 	// The Zero constraint XORs the linear constraint's terms with its destination, and names no
 	// all-ones constant.
@@ -149,9 +150,9 @@ fn test_zero_constraints_reach_a_fused_committed_lin_def() {
 	let zero_cs = zero_circuit.constraint_system();
 
 	// The committed shift pair is a ZERO constraint, and it names no all-ones constant — the AND
-	// set holds only the `band` and the assertion.
-	assert_eq!(zero_cs.n_zero_constraints(), 1);
-	assert_eq!(zero_cs.n_and_constraints(), 2);
+	// set holds only the `band`, since the assertion is a ZERO constraint too.
+	assert_eq!(zero_cs.n_zero_constraints(), 2);
+	assert_eq!(zero_cs.n_and_constraints(), 1);
 	assert!(
 		zero_cs.zero_constraints[0]
 			.val()
@@ -991,24 +992,27 @@ fn test_zero_constant_not_in_binius64_operands() {
 // exposed. `a & b` is an AND-gate output, so it occupies a committed word in every one of them.
 #[test]
 fn mark_inout_promotes_without_duplicating() {
-	// The inout count, the private count, and the AND-constraint count of one circuit.
+	// The inout count, the private count, and the constraint count of one circuit. An equality
+	// assertion is a ZERO constraint and the conjunction is an AND constraint, so the count spans
+	// both sets to stay independent of which one each lands in.
 	let shape = |build: &dyn Fn(&CircuitBuilder)| {
 		let builder = CircuitBuilder::new();
 		build(&builder);
 		let circuit = builder.build();
 		let layout = circuit.value_vec_layout();
-		(layout.n_inout, layout.n_private(), circuit.constraint_system().and_constraints.len())
+		let cs = circuit.constraint_system();
+		(layout.n_inout, layout.n_private(), cs.and_constraints.len() + cs.zero_constraints.len())
 	};
 
 	// The result kept alive by pinning: private, and not part of the public interface.
-	let (pinned_inout, pinned_private, pinned_and) = shape(&|builder| {
+	let (pinned_inout, pinned_private, pinned_constraints) = shape(&|builder| {
 		let a = builder.add_inout();
 		let b = builder.add_inout();
 		builder.force_commit(builder.band(a, b));
 	});
 
 	// The result asserted against a separately declared public output.
-	let (asserted_inout, asserted_private, asserted_and) = shape(&|builder| {
+	let (asserted_inout, asserted_private, asserted_constraints) = shape(&|builder| {
 		let a = builder.add_inout();
 		let b = builder.add_inout();
 		let out = builder.add_inout();
@@ -1016,20 +1020,20 @@ fn mark_inout_promotes_without_duplicating() {
 	});
 
 	// The result promoted in place.
-	let (promoted_inout, promoted_private, promoted_and) = shape(&|builder| {
+	let (promoted_inout, promoted_private, promoted_constraints) = shape(&|builder| {
 		let a = builder.add_inout();
 		let b = builder.add_inout();
 		builder.mark_inout(builder.band(a, b));
 	});
 
 	// Asserting duplicates the conjunction: its own committed word, plus the declared output's,
-	// plus the AND constraint tying them together.
+	// plus the constraint tying them together.
 	assert_eq!(asserted_inout + asserted_private, pinned_inout + pinned_private + 1);
-	assert_eq!(asserted_and, pinned_and + 1);
+	assert_eq!(asserted_constraints, pinned_constraints + 1);
 
 	// Promoting costs nothing over pinning — it is the same word, relabelled public.
 	assert_eq!(promoted_inout + promoted_private, pinned_inout + pinned_private);
-	assert_eq!(promoted_and, pinned_and);
+	assert_eq!(promoted_constraints, pinned_constraints);
 	assert_eq!(promoted_inout, pinned_inout + 1);
 	assert_eq!(promoted_private, pinned_private - 1);
 }

--- a/crates/frontend/src/compiler/zero_fold.rs
+++ b/crates/frontend/src/compiler/zero_fold.rs
@@ -163,9 +163,10 @@ mod tests {
 			crate::CircuitStat::collect(&circuit).n_and_constraints
 		};
 
-		// Folded, only the equality assertion remains; unfolded, the carry chain is paid too.
+		// Folded, only the equality assertion remains, and that is a ZERO constraint; unfolded, the
+		// carry chain is paid in AND constraints.
 		assert!(count_and(true) < count_and(false));
-		assert_eq!(count_and(true), 1);
+		assert_eq!(count_and(true), 0);
 	}
 
 	#[test]


### PR DESCRIPTION
Closes [BINIUS-435](https://linear.app/jimpo/issue/BINIUS-435/frontend-constraint-assert-gates-with-a-zero-constraint-instead-of-and).

The frontend's `ConstraintBuilder` could only reach a ZERO constraint through a *linear* constraint, which names a destination wire. An assertion has no destination, so every assert gate paid an AND constraint against the all-ones (or MSB-one) constant instead.

Two commits:

**1. `assert_eq` / `assert_zero` — `ConstraintBuilder::zero`**

Adds a `zero()` method with its own bucket, and teaches gate fusion to treat a ZERO constraint as an inlining *root*: a linear definition feeding an assertion now inlines into it exactly as it inlines into an AND operand (`ConstraintRef::Zero`). Without that, converting the assertions would have stranded their operands' linear definitions and forced them to commit.

**2. `assert_true` / `assert_false` / `assert_non_zero`'s MSB check**

`sar(x, 63)` broadcasts the most-significant bit across the word — all-1 when set, 0 when clear — so the MSB test reads as a ZERO constraint. `assert_false` now names no constant at all; `assert_true` swaps `MSB_ONE` for the all-ones word the gate graph already seeds.

`assert_eq_cond` stays an AND: it is genuinely conditional (`(x ⊕ y) ∧ (cond ~>> 63) = 0`).

### Soundness note

`assert_non_zero`'s second constraint carried a comment explaining it was emitted as an AND *specifically* so gate fusion could not inline it and substitute the constant back into the carry constraint. That property is preserved: a ZERO constraint is an assertion and defines no wire, so fusion never reads it as a definition. `test_assert_non_zero_forge_zero_rejected` still passes.

### Constraint counts

Rebased onto `main` at #2084 (select → BMUL), which lowered AND counts across the board.

| example | AND before → after | padded AND | ZERO before → after |
|---|---|---|---|
| ethsign | 133,816 → 114,068 (−14.8%) | **2^18 → 2^17** | 2,173 → 21,921 |
| ec_msm | 132,481 → 112,695 (−14.9%) | **2^18 → 2^17** | 2,140 → 21,926 |
| bitcoin_p2pkh | 98,901 → 84,233 (−14.8%) | 2^17 → 2^17 | 1,914 → 16,582 |
| zklogin | 203,408 → 187,912 (−7.6%) | 2^18 → 2^18 | 22,862 → 38,358 |
| hashsign | 142,844 → 136,383 (−4.5%) | 2^18 → 2^18 | 110,514 → 116,975 |
| bitcoin_headers | 15,234 → 15,104 (−0.9%) | 2^14 → 2^14 | 4,614 → 4,744 |
| sha256 | 6,575 → 6,503 (−1.1%) | 2^13 → 2^13 | 2,005 → 2,077 |

No example gains a committed word; the Value Vector section of every snapshot is unchanged.

### Performance

`build_operation_columns` sizes the AND operand columns at `n_constraints.next_power_of_two()`, so the BitAnd sumcheck costs the *padded* size. **ethsign and ec_msm now cross a boundary (2^18 → 2^17), halving their AND reduction.** Measured on ethsign (quiet machine, interleaved A/B, 8 pairs, release + `target-cpu=native`):

| span | baseline | branch | delta |
|---|---|---|---|
| Prove (total) | 136.0 ms | 134.0 ms | −1.5% |
| **BitAnd check** | 13.6 ms | 8.2 ms | **−39.9%** |
| Shift Reduction | 17.9 ms | 19.0 ms | +6.1% |

Examples that don't cross a boundary stay a wash on total prove time — the AND-count reduction is headroom there. Full numbers and caveats in the comments below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)