### PR TITLE
BINIUS-459: use Gao-Mateer domain contexts for provers and verifiers

### DIFF
--- a/crates/iop/src/basefold/compiler.rs
+++ b/crates/iop/src/basefold/compiler.rs
@@ -6,7 +6,7 @@ use std::borrow::BorrowMut;
 
 use binius_field::BinaryField;
 use binius_hash::binary_merkle_tree::HashSuite;
-use binius_math::{BinarySubspace, ntt::domain_context::GenericOnTheFly};
+use binius_math::{BinarySubspace, ntt::domain_context::GaoMateerOnTheFly};
 use binius_transcript::{VerifierTranscript, fiat_shamir::Challenger};
 use binius_utils::{DeserializeBytes, FixedSizeSerializeBytes};
 use digest::Output;
@@ -67,8 +67,12 @@ where
 			.max()
 			.expect("oracle_specs is non-empty")
 			+ log_inv_rate;
-		let subspace = BinarySubspace::with_dim(max_log_code_len);
-		let domain_context = GenericOnTheFly::generate_from_subspace(&subspace);
+		// The whole protocol's evaluation domain is fixed here: `FRIParams` stores this context's
+		// subspace on its Reed-Solomon code, and every prover and verifier reads the domain back
+		// off that. A Gao-Mateer basis makes the folding maps all $x \mapsto x^2 + x$ with no
+		// normalization factors, and puts the early layers' twiddles in small subfields. See
+		// [`GaoMateerOnTheFly`] for the full list of properties.
+		let domain_context = GaoMateerOnTheFly::<F>::generate(max_log_code_len);
 
 		// The single combined FRI parameters over all oracles. `optimal_for_batch` chooses the fold
 		// arities to minimize proof size, so `_arity_strategy` is not consulted here. It derives
@@ -135,5 +139,48 @@ where
 		Output<H::LeafHash>: DeserializeBytes,
 	{
 		self.create_channel(VerifierMerkleTranscriptChannel::new(transcript))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use binius_field::BinaryField128bGhash as B128;
+	use binius_hash::StdHashSuite;
+	use binius_math::ntt::{DomainContext, domain_context::GaoMateerPreExpanded};
+
+	use super::*;
+	use crate::{channel::OracleSpec, fri::MinProofSizeStrategy};
+
+	/// Every prover rebuilds the evaluation domain from `max_subspace().dim()` alone, rather than
+	/// from the subspace itself. That is only sound because this compiler fixed the domain as the
+	/// Gao-Mateer basis, so regenerating it at the same dimension reproduces it exactly.
+	///
+	/// This pins that agreement. Were the compiler to go back to `BinarySubspace::with_dim`, the
+	/// provers would silently encode over a different domain than the verifier checks.
+	#[test]
+	fn max_subspace_is_the_gao_mateer_basis_of_its_dimension() {
+		for oracle_specs in [
+			vec![OracleSpec::new(10)],
+			vec![OracleSpec::new_zk(10)],
+			// A batch of unequal, non-power-of-two message lengths, so the reduced dimension and
+			// the max code length come apart.
+			vec![
+				OracleSpec::new(7),
+				OracleSpec::new_zk(12),
+				OracleSpec::new(9),
+			],
+		] {
+			let compiler = BaseFoldVerifierCompiler::<B128>::new(
+				&BinaryMerkleTreeScheme::<B128, StdHashSuite>::new(),
+				oracle_specs,
+				1,
+				32,
+				&MinProofSizeStrategy,
+			);
+
+			let subspace = compiler.max_subspace();
+			let regenerated = GaoMateerPreExpanded::<B128>::generate(subspace.dim());
+			assert_eq!(regenerated.subspace(subspace.dim()), *subspace);
+		}
 	}
 }

--- a/crates/iop/src/fri/verify.rs
+++ b/crates/iop/src/fri/verify.rs
@@ -148,6 +148,9 @@ where
 
 		// All FRI reductions fold cosets of the same Reed–Solomon codeword domain, so they share a
 		// single domain context.
+		// Derived from the subspace the params carry, not regenerated from its dimension: a
+		// `FRIParams` may be built over any subspace, so the verifier cannot assume the
+		// Gao-Mateer basis the BaseFold compiler happens to choose.
 		let domain_context = GenericOnTheFly::generate_from_subspace(params.rs_code().subspace());
 		let mut fri_oracles = Vec::with_capacity(params.fold_arities().len());
 		let mut depth = index_bits;

--- a/crates/m4-prover/src/prove.rs
+++ b/crates/m4-prover/src/prove.rs
@@ -21,7 +21,7 @@ use binius_math::{
 	BinarySubspace,
 	inner_product::inner_product,
 	multilinear::eq::eq_ind_partial_eval_scalars,
-	ntt::{NeighborsLastMultiThread, domain_context::GenericPreExpanded},
+	ntt::{NeighborsLastMultiThread, domain_context::GaoMateerPreExpanded},
 	univariate::lagrange_evals_scalars,
 };
 use binius_prover::{
@@ -49,7 +49,7 @@ use crate::{
 };
 
 /// The multithreaded additive NTT used to encode the committed codeword.
-type ProverNtt = NeighborsLastMultiThread<GenericPreExpanded<B128>>;
+type ProverNtt = NeighborsLastMultiThread<GaoMateerPreExpanded<B128>>;
 
 /// IOP prover for the M4 constraint reduction of a particular constraint system.
 ///
@@ -367,9 +367,10 @@ where
 	/// The prover encodes the codeword with the multithreaded NTT, spread across the cores.
 	/// Reusing the verifier's compiler keeps both sides on one set of FRI parameters.
 	pub fn setup(verifier: &Verifier) -> Self {
-		// Reuse the verifier's evaluation domain so both sides agree on the code.
+		// Reuse the verifier's evaluation domain so both sides agree on the code: its compiler
+		// fixed that domain as the Gao-Mateer basis of this dimension.
 		let domain_context =
-			GenericPreExpanded::generate_from_subspace(verifier.iop_compiler().max_subspace());
+			GaoMateerPreExpanded::generate(verifier.iop_compiler().max_subspace().dim());
 
 		// Spread the NTT across the available cores.
 		let log_num_shares = binius_utils::rayon::current_num_threads().ilog2() as usize;

--- a/crates/prover/src/prove.rs
+++ b/crates/prover/src/prove.rs
@@ -16,7 +16,7 @@ use binius_ip_prover::channel::WordIPProverChannel;
 use binius_math::{
 	BinarySubspace, FieldBuffer, FieldVec,
 	inner_product::inner_product,
-	ntt::{NeighborsLastMultiThread, domain_context::GenericPreExpanded},
+	ntt::{NeighborsLastMultiThread, domain_context::GaoMateerPreExpanded},
 	univariate::lagrange_evals,
 };
 use binius_transcript::{ProverTranscript, fiat_shamir::Challenger};
@@ -45,7 +45,7 @@ use crate::{
 };
 
 /// Type alias for the prover NTT parameterized by field.
-type ProverNTT<F> = NeighborsLastMultiThread<GenericPreExpanded<F>>;
+type ProverNTT<F> = NeighborsLastMultiThread<GaoMateerPreExpanded<F>>;
 
 /// IOP prover for a particular constraint system.
 ///
@@ -399,9 +399,10 @@ where
 	) -> Result<Self, Error> {
 		warn_on_software_field_arithmetic();
 
-		// Get max subspace from verifier's IOP compiler (reuses FRI params)
-		let subspace = verifier.iop_compiler().max_subspace();
-		let domain_context = GenericPreExpanded::generate_from_subspace(subspace);
+		// Rebuild the verifier's evaluation domain, which its compiler fixed as the Gao-Mateer
+		// basis of that dimension.
+		let domain_context =
+			GaoMateerPreExpanded::generate(verifier.iop_compiler().max_subspace().dim());
 		// FIXME TODO For mobile phones, the number of shares should potentially be more than the
 		// number of threads, because the threads/cores have different performance (but in the NTT
 		// each share has the same amount of work)

--- a/crates/prover/src/zk_config.rs
+++ b/crates/prover/src/zk_config.rs
@@ -13,7 +13,7 @@ use binius_core::constraint_system::{ConstraintSystem, InoutSegment, ValueVec};
 use binius_field::{BinaryField128bGhash as B128, PackedField};
 use binius_hash::binary_merkle_tree::HashSuite;
 use binius_iop_prover::basefold::compiler::BaseFoldProverCompiler;
-use binius_math::ntt::{NeighborsLastMultiThread, domain_context::GenericPreExpanded};
+use binius_math::ntt::{NeighborsLastMultiThread, domain_context::GaoMateerPreExpanded};
 use binius_spartan_frontend::constraint_system::WitnessLayout;
 use binius_spartan_prover::wrapper::{ReplayChannel, ZKWrappedProverChannel};
 use binius_transcript::{ProverTranscript, fiat_shamir::Challenger};
@@ -28,7 +28,7 @@ use crate::{
 	protocols::shift::{KeyCollection, build_key_collection},
 };
 
-type ProverNTT<F> = NeighborsLastMultiThread<GenericPreExpanded<F>>;
+type ProverNTT<F> = NeighborsLastMultiThread<GaoMateerPreExpanded<F>>;
 
 /// Zero-knowledge prover for Binius64 constraint systems.
 ///
@@ -97,10 +97,10 @@ where
 		let outer_iop_prover = binius_spartan_prover::IOPProver::new(outer_cs);
 
 		// Build the BaseFold prover compiler from the verifier compiler.
-		let subspace = zk_verifier.basefold_compiler().max_subspace();
+		let log_domain_size = zk_verifier.basefold_compiler().max_subspace().dim();
 		let domain_context = {
 			let _guard = tracing::debug_span!("Precompute NTT domain").entered();
-			GenericPreExpanded::generate_from_subspace(subspace)
+			GaoMateerPreExpanded::generate(log_domain_size)
 		};
 		let log_num_shares = binius_utils::rayon::current_num_threads().ilog2() as usize;
 		let ntt = NeighborsLastMultiThread::new(domain_context, log_num_shares);

--- a/crates/spartan-prover/src/lib.rs
+++ b/crates/spartan-prover/src/lib.rs
@@ -48,7 +48,7 @@ use binius_ip_prover::{
 use binius_math::{
 	FieldBuffer, FieldSlice, FieldVec,
 	multilinear::eq::eq_ind_partial_eval,
-	ntt::{NeighborsLastMultiThread, domain_context::GenericPreExpanded},
+	ntt::{NeighborsLastMultiThread, domain_context::GaoMateerPreExpanded},
 	univariate::evaluate_univariate,
 };
 use binius_spartan_frontend::constraint_system::{
@@ -68,7 +68,7 @@ use rand::CryptoRng;
 
 use crate::wiring::{WiringTranspose, fold_constraints};
 
-type ProverNTT<F> = NeighborsLastMultiThread<GenericPreExpanded<F>>;
+type ProverNTT<F> = NeighborsLastMultiThread<GaoMateerPreExpanded<F>>;
 
 /// IOP prover for a particular constraint system.
 ///
@@ -341,9 +341,10 @@ where
 	pub fn setup(verifier: &Verifier<F, H>) -> Result<Self, Error> {
 		let log_num_shares = binius_utils::rayon::current_num_threads().ilog2() as usize;
 
-		// Get the largest subspace from the verifier compiler for NTT creation
-		let subspace = verifier.iop_compiler().max_subspace();
-		let domain_context = GenericPreExpanded::generate_from_subspace(subspace);
+		// Rebuild the verifier's evaluation domain, which its compiler fixed as the Gao-Mateer
+		// basis of that dimension.
+		let domain_context =
+			GaoMateerPreExpanded::generate(verifier.iop_compiler().max_subspace().dim());
 		let ntt = NeighborsLastMultiThread::new(domain_context, log_num_shares);
 
 		// Create the BaseFold ZK compiler from verifier compiler (reuses oracle_specs and


### PR DESCRIPTION
Closes [BINIUS-459](https://linear.app/jimpo/issue/BINIUS-459/use-gao-mateer-domain-contexts-for-all-provers-and-verifiers). Follows #2092, which made `GaoMateer*` usable over any binary field.

The issue had no description, so I scoped it from the code; two things worth your eye are flagged below.

### 1. The compiler picks the Gao-Mateer basis

`BaseFoldVerifierCompiler::new` is the single place the evaluation domain is chosen. It hands a domain context to `FRIParams::optimal_for_batch`, which stores that context's subspace on the Reed-Solomon code, and every prover and verifier reads the domain back off there — so one line moves the whole protocol.

**This changes proof bytes.** The domain moves off `BinarySubspace::with_dim` (the default $\mathbb{F}_2$ basis) onto the Gao-Mateer basis. Proof *size*, the FRI parameters and the security analysis are unaffected: the arity search costs lengths, not domain values.

### 2. The provers construct the context directly

All four provers precomputed with `GenericPreExpanded::generate_from_subspace(compiler.max_subspace())`, which recovers the subspace-polynomial evaluations in $O(n^2)$ field operations. The same domain is now reachable in $O(n)$ by descending from the field's trace-1 element, so they regenerate it from the dimension.

Same domain, so this second commit does not move a proof relative to the first.

## The FRI verifier is deliberately *not* switched

My first attempt also swapped `FRIVerifier`'s context for `GaoMateerOnTheFly::generate(subspace.dim())`. **That is wrong, and nine tests caught it.** `FRIParams` may be constructed over any subspace — `ReedSolomonCode::with_subspace` is public and the FRI unit tests use it — so the verifier must derive its domain from the subspace it is *handed*, not regenerate one at that dimension and assume the basis the BaseFold compiler happens to pick. It keeps `generate_from_subspace`, with a comment saying why.

So "all provers & verifiers" lands as: the BaseFold verifier compiler chooses Gao-Mateer, the four provers construct it directly, and the generic FRI verifier stays basis-agnostic. If you want the FRI verifier on it too, that needs `FRIParams` to carry the basis choice rather than just a subspace — happy to do it, but it is a different change.

`max_subspace_is_the_gao_mateer_basis_of_its_dimension` pins the invariant the provers now depend on: regenerating from a dimension reproduces `max_subspace()` exactly. Were the compiler to go back to `with_dim`, provers would silently encode over a different domain than the verifier checks, and that test is what fails first. I confirmed it has teeth — the two bases genuinely differ at these dimensions.

## Also out of scope

`and_reduction/ntt_lookup.rs` builds `GenericOnTheFly` contexts too, but over the AND check's univariate-skip domain (`BinarySubspace::<B8>::with_dim(Word::LOG_BITS + 1)`), which is fixed by the protocol and shared with the verifier. Moving that is a protocol change, not a domain-context swap. Say the word if you want it.

## Performance

In-process A/B, `log_domain_size = 20`, medians of 9:

| | before | after | delta |
|---|---|---|---|
| construct the domain context | 11.1 ms | 3.4 ms | **−69%** |
| `forward_transform` (log_msg 18) | 14.7 ms | 15.8 ms | within noise |

The transform is unchanged, as expected — Gao-Mateer changes the twiddle *values*, not how many multiplies happen. The sign flips pair-by-pair across the nine reps (four faster, three slower, two equal), so read it as "no difference" rather than a 7% regression. The construction win is one-time per prover setup and is consistent in every pair.

The structural properties are the durable payoff: every FRI folding map becomes $x \mapsto x^2 + x$ with no normalization factor, and early-layer twiddles land in small subfields, which is where a specialized subfield multiply could pay off later.

## Verification

`cargo test --all` and `cargo clippy --all --tests --benches --examples -- -D warnings` green on the pre-rebase tree, which is byte-identical in content to this one (the rebase only swapped my local #2092 commits for the merged squash). Each commit was also checked on its own. `cargo +nightly-2026-07-01 fmt`, `typos` clean on the touched crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)