### PR TITLE
BINIUS-454: warm the rust-checks cache on pushes to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,18 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
   merge_group:
+  # Cache warming only — main is already gated by the merge queue, so nothing here re-checks it.
+  #
+  # Actions restores a cache from the current ref, the base branch, and the default branch, but
+  # neither of the triggers above writes to main's scope: pull requests save to `refs/pull/<N>/merge`
+  # and merge-queue runs save to a `gh-readonly-queue` branch that is deleted immediately. With
+  # nothing on main to fall back to, every run compiles the workspace from scratch. A push run
+  # writes the entry both of them then restore.
+  #
+  # Only `rust-checks` participates, and only far enough to populate its cache; see the `if`
+  # conditions below.
+  push:
+    branches: [main]
 
 env:
   CARGO_TERM_COLOR: always
@@ -20,6 +32,7 @@ concurrency:
 jobs:
   format:
     name: format
+    if: github.event_name != 'push'
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repository
@@ -66,6 +79,15 @@ jobs:
             rustflags: "-Ctarget-cpu=native"
             test_args: "-E 'not package(binius-circuits)'"
     name: rust-checks-${{ matrix.arch.name }}
+    # This job also runs on pushes to main, where it stops after Compile and exists only to write a
+    # cache entry that pull-request and merge-queue runs can restore. The verification steps below
+    # are skipped there, since the merge queue already ran them on the same tree.
+    #
+    # The warming runs live inside this job rather than in a workflow of their own so that the cache
+    # keys match by construction. `Swatinem/rust-cache` derives the key from, among other things, the
+    # literal job id and every `CARGO*`/`RUST*` environment variable, so a separate workflow would
+    # have to restate the job id, the per-leg RUSTFLAGS and the workflow-level CARGO_* settings — and
+    # would silently stop matching the moment one of them is edited here.
     runs-on: ${{ matrix.arch.runner }}
     env:
       # Link with lld instead of the default ld.bfd: the rust-checks build links many test and
@@ -80,6 +102,7 @@ jobs:
         with:
           components: clippy
       - name: Install cargo-nextest
+        if: github.event_name != 'push'
         uses: taiki-e/install-action@v2.85.10
         with:
           tool: cargo-nextest
@@ -92,18 +115,23 @@ jobs:
       - name: Compile
         run: cargo build --workspace --lib --bins --tests --examples
       - name: Run platform diagnostics
+        if: github.event_name != 'push'
         run: cargo test -p binius-utils --features platform-diagnostics test_platform_diagnostics -- --nocapture
       - name: Run clippy
+        if: github.event_name != 'push'
         run: cargo clippy --workspace --all-targets -- -D warnings
       - name: Run tests
+        if: github.event_name != 'push'
         run: cargo nextest run --workspace --no-fail-fast ${{ matrix.arch.test_args }}
       # Must run doctests separately, see https://github.com/nextest-rs/nextest/issues/16
       - name: Run doctests
+        if: github.event_name != 'push'
         run: cargo test --doc --workspace
 
   # Build against wasm32-unknown-unknown target to test that our libraries compile to wasm.
   wasm-vanilla-build:
     name: wasm-vanilla-build
+    if: github.event_name != 'push'
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repository
@@ -117,6 +145,7 @@ jobs:
 
   wasm-tests:
     name: wasm-tests
+    if: github.event_name != 'push'
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repository
@@ -134,6 +163,7 @@ jobs:
 
   rust-doc:
     name: rust-doc
+    if: github.event_name != 'push'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -149,6 +179,7 @@ jobs:
 
   circuits-snapshot:
     name: circuits-snapshot
+    if: github.event_name != 'push'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
Closes [BINIUS-454](https://linear.app/jimpo/issue/BINIUS-454/ci-warm-the-rust-checks-cache-with-a-compile-only-leg-on-pushes-to).

Actions restores a cache from the current ref, the base branch and the default branch, but none of `ci.yml`'s triggers wrote to main's scope. With nothing on main to fall back to, every run rebuilds the dependency graph from scratch.

`ci.yml` now also runs on pushes to main, doing just enough to populate that cache: only `rust-checks` participates, and only through `Compile`. Every other job and every verification step after `Compile` is skipped — the merge queue already ran them against the same tree, so this is not a second gate on main.

**The pull-request and merge-queue paths are byte-for-byte unchanged.** I simulated the job/step selection per event off the parsed YAML:

| event | jobs that run | `rust-checks` steps |
|---|---|---|
| `pull_request` | all 6 | Checkout → Setup Rust → Install cargo-nextest → Install lld → Compile → platform diagnostics → clippy → tests → doctests |
| `merge_group` | all 6 | *(identical to above)* |
| `push` | `rust-checks` only | Checkout → Setup Rust → Install lld → **Compile**, then stop |

## Why the keys match

This only works if the push run writes the key the PR run looks for, so I checked the key construction in `Swatinem/rust-cache` at the pinned `c193711` (v2.9.1) rather than taking it on faith:

```
v0-rust · <cache-key input> · $GITHUB_JOB · os.type() · os.arch() · <env hash> · <lock hash>
```

There is **no ref or event component anywhere in the key**, and `$GITHUB_JOB` is the literal YAML job id (`rust-checks`) — not the display name, not the matrix values. Since the warming path is the same job in the same workflow with the same job-level `RUSTFLAGS`, the keys match by construction. That is the reason to gate steps inside `rust-checks` instead of adding a `cache-warm.yml`, which would have to restate the job id, the per-leg `RUSTFLAGS` and the workflow-level `CARGO_*` settings — and would break silently the first time one of them changed here.

The three matrix legs stay distinct because `x86_64-portable` and `x86_64` differ in `RUSTFLAGS` (which feeds the env hash) and `arm64` differs in `os.arch()` and the CPU key.

## Three caveats on the expected benefit

Flagging these because they temper "every PR gets a cache hit", not because they argue against the change:

1. **It caches dependencies, not the workspace.** `cache-workspace-crates` defaults to `false`, so rust-cache prunes our own crates out of the target dir before saving. The win is "don't rebuild the dependency graph", which is still the bulk of a cold compile — but a PR will still compile all of `binius-*` itself.
2. **Runner SKU still splits the cache.** `setup-rust` namespaces the key by a `/proc/cpuinfo` hash because GitHub mixes Intel and AMD x86_64 runners and `-Ctarget-cpu=native` artifacts are not portable between them. A push that warms on one SKU does nothing for a PR that lands on the other, so hit rate will be partial rather than universal.
3. **Steady state won't refresh the entry often.** When deps and lockfile are unchanged the push run computes a key identical to what it just restored, so rust-cache reports the cache up to date and skips the save. That is correct — and it helps, since a restore counts as an access for LRU eviction.

## Two judgement calls

**Concurrency: left alone, deliberately.** The issue floated allowing `cancel-in-progress` for `push` too. I'd rather not: the group is `${{ github.event_name }}-${{ github.ref }}`, so under a burst of merges each new push would kill the in-flight warm run, and if pushes arrive faster than a cold compile finishes, nothing ever warms — defeating the point. Leaving it `false` bounds the cost anyway, because GitHub keeps at most one *pending* run per group and cancels older pending ones. A superseded warm run is not wasted either: it writes a dependency cache that is almost certainly still valid. Happy to flip it if you disagree.

**Required checks.** Push runs are not gated by branch protection, and the PR / merge-group contexts are unchanged, so required checks should be unaffected. Worth a glance at the branch-protection settings before merging, since I can't read them from here — the failure mode would be a required check name now also appearing (or appearing as skipped) on main commits.

## Verification after merge

`gh cache list` should start showing `refs/heads/main` entries containing `-rust-checks-`, and the next PR's `rust-checks` job should log a restore instead of `No cache found.`

Independent of, and composes with, #2086 (BINIUS-453): that one stops merge-queue runs from *writing*, this one gives them something to *read*. Its `cache-save-if: ${{ github.event_name != 'merge_group' }}` is true for `push`, so warming still saves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)