### PR TITLE
BINIUS-455: build the single-instance operand columns without their padding rows

### DIFF
--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -552,10 +552,17 @@ pub fn pack_witness<P: PackedField<Scalar = B128>, A: Allocator>(
 /// materialized column per operand.
 ///
 /// Column `i` holds operand `i` of every constraint, in the constraint type's storage order — the
-/// order the shift reduction batches operands in. Each column has one row per constraint, in the
-/// same order, followed by zero rows up to `constraints.len().next_power_of_two()`: the reductions
-/// consume power-of-two-length columns, and a zero row satisfies every constraint type. An empty
-/// constraint slice still yields one zero row, since that is the smallest power-of-two length.
+/// order the shift reduction batches operands in. Each column has exactly one row per constraint,
+/// in the same order, and nothing beyond them: every reduction rounds the constraint axis up to
+/// `constraints.len().next_power_of_two()` itself and reads the rows past a column's end as zero,
+/// which satisfies every constraint type.
+///
+/// An empty constraint slice still yields one zero row. [`ConstraintSystem::log_and_constraints`]
+/// reports `None` for an empty AND set and the verifier reads that as *zero* constraint variables —
+/// one all-zero row, not zero rows — and the BitAnd check has no skip branch. The two
+/// multiplication checks run only on a non-empty constraint set, so only AND reaches this.
+///
+/// [`ConstraintSystem::log_and_constraints`]: binius_core::constraint_system::ConstraintSystem::log_and_constraints
 ///
 /// `N_COLS` may be smaller than `ARITY`, in which case the trailing operands are not evaluated. The
 /// BitAnd check uses that to skip its `C` column: on a satisfying witness `C = A & B` holds
@@ -574,24 +581,27 @@ where
 	}
 
 	let n_constraints = constraints.len();
-	let n_rows = n_constraints.next_power_of_two();
+	// One row per constraint, and one standing in for an empty set (see above).
+	let n_rows = n_constraints.max(1);
 	(0..N_COLS)
 		.into_par_iter()
 		.map(|op_idx| {
 			let mut column = alloc.alloc::<Word>(n_rows);
 			// The allocator may hand back more capacity than requested, so bound the spare slice to
-			// the row count before splitting it into the constraint rows and the zero padding.
-			let (constraint_rows, padding_rows) =
-				column.spare_capacity_mut()[..n_rows].split_at_mut(n_constraints);
-			(constraints, &mut *constraint_rows)
+			// the row count.
+			let rows = &mut column.spare_capacity_mut()[..n_rows];
+			// No constraint writes the empty set's row, so zero it here.
+			if n_constraints == 0 {
+				rows.fill(MaybeUninit::new(Word::ZERO));
+			}
+			(constraints, &mut *rows)
 				.into_par_iter()
 				.for_each(|(constraint, out)| {
 					out.write(witness.eval_operand(&constraint.as_ref()[op_idx]));
 				});
-			padding_rows.fill(MaybeUninit::new(Word::ZERO));
-			// Safety: the two halves partition the first `n_rows` entries of `column`; the parallel
-			// loop writes each constraint row exactly once (the zip is over equal-length sides) and
-			// the loop above writes each padding row exactly once.
+			// Safety: the parallel loop writes each of the `n_rows` entries exactly once, since the
+			// zip is over equal-length sides — except when the constraint set is empty and the one
+			// row standing in for it was zeroed above.
 			unsafe { column.set_len(n_rows) };
 			column
 		})
@@ -603,9 +613,75 @@ where
 #[cfg(test)]
 mod tests {
 	use binius_compute::GlobalAllocator;
+	use binius_core::constraint_system::AndConstraint;
 	use binius_field::{Field, PackedBinaryGhash2x128b};
+	use binius_frontend::CircuitBuilder;
 
-	use super::{B128, Word, pack_witness};
+	use super::{B128, ValueVec, Word, build_operation_columns, pack_witness};
+
+	/// A circuit of `n_gates` independent AND gates, and a witness satisfying it.
+	///
+	/// One gate yields one AND constraint, so the constraint count is `n_gates` exactly.
+	fn and_gate_witness(n_gates: usize) -> (Vec<AndConstraint>, ValueVec) {
+		let builder = CircuitBuilder::new();
+		let wires: Vec<_> = (0..n_gates)
+			.map(|_| {
+				let x = builder.add_witness();
+				let y = builder.add_witness();
+				builder.force_commit(builder.band(x, y));
+				(x, y)
+			})
+			.collect();
+		let circuit = builder.build();
+
+		let mut w = circuit.new_witness_filler();
+		for (i, &(x, y)) in wires.iter().enumerate() {
+			// Both operands are non-zero on every gate, so a zero row can only be padding.
+			w[x] = Word(0x0123_4567_89AB_CDEF | (i as u64) << 32 | 1);
+			w[y] = Word(0xFEDC_BA98_7654_3210 | (i as u64) | 1);
+		}
+		circuit.populate_wire_witness(&mut w).unwrap();
+
+		let cs = circuit.constraint_system().clone();
+		cs.validate().unwrap();
+		assert_eq!(cs.n_and_constraints(), n_gates);
+		(cs.and_constraints, w.into_value_vec())
+	}
+
+	/// The columns stop at the last constraint rather than rounding up to a power of two: the
+	/// reductions round the constraint axis up themselves and read the rows past a column's end as
+	/// zero.
+	#[test]
+	fn build_operation_columns_stops_at_the_last_constraint() {
+		let (constraints, witness) = and_gate_witness(3);
+		let columns = build_operation_columns::<AndConstraint, _, 3, 2>(
+			&constraints,
+			&witness,
+			&GlobalAllocator,
+		);
+
+		// Three rows, not the four the reduction runs over. The fixture makes every operand
+		// non-zero, so a surviving padding row would show up as a zero tail.
+		for column in &columns {
+			assert_eq!(column.len(), 3);
+			assert!(column.iter().all(|&word| word != Word::ZERO));
+		}
+	}
+
+	/// An empty constraint set still yields one all-zero row: the verifier reads
+	/// `log_and_constraints() == None` as zero constraint variables, which is one row, and the
+	/// BitAnd check has no skip branch.
+	#[test]
+	fn build_operation_columns_gives_an_empty_set_one_zero_row() {
+		let (_, witness) = and_gate_witness(1);
+		let columns =
+			build_operation_columns::<AndConstraint, _, 3, 2>(&[], &witness, &GlobalAllocator);
+
+		for column in &columns {
+			assert_eq!(column.len(), 1);
+			assert_eq!(column[0], Word::ZERO);
+		}
+	}
 
 	/// The packing `pack_witness` is specified to produce: consecutive little-endian B128 elements
 	/// (low word in bits 0..64, high word in bits 64..128), a final unpaired word in the low half,

--- a/crates/prover/tests/prove_verify.rs
+++ b/crates/prover/tests/prove_verify.rs
@@ -5,7 +5,10 @@ use std::collections::HashSet;
 
 use binius_circuits::sha256::{State, populate_message_block, sha256_compress};
 use binius_core::{
-	constraint_system::{ConstraintSystem, InoutSegment, ValueSegment, ValueVec},
+	constraint_system::{
+		AndConstraint, BmulConstraint, ConstraintSystem, ImulConstraint, InoutSegment,
+		ValueSegment, ValueVec,
+	},
 	word::Word,
 };
 use binius_field::{BinaryField128bGhash, Field, Random, arch::OptimalPackedB128};
@@ -182,11 +185,11 @@ fn test_prove_verify_binmul_seventh_power() {
 }
 
 /// Builds a circuit whose AND, IMUL and BMUL constraint counts are all non-powers of two, so every
-/// reduction runs over operand columns whose tail rows are zero padding.
+/// reduction runs over a constraint axis wider than the operand columns it is handed.
 ///
-/// Each asserted `band` contributes two AND constraints (the `band` itself and the equality), each
-/// `imul` gate one IMUL constraint, and each `bmul` gate one BMUL constraint — 6, 3 and 3 in total.
-/// The caller asserts those counts are not powers of two rather than relying on it silently.
+/// Each `band` gate contributes one AND constraint, each `imul` gate one IMUL constraint, and each
+/// `bmul` gate one BMUL constraint. The caller asserts the counts are not powers of two rather
+/// than relying on that silently, since the frontend decides how a gate lowers.
 fn non_power_of_two_constraint_circuit() -> (ConstraintSystem, ValueVec) {
 	const N_AND_GATES: usize = 3;
 	const N_IMUL_GATES: usize = 3;
@@ -266,9 +269,10 @@ fn non_power_of_two_constraint_circuit() -> (ConstraintSystem, ValueVec) {
 }
 
 /// A circuit whose AND, IMUL and BMUL constraint counts are all non-powers of two proves and
-/// verifies. The constraint system keeps those true counts; the prover zero-pads each operand
-/// column up to a power of two, and both sides derive their sumcheck variable counts by rounding
-/// the same true count up.
+/// verifies. The constraint system keeps those true counts, and the prover's operand columns stop
+/// at the last constraint; each reduction rounds its own constraint axis up to a power of two and
+/// reads the rows past a column's end as zero, and both sides derive their sumcheck variable
+/// counts by rounding the same true count up.
 #[test]
 fn test_prove_verify_non_power_of_two_constraint_counts() {
 	let (cs, witness) = non_power_of_two_constraint_circuit();
@@ -285,6 +289,44 @@ fn test_prove_verify_non_power_of_two_constraint_counts() {
 	}
 	prove_verify(cs.clone(), &witness);
 	prove_verify_zk(cs, &witness);
+}
+
+/// Dropping the operand columns' padding rows moves nothing on the wire.
+///
+/// Every constraint type's `Default` has empty operands, so its row is identically zero — exactly
+/// the padding row the prover used to materialize. Padding each constraint list up to a power of
+/// two therefore reconstructs the old column shape without touching the prover, and the two must
+/// produce the same proof byte for byte. The reduction runs over the same axis either way, since
+/// `log2_ceil` of a count and of that count rounded up agree.
+#[test]
+fn test_padded_constraint_lists_produce_an_identical_proof() {
+	let (cs, witness) = non_power_of_two_constraint_circuit();
+
+	let mut padded_cs = cs.clone();
+	padded_cs
+		.and_constraints
+		.resize(cs.n_and_constraints().next_power_of_two(), AndConstraint::default());
+	padded_cs
+		.imul_constraints
+		.resize(cs.n_imul_constraints().next_power_of_two(), ImulConstraint::default());
+	padded_cs
+		.bmul_constraints
+		.resize(cs.n_bmul_constraints().next_power_of_two(), BmulConstraint::default());
+	padded_cs.validate().unwrap();
+
+	assert_eq!(prove_to_bytes(cs, &witness), prove_to_bytes(padded_cs, &witness));
+}
+
+/// Proves `witness` against `cs` and returns the proof bytes.
+fn prove_to_bytes(cs: ConstraintSystem, witness: &ValueVec) -> Vec<u8> {
+	const LOG_INV_RATE: usize = 1;
+
+	let verifier = Verifier::<StdHashSuite>::setup(cs, LOG_INV_RATE).unwrap();
+	let prover = Prover::<OptimalPackedB128, StdHashSuite>::setup(verifier).unwrap();
+
+	let mut transcript = ProverTranscript::new(StdChallenger::default());
+	prover.prove(witness, &mut transcript).unwrap();
+	transcript.finalize().to_vec()
 }
 
 /// A SHA-256 circuit uses only AND constraints, so its constraint system has zero IMUL


### PR DESCRIPTION
Closes [BINIUS-455](https://linear.app/jimpo/issue/BINIUS-455/stop-padding-the-single-instance-provers-operand-columns) — the `binius-prover` twin of #2089, and the last sub-issue of [BINIUS-388](https://linear.app/jimpo/issue/BINIUS-388). Independent of #2089: different crate, disjoint files, either can land first.

`build_operation_columns` sized every column at `constraints.len().next_power_of_two()` and filled the rows past the last constraint with `Word::ZERO`. All three reductions now round the constraint axis up themselves and read the rows past a column's end as zero (#1967 / #1971 / #1968 / #1969), so the columns stop at the last real constraint instead.

Nothing else in `prove` reads the columns — they are built, handed to the reduction, and dropped — and each reduction's `eval_point` still spans the rounded-up axis, so the `OperatorData` the shift reduction consumes is unchanged.

**The empty AND set** is the one case that can't shrink to its literal count. `ConstraintSystem::log_and_constraints` returns `None` for an empty set and `reduce_constraints` (`crates/verifier/src/reduction.rs:204`) reads that as *zero* constraint variables — one all-zero row, not zero rows — and the BitAnd check has no skip branch. So the row count is `n_constraints.max(1)`. IMUL and BMUL are guarded by non-empty sets at their call sites.

## Proofs are byte-identical

`test_padded_constraint_lists_produce_an_identical_proof` proves the same witness twice: once against the real constraint system, once against one whose AND, IMUL and BMUL lists are each padded up to a power of two with `Default` constraints. Every constraint type's `Default` has empty operands, so its row is identically zero — exactly the padding row this PR removes — which reconstructs the old column shape without touching the prover. The proofs must match byte for byte, and do.

Also added, at the unit level on `build_operation_columns` itself:

- `build_operation_columns_stops_at_the_last_constraint` — three AND gates whose operands are all non-zero, so a surviving padding row would show as a zero tail.
- `build_operation_columns_gives_an_empty_set_one_zero_row` — pins the `max(1)` case.

One drive-by doc fix: `non_power_of_two_constraint_circuit`'s comment claimed each asserted `band` contributes *two* AND constraints, "6, 3 and 3 in total". Since #2085 the equality lowers to a ZERO constraint, so it is 3/3/3. I rewrote that paragraph anyway because its first line described the padding this PR deletes.

## Performance

The measurement box is shared and 4-core; cross-revision timings on it varied by up to 60% for identical code. So these are **interleaved A/B inside one process**, alternating the two column shapes rep by rep, medians of 9. Circuit: chained SHA-256 compressions, sized to two fill ratios of the same 2^17 constraint axis.

Isolating `and_reduction::prove` — the only thing the column length reaches:

| AND fill | padded | unpadded | delta |
|---|---|---|---|
| 72,070 / 131,072 (55.0%) | 174.6 ms | 128.0 ms | **−26.7%** |
| 124,486 / 131,072 (95.0%) | 205.1 ms | 202.3 ms | −1.3% (noise) |

**The win is exactly as large as the padding was, and no larger.** At 55% fill, 45% of the rows disappear from the round-1 message and the reduction drops 27% — less than 45% because the MLE-check rounds after the univariate fold run over the full axis regardless. At 95% fill there is almost nothing to skip and the result is indistinguishable from noise. An earlier 5-rep run of the same harness reported −19% for the 95% case; that was noise, and I'm reporting the 9-rep figure instead.

Whole `prove`, same harness: −26.3% at 55% fill (295 → 217 ms), +4.2% at 95% fill (noise). **Read the −26.3% as an upper bound, not a clean number** — padding the constraint *list* to simulate `main` also hands the rest of the prover 59,002 extra (empty) constraints to walk, and the end-to-end saving (−78 ms) exceeds the reduction's own (−47 ms) by about that much.

The columns themselves are ~1 MB here, so the assembly cost is negligible either way; unlike the m4 prover (#2089, columns 8192× larger), there is no meaningful allocation story on this side.

## Verification

`cargo test --all` green (40 test binaries), `cargo clippy --all --tests --benches --examples -- -D warnings` clean, `cargo +nightly-2026-07-01 fmt`, `typos` clean on the crate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)