### PR TITLE
BINIUS-453: stop saving Actions caches on merge-queue runs

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -30,9 +30,16 @@ runs:
           HASH=portable
         fi
         echo "key=cpu-${HASH}" >> "$GITHUB_OUTPUT"
+    # Actions scopes every cache entry to the ref that wrote it, and a run may only restore from
+    # its own ref, its base branch, or the default branch. Merge-queue runs execute on
+    # `refs/heads/gh-readonly-queue/main/pr-<N>-<sha>`, which GitHub deletes the moment the run
+    # finishes, so anything they save is unreachable from that point on — it only occupies the
+    # repo's cache quota and evicts entries that pull-request and main runs can still restore.
+    # Merge-queue runs therefore restore as usual but do not write.
     - name: Setup Rust toolchain
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         components: ${{ inputs.components }}
         target: ${{ inputs.target }}
         cache-key: ${{ steps.cpu.outputs.key }}
+        cache-save-if: ${{ github.event_name != 'merge_group' }}


### PR DESCRIPTION
Closes [BINIUS-453](https://linear.app/jimpo/issue/BINIUS-453/ci-stop-saving-actions-caches-on-merge-group-runs).

Actions scopes every cache entry to the ref that wrote it, and a run may restore only from its own ref, its base branch, or the default branch. Merge-queue runs execute on `refs/heads/gh-readonly-queue/main/pr-<N>-<sha>`, a branch GitHub deletes as soon as the run finishes — so every cache they save is unreachable from the moment it lands.

Those entries are not merely wasted writes. The repo sits at its 10 GB quota, so they evict entries that pull-request and main runs could still restore; the whole store currently turns over in about an hour, which is a large part of why cache hits are effectively never observed.

`cache-save-if` is passed through to `setup-rust-toolchain` so merge-queue runs restore as usual but stop writing.

## Verification

- `cache-save-if` is a real input on `actions-rust-lang/setup-rust-toolchain@v1` (default `"true"`), and the action forwards it to `Swatinem/rust-cache`'s `save-if`. Worth confirming rather than assuming — Actions silently ignores an unknown `with:` key, so a typo here would look like it worked and change nothing.
- The `github` context is available inside composite action steps, so `github.event_name` resolves as expected.
- YAML re-parsed after the edit; `typos` clean.

## Blast radius

Six jobs in `ci.yml` use this action, plus `build-docs` in `docs.yml`.

`docs.yml` runs only on push to main, so the condition is always true there and it keeps saving — which is what we want, since main's scope is the one every PR can restore from.

**The merge queue loses nothing.** Its runs already restored nothing: their own ref is created fresh for each run, and nothing writes to main's scope today. So they were paying a full cold compile before this change and still do — they just stop evicting everyone else's caches on the way out.

## Not in scope

The follow-up in the issue — tightening to `github.event_name == 'push'` so only main writes — waits on [BINIUS-454](https://linear.app/jimpo/issue/BINIUS-454), since today nothing populates main's scope for PRs to restore from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)