### PR TITLE
BINIUS-458: put TRACE_ONE_ELEMENT on the BinaryField trait

### DIFF
--- a/crates/field/src/aes_field.rs
+++ b/crates/field/src/aes_field.rs
@@ -26,7 +26,8 @@ use crate::{ExtensionField, Field, underlier::U1};
 //  - AESTowerField32b is GF(2^32) / (x^2 + x * x_3 + 1), where `x_3` is 0x1000 from
 //    AESTowerField16b.
 //  ...
-binary_field!(pub AESTowerField8b(u8), 0xD0);
+// `1 << 5` is the lowest single-bit element of trace 1; `1 << 7` is the only other one.
+binary_field!(pub AESTowerField8b(u8), 0xD0, 1 << 5);
 
 impl AESTowerField8b {
 	pub const fn new(value: u8) -> Self {

--- a/crates/field/src/binary_field.rs
+++ b/crates/field/src/binary_field.rs
@@ -21,24 +21,42 @@ pub trait BinaryField:
 	ExtensionField<BinaryField1b> + WithUnderlier<Underlier: UnderlierType>
 {
 	const N_BITS: usize = Self::ORDER_EXPONENT;
+
+	/// An element whose absolute trace is 1.
+	///
+	/// The absolute trace is the $\mathbb{F}_2$-linear map
+	///
+	/// $$\operatorname{Tr}(x) = \sum_{i=0}^{n-1} x^{2^i},$$
+	///
+	/// which lands in $\mathbb{F}_2$ and is surjective, so such an element always exists and
+	/// exactly half the field has trace 1. Which one is named here is arbitrary; each field picks
+	/// a single-bit element, the lowest one that qualifies.
+	///
+	/// The NTT's Gao-Mateer domain context seeds its basis with this: the descent
+	/// $\beta_i = \beta_{i+1}^2 + \beta_{i+1}$ reaches $\beta_0 = 1$ exactly when it starts from
+	/// an element of trace 1.
+	const TRACE_ONE_ELEMENT: Self;
 }
 
 /// Generates a binary field type over an underlier `$typ`.
+///
+/// `$gen` is the multiplicative generator and `$trace_one` an element of trace 1, both as raw
+/// underlier values.
 ///
 /// The default form derives the field's arithmetic from its width-one packing.
 /// The `custom_arithmetic` form omits that, for a field that defines its own arithmetic.
 macro_rules! binary_field {
 	// Default: the field's arithmetic is its width-one packing's arithmetic.
-	($vis:vis $name:ident($typ:ty), $gen:expr) => {
-		binary_field!(@base $vis $name($typ), $gen);
+	($vis:vis $name:ident($typ:ty), $gen:expr, $trace_one:expr) => {
+		binary_field!(@base $vis $name($typ), $gen, $trace_one);
 		binary_field!(@arithmetic_via_packed $name, $typ);
 	};
 	// The field provides its own `Mul`/`Square`/`InvertOrZero`/`WideMul` separately.
-	(custom_arithmetic $vis:vis $name:ident($typ:ty), $gen:expr) => {
-		binary_field!(@base $vis $name($typ), $gen);
+	(custom_arithmetic $vis:vis $name:ident($typ:ty), $gen:expr, $trace_one:expr) => {
+		binary_field!(@base $vis $name($typ), $gen, $trace_one);
 	};
 
-	(@base $vis:vis $name:ident($typ:ty), $gen:expr) => {
+	(@base $vis:vis $name:ident($typ:ty), $gen:expr, $trace_one:expr) => {
 		#[derive(Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Zeroable, bytemuck::TransparentWrapper)]
 		#[repr(transparent)]
 		$vis struct $name(pub(crate) $typ);
@@ -296,7 +314,9 @@ macro_rules! binary_field {
 			}
 		}
 
-		impl BinaryField for $name {}
+		impl BinaryField for $name {
+			const TRACE_ONE_ELEMENT: Self = $name($trace_one);
+		}
 
 		impl From<$typ> for $name {
 			fn from(val: $typ) -> Self {
@@ -563,7 +583,8 @@ macro_rules! impl_field_extension {
 
 pub(crate) use impl_field_extension;
 
-binary_field!(pub BinaryField1b(U1), U1::new(0x1));
+// The trace over the prime field is the identity here, so `ONE` is the only trace-1 element.
+binary_field!(pub BinaryField1b(U1), U1::new(0x1), U1::new(0x1));
 
 macro_rules! serialize_deserialize {
 	($bin_type:ty) => {
@@ -715,6 +736,44 @@ pub(crate) mod tests {
 		assert!(is_binary_field_valid_generator::<BinaryField1b>());
 		assert!(is_binary_field_valid_generator::<AESTowerField8b>());
 		assert!(is_binary_field_valid_generator::<BinaryField128bGhash>());
+	}
+
+	/// The absolute trace $\operatorname{Tr}(x) = \sum_{i=0}^{n-1} x^{2^i}$, computed by repeated
+	/// squaring rather than by any property of the field's representation.
+	fn trace<F: BinaryField>(x: F) -> F {
+		let mut acc = F::ZERO;
+		let mut square = x;
+		for _ in 0..F::N_BITS {
+			acc += square;
+			square = square.square();
+		}
+		acc
+	}
+
+	/// Every field's declared element really has trace 1.
+	///
+	/// A wrong constant would not fail loudly on its own: the Gao-Mateer basis it seeds asserts
+	/// $\beta_0 = 1$, so it would surface as a panic deep inside NTT setup rather than here.
+	#[test]
+	fn test_trace_one_elements() {
+		fn check<F: BinaryField>() {
+			assert_eq!(trace(F::TRACE_ONE_ELEMENT), F::ONE);
+		}
+		check::<BinaryField1b>();
+		check::<AESTowerField8b>();
+		check::<BinaryField128bGhash>();
+		check::<GhashSq256b>();
+	}
+
+	/// The trace lands in $\mathbb{F}_2$ for every element, not just the declared one. This pins
+	/// the helper above, so a `trace` that silently computed something else could not make the
+	/// previous test pass.
+	#[test]
+	fn test_trace_lands_in_the_prime_subfield() {
+		for value in 0..=u8::MAX {
+			let t = trace(AESTowerField8b::new(value));
+			assert!(t == AESTowerField8b::ZERO || t == AESTowerField8b::ONE, "value {value:#04x}");
+		}
 	}
 
 	#[test]

--- a/crates/field/src/ghash.rs
+++ b/crates/field/src/ghash.rs
@@ -27,7 +27,12 @@ use crate::{
 	underlier::{U1, WithUnderlier},
 };
 
-binary_field!(pub BinaryField128bGhash(M128), M128::from_u128(0x494ef99794d5244f9152df59d87a9186));
+// `1 << 121` is the lowest single-bit element of trace 1; `1 << 127` is the only other one.
+binary_field!(
+	pub BinaryField128bGhash(M128),
+	M128::from_u128(0x494ef99794d5244f9152df59d87a9186),
+	M128::from_u128(1 << 121)
+);
 
 // Convenience `u128` conversions. `binary_field!` already provides `From<M128>`/`From<.. for
 // M128>`; these let callers keep constructing/inspecting `BinaryField128bGhash` via `u128`. `M128`

--- a/crates/field/src/ghash_sq.rs
+++ b/crates/field/src/ghash_sq.rs
@@ -46,7 +46,9 @@ use crate::{
 // The field's `Mul`/`Square`/`InvertOrZero`/`WideMul` are the width-one packing's arithmetic,
 // derived by the `binary_field!` macro from [`PackedGhashSq1x256b`] (`PackedPrimitiveType<M256,
 // GhashSq256b>`), whose implementation lives in `packed_ghash_sq`.
-binary_field!(pub GhashSq256b(M256), m256_from_u128s(0, 1));
+// Bit 248 is the lowest single-bit element of trace 1; bit 254 is the only other one. Bit 248 sits
+// at position 120 of the high word.
+binary_field!(pub GhashSq256b(M256), m256_from_u128s(0, 1), m256_from_u128s(0, 1 << 120));
 
 unsafe impl Pod for GhashSq256b {}
 

--- a/crates/math/src/ntt/domain_context.rs
+++ b/crates/math/src/ntt/domain_context.rs
@@ -160,18 +160,6 @@ impl<F: BinaryField> DomainContext for GenericPreExpanded<F> {
 	}
 }
 
-/// Provides a field element of trace 1.
-pub trait TraceOneElement {
-	/// Returns a field element which has trace 1.
-	fn trace_one_element() -> Self;
-}
-
-impl TraceOneElement for binius_field::BinaryField128bGhash {
-	fn trace_one_element() -> Self {
-		Self::new(1 << 121)
-	}
-}
-
 /// Computes the first `num_basis_elements` Gao-Mateer basis elements of the field.
 ///
 /// ## Preconditions
@@ -179,14 +167,14 @@ impl TraceOneElement for binius_field::BinaryField128bGhash {
 /// - The degree (over $\mathbb{F}_2$) of the field needs to be a tower of two. For example, it does
 ///   **not** work with $\mathbb{F}_{2^3}$, but it works with $\mathbb{F}_{2^4}$.
 /// - `num_basis_elements` must be nonzero
-fn gao_mateer_basis<F: BinaryField + TraceOneElement>(num_basis_elements: usize) -> Vec<F> {
+fn gao_mateer_basis<F: BinaryField>(num_basis_elements: usize) -> Vec<F> {
 	const {
 		assert!(F::N_BITS.is_power_of_two(), "the field degree over F_2 must be a power of two");
 	}
 
 	// this is beta_(F::N_BITS - 1)
 	// e.g. for a 128-bit field, this is beta_127
-	let mut beta = F::trace_one_element();
+	let mut beta = F::TRACE_ONE_ELEMENT;
 
 	// we compute beta_126, then beta_125, etc, by repeatedly applying x |-> x^2 + x
 	for _i in 0..(F::N_BITS - num_basis_elements) {
@@ -240,7 +228,7 @@ pub struct GaoMateerOnTheFly<F> {
 	basis: Vec<F>,
 }
 
-impl<F: BinaryField + TraceOneElement> GaoMateerOnTheFly<F> {
+impl<F: BinaryField> GaoMateerOnTheFly<F> {
 	/// Given the intended size of $S^{(0)}$, computes a "nice" Gao-Mateer [`DomainContext`].
 	///
 	/// This will _not_ precompute the twiddles; instead they will be computed on-the-fly.
@@ -292,7 +280,7 @@ pub struct GaoMateerPreExpanded<F> {
 	expanded: Vec<F>,
 }
 
-impl<F: BinaryField + TraceOneElement> GaoMateerPreExpanded<F> {
+impl<F: BinaryField> GaoMateerPreExpanded<F> {
 	/// Given the intended size of $S^{(0)}$, computes a "nice" Gao-Mateer [`DomainContext`].
 	///
 	/// This will _precompute_ the twiddles.
@@ -343,6 +331,8 @@ impl<F: BinaryField> DomainContext for GaoMateerPreExpanded<F> {
 
 #[cfg(test)]
 mod tests {
+	use binius_field::{AESTowerField8b, GhashSq256b};
+
 	use super::*;
 	use crate::test_utils::B128;
 
@@ -387,6 +377,33 @@ mod tests {
 
 		test_equivalence(&dc_gm_otf, &dc_gm_pre, LOG_SIZE);
 		test_equivalence(&dc_gm_otf, &dc_generic_otf, LOG_SIZE);
+	}
+
+	// Every binary field can seed a Gao-Mateer basis, not just the 128-bit one the old
+	// `TraceOneElement` trait was implemented for.
+	//
+	// `gao_mateer_basis` asserts `beta_0 == ONE`, which holds only if the field's
+	// `TRACE_ONE_ELEMENT` really has trace 1 — so this exercises each constant through the code
+	// that consumes it. The basis must also be linearly independent, which the subspace's
+	// dimension reports.
+	#[test]
+	fn test_gao_mateer_over_every_field() {
+		fn check<F: BinaryField>(log_size: usize) {
+			let dc = GaoMateerPreExpanded::<F>::generate(log_size);
+			let basis = dc.subspace(log_size);
+			assert_eq!(basis.dim(), log_size);
+			assert_eq!(basis.basis()[0], F::ONE);
+
+			// The defining descent: beta_i = beta_{i+1}^2 + beta_{i+1}.
+			for window in basis.basis().windows(2) {
+				assert_eq!(window[0], window[1].square() + window[1]);
+			}
+		}
+
+		// The domain cannot exceed the field's degree over F_2, so each field gets its own size.
+		check::<AESTowerField8b>(8);
+		check::<B128>(5);
+		check::<GhashSq256b>(5);
 	}
 
 	#[test]

--- a/crates/math/src/ntt/tests_reference.rs
+++ b/crates/math/src/ntt/tests_reference.rs
@@ -14,9 +14,7 @@ use crate::{
 	field_buffer::FieldSliceMut,
 	ntt::{
 		NeighborsLastMultiThread, NeighborsLastReference, NeighborsLastSingleThread,
-		domain_context::{
-			GaoMateerPreExpanded, GenericOnTheFly, GenericPreExpanded, TraceOneElement,
-		},
+		domain_context::{GaoMateerPreExpanded, GenericOnTheFly, GenericPreExpanded},
 	},
 	test_utils::{B128, Packed128b, random_field_buffer},
 };
@@ -209,7 +207,7 @@ fn test_forward_transform_is_identity(#[case] ntt_factory: impl NTTFactory<B128>
 
 fn test_equivalence_ntts_domain_contexts<P: PackedField>()
 where
-	P::Scalar: BinaryField + TraceOneElement,
+	P::Scalar: BinaryField,
 {
 	let dc_1 = GaoMateerPreExpanded::<P::Scalar>::generate(10);
 	test_equivalence_ntts::<P>(&dc_1);


### PR DESCRIPTION
Closes [BINIUS-458](https://linear.app/jimpo/issue/BINIUS-458/field-put-trace-one-element-const-on-binaryfield-trait). Unblocks [BINIUS-459](https://linear.app/jimpo/issue/BINIUS-459).

Two commits, as the issue asks.

### 1. `TRACE_ONE_ELEMENT` on `BinaryField`

Every binary field has an element of trace 1 — the absolute trace $\operatorname{Tr}(x) = \sum_{i=0}^{n-1} x^{2^i}$ is a surjective $\mathbb{F}_2$-linear map, so exactly half the field qualifies. Naming it on `BinaryField` rather than on its own trait means a caller reaches it without an extra bound.

Which element is "nice" is a per-field question and I searched for it rather than guessing. **There is no uniform rule** — the qualifying bit positions are 0, 5, 121 and 248 across the four fields, which is not a function of `N_BITS` — so each field declares its own, chosen as the lowest single-bit element that qualifies:

| field | `TRACE_ONE_ELEMENT` | other single-bit trace-1 element |
|---|---|---|
| `BinaryField1b` | bit 0 (`ONE`) | — (the trace is the identity, so `ONE` is the only one) |
| `AESTowerField8b` | bit 5 | bit 7 |
| `BinaryField128bGhash` | bit 121 | bit 127 |
| `GhashSq256b` | bit 248 | bit 254 |

Bit 121 is what `TraceOneElement` already used for GHASH, so that field's behaviour is unchanged. For the 8-bit field, bit 5 (`0x20`) also happens to be the smallest trace-1 element by value; neither 128-bit nor 256-bit field has a trace-1 element below `1 << 12`, so single-bit is the only sensible notion of "nice" there.

The constants are validated by `test_trace_one_elements`, which computes the trace by repeated squaring — from the definition, not from any property of the representation. `test_trace_lands_in_the_prime_subfield` pins that helper by checking all 256 elements of the 8-bit field land in $\{0, 1\}$, so a `trace` that silently computed something else could not make the first test pass.

### 2. Delete `TraceOneElement`

It existed only to supply the Gao-Mateer seed and only `BinaryField128bGhash` implemented it, so `GaoMateerOnTheFly` and `GaoMateerPreExpanded` were usable with exactly one field. Reading the seed off `BinaryField` drops the bound from `gao_mateer_basis` and both contexts. The trait was never re-exported past `binius_math::ntt::domain_context` and had no other impls, so nothing outside the module changes.

`test_gao_mateer_over_every_field` now builds a Gao-Mateer basis over `AESTowerField8b` and `GhashSq256b` as well as B128, checking $\beta_0 = 1$, the descent $\beta_i = \beta_{i+1}^2 + \beta_{i+1}$, and that the basis is independent. That exercises each new constant through the code that consumes it — `gao_mateer_basis` asserts $\beta_0 = 1$, which holds only if the seed really has trace 1.

## Verification

Both commits are independently green. `cargo test --all` green on each, `cargo clippy --all --tests --benches --examples -- -D warnings` clean, `cargo +nightly-2026-07-01 fmt`, `typos` clean.

Nothing here changes a proof: the only field whose Gao-Mateer basis was ever built is B128, and its seed is the same element as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)