### PR TITLE
BINIUS-427 (1/2): make the BaseFold channels generic over Channel::Elem

### DIFF
--- a/crates/iop/src/basefold/channel.rs
+++ b/crates/iop/src/basefold/channel.rs
@@ -8,7 +8,7 @@ use binius_ip::{
 	sumcheck::{self, BatchSumcheckOutput},
 };
 use binius_math::{
-	line::extrapolate_line_packed,
+	line::extrapolate_line,
 	multilinear::eq::{eq_ind_partial_eval_scalars, eq_ind_zero},
 	univariate::evaluate_univariate,
 };
@@ -41,7 +41,7 @@ pub struct BaseFoldOracle {
 pub struct BaseFoldVerifierChannel<'a, F, Channel>
 where
 	F: BinaryField,
-	Channel: MerkleIPVerifierChannel<F, Elem = F>,
+	Channel: MerkleIPVerifierChannel<F, Elem: From<F> + 'static>,
 {
 	/// The Merkle channel carrying all prover interaction: field elements, challenges,
 	/// commitments, and openings.
@@ -51,14 +51,14 @@ where
 	oracle_commitments: Vec<Channel::Commitment>,
 	/// Oracle relations queued by [`Self::verify_oracle_relations`], opened together in
 	/// [`Self::finish`].
-	queue: Vec<OracleLinearRelation<BaseFoldOracle, F>>,
+	queue: Vec<OracleLinearRelation<BaseFoldOracle, Channel::Elem>>,
 	next_oracle_index: usize,
 }
 
 impl<'a, F, Channel> BaseFoldVerifierChannel<'a, F, Channel>
 where
 	F: BinaryField,
-	Channel: MerkleIPVerifierChannel<F, Elem = F>,
+	Channel: MerkleIPVerifierChannel<F, Elem: From<F> + 'static>,
 {
 	/// Creates a new BaseFold ZK verifier channel over a Merkle channel from precomputed FRI
 	/// parameters.
@@ -141,11 +141,11 @@ fn verify_batch_zk_basefold<F, Channel>(
 	oracle_specs: &[OracleSpec],
 	fri_params: &FRIParams<F>,
 	oracle_commitments: &[Channel::Commitment],
-	relations: Vec<OracleLinearRelation<BaseFoldOracle, F>>,
+	relations: Vec<OracleLinearRelation<BaseFoldOracle, Channel::Elem>>,
 ) -> Result<(), Error>
 where
 	F: BinaryField,
-	Channel: MerkleIPVerifierChannel<F, Elem = F>,
+	Channel: MerkleIPVerifierChannel<F, Elem: From<F> + 'static>,
 {
 	let n_committed = oracle_commitments.len();
 
@@ -171,13 +171,13 @@ where
 		.map(|relation| {
 			if oracle_specs[relation.oracle.index].is_zk {
 				let sigma = sigma_iter.next().expect("one σ per ZK oracle");
-				extrapolate_line_packed(
-					relation.claim,
+				extrapolate_line(
+					relation.claim.clone(),
 					sigma,
-					gamma.expect("γ sampled when ZK oracles present"),
+					gamma.clone().expect("γ sampled when ZK oracles present"),
 				)
 			} else {
-				relation.claim
+				relation.claim.clone()
 			}
 		})
 		.collect::<Vec<_>>();
@@ -190,7 +190,7 @@ where
 	} = sumcheck::batch_verify::<F, _>(max_n, 2, &sum_primes, channel)?;
 
 	// Receive the evaluation of each oracle at the challenge point.
-	let alphas: Vec<F> = channel.recv_many(n_committed)?;
+	let alphas = channel.recv_many(n_committed)?;
 
 	// `batch_verify` returns binding-order challenges; reverse to variable-indexed (low-to-high).
 	let mut point = sumcheck_challenges;
@@ -200,7 +200,7 @@ where
 	let contributions = relations
 		.into_iter()
 		.map(|relation| {
-			let alpha_i = alphas[relation.oracle.index];
+			let alpha_i = alphas[relation.oracle.index].clone();
 			let n_i = oracle_specs[relation.oracle.index].log_msg_len;
 			let (eval_coords, padding_coords) = point.split_at(n_i);
 			let pad_eq = eq_ind_zero(padding_coords);
@@ -217,7 +217,7 @@ where
 	// is s' = 𝛑(r) = Σ_i e[i]·α_i·∏_{j≥n_i}(1 - r_j).
 	let log_n_oracles = log2_ceil_usize(n_committed);
 	let outer_challenges = channel.sample_many(log_n_oracles);
-	let eq_tensor = eq_ind_partial_eval_scalars::<F>(&outer_challenges);
+	let eq_tensor = eq_ind_partial_eval_scalars(&outer_challenges);
 	// In the combined buffer each oracle is zero-padded over its `log_lift` dims and *repeated*
 	// over the remaining `log_repeat = max_n - n_i - log_lift` high dims, so its evaluation at
 	// `point` picks up the eq-to-zero factor over the lift dims only (the repeat dims contribute
@@ -228,7 +228,7 @@ where
 			let log_lift = fri_oracle.log_lift;
 			eq_i * alpha_i * eq_ind_zero(&point[n_i..][..log_lift])
 		})
-		.sum::<F>();
+		.sum::<Channel::Elem>();
 
 	// The opening routine asserts the final FRI/MLE-check consistency internally.
 	basefold::verify_mlecheck_basefold(
@@ -247,39 +247,39 @@ where
 impl<F, Channel> IPVerifierChannel<F> for BaseFoldVerifierChannel<'_, F, Channel>
 where
 	F: BinaryField,
-	Channel: MerkleIPVerifierChannel<F, Elem = F>,
+	Channel: MerkleIPVerifierChannel<F, Elem: From<F> + 'static>,
 {
-	type Elem = F;
+	type Elem = Channel::Elem;
 
-	fn recv_one(&mut self) -> Result<F, binius_ip::channel::Error> {
+	fn recv_one(&mut self) -> Result<Self::Elem, binius_ip::channel::Error> {
 		self.channel.recv_one()
 	}
 
-	fn recv_many(&mut self, n: usize) -> Result<Vec<F>, binius_ip::channel::Error> {
+	fn recv_many(&mut self, n: usize) -> Result<Vec<Self::Elem>, binius_ip::channel::Error> {
 		self.channel.recv_many(n)
 	}
 
-	fn recv_array<const N: usize>(&mut self) -> Result<[F; N], binius_ip::channel::Error> {
+	fn recv_array<const N: usize>(&mut self) -> Result<[Self::Elem; N], binius_ip::channel::Error> {
 		self.channel.recv_array()
 	}
 
-	fn sample(&mut self) -> F {
+	fn sample(&mut self) -> Self::Elem {
 		self.channel.sample()
 	}
 
-	fn observe_one(&mut self, val: F) -> F {
+	fn observe_one(&mut self, val: F) -> Self::Elem {
 		self.channel.observe_one(val)
 	}
 
-	fn observe_many(&mut self, vals: &[F]) -> Vec<F> {
+	fn observe_many(&mut self, vals: &[F]) -> Vec<Self::Elem> {
 		self.channel.observe_many(vals)
 	}
 
-	fn assert_zero(&mut self, val: F) -> Result<(), binius_ip::channel::Error> {
+	fn assert_zero(&mut self, val: Self::Elem) -> Result<(), binius_ip::channel::Error> {
 		self.channel.assert_zero(val)
 	}
 
-	fn compute_public_value(&mut self, inputs: &[F], f: impl FieldFn<F>) -> F {
+	fn compute_public_value(&mut self, inputs: &[Self::Elem], f: impl FieldFn<F>) -> Self::Elem {
 		self.channel.compute_public_value(inputs, f)
 	}
 }
@@ -287,7 +287,7 @@ where
 impl<'a, F, Channel> IOPVerifierChannel<F> for BaseFoldVerifierChannel<'a, F, Channel>
 where
 	F: BinaryField,
-	Channel: MerkleIPVerifierChannel<F, Elem = F>,
+	Channel: MerkleIPVerifierChannel<F, Elem: From<F> + 'static>,
 {
 	type Oracle = BaseFoldOracle;
 

--- a/crates/iop/src/basefold/compiler.rs
+++ b/crates/iop/src/basefold/compiler.rs
@@ -113,7 +113,7 @@ where
 		channel: Channel,
 	) -> BaseFoldVerifierChannel<'_, F, Channel>
 	where
-		Channel: MerkleIPVerifierChannel<F, Elem = F>,
+		Channel: MerkleIPVerifierChannel<F, Elem: From<F> + 'static>,
 	{
 		BaseFoldVerifierChannel::new(channel, &self.oracle_specs, &self.fri_params)
 	}

--- a/crates/iop/src/basefold/opening.rs
+++ b/crates/iop/src/basefold/opening.rs
@@ -47,15 +47,16 @@ use crate::{
 pub fn verify_mlecheck_basefold<F, Channel>(
 	fri_params: &FRIParams<F>,
 	codeword_commitments: &[Channel::Commitment],
-	eval_claim: F,
-	eval_point: &[F],
-	batch_challenge: Option<F>,
-	outer_challenges: &[F],
+	eval_claim: Channel::Elem,
+	eval_point: &[Channel::Elem],
+	batch_challenge: Option<Channel::Elem>,
+	outer_challenges: &[Channel::Elem],
 	channel: &mut Channel,
 ) -> Result<(), Error>
 where
 	F: BinaryField,
-	Channel: MerkleIPVerifierChannel<F, Elem = F>,
+	Channel: MerkleIPVerifierChannel<F>,
+	Channel::Elem: From<F>,
 {
 	// The MLE-check round polynomial is degree 1 (the composite is the multilinear itself).
 	const DEGREE: usize = 1;
@@ -87,9 +88,9 @@ where
 	// The first fold consumes its challenges as `[γ] ++ r' ++ fresh_X`, so the outer challenges are
 	// processed here (right after γ) to land in the outer window; the leading standard rounds then
 	// supply each non-ZK oracle's later batch fold.
-	for &outer_challenge in outer_challenges {
+	for outer_challenge in outer_challenges {
 		fri_fold_verifier.process_round(channel)?;
-		challenges.push(outer_challenge);
+		challenges.push(outer_challenge.clone());
 	}
 
 	// Standard rounds: the only sumcheck (MLE-check) rounds, folding the combined codeword at the
@@ -100,7 +101,7 @@ where
 		fri_fold_verifier.process_round(channel)?;
 
 		// MLE-check binds variables high-to-low, so round `i` uses coordinate `eval_point[n-1-i]`.
-		let alpha = eval_point[n_vars - 1 - round];
+		let alpha = eval_point[n_vars - 1 - round].clone();
 		let round_coeffs = round_proof.recover(sum, alpha);
 		let challenge = channel.sample();
 		sum = round_coeffs.evaluate(&challenge);

--- a/crates/iop/src/fri/batch.rs
+++ b/crates/iop/src/fri/batch.rs
@@ -2,7 +2,7 @@
 
 use std::iter;
 
-use binius_field::BinaryField;
+use binius_field::{BinaryField, FieldOps};
 use binius_math::{line::extrapolate_line, multilinear, ntt::DomainContext};
 
 use crate::merkle_channel::MerkleIPVerifierChannel;
@@ -15,7 +15,10 @@ use crate::merkle_channel::MerkleIPVerifierChannel;
 /// implementation therefore holds a handle to the committed oracle along with the folding
 /// challenges, and receives openings over a Merkle channel in order to evaluate the virtual oracle
 /// at queried locations.
-pub trait ProxTestOracle<F: BinaryField> {
+///
+/// The oracle is parameterized by the element type `E` of the channel it is opened over, since the
+/// folding challenges it holds were sampled from that channel.
+pub trait ProxTestOracle<F: BinaryField, E> {
 	/// The Merkle commitment handle for the committed oracle.
 	type Commitment;
 
@@ -40,16 +43,16 @@ pub trait ProxTestOracle<F: BinaryField> {
 		&self,
 		indices: &[usize],
 		channel: &mut Channel,
-	) -> Result<Vec<F>, Error>
+	) -> Result<Vec<E>, Error>
 	where
-		Channel: MerkleIPVerifierChannel<F, Commitment = Self::Commitment>;
+		Channel: MerkleIPVerifierChannel<F, Commitment = Self::Commitment, Elem = E>;
 }
 
 /// A [ProxTestOracle] implementation for a [Brakedown]-style interleaved code proximity check.
 ///
 /// [Brakedown]: <https://dl.acm.org/doi/10.1007/978-3-031-38545-2_7>
-pub struct BrakedownOracle<F, C> {
-	challenges: Vec<F>,
+pub struct BrakedownOracle<E, C> {
+	challenges: Vec<E>,
 	commitment: C,
 	/// The depth of the committed Merkle tree.
 	depth: usize,
@@ -59,13 +62,13 @@ pub struct BrakedownOracle<F, C> {
 	log_lift: usize,
 }
 
-impl<F: BinaryField, C> BrakedownOracle<F, C> {
+impl<E, C> BrakedownOracle<E, C> {
 	/// Constructs a new oracle from the committed interleaved codeword and the folding challenges.
 	///
 	/// `depth` is the depth of the committed Merkle tree. `log_lift` is the oracle-padding lift
 	/// factor (the committed codeword is virtually duplicated `2^log_lift` times to reach the
 	/// common first-round length); pass `0` when no lifting is needed.
-	pub const fn new(challenges: Vec<F>, commitment: C, depth: usize, log_lift: usize) -> Self {
+	pub const fn new(challenges: Vec<E>, commitment: C, depth: usize, log_lift: usize) -> Self {
 		Self {
 			challenges,
 			commitment,
@@ -75,7 +78,7 @@ impl<F: BinaryField, C> BrakedownOracle<F, C> {
 	}
 }
 
-impl<F: BinaryField, C> ProxTestOracle<F> for BrakedownOracle<F, C> {
+impl<F: BinaryField, E: FieldOps<Scalar = F>, C> ProxTestOracle<F, E> for BrakedownOracle<E, C> {
 	type Commitment = C;
 
 	fn log_len(&self) -> usize {
@@ -88,9 +91,9 @@ impl<F: BinaryField, C> ProxTestOracle<F> for BrakedownOracle<F, C> {
 		&self,
 		indices: &[usize],
 		channel: &mut Channel,
-	) -> Result<Vec<F>, Error>
+	) -> Result<Vec<E>, Error>
 	where
-		Channel: MerkleIPVerifierChannel<F, Commitment = C>,
+		Channel: MerkleIPVerifierChannel<F, Commitment = C, Elem = E>,
 	{
 		assert!(indices.iter().all(|&index| index < 1 << self.log_len())); // precondition
 		// Translate each query on the virtual lifted oracle into a query on the committed codeword
@@ -118,14 +121,14 @@ impl<F: BinaryField, C> ProxTestOracle<F> for BrakedownOracle<F, C> {
 /// are combined as `\sum_i values_i[q] * outer_tensor[i]`, where
 /// `outer_tensor = eq_ind_partial_eval(outer_challenges)`. This mirrors the prover's
 /// `BatchBrakedownFolder::fold`.
-pub struct BatchBrakedownOracle<F, C> {
-	oracles: Vec<BrakedownOracle<F, C>>,
-	outer_challenges: Vec<F>,
+pub struct BatchBrakedownOracle<E, C> {
+	oracles: Vec<BrakedownOracle<E, C>>,
+	outer_challenges: Vec<E>,
 }
 
-impl<F: BinaryField, C> BatchBrakedownOracle<F, C> {
+impl<E, C> BatchBrakedownOracle<E, C> {
 	/// Constructs a batch oracle from the per-commitment oracles and the batching challenges.
-	pub fn new(oracles: Vec<BrakedownOracle<F, C>>, outer_challenges: Vec<F>) -> Self {
+	pub fn new(oracles: Vec<BrakedownOracle<E, C>>, outer_challenges: Vec<E>) -> Self {
 		assert!(!oracles.is_empty()); // precondition
 		Self {
 			oracles,
@@ -134,7 +137,9 @@ impl<F: BinaryField, C> BatchBrakedownOracle<F, C> {
 	}
 }
 
-impl<F: BinaryField, C> ProxTestOracle<F> for BatchBrakedownOracle<F, C> {
+impl<F: BinaryField, E: FieldOps<Scalar = F>, C> ProxTestOracle<F, E>
+	for BatchBrakedownOracle<E, C>
+{
 	type Commitment = C;
 
 	fn log_len(&self) -> usize {
@@ -143,25 +148,26 @@ impl<F: BinaryField, C> ProxTestOracle<F> for BatchBrakedownOracle<F, C> {
 		debug_assert!(
 			self.oracles
 				.iter()
-				.all(|oracle| oracle.log_len() == self.oracles[0].log_len())
+				.all(|oracle| ProxTestOracle::<F, E>::log_len(oracle)
+					== ProxTestOracle::<F, E>::log_len(&self.oracles[0]))
 		);
-		self.oracles[0].log_len()
+		ProxTestOracle::<F, E>::log_len(&self.oracles[0])
 	}
 
 	fn open_queries<Channel>(
 		&self,
 		indices: &[usize],
 		channel: &mut Channel,
-	) -> Result<Vec<F>, Error>
+	) -> Result<Vec<E>, Error>
 	where
-		Channel: MerkleIPVerifierChannel<F, Commitment = C>,
+		Channel: MerkleIPVerifierChannel<F, Commitment = C, Elem = E>,
 	{
 		// Receive each bundled oracle's openings in commit order (matching the prover), then
 		// combine across oracles by the outer-challenge tensor expansion:
 		// combined[q] = \sum_i values_i[q] * outer_tensor[i].
-		let outer_tensor = multilinear::eq::eq_ind_partial_eval::<F>(&self.outer_challenges);
-		let mut combined = vec![F::ZERO; indices.len()];
-		for (oracle, &scalar) in self.oracles.iter().zip(outer_tensor.as_ref()) {
+		let outer_tensor = multilinear::eq::eq_ind_partial_eval_scalars(&self.outer_challenges);
+		let mut combined = vec![E::zero(); indices.len()];
+		for (oracle, scalar) in self.oracles.iter().zip(&outer_tensor) {
 			let values = oracle.open_queries(indices, channel)?;
 			for (acc, value) in combined.iter_mut().zip(values) {
 				*acc += value * scalar;
@@ -179,27 +185,20 @@ impl<F: BinaryField, C> ProxTestOracle<F> for BatchBrakedownOracle<F, C> {
 ///
 /// Unlike a [`ProxTestOracle`], this reduces *claims* about the base codeword rather than opening
 /// the virtual oracle outright — see [`Self::reduce_queries`].
-pub struct FRIOracle<F, C, DC>
-where
-	DC: DomainContext<Field = F>,
-{
-	challenges: Vec<F>,
+pub struct FRIOracle<E, C, DC> {
+	challenges: Vec<E>,
 	commitment: C,
 	/// The depth of the committed Merkle tree.
 	depth: usize,
 	domain_context: DC,
 }
 
-impl<F, C, DC> FRIOracle<F, C, DC>
-where
-	F: BinaryField,
-	DC: DomainContext<Field = F>,
-{
+impl<E, C, DC> FRIOracle<E, C, DC> {
 	/// Constructs a new oracle from a committed oracle, its folding challenges, and the domain
 	/// context providing the FRI fold twiddles.
 	///
 	/// `depth` is the depth of the committed Merkle tree.
-	pub const fn new(challenges: Vec<F>, commitment: C, depth: usize, domain_context: DC) -> Self {
+	pub const fn new(challenges: Vec<E>, commitment: C, depth: usize, domain_context: DC) -> Self {
 		Self {
 			challenges,
 			commitment,
@@ -217,13 +216,20 @@ where
 	const fn coset_log_size(&self) -> usize {
 		self.challenges.len()
 	}
+}
 
+impl<F, E, C, DC> FRIOracle<E, C, DC>
+where
+	F: BinaryField,
+	E: FieldOps<Scalar = F> + From<F>,
+	DC: DomainContext<Field = F>,
+{
 	/// Folds an opened coset into a single value.
 	///
 	/// The committed oracle's codeword length in log terms is the Merkle tree depth plus the number
 	/// of folding challenges (one coset per leaf), which is the `log_len` consumed by
 	/// [`fold_coset`].
-	fn fold_coset(&self, chunk_index: usize, values: Vec<F>) -> F {
+	fn fold_coset(&self, chunk_index: usize, values: Vec<E>) -> E {
 		fold_coset(
 			&self.domain_context,
 			self.depth + self.challenges.len(),
@@ -243,8 +249,8 @@ where
 	///     low coset_log_size() bits    the offset within that coset
 	/// ```
 	///
-	/// Each query checks the opened coset at its offset against the matching claim.
-	/// The coset then folds into the virtual oracle value.
+	/// Each query checks the opened coset at its offset against the matching claim, which is
+	/// asserted over the channel. The coset then folds into the virtual oracle value.
 	///
 	/// ## Preconditions
 	/// `claims` must have the same length as `indices`, and the indices must lie in the range
@@ -255,11 +261,11 @@ where
 	pub fn reduce_queries<Channel>(
 		&self,
 		indices: &[usize],
-		claims: &[F],
+		claims: &[E],
 		channel: &mut Channel,
-	) -> Result<Vec<F>, Error>
+	) -> Result<Vec<E>, Error>
 	where
-		Channel: MerkleIPVerifierChannel<F, Commitment = C>,
+		Channel: MerkleIPVerifierChannel<F, Commitment = C, Elem = E>,
 	{
 		assert_eq!(indices.len(), claims.len()); // precondition
 		assert!(
@@ -278,11 +284,9 @@ where
 		let values = channel.recv_openings(&self.commitment, &coset_indices)?;
 		iter::zip(values.chunks(1 << coset_log_size), iter::zip(&coset_indices, indices))
 			.zip(claims)
-			.map(|((coset, (&coset_index, &index)), &claim)| {
-				// Verify the claimed base-codeword value against the opened coset.
-				if coset[index & coset_mask] != claim {
-					return Err(Error::ClaimMismatch { index });
-				}
+			.map(|((coset, (&coset_index, &index)), claim)| {
+				// Check the claimed base-codeword value against the opened coset.
+				channel.assert_zero(coset[index & coset_mask].clone() - claim.clone())?;
 				Ok(self.fold_coset(coset_index, coset.to_vec()))
 			})
 			.collect()
@@ -296,42 +300,42 @@ where
 /// to; the twiddle layer is absolute within the full NTT domain and decreases with each challenge.
 ///
 /// [DP24]: <https://eprint.iacr.org/2024/504>
-pub fn fold_coset<F, DC>(
+pub fn fold_coset<F, E, DC>(
 	domain_context: &DC,
 	mut log_len: usize,
 	chunk_index: usize,
-	challenges: &[F],
-	mut values: Vec<F>,
-) -> F
+	challenges: &[E],
+	mut values: Vec<E>,
+) -> E
 where
 	F: BinaryField,
+	E: FieldOps<Scalar = F> + From<F>,
 	DC: DomainContext<Field = F>,
 {
 	let mut log_size = challenges.len();
-	for &challenge in challenges {
+	for challenge in challenges {
 		for index_offset in 0..1 << (log_size - 1) {
 			// Perform the inverse additive NTT butterfly, then extrapolate the resulting line at
 			// the folding challenge.
-			let mut u = values[index_offset << 1];
-			let mut v = values[(index_offset << 1) | 1];
 			let twiddle =
 				domain_context.twiddle(log_len - 1, (chunk_index << (log_size - 1)) | index_offset);
-			v += u;
-			u += v * twiddle;
-			values[index_offset] = extrapolate_line(u, v, challenge);
+			let mut u = values[index_offset << 1].clone();
+			let v = values[(index_offset << 1) | 1].clone() + &u;
+			u += v.clone() * E::from(twiddle);
+			values[index_offset] = extrapolate_line(u, v, challenge.clone());
 		}
 
 		log_len -= 1;
 		log_size -= 1;
 	}
 
-	values[0]
+	values[0].clone()
 }
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-	#[error("claimed value at index {index} does not match the committed codeword")]
-	ClaimMismatch { index: usize },
 	#[error("Merkle channel error: {0}")]
 	Channel(#[from] crate::merkle_channel::Error),
+	#[error("IP channel error: {0}")]
+	IPChannel(#[from] binius_ip::channel::Error),
 }

--- a/crates/iop/src/fri/error.rs
+++ b/crates/iop/src/fri/error.rs
@@ -12,6 +12,12 @@ pub enum Error {
 	Verification(#[from] VerificationError),
 }
 
+impl From<binius_ip::channel::Error> for Error {
+	fn from(err: binius_ip::channel::Error) -> Self {
+		Self::Channel(err.into())
+	}
+}
+
 impl From<merkle_channel::Error> for Error {
 	fn from(err: merkle_channel::Error) -> Self {
 		match err {
@@ -27,21 +33,13 @@ impl From<batch::Error> for Error {
 	fn from(err: batch::Error) -> Self {
 		match err {
 			batch::Error::Channel(err) => err.into(),
-			batch::Error::ClaimMismatch { index } => VerificationError::IncorrectFold {
-				query_round: 0,
-				index,
-			}
-			.into(),
+			batch::Error::IPChannel(err) => Self::Channel(err.into()),
 		}
 	}
 }
 
 #[derive(Debug, thiserror::Error)]
 pub enum VerificationError {
-	#[error("incorrect codeword folding in query round {query_round} at index {index}")]
-	IncorrectFold { query_round: usize, index: usize },
-	#[error("The dimension-1 codeword must contain the same values")]
-	IncorrectDegree,
 	#[error("Merkle tree error: {0}")]
 	MerkleError(#[from] merkle_tree::VerificationError),
 }

--- a/crates/iop/src/fri/verify.rs
+++ b/crates/iop/src/fri/verify.rs
@@ -3,14 +3,14 @@
 
 use std::iter::{self, repeat_with};
 
-use binius_field::BinaryField;
+use binius_field::{BinaryField, FieldOps};
 use binius_math::ntt::domain_context::GenericOnTheFly;
 use binius_utils::checked_arithmetics::log2_ceil_usize;
 
 use super::{
 	batch::{BatchBrakedownOracle, BrakedownOracle, FRIOracle, ProxTestOracle, fold_coset},
 	common::FRIParams,
-	error::{Error, VerificationError},
+	error::Error,
 };
 use crate::merkle_channel::MerkleIPVerifierChannel;
 
@@ -25,7 +25,7 @@ use crate::merkle_channel::MerkleIPVerifierChannel;
 /// between these oracles and the final, fully-folded terminal codeword. The oracles are
 /// parameterized by the Merkle commitment handle type `C` of the channel that receives the query
 /// openings.
-pub struct FRIQueryVerifier<'a, F, C>
+pub struct FRIQueryVerifier<'a, F, E, C>
 where
 	F: BinaryField,
 {
@@ -33,23 +33,24 @@ where
 	/// Commitment to the fully-folded terminal codeword, sent in full by the prover.
 	terminal_commitment: C,
 	/// The folding challenges applied after the last committed oracle.
-	final_challenges: &'a [F],
+	final_challenges: &'a [E],
 	/// Performs the first, interleaved reduction of the committed codeword(s).
-	codeword_oracle: BatchBrakedownOracle<F, C>,
+	codeword_oracle: BatchBrakedownOracle<E, C>,
 	/// Performs each subsequent FRI reduction, one per fold arity.
-	fri_oracles: Vec<FRIOracle<F, C, GenericOnTheFly<F>>>,
+	fri_oracles: Vec<FRIOracle<E, C, GenericOnTheFly<F>>>,
 }
 
-impl<'a, F, C> FRIQueryVerifier<'a, F, C>
+impl<'a, F, E, C> FRIQueryVerifier<'a, F, E, C>
 where
 	F: BinaryField,
+	E: FieldOps<Scalar = F> + From<F>,
 	C: Clone,
 {
 	pub fn new(
 		params: &'a FRIParams<F>,
 		codeword_commitment: &C,
 		round_commitments: &[C],
-		challenges: &'a [F],
+		challenges: &'a [E],
 	) -> Self {
 		Self::new_batch(
 			params,
@@ -76,7 +77,7 @@ where
 		params: &'a FRIParams<F>,
 		codeword_commitments: &[C],
 		round_commitments: &[C],
-		challenges: &'a [F],
+		challenges: &'a [E],
 	) -> Self {
 		assert_eq!(
 			codeword_commitments.len(),
@@ -137,14 +138,12 @@ where
 				// The oracle's own codeword has dimension `log_dim - log_lift`, so its Merkle tree
 				// depth is that plus the inverse rate. It is lifted to the common first-round
 				// length (`index_bits`) by duplicating each entry `2^log_lift` times.
-				let oracle_log_dim = log_dim - spec.log_lift;
-				let depth = oracle_log_dim + log_inv_rate;
-				let log_lift = spec.log_lift;
+				let depth = (log_dim - spec.log_lift) + log_inv_rate;
 				let early_window = &early_challenges[max_early - spec.log_early_batch_size..];
 				let later_window = &later_challenges[max_later - spec.log_later_batch_size..];
-				let fold_challenges: Vec<F> =
-					early_window.iter().chain(later_window).copied().collect();
-				BrakedownOracle::new(fold_challenges, commitment.clone(), depth, log_lift)
+				let fold_challenges: Vec<E> =
+					early_window.iter().chain(later_window).cloned().collect();
+				BrakedownOracle::new(fold_challenges, commitment.clone(), depth, spec.log_lift)
 			})
 			.collect();
 		let codeword_oracle = BatchBrakedownOracle::new(codeword_sub_oracles, outer_challenges);
@@ -186,9 +185,9 @@ where
 		self.params.n_oracles()
 	}
 
-	pub fn verify<Channel>(&self, channel: &mut Channel) -> Result<F, Error>
+	pub fn verify<Channel>(&self, channel: &mut Channel) -> Result<E, Error>
 	where
-		Channel: MerkleIPVerifierChannel<F, Commitment = C>,
+		Channel: MerkleIPVerifierChannel<F, Commitment = C, Elem = E>,
 	{
 		// Sample all query indices up front to facilitate batched Merkle openings.
 		let mut indices = repeat_with(|| channel.sample_bits(self.params.index_bits()))
@@ -198,21 +197,8 @@ where
 		// Open and reduce the queries through each oracle in turn, receiving the per-oracle
 		// batched openings over the channel.
 		let mut claims = self.codeword_oracle.open_queries(&indices, channel)?;
-		for (query_round, (oracle, &arity)) in self
-			.fri_oracles
-			.iter()
-			.zip(self.params.fold_arities())
-			.enumerate()
-		{
-			claims =
-				oracle
-					.reduce_queries(&indices, &claims, channel)
-					.map_err(|err| match err {
-						super::batch::Error::ClaimMismatch { index } => {
-							VerificationError::IncorrectFold { query_round, index }.into()
-						}
-						err => Error::from(err),
-					})?;
+		for (oracle, &arity) in self.fri_oracles.iter().zip(self.params.fold_arities()) {
+			claims = oracle.reduce_queries(&indices, &claims, channel)?;
 			for index in &mut indices {
 				*index >>= arity;
 			}
@@ -230,12 +216,12 @@ where
 	/// repetition codeword of the claimed low degree, and returns the fully-folded message value.
 	fn verify_terminal_queries<Channel>(
 		&self,
-		claims: &[F],
+		claims: &[E],
 		indices: &[usize],
 		channel: &mut Channel,
-	) -> Result<F, Error>
+	) -> Result<E, Error>
 	where
-		Channel: MerkleIPVerifierChannel<F, Commitment = C>,
+		Channel: MerkleIPVerifierChannel<F, Commitment = C, Elem = E>,
 	{
 		let n_final_challenges = self.params.n_final_challenges();
 		let log_inv_rate = self.params.rs_code().log_inv_rate();
@@ -243,15 +229,9 @@ where
 		let terminate_codeword = channel.recv_committed_vector(&self.terminal_commitment)?;
 
 		// Check the fully-reduced claims against the terminal codeword the verifier holds in full.
-		for (&claim, &index) in iter::zip(claims, indices) {
-			if claim != terminate_codeword[index] {
-				return Err(VerificationError::IncorrectFold {
-					query_round: self.n_oracles() - 1,
-					index,
-				}
-				.into());
-			}
-		}
+		iter::zip(claims, indices).try_for_each(|(claim, &index)| {
+			channel.assert_zero(claim.clone() - terminate_codeword[index].clone())
+		})?;
 
 		// Fold each coset of the terminal codeword and check that the folds are all equal, i.e.
 		// that the codeword has the claimed low degree.
@@ -272,15 +252,12 @@ where
 			})
 			.collect::<Vec<_>>();
 
-		let final_value = repetition_codeword[0];
+		let final_value = repetition_codeword[0].clone();
 
 		// Check that the fully-folded purported codeword is a repetition codeword.
-		if repetition_codeword[1..]
+		repetition_codeword[1..]
 			.iter()
-			.any(|&entry| entry != final_value)
-		{
-			return Err(VerificationError::IncorrectDegree.into());
-		}
+			.try_for_each(|entry| channel.assert_zero(entry.clone() - final_value.clone()))?;
 
 		Ok(final_value)
 	}

--- a/crates/iop/src/merkle_channel.rs
+++ b/crates/iop/src/merkle_channel.rs
@@ -33,7 +33,7 @@ pub trait MerkleIPVerifierChannel<F: Field>: IPVerifierChannel<F> {
 
 	/// Receives a Merkle commitment for a tree with the given depth and leaf size.
 	///
-	/// The leaves of the Merkle tree each contain exactly `leaf_size` `F` elements.
+	/// The leaves of the Merkle tree each contain exactly `leaf_size` field elements.
 	fn recv_merkle_commitment(
 		&mut self,
 		leaf_size: usize,
@@ -45,18 +45,21 @@ pub trait MerkleIPVerifierChannel<F: Field>: IPVerifierChannel<F> {
 	/// Each commitment is associated with the `leaf_size` and `depth` requested when received with
 	/// [`Self::recv_merkle_commitment`]. All indices must be less than `2^depth`.
 	///
-	/// Returns `indices.len() * leaf_size` field elements, where each chunk of `leaf_size`
+	/// Returns `indices.len() * leaf_size` elements, where each chunk of `leaf_size`
 	/// contiguous elements corresponds to one provided index.
 	fn recv_openings(
 		&mut self,
 		commitment: &Self::Commitment,
 		indices: &[usize],
-	) -> Result<Vec<F>, Error>;
+	) -> Result<Vec<Self::Elem>, Error>;
 
 	/// Receives the full committed vector, bound by a Merkle commitment.
 	///
-	/// Returns `leaf_size << depth` field elements, in leaf order.
-	fn recv_committed_vector(&mut self, commitment: &Self::Commitment) -> Result<Vec<F>, Error>;
+	/// Returns `leaf_size << depth` elements, in leaf order.
+	fn recv_committed_vector(
+		&mut self,
+		commitment: &Self::Commitment,
+	) -> Result<Vec<Self::Elem>, Error>;
 
 	/// Samples a uniform integer with the given number of bits.
 	///


### PR DESCRIPTION
First of two PRs for [BINIUS-427](https://linear.app/jimpo/issue/BINIUS-427/add-wordip-channel-traits-and-generalize-the-iop-verifier-stack-over), split per review on #2083. This one only removes the `Elem = F` bound so the BaseFold and FRI verifiers can run over a symbolic element type. The `WordIP` channel traits follow in #2083, which is now stacked on this branch.

The IP layer is already generic over `Channel::Elem` — that is how `IronSpartanBuilderChannel` works — but everything above it pins `Elem = F`, so a channel that symbolically executes the verifier to build a circuit cannot be plugged in.

## What changes

`MerkleIPVerifierChannel::recv_openings` and `recv_committed_vector` return `Vec<Self::Elem>` rather than `Vec<F>`. The `Elem = F` bounds then come off `basefold::{channel, compiler, opening}` and `fri::{verify, batch, fold}`.

The FRI oracle types (`BrakedownOracle`, `BatchBrakedownOracle`, `FRIOracle`, `FRIQueryVerifier`) are parameterized by the element type instead of the base field, since the folding challenges they hold were sampled from the channel. Twiddles stay in `F` and convert at use, so the bound is `E: FieldOps<Scalar = F> + From<F>`.

Two math calls swap to their generic forms: `extrapolate_line_packed` → `extrapolate_line`, and `eq_ind_partial_eval` → `eq_ind_partial_eval_scalars`. Everything else on the path already had a `FieldOps` form.

Query indices stay `usize` and `sample_bits` stays on `MerkleIPVerifierChannel` — making those symbolic is #2083's job, along with the `binius-core` dependency that comes with it. Nothing here touches `Cargo.toml`.

## The FRI error surface narrows

A symbolic element has no equality, so the checks that compared an opened value against a claim become channel assertions: `fri::batch::reduce_queries` and `verify_terminal_queries` call `channel.assert_zero` where they returned `ClaimMismatch` / `IncorrectFold` / `IncorrectDegree`. A channel over concrete values still rejects, but reports `IPChannel(InvalidAssert)` instead of naming the query round and index. Nothing produces those three variants any more, so they are removed.

This is the one behavioural change in the PR, and it is forced by the generalization rather than incidental to it. Say the word if the query-round/index detail is worth keeping — it could be preserved by threading a position through the assertion.

## Testing

7 files, all in `binius-iop`.

* `cargo check --workspace --all-targets`: clean, including every example.
* `cargo test --workspace --exclude binius-examples --exclude binius-arith-bench`: **1396 passed, 0 failed, 19 ignored** across 50 binaries. The `iop-prover` FRI and BaseFold round-trips are the checks that the path over concrete values is unchanged.

`binius-examples` is excluded for disk, not correctness — linking its 328 example binaries needs ~6.3G my volume cannot spare; they all compile under `cargo check --all-targets`. `binius-arith-bench` does not build on aarch64 at stock `HEAD` and depends on nothing here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)